### PR TITLE
refactor(api): rename /v2/sidebar and /v2/follow routes to /v1/*

### DIFF
--- a/modules/conversation_ext/1module.go
+++ b/modules/conversation_ext/1module.go
@@ -54,10 +54,10 @@ type followRouter struct {
 	f   *Follow
 }
 
-// Route registers all 7 Follow endpoints under /v2/follow with auth and space
+// Route registers all 7 Follow endpoints under /v1/follow with auth and space
 // middleware — mirrors the pattern in modules/user/api.go (pinned group).
 func (fr *followRouter) Route(r *wkhttp.WKHttp) {
-	grp := r.Group("/v2/follow",
+	grp := r.Group("/v1/follow",
 		fr.ctx.AuthMiddleware(r),
 		spacepkg.SpaceMiddleware(fr.ctx),
 	)

--- a/modules/conversation_ext/api.go
+++ b/modules/conversation_ext/api.go
@@ -112,7 +112,7 @@ func spaceGuard(c *wkhttp.Context) (spaceID string, ok bool) {
 // ---------------------------------------------------------------------------
 
 // FollowDM 关注 DM 并可选指定分组
-// POST /v2/follow/dm
+// POST /v1/follow/dm
 func (f *Follow) FollowDM(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	spaceID, ok := spaceGuard(c)
@@ -145,7 +145,7 @@ func (f *Follow) FollowDM(c *wkhttp.Context) {
 }
 
 // UnfollowDM 取消关注 DM
-// DELETE /v2/follow/dm?peer_uid=xxx
+// DELETE /v1/follow/dm?peer_uid=xxx
 func (f *Follow) UnfollowDM(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	spaceID, ok := spaceGuard(c)
@@ -168,7 +168,7 @@ func (f *Follow) UnfollowDM(c *wkhttp.Context) {
 }
 
 // UnfollowChannel 群"取消关注"（写黑名单）
-// POST /v2/follow/channel/unfollow
+// POST /v1/follow/channel/unfollow
 func (f *Follow) UnfollowChannel(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	spaceID, ok := spaceGuard(c)
@@ -195,7 +195,7 @@ func (f *Follow) UnfollowChannel(c *wkhttp.Context) {
 }
 
 // FollowChannel 重新关注群（清黑名单）
-// POST /v2/follow/channel/refollow
+// POST /v1/follow/channel/refollow
 func (f *Follow) FollowChannel(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	spaceID, ok := spaceGuard(c)
@@ -222,7 +222,7 @@ func (f *Follow) FollowChannel(c *wkhttp.Context) {
 }
 
 // FollowThread 关注子区（隐式连带父群）
-// POST /v2/follow/thread
+// POST /v1/follow/thread
 func (f *Follow) FollowThread(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	spaceID, ok := spaceGuard(c)
@@ -256,7 +256,7 @@ func (f *Follow) FollowThread(c *wkhttp.Context) {
 }
 
 // UnfollowThread 取消关注子区
-// DELETE /v2/follow/thread?thread_channel_id=xxx
+// DELETE /v1/follow/thread?thread_channel_id=xxx
 func (f *Follow) UnfollowThread(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	spaceID, ok := spaceGuard(c)
@@ -279,7 +279,7 @@ func (f *Follow) UnfollowThread(c *wkhttp.Context) {
 }
 
 // UpdateSort 关注 Tab 内手动排序 CAS
-// PUT /v2/follow/sort
+// PUT /v1/follow/sort
 func (f *Follow) UpdateSort(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	spaceID, ok := spaceGuard(c)

--- a/modules/conversation_ext/api_test.go
+++ b/modules/conversation_ext/api_test.go
@@ -114,7 +114,7 @@ func newTestRouter(svc followService, db sortDB) *wkhttp.WKHttp {
 		c.Next()
 	}
 
-	grp := r.Group("/v2/follow", inject)
+	grp := r.Group("/v1/follow", inject)
 	grp.POST("/dm", f.FollowDM)
 	grp.DELETE("/dm", f.UnfollowDM)
 	grp.POST("/channel/unfollow", f.UnfollowChannel)
@@ -167,7 +167,7 @@ func TestFollow_FollowDM_HappyPath(t *testing.T) {
 		},
 	}
 	r := newTestRouter(svc, &stubDB{})
-	w := do(r, "POST", "/v2/follow/dm", map[string]interface{}{"peer_uid": "peer1"})
+	w := do(r, "POST", "/v1/follow/dm", map[string]interface{}{"peer_uid": "peer1"})
 
 	assertOK(t, w)
 	assert.Equal(t, "test-uid", gotUID)
@@ -186,7 +186,7 @@ func TestFollow_FollowDM_WithCategoryID(t *testing.T) {
 	}
 	r := newTestRouter(svc, &stubDB{})
 	catID := "cat-uuid-abc"
-	w := do(r, "POST", "/v2/follow/dm", map[string]interface{}{
+	w := do(r, "POST", "/v1/follow/dm", map[string]interface{}{
 		"peer_uid":    "peer2",
 		"category_id": catID,
 	})
@@ -198,7 +198,7 @@ func TestFollow_FollowDM_WithCategoryID(t *testing.T) {
 
 func TestFollow_FollowDM_MissingPeerUID(t *testing.T) {
 	r := newTestRouter(&stubService{}, &stubDB{})
-	w := do(r, "POST", "/v2/follow/dm", map[string]interface{}{})
+	w := do(r, "POST", "/v1/follow/dm", map[string]interface{}{})
 	assertBadRequest(t, w)
 }
 
@@ -209,7 +209,7 @@ func TestFollow_FollowDM_ServiceError(t *testing.T) {
 		},
 	}
 	r := newTestRouter(svc, &stubDB{})
-	w := do(r, "POST", "/v2/follow/dm", map[string]interface{}{"peer_uid": "peer1"})
+	w := do(r, "POST", "/v1/follow/dm", map[string]interface{}{"peer_uid": "peer1"})
 	assertBadRequest(t, w)
 }
 
@@ -222,7 +222,7 @@ func TestFollow_FollowDM_CategoryForbidden(t *testing.T) {
 		},
 	}
 	r := newTestRouter(svc, &stubDB{})
-	w := do(r, "POST", "/v2/follow/dm", map[string]interface{}{
+	w := do(r, "POST", "/v1/follow/dm", map[string]interface{}{
 		"peer_uid":    "peer3",
 		"category_id": "not-mine-uuid",
 	})
@@ -243,7 +243,7 @@ func TestFollow_UnfollowDM_HappyPath(t *testing.T) {
 		},
 	}
 	r := newTestRouter(svc, &stubDB{})
-	w := do(r, "DELETE", "/v2/follow/dm?peer_uid=peerX", nil)
+	w := do(r, "DELETE", "/v1/follow/dm?peer_uid=peerX", nil)
 
 	assertOK(t, w)
 	assert.Equal(t, "peerX", gotPeerUID)
@@ -251,7 +251,7 @@ func TestFollow_UnfollowDM_HappyPath(t *testing.T) {
 
 func TestFollow_UnfollowDM_MissingPeerUID(t *testing.T) {
 	r := newTestRouter(&stubService{}, &stubDB{})
-	w := do(r, "DELETE", "/v2/follow/dm", nil)
+	w := do(r, "DELETE", "/v1/follow/dm", nil)
 	assertBadRequest(t, w)
 }
 
@@ -262,7 +262,7 @@ func TestFollow_UnfollowDM_ServiceError(t *testing.T) {
 		},
 	}
 	r := newTestRouter(svc, &stubDB{})
-	w := do(r, "DELETE", "/v2/follow/dm?peer_uid=p", nil)
+	w := do(r, "DELETE", "/v1/follow/dm?peer_uid=p", nil)
 	assertBadRequest(t, w)
 }
 
@@ -279,7 +279,7 @@ func TestFollow_UnfollowChannel_HappyPath(t *testing.T) {
 		},
 	}
 	r := newTestRouter(svc, &stubDB{})
-	w := do(r, "POST", "/v2/follow/channel/unfollow", map[string]interface{}{"group_no": "grp1"})
+	w := do(r, "POST", "/v1/follow/channel/unfollow", map[string]interface{}{"group_no": "grp1"})
 
 	assertOK(t, w)
 	assert.Equal(t, "grp1", gotGroupNo)
@@ -287,7 +287,7 @@ func TestFollow_UnfollowChannel_HappyPath(t *testing.T) {
 
 func TestFollow_UnfollowChannel_MissingGroupNo(t *testing.T) {
 	r := newTestRouter(&stubService{}, &stubDB{})
-	w := do(r, "POST", "/v2/follow/channel/unfollow", map[string]interface{}{})
+	w := do(r, "POST", "/v1/follow/channel/unfollow", map[string]interface{}{})
 	assertBadRequest(t, w)
 }
 
@@ -298,7 +298,7 @@ func TestFollow_UnfollowChannel_ServiceError(t *testing.T) {
 		},
 	}
 	r := newTestRouter(svc, &stubDB{})
-	w := do(r, "POST", "/v2/follow/channel/unfollow", map[string]interface{}{"group_no": "grp1"})
+	w := do(r, "POST", "/v1/follow/channel/unfollow", map[string]interface{}{"group_no": "grp1"})
 	assertBadRequest(t, w)
 }
 
@@ -315,7 +315,7 @@ func TestFollow_FollowChannel_HappyPath(t *testing.T) {
 		},
 	}
 	r := newTestRouter(svc, &stubDB{})
-	w := do(r, "POST", "/v2/follow/channel/refollow", map[string]interface{}{"group_no": "grp2"})
+	w := do(r, "POST", "/v1/follow/channel/refollow", map[string]interface{}{"group_no": "grp2"})
 
 	assertOK(t, w)
 	assert.Equal(t, "grp2", gotGroupNo)
@@ -323,7 +323,7 @@ func TestFollow_FollowChannel_HappyPath(t *testing.T) {
 
 func TestFollow_FollowChannel_MissingGroupNo(t *testing.T) {
 	r := newTestRouter(&stubService{}, &stubDB{})
-	w := do(r, "POST", "/v2/follow/channel/refollow", map[string]interface{}{})
+	w := do(r, "POST", "/v1/follow/channel/refollow", map[string]interface{}{})
 	assertBadRequest(t, w)
 }
 
@@ -334,7 +334,7 @@ func TestFollow_FollowChannel_ServiceError(t *testing.T) {
 		},
 	}
 	r := newTestRouter(svc, &stubDB{})
-	w := do(r, "POST", "/v2/follow/channel/refollow", map[string]interface{}{"group_no": "grp2"})
+	w := do(r, "POST", "/v1/follow/channel/refollow", map[string]interface{}{"group_no": "grp2"})
 	assertBadRequest(t, w)
 }
 
@@ -351,7 +351,7 @@ func TestFollow_FollowThread_HappyPath(t *testing.T) {
 		},
 	}
 	r := newTestRouter(svc, &stubDB{})
-	w := do(r, "POST", "/v2/follow/thread", map[string]interface{}{"thread_channel_id": "grp1____thr1"})
+	w := do(r, "POST", "/v1/follow/thread", map[string]interface{}{"thread_channel_id": "grp1____thr1"})
 
 	assertOK(t, w)
 	assert.Equal(t, "grp1____thr1", gotThreadID)
@@ -359,7 +359,7 @@ func TestFollow_FollowThread_HappyPath(t *testing.T) {
 
 func TestFollow_FollowThread_MissingThreadChannelID(t *testing.T) {
 	r := newTestRouter(&stubService{}, &stubDB{})
-	w := do(r, "POST", "/v2/follow/thread", map[string]interface{}{})
+	w := do(r, "POST", "/v1/follow/thread", map[string]interface{}{})
 	assertBadRequest(t, w)
 }
 
@@ -370,7 +370,7 @@ func TestFollow_FollowThread_ServiceError(t *testing.T) {
 		},
 	}
 	r := newTestRouter(svc, &stubDB{})
-	w := do(r, "POST", "/v2/follow/thread", map[string]interface{}{"thread_channel_id": "grp1____thr1"})
+	w := do(r, "POST", "/v1/follow/thread", map[string]interface{}{"thread_channel_id": "grp1____thr1"})
 	assertBadRequest(t, w)
 }
 
@@ -421,7 +421,7 @@ func TestFollow_FollowThread_Forbidden_Returns403(t *testing.T) {
 		},
 	}
 	r := newTestRouter(svc, &stubDB{})
-	w := do(r, "POST", "/v2/follow/thread", map[string]interface{}{"thread_channel_id": "grp1____thr1"})
+	w := do(r, "POST", "/v1/follow/thread", map[string]interface{}{"thread_channel_id": "grp1____thr1"})
 	assert.Equal(t, http.StatusForbidden, w.Code, "body: %s", w.Body.String())
 }
 
@@ -438,7 +438,7 @@ func TestFollow_UnfollowThread_HappyPath(t *testing.T) {
 		},
 	}
 	r := newTestRouter(svc, &stubDB{})
-	w := do(r, "DELETE", "/v2/follow/thread?thread_channel_id=grp1____thr2", nil)
+	w := do(r, "DELETE", "/v1/follow/thread?thread_channel_id=grp1____thr2", nil)
 
 	assertOK(t, w)
 	assert.Equal(t, "grp1____thr2", gotThreadID)
@@ -446,7 +446,7 @@ func TestFollow_UnfollowThread_HappyPath(t *testing.T) {
 
 func TestFollow_UnfollowThread_MissingThreadChannelID(t *testing.T) {
 	r := newTestRouter(&stubService{}, &stubDB{})
-	w := do(r, "DELETE", "/v2/follow/thread", nil)
+	w := do(r, "DELETE", "/v1/follow/thread", nil)
 	assertBadRequest(t, w)
 }
 
@@ -457,7 +457,7 @@ func TestFollow_UnfollowThread_ServiceError(t *testing.T) {
 		},
 	}
 	r := newTestRouter(svc, &stubDB{})
-	w := do(r, "DELETE", "/v2/follow/thread?thread_channel_id=grp1____thr2", nil)
+	w := do(r, "DELETE", "/v1/follow/thread?thread_channel_id=grp1____thr2", nil)
 	assertBadRequest(t, w)
 }
 
@@ -476,7 +476,7 @@ func TestFollow_UpdateSort_HappyPath(t *testing.T) {
 		},
 	}
 	r := newTestRouter(&stubService{}, db)
-	w := do(r, "PUT", "/v2/follow/sort", map[string]interface{}{
+	w := do(r, "PUT", "/v1/follow/sort", map[string]interface{}{
 		"items": []map[string]interface{}{
 			{"target_type": 1, "target_id": "dm-1", "sort": 1},
 			{"target_type": 2, "target_id": "grp-1", "sort": 2},
@@ -493,7 +493,7 @@ func TestFollow_UpdateSort_HappyPath(t *testing.T) {
 
 func TestFollow_UpdateSort_MissingItems(t *testing.T) {
 	r := newTestRouter(&stubService{}, &stubDB{})
-	w := do(r, "PUT", "/v2/follow/sort", map[string]interface{}{
+	w := do(r, "PUT", "/v1/follow/sort", map[string]interface{}{
 		"items":   []interface{}{},
 		"version": 0,
 	})
@@ -502,7 +502,7 @@ func TestFollow_UpdateSort_MissingItems(t *testing.T) {
 
 func TestFollow_UpdateSort_InvalidTargetType(t *testing.T) {
 	r := newTestRouter(&stubService{}, &stubDB{})
-	w := do(r, "PUT", "/v2/follow/sort", map[string]interface{}{
+	w := do(r, "PUT", "/v1/follow/sort", map[string]interface{}{
 		"items": []map[string]interface{}{
 			{"target_type": 99, "target_id": "x", "sort": 1},
 		},
@@ -518,7 +518,7 @@ func TestFollow_UpdateSort_CASConflict(t *testing.T) {
 		},
 	}
 	r := newTestRouter(&stubService{}, db)
-	w := do(r, "PUT", "/v2/follow/sort", map[string]interface{}{
+	w := do(r, "PUT", "/v1/follow/sort", map[string]interface{}{
 		"items": []map[string]interface{}{
 			{"target_type": 1, "target_id": "dm-1", "sort": 1},
 		},
@@ -535,7 +535,7 @@ func TestFollow_UpdateSort_DBError(t *testing.T) {
 		},
 	}
 	r := newTestRouter(&stubService{}, db)
-	w := do(r, "PUT", "/v2/follow/sort", map[string]interface{}{
+	w := do(r, "PUT", "/v1/follow/sort", map[string]interface{}{
 		"items": []map[string]interface{}{
 			{"target_type": 1, "target_id": "dm-1", "sort": 1},
 		},
@@ -562,7 +562,7 @@ func TestFollow_UpdateSort_TooManyItems_Rejected(t *testing.T) {
 			"sort":        i,
 		})
 	}
-	w := do(r, "PUT", "/v2/follow/sort", map[string]interface{}{
+	w := do(r, "PUT", "/v1/follow/sort", map[string]interface{}{
 		"items":   items,
 		"version": 0,
 	})
@@ -577,7 +577,7 @@ func TestFollow_UpdateSort_EmptyTargetID_Rejected(t *testing.T) {
 			return nil
 		},
 	})
-	w := do(r, "PUT", "/v2/follow/sort", map[string]interface{}{
+	w := do(r, "PUT", "/v1/follow/sort", map[string]interface{}{
 		"items": []map[string]interface{}{
 			{"target_type": 1, "target_id": "", "sort": 1},
 		},
@@ -594,7 +594,7 @@ func TestFollow_UpdateSort_DuplicateItems_Rejected(t *testing.T) {
 			return nil
 		},
 	})
-	w := do(r, "PUT", "/v2/follow/sort", map[string]interface{}{
+	w := do(r, "PUT", "/v1/follow/sort", map[string]interface{}{
 		"items": []map[string]interface{}{
 			{"target_type": 1, "target_id": "dm-1", "sort": 1},
 			{"target_type": 1, "target_id": "dm-1", "sort": 2},
@@ -614,7 +614,7 @@ func TestFollow_UpdateSort_TargetNotFound_DistinctError(t *testing.T) {
 		},
 	}
 	r := newTestRouter(&stubService{}, db)
-	w := do(r, "PUT", "/v2/follow/sort", map[string]interface{}{
+	w := do(r, "PUT", "/v1/follow/sort", map[string]interface{}{
 		"items": []map[string]interface{}{
 			{"target_type": 1, "target_id": "dm-1", "sort": 1},
 		},
@@ -641,7 +641,7 @@ func newTestRouterNoSpace(svc followService, db sortDB) *wkhttp.WKHttp {
 		c.Next()
 	}
 
-	grp := r.Group("/v2/follow", inject)
+	grp := r.Group("/v1/follow", inject)
 	grp.POST("/dm", f.FollowDM)
 	grp.DELETE("/dm", f.UnfollowDM)
 	grp.POST("/channel/unfollow", f.UnfollowChannel)
@@ -655,45 +655,45 @@ func newTestRouterNoSpace(svc followService, db sortDB) *wkhttp.WKHttp {
 
 func TestFollow_FollowDM_MissingSpaceID(t *testing.T) {
 	r := newTestRouterNoSpace(&stubService{}, &stubDB{})
-	w := do(r, "POST", "/v2/follow/dm", map[string]interface{}{"peer_uid": "peer1"})
+	w := do(r, "POST", "/v1/follow/dm", map[string]interface{}{"peer_uid": "peer1"})
 	assertBadRequest(t, w)
 	assert.Contains(t, w.Body.String(), "space_id")
 }
 
 func TestFollow_UnfollowDM_MissingSpaceID(t *testing.T) {
 	r := newTestRouterNoSpace(&stubService{}, &stubDB{})
-	w := do(r, "DELETE", "/v2/follow/dm?peer_uid=p", nil)
+	w := do(r, "DELETE", "/v1/follow/dm?peer_uid=p", nil)
 	assertBadRequest(t, w)
 	assert.Contains(t, w.Body.String(), "space_id")
 }
 
 func TestFollow_UnfollowChannel_MissingSpaceID(t *testing.T) {
 	r := newTestRouterNoSpace(&stubService{}, &stubDB{})
-	w := do(r, "POST", "/v2/follow/channel/unfollow", map[string]interface{}{"group_no": "g"})
+	w := do(r, "POST", "/v1/follow/channel/unfollow", map[string]interface{}{"group_no": "g"})
 	assertBadRequest(t, w)
 }
 
 func TestFollow_FollowChannel_MissingSpaceID(t *testing.T) {
 	r := newTestRouterNoSpace(&stubService{}, &stubDB{})
-	w := do(r, "POST", "/v2/follow/channel/refollow", map[string]interface{}{"group_no": "g"})
+	w := do(r, "POST", "/v1/follow/channel/refollow", map[string]interface{}{"group_no": "g"})
 	assertBadRequest(t, w)
 }
 
 func TestFollow_FollowThread_MissingSpaceID(t *testing.T) {
 	r := newTestRouterNoSpace(&stubService{}, &stubDB{})
-	w := do(r, "POST", "/v2/follow/thread", map[string]interface{}{"thread_channel_id": "g____t"})
+	w := do(r, "POST", "/v1/follow/thread", map[string]interface{}{"thread_channel_id": "g____t"})
 	assertBadRequest(t, w)
 }
 
 func TestFollow_UnfollowThread_MissingSpaceID(t *testing.T) {
 	r := newTestRouterNoSpace(&stubService{}, &stubDB{})
-	w := do(r, "DELETE", "/v2/follow/thread?thread_channel_id=g____t", nil)
+	w := do(r, "DELETE", "/v1/follow/thread?thread_channel_id=g____t", nil)
 	assertBadRequest(t, w)
 }
 
 func TestFollow_UpdateSort_MissingSpaceID(t *testing.T) {
 	r := newTestRouterNoSpace(&stubService{}, &stubDB{})
-	w := do(r, "PUT", "/v2/follow/sort", map[string]interface{}{
+	w := do(r, "PUT", "/v1/follow/sort", map[string]interface{}{
 		"items": []map[string]interface{}{
 			{"target_type": 1, "target_id": "dm-1", "sort": 1},
 		},

--- a/modules/conversation_ext/sql/20260513000002_user_follow_version.sql
+++ b/modules/conversation_ext/sql/20260513000002_user_follow_version.sql
@@ -3,7 +3,7 @@
 -- 用户关注列表版本号（issue #337, PR review Round-3 Blocking #1/#2）
 --
 -- 设计动机：
---   v2 sidebar 既要支持 follow 列表的 CAS 排序（/v2/follow/sort），
+--   v2 sidebar 既要支持 follow 列表的 CAS 排序（/v1/follow/sort），
 --   又要让客户端感知 follow/unfollow/category 变更后的列表刷新。
 --
 --   原方案把 IM 会话游标当作 follow_version 用，但 IM 游标只在收到消息时推进，

--- a/modules/conversation_ext/sql/20260513000002_user_follow_version.sql
+++ b/modules/conversation_ext/sql/20260513000002_user_follow_version.sql
@@ -3,7 +3,7 @@
 -- 用户关注列表版本号（issue #337, PR review Round-3 Blocking #1/#2）
 --
 -- 设计动机：
---   v2 sidebar 既要支持 follow 列表的 CAS 排序（/v1/follow/sort），
+--   sidebar 聚合既要支持 follow 列表的 CAS 排序（/v1/follow/sort），
 --   又要让客户端感知 follow/unfollow/category 变更后的列表刷新。
 --
 --   原方案把 IM 会话游标当作 follow_version 用，但 IM 游标只在收到消息时推进，

--- a/modules/conversation_ext/swagger/api.yaml
+++ b/modules/conversation_ext/swagger/api.yaml
@@ -9,7 +9,7 @@ tags:
     description: "关注 Tab 相关操作（DM 关注、群黑名单、子区关注、手动排序）"
 schemes:
   - "https"
-basePath: "/v2"
+basePath: "/v1"
 
 paths:
   /follow/dm:

--- a/modules/message/1module.go
+++ b/modules/message/1module.go
@@ -21,8 +21,8 @@ var swaggerContent string
 //go:embed swagger/conversation.yaml
 var conversationSwagger string
 
-//go:embed swagger/conversation_v2.yaml
-var conversationV2Swagger string
+//go:embed swagger/sidebar.yaml
+var sidebarSwagger string
 
 func init() {
 
@@ -76,12 +76,12 @@ func init() {
 		return register.Module{Name: "conversation_ext_thread_auth"}
 	})
 
-	// PR review (Round 3) Important #3 — register the v2 sidebar swagger file
-	// independently so its `basePath: /v2` is honoured (the legacy file uses /v1).
+	// Sidebar swagger lives in its own file so the sidebar/follow surface can
+	// evolve independently from the legacy /v1/conversation contract.
 	register.AddModule(func(ctx interface{}) register.Module {
 		return register.Module{
-			Name:    "conversation_v2",
-			Swagger: conversationV2Swagger,
+			Name:    "sidebar",
+			Swagger: sidebarSwagger,
 		}
 	})
 }

--- a/modules/message/api_conversation.go
+++ b/modules/message/api_conversation.go
@@ -122,7 +122,7 @@ func (co *Conversation) Route(r *wkhttp.WKHttp) {
 		co.handleConversationDeleteEvent(data, commit)
 	})
 
-	// v2 sidebar
+	// sidebar 聚合接口（/v1/sidebar/sync）
 	RegisterSidebarRoutes(r, co.ctx)
 }
 

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -1,4 +1,4 @@
-// Package message — POST /v2/sidebar/sync
+// Package message — POST /v1/sidebar/sync
 //
 // # Data-flow overview
 //
@@ -52,7 +52,7 @@ import (
 // Structs
 // ---------------------------------------------------------------------------
 
-// Sidebar handles POST /v2/sidebar/sync.
+// Sidebar handles POST /v1/sidebar/sync.
 type Sidebar struct {
 	ctx             *config.Context
 	groupCategoryDB *groupCategoryDB
@@ -81,7 +81,7 @@ func NewSidebar(ctx *config.Context) *Sidebar {
 	}
 }
 
-// sidebarSyncReq is the JSON body for POST /v2/sidebar/sync.
+// sidebarSyncReq is the JSON body for POST /v1/sidebar/sync.
 type sidebarSyncReq struct {
 	Tab         string `json:"tab"`     // "follow" | "recent"
 	Version     int64  `json:"version"` // IM core version cursor
@@ -113,14 +113,14 @@ type SidebarItem struct {
 	ParentChannelID   string `json:"parent_channel_id,omitempty"` // thread only
 }
 
-// sidebarSyncResp is the JSON response for POST /v2/sidebar/sync.
+// sidebarSyncResp is the JSON response for POST /v1/sidebar/sync.
 //
 // Version 是 IM 会话游标（recent tab 的 cursor）。
 // FollowVersion 是 user_follow_version 的当前值（follow tab 的 CAS / 增量检测）。
 // PR review (Round 3) Blocking #1/#2 — IM 游标无法感知 follow 状态变化，所以需要
 // 独立的 follow_version。客户端使用方式：
 //   - 拉取 follow tab 后保存 follow_version，下次比较是否需要全量重建。
-//   - 调 /v2/follow/sort 时把 follow_version 原样回传做 CAS。
+//   - 调 /v1/follow/sort 时把 follow_version 原样回传做 CAS。
 type sidebarSyncResp struct {
 	Items         []*SidebarItem `json:"items"`
 	Version       int64          `json:"version"`
@@ -131,13 +131,13 @@ type sidebarSyncResp struct {
 // Route registration helper (called from Conversation.Route or standalone)
 // ---------------------------------------------------------------------------
 
-// RegisterSidebarRoutes mounts /v2/sidebar/sync onto the router.
+// RegisterSidebarRoutes mounts /v1/sidebar/sync onto the router.
 func RegisterSidebarRoutes(r *wkhttp.WKHttp, ctx *config.Context) {
 	sb := NewSidebar(ctx)
 	uidLimit := appwkhttp.SharedUIDRateLimiter(ctx)
-	v2 := r.Group("/v2/sidebar", ctx.AuthMiddleware(r), uidLimit, spacepkg.SpaceMiddleware(ctx))
+	grp := r.Group("/v1/sidebar", ctx.AuthMiddleware(r), uidLimit, spacepkg.SpaceMiddleware(ctx))
 	{
-		v2.POST("/sync", sb.Sync)
+		grp.POST("/sync", sb.Sync)
 	}
 }
 
@@ -188,7 +188,7 @@ func validateSidebarRequest(req *sidebarSyncReq) error {
 // HTTP handler
 // ---------------------------------------------------------------------------
 
-// Sync handles POST /v2/sidebar/sync.
+// Sync handles POST /v1/sidebar/sync.
 func (sb *Sidebar) Sync(c *wkhttp.Context) {
 	var req sidebarSyncReq
 	if err := c.BindJSON(&req); err != nil {

--- a/modules/message/swagger/conversation.yaml
+++ b/modules/message/swagger/conversation.yaml
@@ -297,7 +297,7 @@ paths:
             $ref: "#/definitions/response"
       security:
         - token: []
-  # NOTE: v2 sidebar 接口的 swagger 文档独立放在 conversation_v2.yaml
+  # NOTE: sidebar/follow 接口的 swagger 文档独立放在 sidebar.yaml
   # 因为本文件的 basePath 是 /v1。
 
 securityDefinitions:

--- a/modules/message/swagger/sidebar.yaml
+++ b/modules/message/swagger/sidebar.yaml
@@ -1,22 +1,22 @@
 swagger: "2.0"
 info:
-  description: "DMWork API v2 - Sidebar 聚合接口"
-  version: "2.0.0"
-  title: "DMWork API v2"
+  description: "DMWork API - Sidebar 聚合接口"
+  version: "1.0.0"
+  title: "DMWork API - Sidebar"
 host: "api.botgate.cn"
 tags:
   - name: "sidebar"
-    description: "v2 Sidebar 聚合（关注 / 最近 Tab，issue #337）"
+    description: "Sidebar 聚合（关注 / 最近 Tab，issue #337）"
 schemes:
   - "https"
-basePath: "/v2"
+basePath: "/v1"
 
 paths:
   /sidebar/sync:
     post:
       tags:
         - "sidebar"
-      summary: "v2 Sidebar 聚合同步（按 Tab）"
+      summary: "Sidebar 聚合同步（按 Tab）"
       description: |
         Web 端 Sidebar 聚合接口。根据 tab 参数返回不同维度的会话条目列表。
 
@@ -32,7 +32,7 @@ paths:
         - 群 / 子区：仅保留 `timestamp > NOW - 72h`
         - DM：全保留（不受时间窗口限制）
         - 排序：`pinned DESC` → `timestamp DESC`
-      operationId: "v2SidebarSync"
+      operationId: "sidebarSync"
       consumes:
         - "application/json"
       produces:
@@ -82,7 +82,7 @@ paths:
               follow_version:
                 type: integer
                 format: int64
-                description: "user_follow_version 的当前值（follow tab 的 CAS / 增量检测）。调用 /v2/follow/sort 时原样传回。"
+                description: "user_follow_version 的当前值（follow tab 的 CAS / 增量检测）。调用 /v1/follow/sort 时原样传回。"
         400:
           description: "参数错误"
           schema:


### PR DESCRIPTION
Closes #39.

## Why

The sidebar + follow endpoints introduced in #21 were prefixed with \`v2\`, but they are net-new business capabilities — not an incompatible revision of any existing v1 contract. \`/v1/conversation/sync\` is still serving the legacy WeChat-style chronological list; nothing was replaced.

Using \`v2\` for new capabilities causes:

- **Client overhead** — HTTP wrappers key off the prefix for baseURL / interceptors / error-code mapping; a second prefix doubles maintenance for no protocol benefit.
- **Version-space pollution** — when these endpoints do eventually receive a real breaking change, we'd be forced into \`v3\`, devaluing the major-version signal.
- **Inconsistency** — every other route in the codebase stays on \`v1\`.

See #39 for the full rationale.

## What changed

### Route prefixes

| Before | After |
|---|---|
| \`POST /v2/sidebar/sync\` | \`POST /v1/sidebar/sync\` |
| \`POST /v2/follow/dm\` | \`POST /v1/follow/dm\` |
| \`DELETE /v2/follow/dm\` | \`DELETE /v1/follow/dm\` |
| \`POST /v2/follow/channel/unfollow\` | \`POST /v1/follow/channel/unfollow\` |
| \`POST /v2/follow/channel/refollow\` | \`POST /v1/follow/channel/refollow\` |
| \`POST /v2/follow/thread\` | \`POST /v1/follow/thread\` |
| \`DELETE /v2/follow/thread\` | \`DELETE /v1/follow/thread\` |
| \`PUT /v2/follow/sort\` | \`PUT /v1/follow/sort\` |

### Swagger / module registration

- \`modules/message/swagger/conversation_v2.yaml\` renamed to \`sidebar.yaml\`, \`basePath\` \`/v2\` → \`/v1\`, title / tag / operationId scrubbed of \`v2\`.
- \`modules/conversation_ext/swagger/api.yaml\` \`basePath\` \`/v2\` → \`/v1\` (this one was reported by go-reviewer — easy miss).
- Module registration \`Name: \"conversation_v2\"\` → \`Name: \"sidebar\"\`; embedded variable \`conversationV2Swagger\` → \`sidebarSwagger\`.

### Tests / migrations / comments

- All \`/v2/follow/...\` path literals in \`modules/conversation_ext/api_test.go\` updated in lockstep with the route group prefix.
- SQL migration comment in \`20260513000002_user_follow_version.sql\` and cross-refs in \`api.go\`, \`api_sidebar.go\`, \`conversation.yaml\` updated.

Pure rename — no handler logic was touched.

## Coordination

Since #21 just landed and clients have not shipped to production against the \`v2\` paths, this is a clean swap without a deprecation window. Frontend must update its base prefix in lockstep with this merge.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test -tags=integration ./modules/conversation_ext ./modules/message\` — pass (one pre-existing flake in conversation_ext integration tests unrelated to this change, retries pass)
- [x] grep \`v2/sidebar\`, \`v2/follow\`, \`conversation_v2\`, \`DMWork API v2\` — zero remaining production references
- [x] go-reviewer pass — only finding was the missed \`conversation_ext/swagger/api.yaml\` basePath, fixed in this PR
- [ ] Reviewer: smoke-test against im-test once deployed