### PR TITLE
fix(bot,robot): deterministic SpaceID for multi-Space User Bots (Fixes #36)

### DIFF
--- a/modules/bot_api/db.go
+++ b/modules/bot_api/db.go
@@ -131,18 +131,62 @@ func (d *botAPIDB) querySpaceIDsByRobotID(robotID string) (string, []string, err
 	return spaceIDs[0], spaceIDs, nil
 }
 
-// isBotSpaceMember reports whether `robotID` is currently an active member of
-// the given `spaceID` (both rows status=1). Used by `/v1/bot/sendMessage` to
-// validate an `X-Space-ID` header hint before honoring it (Option B from
-// issue#36) — without this check, the header would be a trivial bypass.
-func (d *botAPIDB) isBotSpaceMember(robotID, spaceID string) (bool, error) {
+// isBotSpaceAuthorized reports whether `robotID` is allowed to dispatch into
+// the given `spaceID`. Used by `/v1/bot/sendMessage` to validate an
+// `X-Space-ID` header hint before honoring it (Option B from issue#36).
+// Without this check, the header would be a trivial cross-Space bypass.
+//
+// Authorization is the OR of three production conditions — all gated on the
+// target Space being active (`space.status=1`):
+//
+//  1. **User Bot / manually-added bot membership** — the bot has an active
+//     `space_member` row for the target Space (status=1).
+//  2. **Platform App Bot** — the bot is a published `app_bot` row with
+//     `scope='platform'` (status=1). Platform App Bots are visible in every
+//     active Space (mirrors `pkg/space/query.go:CheckBotsInSpace`) and never
+//     get a `space_member` insert (see `modules/app_bot/db.go:insertAppBot`).
+//     Without this branch the validator rejects every legitimate platform App
+//     Bot dispatch and the caller's `enrichBotPayloadWithSpaceID` strips the
+//     payload.space_id, downgrading the request to PERSONAL DM (Mininglamp-OSS/
+//     octo-server PR#43 R1 critical from Jerry-Xin + lml2468).
+//  3. **Scope=space App Bot** — the bot is a published `app_bot` row with
+//     `scope='space'` AND its own `space_id` matches the requested SpaceID.
+//     This branch is mostly defensive; production traffic for scope=space App
+//     Bots reaches `resolveBotActiveSpaceID` via `CtxKeyAppBotSpaceID` (the
+//     ctx fast path) and never falls through to the header validator. The
+//     branch is included so a future refactor (or test regression) cannot
+//     turn the header path into a cross-Space bypass for scope=space bots.
+//
+// Implementation note: two short queries instead of one OR-joined statement.
+// Both run on indexed columns (`space_member(uid, space_id)`, `app_bot.uid`)
+// and the second is skipped when the first hits, so the common case is a
+// single round trip. A single combined query was rejected because OR-of-
+// EXISTS in MySQL with parameter reuse forces the planner to materialize
+// both branches even when the first short-circuits.
+func (d *botAPIDB) isBotSpaceAuthorized(robotID, spaceID string) (bool, error) {
 	if robotID == "" || spaceID == "" {
 		return false, nil
 	}
+	// (1) space_member path: active member row in the target active Space.
 	var count int
 	err := d.session.SelectBySql(
 		"SELECT COUNT(*) FROM space_member sm INNER JOIN space s ON s.space_id = sm.space_id WHERE sm.uid=? AND sm.space_id=? AND sm.status=1 AND s.status=1",
 		robotID, spaceID,
+	).LoadOne(&count)
+	if err != nil {
+		return false, err
+	}
+	if count > 0 {
+		return true, nil
+	}
+	// (2)+(3) app_bot path: published platform Bot in any active Space, OR
+	// scope=space Bot whose own SpaceID matches the requested target Space.
+	// Both branches require the target Space to be active.
+	err = d.session.SelectBySql(
+		"SELECT COUNT(*) FROM app_bot ab INNER JOIN space s ON s.space_id=? "+
+			"WHERE ab.uid=? AND ab.status=1 AND s.status=1 "+
+			"AND (ab.scope='platform' OR (ab.scope='space' AND ab.space_id=?))",
+		spaceID, robotID, spaceID,
 	).LoadOne(&count)
 	if err != nil {
 		return false, err

--- a/modules/bot_api/db.go
+++ b/modules/bot_api/db.go
@@ -93,13 +93,61 @@ func (d *botAPIDB) queryAllActiveRobots() ([]*robotModel, error) {
 }
 
 // querySpaceIDByRobotID returns the active Space ID for the given bot.
+//
+// Mininglamp-OSS/octo-server#36 (multi-Space ambiguity, PR#35 deep-review
+// High-2): when a User Bot is a member of multiple active Spaces, the prior
+// SQL had no `ORDER BY` and used `LoadOne`, leaving the result up to the DB
+// engine. This function now:
+//
+//  1. Loads all matching rows (not just one) so the count is observable.
+//  2. Orders by `sm.created_at ASC, sm.space_id ASC` so ties resolve to the
+//     earliest joined Space, with `space_id` as a deterministic tie-breaker.
+//  3. Returns `dbr.ErrNotFound` for the empty case to preserve the existing
+//     caller contract (callers branch on `errors.Is(err, dbr.ErrNotFound)`).
+//
+// The full row list is exposed via `querySpaceIDsByRobotID` for callers that
+// want to observe ambiguity (`len(spaceIDs) > 1`) without issuing a second
+// query — see `resolveBotActiveSpaceID` for the structured warn it emits.
 func (d *botAPIDB) querySpaceIDByRobotID(robotID string) (string, error) {
-	var spaceID string
-	err := d.session.SelectBySql(
-		"SELECT sm.space_id FROM space_member sm INNER JOIN space s ON s.space_id = sm.space_id WHERE sm.uid=? AND sm.status=1 AND s.status=1",
-		robotID,
-	).LoadOne(&spaceID)
+	spaceID, _, err := d.querySpaceIDsByRobotID(robotID)
 	return spaceID, err
+}
+
+// querySpaceIDsByRobotID is the multi-row variant. Returns the deterministic
+// primary SpaceID, the full ordered list of matching SpaceIDs, and any DB
+// error. Empty result → `dbr.ErrNotFound` (preserves caller contract).
+func (d *botAPIDB) querySpaceIDsByRobotID(robotID string) (string, []string, error) {
+	var spaceIDs []string
+	_, err := d.session.SelectBySql(
+		"SELECT sm.space_id FROM space_member sm INNER JOIN space s ON s.space_id = sm.space_id WHERE sm.uid=? AND sm.status=1 AND s.status=1 ORDER BY sm.created_at ASC, sm.space_id ASC",
+		robotID,
+	).Load(&spaceIDs)
+	if err != nil {
+		return "", nil, err
+	}
+	if len(spaceIDs) == 0 {
+		return "", nil, dbr.ErrNotFound
+	}
+	return spaceIDs[0], spaceIDs, nil
+}
+
+// isBotSpaceMember reports whether `robotID` is currently an active member of
+// the given `spaceID` (both rows status=1). Used by `/v1/bot/sendMessage` to
+// validate an `X-Space-ID` header hint before honoring it (Option B from
+// issue#36) — without this check, the header would be a trivial bypass.
+func (d *botAPIDB) isBotSpaceMember(robotID, spaceID string) (bool, error) {
+	if robotID == "" || spaceID == "" {
+		return false, nil
+	}
+	var count int
+	err := d.session.SelectBySql(
+		"SELECT COUNT(*) FROM space_member sm INNER JOIN space s ON s.space_id = sm.space_id WHERE sm.uid=? AND sm.space_id=? AND sm.status=1 AND s.status=1",
+		robotID, spaceID,
+	).LoadOne(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }
 
 // ==================== App Bot Model ====================

--- a/modules/bot_api/space_inject.go
+++ b/modules/bot_api/space_inject.go
@@ -1,4 +1,4 @@
-// Package bot_api · YUJ-644 / Mininglamp-OSS#33 / YUJ-660
+// Package bot_api · YUJ-644 / Mininglamp-OSS#33 / YUJ-660 / YUJ-688
 //
 // PERSONAL DM 派发前为 payload 注入 Bot 的权威 SpaceID。WuKongIM 在 DM 上仅按
 // 裸 uid 路由（无 Space 概念），收端客户端 SpaceFilter 唯一可信信号源是
@@ -26,10 +26,24 @@
 // 件（或孤儿 Bot 触发条件）伪造 payload.space_id="victim_space" 通过派发，realtime
 // + offline push 都会信任这个值。strip 是唯一 fail-closed 行为；message 层 R2
 // High-3 strip 只在 sendMsg 路径生效，bot_api / robot 路径需要本层独立 strip。
+//
+// **YUJ-688 / PR#43 R1 fix-up — platform App Bot validator gap (Critical from
+// Jerry-Xin + lml2468)**: the X-Space-ID validator previously checked only
+// `space_member`. Platform App Bots are inserted in `app_bot` with
+// `scope='platform'` and never get a `space_member` row, yet they are
+// legitimately visible in every active Space (`pkg/space/query.go:99`).
+// Result: every valid platform App Bot dispatch with a valid X-Space-ID
+// header was rejected by the validator and the caller's strip path downgraded
+// the payload, sending the message as a personal DM with no SpaceID. The fix
+// renames `isBotSpaceMember` to `isBotSpaceAuthorized` and broadens the SQL
+// to honor the production `app_bot` rows (platform OR scope=space-with-match).
+// Trim whitespace from the header value first to avoid noisy reject logs from
+// "  space_X  " / trailing CR.
 package bot_api
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/gocraft/dbr/v2"
@@ -44,13 +58,16 @@ import (
 //   - querySpaceIDsByRobotID returns the full ordered match list so the
 //     resolver can warn when a User Bot is in multiple Spaces (the ambiguity
 //     case Option C makes deterministic but doesn't *fix*).
-//   - isBotSpaceMember validates an X-Space-ID header hint before honoring it
-//     (Option B). Required because the legacy header path is not gated by
-//     SpaceMiddleware on /v1/bot/sendMessage.
+//   - isBotSpaceAuthorized validates an X-Space-ID header hint before honoring
+//     it (Option B). Required because the legacy header path is not gated by
+//     SpaceMiddleware on /v1/bot/sendMessage. Authorization is broader than
+//     space_member: it also recognizes platform App Bots (scope='platform'
+//     visible in every active Space) and scope=space App Bots dispatching
+//     into their own Space — see modules/bot_api/db.go for the full rule.
 type botSpaceQuerier interface {
 	querySpaceIDByRobotID(robotID string) (string, error)
 	querySpaceIDsByRobotID(robotID string) (string, []string, error)
-	isBotSpaceMember(robotID, spaceID string) (bool, error)
+	isBotSpaceAuthorized(robotID, spaceID string) (bool, error)
 }
 
 // enrichBotPayloadWithSpaceID 在 PERSONAL DM 派发前用 Bot 的权威 SpaceID 覆盖
@@ -90,7 +107,7 @@ func (ba *BotAPI) enrichBotPayloadWithSpaceID(c *wkhttp.Context, robotID string,
 }
 
 // resolveBotActiveSpaceID 优先读 gin-context（App Bot scope=space），其次接受
-// /v1/bot/sendMessage 上 X-Space-ID 头（前提是 Bot 是该 Space 的活跃成员），
+// /v1/bot/sendMessage 上 X-Space-ID 头（前提是 Bot 被授权在该 Space 派发），
 // fallback 到 querySpaceIDByRobotID。返回 "" 表示 Bot 没有活跃 SpaceID
 // （任何原因 — 孤儿 Bot、DB 错误、或 ErrNotFound）。调用方必须在 "" 返回时
 // 执行 strip 而非 passthrough。
@@ -100,10 +117,10 @@ func (ba *BotAPI) enrichBotPayloadWithSpaceID(c *wkhttp.Context, robotID string,
 //  1. App Bot scope=space → CtxKeyAppBotSpaceID（O(1)，由 authAppBot 写入）。
 //     这是最强的服务端权威信号，不接受任何 client override。
 //
-//  2. X-Space-ID 头（仅在 ctx 第一项缺失时才生效）→ 验证 Bot 是该 Space 的
-//     成员后采纳。User Bot 若已被加入 N 个 Space，client 可通过该头显式选择
-//     语义 Space；不命中（非成员 / 头空）则 fall through。验证通过 isBotSpaceMember
-//     —— 没有此校验，client 用任意头值就可绕过 Space 隔离。
+//  2. X-Space-ID 头（仅在 ctx 第一项缺失时才生效）→ 验证 Bot 在该 Space 被
+//     授权后采纳。授权语义见 isBotSpaceAuthorized：space_member 成员 OR
+//     published platform App Bot OR scope=space App Bot 派发到自身 Space。
+//     不命中（未授权 / 头空 / 头被空白填充）则 fall through。
 //
 //  3. querySpaceIDByRobotID（DB） → 取 deterministic 首行。多归属时 emit
 //     `multi_space_membership=true` warn 让运维定位需要走 Option B 的 Bot。
@@ -129,18 +146,24 @@ func (ba *BotAPI) resolveBotActiveSpaceID(c *wkhttp.Context, robotID string) str
 	// Option B 的精确实现：context-aware preference for Space-scoped routes
 	// without taking a hard dependency on SpaceMiddleware (which the /v1/bot
 	// route group does not currently mount).
+	//
+	// YUJ-688: trim whitespace from the header value before validation. Some
+	// clients send "  space_X  " or trailing CR; without TrimSpace these were
+	// rejected as non-member and emitted noisy reject warns.
 	if c != nil && c.Request != nil {
-		if hint := c.GetHeader("X-Space-ID"); hint != "" {
-			isMember, err := q.isBotSpaceMember(robotID, hint)
+		if hint := strings.TrimSpace(c.GetHeader("X-Space-ID")); hint != "" {
+			isAuthorized, err := q.isBotSpaceAuthorized(robotID, hint)
 			if err != nil {
-				ba.Warn("isBotSpaceMember 失败，回退到 deterministic DB 查询",
+				ba.Warn("isBotSpaceAuthorized 失败，回退到 deterministic DB 查询",
 					zap.String("robotID", robotID), zap.String("hint", hint), zap.Error(err))
-			} else if isMember {
+			} else if isAuthorized {
 				return hint
 			} else {
-				// Header sent but Bot isn't a member: log so operators can
-				// detect bots that need to be added (or attackers probing).
-				ba.Warn("x_space_id_header_rejected_not_member",
+				// Header sent but Bot isn't authorized for that Space: log so
+				// operators can detect bots that need to be added (or attackers
+				// probing). Authorization spans space_member + active platform
+				// App Bots + scope=space App Bots in their own active Space.
+				ba.Warn("x_space_id_header_rejected_not_authorized",
 					zap.Bool("x_space_id_header_rejected", true),
 					zap.String("dispatcher", "bot_api"),
 					zap.String("robotID", robotID),

--- a/modules/bot_api/space_inject.go
+++ b/modules/bot_api/space_inject.go
@@ -39,8 +39,18 @@ import (
 // botSpaceQuerier is the minimal data dependency of resolveBotActiveSpaceID,
 // extracted as an interface so unit tests can stub the DB call without
 // constructing a full *botAPIDB. *botAPIDB satisfies it implicitly.
+//
+// Mininglamp-OSS/octo-server#36 expansion:
+//   - querySpaceIDsByRobotID returns the full ordered match list so the
+//     resolver can warn when a User Bot is in multiple Spaces (the ambiguity
+//     case Option C makes deterministic but doesn't *fix*).
+//   - isBotSpaceMember validates an X-Space-ID header hint before honoring it
+//     (Option B). Required because the legacy header path is not gated by
+//     SpaceMiddleware on /v1/bot/sendMessage.
 type botSpaceQuerier interface {
 	querySpaceIDByRobotID(robotID string) (string, error)
+	querySpaceIDsByRobotID(robotID string) (string, []string, error)
+	isBotSpaceMember(robotID, spaceID string) (bool, error)
 }
 
 // enrichBotPayloadWithSpaceID 在 PERSONAL DM 派发前用 Bot 的权威 SpaceID 覆盖
@@ -79,14 +89,28 @@ func (ba *BotAPI) enrichBotPayloadWithSpaceID(c *wkhttp.Context, robotID string,
 	return payload
 }
 
-// resolveBotActiveSpaceID 优先读 gin-context（App Bot scope=space），fallback 到
-// querySpaceIDByRobotID。返回 "" 表示 Bot 没有活跃 SpaceID（任何原因 — 孤儿
-// Bot、DB 错误、或 ErrNotFound）。调用方必须在 "" 返回时执行 strip 而非
-// passthrough。
+// resolveBotActiveSpaceID 优先读 gin-context（App Bot scope=space），其次接受
+// /v1/bot/sendMessage 上 X-Space-ID 头（前提是 Bot 是该 Space 的活跃成员），
+// fallback 到 querySpaceIDByRobotID。返回 "" 表示 Bot 没有活跃 SpaceID
+// （任何原因 — 孤儿 Bot、DB 错误、或 ErrNotFound）。调用方必须在 "" 返回时
+// 执行 strip 而非 passthrough。
+//
+// 解析顺序（来自 Mininglamp-OSS/octo-server#36 推荐方案 B + C 混合）：
+//
+//  1. App Bot scope=space → CtxKeyAppBotSpaceID（O(1)，由 authAppBot 写入）。
+//     这是最强的服务端权威信号，不接受任何 client override。
+//
+//  2. X-Space-ID 头（仅在 ctx 第一项缺失时才生效）→ 验证 Bot 是该 Space 的
+//     成员后采纳。User Bot 若已被加入 N 个 Space，client 可通过该头显式选择
+//     语义 Space；不命中（非成员 / 头空）则 fall through。验证通过 isBotSpaceMember
+//     —— 没有此校验，client 用任意头值就可绕过 Space 隔离。
+//
+//  3. querySpaceIDByRobotID（DB） → 取 deterministic 首行。多归属时 emit
+//     `multi_space_membership=true` warn 让运维定位需要走 Option B 的 Bot。
 //
 // querier 默认是 ba.db；测试可通过 ba.spaceQuerier 注入 stub。
 func (ba *BotAPI) resolveBotActiveSpaceID(c *wkhttp.Context, robotID string) string {
-	// 优先：authAppBot 写入的 CtxKeyAppBotSpaceID（仅 App Bot scope=space）
+	// (1) authAppBot 写入的 CtxKeyAppBotSpaceID（仅 App Bot scope=space）
 	if scope, _ := c.Get(CtxKeyAppBotScope); scope == "space" {
 		if v, ok := c.Get(CtxKeyAppBotSpaceID); ok {
 			if s, _ := v.(string); s != "" {
@@ -94,14 +118,39 @@ func (ba *BotAPI) resolveBotActiveSpaceID(c *wkhttp.Context, robotID string) str
 			}
 		}
 	}
-	// Fallback：用户 Bot / 平台级 App Bot 查 space_member
 	q := ba.spaceQuerierOrDefault()
 	if q == nil {
 		// Defensive: tests sometimes construct &BotAPI{} with no db wired.
 		// Treat as "no active space" instead of nil-dereferencing.
 		return ""
 	}
-	spaceID, err := q.querySpaceIDByRobotID(robotID)
+	// (2) X-Space-ID 头 — 仅当 Bot 确实是该 Space 的活跃成员才采纳，否则
+	// fall through 到 deterministic DB query。这是 Mininglamp-OSS/octo-server#36
+	// Option B 的精确实现：context-aware preference for Space-scoped routes
+	// without taking a hard dependency on SpaceMiddleware (which the /v1/bot
+	// route group does not currently mount).
+	if c != nil && c.Request != nil {
+		if hint := c.GetHeader("X-Space-ID"); hint != "" {
+			isMember, err := q.isBotSpaceMember(robotID, hint)
+			if err != nil {
+				ba.Warn("isBotSpaceMember 失败，回退到 deterministic DB 查询",
+					zap.String("robotID", robotID), zap.String("hint", hint), zap.Error(err))
+			} else if isMember {
+				return hint
+			} else {
+				// Header sent but Bot isn't a member: log so operators can
+				// detect bots that need to be added (or attackers probing).
+				ba.Warn("x_space_id_header_rejected_not_member",
+					zap.Bool("x_space_id_header_rejected", true),
+					zap.String("dispatcher", "bot_api"),
+					zap.String("robotID", robotID),
+					zap.String("hint", hint),
+				)
+			}
+		}
+	}
+	// (3) Fallback：用户 Bot / 平台级 App Bot 查 space_member（deterministic）
+	primary, allSpaces, err := q.querySpaceIDsByRobotID(robotID)
 	if err != nil {
 		// YUJ-660 Medium-2: dbr.ErrNotFound is "Bot has no Space" — a valid
 		// state for orphan bots / non-Space deployments — NOT a DB error.
@@ -113,7 +162,21 @@ func (ba *BotAPI) resolveBotActiveSpaceID(c *wkhttp.Context, robotID string) str
 		}
 		return ""
 	}
-	return spaceID
+	if len(allSpaces) > 1 {
+		// Mininglamp-OSS/octo-server#36 — multi-Space User Bot. The result
+		// IS deterministic now (earliest joined wins) but the caller may
+		// have intended a different Space. Emit a structured warn so
+		// operators can route the affected Bot through the X-Space-ID
+		// header (Option B) or via authAppBot scope=space.
+		ba.Warn("multi_space_membership",
+			zap.Bool("multi_space_membership", true),
+			zap.String("dispatcher", "bot_api"),
+			zap.String("robotID", robotID),
+			zap.String("chosen_space_id", primary),
+			zap.Strings("all_space_ids", allSpaces),
+		)
+	}
+	return primary
 }
 
 // spaceQuerierOrDefault returns the test-injected stub when present, otherwise

--- a/modules/bot_api/space_inject_multispace_test.go
+++ b/modules/bot_api/space_inject_multispace_test.go
@@ -1,0 +1,173 @@
+// Package bot_api · Mininglamp-OSS/octo-server#36 (PR#35 deep-review High-2):
+// querySpaceIDByRobotID multi-Space ambiguity. Coverage:
+//
+//   - 2-Space User Bot dispatch with no header → deterministic primary
+//   - 2-Space User Bot with valid X-Space-ID header → header wins (Option B)
+//   - 2-Space User Bot with X-Space-ID header for non-member space → fall
+//     through to deterministic primary (Option B safe-bypass guard)
+//   - X-Space-ID header preferred over App Bot scope=platform DB result
+//   - X-Space-ID header IGNORED when App Bot scope=space already present
+//     (CtxKeyAppBotSpaceID is the strongest server-authoritative signal)
+package bot_api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Mininglamp-OSS/octo-server#36 — User Bot is a member of Space A and Space B.
+// Without any header, the deterministic ORDER BY (earliest joined wins) picks
+// Space A. This test asserts the result is *stable* — repeated calls return
+// the same value — and matches the chosen primary from the multi-row stub.
+func TestResolveBotActiveSpaceID_MultiSpace_NoHeader_DeterministicPrimary(t *testing.T) {
+	q := &fakeSpaceQuerier{
+		// `multiRows` for "user_bot_2_spaces" is the engine-stable order:
+		// Space A is the earliest-joined → first element.
+		multiRows: map[string][]string{
+			"user_bot_2_spaces": {"space_A", "space_B"},
+		},
+		defaultSpace: "space_A", // for querySpaceIDByRobotID single-row path
+	}
+	ba := newTestBotAPI(q)
+	c := fakeWkContext()
+
+	first := ba.resolveBotActiveSpaceID(c, "user_bot_2_spaces")
+	second := ba.resolveBotActiveSpaceID(c, "user_bot_2_spaces")
+
+	assert.Equal(t, "space_A", first,
+		"deterministic primary = earliest joined Space A")
+	assert.Equal(t, first, second,
+		"repeated calls must return the same SpaceID (no engine flapping)")
+}
+
+// Option B happy-path: 2-Space User Bot with X-Space-ID=space_B → bot is a
+// member → header wins.
+func TestResolveBotActiveSpaceID_MultiSpace_HeaderHit_HeaderWins(t *testing.T) {
+	q := &fakeSpaceQuerier{
+		multiRows: map[string][]string{
+			"user_bot_2_spaces": {"space_A", "space_B"},
+		},
+		defaultSpace: "space_A",
+		memberships: map[string]map[string]bool{
+			"user_bot_2_spaces": {"space_B": true},
+		},
+	}
+	ba := newTestBotAPI(q)
+	c := fakeWkContextWithHeader("X-Space-ID", "space_B")
+
+	got := ba.resolveBotActiveSpaceID(c, "user_bot_2_spaces")
+	assert.Equal(t, "space_B", got,
+		"X-Space-ID header should be honored when Bot is a member of that Space")
+	assert.Equal(t, []memberCall{{"user_bot_2_spaces", "space_B"}}, q.memberCalls,
+		"isBotSpaceMember must be called with the header value to validate it")
+	// DB fallback should NOT have been called when header wins.
+	assert.Empty(t, q.calls,
+		"querySpaceIDByRobotID must not be reached when the header is honored")
+}
+
+// Option B safe-bypass guard: if the client sends X-Space-ID for a space the
+// Bot is NOT a member of, fall through to the deterministic DB query — never
+// trust the header value standalone.
+func TestResolveBotActiveSpaceID_MultiSpace_HeaderMiss_FallsThrough(t *testing.T) {
+	q := &fakeSpaceQuerier{
+		multiRows: map[string][]string{
+			"user_bot_2_spaces": {"space_A", "space_B"},
+		},
+		defaultSpace: "space_A",
+		memberships: map[string]map[string]bool{
+			"user_bot_2_spaces": {"space_C": false}, // explicitly non-member
+		},
+	}
+	ba := newTestBotAPI(q)
+	c := fakeWkContextWithHeader("X-Space-ID", "space_C")
+
+	got := ba.resolveBotActiveSpaceID(c, "user_bot_2_spaces")
+	assert.Equal(t, "space_A", got,
+		"non-member header → fall through to deterministic primary (Space A)")
+	assert.Equal(t, []memberCall{{"user_bot_2_spaces", "space_C"}}, q.memberCalls,
+		"isBotSpaceMember must still be called once to make the non-member decision")
+	assert.Equal(t, []string{"user_bot_2_spaces"}, q.calls,
+		"querySpaceIDByRobotID must be invoked (via querySpaceIDsByRobotID) on miss")
+}
+
+// App Bot scope=space (CtxKeyAppBotSpaceID present) outranks the X-Space-ID
+// header. The header should NOT cause a Bot scope=space dispatch to leak into
+// a different Space — authAppBot already wrote the authoritative SpaceID.
+func TestResolveBotActiveSpaceID_AppBotScopeSpace_OutranksHeader(t *testing.T) {
+	q := &fakeSpaceQuerier{}
+	ba := newTestBotAPI(q)
+	c := fakeWkContextWithHeader("X-Space-ID", "space_attacker")
+	c.Set(CtxKeyAppBotScope, "space")
+	c.Set(CtxKeyAppBotSpaceID, "space_authoritative")
+
+	got := ba.resolveBotActiveSpaceID(c, "app_bot_scope_space")
+	assert.Equal(t, "space_authoritative", got,
+		"App Bot scope=space ctx must outrank X-Space-ID header")
+	assert.Empty(t, q.memberCalls,
+		"isBotSpaceMember must not be called when ctx already has the SpaceID")
+	assert.Empty(t, q.calls,
+		"querySpaceIDByRobotID must not be called when ctx already has the SpaceID")
+}
+
+// App Bot scope=platform (no CtxKeyAppBotSpaceID) — header is honored when the
+// platform Bot is a member of the requested Space. Platform Bots can dispatch
+// to multiple Spaces; the header makes the dispatch context explicit.
+func TestResolveBotActiveSpaceID_AppBotScopePlatform_HeaderHit(t *testing.T) {
+	q := &fakeSpaceQuerier{
+		defaultSpace: "space_A",
+		memberships: map[string]map[string]bool{
+			"app_bot_platform": {"space_B": true},
+		},
+	}
+	ba := newTestBotAPI(q)
+	c := fakeWkContextWithHeader("X-Space-ID", "space_B")
+	c.Set(CtxKeyAppBotScope, "platform") // not "space" → ctx fast-path skipped
+
+	got := ba.resolveBotActiveSpaceID(c, "app_bot_platform")
+	assert.Equal(t, "space_B", got)
+	assert.Empty(t, q.calls,
+		"DB fallback must not be reached when header is honored")
+}
+
+// Mininglamp-OSS/octo-server#36 enrich-end-to-end: 2-Space User Bot dispatching
+// PERSONAL DM. Without the header, payload.space_id should match the
+// deterministic primary (not whatever the client put in payload.space_id).
+func TestEnrichBotPayloadWithSpaceID_MultiSpace_NoHeader_DeterministicOverride(t *testing.T) {
+	q := &fakeSpaceQuerier{
+		multiRows: map[string][]string{
+			"user_bot_2_spaces": {"space_A", "space_B"},
+		},
+		defaultSpace: "space_A",
+	}
+	ba := newTestBotAPI(q)
+	c := fakeWkContext()
+	payload := map[string]interface{}{"content": "hi", "space_id": "space_attacker"}
+
+	got := ba.enrichBotPayloadWithSpaceID(c, "user_bot_2_spaces", payload)
+	assert.Equal(t, "space_A", got["space_id"],
+		"client-supplied forged space_id must be overridden by deterministic primary")
+}
+
+// Mininglamp-OSS/octo-server#36 enrich-end-to-end with header: 2-Space User
+// Bot dispatching PERSONAL DM with X-Space-ID=space_B → payload.space_id ends
+// up as space_B (not the deterministic primary, not the client-supplied
+// forged value).
+func TestEnrichBotPayloadWithSpaceID_MultiSpace_HeaderHit_HeaderOverridesPrimary(t *testing.T) {
+	q := &fakeSpaceQuerier{
+		multiRows: map[string][]string{
+			"user_bot_2_spaces": {"space_A", "space_B"},
+		},
+		defaultSpace: "space_A",
+		memberships: map[string]map[string]bool{
+			"user_bot_2_spaces": {"space_B": true},
+		},
+	}
+	ba := newTestBotAPI(q)
+	c := fakeWkContextWithHeader("X-Space-ID", "space_B")
+	payload := map[string]interface{}{"content": "hi", "space_id": "space_attacker"}
+
+	got := ba.enrichBotPayloadWithSpaceID(c, "user_bot_2_spaces", payload)
+	assert.Equal(t, "space_B", got["space_id"],
+		"valid X-Space-ID header must drive payload.space_id, overriding both client forge and DB primary")
+}

--- a/modules/bot_api/space_inject_multispace_test.go
+++ b/modules/bot_api/space_inject_multispace_test.go
@@ -8,11 +8,24 @@
 //   - X-Space-ID header preferred over App Bot scope=platform DB result
 //   - X-Space-ID header IGNORED when App Bot scope=space already present
 //     (CtxKeyAppBotSpaceID is the strongest server-authoritative signal)
+//
+// YUJ-688 / PR#43 R1 — additional coverage for the platform App Bot validator
+// gap (Critical from Jerry-Xin + lml2468). The previous validator only
+// checked space_member; platform App Bots have no space_member row but are
+// visible in every active Space. Coverage added below:
+//
+//   - Production-shaped platform App Bot: NO space_member row, only an
+//     app_bot row with scope='platform' status=1 → header is honored
+//   - Platform App Bot but target Space is inactive → header is rejected
+//   - Scope=space App Bot dispatching into its own Space (defensive path)
+//   - Scope=space App Bot rejected when header asks for a different Space
+//   - X-Space-ID header value with leading/trailing whitespace is trimmed
 package bot_api
 
 import (
 	"testing"
 
+	"github.com/gocraft/dbr/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -59,16 +72,16 @@ func TestResolveBotActiveSpaceID_MultiSpace_HeaderHit_HeaderWins(t *testing.T) {
 	got := ba.resolveBotActiveSpaceID(c, "user_bot_2_spaces")
 	assert.Equal(t, "space_B", got,
 		"X-Space-ID header should be honored when Bot is a member of that Space")
-	assert.Equal(t, []memberCall{{"user_bot_2_spaces", "space_B"}}, q.memberCalls,
-		"isBotSpaceMember must be called with the header value to validate it")
+	assert.Equal(t, []memberCall{{"user_bot_2_spaces", "space_B"}}, q.authCalls,
+		"isBotSpaceAuthorized must be called with the header value to validate it")
 	// DB fallback should NOT have been called when header wins.
 	assert.Empty(t, q.calls,
 		"querySpaceIDByRobotID must not be reached when the header is honored")
 }
 
 // Option B safe-bypass guard: if the client sends X-Space-ID for a space the
-// Bot is NOT a member of, fall through to the deterministic DB query — never
-// trust the header value standalone.
+// Bot is NOT authorized for, fall through to the deterministic DB query —
+// never trust the header value standalone.
 func TestResolveBotActiveSpaceID_MultiSpace_HeaderMiss_FallsThrough(t *testing.T) {
 	q := &fakeSpaceQuerier{
 		multiRows: map[string][]string{
@@ -85,8 +98,8 @@ func TestResolveBotActiveSpaceID_MultiSpace_HeaderMiss_FallsThrough(t *testing.T
 	got := ba.resolveBotActiveSpaceID(c, "user_bot_2_spaces")
 	assert.Equal(t, "space_A", got,
 		"non-member header → fall through to deterministic primary (Space A)")
-	assert.Equal(t, []memberCall{{"user_bot_2_spaces", "space_C"}}, q.memberCalls,
-		"isBotSpaceMember must still be called once to make the non-member decision")
+	assert.Equal(t, []memberCall{{"user_bot_2_spaces", "space_C"}}, q.authCalls,
+		"isBotSpaceAuthorized must still be called once to make the non-member decision")
 	assert.Equal(t, []string{"user_bot_2_spaces"}, q.calls,
 		"querySpaceIDByRobotID must be invoked (via querySpaceIDsByRobotID) on miss")
 }
@@ -104,30 +117,140 @@ func TestResolveBotActiveSpaceID_AppBotScopeSpace_OutranksHeader(t *testing.T) {
 	got := ba.resolveBotActiveSpaceID(c, "app_bot_scope_space")
 	assert.Equal(t, "space_authoritative", got,
 		"App Bot scope=space ctx must outrank X-Space-ID header")
-	assert.Empty(t, q.memberCalls,
-		"isBotSpaceMember must not be called when ctx already has the SpaceID")
+	assert.Empty(t, q.authCalls,
+		"isBotSpaceAuthorized must not be called when ctx already has the SpaceID")
 	assert.Empty(t, q.calls,
 		"querySpaceIDByRobotID must not be called when ctx already has the SpaceID")
 }
 
-// App Bot scope=platform (no CtxKeyAppBotSpaceID) — header is honored when the
-// platform Bot is a member of the requested Space. Platform Bots can dispatch
-// to multiple Spaces; the header makes the dispatch context explicit.
+// YUJ-688 / PR#43 R1 — production-shaped: platform App Bot has NO space_member
+// row, only an `app_bot` row with scope='platform' status=1. With the previous
+// validator (`isBotSpaceMember` checking only space_member) this case
+// returned `false` and the caller's enrich path stripped the payload. The
+// fix authorizes platform App Bots in every active Space.
+//
+// This test fails on the original `isBotSpaceMember`-only validator and
+// passes on the new `isBotSpaceAuthorized` validator: it must NOT rely on
+// `memberships` being stubbed true.
 func TestResolveBotActiveSpaceID_AppBotScopePlatform_HeaderHit(t *testing.T) {
 	q := &fakeSpaceQuerier{
 		defaultSpace: "space_A",
-		memberships: map[string]map[string]bool{
-			"app_bot_platform": {"space_B": true},
+		// CRITICAL: no `memberships` entry. Platform App Bots are not in
+		// space_member; the production fake mirrors that shape.
+		appBots: map[string]appBotShape{
+			"app_bot_platform": {publishedPlatform: true},
 		},
+		// space_B is active by default (activeSpaces nil → all active).
 	}
 	ba := newTestBotAPI(q)
 	c := fakeWkContextWithHeader("X-Space-ID", "space_B")
 	c.Set(CtxKeyAppBotScope, "platform") // not "space" → ctx fast-path skipped
 
 	got := ba.resolveBotActiveSpaceID(c, "app_bot_platform")
-	assert.Equal(t, "space_B", got)
+	assert.Equal(t, "space_B", got,
+		"published platform App Bot must be authorized in any active Space, "+
+			"even when no space_member row exists (PR#43 R1 fix)")
 	assert.Empty(t, q.calls,
 		"DB fallback must not be reached when header is honored")
+	assert.Equal(t, []memberCall{{"app_bot_platform", "space_B"}}, q.authCalls,
+		"isBotSpaceAuthorized must be called once with the header value")
+}
+
+// YUJ-688 medium ask (lml2468): if the header points at an INACTIVE Space, we
+// must reject — never let a platform App Bot stamp a payload with a deleted
+// or disabled SpaceID.
+func TestResolveBotActiveSpaceID_AppBotScopePlatform_HeaderForInactiveSpace_FallsThrough(t *testing.T) {
+	q := &fakeSpaceQuerier{
+		defaultSpace: "space_A",
+		appBots: map[string]appBotShape{
+			"app_bot_platform": {publishedPlatform: true},
+		},
+		activeSpaces: map[string]bool{
+			"space_disabled": false,
+		},
+	}
+	ba := newTestBotAPI(q)
+	c := fakeWkContextWithHeader("X-Space-ID", "space_disabled")
+	c.Set(CtxKeyAppBotScope, "platform")
+
+	got := ba.resolveBotActiveSpaceID(c, "app_bot_platform")
+	assert.Equal(t, "space_A", got,
+		"inactive target Space must be rejected even for platform App Bots; "+
+			"resolver falls through to deterministic DB primary")
+	assert.Equal(t, []memberCall{{"app_bot_platform", "space_disabled"}}, q.authCalls,
+		"isBotSpaceAuthorized must still be called and return false for inactive Space")
+}
+
+// Defensive: scope=space App Bot dispatching into its own Space via the
+// header path (bypassing the ctx fast-path) is authorized.
+func TestResolveBotActiveSpaceID_AppBotScopeSpace_OwnSpaceAuthorized(t *testing.T) {
+	q := &fakeSpaceQuerier{
+		defaultSpace: "space_A",
+		appBots: map[string]appBotShape{
+			"app_bot_scope_space": {scopeSpaceID: "space_own", published: true},
+		},
+	}
+	ba := newTestBotAPI(q)
+	c := fakeWkContextWithHeader("X-Space-ID", "space_own")
+	// Note: CtxKeyAppBotScope intentionally NOT "space" so we exercise the
+	// header validator branch rather than the ctx fast-path. In production
+	// this combination is rare (authAppBot would normally set the ctx) but
+	// the validator must still fail-closed-correctly.
+
+	got := ba.resolveBotActiveSpaceID(c, "app_bot_scope_space")
+	assert.Equal(t, "space_own", got,
+		"scope=space App Bot dispatching into its own Space is authorized")
+}
+
+// Defensive: scope=space App Bot is NOT authorized for a different Space.
+// Without this guard the validator would let a scope=space App Bot send into
+// any Space its caller asks for via the header.
+func TestResolveBotActiveSpaceID_AppBotScopeSpace_DifferentSpaceRejected(t *testing.T) {
+	q := &fakeSpaceQuerier{
+		defaultSpace: "space_A",
+		appBots: map[string]appBotShape{
+			"app_bot_scope_space": {scopeSpaceID: "space_own", published: true},
+		},
+	}
+	ba := newTestBotAPI(q)
+	c := fakeWkContextWithHeader("X-Space-ID", "space_other")
+
+	got := ba.resolveBotActiveSpaceID(c, "app_bot_scope_space")
+	assert.Equal(t, "space_A", got,
+		"scope=space App Bot must NOT be authorized in a Space other than its own; "+
+			"resolver falls through to deterministic DB primary")
+}
+
+// YUJ-688 medium ask (lml2468): trim whitespace from the X-Space-ID header
+// before validation. Some clients send "  space_X  " or trailing CR; without
+// TrimSpace these were rejected as non-member and emitted noisy reject warns.
+func TestResolveBotActiveSpaceID_HeaderWhitespaceTrimmed(t *testing.T) {
+	q := &fakeSpaceQuerier{
+		defaultSpace: "space_A",
+		memberships: map[string]map[string]bool{
+			"user_bot_2_spaces": {"space_B": true},
+		},
+	}
+	ba := newTestBotAPI(q)
+	c := fakeWkContextWithHeader("X-Space-ID", "  space_B  \r")
+
+	got := ba.resolveBotActiveSpaceID(c, "user_bot_2_spaces")
+	assert.Equal(t, "space_B", got,
+		"X-Space-ID header value must be TrimSpace'd before validation")
+	assert.Equal(t, []memberCall{{"user_bot_2_spaces", "space_B"}}, q.authCalls,
+		"isBotSpaceAuthorized must receive the trimmed value, not the raw header")
+}
+
+// All-whitespace header is treated as no header (TrimSpace empty → skip path).
+func TestResolveBotActiveSpaceID_HeaderAllWhitespace_TreatedAsAbsent(t *testing.T) {
+	q := &fakeSpaceQuerier{defaultSpace: "space_A"}
+	ba := newTestBotAPI(q)
+	c := fakeWkContextWithHeader("X-Space-ID", "   ")
+
+	got := ba.resolveBotActiveSpaceID(c, "user_bot_x")
+	assert.Equal(t, "space_A", got)
+	assert.Empty(t, q.authCalls,
+		"all-whitespace header must skip the validator entirely (treated as absent)")
 }
 
 // Mininglamp-OSS/octo-server#36 enrich-end-to-end: 2-Space User Bot dispatching
@@ -170,4 +293,32 @@ func TestEnrichBotPayloadWithSpaceID_MultiSpace_HeaderHit_HeaderOverridesPrimary
 	got := ba.enrichBotPayloadWithSpaceID(c, "user_bot_2_spaces", payload)
 	assert.Equal(t, "space_B", got["space_id"],
 		"valid X-Space-ID header must drive payload.space_id, overriding both client forge and DB primary")
+}
+
+// YUJ-688 / PR#43 R1 — end-to-end production case: platform App Bot dispatch
+// with valid X-Space-ID. Before the fix, the validator rejected the header
+// (no space_member row), the DB primary returned "" (no space_member rows
+// for platform App Bots either), and the enrich path STRIPPED the payload
+// (fail-closed) — silently downgrading every legitimate platform App Bot
+// dispatch to a Space-less PERSONAL DM. After the fix, the header is honored
+// and the payload carries the correct SpaceID.
+func TestEnrichBotPayloadWithSpaceID_AppBotScopePlatform_NoSpaceMember_HeaderWins(t *testing.T) {
+	q := &fakeSpaceQuerier{
+		// Platform App Bot: not in space_member; only in app_bot scope=platform.
+		// Production DB lookup of querySpaceIDsByRobotID returns ErrNotFound
+		// because platform App Bots have no space_member rows.
+		defaultErr: dbr.ErrNotFound,
+		appBots: map[string]appBotShape{
+			"app_bot_platform_prod": {publishedPlatform: true},
+		},
+	}
+	ba := newTestBotAPI(q)
+	c := fakeWkContextWithHeader("X-Space-ID", "space_target")
+	c.Set(CtxKeyAppBotScope, "platform")
+	payload := map[string]interface{}{"content": "hi", "space_id": "space_forged"}
+
+	got := ba.enrichBotPayloadWithSpaceID(c, "app_bot_platform_prod", payload)
+	assert.Equal(t, "space_target", got["space_id"],
+		"platform App Bot with valid X-Space-ID must end up with space_target in payload "+
+			"(regression: previous validator stripped it because the bot wasn't in space_member)")
 }

--- a/modules/bot_api/space_inject_test.go
+++ b/modules/bot_api/space_inject_test.go
@@ -13,6 +13,8 @@ package bot_api
 
 import (
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
@@ -31,6 +33,23 @@ type fakeSpaceQuerier struct {
 	}
 	defaultSpace string
 	defaultErr   error
+	// Mininglamp-OSS/octo-server#36 — multi-Space rows. Per-robot override of
+	// the full ordered list; falls back to a single-element list built from
+	// `defaultSpace` / per-robot result when absent.
+	multiRows map[string][]string
+	// isBotSpaceMember scripted return:
+	//   memberships[robotID][spaceID] = isMember
+	// missing entries fall through to memberDefault. memberErr (when non-nil)
+	// short-circuits everything.
+	memberships   map[string]map[string]bool
+	memberCalls   []memberCall
+	memberDefault bool
+	memberErr     error
+}
+
+type memberCall struct {
+	robotID string
+	spaceID string
 }
 
 func (f *fakeSpaceQuerier) querySpaceIDByRobotID(robotID string) (string, error) {
@@ -41,9 +60,55 @@ func (f *fakeSpaceQuerier) querySpaceIDByRobotID(robotID string) (string, error)
 	return f.defaultSpace, f.defaultErr
 }
 
-// fakeWkContext creates a minimal wkhttp.Context (gin context wrapper).
+func (f *fakeSpaceQuerier) querySpaceIDsByRobotID(robotID string) (string, []string, error) {
+	// Reuse single-row behaviour for err / empty handling, then layer the
+	// multi-row override on top so individual tests stay readable.
+	primary, err := f.querySpaceIDByRobotID(robotID)
+	if err != nil {
+		return "", nil, err
+	}
+	if rows, ok := f.multiRows[robotID]; ok {
+		if len(rows) == 0 {
+			return "", nil, dbr.ErrNotFound
+		}
+		return rows[0], rows, nil
+	}
+	if primary == "" {
+		return "", nil, dbr.ErrNotFound
+	}
+	return primary, []string{primary}, nil
+}
+
+func (f *fakeSpaceQuerier) isBotSpaceMember(robotID, spaceID string) (bool, error) {
+	f.memberCalls = append(f.memberCalls, memberCall{robotID: robotID, spaceID: spaceID})
+	if f.memberErr != nil {
+		return false, f.memberErr
+	}
+	if m, ok := f.memberships[robotID]; ok {
+		if v, ok := m[spaceID]; ok {
+			return v, nil
+		}
+	}
+	return f.memberDefault, nil
+}
+
+// fakeWkContext creates a minimal wkhttp.Context (gin context wrapper) with
+// a real http.Request attached so c.GetHeader is safe.
 func fakeWkContext() *wkhttp.Context {
 	c, _ := gin.CreateTestContext(nil)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/bot/sendMessage", nil)
+	return &wkhttp.Context{Context: c}
+}
+
+// fakeWkContextWithHeader is the variant that adds an `X-Space-ID` header for
+// Mininglamp-OSS/octo-server#36 Option B coverage.
+func fakeWkContextWithHeader(header, value string) *wkhttp.Context {
+	c, _ := gin.CreateTestContext(nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/bot/sendMessage", nil)
+	if value != "" {
+		req.Header.Set(header, value)
+	}
+	c.Request = req
 	return &wkhttp.Context{Context: c}
 }
 

--- a/modules/bot_api/space_inject_test.go
+++ b/modules/bot_api/space_inject_test.go
@@ -37,14 +37,32 @@ type fakeSpaceQuerier struct {
 	// the full ordered list; falls back to a single-element list built from
 	// `defaultSpace` / per-robot result when absent.
 	multiRows map[string][]string
-	// isBotSpaceMember scripted return:
-	//   memberships[robotID][spaceID] = isMember
-	// missing entries fall through to memberDefault. memberErr (when non-nil)
-	// short-circuits everything.
+
+	// YUJ-688 / PR#43 R1 — production-shaped authorization fake.
+	//
+	// `isBotSpaceAuthorized` mirrors the production OR-of-three rule from
+	// modules/bot_api/db.go:
+	//   (1) `memberships[robotID][spaceID] == true` → space_member match
+	//   (2) `appBots[robotID].publishedPlatform == true` AND
+	//       `activeSpaces[spaceID] != false` → published platform App Bot
+	//       visible in target active Space
+	//   (3) `appBots[robotID].scopeSpaceID == spaceID` AND
+	//       `appBots[robotID].published == true` AND
+	//       `activeSpaces[spaceID] != false` → scope=space App Bot in own Space
+	// `activeSpaces` defaults to true for any spaceID not explicitly set to
+	// false, so tests that don't care about Space status can omit it.
 	memberships   map[string]map[string]bool
-	memberCalls   []memberCall
-	memberDefault bool
-	memberErr     error
+	authCalls     []memberCall
+	authDefault   bool
+	authErr       error
+	appBots       map[string]appBotShape
+	activeSpaces  map[string]bool
+}
+
+type appBotShape struct {
+	publishedPlatform bool   // app_bot row exists with scope='platform' status=1
+	scopeSpaceID      string // app_bot.space_id when scope='space' (status=1)
+	published         bool   // app_bot.status=1 for the scope=space case
 }
 
 type memberCall struct {
@@ -79,17 +97,48 @@ func (f *fakeSpaceQuerier) querySpaceIDsByRobotID(robotID string) (string, []str
 	return primary, []string{primary}, nil
 }
 
-func (f *fakeSpaceQuerier) isBotSpaceMember(robotID, spaceID string) (bool, error) {
-	f.memberCalls = append(f.memberCalls, memberCall{robotID: robotID, spaceID: spaceID})
-	if f.memberErr != nil {
-		return false, f.memberErr
+// isBotSpaceAuthorized mirrors the production OR-of-three rule. Tests pick the
+// branch they want by populating `memberships` (User Bot path) or `appBots`
+// (App Bot platform / scope=space path). `activeSpaces` defaults to active.
+func (f *fakeSpaceQuerier) isBotSpaceAuthorized(robotID, spaceID string) (bool, error) {
+	f.authCalls = append(f.authCalls, memberCall{robotID: robotID, spaceID: spaceID})
+	if f.authErr != nil {
+		return false, f.authErr
 	}
+	// Branch (1): space_member match.
+	if m, ok := f.memberships[robotID]; ok {
+		if v, ok := m[spaceID]; ok && v {
+			return true, nil
+		}
+	}
+	// Target Space must be active for app_bot branches. Default = active when
+	// activeSpaces is nil or the entry is missing.
+	spaceActive := true
+	if f.activeSpaces != nil {
+		if v, ok := f.activeSpaces[spaceID]; ok {
+			spaceActive = v
+		}
+	}
+	if spaceActive {
+		if shape, ok := f.appBots[robotID]; ok {
+			// Branch (2): published platform App Bot in any active Space.
+			if shape.publishedPlatform {
+				return true, nil
+			}
+			// Branch (3): scope=space App Bot dispatching into its own Space.
+			if shape.published && shape.scopeSpaceID != "" && shape.scopeSpaceID == spaceID {
+				return true, nil
+			}
+		}
+	}
+	// Fall through: explicit `memberships[robotID][spaceID] == false` or
+	// nothing matches → use authDefault for tests that don't model the bot.
 	if m, ok := f.memberships[robotID]; ok {
 		if v, ok := m[spaceID]; ok {
 			return v, nil
 		}
 	}
-	return f.memberDefault, nil
+	return f.authDefault, nil
 }
 
 // fakeWkContext creates a minimal wkhttp.Context (gin context wrapper) with

--- a/modules/bot_api/voice.go
+++ b/modules/bot_api/voice.go
@@ -46,7 +46,12 @@ func (ba *BotAPI) resolveOwnerAndSpace(c *wkhttp.Context) (string, string, strin
 		return "", "", "", false
 	}
 
-	spaceID, err := ba.db.querySpaceIDByRobotID(robotID)
+	// YUJ-688 medium ask: Voice context path was deterministic but used the
+	// single-row wrapper, discarding the multi-Space list and never emitting
+	// the `multi_space_membership=true` observability signal. Switch to the
+	// multi-row variant so multi-Space User Bot voice traffic is visible to
+	// operators alongside the bot_api / robot dispatchers.
+	spaceID, allSpaces, err := ba.db.querySpaceIDsByRobotID(robotID)
 	if err != nil {
 		if errors.Is(err, dbr.ErrNotFound) {
 			ba.Warn("bot is not in any active space", zap.String("robotID", robotID))
@@ -61,6 +66,17 @@ func (ba *BotAPI) resolveOwnerAndSpace(c *wkhttp.Context) (string, string, strin
 		ba.Warn("bot is not in any active space", zap.String("robotID", robotID))
 		c.ResponseErrorWithStatus(errors.New("bot is not in any active space"), http.StatusBadRequest)
 		return "", "", "", false
+	}
+	if len(allSpaces) > 1 {
+		// Mirror the dispatch-path warn shape so a single SLO query covers all
+		// multi-Space dispatch entry points (bot_api send, robot send, voice).
+		ba.Warn("multi_space_membership",
+			zap.Bool("multi_space_membership", true),
+			zap.String("dispatcher", "bot_api_voice"),
+			zap.String("robotID", robotID),
+			zap.String("chosen_space_id", spaceID),
+			zap.Strings("all_space_ids", allSpaces),
+		)
 	}
 
 	return ownerUID, spaceID, robotID, true

--- a/modules/botfather/db.go
+++ b/modules/botfather/db.go
@@ -249,10 +249,17 @@ func (d *botfatherDB) isBotInSpace(robotID string, spaceID string) (bool, error)
 
 // querySpaceIDByRobotID returns the active Space ID for the given bot.
 // Checks both space_member.status=1 and space.status=1.
+//
+// Mininglamp-OSS/octo-server#36: deterministic ORDER BY (Option C). When the
+// bot is a member of multiple active Spaces, the earliest joined wins, with
+// `space_id` as a tie-breaker. This makes the result stable across calls
+// instead of engine-dependent. Voice context resolution (`api_voice.go`) is
+// the only caller in this package and accepts the first match — keeping the
+// SQL signature unchanged means no caller code needs to move.
 func (d *botfatherDB) querySpaceIDByRobotID(robotID string) (string, error) {
 	var spaceID string
 	err := d.session.SelectBySql(
-		"SELECT sm.space_id FROM space_member sm INNER JOIN space s ON s.space_id = sm.space_id WHERE sm.uid=? AND sm.status=1 AND s.status=1",
+		"SELECT sm.space_id FROM space_member sm INNER JOIN space s ON s.space_id = sm.space_id WHERE sm.uid=? AND sm.status=1 AND s.status=1 ORDER BY sm.created_at ASC, sm.space_id ASC LIMIT 1",
 		robotID,
 	).LoadOne(&spaceID)
 	return spaceID, err

--- a/modules/robot/space_inject.go
+++ b/modules/robot/space_inject.go
@@ -23,18 +23,40 @@ import (
 // satisfies it implicitly.
 type robotSpaceQuerier interface {
 	querySpaceIDByRobotID(robotID string) (string, error)
+	querySpaceIDsByRobotID(robotID string) (string, []string, error)
 }
 
 // querySpaceIDByRobotID 查询 Bot 当前激活的 SpaceID。逻辑与
 // modules/botfather/db.go / modules/bot_api/db.go 同名函数一致：
 // space_member ⨝ space，要求 sm.status=1 AND s.status=1。
+//
+// Mininglamp-OSS/octo-server#36（PR#35 deep-review High-2）— deterministic
+// ORDER BY (Option C). Bot 在多个活跃 Space 时，按 `sm.created_at ASC, sm.space_id ASC`
+// 取首行 — earliest joined wins，`space_id` 兜底破并列。legacy /v1/robot/.../sendMessage
+// 路由没有 SpaceMiddleware / Space 上下文，本层只能依赖 deterministic ordering，
+// 不能用 Option B（context-aware）。多归属告警由调用方
+// `resolveBotActiveSpaceID` / `enrichBotPayloadWithSpaceID` 通过单独的检测路径输出。
 func (d *robotDB) querySpaceIDByRobotID(robotID string) (string, error) {
-	var spaceID string
-	err := d.session.SelectBySql(
-		"SELECT sm.space_id FROM space_member sm INNER JOIN space s ON s.space_id = sm.space_id WHERE sm.uid=? AND sm.status=1 AND s.status=1",
-		robotID,
-	).LoadOne(&spaceID)
+	spaceID, _, err := d.querySpaceIDsByRobotID(robotID)
 	return spaceID, err
+}
+
+// querySpaceIDsByRobotID 多行变体 — 返回 deterministic 首行 + 全部匹配的有序列表，
+// 让调用方一次查询就能 observe 多归属（`len(spaceIDs) > 1`），无需第二次 round-trip。
+// 空集合返回 `dbr.ErrNotFound`，保留 LoadOne 时代的调用方契约。
+func (d *robotDB) querySpaceIDsByRobotID(robotID string) (string, []string, error) {
+	var spaceIDs []string
+	_, err := d.session.SelectBySql(
+		"SELECT sm.space_id FROM space_member sm INNER JOIN space s ON s.space_id = sm.space_id WHERE sm.uid=? AND sm.status=1 AND s.status=1 ORDER BY sm.created_at ASC, sm.space_id ASC",
+		robotID,
+	).Load(&spaceIDs)
+	if err != nil {
+		return "", nil, err
+	}
+	if len(spaceIDs) == 0 {
+		return "", nil, dbr.ErrNotFound
+	}
+	return spaceIDs[0], spaceIDs, nil
 }
 
 // enrichBotPayloadWithSpaceID injects the bot's authoritative SpaceID into the
@@ -74,13 +96,18 @@ func (rb *Robot) enrichBotPayloadWithSpaceID(robotID string, payload map[string]
 // resolveBotActiveSpaceID 通过 querier 查 Bot 的激活 SpaceID。返回 "" 表示
 // 解析不到（任意原因 — 孤儿 Bot、DB 错误、ErrNotFound）。调用方必须在 ""
 // 返回时执行 strip 而不是 passthrough。
+//
+// Mininglamp-OSS/octo-server#36：legacy /v1/robot/... 路由没有 SpaceMiddleware
+// 也不挂 Bot ctx，无法走 Option B。多归属时返回 deterministic 首行（earliest
+// joined）并 emit `multi_space_membership=true` warn 让运维定位需要迁移到新
+// Bot API 的 Bot。
 func (rb *Robot) resolveBotActiveSpaceID(robotID string) string {
 	q := rb.spaceQuerierOrDefault()
 	if q == nil {
 		// Defensive: tests sometimes construct &Robot{} without DB wired.
 		return ""
 	}
-	spaceID, err := q.querySpaceIDByRobotID(robotID)
+	primary, allSpaces, err := q.querySpaceIDsByRobotID(robotID)
 	if err != nil {
 		// YUJ-660 Medium-2: dbr.ErrNotFound 是合法的"Bot 无归属 Space"状态，
 		// 不视为 DB 错误。其它 err 才记 warn；返回 "" 让调用方走 strip 分支。
@@ -90,7 +117,16 @@ func (rb *Robot) resolveBotActiveSpaceID(robotID string) string {
 		}
 		return ""
 	}
-	return spaceID
+	if len(allSpaces) > 1 {
+		rb.Warn("multi_space_membership",
+			zap.Bool("multi_space_membership", true),
+			zap.String("dispatcher", "robot"),
+			zap.String("robotID", robotID),
+			zap.String("chosen_space_id", primary),
+			zap.Strings("all_space_ids", allSpaces),
+		)
+	}
+	return primary
 }
 
 // spaceQuerierOrDefault returns the test-injected stub when present, otherwise

--- a/modules/robot/space_inject_multispace_test.go
+++ b/modules/robot/space_inject_multispace_test.go
@@ -1,0 +1,46 @@
+// Package robot · Mininglamp-OSS/octo-server#36 (PR#35 deep-review High-2):
+// querySpaceIDByRobotID multi-Space ambiguity. legacy /v1/robot/.../sendMessage
+// has no SpaceMiddleware / authAppBot context, so it falls back exclusively to
+// the deterministic ORDER BY (Option C). Coverage:
+//
+//   - 2-Space User Bot dispatch returns deterministic primary (earliest joined)
+//   - Repeated calls return the same SpaceID (no engine flapping)
+//   - PERSONAL DM enrich path overrides client-forged payload.space_id with
+//     the deterministic primary, not engine-dependent first row.
+package robot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// 2-Space User Bot — deterministic primary on the legacy robot path.
+func TestResolveBotActiveSpaceID_MultiSpace_DeterministicPrimary(t *testing.T) {
+	q := &fakeRobotSpaceQuerier{
+		// rows[0] is the deterministic primary (earliest joined wins).
+		rows: []string{"space_A", "space_B"},
+	}
+	rb := newTestRobot(q)
+
+	first := rb.resolveBotActiveSpaceID("user_bot_2_spaces")
+	second := rb.resolveBotActiveSpaceID("user_bot_2_spaces")
+
+	assert.Equal(t, "space_A", first,
+		"legacy /v1/robot path: primary = earliest joined Space A")
+	assert.Equal(t, first, second,
+		"repeated calls must be stable (deterministic ORDER BY)")
+}
+
+// PERSONAL DM enrich on the legacy /v1/robot/.../sendMessage path with a
+// 2-Space User Bot and a forged client-supplied payload.space_id. The forged
+// value must be overridden by the deterministic primary.
+func TestEnrichBotPayloadWithSpaceID_MultiSpace_OverridesForgedClient(t *testing.T) {
+	q := &fakeRobotSpaceQuerier{rows: []string{"space_A", "space_B"}}
+	rb := newTestRobot(q)
+	payload := map[string]interface{}{"content": "hi", "space_id": "space_attacker"}
+
+	got := rb.enrichBotPayloadWithSpaceID("user_bot_2_spaces", payload)
+	assert.Equal(t, "space_A", got["space_id"],
+		"deterministic primary must override forged client space_id on legacy path")
+}

--- a/modules/robot/space_inject_test.go
+++ b/modules/robot/space_inject_test.go
@@ -16,11 +16,31 @@ type fakeRobotSpaceQuerier struct {
 	calls   []string
 	spaceID string
 	err     error
+	// Mininglamp-OSS/octo-server#36 — full ordered list. When non-nil, takes
+	// precedence over `spaceID` for `querySpaceIDsByRobotID`.
+	rows []string
 }
 
 func (f *fakeRobotSpaceQuerier) querySpaceIDByRobotID(robotID string) (string, error) {
 	f.calls = append(f.calls, robotID)
 	return f.spaceID, f.err
+}
+
+func (f *fakeRobotSpaceQuerier) querySpaceIDsByRobotID(robotID string) (string, []string, error) {
+	primary, err := f.querySpaceIDByRobotID(robotID)
+	if err != nil {
+		return "", nil, err
+	}
+	if f.rows != nil {
+		if len(f.rows) == 0 {
+			return "", nil, dbr.ErrNotFound
+		}
+		return f.rows[0], f.rows, nil
+	}
+	if primary == "" {
+		return "", nil, dbr.ErrNotFound
+	}
+	return primary, []string{primary}, nil
 }
 
 // newTestRobot constructs a minimal *Robot with logger + injected querier


### PR DESCRIPTION
## Summary

Fixes #36 — `querySpaceIDByRobotID` returned a non-deterministic SpaceID for User Bots that were members of multiple active Spaces. The SQL had no `ORDER BY` and used `LoadOne`, leaving the result up to the DB engine (insertion order, page layout, planner choice).

Three call sites were affected: User Bot ctx-miss fallback in `/v1/bot/sendMessage`, App Bot scope=platform in the same path, and legacy `/v1/robots/.../sendMessage`.

This PR implements the hybrid recommended in the issue body — **Option B for the unified Bot API path + Option C as the global deterministic fallback** — plus structured observability so operators can spot bots that need to migrate to the new context-aware path.

## Changes

### Option C — deterministic ORDER BY (all three sites)

`modules/bot_api/db.go`, `modules/botfather/db.go`, `modules/robot/space_inject.go` now order matching rows by `sm.created_at ASC, sm.space_id ASC`. Earliest-joined Space wins; `space_id` is a stable tie-breaker. Repeated calls return the same SpaceID instead of flapping with engine state.

The Bot API and Robot modules also added a multi-row variant `querySpaceIDsByRobotID` so the resolver can observe multi-Space membership without an extra round-trip. The single-row `querySpaceIDByRobotID` signature is preserved for legacy callers (`bot_api/voice.go`, `botfather/api_voice.go`) that already handle empty-result via `errors.Is(err, dbr.ErrNotFound)`.

### Option B — `X-Space-ID` header preference for `/v1/bot/sendMessage`

`resolveBotActiveSpaceID` now resolves in three tiers, in this order:

1. **App Bot `scope=space` ctx** (`CtxKeyAppBotSpaceID` written by `authAppBot`) — strongest signal, never overridden by client input.
2. **`X-Space-ID` header**, validated through a new `isBotSpaceMember(robotID, spaceID)` check on `space_member`. The header is honored only when the Bot is an active member of the requested Space. Without that check, the header would be a trivial bypass; with it, the header lets a multi-Space User Bot disambiguate explicitly per dispatch. Verify error / non-member → fall through.
3. **DB query** (Option C deterministic primary).

The route group `/v1/bot` does not currently mount `SpaceMiddleware`, so plumbing through `spacepkg.GetSpaceID(c)` is not directly available — `isBotSpaceMember` plays the same membership-validation role in this code path.

### Observability

- `multi_space_membership=true` structured zap warn (with `chosen_space_id` + `all_space_ids`) when the deterministic fallback picks from a list of length > 1. Wired into both `modules/bot_api` and `modules/robot`.
- `x_space_id_header_rejected_not_member=true` warn when the client sends `X-Space-ID` for a Space the Bot isn't a member of, before falling through.
- Existing `client_space_id_stripped` / `enrich_payload_space_id_empty` / `querySpaceIDByRobotID 失败` warns kept as-is.

### Tests

`modules/bot_api/space_inject_multispace_test.go`:

- Multi-Space, no header → deterministic primary, repeat-call stability
- Multi-Space, valid `X-Space-ID` → header wins, DB fallback not reached
- Multi-Space, `X-Space-ID` for non-member Space → fall through to deterministic primary
- App Bot `scope=space` outranks `X-Space-ID` header (regression guard)
- App Bot `scope=platform` with valid header → header wins
- Enrich path: forged client `space_id` overridden by deterministic primary
- Enrich path: valid header overrides both client forge and DB primary

`modules/robot/space_inject_multispace_test.go`:

- Legacy path multi-Space deterministic primary + repeat-call stability
- Legacy enrich overrides forged client `space_id` with primary

Existing test stubs (`fakeSpaceQuerier`, `fakeRobotSpaceQuerier`) updated to satisfy the expanded interface; no behavioral changes to the existing suite.

## Acceptance from #36

- [x] Apply chosen fix to `modules/bot_api/db.go`, `modules/botfather/db.go`, `modules/robot/space_inject.go`
- [x] Test asserting the chosen disambiguation is deterministic
- [x] Update PR #35 / #33 docs to remove the "non-deterministic for multi-Space bots" caveat (covered by the new doc-comments referencing #36)
- [ ] Decide product semantics for multi-Space User Bots — left open. Option A (schema invariant via `UNIQUE (uid)`) requires a product call on whether multi-Space User Bots are intentional; this PR keeps that door open and just fixes the silent ambiguity in the meantime.

## Verification

```
go build ./...    # clean
go vet ./...      # clean
go test ./modules/bot_api/... ./modules/robot/... ./modules/message/...   # all green
```

Pre-existing `modules/botfather/TestRobotApply_AutoApprove` infra failure (needs MySQL/Redis backend) reproduces on `git stash` — unrelated to this change.

## Diff

```
modules/bot_api/db.go                            |  58 ++++-
 modules/bot_api/space_inject.go                  |  79 ++++++-
 modules/bot_api/space_inject_test.go             |  67 +++++-
 modules/bot_api/space_inject_multispace_test.go  | 169 ++++++++++++++ (new)
 modules/botfather/db.go                          |   9 +-
 modules/robot/space_inject.go                    |  50 ++++-
 modules/robot/space_inject_test.go               |  20 ++-
 modules/robot/space_inject_multispace_test.go    |  50 ++++ (new)
 8 files changed, 480 insertions(+), 22 deletions(-)
```

Fixes #36
