### PR TITLE
feat(bot_api): Persona Clone OBO backend v0 (PR-A)

### DIFF
--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -3,14 +3,15 @@ package bot_api
 import (
 	"fmt"
 
-	"github.com/Mininglamp-OSS/octo-server/modules/file"
-	"github.com/Mininglamp-OSS/octo-server/modules/group"
-	"github.com/Mininglamp-OSS/octo-server/modules/thread"
-	"github.com/Mininglamp-OSS/octo-server/modules/user"
-	"github.com/Mininglamp-OSS/octo-server/modules/voice"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/file"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/robot"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/modules/voice"
 )
 
 const (
@@ -32,9 +33,20 @@ type BotAPI struct {
 	groupService  group.IService
 	userDB        *user.DB
 	threadService thread.IService
-	voiceDB       *voice.VoiceDB
-	voiceSvc      *voice.VoiceService
-	voiceCfg      *voice.VoiceConfig
+	// robotService gives the OBO fan-out path a way to enqueue synthetic
+	// events directly into a grantee bot's /v1/bot/events queue. The
+	// webhook layer drops NoPersist=1 messages before NotifyMessagesListeners
+	// (modules/webhook/api.go handleMessageNotify), and the OBO fan-out
+	// copy intentionally sets NoPersist=1 to keep the copy out of chat
+	// history. Without a direct enqueue, the fan-out copy reaches
+	// WuKongIM but never reaches the bot — see YUJ-1424 / PR#82
+	// Jerry-Xin review blocker. fanoutForMessage calls robotService
+	// AFTER dispatchFanout succeeds so we only enqueue events that
+	// WuKongIM actually accepted.
+	robotService robot.IService
+	voiceDB      *voice.VoiceDB
+	voiceSvc     *voice.VoiceService
+	voiceCfg     *voice.VoiceConfig
 	// spaceQuerier overrides ba.db for resolveBotActiveSpaceID (test injection).
 	// nil in production; tests set it to stub the DB call deterministically.
 	spaceQuerier botSpaceQuerier
@@ -53,6 +65,14 @@ type BotAPI struct {
 	// dispatchOverride hook keeps capturing sends in handler tests.
 	// nil in production.
 	oboFanoutDispatch func(*config.MsgSendReq) error
+	// oboFanoutBotEnqueue lets unit tests intercept the bot-event-queue
+	// enqueue that fanoutForMessage performs after a successful dispatch.
+	// Without this seam, fan-out tests would need a live Redis to assert
+	// the synthetic event reaches /v1/bot/events. The production path
+	// goes through ba.robotService.EnqueueBotEvent (see YUJ-1424 / PR#82
+	// Jerry-Xin blocker for why direct enqueue is necessary at all).
+	// nil in production → robotService path runs.
+	oboFanoutBotEnqueue func(robotID string, message *config.MessageResp) error
 	// oboChannelAccessOverride lets unit tests stub the grantor channel-
 	// access check used by oboCreateScope (PR#82 review P0 — channel-wiretap
 	// fix). Production path runs grantorCanReadChannel, which queries
@@ -94,6 +114,7 @@ func NewBotAPI(ctx *config.Context) *BotAPI {
 		groupService:  group.NewService(ctx),
 		userDB:        user.NewDB(ctx),
 		threadService: thread.NewService(ctx),
+		robotService:  robot.NewService(ctx),
 		voiceDB:       voice.NewVoiceDB(ctx),
 		voiceSvc:      voice.NewVoiceService(voiceCfg),
 		voiceCfg:      voiceCfg,
@@ -206,5 +227,3 @@ func (ba *BotAPI) clearTypingThrottle(robotID string, channelID string, channelT
 	ba.ctx.GetRedisConn().Del(typingStartKey)
 	ba.ctx.GetRedisConn().Del(typingCountKey)
 }
-
-

--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -53,6 +53,14 @@ type BotAPI struct {
 	// dispatchOverride hook keeps capturing sends in handler tests.
 	// nil in production.
 	oboFanoutDispatch func(*config.MsgSendReq) error
+	// oboChannelAccessOverride lets unit tests stub the grantor channel-
+	// access check used by oboCreateScope (PR#82 review P0 — channel-wiretap
+	// fix). Production path runs grantorCanReadChannel, which queries
+	// group_member + userService.IsFriend; tests that build BotAPI without
+	// a live DB session set this hook to deterministically accept or reject
+	// (uid, channel_id, channel_type) without touching MySQL.
+	// nil in production → the real DB-backed check runs.
+	oboChannelAccessOverride func(uid, channelID string, channelType uint8) (bool, error)
 	log.Log
 }
 

--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -42,6 +42,17 @@ type BotAPI struct {
 	// final MsgSendReq (including server-authoritative payload.space_id).
 	// nil in production; the real path goes through ba.ctx.SendMessageWithResult.
 	dispatchOverride func(*config.MsgSendReq) (*config.MsgSendResp, error)
+	// oboStoreOverride lets unit tests inject an in-memory oboStore so
+	// checkOBO / REST handlers / fan-out can run without standing up MySQL.
+	// nil in production; the real path uses ba.db (which satisfies oboStore).
+	// See modules/bot_api/obo_db.go for the interface contract.
+	oboStoreOverride oboStore
+	// oboFanoutDispatch lets unit tests intercept the per-grantee copy that
+	// the fan-out listener would otherwise hand to ba.ctx.SendMessage. The
+	// production path delegates to ba.dispatchMsgSendReq so the existing
+	// dispatchOverride hook keeps capturing sends in handler tests.
+	// nil in production.
+	oboFanoutDispatch func(*config.MsgSendReq) error
 	log.Log
 }
 
@@ -57,7 +68,7 @@ func (ba *BotAPI) dispatchMsgSendReq(req *config.MsgSendReq) (*config.MsgSendRes
 // NewBotAPI creates the Bot API gateway module.
 func NewBotAPI(ctx *config.Context) *BotAPI {
 	voiceCfg := voice.NewVoiceConfigFromEnv()
-	return &BotAPI{
+	ba := &BotAPI{
 		ctx:           ctx,
 		db:            newBotAPIDB(ctx),
 		userService:   user.NewService(ctx),
@@ -70,6 +81,14 @@ func NewBotAPI(ctx *config.Context) *BotAPI {
 		voiceCfg:      voiceCfg,
 		Log:           log.NewTLog("BotAPI"),
 	}
+	// YUJ-1166 / Mininglamp-OSS/octo-server#81 — Persona Clone fan-out.
+	// Subscribed AFTER the dependency wiring above so oboMessagesListen
+	// can safely consult ba.db (oboStore). Idempotent: the listener
+	// short-circuits when no grants exist for the message's channel.
+	if ctx != nil {
+		ctx.AddMessagesListener(ba.oboMessagesListen)
+	}
+	return ba
 }
 
 // Route registers all Bot API routes.
@@ -129,6 +148,11 @@ func (ba *BotAPI) Route(r *wkhttp.WKHttp) {
 		botFileAPI.GET("/*path", ba.botProxyFile)
 		botFileAPI.POST("/upload", ba.botUploadFile)
 	}
+
+	// YUJ-1166 / Mininglamp-OSS/octo-server#81 — Persona Clone (OBO) REST.
+	// User-token endpoints under /v1/obo. Implementation in obo_api.go;
+	// the call is split out so this Route function doesn't grow further.
+	ba.registerOBORoutes(r)
 }
 
 // ==================== Helper Functions ====================

--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -61,6 +61,16 @@ type BotAPI struct {
 	// (uid, channel_id, channel_type) without touching MySQL.
 	// nil in production → the real DB-backed check runs.
 	oboChannelAccessOverride func(uid, channelID string, channelType uint8) (bool, error)
+	// friendCheckOverride lets unit tests stub userService.IsFriend for the
+	// friend-gate decision in checkSendPermission / syncMessages, and for
+	// the OBO friend-gate bypass (see obo_friend_gate.go). Production path
+	// uses ba.userService.IsFriend; tests that build BotAPI without a live
+	// user service set this hook to deterministically accept or reject
+	// (uid, toUID) without touching MySQL. PR#82 R6 P0 — managed-persona
+	// OBO friend-gate bypass needs to be testable end-to-end without the
+	// full user-service stack.
+	// nil in production → the real userService.IsFriend runs.
+	friendCheckOverride func(uid, toUID string) (bool, error)
 	log.Log
 }
 

--- a/modules/bot_api/obo_api.go
+++ b/modules/bot_api/obo_api.go
@@ -10,9 +10,12 @@
 //   200 — success (single object or list)
 //   400 — bad request body / missing required fields
 //   401 — no user token (handled by upstream middleware)
-//   403 — grantor mismatch / cross-user attempt
-//   404 — grant_id / scope_id not found
-//   409 — duplicate (grantor+grantee already exists / scope already exists)
+//   403 — (reserved — production currently uses 404 for cross-user attempts
+//          as a user-enumeration defense; see requireOwnedGrant comment.)
+//   404 — grant_id / scope_id not found; cross-user grant/scope access
+//          (existence-leak defense)
+//   409 — duplicate (grantor+grantee already exists / scope already exists,
+//          with no soft-deleted row to reactivate in place)
 //   500 — DB error
 package bot_api
 
@@ -22,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"go.uber.org/zap"
 )
@@ -79,6 +83,21 @@ type oboCreateScopeReq struct {
 // oboCreateGrant — POST /v1/obo/grants.
 // Body: { grantee_bot_uid, mode? }. Grantor is inferred from the auth token
 // — the caller cannot create a grant on someone else's behalf.
+//
+// PR#82 hardening:
+//   - grantee_bot_uid MUST resolve to a robot row with CreatorUID == uid
+//     AND user.robot=1. Without this check a user could install an OBO
+//     grant against someone ELSE's bot, force-feeding it copies of any
+//     channel traffic the grantor can see and muddying audit trails that
+//     key on grantee_bot_uid. (Review #1 task spec P1-2 + review #2 P2-3.)
+//   - When the UNIQUE KEY uk_grantor_grantee fires on insert, look up the
+//     existing row. If it's a soft-deleted row the caller already owns,
+//     reactivate it in place (active=1, global_enabled=0, revoked_at=NULL)
+//     rather than returning 409. Without this path a single
+//     DELETE /v1/obo/grants/:id would permanently brick the (grantor, bot)
+//     pair (review #2 P1-1). global_enabled is intentionally reset to 0
+//     on reactivation so the caller must re-issue a PUT to enable fan-out
+//     — matches the fail-closed default for a brand-new grant.
 func (ba *BotAPI) oboCreateGrant(c *wkhttp.Context) {
 	uid := c.GetLoginUID()
 	if uid == "" {
@@ -108,10 +127,62 @@ func (ba *BotAPI) oboCreateGrant(c *wkhttp.Context) {
 		return
 	}
 
+	// PR#82 review #1 P1-2 / review #2 P2-3 — grantee_bot_uid must be a bot
+	// the caller owns. Lookup hits the robot table (creator_uid) joined to
+	// the user table (robot=1). 404 (not 403) on miss to keep with the
+	// existence-leak posture used elsewhere in this module.
+	creatorUID, isBot, found, err := ba.oboStoreOrDefault().queryRobotOwner(req.GranteeBotUID)
+	if err != nil {
+		ba.Error("queryRobotOwner failed", zap.Error(err), zap.String("bot", req.GranteeBotUID))
+		c.ResponseError(errors.New("内部错误"))
+		return
+	}
+	if !found || !isBot {
+		c.JSON(http.StatusNotFound, gin404("grantee_bot_uid not a registered bot"))
+		return
+	}
+	if creatorUID != uid {
+		// Owned by someone else; treat as not-found to avoid telling the
+		// caller "this bot exists but isn't yours". Same posture as
+		// requireOwnedGrant.
+		c.JSON(http.StatusNotFound, gin404("grantee_bot_uid not a registered bot"))
+		return
+	}
+
 	id, err := ba.oboStoreOrDefault().insertGrant(uid, req.GranteeBotUID, mode)
 	if err != nil {
 		if isDuplicateKeyErr(err) {
-			c.JSON(http.StatusConflict, gin404("grant already exists"))
+			// Reactivation path: a row already exists. If it's a soft-deleted
+			// row owned by the same caller, flip it back to active and return
+			// the refreshed row. Anything else → 409.
+			existing, lookupErr := ba.oboStoreOrDefault().findGrantByGrantorBot(uid, req.GranteeBotUID)
+			if lookupErr != nil {
+				ba.Error("post-duplicate findGrant lookup failed", zap.Error(lookupErr))
+				c.JSON(http.StatusConflict, gin404("grant already exists"))
+				return
+			}
+			if existing == nil || existing.GrantorUID != uid {
+				// Shouldn't happen — UNIQUE on (grantor, grantee) means the
+				// duplicate must be ours. Defensive: 409 rather than 500.
+				c.JSON(http.StatusConflict, gin404("grant already exists"))
+				return
+			}
+			if existing.Active == 1 {
+				// Live row → genuine duplicate, not a reactivation case.
+				c.JSON(http.StatusConflict, gin404("grant already exists"))
+				return
+			}
+			if reactErr := ba.oboStoreOrDefault().reactivateGrant(existing.ID); reactErr != nil {
+				ba.Error("reactivateGrant failed", zap.Error(reactErr), zap.Int64("id", existing.ID))
+				c.ResponseError(errors.New("内部错误"))
+				return
+			}
+			refreshed, _ := ba.oboStoreOrDefault().findGrantByID(existing.ID)
+			if refreshed != nil {
+				c.Response(refreshed)
+				return
+			}
+			c.Response(map[string]interface{}{"id": existing.ID})
 			return
 		}
 		ba.Error("insertGrant failed", zap.Error(err))
@@ -206,6 +277,17 @@ func (ba *BotAPI) oboUpdateGrant(c *wkhttp.Context) {
 
 // oboCreateScope — POST /v1/obo/scopes. Adds (or upserts via the unique
 // key) a per-channel white-list entry to an existing owned grant.
+//
+// PR#82 P0 (channel-wiretap, three reviewers concur): after grant ownership
+// passes, verify the GRANTOR (= calling user uid) has read access to the
+// target (channel_id, channel_type). Without this check, a logged-in user
+// could create a scope for a channel they are not a member of — every
+// inbound message in that channel would then be fan-out-copied to their
+// bot, exfiltrating channel traffic the grantor was never authorized to
+// see. The check fails closed: any DB error, missing membership row, or
+// unknown channel type → 404 (existence-leak posture). 404 (not 403)
+// matches requireOwnedGrant; combined, the two checks never reveal
+// "grant exists but channel access denied" vs "channel doesn't exist".
 func (ba *BotAPI) oboCreateScope(c *wkhttp.Context) {
 	uid := c.GetLoginUID()
 	if uid == "" {
@@ -225,6 +307,29 @@ func (ba *BotAPI) oboCreateScope(c *wkhttp.Context) {
 	if err != nil || grant == nil {
 		return
 	}
+	// P0 — channel-wiretap defense. Grantor MUST be able to read the
+	// target channel themselves before they can authorize a bot to read it
+	// on their behalf. See grantorCanReadChannel for the per-channel-type
+	// predicate. Failed check → 404 (existence-leak defense; never tell
+	// the caller whether the channel exists).
+	ok, err := ba.grantorCanReadChannel(uid, req.ChannelID, req.ChannelType)
+	if err != nil {
+		ba.Error("grantor channel-access check failed",
+			zap.Error(err), zap.String("grantor", uid),
+			zap.String("channel_id", req.ChannelID),
+			zap.Uint8("channel_type", req.ChannelType))
+		c.ResponseError(errors.New("内部错误"))
+		return
+	}
+	if !ok {
+		ba.Warn("OBO scope denied: grantor has no read access to channel",
+			zap.String("grantor", uid),
+			zap.String("channel_id", req.ChannelID),
+			zap.Uint8("channel_type", req.ChannelType))
+		c.JSON(http.StatusNotFound, gin404("channel not found"))
+		return
+	}
+
 	enabled := 1
 	if req.Enabled != nil && *req.Enabled == 0 {
 		enabled = 0
@@ -249,7 +354,13 @@ func (ba *BotAPI) oboCreateScope(c *wkhttp.Context) {
 }
 
 // oboDeleteScope — DELETE /v1/obo/scopes/:id. Caller must own the parent
-// grant. (No ownership shortcut — we have to look up the scope first.)
+// grant.
+//
+// PR#82 review #2 P1-3: ownership resolves in a single JOIN query
+// (oboStore.findScopeOwner) instead of the previous
+// O(grants × scopes_per_grant) scan. A power user with 50 grants × 200
+// scopes/grant required ~10k DB queries to delete one scope under the
+// old path; now it is two queries (find owner + delete row).
 func (ba *BotAPI) oboDeleteScope(c *wkhttp.Context) {
 	uid := c.GetLoginUID()
 	if uid == "" {
@@ -260,18 +371,16 @@ func (ba *BotAPI) oboDeleteScope(c *wkhttp.Context) {
 	if !ok {
 		return
 	}
-	// Look up scope → grant → ownership. We use listScopesByGrant with a
-	// known grant_id once we have it, but to *get* the grant_id from a
-	// scope id we need a peek; simplest is to issue findGrantByID after a
-	// dedicated lookup. To avoid adding another store method, REST tests
-	// drive this through the in-memory fake which short-circuits ownership.
-	scopeOwnerOK, err := ba.scopeOwnedBy(uid, id)
+	owner, found, err := ba.oboStoreOrDefault().findScopeOwner(id)
 	if err != nil {
-		ba.Error("scope ownership lookup failed", zap.Error(err))
+		ba.Error("scope ownership lookup failed", zap.Error(err), zap.Int64("id", id))
 		c.ResponseError(errors.New("内部错误"))
 		return
 	}
-	if !scopeOwnerOK {
+	if !found || owner != uid {
+		// Existence-leak defense: cross-user delete attempts return 404,
+		// indistinguishable from "scope id never existed". Matches the
+		// posture in requireOwnedGrant.
 		c.JSON(http.StatusNotFound, gin404("scope not found"))
 		return
 	}
@@ -332,30 +441,89 @@ func (ba *BotAPI) requireOwnedGrant(c *wkhttp.Context, uid string, id int64) (*o
 	return grant, nil
 }
 
-// scopeOwnedBy returns true if scope `id` exists AND its parent grant is
-// owned by `uid`. Implemented by iterating the caller's grants because the
-// store interface deliberately does not expose findScopeByID (the v0
-// surface stays minimal and the per-user scope volume is tiny).
-func (ba *BotAPI) scopeOwnedBy(uid string, id int64) (bool, error) {
-	if uid == "" {
+// grantorCanReadChannel verifies the grantor (the calling user) has read
+// access to (channelID, channelType). Used by oboCreateScope to plug the
+// channel-wiretap vulnerability described in PR#82 reviews — a scope row
+// must NOT be creatable for a channel the grantor cannot themselves read,
+// because once it lands, the fan-out listener will replay every inbound
+// message from that channel to the grantee bot regardless of whether the
+// grantor is still (or ever was) a member.
+//
+// Per-type predicates mirror checkSendPermission (modules/bot_api/send.go)
+// so the rules can't diverge over time:
+//   - ChannelTypeGroup → grantor must have an undeleted group_member row
+//     for group_no = channel_id.
+//   - ChannelTypeCommunityTopic → channel_id is "<parent_group_no>____<short_id>";
+//     grantor must be a member of the parent group. Threads inherit
+//     parent-group read-ACL in the rest of the codebase (see send.go:200,
+//     sync.go:106); we reuse that invariant here.
+//   - ChannelTypePerson → channel_id is the peer uid for a DM. The
+//     grantor is "in" a DM iff they ARE the peer (DM channel ids in
+//     octo-server are bare uids — see resolveSpaceChannelID for the no-op
+//     return that documents this) or they're friends with the peer. We
+//     allow either: a user has read access to "their own DM with X" if
+//     they are X (the peer), and a real user is allowed to authorize
+//     fan-out from a DM-with-friend regardless of which side initiated.
+//
+// Test hook: ba.oboChannelAccessOverride lets unit tests stub the answer
+// without standing up MySQL or a user service. nil override → DB path.
+func (ba *BotAPI) grantorCanReadChannel(uid, channelID string, channelType uint8) (bool, error) {
+	if ba.oboChannelAccessOverride != nil {
+		return ba.oboChannelAccessOverride(uid, channelID, channelType)
+	}
+	if uid == "" || channelID == "" {
 		return false, nil
 	}
-	grants, err := ba.oboStoreOrDefault().listGrantsByGrantor(uid)
+	switch channelType {
+	case common.ChannelTypeGroup.Uint8():
+		return ba.userIsGroupMember(uid, channelID)
+	case common.ChannelTypeCommunityTopic.Uint8():
+		// Thread channel id format: "<parent_group_no>____<short_id>".
+		// Reuse threadChannelIDSeparator + the convention already
+		// established by send.go / sync.go for parent-group membership.
+		parts := strings.SplitN(channelID, threadChannelIDSeparator, 2)
+		if len(parts) != 2 || parts[0] == "" {
+			// Malformed thread id — treat as no-access (fail-closed).
+			return false, nil
+		}
+		return ba.userIsGroupMember(uid, parts[0])
+	case common.ChannelTypePerson.Uint8():
+		// DM peer self-access: a user is trivially "in" a DM that is
+		// themselves (the channel id is the peer; if uid == peer they
+		// would be DMing themselves, which is degenerate but allowed).
+		if uid == channelID {
+			return true, nil
+		}
+		// Otherwise: must be friends with the peer. Mirrors the
+		// BotKindUser ChannelTypePerson branch of checkSendPermission.
+		if ba.userService == nil {
+			// No user service wired (tests should set override) — fail-closed.
+			return false, nil
+		}
+		return ba.userService.IsFriend(uid, channelID)
+	default:
+		// Unknown channel type → cannot authorize fan-out for it.
+		return false, nil
+	}
+}
+
+// userIsGroupMember returns true iff `uid` has an undeleted row in
+// group_member for group_no=groupNo. Mirrors the SQL used by
+// checkSendPermission's BotKindUser/ChannelTypeGroup branch.
+func (ba *BotAPI) userIsGroupMember(uid, groupNo string) (bool, error) {
+	if ba.db == nil || ba.db.session == nil {
+		// No DB session (some test contexts) — fail-closed.
+		return false, nil
+	}
+	var count int
+	err := ba.db.session.SelectBySql(
+		"SELECT COUNT(*) FROM group_member WHERE group_no=? AND uid=? AND is_deleted=0",
+		groupNo, uid,
+	).LoadOne(&count)
 	if err != nil {
 		return false, err
 	}
-	for _, g := range grants {
-		scopes, err := ba.oboStoreOrDefault().listScopesByGrant(g.ID)
-		if err != nil {
-			return false, err
-		}
-		for _, s := range scopes {
-			if s.ID == id {
-				return true, nil
-			}
-		}
-	}
-	return false, nil
+	return count > 0, nil
 }
 
 // parseIDParam reads ":id" as int64. On failure writes 400 and returns

--- a/modules/bot_api/obo_api.go
+++ b/modules/bot_api/obo_api.go
@@ -1,0 +1,377 @@
+// Package bot_api · YUJ-1166 / Mininglamp-OSS/octo-server#81 — Persona Clone
+// OBO REST endpoints.
+//
+// These endpoints are mounted under /v1/obo behind the standard user-auth
+// middleware (ba.ctx.AuthMiddleware) — they take a USER token, not a bot
+// token. The acting user must be the grantor of the row they CRUD; we do
+// NOT support cross-user persona management in v0 (RFC §2 / out-of-scope).
+//
+// Status code map (kept narrow on purpose):
+//   200 — success (single object or list)
+//   400 — bad request body / missing required fields
+//   401 — no user token (handled by upstream middleware)
+//   403 — grantor mismatch / cross-user attempt
+//   404 — grant_id / scope_id not found
+//   409 — duplicate (grantor+grantee already exists / scope already exists)
+//   500 — DB error
+package bot_api
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"go.uber.org/zap"
+)
+
+// registerOBORoutes mounts the OBO endpoints onto r under user-auth.
+// Called from BotAPI.Route. Split out so the route table in bot_api.go
+// stays focused on bot-token routes.
+func (ba *BotAPI) registerOBORoutes(r *wkhttp.WKHttp) {
+	// Defensive: ctx may be nil in unit tests that build a bare BotAPI
+	// (e.g. send_test.go's BotAPI literal). Skip mounting in that case —
+	// tests of the OBO REST surface construct their own gin engines.
+	if ba.ctx == nil {
+		return
+	}
+	auth := r.Group("/v1/obo", ba.ctx.AuthMiddleware(r))
+	auth.POST("/grants", ba.oboCreateGrant)
+	auth.GET("/grants", ba.oboListGrants)
+	auth.DELETE("/grants/:id", ba.oboDeleteGrant)
+	auth.PUT("/grants/:id", ba.oboUpdateGrant)
+	auth.POST("/scopes", ba.oboCreateScope)
+	auth.DELETE("/scopes/:id", ba.oboDeleteScope)
+	auth.GET("/grants/:id/scopes", ba.oboListScopes)
+}
+
+// ==================== Request DTOs ====================
+
+type oboCreateGrantReq struct {
+	GranteeBotUID string `json:"grantee_bot_uid"`
+	// Mode defaults to "auto" on the server. v0 rejects anything else so a
+	// client can't quietly set "draft" and expect functionality. The field
+	// is kept on the wire for forward-compat with v1.
+	Mode string `json:"mode,omitempty"`
+}
+
+type oboUpdateGrantReq struct {
+	Mode string `json:"mode,omitempty"`
+	// GlobalEnabled uses *int (not int / bool) so "field omitted" and
+	// "field set to 0" are distinguishable on the wire. Per RFC §5.1
+	// PUT semantics: only provided fields are updated.
+	GlobalEnabled *int `json:"global_enabled,omitempty"`
+}
+
+type oboCreateScopeReq struct {
+	GrantID     int64  `json:"grant_id"`
+	ChannelID   string `json:"channel_id"`
+	ChannelType uint8  `json:"channel_type"`
+	// Enabled defaults to 1 when omitted. Clients that want to add a row
+	// in the "off" state can set it to 0 — the cheaper alternative to
+	// add-then-toggle.
+	Enabled *int `json:"enabled,omitempty"`
+}
+
+// ==================== Handlers ====================
+
+// oboCreateGrant — POST /v1/obo/grants.
+// Body: { grantee_bot_uid, mode? }. Grantor is inferred from the auth token
+// — the caller cannot create a grant on someone else's behalf.
+func (ba *BotAPI) oboCreateGrant(c *wkhttp.Context) {
+	uid := c.GetLoginUID()
+	if uid == "" {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin404("unauthorized"))
+		return
+	}
+	var req oboCreateGrantReq
+	if err := c.BindJSON(&req); err != nil {
+		c.ResponseError(errors.New("数据格式有误"))
+		return
+	}
+	if strings.TrimSpace(req.GranteeBotUID) == "" {
+		c.ResponseError(errors.New("grantee_bot_uid 不能为空"))
+		return
+	}
+	if req.GranteeBotUID == uid {
+		c.ResponseError(errors.New("grantee_bot_uid 不能等于自己"))
+		return
+	}
+	mode := req.Mode
+	if mode == "" {
+		mode = "auto"
+	}
+	if mode != "auto" {
+		// v0 — see RFC §2 / out-of-scope. Draft mode lands in v1.
+		c.ResponseError(errors.New("mode 仅支持 auto (v0)"))
+		return
+	}
+
+	id, err := ba.oboStoreOrDefault().insertGrant(uid, req.GranteeBotUID, mode)
+	if err != nil {
+		if isDuplicateKeyErr(err) {
+			c.JSON(http.StatusConflict, gin404("grant already exists"))
+			return
+		}
+		ba.Error("insertGrant failed", zap.Error(err))
+		c.ResponseError(errors.New("内部错误"))
+		return
+	}
+	grant, err := ba.oboStoreOrDefault().findGrantByID(id)
+	if err != nil || grant == nil {
+		// Insert succeeded but read-back failed — return the bare ID so the
+		// client can still call other endpoints.
+		c.Response(map[string]interface{}{"id": id})
+		return
+	}
+	c.Response(grant)
+}
+
+// oboListGrants — GET /v1/obo/grants. Lists ALL grants (active + revoked)
+// owned by the caller. UI usually filters to active on its side.
+func (ba *BotAPI) oboListGrants(c *wkhttp.Context) {
+	uid := c.GetLoginUID()
+	if uid == "" {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin404("unauthorized"))
+		return
+	}
+	grants, err := ba.oboStoreOrDefault().listGrantsByGrantor(uid)
+	if err != nil {
+		ba.Error("listGrants failed", zap.Error(err))
+		c.ResponseError(errors.New("内部错误"))
+		return
+	}
+	c.Response(map[string]interface{}{"items": grants})
+}
+
+// oboDeleteGrant — DELETE /v1/obo/grants/:id. Soft delete (revoke). Caller
+// must own the row.
+func (ba *BotAPI) oboDeleteGrant(c *wkhttp.Context) {
+	uid := c.GetLoginUID()
+	id, ok := parseIDParam(c, "id")
+	if !ok {
+		return
+	}
+	grant, err := ba.requireOwnedGrant(c, uid, id)
+	if err != nil || grant == nil {
+		return // requireOwnedGrant already wrote the response
+	}
+	if err := ba.oboStoreOrDefault().revokeGrant(id); err != nil {
+		ba.Error("revokeGrant failed", zap.Error(err), zap.Int64("id", id))
+		c.ResponseError(errors.New("内部错误"))
+		return
+	}
+	c.ResponseOK()
+}
+
+// oboUpdateGrant — PUT /v1/obo/grants/:id. Toggle global_enabled / change
+// mode. mode validation matches Create (v0 only accepts "auto").
+func (ba *BotAPI) oboUpdateGrant(c *wkhttp.Context) {
+	uid := c.GetLoginUID()
+	id, ok := parseIDParam(c, "id")
+	if !ok {
+		return
+	}
+	grant, err := ba.requireOwnedGrant(c, uid, id)
+	if err != nil || grant == nil {
+		return
+	}
+	var req oboUpdateGrantReq
+	if err := c.BindJSON(&req); err != nil {
+		c.ResponseError(errors.New("数据格式有误"))
+		return
+	}
+	if req.Mode != "" && req.Mode != "auto" {
+		c.ResponseError(errors.New("mode 仅支持 auto (v0)"))
+		return
+	}
+	if req.Mode == "" && req.GlobalEnabled == nil {
+		// Idempotent no-op — return the existing row.
+		c.Response(grant)
+		return
+	}
+	if err := ba.oboStoreOrDefault().updateGrant(id, req.Mode, req.GlobalEnabled); err != nil {
+		ba.Error("updateGrant failed", zap.Error(err), zap.Int64("id", id))
+		c.ResponseError(errors.New("内部错误"))
+		return
+	}
+	refreshed, _ := ba.oboStoreOrDefault().findGrantByID(id)
+	if refreshed != nil {
+		c.Response(refreshed)
+		return
+	}
+	c.ResponseOK()
+}
+
+// oboCreateScope — POST /v1/obo/scopes. Adds (or upserts via the unique
+// key) a per-channel white-list entry to an existing owned grant.
+func (ba *BotAPI) oboCreateScope(c *wkhttp.Context) {
+	uid := c.GetLoginUID()
+	if uid == "" {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin404("unauthorized"))
+		return
+	}
+	var req oboCreateScopeReq
+	if err := c.BindJSON(&req); err != nil {
+		c.ResponseError(errors.New("数据格式有误"))
+		return
+	}
+	if req.GrantID == 0 || strings.TrimSpace(req.ChannelID) == "" || req.ChannelType == 0 {
+		c.ResponseError(errors.New("grant_id / channel_id / channel_type 不能为空"))
+		return
+	}
+	grant, err := ba.requireOwnedGrant(c, uid, req.GrantID)
+	if err != nil || grant == nil {
+		return
+	}
+	enabled := 1
+	if req.Enabled != nil && *req.Enabled == 0 {
+		enabled = 0
+	}
+	id, err := ba.oboStoreOrDefault().insertScope(req.GrantID, req.ChannelID, req.ChannelType, enabled)
+	if err != nil {
+		if isDuplicateKeyErr(err) {
+			c.JSON(http.StatusConflict, gin404("scope already exists"))
+			return
+		}
+		ba.Error("insertScope failed", zap.Error(err))
+		c.ResponseError(errors.New("内部错误"))
+		return
+	}
+	c.Response(map[string]interface{}{
+		"id":           id,
+		"grant_id":     req.GrantID,
+		"channel_id":   req.ChannelID,
+		"channel_type": req.ChannelType,
+		"enabled":      enabled,
+	})
+}
+
+// oboDeleteScope — DELETE /v1/obo/scopes/:id. Caller must own the parent
+// grant. (No ownership shortcut — we have to look up the scope first.)
+func (ba *BotAPI) oboDeleteScope(c *wkhttp.Context) {
+	uid := c.GetLoginUID()
+	if uid == "" {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin404("unauthorized"))
+		return
+	}
+	id, ok := parseIDParam(c, "id")
+	if !ok {
+		return
+	}
+	// Look up scope → grant → ownership. We use listScopesByGrant with a
+	// known grant_id once we have it, but to *get* the grant_id from a
+	// scope id we need a peek; simplest is to issue findGrantByID after a
+	// dedicated lookup. To avoid adding another store method, REST tests
+	// drive this through the in-memory fake which short-circuits ownership.
+	scopeOwnerOK, err := ba.scopeOwnedBy(uid, id)
+	if err != nil {
+		ba.Error("scope ownership lookup failed", zap.Error(err))
+		c.ResponseError(errors.New("内部错误"))
+		return
+	}
+	if !scopeOwnerOK {
+		c.JSON(http.StatusNotFound, gin404("scope not found"))
+		return
+	}
+	if err := ba.oboStoreOrDefault().deleteScope(id); err != nil {
+		ba.Error("deleteScope failed", zap.Error(err), zap.Int64("id", id))
+		c.ResponseError(errors.New("内部错误"))
+		return
+	}
+	c.ResponseOK()
+}
+
+// oboListScopes — GET /v1/obo/grants/:id/scopes.
+func (ba *BotAPI) oboListScopes(c *wkhttp.Context) {
+	uid := c.GetLoginUID()
+	id, ok := parseIDParam(c, "id")
+	if !ok {
+		return
+	}
+	grant, err := ba.requireOwnedGrant(c, uid, id)
+	if err != nil || grant == nil {
+		return
+	}
+	scopes, err := ba.oboStoreOrDefault().listScopesByGrant(id)
+	if err != nil {
+		ba.Error("listScopes failed", zap.Error(err))
+		c.ResponseError(errors.New("内部错误"))
+		return
+	}
+	c.Response(map[string]interface{}{"items": scopes})
+}
+
+// ==================== Helpers ====================
+
+// requireOwnedGrant resolves the grant and verifies the caller owns it.
+// Writes the appropriate HTTP error response and returns (nil, err) on
+// any failure path so callers can simply `return`.
+func (ba *BotAPI) requireOwnedGrant(c *wkhttp.Context, uid string, id int64) (*oboGrantModel, error) {
+	if uid == "" {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin404("unauthorized"))
+		return nil, nil
+	}
+	grant, err := ba.oboStoreOrDefault().findGrantByID(id)
+	if err != nil {
+		ba.Error("findGrantByID failed", zap.Error(err), zap.Int64("id", id))
+		c.ResponseError(errors.New("内部错误"))
+		return nil, err
+	}
+	if grant == nil {
+		c.JSON(http.StatusNotFound, gin404("grant not found"))
+		return nil, nil
+	}
+	if grant.GrantorUID != uid {
+		// Treat as 404, not 403, so we don't leak grant existence to
+		// non-owners. (Same logic as classic "user enumeration" defense.)
+		c.JSON(http.StatusNotFound, gin404("grant not found"))
+		return nil, nil
+	}
+	return grant, nil
+}
+
+// scopeOwnedBy returns true if scope `id` exists AND its parent grant is
+// owned by `uid`. Implemented by iterating the caller's grants because the
+// store interface deliberately does not expose findScopeByID (the v0
+// surface stays minimal and the per-user scope volume is tiny).
+func (ba *BotAPI) scopeOwnedBy(uid string, id int64) (bool, error) {
+	if uid == "" {
+		return false, nil
+	}
+	grants, err := ba.oboStoreOrDefault().listGrantsByGrantor(uid)
+	if err != nil {
+		return false, err
+	}
+	for _, g := range grants {
+		scopes, err := ba.oboStoreOrDefault().listScopesByGrant(g.ID)
+		if err != nil {
+			return false, err
+		}
+		for _, s := range scopes {
+			if s.ID == id {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// parseIDParam reads ":id" as int64. On failure writes 400 and returns
+// (0, false) so the caller can `return`.
+func parseIDParam(c *wkhttp.Context, name string) (int64, bool) {
+	raw := c.Param(name)
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		c.ResponseError(errors.New(name + " 无效"))
+		return 0, false
+	}
+	return id, true
+}
+
+// gin404 is a tiny helper to avoid importing gin.H here (keeps the package's
+// import surface for tests slim).
+func gin404(msg string) map[string]interface{} {
+	return map[string]interface{}{"msg": msg}
+}

--- a/modules/bot_api/obo_api.go
+++ b/modules/bot_api/obo_api.go
@@ -7,16 +7,17 @@
 // NOT support cross-user persona management in v0 (RFC §2 / out-of-scope).
 //
 // Status code map (kept narrow on purpose):
-//   200 — success (single object or list)
-//   400 — bad request body / missing required fields
-//   401 — no user token (handled by upstream middleware)
-//   403 — (reserved — production currently uses 404 for cross-user attempts
-//          as a user-enumeration defense; see requireOwnedGrant comment.)
-//   404 — grant_id / scope_id not found; cross-user grant/scope access
-//          (existence-leak defense)
-//   409 — duplicate (grantor+grantee already exists / scope already exists,
-//          with no soft-deleted row to reactivate in place)
-//   500 — DB error
+//
+//	200 — success (single object or list)
+//	400 — bad request body / missing required fields
+//	401 — no user token (handled by upstream middleware)
+//	403 — (reserved — production currently uses 404 for cross-user attempts
+//	       as a user-enumeration defense; see requireOwnedGrant comment.)
+//	404 — grant_id / scope_id not found; cross-user grant/scope access
+//	       (existence-leak defense)
+//	409 — duplicate (grantor+grantee already exists / scope already exists,
+//	       with no soft-deleted row to reactivate in place)
+//	500 — DB error
 package bot_api
 
 import (
@@ -238,6 +239,26 @@ func (ba *BotAPI) oboDeleteGrant(c *wkhttp.Context) {
 
 // oboUpdateGrant — PUT /v1/obo/grants/:id. Toggle global_enabled / change
 // mode. mode validation matches Create (v0 only accepts "auto").
+//
+// YUJ-1424 / PR#82 Jerry-Xin review (2026-05-20, "Also fix" non-blocking):
+// requireOwnedGrant verifies ownership but NOT `active` status, so a
+// caller can flip mode / global_enabled on a grant they previously
+// revoked (active=0). That silently un-tombstones the row's logical
+// state from the caller's perspective (the row still has active=0 and
+// won't be picked up by findActiveGrantByGrantorBot / -ForChannel, but
+// PUTting mode="auto" + global_enabled=1 reads back as "live" via
+// findGrantByID and gives misleading client UX). The fix is to reject
+// the PUT when the row is revoked — callers that want to revive a
+// revoked grant must POST /v1/obo/grants (Create takes the
+// reactivation path; see oboCreateGrant's "soft-revoked → reactivate
+// in place" branch). 404 (not 409) mirrors the existence-leak posture
+// of requireOwnedGrant: a revoked grant is treated as "no longer
+// addressable" by per-grant write endpoints.
+//
+// Scope: oboUpdateGrant only. oboDeleteGrant is intentionally left
+// idempotent on already-revoked rows (re-revoke is a no-op), and
+// oboListScopes / per-grant reads on a revoked grant still surface
+// history so the UI can render audit trails.
 func (ba *BotAPI) oboUpdateGrant(c *wkhttp.Context) {
 	uid := c.GetLoginUID()
 	id, ok := parseIDParam(c, "id")
@@ -246,6 +267,16 @@ func (ba *BotAPI) oboUpdateGrant(c *wkhttp.Context) {
 	}
 	grant, err := ba.requireOwnedGrant(c, uid, id)
 	if err != nil || grant == nil {
+		return
+	}
+	// YUJ-1424 — active gate. See function doc for rationale. Defensive
+	// check on the row we already loaded; no extra DB roundtrip.
+	if grant.Active != 1 {
+		ba.Warn("OBO update rejected: grant is revoked",
+			zap.Int64("grant_id", id),
+			zap.String("grantor", uid),
+			zap.Int("active", grant.Active))
+		c.JSON(http.StatusNotFound, gin404("grant not found"))
 		return
 	}
 	var req oboUpdateGrantReq

--- a/modules/bot_api/obo_api_test.go
+++ b/modules/bot_api/obo_api_test.go
@@ -551,3 +551,112 @@ func TestOBO_DeleteScope_FindScopeOwner_LookupErr(t *testing.T) {
 		t.Fatalf("expected error body, got empty response")
 	}
 }
+
+// ==================== YUJ-1358 grantee_bot_name regression ====================
+
+// TestOBO_ListGrants_PopulatesGranteeBotName — GET /v1/obo/grants must
+// return a non-empty `grantee_bot_name` on every row so the web
+// PersonaCard does NOT fall back to rendering the raw bot uid
+// (`27qFHDRBCJQ2c868c93_bot`). The prod query enriches via
+// LEFT JOIN `user` u ON u.uid = g.grantee_bot_uid; the fake mirrors that
+// via seedBotName. Verifies both the JOIN-success and the COALESCE
+// fallback (bot with no user row → uid surfaces, never empty string).
+// Refs YUJ-1358 / octo-web#60.
+func TestOBO_ListGrants_PopulatesGranteeBotName(t *testing.T) {
+	s := newFakeOBOStore()
+	// Two grants for the same grantor:
+	//   1. bot with a known display name (JOIN-success path)
+	//   2. bot with no name seeded → fallback to uid (COALESCE path)
+	s.seedBot(tRESTBot, tRESTOwner)
+	s.seedBotName(tRESTBot, "james")
+	_, _ = s.insertGrant(tRESTOwner, tRESTBot, "auto")
+
+	const unnamedBot = "bot_no_user_row"
+	s.seedBot(unnamedBot, tRESTOwner)
+	_, _ = s.insertGrant(tRESTOwner, unnamedBot, "auto")
+
+	ba := newBAforREST(s)
+	c, rec := makeCtx(t, tRESTOwner, http.MethodGet, "/v1/obo/grants", nil, nil)
+	ba.oboListGrants(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Decode the envelope used by the handler: c.Response wraps the payload
+	// inside the standard {status, data} shape. We unmarshal loosely.
+	var env struct {
+		Data struct {
+			Items []map[string]interface{} `json:"items"`
+		} `json:"data"`
+		Items []map[string]interface{} `json:"items"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode list body: %v body=%s", err, rec.Body.String())
+	}
+	items := env.Data.Items
+	if len(items) == 0 {
+		items = env.Items
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d body=%s", len(items), rec.Body.String())
+	}
+
+	byUID := map[string]map[string]interface{}{}
+	for _, it := range items {
+		uid, _ := it["grantee_bot_uid"].(string)
+		byUID[uid] = it
+	}
+	if got, _ := byUID[tRESTBot]["grantee_bot_name"].(string); got != "james" {
+		t.Errorf("grant %s grantee_bot_name = %q, want %q", tRESTBot, got, "james")
+	}
+	if got, _ := byUID[unnamedBot]["grantee_bot_name"].(string); got != unnamedBot {
+		t.Errorf("grant %s grantee_bot_name = %q, want %q (COALESCE fallback)",
+			unnamedBot, got, unnamedBot)
+	}
+	// Hard contract: every row's grantee_bot_name MUST be non-empty so the
+	// frontend never falls back to the uid render path that motivated this
+	// fix in the first place.
+	for _, it := range items {
+		name, _ := it["grantee_bot_name"].(string)
+		if name == "" {
+			t.Errorf("grantee_bot_name must never be empty; row=%+v", it)
+		}
+	}
+}
+
+// TestOBO_StoreListGrantsByGrantor_GranteeBotNameContract — the same
+// invariant at the store layer (no HTTP). Pins down the fake's contract
+// so future contributors who add another caller of listGrantsByGrantor
+// can rely on a non-empty GranteeBotName without re-reading the SQL.
+func TestOBO_StoreListGrantsByGrantor_GranteeBotNameContract(t *testing.T) {
+	s := newFakeOBOStore()
+	s.seedBot(tRESTBot, tRESTOwner)
+	s.seedBotName(tRESTBot, "james")
+	_, _ = s.insertGrant(tRESTOwner, tRESTBot, "auto")
+
+	rows, err := s.listGrantsByGrantor(tRESTOwner)
+	if err != nil {
+		t.Fatalf("listGrantsByGrantor err=%v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d", len(rows))
+	}
+	if rows[0].GranteeBotName != "james" {
+		t.Errorf("GranteeBotName = %q, want %q", rows[0].GranteeBotName, "james")
+	}
+
+	// Fallback: bot without a seeded display name → uid surfaces.
+	const unnamedBot = "bot_no_display"
+	s.seedBot(unnamedBot, tRESTOwner)
+	_, _ = s.insertGrant(tRESTOwner, unnamedBot, "auto")
+	rows, _ = s.listGrantsByGrantor(tRESTOwner)
+	for _, r := range rows {
+		if r.GranteeBotName == "" {
+			t.Errorf("GranteeBotName must never be empty (uid=%s)", r.GranteeBotUID)
+		}
+		if r.GranteeBotUID == unnamedBot && r.GranteeBotName != unnamedBot {
+			t.Errorf("fallback name for %s = %q, want %q (COALESCE)",
+				unnamedBot, r.GranteeBotName, unnamedBot)
+		}
+	}
+}

--- a/modules/bot_api/obo_api_test.go
+++ b/modules/bot_api/obo_api_test.go
@@ -15,6 +15,7 @@ package bot_api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -64,6 +65,12 @@ func newBAforREST(s *fakeOBOStore) *BotAPI {
 	return &BotAPI{
 		Log:              log.NewTLog("BotAPI-rest-test"),
 		oboStoreOverride: s,
+		// Default test override: grantor has access to any channel. The
+		// channel-wiretap regression test (TestOBO_CreateScope_NoChannelAccess)
+		// installs a denying override explicitly.
+		oboChannelAccessOverride: func(uid, channelID string, channelType uint8) (bool, error) {
+			return true, nil
+		},
 	}
 }
 
@@ -71,6 +78,7 @@ func newBAforREST(s *fakeOBOStore) *BotAPI {
 
 func TestOBO_CreateGrant_Happy(t *testing.T) {
 	s := newFakeOBOStore()
+	s.seedBot(tRESTBot, tRESTOwner)
 	ba := newBAforREST(s)
 
 	c, rec := makeCtx(t, tRESTOwner, http.MethodPost, "/v1/obo/grants",
@@ -122,6 +130,7 @@ func TestOBO_CreateGrant_BadMode(t *testing.T) {
 
 func TestOBO_CreateGrant_Duplicate(t *testing.T) {
 	s := newFakeOBOStore()
+	s.seedBot(tRESTBot, tRESTOwner)
 	_, _ = s.insertGrant(tRESTOwner, tRESTBot, "auto")
 	ba := newBAforREST(s)
 
@@ -313,5 +322,232 @@ func TestOBO_DeleteScope_CrossUser404(t *testing.T) {
 	scopes, _ := s.listScopesByGrant(gid)
 	if len(scopes) != 1 {
 		t.Fatalf("scope must survive cross-user attempt, got %d", len(scopes))
+	}
+}
+
+// ==================== PR#82 hardening regression tests ====================
+
+// TestOBO_CreateGrant_NotOwnBot_404 — caller MUST own the grantee bot
+// (review #1 task spec P1-2). The fake oboStore seeds bot_X as owned by
+// tRESTOther; the caller tRESTOwner is not allowed to install an OBO
+// grant targeting it, even with a syntactically valid body. 404 (not 403)
+// matches the existence-leak posture.
+func TestOBO_CreateGrant_NotOwnBot_404(t *testing.T) {
+	s := newFakeOBOStore()
+	s.seedBot("bot_X", tRESTOther) // owned by someone else
+	ba := newBAforREST(s)
+
+	c, rec := makeCtx(t, tRESTOwner, http.MethodPost, "/v1/obo/grants",
+		oboCreateGrantReq{GranteeBotUID: "bot_X"}, nil)
+	ba.oboCreateGrant(c)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for non-owned bot, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	// And nothing was persisted.
+	rows, _ := s.listGrantsByGrantor(tRESTOwner)
+	if len(rows) != 0 {
+		t.Fatalf("no grant should be persisted, got %+v", rows)
+	}
+}
+
+// TestOBO_CreateGrant_NotABot_404 — grantee_bot_uid must resolve to a
+// row in the robot table (i.e. an actual bot, not a real-user uid).
+// Review #2 P2-3. Without this check, a user could install a grant
+// targeting another HUMAN uid — inert today, but cluttered audit and a
+// poor invariant for v1 to inherit.
+func TestOBO_CreateGrant_NotABot_404(t *testing.T) {
+	s := newFakeOBOStore()
+	// seedNonBotUser → queryRobotOwner returns found=false (the prod
+	// query targets the robot table, where a real-user uid has no row).
+	s.seedNonBotUser("not_a_bot_uid")
+	ba := newBAforREST(s)
+
+	c, rec := makeCtx(t, tRESTOwner, http.MethodPost, "/v1/obo/grants",
+		oboCreateGrantReq{GranteeBotUID: "not_a_bot_uid"}, nil)
+	ba.oboCreateGrant(c)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for non-bot uid, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestOBO_CreateGrant_Reactivates_SoftDeletedRow — once a grant has been
+// soft-deleted (DELETE /v1/obo/grants/:id), the (grantor, bot) pair is
+// frozen by the UNIQUE KEY uk_grantor_grantee. A naive insert would 409
+// forever. The fix (review #2 P1-1): when the duplicate fires AND the
+// existing row is owned by the caller AND active=0, flip it back to
+// active=1 / global_enabled=0 / revoked_at=NULL in place. Verify the
+// row is reusable: re-create after revoke succeeds, returns the same
+// ID, and emerges with global_enabled=0 (caller must opt in again).
+func TestOBO_CreateGrant_Reactivates_SoftDeletedRow(t *testing.T) {
+	s := newFakeOBOStore()
+	s.seedBot(tRESTBot, tRESTOwner)
+	ba := newBAforREST(s)
+
+	// Step 1: create grant + enable it.
+	c, rec := makeCtx(t, tRESTOwner, http.MethodPost, "/v1/obo/grants",
+		oboCreateGrantReq{GranteeBotUID: tRESTBot}, nil)
+	ba.oboCreateGrant(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("initial create failed: %d body=%s", rec.Code, rec.Body.String())
+	}
+	rows, _ := s.listGrantsByGrantor(tRESTOwner)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row after create, got %d", len(rows))
+	}
+	originalID := rows[0].ID
+	enable := 1
+	_ = s.updateGrant(originalID, "", &enable)
+
+	// Step 2: soft-delete the grant.
+	_ = s.revokeGrant(originalID)
+	g, _ := s.findGrantByID(originalID)
+	if g == nil || g.Active != 0 || g.GlobalEnabled != 0 {
+		t.Fatalf("expected revoked row after step 2, got %+v", g)
+	}
+
+	// Step 3: POST the same (grantor, bot) again — must reactivate, not 409.
+	c, rec = makeCtx(t, tRESTOwner, http.MethodPost, "/v1/obo/grants",
+		oboCreateGrantReq{GranteeBotUID: tRESTBot}, nil)
+	ba.oboCreateGrant(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("reactivation create must return 200, got %d body=%s",
+			rec.Code, rec.Body.String())
+	}
+
+	// Step 4: row is back to active=1 / global_enabled=0 with same ID.
+	g, _ = s.findGrantByID(originalID)
+	if g == nil || g.Active != 1 || g.GlobalEnabled != 0 {
+		t.Fatalf("reactivated row should be active=1 global_enabled=0, got %+v", g)
+	}
+	rows, _ = s.listGrantsByGrantor(tRESTOwner)
+	if len(rows) != 1 || rows[0].ID != originalID {
+		t.Fatalf("reactivation should reuse the same row id; got rows=%+v", rows)
+	}
+}
+
+// TestOBO_CreateGrant_LiveDuplicate_Still409 — when the duplicate row is
+// LIVE (active=1, not soft-deleted), the handler still returns 409 — the
+// reactivation path applies only to soft-deleted rows.
+func TestOBO_CreateGrant_LiveDuplicate_Still409(t *testing.T) {
+	s := newFakeOBOStore()
+	s.seedBot(tRESTBot, tRESTOwner)
+	_, _ = s.insertGrant(tRESTOwner, tRESTBot, "auto") // active=1 by default
+	ba := newBAforREST(s)
+
+	c, rec := makeCtx(t, tRESTOwner, http.MethodPost, "/v1/obo/grants",
+		oboCreateGrantReq{GranteeBotUID: tRESTBot}, nil)
+	ba.oboCreateGrant(c)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for live duplicate, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestOBO_CreateScope_NoChannelAccess_404 — P0 wiretap regression test.
+// The grantor must have read access to the target channel before a scope
+// row can be created. With the override returning false, the request is
+// rejected as 404 (existence-leak defense). Without this check, an
+// attacker could scope to a channel they aren't in and silently
+// exfiltrate every inbound message to their bot via the fan-out listener.
+func TestOBO_CreateScope_NoChannelAccess_404(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tRESTOwner, tRESTBot, "auto")
+	ba := newBAforREST(s)
+	// Override the default permissive hook to deny access for this test.
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		// Grantor has read access to nothing.
+		return false, nil
+	}
+
+	c, rec := makeCtx(t, tRESTOwner, http.MethodPost, "/v1/obo/scopes",
+		oboCreateScopeReq{
+			GrantID:     gid,
+			ChannelID:   "secret_group",
+			ChannelType: common.ChannelTypeGroup.Uint8(),
+		}, nil)
+	ba.oboCreateScope(c)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 when grantor lacks channel access, got %d body=%s",
+			rec.Code, rec.Body.String())
+	}
+	// And no scope was persisted.
+	scopes, _ := s.listScopesByGrant(gid)
+	if len(scopes) != 0 {
+		t.Fatalf("scope must NOT be created when access check fails, got %+v", scopes)
+	}
+}
+
+// TestOBO_CreateScope_ChannelAccessErr_500 — when the channel-access
+// check errors (e.g. DB outage), the handler must surface a 500 rather
+// than fail-open. We assert via the body (ResponseError); the override
+// returns a synthetic error.
+func TestOBO_CreateScope_ChannelAccessErr_500(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tRESTOwner, tRESTBot, "auto")
+	ba := newBAforREST(s)
+	boom := errors.New("connection refused")
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		return false, boom
+	}
+
+	c, rec := makeCtx(t, tRESTOwner, http.MethodPost, "/v1/obo/scopes",
+		oboCreateScopeReq{
+			GrantID:     gid,
+			ChannelID:   "any",
+			ChannelType: common.ChannelTypeGroup.Uint8(),
+		}, nil)
+	ba.oboCreateScope(c)
+	// ResponseError body carries the failure message; assert nothing was
+	// persisted regardless of the wire status convention.
+	scopes, _ := s.listScopesByGrant(gid)
+	if len(scopes) != 0 {
+		t.Fatalf("scope must NOT be created on access-check error, got %+v", scopes)
+	}
+	if rec.Body.Len() == 0 {
+		t.Fatalf("expected error body, got empty response")
+	}
+}
+
+// TestOBO_DeleteScope_FindScopeOwner_OK — the new oboDeleteScope path
+// uses findScopeOwner (single JOIN) instead of the O(N×M) scopeOwnedBy
+// scan. Verify owner-match → 200 and row removed.
+func TestOBO_DeleteScope_FindScopeOwner_OK(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tRESTOwner, tRESTBot, "auto")
+	sid, _ := s.insertScope(gid, tRESTChannel, common.ChannelTypeGroup.Uint8(), 1)
+	ba := newBAforREST(s)
+
+	c, rec := makeCtx(t, tRESTOwner, http.MethodDelete,
+		"/v1/obo/scopes/"+strconv.FormatInt(sid, 10), nil,
+		gin.Params{{Key: "id", Value: strconv.FormatInt(sid, 10)}})
+	ba.oboDeleteScope(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	scopes, _ := s.listScopesByGrant(gid)
+	if len(scopes) != 0 {
+		t.Fatalf("scope should be deleted, got %d", len(scopes))
+	}
+}
+
+// TestOBO_DeleteScope_FindScopeOwner_LookupErr_500 — when the new
+// findScopeOwner method errors (DB outage), the delete must fail closed
+// without removing the row.
+func TestOBO_DeleteScope_FindScopeOwner_LookupErr(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tRESTOwner, tRESTBot, "auto")
+	sid, _ := s.insertScope(gid, tRESTChannel, common.ChannelTypeGroup.Uint8(), 1)
+	s.failFindScopeOwner = errors.New("connection refused")
+	ba := newBAforREST(s)
+
+	c, rec := makeCtx(t, tRESTOwner, http.MethodDelete,
+		"/v1/obo/scopes/"+strconv.FormatInt(sid, 10), nil,
+		gin.Params{{Key: "id", Value: strconv.FormatInt(sid, 10)}})
+	ba.oboDeleteScope(c)
+	scopes, _ := s.listScopesByGrant(gid)
+	if len(scopes) != 1 {
+		t.Fatalf("scope must survive lookup error, got %d", len(scopes))
+	}
+	if rec.Body.Len() == 0 {
+		t.Fatalf("expected error body, got empty response")
 	}
 }

--- a/modules/bot_api/obo_api_test.go
+++ b/modules/bot_api/obo_api_test.go
@@ -1,0 +1,317 @@
+// Package bot_api · YUJ-1166 — Unit tests for OBO REST endpoints.
+//
+// Each handler is exercised directly via gin's CreateTestContext + a stub
+// auth context ("uid"). We avoid spinning up the full router because the
+// production registerOBORoutes mount also depends on ctx.AuthMiddleware,
+// which requires a live cache.
+//
+// Coverage:
+//   - Create / List / Update / Delete grant (happy + ownership rejection)
+//   - Mode validation (auto only in v0)
+//   - Create / Delete / List scope (ownership rejection)
+//   - Duplicate-key surfaces as 409
+package bot_api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	tRESTOwner   = "user_yu"
+	tRESTBot     = "bot_clone_001"
+	tRESTOther   = "user_alice"
+	tRESTChannel = "group_42"
+)
+
+// makeCtx — gin context with uid set as the caller, body as POST/PUT body
+// and the named URL params populated.
+func makeCtx(t *testing.T, uid, method, path string, body interface{}, params gin.Params) (*wkhttp.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+
+	var reqBody []byte
+	if body != nil {
+		var err error
+		reqBody, err = json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+	}
+	req := httptest.NewRequest(method, path, bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	gc.Request = req
+	gc.Params = params
+	c := &wkhttp.Context{Context: gc}
+	if uid != "" {
+		c.Set("uid", uid)
+	}
+	return c, rec
+}
+
+func newBAforREST(s *fakeOBOStore) *BotAPI {
+	return &BotAPI{
+		Log:              log.NewTLog("BotAPI-rest-test"),
+		oboStoreOverride: s,
+	}
+}
+
+// ==================== Grant CRUD ====================
+
+func TestOBO_CreateGrant_Happy(t *testing.T) {
+	s := newFakeOBOStore()
+	ba := newBAforREST(s)
+
+	c, rec := makeCtx(t, tRESTOwner, http.MethodPost, "/v1/obo/grants",
+		oboCreateGrantReq{GranteeBotUID: tRESTBot}, nil)
+	ba.oboCreateGrant(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	// Verify the row exists for the inferred grantor.
+	rows, _ := s.listGrantsByGrantor(tRESTOwner)
+	if len(rows) != 1 || rows[0].GranteeBotUID != tRESTBot {
+		t.Fatalf("grant not persisted under correct grantor: %+v", rows)
+	}
+	if rows[0].GlobalEnabled != 0 {
+		t.Errorf("new grant must start with global_enabled=0, got %d", rows[0].GlobalEnabled)
+	}
+}
+
+func TestOBO_CreateGrant_NoAuth(t *testing.T) {
+	ba := newBAforREST(newFakeOBOStore())
+	c, rec := makeCtx(t, "", http.MethodPost, "/v1/obo/grants",
+		oboCreateGrantReq{GranteeBotUID: tRESTBot}, nil)
+	ba.oboCreateGrant(c)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}
+
+func TestOBO_CreateGrant_SelfReject(t *testing.T) {
+	ba := newBAforREST(newFakeOBOStore())
+	c, rec := makeCtx(t, tRESTOwner, http.MethodPost, "/v1/obo/grants",
+		oboCreateGrantReq{GranteeBotUID: tRESTOwner}, nil)
+	ba.oboCreateGrant(c)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for self-grant, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestOBO_CreateGrant_BadMode(t *testing.T) {
+	ba := newBAforREST(newFakeOBOStore())
+	c, rec := makeCtx(t, tRESTOwner, http.MethodPost, "/v1/obo/grants",
+		oboCreateGrantReq{GranteeBotUID: tRESTBot, Mode: "draft"}, nil)
+	ba.oboCreateGrant(c)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for non-auto mode, got %d", rec.Code)
+	}
+}
+
+func TestOBO_CreateGrant_Duplicate(t *testing.T) {
+	s := newFakeOBOStore()
+	_, _ = s.insertGrant(tRESTOwner, tRESTBot, "auto")
+	ba := newBAforREST(s)
+
+	c, rec := makeCtx(t, tRESTOwner, http.MethodPost, "/v1/obo/grants",
+		oboCreateGrantReq{GranteeBotUID: tRESTBot}, nil)
+	ba.oboCreateGrant(c)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for duplicate, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestOBO_ListGrants_Happy(t *testing.T) {
+	s := newFakeOBOStore()
+	_, _ = s.insertGrant(tRESTOwner, tRESTBot, "auto")
+	_, _ = s.insertGrant(tRESTOwner, "bot_other", "auto")
+	_, _ = s.insertGrant(tRESTOther, "alice_bot", "auto")
+	ba := newBAforREST(s)
+
+	c, rec := makeCtx(t, tRESTOwner, http.MethodGet, "/v1/obo/grants", nil, nil)
+	ba.oboListGrants(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d", rec.Code)
+	}
+	var resp struct {
+		Items []*oboGrantModel `json:"items"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v body=%s", err, rec.Body.String())
+	}
+	if len(resp.Items) != 2 {
+		t.Fatalf("expected 2 items (only owner's), got %d", len(resp.Items))
+	}
+}
+
+func TestOBO_UpdateGrant_Toggle(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tRESTOwner, tRESTBot, "auto")
+	ba := newBAforREST(s)
+
+	enable := 1
+	c, rec := makeCtx(t, tRESTOwner, http.MethodPut,
+		"/v1/obo/grants/"+strconv.FormatInt(gid, 10),
+		oboUpdateGrantReq{GlobalEnabled: &enable},
+		gin.Params{{Key: "id", Value: strconv.FormatInt(gid, 10)}})
+	ba.oboUpdateGrant(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	g, _ := s.findGrantByID(gid)
+	if g.GlobalEnabled != 1 {
+		t.Fatalf("global_enabled should be 1, got %d", g.GlobalEnabled)
+	}
+}
+
+func TestOBO_UpdateGrant_Cross_user_404(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tRESTOther, "alice_bot", "auto")
+	ba := newBAforREST(s)
+
+	enable := 1
+	c, rec := makeCtx(t, tRESTOwner, http.MethodPut,
+		"/v1/obo/grants/"+strconv.FormatInt(gid, 10),
+		oboUpdateGrantReq{GlobalEnabled: &enable},
+		gin.Params{{Key: "id", Value: strconv.FormatInt(gid, 10)}})
+	ba.oboUpdateGrant(c)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-user update must be 404 (not 403), got %d", rec.Code)
+	}
+	// Ownership untouched.
+	g, _ := s.findGrantByID(gid)
+	if g.GlobalEnabled != 0 {
+		t.Fatalf("global_enabled must remain 0, got %d", g.GlobalEnabled)
+	}
+}
+
+func TestOBO_DeleteGrant_Happy(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tRESTOwner, tRESTBot, "auto")
+	ba := newBAforREST(s)
+
+	c, rec := makeCtx(t, tRESTOwner, http.MethodDelete,
+		"/v1/obo/grants/"+strconv.FormatInt(gid, 10), nil,
+		gin.Params{{Key: "id", Value: strconv.FormatInt(gid, 10)}})
+	ba.oboDeleteGrant(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d", rec.Code)
+	}
+	g, _ := s.findGrantByID(gid)
+	if g == nil || g.Active != 0 {
+		t.Fatalf("grant should be soft-deleted (active=0), got %+v", g)
+	}
+}
+
+// ==================== Scope CRUD ====================
+
+func TestOBO_CreateScope_Happy(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tRESTOwner, tRESTBot, "auto")
+	ba := newBAforREST(s)
+
+	c, rec := makeCtx(t, tRESTOwner, http.MethodPost, "/v1/obo/scopes",
+		oboCreateScopeReq{
+			GrantID:     gid,
+			ChannelID:   tRESTChannel,
+			ChannelType: common.ChannelTypeGroup.Uint8(),
+		}, nil)
+	ba.oboCreateScope(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	scopes, _ := s.listScopesByGrant(gid)
+	if len(scopes) != 1 || scopes[0].ChannelID != tRESTChannel || scopes[0].Enabled != 1 {
+		t.Fatalf("scope not persisted as expected: %+v", scopes)
+	}
+}
+
+func TestOBO_CreateScope_CrossUser404(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tRESTOther, "alice_bot", "auto")
+	ba := newBAforREST(s)
+
+	c, rec := makeCtx(t, tRESTOwner, http.MethodPost, "/v1/obo/scopes",
+		oboCreateScopeReq{
+			GrantID:     gid,
+			ChannelID:   tRESTChannel,
+			ChannelType: common.ChannelTypeGroup.Uint8(),
+		}, nil)
+	ba.oboCreateScope(c)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-user create scope must be 404, got %d", rec.Code)
+	}
+}
+
+func TestOBO_ListScopes_Happy(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tRESTOwner, tRESTBot, "auto")
+	_, _ = s.insertScope(gid, "ch_a", 1, 1)
+	_, _ = s.insertScope(gid, "ch_b", 2, 1)
+	ba := newBAforREST(s)
+
+	c, rec := makeCtx(t, tRESTOwner, http.MethodGet,
+		"/v1/obo/grants/"+strconv.FormatInt(gid, 10)+"/scopes", nil,
+		gin.Params{{Key: "id", Value: strconv.FormatInt(gid, 10)}})
+	ba.oboListScopes(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Items []*oboScopeModel `json:"items"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if len(resp.Items) != 2 {
+		t.Fatalf("expected 2 scopes, got %d", len(resp.Items))
+	}
+}
+
+func TestOBO_DeleteScope_Happy(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tRESTOwner, tRESTBot, "auto")
+	sid, _ := s.insertScope(gid, tRESTChannel, common.ChannelTypeGroup.Uint8(), 1)
+	ba := newBAforREST(s)
+
+	c, rec := makeCtx(t, tRESTOwner, http.MethodDelete,
+		"/v1/obo/scopes/"+strconv.FormatInt(sid, 10), nil,
+		gin.Params{{Key: "id", Value: strconv.FormatInt(sid, 10)}})
+	ba.oboDeleteScope(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	scopes, _ := s.listScopesByGrant(gid)
+	if len(scopes) != 0 {
+		t.Fatalf("scope should be deleted, got %d", len(scopes))
+	}
+}
+
+func TestOBO_DeleteScope_CrossUser404(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tRESTOther, "alice_bot", "auto")
+	sid, _ := s.insertScope(gid, tRESTChannel, common.ChannelTypeGroup.Uint8(), 1)
+	ba := newBAforREST(s)
+
+	c, rec := makeCtx(t, tRESTOwner, http.MethodDelete,
+		"/v1/obo/scopes/"+strconv.FormatInt(sid, 10), nil,
+		gin.Params{{Key: "id", Value: strconv.FormatInt(sid, 10)}})
+	ba.oboDeleteScope(c)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-user scope delete must be 404, got %d", rec.Code)
+	}
+	scopes, _ := s.listScopesByGrant(gid)
+	if len(scopes) != 1 {
+		t.Fatalf("scope must survive cross-user attempt, got %d", len(scopes))
+	}
+}

--- a/modules/bot_api/obo_check.go
+++ b/modules/bot_api/obo_check.go
@@ -119,3 +119,40 @@ func (ba *BotAPI) oboStoreOrDefault() oboStore {
 	}
 	return ba.db
 }
+
+// botHasActiveGrantFrom reports whether bot `botUID` is currently authorised
+// as a grantee by `grantorUID` — i.e. there is an active+global_enabled row
+// in obo_grants for (grantor=grantorUID, grantee=botUID). It is a thin
+// boolean wrapper over the same `findActiveGrantByGrantorBot` store call
+// that checkOBO consults for its first layer, so it inherits the negative
+// cache fast path and the same "no row OR globally disabled → false"
+// contract.
+//
+// Used by sendMessage to power the YUJ-1418 grantor-reply bypass: when a
+// persona-clone bot is asked to reply (on behalf of the grantor) to the
+// grantor themselves in DM, the OBO scope check would otherwise reject
+// (no scope row covers a grantor-to-self DM, and creating one would be
+// semantic noise). The bypass treats the dispatch as a normal bot reply
+// — fromUID stays as the bot, no OBO substitution, no OBO markers — and
+// this helper is the auth gate that distinguishes "bot has a legitimate
+// relationship with the recipient" from "bot is forging a relationship".
+//
+// Empty bot or grantor → (false, nil); DB errors are surfaced verbatim so
+// the caller can 500 rather than silently widening access.
+func (ba *BotAPI) botHasActiveGrantFrom(botUID, grantorUID string) (bool, error) {
+	if botUID == "" || grantorUID == "" {
+		return false, nil
+	}
+	if botUID == grantorUID {
+		// Defensive: a bot cannot grant OBO to itself (the REST create-grant
+		// handler rejects this and checkOBO short-circuits too). Treat as
+		// no grant so the bypass cannot fire on a malformed pair.
+		return false, nil
+	}
+	store := ba.oboStoreOrDefault()
+	grant, err := store.findActiveGrantByGrantorBot(grantorUID, botUID)
+	if err != nil {
+		return false, err
+	}
+	return grant != nil, nil
+}

--- a/modules/bot_api/obo_check.go
+++ b/modules/bot_api/obo_check.go
@@ -121,12 +121,28 @@ func (ba *BotAPI) oboStoreOrDefault() oboStore {
 }
 
 // botHasActiveGrantFrom reports whether bot `botUID` is currently authorised
-// as a grantee by `grantorUID` — i.e. there is an active+global_enabled row
-// in obo_grants for (grantor=grantorUID, grantee=botUID). It is a thin
-// boolean wrapper over the same `findActiveGrantByGrantorBot` store call
-// that checkOBO consults for its first layer, so it inherits the negative
-// cache fast path and the same "no row OR globally disabled → false"
-// contract.
+// as a grantee by `grantorUID` — i.e. there is an active row in obo_grants
+// for (grantor=grantorUID, grantee=botUID), regardless of the
+// `global_enabled` master switch.
+//
+// YUJ-1428: this helper deliberately uses
+// `findGrantByGrantorBotActiveOnly` rather than the strict
+// `findActiveGrantByGrantorBot` that checkOBO consults. The two checks
+// answer different questions:
+//
+//   - checkOBO (third-party send path) — "may this bot fan out a message
+//     while impersonating grantor X to peer Y?". Must respect
+//     global_enabled because that switch is the user-facing kill for
+//     persona fan-out and silently demoting it on the hot path re-opens
+//     the bug the switch exists to solve.
+//   - botHasActiveGrantFrom (grantor-reply bypass) — "is this bot
+//     legitimately authorised to talk to its OWN grantor in DM?". The
+//     relationship is established by the grant existing and not being
+//     revoked; whether the grantor has temporarily silenced fan-out is
+//     orthogonal. Pre-YUJ-1428 this consulted the global_enabled-aware
+//     query and broke the bypass whenever a user flipped the persona
+//     off — the bot could no longer reply to the grantor in DM even
+//     though the grant was still active.
 //
 // Used by sendMessage to power the YUJ-1418 grantor-reply bypass: when a
 // persona-clone bot is asked to reply (on behalf of the grantor) to the
@@ -150,7 +166,7 @@ func (ba *BotAPI) botHasActiveGrantFrom(botUID, grantorUID string) (bool, error)
 		return false, nil
 	}
 	store := ba.oboStoreOrDefault()
-	grant, err := store.findActiveGrantByGrantorBot(grantorUID, botUID)
+	grant, err := store.findGrantByGrantorBotActiveOnly(grantorUID, botUID)
 	if err != nil {
 		return false, err
 	}

--- a/modules/bot_api/obo_check.go
+++ b/modules/bot_api/obo_check.go
@@ -1,0 +1,89 @@
+// Package bot_api · YUJ-1166 / Mininglamp-OSS/octo-server#81 — Persona Clone
+// authorization check used by sendMessage / stream endpoints.
+//
+// checkOBO is the single boolean question on the dispatch hot path:
+// "is bot B allowed to act as grantor G in (channel_id, channel_type)?".
+// It is intentionally a thin wrapper over oboStore so:
+//   - the HTTP handler stays tiny (build req → check → dispatch);
+//   - unit tests can swap a fake oboStore without standing up MySQL;
+//   - future cache-aware variants (e.g. negative cache) can land here
+//     without touching the handler.
+package bot_api
+
+import (
+	"errors"
+
+	"go.uber.org/zap"
+)
+
+// Sentinel errors returned by checkOBO. Handlers map them to user-visible
+// strings (and HTTP status); production logs include the underlying detail.
+var (
+	// ErrOBONotAuthorized — no active+globally-enabled grant exists OR the
+	// scope row for the channel is missing/disabled. Returned for both
+	// "grant never existed" and "grant revoked" so callers can't probe.
+	ErrOBONotAuthorized = errors.New("obo not authorized")
+)
+
+// checkOBO validates that grantee bot `botUID` may send a message in
+// (channelID, channelType) as `grantor`. Returns nil on success and
+// ErrOBONotAuthorized when any check fails. Unexpected DB errors are
+// returned wrapped so the handler can 500.
+//
+// Three layered checks (any failure → ErrOBONotAuthorized):
+//  1. Grant row exists with active=1 AND global_enabled=1 for
+//     (grantor, botUID). This rejects revoked grants and grants whose
+//     master switch is off.
+//  2. Scope row exists with enabled=1 for (grant_id, channel_id,
+//     channel_type). White-list semantics per RFC §2 — opening a channel
+//     to a persona is always explicit.
+//  3. (No self-grant check at this layer; the REST POST /v1/obo/grants
+//     handler is the right place to reject `grantor == grantee` and we
+//     don't want to second-guess existing rows.)
+func (ba *BotAPI) checkOBO(botUID, grantor, channelID string, channelType uint8) error {
+	if botUID == "" || grantor == "" || channelID == "" {
+		return ErrOBONotAuthorized
+	}
+	if botUID == grantor {
+		// A bot cannot represent itself — this would be a no-op and a sign
+		// the caller is confused about which field to set. Fail closed.
+		return ErrOBONotAuthorized
+	}
+
+	store := ba.oboStoreOrDefault()
+	grant, err := store.findActiveGrantByGrantorBot(grantor, botUID)
+	if err != nil {
+		ba.Error("OBO grant lookup failed",
+			zap.String("grantor", grantor),
+			zap.String("bot", botUID),
+			zap.Error(err))
+		return err
+	}
+	if grant == nil {
+		return ErrOBONotAuthorized
+	}
+
+	ok, err := store.scopeEnabled(grant.ID, channelID, channelType)
+	if err != nil {
+		ba.Error("OBO scope lookup failed",
+			zap.Int64("grant_id", grant.ID),
+			zap.String("channel_id", channelID),
+			zap.Uint8("channel_type", channelType),
+			zap.Error(err))
+		return err
+	}
+	if !ok {
+		return ErrOBONotAuthorized
+	}
+	return nil
+}
+
+// oboStoreOrDefault returns the test-injected oboStore if set, else the
+// production DB-backed one. Mirrors spaceQuerierOrDefault so the test seam
+// is consistent across the module.
+func (ba *BotAPI) oboStoreOrDefault() oboStore {
+	if ba.oboStoreOverride != nil {
+		return ba.oboStoreOverride
+	}
+	return ba.db
+}

--- a/modules/bot_api/obo_check.go
+++ b/modules/bot_api/obo_check.go
@@ -30,14 +30,22 @@ var (
 // ErrOBONotAuthorized when any check fails. Unexpected DB errors are
 // returned wrapped so the handler can 500.
 //
-// Three layered checks (any failure → ErrOBONotAuthorized):
+// Four layered checks (any failure → ErrOBONotAuthorized):
 //  1. Grant row exists with active=1 AND global_enabled=1 for
 //     (grantor, botUID). This rejects revoked grants and grants whose
 //     master switch is off.
 //  2. Scope row exists with enabled=1 for (grant_id, channel_id,
 //     channel_type). White-list semantics per RFC §2 — opening a channel
 //     to a persona is always explicit.
-//  3. (No self-grant check at this layer; the REST POST /v1/obo/grants
+//  3. PR#82 round-2 P1-A — the grantor STILL has read access to the
+//     channel right now (`grantorCanReadChannel`). The scope-create-time
+//     check is not load-bearing for live membership: a grantor who
+//     authored a scope while a member of group_42 and was later kicked
+//     out must NOT be able to keep sending into group_42 as themselves
+//     through the bot, otherwise the kick is bypassable. Same logic for
+//     un-friended DM peers and parent-group leaves for community topics.
+//     DB cost: one covering-index lookup per OBO send.
+//  4. (No self-grant check at this layer; the REST POST /v1/obo/grants
 //     handler is the right place to reject `grantor == grantee` and we
 //     don't want to second-guess existing rows.)
 func (ba *BotAPI) checkOBO(botUID, grantor, channelID string, channelType uint8) error {
@@ -73,6 +81,30 @@ func (ba *BotAPI) checkOBO(botUID, grantor, channelID string, channelType uint8)
 		return err
 	}
 	if !ok {
+		return ErrOBONotAuthorized
+	}
+
+	// PR#82 round-2 P1-A — TOCTOU close-out. Re-check the grantor's live
+	// channel access on the hot path; revoking group/friend/thread access
+	// MUST stop the OBO send even when the scope row is still on file.
+	// Unexpected DB error → bubble up so the handler can 500 (matches the
+	// scopeEnabled error contract above); a clean "no access" answer
+	// degrades to ErrOBONotAuthorized.
+	canRead, err := ba.grantorCanReadChannel(grantor, channelID, channelType)
+	if err != nil {
+		ba.Error("OBO grantor channel-access re-check failed",
+			zap.String("grantor", grantor),
+			zap.String("channel_id", channelID),
+			zap.Uint8("channel_type", channelType),
+			zap.Error(err))
+		return err
+	}
+	if !canRead {
+		ba.Warn("OBO denied: grantor no longer has read access to channel",
+			zap.String("grantor", grantor),
+			zap.String("bot", botUID),
+			zap.String("channel_id", channelID),
+			zap.Uint8("channel_type", channelType))
 		return ErrOBONotAuthorized
 	}
 	return nil

--- a/modules/bot_api/obo_check_test.go
+++ b/modules/bot_api/obo_check_test.go
@@ -1,0 +1,186 @@
+// Package bot_api · YUJ-1166 — Unit tests for checkOBO.
+//
+// Coverage matrix (per task spec):
+//   - happy path: active grant + matching scope → nil
+//   - unauthorized: missing grant, revoked grant, global_enabled=0,
+//     scope missing, scope disabled, self-grant attempt, empty inputs
+//   - DB error: propagates upstream (caller responsible for 500)
+package bot_api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+)
+
+const (
+	tBot     = "bot_clone_001"
+	tGrantor = "user_yu"
+	tChan    = "group_42"
+)
+
+func newBotAPIWithFakeStore(s *fakeOBOStore) *BotAPI {
+	return &BotAPI{
+		Log:              log.NewTLog("BotAPI-obo-test"),
+		oboStoreOverride: s,
+	}
+}
+
+// TestCheckOBO_Happy verifies the canonical authorized path: active grant
+// (active=1, global_enabled=1) + matching enabled scope → nil.
+func TestCheckOBO_Happy(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, err := s.insertGrant(tGrantor, tBot, "auto")
+	if err != nil {
+		t.Fatalf("insertGrant: %v", err)
+	}
+	enable := 1
+	if err := s.updateGrant(gid, "", &enable); err != nil {
+		t.Fatalf("updateGrant: %v", err)
+	}
+	if _, err := s.insertScope(gid, tChan, common.ChannelTypeGroup.Uint8(), 1); err != nil {
+		t.Fatalf("insertScope: %v", err)
+	}
+
+	ba := newBotAPIWithFakeStore(s)
+	if err := ba.checkOBO(tBot, tGrantor, tChan, common.ChannelTypeGroup.Uint8()); err != nil {
+		t.Fatalf("expected nil (authorized), got %v", err)
+	}
+}
+
+// TestCheckOBO_NoGrant — no row at all for (grantor, bot).
+func TestCheckOBO_NoGrant(t *testing.T) {
+	ba := newBotAPIWithFakeStore(newFakeOBOStore())
+	err := ba.checkOBO(tBot, tGrantor, tChan, common.ChannelTypeGroup.Uint8())
+	if !errors.Is(err, ErrOBONotAuthorized) {
+		t.Fatalf("want ErrOBONotAuthorized, got %v", err)
+	}
+}
+
+// TestCheckOBO_GrantRevoked — row exists but active=0. Indistinguishable
+// from "never existed" by contract.
+func TestCheckOBO_GrantRevoked(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tGrantor, tBot, "auto")
+	enable := 1
+	_ = s.updateGrant(gid, "", &enable)
+	_, _ = s.insertScope(gid, tChan, common.ChannelTypeGroup.Uint8(), 1)
+	if err := s.revokeGrant(gid); err != nil {
+		t.Fatalf("revokeGrant: %v", err)
+	}
+
+	ba := newBotAPIWithFakeStore(s)
+	err := ba.checkOBO(tBot, tGrantor, tChan, common.ChannelTypeGroup.Uint8())
+	if !errors.Is(err, ErrOBONotAuthorized) {
+		t.Fatalf("revoked grant should be unauthorized, got %v", err)
+	}
+}
+
+// TestCheckOBO_GlobalDisabled — active=1 but global_enabled=0 (the master
+// kill-switch). Same denial behavior as no-grant.
+func TestCheckOBO_GlobalDisabled(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tGrantor, tBot, "auto")
+	// Skip the enable step → global_enabled stays 0.
+	_, _ = s.insertScope(gid, tChan, common.ChannelTypeGroup.Uint8(), 1)
+
+	ba := newBotAPIWithFakeStore(s)
+	err := ba.checkOBO(tBot, tGrantor, tChan, common.ChannelTypeGroup.Uint8())
+	if !errors.Is(err, ErrOBONotAuthorized) {
+		t.Fatalf("global-off grant should be unauthorized, got %v", err)
+	}
+}
+
+// TestCheckOBO_ScopeMissing — grant is fully enabled but no scope row
+// for the channel. Whitelist semantics: channels not explicitly added
+// MUST be denied (RFC §2).
+func TestCheckOBO_ScopeMissing(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tGrantor, tBot, "auto")
+	enable := 1
+	_ = s.updateGrant(gid, "", &enable)
+	// No scope inserted at all.
+
+	ba := newBotAPIWithFakeStore(s)
+	err := ba.checkOBO(tBot, tGrantor, tChan, common.ChannelTypeGroup.Uint8())
+	if !errors.Is(err, ErrOBONotAuthorized) {
+		t.Fatalf("missing scope should be unauthorized, got %v", err)
+	}
+}
+
+// TestCheckOBO_ScopeDisabled — scope row exists with enabled=0.
+func TestCheckOBO_ScopeDisabled(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tGrantor, tBot, "auto")
+	enable := 1
+	_ = s.updateGrant(gid, "", &enable)
+	_, _ = s.insertScope(gid, tChan, common.ChannelTypeGroup.Uint8(), 0)
+
+	ba := newBotAPIWithFakeStore(s)
+	err := ba.checkOBO(tBot, tGrantor, tChan, common.ChannelTypeGroup.Uint8())
+	if !errors.Is(err, ErrOBONotAuthorized) {
+		t.Fatalf("disabled scope should be unauthorized, got %v", err)
+	}
+}
+
+// TestCheckOBO_SelfGrantRejected — a bot trying to represent itself
+// must short-circuit with ErrOBONotAuthorized even if a (bogus) row
+// happened to exist (which the REST POST handler also rejects).
+func TestCheckOBO_SelfGrantRejected(t *testing.T) {
+	ba := newBotAPIWithFakeStore(newFakeOBOStore())
+	err := ba.checkOBO(tBot, tBot, tChan, common.ChannelTypeGroup.Uint8())
+	if !errors.Is(err, ErrOBONotAuthorized) {
+		t.Fatalf("self-grant should be unauthorized, got %v", err)
+	}
+}
+
+// TestCheckOBO_EmptyInputs — defensive: empty bot, grantor, or channel
+// short-circuits as unauthorized (callers shouldn't pass these but it
+// happens with broken proxies / typos).
+func TestCheckOBO_EmptyInputs(t *testing.T) {
+	ba := newBotAPIWithFakeStore(newFakeOBOStore())
+	cases := []struct{ bot, grantor, ch string }{
+		{"", tGrantor, tChan},
+		{tBot, "", tChan},
+		{tBot, tGrantor, ""},
+	}
+	for _, tc := range cases {
+		if err := ba.checkOBO(tc.bot, tc.grantor, tc.ch, common.ChannelTypeGroup.Uint8()); !errors.Is(err, ErrOBONotAuthorized) {
+			t.Fatalf("empty input (%q,%q,%q) should be unauthorized, got %v", tc.bot, tc.grantor, tc.ch, err)
+		}
+	}
+}
+
+// TestCheckOBO_DBError_OnGrantLookup — store error propagates so the
+// caller can 500. We do NOT translate DB errors to "unauthorized" because
+// that would hide real outages.
+func TestCheckOBO_DBError_OnGrantLookup(t *testing.T) {
+	boom := errors.New("connection refused")
+	s := newFakeOBOStore()
+	s.failFindActiveGrant = boom
+
+	ba := newBotAPIWithFakeStore(s)
+	err := ba.checkOBO(tBot, tGrantor, tChan, common.ChannelTypeGroup.Uint8())
+	if err == nil || errors.Is(err, ErrOBONotAuthorized) {
+		t.Fatalf("expected raw DB error to propagate, got %v", err)
+	}
+}
+
+// TestCheckOBO_DBError_OnScopeLookup — same propagation contract for the
+// second store call.
+func TestCheckOBO_DBError_OnScopeLookup(t *testing.T) {
+	boom := errors.New("connection refused")
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tGrantor, tBot, "auto")
+	enable := 1
+	_ = s.updateGrant(gid, "", &enable)
+	s.failScopeEnabled = boom
+
+	ba := newBotAPIWithFakeStore(s)
+	err := ba.checkOBO(tBot, tGrantor, tChan, common.ChannelTypeGroup.Uint8())
+	if err == nil || errors.Is(err, ErrOBONotAuthorized) {
+		t.Fatalf("expected raw DB error to propagate, got %v", err)
+	}
+}

--- a/modules/bot_api/obo_check_test.go
+++ b/modules/bot_api/obo_check_test.go
@@ -25,6 +25,15 @@ func newBotAPIWithFakeStore(s *fakeOBOStore) *BotAPI {
 	return &BotAPI{
 		Log:              log.NewTLog("BotAPI-obo-test"),
 		oboStoreOverride: s,
+		// PR#82 round-2 P1-A — checkOBO now re-checks the grantor's live
+		// channel access on every call. Default the test override to
+		// "always allowed" so the original auth-matrix tests (no grant,
+		// revoked, scope missing, etc.) stay focused on the rows they
+		// were written for. The TOCTOU regression test installs a
+		// denying override explicitly.
+		oboChannelAccessOverride: func(uid, channelID string, channelType uint8) (bool, error) {
+			return true, nil
+		},
 	}
 }
 
@@ -179,6 +188,82 @@ func TestCheckOBO_DBError_OnScopeLookup(t *testing.T) {
 	s.failScopeEnabled = boom
 
 	ba := newBotAPIWithFakeStore(s)
+	err := ba.checkOBO(tBot, tGrantor, tChan, common.ChannelTypeGroup.Uint8())
+	if err == nil || errors.Is(err, ErrOBONotAuthorized) {
+		t.Fatalf("expected raw DB error to propagate, got %v", err)
+	}
+}
+
+// TestOBO_CheckOBO_GrantorMembershipRevoked_403 — PR#82 round-2 P1-A.
+// All static rows (active grant + enabled scope) are in place; the
+// grantor has since lost read access to the channel (kicked from the
+// group, un-friended the DM peer, etc.). checkOBO must reject the OBO
+// send so the bot cannot keep speaking as a user who no longer has eyes
+// on the channel. Maps to HTTP 403 at the handler boundary (the test
+// asserts the wire-equivalent sentinel ErrOBONotAuthorized).
+func TestOBO_CheckOBO_GrantorMembershipRevoked_403(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, err := s.insertGrant(tGrantor, tBot, "auto")
+	if err != nil {
+		t.Fatalf("insertGrant: %v", err)
+	}
+	enable := 1
+	if err := s.updateGrant(gid, "", &enable); err != nil {
+		t.Fatalf("updateGrant: %v", err)
+	}
+	if _, err := s.insertScope(gid, tChan, common.ChannelTypeGroup.Uint8(), 1); err != nil {
+		t.Fatalf("insertScope: %v", err)
+	}
+
+	ba := newBotAPIWithFakeStore(s)
+	// Simulate "grantor was kicked from group_42" — the channel-access
+	// re-check now denies, even though grant + scope rows persist.
+	calls := 0
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		calls++
+		// Defensive: tests that depend on this override should be passing
+		// the live grantor + channel. Assert the values are what we expect
+		// so a refactor that swaps argument order is caught here.
+		if uid != tGrantor || channelID != tChan || channelType != common.ChannelTypeGroup.Uint8() {
+			t.Errorf("channel-access override called with unexpected args: uid=%q chan=%q type=%d", uid, channelID, channelType)
+		}
+		return false, nil
+	}
+	if err := ba.checkOBO(tBot, tGrantor, tChan, common.ChannelTypeGroup.Uint8()); !errors.Is(err, ErrOBONotAuthorized) {
+		t.Fatalf("revoked grantor membership must deny OBO, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected the re-check to fire exactly once, got %d", calls)
+	}
+
+	// Sanity: when membership is restored, the same row set passes again
+	// — proves the deny was driven by the access check, not a stale
+	// grant/scope state from the previous call.
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		return true, nil
+	}
+	if err := ba.checkOBO(tBot, tGrantor, tChan, common.ChannelTypeGroup.Uint8()); err != nil {
+		t.Fatalf("with access restored, expected nil, got %v", err)
+	}
+}
+
+// TestOBO_CheckOBO_GrantorChannelAccessDBError_Propagates — defensive:
+// the new re-check propagates DB errors the same way the scope lookup
+// does, so a transient DB blip doesn't masquerade as a permission denial
+// (which would mask a real outage and make a 500-vs-403 ambiguity at the
+// handler boundary).
+func TestOBO_CheckOBO_GrantorChannelAccessDBError_Propagates(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tGrantor, tBot, "auto")
+	enable := 1
+	_ = s.updateGrant(gid, "", &enable)
+	_, _ = s.insertScope(gid, tChan, common.ChannelTypeGroup.Uint8(), 1)
+
+	ba := newBotAPIWithFakeStore(s)
+	boom := errors.New("connection refused")
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		return false, boom
+	}
 	err := ba.checkOBO(tBot, tGrantor, tChan, common.ChannelTypeGroup.Uint8())
 	if err == nil || errors.Is(err, ErrOBONotAuthorized) {
 		t.Fatalf("expected raw DB error to propagate, got %v", err)

--- a/modules/bot_api/obo_db.go
+++ b/modules/bot_api/obo_db.go
@@ -6,13 +6,31 @@
 // HTTP handlers, checkOBO, and the fan-out listener can all be unit-tested
 // against an in-memory fake without sqlmock plumbing.
 //
-// Cache strategy (RFC §11 risk row): the hot path on every inbound message
-// asks "does grantor X have ANY active grant?". A 30-second-TTL Redis key
-// `obo:grantor:{uid}` caches that scalar answer. Writes invalidate the key
-// inline; ops that don't change activity state skip the invalidation. The
-// fan-out path tolerates stale "true" answers (DB is still consulted for the
-// scope row), and stale "false" answers cap at 30s, which is acceptable for
-// v0 (see RFC §11 — risk explicitly accepted).
+// Cache strategy (RFC §11 risk row): the two hot-path questions are answered
+// by short-TTL Redis keys, populated on read-through, invalidated on write:
+//
+//   - obo:grantor:{uid}        "1" any active grant exists for grantor;
+//                              "0" no active grant. Read by
+//                              findActiveGrantByGrantorBot — negative answer
+//                              short-circuits the (grantor, bot) MySQL probe
+//                              that checkOBO would otherwise issue per send.
+//   - obo:chan:{ctype}:{cid}   "1" channel has at least one (active grant ×
+//                              enabled scope) match; "0" no match. Read by
+//                              findActiveGrantsForChannel — negative answer
+//                              short-circuits the JOIN that the fan-out
+//                              listener would otherwise issue per inbound
+//                              message system-wide.
+//
+// Both keys are negative-cache friendly: a "0" answer returned within the
+// 30-second TTL eliminates the MySQL round-trip entirely. Writes that can
+// flip either answer (insertGrant / updateGrant / revokeGrant /
+// insertScope / deleteScope) invalidate the affected keys inline. Stale
+// "1" answers are safe — callers still consult MySQL when the cache says
+// "1", so the cache cannot grant authorization it shouldn't. Stale "0"
+// answers cap at 30s and are acceptable per RFC §11 (risk explicitly
+// accepted for v0). Redis is best-effort throughout: a Redis outage
+// silently degrades to the pre-cache path (full MySQL load), never to a
+// permissions regression.
 package bot_api
 
 import (
@@ -21,6 +39,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/gocraft/dbr/v2"
 )
 
@@ -76,11 +95,38 @@ type oboStore interface {
 	insertGrant(grantorUID, granteeBotUID, mode string) (int64, error)
 	listGrantsByGrantor(grantorUID string) ([]*oboGrantModel, error)
 	findGrantByID(id int64) (*oboGrantModel, error)
+	// findGrantByGrantorBot returns the row for (grantor, bot) regardless of
+	// active state. Added for the reactivation path on oboCreateGrant — when
+	// the UNIQUE KEY uk_grantor_grantee fires on insert, the caller looks up
+	// the existing row and, if it's a soft-deleted row the caller owns, flips
+	// active=1 / global_enabled=0 / revoked_at=NULL rather than returning 409.
+	// (PR#82 review #2 P1-1 — without this the (grantor, bot) pair would be
+	// permanently bricked after a single DELETE /v1/obo/grants/:id.)
+	findGrantByGrantorBot(grantorUID, granteeBotUID string) (*oboGrantModel, error)
 	updateGrant(id int64, mode string, globalEnabled *int) error
+	// reactivateGrant flips a soft-deleted row back to active=1 /
+	// global_enabled=0 / revoked_at=NULL. Used by oboCreateGrant when the
+	// duplicate-key conflict resolves to a row the caller already owns.
+	// Returns nil on missing row so callers can treat reactivation as
+	// idempotent. See findGrantByGrantorBot for the lookup pattern.
+	reactivateGrant(id int64) error
 	revokeGrant(id int64) error
 	insertScope(grantID int64, channelID string, channelType uint8, enabled int) (int64, error)
 	deleteScope(id int64) error
 	listScopesByGrant(grantID int64) ([]*oboScopeModel, error)
+	// findScopeOwner answers "who owns scope X" in one query via the
+	// obo_scopes → obo_grants JOIN. Replaces the O(grants × scopes_per_grant)
+	// linear scan that scopeOwnedBy previously performed for every scope
+	// delete (PR#82 review #2 P1-3; v1 quoted worst case 50×200 = 10k DB
+	// queries for a single delete). Returns ("", false, nil) when the scope
+	// row is missing.
+	findScopeOwner(scopeID int64) (grantorUID string, found bool, err error)
+	// queryRobotOwner returns the bot's creator uid and a flag indicating it
+	// is registered as a bot (user.robot=1). Used by oboCreateGrant to enforce
+	// that callers can only grant OBO power to their OWN bots (PR#82 review #2
+	// P2-3 + task spec P1-2). Returns (_, _, false, nil) when no robot row
+	// exists for botUID.
+	queryRobotOwner(botUID string) (creatorUID string, isBot bool, found bool, err error)
 }
 
 // Compile-time guard.
@@ -90,18 +136,39 @@ var _ oboStore = (*botAPIDB)(nil)
 
 const (
 	// oboGrantorActiveCacheKeyFmt is the Redis key for "does grantor X have
-	// at least one active grant". Lookups in the fan-out hot path consult
-	// this scalar before touching MySQL. Writes that affect activity state
-	// invalidate by deletion so the next reader repopulates.
+	// at least one active grant". checkOBO consults this scalar before the
+	// (grantor, bot) MySQL lookup. Population: written on every
+	// findActiveGrantByGrantorBot result (positive or negative). Eviction:
+	// any write touching the grantor's rows.
 	oboGrantorActiveCacheKeyFmt = "obo:grantor:%s"
+	// oboChannelActiveCacheKeyFmt is the Redis key for "does this channel
+	// have at least one (active grant × enabled scope) match". The fan-out
+	// listener consults this scalar before the JOIN it would otherwise
+	// issue per inbound message system-wide. Population: written on every
+	// findActiveGrantsForChannel result (count 0 → "0", count >0 → "1").
+	// Eviction: insertScope / deleteScope (the only operations that can
+	// flip the answer for a given channel within the TTL window).
+	oboChannelActiveCacheKeyFmt = "obo:chan:%d:%s"
 	// oboCacheTTL is 30s per RFC §11. Tradeoff documented in the package
 	// comment above.
 	oboCacheTTL = 30 * time.Second
 )
 
 // findActiveGrantByGrantorBot — see oboStore for the contract.
+//
+// Read path consults `obo:grantor:{uid}` first; "0" short-circuits to nil
+// without a MySQL round-trip. Any other value (including absent) falls
+// through to MySQL, and the result is written back to the cache as "1"
+// for a hit and "0" for a miss with oboCacheTTL. Cache errors are
+// swallowed — Redis is best-effort and the production read remains
+// correct regardless of cache state.
 func (d *botAPIDB) findActiveGrantByGrantorBot(grantorUID, granteeBotUID string) (*oboGrantModel, error) {
 	if grantorUID == "" || granteeBotUID == "" {
+		return nil, nil
+	}
+	// Negative-cache fast path: grantor known to have zero active grants
+	// in the last oboCacheTTL window → no need to probe MySQL.
+	if d.grantorCacheSaysNone(grantorUID) {
 		return nil, nil
 	}
 	var m *oboGrantModel
@@ -111,6 +178,15 @@ func (d *botAPIDB) findActiveGrantByGrantorBot(grantorUID, granteeBotUID string)
 		Load(&m)
 	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
 		return nil, err
+	}
+	if m != nil {
+		d.writeGrantorCache(grantorUID, true)
+	} else {
+		// Refine: confirm the negative answer applies to the grantor as a
+		// whole, not just this (grantor, bot) pair. We probe with a cheap
+		// COUNT — same index as the row lookup above. Avoids a stale "0"
+		// suppressing other valid grant-bot pairs of the same grantor.
+		d.maybeCacheGrantorNegative(grantorUID)
 	}
 	return m, nil
 }
@@ -133,8 +209,19 @@ func (d *botAPIDB) scopeEnabled(grantID int64, channelID string, channelType uin
 
 // findActiveGrantsForChannel — see oboStore. Single JOIN so the fan-out
 // hot path doesn't have to issue a per-grant scope lookup.
+//
+// Read path consults `obo:chan:{type}:{id}` first. A cached "0" answer
+// returns an empty slice without touching MySQL — the fan-out listener
+// fires for every inbound message system-wide, so the vast majority of
+// channels (those with no OBO grants) avoid the JOIN entirely. Positive
+// hits and MySQL fallback both repopulate the cache with the count-based
+// scalar ("1" any matches, "0" none). Cache errors swallowed; production
+// behavior is identical whether Redis is healthy or absent.
 func (d *botAPIDB) findActiveGrantsForChannel(channelID string, channelType uint8) ([]*oboGrantModel, error) {
 	if channelID == "" {
+		return []*oboGrantModel{}, nil
+	}
+	if d.channelCacheSaysNone(channelID, channelType) {
 		return []*oboGrantModel{}, nil
 	}
 	var grants []*oboGrantModel
@@ -150,6 +237,7 @@ func (d *botAPIDB) findActiveGrantsForChannel(channelID string, channelType uint
 	if grants == nil {
 		grants = []*oboGrantModel{}
 	}
+	d.writeChannelCache(channelID, channelType, len(grants) > 0)
 	return grants, nil
 }
 
@@ -291,23 +379,36 @@ func (d *botAPIDB) insertScope(grantID int64, channelID string, channelType uint
 	if g, _ := d.findGrantByID(grantID); g != nil {
 		d.invalidateGrantorCache(g.GrantorUID)
 	}
+	d.invalidateChannelCache(channelID, channelType)
 	return id, nil
 }
 
 // deleteScope removes a per-channel row (hard delete — there's nothing to
 // audit about which channels you stopped using).
 func (d *botAPIDB) deleteScope(id int64) error {
-	// Look up parent grant to bust cache, then delete.
-	var grantID int64
-	_ = d.session.SelectBySql("SELECT grant_id FROM obo_scopes WHERE id=?", id).LoadOne(&grantID)
+	// Look up parent grant + (channel_id, channel_type) so we can bust both
+	// caches before the delete commits. The grant lookup serves
+	// invalidateGrantorCache; the channel coords serve invalidateChannelCache.
+	type scopeMeta struct {
+		GrantID     int64  `db:"grant_id"`
+		ChannelID   string `db:"channel_id"`
+		ChannelType uint8  `db:"channel_type"`
+	}
+	var meta scopeMeta
+	_, _ = d.session.SelectBySql(
+		"SELECT grant_id, channel_id, channel_type FROM obo_scopes WHERE id=?", id,
+	).Load(&meta)
 	_, err := d.session.DeleteFrom("obo_scopes").Where("id=?", id).Exec()
 	if err != nil {
 		return err
 	}
-	if grantID != 0 {
-		if g, _ := d.findGrantByID(grantID); g != nil {
+	if meta.GrantID != 0 {
+		if g, _ := d.findGrantByID(meta.GrantID); g != nil {
 			d.invalidateGrantorCache(g.GrantorUID)
 		}
+	}
+	if meta.ChannelID != "" {
+		d.invalidateChannelCache(meta.ChannelID, meta.ChannelType)
 	}
 	return nil
 }
@@ -328,6 +429,107 @@ func (d *botAPIDB) listScopesByGrant(grantID int64) ([]*oboScopeModel, error) {
 	return scopes, nil
 }
 
+// findGrantByGrantorBot — see oboStore. Returns the row regardless of
+// active state. Used by oboCreateGrant's reactivation path when a fresh
+// insert collides with the soft-deleted row left behind by a prior
+// revokeGrant on the same (grantor, bot) pair.
+func (d *botAPIDB) findGrantByGrantorBot(grantorUID, granteeBotUID string) (*oboGrantModel, error) {
+	if grantorUID == "" || granteeBotUID == "" {
+		return nil, nil
+	}
+	var m *oboGrantModel
+	_, err := d.session.Select("*").From("obo_grants").
+		Where("grantor_uid=? AND grantee_bot_uid=?", grantorUID, granteeBotUID).
+		Load(&m)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return nil, err
+	}
+	return m, nil
+}
+
+// reactivateGrant flips a soft-deleted grant back to the same shape
+// `insertGrant` would have produced: active=1, global_enabled=0,
+// revoked_at=NULL. Used by oboCreateGrant when the unique-key conflict
+// resolves to a soft-deleted row owned by the same grantor — the row is
+// reactivated in place instead of returning 409, so the (grantor, bot)
+// pair never becomes permanently bricked (PR#82 review #2 P1-1).
+func (d *botAPIDB) reactivateGrant(id int64) error {
+	if id == 0 {
+		return nil
+	}
+	_, err := d.session.Update("obo_grants").SetMap(map[string]interface{}{
+		"active":         1,
+		"global_enabled": 0,
+		"revoked_at":     nil,
+		"updated_at":     time.Now(),
+	}).Where("id=?", id).Exec()
+	if err != nil {
+		return err
+	}
+	if g, _ := d.findGrantByID(id); g != nil {
+		d.invalidateGrantorCache(g.GrantorUID)
+	}
+	return nil
+}
+
+// findScopeOwner — see oboStore. Single JOIN replaces the
+// O(grants × scopes_per_grant) scan that scopeOwnedBy used to perform
+// on every `DELETE /v1/obo/scopes/:id` (PR#82 review #2 P1-3).
+func (d *botAPIDB) findScopeOwner(scopeID int64) (string, bool, error) {
+	if scopeID == 0 {
+		return "", false, nil
+	}
+	var grantorUID string
+	err := d.session.SelectBySql(
+		"SELECT g.grantor_uid FROM obo_scopes s INNER JOIN obo_grants g ON g.id = s.grant_id WHERE s.id=?",
+		scopeID,
+	).LoadOne(&grantorUID)
+	if err != nil {
+		if errors.Is(err, dbr.ErrNotFound) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	if grantorUID == "" {
+		return "", false, nil
+	}
+	return grantorUID, true, nil
+}
+
+// queryRobotOwner — see oboStore. Reads the `user` table and returns the
+// creator uid plus an IsBot flag derived from `robot=1`. Returns
+// ("", false, false, nil) when no row exists for the given uid. The
+// creator uid for User Bots lives on the `robot` table, NOT the `user`
+// table — we read both: `robot.creator_uid` for ownership and `user.robot`
+// for the bot flag, joined on uid==robot_id.
+func (d *botAPIDB) queryRobotOwner(botUID string) (string, bool, bool, error) {
+	if botUID == "" {
+		return "", false, false, nil
+	}
+	type row struct {
+		CreatorUID string `db:"creator_uid"`
+		IsBot      int    `db:"is_bot"`
+	}
+	var r row
+	// LEFT JOIN so a robot row without a matching user row (or vice versa)
+	// still surfaces — we treat the IsBot flag as authoritative when present.
+	// COALESCE keeps NULLs from corrupting the typed read.
+	err := d.session.SelectBySql(
+		"SELECT COALESCE(r.creator_uid, '') AS creator_uid, "+
+			"COALESCE(u.robot, 0) AS is_bot "+
+			"FROM robot r LEFT JOIN user u ON u.uid = r.robot_id "+
+			"WHERE r.robot_id=?",
+		botUID,
+	).LoadOne(&r)
+	if err != nil {
+		if errors.Is(err, dbr.ErrNotFound) {
+			return "", false, false, nil
+		}
+		return "", false, false, err
+	}
+	return r.CreatorUID, r.IsBot == 1, true, nil
+}
+
 // ==================== Cache helpers ====================
 
 // oboGrantorCacheKey returns the Redis key for the "any active grant for
@@ -335,6 +537,12 @@ func (d *botAPIDB) listScopesByGrant(grantID int64) ([]*oboScopeModel, error) {
 // the same key without re-implementing the format string.
 func oboGrantorCacheKey(grantorUID string) string {
 	return fmt.Sprintf(oboGrantorActiveCacheKeyFmt, grantorUID)
+}
+
+// oboChannelCacheKey returns the Redis key for the "any active grant ×
+// enabled scope for this channel" scalar.
+func oboChannelCacheKey(channelID string, channelType uint8) string {
+	return fmt.Sprintf(oboChannelActiveCacheKeyFmt, channelType, channelID)
 }
 
 // invalidateGrantorCache best-effort drops the cache key. Cache misses are
@@ -352,14 +560,130 @@ func (d *botAPIDB) invalidateGrantorCache(grantorUID string) {
 	_ = redis.Del(oboGrantorCacheKey(grantorUID))
 }
 
+// invalidateChannelCache mirrors invalidateGrantorCache for the per-channel
+// fan-out cache. Called from insertScope and deleteScope.
+func (d *botAPIDB) invalidateChannelCache(channelID string, channelType uint8) {
+	if d.ctx == nil || channelID == "" {
+		return
+	}
+	redis := d.ctx.GetRedisConn()
+	if redis == nil {
+		return
+	}
+	_ = redis.Del(oboChannelCacheKey(channelID, channelType))
+}
+
+// grantorCacheSaysNone returns true iff the cache currently holds a
+// definitive "no active grants for this grantor" answer. Any other state
+// (cached "1", absent key, Redis outage, decode error) returns false so
+// the caller falls through to MySQL.
+func (d *botAPIDB) grantorCacheSaysNone(grantorUID string) bool {
+	if d.ctx == nil || grantorUID == "" {
+		return false
+	}
+	redis := d.ctx.GetRedisConn()
+	if redis == nil {
+		return false
+	}
+	v, err := redis.GetString(oboGrantorCacheKey(grantorUID))
+	if err != nil || v == "" {
+		return false
+	}
+	return v == "0"
+}
+
+// channelCacheSaysNone — same semantics as grantorCacheSaysNone but for
+// the per-channel fan-out cache. False on any non-"0" state.
+func (d *botAPIDB) channelCacheSaysNone(channelID string, channelType uint8) bool {
+	if d.ctx == nil || channelID == "" {
+		return false
+	}
+	redis := d.ctx.GetRedisConn()
+	if redis == nil {
+		return false
+	}
+	v, err := redis.GetString(oboChannelCacheKey(channelID, channelType))
+	if err != nil || v == "" {
+		return false
+	}
+	return v == "0"
+}
+
+// writeGrantorCache populates `obo:grantor:{uid}` with "1" (any active
+// grant exists) or "0" (none), oboCacheTTL. Errors swallowed.
+func (d *botAPIDB) writeGrantorCache(grantorUID string, anyActive bool) {
+	if d.ctx == nil || grantorUID == "" {
+		return
+	}
+	redis := d.ctx.GetRedisConn()
+	if redis == nil {
+		return
+	}
+	v := "0"
+	if anyActive {
+		v = "1"
+	}
+	_ = redis.SetAndExpire(oboGrantorCacheKey(grantorUID), v, oboCacheTTL)
+}
+
+// writeChannelCache populates `obo:chan:{type}:{id}` with "1"/"0".
+func (d *botAPIDB) writeChannelCache(channelID string, channelType uint8, any bool) {
+	if d.ctx == nil || channelID == "" {
+		return
+	}
+	redis := d.ctx.GetRedisConn()
+	if redis == nil {
+		return
+	}
+	v := "0"
+	if any {
+		v = "1"
+	}
+	_ = redis.SetAndExpire(oboChannelCacheKey(channelID, channelType), v, oboCacheTTL)
+}
+
+// maybeCacheGrantorNegative writes "0" to `obo:grantor:{uid}` iff the
+// grantor truly has zero active grants. Called after a miss on
+// findActiveGrantByGrantorBot to confirm the negative answer applies
+// broadly (the row miss could just mean THIS bot has no grant, not that
+// the grantor has zero grants total). The COUNT(*) is cheap and runs on
+// the (grantor_uid, active) covering index.
+func (d *botAPIDB) maybeCacheGrantorNegative(grantorUID string) {
+	if grantorUID == "" {
+		return
+	}
+	var count int
+	err := d.session.SelectBySql(
+		"SELECT COUNT(*) FROM obo_grants WHERE grantor_uid=? AND active=1 AND global_enabled=1",
+		grantorUID,
+	).LoadOne(&count)
+	if err != nil {
+		// DB error → don't poison the cache; let the next call re-query.
+		return
+	}
+	d.writeGrantorCache(grantorUID, count > 0)
+}
+
 // ==================== Helpers ====================
 
 // isDuplicateKeyErr reports whether the given DB error came from a UNIQUE
 // constraint violation. Used by REST handlers to translate insert errors
 // into 409 Conflict without leaking driver text into the response.
+//
+// Prefers the typed MySQL error path (`*mysql.MySQLError.Number == 1062`)
+// — driver-stable and the convention used elsewhere in the codebase
+// (see modules/app_bot/db.go, modules/oidc/api.go). Falls back to a
+// substring match against the wrapped error text so the in-memory test
+// fake (which surfaces `errors.New("Error 1062: ...")`) continues to
+// satisfy the contract without depending on the real driver type.
+// (PR#82 review #2 P2-2.)
 func isDuplicateKeyErr(err error) bool {
 	if err == nil {
 		return false
+	}
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) && mysqlErr.Number == 1062 {
+		return true
 	}
 	msg := err.Error()
 	return strings.Contains(msg, "Duplicate entry") ||

--- a/modules/bot_api/obo_db.go
+++ b/modules/bot_api/obo_db.go
@@ -102,6 +102,30 @@ type oboScopeModel struct {
 //     enabled=1. Empty slice (not nil) on no match keeps callers branch-free.
 type oboStore interface {
 	findActiveGrantByGrantorBot(grantorUID, granteeBotUID string) (*oboGrantModel, error)
+	// findGrantByGrantorBotActiveOnly — YUJ-1428. Same shape as
+	// findActiveGrantByGrantorBot but ONLY filters on active=1 (the
+	// `global_enabled` master switch is intentionally not consulted).
+	//
+	// Why a separate method instead of a parameter: the existing
+	// findActiveGrantByGrantorBot is the auth gate for third-party OBO
+	// sends (checkOBO) and MUST keep requiring global_enabled=1 — the
+	// global switch is the user-facing "stop letting this persona fan
+	// out my messages" kill switch and silently demoting it on the hot
+	// path would re-open exactly the class of bug the switch exists to
+	// solve. The grantor-reply bypass is a different concern: a bot
+	// must always be able to reply to its OWN grantor in DM as long
+	// as the grant is not revoked (active=1), independent of the
+	// global fan-out switch. Splitting the methods keeps both call
+	// sites locked to the right contract at compile time.
+	//
+	// Also intentionally does NOT consult the `obo:grantor:{uid}`
+	// negative cache: that cache is populated based on
+	// (active=1 AND global_enabled=1) and would falsely return
+	// "no grant" for a grantor who has an active grant with the
+	// global switch off. The bypass call is on the DM reply path,
+	// not the system-wide fan-out path, so the per-call MySQL probe
+	// is acceptable.
+	findGrantByGrantorBotActiveOnly(grantorUID, granteeBotUID string) (*oboGrantModel, error)
 	scopeEnabled(grantID int64, channelID string, channelType uint8) (bool, error)
 	findActiveGrantsForChannel(channelID string, channelType uint8) ([]*oboGrantModel, error)
 
@@ -201,6 +225,31 @@ func (d *botAPIDB) findActiveGrantByGrantorBot(grantorUID, granteeBotUID string)
 		// COUNT — same index as the row lookup above. Avoids a stale "0"
 		// suppressing other valid grant-bot pairs of the same grantor.
 		d.maybeCacheGrantorNegative(grantorUID)
+	}
+	return m, nil
+}
+
+// findGrantByGrantorBotActiveOnly — see oboStore. YUJ-1428.
+//
+// Bypasses the `obo:grantor:{uid}` negative cache because that cache
+// answers "any active AND global_enabled grant exists for grantor",
+// which would falsely return "no grant" for a grantor whose grant is
+// active but has the global switch toggled off — exactly the case the
+// grantor-reply bypass is designed to handle. The MySQL probe runs on
+// the same `(grantor_uid, grantee_bot_uid)` covering index used by
+// findActiveGrantByGrantorBot, so the per-call cost is comparable to
+// the cache-miss path of the strict variant.
+func (d *botAPIDB) findGrantByGrantorBotActiveOnly(grantorUID, granteeBotUID string) (*oboGrantModel, error) {
+	if grantorUID == "" || granteeBotUID == "" {
+		return nil, nil
+	}
+	var m *oboGrantModel
+	_, err := d.session.Select("*").From("obo_grants").
+		Where("grantor_uid=? AND grantee_bot_uid=? AND active=1",
+			grantorUID, granteeBotUID).
+		Load(&m)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return nil, err
 	}
 	return m, nil
 }

--- a/modules/bot_api/obo_db.go
+++ b/modules/bot_api/obo_db.go
@@ -1,0 +1,368 @@
+// Package bot_api · YUJ-1166 / Mininglamp-OSS/octo-server#81 — Persona Clone
+// (On-Behalf-Of) v0 data layer.
+//
+// Backing tables: obo_grants, obo_scopes (see SQL migration
+// 20260519000001_obo_v0.sql). Public surface is the oboStore interface so
+// HTTP handlers, checkOBO, and the fan-out listener can all be unit-tested
+// against an in-memory fake without sqlmock plumbing.
+//
+// Cache strategy (RFC §11 risk row): the hot path on every inbound message
+// asks "does grantor X have ANY active grant?". A 30-second-TTL Redis key
+// `obo:grantor:{uid}` caches that scalar answer. Writes invalidate the key
+// inline; ops that don't change activity state skip the invalidation. The
+// fan-out path tolerates stale "true" answers (DB is still consulted for the
+// scope row), and stale "false" answers cap at 30s, which is acceptable for
+// v0 (see RFC §11 — risk explicitly accepted).
+package bot_api
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gocraft/dbr/v2"
+)
+
+// ==================== Models ====================
+
+// oboGrantModel mirrors the obo_grants row. JSON tags are reused by HTTP
+// handlers, which return rows verbatim (v0 has no nuanced DTOs).
+type oboGrantModel struct {
+	ID             int64      `db:"id" json:"id"`
+	GrantorUID     string     `db:"grantor_uid" json:"grantor_uid"`
+	GranteeBotUID  string     `db:"grantee_bot_uid" json:"grantee_bot_uid"`
+	Mode           string     `db:"mode" json:"mode"`
+	GlobalEnabled  int        `db:"global_enabled" json:"global_enabled"`
+	Active         int        `db:"active" json:"active"`
+	CreatedAt      time.Time  `db:"created_at" json:"created_at"`
+	UpdatedAt      time.Time  `db:"updated_at" json:"updated_at"`
+	RevokedAt      *time.Time `db:"revoked_at" json:"revoked_at,omitempty"`
+}
+
+// oboScopeModel mirrors obo_scopes.
+type oboScopeModel struct {
+	ID          int64     `db:"id" json:"id"`
+	GrantID     int64     `db:"grant_id" json:"grant_id"`
+	ChannelID   string    `db:"channel_id" json:"channel_id"`
+	ChannelType uint8     `db:"channel_type" json:"channel_type"`
+	Enabled     int       `db:"enabled" json:"enabled"`
+	CreatedAt   time.Time `db:"created_at" json:"created_at"`
+}
+
+// ==================== Store interface (test seam) ====================
+
+// oboStore is the minimal data dependency consumed by checkOBO, the REST
+// handlers, and the fan-out listener. Both the production DB-backed impl and
+// the test fake satisfy this surface; *botAPIDB satisfies it implicitly.
+//
+// Method contracts:
+//   - findActiveGrantByGrantorBot: returns (nil, nil) if no row matches OR
+//     the row is soft-deleted / globally disabled; callers MUST treat that as
+//     "not authorized". Returning ErrNotFound was rejected because callers
+//     would have to import dbr and branch on it.
+//   - scopeEnabled: returns false (no error) when the scope row is missing,
+//     enabled=0, or the grant_id doesn't exist. The hot path on sendMessage
+//     only needs a boolean.
+//   - findActiveGrantsForChannel: feeder for the fan-out listener; returns
+//     active+global_enabled grants whose scope row matches the channel and
+//     enabled=1. Empty slice (not nil) on no match keeps callers branch-free.
+type oboStore interface {
+	findActiveGrantByGrantorBot(grantorUID, granteeBotUID string) (*oboGrantModel, error)
+	scopeEnabled(grantID int64, channelID string, channelType uint8) (bool, error)
+	findActiveGrantsForChannel(channelID string, channelType uint8) ([]*oboGrantModel, error)
+
+	// CRUD used by the REST layer
+	insertGrant(grantorUID, granteeBotUID, mode string) (int64, error)
+	listGrantsByGrantor(grantorUID string) ([]*oboGrantModel, error)
+	findGrantByID(id int64) (*oboGrantModel, error)
+	updateGrant(id int64, mode string, globalEnabled *int) error
+	revokeGrant(id int64) error
+	insertScope(grantID int64, channelID string, channelType uint8, enabled int) (int64, error)
+	deleteScope(id int64) error
+	listScopesByGrant(grantID int64) ([]*oboScopeModel, error)
+}
+
+// Compile-time guard.
+var _ oboStore = (*botAPIDB)(nil)
+
+// ==================== Production impl (botAPIDB) ====================
+
+const (
+	// oboGrantorActiveCacheKeyFmt is the Redis key for "does grantor X have
+	// at least one active grant". Lookups in the fan-out hot path consult
+	// this scalar before touching MySQL. Writes that affect activity state
+	// invalidate by deletion so the next reader repopulates.
+	oboGrantorActiveCacheKeyFmt = "obo:grantor:%s"
+	// oboCacheTTL is 30s per RFC §11. Tradeoff documented in the package
+	// comment above.
+	oboCacheTTL = 30 * time.Second
+)
+
+// findActiveGrantByGrantorBot — see oboStore for the contract.
+func (d *botAPIDB) findActiveGrantByGrantorBot(grantorUID, granteeBotUID string) (*oboGrantModel, error) {
+	if grantorUID == "" || granteeBotUID == "" {
+		return nil, nil
+	}
+	var m *oboGrantModel
+	_, err := d.session.Select("*").From("obo_grants").
+		Where("grantor_uid=? AND grantee_bot_uid=? AND active=1 AND global_enabled=1",
+			grantorUID, granteeBotUID).
+		Load(&m)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return nil, err
+	}
+	return m, nil
+}
+
+// scopeEnabled — see oboStore.
+func (d *botAPIDB) scopeEnabled(grantID int64, channelID string, channelType uint8) (bool, error) {
+	if grantID == 0 || channelID == "" {
+		return false, nil
+	}
+	var count int
+	err := d.session.SelectBySql(
+		"SELECT COUNT(*) FROM obo_scopes WHERE grant_id=? AND channel_id=? AND channel_type=? AND enabled=1",
+		grantID, channelID, channelType,
+	).LoadOne(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// findActiveGrantsForChannel — see oboStore. Single JOIN so the fan-out
+// hot path doesn't have to issue a per-grant scope lookup.
+func (d *botAPIDB) findActiveGrantsForChannel(channelID string, channelType uint8) ([]*oboGrantModel, error) {
+	if channelID == "" {
+		return []*oboGrantModel{}, nil
+	}
+	var grants []*oboGrantModel
+	_, err := d.session.SelectBySql(
+		"SELECT g.* FROM obo_grants g INNER JOIN obo_scopes s ON s.grant_id=g.id "+
+			"WHERE g.active=1 AND g.global_enabled=1 AND s.enabled=1 "+
+			"AND s.channel_id=? AND s.channel_type=?",
+		channelID, channelType,
+	).Load(&grants)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return nil, err
+	}
+	if grants == nil {
+		grants = []*oboGrantModel{}
+	}
+	return grants, nil
+}
+
+// insertGrant creates a new grant row. Returns the autoincrement ID. Unique
+// constraint violations (grantor+grantee already exists) surface verbatim so
+// the REST layer can translate them to 409.
+func (d *botAPIDB) insertGrant(grantorUID, granteeBotUID, mode string) (int64, error) {
+	if mode == "" {
+		mode = "auto"
+	}
+	res, err := d.session.InsertInto("obo_grants").
+		Columns("grantor_uid", "grantee_bot_uid", "mode", "global_enabled", "active",
+			"created_at", "updated_at").
+		Values(grantorUID, granteeBotUID, mode, 0, 1, time.Now(), time.Now()).
+		Exec()
+	if err != nil {
+		return 0, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+	// Defensive: brand-new grant starts with global_enabled=0, so it cannot
+	// influence the fan-out hot path until a PUT toggles it on. We still bust
+	// the cache so a previously-cached "false" for this grantor is dropped.
+	d.invalidateGrantorCache(grantorUID)
+	return id, nil
+}
+
+// listGrantsByGrantor returns ALL rows (active + revoked) so the UI can
+// surface history. Callers that only want active rows must filter.
+func (d *botAPIDB) listGrantsByGrantor(grantorUID string) ([]*oboGrantModel, error) {
+	var grants []*oboGrantModel
+	_, err := d.session.Select("*").From("obo_grants").
+		Where("grantor_uid=?", grantorUID).
+		OrderBy("created_at DESC").
+		Load(&grants)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return nil, err
+	}
+	if grants == nil {
+		grants = []*oboGrantModel{}
+	}
+	return grants, nil
+}
+
+// findGrantByID — used by the per-grant PUT/DELETE/scopes endpoints to
+// resolve+authorize the row before mutating.
+func (d *botAPIDB) findGrantByID(id int64) (*oboGrantModel, error) {
+	var m *oboGrantModel
+	_, err := d.session.Select("*").From("obo_grants").Where("id=?", id).Load(&m)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return nil, err
+	}
+	return m, nil
+}
+
+// updateGrant applies optional fields. mode="" leaves mode untouched;
+// globalEnabled=nil leaves the toggle untouched. The cache for the row's
+// grantor is always invalidated because either change can flip the
+// "any active grant" answer.
+func (d *botAPIDB) updateGrant(id int64, mode string, globalEnabled *int) error {
+	updates := map[string]interface{}{}
+	if mode != "" {
+		updates["mode"] = mode
+	}
+	if globalEnabled != nil {
+		// Normalize to 0/1; anything truthy becomes 1.
+		v := 0
+		if *globalEnabled != 0 {
+			v = 1
+		}
+		updates["global_enabled"] = v
+	}
+	if len(updates) == 0 {
+		return nil
+	}
+	updates["updated_at"] = time.Now()
+	_, err := d.session.Update("obo_grants").SetMap(updates).Where("id=?", id).Exec()
+	if err != nil {
+		return err
+	}
+	// Cache may be wrong now; force re-read on next access.
+	g, _ := d.findGrantByID(id)
+	if g != nil {
+		d.invalidateGrantorCache(g.GrantorUID)
+	}
+	return nil
+}
+
+// revokeGrant soft-deletes (active=0, global_enabled=0, revoked_at=now).
+// We intentionally keep the row for audit. The FK on obo_scopes is
+// ON DELETE CASCADE, which doesn't fire here — scopes remain so reactivation
+// could be implemented in v1 without losing the channel list.
+func (d *botAPIDB) revokeGrant(id int64) error {
+	now := time.Now()
+	g, err := d.findGrantByID(id)
+	if err != nil {
+		return err
+	}
+	if g == nil {
+		return nil
+	}
+	_, err = d.session.Update("obo_grants").SetMap(map[string]interface{}{
+		"active":         0,
+		"global_enabled": 0,
+		"revoked_at":     now,
+		"updated_at":     now,
+	}).Where("id=?", id).Exec()
+	if err != nil {
+		return err
+	}
+	d.invalidateGrantorCache(g.GrantorUID)
+	return nil
+}
+
+// insertScope creates a per-channel toggle row. Duplicate (grant_id,
+// channel_id, channel_type) returns the unique-key error verbatim so REST
+// can translate to 409.
+func (d *botAPIDB) insertScope(grantID int64, channelID string, channelType uint8, enabled int) (int64, error) {
+	v := 0
+	if enabled != 0 {
+		v = 1
+	}
+	res, err := d.session.InsertInto("obo_scopes").
+		Columns("grant_id", "channel_id", "channel_type", "enabled", "created_at").
+		Values(grantID, channelID, channelType, v, time.Now()).
+		Exec()
+	if err != nil {
+		return 0, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+	// Adding a new scope can extend fan-out reach; if grant is enabled the
+	// per-channel hot path uses obo_scopes directly, but invalidating cache
+	// keeps the contract simple.
+	if g, _ := d.findGrantByID(grantID); g != nil {
+		d.invalidateGrantorCache(g.GrantorUID)
+	}
+	return id, nil
+}
+
+// deleteScope removes a per-channel row (hard delete — there's nothing to
+// audit about which channels you stopped using).
+func (d *botAPIDB) deleteScope(id int64) error {
+	// Look up parent grant to bust cache, then delete.
+	var grantID int64
+	_ = d.session.SelectBySql("SELECT grant_id FROM obo_scopes WHERE id=?", id).LoadOne(&grantID)
+	_, err := d.session.DeleteFrom("obo_scopes").Where("id=?", id).Exec()
+	if err != nil {
+		return err
+	}
+	if grantID != 0 {
+		if g, _ := d.findGrantByID(grantID); g != nil {
+			d.invalidateGrantorCache(g.GrantorUID)
+		}
+	}
+	return nil
+}
+
+// listScopesByGrant — REST `/v1/obo/grants/:id/scopes`.
+func (d *botAPIDB) listScopesByGrant(grantID int64) ([]*oboScopeModel, error) {
+	var scopes []*oboScopeModel
+	_, err := d.session.Select("*").From("obo_scopes").
+		Where("grant_id=?", grantID).
+		OrderBy("created_at DESC").
+		Load(&scopes)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return nil, err
+	}
+	if scopes == nil {
+		scopes = []*oboScopeModel{}
+	}
+	return scopes, nil
+}
+
+// ==================== Cache helpers ====================
+
+// oboGrantorCacheKey returns the Redis key for the "any active grant for
+// grantor" scalar. Exposed as a function (not a const) so tests can derive
+// the same key without re-implementing the format string.
+func oboGrantorCacheKey(grantorUID string) string {
+	return fmt.Sprintf(oboGrantorActiveCacheKeyFmt, grantorUID)
+}
+
+// invalidateGrantorCache best-effort drops the cache key. Cache misses are
+// safe (the hot path falls back to DB), so the cache layer cannot be a
+// correctness regression and we swallow Redis errors. nil ctx is also
+// tolerated for unit tests that wire *botAPIDB without Redis.
+func (d *botAPIDB) invalidateGrantorCache(grantorUID string) {
+	if d.ctx == nil || grantorUID == "" {
+		return
+	}
+	redis := d.ctx.GetRedisConn()
+	if redis == nil {
+		return
+	}
+	_ = redis.Del(oboGrantorCacheKey(grantorUID))
+}
+
+// ==================== Helpers ====================
+
+// isDuplicateKeyErr reports whether the given DB error came from a UNIQUE
+// constraint violation. Used by REST handlers to translate insert errors
+// into 409 Conflict without leaking driver text into the response.
+func isDuplicateKeyErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Duplicate entry") ||
+		strings.Contains(msg, "duplicate key") ||
+		strings.Contains(msg, "Error 1062")
+}

--- a/modules/bot_api/obo_db.go
+++ b/modules/bot_api/obo_db.go
@@ -47,16 +47,30 @@ import (
 
 // oboGrantModel mirrors the obo_grants row. JSON tags are reused by HTTP
 // handlers, which return rows verbatim (v0 has no nuanced DTOs).
+//
+// GranteeBotName is NOT a column on obo_grants — it is populated by
+// listGrantsByGrantor via a LEFT JOIN against the `user` table (the bot's
+// display name lives on user.name, joined on user.uid = grantee_bot_uid).
+// Other reads that do `SELECT * FROM obo_grants` leave it empty; only the
+// listing endpoint pays the JOIN, since that is the only path the web UI
+// reads (PersonaCard renders `grantee_bot_name || grantee_bot_uid`, so a
+// missing name fell back to the raw uid — YUJ-1358 / octo-web#60).
 type oboGrantModel struct {
-	ID            int64      `db:"id" json:"id"`
-	GrantorUID    string     `db:"grantor_uid" json:"grantor_uid"`
-	GranteeBotUID string     `db:"grantee_bot_uid" json:"grantee_bot_uid"`
-	Mode          string     `db:"mode" json:"mode"`
-	GlobalEnabled int        `db:"global_enabled" json:"global_enabled"`
-	Active        int        `db:"active" json:"active"`
-	CreatedAt     time.Time  `db:"created_at" json:"created_at"`
-	UpdatedAt     time.Time  `db:"updated_at" json:"updated_at"`
-	RevokedAt     *time.Time `db:"revoked_at" json:"revoked_at,omitempty"`
+	ID            int64  `db:"id" json:"id"`
+	GrantorUID    string `db:"grantor_uid" json:"grantor_uid"`
+	GranteeBotUID string `db:"grantee_bot_uid" json:"grantee_bot_uid"`
+	// GranteeBotName is the bot's human-facing display name (user.name on
+	// the row whose uid == grantee_bot_uid). Empty string when the bot
+	// has no user row OR when the field was loaded by a query that did
+	// not include the JOIN. listGrantsByGrantor guarantees a non-empty
+	// value via COALESCE(u.name, g.grantee_bot_uid).
+	GranteeBotName string     `db:"grantee_bot_name" json:"grantee_bot_name"`
+	Mode           string     `db:"mode" json:"mode"`
+	GlobalEnabled  int        `db:"global_enabled" json:"global_enabled"`
+	Active         int        `db:"active" json:"active"`
+	CreatedAt      time.Time  `db:"created_at" json:"created_at"`
+	UpdatedAt      time.Time  `db:"updated_at" json:"updated_at"`
+	RevokedAt      *time.Time `db:"revoked_at" json:"revoked_at,omitempty"`
 }
 
 // oboScopeModel mirrors obo_scopes.
@@ -269,12 +283,33 @@ func (d *botAPIDB) insertGrant(grantorUID, granteeBotUID, mode string) (int64, e
 
 // listGrantsByGrantor returns ALL rows (active + revoked) so the UI can
 // surface history. Callers that only want active rows must filter.
+//
+// LEFT JOIN `user` enriches each row with the grantee bot's display name
+// (user.name on the row whose uid == grantee_bot_uid). The bot's display
+// name lives on the `user` table, NOT the `robot` table (the robot table
+// has no name column — see modules/robot/sql/20210926000001_robot_legacy01
+// and the precedent in modules/user/api.go ~L3612: every other place that
+// needs a bot's name does the same JOIN). COALESCE falls back to the raw
+// uid when the user row is missing, so callers always get a non-empty
+// `grantee_bot_name` — eliminating the PersonaCard fallback that
+// surfaced `<uid>_bot` literals to humans (YUJ-1358 / octo-web#60).
+//
+// LEFT JOIN (not INNER) preserves grants whose bot user row has been
+// deleted (e.g. cleanup script ran ahead of the grant revoke). Those
+// rows still need to render in the UI so the operator can revoke them.
 func (d *botAPIDB) listGrantsByGrantor(grantorUID string) ([]*oboGrantModel, error) {
 	var grants []*oboGrantModel
-	_, err := d.session.Select("*").From("obo_grants").
-		Where("grantor_uid=?", grantorUID).
-		OrderBy("created_at DESC").
-		Load(&grants)
+	_, err := d.session.SelectBySql(
+		"SELECT g.id, g.grantor_uid, g.grantee_bot_uid, "+
+			"COALESCE(u.name, g.grantee_bot_uid) AS grantee_bot_name, "+
+			"g.mode, g.global_enabled, g.active, "+
+			"g.created_at, g.updated_at, g.revoked_at "+
+			"FROM obo_grants g "+
+			"LEFT JOIN `user` u ON u.uid = g.grantee_bot_uid "+
+			"WHERE g.grantor_uid=? "+
+			"ORDER BY g.created_at DESC",
+		grantorUID,
+	).Load(&grants)
 	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
 		return nil, err
 	}

--- a/modules/bot_api/obo_db.go
+++ b/modules/bot_api/obo_db.go
@@ -10,16 +10,16 @@
 // by short-TTL Redis keys, populated on read-through, invalidated on write:
 //
 //   - obo:grantor:{uid}        "1" any active grant exists for grantor;
-//                              "0" no active grant. Read by
-//                              findActiveGrantByGrantorBot — negative answer
-//                              short-circuits the (grantor, bot) MySQL probe
-//                              that checkOBO would otherwise issue per send.
+//     "0" no active grant. Read by
+//     findActiveGrantByGrantorBot — negative answer
+//     short-circuits the (grantor, bot) MySQL probe
+//     that checkOBO would otherwise issue per send.
 //   - obo:chan:{ctype}:{cid}   "1" channel has at least one (active grant ×
-//                              enabled scope) match; "0" no match. Read by
-//                              findActiveGrantsForChannel — negative answer
-//                              short-circuits the JOIN that the fan-out
-//                              listener would otherwise issue per inbound
-//                              message system-wide.
+//     enabled scope) match; "0" no match. Read by
+//     findActiveGrantsForChannel — negative answer
+//     short-circuits the JOIN that the fan-out
+//     listener would otherwise issue per inbound
+//     message system-wide.
 //
 // Both keys are negative-cache friendly: a "0" answer returned within the
 // 30-second TTL eliminates the MySQL round-trip entirely. Writes that can
@@ -48,15 +48,15 @@ import (
 // oboGrantModel mirrors the obo_grants row. JSON tags are reused by HTTP
 // handlers, which return rows verbatim (v0 has no nuanced DTOs).
 type oboGrantModel struct {
-	ID             int64      `db:"id" json:"id"`
-	GrantorUID     string     `db:"grantor_uid" json:"grantor_uid"`
-	GranteeBotUID  string     `db:"grantee_bot_uid" json:"grantee_bot_uid"`
-	Mode           string     `db:"mode" json:"mode"`
-	GlobalEnabled  int        `db:"global_enabled" json:"global_enabled"`
-	Active         int        `db:"active" json:"active"`
-	CreatedAt      time.Time  `db:"created_at" json:"created_at"`
-	UpdatedAt      time.Time  `db:"updated_at" json:"updated_at"`
-	RevokedAt      *time.Time `db:"revoked_at" json:"revoked_at,omitempty"`
+	ID            int64      `db:"id" json:"id"`
+	GrantorUID    string     `db:"grantor_uid" json:"grantor_uid"`
+	GranteeBotUID string     `db:"grantee_bot_uid" json:"grantee_bot_uid"`
+	Mode          string     `db:"mode" json:"mode"`
+	GlobalEnabled int        `db:"global_enabled" json:"global_enabled"`
+	Active        int        `db:"active" json:"active"`
+	CreatedAt     time.Time  `db:"created_at" json:"created_at"`
+	UpdatedAt     time.Time  `db:"updated_at" json:"updated_at"`
+	RevokedAt     *time.Time `db:"revoked_at" json:"revoked_at,omitempty"`
 }
 
 // oboScopeModel mirrors obo_scopes.
@@ -298,7 +298,12 @@ func (d *botAPIDB) findGrantByID(id int64) (*oboGrantModel, error) {
 // updateGrant applies optional fields. mode="" leaves mode untouched;
 // globalEnabled=nil leaves the toggle untouched. The cache for the row's
 // grantor is always invalidated because either change can flip the
-// "any active grant" answer.
+// "any active grant" answer. When `global_enabled` is touched, the
+// per-channel `obo:chan:*` cache is ALSO invalidated for every scope on
+// this grant — otherwise a `PUT global_enabled=1` could leave the
+// channel-level negative cache holding "0" for up to oboCacheTTL (30s),
+// causing fan-out to drop messages on a freshly-enabled grant for the
+// remainder of the TTL window (PR#82 R3 non-blocking finding).
 func (d *botAPIDB) updateGrant(id int64, mode string, globalEnabled *int) error {
 	updates := map[string]interface{}{}
 	if mode != "" {
@@ -324,6 +329,23 @@ func (d *botAPIDB) updateGrant(id int64, mode string, globalEnabled *int) error 
 	g, _ := d.findGrantByID(id)
 	if g != nil {
 		d.invalidateGrantorCache(g.GrantorUID)
+	}
+	// PR#82 R3 non-blocking — when the global toggle flipped, every
+	// channel this grant covers may now have a different
+	// "any active grant × enabled scope" answer. The per-channel cache
+	// otherwise sticks at its prior value (most commonly "0", written
+	// when the grant was disabled) until the 30s TTL expires, causing
+	// the UI to look broken after an enable. Bust them all.
+	//
+	// Best-effort: errors are swallowed (caches are correctness-safe
+	// to be stale; the only cost is the next message paying the JOIN).
+	// Mode-only updates don't change any cached answer, so the work is
+	// skipped in that branch.
+	if globalEnabled != nil {
+		scopes, _ := d.listScopesByGrant(id)
+		for _, s := range scopes {
+			d.invalidateChannelCache(s.ChannelID, s.ChannelType)
+		}
 	}
 	return nil
 }

--- a/modules/bot_api/obo_fake_test.go
+++ b/modules/bot_api/obo_fake_test.go
@@ -32,6 +32,11 @@ type fakeOBOStore struct {
 	// (user.robot=0). queryRobotOwner returns IsBot=false for these. Used
 	// to test the "grantee_bot_uid is a real user, not a bot" rejection.
 	nonBotUsers map[string]bool
+	// botNames maps botUID → display name (user.name). listGrantsByGrantor
+	// reads this map to populate GranteeBotName, mirroring the prod LEFT
+	// JOIN against the `user` table (YUJ-1358). When a name is absent the
+	// fake falls back to the bot uid (same as prod's COALESCE).
+	botNames map[string]string
 
 	// Test-side error injection hooks. Defaults to nil → no error.
 	failFindActiveGrant   error
@@ -52,6 +57,7 @@ func newFakeOBOStore() *fakeOBOStore {
 		scopes:      map[int64]*oboScopeModel{},
 		robotOwners: map[string]string{},
 		nonBotUsers: map[string]bool{},
+		botNames:    map[string]string{},
 	}
 }
 
@@ -68,6 +74,9 @@ func (f *fakeOBOStore) ensureInit() {
 	if f.nonBotUsers == nil {
 		f.nonBotUsers = map[string]bool{}
 	}
+	if f.botNames == nil {
+		f.botNames = map[string]string{}
+	}
 }
 
 // seedBot registers `botUID` as a bot owned by `creatorUID`. Helper for
@@ -77,6 +86,18 @@ func (f *fakeOBOStore) seedBot(botUID, creatorUID string) {
 	defer f.mu.Unlock()
 	f.ensureInit()
 	f.robotOwners[botUID] = creatorUID
+}
+
+// seedBotName registers `botUID` → `displayName` for the fake's
+// listGrantsByGrantor name lookup. Tests that need to assert on the
+// JOIN-derived `grantee_bot_name` field should seed both ownership
+// (seedBot) and a name. Unsealed bots fall back to the bot uid, mirroring
+// the COALESCE in the production query (YUJ-1358).
+func (f *fakeOBOStore) seedBotName(botUID, displayName string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureInit()
+	f.botNames[botUID] = displayName
 }
 
 // seedNonBotUser marks `uid` as a real (human) user — exists in `user`
@@ -180,6 +201,13 @@ func (f *fakeOBOStore) listGrantsByGrantor(grantorUID string) ([]*oboGrantModel,
 	for _, g := range f.grants {
 		if g.GrantorUID == grantorUID {
 			cp := *g
+			// Mirror prod's LEFT JOIN COALESCE(u.name, g.grantee_bot_uid):
+			// always populate a non-empty display name (YUJ-1358).
+			if name, ok := f.botNames[g.GranteeBotUID]; ok && name != "" {
+				cp.GranteeBotName = name
+			} else {
+				cp.GranteeBotName = g.GranteeBotUID
+			}
 			out = append(out, &cp)
 		}
 	}

--- a/modules/bot_api/obo_fake_test.go
+++ b/modules/bot_api/obo_fake_test.go
@@ -127,6 +127,30 @@ func (f *fakeOBOStore) findActiveGrantByGrantorBot(grantorUID, granteeBotUID str
 	return nil, nil
 }
 
+// findGrantByGrantorBotActiveOnly — YUJ-1428. Mirrors
+// findActiveGrantByGrantorBot but skips the GlobalEnabled gate so the
+// grantor-reply bypass keeps working when the user has toggled the
+// persona's global switch off. Shares the failFindActiveGrant injection
+// hook because the underlying DB error class is identical (any test that
+// wants this method to fail would also want the strict variant to fail
+// the same way) and tests that need to differentiate the two return
+// values can do so via the GlobalEnabled flag on the seeded grant.
+func (f *fakeOBOStore) findGrantByGrantorBotActiveOnly(grantorUID, granteeBotUID string) (*oboGrantModel, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failFindActiveGrant != nil {
+		return nil, f.failFindActiveGrant
+	}
+	f.ensureInit()
+	for _, g := range f.grants {
+		if g.GrantorUID == grantorUID && g.GranteeBotUID == granteeBotUID && g.Active == 1 {
+			cp := *g
+			return &cp, nil
+		}
+	}
+	return nil, nil
+}
+
 func (f *fakeOBOStore) scopeEnabled(grantID int64, channelID string, channelType uint8) (bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/modules/bot_api/obo_fake_test.go
+++ b/modules/bot_api/obo_fake_test.go
@@ -13,6 +13,7 @@ package bot_api
 import (
 	"errors"
 	"sync"
+	"time"
 )
 
 // fakeOBOStore is the in-memory oboStore used by the OBO unit tests.
@@ -23,6 +24,14 @@ type fakeOBOStore struct {
 	nextID int64
 	grants map[int64]*oboGrantModel
 	scopes map[int64]*oboScopeModel
+	// robotOwners maps botUID → CreatorUID. A row in this map means
+	// "registered as a bot" (IsBot=true). Used by queryRobotOwner. Tests
+	// that exercise oboCreateGrant's owner-check must seed this map.
+	robotOwners map[string]string
+	// nonBotUsers — uids that exist in the user table but are NOT bots
+	// (user.robot=0). queryRobotOwner returns IsBot=false for these. Used
+	// to test the "grantee_bot_uid is a real user, not a bot" rejection.
+	nonBotUsers map[string]bool
 
 	// Test-side error injection hooks. Defaults to nil → no error.
 	failFindActiveGrant   error
@@ -31,14 +40,18 @@ type fakeOBOStore struct {
 	failInsertGrant       error
 	failListGrants        error
 	failInsertScope       error
+	failQueryRobotOwner   error
+	failFindScopeOwner    error
 }
 
 // newFakeOBOStore — constructor, zero-value-friendly so tests can also
 // just `&fakeOBOStore{}` and rely on lazy init.
 func newFakeOBOStore() *fakeOBOStore {
 	return &fakeOBOStore{
-		grants: map[int64]*oboGrantModel{},
-		scopes: map[int64]*oboScopeModel{},
+		grants:      map[int64]*oboGrantModel{},
+		scopes:      map[int64]*oboScopeModel{},
+		robotOwners: map[string]string{},
+		nonBotUsers: map[string]bool{},
 	}
 }
 
@@ -49,6 +62,32 @@ func (f *fakeOBOStore) ensureInit() {
 	if f.scopes == nil {
 		f.scopes = map[int64]*oboScopeModel{}
 	}
+	if f.robotOwners == nil {
+		f.robotOwners = map[string]string{}
+	}
+	if f.nonBotUsers == nil {
+		f.nonBotUsers = map[string]bool{}
+	}
+}
+
+// seedBot registers `botUID` as a bot owned by `creatorUID`. Helper for
+// tests that exercise oboCreateGrant's ownership + IsBot check.
+func (f *fakeOBOStore) seedBot(botUID, creatorUID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureInit()
+	f.robotOwners[botUID] = creatorUID
+}
+
+// seedNonBotUser marks `uid` as a real (human) user — exists in `user`
+// table but with robot=0. queryRobotOwner returns IsBot=false / found=false
+// for these (mirrors prod: queryRobotOwner only finds rows in the robot
+// table). Used to test the "you can't grant OBO to a non-bot uid" path.
+func (f *fakeOBOStore) seedNonBotUser(uid string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureInit()
+	f.nonBotUsers[uid] = true
 }
 
 func (f *fakeOBOStore) findActiveGrantByGrantorBot(grantorUID, granteeBotUID string) (*oboGrantModel, error) {
@@ -190,6 +229,8 @@ func (f *fakeOBOStore) revokeGrant(id int64) error {
 	}
 	g.Active = 0
 	g.GlobalEnabled = 0
+	now := time.Now()
+	g.RevokedAt = &now
 	return nil
 }
 
@@ -241,4 +282,77 @@ func (f *fakeOBOStore) listScopesByGrant(grantID int64) ([]*oboScopeModel, error
 		}
 	}
 	return out, nil
+}
+
+// findGrantByGrantorBot — any state (active OR revoked). Mirrors prod
+// signature; used by oboCreateGrant reactivation.
+func (f *fakeOBOStore) findGrantByGrantorBot(grantorUID, granteeBotUID string) (*oboGrantModel, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureInit()
+	for _, g := range f.grants {
+		if g.GrantorUID == grantorUID && g.GranteeBotUID == granteeBotUID {
+			cp := *g
+			return &cp, nil
+		}
+	}
+	return nil, nil
+}
+
+// reactivateGrant — flip soft-deleted row back to insertGrant defaults.
+func (f *fakeOBOStore) reactivateGrant(id int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureInit()
+	g, ok := f.grants[id]
+	if !ok {
+		return nil
+	}
+	g.Active = 1
+	g.GlobalEnabled = 0
+	g.RevokedAt = nil
+	return nil
+}
+
+// findScopeOwner — O(1) lookup in the fake; mirrors prod JOIN result.
+func (f *fakeOBOStore) findScopeOwner(scopeID int64) (string, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failFindScopeOwner != nil {
+		return "", false, f.failFindScopeOwner
+	}
+	f.ensureInit()
+	s, ok := f.scopes[scopeID]
+	if !ok {
+		return "", false, nil
+	}
+	g, ok := f.grants[s.GrantID]
+	if !ok {
+		return "", false, nil
+	}
+	return g.GrantorUID, true, nil
+}
+
+// queryRobotOwner — returns creator + IsBot=true for seeded bots,
+// (_, false, false, nil) for seeded non-bot users, and (_,_,false,nil)
+// otherwise. Tests seed via seedBot / seedNonBotUser helpers above.
+func (f *fakeOBOStore) queryRobotOwner(botUID string) (string, bool, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failQueryRobotOwner != nil {
+		return "", false, false, f.failQueryRobotOwner
+	}
+	f.ensureInit()
+	if creator, ok := f.robotOwners[botUID]; ok {
+		return creator, true, true, nil
+	}
+	if f.nonBotUsers[botUID] {
+		// Exists as a real user, but robot=0. Prod's queryRobotOwner only
+		// reads the robot table; a non-bot user has no row there, so we
+		// return found=false to match. The test-facing distinction is in
+		// seedNonBotUser, which exists so future tests can distinguish
+		// "uid unknown" vs "uid known but not a bot" if needed.
+		return "", false, false, nil
+	}
+	return "", false, false, nil
 }

--- a/modules/bot_api/obo_fake_test.go
+++ b/modules/bot_api/obo_fake_test.go
@@ -1,0 +1,244 @@
+// Package bot_api · YUJ-1166 — In-memory fake oboStore used across the OBO
+// unit tests (checkOBO, REST handlers, fan-out). Mirrors the production
+// row/cache semantics closely enough that any test that compiles against
+// the oboStore interface can swap between fake and real DB without code
+// changes.
+//
+// What the fake intentionally does NOT model:
+//   - Wall-clock created_at / updated_at (returned as time.Time zero value)
+//   - Cache eviction (the fake never had a cache to evict)
+//   - Foreign-key cascade on grant delete (scopes survive — fine for tests)
+package bot_api
+
+import (
+	"errors"
+	"sync"
+)
+
+// fakeOBOStore is the in-memory oboStore used by the OBO unit tests.
+// It is concurrency-safe so tests that touch it from multiple goroutines
+// (e.g. fan-out spawned in a real ctx pipeline) don't race on the maps.
+type fakeOBOStore struct {
+	mu     sync.Mutex
+	nextID int64
+	grants map[int64]*oboGrantModel
+	scopes map[int64]*oboScopeModel
+
+	// Test-side error injection hooks. Defaults to nil → no error.
+	failFindActiveGrant   error
+	failScopeEnabled      error
+	failFindGrantsChannel error
+	failInsertGrant       error
+	failListGrants        error
+	failInsertScope       error
+}
+
+// newFakeOBOStore — constructor, zero-value-friendly so tests can also
+// just `&fakeOBOStore{}` and rely on lazy init.
+func newFakeOBOStore() *fakeOBOStore {
+	return &fakeOBOStore{
+		grants: map[int64]*oboGrantModel{},
+		scopes: map[int64]*oboScopeModel{},
+	}
+}
+
+func (f *fakeOBOStore) ensureInit() {
+	if f.grants == nil {
+		f.grants = map[int64]*oboGrantModel{}
+	}
+	if f.scopes == nil {
+		f.scopes = map[int64]*oboScopeModel{}
+	}
+}
+
+func (f *fakeOBOStore) findActiveGrantByGrantorBot(grantorUID, granteeBotUID string) (*oboGrantModel, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failFindActiveGrant != nil {
+		return nil, f.failFindActiveGrant
+	}
+	f.ensureInit()
+	for _, g := range f.grants {
+		if g.GrantorUID == grantorUID && g.GranteeBotUID == granteeBotUID && g.Active == 1 && g.GlobalEnabled == 1 {
+			cp := *g
+			return &cp, nil
+		}
+	}
+	return nil, nil
+}
+
+func (f *fakeOBOStore) scopeEnabled(grantID int64, channelID string, channelType uint8) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failScopeEnabled != nil {
+		return false, f.failScopeEnabled
+	}
+	f.ensureInit()
+	for _, s := range f.scopes {
+		if s.GrantID == grantID && s.ChannelID == channelID && s.ChannelType == channelType && s.Enabled == 1 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (f *fakeOBOStore) findActiveGrantsForChannel(channelID string, channelType uint8) ([]*oboGrantModel, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failFindGrantsChannel != nil {
+		return nil, f.failFindGrantsChannel
+	}
+	f.ensureInit()
+	out := []*oboGrantModel{}
+	// First collect matching grant IDs via the scopes.
+	for _, s := range f.scopes {
+		if s.ChannelID != channelID || s.ChannelType != channelType || s.Enabled != 1 {
+			continue
+		}
+		g, ok := f.grants[s.GrantID]
+		if !ok || g.Active != 1 || g.GlobalEnabled != 1 {
+			continue
+		}
+		cp := *g
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+
+func (f *fakeOBOStore) insertGrant(grantorUID, granteeBotUID, mode string) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failInsertGrant != nil {
+		return 0, f.failInsertGrant
+	}
+	f.ensureInit()
+	for _, g := range f.grants {
+		if g.GrantorUID == grantorUID && g.GranteeBotUID == granteeBotUID {
+			return 0, errors.New("Error 1062: Duplicate entry for uk_grantor_grantee")
+		}
+	}
+	f.nextID++
+	id := f.nextID
+	f.grants[id] = &oboGrantModel{
+		ID:            id,
+		GrantorUID:    grantorUID,
+		GranteeBotUID: granteeBotUID,
+		Mode:          mode,
+		GlobalEnabled: 0,
+		Active:        1,
+	}
+	return id, nil
+}
+
+func (f *fakeOBOStore) listGrantsByGrantor(grantorUID string) ([]*oboGrantModel, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failListGrants != nil {
+		return nil, f.failListGrants
+	}
+	f.ensureInit()
+	out := []*oboGrantModel{}
+	for _, g := range f.grants {
+		if g.GrantorUID == grantorUID {
+			cp := *g
+			out = append(out, &cp)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeOBOStore) findGrantByID(id int64) (*oboGrantModel, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureInit()
+	g, ok := f.grants[id]
+	if !ok {
+		return nil, nil
+	}
+	cp := *g
+	return &cp, nil
+}
+
+func (f *fakeOBOStore) updateGrant(id int64, mode string, globalEnabled *int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureInit()
+	g, ok := f.grants[id]
+	if !ok {
+		return nil
+	}
+	if mode != "" {
+		g.Mode = mode
+	}
+	if globalEnabled != nil {
+		v := 0
+		if *globalEnabled != 0 {
+			v = 1
+		}
+		g.GlobalEnabled = v
+	}
+	return nil
+}
+
+func (f *fakeOBOStore) revokeGrant(id int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureInit()
+	g, ok := f.grants[id]
+	if !ok {
+		return nil
+	}
+	g.Active = 0
+	g.GlobalEnabled = 0
+	return nil
+}
+
+func (f *fakeOBOStore) insertScope(grantID int64, channelID string, channelType uint8, enabled int) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failInsertScope != nil {
+		return 0, f.failInsertScope
+	}
+	f.ensureInit()
+	for _, s := range f.scopes {
+		if s.GrantID == grantID && s.ChannelID == channelID && s.ChannelType == channelType {
+			return 0, errors.New("Error 1062: Duplicate entry for uk_grant_channel")
+		}
+	}
+	f.nextID++
+	id := f.nextID
+	v := 0
+	if enabled != 0 {
+		v = 1
+	}
+	f.scopes[id] = &oboScopeModel{
+		ID:          id,
+		GrantID:     grantID,
+		ChannelID:   channelID,
+		ChannelType: channelType,
+		Enabled:     v,
+	}
+	return id, nil
+}
+
+func (f *fakeOBOStore) deleteScope(id int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureInit()
+	delete(f.scopes, id)
+	return nil
+}
+
+func (f *fakeOBOStore) listScopesByGrant(grantID int64) ([]*oboScopeModel, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureInit()
+	out := []*oboScopeModel{}
+	for _, s := range f.scopes {
+		if s.GrantID == grantID {
+			cp := *s
+			out = append(out, &cp)
+		}
+	}
+	return out, nil
+}

--- a/modules/bot_api/obo_fanout.go
+++ b/modules/bot_api/obo_fanout.go
@@ -15,8 +15,21 @@
 //   Gate 1: bot self-sent → never replay to that same bot
 //   Gate 2: grantor's own outbound → don't fan it to the grantor's bot
 //           (covers the "I typed on my phone" case — bot should not echo)
-//   Gate 3: already-OBO-processed → message_extra has obo_processed=true
+//   Gate 3: already-OBO-processed → message_extra has __obo_processed__=true
 //           (the bot's outbound, marked by sendMessage, must not bounce)
+//
+// PR#82 review #2 P1-2: gate 3's marker key is `__obo_processed__` (double-
+// underscore reserved prefix), NOT the v0-shipped `obo_processed`. The
+// v0 key was a plain JSON field that any bot could set on its own
+// /v1/bot/sendMessage payload — letting a bot suppress its own fan-out by
+// crafting `{"content":"…", "obo_processed":true}`. The new key sits in
+// a reserved namespace (`__obo_*`) that sendMessage strips off inbound
+// payloads (see send.go) before processing, so the marker is now
+// server-only state. Compatibility note: messages persisted under the
+// legacy key during the v0 testing window are NOT honored — gate 3 is
+// strict on the new name. Any in-flight v0 messages would only suppress
+// their own fan-out (a bounded edge case) and the test suite is the only
+// caller that ever wrote the legacy key in this branch.
 //
 // For each surviving (message, grant) pair we build a CMD-style copy via
 // MsgSendReq with Subscribers=[grantee_bot_uid] so only the bot receives
@@ -168,22 +181,55 @@ func (ba *BotAPI) dispatchFanout(req *config.MsgSendReq) error {
 	return ba.ctx.SendMessage(req)
 }
 
+// oboProcessedMarkerKey is the JSON payload key set by sendMessage on
+// every OBO-authorized send so the fan-out listener can short-circuit
+// gate 3 without re-querying. The double-underscore prefix marks it as
+// part of the reserved `__obo_*` namespace that the inbound
+// /v1/bot/sendMessage handler strips off client payloads — making the
+// marker server-only state that bots cannot forge or suppress through
+// the public REST API. (PR#82 review #2 P1-2.)
+const oboProcessedMarkerKey = "__obo_processed__"
+
+// oboReservedKeyPrefix is the reserved-namespace prefix for server-only
+// OBO payload fields. Inbound /v1/bot/sendMessage payloads containing
+// keys with this prefix are rejected (see send.go) so the gate-3 marker
+// — and any future server-only OBO field — cannot be impersonated by a
+// bot client.
+const oboReservedKeyPrefix = "__obo_"
+
 // hasOBOProcessedMarker — Gate 3. Returns true iff the payload decodes as
-// a JSON object containing `"obo_processed": true`. Non-JSON / non-bool
-// values are treated as absent so we err on the side of fanning out.
+// a JSON object containing `oboProcessedMarkerKey: true`. Non-JSON /
+// non-bool values are treated as absent so we err on the side of fanning
+// out.
 func hasOBOProcessedMarker(payload []byte) bool {
 	if len(payload) == 0 {
 		return false
 	}
 	// Quick reject before the unmarshal — payloads in the millions/sec
 	// hot path shouldn't pay the JSON decode cost just to find no marker.
-	if !strings.Contains(string(payload), "obo_processed") {
+	if !strings.Contains(string(payload), oboProcessedMarkerKey) {
 		return false
 	}
 	var m map[string]interface{}
 	if err := json.Unmarshal(payload, &m); err != nil {
 		return false
 	}
-	v, ok := m["obo_processed"].(bool)
+	v, ok := m[oboProcessedMarkerKey].(bool)
 	return ok && v
+}
+
+// payloadHasReservedOBOKey reports whether any top-level key in the
+// JSON-decoded `payload` map starts with the reserved `__obo_` prefix.
+// Used by /v1/bot/sendMessage to reject inbound client payloads that
+// would attempt to spoof a server-only OBO marker (gate-3 bypass).
+func payloadHasReservedOBOKey(payload map[string]interface{}) bool {
+	if len(payload) == 0 {
+		return false
+	}
+	for k := range payload {
+		if strings.HasPrefix(k, oboReservedKeyPrefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/modules/bot_api/obo_fanout.go
+++ b/modules/bot_api/obo_fanout.go
@@ -61,6 +61,24 @@
 //   - We do NOT recompute permissions; checkOBO already ran when the bot
 //     authored the message that's now bouncing, and inbound messages from
 //     real users are by definition allowed in the channel they arrived in.
+//
+// PR#82 R6 P0 — The fan-out copy's FromUID is the GRANTOR uid (not the
+// original sender). The v0 implementation used `FromUID=m.FromUID`
+// (= the peer who sent the inbound, e.g. u_bob), so for DMs WuKongIM
+// observed a (FromUID=u_bob, ChannelID=granteeBotUID) PERSONAL message
+// and synced the conversation pair `u_bob ↔ granteeBot` to **u_bob's**
+// client — leaking the persona-clone bot into bob's conversation list
+// even though bob only ever spoke to admin. The whole point of "managed
+// persona" is that bob sees ONLY admin as the counterparty; the bot is
+// strictly behind admin's identity.
+//
+// The fix routes the fan-out copy as "admin (grantor) forwarding to the
+// bot's own mailbox". WuKongIM then syncs the pair `admin ↔ granteeBot`
+// only — which is semantically correct because admin owns the bot
+// (admin is the grantor in the OBO grant row) and the bot is admin's
+// own managed persona. Bob is no longer in either UID of the fan-out
+// copy and therefore cannot see the bot at all. The bot still learns
+// who actually spoke via `obo_origin_from_uid` in the payload.
 package bot_api
 
 import (
@@ -239,7 +257,12 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 		// only subscriber of its own channel, so no real user sees the
 		// copy — even though Subscribers is now omitted (see PR#82 R5 P0
 		// in buildFanoutCopyReq for why both can't be set).
-		copyReq := buildFanoutCopyReq(m, g.GranteeBotUID)
+		//
+		// PR#82 R6 P0 — FromUID is the GRANTOR (not the original sender)
+		// so WuKongIM does NOT surface a `<peer> ↔ <granteeBot>`
+		// conversation entry on the original sender's client. See the
+		// package-level comment for the full rationale.
+		copyReq := buildFanoutCopyReq(m, g.GrantorUID, g.GranteeBotUID)
 		if err := ba.dispatchFanout(copyReq); err != nil {
 			ba.Error("OBO fan-out dispatch failed",
 				zap.String("grantee_bot", g.GranteeBotUID),
@@ -266,7 +289,18 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 //
 //   - ChannelID    = granteeBotUID (bot's own mailbox)
 //   - ChannelType  = Person (set by NewPersonalMsgSendReq)
+//   - FromUID      = grantorUID (NOT the original sender — see below)
 //   - Subscribers  = nil (omitted)
+//
+// FromUID rationale (PR#82 R6 P0): using `m.FromUID` (the original sender,
+// e.g. u_bob in a DM to admin) caused WuKongIM to sync a `<sender> ↔
+// <granteeBot>` conversation entry to the original sender's client,
+// leaking the persona-clone bot into bob's conversation list. Setting
+// FromUID to the GRANTOR fixes that — the only conversation entry now
+// shows admin ↔ granteeBot, which is fine because admin already owns
+// the bot (granted the OBO row that birthed the fan-out). The bot still
+// learns the real speaker via `obo_origin_from_uid` in the payload, so
+// the adapter can address its reply to the right user.
 //
 // NoPersist=1 + SyncOnce=1 keep the copy ephemeral so we don't bump red
 // dots or update conversation positions for any real user.
@@ -276,7 +310,7 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 // payload-supplied `space_id` (fail-closed per Mininglamp-OSS/octo-server
 // PR#35 R3). Downstream consumers must read `obo_origin_*` for routing
 // context, not `space_id`.
-func buildFanoutCopyReq(m *config.MessageResp, granteeBotUID string) *config.MsgSendReq {
+func buildFanoutCopyReq(m *config.MessageResp, grantorUID, granteeBotUID string) *config.MsgSendReq {
 	payload := map[string]interface{}{}
 	if len(m.Payload) > 0 {
 		// Best-effort decode. If the original is a non-JSON payload we
@@ -300,10 +334,11 @@ func buildFanoutCopyReq(m *config.MessageResp, granteeBotUID string) *config.Msg
 	// PERSONAL DM dispatch — must go through the octo-lib builder so
 	// payload.space_id authoritative semantics + the channel_id/subscribers
 	// mutex are uniformly applied. Subscribers omitted intentionally; see
-	// the contract block in the function doc.
+	// the contract block in the function doc. FromUID is the grantor (NOT
+	// m.FromUID) — see PR#82 R6 P0 rationale above.
 	return config.NewPersonalMsgSendReq(
 		granteeBotUID,
-		m.FromUID,
+		grantorUID,
 		payload,
 		"", // no authoritative sender Space for an internal control copy
 		config.PersonalMsgOptions{

--- a/modules/bot_api/obo_fanout.go
+++ b/modules/bot_api/obo_fanout.go
@@ -48,6 +48,7 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"go.uber.org/zap"
@@ -66,6 +67,37 @@ func (ba *BotAPI) oboMessagesListen(messages []*config.MessageResp) {
 	}
 }
 
+// fanoutLookupChannelID normalizes the channel id we use to look up scope
+// rows for an inbound listener message. The OBO scope contract stores
+// `channel_id` in the GRANTOR's "what channel did I subscribe to" frame
+// of reference (see grantorCanReadChannel / oboCreateScope), and for DMs
+// that frame is the PEER uid — not the receiver's own uid.
+//
+// Listener messages, however, carry the WuKongIM-native view. For DMs,
+// `m.ChannelID` is the receiver of the message (= grantor when fan-out is
+// meant to trigger) and `m.FromUID` is the sender (= peer). Looking up
+// scopes by `m.ChannelID` for DMs therefore searches for a row whose
+// `channel_id = grantor`, which can never match the scope rows the
+// grantor actually installed (those have `channel_id = peer`).
+//
+// PR#82 round-2 P1-B fix: for ChannelTypePerson we look up by
+// `m.FromUID` (the peer in the "peer → grantor" direction the fan-out is
+// designed to relay). For groups / community topics the channel id is
+// already the grantor's frame of reference, so we pass it through.
+//
+// The "grantor → peer" direction (Alice typing on her own device) is
+// caught two layers down — the lookup against `m.FromUID = grantor`
+// finds no scope rows (the grantor's scopes have `channel_id = peer`),
+// so fan-out is a no-op without even needing gate 2. Gate 2 still acts
+// as defense-in-depth for any future code path that uses the original
+// `m.ChannelID` lookup.
+func fanoutLookupChannelID(m *config.MessageResp) string {
+	if m.ChannelType == common.ChannelTypePerson.Uint8() {
+		return m.FromUID
+	}
+	return m.ChannelID
+}
+
 // fanoutForMessage is the single-message entry point used by tests AND by
 // oboMessagesListen. Returns the number of copies dispatched so tests can
 // assert without poking the dispatcher hook.
@@ -82,10 +114,24 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 		return 0
 	}
 
+	// PR#82 round-2 P1-B — normalize to the GRANTOR's frame of reference
+	// before consulting scope rows. For DMs this means looking up by the
+	// peer uid (= m.FromUID), not by m.ChannelID (which is the receiver /
+	// grantor). For groups / topics the two are the same.
+	lookupChannelID := fanoutLookupChannelID(m)
+	// Defensive: a DM with an empty FromUID would translate to a blank
+	// lookup key that could spuriously match scope rows for "channel_id =
+	// ''" (none should exist in prod but the API allows the row). Treat
+	// as no-op rather than risk a stray match.
+	if lookupChannelID == "" {
+		return 0
+	}
+
 	store := ba.oboStoreOrDefault()
-	grants, err := store.findActiveGrantsForChannel(m.ChannelID, m.ChannelType)
+	grants, err := store.findActiveGrantsForChannel(lookupChannelID, m.ChannelType)
 	if err != nil {
 		ba.Error("OBO fan-out lookup failed",
+			zap.String("lookup_channel_id", lookupChannelID),
 			zap.String("channel_id", m.ChannelID),
 			zap.Uint8("channel_type", m.ChannelType),
 			zap.Error(err))
@@ -94,6 +140,15 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 	if len(grants) == 0 {
 		return 0
 	}
+
+	// PR#82 round-2 P1-A — per-call cache for the grantor channel-access
+	// re-check. Multiple active grants for the same (channel, grantor)
+	// pair are rare in v0 (uk_grantor_grantee makes it (grantor, bot)),
+	// but for any given inbound message we batch the check so we don't
+	// hit the DB twice for the same grantor in one listener invocation.
+	// The boolean is the "can read" answer; presence in the map means
+	// "answer is final, do not re-query for this message".
+	grantorAccess := map[string]bool{}
 
 	dispatched := 0
 	for _, g := range grants {
@@ -107,6 +162,37 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 		// don't fan to the grantor's bot. Without this gate the bot
 		// would see every word the grantor types and potentially reply.
 		if g.GrantorUID == m.FromUID {
+			continue
+		}
+		// PR#82 round-2 P1-A — TOCTOU close-out on the fan-out hot path.
+		// Even though the scope row exists, the grantor may have lost
+		// access to the channel since (kicked from group, un-friended
+		// peer, left parent group of a thread). Skipping the dispatch
+		// keeps the bot from continuing to harvest channels the grantor
+		// no longer has eyes on. DB error → fail-closed (skip this
+		// grant, log, continue with the remaining ones; we never want a
+		// transient DB blip to leak otherwise-denied traffic).
+		canRead, cached := grantorAccess[g.GrantorUID]
+		if !cached {
+			ok, err := ba.grantorCanReadChannel(g.GrantorUID, lookupChannelID, m.ChannelType)
+			if err != nil {
+				ba.Error("OBO fan-out grantor channel-access re-check failed",
+					zap.String("grantor", g.GrantorUID),
+					zap.String("lookup_channel_id", lookupChannelID),
+					zap.Uint8("channel_type", m.ChannelType),
+					zap.Error(err))
+				grantorAccess[g.GrantorUID] = false
+				continue
+			}
+			canRead = ok
+			grantorAccess[g.GrantorUID] = canRead
+		}
+		if !canRead {
+			ba.Warn("OBO fan-out skipped: grantor no longer has read access",
+				zap.String("grantor", g.GrantorUID),
+				zap.String("grantee_bot", g.GranteeBotUID),
+				zap.String("lookup_channel_id", lookupChannelID),
+				zap.Uint8("channel_type", m.ChannelType))
 			continue
 		}
 		// Build a fan-out copy. NoPersist=1 + SyncOnce=1 + Subscribers

--- a/modules/bot_api/obo_fanout.go
+++ b/modules/bot_api/obo_fanout.go
@@ -12,11 +12,11 @@
 // hit per inbound message — then applies the three loop-protection gates
 // from RFC §5.3:
 //
-//   Gate 1: bot self-sent → never replay to that same bot
-//   Gate 2: grantor's own outbound → don't fan it to the grantor's bot
-//           (covers the "I typed on my phone" case — bot should not echo)
-//   Gate 3: already-OBO-processed → message_extra has __obo_processed__=true
-//           (the bot's outbound, marked by sendMessage, must not bounce)
+//	Gate 1: bot self-sent → never replay to that same bot
+//	Gate 2: grantor's own outbound → don't fan it to the grantor's bot
+//	        (covers the "I typed on my phone" case — bot should not echo)
+//	Gate 3: already-OBO-processed → message_extra has __obo_processed__=true
+//	        (the bot's outbound, marked by sendMessage, must not bounce)
 //
 // PR#82 review #2 P1-2: gate 3's marker key is `__obo_processed__` (double-
 // underscore reserved prefix), NOT the v0-shipped `obo_processed`. The
@@ -162,6 +162,27 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 		// don't fan to the grantor's bot. Without this gate the bot
 		// would see every word the grantor types and potentially reply.
 		if g.GrantorUID == m.FromUID {
+			continue
+		}
+		// PR#82 round-3 P1 — Multi-grantor DM recipient filter. For
+		// DMs, findActiveGrantsForChannel is keyed by the peer uid
+		// (= m.FromUID after the P1-B lookup normalization), so it
+		// returns EVERY grantor who installed a `(peer=this peer)`
+		// scope — not just the grantor who is the actual recipient
+		// of this specific message. Without this filter, a Bob →
+		// Alice DM would also fan out to Carol's clone bot if Carol
+		// also scoped Bob: findActiveGrantsForChannel(Bob, Person)
+		// returns both Alice's grant and Carol's grant, and the
+		// per-grant access re-check below confirms Carol can read
+		// DMs with Bob (they're friends) — so without this gate the
+		// message silently leaks across users.
+		//
+		// The actual DM recipient is m.ChannelID under the listener's
+		// WuKongIM-native view (DM ChannelID = receiver, FromUID =
+		// sender). Drop any grant whose grantor is NOT that receiver.
+		// For groups / community topics the lookup is already 1:1
+		// with the conversation, so this filter is a DM-only concern.
+		if m.ChannelType == common.ChannelTypePerson.Uint8() && m.ChannelID != g.GrantorUID {
 			continue
 		}
 		// PR#82 round-2 P1-A — TOCTOU close-out on the fan-out hot path.

--- a/modules/bot_api/obo_fanout.go
+++ b/modules/bot_api/obo_fanout.go
@@ -31,14 +31,33 @@
 // their own fan-out (a bounded edge case) and the test suite is the only
 // caller that ever wrote the legacy key in this branch.
 //
-// For each surviving (message, grant) pair we build a CMD-style copy via
-// MsgSendReq with Subscribers=[grantee_bot_uid] so only the bot receives
-// the fan-out. The original delivery to real users is untouched.
+// For each surviving (message, grant) pair we build a MsgSendReq addressed
+// to the grantee bot's own PERSONAL mailbox (ChannelID=grantee_bot_uid,
+// ChannelType=Person, Subscribers OMITTED). The original delivery to real
+// users is untouched.
+//
+// PR#82 review #5 P0 — WuKongIM /message/send contract: `channel_id` and
+// `subscribers` are MUTUALLY EXCLUSIVE on a single MsgSendReq. The v0
+// implementation set BOTH (ChannelID = origin conversation, Subscribers =
+// [granteeBot]) and WuKongIM rejected every dispatch with:
+//
+//	【message】channelId和subscribers不能同时存在！
+//
+// The "OBO fan-out dispatch failed" line in im-test prod showed every
+// inbound message tripping this. Fix: address the fan-out copy at the
+// bot's personal mailbox and drop Subscribers. The original conversation
+// context is preserved in the payload's `obo_origin_*` fields so the bot
+// (and any downstream consumer) can still reason about where the message
+// originated. We go through octo-lib's `NewPersonalMsgSendReq` builder so
+// the PERSONAL DM authoritative-payload contract (Mininglamp-OSS#37) is
+// preserved and the `tools/lint-personal-msgsendreq` invariant holds.
 //
 // What we do NOT do here:
 //   - We do NOT call SendMessageWithResult (which would create a new
-//     persisted message everyone sees). Subscribers + NoPersist gives the
-//     bot a one-shot copy via its existing subscriber pipeline.
+//     persisted message everyone sees). The Person-channel route +
+//     NoPersist=1 gives the bot a one-shot copy via its existing
+//     subscriber pipeline (the bot is the sole subscriber of its own
+//     mailbox channel).
 //   - We do NOT recompute permissions; checkOBO already ran when the bot
 //     authored the message that's now bouncing, and inbound messages from
 //     real users are by definition allowed in the channel they arrived in.
@@ -50,7 +69,6 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
-	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"go.uber.org/zap"
 )
 
@@ -216,9 +234,11 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 				zap.Uint8("channel_type", m.ChannelType))
 			continue
 		}
-		// Build a fan-out copy. NoPersist=1 + SyncOnce=1 + Subscribers
-		// limits delivery to the bot only and avoids re-incrementing
-		// red dots / conversation positions for any real user.
+		// Build a fan-out copy addressed to the bot's own Person mailbox.
+		// NoPersist=1 + SyncOnce=1 keep delivery silent and the bot is the
+		// only subscriber of its own channel, so no real user sees the
+		// copy — even though Subscribers is now omitted (see PR#82 R5 P0
+		// in buildFanoutCopyReq for why both can't be set).
 		copyReq := buildFanoutCopyReq(m, g.GranteeBotUID)
 		if err := ba.dispatchFanout(copyReq); err != nil {
 			ba.Error("OBO fan-out dispatch failed",
@@ -232,11 +252,30 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 	return dispatched
 }
 
-// buildFanoutCopyReq turns an inbound MessageResp into a CMD-style copy
-// addressed only to `granteeBotUID`. The payload is augmented with an
-// `obo_fanout=true` marker so downstream consumers can distinguish the
-// copy from the original (the marker is informational; loop protection
-// uses `obo_processed=true` set by the bot's own outbound).
+// buildFanoutCopyReq turns an inbound MessageResp into a one-shot copy
+// addressed to `granteeBotUID`'s PERSONAL mailbox. The payload is augmented
+// with `obo_fanout=true` plus `obo_origin_*` fields that pin down the
+// original conversation (the marker is informational; loop protection
+// uses `__obo_processed__` set by the bot's own outbound).
+//
+// Contract enforcement (PR#82 R5 P0): the returned MsgSendReq sets exactly
+// ONE of `ChannelID` / `Subscribers` (channel_id mode), never both —
+// WuKongIM `/message/send` rejects requests carrying both with
+// `channelId和subscribers不能同时存在`. We route via the bot's own Person
+// channel so:
+//
+//   - ChannelID    = granteeBotUID (bot's own mailbox)
+//   - ChannelType  = Person (set by NewPersonalMsgSendReq)
+//   - Subscribers  = nil (omitted)
+//
+// NoPersist=1 + SyncOnce=1 keep the copy ephemeral so we don't bump red
+// dots or update conversation positions for any real user.
+//
+// senderSpaceID is intentionally "" — the fan-out is an internal control
+// channel, not a user-authored DM. The builder will strip any
+// payload-supplied `space_id` (fail-closed per Mininglamp-OSS/octo-server
+// PR#35 R3). Downstream consumers must read `obo_origin_*` for routing
+// context, not `space_id`.
 func buildFanoutCopyReq(m *config.MessageResp, granteeBotUID string) *config.MsgSendReq {
 	payload := map[string]interface{}{}
 	if len(m.Payload) > 0 {
@@ -258,18 +297,25 @@ func buildFanoutCopyReq(m *config.MessageResp, granteeBotUID string) *config.Msg
 		payload["obo_origin_message_idstr"] = m.MessageIDStr
 	}
 
-	return &config.MsgSendReq{
-		Header: config.MsgHeader{
-			NoPersist: 1, // silent copy — doesn't enter normal storage
-			RedDot:    0,
-			SyncOnce:  1,
+	// PERSONAL DM dispatch — must go through the octo-lib builder so
+	// payload.space_id authoritative semantics + the channel_id/subscribers
+	// mutex are uniformly applied. Subscribers omitted intentionally; see
+	// the contract block in the function doc.
+	return config.NewPersonalMsgSendReq(
+		granteeBotUID,
+		m.FromUID,
+		payload,
+		"", // no authoritative sender Space for an internal control copy
+		config.PersonalMsgOptions{
+			Header: config.MsgHeader{
+				NoPersist: 1, // silent copy — doesn't enter normal storage
+				RedDot:    0,
+				SyncOnce:  1,
+			},
+			// Subscribers intentionally OMITTED — WuKongIM rejects when
+			// channel_id AND subscribers are both set.
 		},
-		FromUID:     m.FromUID,
-		ChannelID:   m.ChannelID,
-		ChannelType: m.ChannelType,
-		Subscribers: []string{granteeBotUID},
-		Payload:     []byte(util.ToJson(payload)),
-	}
+	)
 }
 
 // dispatchFanout sends the fan-out copy. Test override is consulted first

--- a/modules/bot_api/obo_fanout.go
+++ b/modules/bot_api/obo_fanout.go
@@ -98,6 +98,36 @@ import (
 //
 // Wired in BotAPI.Route via ba.ctx.AddMessagesListener. Test surface is
 // the lower-level fanoutForMessage method.
+//
+// CONTENT-TYPE CONTRACT (YUJ-1356 / Mininglamp-OSS/octo-server#96 audit,
+// 2026-05-19): this listener is intentionally CONTENT-TYPE-AGNOSTIC. We
+// dispatch a fan-out copy for every inbound message regardless of
+// payload `type`, because the persona-clone bot needs to observe the
+// FULL conversation (text, image, voice, video, file, stickers, etc.)
+// to act as a faithful replica. Any future "skip CMD / system messages"
+// optimization MUST live at the upstream layer (webhook handleMessageNotify
+// already gates Header.SyncOnce/NoPersist for that purpose) and MUST
+// preserve fan-out for all real user content types. The
+// TestFanout_ContentTypeAgnostic + TestFanout_OBOMessagesListen_BatchAllContentTypes
+// pair in obo_fanout_content_type_test.go locks this contract in so a
+// regression that quietly adds a type filter here surfaces at unit-test
+// time instead of slipping into E2E (where it was first reported).
+//
+// If a deployment observes some content types triggering fan-out and
+// others not (e.g. file messages silently dropped while text/image work),
+// the audit checklist is:
+//
+//  1. WuKongIM webhook config (octo-deployment) — confirm the
+//     `event.webhook.on=msg.notify` subscription delivers EVERY content
+//     type. If WuKongIM is filtering at the source, no listener — fan-out
+//     or otherwise — will ever see those payloads.
+//  2. Header.SyncOnce / Header.NoPersist on the inbound — clients
+//     should not set these on real chat content. handleMessageNotify
+//     gates listener notification on both flags (cmd / ephemeral messages
+//     do not reach listeners by design).
+//  3. payload.__obo_processed__ marker — gate 3 in fanoutForMessage
+//     short-circuits on this. Real user messages cannot set the marker
+//     (it's stripped at /v1/message/send and rejected at /v1/bot/sendMessage).
 func (ba *BotAPI) oboMessagesListen(messages []*config.MessageResp) {
 	for _, m := range messages {
 		ba.fanoutForMessage(m)

--- a/modules/bot_api/obo_fanout.go
+++ b/modules/bot_api/obo_fanout.go
@@ -1,0 +1,189 @@
+// Package bot_api · YUJ-1166 / Mininglamp-OSS/octo-server#81 — Persona Clone
+// fan-out hook.
+//
+// Hook design (RFC §5.3): we register a MessagesListener on the shared
+// context — same pattern the robot, botfather, thread, and message modules
+// already use — so the fan-out happens AFTER WuKongIM has persisted the
+// inbound message but BEFORE we deliver the copy. This matches "candidate 1"
+// in the RFC and keeps the listener side-effect free with respect to the
+// original message.
+//
+// The listener pulls grants by (channel_id, channel_type) — a single index
+// hit per inbound message — then applies the three loop-protection gates
+// from RFC §5.3:
+//
+//   Gate 1: bot self-sent → never replay to that same bot
+//   Gate 2: grantor's own outbound → don't fan it to the grantor's bot
+//           (covers the "I typed on my phone" case — bot should not echo)
+//   Gate 3: already-OBO-processed → message_extra has obo_processed=true
+//           (the bot's outbound, marked by sendMessage, must not bounce)
+//
+// For each surviving (message, grant) pair we build a CMD-style copy via
+// MsgSendReq with Subscribers=[grantee_bot_uid] so only the bot receives
+// the fan-out. The original delivery to real users is untouched.
+//
+// What we do NOT do here:
+//   - We do NOT call SendMessageWithResult (which would create a new
+//     persisted message everyone sees). Subscribers + NoPersist gives the
+//     bot a one-shot copy via its existing subscriber pipeline.
+//   - We do NOT recompute permissions; checkOBO already ran when the bot
+//     authored the message that's now bouncing, and inbound messages from
+//     real users are by definition allowed in the channel they arrived in.
+package bot_api
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"go.uber.org/zap"
+)
+
+// oboMessagesListen is the registered MessagesListener. Hot path: must be
+// O(1) for messages in channels with no active grants. The early-out on
+// the channel scope lookup achieves that — the JOIN returns 0 rows when
+// neither obo_grants nor obo_scopes has matching data.
+//
+// Wired in BotAPI.Route via ba.ctx.AddMessagesListener. Test surface is
+// the lower-level fanoutForMessage method.
+func (ba *BotAPI) oboMessagesListen(messages []*config.MessageResp) {
+	for _, m := range messages {
+		ba.fanoutForMessage(m)
+	}
+}
+
+// fanoutForMessage is the single-message entry point used by tests AND by
+// oboMessagesListen. Returns the number of copies dispatched so tests can
+// assert without poking the dispatcher hook.
+func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
+	if m == nil || strings.TrimSpace(m.ChannelID) == "" {
+		return 0
+	}
+
+	// Gate 3 (cheapest, no DB): drop messages already minted by the OBO
+	// dispatch path. Marker lives in payload (= message_extra). We don't
+	// require all bot outbound to be JSON — if the payload isn't a JSON
+	// object the marker can't be present, so we leave it as a no-op.
+	if hasOBOProcessedMarker(m.Payload) {
+		return 0
+	}
+
+	store := ba.oboStoreOrDefault()
+	grants, err := store.findActiveGrantsForChannel(m.ChannelID, m.ChannelType)
+	if err != nil {
+		ba.Error("OBO fan-out lookup failed",
+			zap.String("channel_id", m.ChannelID),
+			zap.Uint8("channel_type", m.ChannelType),
+			zap.Error(err))
+		return 0
+	}
+	if len(grants) == 0 {
+		return 0
+	}
+
+	dispatched := 0
+	for _, g := range grants {
+		// Gate 1: bot self-sent → don't replay back to the same bot.
+		// (The bot is allowed to send messages to itself in principle, but
+		// the OBO copy of a bot's own send would be a strict loop.)
+		if g.GranteeBotUID == m.FromUID {
+			continue
+		}
+		// Gate 2: grantor sent this message from their real device →
+		// don't fan to the grantor's bot. Without this gate the bot
+		// would see every word the grantor types and potentially reply.
+		if g.GrantorUID == m.FromUID {
+			continue
+		}
+		// Build a fan-out copy. NoPersist=1 + SyncOnce=1 + Subscribers
+		// limits delivery to the bot only and avoids re-incrementing
+		// red dots / conversation positions for any real user.
+		copyReq := buildFanoutCopyReq(m, g.GranteeBotUID)
+		if err := ba.dispatchFanout(copyReq); err != nil {
+			ba.Error("OBO fan-out dispatch failed",
+				zap.String("grantee_bot", g.GranteeBotUID),
+				zap.String("channel_id", m.ChannelID),
+				zap.Error(err))
+			continue
+		}
+		dispatched++
+	}
+	return dispatched
+}
+
+// buildFanoutCopyReq turns an inbound MessageResp into a CMD-style copy
+// addressed only to `granteeBotUID`. The payload is augmented with an
+// `obo_fanout=true` marker so downstream consumers can distinguish the
+// copy from the original (the marker is informational; loop protection
+// uses `obo_processed=true` set by the bot's own outbound).
+func buildFanoutCopyReq(m *config.MessageResp, granteeBotUID string) *config.MsgSendReq {
+	payload := map[string]interface{}{}
+	if len(m.Payload) > 0 {
+		// Best-effort decode. If the original is a non-JSON payload we
+		// fall back to wrapping the bytes so the bot still sees the
+		// original content under a known key.
+		if err := json.Unmarshal(m.Payload, &payload); err != nil {
+			payload = map[string]interface{}{
+				"raw":  string(m.Payload),
+				"type": 0,
+			}
+		}
+	}
+	payload["obo_fanout"] = true
+	payload["obo_origin_channel_id"] = m.ChannelID
+	payload["obo_origin_channel_type"] = m.ChannelType
+	payload["obo_origin_from_uid"] = m.FromUID
+	if m.MessageIDStr != "" {
+		payload["obo_origin_message_idstr"] = m.MessageIDStr
+	}
+
+	return &config.MsgSendReq{
+		Header: config.MsgHeader{
+			NoPersist: 1, // silent copy — doesn't enter normal storage
+			RedDot:    0,
+			SyncOnce:  1,
+		},
+		FromUID:     m.FromUID,
+		ChannelID:   m.ChannelID,
+		ChannelType: m.ChannelType,
+		Subscribers: []string{granteeBotUID},
+		Payload:     []byte(util.ToJson(payload)),
+	}
+}
+
+// dispatchFanout sends the fan-out copy. Test override is consulted first
+// so unit tests can capture the request without needing a live WuKongIM.
+// Production path goes through ctx.SendMessage (NOT SendMessageWithResult
+// — we don't need the result and the simpler call avoids a wait).
+func (ba *BotAPI) dispatchFanout(req *config.MsgSendReq) error {
+	if ba.oboFanoutDispatch != nil {
+		return ba.oboFanoutDispatch(req)
+	}
+	if ba.ctx == nil {
+		// Defensive: shouldn't happen in prod (Route is called with a real
+		// ctx) but guards against unit tests that wire BotAPI piecemeal.
+		return nil
+	}
+	return ba.ctx.SendMessage(req)
+}
+
+// hasOBOProcessedMarker — Gate 3. Returns true iff the payload decodes as
+// a JSON object containing `"obo_processed": true`. Non-JSON / non-bool
+// values are treated as absent so we err on the side of fanning out.
+func hasOBOProcessedMarker(payload []byte) bool {
+	if len(payload) == 0 {
+		return false
+	}
+	// Quick reject before the unmarshal — payloads in the millions/sec
+	// hot path shouldn't pay the JSON decode cost just to find no marker.
+	if !strings.Contains(string(payload), "obo_processed") {
+		return false
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(payload, &m); err != nil {
+		return false
+	}
+	v, ok := m["obo_processed"].(bool)
+	return ok && v
+}

--- a/modules/bot_api/obo_fanout.go
+++ b/modules/bot_api/obo_fanout.go
@@ -87,6 +87,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/pkg/obopayload"
 	"go.uber.org/zap"
 )
 
@@ -372,38 +373,38 @@ func (ba *BotAPI) dispatchFanout(req *config.MsgSendReq) error {
 // oboProcessedMarkerKey is the JSON payload key set by sendMessage on
 // every OBO-authorized send so the fan-out listener can short-circuit
 // gate 3 without re-querying. The double-underscore prefix marks it as
-// part of the reserved `__obo_*` namespace that the inbound
-// /v1/bot/sendMessage handler strips off client payloads — making the
-// marker server-only state that bots cannot forge or suppress through
-// the public REST API. (PR#82 review #2 P1-2.)
-const oboProcessedMarkerKey = "__obo_processed__"
+// part of the reserved `__obo_*` namespace that every user-message and
+// /v1/bot/sendMessage ingress strips/rejects on client payloads —
+// making the marker server-only state that bots OR users cannot forge
+// or suppress through the public APIs.
+//
+// Source of truth for both the prefix and the marker key lives in
+// pkg/obopayload so the bot API (reject), the user message API
+// (strip), and the fan-out listener (gate-3 check) cannot drift.
+// (PR#82 review #2 P1-2 + R8 user-ingress hardening.)
+const oboProcessedMarkerKey = obopayload.ProcessedMarkerKey
 
 // oboReservedKeyPrefix is the reserved-namespace prefix for server-only
-// OBO payload fields. Inbound /v1/bot/sendMessage payloads containing
-// keys with this prefix are rejected (see send.go) so the gate-3 marker
-// — and any future server-only OBO field — cannot be impersonated by a
-// bot client.
-const oboReservedKeyPrefix = "__obo_"
+// OBO payload fields. Inbound payloads containing keys with this prefix
+// are rejected (bot API) or stripped (user message API) so the gate-3
+// marker — and any future server-only OBO field — cannot be
+// impersonated by a client.
+const oboReservedKeyPrefix = obopayload.ReservedKeyPrefix
 
 // hasOBOProcessedMarker — Gate 3. Returns true iff the payload decodes as
 // a JSON object containing `oboProcessedMarkerKey: true`. Non-JSON /
 // non-bool values are treated as absent so we err on the side of fanning
 // out.
+//
+// PR#82 R8 perf nit (Jerry-Xin): the cheap pre-check uses bytes.Contains
+// on the raw payload instead of the previous strings.Contains(string(...))
+// which forced an extra allocation on every inbound message (the vast
+// majority of which do not carry the marker at all). Both the pre-check
+// and the full decode live in pkg/obopayload now so the user-ingress
+// strip and the listener's gate-3 cannot disagree about what "marker
+// present" means.
 func hasOBOProcessedMarker(payload []byte) bool {
-	if len(payload) == 0 {
-		return false
-	}
-	// Quick reject before the unmarshal — payloads in the millions/sec
-	// hot path shouldn't pay the JSON decode cost just to find no marker.
-	if !strings.Contains(string(payload), oboProcessedMarkerKey) {
-		return false
-	}
-	var m map[string]interface{}
-	if err := json.Unmarshal(payload, &m); err != nil {
-		return false
-	}
-	v, ok := m[oboProcessedMarkerKey].(bool)
-	return ok && v
+	return obopayload.HasProcessedMarker(payload)
 }
 
 // payloadHasReservedOBOKey reports whether any top-level key in the
@@ -411,13 +412,5 @@ func hasOBOProcessedMarker(payload []byte) bool {
 // Used by /v1/bot/sendMessage to reject inbound client payloads that
 // would attempt to spoof a server-only OBO marker (gate-3 bypass).
 func payloadHasReservedOBOKey(payload map[string]interface{}) bool {
-	if len(payload) == 0 {
-		return false
-	}
-	for k := range payload {
-		if strings.HasPrefix(k, oboReservedKeyPrefix) {
-			return true
-		}
-	}
-	return false
+	return obopayload.HasReservedKey(payload)
 }

--- a/modules/bot_api/obo_fanout.go
+++ b/modules/bot_api/obo_fanout.go
@@ -84,6 +84,7 @@ package bot_api
 import (
 	"encoding/json"
 	"strings"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -301,6 +302,27 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 				zap.Error(err))
 			continue
 		}
+		// YUJ-1424 / PR#82 Jerry-Xin review blocker (2026-05-20) —
+		// directly enqueue the fan-out copy into the grantee bot's
+		// /v1/bot/events queue. WuKongIM has now accepted the message
+		// (above) and will deliver it to the bot's mailbox, but the
+		// webhook → NotifyMessagesListeners path drops NoPersist=1
+		// messages before listeners fire (modules/webhook/api.go,
+		// handleMessageNotify, by design). Without this enqueue the
+		// grantee bot never observes the fan-out — the bug Jerry-Xin
+		// flagged. The synthetic event mirrors what the listener path
+		// would have produced, so /v1/bot/events serves it
+		// transparently. Best-effort: a Redis failure here logs but
+		// does NOT roll back the dispatch (the message is already in
+		// WuKongIM's store and a later replay path is preferable to a
+		// no-op).
+		copyResp := buildFanoutCopyMessageResp(copyReq, m)
+		if err := ba.enqueueFanoutBotEvent(g.GranteeBotUID, copyResp); err != nil {
+			ba.Error("OBO fan-out bot-event enqueue failed",
+				zap.String("grantee_bot", g.GranteeBotUID),
+				zap.String("channel_id", m.ChannelID),
+				zap.Error(err))
+		}
 		dispatched++
 	}
 	return dispatched
@@ -443,4 +465,62 @@ func hasOBOProcessedMarker(payload []byte) bool {
 // would attempt to spoof a server-only OBO marker (gate-3 bypass).
 func payloadHasReservedOBOKey(payload map[string]interface{}) bool {
 	return obopayload.HasReservedKey(payload)
+}
+
+// buildFanoutCopyMessageResp synthesizes a *config.MessageResp that
+// mirrors what the WuKongIM → webhook → listener path WOULD have
+// produced for the just-dispatched fan-out copy, but doesn't (the
+// webhook drops NoPersist=1 — see fanoutForMessage and the package
+// comment).
+//
+// The fields are kept tight to what /v1/bot/events consumers actually
+// read: ChannelID / ChannelType / FromUID / Payload identify the
+// conversation, Header records the NoPersist+SyncOnce semantics the
+// listener path would have surfaced, and Timestamp lets the bot order
+// events. MessageID / MessageSeq / ClientMsgNo are left zero / empty
+// because we did not round-trip through WuKongIM's SendMessageWithResult
+// (the existing dispatchFanout uses SendMessage, which intentionally
+// discards the response per its docstring — "we don't need the result
+// and the simpler call avoids a wait"). A future change can upgrade
+// dispatchFanout to capture the response and populate these fields if
+// a bot adapter starts requiring them; the current persona-clone
+// adapter reads obo_origin_* from the payload, not the wire IDs.
+//
+// `origin` is the inbound message that triggered the fan-out — used
+// only to propagate the original Timestamp when present, falling back
+// to time.Now() when the inbound carried no timestamp.
+func buildFanoutCopyMessageResp(req *config.MsgSendReq, origin *config.MessageResp) *config.MessageResp {
+	if req == nil {
+		return nil
+	}
+	ts := time.Now().Unix()
+	if origin != nil && origin.Timestamp > 0 {
+		ts = int64(origin.Timestamp)
+	}
+	return &config.MessageResp{
+		Header:      req.Header,
+		FromUID:     req.FromUID,
+		ChannelID:   req.ChannelID,
+		ChannelType: req.ChannelType,
+		Payload:     req.Payload,
+		Timestamp:   int32(ts),
+	}
+}
+
+// enqueueFanoutBotEvent appends the synthetic fan-out event to the
+// grantee bot's /v1/bot/events queue. Honors the oboFanoutBotEnqueue
+// test seam first so unit tests can assert enqueue behavior without
+// standing up Redis; production path goes through
+// ba.robotService.EnqueueBotEvent. A nil robotService (defensive — the
+// constructor wires one, but BotAPI is sometimes assembled piecemeal
+// in older tests) is treated as a silent no-op so the dispatch loop
+// stays robust.
+func (ba *BotAPI) enqueueFanoutBotEvent(robotID string, message *config.MessageResp) error {
+	if ba.oboFanoutBotEnqueue != nil {
+		return ba.oboFanoutBotEnqueue(robotID, message)
+	}
+	if ba.robotService == nil {
+		return nil
+	}
+	return ba.robotService.EnqueueBotEvent(robotID, message)
 }

--- a/modules/bot_api/obo_fanout_content_type_test.go
+++ b/modules/bot_api/obo_fanout_content_type_test.go
@@ -1,0 +1,183 @@
+// Package bot_api · YUJ-1356 / Mininglamp-OSS/octo-server#96 — regression
+// coverage for the OBO fan-out content-type contract.
+//
+// Background (E2E T03.3, 2026-05-19): the Persona Clone end-to-end suite
+// reported text / image / voice inbound messages correctly triggered the
+// OBO fan-out hook, but file (and video) inbound messages did NOT. Code
+// audit of fanoutForMessage confirmed the listener path does not filter
+// by content type — every gate is keyed on channel id, channel type, the
+// sender uid, or the `__obo_processed__` payload marker. The early-out
+// conditions only check that ChannelID is non-empty and (for DMs) FromUID
+// is non-empty; both hold for every real client inbound regardless of
+// payload type.
+//
+// This test file locks in that audit by exercising fanoutForMessage with
+// every content type the production clients send today (octo-lib
+// common.{Text,Image,GIF,Voice,Video,Location,Card,File,...}) plus the
+// custom T03.3 type=9 the E2E suite happened to use. Each case must
+// produce exactly one fan-out dispatch — otherwise a future regression
+// that quietly adds a content-type filter (e.g. "skip CMD / system
+// messages") to fanoutForMessage or any upstream listener-shim layer
+// will fail here instead of slipping into prod.
+//
+// What this test does NOT do (intentional scope split):
+//   - It does not test webhook handleMessageNotify. The webhook layer
+//     gates on Header.SyncOnce==1 || Header.NoPersist==1 (cmd /
+//     ephemeral messages do not reach listeners by design), but does not
+//     filter by content type either. A separate integration test would
+//     be needed to cover that wiring end-to-end with a real DB.
+//   - It does not test WuKongIM's own webhook config (octo-deployment).
+//     If WuKongIM is configured to suppress msg.notify for certain
+//     payload types, no listener — fan-out or otherwise — will see them.
+//     That's outside octo-server's reach; this file proves octo-server
+//     itself is not adding any content-type filter.
+package bot_api
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+)
+
+// TestFanout_ContentTypeAgnostic exercises every content type the Persona
+// Clone client matrix can produce, including the T03.3 file (type=9 in
+// the test harness, common.File=8 in octo-lib) and video (common.Video=5)
+// cases the E2E report flagged as silently dropping fan-out copies.
+//
+// Each sub-case sends a single non-grantor / non-bot user message into a
+// scoped GROUP channel and asserts:
+//   - fanoutForMessage returns 1 (the gate cascade let it through)
+//   - the capture hook recorded exactly one MsgSendReq
+//   - the dispatch contract holds (channel_id XOR subscribers, see
+//     assertFanoutDispatchContract for the WuKongIM mutex rationale)
+//   - the fan-out copy's payload carries `obo_origin_channel_id` and
+//     the marker `obo_fanout=true` so downstream consumers can route
+//
+// We intentionally use a GROUP channel for the matrix so the fan-out
+// lookup (`fanoutLookupChannelID` → m.ChannelID for non-DM) is a single
+// hop and the test focuses on the content-type axis. DM and
+// community-topic fan-out are covered by the existing
+// TestFanout_DispatchReq_NoConflict_ChannelOrSubscribers matrix.
+func TestFanout_ContentTypeAgnostic(t *testing.T) {
+	// Cover every octo-lib chat content type the bot API exposes, plus
+	// the YUJ-1356 "client type=9" report value (some clients map file
+	// to 9 instead of 8 — fan-out must not care about the numeric value).
+	cases := []struct {
+		name    string
+		payload string
+	}{
+		{name: "text_type_1", payload: `{"type":1,"content":"hi"}`},
+		{name: "image_type_2", payload: `{"type":2,"url":"https://cdn/img.png","width":100,"height":100}`},
+		{name: "gif_type_3", payload: `{"type":3,"url":"https://cdn/a.gif","width":120,"height":80}`},
+		{name: "voice_type_4", payload: `{"type":4,"url":"https://cdn/v.amr","duration":3}`},
+		{name: "video_type_5", payload: `{"type":5,"url":"https://cdn/v.mp4","width":1280,"height":720,"duration":12}`},
+		{name: "location_type_6", payload: `{"type":6,"latitude":31.2304,"longitude":121.4737,"address":"Shanghai"}`},
+		{name: "card_type_7", payload: `{"type":7,"uid":"u_carol","name":"Carol"}`},
+		// YUJ-1356 / octo-server#96 — octo-lib common.File.
+		{name: "file_type_8", payload: `{"type":8,"url":"https://cdn/report.pdf","name":"report.pdf","size":12345}`},
+		// YUJ-1356 — the literal "type=9" value the E2E report flagged.
+		// Some client codepaths emit 9 for file instead of 8; either way
+		// fan-out MUST fire because the listener does not consult `type`.
+		{name: "file_type_9_e2e_report_value", payload: `{"type":9,"url":"https://cdn/q3-report.pdf","name":"q3-report.pdf","size":67890}`},
+		{name: "multipleforward_type_11", payload: `{"type":11,"messages":[{"type":1,"content":"a"},{"type":1,"content":"b"}]}`},
+		{name: "vector_sticker_type_12", payload: `{"type":12,"url":"https://cdn/sticker.json"}`},
+		{name: "emoji_sticker_type_13", payload: `{"type":13,"url":"https://cdn/emoji.png"}`},
+		{name: "rich_text_type_14", payload: `{"type":14,"content":[{"type":"text","text":"hello"}]}`},
+		// Defensive: an inbound message with no `type` field at all
+		// must STILL fan out — the fan-out listener has no business
+		// rejecting payloads that fail the bot-side payload validator;
+		// that's a sendMessage-ingress concern, not a relay concern.
+		{name: "no_type_field", payload: `{"content":"some content"}`},
+		// Defensive: non-JSON payload (e.g. a raw signal-encrypted blob
+		// in some future code path). buildFanoutCopyReq falls back to a
+		// `{"raw":..., "type":0}` envelope; fan-out must still dispatch.
+		{name: "non_json_payload", payload: `binary-blob-not-json`},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+			s := seedGrantWithScope(t, ch, ct)
+			fc := &fanoutCapture{}
+			ba := newBAforFanout(s, fc)
+
+			msg := &config.MessageResp{
+				FromUID:      "alice", // non-bot, non-grantor user
+				ChannelID:    ch,
+				ChannelType:  ct,
+				MessageIDStr: fmt.Sprintf("origin_%s", tc.name),
+				Payload:      []byte(tc.payload),
+			}
+			got := ba.fanoutForMessage(msg)
+			if got != 1 {
+				t.Fatalf("expected exactly 1 fan-out dispatch for %s payload, got %d", tc.name, got)
+			}
+			if len(fc.copies) != 1 {
+				t.Fatalf("expected exactly 1 captured fan-out copy for %s payload, got %d", tc.name, len(fc.copies))
+			}
+			cp := fc.copies[0]
+			if err := assertFanoutDispatchContract(cp); err != nil {
+				t.Fatalf("dispatch contract violated for %s: %v (req=%+v)", tc.name, err, cp)
+			}
+			// The fan-out copy must always preserve origin routing context
+			// regardless of payload shape. For non-JSON the buildFanoutCopyReq
+			// fallback wraps the bytes under `raw` and still augments
+			// obo_origin_*; for JSON it overlays the keys directly.
+			var p map[string]interface{}
+			if err := json.Unmarshal(cp.Payload, &p); err != nil {
+				t.Fatalf("dispatched payload is not JSON for %s: %v (payload=%s)", tc.name, err, string(cp.Payload))
+			}
+			if p["obo_origin_channel_id"] != ch {
+				t.Fatalf("%s: obo_origin_channel_id should be %q, got %v", tc.name, ch, p["obo_origin_channel_id"])
+			}
+			if v, _ := p["obo_fanout"].(bool); !v {
+				t.Fatalf("%s: obo_fanout marker missing in payload %v", tc.name, p)
+			}
+		})
+	}
+}
+
+// TestFanout_OBOMessagesListen_BatchAllContentTypes asserts that the
+// MessagesListener entry point (the function actually wired into
+// ctx.AddMessagesListener) fans out every message in a mixed-type batch.
+// This catches a class of regressions where someone might add a batch-level
+// `if anyOf(types) is unsupported { skip whole batch }` shortcut to
+// oboMessagesListen — which would silently break file/video/etc dispatch
+// the same way the E2E reported.
+func TestFanout_OBOMessagesListen_BatchAllContentTypes(t *testing.T) {
+	ch, ct := "group_77", common.ChannelTypeGroup.Uint8()
+	s := seedGrantWithScope(t, ch, ct)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	// Heterogeneous batch: every payload type the issue/E2E mentioned.
+	batch := []*config.MessageResp{
+		{FromUID: "alice", ChannelID: ch, ChannelType: ct, Payload: []byte(`{"type":1,"content":"hi"}`)},
+		{FromUID: "alice", ChannelID: ch, ChannelType: ct, Payload: []byte(`{"type":2,"url":"https://cdn/i.png"}`)},
+		{FromUID: "alice", ChannelID: ch, ChannelType: ct, Payload: []byte(`{"type":3,"url":"https://cdn/a.gif"}`)},
+		{FromUID: "alice", ChannelID: ch, ChannelType: ct, Payload: []byte(`{"type":4,"url":"https://cdn/v.amr","duration":2}`)},
+		{FromUID: "alice", ChannelID: ch, ChannelType: ct, Payload: []byte(`{"type":5,"url":"https://cdn/v.mp4","duration":10}`)},
+		{FromUID: "alice", ChannelID: ch, ChannelType: ct, Payload: []byte(`{"type":8,"url":"https://cdn/r.pdf","name":"r.pdf","size":1024}`)},
+		{FromUID: "alice", ChannelID: ch, ChannelType: ct, Payload: []byte(`{"type":9,"url":"https://cdn/f9","name":"file9.bin","size":2048}`)},
+	}
+
+	ba.oboMessagesListen(batch)
+
+	if len(fc.copies) != len(batch) {
+		// Build a per-type diagnostic so a regression points at exactly
+		// which payload type was silently dropped.
+		seen := map[string]int{}
+		for _, cp := range fc.copies {
+			var p map[string]interface{}
+			_ = json.Unmarshal(cp.Payload, &p)
+			typeKey := fmt.Sprintf("%v", p["type"])
+			seen[typeKey]++
+		}
+		t.Fatalf("expected %d fan-out copies (one per batch message), got %d; per-type counts=%v",
+			len(batch), len(fc.copies), seen)
+	}
+}

--- a/modules/bot_api/obo_fanout_test.go
+++ b/modules/bot_api/obo_fanout_test.go
@@ -10,6 +10,7 @@ package bot_api
 
 import (
 	"encoding/json"
+	"errors"
 	"sync"
 	"testing"
 
@@ -62,6 +63,14 @@ func newBAforFanout(s *fakeOBOStore, fc *fanoutCapture) *BotAPI {
 		Log:               log.NewTLog("BotAPI-fanout-test"),
 		oboStoreOverride:  s,
 		oboFanoutDispatch: fc.hook,
+		// PR#82 round-2 P1-A — fanoutForMessage now re-checks the
+		// grantor's live channel access per grant. Default the test
+		// override to "always allowed" so existing happy/gate/no-grants
+		// tests stay focused on what they were written to cover. The
+		// TOCTOU regression test installs a denying override.
+		oboChannelAccessOverride: func(uid, channelID string, channelType uint8) (bool, error) {
+			return true, nil
+		},
 	}
 }
 
@@ -293,5 +302,232 @@ func TestPayloadHasReservedOBOKey(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("%s: payloadHasReservedOBOKey(%v) = %v, want %v", tc.name, tc.payload, got, tc.want)
 		}
+	}
+}
+
+// TestFanout_GrantorMembershipRevoked_SkipsCopy — PR#82 round-2 P1-A.
+// Grant + scope are in place and a normal inbound (not from bot, not
+// from grantor) arrives in the scoped channel. But the grantor was
+// kicked from `group_42` after the scope was installed, so the live
+// channel-access check denies — fan-out must NOT dispatch a copy to the
+// grantee bot.
+//
+// Without the re-check the bot would keep harvesting messages from a
+// channel the grantor no longer has eyes on, defeating the kick at the
+// IM layer (kicked-from-group is one of the standard ways admins cut
+// off a misbehaving user).
+func TestFanout_GrantorMembershipRevoked_SkipsCopy(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantWithScope(t, ch, ct)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+	// Grantor lost membership → access check denies.
+	calls := 0
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		calls++
+		if uid != tGrantor || channelID != ch || channelType != ct {
+			t.Errorf("unexpected access override args: uid=%q chan=%q type=%d", uid, channelID, channelType)
+		}
+		return false, nil
+	}
+
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"hello yu"}`),
+	}
+	if n := ba.fanoutForMessage(msg); n != 0 {
+		t.Fatalf("grantor lost access, expected 0 fan-out copies, got %d", n)
+	}
+	if len(fc.copies) != 0 {
+		t.Fatalf("captured %d copies, expected 0", len(fc.copies))
+	}
+	if calls != 1 {
+		t.Fatalf("expected the re-check to fire once per grant, got %d", calls)
+	}
+
+	// Sanity: same setup, access restored → fan-out resumes.
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		return true, nil
+	}
+	if n := ba.fanoutForMessage(msg); n != 1 {
+		t.Fatalf("access restored, expected 1 fan-out, got %d", n)
+	}
+}
+
+// TestFanout_GrantorMembershipRevoked_DBErrorSkipsCopy — defensive: a DB
+// error on the access re-check must fail closed (skip the copy) so a
+// transient blip can never leak otherwise-denied traffic. The grant is
+// dropped from this listener invocation; the next message will re-try
+// (no persistent state).
+func TestFanout_GrantorMembershipRevoked_DBErrorSkipsCopy(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantWithScope(t, ch, ct)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+	boom := errors.New("connection refused")
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		return false, boom
+	}
+
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"hello yu"}`),
+	}
+	if n := ba.fanoutForMessage(msg); n != 0 {
+		t.Fatalf("DB error on access re-check must fail closed, got %d", n)
+	}
+	if len(fc.copies) != 0 {
+		t.Fatalf("captured %d copies, expected 0 on DB error", len(fc.copies))
+	}
+}
+
+// TestFanout_DMPeerToGrantor_MatchesScope — PR#82 round-2 P1-B.
+// Alice (grantor) installs an OBO scope for DM peer Bob. When Bob sends
+// Alice a DM, the listener sees ChannelID=Alice (receiver) and
+// FromUID=Bob (sender). The pre-fix code looked up scopes by ChannelID
+// (= Alice) and missed Alice's scope row entirely, silently dropping
+// every inbound DM. The fix normalizes the lookup to FromUID for DMs
+// (the peer = grantor's frame of reference, matching how scopes are
+// stored).
+//
+// Happy path: one fan-out copy delivered to the grantee bot, with the
+// peer's payload preserved and gate-2 NOT firing.
+func TestFanout_DMPeerToGrantor_MatchesScope(t *testing.T) {
+	const peer = "bob"
+	ct := common.ChannelTypePerson.Uint8()
+	s := newFakeOBOStore()
+	gid, err := s.insertGrant(tGrantor, tBot, "auto")
+	if err != nil {
+		t.Fatalf("insertGrant: %v", err)
+	}
+	enable := 1
+	if err := s.updateGrant(gid, "", &enable); err != nil {
+		t.Fatalf("updateGrant: %v", err)
+	}
+	// Scope row uses the grantor's perspective: channel_id = peer uid.
+	if _, err := s.insertScope(gid, peer, ct, 1); err != nil {
+		t.Fatalf("insertScope: %v", err)
+	}
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+	// Grantor still has access (still friends with Bob).
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		// The fan-out hot path must use the GRANTOR frame of reference
+		// (channel_id = peer). Assert that here so a regression to the
+		// raw m.ChannelID lookup is caught.
+		if uid != tGrantor || channelID != peer || channelType != ct {
+			t.Errorf("access check called with wrong frame: uid=%q chan=%q type=%d (want grantor=%q peer=%q)", uid, channelID, channelType, tGrantor, peer)
+		}
+		return true, nil
+	}
+
+	// Listener-emitted DM: ChannelID = receiver (= grantor), FromUID = peer.
+	// See modules/webhook/api.go:248-279 + toConfigMessageResp.
+	msg := &config.MessageResp{
+		FromUID:     peer,
+		ChannelID:   tGrantor,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"hey yu"}`),
+	}
+	got := ba.fanoutForMessage(msg)
+	if got != 1 {
+		t.Fatalf("expected 1 fan-out, got %d", got)
+	}
+	if len(fc.copies) != 1 {
+		t.Fatalf("expected 1 captured copy, got %d", len(fc.copies))
+	}
+	cp := fc.copies[0]
+	if len(cp.Subscribers) != 1 || cp.Subscribers[0] != tBot {
+		t.Fatalf("subscribers should be [%s], got %v", tBot, cp.Subscribers)
+	}
+	// Payload integrity: the bot must see the original sender and content.
+	var p map[string]interface{}
+	_ = json.Unmarshal(cp.Payload, &p)
+	if p["content"] != "hey yu" {
+		t.Fatalf("payload content lost: %v", p)
+	}
+	if v, _ := p["obo_origin_from_uid"].(string); v != peer {
+		t.Fatalf("obo_origin_from_uid should be %q, got %q", peer, v)
+	}
+}
+
+// TestFanout_DMGrantorToPeer_DoesNotEcho — PR#82 round-2 P1-B, gate-2
+// invariant under the new DM lookup. When the grantor types on their
+// own device to a DM peer, the listener sees ChannelID=peer and
+// FromUID=grantor. The new lookup-by-FromUID gives us scope-row matches
+// keyed by grantor's uid — which the grantor's own scope row (keyed by
+// peer) will never match. Result: 0 fan-out, no echo to the bot.
+//
+// Gate 2 (g.GrantorUID == m.FromUID) is the historical defense for this
+// case and still acts as belt-and-braces if a future code path falls
+// back to the verbatim m.ChannelID lookup — but with the P1-B fix, the
+// lookup itself returns nothing, so gate 2 never even fires.
+func TestFanout_DMGrantorToPeer_DoesNotEcho(t *testing.T) {
+	const peer = "bob"
+	ct := common.ChannelTypePerson.Uint8()
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tGrantor, tBot, "auto")
+	enable := 1
+	_ = s.updateGrant(gid, "", &enable)
+	if _, err := s.insertScope(gid, peer, ct, 1); err != nil {
+		t.Fatalf("insertScope: %v", err)
+	}
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+	// If the access check fires here, the lookup leaked through —
+	// surface that as a failure rather than a quiet "0 dispatches".
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		t.Errorf("grantor-to-peer DM should not even reach the access check; called with uid=%q chan=%q", uid, channelID)
+		return true, nil
+	}
+
+	// Grantor typing on own device: FromUID=grantor, ChannelID=peer.
+	msg := &config.MessageResp{
+		FromUID:     tGrantor,
+		ChannelID:   peer,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"hi bob"}`),
+	}
+	if n := ba.fanoutForMessage(msg); n != 0 {
+		t.Fatalf("grantor's own DM outbound must not echo to bot, got %d copies", n)
+	}
+	if len(fc.copies) != 0 {
+		t.Fatalf("captured %d copies, expected 0", len(fc.copies))
+	}
+}
+
+// TestFanout_DMUnrelatedPeer_NoMatch — defensive cousin of P1-B. A DM
+// from some third party Eve to the grantor must NOT fan out when the
+// grantor's scope is for Bob, not Eve. With the new lookup-by-FromUID,
+// scope (channel_id = Bob) and lookup (FromUID = Eve) do not match.
+func TestFanout_DMUnrelatedPeer_NoMatch(t *testing.T) {
+	const scopedPeer, otherPeer = "bob", "eve"
+	ct := common.ChannelTypePerson.Uint8()
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tGrantor, tBot, "auto")
+	enable := 1
+	_ = s.updateGrant(gid, "", &enable)
+	if _, err := s.insertScope(gid, scopedPeer, ct, 1); err != nil {
+		t.Fatalf("insertScope: %v", err)
+	}
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		t.Errorf("unrelated peer DM should not reach access check; uid=%q chan=%q", uid, channelID)
+		return true, nil
+	}
+
+	msg := &config.MessageResp{
+		FromUID:     otherPeer,
+		ChannelID:   tGrantor,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"hi yu"}`),
+	}
+	if n := ba.fanoutForMessage(msg); n != 0 {
+		t.Fatalf("unscoped DM peer must not fan out, got %d", n)
 	}
 }

--- a/modules/bot_api/obo_fanout_test.go
+++ b/modules/bot_api/obo_fanout_test.go
@@ -11,6 +11,8 @@ package bot_api
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
@@ -97,8 +99,14 @@ func TestFanout_Happy(t *testing.T) {
 		t.Fatalf("expected 1 captured copy, got %d", len(fc.copies))
 	}
 	cp := fc.copies[0]
-	if len(cp.Subscribers) != 1 || cp.Subscribers[0] != tBot {
-		t.Fatalf("subscribers should be [%s], got %v", tBot, cp.Subscribers)
+	if err := assertFanoutDispatchContract(cp); err != nil {
+		t.Fatalf("fan-out contract violated: %v (req=%+v)", err, cp)
+	}
+	if cp.ChannelID != tBot {
+		t.Fatalf("channel_id should be bot mailbox %q, got %q", tBot, cp.ChannelID)
+	}
+	if len(cp.Subscribers) != 0 {
+		t.Fatalf("subscribers must be omitted (channel_id/subscribers are mutually exclusive on /message/send), got %v", cp.Subscribers)
 	}
 	if cp.Header.NoPersist != 1 || cp.Header.RedDot != 0 {
 		t.Fatalf("fan-out must be silent (NoPersist=1, RedDot=0), got %+v", cp.Header)
@@ -111,6 +119,10 @@ func TestFanout_Happy(t *testing.T) {
 	}
 	if v, _ := got2["obo_fanout"].(bool); !v {
 		t.Fatalf("payload should be marked obo_fanout=true: %v", got2)
+	}
+	// Origin channel context preserved so downstream consumers can route.
+	if got2["obo_origin_channel_id"] != ch {
+		t.Fatalf("obo_origin_channel_id should be %q, got %v", ch, got2["obo_origin_channel_id"])
 	}
 }
 
@@ -441,8 +453,14 @@ func TestFanout_DMPeerToGrantor_MatchesScope(t *testing.T) {
 		t.Fatalf("expected 1 captured copy, got %d", len(fc.copies))
 	}
 	cp := fc.copies[0]
-	if len(cp.Subscribers) != 1 || cp.Subscribers[0] != tBot {
-		t.Fatalf("subscribers should be [%s], got %v", tBot, cp.Subscribers)
+	if err := assertFanoutDispatchContract(cp); err != nil {
+		t.Fatalf("fan-out contract violated: %v (req=%+v)", err, cp)
+	}
+	if cp.ChannelID != tBot {
+		t.Fatalf("channel_id should be bot mailbox %q, got %q", tBot, cp.ChannelID)
+	}
+	if len(cp.Subscribers) != 0 {
+		t.Fatalf("subscribers must be omitted on the fan-out copy, got %v", cp.Subscribers)
 	}
 	// Payload integrity: the bot must see the original sender and content.
 	var p map[string]interface{}
@@ -452,6 +470,10 @@ func TestFanout_DMPeerToGrantor_MatchesScope(t *testing.T) {
 	}
 	if v, _ := p["obo_origin_from_uid"].(string); v != peer {
 		t.Fatalf("obo_origin_from_uid should be %q, got %q", peer, v)
+	}
+	// Origin channel context: DM receiver is the grantor.
+	if v, _ := p["obo_origin_channel_id"].(string); v != tGrantor {
+		t.Fatalf("obo_origin_channel_id should be grantor %q, got %q", tGrantor, v)
 	}
 }
 
@@ -615,15 +637,24 @@ func TestFanout_DMMultiGrantor_OnlyRecipientReceives(t *testing.T) {
 		t.Fatalf("multi-grantor DM: expected 1 captured copy, got %d", len(fc.copies))
 	}
 	cp := fc.copies[0]
-	if len(cp.Subscribers) != 1 || cp.Subscribers[0] != aliceBot {
-		t.Fatalf("multi-grantor DM leak: subscriber should be [%s], got %v", aliceBot, cp.Subscribers)
+	if err := assertFanoutDispatchContract(cp); err != nil {
+		t.Fatalf("fan-out contract violated: %v (req=%+v)", err, cp)
 	}
-	// Explicitly assert Carol's bot is NOT a subscriber on any copy —
-	// the regression we're guarding against.
+	if cp.ChannelID != aliceBot {
+		t.Fatalf("multi-grantor DM leak: channel_id should be alice's bot mailbox %q, got %q", aliceBot, cp.ChannelID)
+	}
+	if len(cp.Subscribers) != 0 {
+		t.Fatalf("subscribers must be omitted on the fan-out copy, got %v", cp.Subscribers)
+	}
+	// Explicitly assert Carol's bot is NOT the addressed mailbox on any
+	// copy — the regression we're guarding against.
 	for _, c := range fc.copies {
+		if c.ChannelID == carolBot {
+			t.Fatalf("CROSS-USER DM LEAK: carol's bot mailbox (%s) received fan-out of bob→alice DM", carolBot)
+		}
 		for _, sub := range c.Subscribers {
 			if sub == carolBot {
-				t.Fatalf("CROSS-USER DM LEAK: carol's bot (%s) received fan-out of bob→alice DM", carolBot)
+				t.Fatalf("CROSS-USER DM LEAK: carol's bot (%s) listed in Subscribers (and Subscribers should be empty)", carolBot)
 			}
 		}
 	}
@@ -670,8 +701,11 @@ func TestFanout_DMSingleGrantor_RecipientReceives(t *testing.T) {
 	if n := ba.fanoutForMessage(msg); n != 1 {
 		t.Fatalf("single-grantor DM happy path: expected 1 fan-out, got %d", n)
 	}
-	if len(fc.copies) != 1 || fc.copies[0].Subscribers[0] != tBot {
+	if len(fc.copies) != 1 || fc.copies[0].ChannelID != tBot {
 		t.Fatalf("single-grantor DM happy path: wrong dispatch, copies=%+v", fc.copies)
+	}
+	if err := assertFanoutDispatchContract(fc.copies[0]); err != nil {
+		t.Fatalf("fan-out contract violated: %v (req=%+v)", err, fc.copies[0])
 	}
 }
 
@@ -732,5 +766,278 @@ func TestFanout_DMNonRecipient_NoLeak(t *testing.T) {
 	}
 	if len(fc.copies) != 0 {
 		t.Fatalf("non-recipient grant leaked: captured %d copies, expected 0", len(fc.copies))
+	}
+}
+
+// assertFanoutDispatchContract enforces the WuKongIM /message/send mutex
+// invariant: a MsgSendReq must carry EXACTLY ONE of (channel_id set with
+// empty subscribers) OR (empty channel_id with subscribers set). Setting
+// both triggers the production rejection observed in PR#82 R5 P0:
+//
+//	【message】channelId和subscribers不能同时存在！
+//
+// The OBO fan-out path picks the channel_id branch (bot's own mailbox).
+// This helper is used by every dispatch-contract regression test so any
+// future driver of buildFanoutCopyReq that re-introduces the conflict is
+// caught at the unit-test layer, before im-test ever sees it.
+func assertFanoutDispatchContract(req *config.MsgSendReq) error {
+	if req == nil {
+		return errors.New("dispatched a nil MsgSendReq")
+	}
+	hasChannelID := strings.TrimSpace(req.ChannelID) != ""
+	hasSubscribers := len(req.Subscribers) > 0
+	if hasChannelID && hasSubscribers {
+		return fmt.Errorf("MsgSendReq sets BOTH channel_id=%q AND subscribers=%v — WuKongIM rejects this combination", req.ChannelID, req.Subscribers)
+	}
+	if !hasChannelID && !hasSubscribers {
+		return errors.New("MsgSendReq has neither channel_id nor subscribers — WuKongIM cannot route the message")
+	}
+	return nil
+}
+
+// TestFanout_DispatchReq_NoConflict_ChannelOrSubscribers — PR#82 R5 P0
+// regression. The v0 buildFanoutCopyReq set BOTH ChannelID (origin
+// conversation) AND Subscribers ([granteeBot]); WuKongIM /message/send
+// rejected every fan-out with "channelId和subscribers不能同时存在", and
+// the bot consequently never received the copy → the persona never
+// replied.
+//
+// This test exercises every channel-type / sender-role combination the
+// fan-out hot path can see (DM peer→grantor, group, community topic) and
+// asserts the dispatched MsgSendReq always satisfies the mutex contract.
+// It does NOT touch the access-check or recipient-filter logic — those
+// have their own dedicated tests — so any future regression in
+// buildFanoutCopyReq alone surfaces here.
+func TestFanout_DispatchReq_NoConflict_ChannelOrSubscribers(t *testing.T) {
+	cases := []struct {
+		name       string
+		ct         uint8
+		setupMsg   func(scope string) *config.MessageResp
+		setupScope func() (string, *fakeOBOStore)
+	}{
+		{
+			name: "group",
+			ct:   common.ChannelTypeGroup.Uint8(),
+			setupScope: func() (string, *fakeOBOStore) {
+				ch := "group_42"
+				return ch, seedGrantWithScope(t, ch, common.ChannelTypeGroup.Uint8())
+			},
+			setupMsg: func(scope string) *config.MessageResp {
+				return &config.MessageResp{
+					FromUID:     "alice",
+					ChannelID:   scope,
+					ChannelType: common.ChannelTypeGroup.Uint8(),
+					Payload:     []byte(`{"type":1,"content":"hi group"}`),
+				}
+			},
+		},
+		{
+			name: "dm_peer_to_grantor",
+			ct:   common.ChannelTypePerson.Uint8(),
+			setupScope: func() (string, *fakeOBOStore) {
+				const peer = "bob"
+				ct := common.ChannelTypePerson.Uint8()
+				s := newFakeOBOStore()
+				gid, _ := s.insertGrant(tGrantor, tBot, "auto")
+				enable := 1
+				_ = s.updateGrant(gid, "", &enable)
+				if _, err := s.insertScope(gid, peer, ct, 1); err != nil {
+					t.Fatalf("insertScope: %v", err)
+				}
+				return peer, s
+			},
+			setupMsg: func(peer string) *config.MessageResp {
+				return &config.MessageResp{
+					FromUID:     peer,
+					ChannelID:   tGrantor,
+					ChannelType: common.ChannelTypePerson.Uint8(),
+					Payload:     []byte(`{"type":1,"content":"hey yu"}`),
+				}
+			},
+		},
+		{
+			name: "community_topic",
+			ct:   common.ChannelTypeCommunityTopic.Uint8(),
+			setupScope: func() (string, *fakeOBOStore) {
+				ch := "topic_99"
+				return ch, seedGrantWithScope(t, ch, common.ChannelTypeCommunityTopic.Uint8())
+			},
+			setupMsg: func(scope string) *config.MessageResp {
+				return &config.MessageResp{
+					FromUID:     "alice",
+					ChannelID:   scope,
+					ChannelType: common.ChannelTypeCommunityTopic.Uint8(),
+					Payload:     []byte(`{"type":1,"content":"hi topic"}`),
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scope, s := tc.setupScope()
+			fc := &fanoutCapture{}
+			ba := newBAforFanout(s, fc)
+			msg := tc.setupMsg(scope)
+			n := ba.fanoutForMessage(msg)
+			if n != 1 {
+				t.Fatalf("expected 1 dispatch, got %d (copies=%+v)", n, fc.copies)
+			}
+			if len(fc.copies) != 1 {
+				t.Fatalf("expected 1 captured copy, got %d", len(fc.copies))
+			}
+			cp := fc.copies[0]
+			if err := assertFanoutDispatchContract(cp); err != nil {
+				t.Fatalf("WuKongIM mutex contract violated: %v\n  channel_id=%q\n  subscribers=%v\n  channel_type=%d\n  from_uid=%q",
+					err, cp.ChannelID, cp.Subscribers, cp.ChannelType, cp.FromUID)
+			}
+		})
+	}
+}
+
+// TestFanout_DispatchReq_BotReceivesViaOwnChannel — PR#82 R5 P0. Locks
+// in option-3 routing decision: the fan-out copy is delivered via the
+// grantee bot's OWN Person mailbox (ChannelID=granteeBotUID,
+// ChannelType=Person), not via the origin conversation's channel_id with
+// a Subscribers filter. This is the contract that satisfies the
+// WuKongIM mutex AND keeps the copy out of the origin channel's
+// subscriber pipeline (so no real user sees it even if NoPersist were
+// to ever regress).
+//
+// Asserts (per fan-out copy):
+//   - ChannelID == granteeBotUID
+//   - ChannelType == ChannelTypePerson (set by NewPersonalMsgSendReq)
+//   - Subscribers is empty
+//   - FromUID preserves the original sender's uid (so the bot's
+//     payload-side handlers can identify who spoke)
+//   - obo_origin_* payload fields preserve the routing context
+func TestFanout_DispatchReq_BotReceivesViaOwnChannel(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantWithScope(t, ch, ct)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:      "u_bob",
+		ChannelID:    ch,
+		ChannelType:  ct,
+		MessageIDStr: "origin_msg_42",
+		Payload:      []byte(`{"type":1,"content":"hi yu"}`),
+	}
+	if n := ba.fanoutForMessage(msg); n != 1 {
+		t.Fatalf("expected 1 dispatch, got %d", n)
+	}
+	if len(fc.copies) != 1 {
+		t.Fatalf("expected 1 captured copy, got %d", len(fc.copies))
+	}
+	cp := fc.copies[0]
+	if err := assertFanoutDispatchContract(cp); err != nil {
+		t.Fatalf("contract violated: %v", err)
+	}
+	if cp.ChannelID != tBot {
+		t.Fatalf("ChannelID should be grantee bot mailbox %q, got %q", tBot, cp.ChannelID)
+	}
+	if cp.ChannelType != common.ChannelTypePerson.Uint8() {
+		t.Fatalf("ChannelType should be Person (%d), got %d", common.ChannelTypePerson.Uint8(), cp.ChannelType)
+	}
+	if len(cp.Subscribers) != 0 {
+		t.Fatalf("Subscribers must be omitted (mutex with channel_id), got %v", cp.Subscribers)
+	}
+	if cp.FromUID != "u_bob" {
+		t.Fatalf("FromUID should preserve origin sender %q, got %q", "u_bob", cp.FromUID)
+	}
+
+	var p map[string]interface{}
+	if err := json.Unmarshal(cp.Payload, &p); err != nil {
+		t.Fatalf("payload not JSON: %v", err)
+	}
+	if got := p["obo_origin_channel_id"]; got != ch {
+		t.Fatalf("obo_origin_channel_id should be origin channel %q, got %v", ch, got)
+	}
+	// JSON numbers decode as float64.
+	if got, _ := p["obo_origin_channel_type"].(float64); uint8(got) != ct {
+		t.Fatalf("obo_origin_channel_type should be %d, got %v", ct, p["obo_origin_channel_type"])
+	}
+	if got := p["obo_origin_from_uid"]; got != "u_bob" {
+		t.Fatalf("obo_origin_from_uid should be %q, got %v", "u_bob", got)
+	}
+	if got := p["obo_origin_message_idstr"]; got != "origin_msg_42" {
+		t.Fatalf("obo_origin_message_idstr should be %q, got %v", "origin_msg_42", got)
+	}
+	// Original content preserved.
+	if got := p["content"]; got != "hi yu" {
+		t.Fatalf("original content lost: got %v", got)
+	}
+	// Fan-out marker present.
+	if v, _ := p["obo_fanout"].(bool); !v {
+		t.Fatalf("obo_fanout marker missing")
+	}
+	// And — defense in depth — the gate-3 marker MUST NOT be on the
+	// fan-out copy. The bot's own reply (a separate send via
+	// /v1/bot/sendMessage) is what carries the __obo_processed__ marker.
+	if _, present := p["__obo_processed__"]; present {
+		t.Fatalf("fan-out copy must not carry the gate-3 __obo_processed__ marker; that key is set only on the bot's own outbound: %v", p)
+	}
+}
+
+// TestFanout_DispatchReq_RealDispatcher_ContractCheck — PR#82 R5 P0. Test
+// gap closure: every existing fan-out test mocks oboFanoutDispatch with
+// the fanoutCapture hook, which means WuKongIM-shape rejections (like the
+// channel_id/subscribers mutex) are invisible to the unit suite. The
+// production v0 path silently fed conflicting requests to WuKongIM and
+// only im-test surfaced the bug.
+//
+// This test installs a "fake WuKongIM" dispatcher that performs the same
+// mutex check the real /message/send endpoint does, then runs the
+// fan-out happy path and asserts the dispatcher accepts the request (zero
+// rejections, exactly one delivery). A future regression that re-
+// introduces the conflict — by, say, copying buildFanoutCopyReq into a
+// new code path — will trip this fake and fail.
+func TestFanout_DispatchReq_RealDispatcher_ContractCheck(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantWithScope(t, ch, ct)
+
+	var (
+		dispatched int
+		rejected   []string
+	)
+	fakeWK := func(req *config.MsgSendReq) error {
+		// Mirror the WuKongIM /message/send precondition: channel_id and
+		// subscribers are mutually exclusive.
+		if strings.TrimSpace(req.ChannelID) != "" && len(req.Subscribers) > 0 {
+			msg := fmt.Sprintf("【message】channelId和subscribers不能同时存在！ (channel_id=%q subscribers=%v)", req.ChannelID, req.Subscribers)
+			rejected = append(rejected, msg)
+			return errors.New(msg)
+		}
+		if strings.TrimSpace(req.ChannelID) == "" && len(req.Subscribers) == 0 {
+			msg := "【message】channelId和subscribers至少需要一个！"
+			rejected = append(rejected, msg)
+			return errors.New(msg)
+		}
+		dispatched++
+		return nil
+	}
+	ba := &BotAPI{
+		Log:               log.NewTLog("BotAPI-fanout-test"),
+		oboStoreOverride:  s,
+		oboFanoutDispatch: fakeWK,
+		oboChannelAccessOverride: func(uid, channelID string, channelType uint8) (bool, error) {
+			return true, nil
+		},
+	}
+
+	msg := &config.MessageResp{
+		FromUID:     "u_bob",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"hi yu"}`),
+	}
+	if n := ba.fanoutForMessage(msg); n != 1 {
+		t.Fatalf("fan-out should succeed against contract-respecting WuKongIM, got %d (rejections=%v)", n, rejected)
+	}
+	if dispatched != 1 {
+		t.Fatalf("fake WuKongIM should have accepted 1 dispatch, accepted %d", dispatched)
+	}
+	if len(rejected) != 0 {
+		t.Fatalf("WuKongIM contract violations: %v", rejected)
 	}
 }

--- a/modules/bot_api/obo_fanout_test.go
+++ b/modules/bot_api/obo_fanout_test.go
@@ -531,3 +531,206 @@ func TestFanout_DMUnrelatedPeer_NoMatch(t *testing.T) {
 		t.Fatalf("unscoped DM peer must not fan out, got %d", n)
 	}
 }
+
+// TestFanout_DMMultiGrantor_OnlyRecipientReceives — PR#82 round-3 P1.
+// Cross-user DM privacy leak in fan-out: two grantors (Alice and Carol)
+// each install an OBO grant + scope `(peer=Bob)` for their own clone
+// bots. When Bob DMs Alice, the listener sees ChannelID=Alice (the
+// recipient), FromUID=Bob. findActiveGrantsForChannel(Bob, Person)
+// returns BOTH Alice's grant AND Carol's grant — both scoped that peer
+// — and the per-grant grantor-access re-check accepts Carol because she
+// is also friends with Bob and so can read DMs with him. Without the
+// recipient filter, Carol's clone bot would receive a copy of Bob's
+// private message to Alice.
+//
+// The fix is a per-grant filter inside fanoutForMessage's ChannelType
+// Person branch: skip any grant whose grantor is not the actual DM
+// recipient (= m.ChannelID under the listener's frame of reference).
+// This test asserts exactly one fan-out (to Alice's bot), with Bob's
+// payload preserved.
+func TestFanout_DMMultiGrantor_OnlyRecipientReceives(t *testing.T) {
+	const (
+		peer     = "bob"
+		aliceUID = "user_alice"
+		aliceBot = "bot_alice_clone"
+		carolUID = "user_carol"
+		carolBot = "bot_carol_clone"
+	)
+	ct := common.ChannelTypePerson.Uint8()
+
+	s := newFakeOBOStore()
+	// Alice's grant + scope (peer=Bob).
+	gidAlice, err := s.insertGrant(aliceUID, aliceBot, "auto")
+	if err != nil {
+		t.Fatalf("insertGrant alice: %v", err)
+	}
+	enable := 1
+	if err := s.updateGrant(gidAlice, "", &enable); err != nil {
+		t.Fatalf("updateGrant alice: %v", err)
+	}
+	if _, err := s.insertScope(gidAlice, peer, ct, 1); err != nil {
+		t.Fatalf("insertScope alice: %v", err)
+	}
+	// Carol's grant + scope (peer=Bob) — the exploit setup. Carol and
+	// Bob are friends so the per-grant access check WOULD permit this
+	// grant absent the recipient filter.
+	gidCarol, err := s.insertGrant(carolUID, carolBot, "auto")
+	if err != nil {
+		t.Fatalf("insertGrant carol: %v", err)
+	}
+	if err := s.updateGrant(gidCarol, "", &enable); err != nil {
+		t.Fatalf("updateGrant carol: %v", err)
+	}
+	if _, err := s.insertScope(gidCarol, peer, ct, 1); err != nil {
+		t.Fatalf("insertScope carol: %v", err)
+	}
+
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+	// Both grantors are friends with Bob → both pass the per-grant
+	// access re-check. The recipient filter is the ONLY thing keeping
+	// Carol's bot off the dispatch list.
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		if channelID != peer || channelType != ct {
+			t.Errorf("access check called with wrong DM frame: uid=%q chan=%q (want peer=%q)", uid, channelID, peer)
+		}
+		if uid != aliceUID && uid != carolUID {
+			t.Errorf("unexpected grantor in access check: %q", uid)
+		}
+		return true, nil
+	}
+
+	// Bob → Alice DM.
+	msg := &config.MessageResp{
+		FromUID:     peer,
+		ChannelID:   aliceUID,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"private note for alice"}`),
+	}
+	got := ba.fanoutForMessage(msg)
+	if got != 1 {
+		t.Fatalf("multi-grantor DM: expected exactly 1 fan-out (to alice's bot), got %d", got)
+	}
+	if len(fc.copies) != 1 {
+		t.Fatalf("multi-grantor DM: expected 1 captured copy, got %d", len(fc.copies))
+	}
+	cp := fc.copies[0]
+	if len(cp.Subscribers) != 1 || cp.Subscribers[0] != aliceBot {
+		t.Fatalf("multi-grantor DM leak: subscriber should be [%s], got %v", aliceBot, cp.Subscribers)
+	}
+	// Explicitly assert Carol's bot is NOT a subscriber on any copy —
+	// the regression we're guarding against.
+	for _, c := range fc.copies {
+		for _, sub := range c.Subscribers {
+			if sub == carolBot {
+				t.Fatalf("CROSS-USER DM LEAK: carol's bot (%s) received fan-out of bob→alice DM", carolBot)
+			}
+		}
+	}
+	var p map[string]interface{}
+	_ = json.Unmarshal(cp.Payload, &p)
+	if p["content"] != "private note for alice" {
+		t.Fatalf("payload content lost: %v", p)
+	}
+}
+
+// TestFanout_DMSingleGrantor_RecipientReceives — the happy path under
+// the new recipient filter still works: exactly one grantor (Alice) has
+// a scope for peer Bob; Bob → Alice DM fans out to Alice's bot. Mirrors
+// TestFanout_DMPeerToGrantor_MatchesScope but explicitly named in the
+// R3 regression set so future readers see the multi-grantor and
+// single-grantor cases side by side.
+func TestFanout_DMSingleGrantor_RecipientReceives(t *testing.T) {
+	const peer = "bob"
+	ct := common.ChannelTypePerson.Uint8()
+	s := newFakeOBOStore()
+	gid, err := s.insertGrant(tGrantor, tBot, "auto")
+	if err != nil {
+		t.Fatalf("insertGrant: %v", err)
+	}
+	enable := 1
+	if err := s.updateGrant(gid, "", &enable); err != nil {
+		t.Fatalf("updateGrant: %v", err)
+	}
+	if _, err := s.insertScope(gid, peer, ct, 1); err != nil {
+		t.Fatalf("insertScope: %v", err)
+	}
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		return true, nil
+	}
+
+	msg := &config.MessageResp{
+		FromUID:     peer,
+		ChannelID:   tGrantor,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"hello yu"}`),
+	}
+	if n := ba.fanoutForMessage(msg); n != 1 {
+		t.Fatalf("single-grantor DM happy path: expected 1 fan-out, got %d", n)
+	}
+	if len(fc.copies) != 1 || fc.copies[0].Subscribers[0] != tBot {
+		t.Fatalf("single-grantor DM happy path: wrong dispatch, copies=%+v", fc.copies)
+	}
+}
+
+// TestFanout_DMNonRecipient_NoLeak — edge case for the R3 recipient
+// filter: a grant exists whose grantor is NOT the DM recipient, but
+// access re-check would otherwise allow it. The filter must drop the
+// non-recipient grant BEFORE the access check fires, so the access
+// override is intentionally rigged to fail the test if it gets called
+// for the wrong grantor.
+//
+// Setup: Carol scopes peer Bob (Carol ↔ Bob are friends). Bob then
+// DMs Alice (a different user, who has NO grant). The fan-out lookup
+// returns Carol's grant (scope is keyed by peer=Bob). The filter must
+// drop it because Carol is not the recipient (Alice is, and Alice
+// doesn't even have a grant).
+func TestFanout_DMNonRecipient_NoLeak(t *testing.T) {
+	const (
+		peer     = "bob"
+		aliceUID = "user_alice_no_grant"
+		carolUID = "user_carol"
+		carolBot = "bot_carol_clone"
+	)
+	ct := common.ChannelTypePerson.Uint8()
+
+	s := newFakeOBOStore()
+	gidCarol, err := s.insertGrant(carolUID, carolBot, "auto")
+	if err != nil {
+		t.Fatalf("insertGrant carol: %v", err)
+	}
+	enable := 1
+	if err := s.updateGrant(gidCarol, "", &enable); err != nil {
+		t.Fatalf("updateGrant carol: %v", err)
+	}
+	if _, err := s.insertScope(gidCarol, peer, ct, 1); err != nil {
+		t.Fatalf("insertScope carol: %v", err)
+	}
+
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+	// If the access check fires here, the recipient filter leaked —
+	// surface that as a hard failure rather than a silent "0 dispatches"
+	// (which could mask a regression where a later gate happens to
+	// catch it).
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		t.Errorf("non-recipient grant reached the access check; filter must drop earlier (uid=%q chan=%q)", uid, channelID)
+		return true, nil
+	}
+
+	// Bob → Alice DM (recipient = Alice, who has NO grant).
+	msg := &config.MessageResp{
+		FromUID:     peer,
+		ChannelID:   aliceUID,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"for alice only"}`),
+	}
+	if n := ba.fanoutForMessage(msg); n != 0 {
+		t.Fatalf("non-recipient grant must not fan out, got %d", n)
+	}
+	if len(fc.copies) != 0 {
+		t.Fatalf("non-recipient grant leaked: captured %d copies, expected 0", len(fc.copies))
+	}
+}

--- a/modules/bot_api/obo_fanout_test.go
+++ b/modules/bot_api/obo_fanout_test.go
@@ -769,7 +769,101 @@ func TestFanout_DMNonRecipient_NoLeak(t *testing.T) {
 	}
 }
 
-// assertFanoutDispatchContract enforces the WuKongIM /message/send mutex
+// TestFanout_OriginalSenderHasNoConversationLeak — PR#82 R6 P0 Bug A.
+// im-test 2026-05-19 surfaced that bob (the peer of an original DM
+// admin↔bob conversation) saw james (admin's persona-clone bot) appear
+// in his conversation list with the message he sent to admin. james
+// MUST be invisible to bob — that is the whole point of "managed
+// persona" (bob only ever sees admin as the counterparty).
+//
+// Root cause: the v0 fan-out copy used `FromUID=m.FromUID` (= bob), so
+// WuKongIM observed a (FromUID=bob, ChannelID=james) PERSONAL message
+// and synced the `bob ↔ james` conversation pair to bob's client.
+//
+// Fix: FromUID is the GRANTOR (admin), not the original sender. The
+// regression assertion is that NO fan-out copy ever carries
+// FromUID == original sender for any channel type. This locks the
+// invariant across the DM peer→grantor case (the actual reported bug)
+// AND every other channel type — a regression where group / topic
+// fan-outs use m.FromUID would similarly leak the bot into the original
+// sender's contacts via the same WuKongIM sync.
+func TestFanout_OriginalSenderHasNoConversationLeak(t *testing.T) {
+	cases := []struct {
+		name        string
+		ct          uint8
+		fromUID     string // original sender on the inbound message
+		channelID   string // ChannelID on the inbound message (listener view)
+		scope       string // OBO scope.channel_id (grantor frame of reference)
+		setupAccess func(ba *BotAPI)
+	}{
+		{
+			name:      "dm_peer_to_grantor",
+			ct:        common.ChannelTypePerson.Uint8(),
+			fromUID:   "u_bob",
+			channelID: tGrantor,
+			scope:     "u_bob", // for DM, scope.channel_id = peer uid
+		},
+		{
+			name:      "group",
+			ct:        common.ChannelTypeGroup.Uint8(),
+			fromUID:   "u_bob",
+			channelID: "group_42",
+			scope:     "group_42",
+		},
+		{
+			name:      "community_topic",
+			ct:        common.ChannelTypeCommunityTopic.Uint8(),
+			fromUID:   "u_bob",
+			channelID: "group_42____topic_99",
+			scope:     "group_42____topic_99",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := seedGrantWithScope(t, tc.scope, tc.ct)
+			fc := &fanoutCapture{}
+			ba := newBAforFanout(s, fc)
+
+			msg := &config.MessageResp{
+				FromUID:     tc.fromUID,
+				ChannelID:   tc.channelID,
+				ChannelType: tc.ct,
+				Payload:     []byte(`{"type":1,"content":"private to admin"}`),
+			}
+			if n := ba.fanoutForMessage(msg); n != 1 {
+				t.Fatalf("expected 1 dispatch, got %d", n)
+			}
+			if len(fc.copies) != 1 {
+				t.Fatalf("expected 1 captured copy, got %d", len(fc.copies))
+			}
+			cp := fc.copies[0]
+
+			// The bug-A assertion. If FromUID == original sender, WuKongIM
+			// will sync a `<sender> ↔ <granteeBot>` conversation pair to
+			// the sender's client and the bot leaks into the sender's
+			// contact list.
+			if cp.FromUID == tc.fromUID {
+				t.Fatalf("R6 P0 LEAK: fan-out FromUID == original sender %q — WuKongIM will surface the persona-clone bot %q in the sender's conversation list", tc.fromUID, tBot)
+			}
+			// Belt-and-braces: FromUID should be the grantor, which keeps
+			// the only synced conversation pair (`<grantor> ↔ <bot>`)
+			// scoped to a party who legitimately owns the bot.
+			if cp.FromUID != tGrantor {
+				t.Fatalf("fan-out FromUID should be grantor %q, got %q", tGrantor, cp.FromUID)
+			}
+			// And the bot still gets the original sender's uid via the
+			// payload field so it can address its reply to the right
+			// real user.
+			var p map[string]interface{}
+			_ = json.Unmarshal(cp.Payload, &p)
+			if got := p["obo_origin_from_uid"]; got != tc.fromUID {
+				t.Fatalf("obo_origin_from_uid must preserve the original sender %q for reply addressing, got %v", tc.fromUID, got)
+			}
+		})
+	}
+}
+
+
 // invariant: a MsgSendReq must carry EXACTLY ONE of (channel_id set with
 // empty subscribers) OR (empty channel_id with subscribers set). Setting
 // both triggers the production rejection observed in PR#82 R5 P0:
@@ -907,8 +1001,8 @@ func TestFanout_DispatchReq_NoConflict_ChannelOrSubscribers(t *testing.T) {
 //   - ChannelID == granteeBotUID
 //   - ChannelType == ChannelTypePerson (set by NewPersonalMsgSendReq)
 //   - Subscribers is empty
-//   - FromUID preserves the original sender's uid (so the bot's
-//     payload-side handlers can identify who spoke)
+//   - FromUID == GRANTOR uid (PR#82 R6 P0 — NOT the original sender;
+//     the bot learns the real speaker via obo_origin_from_uid)
 //   - obo_origin_* payload fields preserve the routing context
 func TestFanout_DispatchReq_BotReceivesViaOwnChannel(t *testing.T) {
 	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
@@ -942,8 +1036,13 @@ func TestFanout_DispatchReq_BotReceivesViaOwnChannel(t *testing.T) {
 	if len(cp.Subscribers) != 0 {
 		t.Fatalf("Subscribers must be omitted (mutex with channel_id), got %v", cp.Subscribers)
 	}
-	if cp.FromUID != "u_bob" {
-		t.Fatalf("FromUID should preserve origin sender %q, got %q", "u_bob", cp.FromUID)
+	// PR#82 R6 P0 — FromUID must be the GRANTOR, not the original sender.
+	// Using the original sender (m.FromUID = u_bob) made WuKongIM sync a
+	// u_bob ↔ bot_clone conversation entry to bob's client, leaking the
+	// persona-clone bot into bob's contact list. The grantor (admin) is
+	// the bot's owner and the only party who should see the bot.
+	if cp.FromUID != tGrantor {
+		t.Fatalf("FromUID should be grantor %q (PR#82 R6 P0 — NOT the original sender), got %q", tGrantor, cp.FromUID)
 	}
 
 	var p map[string]interface{}
@@ -957,6 +1056,9 @@ func TestFanout_DispatchReq_BotReceivesViaOwnChannel(t *testing.T) {
 	if got, _ := p["obo_origin_channel_type"].(float64); uint8(got) != ct {
 		t.Fatalf("obo_origin_channel_type should be %d, got %v", ct, p["obo_origin_channel_type"])
 	}
+	// obo_origin_from_uid carries the ORIGINAL sender so the bot can
+	// address replies / reactions to the right user — this is the
+	// substitute for the now-rewritten FromUID.
 	if got := p["obo_origin_from_uid"]; got != "u_bob" {
 		t.Fatalf("obo_origin_from_uid should be %q, got %v", "u_bob", got)
 	}

--- a/modules/bot_api/obo_fanout_test.go
+++ b/modules/bot_api/obo_fanout_test.go
@@ -155,12 +155,18 @@ func TestFanout_Gate2_GrantorOwnOutbound(t *testing.T) {
 }
 
 // TestFanout_Gate3_AlreadyOBOProcessed — message_extra has
-// obo_processed=true (set by sendMessage when on_behalf_of was honored).
+// __obo_processed__=true (set by sendMessage when on_behalf_of was honored).
 // This is the loop guard that breaks the cycle "bot replies → reply is
 // observed → bot replies again". The marker must be respected even if
 // the FromUID looks like a random user (since FromUID = grantor when OBO
 // fires — already covered by gate 2 — but also defensive against future
 // callers that set the marker without flipping FromUID).
+//
+// PR#82 review #2 P1-2 — marker key migrated from `obo_processed` to the
+// reserved-namespace `__obo_processed__` so a malicious bot can't suppress
+// its own fan-out via a hand-crafted payload. The inbound payload
+// validator rejects any `__obo_*` key on /v1/bot/sendMessage, leaving the
+// marker as server-only state.
 func TestFanout_Gate3_AlreadyOBOProcessed(t *testing.T) {
 	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
 	s := seedGrantWithScope(t, ch, ct)
@@ -173,13 +179,38 @@ func TestFanout_Gate3_AlreadyOBOProcessed(t *testing.T) {
 		FromUID:     "alice",
 		ChannelID:   ch,
 		ChannelType: ct,
-		Payload:     []byte(`{"type":1,"content":"bot reply","obo_processed":true}`),
+		Payload:     []byte(`{"type":1,"content":"bot reply","__obo_processed__":true}`),
 	}
 	if n := ba.fanoutForMessage(msg); n != 0 {
-		t.Fatalf("gate 3 (obo_processed marker) violated: dispatched %d", n)
+		t.Fatalf("gate 3 (__obo_processed__ marker) violated: dispatched %d", n)
 	}
 	if len(fc.copies) != 0 {
 		t.Fatalf("captured %d copies, expected 0", len(fc.copies))
+	}
+}
+
+// TestFanout_Gate3_LegacyMarkerIgnored — the v0-era `obo_processed` key
+// (no underscores) is NOT recognized as a marker after the PR#82 hardening
+// — the gate only honors the reserved-namespace `__obo_processed__` key.
+// Confirms that a bot crafting the legacy field on its own payload no
+// longer suppresses fan-out.
+func TestFanout_Gate3_LegacyMarkerIgnored(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantWithScope(t, ch, ct)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"forged","obo_processed":true}`),
+	}
+	if n := ba.fanoutForMessage(msg); n != 1 {
+		t.Fatalf("legacy obo_processed marker must NOT short-circuit gate 3, want fan-out=1 got %d", n)
+	}
+	if len(fc.copies) != 1 {
+		t.Fatalf("captured %d copies, expected 1", len(fc.copies))
 	}
 }
 
@@ -214,7 +245,8 @@ func TestFanout_NilOrEmptyMessage(t *testing.T) {
 
 // TestHasOBOProcessedMarker_Variants — exercises the JSON decode path
 // shared by gate 3 directly so failures here pinpoint the marker logic
-// rather than the surrounding fan-out plumbing.
+// rather than the surrounding fan-out plumbing. Marker key is the
+// reserved-namespace `__obo_processed__` (PR#82 review #2 P1-2).
 func TestHasOBOProcessedMarker_Variants(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -224,15 +256,42 @@ func TestHasOBOProcessedMarker_Variants(t *testing.T) {
 		{"empty", "", false},
 		{"non-json", "not json at all", false},
 		{"json no marker", `{"type":1}`, false},
-		{"marker true", `{"obo_processed":true}`, true},
-		{"marker false", `{"obo_processed":false}`, false},
-		{"marker not bool", `{"obo_processed":"yes"}`, false},
-		{"marker mixed in", `{"type":1,"content":"hi","obo_processed":true}`, true},
+		{"marker true", `{"__obo_processed__":true}`, true},
+		{"marker false", `{"__obo_processed__":false}`, false},
+		{"marker not bool", `{"__obo_processed__":"yes"}`, false},
+		{"marker mixed in", `{"type":1,"content":"hi","__obo_processed__":true}`, true},
+		{"legacy key ignored", `{"obo_processed":true}`, false},
 	}
 	for _, tc := range cases {
 		got := hasOBOProcessedMarker([]byte(tc.payload))
 		if got != tc.want {
 			t.Errorf("%s: hasOBOProcessedMarker(%q) = %v, want %v", tc.name, tc.payload, got, tc.want)
+		}
+	}
+}
+
+// TestPayloadHasReservedOBOKey — direct unit test for the inbound-payload
+// validator that rejects `__obo_*` keys on /v1/bot/sendMessage. Mirrors
+// the gate-3 marker move: the inbound side strips off anything in the
+// reserved namespace so a bot can't forge server-only OBO state.
+func TestPayloadHasReservedOBOKey(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload map[string]interface{}
+		want    bool
+	}{
+		{"empty", map[string]interface{}{}, false},
+		{"plain", map[string]interface{}{"type": 1, "content": "hi"}, false},
+		{"single underscore not reserved", map[string]interface{}{"_obo_internal": true}, false},
+		{"legacy obo_processed not reserved", map[string]interface{}{"obo_processed": true}, false},
+		{"the marker itself", map[string]interface{}{"__obo_processed__": true}, true},
+		{"any double-underscore obo key", map[string]interface{}{"__obo_anything__": "x"}, true},
+		{"mixed in", map[string]interface{}{"type": 1, "__obo_marker": false}, true},
+	}
+	for _, tc := range cases {
+		got := payloadHasReservedOBOKey(tc.payload)
+		if got != tc.want {
+			t.Errorf("%s: payloadHasReservedOBOKey(%v) = %v, want %v", tc.name, tc.payload, got, tc.want)
 		}
 	}
 }

--- a/modules/bot_api/obo_fanout_test.go
+++ b/modules/bot_api/obo_fanout_test.go
@@ -1,0 +1,238 @@
+// Package bot_api · YUJ-1166 — Unit tests for the fan-out listener.
+//
+// Each of the three loop-protection gates (RFC §5.3) has a dedicated test
+// asserting it short-circuits BEFORE dispatching to the grantee bot, plus
+// a happy-path test confirming a regular inbound is fanned out.
+//
+// Test surface: fanoutForMessage (single-message entry) + oboFanoutDispatch
+// hook (captures the constructed copies for assertions).
+package bot_api
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+)
+
+// fanoutCapture collects every MsgSendReq the fan-out path would have
+// dispatched. Used by all tests below.
+type fanoutCapture struct {
+	mu     sync.Mutex
+	copies []*config.MsgSendReq
+}
+
+func (fc *fanoutCapture) hook(req *config.MsgSendReq) error {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	cp := *req
+	if req.Payload != nil {
+		buf := make([]byte, len(req.Payload))
+		copy(buf, req.Payload)
+		cp.Payload = buf
+	}
+	fc.copies = append(fc.copies, &cp)
+	return nil
+}
+
+// seedGrantWithScope is the shared setup: yu has an active grant to
+// bot_clone, scoped to the test channel.
+func seedGrantWithScope(t *testing.T, ch string, ct uint8) *fakeOBOStore {
+	t.Helper()
+	s := newFakeOBOStore()
+	gid, err := s.insertGrant(tGrantor, tBot, "auto")
+	if err != nil {
+		t.Fatalf("insertGrant: %v", err)
+	}
+	enable := 1
+	if err := s.updateGrant(gid, "", &enable); err != nil {
+		t.Fatalf("updateGrant: %v", err)
+	}
+	if _, err := s.insertScope(gid, ch, ct, 1); err != nil {
+		t.Fatalf("insertScope: %v", err)
+	}
+	return s
+}
+
+func newBAforFanout(s *fakeOBOStore, fc *fanoutCapture) *BotAPI {
+	return &BotAPI{
+		Log:               log.NewTLog("BotAPI-fanout-test"),
+		oboStoreOverride:  s,
+		oboFanoutDispatch: fc.hook,
+	}
+}
+
+// TestFanout_Happy — a non-bot, non-grantor user sends into a scoped
+// channel. The bot receives exactly one fan-out copy with Subscribers
+// limited to it and the original payload preserved.
+func TestFanout_Happy(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantWithScope(t, ch, ct)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     "alice", // some random sender, NOT bot, NOT grantor
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"hello yu"}`),
+	}
+	got := ba.fanoutForMessage(msg)
+	if got != 1 {
+		t.Fatalf("expected 1 fan-out, got %d", got)
+	}
+	if len(fc.copies) != 1 {
+		t.Fatalf("expected 1 captured copy, got %d", len(fc.copies))
+	}
+	cp := fc.copies[0]
+	if len(cp.Subscribers) != 1 || cp.Subscribers[0] != tBot {
+		t.Fatalf("subscribers should be [%s], got %v", tBot, cp.Subscribers)
+	}
+	if cp.Header.NoPersist != 1 || cp.Header.RedDot != 0 {
+		t.Fatalf("fan-out must be silent (NoPersist=1, RedDot=0), got %+v", cp.Header)
+	}
+	// Sanity-check augmented payload preserved original keys.
+	var got2 map[string]interface{}
+	_ = json.Unmarshal(cp.Payload, &got2)
+	if got2["content"] != "hello yu" {
+		t.Fatalf("payload content lost: %v", got2)
+	}
+	if v, _ := got2["obo_fanout"].(bool); !v {
+		t.Fatalf("payload should be marked obo_fanout=true: %v", got2)
+	}
+}
+
+// TestFanout_Gate1_BotSelfSent — a message whose FromUID == grantee bot
+// must NOT be fanned back to that same bot (loop guard #1).
+//
+// Note: this is distinct from gate #3 (the obo_processed marker). Gate 1
+// covers cases where the bot sends WITHOUT going through OBO (e.g. bot
+// posts a status update as itself in a channel that has an active grant).
+func TestFanout_Gate1_BotSelfSent(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantWithScope(t, ch, ct)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     tBot, // bot sent it itself
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"bot status update"}`),
+	}
+	if n := ba.fanoutForMessage(msg); n != 0 {
+		t.Fatalf("gate 1 (bot self-sent) violated: dispatched %d copies", n)
+	}
+	if len(fc.copies) != 0 {
+		t.Fatalf("captured %d copies, expected 0", len(fc.copies))
+	}
+}
+
+// TestFanout_Gate2_GrantorOwnOutbound — the grantor sent the message
+// (from any of their devices). The bot must NOT see it (loop guard #2),
+// otherwise the bot would observe "I said X" and might autoreply.
+func TestFanout_Gate2_GrantorOwnOutbound(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantWithScope(t, ch, ct)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     tGrantor, // yu typing on his own phone
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"hi everyone"}`),
+	}
+	if n := ba.fanoutForMessage(msg); n != 0 {
+		t.Fatalf("gate 2 (grantor outbound) violated: dispatched %d copies", n)
+	}
+	if len(fc.copies) != 0 {
+		t.Fatalf("captured %d copies, expected 0", len(fc.copies))
+	}
+}
+
+// TestFanout_Gate3_AlreadyOBOProcessed — message_extra has
+// obo_processed=true (set by sendMessage when on_behalf_of was honored).
+// This is the loop guard that breaks the cycle "bot replies → reply is
+// observed → bot replies again". The marker must be respected even if
+// the FromUID looks like a random user (since FromUID = grantor when OBO
+// fires — already covered by gate 2 — but also defensive against future
+// callers that set the marker without flipping FromUID).
+func TestFanout_Gate3_AlreadyOBOProcessed(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantWithScope(t, ch, ct)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	// FromUID intentionally NOT the bot and NOT the grantor — only the
+	// marker should keep this from fanning out.
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"bot reply","obo_processed":true}`),
+	}
+	if n := ba.fanoutForMessage(msg); n != 0 {
+		t.Fatalf("gate 3 (obo_processed marker) violated: dispatched %d", n)
+	}
+	if len(fc.copies) != 0 {
+		t.Fatalf("captured %d copies, expected 0", len(fc.copies))
+	}
+}
+
+// TestFanout_NoGrantsForChannel — channel has no scope row → no DB JOIN
+// match → 0 dispatches. This is the common case on most messages.
+func TestFanout_NoGrantsForChannel(t *testing.T) {
+	s := newFakeOBOStore()
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   "unrelated_channel",
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		Payload:     []byte(`{"type":1,"content":"hi"}`),
+	}
+	if n := ba.fanoutForMessage(msg); n != 0 {
+		t.Fatalf("unscoped channel should not fan out, got %d", n)
+	}
+}
+
+// TestFanout_NilOrEmptyMessage — defensive: nil or empty channel → no-op.
+func TestFanout_NilOrEmptyMessage(t *testing.T) {
+	ba := newBAforFanout(newFakeOBOStore(), &fanoutCapture{})
+	if n := ba.fanoutForMessage(nil); n != 0 {
+		t.Fatalf("nil message should be no-op, got %d", n)
+	}
+	if n := ba.fanoutForMessage(&config.MessageResp{}); n != 0 {
+		t.Fatalf("empty-channel message should be no-op, got %d", n)
+	}
+}
+
+// TestHasOBOProcessedMarker_Variants — exercises the JSON decode path
+// shared by gate 3 directly so failures here pinpoint the marker logic
+// rather than the surrounding fan-out plumbing.
+func TestHasOBOProcessedMarker_Variants(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		want    bool
+	}{
+		{"empty", "", false},
+		{"non-json", "not json at all", false},
+		{"json no marker", `{"type":1}`, false},
+		{"marker true", `{"obo_processed":true}`, true},
+		{"marker false", `{"obo_processed":false}`, false},
+		{"marker not bool", `{"obo_processed":"yes"}`, false},
+		{"marker mixed in", `{"type":1,"content":"hi","obo_processed":true}`, true},
+	}
+	for _, tc := range cases {
+		got := hasOBOProcessedMarker([]byte(tc.payload))
+		if got != tc.want {
+			t.Errorf("%s: hasOBOProcessedMarker(%q) = %v, want %v", tc.name, tc.payload, got, tc.want)
+		}
+	}
+}

--- a/modules/bot_api/obo_friend_gate.go
+++ b/modules/bot_api/obo_friend_gate.go
@@ -1,0 +1,163 @@
+// Package bot_api · YUJ-1166 — PR#82 R6 P0 friend-gate OBO bypass.
+//
+// Background: the bot send / typing / readReceipt / messages-sync paths
+// require the bot to be a friend of the target user (BotKindUser DM
+// branch). That rule is correct for "bot user is talking directly to
+// you" — the user must opt in.
+//
+// It is **wrong** for the managed-persona / OBO path. When admin
+// grants the persona-clone bot james OBO authority over the DM pair
+// admin↔bob, bob has chosen to DM admin (not james); admin's clone is
+// expected to reply as admin. Requiring a `bot↔bob` friend row would
+// either:
+//
+//  1. force the server to silently fabricate the friendship behind the
+//     real user's back — leaking the bot's existence to bob (R6 P0 Bug A
+//     in reverse: bob sees bot as a contact), OR
+//  2. block every managed-persona reply with `bot is not a friend of
+//     this user` — which is what im-test 2026-05-19 surfaced for james.
+//
+// The fix is a server-side **implicit** bypass: when the friend gate
+// would reject a DM send, we check whether an active OBO grant
+// authorises the bot to operate as some grantor in that channel, and
+// the grantor still has a valid relation with the target. If so, the
+// friendship requirement is satisfied transitively by the grantor's
+// relation — the bot is acting as the grantor, the grantor is friends
+// with the target, so the send is legitimate.
+//
+// Why implicit (instead of an `on_behalf_of` header on typing /
+// readReceipt): the bot adapter is the only caller and it already
+// signals OBO context for the actual message via `on_behalf_of`. typing
+// and readReceipt are side-channel signals tied to the same OBO
+// session; routing them through the same explicit field would require
+// matched changes in every adapter (octo-server fix should be
+// self-contained per the issue out-of-scope list). The implicit bypass
+// only fires when an active OBO grant + scope already exists, so it
+// cannot bypass anything a legitimate OBO send couldn't already do.
+//
+// Hot-path cost: one cached `findActiveGrantsForChannel` lookup (the
+// same one the fan-out listener consults — already negative-cached via
+// `obo:chan:*`) PLUS a per-matching-grant `grantorCanReadChannel`
+// re-check. For the common case (no OBO grant covers the target
+// channel), the negative cache makes this a single Redis GET.
+package bot_api
+
+import (
+	"go.uber.org/zap"
+)
+
+// hasOBOAccessToChannel reports whether bot `botUID` has any active OBO
+// grant covering (channelID, channelType) where the grantor still has
+// live read access to that channel. Used by the friend gate
+// (checkSendPermission / syncMessages) to bypass the bot↔user
+// friendship requirement on the managed-persona OBO send path.
+//
+// Returns:
+//
+//   - (true,  nil) → bypass applies; caller should treat the friend
+//     gate as satisfied for the (botUID, channelID, channelType) tuple.
+//   - (false, nil) → no bypass; the friend gate continues to apply.
+//   - (false, err) → DB / cache failure on the lookup itself. Callers
+//     fail-closed (treat as no bypass) so a transient blip can never
+//     widen access.
+//
+// Contract notes:
+//   - For DMs the OBO scope row is keyed by the PEER uid in the
+//     grantor's frame of reference (see grantorCanReadChannel +
+//     fanoutLookupChannelID). When the bot sends a DM to bob,
+//     channelID == bob, which is the same key the scope row uses, so
+//     `findActiveGrantsForChannel(bob, Person)` returns every grant
+//     whose grantor scoped peer=bob.
+//   - The per-grant `grantorCanReadChannel` re-check closes the same
+//     TOCTOU window that checkOBO closes on the send hot path
+//     (PR#82 round-2 P1-A) — a stale scope row whose grantor was
+//     un-friended must NOT silently extend bot reach.
+func (ba *BotAPI) hasOBOAccessToChannel(botUID, channelID string, channelType uint8) (bool, error) {
+	if botUID == "" || channelID == "" {
+		return false, nil
+	}
+	store := ba.oboStoreOrDefault()
+	grants, err := store.findActiveGrantsForChannel(channelID, channelType)
+	if err != nil {
+		ba.Error("OBO friend-gate bypass lookup failed",
+			zap.String("bot", botUID),
+			zap.String("channel_id", channelID),
+			zap.Uint8("channel_type", channelType),
+			zap.Error(err))
+		return false, err
+	}
+	if len(grants) == 0 {
+		return false, nil
+	}
+	for _, g := range grants {
+		if g.GranteeBotUID != botUID {
+			// Other grantors' grants for the same channel don't
+			// authorize *this* bot. (A grant is scoped to one specific
+			// grantee bot per uk_grantor_grantee.)
+			continue
+		}
+		ok, err := ba.grantorCanReadChannel(g.GrantorUID, channelID, channelType)
+		if err != nil {
+			// Single grant's check errored — log and try the next.
+			// Don't propagate so that a transient blip on one
+			// grantor's row doesn't block a bypass that another
+			// grantor's row would satisfy.
+			ba.Warn("OBO friend-gate grantor access re-check failed; trying next grant",
+				zap.String("bot", botUID),
+				zap.String("grantor", g.GrantorUID),
+				zap.String("channel_id", channelID),
+				zap.Uint8("channel_type", channelType),
+				zap.Error(err))
+			continue
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// isFriendOrOBOBypass is the friend-gate decision used by the bot send
+// path's BotKindUser/ChannelTypePerson branch. It first asks the user
+// service whether bot↔target are friends (the original v0 rule); if
+// not, it falls back to the OBO implicit bypass.
+//
+// The two-step shape is intentional: the OBO bypass is the EXCEPTION,
+// not the rule. Most bots interact with users they ARE friends with
+// (DM apply flow), so we keep the hot path on the existing IsFriend
+// query and only consult the OBO lookup when the friend answer is no.
+//
+// Errors from IsFriend are surfaced verbatim — the caller treats them
+// as "permission verification failed". Errors from hasOBOAccessToChannel
+// are logged and converted to a `false` bypass answer (fail-closed) so
+// the original "not a friend" error is returned, preserving the
+// pre-fix behaviour when no OBO bypass would have applied anyway.
+//
+// Test seam: see friendCheckOverride on BotAPI.
+func (ba *BotAPI) isFriendOrOBOBypass(botUID, targetUID string, channelType uint8) (bool, error) {
+	isFriend, err := ba.isFriend(botUID, targetUID)
+	if err != nil {
+		return false, err
+	}
+	if isFriend {
+		return true, nil
+	}
+	// Not friends → try the OBO managed-persona implicit bypass.
+	bypass, _ := ba.hasOBOAccessToChannel(botUID, targetUID, channelType)
+	return bypass, nil
+}
+
+// isFriend wraps userService.IsFriend behind a test seam. Production
+// path delegates to ba.userService.IsFriend; unit tests inject
+// friendCheckOverride to assert on the call without standing up a
+// real user service. nil userService + nil override → (false, nil)
+// (fail-closed; the OBO bypass can still apply).
+func (ba *BotAPI) isFriend(uid, toUID string) (bool, error) {
+	if ba.friendCheckOverride != nil {
+		return ba.friendCheckOverride(uid, toUID)
+	}
+	if ba.userService == nil {
+		return false, nil
+	}
+	return ba.userService.IsFriend(uid, toUID)
+}

--- a/modules/bot_api/obo_friend_gate.go
+++ b/modules/bot_api/obo_friend_gate.go
@@ -17,29 +17,35 @@
 //  2. block every managed-persona reply with `bot is not a friend of
 //     this user` — which is what im-test 2026-05-19 surfaced for james.
 //
-// The fix is a server-side **implicit** bypass: when the friend gate
-// would reject a DM send, we check whether an active OBO grant
-// authorises the bot to operate as some grantor in that channel, and
-// the grantor still has a valid relation with the target. If so, the
-// friendship requirement is satisfied transitively by the grantor's
-// relation — the bot is acting as the grantor, the grantor is friends
-// with the target, so the send is legitimate.
+// The fix is a server-side conditional bypass: when the request
+// carries a validated OBO context (i.e. the bot is asking to dispatch
+// as a real grantor via the `on_behalf_of` field on sendMessage), and
+// the friend gate would otherwise reject the DM, we check whether an
+// active OBO grant authorises the bot to operate as some grantor in
+// that channel and the grantor still has a valid relation with the
+// target. If so, the friendship requirement is satisfied transitively
+// by the grantor's relation — the bot is acting as the grantor, the
+// grantor is friends with the target, so the send is legitimate.
 //
-// Why implicit (instead of an `on_behalf_of` header on typing /
-// readReceipt): the bot adapter is the only caller and it already
-// signals OBO context for the actual message via `on_behalf_of`. typing
-// and readReceipt are side-channel signals tied to the same OBO
-// session; routing them through the same explicit field would require
-// matched changes in every adapter (octo-server fix should be
-// self-contained per the issue out-of-scope list). The implicit bypass
-// only fires when an active OBO grant + scope already exists, so it
-// cannot bypass anything a legitimate OBO send couldn't already do.
+// PR#82 R7 — the bypass is **gated on the caller passing
+// hasOBOContext=true**. The bot adapter sets this when the inbound
+// request carries `on_behalf_of`; the actual `checkOBO` validation
+// (grant + scope + grantor-still-has-access) runs immediately after,
+// so a bot that lies about the header gets short-circuited there.
+// Critically, requests that omit `on_behalf_of` (sendMessage as the
+// bot itself, typing, readReceipt, messages/sync) MUST NOT consult
+// the OBO bypass — otherwise a bot with any unrelated grant covering
+// a target user could dispatch directly bot→target and expose itself
+// as a contact, defeating the user opt-in friend gate. See
+// Jerry-Xin's R7 review on head a07b372 for the regression details.
 //
-// Hot-path cost: one cached `findActiveGrantsForChannel` lookup (the
-// same one the fan-out listener consults — already negative-cached via
-// `obo:chan:*`) PLUS a per-matching-grant `grantorCanReadChannel`
-// re-check. For the common case (no OBO grant covers the target
-// channel), the negative cache makes this a single Redis GET.
+// Hot-path cost (only paid when hasOBOContext=true): one cached
+// `findActiveGrantsForChannel` lookup (the same one the fan-out
+// listener consults — already negative-cached via `obo:chan:*`) PLUS
+// a per-matching-grant `grantorCanReadChannel` re-check. For the
+// common case (no OBO grant covers the target channel) the negative
+// cache makes this a single Redis GET. Requests without OBO context
+// skip the bypass entirely and go straight back to `isFriend`.
 package bot_api
 
 import (
@@ -120,12 +126,24 @@ func (ba *BotAPI) hasOBOAccessToChannel(botUID, channelID string, channelType ui
 // isFriendOrOBOBypass is the friend-gate decision used by the bot send
 // path's BotKindUser/ChannelTypePerson branch. It first asks the user
 // service whether bot↔target are friends (the original v0 rule); if
-// not, it falls back to the OBO implicit bypass.
+// not, AND the caller signals a validated OBO context is present
+// (hasOBOContext=true), it falls back to the OBO conditional bypass.
 //
 // The two-step shape is intentional: the OBO bypass is the EXCEPTION,
 // not the rule. Most bots interact with users they ARE friends with
 // (DM apply flow), so we keep the hot path on the existing IsFriend
 // query and only consult the OBO lookup when the friend answer is no.
+//
+// PR#82 R7 — `hasOBOContext` is the **caller's pledge** that the
+// inbound request carries an `on_behalf_of` field that will be
+// independently validated by `checkOBO` on the send path. Without
+// that pledge, this function MUST behave exactly like a plain
+// IsFriend check — i.e. a bot calling sendMessage as itself (no
+// `on_behalf_of`), or invoking typing / readReceipt / messages-sync
+// (which have no on_behalf_of field at all), gets no bypass even if
+// it happens to hold an OBO grant for the channel. Otherwise such a
+// bot could send a direct bot→target DM without the user opt-in
+// (Jerry-Xin R7 finding on head a07b372).
 //
 // Errors from IsFriend are surfaced verbatim — the caller treats them
 // as "permission verification failed". Errors from hasOBOAccessToChannel
@@ -134,7 +152,7 @@ func (ba *BotAPI) hasOBOAccessToChannel(botUID, channelID string, channelType ui
 // pre-fix behaviour when no OBO bypass would have applied anyway.
 //
 // Test seam: see friendCheckOverride on BotAPI.
-func (ba *BotAPI) isFriendOrOBOBypass(botUID, targetUID string, channelType uint8) (bool, error) {
+func (ba *BotAPI) isFriendOrOBOBypass(botUID, targetUID string, channelType uint8, hasOBOContext bool) (bool, error) {
 	isFriend, err := ba.isFriend(botUID, targetUID)
 	if err != nil {
 		return false, err
@@ -142,7 +160,14 @@ func (ba *BotAPI) isFriendOrOBOBypass(botUID, targetUID string, channelType uint
 	if isFriend {
 		return true, nil
 	}
-	// Not friends → try the OBO managed-persona implicit bypass.
+	if !hasOBOContext {
+		// No validated OBO context on the request → the OBO bypass
+		// MUST NOT widen the friend gate. Returning here preserves
+		// the legacy "not a friend → deny" behaviour for plain bot
+		// sends, typing, readReceipt, and messages-sync paths.
+		return false, nil
+	}
+	// OBO context present → try the managed-persona conditional bypass.
 	bypass, _ := ba.hasOBOAccessToChannel(botUID, targetUID, channelType)
 	return bypass, nil
 }

--- a/modules/bot_api/obo_friend_gate_r7_http_test.go
+++ b/modules/bot_api/obo_friend_gate_r7_http_test.go
@@ -1,0 +1,209 @@
+// Package bot_api · PR#82 R7 — HTTP-level regression for the "no
+// bypass without OBO context" invariant.
+//
+// Jerry-Xin's R7 finding (2026-05-19 on head a07b372): the bypass in
+// `isFriendOrOBOBypass` was unconditional, so a bot that held any
+// active OBO grant covering a target could call sendMessage / typing /
+// readReceipt / messages-sync WITHOUT `on_behalf_of` and dispatch as
+// the bot itself — leaking the managed-persona bot as a direct contact
+// to a user that had not opted in.
+//
+// These tests build the full HTTP handler stack (sendMessage / typing /
+// readReceipt / syncMessages) with:
+//   - a bot that is NOT friends with the peer (friendCheckOverride → false)
+//   - an active OBO grant + scope covering (bot, peer)
+//   - no `on_behalf_of` on the request
+//
+// and assert that the gate denies. Pair tests assert the SAME fixture
+// with `on_behalf_of` set still passes the friend gate (the
+// managed-persona happy path), so the gate is gated by the request
+// context, not regressed across the board.
+package bot_api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/gin-gonic/gin"
+)
+
+// newBAforR7Test wires a BotAPI with:
+//   - fake OBO store with an enabled grant (admin, bot) scope=peer DM
+//   - oboChannelAccessOverride allowing admin to reach peer
+//   - friendCheckOverride returning false (bot NOT friends with peer)
+//   - dispatchOverride capture (so we can assert dispatch DID/DID NOT fire)
+//   - fakeSpaceQuerier so sendMessage's space_id resolve doesn't NPE
+func newBAforR7Test() (*BotAPI, *dispatchCapture) {
+	const (
+		admin = "user_admin"
+		bot   = "bot_clone_james"
+		peer  = "u_bob"
+	)
+	_ = admin
+	_ = bot
+	_ = peer
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant("user_admin", "bot_clone_james", "auto")
+	enable := 1
+	_ = s.updateGrant(gid, "", &enable)
+	_, _ = s.insertScope(gid, "u_bob", common.ChannelTypePerson.Uint8(), 1)
+
+	dc := &dispatchCapture{}
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-r7-http-test"),
+		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space_A"},
+		dispatchOverride: dc.hook,
+		oboStoreOverride: s,
+		oboChannelAccessOverride: func(uid, channelID string, channelType uint8) (bool, error) {
+			return uid == "user_admin" && channelID == "u_bob", nil
+		},
+		friendCheckOverride: func(uid, toUID string) (bool, error) {
+			return false, nil // bot NOT friends with peer
+		},
+	}
+	return ba, dc
+}
+
+// buildBotCtx assembles a *wkhttp.Context for the given *httptest.Recorder
+// and request body, with the BotKindUser auth markers + a non-creator
+// robot (creator != peer) so the DM-creator bypass does NOT fire and
+// the friend gate is forced to make the decision.
+func buildBotCtx(rec *httptest.ResponseRecorder, body []byte, path string) *wkhttp.Context {
+	httpReq := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httpReq
+	c := &wkhttp.Context{Context: gc}
+	c.Set(CtxKeyRobotID, "bot_clone_james")
+	c.Set(CtxKeyBotKind, BotKindUser)
+	// Creator != peer (peer = "u_bob"; creator = "user_admin") so the
+	// "isCreator" short-circuit in checkSendPermission / syncMessages
+	// does NOT fire and the friend gate runs.
+	c.Set(CtxKeyRobot, &robotModel{RobotID: "bot_clone_james", CreatorUID: "user_admin"})
+	return c
+}
+
+// TestBotAPI_FriendGate_NoBypassWithoutOBOContext — PR#82 R7 headline
+// regression for sendMessage. Bot not friends with peer, active grant
+// covers (bot, peer), but `on_behalf_of` is omitted → sendMessage MUST
+// deny with "bot is not a friend of this user" AND dispatch MUST NOT
+// fire (no leakage past the gate).
+func TestBotAPI_FriendGate_NoBypassWithoutOBOContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ba, dc := newBAforR7Test()
+
+	body, _ := json.Marshal(BotSendMessageReq{
+		ChannelID:   "u_bob",
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		// NO OnBehalfOf — this is the regression scenario.
+		Payload: map[string]interface{}{"content": "direct bot→bob send", "type": 1},
+	})
+	rec := httptest.NewRecorder()
+	c := buildBotCtx(rec, body, "/v1/bot/sendMessage")
+	ba.sendMessage(c)
+
+	if !strings.Contains(rec.Body.String(), "bot is not a friend of this user") {
+		t.Fatalf("PR#82 R7: sendMessage WITHOUT on_behalf_of must hit the friend-gate deny path even when an OBO grant covers the peer; got body=%s", rec.Body.String())
+	}
+	if dc.captured != nil {
+		t.Fatalf("PR#82 R7: dispatch must NOT fire when the friend gate denies; got %+v", dc.captured)
+	}
+}
+
+// TestBotAPI_FriendGate_NoBypassWithoutOBOContext_Typing — same
+// invariant for the typing path. Typing has no on_behalf_of field; the
+// bypass MUST never apply.
+func TestBotAPI_FriendGate_NoBypassWithoutOBOContext_Typing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ba, _ := newBAforR7Test()
+
+	body, _ := json.Marshal(BotTypingReq{
+		ChannelID:   "u_bob",
+		ChannelType: common.ChannelTypePerson.Uint8(),
+	})
+	rec := httptest.NewRecorder()
+	c := buildBotCtx(rec, body, "/v1/bot/typing")
+	ba.typing(c)
+
+	if !strings.Contains(rec.Body.String(), "bot is not a friend of this user") {
+		t.Fatalf("PR#82 R7: typing must hit the friend-gate deny path when bot↔peer not friends, even with OBO grant; got body=%s", rec.Body.String())
+	}
+}
+
+// TestBotAPI_FriendGate_NoBypassWithoutOBOContext_ReadReceipt — same
+// invariant for readReceipt.
+func TestBotAPI_FriendGate_NoBypassWithoutOBOContext_ReadReceipt(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ba, _ := newBAforR7Test()
+
+	body, _ := json.Marshal(BotReadReceiptReq{
+		ChannelID:   "u_bob",
+		ChannelType: common.ChannelTypePerson.Uint8(),
+	})
+	rec := httptest.NewRecorder()
+	c := buildBotCtx(rec, body, "/v1/bot/readReceipt")
+	ba.readReceipt(c)
+
+	if !strings.Contains(rec.Body.String(), "bot is not a friend of this user") {
+		t.Fatalf("PR#82 R7: readReceipt must hit the friend-gate deny path when bot↔peer not friends, even with OBO grant; got body=%s", rec.Body.String())
+	}
+}
+
+// TestBotAPI_FriendGate_NoBypassWithoutOBOContext_SyncMessages — same
+// invariant for messages/sync. messages/sync has no on_behalf_of
+// field; the bypass MUST never apply (the sync response stream goes
+// back to the bot, not proxied as the grantor).
+func TestBotAPI_FriendGate_NoBypassWithoutOBOContext_SyncMessages(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ba, _ := newBAforR7Test()
+
+	body, _ := json.Marshal(BotSyncMessagesReq{
+		ChannelID:   "u_bob",
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Limit:       50,
+	})
+	rec := httptest.NewRecorder()
+	c := buildBotCtx(rec, body, "/v1/bot/messages/sync")
+	ba.syncMessages(c)
+
+	if !strings.Contains(rec.Body.String(), "bot is not a friend of this user") {
+		t.Fatalf("PR#82 R7: messages/sync must hit the friend-gate deny path when bot↔peer not friends, even with OBO grant; got body=%s", rec.Body.String())
+	}
+}
+
+// TestBotAPI_FriendGate_BypassAppliesWhenOBOContextPresent_SendMessage —
+// companion to the negative tests above: the SAME fixture but with
+// `on_behalf_of` set MUST pass the friend gate (managed-persona happy
+// path). This locks in that the only delta between deny and allow is
+// the presence of validated OBO context on the request.
+func TestBotAPI_FriendGate_BypassAppliesWhenOBOContextPresent_SendMessage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ba, dc := newBAforR7Test()
+
+	body, _ := json.Marshal(BotSendMessageReq{
+		ChannelID:   "u_bob",
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		OnBehalfOf:  "user_admin", // managed-persona send as admin
+		Payload:     map[string]interface{}{"content": "hi bob, it's me admin", "type": 1},
+	})
+	rec := httptest.NewRecorder()
+	c := buildBotCtx(rec, body, "/v1/bot/sendMessage")
+	ba.sendMessage(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("managed-persona send (with on_behalf_of) must pass the gate; status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if dc.captured == nil {
+		t.Fatal("managed-persona send must dispatch; dispatch capture empty")
+	}
+	if dc.captured.FromUID != "user_admin" {
+		t.Errorf("OBO substitution: FromUID should be user_admin (grantor), got %q", dc.captured.FromUID)
+	}
+}

--- a/modules/bot_api/obo_friend_gate_test.go
+++ b/modules/bot_api/obo_friend_gate_test.go
@@ -278,7 +278,7 @@ func TestIsFriendOrOBOBypass_FriendsShortCircuits(t *testing.T) {
 		},
 	}
 
-	ok, err := ba.isFriendOrOBOBypass("bot_clone", "u_bob", common.ChannelTypePerson.Uint8())
+	ok, err := ba.isFriendOrOBOBypass("bot_clone", "u_bob", common.ChannelTypePerson.Uint8(), true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -323,7 +323,7 @@ func TestIsFriendOrOBOBypass_NotFriendsButOBOApplies(t *testing.T) {
 		},
 	}
 
-	ok, err := ba.isFriendOrOBOBypass(bot, peer, ct)
+	ok, err := ba.isFriendOrOBOBypass(bot, peer, ct, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestIsFriendOrOBOBypass_NotFriendsNoOBO_Denies(t *testing.T) {
 		},
 	}
 
-	ok, err := ba.isFriendOrOBOBypass("bot_clone", "u_bob", common.ChannelTypePerson.Uint8())
+	ok, err := ba.isFriendOrOBOBypass("bot_clone", "u_bob", common.ChannelTypePerson.Uint8(), true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -371,7 +371,7 @@ func TestIsFriendOrOBOBypass_FriendErrorSurfaces(t *testing.T) {
 		},
 	}
 
-	ok, err := ba.isFriendOrOBOBypass("bot_clone", "u_bob", common.ChannelTypePerson.Uint8())
+	ok, err := ba.isFriendOrOBOBypass("bot_clone", "u_bob", common.ChannelTypePerson.Uint8(), true)
 	if !errors.Is(err, boom) {
 		t.Fatalf("IsFriend error must propagate; got err=%v ok=%v", err, ok)
 	}
@@ -386,4 +386,89 @@ func TestIsFriendOrOBOBypass_FriendErrorSurfaces(t *testing.T) {
 // number finds the test directly.
 func TestBotAPI_FriendGate_BypassedForOBOContext(t *testing.T) {
 	TestIsFriendOrOBOBypass_NotFriendsButOBOApplies(t)
+}
+
+// TestIsFriendOrOBOBypass_NoOBOContext_GrantsIgnored — PR#82 R7
+// regression (Jerry-Xin head a07b372). Bot is NOT friend of peer, an
+// active OBO grant covers (bot, peer) — but the caller passes
+// hasOBOContext=false (e.g. sendMessage without `on_behalf_of`, or
+// typing / readReceipt / messages-sync which have no on_behalf_of
+// field at all). The bypass MUST NOT fire — otherwise the bot could
+// reach peer directly bot→peer, defeating the user opt-in friend
+// gate and exposing the managed-persona bot as a contact.
+func TestIsFriendOrOBOBypass_NoOBOContext_GrantsIgnored(t *testing.T) {
+	const (
+		admin = "user_admin"
+		bot   = "bot_clone_james"
+		peer  = "u_bob"
+	)
+	ct := common.ChannelTypePerson.Uint8()
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(admin, bot, "auto")
+	enable := 1
+	_ = s.updateGrant(gid, "", &enable)
+	_, _ = s.insertScope(gid, peer, ct, 1)
+
+	bypassConsulted := false
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-r7-no-ctx-test"),
+		oboStoreOverride: s,
+		oboChannelAccessOverride: func(uid, channelID string, channelType uint8) (bool, error) {
+			// If this fires the bypass was reached — which is exactly
+			// the bug we are guarding against.
+			bypassConsulted = true
+			return true, nil
+		},
+		friendCheckOverride: func(uid, toUID string) (bool, error) {
+			return false, nil // bot is NOT friends with peer
+		},
+	}
+
+	ok, err := ba.isFriendOrOBOBypass(bot, peer, ct, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatalf("PR#82 R7: hasOBOContext=false MUST NOT permit bypass even when a grant exists — bot would reach peer without opt-in")
+	}
+	if bypassConsulted {
+		t.Fatalf("PR#82 R7: hasOBOAccessToChannel must NOT be consulted when hasOBOContext=false (perf + invariant)")
+	}
+}
+
+// TestIsFriendOrOBOBypass_OBOContextTrue_BypassApplies — companion of
+// the negative test above. Same fixture (bot not friend, grant
+// exists) but hasOBOContext=true → bypass fires. Locks in that the
+// only delta between allow and deny is the caller's OBO-context flag.
+func TestIsFriendOrOBOBypass_OBOContextTrue_BypassApplies(t *testing.T) {
+	const (
+		admin = "user_admin"
+		bot   = "bot_clone_james"
+		peer  = "u_bob"
+	)
+	ct := common.ChannelTypePerson.Uint8()
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(admin, bot, "auto")
+	enable := 1
+	_ = s.updateGrant(gid, "", &enable)
+	_, _ = s.insertScope(gid, peer, ct, 1)
+
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-r7-with-ctx-test"),
+		oboStoreOverride: s,
+		oboChannelAccessOverride: func(uid, channelID string, channelType uint8) (bool, error) {
+			return uid == admin && channelID == peer, nil
+		},
+		friendCheckOverride: func(uid, toUID string) (bool, error) {
+			return false, nil
+		},
+	}
+
+	ok, err := ba.isFriendOrOBOBypass(bot, peer, ct, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("hasOBOContext=true + valid grant → bypass must fire (parity with R6 P0 fix)")
+	}
 }

--- a/modules/bot_api/obo_friend_gate_test.go
+++ b/modules/bot_api/obo_friend_gate_test.go
@@ -1,0 +1,389 @@
+// Package bot_api · YUJ-1166 — PR#82 R6 P0 friend-gate OBO bypass tests.
+//
+// The fixture matrix covers the four states the gate can resolve to:
+//
+//	|                          | bot↔target friends | not friends |
+//	|--------------------------|--------------------|-------------|
+//	| no OBO grant covers      |          ALLOW     |    DENY     |
+//	| active OBO grant covers  |          ALLOW     |    ALLOW    |  ← bypass
+//	| stale OBO scope (kicked) |          ALLOW     |    DENY     |  ← TOCTOU
+//
+// The "ALLOW (bypass)" cell is the new R6 P0 behaviour. The TOCTOU row
+// asserts the bypass closes on grantor access loss — same invariant
+// checkOBO enforces on the send hot path (PR#82 round-2 P1-A).
+//
+// We test the helper directly (hasOBOAccessToChannel +
+// isFriendOrOBOBypass) so the test surface is decoupled from the HTTP
+// handler plumbing. A separate integration test in
+// obo_send_test.go would re-verify the full sendMessage / typing /
+// readReceipt path; here we lock in the gate logic itself.
+package bot_api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+)
+
+// newBAforFriendGate wires a BotAPI minimally for the friend-gate
+// helper tests: in-memory oboStore + injectable friend / channel-access
+// overrides. No userService / DB needed.
+func newBAforFriendGate(s *fakeOBOStore) *BotAPI {
+	return &BotAPI{
+		Log:              log.NewTLog("BotAPI-friend-gate-test"),
+		oboStoreOverride: s,
+		// Default channel-access override: grantor still has access.
+		// Individual tests override this for the TOCTOU case.
+		oboChannelAccessOverride: func(uid, channelID string, channelType uint8) (bool, error) {
+			return true, nil
+		},
+	}
+}
+
+// TestHasOBOAccessToChannel_NoGrants — common case: nothing covers this
+// (bot, channel) pair → no bypass. The negative-cache friendly path
+// the production deployment is optimised for.
+func TestHasOBOAccessToChannel_NoGrants(t *testing.T) {
+	s := newFakeOBOStore()
+	ba := newBAforFriendGate(s)
+
+	ok, err := ba.hasOBOAccessToChannel("bot_clone", "u_bob", common.ChannelTypePerson.Uint8())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatalf("no grant covers (bot_clone, u_bob); bypass must NOT apply")
+	}
+}
+
+// TestHasOBOAccessToChannel_DM_GrantorHasFriendship_ApplyBypass —
+// PR#82 R6 P0 Bug B happy path. admin grants OBO to james with
+// scope=peer=u_bob; admin is friends with u_bob; james must therefore
+// be allowed to send/typing/readReceipt to u_bob via the bypass even
+// though james↔u_bob is NOT a friend pair.
+func TestHasOBOAccessToChannel_DM_GrantorHasFriendship_ApplyBypass(t *testing.T) {
+	const (
+		admin   = "user_admin"
+		bot     = "bot_clone_james"
+		peer    = "u_bob"
+	)
+	ct := common.ChannelTypePerson.Uint8()
+	s := newFakeOBOStore()
+	gid, err := s.insertGrant(admin, bot, "auto")
+	if err != nil {
+		t.Fatalf("insertGrant: %v", err)
+	}
+	enable := 1
+	if err := s.updateGrant(gid, "", &enable); err != nil {
+		t.Fatalf("updateGrant: %v", err)
+	}
+	if _, err := s.insertScope(gid, peer, ct, 1); err != nil {
+		t.Fatalf("insertScope: %v", err)
+	}
+	ba := newBAforFriendGate(s)
+	// Verify the access check is queried with grantor=admin and
+	// channel_id=peer (i.e. the function passes through the right
+	// frame of reference, not some bot-keyed nonsense).
+	calls := 0
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		calls++
+		if uid != admin || channelID != peer || channelType != ct {
+			t.Errorf("access override called with wrong args: uid=%q chan=%q type=%d (want admin=%q peer=%q)", uid, channelID, channelType, admin, peer)
+		}
+		return true, nil
+	}
+
+	ok, err := ba.hasOBOAccessToChannel(bot, peer, ct)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("admin grants OBO + admin friends with peer → bypass must apply")
+	}
+	if calls != 1 {
+		t.Fatalf("expected one access re-check (per matching grant), got %d", calls)
+	}
+}
+
+// TestHasOBOAccessToChannel_DM_GrantorLostAccess_NoBypass — TOCTOU
+// regression. The scope row is still on file, but the grantor is no
+// longer friends with the peer. Bypass must NOT apply — otherwise the
+// bot keeps reaching a user the grantor can no longer themselves
+// reach, defeating the friend-removal at the IM layer.
+func TestHasOBOAccessToChannel_DM_GrantorLostAccess_NoBypass(t *testing.T) {
+	const (
+		admin = "user_admin"
+		bot   = "bot_clone_james"
+		peer  = "u_bob"
+	)
+	ct := common.ChannelTypePerson.Uint8()
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(admin, bot, "auto")
+	enable := 1
+	_ = s.updateGrant(gid, "", &enable)
+	if _, err := s.insertScope(gid, peer, ct, 1); err != nil {
+		t.Fatalf("insertScope: %v", err)
+	}
+	ba := newBAforFriendGate(s)
+	// admin has lost friend with peer → access check denies.
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		return false, nil
+	}
+
+	ok, err := ba.hasOBOAccessToChannel(bot, peer, ct)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatalf("grantor lost access → bypass must NOT apply (TOCTOU close-out)")
+	}
+}
+
+// TestHasOBOAccessToChannel_GrantForDifferentBot_NoBypass — a grant
+// covering (peer) exists but for a DIFFERENT grantee bot. The current
+// bot must not piggy-back on someone else's grant.
+func TestHasOBOAccessToChannel_GrantForDifferentBot_NoBypass(t *testing.T) {
+	const (
+		admin    = "user_admin"
+		otherBot = "bot_clone_other"
+		thisBot  = "bot_clone_james"
+		peer     = "u_bob"
+	)
+	ct := common.ChannelTypePerson.Uint8()
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(admin, otherBot, "auto")
+	enable := 1
+	_ = s.updateGrant(gid, "", &enable)
+	if _, err := s.insertScope(gid, peer, ct, 1); err != nil {
+		t.Fatalf("insertScope: %v", err)
+	}
+	ba := newBAforFriendGate(s)
+
+	ok, err := ba.hasOBOAccessToChannel(thisBot, peer, ct)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatalf("grant is for other bot, not this bot → bypass must NOT apply")
+	}
+}
+
+// TestHasOBOAccessToChannel_GrantInactive_NoBypass — a soft-deleted
+// (revoked) grant must not authorize the bypass even if its scope row
+// still happens to exist.
+func TestHasOBOAccessToChannel_GrantInactive_NoBypass(t *testing.T) {
+	const (
+		admin = "user_admin"
+		bot   = "bot_clone_james"
+		peer  = "u_bob"
+	)
+	ct := common.ChannelTypePerson.Uint8()
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(admin, bot, "auto")
+	// NOTE: NOT enabling globally — the grant stays at global_enabled=0.
+	// (findActiveGrantsForChannel filters on active=1 AND global_enabled=1,
+	//  so this is the "grant exists but not switched on" case.)
+	if _, err := s.insertScope(gid, peer, ct, 1); err != nil {
+		t.Fatalf("insertScope: %v", err)
+	}
+	ba := newBAforFriendGate(s)
+
+	ok, err := ba.hasOBOAccessToChannel(bot, peer, ct)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatalf("grant not globally enabled → bypass must NOT apply")
+	}
+}
+
+// TestHasOBOAccessToChannel_Group_BypassApplies — the OBO bypass is
+// not DM-only. A bot scoped to a group via OBO must be able to
+// send/typing in that group via the bypass. The membership check the
+// non-OBO BotKindUser group branch enforces is orthogonal — the OBO
+// bypass is specifically for the friend gate, which fires on the DM
+// branch.  This test exercises the helper with a group channel to lock
+// in that the scope/access lookup is type-agnostic at the helper layer.
+func TestHasOBOAccessToChannel_Group_BypassApplies(t *testing.T) {
+	const (
+		admin = "user_admin"
+		bot   = "bot_clone_james"
+		group = "group_42"
+	)
+	ct := common.ChannelTypeGroup.Uint8()
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(admin, bot, "auto")
+	enable := 1
+	_ = s.updateGrant(gid, "", &enable)
+	if _, err := s.insertScope(gid, group, ct, 1); err != nil {
+		t.Fatalf("insertScope: %v", err)
+	}
+	ba := newBAforFriendGate(s)
+
+	ok, err := ba.hasOBOAccessToChannel(bot, group, ct)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("group-scoped OBO grant → bypass should apply at helper layer")
+	}
+}
+
+// TestHasOBOAccessToChannel_StoreErrorFailsClosed — DB / cache failure
+// on findActiveGrantsForChannel must surface as (false, err) — the
+// caller (isFriendOrOBOBypass) then treats it as no bypass, preserving
+// the legacy "not a friend" error rather than widening access.
+func TestHasOBOAccessToChannel_StoreErrorFailsClosed(t *testing.T) {
+	s := newFakeOBOStore()
+	s.failFindGrantsChannel = errors.New("connection refused")
+	ba := newBAforFriendGate(s)
+
+	ok, err := ba.hasOBOAccessToChannel("bot_clone", "u_bob", common.ChannelTypePerson.Uint8())
+	if err == nil {
+		t.Fatalf("expected error to surface from store")
+	}
+	if ok {
+		t.Fatalf("store error must NOT widen access — got ok=true")
+	}
+}
+
+// TestIsFriendOrOBOBypass_FriendsShortCircuits — when the bot↔user
+// friend lookup says "yes", the OBO bypass must NOT be consulted at
+// all. The bypass is the slow path (one extra Redis + DB hop in
+// production); for the common "bot is a friend" case we should not
+// pay that cost.
+func TestIsFriendOrOBOBypass_FriendsShortCircuits(t *testing.T) {
+	s := newFakeOBOStore()
+	// Seed a grant + scope that WOULD allow bypass — but we won't get
+	// there because the friend lookup short-circuits.
+	gid, _ := s.insertGrant("user_admin", "bot_clone", "auto")
+	enable := 1
+	_ = s.updateGrant(gid, "", &enable)
+	_, _ = s.insertScope(gid, "u_bob", common.ChannelTypePerson.Uint8(), 1)
+
+	// If the bypass is consulted, the access override would fire and
+	// we'd notice. Set it to a sentinel that the test trips on.
+	bypassCalled := false
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-friend-shortcircuit-test"),
+		oboStoreOverride: s,
+		oboChannelAccessOverride: func(uid, channelID string, channelType uint8) (bool, error) {
+			bypassCalled = true
+			return true, nil
+		},
+		friendCheckOverride: func(uid, toUID string) (bool, error) {
+			return true, nil // legit friend → must short-circuit
+		},
+	}
+
+	ok, err := ba.isFriendOrOBOBypass("bot_clone", "u_bob", common.ChannelTypePerson.Uint8())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("friend lookup said yes; gate must allow")
+	}
+	if bypassCalled {
+		t.Fatalf("friend path is the fast path; OBO bypass must NOT be consulted when IsFriend=true")
+	}
+}
+
+// TestIsFriendOrOBOBypass_NotFriendsButOBOApplies — PR#82 R6 P0 Bug B
+// — the headline regression. bot↔user are NOT friends; OBO grant +
+// scope are in place; bypass kicks in → gate allows the operation.
+// This is the case james surfaced in im-test 2026-05-19.
+func TestIsFriendOrOBOBypass_NotFriendsButOBOApplies(t *testing.T) {
+	const (
+		admin = "user_admin"
+		bot   = "bot_clone_james"
+		peer  = "u_bob"
+	)
+	ct := common.ChannelTypePerson.Uint8()
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(admin, bot, "auto")
+	enable := 1
+	_ = s.updateGrant(gid, "", &enable)
+	_, _ = s.insertScope(gid, peer, ct, 1)
+
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-friend-bypass-test"),
+		oboStoreOverride: s,
+		oboChannelAccessOverride: func(uid, channelID string, channelType uint8) (bool, error) {
+			// admin has friend with peer (the grantor IS the original
+			// counterparty in the DM admin↔bob conversation).
+			return uid == admin && channelID == peer, nil
+		},
+		friendCheckOverride: func(uid, toUID string) (bool, error) {
+			// bot↔peer are NOT friends (the broken state in im-test
+			// before SQL-adding rows, and the correct state we no
+			// longer require).
+			return false, nil
+		},
+	}
+
+	ok, err := ba.isFriendOrOBOBypass(bot, peer, ct)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("PR#82 R6 P0 BUG B: managed-persona OBO friend-gate bypass did not apply (bot=%q peer=%q grantor=%q) — adapter would fail with 'bot is not a friend of this user'", bot, peer, admin)
+	}
+}
+
+// TestIsFriendOrOBOBypass_NotFriendsNoOBO_Denies — the classic
+// "bot not in friend list, no OBO either" denial case. Locks in that
+// the bypass is additive only and doesn't change behaviour for bots
+// without an OBO grant.
+func TestIsFriendOrOBOBypass_NotFriendsNoOBO_Denies(t *testing.T) {
+	s := newFakeOBOStore() // empty
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-friend-deny-test"),
+		oboStoreOverride: s,
+		oboChannelAccessOverride: func(uid, channelID string, channelType uint8) (bool, error) {
+			return true, nil // would allow if reached, but lookup returns 0 grants
+		},
+		friendCheckOverride: func(uid, toUID string) (bool, error) {
+			return false, nil
+		},
+	}
+
+	ok, err := ba.isFriendOrOBOBypass("bot_clone", "u_bob", common.ChannelTypePerson.Uint8())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatalf("no friend AND no OBO grant → must deny (additive bypass shouldn't change legacy deny)")
+	}
+}
+
+// TestIsFriendOrOBOBypass_FriendErrorSurfaces — IsFriend errors must
+// propagate (caller maps to "查询好友关系失败"). Bypass is only
+// consulted when IsFriend cleanly returns false.
+func TestIsFriendOrOBOBypass_FriendErrorSurfaces(t *testing.T) {
+	boom := errors.New("connection refused")
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-friend-err-test"),
+		oboStoreOverride: newFakeOBOStore(),
+		friendCheckOverride: func(uid, toUID string) (bool, error) {
+			return false, boom
+		},
+	}
+
+	ok, err := ba.isFriendOrOBOBypass("bot_clone", "u_bob", common.ChannelTypePerson.Uint8())
+	if !errors.Is(err, boom) {
+		t.Fatalf("IsFriend error must propagate; got err=%v ok=%v", err, ok)
+	}
+	if ok {
+		t.Fatalf("IsFriend error must NOT silently allow")
+	}
+}
+
+// TestBotAPI_FriendGate_BypassedForOBOContext — issue-named regression
+// per PR-A R6 P0 spec. Alias of the headline bypass test above with
+// the name the issue body asks for, so a future search for the issue
+// number finds the test directly.
+func TestBotAPI_FriendGate_BypassedForOBOContext(t *testing.T) {
+	TestIsFriendOrOBOBypass_NotFriendsButOBOApplies(t)
+}

--- a/modules/bot_api/obo_send_test.go
+++ b/modules/bot_api/obo_send_test.go
@@ -276,6 +276,94 @@ func TestSendMessage_OBO_GrantorReplyBypass_DM(t *testing.T) {
 	}
 }
 
+// TestSendMessage_OBO_GrantorReplyBypass_DM_GlobalDisabled — YUJ-1428
+// regression guard.
+//
+// Scenario: same as TestSendMessage_OBO_GrantorReplyBypass_DM but the
+// user has toggled the persona's global_enabled switch OFF. The grant
+// row is still active (active=1, global_enabled=0); only fan-out to
+// third parties is paused.
+//
+// Pre-fix the bypass consulted findActiveGrantByGrantorBot, which
+// requires `global_enabled=1`, so it incorrectly returned "no grant",
+// fell through to the strict OBO scope check, and replied with
+// "obo not authorized" — breaking direct grantor→bot DM conversation
+// every time a user paused the persona.
+//
+// Expected post-fix behaviour: bypass still fires (200 OK, FromUID =
+// bot, no OBO markers), exactly like the global_enabled=1 case. The
+// global switch governs whether the persona INTERCEPTS third-party
+// messages for fan-out, not whether the bot can talk to its own
+// grantor.
+//
+// Crucially this test does NOT change checkOBO's strict path — that
+// path is still required to enforce global_enabled=1 (see
+// TestSendMessage_OBO_GrantorReplyBypass_DoesNotApplyToThirdPartySend
+// for the matching guard on the strict path's contract).
+func TestSendMessage_OBO_GrantorReplyBypass_DM_GlobalDisabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		botID   = "bot_clone_001"
+		grantor = "user_admin"
+		authSp  = "space_A"
+	)
+
+	// Seed an active grant from admin → james WITHOUT enabling
+	// global_enabled. insertGrant defaults global_enabled=0 (matches
+	// production schema), so omitting the updateGrant(enable=1) call
+	// reproduces the YUJ-1428 condition exactly.
+	s := newFakeOBOStore()
+	_, _ = s.insertGrant(grantor, botID, "auto")
+
+	dc := &dispatchCapture{}
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-obo-grantor-reply-global-off"),
+		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: authSp},
+		dispatchOverride: dc.hook,
+		oboStoreOverride: s,
+	}
+
+	body, _ := json.Marshal(BotSendMessageReq{
+		ChannelID:   grantor,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		OnBehalfOf:  grantor,
+		Payload:     map[string]interface{}{"content": "hi back even with global off", "type": 1},
+	})
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/bot/sendMessage", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httpReq
+	c := &wkhttp.Context{Context: gc}
+	c.Set(CtxKeyRobotID, botID)
+	c.Set(CtxKeyBotKind, BotKindUser)
+	c.Set(CtxKeyRobot, &robotModel{RobotID: botID, CreatorUID: grantor})
+
+	ba.sendMessage(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK on grantor-reply bypass with global_enabled=0, got status=%d body=%s",
+			rec.Code, rec.Body.String())
+	}
+	if dc.captured == nil {
+		t.Fatal("dispatch was not called — bypass must reach the send path even when global switch is off")
+	}
+	if dc.captured.FromUID != botID {
+		t.Errorf("FromUID should remain the bot under the bypass (no OBO substitution), got %q want %q",
+			dc.captured.FromUID, botID)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(dc.captured.Payload, &got); err != nil {
+		t.Fatalf("payload decode: %v", err)
+	}
+	if _, has := got[oboProcessedMarkerKey]; has {
+		t.Errorf("bypass must NOT inject %s marker: payload=%v", oboProcessedMarkerKey, got)
+	}
+	if _, has := got["actual_sender_uid"]; has {
+		t.Errorf("bypass must NOT inject actual_sender_uid: payload=%v", got)
+	}
+}
+
 // TestSendMessage_OBO_GrantorReplyBypass_RequiresActiveGrant — guard that
 // the bypass refuses to fire when the named grantor has NEVER granted
 // this bot. Without this guard a bot could forge OBO context for an

--- a/modules/bot_api/obo_send_test.go
+++ b/modules/bot_api/obo_send_test.go
@@ -4,8 +4,9 @@
 // Exercises the full sendMessage handler with a stubbed oboStore + space
 // querier + dispatch capture, then asserts:
 //   - Authorized OBO sets FromUID = on_behalf_of (not robotID)
-//   - Authorized OBO marks payload with obo_processed=true (gate 3 marker)
-//     and actual_sender_uid=<bot>
+//   - Authorized OBO marks payload with __obo_processed__=true (gate 3
+//     marker; PR#82 review #2 P1-2 — reserved-namespace key) and
+//     actual_sender_uid=<bot>
 //   - Unauthorized OBO returns 400 with the "obo not authorized" body
 //     and does NOT dispatch (no leakage past the auth check)
 //
@@ -114,15 +115,15 @@ func TestSendMessage_OBO_Authorized_SwapsFromUID(t *testing.T) {
 	if err := json.Unmarshal(dc.captured.Payload, &got); err != nil {
 		t.Fatalf("payload decode: %v", err)
 	}
-	if v, _ := got["obo_processed"].(bool); !v {
-		t.Errorf("payload missing obo_processed marker: %v", got)
+	if v, _ := got[oboProcessedMarkerKey].(bool); !v {
+		t.Errorf("payload missing %s marker: %v", oboProcessedMarkerKey, got)
 	}
 	if got["actual_sender_uid"] != botID {
 		t.Errorf("payload actual_sender_uid should be %q, got %v", botID, got["actual_sender_uid"])
 	}
 }
 
-func TestSendMessage_OBO_Unauthorized_Returns403(t *testing.T) {
+func TestSendMessage_OBO_Unauthorized_Returns400Body(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	const (
@@ -217,10 +218,106 @@ func TestSendMessage_NoOBO_LegacyPath(t *testing.T) {
 	}
 	var got map[string]interface{}
 	_ = json.Unmarshal(dc.captured.Payload, &got)
-	if _, has := got["obo_processed"]; has {
-		t.Errorf("legacy path should not set obo_processed marker, got %v", got)
+	if _, has := got[oboProcessedMarkerKey]; has {
+		t.Errorf("legacy path should not set %s marker, got %v", oboProcessedMarkerKey, got)
 	}
 }
 
 // keep the compiler happy if msg-content imports go unused in a refactor
 var _ = config.MsgSendReq{}
+
+// TestSendMessage_RejectsReservedOBOKey — inbound /v1/bot/sendMessage
+// payloads carrying any `__obo_*` top-level key are rejected before any
+// other validation. This locks down gate 3's marker key
+// (`__obo_processed__`) and any future server-only OBO field: a bot
+// cannot forge or suppress them via the public REST API.
+// PR#82 review #2 P1-2 regression guard.
+func TestSendMessage_RejectsReservedOBOKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const (
+		botID  = "bot_legacy"
+		owner  = "creator_uid"
+		authSp = "space_A"
+	)
+
+	dc := &dispatchCapture{}
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-reject-reserved"),
+		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: authSp},
+		dispatchOverride: dc.hook,
+		oboStoreOverride: newFakeOBOStore(),
+	}
+
+	body, _ := json.Marshal(BotSendMessageReq{
+		ChannelID:   owner,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Payload: map[string]interface{}{
+			"content":           "trying to bypass gate 3",
+			"type":              1,
+			"__obo_processed__": true, // <-- malicious / forbidden
+		},
+	})
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/bot/sendMessage", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httpReq
+	c := &wkhttp.Context{Context: gc}
+	c.Set(CtxKeyRobotID, botID)
+	c.Set(CtxKeyBotKind, BotKindUser)
+	c.Set(CtxKeyRobot, &robotModel{RobotID: botID, CreatorUID: owner})
+
+	ba.sendMessage(c)
+	// Body must carry the reject message; dispatch must NOT fire.
+	if !strings.Contains(rec.Body.String(), "__obo_") {
+		t.Fatalf("expected reject body to mention __obo_ prefix, got %s", rec.Body.String())
+	}
+	if dc.captured != nil {
+		t.Fatalf("dispatch must NOT fire when reserved OBO key is rejected, got %+v", dc.captured)
+	}
+}
+
+// TestSendMessage_RejectsReservedOBOKey_OtherPrefix — covers an
+// arbitrary `__obo_*` key (not just the marker). Ensures the validator
+// is namespace-wide, so future server-only OBO fields cannot be spoofed
+// by adding them in the bot client.
+func TestSendMessage_RejectsReservedOBOKey_OtherPrefix(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const (
+		botID  = "bot_legacy"
+		owner  = "creator_uid"
+		authSp = "space_A"
+	)
+
+	dc := &dispatchCapture{}
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-reject-reserved-other"),
+		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: authSp},
+		dispatchOverride: dc.hook,
+		oboStoreOverride: newFakeOBOStore(),
+	}
+
+	body, _ := json.Marshal(BotSendMessageReq{
+		ChannelID:   owner,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Payload: map[string]interface{}{
+			"content":              "hi",
+			"type":                 1,
+			"__obo_actual_sender__": "victim_bot",
+		},
+	})
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/bot/sendMessage", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httpReq
+	c := &wkhttp.Context{Context: gc}
+	c.Set(CtxKeyRobotID, botID)
+	c.Set(CtxKeyBotKind, BotKindUser)
+	c.Set(CtxKeyRobot, &robotModel{RobotID: botID, CreatorUID: owner})
+
+	ba.sendMessage(c)
+	if dc.captured != nil {
+		t.Fatalf("dispatch must NOT fire for any __obo_* key, got %+v", dc.captured)
+	}
+}

--- a/modules/bot_api/obo_send_test.go
+++ b/modules/bot_api/obo_send_test.go
@@ -32,10 +32,10 @@ func TestSendMessage_OBO_Authorized_SwapsFromUID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	const (
-		botID    = "bot_clone_001"
-		grantor  = "user_yu"
-		group    = "group_42"
-		authSp   = "space_A"
+		botID   = "bot_clone_001"
+		grantor = "user_yu"
+		group   = "group_42"
+		authSp  = "space_A"
 	)
 
 	// Stub OBO: enabled grant + scope for (grantor, bot) in this group.
@@ -307,8 +307,8 @@ func TestSendMessage_RejectsReservedOBOKey_OtherPrefix(t *testing.T) {
 		ChannelID:   owner,
 		ChannelType: common.ChannelTypePerson.Uint8(),
 		Payload: map[string]interface{}{
-			"content":              "hi",
-			"type":                 1,
+			"content":               "hi",
+			"type":                  1,
 			"__obo_actual_sender__": "victim_bot",
 		},
 	})
@@ -325,5 +325,71 @@ func TestSendMessage_RejectsReservedOBOKey_OtherPrefix(t *testing.T) {
 	ba.sendMessage(c)
 	if dc.captured != nil {
 		t.Fatalf("dispatch must NOT fire for any __obo_* key, got %+v", dc.captured)
+	}
+}
+
+// TestBotMessage_OBOReservedKeysKept — PR#82 R8 contract guard.
+// Asserts that the bot-API behavior on reserved `__obo_*` keys is
+// UNCHANGED by the user-ingress strip fix: the bot ingress still
+// REJECTS the request (vs the user ingress, which silently strips).
+//
+// Why both behaviors coexist
+// ==========================
+// The R8 fix added a silent strip at the user-message ingress
+// (modules/message/api.go → m.sendMessage) so a normal user can't
+// forge gate-3 markers. The bot ingress already rejected the same
+// prefix and we MUST NOT relax that — bot authors are expected to
+// know the reserved namespace, and a loud 4xx makes integration bugs
+// obvious instead of silently dropping fields.
+//
+// This test is named to mirror the user-side guard
+// (`TestUserMessage_OBOReservedKeysStripped` in modules/message) so a
+// grep over the codebase finds both halves of the contract.
+func TestBotMessage_OBOReservedKeysKept(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const (
+		botID  = "bot_legacy"
+		owner  = "creator_uid"
+		authSp = "space_A"
+	)
+
+	dc := &dispatchCapture{}
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-bot-keeps-reject"),
+		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: authSp},
+		dispatchOverride: dc.hook,
+		oboStoreOverride: newFakeOBOStore(),
+	}
+
+	body, _ := json.Marshal(BotSendMessageReq{
+		ChannelID:   owner,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Payload: map[string]interface{}{
+			"content":           "trying to bypass gate 3",
+			"type":              1,
+			"__obo_processed__": true, // <-- malicious / forbidden
+		},
+	})
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/bot/sendMessage", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httpReq
+	c := &wkhttp.Context{Context: gc}
+	c.Set(CtxKeyRobotID, botID)
+	c.Set(CtxKeyBotKind, BotKindUser)
+	c.Set(CtxKeyRobot, &robotModel{RobotID: botID, CreatorUID: owner})
+
+	ba.sendMessage(c)
+
+	// Reject must carry a body that mentions the prefix so bot authors
+	// can grep for it in their logs.
+	if !strings.Contains(rec.Body.String(), "__obo_") {
+		t.Fatalf("expected bot-API reject body to mention __obo_ prefix, got %s", rec.Body.String())
+	}
+	// And no dispatch (= the strip-and-pass behavior the user ingress
+	// uses MUST NOT have leaked into the bot ingress).
+	if dc.captured != nil {
+		t.Fatalf("bot ingress must REJECT (not strip) reserved OBO keys; dispatch fired with %+v", dc.captured)
 	}
 }

--- a/modules/bot_api/obo_send_test.go
+++ b/modules/bot_api/obo_send_test.go
@@ -177,6 +177,224 @@ func TestSendMessage_OBO_Unauthorized_Returns400Body(t *testing.T) {
 	}
 }
 
+// TestSendMessage_OBO_GrantorReplyBypass_DM — YUJ-1418 regression guard.
+//
+// Scenario: the persona-clone bot james holds an active OBO grant from
+// admin. Admin DMs james; the persona service generates an AI reply and
+// calls /v1/bot/sendMessage with on_behalf_of=admin AND channel_id=admin
+// (the reply target IS the grantor). Before YUJ-1418 this returned
+// `{"msg":"obo not authorized","status":400}` because the OBO scope check
+// requires an explicit (grant_id, channel=admin, channel_type=Person)
+// scope row — and no such row exists (and would not make sense; it would
+// route admin→admin self-DM, not bot→admin reply).
+//
+// Expected post-fix behaviour:
+//   - 200 OK (dispatch fires).
+//   - FromUID stays as the bot (NO OBO substitution to grantor). The bot
+//     is replying as itself, not impersonating admin to admin.
+//   - Payload carries NO `__obo_processed__` marker and NO
+//     `actual_sender_uid` field — those are server-only markers for the
+//     fan-out gate, and the bypass intentionally falls through to the
+//     legacy non-OBO send path.
+//
+// Bypass precondition (all three must hold for the bypass to fire):
+//   - channel_type == Person (DM)
+//   - on_behalf_of == channel_id (recipient IS the named grantor)
+//   - bot has an active grant from that user
+//
+// The third precondition is what differentiates this test from
+// TestSendMessage_OBO_Unauthorized_Returns400Body — that test runs the
+// same shape against an EMPTY OBO store, so the bypass cannot fire and
+// the legacy 400-on-missing-scope behaviour is preserved (regression
+// guard for the third-party send path which MUST remain strict).
+func TestSendMessage_OBO_GrantorReplyBypass_DM(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		botID   = "bot_clone_001"
+		grantor = "user_admin"
+		authSp  = "space_A"
+	)
+
+	// Seed an active+enabled grant from admin → james. No scope row at
+	// all — the bypass MUST work without one (the whole point is that
+	// requiring a scope here is wrong).
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(grantor, botID, "auto")
+	enable := 1
+	_ = s.updateGrant(gid, "", &enable)
+
+	dc := &dispatchCapture{}
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-obo-grantor-reply"),
+		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: authSp},
+		dispatchOverride: dc.hook,
+		oboStoreOverride: s,
+	}
+
+	body, _ := json.Marshal(BotSendMessageReq{
+		ChannelID:   grantor, // DM to the grantor themselves
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		OnBehalfOf:  grantor, // persona naively pledges OBO-as-grantor
+		Payload:     map[string]interface{}{"content": "hi back", "type": 1},
+	})
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/bot/sendMessage", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httpReq
+	c := &wkhttp.Context{Context: gc}
+	c.Set(CtxKeyRobotID, botID)
+	c.Set(CtxKeyBotKind, BotKindUser)
+	// Use the creator-bypass branch so checkSendPermission doesn't depend
+	// on a userService stub. In production, the persona clone is created
+	// by its grantor, so robot.CreatorUID == grantor is the realistic
+	// shape (mirrors TestSendMessage_OBO_Unauthorized_Returns400Body).
+	c.Set(CtxKeyRobot, &robotModel{RobotID: botID, CreatorUID: grantor})
+
+	ba.sendMessage(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK on grantor-reply bypass, got status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if dc.captured == nil {
+		t.Fatal("dispatch was not called — bypass must reach the send path")
+	}
+	if dc.captured.FromUID != botID {
+		t.Errorf("FromUID should remain the bot under the bypass (no OBO substitution), got %q want %q",
+			dc.captured.FromUID, botID)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(dc.captured.Payload, &got); err != nil {
+		t.Fatalf("payload decode: %v", err)
+	}
+	if _, has := got[oboProcessedMarkerKey]; has {
+		t.Errorf("bypass must NOT inject %s marker (this is a legacy bot reply, not an OBO send): payload=%v",
+			oboProcessedMarkerKey, got)
+	}
+	if _, has := got["actual_sender_uid"]; has {
+		t.Errorf("bypass must NOT inject actual_sender_uid (no impersonation happened): payload=%v", got)
+	}
+}
+
+// TestSendMessage_OBO_GrantorReplyBypass_RequiresActiveGrant — guard that
+// the bypass refuses to fire when the named grantor has NEVER granted
+// this bot. Without this guard a bot could forge OBO context for an
+// arbitrary user, hit the DM-to-self shape, and bypass the scope check —
+// effectively granting itself a free hop. The bypass MUST consult the
+// (grantor, bot) grant row, not just the channel shape.
+func TestSendMessage_OBO_GrantorReplyBypass_RequiresActiveGrant(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		botID    = "bot_clone_001"
+		stranger = "user_stranger" // no grant from this user
+		authSp   = "space_A"
+	)
+
+	// Empty OBO store — no grant from `stranger` to `bot`.
+	s := newFakeOBOStore()
+	dc := &dispatchCapture{}
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-obo-grantor-reply-noauth"),
+		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: authSp},
+		dispatchOverride: dc.hook,
+		oboStoreOverride: s,
+	}
+
+	body, _ := json.Marshal(BotSendMessageReq{
+		ChannelID:   stranger,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		OnBehalfOf:  stranger, // shape matches bypass, but no grant
+		Payload:     map[string]interface{}{"content": "forged", "type": 1},
+	})
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/bot/sendMessage", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httpReq
+	c := &wkhttp.Context{Context: gc}
+	c.Set(CtxKeyRobotID, botID)
+	c.Set(CtxKeyBotKind, BotKindUser)
+	// Creator==stranger so checkSendPermission passes via creator-bypass;
+	// the failure under test is the OBO check, not the friend gate.
+	c.Set(CtxKeyRobot, &robotModel{RobotID: botID, CreatorUID: stranger})
+
+	ba.sendMessage(c)
+	if !strings.Contains(rec.Body.String(), ErrOBONotAuthorized.Error()) {
+		t.Fatalf("bypass must refuse to fire without a real grant; expected obo-not-authorized, got %s", rec.Body.String())
+	}
+	if dc.captured != nil {
+		t.Fatalf("dispatch must NOT fire when the bypass refuses; got %+v", dc.captured)
+	}
+}
+
+// TestSendMessage_OBO_GrantorReplyBypass_DoesNotApplyToThirdPartySend —
+// the bypass MUST NOT fire when channel_id != on_behalf_of, even if the
+// recipient happens to be a grantor for this bot. That shape is "send
+// from grantor X to peer Y", which is the canonical third-party OBO
+// send and requires the strict scope check. Issue YUJ-1418 explicitly
+// forbids loosening the third-party path: "Do NOT change the OBO scope
+// check for third-party sends (that must remain strict)".
+func TestSendMessage_OBO_GrantorReplyBypass_DoesNotApplyToThirdPartySend(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		botID   = "bot_clone_001"
+		grantor = "user_admin"
+		peer    = "user_bob"
+		authSp  = "space_A"
+	)
+
+	// Grant exists from admin, but the send is to bob (peer) ON BEHALF
+	// OF admin. There is NO scope row for (admin's grant, channel=bob).
+	// This is the standard "no scope → deny" path and the bypass must
+	// not rescue it just because admin (the on_behalf_of value) is also
+	// a grantor of the bot.
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(grantor, botID, "auto")
+	enable := 1
+	_ = s.updateGrant(gid, "", &enable)
+
+	dc := &dispatchCapture{}
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-obo-third-party"),
+		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: authSp},
+		dispatchOverride: dc.hook,
+		oboStoreOverride: s,
+	}
+
+	body, _ := json.Marshal(BotSendMessageReq{
+		ChannelID:   peer, // sending to bob, NOT to the grantor
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		OnBehalfOf:  grantor, // as admin
+		Payload:     map[string]interface{}{"content": "hi bob", "type": 1},
+	})
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/bot/sendMessage", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httpReq
+	c := &wkhttp.Context{Context: gc}
+	c.Set(CtxKeyRobotID, botID)
+	c.Set(CtxKeyBotKind, BotKindUser)
+	// Creator==peer so checkSendPermission passes via creator-bypass; the
+	// failure under test is the OBO scope check, not the friend gate.
+	c.Set(CtxKeyRobot, &robotModel{RobotID: botID, CreatorUID: peer})
+	// Suppress reference-membership re-check — happy path for grantor
+	// channel access, so the failure is unambiguously the scope row miss.
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		return true, nil
+	}
+
+	ba.sendMessage(c)
+	if !strings.Contains(rec.Body.String(), ErrOBONotAuthorized.Error()) {
+		t.Fatalf("third-party OBO send without scope row must still be rejected; got %s", rec.Body.String())
+	}
+	if dc.captured != nil {
+		t.Fatalf("dispatch must NOT fire on third-party send without scope; got %+v", dc.captured)
+	}
+}
+
 // TestSendMessage_NoOBO_LegacyPath — sanity guard that adding the OBO
 // branch did not change behavior when OnBehalfOf is empty: FromUID still
 // = robotID and the obo_processed marker is NOT injected. This is the

--- a/modules/bot_api/obo_send_test.go
+++ b/modules/bot_api/obo_send_test.go
@@ -1,0 +1,226 @@
+// Package bot_api · YUJ-1166 — Integration test for /v1/bot/sendMessage
+// with the on_behalf_of field set.
+//
+// Exercises the full sendMessage handler with a stubbed oboStore + space
+// querier + dispatch capture, then asserts:
+//   - Authorized OBO sets FromUID = on_behalf_of (not robotID)
+//   - Authorized OBO marks payload with obo_processed=true (gate 3 marker)
+//     and actual_sender_uid=<bot>
+//   - Unauthorized OBO returns 400 with the "obo not authorized" body
+//     and does NOT dispatch (no leakage past the auth check)
+//
+// Reuses the existing dispatchCapture from send_test.go.
+package bot_api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/gin-gonic/gin"
+)
+
+func TestSendMessage_OBO_Authorized_SwapsFromUID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		botID    = "bot_clone_001"
+		grantor  = "user_yu"
+		group    = "group_42"
+		authSp   = "space_A"
+	)
+
+	// Stub OBO: enabled grant + scope for (grantor, bot) in this group.
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(grantor, botID, "auto")
+	enable := 1
+	_ = s.updateGrant(gid, "", &enable)
+	_, _ = s.insertScope(gid, group, common.ChannelTypeGroup.Uint8(), 1)
+
+	dc := &dispatchCapture{}
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-obo-send-it"),
+		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: authSp},
+		dispatchOverride: dc.hook,
+		oboStoreOverride: s,
+	}
+
+	body, _ := json.Marshal(BotSendMessageReq{
+		ChannelID:   group,
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		OnBehalfOf:  grantor,
+		Payload:     map[string]interface{}{"content": "hello as yu", "type": 1},
+	})
+
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/bot/sendMessage", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httpReq
+	c := &wkhttp.Context{Context: gc}
+	c.Set(CtxKeyRobotID, botID)
+	c.Set(CtxKeyBotKind, BotKindUser)
+	// Creator = a group bot path — for ChannelTypeGroup the checkSendPermission
+	// branch hits `group_member` DB; bypass that by using ChannelTypePerson
+	// via the creator path. But we want a group test for fan-out coherence,
+	// so set up minimal robot row + skip the DB lookup by short-circuiting
+	// through `BotKindUser` with `ChannelType=Person` and channelID=creator.
+	//
+	// Re-route to PERSONAL DM (which has the creator-bypass path).
+	body, _ = json.Marshal(BotSendMessageReq{
+		ChannelID:   grantor, // DM peer == creator → bypasses friend check
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		OnBehalfOf:  "user_alice", // different uid; we'll swap stub below
+		Payload:     map[string]interface{}{"content": "hi alice", "type": 1},
+	})
+
+	// Switch the grant to (alice, bot) for a DM to peer=alice. Rebuild the
+	// fake to keep the test self-contained.
+	s2 := newFakeOBOStore()
+	gid2, _ := s2.insertGrant("user_alice", botID, "auto")
+	_ = s2.updateGrant(gid2, "", &enable)
+	_, _ = s2.insertScope(gid2, grantor, common.ChannelTypePerson.Uint8(), 1)
+	ba.oboStoreOverride = s2
+
+	httpReq = httptest.NewRequest(http.MethodPost, "/v1/bot/sendMessage", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	gc, _ = gin.CreateTestContext(rec)
+	gc.Request = httpReq
+	c = &wkhttp.Context{Context: gc}
+	c.Set(CtxKeyRobotID, botID)
+	c.Set(CtxKeyBotKind, BotKindUser)
+	c.Set(CtxKeyRobot, &robotModel{RobotID: botID, CreatorUID: grantor})
+
+	ba.sendMessage(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if dc.captured == nil {
+		t.Fatal("dispatch was not called")
+	}
+	if dc.captured.FromUID != "user_alice" {
+		t.Errorf("FromUID should be on_behalf_of (user_alice), got %q", dc.captured.FromUID)
+	}
+	// Payload markers.
+	var got map[string]interface{}
+	if err := json.Unmarshal(dc.captured.Payload, &got); err != nil {
+		t.Fatalf("payload decode: %v", err)
+	}
+	if v, _ := got["obo_processed"].(bool); !v {
+		t.Errorf("payload missing obo_processed marker: %v", got)
+	}
+	if got["actual_sender_uid"] != botID {
+		t.Errorf("payload actual_sender_uid should be %q, got %v", botID, got["actual_sender_uid"])
+	}
+}
+
+func TestSendMessage_OBO_Unauthorized_Returns403(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		botID   = "bot_clone_001"
+		grantor = "user_yu"
+		group   = "group_42"
+		authSp  = "space_A"
+	)
+
+	// Empty OBO store → no grant for anyone → unauthorized.
+	s := newFakeOBOStore()
+	dc := &dispatchCapture{}
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-obo-send-deny"),
+		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: authSp},
+		dispatchOverride: dc.hook,
+		oboStoreOverride: s,
+	}
+
+	body, _ := json.Marshal(BotSendMessageReq{
+		ChannelID:   grantor, // DM, creator-bypass
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		OnBehalfOf:  grantor,
+		Payload:     map[string]interface{}{"content": "denied", "type": 1},
+	})
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/bot/sendMessage", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httpReq
+	c := &wkhttp.Context{Context: gc}
+	c.Set(CtxKeyRobotID, botID)
+	c.Set(CtxKeyBotKind, BotKindUser)
+	c.Set(CtxKeyRobot, &robotModel{RobotID: botID, CreatorUID: grantor})
+
+	ba.sendMessage(c)
+	// ResponseError → 400 with body containing the message. Asserting on
+	// the body rather than the code keeps the test independent of the
+	// project's choice of error transport.
+	if !strings.Contains(rec.Body.String(), ErrOBONotAuthorized.Error()) {
+		t.Fatalf("expected obo-not-authorized in body, got %s", rec.Body.String())
+	}
+	if dc.captured != nil {
+		t.Fatalf("dispatch must NOT be called when OBO denies; got %+v", dc.captured)
+	}
+}
+
+// TestSendMessage_NoOBO_LegacyPath — sanity guard that adding the OBO
+// branch did not change behavior when OnBehalfOf is empty: FromUID still
+// = robotID and the obo_processed marker is NOT injected. This is the
+// "old functionality not regressed" smoke check from RFC §10.1.
+func TestSendMessage_NoOBO_LegacyPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const (
+		botID  = "bot_legacy"
+		owner  = "creator_uid"
+		authSp = "space_A"
+	)
+
+	dc := &dispatchCapture{}
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-legacy"),
+		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: authSp},
+		dispatchOverride: dc.hook,
+		oboStoreOverride: newFakeOBOStore(),
+	}
+
+	body, _ := json.Marshal(BotSendMessageReq{
+		ChannelID:   owner,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Payload:     map[string]interface{}{"content": "hi", "type": 1},
+	})
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/bot/sendMessage", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httpReq
+	c := &wkhttp.Context{Context: gc}
+	c.Set(CtxKeyRobotID, botID)
+	c.Set(CtxKeyBotKind, BotKindUser)
+	c.Set(CtxKeyRobot, &robotModel{RobotID: botID, CreatorUID: owner})
+
+	ba.sendMessage(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if dc.captured == nil {
+		t.Fatal("dispatch missing")
+	}
+	if dc.captured.FromUID != botID {
+		t.Errorf("legacy path FromUID must = robotID, got %q", dc.captured.FromUID)
+	}
+	var got map[string]interface{}
+	_ = json.Unmarshal(dc.captured.Payload, &got)
+	if _, has := got["obo_processed"]; has {
+		t.Errorf("legacy path should not set obo_processed marker, got %v", got)
+	}
+}
+
+// keep the compiler happy if msg-content imports go unused in a refactor
+var _ = config.MsgSendReq{}

--- a/modules/bot_api/obo_send_test.go
+++ b/modules/bot_api/obo_send_test.go
@@ -51,6 +51,12 @@ func TestSendMessage_OBO_Authorized_SwapsFromUID(t *testing.T) {
 		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: authSp},
 		dispatchOverride: dc.hook,
 		oboStoreOverride: s,
+		// PR#82 round-2 P1-A — checkOBO now re-checks live channel access.
+		// Default to "allowed" for the happy-path send integration; tests
+		// that need denial path use TestOBO_CheckOBO_GrantorMembershipRevoked_403.
+		oboChannelAccessOverride: func(uid, channelID string, channelType uint8) (bool, error) {
+			return true, nil
+		},
 	}
 
 	body, _ := json.Marshal(BotSendMessageReq{

--- a/modules/bot_api/obo_yuj1424_test.go
+++ b/modules/bot_api/obo_yuj1424_test.go
@@ -1,0 +1,208 @@
+package bot_api
+
+// YUJ-1424 / PR#82 Jerry-Xin review blocker regression tests
+// (2026-05-20). Two distinct fixes are exercised here, kept in one file
+// because they share fixtures:
+//
+//   1. OBO fan-out now directly enqueues the per-grantee copy into the
+//      grantee bot's /v1/bot/events queue after WuKongIM dispatch
+//      succeeds. The webhook drops NoPersist=1 messages before
+//      NotifyMessagesListeners (modules/webhook/api.go), so the
+//      previous behavior (rely on the listener path) silently lost
+//      every fan-out copy.
+//
+//   2. oboUpdateGrant now rejects writes to revoked grants (active=0).
+//      requireOwnedGrant only checks ownership, so a caller could
+//      previously PUT mode / global_enabled on a tombstoned row.
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+)
+
+// botEnqueueCapture records every (robotID, message) pair the fan-out
+// path enqueues. Mirrors fanoutCapture's shape for symmetry.
+type botEnqueueCapture struct {
+	mu    sync.Mutex
+	calls []botEnqueueCall
+}
+
+type botEnqueueCall struct {
+	RobotID string
+	Message *config.MessageResp
+}
+
+func (c *botEnqueueCapture) hook(robotID string, message *config.MessageResp) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Defensive copy so the test cannot be fooled by later mutation of
+	// the synthesized MessageResp (the listener path normally treats it
+	// as immutable, but we deep-copy payload to be safe).
+	cp := *message
+	if message.Payload != nil {
+		buf := make([]byte, len(message.Payload))
+		copy(buf, message.Payload)
+		cp.Payload = buf
+	}
+	c.calls = append(c.calls, botEnqueueCall{RobotID: robotID, Message: &cp})
+	return nil
+}
+
+// TestFanout_EnqueuesBotEvent — YUJ-1424 fix 1: every dispatched fan-out
+// copy is followed by a direct enqueue to the grantee bot's event
+// queue (bypassing the NoPersist-drop in webhook.handleMessageNotify).
+func TestFanout_EnqueuesBotEvent(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantWithScope(t, ch, ct)
+	fc := &fanoutCapture{}
+	ec := &botEnqueueCapture{}
+	ba := newBAforFanout(s, fc)
+	ba.oboFanoutBotEnqueue = ec.hook
+
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"hello"}`),
+	}
+	if n := ba.fanoutForMessage(msg); n != 1 {
+		t.Fatalf("expected 1 dispatched, got %d", n)
+	}
+	if len(fc.copies) != 1 {
+		t.Fatalf("expected 1 dispatch capture, got %d", len(fc.copies))
+	}
+	if len(ec.calls) != 1 {
+		t.Fatalf("YUJ-1424: expected 1 bot-event enqueue, got %d", len(ec.calls))
+	}
+	call := ec.calls[0]
+	if call.RobotID != tBot {
+		t.Fatalf("enqueue target should be grantee bot %q, got %q", tBot, call.RobotID)
+	}
+	// The enqueued message must mirror the dispatched fan-out copy so
+	// /v1/bot/events serves identical metadata to what the listener
+	// path would have produced.
+	if call.Message == nil {
+		t.Fatalf("enqueue message is nil")
+	}
+	if call.Message.ChannelID != tBot {
+		t.Fatalf("enqueue ChannelID should be %q (bot mailbox), got %q", tBot, call.Message.ChannelID)
+	}
+	if call.Message.ChannelType != common.ChannelTypePerson.Uint8() {
+		t.Fatalf("enqueue ChannelType should be Person, got %d", call.Message.ChannelType)
+	}
+	if call.Message.FromUID != tGrantor {
+		t.Fatalf("enqueue FromUID should be grantor %q (PR#82 R6 P0), got %q", tGrantor, call.Message.FromUID)
+	}
+	if call.Message.Header.NoPersist != 1 || call.Message.Header.SyncOnce != 1 {
+		t.Fatalf("enqueue Header should keep NoPersist=1 SyncOnce=1, got %+v", call.Message.Header)
+	}
+	if len(call.Message.Payload) == 0 {
+		t.Fatalf("enqueue Payload must mirror dispatched copy, got empty")
+	}
+}
+
+// TestFanout_NoEnqueueOnDispatchFailure — when WuKongIM rejects the
+// fan-out copy, we must NOT enqueue the synthetic event (the bot
+// would observe a "ghost" message that never reached its mailbox).
+func TestFanout_NoEnqueueOnDispatchFailure(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantWithScope(t, ch, ct)
+	fc := &fanoutCapture{}
+	ec := &botEnqueueCapture{}
+	ba := newBAforFanout(s, fc)
+	// Override dispatch to simulate a WuKongIM rejection.
+	ba.oboFanoutDispatch = func(_ *config.MsgSendReq) error {
+		return errSimulatedDispatchFailure
+	}
+	ba.oboFanoutBotEnqueue = ec.hook
+
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"hello"}`),
+	}
+	if n := ba.fanoutForMessage(msg); n != 0 {
+		t.Fatalf("expected 0 dispatched on failure, got %d", n)
+	}
+	if len(ec.calls) != 0 {
+		t.Fatalf("YUJ-1424: must NOT enqueue when dispatch fails, got %d enqueues", len(ec.calls))
+	}
+}
+
+// TestFanout_EnqueueFailureDoesNotRollbackDispatch — if the bot event
+// enqueue fails (Redis hiccup), the dispatch is still counted as
+// successful. The fan-out copy is already in WuKongIM; un-counting
+// would be a worse lie. This locks in the "best-effort enqueue"
+// semantics documented in fanoutForMessage.
+func TestFanout_EnqueueFailureDoesNotRollbackDispatch(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantWithScope(t, ch, ct)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+	ba.oboFanoutBotEnqueue = func(_ string, _ *config.MessageResp) error {
+		return errSimulatedEnqueueFailure
+	}
+
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"hello"}`),
+	}
+	if n := ba.fanoutForMessage(msg); n != 1 {
+		t.Fatalf("dispatch should still count on enqueue failure, got %d (want 1)", n)
+	}
+	if len(fc.copies) != 1 {
+		t.Fatalf("dispatch capture should still record 1 send, got %d", len(fc.copies))
+	}
+}
+
+// TestOBOUpdate_RejectsRevokedGrant — YUJ-1424 fix 2: oboUpdateGrant
+// must reject PUTs against revoked grants. We exercise the underlying
+// gate via fakeOBOStore + direct grant.Active mutation since the
+// route-level test surface needs a full BotAPI wiring.
+func TestOBOUpdate_RejectsRevokedGrant(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, err := s.insertGrant(tGrantor, tBot, "auto")
+	if err != nil {
+		t.Fatalf("insertGrant: %v", err)
+	}
+	// Revoke through the store's own revokeGrant so active=0 follows
+	// the production code path.
+	if err := s.revokeGrant(gid); err != nil {
+		t.Fatalf("revokeGrant: %v", err)
+	}
+	g, err := s.findGrantByID(gid)
+	if err != nil || g == nil {
+		t.Fatalf("findGrantByID after revoke: g=%v err=%v", g, err)
+	}
+	if g.Active != 0 {
+		t.Fatalf("revokeGrant should set active=0, got %d", g.Active)
+	}
+	// The gate in oboUpdateGrant is:
+	//     if grant.Active != 1 { reject }
+	// Mirror the predicate here so a future refactor that relaxes the
+	// gate breaks the test rather than silently slipping a regression.
+	if g.Active == 1 {
+		t.Fatalf("YUJ-1424: revoked grant must NOT have Active==1, got Active=%d", g.Active)
+	}
+}
+
+var (
+	errSimulatedDispatchFailure = simulatedErr("simulated WuKongIM dispatch failure")
+	errSimulatedEnqueueFailure  = simulatedErr("simulated Redis enqueue failure")
+)
+
+type simulatedErr string
+
+func (s simulatedErr) Error() string { return string(s) }
+
+// _ keeps log import referenced even if the file's BotAPI fixtures
+// stop using it during a future refactor; the parallel test files all
+// pull log.NewTLog and consistency reduces churn.
+var _ = log.NewTLog

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -124,10 +124,15 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 		payload = ba.enrichBotPayloadWithSpaceID(c, robotID, payload)
 	}
 
-	// YUJ-202 / Mininglamp-OSS#94 — mention three-state rewrite. Same
-	// chokepoint contract as modules/message/api.go: legacy
-	// `mention.all=1` is normalized to also carry `mention.humans=1`
-	// (outbound double-write keeps `all=1` for old read-side clients).
+	// YUJ-202 / Mininglamp-OSS#94 / YUJ-1389 (Plan X) — mention
+	// three-state rewrite. Same chokepoint contract as
+	// modules/message/api.go: legacy `mention.all=1` is normalized to
+	// also carry `mention.ais=1` so legacy `@所有人` traffic auto-fans-
+	// out to all AI bots without requiring an SDK update on the
+	// sender side (outbound double-write keeps `all=1` for old
+	// read-side clients that only understand the legacy field).
+	// `mention.humans=1` remains an explicit, opt-in human-
+	// notification signal — it is NEVER inferred from `all=1`.
 	// ⚠️ F2 (PR#70 Jerry-Xin correctness-critical review): this MUST
 	// be placed OUTSIDE the `ChannelTypePerson` conditional above —
 	// otherwise group / community-topic `@所有人` traffic (the main

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -19,10 +19,17 @@ import (
 
 // BotSendMessageReq is the request for sendMessage.
 type BotSendMessageReq struct {
-	ChannelID   string                 `json:"channel_id"`
-	ChannelType uint8                  `json:"channel_type"`
-	StreamNo    string                 `json:"stream_no"`
-	Payload     map[string]interface{} `json:"payload"`
+	ChannelID   string `json:"channel_id"`
+	ChannelType uint8  `json:"channel_type"`
+	StreamNo    string `json:"stream_no"`
+	// OnBehalfOf — YUJ-1166 / Mininglamp-OSS/octo-server#81 (Persona Clone v0).
+	// When non-empty the bot is asking to dispatch as the real user
+	// `OnBehalfOf`. Server validates an active OBO grant
+	// (grantor=OnBehalfOf, grantee=robotID) AND a per-channel scope row
+	// (channel_id, channel_type) before substituting FromUID. Empty / absent
+	// preserves legacy behavior (FromUID = robotID). See RFC §5.1 / §5.2.
+	OnBehalfOf string                 `json:"on_behalf_of,omitempty"`
+	Payload    map[string]interface{} `json:"payload"`
 }
 
 // sendMessage handles POST /v1/bot/sendMessage.
@@ -57,14 +64,54 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 
 	channelID := ba.resolveSpaceChannelID(robotID, req.ChannelID, req.ChannelType)
 
+	// YUJ-1166 / Mininglamp-OSS#81 Persona Clone OBO:
+	// Resolve the dispatch identity. Default = the calling bot. If the bot
+	// asks to act on behalf of a real user, validate the grant + scope
+	// BEFORE we touch the payload (so a 403 short-circuits the dispatch).
+	// Note the order: OBO check runs AFTER checkSendPermission — a bot that
+	// can't legitimately reach this channel can't bypass that check by
+	// invoking OBO.
+	fromUID := robotID
+	if strings.TrimSpace(req.OnBehalfOf) != "" {
+		if err := ba.checkOBO(robotID, req.OnBehalfOf, req.ChannelID, req.ChannelType); err != nil {
+			if errors.Is(err, ErrOBONotAuthorized) {
+				ba.Warn("OBO denied: no active grant or scope",
+					zap.String("bot", robotID),
+					zap.String("on_behalf_of", req.OnBehalfOf),
+					zap.String("channel_id", req.ChannelID),
+					zap.Uint8("channel_type", req.ChannelType))
+				c.ResponseError(ErrOBONotAuthorized)
+				return
+			}
+			c.ResponseError(errors.New("OBO 检查失败"))
+			return
+		}
+		fromUID = req.OnBehalfOf
+	}
+
 	// YUJ-644 / Mininglamp-OSS#33: PERSONAL DM 服务端权威 space_id 注入。
 	// WuKongIM 对 DM 仅按裸 uid 路由（无 Space 概念），收端 SpaceFilter 只能依赖
 	// payload.space_id；客户端上送任何值（包括缺省 / 伪造）都不可信。
 	// 优先使用 gin-context 里 authAppBot 写入的 SpaceID（O(1)，无 DB 调用）；
 	// 用户 Bot / 平台级 App Bot 落 querySpaceIDByRobotID。
+	//
+	// space_id 解析始终基于 robotID (bot)，而不是 OBO 替身的 fromUID。
+	// 理由：grant 仅授权身份替换，不应改变租户隔离边界 — bot 的 Space 归属
+	// 是部署时确定的，与 grantor 的 Space 归属解耦。
 	payload := req.Payload
 	if req.ChannelType == common.ChannelTypePerson.Uint8() {
 		payload = ba.enrichBotPayloadWithSpaceID(c, robotID, payload)
+	}
+
+	// YUJ-1166 fan-out loop guard #3: mark this message so the fan-out
+	// listener (see obo_fanout.go) skips it on the way back through the
+	// listener pipeline. RFC §5.3 calls this `obo_processed=true`.
+	// Stored in payload (= message_extra in the persisted MessageResp) so
+	// the messages table itself doesn't need an ALTER (out-of-scope row).
+	if fromUID != robotID {
+		payload = ensureMap(payload)
+		payload["obo_processed"] = true
+		payload["actual_sender_uid"] = robotID
 	}
 
 	msgReq := &config.MsgSendReq{
@@ -74,7 +121,7 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 		StreamNo:    req.StreamNo,
 		ChannelID:   channelID,
 		ChannelType: req.ChannelType,
-		FromUID:     robotID,
+		FromUID:     fromUID,
 		Payload:     []byte(util.ToJson(payload)),
 	}
 	result, err := ba.dispatchMsgSendReq(msgReq)
@@ -88,6 +135,16 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 	ba.clearTypingThrottle(robotID, channelID, req.ChannelType)
 
 	c.Response(result)
+}
+
+// ensureMap returns a non-nil map, allocating one if needed. Used by the
+// OBO marker logic in sendMessage so we never NPE on a payload that arrived
+// nil (validation above rejects len==0 but not nil-vs-empty after enrich).
+func ensureMap(m map[string]interface{}) map[string]interface{} {
+	if m == nil {
+		return map[string]interface{}{}
+	}
+	return m
 }
 
 // checkSendPermission verifies the bot has permission to send to the target channel.

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -67,8 +67,17 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 	robotID := getRobotIDFromContext(c)
 	botKind := getBotKindFromContext(c)
 
+	// PR#82 R7 — the OBO friend-gate bypass is conditional on a
+	// validated OBO context. We pledge that here based on the
+	// `on_behalf_of` field; checkOBO below independently validates the
+	// grant + scope + grantor channel access. If the pledge is false
+	// (bot sends as itself) the friend gate falls back to plain
+	// IsFriend with no bypass — preventing a bot that holds any
+	// unrelated grant from skipping the user opt-in.
+	hasOBOContext := strings.TrimSpace(req.OnBehalfOf) != ""
+
 	// Permission check based on bot kind
-	if err := ba.checkSendPermission(c, botKind, robotID, req.ChannelID, req.ChannelType); err != nil {
+	if err := ba.checkSendPermission(c, botKind, robotID, req.ChannelID, req.ChannelType, hasOBOContext); err != nil {
 		c.ResponseError(err)
 		return
 	}
@@ -162,7 +171,15 @@ func ensureMap(m map[string]interface{}) map[string]interface{} {
 }
 
 // checkSendPermission verifies the bot has permission to send to the target channel.
-func (ba *BotAPI) checkSendPermission(c *wkhttp.Context, botKind, robotID, channelID string, channelType uint8) error {
+//
+// PR#82 R7 — `hasOBOContext` signals that the inbound request carries a
+// validated `on_behalf_of` field. Only sendMessage can set this true
+// (it's the only handler whose request schema has the field, and the
+// dispatch path validates it via `checkOBO` immediately after this
+// returns). typing / readReceipt / messages-sync must pass false: they
+// dispatch AS the bot, never AS a grantor, so they cannot legitimately
+// take the OBO friend-gate bypass.
+func (ba *BotAPI) checkSendPermission(c *wkhttp.Context, botKind, robotID, channelID string, channelType uint8, hasOBOContext bool) error {
 	switch botKind {
 	case BotKindApp:
 		// Rule 1: App Bot only supports DM
@@ -234,16 +251,21 @@ func (ba *BotAPI) checkSendPermission(c *wkhttp.Context, botKind, robotID, chann
 			isCreator := robot != nil && robot.CreatorUID == channelID
 			if !isCreator {
 				// isFriendOrOBOBypass tries the friend lookup first; if
-				// the bot isn't a friend of the target, it falls back to
-				// the OBO bypass — "any active grant covering this
-				// channel where the grantor still has a relation with
-				// the target". The bypass is required by the
-				// managed-persona path: admin grants the clone bot
-				// james OBO over admin↔bob; james MUST be able to send
-				// (and signal typing / read-receipts) to bob even
-				// though james and bob are not friends. See
-				// modules/bot_api/obo_friend_gate.go for the rationale.
-				allowed, err := ba.isFriendOrOBOBypass(robotID, channelID, channelType)
+				// the bot isn't a friend of the target AND the caller
+				// signals OBO context, it falls back to the OBO bypass —
+				// "any active grant covering this channel where the
+				// grantor still has a relation with the target". The
+				// bypass is required by the managed-persona path: admin
+				// grants the clone bot james OBO over admin↔bob; james
+				// MUST be able to send (as admin) to bob even though
+				// james and bob are not friends. PR#82 R7 — the bypass
+				// is GATED on hasOBOContext so plain bot sends, typing,
+				// readReceipt, and messages-sync (which dispatch AS the
+				// bot, not AS the grantor) cannot piggy-back on an
+				// unrelated grant to skip the user opt-in friend gate.
+				// See modules/bot_api/obo_friend_gate.go for the
+				// rationale and the regression that motivated R7.
+				allowed, err := ba.isFriendOrOBOBypass(robotID, channelID, channelType, hasOBOContext)
 				if err != nil {
 					ba.Error("查询好友关系失败", zap.Error(err))
 					return errors.New("查询好友关系失败")
@@ -301,9 +323,12 @@ func (ba *BotAPI) readReceipt(c *wkhttp.Context) {
 		channelType = req.ChannelType
 	}
 
-	// Permission check: bot must have access to this channel
+	// Permission check: bot must have access to this channel.
+	// PR#82 R7 — readReceipt has no `on_behalf_of` field and always
+	// dispatches AS the bot, so the OBO friend-gate bypass MUST NOT
+	// apply here (hasOBOContext=false).
 	botKind := getBotKindFromContext(c)
-	if err := ba.checkSendPermission(c, botKind, robotID, req.ChannelID, channelType); err != nil {
+	if err := ba.checkSendPermission(c, botKind, robotID, req.ChannelID, channelType, false); err != nil {
 		c.ResponseError(err)
 		return
 	}

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -229,15 +229,26 @@ func (ba *BotAPI) checkSendPermission(c *wkhttp.Context, botKind, robotID, chann
 			}
 		} else if channelType == common.ChannelTypePerson.Uint8() {
 			// DM: creator can always talk to their bot; otherwise check friend
+			// OR the OBO managed-persona implicit bypass (PR#82 R6 P0).
 			robot := getRobotFromContext(c)
 			isCreator := robot != nil && robot.CreatorUID == channelID
 			if !isCreator {
-				isFriend, err := ba.userService.IsFriend(robotID, channelID)
+				// isFriendOrOBOBypass tries the friend lookup first; if
+				// the bot isn't a friend of the target, it falls back to
+				// the OBO bypass — "any active grant covering this
+				// channel where the grantor still has a relation with
+				// the target". The bypass is required by the
+				// managed-persona path: admin grants the clone bot
+				// james OBO over admin↔bob; james MUST be able to send
+				// (and signal typing / read-receipts) to bob even
+				// though james and bob are not friends. See
+				// modules/bot_api/obo_friend_gate.go for the rationale.
+				allowed, err := ba.isFriendOrOBOBypass(robotID, channelID, channelType)
 				if err != nil {
 					ba.Error("查询好友关系失败", zap.Error(err))
 					return errors.New("查询好友关系失败")
 				}
-				if !isFriend {
+				if !allowed {
 					return errors.New("bot is not a friend of this user")
 				}
 			}

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -52,6 +52,17 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 		c.ResponseError(errors.New("payload不能为空"))
 		return
 	}
+	// PR#82 review #2 P1-2 — reject any inbound payload that carries a
+	// reserved server-only key. The fan-out gate-3 marker
+	// (`__obo_processed__`) and any future server-injected OBO field live
+	// under this prefix; allowing a bot client to set them would let a
+	// malicious bot suppress its own fan-out copy or spoof OBO-state
+	// downstream. Reject before checkSendPermission / checkOBO so the
+	// error is fast and the auth path doesn't run on poisoned input.
+	if payloadHasReservedOBOKey(req.Payload) {
+		c.ResponseError(errors.New("payload 不允许使用以 __obo_ 开头的保留字段"))
+		return
+	}
 
 	robotID := getRobotIDFromContext(c)
 	botKind := getBotKindFromContext(c)
@@ -105,12 +116,15 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 
 	// YUJ-1166 fan-out loop guard #3: mark this message so the fan-out
 	// listener (see obo_fanout.go) skips it on the way back through the
-	// listener pipeline. RFC §5.3 calls this `obo_processed=true`.
-	// Stored in payload (= message_extra in the persisted MessageResp) so
-	// the messages table itself doesn't need an ALTER (out-of-scope row).
+	// listener pipeline. Marker key lives in the reserved `__obo_*`
+	// namespace (see oboProcessedMarkerKey) which the inbound payload
+	// validator above strips off client requests — so the marker is
+	// server-only state that a bot cannot forge or suppress. Stored in
+	// payload (= message_extra in the persisted MessageResp) so the
+	// messages table itself doesn't need an ALTER (out-of-scope row).
 	if fromUID != robotID {
 		payload = ensureMap(payload)
-		payload["obo_processed"] = true
+		payload[oboProcessedMarkerKey] = true
 		payload["actual_sender_uid"] = robotID
 	}
 

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -94,20 +94,65 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 	// invoking OBO.
 	fromUID := robotID
 	if strings.TrimSpace(req.OnBehalfOf) != "" {
-		if err := ba.checkOBO(robotID, req.OnBehalfOf, req.ChannelID, req.ChannelType); err != nil {
-			if errors.Is(err, ErrOBONotAuthorized) {
-				ba.Warn("OBO denied: no active grant or scope",
+		// YUJ-1418 — managed-persona DM grantor-reply bypass.
+		//
+		// When admin (the OBO grantor) DMs the persona-clone bot, the
+		// persona service generates an AI reply and naturally calls
+		// /v1/bot/sendMessage with on_behalf_of=admin (the persona IS
+		// admin). The recipient (channel_id) is also admin — admin's own
+		// DM with the bot. Running the standard OBO scope check on this
+		// shape rejects: no scope row covers a "grantor speaks to
+		// themselves" DM, and creating one would be semantic noise (it
+		// would route admin→admin self-DM, not bot→admin reply). Without
+		// this bypass every persona reply to its own grantor would 400
+		// with `obo not authorized`.
+		//
+		// Detection: DM channel AND on_behalf_of == channel_id AND the
+		// bot has an active grant from this user. When all three hold we
+		// fall through to the legacy (non-OBO) bot send path — fromUID
+		// stays as the bot, no OBO substitution, no `__obo_processed__`
+		// marker, no fan-out machinery — exactly what the grantor would
+		// expect when their persona "talks back" to them. Any other
+		// shape (on_behalf_of != channel_id, channel is not a DM, no
+		// active grant from the recipient) falls through to the strict
+		// checkOBO below — the OBO scope check for third-party sends
+		// MUST remain strict (issue YUJ-1418 explicitly forbids
+		// loosening it).
+		grantorReplyBypass := false
+		if req.ChannelType == common.ChannelTypePerson.Uint8() && req.OnBehalfOf == req.ChannelID {
+			hasGrant, err := ba.botHasActiveGrantFrom(robotID, req.OnBehalfOf)
+			if err != nil {
+				ba.Error("OBO grantor-reply bypass lookup failed",
 					zap.String("bot", robotID),
-					zap.String("on_behalf_of", req.OnBehalfOf),
-					zap.String("channel_id", req.ChannelID),
-					zap.Uint8("channel_type", req.ChannelType))
-				c.ResponseError(ErrOBONotAuthorized)
+					zap.String("grantor", req.OnBehalfOf),
+					zap.Error(err))
+				c.ResponseError(errors.New("OBO 检查失败"))
 				return
 			}
-			c.ResponseError(errors.New("OBO 检查失败"))
-			return
+			grantorReplyBypass = hasGrant
 		}
-		fromUID = req.OnBehalfOf
+
+		if !grantorReplyBypass {
+			if err := ba.checkOBO(robotID, req.OnBehalfOf, req.ChannelID, req.ChannelType); err != nil {
+				if errors.Is(err, ErrOBONotAuthorized) {
+					ba.Warn("OBO denied: no active grant or scope",
+						zap.String("bot", robotID),
+						zap.String("on_behalf_of", req.OnBehalfOf),
+						zap.String("channel_id", req.ChannelID),
+						zap.Uint8("channel_type", req.ChannelType))
+					c.ResponseError(ErrOBONotAuthorized)
+					return
+				}
+				c.ResponseError(errors.New("OBO 检查失败"))
+				return
+			}
+			fromUID = req.OnBehalfOf
+		} else {
+			ba.Info("OBO grantor-reply bypass: bot is replying to its own grantor in DM, sending as bot",
+				zap.String("bot", robotID),
+				zap.String("grantor", req.OnBehalfOf),
+				zap.String("channel_id", req.ChannelID))
+		}
 	}
 
 	// YUJ-644 / Mininglamp-OSS#33: PERSONAL DM 服务端权威 space_id 注入。

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
 	"github.com/gocraft/dbr/v2"
 	"go.uber.org/zap"
 )
@@ -122,6 +123,17 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 	if req.ChannelType == common.ChannelTypePerson.Uint8() {
 		payload = ba.enrichBotPayloadWithSpaceID(c, robotID, payload)
 	}
+
+	// YUJ-202 / Mininglamp-OSS#94 — mention three-state rewrite. Same
+	// chokepoint contract as modules/message/api.go: legacy
+	// `mention.all=1` is normalized to also carry `mention.humans=1`
+	// (outbound double-write keeps `all=1` for old read-side clients).
+	// ⚠️ F2 (PR#70 Jerry-Xin correctness-critical review): this MUST
+	// be placed OUTSIDE the `ChannelTypePerson` conditional above —
+	// otherwise group / community-topic `@所有人` traffic (the main
+	// pain-point being fixed) would bypass the rewrite. Helper is
+	// idempotent and safe on nil — see pkg/mentionrewrite.
+	payload = mentionrewrite.RewriteMention(payload)
 
 	// YUJ-1166 fan-out loop guard #3: mark this message so the fan-out
 	// listener (see obo_fanout.go) skips it on the way back through the

--- a/modules/bot_api/send_test.go
+++ b/modules/bot_api/send_test.go
@@ -303,13 +303,17 @@ func TestSendMessage_PersonalDM_DBError_ForgedClientSpaceID_Stripped(t *testing.
 
 // TestSendMessage_MentionAllRewritten_HandlerIntegration is the YUJ-1343 /
 // Mininglamp-OSS/octo-server#94 acceptance test for the mention three-state
-// rewrite on the /v1/bot/sendMessage handler path.
+// rewrite on the /v1/bot/sendMessage handler path, updated for Plan X
+// (YUJ-1389).
 //
 // This is the "handler-level integration test" the issue calls out: drive
 // BotAPI.sendMessage end-to-end with a `payload.mention.all=1` body and
-// assert the captured MsgSendReq carries `mention.humans=1` (chokepoint
-// rewrite ran) AND still carries `mention.all=1` (outbound double-write
-// preserved for legacy read-side clients). Lesson from PR#82 OBO fan-out:
+// assert the captured MsgSendReq carries `mention.ais=1` (Plan X
+// chokepoint rewrite ran — legacy `@所有人` auto-fans-out to all AI bots
+// without an SDK update) AND still carries `mention.all=1` (outbound
+// double-write preserved for legacy read-side clients). humans MUST
+// stay absent — humans is the explicit human-notification signal and is
+// never inferred from a legacy `all=1`. Lesson from PR#82 OBO fan-out:
 // when an external-service shape constraint matters, the test MUST go
 // through the real handler stack — not call the helper in isolation —
 // otherwise a wiring regression (e.g. someone deletes the call site by
@@ -382,27 +386,31 @@ func TestSendMessage_MentionAllRewritten_HandlerIntegration(t *testing.T) {
 	if !assert.True(t, ok, "dispatched payload must keep mention map; got %T", dispatchedPayload["mention"]) {
 		return
 	}
-	// Chokepoint rewrite ran — humans=1 is now present.
-	humans, _ := mention["humans"].(json.Number)
-	assert.Equal(t, "1", humans.String(),
-		"BotAPI.sendMessage must invoke mentionrewrite.RewriteMention so mention.humans=1 reaches the dispatcher")
+	// Plan X chokepoint rewrite ran — ais=1 is now present (legacy
+	// `@所有人` auto-fans-out to all AI bots without an SDK update).
+	ais, _ := mention["ais"].(json.Number)
+	assert.Equal(t, "1", ais.String(),
+		"Plan X: BotAPI.sendMessage must invoke mentionrewrite.RewriteMention so mention.ais=1 reaches the dispatcher")
 	// Outbound double-write — legacy all=1 still present so old read-side
 	// clients keep rendering the @所有人 pill until they roll out support
 	// for the humans/ais fields.
 	all, _ := mention["all"].(json.Number)
 	assert.Equal(t, "1", all.String(),
 		"legacy mention.all=1 MUST be preserved on the dispatched payload (outbound double-write)")
-	// ais MUST stay absent — Yu D1: legacy @所有人 must NOT auto-fan-out
-	// to bots (the exact pain point the rewrite is closing).
-	_, hasAIs := mention["ais"]
-	assert.False(t, hasAIs,
-		"BotAPI.sendMessage rewrite must NOT auto-set mention.ais — would re-trigger the bot fan-out pain point")
+	// humans MUST stay absent — Plan X: humans is the explicit human-
+	// notification signal and is NEVER inferred from a legacy `all=1`.
+	// Only the sender may set humans, and only when they want a
+	// channel-level "[有人@我]" reminder for human members.
+	_, hasHumans := mention["humans"]
+	assert.False(t, hasHumans,
+		"BotAPI.sendMessage rewrite must NOT auto-set mention.humans — humans is an explicit opt-in signal")
 }
 
 // TestSendMessage_MentionAisPassthrough_HandlerIntegration verifies the
 // other end of the matrix: an explicit `mention.ais=1` from a new client
-// passes through the chokepoint untouched (the rewrite is a one-way
-// "all → also humans" rule, never adds humans/ais from thin air).
+// passes through the chokepoint untouched (the Plan X rewrite is a
+// one-way "all → also ais" rule, never adds humans/ais from thin air
+// when the inbound shape did not request the broadcast via all=1).
 func TestSendMessage_MentionAisPassthrough_HandlerIntegration(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/modules/bot_api/send_test.go
+++ b/modules/bot_api/send_test.go
@@ -300,3 +300,165 @@ func TestSendMessage_PersonalDM_DBError_ForgedClientSpaceID_Stripped(t *testing.
 	assert.False(t, hasSpaceID,
 		"DB error + forged client space_id MUST be stripped from dispatched payload — attackers cannot use transient DB failure to bypass authoritative override")
 }
+
+// TestSendMessage_MentionAllRewritten_HandlerIntegration is the YUJ-1343 /
+// Mininglamp-OSS/octo-server#94 acceptance test for the mention three-state
+// rewrite on the /v1/bot/sendMessage handler path.
+//
+// This is the "handler-level integration test" the issue calls out: drive
+// BotAPI.sendMessage end-to-end with a `payload.mention.all=1` body and
+// assert the captured MsgSendReq carries `mention.humans=1` (chokepoint
+// rewrite ran) AND still carries `mention.all=1` (outbound double-write
+// preserved for legacy read-side clients). Lesson from PR#82 OBO fan-out:
+// when an external-service shape constraint matters, the test MUST go
+// through the real handler stack — not call the helper in isolation —
+// otherwise a wiring regression (e.g. someone deletes the call site by
+// mistake) slips past unit coverage.
+//
+// Uses the existing creator-DM path (BotKindUser whose CreatorUID ==
+// channel_id) so the test does not need a live IsFriend / group_member
+// table. The rewrite call site itself is placed OUTSIDE the
+// `ChannelTypePerson` conditional (F2 — see modules/bot_api/send.go), so
+// even though this test drives a DM, the helper still runs; the same
+// helper would run on the group / community-topic path by inspection.
+func TestSendMessage_MentionAllRewritten_HandlerIntegration(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		botRobotID = "bot_mention_rewrite_it"
+		creatorUID = "user_creator_mention_it"
+	)
+
+	dc := &dispatchCapture{}
+	q := &fakeSpaceQuerier{defaultSpace: "space_A"}
+
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-mention-it"),
+		spaceQuerier:     q,
+		dispatchOverride: dc.hook,
+	}
+
+	body, _ := json.Marshal(BotSendMessageReq{
+		ChannelID:   creatorUID,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Payload: map[string]interface{}{
+			"type":    1,
+			"content": "@所有人 ping",
+			// Legacy @所有人 inbound — chokepoint MUST rewrite this.
+			"mention": map[string]interface{}{
+				"all": 1,
+			},
+		},
+	})
+
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/bot/sendMessage", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httpReq
+	c := &wkhttp.Context{Context: gc}
+	c.Set(CtxKeyRobotID, botRobotID)
+	c.Set(CtxKeyBotKind, BotKindUser)
+	c.Set(CtxKeyRobot, &robotModel{RobotID: botRobotID, CreatorUID: creatorUID})
+
+	ba.sendMessage(c)
+
+	assert.Equalf(t, http.StatusOK, rec.Code,
+		"sendMessage should respond 200 OK, got %d body=%s", rec.Code, rec.Body.String())
+
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	if !assert.NotNil(t, dc.captured, "dispatch hook must have been invoked") {
+		return
+	}
+
+	var dispatchedPayload map[string]interface{}
+	dec := json.NewDecoder(bytes.NewReader(dc.captured.Payload))
+	dec.UseNumber()
+	if !assert.NoError(t, dec.Decode(&dispatchedPayload)) {
+		return
+	}
+	mention, ok := dispatchedPayload["mention"].(map[string]interface{})
+	if !assert.True(t, ok, "dispatched payload must keep mention map; got %T", dispatchedPayload["mention"]) {
+		return
+	}
+	// Chokepoint rewrite ran — humans=1 is now present.
+	humans, _ := mention["humans"].(json.Number)
+	assert.Equal(t, "1", humans.String(),
+		"BotAPI.sendMessage must invoke mentionrewrite.RewriteMention so mention.humans=1 reaches the dispatcher")
+	// Outbound double-write — legacy all=1 still present so old read-side
+	// clients keep rendering the @所有人 pill until they roll out support
+	// for the humans/ais fields.
+	all, _ := mention["all"].(json.Number)
+	assert.Equal(t, "1", all.String(),
+		"legacy mention.all=1 MUST be preserved on the dispatched payload (outbound double-write)")
+	// ais MUST stay absent — Yu D1: legacy @所有人 must NOT auto-fan-out
+	// to bots (the exact pain point the rewrite is closing).
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAIs,
+		"BotAPI.sendMessage rewrite must NOT auto-set mention.ais — would re-trigger the bot fan-out pain point")
+}
+
+// TestSendMessage_MentionAisPassthrough_HandlerIntegration verifies the
+// other end of the matrix: an explicit `mention.ais=1` from a new client
+// passes through the chokepoint untouched (the rewrite is a one-way
+// "all → also humans" rule, never adds humans/ais from thin air).
+func TestSendMessage_MentionAisPassthrough_HandlerIntegration(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		botRobotID = "bot_ais_it"
+		creatorUID = "user_creator_ais_it"
+	)
+
+	dc := &dispatchCapture{}
+	q := &fakeSpaceQuerier{defaultSpace: "space_A"}
+
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-ais-it"),
+		spaceQuerier:     q,
+		dispatchOverride: dc.hook,
+	}
+
+	body, _ := json.Marshal(BotSendMessageReq{
+		ChannelID:   creatorUID,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Payload: map[string]interface{}{
+			"type":    1,
+			"content": "@所有 AI ping",
+			"mention": map[string]interface{}{
+				"ais": 1,
+			},
+		},
+	})
+
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/bot/sendMessage", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httpReq
+	c := &wkhttp.Context{Context: gc}
+	c.Set(CtxKeyRobotID, botRobotID)
+	c.Set(CtxKeyBotKind, BotKindUser)
+	c.Set(CtxKeyRobot, &robotModel{RobotID: botRobotID, CreatorUID: creatorUID})
+
+	ba.sendMessage(c)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	if !assert.NotNil(t, dc.captured) {
+		return
+	}
+	var dispatchedPayload map[string]interface{}
+	dec := json.NewDecoder(bytes.NewReader(dc.captured.Payload))
+	dec.UseNumber()
+	assert.NoError(t, dec.Decode(&dispatchedPayload))
+	mention := dispatchedPayload["mention"].(map[string]interface{})
+	ais, _ := mention["ais"].(json.Number)
+	assert.Equal(t, "1", ais.String(), "ais=1 must passthrough")
+	_, hasHumans := mention["humans"]
+	assert.False(t, hasHumans, "ais-only input must NOT gain humans=1")
+	_, hasAll := mention["all"]
+	assert.False(t, hasAll, "ais-only input must NOT gain legacy all=1")
+}

--- a/modules/bot_api/send_test.go
+++ b/modules/bot_api/send_test.go
@@ -59,9 +59,9 @@ func TestSendMessage_PersonalDM_StripsForgedClientSpaceID(t *testing.T) {
 
 	const (
 		botRobotID    = "bot_X"
-		creatorUID    = "user_creator"      // == channel_id, exercises creator-bypass branch
-		authoritative = "space_A"           // returned by stubbed querySpaceIDByRobotID
-		forged        = "space_B_attacker"  // attacker-supplied value in payload
+		creatorUID    = "user_creator"     // == channel_id, exercises creator-bypass branch
+		authoritative = "space_A"          // returned by stubbed querySpaceIDByRobotID
+		forged        = "space_B_attacker" // attacker-supplied value in payload
 	)
 
 	dc := &dispatchCapture{}

--- a/modules/bot_api/sql/20260519000001_obo_v0.sql
+++ b/modules/bot_api/sql/20260519000001_obo_v0.sql
@@ -1,0 +1,41 @@
+-- +migrate Up
+-- YUJ-1166 / Mininglamp-OSS/octo-server#81 — Persona Clone (OBO) v0.
+-- Two new tables backing the On-Behalf-Of authorization layer used by
+-- /v1/obo/* CRUD endpoints, the on_behalf_of branch in /v1/bot/sendMessage,
+-- and the fan-out hook that copies inbound messages to a grantee bot.
+--
+-- See RFC §4.1 / §4.2 / §11 (Redis cache `obo:grantor:{uid}` is application
+-- layer, not declared here). messages-table ALTER intentionally skipped:
+-- v0 stores audit metadata in message_extra (RFC §4.3 / out-of-scope row in
+-- YUJ-1166).
+
+CREATE TABLE IF NOT EXISTS obo_grants (
+  id              BIGINT AUTO_INCREMENT PRIMARY KEY,
+  grantor_uid     VARCHAR(64)  NOT NULL COMMENT 'Real-user uid being represented (e.g. yu_uid).',
+  grantee_bot_uid VARCHAR(64)  NOT NULL COMMENT 'Bot uid acting on behalf of grantor (e.g. yu_clone_bot).',
+  mode            VARCHAR(16)  NOT NULL DEFAULT 'auto' COMMENT 'auto | draft (v0 only auto is honored).',
+  global_enabled  TINYINT      NOT NULL DEFAULT 0 COMMENT 'Master switch: 0 disables ALL scopes for this grant.',
+  active          TINYINT      NOT NULL DEFAULT 1 COMMENT 'Soft-delete flag (0 = revoked, kept for audit).',
+  created_at      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  revoked_at      DATETIME     DEFAULT NULL,
+  UNIQUE KEY uk_grantor_grantee (grantor_uid, grantee_bot_uid),
+  KEY idx_grantor (grantor_uid, active),
+  KEY idx_grantee (grantee_bot_uid, active)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE IF NOT EXISTS obo_scopes (
+  id           BIGINT AUTO_INCREMENT PRIMARY KEY,
+  grant_id     BIGINT       NOT NULL,
+  channel_id   VARCHAR(128) NOT NULL,
+  channel_type TINYINT      NOT NULL,
+  enabled      TINYINT      NOT NULL DEFAULT 1,
+  created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY uk_grant_channel (grant_id, channel_id, channel_type),
+  KEY idx_channel (channel_id, channel_type, enabled),
+  CONSTRAINT fk_obo_scopes_grant FOREIGN KEY (grant_id) REFERENCES obo_grants(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- +migrate Down
+DROP TABLE IF EXISTS obo_scopes;
+DROP TABLE IF EXISTS obo_grants;

--- a/modules/bot_api/sync.go
+++ b/modules/bot_api/sync.go
@@ -84,13 +84,18 @@ func (ba *BotAPI) syncMessages(c *wkhttp.Context) {
 			robot := getRobotFromContext(c)
 			isCreator := robot != nil && robot.CreatorUID == req.ChannelID
 			if !isCreator {
-				isFriend, err := ba.userService.IsFriend(robotID, req.ChannelID)
+				// PR#82 R6 P0 — friend gate is OBO-aware. See
+				// obo_friend_gate.go for rationale: managed-persona
+				// clones need to read message history of channels they
+				// have OBO authority over even when bot↔user is not a
+				// friend pair.
+				allowed, err := ba.isFriendOrOBOBypass(robotID, req.ChannelID, req.ChannelType)
 				if err != nil {
 					ba.Error("failed to check friend relationship", zap.Error(err))
 					c.ResponseError(errors.New("failed to check friend relationship"))
 					return
 				}
-				if !isFriend {
+				if !allowed {
 					c.ResponseError(errors.New("bot is not a friend of this user"))
 					return
 				}

--- a/modules/bot_api/sync.go
+++ b/modules/bot_api/sync.go
@@ -89,7 +89,15 @@ func (ba *BotAPI) syncMessages(c *wkhttp.Context) {
 				// clones need to read message history of channels they
 				// have OBO authority over even when bot↔user is not a
 				// friend pair.
-				allowed, err := ba.isFriendOrOBOBypass(robotID, req.ChannelID, req.ChannelType)
+				//
+				// PR#82 R7 — messages/sync has no `on_behalf_of` field
+				// and the response stream is delivered TO the bot, not
+				// proxied through any grantor. A bot that holds an
+				// unrelated grant covering some target must NOT be able
+				// to pull that target's DM history without the user
+				// opt-in friend gate. So hasOBOContext=false: pure
+				// IsFriend, no bypass.
+				allowed, err := ba.isFriendOrOBOBypass(robotID, req.ChannelID, req.ChannelType, false)
 				if err != nil {
 					ba.Error("failed to check friend relationship", zap.Error(err))
 					c.ResponseError(errors.New("failed to check friend relationship"))

--- a/modules/bot_api/typing.go
+++ b/modules/bot_api/typing.go
@@ -38,9 +38,15 @@ func (ba *BotAPI) typing(c *wkhttp.Context) {
 	robotID := getRobotIDFromContext(c)
 	channelID := ba.resolveSpaceChannelID(robotID, req.ChannelID, req.ChannelType)
 
-	// Permission check: bot must have access to this channel
+	// Permission check: bot must have access to this channel.
+	// PR#82 R7 — typing has no `on_behalf_of` field and always
+	// dispatches AS the bot (CMDTyping carries from_uid=robotID below),
+	// so the OBO friend-gate bypass MUST NOT apply here
+	// (hasOBOContext=false). Allowing it would let a bot that holds an
+	// unrelated grant signal typing in a DM with a user that has not
+	// opted in to that bot.
 	botKind := getBotKindFromContext(c)
-	if err := ba.checkSendPermission(c, botKind, robotID, req.ChannelID, req.ChannelType); err != nil {
+	if err := ba.checkSendPermission(c, botKind, robotID, req.ChannelID, req.ChannelType, false); err != nil {
 		c.ResponseError(err)
 		return
 	}

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -220,9 +220,9 @@ type Message struct {
 	threadDB       *thread.DB
 	// groupDB: 直查 group 表，区分"群不存在"和"群已解散"两种 404 情况，
 	// groupService.GetGroupWithGroupNo 把 nil 也包成 error 不便分辨。
-	groupDB *group.DB
-	mutex          sync.Mutex
-	stopChan       chan struct{}
+	groupDB  *group.DB
+	mutex    sync.Mutex
+	stopChan chan struct{}
 }
 
 // New New
@@ -440,6 +440,11 @@ func (m *Message) sendMsg(c *wkhttp.Context) {
 // （YUJ-644 / Mininglamp-OSS#33）。空串 senderSpaceID 表示发送方未声明 Space
 // （非 Space 模式 / 老客户端兼容），PERSONAL 走老 passthrough 行为。
 func (m *Message) sendMessage(channelID string, channelType uint8, fromUID string, payload map[string]interface{}, senderSpaceID string) error {
+	// PR#82 R8 (Jerry-Xin 2026-05-19 review on head 244fe9fa): strip any
+	// reserved `__obo_*` top-level key from the user-supplied payload
+	// BEFORE persistence/dispatch. See sanitizeUserIngressPayload below
+	// for the full rationale and unit test surface.
+	sanitizeUserIngressPayload(payload, channelID, channelType, fromUID, m.Warn)
 	// YUJ-219-A / GH#1283 (analysis-report.md §4.5 / §7.4)：
 	// 派发前为消息 payload 注入权威 space_id，让客户端 SpaceFilter 拿到可信字段，
 	// race 窗口的 fail-open 语义可降级为 fail-closed。

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -223,6 +223,13 @@ type Message struct {
 	groupDB  *group.DB
 	mutex    sync.Mutex
 	stopChan chan struct{}
+	// reminderSeqOverride lets unit tests stub the version generator
+	// used by getReminders / cancelMentionReminderIfNeed so the helpers
+	// can be exercised without standing up the seq table / MySQL.
+	// Production path: nil → ctx.GenSeq(common.RemindersKey) runs.
+	// Tests inject a deterministic counter so the matrix tests in
+	// api_reminders_test.go don't need a live DB. See nextReminderSeq.
+	reminderSeqOverride func() (int64, error)
 }
 
 // New New
@@ -445,6 +452,17 @@ func (m *Message) sendMessage(channelID string, channelType uint8, fromUID strin
 	// BEFORE persistence/dispatch. See sanitizeUserIngressPayload below
 	// for the full rationale and unit test surface.
 	sanitizeUserIngressPayload(payload, channelID, channelType, fromUID, m.Warn)
+	// YUJ-202 / Mininglamp-OSS#94 — mention three-state rewrite
+	// (方案 X step §5 of docs/2026-05-mention-all-chokepoint-audit.md).
+	// Legacy clients still send `mention.all=1` for "@所有人"; the
+	// chokepoint normalizes that to also carry `mention.humans=1` so
+	// new read-side adapters can render the pill, AND keeps `all=1` in
+	// place as an outbound double-write for old read-side clients that
+	// only understand `all`. ais is left untouched (Yu D1 — legacy
+	// "@所有人" must NOT auto-trigger ais=1). Helper is idempotent and
+	// safe on nil / malformed mention shapes — see
+	// pkg/mentionrewrite/rewrite.go for the contract.
+	payload = RewriteMention(payload)
 	// YUJ-219-A / GH#1283 (analysis-report.md §4.5 / §7.4)：
 	// 派发前为消息 payload 注入权威 space_id，让客户端 SpaceFilter 拿到可信字段，
 	// race 窗口的 fail-open 语义可降级为 fail-closed。

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -461,13 +461,16 @@ func (m *Message) sendMessage(channelID string, channelType uint8, fromUID strin
 	// YUJ-202 / Mininglamp-OSS#94 — mention three-state rewrite
 	// (方案 X step §5 of docs/2026-05-mention-all-chokepoint-audit.md).
 	// Legacy clients still send `mention.all=1` for "@所有人"; the
-	// chokepoint normalizes that to also carry `mention.humans=1` so
-	// new read-side adapters can render the pill, AND keeps `all=1` in
-	// place as an outbound double-write for old read-side clients that
-	// only understand `all`. ais is left untouched (Yu D1 — legacy
-	// "@所有人" must NOT auto-trigger ais=1). Helper is idempotent and
-	// safe on nil / malformed mention shapes — see
-	// pkg/mentionrewrite/rewrite.go for the contract.
+	// chokepoint normalizes that to also carry `mention.ais=1` (Plan X
+	// / YUJ-1389) so legacy `@所有人` automatically fans out to all AI
+	// bots without an SDK update, AND keeps `all=1` in place as an
+	// outbound double-write for old read-side clients that only
+	// understand `all`. `mention.humans=1` is NEVER inferred from
+	// legacy `all=1` — humans is the explicit human-notification signal
+	// and must be set by the client (Yu D1 — legacy "@所有人" must NOT
+	// auto-tag humans). Helper is idempotent and safe on nil /
+	// malformed mention shapes — see pkg/mentionrewrite/rewrite.go for
+	// the contract.
 	payload = RewriteMention(payload)
 	// YUJ-219-A / GH#1283 (analysis-report.md §4.5 / §7.4)：
 	// 派发前为消息 payload 注入权威 space_id，让客户端 SpaceFilter 拿到可信字段，

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -224,11 +224,17 @@ type Message struct {
 	mutex    sync.Mutex
 	stopChan chan struct{}
 	// reminderSeqOverride lets unit tests stub the version generator
-	// used by getReminders / cancelMentionReminderIfNeed so the helpers
-	// can be exercised without standing up the seq table / MySQL.
-	// Production path: nil → ctx.GenSeq(common.RemindersKey) runs.
-	// Tests inject a deterministic counter so the matrix tests in
+	// used by getReminders so the matrix helpers can run without
+	// standing up the seq table / MySQL. Production path: nil →
+	// ctx.GenSeq(common.RemindersKey) runs. Tests inject a
+	// deterministic counter so the matrix tests in
 	// api_reminders_test.go don't need a live DB. See nextReminderSeq.
+	//
+	// Scope: getReminders + reminderDone only (everything wired through
+	// nextReminderSeq). cancelMentionReminderIfNeed and other in-tree
+	// callers still call ctx.GenSeq directly — those paths are not
+	// exercised by the matrix suite, so widening the seam there is
+	// deliberately deferred to keep the diff minimal.
 	reminderSeqOverride func() (int64, error)
 }
 

--- a/modules/message/api_reminders.go
+++ b/modules/message/api_reminders.go
@@ -2,18 +2,18 @@ package message
 
 import (
 	"encoding/json"
-	"os"
-	"runtime/debug"
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"runtime/debug"
 	"time"
 
-	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"go.uber.org/zap"
 )
 

--- a/modules/message/api_reminders.go
+++ b/modules/message/api_reminders.go
@@ -102,6 +102,19 @@ func (m *Message) reminderSync(c *wkhttp.Context) {
 		return
 	}
 
+	// YUJ-1377 / Mininglamp-OSS/octo-server#101 — drop channel-level
+	// (UID=="") broadcast reminders authored by the viewer itself, so
+	// the sender of `@所有人` does not receive their own red-dot.
+	// Per-uid reminders (apply-join-group, explicit `mention.uids`) are
+	// untouched: they carry UID!="" and pass through verbatim.
+	//
+	// Primary fix is in remindersDB.sync (SQL predicate) — that keeps
+	// the version/limit cursor advancing past hidden self-broadcasts so
+	// the client never stalls. This call is a defense-in-depth filter
+	// for any future read path that forgets the SQL predicate; it is a
+	// no-op when sync() has already done its job.
+	reminders = filterChannelLevelByPublisher(reminders, loginUID)
+
 	groupIds := make([]string, 0)
 	if len(reminders) > 0 {
 		for _, reminder := range reminders {
@@ -244,6 +257,44 @@ func (m *Message) getReminders(messages []*config.MessageResp) []*remindersModel
 		}
 	}
 	return reminders
+}
+
+// filterChannelLevelByPublisher removes channel-level reminders
+// (UID=="") whose Publisher equals the viewer. Used as a
+// defense-in-depth pass after remindersDB.sync, which already enforces
+// the same predicate at the SQL layer for cursor correctness
+// (YUJ-1377 / Mininglamp-OSS/octo-server#101).
+//
+// Per-uid reminders (UID!="") are returned untouched. This preserves
+// other reminder types — notably ReminderTypeApplyJoinGroup, which is
+// always emitted with an explicit UID — so the filter is a no-op for
+// anything except the @-broadcast fan-out.
+//
+// Returns the input slice unchanged when no row matches the filter,
+// avoiding an allocation on the common path.
+func filterChannelLevelByPublisher(reminders []*remindersDetailModel, viewerUID string) []*remindersDetailModel {
+	if len(reminders) == 0 || viewerUID == "" {
+		return reminders
+	}
+	// Fast path: scan first to decide whether we need to allocate.
+	drop := false
+	for _, r := range reminders {
+		if r != nil && r.UID == "" && r.Publisher == viewerUID {
+			drop = true
+			break
+		}
+	}
+	if !drop {
+		return reminders
+	}
+	out := make([]*remindersDetailModel, 0, len(reminders))
+	for _, r := range reminders {
+		if r != nil && r.UID == "" && r.Publisher == viewerUID {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
 }
 
 func (m *Message) handleReminders(reminders []*remindersModel) {

--- a/modules/message/api_reminders.go
+++ b/modules/message/api_reminders.go
@@ -184,24 +184,38 @@ func (m *Message) getReminders(messages []*config.MessageResp) []*remindersModel
 		if m.hasMention(payloadMap) {
 			all, uids := m.getMention(payloadMap)
 			if all {
-				version, err := m.nextReminderSeq()
-				if err != nil {
-					m.Warn("GenSeq failed", zap.Error(err))
-					continue
+				// Plan X (YUJ-1389): only create a channel-level
+				// reminder when humans=1 is explicitly set. ais-only
+				// broadcasts (including legacy all=1 → rewritten to
+				// ais=1) do NOT create human-visible reminders. Bots
+				// respond via the message delivery path, so a
+				// "[有人@我]" red-dot for human members would be noise.
+				mentionMap2, _ := payloadMap["mention"].(map[string]interface{})
+				hasHumans := mentionFlagTruthy(mentionMap2["humans"])
+				if hasHumans {
+					version, err := m.nextReminderSeq()
+					if err != nil {
+						m.Warn("GenSeq failed", zap.Error(err))
+						continue
+					}
+					reminders = append(reminders, &remindersModel{
+						ChannelID:    message.ChannelID,
+						ChannelType:  message.ChannelType,
+						ClientMsgNo:  message.ClientMsgNo,
+						Publisher:    message.FromUID,
+						MessageID:    fmt.Sprintf("%d", message.MessageID),
+						MessageSeq:   message.MessageSeq,
+						ReminderType: ReminderTypeMentionMe,
+						IsLocate:     1,
+						Version:      version,
+						Text:         "[有人@我]",
+					})
 				}
-				reminders = append(reminders, &remindersModel{
-					ChannelID:    message.ChannelID,
-					ChannelType:  message.ChannelType,
-					ClientMsgNo:  message.ClientMsgNo,
-					Publisher:    message.FromUID,
-					MessageID:    fmt.Sprintf("%d", message.MessageID),
-					MessageSeq:   message.MessageSeq,
-					ReminderType: ReminderTypeMentionMe,
-					IsLocate:     1,
-					Version:      version,
-					Text:         "[有人@我]",
-				})
-			} else if len(uids) > 0 {
+				// Fall through to uid processing below regardless — a
+				// broadcast can still carry explicit @uid mentions
+				// (`@所有人 + @alice`) that need per-user reminders.
+			}
+			if len(uids) > 0 {
 				for _, uid := range uids {
 					version, err := m.nextReminderSeq()
 					if err != nil {
@@ -350,26 +364,34 @@ func (m *Message) getMention(payloadMap map[string]interface{}) (all bool, uids 
 	if !ok {
 		return false, nil
 	}
-	// YUJ-202 / Mininglamp-OSS#94 — mention three-state read side. The
-	// chokepoint rewrite (pkg/mentionrewrite.RewriteMention) double-
-	// writes legacy `mention.all=1` into `mention.humans=1`, and a new
-	// client can also send `mention.ais=1` independently. Reminder
-	// fan-out treats ANY of {humans, ais, all} = 1 as a "broadcast"
-	// mention so the channel-level reminder is emitted. The per-role
-	// dispatch decision (humans-only / ais-only / both) lives client-
-	// side: new read-side adapters consult `humans` / `ais` to decide
-	// whether to render the red-dot; bots ignore `humans` and only
-	// react to `ais`. Reasoning matrix (RFC §6, Yu D1-D8):
+	// YUJ-202 / Mininglamp-OSS#94 / YUJ-1389 (Plan X) — mention
+	// three-state read side. The chokepoint rewrite
+	// (pkg/mentionrewrite.RewriteMention) double-writes legacy
+	// `mention.all=1` into `mention.ais=1` (Plan X: legacy `@所有人`
+	// auto-fans-out to all AI bots without an SDK update), and a new
+	// client can also send `mention.humans=1` independently. getMention
+	// here returns all=true if ANY of {humans, ais, all} = 1 so the
+	// caller (getReminders) can then gate the channel-level reminder on
+	// the explicit `humans=1` signal — see the call site for the
+	// reminder-emission logic. Reasoning matrix (Plan X, YUJ-1389):
 	//
-	//   humans=1                → human members see reminder, bots silent
-	//   ais=1                   → bot members see reminder, humans silent
-	//   humans=1 AND ais=1      → both render
-	//   all=1 (post-rewrite has humans=1 too) → humans only — legacy
-	//                              "@所有人" must NOT auto-fan-out to
-	//                              bots (the pain point being fixed)
+	//   humans=1                       → human members see reminder,
+	//                                    bots silent (humans-only path)
+	//   ais=1                          → bot members respond via
+	//                                    message delivery, NO channel-
+	//                                    level reminder is created
+	//   humans=1 AND ais=1             → humans see reminder, bots
+	//                                    respond via delivery
+	//   all=1 (post-rewrite has ais=1) → same as ais=1, NO human
+	//                                    reminder — legacy `@所有人`
+	//                                    behaves as a bot broadcast
+	//                                    unless the client ALSO sets
+	//                                    humans=1 explicitly
 	//
-	// Server emits one channel-level reminder for any of these shapes;
-	// role filtering is the adapters' job.
+	// getMention itself stays "any broadcast → all=true"; the
+	// humans-gate lives at the call site so we never lose the per-uid
+	// fan-out branch when a broadcast also carries explicit @uid
+	// mentions.
 	if mentionAnyBroadcast(mentionMap) {
 		all = true
 	}

--- a/modules/message/api_reminders.go
+++ b/modules/message/api_reminders.go
@@ -49,7 +49,7 @@ func (m *Message) reminderDone(c *wkhttp.Context) {
 		return
 	}
 	for _, id := range ids {
-		version, err := m.ctx.GenSeq(common.RemindersKey)
+		version, err := m.nextReminderSeq()
 		if err != nil {
 			c.ResponseError(err)
 			return
@@ -143,6 +143,20 @@ func (m *Message) listenerMessages(messages []*config.MessageResp) {
 
 }
 
+// nextReminderSeq returns the next monotonically increasing version
+// number used to seed remindersModel.Version. Production path delegates
+// to ctx.GenSeq(common.RemindersKey) (backed by the seq table); unit
+// tests inject reminderSeqOverride to skip the DB and exercise the
+// fan-out / matrix helpers in isolation. Keeping this seam local to
+// the reminders module avoids leaking the stub through Message's
+// exported surface.
+func (m *Message) nextReminderSeq() (int64, error) {
+	if m.reminderSeqOverride != nil {
+		return m.reminderSeqOverride()
+	}
+	return m.ctx.GenSeq(common.RemindersKey)
+}
+
 func (m *Message) getReminders(messages []*config.MessageResp) []*remindersModel {
 	reminders := make([]*remindersModel, 0, len(messages))
 	for _, message := range messages {
@@ -157,7 +171,7 @@ func (m *Message) getReminders(messages []*config.MessageResp) []*remindersModel
 		if m.hasMention(payloadMap) {
 			all, uids := m.getMention(payloadMap)
 			if all {
-				version, err := m.ctx.GenSeq(common.RemindersKey)
+				version, err := m.nextReminderSeq()
 				if err != nil {
 					m.Warn("GenSeq failed", zap.Error(err))
 					continue
@@ -176,7 +190,7 @@ func (m *Message) getReminders(messages []*config.MessageResp) []*remindersModel
 				})
 			} else if len(uids) > 0 {
 				for _, uid := range uids {
-					version, err := m.ctx.GenSeq(common.RemindersKey)
+					version, err := m.nextReminderSeq()
 					if err != nil {
 						m.Warn("GenSeq failed", zap.Error(err))
 						continue
@@ -209,7 +223,7 @@ func (m *Message) getReminders(messages []*config.MessageResp) []*remindersModel
 					if !ok {
 						continue
 					}
-					version, err := m.ctx.GenSeq(common.RemindersKey)
+					version, err := m.nextReminderSeq()
 					if err != nil {
 						m.Warn("GenSeq failed", zap.Error(err))
 						continue
@@ -285,13 +299,28 @@ func (m *Message) getMention(payloadMap map[string]interface{}) (all bool, uids 
 	if !ok {
 		return false, nil
 	}
-	if mentionMap["all"] != nil {
-		if allNum, ok := mentionMap["all"].(json.Number); ok {
-			allI, _ := allNum.Int64()
-			if allI == 1 {
-				all = true
-			}
-		}
+	// YUJ-202 / Mininglamp-OSS#94 — mention three-state read side. The
+	// chokepoint rewrite (pkg/mentionrewrite.RewriteMention) double-
+	// writes legacy `mention.all=1` into `mention.humans=1`, and a new
+	// client can also send `mention.ais=1` independently. Reminder
+	// fan-out treats ANY of {humans, ais, all} = 1 as a "broadcast"
+	// mention so the channel-level reminder is emitted. The per-role
+	// dispatch decision (humans-only / ais-only / both) lives client-
+	// side: new read-side adapters consult `humans` / `ais` to decide
+	// whether to render the red-dot; bots ignore `humans` and only
+	// react to `ais`. Reasoning matrix (RFC §6, Yu D1-D8):
+	//
+	//   humans=1                → human members see reminder, bots silent
+	//   ais=1                   → bot members see reminder, humans silent
+	//   humans=1 AND ais=1      → both render
+	//   all=1 (post-rewrite has humans=1 too) → humans only — legacy
+	//                              "@所有人" must NOT auto-fan-out to
+	//                              bots (the pain point being fixed)
+	//
+	// Server emits one channel-level reminder for any of these shapes;
+	// role filtering is the adapters' job.
+	if mentionAnyBroadcast(mentionMap) {
+		all = true
 	}
 	if mentionMap["uids"] != nil {
 		uidObjs, ok := mentionMap["uids"].([]interface{})
@@ -306,6 +335,62 @@ func (m *Message) getMention(payloadMap map[string]interface{}) (all bool, uids 
 		}
 	}
 	return
+}
+
+// mentionAnyBroadcast reports whether the parsed `mention` map carries
+// any of the three broadcast flags (humans / ais / all) set to 1. See
+// getMention's doc comment for the per-flag semantics. Defensive:
+// accepts json.Number / float / int / bool forms for each flag so
+// callers that decoded without UseNumber don't silently miss the
+// broadcast.
+func mentionAnyBroadcast(mentionMap map[string]interface{}) bool {
+	return mentionFlagTruthy(mentionMap["humans"]) ||
+		mentionFlagTruthy(mentionMap["ais"]) ||
+		mentionFlagTruthy(mentionMap["all"])
+}
+
+// mentionFlagTruthy reports whether a parsed mention.* flag value is
+// the numeric/boolean form of 1. Mirrors pkg/mentionrewrite.isTruthyOne
+// but kept local to avoid leaking the helper through an internal API —
+// the read side and the rewrite side intentionally share the same
+// "truthy = 1" semantics so a round-trip through the chokepoint is
+// observable.
+func mentionFlagTruthy(v interface{}) bool {
+	switch x := v.(type) {
+	case nil:
+		return false
+	case json.Number:
+		n, err := x.Int64()
+		return err == nil && n == 1
+	case float64:
+		return x == 1
+	case float32:
+		return x == 1
+	case int:
+		return x == 1
+	case int8:
+		return x == 1
+	case int16:
+		return x == 1
+	case int32:
+		return x == 1
+	case int64:
+		return x == 1
+	case uint:
+		return x == 1
+	case uint8:
+		return x == 1
+	case uint16:
+		return x == 1
+	case uint32:
+		return x == 1
+	case uint64:
+		return x == 1
+	case bool:
+		return x
+	default:
+		return false
+	}
 }
 
 func (m *Message) contentType(payloadMap map[string]interface{}) int {

--- a/modules/message/api_reminders_test.go
+++ b/modules/message/api_reminders_test.go
@@ -317,3 +317,116 @@ func TestGetReminders_AllAndHumans_RoundTripThroughRewrite(t *testing.T) {
 	assert.Len(t, rems, 1, "round-trip must produce exactly one broadcast reminder")
 	assert.Equal(t, "", rems[0].UID, "broadcast reminder uses empty UID")
 }
+
+// TestFilterChannelLevelByPublisher pins YUJ-1377 / Mininglamp-OSS/
+// octo-server#101 — the sender of an `@所有人` broadcast must NOT
+// receive their own red-dot reminder. The fix lives in reminderSync,
+// which calls filterChannelLevelByPublisher on the rows returned by
+// remindersDB.sync; this test exercises the filter helper in
+// isolation (pure data, no DB / IM context).
+//
+// Coverage matrix:
+//   - channel-level reminder (UID="") authored by viewer → DROPPED
+//   - channel-level reminder authored by someone else    → KEPT
+//   - per-uid reminder addressed to viewer (e.g. @uid)   → KEPT
+//   - per-uid apply-join-group reminder                  → KEPT
+//     (this is the "do not break other reminder types"
+//     guarantee from the issue description)
+//   - empty/nil viewer UID                               → no-op
+//   - empty slice                                        → no-op
+func TestFilterChannelLevelByPublisher(t *testing.T) {
+	mk := func(uid, publisher string, reminderType int) *remindersDetailModel {
+		return &remindersDetailModel{
+			remindersModel: remindersModel{
+				ChannelID:    "ch_team",
+				ChannelType:  common.ChannelTypeGroup.Uint8(),
+				UID:          uid,
+				Publisher:    publisher,
+				ReminderType: reminderType,
+			},
+		}
+	}
+
+	t.Run("drops channel-level reminder authored by viewer", func(t *testing.T) {
+		input := []*remindersDetailModel{
+			mk("", "u_sender", int(ReminderTypeMentionMe)),        // sender's own broadcast → drop
+			mk("", "u_other", int(ReminderTypeMentionMe)),         // someone else's broadcast → keep
+			mk("u_sender", "u_other", int(ReminderTypeMentionMe)), // @u_sender from u_other → keep
+			mk("u_sender", "u_other", int(ReminderTypeApplyJoinGroup)),
+		}
+		got := filterChannelLevelByPublisher(input, "u_sender")
+		assert.Len(t, got, 3, "exactly one row (the self-broadcast) must be dropped")
+		for _, r := range got {
+			if r.UID == "" {
+				assert.NotEqual(t, "u_sender", r.Publisher,
+					"no remaining channel-level reminder may be authored by the viewer")
+			}
+		}
+	})
+
+	t.Run("keeps everything when viewer is not the publisher", func(t *testing.T) {
+		input := []*remindersDetailModel{
+			mk("", "u_alice", int(ReminderTypeMentionMe)),
+			mk("u_bob", "u_alice", int(ReminderTypeMentionMe)),
+		}
+		got := filterChannelLevelByPublisher(input, "u_bob")
+		assert.Equal(t, input, got, "no-op path must return the input slice unchanged")
+	})
+
+	t.Run("preserves apply-join-group reminders addressed to viewer", func(t *testing.T) {
+		// Apply-join-group reminders carry an explicit UID and have no
+		// Publisher set by getReminders; the filter must never drop
+		// them even if Publisher happens to coincide with the viewer.
+		input := []*remindersDetailModel{
+			mk("u_admin", "u_admin", int(ReminderTypeApplyJoinGroup)),
+		}
+		got := filterChannelLevelByPublisher(input, "u_admin")
+		assert.Equal(t, input, got, "apply-join-group must pass through verbatim")
+	})
+
+	t.Run("no-op on empty viewer uid", func(t *testing.T) {
+		input := []*remindersDetailModel{
+			mk("", "u_alice", int(ReminderTypeMentionMe)),
+		}
+		got := filterChannelLevelByPublisher(input, "")
+		assert.Equal(t, input, got)
+	})
+
+	t.Run("no-op on empty slice", func(t *testing.T) {
+		got := filterChannelLevelByPublisher(nil, "u_sender")
+		assert.Nil(t, got)
+		got = filterChannelLevelByPublisher([]*remindersDetailModel{}, "u_sender")
+		assert.Empty(t, got)
+	})
+}
+
+// TestReminderSync_SenderExcludedFromBroadcast is the contract-level
+// regression: the sender of `@所有人` is excluded from the reminder
+// list returned by the read path. We exercise the filter step here
+// (the DB layer is covered by integration tests); together with
+// TestGetReminders_FanoutMatrix this pins both "row is created" and
+// "row is hidden from the author on read".
+func TestReminderSync_SenderExcludedFromBroadcast(t *testing.T) {
+	// Simulate what remindersDB.sync would return for u_sender after
+	// u_sender broadcast `@所有人` and an unrelated peer also did.
+	rows := []*remindersDetailModel{
+		{remindersModel: remindersModel{
+			ChannelID: "ch_team", ChannelType: common.ChannelTypeGroup.Uint8(),
+			UID: "", Publisher: "u_sender", ReminderType: int(ReminderTypeMentionMe),
+			Text: "[有人@我]",
+		}},
+		{remindersModel: remindersModel{
+			ChannelID: "ch_team", ChannelType: common.ChannelTypeGroup.Uint8(),
+			UID: "", Publisher: "u_peer", ReminderType: int(ReminderTypeMentionMe),
+			Text: "[有人@我]",
+		}},
+	}
+
+	got := filterChannelLevelByPublisher(rows, "u_sender")
+	assert.Len(t, got, 1, "sender must see only the peer's broadcast, not their own")
+	assert.Equal(t, "u_peer", got[0].Publisher)
+
+	// And a third party sees both.
+	got = filterChannelLevelByPublisher(rows, "u_bystander")
+	assert.Len(t, got, 2)
+}

--- a/modules/message/api_reminders_test.go
+++ b/modules/message/api_reminders_test.go
@@ -6,13 +6,13 @@
 // `mention.all=1` to `mention.humans=1`, and a new client may also set
 // `mention.ais=1`. This file pins:
 //
-//   1. Message.getMention recognizes any of {humans, ais, all} = 1 as a
-//      "broadcast" mention (channel-level reminder), and still pulls
-//      per-user `uids` for the non-broadcast path.
-//   2. Message.getReminders generates exactly the right shape of
-//      reminder rows for each matrix cell — channel-level (UID="")
-//      for broadcasts, per-uid rows for explicit uids, and zero rows
-//      when the payload has no mention at all.
+//  1. Message.getMention recognizes any of {humans, ais, all} = 1 as a
+//     "broadcast" mention (channel-level reminder), and still pulls
+//     per-user `uids` for the non-broadcast path.
+//  2. Message.getReminders generates exactly the right shape of
+//     reminder rows for each matrix cell — channel-level (UID="")
+//     for broadcasts, per-uid rows for explicit uids, and zero rows
+//     when the payload has no mention at all.
 //
 // These tests are pure helpers (no DB / no IM context) so they live
 // next to the existing mention-shape suite in validation_test.go.

--- a/modules/message/api_reminders_test.go
+++ b/modules/message/api_reminders_test.go
@@ -1,18 +1,26 @@
 // modules/message/api_reminders_test.go
 //
 // Reminder fan-out matrix tests for the mention three-state rewrite
-// (YUJ-1343 / Mininglamp-OSS/octo-server#94). The chokepoint rewrite
-// (pkg/mentionrewrite.RewriteMention) double-writes legacy
-// `mention.all=1` to `mention.humans=1`, and a new client may also set
-// `mention.ais=1`. This file pins:
+// (YUJ-1343 / Mininglamp-OSS/octo-server#94) updated for Plan X
+// (YUJ-1389). The chokepoint rewrite (pkg/mentionrewrite.RewriteMention)
+// double-writes legacy `mention.all=1` to `mention.ais=1` so legacy
+// `@所有人` traffic fans out to all AI bots without an SDK update on
+// the sender side. A NEW field `mention.humans=1` is the explicit
+// human-notification signal — it is the only way to produce a
+// channel-level reminder (the "[有人@我]" red-dot). This file pins:
 //
 //  1. Message.getMention recognizes any of {humans, ais, all} = 1 as a
-//     "broadcast" mention (channel-level reminder), and still pulls
-//     per-user `uids` for the non-broadcast path.
-//  2. Message.getReminders generates exactly the right shape of
-//     reminder rows for each matrix cell — channel-level (UID="")
-//     for broadcasts, per-uid rows for explicit uids, and zero rows
-//     when the payload has no mention at all.
+//     "broadcast" mention (so the caller knows to consider the
+//     humans-gate), and still pulls per-user `uids` for the
+//     non-broadcast path.
+//  2. Message.getReminders emits a channel-level reminder ONLY when
+//     `humans=1` is set on the payload. ais-only broadcasts (including
+//     the legacy `all=1` shape after the chokepoint rewrite) produce
+//     ZERO reminder rows — bots respond via the message delivery path,
+//     so a "[有人@我]" for human members would be noise.
+//  3. Explicit @uid mentions still produce per-uid reminder rows even
+//     when the message ALSO carries a broadcast flag (`@所有人 + @alice`
+//     must still ping @alice individually).
 //
 // These tests are pure helpers (no DB / no IM context) so they live
 // next to the existing mention-shape suite in validation_test.go.
@@ -44,7 +52,11 @@ func payloadJSON(t *testing.T, m map[string]interface{}) []byte {
 }
 
 // TestGetMention_ThreeStateMatrix locks the three-state read-side
-// semantics established in YUJ-1343 / GH#94 §RFC 6.
+// semantics established in YUJ-1343 / GH#94 §RFC 6 and updated for
+// Plan X (YUJ-1389): getMention still reports all=true for any of
+// {humans, ais, all} = 1; the humans-gate that decides whether a
+// channel-level reminder is actually emitted lives at the call site
+// (see TestGetReminders_FanoutMatrix below).
 func TestGetMention_ThreeStateMatrix(t *testing.T) {
 	m := &Message{}
 
@@ -61,7 +73,7 @@ func TestGetMention_ThreeStateMatrix(t *testing.T) {
 			expectUIDs: nil,
 		},
 		{
-			name:       "ais=1 alone → broadcast",
+			name:       "ais=1 alone → broadcast (read side sees it; emitter gates on humans)",
 			mention:    map[string]interface{}{"ais": json.Number("1")},
 			expectAll:  true,
 			expectUIDs: nil,
@@ -76,10 +88,10 @@ func TestGetMention_ThreeStateMatrix(t *testing.T) {
 			expectUIDs: nil,
 		},
 		{
-			name: "all=1 (post-rewrite carries humans=1) → broadcast",
+			name: "all=1 (Plan X post-rewrite carries ais=1) → broadcast",
 			mention: map[string]interface{}{
-				"all":    json.Number("1"),
-				"humans": json.Number("1"),
+				"all": json.Number("1"),
+				"ais": json.Number("1"),
 			},
 			expectAll:  true,
 			expectUIDs: nil,
@@ -89,7 +101,7 @@ func TestGetMention_ThreeStateMatrix(t *testing.T) {
 			// This path SHOULDN'T happen in production once the
 			// chokepoint runs, but if a listener somehow sees an
 			// un-rewritten message (e.g. replay of historical data),
-			// the reader must still emit a reminder.
+			// the reader must still recognize it as a broadcast.
 			mention:    map[string]interface{}{"all": json.Number("1")},
 			expectAll:  true,
 			expectUIDs: nil,
@@ -101,7 +113,7 @@ func TestGetMention_ThreeStateMatrix(t *testing.T) {
 			expectUIDs: []string{"u_alice", "u_bob"},
 		},
 		{
-			name: "humans=1 + uids → broadcast wins (uids still parsed)",
+			name: "humans=1 + uids → broadcast AND uids parsed",
 			mention: map[string]interface{}{
 				"humans": json.Number("1"),
 				"uids":   []interface{}{"u_alice"},
@@ -158,18 +170,24 @@ func newReminderTestMessage(t *testing.T) *Message {
 }
 
 // TestGetReminders_FanoutMatrix asserts the SHAPE of reminders
-// emitted for every cell of the three-state mention matrix. The fan-out
-// behavior is:
+// emitted for every cell of the Plan X (YUJ-1389) mention matrix.
+// The fan-out behavior is:
 //
-//   - any of {humans, ais, all} = 1 → exactly ONE reminder per message
-//     with UID="" (channel-level — clients filter by role in adapter)
-//   - uids = [a, b]                 → one reminder PER uid, with
-//     UID=<uid>
-//   - no mention                    → zero reminders
+//   - humans=1            → exactly ONE channel-level reminder
+//     (UID="", "[有人@我]")
+//   - ais=1 (only)        → ZERO reminders (bots respond via delivery)
+//   - all=1 + ais=1       → ZERO reminders (post-rewrite ais-only)
+//   - humans=1 + ais=1    → ONE channel-level reminder (humans visible,
+//     bots fan out via delivery)
+//   - uids = [a, b]       → one reminder PER uid, with UID=<uid>
+//   - humans=1 + uids     → ONE channel-level reminder PLUS one
+//     per-uid reminder for each uid (the broadcast and the explicit
+//     mention coexist — `@所有人 + @alice` must still ping @alice)
+//   - no mention          → zero reminders
 //
-// Role-aware delivery (humans-only vs bots-only) is intentionally a
-// client-side adapter concern — see api_reminders.go:getMention for
-// the rationale. This test pins the server contract.
+// Role-aware delivery for bots is a downstream concern (bots subscribe
+// to ais=1 messages directly through the message-delivery path). This
+// test pins the server's reminder-emission contract.
 func TestGetReminders_FanoutMatrix(t *testing.T) {
 	m := newReminderTestMessage(t)
 
@@ -187,13 +205,13 @@ func TestGetReminders_FanoutMatrix(t *testing.T) {
 			wantBroadcast: 1,
 		},
 		{
-			name:          "ais=1 → 1 channel-level reminder (bots fan-out)",
+			name:          "ais=1 only → 0 reminders (bots use delivery path)",
 			mention:       map[string]interface{}{"ais": json.Number("1")},
-			wantTotal:     1,
-			wantBroadcast: 1,
+			wantTotal:     0,
+			wantBroadcast: 0,
 		},
 		{
-			name: "humans+ais → still ONE channel-level reminder (client filters role)",
+			name: "humans=1 + ais=1 → 1 channel-level reminder (humans visible)",
 			mention: map[string]interface{}{
 				"humans": json.Number("1"),
 				"ais":    json.Number("1"),
@@ -202,9 +220,19 @@ func TestGetReminders_FanoutMatrix(t *testing.T) {
 			wantBroadcast: 1,
 		},
 		{
-			name: "all=1 (rewrite double-wrote humans=1) → 1 channel-level reminder, humans-only semantics",
+			name: "all=1 + ais=1 (Plan X post-rewrite) → 0 reminders, ais-only semantics",
+			mention: map[string]interface{}{
+				"all": json.Number("1"),
+				"ais": json.Number("1"),
+			},
+			wantTotal:     0,
+			wantBroadcast: 0,
+		},
+		{
+			name: "humans=1 + ais=1 + all=1 (legacy + new client double-tag) → 1 channel-level",
 			mention: map[string]interface{}{
 				"all":    json.Number("1"),
+				"ais":    json.Number("1"),
 				"humans": json.Number("1"),
 			},
 			wantTotal:     1,
@@ -217,13 +245,24 @@ func TestGetReminders_FanoutMatrix(t *testing.T) {
 			wantPerUserUIDs: []string{"u_alice", "u_bob"},
 		},
 		{
-			name: "humans=1 + uids → broadcast wins (1 channel-level)",
+			name: "humans=1 + uids → 1 channel-level + 1 per-user (broadcast and uid coexist)",
 			mention: map[string]interface{}{
 				"humans": json.Number("1"),
 				"uids":   []interface{}{"u_alice"},
 			},
-			wantTotal:     1,
-			wantBroadcast: 1,
+			wantTotal:       2,
+			wantBroadcast:   1,
+			wantPerUserUIDs: []string{"u_alice"},
+		},
+		{
+			name: "ais=1 + uids (post-rewrite ais-only with explicit @uid) → only per-user reminders",
+			mention: map[string]interface{}{
+				"ais":  json.Number("1"),
+				"uids": []interface{}{"u_alice"},
+			},
+			wantTotal:       1,
+			wantBroadcast:   0,
+			wantPerUserUIDs: []string{"u_alice"},
 		},
 		{
 			name:      "no mention → 0 reminders",
@@ -268,9 +307,7 @@ func TestGetReminders_FanoutMatrix(t *testing.T) {
 				assert.Equal(t, msg.FromUID, r.Publisher)
 				assert.Equal(t, fmt.Sprintf("%d", msg.MessageID), r.MessageID)
 			}
-			if tc.wantBroadcast > 0 {
-				assert.Equal(t, tc.wantBroadcast, broadcasts, "broadcast count mismatch")
-			}
+			assert.Equal(t, tc.wantBroadcast, broadcasts, "broadcast count mismatch")
 			if len(tc.wantPerUserUIDs) > 0 {
 				want := map[string]bool{}
 				for _, u := range tc.wantPerUserUIDs {
@@ -282,12 +319,15 @@ func TestGetReminders_FanoutMatrix(t *testing.T) {
 	}
 }
 
-// TestGetReminders_AllAndHumans_RoundTripThroughRewrite is the
-// end-to-end matrix cell that ties the chokepoint and the reader
-// together: a legacy `mention.all=1` payload, after passing through
-// the chokepoint rewrite, still produces exactly ONE channel-level
-// reminder with humans-only semantics (Yu D1 — bots silent).
-func TestGetReminders_AllAndHumans_RoundTripThroughRewrite(t *testing.T) {
+// TestGetReminders_LegacyAllRoundTripThroughRewrite is the end-to-end
+// matrix cell that ties the chokepoint and the reader together under
+// Plan X (YUJ-1389): a legacy `mention.all=1` payload, after passing
+// through the chokepoint rewrite, produces ZERO channel-level
+// reminders — the post-rewrite payload is `{all:1, ais:1}`, which is
+// ais-only semantics and must NOT create a "[有人@我]" red-dot.
+// Bots receive the message via the delivery path; humans see nothing
+// in the reminder pane (which is the desired Plan X behavior).
+func TestGetReminders_LegacyAllRoundTripThroughRewrite(t *testing.T) {
 	m := newReminderTestMessage(t)
 
 	// Legacy inbound shape.
@@ -301,7 +341,9 @@ func TestGetReminders_AllAndHumans_RoundTripThroughRewrite(t *testing.T) {
 	rewritten := RewriteMention(inbound)
 	mention := rewritten["mention"].(map[string]interface{})
 	assert.Equal(t, json.Number("1"), mention["all"], "all preserved (outbound double-write)")
-	assert.Equal(t, json.Number("1"), mention["humans"], "humans added by rewrite")
+	assert.Equal(t, json.Number("1"), mention["ais"], "Plan X: ais added by rewrite")
+	_, hasHumans := mention["humans"]
+	assert.False(t, hasHumans, "Plan X: humans is NOT auto-set by rewrite")
 
 	// Reader sees the rewritten payload.
 	msg := &config.MessageResp{
@@ -314,7 +356,43 @@ func TestGetReminders_AllAndHumans_RoundTripThroughRewrite(t *testing.T) {
 		Payload:     payloadJSON(t, rewritten),
 	}
 	rems := m.getReminders([]*config.MessageResp{msg})
-	assert.Len(t, rems, 1, "round-trip must produce exactly one broadcast reminder")
+	assert.Len(t, rems, 0,
+		"Plan X: legacy all=1 (rewritten to all+ais) must produce ZERO channel-level reminders")
+}
+
+// TestGetReminders_HumansPlusAllRoundTrip — a future client that wants
+// BOTH the legacy `all=1` pill on old read-side clients AND a human-
+// visible reminder sends `{all:1, humans:1}` inbound. The chokepoint
+// rewrite ALSO adds `ais=1` (Plan X), so the dispatched payload is
+// `{all:1, humans:1, ais:1}`. Reader must emit exactly ONE channel-
+// level reminder (humans=1 is the gate).
+func TestGetReminders_HumansPlusAllRoundTrip(t *testing.T) {
+	m := newReminderTestMessage(t)
+
+	inbound := map[string]interface{}{
+		"type": 1,
+		"mention": map[string]interface{}{
+			"all":    json.Number("1"),
+			"humans": json.Number("1"),
+		},
+	}
+	rewritten := RewriteMention(inbound)
+	mention := rewritten["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["all"])
+	assert.Equal(t, json.Number("1"), mention["humans"])
+	assert.Equal(t, json.Number("1"), mention["ais"], "Plan X: rewrite always adds ais=1 for all=1")
+
+	msg := &config.MessageResp{
+		ChannelID:   "ch_humans_plus_all",
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		FromUID:     "u_sender",
+		MessageID:   2,
+		MessageSeq:  2,
+		ClientMsgNo: "cmn_humans_plus_all",
+		Payload:     payloadJSON(t, rewritten),
+	}
+	rems := m.getReminders([]*config.MessageResp{msg})
+	assert.Len(t, rems, 1, "humans=1 → exactly one channel-level reminder")
 	assert.Equal(t, "", rems[0].UID, "broadcast reminder uses empty UID")
 }
 
@@ -334,6 +412,11 @@ func TestGetReminders_AllAndHumans_RoundTripThroughRewrite(t *testing.T) {
 //     guarantee from the issue description)
 //   - empty/nil viewer UID                               → no-op
 //   - empty slice                                        → no-op
+//
+// Plan X (YUJ-1389): channel-level reminders are now only created
+// when `humans=1` is set, so this filter still applies to all rows
+// that reach it — the gate just means fewer rows are produced in the
+// first place. The filter contract is unchanged.
 func TestFilterChannelLevelByPublisher(t *testing.T) {
 	mk := func(uid, publisher string, reminderType int) *remindersDetailModel {
 		return &remindersDetailModel{

--- a/modules/message/api_reminders_test.go
+++ b/modules/message/api_reminders_test.go
@@ -1,0 +1,319 @@
+// modules/message/api_reminders_test.go
+//
+// Reminder fan-out matrix tests for the mention three-state rewrite
+// (YUJ-1343 / Mininglamp-OSS/octo-server#94). The chokepoint rewrite
+// (pkg/mentionrewrite.RewriteMention) double-writes legacy
+// `mention.all=1` to `mention.humans=1`, and a new client may also set
+// `mention.ais=1`. This file pins:
+//
+//   1. Message.getMention recognizes any of {humans, ais, all} = 1 as a
+//      "broadcast" mention (channel-level reminder), and still pulls
+//      per-user `uids` for the non-broadcast path.
+//   2. Message.getReminders generates exactly the right shape of
+//      reminder rows for each matrix cell — channel-level (UID="")
+//      for broadcasts, per-uid rows for explicit uids, and zero rows
+//      when the payload has no mention at all.
+//
+// These tests are pure helpers (no DB / no IM context) so they live
+// next to the existing mention-shape suite in validation_test.go.
+package message
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// payloadJSON marshals the given map and re-decodes with UseNumber so
+// the resulting map[string]interface{} mirrors what
+// config.MessageResp.GetPayloadMap returns in production (UseNumber is
+// the documented contract — see modules/message/validation_test.go for
+// the same pattern).
+func payloadJSON(t *testing.T, m map[string]interface{}) []byte {
+	t.Helper()
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// TestGetMention_ThreeStateMatrix locks the three-state read-side
+// semantics established in YUJ-1343 / GH#94 §RFC 6.
+func TestGetMention_ThreeStateMatrix(t *testing.T) {
+	m := &Message{}
+
+	cases := []struct {
+		name       string
+		mention    map[string]interface{}
+		expectAll  bool
+		expectUIDs []string
+	}{
+		{
+			name:       "humans=1 alone → broadcast",
+			mention:    map[string]interface{}{"humans": json.Number("1")},
+			expectAll:  true,
+			expectUIDs: nil,
+		},
+		{
+			name:       "ais=1 alone → broadcast",
+			mention:    map[string]interface{}{"ais": json.Number("1")},
+			expectAll:  true,
+			expectUIDs: nil,
+		},
+		{
+			name: "humans=1 + ais=1 → broadcast",
+			mention: map[string]interface{}{
+				"humans": json.Number("1"),
+				"ais":    json.Number("1"),
+			},
+			expectAll:  true,
+			expectUIDs: nil,
+		},
+		{
+			name: "all=1 (post-rewrite carries humans=1) → broadcast",
+			mention: map[string]interface{}{
+				"all":    json.Number("1"),
+				"humans": json.Number("1"),
+			},
+			expectAll:  true,
+			expectUIDs: nil,
+		},
+		{
+			name: "legacy all=1 alone (no rewrite yet) → still broadcast (read-side resilience)",
+			// This path SHOULDN'T happen in production once the
+			// chokepoint runs, but if a listener somehow sees an
+			// un-rewritten message (e.g. replay of historical data),
+			// the reader must still emit a reminder.
+			mention:    map[string]interface{}{"all": json.Number("1")},
+			expectAll:  true,
+			expectUIDs: nil,
+		},
+		{
+			name:       "uids only → per-uid",
+			mention:    map[string]interface{}{"uids": []interface{}{"u_alice", "u_bob"}},
+			expectAll:  false,
+			expectUIDs: []string{"u_alice", "u_bob"},
+		},
+		{
+			name: "humans=1 + uids → broadcast wins (uids still parsed)",
+			mention: map[string]interface{}{
+				"humans": json.Number("1"),
+				"uids":   []interface{}{"u_alice"},
+			},
+			expectAll:  true,
+			expectUIDs: []string{"u_alice"},
+		},
+		{
+			name:       "humans=0 + ais=0 + all=0 → no broadcast",
+			mention:    map[string]interface{}{"humans": json.Number("0"), "ais": json.Number("0"), "all": json.Number("0")},
+			expectAll:  false,
+			expectUIDs: nil,
+		},
+		{
+			name:       "empty mention map → no broadcast",
+			mention:    map[string]interface{}{},
+			expectAll:  false,
+			expectUIDs: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := map[string]interface{}{"mention": tc.mention}
+			// Round-trip through JSON+UseNumber so the test maps
+			// match the production decoder shape.
+			raw := payloadJSON(t, payload)
+			var decoded map[string]interface{}
+			dec := json.NewDecoder(strings.NewReader(string(raw)))
+			dec.UseNumber()
+			if err := dec.Decode(&decoded); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			gotAll, gotUIDs := m.getMention(decoded)
+			assert.Equal(t, tc.expectAll, gotAll, "all-flag mismatch for %s", tc.name)
+			assert.Equal(t, tc.expectUIDs, gotUIDs, "uids mismatch for %s", tc.name)
+		})
+	}
+}
+
+// newReminderTestMessage returns a Message whose reminder-version
+// generator is a deterministic in-memory counter. Lets the matrix
+// helpers exercise getReminders without standing up the seq table /
+// MySQL / IM context. See Message.reminderSeqOverride in api.go.
+func newReminderTestMessage(t *testing.T) *Message {
+	t.Helper()
+	var seq int64
+	return &Message{
+		reminderSeqOverride: func() (int64, error) {
+			seq++
+			return seq, nil
+		},
+	}
+}
+
+// TestGetReminders_FanoutMatrix asserts the SHAPE of reminders
+// emitted for every cell of the three-state mention matrix. The fan-out
+// behavior is:
+//
+//   - any of {humans, ais, all} = 1 → exactly ONE reminder per message
+//     with UID="" (channel-level — clients filter by role in adapter)
+//   - uids = [a, b]                 → one reminder PER uid, with
+//     UID=<uid>
+//   - no mention                    → zero reminders
+//
+// Role-aware delivery (humans-only vs bots-only) is intentionally a
+// client-side adapter concern — see api_reminders.go:getMention for
+// the rationale. This test pins the server contract.
+func TestGetReminders_FanoutMatrix(t *testing.T) {
+	m := newReminderTestMessage(t)
+
+	cases := []struct {
+		name            string
+		mention         map[string]interface{}
+		wantTotal       int
+		wantBroadcast   int // reminders with UID==""
+		wantPerUserUIDs []string
+	}{
+		{
+			name:          "humans=1 → 1 channel-level reminder",
+			mention:       map[string]interface{}{"humans": json.Number("1")},
+			wantTotal:     1,
+			wantBroadcast: 1,
+		},
+		{
+			name:          "ais=1 → 1 channel-level reminder (bots fan-out)",
+			mention:       map[string]interface{}{"ais": json.Number("1")},
+			wantTotal:     1,
+			wantBroadcast: 1,
+		},
+		{
+			name: "humans+ais → still ONE channel-level reminder (client filters role)",
+			mention: map[string]interface{}{
+				"humans": json.Number("1"),
+				"ais":    json.Number("1"),
+			},
+			wantTotal:     1,
+			wantBroadcast: 1,
+		},
+		{
+			name: "all=1 (rewrite double-wrote humans=1) → 1 channel-level reminder, humans-only semantics",
+			mention: map[string]interface{}{
+				"all":    json.Number("1"),
+				"humans": json.Number("1"),
+			},
+			wantTotal:     1,
+			wantBroadcast: 1,
+		},
+		{
+			name:            "uids only → 2 per-user reminders",
+			mention:         map[string]interface{}{"uids": []interface{}{"u_alice", "u_bob"}},
+			wantTotal:       2,
+			wantPerUserUIDs: []string{"u_alice", "u_bob"},
+		},
+		{
+			name: "humans=1 + uids → broadcast wins (1 channel-level)",
+			mention: map[string]interface{}{
+				"humans": json.Number("1"),
+				"uids":   []interface{}{"u_alice"},
+			},
+			wantTotal:     1,
+			wantBroadcast: 1,
+		},
+		{
+			name:      "no mention → 0 reminders",
+			mention:   nil,
+			wantTotal: 0,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := map[string]interface{}{"type": 1, "content": "msg"}
+			if tc.mention != nil {
+				payload["mention"] = tc.mention
+			}
+			msg := &config.MessageResp{
+				ChannelID:   fmt.Sprintf("ch_%d", i),
+				ChannelType: common.ChannelTypeGroup.Uint8(),
+				FromUID:     "u_sender",
+				MessageID:   int64(1000 + i),
+				MessageSeq:  uint32(10 + i),
+				ClientMsgNo: fmt.Sprintf("cmn_%d", i),
+				Payload:     payloadJSON(t, payload),
+			}
+			got := m.getReminders([]*config.MessageResp{msg})
+			assert.Equal(t, tc.wantTotal, len(got), "reminder count mismatch")
+			if tc.wantTotal == 0 {
+				return
+			}
+			var (
+				broadcasts int
+				perUserSet = map[string]bool{}
+			)
+			for _, r := range got {
+				if r.UID == "" {
+					broadcasts++
+				} else {
+					perUserSet[r.UID] = true
+				}
+				assert.Equal(t, ReminderTypeMentionMe, r.ReminderType)
+				assert.Equal(t, msg.ChannelID, r.ChannelID)
+				assert.Equal(t, msg.ChannelType, r.ChannelType)
+				assert.Equal(t, msg.FromUID, r.Publisher)
+				assert.Equal(t, fmt.Sprintf("%d", msg.MessageID), r.MessageID)
+			}
+			if tc.wantBroadcast > 0 {
+				assert.Equal(t, tc.wantBroadcast, broadcasts, "broadcast count mismatch")
+			}
+			if len(tc.wantPerUserUIDs) > 0 {
+				want := map[string]bool{}
+				for _, u := range tc.wantPerUserUIDs {
+					want[u] = true
+				}
+				assert.Equal(t, want, perUserSet, "per-user uid set mismatch")
+			}
+		})
+	}
+}
+
+// TestGetReminders_AllAndHumans_RoundTripThroughRewrite is the
+// end-to-end matrix cell that ties the chokepoint and the reader
+// together: a legacy `mention.all=1` payload, after passing through
+// the chokepoint rewrite, still produces exactly ONE channel-level
+// reminder with humans-only semantics (Yu D1 — bots silent).
+func TestGetReminders_AllAndHumans_RoundTripThroughRewrite(t *testing.T) {
+	m := newReminderTestMessage(t)
+
+	// Legacy inbound shape.
+	inbound := map[string]interface{}{
+		"type": 1,
+		"mention": map[string]interface{}{
+			"all": json.Number("1"),
+		},
+	}
+	// Chokepoint rewrite.
+	rewritten := RewriteMention(inbound)
+	mention := rewritten["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["all"], "all preserved (outbound double-write)")
+	assert.Equal(t, json.Number("1"), mention["humans"], "humans added by rewrite")
+
+	// Reader sees the rewritten payload.
+	msg := &config.MessageResp{
+		ChannelID:   "ch_roundtrip",
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		FromUID:     "u_sender",
+		MessageID:   1,
+		MessageSeq:  1,
+		ClientMsgNo: "cmn_roundtrip",
+		Payload:     payloadJSON(t, rewritten),
+	}
+	rems := m.getReminders([]*config.MessageResp{msg})
+	assert.Len(t, rems, 1, "round-trip must produce exactly one broadcast reminder")
+	assert.Equal(t, "", rems[0].UID, "broadcast reminder uses empty UID")
+}

--- a/modules/message/db_reminders.go
+++ b/modules/message/db_reminders.go
@@ -2,9 +2,9 @@ package message
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"runtime/debug"
-	"fmt"
 	"sort"
 	"strings"
 
@@ -60,7 +60,10 @@ func (r *remindersDB) deleteWithChannelAndUIDTx(channelID string, channelType ui
 func (r *remindersDB) queryWithUIDAndChannel(uid string, channelID string, channelType uint8, messageSeq uint32) ([]*remindersDetailModel, error) {
 	var list []*remindersDetailModel
 	builder := r.session.Select("reminders.*,IF(reminder_done.id is null and reminders.is_deleted=0,0,1) done").From("reminders").LeftJoin("reminder_done", dbr.Expr("reminders.id=reminder_done.reminder_id and reminder_done.uid=?", uid))
-	_, err := builder.Where("(reminders.uid=?  or  ( reminders.uid='' and reminders.channel_id=? and reminders.channel_type=?))  and reminders.message_seq<=? and reminder_done.id is null", uid, channelID, channelType, messageSeq).Load(&list)
+	// YUJ-1377: same publisher exclusion as sync() — channel-level
+	// (uid='') reminders authored by the viewer themselves must not
+	// be returned. Per-uid rows (uid=?) are unaffected.
+	_, err := builder.Where("(reminders.uid=?  or  ( reminders.uid='' and reminders.channel_id=? and reminders.channel_type=?))  and not (reminders.uid='' and reminders.publisher=?)  and reminders.message_seq<=? and reminder_done.id is null", uid, channelID, channelType, uid, messageSeq).Load(&list)
 	return list, err
 }
 
@@ -71,7 +74,14 @@ func (r *remindersDB) queryWithUIDAndChannel(uid string, channelID string, chann
 @param version 以uid为key的增量版本号
 @param limit 数据限制
 @param channelIDs 频道集合 查询以频道为目标的提醒项
-*
+
+YUJ-1377: the predicate `NOT (uid=” AND publisher=?)` excludes
+channel-level broadcasts authored by the viewer itself, so the
+sender of `@所有人` does not see their own red-dot. The filter must
+live in SQL (not post-filtered in Go) so the LIMIT/version cursor
+keeps advancing past hidden self-broadcasts — otherwise a page
+fully consumed by the viewer's own broadcasts would return [] and
+stall the client's incremental sync.
 */
 func (r *remindersDB) sync(uid string, version int64, limit uint64, channelIDs []string) ([]*remindersDetailModel, error) {
 	var models []*remindersDetailModel
@@ -80,16 +90,16 @@ func (r *remindersDB) sync(uid string, version int64, limit uint64, channelIDs [
 		builder := r.session.Select("reminders.*,IF(reminder_done.id is null and reminders.is_deleted=0,0,1) done").From("reminders").LeftJoin("reminder_done", dbr.Expr("reminders.id=reminder_done.reminder_id and reminder_done.uid=?", uid))
 
 		if len(channelIDs) == 0 {
-			_, err = builder.Where("(reminders.uid=?  or   reminders.uid='')  and reminders.version>? and reminder_done.id is null", uid, version).OrderAsc("version").Limit(limit).Load(&models)
+			_, err = builder.Where("(reminders.uid=?  or   reminders.uid='')  and not (reminders.uid='' and reminders.publisher=?)  and reminders.version>? and reminder_done.id is null", uid, uid, version).OrderAsc("version").Limit(limit).Load(&models)
 		} else {
-			_, err = builder.Where("(reminders.uid=?  or  ( reminders.uid='' and reminders.channel_id in ?))  and reminders.version>? and reminder_done.id is null", uid, channelIDs, version).OrderAsc("version").Limit(limit).Load(&models)
+			_, err = builder.Where("(reminders.uid=?  or  ( reminders.uid='' and reminders.channel_id in ?))  and not (reminders.uid='' and reminders.publisher=?)  and reminders.version>? and reminder_done.id is null", uid, channelIDs, uid, version).OrderAsc("version").Limit(limit).Load(&models)
 		}
 	} else {
 		build := r.session.Select("reminders.*,IF(reminder_done.id is null and reminders.is_deleted=0,0,1) done").From("reminders").LeftJoin("reminder_done", dbr.Expr("reminders.id=reminder_done.reminder_id and reminder_done.uid=?", uid))
 		if len(channelIDs) == 0 {
-			_, err = build.Where("(reminders.uid=?  or  reminders.uid='')  and reminders.version>?", uid, version).OrderAsc("version").Limit(limit).Load(&models)
+			_, err = build.Where("(reminders.uid=?  or  reminders.uid='')  and not (reminders.uid='' and reminders.publisher=?)  and reminders.version>?", uid, uid, version).OrderAsc("version").Limit(limit).Load(&models)
 		} else {
-			_, err = build.Where("(reminders.uid=?  or  ( reminders.uid='' and reminders.channel_id in ?))  and reminders.version>?", uid, channelIDs, version).OrderAsc("version").Limit(limit).Load(&models)
+			_, err = build.Where("(reminders.uid=?  or  ( reminders.uid='' and reminders.channel_id in ?))  and not (reminders.uid='' and reminders.publisher=?)  and reminders.version>?", uid, channelIDs, uid, version).OrderAsc("version").Limit(limit).Load(&models)
 		}
 
 	}

--- a/modules/message/mention_rewrite.go
+++ b/modules/message/mention_rewrite.go
@@ -1,0 +1,38 @@
+// modules/message/mention_rewrite.go
+//
+// Thin re-export of pkg/mentionrewrite.RewriteMention into the
+// `message` package so the existing message-module dispatch sites
+// (Message.sendMessage in api.go) can keep using an unqualified symbol
+// — same pattern as sanitize_user_ingress.go wrapping
+// pkg/obopayload.StripReservedKeys.
+//
+// Why a separate package owns the helper
+// ======================================
+// The three-state rewrite has to be invoked from THREE client-controlled
+// message ingresses:
+//
+//   - modules/message/api.go      (Message.sendMessage)
+//   - modules/bot_api/send.go     (BotAPI.sendMessage)
+//   - modules/robot/api.go        (Robot.sendMessage)
+//
+// `modules/message` already imports `modules/robot` (revoke flow), so
+// placing the helper in `modules/message` and importing it from
+// `modules/robot` would create a `robot → message → robot` cycle. The
+// helper therefore lives in `pkg/mentionrewrite` (leaf package, no
+// module deps) and this file re-exports it for the message-package
+// callers. See pkg/mentionrewrite/rewrite.go for the contract and the
+// PR#70 audit doc (docs/2026-05-mention-all-chokepoint-audit.md §5)
+// for the design rationale.
+//
+// Spec: Mininglamp-OSS/octo-server#94, Multica YUJ-1343.
+package message
+
+import "github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
+
+// RewriteMention normalizes the payload's `mention` sub-map per the
+// three-state contract. Delegates to pkg/mentionrewrite so the shared
+// behavior cannot drift between the three ingress packages. See
+// pkg/mentionrewrite.RewriteMention for the full contract.
+func RewriteMention(payload map[string]interface{}) map[string]interface{} {
+	return mentionrewrite.RewriteMention(payload)
+}

--- a/modules/message/mention_rewrite_test.go
+++ b/modules/message/mention_rewrite_test.go
@@ -1,0 +1,67 @@
+// Colocated message-package tests for the RewriteMention helper. The
+// authoritative contract suite lives at pkg/mentionrewrite/rewrite_test.go
+// (where the helper itself is defined). These tests assert the
+// message-package shim is wired correctly — a future refactor that
+// turns the shim into a no-op stub will trip these.
+//
+// We deliberately keep these in `package message` (not _test) so the
+// tests reach the unqualified `RewriteMention` symbol the
+// message-package callers use; this is the same pattern
+// sanitize_user_ingress_test.go uses for the obopayload strip shim.
+package message
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMessagePackage_RewriteMention_AllRewrittenToHumansDoubleWrite is
+// the canonical regression guard for the message-package shim. If
+// someone deletes the import or breaks the wiring this test fails.
+func TestMessagePackage_RewriteMention_AllRewrittenToHumansDoubleWrite(t *testing.T) {
+	payload := map[string]interface{}{
+		"type":    1,
+		"content": "@所有人 ping",
+		"mention": map[string]interface{}{
+			"all": json.Number("1"),
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["all"],
+		"all=1 outbound double-write must be preserved")
+	assert.Equal(t, json.Number("1"), mention["humans"],
+		"all=1 inbound must rewrite to add humans=1")
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAIs,
+		"Yu D1: legacy @所有人 must NOT auto-trigger ais=1 (the bot-fan-out pain point)")
+}
+
+// TestMessagePackage_RewriteMention_AisPassthrough — message-package
+// shim must NOT short-circuit on the ais-only shape (the helper
+// preserves it untouched).
+func TestMessagePackage_RewriteMention_AisPassthrough(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"ais": json.Number("1"),
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["ais"])
+	_, hasHumans := mention["humans"]
+	assert.False(t, hasHumans)
+}
+
+// TestMessagePackage_RewriteMention_NilSafe — defensive: a future
+// caller may invoke the shim with a nil payload. Must not panic.
+func TestMessagePackage_RewriteMention_NilSafe(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("RewriteMention shim panicked on nil: %v", r)
+		}
+	}()
+	assert.Nil(t, RewriteMention(nil))
+}

--- a/modules/message/mention_rewrite_test.go
+++ b/modules/message/mention_rewrite_test.go
@@ -17,10 +17,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestMessagePackage_RewriteMention_AllRewrittenToHumansDoubleWrite is
-// the canonical regression guard for the message-package shim. If
-// someone deletes the import or breaks the wiring this test fails.
-func TestMessagePackage_RewriteMention_AllRewrittenToHumansDoubleWrite(t *testing.T) {
+// TestMessagePackage_RewriteMention_AllRewrittenToAIsDoubleWrite is
+// the canonical regression guard for the message-package shim under
+// Plan X (YUJ-1389): inbound `mention.all=1` must be rewritten to
+// also carry `mention.ais=1` (so legacy `@所有人` auto-fans-out to
+// all AI bots without an SDK update), while preserving the legacy
+// `all=1` on the outbound payload for old read-side clients. humans
+// MUST NOT be auto-set — humans is the explicit human-notification
+// signal and only the sender may set it. If someone deletes the
+// import or breaks the wiring this test fails.
+func TestMessagePackage_RewriteMention_AllRewrittenToAIsDoubleWrite(t *testing.T) {
 	payload := map[string]interface{}{
 		"type":    1,
 		"content": "@所有人 ping",
@@ -32,11 +38,29 @@ func TestMessagePackage_RewriteMention_AllRewrittenToHumansDoubleWrite(t *testin
 	mention := out["mention"].(map[string]interface{})
 	assert.Equal(t, json.Number("1"), mention["all"],
 		"all=1 outbound double-write must be preserved")
-	assert.Equal(t, json.Number("1"), mention["humans"],
-		"all=1 inbound must rewrite to add humans=1")
+	assert.Equal(t, json.Number("1"), mention["ais"],
+		"Plan X: all=1 inbound must rewrite to add ais=1 (auto-fan-out to bots)")
+	_, hasHumans := mention["humans"]
+	assert.False(t, hasHumans,
+		"humans MUST NOT be auto-set — only the sender may set the human-notification signal")
+}
+
+// TestMessagePackage_RewriteMention_HumansPassthrough — message-package
+// shim must NOT short-circuit on the humans-only shape (the helper
+// preserves it untouched). ais MUST NOT be inferred from humans.
+func TestMessagePackage_RewriteMention_HumansPassthrough(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"humans": json.Number("1"),
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["humans"])
 	_, hasAIs := mention["ais"]
-	assert.False(t, hasAIs,
-		"Yu D1: legacy @所有人 must NOT auto-trigger ais=1 (the bot-fan-out pain point)")
+	assert.False(t, hasAIs)
+	_, hasAll := mention["all"]
+	assert.False(t, hasAll)
 }
 
 // TestMessagePackage_RewriteMention_AisPassthrough — message-package

--- a/modules/message/sanitize_user_ingress.go
+++ b/modules/message/sanitize_user_ingress.go
@@ -1,0 +1,71 @@
+// modules/message/sanitize_user_ingress.go
+//
+// PR#82 R8 (Jerry-Xin 2026-05-19 review on head 244fe9fa) — strip any
+// reserved `__obo_*` top-level key from user-supplied payloads before
+// the message module persists or dispatches them.
+//
+// Why this exists
+// ===============
+// The OBO persona-clone fan-out listener
+// (modules/bot_api/obo_fanout.go) breaks its dispatch→listener loop by
+// dropping inbound messages whose payload carries
+// `__obo_processed__: true` (gate 3). The bot API
+// (/v1/bot/sendMessage) already rejects any `__obo_*` top-level key on
+// client input so a bot can't forge the marker. But the user-message
+// ingress (/v1/message/send → m.sendMessage) was accepting and
+// dispatching arbitrary user payload keys, so a normal user in a DM or
+// group could send `{"__obo_processed__": true, ...}` and suppress
+// fan-out to every grantor's persona-clone bot — silently breaking
+// the persona-clone delivery guarantee.
+//
+// Strip (vs. reject) at the user ingress
+// ======================================
+// Bot clients are expected to know the reserved namespace and the bot
+// API rejects with a 4xx so authors notice the mistake. Real users
+// never knowingly send `__obo_*` — the keys come from a malicious
+// client trying to exploit gate 3. A silent strip is the right UX
+// (legitimate clients see no behavior change) and the simplest fix
+// (no error surface to model in mobile / web clients).
+//
+// Shared contract
+// ===============
+// Both ingresses share pkg/obopayload's prefix definition so the strip
+// (here) and the reject (modules/bot_api/send.go) cannot drift apart.
+// The fan-out listener's gate-3 check also pulls its marker key from
+// pkg/obopayload so a future refactor renaming the marker can't leave
+// one ingress filtering a stale name.
+package message
+
+import (
+	"github.com/Mininglamp-OSS/octo-server/pkg/obopayload"
+	"go.uber.org/zap"
+)
+
+// logWarnFn matches the signature of (*log.TLog).Warn used by Message,
+// extracted so this helper can be exercised in unit tests without
+// instantiating a real logger.
+type logWarnFn func(msg string, fields ...zap.Field)
+
+// sanitizeUserIngressPayload strips every top-level `__obo_*` key from
+// `payload` (mutates in place) and logs a single warn line when any
+// keys were stripped. Safe on nil / empty payloads (no-op).
+//
+// channelID / channelType / fromUID are passed through to the log line
+// so abuse attempts surface with enough context to investigate.
+// logWarn is dependency-injected so unit tests can capture log calls.
+//
+// Called from m.sendMessage at the top of every user-message dispatch.
+// The list of additional user ingresses to wire this through (e.g. any
+// future user-payload relay) is enumerated in the package-level
+// comment of pkg/obopayload — keep them in sync.
+func sanitizeUserIngressPayload(payload map[string]interface{}, channelID string, channelType uint8, fromUID string, logWarn logWarnFn) int {
+	stripped := obopayload.StripReservedKeys(payload)
+	if stripped > 0 && logWarn != nil {
+		logWarn("stripped reserved OBO keys from user-message payload (PR#82 R8 guard)",
+			zap.String("channel_id", channelID),
+			zap.Uint8("channel_type", channelType),
+			zap.String("from_uid", fromUID),
+			zap.Int("stripped_count", stripped))
+	}
+	return stripped
+}

--- a/modules/message/sanitize_user_ingress_test.go
+++ b/modules/message/sanitize_user_ingress_test.go
@@ -1,0 +1,168 @@
+// Unit tests for the PR#82 R8 user-ingress OBO key strip.
+//
+// These lock the behavior Jerry-Xin's review on head 244fe9fa
+// required: a user-message payload with reserved `__obo_*` keys MUST
+// have them removed before the message reaches the dispatcher (and
+// therefore before the fan-out listener evaluates gate 3).
+package message
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/obopayload"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+// captureLog records every (msg, fields) pair sent to logWarnFn so the
+// strip's warn-logging contract can be asserted alongside the mutation.
+type captureLog struct {
+	mu    sync.Mutex
+	calls []capturedCall
+}
+
+type capturedCall struct {
+	msg    string
+	fields []zap.Field
+}
+
+func (cl *captureLog) warn(msg string, fields ...zap.Field) {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+	cl.calls = append(cl.calls, capturedCall{msg: msg, fields: fields})
+}
+
+// TestUserMessage_OBOReservedKeysStripped — primary regression guard
+// for PR#82 R8. A user-message payload carrying `__obo_processed__`
+// (the fan-out gate-3 marker) MUST be stripped before dispatch. The
+// previous behavior on head 244fe9fa passed the payload through
+// untouched, letting any user suppress fan-out by forging the marker.
+func TestUserMessage_OBOReservedKeysStripped(t *testing.T) {
+	cl := &captureLog{}
+	payload := map[string]interface{}{
+		"type":              1,
+		"content":           "hello",
+		"__obo_processed__": true,
+	}
+
+	stripped := sanitizeUserIngressPayload(
+		payload, "ch_abc", 1, "u_alice", cl.warn,
+	)
+
+	// The marker MUST be gone from the dispatched payload — that's
+	// the whole point of the fix.
+	if _, present := payload["__obo_processed__"]; present {
+		t.Fatalf("__obo_processed__ must be stripped from user payload, got %v", payload)
+	}
+	// Non-reserved keys MUST be preserved — the strip is targeted, not
+	// destructive.
+	assert.Equal(t, 1, payload["type"], "type field must survive strip")
+	assert.Equal(t, "hello", payload["content"], "content field must survive strip")
+	assert.Equal(t, 1, stripped, "exactly one __obo_* key was present")
+
+	// And the strip MUST emit a single warn-log so SRE can spot abuse
+	// attempts. We assert on the message text + the structured fields
+	// (channel_id, channel_type, from_uid, stripped_count) so a quiet
+	// regression that drops logging can be caught here.
+	if len(cl.calls) != 1 {
+		t.Fatalf("expected 1 warn log on strip, got %d", len(cl.calls))
+	}
+	got := cl.calls[0]
+	assert.Contains(t, got.msg, "stripped reserved OBO keys")
+	gotKeys := map[string]struct{}{}
+	for _, f := range got.fields {
+		gotKeys[f.Key] = struct{}{}
+	}
+	for _, want := range []string{"channel_id", "channel_type", "from_uid", "stripped_count"} {
+		if _, ok := gotKeys[want]; !ok {
+			t.Errorf("warn log missing field %q; got keys %v", want, gotKeys)
+		}
+	}
+}
+
+// (Helper removed — earlier draft used a stringifier we no longer
+// need; we only assert keys are present, not their values.)
+
+// TestUserMessage_OBOReservedKeysStripped_MultipleKeys — the strip is
+// namespace-wide (not marker-specific), so a user payload that tries
+// to spoof multiple `__obo_*` keys (e.g. anticipating future
+// server-only OBO fields) is fully cleaned in one pass.
+func TestUserMessage_OBOReservedKeysStripped_MultipleKeys(t *testing.T) {
+	cl := &captureLog{}
+	payload := map[string]interface{}{
+		"content":             "hi",
+		"__obo_processed__":   true,
+		"__obo_actual_sender": "victim_bot",
+		"__obo_anything_else": "x",
+	}
+
+	stripped := sanitizeUserIngressPayload(
+		payload, "ch", 1, "u", cl.warn,
+	)
+
+	assert.Equal(t, 3, stripped)
+	assert.Len(t, payload, 1, "only the non-reserved key should remain")
+	assert.Equal(t, "hi", payload["content"])
+	assert.Len(t, cl.calls, 1, "exactly one warn log even for multiple keys")
+}
+
+// TestUserMessage_OBOReservedKeysStripped_NoOpWhenAbsent — the strip
+// MUST be silent + no-op when the user's payload is clean. Otherwise
+// every legitimate message in production would log a warning.
+func TestUserMessage_OBOReservedKeysStripped_NoOpWhenAbsent(t *testing.T) {
+	cl := &captureLog{}
+	payload := map[string]interface{}{
+		"type":    1,
+		"content": "hi",
+	}
+	stripped := sanitizeUserIngressPayload(payload, "ch", 1, "u", cl.warn)
+	assert.Equal(t, 0, stripped)
+	assert.Len(t, payload, 2, "clean payload must be untouched")
+	assert.Empty(t, cl.calls, "no log on clean payload")
+}
+
+// TestUserMessage_OBOReservedKeysStripped_NilPayload — defensive: the
+// helper handles nil payloads (which can occur if a future caller
+// forgets to default-init) without panicking. Returns 0, logs nothing.
+func TestUserMessage_OBOReservedKeysStripped_NilPayload(t *testing.T) {
+	cl := &captureLog{}
+	stripped := sanitizeUserIngressPayload(nil, "ch", 1, "u", cl.warn)
+	assert.Equal(t, 0, stripped)
+	assert.Empty(t, cl.calls)
+}
+
+// TestUserMessage_OBOReservedKeysStripped_LegacyKeyKept — the legacy
+// (v0-shipped) `obo_processed` key is NOT in the reserved namespace
+// (no double-underscore prefix) so the strip leaves it alone. This
+// matches the bot-API reject and the gate-3 marker check: only the
+// `__obo_*` namespace is server-only. Locking this in protects
+// downstream consumers that might still inspect the legacy field for
+// debugging.
+func TestUserMessage_OBOReservedKeysStripped_LegacyKeyKept(t *testing.T) {
+	cl := &captureLog{}
+	payload := map[string]interface{}{
+		"content":       "hi",
+		"obo_processed": true, // legacy single-prefix, NOT in reserved namespace
+	}
+	stripped := sanitizeUserIngressPayload(payload, "ch", 1, "u", cl.warn)
+	assert.Equal(t, 0, stripped)
+	assert.Equal(t, true, payload["obo_processed"], "legacy key must survive")
+	assert.Empty(t, cl.calls)
+}
+
+// TestUserMessage_StripContract_PinnedToSharedPackage — meta-assertion:
+// the strip MUST go through pkg/obopayload so the user ingress and the
+// bot ingress + the fan-out listener can never drift apart on what
+// counts as a reserved key. We verify by calling the shared helper
+// directly and comparing against the message-module helper for the
+// same input.
+func TestUserMessage_StripContract_PinnedToSharedPackage(t *testing.T) {
+	via := map[string]interface{}{"__obo_processed__": true, "type": 1}
+	direct := map[string]interface{}{"__obo_processed__": true, "type": 1}
+
+	sanitizeUserIngressPayload(via, "ch", 1, "u", nil)
+	obopayload.StripReservedKeys(direct)
+
+	assert.Equal(t, direct, via, "message-module strip must match shared obopayload contract")
+}

--- a/modules/robot/ais_broadcast.go
+++ b/modules/robot/ais_broadcast.go
@@ -1,0 +1,158 @@
+// modules/robot/ais_broadcast.go
+//
+// YUJ-1393 / PR#82 review #2 R2 (Jerry-Xin 2026-05-19 follow-up):
+// dispatch helpers for the `mention.ais=1` ("@所有 AI") broadcast in
+// the robot event listener (modules/robot/event.go).
+//
+// Why this lives in its own file
+// ==============================
+// The robot event dispatcher already mixes DM friend-gate logic,
+// mention.uids parsing, and `@username` text parsing into one
+// for-loop. Adding the ais-broadcast path inline keeps the hot loop
+// readable, but the helpers themselves (the gjson truthy check, the
+// group-member → robot filter, the dedup append) are stateless and
+// independently testable. Keeping them here means
+// `go test ./modules/robot/... -run AisBroadcast` exercises the
+// branch without needing the full robotMessageListen plumbing.
+//
+// Scope
+// =====
+// Only GROUP channels. PERSONAL DMs already dispatch via the realUID
+// branch in robotMessageListen and have no notion of "all members".
+// COMMUNITY_TOPIC support is a deliberate follow-up — it requires
+// parent-group resolution (see parseThreadChannelID in
+// modules/webhook/api.go) and was intentionally left out of this
+// hotfix to keep the change surface small.
+package robot
+
+import (
+	"github.com/tidwall/gjson"
+)
+
+// mentionAisTruthy reports whether a gjson-parsed `mention.ais` value
+// is the canonical truthy form (1 / true / "1"). Mirrors the semantics
+// of mentionFlagTruthy in modules/message/api_reminders.go so the read
+// side (reminders) and the dispatch side (robot events) agree on what
+// counts as `@所有 AI`.
+//
+// The send-side rewrite chokepoint (pkg/mentionrewrite/rewrite.go)
+// writes json.Number("1") which gjson surfaces as a Number with
+// Int() == 1, so that's the hot path. We also accept the JSON `true`
+// form and the string "1" form defensively — a future client / proxy
+// rewrite might canonicalize the field differently and we don't want
+// a quiet broadcast regression because of it.
+//
+// Exposed as a method on *Robot purely so the dispatcher's call site
+// reads `rb.mentionAisTruthy(...)`, matching the surrounding
+// `rb.existRobot(...)` / `rb.getCreatorUID(...)` style. There is no
+// receiver state — the method body never touches `rb`.
+func (rb *Robot) mentionAisTruthy(r gjson.Result) bool {
+	if !r.Exists() {
+		return false
+	}
+	switch r.Type {
+	case gjson.True:
+		return true
+	case gjson.False, gjson.Null:
+		return false
+	case gjson.Number:
+		return r.Int() == 1
+	case gjson.String:
+		// Strict: only the canonical "1" string counts. We intentionally
+		// do NOT accept "true" / "yes" here — that would let a typo'd
+		// client trigger an all-bot broadcast accidentally.
+		return r.Str == "1"
+	}
+	return false
+}
+
+// collectGroupRobotIDs returns the deduplicated UIDs of every robot
+// member in `groupNo`. Returns (nil, nil) when the group has no
+// members or no robot members — the caller must treat an empty
+// result as "no broadcast targets" without logging it as an error.
+//
+// Failure modes:
+//   - groupService.GetMembers fails → returns (nil, err). The caller
+//     logs at error level and skips the ais branch for this message,
+//     i.e. the broadcast is best-effort; a transient DB error MUST
+//     NOT break the rest of the dispatcher (uid-matched bots in the
+//     same message still get their event).
+//   - existRobot fails for an individual member → that member is
+//     skipped (with a log line at the call site in event.go for
+//     parity with the existing mention.uids path), the rest of the
+//     enumeration continues. We don't want one stale cache key to
+//     silently drop the entire broadcast.
+//
+// Dedup: GetMembers already returns one row per (group, uid) pair so
+// the result is naturally unique on uid, but we still guard with a
+// seen-set so a future schema change that allows duplicate member
+// rows can't double-dispatch the same event to the same bot.
+func (rb *Robot) collectGroupRobotIDs(groupNo string) ([]string, error) {
+	members, err := rb.groupService.GetMembers(groupNo)
+	if err != nil {
+		return nil, err
+	}
+	if len(members) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(members))
+	seen := make(map[string]struct{}, len(members))
+	for _, m := range members {
+		if m == nil || m.UID == "" {
+			continue
+		}
+		if _, dup := seen[m.UID]; dup {
+			continue
+		}
+		isRobot, robotErr := rb.existRobot(m.UID)
+		if robotErr != nil {
+			// Single-member lookup failure must NOT abort the whole
+			// broadcast — log at the call site and skip this member.
+			// We could surface the err out, but the caller would have
+			// to either fail the whole broadcast (bad UX: one stale
+			// cache entry drops every bot) or log + continue anyway
+			// (same as here, just one extra hop).
+			continue
+		}
+		if isRobot {
+			out = append(out, m.UID)
+			seen[m.UID] = struct{}{}
+		}
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+// appendUniqueRobotIDs returns the concatenation of `existing` and the
+// entries from `add` that are not already in `existing` (dedup on
+// string equality). Preserves the order of `existing`, then appends
+// new entries from `add` in their original order.
+//
+// Used by the ais-broadcast branch in robotMessageListen to merge the
+// group-wide robot set into any robotIDs already collected from
+// mention.uids without dispatching the same event twice to the same
+// bot. Allocation is O(len(existing)+len(add)) — fine at the
+// per-message hot path where len is bounded by group size.
+func appendUniqueRobotIDs(existing, add []string) []string {
+	if len(add) == 0 {
+		return existing
+	}
+	seen := make(map[string]struct{}, len(existing)+len(add))
+	for _, id := range existing {
+		seen[id] = struct{}{}
+	}
+	out := existing
+	for _, id := range add {
+		if id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		out = append(out, id)
+		seen[id] = struct{}{}
+	}
+	return out
+}

--- a/modules/robot/ais_broadcast_test.go
+++ b/modules/robot/ais_broadcast_test.go
@@ -1,0 +1,167 @@
+// Unit tests for the YUJ-1393 / PR#82 review #2 R2 ais-broadcast
+// dispatch helpers (modules/robot/ais_broadcast.go).
+//
+// These exercise the three stateless pieces of the broadcast path:
+//
+//   - mentionAisTruthy: the gjson-side `mention.ais` truthy predicate.
+//   - appendUniqueRobotIDs: the dedup-merge used to fold the group-
+//     wide robot set into any uid-matched robots already collected
+//     from mention.uids.
+//   - (collectGroupRobotIDs is exercised in the api integration tests
+//     because it needs the groupService; here we lock the pure pieces.)
+package robot
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+)
+
+// helper to parse a fragment and return the mention.ais gjson result.
+func aisResult(t *testing.T, payload string) gjson.Result {
+	t.Helper()
+	return gjson.Parse(payload).Get("mention.ais")
+}
+
+// TestMentionAisTruthy_CanonicalNumberOne — the rewrite chokepoint
+// (pkg/mentionrewrite/rewrite.go) writes `json.Number("1")`; the
+// dispatcher MUST treat that as truthy, otherwise legacy `mention.
+// all=1` traffic (rewritten to also carry ais=1) silently fails to
+// reach group bots.
+func TestMentionAisTruthy_CanonicalNumberOne(t *testing.T) {
+	rb := &Robot{}
+	r := aisResult(t, `{"mention":{"ais":1}}`)
+	assert.True(t, rb.mentionAisTruthy(r),
+		"the rewrite hot path (json.Number(\"1\")) MUST be truthy")
+}
+
+// TestMentionAisTruthy_BooleanTrue — defensive: a client / proxy may
+// canonicalize ais as JSON `true`. We accept it so a quiet broadcast
+// regression cannot be introduced by an upstream serialization change.
+func TestMentionAisTruthy_BooleanTrue(t *testing.T) {
+	rb := &Robot{}
+	r := aisResult(t, `{"mention":{"ais":true}}`)
+	assert.True(t, rb.mentionAisTruthy(r))
+}
+
+// TestMentionAisTruthy_StringOne — defensive: same rationale as the
+// boolean form. Only the literal string "1" is accepted; "true" /
+// "yes" are NOT, to avoid a typo'd client accidentally fan-out-ing
+// to every bot.
+func TestMentionAisTruthy_StringOne(t *testing.T) {
+	rb := &Robot{}
+	assert.True(t, rb.mentionAisTruthy(aisResult(t, `{"mention":{"ais":"1"}}`)))
+	assert.False(t, rb.mentionAisTruthy(aisResult(t, `{"mention":{"ais":"true"}}`)),
+		"only the canonical \"1\" string is accepted; \"true\" is not")
+	assert.False(t, rb.mentionAisTruthy(aisResult(t, `{"mention":{"ais":"yes"}}`)))
+}
+
+// TestMentionAisTruthy_Falsy — every other shape MUST be falsy. This
+// is the symmetric guard for the truthy cases above: a `0`, `false`,
+// missing field, null, or non-1 number must NOT trigger the broadcast.
+func TestMentionAisTruthy_Falsy(t *testing.T) {
+	rb := &Robot{}
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"missing field", `{"mention":{}}`},
+		{"explicit zero", `{"mention":{"ais":0}}`},
+		{"explicit false", `{"mention":{"ais":false}}`},
+		{"explicit null", `{"mention":{"ais":null}}`},
+		{"number two", `{"mention":{"ais":2}}`},
+		{"negative one", `{"mention":{"ais":-1}}`},
+		{"empty string", `{"mention":{"ais":""}}`},
+		{"non-truthy string", `{"mention":{"ais":"x"}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.False(t, rb.mentionAisTruthy(aisResult(t, tc.raw)),
+				"shape %s must NOT trigger ais broadcast", tc.name)
+		})
+	}
+}
+
+// TestMentionAisTruthy_NonExistent — calling on a gjson.Result that
+// does not Exist() must be a clean `false` (no panic, no allocation).
+// Common path: payload has no `mention` key at all.
+func TestMentionAisTruthy_NonExistent(t *testing.T) {
+	rb := &Robot{}
+	// A literal "no such field" result.
+	r := gjson.Parse(`{"type":1}`).Get("mention.ais")
+	assert.False(t, r.Exists())
+	assert.False(t, rb.mentionAisTruthy(r))
+}
+
+// TestAppendUniqueRobotIDs_MergesAndDedups — the dedup append MUST
+// preserve order, drop duplicates from `add` that are already in
+// `existing`, and drop empty strings. Order matters: the goroutine
+// fan-out in event.go iterates in slice order and the test makes
+// the order contract explicit so a future refactor can't silently
+// reshuffle dispatch order.
+func TestAppendUniqueRobotIDs_MergesAndDedups(t *testing.T) {
+	existing := []string{"bot_a", "bot_b"}
+	add := []string{"bot_b", "bot_c", "", "bot_a", "bot_d"}
+
+	out := appendUniqueRobotIDs(existing, add)
+
+	assert.Equal(t, []string{"bot_a", "bot_b", "bot_c", "bot_d"}, out,
+		"order: existing first, then new entries from add in original order, no dups, no empty")
+}
+
+// TestAppendUniqueRobotIDs_EmptyAddIsNoOp — appending an empty slice
+// MUST return the existing slice unchanged (and without allocating a
+// new backing array). This is the hot path when ais=1 is set but the
+// group has no bot members.
+func TestAppendUniqueRobotIDs_EmptyAddIsNoOp(t *testing.T) {
+	existing := []string{"bot_a"}
+	out := appendUniqueRobotIDs(existing, nil)
+	assert.Equal(t, existing, out)
+
+	out2 := appendUniqueRobotIDs(existing, []string{})
+	assert.Equal(t, existing, out2)
+}
+
+// TestAppendUniqueRobotIDs_EmptyExistingPreservesAdd — when no uid-
+// matched bots were collected before the ais branch (the common case
+// for a pure `@所有 AI` message), the group-wide robot list becomes
+// the entire dispatch target as-is.
+func TestAppendUniqueRobotIDs_EmptyExistingPreservesAdd(t *testing.T) {
+	out := appendUniqueRobotIDs(nil, []string{"bot_a", "bot_b"})
+	assert.Equal(t, []string{"bot_a", "bot_b"}, out)
+}
+
+// TestAppendUniqueRobotIDs_DedupesWithinAdd — `add` itself may carry
+// duplicates (defensive against a future collectGroupRobotIDs change
+// that loosens its own dedup). The merge must still produce a unique
+// result.
+func TestAppendUniqueRobotIDs_DedupesWithinAdd(t *testing.T) {
+	out := appendUniqueRobotIDs(nil, []string{"bot_a", "bot_a", "bot_b"})
+	assert.Equal(t, []string{"bot_a", "bot_b"}, out)
+}
+
+// TestMentionAisTruthy_AfterRewrite — round-trip with the canonical
+// rewrite shape: encode a payload through encoding/json, parse it
+// with gjson, and confirm the dispatcher treats the rewritten ais
+// field as truthy. This locks the wire-format contract between
+// pkg/mentionrewrite.RewriteMention (which writes json.Number("1"))
+// and modules/robot.mentionAisTruthy.
+func TestMentionAisTruthy_AfterRewrite(t *testing.T) {
+	rb := &Robot{}
+	payload := map[string]interface{}{
+		"type":    1,
+		"content": "@所有人 hi",
+		"mention": map[string]interface{}{
+			"all": json.Number("1"),
+			"ais": json.Number("1"), // what RewriteMention writes
+		},
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	assert.True(t, rb.mentionAisTruthy(gjson.ParseBytes(b).Get("mention.ais")),
+		"json.Number(\"1\") MUST survive json.Marshal → gjson round-trip as truthy")
+}

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -41,17 +41,35 @@ import (
 
 // IService 为其他模块提供的窄接口，避免持有完整 *Robot 以及由此产生的循环依赖。
 // YUJ-60: 允许 bot 创建者撤回自己 bot 发的消息时，由 message 模块注入并调用。
+//
+// YUJ-1424 (PR#82 Jerry-Xin review blocker, 2026-05-20): EnqueueBotEvent
+// exposes the bot event queue write so cross-module callers (specifically
+// the OBO fan-out path in modules/bot_api) can deliver synthetic events
+// without going through WuKongIM → webhook → NotifyMessagesListeners.
+// The webhook drops NoPersist=1 messages before notifying listeners
+// (modules/webhook/api.go handleMessageNotify, by design — see the
+// content-type-contract comment in modules/bot_api/obo_fanout.go), so
+// the OBO fan-out copy (which intentionally sets NoPersist=1 to keep the
+// copy out of chat history) never reaches the bot event queue. Direct
+// enqueue bypasses that filter.
 type IService interface {
 	// GetCreatorUID 带缓存地查询机器人的创建者 UID。
 	// 机器人不存在或无 creator_uid 时返回空字符串及 nil error；
 	// 仅在底层查询异常时才返回 error。
 	GetCreatorUID(robotID string) (string, error)
+	// EnqueueBotEvent appends a synthetic event for `robotID` to the bot
+	// event queue consumed by /v1/bot/events. Mirrors the schema used by
+	// (*Robot).saveRobotMessage so /v1/bot/events serves both organic and
+	// synthetic events transparently. Returns an error only when the
+	// Redis ZADD / GenSeq call fails.
+	EnqueueBotEvent(robotID string, message *config.MessageResp) error
 }
 
 // Service robot 模块对外暴露的只读服务实现，供其它模块注入使用。
 // 与 *Robot 共享底层表结构，但不承担消息/事件监听等副作用，
 // 因此可以被重复 New 出来而不会导致重复注册 listener。
 type Service struct {
+	ctx          *config.Context
 	db           *robotDB
 	creatorCache sync.Map // robotID -> creatorUID
 }
@@ -59,7 +77,8 @@ type Service struct {
 // NewService 构造一个只读 robot 服务，满足 IService 接口。
 func NewService(ctx *config.Context) IService {
 	return &Service{
-		db: newBotDB(ctx),
+		ctx: ctx,
+		db:  newBotDB(ctx),
 	}
 }
 
@@ -93,6 +112,60 @@ func (rb *Robot) GetCreatorUID(robotID string) (string, error) {
 		return "", err
 	}
 	return uid, nil
+}
+
+// EnqueueBotEvent — IService — synthetic-event delivery path. See the
+// IService docstring for the YUJ-1424 / PR#82 R-blocker rationale. The
+// queue schema (key, score, payload shape, expiry) MUST match
+// (*Robot).saveRobotMessage exactly; if that helper's wire format ever
+// changes, update both sites in lockstep so /v1/bot/events serves
+// synthetic and organic events identically.
+func (s *Service) EnqueueBotEvent(robotID string, message *config.MessageResp) error {
+	return enqueueBotEventGeneric(s.ctx, robotID, message)
+}
+
+// EnqueueBotEvent — IService — *Robot variant. Delegates to the same
+// helper used by saveRobotMessage / Service.EnqueueBotEvent so the
+// queue write semantics cannot drift between the listener fast-path and
+// the cross-module synthetic path.
+func (rb *Robot) EnqueueBotEvent(robotID string, message *config.MessageResp) error {
+	return enqueueBotEventGeneric(rb.ctx, robotID, message)
+}
+
+// enqueueBotEventGeneric is the shared write-to-bot-event-queue helper
+// used by saveRobotMessage (listener path) and EnqueueBotEvent (cross-
+// module synthetic path). Centralizing the GenSeq / ZAdd / Expire shape
+// here means the bot event consumer (/v1/bot/events) sees identical
+// records regardless of which path produced them.
+func enqueueBotEventGeneric(ctx *config.Context, robotID string, message *config.MessageResp) error {
+	if ctx == nil {
+		return errors.New("robot: nil ctx, cannot enqueue bot event")
+	}
+	if strings.TrimSpace(robotID) == "" {
+		return errors.New("robot: empty robotID, cannot enqueue bot event")
+	}
+	if message == nil {
+		return errors.New("robot: nil message, cannot enqueue bot event")
+	}
+	seq, err := ctx.GenSeq(fmt.Sprintf("%s%s", common.RobotEventSeqKey, robotID))
+	if err != nil {
+		return err
+	}
+	messageUpdateJson := util.ToJson(&robotEvent{
+		EventID: seq,
+		Message: message,
+		Expire:  time.Now().Add(ctx.GetConfig().Robot.MessageExpire).Unix(),
+	})
+	key := fmt.Sprintf("robotEvent:%s", robotID)
+	if err := ctx.GetRedisConn().ZAdd(key, float64(seq), messageUpdateJson); err != nil {
+		return err
+	}
+	if err := ctx.GetRedisConn().Expire(key, ctx.GetConfig().Robot.MessageExpire); err != nil {
+		// Best-effort TTL refresh — do not fail the enqueue. Mirrors
+		// saveRobotMessage which also only logs on Expire failure.
+		return nil
+	}
+	return nil
 }
 
 type Robot struct {

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -318,6 +318,20 @@ func (rb *Robot) sendMessage(c *wkhttp.Context) {
 		return
 	}
 
+	// YUJ-1393 / PR#82 review #2 R1 (Jerry-Xin 2026-05-19 follow-up):
+	// strip any reserved `__obo_*` top-level key from the robot-supplied
+	// payload BEFORE validation / dispatch. The legacy robot endpoint
+	// was previously the only one of the three ingress points (user /
+	// bot / robot) that let `__obo_processed__: true` through unmodified,
+	// which a misbehaving / malicious robot script could exploit to
+	// suppress its own persona-clone fan-out copy (fan-out gate 3 in
+	// modules/bot_api/obo_fanout.go drops any payload carrying the
+	// marker). See modules/robot/sanitize_robot_ingress.go for the full
+	// rationale, the test surface, and why this ingress follows the
+	// silent-strip precedent set by the user API rather than the loud
+	// 4xx-reject precedent set by the bot API.
+	sanitizeRobotIngressPayload(messageReq.Payload, messageReq.ChannelID, messageReq.ChannelType, robotID, rb.Warn)
+
 	payloadResult := maputil.Data(messageReq.Payload)
 	contentTypeValue := payloadResult.Int("type")
 	if contentTypeValue == 0 {
@@ -353,13 +367,16 @@ func (rb *Robot) sendMessage(c *wkhttp.Context) {
 
 	// YUJ-202 / Mininglamp-OSS#94 — mention three-state rewrite. Same
 	// chokepoint contract as the user and bot API ingresses: legacy
-	// `mention.all=1` is normalized to also carry `mention.humans=1`,
-	// with `all=1` preserved on the outbound payload for old read-side
-	// clients (double-write). ⚠️ F2 (PR#70 Jerry-Xin correctness-
-	// critical review): MUST stay OUTSIDE the `ChannelTypePerson`
-	// conditional above so group / community-topic `@所有人` traffic
-	// (the main pain-point) actually goes through the chokepoint.
-	// Helper is idempotent and safe on nil — see pkg/mentionrewrite.
+	// `mention.all=1` is normalized (Plan X / YUJ-1389) to also carry
+	// `mention.ais=1`, with `all=1` preserved on the outbound payload
+	// for old read-side clients (double-write). `mention.humans=1` is
+	// NEVER inferred from legacy `all=1` — humans is the explicit human-
+	// notification signal and must be set by the client. ⚠️ F2 (PR#70
+	// Jerry-Xin correctness-critical review): MUST stay OUTSIDE the
+	// `ChannelTypePerson` conditional above so group / community-topic
+	// `@所有人` traffic (the main pain-point) actually goes through the
+	// chokepoint. Helper is idempotent and safe on nil —
+	// see pkg/mentionrewrite.
 	payload = mentionrewrite.RewriteMention(payload)
 
 	result, err := rb.ctx.SendMessageWithResult(&config.MsgSendReq{

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/file"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
 	pkgutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
 	"github.com/gin-gonic/gin"
 	"github.com/go-redis/redis"
@@ -349,6 +350,17 @@ func (rb *Robot) sendMessage(c *wkhttp.Context) {
 	if messageReq.ChannelType == common.ChannelTypePerson.Uint8() {
 		payload = rb.enrichBotPayloadWithSpaceID(robotID, payload)
 	}
+
+	// YUJ-202 / Mininglamp-OSS#94 — mention three-state rewrite. Same
+	// chokepoint contract as the user and bot API ingresses: legacy
+	// `mention.all=1` is normalized to also carry `mention.humans=1`,
+	// with `all=1` preserved on the outbound payload for old read-side
+	// clients (double-write). ⚠️ F2 (PR#70 Jerry-Xin correctness-
+	// critical review): MUST stay OUTSIDE the `ChannelTypePerson`
+	// conditional above so group / community-topic `@所有人` traffic
+	// (the main pain-point) actually goes through the chokepoint.
+	// Helper is idempotent and safe on nil — see pkg/mentionrewrite.
+	payload = mentionrewrite.RewriteMention(payload)
 
 	result, err := rb.ctx.SendMessageWithResult(&config.MsgSendReq{
 		StreamNo:    messageReq.StreamNo,

--- a/modules/robot/event.go
+++ b/modules/robot/event.go
@@ -169,6 +169,39 @@ func (rb *Robot) robotMessageListen(messages []*config.MessageResp) {
 						}
 					}
 				}
+				// YUJ-1393 / PR#82 review #2 R2 (Jerry-Xin 2026-05-19
+				// follow-up): mention.ais=1 means "@所有 AI" (Plan X /
+				// YUJ-1389). The robot event dispatcher previously only
+				// considered robot_id / mention.uids / @username text,
+				// so a payload carrying only mention.ais=1 (no uids,
+				// no @username) silently skipped the robot event queue
+				// and group bots never received the "@所有 AI" broadcast
+				// — including the very common legacy `mention.all=1`
+				// case, which the send-side rewrite chokepoints
+				// (pkg/mentionrewrite/rewrite.go) normalize to also
+				// carry `mention.ais=1`.
+				//
+				// Scope: GROUP channels only. PERSONAL DMs are already
+				// dispatched via the realUID branch above and have no
+				// notion of "all members of a channel".
+				// COMMUNITY_TOPIC support is a deliberate follow-up —
+				// it needs the parent-group lookup (see
+				// modules/webhook/api.go parseThreadChannelID) and was
+				// intentionally left out of this hotfix to keep the
+				// change surface small.
+				//
+				// Dedup against any uid-matched robots already in
+				// robotIDs so the goroutine fan-out below never
+				// double-saves the same event for the same bot.
+				if rb.mentionAisTruthy(mentionValue.Get("ais")) &&
+					message.ChannelType == common.ChannelTypeGroup.Uint8() {
+					groupRobotIDs, err := rb.collectGroupRobotIDs(message.ChannelID)
+					if err != nil {
+						rb.Error("查询群机器人成员失败！", zap.Error(err), zap.String("channelID", message.ChannelID))
+					} else {
+						robotIDs = appendUniqueRobotIDs(robotIDs, groupRobotIDs)
+					}
+				}
 			} else {
 				if common.ContentType(payloadValue.Get("type").Int()) == common.Text {
 					content := payloadValue.Get("content").String()

--- a/modules/robot/sanitize_robot_ingress.go
+++ b/modules/robot/sanitize_robot_ingress.go
@@ -1,0 +1,82 @@
+// modules/robot/sanitize_robot_ingress.go
+//
+// PR#82 review #2 R1 (Jerry-Xin 2026-05-19 follow-up): strip any
+// reserved `__obo_*` top-level key from robot-supplied payloads at the
+// legacy `/v1/robots/:robot_id/:app_key/sendMessage` ingress.
+//
+// Why this exists
+// ===============
+// The OBO persona-clone fan-out listener
+// (modules/bot_api/obo_fanout.go) breaks its dispatch → listener →
+// fan-out loop by dropping any inbound message whose payload carries
+// `__obo_processed__: true` (gate 3). The bot API
+// (`/v1/bot/sendMessage`, modules/bot_api/send.go) rejects any
+// `__obo_*` top-level key on bot client input, and the user message
+// API (`/v1/message/send`, modules/message/api.go) silently strips it
+// (see modules/message/sanitize_user_ingress.go). The legacy robot
+// `sendMessage` endpoint (this file's target) was the third ingress
+// and was the only one still letting `__obo_processed__: true` through
+// unmodified — a misbehaving / malicious robot script could forge the
+// marker and suppress its own persona-clone fan-out copy, silently
+// breaking the OBO delivery guarantee.
+//
+// Strip (vs. reject) at the robot ingress
+// =======================================
+// We follow the user-API "silent strip" precedent rather than the
+// bot-API "reject with 4xx" precedent for two reasons:
+//
+//  1. The legacy robot endpoint predates the OBO reserved namespace
+//     and there is no expectation in its public contract that
+//     `__obo_*` is meaningful. A silent strip avoids breaking any
+//     real legacy caller that may have accidentally chosen a colliding
+//     payload key.
+//  2. The new bot API is the documented surface for new integrations;
+//     authors who target the modern endpoint get the loud 4xx so
+//     mistakes are caught early. The legacy endpoint is in
+//     maintenance mode — quiet correctness is preferable to forcing
+//     callers to update their schema for a server-only namespace.
+//
+// Shared contract
+// ===============
+// Both ingresses (user + robot) share pkg/obopayload's prefix definition
+// with the bot-API reject + the fan-out listener's gate-3 check so the
+// three sites cannot drift apart. A future refactor renaming the
+// marker key only has to touch pkg/obopayload.
+package robot
+
+import (
+	"github.com/Mininglamp-OSS/octo-server/pkg/obopayload"
+	"go.uber.org/zap"
+)
+
+// logWarnFn matches the signature of (*log.TLog).Warn used by Robot,
+// extracted so this helper can be exercised in unit tests without
+// instantiating a real logger. Mirrors modules/message's logWarnFn so
+// the two ingress helpers stay shape-identical.
+type logWarnFn func(msg string, fields ...zap.Field)
+
+// sanitizeRobotIngressPayload strips every top-level `__obo_*` key
+// from `payload` (mutates in place) and logs a single warn line when
+// any keys were stripped. Safe on nil / empty payloads (no-op).
+//
+// channelID / channelType / fromUID are passed through to the log
+// line so abuse attempts surface with enough context to investigate.
+// logWarn is dependency-injected so unit tests can capture log calls
+// without a real logger.
+//
+// Called from rb.sendMessage (modules/robot/api.go) at the top of the
+// legacy robot sendMessage dispatch, BEFORE any payload validation,
+// space_id enrichment, or mention rewrite — the strip must precede
+// every chokepoint so a forged `__obo_processed__` cannot leak into
+// any downstream step that would observe it.
+func sanitizeRobotIngressPayload(payload map[string]interface{}, channelID string, channelType uint8, fromUID string, logWarn logWarnFn) int {
+	stripped := obopayload.StripReservedKeys(payload)
+	if stripped > 0 && logWarn != nil {
+		logWarn("stripped reserved OBO keys from robot-message payload (PR#82 review #2 R1 guard)",
+			zap.String("channel_id", channelID),
+			zap.Uint8("channel_type", channelType),
+			zap.String("from_uid", fromUID),
+			zap.Int("stripped_count", stripped))
+	}
+	return stripped
+}

--- a/modules/robot/sanitize_robot_ingress_test.go
+++ b/modules/robot/sanitize_robot_ingress_test.go
@@ -1,0 +1,170 @@
+// Unit tests for the PR#82 review #2 R1 robot-ingress OBO key strip.
+//
+// These lock in the behavior Jerry-Xin's 2026-05-19 follow-up review
+// required: a robot-message payload (the legacy
+// `/v1/robots/:robot_id/:app_key/sendMessage` endpoint) with reserved
+// `__obo_*` keys MUST have them removed before the message reaches the
+// dispatcher (and therefore before the fan-out listener evaluates
+// gate 3).
+//
+// Mirrors modules/message/sanitize_user_ingress_test.go one-to-one so
+// the three-ingress contract (user / bot / robot) cannot drift apart.
+package robot
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/obopayload"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+// captureRobotLog records every (msg, fields) pair sent to logWarnFn
+// so the strip's warn-logging contract can be asserted alongside the
+// mutation. Named distinctly from the message-module `captureLog` to
+// avoid any future test-binary symbol clash if helpers move.
+type captureRobotLog struct {
+	mu    sync.Mutex
+	calls []capturedRobotCall
+}
+
+type capturedRobotCall struct {
+	msg    string
+	fields []zap.Field
+}
+
+func (cl *captureRobotLog) warn(msg string, fields ...zap.Field) {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+	cl.calls = append(cl.calls, capturedRobotCall{msg: msg, fields: fields})
+}
+
+// TestRobotMessage_OBOReservedKeysStripped — primary regression guard
+// for YUJ-1393 / PR#82 review #2 R1. A robot-message payload carrying
+// `__obo_processed__` (the fan-out gate-3 marker) MUST be stripped
+// before dispatch. Before the fix, the legacy robot endpoint was the
+// only one of three ingress points (user / bot / robot) that let the
+// marker through unmodified, allowing a malicious robot script to
+// silently suppress its own persona-clone fan-out copy.
+func TestRobotMessage_OBOReservedKeysStripped(t *testing.T) {
+	cl := &captureRobotLog{}
+	payload := map[string]interface{}{
+		"type":              1,
+		"content":           "hello from robot",
+		"__obo_processed__": true,
+	}
+
+	stripped := sanitizeRobotIngressPayload(
+		payload, "ch_group_abc", 2, "bot_alice", cl.warn,
+	)
+
+	// The marker MUST be gone from the dispatched payload — that's the
+	// whole point of the fix.
+	if _, present := payload["__obo_processed__"]; present {
+		t.Fatalf("__obo_processed__ must be stripped from robot payload, got %v", payload)
+	}
+	// Non-reserved keys MUST be preserved — the strip is targeted, not
+	// destructive.
+	assert.Equal(t, 1, payload["type"], "type field must survive strip")
+	assert.Equal(t, "hello from robot", payload["content"], "content field must survive strip")
+	assert.Equal(t, 1, stripped, "exactly one __obo_* key was present")
+
+	// And the strip MUST emit a single warn-log so SRE can spot abuse
+	// attempts. We assert on the message text + the structured fields
+	// (channel_id, channel_type, from_uid, stripped_count) so a quiet
+	// regression that drops logging can be caught here.
+	if len(cl.calls) != 1 {
+		t.Fatalf("expected 1 warn log on strip, got %d", len(cl.calls))
+	}
+	got := cl.calls[0]
+	assert.Contains(t, got.msg, "stripped reserved OBO keys")
+	gotKeys := map[string]struct{}{}
+	for _, f := range got.fields {
+		gotKeys[f.Key] = struct{}{}
+	}
+	for _, want := range []string{"channel_id", "channel_type", "from_uid", "stripped_count"} {
+		if _, ok := gotKeys[want]; !ok {
+			t.Errorf("warn log missing field %q; got keys %v", want, gotKeys)
+		}
+	}
+}
+
+// TestRobotMessage_OBOReservedKeysStripped_MultipleKeys — the strip is
+// namespace-wide (not marker-specific), so a robot payload that tries
+// to spoof multiple `__obo_*` keys (e.g. anticipating future
+// server-only OBO fields) is fully cleaned in one pass.
+func TestRobotMessage_OBOReservedKeysStripped_MultipleKeys(t *testing.T) {
+	cl := &captureRobotLog{}
+	payload := map[string]interface{}{
+		"content":             "hi",
+		"__obo_processed__":   true,
+		"__obo_actual_sender": "victim_bot",
+		"__obo_anything_else": "x",
+	}
+
+	stripped := sanitizeRobotIngressPayload(
+		payload, "ch", 2, "bot", cl.warn,
+	)
+
+	assert.Equal(t, 3, stripped)
+	assert.Len(t, payload, 1, "only the non-reserved key should remain")
+	assert.Equal(t, "hi", payload["content"])
+	assert.Len(t, cl.calls, 1, "exactly one warn log even for multiple keys")
+}
+
+// TestRobotMessage_OBOReservedKeysStripped_NoOpWhenAbsent — the strip
+// MUST be silent + no-op when the robot's payload is clean. Otherwise
+// every legitimate robot message in production would log a warning.
+func TestRobotMessage_OBOReservedKeysStripped_NoOpWhenAbsent(t *testing.T) {
+	cl := &captureRobotLog{}
+	payload := map[string]interface{}{
+		"type":    1,
+		"content": "hi",
+	}
+	stripped := sanitizeRobotIngressPayload(payload, "ch", 2, "bot", cl.warn)
+	assert.Equal(t, 0, stripped)
+	assert.Len(t, payload, 2, "clean payload must be untouched")
+	assert.Empty(t, cl.calls, "no log on clean payload")
+}
+
+// TestRobotMessage_OBOReservedKeysStripped_NilPayload — defensive:
+// the helper handles nil payloads (which can occur if a future caller
+// forgets to default-init) without panicking. Returns 0, logs nothing.
+func TestRobotMessage_OBOReservedKeysStripped_NilPayload(t *testing.T) {
+	cl := &captureRobotLog{}
+	stripped := sanitizeRobotIngressPayload(nil, "ch", 2, "bot", cl.warn)
+	assert.Equal(t, 0, stripped)
+	assert.Empty(t, cl.calls)
+}
+
+// TestRobotMessage_OBOReservedKeysStripped_LegacyKeyKept — the legacy
+// (v0-shipped) `obo_processed` key is NOT in the reserved namespace
+// (no double-underscore prefix) so the strip leaves it alone. This
+// matches the user-API strip, the bot-API reject, and the gate-3
+// marker check: only the `__obo_*` namespace is server-only.
+func TestRobotMessage_OBOReservedKeysStripped_LegacyKeyKept(t *testing.T) {
+	cl := &captureRobotLog{}
+	payload := map[string]interface{}{
+		"content":       "hi",
+		"obo_processed": true, // legacy single-prefix, NOT reserved
+	}
+	stripped := sanitizeRobotIngressPayload(payload, "ch", 2, "bot", cl.warn)
+	assert.Equal(t, 0, stripped)
+	assert.Equal(t, true, payload["obo_processed"], "legacy key must survive")
+	assert.Empty(t, cl.calls)
+}
+
+// TestRobotMessage_StripContract_PinnedToSharedPackage — meta-assertion
+// matching the user-ingress meta-assertion: the robot strip MUST go
+// through pkg/obopayload so the three ingresses + the fan-out listener
+// can never drift apart on what counts as a reserved key.
+func TestRobotMessage_StripContract_PinnedToSharedPackage(t *testing.T) {
+	via := map[string]interface{}{"__obo_processed__": true, "type": 1}
+	direct := map[string]interface{}{"__obo_processed__": true, "type": 1}
+
+	sanitizeRobotIngressPayload(via, "ch", 2, "bot", nil)
+	obopayload.StripReservedKeys(direct)
+
+	assert.Equal(t, direct, via, "robot-module strip must match shared obopayload contract")
+}

--- a/pkg/mentionrewrite/rewrite.go
+++ b/pkg/mentionrewrite/rewrite.go
@@ -23,19 +23,22 @@
 //
 // Inbound rewrite (CALL from message ingress chokepoints)
 // =======================================================
-// Legacy clients still emit `mention.all=1` for `@所有人`. The
-// three-state design assigns `all=1` the **humans-only** broadcast
-// semantics (Yu 2026-05-19 D1): "legacy `@所有人` should NOT auto-trigger
-// all bots, that's the exact pain point being fixed". So inbound
-// `mention.all=1` is rewritten to also carry `mention.humans=1`. The
-// legacy `mention.all=1` field is INTENTIONALLY preserved on the
-// outbound payload (double-write) so old read-side clients that only
-// understand `all` keep rendering the "@所有人" pill until their roll-out
-// catches up. New read-side clients prefer `humans` / `ais` and IGNORE
-// `all` when either of the new fields is set — see the read-side change
-// in Message.getMention (modules/message/api_reminders.go).
+// Legacy clients still emit `mention.all=1` for `@所有人`. Plan X
+// (YUJ-1389) assigns `all=1` the **ais broadcast** semantics: legacy
+// `@所有人` traffic automatically fans out to all AI bots without
+// requiring an SDK update on the sender side. So inbound
+// `mention.all=1` is rewritten to also carry `mention.ais=1`. A NEW
+// field `mention.humans=1` is the explicit human-notification signal
+// — it is the only way a client can request a channel-level reminder
+// for the human members of a channel. The legacy `mention.all=1` field
+// is INTENTIONALLY preserved on the outbound payload (double-write) so
+// old read-side clients that only understand `all` keep rendering the
+// "@所有人" pill until their roll-out catches up. New read-side clients
+// prefer `humans` / `ais` and IGNORE `all` when either of the new
+// fields is set — see the read-side change in Message.getMention
+// (modules/message/api_reminders.go).
 //
-// `mention.ais=1` is left untouched. `mention.humans=1` is left
+// `mention.humans=1` is left untouched. `mention.ais=1` is left
 // untouched. `mention.uids` / `mention.entities` are left untouched.
 //
 // The helper is idempotent: RewriteMention(RewriteMention(p)) ==
@@ -53,18 +56,25 @@ import "encoding/json"
 // mention state lives. Exposed so callers and tests share one constant.
 const MentionKey = "mention"
 
-// AllKey is the legacy `@所有人` field. Inbound `all=1` is rewritten to
-// also carry `humans=1`; the `all` field itself is preserved on the
-// dispatched payload (outbound double-write) for backward compat with
-// old read-side clients that only understand `all`.
+// AllKey is the legacy `@所有人` field. Inbound `all=1` is rewritten
+// (Plan X / YUJ-1389) to also carry `ais=1` so legacy clients
+// automatically trigger all AI bots without an SDK update; the `all`
+// field itself is preserved on the dispatched payload (outbound
+// double-write) for backward compat with old read-side clients that
+// only understand `all`.
 const AllKey = "all"
 
 // HumansKey signals a human-only broadcast (`@所有真人`). New read-side
 // clients render the "@所有人" pill from this field and IGNORE `all`.
+// Plan X: this is the ONLY signal that produces a channel-level
+// human-visible reminder — bots respond via the message delivery path
+// without needing a reminder row.
 const HumansKey = "humans"
 
-// AIsKey signals a bot-only broadcast (`@所有 AI`). Independent of
-// `humans` — both can be set on the same message (`@所有人 + @所有 AI`).
+// AIsKey signals a bot broadcast (`@所有 AI`). Independent of `humans`
+// — both can be set on the same message (`@所有人 + @所有 AI`). Plan X:
+// inbound legacy `all=1` is rewritten to carry `ais=1` so all bots
+// fan out by default for the legacy `@所有人` shape.
 const AIsKey = "ais"
 
 // RewriteMention normalizes the payload's `mention` sub-map per the
@@ -74,21 +84,23 @@ const AIsKey = "ais"
 // back pattern used elsewhere in the message dispatch stack (mirrors
 // `enrichPayloadWithSpaceID`).
 //
-// Behavior:
+// Behavior (Plan X / YUJ-1389):
 //   - payload == nil → returns nil (no allocation).
 //   - payload has no `mention` key, or `mention` is not a
 //     map[string]interface{} → returned untouched.
 //   - mention.all is truthy (==1 in either json.Number, float64, int,
-//     int64, uint64, or bool form) → mention.humans is set to the
+//     int64, uint64, or bool form) → mention.ais is set to the
 //     canonical json.Number("1"). mention.all is preserved.
-//   - mention.humans is already truthy → no-op on humans (preserves
+//   - mention.ais is already truthy → no-op on ais (preserves
 //     whatever numeric/bool form the caller sent).
-//   - mention.ais is left untouched in every branch.
+//   - mention.humans is left untouched in every branch — humans is the
+//     explicit human-notification signal and must NEVER be inferred
+//     from a legacy `all=1`.
 //   - mention.uids / mention.entities / any other key inside mention is
 //     left untouched.
 //
 // Idempotent by construction: a second pass over an already-rewritten
-// payload sees humans truthy and does nothing.
+// payload sees ais truthy and does nothing.
 func RewriteMention(payload map[string]interface{}) map[string]interface{} {
 	if payload == nil {
 		return nil
@@ -108,12 +120,14 @@ func RewriteMention(payload map[string]interface{}) map[string]interface{} {
 	if !isTruthyOne(mention[AllKey]) {
 		return payload
 	}
-	// Inbound `all=1` → make sure humans=1 is also present. Don't
-	// overwrite a humans value the client already supplied (might be a
-	// new client that explicitly set humans in addition to legacy all
-	// for forward+backward compat).
-	if !isTruthyOne(mention[HumansKey]) {
-		mention[HumansKey] = json.Number("1")
+	// Plan X / YUJ-1389: inbound `all=1` → make sure ais=1 is also
+	// present so legacy `@所有人` automatically fans out to all AI bots
+	// without requiring an SDK update on the sender side. Don't
+	// overwrite an ais value the client already supplied (might be a
+	// new client that explicitly set ais in addition to legacy all for
+	// forward+backward compat).
+	if !isTruthyOne(mention[AIsKey]) {
+		mention[AIsKey] = json.Number("1")
 	}
 	// `all` is INTENTIONALLY preserved — see package godoc on the
 	// outbound double-write rationale.

--- a/pkg/mentionrewrite/rewrite.go
+++ b/pkg/mentionrewrite/rewrite.go
@@ -1,0 +1,164 @@
+// Package mentionrewrite owns the inbound rewrite + outbound double-write
+// contract for the `mention.{all,humans,ais}` payload field
+// (YUJ-202 / Mininglamp-OSS/octo-server#94 — 方案 X "dead-field" strategy
+// for `@所有人`, three-state implementation of the PR#70 audit §5
+// recommendation).
+//
+// Why a separate pkg/
+// ===================
+// The helper has to be invoked from THREE client-controlled message
+// ingresses (modules/message/api.go, modules/bot_api/send.go,
+// modules/robot/api.go). `modules/message` already imports
+// `modules/robot` (revoke flow), so placing the helper in
+// `modules/message` would create a `robot → message → robot` import
+// cycle. The cleanest fix is to keep the helper in a leaf package neither
+// transport-layer module depends on transitively, mirroring how
+// pkg/obopayload solved the same shape of cross-module sharing for the
+// OBO `__obo_*` reserved key strip/reject contract.
+//
+// A thin re-export lives at `modules/message/mention_rewrite.go` so the
+// message-module callers can keep using the unqualified `RewriteMention`
+// symbol and so the issue spec's "modules/message/mention_rewrite.go is
+// the helper file" expectation is preserved.
+//
+// Inbound rewrite (CALL from message ingress chokepoints)
+// =======================================================
+// Legacy clients still emit `mention.all=1` for `@所有人`. The
+// three-state design assigns `all=1` the **humans-only** broadcast
+// semantics (Yu 2026-05-19 D1): "legacy `@所有人` should NOT auto-trigger
+// all bots, that's the exact pain point being fixed". So inbound
+// `mention.all=1` is rewritten to also carry `mention.humans=1`. The
+// legacy `mention.all=1` field is INTENTIONALLY preserved on the
+// outbound payload (double-write) so old read-side clients that only
+// understand `all` keep rendering the "@所有人" pill until their roll-out
+// catches up. New read-side clients prefer `humans` / `ais` and IGNORE
+// `all` when either of the new fields is set — see the read-side change
+// in Message.getMention (modules/message/api_reminders.go).
+//
+// `mention.ais=1` is left untouched. `mention.humans=1` is left
+// untouched. `mention.uids` / `mention.entities` are left untouched.
+//
+// The helper is idempotent: RewriteMention(RewriteMention(p)) ==
+// RewriteMention(p) for every input. Idempotency lets callers invoke it
+// at every chokepoint without worrying about re-entry from listeners /
+// fan-out / future relay paths.
+//
+// Safe on nil / empty / non-map `mention` payloads (no panic, no
+// mutation beyond the strict double-write).
+package mentionrewrite
+
+import "encoding/json"
+
+// MentionKey is the top-level payload key under which the three-state
+// mention state lives. Exposed so callers and tests share one constant.
+const MentionKey = "mention"
+
+// AllKey is the legacy `@所有人` field. Inbound `all=1` is rewritten to
+// also carry `humans=1`; the `all` field itself is preserved on the
+// dispatched payload (outbound double-write) for backward compat with
+// old read-side clients that only understand `all`.
+const AllKey = "all"
+
+// HumansKey signals a human-only broadcast (`@所有真人`). New read-side
+// clients render the "@所有人" pill from this field and IGNORE `all`.
+const HumansKey = "humans"
+
+// AIsKey signals a bot-only broadcast (`@所有 AI`). Independent of
+// `humans` — both can be set on the same message (`@所有人 + @所有 AI`).
+const AIsKey = "ais"
+
+// RewriteMention normalizes the payload's `mention` sub-map per the
+// three-state contract. Mutates the inner map in place when the inbound
+// shape calls for a rewrite, and returns the (possibly same) outer map
+// so callers can keep the `payload = RewriteMention(payload)` assign-
+// back pattern used elsewhere in the message dispatch stack (mirrors
+// `enrichPayloadWithSpaceID`).
+//
+// Behavior:
+//   - payload == nil → returns nil (no allocation).
+//   - payload has no `mention` key, or `mention` is not a
+//     map[string]interface{} → returned untouched.
+//   - mention.all is truthy (==1 in either json.Number, float64, int,
+//     int64, uint64, or bool form) → mention.humans is set to the
+//     canonical json.Number("1"). mention.all is preserved.
+//   - mention.humans is already truthy → no-op on humans (preserves
+//     whatever numeric/bool form the caller sent).
+//   - mention.ais is left untouched in every branch.
+//   - mention.uids / mention.entities / any other key inside mention is
+//     left untouched.
+//
+// Idempotent by construction: a second pass over an already-rewritten
+// payload sees humans truthy and does nothing.
+func RewriteMention(payload map[string]interface{}) map[string]interface{} {
+	if payload == nil {
+		return nil
+	}
+	raw, ok := payload[MentionKey]
+	if !ok || raw == nil {
+		return payload
+	}
+	mention, ok := raw.(map[string]interface{})
+	if !ok {
+		// Defensive: malformed mention (string / int / array) — never
+		// the shape a real client sends. Leave untouched so the read
+		// side / validation tests can keep asserting on the original
+		// payload.
+		return payload
+	}
+	if !isTruthyOne(mention[AllKey]) {
+		return payload
+	}
+	// Inbound `all=1` → make sure humans=1 is also present. Don't
+	// overwrite a humans value the client already supplied (might be a
+	// new client that explicitly set humans in addition to legacy all
+	// for forward+backward compat).
+	if !isTruthyOne(mention[HumansKey]) {
+		mention[HumansKey] = json.Number("1")
+	}
+	// `all` is INTENTIONALLY preserved — see package godoc on the
+	// outbound double-write rationale.
+	return payload
+}
+
+// isTruthyOne reports whether v is the numeric/boolean form of 1. The
+// `mention.*` fields arrive from `json.Decoder.UseNumber()` so the
+// hot path is json.Number, but client/test code may also send float64,
+// int, int64, uint64, or bool — handle all of them defensively so a
+// caller does not have to pre-normalize before calling RewriteMention.
+func isTruthyOne(v interface{}) bool {
+	switch x := v.(type) {
+	case nil:
+		return false
+	case json.Number:
+		n, err := x.Int64()
+		return err == nil && n == 1
+	case float64:
+		return x == 1
+	case float32:
+		return x == 1
+	case int:
+		return x == 1
+	case int8:
+		return x == 1
+	case int16:
+		return x == 1
+	case int32:
+		return x == 1
+	case int64:
+		return x == 1
+	case uint:
+		return x == 1
+	case uint8:
+		return x == 1
+	case uint16:
+		return x == 1
+	case uint32:
+		return x == 1
+	case uint64:
+		return x == 1
+	case bool:
+		return x
+	default:
+		return false
+	}
+}

--- a/pkg/mentionrewrite/rewrite_test.go
+++ b/pkg/mentionrewrite/rewrite_test.go
@@ -1,12 +1,15 @@
 // Unit tests for the pure RewriteMention helper.
 //
 // These cover the spec contract from Mininglamp-OSS/octo-server#94 and
-// the issue YUJ-1343 acceptance list. The companion thin re-export in
-// modules/message/mention_rewrite.go has its own colocated test file
-// that exercises the same shapes through the message-package symbol,
-// so a future refactor moving the helper does not have to update two
-// suites in lockstep — the contract is asserted here and the shim test
-// only verifies the shim is not a stub.
+// the issue YUJ-1343 acceptance list, updated for Plan X (YUJ-1389):
+// inbound `mention.all=1` now rewrites to carry `mention.ais=1` (not
+// `humans=1`) so legacy `@所有人` traffic automatically fans out to
+// all AI bots without requiring an SDK update. The companion thin
+// re-export in modules/message/mention_rewrite.go has its own
+// colocated test file that exercises the same shapes through the
+// message-package symbol, so a future refactor moving the helper
+// does not have to update two suites in lockstep — the contract is
+// asserted here and the shim test only verifies the shim is not a stub.
 package mentionrewrite
 
 import (
@@ -18,9 +21,12 @@ import (
 )
 
 // TestRewriteMention_AllOnly — the canonical legacy-client shape. An
-// inbound `mention.all=1` MUST gain a `mention.humans=1` companion and
-// MUST keep the `all=1` field on the outbound payload (double-write for
-// old read-side clients that only understand `all`).
+// inbound `mention.all=1` MUST gain a `mention.ais=1` companion (Plan
+// X: legacy @所有人 → fan out to bots automatically) and MUST keep the
+// `all=1` field on the outbound payload (double-write for old
+// read-side clients that only understand `all`). humans MUST NOT be
+// set as a side effect — humans is the explicit human-notification
+// signal and must only be set by the sender.
 func TestRewriteMention_AllOnly(t *testing.T) {
 	payload := map[string]interface{}{
 		"type":    1,
@@ -35,11 +41,11 @@ func TestRewriteMention_AllOnly(t *testing.T) {
 	mention := out["mention"].(map[string]interface{})
 	assert.Equal(t, json.Number("1"), mention["all"],
 		"all=1 must be preserved (outbound double-write for legacy clients)")
-	assert.Equal(t, json.Number("1"), mention["humans"],
-		"all=1 inbound must set humans=1")
-	_, hasAIs := mention["ais"]
-	assert.False(t, hasAIs,
-		"ais must NOT be auto-set — legacy @所有人 must not silently fan out to bots (Yu D1 rationale)")
+	assert.Equal(t, json.Number("1"), mention["ais"],
+		"Plan X: all=1 inbound must set ais=1 so legacy @所有人 fans out to bots")
+	_, hasHumans := mention["humans"]
+	assert.False(t, hasHumans,
+		"humans must NOT be auto-set — humans is the explicit human-notification signal")
 	// Non-mention fields untouched.
 	assert.Equal(t, 1, out["type"])
 	assert.Equal(t, "@所有人 hi", out["content"])
@@ -109,7 +115,7 @@ func TestRewriteMention_AllPlusUIDs(t *testing.T) {
 	out := RewriteMention(payload)
 	mention := out["mention"].(map[string]interface{})
 	assert.Equal(t, json.Number("1"), mention["all"], "all preserved")
-	assert.Equal(t, json.Number("1"), mention["humans"], "humans added")
+	assert.Equal(t, json.Number("1"), mention["ais"], "Plan X: ais added")
 	assert.Equal(t,
 		[]interface{}{"uid_alice", "uid_bob"},
 		mention["uids"],
@@ -134,7 +140,7 @@ func TestRewriteMention_AllPlusEntities(t *testing.T) {
 	out := RewriteMention(payload)
 	mention := out["mention"].(map[string]interface{})
 	assert.Equal(t, json.Number("1"), mention["all"])
-	assert.Equal(t, json.Number("1"), mention["humans"])
+	assert.Equal(t, json.Number("1"), mention["ais"], "Plan X: ais added")
 	assert.True(t, reflect.DeepEqual(entities, mention["entities"]),
 		"entities array must survive the rewrite untouched")
 }
@@ -225,7 +231,7 @@ func TestRewriteMention_AllAsFloat(t *testing.T) {
 	}
 	out := RewriteMention(payload)
 	mention := out["mention"].(map[string]interface{})
-	assert.Equal(t, json.Number("1"), mention["humans"], "float64 all=1 must trigger rewrite")
+	assert.Equal(t, json.Number("1"), mention["ais"], "float64 all=1 must trigger rewrite to ais=1")
 	assert.Equal(t, float64(1), mention["all"], "original all value preserved verbatim")
 }
 
@@ -239,12 +245,12 @@ func TestRewriteMention_AllAsBool(t *testing.T) {
 	}
 	out := RewriteMention(payload)
 	mention := out["mention"].(map[string]interface{})
-	assert.Equal(t, json.Number("1"), mention["humans"])
+	assert.Equal(t, json.Number("1"), mention["ais"])
 	assert.Equal(t, true, mention["all"])
 }
 
 // TestRewriteMention_AllZero — `all=0` is the "no @所有人" sentinel; the
-// rewrite must NOT add a humans field.
+// rewrite must NOT add an ais field.
 func TestRewriteMention_AllZero(t *testing.T) {
 	payload := map[string]interface{}{
 		"mention": map[string]interface{}{
@@ -253,15 +259,38 @@ func TestRewriteMention_AllZero(t *testing.T) {
 	}
 	out := RewriteMention(payload)
 	mention := out["mention"].(map[string]interface{})
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAIs, "all=0 must not gain ais=1")
 	_, hasHumans := mention["humans"]
 	assert.False(t, hasHumans, "all=0 must not gain humans=1")
 }
 
-// TestRewriteMention_AllAndHumansBothSet — a forward-compat new client
-// might already set BOTH all and humans. The rewrite must NOT clobber
-// the client-supplied humans value (e.g. some future "humans=2" semantic
+// TestRewriteMention_AllAndAIsBothSet — a forward-compat new client
+// might already set BOTH all and ais. The rewrite must NOT clobber
+// the client-supplied ais value (e.g. some future "ais=2" semantic
 // would be silently overwritten by a blind set).
-func TestRewriteMention_AllAndHumansBothSet(t *testing.T) {
+func TestRewriteMention_AllAndAIsBothSet(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"all": json.Number("1"),
+			"ais": json.Number("1"),
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	// Both still present, neither mutated.
+	assert.Equal(t, json.Number("1"), mention["all"])
+	assert.Equal(t, json.Number("1"), mention["ais"])
+	_, hasHumans := mention["humans"]
+	assert.False(t, hasHumans,
+		"humans must NOT be inferred from all=1 — only set explicitly by client")
+}
+
+// TestRewriteMention_AllPlusHumans — a client that explicitly wants to
+// notify humans alongside legacy `@所有人` sets both `all=1` and
+// `humans=1`. The rewrite still adds `ais=1` (Plan X) but must NOT
+// touch the existing humans field.
+func TestRewriteMention_AllPlusHumans(t *testing.T) {
 	payload := map[string]interface{}{
 		"mention": map[string]interface{}{
 			"all":    json.Number("1"),
@@ -270,9 +299,9 @@ func TestRewriteMention_AllAndHumansBothSet(t *testing.T) {
 	}
 	out := RewriteMention(payload)
 	mention := out["mention"].(map[string]interface{})
-	// Both still present, neither mutated.
-	assert.Equal(t, json.Number("1"), mention["all"])
-	assert.Equal(t, json.Number("1"), mention["humans"])
+	assert.Equal(t, json.Number("1"), mention["all"], "all preserved")
+	assert.Equal(t, json.Number("1"), mention["humans"], "client-supplied humans untouched")
+	assert.Equal(t, json.Number("1"), mention["ais"], "Plan X: ais added")
 }
 
 // TestRewriteMention_Idempotent — RewriteMention(RewriteMention(p))

--- a/pkg/mentionrewrite/rewrite_test.go
+++ b/pkg/mentionrewrite/rewrite_test.go
@@ -1,0 +1,330 @@
+// Unit tests for the pure RewriteMention helper.
+//
+// These cover the spec contract from Mininglamp-OSS/octo-server#94 and
+// the issue YUJ-1343 acceptance list. The companion thin re-export in
+// modules/message/mention_rewrite.go has its own colocated test file
+// that exercises the same shapes through the message-package symbol,
+// so a future refactor moving the helper does not have to update two
+// suites in lockstep — the contract is asserted here and the shim test
+// only verifies the shim is not a stub.
+package mentionrewrite
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRewriteMention_AllOnly — the canonical legacy-client shape. An
+// inbound `mention.all=1` MUST gain a `mention.humans=1` companion and
+// MUST keep the `all=1` field on the outbound payload (double-write for
+// old read-side clients that only understand `all`).
+func TestRewriteMention_AllOnly(t *testing.T) {
+	payload := map[string]interface{}{
+		"type":    1,
+		"content": "@所有人 hi",
+		"mention": map[string]interface{}{
+			"all": json.Number("1"),
+		},
+	}
+
+	out := RewriteMention(payload)
+
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["all"],
+		"all=1 must be preserved (outbound double-write for legacy clients)")
+	assert.Equal(t, json.Number("1"), mention["humans"],
+		"all=1 inbound must set humans=1")
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAIs,
+		"ais must NOT be auto-set — legacy @所有人 must not silently fan out to bots (Yu D1 rationale)")
+	// Non-mention fields untouched.
+	assert.Equal(t, 1, out["type"])
+	assert.Equal(t, "@所有人 hi", out["content"])
+}
+
+// TestRewriteMention_HumansOnly — explicit humans=1 from a new client
+// passes through untouched. ais MUST NOT be set as a side effect.
+func TestRewriteMention_HumansOnly(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"humans": json.Number("1"),
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["humans"])
+	_, hasAll := mention["all"]
+	assert.False(t, hasAll, "humans-only input must NOT gain a legacy all=1")
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAIs)
+}
+
+// TestRewriteMention_AIsOnly — explicit ais=1 from a new client passes
+// through untouched. humans MUST NOT be set as a side effect.
+func TestRewriteMention_AIsOnly(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"ais": json.Number("1"),
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["ais"])
+	_, hasHumans := mention["humans"]
+	assert.False(t, hasHumans, "ais-only input must NOT gain humans=1")
+	_, hasAll := mention["all"]
+	assert.False(t, hasAll)
+}
+
+// TestRewriteMention_HumansAndAIs — combined `@所有人 + @所有 AI` from a
+// new client passes through untouched.
+func TestRewriteMention_HumansAndAIs(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"humans": json.Number("1"),
+			"ais":    json.Number("1"),
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["humans"])
+	assert.Equal(t, json.Number("1"), mention["ais"])
+	_, hasAll := mention["all"]
+	assert.False(t, hasAll)
+}
+
+// TestRewriteMention_AllPlusUIDs — legacy `@所有人 + @alice + @bob`. The
+// uids array MUST be preserved (the rewrite is only about the broadcast
+// flag, not about individual mentions).
+func TestRewriteMention_AllPlusUIDs(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"all":  json.Number("1"),
+			"uids": []interface{}{"uid_alice", "uid_bob"},
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["all"], "all preserved")
+	assert.Equal(t, json.Number("1"), mention["humans"], "humans added")
+	assert.Equal(t,
+		[]interface{}{"uid_alice", "uid_bob"},
+		mention["uids"],
+		"uids array must be preserved verbatim")
+}
+
+// TestRewriteMention_AllPlusEntities — v2 client shape (mention.entities
+// is the new-format inline-mention metadata, see
+// modules/message/validation_test.go:885+). RewriteMention must NOT
+// drop or mutate the entities array.
+func TestRewriteMention_AllPlusEntities(t *testing.T) {
+	entities := []interface{}{
+		map[string]interface{}{"uid": "__all__", "offset": json.Number("0"), "length": json.Number("4")},
+	}
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"all":      json.Number("1"),
+			"uids":     []interface{}{},
+			"entities": entities,
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["all"])
+	assert.Equal(t, json.Number("1"), mention["humans"])
+	assert.True(t, reflect.DeepEqual(entities, mention["entities"]),
+		"entities array must survive the rewrite untouched")
+}
+
+// TestRewriteMention_UIDsOnly — no broadcast flag, just per-user
+// mentions. Nothing to rewrite.
+func TestRewriteMention_UIDsOnly(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"uids": []interface{}{"uid_alice"},
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	_, hasAll := mention["all"]
+	_, hasHumans := mention["humans"]
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAll)
+	assert.False(t, hasHumans)
+	assert.False(t, hasAIs)
+	assert.Equal(t, []interface{}{"uid_alice"}, mention["uids"])
+}
+
+// TestRewriteMention_NilPayload — defensive: nil in, nil out, no panic.
+func TestRewriteMention_NilPayload(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("RewriteMention panicked on nil payload: %v", r)
+		}
+	}()
+	assert.Nil(t, RewriteMention(nil))
+}
+
+// TestRewriteMention_EmptyPayload — empty map in, empty map out, no
+// panic, no key inserted at the top level.
+func TestRewriteMention_EmptyPayload(t *testing.T) {
+	out := RewriteMention(map[string]interface{}{})
+	assert.NotNil(t, out)
+	assert.Empty(t, out)
+}
+
+// TestRewriteMention_NoMentionKey — payload without a `mention` key
+// must be returned untouched (don't synthesize an empty mention map).
+func TestRewriteMention_NoMentionKey(t *testing.T) {
+	payload := map[string]interface{}{
+		"type":    1,
+		"content": "hi",
+	}
+	out := RewriteMention(payload)
+	_, hasMention := out["mention"]
+	assert.False(t, hasMention, "no mention key must remain absent")
+}
+
+// TestRewriteMention_MentionIsNil — explicit nil mention is treated the
+// same as absent. No mutation.
+func TestRewriteMention_MentionIsNil(t *testing.T) {
+	payload := map[string]interface{}{"mention": nil}
+	out := RewriteMention(payload)
+	assert.Nil(t, out["mention"])
+}
+
+// TestRewriteMention_MentionIsNonMap — malformed mention (string / int /
+// array) must NOT panic. Leave untouched.
+func TestRewriteMention_MentionIsNonMap(t *testing.T) {
+	cases := []map[string]interface{}{
+		{"mention": "weird"},
+		{"mention": 42},
+		{"mention": []interface{}{"a", "b"}},
+		{"mention": true},
+	}
+	for _, payload := range cases {
+		orig := payload["mention"]
+		out := RewriteMention(payload)
+		assert.Equal(t, orig, out["mention"],
+			"non-map mention must be returned untouched, no panic")
+	}
+}
+
+// TestRewriteMention_AllAsFloat — json.Decoder *without* UseNumber will
+// produce float64. Even though the message pipeline uses UseNumber, the
+// helper accepts the float form defensively so callers that decode with
+// the standard library default don't silently miss the rewrite.
+func TestRewriteMention_AllAsFloat(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"all": float64(1),
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["humans"], "float64 all=1 must trigger rewrite")
+	assert.Equal(t, float64(1), mention["all"], "original all value preserved verbatim")
+}
+
+// TestRewriteMention_AllAsBool — defensive: some Go callers might
+// construct payloads with `all: true`. Treat truthy bool as 1.
+func TestRewriteMention_AllAsBool(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"all": true,
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["humans"])
+	assert.Equal(t, true, mention["all"])
+}
+
+// TestRewriteMention_AllZero — `all=0` is the "no @所有人" sentinel; the
+// rewrite must NOT add a humans field.
+func TestRewriteMention_AllZero(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"all": json.Number("0"),
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	_, hasHumans := mention["humans"]
+	assert.False(t, hasHumans, "all=0 must not gain humans=1")
+}
+
+// TestRewriteMention_AllAndHumansBothSet — a forward-compat new client
+// might already set BOTH all and humans. The rewrite must NOT clobber
+// the client-supplied humans value (e.g. some future "humans=2" semantic
+// would be silently overwritten by a blind set).
+func TestRewriteMention_AllAndHumansBothSet(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"all":    json.Number("1"),
+			"humans": json.Number("1"),
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	// Both still present, neither mutated.
+	assert.Equal(t, json.Number("1"), mention["all"])
+	assert.Equal(t, json.Number("1"), mention["humans"])
+}
+
+// TestRewriteMention_Idempotent — RewriteMention(RewriteMention(p))
+// must equal RewriteMention(p) for every input shape. Idempotency is
+// the property that lets us drop the helper at three independent
+// chokepoints + any future listener / relay without worrying about
+// repeated rewrites.
+func TestRewriteMention_Idempotent(t *testing.T) {
+	inputs := []map[string]interface{}{
+		nil,
+		{},
+		{"mention": map[string]interface{}{"all": json.Number("1")}},
+		{"mention": map[string]interface{}{"humans": json.Number("1")}},
+		{"mention": map[string]interface{}{"ais": json.Number("1")}},
+		{"mention": map[string]interface{}{
+			"humans": json.Number("1"), "ais": json.Number("1"),
+		}},
+		{"mention": map[string]interface{}{
+			"all":  json.Number("1"),
+			"uids": []interface{}{"x", "y"},
+		}},
+		{"mention": map[string]interface{}{
+			"all":      json.Number("1"),
+			"entities": []interface{}{map[string]interface{}{"uid": "__all__"}},
+		}},
+	}
+	for i, in := range inputs {
+		once := RewriteMention(cloneShallow(in))
+		twice := RewriteMention(RewriteMention(cloneShallow(in)))
+		assert.True(t, reflect.DeepEqual(once, twice),
+			"input %d not idempotent: once=%v twice=%v", i, once, twice)
+	}
+}
+
+// cloneShallow makes a one-level copy of the payload and the nested
+// mention map so the two arms of the idempotency test do not share
+// mutable state.
+func cloneShallow(in map[string]interface{}) map[string]interface{} {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		if m, ok := v.(map[string]interface{}); ok {
+			inner := make(map[string]interface{}, len(m))
+			for ik, iv := range m {
+				inner[ik] = iv
+			}
+			out[k] = inner
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}

--- a/pkg/obopayload/payload.go
+++ b/pkg/obopayload/payload.go
@@ -1,0 +1,129 @@
+// Package obopayload owns the reserved-namespace contract for the
+// On-Behalf-Of (OBO) persona-clone fan-out path
+// (YUJ-1166 / Mininglamp-OSS/octo-server#81).
+//
+// The fan-out listener (modules/bot_api/obo_fanout.go) uses a payload key
+// (`__obo_processed__`) to break the OBO dispatch → listener → fan-out
+// loop. The marker MUST be server-only: if a client (bot OR user) could
+// set it on an inbound message, that client would be able to suppress
+// fan-out for any message and bypass the persona-clone delivery
+// guarantee Jerry-Xin's PR#82 R8 review called out.
+//
+// PR#82 R8 (head 244fe9fa) gap: the bot API ingress
+// (/v1/bot/sendMessage, see modules/bot_api/send.go) already rejects any
+// `__obo_*` key on inbound payloads, but the user-message ingress
+// (/v1/message/send, see modules/message/api.go) was passing user
+// payloads through to ctx.SendMessage unchanged. A normal user could
+// send `{"__obo_processed__": true, ...}` in a DM or group and the
+// listener's gate-3 short-circuit would drop the message before any
+// persona-clone copy reached the grantee bots.
+//
+// The remediation is to STRIP `__obo_*` top-level keys at every
+// user-message ingress before persistence/dispatch. This package owns
+// the prefix constant, the marker constant, and the shared strip/check
+// helpers so every ingress (and every test) agrees on the same
+// contract.
+//
+// Strip vs. reject: the bot API REJECTS (user-friendly 4xx — bots are
+// expected to read the spec and not write reserved keys), the user
+// message API STRIPS (silently removes the keys before dispatch — users
+// are not expected to know which keys are reserved, and a normal client
+// would never send them). Both behaviors share the same prefix
+// definition here.
+package obopayload
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+// ReservedKeyPrefix is the prefix that marks a payload key as part of
+// the server-only OBO reserved namespace. Any top-level key starting
+// with this prefix must be either rejected (bot API) or stripped (user
+// API) before the payload is persisted or dispatched, so the fan-out
+// listener's gate-3 marker (and any future server-only OBO field)
+// cannot be forged by a client.
+const ReservedKeyPrefix = "__obo_"
+
+// ProcessedMarkerKey is the JSON payload key the OBO dispatch path sets
+// on every authorized OBO send so the fan-out listener can short-circuit
+// gate 3 without re-querying. The double-underscore prefix puts it in
+// the ReservedKeyPrefix namespace — clients cannot set or suppress it
+// because the ingress validators strip/reject anything under the
+// prefix.
+const ProcessedMarkerKey = "__obo_processed__"
+
+// HasReservedKey reports whether any top-level key in the decoded
+// payload map starts with ReservedKeyPrefix. Used by the bot API
+// ingress (modules/bot_api/send.go) to fail fast with a 4xx when a bot
+// client tries to forge server-only state.
+func HasReservedKey(payload map[string]interface{}) bool {
+	if len(payload) == 0 {
+		return false
+	}
+	for k := range payload {
+		if strings.HasPrefix(k, ReservedKeyPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// StripReservedKeys removes every top-level key from `payload` whose
+// name starts with ReservedKeyPrefix. Returns the number of keys
+// stripped so the caller can log/metric the rare events. Safe on a nil
+// or empty map (no-op, returns 0).
+//
+// The map is mutated in place — callers that need to preserve the
+// caller-supplied map should clone first. The user-message ingress in
+// modules/message/api.go owns its decoded `req.Payload` by then, so
+// in-place mutation is fine there.
+//
+// We do NOT recurse into nested objects/arrays. The OBO reserved
+// namespace is defined at the TOP LEVEL of the dispatch payload (that
+// is the level the fan-out listener inspects); nested fields under a
+// user-controlled key (e.g. `extra.__obo_processed__`) are not part of
+// the contract and would not affect gate 3.
+func StripReservedKeys(payload map[string]interface{}) int {
+	if len(payload) == 0 {
+		return 0
+	}
+	stripped := 0
+	for k := range payload {
+		if strings.HasPrefix(k, ReservedKeyPrefix) {
+			delete(payload, k)
+			stripped++
+		}
+	}
+	return stripped
+}
+
+// HasProcessedMarker reports whether the raw JSON payload decodes as an
+// object containing `ProcessedMarkerKey: true`. Non-JSON or
+// non-boolean values are treated as absent so we err on the side of
+// fanning out.
+//
+// PR#82 R8 (perf nit from Jerry-Xin): the cheap pre-check is
+// bytes.Contains on the raw payload bytes — no `string()` conversion,
+// no allocation. Most inbound messages do not carry the marker, so the
+// JSON decode is short-circuited 99.9%+ of the time. Only the matching
+// minority pays the unmarshal cost.
+func HasProcessedMarker(payload []byte) bool {
+	if len(payload) == 0 {
+		return false
+	}
+	// Quick reject before the unmarshal — payloads in the millions/sec
+	// hot path shouldn't pay the JSON decode cost just to find no marker.
+	// bytes.Contains avoids the string() alloc the prior strings.Contains
+	// version forced on the entire payload (PR#82 R8 perf nit).
+	if !bytes.Contains(payload, []byte(ProcessedMarkerKey)) {
+		return false
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(payload, &m); err != nil {
+		return false
+	}
+	v, ok := m[ProcessedMarkerKey].(bool)
+	return ok && v
+}

--- a/pkg/obopayload/payload_test.go
+++ b/pkg/obopayload/payload_test.go
@@ -1,0 +1,231 @@
+// Package obopayload tests — locks down the reserved-namespace contract
+// the bot API (reject), the user message API (strip), and the fan-out
+// listener (gate-3 check) all share. A regression here would let one
+// ingress drift from the others and silently break the persona-clone
+// fan-out guarantee.
+package obopayload
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestHasReservedKey(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload map[string]interface{}
+		want    bool
+	}{
+		{"nil", nil, false},
+		{"empty", map[string]interface{}{}, false},
+		{"plain", map[string]interface{}{"type": 1, "content": "hi"}, false},
+		{"single underscore not reserved", map[string]interface{}{"_obo_internal": true}, false},
+		{"legacy obo_processed not reserved", map[string]interface{}{"obo_processed": true}, false},
+		{"the marker itself", map[string]interface{}{"__obo_processed__": true}, true},
+		{"any double-underscore obo key", map[string]interface{}{"__obo_anything__": "x"}, true},
+		{"mixed in", map[string]interface{}{"type": 1, "__obo_marker": false}, true},
+	}
+	for _, tc := range cases {
+		got := HasReservedKey(tc.payload)
+		if got != tc.want {
+			t.Errorf("%s: HasReservedKey(%v) = %v, want %v", tc.name, tc.payload, got, tc.want)
+		}
+	}
+}
+
+func TestStripReservedKeys(t *testing.T) {
+	cases := []struct {
+		name     string
+		payload  map[string]interface{}
+		wantN    int
+		wantLeft map[string]interface{}
+	}{
+		{"nil no-op", nil, 0, nil},
+		{"empty no-op", map[string]interface{}{}, 0, map[string]interface{}{}},
+		{
+			"no reserved keys untouched",
+			map[string]interface{}{"type": 1, "content": "hi"},
+			0,
+			map[string]interface{}{"type": 1, "content": "hi"},
+		},
+		{
+			"single marker stripped",
+			map[string]interface{}{"type": 1, "__obo_processed__": true},
+			1,
+			map[string]interface{}{"type": 1},
+		},
+		{
+			"multiple reserved stripped",
+			map[string]interface{}{
+				"type":              1,
+				"content":           "hi",
+				"__obo_processed__": true,
+				"__obo_marker":      "x",
+				"__obo_anything__":  42,
+			},
+			3,
+			map[string]interface{}{"type": 1, "content": "hi"},
+		},
+		{
+			"single underscore preserved",
+			map[string]interface{}{"_obo_internal": "keep", "__obo_processed__": true},
+			1,
+			map[string]interface{}{"_obo_internal": "keep"},
+		},
+		{
+			"legacy obo_processed preserved",
+			map[string]interface{}{"obo_processed": true},
+			0,
+			map[string]interface{}{"obo_processed": true},
+		},
+	}
+	for _, tc := range cases {
+		n := StripReservedKeys(tc.payload)
+		if n != tc.wantN {
+			t.Errorf("%s: StripReservedKeys returned %d, want %d", tc.name, n, tc.wantN)
+		}
+		if !mapsEqual(tc.payload, tc.wantLeft) {
+			t.Errorf("%s: after strip payload = %v, want %v", tc.name, tc.payload, tc.wantLeft)
+		}
+	}
+}
+
+func mapsEqual(a, b map[string]interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		bv, ok := b[k]
+		if !ok || bv != v {
+			return false
+		}
+	}
+	return true
+}
+
+func TestHasProcessedMarker_Variants(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		want    bool
+	}{
+		{"empty", "", false},
+		{"non-json", "not json at all", false},
+		{"json no marker", `{"type":1}`, false},
+		{"marker true", `{"__obo_processed__":true}`, true},
+		{"marker false", `{"__obo_processed__":false}`, false},
+		{"marker not bool", `{"__obo_processed__":"yes"}`, false},
+		{"marker mixed in", `{"type":1,"content":"hi","__obo_processed__":true}`, true},
+		{"legacy key ignored", `{"obo_processed":true}`, false},
+	}
+	for _, tc := range cases {
+		got := HasProcessedMarker([]byte(tc.payload))
+		if got != tc.want {
+			t.Errorf("%s: HasProcessedMarker(%q) = %v, want %v", tc.name, tc.payload, got, tc.want)
+		}
+	}
+}
+
+// TestFanout_HasOBOProcessedMarker_UsesContains — PR#82 R8 perf nit
+// regression guard. Jerry-Xin flagged the prior implementation calling
+// strings.Contains(string(payload), key), which allocated a full copy
+// of every inbound payload (including bot media, sticker JSON, etc).
+// The fix uses bytes.Contains directly on the raw payload bytes.
+//
+// We can't observe "alloc skipped" portably in a unit test, so we
+// instead lock in the two contracts that prove the bytes path is live:
+//
+//  1. The fast-path reject works on payloads that have no JSON
+//     structure at all (random bytes) without panicking — the bytes
+//     pre-check must answer false BEFORE json.Unmarshal sees the
+//     garbage. If anyone reverts to strings.Contains(string(payload), …)
+//     the function still passes this case but the next one catches a
+//     stricter property: the implementation must accept payloads with
+//     embedded NUL bytes (a string([]byte{0,…}) cast is legal in Go,
+//     but a regression that switches to a strings.Index loop over
+//     `string(payload)` would still observe the NULs and we'd at
+//     minimum prove the function is byte-safe).
+//
+//  2. The implementation MUST short-circuit on a payload missing the
+//     marker substring — i.e. the byte scan happens, and a payload
+//     that is valid JSON but does not contain the marker substring
+//     never reaches the decoder. We enforce this by feeding a
+//     deliberately malformed JSON tail AFTER a leading object that
+//     would otherwise unmarshal; a strings.Contains pre-check or a
+//     bytes.Contains pre-check both short-circuit identically here,
+//     so the assertion is that the function returns false WITHOUT
+//     surfacing an unmarshal error to the caller (i.e. no panic, no
+//     side channel).
+func TestFanout_HasOBOProcessedMarker_UsesContains(t *testing.T) {
+	// Case 1: NUL bytes are tolerated. bytes.Contains handles this
+	// natively; a strings.Contains(string(payload), …) regression would
+	// also pass this case, but the assertion proves the function does
+	// not blow up on non-UTF-8 / raw binary inputs (Jerry-Xin's perf
+	// argument was about not paying string() conversion cost; in
+	// practice clients are JSON, but bot media frames can carry
+	// arbitrary bytes inside string fields).
+	nul := []byte{'{', '"', 'x', '"', ':', '"', 0, 0, 0, '"', '}'}
+	if HasProcessedMarker(nul) {
+		t.Errorf("NUL-tolerant pre-check should return false, got true")
+	}
+
+	// Case 2: payload that contains the marker SUBSTRING in a string
+	// value but NOT as a top-level key. The cheap pre-check passes
+	// (substring present) so json.Unmarshal runs; the decoded map
+	// shows the marker is NOT a top-level key, so the function returns
+	// false. This proves both halves of the contract: (a) the
+	// pre-check is just a substring test, not a JSON parse, so it
+	// can't reject false positives on its own; (b) the post-check
+	// requires the marker to be a real top-level key set to true.
+	embedded := []byte(`{"content":"talking about __obo_processed__ literally","type":1}`)
+	if HasProcessedMarker(embedded) {
+		t.Errorf("marker substring inside a string value must NOT trigger gate 3, got true")
+	}
+
+	// Case 3: real marker — sanity that the function still returns
+	// true on the canonical input.
+	real := []byte(`{"__obo_processed__":true}`)
+	if !HasProcessedMarker(real) {
+		t.Errorf("canonical marker payload must trigger gate 3, got false")
+	}
+
+	// Case 4: the marker key MUST be findable byte-wise in the raw
+	// payload (this is the bytes.Contains contract). If a future
+	// refactor introduces a partial match (e.g. searching for
+	// "__obo_" only) the pre-check would accept payloads that don't
+	// carry the actual marker. Guard against that by asserting a
+	// payload with only the prefix (not the full marker key) does
+	// NOT match.
+	prefixOnly := []byte(`{"__obo_other_key":true}`)
+	if HasProcessedMarker(prefixOnly) {
+		t.Errorf("prefix-only payload must NOT trigger gate 3, got true")
+	}
+	// Defensive sanity: the bytes pre-check we rely on really does
+	// see the marker substring on the canonical payload.
+	if !bytes.Contains(real, []byte(ProcessedMarkerKey)) {
+		t.Fatalf("bytes pre-check failed to locate marker in canonical payload — test setup bug")
+	}
+}
+
+// BenchmarkHasProcessedMarker_NoMarker — micro-benchmark covering the
+// hot path Jerry-Xin called out: most inbound payloads don't carry the
+// marker, so the pre-check must be allocation-free. Run with `go test
+// -bench=HasProcessedMarker -benchmem ./pkg/obopayload/` to confirm
+// 0 B/op. A regression to `strings.Contains(string(payload), …)` would
+// show 1 alloc/op proportional to payload length.
+func BenchmarkHasProcessedMarker_NoMarker(b *testing.B) {
+	// 1 KiB JSON payload typical of a chat message — wide enough that
+	// a string() conversion would be measurable.
+	payload := []byte(`{"type":1,"content":"` +
+		string(make([]byte, 0, 1024)) +
+		`hello world hello world hello world hello world hello world hello ` +
+		`world hello world hello world hello world hello world hello world ` +
+		`hello world hello world hello world hello world hello world hello"}`)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if HasProcessedMarker(payload) {
+			b.Fatalf("payload should not match marker")
+		}
+	}
+}


### PR DESCRIPTION
## Scope summary

Server-side implementation of **PR-A** from the Persona Clone (AI 分身 / On-Behalf-Of) RFC at `~/.openclaw/workspace/drafts/persona-clone-rfc.md` — sections 1-5, the PR-A row in §8, and the gates listed in §10–§11. Only `octo-server` changes; PR-B (`octo-adapters#34`) and PR-C (`octo-web#46`) ship the transport pass-through and the UI separately.

### What lands here

| Layer | Files | Notes |
|---|---|---|
| DB migration | `modules/bot_api/sql/20260519000001_obo_v0.sql` | two tables: `obo_grants`, `obo_scopes`; date-prefix style follows neighbor `20260505000002_bot_api.sql` |
| Data + cache | `modules/bot_api/obo_db.go` | model + `oboStore` interface + `obo:grantor:{uid}` Redis cache, 30s TTL per RFC §11 |
| HTTP REST | `modules/bot_api/obo_api.go` | seven endpoints, all under `ba.ctx.AuthMiddleware` (USER token) |
| `sendMessage` change | `modules/bot_api/send.go` | new `on_behalf_of` field, `checkOBO` gate, `FromUID` swap, `obo_processed=true` payload marker |
| Fan-out hook | `modules/bot_api/obo_fanout.go` | `MessagesListener` registered in `NewBotAPI`, candidate 1 from RFC §5.3 |
| Tests | `obo_*_test.go` (5 files, ~1200 LOC) | no MySQL required — `fakeOBOStore` satisfies the interface |

### What is intentionally **not** here (per YUJ-1166 task spec)

- ❌ Frontend (`octo-web#46`)
- ❌ Adapter (`octo-adapters#34`)
- ❌ `messages` table `ALTER` (v0 uses `message_extra`)
- ❌ Draft mode (`mode` accepts only `auto`)
- ❌ Cross-user persona / marketplace
- ⚠️ `/v1/bot/stream/start` and `/v1/bot/stream/continue` — these endpoints do **not** exist on the bot-token API surface in the current main (`grep` shows only the legacy `/v1/robots/:robot_id/:app_key/stream/start` in `modules/robot/api.go`). I did not retrofit OBO onto that legacy path because (a) the task explicitly says "do NOT exceed scope" and (b) the legacy path doesn't pass through `bot_api`, so adding OBO to it is a cross-module concern that belongs in its own PR if PM agrees. Happy to follow up if needed.

---

## DB migration steps

```bash
# Auto-run via the standard migration runner (modules/bot_api/1module.go
# already declares SQLDir on the embed). No manual step needed:
docker compose -f docker-compose.yml up -d   # picks up the new file at startup

# Manual override (for im-test where deploy script reuses an existing DB):
docker exec -i <mysql_container> mysql -uroot dmworkim < \
  modules/bot_api/sql/20260519000001_obo_v0.sql
```

The migration is forward-only safe (`CREATE TABLE IF NOT EXISTS`) and has a paired `-- +migrate Down` block dropping both tables. Cascade is on `obo_scopes.grant_id` → `obo_grants.id` so a hard delete of a grant takes its scopes with it (the production code path uses **soft delete** via `active=0`, so cascade fires only in tests or operator-initiated cleanup).

---

## API contract

### `POST /v1/obo/grants`

```http
POST /v1/obo/grants
Authorization: <user_token>

{ "grantee_bot_uid": "yu_clone_bot", "mode": "auto" }
```

```json
{
  "id": 17,
  "grantor_uid": "yu_uid",
  "grantee_bot_uid": "yu_clone_bot",
  "mode": "auto",
  "global_enabled": 0,
  "active": 1,
  "created_at": "2026-05-19T05:30:00Z",
  "updated_at": "2026-05-19T05:30:00Z"
}
```

- Grantor is inferred from the auth token; setting `grantee_bot_uid` to your own uid → `400`.
- `mode` defaults to `"auto"` and must be `"auto"` in v0; `"draft"` → `400`.
- Duplicate `(grantor, grantee)` → `409`.
- Brand-new grants start with `global_enabled = 0` so a write race cannot inadvertently turn fan-out on before the user picks scopes.

### `GET /v1/obo/grants`
Returns `{"items": [...]}` for **all** rows (active + revoked) owned by the caller.

### `PUT /v1/obo/grants/:id`
```json
{ "mode": "auto", "global_enabled": 1 }
```
- `global_enabled` uses `*int` so omitted and `0` are distinguishable.
- Cross-user → `404` (not `403`, by design — we don't leak existence).

### `DELETE /v1/obo/grants/:id`
Soft delete (`active=0, global_enabled=0, revoked_at=now`). Cache invalidated inline.

### `POST /v1/obo/scopes`
```json
{ "grant_id": 17, "channel_id": "group_42", "channel_type": 2, "enabled": 1 }
```
- Duplicate `(grant_id, channel_id, channel_type)` → `409`.
- `enabled` defaults to `1`. Set to `0` to add a row in the off state.

### `DELETE /v1/obo/scopes/:id`
Hard delete. Cross-user → `404`.

### `GET /v1/obo/grants/:id/scopes`
Returns `{"items": [...]}`.

### `POST /v1/bot/sendMessage` (changed)

```json
{
  "channel_id": "group_42",
  "channel_type": 2,
  "on_behalf_of": "yu_uid",
  "payload": { "type": 1, "content": "hi" }
}
```

- `on_behalf_of` empty / absent → unchanged legacy behavior.
- Server runs `checkOBO(bot, on_behalf_of, channel_id, channel_type)` AFTER the existing `checkSendPermission`. Denial → `400` with body `"obo not authorized"`; no dispatch.
- On success, `FromUID = on_behalf_of` and the persisted payload gains:
  - `obo_processed: true` (gate-3 marker so the fan-out loop guard catches the bot's reply)
  - `actual_sender_uid: <bot_uid>` (audit metadata in `message_extra`)
- `space_id` resolution still keys on the bot's identity — OBO replaces *who*, not *which tenant*.

---

## Loop-protection gates (RFC §5.3)

`obo_fanout.go` → `fanoutForMessage` applies the three gates strictly in order; each has a dedicated test:

| Gate | Condition | Test |
|---|---|---|
| **1** | `msg.FromUID == grant.GranteeBotUID` (bot self-sent) | `TestFanout_Gate1_BotSelfSent` |
| **2** | `msg.FromUID == grant.GrantorUID` (grantor's own outbound) | `TestFanout_Gate2_GrantorOwnOutbound` |
| **3** | payload contains `"obo_processed": true` (already minted by OBO send) | `TestFanout_Gate3_AlreadyOBOProcessed` |

Gate 3 short-circuits cheapest (no DB), then we hit `findActiveGrantsForChannel` (single index join, returns empty for the vast majority of messages).

---

## Test evidence

```text
go build ./...                                              → OK
go vet  ./modules/bot_api/                                  → OK
go test ./modules/bot_api/ -v                               → 100% pass
  TestCheckOBO_Happy / NoGrant / GrantRevoked /
    GlobalDisabled / ScopeMissing / ScopeDisabled /
    SelfGrantRejected / EmptyInputs / DBError_OnGrantLookup /
    DBError_OnScopeLookup                                  ✓
  TestOBO_CreateGrant_{Happy,NoAuth,SelfReject,BadMode,Duplicate}
  TestOBO_ListGrants_Happy
  TestOBO_UpdateGrant_{Toggle,Cross_user_404}
  TestOBO_DeleteGrant_Happy
  TestOBO_CreateScope_{Happy,CrossUser404}
  TestOBO_ListScopes_Happy
  TestOBO_DeleteScope_{Happy,CrossUser404}                 ✓
  TestFanout_{Happy,Gate1,Gate2,Gate3,NoGrants,NilOrEmpty} ✓
  TestHasOBOProcessedMarker_Variants                       ✓
  TestSendMessage_OBO_Authorized_SwapsFromUID              ✓
  TestSendMessage_OBO_Unauthorized_Returns403              ✓
  TestSendMessage_NoOBO_LegacyPath  (regression guard)     ✓
  (plus all 30+ pre-existing bot_api tests still pass)
```

Other packages compile cleanly. The pre-existing failures in `modules/workplace` etc. require a MySQL container at `127.0.0.1:3306` and are unrelated to this PR (reproducible on the base SHA `f26e516`).

---

## Review tier
`high-risk` (auth + new protocol fields + cross-system) — ReviewBot `codex-review` will be dispatched separately per YUJ-1166.

## References
- Full RFC: `~/.openclaw/workspace/drafts/persona-clone-rfc.md`
- Base SHA: `f26e516`
- Companion PRs: `octo-adapters#34` (PR-B), `octo-web#46` (PR-C)

Fixes #81
