### PR TITLE
fix(oidc): bind redirect carries provider + Referrer-Policy no-referrer

### DIFF
--- a/modules/oidc/api.go
+++ b/modules/oidc/api.go
@@ -1003,11 +1003,12 @@ func (o *OIDC) redirectToBindPage(c *wkhttp.Context, sd *StateData, jti string) 
 		}
 	}
 	target.RawQuery = q.Encode()
-	// Referrer-Policy: no-referrer 防止 bind 页(可能位于独立域)及其内部子资源
-	// 把 callback URL 经 Referer 头泄漏。authcode 是 ThirdAuthcode 的 Redis key
-	// (5min 单次有效),仍是凭据,不应出现在跨域 Referer 上。后端单点强制比依赖
-	// 前端 <meta> 更可靠 —— meta 要等 bind 页 HTML 解析后才生效,防不了对 bind
-	// 页本身的请求那一跳。
+	// Referrer-Policy: no-referrer 仅保护这一跳:浏览器从 callback URL 跳到
+	// bind 页时不会把 callback 的 ?code=... &state=... 经 Referer 泄漏给 bind
+	// 页 host。bind 页加载之后,其内部子资源是否泄漏"含 token/authcode 的
+	// bind 页 URL",取决于 bind 页**自己**的 Referrer-Policy(响应头或 meta),
+	// 后端无法跨域强制。前端 host 应同步下发 Referrer-Policy: no-referrer
+	// 作为纵深防御。
 	c.Header("Referrer-Policy", "no-referrer")
 	c.Redirect(http.StatusFound, target.String())
 }
@@ -1048,6 +1049,11 @@ func (o *OIDC) redirectAfterCallback(c *wkhttp.Context, sd *StateData, failed bo
 		}
 		target = target + sep + "oidc_error=1"
 	}
+	// 与 redirectToBindPage 同语义:防止 callback URL(IdP 回填的 code/state +
+	// 我们注入的 oidc_error 标记)在跳到 return_to 那一跳经 Referer 泄漏。code
+	// 是单次消费的,但 state 与时间窗内的 code 组合对反查仍有价值。无论成功还
+	// 是失败 callback 都走这条路径,所以统一加上。
+	c.Header("Referrer-Policy", "no-referrer")
 	c.Redirect(http.StatusFound, target)
 }
 

--- a/modules/oidc/api.go
+++ b/modules/oidc/api.go
@@ -987,6 +987,11 @@ func (o *OIDC) redirectToBindPage(c *wkhttp.Context, sd *StateData, jti string) 
 	}
 	q := target.Query()
 	q.Set("token", jti)
+	// provider 段在 bind API 路径里 (/v1/auth/oidc/<provider>/bind/*),前端从
+	// query 取出后拼回 API URL;缺失时前端兜底到 legacyProviderPathID="aegis"。
+	if o.cfg.Provider.ID != "" {
+		q.Set("provider", o.cfg.Provider.ID)
+	}
 	if sd != nil && sd.ClientAuthcode != "" {
 		q.Set("authcode", sd.ClientAuthcode)
 	}
@@ -998,6 +1003,12 @@ func (o *OIDC) redirectToBindPage(c *wkhttp.Context, sd *StateData, jti string) 
 		}
 	}
 	target.RawQuery = q.Encode()
+	// Referrer-Policy: no-referrer 防止 bind 页(可能位于独立域)及其内部子资源
+	// 把 callback URL 经 Referer 头泄漏。authcode 是 ThirdAuthcode 的 Redis key
+	// (5min 单次有效),仍是凭据,不应出现在跨域 Referer 上。后端单点强制比依赖
+	// 前端 <meta> 更可靠 —— meta 要等 bind 页 HTML 解析后才生效,防不了对 bind
+	// 页本身的请求那一跳。
+	c.Header("Referrer-Policy", "no-referrer")
 	c.Redirect(http.StatusFound, target.String())
 }
 

--- a/modules/oidc/api_bind_test.go
+++ b/modules/oidc/api_bind_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -668,5 +669,51 @@ func TestAPI_RedirectToBindPage_EmptyBaseWritesAuthcodeZero(t *testing.T) {
 
 	if got := fakeAC.get("ac-empty-base"); got != "0" {
 		t.Fatalf("RedirectBase 为空必须先写 ThirdAuthcode \"0\",got %q", got)
+	}
+}
+
+// TestAPI_RedirectToBindPage_EmptyProviderIDOmitsParam 锁定 PR #80 的回退契约:
+// cfg.Provider.ID 为空时,redirect URL **不**应出现 provider= 字段(让前端按
+// legacyProviderPathID="aegis" 兜底),而不是写空串 provider=。
+//
+// 生产路径下 LoadConfig 已用 ^[a-z0-9][a-z0-9_-]{0,63}$ 拦了空 ID,本测试钉住的是
+// 兜底 if 行为本身,防回退路径被无声删除后仍编译通过。
+func TestAPI_RedirectToBindPage_EmptyProviderIDOmitsParam(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	o := &OIDC{
+		Log: log.NewTLog("OIDC-test"),
+		cfg: &Config{
+			Enabled: true,
+			Provider: ProviderConfig{
+				ID:            "",
+				ReturnToHosts: []string{"app.example.com"},
+			},
+			Bind: BindConfig{
+				Enabled:      true,
+				RedirectBase: "https://im.example.com/oidc/bind",
+			},
+		},
+		authcode: newFakeAuthcode(),
+	}
+	r := gin.New()
+	r.GET("/x", func(c *gin.Context) {
+		o.redirectToBindPage(wrapWk(c), &StateData{
+			ClientAuthcode: "ac-no-provider",
+		}, "jti-xyz")
+	})
+	req := httptest.NewRequest("GET", "/x", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("status=%d want 302, body=%s", w.Code, w.Body.String())
+	}
+	loc, err := url.Parse(w.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse Location: %v", err)
+	}
+	if loc.Query().Has("provider") {
+		t.Fatalf("provider must be omitted when cfg.Provider.ID=\"\", got %q in %q",
+			loc.Query().Get("provider"), w.Header().Get("Location"))
 	}
 }

--- a/modules/oidc/api_test.go
+++ b/modules/oidc/api_test.go
@@ -833,6 +833,14 @@ func TestAPI_Callback_TakesOverWithBindEnabled(t *testing.T) {
 	if q.Get("authcode") != "front-bind" {
 		t.Errorf("redirect authcode=%q want front-bind", q.Get("authcode"))
 	}
+	// 前端从 query 取 provider 拼回 /v1/auth/oidc/<provider>/bind/* API URL。
+	if q.Get("provider") != "aegis" {
+		t.Errorf("redirect provider=%q want aegis", q.Get("provider"))
+	}
+	// Referrer-Policy: no-referrer 防止 callback URL (含 authcode) 经 Referer 泄漏。
+	if got := w2.Header().Get("Referrer-Policy"); got != "no-referrer" {
+		t.Errorf("Referrer-Policy=%q want no-referrer", got)
+	}
 	// LoginRespJSON / "0" 都不该出现 —— bind 还没完成
 	if got := fakeAC.get("front-bind"); got != "" {
 		t.Errorf("ThirdAuthcode must NOT be set during bind takeover, got %q", got)

--- a/modules/oidc/state_store.go
+++ b/modules/oidc/state_store.go
@@ -25,7 +25,8 @@ type StateData struct {
 	// ClientAuthcode 前端在 /authorize 阶段传入的短码,callback 完成后用作 ThirdAuthcode
 	// Redis key 的后半段,前端按 GitHub 模式短码轮询取 LoginRespJSON。
 	ClientAuthcode string `json:"client_authcode,omitempty"`
-	// DeviceFlag 调用方期望的设备类型(0=APP / 1=PC / 2=Web ...),透传给 IssueSession。
+	// DeviceFlag 调用方期望的设备类型,透传给 IssueSession。
+	// 取值与 octo-lib config.DeviceFlag 一致(iota 顺序):0=APP / 1=Web / 2=PC。
 	DeviceFlag uint8 `json:"device_flag,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

Two small follow-ups to the OIDC self-service bind flow merged in #73, surfaced by frontend integration:

- **Carry `provider` in the bind redirect query.** Bind endpoints are mounted at `/v1/auth/oidc/<provider>/bind/*`, but `redirectToBindPage` only emitted `token` / `authcode` / `return_to`, leaving the bind page no reliable way to know which provider segment to call back into. Now appends `&provider=<cfg.Provider.ID>`. Older frontends that ignore the field fall back to the legacy `/aegis` path the backend still mounts in parallel — zero impact on existing deployments.
- **Set `Referrer-Policy: no-referrer` on the 302.** When `OCTO_OIDC_BIND_REDIRECT_BASE` points at a separate origin, the callback URL (containing the single-use `ThirdAuthcode` Redis key) would otherwise leak through the `Referer` header to the bind page and any sub-resources it loads. Enforcing this from the backend covers all clients without depending on a frontend `<meta>` tag, which only applies after the bind page has already loaded.

## Test plan

- [x] `go test ./modules/oidc/ -run TestAPI_Callback_TakesOverWithBindEnabled -race`
- [x] `go test ./modules/oidc/ -run TestAPI_RedirectToBindPage_EmptyBaseWritesAuthcodeZero -race`
- [x] Updated `TestAPI_Callback_TakesOverWithBindEnabled` asserts `provider=aegis` in redirect query and `Referrer-Policy: no-referrer` on the response.