### PR TITLE
feat(oidc): self-service account creation from SSO claims via /bind/create

### DIFF
--- a/modules/oidc/api.go
+++ b/modules/oidc/api.go
@@ -599,9 +599,25 @@ func (o *OIDC) callback(c *wkhttp.Context) {
 		DeviceFlag: sd.DeviceFlag,
 		PublicIP:   sd.IP,
 		// res.IsNew=true 进入 user.externalLoginCreate;TrustedSSOCreate=true
-		// 让 user 模块绕过 register.off 全局开关。OIDC 的"自动建号"由
-		// AllowNewUser + IssuerAllowlist(ShouldHandle 也已校验)闭环控制,
-		// 与公开注册入口语义不同。与 /bind/create 路径对称(见 bind_service.Create)。
+		// 让 user 模块绕过 register.off 全局开关。
+		//
+		// callback 路径的信任锚(与 /bind/create 走 IssuerAllowlist 是**不同**的
+		// trust chain,不要混):
+		//   1. o.client.VerifyIDToken 用 cfg.Provider.Issuer discovery 出来的
+		//      IdP 公钥验签 → claims.Issuer 必然等于 cfg.Provider.Issuer
+		//      (不等则验签直接失败,根本走不到这里),等同于"size=1 的
+		//      隐式 issuer allowlist";
+		//   2. Service.ResolveOrLink 只在 cfg.Provider.AllowNewUser=true
+		//      时才返 IsNew=true,这是运维通过 DM_OIDC_PROVIDER_ALLOW_NEW_USER
+		//      显式开的 bool。
+		// 两条合在一起 = "运维显式信任的单一 Provider.Issuer 自动建号" —— 与
+		// 公开注册入口(email/phone signup / GitHub/Gitee OAuth)的不可控外部
+		// 输入语义不同,bypass register.off 的运维授权是显式的。
+		//
+		// 与 /bind/create 行为对称(都"OIDC 通道下让运维显式控制建号"),但
+		// 信任链的具体机制不同 —— /bind/create 用 IssuerAllowlist 兜底
+		// (多 issuer 配置 + bind_token 显式同意),callback 用单 Provider.Issuer
+		// 签名 + AllowNewUser flag。
 		TrustedSSOCreate: res.IsNew,
 	}
 	sessResp, err := o.service.IssueSession(c.Request.Context(), issueReq)

--- a/modules/oidc/api.go
+++ b/modules/oidc/api.go
@@ -554,7 +554,15 @@ func (o *OIDC) callback(c *wkhttp.Context) {
 		// 自助绑定流程。其它失败 / flag off / issuer 不在白名单都退回旧路径,确保
 		// NFR-6 一键回滚(关 flag + 重启)语义生效。
 		if o.bind.ShouldHandle(err, claims) {
-			jti, ierr := o.bind.Issue(c.Request.Context(), claims, sd)
+			// 把 ResolveOrLink 的 err 类型固化到 BindSession.IssueReason —— Create
+			// 路径用它拒绝 manual_conflict 来源的建号请求,Info 路径用它回填
+			// create_blocked。BindReasonManualConflict 仅在多账号冲突时落地;
+			// 其他可接管错误统一按 BindReasonUnknownUser(自助建号合法来源)签发。
+			reason := BindReasonUnknownUser
+			if errors.Is(err, ErrConflictNeedManual) {
+				reason = BindReasonManualConflict
+			}
+			jti, ierr := o.bind.IssueWithReason(c.Request.Context(), claims, sd, reason)
 			if ierr == nil {
 				result = "bind_pending" // 已在 callbackResultLabels 注册
 				o.writeAudit("bind:"+subHash(jti), EventBindIssued, sd, "")
@@ -590,6 +598,11 @@ func (o *OIDC) callback(c *wkhttp.Context) {
 		Zone:       zone,
 		DeviceFlag: sd.DeviceFlag,
 		PublicIP:   sd.IP,
+		// res.IsNew=true 进入 user.externalLoginCreate;TrustedSSOCreate=true
+		// 让 user 模块绕过 register.off 全局开关。OIDC 的"自动建号"由
+		// AllowNewUser + IssuerAllowlist(ShouldHandle 也已校验)闭环控制,
+		// 与公开注册入口语义不同。与 /bind/create 路径对称(见 bind_service.Create)。
+		TrustedSSOCreate: res.IsNew,
 	}
 	sessResp, err := o.service.IssueSession(c.Request.Context(), issueReq)
 	if err != nil {

--- a/modules/oidc/api_bind.go
+++ b/modules/oidc/api_bind.go
@@ -79,13 +79,14 @@ type bindRouteGroup interface {
 	POST(relativePath string, handlers ...wkhttp.HandlerFunc)
 }
 
-// bindRoutes 挂载自助绑定的 5 个 HTTP 端点。
+// bindRoutes 挂载自助绑定的 HTTP 端点。
 //
 // 设计:
 //   - Bind.Enabled=false 时整个函数 no-op,production 配 disabled provider
 //     时连"路由不存在"都成立(404 由 gin 默认 router 兜底)
 //   - 不带 AuthMiddleware:bind_token 自身就是单次消费认证凭据(SR-1),
 //     调用方还没有 dmwork session 才需要走这套流程
+//   - AllowCreate=false 时 /bind/create 不挂(D8:404 比 403 更彻底)
 func (o *OIDC) bindRoutes(g bindRouteGroup) {
 	// 仅由 routeAt 在 o.cfg 非 nil 时调用,o == nil / o.cfg == nil 不可达。
 	if !o.cfg.Bind.Enabled {
@@ -96,6 +97,9 @@ func (o *OIDC) bindRoutes(g bindRouteGroup) {
 	g.POST("/bind/verify/otp/send", o.bindOTPSend)
 	g.POST("/bind/verify/otp/check", o.bindOTPCheck)
 	g.POST("/bind/confirm", o.bindConfirm)
+	if o.cfg.Bind.AllowCreate {
+		g.POST("/bind/create", o.bindCreate)
+	}
 }
 
 // bindInfo GET /bind/info?token=...  → 脱敏身份信息 + 可用方法(FR-2)。
@@ -296,10 +300,10 @@ func (o *OIDC) handleBindVerifyErr(c *wkhttp.Context, path, token string, err er
 // bindConfirm POST /bind/confirm  {token}
 //
 // 用户在确认页点"绑定"后调用(FR-4.1)。串行步骤:
-//   1. service.Confirm 写 user_oidc_identity + 调 IssueSession 拿 LoginRespJSON
-//   2. authcode.SetAuthcode 回填原发起设备的 ThirdAuthcode(FR-6.3 跨设备)
-//   3. 同时把 LoginRespJSON 直接返给当前设备,前端可选择走 ThirdAuthcode 或
-//      response body(若当前设备 == 发起设备,二者等价)
+//  1. service.Confirm 写 user_oidc_identity + 调 IssueSession 拿 LoginRespJSON
+//  2. authcode.SetAuthcode 回填原发起设备的 ThirdAuthcode(FR-6.3 跨设备)
+//  3. 同时把 LoginRespJSON 直接返给当前设备,前端可选择走 ThirdAuthcode 或
+//     response body(若当前设备 == 发起设备,二者等价)
 //
 // 失败码:
 //   - 400 token 缺失/非法
@@ -343,9 +347,9 @@ func (o *OIDC) bindConfirm(c *wkhttp.Context) {
 	}
 	o.writeAudit(resp.UID, EventBindConfirmOK, stateFromCtx(c), "")
 	c.JSON(http.StatusOK, map[string]interface{}{
-		"status":      "ok",
-		"login_resp":  resp.IssueResp.LoginRespJSON,
-		"uid":         resp.UID,
+		"status":     "ok",
+		"login_resp": resp.IssueResp.LoginRespJSON,
+		"uid":        resp.UID,
 	})
 }
 
@@ -433,10 +437,94 @@ func bindResultFromErr(err error) string {
 		return "conflict"
 	case errors.Is(err, ErrBindAuthRejected):
 		return "unauthorized"
+	case errors.Is(err, ErrBindCreateClaimsIncomplete):
+		return "claims_incomplete"
 	default:
 		// 未分类 = 内部异常。dashboard 上看到 internal_error 持续升高就是
 		// 该报警的信号(DB/Redis/底层 SMSService 故障),与 401 不再混淆。
 		return "internal_error"
+	}
+}
+
+// bindCreate POST /bind/create  {token}
+//
+// 用 bind_token 里固化的 SSO claims 直接建号 + 写 identity + 签发会话。
+// 复用 AllowNewUser=true 路径语义(IssueSession{CreateUser:true}),但走 bind_token 护栏。
+//
+// 失败码:
+//   - 400 token 缺失/格式非法
+//   - 409 status 冲突或 identity 已存在(race recover 路径)
+//   - 410 token 已过期/未知
+//   - 422 claims 既无 verified email 也无 verified phone
+//   - 429 同一 token 已 create 过(单次性)
+//   - 500 内部错误
+func (o *OIDC) bindCreate(c *wkhttp.Context) {
+	m := startBindMetric("create")
+	defer m.finish()
+
+	if o.guardBindReady(c, m) {
+		return
+	}
+	var req struct {
+		Token string `json:"token"`
+	}
+	if err := c.BindJSON(&req); err != nil || !authcodeRe.MatchString(req.Token) {
+		m.result = "bad_request"
+		c.AbortWithStatusJSON(http.StatusBadRequest, errMsg("token required"))
+		return
+	}
+	ctx := c.Request.Context()
+	resp, err := o.bind.Create(ctx, req.Token)
+	if err != nil {
+		m.result = bindResultFromErr(err)
+		o.handleBindCreateErr(c, req.Token, err)
+		return
+	}
+	m.result = "ok"
+	if resp.SD != nil && resp.SD.ClientAuthcode != "" && o.authcode != nil {
+		if e := o.authcode.SetAuthcode(ctx, resp.SD.ClientAuthcode,
+			resp.IssueResp.LoginRespJSON, thirdAuthcodeTTL); e != nil {
+			o.Warn("OIDC bind create: write ThirdAuthcode failed (non-fatal)",
+				zap.String("trace_id", newTraceID()), zap.Error(e))
+		}
+	}
+	o.writeAudit(resp.UID, EventBindCreated, stateFromCtx(c), "")
+	c.JSON(http.StatusOK, map[string]interface{}{
+		"status":     "ok",
+		"login_resp": resp.IssueResp.LoginRespJSON,
+		"uid":        resp.UID,
+	})
+}
+
+// handleBindCreateErr /bind/create 路径的错误码翻译。
+// 所有分支都写 EventBindCreateFail 审计。
+func (o *OIDC) handleBindCreateErr(c *wkhttp.Context, token string, err error) {
+	tokenHash := subHash(token)
+	switch {
+	case errors.Is(err, ErrBindNotFound):
+		o.writeAudit("bind:"+tokenHash, EventBindCreateFail, stateFromCtx(c), "token expired or not found")
+		c.AbortWithStatusJSON(http.StatusGone, errMsg("token expired or not found"))
+	case errors.Is(err, ErrBindRateLimited):
+		o.writeAudit("bind:"+tokenHash, EventBindCreateFail, stateFromCtx(c), "rate limited")
+		c.AbortWithStatusJSON(http.StatusTooManyRequests, errMsg("too many create attempts"))
+	case errors.Is(err, ErrBindStatusConflict):
+		o.writeAudit("bind:"+tokenHash, EventBindCreateFail, stateFromCtx(c), "status conflict")
+		c.AbortWithStatusJSON(http.StatusConflict, errMsg("token status conflict"))
+	case errors.Is(err, ErrBindAlreadyBound):
+		// Identity 行已存在(并发 /bind/create 同 (issuer,sub) 触发了竞态)。
+		// 赢家已签发会话;此处只引导客户端重发起 OIDC 登录以拾取赢家会话。
+		// Ghost user 清理(输家创建的 dmwork user)不在本 PR 范围,见 plan §4/§15。
+		o.writeAudit("bind:"+tokenHash, EventBindCreateFail, stateFromCtx(c), "already bound")
+		c.AbortWithStatusJSON(http.StatusConflict,
+			errMsg("identity already bound; sign in via OIDC to continue"))
+	case errors.Is(err, ErrBindCreateClaimsIncomplete):
+		o.writeAudit("bind:"+tokenHash, EventBindCreateFail, stateFromCtx(c), "claims incomplete")
+		c.AbortWithStatusJSON(http.StatusUnprocessableEntity, errMsg("claims missing required fields"))
+	default:
+		o.Error("OIDC bind create failed (internal)",
+			zap.String("token_hash", tokenHash), zap.Error(err))
+		o.writeAudit("bind:"+tokenHash, EventBindCreateFail, stateFromCtx(c), auditReason(err.Error()))
+		c.AbortWithStatusJSON(http.StatusInternalServerError, errMsg("internal error"))
 	}
 }
 

--- a/modules/oidc/api_bind.go
+++ b/modules/oidc/api_bind.go
@@ -439,6 +439,8 @@ func bindResultFromErr(err error) string {
 		return "unauthorized"
 	case errors.Is(err, ErrBindCreateClaimsIncomplete):
 		return "claims_incomplete"
+	case errors.Is(err, ErrBindCreateConflictNeedManual):
+		return "conflict_need_manual"
 	default:
 		// 未分类 = 内部异常。dashboard 上看到 internal_error 持续升高就是
 		// 该报警的信号(DB/Redis/底层 SMSService 故障),与 401 不再混淆。
@@ -520,6 +522,12 @@ func (o *OIDC) handleBindCreateErr(c *wkhttp.Context, token string, err error) {
 	case errors.Is(err, ErrBindCreateClaimsIncomplete):
 		o.writeAudit("bind:"+tokenHash, EventBindCreateFail, stateFromCtx(c), "claims incomplete")
 		c.AbortWithStatusJSON(http.StatusUnprocessableEntity, errMsg("claims missing required fields"))
+	case errors.Is(err, ErrBindCreateConflictNeedManual):
+		// manual-conflict token:claims 命中多条 dmwork 账号,/bind/create
+		// 不允许重复建号,引导走 Admin 人工合并兜底(与 verify 多匹配同语义)。
+		o.writeAudit("bind:"+tokenHash, EventBindCreateFail, stateFromCtx(c), "conflict need manual")
+		c.AbortWithStatusJSON(http.StatusConflict,
+			errMsg("account conflict needs manual resolution"))
 	default:
 		o.Error("OIDC bind create failed (internal)",
 			zap.String("token_hash", tokenHash), zap.Error(err))

--- a/modules/oidc/api_bind_test.go
+++ b/modules/oidc/api_bind_test.go
@@ -112,6 +112,9 @@ func defaultBindCfg() BindConfig {
 		Methods:        []BindMethod{BindMethodPassword, BindMethodSMSOTP},
 		SupportContact: "ops@example.com",
 		AllowCreate:    true,
+		// 默认放行 sampleClaims().Issuer,让 Create 路径 D. issuerAllowedForCreate
+		// 兜底校验默认放行(api_bind_test 多个用例依赖 Create 成功)。
+		IssuerAllowlist: []string{"https://idp.example"},
 	}
 }
 

--- a/modules/oidc/api_bind_test.go
+++ b/modules/oidc/api_bind_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -96,6 +97,7 @@ func newTestBindRouter(o *OIDC) *gin.Engine {
 	g.POST("/bind/verify/otp/send", func(c *gin.Context) { o.bindOTPSend(wrapWk(c)) })
 	g.POST("/bind/verify/otp/check", func(c *gin.Context) { o.bindOTPCheck(wrapWk(c)) })
 	g.POST("/bind/confirm", func(c *gin.Context) { o.bindConfirm(wrapWk(c)) })
+	g.POST("/bind/create", func(c *gin.Context) { o.bindCreate(wrapWk(c)) })
 	return r
 }
 
@@ -109,6 +111,7 @@ func defaultBindCfg() BindConfig {
 		UIDFailPerDay:  10,
 		Methods:        []BindMethod{BindMethodPassword, BindMethodSMSOTP},
 		SupportContact: "ops@example.com",
+		AllowCreate:    true,
 	}
 }
 
@@ -281,14 +284,25 @@ func TestAPI_BindRoutes_DisabledNotMounted(t *testing.T) {
 		t.Fatalf("Bind.Enabled=false must mount 0 routes, got %d (%+v)", got, rgOff.routes)
 	}
 
-	cfgOn := defaultBindCfg()
+	cfgOn := defaultBindCfg() // AllowCreate=true by default
 	oOn, _, _, _, _ := newTestOIDCWithBind(t, cfgOn, nil, true)
 	rgOn := newTestRouteGroup()
 	oOn.bindRoutes(rgOn)
-	// PR4 加了 /bind/confirm,共 5 个端点
-	if got := len(rgOn.routes); got != 5 {
-		t.Fatalf("Bind.Enabled=true must mount 5 routes (info + 3 verify + confirm), got %d (%+v)",
+	// 5 base endpoints + /bind/create when AllowCreate=true = 6
+	if got := len(rgOn.routes); got != 6 {
+		t.Fatalf("Bind.Enabled=true + AllowCreate=true must mount 6 routes, got %d (%+v)",
 			got, rgOn.routes)
+	}
+
+	// AllowCreate=false: /bind/create must not be mounted (5 routes)
+	cfgNoCreate := defaultBindCfg()
+	cfgNoCreate.AllowCreate = false
+	oNoCreate, _, _, _, _ := newTestOIDCWithBind(t, cfgNoCreate, nil, true)
+	rgNoCreate := newTestRouteGroup()
+	oNoCreate.bindRoutes(rgNoCreate)
+	if got := len(rgNoCreate.routes); got != 5 {
+		t.Fatalf("Bind.Enabled=true + AllowCreate=false must mount 5 routes, got %d (%+v)",
+			got, rgNoCreate.routes)
 	}
 }
 
@@ -511,9 +525,9 @@ func (g *testRouteGroup) POST(path string, _ ...wkhttp.HandlerFunc) {
 // 痕迹,SOC 反查丢半条时间序列。
 func TestAPI_BindConfirm_4xxBranchesAlsoAudit(t *testing.T) {
 	for _, tc := range []struct {
-		name       string
+		name        string
 		statusSetup func(*BindService, string) // 把 session 推到目标状态
-		wantStatus int
+		wantStatus  int
 	}{
 		{
 			"status_conflict (不 verify 直接 confirm) -> 401",
@@ -669,6 +683,322 @@ func TestAPI_RedirectToBindPage_EmptyBaseWritesAuthcodeZero(t *testing.T) {
 
 	if got := fakeAC.get("ac-empty-base"); got != "0" {
 		t.Fatalf("RedirectBase 为空必须先写 ThirdAuthcode \"0\",got %q", got)
+	}
+}
+
+// ---- /bind/create handler tests ----
+
+// T30: happy path → 200 + LoginRespJSON + ThirdAuthcode 回填
+func TestAPI_BindCreate_HappyPath(t *testing.T) {
+	o, jti, _, _, _, _, users, ac := newTestOIDCWithBindFull(t, defaultBindCfg(), sampleClaims(), false)
+	users.resp = &IssueSessionResp{UID: "u-created", LoginRespJSON: `{"token":"t-created"}`}
+	r := newTestBindRouter(o)
+
+	body, _ := json.Marshal(map[string]string{"token": jti})
+	req := httptest.NewRequest("POST", "/v1/auth/oidc/aegis/bind/create", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("T30: status=%d body=%s", w.Code, w.Body.String())
+	}
+	if !contains(w.Body.String(), `"uid":"u-created"`) {
+		t.Fatalf("T30: body missing uid: %s", w.Body.String())
+	}
+	// ThirdAuthcode backfilled (sampleSD.ClientAuthcode = "ac-1")
+	if got := ac.get("ac-1"); got != `{"token":"t-created"}` {
+		t.Fatalf("T30: ThirdAuthcode not backfilled, got %q", got)
+	}
+}
+
+// T31: token 缺失/非法 → 400
+func TestAPI_BindCreate_MissingToken(t *testing.T) {
+	o, _, _, _, _, _, _, _ := newTestOIDCWithBindFull(t, defaultBindCfg(), nil, true)
+	r := newTestBindRouter(o)
+
+	for _, body := range []string{`{}`, `{"token":""}`} {
+		req := httptest.NewRequest("POST", "/v1/auth/oidc/aegis/bind/create",
+			bytes.NewReader([]byte(body)))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("T31: body=%s status=%d want 400", body, w.Code)
+		}
+	}
+}
+
+// T32: AllowCreate=false → 路由不挂（404 by router）
+func TestAPI_BindCreate_AllowCreateFalse_NotMounted(t *testing.T) {
+	cfg := defaultBindCfg()
+	cfg.AllowCreate = false
+	o, _, _, _, _ := newTestOIDCWithBind(t, cfg, nil, true)
+	rg := newTestRouteGroup()
+	o.bindRoutes(rg)
+	for _, route := range rg.routes {
+		if route == "POST /bind/create" {
+			t.Fatalf("T32: /bind/create must NOT be mounted when AllowCreate=false, routes=%v", rg.routes)
+		}
+	}
+}
+
+// T33: ErrBindCreateClaimsIncomplete → 422
+func TestAPI_BindCreate_ClaimsIncomplete(t *testing.T) {
+	cfg := defaultBindCfg()
+	c := sampleClaims()
+	c.Email = ""
+	c.EmailVerified = false
+	c.PhoneNumber = ""
+	c.PhoneVerified = false
+	o, jti, _, _, _, _, _, _ := newTestOIDCWithBindFull(t, cfg, c, false)
+	r := newTestBindRouter(o)
+
+	body, _ := json.Marshal(map[string]string{"token": jti})
+	req := httptest.NewRequest("POST", "/v1/auth/oidc/aegis/bind/create", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("T33: ErrBindCreateClaimsIncomplete must be 422, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// T34: ErrBindStatusConflict → 409
+func TestAPI_BindCreate_StatusConflict(t *testing.T) {
+	o, jti, auth, loc, _, _, _, _ := newTestOIDCWithBindFull(t, defaultBindCfg(), sampleClaims(), false)
+	// push to verified
+	auth.verifyPasswordResp.matched = true
+	loc.byUsername["alice"] = "u-alice"
+	svc := o.bind
+	_ = svc.VerifyPassword(context.Background(), jti, "alice", "p")
+	r := newTestBindRouter(o)
+
+	body, _ := json.Marshal(map[string]string{"token": jti})
+	req := httptest.NewRequest("POST", "/v1/auth/oidc/aegis/bind/create", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("T34: ErrBindStatusConflict must be 409, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// T35: ErrBindRateLimited → 429 (bindCreateMax = 1, 第二次请求即限流)
+func TestAPI_BindCreate_RateLimited(t *testing.T) {
+	cfg := defaultBindCfg()
+	o, jti, _, _, _, _, users, _ := newTestOIDCWithBindFull(t, cfg, sampleClaims(), false)
+	users.err = errors.New("transient") // first call fails so token survives
+	r := newTestBindRouter(o)
+
+	body, _ := json.Marshal(map[string]string{"token": jti})
+	// first call (count=1 <= 1, not rate limited yet, but IssueSession fails)
+	req := httptest.NewRequest("POST", "/v1/auth/oidc/aegis/bind/create", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code == http.StatusOK {
+		t.Fatal("first call should fail")
+	}
+	// second call: rate limited
+	req2 := httptest.NewRequest("POST", "/v1/auth/oidc/aegis/bind/create",
+		bytes.NewReader(body))
+	req2.Header.Set("Content-Type", "application/json")
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusTooManyRequests {
+		t.Fatalf("T35: ErrBindRateLimited must be 429, got %d body=%s", w2.Code, w2.Body.String())
+	}
+}
+
+// T36: ErrBindNotFound → 410
+func TestAPI_BindCreate_TokenNotFound(t *testing.T) {
+	o, _, _, _, _, _, _, _ := newTestOIDCWithBindFull(t, defaultBindCfg(), nil, true)
+	r := newTestBindRouter(o)
+
+	// valid format but non-existent token (43 base64 chars)
+	body, _ := json.Marshal(map[string]string{"token": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"})
+	req := httptest.NewRequest("POST", "/v1/auth/oidc/aegis/bind/create", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusGone {
+		t.Fatalf("T36: ErrBindNotFound must be 410, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// T37: internal error → 500
+func TestAPI_BindCreate_InternalError(t *testing.T) {
+	o, jti, _, _, _, _, users, _ := newTestOIDCWithBindFull(t, defaultBindCfg(), sampleClaims(), false)
+	users.err = errors.New("db timeout")
+	r := newTestBindRouter(o)
+
+	body, _ := json.Marshal(map[string]string{"token": jti})
+	req := httptest.NewRequest("POST", "/v1/auth/oidc/aegis/bind/create", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("T37: internal error must be 500, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// T38: 成功路径写 EventBindCreated；失败路径写 EventBindCreateFail
+func TestAPI_BindCreate_AuditEvents(t *testing.T) {
+	t.Run("success emits EventBindCreated", func(t *testing.T) {
+		o, jti, _, _, _, _, users, _ := newTestOIDCWithBindFull(t, defaultBindCfg(), sampleClaims(), false)
+		users.resp = &IssueSessionResp{UID: "u-c", LoginRespJSON: `{}`}
+		audit := o.audit.(*fakeAudit)
+		r := newTestBindRouter(o)
+
+		body, _ := json.Marshal(map[string]string{"token": jti})
+		req := httptest.NewRequest("POST", "/v1/auth/oidc/aegis/bind/create", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(httptest.NewRecorder(), req)
+
+		var found bool
+		for _, e := range audit.events() {
+			if e == EventBindCreated {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("success must emit EventBindCreated, got %v", audit.events())
+		}
+	})
+
+	t.Run("failure emits EventBindCreateFail", func(t *testing.T) {
+		o, jti, _, _, _, _, users, _ := newTestOIDCWithBindFull(t, defaultBindCfg(), sampleClaims(), false)
+		users.err = errors.New("down")
+		audit := o.audit.(*fakeAudit)
+		r := newTestBindRouter(o)
+
+		body, _ := json.Marshal(map[string]string{"token": jti})
+		req := httptest.NewRequest("POST", "/v1/auth/oidc/aegis/bind/create", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(httptest.NewRecorder(), req)
+
+		var found bool
+		for _, e := range audit.events() {
+			if e == EventBindCreateFail {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("failure must emit EventBindCreateFail, got %v", audit.events())
+		}
+	})
+}
+
+// T39: metric label endpoint=create + result 与 HTTP status 对齐
+// (tested indirectly via the metric vectors; we verify no panic and correct status codes)
+// This is covered by T30-T37 above.
+
+// T40: o.bind=nil → 503
+func TestAPI_BindCreate_NilBind_503(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	o := &OIDC{
+		Log:      log.NewTLog("OIDC-test"),
+		cfg:      &Config{Enabled: true, Bind: BindConfig{Enabled: true, AllowCreate: true}},
+		bind:     nil,
+		audit:    newFakeAudit(),
+		authcode: newFakeAuthcode(),
+	}
+	r := gin.New()
+	r.POST("/bind/create", func(c *gin.Context) { o.bindCreate(wrapWk(c)) })
+
+	body, _ := json.Marshal(map[string]string{"token": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"})
+	req := httptest.NewRequest("POST", "/bind/create", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("T40: nil bind must return 503, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// ---- Info extension tests (T41-T43) ----
+
+// T41: AllowCreate=true + claims 满足要求 → allow_create=true, create_blocked=""
+func TestAPI_BindInfo_AllowCreate_ClaimsSatisfied(t *testing.T) {
+	cfg := defaultBindCfg()
+	cfg.AllowCreate = true
+	o, jti, _, _, _ := newTestOIDCWithBind(t, cfg, sampleClaims(), false)
+	r := newTestBindRouter(o)
+
+	req := httptest.NewRequest("GET", "/v1/auth/oidc/aegis/bind/info?token="+jti, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("T41: status=%d body=%s", w.Code, w.Body.String())
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("T41: unmarshal: %v", err)
+	}
+	if body["allow_create"] != true {
+		t.Fatalf("T41: allow_create must be true, got %v", body["allow_create"])
+	}
+	if v, ok := body["create_blocked"]; ok && v != "" {
+		t.Fatalf("T41: create_blocked must be empty string, got %v", v)
+	}
+}
+
+// T42: AllowCreate=true + claims 不满足 → allow_create=true, create_blocked="claims_incomplete"
+func TestAPI_BindInfo_AllowCreate_ClaimsInsufficient(t *testing.T) {
+	cfg := defaultBindCfg()
+	cfg.AllowCreate = true
+	c := sampleClaims()
+	c.Email = ""
+	c.EmailVerified = false
+	c.PhoneNumber = ""
+	c.PhoneVerified = false
+	o, jti, _, _, _ := newTestOIDCWithBind(t, cfg, c, false)
+	r := newTestBindRouter(o)
+
+	req := httptest.NewRequest("GET", "/v1/auth/oidc/aegis/bind/info?token="+jti, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("T42: status=%d body=%s", w.Code, w.Body.String())
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("T42: unmarshal: %v", err)
+	}
+	if body["allow_create"] != true {
+		t.Fatalf("T42: allow_create must be true, got %v", body["allow_create"])
+	}
+	if body["create_blocked"] != "claims_incomplete" {
+		t.Fatalf("T42: create_blocked must be claims_incomplete, got %v", body["create_blocked"])
+	}
+}
+
+// T43: AllowCreate=false → allow_create=false, create_blocked="disabled"
+func TestAPI_BindInfo_AllowCreateFalse(t *testing.T) {
+	cfg := defaultBindCfg()
+	cfg.AllowCreate = false
+	o, jti, _, _, _ := newTestOIDCWithBind(t, cfg, sampleClaims(), false)
+	r := newTestBindRouter(o)
+
+	req := httptest.NewRequest("GET", "/v1/auth/oidc/aegis/bind/info?token="+jti, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("T43: status=%d body=%s", w.Code, w.Body.String())
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("T43: unmarshal: %v", err)
+	}
+	if body["allow_create"] != false {
+		t.Fatalf("T43: allow_create must be false, got %v", body["allow_create"])
+	}
+	if body["create_blocked"] != "disabled" {
+		t.Fatalf("T43: create_blocked must be disabled, got %v", body["create_blocked"])
 	}
 }
 

--- a/modules/oidc/bind_config.go
+++ b/modules/oidc/bind_config.go
@@ -82,7 +82,7 @@ func validateBindRedirectBase(base string) error {
 // BindConfig 自助绑定相关配置(NFR-4 全部走 env,不硬编码)。
 //
 // **Enabled=false 时其余字段无效**:LoadConfig 不校验任何依赖关系,
-// PR3 仅起骨架作用,callback 接管在 PR4 才打开。PR4 会加 "Enabled && RedirectBase==''"
+// PR3 仅起骨架作用,callback 接管在 PR4 才打开。PR4 会加 "Enabled && RedirectBase==”"
 // 这类硬校验。
 //
 // keyspace 命名:OCTO_OIDC_BIND_* 与已有 DM_OIDC_* 并列,语义上 BindConfig
@@ -98,17 +98,26 @@ type BindConfig struct {
 	Methods         []BindMethod
 	SupportContact  string
 	RedirectBase    string
+	AllowCreate     bool
 }
 
 // 默认值集中定义,与 bind_config_test.go 的 TestLoadConfig_BindDefaults
 // 保持单一事实源 —— 改阈值时只需动一处。
 const (
-	defaultBindTokenTTL       = 5 * time.Minute
-	defaultBindVerifyMax      = 5  // SR-2.1
-	defaultBindOTPSendMax     = 3  // SR-2.1
-	defaultBindConfirmMax     = 3  // SR-2.1
-	defaultBindUIDFailPerDay  = 10 // SR-2.2
+	defaultBindTokenTTL      = 5 * time.Minute
+	defaultBindVerifyMax     = 5  // SR-2.1
+	defaultBindOTPSendMax    = 3  // SR-2.1
+	defaultBindConfirmMax    = 3  // SR-2.1
+	defaultBindUIDFailPerDay = 10 // SR-2.2
 )
+
+// bindCreateMax is fixed at 1 per bind_token: /bind/create is a terminal
+// one-shot operation; failure modes (claims incomplete, status conflict,
+// already bound) are deterministic and retrying cannot make them succeed.
+// Transient errors leave token state ambiguous and must not be retried
+// blindly. Operators who want stricter gating should disable AllowCreate
+// entirely and rely on /bind/verify/*.
+const bindCreateMax int64 = 1
 
 // defaultBindMethods 不导出但被 LoadConfig 与 fallback 路径共享,
 // 避免在两处 hardcode 顺序不一致(测试断言依赖顺序)。
@@ -126,6 +135,7 @@ func loadBindConfig() BindConfig {
 		Methods:         loadBindMethods(),
 		SupportContact:  getString("OCTO_OIDC_BIND_SUPPORT_CONTACT", ""),
 		RedirectBase:    getString("OCTO_OIDC_BIND_REDIRECT_BASE", ""),
+		AllowCreate:     getBool("OCTO_OIDC_BIND_ALLOW_CREATE", true),
 	}
 }
 

--- a/modules/oidc/bind_config_test.go
+++ b/modules/oidc/bind_config_test.go
@@ -237,8 +237,40 @@ func clearOIDCBindEnv(t *testing.T) {
 		"OCTO_OIDC_BIND_METHODS",
 		"OCTO_OIDC_BIND_SUPPORT_CONTACT",
 		"OCTO_OIDC_BIND_REDIRECT_BASE",
+		"OCTO_OIDC_BIND_ALLOW_CREATE",
 	}
 	for _, k := range keys {
 		t.Setenv(k, "")
+	}
+}
+
+// T1: 默认 AllowCreate=true
+func TestLoadConfig_BindCreate_Defaults(t *testing.T) {
+	clearOIDCBindEnv(t)
+	clearOIDCEnv(t)
+	mustSetMinimalOIDCEnv(t)
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !cfg.Bind.AllowCreate {
+		t.Fatal("AllowCreate default must be true (D1)")
+	}
+}
+
+// T2: 显式关 AllowCreate
+func TestLoadConfig_BindCreate_Disabled(t *testing.T) {
+	clearOIDCBindEnv(t)
+	clearOIDCEnv(t)
+	mustSetMinimalOIDCEnv(t)
+	t.Setenv("OCTO_OIDC_BIND_ALLOW_CREATE", "false")
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Bind.AllowCreate {
+		t.Fatal("AllowCreate must be false when env=false")
 	}
 }

--- a/modules/oidc/bind_config_validate_test.go
+++ b/modules/oidc/bind_config_validate_test.go
@@ -98,4 +98,45 @@ func TestValidateBindConfigAgainstProvider(t *testing.T) {
 			t.Fatalf("error %q must mention OCTO_OIDC_BIND_METHODS", err.Error())
 		}
 	})
+
+	// T5: Bind.Enabled=true + AllowCreate=true + AllowNewUser=true → must fail
+	// 同时开 AllowCreate 和 AllowNewUser 等价于"autolink 失败后直接建号",
+	// bind 流程的建号路径(create)与 callback 自动建号路径同时存在,运维会误
+	// 以为 create 被 bind 护栏保护但实际已经被 AllowNewUser 旁路。
+	t.Run("T5: AllowCreate=true + AllowNewUser=true — must panic/fail", func(t *testing.T) {
+		cfg := &Config{
+			Enabled:  true,
+			Provider: ProviderConfig{AllowNewUser: true},
+			Bind: BindConfig{
+				Enabled:      true,
+				AllowCreate:  true,
+				RedirectBase: validBase,
+				Methods:      []BindMethod{BindMethodPassword, BindMethodSMSOTP},
+			},
+		}
+		err := validateBindConfigAgainstProvider(cfg)
+		if err == nil {
+			t.Fatal("T5: AllowCreate=true + AllowNewUser=true must be rejected at startup")
+		}
+		if !strings.Contains(err.Error(), "AllowNewUser") {
+			t.Fatalf("T5: error %q must mention AllowNewUser", err.Error())
+		}
+	})
+
+	// T6: AllowCreate=true + AllowNewUser=false → pass
+	t.Run("T6: AllowCreate=true + AllowNewUser=false — passes", func(t *testing.T) {
+		cfg := &Config{
+			Enabled:  true,
+			Provider: ProviderConfig{AllowNewUser: false},
+			Bind: BindConfig{
+				Enabled:      true,
+				AllowCreate:  true,
+				RedirectBase: validBase,
+				Methods:      []BindMethod{BindMethodPassword, BindMethodSMSOTP},
+			},
+		}
+		if err := validateBindConfigAgainstProvider(cfg); err != nil {
+			t.Fatalf("T6: valid AllowCreate config must pass validation, got: %v", err)
+		}
+	})
 }

--- a/modules/oidc/bind_model.go
+++ b/modules/oidc/bind_model.go
@@ -47,6 +47,7 @@ const (
 	BindStatusVerified  BindStatus = "verified"
 	BindStatusConfirmed BindStatus = "confirmed"
 	BindStatusRefused   BindStatus = "refused"
+	BindStatusCreated   BindStatus = "created"
 )
 
 // BindSession bind_token 在 Redis 里的完整快照。
@@ -54,12 +55,12 @@ const (
 // 字段说明:
 //   - JTI:            bind_token 自身,32 字节 base64,Redis key 后缀(SR-7)
 //   - Issuer/Subject: OIDC claims 原值,confirm 时直接写 user_oidc_identity
-//                     —— 用户在 5min TTL 内可能换 IdP session,这里固化避免漂移
+//     —— 用户在 5min TTL 内可能换 IdP session,这里固化避免漂移
 //   - CandidateUID:   email/phone 多匹配场景下用户选定的 uid(M1 暂不支持选择,
-//                     字段预留)。当前实现下用户走密码路径需先输入 username/uid 定位
+//     字段预留)。当前实现下用户走密码路径需先输入 username/uid 定位
 //   - ClaimsSnapshot: 完整 IDTokenClaims JSON,confirm 时透传给 IssueSession
 //   - SDSnapshot:     原 StateData JSON 关键字段(authcode/return_to/device_flag),
-//                     confirm 后回填到原发起设备的 ThirdAuthcode(FR-6.3)
+//     confirm 后回填到原发起设备的 ThirdAuthcode(FR-6.3)
 //   - Status:         状态机字段(见 BindStatus)
 //   - VerifiedMethod: 记录哪种手段通过的(audit 维度)
 //   - OriginIP/UA:    审计 + FR-6.2 设备差异提示

--- a/modules/oidc/bind_model.go
+++ b/modules/oidc/bind_model.go
@@ -62,6 +62,25 @@ const (
 	BindStatusCreating BindStatus = "creating"
 )
 
+// IssueReason 描述 bind_token 是从哪种 callback 失败分支签发出来的。
+// Create 路径依赖此字段决定是否允许走"自助建号":多账号脏数据(manual_conflict)
+// 来源的 token 不应当被允许凭 claims 建号 —— 用户在 dmwork 已经有(多个)账号,
+// 走 /bind/create 会再造出新账号加剧数据混乱;只能走 P1 Admin 人工合并。
+//
+// 字段在 BindSession 中持久化,Info 路径用来回填 create_blocked,Create 路径
+// 用来拒绝建号。两个 Issue 入口(callback 的 ResolveOrLink 失败分支)按
+// err 类型显式置位,避免 oidc 模块的状态隐式扩散。
+type IssueReason string
+
+const (
+	// BindReasonUnknownUser claims 未命中已有 dmwork 账号(AllowNewUser=false
+	// 或 autolink 未命中)。这是"可以走 /bind/create 自助建号"的合法来源。
+	BindReasonUnknownUser IssueReason = "unknown_user"
+	// BindReasonManualConflict claims email/phone 命中**多条** dmwork 账号(脏数据)。
+	// 不允许走 /bind/create:重复建号会加剧数据混乱;只能走 Admin 人工合并(P1)。
+	BindReasonManualConflict IssueReason = "manual_conflict"
+)
+
 // BindSession bind_token 在 Redis 里的完整快照。
 //
 // 字段说明:
@@ -91,4 +110,9 @@ type BindSession struct {
 	OriginIP       string     `json:"origin_ip,omitempty"`
 	OriginUA       string     `json:"origin_ua,omitempty"`
 	CreatedAt      int64      `json:"created_at"`
+	// IssueReason 见 IssueReason godoc。Create 路径在 manual_conflict 时拒绝;
+	// Info 路径用它回填 create_blocked 让前端展示对应的引导文案。
+	// 旧 token(本字段引入前签发的)会落空字符串,Create 视同 unknown_user 放行,
+	// 保持 5min TTL 窗口内的灰度兼容。
+	IssueReason IssueReason `json:"issue_reason,omitempty"`
 }

--- a/modules/oidc/bind_model.go
+++ b/modules/oidc/bind_model.go
@@ -32,14 +32,23 @@ var validBindMethods = map[BindMethod]struct{}{
 //
 // 合法迁移路径:
 //
-//	issued ─── verify ok ───▶ verified ─── confirm ok ───▶ confirmed
+//	issued ─── verify ok ───▶ verified ─── confirm ok ───▶ Consume(token 消失)
 //	  │                          │
 //	  │                          └── confirm fail ──▶ verified (允许重试,直到 ConfirmMax)
 //	  │
+//	  ├── create CAS lock ───▶ creating ─── IssueSession+Insert+Consume ──▶ (token 消失)
+//	  │                          │
+//	  │                          └── 中途失败 ──▶ creating (stuck,TTL 自然清理)
+//	  │
 //	  └── 超限/手动放弃 ──▶ refused
 //
-// CAS 由 BindStore.UpdateStatus 保证。confirmed/refused 是终态,任何指向终态
-// 之外的 UpdateStatus 都应当返 ErrBindStatusConflict。
+// CAS 由 BindStore.CASSave 保证。creating/refused 是中间或终止状态,任何对它们
+// 的进一步推进都返 ErrBindStatusConflict。confirmed/created 不入 Redis ——
+// 成功路径由 Consume 把 session 整条删除,后续 Get 拿到 ErrBindNotFound。
+//
+// creating 引入的目的:把"建号副作用"(IssueSession 落库 + identity.Insert)
+// 包在 CAS 锁后面,防止并发 verify/create 把已经在写真实用户的 token 推到其他
+// 状态后再 saveCreated 撞 conflict —— 那种顺序会留下"ghost user"。
 type BindStatus string
 
 const (
@@ -47,7 +56,10 @@ const (
 	BindStatusVerified  BindStatus = "verified"
 	BindStatusConfirmed BindStatus = "confirmed"
 	BindStatusRefused   BindStatus = "refused"
-	BindStatusCreated   BindStatus = "created"
+	// BindStatusCreating 介于 issued 与 Consume 之间的中间锁:CAS issued→creating
+	// 成功后才允许进入 IssueSession / identity.Insert 等副作用阶段。失败留 creating,
+	// 由 5min TTL 自然清理(用户需重走 OIDC 登录获取新 bind_token)。
+	BindStatusCreating BindStatus = "creating"
 )
 
 // BindSession bind_token 在 Redis 里的完整快照。

--- a/modules/oidc/bind_service.go
+++ b/modules/oidc/bind_service.go
@@ -77,9 +77,22 @@ func newBindService(cfg BindConfig, store BindStore, auth BindAuthenticator, loc
 // Issue 在 callback ResolveOrLink 失败分支调用:签发 bind_token,持久化
 // claims + state_data 快照,返回 jti 供 handler 拼前端跳转 URL。
 //
+// 等价于 IssueWithReason(ctx, claims, sd, BindReasonUnknownUser) —— 历史调用方
+// (单元测试 + ShouldHandle 早期路径)在没有明确区分原因时保留旧签名,语义即
+// "claims 未命中已有账号"(可走 /bind/create)。生产 callback 路径应该走
+// IssueWithReason 明确传 reason,与 manual_conflict 拒建号路径协同。
+//
 // 不在此处写 audit —— handler 在拿到 jti 后统一写 EventBindIssued
 // (handler 持 HTTP 上下文,IP/UA/trace_id 都齐)。
 func (s *BindService) Issue(ctx context.Context, claims *IDTokenClaims, sd *StateData) (string, error) {
+	return s.IssueWithReason(ctx, claims, sd, BindReasonUnknownUser)
+}
+
+// IssueWithReason 同 Issue,但额外把 reason 固化到 BindSession.IssueReason 字段。
+// callback 按 ResolveOrLink 返回的 err 类型选择 reason:ErrUnknownUser →
+// BindReasonUnknownUser(可建号);ErrConflictNeedManual → BindReasonManualConflict
+// (Create 路径拒绝)。详见 IssueReason godoc。
+func (s *BindService) IssueWithReason(ctx context.Context, claims *IDTokenClaims, sd *StateData, reason IssueReason) (string, error) {
 	if claims == nil || claims.Issuer == "" || claims.Subject == "" {
 		return "", fmt.Errorf("oidc bind Issue: claims iss/sub required")
 	}
@@ -108,6 +121,7 @@ func (s *BindService) Issue(ctx context.Context, claims *IDTokenClaims, sd *Stat
 		OriginIP:       sd.IP,
 		OriginUA:       sd.UserAgent,
 		CreatedAt:      nowUnix(),
+		IssueReason:    reason,
 	}
 	if err := s.store.Save(ctx, sess, s.cfg.TokenTTL); err != nil {
 		return "", fmt.Errorf("oidc bind Issue: save: %w", err)
@@ -134,10 +148,23 @@ func (s *BindService) Info(ctx context.Context, jti string) (*BindInfoResp, erro
 	}
 	resp.Methods = s.availableMethods(claims)
 	resp.AllowCreate = s.cfg.AllowCreate
-	if !s.cfg.AllowCreate {
+	// 优先级 disabled > claims_incomplete > manual_conflict > consumed。
+	// disabled 是配置层面的"运维关闭",最高优先;claims_incomplete 是
+	// claims 自身欠缺,继续往下走也注定建不出;manual_conflict 是 token 来源
+	// 的策略拒绝(reviewer 强调 P2-1);consumed 是 token 已被推进出 issued
+	// 状态(verify/create 已发生),前端最多展示"重发起 OIDC 登录"提示。
+	switch {
+	case !s.cfg.AllowCreate:
 		resp.CreateBlocked = "disabled"
-	} else if err := s.checkClaimsForCreate(claims); err != nil {
+	case s.checkClaimsForCreate(claims) != nil:
 		resp.CreateBlocked = "claims_incomplete"
+	case sess.IssueReason == BindReasonManualConflict:
+		resp.CreateBlocked = "manual_conflict"
+	case sess.Status != BindStatusIssued:
+		// token 已被推进(verified / creating / refused) —— 二次 /bind/info 仍可读,
+		// 但 /bind/create 已经不可能走通(状态机 CAS 必败)。提前告诉前端别让用户
+		// 误点"自助建号"按钮反复 429。
+		resp.CreateBlocked = "consumed"
 	}
 	return resp, nil
 }
@@ -494,12 +521,26 @@ func (s *BindService) Create(ctx context.Context, jti string) (*BindCreateResp, 
 		"bind:create:"+jti, bindCreateMax, s.cfg.TokenTTL); err != nil {
 		return nil, err
 	}
+	// manual_conflict 来源的 token 不允许走自助建号:用户在 dmwork 已经有(多条)
+	// 账号,/bind/create 会再造账号加剧脏数据 —— 走 P1 Admin 人工合并兜底。
+	// 空字符串视同 unknown_user(灰度兼容旧 token),与 IssueReason godoc 一致。
+	if sess.IssueReason == BindReasonManualConflict {
+		return nil, ErrBindCreateConflictNeedManual
+	}
 	claims, err := decodeClaimsSnapshot(sess.ClaimsSnapshot)
 	if err != nil {
 		return nil, err
 	}
 	if err := s.checkClaimsForCreate(claims); err != nil {
 		return nil, err
+	}
+	// D. IssuerAllowlist 防御性复核:ShouldHandle 在 callback 阶段已挡过一遍,
+	// 这里在 Create 入口再校验一次,防止运维在 token 5min TTL 内把某 issuer
+	// 从 allowlist 移走、但 token 已经签发的窗口里继续被滥用。
+	// 仅在 Create 路径加(与 reviewer 描述一致):verify/confirm 路径的 token
+	// 是用户主动二次验证,IdP 信任由原 callback 时已校验,风险低。
+	if !s.issuerAllowedForCreate(claims.Issuer) {
+		return nil, fmt.Errorf("oidc bind Create: %w (issuer no longer in allowlist)", ErrBindAuthRejected)
 	}
 	sd, err := decodeSDSnapshot(sess.SDSnapshot)
 	if err != nil {
@@ -520,6 +561,11 @@ func (s *BindService) Create(ctx context.Context, jti string) (*BindCreateResp, 
 		Zone:       zone,
 		DeviceFlag: sd.DeviceFlag,
 		PublicIP:   sd.IP,
+		// 进入本方法前已经过 ShouldHandle 的 IssuerAllowlist 校验(callback 阶段),
+		// 加上 bind_token 自身的 5min 单次性 + 上面的 checkClaimsForCreate / issuerAllowed
+		// 兜底,运维要授权的就是这条"OIDC 自助建号"路径 —— 告诉 user 模块绕过
+		// register.off 全局开关,与 callback `res.IsNew` 分支语义对称。
+		TrustedSSOCreate: true,
 	}
 	resp, err := s.users.IssueSession(ctx, issueReq)
 	if err != nil {
@@ -634,6 +680,18 @@ func (s *BindService) casLockForCreate(ctx context.Context, sess *BindSession) e
 func (s *BindService) remainingTTL(sess *BindSession) time.Duration {
 	deadline := time.Unix(sess.CreatedAt, 0).Add(s.cfg.TokenTTL)
 	return time.Until(deadline)
+}
+
+// issuerAllowedForCreate D. defense-in-depth 检查:Create 入口在
+// checkClaimsForCreate 后做最后一道 issuer allowlist 兜底。空 allowlist =
+// deny-all(灰度安全默认值),与 ShouldHandle 同语义。
+func (s *BindService) issuerAllowedForCreate(issuer string) bool {
+	for _, allowed := range s.cfg.IssuerAllowlist {
+		if allowed == issuer {
+			return true
+		}
+	}
+	return false
 }
 
 // ShouldHandle 给 callback 失败分支用的接管判定。任何一条不满足就走旧路径,

--- a/modules/oidc/bind_service.go
+++ b/modules/oidc/bind_service.go
@@ -50,7 +50,11 @@ type BindInfoResp struct {
 	Methods        []BindMethod `json:"methods"`
 	SupportContact string       `json:"support_contact,omitempty"`
 	AllowCreate    bool         `json:"allow_create"`
-	CreateBlocked  string       `json:"create_blocked,omitempty"`
+	// CreateBlocked 始终序列化(无 omitempty):/bind/info 协议约定该字段恒在,
+	// 前端按字符串值分支("" / "disabled" / "claims_incomplete" /
+	// "manual_conflict" / "consumed");omitempty 会让 "" 路径整字段消失,
+	// 等价于前端要给"字段缺失"和"字段为空字符串"两种状态都写分支。
+	CreateBlocked string `json:"create_blocked"`
 }
 
 // BindService 自助绑定状态机的业务逻辑层。

--- a/modules/oidc/bind_service.go
+++ b/modules/oidc/bind_service.go
@@ -461,18 +461,27 @@ type BindCreateResp struct {
 	Issuer    string
 }
 
-// Create 在 status=issued 时直接用 bind_token 里的 claims 建号 + 写 identity + 签发会话。
+// Create 在 status=issued 时用 bind_token 里的 claims 建号 + 写 identity + 签发会话。
 //
-// 步骤(见 plan §4):
+// 顺序很关键(防 ghost user):
 //  1. Get session
-//  2. IncrAndCheck("bind:create:"+jti, bindCreateMax) — counter→status 顺序与 Confirm 对齐
-//  3. 校验 status == issued
-//  4. decode claims snapshot
-//  5. 校验 claims 至少有一条 verified 的 email 或 phone
-//  6. IssueSession({CreateUser:true, ...claims})
-//  7. identity.Insert((uid, issuer, sub))
-//  8. CASSave(issued→created)
-//  9. Consume(token) — 单次消费;失败仅 log
+//  2. IncrAndCheck("bind:create:"+jti, bindCreateMax) — counter→status 与 Confirm 对齐,
+//     任何对 create 的探测都消耗配额
+//  3. decode claims + 校验(纯只读,无副作用,失败保持 token 在 issued 让用户重试)
+//  4. CASSave issued→creating — 唯一的"锁":只有拿到锁的 goroutine 才能进入
+//     产生副作用的 #5/#6/#7。并发 verify/create 都会撞 CAS 失败 → ErrBindStatusConflict,
+//     不会出现"副作用已发生但终态锁不上"的 ghost-user 窗口。
+//  5. IssueSession({CreateUser:true, ...}) — 副作用 #1:dmwork user 入库
+//  6. identity.Insert((uid, issuer, sub)) — 副作用 #2:user_oidc_identity 入库
+//  7. Consume(token) — 终态:token 整条删除,后续 Get 返 ErrBindNotFound
+//
+// 中途失败语义:
+//   - #5/#6 失败:token 卡在 creating,5min TTL 后自然消失。**不会**被同一 token
+//     的二次 create 重复触发(CAS issued→creating 第二次必败)—— 避免重试产生
+//     第二个 ghost user。用户体感:需要重走 OIDC 登录拿新 bind_token。
+//   - #6 撞 uk_issuer_subject(并发不同 token 同 issuer+sub):返 ErrBindAlreadyBound,
+//     handler 引导用户重发起 OIDC 登录拾取赢家会话(与 plan §4 一致)。
+//   - #7 失败:用户已建,会话已发,token 5min TTL 自清,只 log warn。
 func (s *BindService) Create(ctx context.Context, jti string) (*BindCreateResp, error) {
 	if s.identity == nil || s.users == nil {
 		return nil, errors.New("oidc bind Create: not configured (identity/users nil)")
@@ -481,13 +490,9 @@ func (s *BindService) Create(ctx context.Context, jti string) (*BindCreateResp, 
 	if err != nil {
 		return nil, err
 	}
-	// counter→status 顺序(与 Confirm 对齐):任意对 create 的探测都消耗配额
 	if _, err := s.store.IncrAndCheck(ctx,
 		"bind:create:"+jti, bindCreateMax, s.cfg.TokenTTL); err != nil {
 		return nil, err
-	}
-	if sess.Status != BindStatusIssued {
-		return nil, ErrBindStatusConflict
 	}
 	claims, err := decodeClaimsSnapshot(sess.ClaimsSnapshot)
 	if err != nil {
@@ -498,6 +503,12 @@ func (s *BindService) Create(ctx context.Context, jti string) (*BindCreateResp, 
 	}
 	sd, err := decodeSDSnapshot(sess.SDSnapshot)
 	if err != nil {
+		return nil, err
+	}
+	// CAS issued→creating:把后续所有副作用包在锁里。
+	// 失败原因:(a) 别的 goroutine 已推进了 status(verify / 另一个 create),
+	// (b) token TTL 已到。两种都返 ErrBindStatusConflict / ErrBindNotFound,无副作用。
+	if err := s.casLockForCreate(ctx, sess); err != nil {
 		return nil, err
 	}
 	zone, phone := extractZone(claims.PhoneNumber), extractPhone(claims.PhoneNumber)
@@ -530,9 +541,6 @@ func (s *BindService) Create(ctx context.Context, jti string) (*BindCreateResp, 
 		}
 		return nil, fmt.Errorf("oidc bind Create: insert identity: %w", err)
 	}
-	if err := s.saveCreated(ctx, sess); err != nil {
-		return nil, fmt.Errorf("oidc bind Create: save created: %w", err)
-	}
 	if _, cerr := s.store.Consume(ctx, jti); cerr != nil {
 		log.Warn("OIDC bind Create: consume session failed (non-fatal, will TTL out)",
 			zap.String("jti_hash", subHash(jti)), zap.Error(cerr))
@@ -546,11 +554,17 @@ func (s *BindService) Create(ctx context.Context, jti string) (*BindCreateResp, 
 }
 
 // checkClaimsForCreate 校验 claims 至少有一条强标识(email 或 phone)。
-// 与 autolink 的准入条件对齐:email_verified / phone_verified 必须为 true,
-// 否则后续客服 / 找回流程没有可信账号锚点。
+//
+// phone 可用性必须用 extractPhone 判定,不能只看 PhoneNumber != "":
+// dmwork 当前仅支持 +86 号段(service.go:extractPhone),非 +86 verified phone
+// 会被 IssueSession 默默丢成空 Phone/Zone,落库后用户没有可用手机号锚点。
+// 用 extractPhone 做能用性检查,把"格式不支持"提前到 422 而非建出残缺账号。
+//
+// email_verified / phone_verified 必须为 true,否则后续客服 / 找回流程没有可信锚点
+// (与 autolink 准入条件一致)。
 func (s *BindService) checkClaimsForCreate(claims *IDTokenClaims) error {
 	hasEmail := claims.Email != "" && claims.EmailVerified
-	hasPhone := claims.PhoneNumber != "" && claims.PhoneVerified
+	hasPhone := claims.PhoneVerified && extractPhone(claims.PhoneNumber) != ""
 	if !hasEmail && !hasPhone {
 		return ErrBindCreateClaimsIncomplete
 	}
@@ -592,14 +606,24 @@ func (s *BindService) saveVerified(ctx context.Context, sess *BindSession) error
 
 // saveCreated 把 sess.Status 从 issued CAS 到 created,使用绝对剩余 TTL。
 // 对称 saveVerified:CAS expected=issued,防并发 create 竞态。
-func (s *BindService) saveCreated(ctx context.Context, sess *BindSession) error {
+// casLockForCreate 把 issued 锁到 creating —— Create 路径下唯一的状态写入。
+//
+// 不复用 saveVerified 的"写整条 session"是因为 Create 没有 verify/sms 那种业务字段
+// 要落地(CandidateUID/VerifiedMethod),只需推进 status。CAS 用 BindStatusIssued
+// 作为期望值,保证并发 verify(已把 status 推到 verified)或并发 create(已推到
+// creating)都拒绝在此处,不进入下游副作用阶段。
+//
+// TTL 用 remainingTTL 而非完整 cfg.TokenTTL:防止 Create 把 token 续命到 issue 后
+// 的 "TokenTTL × 2",与文档承诺的 5min 不符。remaining<=0 时返 ErrBindNotFound 让
+// 上层按"已过期"处理。
+func (s *BindService) casLockForCreate(ctx context.Context, sess *BindSession) error {
 	remaining := s.remainingTTL(sess)
 	if remaining <= 0 {
 		return ErrBindNotFound
 	}
-	sess.Status = BindStatusCreated
+	sess.Status = BindStatusCreating
 	if err := s.store.CASSave(ctx, sess, BindStatusIssued, remaining); err != nil {
-		return fmt.Errorf("oidc bind: cas save created session: %w", err)
+		return fmt.Errorf("oidc bind: cas lock creating: %w", err)
 	}
 	return nil
 }

--- a/modules/oidc/bind_service.go
+++ b/modules/oidc/bind_service.go
@@ -49,6 +49,8 @@ type BindInfoResp struct {
 	Name           string       `json:"name,omitempty"`
 	Methods        []BindMethod `json:"methods"`
 	SupportContact string       `json:"support_contact,omitempty"`
+	AllowCreate    bool         `json:"allow_create"`
+	CreateBlocked  string       `json:"create_blocked,omitempty"`
 }
 
 // BindService 自助绑定状态机的业务逻辑层。
@@ -113,8 +115,8 @@ func (s *BindService) Issue(ctx context.Context, claims *IDTokenClaims, sd *Stat
 	return jti, nil
 }
 
-// Info 返回脱敏 claims + 可用方法。可用方法 = 配置 Methods ∩ 当前 claims 支持
-// 的手段(claims 无 verified phone → 屏蔽 sms_otp,FR-3.3)。
+// Info 返回脱敏 claims + 可用方法 + create 能力状态。
+// 可用方法 = 配置 Methods ∩ 当前 claims 支持的手段(claims 无 verified phone → 屏蔽 sms_otp,FR-3.3)。
 func (s *BindService) Info(ctx context.Context, jti string) (*BindInfoResp, error) {
 	sess, err := s.store.Get(ctx, jti)
 	if err != nil {
@@ -131,6 +133,12 @@ func (s *BindService) Info(ctx context.Context, jti string) (*BindInfoResp, erro
 		SupportContact: s.cfg.SupportContact,
 	}
 	resp.Methods = s.availableMethods(claims)
+	resp.AllowCreate = s.cfg.AllowCreate
+	if !s.cfg.AllowCreate {
+		resp.CreateBlocked = "disabled"
+	} else if err := s.checkClaimsForCreate(claims); err != nil {
+		resp.CreateBlocked = "claims_incomplete"
+	}
 	return resp, nil
 }
 
@@ -445,6 +453,110 @@ func (s *BindService) Confirm(ctx context.Context, jti string) (*BindConfirmResp
 	}, nil
 }
 
+// BindCreateResp Create 返给 handler 的完整快照,与 BindConfirmResp 对齐。
+type BindCreateResp struct {
+	IssueResp *IssueSessionResp
+	SD        *StateData
+	UID       string
+	Issuer    string
+}
+
+// Create 在 status=issued 时直接用 bind_token 里的 claims 建号 + 写 identity + 签发会话。
+//
+// 步骤(见 plan §4):
+//  1. Get session
+//  2. IncrAndCheck("bind:create:"+jti, bindCreateMax) — counter→status 顺序与 Confirm 对齐
+//  3. 校验 status == issued
+//  4. decode claims snapshot
+//  5. 校验 claims 至少有一条 verified 的 email 或 phone
+//  6. IssueSession({CreateUser:true, ...claims})
+//  7. identity.Insert((uid, issuer, sub))
+//  8. CASSave(issued→created)
+//  9. Consume(token) — 单次消费;失败仅 log
+func (s *BindService) Create(ctx context.Context, jti string) (*BindCreateResp, error) {
+	if s.identity == nil || s.users == nil {
+		return nil, errors.New("oidc bind Create: not configured (identity/users nil)")
+	}
+	sess, err := s.store.Get(ctx, jti)
+	if err != nil {
+		return nil, err
+	}
+	// counter→status 顺序(与 Confirm 对齐):任意对 create 的探测都消耗配额
+	if _, err := s.store.IncrAndCheck(ctx,
+		"bind:create:"+jti, bindCreateMax, s.cfg.TokenTTL); err != nil {
+		return nil, err
+	}
+	if sess.Status != BindStatusIssued {
+		return nil, ErrBindStatusConflict
+	}
+	claims, err := decodeClaimsSnapshot(sess.ClaimsSnapshot)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.checkClaimsForCreate(claims); err != nil {
+		return nil, err
+	}
+	sd, err := decodeSDSnapshot(sess.SDSnapshot)
+	if err != nil {
+		return nil, err
+	}
+	zone, phone := extractZone(claims.PhoneNumber), extractPhone(claims.PhoneNumber)
+	issueReq := IssueSessionReq{
+		CreateUser: true,
+		Name:       claims.Name,
+		Email:      claims.Email,
+		Phone:      phone,
+		Zone:       zone,
+		DeviceFlag: sd.DeviceFlag,
+		PublicIP:   sd.IP,
+	}
+	resp, err := s.users.IssueSession(ctx, issueReq)
+	if err != nil {
+		return nil, fmt.Errorf("oidc bind Create: issue session: %w", err)
+	}
+	uid := resp.UID
+	if err := s.identity.Insert(&IdentityModel{
+		UID:           uid,
+		Issuer:        claims.Issuer,
+		Subject:       claims.Subject,
+		Email:         claims.Email,
+		EmailVerified: boolToInt(claims.EmailVerified),
+		Phone:         claims.PhoneNumber,
+		PhoneVerified: boolToInt(claims.PhoneVerified),
+		LinkedAt:      time.Now(),
+	}); err != nil {
+		if isDuplicateKeyError(err) {
+			return nil, ErrBindAlreadyBound
+		}
+		return nil, fmt.Errorf("oidc bind Create: insert identity: %w", err)
+	}
+	if err := s.saveCreated(ctx, sess); err != nil {
+		return nil, fmt.Errorf("oidc bind Create: save created: %w", err)
+	}
+	if _, cerr := s.store.Consume(ctx, jti); cerr != nil {
+		log.Warn("OIDC bind Create: consume session failed (non-fatal, will TTL out)",
+			zap.String("jti_hash", subHash(jti)), zap.Error(cerr))
+	}
+	return &BindCreateResp{
+		IssueResp: resp,
+		SD:        sd,
+		UID:       uid,
+		Issuer:    claims.Issuer,
+	}, nil
+}
+
+// checkClaimsForCreate 校验 claims 至少有一条强标识(email 或 phone)。
+// 与 autolink 的准入条件对齐:email_verified / phone_verified 必须为 true,
+// 否则后续客服 / 找回流程没有可信账号锚点。
+func (s *BindService) checkClaimsForCreate(claims *IDTokenClaims) error {
+	hasEmail := claims.Email != "" && claims.EmailVerified
+	hasPhone := claims.PhoneNumber != "" && claims.PhoneVerified
+	if !hasEmail && !hasPhone {
+		return ErrBindCreateClaimsIncomplete
+	}
+	return nil
+}
+
 // decodeSDSnapshot 与 decodeClaimsSnapshot 对称。
 func decodeSDSnapshot(b []byte) (*StateData, error) {
 	var sd StateData
@@ -474,6 +586,20 @@ func (s *BindService) saveVerified(ctx context.Context, sess *BindSession) error
 	}
 	if err := s.store.CASSave(ctx, sess, BindStatusIssued, remaining); err != nil {
 		return fmt.Errorf("oidc bind: cas save verified session: %w", err)
+	}
+	return nil
+}
+
+// saveCreated 把 sess.Status 从 issued CAS 到 created,使用绝对剩余 TTL。
+// 对称 saveVerified:CAS expected=issued,防并发 create 竞态。
+func (s *BindService) saveCreated(ctx context.Context, sess *BindSession) error {
+	remaining := s.remainingTTL(sess)
+	if remaining <= 0 {
+		return ErrBindNotFound
+	}
+	sess.Status = BindStatusCreated
+	if err := s.store.CASSave(ctx, sess, BindStatusIssued, remaining); err != nil {
+		return fmt.Errorf("oidc bind: cas save created session: %w", err)
 	}
 	return nil
 }

--- a/modules/oidc/bind_service_test.go
+++ b/modules/oidc/bind_service_test.go
@@ -1163,6 +1163,26 @@ func TestBindService_Create_PhoneNotVerified(t *testing.T) {
 	}
 }
 
+// 非 +86 verified phone + 无 email → ErrBindCreateClaimsIncomplete。
+//
+// extractPhone 当前只识别 +86;放过其他号段会让 IssueSession 收到空 Phone/Zone,
+// 落库后用户没有可用手机号锚点。把"格式不支持"提前到 422 而非建残缺账号。
+func TestBindService_Create_NonCNPhone_NoEmail_ClaimsIncomplete(t *testing.T) {
+	h := newBindHarness(t, func(c *BindConfig) {
+		c.AllowCreate = true
+	})
+	c := sampleClaims()
+	c.Email = ""
+	c.EmailVerified = false
+	c.PhoneNumber = "+14155551234" // verified 但 dmwork 不支持
+	c.PhoneVerified = true
+	jti, _ := h.svc.Issue(context.Background(), c, sampleSD())
+	_, err := h.svc.Create(context.Background(), jti)
+	if !errors.Is(err, ErrBindCreateClaimsIncomplete) {
+		t.Fatalf("non-+86 phone + no email must be rejected, got %v", err)
+	}
+}
+
 // T22: email 存在但未 verified + phone 缺失 → ErrBindCreateClaimsIncomplete
 func TestBindService_Create_EmailNotVerified(t *testing.T) {
 	h := newBindHarness(t, func(c *BindConfig) {
@@ -1179,12 +1199,16 @@ func TestBindService_Create_EmailNotVerified(t *testing.T) {
 	}
 }
 
-// T16: 超过 bindCreateMax(=1)→ ErrBindRateLimited,status 不变
+// T16: 超过 bindCreateMax(=1)→ ErrBindRateLimited
+//
+// 新设计语义:第一次 Create 失败(IssueSession 报错)会把 token 留在 creating 锁
+// 状态(防 ghost user)。第二次 Create:counter=2 > bindCreateMax=1,先被
+// IncrAndCheck 拦下返 ErrBindRateLimited,不到 CAS。两个失败状态都不会让 token
+// 被同样的 jti 复用建出第二个 user。
 func TestBindService_Create_RateLimited(t *testing.T) {
 	h := newBindHarness(t, func(c *BindConfig) {
 		c.AllowCreate = true
 	})
-	// 让 IssueSession 失败,避免第一次 Create 把 token 消费掉
 	h.users.err = errors.New("transient")
 	jti, _ := h.svc.Issue(context.Background(), sampleClaims(), sampleSD())
 
@@ -1192,17 +1216,12 @@ func TestBindService_Create_RateLimited(t *testing.T) {
 		t.Fatal("first create should fail due to IssueSession error")
 	}
 	sess, _ := h.store.Get(context.Background(), jti)
-	if sess.Status != BindStatusIssued {
-		t.Fatalf("T16: status must remain issued after failed create, got %v", sess.Status)
+	if sess.Status != BindStatusCreating {
+		t.Fatalf("T16: status must be 'creating' after failed create (lock-before-side-effect), got %v", sess.Status)
 	}
-	// 第二次:counter=2 > bindCreateMax=1 → ErrBindRateLimited
 	_, err := h.svc.Create(context.Background(), jti)
 	if !errors.Is(err, ErrBindRateLimited) {
 		t.Fatalf("T16: expected ErrBindRateLimited, got %v", err)
-	}
-	sess2, _ := h.store.Get(context.Background(), jti)
-	if sess2.Status != BindStatusIssued {
-		t.Fatalf("T16: status must remain issued after rate limit, got %v", sess2.Status)
 	}
 }
 
@@ -1227,21 +1246,31 @@ func TestBindService_Create_AfterVerifyFail_Succeeds(t *testing.T) {
 	}
 }
 
-// T26: create 失败后再 verify → 通过(D3)
-func TestBindService_Create_FailThenVerify_Succeeds(t *testing.T) {
+// T26: claims invalid 的 create 失败不会污染 token 状态 → 之后 verify 仍可走。
+//
+// 新设计语义:claims 校验在 CAS 之前(纯只读),失败保持 token 在 issued。
+// 这是"create 失败不阻塞 verify"的合法路径 —— IssueSession 已经发生的失败
+// 会把 token 锁到 creating(防 ghost user),此后 verify 也会被拒,符合预期。
+func TestBindService_Create_ClaimsFailThenVerify_Succeeds(t *testing.T) {
 	h := newBindHarness(t, func(c *BindConfig) {
 		c.AllowCreate = true
 		c.VerifyMax = 3
 	})
-	jti, _ := h.svc.Issue(context.Background(), sampleClaims(), sampleSD())
+	c := sampleClaims()
+	c.Email = ""
+	c.EmailVerified = false
+	c.PhoneNumber = ""
+	c.PhoneVerified = false
+	jti, _ := h.svc.Issue(context.Background(), c, sampleSD())
 
-	// create fails (IssueSession error)
-	h.users.err = errors.New("transient")
-	if _, err := h.svc.Create(context.Background(), jti); err == nil {
-		t.Fatal("Create should fail with IssueSession error")
+	if _, err := h.svc.Create(context.Background(), jti); !errors.Is(err, ErrBindCreateClaimsIncomplete) {
+		t.Fatalf("Create must fail with claims incomplete, got %v", err)
+	}
+	sess, _ := h.store.Get(context.Background(), jti)
+	if sess.Status != BindStatusIssued {
+		t.Fatalf("status after claims-check failure must remain issued, got %v", sess.Status)
 	}
 
-	// status still issued → verify should work
 	h.auth.verifyPasswordResp.matched = true
 	h.loc.byUsername["alice"] = "u-alice"
 	if err := h.svc.VerifyPassword(context.Background(), jti, "alice", "p"); err != nil {
@@ -1249,8 +1278,13 @@ func TestBindService_Create_FailThenVerify_Succeeds(t *testing.T) {
 	}
 }
 
-// T23: IssueSession 失败 → wrap error，不消费 token（允许 retry）
-func TestBindService_Create_IssueSessionFail_TokenNotConsumed(t *testing.T) {
+// T23: IssueSession 失败 → wrap error,token 留在 creating 锁状态。
+//
+// 新设计语义:token 不被 Consume(Redis 行还在),但 status 已经被 CAS 推到
+// creating(防 ghost user)。retry 同 jti 会撞 CAS conflict 或 rate limit ——
+// 这是有意为之:确保单个 IdP 身份只产生一个本地 user。
+// 用户需重走 OIDC 登录拿新 bind_token 才能再次尝试。
+func TestBindService_Create_IssueSessionFail_TokenLockedCreating(t *testing.T) {
 	h := newBindHarness(t, func(c *BindConfig) {
 		c.AllowCreate = true
 	})
@@ -1261,9 +1295,12 @@ func TestBindService_Create_IssueSessionFail_TokenNotConsumed(t *testing.T) {
 	if err == nil {
 		t.Fatal("T23: Create must propagate IssueSession error")
 	}
-	// token must NOT be consumed — still available for retry
-	if _, err := h.store.Get(context.Background(), jti); err != nil {
-		t.Fatalf("T23: session must remain for retry after IssueSession failure, got err=%v", err)
+	sess, gerr := h.store.Get(context.Background(), jti)
+	if gerr != nil {
+		t.Fatalf("T23: session must NOT be consumed (Redis row still exists), got %v", gerr)
+	}
+	if sess.Status != BindStatusCreating {
+		t.Fatalf("T23: status must be 'creating' after IssueSession failure (防 ghost user), got %v", sess.Status)
 	}
 }
 
@@ -1399,10 +1436,10 @@ func TestBindService_Create_StatusGuards(t *testing.T) {
 			ErrBindStatusConflict,
 		},
 		{
-			"T13: status=created → conflict (防重复 create)",
+			"T13: status=creating → conflict (防重复 create / 抢到锁的另一 goroutine 正在副作用阶段)",
 			func(h *bindTestHarness, jti string) {
 				sess, _ := h.store.Get(context.Background(), jti)
-				sess.Status = BindStatusCreated
+				sess.Status = BindStatusCreating
 				_ = h.store.Save(context.Background(), sess, time.Minute)
 			},
 			ErrBindStatusConflict,
@@ -1443,42 +1480,41 @@ func TestBindService_Create_TokenNotFound(t *testing.T) {
 	}
 }
 
-// TestBindService_SaveCreated_CASIssued 锁定 saveCreated:
-// CAS issued → created,并用绝对 TTL(与 saveVerified 对称)。
-// 并发两次 saveCreated 只有一个成功,另一个 ErrBindStatusConflict。
-func TestBindService_SaveCreated_CASIssued(t *testing.T) {
+// TestBindService_CasLockForCreate_Issued CAS issued → creating,
+// 并用绝对剩余 TTL(与 saveVerified 对称,不续命到 TokenTTL × 2)。
+func TestBindService_CasLockForCreate_Issued(t *testing.T) {
 	h := newBindHarness(t)
 	jti, err := h.svc.Issue(context.Background(), sampleClaims(), sampleSD())
 	if err != nil {
 		t.Fatalf("Issue: %v", err)
 	}
-
 	sess, err := h.store.Get(context.Background(), jti)
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if err := h.svc.saveCreated(context.Background(), sess); err != nil {
-		t.Fatalf("saveCreated: %v", err)
+	if err := h.svc.casLockForCreate(context.Background(), sess); err != nil {
+		t.Fatalf("casLockForCreate: %v", err)
 	}
 	got, err := h.store.Get(context.Background(), jti)
 	if err != nil {
-		t.Fatalf("Get after saveCreated: %v", err)
+		t.Fatalf("Get after casLockForCreate: %v", err)
 	}
-	if got.Status != BindStatusCreated {
-		t.Fatalf("status=%v want created", got.Status)
+	if got.Status != BindStatusCreating {
+		t.Fatalf("status=%v want creating", got.Status)
 	}
 }
 
-func TestBindService_SaveCreated_CASConflictOnSecondCall(t *testing.T) {
+// TestBindService_CasLockForCreate_ConflictOnSecondCall 第二次 CAS 应当撞 conflict —
+// 这是"防 ghost user"的核心:并发两个 create 永远只有一个进入副作用阶段。
+func TestBindService_CasLockForCreate_ConflictOnSecondCall(t *testing.T) {
 	h := newBindHarness(t)
 	jti, _ := h.svc.Issue(context.Background(), sampleClaims(), sampleSD())
 	sess, _ := h.store.Get(context.Background(), jti)
-	if err := h.svc.saveCreated(context.Background(), sess); err != nil {
-		t.Fatalf("first saveCreated: %v", err)
+	if err := h.svc.casLockForCreate(context.Background(), sess); err != nil {
+		t.Fatalf("first casLockForCreate: %v", err)
 	}
-	// second call: status is now created, not issued → conflict
-	if err := h.svc.saveCreated(context.Background(), sess); !errors.Is(err, ErrBindStatusConflict) {
-		t.Fatalf("second saveCreated must ErrBindStatusConflict, got %v", err)
+	if err := h.svc.casLockForCreate(context.Background(), sess); !errors.Is(err, ErrBindStatusConflict) {
+		t.Fatalf("second casLockForCreate must ErrBindStatusConflict, got %v", err)
 	}
 }
 

--- a/modules/oidc/bind_service_test.go
+++ b/modules/oidc/bind_service_test.go
@@ -96,6 +96,7 @@ func (f *fakeBindLocator) UIDsByPhone(zone, phone string) ([]string, error) {
 }
 
 type fakeIdentityWriter struct {
+	mu          sync.Mutex
 	inserted    []*IdentityModel
 	insertErr   error
 	duplicate   bool // true => insertErr is treated as MySQL 1062
@@ -104,12 +105,16 @@ type fakeIdentityWriter struct {
 }
 
 func (f *fakeIdentityWriter) Get(issuer, subject string) (*IdentityModel, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.getResp == nil {
 		return nil, nil
 	}
 	return f.getResp[issuer+"|"+subject], nil
 }
 func (f *fakeIdentityWriter) Insert(m *IdentityModel) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.insertErr != nil {
 		return f.insertErr
 	}
@@ -122,6 +127,7 @@ func (f *fakeIdentityWriter) UpdateLogin(_ int64, _ string, _ int, _ string, _ i
 }
 
 type fakeIssueSession struct {
+	mu      sync.Mutex
 	resp    *IssueSessionResp
 	err     error
 	gotReq  IssueSessionReq
@@ -131,6 +137,8 @@ type fakeIssueSession struct {
 func (f *fakeIssueSession) UIDsByEmail(string) ([]string, error)         { return nil, nil }
 func (f *fakeIssueSession) UIDsByPhone(string, string) ([]string, error) { return nil, nil }
 func (f *fakeIssueSession) IssueSession(_ context.Context, req IssueSessionReq) (*IssueSessionResp, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.callCnt++
 	f.gotReq = req
 	if f.err != nil {
@@ -1084,6 +1092,496 @@ func TestBindService_VerifyPassword_UnknownIdentifierConsumesUIDFailBudget(t *te
 	if !errors.Is(err, ErrBindRateLimited) {
 		t.Fatalf("repeated unknown identifier must hit uid-fail limit (anti-enumeration), got %v", err)
 	}
+}
+
+// ---- Create tests ----
+
+// T10: happy path
+func TestBindService_Create_HappyPath(t *testing.T) {
+	h := newBindHarness(t, func(c *BindConfig) {
+		c.AllowCreate = true
+	})
+	h.users.resp = &IssueSessionResp{UID: "u-new", LoginRespJSON: `{"token":"t-new"}`}
+	jti, _ := h.svc.Issue(context.Background(), sampleClaims(), sampleSD())
+
+	resp, err := h.svc.Create(context.Background(), jti)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if resp.IssueResp.UID != "u-new" {
+		t.Fatalf("resp UID=%q want u-new", resp.IssueResp.UID)
+	}
+	// IssueSession called with CreateUser=true
+	if !h.users.gotReq.CreateUser {
+		t.Fatal("IssueSession must be called with CreateUser=true")
+	}
+	// identity.Insert called
+	if len(h.identity.inserted) != 1 {
+		t.Fatalf("identity inserts=%d want 1", len(h.identity.inserted))
+	}
+	// token must be consumed after successful Create (SR-1)
+	if _, err := h.store.Get(context.Background(), jti); !errors.Is(err, ErrBindNotFound) {
+		t.Fatalf("session must be consumed after Create, got err=%v", err)
+	}
+	// SD is returned for cross-device authcode backfill
+	if resp.SD == nil {
+		t.Fatal("SD must be non-nil in Create response")
+	}
+}
+
+// T17: claims 既无 verified email 也无 verified phone → ErrBindCreateClaimsIncomplete
+func TestBindService_Create_ClaimsMissingEmailAndPhone(t *testing.T) {
+	h := newBindHarness(t, func(c *BindConfig) {
+		c.AllowCreate = true
+	})
+	c := sampleClaims()
+	c.Email = ""
+	c.EmailVerified = false
+	c.PhoneNumber = ""
+	c.PhoneVerified = false
+	jti, _ := h.svc.Issue(context.Background(), c, sampleSD())
+	_, err := h.svc.Create(context.Background(), jti)
+	if !errors.Is(err, ErrBindCreateClaimsIncomplete) {
+		t.Fatalf("T17: expected ErrBindCreateClaimsIncomplete, got %v", err)
+	}
+}
+
+// T21: phone 存在但未 verified + email 缺失 → ErrBindCreateClaimsIncomplete
+// (单一标识但 verified=false 等价于"没有可信标识")
+func TestBindService_Create_PhoneNotVerified(t *testing.T) {
+	h := newBindHarness(t, func(c *BindConfig) {
+		c.AllowCreate = true
+	})
+	c := sampleClaims()
+	c.Email = ""
+	c.EmailVerified = false
+	c.PhoneVerified = false
+	jti, _ := h.svc.Issue(context.Background(), c, sampleSD())
+	_, err := h.svc.Create(context.Background(), jti)
+	if !errors.Is(err, ErrBindCreateClaimsIncomplete) {
+		t.Fatalf("T21: unverified phone + no email must return ErrBindCreateClaimsIncomplete, got %v", err)
+	}
+}
+
+// T22: email 存在但未 verified + phone 缺失 → ErrBindCreateClaimsIncomplete
+func TestBindService_Create_EmailNotVerified(t *testing.T) {
+	h := newBindHarness(t, func(c *BindConfig) {
+		c.AllowCreate = true
+	})
+	c := sampleClaims()
+	c.EmailVerified = false
+	c.PhoneNumber = ""
+	c.PhoneVerified = false
+	jti, _ := h.svc.Issue(context.Background(), c, sampleSD())
+	_, err := h.svc.Create(context.Background(), jti)
+	if !errors.Is(err, ErrBindCreateClaimsIncomplete) {
+		t.Fatalf("T22: unverified email + no phone must return ErrBindCreateClaimsIncomplete, got %v", err)
+	}
+}
+
+// T16: 超过 bindCreateMax(=1)→ ErrBindRateLimited,status 不变
+func TestBindService_Create_RateLimited(t *testing.T) {
+	h := newBindHarness(t, func(c *BindConfig) {
+		c.AllowCreate = true
+	})
+	// 让 IssueSession 失败,避免第一次 Create 把 token 消费掉
+	h.users.err = errors.New("transient")
+	jti, _ := h.svc.Issue(context.Background(), sampleClaims(), sampleSD())
+
+	if _, err := h.svc.Create(context.Background(), jti); err == nil {
+		t.Fatal("first create should fail due to IssueSession error")
+	}
+	sess, _ := h.store.Get(context.Background(), jti)
+	if sess.Status != BindStatusIssued {
+		t.Fatalf("T16: status must remain issued after failed create, got %v", sess.Status)
+	}
+	// 第二次:counter=2 > bindCreateMax=1 → ErrBindRateLimited
+	_, err := h.svc.Create(context.Background(), jti)
+	if !errors.Is(err, ErrBindRateLimited) {
+		t.Fatalf("T16: expected ErrBindRateLimited, got %v", err)
+	}
+	sess2, _ := h.store.Get(context.Background(), jti)
+	if sess2.Status != BindStatusIssued {
+		t.Fatalf("T16: status must remain issued after rate limit, got %v", sess2.Status)
+	}
+}
+
+// T25: verify 失败后再 create → 通过(D3：限频独立)
+func TestBindService_Create_AfterVerifyFail_Succeeds(t *testing.T) {
+	h := newBindHarness(t, func(c *BindConfig) {
+		c.AllowCreate = true
+		c.VerifyMax = 3
+	})
+	h.users.resp = &IssueSessionResp{UID: "u-new", LoginRespJSON: `{}`}
+	jti, _ := h.svc.Issue(context.Background(), sampleClaims(), sampleSD())
+
+	// verify fails (wrong password)
+	h.auth.verifyPasswordResp.matched = false
+	h.loc.byUsername["alice"] = "u-alice"
+	_ = h.svc.VerifyPassword(context.Background(), jti, "alice", "wrong")
+
+	// status still issued → create should work
+	_, err := h.svc.Create(context.Background(), jti)
+	if err != nil {
+		t.Fatalf("T25: Create after failed verify must succeed, got: %v", err)
+	}
+}
+
+// T26: create 失败后再 verify → 通过(D3)
+func TestBindService_Create_FailThenVerify_Succeeds(t *testing.T) {
+	h := newBindHarness(t, func(c *BindConfig) {
+		c.AllowCreate = true
+		c.VerifyMax = 3
+	})
+	jti, _ := h.svc.Issue(context.Background(), sampleClaims(), sampleSD())
+
+	// create fails (IssueSession error)
+	h.users.err = errors.New("transient")
+	if _, err := h.svc.Create(context.Background(), jti); err == nil {
+		t.Fatal("Create should fail with IssueSession error")
+	}
+
+	// status still issued → verify should work
+	h.auth.verifyPasswordResp.matched = true
+	h.loc.byUsername["alice"] = "u-alice"
+	if err := h.svc.VerifyPassword(context.Background(), jti, "alice", "p"); err != nil {
+		t.Fatalf("T26: VerifyPassword after failed create must succeed, got: %v", err)
+	}
+}
+
+// T23: IssueSession 失败 → wrap error，不消费 token（允许 retry）
+func TestBindService_Create_IssueSessionFail_TokenNotConsumed(t *testing.T) {
+	h := newBindHarness(t, func(c *BindConfig) {
+		c.AllowCreate = true
+	})
+	h.users.err = errors.New("downstream down")
+	jti, _ := h.svc.Issue(context.Background(), sampleClaims(), sampleSD())
+
+	_, err := h.svc.Create(context.Background(), jti)
+	if err == nil {
+		t.Fatal("T23: Create must propagate IssueSession error")
+	}
+	// token must NOT be consumed — still available for retry
+	if _, err := h.store.Get(context.Background(), jti); err != nil {
+		t.Fatalf("T23: session must remain for retry after IssueSession failure, got err=%v", err)
+	}
+}
+
+// T24: identity.Insert 撞 uk_issuer_subject → ErrBindAlreadyBound
+func TestBindService_Create_IdentityInsertDuplicate_AlreadyBound(t *testing.T) {
+	h := newBindHarness(t, func(c *BindConfig) {
+		c.AllowCreate = true
+	})
+	h.users.resp = &IssueSessionResp{UID: "u-new", LoginRespJSON: `{}`}
+	h.identity.insertErr = mockDuplicateKeyErr()
+	jti, _ := h.svc.Issue(context.Background(), sampleClaims(), sampleSD())
+
+	_, err := h.svc.Create(context.Background(), jti)
+	if !errors.Is(err, ErrBindAlreadyBound) {
+		t.Fatalf("T24: duplicate identity must surface ErrBindAlreadyBound, got %v", err)
+	}
+}
+
+// T27: 并发 create 同 token：只有一个 CASSave 成功，另一个 ErrBindStatusConflict
+func TestBindService_Create_ConcurrentRaceOnlyOneWins(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		h := newBindHarness(t, func(c *BindConfig) {
+			c.AllowCreate = true
+		})
+		h.users.resp = &IssueSessionResp{UID: "u-new", LoginRespJSON: `{}`}
+		jti, _ := h.svc.Issue(context.Background(), sampleClaims(), sampleSD())
+
+		var wg sync.WaitGroup
+		errs := make([]error, 2)
+		start := make(chan struct{})
+		for idx := 0; idx < 2; idx++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				<-start
+				_, errs[idx] = h.svc.Create(context.Background(), jti)
+			}(idx)
+		}
+		close(start)
+		wg.Wait()
+
+		var okCount, failCount int
+		for _, e := range errs {
+			switch {
+			case e == nil:
+				okCount++
+			case errors.Is(e, ErrBindStatusConflict),
+				errors.Is(e, ErrBindNotFound),
+				errors.Is(e, ErrBindRateLimited):
+				// ErrBindStatusConflict: loser's CASSave sees status already advanced
+				// ErrBindNotFound:       winner already Consumed session before loser's CASSave
+				// ErrBindRateLimited:    bindCreateMax=1 → 2nd IncrAndCheck exceeds limit
+				failCount++
+			default:
+				t.Fatalf("iter %d: unexpected err %v", i, e)
+			}
+		}
+		if okCount != 1 || failCount != 1 {
+			t.Fatalf("iter %d: want 1 ok + 1 fail, got ok=%d fail=%d", i, okCount, failCount)
+		}
+	}
+}
+
+// T28: Consume 失败仅 log，不返 error
+func TestBindService_Create_ConsumeFailureIsNonFatal(t *testing.T) {
+	h := newBindHarness(t, func(c *BindConfig) {
+		c.AllowCreate = true
+	})
+	h.users.resp = &IssueSessionResp{UID: "u-new", LoginRespJSON: `{}`}
+
+	// Use a store that makes Consume fail but Get/Save/CASSave work
+	failConsumeStore := &failingConsumeStore{inner: h.store}
+	h.svc.store = failConsumeStore
+	jti, _ := h.svc.Issue(context.Background(), sampleClaims(), sampleSD())
+
+	resp, err := h.svc.Create(context.Background(), jti)
+	if err != nil {
+		t.Fatalf("T28: Consume failure must not propagate, got: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("T28: Create must return valid resp despite Consume failure")
+	}
+}
+
+// failingConsumeStore wraps memoryBindStore and makes Consume always fail.
+type failingConsumeStore struct {
+	inner *memoryBindStore
+}
+
+func (f *failingConsumeStore) Save(ctx context.Context, s *BindSession, ttl time.Duration) error {
+	return f.inner.Save(ctx, s, ttl)
+}
+func (f *failingConsumeStore) Get(ctx context.Context, jti string) (*BindSession, error) {
+	return f.inner.Get(ctx, jti)
+}
+func (f *failingConsumeStore) CASSave(ctx context.Context, sess *BindSession, expected BindStatus, ttl time.Duration) error {
+	return f.inner.CASSave(ctx, sess, expected, ttl)
+}
+func (f *failingConsumeStore) Consume(_ context.Context, _ string) (*BindSession, error) {
+	return nil, errors.New("redis: connection refused")
+}
+func (f *failingConsumeStore) IncrAndCheck(ctx context.Context, key string, limit int64, ttl time.Duration) (int64, error) {
+	return f.inner.IncrAndCheck(ctx, key, limit, ttl)
+}
+
+// T11-T14: status guards — only issued can create
+func TestBindService_Create_StatusGuards(t *testing.T) {
+	cases := []struct {
+		name    string
+		setup   func(h *bindTestHarness, jti string)
+		wantErr error
+	}{
+		{
+			"T11: status=verified → conflict",
+			func(h *bindTestHarness, jti string) {
+				h.auth.verifyPasswordResp.matched = true
+				h.loc.byUsername["alice"] = "u-alice"
+				_ = h.svc.VerifyPassword(context.Background(), jti, "alice", "p")
+			},
+			ErrBindStatusConflict,
+		},
+		{
+			"T12: status=confirmed → conflict",
+			func(h *bindTestHarness, jti string) {
+				// manually force confirmed via store
+				h.auth.verifyPasswordResp.matched = true
+				h.loc.byUsername["alice"] = "u-alice"
+				_ = h.svc.VerifyPassword(context.Background(), jti, "alice", "p")
+				sess, _ := h.store.Get(context.Background(), jti)
+				sess.Status = BindStatusConfirmed
+				_ = h.store.Save(context.Background(), sess, time.Minute)
+			},
+			ErrBindStatusConflict,
+		},
+		{
+			"T13: status=created → conflict (防重复 create)",
+			func(h *bindTestHarness, jti string) {
+				sess, _ := h.store.Get(context.Background(), jti)
+				sess.Status = BindStatusCreated
+				_ = h.store.Save(context.Background(), sess, time.Minute)
+			},
+			ErrBindStatusConflict,
+		},
+		{
+			"T14: status=refused → conflict",
+			func(h *bindTestHarness, jti string) {
+				sess, _ := h.store.Get(context.Background(), jti)
+				sess.Status = BindStatusRefused
+				_ = h.store.Save(context.Background(), sess, time.Minute)
+			},
+			ErrBindStatusConflict,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newBindHarness(t, func(c *BindConfig) {
+				c.AllowCreate = true
+			})
+			jti, _ := h.svc.Issue(context.Background(), sampleClaims(), sampleSD())
+			tc.setup(h, jti)
+			_, err := h.svc.Create(context.Background(), jti)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("expected %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// T15: token not found → ErrBindNotFound
+func TestBindService_Create_TokenNotFound(t *testing.T) {
+	h := newBindHarness(t, func(c *BindConfig) {
+		c.AllowCreate = true
+	})
+	_, err := h.svc.Create(context.Background(), "nonexistent-jti")
+	if !errors.Is(err, ErrBindNotFound) {
+		t.Fatalf("T15: expected ErrBindNotFound, got %v", err)
+	}
+}
+
+// TestBindService_SaveCreated_CASIssued 锁定 saveCreated:
+// CAS issued → created,并用绝对 TTL(与 saveVerified 对称)。
+// 并发两次 saveCreated 只有一个成功,另一个 ErrBindStatusConflict。
+func TestBindService_SaveCreated_CASIssued(t *testing.T) {
+	h := newBindHarness(t)
+	jti, err := h.svc.Issue(context.Background(), sampleClaims(), sampleSD())
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	sess, err := h.store.Get(context.Background(), jti)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := h.svc.saveCreated(context.Background(), sess); err != nil {
+		t.Fatalf("saveCreated: %v", err)
+	}
+	got, err := h.store.Get(context.Background(), jti)
+	if err != nil {
+		t.Fatalf("Get after saveCreated: %v", err)
+	}
+	if got.Status != BindStatusCreated {
+		t.Fatalf("status=%v want created", got.Status)
+	}
+}
+
+func TestBindService_SaveCreated_CASConflictOnSecondCall(t *testing.T) {
+	h := newBindHarness(t)
+	jti, _ := h.svc.Issue(context.Background(), sampleClaims(), sampleSD())
+	sess, _ := h.store.Get(context.Background(), jti)
+	if err := h.svc.saveCreated(context.Background(), sess); err != nil {
+		t.Fatalf("first saveCreated: %v", err)
+	}
+	// second call: status is now created, not issued → conflict
+	if err := h.svc.saveCreated(context.Background(), sess); !errors.Is(err, ErrBindStatusConflict) {
+		t.Fatalf("second saveCreated must ErrBindStatusConflict, got %v", err)
+	}
+}
+
+// T60: 并发两个 /bind/create 同 (issuer,sub) 不同 token:
+// 两个都建 user，只有一个 identity.Insert 成功；
+// 输家得到 ErrBindAlreadyBound，由 handler 决定 recover 策略。
+func TestBindService_Create_IdentityRaceRecovery(t *testing.T) {
+	// Simulate: two separate tokens, both issued, both proceed to IssueSession.
+	// First Insert succeeds, second Insert returns duplicate-key → ErrBindAlreadyBound.
+	h1 := newBindHarness(t, func(c *BindConfig) {
+		c.AllowCreate = true
+	})
+	h1.users.resp = &IssueSessionResp{UID: "u-winner", LoginRespJSON: `{"token":"winner"}`}
+	jti1, _ := h1.svc.Issue(context.Background(), sampleClaims(), sampleSD())
+
+	h2 := newBindHarness(t, func(c *BindConfig) {
+		c.AllowCreate = true
+	})
+	h2.users.resp = &IssueSessionResp{UID: "u-loser", LoginRespJSON: `{"token":"loser"}`}
+	h2.identity.insertErr = mockDuplicateKeyErr() // simulates race: winner already inserted
+	jti2, _ := h2.svc.Issue(context.Background(), sampleClaims(), sampleSD())
+
+	// winner succeeds
+	resp1, err := h1.svc.Create(context.Background(), jti1)
+	if err != nil {
+		t.Fatalf("T60: winner Create must succeed, got: %v", err)
+	}
+	if resp1.UID != "u-winner" {
+		t.Fatalf("T60: winner UID=%q", resp1.UID)
+	}
+
+	// loser gets ErrBindAlreadyBound — handler is responsible for recovery
+	_, err = h2.svc.Create(context.Background(), jti2)
+	if !errors.Is(err, ErrBindAlreadyBound) {
+		t.Fatalf("T60: loser must get ErrBindAlreadyBound for handler to recover, got %v", err)
+	}
+}
+
+// T50: Redis CAS integration (skipped if Redis unavailable)
+// Verifies that CAS issued→created works correctly with real Redis,
+// and a verified-status token cannot create.
+func TestBindService_Create_RedisIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipped in short mode: requires Redis at 127.0.0.1:6379")
+	}
+	client := newProbeRedisClientForService(t)
+	if client == nil {
+		t.Skip("Redis not available")
+	}
+	defer client.Close()
+
+	store := newRedisBindStoreForTest(client)
+	auth := &fakeBindAuth{}
+	loc := &fakeBindLocator{byUsername: map[string]string{}, byPhone: map[string][]string{}}
+	identity := &fakeIdentityWriter{}
+	users := &fakeIssueSession{resp: &IssueSessionResp{UID: "u-redis", LoginRespJSON: `{}`}}
+	cfg := BindConfig{
+		Enabled:   true,
+		TokenTTL:  time.Minute,
+		VerifyMax: 5, OTPSendMax: 3, ConfirmMax: 3, UIDFailPerDay: 10,
+		Methods:     []BindMethod{BindMethodPassword, BindMethodSMSOTP},
+		AllowCreate: true,
+	}
+	svc := newBindService(cfg, store, auth, loc)
+	svc.identity = identity
+	svc.users = users
+
+	ctx := context.Background()
+
+	// T50a: happy path — CAS issued→created
+	jti1, err := svc.Issue(ctx, sampleClaims(), sampleSD())
+	if err != nil {
+		t.Fatalf("T50: Issue: %v", err)
+	}
+	resp, err := svc.Create(ctx, jti1)
+	if err != nil {
+		t.Fatalf("T50: Create: %v", err)
+	}
+	if resp.UID != "u-redis" {
+		t.Fatalf("T50: UID=%q want u-redis", resp.UID)
+	}
+
+	// T50b: verified token cannot create (status conflict)
+	auth.verifyPasswordResp.matched = true
+	loc.byUsername["alice"] = "u-alice"
+	jti2, _ := svc.Issue(ctx, sampleClaims(), sampleSD())
+	_ = svc.VerifyPassword(ctx, jti2, "alice", "p")
+	_, err = svc.Create(ctx, jti2)
+	if !errors.Is(err, ErrBindStatusConflict) {
+		t.Fatalf("T50: verified token must conflict on Create, got %v", err)
+	}
+}
+
+func newProbeRedisClientForService(t *testing.T) interface{ Close() error } {
+	t.Helper()
+	// We can't use newProbeRedisClient (it's in api_bind_test.go)
+	// This is a simplified version for the service test.
+	// Skip by default — Redis integration is covered at the store level.
+	return nil
+}
+
+func newRedisBindStoreForTest(_ interface{ Close() error }) BindStore {
+	return newMemoryBindStore()
 }
 
 // TestBindService_ShouldHandle 一致地决定 callback 失败分支接管。

--- a/modules/oidc/bind_service_test.go
+++ b/modules/oidc/bind_service_test.go
@@ -185,6 +185,9 @@ func newBindHarness(t *testing.T, cfgMutators ...func(*BindConfig)) *bindTestHar
 		UIDFailPerDay:  10,
 		Methods:        []BindMethod{BindMethodPassword, BindMethodSMSOTP},
 		SupportContact: "support@example.com",
+		// 默认放行 sampleClaims().Issuer,让 Create 路径的 issuerAllowedForCreate
+		// 兜底校验默认放行;需要测"allowlist 拒绝"的用例显式覆盖。
+		IssuerAllowlist: []string{"https://idp.example"},
 	}
 	for _, mut := range cfgMutators {
 		mut(&cfg)
@@ -1480,6 +1483,140 @@ func TestBindService_Create_TokenNotFound(t *testing.T) {
 	}
 }
 
+// B. manual_conflict 来源的 bind_token Create 必须返 ErrBindCreateConflictNeedManual。
+// 锚定 P2-1:dmwork 端命中多账号脏数据时不允许走自助建号(会再造新账号加剧混乱),
+// 走 P1 Admin 人工合并兜底。
+func TestBindService_Create_ManualConflictRejected(t *testing.T) {
+	h := newBindHarness(t, func(c *BindConfig) {
+		c.AllowCreate = true
+	})
+	jti, err := h.svc.IssueWithReason(context.Background(), sampleClaims(), sampleSD(), BindReasonManualConflict)
+	if err != nil {
+		t.Fatalf("IssueWithReason: %v", err)
+	}
+	_, err = h.svc.Create(context.Background(), jti)
+	if !errors.Is(err, ErrBindCreateConflictNeedManual) {
+		t.Fatalf("expected ErrBindCreateConflictNeedManual, got %v", err)
+	}
+	// 副作用零容忍:identity 未写、IssueSession 未调
+	if len(h.identity.inserted) != 0 {
+		t.Fatalf("identity inserts=%d want 0 (no side-effect on rejected manual_conflict)", len(h.identity.inserted))
+	}
+	if h.users.callCnt != 0 {
+		t.Fatalf("IssueSession calls=%d want 0", h.users.callCnt)
+	}
+}
+
+// B. Info 在 manual_conflict 来源的 token 上必须把 create_blocked 置为
+// "manual_conflict",让前端展示"联系管理员人工合并"引导而不是"自助建号"按钮。
+func TestBindService_Info_ManualConflict_CreateBlocked(t *testing.T) {
+	h := newBindHarness(t, func(c *BindConfig) {
+		c.AllowCreate = true
+	})
+	jti, err := h.svc.IssueWithReason(context.Background(), sampleClaims(), sampleSD(), BindReasonManualConflict)
+	if err != nil {
+		t.Fatalf("IssueWithReason: %v", err)
+	}
+	info, err := h.svc.Info(context.Background(), jti)
+	if err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if info.CreateBlocked != "manual_conflict" {
+		t.Fatalf("create_blocked=%q want manual_conflict", info.CreateBlocked)
+	}
+	if !info.AllowCreate {
+		t.Fatal("AllowCreate must remain true (config-level) — block reason is token-source")
+	}
+}
+
+// E. Info 在 token 已被推进出 issued 状态时,create_blocked = "consumed"。
+// 优先级低于 disabled / claims_incomplete / manual_conflict。
+func TestBindService_Info_ConsumedToken_CreateBlocked(t *testing.T) {
+	h := newBindHarness(t, func(c *BindConfig) {
+		c.AllowCreate = true
+	})
+	jti, _ := h.svc.Issue(context.Background(), sampleClaims(), sampleSD())
+	// 把 token 推进到 verified
+	sess, _ := h.store.Get(context.Background(), jti)
+	sess.Status = BindStatusVerified
+	if err := h.store.CASSave(context.Background(), sess, BindStatusIssued, time.Minute); err != nil {
+		t.Fatalf("CASSave: %v", err)
+	}
+	info, err := h.svc.Info(context.Background(), jti)
+	if err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if info.CreateBlocked != "consumed" {
+		t.Fatalf("create_blocked=%q want consumed", info.CreateBlocked)
+	}
+}
+
+// E. Info 优先级断言:disabled > claims_incomplete > manual_conflict > consumed。
+// 当多个条件同时成立时,最高优先级取胜 —— disabled 始终遮蔽其他。
+func TestBindService_Info_CreateBlocked_PriorityOrder(t *testing.T) {
+	t.Run("disabled wins over claims_incomplete", func(t *testing.T) {
+		h := newBindHarness(t, func(c *BindConfig) {
+			c.AllowCreate = false // disabled
+		})
+		c := sampleClaims()
+		c.Email = "" // claims_incomplete would also apply if AllowCreate=true
+		c.EmailVerified = false
+		c.PhoneNumber = ""
+		c.PhoneVerified = false
+		jti, _ := h.svc.Issue(context.Background(), c, sampleSD())
+		info, _ := h.svc.Info(context.Background(), jti)
+		if info.CreateBlocked != "disabled" {
+			t.Fatalf("create_blocked=%q want disabled (higher prio)", info.CreateBlocked)
+		}
+	})
+	t.Run("claims_incomplete wins over manual_conflict", func(t *testing.T) {
+		h := newBindHarness(t, func(c *BindConfig) {
+			c.AllowCreate = true
+		})
+		c := sampleClaims()
+		c.Email = ""
+		c.EmailVerified = false
+		c.PhoneNumber = ""
+		c.PhoneVerified = false
+		jti, _ := h.svc.IssueWithReason(context.Background(), c, sampleSD(), BindReasonManualConflict)
+		info, _ := h.svc.Info(context.Background(), jti)
+		if info.CreateBlocked != "claims_incomplete" {
+			t.Fatalf("create_blocked=%q want claims_incomplete (higher prio)", info.CreateBlocked)
+		}
+	})
+	t.Run("manual_conflict wins over consumed", func(t *testing.T) {
+		h := newBindHarness(t, func(c *BindConfig) {
+			c.AllowCreate = true
+		})
+		jti, _ := h.svc.IssueWithReason(context.Background(), sampleClaims(), sampleSD(), BindReasonManualConflict)
+		sess, _ := h.store.Get(context.Background(), jti)
+		sess.Status = BindStatusVerified
+		_ = h.store.CASSave(context.Background(), sess, BindStatusIssued, time.Minute)
+		info, _ := h.svc.Info(context.Background(), jti)
+		if info.CreateBlocked != "manual_conflict" {
+			t.Fatalf("create_blocked=%q want manual_conflict (higher prio than consumed)", info.CreateBlocked)
+		}
+	})
+}
+
+// D. P2-3: issuer 不在 IssuerAllowlist 时 Create 必须拒绝(defense-in-depth)。
+// 即便 token 已签发(ShouldHandle 当时放行),运维在 5min TTL 内把 issuer
+// 移走也要被 Create 入口拦下。返 ErrBindAuthRejected → handler 翻 401。
+func TestBindService_Create_IssuerNotAllowed_Rejected(t *testing.T) {
+	h := newBindHarness(t, func(c *BindConfig) {
+		c.AllowCreate = true
+		c.IssuerAllowlist = []string{"https://other"} // sampleClaims().Issuer 不在内
+	})
+	jti, _ := h.svc.Issue(context.Background(), sampleClaims(), sampleSD())
+	_, err := h.svc.Create(context.Background(), jti)
+	if !errors.Is(err, ErrBindAuthRejected) {
+		t.Fatalf("expected ErrBindAuthRejected, got %v", err)
+	}
+	if len(h.identity.inserted) != 0 || h.users.callCnt != 0 {
+		t.Fatal("Create must short-circuit before any side-effect when issuer not allowed")
+	}
+}
+
 // TestBindService_CasLockForCreate_Issued CAS issued → creating,
 // 并用绝对剩余 TTL(与 saveVerified 对称,不续命到 TokenTTL × 2)。
 func TestBindService_CasLockForCreate_Issued(t *testing.T) {
@@ -1551,73 +1688,6 @@ func TestBindService_Create_IdentityRaceRecovery(t *testing.T) {
 	if !errors.Is(err, ErrBindAlreadyBound) {
 		t.Fatalf("T60: loser must get ErrBindAlreadyBound for handler to recover, got %v", err)
 	}
-}
-
-// T50: Redis CAS integration (skipped if Redis unavailable)
-// Verifies that CAS issued→created works correctly with real Redis,
-// and a verified-status token cannot create.
-func TestBindService_Create_RedisIntegration(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipped in short mode: requires Redis at 127.0.0.1:6379")
-	}
-	client := newProbeRedisClientForService(t)
-	if client == nil {
-		t.Skip("Redis not available")
-	}
-	defer client.Close()
-
-	store := newRedisBindStoreForTest(client)
-	auth := &fakeBindAuth{}
-	loc := &fakeBindLocator{byUsername: map[string]string{}, byPhone: map[string][]string{}}
-	identity := &fakeIdentityWriter{}
-	users := &fakeIssueSession{resp: &IssueSessionResp{UID: "u-redis", LoginRespJSON: `{}`}}
-	cfg := BindConfig{
-		Enabled:   true,
-		TokenTTL:  time.Minute,
-		VerifyMax: 5, OTPSendMax: 3, ConfirmMax: 3, UIDFailPerDay: 10,
-		Methods:     []BindMethod{BindMethodPassword, BindMethodSMSOTP},
-		AllowCreate: true,
-	}
-	svc := newBindService(cfg, store, auth, loc)
-	svc.identity = identity
-	svc.users = users
-
-	ctx := context.Background()
-
-	// T50a: happy path — CAS issued→created
-	jti1, err := svc.Issue(ctx, sampleClaims(), sampleSD())
-	if err != nil {
-		t.Fatalf("T50: Issue: %v", err)
-	}
-	resp, err := svc.Create(ctx, jti1)
-	if err != nil {
-		t.Fatalf("T50: Create: %v", err)
-	}
-	if resp.UID != "u-redis" {
-		t.Fatalf("T50: UID=%q want u-redis", resp.UID)
-	}
-
-	// T50b: verified token cannot create (status conflict)
-	auth.verifyPasswordResp.matched = true
-	loc.byUsername["alice"] = "u-alice"
-	jti2, _ := svc.Issue(ctx, sampleClaims(), sampleSD())
-	_ = svc.VerifyPassword(ctx, jti2, "alice", "p")
-	_, err = svc.Create(ctx, jti2)
-	if !errors.Is(err, ErrBindStatusConflict) {
-		t.Fatalf("T50: verified token must conflict on Create, got %v", err)
-	}
-}
-
-func newProbeRedisClientForService(t *testing.T) interface{ Close() error } {
-	t.Helper()
-	// We can't use newProbeRedisClient (it's in api_bind_test.go)
-	// This is a simplified version for the service test.
-	// Skip by default — Redis integration is covered at the store level.
-	return nil
-}
-
-func newRedisBindStoreForTest(_ interface{ Close() error }) BindStore {
-	return newMemoryBindStore()
 }
 
 // TestBindService_ShouldHandle 一致地决定 callback 失败分支接管。

--- a/modules/oidc/bind_store.go
+++ b/modules/oidc/bind_store.go
@@ -89,6 +89,13 @@ var (
 	// /bind/create 拒绝建号,因为后续客服 / 找回流程没有可信账号锚点。
 	// handler 翻 422,metric label claims_incomplete。
 	ErrBindCreateClaimsIncomplete = errors.New("oidc bind: claims missing required fields")
+
+	// ErrBindCreateConflictNeedManual bind_token 是从 manual-conflict 来源签发的
+	// (claims 命中多条 dmwork 账号);Create 路径拒绝建号,只能走 P1 Admin 人工合并。
+	// handler 翻 409,metric label conflict_need_manual。与 ErrBindConflictNeedManual
+	// (verify 路径短信多匹配)语义平行,但 token 维度的拒绝在 Create 入口落地,
+	// 与 Issue 阶段固化的 IssueReason 字段联动。
+	ErrBindCreateConflictNeedManual = errors.New("oidc bind: create rejected: claims conflict needs manual resolution")
 )
 
 // ---------- memory impl (单测 + 本地开发) ----------

--- a/modules/oidc/bind_store.go
+++ b/modules/oidc/bind_store.go
@@ -84,6 +84,11 @@ var (
 	// 端点绕过运维"禁用密码"的安全开关。handler 翻 400,与"参数非法"同档,
 	// 不属于身份凭据拒绝,因此与 ErrBindAuthRejected 区分。
 	ErrBindMethodDisabled = errors.New("oidc: bind method disabled by configuration")
+
+	// ErrBindCreateClaimsIncomplete claims 既无 verified email 也无 verified phone:
+	// /bind/create 拒绝建号,因为后续客服 / 找回流程没有可信账号锚点。
+	// handler 翻 422,metric label claims_incomplete。
+	ErrBindCreateClaimsIncomplete = errors.New("oidc bind: claims missing required fields")
 )
 
 // ---------- memory impl (单测 + 本地开发) ----------

--- a/modules/oidc/metrics.go
+++ b/modules/oidc/metrics.go
@@ -59,7 +59,7 @@ func syncVerificationSyncedResultLabels() []string {
 // callback "bind_pending"(callback 接管入口)单独走 callbackResultLabels,这里
 // 只列 /bind/* handler。
 func bindEndpointLabels() []string {
-	return []string{"info", "verify_password", "otp_send", "otp_check", "confirm"}
+	return []string{"info", "verify_password", "otp_send", "otp_check", "confirm", "create"}
 }
 
 // bindResultLabels handler 的统一结果维度。与 callbackResultLabels 对应,
@@ -67,13 +67,15 @@ func bindEndpointLabels() []string {
 func bindResultLabels() []string {
 	return []string{
 		"ok",
-		"bad_request",     // 400:入参校验失败
-		"unauthorized",    // 401:密码/OTP 错;状态机不是 verified
-		"not_found",       // 410:token 已过期/未知
-		"rate_limited",    // 429
-		"conflict",        // 409:already_bound
-		"internal_error",  // 500
-		"not_ready",       // 503:Discovery 失败,bind service 未构造
+		"bad_request",          // 400:入参校验失败
+		"unauthorized",         // 401:密码/OTP 错;状态机不是 verified
+		"not_found",            // 410:token 已过期/未知
+		"rate_limited",         // 429
+		"conflict",             // 409:already_bound / status conflict
+		"conflict_need_manual", // 409:manual_conflict 来源 token 拒建号(B. P2-1)
+		"claims_incomplete",    // 422:/bind/create claims 缺 verified email/phone
+		"internal_error",       // 500
+		"not_ready",            // 503:Discovery 失败,bind service 未构造
 	}
 }
 
@@ -98,7 +100,7 @@ func init() {
 	for _, l := range syncVerificationSyncedResultLabels() {
 		metricSyncVerificationSyncedTotal.WithLabelValues(l).Add(0)
 	}
-	// 自助绑定:5 端点 × 7 结果 = 35 个序列,Prometheus 内存可忽略。
+	// 自助绑定:6 端点 × 10 结果 = 60 个序列,Prometheus 内存可忽略。
 	for _, ep := range bindEndpointLabels() {
 		for _, r := range bindResultLabels() {
 			metricBindRequestTotal.WithLabelValues(ep, r).Add(0)
@@ -166,7 +168,7 @@ var (
 	metricBindRequestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metricNamespace,
 		Name:      "bind_request_total",
-		Help:      "OIDC self-service bind handler outcomes by endpoint (info|verify_password|otp_send|otp_check|confirm) and result (ok|bad_request|unauthorized|not_found|rate_limited|conflict|internal_error).",
+		Help:      "OIDC self-service bind handler outcomes by endpoint (info|verify_password|otp_send|otp_check|confirm|create) and result (ok|bad_request|unauthorized|not_found|rate_limited|conflict|conflict_need_manual|claims_incomplete|internal_error|not_ready).",
 	}, []string{"endpoint", "result"})
 
 	metricBindRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{

--- a/modules/oidc/model.go
+++ b/modules/oidc/model.go
@@ -8,26 +8,26 @@ import (
 
 // IdentityModel 第三方 OIDC 身份与本地 UID 的绑定关系
 type IdentityModel struct {
-	UID            string
-	Issuer         string
-	Subject        string
-	Email          string
-	EmailVerified  int
-	Phone          string
-	PhoneVerified  int
-	LinkedAt       time.Time
-	LastLoginAt    *time.Time
+	UID           string
+	Issuer        string
+	Subject       string
+	Email         string
+	EmailVerified int
+	Phone         string
+	PhoneVerified int
+	LinkedAt      time.Time
+	LastLoginAt   *time.Time
 	db.BaseModel
 }
 
 // RefreshModel OIDC refresh_token 的加密存储,用于后台状态同步轮询
 type RefreshModel struct {
-	IdentityID       int64
-	TokenHash        string
-	TokenCiphertext  []byte
-	ExpiresAt        time.Time
-	LastRefreshedAt  *time.Time
-	RevokedAt        *time.Time
+	IdentityID      int64
+	TokenHash       string
+	TokenCiphertext []byte
+	ExpiresAt       time.Time
+	LastRefreshedAt *time.Time
+	RevokedAt       *time.Time
 	db.BaseModel
 }
 
@@ -52,6 +52,8 @@ const (
 	EventBindConfirmOK   AuditEvent = "bind_confirm_ok"
 	EventBindConfirmFail AuditEvent = "bind_confirm_fail"
 	EventBindRefused     AuditEvent = "bind_refused"
+	EventBindCreated     AuditEvent = "bind_created"
+	EventBindCreateFail  AuditEvent = "bind_create_fail"
 )
 
 // AuditModel 登录与状态同步审计

--- a/modules/oidc/service.go
+++ b/modules/oidc/service.go
@@ -39,6 +39,15 @@ type IssueSessionReq struct {
 	DeviceName string
 	DeviceMod  string
 	PublicIP   string
+
+	// TrustedSSOCreate 透传到 user.ExternalLoginReq.TrustedSSOCreate,
+	// 让可信 IdP 触发的新建用户路径绕过 user 模块的 register.off 全局开关。
+	//
+	// 仅在 CreateUser=true 时有意义。callback `res.IsNew=true` 与 /bind/create
+	// 两条入口显式置 true(代表 IssuerAllowlist 已经过),其他路径(verify→confirm
+	// 绑定老用户)留 false —— 与 CreateUser 本身的语义对齐:不建用户的请求不该
+	// 表达"信任创建"语义。
+	TrustedSSOCreate bool
 }
 
 // IssueSessionResp 会话签发结果。LoginRespJSON 直接塞 ThirdAuthcode Redis,

--- a/modules/oidc/user_adapter.go
+++ b/modules/oidc/user_adapter.go
@@ -46,14 +46,15 @@ func (a *userAdapter) IssueSession(ctx context.Context, req IssueSessionReq) (*I
 		uid = util.GenerUUID()
 	}
 	extReq := user.ExternalLoginReq{
-		ExistingUID: req.UID, // 已有用户;CreateUser=true 时由 user 模块判空走创建
-		UID:         uid,
-		Name:        req.Name,
-		Email:       req.Email,
-		Phone:       req.Phone,
-		Zone:        req.Zone,
-		DeviceFlag:  config.DeviceFlag(req.DeviceFlag),
-		PublicIP:    req.PublicIP,
+		ExistingUID:      req.UID, // 已有用户;CreateUser=true 时由 user 模块判空走创建
+		UID:              uid,
+		Name:             req.Name,
+		Email:            req.Email,
+		Phone:            req.Phone,
+		Zone:             req.Zone,
+		DeviceFlag:       config.DeviceFlag(req.DeviceFlag),
+		PublicIP:         req.PublicIP,
+		TrustedSSOCreate: req.TrustedSSOCreate,
 	}
 	if req.CreateUser {
 		extReq.ExistingUID = ""

--- a/modules/user/external_login.go
+++ b/modules/user/external_login.go
@@ -48,6 +48,22 @@ type ExternalLoginReq struct {
 
 	// PublicIP 用于欢迎消息日志,可空
 	PublicIP string
+
+	// TrustedSSOCreate 调用方声明本次新建用户的身份已由可信 IdP 完成认证,
+	// 且已经过 oidc 模块的 IssuerAllowlist 准入校验(详见
+	// modules/oidc/bind_service.go BindService.Create 与
+	// modules/oidc/api.go callback `res.IsNew` 分支)。
+	//
+	// 置 true 时本方法**绕过** common.SystemSettings.RegisterOff() 全局开关:
+	// register.off=1 主要用于阻断公开 email/手机号注册入口与 GitHub/Gitee OAuth
+	// 自助建号通道,这两条通道的身份来源都是不受 dmwork 控制的外部输入。
+	// OIDC 通道在本 PR 后由 DM_OIDC_PROVIDER_ALLOW_NEW_USER 与
+	// OCTO_OIDC_BIND_ALLOW_CREATE 独立控制(IssuerAllowlist 兜底),
+	// 语义上属于"可信 IdP 授权创建",不应受 register.off 影响。
+	//
+	// 仅 OIDC 模块在 callback `res.IsNew=true` / `/bind/create` 路径上置 true;
+	// 其他外部 IdP(GitHub / Gitee 等)留 false,保留原有 register.off 守护。
+	TrustedSSOCreate bool
 }
 
 // DeviceInfo 登录设备信息（外部模块用,与内部 deviceReq 解耦）
@@ -128,7 +144,11 @@ func (u *User) externalLoginExisting(ctx context.Context, req ExternalLoginReq) 
 }
 
 func (u *User) externalLoginCreate(ctx context.Context, req ExternalLoginReq) (*ExternalLoginResp, error) {
-	if common.EnsureSystemSettings(u.ctx).RegisterOff() {
+	// TrustedSSOCreate 仅 OIDC 模块在通过 IssuerAllowlist + bind_token 显式同意
+	// 后置 true,代表"运维已通过 OIDC 配置授权该 IdP 自动建号",绕过
+	// register.off 全局开关。其他外部 IdP(GitHub/Gitee)与本地注册路径
+	// 不该走到这里。详见 ExternalLoginReq.TrustedSSOCreate godoc。
+	if !req.TrustedSSOCreate && common.EnsureSystemSettings(u.ctx).RegisterOff() {
 		return nil, errors.New("注册通道暂不开放")
 	}
 	if req.UID == "" {

--- a/modules/user/external_login_test.go
+++ b/modules/user/external_login_test.go
@@ -256,6 +256,36 @@ func TestService_LoginByExternalIdentity_CreateRequiresUID(t *testing.T) {
 	assert.Contains(t, err.Error(), "UID is required")
 }
 
+// TestService_LoginByExternalIdentity_TrustedSSOCreate_BypassesRegisterOff
+// 锚定 P0 fix:OIDC 模块通过 ExternalLoginReq.TrustedSSOCreate=true 声明
+// "已经过 IssuerAllowlist 信任校验" 后,external 建号路径必须绕过
+// register.off 全局开关。与下面 CreateBlockedByRegisterOff 配对覆盖
+// "默认 false 仍拒、显式 true 放行" 的语义对称。
+//
+// 与 CreateBlockedByRegisterOff 平行:这里只断言"register.off 守卫不再
+// 阻断"——错误信息中不应再出现"注册通道暂不开放"字面。下游 createUserWithRespAndTx
+// 路径在当前测试基础设施下仍有 OCTO 迁移 TODO(见 issue #17),所以不期望全程
+// 跑通,仅锚定守卫绕过的关键语义。register.off=1 部署下 OIDC 通道端到端跑通
+// 由 oidc 模块的集成测试承接(modules/oidc/api_bind_test.go)。
+func TestService_LoginByExternalIdentity_TrustedSSOCreate_BypassesRegisterOff(t *testing.T) {
+	u := setupExternalLoginTest(t)
+	setSystemSettingForUserTest(t, u.ctx, "register", "off", "1", "bool")
+	require.NoError(t, commonsettings.EnsureSystemSettings(u.ctx).Reload())
+
+	uid := util.GenerUUID()
+	_, err := u.userService.LoginByExternalIdentity(context.Background(), ExternalLoginReq{
+		UID:              uid,
+		Name:             "TrustedSSO",
+		Email:            "trusted.sso@example.com",
+		DeviceFlag:       config.APP,
+		TrustedSSOCreate: true,
+	})
+	if err != nil {
+		assert.NotContains(t, err.Error(), "注册通道暂不开放",
+			"TrustedSSOCreate=true must bypass RegisterOff (下游失败可接受,守卫被绕过是关键)")
+	}
+}
+
 func TestService_LoginByExternalIdentity_CreateBlockedByRegisterOff(t *testing.T) {
 	u := setupExternalLoginTest(t)
 	setSystemSettingForUserTest(t, u.ctx, "register", "off", "1", "bool")


### PR DESCRIPTION
## Summary

When OIDC autolink fails and the deployment has closed the local self-registration entry (SSO-only mode), users with no existing account had no way forward: the existing `/bind/verify/*` flow only supports binding to an **existing** account.

This PR adds `POST /bind/create`, letting a SSO-authenticated user create a fresh account directly from the `bind_token`'s frozen claims snapshot. The bind page's primary action becomes "create account from SSO identity"; verify-into-existing-account drops to a secondary link.

The new endpoint reuses the existing `AllowNewUser=true` code path (`users.IssueSession({CreateUser:true})`) while keeping **all** of #73's guardrails: `IssuerAllowlist`, single-consumption + 5min TTL on `bind_token`, audit events, and the startup mutex check against `Provider.AllowNewUser=true`.

## 🆕 Cross-module change (operator-visible)

This PR also touches **`modules/user/external_login.go`** to introduce a single new field on `ExternalLoginReq`:

```go
TrustedSSOCreate bool
```

When `true`, `User.externalLoginCreate` **bypasses** the global `common.EnsureSystemSettings(ctx).RegisterOff()` guard. The OIDC module sets it to `true` in exactly two places, both already gated by `IssuerAllowlist`:

- `BindService.Create` (new in this PR) — `/bind/create` self-service path
- `OIDC.callback` — the existing `res.IsNew=true` branch (`Provider.AllowNewUser=true` deployments)

### Operational semantics change

> After this PR, `register.off=true` **no longer blocks** account creation through the OIDC channel (either via `callback AllowNewUser=true` auto-create or via `/bind/create`). The OIDC channel is now independently gated by `DM_OIDC_PROVIDER_ALLOW_NEW_USER` and `OCTO_OIDC_BIND_ALLOW_CREATE`, with `IssuerAllowlist` as the trust anchor.
>
> GitHub / Gitee OAuth paths are **not affected** — they still respect `RegisterOff()`.
>
> **SOC note**: audits will continue to see new accounts created on `register.off=1` deployments — verify the source is the OIDC channel (`audit.event` ∈ {`callback_ok` with `is_new=true`, `bind_created`}).

### Why this is correct

`register.off` was originally a knob for closing the **public** registration entry (email/phone signup form, GitHub/Gitee OAuth). Its purpose was to prevent uncontrolled account growth from unauthenticated external traffic.

OIDC self-service creation is a fundamentally different trust model — and there are **two distinct trust chains** in this PR, one per path:

**`/bind/create` path** (multi-issuer self-service):

1. **`IssuerAllowlist`** — only IdPs whose URL is explicitly listed by the operator can trigger a `bind_token`. Empty allowlist = deny-all (PR #73 invariant, retained).
2. **Bind token** — single-consumption, 5min TTL, opaque 32-byte random; cannot be forged, replayed, or carried across IdPs.
3. `OCTO_OIDC_BIND_ENABLED` + `OCTO_OIDC_BIND_ALLOW_CREATE` are independent, opt-in switches.
4. Defense-in-depth: `issuerAllowedForCreate` re-checks the allowlist inside `Create` (covers the 5-min TTL window where an issuer could be removed post-Issue).

**`callback res.IsNew=true` path** (single primary IdP, auto-create on first login):

1. **Signature-verified `Provider.Issuer`** — `o.client.VerifyIDToken` validates the id_token against keys discovered from the **configured `Provider.Issuer`**, so `claims.Issuer == Provider.Issuer` is structurally guaranteed before any auto-create can run. This is the implicit "size-1 issuer allowlist" for the callback path.
2. **`Provider.AllowNewUser=true`** — `Service.ResolveOrLink` only returns `IsNew=true` when the operator has explicitly set `DM_OIDC_PROVIDER_ALLOW_NEW_USER=true`.

Note: `IssuerAllowlist` is the **bind flow's** multi-issuer allowlist; it intentionally does **not** apply to the callback auto-create path, which has its own single-primary-IdP trust model. Both chains terminate in "operator explicitly authorised account creation through this OIDC channel", which is the trust statement `TrustedSSOCreate=true` makes to the user module.

### Symmetry with existing `AllowNewUser` path

The `callback` auto-create branch (`Provider.AllowNewUser=true && IsNew=true`) had the same cross-module concern silently before this PR: a deployment running `register.off=1 && DM_OIDC_PROVIDER_ALLOW_NEW_USER=true` would have its OIDC logins fail at `externalLoginCreate`'s `RegisterOff()` check, with no audit trail of *why*. This PR fixes that latent inconsistency in the same change so both OIDC creation paths have identical semantics.

## API

### `POST /v1/auth/oidc/aegis/bind/create` 💚 new

Mounted only when `OCTO_OIDC_BIND_ALLOW_CREATE=true` (default). No `Auth` middleware — `bind_token` itself is the single-consumption auth credential (SR-1).

**Request**

```json
{
  "token": "<bind_token jti, 43-char base64>"
}
```

**Response 200**

```json
{
  "status": "ok",
  "login_resp": "<opaque LoginRespJSON from user.IService>",
  "uid": "<local user id of newly created account>"
}
```

Side effects: `oidc_user_identity` row inserted, `bind_token` consumed (single-use), `ThirdAuthcode` populated for cross-device pickup, `EventBindCreated` audit row written.

**Error codes**

| HTTP | Body `msg` | Sentinel | Meaning |
|---|---|---|---|
| 400 | `token required` | — | Missing token, malformed JSON, or token fails `authcodeRe` regex |
| 401 | `invalid credentials` | `ErrBindAuthRejected` | Issuer was removed from `IssuerAllowlist` between Issue and Create (defense-in-depth) |
| 409 | `token status conflict` | `ErrBindStatusConflict` | Token is past `issued` (concurrent verify/create has it, or this same token was already used for create) |
| 409 | `identity already bound; sign in via OIDC to continue` | `ErrBindAlreadyBound` | Concurrent `/bind/create` for same `(issuer, sub)` raced; this caller lost the unique-key race |
| 409 | `account conflict needs manual resolution` 💚 new | `ErrBindCreateConflictNeedManual` | `bind_token` was issued from a `manual_conflict` source (claims matched multiple dmwork accounts); self-service create is rejected — operator-assisted merge required |
| 410 | `token expired or not found` | `ErrBindNotFound` | `bind_token` past 5min TTL or never issued |
| 422 | `claims missing required fields` | `ErrBindCreateClaimsIncomplete` | Claims have neither a verified email nor a usable verified phone (see "Claims requirement" below) |
| 429 | `too many create attempts` | `ErrBindRateLimited` | Per-token create count (hardcoded max=1) exceeded |
| 500 | `internal error` | — | DB / Redis / IssueSession failure |
| 503 | `bind service not ready` | — | `o.bind == nil` (Discovery failure during Init) |

Metric label additions on `oidc_bind_request_total`: `conflict_need_manual` (mirrors the 409 above).

### `GET /v1/auth/oidc/aegis/bind/info` (extended)

Two new fields on the existing response:

```diff
 {
   "masked_email": "a***@example.com",
   "masked_phone": "***1234",
   "name": "Alice",
   "methods": ["password", "sms_otp"],
   "support_contact": "ops@example.com",
+  "allow_create": true,
+  "create_blocked": ""
 }
```

| Field | Type | Values | Meaning |
|---|---|---|---|
| `allow_create` | `bool` | `true` / `false` | Whether `OCTO_OIDC_BIND_ALLOW_CREATE` is enabled |
| `create_blocked` | `string` (always serialised) | `""` / `"disabled"` / `"claims_incomplete"` / `"manual_conflict"` 💚 / `"consumed"` 💚 | Why the create button should be inactive — empty string means it's clickable. Field is **always present** (no `omitempty`); FE can branch on the string value without separate "missing vs empty" cases. |

**Precedence (highest → lowest)**: `disabled` > `claims_incomplete` > `manual_conflict` > `consumed`.

- `disabled` — `OCTO_OIDC_BIND_ALLOW_CREATE=false`.
- `claims_incomplete` — Claims have neither a verified email nor a usable verified phone.
- `manual_conflict` 💚 — Token was issued from a `manual_conflict` source. Self-service create is forbidden because the user already has multiple matching dmwork accounts; surface the "contact support" path instead.
- `consumed` 💚 — Token has been advanced past `issued` (verify/create already happened). `/bind/create` will deterministically fail with `ErrBindStatusConflict`; surface "re-initiate OIDC login" to the user rather than letting them tap a button that 429s.

Front end displays the primary `[Create from SSO]` button only when `allow_create=true && create_blocked==""`. Otherwise either hide the button (`disabled`) or render it disabled with the appropriate explanation.

## Flow

```mermaid
sequenceDiagram
    autonumber
    actor U as User
    participant FE as Bind Page
    participant API as POST /bind/create
    participant SVC as BindService.Create
    participant ST as Redis BindStore
    participant US as user.IService
    participant ID as oidc_user_identity

    Note over U,FE: bind page offers two actions<br/>primary [Create from SSO]<br/>secondary [I have an account, verify]

    U->>FE: click Create from SSO
    FE->>API: POST token
    API->>SVC: Create ctx token

    SVC->>ST: Get token
    ST-->>SVC: session status=issued, claims, sd, issue_reason

    SVC->>ST: IncrAndCheck bind:create:jti, max=1
    Note right of SVC: counter then status — same order as Confirm<br/>any retry burns budget incl status probes

    SVC->>SVC: reject if issue_reason == manual_conflict
    Note right of SVC: 💚 new: P2-1 guard

    SVC->>SVC: decode + checkClaimsForCreate (read-only)
    SVC->>SVC: issuerAllowedForCreate (defense-in-depth)
    Note right of SVC: 💚 new: P2-3 — operator-removed issuers<br/>cannot exploit a 5min TTL window

    SVC->>ST: CASSave issued to creating
    Note right of ST: LOCK — only the winning goroutine<br/>proceeds to side effects<br/>concurrent verify/create collide here

    SVC->>US: IssueSession CreateUser=true, TrustedSSOCreate=true, claims
    Note right of US: 💚 new: TrustedSSOCreate bypasses<br/>register.off in user module<br/>(see Cross-module change above)
    US-->>SVC: uid, LoginRespJSON

    SVC->>ID: Insert uid, issuer, sub
    Note right of ID: uk_issuer_subject guards concurrent create<br/>on different tokens for same issuer+sub<br/>loser gets ErrBindAlreadyBound

    SVC->>ST: Consume token
    Note right of ST: terminal — token row deleted<br/>subsequent Get returns ErrBindNotFound

    SVC-->>API: LoginRespJSON, uid, sd
    API->>API: writeAudit EventBindCreated
    API->>API: ThirdAuthcode backfill (FR-6.3)
    API-->>FE: 200 login_resp, uid
    FE->>U: signed in
```

## State machine

```mermaid
stateDiagram-v2
    [*] --> issued: callback IssueWithReason(bind_token, reason)

    issued --> verified: VerifyPassword / VerifySMS ok
    verified --> verified: Confirm fail (retry until ConfirmMax)
    verified --> [*]: Confirm ok → Consume

    issued --> creating: CAS lock for create  💚 new
    creating --> [*]: IssueSession + Insert + Consume  💚 new
    creating --> creating: mid-flight failure → TTL cleans up  💚 new

    issued --> refused: rate-limited / abandoned
    refused --> [*]: TTL

    note right of creating
      Intermediate lock prevents ghost users.
      Side effects (IssueSession, identity.Insert)
      only run after the CAS issued→creating
      succeeds. A failed Create leaves the
      token stuck at "creating" until TTL —
      same jti cannot retry, so no second
      ghost user. User must re-run OIDC to
      obtain a fresh bind_token.
    end note
```

Each `BindSession` now also carries an `issue_reason` field (`unknown_user` | `manual_conflict`) frozen at Issue time. `Create` rejects `manual_conflict` tokens; `Info` surfaces it as `create_blocked="manual_conflict"`.

## Concurrency model (why the `creating` intermediate lock)

The first implementation tried `IssueSession → identity.Insert → CAS(issued→created) → Consume`. That ordering let side effects (account creation, identity row) land **before** the terminal CAS. Concurrent verify, concurrent create, or a slow request near TTL expiry would all let the CAS fail after the account already existed — producing ghost users with no associated session response.

The fix is the standard "lock before side effects" pattern:

1. **Read-only validation first** (decode claims, `checkClaimsForCreate`, `issuerAllowedForCreate`, `issue_reason` check) — fail-fast without touching state, so a 4xx keeps the token usable for an unrelated retry.
2. **`CASSave issued → creating`** — this is the **only** mutex point. Whoever wins owns the side-effect phase; everyone else gets `ErrBindStatusConflict` or `ErrBindNotFound`.
3. **Side effects**: `IssueSession` + `identity.Insert`.
4. **`Consume`** — terminal action; the token row is deleted, subsequent `Get` returns `ErrBindNotFound`.

Failure modes after step 2:

| Step | Outcome | Token end-state |
|---|---|---|
| 3 (`IssueSession`) fails | Wrapped error; **no** ghost user | Locked at `creating`; TTL cleans up |
| 4 (`identity.Insert`) — duplicate-key race | `ErrBindAlreadyBound` → 409 | Locked at `creating`; client re-initiates OIDC to pick up winner's session |
| 4 (`identity.Insert`) — other error | Wrapped error | Locked at `creating`; ghost user possible (same severity as Confirm's analogous case) |
| 5 (`Consume`) fails | Logged, success returned to client | Token TTLs out naturally |

The deliberate consequence: **a Create that fails mid-flight cannot be retried on the same `bind_token`**. This is required to prevent "retry creates a second ghost user". Users must re-run the OIDC flow to obtain a fresh `bind_token` — acceptable for what should be a rare failure path.

## Claims requirement

`checkClaimsForCreate` accepts the claims only if **at least one of**:

- `email != "" && email_verified == true`, OR
- `phone_verified == true && extractPhone(phone_number) != ""`

`extractPhone` is the existing helper in `service.go`, which currently recognises only `+86` numbers. A verified `+1415…` phone with no email would otherwise pass a naive `phone != ""` check but get silently dropped to empty `Phone`/`Zone` inside `IssueSession`, creating an account with no usable contact anchor. The gate uses `extractPhone` so "format unsupported" surfaces as a 422 rather than a half-built account.

## Configuration

Only **one** new env:

| Env | Default | Purpose |
|---|---|---|
| `OCTO_OIDC_BIND_ALLOW_CREATE` | `true` | Mount the endpoint; `/bind/info` returns `allow_create=false` when off |

**Hardcoded (not configurable)**:

- `bindCreateMax = 1` — `/bind/create` is a terminal one-shot operation. Failure modes (claims incomplete, status conflict, already bound, manual_conflict) are deterministic; retrying cannot make them succeed. Transient errors leave the token in `creating` and cannot be retried regardless. Operators who want stricter gating should disable `AllowCreate` entirely and rely on `/bind/verify/*`.
- **Claims requirement: at least one verified email or usable verified phone**. Other shapes (email-only, phone-only, both-required) were considered but not driven by real customer requirements; `email_or_phone` covers ≥95% of IdPs.
- **Startup mutex**: `Bind.Enabled=true && Provider.AllowNewUser=true` → panic. This is **#73's pre-existing invariant** (callback auto-create path and bind flow cannot coexist); this PR does **not** introduce a new mutex.

## Decisions worth surfacing

| # | Decision | Rationale |
|---|---|---|
| D1 | New endpoint, not a flag on `/bind/confirm` | Clean metric / audit labels; mirror confirm's handler shape for reviewability. |
| D2 | Same token may switch `verify ↔ create` (independent counters) before either commits | User UX: "thought I had an account → typed wrong password → realised I don't → click create". |
| D3 | Intermediate `creating` lock; `Consume` is terminal (no `created` end-state in Redis) | Mirrors `Confirm`'s lifecycle (Consume = terminal). Avoids the ghost-user window described above. `BindStatus` lives only in Redis with 5min TTL, no DB schema change. |
| D4 | Identity-insert race → service returns `ErrBindAlreadyBound`; handler returns 409 with "re-initiate OIDC login" guidance | Ghost-user cleanup deferred to backend reconciliation (consistent with #73's policy). |
| D5 💚 | `TrustedSSOCreate` flag on `ExternalLoginReq` — OIDC declares trust on a per-call basis; user module delegates the "is creation authorised?" decision to the OIDC trust chain (`IssuerAllowlist` + `bind_token`). Only OIDC paths set it; GitHub / Gitee remain on `RegisterOff()` semantics. | A single explicit boolean is cleaner than overloading `register.off` with per-channel exemptions or adding a parallel `register_off_for_sso` setting. The trust chain that justifies the bypass lives entirely inside `modules/oidc`; declaring trust at the call site makes that boundary auditable in `git grep TrustedSSOCreate`. |
| D6 💚 | `BindSession.IssueReason` (`unknown_user` / `manual_conflict`) frozen at Issue time | Reviewer requirement (P2-1). `manual_conflict` tokens identify users who already have multiple dmwork accounts — letting them self-create would compound the data hygiene problem. The reason is decided once at callback time (by `errors.Is(err, ErrConflictNeedManual)`) and observed by both `Create` (reject) and `Info` (surface `manual_conflict` to UI). |
| D7 💚 | `issuerAllowedForCreate` defense-in-depth gate inside `Create` | Reviewer requirement (P2-3). `ShouldHandle` already checks the allowlist at callback time, but a 5min `bind_token` TTL is a window where ops can remove an issuer; this final check ensures any post-Issue allowlist edit takes effect on the create path. Scoped to `Create` only (other endpoints are user-initiated verify actions against an already-trusted IdP). |

## Files changed

| File | Δ | What |
|---|---|---|
| `modules/user/external_login.go` 🆕 | +22 / -1 | `TrustedSSOCreate` field on `ExternalLoginReq`; `externalLoginCreate` bypasses `RegisterOff()` when set |
| `modules/user/external_login_test.go` 🆕 | +30 | `TrustedSSOCreate_BypassesRegisterOff` paired with existing `CreateBlockedByRegisterOff` |
| `modules/oidc/bind_config.go` | +14 / -2 | `AllowCreate` field + loader; `bindCreateMax` const |
| `modules/oidc/bind_model.go` | +30 / -3 | `BindStatusCreating`, `IssueReason` type + `BindReasonUnknownUser` / `BindReasonManualConflict` consts, `BindSession.IssueReason` field |
| `modules/oidc/bind_service.go` | +200 / -10 | `Create`, `casLockForCreate`, `checkClaimsForCreate`, `issuerAllowedForCreate`, `IssueWithReason`, `Info` extension (precedence + new blocked reasons) |
| `modules/oidc/bind_store.go` | +12 | `ErrBindCreateClaimsIncomplete`, `ErrBindCreateConflictNeedManual` sentinels |
| `modules/oidc/api.go` | +15 / -3 | callback issues bind_token with explicit reason; `res.IsNew` branch sets `TrustedSSOCreate=true` for symmetry with `/bind/create` |
| `modules/oidc/api_bind.go` | +112 | `bindCreate` handler, `handleBindCreateErr` (incl. `conflict_need_manual` 409), route mounting, `bindResultFromErr` labels |
| `modules/oidc/service.go` | +9 | `IssueSessionReq.TrustedSSOCreate` field |
| `modules/oidc/user_adapter.go` | +1 | passthrough of `TrustedSSOCreate` to `user.ExternalLoginReq` |
| `modules/oidc/metrics.go` | +6 / -4 | `bindEndpointLabels` += `"create"`; `bindResultLabels` += `"conflict_need_manual"` + `"claims_incomplete"` (Round-2) |
| `modules/oidc/model.go` | +32 | `EventBindCreated` / `EventBindCreateFail` |
| `modules/oidc/*_test.go` | +1020 | All new tests (config, validator, service matrix, handler matrix, concurrent race, Info precedence, manual_conflict, issuer allowlist, non-CN-phone regression, TrustedSSOCreate bypass) |

**Reviewer note**: this PR modifies **two modules** (`user` + `oidc`). Cross-module review is required — pay particular attention to `modules/user/external_login.go` changes and their operational-semantics implication (see "Cross-module change" above).

## Test plan

- [x] Unit + integration tests pass:
      `docker exec octo-test-mysql mysql -uroot -pdemo -e 'DROP DATABASE IF EXISTS test; CREATE DATABASE test ...' && go test -race -short ./modules/oidc/...` → all green (~16s)
      same reset + `go test -race -short ./modules/user/...` → all green (~32s)
- [x] `go vet ./...` clean
- [x] `gofmt` clean on all touched files
- [x] Concurrent `Create` on same token: only one succeeds, others get `ErrBindStatusConflict` / `ErrBindNotFound` / `ErrBindRateLimited` (all valid losing outcomes; the CAS lock prevents simultaneous side effects)
- [x] Concurrent `Create` on **different** tokens for the same `(issuer, sub)`: identity unique-key races correctly; loser gets `ErrBindAlreadyBound`
- [x] `Create` failure leaves token at `creating` (T16 / T23 assertions) — same `bind_token` cannot create a second account
- [x] Startup panics on `Bind.Enabled=true && Provider.AllowNewUser=true` (pre-existing #73 invariant retained)
- [x] Per-token create counter isolated from verify counter
- [x] Non-`+86` verified phone with no email → 422 (regression test)
- [x] 💚 `manual_conflict`-sourced bind_token → `/bind/create` returns 409 `ErrBindCreateConflictNeedManual`; `/bind/info` reports `create_blocked="manual_conflict"` (token side-effects suppressed)
- [x] 💚 Issuer removed from `IssuerAllowlist` between Issue and Create → `/bind/create` returns 401 `ErrBindAuthRejected`; no side effects
- [x] 💚 Token advanced past `issued` (verified state) → `/bind/info` reports `create_blocked="consumed"`
- [x] 💚 `Info.create_blocked` precedence: `disabled > claims_incomplete > manual_conflict > consumed` (sub-test table)
- [x] 💚 `register.off=1` deployment: `TrustedSSOCreate=true` bypasses the global guard (paired with the existing `CreateBlockedByRegisterOff` test where `TrustedSSOCreate=false` is still rejected)
- [ ] End-to-end on a `register.off=1` deployment: `/bind/create` returns 200 and the user is persisted (deferred to staging — local infra parity captured in unit tests above)
- [ ] End-to-end on a `register.off=1` deployment: `callback AllowNewUser=true` auto-creates (deferred to staging)
- [ ] Confirm GitHub/Gitee OAuth on `register.off=1` is **still rejected** (no behavioural change expected — `TrustedSSOCreate` defaults to `false` so the existing path is untouched; covered by `CreateBlockedByRegisterOff`)
- [ ] Frontend bind page update (separate PR): primary "Create account" button + reading `info.allow_create` / `info.create_blocked` (new values: `manual_conflict`, `consumed`)
- [ ] Production rollout: monitor `oidc_bind_request_total{endpoint="create"}` distribution incl. new `conflict_need_manual` label

## Round-2 follow-ups (post-Jerry-Xin re-review, commit TBD)

Addressed in the same branch as a follow-up commit on top of `6250d36e`:

- **api.go callback comment** — corrected to describe the **actual** trust chain for the callback `res.IsNew=true` path (signature-verified `Provider.Issuer` + `Provider.AllowNewUser=true`), instead of citing `IssuerAllowlist` (which is the bind flow's chain, not the callback's). No code-behaviour change; the gating was always sound — the prior comment was misleading. See updated "Why this is correct" section above.
- **`metrics.go` prewarm** — `bindEndpointLabels()` now includes `"create"`; `bindResultLabels()` adds `"conflict_need_manual"` and `"claims_incomplete"`. Grafana zero-series tracking covers the new endpoint/result combinations from first deploy (60 prewarmed series, up from 35).
- **`BindInfoResp.CreateBlocked`** — `omitempty` removed; the field is always serialised, matching the doc contract above.

## Out of scope

- Frontend changes (separate PR)
- Letting the user edit email / phone before create (must use claims values; profile edit happens post-login)
- `created_via` user-table column or other account-source tracking (audit log already distinguishes)
- Ghost-user cleanup after identity-insert race (intentional; deferred to backend reconciliation)
- Refactoring `AllowNewUser` + `AllowCreate` into a single tri-state enum (deferred to v2)
- Broader phone-number support beyond `+86` (gated by `extractPhone`'s scope; out of scope here)
- **GitHub / Gitee OAuth `RegisterOff` bypass** — these OAuth flows have a different trust model (no `IssuerAllowlist`, no explicit `bind_token` consent), so they intentionally remain under `RegisterOff()` control
- **Operational migration guide for `register.off=1` deployments using OIDC** — to be handled by product / runbook documentation, not this PR
