### PR TITLE
ci: add GitHub Actions CI workflow (build, test, vet, lint)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+# CI pipeline for octo-server
+# Runs on every pull request targeting main or release/** branches.
+# Designed to be used as required status checks in branch rulesets.
+
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release/**'
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  GO_VERSION: '1.20'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build
+        run: CGO_ENABLED=0 go build -v ./...
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Run tests
+        run: go test -race -count=1 -timeout 10m ./...
+
+  vet:
+    name: Vet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Vet
+        run: go vet ./...
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          args: --timeout=5m


### PR DESCRIPTION
## Summary

Add a CI pipeline for octo-server, triggered on every PR to `main` and `release/**` branches.

## Jobs

| Job | Command | Purpose |
|-----|---------|---------|
| **Build** | `CGO_ENABLED=0 go build -v ./...` | Compile check |
| **Test** | `go test -race -count=1 -timeout 10m ./...` | Unit tests with race detector |
| **Vet** | `go vet ./...` | Static analysis |
| **Lint** | `golangci-lint` (latest, 5m timeout) | Code quality |

## Design Decisions

- **Go 1.20** — matches go.mod and Dockerfile
- **CGO_ENABLED=0** — matches production build (Dockerfile)
- **`-race` flag** — catches data races early
- **`-count=1`** — disables test caching for reliable CI results
- **Concurrency control** — cancels in-progress runs on the same PR to save runner minutes
- **Read-only permissions** — principle of least privilege
- **`test` depends on `build`** — fail fast on compile errors before running 192 test files

## Next Steps

After this CI workflow runs green, add these as required status checks to the `main-protection` and `release-protection` rulesets:
- `Build`
- `Test`
- `Vet`
- `Lint`
