### PR TITLE
feat(user): add bot_only/system_only inclusive filters to /manager/user/list

### DIFF
--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -561,6 +561,19 @@ func (m *Manager) list(c *wkhttp.Context) {
 		OnlineStatus:  int(online),
 		ExcludeBot:    c.Query("exclude_bot") == "1",
 		ExcludeSystem: c.Query("exclude_system") == "1",
+		BotOnly:       c.Query("bot_only") == "1",
+		SystemOnly:    c.Query("system_only") == "1",
+	}
+	// 互斥校验：bot_only 与 exclude_bot、system_only 与 exclude_system 同时存在
+	// 是逻辑矛盾，会得到空结果集。返回 400 让前端及早发现 query 构造 bug，
+	// 比静默返回空更好。允许 bot_only + system_only（交集语义清晰）。
+	if filter.BotOnly && filter.ExcludeBot {
+		c.ResponseError(errors.New("bot_only 与 exclude_bot 互斥"))
+		return
+	}
+	if filter.SystemOnly && filter.ExcludeSystem {
+		c.ResponseError(errors.New("system_only 与 exclude_system 互斥"))
+		return
 	}
 	pageIndex, pageSize := c.GetPage()
 	var userList []*managerUserModel

--- a/modules/user/api_manager_test.go
+++ b/modules/user/api_manager_test.go
@@ -343,6 +343,19 @@ func TestUserListBotAndSystemFlags(t *testing.T) {
 		Password: util.MD5(util.MD5("333")),
 	})
 	assert.NoError(t, err)
+	// 系统账号 + Bot 同时成立的关键 case（is_bot=1 & is_system=1）。
+	// 生产环境数据印证：botfather/u_10000/notification 都是 robot=1 的系统账号，
+	// bot_only=1&system_only=1 必须能精准命中这种交集账号。
+	err = m.userDB.Insert(&Model{
+		UID:      "botfather",
+		ShortNo:  util.GenerUUID(),
+		Username: "botfather",
+		Name:     "BotFather",
+		Status:   1,
+		Robot:    1,
+		Password: util.MD5(util.MD5("444")),
+	})
+	assert.NoError(t, err)
 
 	// 响应解析成结构化数据，便于断言 count 与 list 一致 —— PR #62 review
 	// 反复强调"count/list 一致性"是这次重构的主旨，所以测试必须显式覆盖。
@@ -389,21 +402,21 @@ func TestUserListBotAndSystemFlags(t *testing.T) {
 		notWantUIDs []string // 期望响应不应包含的 UID
 	}{
 		{
-			name:     "default returns all three",
+			name:     "default returns all four",
 			query:    "page_index=1&page_size=10",
-			wantUIDs: []string{"user_normal_001", "user_bot_001", "fileHelper"},
+			wantUIDs: []string{"user_normal_001", "user_bot_001", "fileHelper", "botfather"},
 		},
 		{
 			name:        "exclude_bot filters user.robot=1",
 			query:       "page_index=1&page_size=10&exclude_bot=1",
 			wantUIDs:    []string{"user_normal_001", "fileHelper"},
-			notWantUIDs: []string{"user_bot_001"},
+			notWantUIDs: []string{"user_bot_001", "botfather"},
 		},
 		{
 			name:        "exclude_system filters SystemBots UIDs",
 			query:       "page_index=1&page_size=10&exclude_system=1",
 			wantUIDs:    []string{"user_normal_001", "user_bot_001"},
-			notWantUIDs: []string{"fileHelper"},
+			notWantUIDs: []string{"fileHelper", "botfather"},
 		},
 		{
 			name:        "exclude_bot + keyword still filters bots",
@@ -415,7 +428,35 @@ func TestUserListBotAndSystemFlags(t *testing.T) {
 			name:        "exclude_bot + exclude_system filters both",
 			query:       "page_index=1&page_size=10&exclude_bot=1&exclude_system=1",
 			wantUIDs:    []string{"user_normal_001"},
-			notWantUIDs: []string{"user_bot_001", "fileHelper"},
+			notWantUIDs: []string{"user_bot_001", "fileHelper", "botfather"},
+		},
+		// bot_only / system_only：前端"只看 Bot""只看系统账号"档位需要的反向筛选。
+		// 没有这两个参数时前端只能客户端过滤当前页，会导致 total 与可见行数不一致。
+		{
+			name:        "bot_only returns all robot=1 (including system bots)",
+			query:       "page_index=1&page_size=10&bot_only=1",
+			wantUIDs:    []string{"user_bot_001", "botfather"},
+			notWantUIDs: []string{"user_normal_001", "fileHelper"},
+		},
+		{
+			name:        "system_only returns all SystemBots UIDs",
+			query:       "page_index=1&page_size=10&system_only=1",
+			wantUIDs:    []string{"fileHelper", "botfather"},
+			notWantUIDs: []string{"user_normal_001", "user_bot_001"},
+		},
+		{
+			name:        "bot_only + exclude_system narrows to user-created bots",
+			query:       "page_index=1&page_size=10&bot_only=1&exclude_system=1",
+			wantUIDs:    []string{"user_bot_001"},
+			notWantUIDs: []string{"user_normal_001", "fileHelper", "botfather"},
+		},
+		// 交集：既是 Bot 又是系统账号 —— botfather 是这种账号的代表。
+		// 这是 bot_only 和 system_only 共存的唯一有意义组合，因此显式覆盖。
+		{
+			name:        "bot_only + system_only returns intersection",
+			query:       "page_index=1&page_size=10&bot_only=1&system_only=1",
+			wantUIDs:    []string{"botfather"},
+			notWantUIDs: []string{"user_normal_001", "user_bot_001", "fileHelper"},
 		},
 	}
 	for _, tc := range cases {
@@ -434,7 +475,7 @@ func TestUserListBotAndSystemFlags(t *testing.T) {
 		})
 	}
 
-	// 字段语义单测：分别校验三类账号的 is_bot/is_system 取值。
+	// 字段语义单测：分别校验四类账号的 is_bot/is_system 取值。
 	t.Run("flag values per account type", func(t *testing.T) {
 		resp := doList(t, "page_index=1&page_size=10")
 		normal, ok := findUID(resp.List, "user_normal_001")
@@ -453,7 +494,32 @@ func TestUserListBotAndSystemFlags(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, 0, sys.IsBot)
 		assert.Equal(t, 1, sys.IsSystem)
+
+		// botfather：交集账号，is_bot=1 且 is_system=1 同时成立。
+		bf, ok := findUID(resp.List, "botfather")
+		assert.True(t, ok)
+		assert.Equal(t, 1, bf.IsBot)
+		assert.Equal(t, 1, bf.IsSystem)
 	})
+
+	// 互斥校验：bot_only 与 exclude_bot、system_only 与 exclude_system 同时为 1
+	// 是逻辑矛盾，返回 400 比静默返回空更利于前端发现 bug。
+	conflictCases := []struct {
+		name  string
+		query string
+	}{
+		{"bot_only conflicts with exclude_bot", "page_index=1&page_size=10&bot_only=1&exclude_bot=1"},
+		{"system_only conflicts with exclude_system", "page_index=1&page_size=10&system_only=1&exclude_system=1"},
+	}
+	for _, tc := range conflictCases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/v1/manager/user/list?"+tc.query, nil)
+			req.Header.Set("token", testutil.Token)
+			s.GetRoute().ServeHTTP(w, req)
+			assert.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+		})
+	}
 }
 
 func TestUserDisablelist(t *testing.T) {

--- a/modules/user/db_manager.go
+++ b/modules/user/db_manager.go
@@ -14,13 +14,19 @@ const userListColumns = "user.uid,user.name,user.username,user.email,user.status
 
 // userListFilter 汇总 manager 端列表查询的过滤维度，方便 list/count 复用同一套
 // WHERE 条件，避免分页 count 与实际 list 不一致。
+//
+// Exclude* 与 *Only 是对称的两个方向：前者用于"全部里剔除某类"，后者用于"只看某类"。
+// 互斥校验由 handler 负责（同时传 ExcludeBot 与 BotOnly 应直接拒绝），DB 层只
+// 老实拼接 WHERE，不做语义合法性判断。
 type userListFilter struct {
 	OnlineStatus  int  // -1 表示不过滤；0/1 过滤离线/在线
 	ExcludeBot    bool // 剔除 user.robot=1 的账号
 	ExcludeSystem bool // 剔除 pkg/space.SystemBots 中的系统 UID
+	BotOnly       bool // 仅返回 user.robot=1 的账号
+	SystemOnly    bool // 仅返回 pkg/space.SystemBots 中的系统 UID
 }
 
-// applyExcludes 把 exclude_bot / exclude_system 翻译成 WHERE 子句。
+// applyExcludes 把账号过滤维度翻译成 WHERE 子句（exclude_* 与 *_only 同处）。
 // 不处理 OnlineStatus —— 那个只对 list 主查询有效，count 端不需要 JOIN user_online。
 func (f userListFilter) applyExcludes(stmt *dbr.SelectStmt) *dbr.SelectStmt {
 	if f.ExcludeBot {
@@ -28,6 +34,12 @@ func (f userListFilter) applyExcludes(stmt *dbr.SelectStmt) *dbr.SelectStmt {
 	}
 	if f.ExcludeSystem {
 		stmt = stmt.Where("user.uid NOT IN ?", spacepkg.SystemBotList())
+	}
+	if f.BotOnly {
+		stmt = stmt.Where("user.robot=1")
+	}
+	if f.SystemOnly {
+		stmt = stmt.Where("user.uid IN ?", spacepkg.SystemBotList())
 	}
 	return stmt
 }

--- a/modules/user/swagger/api.yaml
+++ b/modules/user/swagger/api.yaml
@@ -140,12 +140,22 @@ paths:
         - in: "query"
           name: "exclude_bot"
           type: integer
-          description: "是否排除 Bot 账号(user.robot=1) 0.否(默认) 1.是。与 exclude_system 是独立维度；如需排除所有非自然人账号，请同时传 exclude_bot=1&exclude_system=1"
+          description: "是否排除 Bot 账号(user.robot=1) 0.否(默认) 1.是。与 exclude_system 是独立维度；如需排除所有非自然人账号，请同时传 exclude_bot=1&exclude_system=1。与 bot_only 互斥（同时传返回 400）"
           required: false
         - in: "query"
           name: "exclude_system"
           type: integer
-          description: "是否排除系统内置账号(botfather/u_10000/fileHelper/notification) 0.否(默认) 1.是。注意系统账号未必同时是 Bot（如 botfather 自身 user.robot=0），如需排除所有非自然人账号请配合 exclude_bot=1"
+          description: "是否排除系统内置账号(botfather/u_10000/fileHelper/notification) 0.否(默认) 1.是。注意系统账号未必同时是 Bot（如 fileHelper 自身 user.robot=0），如需排除所有非自然人账号请配合 exclude_bot=1。与 system_only 互斥（同时传返回 400）"
+          required: false
+        - in: "query"
+          name: "bot_only"
+          type: integer
+          description: "仅返回 Bot 账号(user.robot=1) 0.否(默认) 1.是。与 exclude_bot 互斥。可与 exclude_system=1 组合得到非系统 Bot；可与 system_only=1 组合得到既是 Bot 又是系统账号的交集"
+          required: false
+        - in: "query"
+          name: "system_only"
+          type: integer
+          description: "仅返回系统内置账号(botfather/u_10000/fileHelper/notification) 0.否(默认) 1.是。与 exclude_system 互斥。可与 bot_only=1 组合定位系统 Bot"
           required: false
       responses:
         200:

--- a/modules/user/swagger/api.yaml
+++ b/modules/user/swagger/api.yaml
@@ -2468,7 +2468,7 @@ definitions:
         description: "GitHub授权登录返回"
       is_bot:
         type: integer
-        description: "是否为 Bot 账号 0.否 1.是；来源 user.robot，与 /v1/robot/space_bots 判定一致。与 is_system 是独立维度——系统账号（如 botfather）可能 is_system=1, is_bot=0"
+        description: "是否为 Bot 账号 0.否 1.是；来源 user.robot，与 /v1/robot/space_bots 判定一致。与 is_system 是独立维度——系统账号（如 fileHelper）可能 is_system=1, is_bot=0"
       is_system:
         type: integer
         description: "是否为系统内置账号 0.否 1.是；当前覆盖 botfather/u_10000/fileHelper/notification。与 is_bot 是独立维度——前端如需识别所有非自然人账号，应取 is_bot=1 或 is_system=1 的并集"


### PR DESCRIPTION
## Summary

PR #62 shipped the **exclusive** filtering direction (`exclude_bot`, `exclude_system`). The admin UI's "only show bots" / "only show system accounts" filter options still had no backend support, forcing the frontend into client-side filtering of the current page only. This silently broke pagination — `count` stayed at the unfiltered total while visible rows could drop to zero.

- Add `bot_only=1` and `system_only=1` as the inclusive complements.
- Reject the contradictory combinations (`bot_only=1&exclude_bot=1`, `system_only=1&exclude_system=1`) with HTTP 400; an empty result would have hidden the caller's bug.
- Allow `bot_only=1&system_only=1` as the well-defined intersection (system accounts that are also `robot=1`, e.g. `botfather` in prod).

## Param matrix

| Use case | Query |
|---|---|
| All accounts | (defaults) |
| Real users only | `exclude_bot=1&exclude_system=1` |
| Bots only (incl. system bots) | `bot_only=1` |
| User-created bots only | `bot_only=1&exclude_system=1` |
| System accounts only | `system_only=1` |
| System accounts that are bots | `bot_only=1&system_only=1` |

## Notable detail

The filter struct stays the single source of truth — `list` and `count` queries both pass through `applyExcludes`, so the count/list consistency guarantee from PR #62 extends to the new params with zero extra wiring.

## Test plan

- [x] `go test -race ./modules/user/...` — table-driven test now covers 9 filter combos; two extra subtests assert `400` for the contradictory combinations.
- [x] `go vet ./modules/user/...`
- [x] `go build ./...`
- [ ] Manual smoke against the admin UI once deployed.

## Frontend follow-up (out of scope, please coordinate)

The current admin UI does client-side filtering on the page payload, which is the bug that prompted this PR. The frontend should migrate every filter dropdown to a backend query param so `count` and `list` stay in sync.