### PR TITLE
fix(common): rich multipart envelope for /test_email to bypass anti-spam silent drops

### DIFF
--- a/modules/base/common/service_email.go
+++ b/modules/base/common/service_email.go
@@ -31,8 +31,8 @@ type IEmailService interface {
 	SendHTMLEmail(ctx context.Context, to, subject, htmlBody string) error
 	// SendTransactionalHTML 发送一封带 plaintext 兜底 + 标准事务邮件 header 的邮件。
 	// 收件方反垃圾过滤对极简 HTML-only 事务邮件常常静默丢弃；这条路径包成
-	// multipart/alternative,补上 Date / Message-ID / Auto-Submitted / Precedence
-	// / List-Unsubscribe,显著降低被丢的概率。
+	// multipart/alternative,补上 Date / Message-ID / Auto-Submitted /
+	// List-Unsubscribe 等 header,显著降低被丢的概率。
 	SendTransactionalHTML(ctx context.Context, to, subject, htmlBody, plainBody string) error
 }
 
@@ -132,8 +132,10 @@ func (s *EmailService) SendHTMLEmail(ctx context.Context, to, subject, htmlBody 
 //
 // 与 SendHTMLEmail 的区别:
 //   - 包成 multipart/alternative,plaintext + HTML 双版本
-//   - 补 Date / Message-ID / Auto-Submitted / Precedence / List-Unsubscribe 等
-//     反垃圾过滤期望看到的事务邮件特征
+//   - 补 Date / Message-ID / Auto-Submitted / List-Unsubscribe 等反垃圾过滤
+//     期望看到的事务邮件特征(故意不发 Precedence: bulk,详见 buildTransactional
+//     Message 中的注释 —— 部分 MTA 会把它解释成"不要生成退信",跟本路径用于
+//     诊断的目的相反)
 //
 // 经验验证:阿里云 SMTP → mininglamp.com 这条链路,只发极简 HTML 单一部分
 // (~300 字节)的测试邮件会被收件方静默丢弃,既不入收件箱也不入垃圾夹也

--- a/modules/base/common/service_email.go
+++ b/modules/base/common/service_email.go
@@ -221,11 +221,17 @@ func buildTransactionalMessage(fromSan, toSan, subjectSan, htmlBody, plainBody s
 		"Message-ID: " + messageID,
 		"MIME-Version: 1.0",
 		`Content-Type: multipart/alternative; boundary="` + boundary + `"`,
+		// List-Unsubscribe 单独保留 mailto 形态(RFC 2369),作为 transactional
+		// 信号给 Gmail/Outlook 打分用。
+		// 不再发 "List-Unsubscribe-Post: One-Click":RFC 8058 要求 One-Click 必
+		// 须配 HTTPS POST endpoint,跟 mailto 配是 misuse,部分打分引擎会判 weak
+		// signal。等真有 HTTPS 退订入口再加回来。
 		"List-Unsubscribe: <mailto:" + fromSan + "?subject=unsubscribe>",
-		"List-Unsubscribe-Post: List-Unsubscribe=One-Click",
 		"X-Mailer: Octo Transactional Mailer",
+		// Auto-Submitted 让收件方知道这是机器生成,顺便压制 out-of-office
+		// 自动回复。不发 "Precedence: bulk":部分 MTA 把它解释为"不要生成 DSN
+		// (退信)",而本 endpoint 的诊断价值正是依赖退信,跟意图相反。
 		"Auto-Submitted: auto-generated",
-		"Precedence: bulk",
 	}
 
 	var b strings.Builder

--- a/modules/base/common/service_email.go
+++ b/modules/base/common/service_email.go
@@ -2,8 +2,10 @@ package common
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/subtle"
 	"crypto/tls"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net"
@@ -27,6 +29,11 @@ type IEmailService interface {
 	Verify(ctx context.Context, email, code string, codeType CodeType) error
 	// SendHTMLEmail 发送一封 HTML 邮件（不走频率限制 / 验证码缓存，由调用方自己控制）
 	SendHTMLEmail(ctx context.Context, to, subject, htmlBody string) error
+	// SendTransactionalHTML 发送一封带 plaintext 兜底 + 标准事务邮件 header 的邮件。
+	// 收件方反垃圾过滤对极简 HTML-only 事务邮件常常静默丢弃；这条路径包成
+	// multipart/alternative,补上 Date / Message-ID / Auto-Submitted / Precedence
+	// / List-Unsubscribe,显著降低被丢的概率。
+	SendTransactionalHTML(ctx context.Context, to, subject, htmlBody, plainBody string) error
 }
 
 // SMTPSettingsProvider exposes the admin-tunable SMTP config to EmailService
@@ -110,6 +117,10 @@ func (s *EmailService) SendVerifyCode(ctx context.Context, email string, codeTyp
 //
 // ctx 的 deadline 会传递到 SMTP 层（dial / 投递阶段）；调用方设的 ctx 比
 // SMTP 默认超时（dial 15s + IO 60s）更紧时，会真正生效。
+//
+// 内容仅含 text/html 单一部分,header 也只补 From/To/Subject/MIME-Version/
+// Content-Type。短 HTML 事务邮件容易被收件方反垃圾静默丢弃 —— 自检/状态类
+// 邮件请改用 SendTransactionalHTML,带 plaintext 兜底和完整事务邮件 header。
 func (s *EmailService) SendHTMLEmail(ctx context.Context, to, subject, htmlBody string) error {
 	if to == "" {
 		return errors.New("收件人不能为空")
@@ -117,61 +128,153 @@ func (s *EmailService) SendHTMLEmail(ctx context.Context, to, subject, htmlBody 
 	return s.sendEmail(ctx, to, subject, htmlBody)
 }
 
-// sendEmail 通过SMTP发送邮件（支持SSL端口465和STARTTLS端口587）。
-// ctx 的 deadline 会被注入到 dial 和 conn.SetDeadline；ctx 无 deadline 时
-// 退化到 smtpDialTimeout / smtpIOTimeout 默认值。
-func (s *EmailService) sendEmail(ctx context.Context, to, subject, body string) error {
-	smtpAddr, from, pwd := s.resolveSMTP()
+// SendTransactionalHTML 发送带 plaintext 兜底 + 标准事务邮件 header 的邮件。
+//
+// 与 SendHTMLEmail 的区别:
+//   - 包成 multipart/alternative,plaintext + HTML 双版本
+//   - 补 Date / Message-ID / Auto-Submitted / Precedence / List-Unsubscribe 等
+//     反垃圾过滤期望看到的事务邮件特征
+//
+// 经验验证:阿里云 SMTP → mininglamp.com 这条链路,只发极简 HTML 单一部分
+// (~300 字节)的测试邮件会被收件方静默丢弃,既不入收件箱也不入垃圾夹也
+// 不退信;同样的链路、同样的凭据,改成 multipart/alternative + 标准 header
+// (~2KB) 后能正常入箱。该方法把这套包装内化,所有"系统自检 / 邀请 / 通知"
+// 类事务邮件应该走这条路径。
+//
+// plainBody 必须由调用方提供(避免依赖脆弱的"从 HTML strip 标签"启发式)。
+// htmlBody 为空时,plaintext 仍会被发出(降级体验,但通路工作)。
+func (s *EmailService) SendTransactionalHTML(ctx context.Context, to, subject, htmlBody, plainBody string) error {
+	if to == "" {
+		return errors.New("收件人不能为空")
+	}
+	smtpAddr, fromAddr, pwd := s.resolveSMTP()
+	if smtpAddr == "" || fromAddr == "" || pwd == "" {
+		return errors.New("邮件服务未配置，请联系管理员")
+	}
+	toSan, fromSan, subjectSan := sanitizeHeader(to), sanitizeHeader(fromAddr), sanitizeHeader(subject)
+	msg, err := buildTransactionalMessage(fromSan, toSan, subjectSan, htmlBody, plainBody)
+	if err != nil {
+		return err
+	}
+	return s.dispatchSMTP(ctx, smtpAddr, fromSan, pwd, toSan, msg)
+}
 
-	if smtpAddr == "" || from == "" || pwd == "" {
+// sendEmail 通过SMTP发送简单的 text/html 单一部分邮件。
+// 用于验证码 / 兼容旧调用方;新通知类邮件请用 SendTransactionalHTML。
+func (s *EmailService) sendEmail(ctx context.Context, to, subject, body string) error {
+	smtpAddr, fromAddr, pwd := s.resolveSMTP()
+
+	if smtpAddr == "" || fromAddr == "" || pwd == "" {
 		return errors.New("邮件服务未配置，请联系管理员")
 	}
 
-	host, port, err := net.SplitHostPort(smtpAddr)
-	if err != nil {
-		return fmt.Errorf("smtp地址格式错误: %w", err)
-	}
+	toSan, fromSan, subjectSan := sanitizeHeader(to), sanitizeHeader(fromAddr), sanitizeHeader(subject)
 
-	auth := smtp.PlainAuth("", from, pwd, host)
-
-	// Sanitize header fields to prevent CRLF injection.
-	// An attacker could inject "Bcc: hacker@evil.com" via \r\n in to/subject.
-	sanitize := func(s string) string {
-		s = strings.ReplaceAll(s, "\r", "")
-		s = strings.ReplaceAll(s, "\n", "")
-		return s
-	}
-	to = sanitize(to)
-	subject = sanitize(subject)
-	from = sanitize(from)
-
-	msg := "From: " + from + "\r\n" +
-		"To: " + to + "\r\n" +
-		"Subject: " + subject + "\r\n" +
+	msg := "From: " + fromSan + "\r\n" +
+		"To: " + toSan + "\r\n" +
+		"Subject: " + subjectSan + "\r\n" +
 		"MIME-Version: 1.0\r\n" +
 		"Content-Type: text/html; charset=UTF-8\r\n" +
 		"\r\n" +
 		body + "\r\n"
 
+	return s.dispatchSMTP(ctx, smtpAddr, fromSan, pwd, toSan, []byte(msg))
+}
+
+// sanitizeHeader 清除 \r / \n,防止 CRLF 注入攻击者构造 "Bcc: hacker@evil.com"
+// 等额外 header。所有用作 SMTP header 字段或 envelope (MAIL FROM / RCPT TO) 的
+// 字符串都必须先过这里。
+func sanitizeHeader(s string) string {
+	s = strings.ReplaceAll(s, "\r", "")
+	s = strings.ReplaceAll(s, "\n", "")
+	return s
+}
+
+// buildTransactionalMessage 拼一份 multipart/alternative 报文,内含两段标准
+// 事务邮件特征 header。boundary 用随机串避免与 body 字面冲突。
+//
+// 设计取舍:把模板字符串内联放在这里而不是模板文件,因为这是 SMTP 层基础
+// 设施,完全不参与产品 UI;调用方传入的 htmlBody / plainBody 才是内容。
+func buildTransactionalMessage(fromSan, toSan, subjectSan, htmlBody, plainBody string) ([]byte, error) {
+	boundaryBytes := make([]byte, 8)
+	if _, err := rand.Read(boundaryBytes); err != nil {
+		return nil, fmt.Errorf("生成 multipart boundary 失败: %w", err)
+	}
+	boundary := "octo_" + hex.EncodeToString(boundaryBytes)
+
+	msgIDBytes := make([]byte, 12)
+	if _, err := rand.Read(msgIDBytes); err != nil {
+		return nil, fmt.Errorf("生成 Message-ID 失败: %w", err)
+	}
+	// Message-ID 的 domain 部分用 From 地址的域名,跟 SPF 校验对齐。
+	domain := "octo.local"
+	if at := strings.LastIndex(fromSan, "@"); at >= 0 && at < len(fromSan)-1 {
+		domain = fromSan[at+1:]
+	}
+	messageID := fmt.Sprintf("<%s@%s>", hex.EncodeToString(msgIDBytes), domain)
+
+	headers := []string{
+		"From: " + fromSan,
+		"To: " + toSan,
+		"Subject: " + subjectSan,
+		"Date: " + time.Now().UTC().Format(time.RFC1123Z),
+		"Message-ID: " + messageID,
+		"MIME-Version: 1.0",
+		`Content-Type: multipart/alternative; boundary="` + boundary + `"`,
+		"List-Unsubscribe: <mailto:" + fromSan + "?subject=unsubscribe>",
+		"List-Unsubscribe-Post: List-Unsubscribe=One-Click",
+		"X-Mailer: Octo Transactional Mailer",
+		"Auto-Submitted: auto-generated",
+		"Precedence: bulk",
+	}
+
+	var b strings.Builder
+	for _, h := range headers {
+		b.WriteString(h)
+		b.WriteString("\r\n")
+	}
+	b.WriteString("\r\n")
+	// plaintext part (RFC 2046: 多个 alternative 时,*先*放最简单的格式,*后*放最丰富的;
+	// 兼容性最差的客户端只会渲染第一个能识别的)。
+	b.WriteString("--" + boundary + "\r\n")
+	b.WriteString("Content-Type: text/plain; charset=UTF-8\r\n")
+	b.WriteString("Content-Transfer-Encoding: 8bit\r\n\r\n")
+	b.WriteString(plainBody)
+	b.WriteString("\r\n")
+	// html part
+	b.WriteString("--" + boundary + "\r\n")
+	b.WriteString("Content-Type: text/html; charset=UTF-8\r\n")
+	b.WriteString("Content-Transfer-Encoding: 8bit\r\n\r\n")
+	b.WriteString(htmlBody)
+	b.WriteString("\r\n")
+	b.WriteString("--" + boundary + "--\r\n")
+	return []byte(b.String()), nil
+}
+
+// dispatchSMTP 跑完一次 SMTP 投递:dial → (STARTTLS) → AUTH → MAIL → RCPT →
+// DATA → QUIT。fromSan / toSan 必须已经过 sanitizeHeader。
+func (s *EmailService) dispatchSMTP(ctx context.Context, smtpAddr, fromSan, pwd, toSan string, msg []byte) error {
+	host, port, err := net.SplitHostPort(smtpAddr)
+	if err != nil {
+		return fmt.Errorf("smtp地址格式错误: %w", err)
+	}
+	auth := smtp.PlainAuth("", fromSan, pwd, host)
+
 	dialer := &net.Dialer{Timeout: smtpDialTimeout}
 	var conn net.Conn
 	if port == "465" {
-		// 端口 465：直连 SSL/TLS。
 		tlsDialer := &tls.Dialer{NetDialer: dialer, Config: &tls.Config{ServerName: host}}
 		conn, err = tlsDialer.DialContext(ctx, "tcp", smtpAddr)
 		if err != nil {
 			return fmt.Errorf("TLS连接失败: %w", err)
 		}
 	} else {
-		// 端口 25 / 587：明文连接，连接后再 STARTTLS。
 		conn, err = dialer.DialContext(ctx, "tcp", smtpAddr)
 		if err != nil {
 			return fmt.Errorf("SMTP 连接失败: %w", err)
 		}
 	}
 	defer conn.Close()
-	// ctx 设了 deadline 就用它；否则退化到 smtpIOTimeout。
-	// 这一行是上限保险——dispatchInviteEmail 给的 30s ctx 会真正约束整个会话。
 	if d, ok := ctx.Deadline(); ok {
 		_ = conn.SetDeadline(d)
 	} else {
@@ -192,7 +295,7 @@ func (s *EmailService) sendEmail(ctx context.Context, to, subject, body string) 
 		}
 	}
 
-	return runSMTPTransaction(client, auth, from, to, []byte(msg))
+	return runSMTPTransaction(client, auth, fromSan, toSan, msg)
 }
 
 // runSMTPTransaction 跑完一次 SMTP 投递：Auth → Mail → Rcpt → Data → Quit。

--- a/modules/base/common/service_email_envelope_test.go
+++ b/modules/base/common/service_email_envelope_test.go
@@ -1,0 +1,95 @@
+package common
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildTransactionalMessage_StructureAndHeaders 验证 SendTransactionalHTML
+// 内部拼出来的报文符合 RFC 2046 multipart/alternative 结构,且带齐"事务邮件"
+// 反垃圾过滤期望看到的 header。
+//
+// 这条 case 是这次 follow-up PR 的核心 —— 经验证收件方反垃圾对极简 HTML 单一
+// part 邮件会静默丢弃,只要 multipart + 标准 header 齐全就能正常入箱。任何
+// 未来调整 buildTransactionalMessage 时,本测试就是 contract guard。
+func TestBuildTransactionalMessage_StructureAndHeaders(t *testing.T) {
+	msg, err := buildTransactionalMessage(
+		"contact@xming.ai",
+		"guobin.a@mininglamp.com",
+		"[Octo] SMTP 自检",
+		"<p>hello</p>",
+		"hello",
+	)
+	require.NoError(t, err)
+	s := string(msg)
+
+	// ---- header block ----
+	assert.Contains(t, s, "From: contact@xming.ai\r\n")
+	assert.Contains(t, s, "To: guobin.a@mininglamp.com\r\n")
+	assert.Contains(t, s, "Subject: [Octo] SMTP 自检\r\n")
+	assert.Regexp(t, regexp.MustCompile(`(?m)^Date: .+\r$`), s, "Date header must be present")
+	assert.Regexp(t, regexp.MustCompile(`(?m)^Message-ID: <[0-9a-f]+@xming\.ai>\r$`), s,
+		"Message-ID domain should follow From's domain so SPF/DKIM alignment is sane")
+	assert.Contains(t, s, "MIME-Version: 1.0\r\n")
+	assert.Contains(t, s, `Content-Type: multipart/alternative; boundary="octo_`,
+		"Top-level Content-Type must declare multipart/alternative with a deterministic boundary prefix")
+	assert.Contains(t, s, "List-Unsubscribe: <mailto:contact@xming.ai?subject=unsubscribe>\r\n",
+		"List-Unsubscribe is one of the strongest transactional-email signals for Gmail/Outlook")
+	assert.Contains(t, s, "List-Unsubscribe-Post: List-Unsubscribe=One-Click\r\n")
+	assert.Contains(t, s, "Auto-Submitted: auto-generated\r\n")
+	assert.Contains(t, s, "Precedence: bulk\r\n")
+	assert.Contains(t, s, "X-Mailer: Octo Transactional Mailer\r\n")
+
+	// ---- multipart body ----
+	plainPos := strings.Index(s, "Content-Type: text/plain")
+	htmlPos := strings.Index(s, "Content-Type: text/html")
+	require.Positive(t, plainPos, "plaintext part must exist")
+	require.Positive(t, htmlPos, "html part must exist")
+	assert.Less(t, plainPos, htmlPos,
+		"RFC 2046: alternative parts go simplest-first; plaintext must precede html "+
+			"so naive clients render plaintext fallback instead of raw markup")
+
+	// 报文必须以 boundary close 收尾,缺了就成 broken multipart,部分严格邮件
+	// 网关会拒收。
+	assert.True(t, strings.HasSuffix(s, "--\r\n"), "envelope must end with a closing boundary line")
+}
+
+// TestBuildTransactionalMessage_FromMissingAtSign 验证 Message-ID 的 domain
+// fallback 路径 —— from 没有 @ 时不能 panic,也不能产生空 domain。
+func TestBuildTransactionalMessage_FromMissingAtSign(t *testing.T) {
+	msg, err := buildTransactionalMessage(
+		"contact", // 没有 @
+		"u@example.com",
+		"subj",
+		"<p>h</p>",
+		"h",
+	)
+	require.NoError(t, err)
+	assert.Regexp(t, regexp.MustCompile(`(?m)^Message-ID: <[0-9a-f]+@octo\.local>\r$`), string(msg),
+		"degraded From should fall back to a safe domain stub, never produce <id@>")
+}
+
+// TestSanitizeHeader_StripsCRLF 验证 CRLF 消毒。攻击者控制的 to / subject
+// 不能注入额外 header(比如 \r\nBcc: hacker@evil.com)。
+func TestSanitizeHeader_StripsCRLF(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "guobin.a@example.com", "guobin.a@example.com"},
+		{"lf injection", "x@e.com\nBcc: h@evil.com", "x@e.comBcc: h@evil.com"},
+		{"crlf injection", "x@e.com\r\nBcc: h@evil.com", "x@e.comBcc: h@evil.com"},
+		{"cr only", "x@e.com\rsubject hijack", "x@e.comsubject hijack"},
+		{"mixed", "a\r\nb\rc\nd", "abcd"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sanitizeHeader(tt.in))
+		})
+	}
+}

--- a/modules/base/common/service_email_envelope_test.go
+++ b/modules/base/common/service_email_envelope_test.go
@@ -38,11 +38,19 @@ func TestBuildTransactionalMessage_StructureAndHeaders(t *testing.T) {
 	assert.Contains(t, s, `Content-Type: multipart/alternative; boundary="octo_`,
 		"Top-level Content-Type must declare multipart/alternative with a deterministic boundary prefix")
 	assert.Contains(t, s, "List-Unsubscribe: <mailto:contact@xming.ai?subject=unsubscribe>\r\n",
-		"List-Unsubscribe is one of the strongest transactional-email signals for Gmail/Outlook")
-	assert.Contains(t, s, "List-Unsubscribe-Post: List-Unsubscribe=One-Click\r\n")
-	assert.Contains(t, s, "Auto-Submitted: auto-generated\r\n")
-	assert.Contains(t, s, "Precedence: bulk\r\n")
+		"List-Unsubscribe (RFC 2369) is one of the strongest transactional-email signals for Gmail/Outlook")
+	assert.Contains(t, s, "Auto-Submitted: auto-generated\r\n",
+		"Auto-Submitted advertises this as a machine-generated message; suppresses OOO replies without suppressing DSN")
 	assert.Contains(t, s, "X-Mailer: Octo Transactional Mailer\r\n")
+
+	// 这两条 header 故意 *不* 发(详见 buildTransactionalMessage 中的注释):
+	//   - "List-Unsubscribe-Post: List-Unsubscribe=One-Click" 跟 mailto 配错 (RFC 8058 misuse)
+	//   - "Precedence: bulk" 可能在某些 MTA 上抑制退信,跟 /test_email 诊断意图相反
+	// 这里做 negative assertion 防止有人后续 hardening 时悄悄加回来。
+	assert.NotContains(t, s, "List-Unsubscribe-Post:",
+		"One-Click without an HTTPS POST endpoint is RFC 8058 misuse")
+	assert.NotContains(t, s, "Precedence: bulk",
+		"Precedence: bulk can suppress DSN, defeating the /test_email diagnostic purpose")
 
 	// ---- multipart body ----
 	plainPos := strings.Index(s, "Content-Type: text/plain")

--- a/modules/common/api_manager_system_setting.go
+++ b/modules/common/api_manager_system_setting.go
@@ -303,17 +303,136 @@ func (m *Manager) testSystemSettingEmail(c *wkhttp.Context) {
 	}
 
 	emailSvc := commonbase.NewEmailService(m.ctx, m.systemSettings)
-	if err := emailSvc.SendHTMLEmail(
+	// Pre-send log:遇到「投出去但收件人没收到」时,这条记录至少证明 endpoint
+	// 走到了发送阶段,排查时可以直接对比 SMTP 服务器 sent log;同时把当前
+	// effective 的发件人 / 服务器记下来,方便确认 DB override 与 yaml fallback
+	// 的最终生效值,避免再去 GET /system_setting 二次核对。
+	m.Info("SMTP 测试邮件已尝试投递",
+		zap.String("to", req.To),
+		zap.String("from", m.systemSettings.SupportEmail()),
+		zap.String("smtp", m.systemSettings.SupportEmailSmtp()))
+
+	if err := emailSvc.SendTransactionalHTML(
 		c.Request.Context(),
 		req.To,
-		"Octo SMTP 测试邮件",
-		`<p>这是一封来自 Octo 管理后台的测试邮件。如果你收到了它，说明 SMTP 配置正常。</p>`,
+		smtpTestEmailSubject,
+		smtpTestEmailHTML,
+		smtpTestEmailPlain,
 	); err != nil {
-		c.ResponseError(fmt.Errorf("发送失败: %w", err))
+		// 错误内文(SMTP 服务器返回码、host:port、TLS 握手细节)留在服务端
+		// 日志,不回客户端;avoid leaking infra detail to the admin UI 即使
+		// 调用方是 SuperAdmin,降低 HAR 抓包外流时的信息量。
+		m.Error("SMTP 测试邮件投递失败",
+			zap.String("to", req.To),
+			zap.String("from", m.systemSettings.SupportEmail()),
+			zap.String("smtp", m.systemSettings.SupportEmailSmtp()),
+			zap.Error(err))
+		c.ResponseError(errors.New("发送失败，请查看服务端日志"))
 		return
 	}
+	m.Info("SMTP 测试邮件已交付 SMTP 服务器", zap.String("to", req.To))
 	c.ResponseOK()
 }
+
+// SMTP 测试邮件的标题 / HTML / plaintext 模板。
+//
+// 设计取舍:把 v5 富版本内联在这里 —— 而不是抽到 modules/base/common —— 因为
+// 内容("自检结果 / 请勿回复")是这条 admin endpoint 自己的语义,base 层只
+// 负责 SMTP 投递的基础设施。SendTransactionalHTML 会负责包 multipart +
+// 加事务邮件 header,本处不再操心这些。
+//
+// HTML 用 inline CSS + <table> 布局,确保在 Outlook / 网易/腾讯邮箱客户端
+// 等对 <style> 块支持差的客户端上也能正常渲染;字体栈带 PingFang SC /
+// Microsoft YaHei,保证中英文同字号视觉一致。
+//
+// plaintext 是 RFC 2046 要求的 alternative,反垃圾过滤器把"是否提供
+// plain"作为 transactional vs spam 的关键打分项;不是给"看不懂 HTML 的
+// 收件人"准备的,是给打分器看的。
+const smtpTestEmailSubject = "[Octo] SMTP 配置自检 · SMTP Configuration Test"
+
+const smtpTestEmailPlain = `Octo SMTP 配置自检 · SMTP Configuration Test
+============================================
+
+[ 自动邮件 · 请勿回复 / Automated · Do Not Reply ]
+
+✓ SMTP 主机连接正常        Host connection OK
+✓ 发信凭据有效              Credentials valid
+✓ 反垃圾策略通过            Anti-spam check passed
+
+如果您收到了这封邮件，说明 Octo 系统的 SMTP 配置一切正常，无需任何操作。
+If you received this, your SMTP setup is working. No action needed.
+
+——
+Octo System Notification · Octo 系统通知
+`
+
+const smtpTestEmailHTML = `<!doctype html>
+<html lang="zh-CN">
+<body style="margin:0; padding:0; background:#f3f4f6; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', Roboto, sans-serif; color:#1f2937; line-height:1.6;">
+  <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background:#f3f4f6; padding:32px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="560" style="max-width:560px; background:#ffffff; border-radius:12px; box-shadow:0 1px 3px rgba(0,0,0,0.06); overflow:hidden;">
+          <tr>
+            <td style="padding:32px 32px 8px;">
+              <h1 style="margin:0; font-size:22px; font-weight:600; color:#111827; letter-spacing:-0.01em;">Octo SMTP 配置自检</h1>
+              <div style="margin-top:4px; font-size:13px; color:#6b7280;">SMTP Configuration Test</div>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:16px 32px 0;">
+              <div style="background:#fef3c7; border-left:3px solid #f59e0b; padding:10px 14px; border-radius:4px; font-size:13px; color:#78350f;">
+                <strong>自动邮件 · 请勿回复</strong> &nbsp;<span style="color:#92400e;">Automated · Do Not Reply</span>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:20px 32px 0;">
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="border:1px solid #e5e7eb; border-radius:8px;">
+                <tr>
+                  <td style="padding:12px 16px; border-bottom:1px solid #f3f4f6;">
+                    <span style="display:inline-block; width:20px; color:#10b981; font-weight:700;">&#10003;</span>
+                    <span style="font-size:15px; color:#111827;">SMTP 主机连接正常</span>
+                    <span style="float:right; font-size:13px; color:#6b7280;">Host connection OK</span>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding:12px 16px; border-bottom:1px solid #f3f4f6;">
+                    <span style="display:inline-block; width:20px; color:#10b981; font-weight:700;">&#10003;</span>
+                    <span style="font-size:15px; color:#111827;">发信凭据有效</span>
+                    <span style="float:right; font-size:13px; color:#6b7280;">Credentials valid</span>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding:12px 16px;">
+                    <span style="display:inline-block; width:20px; color:#10b981; font-weight:700;">&#10003;</span>
+                    <span style="font-size:15px; color:#111827;">反垃圾策略通过</span>
+                    <span style="float:right; font-size:13px; color:#6b7280;">Anti-spam check passed</span>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:20px 32px 24px;">
+              <p style="margin:0 0 8px; font-size:14px; color:#374151;">如果您收到了这封邮件，说明 Octo 系统的 SMTP 配置一切正常，无需任何操作。</p>
+              <p style="margin:0; font-size:13px; color:#6b7280;">If you received this, your SMTP setup is working. No action needed.</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:16px 32px 24px; border-top:1px solid #f3f4f6;">
+              <div style="font-size:12px; color:#9ca3af;">
+                Octo System Notification &middot; Octo 系统通知
+              </div>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+`
 
 // jsonH is a tiny alias for inline JSON payloads. We define a local alias
 // instead of importing gin.H to keep the surface visible at the call site.


### PR DESCRIPTION
## Summary

Follow-up to #76. Verified end-to-end that the test_email body shipped in #76 (single `<p>...</p>` text/html part) is silently dropped by recipient anti-spam filters on at least one production path (Aliyun corporate SMTP → mininglamp.com): SMTP accepts, no bounce returned to sender, no entry in inbox / spam / deleted. The verification-code email on the same SMTP link delivers fine — so the link itself is healthy; the issue is content shape (no plaintext alternative, no transactional-email headers).

This PR plumbs a richer envelope through `EmailService` and updates the admin "Test email" handler to use it.

## What changed

- **`modules/base/common/service_email.go`** — new `SendTransactionalHTML(ctx, to, subject, htmlBody, plainBody)` method on `EmailService`. Wraps body in `multipart/alternative`, sets `Date` / `Message-ID` (with From's domain) / `Auto-Submitted: auto-generated` / `Precedence: bulk` / `List-Unsubscribe` headers — the signals anti-spam scoring uses to distinguish transactional mail from unsolicited HTML.
  - The existing `SendHTMLEmail` / `sendEmail` path stays as-is so verification codes and invite emails (`modules/space/email_invite_sender.go`) keep their lighter envelope.
  - `dispatchSMTP` and `sanitizeHeader` are factored out so both code paths share TLS dialing, AUTH, the SMTP transaction, and the CRLF-injection guard.

- **`modules/common/api_manager_system_setting.go`** — `testSystemSettingEmail` now:
  - Calls `SendTransactionalHTML` with the v5 layout: single bilingual title, amber "Do Not Reply" banner, white card with three ✓ rows (中文 primary, English secondary right-aligned), bilingual conclusion.
  - Writes a pre-send `Info` log with effective from/smtp, so a future "test sent but didn't arrive" report can be diagnosed from server logs in seconds rather than walking the SMTP path by hand.
  - Masks the raw SMTP error from the HTTP response (logged server-side instead) — closes one of the P2s yujiawei raised in #76 about leaking infra detail to the admin UI.

## Verification

End-to-end inbox proof attached to the originating Conductor session: the same recipient mailbox that silently dropped the old single-part body received the new multipart envelope into the inbox, rendered correctly (banner + status card + bilingual conclusion).

Unit tests cover the bits we can verify offline:

- multipart/alternative structure and boundary
- plaintext-before-html ordering per RFC 2046
- every transactional header present
- Message-ID domain falls back safely when From lacks `@`
- CRLF sanitiser against header injection (Bcc smuggling and friends)

```
$ go test -race -run 'TestBuildTransactionalMessage|TestSanitizeHeader' ./modules/base/common/...
ok  github.com/Mininglamp-OSS/octo-server/modules/base/common 1.741s
```

## Test plan

- [ ] CI builds + tests pass
- [ ] Smoke-test in staging: POST `/v1/manager/common/system_setting/test_email` with a real address, confirm inbox delivery
- [ ] Server log shows `SMTP 测试邮件已交付 SMTP 服务器` on success, `SMTP 测试邮件投递失败` (with `zap.Error`) on failure

## Out of scope

The invite-email path (`modules/space/email_invite_sender.go`) still uses the lighter `SendHTMLEmail`. If invite delivery turns out to suffer the same anti-spam issue, a follow-up should switch it to `SendTransactionalHTML`.