### PR TITLE
fix(category): unfollow conversations when a category is deleted

### DIFF
--- a/modules/category/api.go
+++ b/modules/category/api.go
@@ -336,32 +336,60 @@ func (c *Category) delete(ctx *wkhttp.Context) {
 	}
 	defer tx.RollbackUnlessCommitted()
 
-	_, err = tx.Update("group_category").
+	// 1. 把分组标记为已删除。
+	if _, err = tx.Update("group_category").
 		Set("status", 2).
 		Where("category_id=?", categoryID).
-		Exec()
-	if err != nil {
+		Exec(); err != nil {
 		c.Error("删除类别失败", zap.Error(err))
 		ctx.ResponseError(errors.New("删除类别失败"))
 		return
 	}
 
-	_, err = tx.Update("group_setting").
+	// 2. 采集该分组下用户名下的群编号列表（在解绑前先读，否则丢失对应关系）。
+	var groupNos []string
+	if _, err = tx.SelectBySql(
+		"SELECT group_no FROM group_setting WHERE category_id=? AND uid=?",
+		categoryID, loginUID,
+	).Load(&groupNos); err != nil {
+		c.Error("查询分组下群列表失败", zap.Error(err))
+		ctx.ResponseError(errors.New("删除类别失败"))
+		return
+	}
+
+	// 3. 清空 group_setting.category_id 必须在 bump 之前。
+	// 锁序统一为 group_setting → user_follow_version → user_conversation_ext，
+	// 与 moveGroupToCategory（先 UPDATE group_setting 再 bump）一致，
+	// 否则两路并发时会形成 AB-BA 死锁。
+	// 同时这一步也避免重新关注后 category_id 仍指向已删分组（list 渲染会丢群）。
+	if _, err = tx.Update("group_setting").
 		Set("category_id", nil).
 		Set("category_sort", 0).
 		Where("category_id=? and uid=?", categoryID, loginUID).
-		Exec()
-	if err != nil {
+		Exec(); err != nil {
 		c.Error("清理群设置失败", zap.Error(err))
 		ctx.ResponseError(errors.New("删除类别失败"))
 		return
 	}
 
-	// PR review follow-up: category_id 置 NULL 会让群从 follow tab 消失，
-	// 必须同 tx 内 +1 follow_version，否则客户端拿同样的 follow_version
-	// 会跳过列表重建。
+	// 4. bump follow_version 必须先于 user_conversation_ext 的写操作，
+	// 与 UpdateSort 同序拿 (version → ext) 锁（PR #21 Round-3 blocker #2）。
 	if _, err := convext.BumpFollowVersionTx(tx, loginUID, cat.SpaceID); err != nil {
 		c.Error("更新 follow_version 失败", zap.Error(err))
+		ctx.ResponseError(errors.New("删除类别失败"))
+		return
+	}
+
+	// 5. 退订语义（前端提示「分组下的所有会话将取消关注」）：
+	//    - 群：group_unfollowed=1 + 级联删 thread ext 行
+	//    - DM：DELETE dm_category_id=cat 的 ext 行
+	if err := convext.UnfollowGroupsTx(tx, loginUID, cat.SpaceID, groupNos); err != nil {
+		c.Error("取消关注分组下群失败", zap.Error(err))
+		ctx.ResponseError(errors.New("删除类别失败"))
+		return
+	}
+	if err := convext.UnfollowDMsByCategoryTx(tx, loginUID, cat.SpaceID, categoryID); err != nil {
+		c.Error("取消关注分组下私聊失败", zap.Error(err))
 		ctx.ResponseError(errors.New("删除类别失败"))
 		return
 	}

--- a/modules/category/api.go
+++ b/modules/category/api.go
@@ -337,9 +337,11 @@ func (c *Category) delete(ctx *wkhttp.Context) {
 	defer tx.RollbackUnlessCommitted()
 
 	// 1. 把分组标记为已删除。
+	// AND uid=? 是防御性过滤——上层 cat.UID != loginUID 检查已能挡住越权，
+	// 这里再加一道，避免将来调用方绕过 ownership 检查时仍能误改他人分组。
 	if _, err = tx.Update("group_category").
 		Set("status", 2).
-		Where("category_id=?", categoryID).
+		Where("category_id=? AND uid=?", categoryID, loginUID).
 		Exec(); err != nil {
 		c.Error("删除类别失败", zap.Error(err))
 		ctx.ResponseError(errors.New("删除类别失败"))
@@ -347,9 +349,13 @@ func (c *Category) delete(ctx *wkhttp.Context) {
 	}
 
 	// 2. 采集该分组下用户名下的群编号列表（在解绑前先读，否则丢失对应关系）。
+	// FOR UPDATE 锁住目标 group_setting 行：本路径走 group_setting → version → ext
+	// 的锁序，moveGroupToCategory 也是同向；不加锁的话同用户并发 move/delete 时
+	// 会出现 G1 既被移到新分组又被标记 group_unfollowed=1 的不一致状态
+	// （PR #74 review by yujiawei P1）。
 	var groupNos []string
 	if _, err = tx.SelectBySql(
-		"SELECT group_no FROM group_setting WHERE category_id=? AND uid=?",
+		"SELECT group_no FROM group_setting WHERE category_id=? AND uid=? FOR UPDATE",
 		categoryID, loginUID,
 	).Load(&groupNos); err != nil {
 		c.Error("查询分组下群列表失败", zap.Error(err))

--- a/modules/category/api_test.go
+++ b/modules/category/api_test.go
@@ -231,6 +231,9 @@ func TestCategory_Delete(t *testing.T) {
 	assert.Nil(t, setting.CategoryID) // category_id should be nil after delete
 
 	// 删除分组应同时取消关注分组下的群（退订语义，前端已提示用户）。
+	// 该 ext 行在 delete 之前并不存在——moveGroupToCategory 不会预先 seed
+	// user_conversation_ext，而是 delete 中 UnfollowGroupsTx 的 upsert 写出来的。
+	// 若将来改成"不再为仅退订的群创建 ext 行"（例如改成软标记），需同步调整这条断言。
 	var groupUnfollowed int
 	_, err = f.db.session.SelectBySql(
 		"SELECT group_unfollowed FROM user_conversation_ext"+

--- a/modules/category/api_test.go
+++ b/modules/category/api_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -228,6 +229,103 @@ func TestCategory_Delete(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, setting)
 	assert.Nil(t, setting.CategoryID) // category_id should be nil after delete
+
+	// 删除分组应同时取消关注分组下的群（退订语义，前端已提示用户）。
+	var groupUnfollowed int
+	_, err = f.db.session.SelectBySql(
+		"SELECT group_unfollowed FROM user_conversation_ext"+
+			" WHERE uid=? AND space_id=? AND target_type=2 AND target_id=?",
+		testutil.UID, spaceID, groupNo,
+	).Load(&groupUnfollowed)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, groupUnfollowed)
+}
+
+// TestCategory_DeleteUnfollowsContents 验证删除分组时同步取消关注分组下的
+// 群（含 thread 级联）与 DM —— 前端提示「分组下的所有会话将取消关注」对应
+// 的服务端行为。
+func TestCategory_DeleteUnfollowsContents(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+
+	err := testutil.CleanAllTables(ctx)
+	assert.NoError(t, err)
+
+	spaceID := "space-delete-cascade"
+	seedSpaceAndMember(t, f, spaceID, 0)
+	route := s.GetRoute()
+
+	// 1. 建一个分组，挂一个群进去
+	wc := createCategory(t, route, spaceID, "待退订")
+	assert.Equal(t, http.StatusOK, wc.Code)
+	catID := parseJSON(t, wc)["category_id"].(string)
+
+	groupNo := "group-cascade-001"
+	seedGroup(t, f, groupNo, spaceID)
+	wm := doRequest(t, route, "PUT", "/v1/groups/"+groupNo+"/category", map[string]string{
+		"category_id": catID,
+	})
+	assert.Equal(t, http.StatusOK, wm.Code)
+
+	// 2. 直接在 user_conversation_ext 里塞一行该群的 thread ext，
+	// 以及一行 dm_category_id 指向当前分组的 DM ext。
+	threadID := groupNo + "____abc12345"
+	_, err = f.db.session.InsertBySql(
+		"INSERT INTO user_conversation_ext (uid, space_id, target_type, target_id) VALUES (?, ?, 5, ?)",
+		testutil.UID, spaceID, threadID,
+	).Exec()
+	assert.NoError(t, err)
+
+	dmPeer := "peer-cascade-001"
+	_, err = f.db.session.InsertBySql(
+		"INSERT INTO user_conversation_ext (uid, space_id, target_type, target_id, followed_dm, dm_category_id) VALUES (?, ?, 1, ?, 1, ?)",
+		testutil.UID, spaceID, dmPeer, catID,
+	).Exec()
+	assert.NoError(t, err)
+
+	// 记录删除前的 follow_version 以验证 bump。
+	versionDB := convext.NewFollowVersionDB(ctx)
+	beforeVer, err := versionDB.Get(testutil.UID, spaceID)
+	assert.NoError(t, err)
+
+	// 3. 删除分组
+	wd := doRequest(t, route, "DELETE", "/v1/spaces/"+spaceID+"/categories/"+catID, nil)
+	assert.Equal(t, http.StatusOK, wd.Code)
+
+	// 4a. 群取消关注：group_unfollowed=1
+	var groupUnfollowed int
+	_, err = f.db.session.SelectBySql(
+		"SELECT group_unfollowed FROM user_conversation_ext"+
+			" WHERE uid=? AND space_id=? AND target_type=2 AND target_id=?",
+		testutil.UID, spaceID, groupNo,
+	).Load(&groupUnfollowed)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, groupUnfollowed)
+
+	// 4b. thread ext 行被级联删除
+	var threadCount int
+	_, err = f.db.session.SelectBySql(
+		"SELECT COUNT(*) FROM user_conversation_ext"+
+			" WHERE uid=? AND space_id=? AND target_type=5 AND target_id=?",
+		testutil.UID, spaceID, threadID,
+	).Load(&threadCount)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, threadCount)
+
+	// 4c. DM ext 行被删除
+	var dmCount int
+	_, err = f.db.session.SelectBySql(
+		"SELECT COUNT(*) FROM user_conversation_ext"+
+			" WHERE uid=? AND space_id=? AND target_type=1 AND target_id=?",
+		testutil.UID, spaceID, dmPeer,
+	).Load(&dmCount)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, dmCount)
+
+	// 4d. follow_version 至少 +1，让客户端能感知到关注集合变化
+	afterVer, err := versionDB.Get(testutil.UID, spaceID)
+	assert.NoError(t, err)
+	assert.Greater(t, afterVer, beforeVer)
 }
 
 func TestCategory_Sort(t *testing.T) {

--- a/modules/conversation_ext/category_cleanup.go
+++ b/modules/conversation_ext/category_cleanup.go
@@ -1,0 +1,61 @@
+package conversation_ext
+
+import (
+	"fmt"
+
+	"github.com/gocraft/dbr/v2"
+)
+
+// UnfollowGroupsTx 在传入 tx 内把一组 (uid, spaceID) 下的群批量标记为取消关注
+// （group_unfollowed=1），并级联删除每个群下的 thread ext 行。
+//
+// 语义与 service.UnfollowChannel 一致，区别仅在于：
+//   - 作用于多个群，而非单个；
+//   - 由调用方持有 tx，并由调用方负责 BumpFollowVersionTx（必须在本函数之前 bump，
+//     与 UpdateSort 同序拿 (version → ext) 锁，避免死锁，详见 PR #21 Round-3 blocker #2）。
+//
+// groupNos 为空时 no-op。
+func UnfollowGroupsTx(tx *dbr.Tx, uid, spaceID string, groupNos []string) error {
+	if len(groupNos) == 0 {
+		return nil
+	}
+	one := int8(1)
+	for _, groupNo := range groupNos {
+		if groupNo == "" {
+			continue
+		}
+		if err := upsertTx(tx, uid, spaceID, targetTypeGroup, groupNo, ConvExtFields{
+			GroupUnfollowed: &one,
+		}); err != nil {
+			return fmt.Errorf("UnfollowGroupsTx upsert group %q: %w", groupNo, err)
+		}
+		prefix := escapeLike(groupNo) + escapeLike(threadSeparator) + "%"
+		if _, err := tx.DeleteBySql(
+			"DELETE FROM "+table+
+				" WHERE uid=? AND space_id=? AND target_type=? AND target_id LIKE ? ESCAPE '|'",
+			uid, spaceID, targetTypeThread, prefix,
+		).Exec(); err != nil {
+			return fmt.Errorf("UnfollowGroupsTx delete threads for %q: %w", groupNo, err)
+		}
+	}
+	return nil
+}
+
+// UnfollowDMsByCategoryTx 在传入 tx 内删除 (uid, spaceID) 下 dm_category_id=categoryID
+// 的全部 DM ext 行。
+//
+// 由调用方负责事先 BumpFollowVersionTx（同 UnfollowGroupsTx 的锁序约束）。
+// categoryID 为空时 no-op。
+func UnfollowDMsByCategoryTx(tx *dbr.Tx, uid, spaceID, categoryID string) error {
+	if categoryID == "" {
+		return nil
+	}
+	if _, err := tx.DeleteBySql(
+		"DELETE FROM "+table+
+			" WHERE uid=? AND space_id=? AND target_type=? AND dm_category_id=?",
+		uid, spaceID, targetTypeDM, categoryID,
+	).Exec(); err != nil {
+		return fmt.Errorf("UnfollowDMsByCategoryTx delete DMs: %w", err)
+	}
+	return nil
+}

--- a/modules/conversation_ext/category_cleanup.go
+++ b/modules/conversation_ext/category_cleanup.go
@@ -29,11 +29,10 @@ func UnfollowGroupsTx(tx *dbr.Tx, uid, spaceID string, groupNos []string) error 
 		}); err != nil {
 			return fmt.Errorf("UnfollowGroupsTx upsert group %q: %w", groupNo, err)
 		}
-		prefix := escapeLike(groupNo) + escapeLike(threadSeparator) + "%"
 		if _, err := tx.DeleteBySql(
 			"DELETE FROM "+table+
 				" WHERE uid=? AND space_id=? AND target_type=? AND target_id LIKE ? ESCAPE '|'",
-			uid, spaceID, targetTypeThread, prefix,
+			uid, spaceID, targetTypeThread, threadLikePrefix(groupNo),
 		).Exec(); err != nil {
 			return fmt.Errorf("UnfollowGroupsTx delete threads for %q: %w", groupNo, err)
 		}

--- a/modules/conversation_ext/cleanup.go
+++ b/modules/conversation_ext/cleanup.go
@@ -92,11 +92,10 @@ func RemoveConvExtForUserInSpace(uid, spaceID, channelID string, channelType uin
 
 	// Cascade thread rows only for group cleanup.
 	if channelType == targetTypeGroup {
-		prefix := escapeLike(channelID) + escapeLike(threadSeparator) + "%"
 		if _, err := tx.DeleteBySql(
 			"DELETE FROM "+table+
 				" WHERE uid=? AND space_id=? AND target_type=? AND target_id LIKE ? ESCAPE '|'",
-			uid, spaceID, targetTypeThread, prefix,
+			uid, spaceID, targetTypeThread, threadLikePrefix(channelID),
 		).Exec(); err != nil {
 			db.Warn("RemoveConvExtForUserInSpace: 级联删除子区 ext 行失败（事务回滚）",
 				zap.String("uid", uid),
@@ -208,12 +207,11 @@ func RemoveConvExtForChannel(channelID string, channelType uint8) {
 	}
 	var owners []owner
 	if channelType == targetTypeGroup {
-		prefix := escapeLike(channelID) + escapeLike(threadSeparator) + "%"
 		if _, err := tx.SelectBySql(
 			"SELECT DISTINCT uid, space_id FROM "+table+
 				" WHERE (target_type=? AND target_id=?)"+
 				" OR (target_type=? AND target_id LIKE ? ESCAPE '|')",
-			channelType, channelID, targetTypeThread, prefix,
+			channelType, channelID, targetTypeThread, threadLikePrefix(channelID),
 		).Load(&owners); err != nil {
 			db.Warn("RemoveConvExtForChannel: SELECT owners 失败",
 				zap.String("channelID", channelID), zap.Error(err))
@@ -258,11 +256,10 @@ func RemoveConvExtForChannel(channelID string, channelType uint8) {
 		return
 	}
 	if channelType == targetTypeGroup {
-		prefix := escapeLike(channelID) + escapeLike(threadSeparator) + "%"
 		if _, err := tx.DeleteBySql(
 			"DELETE FROM "+table+
 				" WHERE target_type=? AND target_id LIKE ? ESCAPE '|'",
-			targetTypeThread, prefix,
+			targetTypeThread, threadLikePrefix(channelID),
 		).Exec(); err != nil {
 			db.Warn("RemoveConvExtForChannel: 级联删除子区 ext 行失败（事务回滚）",
 				zap.String("channelID", channelID), zap.Error(err))

--- a/modules/conversation_ext/service.go
+++ b/modules/conversation_ext/service.go
@@ -140,6 +140,12 @@ func parseThreadChannelID(threadChannelID string) (groupNo, shortID string, err 
 	return parts[0], parts[1], nil
 }
 
+// threadLikePrefix 构造 "{groupNo}____%" 的 LIKE 前缀，并用 '|' 作为转义符
+// （配合 ESCAPE '|' 使用）。集中在一处避免不同调用方对 ESCAPE 字符产生分歧。
+func threadLikePrefix(groupNo string) string {
+	return escapeLike(groupNo) + escapeLike(threadSeparator) + "%"
+}
+
 // escapeLike escapes LIKE special characters for use with ESCAPE '|'.
 // The pipe character is chosen as the escape character because it never
 // appears in snowflake IDs or our thread channel IDs, avoiding the
@@ -230,11 +236,10 @@ func (s *Service) UnfollowChannel(uid, spaceID, groupNo string) error {
 		}); err != nil {
 			return fmt.Errorf("UnfollowChannel upsert group: %w", err)
 		}
-		prefix := escapeLike(groupNo) + escapeLike(threadSeparator) + "%"
 		if _, err := tx.DeleteBySql(
 			"DELETE FROM "+table+
 				" WHERE uid=? AND space_id=? AND target_type=? AND target_id LIKE ? ESCAPE '|'",
-			uid, spaceID, targetTypeThread, prefix,
+			uid, spaceID, targetTypeThread, threadLikePrefix(groupNo),
 		).Exec(); err != nil {
 			return fmt.Errorf("UnfollowChannel delete threads: %w", err)
 		}


### PR DESCRIPTION
## Why

The client already warns the user when deleting a category:

> 确定删除「CA」吗？分组下的所有会话将取消关注。
> (Delete category 「CA」? All conversations under this category will be unfollowed.)

But the server only sets `group_setting.category_id` to `NULL`, which:

- Leaves groups followed (they just fall back into the default category).
- Leaves DM ext rows with `dm_category_id` pointing at a now-deleted category UUID (effectively dangling).

So the server contract diverged from the UX promise. This PR aligns the server with the dialog.

## What

In the same transaction, deleting a category now:

1. Marks every group under the category as unfollowed (`group_unfollowed=1`) and cascade-deletes its thread ext rows — matching `Service.UnfollowChannel` semantics.
2. Deletes every DM ext row whose `dm_category_id` points at the deleted category.
3. Bumps `user_follow_version` so clients observing the version detect the follow-set change.
4. Clears `group_setting.category_id` so re-following a group later doesn't leave a dangling reference.

Two new tx-scoped helpers in `modules/conversation_ext`:

- `UnfollowGroupsTx(tx, uid, spaceID, groupNos)` — batch group unfollow + thread cascade.
- `UnfollowDMsByCategoryTx(tx, uid, spaceID, categoryID)` — delete DM ext rows by category.

## Lock order

The transaction now acquires rows in this order:

```
group_category → group_setting → user_follow_version → user_conversation_ext
```

This matches the order used by \`moveGroupToCategory\` (\`group_setting\` → version). Both writers go through the same chain, eliminating the AB-BA deadlock that would otherwise be possible when a user deletes a category at the same time as another request moves a group within it.

The \`version → ext\` half also matches \`UpdateSort\` (PR #21 Round-3 blocker #2), so the existing concurrency invariant for \`user_conversation_ext\` writes is preserved.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./modules/category -run \"TestCategory_Delete\$|TestCategory_DeleteUnfollowsContents\$|TestCategory_DeleteNotFound\$|TestCategory_DeleteDefaultRejected\$|TestCategory_DeleteNotOwner\$\"\` — pass against a local MySQL 8 container (\`utf8mb4_general_ci\`).
- [x] \`go test ./modules/conversation_ext\` — pass.
- Extended \`TestCategory_Delete\` to assert \`group_unfollowed=1\` on the group ext row.
- Added \`TestCategory_DeleteUnfollowsContents\` covering DM deletion, thread cascade, and follow_version bump.

## Out of scope

This PR addresses only Q1 in the sidebar follow-up. Q2 (whether following a group should auto-follow all of its threads) is still under product discussion and is not touched here.