### PR TITLE
ci: improve GitHub Actions workflows for octo-server

### DIFF
--- a/.github/workflows/octo-ci-status.yml
+++ b/.github/workflows/octo-ci-status.yml
@@ -16,5 +16,6 @@ jobs:
       run_id: ${{ github.event.workflow_run.id }}
       run_url: ${{ github.event.workflow_run.html_url }}
       project_group_id: "9ea115c7462b4b45b8c85d07d07e0dde"
+      workflow_id: ${{ github.event.workflow_run.workflow_id }}
     secrets:
       OCTO_BOT_TOKEN: ${{ secrets.OCTO_BOT_TOKEN }}

--- a/.github/workflows/octo-pr-feed.yml
+++ b/.github/workflows/octo-pr-feed.yml
@@ -1,12 +1,14 @@
 name: Octo PR Feed
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, closed, reopened, ready_for_review, review_requested]
+
+permissions: {}
 
 jobs:
   notify:
-    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-feed.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-feed.yml@c6c51348fccac99161166dce1b52dec1063aeea2
     with:
       repo_name: ${{ github.event.repository.name }}
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-merged-done.yml
+++ b/.github/workflows/pr-merged-done.yml
@@ -17,6 +17,8 @@ on:
   pull_request_target:
     types: [closed]
 
+permissions: {}  # GITHUB_TOKEN not used; PROJECT_TOKEN is passed explicitly
+
 jobs:
   move-to-done:
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == github.event.repository.default_branch


### PR DESCRIPTION
## Changes

### B: Migrate `octo-pr-feed.yml` to `pull_request_target` + pinned SHA + `permissions: {}`

- Changed trigger from `pull_request` to `pull_request_target` so org secrets are available for fork PRs
- Pinned reusable workflow to SHA `c6c51348fccac99161166dce1b52dec1063aeea2` for supply-chain security
- Added `permissions: {}` to restrict default token permissions

### C: Add `workflow_id` to `octo-ci-status.yml`

Added `workflow_id: ${{ github.event.workflow_run.workflow_id }}` to the `with` block in `octo-ci-status.yml` so the CI status notification includes the workflow identifier.

### D: Add `permissions: {}` to `pr-merged-done.yml`

Adds explicit `permissions: {}` block between `on:` and `jobs:` to clarify that `GITHUB_TOKEN` is not used; only `PROJECT_TOKEN` is passed explicitly.