### PR TITLE
feat(voice): return request_id in transcribe API response

### DIFF
--- a/modules/voice/api.go
+++ b/modules/voice/api.go
@@ -1,7 +1,10 @@
 package voice
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -173,28 +176,39 @@ func (v *Voice) transcribe(c *wkhttp.Context) {
 
 	if err != nil {
 		v.Error("transcription failed", zap.Error(err))
+		var requestID string
 		if v.asrLogger != nil {
 			entry := v.buildASREntry("app", effectiveMode, audioData, mimeType, contextText, origChatContext,
 				personalContext, memberContext, channelType, startTime, durationMs, result, err)
+			requestID = entry.RequestID
 			v.asrLogger.Enqueue(entry)
+		} else {
+			requestID = generateFallbackRequestID()
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{
-			"status": http.StatusInternalServerError,
-			"msg":    "transcription failed",
+			"status":     http.StatusInternalServerError,
+			"msg":        "transcription failed",
+			"request_id": requestID,
 		})
 		return
 	}
 
+	var requestID string
 	if v.asrLogger != nil {
-		v.asrLogger.Enqueue(v.buildASREntry("app", effectiveMode, audioData, mimeType, contextText, origChatContext,
-			personalContext, memberContext, channelType, startTime, durationMs, result, nil))
+		entry := v.buildASREntry("app", effectiveMode, audioData, mimeType, contextText, origChatContext,
+			personalContext, memberContext, channelType, startTime, durationMs, result, nil)
+		requestID = entry.RequestID
+		v.asrLogger.Enqueue(entry)
+	} else {
+		requestID = generateFallbackRequestID()
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"status": http.StatusOK,
-		"text":   result.Text,
-		"m":      shortenModelName(result.Model),
-		"engine": ShortenEngineName(v.cfg.Engine),
+		"status":     http.StatusOK,
+		"text":       result.Text,
+		"m":          shortenModelName(result.Model),
+		"engine":     ShortenEngineName(v.cfg.Engine),
+		"request_id": requestID,
 	})
 }
 
@@ -303,6 +317,12 @@ func (v *Voice) getContext(c *wkhttp.Context) {
 
 func shortenModelName(model string) string {
 	return ShortenModelName(model)
+}
+
+func generateFallbackRequestID() string {
+	b := make([]byte, 3)
+	rand.Read(b)
+	return fmt.Sprintf("nolog_%d_%s", time.Now().UTC().UnixMilli(), hex.EncodeToString(b))
 }
 
 // ShortenEngineName returns a short identifier for an engine name.

--- a/modules/voice/api_test.go
+++ b/modules/voice/api_test.go
@@ -1192,6 +1192,84 @@ func TestTranscribeAPI_ModeEditOnly_GPTEngineRejected(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "edit mode is not supported with GPT engine")
 }
 
+func TestTranscribeAPI_ReturnsRequestID(t *testing.T) {
+	litellmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := chatCompletionResponse{
+			Choices: []choice{{Message: responseMessage{Content: "hello"}}},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer litellmServer.Close()
+
+	cfg := newTestAPIConfig(litellmServer.URL)
+	svc := NewVoiceService(cfg)
+	r := wkhttp.New()
+
+	logDir := t.TempDir()
+	asrLogger := NewASRLogger(logDir, 10)
+	defer asrLogger.Close()
+
+	v := &Voice{cfg: cfg, service: svc, Log: log.NewTLog("VoiceTest"), asrLogger: asrLogger}
+	group := r.Group("/v1/voice")
+	group.POST("/transcribe", v.transcribe)
+
+	w := httptest.NewRecorder()
+	req := createMultipartRequest(t, "/v1/voice/transcribe", []byte("fake-audio"), "")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+
+	requestID, ok := resp["request_id"].(string)
+	assert.True(t, ok, "request_id should be a string")
+	assert.NotEmpty(t, requestID, "request_id should not be empty")
+
+	// Verify format: {podID}_{unixMs}_{6hexChars}
+	parts := strings.Split(requestID, "_")
+	assert.Len(t, parts, 3, "request_id should have 3 underscore-separated parts")
+	assert.NotEmpty(t, parts[0], "pod ID part should not be empty")
+	assert.NotEmpty(t, parts[1], "timestamp part should not be empty")
+	assert.Len(t, parts[2], 6, "random hex part should be 6 characters")
+}
+
+func TestTranscribeAPI_RequestIDEmptyWithoutLogger(t *testing.T) {
+	litellmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := chatCompletionResponse{
+			Choices: []choice{{Message: responseMessage{Content: "hello"}}},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer litellmServer.Close()
+
+	cfg := newTestAPIConfig(litellmServer.URL)
+	router := setupTestRouter(cfg, "")
+
+	w := httptest.NewRecorder()
+	req := createMultipartRequest(t, "/v1/voice/transcribe", []byte("fake-audio"), "")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	// When asrLogger is nil, request_id should use fallback with nolog_ prefix
+	requestID, ok := resp["request_id"].(string)
+	assert.True(t, ok, "request_id should be a string")
+	assert.NotEmpty(t, requestID, "request_id should not be empty even without logger")
+	assert.True(t, strings.HasPrefix(requestID, "nolog_"), "request_id should have nolog_ prefix")
+
+	parts := strings.Split(requestID, "_")
+	assert.Len(t, parts, 3, "request_id should have 3 underscore-separated parts")
+	assert.Equal(t, "nolog", parts[0])
+	assert.NotEmpty(t, parts[1], "timestamp part should not be empty")
+	assert.Len(t, parts[2], 6, "random hex part should be 6 characters")
+}
+
 func TestTranscribeAPI_MemberContextTruncation(t *testing.T) {
 	var receivedPrompt string
 	litellmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Return a `request_id` field in the voice transcribe API response (`POST /v1/voice/transcribe`), enabling end-to-end log correlation between frontend ASR hooks and backend transcription logs.

## Changes

- **`modules/voice/api.go`**:
  - Extract `request_id` from `ASREntry` before enqueueing to the ASR logger
  - Add `request_id` field to both success (200) and error (500) JSON responses
  - Add `generateFallbackRequestID()` for deployments without ASR logger enabled (`ASR_LOG_DIR` unset)

- **`modules/voice/api_test.go`**:
  - Add test for `request_id` presence in success response
  - Add test for fallback `request_id` generation when ASR logger is nil

## How It Works

```
Frontend  ──(POST /v1/voice/transcribe)──▶  Backend
                                              │
                                              ├─ Generate/extract request_id
                                              ├─ Enqueue ASR log entry
                                              │
          ◀── { status, text, request_id } ───┘
                    │
                    ▼
          Frontend hooks pass request_id
          to collection service for correlation
```

- When `ASR_LOG_DIR` is configured: `request_id` comes from the ASR log entry (format: `{pod_id}_{timestamp}_{random}`)
- When `ASR_LOG_DIR` is not set: a fallback `nolog_{timestamp}_{random}` ID is generated

## Testing

- 2 new unit tests added, all existing tests pass
- Manually verified with local Docker deployment: response includes `request_id` field