### PR TITLE
fix(group): unsubscribe removed members from all non-deleted thread channels (#27)

### DIFF
--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -2966,49 +2966,11 @@ func (g *Group) groupExit(c *wkhttp.Context) {
 
 }
 
-// removeUserFromGroupThreads 移除用户在某群下所有子区的成员记录、IM 订阅和置顶
+// removeUserFromGroupThreads 移除用户在某群下所有子区的成员记录、IM 订阅和置顶。
+// 委托给包级 removeUserFromGroupThreadsCleanup，保留方法签名以最小化调用方改动；
+// 见 thread_cleanup.go 注释（Issue #27）。
 func (g *Group) removeUserFromGroupThreads(groupNo, uid, spaceID string) {
-	// 查询用户在该群加入的所有子区（shortID 用于构建 IM channelID）
-	type threadInfo struct {
-		ShortID string `db:"short_id"`
-	}
-	var threads []threadInfo
-	_, err := g.db.session.Select("thread.short_id").
-		From("thread").
-		Join("thread_member", "thread.id = thread_member.thread_id").
-		Where("thread.group_no=? AND thread_member.uid=? AND thread.status!=3", groupNo, uid).
-		Load(&threads)
-	if err != nil {
-		g.Error("查询用户子区失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("uid", uid))
-		return
-	}
-	if len(threads) == 0 {
-		return
-	}
-
-	// 删除成员记录
-	_, err = g.db.session.DeleteFrom("thread_member").
-		Where("uid=? AND thread_id IN (SELECT id FROM thread WHERE group_no=?)", uid, groupNo).
-		Exec()
-	if err != nil {
-		g.Error("删除子区成员失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("uid", uid))
-		return
-	}
-
-	// 移除 IM 订阅和置顶
-	for _, t := range threads {
-		// 子区 channelID 格式: {groupNo}____{shortID} (与 thread.BuildChannelID 一致)
-		channelID := groupNo + "____" + t.ShortID
-		if rmErr := g.ctx.IMRemoveSubscriber(&config.SubscriberRemoveReq{
-			ChannelID:   channelID,
-			ChannelType: common.ChannelTypeCommunityTopic.Uint8(),
-			Subscribers: []string{uid},
-		}); rmErr != nil {
-			g.Error("移除子区IM订阅者失败", zap.Error(rmErr), zap.String("channelID", channelID), zap.String("uid", uid))
-		}
-		// 清理用户在该子区的置顶
-		user.RemovePinnedForUserInSpace(uid, spaceID, channelID, common.ChannelTypeCommunityTopic.Uint8())
-	}
+	removeUserFromGroupThreadsCleanup(g.ctx, g.Log, groupNo, uid, spaceID)
 }
 
 // addUsersToGroupThreads 新成员入群时，将其加入该群所有子区的 IM 订阅（允许发消息）

--- a/modules/group/api_groupexit_cascade_thread_test.go
+++ b/modules/group/api_groupexit_cascade_thread_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/stretchr/testify/assert"
@@ -15,7 +16,13 @@ import (
 // group 模块的测试不会自动运行 thread 模块的迁移，沿用 TestMain 里手工建表的同款做法。
 func ensureThreadTables(t *testing.T, f *Group) {
 	t.Helper()
-	_, err := f.ctx.DB().UpdateBySql(`CREATE TABLE IF NOT EXISTS thread (
+	ensureThreadTablesByCtx(t, f.ctx)
+}
+
+// ensureThreadTablesByCtx 同 ensureThreadTables 但直接接受 ctx，方便 service 层 / 纯 ctx 测试复用。
+func ensureThreadTablesByCtx(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	_, err := ctx.DB().UpdateBySql(`CREATE TABLE IF NOT EXISTS thread (
 		id BIGINT AUTO_INCREMENT PRIMARY KEY,
 		short_id VARCHAR(32) NOT NULL,
 		group_no VARCHAR(40) NOT NULL,
@@ -29,7 +36,7 @@ func ensureThreadTables(t *testing.T, f *Group) {
 		UNIQUE KEY uk_short_id (short_id)
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`).Exec()
 	require.NoError(t, err)
-	_, err = f.ctx.DB().UpdateBySql(`CREATE TABLE IF NOT EXISTS thread_member (
+	_, err = ctx.DB().UpdateBySql(`CREATE TABLE IF NOT EXISTS thread_member (
 		id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
 		thread_id BIGINT UNSIGNED NOT NULL,
 		uid VARCHAR(40) NOT NULL,
@@ -41,8 +48,8 @@ func ensureThreadTables(t *testing.T, f *Group) {
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`).Exec()
 	require.NoError(t, err)
 	// CleanAllTables 之后再 delete 一遍，保证干净
-	_, _ = f.ctx.DB().DeleteFrom("thread_member").Exec()
-	_, _ = f.ctx.DB().DeleteFrom("thread").Exec()
+	_, _ = ctx.DB().DeleteFrom("thread_member").Exec()
+	_, _ = ctx.DB().DeleteFrom("thread").Exec()
 }
 
 // TestGroupExit_CascadeBot_AlsoRemovesFromThread 回归 YUJ-52 / Mininglamp-OSS/octo-server#1189：

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -1827,47 +1827,10 @@ func beginAvatarUpdateEvent(ctx *config.Context, db *DB, groupNo string, memberU
 	return eventID, nil
 }
 
-// removeUserFromGroupThreads 移除用户在某群下所有子区的成员记录、IM 订阅和置顶（直接 SQL）
+// removeUserFromGroupThreads 委托给包级 removeUserFromGroupThreadsCleanup；
+// 见 thread_cleanup.go 注释（Issue #27）。
 func (s *Service) removeUserFromGroupThreads(groupNo, uid, spaceID string) {
-	type threadInfo struct {
-		ShortID string `db:"short_id"`
-	}
-	var threads []threadInfo
-	_, err := s.ctx.DB().Select("thread.short_id").
-		From("thread").
-		Join("thread_member", "thread.id = thread_member.thread_id").
-		Where("thread.group_no=? AND thread_member.uid=? AND thread.status!=3", groupNo, uid).
-		Load(&threads)
-	if err != nil {
-		s.Error("query user threads failed", zap.Error(err), zap.String("groupNo", groupNo), zap.String("uid", uid))
-		return
-	}
-	if len(threads) == 0 {
-		return
-	}
-
-	// 删除成员记录
-	_, err = s.ctx.DB().DeleteFrom("thread_member").
-		Where("uid=? AND thread_id IN (SELECT id FROM thread WHERE group_no=?)", uid, groupNo).
-		Exec()
-	if err != nil {
-		s.Error("delete thread member failed", zap.Error(err), zap.String("groupNo", groupNo), zap.String("uid", uid))
-		return
-	}
-
-	// 移除 IM 订阅和置顶
-	for _, t := range threads {
-		channelID := groupNo + "____" + t.ShortID
-		if rmErr := s.ctx.IMRemoveSubscriber(&config.SubscriberRemoveReq{
-			ChannelID:   channelID,
-			ChannelType: common.ChannelTypeCommunityTopic.Uint8(),
-			Subscribers: []string{uid},
-		}); rmErr != nil {
-			s.Error("remove thread IM subscriber failed", zap.Error(rmErr), zap.String("channelID", channelID), zap.String("uid", uid))
-		}
-		// 清理用户在该子区的置顶
-		user.RemovePinnedForUserInSpace(uid, spaceID, channelID, common.ChannelTypeCommunityTopic.Uint8())
-	}
+	removeUserFromGroupThreadsCleanup(s.ctx, s.Log, groupNo, uid, spaceID)
 }
 
 // addUsersToGroupThreads 新成员入群时，将其加入该群所有子区的 IM 订阅（直接 SQL）

--- a/modules/group/thread_cleanup.go
+++ b/modules/group/thread_cleanup.go
@@ -1,0 +1,81 @@
+package group
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"go.uber.org/zap"
+)
+
+// queryThreadShortIDsForCleanup 返回某群下所有需要在"成员被踢/退群"时摘除 IM 订阅的子区
+// short_id（active + archived，排除 deleted）。
+//
+// Issue #27：旧实现把 thread JOIN thread_member 过滤，导致没主动 JoinThread 的成员（典型
+// 就是 Bot）查不到子区 → IMRemoveSubscriber 不被调用 → Bot 被踢后仍订阅子区频道并通过
+// WuKongIM WebSocket 持续收子区消息。子区频道的 IM 订阅本就是入群时按"父群成员"批量挂上
+// 的（参考 addUsersToGroupThreads，WHERE status!=3），出群必须对称地按"父群所有非删除子区"
+// 摘订阅。archived 子区可被 UnarchiveThread 重新激活，因此也必须摘除。
+func queryThreadShortIDsForCleanup(ctx *config.Context, groupNo string) ([]string, error) {
+	if groupNo == "" {
+		return nil, nil
+	}
+	type row struct {
+		ShortID string `db:"short_id"`
+	}
+	var rows []row
+	_, err := ctx.DB().Select("short_id").
+		From("thread").
+		Where("group_no=? AND status!=3", groupNo).
+		Load(&rows)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r.ShortID)
+	}
+	return out, nil
+}
+
+// removeUserFromGroupThreadsCleanup 是被踢/退群路径上"清理某用户在某群所有子区的 thread_member
+// 记录、IM 订阅和置顶"的统一入口。原本 (*Group).removeUserFromGroupThreads 与
+// (*Service).removeUserFromGroupThreads 是两份逐字重复的实现且各自带 Issue #27 的同型 bug；
+// 这里合并到一处，避免下次再"修一处漏一处"。
+//
+// 调用方负责自己的日志 zap 字段上下文，这里的错误仅写 ctx 默认 logger（与原行为一致：失败
+// 只记日志、不中断）。logger 由调用方传入以保留原有 module 标签。
+func removeUserFromGroupThreadsCleanup(ctx *config.Context, logger log.Log, groupNo, uid, spaceID string) {
+	if groupNo == "" || uid == "" {
+		return
+	}
+	shortIDs, err := queryThreadShortIDsForCleanup(ctx, groupNo)
+	if err != nil {
+		logger.Error("查询群子区失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("uid", uid))
+		return
+	}
+	if len(shortIDs) == 0 {
+		return
+	}
+
+	// best-effort 删除 thread_member 行：DELETE 按 uid 过滤，没有匹配行也是 0 rows affected。
+	// 即使删除失败也要继续摘 IM 订阅 —— 不能让 DB 异常导致订阅泄漏。
+	if _, err := ctx.DB().DeleteFrom("thread_member").
+		Where("uid=? AND thread_id IN (SELECT id FROM thread WHERE group_no=?)", uid, groupNo).
+		Exec(); err != nil {
+		logger.Error("删除子区成员记录失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("uid", uid))
+	}
+
+	for _, shortID := range shortIDs {
+		// 子区 channelID 格式: {groupNo}____{shortID} (与 thread.BuildChannelID 一致)
+		channelID := groupNo + "____" + shortID
+		if rmErr := ctx.IMRemoveSubscriber(&config.SubscriberRemoveReq{
+			ChannelID:   channelID,
+			ChannelType: common.ChannelTypeCommunityTopic.Uint8(),
+			Subscribers: []string{uid},
+		}); rmErr != nil {
+			logger.Error("移除子区IM订阅者失败", zap.Error(rmErr), zap.String("channelID", channelID), zap.String("uid", uid))
+		}
+		user.RemovePinnedForUserInSpace(uid, spaceID, channelID, common.ChannelTypeCommunityTopic.Uint8())
+	}
+}

--- a/modules/group/thread_cleanup_test.go
+++ b/modules/group/thread_cleanup_test.go
@@ -1,0 +1,159 @@
+package group
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestQueryThreadShortIDsForCleanup_ReturnsAllNonDeletedRegardlessOfMembership
+// 这是 Issue #27 的核心回归：群下有 active+archived 子区，但 uid 未在 thread_member
+// 表里出现（Bot 入群后不会主动 JoinThread 的常见情况）。修复前 SQL 用 JOIN
+// thread_member 过滤导致返回空切片，IMRemoveSubscriber 永远不被调用 → Bot 被踢后
+// 仍订阅子区频道。修复后应返回所有非 deleted 子区的 short_id。
+func TestQueryThreadShortIDsForCleanup_ReturnsAllNonDeletedRegardlessOfMembership(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	ensureThreadTablesByCtx(t, ctx)
+
+	const groupNo = "g_issue27_basic"
+	// active
+	_, err := ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("th_active", groupNo, "active", "owner", 1, 1).Exec()
+	require.NoError(t, err)
+	// archived (status=2) — 可被 unarchive 重激活，不能漏摘订阅
+	_, err = ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("th_archived", groupNo, "archived", "owner", 2, 1).Exec()
+	require.NoError(t, err)
+	// deleted (status=3) — 必须排除（IM 频道已销毁）
+	_, err = ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("th_deleted", groupNo, "deleted", "owner", 3, 1).Exec()
+	require.NoError(t, err)
+	// 另一个群下的子区，不应被返回
+	_, err = ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("th_other_group", "g_other", "other", "owner", 1, 1).Exec()
+	require.NoError(t, err)
+
+	// 关键：不插入任何 thread_member 行 —— 模拟 Bot 入群后未 JoinThread
+	shortIDs, err := queryThreadShortIDsForCleanup(ctx, groupNo)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"th_active", "th_archived"}, shortIDs,
+		"必须返回所有非 deleted 子区，不能依赖 thread_member（Issue #27）")
+}
+
+// TestQueryThreadShortIDsForCleanup_EmptyGroupNo 防御：空 group_no 直接返回空。
+func TestQueryThreadShortIDsForCleanup_EmptyGroupNo(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	ensureThreadTablesByCtx(t, ctx)
+
+	shortIDs, err := queryThreadShortIDsForCleanup(ctx, "")
+	require.NoError(t, err)
+	assert.Empty(t, shortIDs)
+}
+
+// TestQueryThreadShortIDsForCleanup_NoThreads 群下没子区 → 空切片。
+func TestQueryThreadShortIDsForCleanup_NoThreads(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	ensureThreadTablesByCtx(t, ctx)
+
+	shortIDs, err := queryThreadShortIDsForCleanup(ctx, "g_nothreads")
+	require.NoError(t, err)
+	assert.Empty(t, shortIDs)
+}
+
+// TestQueryThreadShortIDsForCleanup_OnlyDeleted 群下只有已删除子区 → 空切片。
+// 保证已删除子区永不被回流为 IMRemoveSubscriber 调用对象。
+func TestQueryThreadShortIDsForCleanup_OnlyDeleted(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	ensureThreadTablesByCtx(t, ctx)
+
+	const groupNo = "g_only_deleted"
+	_, err := ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("th_dead", groupNo, "dead", "owner", 3, 1).Exec()
+	require.NoError(t, err)
+
+	shortIDs, err := queryThreadShortIDsForCleanup(ctx, groupNo)
+	require.NoError(t, err)
+	assert.Empty(t, shortIDs)
+}
+
+// TestQueryThreadShortIDsForCleanup_IgnoresThreadMember 回归：thread_member 表的内容
+// 不应影响结果 —— 不管目标 uid 自己在不在 thread_member、不管别的 uid 在不在，
+// 输出只由 thread.group_no + thread.status 决定（防止 JOIN 过滤式 bug 复发）。
+func TestQueryThreadShortIDsForCleanup_IgnoresThreadMember(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	ensureThreadTablesByCtx(t, ctx)
+
+	const groupNo = "g_with_members"
+	const targetUID = "target_uid"
+	// 两个活跃子区：一个 target 自己 join 过，一个 target 没 join
+	res1, err := ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("th_joined", groupNo, "joined", "owner", 1, 1).Exec()
+	require.NoError(t, err)
+	threadIDJoined, err := res1.LastInsertId()
+	require.NoError(t, err)
+	_, err = ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("th_not_joined", groupNo, "not-joined", "owner", 1, 1).Exec()
+	require.NoError(t, err)
+
+	// target 自己在 th_joined 上有 thread_member 行
+	_, err = ctx.DB().InsertInto("thread_member").
+		Columns("thread_id", "uid", "role", "version").
+		Values(threadIDJoined, targetUID, 0, 1).Exec()
+	require.NoError(t, err)
+	// 另一个无关用户在同一个子区上也有 thread_member 行（防止 GROUP BY / DISTINCT 误折叠）
+	_, err = ctx.DB().InsertInto("thread_member").
+		Columns("thread_id", "uid", "role", "version").
+		Values(threadIDJoined, "some_other_user", 0, 1).Exec()
+	require.NoError(t, err)
+
+	shortIDs, err := queryThreadShortIDsForCleanup(ctx, groupNo)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"th_joined", "th_not_joined"}, shortIDs,
+		"无论 uid 在不在 thread_member，结果都必须是该群所有非 deleted 子区，且每个子区只出现一次")
+}
+
+// TestRemoveUserFromGroupThreadsCleanup_EmptyInputs 验证 uid/groupNo 防御守卫：
+// 空 uid 或空 groupNo 时直接 no-op，绝不下发任何 SQL/IM 调用。
+func TestRemoveUserFromGroupThreadsCleanup_EmptyInputs(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	ensureThreadTablesByCtx(t, ctx)
+
+	// 准备一个子区 + 一个 thread_member 行，用来证明守卫触发时不会被清理
+	res, err := ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("th_guard", "g_guard", "guard", "owner", 1, 1).Exec()
+	require.NoError(t, err)
+	threadID, err := res.LastInsertId()
+	require.NoError(t, err)
+	_, err = ctx.DB().InsertInto("thread_member").
+		Columns("thread_id", "uid", "role", "version").
+		Values(threadID, "u", 0, 1).Exec()
+	require.NoError(t, err)
+
+	logger := log.NewTLog("thread_cleanup_test")
+
+	removeUserFromGroupThreadsCleanup(ctx, logger, "", "u", "sp")
+	removeUserFromGroupThreadsCleanup(ctx, logger, "g_guard", "", "sp")
+
+	var count int
+	_, err = ctx.DB().Select("count(*)").From("thread_member").
+		Where("thread_id=? AND uid=?", threadID, "u").Load(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "空参数时 helper 必须立即返回、不下发 DELETE/IMRemoveSubscriber")
+}


### PR DESCRIPTION
Closes #27.

## Summary

When a member (typically a bot) is removed from a group, the parent group channel was correctly unsubscribed from WuKongIM but **thread (子区) channel subscriptions were leaked**. The removed member therefore kept receiving every thread message over its WuKongIM WebSocket connection — and any bot using that stream re-emitted them as DMs back to the user, looking like the bot was spying after removal.

## Root cause

`removeUserFromGroupThreads` (duplicated verbatim in `modules/group/api.go` and `modules/group/service.go`) listed threads via:

```sql
SELECT thread.short_id
FROM thread
JOIN thread_member ON thread.id = thread_member.thread_id
WHERE thread.group_no=? AND thread_member.uid=? AND thread.status!=3
```

The `JOIN thread_member` made the query return zero rows for any member who never actively called `JoinThread` — which is the default for bots, and also for any non-bot member who never opened a specific thread. With zero rows the helper returned early before `IMRemoveSubscriber`, so all thread channels stayed subscribed.

The mirror path is asymmetric: `addUsersToGroupThreads` subscribes a new member to **every** thread `WHERE group_no=? AND status!=3` (active + archived), regardless of `thread_member`. The remove path must match.

## What changed

- New `modules/group/thread_cleanup.go` with:
  - `queryThreadShortIDsForCleanup(ctx, groupNo)` — returns all non-deleted thread short_ids for a group; archived (`status=2`) threads are included because they can be reactivated via `UnarchiveThread`.
  - `removeUserFromGroupThreadsCleanup(ctx, logger, groupNo, uid, spaceID)` — single source of truth for the cleanup sequence: list threads → best-effort `DELETE thread_member` (no longer gates the loop on row count) → `IMRemoveSubscriber` + pinned cleanup per thread.
- `(*Group).removeUserFromGroupThreads` and `(*Service).removeUserFromGroupThreads` are now one-line delegations to the shared helper so the bug cannot regress in one copy only.
- Added `modules/group/thread_cleanup_test.go` covering:
  - bot in group with **no `thread_member` row** (the Issue #27 reproducer) — still returns all active + archived threads;
  - archived (`status=2`) included, deleted (`status=3`) excluded;
  - empty `group_no` / no-thread group → empty slice, no error;
  - unrelated user's `thread_member` row does not affect output.
- Extended `ensureThreadTables` test helper into a ctx-based variant so cleanup tests don't need a `*Group` instance.

Behavior change is intentional and surgical: only the thread-channel cleanup is widened to match the addition path. Parent-channel cleanup (`service.go:1636`) and the cascade flows (`api.go:2941`, `api.go:2902`) are unchanged.

## Verification

```
docker exec testenv-mysql-1 mysql -uroot -pdemo -e "DROP DATABASE IF EXISTS test; CREATE DATABASE test CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;"
go test -race ./modules/group/ -run "TestQueryThreadShortIDsForCleanup|TestGroupExit_CascadeBot_AlsoRemovesFromThread|TestRemoveGroupMembers_CascadeRemovesInvitedBots|TestQueryBotsInvitedByUIDTx" -count=1 -timeout 180s -v
```

All pass:
- `TestQueryThreadShortIDsForCleanup_ReturnsAllNonDeletedRegardlessOfMembership` — the direct Issue #27 reproducer
- `TestQueryThreadShortIDsForCleanup_EmptyGroupNo`
- `TestQueryThreadShortIDsForCleanup_NoThreads`
- `TestQueryThreadShortIDsForCleanup_OnlyDeleted`
- `TestQueryThreadShortIDsForCleanup_IgnoresThreadMember`
- `TestGroupExit_CascadeBot_AlsoRemovesFromThread` (existing thread regression intact)
- `TestRemoveGroupMembers_CascadeRemovesInvitedBots` (existing kick regression intact)
- `TestQueryBotsInvitedByUIDTx_BasicMatch` / `_SkipsInactiveRobot`

The package's full `-race` run hits a pre-existing infrastructure timeout from `CheckForbiddenLoop` goroutines started by `Route()` (unrelated to this change, see existing skips referencing #17); the regression-relevant subset above runs clean.

## Out of scope / follow-ups noted in #27

- `modules/botfather/command.go` bot-delete iterates parent channels but does not call into thread cleanup either. Same shape, separate fix.
- `modules/robot/event.go` `robotMessageListen` group-message dispatch has no group membership check. Affects bots polling `/v1/bot/events`, not the WebSocket-attached path that caused this report.

## Test plan

- [ ] CI green
- [ ] Manual: in a group with one or more threads, add a bot that does not auto-join threads, kick it, verify subsequent thread messages do not reach the bot's WS (check WuKongIM `channel/subscribers` for `{groupNo}____{shortID}`)