### PR TITLE
fix(conversation_ext): UpdateSort no longer false-reports version conflict on unchanged follow_sort

### DIFF
--- a/modules/conversation_ext/bugfix_test.go
+++ b/modules/conversation_ext/bugfix_test.go
@@ -249,6 +249,81 @@ func TestDB_UpdateSort_CASUsesFollowVersion(t *testing.T) {
 	assert.Equal(t, int64(2), v)
 }
 
+// TestDB_UpdateSort_UnchangedSortValues_NotConflict 复现真实环境抓到的 bug：
+// 用户拖拽排序时，如果序列里某一项的新 follow_sort 等于它当前的 follow_sort
+// （最常见就是首项保持不动），MySQL 驱动默认以 rows-changed 语义返回
+// RowsAffected=0，老实现误判为 ErrVersionConflict 并整个 tx 回滚。
+//
+// 修复后：SELECT ... FOR UPDATE 已经在前面校验过 len(locked)==len(items)，
+// 行的存在性已被保证，affected==0 唯一含义是"新值等于旧值"，应当视作成功。
+func TestDB_UpdateSort_UnchangedSortValues_NotConflict(t *testing.T) {
+	ctx := newCtxForTest(t)
+	_, _ = ctx.DB().DeleteFrom(table).Exec()
+	_, _ = ctx.DB().DeleteFrom(followVersionTable).Exec()
+
+	db := NewDB(ctx)
+	fvDB := NewFollowVersionDB(ctx)
+
+	// Seed two rows already at the "target" sort values (1, 2).
+	require.NoError(t, db.Upsert("u1", "s1", 1, "dm-a", ConvExtFields{
+		FollowedDM: int8Ptr(1), FollowSort: intPtr(1),
+	}))
+	require.NoError(t, db.Upsert("u1", "s1", 1, "dm-b", ConvExtFields{
+		FollowedDM: int8Ptr(1), FollowSort: intPtr(2),
+	}))
+
+	// Submitting the same order: every row's new follow_sort equals its current
+	// value → MySQL reports RowsAffected=0 for each UPDATE. Must still succeed.
+	err := db.UpdateSort("u1", "s1", []SortItem{
+		{TargetType: 1, TargetID: "dm-a"},
+		{TargetType: 1, TargetID: "dm-b"},
+	}, 0)
+	require.NoError(t, err, "no-op sort (values unchanged) must not be reported as version conflict")
+
+	// follow_version must still advance — caller's optimistic CAS depends on it.
+	v, err := fvDB.Get("u1", "s1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), v)
+}
+
+// TestDB_UpdateSort_FirstItemUnchanged_NotConflict 覆盖最常见的复现路径：
+// 用户拖动列表但首项不动，items[0] 的旧值 (=1) 与新值 (i=0, i+1=1) 相同，
+// 老实现在第一次 UPDATE 就 affected=0，整个 tx 误回滚。
+func TestDB_UpdateSort_FirstItemUnchanged_NotConflict(t *testing.T) {
+	ctx := newCtxForTest(t)
+	_, _ = ctx.DB().DeleteFrom(table).Exec()
+	_, _ = ctx.DB().DeleteFrom(followVersionTable).Exec()
+
+	db := NewDB(ctx)
+
+	// dm-head sort=1 (head), dm-tail sort=2.
+	require.NoError(t, db.Upsert("u1", "s1", 1, "dm-head", ConvExtFields{
+		FollowedDM: int8Ptr(1), FollowSort: intPtr(1),
+	}))
+	require.NoError(t, db.Upsert("u1", "s1", 1, "dm-tail", ConvExtFields{
+		FollowedDM: int8Ptr(1), FollowSort: intPtr(2),
+	}))
+
+	// Keep head at position 0, swap tail (still ends up at 2).
+	// items[0]=dm-head: old=1, new=1 → affected=0 in rows-changed semantics.
+	err := db.UpdateSort("u1", "s1", []SortItem{
+		{TargetType: 1, TargetID: "dm-head"},
+		{TargetType: 1, TargetID: "dm-tail"},
+	}, 0)
+	require.NoError(t, err, "first item staying in place must not trigger version conflict")
+
+	// Final state still correct.
+	head, err := db.Get("u1", "s1", 1, "dm-head")
+	require.NoError(t, err)
+	require.NotNil(t, head)
+	assert.Equal(t, 1, head.FollowSort)
+
+	tail, err := db.Get("u1", "s1", 1, "dm-tail")
+	require.NoError(t, err)
+	require.NotNil(t, tail)
+	assert.Equal(t, 2, tail.FollowSort)
+}
+
 // TestRemoveConvExtForUserInSpace_GroupCascade_LeavesNoOrphans is a regression
 // guard for PR review Blocking #2.
 //

--- a/modules/conversation_ext/bugfix_test.go
+++ b/modules/conversation_ext/bugfix_test.go
@@ -304,8 +304,8 @@ func TestDB_UpdateSort_FirstItemUnchanged_NotConflict(t *testing.T) {
 		FollowedDM: int8Ptr(1), FollowSort: intPtr(2),
 	}))
 
-	// Keep head at position 0, swap tail (still ends up at 2).
-	// items[0]=dm-head: old=1, new=1 → affected=0 in rows-changed semantics.
+	// Submit the same order so dm-head stays at position 0 (new follow_sort=1,
+	// equal to its current value → affected=0 in rows-changed semantics).
 	err := db.UpdateSort("u1", "s1", []SortItem{
 		{TargetType: 1, TargetID: "dm-head"},
 		{TargetType: 1, TargetID: "dm-tail"},

--- a/modules/conversation_ext/db.go
+++ b/modules/conversation_ext/db.go
@@ -226,7 +226,8 @@ func (d *DB) ListThreadExts(uid, spaceID string) ([]*Model, error) {
 //   - cur != expectedVersion → ErrVersionConflict（回滚）。
 //   - 用 (target_type, target_id) 升序 FOR UPDATE 锁 user_conversation_ext 全部目标行。
 //     返回行数 != len(items) → ErrSortTargetNotFound（回滚）。
-//   - 对每一行 UPDATE follow_sort，并校验 RowsAffected==1。
+//   - 对每一行 UPDATE follow_sort。RowsAffected ∈ {0,1}：0=新值与旧值相同（无变化，
+//     仍视为成功），1=正常更新；>1 不可达（WHERE 含逻辑主键），仅作防御性守卫。
 //   - 最后在同 tx 内把 user_follow_version +1。
 //   - items 为空时什么也不做，返回 nil。
 //
@@ -292,7 +293,8 @@ func (d *DB) UpdateSort(uid, spaceID string, items []SortItem, expectedVersion i
 		return ErrSortTargetNotFound
 	}
 
-	// 3. 逐行 UPDATE follow_sort，确认 RowsAffected==1。
+	// 3. 逐行 UPDATE follow_sort。RowsAffected ∈ {0,1}（见函数注释）：0 仅意味着
+	//    新值等于旧值，仍是成功；>1 不可达，作为防御性守卫报错。
 	for i, item := range items {
 		res, err := tx.UpdateBySql(
 			"UPDATE "+table+" SET follow_sort=?"+

--- a/modules/conversation_ext/db.go
+++ b/modules/conversation_ext/db.go
@@ -306,9 +306,11 @@ func (d *DB) UpdateSort(uid, spaceID string, items []SortItem, expectedVersion i
 		if err != nil {
 			return fmt.Errorf("update sort: rows affected: %w", err)
 		}
-		if affected != 1 {
-			// 锁后行被并发删除等，逻辑上不可达。保守起见按 conflict 处理。
-			return ErrVersionConflict
+		// MySQL 驱动默认走 rows-changed 语义：新值等于旧值时 affected=0。
+		// 行的存在性已由前面的 SELECT ... FOR UPDATE + len(locked) 校验保证，
+		// 所以 affected ∈ {0, 1}，0 仅意味着无需变更，不是 conflict。
+		if affected > 1 {
+			return fmt.Errorf("update sort: unexpected rows affected=%d for (%d,%s)", affected, item.TargetType, item.TargetID)
 		}
 	}
 

--- a/modules/conversation_ext/db_test.go
+++ b/modules/conversation_ext/db_test.go
@@ -28,6 +28,10 @@ func newDBForTest(t *testing.T) *DB {
 	ctx := config.NewContext(cfg)
 	_, err := ctx.DB().DeleteFrom(table).Exec()
 	require.NoError(t, err, "clean "+table+" before test")
+	// followVersionTable 必须一起清掉，否则上一个 test 留下的 follow_version
+	// 会让本 test 的 expectedVersion=0 失败为 ErrVersionConflict。
+	_, err = ctx.DB().DeleteFrom(followVersionTable).Exec()
+	require.NoError(t, err, "clean "+followVersionTable+" before test")
 	return NewDB(ctx)
 }
 


### PR DESCRIPTION
## Summary

`modules/conversation_ext.UpdateSort` falsely reports `ErrVersionConflict` whenever any item in the submitted sequence has a new `follow_sort` equal to its current value — most commonly when the user drags the list but the first item stays in place. The transaction is rolled back and the client sees a 400 `version conflict: please retry` even though the CAS `follow_version` is correct and all rows exist.

### Root cause

The default MySQL driver uses *rows-changed* semantics for `RowsAffected()`, not *rows-matched*. When `UPDATE ... SET follow_sort=?` is issued with the same value already stored, `affected` is `0`. The old code treated `affected != 1` as `ErrVersionConflict`:

```go
if affected != 1 {
    // 锁后行被并发删除等，逻辑上不可达。保守起见按 conflict 处理。
    return ErrVersionConflict
}
```

The comment was wrong: row existence is already guaranteed by the preceding `SELECT ... FOR UPDATE` plus `len(locked) == len(items)` check, so `affected ∈ {0, 1}`. `0` simply means "value unchanged", not "row missing" and not a conflict.

### Reproduction (on im-test)

```
PUT /v2/follow/sort  version=2  items=[botfather, fileHelper]  → 200 OK   (rows 0→1, 0→2, both changed)
follow_version advances 2 → 3
PUT /v2/follow/sort  version=3  items=[botfather, fileHelper]  → 400 version conflict
                                                                  (rows already at 1,2 → affected=0 → false positive)
```

### Fix

- `db.go`: change `affected != 1` to `affected > 1` and rewrite the misleading comment. `affected > 1` is unreachable (WHERE includes the logical primary key) but kept as a defensive guard for schema drift.

### Tests

Two new regression tests in `bugfix_test.go`:

- `TestDB_UpdateSort_UnchangedSortValues_NotConflict` — seed rows already at the target sort values, submit the same order, expect success.
- `TestDB_UpdateSort_FirstItemUnchanged_NotConflict` — covers the most common user-facing path: dragging the list while keeping the head in place.

Both fail on `main`, pass after the fix.

Also incidentally fixes a long-standing test-isolation bug: `newDBForTest` only cleared `user_conversation_ext` but not `user_follow_version`. Four existing `UpdateSort` tests (`TestDB_UpdateSort_Success`, `TestDB_UpdateSort_VersionConflict`, `TestDB_UpdateSort_AllAffectedItemsLocked`, `TestDB_UpdateSort_ConcurrentConflict`) fail when run individually because the residual `follow_version` from a previous test breaks their `expectedVersion=0` assumption. Adding the table to the fixture cleanup makes the whole `UpdateSort` suite green standalone and in aggregate.

## Test plan

- [x] `go test -tags=integration -run 'TestDB_UpdateSort' ./modules/conversation_ext` — all pass
- [x] `go test -tags=integration -race ./modules/conversation_ext` — all pass
- [x] `go build ./...` — clean
- [x] Manual reproduction on im-test environment — bug confirmed before fix, gone after fix
- [ ] Reviewer to sanity-check that no other call site depends on `RowsAffected==1` for "row exists" semantics in this transaction