### PR TITLE
feat(user): add is_bot/is_system fields and exclude filters to /manager/user/list

### DIFF
--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	common2 "github.com/Mininglamp-OSS/octo-server/modules/common"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	wkutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
@@ -555,32 +556,38 @@ func (m *Manager) list(c *wkhttp.Context) {
 	if strings.TrimSpace(onlineStr) != "" {
 		online = wkutil.ParseInt64OrDefault(onlineStr, -1)
 	}
+	// 默认不过滤，确保兼容旧前端；前端只在需要时显式传 1。
+	filter := userListFilter{
+		OnlineStatus:  int(online),
+		ExcludeBot:    c.Query("exclude_bot") == "1",
+		ExcludeSystem: c.Query("exclude_system") == "1",
+	}
 	pageIndex, pageSize := c.GetPage()
 	var userList []*managerUserModel
 	var count int64
 	if keyword == "" {
-		userList, err = m.db.queryUserListWithPage(uint64(pageSize), uint64(pageIndex), int(online))
+		userList, err = m.db.queryUserListWithPage(uint64(pageSize), uint64(pageIndex), filter)
 		if err != nil {
 			m.Error("查询用户列表报错", zap.Error(err))
 			c.ResponseError(err)
 			return
 		}
 
-		count, err = m.userDB.queryUserCount()
+		count, err = m.db.queryUserCount(filter)
 		if err != nil {
 			m.Error("查询用户数量错误", zap.Error(err))
 			c.ResponseError(errors.New("查询用户数量错误"))
 			return
 		}
 	} else {
-		userList, err = m.db.queryUserListWithPageAndKeyword(keyword, int(online), uint64(pageSize), uint64(pageIndex))
+		userList, err = m.db.queryUserListWithPageAndKeyword(keyword, uint64(pageSize), uint64(pageIndex), filter)
 		if err != nil {
 			m.Error("查询用户列表报错", zap.Error(err))
 			c.ResponseError(err)
 			return
 		}
 
-		count, err = m.db.queryUserCountWithKeyWord(keyword)
+		count, err = m.db.queryUserCountWithKeyWord(keyword, filter)
 		if err != nil {
 			m.Error("查询用户数量错误", zap.Error(err))
 			c.ResponseError(errors.New("查询用户数量错误"))
@@ -642,6 +649,10 @@ func (m *Manager) list(c *wkhttp.Context) {
 				lastOnlineTime = util.ToyyyyMMddHHmm(time.Unix(int64(respsdata[user.UID].LastOffline), 0))
 			}
 			showPhone := getShowPhoneNum(user.Phone)
+			isSystem := 0
+			if spacepkg.SystemBots[user.UID] {
+				isSystem = 1
+			}
 			result = append(result, &managerUserResp{
 				UID:      user.UID,
 				Username: user.Username,
@@ -662,6 +673,8 @@ func (m *Manager) list(c *wkhttp.Context) {
 				GiteeUID:       user.GiteeUID,
 				GithubUID:      user.GithubUID,
 				WXOpenid:       user.WXOpenid,
+				IsBot:          user.Robot,
+				IsSystem:       isSystem,
 			})
 			i++
 		}
@@ -1210,6 +1223,8 @@ type managerUserResp struct {
 	WXOpenid       string `json:"wx_openid"`  // 微信openid
 	GiteeUID       string `json:"gitee_uid"`  // gitee uid
 	GithubUID      string `json:"github_uid"` // github uid
+	IsBot          int    `json:"is_bot"`     // 0.否 1.是；来源 user.robot，与 /v1/robot/space_bots 一致
+	IsSystem       int    `json:"is_system"`  // 0.否 1.是；来源 pkg/space.SystemBots（botfather/u_10000/fileHelper/notification）
 }
 
 type managerFriendResp struct {

--- a/modules/user/api_manager_test.go
+++ b/modules/user/api_manager_test.go
@@ -297,6 +297,109 @@ func TestUserListByEmailKeyword(t *testing.T) {
 	}
 }
 
+// 后台需要区分三类账号：普通用户、Bot（user.robot=1）与系统账号
+// （pkg/space.SystemBots，如 fileHelper/u_10000/botfather/notification）。
+// 之前前端只能靠 username 后缀 _bot 推断 bot，存在撞名/伪装风险，
+// 因此 /v1/manager/user/list 必须在响应里显式带 is_bot/is_system，
+// 并提供 exclude_bot / exclude_system 查询参数以便后台筛除。
+func TestUserListBotAndSystemFlags(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	m := NewManager(ctx)
+	err := testutil.CleanAllTables(ctx)
+	assert.NoError(t, err)
+
+	err = ctx.Cache().Set(ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token, testutil.UID+"@test@"+string(wkhttp.SuperAdmin))
+	assert.NoError(t, err)
+
+	// 普通用户
+	err = m.userDB.Insert(&Model{
+		UID:      "user_normal_001",
+		ShortNo:  util.GenerUUID(),
+		Username: "normaluser",
+		Name:     "NormalUser",
+		Status:   1,
+		Password: util.MD5(util.MD5("111")),
+	})
+	assert.NoError(t, err)
+	// Bot：与 /v1/robot/space_bots 判定一致，user.robot=1
+	err = m.userDB.Insert(&Model{
+		UID:      "user_bot_001",
+		ShortNo:  util.GenerUUID(),
+		Username: "thirdpartybot",
+		Name:     "ThirdPartyBot",
+		Status:   1,
+		Robot:    1,
+		Password: util.MD5(util.MD5("222")),
+	})
+	assert.NoError(t, err)
+	// 系统账号：pkg/space.SystemBots 中固定的 UID
+	err = m.userDB.Insert(&Model{
+		UID:      "fileHelper",
+		ShortNo:  util.GenerUUID(),
+		Username: "fileHelper",
+		Name:     "FileHelper",
+		Status:   1,
+		Password: util.MD5(util.MD5("333")),
+	})
+	assert.NoError(t, err)
+
+	t.Run("default returns all with correct flags", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/v1/manager/user/list?page_index=1&page_size=10", nil)
+		req.Header.Set("token", testutil.Token)
+		s.GetRoute().ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		body := w.Body.String()
+		// 三个账号都在
+		assert.Contains(t, body, `"uid":"user_normal_001"`)
+		assert.Contains(t, body, `"uid":"user_bot_001"`)
+		assert.Contains(t, body, `"uid":"fileHelper"`)
+		// 字段一定出现（即使取 0 也要序列化出来）
+		assert.Contains(t, body, `"is_bot"`)
+		assert.Contains(t, body, `"is_system"`)
+
+		// 各账号自身的 flag 取值
+		assert.Regexp(t, `"uid":"user_normal_001"[^}]*"is_bot":0[^}]*"is_system":0|"uid":"user_normal_001"[^}]*"is_system":0[^}]*"is_bot":0`, body)
+		assert.Regexp(t, `"uid":"user_bot_001"[^}]*"is_bot":1`, body)
+		assert.Regexp(t, `"uid":"fileHelper"[^}]*"is_system":1`, body)
+	})
+
+	t.Run("exclude_bot filters out user.robot=1", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/v1/manager/user/list?page_index=1&page_size=10&exclude_bot=1", nil)
+		req.Header.Set("token", testutil.Token)
+		s.GetRoute().ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		body := w.Body.String()
+		assert.Contains(t, body, `"uid":"user_normal_001"`)
+		assert.Contains(t, body, `"uid":"fileHelper"`)
+		assert.NotContains(t, body, `"uid":"user_bot_001"`)
+	})
+
+	t.Run("exclude_system filters out SystemBots UIDs", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/v1/manager/user/list?page_index=1&page_size=10&exclude_system=1", nil)
+		req.Header.Set("token", testutil.Token)
+		s.GetRoute().ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		body := w.Body.String()
+		assert.Contains(t, body, `"uid":"user_normal_001"`)
+		assert.Contains(t, body, `"uid":"user_bot_001"`)
+		assert.NotContains(t, body, `"uid":"fileHelper"`)
+	})
+
+	t.Run("exclude_bot with keyword still filters bots", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/v1/manager/user/list?page_index=1&page_size=10&keyword=user_&exclude_bot=1", nil)
+		req.Header.Set("token", testutil.Token)
+		s.GetRoute().ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		body := w.Body.String()
+		assert.Contains(t, body, `"uid":"user_normal_001"`)
+		assert.NotContains(t, body, `"uid":"user_bot_001"`)
+	})
+}
+
 func TestUserDisablelist(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	s, ctx := testutil.NewTestServer()

--- a/modules/user/api_manager_test.go
+++ b/modules/user/api_manager_test.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -343,60 +344,115 @@ func TestUserListBotAndSystemFlags(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	t.Run("default returns all with correct flags", func(t *testing.T) {
+	// 响应解析成结构化数据，便于断言 count 与 list 一致 —— PR #62 review
+	// 反复强调"count/list 一致性"是这次重构的主旨，所以测试必须显式覆盖。
+	type userRow struct {
+		UID      string `json:"uid"`
+		IsBot    int    `json:"is_bot"`
+		IsSystem int    `json:"is_system"`
+	}
+	type listResp struct {
+		Count int64     `json:"count"`
+		List  []userRow `json:"list"`
+	}
+	doList := func(t *testing.T, query string) listResp {
+		t.Helper()
 		w := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/v1/manager/user/list?page_index=1&page_size=10", nil)
+		req, _ := http.NewRequest("GET", "/v1/manager/user/list?"+query, nil)
 		req.Header.Set("token", testutil.Token)
 		s.GetRoute().ServeHTTP(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
-		body := w.Body.String()
-		// 三个账号都在
-		assert.Contains(t, body, `"uid":"user_normal_001"`)
-		assert.Contains(t, body, `"uid":"user_bot_001"`)
-		assert.Contains(t, body, `"uid":"fileHelper"`)
-		// 字段一定出现（即使取 0 也要序列化出来）
-		assert.Contains(t, body, `"is_bot"`)
-		assert.Contains(t, body, `"is_system"`)
+		var resp listResp
+		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "response is not JSON: %s", w.Body.String())
+		return resp
+	}
+	uidsOf := func(rs []userRow) []string {
+		out := make([]string, 0, len(rs))
+		for _, r := range rs {
+			out = append(out, r.UID)
+		}
+		return out
+	}
+	findUID := func(rs []userRow, uid string) (userRow, bool) {
+		for _, r := range rs {
+			if r.UID == uid {
+				return r, true
+			}
+		}
+		return userRow{}, false
+	}
 
-		// 各账号自身的 flag 取值
-		assert.Regexp(t, `"uid":"user_normal_001"[^}]*"is_bot":0[^}]*"is_system":0|"uid":"user_normal_001"[^}]*"is_system":0[^}]*"is_bot":0`, body)
-		assert.Regexp(t, `"uid":"user_bot_001"[^}]*"is_bot":1`, body)
-		assert.Regexp(t, `"uid":"fileHelper"[^}]*"is_system":1`, body)
-	})
+	cases := []struct {
+		name        string
+		query       string
+		wantUIDs    []string // 期望响应包含的 UID（顺序无关）
+		notWantUIDs []string // 期望响应不应包含的 UID
+	}{
+		{
+			name:     "default returns all three",
+			query:    "page_index=1&page_size=10",
+			wantUIDs: []string{"user_normal_001", "user_bot_001", "fileHelper"},
+		},
+		{
+			name:        "exclude_bot filters user.robot=1",
+			query:       "page_index=1&page_size=10&exclude_bot=1",
+			wantUIDs:    []string{"user_normal_001", "fileHelper"},
+			notWantUIDs: []string{"user_bot_001"},
+		},
+		{
+			name:        "exclude_system filters SystemBots UIDs",
+			query:       "page_index=1&page_size=10&exclude_system=1",
+			wantUIDs:    []string{"user_normal_001", "user_bot_001"},
+			notWantUIDs: []string{"fileHelper"},
+		},
+		{
+			name:        "exclude_bot + keyword still filters bots",
+			query:       "page_index=1&page_size=10&keyword=user_&exclude_bot=1",
+			wantUIDs:    []string{"user_normal_001"},
+			notWantUIDs: []string{"user_bot_001"},
+		},
+		{
+			name:        "exclude_bot + exclude_system filters both",
+			query:       "page_index=1&page_size=10&exclude_bot=1&exclude_system=1",
+			wantUIDs:    []string{"user_normal_001"},
+			notWantUIDs: []string{"user_bot_001", "fileHelper"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := doList(t, tc.query)
+			gotUIDs := uidsOf(resp.List)
+			for _, uid := range tc.wantUIDs {
+				assert.Contains(t, gotUIDs, uid)
+			}
+			for _, uid := range tc.notWantUIDs {
+				assert.NotContains(t, gotUIDs, uid)
+			}
+			// list/count 一致 —— 测试用例样本量都小于 page_size，所以 count 必须
+			// 与返回的 list 长度一致；如果 count 端漏掉了某个 filter，这里会立刻挂掉。
+			assert.Equal(t, int64(len(resp.List)), resp.Count, "count must equal list length under the same filter")
+		})
+	}
 
-	t.Run("exclude_bot filters out user.robot=1", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/v1/manager/user/list?page_index=1&page_size=10&exclude_bot=1", nil)
-		req.Header.Set("token", testutil.Token)
-		s.GetRoute().ServeHTTP(w, req)
-		assert.Equal(t, http.StatusOK, w.Code)
-		body := w.Body.String()
-		assert.Contains(t, body, `"uid":"user_normal_001"`)
-		assert.Contains(t, body, `"uid":"fileHelper"`)
-		assert.NotContains(t, body, `"uid":"user_bot_001"`)
-	})
+	// 字段语义单测：分别校验三类账号的 is_bot/is_system 取值。
+	t.Run("flag values per account type", func(t *testing.T) {
+		resp := doList(t, "page_index=1&page_size=10")
+		normal, ok := findUID(resp.List, "user_normal_001")
+		assert.True(t, ok)
+		assert.Equal(t, 0, normal.IsBot)
+		assert.Equal(t, 0, normal.IsSystem)
 
-	t.Run("exclude_system filters out SystemBots UIDs", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/v1/manager/user/list?page_index=1&page_size=10&exclude_system=1", nil)
-		req.Header.Set("token", testutil.Token)
-		s.GetRoute().ServeHTTP(w, req)
-		assert.Equal(t, http.StatusOK, w.Code)
-		body := w.Body.String()
-		assert.Contains(t, body, `"uid":"user_normal_001"`)
-		assert.Contains(t, body, `"uid":"user_bot_001"`)
-		assert.NotContains(t, body, `"uid":"fileHelper"`)
-	})
+		bot, ok := findUID(resp.List, "user_bot_001")
+		assert.True(t, ok)
+		assert.Equal(t, 1, bot.IsBot)
+		assert.Equal(t, 0, bot.IsSystem)
 
-	t.Run("exclude_bot with keyword still filters bots", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/v1/manager/user/list?page_index=1&page_size=10&keyword=user_&exclude_bot=1", nil)
-		req.Header.Set("token", testutil.Token)
-		s.GetRoute().ServeHTTP(w, req)
-		assert.Equal(t, http.StatusOK, w.Code)
-		body := w.Body.String()
-		assert.Contains(t, body, `"uid":"user_normal_001"`)
-		assert.NotContains(t, body, `"uid":"user_bot_001"`)
+		// fileHelper 是系统账号但没有 user.robot=1 —— 这正是 is_bot 与
+		// is_system 设计为独立维度的关键 case（PR #62 review 共识）。
+		sys, ok := findUID(resp.List, "fileHelper")
+		assert.True(t, ok)
+		assert.Equal(t, 0, sys.IsBot)
+		assert.Equal(t, 1, sys.IsSystem)
 	})
 }
 

--- a/modules/user/db_manager.go
+++ b/modules/user/db_manager.go
@@ -3,8 +3,34 @@ package user
 import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/db"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"github.com/gocraft/dbr/v2"
 )
+
+// userListColumns 是 /manager/user/list 主查询的 SELECT 列表与 GROUP BY 列表
+// 二者必须一致，避免 ONLY_FULL_GROUP_BY 报错。`user.robot` 用于响应里的
+// is_bot 字段，与 /v1/robot/space_bots (modules/robot/api.go:1065) 判定口径一致。
+const userListColumns = "user.uid,user.name,user.username,user.email,user.status,user.phone,user.short_no,user.sex,user.is_destroy,user.created_at,user.gitee_uid,user.github_uid,user.wx_openid,user.robot"
+
+// userListFilter 汇总 manager 端列表查询的过滤维度，方便 list/count 复用同一套
+// WHERE 条件，避免分页 count 与实际 list 不一致。
+type userListFilter struct {
+	OnlineStatus  int  // -1 表示不过滤；0/1 过滤离线/在线
+	ExcludeBot    bool // 剔除 user.robot=1 的账号
+	ExcludeSystem bool // 剔除 pkg/space.SystemBots 中的系统 UID
+}
+
+// applyExcludes 把 exclude_bot / exclude_system 翻译成 WHERE 子句。
+// 不处理 OnlineStatus —— 那个只对 list 主查询有效，count 端不需要 JOIN user_online。
+func (f userListFilter) applyExcludes(stmt *dbr.SelectStmt) *dbr.SelectStmt {
+	if f.ExcludeBot {
+		stmt = stmt.Where("user.robot=0")
+	}
+	if f.ExcludeSystem {
+		stmt = stmt.Where("user.uid NOT IN ?", spacepkg.SystemBotList())
+	}
+	return stmt
+}
 
 type managerDB struct {
 	session *dbr.Session
@@ -27,46 +53,54 @@ func (m *managerDB) queryUserInfoWithNameAndPwd(username string) (*managerLoginM
 }
 
 // 获取用户列表
-func (m *managerDB) queryUserListWithPage(pageSize, page uint64, onelineStatus int) ([]*managerUserModel, error) {
-	// var users []*managerUserModel
-	// _, err := m.session.Select("*").From("user").Offset((page-1)*pageSize).Limit(pageSize).OrderDir("created_at", false).Load(&users)
-	// return users, err
-
+func (m *managerDB) queryUserListWithPage(pageSize, page uint64, f userListFilter) ([]*managerUserModel, error) {
 	var users []*managerUserModel
-	selectStm := m.session.Select("user.uid,user.name,user.username,user.email,user.status,user.phone,user.short_no,user.sex,user.is_destroy,user.created_at,user.gitee_uid,user.github_uid,user.wx_openid,max(user_online.online) online").From("user").LeftJoin("user_online", "user.uid=user_online.uid")
-	if onelineStatus != -1 {
-		selectStm = selectStm.Where("user_online.online=?", onelineStatus)
+	selectStm := m.session.Select(userListColumns+",max(user_online.online) online").From("user").LeftJoin("user_online", "user.uid=user_online.uid")
+	if f.OnlineStatus != -1 {
+		selectStm = selectStm.Where("user_online.online=?", f.OnlineStatus)
 	}
-	selectStm = selectStm.GroupBy("user.uid,user.name,user.username,user.email,user.status,user.phone,user.short_no,user.sex,user.is_destroy,user.created_at,user.gitee_uid,user.github_uid,user.wx_openid")
+	selectStm = f.applyExcludes(selectStm)
+	selectStm = selectStm.GroupBy(userListColumns)
 
-	// select  from user left join user_online on user.uid=user_online.uid where user_online.online=1  group by user.uid,user.name,user.status,user.phone,user.short_no,user.sex,user.is_destroy,user.created_at  limit 100
 	_, err := selectStm.Offset((page-1)*pageSize).Limit(pageSize).OrderDir("user.created_at", false).Load(&users)
 	return users, err
 }
 
 // 模糊查询用户列表
-// onelineStatus 在线状态 -1 为所有 0. 离线 1. 在线
-func (m *managerDB) queryUserListWithPageAndKeyword(keyword string, onelineStatus int, pageSize, page uint64) ([]*managerUserModel, error) {
+func (m *managerDB) queryUserListWithPageAndKeyword(keyword string, pageSize, page uint64, f userListFilter) ([]*managerUserModel, error) {
 	var users []*managerUserModel
 	like := "%" + keyword + "%"
 	// SSO/OIDC 用户的 user.username 仅在 phone 非空时被填充(api.go createUserWithRespAndTx)
 	// 邮箱登录场景下 username 为空,只能靠 user.email 定位用户,故 WHERE 必须包含 email。
-	selectStm := m.session.Select("user.uid,user.name,user.username,user.email,user.status,user.phone,user.short_no,user.sex,user.is_destroy,user.created_at,user.gitee_uid,user.github_uid,user.wx_openid,max(user_online.online) online").From("user").LeftJoin("user_online", "user.uid=user_online.uid").Where("user.name like ? or user.username like ? or user.uid like ? or user.phone like ? or user.short_no like ? or user.email like ?", like, like, like, like, like, like)
-	if onelineStatus != -1 {
-		selectStm = selectStm.Where("user_online.online=?", onelineStatus)
+	selectStm := m.session.Select(userListColumns+",max(user_online.online) online").From("user").LeftJoin("user_online", "user.uid=user_online.uid").Where("user.name like ? or user.username like ? or user.uid like ? or user.phone like ? or user.short_no like ? or user.email like ?", like, like, like, like, like, like)
+	if f.OnlineStatus != -1 {
+		selectStm = selectStm.Where("user_online.online=?", f.OnlineStatus)
 	}
-	selectStm = selectStm.GroupBy("user.uid,user.name,user.username,user.email,user.status,user.phone,user.short_no,user.sex,user.is_destroy,user.created_at,user.gitee_uid,user.github_uid,user.wx_openid")
+	selectStm = f.applyExcludes(selectStm)
+	selectStm = selectStm.GroupBy(userListColumns)
 
-	// select  from user left join user_online on user.uid=user_online.uid where user_online.online=1  group by user.uid,user.name,user.status,user.phone,user.short_no,user.sex,user.is_destroy,user.created_at  limit 100
 	_, err := selectStm.Offset((page-1)*pageSize).Limit(pageSize).OrderDir("user.created_at", false).Load(&users)
 	return users, err
 }
 
+// 用户总数（带过滤）— 与 queryUserListWithPage 走相同的 ExcludeBot/ExcludeSystem 条件，
+// 保证 count 与 list 的样本一致，不会出现"列表少于 count"的分页错位。
+// 不带 keyword 时的 count 也走这里，不再调用 DB.queryUserCount（那个无法感知过滤）。
+func (m *managerDB) queryUserCount(f userListFilter) (int64, error) {
+	var count int64
+	stmt := m.session.Select("count(*)").From("user")
+	stmt = f.applyExcludes(stmt)
+	_, err := stmt.Load(&count)
+	return count, err
+}
+
 // 模糊查询用户数量
-func (m *managerDB) queryUserCountWithKeyWord(keyword string) (int64, error) {
+func (m *managerDB) queryUserCountWithKeyWord(keyword string, f userListFilter) (int64, error) {
 	var count int64
 	like := "%" + keyword + "%"
-	_, err := m.session.Select("count(*)").From("user").Where("user.name like ? or user.username like ? or user.uid like ? or user.phone like ? or user.short_no like ? or user.email like ?", like, like, like, like, like, like).Load(&count)
+	stmt := m.session.Select("count(*)").From("user").Where("user.name like ? or user.username like ? or user.uid like ? or user.phone like ? or user.short_no like ? or user.email like ?", like, like, like, like, like, like)
+	stmt = f.applyExcludes(stmt)
+	_, err := stmt.Load(&count)
 	return count, err
 }
 
@@ -134,6 +168,7 @@ type managerUserModel struct {
 	GithubUID string // github uid
 	Sex       int
 	IsDestroy int
+	Robot     int // 0.否 1.是；与 /v1/robot/space_bots 判定一致
 	db.BaseModel
 }
 

--- a/modules/user/swagger/api.yaml
+++ b/modules/user/swagger/api.yaml
@@ -137,6 +137,16 @@ paths:
           type: integer
           description: "在线状态 -1为所有 0.离线 1.在线"
           required: true
+        - in: "query"
+          name: "exclude_bot"
+          type: integer
+          description: "是否排除 Bot 账号(user.robot=1) 0.否(默认) 1.是"
+          required: false
+        - in: "query"
+          name: "exclude_system"
+          type: integer
+          description: "是否排除系统内置账号(botfather/u_10000/fileHelper/notification) 0.否(默认) 1.是"
+          required: false
       responses:
         200:
           description: "返回"
@@ -2446,6 +2456,12 @@ definitions:
       github_uid:
         type: string
         description: "GitHub授权登录返回"
+      is_bot:
+        type: integer
+        description: "是否为 Bot 账号 0.否 1.是；来源 user.robot，与 /v1/robot/space_bots 判定一致"
+      is_system:
+        type: integer
+        description: "是否为系统内置账号 0.否 1.是；当前覆盖 botfather/u_10000/fileHelper/notification"
   UserLoginReq:
     type: "object"
     properties:

--- a/modules/user/swagger/api.yaml
+++ b/modules/user/swagger/api.yaml
@@ -140,12 +140,12 @@ paths:
         - in: "query"
           name: "exclude_bot"
           type: integer
-          description: "是否排除 Bot 账号(user.robot=1) 0.否(默认) 1.是"
+          description: "是否排除 Bot 账号(user.robot=1) 0.否(默认) 1.是。与 exclude_system 是独立维度；如需排除所有非自然人账号，请同时传 exclude_bot=1&exclude_system=1"
           required: false
         - in: "query"
           name: "exclude_system"
           type: integer
-          description: "是否排除系统内置账号(botfather/u_10000/fileHelper/notification) 0.否(默认) 1.是"
+          description: "是否排除系统内置账号(botfather/u_10000/fileHelper/notification) 0.否(默认) 1.是。注意系统账号未必同时是 Bot（如 botfather 自身 user.robot=0），如需排除所有非自然人账号请配合 exclude_bot=1"
           required: false
       responses:
         200:
@@ -2458,10 +2458,10 @@ definitions:
         description: "GitHub授权登录返回"
       is_bot:
         type: integer
-        description: "是否为 Bot 账号 0.否 1.是；来源 user.robot，与 /v1/robot/space_bots 判定一致"
+        description: "是否为 Bot 账号 0.否 1.是；来源 user.robot，与 /v1/robot/space_bots 判定一致。与 is_system 是独立维度——系统账号（如 botfather）可能 is_system=1, is_bot=0"
       is_system:
         type: integer
-        description: "是否为系统内置账号 0.否 1.是；当前覆盖 botfather/u_10000/fileHelper/notification"
+        description: "是否为系统内置账号 0.否 1.是；当前覆盖 botfather/u_10000/fileHelper/notification。与 is_bot 是独立维度——前端如需识别所有非自然人账号，应取 is_bot=1 或 is_system=1 的并集"
   UserLoginReq:
     type: "object"
     properties:


### PR DESCRIPTION
## Summary

- `/v1/manager/user/list` response now carries `is_bot` and `is_system` so the admin UI no longer has to infer bot accounts from the `_bot` username suffix (fragile against collisions / impersonation).
- New optional query params `exclude_bot=1` and `exclude_system=1` let the caller filter those accounts out server-side.
- Both flags default to off — existing clients see no behavior change.

## Why

- `is_bot` is sourced from `user.robot`, the same predicate `/v1/robot/space_bots` already uses (`modules/robot/api.go:1064-1066`), keeping bot identification consistent across the codebase.
- `is_system` is sourced from `pkg/space.SystemBots`, the single authoritative list of built-in UIDs (`botfather`, `u_10000`, `fileHelper`, `notification`).
- The two flags are intentionally orthogonal: a system bot like `botfather` is both `is_system=1` and `is_bot=1`.

## Notable detail

The no-keyword count path previously called `DB.queryUserCount()`, which ignored every filter. Once `exclude_*` is on, that would have produced "count larger than the list" pagination drift. This PR routes both the list and count through the same `userListFilter` so the two stay consistent.

## Test plan

- [x] `go test -race ./modules/user/...` — new `TestUserListBotAndSystemFlags` covers default response shape, `exclude_bot`, `exclude_system`, and `exclude_bot + keyword`. Existing `TestUserListByUsernameKeyword` / `TestUserListByEmailKeyword` still pass.
- [x] `go vet ./modules/user/...`
- [x] `go build ./...`
- [ ] Manual smoke against admin UI once merged into the deploy pipeline.