### PR TITLE
ci: add Octo CI status caller workflow

### DIFF
--- a/.github/workflows/octo-ci-status.yml
+++ b/.github/workflows/octo-ci-status.yml
@@ -13,7 +13,6 @@ jobs:
       repo_name: ${{ github.event.workflow_run.repository.name }}
       workflow_name: ${{ github.event.workflow_run.name }}
       conclusion: ${{ github.event.workflow_run.conclusion }}
-      run_id: ${{ github.event.workflow_run.id }}
       run_url: ${{ github.event.workflow_run.html_url }}
       project_group_id: "9ea115c7462b4b45b8c85d07d07e0dde"
     secrets:


### PR DESCRIPTION
Caller workflow that triggers the org-level reusable `octo-ci-status.yml` when the `CI` workflow completes on main.

Only notifies Octo on state changes (success→failure or failure→success). Silent when state is unchanged.