### PR TITLE
fix(wukongim): pass managerToken header on /route + /message/search

### DIFF
--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -1180,7 +1180,11 @@ func (m *Message) search(c *wkhttp.Context) {
 		spaceID = c.GetHeader("X-Space-ID")
 	}
 
-	resp, err := network.Post(fmt.Sprintf("%s/message/search", m.ctx.GetConfig().WuKongIM.APIURL), []byte(util.ToJson(req)), nil)
+	headers := map[string]string{"Content-Type": "application/json"}
+	if mt := m.ctx.GetConfig().WuKongIM.ManagerToken; mt != "" {
+		headers["token"] = mt
+	}
+	resp, err := network.Post(fmt.Sprintf("%s/message/search", m.ctx.GetConfig().WuKongIM.APIURL), []byte(util.ToJson(req)), headers)
 	if err != nil {
 		m.Error("调用搜索失败！", zap.Error(err))
 		c.ResponseError(errors.New("调用搜索失败！"))

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -629,7 +629,11 @@ func (u *User) uploadAvatar(c *wkhttp.Context) {
 // 获取用户的IM连接地址
 func (u *User) userIM(c *wkhttp.Context) {
 	uid := c.Param("uid")
-	resp, err := network.Get(fmt.Sprintf("%s/route?uid=%s", u.ctx.GetConfig().WuKongIM.APIURL, uid), nil, nil)
+	headers := map[string]string{}
+	if mt := u.ctx.GetConfig().WuKongIM.ManagerToken; mt != "" {
+		headers["token"] = mt
+	}
+	resp, err := network.Get(fmt.Sprintf("%s/route?uid=%s", u.ctx.GetConfig().WuKongIM.APIURL, uid), nil, headers)
 	if err != nil {
 		u.Error("调用IM服务失败！", zap.Error(err))
 		c.ResponseError(errors.New("调用IM服务失败！"))


### PR DESCRIPTION
## Summary

Two call sites to WuKongIM manager API were passing `nil` for the headers map, causing 401 when `wk.yaml` has `tokenAuthOn: true` (the safe default in `Mininglamp-OSS/octo-deployment`). This broke the default web client flow immediately after login (`{"msg":"EOF","status":400}` on `GET /v1/users/:uid/im`).

Fixes #64

## Changes

- `modules/user/api.go:userIM` — inject `headers["token"] = ManagerToken` before calling `network.Get("/route?uid=...")`.
- `modules/message/api.go:messageSearch` — same pattern, plus existing `Content-Type: application/json` header preserved.

Both match the existing correct pattern in `modules/notify/bot_manager.go:syncBotNameToWuKongIM`.

## Verification

Local build + drop-in replace into `octo-deployment` stack with `tokenAuthOn: true`:

**Before** (`mininglamposs/octo-server:latest`):
```
$ curl /api/v1/users/admin/im -H "token: <user>"
{"msg":"EOF","status":400}

$ docker exec octo-server wget /route?uid=admin   # no header
401 Unauthorized
```

**After** (with this patch):
```
$ curl /api/v1/users/admin/im -H "token: <user>"
{"tcp_addr":"34.81.189.173:5100","ws_addr":"ws://im-test.xming.ai:28080/ws","wss_addr":""}

$ docker logs octo-server | grep /users/.*/im
[GIN] GET /v1/users/admin/im | 200
```

Web client successfully establishes WSS connection after login.

## Note for reviewers

Worth a follow-up grep audit for other `network.Get/Post(...WuKongIM.APIURL...)` call sites to ensure header parity across the codebase. This PR addresses the two that break default login; bulk audit can be a separate PR.