### PR TITLE
chore: unify CODEOWNERS to use maintainers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,4 @@
-# Default owners — multiple maintainers so any one of them can satisfy
-# the "Require code-owner review" branch protection rule on PRs authored
-# by another default owner. Without multiple default owners, a PR by
-# @yujiawei (the original sole default owner) cannot satisfy the
-# required code-owner review without admin override.
-* @Jerry-Xin @lml2468 @yujiawei
+# CODEOWNERS — unified team ownership
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# Server (Go backend)
-/server/ @an9xyz @Jerry-Xin @yujiawei
-
-# Docs
-/docs/ @yujiawei
+* @Mininglamp-OSS/maintainers


### PR DESCRIPTION
## What

Unify CODEOWNERS to use `@Mininglamp-OSS/maintainers` team instead of individual account references.

## Why

The current CODEOWNERS uses individual GitHub accounts (`@Jerry-Xin @lml2468 @yujiawei @an9xyz`), which requires editing this file every time a maintainer is added or removed. Switching to the `@Mininglamp-OSS/maintainers` team reference means membership changes are managed centrally at the team level.

This is part of an org-wide effort to unify CODEOWNERS across all Mininglamp-OSS repositories (see octo-adapters PR #28).

## How

Replace all individual `@username` references with `@Mininglamp-OSS/maintainers`. The team has admin permission on this repo and includes: Jerry-Xin, yujiawei, an9xyz, lml2468.

## Checklist

- [x] Self-reviewed the full diff from a reviewer's perspective
- [x] Rebased onto latest `main`
- [x] Commit messages follow Conventional Commits

## Testing

N/A — configuration-only change. Verified `@Mininglamp-OSS/maintainers` team exists and has admin permission via GitHub API.

## Breaking Changes

N/A