### PR TITLE
feat(voice): add feedback_url to voice config API

### DIFF
--- a/modules/voice/api.go
+++ b/modules/voice/api.go
@@ -215,7 +215,7 @@ func (v *Voice) transcribe(c *wkhttp.Context) {
 // getConfig returns voice feature configuration
 func (v *Voice) getConfig(c *wkhttp.Context) {
 	enabled := v.cfg.Validate() == nil
-	c.JSON(http.StatusOK, gin.H{
+	resp := gin.H{
 		"enabled":              enabled,
 		"max_duration":         v.cfg.MaxDuration,
 		"max_file_size":        v.cfg.MaxFileSize,
@@ -225,7 +225,11 @@ func (v *Voice) getConfig(c *wkhttp.Context) {
 		"local_timeout_ms":     v.cfg.LocalTimeoutMs,
 		"local_probe_url":      v.cfg.LocalProbeURL,
 		"local_transcribe_url": v.cfg.LocalTranscribeURL,
-	})
+	}
+	if v.cfg.FeedbackURL != "" {
+		resp["feedback_url"] = v.cfg.FeedbackURL
+	}
+	c.JSON(http.StatusOK, resp)
 }
 
 // buildASREntry constructs an ASREntry with common fields populated.

--- a/modules/voice/api_test.go
+++ b/modules/voice/api_test.go
@@ -1304,3 +1304,50 @@ func TestTranscribeAPI_MemberContextTruncation(t *testing.T) {
 	assert.Contains(t, receivedPrompt, longSuffix)
 	assert.NotContains(t, receivedPrompt, longPrefix)
 }
+
+func TestGetConfigAPI_FeedbackURL_Present(t *testing.T) {
+	cfg := &VoiceConfig{
+		LiteLLMUrl:  "https://example.com",
+		LiteLLMKey:  "key",
+		Models:      []string{"m"},
+		MaxDuration: 60,
+		MaxFileSize: 3 * 1024 * 1024,
+		Engine:      "gemini",
+		EditMode:    "edit",
+		FeedbackURL: "/feedback",
+	}
+
+	router := setupTestRouter(cfg, "")
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/voice/config", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "/feedback", resp["feedback_url"])
+}
+
+func TestGetConfigAPI_FeedbackURL_Absent(t *testing.T) {
+	cfg := &VoiceConfig{
+		LiteLLMUrl:  "https://example.com",
+		LiteLLMKey:  "key",
+		Models:      []string{"m"},
+		MaxDuration: 60,
+		MaxFileSize: 3 * 1024 * 1024,
+		Engine:      "gemini",
+		EditMode:    "edit",
+		FeedbackURL: "",
+	}
+
+	router := setupTestRouter(cfg, "")
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/voice/config", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	_, exists := resp["feedback_url"]
+	assert.False(t, exists, "feedback_url should not be present when empty")
+}

--- a/modules/voice/config.go
+++ b/modules/voice/config.go
@@ -64,6 +64,8 @@ type VoiceConfig struct {
 	LocalProbeURL      string // Full URL for local model health probe (env: VOICE_LOCAL_PROBE_URL, default: "http://localhost:8787/")
 	LocalTranscribeURL string // Full URL for local model transcription (env: VOICE_LOCAL_TRANSCRIBE_URL, default: "http://localhost:8787/v1/voice/transcribe")
 
+	FeedbackURL string // Voice quality feedback service URL (env: VOICE_FEEDBACK_URL)
+
 	MaxVoiceContextLength  int // max personal voice context runes (env: VOICE_MAX_VOICE_CONTEXT_LENGTH)
 	MaxContextTextLength   int // max context_text runes (env: VOICE_MAX_CONTEXT_TEXT_LENGTH)
 	MaxChatContextLength   int // max chat_context runes (env: VOICE_MAX_CHAT_CONTEXT_LENGTH)
@@ -238,6 +240,10 @@ func NewVoiceConfigFromEnv() *VoiceConfig {
 	cfg.LocalTranscribeURL = "http://localhost:8787/v1/voice/transcribe"
 	if v := os.Getenv("VOICE_LOCAL_TRANSCRIBE_URL"); v != "" {
 		cfg.LocalTranscribeURL = v
+	}
+
+	if v := os.Getenv("VOICE_FEEDBACK_URL"); v != "" {
+		cfg.FeedbackURL = v
 	}
 
 	return cfg

--- a/modules/voice/config_test.go
+++ b/modules/voice/config_test.go
@@ -29,6 +29,7 @@ func clearVoiceEnv() {
 	os.Unsetenv("VOICE_MAX_CONTEXT_TEXT_LENGTH")
 	os.Unsetenv("VOICE_MAX_CHAT_CONTEXT_LENGTH")
 	os.Unsetenv("VOICE_MAX_MEMBER_CONTEXT_LENGTH")
+	os.Unsetenv("VOICE_FEEDBACK_URL")
 }
 
 func TestNewVoiceConfigFromEnv_Defaults(t *testing.T) {
@@ -606,4 +607,21 @@ func TestNewVoiceConfigFromEnv_EmotionEmoji_OtherValues(t *testing.T) {
 	os.Setenv("VOICE_EMOTION_EMOJI", "yes")
 	cfg := NewVoiceConfigFromEnv()
 	assert.True(t, cfg.EmotionEmoji)
+}
+
+func TestNewVoiceConfigFromEnv_FeedbackURL_Default(t *testing.T) {
+	clearVoiceEnv()
+	defer clearVoiceEnv()
+
+	cfg := NewVoiceConfigFromEnv()
+	assert.Empty(t, cfg.FeedbackURL)
+}
+
+func TestNewVoiceConfigFromEnv_FeedbackURL_Set(t *testing.T) {
+	clearVoiceEnv()
+	defer clearVoiceEnv()
+
+	os.Setenv("VOICE_FEEDBACK_URL", "/feedback")
+	cfg := NewVoiceConfigFromEnv()
+	assert.Equal(t, "/feedback", cfg.FeedbackURL)
 }


### PR DESCRIPTION
## Summary

Add `feedback_url` field to the voice config API response, allowing the frontend to discover the voice quality feedback endpoint dynamically.

## Changes

- **config.go**: Add `FeedbackURL` field to `VoiceConfig`, read from `VOICE_FEEDBACK_URL` env var
- **api.go**: Return `feedback_url` in `GET /voice/config` only when configured (omitted when empty)
- **Tests**: 4 new tests covering config parsing and API response for both present/absent cases

## Behavior

| `VOICE_FEEDBACK_URL` | API response |
|---|---|
| Not set / empty | `feedback_url` field omitted |
| Set (e.g. `/feedback`) | `"feedback_url": "/feedback"` included |

Follows the same pattern as `local_probe_url` / `local_transcribe_url`.

## How to test

```bash
# With feedback URL configured
export VOICE_FEEDBACK_URL=/feedback
curl -s localhost:8090/voice/config | jq .feedback_url
# → "/feedback"

# Without
unset VOICE_FEEDBACK_URL
curl -s localhost:8090/voice/config | jq .feedback_url
# → null (field absent)
```