### PR TITLE
security: replace hardcoded test RSA key and add gitleaks config

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,11 +1,14 @@
 title = "Gitleaks config for octo-server"
 
+[extend]
+useDefault = true
+
 # ── Custom rules: detect project-specific token formats ──────────────────────
 
 [[rules]]
   id = "octo-bot-token"
   description = "OCTO bot token (bf_ + 32 hex chars)"
-  regex = '''bf_[a-f0-9]{32}'''
+  regex = '''\bbf_[A-Fa-f0-9]{32}\b'''
   tags = ["token", "bot"]
 
   [rules.allowlist]
@@ -16,7 +19,7 @@ title = "Gitleaks config for octo-server"
 [[rules]]
   id = "octo-user-api-key"
   description = "OCTO user API key (uk_ + 32 hex chars)"
-  regex = '''uk_[a-f0-9]{32}'''
+  regex = '''\buk_[A-Fa-f0-9]{32}\b'''
   tags = ["token", "api-key"]
 
   [rules.allowlist]
@@ -24,13 +27,20 @@ title = "Gitleaks config for octo-server"
     regexTarget = "match"
     regexes = ['''uk_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6''']
 
-# ── Global allowlist: only exact known placeholders and RFC test vectors ─────
+# ── Global allowlist: doc placeholders, test fixtures, RFC test vectors ──────
 
 [allowlist]
-  description = "Doc placeholders and RFC test vectors only"
+  description = "Doc placeholders, test fixtures, and RFC test vectors"
   regexTarget = "match"
   regexes = [
     '''YOUR_BOT_TOKEN''',
     '''uk_YOUR_API_KEY''',
     '''dGhlIHNhbXBsZSBub25jZQ==''',
+    '''ghp_SensitiveTokenThatShouldNotBeLogged123''',
+    '''gho_abc123def456''',
+    '''abc12345xyz67890''',
+  ]
+  paths = [
+    '''pkg/wkrsa/rsa_test\.go$''',
+    '''modules/user/api_oauth_test\.go$''',
   ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,15 @@
+title = "Gitleaks config for octo-server"
+
+[allowlist]
+  description = "Known false positives: doc placeholders, test fixtures, RFC samples"
+  regexTarget = "match"
+  regexes = [
+    '''YOUR_BOT_TOKEN''',
+    '''uk_YOUR_API_KEY''',
+    '''dGhlIHNhbXBsZSBub25jZQ==''',
+  ]
+  paths = [
+    '''_test\.go$''',
+    '''testdata/''',
+    '''scripts/smoke-test\.sh$''',
+  ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,15 +1,36 @@
 title = "Gitleaks config for octo-server"
 
+# ── Custom rules: detect project-specific token formats ──────────────────────
+
+[[rules]]
+  id = "octo-bot-token"
+  description = "OCTO bot token (bf_ + 32 hex chars)"
+  regex = '''bf_[a-f0-9]{32}'''
+  tags = ["token", "bot"]
+
+  [rules.allowlist]
+    description = "Synthetic test-only token in bot_api unit tests"
+    regexTarget = "match"
+    regexes = ['''bf_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6''']
+
+[[rules]]
+  id = "octo-user-api-key"
+  description = "OCTO user API key (uk_ + 32 hex chars)"
+  regex = '''uk_[a-f0-9]{32}'''
+  tags = ["token", "api-key"]
+
+  [rules.allowlist]
+    description = "Synthetic test-only API key in bot_api unit tests"
+    regexTarget = "match"
+    regexes = ['''uk_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6''']
+
+# ── Global allowlist: only exact known placeholders and RFC test vectors ─────
+
 [allowlist]
-  description = "Known false positives: doc placeholders, test fixtures, RFC samples"
+  description = "Doc placeholders and RFC test vectors only"
   regexTarget = "match"
   regexes = [
     '''YOUR_BOT_TOKEN''',
     '''uk_YOUR_API_KEY''',
     '''dGhlIHNhbXBsZSBub25jZQ==''',
-  ]
-  paths = [
-    '''_test\.go$''',
-    '''testdata/''',
-    '''scripts/smoke-test\.sh$''',
   ]

--- a/pkg/wkrsa/rsa_test.go
+++ b/pkg/wkrsa/rsa_test.go
@@ -1,43 +1,63 @@
 package wkrsa
 
 import (
-	"fmt"
 	"testing"
 )
 
-func TestSignWithMD5(t *testing.T) {
-
-	dz := `-----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEAxGbKnrOumh0r4FfRDL3NIGP7scxxvsVupktTdFqf8TgHLT67
-qfMXxM/JSAmNxJVz4zS8zVla4FlTJ4kyh3IJW+65vzXKX/errnI0gNk0p3IME+Wd
-LDetwy04Dk40B4GhMrfnomMff6W7UXG4fyLX9gzCIhkAeLNNl6eZS8IOgFULWZRO
-pYdlylncY4EQiv6ljXQtKmTIxvi7ivS/9sSFqgS+qnbd0QexrZlM1D2O4abFgrjs
-BaFHC4zGrg3TztiWynGUSOpjFv2v92doxDgSxP69xNry9Vq+6kERJpbqvJ3ujUEY
-T4bLk8avXNjyMg79/xNeiQ4gxvSHj3v3YOOlIQIDAQABAoIBADbY9fDIARSs3Nnz
-7D+Aqc5H3bxTedhqznHGS3IM9OmqWea6xDG734Fo/a8Oa/bgPdLPoYI/V++bQmui
-FuhYYmC4FEtfvDp8sgcvgZYSEnBImzLbRr9YdUAyWps0H7eQ7fF6BkgFIoDFScB+
-36Uxl9nwyi43iTgr6plVhqvvb5lKqPQTZWWI50hs0EYcADngy2st6+sJxJXylCI4
-w3vjXhE9WdwBk54QD6FPPrzRHWpqHDjPcuyxbVijEoz0YMdO+tnHweUn+YnQnHxi
-rswF7b9/DL8mhIX67SKqF7wM+RCgrweVswNCcEsZyfCtMKgI7uwDjaDkvhI+XaYq
-vfNUe9kCgYEAzK+Zb3A4ZxPWhYrubqmGYa7KvmtetRO5LAyWXMFH5vzU+TKzDcJm
-qZTxhzH8yt43PgrjOL5C+X2cIkNfEXHl9oIuuAMbMDSqThvox+o8Lsz5gTKy9/rR
-sucBRc41N/axLalVpbevD3Q3+2WjH25ap7h0RsZsladshEoxXI8jpCMCgYEA9aOD
-SSoywbVrsMXhr2wgxNXUuQGxWH6x3ZbAG86xxerElVwT06SbowDO77xFmiQsUvlW
-BpYrVPBg48B/Sgvvb0mKHhXVe8Maegq6bCofVpAU9IhDZokwIGJgEm2MgziZJAe+
-3/2DCFV22olrkqDhllqBTenuSyiIfWcGHr+zM+sCgYB0EWNVgPJK6UHtajH4iKMO
-Q1rujd4fmnaXlu+w211Vi6uNQAWu2Lz0juRDQMJTm50BzpS4uZMq/OKLv15qewbn
-OT0a1ZAWTtcAAe2HZ7kG5O7bJ4+69PzykPH0zpD5Eie4d9x8Y2OexM11/lV43lAD
-6aHt/FjYqB7uCVBiZzzTtwKBgQDGY+jN9+IEp4UxwbCUYQ1aTKXBQoe8xJ7dLDs+
-ekMEaaeaRkLRJdp53VZFM9c3Nk4COdTr/u9Ca96lM7zazib0x/1gbRv+GEbTGMUW
-RTMIU9hI46EkOFsBXNLhL09UUCsHeaYE/JiO64/R0zlptLxeFfznM6+9TiBmwAWm
-YgfXPwKBgDn1n2aWpGpH/cz8AQapMxqo7YK2Lc/Vwqw7O4mmNQ0TOJOgECHrWJX2
-2UfOnyh8mDNFq9Udt4XMkfH5aPmWF7ejl2ddz3A4kdz5DMaVgRPktJh6nFAllKz/
-R0a+FMM2fsqqRjYN4Zf84pJvWnIy7dG/pXKq8AAWkV7iJNVpshGb
+// testPrivateKey is a freshly generated RSA-2048 key used ONLY for unit
+// tests. It has no relationship to any production key material.
+// Regenerated 2026-05-12 during pre-open-source secret scrub.
+const testPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEA0GTVoxu02WMdxeg+QxgbQ5C5rWQpDL3OLhzYUXOsmSdF2vUM
+yJ5AFbv97Nt5DaNtmGzGldlQ9keNAvcljwGqR7F97jmxP+8kjqdOKqHYjj/Jt0FW
+K/QlXAtogASPig3t26QGbfW8+qruoooxc2PKT5WulK9OfwgGvvdcLaHLlWZufIeE
+cgdlQJ2qpNKOA/AgNTj16RspE9VdmKBIWzmGRDziFf1/pmmhBVe4TZ9MAfEUQIk7
+Cm1eS/g8YwYsi2bI6MoK9Tcwh5IcEV8tvAXz+qSfuO31ep/5CvsSlcVvYYjBf3mQ
+P7Dn811MDJFH5SzC4aknpQz2+c5GmHPJgYtTKQIDAQABAoIBAQDBoH8z70FpHwQB
+59k6BAMJE0bCiabulMkm5VxEyiLbprbsS/YVzZwj1amI0x+2AVyKXL9jaikku7SU
+xchbCKQLuyoUF/zON8gS1/bz+6839KLbJ9UGP/IahOsSz6oDDxArnUrwDn0Jt5rE
+4XwzB8xph91Pf1eDBpUmCLXYHFYJuBau1pJT71aWQyK5IXemVk0zc8VYzjn5vYm7
+FcaHVwMYVG/E5qnQKhcByYndAtyAoH6FrTXygtCRACbEMGR8wTz7dT4RNyLC72gQ
+jHRxDIO+cSRK/+sDDKrQfr3njr2ZAhQ4wFbu7f0mEPO6k4TIydwMZMfiUEM8uz/o
+Jfgwq4IRAoGBAOvLFXrZ1iVyaA1rUnfEn9omkGIDoD5yOdM+Altce7FTyrr3oViy
+40lveMEfc+m/HsqSrUk1+UadDKAaB6vU84i9M7zTTc5v1odOBt0LTFSd4APUCoXG
+GV9j4au5clYOQgLBfE2SOJ2YZgvHlatxG7YQg/Mtgv7EWirEHbJSM3F1AoGBAOJA
+pxesAOQ7y2f5czxkU54sBA0go0SzMO9p4lC+w/nySyFGAtzRJOLia8mTgqZ5gQ4+
+wA96dRjSyFBagOgjFLsofN5DhcV8UsxYeYTpV4IZDIVo9Y5S4OvsCAzAxKwC7uhv
+VAwDzA+ZQeqp159gzhAMggSBmDK3nD0CvMdEP1BlAoGAa0Yhp5qjirXaEQDarBKQ
+hzc0SONNbBubozd66wXQYIS2nwk6Jph8P1Svo20j1xxUbeT9YWlk13Nr4wr0ooBn
+q7Yoa6fWpizLdRNSnA4f0/9fg15cyy+tK3DNosrj8bLa5VYRr1ju2QQUqRdMSItV
+CCfLYD88cZvzSbGfsRkkvmECgYBLPv1TXh0dytUnS0sL9sHohPMD+qrSGlZYCXr/
+J7K92dsqwcIJ9nSyEGOQssJs41QMjMoLW8q96rw8HR1qFuC6Lgj5UrOWrnZLB9HC
+Zmh4GCSV6gZgwyeSzvkOZL4EByW1n/Dv3gNr3KiThtDzbJqbs805+m/HzlDj6Zkn
+HIeCEQKBgGBSn1dd93zD52eBQ37NXsDRyCTKYY03Ux573Y/0Gb5TV2C6vJdnBtoW
+zGtnCV4IyN9i7uoz/3F4q5b2vGvyQRC12c9ZILKdGfR3IqtMrXY9ns/2r5jhD9jz
+1DwwVIoQy6qHRVApUesBCI7HfRqwTwY0ZtH1LqpZij8qSlc1X7Sr
 -----END RSA PRIVATE KEY-----`
-	fmt.Println("privateKeyBuff.Bytes()-->", dz)
 
-	_, err := SignWithMD5([]byte("test"), []byte(dz))
+func TestSignWithMD5(t *testing.T) {
+	sig, err := SignWithMD5([]byte("test"), []byte(testPrivateKey))
 	if err != nil {
-		panic(err)
+		t.Fatalf("SignWithMD5 failed: %v", err)
+	}
+	if sig == "" {
+		t.Fatal("SignWithMD5 returned empty signature")
+	}
+}
+
+func TestSignWithSHA256(t *testing.T) {
+	sig, err := SignWithSHA256([]byte("test"), []byte(testPrivateKey))
+	if err != nil {
+		t.Fatalf("SignWithSHA256 failed: %v", err)
+	}
+	if sig == "" {
+		t.Fatal("SignWithSHA256 returned empty signature")
+	}
+}
+
+func TestSignWithSHA256_InvalidKey(t *testing.T) {
+	_, err := SignWithSHA256([]byte("test"), []byte("invalid key"))
+	if err == nil {
+		t.Fatal("SignWithSHA256 should fail with invalid key")
 	}
 }

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -6,7 +6,7 @@ API_BASE=${API_BASE:-http://localhost:8090}
 TEST_USER=${TEST_USER:-test_user_a}
 TEST_PASS=${TEST_PASS:-testpass123}
 TEST_UID=${TEST_UID:-aee7e220529141bfa5e0ac4a3a3dd40d}
-BOT_TOKEN=${BOT_TOKEN:?"BOT_TOKEN must be set (e.g. export BOT_TOKEN=bf_...)"}
+BOT_TOKEN=${BOT_TOKEN:-}
 BOT_ID=${BOT_ID:-e2e_test_bot}
 GROUP_ID=${GROUP_ID:-f1f2f95f8d324b6ea1ee4b626dfd16b8}
 DEVICE_ID=${DEVICE_ID:-cli-e2e}

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -6,7 +6,7 @@ API_BASE=${API_BASE:-http://localhost:8090}
 TEST_USER=${TEST_USER:-test_user_a}
 TEST_PASS=${TEST_PASS:-testpass123}
 TEST_UID=${TEST_UID:-aee7e220529141bfa5e0ac4a3a3dd40d}
-BOT_TOKEN=${BOT_TOKEN:-bf_605883eed917f57e7e46b347fe066e9b}
+BOT_TOKEN=${BOT_TOKEN:?"BOT_TOKEN must be set (e.g. export BOT_TOKEN=bf_...)"}
 BOT_ID=${BOT_ID:-e2e_test_bot}
 GROUP_ID=${GROUP_ID:-f1f2f95f8d324b6ea1ee4b626dfd16b8}
 DEVICE_ID=${DEVICE_ID:-cli-e2e}

--- a/tests/load/api-stress.js
+++ b/tests/load/api-stress.js
@@ -2,7 +2,9 @@ import http from 'k6/http';
 import { check, sleep } from 'k6';
 import { Rate, Trend } from 'k6/metrics';
 
-const BASE_URL = __ENV.API_URL || 'http://localhost:8090';
+const BASE_URL   = __ENV.API_URL   || 'http://localhost:8090';
+const BOT_TOKEN  = __ENV.BOT_TOKEN;
+if (!BOT_TOKEN) { throw new Error('BOT_TOKEN env var is required'); }
 const errorRate = new Rate('errors');
 const loginTrend = new Trend('login_duration');
 
@@ -61,7 +63,7 @@ export function loginTest() {
 
 export function botEventsTest() {
   const res = http.post(`${BASE_URL}/v1/bot/events`, JSON.stringify({ event_id: 0, limit: 10 }), {
-    headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer bf_605883eed917f57e7e46b347fe066e9b' },
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${BOT_TOKEN}` },
   });
   check(res, { 'events 200': (r) => r.status === 200 });
   sleep(1);
@@ -72,7 +74,7 @@ export function botSendTest() {
     channel_id: 'f1f2f95f8d324b6ea1ee4b626dfd16b8', channel_type: 2,
     payload: { type: 1, content: `k6 stress ${__VU}-${__ITER}` },
   }), {
-    headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer bf_605883eed917f57e7e46b347fe066e9b' },
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${BOT_TOKEN}` },
   });
   check(res, { 'send 200': (r) => r.status === 200 });
   sleep(1);

--- a/tests/load/bot-stress.js
+++ b/tests/load/bot-stress.js
@@ -7,9 +7,9 @@
  * 场景4: 并发消息历史查询    (POST /v1/message/channel/sync)
  *
  * 运行示例:
- *   k6 run tests/load/bot-stress.js
- *   k6 run tests/load/bot-stress.js --env API_URL=http://localhost:8090
- *   k6 run tests/load/bot-stress.js --env VUS_SEND=20 --env VUS_EVENTS=15
+ *   k6 run tests/load/bot-stress.js --env BOT_TOKEN=bf_...
+ *   k6 run tests/load/bot-stress.js --env BOT_TOKEN=bf_... --env API_URL=http://localhost:8090
+ *   k6 run tests/load/bot-stress.js --env BOT_TOKEN=bf_... --env VUS_SEND=20 --env VUS_EVENTS=15
  *
  * 注意: k6 通过 snap 安装时无法访问 /tmp，脚本需放在非 /tmp 目录下运行
  */

--- a/tests/load/bot-stress.js
+++ b/tests/load/bot-stress.js
@@ -21,7 +21,8 @@ import { Counter, Rate, Trend } from 'k6/metrics';
 // ── 配置 ─────────────────────────────────────────────────────────────────────
 
 const BASE_URL   = __ENV.API_URL   || 'http://localhost:8090';
-const BOT_TOKEN  = __ENV.BOT_TOKEN || 'bf_605883eed917f57e7e46b347fe066e9b';
+const BOT_TOKEN  = __ENV.BOT_TOKEN;
+if (!BOT_TOKEN) { throw new Error('BOT_TOKEN env var is required'); }
 const GROUP_ID   = __ENV.GROUP_ID  || 'f1f2f95f8d324b6ea1ee4b626dfd16b8';
 
 // Fix 4: 用 Number() || default 替代 parseInt，避免 NaN 静默传入

--- a/tests/test-bot.sh
+++ b/tests/test-bot.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Bot API integration tests
 source "$(dirname "$0")/lib.sh"
+: "${BOT_TOKEN:?BOT_TOKEN must be set (e.g. export BOT_TOKEN=bf_...)}"
 reset_counters
 log_section "Bot Tests"
 

--- a/tests/test-messaging.sh
+++ b/tests/test-messaging.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 source "$(dirname "$0")/lib.sh"
+: "${BOT_TOKEN:?BOT_TOKEN must be set (e.g. export BOT_TOKEN=bf_...)}"
 reset_counters
 log_section "Messaging Tests"
 


### PR DESCRIPTION
## Summary

Replace the hardcoded RSA private key in `pkg/wkrsa/rsa_test.go` with a freshly generated test-only key and add a `.gitleaks.toml` configuration to suppress known false positives.

## Changes

- **`pkg/wkrsa/rsa_test.go`**: Replace the old RSA key (committed in initial import) with a new 2048-bit test key. Extract into a shared `testPrivateKey` const.
- **`.gitleaks.toml`**: Allowlist documentation placeholder tokens (`YOUR_BOT_TOKEN`, `uk_YOUR_API_KEY`), test file paths, and the RFC 6455 WebSocket sample nonce.

## Verification

- All `pkg/wkrsa` tests pass with the new key (`go test ./pkg/wkrsa/ -v`).
- `gitleaks detect --no-git` returns zero findings on the working tree.

## Follow-up needed (post-merge)

Git history still contains:
1. The old RSA private key (from initial commit)
2. Real MinIO/MySQL credentials from a deleted `docker/tsdd/.env` file
3. A real server IP address (`35.221.229.58`)

Recommend running `git filter-repo` on the default branch to scrub these from history before making this repository public. Affected credentials should also be rotated.