### PR TITLE
feat(incomingwebhook): Discord-style group incoming webhooks

### DIFF
--- a/internal/modules.go
+++ b/internal/modules.go
@@ -33,6 +33,7 @@ import (
 	_ "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/file"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/group"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/incomingwebhook"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/message"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/notify"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/oidc"

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -103,13 +103,17 @@ func (d *DB) queryMemberWithVercodes(vercodes []string) ([]*MemberGroupDetailMod
 
 // QueryIsGroupManagerOrCreator 是否是群管理者或创建者
 //
-// Fail-safe 过滤 is_external=0：外部成员即使在 DB 中残留 role=creator/manager
-// （历史脏数据或绕过 managerAdd 入口校验写入），也不视为该群的管理者。
-// 与 managerAdd / transferGrouper 的前置 is_external 校验构成双层防御
-// （YUJ-231 / GH#1289，ReviewBot YUJ-230 P1）。
+// Fail-safe 过滤：
+//   - is_external=0：外部成员即使在 DB 中残留 role=creator/manager（历史脏数据或
+//     绕过 managerAdd 入口校验写入），也不视为该群的管理者。与 managerAdd /
+//     transferGrouper 的前置 is_external 校验构成双层防御（YUJ-231 / GH#1289，
+//     ReviewBot YUJ-230 P1）。
+//   - status=GroupMemberStatusNormal：黑名单 / 已退出但 is_deleted 仍为 0 的成员
+//     即便保留 role=creator/manager，也不视为有效管理者，避免被踢出的管理者继续
+//     调用敏感 API（PR #31 round-3，Jerry-Xin）。
 func (d *DB) QueryIsGroupManagerOrCreator(groupNo string, uid string) (bool, error) {
 	var count int64
-	_, err := d.session.Select("count(*)").From("group_member").Where("group_no=? and uid=? and is_deleted=0 and is_external=0 and (role=? or role=?)", groupNo, uid, MemberRoleCreator, MemberRoleManager).Load(&count)
+	_, err := d.session.Select("count(*)").From("group_member").Where("group_no=? and uid=? and is_deleted=0 and is_external=0 and status=? and (role=? or role=?)", groupNo, uid, int(common.GroupMemberStatusNormal), MemberRoleCreator, MemberRoleManager).Load(&count)
 	return count > 0, err
 }
 

--- a/modules/group/is_manager_external_test.go
+++ b/modules/group/is_manager_external_test.go
@@ -3,6 +3,7 @@ package group
 import (
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -25,6 +26,7 @@ func TestQueryIsGroupManagerOrCreator_ExternalMemberFailSafe(t *testing.T) {
 		UID:        "internal-creator",
 		Role:       MemberRoleCreator,
 		IsExternal: 0,
+		Status:     int(common.GroupMemberStatusNormal),
 		Version:    1,
 	})
 	assert.NoError(t, err)
@@ -35,6 +37,7 @@ func TestQueryIsGroupManagerOrCreator_ExternalMemberFailSafe(t *testing.T) {
 		UID:        "external-dirty-manager",
 		Role:       MemberRoleManager,
 		IsExternal: 1,
+		Status:     int(common.GroupMemberStatusNormal),
 		Version:    2,
 	})
 	assert.NoError(t, err)
@@ -45,6 +48,7 @@ func TestQueryIsGroupManagerOrCreator_ExternalMemberFailSafe(t *testing.T) {
 		UID:        "external-dirty-creator",
 		Role:       MemberRoleCreator,
 		IsExternal: 1,
+		Status:     int(common.GroupMemberStatusNormal),
 		Version:    3,
 	})
 	assert.NoError(t, err)
@@ -55,6 +59,7 @@ func TestQueryIsGroupManagerOrCreator_ExternalMemberFailSafe(t *testing.T) {
 		UID:        "common-member",
 		Role:       MemberRoleCommon,
 		IsExternal: 0,
+		Status:     int(common.GroupMemberStatusNormal),
 		Version:    4,
 	})
 	assert.NoError(t, err)

--- a/modules/group/is_manager_status_test.go
+++ b/modules/group/is_manager_status_test.go
@@ -1,0 +1,73 @@
+package group
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestQueryIsGroupManagerOrCreator_BlacklistedFailSafe 验证 fail-safe 语义
+// （PR #31 round-3，Jerry-Xin）：status=Blacklist / Quit 但 is_deleted=0 的
+// 历史/异常成员，即使 role 仍是 creator/manager，也不应被 QueryIsGroupManagerOrCreator
+// 识别为有效管理者。否则被踢出的管理员可继续调用所有依赖该 query 的敏感 API
+// （转让群主、邀请、踢人、修改群设置、incoming webhook 管理 …）。
+//
+// 配对 [[is_manager_external_test]]：两条 fail-safe 都在同一处 WHERE 上叠加。
+func TestQueryIsGroupManagerOrCreator_BlacklistedFailSafe(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	err := testutil.CleanAllTables(ctx)
+	assert.NoError(t, err)
+
+	db := NewDB(ctx)
+	groupNo := "g-pr31-status-failsafe"
+
+	// 正常 internal creator（应被识别）
+	err = db.InsertMember(&MemberModel{
+		GroupNo:    groupNo,
+		UID:        "normal-creator",
+		Role:       MemberRoleCreator,
+		IsExternal: 0,
+		Status:     int(common.GroupMemberStatusNormal),
+		Version:    1,
+	})
+	assert.NoError(t, err)
+
+	// 黑名单 + role=creator（is_deleted=0，模拟脏数据 / 历史残留）
+	err = db.InsertMember(&MemberModel{
+		GroupNo:    groupNo,
+		UID:        "blacklisted-creator",
+		Role:       MemberRoleCreator,
+		IsExternal: 0,
+		Status:     int(common.GroupMemberStatusBlacklist),
+		Version:    2,
+	})
+	assert.NoError(t, err)
+
+	// 黑名单 + role=manager
+	err = db.InsertMember(&MemberModel{
+		GroupNo:    groupNo,
+		UID:        "blacklisted-manager",
+		Role:       MemberRoleManager,
+		IsExternal: 0,
+		Status:     int(common.GroupMemberStatusBlacklist),
+		Version:    3,
+	})
+	assert.NoError(t, err)
+
+	// 正常 creator → true
+	ok, err := db.QueryIsGroupManagerOrCreator(groupNo, "normal-creator")
+	assert.NoError(t, err)
+	assert.True(t, ok, "normal creator 应识别为管理者")
+
+	// 黑名单 creator → false（fail-safe 拦截）
+	ok, err = db.QueryIsGroupManagerOrCreator(groupNo, "blacklisted-creator")
+	assert.NoError(t, err)
+	assert.False(t, ok, "黑名单成员即便 role=creator 也不应识别为管理者")
+
+	// 黑名单 manager → false（fail-safe 拦截）
+	ok, err = db.QueryIsGroupManagerOrCreator(groupNo, "blacklisted-manager")
+	assert.NoError(t, err)
+	assert.False(t, ok, "黑名单成员即便 role=manager 也不应识别为管理者")
+}

--- a/modules/incomingwebhook/1module.go
+++ b/modules/incomingwebhook/1module.go
@@ -1,0 +1,23 @@
+package incomingwebhook
+
+import (
+	"embed"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
+)
+
+//go:embed sql
+var sqlFS embed.FS
+
+func init() {
+	register.AddModule(func(ctx interface{}) register.Module {
+		return register.Module{
+			Name: "incomingwebhook",
+			SetupAPI: func() register.APIRouter {
+				return New(ctx.(*config.Context))
+			},
+			SQLDir: register.NewSQLFS(sqlFS),
+		}
+	})
+}

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -261,18 +261,6 @@ func (w *IncomingWebhook) create(c *wkhttp.Context) {
 		return
 	}
 
-	// 配额检查
-	count, err := w.db.countByGroupNo(groupNo)
-	if err != nil {
-		w.Error("count webhooks failed", zap.Error(err))
-		c.ResponseError(errors.New("查询配额失败"))
-		return
-	}
-	if count >= maxPerGroup() {
-		c.ResponseError(fmt.Errorf("每个群最多 %d 个 webhook", maxPerGroup()))
-		return
-	}
-
 	// 查询 group 拿 space_id；同时确保群处于 Normal 状态。
 	// 已解散/已禁用的群禁止创建新 webhook，避免 disband 后被 stale 管理员复活。
 	g, err := w.requireActiveGroup(groupNo)
@@ -303,7 +291,12 @@ func (w *IncomingWebhook) create(c *wkhttp.Context) {
 		CreatorUID: loginUID,
 		Status:     1,
 	}
-	if err := w.db.insert(m); err != nil {
+	// 配额校验 + 写入在事务内原子完成；FOR UPDATE 锁住 group_no 范围，防止并发越限。
+	if err := w.db.insertWithQuota(m, maxPerGroup()); err != nil {
+		if errors.Is(err, ErrQuotaExceeded) {
+			c.ResponseError(fmt.Errorf("每个群最多 %d 个 webhook", maxPerGroup()))
+			return
+		}
 		w.Error("insert webhook failed", zap.Error(err))
 		c.ResponseError(errors.New("创建失败"))
 		return
@@ -620,6 +613,11 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 //   - 注入 from.kind=webhook 元信息，便于客户端识别非真实用户消息；
 //     客户端可统一按 markdown 渲染 webhook 消息（无 markdown 时退化为纯文本）。
 //   - @all/@here 降级为纯文本：调用方写在 content 里的字面量保留，不附 mention 字段。
+//
+// 安全：调用方 req.Extra 一律**丢弃**，不进入持久化 payload。原因：message 模块对
+// 顶层 payload 字段（如 visibles / mention / reminder 等）按服务端控制语义解释，
+// 让外部 token 持有者写这些字段会绕过群可见性 / 通知策略。如需扩展，请在此处显式
+// 列入允许字段（且明确该字段无访问控制语义），不要再走透传。
 func buildPayload(m *incomingWebhookModel, req *pushPayloadReq) map[string]interface{} {
 	name := req.Username
 	if name == "" {
@@ -629,7 +627,7 @@ func buildPayload(m *incomingWebhookModel, req *pushPayloadReq) map[string]inter
 	if avatar == "" {
 		avatar = m.Avatar
 	}
-	payload := map[string]interface{}{
+	return map[string]interface{}{
 		"type":    int(common.Text),
 		"content": req.Content,
 		"from": map[string]interface{}{
@@ -638,20 +636,10 @@ func buildPayload(m *incomingWebhookModel, req *pushPayloadReq) map[string]inter
 			"name":       name,
 			"avatar":     avatar,
 		},
+		// space_id 必须由服务端从 group 表派生，不接受调用方覆盖，
+		// 防止 webhook 消息被伪造到其他 Space。
+		"space_id": m.SpaceID,
 	}
-	if len(req.Extra) > 0 {
-		// 透传白名单字段，避免覆盖关键字段
-		for k, v := range req.Extra {
-			if k == "type" || k == "content" || k == "from" || k == "mention" || k == "space_id" {
-				continue
-			}
-			payload[k] = v
-		}
-	}
-	// space_id 必须由服务端从 group 表派生，不接受调用方覆盖，
-	// 防止 webhook 消息被伪造到其他 Space。
-	payload["space_id"] = m.SpaceID
-	return payload
 }
 
 // recordSuccess 写审计 + 累加调用计数。失败仅记日志，不阻塞主流程。

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -608,16 +609,38 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 	})
 }
 
+// 与 create/update 路径的 webhook 名称/头像列长度约束一致，避免 push 路径成为绕过。
+const (
+	maxFromNameBytes   = 64
+	maxFromAvatarBytes = 255
+)
+
+// truncateUTF8 在 max 字节处裁剪，回退到上一 rune 边界避免破坏多字节字符。
+func truncateUTF8(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	for i := max; i > 0; i-- {
+		if utf8.RuneStart(s[i]) {
+			return s[:i]
+		}
+	}
+	return s[:max]
+}
+
 // buildPayload 把 webhook 请求映射到群消息 payload。
 //   - WuKongIM 只有 Text 类型，所有 webhook 消息都用 Text(1) 投递。
 //   - 注入 from.kind=webhook 元信息，便于客户端识别非真实用户消息；
 //     客户端可统一按 markdown 渲染 webhook 消息（无 markdown 时退化为纯文本）。
 //   - @all/@here 降级为纯文本：调用方写在 content 里的字面量保留，不附 mention 字段。
 //
-// 安全：调用方 req.Extra 一律**丢弃**，不进入持久化 payload。原因：message 模块对
-// 顶层 payload 字段（如 visibles / mention / reminder 等）按服务端控制语义解释，
-// 让外部 token 持有者写这些字段会绕过群可见性 / 通知策略。如需扩展，请在此处显式
-// 列入允许字段（且明确该字段无访问控制语义），不要再走透传。
+// 安全：
+//   - 调用方 req.Extra 一律**丢弃**，不进入持久化 payload。原因：message 模块对
+//     顶层 payload 字段（如 visibles / mention / reminder 等）按服务端控制语义解释，
+//     让外部 token 持有者写这些字段会绕过群可见性 / 通知策略。如需扩展，请在此处
+//     显式列入允许字段（且明确该字段无访问控制语义），不要再走透传。
+//   - req.Username / req.AvatarURL 服务端裁剪到 create 侧同样的字节上限。push 路径
+//     原本只受 8KB body cap 约束，调用方可塞 KB 级字符串污染所有客户端 from.* 渲染。
 func buildPayload(m *incomingWebhookModel, req *pushPayloadReq) map[string]interface{} {
 	name := req.Username
 	if name == "" {
@@ -627,6 +650,8 @@ func buildPayload(m *incomingWebhookModel, req *pushPayloadReq) map[string]inter
 	if avatar == "" {
 		avatar = m.Avatar
 	}
+	name = truncateUTF8(name, maxFromNameBytes)
+	avatar = truncateUTF8(avatar, maxFromAvatarBytes)
 	return map[string]interface{}{
 		"type":    int(common.Text),
 		"content": req.Content,

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -1,0 +1,691 @@
+package incomingwebhook
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
+	"github.com/go-redis/redis"
+	"go.uber.org/zap"
+)
+
+// 默认配置（可被环境变量覆盖）。
+const (
+	envMaxPerGroup         = "DM_INCOMINGWEBHOOK_MAX_PER_GROUP"
+	envBodyMax             = "DM_INCOMINGWEBHOOK_MAX_BYTES"
+	envRatePerWebhookRPS   = "DM_INCOMINGWEBHOOK_RPS"
+	envRatePerWebhookBurst = "DM_INCOMINGWEBHOOK_BURST"
+	envIngressIPRPS        = "DM_INCOMINGWEBHOOK_IP_RPS"
+	envIngressIPBurst      = "DM_INCOMINGWEBHOOK_IP_BURST"
+
+	defaultMaxPerGroup    = 10
+	defaultMaxBytes       = 8 * 1024
+	defaultRatePerWHRPS   = 5.0
+	defaultRatePerWHBurst = 10
+	defaultIngressIPRPS   = 30.0
+	defaultIngressIPBurst = 60
+)
+
+// 撤回权限说明：webhook 消息的 FromUID 形如 "iwh_xxx"，永远不是群成员。
+// 当群主/管理员调撤回 API 时，message.hasRevokePermission 走 fromMember==nil
+// 兜底分支允许撤回；普通成员（包括 webhook 创建者）走否定分支。这条契约依赖
+// message 模块的现有实现，未来若 message 重构 hasRevokePermission，需要在此处
+// 同步加测试或改为显式 "iwh_" 前缀分支。
+
+// IncomingWebhook 群入站 Webhook 路由层。
+type IncomingWebhook struct {
+	ctx *config.Context
+	log.Log
+	db        *incomingWebhookDB
+	groupDB   *group.DB
+	rateRedis *redis.Client
+}
+
+// rateRedisOnce 让限流用的 redis client 在进程内单例化，避免每次 New() 都开新连接池
+// 在测试或多次注册场景下泄漏（参考 pkg/wkhttp/ratelimit_helper.go 的 SharedUIDRateLimiter）。
+var (
+	rateRedisOnce   sync.Once
+	rateRedisClient *redis.Client
+)
+
+func sharedRateRedis(cfg *config.Config) *redis.Client {
+	rateRedisOnce.Do(func() {
+		rateRedisClient = redis.NewClient(&redis.Options{
+			Addr:       cfg.DB.RedisAddr,
+			Password:   cfg.DB.RedisPass,
+			MaxRetries: 1,
+			PoolSize:   10,
+		})
+	})
+	return rateRedisClient
+}
+
+// New 构造路由模块。
+func New(ctx *config.Context) *IncomingWebhook {
+	w := &IncomingWebhook{
+		ctx:       ctx,
+		Log:       log.NewTLog("IncomingWebhook"),
+		db:        newDB(ctx),
+		groupDB:   group.NewDB(ctx),
+		rateRedis: sharedRateRedis(ctx.GetConfig()),
+	}
+	// 群解散级联禁用所有 webhook
+	w.ctx.AddEventListener(event.GroupDisband, w.handleGroupDisband)
+	return w
+}
+
+// Route 注册路由。
+func (w *IncomingWebhook) Route(r *wkhttp.WKHttp) {
+	// 管理类：登录用户 + 群管理员校验。
+	mgr := r.Group("/v1/groups", w.ctx.AuthMiddleware(r))
+	{
+		mgr.POST("/:group_no/incoming-webhooks", w.create)
+		mgr.GET("/:group_no/incoming-webhooks", w.list)
+		mgr.PUT("/:group_no/incoming-webhooks/:webhook_id", w.update)
+		mgr.DELETE("/:group_no/incoming-webhooks/:webhook_id", w.delete)
+		mgr.POST("/:group_no/incoming-webhooks/:webhook_id/regenerate", w.regenerate)
+	}
+
+	// 推送类：URL 内 token 鉴权，无 AuthMiddleware；外加 IP 限流防扫 token。
+	ipRPS := appwkhttp.ParseRPSFromEnv(envIngressIPRPS, defaultIngressIPRPS)
+	ipBurst := appwkhttp.ParseBurstFromEnv(envIngressIPBurst, defaultIngressIPBurst)
+	ipLimit := appwkhttp.StrictIPRateLimitMiddleware(context.Background(), w.rateRedis, "incoming_webhook", ipRPS, ipBurst)
+
+	push := r.Group("/v1")
+	{
+		push.POST("/incoming-webhooks/:webhook_id/:token", ipLimit, w.push)
+	}
+}
+
+// ============================================================
+// 配置读取（每次读 env，便于运行时调参）
+// ============================================================
+
+func maxPerGroup() int {
+	if v := os.Getenv(envMaxPerGroup); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultMaxPerGroup
+}
+
+func maxBytes() int {
+	if v := os.Getenv(envBodyMax); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultMaxBytes
+}
+
+func perWebhookRPS() float64 {
+	return appwkhttp.ParseRPSFromEnv(envRatePerWebhookRPS, defaultRatePerWHRPS)
+}
+
+func perWebhookBurst() int {
+	return appwkhttp.ParseBurstFromEnv(envRatePerWebhookBurst, defaultRatePerWHBurst)
+}
+
+// ============================================================
+// 工具函数
+// ============================================================
+
+func generateToken() (token, hash string, err error) {
+	buf := make([]byte, 32)
+	if _, err = rand.Read(buf); err != nil {
+		return "", "", fmt.Errorf("generate token: %w", err)
+	}
+	token = hex.EncodeToString(buf)
+	sum := sha256.Sum256([]byte(token))
+	hash = hex.EncodeToString(sum[:])
+	return token, hash, nil
+}
+
+func hashToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+// generateWebhookID 用 16 字节随机数构造 webhook 的公开 ID（URL 路径段）。
+// 不截断 UUID 时间戳前缀，避免高并发下毫秒级碰撞。
+func generateWebhookID() string {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		// crypto/rand 失败概率极低；退化到 UUID 仍可保证唯一性。
+		return "iwh_" + strings.ReplaceAll(util.GenerUUID(), "-", "")
+	}
+	return "iwh_" + hex.EncodeToString(buf)
+}
+
+func toResp(m *incomingWebhookModel) webhookResp {
+	r := webhookResp{
+		WebhookID:  m.WebhookID,
+		GroupNo:    m.GroupNo,
+		Name:       m.Name,
+		Avatar:     m.Avatar,
+		CreatorUID: m.CreatorUID,
+		Status:     m.Status,
+		CallCount:  m.CallCount,
+		CreatedAt:  time.Time(m.CreatedAt).Unix(),
+	}
+	if m.LastUsedAt.Valid {
+		r.LastUsedAt = m.LastUsedAt.Time.Unix()
+	}
+	return r
+}
+
+// publicURL 构造对外推送 URL（不含 host，由前端拼接基础域名）。
+func publicURL(webhookID, token string) string {
+	return fmt.Sprintf("/v1/incoming-webhooks/%s/%s", webhookID, token)
+}
+
+// ============================================================
+// 鉴权辅助
+// ============================================================
+
+// requireActiveGroup 查询群并校验状态为 Normal；非 Normal（含已禁用/已解散/不存在）
+// 一律按 404 拒绝。所有"会让 webhook 进入可推送状态"的写操作（create / update 启用 /
+// regenerate）以及 push 路径都必须先过这一关，确保 disband 后没有窗口期可被复活或继续推送。
+func (w *IncomingWebhook) requireActiveGroup(groupNo string) (*group.Model, error) {
+	g, err := w.groupDB.QueryWithGroupNo(groupNo)
+	if err != nil {
+		return nil, fmt.Errorf("query group: %w", err)
+	}
+	if g == nil || g.Status != group.GroupStatusNormal {
+		return nil, nil
+	}
+	return g, nil
+}
+
+// requireGroupAdmin 校验登录用户是否为群主或管理员，是则返回 (loginUID, true)；
+// 否则已写入 4xx 响应。
+func (w *IncomingWebhook) requireGroupAdmin(c *wkhttp.Context, groupNo string) (string, bool) {
+	loginUID := c.MustGet("uid").(string)
+	ok, err := w.groupDB.QueryIsGroupManagerOrCreator(groupNo, loginUID)
+	if err != nil {
+		w.Error("query group manager failed", zap.Error(err))
+		c.ResponseError(errors.New("查询群权限失败"))
+		return "", false
+	}
+	if !ok {
+		c.ResponseErrorWithStatus(errors.New("仅群主或管理员可管理 webhook"), http.StatusForbidden)
+		return "", false
+	}
+	return loginUID, true
+}
+
+// ============================================================
+// 管理端点
+// ============================================================
+
+func (w *IncomingWebhook) create(c *wkhttp.Context) {
+	groupNo := c.Param("group_no")
+	loginUID, ok := w.requireGroupAdmin(c, groupNo)
+	if !ok {
+		return
+	}
+
+	var req createReq
+	if err := c.BindJSON(&req); err != nil {
+		c.ResponseError(fmt.Errorf("无效请求: %w", err))
+		return
+	}
+	req.Name = strings.TrimSpace(req.Name)
+	if req.Name == "" {
+		c.ResponseError(errors.New("name 不能为空"))
+		return
+	}
+	if len(req.Name) > 64 {
+		c.ResponseError(errors.New("name 长度需 ≤ 64"))
+		return
+	}
+
+	// 配额检查
+	count, err := w.db.countByGroupNo(groupNo)
+	if err != nil {
+		w.Error("count webhooks failed", zap.Error(err))
+		c.ResponseError(errors.New("查询配额失败"))
+		return
+	}
+	if count >= maxPerGroup() {
+		c.ResponseError(fmt.Errorf("每个群最多 %d 个 webhook", maxPerGroup()))
+		return
+	}
+
+	// 查询 group 拿 space_id；同时确保群处于 Normal 状态。
+	// 已解散/已禁用的群禁止创建新 webhook，避免 disband 后被 stale 管理员复活。
+	g, err := w.requireActiveGroup(groupNo)
+	if err != nil {
+		w.Error("query group failed", zap.Error(err))
+		c.ResponseError(errors.New("查询群信息失败"))
+		return
+	}
+	if g == nil {
+		c.ResponseErrorWithStatus(errors.New("群不存在或已解散"), http.StatusNotFound)
+		return
+	}
+
+	token, hash, err := generateToken()
+	if err != nil {
+		w.Error("generate token failed", zap.Error(err))
+		c.ResponseError(errors.New("创建失败"))
+		return
+	}
+
+	m := &incomingWebhookModel{
+		WebhookID:  generateWebhookID(),
+		TokenHash:  hash,
+		GroupNo:    groupNo,
+		SpaceID:    g.SpaceID,
+		Name:       req.Name,
+		Avatar:     req.Avatar,
+		CreatorUID: loginUID,
+		Status:     1,
+	}
+	if err := w.db.insert(m); err != nil {
+		w.Error("insert webhook failed", zap.Error(err))
+		c.ResponseError(errors.New("创建失败"))
+		return
+	}
+
+	resp := createResp{
+		webhookResp: toResp(m),
+		Token:       token,
+		URL:         publicURL(m.WebhookID, token),
+	}
+	c.Response(resp)
+}
+
+func (w *IncomingWebhook) list(c *wkhttp.Context) {
+	groupNo := c.Param("group_no")
+	if _, ok := w.requireGroupAdmin(c, groupNo); !ok {
+		return
+	}
+	list, err := w.db.queryByGroupNo(groupNo)
+	if err != nil {
+		w.Error("list webhooks failed", zap.Error(err))
+		c.ResponseError(errors.New("查询失败"))
+		return
+	}
+	resps := make([]webhookResp, 0, len(list))
+	for _, m := range list {
+		resps = append(resps, toResp(m))
+	}
+	c.Response(map[string]interface{}{"list": resps})
+}
+
+func (w *IncomingWebhook) update(c *wkhttp.Context) {
+	groupNo := c.Param("group_no")
+	webhookID := c.Param("webhook_id")
+	if _, ok := w.requireGroupAdmin(c, groupNo); !ok {
+		return
+	}
+
+	m, err := w.db.queryByWebhookID(webhookID)
+	if err != nil {
+		w.Error("query webhook failed", zap.Error(err))
+		c.ResponseError(errors.New("查询失败"))
+		return
+	}
+	if m == nil || m.GroupNo != groupNo {
+		c.ResponseErrorWithStatus(errors.New("webhook 不存在"), http.StatusNotFound)
+		return
+	}
+
+	var req updateReq
+	if err := c.BindJSON(&req); err != nil {
+		c.ResponseError(fmt.Errorf("无效请求: %w", err))
+		return
+	}
+
+	fields := map[string]interface{}{}
+	if req.Name != nil {
+		name := strings.TrimSpace(*req.Name)
+		if name == "" || len(name) > 64 {
+			c.ResponseError(errors.New("name 不合法"))
+			return
+		}
+		fields["name"] = name
+	}
+	if req.Avatar != nil {
+		fields["avatar"] = *req.Avatar
+	}
+	if req.Status != nil {
+		if *req.Status != 0 && *req.Status != 1 {
+			c.ResponseError(errors.New("status 仅允许 0 或 1"))
+			return
+		}
+		// 启用 webhook 前必须确认群仍处于 Normal —— 阻断 disband → re-enable 复活路径。
+		// 禁用（status=0）始终允许，便于管理员主动关停。
+		if *req.Status == 1 {
+			g, err := w.requireActiveGroup(groupNo)
+			if err != nil {
+				w.Error("query group failed", zap.Error(err))
+				c.ResponseError(errors.New("查询群信息失败"))
+				return
+			}
+			if g == nil {
+				c.ResponseErrorWithStatus(errors.New("群不存在或已解散，无法启用 webhook"), http.StatusNotFound)
+				return
+			}
+		}
+		fields["status"] = *req.Status
+	}
+	if len(fields) == 0 {
+		c.Response(toResp(m))
+		return
+	}
+	if err := w.db.updateFields(webhookID, fields); err != nil {
+		w.Error("update webhook failed", zap.Error(err))
+		c.ResponseError(errors.New("更新失败"))
+		return
+	}
+	updated, qErr := w.db.queryByWebhookID(webhookID)
+	if qErr != nil || updated == nil {
+		// 更新已成功落库，但回读失败/为空时返回更新前数据，不阻塞客户端。
+		c.Response(toResp(m))
+		return
+	}
+	c.Response(toResp(updated))
+}
+
+func (w *IncomingWebhook) delete(c *wkhttp.Context) {
+	groupNo := c.Param("group_no")
+	webhookID := c.Param("webhook_id")
+	if _, ok := w.requireGroupAdmin(c, groupNo); !ok {
+		return
+	}
+	m, err := w.db.queryByWebhookID(webhookID)
+	if err != nil {
+		w.Error("query webhook failed", zap.Error(err))
+		c.ResponseError(errors.New("查询失败"))
+		return
+	}
+	if m == nil || m.GroupNo != groupNo {
+		c.ResponseErrorWithStatus(errors.New("webhook 不存在"), http.StatusNotFound)
+		return
+	}
+	if err := w.db.deleteByWebhookID(webhookID); err != nil {
+		w.Error("delete webhook failed", zap.Error(err))
+		c.ResponseError(errors.New("删除失败"))
+		return
+	}
+	c.ResponseOK()
+}
+
+func (w *IncomingWebhook) regenerate(c *wkhttp.Context) {
+	groupNo := c.Param("group_no")
+	webhookID := c.Param("webhook_id")
+	if _, ok := w.requireGroupAdmin(c, groupNo); !ok {
+		return
+	}
+	// 与 create / update(启用) 保持一致：群非 Normal 不允许颁发新 token。
+	g, err := w.requireActiveGroup(groupNo)
+	if err != nil {
+		w.Error("query group failed", zap.Error(err))
+		c.ResponseError(errors.New("查询群信息失败"))
+		return
+	}
+	if g == nil {
+		c.ResponseErrorWithStatus(errors.New("群不存在或已解散"), http.StatusNotFound)
+		return
+	}
+	m, err := w.db.queryByWebhookID(webhookID)
+	if err != nil {
+		w.Error("query webhook failed", zap.Error(err))
+		c.ResponseError(errors.New("查询失败"))
+		return
+	}
+	if m == nil || m.GroupNo != groupNo {
+		c.ResponseErrorWithStatus(errors.New("webhook 不存在"), http.StatusNotFound)
+		return
+	}
+	token, hash, err := generateToken()
+	if err != nil {
+		w.Error("generate token failed", zap.Error(err))
+		c.ResponseError(errors.New("重置失败"))
+		return
+	}
+	if err := w.db.updateFields(webhookID, map[string]interface{}{"token_hash": hash}); err != nil {
+		w.Error("update token_hash failed", zap.Error(err))
+		c.ResponseError(errors.New("重置失败"))
+		return
+	}
+	m.TokenHash = hash
+	c.Response(createResp{
+		webhookResp: toResp(m),
+		Token:       token,
+		URL:         publicURL(webhookID, token),
+	})
+}
+
+// ============================================================
+// 推送端点
+// ============================================================
+
+// pushErrUnauthorized 用统一文案返回 401，不区分原因（防探测）。
+func pushUnauthorized(c *wkhttp.Context) {
+	c.AbortWithStatusJSON(http.StatusUnauthorized, map[string]interface{}{
+		"status": http.StatusUnauthorized,
+		"msg":    "unauthorized",
+	})
+}
+
+func (w *IncomingWebhook) push(c *wkhttp.Context) {
+	webhookID := c.Param("webhook_id")
+	token := c.Param("token")
+	if webhookID == "" || token == "" {
+		pushUnauthorized(c)
+		return
+	}
+
+	// 1) 查 webhook（queryByWebhookID 已把 ErrNotFound 吸收为 nil/nil）
+	m, err := w.db.queryByWebhookID(webhookID)
+	if err != nil {
+		w.Error("query webhook failed", zap.Error(err))
+		pushUnauthorized(c)
+		return
+	}
+	if m == nil || m.Status != 1 {
+		pushUnauthorized(c)
+		return
+	}
+
+	// 2) 常量时间比对 token
+	expected := hashToken(token)
+	if subtle.ConstantTimeCompare([]byte(expected), []byte(m.TokenHash)) != 1 {
+		pushUnauthorized(c)
+		return
+	}
+
+	// 2.5) 群必须仍处于 Normal —— 兜底 handleGroupDisband 的异步窗口期，
+	// 也防止对已解散群继续推送消息。统一返回 401（不区分原因，防探测）。
+	g, err := w.requireActiveGroup(m.GroupNo)
+	if err != nil {
+		w.Error("query group on push failed",
+			zap.String("webhook_id", m.WebhookID), zap.Error(err))
+		pushUnauthorized(c)
+		return
+	}
+	if g == nil {
+		pushUnauthorized(c)
+		return
+	}
+
+	// 3) per-webhook 限流；Redis 故障时显式 fail-open，避免 Redis 抖动导致全量推送被拒。
+	allowed, err := w.allowPerWebhook(c.Request.Context(), webhookID)
+	if err != nil {
+		w.Warn("per-webhook rate limit redis failed, fail-open", zap.Error(err))
+		allowed = true
+	}
+	if !allowed {
+		c.AbortWithStatusJSON(http.StatusTooManyRequests, map[string]interface{}{
+			"status": http.StatusTooManyRequests,
+			"msg":    "rate limited",
+		})
+		return
+	}
+
+	// 4) 读 body 并按统一上限拒绝过大请求。LimitReader 多读 1 字节用于判超。
+	limit := maxBytes()
+	body, err := io.ReadAll(io.LimitReader(c.Request.Body, int64(limit)+1))
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, map[string]interface{}{
+			"status": http.StatusBadRequest,
+			"msg":    "invalid body",
+		})
+		return
+	}
+	if len(body) > limit {
+		c.AbortWithStatusJSON(http.StatusRequestEntityTooLarge, map[string]interface{}{
+			"status": http.StatusRequestEntityTooLarge,
+			"msg":    "payload too large",
+		})
+		return
+	}
+
+	var req pushPayloadReq
+	if err := json.Unmarshal(body, &req); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, map[string]interface{}{
+			"status": http.StatusBadRequest,
+			"msg":    "invalid json",
+		})
+		return
+	}
+	if strings.TrimSpace(req.Content) == "" {
+		c.AbortWithStatusJSON(http.StatusBadRequest, map[string]interface{}{
+			"status": http.StatusBadRequest,
+			"msg":    "content required",
+		})
+		return
+	}
+
+	// 5) 构造 payload 并发送
+	payload := buildPayload(m, &req)
+	resp, err := w.ctx.SendMessageWithResult(&config.MsgSendReq{
+		// RedDot=1 让 webhook 消息触发未读红点和推送，与 botfather/robot 一致。
+		Header:      config.MsgHeader{RedDot: 1},
+		ChannelID:   m.GroupNo,
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		// WebhookID 已经自带 "iwh_" 前缀，这里直接用即可，避免双前缀。
+		FromUID: m.WebhookID,
+		Payload: []byte(util.ToJson(payload)),
+	})
+	if err != nil {
+		w.Error("send incoming webhook message failed",
+			zap.String("webhook_id", m.WebhookID), zap.Error(err))
+		c.AbortWithStatusJSON(http.StatusBadGateway, map[string]interface{}{
+			"status": http.StatusBadGateway,
+			"msg":    "send failed",
+		})
+		return
+	}
+
+	// 6) 异步审计 + markUsed（失败不影响响应）
+	var msgID int64
+	if resp != nil {
+		msgID = resp.MessageID
+	}
+	go w.recordSuccess(m, len(body), c.ClientIP(), msgID)
+
+	c.Response(map[string]interface{}{
+		"status":     0,
+		"message_id": msgID,
+	})
+}
+
+// buildPayload 把 webhook 请求映射到群消息 payload。
+//   - WuKongIM 只有 Text 类型，所有 webhook 消息都用 Text(1) 投递。
+//   - 注入 from.kind=webhook 元信息，便于客户端识别非真实用户消息；
+//     客户端可统一按 markdown 渲染 webhook 消息（无 markdown 时退化为纯文本）。
+//   - @all/@here 降级为纯文本：调用方写在 content 里的字面量保留，不附 mention 字段。
+func buildPayload(m *incomingWebhookModel, req *pushPayloadReq) map[string]interface{} {
+	name := req.Username
+	if name == "" {
+		name = m.Name
+	}
+	avatar := req.AvatarURL
+	if avatar == "" {
+		avatar = m.Avatar
+	}
+	payload := map[string]interface{}{
+		"type":    int(common.Text),
+		"content": req.Content,
+		"from": map[string]interface{}{
+			"kind":       "webhook",
+			"webhook_id": m.WebhookID,
+			"name":       name,
+			"avatar":     avatar,
+		},
+	}
+	if len(req.Extra) > 0 {
+		// 透传白名单字段，避免覆盖关键字段
+		for k, v := range req.Extra {
+			if k == "type" || k == "content" || k == "from" || k == "mention" {
+				continue
+			}
+			payload[k] = v
+		}
+	}
+	return payload
+}
+
+// recordSuccess 写审计 + 累加调用计数。失败仅记日志，不阻塞主流程。
+func (w *IncomingWebhook) recordSuccess(m *incomingWebhookModel, byteSize int, ip string, msgID int64) {
+	defer func() {
+		if r := recover(); r != nil {
+			w.Error("recordSuccess panic", zap.Any("recover", r))
+		}
+	}()
+	if err := w.db.markUsed(m.WebhookID, time.Now()); err != nil {
+		w.Warn("markUsed failed", zap.String("webhook_id", m.WebhookID), zap.Error(err))
+	}
+	audit := &auditModel{
+		WebhookID: m.WebhookID,
+		GroupNo:   m.GroupNo,
+		IP:        ip,
+		ByteSize:  byteSize,
+		MessageID: msgID,
+	}
+	if err := w.db.insertAudit(audit); err != nil {
+		w.Warn("insert audit failed", zap.String("webhook_id", m.WebhookID), zap.Error(err))
+	}
+}
+
+// handleGroupDisband 群解散时禁用所有 webhook（事件 payload 包含 group_no）。
+func (w *IncomingWebhook) handleGroupDisband(data []byte, commit config.EventCommit) {
+	var req config.MsgGroupDisband
+	if err := json.Unmarshal(data, &req); err != nil || req.GroupNo == "" {
+		commit(nil) // 忽略错误事件，不阻塞队列
+		return
+	}
+	if err := w.db.disableByGroupNo(req.GroupNo); err != nil {
+		w.Warn("disable webhooks on group disband failed",
+			zap.String("group_no", req.GroupNo), zap.Error(err))
+	}
+	// 故意 commit(nil)：disable 失败也不重试，避免阻塞事件队列。
+	// 异步窗口期由 push 路径的 requireActiveGroup 兜底（belt + suspenders）：
+	// 即便此处尚未把 webhook.status 改为 0，推送也会因群非 Normal 而 401。
+	commit(nil)
+}

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -642,12 +642,15 @@ func buildPayload(m *incomingWebhookModel, req *pushPayloadReq) map[string]inter
 	if len(req.Extra) > 0 {
 		// 透传白名单字段，避免覆盖关键字段
 		for k, v := range req.Extra {
-			if k == "type" || k == "content" || k == "from" || k == "mention" {
+			if k == "type" || k == "content" || k == "from" || k == "mention" || k == "space_id" {
 				continue
 			}
 			payload[k] = v
 		}
 	}
+	// space_id 必须由服务端从 group 表派生，不接受调用方覆盖，
+	// 防止 webhook 消息被伪造到其他 Space。
+	payload["space_id"] = m.SpaceID
 	return payload
 }
 

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"github.com/go-redis/redis"
 	"go.uber.org/zap"
@@ -71,12 +72,14 @@ var (
 
 func sharedRateRedis(cfg *config.Config) *redis.Client {
 	rateRedisOnce.Do(func() {
-		rateRedisClient = redis.NewClient(&redis.Options{
-			Addr:       cfg.DB.RedisAddr,
-			Password:   cfg.DB.RedisPass,
-			MaxRetries: 1,
-			PoolSize:   10,
-		})
+		// 通过 octoredis.MustBuildOptions 构造，确保 cfg.DB.RedisTLS 启用时
+		// （AWS ElastiCache / Azure Cache 等托管 TLS Redis）TLSConfig 不被遗漏。
+		// 否则限流 client 连不上 TLS-only Redis，per-IP / per-webhook 两个限流器
+		// 都会 fail-open，未认证 push 端点的反扫描/防洪泛保护被静默关闭。
+		rateRedisClient = redis.NewClient(octoredis.MustBuildOptions(cfg, func(o *redis.Options) {
+			o.MaxRetries = 1
+			o.PoolSize = 10
+		}))
 	})
 	return rateRedisClient
 }

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -97,8 +97,10 @@ func New(ctx *config.Context) *IncomingWebhook {
 
 // Route 注册路由。
 func (w *IncomingWebhook) Route(r *wkhttp.WKHttp) {
-	// 管理类：登录用户 + 群管理员校验。
-	mgr := r.Group("/v1/groups", w.ctx.AuthMiddleware(r))
+	// 管理类：登录用户 + 群管理员校验。认证路由默认挂 SharedUIDRateLimiter（须在
+	// AuthMiddleware 之后，否则读不到 uid 会静默 fail-open），与全局 IP floor 叠加，
+	// 给 create/regenerate 等敏感写操作补 per-login-user 限流。
+	mgr := r.Group("/v1/groups", w.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, w.ctx))
 	{
 		mgr.POST("/:group_no/incoming-webhooks", w.create)
 		mgr.GET("/:group_no/incoming-webhooks", w.list)

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -110,9 +110,9 @@ func (w *IncomingWebhook) Route(r *wkhttp.WKHttp) {
 	}
 
 	// 推送类：URL 内 token 鉴权，无 AuthMiddleware；外加 IP 限流防扫 token。
-	ipRPS := appwkhttp.ParseRPSFromEnv(envIngressIPRPS, defaultIngressIPRPS)
-	ipBurst := appwkhttp.ParseBurstFromEnv(envIngressIPBurst, defaultIngressIPBurst)
-	ipLimit := appwkhttp.StrictIPRateLimitMiddleware(context.Background(), w.rateRedis, "incoming_webhook", ipRPS, ipBurst)
+	ipRPS := wkhttp.ParseRPSFromEnv(envIngressIPRPS, defaultIngressIPRPS)
+	ipBurst := wkhttp.ParseBurstFromEnv(envIngressIPBurst, defaultIngressIPBurst)
+	ipLimit := r.StrictIPRateLimitMiddleware(context.Background(), w.rateRedis, "incoming_webhook", ipRPS, ipBurst)
 
 	push := r.Group("/v1")
 	{
@@ -143,11 +143,11 @@ func maxBytes() int {
 }
 
 func perWebhookRPS() float64 {
-	return appwkhttp.ParseRPSFromEnv(envRatePerWebhookRPS, defaultRatePerWHRPS)
+	return wkhttp.ParseRPSFromEnv(envRatePerWebhookRPS, defaultRatePerWHRPS)
 }
 
 func perWebhookBurst() int {
-	return appwkhttp.ParseBurstFromEnv(envRatePerWebhookBurst, defaultRatePerWHBurst)
+	return wkhttp.ParseBurstFromEnv(envRatePerWebhookBurst, defaultRatePerWHBurst)
 }
 
 // ============================================================
@@ -480,14 +480,6 @@ func (w *IncomingWebhook) regenerate(c *wkhttp.Context) {
 // 推送端点
 // ============================================================
 
-// pushErrUnauthorized 用统一文案返回 401，不区分原因（防探测）。
-func pushUnauthorized(c *wkhttp.Context) {
-	c.AbortWithStatusJSON(http.StatusUnauthorized, map[string]interface{}{
-		"status": http.StatusUnauthorized,
-		"msg":    "unauthorized",
-	})
-}
-
 func (w *IncomingWebhook) push(c *wkhttp.Context) {
 	webhookID := c.Param("webhook_id")
 	token := c.Param("token")
@@ -536,10 +528,7 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 		allowed = true
 	}
 	if !allowed {
-		c.AbortWithStatusJSON(http.StatusTooManyRequests, map[string]interface{}{
-			"status": http.StatusTooManyRequests,
-			"msg":    "rate limited",
-		})
+		pushRateLimited(c)
 		return
 	}
 
@@ -547,33 +536,21 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 	limit := maxBytes()
 	body, err := io.ReadAll(io.LimitReader(c.Request.Body, int64(limit)+1))
 	if err != nil {
-		c.AbortWithStatusJSON(http.StatusBadRequest, map[string]interface{}{
-			"status": http.StatusBadRequest,
-			"msg":    "invalid body",
-		})
+		pushPayloadInvalid(c, "body")
 		return
 	}
 	if len(body) > limit {
-		c.AbortWithStatusJSON(http.StatusRequestEntityTooLarge, map[string]interface{}{
-			"status": http.StatusRequestEntityTooLarge,
-			"msg":    "payload too large",
-		})
+		pushPayloadTooLarge(c)
 		return
 	}
 
 	var req pushPayloadReq
 	if err := json.Unmarshal(body, &req); err != nil {
-		c.AbortWithStatusJSON(http.StatusBadRequest, map[string]interface{}{
-			"status": http.StatusBadRequest,
-			"msg":    "invalid json",
-		})
+		pushPayloadInvalid(c, "json")
 		return
 	}
 	if strings.TrimSpace(req.Content) == "" {
-		c.AbortWithStatusJSON(http.StatusBadRequest, map[string]interface{}{
-			"status": http.StatusBadRequest,
-			"msg":    "content required",
-		})
+		pushPayloadInvalid(c, "content")
 		return
 	}
 
@@ -591,10 +568,7 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 	if err != nil {
 		w.Error("send incoming webhook message failed",
 			zap.String("webhook_id", m.WebhookID), zap.Error(err))
-		c.AbortWithStatusJSON(http.StatusBadGateway, map[string]interface{}{
-			"status": http.StatusBadGateway,
-			"msg":    "send failed",
-		})
+		pushDeliveryFailed(c)
 		return
 	}
 

--- a/modules/incomingwebhook/api_i18n.go
+++ b/modules/incomingwebhook/api_i18n.go
@@ -1,0 +1,52 @@
+package incomingwebhook
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+// push-path error responders. The push endpoint is unauthenticated (token in
+// URL); all error responses go through the i18n facade instead of raw
+// c.AbortWithStatusJSON, satisfying the D23 lint gate. ResponseErrorLWithStatus
+// preserves the real HTTP status (401/429/400/413/502) — webhook senders are
+// machines that key off the status code, so it must stay truthful. Each helper
+// Aborts so no later handler runs (mirrors the previous AbortWithStatusJSON).
+
+// pushUnauthorized returns the uniform 401 for EVERY auth failure on the push
+// path (missing/disabled webhook, bad token, disbanded group). It must stay a
+// single code/message: differentiating the reason would leak webhook existence
+// to a probe scanning tokens.
+func pushUnauthorized(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookPushUnauthorized, nil, nil)
+	c.Abort()
+}
+
+// pushRateLimited returns 429 when the per-webhook token bucket rejects.
+func pushRateLimited(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookPushRateLimited, nil, nil)
+	c.Abort()
+}
+
+// pushPayloadInvalid returns 400 for unreadable body / malformed JSON / empty
+// content; reason ∈ {body, json, content} is surfaced via the safe-listed
+// Details key so callers can tell what to fix.
+func pushPayloadInvalid(c *wkhttp.Context, reason string) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookPushPayloadInvalid, nil, i18n.Details{"reason": reason})
+	c.Abort()
+}
+
+// pushPayloadTooLarge returns 413 when the body exceeds the configured cap.
+func pushPayloadTooLarge(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookPushPayloadTooLarge, nil, nil)
+	c.Abort()
+}
+
+// pushDeliveryFailed returns 502 when the downstream SendMessage fails. The
+// code is Internal=true, so the renderer emits a generic message and the real
+// error is only logged by the caller.
+func pushDeliveryFailed(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookPushDeliveryFailed, nil, nil)
+	c.Abort()
+}

--- a/modules/incomingwebhook/api_test.go
+++ b/modules/incomingwebhook/api_test.go
@@ -1,0 +1,445 @@
+package incomingwebhook_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+
+	// 该模块自身需注册以触发其 SQL 迁移
+	_ "github.com/Mininglamp-OSS/octo-server/modules/incomingwebhook"
+	// 迁移依赖链：以下模块的 SQL 迁移会修改本模块依赖的 group/group_member/user 表，
+	// 缺失任何一个都会导致 module.Setup 在跨模块 ALTER 时报错。
+	// 详见 memory: skill_service_test.md「迁移顺序陷阱」。
+	_ "github.com/Mininglamp-OSS/octo-server/modules/base"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/common"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/group"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/robot"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/space"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/user"
+)
+
+// TestMain 准备 common.Setup 所需的 master key（必须 32 字节，见 memory）。
+func TestMain(m *testing.M) {
+	if os.Getenv("DMWORK_MASTER_KEY") == "" {
+		os.Setenv("DMWORK_MASTER_KEY", "12345678901234567890123456789012")
+	}
+	os.Exit(m.Run())
+}
+
+// 在 _test 包下没法直接引用未导出类型，因此推送请求体在测试里独立定义。
+type pushReq struct {
+	Content  string `json:"content"`
+	Username string `json:"username,omitempty"`
+}
+
+// setupTestEnv 启动测试服务并准备好群 + 群主成员。
+func setupTestEnv(t *testing.T) (http.Handler, *config.Context, string) {
+	s, ctx := testutil.NewTestServer()
+	groupNo := "g_" + util.GenerUUID()[:12]
+
+	// 群记录（最简：name + space_id）
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `group`(group_no, name, status, space_id) VALUES(?, ?, 1, '')",
+		groupNo, "test").Exec()
+	assert.NoError(t, err)
+
+	// 群主成员
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO group_member(group_no, uid, role, status, is_deleted, version) VALUES(?, ?, 1, 1, 0, 1)",
+		groupNo, testutil.UID).Exec()
+	assert.NoError(t, err)
+
+	return s.GetRoute(), ctx, groupNo
+}
+
+func authReq(method, path string, body interface{}) *http.Request {
+	var r *bytes.Reader
+	if body != nil {
+		r = bytes.NewReader([]byte(util.ToJson(body)))
+	} else {
+		r = bytes.NewReader(nil)
+	}
+	req, _ := http.NewRequest(method, path, r)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("token", testutil.Token)
+	return req
+}
+
+func anonReq(method, path string, body []byte) *http.Request {
+	req, _ := http.NewRequest(method, path, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func do(handler http.Handler, req *http.Request) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+func parseJSON(t *testing.T, w *httptest.ResponseRecorder) map[string]interface{} {
+	var m map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &m)
+	assert.NoErrorf(t, err, "body: %s", w.Body.String())
+	return m
+}
+
+// ============================================================
+// 创建
+// ============================================================
+
+func TestCreate_HappyPath(t *testing.T) {
+	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
+	handler, _, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "GitHub Bot",
+	}))
+	assert.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	res := parseJSON(t, w)
+	assert.NotEmpty(t, res["webhook_id"])
+	assert.NotEmpty(t, res["token"])
+	assert.NotEmpty(t, res["url"])
+	url, _ := res["url"].(string)
+	assert.True(t, strings.HasPrefix(url, "/v1/incoming-webhooks/"))
+}
+
+func TestCreate_RejectsEmptyName(t *testing.T) {
+	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
+	handler, _, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{}))
+	assert.NotEqual(t, http.StatusOK, w.Code)
+}
+
+func TestCreate_NonAdminForbidden(t *testing.T) {
+	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
+	handler, ctx, groupNo := setupTestEnv(t)
+	// 把当前用户降级为普通成员
+	_, err := ctx.DB().UpdateBySql("UPDATE group_member SET role=0 WHERE group_no=? AND uid=?", groupNo, testutil.UID).Exec()
+	assert.NoError(t, err)
+
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// ============================================================
+// 列表 / 删除 / 重置
+// ============================================================
+
+func TestListAndDelete(t *testing.T) {
+	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
+	handler, _, groupNo := setupTestEnv(t)
+
+	// 创建 2 个
+	for i := 0; i < 2; i++ {
+		w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+			"name": fmt.Sprintf("wh-%d", i),
+		}))
+		assert.Equal(t, http.StatusOK, w.Code)
+	}
+
+	w := do(handler, authReq("GET", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	res := parseJSON(t, w)
+	list, _ := res["list"].([]interface{})
+	assert.Equal(t, 2, len(list))
+
+	// 删一个
+	first := list[0].(map[string]interface{})
+	whID := first["webhook_id"].(string)
+	w = do(handler, authReq("DELETE", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID), nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	w = do(handler, authReq("GET", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), nil))
+	res = parseJSON(t, w)
+	list, _ = res["list"].([]interface{})
+	assert.Equal(t, 1, len(list))
+}
+
+func TestRegenerate_RotatesToken(t *testing.T) {
+	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
+	handler, _, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	assert.Equal(t, http.StatusOK, w.Code)
+	created := parseJSON(t, w)
+	whID := created["webhook_id"].(string)
+	oldToken := created["token"].(string)
+
+	w = do(handler, authReq("POST",
+		fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s/regenerate", groupNo, whID), nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	res := parseJSON(t, w)
+	newToken := res["token"].(string)
+	assert.NotEqual(t, oldToken, newToken)
+}
+
+// ============================================================
+// 推送端点鉴权
+// ============================================================
+
+func TestPush_RejectsBadToken(t *testing.T) {
+	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
+	handler, _, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	created := parseJSON(t, w)
+	whID := created["webhook_id"].(string)
+
+	// 错 token
+	body, _ := json.Marshal(pushReq{Content: "hi"})
+	w = do(handler, anonReq("POST",
+		fmt.Sprintf("/v1/incoming-webhooks/%s/wrong-token", whID), body))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestPush_RejectsDisabledWebhook(t *testing.T) {
+	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
+	handler, ctx, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	created := parseJSON(t, w)
+	whID := created["webhook_id"].(string)
+	token := created["token"].(string)
+
+	// 禁用
+	_, err := ctx.DB().UpdateBySql("UPDATE incoming_webhook SET status=0 WHERE webhook_id=?", whID).Exec()
+	assert.NoError(t, err)
+
+	body, _ := json.Marshal(pushReq{Content: "hi"})
+	w = do(handler, anonReq("POST",
+		fmt.Sprintf("/v1/incoming-webhooks/%s/%s", whID, token), body))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestPush_RejectsTooLargeBody(t *testing.T) {
+	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
+	// 用 env 把上限收紧到 1KB，让测试与运行时配置共用同一函数（maxBytes()），
+	// 避免在测试里硬编码 8KB 与生产默认值漂移。
+	t.Setenv("DM_INCOMINGWEBHOOK_MAX_BYTES", "1024")
+
+	handler, _, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	created := parseJSON(t, w)
+	whID := created["webhook_id"].(string)
+	token := created["token"].(string)
+
+	big := strings.Repeat("A", 1024+100)
+	body, _ := json.Marshal(pushReq{Content: big})
+	w = do(handler, anonReq("POST",
+		fmt.Sprintf("/v1/incoming-webhooks/%s/%s", whID, token), body))
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
+}
+
+func TestPush_RejectsEmptyContent(t *testing.T) {
+	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
+	handler, _, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	created := parseJSON(t, w)
+	whID := created["webhook_id"].(string)
+	token := created["token"].(string)
+
+	body, _ := json.Marshal(pushReq{Content: "   "})
+	w = do(handler, anonReq("POST",
+		fmt.Sprintf("/v1/incoming-webhooks/%s/%s", whID, token), body))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestPush_PerWebhookRateLimitTriggers429 验证 per-webhook 令牌桶真的连通 Redis：
+// 把 burst 收紧到 2、rps 收紧到 0.01（10s 补 1 个），连发 3 次，第 3 次必拒。
+// 前两次允许的请求可能因 WuKongIM 投递失败返回 502；这里只断言限流分支。
+func TestPush_PerWebhookRateLimitTriggers429(t *testing.T) {
+	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
+	t.Setenv("DM_INCOMINGWEBHOOK_BURST", "2")
+	t.Setenv("DM_INCOMINGWEBHOOK_RPS", "0.01")
+
+	handler, _, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	created := parseJSON(t, w)
+	whID := created["webhook_id"].(string)
+	token := created["token"].(string)
+
+	body, _ := json.Marshal(pushReq{Content: "hi"})
+	url := fmt.Sprintf("/v1/incoming-webhooks/%s/%s", whID, token)
+
+	// 前两次消耗 burst（结果不强求 200，可能 200/502，关键是没被限流）
+	for i := 0; i < 2; i++ {
+		w = do(handler, anonReq("POST", url, body))
+		assert.NotEqualf(t, http.StatusTooManyRequests, w.Code, "i=%d body=%s", i, w.Body.String())
+	}
+	// 第三次必被限流
+	w = do(handler, anonReq("POST", url, body))
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+}
+
+// TestPush_PerWebhookRateLimitIsPerWebhook 验证一个 webhook 被打满不影响另一个 webhook
+// （限流键空间按 webhook_id 隔离）。
+func TestPush_PerWebhookRateLimitIsPerWebhook(t *testing.T) {
+	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
+	t.Setenv("DM_INCOMINGWEBHOOK_BURST", "1")
+	t.Setenv("DM_INCOMINGWEBHOOK_RPS", "0.01")
+
+	handler, _, groupNo := setupTestEnv(t)
+	create := func(name string) (string, string) {
+		w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+			"name": name,
+		}))
+		c := parseJSON(t, w)
+		return c["webhook_id"].(string), c["token"].(string)
+	}
+	wh1, tk1 := create("a")
+	wh2, tk2 := create("b")
+	body, _ := json.Marshal(pushReq{Content: "hi"})
+
+	// 把 wh1 的桶耗尽
+	do(handler, anonReq("POST", fmt.Sprintf("/v1/incoming-webhooks/%s/%s", wh1, tk1), body))
+	w := do(handler, anonReq("POST", fmt.Sprintf("/v1/incoming-webhooks/%s/%s", wh1, tk1), body))
+	assert.Equal(t, http.StatusTooManyRequests, w.Code, "wh1 second call must hit 429")
+
+	// wh2 不应受影响（burst=1 第一次请求应当通过限流分支，可能 200/502）
+	w = do(handler, anonReq("POST", fmt.Sprintf("/v1/incoming-webhooks/%s/%s", wh2, tk2), body))
+	assert.NotEqualf(t, http.StatusTooManyRequests, w.Code,
+		"wh2 must not be limited by wh1's bucket; got %d body=%s", w.Code, w.Body.String())
+}
+
+func TestPush_RegenerateInvalidatesOldToken(t *testing.T) {
+	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
+	handler, _, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	created := parseJSON(t, w)
+	whID := created["webhook_id"].(string)
+	oldToken := created["token"].(string)
+
+	w = do(handler, authReq("POST",
+		fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s/regenerate", groupNo, whID), nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// 旧 token 应当 401
+	body, _ := json.Marshal(pushReq{Content: "hi"})
+	w = do(handler, anonReq("POST",
+		fmt.Sprintf("/v1/incoming-webhooks/%s/%s", whID, oldToken), body))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestCreate_QuotaEnforced(t *testing.T) {
+	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
+	handler, _, groupNo := setupTestEnv(t)
+	// 把每群配额降到 2，避免循环 10 次拖慢测试
+	t.Setenv("DM_INCOMINGWEBHOOK_MAX_PER_GROUP", "2")
+
+	for i := 0; i < 2; i++ {
+		w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+			"name": fmt.Sprintf("wh-%d", i),
+		}))
+		assert.Equalf(t, http.StatusOK, w.Code, "i=%d body=%s", i, w.Body.String())
+	}
+	// 第 3 个应当拒绝
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "overflow",
+	}))
+	assert.NotEqual(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "最多")
+}
+
+// TestDisbandedGroup_FailsClosed 锁定 disband 生命周期：群一旦进入非 Normal
+// 状态，create / update(启用) / push 三条路径都必须拒绝，杜绝 stale 管理员
+// 在 handleGroupDisband 异步窗口或之后让 webhook 复活。
+func TestDisbandedGroup_FailsClosed(t *testing.T) {
+	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
+	handler, ctx, groupNo := setupTestEnv(t)
+
+	// 在群 Normal 状态下先建一个 webhook，方便后续测 update / push
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	assert.Equal(t, http.StatusOK, w.Code)
+	created := parseJSON(t, w)
+	whID := created["webhook_id"].(string)
+	token := created["token"].(string)
+
+	// 把群标记为已解散（GroupStatusDisband=2）
+	_, err := ctx.DB().UpdateBySql("UPDATE `group` SET status=2 WHERE group_no=?", groupNo).Exec()
+	assert.NoError(t, err)
+
+	// 1) push：即便 webhook.status=1 且 token 正确也必须 401
+	body, _ := json.Marshal(pushReq{Content: "hi"})
+	w = do(handler, anonReq("POST",
+		fmt.Sprintf("/v1/incoming-webhooks/%s/%s", whID, token), body))
+	assert.Equalf(t, http.StatusUnauthorized, w.Code,
+		"push must fail closed on disbanded group, body=%s", w.Body.String())
+
+	// 2) update 启用：先模拟"异步禁用已落库"，管理员 PUT status=1 复活必须 404
+	_, err = ctx.DB().UpdateBySql("UPDATE incoming_webhook SET status=0 WHERE webhook_id=?", whID).Exec()
+	assert.NoError(t, err)
+	statusOne := 1
+	w = do(handler, authReq("PUT",
+		fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID),
+		map[string]interface{}{"status": statusOne}))
+	assert.Equalf(t, http.StatusNotFound, w.Code,
+		"re-enable on disbanded group must fail closed, body=%s", w.Body.String())
+
+	// 3) create：群已解散，重新创建 webhook 必须 404
+	w = do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "revive",
+	}))
+	assert.Equalf(t, http.StatusNotFound, w.Code,
+		"create on disbanded group must fail closed, body=%s", w.Body.String())
+
+	// 4) regenerate：群已解散，重置 token（即便走管理员路径）必须 404
+	w = do(handler, authReq("POST",
+		fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s/regenerate", groupNo, whID), nil))
+	assert.Equalf(t, http.StatusNotFound, w.Code,
+		"regenerate on disbanded group must fail closed, body=%s", w.Body.String())
+}
+
+func TestUpdate_RejectsCrossGroupAccess(t *testing.T) {
+	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
+	handler, ctx, groupNoA := setupTestEnv(t)
+
+	// 在群 A 创建一个 webhook
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNoA), map[string]interface{}{
+		"name": "x",
+	}))
+	created := parseJSON(t, w)
+	whID := created["webhook_id"].(string)
+
+	// 创建群 B 并把 testutil.UID 设为群主
+	groupNoB := "g_" + util.GenerUUID()[:12]
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `group`(group_no, name, status, space_id) VALUES(?, 'b', 1, '')", groupNoB).Exec()
+	assert.NoError(t, err)
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO group_member(group_no, uid, role, status, is_deleted, version) VALUES(?, ?, 1, 1, 0, 1)",
+		groupNoB, testutil.UID).Exec()
+	assert.NoError(t, err)
+
+	// 拿 A 的 webhook_id 去群 B 路径下尝试更新，应 404
+	name := "hijack"
+	w = do(handler, authReq("PUT",
+		fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNoB, whID),
+		map[string]interface{}{"name": name}))
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/modules/incomingwebhook/api_test.go
+++ b/modules/incomingwebhook/api_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -100,7 +102,6 @@ func parseJSON(t *testing.T, w *httptest.ResponseRecorder) map[string]interface{
 // ============================================================
 
 func TestCreate_HappyPath(t *testing.T) {
-	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	handler, _, groupNo := setupTestEnv(t)
 	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
 		"name": "GitHub Bot",
@@ -112,6 +113,9 @@ func TestCreate_HappyPath(t *testing.T) {
 	assert.NotEmpty(t, res["url"])
 	url, _ := res["url"].(string)
 	assert.True(t, strings.HasPrefix(url, "/v1/incoming-webhooks/"))
+	// created_at 必须由 insertWithQuota 回填，否则会以 epoch(0) 返回给客户端
+	createdAt, _ := res["created_at"].(float64)
+	assert.Greater(t, int64(createdAt), int64(0), "created_at must be populated, not zero/epoch")
 }
 
 func TestCreate_RejectsEmptyName(t *testing.T) {
@@ -192,7 +196,6 @@ func TestRegenerate_RotatesToken(t *testing.T) {
 // ============================================================
 
 func TestPush_RejectsBadToken(t *testing.T) {
-	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	handler, _, groupNo := setupTestEnv(t)
 	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
 		"name": "x",
@@ -208,7 +211,6 @@ func TestPush_RejectsBadToken(t *testing.T) {
 }
 
 func TestPush_RejectsDisabledWebhook(t *testing.T) {
-	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	handler, ctx, groupNo := setupTestEnv(t)
 	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
 		"name": "x",
@@ -345,7 +347,6 @@ func TestPush_RegenerateInvalidatesOldToken(t *testing.T) {
 }
 
 func TestCreate_QuotaEnforced(t *testing.T) {
-	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	handler, _, groupNo := setupTestEnv(t)
 	// 把每群配额降到 2，避免循环 10 次拖慢测试
 	t.Setenv("DM_INCOMINGWEBHOOK_MAX_PER_GROUP", "2")
@@ -362,6 +363,44 @@ func TestCreate_QuotaEnforced(t *testing.T) {
 	}))
 	assert.NotEqual(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "最多")
+}
+
+// TestCreate_QuotaConcurrent 验证 insertWithQuota 在并发下守住上限。
+// 之前的 countByGroupNo + insert 两步式写法在并发下会让多个请求同时通过配额校验，
+// 实际写入超过 maxPerGroup（PR #31 lml2468 / Jerry-Xin 反馈）。
+func TestCreate_QuotaConcurrent(t *testing.T) {
+	handler, ctx, groupNo := setupTestEnv(t)
+	const cap = 3
+	const fanout = 10
+	t.Setenv("DM_INCOMINGWEBHOOK_MAX_PER_GROUP", strconv.Itoa(cap))
+
+	var wg sync.WaitGroup
+	codes := make([]int, fanout)
+	for i := 0; i < fanout; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+				"name": fmt.Sprintf("wh-%d", idx),
+			}))
+			codes[idx] = w.Code
+		}(i)
+	}
+	wg.Wait()
+
+	ok := 0
+	for _, c := range codes {
+		if c == http.StatusOK {
+			ok++
+		}
+	}
+	assert.Equalf(t, cap, ok, "exactly %d concurrent creates should succeed, got %d (codes=%v)", cap, ok, codes)
+
+	// DB 里也应当只有 cap 条记录
+	var rows int
+	_, err := ctx.DB().SelectBySql("SELECT count(*) FROM incoming_webhook WHERE group_no=?", groupNo).Load(&rows)
+	assert.NoError(t, err)
+	assert.Equal(t, cap, rows, "DB row count must equal cap; quota leaked under concurrency")
 }
 
 // TestDisbandedGroup_FailsClosed 锁定 disband 生命周期：群一旦进入非 Normal

--- a/modules/incomingwebhook/api_test.go
+++ b/modules/incomingwebhook/api_test.go
@@ -31,10 +31,11 @@ import (
 	_ "github.com/Mininglamp-OSS/octo-server/modules/user"
 )
 
-// TestMain 准备 common.Setup 所需的 master key（必须 32 字节，见 memory）。
+// TestMain 准备 common.Setup 所需的 master key（必须 32 字节）。CI 通过 ci.yml
+// 全局环境变量已经注入；本地直接 go test 也能跑通，无需额外设置。
 func TestMain(m *testing.M) {
-	if os.Getenv("DMWORK_MASTER_KEY") == "" {
-		os.Setenv("DMWORK_MASTER_KEY", "12345678901234567890123456789012")
+	if os.Getenv("OCTO_MASTER_KEY") == "" {
+		os.Setenv("OCTO_MASTER_KEY", "12345678901234567890123456789012")
 	}
 	os.Exit(m.Run())
 }

--- a/modules/incomingwebhook/api_test.go
+++ b/modules/incomingwebhook/api_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/go-redis/redis"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 
@@ -63,7 +64,27 @@ func setupTestEnv(t *testing.T) (http.Handler, *config.Context, string) {
 		groupNo, testutil.UID).Exec()
 	assert.NoError(t, err)
 
+	// 管理类路由挂了 SharedUIDRateLimiter（per-login-user 桶 ratelimit:uid:{uid}），
+	// 该桶在 Redis 持久、CleanAllTables 不清，跨测试 / -count=N 累积会撞 burst 触发
+	// 429。每次 setup 清桶，保证每个测试从满桶开始（参考 category 测试同名 helper）。
+	resetUIDRateLimit(t, ctx)
+
 	return s.GetRoute(), ctx, groupNo
+}
+
+// resetUIDRateLimit 清空 per-uid 令牌桶键（ratelimit:uid:{uid}），让后续 HTTP
+// 调用从满桶开始。SharedUIDRateLimiter 的桶不随 CleanAllTables 清理。
+func resetUIDRateLimit(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	rdsClient := redis.NewClient(&redis.Options{
+		Addr:     ctx.GetConfig().DB.RedisAddr,
+		Password: ctx.GetConfig().DB.RedisPass,
+	})
+	defer rdsClient.Close()
+	keys, err := rdsClient.Keys("ratelimit:uid:*").Result()
+	if err == nil && len(keys) > 0 {
+		_ = rdsClient.Del(keys...).Err()
+	}
 }
 
 func authReq(method, path string, body interface{}) *http.Request {

--- a/modules/incomingwebhook/db.go
+++ b/modules/incomingwebhook/db.go
@@ -1,0 +1,97 @@
+package incomingwebhook
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/gocraft/dbr/v2"
+)
+
+type incomingWebhookDB struct {
+	session *dbr.Session
+	ctx     *config.Context
+}
+
+func newDB(ctx *config.Context) *incomingWebhookDB {
+	return &incomingWebhookDB{ctx: ctx, session: ctx.DB()}
+}
+
+func (d *incomingWebhookDB) insert(m *incomingWebhookModel) error {
+	_, err := d.session.InsertInto("incoming_webhook").
+		Columns(util.AttrToUnderscore(m)...).
+		Record(m).Exec()
+	if err != nil {
+		return fmt.Errorf("incomingwebhook: insert: %w", err)
+	}
+	return nil
+}
+
+// queryByWebhookID 不存在时返回 (nil, nil)；dbr.Load 在无结果时即返回 (0, nil)，
+// 调用方按 m == nil 判断未命中，无需特别处理 ErrNotFound（那是 LoadOne 的语义）。
+func (d *incomingWebhookDB) queryByWebhookID(webhookID string) (*incomingWebhookModel, error) {
+	var m *incomingWebhookModel
+	_, err := d.session.Select("*").From("incoming_webhook").
+		Where("webhook_id=?", webhookID).Load(&m)
+	return m, err
+}
+
+func (d *incomingWebhookDB) queryByGroupNo(groupNo string) ([]*incomingWebhookModel, error) {
+	var list []*incomingWebhookModel
+	_, err := d.session.Select("*").From("incoming_webhook").
+		Where("group_no=?", groupNo).
+		OrderDir("created_at", false).
+		Load(&list)
+	return list, err
+}
+
+// countByGroupNo 统计某群下所有 webhook 数量，**不**过滤 status——禁用的也占配额。
+// 这是有意为之：避免 enable→disable→create 循环绕过 max_per_group 限制。
+// 删除（不仅是禁用）才会释放配额。
+func (d *incomingWebhookDB) countByGroupNo(groupNo string) (int, error) {
+	var n int
+	err := d.session.Select("count(*)").From("incoming_webhook").
+		Where("group_no=?", groupNo).LoadOne(&n)
+	return n, err
+}
+
+func (d *incomingWebhookDB) updateFields(webhookID string, fields map[string]interface{}) error {
+	if len(fields) == 0 {
+		return nil
+	}
+	_, err := d.session.Update("incoming_webhook").
+		SetMap(fields).
+		Where("webhook_id=?", webhookID).Exec()
+	return err
+}
+
+func (d *incomingWebhookDB) deleteByWebhookID(webhookID string) error {
+	_, err := d.session.DeleteFrom("incoming_webhook").
+		Where("webhook_id=?", webhookID).Exec()
+	return err
+}
+
+// markUsed 累加调用计数并刷新 last_used_at；非关键路径，调用方应忽略错误（最多记日志）。
+func (d *incomingWebhookDB) markUsed(webhookID string, now time.Time) error {
+	_, err := d.session.UpdateBySql(
+		"UPDATE incoming_webhook SET call_count = call_count + 1, last_used_at = ? WHERE webhook_id = ?",
+		now, webhookID,
+	).Exec()
+	return err
+}
+
+// disableByGroupNo 把指定群下所有 webhook 置为禁用，用于群解散等级联场景。
+func (d *incomingWebhookDB) disableByGroupNo(groupNo string) error {
+	_, err := d.session.Update("incoming_webhook").
+		Set("status", 0).
+		Where("group_no=?", groupNo).Exec()
+	return err
+}
+
+func (d *incomingWebhookDB) insertAudit(m *auditModel) error {
+	_, err := d.session.InsertInto("incoming_webhook_audit").
+		Columns(util.AttrToUnderscore(m)...).
+		Record(m).Exec()
+	return err
+}

--- a/modules/incomingwebhook/db.go
+++ b/modules/incomingwebhook/db.go
@@ -1,13 +1,18 @@
 package incomingwebhook
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/db"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/gocraft/dbr/v2"
 )
+
+// ErrQuotaExceeded 创建时配额已满，由 insertWithQuota 在事务内原子判定。
+var ErrQuotaExceeded = errors.New("incomingwebhook: per-group quota exceeded")
 
 type incomingWebhookDB struct {
 	session *dbr.Session
@@ -18,14 +23,42 @@ func newDB(ctx *config.Context) *incomingWebhookDB {
 	return &incomingWebhookDB{ctx: ctx, session: ctx.DB()}
 }
 
-func (d *incomingWebhookDB) insert(m *incomingWebhookModel) error {
-	_, err := d.session.InsertInto("incoming_webhook").
-		Columns(util.AttrToUnderscore(m)...).
-		Record(m).Exec()
+// insertWithQuota 在事务内做"配额校验 + 写入"原子操作：
+//  1. SELECT count(*) ... WHERE group_no=? FOR UPDATE：在 idx_incoming_webhook_group
+//     上对该 group_no 范围加 next-key lock（InnoDB REPEATABLE READ 下覆盖间隙），
+//     并发的同 group 创建请求会被阻塞在此处直到本事务结束。
+//  2. count >= max 返回 ErrQuotaExceeded，事务回滚。
+//  3. 显式回填 CreatedAt：dbr 的 InsertInto.Record 不会从 DB 默认值回读时间，
+//     不写就会导致响应里的 created_at = epoch(0)。
+//
+// 替代之前的 countByGroupNo + insert 两步式调用——那种写法在没有锁的情况下并发
+// 创建会同时通过配额检查并都执行 INSERT，绕过 maxPerGroup 上限（lml2468 / Jerry-Xin
+// PR #31 review）。
+func (d *incomingWebhookDB) insertWithQuota(m *incomingWebhookModel, max int) error {
+	tx, err := d.session.Begin()
 	if err != nil {
+		return fmt.Errorf("incomingwebhook: begin tx: %w", err)
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	var count int
+	if _, err = tx.SelectBySql(
+		"SELECT count(*) FROM incoming_webhook WHERE group_no=? FOR UPDATE",
+		m.GroupNo,
+	).Load(&count); err != nil {
+		return fmt.Errorf("incomingwebhook: count for update: %w", err)
+	}
+	if count >= max {
+		return ErrQuotaExceeded
+	}
+
+	m.CreatedAt = db.Time(time.Now())
+	if _, err = tx.InsertInto("incoming_webhook").
+		Columns(util.AttrToUnderscore(m)...).
+		Record(m).Exec(); err != nil {
 		return fmt.Errorf("incomingwebhook: insert: %w", err)
 	}
-	return nil
+	return tx.Commit()
 }
 
 // queryByWebhookID 不存在时返回 (nil, nil)；dbr.Load 在无结果时即返回 (0, nil)，
@@ -44,16 +77,6 @@ func (d *incomingWebhookDB) queryByGroupNo(groupNo string) ([]*incomingWebhookMo
 		OrderDir("created_at", false).
 		Load(&list)
 	return list, err
-}
-
-// countByGroupNo 统计某群下所有 webhook 数量，**不**过滤 status——禁用的也占配额。
-// 这是有意为之：避免 enable→disable→create 循环绕过 max_per_group 限制。
-// 删除（不仅是禁用）才会释放配额。
-func (d *incomingWebhookDB) countByGroupNo(groupNo string) (int, error) {
-	var n int
-	err := d.session.Select("count(*)").From("incoming_webhook").
-		Where("group_no=?", groupNo).LoadOne(&n)
-	return n, err
 }
 
 // updateFieldsAllowed 限定 updateFields 可写的列，防御未来调用方误传用户输入作 key

--- a/modules/incomingwebhook/db.go
+++ b/modules/incomingwebhook/db.go
@@ -56,9 +56,23 @@ func (d *incomingWebhookDB) countByGroupNo(groupNo string) (int, error) {
 	return n, err
 }
 
+// updateFieldsAllowed 限定 updateFields 可写的列，防御未来调用方误传用户输入作 key
+// 触发任意列改写。新增可更新列时显式在此追加。
+var updateFieldsAllowed = map[string]struct{}{
+	"name":       {},
+	"avatar":     {},
+	"status":     {},
+	"token_hash": {},
+}
+
 func (d *incomingWebhookDB) updateFields(webhookID string, fields map[string]interface{}) error {
 	if len(fields) == 0 {
 		return nil
+	}
+	for k := range fields {
+		if _, ok := updateFieldsAllowed[k]; !ok {
+			return fmt.Errorf("incomingwebhook: updateFields: disallowed column %q", k)
+		}
 	}
 	_, err := d.session.Update("incoming_webhook").
 		SetMap(fields).

--- a/modules/incomingwebhook/db.go
+++ b/modules/incomingwebhook/db.go
@@ -24,16 +24,19 @@ func newDB(ctx *config.Context) *incomingWebhookDB {
 }
 
 // insertWithQuota 在事务内做"配额校验 + 写入"原子操作：
-//  1. SELECT count(*) ... WHERE group_no=? FOR UPDATE：在 idx_incoming_webhook_group
-//     上对该 group_no 范围加 next-key lock（InnoDB REPEATABLE READ 下覆盖间隙），
-//     并发的同 group 创建请求会被阻塞在此处直到本事务结束。
-//  2. count >= max 返回 ErrQuotaExceeded，事务回滚。
+//  1. SELECT id FROM `group` ... FOR UPDATE：对父群行加 X 记录锁（group_no 命中
+//     UNIQUE 索引 group_groupNo，锁的是必然存在的单行 record lock）。并发的同 group
+//     创建请求在此串行化，逐个进入配额校验+写入。
+//  2. SELECT count(*) FROM incoming_webhook WHERE group_no=?：父群行锁已串行化，
+//     此处普通读即可；count >= max 返回 ErrQuotaExceeded，事务回滚。
 //  3. 显式回填 CreatedAt：dbr 的 InsertInto.Record 不会从 DB 默认值回读时间，
 //     不写就会导致响应里的 created_at = epoch(0)。
 //
-// 替代之前的 countByGroupNo + insert 两步式调用——那种写法在没有锁的情况下并发
-// 创建会同时通过配额检查并都执行 INSERT，绕过 maxPerGroup 上限（lml2468 / Jerry-Xin
-// PR #31 review）。
+// 为何锁父群行而非 `SELECT count(*) FROM incoming_webhook ... FOR UPDATE`：后者在
+// 空群首次插入时只命中 0 行 → 纯 gap lock。gap-X 锁互相兼容，并发事务会全部通过
+// count 检查、各自 INSERT 抢 insert-intention lock 互等 → InnoDB 死锁(1213)，且无
+// 重试，合法并发创建会以不透明的"创建失败"500 收场。锁父群这一必然存在的单行可彻底
+// 串行化而不触发 gap-lock 死锁（PR #31 yujiawei / Jerry-Xin review）。
 func (d *incomingWebhookDB) insertWithQuota(m *incomingWebhookModel, max int) error {
 	tx, err := d.session.Begin()
 	if err != nil {
@@ -41,12 +44,20 @@ func (d *incomingWebhookDB) insertWithQuota(m *incomingWebhookModel, max int) er
 	}
 	defer tx.RollbackUnlessCommitted()
 
+	var gid int
+	if _, err = tx.SelectBySql(
+		"SELECT id FROM `group` WHERE group_no=? FOR UPDATE",
+		m.GroupNo,
+	).Load(&gid); err != nil {
+		return fmt.Errorf("incomingwebhook: lock group for update: %w", err)
+	}
+
 	var count int
 	if _, err = tx.SelectBySql(
-		"SELECT count(*) FROM incoming_webhook WHERE group_no=? FOR UPDATE",
+		"SELECT count(*) FROM incoming_webhook WHERE group_no=?",
 		m.GroupNo,
 	).Load(&count); err != nil {
-		return fmt.Errorf("incomingwebhook: count for update: %w", err)
+		return fmt.Errorf("incomingwebhook: count: %w", err)
 	}
 	if count >= max {
 		return ErrQuotaExceeded

--- a/modules/incomingwebhook/model.go
+++ b/modules/incomingwebhook/model.go
@@ -1,0 +1,72 @@
+package incomingwebhook
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/db"
+	"github.com/gocraft/dbr/v2"
+)
+
+// incomingWebhookModel 对应 incoming_webhook 表。
+type incomingWebhookModel struct {
+	WebhookID  string
+	TokenHash  string
+	GroupNo    string
+	SpaceID    string
+	Name       string
+	Avatar     string
+	CreatorUID string
+	Status     int
+	LastUsedAt dbr.NullTime
+	CallCount  int64
+	db.BaseModel
+}
+
+// auditModel 对应 incoming_webhook_audit 表，记录成功推送的最小审计信息。
+type auditModel struct {
+	WebhookID string
+	GroupNo   string
+	IP        string
+	ByteSize  int
+	MessageID int64
+	db.BaseModel
+}
+
+// pushPayloadReq 推送端点的请求体。
+type pushPayloadReq struct {
+	Content   string                 `json:"content"`
+	Username  string                 `json:"username,omitempty"`
+	AvatarURL string                 `json:"avatar_url,omitempty"`
+	Extra     map[string]interface{} `json:"extra,omitempty"`
+}
+
+// createReq 管理端创建 webhook 的请求体。
+type createReq struct {
+	Name   string `json:"name"`
+	Avatar string `json:"avatar,omitempty"`
+}
+
+// updateReq 修改 webhook 的请求体。零值字段不更新。
+type updateReq struct {
+	Name   *string `json:"name,omitempty"`
+	Avatar *string `json:"avatar,omitempty"`
+	Status *int    `json:"status,omitempty"`
+}
+
+// webhookResp 对外暴露的 webhook 元信息（不含 token / token_hash）。
+type webhookResp struct {
+	WebhookID  string `json:"webhook_id"`
+	GroupNo    string `json:"group_no"`
+	Name       string `json:"name"`
+	Avatar     string `json:"avatar"`
+	CreatorUID string `json:"creator_uid"`
+	Status     int    `json:"status"`
+	LastUsedAt int64  `json:"last_used_at"`
+	CallCount  int64  `json:"call_count"`
+	CreatedAt  int64  `json:"created_at"`
+}
+
+// createResp 创建/重置返回；token 仅此一次出现。
+type createResp struct {
+	webhookResp
+	Token string `json:"token"`
+	URL   string `json:"url"`
+}

--- a/modules/incomingwebhook/ratelimit.go
+++ b/modules/incomingwebhook/ratelimit.go
@@ -1,0 +1,75 @@
+package incomingwebhook
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-redis/redis"
+)
+
+// tokenBucketScript 与 pkg/wkhttp/ratelimit.go 中的脚本同形，单独维护一份是为了
+// 让 incoming webhook 的限流键空间独立、并允许后续按需调优配额而不牵连其他端点。
+const tokenBucketScript = `
+local key = KEYS[1]
+local rate = tonumber(ARGV[1])
+local burst = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
+
+if rate <= 0 then return {0, 0, 1} end
+
+local fill_time = burst / rate
+local ttl = math.max(1, math.ceil(fill_time * 2))
+
+local state = redis.call("HMGET", key, "tokens", "ts")
+local tokens = tonumber(state[1])
+local ts = tonumber(state[2])
+if tokens == nil then tokens = burst end
+if ts == nil then ts = now end
+
+local delta = math.max(0, now - ts)
+local filled = math.min(burst, tokens + delta * rate)
+
+local allowed = 0
+local retry_after = 0
+local need_write = false
+if filled >= 1 then
+    allowed = 1
+    filled = filled - 1
+    need_write = true
+else
+    retry_after = math.max(1, math.ceil((1 - filled) / rate))
+    if state[2] == false then
+        need_write = true
+    end
+end
+
+if need_write then
+    redis.call("HMSET", key, "tokens", filled, "ts", now)
+    redis.call("EXPIRE", key, ttl)
+end
+
+return {allowed, math.floor(filled), retry_after}
+`
+
+// allowPerWebhook 按 webhook_id 维度做令牌桶判定，独立于 IP 限流。
+// Redis 故障时返回 (true, err)，由调用方决定是否记日志（fail-open）。
+func (w *IncomingWebhook) allowPerWebhook(_ context.Context, webhookID string) (bool, error) {
+	rps := perWebhookRPS()
+	burst := perWebhookBurst()
+	if rps <= 0 || burst <= 0 {
+		return true, nil
+	}
+	now := float64(time.Now().UnixNano()) / float64(time.Second)
+	script := redis.NewScript(tokenBucketScript)
+	res, err := script.Run(w.rateRedis, []string{"ratelimit:incoming_webhook:" + webhookID},
+		rps, burst, now).Result()
+	if err != nil {
+		return true, err
+	}
+	arr, ok := res.([]interface{})
+	if !ok || len(arr) != 3 {
+		return true, nil
+	}
+	allowed, _ := arr[0].(int64)
+	return allowed == 1, nil
+}

--- a/modules/incomingwebhook/ratelimit.go
+++ b/modules/incomingwebhook/ratelimit.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-redis/redis"
 )
 
-// tokenBucketScript 与 pkg/wkhttp/ratelimit.go 中的脚本同形，单独维护一份是为了
+// tokenBucketScript 与 octo-lib pkg/wkhttp/ratelimit.go 中的脚本同形，单独维护一份是为了
 // 让 incoming webhook 的限流键空间独立、并允许后续按需调优配额而不牵连其他端点。
 const tokenBucketScript = `
 local key = KEYS[1]

--- a/modules/incomingwebhook/sql/20260514000003_incomingwebhook_init.sql
+++ b/modules/incomingwebhook/sql/20260514000003_incomingwebhook_init.sql
@@ -1,0 +1,36 @@
+-- +migrate Up
+
+-- 群入站 Webhook：外部服务通过该 URL 推送消息到指定群聊
+CREATE TABLE `incoming_webhook` (
+  `id`                  BIGINT       NOT NULL PRIMARY KEY AUTO_INCREMENT,
+  `webhook_id`          VARCHAR(64)  NOT NULL DEFAULT '' COMMENT '公开 ID，URL 路径段（iwh_ + 32 hex 或 fallback 路径下的去横线 UUID）',
+  `token_hash`          VARCHAR(64)  NOT NULL DEFAULT '' COMMENT 'SHA-256(token) 十六进制；token 仅创建/重置时返回',
+  `group_no`            VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '所属群编号',
+  `space_id`            VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '冗余：群所属 Space',
+  `name`                VARCHAR(64)  NOT NULL DEFAULT '' COMMENT '展示名',
+  `avatar`              VARCHAR(255) NOT NULL DEFAULT '' COMMENT '展示头像 URL',
+  `creator_uid`         VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '创建者 UID',
+  `status`              SMALLINT     NOT NULL DEFAULT 1 COMMENT '0=禁用,1=启用',
+  `last_used_at`        TIMESTAMP    NULL DEFAULT NULL COMMENT '最近一次成功推送时间',
+  `call_count`          BIGINT       NOT NULL DEFAULT 0 COMMENT '累计成功调用次数',
+  `created_at`          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at`          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+CREATE UNIQUE INDEX `uk_incoming_webhook_id` ON `incoming_webhook` (`webhook_id`);
+CREATE INDEX `idx_incoming_webhook_group` ON `incoming_webhook` (`group_no`, `status`);
+
+-- 入站 Webhook 调用审计日志（仅成功调用，TTL 由清理任务/定时 DELETE 维护）
+CREATE TABLE `incoming_webhook_audit` (
+  `id`           BIGINT       NOT NULL PRIMARY KEY AUTO_INCREMENT,
+  `webhook_id`   VARCHAR(64)  NOT NULL DEFAULT '',
+  `group_no`     VARCHAR(40)  NOT NULL DEFAULT '',
+  `ip`           VARCHAR(64)  NOT NULL DEFAULT '',
+  `byte_size`    INT          NOT NULL DEFAULT 0,
+  `message_id`   BIGINT       NOT NULL DEFAULT 0,
+  `created_at`   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX `idx_iwa_webhook_time` ON `incoming_webhook_audit` (`webhook_id`, `created_at`);
+
+-- +migrate Down
+DROP TABLE IF EXISTS `incoming_webhook_audit`;
+DROP TABLE IF EXISTS `incoming_webhook`;

--- a/modules/incomingwebhook/sql/20260514000003_incomingwebhook_init.sql
+++ b/modules/incomingwebhook/sql/20260514000003_incomingwebhook_init.sql
@@ -4,7 +4,7 @@
 CREATE TABLE `incoming_webhook` (
   `id`                  BIGINT       NOT NULL PRIMARY KEY AUTO_INCREMENT,
   `webhook_id`          VARCHAR(64)  NOT NULL DEFAULT '' COMMENT '公开 ID，URL 路径段（iwh_ + 32 hex 或 fallback 路径下的去横线 UUID）',
-  `token_hash`          VARCHAR(64)  NOT NULL DEFAULT '' COMMENT 'SHA-256(token) 十六进制；token 仅创建/重置时返回',
+  `token_hash`          VARCHAR(128) NOT NULL DEFAULT '' COMMENT '哈希(token) 十六进制；SHA-256 占 64 字符，128 字符留余量便于未来切换 SHA-512',
   `group_no`            VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '所属群编号',
   `space_id`            VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '冗余：群所属 Space',
   `name`                VARCHAR(64)  NOT NULL DEFAULT '' COMMENT '展示名',

--- a/modules/incomingwebhook/sql/20260514000003_incomingwebhook_init.sql
+++ b/modules/incomingwebhook/sql/20260514000003_incomingwebhook_init.sql
@@ -2,34 +2,34 @@
 
 -- 群入站 Webhook：外部服务通过该 URL 推送消息到指定群聊
 CREATE TABLE `incoming_webhook` (
-  `id`                  BIGINT       NOT NULL PRIMARY KEY AUTO_INCREMENT,
-  `webhook_id`          VARCHAR(64)  NOT NULL DEFAULT '' COMMENT '公开 ID，URL 路径段（iwh_ + 32 hex 或 fallback 路径下的去横线 UUID）',
-  `token_hash`          VARCHAR(128) NOT NULL DEFAULT '' COMMENT '哈希(token) 十六进制；SHA-256 占 64 字符，128 字符留余量便于未来切换 SHA-512',
-  `group_no`            VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '所属群编号',
-  `space_id`            VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '冗余：群所属 Space',
-  `name`                VARCHAR(64)  NOT NULL DEFAULT '' COMMENT '展示名',
-  `avatar`              VARCHAR(255) NOT NULL DEFAULT '' COMMENT '展示头像 URL',
-  `creator_uid`         VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '创建者 UID',
-  `status`              SMALLINT     NOT NULL DEFAULT 1 COMMENT '0=禁用,1=启用',
-  `last_used_at`        TIMESTAMP    NULL DEFAULT NULL COMMENT '最近一次成功推送时间',
-  `call_count`          BIGINT       NOT NULL DEFAULT 0 COMMENT '累计成功调用次数',
+  `id`                  BIGINT       AUTO_INCREMENT PRIMARY KEY,
+  `webhook_id`          VARCHAR(64)  NOT NULL DEFAULT ''         COMMENT '公开 ID，URL 路径段（iwh_ + 32 hex 或 fallback 路径下的去横线 UUID）',
+  `token_hash`          VARCHAR(128) NOT NULL DEFAULT ''         COMMENT '哈希(token) 十六进制；SHA-256 占 64 字符，128 字符留余量便于未来切换 SHA-512',
+  `group_no`            VARCHAR(40)  NOT NULL DEFAULT ''         COMMENT '所属群编号',
+  `space_id`            VARCHAR(40)  NOT NULL DEFAULT ''         COMMENT '冗余：群所属 Space',
+  `name`                VARCHAR(64)  NOT NULL DEFAULT ''         COMMENT '展示名',
+  `avatar`              VARCHAR(255) NOT NULL DEFAULT ''         COMMENT '展示头像 URL',
+  `creator_uid`         VARCHAR(40)  NOT NULL DEFAULT ''         COMMENT '创建者 UID',
+  `status`              SMALLINT     NOT NULL DEFAULT 1          COMMENT '0=禁用,1=启用',
+  `last_used_at`        TIMESTAMP    NULL DEFAULT NULL           COMMENT '最近一次成功推送时间',
+  `call_count`          BIGINT       NOT NULL DEFAULT 0          COMMENT '累计成功调用次数',
   `created_at`          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `updated_at`          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
-);
-CREATE UNIQUE INDEX `uk_incoming_webhook_id` ON `incoming_webhook` (`webhook_id`);
-CREATE INDEX `idx_incoming_webhook_group` ON `incoming_webhook` (`group_no`, `status`);
+  `updated_at`          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY `uk_incoming_webhook_id` (`webhook_id`),
+  INDEX `idx_incoming_webhook_group` (`group_no`, `status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='群入站 Webhook';
 
 -- 入站 Webhook 调用审计日志（仅成功调用，TTL 由清理任务/定时 DELETE 维护）
 CREATE TABLE `incoming_webhook_audit` (
-  `id`           BIGINT       NOT NULL PRIMARY KEY AUTO_INCREMENT,
+  `id`           BIGINT       AUTO_INCREMENT PRIMARY KEY,
   `webhook_id`   VARCHAR(64)  NOT NULL DEFAULT '',
   `group_no`     VARCHAR(40)  NOT NULL DEFAULT '',
   `ip`           VARCHAR(64)  NOT NULL DEFAULT '',
   `byte_size`    INT          NOT NULL DEFAULT 0,
   `message_id`   BIGINT       NOT NULL DEFAULT 0,
-  `created_at`   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-CREATE INDEX `idx_iwa_webhook_time` ON `incoming_webhook_audit` (`webhook_id`, `created_at`);
+  `created_at`   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX `idx_iwa_webhook_time` (`webhook_id`, `created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='群入站 Webhook 调用审计';
 
 -- +migrate Down
 DROP TABLE IF EXISTS `incoming_webhook_audit`;

--- a/modules/incomingwebhook/util_test.go
+++ b/modules/incomingwebhook/util_test.go
@@ -1,7 +1,9 @@
 package incomingwebhook
 
 import (
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/stretchr/testify/assert"
@@ -107,6 +109,43 @@ func TestBuildPayload_SpaceIDSetEvenWhenExtraOmitsIt(t *testing.T) {
 	req := &pushPayloadReq{Content: "hi"}
 	p := buildPayload(m, req)
 	assert.Equal(t, "real_space", p["space_id"])
+}
+
+// TestBuildPayload_TruncatesLongUsernameAvatar 锁定 push 路径 username / avatar_url
+// 服务端裁剪：调用方塞 KB 级字符串时，from.name / from.avatar 被截断到 create 侧
+// 的列长度上限（64 / 255 字节），防止污染所有客户端渲染。原回归来自 PR #31
+// yujiawei review P2-3。
+func TestBuildPayload_TruncatesLongUsernameAvatar(t *testing.T) {
+	m := &incomingWebhookModel{WebhookID: "iwh_x", Name: "WH", Avatar: "https://default"}
+	longName := strings.Repeat("A", 10000)
+	longAvatar := "https://" + strings.Repeat("x", 10000)
+	req := &pushPayloadReq{
+		Content:   "hi",
+		Username:  longName,
+		AvatarURL: longAvatar,
+	}
+	p := buildPayload(m, req)
+	from := p["from"].(map[string]interface{})
+	gotName := from["name"].(string)
+	gotAvatar := from["avatar"].(string)
+
+	assert.Equalf(t, 64, len(gotName), "from.name capped at 64 bytes; got %d", len(gotName))
+	assert.Equalf(t, 255, len(gotAvatar), "from.avatar capped at 255 bytes; got %d", len(gotAvatar))
+}
+
+// TestBuildPayload_TruncateRespectsUTF8 验证截断在 rune 边界回退，不会把多字节字符
+// 切成乱码字节。中文字符 3 字节，64 字节上限最多保留 21 个完整中文。
+func TestBuildPayload_TruncateRespectsUTF8(t *testing.T) {
+	m := &incomingWebhookModel{WebhookID: "iwh_x", Name: "WH"}
+	req := &pushPayloadReq{
+		Content:  "hi",
+		Username: strings.Repeat("一", 100), // 100 × 3 = 300 字节
+	}
+	p := buildPayload(m, req)
+	from := p["from"].(map[string]interface{})
+	gotName := from["name"].(string)
+	assert.LessOrEqualf(t, len(gotName), 64, "byte length capped; got %d", len(gotName))
+	assert.Truef(t, utf8.ValidString(gotName), "truncated name must remain valid UTF-8; got %q", gotName)
 }
 
 func TestPublicURL(t *testing.T) {

--- a/modules/incomingwebhook/util_test.go
+++ b/modules/incomingwebhook/util_test.go
@@ -54,24 +54,40 @@ func TestBuildPayload_OverrideUsernameAndAvatar(t *testing.T) {
 	assert.Equal(t, "https://gh/a.png", from["avatar"])
 }
 
-func TestBuildPayload_ExtraDoesNotOverrideKeyFields(t *testing.T) {
+// TestBuildPayload_DropsAllExtra 锁定 Extra 一律丢弃的语义：调用方任何 key
+// 都不能写入持久化 payload。重点防御 visibles —— message 模块把它当作服务端
+// 强制的可见性白名单解释（不在列表内的用户会被同步标删 + 单消息 404），允许
+// token 持有者写就等于给了一个"对管理员隐身的群消息"通道。
+func TestBuildPayload_DropsAllExtra(t *testing.T) {
 	m := &incomingWebhookModel{WebhookID: "iwh_x", Name: "WH"}
 	req := &pushPayloadReq{
 		Content: "real",
 		Extra: map[string]interface{}{
-			"type":    9999,        // 不能覆盖
-			"content": "fake",      // 不能覆盖
-			"from":    "fake",      // 不能覆盖
-			"mention": "fake",      // 不能覆盖
-			"link":    "https://x", // 允许透传
+			"visibles":   []string{"attacker_uid"}, // 关键：访问控制字段必须被丢弃
+			"mention":    map[string]interface{}{"all": true},
+			"reminder":   "fake",
+			"link":       "https://x",
+			"type":       9999,
+			"content":    "fake",
+			"from":       "fake",
+			"space_id":   "forged",
+			"anything":   "else",
 		},
 	}
 	p := buildPayload(m, req)
+	// 核心字段保持服务端值
 	assert.Equal(t, int(common.Text), p["type"])
 	assert.Equal(t, "real", p["content"])
 	_, isMap := p["from"].(map[string]interface{})
 	assert.True(t, isMap, "from must remain the structured object")
-	assert.Equal(t, "https://x", p["link"])
+	// Extra 中任何 key 都不能写入 payload
+	for k := range req.Extra {
+		if k == "type" || k == "content" || k == "from" || k == "space_id" {
+			continue // 这些是服务端字段，断言已在上面
+		}
+		_, exists := p[k]
+		assert.Falsef(t, exists, "extra key %q must not leak into payload", k)
+	}
 }
 
 func TestBuildPayload_SpaceIDFromModelNotExtra(t *testing.T) {

--- a/modules/incomingwebhook/util_test.go
+++ b/modules/incomingwebhook/util_test.go
@@ -74,6 +74,25 @@ func TestBuildPayload_ExtraDoesNotOverrideKeyFields(t *testing.T) {
 	assert.Equal(t, "https://x", p["link"])
 }
 
+func TestBuildPayload_SpaceIDFromModelNotExtra(t *testing.T) {
+	m := &incomingWebhookModel{WebhookID: "iwh_x", Name: "WH", SpaceID: "real_space"}
+	req := &pushPayloadReq{
+		Content: "hi",
+		Extra: map[string]interface{}{
+			"space_id": "forged_space",
+		},
+	}
+	p := buildPayload(m, req)
+	assert.Equal(t, "real_space", p["space_id"], "space_id must come from model, not Extra")
+}
+
+func TestBuildPayload_SpaceIDSetEvenWhenExtraOmitsIt(t *testing.T) {
+	m := &incomingWebhookModel{WebhookID: "iwh_x", Name: "WH", SpaceID: "real_space"}
+	req := &pushPayloadReq{Content: "hi"}
+	p := buildPayload(m, req)
+	assert.Equal(t, "real_space", p["space_id"])
+}
+
 func TestPublicURL(t *testing.T) {
 	got := publicURL("iwh_abc", "tk")
 	assert.Equal(t, "/v1/incoming-webhooks/iwh_abc/tk", got)

--- a/modules/incomingwebhook/util_test.go
+++ b/modules/incomingwebhook/util_test.go
@@ -1,0 +1,85 @@
+package incomingwebhook
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateToken(t *testing.T) {
+	tok1, h1, err := generateToken()
+	assert.NoError(t, err)
+	assert.Equal(t, 64, len(tok1), "32 bytes hex = 64 chars")
+	assert.Equal(t, 64, len(h1), "sha256 hex = 64 chars")
+	assert.Equal(t, h1, hashToken(tok1))
+
+	tok2, h2, err := generateToken()
+	assert.NoError(t, err)
+	assert.NotEqual(t, tok1, tok2, "token should be random")
+	assert.NotEqual(t, h1, h2)
+}
+
+func TestHashTokenIsDeterministic(t *testing.T) {
+	assert.Equal(t, hashToken("foo"), hashToken("foo"))
+	assert.NotEqual(t, hashToken("foo"), hashToken("bar"))
+}
+
+func TestBuildPayload_DefaultsToWebhookNameAvatar(t *testing.T) {
+	m := &incomingWebhookModel{
+		WebhookID: "iwh_x",
+		Name:      "WH",
+		Avatar:    "https://avatar/x.png",
+	}
+	req := &pushPayloadReq{Content: "hi"}
+	p := buildPayload(m, req)
+
+	assert.Equal(t, int(common.Text), p["type"])
+	assert.Equal(t, "hi", p["content"])
+	from, _ := p["from"].(map[string]interface{})
+	assert.Equal(t, "webhook", from["kind"])
+	assert.Equal(t, "iwh_x", from["webhook_id"])
+	assert.Equal(t, "WH", from["name"])
+	assert.Equal(t, "https://avatar/x.png", from["avatar"])
+}
+
+func TestBuildPayload_OverrideUsernameAndAvatar(t *testing.T) {
+	m := &incomingWebhookModel{WebhookID: "iwh_x", Name: "default"}
+	req := &pushPayloadReq{
+		Content:  "hi",
+		Username: "GitHub Bot", AvatarURL: "https://gh/a.png",
+	}
+	from := buildPayload(m, req)["from"].(map[string]interface{})
+	assert.Equal(t, "GitHub Bot", from["name"])
+	assert.Equal(t, "https://gh/a.png", from["avatar"])
+}
+
+func TestBuildPayload_ExtraDoesNotOverrideKeyFields(t *testing.T) {
+	m := &incomingWebhookModel{WebhookID: "iwh_x", Name: "WH"}
+	req := &pushPayloadReq{
+		Content: "real",
+		Extra: map[string]interface{}{
+			"type":    9999,        // 不能覆盖
+			"content": "fake",      // 不能覆盖
+			"from":    "fake",      // 不能覆盖
+			"mention": "fake",      // 不能覆盖
+			"link":    "https://x", // 允许透传
+		},
+	}
+	p := buildPayload(m, req)
+	assert.Equal(t, int(common.Text), p["type"])
+	assert.Equal(t, "real", p["content"])
+	_, isMap := p["from"].(map[string]interface{})
+	assert.True(t, isMap, "from must remain the structured object")
+	assert.Equal(t, "https://x", p["link"])
+}
+
+func TestPublicURL(t *testing.T) {
+	got := publicURL("iwh_abc", "tk")
+	assert.Equal(t, "/v1/incoming-webhooks/iwh_abc/tk", got)
+}
+
+func TestGenerateWebhookID_HasPrefix(t *testing.T) {
+	id := generateWebhookID()
+	assert.Truef(t, len(id) > 4 && id[:4] == "iwh_", "id should start with iwh_, got %s", id)
+}

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -2171,6 +2171,16 @@ func (m *Message) groupRoleRevokeAllowed(groupNo, fromUID, loginUID string) (boo
 	if loginMember == nil {
 		return false, nil
 	}
+	// Fail-safe：黑名单 / 已退出但 is_deleted=0 的成员（脏数据或软删除残留）即使
+	// role 仍是 manager/creator，也不视为有效管理者；否则被踢出的管理员仍能撤回
+	// 任意 webhook 消息（FromUID = "iwh_..."，走 fromMember==nil 分支）或普通成员
+	// 消息。PR Mininglamp-OSS/octo-server#31 round-4 (Jerry-Xin)。
+	// 与 modules/group/db.go:QueryIsGroupManagerOrCreator 的 status=Normal 过滤
+	// 配对——前者守住管理 API 入口，后者守住消息撤回入口。群聊与子区共用此函数，
+	// 故两条撤回路径均受保护。
+	if loginMember.Status != int(common.GroupMemberStatusNormal) {
+		return false, nil
+	}
 	fromMember, err := m.groupService.GetMember(groupNo, fromUID)
 	if err != nil {
 		return false, err

--- a/modules/message/revoke_bot_test.go
+++ b/modules/message/revoke_bot_test.go
@@ -148,8 +148,8 @@ func TestHasRevokePermission_NotBotOwner_Group_NotAdmin(t *testing.T) {
 func TestHasRevokePermission_NotBotOwner_Group_Admin(t *testing.T) {
 	rb := &fakeRobotService{byRobotID: map[string]string{botUID: ownerUID}}
 	gs := &fakeGroupService{members: map[string]*group.MemberResp{
-		adminUID: {GroupNo: groupNo, UID: adminUID, Role: int(common.GroupMemberRoleManager)},
-		botUID:   {GroupNo: groupNo, UID: botUID, Role: int(common.GroupMemberRoleNormal)},
+		adminUID: {GroupNo: groupNo, UID: adminUID, Role: int(common.GroupMemberRoleManager), Status: int(common.GroupMemberStatusNormal)},
+		botUID:   {GroupNo: groupNo, UID: botUID, Role: int(common.GroupMemberRoleNormal), Status: int(common.GroupMemberStatusNormal)},
 	}}
 	m := newRevokeTestMessage(rb, gs)
 
@@ -181,13 +181,62 @@ func TestHasRevokePermission_EmptyCreatorUID(t *testing.T) {
 	assert.False(t, allow, "creator_uid 为空时不应意外授予 bot-owner 权限")
 }
 
-// 场景 7: robotService.GetCreatorUID 返回 error → 降级不阻断后续分支
+// 场景 7-blacklisted: 黑名单 manager 不能撤回 webhook 消息（fromMember==nil 分支）
+//
+// PR Mininglamp-OSS/octo-server#31 round-4 (Jerry-Xin)。webhook 消息的 FromUID
+// 形如 "iwh_..."，不是真实群成员 → 走 fromMember==nil 分支。该分支历史上
+// 「只要 loginMember.Role != normal 就允许撤回」，忽略 loginMember.Status，
+// 等于让被踢出（status=Blacklist 但 is_deleted=0）的 manager 仍能任意撤回。
+// 修复后必须 status=Normal 才视为有效管理者。
+func TestHasRevokePermission_BlacklistedManager_CannotRevokeWebhookMsg(t *testing.T) {
+	const webhookUID = "iwh_abcdef" // 模拟 webhook 发送方（非群成员）
+	rb := &fakeRobotService{}       // bot-owner 分支不命中
+	gs := &fakeGroupService{members: map[string]*group.MemberResp{
+		// 黑名单 manager：is_deleted=0 但 status=Blacklist —— 脏数据 / 被踢出但未硬删
+		adminUID: {GroupNo: groupNo, UID: adminUID, Role: int(common.GroupMemberRoleManager), Status: int(common.GroupMemberStatusBlacklist)},
+		// webhook 不写 member 表，故 webhookUID 不存在 → GetMember 返回 nil
+	}}
+	m := newRevokeTestMessage(rb, gs)
+
+	msg := &messageModel{
+		FromUID:     webhookUID,
+		ChannelID:   groupNo,
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+	}
+
+	allow, err := m.hasRevokePermission(msg, adminUID)
+	assert.NoError(t, err)
+	assert.False(t, allow, "黑名单 manager 不应能撤回 webhook 消息")
+}
+
+// 场景 7-blacklisted-2: 黑名单 manager 也不能撤回普通成员消息
+// （证明修复不只针对 fromMember==nil 分支，所有 group-revoke 路径都受 status 校验拦截）
+func TestHasRevokePermission_BlacklistedManager_CannotRevokeNormalMemberMsg(t *testing.T) {
+	rb := &fakeRobotService{} // bot-owner 分支不命中
+	gs := &fakeGroupService{members: map[string]*group.MemberResp{
+		adminUID:   {GroupNo: groupNo, UID: adminUID, Role: int(common.GroupMemberRoleManager), Status: int(common.GroupMemberStatusBlacklist)},
+		strangerID: {GroupNo: groupNo, UID: strangerID, Role: int(common.GroupMemberRoleNormal), Status: int(common.GroupMemberStatusNormal)},
+	}}
+	m := newRevokeTestMessage(rb, gs)
+
+	msg := &messageModel{
+		FromUID:     strangerID,
+		ChannelID:   groupNo,
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+	}
+
+	allow, err := m.hasRevokePermission(msg, adminUID)
+	assert.NoError(t, err)
+	assert.False(t, allow, "黑名单 manager 不应能撤回普通成员消息")
+}
+
+// 场景 8: robotService.GetCreatorUID 返回 error → 降级不阻断后续分支
 // 并且不应向上返回 error。通过设置群管理员分支可命中来验证降级正确。
 func TestHasRevokePermission_RobotServiceError(t *testing.T) {
 	rb := &fakeRobotService{err: errors.New("mock db down")}
 	gs := &fakeGroupService{members: map[string]*group.MemberResp{
-		adminUID: {GroupNo: groupNo, UID: adminUID, Role: int(common.GroupMemberRoleCreater)},
-		botUID:   {GroupNo: groupNo, UID: botUID, Role: int(common.GroupMemberRoleNormal)},
+		adminUID: {GroupNo: groupNo, UID: adminUID, Role: int(common.GroupMemberRoleCreater), Status: int(common.GroupMemberStatusNormal)},
+		botUID:   {GroupNo: groupNo, UID: botUID, Role: int(common.GroupMemberRoleNormal), Status: int(common.GroupMemberStatusNormal)},
 	}}
 	m := newRevokeTestMessage(rb, gs)
 

--- a/modules/message/revoke_topic_test.go
+++ b/modules/message/revoke_topic_test.go
@@ -30,7 +30,11 @@ const (
 )
 
 func member(uid string, role common.GroupMemberRole) *group.MemberResp {
-	return &group.MemberResp{GroupNo: "PG1", UID: uid, Role: int(role)}
+	// Status 必须显式设为 Normal：groupRoleRevokeAllowed 现在对 loginMember 做
+	// status=Normal 的 fail-safe 校验（黑名单/已退群但 is_deleted=0 的脏数据不视为
+	// 有效管理者）。零值 Status=0 会被判为非 Normal，使所有"应允许"子用例返回 false。
+	// 与 revoke_bot_test.go / is_manager_external_test.go 的 fixture 对齐。
+	return &group.MemberResp{GroupNo: "PG1", UID: uid, Role: int(role), Status: int(common.GroupMemberStatusNormal)}
 }
 
 func TestHasRevokePermission_CommunityTopic_ParentRoleMatrix(t *testing.T) {

--- a/pkg/errcode/incomingwebhook.go
+++ b/pkg/errcode/incomingwebhook.go
@@ -1,0 +1,63 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// err.server.incomingwebhook.* — modules/incomingwebhook push-endpoint error
+// codes (api.go push path). DefaultMessage holds the en-US source; the zh-CN
+// runtime translation lives in pkg/i18n/locales/active.zh-CN.toml.
+//
+// The push endpoint is an unauthenticated, token-in-URL surface. Every
+// authentication failure (missing/disabled webhook, bad token, disbanded
+// group) intentionally collapses to the SINGLE push_unauthorized code with a
+// uniform message, so a probe cannot tell "no such webhook" from "wrong token"
+// — see modules/incomingwebhook/api.go respondPushUnauthorized. Migrated off
+// the raw c.AbortWithStatusJSON pattern to satisfy the D23 i18n lint gate
+// (PR Mininglamp-OSS/octo-server#31, yujiawei review #3).
+var (
+	// ErrIncomingWebhookPushUnauthorized (401) — uniform anti-probe response for
+	// every auth failure on the push path; never differentiate the reason.
+	ErrIncomingWebhookPushUnauthorized = register(codes.Code{
+		ID:             "err.server.incomingwebhook.push_unauthorized",
+		HTTPStatus:     http.StatusUnauthorized,
+		DefaultMessage: "Unauthorized.",
+	})
+
+	// ErrIncomingWebhookPushRateLimited (429) — the per-webhook token bucket
+	// rejected this request.
+	ErrIncomingWebhookPushRateLimited = register(codes.Code{
+		ID:             "err.server.incomingwebhook.push_rate_limited",
+		HTTPStatus:     http.StatusTooManyRequests,
+		DefaultMessage: "Too many requests. Please retry later.",
+	})
+
+	// ErrIncomingWebhookPushPayloadInvalid (400) — unreadable body, malformed
+	// JSON, or empty content. The offending stage is surfaced via
+	// Details["reason"] (body / json / content).
+	ErrIncomingWebhookPushPayloadInvalid = register(codes.Code{
+		ID:             "err.server.incomingwebhook.push_payload_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid request payload.",
+		SafeDetailKeys: []string{"reason"},
+	})
+
+	// ErrIncomingWebhookPushPayloadTooLarge (413) — body exceeds the configured
+	// byte cap (DM_INCOMINGWEBHOOK_MAX_BYTES).
+	ErrIncomingWebhookPushPayloadTooLarge = register(codes.Code{
+		ID:             "err.server.incomingwebhook.push_payload_too_large",
+		HTTPStatus:     http.StatusRequestEntityTooLarge,
+		DefaultMessage: "Request payload is too large.",
+	})
+
+	// ErrIncomingWebhookPushDeliveryFailed (502, Internal) — the downstream
+	// SendMessage failed; the underlying error is logged, not surfaced.
+	ErrIncomingWebhookPushDeliveryFailed = register(codes.Code{
+		ID:             "err.server.incomingwebhook.push_delivery_failed",
+		HTTPStatus:     http.StatusBadGateway,
+		DefaultMessage: "Failed to deliver the webhook message.",
+		Internal:       true,
+	})
+)

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -648,3 +648,20 @@ other = "绑定会话已过期或无效，请重新发起。"
 
 ["err.server.oidc.bind_claims_incomplete"]
 other = "身份提供方未返回创建账号所需的账号信息。"
+
+# ---- err.server.incomingwebhook.* (modules/incomingwebhook push path, PR #31 D23) ----
+
+["err.server.incomingwebhook.push_unauthorized"]
+other = "未授权。"
+
+["err.server.incomingwebhook.push_rate_limited"]
+other = "请求过于频繁，请稍后再试。"
+
+["err.server.incomingwebhook.push_payload_invalid"]
+other = "请求内容无效。"
+
+["err.server.incomingwebhook.push_payload_too_large"]
+other = "请求内容过大。"
+
+["err.server.incomingwebhook.push_delivery_failed"]
+other = "Webhook 消息投递失败。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -168,6 +168,21 @@ other = "The target user does not exist or has been deactivated."
 ["err.server.group.view_forbidden"]
 other = "You do not have permission to view this."
 
+["err.server.incomingwebhook.push_delivery_failed"]
+other = "Failed to deliver the webhook message."
+
+["err.server.incomingwebhook.push_payload_invalid"]
+other = "Invalid request payload."
+
+["err.server.incomingwebhook.push_payload_too_large"]
+other = "Request payload is too large."
+
+["err.server.incomingwebhook.push_rate_limited"]
+other = "Too many requests. Please retry later."
+
+["err.server.incomingwebhook.push_unauthorized"]
+other = "Unauthorized."
+
 ["err.server.message.banword_not_found"]
 other = "The banned word does not exist."
 


### PR DESCRIPTION
## Summary

Add `modules/incomingwebhook`: group incoming webhooks that let external services push messages to a group via a token-bearing URL (Discord/Slack-style semantics).

- Group owners and managers create webhooks through an authenticated API and receive a one-time token + URL; only the SHA-256(token) is persisted.
- Push endpoint accepts JSON (`content` / `username` / `avatar_url`) and delivers as a Text message with `from.kind=webhook` so clients can render the virtual sender without a real user profile.
- Revoke permission follows the existing message module: owners and managers can revoke webhook messages; regular members (including the webhook creator) cannot — matching Discord semantics.

## Defenses

- Token comparison via `crypto/subtle.ConstantTimeCompare`.
- Rate limiting: per-IP and per-webhook token buckets (Redis Lua, fail-open on Redis failure).
- Caps: 8 KB body (`io.LimitReader` + 1-byte overflow detection); per-group quota (default 10, env-tunable) enforced atomically inside a transaction with `SELECT ... FOR UPDATE` on the (group_no, status) index — concurrent creators are serialized so the configured cap holds.
- Audit log of successful pushes (`incoming_webhook_audit`).
- Lifecycle: listens for `event.GroupDisband` to cascade-disable; `create` / `update(status=1)` / `regenerate` / `push` all gated by `requireActiveGroup` to prevent disband → re-enable revival.
- Payload: `space_id` is authoritatively derived from the group row server-side. Caller-supplied `extra` is dropped wholesale — `payload.visibles` is a server-enforced visibility allowlist in the message module (non-listed users see the message as deleted / 404), so an unauthenticated token holder must not be able to set it. Future metadata fields must be added by explicit name only.
- Push-side `username` / `avatar_url` are server-truncated in `buildPayload` to the same byte limits as the create-side columns (64 / 255), with UTF-8 rune-boundary fallback. The push path is otherwise only bounded by the 8 KB body cap, so without this a token holder could stuff KB-class strings into `from.*` and pollute every client's render path.
- `updateFields` enforces a column allowlist (`name` / `avatar` / `status` / `token_hash`) so a future caller passing user-controlled keys cannot drive an arbitrary column update.

## Cross-module hardening (admin role semantics)

Two existing helpers gated "is this user an effective admin" purely on `role != Normal` without inspecting `group_member.status`, so a blacklisted manager row (`is_deleted=0, status=Blacklist, role=Manager`) still passed. The new webhook surface made these reachable in fresh ways (management API + the `fromMember==nil` revoke branch via `FromUID = "iwh_..."`), so the fixes are bundled here rather than deferred:

- **`modules/group/db.go::QueryIsGroupManagerOrCreator`** — added `AND status=GroupMemberStatusNormal` to the WHERE clause. Pairs with the existing `is_external=0` fail-safe (YUJ-231); 12 callers across group/api.go, group/invite.go, group/service.go and the new incomingwebhook all benefit. Regression: `is_manager_status_test.go` mirrors the existing `is_manager_external_test.go` pattern.
- **`modules/message/api.go::hasRevokePermission`** — added an explicit `loginMember.Status == Normal` check before the role branches. Closes the path where a blacklisted manager could revoke webhook messages (FromUID = "iwh_..." → `fromMember==nil` branch) or normal-member messages. Regression: two new cases in `revoke_bot_test.go` cover both subpaths.

## Design notes

- **Disabled webhooks count toward `maxPerGroup`.** `insertWithQuota` counts all rows for a group regardless of `status`. This is intentional: scoping the count by `status=1` would turn `enable → disable → create` into a quota-bypass loop and let a disband cascade (which flips every webhook to `status=0`) silently re-open creation slots for a stale admin. Admins reclaim a slot by `DELETE`, not by disabling. The trade-off is documented inline at `db.go` next to the count query.

## Schema

`modules/incomingwebhook/sql/20260514000003_incomingwebhook_init.sql`

- Layout aligned with `modules/category` / `modules/conversation_ext`: indexes inline inside `CREATE TABLE`, explicit `ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='...'` suffix.
- `incoming_webhook`: `webhook_id` (unique), `token_hash` (`VARCHAR(128)` — leaves headroom for a future hash algorithm switch), `group_no`, `space_id`, `name`, `avatar`, `creator_uid`, `status`, `last_used_at`, `call_count`, `created_at`, `updated_at`.
- `incoming_webhook_audit`: `webhook_id`, `group_no`, `ip`, `byte_size`, `message_id`, `created_at`.
- Indexes: `uk_incoming_webhook_id`, `idx_incoming_webhook_group(group_no, status)`, `idx_iwa_webhook_time(webhook_id, created_at)`.

## Tests

- 11 unit tests in `modules/incomingwebhook/util_test.go`: token generation, hash determinism, `buildPayload` paths (incl. `space_id` derivation, unconditional Extra drop covering `visibles` / `mention` / `reminder`, push-side username / avatar truncation with UTF-8 rune-boundary fallback).
- 16 API integration tests in `modules/incomingwebhook/api_test.go`. Five run on every CI build (`TestCreate_HappyPath` — also asserts `created_at > 0`; `TestPush_RejectsBadToken`; `TestPush_RejectsDisabledWebhook`; `TestCreate_QuotaEnforced`; `TestCreate_QuotaConcurrent` — the regression for the quota race). The remaining 11 carry `t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")` per the existing repo convention; they will be un-skipped together with the rest once #17 is resolved.
- New `modules/group/is_manager_status_test.go`: blacklisted manager / creator fail-safe (paired with the existing external-member fail-safe).
- New cases in `modules/message/revoke_bot_test.go`: blacklisted manager cannot revoke a webhook message (the `fromMember==nil` branch) and cannot revoke a normal member's message.

Locally verified against MySQL 8 + Redis with all 16 unskipped + 11 unit tests passing under `-race`, plus the new fail-safe tests in `modules/group` and `modules/message`.

## Review history

Four rounds of upstream review (Jerry-Xin / lml2468 / yujiawei). All P1/P2 blockers and the cross-module admin-role gaps now resolved:

- **R1 P1 (lml2468)** — `extra.visibles` injection: drop `Extra` wholesale.
- **R1 P1 (Jerry-Xin + lml2468)** — quota race: `insertWithQuota` + `SELECT ... FOR UPDATE` + `TestCreate_QuotaConcurrent`.
- **R1 P2 (both)** — `created_at` epoch(0): `db.Time(time.Now())` before insert + `TestCreate_HappyPath` assertion.
- **R2 P2-3 (yujiawei)** — push username / avatar_url unbounded: `truncateUTF8` to 64 / 255 bytes.
- **R3 (Jerry-Xin)** — `QueryIsGroupManagerOrCreator` missed `status=Normal`: fixed at source per @lml2468's suggestion (one-line WHERE clause; covers all 12 callers).
- **R4 (Jerry-Xin)** — `hasRevokePermission` missed `loginMember.Status=Normal`: fixed at source. Symmetric to R3 — both helpers now require `status=Normal` for any admin-role judgment.

## Test plan

- [x] CI: Build / Vet / Lint green; Test exercises the 5 un-skipped integration tests on the service-container MySQL/Redis.
- [ ] After #17 is fixed, un-skip the remaining 11 `OCTO migration TODO` tests in this file as part of the global pass, plus add a disband-cascade test (per yujiawei R3 P2).
- [ ] Production rollout follow-ups (separate issues, all noted by yujiawei): audit retention job + `INDEX(created_at)` on `incoming_webhook_audit`; bounded `recordSuccess` worker pool; operator runbook entry for `:token` access-log redaction (consider also accepting `Authorization: Bearer …` to keep tokens out of the URL path); verify proxy `X-Forwarded-For` trust boundaries match the `StrictIPRateLimitMiddleware` expectations; pick an explicit `content` size cap (Discord 2k / Slack 40k); always run `requireActiveGroup` on `update` (cosmetic edits on disbanded groups are currently allowed but harmless because push fail-closes regardless).