### PR TITLE
YUJ-446 Round-5: fix server boot crash — register notify + oidc modules

### DIFF
--- a/internal/modules.go
+++ b/internal/modules.go
@@ -28,6 +28,8 @@ import (
 	_ "github.com/Mininglamp-OSS/octo-server/modules/file"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/group"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/message"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/notify"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/oidc"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/openapi"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/qrcode"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/report"


### PR DESCRIPTION
Follow-up from [PR #2](https://github.com/Mininglamp-OSS/octo-server/pull/2).

## Problem

Round-5 end-to-end verification re-deployed the stack from a clean
\`docker compose down -v\` state, exactly following the quickstart
in the new README. The stack brought up all 11 containers, but
octo-server crash-looped with:

```
panic: Unable to create migration plan because of oidc-20260427-01.sql: unknown migration in database

panic: Unable to create migration plan because of app_bot-20260510-01.sql: unknown migration in database
```

## Root cause

\`scripts/init-db.sql\` (the schema snapshot) seeds \`gorp_migrations\`
rows for every migration in the internal dmworkim source tree,
including rows for the \`notify\` and \`oidc\` modules. The module
source for both is present in \`modules/notify/\` and \`modules/oidc/\`
with \`//go:embed sql\` wired through \`1module.go\`.

However \`internal/modules.go\` only blank-imports 22 of the
24 relevant module packages — \`notify\` and \`oidc\` are missing.
Without the blank import, \`init()\` in \`1module.go\` never runs,
\`register.AddModule\` is never called, and sql-migrate does not see
the embedded \`sql/\` directory at boot. The seeded rows then look
like \"unknown migrations\" to the planner and it panics.

This blocks the documented quickstart path entirely; every fresh
OSS deployment of this repo crashes the API server immediately
after MySQL finishes initializing.

Why didn't PR #2 catch this? The im-test pilot reused a MySQL
volume that had already been populated by a pre-existing \`octo-server\`
binary built from a different source drop (which *did* register both
modules), so the migration plan matched on that first boot. A fresh
OSS user following the README from scratch would hit this every
time.

## Fix

Two lines in \`internal/modules.go\`:

```go
_ \"github.com/Mininglamp-OSS/octo-server/modules/notify\"
_ \"github.com/Mininglamp-OSS/octo-server/modules/oidc\"
```

Placed between \`message\` and \`openapi\` to keep the file's existing
\"group by alpha, respect ordering comments\" convention. No ordering
dependency affects these two — \`notify\` only needs \`message\`
semantics at runtime (already registered above) and \`oidc\` depends
on \`user\` (already registered later, but no SQL cross-dependency).

## Verification

Fresh re-deploy from merged main HEAD:

| Endpoint              | Expected  | Actual |
| --------------------- | --------- | ------ |
| `GET /api/v1/health`  | 200 JSON  | ✅     |
| `GET /api/v1/ping`    | 200 JSON  | ✅     |
| `GET /ws` (Upgrade)   | 101       | ✅     |
| `GET /` (web SPA)     | 200       | ✅     |
| `GET /admin/`         | 200       | ✅     |
| `GET /matter/health`  | 200       | ✅     |
| `GET /summary/health` | 200       | ✅     |
| `GET /minio-console/` | 200       | ✅     |

All 11 containers reach \`healthy\` or \`up\` on first boot.

## Follow-ups (not in this PR)

- A CI job that runs \`docker compose up -d\` against main each
  merge would have caught this. The verification here was manual.
- WuKongIM \`WK_EXTERNAL_WSADDR\` env does not appear to override
  \`external.wsAddr\` at runtime (only \`wssAddr\` and \`ip\` take
  effect). Not a blocker because browsers on HTTPS pages prefer the
  \`wss_addr\` field, which is correctly populated from
  \`WK_EXTERNAL_WSSADDR\`. Worth reporting upstream to WuKongIM
  and documenting as a limitation.