### PR TITLE
feat(common): allow DB overrides for YAML settings

### DIFF
--- a/modules/base/common/service_email.go
+++ b/modules/base/common/service_email.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"net"
 	"net/smtp"
-	"strings"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -29,17 +29,35 @@ type IEmailService interface {
 	SendHTMLEmail(ctx context.Context, to, subject, htmlBody string) error
 }
 
+// SMTPSettingsProvider exposes the admin-tunable SMTP config to EmailService
+// without creating an import dependency on modules/common (which itself
+// imports modules/base/common — a cycle if we depended back). Any type that
+// implements these three getters can drive the email sender; the production
+// implementation lives in modules/common.SystemSettings.
+type SMTPSettingsProvider interface {
+	SupportEmail() string
+	SupportEmailSmtp() string
+	SupportEmailPwd() string
+}
+
 // EmailService 邮件服务
 type EmailService struct {
-	ctx *config.Context
+	ctx      *config.Context
+	settings SMTPSettingsProvider
 	log.Log
 }
 
-// NewEmailService 创建邮件服务
-func NewEmailService(ctx *config.Context) *EmailService {
+// NewEmailService 创建邮件服务。
+//
+// settings 为 nil 时退化到读取 cfg.Support.*（yaml 静态值）。生产路径
+// 应传入 common.EnsureSystemSettings(ctx) 以启用 admin 覆盖。参数显式
+// 强制每个 call site 在 nil（yaml-only）和实际注入之间做出选择，避免
+// 静默漏掉 admin 配置入口。
+func NewEmailService(ctx *config.Context, settings SMTPSettingsProvider) *EmailService {
 	return &EmailService{
-		ctx: ctx,
-		Log: log.NewTLog("EmailService"),
+		ctx:      ctx,
+		settings: settings,
+		Log:      log.NewTLog("EmailService"),
 	}
 }
 
@@ -103,10 +121,7 @@ func (s *EmailService) SendHTMLEmail(ctx context.Context, to, subject, htmlBody 
 // ctx 的 deadline 会被注入到 dial 和 conn.SetDeadline；ctx 无 deadline 时
 // 退化到 smtpDialTimeout / smtpIOTimeout 默认值。
 func (s *EmailService) sendEmail(ctx context.Context, to, subject, body string) error {
-	cfg := s.ctx.GetConfig()
-	smtpAddr := cfg.Support.EmailSmtp
-	from := cfg.Support.Email
-	pwd := cfg.Support.EmailPwd
+	smtpAddr, from, pwd := s.resolveSMTP()
 
 	if smtpAddr == "" || from == "" || pwd == "" {
 		return errors.New("邮件服务未配置，请联系管理员")
@@ -211,6 +226,23 @@ const (
 	smtpDialTimeout = 15 * time.Second
 	smtpIOTimeout   = 60 * time.Second
 )
+
+// resolveSMTP returns the effective SMTP config: admin-tunable values from
+// the injected provider win over yaml; a missing provider (legacy callers
+// and unit tests) falls back to cfg.Support.* directly.
+func (s *EmailService) resolveSMTP() (smtpAddr, from, pwd string) {
+	if s.settings != nil {
+		smtpAddr = s.settings.SupportEmailSmtp()
+		from = s.settings.SupportEmail()
+		pwd = s.settings.SupportEmailPwd()
+		return
+	}
+	cfg := s.ctx.GetConfig()
+	smtpAddr = cfg.Support.EmailSmtp
+	from = cfg.Support.Email
+	pwd = cfg.Support.EmailPwd
+	return
+}
 
 // Verify 验证验证码（验证成功后销毁缓存）
 func (s *EmailService) Verify(ctx context.Context, email, code string, codeType CodeType) error {

--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -29,9 +29,10 @@ import (
 type Common struct {
 	ctx *config.Context
 	log.Log
-	db          *db
-	appConfigDB *appConfigDB
-	threadOn    int // 缓存 DM_THREAD_ON 环境变量
+	db             *db
+	appConfigDB    *appConfigDB
+	systemSettings *SystemSettings
+	threadOn       int // 缓存 DM_THREAD_ON 环境变量
 }
 
 // New New
@@ -41,12 +42,20 @@ func New(ctx *config.Context) *Common {
 		threadOn = 1
 	}
 	return &Common{
-		ctx:         ctx,
-		db:          newDB(ctx.DB()),
-		appConfigDB: newAppConfigDB(ctx),
-		Log:         log.NewTLog("common"),
-		threadOn:    threadOn,
+		ctx:            ctx,
+		db:             newDB(ctx.DB()),
+		appConfigDB:    newAppConfigDB(ctx),
+		systemSettings: EnsureSystemSettings(ctx),
+		Log:            log.NewTLog("common"),
+		threadOn:       threadOn,
 	}
+}
+
+// SystemSettings exposes the shared admin-tunable settings reader for
+// callers that already hold a *Common. New consumers in other packages
+// should prefer common.EnsureSystemSettings(ctx) directly.
+func (cn *Common) SystemSettings() *SystemSettings {
+	return cn.systemSettings
 }
 
 // Route 路由配置
@@ -405,7 +414,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 		OIDCResetPasswordURL:           oidcResetPasswordURL(),
 		OIDCProviders:                  oidcProviders(),
 		// YUJ-219-A / GH#1283：单一真源下发系统 Bot UID 列表，替代三端硬编码。
-		SystemBotUIDs:                  spacepkg.SystemBotList(),
+		SystemBotUIDs: spacepkg.SystemBotList(),
 	})
 }
 

--- a/modules/common/api_manager.go
+++ b/modules/common/api_manager.go
@@ -14,17 +14,21 @@ import (
 type Manager struct {
 	ctx *config.Context
 	log.Log
-	db          *db
-	appconfigDB *appConfigDB
+	db              *db
+	appconfigDB     *appConfigDB
+	systemSettingDB *systemSettingDB
+	systemSettings  *SystemSettings
 }
 
 // NewManager NewManager
 func NewManager(ctx *config.Context) *Manager {
 	return &Manager{
-		ctx:         ctx,
-		Log:         log.NewTLog("commonManager"),
-		db:          newDB(ctx.DB()),
-		appconfigDB: newAppConfigDB(ctx),
+		ctx:             ctx,
+		Log:             log.NewTLog("commonManager"),
+		db:              newDB(ctx.DB()),
+		appconfigDB:     newAppConfigDB(ctx),
+		systemSettingDB: newSystemSettingDB(ctx),
+		systemSettings:  EnsureSystemSettings(ctx),
 	}
 }
 
@@ -38,6 +42,11 @@ func (m *Manager) Route(r *wkhttp.WKHttp) {
 		auth.PUT("/common/appmodule", m.updateAppModule)         // 修改app模块
 		auth.POST("/common/appmodule", m.addAppModule)           // 新增app模块
 		auth.DELETE("/common/:sid/appmodule", m.deleteAppModule) // 删除app模块
+
+		// System-setting KV (admin-tunable runtime config).
+		auth.GET("/common/system_setting", m.listSystemSettings)
+		auth.POST("/common/system_setting", m.updateSystemSettings)
+		auth.POST("/common/system_setting/test_email", m.testSystemSettingEmail)
 	}
 }
 func (m *Manager) deleteAppModule(c *wkhttp.Context) {

--- a/modules/common/api_manager_system_setting.go
+++ b/modules/common/api_manager_system_setting.go
@@ -29,12 +29,25 @@ type systemSettingUpdateReq struct {
 }
 
 // systemSettingItemResp is one entry in the GET response.
+//
+// Field semantics:
+//   - Configured: true iff the DB row exists for this (category, key). The
+//     admin UI uses this to distinguish "explicitly set" from "using default".
+//   - Value: the DB-stored value, or "" if not configured. For encrypted
+//     types this is the secretMask placeholder whenever a non-empty
+//     ciphertext is stored; cleartext is never returned.
+//   - EffectiveValue: the value currently in effect after applying the
+//     DB → yaml → code-default fallback chain. For encrypted types this is
+//     secretMask whenever the effective plaintext is non-empty (whether the
+//     source is DB or yaml), and "" otherwise. Plaintext is NEVER returned.
 type systemSettingItemResp struct {
-	Category    string `json:"category"`
-	Key         string `json:"key"`
-	Value       string `json:"value"`
-	ValueType   string `json:"value_type"`
-	Description string `json:"description"`
+	Category       string `json:"category"`
+	Key            string `json:"key"`
+	Configured     bool   `json:"configured"`
+	Value          string `json:"value"`
+	EffectiveValue string `json:"effective_value"`
+	ValueType      string `json:"value_type"`
+	Description    string `json:"description"`
 }
 
 // systemSettingSchemaResp is the schema metadata surfaced to the admin UI.
@@ -93,15 +106,32 @@ func (m *Manager) listSystemSettings(c *wkhttp.Context) {
 			Description: def.Description,
 		}
 		if row, ok := stored[schemaKey(def.Category, def.Key)]; ok {
+			// A row exists. Configured tracks whether the DB explicitly holds a
+			// value — an empty Value means "DB row present but cleared back to
+			// yaml default" (see TestManagerSystemSetting_BoolEmptyValueResetsToYaml),
+			// so we still mark Configured=false in that case.
+			item.Configured = row.Value != ""
 			if def.Type == settingTypeEncrypted {
-				// Encrypted columns are returned as a mask whenever a value
-				// is stored. Empty stored value is reported as empty so the
-				// UI can render "not configured" rather than masked-empty.
 				if row.Value != "" {
 					item.Value = secretMask
 				}
 			} else {
 				item.Value = row.Value
+			}
+		}
+
+		// EffectiveValue resolves DB → yaml → code default through the typed
+		// getters bound on the schema entry. Encrypted plaintext is replaced
+		// with secretMask before serialisation — a yaml SMTP password must
+		// never leak through this endpoint.
+		if def.Effective != nil {
+			effective := def.Effective(m.systemSettings)
+			if def.Type == settingTypeEncrypted {
+				if effective != "" {
+					item.EffectiveValue = secretMask
+				}
+			} else {
+				item.EffectiveValue = effective
 			}
 		}
 		items = append(items, item)

--- a/modules/common/api_manager_system_setting.go
+++ b/modules/common/api_manager_system_setting.go
@@ -1,0 +1,306 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	commonbase "github.com/Mininglamp-OSS/octo-server/modules/base/common"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"go.uber.org/zap"
+)
+
+// secretMask is the placeholder returned in GET responses for
+// settingTypeEncrypted columns so cleartext never leaves the server.
+const secretMask = "****"
+
+// systemSettingItemReq is one entry in the batch update payload.
+type systemSettingItemReq struct {
+	Category string `json:"category"`
+	Key      string `json:"key"`
+	Value    string `json:"value"`
+}
+
+// systemSettingUpdateReq is the manager update payload.
+type systemSettingUpdateReq struct {
+	Items []systemSettingItemReq `json:"items"`
+}
+
+// systemSettingItemResp is one entry in the GET response.
+type systemSettingItemResp struct {
+	Category    string `json:"category"`
+	Key         string `json:"key"`
+	Value       string `json:"value"`
+	ValueType   string `json:"value_type"`
+	Description string `json:"description"`
+}
+
+// systemSettingSchemaResp is the schema metadata surfaced to the admin UI.
+type systemSettingSchemaResp struct {
+	Category    string `json:"category"`
+	Key         string `json:"key"`
+	Type        string `json:"type"`
+	Description string `json:"description"`
+}
+
+// systemSettingGetResp wraps both the current values and the schema so the
+// admin UI can render a complete form without a second round-trip.
+type systemSettingGetResp struct {
+	Items  []systemSettingItemResp   `json:"items"`
+	Schema []systemSettingSchemaResp `json:"schema"`
+}
+
+// listSystemSettings handles GET /v1/manager/common/system_setting.
+//
+// Read access uses CheckLoginRole — any authenticated admin can view the
+// effective config (encrypted columns are masked). Writes require
+// SuperAdmin (see updateSystemSettings).
+func (m *Manager) listSystemSettings(c *wkhttp.Context) {
+	if err := c.CheckLoginRole(); err != nil {
+		c.ResponseError(err)
+		return
+	}
+	rows, err := m.systemSettingDB.listAll()
+	if err != nil {
+		m.Error("查询系统设置失败", zap.Error(err))
+		c.ResponseError(errors.New("查询系统设置失败"))
+		return
+	}
+
+	// Index existing rows so the response can place schema entries with
+	// their stored value (or blank when not configured).
+	stored := map[string]*systemSettingModel{}
+	for _, r := range rows {
+		stored[schemaKey(r.Category, r.KeyName)] = r
+	}
+
+	items := make([]systemSettingItemResp, 0, len(systemSettingSchema))
+	schema := make([]systemSettingSchemaResp, 0, len(systemSettingSchema))
+	for _, def := range systemSettingSchema {
+		schema = append(schema, systemSettingSchemaResp{
+			Category:    def.Category,
+			Key:         def.Key,
+			Type:        def.Type,
+			Description: def.Description,
+		})
+
+		item := systemSettingItemResp{
+			Category:    def.Category,
+			Key:         def.Key,
+			ValueType:   def.Type,
+			Description: def.Description,
+		}
+		if row, ok := stored[schemaKey(def.Category, def.Key)]; ok {
+			if def.Type == settingTypeEncrypted {
+				// Encrypted columns are returned as a mask whenever a value
+				// is stored. Empty stored value is reported as empty so the
+				// UI can render "not configured" rather than masked-empty.
+				if row.Value != "" {
+					item.Value = secretMask
+				}
+			} else {
+				item.Value = row.Value
+			}
+		}
+		items = append(items, item)
+	}
+
+	c.Response(systemSettingGetResp{Items: items, Schema: schema})
+}
+
+// updateSystemSettings handles POST /v1/manager/common/system_setting.
+//
+// Behavior:
+//  1. SuperAdmin role required.
+//  2. Each item must match a (category, key) in systemSettingSchema —
+//     unknown keys are rejected (400) without partial writes.
+//  3. Type-specific validation: bool accepts "0"/"1"/"true"/"false";
+//     int must parse as base-10 integer; string is unconstrained;
+//     encrypted accepts any string (empty means "do not change").
+//  4. Encrypted columns: empty value is silently skipped (preserves the
+//     existing ciphertext); non-empty values are AES-256-GCM encrypted
+//     via encryptKey before storage.
+//  5. After all rows are upserted, SystemSettings.Reload is called so
+//     this instance serves the new values immediately. Other instances
+//     pick it up within reloadTTL.
+func (m *Manager) updateSystemSettings(c *wkhttp.Context) {
+	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
+		c.ResponseError(err)
+		return
+	}
+
+	var req systemSettingUpdateReq
+	if err := c.BindJSON(&req); err != nil {
+		c.ResponseError(errors.New("请求数据格式有误！"))
+		return
+	}
+	if len(req.Items) == 0 {
+		c.ResponseError(errors.New("items 不能为空"))
+		return
+	}
+
+	// Validate everything first so a malformed item never produces a
+	// half-applied write. The actual writes happen later in one
+	// transaction.
+	type prepared struct {
+		def   *settingDef
+		value string
+		skip  bool
+	}
+	plans := make([]prepared, 0, len(req.Items))
+	for _, item := range req.Items {
+		def := findSchemaDef(item.Category, item.Key)
+		if def == nil {
+			c.JSON(http.StatusBadRequest, jsonH{
+				"msg": fmt.Sprintf("未知的配置项：%s.%s", item.Category, item.Key),
+			})
+			return
+		}
+
+		p := prepared{def: def, value: item.Value}
+		switch def.Type {
+		case settingTypeBool:
+			normalised, ok := normaliseBool(item.Value)
+			if !ok {
+				c.JSON(http.StatusBadRequest, jsonH{
+					"msg": fmt.Sprintf("%s.%s 仅接受 0/1/true/false", item.Category, item.Key),
+				})
+				return
+			}
+			p.value = normalised
+		case settingTypeInt:
+			if item.Value != "" {
+				if _, err := strconv.Atoi(item.Value); err != nil {
+					c.JSON(http.StatusBadRequest, jsonH{
+						"msg": fmt.Sprintf("%s.%s 必须是整数", item.Category, item.Key),
+					})
+					return
+				}
+			}
+		case settingTypeEncrypted:
+			if item.Value == "" {
+				// Empty payload preserves the existing ciphertext — do not
+				// queue an upsert that would blank it out.
+				p.skip = true
+				break
+			}
+			enc, err := encryptKey(item.Value)
+			if err != nil {
+				// The underlying error (e.g. "OCTO_MASTER_KEY not
+				// configured") describes server-internal state — do not
+				// leak it over HTTP, log it for ops to find.
+				m.Error("加密配置失败",
+					zap.String("category", item.Category),
+					zap.String("key", item.Key),
+					zap.Error(err))
+				c.ResponseError(errors.New("加密配置失败，请检查服务端密钥配置"))
+				return
+			}
+			p.value = enc
+		case settingTypeString:
+			// Anything goes.
+		}
+		plans = append(plans, p)
+	}
+
+	// Atomic batch: open one transaction, queue every upsert, commit only
+	// if all rows succeed. A mid-batch DB failure rolls back everything
+	// rather than leaving callers to debug partial state.
+	tx, err := m.systemSettingDB.beginTx()
+	if err != nil {
+		m.Error("开启事务失败", zap.Error(err))
+		c.ResponseError(errors.New("写入系统设置失败"))
+		return
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	for _, p := range plans {
+		if p.skip {
+			continue
+		}
+		if err := m.systemSettingDB.upsertWithTx(
+			tx, p.def.Category, p.def.Key, p.value, p.def.Type, p.def.Description,
+		); err != nil {
+			m.Error("写入系统设置失败", zap.Error(err))
+			c.ResponseError(errors.New("写入系统设置失败"))
+			return
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		m.Error("提交事务失败", zap.Error(err))
+		c.ResponseError(errors.New("写入系统设置失败"))
+		return
+	}
+	committed = true
+
+	if err := m.systemSettings.Reload(); err != nil {
+		// Reload is best-effort — the row is already persisted, so other
+		// instances and the next auto-reload tick will pick it up.
+		m.Warn("Reload SystemSettings 失败，等待自动刷新", zap.Error(err))
+	}
+
+	c.ResponseOK()
+}
+
+// testSystemSettingEmail handles POST /v1/manager/common/system_setting/test_email.
+//
+// Sends a no-op test message to the requested address using the currently
+// effective SMTP config (DB values, falling back to yaml). Lets admins
+// validate SMTP credentials without registering a real user.
+func (m *Manager) testSystemSettingEmail(c *wkhttp.Context) {
+	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
+		c.ResponseError(err)
+		return
+	}
+
+	var req struct {
+		To string `json:"to"`
+	}
+	if err := c.BindJSON(&req); err != nil {
+		c.ResponseError(errors.New("请求数据格式有误！"))
+		return
+	}
+	if req.To == "" {
+		c.ResponseError(errors.New("收件人 to 不能为空"))
+		return
+	}
+
+	emailSvc := commonbase.NewEmailService(m.ctx, m.systemSettings)
+	if err := emailSvc.SendHTMLEmail(
+		c.Request.Context(),
+		req.To,
+		"Octo SMTP 测试邮件",
+		`<p>这是一封来自 Octo 管理后台的测试邮件。如果你收到了它，说明 SMTP 配置正常。</p>`,
+	); err != nil {
+		c.ResponseError(fmt.Errorf("发送失败: %w", err))
+		return
+	}
+	c.ResponseOK()
+}
+
+// jsonH is a tiny alias for inline JSON payloads. We define a local alias
+// instead of importing gin.H to keep the surface visible at the call site.
+type jsonH = map[string]interface{}
+
+// normaliseBool canonicalises any accepted bool spelling to "0" / "1" so
+// the raw DB rows are consistent regardless of admin UI capitalisation.
+// An empty string is also valid and means "reset to yaml default"; the
+// getter side treats empty as "not configured". Returns (value, true) on
+// success or ("", false) for an unrecognised spelling.
+func normaliseBool(v string) (string, bool) {
+	switch v {
+	case "":
+		return "", true
+	case "0", "false", "FALSE", "False":
+		return "0", true
+	case "1", "true", "TRUE", "True":
+		return "1", true
+	}
+	return "", false
+}

--- a/modules/common/api_manager_system_setting.go
+++ b/modules/common/api_manager_system_setting.go
@@ -180,9 +180,10 @@ func (m *Manager) updateSystemSettings(c *wkhttp.Context) {
 				}
 			}
 		case settingTypeEncrypted:
-			if item.Value == "" {
-				// Empty payload preserves the existing ciphertext — do not
-				// queue an upsert that would blank it out.
+			if item.Value == "" || item.Value == secretMask {
+				// Empty payload or the GET mask sentinel preserves the existing
+				// ciphertext — do not queue an upsert that would blank it out
+				// or accidentally store "****" as the real password.
 				p.skip = true
 				break
 			}
@@ -297,9 +298,9 @@ func normaliseBool(v string) (string, bool) {
 	switch v {
 	case "":
 		return "", true
-	case "0", "false", "FALSE", "False":
+	case "0", "false", "FALSE":
 		return "0", true
-	case "1", "true", "TRUE", "True":
+	case "1", "true", "TRUE":
 		return "1", true
 	}
 	return "", false

--- a/modules/common/api_manager_system_setting_test.go
+++ b/modules/common/api_manager_system_setting_test.go
@@ -95,6 +95,24 @@ func TestManagerSystemSetting_UpdateRejectsInvalidBool(t *testing.T) {
 	assert.NotEqual(t, http.StatusOK, w.Code)
 }
 
+func TestManagerSystemSetting_UpdateRejectsMixedCaseBool(t *testing.T) {
+	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.SuperAdmin),
+	))
+
+	body := []byte(`{"items":[{"category":"register","key":"email_on","value":"True"}]}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/manager/common/system_setting", bytes.NewReader(body))
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.NotEqual(t, http.StatusOK, w.Code)
+}
+
 func TestManagerSystemSetting_EncryptedEmptyDoesNotOverwrite(t *testing.T) {
 	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
 	s, ctx := testutil.NewTestServer()
@@ -122,6 +140,35 @@ func TestManagerSystemSetting_EncryptedEmptyDoesNotOverwrite(t *testing.T) {
 	plaintext, err := decryptKey(rows[0].Value)
 	require.NoError(t, err)
 	assert.Equal(t, "original", plaintext, "empty payload must preserve existing secret")
+}
+
+func TestManagerSystemSetting_EncryptedMaskDoesNotOverwrite(t *testing.T) {
+	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.SuperAdmin),
+	))
+
+	db := newSystemSettingDB(ctx)
+	enc, err := encryptKey("original")
+	require.NoError(t, err)
+	require.NoError(t, db.upsert("support", "email_pwd", enc, settingTypeEncrypted, ""))
+
+	body := []byte(`{"items":[{"category":"support","key":"email_pwd","value":"****"}]}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/manager/common/system_setting", bytes.NewReader(body))
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	rows, err := db.listAll()
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	plaintext, err := decryptKey(rows[0].Value)
+	require.NoError(t, err)
+	assert.Equal(t, "original", plaintext, "mask payload must preserve existing secret")
 }
 
 // Writing "" for a bool resets the setting to "fall back to yaml". This

--- a/modules/common/api_manager_system_setting_test.go
+++ b/modules/common/api_manager_system_setting_test.go
@@ -41,8 +41,115 @@ func TestManagerSystemSetting_GetReturnsSchemaAndMaskedSecrets(t *testing.T) {
 	assert.Contains(t, body, `"register"`)
 	assert.Contains(t, body, `"email_on"`)
 	assert.Contains(t, body, `"items":`)
+	assert.Contains(t, body, `"configured"`, "GET must report whether each setting is explicitly configured")
+	assert.Contains(t, body, `"effective_value"`, "GET must report the effective (DB→yaml→default) value")
 	assert.NotContains(t, body, "super-secret", "encrypted values must NEVER be returned in cleartext")
 	assert.Contains(t, body, "****", "encrypted columns must be masked")
+}
+
+// GET must return:
+//   - configured=true + value=DB value for explicitly configured rows
+//   - configured=false + value="" for unconfigured rows
+//   - effective_value reflecting DB → yaml → code-default for every row
+//   - encrypted plaintext (from yaml or DB) is masked, never leaked
+func TestManagerSystemSetting_GetReturnsEffectiveValues(t *testing.T) {
+	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.SuperAdmin),
+	))
+
+	// Mutate via the singleton's captured ctx — see the BoolEmptyValueResetsToYaml
+	// test for the test-infra rationale.
+	settings := EnsureSystemSettings(ctx)
+	cfg := settings.ctx.GetConfig()
+	origRegEmailOn := cfg.Register.EmailOn
+	origRegOff := cfg.Register.Off
+	origSupportEmail := cfg.Support.Email
+	origSupportPwd := cfg.Support.EmailPwd
+	t.Cleanup(func() {
+		cfg.Register.EmailOn = origRegEmailOn
+		cfg.Register.Off = origRegOff
+		cfg.Support.Email = origSupportEmail
+		cfg.Support.EmailPwd = origSupportPwd
+	})
+	// yaml provides defaults the DB will not override.
+	cfg.Register.EmailOn = true
+	cfg.Register.Off = false
+	cfg.Support.Email = "yaml-default@example.com"
+	cfg.Support.EmailPwd = "yaml-fallback-secret"
+
+	// DB explicitly overrides one bool and one string.
+	db := newSystemSettingDB(ctx)
+	require.NoError(t, db.upsert("register", "email_on", "0", settingTypeBool, ""))
+	require.NoError(t, db.upsert("support", "email_smtp", "smtp.db:587", settingTypeString, ""))
+	require.NoError(t, settings.Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/manager/common/system_setting", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var resp struct {
+		Items []struct {
+			Category       string `json:"category"`
+			Key            string `json:"key"`
+			Configured     bool   `json:"configured"`
+			Value          string `json:"value"`
+			EffectiveValue string `json:"effective_value"`
+			ValueType      string `json:"value_type"`
+		} `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	byKey := map[string]struct {
+		Configured     bool
+		Value          string
+		EffectiveValue string
+	}{}
+	for _, it := range resp.Items {
+		byKey[it.Category+"."+it.Key] = struct {
+			Configured     bool
+			Value          string
+			EffectiveValue string
+		}{it.Configured, it.Value, it.EffectiveValue}
+	}
+
+	// DB-overridden bool: configured + DB value wins.
+	got := byKey["register.email_on"]
+	assert.True(t, got.Configured, "DB row present → configured=true")
+	assert.Equal(t, "0", got.Value)
+	assert.Equal(t, "0", got.EffectiveValue, "DB override 0 must be the effective value")
+
+	// Unconfigured bool: falls back to yaml.
+	got = byKey["register.off"]
+	assert.False(t, got.Configured)
+	assert.Equal(t, "", got.Value)
+	assert.Equal(t, "0", got.EffectiveValue, "yaml false → effective_value=\"0\"")
+
+	// Unconfigured string: yaml default surfaces in effective_value.
+	got = byKey["support.email"]
+	assert.False(t, got.Configured)
+	assert.Equal(t, "", got.Value)
+	assert.Equal(t, "yaml-default@example.com", got.EffectiveValue)
+
+	// DB-overridden string.
+	got = byKey["support.email_smtp"]
+	assert.True(t, got.Configured)
+	assert.Equal(t, "smtp.db:587", got.Value)
+	assert.Equal(t, "smtp.db:587", got.EffectiveValue)
+
+	// Encrypted with only a yaml fallback: effective_value must be masked,
+	// plaintext must never appear in the body.
+	got = byKey["support.email_pwd"]
+	assert.False(t, got.Configured, "no DB row → configured=false")
+	assert.Equal(t, "", got.Value, "no DB row → value empty (not masked)")
+	assert.Equal(t, "****", got.EffectiveValue, "yaml-backed secret must surface as mask")
+	assert.NotContains(t, w.Body.String(), "yaml-fallback-secret",
+		"encrypted yaml plaintext must NEVER leak through GET")
 }
 
 func TestManagerSystemSetting_UpdateRequiresSuperAdmin(t *testing.T) {

--- a/modules/common/api_manager_system_setting_test.go
+++ b/modules/common/api_manager_system_setting_test.go
@@ -1,0 +1,211 @@
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerSystemSetting_GetReturnsSchemaAndMaskedSecrets(t *testing.T) {
+	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.SuperAdmin),
+	))
+
+	db := newSystemSettingDB(ctx)
+	require.NoError(t, db.upsert("register", "email_on", "1", settingTypeBool, ""))
+
+	enc, err := encryptKey("super-secret")
+	require.NoError(t, err)
+	require.NoError(t, db.upsert("support", "email_pwd", enc, settingTypeEncrypted, ""))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/manager/common/system_setting", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	body := w.Body.String()
+	assert.Contains(t, body, `"schema":`, "must surface schema for UI to render form")
+	assert.Contains(t, body, `"register"`)
+	assert.Contains(t, body, `"email_on"`)
+	assert.Contains(t, body, `"items":`)
+	assert.NotContains(t, body, "super-secret", "encrypted values must NEVER be returned in cleartext")
+	assert.Contains(t, body, "****", "encrypted columns must be masked")
+}
+
+func TestManagerSystemSetting_UpdateRequiresSuperAdmin(t *testing.T) {
+	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
+	s, _ := testutil.NewTestServer()
+
+	body := []byte(`{"items":[{"category":"register","key":"email_on","value":"1"}]}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/manager/common/system_setting", bytes.NewReader(body))
+	req.Header.Set("token", testutil.Token) // plain user token — should be rejected
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.NotEqual(t, http.StatusOK, w.Code, "non-superAdmin must not be able to write")
+}
+
+func TestManagerSystemSetting_UpdateRejectsUnknownKey(t *testing.T) {
+	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.SuperAdmin),
+	))
+
+	body := []byte(`{"items":[{"category":"register","key":"bogus_key","value":"1"}]}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/manager/common/system_setting", bytes.NewReader(body))
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.NotEqual(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "bogus_key")
+}
+
+func TestManagerSystemSetting_UpdateRejectsInvalidBool(t *testing.T) {
+	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.SuperAdmin),
+	))
+
+	body := []byte(`{"items":[{"category":"register","key":"email_on","value":"yes"}]}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/manager/common/system_setting", bytes.NewReader(body))
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.NotEqual(t, http.StatusOK, w.Code)
+}
+
+func TestManagerSystemSetting_EncryptedEmptyDoesNotOverwrite(t *testing.T) {
+	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.SuperAdmin),
+	))
+
+	db := newSystemSettingDB(ctx)
+	enc, err := encryptKey("original")
+	require.NoError(t, err)
+	require.NoError(t, db.upsert("support", "email_pwd", enc, settingTypeEncrypted, ""))
+
+	body := []byte(`{"items":[{"category":"support","key":"email_pwd","value":""}]}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/manager/common/system_setting", bytes.NewReader(body))
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	rows, err := db.listAll()
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	plaintext, err := decryptKey(rows[0].Value)
+	require.NoError(t, err)
+	assert.Equal(t, "original", plaintext, "empty payload must preserve existing secret")
+}
+
+// Writing "" for a bool resets the setting to "fall back to yaml". This
+// round-trip is the only way to revert an explicit DB override from the
+// admin UI; cover it explicitly so the contract does not regress.
+//
+// Test infra quirk: octo-lib's register.GetModules caches the moduleList
+// with sync.Once, so the Manager + Singleton are bound to the FIRST ctx
+// passed across the test binary. To mutate the yaml fallback that the
+// Manager sees, write through settings.ctx (the singleton's captured ctx)
+// rather than the per-test ctx returned by NewTestServer.
+func TestManagerSystemSetting_BoolEmptyValueResetsToYaml(t *testing.T) {
+	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.SuperAdmin),
+	))
+
+	// The Manager handler reads the yaml fallback through its singleton's
+	// ctx, which may differ from this test's ctx (see comment above).
+	settings := EnsureSystemSettings(ctx)
+	originalEmailOn := settings.ctx.GetConfig().Register.EmailOn
+	t.Cleanup(func() { settings.ctx.GetConfig().Register.EmailOn = originalEmailOn })
+	settings.ctx.GetConfig().Register.EmailOn = true // yaml says enabled
+
+	// DB explicitly says "0" (off).
+	require.NoError(t, newSystemSettingDB(ctx).upsert(
+		"register", "email_on", "0", settingTypeBool, "",
+	))
+	require.NoError(t, settings.Reload())
+	require.False(t, settings.RegisterEmailOn(), "DB override 0 must win over yaml true")
+
+	// Admin clears the override by POSTing an empty value.
+	body := []byte(`{"items":[{"category":"register","key":"email_on","value":""}]}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/manager/common/system_setting", bytes.NewReader(body))
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	rows, err := newSystemSettingDB(ctx).listAll()
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "row should still exist with empty value")
+	assert.Equal(t, "", rows[0].Value, "value column should be empty after reset POST")
+
+	assert.True(t, settings.RegisterEmailOn(), `"" must clear the override and restore yaml default`)
+}
+
+func TestManagerSystemSetting_UpdatePersistsAndReloads(t *testing.T) {
+	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.SuperAdmin),
+	))
+
+	settings := EnsureSystemSettings(ctx)
+	// Mutate via settings.ctx because octo-lib caches the moduleList with
+	// sync.Once — see comment on TestManagerSystemSetting_BoolEmptyValueResetsToYaml
+	// for why the per-test ctx may differ from the Manager's captured ctx.
+	originalEmailOn := settings.ctx.GetConfig().Register.EmailOn
+	t.Cleanup(func() { settings.ctx.GetConfig().Register.EmailOn = originalEmailOn })
+	settings.ctx.GetConfig().Register.EmailOn = false
+	require.NoError(t, settings.Reload())
+	require.False(t, settings.RegisterEmailOn())
+
+	payload := map[string]interface{}{
+		"items": []map[string]string{
+			{"category": "register", "key": "email_on", "value": "1"},
+			{"category": "support", "key": "email_smtp", "value": "smtp.test:587"},
+		},
+	}
+	raw, _ := json.Marshal(payload)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/manager/common/system_setting", bytes.NewReader(raw))
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// The handler must call Reload — the test caller sees the new snapshot
+	// without explicitly invoking Reload itself.
+	assert.True(t, settings.RegisterEmailOn(), "Reload should run inside the update handler")
+	assert.Equal(t, "smtp.test:587", settings.SupportEmailSmtp())
+}

--- a/modules/common/db_system_setting.go
+++ b/modules/common/db_system_setting.go
@@ -1,0 +1,82 @@
+package common
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	ldb "github.com/Mininglamp-OSS/octo-lib/pkg/db"
+	"github.com/gocraft/dbr/v2"
+)
+
+// systemSettingDB is the persistence layer for the system_setting KV table.
+//
+// The table stores admin-tunable global config (paired with octo's static yaml
+// defaults). Each row is uniquely identified by (category, key_name); upsert
+// uses that unique key so admins can overwrite values without producing
+// duplicate rows.
+type systemSettingDB struct {
+	session *dbr.Session
+	ctx     *config.Context
+}
+
+func newSystemSettingDB(ctx *config.Context) *systemSettingDB {
+	return &systemSettingDB{
+		session: ctx.DB(),
+		ctx:     ctx,
+	}
+}
+
+// listAll returns every row in system_setting. Callers should treat the result
+// as the full snapshot; empty value means "not configured, fall back to yaml".
+func (s *systemSettingDB) listAll() ([]*systemSettingModel, error) {
+	var rows []*systemSettingModel
+	_, err := s.session.Select("*").From("system_setting").Load(&rows)
+	return rows, err
+}
+
+// upsert writes the row identified by (category, key_name). If the row exists,
+// value / value_type / description are overwritten; otherwise a new row is
+// inserted. Implemented via INSERT ... ON DUPLICATE KEY UPDATE so the unique
+// index `uk_category_key` enforces idempotency at the database layer.
+func (s *systemSettingDB) upsert(category, key, value, valueType, description string) error {
+	return upsertSystemSettingOn(s.session, category, key, value, valueType, description)
+}
+
+// upsertWithTx is the transactional flavour of upsert. The manager API uses
+// it to apply a batch of admin edits atomically: either every row in the
+// payload is persisted, or none are.
+func (s *systemSettingDB) upsertWithTx(tx *dbr.Tx, category, key, value, valueType, description string) error {
+	return upsertSystemSettingOn(tx, category, key, value, valueType, description)
+}
+
+// beginTx opens a new transaction on the underlying session; callers must
+// commit or rollback. Exposed so the manager layer can batch the entire
+// admin payload without producing partial writes on mid-batch error.
+func (s *systemSettingDB) beginTx() (*dbr.Tx, error) {
+	return s.session.Begin()
+}
+
+// runner is the minimal surface common to *dbr.Session and *dbr.Tx that we
+// need for INSERT ... ON DUPLICATE KEY UPDATE. Keeping it unexported here
+// avoids leaking a dbr type into the public API.
+type sqlRunner interface {
+	InsertBySql(query string, value ...interface{}) *dbr.InsertBuilder
+}
+
+func upsertSystemSettingOn(runner sqlRunner, category, key, value, valueType, description string) error {
+	_, err := runner.InsertBySql(
+		"INSERT INTO system_setting (category, key_name, value, value_type, description) "+
+			"VALUES (?, ?, ?, ?, ?) "+
+			"ON DUPLICATE KEY UPDATE value = VALUES(value), value_type = VALUES(value_type), description = VALUES(description)",
+		category, key, value, valueType, description,
+	).Exec()
+	return err
+}
+
+// systemSettingModel mirrors the system_setting row layout.
+type systemSettingModel struct {
+	Category    string
+	KeyName     string
+	Value       string
+	ValueType   string
+	Description string
+	ldb.BaseModel
+}

--- a/modules/common/db_system_setting_test.go
+++ b/modules/common/db_system_setting_test.go
@@ -1,0 +1,56 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSystemSettingDB_UpsertAndList(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	db := newSystemSettingDB(ctx)
+
+	// Insert path.
+	require.NoError(t, db.upsert("register", "email_on", "1", "bool", "邮箱注册开关"))
+	require.NoError(t, db.upsert("support", "email_smtp", "smtp.example.com:465", "string", "SMTP"))
+
+	rows, err := db.listAll()
+	require.NoError(t, err)
+	assert.Len(t, rows, 2)
+
+	got := map[string]*systemSettingModel{}
+	for _, m := range rows {
+		got[m.Category+"."+m.KeyName] = m
+	}
+
+	assert.Equal(t, "1", got["register.email_on"].Value)
+	assert.Equal(t, "bool", got["register.email_on"].ValueType)
+	assert.Equal(t, "邮箱注册开关", got["register.email_on"].Description)
+	assert.Equal(t, "smtp.example.com:465", got["support.email_smtp"].Value)
+
+	// Update path (unique key collision).
+	require.NoError(t, db.upsert("register", "email_on", "0", "bool", "邮箱注册开关"))
+	rows, err = db.listAll()
+	require.NoError(t, err)
+	assert.Len(t, rows, 2, "upsert must not create a duplicate row")
+
+	for _, m := range rows {
+		if m.Category == "register" && m.KeyName == "email_on" {
+			assert.Equal(t, "0", m.Value)
+		}
+	}
+}
+
+func TestSystemSettingDB_EmptyListing(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	db := newSystemSettingDB(ctx)
+	rows, err := db.listAll()
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}

--- a/modules/common/main_test.go
+++ b/modules/common/main_test.go
@@ -1,0 +1,22 @@
+package common
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain ensures OCTO_MASTER_KEY is set for tests that boot the full
+// common module via testutil.NewTestServer — that path runs
+// insertAppConfigIfNeed which encrypts the RSA private key on first run
+// and panics if the master key is missing. CI sets the same value (see
+// .github/workflows/ci.yml); this fallback keeps local runs ergonomic
+// without leaking the production key into the source tree.
+//
+// Tests that specifically need the env unset (see key_encryption_test.go)
+// must Unset+restore around their assertions; this defaults to set.
+func TestMain(m *testing.M) {
+	if os.Getenv(masterKeyEnv) == "" {
+		_ = os.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
+	}
+	os.Exit(m.Run())
+}

--- a/modules/common/sql/20260518000001_common_legacy01.sql
+++ b/modules/common/sql/20260518000001_common_legacy01.sql
@@ -1,0 +1,24 @@
+-- +migrate Up
+
+-- system_setting: admin 可调全局配置 KV 表
+-- 设计要点：
+--   1. 与旧 app_config 表 keyspace 不重叠；新增 admin 可调字段一律走本表，无需 ALTER TABLE。
+--   2. value 统一字符串存储；helper 层按 value_type 解析。空串视为"未配置"，调用方回落 yaml 默认值。
+--   3. value_type='encrypted' 的字段在 helper 写入侧用 AES-256-GCM (encryptKey) 加密，
+--      读取侧 decryptKey 解密；解密失败回落 yaml 默认值。
+CREATE TABLE `system_setting` (
+    `id`          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `category`    VARCHAR(64)     NOT NULL COMMENT '分类，例如 register / support',
+    `key_name`    VARCHAR(128)    NOT NULL COMMENT 'snake_case 键名',
+    `value`       TEXT            NOT NULL COMMENT '统一字符串存储；bool 用 "1"/"0"；空串=未配置',
+    `value_type`  VARCHAR(16)     NOT NULL DEFAULT 'string' COMMENT 'string / bool / int / encrypted',
+    `description` VARCHAR(255)    NOT NULL DEFAULT '',
+    `created_at`  TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`  TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_category_key` (`category`, `key_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='系统级 admin 可调配置 KV 表';
+
+-- +migrate Down
+
+DROP TABLE `system_setting`;

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -17,6 +17,16 @@ type settingDef struct {
 	Key         string
 	Type        string // settingTypeString | settingTypeBool | settingTypeInt | settingTypeEncrypted
 	Description string
+	// Effective returns the value that is currently in effect for this
+	// setting, applying the DB → yaml → code-default fallback chain. The
+	// listSystemSettings handler uses this to populate `effective_value`
+	// in the GET response so the admin UI can render the actual running
+	// value even when the DB row is absent.
+	//
+	// For settingTypeEncrypted, the returned string is plaintext — the
+	// API layer is responsible for masking before serialisation; never
+	// surface this value directly.
+	Effective func(*SystemSettings) string
 }
 
 // systemSettingSchema enumerates every admin-tunable setting backed by the
@@ -25,15 +35,32 @@ type settingDef struct {
 // — no schema migration is required.
 var systemSettingSchema = []settingDef{
 	// Registration toggles — formerly yaml-only (Register.* in config.go).
-	{Category: "register", Key: "off", Type: settingTypeBool, Description: "是否关闭注册"},
-	{Category: "register", Key: "only_china", Type: settingTypeBool, Description: "仅中国手机号可以注册"},
-	{Category: "register", Key: "username_on", Type: settingTypeBool, Description: "是否开启用户名注册"},
-	{Category: "register", Key: "email_on", Type: settingTypeBool, Description: "是否开启邮箱注册/登录"},
+	{Category: "register", Key: "off", Type: settingTypeBool, Description: "是否关闭注册",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.RegisterOff()) }},
+	{Category: "register", Key: "only_china", Type: settingTypeBool, Description: "仅中国手机号可以注册",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.RegisterOnlyChina()) }},
+	{Category: "register", Key: "username_on", Type: settingTypeBool, Description: "是否开启用户名注册",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.RegisterUsernameOn()) }},
+	{Category: "register", Key: "email_on", Type: settingTypeBool, Description: "是否开启邮箱注册/登录",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.RegisterEmailOn()) }},
 
 	// Email server config — formerly yaml-only (Support.* in config.go).
-	{Category: "support", Key: "email", Type: settingTypeString, Description: "技术支持邮箱（发件人）"},
-	{Category: "support", Key: "email_smtp", Type: settingTypeString, Description: "SMTP 服务器 host:port"},
-	{Category: "support", Key: "email_pwd", Type: settingTypeEncrypted, Description: "SMTP 密码（加密存储）"},
+	{Category: "support", Key: "email", Type: settingTypeString, Description: "技术支持邮箱（发件人）",
+		Effective: func(s *SystemSettings) string { return s.SupportEmail() }},
+	{Category: "support", Key: "email_smtp", Type: settingTypeString, Description: "SMTP 服务器 host:port",
+		Effective: func(s *SystemSettings) string { return s.SupportEmailSmtp() }},
+	{Category: "support", Key: "email_pwd", Type: settingTypeEncrypted, Description: "SMTP 密码（加密存储）",
+		Effective: func(s *SystemSettings) string { return s.SupportEmailPwd() }},
+}
+
+// boolToCanonical normalises a bool to the same "0"/"1" representation that
+// normaliseBool writes to the DB, so GET effective_value and POST request
+// payloads use a single spelling end-to-end.
+func boolToCanonical(v bool) string {
+	if v {
+		return "1"
+	}
+	return "0"
 }
 
 // schemaKey returns the canonical "category.key" string used as map key in

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -1,0 +1,55 @@
+package common
+
+// Value types accepted by system_setting.value_type.
+const (
+	settingTypeString    = "string"
+	settingTypeBool      = "bool"
+	settingTypeInt       = "int"
+	settingTypeEncrypted = "encrypted"
+)
+
+// settingDef is the canonical definition of a system_setting key.
+// The schema slice below is the single source of truth: admin UI reads it to
+// render the form, the helper consults it for type info, and the manager
+// API rejects writes whose (category, key) is not present here.
+type settingDef struct {
+	Category    string
+	Key         string
+	Type        string // settingTypeString | settingTypeBool | settingTypeInt | settingTypeEncrypted
+	Description string
+}
+
+// systemSettingSchema enumerates every admin-tunable setting backed by the
+// system_setting table. To add a new setting, append a row here and use the
+// generic SystemSettings.getBool / getString / getInt / getEncrypted getter
+// — no schema migration is required.
+var systemSettingSchema = []settingDef{
+	// Registration toggles — formerly yaml-only (Register.* in config.go).
+	{Category: "register", Key: "off", Type: settingTypeBool, Description: "是否关闭注册"},
+	{Category: "register", Key: "only_china", Type: settingTypeBool, Description: "仅中国手机号可以注册"},
+	{Category: "register", Key: "username_on", Type: settingTypeBool, Description: "是否开启用户名注册"},
+	{Category: "register", Key: "email_on", Type: settingTypeBool, Description: "是否开启邮箱注册/登录"},
+
+	// Email server config — formerly yaml-only (Support.* in config.go).
+	{Category: "support", Key: "email", Type: settingTypeString, Description: "技术支持邮箱（发件人）"},
+	{Category: "support", Key: "email_smtp", Type: settingTypeString, Description: "SMTP 服务器 host:port"},
+	{Category: "support", Key: "email_pwd", Type: settingTypeEncrypted, Description: "SMTP 密码（加密存储）"},
+}
+
+// schemaKey returns the canonical "category.key" string used as map key in
+// the helper snapshot.
+func schemaKey(category, key string) string {
+	return category + "." + key
+}
+
+// findSchemaDef returns the schema entry for (category, key), or nil if not
+// registered. Manager API write path uses this to reject unknown keys.
+func findSchemaDef(category, key string) *settingDef {
+	for i := range systemSettingSchema {
+		d := &systemSettingSchema[i]
+		if d.Category == category && d.Key == key {
+			return d
+		}
+	}
+	return nil
+}

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -1,0 +1,267 @@
+package common
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"go.uber.org/zap"
+)
+
+// Shared SystemSettings instance. EnsureSystemSettings is the single entry
+// point — every caller (Common.New, NewManager, modules/user/*, modules/base/
+// common.EmailService) goes through it so the in-memory snapshot is shared
+// across the process. Otherwise the admin-write Reload would only update one
+// instance and other modules would keep serving stale values.
+var (
+	sharedMu             sync.Mutex
+	sharedSystemSettings *SystemSettings
+)
+
+// EnsureSystemSettings returns the process-wide SystemSettings instance,
+// constructing it on first call. Safe to call from any goroutine.
+//
+// Failed initial Load is non-fatal: an empty-snapshot instance is stored
+// and the background auto-reload (started here) will retry every
+// reloadTTL. Until then all getters fall back to yaml — degraded mode,
+// not a hard failure. A successful subsequent reload self-heals.
+func EnsureSystemSettings(ctx *config.Context) *SystemSettings {
+	sharedMu.Lock()
+	defer sharedMu.Unlock()
+	if sharedSystemSettings != nil {
+		return sharedSystemSettings
+	}
+	s := NewSystemSettings(ctx, newSystemSettingDB(ctx))
+	if err := s.Load(); err != nil {
+		s.Error("initial SystemSettings load failed; auto-reload will retry",
+			zap.Error(err))
+	}
+	// Self-healing in case Load failed above, and multi-instance sync for
+	// admin writes on peer servers. Lifetime tied to the process: context.
+	// Background is intentional — server has no cancellation handle to
+	// thread through here, and the goroutine is harmless to leak at
+	// shutdown.
+	s.StartAutoReload(context.Background())
+	sharedSystemSettings = s
+	return sharedSystemSettings
+}
+
+// (resetSharedSystemSettingsForTest was removed: octo-lib's
+// register.GetModules caches the moduleList with sync.Once for the lifetime
+// of a test binary, so the Manager's stored *SystemSettings is bound to
+// the first ctx. Resetting the package-level singleton produces a fresh
+// instance that the Manager does NOT see, which historically led to
+// confusing test failures. Tests should instead reuse the singleton
+// captured by NewManager and mutate state through it. See
+// TestManagerSystemSetting_BoolEmptyValueResetsToYaml for the pattern.)
+
+// defaultReloadTTL is how often the background goroutine pulls a fresh
+// snapshot from system_setting. 60s is the agreed budget for multi-instance
+// drift: an admin-side change becomes visible on every server within one TTL.
+const defaultReloadTTL = 60 * time.Second
+
+// SystemSettings is the read path for admin-tunable global config.
+//
+// Lookup model:
+//   - Snapshot is an immutable map[string]string ("category.key" → value),
+//     swapped atomically by Load / Reload. Readers go through atomic.Pointer
+//     and never take a lock; SMTP send (high-frequency) does not block on
+//     admin writes.
+//   - Empty DB value means "not configured" and falls back to the matching
+//     yaml field on *config.Config.
+//   - Encrypted values are decrypted at snapshot-build time and cached in
+//     plaintext form in the map; the high-frequency read path never calls
+//     the cipher. Decryption failure logs an error and skips the entry, so
+//     the getter falls back to yaml rather than serving a corrupt value.
+type SystemSettings struct {
+	ctx       *config.Context
+	db        *systemSettingDB
+	snapshot  atomic.Pointer[map[string]string]
+	reloadTTL time.Duration
+	log.Log
+}
+
+// NewSystemSettings builds a helper with an empty initial snapshot.
+// Callers must invoke Load() once at startup before serving traffic;
+// Reload() is safe to call at any time (admin write path uses it).
+func NewSystemSettings(ctx *config.Context, db *systemSettingDB) *SystemSettings {
+	s := &SystemSettings{
+		ctx:       ctx,
+		db:        db,
+		reloadTTL: defaultReloadTTL,
+		Log:       log.NewTLog("SystemSettings"),
+	}
+	empty := map[string]string{}
+	s.snapshot.Store(&empty)
+	return s
+}
+
+// Load reads every row from system_setting and atomically replaces the
+// snapshot. Used at startup and by Reload (which is just an alias for
+// "load now" with logging semantics).
+func (s *SystemSettings) Load() error {
+	rows, err := s.db.listAll()
+	if err != nil {
+		return err
+	}
+	next := make(map[string]string, len(rows))
+	for _, row := range rows {
+		if row.ValueType == settingTypeEncrypted {
+			if row.Value == "" {
+				continue // empty → fall back to yaml
+			}
+			plaintext, err := decryptKey(row.Value)
+			if err != nil {
+				s.Error("decrypt system_setting failed; falling back to yaml",
+					zap.String("category", row.Category),
+					zap.String("key", row.KeyName),
+					zap.Error(err))
+				continue
+			}
+			next[schemaKey(row.Category, row.KeyName)] = plaintext
+			continue
+		}
+		next[schemaKey(row.Category, row.KeyName)] = row.Value
+	}
+	s.snapshot.Store(&next)
+	return nil
+}
+
+// Reload is the admin-write hook: after the manager API upserts new values
+// it calls this so the change is visible on this instance immediately
+// (other instances pick it up within reloadTTL).
+func (s *SystemSettings) Reload() error {
+	return s.Load()
+}
+
+// StartAutoReload kicks off a goroutine that re-loads the snapshot every
+// reloadTTL until ctx is canceled. Intended to be called once at startup
+// (with a long-lived context). Errors are logged but do not stop the loop.
+//
+// Production callers pass context.Background() — the goroutine therefore
+// runs for the lifetime of the process and shuts down with it. The
+// ctx.Done() arm exists to make this swappable: if a server-shutdown
+// context is ever plumbed through, no code change is needed here. The
+// defer ticker.Stop() is reached only on that future cancellation; with
+// context.Background() it is unreachable but kept so the function stays
+// correct under either invocation.
+func (s *SystemSettings) StartAutoReload(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(s.reloadTTL)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := s.Load(); err != nil {
+					s.Error("auto-reload system_setting failed", zap.Error(err))
+				}
+			}
+		}
+	}()
+}
+
+// ----- generic getters -----
+
+func (s *SystemSettings) lookup(category, key string) (string, bool) {
+	// Defensive: NewSystemSettings always seeds a non-nil map, but a
+	// zero-value SystemSettings literal (e.g. tests that bypass the
+	// constructor) would crash here without this guard.
+	snapPtr := s.snapshot.Load()
+	if snapPtr == nil {
+		return "", false
+	}
+	v, ok := (*snapPtr)[schemaKey(category, key)]
+	if !ok || v == "" {
+		return "", false
+	}
+	return v, true
+}
+
+func (s *SystemSettings) getBool(category, key string, fallback bool) bool {
+	v, ok := s.lookup(category, key)
+	if !ok {
+		return fallback
+	}
+	switch v {
+	case "1", "true", "TRUE":
+		return true
+	case "0", "false", "FALSE":
+		return false
+	default:
+		return fallback
+	}
+}
+
+func (s *SystemSettings) getString(category, key string, fallback string) string {
+	v, ok := s.lookup(category, key)
+	if !ok {
+		return fallback
+	}
+	return v
+}
+
+func (s *SystemSettings) getInt(category, key string, fallback int) int {
+	v, ok := s.lookup(category, key)
+	if !ok {
+		return fallback
+	}
+	parsed, err := strconv.Atoi(v)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}
+
+func (s *SystemSettings) getEncrypted(category, key string, fallback string) string {
+	// Encrypted values are stored decrypted in the snapshot, so a plain
+	// lookup is sufficient. The dedicated method exists so callers — and
+	// readers — can see the difference between "stored as encrypted" and
+	// "stored as string".
+	return s.getString(category, key, fallback)
+}
+
+// ----- typed getters (the 7 settings shipped this iteration) -----
+
+// RegisterOff returns whether registration is globally disabled.
+// DB value wins over cfg.Register.Off when set.
+func (s *SystemSettings) RegisterOff() bool {
+	return s.getBool("register", "off", s.ctx.GetConfig().Register.Off)
+}
+
+// RegisterOnlyChina returns whether only China-region phone numbers may register.
+func (s *SystemSettings) RegisterOnlyChina() bool {
+	return s.getBool("register", "only_china", s.ctx.GetConfig().Register.OnlyChina)
+}
+
+// RegisterUsernameOn returns whether username-based registration is enabled.
+func (s *SystemSettings) RegisterUsernameOn() bool {
+	return s.getBool("register", "username_on", s.ctx.GetConfig().Register.UsernameOn)
+}
+
+// RegisterEmailOn returns whether email-based registration / login is enabled.
+func (s *SystemSettings) RegisterEmailOn() bool {
+	return s.getBool("register", "email_on", s.ctx.GetConfig().Register.EmailOn)
+}
+
+// SupportEmail returns the From address used by the SMTP sender.
+func (s *SystemSettings) SupportEmail() string {
+	return s.getString("support", "email", s.ctx.GetConfig().Support.Email)
+}
+
+// SupportEmailSmtp returns the SMTP host:port endpoint.
+func (s *SystemSettings) SupportEmailSmtp() string {
+	return s.getString("support", "email_smtp", s.ctx.GetConfig().Support.EmailSmtp)
+}
+
+// SupportEmailPwd returns the (decrypted) SMTP password. If the stored
+// ciphertext fails to decrypt at Load time, the snapshot omits the key and
+// this getter returns the yaml fallback.
+func (s *SystemSettings) SupportEmailPwd() string {
+	return s.getEncrypted("support", "email_pwd", s.ctx.GetConfig().Support.EmailPwd)
+}

--- a/modules/common/system_settings_test.go
+++ b/modules/common/system_settings_test.go
@@ -1,0 +1,136 @@
+package common
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// helper to construct a SystemSettings backed by the test DB plus the given
+// yaml-side defaults applied to the context's config.
+func newTestSystemSettings(t *testing.T, apply func(s *SystemSettings)) *SystemSettings {
+	t.Helper()
+	// Defensive reset: key_encryption_test.go intentionally Unsetenvs the
+	// master key without restoring it, so any test running after it would
+	// panic when NewTestServer triggers RSA private-key encryption. Reset
+	// here so test order is irrelevant.
+	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	db := newSystemSettingDB(ctx)
+	s := NewSystemSettings(ctx, db)
+	require.NoError(t, s.Load())
+	if apply != nil {
+		apply(s)
+	}
+	return s
+}
+
+func TestSystemSettings_BoolFallsBackToYamlWhenUnset(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	s.ctx.GetConfig().Register.EmailOn = true
+	s.ctx.GetConfig().Register.Off = false
+	require.NoError(t, s.Reload())
+
+	assert.True(t, s.RegisterEmailOn(), "DB empty -> fall back to yaml true")
+	assert.False(t, s.RegisterOff(), "DB empty -> fall back to yaml false")
+}
+
+func TestSystemSettings_BoolOverridesYamlWhenSet(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	s.ctx.GetConfig().Register.EmailOn = true // yaml says on
+	s.ctx.GetConfig().Register.Off = false    // yaml says open
+
+	// Admin disables both via DB.
+	require.NoError(t, s.db.upsert("register", "email_on", "0", settingTypeBool, ""))
+	require.NoError(t, s.db.upsert("register", "off", "1", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+
+	assert.False(t, s.RegisterEmailOn(), "DB 0 must override yaml true")
+	assert.True(t, s.RegisterOff(), "DB 1 must override yaml false")
+}
+
+func TestSystemSettings_StringFallsBackOnEmpty(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	s.ctx.GetConfig().Support.EmailSmtp = "smtp.yaml.example:465"
+
+	// No DB row -> yaml fallback.
+	assert.Equal(t, "smtp.yaml.example:465", s.SupportEmailSmtp())
+
+	// Empty DB value still triggers fallback (treated as "not configured").
+	require.NoError(t, s.db.upsert("support", "email_smtp", "", settingTypeString, ""))
+	require.NoError(t, s.Reload())
+	assert.Equal(t, "smtp.yaml.example:465", s.SupportEmailSmtp())
+
+	// Non-empty DB value wins.
+	require.NoError(t, s.db.upsert("support", "email_smtp", "smtp.db.example:587", settingTypeString, ""))
+	require.NoError(t, s.Reload())
+	assert.Equal(t, "smtp.db.example:587", s.SupportEmailSmtp())
+}
+
+func TestSystemSettings_EncryptedRoundTrip(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	s.ctx.GetConfig().Support.EmailPwd = "yaml-fallback"
+
+	// Store encrypted; helper must decrypt on read.
+	enc, err := encryptKey("real-smtp-password")
+	require.NoError(t, err)
+	require.NoError(t, s.db.upsert("support", "email_pwd", enc, settingTypeEncrypted, ""))
+	require.NoError(t, s.Reload())
+
+	assert.Equal(t, "real-smtp-password", s.SupportEmailPwd())
+}
+
+func TestSystemSettings_EncryptedDecryptFailureFallsBackToYaml(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	s.ctx.GetConfig().Support.EmailPwd = "yaml-pwd"
+
+	// Corrupted ciphertext (enc: prefix but invalid body).
+	require.NoError(t, s.db.upsert("support", "email_pwd", "enc:not-real-base64", settingTypeEncrypted, ""))
+	require.NoError(t, s.Reload())
+
+	assert.Equal(t, "yaml-pwd", s.SupportEmailPwd(), "decryption failure must fall back to yaml, not panic")
+}
+
+func TestSystemSettings_ReloadRefreshesSnapshot(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	s.ctx.GetConfig().Register.EmailOn = false
+
+	require.NoError(t, s.db.upsert("register", "email_on", "1", settingTypeBool, ""))
+	// Before reload, snapshot still empty -> yaml.
+	assert.False(t, s.RegisterEmailOn())
+
+	require.NoError(t, s.Reload())
+	assert.True(t, s.RegisterEmailOn())
+}
+
+func TestSystemSettings_ConcurrentReadsAndReloads(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	s.ctx.GetConfig().Register.EmailOn = false
+	require.NoError(t, s.db.upsert("register", "email_on", "1", settingTypeBool, ""))
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				_ = s.RegisterEmailOn()
+				_ = s.SupportEmailSmtp()
+			}
+		}()
+	}
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				_ = s.Reload()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/modules/space/api_test.go
+++ b/modules/space/api_test.go
@@ -27,8 +27,18 @@ var (
 	testSpaceDB *DB
 )
 
-// TestMain 确保 space 迁移所依赖的外部表存在，并创建共享测试服务器
+// TestMain 确保 space 迁移所依赖的外部表存在，并创建共享测试服务器。
+//
+// OCTO_MASTER_KEY 必须在 NewTestServer 之前设置：space 包通过
+// email_invite_sender.go 直接 import modules/common，会触发 common 的
+// init() 注册 Module；NewTestServer 走到 common.Route() 时会调用
+// insertAppConfigIfNeed → encryptKey/decryptKey，缺 key 会 panic。
+// 这里 fallback 一个固定值，CI 已显式 export 同名变量，本地裸跑也能过。
 func TestMain(m *testing.M) {
+	if os.Getenv("OCTO_MASTER_KEY") == "" {
+		_ = os.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	}
+
 	db, err := sql.Open("mysql", "root:demo@tcp(127.0.0.1)/test?charset=utf8mb4&parseTime=true")
 	if err != nil {
 		panic("连接测试数据库失败: " + err.Error())

--- a/modules/space/email_invite_sender.go
+++ b/modules/space/email_invite_sender.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	commonapi "github.com/Mininglamp-OSS/octo-server/modules/base/common"
+	common "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"go.uber.org/zap"
 )
 
@@ -48,7 +49,7 @@ func (s *Space) currentInviteSender() inviteEmailSender {
 	if v := getInviteEmailSenderForTest(); v != nil {
 		return v
 	}
-	return commonapi.NewEmailService(s.ctx)
+	return commonapi.NewEmailService(s.ctx, common.EnsureSystemSettings(s.ctx))
 }
 
 // dispatchInviteEmail 同步发送一封 owner/member 邀请邮件。

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -1450,6 +1450,16 @@ func (u *User) register(c *wkhttp.Context) {
 		c.ResponseError(errors.New("注册通道暂不开放，请长按标题使用官网上演示账号登录"))
 		return
 	}
+	// 仅中国号码闸门必须在 register 这里再判一次：sendRegisterCode 处的
+	// 校验只能拦"取码"动作，但管理员把 only_china 切到 1 之前已发出去的
+	// 验证码、或任何能让 smsService.Verify 通过的外部路径，都还能拿着
+	// 非 0086 区号走到这里完成注册。把判断前移到 createUser 之前，
+	// 闭合 time-of-check vs time-of-use 缺口。
+	if common2.EnsureSystemSettings(u.ctx).RegisterOnlyChina() &&
+		strings.TrimSpace(req.Zone) != "0086" {
+		c.ResponseError(errors.New("仅仅支持中国大陆手机号注册！"))
+		return
+	}
 	appConfig, err := u.commonService.GetAppConfig()
 	if err != nil {
 		u.Error("查询应用设置错误", zap.Error(err))

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -1446,7 +1446,7 @@ func (u *User) register(c *wkhttp.Context) {
 		return
 	}
 
-	if u.ctx.GetConfig().Register.Off {
+	if common2.EnsureSystemSettings(u.ctx).RegisterOff() {
 		c.ResponseError(errors.New("注册通道暂不开放，请长按标题使用官网上演示账号登录"))
 		return
 	}
@@ -2241,7 +2241,7 @@ func (u *User) blacklists(c *wkhttp.Context) {
 
 // sendRegisterCode 发送注册短信
 func (u *User) sendRegisterCode(c *wkhttp.Context) {
-	if u.ctx.GetConfig().Register.Off {
+	if common2.EnsureSystemSettings(u.ctx).RegisterOff() {
 		c.ResponseError(errors.New("注册通道暂不开放，请长按标题使用官网上演示账号登录"))
 		return
 	}
@@ -2258,7 +2258,7 @@ func (u *User) sendRegisterCode(c *wkhttp.Context) {
 		c.ResponseError(errors.New("手机号不能为空！"))
 		return
 	}
-	if u.ctx.GetConfig().Register.OnlyChina {
+	if common2.EnsureSystemSettings(u.ctx).RegisterOnlyChina() {
 		if strings.TrimSpace(req.Zone) != "0086" {
 			c.ResponseError(errors.New("仅仅支持中国大陆手机号注册！"))
 			return

--- a/modules/user/api_emaillogin.go
+++ b/modules/user/api_emaillogin.go
@@ -35,14 +35,23 @@ func (u *User) emailSendCode(c *wkhttp.Context) {
 		c.ResponseError(errors.New("邮箱格式不正确"))
 		return
 	}
-	if !common.EnsureSystemSettings(u.ctx).RegisterEmailOn() {
-		switch commonapi.CodeType(req.CodeType) {
+	settings := common.EnsureSystemSettings(u.ctx)
+	codeType := commonapi.CodeType(req.CodeType)
+	if codeType == commonapi.CodeTypeRegister && settings.RegisterOff() {
+		c.ResponseError(errors.New("注册通道暂不开放"))
+		return
+	}
+	if !settings.RegisterEmailOn() {
+		switch codeType {
 		case commonapi.CodeTypeRegister:
 			c.ResponseError(errors.New("暂不支持邮箱注册"))
 			return
 		case commonapi.CodeTypeEmailLogin:
 			c.ResponseError(errors.New("暂不支持邮箱登录"))
 			return
+		default:
+			// RegisterEmailOn controls email registration/login only. Password
+			// recovery codes remain available for existing accounts.
 		}
 	}
 

--- a/modules/user/api_emaillogin.go
+++ b/modules/user/api_emaillogin.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	commonapi "github.com/Mininglamp-OSS/octo-server/modules/base/common"
+	common "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -35,7 +36,7 @@ func (u *User) emailSendCode(c *wkhttp.Context) {
 		return
 	}
 
-	emailService := commonapi.NewEmailService(u.ctx)
+	emailService := commonapi.NewEmailService(u.ctx, common.EnsureSystemSettings(u.ctx))
 	if err := emailService.SendVerifyCode(context.Background(), req.Email, commonapi.CodeType(req.CodeType)); err != nil {
 		u.Error("发送邮箱验证码失败", zap.String("email", req.Email), zap.Error(err))
 		c.ResponseError(err)
@@ -46,7 +47,7 @@ func (u *User) emailSendCode(c *wkhttp.Context) {
 
 // emailRegister 邮箱注册
 func (u *User) emailRegister(c *wkhttp.Context) {
-	if !u.ctx.GetConfig().Register.EmailOn {
+	if !common.EnsureSystemSettings(u.ctx).RegisterEmailOn() {
 		c.ResponseError(errors.New("暂不支持邮箱注册"))
 		return
 	}
@@ -97,7 +98,7 @@ func (u *User) emailRegister(c *wkhttp.Context) {
 			c.ResponseError(errors.New("验证码不能为空"))
 			return
 		}
-		emailService := commonapi.NewEmailService(u.ctx)
+		emailService := commonapi.NewEmailService(u.ctx, common.EnsureSystemSettings(u.ctx))
 		if err := emailService.Verify(context.Background(), req.Email, req.Code, commonapi.CodeTypeRegister); err != nil {
 			c.ResponseError(err)
 			return
@@ -246,7 +247,7 @@ func (u *User) emailLogin(c *wkhttp.Context) {
 
 	// 优先验证码登录，其次密码登录
 	if req.Code != "" {
-		emailService := commonapi.NewEmailService(u.ctx)
+		emailService := commonapi.NewEmailService(u.ctx, common.EnsureSystemSettings(u.ctx))
 		if err := emailService.Verify(loginSpanCtx, req.Email, req.Code, commonapi.CodeTypeEmailLogin); err != nil {
 			c.ResponseError(err)
 			return
@@ -307,7 +308,7 @@ func (u *User) emailForgetPwd(c *wkhttp.Context) {
 	}
 
 	// 验证验证码
-	emailService := commonapi.NewEmailService(u.ctx)
+	emailService := commonapi.NewEmailService(u.ctx, common.EnsureSystemSettings(u.ctx))
 	if err := emailService.Verify(context.Background(), req.Email, req.Code, commonapi.CodeTypeForgetLoginPWD); err != nil {
 		c.ResponseError(err)
 		return

--- a/modules/user/api_emaillogin.go
+++ b/modules/user/api_emaillogin.go
@@ -35,6 +35,16 @@ func (u *User) emailSendCode(c *wkhttp.Context) {
 		c.ResponseError(errors.New("邮箱格式不正确"))
 		return
 	}
+	if !common.EnsureSystemSettings(u.ctx).RegisterEmailOn() {
+		switch commonapi.CodeType(req.CodeType) {
+		case commonapi.CodeTypeRegister:
+			c.ResponseError(errors.New("暂不支持邮箱注册"))
+			return
+		case commonapi.CodeTypeEmailLogin:
+			c.ResponseError(errors.New("暂不支持邮箱登录"))
+			return
+		}
+	}
 
 	emailService := commonapi.NewEmailService(u.ctx, common.EnsureSystemSettings(u.ctx))
 	if err := emailService.SendVerifyCode(context.Background(), req.Email, commonapi.CodeType(req.CodeType)); err != nil {
@@ -47,7 +57,12 @@ func (u *User) emailSendCode(c *wkhttp.Context) {
 
 // emailRegister 邮箱注册
 func (u *User) emailRegister(c *wkhttp.Context) {
-	if !common.EnsureSystemSettings(u.ctx).RegisterEmailOn() {
+	settings := common.EnsureSystemSettings(u.ctx)
+	if settings.RegisterOff() {
+		c.ResponseError(errors.New("注册通道暂不开放"))
+		return
+	}
+	if !settings.RegisterEmailOn() {
 		c.ResponseError(errors.New("暂不支持邮箱注册"))
 		return
 	}
@@ -177,6 +192,10 @@ func (u *User) emailRegister(c *wkhttp.Context) {
 
 // emailLogin 邮箱登录（验证码方式）
 func (u *User) emailLogin(c *wkhttp.Context) {
+	if !common.EnsureSystemSettings(u.ctx).RegisterEmailOn() {
+		c.ResponseError(errors.New("暂不支持邮箱登录"))
+		return
+	}
 	type reqVO struct {
 		Email    string     `json:"email"`
 		Code     string     `json:"code"`

--- a/modules/user/api_emaillogin_test.go
+++ b/modules/user/api_emaillogin_test.go
@@ -151,6 +151,15 @@ func TestEmailForgetPasswordCodeAllowedWhenEmailLoginDisabled(t *testing.T) {
 	assert.NotContains(t, w.Body.String(), "暂不支持邮箱")
 }
 
+// setSystemSettingForUserTest writes a system_setting row and registers a
+// cleanup that deletes the row AND reloads the shared SystemSettings
+// snapshot. Without the cleanup, the singleton's in-memory snapshot keeps
+// the override across tests — testutil.CleanAllTables truncates the table
+// but does not touch process-local caches, so later tests would see
+// `register.off=1` even after the DB row is gone. Caller usually pairs
+// this with EnsureSystemSettings(...).Reload() to push the new value into
+// the snapshot; the cleanup ensures the snapshot is restored regardless of
+// whether the caller did or did not call Reload at write time.
 func setSystemSettingForUserTest(t *testing.T, ctx *config.Context, category, key, value, valueType string) {
 	t.Helper()
 	_, err := ctx.DB().InsertBySql(
@@ -160,6 +169,16 @@ func setSystemSettingForUserTest(t *testing.T, ctx *config.Context, category, ke
 		category, key, value, valueType,
 	).Exec()
 	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if _, delErr := ctx.DB().DeleteFrom("system_setting").
+			Where("category = ? AND key_name = ?", category, key).Exec(); delErr != nil {
+			t.Logf("cleanup: delete system_setting %s.%s failed: %v", category, key, delErr)
+		}
+		if reloadErr := commonsettings.EnsureSystemSettings(ctx).Reload(); reloadErr != nil {
+			t.Logf("cleanup: reload SystemSettings failed: %v", reloadErr)
+		}
+	})
 }
 
 func setPublicIPForUserTest(req *http.Request, ip string) {

--- a/modules/user/api_emaillogin_test.go
+++ b/modules/user/api_emaillogin_test.go
@@ -1,10 +1,19 @@
 package user
 
 import (
+	"bytes"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	commonapi "github.com/Mininglamp-OSS/octo-server/modules/base/common"
+	commonsettings "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestCommitCallbackErrorPropagation verifies that when a commit callback
@@ -49,6 +58,79 @@ func TestCommitCallbackErrorPropagation(t *testing.T) {
 // simulateCommitFailure simulates a database commit failure
 func simulateCommitFailure() error {
 	return errors.New("database commit failed")
+}
+
+func TestEmailRegisterBlockedByRegisterOff(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	setSystemSettingForUserTest(t, ctx, "register", "off", "1", "bool")
+	setSystemSettingForUserTest(t, ctx, "register", "email_on", "1", "bool")
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/user/emailregister", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+		"email":    "blocked@example.com",
+		"code":     "123456",
+		"password": "1234567",
+		"name":     "blocked",
+	}))))
+	setPublicIPForUserTest(req, "8.8.8.8")
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.Contains(t, w.Body.String(), "注册通道暂不开放")
+}
+
+func TestEmailLoginBlockedByEmailOn(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	setSystemSettingForUserTest(t, ctx, "register", "email_on", "0", "bool")
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/user/emaillogin", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+		"email":    "blocked@example.com",
+		"password": "1234567",
+	}))))
+	setPublicIPForUserTest(req, "8.8.4.4")
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.Contains(t, w.Body.String(), "暂不支持邮箱登录")
+}
+
+func TestEmailSendCodeBlockedByEmailOnForLoginAndRegister(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	setSystemSettingForUserTest(t, ctx, "register", "email_on", "0", "bool")
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	for _, codeType := range []commonapi.CodeType{commonapi.CodeTypeRegister, commonapi.CodeTypeEmailLogin} {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/v1/user/email/sendcode", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+			"email":     "blocked@example.com",
+			"code_type": int(codeType),
+		}))))
+		setPublicIPForUserTest(req, "1.1.1.1")
+		s.GetRoute().ServeHTTP(w, req)
+
+		assert.Contains(t, w.Body.String(), "暂不支持邮箱")
+	}
+}
+
+func setSystemSettingForUserTest(t *testing.T, ctx *config.Context, category, key, value, valueType string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO system_setting (category, key_name, value, value_type, description) "+
+			"VALUES (?, ?, ?, ?, '') "+
+			"ON DUPLICATE KEY UPDATE value = VALUES(value), value_type = VALUES(value_type), description = VALUES(description)",
+		category, key, value, valueType,
+	).Exec()
+	require.NoError(t, err)
+}
+
+func setPublicIPForUserTest(req *http.Request, ip string) {
+	req.Header.Set("X-Forwarded-For", ip)
+	req.Header.Set("X-Real-IP", ip)
+	req.RemoteAddr = ip + ":12345"
 }
 
 // TestCallbackErrorHandling verifies the pattern where callback errors

--- a/modules/user/api_emaillogin_test.go
+++ b/modules/user/api_emaillogin_test.go
@@ -116,6 +116,41 @@ func TestEmailSendCodeBlockedByEmailOnForLoginAndRegister(t *testing.T) {
 	}
 }
 
+func TestEmailSendRegisterCodeBlockedByRegisterOff(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	setSystemSettingForUserTest(t, ctx, "register", "off", "1", "bool")
+	setSystemSettingForUserTest(t, ctx, "register", "email_on", "1", "bool")
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/user/email/sendcode", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+		"email":     "blocked@example.com",
+		"code_type": int(commonapi.CodeTypeRegister),
+	}))))
+	setPublicIPForUserTest(req, "1.0.0.1")
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.Contains(t, w.Body.String(), "注册通道暂不开放")
+}
+
+func TestEmailForgetPasswordCodeAllowedWhenEmailLoginDisabled(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	setSystemSettingForUserTest(t, ctx, "register", "email_on", "0", "bool")
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/user/email/sendcode", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+		"email":     "recover@example.com",
+		"code_type": int(commonapi.CodeTypeForgetLoginPWD),
+	}))))
+	setPublicIPForUserTest(req, "1.0.0.2")
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.NotContains(t, w.Body.String(), "暂不支持邮箱")
+}
+
 func setSystemSettingForUserTest(t *testing.T, ctx *config.Context, category, key, value, valueType string) {
 	t.Helper()
 	_, err := ctx.DB().InsertBySql(

--- a/modules/user/api_gitee.go
+++ b/modules/user/api_gitee.go
@@ -2,13 +2,13 @@ package user
 
 import (
 	"context"
-	"os"
-	"runtime/debug"
 	"fmt"
 	"hash/crc32"
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -16,6 +16,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/network"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	common "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/gin-gonic/gin"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -27,7 +28,7 @@ const (
 )
 
 func (u *User) thirdAuthcode(c *wkhttp.Context) {
-	if u.ctx.GetConfig().Register.Off {
+	if common.EnsureSystemSettings(u.ctx).RegisterOff() {
 		c.ResponseError(errors.New("注册通道暂不开放，请长按标题使用官网上演示账号登录"))
 		return
 	}
@@ -45,7 +46,7 @@ func (u *User) thirdAuthcode(c *wkhttp.Context) {
 }
 
 func (u *User) thirdAuthStatus(c *wkhttp.Context) {
-	if u.ctx.GetConfig().Register.Off {
+	if common.EnsureSystemSettings(u.ctx).RegisterOff() {
 		c.ResponseError(errors.New("注册通道暂不开放，请长按标题使用官网上演示账号登录"))
 		return
 	}

--- a/modules/user/api_gitee.go
+++ b/modules/user/api_gitee.go
@@ -28,10 +28,6 @@ const (
 )
 
 func (u *User) thirdAuthcode(c *wkhttp.Context) {
-	if common.EnsureSystemSettings(u.ctx).RegisterOff() {
-		c.ResponseError(errors.New("注册通道暂不开放，请长按标题使用官网上演示账号登录"))
-		return
-	}
 	authcode := util.GenerUUID()
 	err := u.ctx.GetRedisConn().SetAndExpire(fmt.Sprintf("%s%s", ThirdAuthcodePrefix, authcode), "1", time.Minute*5)
 	if err != nil {
@@ -46,10 +42,6 @@ func (u *User) thirdAuthcode(c *wkhttp.Context) {
 }
 
 func (u *User) thirdAuthStatus(c *wkhttp.Context) {
-	if common.EnsureSystemSettings(u.ctx).RegisterOff() {
-		c.ResponseError(errors.New("注册通道暂不开放，请长按标题使用官网上演示账号登录"))
-		return
-	}
 	authcode := c.Query("authcode")
 	key := fmt.Sprintf("%s%s", ThirdAuthcodePrefix, authcode)
 	result, err := u.ctx.GetRedisConn().GetString(key)
@@ -154,6 +146,10 @@ func (u *User) giteeOAuth(c *wkhttp.Context) {
 		publicIP := util.GetClientPublicIP(c.Request)
 		go u.sentWelcomeMsg(publicIP, userInfoM.UID)
 	} else {
+		if common.EnsureSystemSettings(u.ctx).RegisterOff() {
+			c.ResponseError(errors.New("注册通道暂不开放"))
+			return
+		}
 		// 创建用户
 		uid := util.GenerUUID()
 		name := userInfo.Name

--- a/modules/user/api_gitee.go
+++ b/modules/user/api_gitee.go
@@ -147,6 +147,16 @@ func (u *User) giteeOAuth(c *wkhttp.Context) {
 		go u.sentWelcomeMsg(publicIP, userInfoM.UID)
 	} else {
 		if common.EnsureSystemSettings(u.ctx).RegisterOff() {
+			// 必须先把 authcode 标记为登录失败再返回:thirdAuthcode 起手把 Redis
+			// 里的 key 置为 "1"(等待中),后续成功/失败路径都靠下面的 SetAndExpire
+			// 推进状态。直接 return 会让前端的 /thirdlogin/authstatus 轮询一直拿
+			// 到 "等待中" 直至 5min TTL 过期,而非立刻看到登录失败。
+			// 与 OIDC failure 路径(modules/oidc/api.go SetAuthcode "0")对齐。
+			if redisErr := u.ctx.GetRedisConn().SetAndExpire(
+				fmt.Sprintf("%s%s", ThirdAuthcodePrefix, authcode), "0", time.Minute*1,
+			); redisErr != nil {
+				u.Error("write authcode failure marker after RegisterOff", zap.Error(redisErr))
+			}
 			c.ResponseError(errors.New("注册通道暂不开放"))
 			return
 		}

--- a/modules/user/api_github.go
+++ b/modules/user/api_github.go
@@ -84,6 +84,15 @@ func (u *User) githubOAuth(c *wkhttp.Context) {
 		go u.sentWelcomeMsg(publicIP, userInfoM.UID)
 	} else {
 		if common.EnsureSystemSettings(u.ctx).RegisterOff() {
+			// 必须先把 authcode 标记为登录失败再返回,详见 api_gitee.go 同位
+			// 注释:thirdAuthcode 起手把 Redis 写成 "1",前端轮询靠下面的
+			// SetAndExpire 推进。直接 return 会让 /thirdlogin/authstatus 一直
+			// 拿到"等待中"直到 5min TTL 过期。
+			if redisErr := u.ctx.GetRedisConn().SetAndExpire(
+				fmt.Sprintf("%s%s", ThirdAuthcodePrefix, authcode), "0", time.Minute*1,
+			); redisErr != nil {
+				u.Error("write authcode failure marker after RegisterOff", zap.Error(redisErr))
+			}
 			c.ResponseError(errors.New("注册通道暂不开放"))
 			return
 		}

--- a/modules/user/api_github.go
+++ b/modules/user/api_github.go
@@ -2,13 +2,13 @@ package user
 
 import (
 	"context"
-	"os"
-	"runtime/debug"
 	"fmt"
 	"hash/crc32"
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -16,6 +16,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/network"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	common "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -82,6 +83,10 @@ func (u *User) githubOAuth(c *wkhttp.Context) {
 		publicIP := util.GetClientPublicIP(c.Request)
 		go u.sentWelcomeMsg(publicIP, userInfoM.UID)
 	} else {
+		if common.EnsureSystemSettings(u.ctx).RegisterOff() {
+			c.ResponseError(errors.New("注册通道暂不开放"))
+			return
+		}
 		// 创建用户
 		uid := util.GenerUUID()
 		name := userInfo.Name

--- a/modules/user/api_test.go
+++ b/modules/user/api_test.go
@@ -16,10 +16,41 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	commonsettings "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var token = "token122323"
+
+// 验证 register.only_china=1 时,非 0086 区号在真正注册入口被拦截。
+//
+// 这一道闸门必须在 register 这里,而不仅是在 sendRegisterCode:管理员通过
+// 系统设置把 only_china 从 0 改到 1 时,先前已发出去的短信验证码在 5 分钟
+// 缓存窗口里仍然有效。只在取码入口拦截,攻击者就能在 toggle 翻转之前抢
+// 一个非中国区号的验证码,然后用旧码在 toggle=1 之后完成注册。
+//
+// gate 命中点在 sms.Verify / createUser 之前,所以这条用例不需要 mock SMS。
+func TestPhoneRegisterBlockedByOnlyChina(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	setSystemSettingForUserTest(t, ctx, "register", "only_china", "1", "bool")
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/user/register", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+		"name":     "non-china",
+		"code":     "123456",
+		"zone":     "0001",
+		"phone":    "5551234567",
+		"password": "1234567",
+	}))))
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.Contains(t, w.Body.String(), "仅仅支持中国大陆手机号注册",
+		"register handler must enforce only_china before sms verify; "+
+			"sendRegisterCode-only gate leaks a TTL-window bypass when admins flip the toggle at runtime")
+}
 
 func TestUser_Register(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")

--- a/modules/user/api_thirdlogin_test.go
+++ b/modules/user/api_thirdlogin_test.go
@@ -1,0 +1,44 @@
+package user
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	commonsettings "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestThirdAuthcodeAllowedByRegisterOff(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	setSystemSettingForUserTest(t, ctx, "register", "off", "1", "bool")
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/user/thirdlogin/authcode", nil)
+	s.GetRoute().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "authcode")
+}
+
+func TestThirdAuthStatusAllowedByRegisterOff(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	setSystemSettingForUserTest(t, ctx, "register", "off", "1", "bool")
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	authcode := "third-auth-status-off"
+	require.NoError(t, ctx.GetRedisConn().SetAndExpire(ThirdAuthcodePrefix+authcode, "1", time.Minute))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/user/thirdlogin/authstatus?authcode="+authcode, nil)
+	s.GetRoute().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), `"status":0`)
+}

--- a/modules/user/api_usernamelogin.go
+++ b/modules/user/api_usernamelogin.go
@@ -23,7 +23,12 @@ import (
 
 // 通过用户名注册
 func (u *User) usernameRegister(c *wkhttp.Context) {
-	if !common.EnsureSystemSettings(u.ctx).RegisterUsernameOn() {
+	settings := common.EnsureSystemSettings(u.ctx)
+	if settings.RegisterOff() {
+		c.ResponseError(errors.New("注册通道暂不开放"))
+		return
+	}
+	if !settings.RegisterUsernameOn() {
 		c.ResponseError(errors.New("暂不支持用户名注册"))
 		return
 	}

--- a/modules/user/api_usernamelogin.go
+++ b/modules/user/api_usernamelogin.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkevent"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	event "github.com/Mininglamp-OSS/octo-server/modules/base/event"
+	common "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -22,7 +23,7 @@ import (
 
 // 通过用户名注册
 func (u *User) usernameRegister(c *wkhttp.Context) {
-	if !u.ctx.GetConfig().Register.UsernameOn {
+	if !common.EnsureSystemSettings(u.ctx).RegisterUsernameOn() {
 		c.ResponseError(errors.New("暂不支持用户名注册"))
 		return
 	}

--- a/modules/user/api_usernamelogin_test.go
+++ b/modules/user/api_usernamelogin_test.go
@@ -1,0 +1,33 @@
+package user
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	commonsettings "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUsernameRegisterBlockedByRegisterOff(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	setSystemSettingForUserTest(t, ctx, "register", "off", "1", "bool")
+	setSystemSettingForUserTest(t, ctx, "register", "username_on", "1", "bool")
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/user/usernameregister", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+		"username": "blockeduser",
+		"password": "1234567",
+		"name":     "blocked",
+	}))))
+	setPublicIPForUserTest(req, "9.9.9.9")
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.Contains(t, w.Body.String(), "注册通道暂不开放")
+}

--- a/modules/user/external_login.go
+++ b/modules/user/external_login.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	common "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"go.uber.org/zap"
 )
 
@@ -127,6 +128,9 @@ func (u *User) externalLoginExisting(ctx context.Context, req ExternalLoginReq) 
 }
 
 func (u *User) externalLoginCreate(ctx context.Context, req ExternalLoginReq) (*ExternalLoginResp, error) {
+	if common.EnsureSystemSettings(u.ctx).RegisterOff() {
+		return nil, errors.New("注册通道暂不开放")
+	}
 	if req.UID == "" {
 		return nil, errors.New("user: external login: UID is required when creating new user")
 	}

--- a/modules/user/external_login_test.go
+++ b/modules/user/external_login_test.go
@@ -41,6 +41,14 @@ func setupExternalLoginTest(t *testing.T) *User {
 	).Exec()
 	require.NoError(t, err, "seed app_config")
 
+	// 兜底刷新 SystemSettings snapshot。CleanAllTables 只清 DB,不会触动
+	// EnsureSystemSettings 维护的进程级 snapshot;若先前测试通过
+	// setSystemSettingForUserTest + Reload 把 register.off=1 写进了 snapshot,
+	// 这里不重置就会让本测试组里依赖 yaml 默认值的用例(例如 CreateRequiresUID)
+	// 在 RegisterOff 早于 UID 校验的位置就被短路。
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload(),
+		"reset SystemSettings snapshot after CleanAllTables")
+
 	return New(ctx)
 }
 

--- a/modules/user/external_login_test.go
+++ b/modules/user/external_login_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
+	commonsettings "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -62,12 +63,12 @@ func TestService_LoginByExternalIdentity_ExistingUser(t *testing.T) {
 	u := setupExternalLoginTest(t)
 
 	tests := []struct {
-		name      string
-		seed      *Model // nil 表示不预先插入用户
-		req       ExternalLoginReq
-		wantErr   bool
-		assertOK  func(t *testing.T, resp *ExternalLoginResp)
-		assertDB  func(t *testing.T, u *User)
+		name     string
+		seed     *Model // nil 表示不预先插入用户
+		req      ExternalLoginReq
+		wantErr  bool
+		assertOK func(t *testing.T, resp *ExternalLoginResp)
+		assertDB func(t *testing.T, u *User)
 	}{
 		{
 			name: "normal active user issues session",
@@ -245,4 +246,26 @@ func TestService_LoginByExternalIdentity_CreateRequiresUID(t *testing.T) {
 	assert.Nil(t, resp)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "UID is required")
+}
+
+func TestService_LoginByExternalIdentity_CreateBlockedByRegisterOff(t *testing.T) {
+	u := setupExternalLoginTest(t)
+	setSystemSettingForUserTest(t, u.ctx, "register", "off", "1", "bool")
+	require.NoError(t, commonsettings.EnsureSystemSettings(u.ctx).Reload())
+
+	uid := util.GenerUUID()
+	resp, err := u.userService.LoginByExternalIdentity(context.Background(), ExternalLoginReq{
+		UID:        uid,
+		Name:       "BlockedExternal",
+		Email:      "blocked.external@example.com",
+		DeviceFlag: config.APP,
+	})
+
+	assert.Nil(t, resp)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "注册通道暂不开放")
+
+	got, queryErr := u.db.QueryByUID(uid)
+	require.NoError(t, queryErr)
+	assert.Nil(t, got, "register.off must block new external users before insert")
 }


### PR DESCRIPTION
## Summary
- add a `system_setting` KV table for admin-tunable global config
- expose manager APIs to list, update, and test runtime system settings
- route registration toggles and SMTP settings through DB-backed overrides with YAML fallback

## DB override settings

| Category | Key | Type | YAML fallback | Description |
|---|---|---|---|---|
| `register` | `off` | `bool` | `Register.Off` | disable registration globally |
| `register` | `only_china` | `bool` | `Register.OnlyChina` | restrict registration to China phone numbers |
| `register` | `username_on` | `bool` | `Register.UsernameOn` | enable username registration |
| `register` | `email_on` | `bool` | `Register.EmailOn` | enable email registration/login |
| `support` | `email` | `string` | `Support.Email` | SMTP sender/support email |
| `support` | `email_smtp` | `string` | `Support.EmailSmtp` | SMTP server address (`host:port`) |
| `support` | `email_pwd` | `encrypted` | `Support.EmailPwd` | SMTP password, encrypted at rest |

Empty DB values fall back to YAML defaults. Encrypted values are masked in GET responses; empty update payloads and the `****` mask sentinel preserve the existing ciphertext.

Runtime behavior:
- Settings are read from an in-memory atomic snapshot on every call site.
- A successful `POST /v1/manager/common/system_setting` persists the batch and calls `SystemSettings.Reload()`, so the current server instance sees the new values immediately after the request returns.
- Other server instances pick up the same DB values via background auto-reload within `defaultReloadTTL` (60 seconds).
- If the initial DB load or a later auto-reload fails, getters fall back to YAML defaults until a later reload succeeds.

## Manager APIs
- `GET /v1/manager/common/system_setting` lists schema and current values
- `POST /v1/manager/common/system_setting` updates settings in one transaction
- `POST /v1/manager/common/system_setting/test_email` sends a test email using the effective SMTP config

### API examples

`GET /v1/manager/common/system_setting`

```json
{
  "items": [
    {
      "category": "register",
      "key": "email_on",
      "value": "1",
      "value_type": "bool",
      "description": "是否开启邮箱注册/登录"
    },
    {
      "category": "support",
      "key": "email_pwd",
      "value": "****",
      "value_type": "encrypted",
      "description": "SMTP 密码（加密存储）"
    }
  ],
  "schema": [
    {
      "category": "register",
      "key": "email_on",
      "type": "bool",
      "description": "是否开启邮箱注册/登录"
    }
  ]
}
```

`POST /v1/manager/common/system_setting`

Request:

```json
{
  "items": [
    {"category": "register", "key": "off", "value": "0"},
    {"category": "register", "key": "email_on", "value": "1"},
    {"category": "support", "key": "email", "value": "support@example.com"},
    {"category": "support", "key": "email_smtp", "value": "smtp.example.com:587"},
    {"category": "support", "key": "email_pwd", "value": "new-smtp-password"}
  ]
}
```

Response:

```json
{"status": 200}
```

To keep an existing encrypted value unchanged, send either an empty value or the GET mask:

```json
{
  "items": [
    {"category": "support", "key": "email_pwd", "value": "****"}
  ]
}
```

`POST /v1/manager/common/system_setting/test_email`

Request:

```json
{"to": "admin@example.com"}
```

Response:

```json
{"status": 200}
```

## Review fixes
- enforce `register.off` on email and username registration
- enforce `register.off` on Gitee/GitHub/OIDC new-account creation while preserving existing linked-user login
- keep third-party authcode/status polling available when registration is disabled; the guard only blocks actual new-user creation
- enforce `register.off` on email registration-code sends
- enforce `register.email_on` on email login and registration/login code-send flows
- prevent encrypted `****` mask submissions from overwriting stored secrets
- reject mixed-case bool payloads (`True` / `False`) to keep the write contract aligned with the read side

## Tests
- reset local MySQL test database with `DROP DATABASE IF EXISTS test; CREATE DATABASE test CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;` before DB-backed package runs
- `go test ./modules/common -run 'TestManagerSystemSetting_(UpdateRejectsMixedCaseBool|EncryptedMaskDoesNotOverwrite|EncryptedEmptyDoesNotOverwrite|UpdatePersistsAndReloads)'`
- `go test ./modules/user -run 'Test(EmailRegisterBlockedByRegisterOff|EmailLoginBlockedByEmailOn|EmailSendCodeBlockedByEmailOnForLoginAndRegister|UsernameRegisterBlockedByRegisterOff)'`
- `go test ./modules/user -run 'Test(EmailSendRegisterCodeBlockedByRegisterOff|EmailForgetPasswordCodeAllowedWhenEmailLoginDisabled|ThirdAuthcodeAllowedByRegisterOff|ThirdAuthStatusAllowedByRegisterOff|Service_LoginByExternalIdentity_CreateBlockedByRegisterOff)'`
- `go test ./modules/base/common`
- `OCTO_MASTER_KEY=0123456789abcdef0123456789abcdef go test ./modules/space`
- `go test -c` succeeded for `./modules/common`, `./modules/user`, `./modules/base/common`, and `./modules/space`

Note: full local `go test ./modules/user` still has pre-existing Redis state sensitivity in destroy-account tests unless Redis is flushed between package runs, matching CI's package isolation setup.
