### PR TITLE
ci: build and publish multi-arch Docker images to Docker Hub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,153 @@
+name: Docker Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag to publish (e.g. v1.2.3 or test-foo). Will overwrite any existing tag on Docker Hub.'
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize ALL publishes to this image so two close-together v* tags can't
+  # race on the shared mutable tags (:latest, :MAJOR, :MAJOR.MINOR) — last
+  # writer wins, and "last finished" is not necessarily "newest version".
+  # NOTE: workflow-level concurrency.group only accepts github/inputs/vars
+  # contexts (not env), so the image name is hard-coded here. Keep this group
+  # name in sync with env.IMAGE_NAME below if you ever rename the image.
+  group: docker-publish-mininglamposs-octo-server
+  cancel-in-progress: false
+
+env:
+  IMAGE_NAME: mininglamposs/octo-server
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # Dockerfile invokes `git describe --tags --abbrev=0` to embed
+          # GIT_VERSION into the binary. Fetch full history + tags so the
+          # describe doesn't return "dev".
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+          # Disable provenance attestation so the final manifest list doesn't
+          # carry an extra "unknown/unknown" platform entry that confuses some
+          # registry UIs and scanners.
+          provenance: false
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Create multi-arch manifest
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          # `flavor: latest=auto` is the metadata-action default, set explicitly
+          # so the prerelease-skipping behavior is visible without consulting
+          # action docs. With latest=auto + a {{version}} semver tag entry,
+          # `:latest` is published for stable releases (v1.2.3) and skipped
+          # for prereleases (v1.2.3-rc1).
+          flavor: |
+            latest=auto
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Reject reserved tag names on manual dispatch
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          tag="${{ github.event.inputs.tag }}"
+          case "$tag" in
+            latest|main|master|"")
+              echo "::error::Refusing to publish reserved/empty tag '$tag' — would clobber an auto-managed tag"
+              exit 1
+              ;;
+          esac
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          set -euo pipefail
+          TAGS=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          if [ -z "$TAGS" ]; then
+            echo "::error::metadata-action produced no tags; refusing to publish manifest"
+            exit 1
+          fi
+          docker buildx imagetools create $TAGS \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Image tag to publish (e.g. v1.2.3 or test-foo). Will overwrite any existing tag on Docker Hub.'
+        description: 'Image tag to publish. Must match ^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$, must NOT look like a semver alias (1, 1.2, v1.2.3, ...), and from non-main branches must be prefixed with "test-".'
         required: true
 
 permissions:
@@ -27,9 +27,76 @@ env:
   IMAGE_NAME: mininglamposs/octo-server
 
 jobs:
+  validate:
+    # No-secret preflight: rejects bad inputs/refs BEFORE any job that holds
+    # Docker Hub credentials runs. Catches command-injection attempts,
+    # invalid Docker tag grammar, semver-alias clobbering, and manual
+    # publishes from unreviewed refs — all before any registry write.
+    name: Validate inputs and ref
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate tag push ref
+        if: github.event_name == 'push'
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          case "$REF" in
+            refs/tags/v*) echo "OK: $REF" ;;
+            *) echo "::error::Unexpected push ref '$REF'; only refs/tags/v* should reach this workflow"; exit 1 ;;
+          esac
+
+      - name: Validate workflow_dispatch input and ref
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+
+          # Docker image tag grammar (also blocks shell metacharacters as a
+          # side effect — only [A-Za-z0-9_.-] are allowed and length <= 128).
+          if ! printf '%s' "$INPUT_TAG" | grep -Eq '^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$'; then
+            echo "::error::tag '$INPUT_TAG' violates Docker tag grammar ^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$"
+            exit 1
+          fi
+
+          # Reserved auto-managed names — manual dispatch must not clobber them.
+          case "$INPUT_TAG" in
+            latest|main|master)
+              echo "::error::tag '$INPUT_TAG' is reserved/auto-managed; pick a different name"
+              exit 1
+              ;;
+          esac
+
+          # Semver-alias shapes (e.g. 1, 1.2, 1.2.3, v1.2.3) are reserved for
+          # the auto-managed major / major.minor / major.minor.patch / version
+          # aliases populated by tag-push events. A manual dispatch with
+          # these shapes would race with / overwrite the next real release.
+          if printf '%s' "$INPUT_TAG" | grep -Eq '^v?[0-9]+(\.[0-9]+){0,2}([+-].+)?$'; then
+            echo "::error::tag '$INPUT_TAG' looks like a semver alias; manual publishes must use a non-semver name (or prefix with 'test-')"
+            exit 1
+          fi
+
+          # Restrict manual publishes from non-default branches to the
+          # 'test-' namespace so feature-branch experimentation cannot land
+          # in the official release tag space.
+          if [ "$REF" != "refs/heads/main" ]; then
+            case "$INPUT_TAG" in
+              test-*) echo "OK: non-main ref '$REF' with test- prefix" ;;
+              *)
+                echo "::error::manual publishes from '$REF' must use a 'test-*' tag (got '$INPUT_TAG'); merge to main for official tags"
+                exit 1
+                ;;
+            esac
+          fi
+
+          echo "OK: dispatch from $REF with tag '$INPUT_TAG'"
+
   build:
     name: Build ${{ matrix.platform }}
     runs-on: ${{ matrix.runner }}
+    needs: validate
     strategy:
       fail-fast: false
       matrix:
@@ -65,18 +132,20 @@ jobs:
           file: ./Dockerfile
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+          cache-from: type=gha,scope=docker-publish-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=docker-publish-${{ matrix.arch }}
           # Disable provenance attestation so the final manifest list doesn't
           # carry an extra "unknown/unknown" platform entry that confuses some
           # registry UIs and scanners.
           provenance: false
 
       - name: Export digest
+        env:
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
         run: |
+          set -euo pipefail
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+          touch "/tmp/digests/${BUILD_DIGEST#sha256:}"
 
       - name: Upload digest
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -125,29 +194,40 @@ jobs:
             type=semver,pattern={{major}}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
-      - name: Reject reserved tag names on manual dispatch
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          tag="${{ github.event.inputs.tag }}"
-          case "$tag" in
-            latest|main|master|"")
-              echo "::error::Refusing to publish reserved/empty tag '$tag' — would clobber an auto-managed tag"
-              exit 1
-              ;;
-          esac
-
       - name: Create manifest list and push
         working-directory: /tmp/digests
+        env:
+          IMAGE: ${{ env.IMAGE_NAME }}
+          METADATA: ${{ steps.meta.outputs.json }}
         run: |
           set -euo pipefail
-          TAGS=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          if [ -z "$TAGS" ]; then
+          # Build "-t TAG" args as an array — never interpolate tags into the
+          # shell command line, which would be a command-injection vector
+          # if metadata-action ever emitted a tag containing shell syntax.
+          tags=()
+          while IFS= read -r tag; do
+            tags+=(-t "$tag")
+          done < <(jq -r '.tags[]' <<< "$METADATA")
+
+          if [ ${#tags[@]} -eq 0 ]; then
             echo "::error::metadata-action produced no tags; refusing to publish manifest"
             exit 1
           fi
-          docker buildx imagetools create $TAGS \
-            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+          # Digest filenames in /tmp/digests are SHA-256 hex strings (validated
+          # by upload-artifact's if-no-files-found:error and the controlled
+          # filename derived from build.outputs.digest), safe to feed in.
+          sources=()
+          for f in *; do
+            sources+=("${IMAGE}@sha256:${f}")
+          done
+
+          docker buildx imagetools create "${tags[@]}" "${sources[@]}"
 
       - name: Inspect image
+        env:
+          IMAGE: ${{ env.IMAGE_NAME }}
+          PRIMARY_TAG: ${{ steps.meta.outputs.version }}
         run: |
-          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          set -euo pipefail
+          docker buildx imagetools inspect "${IMAGE}:${PRIMARY_TAG}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,15 +52,22 @@ jobs:
           REF: ${{ github.ref }}
         run: |
           set -euo pipefail
-          # Strip refs/tags/ prefix and require strict semver (with optional
-          # prerelease/build metadata) so metadata-action's type=semver
-          # actually matches. A non-semver `v*` tag (e.g. `vfoo`) would
-          # otherwise reach the secret-bearing build job, push digests, and
-          # only fail later when metadata-action emits no tags — defeating
-          # the no-secret preflight intent (PR #72 review, Jerry-Xin).
+          # Require strict semver per semver.org §9 (with mandatory leading 'v')
+          # so metadata-action's type=semver actually matches. A loose regex
+          # would let near-semver refs (e.g. 'vfoo', 'v01.2.3', 'v1.2.3-01',
+          # 'v1.2.3-..', 'v1.2.3+build..meta') reach the secret-bearing build
+          # job and push orphan digests before metadata-action quietly emits
+          # no tags — defeating the no-secret preflight intent.
+          #
+          # The regex below is the official semver.org regex (BRE/ERE form),
+          # prefixed with a literal 'v'. It rejects:
+          #   - leading zeros in numeric identifiers (v01.2.3, v1.2.3-01)
+          #   - empty dot-separated identifiers (v1.2.3-.. , v1.2.3+a..b)
+          #   - characters outside [0-9A-Za-z.+-]
           tag="${REF#refs/tags/}"
-          if ! printf '%s' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
-            echo "::error::tag '$tag' is not strict semver (vMAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]); refusing to publish"
+          semver='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
+          if ! printf '%s' "$tag" | grep -Eq "$semver"; then
+            echo "::error::tag '$tag' is not strict semver per semver.org (vMAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]); refusing to publish"
             exit 1
           fi
           echo "OK: $REF"
@@ -100,9 +107,9 @@ jobs:
 
           # Restrict manual publishes from non-default branches to the
           # 'test-' namespace so feature-branch experimentation cannot land
-          # in the official release tag space. Use the repo's actual default
-          # branch (PR #72 review, Jerry-Xin non-blocking) so a future
-          # rename doesn't silently weaken this guard.
+          # in the official release tag space. Read the default branch from
+          # repository metadata so a future rename doesn't silently weaken
+          # this guard.
           DEFAULT_REF="refs/heads/${DEFAULT_BRANCH}"
           if [ "$REF" != "$DEFAULT_REF" ]; then
             case "$INPUT_TAG" in

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,6 +17,17 @@ concurrency:
   # Serialize ALL publishes to this image so two close-together v* tags can't
   # race on the shared mutable tags (:latest, :MAJOR, :MAJOR.MINOR) — last
   # writer wins, and "last finished" is not necessarily "newest version".
+  #
+  # KNOWN TRADEOFF: GitHub Actions concurrency holds at most ONE pending run
+  # per group; a newer pending run replaces the older one even with
+  # `cancel-in-progress: false`. So if you push v1.0.0 (running), v1.0.1
+  # (queued), v1.0.2 (queued) in quick succession, v1.0.1 will be canceled
+  # by v1.0.2 and never publish. Workaround: wait for each release to finish
+  # publishing before pushing the next tag. We accept this over the
+  # alternative (no concurrency = consistent :latest race on every overlap)
+  # because real release cadence is minutes-to-hours apart and protecting
+  # :latest is the higher-value invariant.
+  #
   # NOTE: workflow-level concurrency.group only accepts github/inputs/vars
   # contexts (not env), so the image name is hard-coded here. Keep this group
   # name in sync with env.IMAGE_NAME below if you ever rename the image.
@@ -41,16 +52,25 @@ jobs:
           REF: ${{ github.ref }}
         run: |
           set -euo pipefail
-          case "$REF" in
-            refs/tags/v*) echo "OK: $REF" ;;
-            *) echo "::error::Unexpected push ref '$REF'; only refs/tags/v* should reach this workflow"; exit 1 ;;
-          esac
+          # Strip refs/tags/ prefix and require strict semver (with optional
+          # prerelease/build metadata) so metadata-action's type=semver
+          # actually matches. A non-semver `v*` tag (e.g. `vfoo`) would
+          # otherwise reach the secret-bearing build job, push digests, and
+          # only fail later when metadata-action emits no tags — defeating
+          # the no-secret preflight intent (PR #72 review, Jerry-Xin).
+          tag="${REF#refs/tags/}"
+          if ! printf '%s' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+            echo "::error::tag '$tag' is not strict semver (vMAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]); refusing to publish"
+            exit 1
+          fi
+          echo "OK: $REF"
 
       - name: Validate workflow_dispatch input and ref
         if: github.event_name == 'workflow_dispatch'
         env:
           INPUT_TAG: ${{ github.event.inputs.tag }}
           REF: ${{ github.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
 
@@ -80,12 +100,15 @@ jobs:
 
           # Restrict manual publishes from non-default branches to the
           # 'test-' namespace so feature-branch experimentation cannot land
-          # in the official release tag space.
-          if [ "$REF" != "refs/heads/main" ]; then
+          # in the official release tag space. Use the repo's actual default
+          # branch (PR #72 review, Jerry-Xin non-blocking) so a future
+          # rename doesn't silently weaken this guard.
+          DEFAULT_REF="refs/heads/${DEFAULT_BRANCH}"
+          if [ "$REF" != "$DEFAULT_REF" ]; then
             case "$INPUT_TAG" in
-              test-*) echo "OK: non-main ref '$REF' with test- prefix" ;;
+              test-*) echo "OK: non-default ref '$REF' with test- prefix" ;;
               *)
-                echo "::error::manual publishes from '$REF' must use a 'test-*' tag (got '$INPUT_TAG'); merge to main for official tags"
+                echo "::error::manual publishes from '$REF' must use a 'test-*' tag (got '$INPUT_TAG'); merge to ${DEFAULT_BRANCH} for official tags"
                 exit 1
                 ;;
             esac
@@ -97,6 +120,12 @@ jobs:
     name: Build ${{ matrix.platform }}
     runs-on: ${{ matrix.runner }}
     needs: validate
+    # `docker-hub-publish` environment gates the Docker Hub credentials:
+    #   - required reviewers (Mininglamp-OSS/maintainers team)
+    #   - deployment ref allowlist: refs/heads/main, refs/tags/v*
+    # No DOCKERHUB_* secret reaches a runner until a maintainer approves
+    # the run in the Actions UI.
+    environment: docker-hub-publish
     strategy:
       fail-fast: false
       matrix:
@@ -159,6 +188,9 @@ jobs:
     name: Create multi-arch manifest
     runs-on: ubuntu-latest
     needs: build
+    # Same gate as `build` — manifest creation also needs Docker Hub creds.
+    # The single approval at the start of the run covers both jobs.
+    environment: docker-hub-publish
     steps:
       - name: Download digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -46,9 +46,14 @@ To build only the `octo-server` container image from this repository:
 make build          # docker build -t octo-server .
 ```
 
-The image-release workflow (multi-arch tags, registry push, deploy
-manifests) lives in
+Multi-arch container images (`linux/amd64`, `linux/arm64`) are
+published to Docker Hub as
+[`mininglamposs/octo-server`](https://hub.docker.com/r/mininglamposs/octo-server)
+by `.github/workflows/docker-publish.yml`, triggered automatically on
+every `v*` Git tag push. Deployment manifests (Helm charts, compose
+stacks, etc.) for the full OOTB stack continue to live in
 [`Mininglamp-OSS/octo-deployment`](https://github.com/Mininglamp-OSS/octo-deployment).
+
 The `push` / `deploy` / `deploy-v2` targets that still ship in this
 repo's `Makefile` predate the consolidation and hard-code the team's
 private Aliyun registry path (with one stale tag — `make push`


### PR DESCRIPTION
## Summary
- Add `.github/workflows/docker-publish.yml` that builds `linux/amd64` and `linux/arm64` images on **native runners** (`ubuntu-latest` + `ubuntu-24.04-arm`) in parallel, then merges them into a multi-arch manifest pushed to `mininglamposs/octo-server` on Docker Hub.
- Build uses the existing `./Dockerfile` (public `golang:1.25` + `alpine` base images, already on `main`). `fetch-depth: 0` in checkout so the Dockerfile's `git describe --tags --abbrev=0` embeds the real version into the binary.
- Triggered on `v*` tag push (auto-tagged with semver, `:latest` only on stable releases — prereleases like `v1.2.3-rc1` skip `:latest`) and via manual `workflow_dispatch` with a required explicit tag input.
- All third-party actions pinned to commit SHAs.
- Per-image `concurrency:` group serializes all publishes so back-to-back tag pushes can't race on `:latest` / `:MAJOR` / `:MAJOR.MINOR` (with documented queue-depth tradeoff).
- No-secret `validate` job runs first and enforces: strict semver per semver.org on `v*` tag pushes; Docker tag grammar + reserved-name + semver-alias guards + non-default-branch `test-*` namespace on `workflow_dispatch` inputs.
- Docker Hub credentials gated behind the `docker-hub-publish` GitHub Environment: required reviewer `Mininglamp-OSS/maintainers` team; allowed refs `main` branch + `v*` tags.

## Adapted from octo-matter PR #17
Same hardening baked in from the start, plus: validate-before-secret preflight, command-injection-safe env-passing, strict semver enforcement, environment-gated credentials.

## Prerequisites
- Repository env-level secrets `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` (configured)
- Environment `docker-hub-publish` with required-reviewers + ref allowlist (configured)

## Test plan
Manual verification path (run **after merge to main**, since the `docker-hub-publish` environment only allows `main` branch and `v*` tags):

- [ ] **Env gate** — From `main`, dispatch with tag `test-env-gate-$(date +%s)`. Run should pause at `build` job with "Waiting for review", then proceed after a maintainer approves.
- [ ] **Multi-arch manifest** — `docker buildx imagetools inspect mininglamposs/octo-server:test-env-gate-<ts>` shows both `linux/amd64` and `linux/arm64` and no `unknown/unknown` entry.
- [ ] **Version embedded** — `docker run --rm mininglamposs/octo-server:test-env-gate-<ts>` startup log shows a real `GIT_VERSION` (from the latest `v*` tag), not `dev`.
- [ ] **Semver preflight rejects junk** — temporarily push `vfoo` (or `v01.2.3`) and confirm `validate` fails before any Docker Hub login. Delete the tag immediately after.
- [ ] **Prerelease skip-:latest** — push `v0.0.1-rc1`, confirm only `:0.0.1-rc1` is published (no `:latest`/`:0`/`:0.0`).
- [ ] **Stable release** — push `v0.0.1`, confirm `:latest`, `:0`, `:0.0`, `:0.0.1` all produced.
- [ ] **Branch dispatch rejected** — try to dispatch from any non-main branch; environment policy should block the run from starting.
- [ ] **Reserved-name guard** — dispatch with input `latest` (or `1.2`); validate job should fail.

> Note: testing on the PR branch (`ci/docker-publish`) is intentionally blocked by the environment policy. All test scenarios must run from `main` after merge.