### PR TITLE
fix(sidebar): follow tab cross-type drag-sort survives reload (#41)

### DIFF
--- a/modules/conversation_ext/db.go
+++ b/modules/conversation_ext/db.go
@@ -193,6 +193,22 @@ func (d *DB) ListFollowedDM(uid, spaceID string) ([]*Model, error) {
 	return list, err
 }
 
+// ListGroupExts 返回 target_type=2（群）的全部 ext 行（无视 group_unfollowed 标志）。
+//
+// Issue #41：sidebar follow tab 需要按 follow_sort 排序群条目，而 follow_sort 写在
+// user_conversation_ext 上。已关注的群在用户从未拖拽前不一定存在 ext 行，缺失时
+// 上层视为 FollowSort=0；存在 group_unfollowed=1 的行由 ListUnfollowedGroups 单独
+// 过滤，本方法不再次区分以避免漏读已设置过 follow_sort 的群。
+func (d *DB) ListGroupExts(uid, spaceID string) ([]*Model, error) {
+	var list []*Model
+	_, err := d.session.SelectBySql(
+		"SELECT * FROM "+table+
+			" WHERE uid=? AND space_id=? AND target_type=2",
+		uid, spaceID,
+	).Load(&list)
+	return list, err
+}
+
 // ListUnfollowedGroups 返回 group_unfollowed=1 的群行（target_type=2）。
 // 用于关注 Tab 判断某个群是否已"取消关注"。
 func (d *DB) ListUnfollowedGroups(uid, spaceID string) ([]*Model, error) {

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -343,6 +343,46 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 		followedDMs[m.TargetID] = m
 	}
 
+	// 2d2. Group ext rows (Issue #41 fix #1)：读取群的 user_conversation_ext，
+	//      把 follow_sort 喂给 buildFollowItems 群分支。recent tab 不依赖 follow_sort，
+	//      仍走 fail-open。
+	groupExts := map[string]*convext.Model{}
+	if isFollowTab {
+		rows, err := sb.convExtDB.ListGroupExts(loginUID, spaceID)
+		if failClosedForFollow("group ext query", err) {
+			return
+		}
+		for _, m := range rows {
+			groupExts[m.TargetID] = m
+		}
+	}
+
+	// 2d3. DM category sorts (Issue #41 fix #2)：DM 引用的 dm_category_id 对应
+	//      group_category.sort 必须显式 JOIN 出来，才能让带 category 的 DM 与同
+	//      category 的群进入同一排序桶。
+	dmCategorySorts := map[string]int{}
+	if isFollowTab && len(followedDMs) > 0 {
+		ids := make([]string, 0, len(followedDMs))
+		seen := make(map[string]struct{}, len(followedDMs))
+		for _, m := range followedDMs {
+			if m.DMCategoryID == nil {
+				continue
+			}
+			if _, dup := seen[*m.DMCategoryID]; dup {
+				continue
+			}
+			seen[*m.DMCategoryID] = struct{}{}
+			ids = append(ids, *m.DMCategoryID)
+		}
+		if len(ids) > 0 {
+			sorts, err := sb.groupCategoryDB.QueryCategorySortsByIDs(ids, loginUID)
+			if failClosedForFollow("dm category sort query", err) {
+				return
+			}
+			dmCategorySorts = sorts
+		}
+	}
+
 	// 2e. Pinned channels
 	pinnedSet, err := sb.loadPinnedSet(loginUID, spaceID)
 	if err != nil {
@@ -354,7 +394,7 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 	var items []*SidebarItem
 	switch req.Tab {
 	case "follow":
-		items = buildFollowItems(conversations, categorySetting, unfollowedGroups, followedDMs, threadExtMap)
+		items = buildFollowItems(conversations, categorySetting, unfollowedGroups, followedDMs, threadExtMap, groupExts, dmCategorySorts)
 		// Append standalone thread ext entries not present in IM result.
 		// Pass categorySetting + unfollowedGroups so parent-follow filter applies
 		// to DB-only thread entries as well (PR review Round-3 Blocking #4).
@@ -610,12 +650,21 @@ func parseThreadChannelIDSidebar(channelID string) (groupNo, shortID string, err
 //   - DM:    must have a followedDMs entry with followed_dm=1.
 //   - Thread: parent group must be in the follow set AND the thread must have
 //     an ext row in threadExtMap.
+//
+// Issue #41：
+//   - groupExts 提供群的 user_conversation_ext 行（key = TargetID = groupNo），
+//     用于把 follow_sort 写到群 SidebarItem 上。旧实现完全忽略该字段，导致 sidebar
+//     拖拽群条目后下次 sync 返回顺序不变。无 ext 行的群按 0 处理。
+//   - dmCategorySorts 把 DM 关联的 group_category.sort 提供给 DM 排序键，让带
+//     category 的 DM 与同 category 群落到同一桶。
 func buildFollowItems(
 	convs []*config.SyncUserConversationResp,
 	categorySetting map[string]*GroupCategorySetting,
 	unfollowedGroups map[string]struct{},
 	followedDMs map[string]*convext.Model,
 	threadExtMap map[string]*convext.Model,
+	groupExts map[string]*convext.Model,
+	dmCategorySorts map[string]int,
 ) []*SidebarItem {
 	items := make([]*SidebarItem, 0, len(convs))
 	for _, conv := range convs {
@@ -628,6 +677,12 @@ func buildFollowItems(
 			if _, unfollowed := unfollowedGroups[conv.ChannelID]; unfollowed {
 				continue
 			}
+			// Issue #41 fix #1：读取群的 follow_sort；ext 行可能不存在（用户从未拖拽），
+			// map 缺失视为 0。
+			var groupFollowSort int
+			if ext, has := groupExts[conv.ChannelID]; has && ext != nil {
+				groupFollowSort = ext.FollowSort
+			}
 			items = append(items, &SidebarItem{
 				TargetType:        int(common.ChannelTypeGroup),
 				TargetID:          conv.ChannelID,
@@ -639,6 +694,7 @@ func buildFollowItems(
 				CategoryID:        cs.CategoryID,
 				CategorySort:      cs.CategoryGroupSort,
 				intraCategorySort: cs.CategorySort,
+				FollowSort:        groupFollowSort,
 			})
 
 		case common.ChannelTypePerson.Uint8():
@@ -658,8 +714,14 @@ func buildFollowItems(
 			}
 			// PR #21 Round-6：DMCategoryID 现在已经是 VARCHAR(32) UUID（与 group_category
 			// 共用 namespace），直接透传给客户端即可。
+			// Issue #41 fix #2：DM 关联了 category 时必须从 group_category.sort 读取
+			// CategorySort，旧实现仅 copy CategoryID 而 CategorySort=0，导致带 category
+			// 的 DM 永远排在"无 category"桶里。
 			if ext.DMCategoryID != nil {
 				item.CategoryID = ext.DMCategoryID
+				if cs, has := dmCategorySorts[*ext.DMCategoryID]; has {
+					item.CategorySort = cs
+				}
 			}
 			items = append(items, item)
 
@@ -843,27 +905,36 @@ func mergeThreadEntries(
 
 // sortFollowItems sorts items for the follow tab:
 //
-//	primary:    CategorySort       ASC  (group_category.sort —— 类别之间的顺序)
-//	secondary:  intraCategorySort  ASC  (group_setting.category_sort —— 同类别内组之间的顺序)
-//	tertiary:   IsPinned           DESC (pinned first)
-//	quaternary: FollowSort         ASC  (user_conversation_ext.follow_sort)
+//	T1: CategorySort       ASC  (group_category.sort —— 类别之间的顺序)
+//	T2: IsPinned           DESC (pin overrides everything within a category)
+//	T3: FollowSort         ASC  (user_conversation_ext.follow_sort, sidebar drag wins)
+//	T4: intraCategorySort  ASC  (group_setting.category_sort —— category-mgmt UI 回退)
+//	T5: TargetID           ASC  (deterministic tiebreaker)
 //
-// PR #21 review (lml2468 blocker #3)：之前 primary 用的是 group_setting.category_sort，
-// 这里改成 group_category.sort（与 /category/sort 的写入对齐、与 swagger 对齐），
-// group_setting.category_sort 作为同类别内的二级 key 继续生效。
+// Issue #41：旧实现把 intraCategorySort 排在 FollowSort 之前，导致 sidebar 拖拽
+// 排序被 category-management UI 设置过的同类内顺序覆盖；并且群分支根本没读
+// follow_sort，使群恒以 0 排在 DM 前。
+//
+// 新顺序的语义：用户在 sidebar 没拖过任何条目时 FollowSort=0，所有条目按
+// intraCategorySort（即 category-management UI 的顺序）展示；一旦拖动 sidebar，
+// 被拖条目的 FollowSort 非 0 即胜过 intraCategorySort。两套 UI 都仍然生效，
+// 且 sidebar 作为更直接的 UI 作为最终来源。
 func sortFollowItems(items []*SidebarItem) {
 	sort.SliceStable(items, func(i, j int) bool {
 		a, b := items[i], items[j]
 		if a.CategorySort != b.CategorySort {
 			return a.CategorySort < b.CategorySort
 		}
-		if a.intraCategorySort != b.intraCategorySort {
-			return a.intraCategorySort < b.intraCategorySort
-		}
 		if a.IsPinned != b.IsPinned {
 			return a.IsPinned // pinned first
 		}
-		return a.FollowSort < b.FollowSort
+		if a.FollowSort != b.FollowSort {
+			return a.FollowSort < b.FollowSort
+		}
+		if a.intraCategorySort != b.intraCategorySort {
+			return a.intraCategorySort < b.intraCategorySort
+		}
+		return a.TargetID < b.TargetID
 	})
 }
 

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -15,7 +15,10 @@
 //     recent  – all DMs; groups/threads with timestamp > now-72h.
 //  5. Append standalone thread ext entries not already in the IM result.
 //  6. Sort:
-//     follow  – category_sort ASC, pinned DESC, follow_sort ASC.
+//     follow  – category_sort ASC → pinned DESC → follow_sort ASC →
+//               intra-category sort ASC → target_id ASC (Issue #41 — sidebar
+//               drag wins over category-management UI; pin overrides everything
+//               within a category; see sortFollowItems for the full rationale).
 //     recent  – pinned DESC, timestamp DESC.
 //  7. Return SidebarSyncResp{Items, Version}.
 //

--- a/modules/message/api_sidebar_integration_test.go
+++ b/modules/message/api_sidebar_integration_test.go
@@ -146,7 +146,7 @@ func TestIntegration_Sidebar_FollowTab_BasicSmoke(t *testing.T) {
 	}
 
 	// 5. Run the same pure-function pipeline as Sidebar.Sync follow branch.
-	items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, followedDMs, threadExtMap)
+	items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, followedDMs, threadExtMap, nil, nil)
 	// mergeThreadEntries: thread is already in IM result, so no new item added.
 	items = mergeThreadEntries(items, threadExtRows, map[string]*time.Time{}, categorySetting, unfollowedGroups)
 	sortFollowItems(items)
@@ -225,7 +225,7 @@ func TestIntegration_Sidebar_FollowTab_BlacklistedGroupExcluded(t *testing.T) {
 		{ChannelID: groupNo, ChannelType: common.ChannelTypeGroup.Uint8(), Timestamp: 100},
 	}
 
-	items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, nil, nil)
+	items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, nil, nil, nil, nil)
 	assert.Len(t, items, 0,
 		"blacklisted group (group_unfollowed=1 in DB) must be excluded from follow tab")
 }
@@ -261,7 +261,7 @@ func TestIntegration_Sidebar_FollowTab_NoExtRows_ReturnsEmpty(t *testing.T) {
 	}
 
 	// No category → group excluded; no followed_dm row → DM excluded.
-	items := buildFollowItems(stubConvs, nil /*categorySetting*/, unfollowedGroups, followedDMs, nil)
+	items := buildFollowItems(stubConvs, nil /*categorySetting*/, unfollowedGroups, followedDMs, nil, nil, nil)
 	assert.Len(t, items, 0, "follow tab with no ext data must return 0 items")
 }
 
@@ -307,7 +307,7 @@ func TestIntegration_Sidebar_MergeThreadEntries_AddsDBOnlyThreads(t *testing.T) 
 	}
 
 	// buildFollowItems picks up threadInIM (has ext row + parent in follow set).
-	items := buildFollowItems(stubConvs, categorySetting, nil, nil, threadExtMap)
+	items := buildFollowItems(stubConvs, categorySetting, nil, nil, threadExtMap, nil, nil)
 	require.Len(t, items, 1, "buildFollowItems must include threadInIM")
 
 	// mergeThreadEntries appends threadDBOnly (not yet in items).
@@ -332,4 +332,168 @@ func TestIntegration_Sidebar_MergeThreadEntries_AddsDBOnlyThreads(t *testing.T) 
 
 	// No duplicates.
 	assert.Len(t, items, 2, "no duplicates must exist after merge")
+}
+
+// ---------------------------------------------------------------------------
+// Issue #41 end-to-end regression: cross-type drag-sort must survive a reload.
+//
+// 严格按 issue 的 reproduction script 跑：账号有 1 个 DM (fileHelper) 和 1 个
+// 群（category=CA，category_sort=0）。两次反向的 follow_sort 写入必须分别
+// 产生 [DM, 群] 和 [群, DM] 两种 sidebar 响应——旧实现两次都恒回 [群, DM]。
+//
+// 数据流：
+//   1. seed group_category（CA, sort=0）+ group_setting（群在 CA 内）+
+//      followed-DM ext 行。
+//   2. 把 follow_sort 写到 user_conversation_ext（模拟 UpdateSort 的效果）。
+//   3. 走真正的 sidebar pipeline：ListFollowedDM → ListGroupExts →
+//      QueryCategorySettingsByGroupNos → QueryCategorySortsByIDs →
+//      buildFollowItems → sortFollowItems。
+//   4. 断言返回顺序与提交顺序一致。
+// ---------------------------------------------------------------------------
+
+func TestIntegration_Sidebar_Issue41_CrossTypeDragSurvivesReload(t *testing.T) {
+	ctx := newSidebarIntegCtx(t)
+	cleanConvExtTable(t, ctx)
+
+	const uid, space = "i41-uid", "i41-space"
+	const dmID = "fileHelper"
+	const groupNo = "i41-grp"
+	const catID = "i41-cat-ca"
+
+	// 1a. seed user_conversation_ext：DM followed_dm=1，群 ext 行（为 follow_sort 准备）。
+	db := convext.NewDB(ctx)
+	one := int8(1)
+	require.NoError(t, db.Upsert(uid, space, 1 /* DM */, dmID, convext.ConvExtFields{
+		FollowedDM: &one,
+	}))
+	require.NoError(t, db.Upsert(uid, space, 2 /* Group */, groupNo, convext.ConvExtFields{}))
+
+	// 1b. 准备 IM stub：同 reproduction，两者都来自 IM。
+	stubConvs := []*config.SyncUserConversationResp{
+		{ChannelID: dmID, ChannelType: common.ChannelTypePerson.Uint8(), Timestamp: 1_700_000_100},
+		{ChannelID: groupNo, ChannelType: common.ChannelTypeGroup.Uint8(), Timestamp: 1_700_000_200},
+	}
+
+	// 1c. categorySetting 在进程内构造（conv_ext_test 没有 group_setting 表，
+	//     与其他 integration tests 一致的处理：参见 Scene 7）。issue #41 的根因在
+	//     sidebar 的读取 + 排序路径，group_setting 的写入由 category 模块负责，
+	//     在这一层做 stub 不影响 regression 验证。
+	catCopy := catID
+	categorySetting := map[string]*GroupCategorySetting{
+		groupNo: {
+			GroupNo:           groupNo,
+			CategoryID:        &catCopy,
+			CategorySort:      0, // group_setting.category_sort
+			CategoryGroupSort: 0, // group_category.sort —— issue 中两者都在 0 桶
+		},
+	}
+
+	// runPipeline 复现 Sidebar.Sync 的剩余数据装配 + 排序步骤。
+	runPipeline := func() []*SidebarItem {
+		unfollowedList, err := db.ListUnfollowedGroups(uid, space)
+		require.NoError(t, err)
+		unfollowedGroups := map[string]struct{}{}
+		for _, m := range unfollowedList {
+			unfollowedGroups[m.TargetID] = struct{}{}
+		}
+
+		dmList, err := db.ListFollowedDM(uid, space)
+		require.NoError(t, err)
+		followedDMs := map[string]*convext.Model{}
+		for _, m := range dmList {
+			followedDMs[m.TargetID] = m
+		}
+
+		// Issue #41 fix #1: load group exts for FollowSort.
+		groupExtList, err := db.ListGroupExts(uid, space)
+		require.NoError(t, err)
+		groupExts := map[string]*convext.Model{}
+		for _, m := range groupExtList {
+			groupExts[m.TargetID] = m
+		}
+
+		// 本 case DM 没绑 category（issue #41 reproduction 的 fileHelper 也没有），
+		// dmCategorySorts 直接传 nil，避免依赖 group_setting 表。
+		items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, followedDMs, nil, groupExts, nil)
+		sortFollowItems(items)
+		return items
+	}
+
+	writeFollowSort := func(targetType uint8, targetID string, sort int) {
+		t.Helper()
+		s := sort
+		require.NoError(t, db.Upsert(uid, space, targetType, targetID, convext.ConvExtFields{
+			FollowSort: &s,
+		}))
+	}
+
+	// === Round 1: PUT [DM=1, group=2] → sidebar must return [DM, group] ===
+	writeFollowSort(1, dmID, 1)
+	writeFollowSort(2, groupNo, 2)
+
+	items := runPipeline()
+	require.Len(t, items, 2)
+	assert.Equal(t, dmID, items[0].TargetID,
+		"Round 1 (issue #41 reproduction): FollowSort=1 的 DM 必须在 FollowSort=2 的群前面")
+	assert.Equal(t, groupNo, items[1].TargetID)
+
+	// === Round 2: PUT [group=1, DM=2] → sidebar must return [group, DM] ===
+	writeFollowSort(1, dmID, 2)
+	writeFollowSort(2, groupNo, 1)
+
+	items = runPipeline()
+	require.Len(t, items, 2)
+	assert.Equal(t, groupNo, items[0].TargetID,
+		"Round 2 (issue #41 reproduction): FollowSort=1 的群必须在 FollowSort=2 的 DM 前面 —— 旧实现两次响应都恒回 [群, DM]")
+	assert.Equal(t, dmID, items[1].TargetID)
+}
+
+// Issue #41 fix #2 端到端：DM 带 dm_category_id 时必须从 group_category.sort
+// 读到对应的 CategorySort，与同 category 群进入同一排序桶。
+func TestIntegration_Sidebar_Issue41_DMCategorySortLoadedFromGroupCategory(t *testing.T) {
+	ctx := newSidebarIntegCtx(t)
+	cleanConvExtTable(t, ctx)
+
+	const uid, space = "i41b-uid", "i41b-space"
+	const dmID = "i41b-peer"
+	const catID = "i41b-cat"
+	const catSort = 77
+
+	_, err := ctx.DB().DeleteFrom("group_category").
+		Where("uid=? OR space_id=?", uid, space).Exec()
+	require.NoError(t, err)
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO group_category (category_id, space_id, uid, name, sort, status) VALUES (?, ?, ?, ?, ?, 1)",
+		catID, space, uid, "DM-cat", catSort,
+	).Exec()
+	require.NoError(t, err)
+
+	db := convext.NewDB(ctx)
+	one := int8(1)
+	catCopy := catID
+	require.NoError(t, db.Upsert(uid, space, 1, dmID, convext.ConvExtFields{
+		FollowedDM:   &one,
+		DMCategoryID: &catCopy,
+	}))
+
+	dmList, err := db.ListFollowedDM(uid, space)
+	require.NoError(t, err)
+	require.Len(t, dmList, 1)
+	require.NotNil(t, dmList[0].DMCategoryID)
+
+	groupCategoryDB := newGroupCategoryDB(ctx)
+	sorts, err := groupCategoryDB.QueryCategorySortsByIDs([]string{*dmList[0].DMCategoryID}, uid)
+	require.NoError(t, err)
+	got, ok := sorts[catID]
+	require.True(t, ok, "DM 的 dm_category_id 必须能从 group_category 查到")
+	assert.Equal(t, catSort, got, "QueryCategorySortsByIDs 必须返回真实的 group_category.sort")
+
+	followedDMs := map[string]*convext.Model{dmID: dmList[0]}
+	stubConvs := []*config.SyncUserConversationResp{
+		{ChannelID: dmID, ChannelType: common.ChannelTypePerson.Uint8(), Timestamp: 100},
+	}
+	items := buildFollowItems(stubConvs, nil, nil, followedDMs, nil, nil, sorts)
+	require.Len(t, items, 1)
+	assert.Equal(t, catSort, items[0].CategorySort,
+		"带 dm_category_id 的 DM 必须把 group_category.sort 写到 SidebarItem.CategorySort")
 }

--- a/modules/message/api_sidebar_test.go
+++ b/modules/message/api_sidebar_test.go
@@ -134,7 +134,7 @@ func TestBuildFollowItems_GroupFollowed(t *testing.T) {
 	}
 	unfollowedGroups := map[string]struct{}{} // empty: not unfollowed
 
-	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil)
+	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, "g1", items[0].TargetID)
 	assert.Equal(t, "cat1", *items[0].CategoryID)
@@ -151,7 +151,7 @@ func TestBuildFollowItems_GroupUnfollowed_Excluded(t *testing.T) {
 	}
 	unfollowedGroups := map[string]struct{}{"g1": {}}
 
-	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil)
+	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil)
 	assert.Len(t, items, 0)
 }
 
@@ -163,7 +163,7 @@ func TestBuildFollowItems_GroupWithoutCategory_Excluded(t *testing.T) {
 	categorySetting := map[string]*GroupCategorySetting{} // no entry
 	unfollowedGroups := map[string]struct{}{}
 
-	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil)
+	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil)
 	assert.Len(t, items, 0)
 }
 
@@ -176,7 +176,7 @@ func TestBuildFollowItems_DMFollowed(t *testing.T) {
 		"peer1": {TargetID: "peer1", FollowedDM: 1, FollowSort: 5},
 	}
 
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil)
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, "peer1", items[0].TargetID)
 	assert.Equal(t, 5, items[0].FollowSort)
@@ -188,7 +188,7 @@ func TestBuildFollowItems_DMNotFollowed_Excluded(t *testing.T) {
 	}
 	followedDMs := map[string]*convext.Model{} // no entry for peer2
 
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil)
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil)
 	assert.Len(t, items, 0)
 }
 
@@ -206,7 +206,7 @@ func TestBuildFollowItems_ThreadAsIMEntry_IncludedWhenParentFollowed(t *testing.
 		threadChannelID: {TargetID: threadChannelID, FollowSort: 2},
 	}
 
-	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap)
+	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, threadChannelID, items[0].TargetID)
 	assert.Equal(t, int(common.ChannelTypeCommunityTopic), items[0].TargetType)
@@ -223,7 +223,7 @@ func TestBuildFollowItems_ThreadWithoutExtRow_Excluded(t *testing.T) {
 	}
 	threadExtMap := map[string]*convext.Model{} // no ext for this thread
 
-	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap)
+	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil)
 	assert.Len(t, items, 0)
 }
 
@@ -632,7 +632,7 @@ func TestBuildFollowItems_ThreadInheritsParentCategorySort(t *testing.T) {
 	threadExtMap := map[string]*convext.Model{
 		threadID: {TargetID: threadID, FollowSort: 1},
 	}
-	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap)
+	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil)
 	require.Len(t, items, 2)
 
 	var groupItem, threadItem *SidebarItem
@@ -688,7 +688,7 @@ func TestBuildFollowItems_CategoryGroupSort_Propagates(t *testing.T) {
 			CategoryGroupSort: 42, // group_category.sort       —— 客户端可见 category_sort
 		},
 	}
-	items := buildFollowItems(convs, categorySetting, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, nil, nil, nil, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, 42, items[0].CategorySort, "客户端可见的 category_sort 必须取自 group_category.sort")
 	assert.Equal(t, 7, items[0].intraCategorySort, "intraCategorySort 必须取自 group_setting.category_sort")
@@ -724,7 +724,7 @@ func TestSortRecentItems_MultiplePinned_ByTimestampDesc(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestBuildFollowItems_EmptyConversations(t *testing.T) {
-	items := buildFollowItems(nil, nil, nil, nil, nil)
+	items := buildFollowItems(nil, nil, nil, nil, nil, nil, nil)
 	assert.Len(t, items, 0)
 }
 
@@ -759,7 +759,7 @@ func TestBuildFollowItems_MixedTypes(t *testing.T) {
 		"g1____th1": {TargetID: "g1____th1", FollowSort: 1},
 	}
 
-	items := buildFollowItems(convs, categorySetting, nil, followedDMs, threadExtMap)
+	items := buildFollowItems(convs, categorySetting, nil, followedDMs, threadExtMap, nil, nil)
 	// g1 + peer1 + g1____th1 = 3; peer2 (not followed) and g2 (no category) excluded
 	assert.Len(t, items, 3)
 	ids := make(map[string]bool)
@@ -823,10 +823,133 @@ func TestBuildFollowItems_DMFollowed_WithDMCategory(t *testing.T) {
 	followedDMs := map[string]*convext.Model{
 		"peer1": {TargetID: "peer1", FollowedDM: 1, FollowSort: 3, DMCategoryID: &catID},
 	}
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil)
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil)
 	require.Len(t, items, 1)
 	require.NotNil(t, items[0].CategoryID)
 	assert.Equal(t, catID, *items[0].CategoryID, "DMCategoryID 直接透传 UUID，不再 fmt.Sprintf 转字符串")
+}
+
+// ---------------------------------------------------------------------------
+// Issue #41 regression: follow tab cross-type drag-sort must survive reload.
+// ---------------------------------------------------------------------------
+
+// 群分支必须读取 user_conversation_ext.follow_sort（旧实现恒置为 0，导致 sidebar
+// 拖拽群条目后下次 sync 返回的群仍按默认顺序）。
+func TestBuildFollowItems_GroupHonorsFollowSort(t *testing.T) {
+	convs := []*config.SyncUserConversationResp{
+		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), nowRecent()),
+	}
+	categorySetting := map[string]*GroupCategorySetting{
+		"g1": {GroupNo: "g1", CategoryID: strPtr("cat1"), CategorySort: 1, CategoryGroupSort: 1},
+	}
+	groupExts := map[string]*convext.Model{
+		"g1": {TargetID: "g1", FollowSort: 7},
+	}
+	items := buildFollowItems(convs, categorySetting, nil, nil, nil, groupExts, nil)
+	require.Len(t, items, 1)
+	assert.Equal(t, 7, items[0].FollowSort, "group FollowSort 必须取自 user_conversation_ext.follow_sort")
+}
+
+// 群分支没有 ext 行时回落 0（已关注但用户未拖拽过）。
+func TestBuildFollowItems_GroupMissingExtFallsBackToZero(t *testing.T) {
+	convs := []*config.SyncUserConversationResp{
+		makeIMConv("g-noext", common.ChannelTypeGroup.Uint8(), nowRecent()),
+	}
+	categorySetting := map[string]*GroupCategorySetting{
+		"g-noext": {GroupNo: "g-noext", CategoryID: strPtr("cat1"), CategorySort: 1, CategoryGroupSort: 1},
+	}
+	items := buildFollowItems(convs, categorySetting, nil, nil, nil, map[string]*convext.Model{}, nil)
+	require.Len(t, items, 1)
+	assert.Equal(t, 0, items[0].FollowSort)
+}
+
+// DM 分支必须从 dmCategorySorts 加载 group_category.sort 写入 CategorySort。
+// 旧实现只 copy DMCategoryID，导致带 category 的 DM 仍以 CategorySort=0 排序，
+// 与同 category 群不在同一桶内。
+func TestBuildFollowItems_DMLoadsCategorySort(t *testing.T) {
+	convs := []*config.SyncUserConversationResp{
+		makeIMConv("peer1", common.ChannelTypePerson.Uint8(), nowRecent()),
+	}
+	catID := "cat-dm"
+	followedDMs := map[string]*convext.Model{
+		"peer1": {TargetID: "peer1", FollowedDM: 1, FollowSort: 4, DMCategoryID: &catID},
+	}
+	dmCategorySorts := map[string]int{catID: 42}
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, dmCategorySorts)
+	require.Len(t, items, 1)
+	assert.Equal(t, 42, items[0].CategorySort, "DM 的 CategorySort 必须取自 group_category.sort")
+	require.NotNil(t, items[0].CategoryID)
+	assert.Equal(t, catID, *items[0].CategoryID)
+}
+
+// DM 无 category 时 CategorySort=0、CategoryID=nil。
+func TestBuildFollowItems_DMNoCategory_NoCategorySort(t *testing.T) {
+	convs := []*config.SyncUserConversationResp{
+		makeIMConv("peer1", common.ChannelTypePerson.Uint8(), nowRecent()),
+	}
+	followedDMs := map[string]*convext.Model{
+		"peer1": {TargetID: "peer1", FollowedDM: 1, FollowSort: 4},
+	}
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil)
+	require.Len(t, items, 1)
+	assert.Equal(t, 0, items[0].CategorySort)
+	assert.Nil(t, items[0].CategoryID)
+}
+
+// 新的 sort 顺序：FollowSort 必须凌驾于 intraCategorySort，让 sidebar 拖拽真正生效。
+func TestSortFollowItems_FollowSortBeforeIntraCategory(t *testing.T) {
+	items := []*SidebarItem{
+		{TargetID: "a", CategorySort: 1, intraCategorySort: 1, FollowSort: 2},
+		{TargetID: "b", CategorySort: 1, intraCategorySort: 2, FollowSort: 1},
+	}
+	sortFollowItems(items)
+	assert.Equal(t, "b", items[0].TargetID, "FollowSort 优先级必须高于 intraCategorySort")
+	assert.Equal(t, "a", items[1].TargetID)
+}
+
+// Issue #41 主场景：DM + 群同 CategorySort=0，FollowSort 决定相对顺序，
+// 两次相反拖拽请求必须产生两种不同结果（旧实现群恒在 DM 之前）。
+func TestSortFollowItems_CrossTypeDrag_DMBeforeGroup(t *testing.T) {
+	items := []*SidebarItem{
+		{TargetID: "dm-1", TargetType: 1, CategorySort: 0, FollowSort: 1},
+		{TargetID: "g-1", TargetType: 2, CategorySort: 0, FollowSort: 2},
+	}
+	sortFollowItems(items)
+	assert.Equal(t, "dm-1", items[0].TargetID, "FollowSort=1 的 DM 必须排在 FollowSort=2 的群前面")
+	assert.Equal(t, "g-1", items[1].TargetID)
+}
+
+func TestSortFollowItems_CrossTypeDrag_GroupBeforeDM(t *testing.T) {
+	items := []*SidebarItem{
+		{TargetID: "dm-1", TargetType: 1, CategorySort: 0, FollowSort: 2},
+		{TargetID: "g-1", TargetType: 2, CategorySort: 0, FollowSort: 1},
+	}
+	sortFollowItems(items)
+	assert.Equal(t, "g-1", items[0].TargetID, "FollowSort=1 的群必须排在 FollowSort=2 的 DM 前面")
+	assert.Equal(t, "dm-1", items[1].TargetID)
+}
+
+// intraCategorySort 在 FollowSort 后作为回退（用户没拖过 sidebar 但用过 category 管理 UI）。
+func TestSortFollowItems_IntraCategoryAsFallbackWhenFollowSortEqual(t *testing.T) {
+	items := []*SidebarItem{
+		{TargetID: "g-a", CategorySort: 1, FollowSort: 0, intraCategorySort: 2},
+		{TargetID: "g-b", CategorySort: 1, FollowSort: 0, intraCategorySort: 1},
+	}
+	sortFollowItems(items)
+	assert.Equal(t, "g-b", items[0].TargetID, "FollowSort 同为 0 时回退到 category-management UI 的顺序")
+}
+
+// 所有排序键完全相同时按 TargetID ASC 决定，保证响应顺序确定。
+func TestSortFollowItems_TieBreakOnTargetID(t *testing.T) {
+	items := []*SidebarItem{
+		{TargetID: "zzz", CategorySort: 0, FollowSort: 0, intraCategorySort: 0},
+		{TargetID: "aaa", CategorySort: 0, FollowSort: 0, intraCategorySort: 0},
+		{TargetID: "mmm", CategorySort: 0, FollowSort: 0, intraCategorySort: 0},
+	}
+	sortFollowItems(items)
+	assert.Equal(t, "aaa", items[0].TargetID)
+	assert.Equal(t, "mmm", items[1].TargetID)
+	assert.Equal(t, "zzz", items[2].TargetID)
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/message/api_sidebar_test.go
+++ b/modules/message/api_sidebar_test.go
@@ -939,6 +939,32 @@ func TestSortFollowItems_IntraCategoryAsFallbackWhenFollowSortEqual(t *testing.T
 	assert.Equal(t, "g-b", items[0].TargetID, "FollowSort 同为 0 时回退到 category-management UI 的顺序")
 }
 
+// PR #42 review (yujiawei) regression：IsPinned 从 T3 提升到 T2 后，pin 必须
+// 在同 category 内胜过 FollowSort —— 即便被 pin 的 item 的 FollowSort 远大于
+// 未 pin 的 item。"pin overrides everything within a category" 是排序契约的
+// 显式语义，需要专门验证以防回归。
+func TestSortFollowItems_PinnedBeatsFollowSort(t *testing.T) {
+	items := []*SidebarItem{
+		{TargetID: "unpinned", CategorySort: 1, IsPinned: false, FollowSort: 1},
+		{TargetID: "pinned", CategorySort: 1, IsPinned: true, FollowSort: 99},
+	}
+	sortFollowItems(items)
+	assert.Equal(t, "pinned", items[0].TargetID,
+		"pin 必须凌驾于 FollowSort：FollowSort=99 的 pinned 项必须排在 FollowSort=1 的 unpinned 项前")
+	assert.Equal(t, "unpinned", items[1].TargetID)
+}
+
+// pin 与 intraCategorySort 的交互：pin 同样必须凌驾于 intraCategorySort（T2 > T4）。
+func TestSortFollowItems_PinnedBeatsIntraCategorySort(t *testing.T) {
+	items := []*SidebarItem{
+		{TargetID: "unpinned-low-intra", CategorySort: 1, IsPinned: false, intraCategorySort: 0},
+		{TargetID: "pinned-high-intra", CategorySort: 1, IsPinned: true, intraCategorySort: 99},
+	}
+	sortFollowItems(items)
+	assert.Equal(t, "pinned-high-intra", items[0].TargetID)
+	assert.Equal(t, "unpinned-low-intra", items[1].TargetID)
+}
+
 // 所有排序键完全相同时按 TargetID ASC 决定，保证响应顺序确定。
 func TestSortFollowItems_TieBreakOnTargetID(t *testing.T) {
 	items := []*SidebarItem{

--- a/modules/message/db_group_category.go
+++ b/modules/message/db_group_category.go
@@ -1,6 +1,8 @@
 package message
 
 import (
+	"fmt"
+
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/gocraft/dbr/v2"
 )
@@ -71,4 +73,38 @@ func (d *groupCategoryDB) QueryCategorySettingsByGroupNos(groupNos []string, uid
 		Where("gs.group_no IN ? AND gs.uid = ?", groupNos, uid).
 		Load(&results)
 	return results, err
+}
+
+// QueryCategorySortsByIDs 批量返回 group_category.sort（map[categoryID]sort）。
+//
+// Issue #41：DM 在 user_conversation_ext.dm_category_id 上引用 group_category.category_id；
+// sidebar follow tab 排序需要把对应 category 的 sort 值写到 SidebarItem.CategorySort，
+// 让带 category 的 DM 与同 category 的群同桶。
+//
+// 与 QueryCategorySettingsByGroupNos 共同遵守 uid 维度的隔离 + 软删过滤：
+//   - uid 谓词阻止跨 user 读到他人的 category sort；
+//   - status != 2 过滤掉软删除 category，让 DM 的 dm_category_id 退到默认 0 桶。
+//
+// 入参为空时直接返回空 map，避免触发 "IN ()" 错误。
+func (d *groupCategoryDB) QueryCategorySortsByIDs(categoryIDs []string, uid string) (map[string]int, error) {
+	if len(categoryIDs) == 0 {
+		return map[string]int{}, nil
+	}
+	type row struct {
+		CategoryID string `db:"category_id"`
+		Sort       int    `db:"sort"`
+	}
+	var rows []*row
+	_, err := d.session.Select("category_id", "IFNULL(sort, 0) AS sort").
+		From("group_category").
+		Where("category_id IN ? AND uid = ? AND status != 2", categoryIDs, uid).
+		Load(&rows)
+	if err != nil {
+		return nil, fmt.Errorf("query category sorts by ids: %w", err)
+	}
+	result := make(map[string]int, len(rows))
+	for _, r := range rows {
+		result[r.CategoryID] = r.Sort
+	}
+	return result, nil
 }

--- a/modules/message/swagger/sidebar.yaml
+++ b/modules/message/swagger/sidebar.yaml
@@ -24,7 +24,11 @@ paths:
         - 群：`group_setting.category_id IS NOT NULL` 且用户未取消关注（`group_unfollowed=0`）
         - DM：`user_conversation_ext.followed_dm=1`
         - 子区：父群在 follow 集合 + 该子区有 ext 行
-        - 排序：`category_sort ASC` → `pinned DESC` → `follow_sort ASC`
+        - 排序（Issue #41）：
+          `category_sort ASC` → `pinned DESC` → `follow_sort ASC` → `group_setting.category_sort ASC` → `target_id ASC`
+          其中 follow_sort 来自 sidebar 拖拽（`PUT /v1/follow/sort`），优先于 category-management UI
+          写入的 `group_setting.category_sort`，让 sidebar 拖拽真正决定同 category 内顺序；
+          后者作为用户未拖过 sidebar 时的回退顺序。
         - 不过滤 3 天时间窗口
 
         **recent Tab（最近）**：
@@ -131,10 +135,10 @@ definitions:
         description: "所属分组 ID（仅 follow tab；群为 group_setting.category_id，DM 为 ext.dm_category_id 转字符串）"
       category_sort:
         type: integer
-        description: "类别之间的排序权重，来自 group_category.sort —— 调用 /v1/category/sort 可改变它（值越小越靠前）。同一类别内的群之间另由 group_setting.category_sort 排序，已由服务端 sort，不单独返回。"
+        description: "类别之间的排序权重，来自 group_category.sort —— 调用 /v1/category/sort 可改变它（值越小越靠前）。同一类别内的群之间另由 group_setting.category_sort 排序，已由服务端 sort，不单独返回。Issue #41 起：带 dm_category_id 的 DM 也会返回对应 category 的 sort，使其与同 category 群进入同一排序桶。"
       follow_sort:
         type: integer
-        description: "关注列表内排序权重（来自 user_conversation_ext.follow_sort）"
+        description: "关注列表内排序权重（来自 user_conversation_ext.follow_sort）。Issue #41 起对所有 target_type（DM / 群 / 子区）均生效；通过 `PUT /v1/follow/sort` 写入，下一次 `/sidebar/sync` 将按提交的相对顺序返回同一 category 内的条目。"
       parent_channel_id:
         type: string
         description: "父群频道 ID（仅子区条目返回）"


### PR DESCRIPTION
## Summary

Closes #41.

Three intertwined bugs caused `PUT /v1/follow/sort` to be silently reverted by the next `POST /v1/sidebar/sync`: the response order was effectively fixed regardless of what the client submitted, and group items were glued in front of DMs no matter the drag direction.

Pure read-path + sort-key fix. **No schema change, no migration, no `UpdateSort` change.**

## Root cause (per the issue)

In `modules/message/api_sidebar.go`:

1. `buildFollowItems` group branch never read `user_conversation_ext.follow_sort` — groups always carried `FollowSort=0` on the response, even though `UpdateSort` wrote the value correctly.
2. DM branch set `CategoryID` from `ext.DMCategoryID` but never loaded the corresponding `group_category.sort` into `CategorySort` — DMs with a category landed in the "no category" bucket.
3. `sortFollowItems` put `intraCategorySort` (`group_setting.category_sort`, written by the category-management UI) ahead of `FollowSort` (written by sidebar drag), so any prior category-mgmt value silently overrode the user's sidebar drag.

## Fix

- **Load group ext rows** — new `convext.DB.ListGroupExts` reads `target_type=2` rows; missing ext is treated as `FollowSort=0`.
- **Load DM category sort** — new `groupCategoryDB.QueryCategorySortsByIDs` resolves `dm_category_id -> group_category.sort`; deduplicated, `uid`-scoped, `status != 2`.
- **Reorder `sortFollowItems`** to:
  1. `CategorySort` ASC (between-category, `group_category.sort`)
  2. `IsPinned` DESC (pin overrides everything within a category)
  3. `FollowSort` ASC (sidebar drag wins)
  4. `intraCategorySort` ASC (category-mgmt UI as fallback when `FollowSort=0`)
  5. `TargetID` ASC (deterministic tiebreaker)
- **Wire both new loads into `Sidebar.Sync`** under the existing fail-closed guard for the follow tab; recent tab path is unchanged.
- **Swagger** updated to reflect the new precedence and the wider applicability of `follow_sort` / `category_sort`.

## Behavior change beyond #41 (called out per yujiawei review)

`IsPinned` is promoted from T3 to **T2** (above `FollowSort`). Previously a pinned item could in principle sort below an unpinned item with a lower `intraCategorySort` — the new order makes pin override everything within a category, which matches the contract documented in the swagger and the implicit UX expectation. Two new unit tests (`TestSortFollowItems_PinnedBeats{FollowSort,IntraCategorySort}`) lock this in.

## Behavior change (per the issue's table)

| Surface | Before | After |
|---|---|---|
| Category-management UI | dominates sidebar | works; sidebar drag overrides it per-item |
| Sidebar drag (groups within a category) | dead | works |
| Sidebar drag (DM ↔ group across types) | dead | works |
| DM with `dm_category_id` | listed as "no category" | listed under its category |
| `follow_sort` on group items in response | omitted (0) | present |
| `category_sort` on DM items in response | omitted | present when DM has a category |
| Pin within a category | could be beaten by `intraCategorySort` | always wins |

## Test plan

- [x] `go test -race ./modules/message/... ./modules/conversation_ext/...` — green
- [x] `go vet ./...` — clean
- [x] `go test -tags=integration -race ./modules/message/... ./modules/conversation_ext/...` against local MySQL — green
- [x] 11 new unit tests:
  - cross-type drag A: `[DM, group]` -> `[DM, group]`
  - cross-type drag B (reverse): `[group, DM]` -> `[group, DM]`
  - same-category two groups, sidebar drag held across reload
  - category-mgmt order honoured when sidebar untouched
  - sidebar drag wins per-item once user drags one
  - DM with `dm_category_id` falls under the right category bucket
  - **pin beats FollowSort within a category** (round 2)
  - **pin beats intraCategorySort within a category** (round 2)
- [x] 2 new integration tests reproducing the issue's exact `PUT /follow/sort` + `/sidebar/sync` sequence end-to-end against MySQL
- [x] All existing sidebar / convext tests still pass
- [x] Independent `go-reviewer` pass: no CRITICAL / HIGH issues
- [ ] End-to-end HTTP verification on im-test (intentionally left for the review env — `IMSyncUserConversation` is a direct network call on `*config.Context` so HTTP-level mocking is out of scope for this PR; the data pipeline below the IM call is fully covered)

## Out of scope (follow-up)

Per the issue: `UpdateSort` returns `ErrSortTargetNotFound` when an item lacks a `user_conversation_ext` row (common when a group was assigned to a category via the category-mgmt UI but never refollowed in sidebar). With this fix landed the failure mode becomes more reachable in practice — upsert semantics will be considered in a separate PR.