### PR TITLE
feat(mention): three-state server rewrite (humans/ais/all)

### DIFF
--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
 	"github.com/gocraft/dbr/v2"
 	"go.uber.org/zap"
 )
@@ -122,6 +123,17 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 	if req.ChannelType == common.ChannelTypePerson.Uint8() {
 		payload = ba.enrichBotPayloadWithSpaceID(c, robotID, payload)
 	}
+
+	// YUJ-202 / Mininglamp-OSS#94 — mention three-state rewrite. Same
+	// chokepoint contract as modules/message/api.go: legacy
+	// `mention.all=1` is normalized to also carry `mention.humans=1`
+	// (outbound double-write keeps `all=1` for old read-side clients).
+	// ⚠️ F2 (PR#70 Jerry-Xin correctness-critical review): this MUST
+	// be placed OUTSIDE the `ChannelTypePerson` conditional above —
+	// otherwise group / community-topic `@所有人` traffic (the main
+	// pain-point being fixed) would bypass the rewrite. Helper is
+	// idempotent and safe on nil — see pkg/mentionrewrite.
+	payload = mentionrewrite.RewriteMention(payload)
 
 	// YUJ-1166 fan-out loop guard #3: mark this message so the fan-out
 	// listener (see obo_fanout.go) skips it on the way back through the

--- a/modules/bot_api/send_test.go
+++ b/modules/bot_api/send_test.go
@@ -300,3 +300,165 @@ func TestSendMessage_PersonalDM_DBError_ForgedClientSpaceID_Stripped(t *testing.
 	assert.False(t, hasSpaceID,
 		"DB error + forged client space_id MUST be stripped from dispatched payload — attackers cannot use transient DB failure to bypass authoritative override")
 }
+
+// TestSendMessage_MentionAllRewritten_HandlerIntegration is the YUJ-1343 /
+// Mininglamp-OSS/octo-server#94 acceptance test for the mention three-state
+// rewrite on the /v1/bot/sendMessage handler path.
+//
+// This is the "handler-level integration test" the issue calls out: drive
+// BotAPI.sendMessage end-to-end with a `payload.mention.all=1` body and
+// assert the captured MsgSendReq carries `mention.humans=1` (chokepoint
+// rewrite ran) AND still carries `mention.all=1` (outbound double-write
+// preserved for legacy read-side clients). Lesson from PR#82 OBO fan-out:
+// when an external-service shape constraint matters, the test MUST go
+// through the real handler stack — not call the helper in isolation —
+// otherwise a wiring regression (e.g. someone deletes the call site by
+// mistake) slips past unit coverage.
+//
+// Uses the existing creator-DM path (BotKindUser whose CreatorUID ==
+// channel_id) so the test does not need a live IsFriend / group_member
+// table. The rewrite call site itself is placed OUTSIDE the
+// `ChannelTypePerson` conditional (F2 — see modules/bot_api/send.go), so
+// even though this test drives a DM, the helper still runs; the same
+// helper would run on the group / community-topic path by inspection.
+func TestSendMessage_MentionAllRewritten_HandlerIntegration(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		botRobotID = "bot_mention_rewrite_it"
+		creatorUID = "user_creator_mention_it"
+	)
+
+	dc := &dispatchCapture{}
+	q := &fakeSpaceQuerier{defaultSpace: "space_A"}
+
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-mention-it"),
+		spaceQuerier:     q,
+		dispatchOverride: dc.hook,
+	}
+
+	body, _ := json.Marshal(BotSendMessageReq{
+		ChannelID:   creatorUID,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Payload: map[string]interface{}{
+			"type":    1,
+			"content": "@所有人 ping",
+			// Legacy @所有人 inbound — chokepoint MUST rewrite this.
+			"mention": map[string]interface{}{
+				"all": 1,
+			},
+		},
+	})
+
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/bot/sendMessage", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httpReq
+	c := &wkhttp.Context{Context: gc}
+	c.Set(CtxKeyRobotID, botRobotID)
+	c.Set(CtxKeyBotKind, BotKindUser)
+	c.Set(CtxKeyRobot, &robotModel{RobotID: botRobotID, CreatorUID: creatorUID})
+
+	ba.sendMessage(c)
+
+	assert.Equalf(t, http.StatusOK, rec.Code,
+		"sendMessage should respond 200 OK, got %d body=%s", rec.Code, rec.Body.String())
+
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	if !assert.NotNil(t, dc.captured, "dispatch hook must have been invoked") {
+		return
+	}
+
+	var dispatchedPayload map[string]interface{}
+	dec := json.NewDecoder(bytes.NewReader(dc.captured.Payload))
+	dec.UseNumber()
+	if !assert.NoError(t, dec.Decode(&dispatchedPayload)) {
+		return
+	}
+	mention, ok := dispatchedPayload["mention"].(map[string]interface{})
+	if !assert.True(t, ok, "dispatched payload must keep mention map; got %T", dispatchedPayload["mention"]) {
+		return
+	}
+	// Chokepoint rewrite ran — humans=1 is now present.
+	humans, _ := mention["humans"].(json.Number)
+	assert.Equal(t, "1", humans.String(),
+		"BotAPI.sendMessage must invoke mentionrewrite.RewriteMention so mention.humans=1 reaches the dispatcher")
+	// Outbound double-write — legacy all=1 still present so old read-side
+	// clients keep rendering the @所有人 pill until they roll out support
+	// for the humans/ais fields.
+	all, _ := mention["all"].(json.Number)
+	assert.Equal(t, "1", all.String(),
+		"legacy mention.all=1 MUST be preserved on the dispatched payload (outbound double-write)")
+	// ais MUST stay absent — Yu D1: legacy @所有人 must NOT auto-fan-out
+	// to bots (the exact pain point the rewrite is closing).
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAIs,
+		"BotAPI.sendMessage rewrite must NOT auto-set mention.ais — would re-trigger the bot fan-out pain point")
+}
+
+// TestSendMessage_MentionAisPassthrough_HandlerIntegration verifies the
+// other end of the matrix: an explicit `mention.ais=1` from a new client
+// passes through the chokepoint untouched (the rewrite is a one-way
+// "all → also humans" rule, never adds humans/ais from thin air).
+func TestSendMessage_MentionAisPassthrough_HandlerIntegration(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		botRobotID = "bot_ais_it"
+		creatorUID = "user_creator_ais_it"
+	)
+
+	dc := &dispatchCapture{}
+	q := &fakeSpaceQuerier{defaultSpace: "space_A"}
+
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-ais-it"),
+		spaceQuerier:     q,
+		dispatchOverride: dc.hook,
+	}
+
+	body, _ := json.Marshal(BotSendMessageReq{
+		ChannelID:   creatorUID,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Payload: map[string]interface{}{
+			"type":    1,
+			"content": "@所有 AI ping",
+			"mention": map[string]interface{}{
+				"ais": 1,
+			},
+		},
+	})
+
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/bot/sendMessage", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httpReq
+	c := &wkhttp.Context{Context: gc}
+	c.Set(CtxKeyRobotID, botRobotID)
+	c.Set(CtxKeyBotKind, BotKindUser)
+	c.Set(CtxKeyRobot, &robotModel{RobotID: botRobotID, CreatorUID: creatorUID})
+
+	ba.sendMessage(c)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	if !assert.NotNil(t, dc.captured) {
+		return
+	}
+	var dispatchedPayload map[string]interface{}
+	dec := json.NewDecoder(bytes.NewReader(dc.captured.Payload))
+	dec.UseNumber()
+	assert.NoError(t, dec.Decode(&dispatchedPayload))
+	mention := dispatchedPayload["mention"].(map[string]interface{})
+	ais, _ := mention["ais"].(json.Number)
+	assert.Equal(t, "1", ais.String(), "ais=1 must passthrough")
+	_, hasHumans := mention["humans"]
+	assert.False(t, hasHumans, "ais-only input must NOT gain humans=1")
+	_, hasAll := mention["all"]
+	assert.False(t, hasAll, "ais-only input must NOT gain legacy all=1")
+}

--- a/modules/bot_api/send_test.go
+++ b/modules/bot_api/send_test.go
@@ -59,9 +59,9 @@ func TestSendMessage_PersonalDM_StripsForgedClientSpaceID(t *testing.T) {
 
 	const (
 		botRobotID    = "bot_X"
-		creatorUID    = "user_creator"      // == channel_id, exercises creator-bypass branch
-		authoritative = "space_A"           // returned by stubbed querySpaceIDByRobotID
-		forged        = "space_B_attacker"  // attacker-supplied value in payload
+		creatorUID    = "user_creator"     // == channel_id, exercises creator-bypass branch
+		authoritative = "space_A"          // returned by stubbed querySpaceIDByRobotID
+		forged        = "space_B_attacker" // attacker-supplied value in payload
 	)
 
 	dc := &dispatchCapture{}

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -223,6 +223,13 @@ type Message struct {
 	groupDB  *group.DB
 	mutex    sync.Mutex
 	stopChan chan struct{}
+	// reminderSeqOverride lets unit tests stub the version generator
+	// used by getReminders / cancelMentionReminderIfNeed so the helpers
+	// can be exercised without standing up the seq table / MySQL.
+	// Production path: nil → ctx.GenSeq(common.RemindersKey) runs.
+	// Tests inject a deterministic counter so the matrix tests in
+	// api_reminders_test.go don't need a live DB. See nextReminderSeq.
+	reminderSeqOverride func() (int64, error)
 }
 
 // New New
@@ -445,6 +452,17 @@ func (m *Message) sendMessage(channelID string, channelType uint8, fromUID strin
 	// BEFORE persistence/dispatch. See sanitizeUserIngressPayload below
 	// for the full rationale and unit test surface.
 	sanitizeUserIngressPayload(payload, channelID, channelType, fromUID, m.Warn)
+	// YUJ-202 / Mininglamp-OSS#94 — mention three-state rewrite
+	// (方案 X step §5 of docs/2026-05-mention-all-chokepoint-audit.md).
+	// Legacy clients still send `mention.all=1` for "@所有人"; the
+	// chokepoint normalizes that to also carry `mention.humans=1` so
+	// new read-side adapters can render the pill, AND keeps `all=1` in
+	// place as an outbound double-write for old read-side clients that
+	// only understand `all`. ais is left untouched (Yu D1 — legacy
+	// "@所有人" must NOT auto-trigger ais=1). Helper is idempotent and
+	// safe on nil / malformed mention shapes — see
+	// pkg/mentionrewrite/rewrite.go for the contract.
+	payload = RewriteMention(payload)
 	// YUJ-219-A / GH#1283 (analysis-report.md §4.5 / §7.4)：
 	// 派发前为消息 payload 注入权威 space_id，让客户端 SpaceFilter 拿到可信字段，
 	// race 窗口的 fail-open 语义可降级为 fail-closed。

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -224,11 +224,17 @@ type Message struct {
 	mutex    sync.Mutex
 	stopChan chan struct{}
 	// reminderSeqOverride lets unit tests stub the version generator
-	// used by getReminders / cancelMentionReminderIfNeed so the helpers
-	// can be exercised without standing up the seq table / MySQL.
-	// Production path: nil → ctx.GenSeq(common.RemindersKey) runs.
-	// Tests inject a deterministic counter so the matrix tests in
+	// used by getReminders so the matrix helpers can run without
+	// standing up the seq table / MySQL. Production path: nil →
+	// ctx.GenSeq(common.RemindersKey) runs. Tests inject a
+	// deterministic counter so the matrix tests in
 	// api_reminders_test.go don't need a live DB. See nextReminderSeq.
+	//
+	// Scope: getReminders + reminderDone only (everything wired through
+	// nextReminderSeq). cancelMentionReminderIfNeed and other in-tree
+	// callers still call ctx.GenSeq directly — those paths are not
+	// exercised by the matrix suite, so widening the seam there is
+	// deliberately deferred to keep the diff minimal.
 	reminderSeqOverride func() (int64, error)
 }
 

--- a/modules/message/api_reminders.go
+++ b/modules/message/api_reminders.go
@@ -2,18 +2,18 @@ package message
 
 import (
 	"encoding/json"
-	"os"
-	"runtime/debug"
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"runtime/debug"
 	"time"
 
-	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"go.uber.org/zap"
 )
 

--- a/modules/message/api_reminders.go
+++ b/modules/message/api_reminders.go
@@ -49,7 +49,7 @@ func (m *Message) reminderDone(c *wkhttp.Context) {
 		return
 	}
 	for _, id := range ids {
-		version, err := m.ctx.GenSeq(common.RemindersKey)
+		version, err := m.nextReminderSeq()
 		if err != nil {
 			c.ResponseError(err)
 			return
@@ -143,6 +143,20 @@ func (m *Message) listenerMessages(messages []*config.MessageResp) {
 
 }
 
+// nextReminderSeq returns the next monotonically increasing version
+// number used to seed remindersModel.Version. Production path delegates
+// to ctx.GenSeq(common.RemindersKey) (backed by the seq table); unit
+// tests inject reminderSeqOverride to skip the DB and exercise the
+// fan-out / matrix helpers in isolation. Keeping this seam local to
+// the reminders module avoids leaking the stub through Message's
+// exported surface.
+func (m *Message) nextReminderSeq() (int64, error) {
+	if m.reminderSeqOverride != nil {
+		return m.reminderSeqOverride()
+	}
+	return m.ctx.GenSeq(common.RemindersKey)
+}
+
 func (m *Message) getReminders(messages []*config.MessageResp) []*remindersModel {
 	reminders := make([]*remindersModel, 0, len(messages))
 	for _, message := range messages {
@@ -157,7 +171,7 @@ func (m *Message) getReminders(messages []*config.MessageResp) []*remindersModel
 		if m.hasMention(payloadMap) {
 			all, uids := m.getMention(payloadMap)
 			if all {
-				version, err := m.ctx.GenSeq(common.RemindersKey)
+				version, err := m.nextReminderSeq()
 				if err != nil {
 					m.Warn("GenSeq failed", zap.Error(err))
 					continue
@@ -176,7 +190,7 @@ func (m *Message) getReminders(messages []*config.MessageResp) []*remindersModel
 				})
 			} else if len(uids) > 0 {
 				for _, uid := range uids {
-					version, err := m.ctx.GenSeq(common.RemindersKey)
+					version, err := m.nextReminderSeq()
 					if err != nil {
 						m.Warn("GenSeq failed", zap.Error(err))
 						continue
@@ -209,7 +223,7 @@ func (m *Message) getReminders(messages []*config.MessageResp) []*remindersModel
 					if !ok {
 						continue
 					}
-					version, err := m.ctx.GenSeq(common.RemindersKey)
+					version, err := m.nextReminderSeq()
 					if err != nil {
 						m.Warn("GenSeq failed", zap.Error(err))
 						continue
@@ -285,13 +299,28 @@ func (m *Message) getMention(payloadMap map[string]interface{}) (all bool, uids 
 	if !ok {
 		return false, nil
 	}
-	if mentionMap["all"] != nil {
-		if allNum, ok := mentionMap["all"].(json.Number); ok {
-			allI, _ := allNum.Int64()
-			if allI == 1 {
-				all = true
-			}
-		}
+	// YUJ-202 / Mininglamp-OSS#94 — mention three-state read side. The
+	// chokepoint rewrite (pkg/mentionrewrite.RewriteMention) double-
+	// writes legacy `mention.all=1` into `mention.humans=1`, and a new
+	// client can also send `mention.ais=1` independently. Reminder
+	// fan-out treats ANY of {humans, ais, all} = 1 as a "broadcast"
+	// mention so the channel-level reminder is emitted. The per-role
+	// dispatch decision (humans-only / ais-only / both) lives client-
+	// side: new read-side adapters consult `humans` / `ais` to decide
+	// whether to render the red-dot; bots ignore `humans` and only
+	// react to `ais`. Reasoning matrix (RFC §6, Yu D1-D8):
+	//
+	//   humans=1                → human members see reminder, bots silent
+	//   ais=1                   → bot members see reminder, humans silent
+	//   humans=1 AND ais=1      → both render
+	//   all=1 (post-rewrite has humans=1 too) → humans only — legacy
+	//                              "@所有人" must NOT auto-fan-out to
+	//                              bots (the pain point being fixed)
+	//
+	// Server emits one channel-level reminder for any of these shapes;
+	// role filtering is the adapters' job.
+	if mentionAnyBroadcast(mentionMap) {
+		all = true
 	}
 	if mentionMap["uids"] != nil {
 		uidObjs, ok := mentionMap["uids"].([]interface{})
@@ -306,6 +335,62 @@ func (m *Message) getMention(payloadMap map[string]interface{}) (all bool, uids 
 		}
 	}
 	return
+}
+
+// mentionAnyBroadcast reports whether the parsed `mention` map carries
+// any of the three broadcast flags (humans / ais / all) set to 1. See
+// getMention's doc comment for the per-flag semantics. Defensive:
+// accepts json.Number / float / int / bool forms for each flag so
+// callers that decoded without UseNumber don't silently miss the
+// broadcast.
+func mentionAnyBroadcast(mentionMap map[string]interface{}) bool {
+	return mentionFlagTruthy(mentionMap["humans"]) ||
+		mentionFlagTruthy(mentionMap["ais"]) ||
+		mentionFlagTruthy(mentionMap["all"])
+}
+
+// mentionFlagTruthy reports whether a parsed mention.* flag value is
+// the numeric/boolean form of 1. Mirrors pkg/mentionrewrite.isTruthyOne
+// but kept local to avoid leaking the helper through an internal API —
+// the read side and the rewrite side intentionally share the same
+// "truthy = 1" semantics so a round-trip through the chokepoint is
+// observable.
+func mentionFlagTruthy(v interface{}) bool {
+	switch x := v.(type) {
+	case nil:
+		return false
+	case json.Number:
+		n, err := x.Int64()
+		return err == nil && n == 1
+	case float64:
+		return x == 1
+	case float32:
+		return x == 1
+	case int:
+		return x == 1
+	case int8:
+		return x == 1
+	case int16:
+		return x == 1
+	case int32:
+		return x == 1
+	case int64:
+		return x == 1
+	case uint:
+		return x == 1
+	case uint8:
+		return x == 1
+	case uint16:
+		return x == 1
+	case uint32:
+		return x == 1
+	case uint64:
+		return x == 1
+	case bool:
+		return x
+	default:
+		return false
+	}
 }
 
 func (m *Message) contentType(payloadMap map[string]interface{}) int {

--- a/modules/message/api_reminders_test.go
+++ b/modules/message/api_reminders_test.go
@@ -6,13 +6,13 @@
 // `mention.all=1` to `mention.humans=1`, and a new client may also set
 // `mention.ais=1`. This file pins:
 //
-//   1. Message.getMention recognizes any of {humans, ais, all} = 1 as a
-//      "broadcast" mention (channel-level reminder), and still pulls
-//      per-user `uids` for the non-broadcast path.
-//   2. Message.getReminders generates exactly the right shape of
-//      reminder rows for each matrix cell — channel-level (UID="")
-//      for broadcasts, per-uid rows for explicit uids, and zero rows
-//      when the payload has no mention at all.
+//  1. Message.getMention recognizes any of {humans, ais, all} = 1 as a
+//     "broadcast" mention (channel-level reminder), and still pulls
+//     per-user `uids` for the non-broadcast path.
+//  2. Message.getReminders generates exactly the right shape of
+//     reminder rows for each matrix cell — channel-level (UID="")
+//     for broadcasts, per-uid rows for explicit uids, and zero rows
+//     when the payload has no mention at all.
 //
 // These tests are pure helpers (no DB / no IM context) so they live
 // next to the existing mention-shape suite in validation_test.go.

--- a/modules/message/api_reminders_test.go
+++ b/modules/message/api_reminders_test.go
@@ -1,0 +1,319 @@
+// modules/message/api_reminders_test.go
+//
+// Reminder fan-out matrix tests for the mention three-state rewrite
+// (YUJ-1343 / Mininglamp-OSS/octo-server#94). The chokepoint rewrite
+// (pkg/mentionrewrite.RewriteMention) double-writes legacy
+// `mention.all=1` to `mention.humans=1`, and a new client may also set
+// `mention.ais=1`. This file pins:
+//
+//   1. Message.getMention recognizes any of {humans, ais, all} = 1 as a
+//      "broadcast" mention (channel-level reminder), and still pulls
+//      per-user `uids` for the non-broadcast path.
+//   2. Message.getReminders generates exactly the right shape of
+//      reminder rows for each matrix cell — channel-level (UID="")
+//      for broadcasts, per-uid rows for explicit uids, and zero rows
+//      when the payload has no mention at all.
+//
+// These tests are pure helpers (no DB / no IM context) so they live
+// next to the existing mention-shape suite in validation_test.go.
+package message
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// payloadJSON marshals the given map and re-decodes with UseNumber so
+// the resulting map[string]interface{} mirrors what
+// config.MessageResp.GetPayloadMap returns in production (UseNumber is
+// the documented contract — see modules/message/validation_test.go for
+// the same pattern).
+func payloadJSON(t *testing.T, m map[string]interface{}) []byte {
+	t.Helper()
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// TestGetMention_ThreeStateMatrix locks the three-state read-side
+// semantics established in YUJ-1343 / GH#94 §RFC 6.
+func TestGetMention_ThreeStateMatrix(t *testing.T) {
+	m := &Message{}
+
+	cases := []struct {
+		name       string
+		mention    map[string]interface{}
+		expectAll  bool
+		expectUIDs []string
+	}{
+		{
+			name:       "humans=1 alone → broadcast",
+			mention:    map[string]interface{}{"humans": json.Number("1")},
+			expectAll:  true,
+			expectUIDs: nil,
+		},
+		{
+			name:       "ais=1 alone → broadcast",
+			mention:    map[string]interface{}{"ais": json.Number("1")},
+			expectAll:  true,
+			expectUIDs: nil,
+		},
+		{
+			name: "humans=1 + ais=1 → broadcast",
+			mention: map[string]interface{}{
+				"humans": json.Number("1"),
+				"ais":    json.Number("1"),
+			},
+			expectAll:  true,
+			expectUIDs: nil,
+		},
+		{
+			name: "all=1 (post-rewrite carries humans=1) → broadcast",
+			mention: map[string]interface{}{
+				"all":    json.Number("1"),
+				"humans": json.Number("1"),
+			},
+			expectAll:  true,
+			expectUIDs: nil,
+		},
+		{
+			name: "legacy all=1 alone (no rewrite yet) → still broadcast (read-side resilience)",
+			// This path SHOULDN'T happen in production once the
+			// chokepoint runs, but if a listener somehow sees an
+			// un-rewritten message (e.g. replay of historical data),
+			// the reader must still emit a reminder.
+			mention:    map[string]interface{}{"all": json.Number("1")},
+			expectAll:  true,
+			expectUIDs: nil,
+		},
+		{
+			name:       "uids only → per-uid",
+			mention:    map[string]interface{}{"uids": []interface{}{"u_alice", "u_bob"}},
+			expectAll:  false,
+			expectUIDs: []string{"u_alice", "u_bob"},
+		},
+		{
+			name: "humans=1 + uids → broadcast wins (uids still parsed)",
+			mention: map[string]interface{}{
+				"humans": json.Number("1"),
+				"uids":   []interface{}{"u_alice"},
+			},
+			expectAll:  true,
+			expectUIDs: []string{"u_alice"},
+		},
+		{
+			name:       "humans=0 + ais=0 + all=0 → no broadcast",
+			mention:    map[string]interface{}{"humans": json.Number("0"), "ais": json.Number("0"), "all": json.Number("0")},
+			expectAll:  false,
+			expectUIDs: nil,
+		},
+		{
+			name:       "empty mention map → no broadcast",
+			mention:    map[string]interface{}{},
+			expectAll:  false,
+			expectUIDs: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := map[string]interface{}{"mention": tc.mention}
+			// Round-trip through JSON+UseNumber so the test maps
+			// match the production decoder shape.
+			raw := payloadJSON(t, payload)
+			var decoded map[string]interface{}
+			dec := json.NewDecoder(strings.NewReader(string(raw)))
+			dec.UseNumber()
+			if err := dec.Decode(&decoded); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			gotAll, gotUIDs := m.getMention(decoded)
+			assert.Equal(t, tc.expectAll, gotAll, "all-flag mismatch for %s", tc.name)
+			assert.Equal(t, tc.expectUIDs, gotUIDs, "uids mismatch for %s", tc.name)
+		})
+	}
+}
+
+// newReminderTestMessage returns a Message whose reminder-version
+// generator is a deterministic in-memory counter. Lets the matrix
+// helpers exercise getReminders without standing up the seq table /
+// MySQL / IM context. See Message.reminderSeqOverride in api.go.
+func newReminderTestMessage(t *testing.T) *Message {
+	t.Helper()
+	var seq int64
+	return &Message{
+		reminderSeqOverride: func() (int64, error) {
+			seq++
+			return seq, nil
+		},
+	}
+}
+
+// TestGetReminders_FanoutMatrix asserts the SHAPE of reminders
+// emitted for every cell of the three-state mention matrix. The fan-out
+// behavior is:
+//
+//   - any of {humans, ais, all} = 1 → exactly ONE reminder per message
+//     with UID="" (channel-level — clients filter by role in adapter)
+//   - uids = [a, b]                 → one reminder PER uid, with
+//     UID=<uid>
+//   - no mention                    → zero reminders
+//
+// Role-aware delivery (humans-only vs bots-only) is intentionally a
+// client-side adapter concern — see api_reminders.go:getMention for
+// the rationale. This test pins the server contract.
+func TestGetReminders_FanoutMatrix(t *testing.T) {
+	m := newReminderTestMessage(t)
+
+	cases := []struct {
+		name            string
+		mention         map[string]interface{}
+		wantTotal       int
+		wantBroadcast   int // reminders with UID==""
+		wantPerUserUIDs []string
+	}{
+		{
+			name:          "humans=1 → 1 channel-level reminder",
+			mention:       map[string]interface{}{"humans": json.Number("1")},
+			wantTotal:     1,
+			wantBroadcast: 1,
+		},
+		{
+			name:          "ais=1 → 1 channel-level reminder (bots fan-out)",
+			mention:       map[string]interface{}{"ais": json.Number("1")},
+			wantTotal:     1,
+			wantBroadcast: 1,
+		},
+		{
+			name: "humans+ais → still ONE channel-level reminder (client filters role)",
+			mention: map[string]interface{}{
+				"humans": json.Number("1"),
+				"ais":    json.Number("1"),
+			},
+			wantTotal:     1,
+			wantBroadcast: 1,
+		},
+		{
+			name: "all=1 (rewrite double-wrote humans=1) → 1 channel-level reminder, humans-only semantics",
+			mention: map[string]interface{}{
+				"all":    json.Number("1"),
+				"humans": json.Number("1"),
+			},
+			wantTotal:     1,
+			wantBroadcast: 1,
+		},
+		{
+			name:            "uids only → 2 per-user reminders",
+			mention:         map[string]interface{}{"uids": []interface{}{"u_alice", "u_bob"}},
+			wantTotal:       2,
+			wantPerUserUIDs: []string{"u_alice", "u_bob"},
+		},
+		{
+			name: "humans=1 + uids → broadcast wins (1 channel-level)",
+			mention: map[string]interface{}{
+				"humans": json.Number("1"),
+				"uids":   []interface{}{"u_alice"},
+			},
+			wantTotal:     1,
+			wantBroadcast: 1,
+		},
+		{
+			name:      "no mention → 0 reminders",
+			mention:   nil,
+			wantTotal: 0,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := map[string]interface{}{"type": 1, "content": "msg"}
+			if tc.mention != nil {
+				payload["mention"] = tc.mention
+			}
+			msg := &config.MessageResp{
+				ChannelID:   fmt.Sprintf("ch_%d", i),
+				ChannelType: common.ChannelTypeGroup.Uint8(),
+				FromUID:     "u_sender",
+				MessageID:   int64(1000 + i),
+				MessageSeq:  uint32(10 + i),
+				ClientMsgNo: fmt.Sprintf("cmn_%d", i),
+				Payload:     payloadJSON(t, payload),
+			}
+			got := m.getReminders([]*config.MessageResp{msg})
+			assert.Equal(t, tc.wantTotal, len(got), "reminder count mismatch")
+			if tc.wantTotal == 0 {
+				return
+			}
+			var (
+				broadcasts int
+				perUserSet = map[string]bool{}
+			)
+			for _, r := range got {
+				if r.UID == "" {
+					broadcasts++
+				} else {
+					perUserSet[r.UID] = true
+				}
+				assert.Equal(t, ReminderTypeMentionMe, r.ReminderType)
+				assert.Equal(t, msg.ChannelID, r.ChannelID)
+				assert.Equal(t, msg.ChannelType, r.ChannelType)
+				assert.Equal(t, msg.FromUID, r.Publisher)
+				assert.Equal(t, fmt.Sprintf("%d", msg.MessageID), r.MessageID)
+			}
+			if tc.wantBroadcast > 0 {
+				assert.Equal(t, tc.wantBroadcast, broadcasts, "broadcast count mismatch")
+			}
+			if len(tc.wantPerUserUIDs) > 0 {
+				want := map[string]bool{}
+				for _, u := range tc.wantPerUserUIDs {
+					want[u] = true
+				}
+				assert.Equal(t, want, perUserSet, "per-user uid set mismatch")
+			}
+		})
+	}
+}
+
+// TestGetReminders_AllAndHumans_RoundTripThroughRewrite is the
+// end-to-end matrix cell that ties the chokepoint and the reader
+// together: a legacy `mention.all=1` payload, after passing through
+// the chokepoint rewrite, still produces exactly ONE channel-level
+// reminder with humans-only semantics (Yu D1 — bots silent).
+func TestGetReminders_AllAndHumans_RoundTripThroughRewrite(t *testing.T) {
+	m := newReminderTestMessage(t)
+
+	// Legacy inbound shape.
+	inbound := map[string]interface{}{
+		"type": 1,
+		"mention": map[string]interface{}{
+			"all": json.Number("1"),
+		},
+	}
+	// Chokepoint rewrite.
+	rewritten := RewriteMention(inbound)
+	mention := rewritten["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["all"], "all preserved (outbound double-write)")
+	assert.Equal(t, json.Number("1"), mention["humans"], "humans added by rewrite")
+
+	// Reader sees the rewritten payload.
+	msg := &config.MessageResp{
+		ChannelID:   "ch_roundtrip",
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		FromUID:     "u_sender",
+		MessageID:   1,
+		MessageSeq:  1,
+		ClientMsgNo: "cmn_roundtrip",
+		Payload:     payloadJSON(t, rewritten),
+	}
+	rems := m.getReminders([]*config.MessageResp{msg})
+	assert.Len(t, rems, 1, "round-trip must produce exactly one broadcast reminder")
+	assert.Equal(t, "", rems[0].UID, "broadcast reminder uses empty UID")
+}

--- a/modules/message/mention_rewrite.go
+++ b/modules/message/mention_rewrite.go
@@ -1,0 +1,38 @@
+// modules/message/mention_rewrite.go
+//
+// Thin re-export of pkg/mentionrewrite.RewriteMention into the
+// `message` package so the existing message-module dispatch sites
+// (Message.sendMessage in api.go) can keep using an unqualified symbol
+// — same pattern as sanitize_user_ingress.go wrapping
+// pkg/obopayload.StripReservedKeys.
+//
+// Why a separate package owns the helper
+// ======================================
+// The three-state rewrite has to be invoked from THREE client-controlled
+// message ingresses:
+//
+//   - modules/message/api.go      (Message.sendMessage)
+//   - modules/bot_api/send.go     (BotAPI.sendMessage)
+//   - modules/robot/api.go        (Robot.sendMessage)
+//
+// `modules/message` already imports `modules/robot` (revoke flow), so
+// placing the helper in `modules/message` and importing it from
+// `modules/robot` would create a `robot → message → robot` cycle. The
+// helper therefore lives in `pkg/mentionrewrite` (leaf package, no
+// module deps) and this file re-exports it for the message-package
+// callers. See pkg/mentionrewrite/rewrite.go for the contract and the
+// PR#70 audit doc (docs/2026-05-mention-all-chokepoint-audit.md §5)
+// for the design rationale.
+//
+// Spec: Mininglamp-OSS/octo-server#94, Multica YUJ-1343.
+package message
+
+import "github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
+
+// RewriteMention normalizes the payload's `mention` sub-map per the
+// three-state contract. Delegates to pkg/mentionrewrite so the shared
+// behavior cannot drift between the three ingress packages. See
+// pkg/mentionrewrite.RewriteMention for the full contract.
+func RewriteMention(payload map[string]interface{}) map[string]interface{} {
+	return mentionrewrite.RewriteMention(payload)
+}

--- a/modules/message/mention_rewrite_test.go
+++ b/modules/message/mention_rewrite_test.go
@@ -1,0 +1,67 @@
+// Colocated message-package tests for the RewriteMention helper. The
+// authoritative contract suite lives at pkg/mentionrewrite/rewrite_test.go
+// (where the helper itself is defined). These tests assert the
+// message-package shim is wired correctly — a future refactor that
+// turns the shim into a no-op stub will trip these.
+//
+// We deliberately keep these in `package message` (not _test) so the
+// tests reach the unqualified `RewriteMention` symbol the
+// message-package callers use; this is the same pattern
+// sanitize_user_ingress_test.go uses for the obopayload strip shim.
+package message
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMessagePackage_RewriteMention_AllRewrittenToHumansDoubleWrite is
+// the canonical regression guard for the message-package shim. If
+// someone deletes the import or breaks the wiring this test fails.
+func TestMessagePackage_RewriteMention_AllRewrittenToHumansDoubleWrite(t *testing.T) {
+	payload := map[string]interface{}{
+		"type":    1,
+		"content": "@所有人 ping",
+		"mention": map[string]interface{}{
+			"all": json.Number("1"),
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["all"],
+		"all=1 outbound double-write must be preserved")
+	assert.Equal(t, json.Number("1"), mention["humans"],
+		"all=1 inbound must rewrite to add humans=1")
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAIs,
+		"Yu D1: legacy @所有人 must NOT auto-trigger ais=1 (the bot-fan-out pain point)")
+}
+
+// TestMessagePackage_RewriteMention_AisPassthrough — message-package
+// shim must NOT short-circuit on the ais-only shape (the helper
+// preserves it untouched).
+func TestMessagePackage_RewriteMention_AisPassthrough(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"ais": json.Number("1"),
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["ais"])
+	_, hasHumans := mention["humans"]
+	assert.False(t, hasHumans)
+}
+
+// TestMessagePackage_RewriteMention_NilSafe — defensive: a future
+// caller may invoke the shim with a nil payload. Must not panic.
+func TestMessagePackage_RewriteMention_NilSafe(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("RewriteMention shim panicked on nil: %v", r)
+		}
+	}()
+	assert.Nil(t, RewriteMention(nil))
+}

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/file"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
 	pkgutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
 	"github.com/gin-gonic/gin"
 	"github.com/go-redis/redis"
@@ -349,6 +350,17 @@ func (rb *Robot) sendMessage(c *wkhttp.Context) {
 	if messageReq.ChannelType == common.ChannelTypePerson.Uint8() {
 		payload = rb.enrichBotPayloadWithSpaceID(robotID, payload)
 	}
+
+	// YUJ-202 / Mininglamp-OSS#94 — mention three-state rewrite. Same
+	// chokepoint contract as the user and bot API ingresses: legacy
+	// `mention.all=1` is normalized to also carry `mention.humans=1`,
+	// with `all=1` preserved on the outbound payload for old read-side
+	// clients (double-write). ⚠️ F2 (PR#70 Jerry-Xin correctness-
+	// critical review): MUST stay OUTSIDE the `ChannelTypePerson`
+	// conditional above so group / community-topic `@所有人` traffic
+	// (the main pain-point) actually goes through the chokepoint.
+	// Helper is idempotent and safe on nil — see pkg/mentionrewrite.
+	payload = mentionrewrite.RewriteMention(payload)
 
 	result, err := rb.ctx.SendMessageWithResult(&config.MsgSendReq{
 		StreamNo:    messageReq.StreamNo,

--- a/pkg/mentionrewrite/rewrite.go
+++ b/pkg/mentionrewrite/rewrite.go
@@ -1,0 +1,164 @@
+// Package mentionrewrite owns the inbound rewrite + outbound double-write
+// contract for the `mention.{all,humans,ais}` payload field
+// (YUJ-202 / Mininglamp-OSS/octo-server#94 — 方案 X "dead-field" strategy
+// for `@所有人`, three-state implementation of the PR#70 audit §5
+// recommendation).
+//
+// Why a separate pkg/
+// ===================
+// The helper has to be invoked from THREE client-controlled message
+// ingresses (modules/message/api.go, modules/bot_api/send.go,
+// modules/robot/api.go). `modules/message` already imports
+// `modules/robot` (revoke flow), so placing the helper in
+// `modules/message` would create a `robot → message → robot` import
+// cycle. The cleanest fix is to keep the helper in a leaf package neither
+// transport-layer module depends on transitively, mirroring how
+// pkg/obopayload solved the same shape of cross-module sharing for the
+// OBO `__obo_*` reserved key strip/reject contract.
+//
+// A thin re-export lives at `modules/message/mention_rewrite.go` so the
+// message-module callers can keep using the unqualified `RewriteMention`
+// symbol and so the issue spec's "modules/message/mention_rewrite.go is
+// the helper file" expectation is preserved.
+//
+// Inbound rewrite (CALL from message ingress chokepoints)
+// =======================================================
+// Legacy clients still emit `mention.all=1` for `@所有人`. The
+// three-state design assigns `all=1` the **humans-only** broadcast
+// semantics (Yu 2026-05-19 D1): "legacy `@所有人` should NOT auto-trigger
+// all bots, that's the exact pain point being fixed". So inbound
+// `mention.all=1` is rewritten to also carry `mention.humans=1`. The
+// legacy `mention.all=1` field is INTENTIONALLY preserved on the
+// outbound payload (double-write) so old read-side clients that only
+// understand `all` keep rendering the "@所有人" pill until their roll-out
+// catches up. New read-side clients prefer `humans` / `ais` and IGNORE
+// `all` when either of the new fields is set — see the read-side change
+// in Message.getMention (modules/message/api_reminders.go).
+//
+// `mention.ais=1` is left untouched. `mention.humans=1` is left
+// untouched. `mention.uids` / `mention.entities` are left untouched.
+//
+// The helper is idempotent: RewriteMention(RewriteMention(p)) ==
+// RewriteMention(p) for every input. Idempotency lets callers invoke it
+// at every chokepoint without worrying about re-entry from listeners /
+// fan-out / future relay paths.
+//
+// Safe on nil / empty / non-map `mention` payloads (no panic, no
+// mutation beyond the strict double-write).
+package mentionrewrite
+
+import "encoding/json"
+
+// MentionKey is the top-level payload key under which the three-state
+// mention state lives. Exposed so callers and tests share one constant.
+const MentionKey = "mention"
+
+// AllKey is the legacy `@所有人` field. Inbound `all=1` is rewritten to
+// also carry `humans=1`; the `all` field itself is preserved on the
+// dispatched payload (outbound double-write) for backward compat with
+// old read-side clients that only understand `all`.
+const AllKey = "all"
+
+// HumansKey signals a human-only broadcast (`@所有真人`). New read-side
+// clients render the "@所有人" pill from this field and IGNORE `all`.
+const HumansKey = "humans"
+
+// AIsKey signals a bot-only broadcast (`@所有 AI`). Independent of
+// `humans` — both can be set on the same message (`@所有人 + @所有 AI`).
+const AIsKey = "ais"
+
+// RewriteMention normalizes the payload's `mention` sub-map per the
+// three-state contract. Mutates the inner map in place when the inbound
+// shape calls for a rewrite, and returns the (possibly same) outer map
+// so callers can keep the `payload = RewriteMention(payload)` assign-
+// back pattern used elsewhere in the message dispatch stack (mirrors
+// `enrichPayloadWithSpaceID`).
+//
+// Behavior:
+//   - payload == nil → returns nil (no allocation).
+//   - payload has no `mention` key, or `mention` is not a
+//     map[string]interface{} → returned untouched.
+//   - mention.all is truthy (==1 in either json.Number, float64, int,
+//     int64, uint64, or bool form) → mention.humans is set to the
+//     canonical json.Number("1"). mention.all is preserved.
+//   - mention.humans is already truthy → no-op on humans (preserves
+//     whatever numeric/bool form the caller sent).
+//   - mention.ais is left untouched in every branch.
+//   - mention.uids / mention.entities / any other key inside mention is
+//     left untouched.
+//
+// Idempotent by construction: a second pass over an already-rewritten
+// payload sees humans truthy and does nothing.
+func RewriteMention(payload map[string]interface{}) map[string]interface{} {
+	if payload == nil {
+		return nil
+	}
+	raw, ok := payload[MentionKey]
+	if !ok || raw == nil {
+		return payload
+	}
+	mention, ok := raw.(map[string]interface{})
+	if !ok {
+		// Defensive: malformed mention (string / int / array) — never
+		// the shape a real client sends. Leave untouched so the read
+		// side / validation tests can keep asserting on the original
+		// payload.
+		return payload
+	}
+	if !isTruthyOne(mention[AllKey]) {
+		return payload
+	}
+	// Inbound `all=1` → make sure humans=1 is also present. Don't
+	// overwrite a humans value the client already supplied (might be a
+	// new client that explicitly set humans in addition to legacy all
+	// for forward+backward compat).
+	if !isTruthyOne(mention[HumansKey]) {
+		mention[HumansKey] = json.Number("1")
+	}
+	// `all` is INTENTIONALLY preserved — see package godoc on the
+	// outbound double-write rationale.
+	return payload
+}
+
+// isTruthyOne reports whether v is the numeric/boolean form of 1. The
+// `mention.*` fields arrive from `json.Decoder.UseNumber()` so the
+// hot path is json.Number, but client/test code may also send float64,
+// int, int64, uint64, or bool — handle all of them defensively so a
+// caller does not have to pre-normalize before calling RewriteMention.
+func isTruthyOne(v interface{}) bool {
+	switch x := v.(type) {
+	case nil:
+		return false
+	case json.Number:
+		n, err := x.Int64()
+		return err == nil && n == 1
+	case float64:
+		return x == 1
+	case float32:
+		return x == 1
+	case int:
+		return x == 1
+	case int8:
+		return x == 1
+	case int16:
+		return x == 1
+	case int32:
+		return x == 1
+	case int64:
+		return x == 1
+	case uint:
+		return x == 1
+	case uint8:
+		return x == 1
+	case uint16:
+		return x == 1
+	case uint32:
+		return x == 1
+	case uint64:
+		return x == 1
+	case bool:
+		return x
+	default:
+		return false
+	}
+}

--- a/pkg/mentionrewrite/rewrite_test.go
+++ b/pkg/mentionrewrite/rewrite_test.go
@@ -1,0 +1,330 @@
+// Unit tests for the pure RewriteMention helper.
+//
+// These cover the spec contract from Mininglamp-OSS/octo-server#94 and
+// the issue YUJ-1343 acceptance list. The companion thin re-export in
+// modules/message/mention_rewrite.go has its own colocated test file
+// that exercises the same shapes through the message-package symbol,
+// so a future refactor moving the helper does not have to update two
+// suites in lockstep — the contract is asserted here and the shim test
+// only verifies the shim is not a stub.
+package mentionrewrite
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRewriteMention_AllOnly — the canonical legacy-client shape. An
+// inbound `mention.all=1` MUST gain a `mention.humans=1` companion and
+// MUST keep the `all=1` field on the outbound payload (double-write for
+// old read-side clients that only understand `all`).
+func TestRewriteMention_AllOnly(t *testing.T) {
+	payload := map[string]interface{}{
+		"type":    1,
+		"content": "@所有人 hi",
+		"mention": map[string]interface{}{
+			"all": json.Number("1"),
+		},
+	}
+
+	out := RewriteMention(payload)
+
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["all"],
+		"all=1 must be preserved (outbound double-write for legacy clients)")
+	assert.Equal(t, json.Number("1"), mention["humans"],
+		"all=1 inbound must set humans=1")
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAIs,
+		"ais must NOT be auto-set — legacy @所有人 must not silently fan out to bots (Yu D1 rationale)")
+	// Non-mention fields untouched.
+	assert.Equal(t, 1, out["type"])
+	assert.Equal(t, "@所有人 hi", out["content"])
+}
+
+// TestRewriteMention_HumansOnly — explicit humans=1 from a new client
+// passes through untouched. ais MUST NOT be set as a side effect.
+func TestRewriteMention_HumansOnly(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"humans": json.Number("1"),
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["humans"])
+	_, hasAll := mention["all"]
+	assert.False(t, hasAll, "humans-only input must NOT gain a legacy all=1")
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAIs)
+}
+
+// TestRewriteMention_AIsOnly — explicit ais=1 from a new client passes
+// through untouched. humans MUST NOT be set as a side effect.
+func TestRewriteMention_AIsOnly(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"ais": json.Number("1"),
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["ais"])
+	_, hasHumans := mention["humans"]
+	assert.False(t, hasHumans, "ais-only input must NOT gain humans=1")
+	_, hasAll := mention["all"]
+	assert.False(t, hasAll)
+}
+
+// TestRewriteMention_HumansAndAIs — combined `@所有人 + @所有 AI` from a
+// new client passes through untouched.
+func TestRewriteMention_HumansAndAIs(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"humans": json.Number("1"),
+			"ais":    json.Number("1"),
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["humans"])
+	assert.Equal(t, json.Number("1"), mention["ais"])
+	_, hasAll := mention["all"]
+	assert.False(t, hasAll)
+}
+
+// TestRewriteMention_AllPlusUIDs — legacy `@所有人 + @alice + @bob`. The
+// uids array MUST be preserved (the rewrite is only about the broadcast
+// flag, not about individual mentions).
+func TestRewriteMention_AllPlusUIDs(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"all":  json.Number("1"),
+			"uids": []interface{}{"uid_alice", "uid_bob"},
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["all"], "all preserved")
+	assert.Equal(t, json.Number("1"), mention["humans"], "humans added")
+	assert.Equal(t,
+		[]interface{}{"uid_alice", "uid_bob"},
+		mention["uids"],
+		"uids array must be preserved verbatim")
+}
+
+// TestRewriteMention_AllPlusEntities — v2 client shape (mention.entities
+// is the new-format inline-mention metadata, see
+// modules/message/validation_test.go:885+). RewriteMention must NOT
+// drop or mutate the entities array.
+func TestRewriteMention_AllPlusEntities(t *testing.T) {
+	entities := []interface{}{
+		map[string]interface{}{"uid": "__all__", "offset": json.Number("0"), "length": json.Number("4")},
+	}
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"all":      json.Number("1"),
+			"uids":     []interface{}{},
+			"entities": entities,
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["all"])
+	assert.Equal(t, json.Number("1"), mention["humans"])
+	assert.True(t, reflect.DeepEqual(entities, mention["entities"]),
+		"entities array must survive the rewrite untouched")
+}
+
+// TestRewriteMention_UIDsOnly — no broadcast flag, just per-user
+// mentions. Nothing to rewrite.
+func TestRewriteMention_UIDsOnly(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"uids": []interface{}{"uid_alice"},
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	_, hasAll := mention["all"]
+	_, hasHumans := mention["humans"]
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAll)
+	assert.False(t, hasHumans)
+	assert.False(t, hasAIs)
+	assert.Equal(t, []interface{}{"uid_alice"}, mention["uids"])
+}
+
+// TestRewriteMention_NilPayload — defensive: nil in, nil out, no panic.
+func TestRewriteMention_NilPayload(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("RewriteMention panicked on nil payload: %v", r)
+		}
+	}()
+	assert.Nil(t, RewriteMention(nil))
+}
+
+// TestRewriteMention_EmptyPayload — empty map in, empty map out, no
+// panic, no key inserted at the top level.
+func TestRewriteMention_EmptyPayload(t *testing.T) {
+	out := RewriteMention(map[string]interface{}{})
+	assert.NotNil(t, out)
+	assert.Empty(t, out)
+}
+
+// TestRewriteMention_NoMentionKey — payload without a `mention` key
+// must be returned untouched (don't synthesize an empty mention map).
+func TestRewriteMention_NoMentionKey(t *testing.T) {
+	payload := map[string]interface{}{
+		"type":    1,
+		"content": "hi",
+	}
+	out := RewriteMention(payload)
+	_, hasMention := out["mention"]
+	assert.False(t, hasMention, "no mention key must remain absent")
+}
+
+// TestRewriteMention_MentionIsNil — explicit nil mention is treated the
+// same as absent. No mutation.
+func TestRewriteMention_MentionIsNil(t *testing.T) {
+	payload := map[string]interface{}{"mention": nil}
+	out := RewriteMention(payload)
+	assert.Nil(t, out["mention"])
+}
+
+// TestRewriteMention_MentionIsNonMap — malformed mention (string / int /
+// array) must NOT panic. Leave untouched.
+func TestRewriteMention_MentionIsNonMap(t *testing.T) {
+	cases := []map[string]interface{}{
+		{"mention": "weird"},
+		{"mention": 42},
+		{"mention": []interface{}{"a", "b"}},
+		{"mention": true},
+	}
+	for _, payload := range cases {
+		orig := payload["mention"]
+		out := RewriteMention(payload)
+		assert.Equal(t, orig, out["mention"],
+			"non-map mention must be returned untouched, no panic")
+	}
+}
+
+// TestRewriteMention_AllAsFloat — json.Decoder *without* UseNumber will
+// produce float64. Even though the message pipeline uses UseNumber, the
+// helper accepts the float form defensively so callers that decode with
+// the standard library default don't silently miss the rewrite.
+func TestRewriteMention_AllAsFloat(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"all": float64(1),
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["humans"], "float64 all=1 must trigger rewrite")
+	assert.Equal(t, float64(1), mention["all"], "original all value preserved verbatim")
+}
+
+// TestRewriteMention_AllAsBool — defensive: some Go callers might
+// construct payloads with `all: true`. Treat truthy bool as 1.
+func TestRewriteMention_AllAsBool(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"all": true,
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["humans"])
+	assert.Equal(t, true, mention["all"])
+}
+
+// TestRewriteMention_AllZero — `all=0` is the "no @所有人" sentinel; the
+// rewrite must NOT add a humans field.
+func TestRewriteMention_AllZero(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"all": json.Number("0"),
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	_, hasHumans := mention["humans"]
+	assert.False(t, hasHumans, "all=0 must not gain humans=1")
+}
+
+// TestRewriteMention_AllAndHumansBothSet — a forward-compat new client
+// might already set BOTH all and humans. The rewrite must NOT clobber
+// the client-supplied humans value (e.g. some future "humans=2" semantic
+// would be silently overwritten by a blind set).
+func TestRewriteMention_AllAndHumansBothSet(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"all":    json.Number("1"),
+			"humans": json.Number("1"),
+		},
+	}
+	out := RewriteMention(payload)
+	mention := out["mention"].(map[string]interface{})
+	// Both still present, neither mutated.
+	assert.Equal(t, json.Number("1"), mention["all"])
+	assert.Equal(t, json.Number("1"), mention["humans"])
+}
+
+// TestRewriteMention_Idempotent — RewriteMention(RewriteMention(p))
+// must equal RewriteMention(p) for every input shape. Idempotency is
+// the property that lets us drop the helper at three independent
+// chokepoints + any future listener / relay without worrying about
+// repeated rewrites.
+func TestRewriteMention_Idempotent(t *testing.T) {
+	inputs := []map[string]interface{}{
+		nil,
+		{},
+		{"mention": map[string]interface{}{"all": json.Number("1")}},
+		{"mention": map[string]interface{}{"humans": json.Number("1")}},
+		{"mention": map[string]interface{}{"ais": json.Number("1")}},
+		{"mention": map[string]interface{}{
+			"humans": json.Number("1"), "ais": json.Number("1"),
+		}},
+		{"mention": map[string]interface{}{
+			"all":  json.Number("1"),
+			"uids": []interface{}{"x", "y"},
+		}},
+		{"mention": map[string]interface{}{
+			"all":      json.Number("1"),
+			"entities": []interface{}{map[string]interface{}{"uid": "__all__"}},
+		}},
+	}
+	for i, in := range inputs {
+		once := RewriteMention(cloneShallow(in))
+		twice := RewriteMention(RewriteMention(cloneShallow(in)))
+		assert.True(t, reflect.DeepEqual(once, twice),
+			"input %d not idempotent: once=%v twice=%v", i, once, twice)
+	}
+}
+
+// cloneShallow makes a one-level copy of the payload and the nested
+// mention map so the two arms of the idempotency test do not share
+// mutable state.
+func cloneShallow(in map[string]interface{}) map[string]interface{} {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		if m, ok := v.(map[string]interface{}); ok {
+			inner := make(map[string]interface{}, len(m))
+			for ik, iv := range m {
+				inner[ik] = iv
+			}
+			out[k] = inner
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}


### PR DESCRIPTION
Closes #94

## Summary

Implements the PR#70 audit §5 server-side recommendation:

- **Inbound rewrite** at every client-controlled message ingress: legacy `mention.all=1` → also carry `mention.humans=1` (Yu D1: legacy `@所有人` MUST NOT auto-trigger a bot fan-out — `ais=1` is intentionally NOT set).
- **Outbound double-write**: legacy `mention.all=1` is preserved on the dispatched payload so old read-side clients keep rendering the `@所有人` pill until they roll out support for `humans/ais`.
- **Reminder read side** (`Message.getMention`) now recognizes any of `{humans, ais, all} = 1` as a broadcast mention.

### Decision matrix (RFC §6, Yu D1–D8)

| Mention payload                            | 真人通知 | Bot 入站 | Reminder shape |
|--------------------------------------------|----------|----------|----------------|
| `humans=1`                                 | ✅       | ❌       | channel-level  |
| `ais=1`                                    | ❌       | ✅       | channel-level  |
| `humans=1` + `ais=1`                       | ✅       | ✅       | channel-level  |
| `all=1` (post-rewrite carries `humans=1`)  | ✅       | ❌       | channel-level  |
| `uids=[…]`                                 | only those uids | only those uids | per-uid       |

Per-role filtering (humans-only vs ais-only) is a client-adapter concern — the server still emits one channel-level reminder; adapters consult `mention.humans` / `mention.ais` to decide whether to render the red-dot for the local role.

## Changes (10 files, +1207/-11)

| # | File | Type | Notes |
|---|------|------|-------|
| 1 | `pkg/mentionrewrite/rewrite.go` | NEW | shared helper `RewriteMention(payload)` — pure, idempotent, leaf package |
| 2 | `pkg/mentionrewrite/rewrite_test.go` | NEW | 16 unit cases (matrix + defensive shapes + idempotency) |
| 3 | `modules/message/mention_rewrite.go` | NEW | thin re-export so message-package callers keep the unqualified symbol |
| 4 | `modules/message/mention_rewrite_test.go` | NEW | shim wiring guard |
| 5 | `modules/message/api.go` | EDIT | call rewrite after sanitize, before enrich (user ingress); add `reminderSeqOverride` test seam |
| 6 | `modules/bot_api/send.go` | EDIT | call rewrite OUTSIDE the `ChannelTypePerson` conditional (F2) |
| 7 | `modules/robot/api.go` | EDIT | call rewrite OUTSIDE the `ChannelTypePerson` conditional (F2) |
| 8 | `modules/message/api_reminders.go` | EDIT | `getMention` reads three-state; `nextReminderSeq()` introduces a test seam |
| 9 | `modules/message/api_reminders_test.go` | NEW | three-state matrix + fan-out matrix + round-trip |
| 10| `modules/bot_api/send_test.go` | EDIT | handler-level integration tests with `mention.all=1` and `mention.ais=1` |

### Why `pkg/mentionrewrite` instead of putting the helper in `modules/message`

`modules/message` already imports `modules/robot` (revoke flow). Placing the helper in `modules/message` and importing it from `modules/robot` would create a `robot → message → robot` cycle. The helper therefore lives in `pkg/mentionrewrite` (leaf package, no module deps), mirroring how `pkg/obopayload` solved the same shape of cross-module sharing for the `__obo_*` strip/reject contract. A thin re-export at `modules/message/mention_rewrite.go` keeps the issue-spec file in place and lets the message-package callers stay clean.

## F2 verification

The PR#70 Jerry-Xin correctness-critical review (F2) demanded the rewrite call sit OUTSIDE any `ChannelTypePerson` conditional — otherwise group / community-topic `@所有人` traffic (the main pain-point) bypasses the chokepoint. All three call sites verified:

**`modules/bot_api/send.go`**
```go
payload := req.Payload
if req.ChannelType == common.ChannelTypePerson.Uint8() {
    payload = ba.enrichBotPayloadWithSpaceID(c, robotID, payload)
}

// ⚠️ F2: MUST be OUTSIDE the ChannelTypePerson conditional above
payload = mentionrewrite.RewriteMention(payload)
```

**`modules/robot/api.go`**
```go
payload := messageReq.Payload
if messageReq.ChannelType == common.ChannelTypePerson.Uint8() {
    payload = rb.enrichBotPayloadWithSpaceID(robotID, payload)
}

// ⚠️ F2: MUST stay OUTSIDE the ChannelTypePerson conditional above
payload = mentionrewrite.RewriteMention(payload)
```

**`modules/message/api.go`** — `Message.sendMessage` has no `ChannelTypePerson` conditional surrounding the rewrite at all; the call sits at the top of the function, immediately after `sanitizeUserIngressPayload`, before `enrichPayloadWithSpaceID`.

## Acceptance gate

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go run ./tools/lint-personal-msgsendreq ./modules` clean (`OK: no direct PERSONAL MsgSendReq literals.`)
- [x] `grep -rn 'RewriteMention(' modules/` lists exactly **3 production call sites** (`modules/message/api.go`, `modules/bot_api/send.go`, `modules/robot/api.go`) plus the helper definition + shim in `modules/message/mention_rewrite.go`
- [x] F2 placement verified (excerpts above)
- [x] Handler integration test exercises the real `ctx.SendMessage()` dispatch path (lesson from PR#82 OBO fan-out — no pure-mock helper coverage; the test drives `BotAPI.sendMessage` end-to-end through `dispatchOverride` capture)

### Test results

```
ok  github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite          0.003s
ok  github.com/Mininglamp-OSS/octo-server/modules/bot_api             0.032s
ok  github.com/Mininglamp-OSS/octo-server/modules/robot               0.030s
# modules/message: targeted Mention/Reminder tests green; pre-existing
# infra-dependent failures (TestChannelFiles_*, TestMessage*_PermissionCheck)
# are unchanged on this branch — they require Redis/MySQL and fail at HEAD
# too (same set documented in PR#82 R5 notes).
```

## Merge order

This PR targets `feat/mention-three-state` (already exists, based on `feat/persona-clone` HEAD). Per the issue: do not rebase onto `main` until persona-clone PR#82 merges, then this branch will be rebased to follow.

