### PR TITLE
fix(bot_api): GET /v1/obo/grants returns grantee_bot_name (YUJ-1358)

### DIFF
--- a/modules/bot_api/obo_api_test.go
+++ b/modules/bot_api/obo_api_test.go
@@ -551,3 +551,112 @@ func TestOBO_DeleteScope_FindScopeOwner_LookupErr(t *testing.T) {
 		t.Fatalf("expected error body, got empty response")
 	}
 }
+
+// ==================== YUJ-1358 grantee_bot_name regression ====================
+
+// TestOBO_ListGrants_PopulatesGranteeBotName — GET /v1/obo/grants must
+// return a non-empty `grantee_bot_name` on every row so the web
+// PersonaCard does NOT fall back to rendering the raw bot uid
+// (`27qFHDRBCJQ2c868c93_bot`). The prod query enriches via
+// LEFT JOIN `user` u ON u.uid = g.grantee_bot_uid; the fake mirrors that
+// via seedBotName. Verifies both the JOIN-success and the COALESCE
+// fallback (bot with no user row → uid surfaces, never empty string).
+// Refs YUJ-1358 / octo-web#60.
+func TestOBO_ListGrants_PopulatesGranteeBotName(t *testing.T) {
+	s := newFakeOBOStore()
+	// Two grants for the same grantor:
+	//   1. bot with a known display name (JOIN-success path)
+	//   2. bot with no name seeded → fallback to uid (COALESCE path)
+	s.seedBot(tRESTBot, tRESTOwner)
+	s.seedBotName(tRESTBot, "james")
+	_, _ = s.insertGrant(tRESTOwner, tRESTBot, "auto")
+
+	const unnamedBot = "bot_no_user_row"
+	s.seedBot(unnamedBot, tRESTOwner)
+	_, _ = s.insertGrant(tRESTOwner, unnamedBot, "auto")
+
+	ba := newBAforREST(s)
+	c, rec := makeCtx(t, tRESTOwner, http.MethodGet, "/v1/obo/grants", nil, nil)
+	ba.oboListGrants(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Decode the envelope used by the handler: c.Response wraps the payload
+	// inside the standard {status, data} shape. We unmarshal loosely.
+	var env struct {
+		Data struct {
+			Items []map[string]interface{} `json:"items"`
+		} `json:"data"`
+		Items []map[string]interface{} `json:"items"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode list body: %v body=%s", err, rec.Body.String())
+	}
+	items := env.Data.Items
+	if len(items) == 0 {
+		items = env.Items
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d body=%s", len(items), rec.Body.String())
+	}
+
+	byUID := map[string]map[string]interface{}{}
+	for _, it := range items {
+		uid, _ := it["grantee_bot_uid"].(string)
+		byUID[uid] = it
+	}
+	if got, _ := byUID[tRESTBot]["grantee_bot_name"].(string); got != "james" {
+		t.Errorf("grant %s grantee_bot_name = %q, want %q", tRESTBot, got, "james")
+	}
+	if got, _ := byUID[unnamedBot]["grantee_bot_name"].(string); got != unnamedBot {
+		t.Errorf("grant %s grantee_bot_name = %q, want %q (COALESCE fallback)",
+			unnamedBot, got, unnamedBot)
+	}
+	// Hard contract: every row's grantee_bot_name MUST be non-empty so the
+	// frontend never falls back to the uid render path that motivated this
+	// fix in the first place.
+	for _, it := range items {
+		name, _ := it["grantee_bot_name"].(string)
+		if name == "" {
+			t.Errorf("grantee_bot_name must never be empty; row=%+v", it)
+		}
+	}
+}
+
+// TestOBO_StoreListGrantsByGrantor_GranteeBotNameContract — the same
+// invariant at the store layer (no HTTP). Pins down the fake's contract
+// so future contributors who add another caller of listGrantsByGrantor
+// can rely on a non-empty GranteeBotName without re-reading the SQL.
+func TestOBO_StoreListGrantsByGrantor_GranteeBotNameContract(t *testing.T) {
+	s := newFakeOBOStore()
+	s.seedBot(tRESTBot, tRESTOwner)
+	s.seedBotName(tRESTBot, "james")
+	_, _ = s.insertGrant(tRESTOwner, tRESTBot, "auto")
+
+	rows, err := s.listGrantsByGrantor(tRESTOwner)
+	if err != nil {
+		t.Fatalf("listGrantsByGrantor err=%v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d", len(rows))
+	}
+	if rows[0].GranteeBotName != "james" {
+		t.Errorf("GranteeBotName = %q, want %q", rows[0].GranteeBotName, "james")
+	}
+
+	// Fallback: bot without a seeded display name → uid surfaces.
+	const unnamedBot = "bot_no_display"
+	s.seedBot(unnamedBot, tRESTOwner)
+	_, _ = s.insertGrant(tRESTOwner, unnamedBot, "auto")
+	rows, _ = s.listGrantsByGrantor(tRESTOwner)
+	for _, r := range rows {
+		if r.GranteeBotName == "" {
+			t.Errorf("GranteeBotName must never be empty (uid=%s)", r.GranteeBotUID)
+		}
+		if r.GranteeBotUID == unnamedBot && r.GranteeBotName != unnamedBot {
+			t.Errorf("fallback name for %s = %q, want %q (COALESCE)",
+				unnamedBot, r.GranteeBotName, unnamedBot)
+		}
+	}
+}

--- a/modules/bot_api/obo_db.go
+++ b/modules/bot_api/obo_db.go
@@ -47,16 +47,30 @@ import (
 
 // oboGrantModel mirrors the obo_grants row. JSON tags are reused by HTTP
 // handlers, which return rows verbatim (v0 has no nuanced DTOs).
+//
+// GranteeBotName is NOT a column on obo_grants — it is populated by
+// listGrantsByGrantor via a LEFT JOIN against the `user` table (the bot's
+// display name lives on user.name, joined on user.uid = grantee_bot_uid).
+// Other reads that do `SELECT * FROM obo_grants` leave it empty; only the
+// listing endpoint pays the JOIN, since that is the only path the web UI
+// reads (PersonaCard renders `grantee_bot_name || grantee_bot_uid`, so a
+// missing name fell back to the raw uid — YUJ-1358 / octo-web#60).
 type oboGrantModel struct {
-	ID            int64      `db:"id" json:"id"`
-	GrantorUID    string     `db:"grantor_uid" json:"grantor_uid"`
-	GranteeBotUID string     `db:"grantee_bot_uid" json:"grantee_bot_uid"`
-	Mode          string     `db:"mode" json:"mode"`
-	GlobalEnabled int        `db:"global_enabled" json:"global_enabled"`
-	Active        int        `db:"active" json:"active"`
-	CreatedAt     time.Time  `db:"created_at" json:"created_at"`
-	UpdatedAt     time.Time  `db:"updated_at" json:"updated_at"`
-	RevokedAt     *time.Time `db:"revoked_at" json:"revoked_at,omitempty"`
+	ID            int64  `db:"id" json:"id"`
+	GrantorUID    string `db:"grantor_uid" json:"grantor_uid"`
+	GranteeBotUID string `db:"grantee_bot_uid" json:"grantee_bot_uid"`
+	// GranteeBotName is the bot's human-facing display name (user.name on
+	// the row whose uid == grantee_bot_uid). Empty string when the bot
+	// has no user row OR when the field was loaded by a query that did
+	// not include the JOIN. listGrantsByGrantor guarantees a non-empty
+	// value via COALESCE(u.name, g.grantee_bot_uid).
+	GranteeBotName string     `db:"grantee_bot_name" json:"grantee_bot_name"`
+	Mode           string     `db:"mode" json:"mode"`
+	GlobalEnabled  int        `db:"global_enabled" json:"global_enabled"`
+	Active         int        `db:"active" json:"active"`
+	CreatedAt      time.Time  `db:"created_at" json:"created_at"`
+	UpdatedAt      time.Time  `db:"updated_at" json:"updated_at"`
+	RevokedAt      *time.Time `db:"revoked_at" json:"revoked_at,omitempty"`
 }
 
 // oboScopeModel mirrors obo_scopes.
@@ -269,12 +283,33 @@ func (d *botAPIDB) insertGrant(grantorUID, granteeBotUID, mode string) (int64, e
 
 // listGrantsByGrantor returns ALL rows (active + revoked) so the UI can
 // surface history. Callers that only want active rows must filter.
+//
+// LEFT JOIN `user` enriches each row with the grantee bot's display name
+// (user.name on the row whose uid == grantee_bot_uid). The bot's display
+// name lives on the `user` table, NOT the `robot` table (the robot table
+// has no name column — see modules/robot/sql/20210926000001_robot_legacy01
+// and the precedent in modules/user/api.go ~L3612: every other place that
+// needs a bot's name does the same JOIN). COALESCE falls back to the raw
+// uid when the user row is missing, so callers always get a non-empty
+// `grantee_bot_name` — eliminating the PersonaCard fallback that
+// surfaced `<uid>_bot` literals to humans (YUJ-1358 / octo-web#60).
+//
+// LEFT JOIN (not INNER) preserves grants whose bot user row has been
+// deleted (e.g. cleanup script ran ahead of the grant revoke). Those
+// rows still need to render in the UI so the operator can revoke them.
 func (d *botAPIDB) listGrantsByGrantor(grantorUID string) ([]*oboGrantModel, error) {
 	var grants []*oboGrantModel
-	_, err := d.session.Select("*").From("obo_grants").
-		Where("grantor_uid=?", grantorUID).
-		OrderBy("created_at DESC").
-		Load(&grants)
+	_, err := d.session.SelectBySql(
+		"SELECT g.id, g.grantor_uid, g.grantee_bot_uid, "+
+			"COALESCE(u.name, g.grantee_bot_uid) AS grantee_bot_name, "+
+			"g.mode, g.global_enabled, g.active, "+
+			"g.created_at, g.updated_at, g.revoked_at "+
+			"FROM obo_grants g "+
+			"LEFT JOIN `user` u ON u.uid = g.grantee_bot_uid "+
+			"WHERE g.grantor_uid=? "+
+			"ORDER BY g.created_at DESC",
+		grantorUID,
+	).Load(&grants)
 	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
 		return nil, err
 	}

--- a/modules/bot_api/obo_fake_test.go
+++ b/modules/bot_api/obo_fake_test.go
@@ -32,6 +32,11 @@ type fakeOBOStore struct {
 	// (user.robot=0). queryRobotOwner returns IsBot=false for these. Used
 	// to test the "grantee_bot_uid is a real user, not a bot" rejection.
 	nonBotUsers map[string]bool
+	// botNames maps botUID → display name (user.name). listGrantsByGrantor
+	// reads this map to populate GranteeBotName, mirroring the prod LEFT
+	// JOIN against the `user` table (YUJ-1358). When a name is absent the
+	// fake falls back to the bot uid (same as prod's COALESCE).
+	botNames map[string]string
 
 	// Test-side error injection hooks. Defaults to nil → no error.
 	failFindActiveGrant   error
@@ -52,6 +57,7 @@ func newFakeOBOStore() *fakeOBOStore {
 		scopes:      map[int64]*oboScopeModel{},
 		robotOwners: map[string]string{},
 		nonBotUsers: map[string]bool{},
+		botNames:    map[string]string{},
 	}
 }
 
@@ -68,6 +74,9 @@ func (f *fakeOBOStore) ensureInit() {
 	if f.nonBotUsers == nil {
 		f.nonBotUsers = map[string]bool{}
 	}
+	if f.botNames == nil {
+		f.botNames = map[string]string{}
+	}
 }
 
 // seedBot registers `botUID` as a bot owned by `creatorUID`. Helper for
@@ -77,6 +86,18 @@ func (f *fakeOBOStore) seedBot(botUID, creatorUID string) {
 	defer f.mu.Unlock()
 	f.ensureInit()
 	f.robotOwners[botUID] = creatorUID
+}
+
+// seedBotName registers `botUID` → `displayName` for the fake's
+// listGrantsByGrantor name lookup. Tests that need to assert on the
+// JOIN-derived `grantee_bot_name` field should seed both ownership
+// (seedBot) and a name. Unsealed bots fall back to the bot uid, mirroring
+// the COALESCE in the production query (YUJ-1358).
+func (f *fakeOBOStore) seedBotName(botUID, displayName string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureInit()
+	f.botNames[botUID] = displayName
 }
 
 // seedNonBotUser marks `uid` as a real (human) user — exists in `user`
@@ -180,6 +201,13 @@ func (f *fakeOBOStore) listGrantsByGrantor(grantorUID string) ([]*oboGrantModel,
 	for _, g := range f.grants {
 		if g.GrantorUID == grantorUID {
 			cp := *g
+			// Mirror prod's LEFT JOIN COALESCE(u.name, g.grantee_bot_uid):
+			// always populate a non-empty display name (YUJ-1358).
+			if name, ok := f.botNames[g.GranteeBotUID]; ok && name != "" {
+				cp.GranteeBotName = name
+			} else {
+				cp.GranteeBotName = g.GranteeBotUID
+			}
 			out = append(out, &cp)
 		}
 	}


### PR DESCRIPTION
## Summary

Persona Clone 分身列表卡片 (octo-web#60) renders the bot's raw uid (e.g. `27qFHDRBCJQ2c868c93_bot`) instead of the display name (e.g. `james`). Root cause: `GET /v1/obo/grants` only returned `grantee_bot_uid`, so the web `PersonaCard`'s `grant.grantee_bot_name || grant.grantee_bot_uid` fallback always hit the uid branch.

Server-side JOIN per task spec (option A) — frontend stays untouched.

## Changes

### `modules/bot_api/obo_db.go`

- `oboGrantModel`: new `GranteeBotName string` field with `db:"grantee_bot_name" json:"grantee_bot_name"`. Not a real `obo_grants` column — populated only by `listGrantsByGrantor` via a SELECT alias. Other reads that do `SELECT * FROM obo_grants` leave it empty (dbr ignores absent columns), which is fine: only the listing endpoint is read by `PersonaCard`.
- `listGrantsByGrantor`: switch from `Select("*").From("obo_grants")` to an explicit `SelectBySql` with `LEFT JOIN user u ON u.uid = g.grantee_bot_uid`, returning `COALESCE(u.name, g.grantee_bot_uid) AS grantee_bot_name`.
  - `LEFT JOIN` (not `INNER`) so grants whose bot `user` row has been deleted out from under them still surface to the UI for revoke.
  - `COALESCE` guarantees the field is never empty.

### Note on which table holds the name

The issue body suggested joining the `robot` table, but `robot` has no `name` column (see `modules/robot/sql/20210926000001_robot_legacy01.sql`). The bot's display name lives on `user.name` joined on `user.uid == robot.robot_id`. This is the same JOIN every other bot-name lookup in this codebase uses — see `modules/user/api.go ~L3612`.

### Fake store

- `fakeOBOStore.botNames` map + `seedBotName` helper
- `listGrantsByGrantor` populates `GranteeBotName` with the same `COALESCE`-style fallback so test assertions mirror prod

### Tests

- `TestOBO_ListGrants_PopulatesGranteeBotName` — HTTP-level: two grants, one with a seeded name, one without. Asserts named → display name; unnamed → uid fallback; every row has a non-empty `grantee_bot_name` (regression guard).
- `TestOBO_StoreListGrantsByGrantor_GranteeBotNameContract` — store-level invariant pinned for future callers.

## Verification

```
go build ./...                              OK
go vet ./...                                OK (clean)
go test ./modules/bot_api/... -run OBO      all PASS (37 tests)
go test ./modules/bot_api/...               all PASS
```

Refs https://github.com/Mininglamp-OSS/octo-web/issues/60
Fixes YUJ-1358
