### PR TITLE
fix(user): restore NOT NULL on user.phone/zone (issue #54)

### DIFF
--- a/modules/user/api_manager_test.go
+++ b/modules/user/api_manager_test.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -520,6 +521,68 @@ func TestUserListBotAndSystemFlags(t *testing.T) {
 			assert.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
 		})
 	}
+}
+
+// GH issue #54: 历史迁移 20220222000001_user_legacy01.sql 用裸 MODIFY 把
+// user.phone / user.zone 改成了 nullable，导致任何外部 INSERT 漏列就会让这
+// 两列出现 NULL，进而让 /v1/manager/user/list 等所有 SELECT phone/zone 到
+// string 字段的接口因 "converting NULL to string is unsupported" 报 400。
+//
+// 修复迁移 20260516000001_user_legacy01.sql 把列改回 NOT NULL DEFAULT ''。
+// 本测试通过 INFORMATION_SCHEMA 校验 schema、并直接走 raw SQL 尝试 NULL
+// 写入来验证约束是否真生效（修复前是 NULL 通过、读取报错；修复后是写入直接被
+// 拒，读取永远安全）。
+func TestUserTablePhoneZoneNotNullable(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	err := testutil.CleanAllTables(ctx)
+	assert.NoError(t, err)
+
+	// 1. INFORMATION_SCHEMA 直接校验 schema。
+	type colMeta struct {
+		ColumnName    string `db:"COLUMN_NAME"`
+		IsNullable    string `db:"IS_NULLABLE"`
+		ColumnDefault sql.NullString `db:"COLUMN_DEFAULT"`
+	}
+	var cols []*colMeta
+	_, err = ctx.DB().SelectBySql(
+		"SELECT COLUMN_NAME, IS_NULLABLE, COLUMN_DEFAULT "+
+			"FROM INFORMATION_SCHEMA.COLUMNS "+
+			"WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME='user' "+
+			"AND COLUMN_NAME IN ('phone','zone') ORDER BY COLUMN_NAME",
+	).Load(&cols)
+	assert.NoError(t, err)
+	assert.Len(t, cols, 2, "expected phone+zone columns to exist")
+	for _, c := range cols {
+		assert.Equal(t, "NO", c.IsNullable, "%s must be NOT NULL", c.ColumnName)
+		assert.True(t, c.ColumnDefault.Valid, "%s must have a non-NULL DEFAULT", c.ColumnName)
+		assert.Equal(t, "", c.ColumnDefault.String, "%s DEFAULT should be empty string", c.ColumnName)
+	}
+
+	// 2. 显式 NULL 写入应被数据库拒绝（NOT NULL 约束实际生效，而不只是元数据声明）。
+	// short_no 走自定义值避免与系统账号或下面的 case 撞 unique 索引。
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO `user` (uid, name, role, username, short_no, phone, zone) VALUES (?, ?, ?, ?, ?, NULL, NULL)",
+		"test_null_phone", "X", "admin", "test_null_phone", "test_short_1",
+	).Exec()
+	assert.Error(t, err, "INSERT with explicit NULL phone/zone must be rejected")
+
+	// 3. 漏列写入应该走 DEFAULT '' —— 这是 issue 报告的"手插 admin 行"场景。
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO `user` (uid, name, role, username, short_no) VALUES (?, ?, ?, ?, ?)",
+		"test_missing_phone", "Y", "admin", "test_missing_phone", "test_short_2",
+	).Exec()
+	assert.NoError(t, err, "INSERT without phone/zone columns should succeed via DEFAULT ''")
+
+	// 4. 验证 DEFAULT 实际值确是 ''。
+	type row struct {
+		Phone string `db:"phone"`
+		Zone  string `db:"zone"`
+	}
+	var r row
+	_, err = ctx.DB().SelectBySql("SELECT phone, zone FROM `user` WHERE uid=?", "test_missing_phone").Load(&r)
+	assert.NoError(t, err)
+	assert.Equal(t, "", r.Phone)
+	assert.Equal(t, "", r.Zone)
 }
 
 func TestUserDisablelist(t *testing.T) {

--- a/modules/user/sql/20260516000001_user_legacy01.sql
+++ b/modules/user/sql/20260516000001_user_legacy01.sql
@@ -1,0 +1,23 @@
+-- +migrate Up
+-- 修复 phone/zone 自 20220222000001 起被改回 nullable 的回归（GitHub issue #54）。
+-- 上次的 MODIFY 漏写 NOT NULL DEFAULT '' ，MySQL 默认把列改成允许 NULL；之后
+-- 任何外部 INSERT 漏列（如手工 bootstrap admin、第三方登录的部分路径）就会
+-- 让 phone/zone 出现 NULL，导致所有把这两列扫到 Go string 字段的接口
+-- （/v1/manager/user/list、/v1/maillist、第三方登录扫描等）返回
+-- "converting NULL to string is unsupported"。
+--
+-- 1) 先 backfill：把存量 NULL 收敛成 ''，避免下一步 ALTER 因列里有 NULL 失败。
+UPDATE `user` SET phone = '' WHERE phone IS NULL;
+UPDATE `user` SET zone  = '' WHERE zone  IS NULL;
+
+-- 2) 重新加 NOT NULL DEFAULT '' 并补回 20191106000003 原始 COMMENT
+--    （20220222 那次裸 MODIFY 把 COMMENT 一起冲掉了）。
+--    ALTER MODIFY 是幂等的——目标状态相同就不会报错，可在 already-fixed
+--    的环境上安全重跑。
+ALTER TABLE `user` MODIFY COLUMN phone VARCHAR(100) NOT NULL DEFAULT '' COMMENT '手机号';
+ALTER TABLE `user` MODIFY COLUMN zone  VARCHAR(20)  NOT NULL DEFAULT '' COMMENT '手机区号';
+
+-- +migrate Down
+-- 保留可逆性，但执行会重新引入 #54，强烈不建议。
+ALTER TABLE `user` MODIFY COLUMN phone VARCHAR(100);
+ALTER TABLE `user` MODIFY COLUMN zone  VARCHAR(20);


### PR DESCRIPTION
Fixes #54.

## Root cause

Migration `modules/user/sql/20220222000001_user_legacy01.sql:4-5` used a bare `ALTER TABLE user MODIFY COLUMN` without `NOT NULL DEFAULT ''`, which MySQL interprets as making the column nullable. From that point on, `user.phone` and `user.zone` have allowed NULL.

The Go scan targets (`Model`, `managerUserModel`, `db_maillist` rows, …) all use plain `string`. Any row that lands with NULL in either column — typically via a hand-written admin bootstrap INSERT or a partial third-party-login path — causes every SELECT touching the row to fail with `converting NULL to string is unsupported`, taking down `/v1/manager/user/list`, `/v1/maillist`, and similar endpoints.

## Why schema, not Go

- `grep "phone IS NULL"` / `"zone IS NULL"` across the repo: 0 matches. Nothing distinguishes NULL from `""` for these columns.
- All sibling text columns on `user` (`email`, `wx_openid`, `gitee_uid`, `github_uid`, …) are already `NOT NULL DEFAULT ''`. The two outliers are the leak.
- The Go-side alternative (option B in the issue) would require migrating 20+ struct fields plus every read site to `sql.NullString` and unwrap at the boundary — high blast radius, and the underlying schema landmine remains.

## Migration design

1. `UPDATE user SET phone='' WHERE phone IS NULL` — backfills any existing NULLs so the subsequent `ALTER` cannot fail with error 1138.
2. `ALTER TABLE user MODIFY COLUMN phone VARCHAR(100) NOT NULL DEFAULT '' COMMENT '手机号'` (and the corresponding `zone` statement).

The `COMMENT` is restored from the original `20191106000003` schema — the 20220222 bare MODIFY had also stripped it. `ALTER MODIFY` is idempotent: re-running on an already-fixed environment leaves the column in the same final state without erroring.

## Production verification

Queried `im_prod` (read-only) at PR time:

| column | nullable | NULL rows | empty rows | total |
|---|---|---|---|---|
| phone | YES | 0 | 5565 | 5720 |
| zone  | YES | 0 | 5566 | 5720 |

No live NULLs, so the `UPDATE` step is a no-op; the `ALTER` is INSTANT / INPLACE at this row count on MySQL 8 InnoDB.

## Test plan

- [x] New `TestUserTablePhoneZoneNotNullable` asserts the schema via `INFORMATION_SCHEMA` (NOT NULL + DEFAULT `''`).
- [x] Test functionally proves the constraint: explicit NULL insert is rejected; missing-column insert succeeds via DEFAULT.
- [x] `go test -race ./modules/user/...` — full module suite passes (~17s).
- [x] `go vet ./...`
- [x] Local migration apply on fresh test DB confirms `IS_NULLABLE='NO'`, `COLUMN_DEFAULT=''`, `COLUMN_COMMENT='手机号'/'手机区号'` (stored as proper utf8mb4).

## Rollout

Standard sql-migrate apply on next deploy. No app-code changes required; existing code is already correct under the fixed schema.