### PR TITLE
chore: add Jerry-Xin and lml2468 as default code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,9 @@
-# Default owner
-* @yujiawei
+# Default owners — multiple maintainers so any one of them can satisfy
+# the "Require code-owner review" branch protection rule on PRs authored
+# by another default owner. Without multiple default owners, a PR by
+# @yujiawei (the original sole default owner) cannot satisfy the
+# required code-owner review without admin override.
+* @Jerry-Xin @lml2468 @yujiawei
 
 # Server (Go backend)
 /server/ @an9xyz @Jerry-Xin @yujiawei


### PR DESCRIPTION
## Why

The current `.github/CODEOWNERS` only lists `@yujiawei` as the default owner for `*`. Combined with the `main` branch protection rule `requireCodeOwnerReview: true`, any PR authored by `@yujiawei` cannot pass the gate without admin override, even when two other reviewers approve. This causes legitimate PRs (e.g. #43) to fall back to admin merge.

## Change

Expand the default owner list to `@Jerry-Xin @lml2468 @yujiawei`. After this change:

- A PR authored by any of the three default owners can be approved by either of the other two as the required code owner.
- No single owner can self-approve (existing GitHub behavior).
- Scoped rules (`/server/`, `/docs/`) are unchanged.

## Verification

After merge, PR#43 (currently blocked by code-owner gate despite two approvals from @Jerry-Xin and @lml2468) should reach `MERGEABLE / CLEAN`.

Governance hygiene change with no code impact.