### PR TITLE
chore(ci): pin octo-issue-feed caller to @v2

### DIFF
--- a/.github/workflows/octo-issue-feed.yml
+++ b/.github/workflows/octo-issue-feed.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   notify:
-    uses: Mininglamp-OSS/.github/.github/workflows/octo-issue-feed.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-issue-feed.yml@v2
     with:
       repo_name: ${{ github.event.repository.name }}
       issue_number: ${{ github.event.issue.number }}


### PR DESCRIPTION
## Summary

Pins `octo-issue-feed.yml` caller from `@main` to `@v2` (stable tag).

## Why
`@main` tracks the head of the default branch — any future change to the reusable workflow takes effect immediately without a local PR. `@v2` pins to a known-good stable release, matching the convention used by other callers in this repo (`@v1` for auto-add-to-project, issue-welcome, etc.).

## What changed
One line: `octo-issue-feed.yml@main` → `octo-issue-feed.yml@v2`

## Merge order
1. `.github` PR #29 (remove deprecated inputs) must be merged first
2. Then `v2` tag is cut pointing at that commit
3. Then merge these caller PRs