### PR TITLE
security: close gitleaks config gaps from PR#5 (app_ token + path allowlist)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -27,20 +27,51 @@ useDefault = true
     regexTarget = "match"
     regexes = ['''uk_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6''']
 
-# ── Global allowlist: doc placeholders, test fixtures, RFC test vectors ──────
+[[rules]]
+  id = "octo-app-bot-token"
+  description = "OCTO App Bot token (app_ + 32 hex chars)"
+  regex = '''\bapp_[A-Fa-f0-9]{32}\b'''
+  tags = ["token", "app-bot"]
+
+  [rules.allowlist]
+    description = "Synthetic test-only tokens in bot_api unit tests"
+    regexTarget = "match"
+    regexes = [
+      '''app_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6''',
+      '''app_d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9''',
+    ]
+
+# ── Global allowlist: doc placeholders and test fixtures ─────────────────────
+#
+# Every entry is an explicit content marker — a substring of a specific,
+# known-safe string (doc placeholder, RFC test vector, or test fixture).
+#
+# Why no `paths = [...]` here (follow-up to issue #8):
+# Gitleaks' legacy `[allowlist]` table ignores `condition = "AND"` in v8.21.x
+# (only `[[allowlists]]` honors it, and not reliably for every match target).
+# A path-only allowlist therefore acts as a blanket OR: any future secret
+# pasted into the listed files would be silently swallowed. Matching on
+# content instead keeps suppression precise — only the specific fixtures we
+# reviewed are allowlisted; a newly planted secret in the same file will
+# still trigger a finding (verified with a planted RSA PEM in rsa_test.go).
 
 [allowlist]
   description = "Doc placeholders, test fixtures, and RFC test vectors"
   regexTarget = "match"
   regexes = [
+    # Documentation placeholders (Botfather SKILL / README samples)
     '''YOUR_BOT_TOKEN''',
     '''uk_YOUR_API_KEY''',
+    # RFC 6455 WebSocket test vector (scripts/smoke-test.sh)
     '''dGhlIHNhbXBsZSBub25jZQ==''',
-    '''ghp_SensitiveTokenThatShouldNotBeLogged123''',
+    # OAuth regression-test fixture (modules/user/api_oauth_test.go)
+    # Note: gitleaks' github-pat rule captures only the first 36 chars after
+    # ghp_, so we match the stable prefix to cover both captures reliably.
+    '''ghp_SensitiveTokenThatShouldNotBeLogged''',
     '''gho_abc123def456''',
+    # Webhook-signing test fixture (modules/webhook/common_test.go)
     '''abc12345xyz67890''',
-  ]
-  paths = [
-    '''pkg/wkrsa/rsa_test\.go$''',
-    '''modules/user/api_oauth_test\.go$''',
+    # RSA test-only PEM fixture (pkg/wkrsa/rsa_test.go) — freshly generated
+    # during the pre-open-source secret scrub; first-line base64 marker.
+    '''MIIEowIBAAKCAQEA0GTVoxu02WMdxeg''',
   ]

--- a/pkg/wkrsa/rsa_test.go
+++ b/pkg/wkrsa/rsa_test.go
@@ -1,6 +1,12 @@
 package wkrsa
 
 import (
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
 	"testing"
 )
 
@@ -46,12 +52,33 @@ func TestSignWithMD5(t *testing.T) {
 }
 
 func TestSignWithSHA256(t *testing.T) {
-	sig, err := SignWithSHA256([]byte("test"), []byte(testPrivateKey))
+	data := []byte("test")
+	sig, err := SignWithSHA256(data, []byte(testPrivateKey))
 	if err != nil {
 		t.Fatalf("SignWithSHA256 failed: %v", err)
 	}
 	if sig == "" {
 		t.Fatal("SignWithSHA256 returned empty signature")
+	}
+
+	// Verify the signature round-trips: decode from base64, then verify
+	// against the public half of the test key. This catches hash/sign
+	// regressions that a non-empty-string assertion alone would miss.
+	sigBytes, err := base64.StdEncoding.DecodeString(sig)
+	if err != nil {
+		t.Fatalf("failed to base64-decode signature: %v", err)
+	}
+	block, _ := pem.Decode([]byte(testPrivateKey))
+	if block == nil {
+		t.Fatal("failed to decode test private key PEM")
+	}
+	priv, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse test private key: %v", err)
+	}
+	hashed := sha256.Sum256(data)
+	if err := rsa.VerifyPKCS1v15(&priv.PublicKey, crypto.SHA256, hashed[:], sigBytes); err != nil {
+		t.Fatalf("signature verify failed: %v", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #8.

Follow-up on @Jerry-Xin's R2 review of PR #5. Two legit warnings plus the P2 test-strength suggestion.

## 1. app_ token rule (detection gap)

`modules/app_bot/app_bot.go:29` defines `AppBotTokenPrefix = "app_"`, but `.gitleaks.toml` only had rules for `bf_` and `uk_`. A leaked production `app_bot` token would have passed gitleaks silently.

Added `octo-app-bot-token` ( `\bapp_[A-Fa-f0-9]{32}\b` ) with a rule-level allowlist covering the two synthetic fixtures currently in `modules/bot_api/*_test.go`.

## 2. Path allowlist silent-swallow (future-proof gap)

Original config had:

```toml
[allowlist]
  paths = [ '''pkg/wkrsa/rsa_test\.go$''', '''modules/user/api_oauth_test\.go$''' ]
```

With gitleaks' default `OR` condition, path match alone suppressed **any** future secret pasted into those files.

I first tried the recommended path A (`condition = "AND"`), but gitleaks v8.21.x's legacy `[allowlist]` table silently ignores `condition` (only the newer `[[allowlists]]` array honors it, and its matching against the `private-key` rule's full-PEM match turned out to be unreliable).

So this PR takes a slightly more thorough path: **remove the path allowlist entirely and list explicit content markers** for every known-safe fixture. Each entry is now a substring of a specific string — doc placeholder, RFC test vector, or fixture PEM header. Suppression is still minimal, but future additions of *different* secrets to those files are no longer silently swallowed.

## 3. TestSignWithSHA256 verify step (P2 — accepted)

The old test only asserted "signature string is non-empty". Added base64-decode + `rsa.VerifyPKCS1v15` against the public half of the test key, so hash/sign regressions can't slip through as a non-empty but wrong blob.

## Verification

```bash
# 1. gitleaks clean on current tree
gitleaks detect --no-git --config .gitleaks.toml --redact
# → no leaks found

# 2. token-prefix horizontal grep (all 3 prefixes mapped to rules)
grep -rnE '(Token|Key|Secret)Prefix\s*=\s*"[a-z]+_"' . --include='*.go'
# → bf_, uk_, app_ — each has a [[rules]] entry in .gitleaks.toml

# 3. planted-key adversarial test (required by issue #8)
#    Temporarily appended a fresh fake RSA PEM to pkg/wkrsa/rsa_test.go
#    that matches no allowlist regex.
gitleaks detect --no-git --config .gitleaks.toml --redact -v
# → leaks found: 1  (RuleID: private-key, pkg/wkrsa/rsa_test.go)
# Confirms the "path-based silent swallow" gap is closed. Planted edit
# reverted before commit.

# 4. go test
go test ./pkg/wkrsa/
# → ok
```

## Scope
`.gitleaks.toml` (+36 / −5) and `pkg/wkrsa/rsa_test.go` (+29 / −2). No production code touched.

<!-- reviewbot-verdict: COMMENTED -->
<!-- reviewbot-head-sha: b7ee73a152b75d945c93c67ec03605dff5746111 -->
<!-- reviewbot-repo: Mininglamp-OSS/octo-server -->
