### PR TITLE
fix(docker): bump build stage to golang:1.25 to match go.mod and CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #     build. The `2>/dev/null || echo dev` guard keeps the build green for
 #     OSS users without sacrificing the real version embed on internal builds.
 
-FROM golang:1.20 as build
+FROM golang:1.25 AS build
 
 ENV GOPROXY https://goproxy.cn,direct
 ENV GO111MODULE on
@@ -32,7 +32,7 @@ RUN GIT_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo unknown) && \
       -installsuffix cgo -o app ./main.go
 
 
-FROM alpine as prod
+FROM alpine AS prod
 COPY --from=build /etc/passwd /etc/passwd
 COPY --from=build /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 RUN mkdir -p /usr/share/zoneinfo/Asia && \


### PR DESCRIPTION
## Summary

PR #55 upgraded `go.mod` and GitHub Actions to Go 1.25, but the `Dockerfile` build stage was still pinned to `golang:1.20`, which causes:

- Local `docker build` to fail (`go.mod` requires `go 1.25` but the base image doesn't satisfy it)
- Any downstream CI that compiles via this Dockerfile (GitLab, image builds, etc.) to fail the same way

This PR bumps the build stage from `golang:1.20` to `golang:1.25` so the Dockerfile is aligned with `go.mod` and `.github/workflows/ci.yml`. It also uppercases both `FROM ... as ...` to `AS` to silence the BuildKit `FromAsCasing` warning.

`Dockerfile.ghcr` is runtime-only (`FROM debian:bookworm-slim`) and does not compile Go, so it does not need to change.

## Test plan

- [x] `docker build .` succeeds locally; resulting `/home/app` runs
- [x] `go build -v ./...` compiles cleanly under Go 1.25
- [x] `go vet ./...` reports no warnings
- [x] Full CI-mirrored test run: `go test -race -count=1 -timeout 5m <pkg>` per package against MySQL 8.0 + Redis 7 with `OCTO_MASTER_KEY` set — 54/54 packages green