### PR TITLE
fix(docker): wait for upstream health + surface register.emailOn

### DIFF
--- a/docker/octo/configs/octo-server.yaml
+++ b/docker/octo/configs/octo-server.yaml
@@ -64,3 +64,4 @@ logger:
 register:
   off: true
   onlyChina: false
+  emailOn: false

--- a/docker/octo/docker-compose.yaml
+++ b/docker/octo/docker-compose.yaml
@@ -213,7 +213,8 @@ services:
     container_name: octo-nginx
     restart: unless-stopped
     depends_on:
-      - octo-server
+      octo-server:
+        condition: service_healthy
     environment:
       OCTO_DOMAIN: ${OCTO_DOMAIN:-octo.local}
     ports:
@@ -247,8 +248,8 @@ services:
     container_name: octo-web
     restart: unless-stopped
     depends_on:
-      - octo-server
-      - summary-api
+      octo-server:
+        condition: service_healthy
     environment:
       API_URL: http://octo-server:8090
       # Optional: smart-summary backend. octo-web handles absence gracefully
@@ -273,7 +274,8 @@ services:
     container_name: octo-admin
     restart: unless-stopped
     depends_on:
-      - octo-server
+      octo-server:
+        condition: service_healthy
     environment:
       API_BACKEND: octo-server:8090
     ports:


### PR DESCRIPTION
## Summary

Two small fixes for OSS users running `docker/octo` for the first time:

- **`fix(docker): wait for upstream health before starting web/admin/nginx`** — nginx and the web/admin SPAs hit `octo-server` via `proxy_pass` at startup, but the implicit `depends_on` (`service_started`) only waits for the container to exist, not for the HTTP listener to accept connections. nginx caches an NXDOMAIN/refused on first request and serves 502 until restarted. Upgrades web/admin/nginx `depends_on` to `condition: service_healthy` so they boot only after octo-server's readiness probe passes. `web` only gates on `octo-server` — `summary-api` stays optional with 503 fallback.
- **`docs: surface register.emailOn in OSS example config`** — the example `docker/octo/configs/octo-server.yaml` did not mention `emailOn` at all, leaving operators to discover it from source. Add the field explicitly with **`emailOn: false`**, matching the closed-by-default registration stance.

## Test plan

- [ ] `cd docker/octo && cp .env.example .env` (fill secrets), `docker compose up -d`
- [ ] All 11 containers reach healthy
- [ ] `curl https://<host>/api/v1/common/appconfig` returns 200 (proves nginx → octo-server proxy reachable)
- [ ] octo-web still starts when `summary-api` is intentionally removed / unhealthy (degraded mode)