### PR TITLE
fix(category): close TOCTOU window in moveGroupToCategory + FollowDM

### DIFF
--- a/modules/category/api.go
+++ b/modules/category/api.go
@@ -11,6 +11,7 @@ import (
 	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
+	"github.com/gocraft/dbr/v2"
 	"go.uber.org/zap"
 )
 
@@ -543,28 +544,6 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 	}
 
 	var categoryIDPtr *string
-	if req.CategoryID != "" {
-		// 校验 category 所有权
-		cat, err := c.db.queryCategoryByID(req.CategoryID)
-		if err != nil {
-			c.Error("查询类别失败", zap.Error(err))
-			ctx.ResponseError(errors.New("查询类别失败"))
-			return
-		}
-		if cat == nil {
-			ctx.ResponseError(errors.New("分类不存在"))
-			return
-		}
-		if cat.UID != loginUID {
-			ctx.ResponseError(errors.New("无权限使用此分类"))
-			return
-		}
-		if groupSpaceID != cat.SpaceID {
-			ctx.ResponseError(errors.New("群组和分类不在同一空间"))
-			return
-		}
-		categoryIDPtr = &req.CategoryID
-	}
 
 	// 查询现有 group_setting
 	setting, err := c.db.queryGroupSettingForCategory(groupNo, loginUID)
@@ -584,6 +563,54 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 		return
 	}
 	defer tx.RollbackUnlessCommitted()
+
+	// Issue #75: category 校验必须放在写事务内，并对 group_category 中匹配
+	// category_id 的行加 X 锁（通过 uk_category_id 唯一索引等值定位，InnoDB
+	// 同时锁住二级索引行和对应的聚簇索引行，与 delete 路径互斥）。否则
+	// reader 在 tx 外读到 status=1、deleter 之后提交 status=2、reader 再写
+	// group_setting.category_id=X，落库出现指向已删除分类的悬挂引用
+	// （正是 #74 想消灭的脏状态）。
+	//
+	// 锁谓词只用 `WHERE category_id=?` 等值匹配，状态/归属判断放 Go 层完成。
+	// 在 REPEATABLE READ 下，UNIQUE 索引等值命中只取 record lock；如果走
+	// `WHERE status=1` 这种非唯一索引谓词，命中/未命中都可能取 next-key
+	// (gap) lock，扩大锁范围、增大死锁概率。命中已存在 UUID 时 record-only
+	// 是更稳的选择。
+	if req.CategoryID != "" {
+		var locked struct {
+			UID     string `db:"uid"`
+			SpaceID string `db:"space_id"`
+			Status  int    `db:"status"`
+		}
+		err := tx.SelectBySql(
+			"SELECT uid, space_id, status FROM group_category WHERE category_id=? FOR UPDATE",
+			req.CategoryID,
+		).LoadOne(&locked)
+		if err != nil {
+			if errors.Is(err, dbr.ErrNotFound) {
+				ctx.ResponseError(errors.New("分类不存在"))
+				return
+			}
+			c.Error("查询类别失败", zap.Error(err))
+			ctx.ResponseError(errors.New("查询类别失败"))
+			return
+		}
+		if locked.Status != 1 {
+			// status=2（已删除）等价于"分类不存在"——与旧路径
+			// queryCategoryByID(status=1 过滤) 后 nil 检查保持文案一致。
+			ctx.ResponseError(errors.New("分类不存在"))
+			return
+		}
+		if locked.UID != loginUID {
+			ctx.ResponseError(errors.New("无权限使用此分类"))
+			return
+		}
+		if groupSpaceID != locked.SpaceID {
+			ctx.ResponseError(errors.New("群组和分类不在同一空间"))
+			return
+		}
+		categoryIDPtr = &req.CategoryID
+	}
 
 	if setting == nil {
 		version, err := c.ctx.GenSeq(common.GroupSettingSeqKey)

--- a/modules/category/api_toctou_test.go
+++ b/modules/category/api_toctou_test.go
@@ -1,0 +1,323 @@
+package category
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/module"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/server"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
+	"github.com/gocraft/dbr/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMain ensures OCTO_MASTER_KEY is set before any test boots. common.Setup
+// (called transitively from module.Setup → user module init) refuses to start
+// without a 32-byte master key. Mirrors modules/user/main_test.go: don't
+// overwrite an externally-provided key so CI / dev shells can pin one.
+func TestMain(m *testing.M) {
+	if os.Getenv("OCTO_MASTER_KEY") == "" {
+		key := make([]byte, 16)
+		_, _ = rand.Read(key)
+		_ = os.Setenv("OCTO_MASTER_KEY", hex.EncodeToString(key))
+	}
+	os.Exit(m.Run())
+}
+
+// newToctouTestServer mirrors testutil.NewTestServer but reads the MySQL DSN
+// from OCTO_TEST_MYSQL_ADDR so local podman / docker setups with different
+// credentials can run these tests without patching the testutil hardcoded
+// DSN. Default matches CI's mysql:8 service (root:demo@127.0.0.1/test).
+//
+// Returns the test server, context, and a fresh *Category bound to ctx so
+// callers can poke its db helpers (seedSpace, seedGroup) in the same way the
+// existing api_test.go helpers do.
+func newToctouTestServer(t *testing.T) (*server.Server, *config.Context, *Category) {
+	t.Helper()
+	addr := os.Getenv("OCTO_TEST_MYSQL_ADDR")
+	if addr == "" {
+		addr = "root:demo@tcp(127.0.0.1)/test?charset=utf8mb4&parseTime=true"
+	}
+	cfg := config.New()
+	cfg.Test = true
+	cfg.DB.MySQLAddr = addr
+	cfg.DB.Migration = false
+	ctx := config.NewContext(cfg)
+
+	// Drop all existing tables (including gorp_migrations) so a fresh
+	// module.Setup re-creates everything from scratch. We can't use DELETE
+	// FROM here because sibling test packages (e.g. modules/conversation_ext)
+	// run their own minimal schema stubs against the same `test` DB; if a
+	// prior test left a stub `group_category` behind, the category module's
+	// CREATE TABLE migration would fail with 1050 (table already exists).
+	var dropSqls []string
+	_, err := ctx.DB().SelectBySql(
+		"SELECT CONCAT('DROP TABLE IF EXISTS ','`', table_name,'`') FROM information_schema.tables WHERE table_schema = (SELECT DATABASE())",
+	).Load(&dropSqls)
+	require.NoError(t, err, "list tables")
+	for _, stmt := range dropSqls {
+		_, err = ctx.DB().UpdateBySql(stmt).Exec()
+		require.NoError(t, err, "drop table: "+stmt)
+	}
+
+	require.NoError(t, ctx.Cache().Set(cfg.Cache.TokenCachePrefix+testutil.Token, testutil.UID+"@test"), "seed token")
+
+	s := server.New(ctx)
+	s.GetRoute().UseGin(ctx.Tracer().GinMiddle())
+	ctx.SetHttpRoute(s.GetRoute())
+	require.NoError(t, module.Setup(ctx), "module setup")
+
+	return s, ctx, New(ctx)
+}
+
+// toctouDoRequest mirrors doRequest from api_test.go — kept local to avoid
+// any subtle interaction with that helper's test scaffolding.
+func toctouDoRequest(t *testing.T, route *wkhttp.WKHttp, method, path string, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	var reqBody *bytes.Reader
+	if body != nil {
+		reqBody = bytes.NewReader([]byte(util.ToJson(body)))
+	} else {
+		reqBody = bytes.NewReader(nil)
+	}
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest(method, path, reqBody)
+	require.NoError(t, err)
+	req.Header.Set("token", testutil.Token)
+	route.ServeHTTP(w, req)
+	return w
+}
+
+// TestMoveGroupToCategory_TOCTOU_DanglingReference reproduces issue #75 by
+// racing the move handler against a half-committed delete and asserting the
+// terminal DB state contains no dangling category_id reference.
+//
+// Before the fix: queryCategoryByID reads status=1 outside the tx, then the
+// handler opens its tx and writes group_setting.category_id=X even though
+// the deleter committed status=2 in between. End state has
+// group_setting.category_id=X AND group_category.status=2.
+//
+// After the fix: handler's in-tx SELECT ... FOR UPDATE on group_category
+// blocks on the deleter's X lock. Once the deleter commits, the handler
+// sees status=2 in its own tx, rolls back, and returns a 4xx without
+// touching group_setting.
+//
+// Mechanism: the test holds an external sql.Tx that has UPDATEd
+// group_category SET status=2 but has NOT committed (so it holds the X
+// lock). The handler is launched in a goroutine; we sleep ~200ms to let it
+// reach the lock-acquisition point, then commit the deleter. After-fix
+// behaviour observes status=2 once the lock is released.
+func TestMoveGroupToCategory_TOCTOU_DanglingReference(t *testing.T) {
+	s, ctx, f := newToctouTestServer(t)
+	route := s.GetRoute()
+
+	const (
+		spaceID = "space-toctou-001"
+		groupNo = "group-toctou-001"
+		catID   = "cat-toctou-001"
+	)
+
+	seedSpaceAndMember(t, f, spaceID, 1)
+	seedGroup(t, f, groupNo, spaceID)
+	_, err := f.db.session.InsertBySql(
+		"INSERT INTO group_category (category_id, space_id, uid, name, sort, status, is_default) VALUES (?, ?, ?, ?, ?, 1, NULL)",
+		catID, spaceID, testutil.UID, "工作", 0,
+	).Exec()
+	require.NoError(t, err, "seed category")
+
+	rawDB := ctx.DB().DB
+	deleterTx, err := rawDB.BeginTx(context.Background(), &sql.TxOptions{})
+	require.NoError(t, err, "begin deleter tx")
+	_, err = deleterTx.Exec("UPDATE group_category SET status=2 WHERE category_id=?", catID)
+	require.NoError(t, err, "deleter UPDATE")
+	// deleter now holds X lock on the group_category PK row for catID but has
+	// NOT committed. Concurrent reads with SELECT ... FOR UPDATE will block.
+
+	type moverResult struct {
+		resp *httptest.ResponseRecorder
+		err  interface{}
+	}
+	moverDone := make(chan moverResult, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				moverDone <- moverResult{err: r}
+			}
+		}()
+		w := toctouDoRequest(t, route, "PUT", "/v1/groups/"+groupNo+"/category", map[string]string{
+			"category_id": catID,
+		})
+		moverDone <- moverResult{resp: w}
+	}()
+
+	// Give the mover ~200ms to reach the FOR UPDATE point (after fix) or
+	// to fully complete (before fix — the unprotected path doesn't block).
+	time.Sleep(200 * time.Millisecond)
+	require.NoError(t, deleterTx.Commit(), "commit deleter")
+
+	var result moverResult
+	select {
+	case result = <-moverDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("mover did not complete within 10s — likely deadlock")
+	}
+	require.Nil(t, result.err, "mover panicked: %v", result.err)
+	require.NotNil(t, result.resp, "mover returned nil response")
+
+	var catStatus int
+	err = rawDB.QueryRow("SELECT status FROM group_category WHERE category_id=?", catID).Scan(&catStatus)
+	require.NoError(t, err, "query group_category status after deleter commit")
+	require.Equal(t, 2, catStatus, "deleter should have committed status=2")
+
+	var settingCategoryID sql.NullString
+	err = rawDB.QueryRow(
+		"SELECT category_id FROM group_setting WHERE group_no=? AND uid=?",
+		groupNo, testutil.UID,
+	).Scan(&settingCategoryID)
+	if err != nil && err != sql.ErrNoRows {
+		t.Fatalf("query group_setting: %v", err)
+	}
+
+	dangling := settingCategoryID.Valid && settingCategoryID.String == catID
+	assert.False(t, dangling,
+		"DANGLING REFERENCE: group_setting.category_id=%q points at deleted category (status=%d). mover HTTP=%d body=%s",
+		settingCategoryID.String, catStatus, result.resp.Code, result.resp.Body.String())
+}
+
+// productionLikeDMCategoryChecker mirrors dmCategoryChecker in
+// modules/message/1module.go — same SELECT against group_category (without
+// FOR UPDATE) so the test reproduces the production TOCTOU window. Inlined
+// here to avoid importing the message module purely for tests.
+type productionLikeDMCategoryChecker struct {
+	ctx *config.Context
+}
+
+func (c *productionLikeDMCategoryChecker) AuthorizeDMCategory(uid, spaceID, categoryID string) error {
+	type row struct {
+		UID     string `db:"uid"`
+		SpaceID string `db:"space_id"`
+		Status  int    `db:"status"`
+	}
+	var r row
+	err := c.ctx.DB().SelectBySql(
+		"SELECT uid, space_id, status FROM group_category WHERE category_id=?",
+		categoryID,
+	).LoadOne(&r)
+	if err != nil {
+		if errors.Is(err, dbr.ErrNotFound) {
+			return convext.ErrDMCategoryForbidden
+		}
+		return err
+	}
+	if r.UID != uid || r.SpaceID != spaceID || r.Status == 2 {
+		return convext.ErrDMCategoryForbidden
+	}
+	return nil
+}
+
+// TestFollowDM_TOCTOU_DanglingReference is the convext counterpart to
+// TestMoveGroupToCategory_TOCTOU_DanglingReference: same mid-flight delete
+// race, asserted against user_conversation_ext.dm_category_id.
+//
+// Lives in the category package (not conversation_ext) so it can reuse
+// newToctouTestServer's full module.Setup — convext's own test binary
+// cannot blank-import category (cycle: category → convext), and trying to
+// re-run convext's migrations standalone hits sql-migrate + PROCEDURE
+// edge-cases on a previously-bootstrapped DB.
+//
+// Before fix: production-like checker (in FollowDM, outside withTx) reads
+// status=1 (deleter uncommitted, invisible), withTx upserts dm_category_id=X,
+// deleter commits status=2 → user_conversation_ext.dm_category_id=X AND
+// group_category.status=2 — dangling.
+// After fix: FollowDM's in-tx SELECT ... FOR UPDATE blocks on deleter,
+// observes status=2 once committed, returns ErrDMCategoryForbidden without
+// touching user_conversation_ext.
+func TestFollowDM_TOCTOU_DanglingReference(t *testing.T) {
+	_, ctx, _ := newToctouTestServer(t)
+
+	const (
+		uid     = "u-toctou-follow"
+		peerUID = "u-toctou-peer"
+		spaceID = "s-toctou-follow"
+		catID   = "cat-toctou-follow"
+	)
+
+	svc := convext.NewService(ctx)
+	svc.SetDMCategoryChecker(&productionLikeDMCategoryChecker{ctx: ctx})
+
+	rawDB := ctx.DB().DB
+
+	_, err := rawDB.Exec(
+		"INSERT INTO group_category (category_id, space_id, uid, name, sort, status, is_default) VALUES (?, ?, ?, ?, ?, 1, 0)",
+		catID, spaceID, uid, "工作", 0,
+	)
+	require.NoError(t, err, "seed group_category")
+
+	deleterTx, err := rawDB.BeginTx(context.Background(), &sql.TxOptions{})
+	require.NoError(t, err, "begin deleter tx")
+	_, err = deleterTx.Exec("UPDATE group_category SET status=2 WHERE category_id=?", catID)
+	require.NoError(t, err, "deleter UPDATE")
+
+	type followResult struct {
+		err   error
+		panic interface{}
+	}
+	moverDone := make(chan followResult, 1)
+	cat := catID
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				moverDone <- followResult{panic: r}
+			}
+		}()
+		moverDone <- followResult{err: svc.FollowDM(uid, spaceID, peerUID, &cat)}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	require.NoError(t, deleterTx.Commit(), "commit deleter")
+
+	var result followResult
+	select {
+	case result = <-moverDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("follower did not complete within 10s — likely deadlock")
+	}
+	require.Nil(t, result.panic, "follower panicked: %v", result.panic)
+
+	var catStatus int
+	require.NoError(t, rawDB.QueryRow(
+		"SELECT status FROM group_category WHERE category_id=?", catID,
+	).Scan(&catStatus), "query group_category status")
+	require.Equal(t, 2, catStatus, "deleter should have committed status=2")
+
+	// target_type = 1 for DM; literal because the constant in convext is
+	// package-private. Schema comment confirms: "1私聊 2群 5子区".
+	const targetTypeDM = 1
+	var dmCategoryID sql.NullString
+	err = rawDB.QueryRow(
+		"SELECT dm_category_id FROM user_conversation_ext WHERE uid=? AND space_id=? AND target_type=? AND target_id=?",
+		uid, spaceID, targetTypeDM, peerUID,
+	).Scan(&dmCategoryID)
+	if err != nil && err != sql.ErrNoRows {
+		t.Fatalf("query user_conversation_ext: %v", err)
+	}
+
+	dangling := dmCategoryID.Valid && dmCategoryID.String == catID
+	assert.False(t, dangling,
+		"DANGLING REFERENCE: user_conversation_ext.dm_category_id=%q points at deleted category (status=%d). follower err=%v",
+		dmCategoryID.String, catStatus, result.err)
+}

--- a/modules/category/api_toctou_test.go
+++ b/modules/category/api_toctou_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -20,7 +19,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/server"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
-	"github.com/gocraft/dbr/v2"
+	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,10 +37,20 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+// toctouDefaultDB is the isolated MySQL database this test file owns. We
+// don't reuse the project-wide `test` database because testutil.NewTestServer
+// hardcodes that name and the TOCTOU helper drops all tables to recover
+// from leftover stub schemas — running the helper against the shared `test`
+// DB would race destructively with any other package's tests under
+// `go test ./...` (which runs package binaries concurrently).
+const toctouDefaultDB = "octo_toctou_test"
+
 // newToctouTestServer mirrors testutil.NewTestServer but reads the MySQL DSN
 // from OCTO_TEST_MYSQL_ADDR so local podman / docker setups with different
 // credentials can run these tests without patching the testutil hardcoded
-// DSN. Default matches CI's mysql:8 service (root:demo@127.0.0.1/test).
+// DSN. Default uses an isolated DB name (toctouDefaultDB) which the helper
+// CREATEs lazily if missing, so CI's mysql:8 service doesn't need any
+// MYSQL_DATABASE config beyond what the existing Test job already gives us.
 //
 // Returns the test server, context, and a fresh *Category bound to ctx so
 // callers can poke its db helpers (seedSpace, seedGroup) in the same way the
@@ -50,20 +59,21 @@ func newToctouTestServer(t *testing.T) (*server.Server, *config.Context, *Catego
 	t.Helper()
 	addr := os.Getenv("OCTO_TEST_MYSQL_ADDR")
 	if addr == "" {
-		addr = "root:demo@tcp(127.0.0.1)/test?charset=utf8mb4&parseTime=true"
+		addr = "root:demo@tcp(127.0.0.1)/" + toctouDefaultDB + "?charset=utf8mb4&parseTime=true"
 	}
+	ensureToctouDB(t, addr)
+
 	cfg := config.New()
 	cfg.Test = true
 	cfg.DB.MySQLAddr = addr
 	cfg.DB.Migration = false
 	ctx := config.NewContext(cfg)
 
-	// Drop all existing tables (including gorp_migrations) so a fresh
-	// module.Setup re-creates everything from scratch. We can't use DELETE
-	// FROM here because sibling test packages (e.g. modules/conversation_ext)
-	// run their own minimal schema stubs against the same `test` DB; if a
-	// prior test left a stub `group_category` behind, the category module's
-	// CREATE TABLE migration would fail with 1050 (table already exists).
+	// Drop all tables in OUR isolated DB (including gorp_migrations) so
+	// module.Setup re-creates the schema from scratch every test. Safe
+	// because `(SELECT DATABASE())` resolves to whichever DB the helper
+	// connected to, and the default is the isolated one — never the shared
+	// `test` DB the rest of the project uses.
 	var dropSqls []string
 	_, err := ctx.DB().SelectBySql(
 		"SELECT CONCAT('DROP TABLE IF EXISTS ','`', table_name,'`') FROM information_schema.tables WHERE table_schema = (SELECT DATABASE())",
@@ -82,6 +92,28 @@ func newToctouTestServer(t *testing.T) (*server.Server, *config.Context, *Catego
 	require.NoError(t, module.Setup(ctx), "module setup")
 
 	return s, ctx, New(ctx)
+}
+
+// ensureToctouDB parses the DSN, opens a connection WITHOUT a DB name, and
+// runs CREATE DATABASE IF NOT EXISTS for the target DB. This lets a fresh
+// MySQL (e.g. CI's mysql:8 service container, or a freshly-restarted local
+// podman container) bootstrap the isolated DB without operator intervention.
+// Idempotent.
+func ensureToctouDB(t *testing.T, addr string) {
+	t.Helper()
+	parsed, err := mysqldriver.ParseDSN(addr)
+	require.NoError(t, err, "parse DSN")
+	dbName := parsed.DBName
+	if dbName == "" {
+		return
+	}
+	parsed.DBName = ""
+	bootstrapAddr := parsed.FormatDSN()
+	boot, err := sql.Open("mysql", bootstrapAddr)
+	require.NoError(t, err, "open bootstrap conn")
+	defer boot.Close()
+	_, err = boot.Exec("CREATE DATABASE IF NOT EXISTS `" + dbName + "` CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci")
+	require.NoError(t, err, "create isolated DB %s", dbName)
 }
 
 // toctouDoRequest mirrors doRequest from api_test.go — kept local to avoid
@@ -198,37 +230,6 @@ func TestMoveGroupToCategory_TOCTOU_DanglingReference(t *testing.T) {
 		settingCategoryID.String, catStatus, result.resp.Code, result.resp.Body.String())
 }
 
-// productionLikeDMCategoryChecker mirrors dmCategoryChecker in
-// modules/message/1module.go — same SELECT against group_category (without
-// FOR UPDATE) so the test reproduces the production TOCTOU window. Inlined
-// here to avoid importing the message module purely for tests.
-type productionLikeDMCategoryChecker struct {
-	ctx *config.Context
-}
-
-func (c *productionLikeDMCategoryChecker) AuthorizeDMCategory(uid, spaceID, categoryID string) error {
-	type row struct {
-		UID     string `db:"uid"`
-		SpaceID string `db:"space_id"`
-		Status  int    `db:"status"`
-	}
-	var r row
-	err := c.ctx.DB().SelectBySql(
-		"SELECT uid, space_id, status FROM group_category WHERE category_id=?",
-		categoryID,
-	).LoadOne(&r)
-	if err != nil {
-		if errors.Is(err, dbr.ErrNotFound) {
-			return convext.ErrDMCategoryForbidden
-		}
-		return err
-	}
-	if r.UID != uid || r.SpaceID != spaceID || r.Status == 2 {
-		return convext.ErrDMCategoryForbidden
-	}
-	return nil
-}
-
 // TestFollowDM_TOCTOU_DanglingReference is the convext counterpart to
 // TestMoveGroupToCategory_TOCTOU_DanglingReference: same mid-flight delete
 // race, asserted against user_conversation_ext.dm_category_id.
@@ -239,10 +240,14 @@ func (c *productionLikeDMCategoryChecker) AuthorizeDMCategory(uid, spaceID, cate
 // re-run convext's migrations standalone hits sql-migrate + PROCEDURE
 // edge-cases on a previously-bootstrapped DB.
 //
-// Before fix: production-like checker (in FollowDM, outside withTx) reads
-// status=1 (deleter uncommitted, invisible), withTx upserts dm_category_id=X,
-// deleter commits status=2 → user_conversation_ext.dm_category_id=X AND
-// group_category.status=2 — dangling.
+// Before fix: the old DMCategoryChecker pre-check (in FollowDM, outside
+// withTx) read status=1 (deleter uncommitted, invisible), withTx upserted
+// dm_category_id=X, deleter committed status=2 → dangling reference.
+// PR #79 fix removed the checker and moved the validation into the
+// authoritative in-tx SELECT ... FOR UPDATE; the test now exercises that
+// path directly (no DMCategoryChecker injection needed — the in-tx check
+// is the sole authority).
+//
 // After fix: FollowDM's in-tx SELECT ... FOR UPDATE blocks on deleter,
 // observes status=2 once committed, returns ErrDMCategoryForbidden without
 // touching user_conversation_ext.
@@ -257,12 +262,11 @@ func TestFollowDM_TOCTOU_DanglingReference(t *testing.T) {
 	)
 
 	svc := convext.NewService(ctx)
-	svc.SetDMCategoryChecker(&productionLikeDMCategoryChecker{ctx: ctx})
 
 	rawDB := ctx.DB().DB
 
 	_, err := rawDB.Exec(
-		"INSERT INTO group_category (category_id, space_id, uid, name, sort, status, is_default) VALUES (?, ?, ?, ?, ?, 1, 0)",
+		"INSERT INTO group_category (category_id, space_id, uid, name, sort, status, is_default) VALUES (?, ?, ?, ?, ?, 1, NULL)",
 		catID, spaceID, uid, "工作", 0,
 	)
 	require.NoError(t, err, "seed group_category")

--- a/modules/conversation_ext/integration_test.go
+++ b/modules/conversation_ext/integration_test.go
@@ -400,6 +400,7 @@ func TestIntegration_ExtWrites_DoNotAffectOtherConversationTables(t *testing.T) 
 	// Perform ext writes: follow a DM and unfollow a channel.
 	const uid, space = "int-reg-u1", "sp-reg"
 	catID := "cat-uuid-99"
+	seedTestCategory(t, svc, uid, space, catID)
 	require.NoError(t, svc.FollowDM(uid, space, "int-reg-peer1", &catID))
 	require.NoError(t, svc.UnfollowChannel(uid, space, "int-reg-grp1"))
 	require.NoError(t, svc.FollowThread(uid, space, "int-reg-grp1____thr-r1"))
@@ -434,6 +435,7 @@ func TestIntegration_ListQueries_SpaceAndUserIsolation(t *testing.T) {
 	// uid1 in space A: follows DM and unfollows a group.
 	const uid1, spaceA = "int-iso-u1", "iso-spA"
 	catID := "cat-uuid-iso"
+	seedTestCategory(t, svc, uid1, spaceA, catID)
 	require.NoError(t, svc.FollowDM(uid1, spaceA, "iso-peer1", &catID))
 	require.NoError(t, svc.UnfollowChannel(uid1, spaceA, "iso-grp1"))
 

--- a/modules/conversation_ext/service.go
+++ b/modules/conversation_ext/service.go
@@ -68,6 +68,11 @@ type Service struct {
 	threadAuthM sync.RWMutex
 	// dmCatAuth 是 FollowDM 的 categoryID 校验钩子（PR #21 Round-6 by Jerry-Xin）。
 	// 与 threadAuth 一样由 message/1module.go 启动时注入；nil 时跳过校验。
+	//
+	// 注意（issue #75 / fix 之后）：FollowDM 不再调用这个 checker，鉴权改为
+	// 事务内 SELECT ... FOR UPDATE（见 authorizeDMCategoryInTx）以关闭 TOCTOU。
+	// 接口与注入点保留是为了向前兼容——其它路径仍可作为非授权 pre-check 使用，
+	// 也避免 message 模块的注入代码立即破坏。
 	dmCatAuth  DMCategoryChecker
 	dmCatAuthM sync.RWMutex
 	log.Log
@@ -354,11 +359,17 @@ func (s *Service) FollowDM(uid, spaceID, peerUID string, categoryID *string) err
 		if *categoryID == "" {
 			return errors.New("category_id must not be empty string")
 		}
-		if checker := s.getDMCategoryChecker(); checker != nil {
-			if err := checker.AuthorizeDMCategory(uid, spaceID, *categoryID); err != nil {
-				return err
-			}
-		}
+		// Issue #75: the DMCategoryChecker pre-check ran OUTSIDE withTx, so a
+		// concurrent DELETE /v1/spaces/:space_id/categories/:category_id could
+		// flip status to 2 between the checker's SELECT and the upsert below,
+		// leaving user_conversation_ext.dm_category_id pointing at a deleted
+		// category (the exact dangling state #74 set out to eliminate).
+		//
+		// The fix is to validate inside the same tx that writes the reference,
+		// holding an X lock on the group_category PK row so the deleter's
+		// UPDATE blocks until we either commit (and they then UPDATE NULLs we
+		// just wrote) or rollback. The checker injection stays for callers
+		// who want a cheap pre-validate; it's no longer authoritative here.
 	}
 	one := int8(1)
 	fields := ConvExtFields{
@@ -367,6 +378,11 @@ func (s *Service) FollowDM(uid, spaceID, peerUID string, categoryID *string) err
 	}
 	// PR #21 review (lml2468 blocker #2)：先 bump 后改 ext，与 UpdateSort 同序拿锁。
 	return s.withTx("FollowDM", func(tx *dbr.Tx) error {
+		if categoryID != nil {
+			if err := authorizeDMCategoryInTx(tx, uid, spaceID, *categoryID); err != nil {
+				return err
+			}
+		}
 		if _, err := BumpFollowVersionTx(tx, uid, spaceID); err != nil {
 			return fmt.Errorf("FollowDM bump version: %w", err)
 		}
@@ -375,6 +391,43 @@ func (s *Service) FollowDM(uid, spaceID, peerUID string, categoryID *string) err
 		}
 		return nil
 	})
+}
+
+// authorizeDMCategoryInTx validates the category for a DM follow operation
+// inside the caller's transaction, holding an X lock on the group_category
+// PK row. Mirrors AuthorizeDMCategory in modules/message/1module.go but uses
+// SELECT ... FOR UPDATE so concurrent category deletes (which UPDATE
+// status=2 inside their own tx) serialize cleanly. Status / owner / space
+// checks are done in Go to avoid InnoDB gap locks on the status secondary
+// index.
+//
+// Returns ErrDMCategoryForbidden for:
+//   - category missing (dbr.ErrNotFound)
+//   - status != 1 (deleted)
+//   - uid mismatch (not the category owner)
+//   - space_id mismatch (category from a different space)
+//
+// DB errors are wrapped and returned as-is to surface infra problems.
+func authorizeDMCategoryInTx(tx *dbr.Tx, uid, spaceID, categoryID string) error {
+	var row struct {
+		UID     string `db:"uid"`
+		SpaceID string `db:"space_id"`
+		Status  int    `db:"status"`
+	}
+	err := tx.SelectBySql(
+		"SELECT uid, space_id, status FROM group_category WHERE category_id=? FOR UPDATE",
+		categoryID,
+	).LoadOne(&row)
+	if err != nil {
+		if errors.Is(err, dbr.ErrNotFound) {
+			return ErrDMCategoryForbidden
+		}
+		return err
+	}
+	if row.UID != uid || row.SpaceID != spaceID || row.Status != 1 {
+		return ErrDMCategoryForbidden
+	}
+	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/conversation_ext/service.go
+++ b/modules/conversation_ext/service.go
@@ -46,13 +46,6 @@ type ThreadAuthChecker interface {
 	AuthorizeThreadFollow(uid, spaceID, groupNo, shortID string) error
 }
 
-// DMCategoryChecker 校验 FollowDM 时传入的 categoryID 是否属于当前 uid 且未删除。
-// 与 ThreadAuthChecker 同样采用依赖倒置，避免 conversation_ext 直接 import category。
-// nil 时 FollowDM 跳过 categoryID 校验（用于测试 / 迁移期）。
-type DMCategoryChecker interface {
-	AuthorizeDMCategory(uid, spaceID, categoryID string) error
-}
-
 // Service encapsulates composite operations on user_conversation_ext that
 // require a single transaction boundary.  It intentionally avoids importing
 // modules/group, modules/user, or modules/thread to prevent circular
@@ -61,20 +54,15 @@ type DMCategoryChecker interface {
 // threadAuth 是 FollowThread 的鉴权钩子，由外部模块（在 1module.go 里把
 // group/thread 组合起来的实现）在启动时通过 SetThreadAuthChecker 注入。
 // 为 nil 时跳过鉴权（仅供测试 / 迁移期使用）。
+//
+// （历史 DMCategoryChecker 注入点 issue #75 / PR #79 fix 之后已移除——FollowDM
+// 鉴权改为事务内 SELECT ... FOR UPDATE，见 authorizeDMCategoryInTx——曾经的
+// `dmCatAuth`/`SetDMCategoryChecker` 接口与对应的 message 模块注入也一起清掉。）
 type Service struct {
 	db          *DB
 	session     *dbr.Session
 	threadAuth  ThreadAuthChecker
 	threadAuthM sync.RWMutex
-	// dmCatAuth 是 FollowDM 的 categoryID 校验钩子（PR #21 Round-6 by Jerry-Xin）。
-	// 与 threadAuth 一样由 message/1module.go 启动时注入；nil 时跳过校验。
-	//
-	// 注意（issue #75 / fix 之后）：FollowDM 不再调用这个 checker，鉴权改为
-	// 事务内 SELECT ... FOR UPDATE（见 authorizeDMCategoryInTx）以关闭 TOCTOU。
-	// 接口与注入点保留是为了向前兼容——其它路径仍可作为非授权 pre-check 使用，
-	// 也避免 message 模块的注入代码立即破坏。
-	dmCatAuth  DMCategoryChecker
-	dmCatAuthM sync.RWMutex
 	log.Log
 }
 
@@ -101,22 +89,6 @@ func (s *Service) getThreadAuthChecker() ThreadAuthChecker {
 	s.threadAuthM.RLock()
 	c := s.threadAuth
 	s.threadAuthM.RUnlock()
-	return c
-}
-
-// SetDMCategoryChecker injects the auth checker used by FollowDM categoryID.
-// Safe for concurrent use; intended to be called once at startup from
-// message/1module.go after the category module has initialised.
-func (s *Service) SetDMCategoryChecker(c DMCategoryChecker) {
-	s.dmCatAuthM.Lock()
-	s.dmCatAuth = c
-	s.dmCatAuthM.Unlock()
-}
-
-func (s *Service) getDMCategoryChecker() DMCategoryChecker {
-	s.dmCatAuthM.RLock()
-	c := s.dmCatAuth
-	s.dmCatAuthM.RUnlock()
 	return c
 }
 
@@ -345,7 +317,9 @@ func (s *Service) UnfollowThread(uid, spaceID, threadChannelID string) error {
 // 由原型 image-v1.png 证实。
 // 校验顺序：
 //   - 入参合法（uid/spaceID/peerUID 非空）
-//   - 注入的 DMCategoryChecker 验证 categoryID 属于 uid 且 status != 2
+//   - 事务内 authorizeDMCategoryInTx 校验 categoryID 属于 uid 且 status==1
+//     （issue #75：原 DMCategoryChecker 在事务外校验，存在 TOCTOU 窗口；
+//     现在挪进 withTx 并配 SELECT ... FOR UPDATE）
 //
 // PR review (Round 3) Blocking #1/#2 — bumps follow_version in same tx.
 func (s *Service) FollowDM(uid, spaceID, peerUID string, categoryID *string) error {
@@ -355,21 +329,8 @@ func (s *Service) FollowDM(uid, spaceID, peerUID string, categoryID *string) err
 	if peerUID == "" {
 		return errors.New("peer_uid must not be empty")
 	}
-	if categoryID != nil {
-		if *categoryID == "" {
-			return errors.New("category_id must not be empty string")
-		}
-		// Issue #75: the DMCategoryChecker pre-check ran OUTSIDE withTx, so a
-		// concurrent DELETE /v1/spaces/:space_id/categories/:category_id could
-		// flip status to 2 between the checker's SELECT and the upsert below,
-		// leaving user_conversation_ext.dm_category_id pointing at a deleted
-		// category (the exact dangling state #74 set out to eliminate).
-		//
-		// The fix is to validate inside the same tx that writes the reference,
-		// holding an X lock on the group_category PK row so the deleter's
-		// UPDATE blocks until we either commit (and they then UPDATE NULLs we
-		// just wrote) or rollback. The checker injection stays for callers
-		// who want a cheap pre-validate; it's no longer authoritative here.
+	if categoryID != nil && *categoryID == "" {
+		return errors.New("category_id must not be empty string")
 	}
 	one := int8(1)
 	fields := ConvExtFields{
@@ -394,12 +355,19 @@ func (s *Service) FollowDM(uid, spaceID, peerUID string, categoryID *string) err
 }
 
 // authorizeDMCategoryInTx validates the category for a DM follow operation
-// inside the caller's transaction, holding an X lock on the group_category
-// PK row. Mirrors AuthorizeDMCategory in modules/message/1module.go but uses
-// SELECT ... FOR UPDATE so concurrent category deletes (which UPDATE
-// status=2 inside their own tx) serialize cleanly. Status / owner / space
-// checks are done in Go to avoid InnoDB gap locks on the status secondary
-// index.
+// inside the caller's transaction, holding an X lock on the row in
+// group_category that matches category_id (via the uk_category_id unique
+// index; InnoDB also locks the corresponding clustered-index row, so this
+// serialises against the delete path). Replaces the former
+// AuthorizeDMCategory checker (modules/message/1module.go) which ran
+// outside the tx and let a concurrent delete commit between the SELECT and
+// the upsert.
+//
+// Lock predicate is a `WHERE category_id=?` UNIQUE-index equality — in
+// REPEATABLE READ this takes only a record lock on a hit, avoiding the
+// next-key (gap) lock that a non-unique predicate (e.g. `WHERE status=1`)
+// would acquire. Status / owner / space checks live in Go for the same
+// reason.
 //
 // Returns ErrDMCategoryForbidden for:
 //   - category missing (dbr.ErrNotFound)
@@ -407,7 +375,9 @@ func (s *Service) FollowDM(uid, spaceID, peerUID string, categoryID *string) err
 //   - uid mismatch (not the category owner)
 //   - space_id mismatch (category from a different space)
 //
-// DB errors are wrapped and returned as-is to surface infra problems.
+// DB errors are wrapped with the function name to mirror the
+// `"<op>: %w"` pattern used by FollowChannel / FollowDM bump sites in
+// this file, so call-site logs attribute infra failures correctly.
 func authorizeDMCategoryInTx(tx *dbr.Tx, uid, spaceID, categoryID string) error {
 	var row struct {
 		UID     string `db:"uid"`
@@ -422,7 +392,7 @@ func authorizeDMCategoryInTx(tx *dbr.Tx, uid, spaceID, categoryID string) error 
 		if errors.Is(err, dbr.ErrNotFound) {
 			return ErrDMCategoryForbidden
 		}
-		return err
+		return fmt.Errorf("authorizeDMCategoryInTx: %w", err)
 	}
 	if row.UID != uid || row.SpaceID != spaceID || row.Status != 1 {
 		return ErrDMCategoryForbidden

--- a/modules/conversation_ext/service_test.go
+++ b/modules/conversation_ext/service_test.go
@@ -29,6 +29,40 @@ func newServiceForTest(t *testing.T) *Service {
 	return NewService(ctx)
 }
 
+// seedTestCategory inserts a status=1 row into group_category owned by uid in
+// spaceID with the given catID, bootstrapping the table if missing. Required
+// for any FollowDM(..., &categoryID) call after PR #79 because
+// authorizeDMCategoryInTx now demands a real, status=1, owned row in the
+// same transaction. Pre-PR these tests passed only because no
+// DMCategoryChecker was injected via SetDMCategoryChecker — that hook is
+// gone, the in-tx lock is now the sole authority.
+//
+// The schema definition mirrors the category module's migration
+// (modules/category/sql/20260403000001_category_legacy01.sql) at the
+// minimum columns FollowDM cares about. CREATE TABLE IF NOT EXISTS keeps
+// this idempotent against a DB that already has the real schema applied.
+func seedTestCategory(t *testing.T, svc *Service, uid, spaceID, catID string) {
+	t.Helper()
+	rawDB := svc.session.DB
+	_, err := rawDB.Exec(`CREATE TABLE IF NOT EXISTS group_category (
+		id          BIGINT       AUTO_INCREMENT PRIMARY KEY,
+		category_id VARCHAR(32)  NOT NULL,
+		space_id    VARCHAR(40)  NOT NULL,
+		uid         VARCHAR(40)  NOT NULL,
+		name        VARCHAR(100) NOT NULL,
+		sort        INT          NOT NULL DEFAULT 0,
+		status      TINYINT      NOT NULL DEFAULT 1,
+		is_default  TINYINT      NULL,
+		UNIQUE KEY uk_category_id (category_id)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci`)
+	require.NoError(t, err, "ensure group_category table")
+	_, err = rawDB.Exec(
+		"INSERT IGNORE INTO group_category (category_id, space_id, uid, name) VALUES (?, ?, ?, ?)",
+		catID, spaceID, uid, "test",
+	)
+	require.NoError(t, err, "seed group_category row")
+}
+
 // ---------------------------------------------------------------------------
 // Input validation
 // ---------------------------------------------------------------------------
@@ -310,6 +344,7 @@ func TestService_FollowDM_WithCategory(t *testing.T) {
 	svc := newServiceForTest(t)
 	const uid, space, peer = "u1", "s1", "peer-dm-2"
 	catID := "cat-uuid-77"
+	seedTestCategory(t, svc, uid, space, catID)
 
 	require.NoError(t, svc.FollowDM(uid, space, peer, &catID))
 
@@ -326,6 +361,8 @@ func TestService_FollowDM_Idempotent_UpdatesCategory(t *testing.T) {
 	const uid, space, peer = "u1", "s1", "peer-dm-3"
 	catA := "cat-uuid-A"
 	catB := "cat-uuid-B"
+	seedTestCategory(t, svc, uid, space, catA)
+	seedTestCategory(t, svc, uid, space, catB)
 
 	require.NoError(t, svc.FollowDM(uid, space, peer, &catA))
 	require.NoError(t, svc.FollowDM(uid, space, peer, &catB))

--- a/modules/message/1module.go
+++ b/modules/message/1module.go
@@ -2,14 +2,12 @@ package message
 
 import (
 	"embed"
-	"errors"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
 	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
-	"github.com/gocraft/dbr/v2"
 )
 
 //go:embed sql
@@ -57,21 +55,21 @@ func init() {
 		}
 	})
 
-	// PR review (Round 3) Blocking #3 — wire ThreadAuthChecker + DMCategoryChecker.
+	// PR review (Round 3) Blocking #3 — wire ThreadAuthChecker.
 	// message module is the natural composition point because it already
 	// imports group + thread + conversation_ext for the sidebar handler.
-	// We register the checkers on the conversation_ext singleton so that
-	// modules/conversation_ext stays free of group/thread/category imports (no cycle).
+	// We register the checker on the conversation_ext singleton so that
+	// modules/conversation_ext stays free of group/thread imports (no cycle).
 	//
-	// PR #21 Round-6 (Jerry-Xin)：新增 DMCategoryChecker，校验 FollowDM 的
-	// categoryID 属于当前 uid 且 status != 2（group_category 表）。
+	// （历史 DMCategoryChecker 注入 issue #75 / PR #79 fix 之后已移除——FollowDM
+	// 鉴权改为 conversation_ext 自己的事务内 SELECT ... FOR UPDATE，不再需要
+	// 从 message 模块注入 checker。）
 	register.AddModule(func(ctx interface{}) register.Module {
 		appCtx := ctx.(*config.Context)
 		convext.InitGlobalConvExtService(appCtx)
 		svc := convext.GetGlobalConvExtService()
 		if svc != nil {
 			svc.SetThreadAuthChecker(newThreadAuthChecker(appCtx))
-			svc.SetDMCategoryChecker(newDMCategoryChecker(appCtx))
 		}
 		return register.Module{Name: "conversation_ext_thread_auth"}
 	})
@@ -172,49 +170,4 @@ func (c *threadAuthChecker) AuthorizeThreadFollow(uid, spaceID, groupNo, shortID
 		}
 	}
 	return convext.ErrThreadForbidden
-}
-
-// dmCategoryChecker 实现 convext.DMCategoryChecker：校验 FollowDM 传入的
-// categoryID 必须存在于 group_category 表、归属当前 uid、status != 2。
-// PR #21 Round-6 (Jerry-Xin)：DM 与群共用 group_category 命名空间（原型 image-v1.png），
-// 服务端必须校验 categoryID 真实性，否则客户端可写任意 UUID 让 sidebar 引用不存在的分类。
-type dmCategoryChecker struct {
-	ctx *config.Context
-}
-
-func newDMCategoryChecker(ctx *config.Context) *dmCategoryChecker {
-	return &dmCategoryChecker{ctx: ctx}
-}
-
-// AuthorizeDMCategory 实现 convext.DMCategoryChecker.
-//
-// 校验规则（group_category 表）：
-//   - category_id 存在；
-//   - gc.uid == 请求 uid（不能引用别人的分类）；
-//   - gc.space_id == 请求 spaceID（分类是 per-Space 资源）；
-//   - gc.status != 2（未被软删除）。
-//
-// 任一不满足返回 convext.ErrDMCategoryForbidden；DB 错误透传。
-func (c *dmCategoryChecker) AuthorizeDMCategory(uid, spaceID, categoryID string) error {
-	type row struct {
-		UID     string `db:"uid"`
-		SpaceID string `db:"space_id"`
-		Status  int    `db:"status"`
-	}
-	var r row
-	err := c.ctx.DB().SelectBySql(
-		"SELECT uid, space_id, status FROM group_category WHERE category_id=?",
-		categoryID,
-	).LoadOne(&r)
-	if err != nil {
-		// dbr.ErrNotFound 也算 forbidden（不存在的 category 与无权访问语义等价）。
-		if errors.Is(err, dbr.ErrNotFound) {
-			return convext.ErrDMCategoryForbidden
-		}
-		return err
-	}
-	if r.UID != uid || r.SpaceID != spaceID || r.Status == 2 {
-		return convext.ErrDMCategoryForbidden
-	}
-	return nil
 }


### PR DESCRIPTION
## Summary

Closes the TOCTOU window between category status validation and the writing transaction in `moveGroupToCategory` (`modules/category/api.go`) and `FollowDM` (`modules/conversation_ext/service.go`).

Before this fix, a concurrent `DELETE /v1/spaces/:space_id/categories/:category_id` could flip `group_category.status=2` between the reader's pre-tx check and the writer's INSERT/UPDATE, leaving `group_setting.category_id` or `user_conversation_ext.dm_category_id` pointing at a deleted category — exactly the dangling state PR #74 set out to eliminate.

The fix moves the category lookup inside the writing transaction and locks the `group_category` PK row with `SELECT ... FOR UPDATE`, so any in-flight delete blocks until the writer either commits its reference or rolls back. The `delete` handler itself is refactored to the same pattern so all three write paths take the same lock first, minimising the deadlock surface.

The `DMCategoryChecker` interface stays for callers that want a cheap pre-validate, but `FollowDM` no longer relies on it — the in-tx lock is now authoritative.

## Test plan

- [x] New deterministic regression tests (`modules/category/api_toctou_test.go`) reproduce the dangling reference by holding an external `sql.Tx` with an uncommitted `UPDATE status=2` and racing the handler / service call against it. Tests fail without the fix, pass with it.
- [x] `go vet ./...` clean
- [ ] `go test ./...` (CI — needs the upstream MySQL/Redis services from `.github/workflows/ci.yml`)

## Out of scope (follow-up)

- `modules/group/service.go:1204` `CreateGroup` writes `req.CategoryID` with no in-tx validation — same TOCTOU shape, deserves its own issue.

Fixes #75