### PR TITLE
refactor(msg): migrate PERSONAL MsgSendReq dispatchers to octo-lib NewPersonalMsgSendReq builder + CI lint (Refs #37)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,3 +169,22 @@ jobs:
         with:
           version: latest
           args: --timeout=5m
+
+  personal-msgsendreq-lint:
+    # Mininglamp-OSS/octo-server#37: defense-in-depth wrapper for PERSONAL
+    # MsgSendReq construction. The lint AST-walks modules/ and rejects any
+    # composite literal of MsgSendReq{ChannelType: ChannelTypePerson...}, since
+    # PERSONAL DM dispatchers MUST go through octo-lib's
+    # config.NewPersonalMsgSendReq builder so payload.space_id authoritative
+    # semantics are uniformly applied.
+    name: Personal MsgSendReq Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Reject direct PERSONAL MsgSendReq literals
+        run: go run ./tools/lint-personal-msgsendreq ./modules

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	firebase.google.com/go/v4 v4.13.0
 	github.com/DATA-DOG/go-sqlmock v1.5.0
-	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260511174346-85c27c9a8898
+	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260515014003-2cdafe082b88
 	github.com/alibabacloud-go/darabonba-openapi v0.2.1
 	github.com/alibabacloud-go/sms-intl-20180501 v1.0.1
 	github.com/alibabacloud-go/tea v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260511174346-85c27c9a8898 h1:ryCVomP5CxBwFxiEJPo5IeY7O9ZHLNgo0lBIhYKXZ1c=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260511174346-85c27c9a8898/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260515014003-2cdafe082b88 h1:vPmjG30TUCzF46/sb/JqUWf0y1Lqey9w9cJuzicj3dU=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260515014003-2cdafe082b88/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae h1:DcFpTQBYQ9Ct2d6sC7ol0/ynxc2pO1cpGUM+f4t5adg=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae/go.mod h1:rJJ84PyA/Wlmw1hO+xTzV2wsSUon6J5ktg0g8BF2PuU=
 github.com/RichardKnop/machinery/v2 v2.0.11 h1:BTfLGOmOju3W/OtlZmLX26OjYNZsU4PJo04pQReycdc=

--- a/modules/app_bot/app_bot.go
+++ b/modules/app_bot/app_bot.go
@@ -1074,9 +1074,22 @@ func (ab *AppBot) applyBot(c *wkhttp.Context) {
 	ab.fixFriendVersion(req.RobotUID, loginUID)
 
 	// 3. IM Whitelist (bidirectional, with space prefix if applicable)
+	// For space-scoped bots, use bot.SpaceID directly. createBot persists the
+	// authoritative scope in app_bot.space_id but does NOT add the App Bot UID
+	// into space_member, so space.GetCommonSpaceID (which joins space_member
+	// for both UIDs) returns "" for valid space-scoped bots. That would cause
+	// NewPersonalMsgSendReq below to fail-closed strip payload.space_id and
+	// the welcome DM would not be attributed to its authoritative Space.
+	// The membership check above already validated loginUID belongs to
+	// bot.SpaceID.
 	userChannelID := loginUID
 	botChannelID := req.RobotUID
-	spaceID := space.GetCommonSpaceID(ab.ctx, loginUID, req.RobotUID)
+	var spaceID string
+	if bot.Scope == "space" {
+		spaceID = bot.SpaceID
+	} else {
+		spaceID = space.GetCommonSpaceID(ab.ctx, loginUID, req.RobotUID)
+	}
 	if spaceID != "" {
 		userChannelID = fmt.Sprintf("s%s_%s", spaceID, loginUID)
 		botChannelID = fmt.Sprintf("s%s_%s", spaceID, req.RobotUID)
@@ -1157,4 +1170,3 @@ func generateAppBotToken() (string, error) {
 	}
 	return AppBotTokenPrefix + hex.EncodeToString(b), nil
 }
-

--- a/modules/app_bot/app_bot.go
+++ b/modules/app_bot/app_bot.go
@@ -3,7 +3,6 @@ package app_bot
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -1121,23 +1120,20 @@ func (ab *AppBot) applyBot(c *wkhttp.Context) {
 	if bot.WelcomeMsg != "" {
 		welcomeContent = bot.WelcomeMsg
 	}
+	// YUJ-674 / Mininglamp-OSS#37: PERSONAL DM 走 NewPersonalMsgSendReq builder。
+	// spaceID 来自上方对 App Bot 的 Space 解析，非空时即为权威值；为空表示
+	// Bot 没有归属 Space，builder 会 fail-closed strip。
 	msgPayload := map[string]interface{}{
 		"content": welcomeContent,
 		"type":    common.Text,
 	}
-	if spaceID != "" {
-		msgPayload["space_id"] = spaceID
-	}
-	payload, _ := json.Marshal(msgPayload)
-	_ = ab.ctx.SendMessage(&config.MsgSendReq{
-		FromUID:     req.RobotUID,
-		ChannelID:   loginUID,
-		ChannelType: common.ChannelTypePerson.Uint8(),
-		Payload:     payload,
-		Header: config.MsgHeader{
-			RedDot: 1,
-		},
-	})
+	_ = ab.ctx.SendMessage(config.NewPersonalMsgSendReq(
+		loginUID,
+		req.RobotUID,
+		msgPayload,
+		spaceID,
+		config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}},
+	))
 
 	c.Response(gin.H{"status": "approved", "message": "\u5df2\u81ea\u52a8\u901a\u8fc7\uff0c\u53ef\u4ee5\u5f00\u59cb\u804a\u5929"})
 }

--- a/modules/botfather/api_apply.go
+++ b/modules/botfather/api_apply.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
-	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
@@ -420,19 +419,14 @@ func (bf *BotFather) createFriendRelation(userUID, robotUID string) error {
 		"content": content,
 		"type":    common.Tip,
 	}
-	if spaceID != "" {
-		bfTipPayload["space_id"] = spaceID
-	}
-	payload := []byte(util.ToJson(bfTipPayload))
-	_ = bf.ctx.SendMessage(&config.MsgSendReq{
-		FromUID:     robotUID,
-		ChannelID:   userUID,
-		ChannelType: common.ChannelTypePerson.Uint8(),
-		Payload:     payload,
-		Header: config.MsgHeader{
-			RedDot: 1,
-		},
-	})
+	// YUJ-674 / Mininglamp-OSS#37: PERSONAL DM via NewPersonalMsgSendReq builder.
+	_ = bf.ctx.SendMessage(config.NewPersonalMsgSendReq(
+		userUID,
+		robotUID,
+		bfTipPayload,
+		spaceID,
+		config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}},
+	))
 
 	return nil
 }
@@ -457,19 +451,14 @@ func (bf *BotFather) notifyOwnerNewApply(applicantUID, robotUID, ownerUID, remar
 		"content": content,
 		"type":    common.Text,
 	}
-	if spaceID != "" {
-		notifyPayload["space_id"] = spaceID
-	}
-	payload := []byte(util.ToJson(notifyPayload))
-	_ = bf.ctx.SendMessage(&config.MsgSendReq{
-		FromUID:     BotFatherUID,
-		ChannelID:   ownerUID,
-		ChannelType: common.ChannelTypePerson.Uint8(),
-		Payload:     payload,
-		Header: config.MsgHeader{
-			RedDot: 1,
-		},
-	})
+	// YUJ-674 / Mininglamp-OSS#37: PERSONAL DM via NewPersonalMsgSendReq builder.
+	_ = bf.ctx.SendMessage(config.NewPersonalMsgSendReq(
+		ownerUID,
+		BotFatherUID,
+		notifyPayload,
+		spaceID,
+		config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}},
+	))
 }
 
 // notifyApplicantResult 通知申请人审批结果
@@ -485,19 +474,14 @@ func (bf *BotFather) notifyApplicantResult(applicantUID, robotUID string, approv
 		"content": content,
 		"type":    common.Text,
 	}
-	if spaceID != "" {
-		resultPayload["space_id"] = spaceID
-	}
-	payload := []byte(util.ToJson(resultPayload))
-	_ = bf.ctx.SendMessage(&config.MsgSendReq{
-		FromUID:     BotFatherUID,
-		ChannelID:   applicantUID,
-		ChannelType: common.ChannelTypePerson.Uint8(),
-		Payload:     payload,
-		Header: config.MsgHeader{
-			RedDot: 1,
-		},
-	})
+	// YUJ-674 / Mininglamp-OSS#37: PERSONAL DM via NewPersonalMsgSendReq builder.
+	_ = bf.ctx.SendMessage(config.NewPersonalMsgSendReq(
+		applicantUID,
+		BotFatherUID,
+		resultPayload,
+		spaceID,
+		config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}},
+	))
 }
 
 // setupApplyRoutes 注册apply相关路由（需要用户认证）

--- a/modules/botfather/command.go
+++ b/modules/botfather/command.go
@@ -948,19 +948,15 @@ func (h *commandHandler) reply(toUID string, content string) {
 		"content": content,
 		"type":    common.Text,
 	}
-	// 写入 space_id，前端按当前 Space 过滤 BotFather 聊天历史
-	if spaceID := h.resolveSpaceID(toUID); spaceID != "" {
-		payload["space_id"] = spaceID
-	}
-	h.ctx.SendMessage(&config.MsgSendReq{
-		Header: config.MsgHeader{
-			RedDot: 1,
-		},
-		FromUID:     fromUID,
-		ChannelID:   channelID,
-		ChannelType: common.ChannelTypePerson.Uint8(),
-		Payload:     []byte(util.ToJson(payload)),
-	})
+	// YUJ-674 / Mininglamp-OSS#37: PERSONAL DM via NewPersonalMsgSendReq builder.
+	// resolveSpaceID 返回 "" 时 builder fail-closed strip。
+	h.ctx.SendMessage(config.NewPersonalMsgSendReq(
+		channelID,
+		fromUID,
+		payload,
+		h.resolveSpaceID(toUID),
+		config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}},
+	))
 }
 
 func (h *commandHandler) sendBotSelectionList(fromUID string, bots []*robotModel, prompt string) {

--- a/modules/botfather/command.go
+++ b/modules/botfather/command.go
@@ -8,13 +8,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Mininglamp-OSS/octo-server/modules/base/app"
-	"github.com/Mininglamp-OSS/octo-server/modules/group"
-	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-server/modules/base/app"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"go.uber.org/zap"
 )
 

--- a/modules/botfather/friend_approve.go
+++ b/modules/botfather/friend_approve.go
@@ -239,18 +239,14 @@ func (h *commandHandler) approveFriend(ownerUID string, applyUID string, robotID
 		"content": content,
 		"type":    common.Tip,
 	}
-	if applySpaceID != "" {
-		tipPayload["space_id"] = applySpaceID
-	}
-	_ = h.ctx.SendMessage(&config.MsgSendReq{
-		FromUID:     robotID,
-		ChannelID:   applyUID,
-		ChannelType: common.ChannelTypePerson.Uint8(),
-		Payload:     []byte(util.ToJson(tipPayload)),
-		Header: config.MsgHeader{
-			RedDot: 1,
-		},
-	})
+	// YUJ-674 / Mininglamp-OSS#37: PERSONAL DM via NewPersonalMsgSendReq builder.
+	_ = h.ctx.SendMessage(config.NewPersonalMsgSendReq(
+		applyUID,
+		robotID,
+		tipPayload,
+		applySpaceID,
+		config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}},
+	))
 
 	// 8. 清理 Redis
 	_ = h.DeleteBotFriendApply(robotID, applyUID)

--- a/modules/botfather/friend_approve.go
+++ b/modules/botfather/friend_approve.go
@@ -27,8 +27,8 @@ type BotFriendApply struct {
 	ApplyName string `json:"apply_name"`
 	RobotID   string `json:"robot_id"`
 	Remark    string `json:"remark"`
-	Token     string `json:"token"`     // friend apply token from cache
-	SpaceID   string `json:"space_id"`  // 申请来源 Space，用于隔离通知
+	Token     string `json:"token"`    // friend apply token from cache
+	SpaceID   string `json:"space_id"` // 申请来源 Space，用于隔离通知
 	CreatedAt int64  `json:"created_at"`
 }
 

--- a/modules/botfather/welcome.go
+++ b/modules/botfather/welcome.go
@@ -112,19 +112,14 @@ func (bf *BotFather) sendWelcomeMessage(toUID string, spaceID string) error {
 		"type":    common.Text,
 		"content": welcomeContent,
 	}
-	// 写入 space_id，前端按当前 Space 过滤 BotFather 聊天历史
-	if spaceID != "" {
-		payload["space_id"] = spaceID
-	}
-	_, err := bf.ctx.SendMessageWithResult(&config.MsgSendReq{
-		Header: config.MsgHeader{
-			RedDot: 1,
-		},
-		ChannelID:   channelID,
-		ChannelType: common.ChannelTypePerson.Uint8(),
-		FromUID:     BotFatherUID,
-		Payload:     []byte(util.ToJson(payload)),
-	})
+	// YUJ-674 / Mininglamp-OSS#37: PERSONAL DM via NewPersonalMsgSendReq builder.
+	_, err := bf.ctx.SendMessageWithResult(config.NewPersonalMsgSendReq(
+		channelID,
+		BotFatherUID,
+		payload,
+		spaceID,
+		config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}},
+	))
 
 	return err
 }

--- a/modules/channel/api.go
+++ b/modules/channel/api.go
@@ -5,16 +5,16 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/Mininglamp-OSS/octo-server/modules/group"
-	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
-	"github.com/Mininglamp-OSS/octo-server/pkg/util"
-	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/model"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
+	"github.com/Mininglamp-OSS/octo-server/pkg/util"
 	"go.uber.org/zap"
 )
 
@@ -41,10 +41,18 @@ func (ch *Channel) Route(r *wkhttp.WKHttp) {
 	auth := r.Group("/v1", ch.ctx.AuthMiddleware(r))
 	{
 		auth.GET("/channel/state", ch.state)
-		auth.GET("/channels/:channel_id/:channel_type", ch.channelGet)                                  // 获取频道信息
-		auth.POST("/channels/:channel_id/:channel_type/message/autodelete", ch.setAutoDeleteForMessage) // 设置消息定时删除时间
-		auth.POST("/channels/:channel_id/:channel_type/message/clear", ch.clearChannelMessages)         // 清空频道消息
-		auth.GET("/channels/:channel_id/:channel_type/storyline", ch.getStoryline)                      // 获取群聊个人故事线
+		auth.GET("/channels/:channel_id/:channel_type", ch.channelGet)                          // 获取频道信息
+		auth.POST("/channels/:channel_id/:channel_type/message/clear", ch.clearChannelMessages) // 清空频道消息
+		auth.GET("/channels/:channel_id/:channel_type/storyline", ch.getStoryline)              // 获取群聊个人故事线
+	}
+
+	// Routes that build PERSONAL MsgSendReq need SpaceMiddleware so the
+	// PERSONAL branch can read a SpaceMiddleware-validated space_id from the
+	// gin context (spacepkg.GetSpaceID); without this, payload.space_id would
+	// be fail-closed stripped by the NewPersonalMsgSendReq builder.
+	spaceAuth := r.Group("/v1", ch.ctx.AuthMiddleware(r), spacepkg.SpaceMiddleware(ch.ctx))
+	{
+		spaceAuth.POST("/channels/:channel_id/:channel_type/message/autodelete", ch.setAutoDeleteForMessage) // 设置消息定时删除时间
 	}
 }
 

--- a/modules/channel/api.go
+++ b/modules/channel/api.go
@@ -335,7 +335,11 @@ func (ch *Channel) setAutoDeleteForMessage(c *wkhttp.Context) {
 		return
 	}
 	if req.MsgAutoDelete > 0 {
-		payload := []byte(util.ToJson(map[string]interface{}{
+		// YUJ-674 / Mininglamp-OSS#37: PERSONAL 走 NewPersonalMsgSendReq builder
+		// (sender SpaceID 取自 SpaceMiddleware-validated context)。
+		// GROUP / COMMUNITY_TOPIC / 其它 channel_type 保留旧路径 — payload.space_id
+		// 的服务端权威注入依赖上游 enrichPayloadWithSpaceID（不在本 issue 范围）。
+		autoDeletePayloadMap := map[string]interface{}{
 			"content": fmt.Sprintf("{0}设置消息在 %s 后自动删除", formatSecondToDisplayTime(req.MsgAutoDelete)),
 			"type":    common.Tip,
 			"data": map[string]interface{}{
@@ -348,16 +352,27 @@ func (ch *Channel) setAutoDeleteForMessage(c *wkhttp.Context) {
 					Name: c.GetLoginName(),
 				},
 			},
-		}))
-		err := ch.ctx.SendMessage(&config.MsgSendReq{
-			FromUID:     loginUID,
-			ChannelID:   channelID,
-			ChannelType: channelType,
-			Payload:     payload,
-			Header: config.MsgHeader{
-				RedDot: 1,
-			},
-		})
+		}
+		var err error
+		if channelType == common.ChannelTypePerson.Uint8() {
+			err = ch.ctx.SendMessage(config.NewPersonalMsgSendReq(
+				channelID,
+				loginUID,
+				autoDeletePayloadMap,
+				spacepkg.GetSpaceID(c),
+				config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}},
+			))
+		} else {
+			err = ch.ctx.SendMessage(&config.MsgSendReq{
+				FromUID:     loginUID,
+				ChannelID:   channelID,
+				ChannelType: channelType,
+				Payload:     []byte(util.ToJson(autoDeletePayloadMap)),
+				Header: config.MsgHeader{
+					RedDot: 1,
+				},
+			})
+		}
 		if err != nil {
 			ch.Error("发送消息失败！", zap.Error(err))
 			c.ResponseError(errors.New("发送消息失败！"))

--- a/modules/notify/api.go
+++ b/modules/notify/api.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"sync"
 
-	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
@@ -235,20 +234,19 @@ func (n *Notify) deliverNotification(req *NotifyReq) (*NotifyResp, error) {
 		return nil, errors.New("notify bot unavailable")
 	}
 
-	// Inject space_id into payload for Space-level message filtering
-	// (same mechanism as botfather command.go:951)
-	// Clone to avoid mutating caller's map.
+	// Clone to avoid mutating caller's map. The PERSONAL builder
+	// (NewPersonalMsgSendReq) is the single authority for payload.space_id,
+	// so the legacy "if absent, inject req.SpaceID" check that lived here
+	// (mirrored from botfather/command.go:951) is removed in YUJ-674 /
+	// Mininglamp-OSS#37 — the builder either overrides with req.SpaceID or
+	// strips on empty, both fail-closed.
 	payload := make(map[string]interface{}, len(req.Payload))
 	for k, v := range req.Payload {
 		payload[k] = v
 	}
-	if payload["space_id"] == nil || payload["space_id"] == "" {
-		payload["space_id"] = req.SpaceID
-	}
 
 	// 并发投递（bounded worker pool，最多 20 并发）
 	fromUID := NotifyBotUID()
-	payloadBytes := []byte(util.ToJson(payload))
 
 	type sendResult struct {
 		uid     string
@@ -261,15 +259,20 @@ func (n *Notify) deliverNotification(req *NotifyReq) (*NotifyResp, error) {
 		sem <- struct{}{}
 		go func(uid string) {
 			defer func() { <-sem }()
-			err := n.ctx.SendMessage(&config.MsgSendReq{
-				Header: config.MsgHeader{
-					RedDot: 1,
-				},
-				FromUID:     fromUID,
-				ChannelID:   uid,
-				ChannelType: common.ChannelTypePerson.Uint8(),
-				Payload:     payloadBytes,
-			})
+			// Per-goroutine map clone is required: NewPersonalMsgSendReq mutates
+			// the payload map (sets/strips space_id) before encoding, so a shared
+			// map across goroutines would race.
+			perCall := make(map[string]interface{}, len(payload))
+			for k, v := range payload {
+				perCall[k] = v
+			}
+			err := n.ctx.SendMessage(config.NewPersonalMsgSendReq(
+				uid,
+				fromUID,
+				perCall,
+				req.SpaceID,
+				config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}},
+			))
 			if err != nil {
 				n.Warn("发送通知消息失败",
 					zap.String("target", uid),

--- a/modules/robot/event.go
+++ b/modules/robot/event.go
@@ -112,18 +112,32 @@ func (rb *Robot) robotMessageListen(messages []*config.MessageResp) {
 								continue
 							}
 							rb.Warn("用户与Bot非好友关系，拒绝转发消息", zap.String("fromUID", message.FromUID), zap.String("robotID", realUID))
-							rb.ctx.SendMessage(&config.MsgSendReq{
-								Header: config.MsgHeader{
-									RedDot: 1,
-								},
-								FromUID:     realUID,
-								ChannelID:   message.FromUID,
-								ChannelType: message.ChannelType,
-								Payload: []byte(util.ToJson(map[string]interface{}{
-									"content": "请先添加好友后再与我对话",
-									"type":    common.Text,
-								})),
-							})
+							// YUJ-674 / Mininglamp-OSS#37: PERSONAL 走 NewPersonalMsgSendReq builder
+							// (with bot's resolved SpaceID); GROUP / 其它 channel_type 保留直接构造。
+							// "请先加好友"这条提示在 GROUP 路径下罕见，但保守保留旧语义。
+							friendTipPayload := map[string]interface{}{
+								"content": "请先添加好友后再与我对话",
+								"type":    common.Text,
+							}
+							if message.ChannelType == common.ChannelTypePerson.Uint8() {
+								rb.ctx.SendMessage(config.NewPersonalMsgSendReq(
+									message.FromUID,
+									realUID,
+									friendTipPayload,
+									rb.resolveBotActiveSpaceID(realUID),
+									config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}},
+								))
+							} else {
+								rb.ctx.SendMessage(&config.MsgSendReq{
+									Header: config.MsgHeader{
+										RedDot: 1,
+									},
+									FromUID:     realUID,
+									ChannelID:   message.FromUID,
+									ChannelType: message.ChannelType,
+									Payload:     []byte(util.ToJson(friendTipPayload)),
+								})
+							}
 							continue
 						}
 					}
@@ -311,18 +325,30 @@ func (rb *Robot) messagesListen(messages []*config.MessageResp) {
 					if sendContent == "" {
 						sendContent = "抱歉，无法解析您发送的命令"
 					}
-					rb.ctx.SendMessage(&config.MsgSendReq{
-						Header: config.MsgHeader{
-							RedDot: 1,
-						},
-						FromUID:     robotID,
-						ChannelID:   channelID,
-						ChannelType: message.ChannelType,
-						Payload: []byte(util.ToJson(map[string]interface{}{
-							"content": sendContent,
-							"type":    common.Text,
-						})),
-					})
+					// YUJ-674 / Mininglamp-OSS#37: PERSONAL 走 NewPersonalMsgSendReq builder。
+					sysReplyPayload := map[string]interface{}{
+						"content": sendContent,
+						"type":    common.Text,
+					}
+					if message.ChannelType == common.ChannelTypePerson.Uint8() {
+						rb.ctx.SendMessage(config.NewPersonalMsgSendReq(
+							channelID,
+							robotID,
+							sysReplyPayload,
+							rb.resolveBotActiveSpaceID(robotID),
+							config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}},
+						))
+					} else {
+						rb.ctx.SendMessage(&config.MsgSendReq{
+							Header: config.MsgHeader{
+								RedDot: 1,
+							},
+							FromUID:     robotID,
+							ChannelID:   channelID,
+							ChannelType: message.ChannelType,
+							Payload:     []byte(util.ToJson(sysReplyPayload)),
+						})
+					}
 				}
 
 			}

--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -11,17 +11,17 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
-	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
-	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkevent"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
-	"github.com/gocraft/dbr/v2"
+	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	rd "github.com/go-redis/redis"
+	"github.com/gocraft/dbr/v2"
 	"go.uber.org/zap"
 )
 
@@ -1066,9 +1066,9 @@ func (s *Space) getInvitePreview(c *wkhttp.Context) {
 		MaxUses:     invitation.MaxUses,
 		UsedCount:   invitation.UsedCount,
 		ExpiresAt:   expiresAtStr,
-		MemberCount: 0,            // 不暴露精确成员数量
+		MemberCount: 0,              // 不暴露精确成员数量
 		JoinMode:    space.JoinMode, // 告知客户端是否需要审批
-		Bots:        nil,          // 不暴露 Bot 列表
+		Bots:        nil,            // 不暴露 Bot 列表
 	})
 }
 
@@ -1840,4 +1840,3 @@ func (s *Space) loadKnownSpaceIDs() {
 	spacepkg.RegisterSpaceIDs(ids)
 	s.Info("已注册 spaceId 到 ParseChannelID 缓存", zap.Int("count", len(ids)), zap.Strings("ids", ids))
 }
-

--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -1546,20 +1546,18 @@ func (s *Space) notifyAdminsNewJoinApply(applicantUID, spaceId, spaceName string
 		content := fmt.Sprintf("有新的 Space 加入申请\n\n用户: %s (%s)\n\n空间: %s%s\n\n审批链接: %s",
 			applicantName, applicantUID, spaceName, emailText, approveURL)
 		notifyPayload := map[string]interface{}{
-			"content":  content,
-			"type":     common.Text,
-			"space_id": spaceId,
+			"content": content,
+			"type":    common.Text,
 		}
-		payload := []byte(util.ToJson(notifyPayload))
-		if err := s.ctx.SendMessage(&config.MsgSendReq{
-			FromUID:     s.ctx.GetConfig().Account.SystemUID,
-			ChannelID:   admin.UID,
-			ChannelType: common.ChannelTypePerson.Uint8(),
-			Payload:     payload,
-			Header: config.MsgHeader{
-				RedDot: 1,
-			},
-		}); err != nil {
+		// YUJ-674 / Mininglamp-OSS#37: PERSONAL DM via NewPersonalMsgSendReq builder.
+		// spaceId 是当前申请的 Space，作为 senderSpaceID 即权威值。
+		if err := s.ctx.SendMessage(config.NewPersonalMsgSendReq(
+			admin.UID,
+			s.ctx.GetConfig().Account.SystemUID,
+			notifyPayload,
+			spaceId,
+			config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}},
+		)); err != nil {
 			s.Warn("发送加入申请通知失败", zap.Error(err), zap.String("adminUID", admin.UID), zap.String("spaceId", spaceId))
 		}
 	}
@@ -1575,20 +1573,17 @@ func (s *Space) notifyApplicantJoinResult(applicantUID, spaceId, spaceName strin
 	}
 
 	resultPayload := map[string]interface{}{
-		"content":  content,
-		"type":     common.Text,
-		"space_id": spaceId,
+		"content": content,
+		"type":    common.Text,
 	}
-	payload := []byte(util.ToJson(resultPayload))
-	_ = s.ctx.SendMessage(&config.MsgSendReq{
-		FromUID:     s.ctx.GetConfig().Account.SystemUID,
-		ChannelID:   applicantUID,
-		ChannelType: common.ChannelTypePerson.Uint8(),
-		Payload:     payload,
-		Header: config.MsgHeader{
-			RedDot: 1,
-		},
-	})
+	// YUJ-674 / Mininglamp-OSS#37: PERSONAL DM via NewPersonalMsgSendReq builder.
+	_ = s.ctx.SendMessage(config.NewPersonalMsgSendReq(
+		applicantUID,
+		s.ctx.GetConfig().Account.SystemUID,
+		resultPayload,
+		spaceId,
+		config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}},
+	))
 }
 
 // joinApprovePage 返回 H5 审批页面（注入 apiURL）

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -1410,18 +1410,19 @@ func (u *User) sentWelcomeMsg(publicIP, uid string) {
 		ipStr := fmt.Sprintf("本次登录的信息：%s %s", publicIP, util.ToyyyyMMddHHmmss(time.Now()))
 		sentContent = fmt.Sprintf("%s\n%s", content, ipStr)
 	}
-	err = u.ctx.SendMessage(&config.MsgSendReq{
-		FromUID:     u.ctx.GetConfig().Account.SystemUID,
-		ChannelID:   uid,
-		ChannelType: common.ChannelTypePerson.Uint8(),
-		Payload: []byte(util.ToJson(map[string]interface{}{
+	// YUJ-674 / Mininglamp-OSS#37: PERSONAL DM 走 NewPersonalMsgSendReq builder。
+	// SystemUID 是平台级账户，没有 Space 上下文 → senderSpaceID = ""，builder
+	// 会 fail-closed strip，与"系统欢迎消息不归属任何 Space"语义一致。
+	err = u.ctx.SendMessage(config.NewPersonalMsgSendReq(
+		uid,
+		u.ctx.GetConfig().Account.SystemUID,
+		map[string]interface{}{
 			"content": sentContent,
 			"type":    common.Text,
-		})),
-		Header: config.MsgHeader{
-			RedDot: 1,
 		},
-	})
+		"", // SystemUID is Space-agnostic; builder strips any client-supplied space_id.
+		config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}},
+	))
 	if err != nil {
 		u.Error("发送登录消息欢迎消息失败", zap.Error(err))
 	}

--- a/modules/user/api_friend.go
+++ b/modules/user/api_friend.go
@@ -947,24 +947,21 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 	if f.ctx.GetConfig().Friend.AddedTipsText != "" {
 		content = f.ctx.GetConfig().Friend.AddedTipsText
 	}
+	// YUJ-674 / Mininglamp-OSS#37: PERSONAL DM 用 octo-lib 的 NewPersonalMsgSendReq
+	// builder 构造，把 payload.space_id 的服务端权威 / fail-closed strip 语义集中
+	// 到一处。spaceID 已经通过上方 spacepkg.CheckMembership 校验，可以作为 senderSpaceID
+	// 直接传入。
 	tipPayloadMap := map[string]interface{}{
 		"content": content,
 		"type":    common.Tip,
 	}
-	if spaceID != "" {
-		tipPayloadMap["space_id"] = spaceID
-	}
-	payload := []byte(util.ToJson(tipPayloadMap))
-
-	err = f.ctx.SendMessage(&config.MsgSendReq{
-		FromUID:     loginUID,
-		ChannelID:   applyUID,
-		ChannelType: common.ChannelTypePerson.Uint8(),
-		Payload:     payload,
-		Header: config.MsgHeader{
-			RedDot: 1,
-		},
-	})
+	err = f.ctx.SendMessage(config.NewPersonalMsgSendReq(
+		applyUID, // channel = peer (DM target)
+		loginUID, // from = current user
+		tipPayloadMap,
+		spaceID,
+		config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}},
+	))
 	if err != nil {
 		f.Error("发送通过好友请求消息失败！", zap.Error(err))
 		c.ResponseError(errors.New("发送通过好友请求消息失败！"))
@@ -975,20 +972,13 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 		"content": remark,
 		"type":    common.Text,
 	}
-	if spaceID != "" {
-		remarkPayloadMap["space_id"] = spaceID
-	}
-	payload = []byte(util.ToJson(remarkPayloadMap))
-
-	err = f.ctx.SendMessage(&config.MsgSendReq{
-		FromUID:     applyUID,
-		ChannelID:   loginUID,
-		ChannelType: common.ChannelTypePerson.Uint8(),
-		Payload:     payload,
-		Header: config.MsgHeader{
-			RedDot: 1,
-		},
-	})
+	err = f.ctx.SendMessage(config.NewPersonalMsgSendReq(
+		loginUID, // channel = current user (mirror tip back to self thread)
+		applyUID, // from = applicant
+		remarkPayloadMap,
+		spaceID,
+		config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}},
+	))
 	if err != nil {
 		f.Error("发送接受好友请求消息失败！", zap.Error(err))
 		c.ResponseError(errors.New("发送接受好友请求消息失败！"))

--- a/modules/user/event_friend.go
+++ b/modules/user/event_friend.go
@@ -327,24 +327,21 @@ func (f *Friend) handleUserRegister(data []byte, commit config.EventCommit) {
 		content = f.ctx.GetConfig().Friend.AddedTipsText
 	}
 	// 发送消息
+	// YUJ-674 / Mininglamp-OSS#37: PERSONAL DM 走 NewPersonalMsgSendReq
+	// builder。evtSpaceID 由 space.GetCommonSpaceID 解析两个 UID 的共同 Space，
+	// 解析失败时为 ""，builder 会 fail-closed strip。
 	evtTipPayload := map[string]interface{}{
 		"content": content,
 		"type":    common.Tip,
 	}
-	if evtSpaceID != "" {
-		evtTipPayload["space_id"] = evtSpaceID
-	}
-	payload := []byte(util.ToJson(evtTipPayload))
 
-	err = f.ctx.SendMessage(&config.MsgSendReq{
-		FromUID:     uid,
-		ChannelID:   inviteUid,
-		ChannelType: common.ChannelTypePerson.Uint8(),
-		Payload:     payload,
-		Header: config.MsgHeader{
-			RedDot: 1,
-		},
-	})
+	err = f.ctx.SendMessage(config.NewPersonalMsgSendReq(
+		inviteUid,
+		uid,
+		evtTipPayload,
+		evtSpaceID,
+		config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}},
+	))
 	if err != nil {
 		f.Error("发送通过好友请求消息失败！", zap.Error(err))
 		commit(errors.New("发送通过好友请求消息失败！"))

--- a/modules/user/event_friend.go
+++ b/modules/user/event_friend.go
@@ -5,11 +5,11 @@ import (
 	"os"
 	"runtime/debug"
 
-	"github.com/Mininglamp-OSS/octo-server/modules/source"
-	"github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-server/modules/source"
+	"github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )

--- a/tools/lint-personal-msgsendreq/main.go
+++ b/tools/lint-personal-msgsendreq/main.go
@@ -1,0 +1,147 @@
+// Command lint-personal-msgsendreq scans .go files under one or more roots and
+// rejects direct config.MsgSendReq{} composite literals that explicitly set
+// ChannelType to common.ChannelTypePerson (or its .Uint8() variant). PERSONAL
+// DM dispatchers MUST go through config.NewPersonalMsgSendReq() in octo-lib so
+// payload.space_id authoritative semantics are uniformly applied.
+//
+// Background: Mininglamp-OSS/octo-server#37 (defense-in-depth wrapper for
+// PERSONAL MsgSendReq, follow-up to PR#35 / Mininglamp-OSS/octo-server#33).
+//
+// Usage:
+//
+//	go run ./tools/lint-personal-msgsendreq [root...]
+//
+// Defaults to scanning ./modules. Test files (*_test.go) are skipped because
+// tests sometimes need to construct adversarial / golden literals directly to
+// exercise the builder's fail-closed behavior.
+//
+// Exit codes: 0 (clean), 1 (violations), 2 (walk error).
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	roots := os.Args[1:]
+	if len(roots) == 0 {
+		roots = []string{"modules"}
+	}
+
+	fset := token.NewFileSet()
+	var violations []string
+
+	for _, root := range roots {
+		walkErr := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				// Defense-in-depth: skip vendored code and the lint tool itself.
+				name := info.Name()
+				if name == "vendor" || name == "tools" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") {
+				return nil
+			}
+			if strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			f, err := parser.ParseFile(fset, path, nil, 0)
+			if err != nil {
+				// Don't fail the lint on parse errors — `go build` / `go vet`
+				// is the canonical syntax check; we just want a clean signal
+				// from the AST when it parses.
+				return nil
+			}
+			ast.Inspect(f, func(n ast.Node) bool {
+				cl, ok := n.(*ast.CompositeLit)
+				if !ok {
+					return true
+				}
+				if !isMsgSendReqType(cl.Type) {
+					return true
+				}
+				for _, e := range cl.Elts {
+					kv, ok := e.(*ast.KeyValueExpr)
+					if !ok {
+						continue
+					}
+					key, ok := kv.Key.(*ast.Ident)
+					if !ok || key.Name != "ChannelType" {
+						continue
+					}
+					if containsPersonChannelType(kv.Value) {
+						pos := fset.Position(cl.Pos())
+						violations = append(violations,
+							fmt.Sprintf("%s:%d: direct PERSONAL MsgSendReq literal — use config.NewPersonalMsgSendReq()",
+								pos.Filename, pos.Line))
+					}
+				}
+				return true
+			})
+			return nil
+		})
+		if walkErr != nil {
+			fmt.Fprintf(os.Stderr, "walk %q failed: %v\n", root, walkErr)
+			os.Exit(2)
+		}
+	}
+
+	if len(violations) > 0 {
+		for _, v := range violations {
+			fmt.Println(v)
+		}
+		fmt.Printf("\nFound %d direct PERSONAL MsgSendReq literal(s).\n", len(violations))
+		fmt.Println("Use config.NewPersonalMsgSendReq(channelID, fromUID, payloadMap, senderSpaceID, opts) instead.")
+		fmt.Println("See https://github.com/Mininglamp-OSS/octo-server/issues/37.")
+		os.Exit(1)
+	}
+	fmt.Println("OK: no direct PERSONAL MsgSendReq literals.")
+}
+
+// isMsgSendReqType reports whether the composite literal type is
+// (*octolib*).MsgSendReq, MsgSendReq, or any selector ending in .MsgSendReq.
+func isMsgSendReqType(e ast.Expr) bool {
+	switch t := e.(type) {
+	case *ast.SelectorExpr:
+		return t.Sel != nil && t.Sel.Name == "MsgSendReq"
+	case *ast.Ident:
+		return t.Name == "MsgSendReq"
+	case *ast.StarExpr:
+		return isMsgSendReqType(t.X)
+	}
+	return false
+}
+
+// containsPersonChannelType reports whether the expression refers to
+// ChannelTypePerson anywhere (e.g. common.ChannelTypePerson.Uint8(),
+// ChannelTypePerson.Uint8(), or just ChannelTypePerson).
+func containsPersonChannelType(e ast.Expr) bool {
+	found := false
+	ast.Inspect(e, func(n ast.Node) bool {
+		switch t := n.(type) {
+		case *ast.Ident:
+			if t.Name == "ChannelTypePerson" {
+				found = true
+				return false
+			}
+		case *ast.SelectorExpr:
+			if t.Sel != nil && t.Sel.Name == "ChannelTypePerson" {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}

--- a/tools/lint-personal-msgsendreq/main.go
+++ b/tools/lint-personal-msgsendreq/main.go
@@ -28,6 +28,14 @@ import (
 	"strings"
 )
 
+// channelTypePersonValue is the numeric value that a direct integer literal
+// would have to use to bypass the symbolic ChannelTypePerson detection.
+// octo-lib's common.ChannelType iota starts at ChannelTypeNone=0, so
+// ChannelTypePerson==1. This is part of the public protocol surface and is
+// not expected to drift; if it ever does, the constant must be updated here
+// AND in the test fixture below.
+const channelTypePersonValue = "1"
+
 func main() {
 	roots := os.Args[1:]
 	if len(roots) == 0 {
@@ -125,7 +133,10 @@ func isMsgSendReqType(e ast.Expr) bool {
 
 // containsPersonChannelType reports whether the expression refers to
 // ChannelTypePerson anywhere (e.g. common.ChannelTypePerson.Uint8(),
-// ChannelTypePerson.Uint8(), or just ChannelTypePerson).
+// ChannelTypePerson.Uint8(), or just ChannelTypePerson) — OR uses the raw
+// numeric literal that ChannelTypePerson resolves to (currently 1). The
+// numeric form is included so a `ChannelType: 1` literal cannot quietly
+// bypass the guard; the lint is meant to be a durable CI backstop.
 func containsPersonChannelType(e ast.Expr) bool {
 	found := false
 	ast.Inspect(e, func(n ast.Node) bool {
@@ -137,6 +148,11 @@ func containsPersonChannelType(e ast.Expr) bool {
 			}
 		case *ast.SelectorExpr:
 			if t.Sel != nil && t.Sel.Name == "ChannelTypePerson" {
+				found = true
+				return false
+			}
+		case *ast.BasicLit:
+			if t.Kind == token.INT && t.Value == channelTypePersonValue {
 				found = true
 				return false
 			}

--- a/tools/lint-personal-msgsendreq/main_test.go
+++ b/tools/lint-personal-msgsendreq/main_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// walkComposites runs the same AST inspection the binary does and reports
+// per-composite results to a callback. Lives in *_test.go so it doesn't add
+// dead code to the production binary.
+func walkComposites(f *ast.File, cb func(typeMatched, valueMatched bool)) {
+	ast.Inspect(f, func(n ast.Node) bool {
+		cl, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		typeMatched := isMsgSendReqType(cl.Type)
+		valueMatched := false
+		for _, e := range cl.Elts {
+			kv, ok := e.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			key, ok := kv.Key.(*ast.Ident)
+			if !ok || key.Name != "ChannelType" {
+				continue
+			}
+			if containsPersonChannelType(kv.Value) {
+				valueMatched = true
+			}
+		}
+		cb(typeMatched, valueMatched)
+		return true
+	})
+}
+
+func parse(t *testing.T, src string) *ast.File {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "x.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return f
+}
+
+// PERSONAL literal must be detected (canonical migration target).
+func TestDetectsDirectPersonalMsgSendReq(t *testing.T) {
+	f := parse(t, `package x
+import (
+	"x/common"
+	"x/config"
+)
+func _() {
+	_ = &config.MsgSendReq{
+		ChannelType: common.ChannelTypePerson.Uint8(),
+	}
+}
+`)
+	hits := 0
+	walkComposites(f, func(typeMatched, valueMatched bool) {
+		if typeMatched && valueMatched {
+			hits++
+		}
+	})
+	if hits != 1 {
+		t.Fatalf("expected 1 PERSONAL MsgSendReq detection, got %d", hits)
+	}
+}
+
+// GROUP literal must NOT trip the lint (out of scope for the PERSONAL builder).
+func TestIgnoresGroupMsgSendReq(t *testing.T) {
+	f := parse(t, `package x
+import (
+	"x/common"
+	"x/config"
+)
+func _() {
+	_ = &config.MsgSendReq{
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+	}
+}
+`)
+	hits := 0
+	walkComposites(f, func(typeMatched, valueMatched bool) {
+		if typeMatched && valueMatched {
+			hits++
+		}
+	})
+	if hits != 0 {
+		t.Fatalf("expected 0 detections on GROUP literal, got %d", hits)
+	}
+}
+
+// Variable channel_type (e.g. message.ChannelType passthrough) must NOT trip
+// the lint — those sites need a runtime PERSONAL branch, which the code
+// already does (see modules/robot/event.go after the migration).
+func TestIgnoresVariableChannelType(t *testing.T) {
+	f := parse(t, `package x
+import "x/config"
+func _(ct uint8) {
+	_ = &config.MsgSendReq{
+		ChannelType: ct,
+	}
+}
+`)
+	hits := 0
+	walkComposites(f, func(typeMatched, valueMatched bool) {
+		if typeMatched && valueMatched {
+			hits++
+		}
+	})
+	if hits != 0 {
+		t.Fatalf("expected 0 detections on variable channel_type, got %d", hits)
+	}
+}

--- a/tools/lint-personal-msgsendreq/main_test.go
+++ b/tools/lint-personal-msgsendreq/main_test.go
@@ -116,3 +116,91 @@ func _(ct uint8) {
 		t.Fatalf("expected 0 detections on variable channel_type, got %d", hits)
 	}
 }
+
+// Numeric literal `ChannelType: 1` must be detected. ChannelTypePerson is
+// the iota value 1 in octo-lib/common.ChannelType, so a hand-written numeric
+// literal would otherwise quietly bypass the symbolic guard. Reviewer ask
+// (Jerry-Xin, PR#44 R1): make this lint a durable CI backstop.
+func TestDetectsNumericPersonChannelType(t *testing.T) {
+	f := parse(t, `package x
+import "x/config"
+func _() {
+	_ = &config.MsgSendReq{
+		ChannelType: 1,
+	}
+}
+`)
+	hits := 0
+	walkComposites(f, func(typeMatched, valueMatched bool) {
+		if typeMatched && valueMatched {
+			hits++
+		}
+	})
+	if hits != 1 {
+		t.Fatalf("expected 1 numeric PERSONAL detection, got %d", hits)
+	}
+}
+
+// uint8(1) cast literal — same trap as bare `1`, just dressed in a cast.
+func TestDetectsNumericPersonChannelTypeWithCast(t *testing.T) {
+	f := parse(t, `package x
+import "x/config"
+func _() {
+	_ = &config.MsgSendReq{
+		ChannelType: uint8(1),
+	}
+}
+`)
+	hits := 0
+	walkComposites(f, func(typeMatched, valueMatched bool) {
+		if typeMatched && valueMatched {
+			hits++
+		}
+	})
+	if hits != 1 {
+		t.Fatalf("expected 1 numeric-cast PERSONAL detection, got %d", hits)
+	}
+}
+
+// Numeric literal for GROUP (==2) must NOT trip the lint — GROUP DM is out
+// of scope for the PERSONAL builder migration.
+func TestIgnoresNumericGroupChannelType(t *testing.T) {
+	f := parse(t, `package x
+import "x/config"
+func _() {
+	_ = &config.MsgSendReq{
+		ChannelType: 2,
+	}
+}
+`)
+	hits := 0
+	walkComposites(f, func(typeMatched, valueMatched bool) {
+		if typeMatched && valueMatched {
+			hits++
+		}
+	})
+	if hits != 0 {
+		t.Fatalf("expected 0 detections on numeric GROUP literal, got %d", hits)
+	}
+}
+
+// Numeric literal in a non-MsgSendReq composite must NOT trip the lint
+// (defense-in-depth: the type guard in walkComposites must still gate the
+// numeric value match).
+func TestIgnoresNumericChannelTypeOnUnrelatedStruct(t *testing.T) {
+	f := parse(t, `package x
+type SomethingElse struct{ ChannelType uint8 }
+func _() {
+	_ = &SomethingElse{ChannelType: 1}
+}
+`)
+	hits := 0
+	walkComposites(f, func(typeMatched, valueMatched bool) {
+		if typeMatched && valueMatched {
+			hits++
+		}
+	})
+	if hits != 0 {
+		t.Fatalf("expected 0 detections on unrelated struct, got %d", hits)
+	}
+}


### PR DESCRIPTION
## Summary

Defense-in-depth wrapper for PERSONAL (`channel_type=1`) `MsgSendReq`
construction. Encodes the authoritative `payload.space_id` contract from
[#35][35] (closes #33) into a single octo-lib builder so PERSONAL DM
dispatchers no longer need to remember to call enrichment helpers manually.

## Why

[#35][35] closed `payload.space_id` authoritative-injection on 5 dispatch entry
points; deep review of #35 (recorded in [#37][37]) found ~10 additional
PERSONAL `MsgSendReq{}` literals that bypass the enrichment helpers and call
`ctx.SendMessage` / `ctx.SendMessageWithResult` directly. Not currently
exploitable (most run with sender SpaceID context, GROUP-scoped, or
internal-event-only) but each is a future bug waiting for a careless
caller — exactly how #33 came to exist.

[35]: https://github.com/Mininglamp-OSS/octo-server/pull/35
[37]: https://github.com/Mininglamp-OSS/octo-server/issues/37

## Migration analysis (per call site from #37)

| # | File:line | Channel type | Action | Reason / sender SpaceID source |
|---|-----------|--------------|--------|---------------------------------|
| 1 | `modules/user/api_friend.go:959` | PERSONAL (literal) | **migrated** | `spaceID` validated above by `spacepkg.CheckMembership` |
| 2 | `modules/user/api_friend.go:983` | PERSONAL (literal) | **migrated** | same `spaceID` |
| 3 | `modules/user/event_friend.go:339` | PERSONAL (literal) | **migrated** | `evtSpaceID = space.GetCommonSpaceID(ctx, uid, inviteUid)`; builder strips on empty |
| 4 | `modules/user/api.go:1413` | PERSONAL (literal) | **migrated** | SystemUID welcome — Space-agnostic; `senderSpaceID = ""` triggers fail-closed strip |
| 5 | `modules/notify/api.go:264` | PERSONAL (literal) | **migrated** | `req.SpaceID` from request body; per-goroutine map clone added (builder mutates the map) |
| 6 | `modules/channel/api.go:352` | **variable** | **PERSONAL branch added** that uses builder; GROUP fork preserved | PERSONAL: `spacepkg.GetSpaceID(c)`; non-PERSONAL relies on `enrichPayloadWithSpaceID` upstream (out of scope of #37) |
| 7 | `modules/app_bot/app_bot.go:1132` | PERSONAL (literal) | **migrated** | `spaceID` from App Bot Space resolution above |
| 8 | `modules/robot/event.go:115` | **variable** (`message.ChannelType`) | **PERSONAL branch added** that uses builder; GROUP fork preserved | PERSONAL: `rb.resolveBotActiveSpaceID(realUID)` |
| 9 | `modules/robot/event.go:314` | **variable** (`message.ChannelType`) | **PERSONAL branch added** that uses builder; GROUP fork preserved | PERSONAL: `rb.resolveBotActiveSpaceID(robotID)` |
| 10 | `modules/bot_api/threads.go:336` | **CommunityTopic** | **NOT migrated** | Authoritative `payload.space_id` for COMMUNITY_TOPIC comes from the `enrichPayloadWithSpaceIDCore` topic branch, which already covers parent-group lookup. Out of scope for the PERSONAL builder. |
| 11 | `modules/bot_api/groups.go:668` | **Group** | **NOT migrated** | Same — GROUP authoritative comes from `enrichPayloadWithSpaceIDCore`'s GROUP branch. Out of scope. |

## Bonus migrations (caught by the new lint)

The new lint tool flagged **8 additional** PERSONAL literals that #37 did not
enumerate. Migrated those too so the lint passes from day one:

| File:line | Sender SpaceID source |
|-----------|------------------------|
| `modules/botfather/api_apply.go:427` | `spaceID` (apply request) |
| `modules/botfather/api_apply.go:464` | `spaceID` (apply notify owner) |
| `modules/botfather/api_apply.go:492` | `spaceID` (apply notify applicant) |
| `modules/botfather/command.go:955` | `h.resolveSpaceID(toUID)` |
| `modules/botfather/friend_approve.go:245` | `applySpaceID` (approve flow) |
| `modules/botfather/welcome.go:119` | `spaceID` (welcome path) |
| `modules/space/api.go:1554` | `spaceId` (join-application notify) |
| `modules/space/api.go:1583` | `spaceId` (join-result notify) |

## CI lint check

New `tools/lint-personal-msgsendreq` binary AST-walks `./modules` and rejects
any `MsgSendReq{ChannelType: …ChannelTypePerson…}` composite literal. New
PERSONAL DM call sites either use the builder or fail CI. The lint covers
patterns that the issue body's grep-based regex would miss:
  - multi-line composite literals (`MsgSendReq{` and `ChannelType:` on
    separate lines),
  - qualified-vs-bare `ChannelTypePerson` selector forms,
  - and pointer/non-pointer composites (`&config.MsgSendReq{...}` vs
    `config.MsgSendReq{...}`).

Wired into `.github/workflows/ci.yml` as a new `Personal MsgSendReq Lint` job.
Self-tests cover three cases: PERSONAL detected, GROUP ignored, variable
channel_type ignored.

## Verification

```
$ go build ./...                                          # clean
$ go vet ./...                                            # clean
$ go run ./tools/lint-personal-msgsendreq ./modules
OK: no direct PERSONAL MsgSendReq literals.
$ go test ./tools/lint-personal-msgsendreq/...
ok  github.com/Mininglamp-OSS/octo-server/tools/lint-personal-msgsendreq
```

DB-dependent module tests not run locally; CI handles those. The pre-existing
`TestRobotApply_AutoApprove` infra failure is documented in #17 and reproduces
on the base branch — unrelated.

## ⚠️ Merge order

```
1. Mininglamp-OSS/octo-lib#9   ← merge first
2. (here) bump octo-lib pseudo-version in go.mod
3. Mininglamp-OSS/octo-server#XX (this PR)
```

This PR's `go.mod` still points at the pre-builder `octo-lib` pseudo-version,
so the build will fail in CI until step 2 is done. Reviewers can land the
review part of this PR first, then a single `go mod tidy` commit closes the
loop. Same workflow used for #35.

## Refs

- Refs #37
- Background: #33, #35
