### PR TITLE
feat(auth): add login.local_off switch to disable local-account login

### DIFF
--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -132,7 +132,9 @@ func (cn *Common) Route(r *wkhttp.WKHttp) {
 	// 启动期校验:DB 已写入 login.local_off=1 但部署没有任何第三方登录
 	// 提供方,LocalLoginOff() 会自动回退为 false 避免锁死。把这个状态作为
 	// error 日志显式打出,让运维一眼能看到"开关写了但当前不生效"。
-	cn.systemSettings.LogLocalLoginOffSafetyOverrideIfActive()
+	// 此处直接读 snapshot 是安全的:Load 刚刚完成,值就是 DB 当前值。
+	cn.systemSettings.LogLocalLoginOffSafetyOverrideIfActive(
+		cn.systemSettings.RawLocalLoginOffFromSnapshot())
 }
 
 // 获取后台运行引导视频

--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -128,6 +128,11 @@ func (cn *Common) Route(r *wkhttp.WKHttp) {
 	}
 	cn.ctx.GetConfig().AppRSAPrivateKey = privateKey
 	cn.ctx.GetConfig().AppRSAPubKey = appConfigM.RSAPublicKey
+
+	// 启动期校验:DB 已写入 login.local_off=1 但部署没有任何第三方登录
+	// 提供方,LocalLoginOff() 会自动回退为 false 避免锁死。把这个状态作为
+	// error 日志显式打出,让运维一眼能看到"开关写了但当前不生效"。
+	cn.systemSettings.LogLocalLoginOffSafetyOverrideIfActive()
 }
 
 // 获取后台运行引导视频
@@ -358,6 +363,17 @@ func (cn *Common) insertAppConfigIfNeed() (*appConfigModel, error) {
 	return appConfigM, err
 }
 
+// boolToFlag normalises a bool getter result to the 0/1 int flag used by
+// existing appconfig JSON fields (phone_search_off, shortno_edit_off, ...).
+// Keeps the wire shape int across the response so frontend doesn't need a
+// special "boolean-or-int" decode path for one field.
+func boolToFlag(v bool) int {
+	if v {
+		return 1
+	}
+	return 0
+}
+
 func (cn *Common) appConfig(c *wkhttp.Context) {
 	versionStr := c.Query("version")
 	appConfigM, err := cn.appConfigDB.query()
@@ -379,6 +395,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 		c.JSON(http.StatusOK, &appConfigResp{
 			Version:       appConfigM.Version,
 			SystemBotUIDs: spacepkg.SystemBotList(),
+			LocalLoginOff: boolToFlag(cn.systemSettings.LocalLoginOff()),
 		})
 		return
 	}
@@ -415,6 +432,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 		OIDCProviders:                  oidcProviders(),
 		// YUJ-219-A / GH#1283：单一真源下发系统 Bot UID 列表，替代三端硬编码。
 		SystemBotUIDs: spacepkg.SystemBotList(),
+		LocalLoginOff: boolToFlag(cn.systemSettings.LocalLoginOff()),
 	})
 }
 
@@ -696,6 +714,14 @@ type appConfigResp struct {
 	// 消费此字段并替换硬编码常量，保持与后端 SystemBotList() 完全一致。
 	// 未来系统 Bot 列表调整（加新 Bot / 改名）只需改后端，无需同步三端。
 	SystemBotUIDs []string `json:"system_bot_uids"`
+
+	// LocalLoginOff 控制前端是否隐藏"本地账号登录"卡片（用户名 / 手机号 / 邮箱
+	// 三种本地登录方式的统一开关）。值来源于 system_setting login.local_off，
+	// 默认 0；为 1 时前端只渲染 SSO/第三方登录入口。
+	//
+	// 与 app_config.version 解耦：即使客户端命中 version 短路分支，也必须能拿到
+	// 最新值，否则 admin 切换开关后老客户端会被本地缓存住。和 SystemBotUIDs 同理。
+	LocalLoginOff int `json:"local_login_off"`
 }
 
 type oidcProviderResp struct {

--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -502,9 +502,20 @@ func oidcResetPasswordURL() string {
 	return os.Getenv("DM_OIDC_RESET_PASSWORD_URL")
 }
 
+// oidcEnabled reports whether OIDC is intended to be on. Parsing must match
+// modules/oidc/config.go:getBool (strconv.ParseBool) byte-for-byte and stay
+// in lockstep with isOIDCFullyConfigured in system_settings.go — diverging
+// here causes a front-end lockout where local_login_off=1 hides the local
+// card while oidc_providers / oidc_account_url are silently omitted because
+// this function rejects spellings like "T" or "True" that the OIDC module
+// itself accepts. See PR #104 P0 (Jerry-Xin).
 func oidcEnabled() bool {
-	v := strings.ToLower(os.Getenv("DM_OIDC_ENABLED"))
-	return v == "true" || v == "1"
+	v := os.Getenv("DM_OIDC_ENABLED")
+	if v == "" {
+		return false
+	}
+	enabled, err := strconv.ParseBool(v)
+	return err == nil && enabled
 }
 
 // 兼容历史 app_config 行（NOT NULL DEFAULT 7 在迁移前的行为）：值 ≤ 0 时回退为 7。

--- a/modules/common/api_manager_system_setting.go
+++ b/modules/common/api_manager_system_setting.go
@@ -276,14 +276,17 @@ func (m *Manager) updateSystemSettings(c *wkhttp.Context) {
 		m.Warn("Reload SystemSettings 失败，等待自动刷新", zap.Error(err))
 	}
 
-	// 写入若涉及 login.local_off,在 Reload 之后再校验一次第三方登录是否齐备。
-	// 故意不阻塞写入:允许 admin 在尚未配置 SSO 时先把开关写到 DB(例如先准
-	// 备运维下一步切流的开关位),LocalLoginOff() 的安全回退会保证此时仍可
-	// 本地登录;日志是唯一信号,告诉运维"开关已落库但当前未生效,先去补
-	// SSO 配置"。
+	// 写入若涉及 login.local_off,直接用刚刚校验过的 plan.value 触发 safety
+	// override 日志。**不** 读 snapshot —— 那会被 Reload 失败路径吞掉信号
+	// (PR #104 P2 from yujiawei)。故意不阻塞写入:允许 admin 在尚未配置 SSO
+	// 时先把开关写到 DB(例如先准备运维下一步切流的开关位),LocalLoginOff()
+	// 的安全回退会保证此时仍可本地登录;日志是唯一信号,告诉运维"开关已
+	// 落库但当前未生效,先去补 SSO 配置"。
 	for _, p := range plans {
 		if p.def.Category == "login" && p.def.Key == "local_off" {
-			m.systemSettings.LogLocalLoginOffSafetyOverrideIfActive()
+			// p.value 已被 normaliseBool 规范成 "0" / "1" / ""(空=回退 yaml,
+			// 即 false)。任何非 "1" 都不视为开启。
+			m.systemSettings.LogLocalLoginOffSafetyOverrideIfActive(p.value == "1")
 			break
 		}
 	}

--- a/modules/common/api_manager_system_setting.go
+++ b/modules/common/api_manager_system_setting.go
@@ -276,6 +276,18 @@ func (m *Manager) updateSystemSettings(c *wkhttp.Context) {
 		m.Warn("Reload SystemSettings 失败，等待自动刷新", zap.Error(err))
 	}
 
+	// 写入若涉及 login.local_off,在 Reload 之后再校验一次第三方登录是否齐备。
+	// 故意不阻塞写入:允许 admin 在尚未配置 SSO 时先把开关写到 DB(例如先准
+	// 备运维下一步切流的开关位),LocalLoginOff() 的安全回退会保证此时仍可
+	// 本地登录;日志是唯一信号,告诉运维"开关已落库但当前未生效,先去补
+	// SSO 配置"。
+	for _, p := range plans {
+		if p.def.Category == "login" && p.def.Key == "local_off" {
+			m.systemSettings.LogLocalLoginOffSafetyOverrideIfActive()
+			break
+		}
+	}
+
 	c.ResponseOK()
 }
 

--- a/modules/common/api_test.go
+++ b/modules/common/api_test.go
@@ -119,6 +119,100 @@ func TestGetAppConfig_SystemBotUIDsOnVersionShortCircuit(t *testing.T) {
 	assert.Contains(t, body, `"fileHelper"`)
 }
 
+// appconfig 必须下发 local_login_off：默认 0（缺 system_setting 行）。
+func TestGetAppConfig_LocalLoginOff_DefaultsZero(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	err := testutil.CleanAllTables(ctx)
+	assert.NoError(t, err)
+	err = f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"local_login_off":0`)
+}
+
+// system_setting login.local_off=1 + 第三方登录配置齐备时，appconfig 必须
+// 下发 local_login_off=1。OIDC 启用满足"第三方登录已配置"前置条件 —— 没有
+// 这一步 LocalLoginOff() 会触发安全回退强行返回 false,前端会继续渲染本地
+// 登录卡片。这条用例对齐"admin 在配齐 SSO 后才开关本地登录"的运维路径。
+func TestGetAppConfig_LocalLoginOff_DBOverride(t *testing.T) {
+	enableFullOIDCForTest(t)
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	err := testutil.CleanAllTables(ctx)
+	assert.NoError(t, err)
+	err = f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+
+	settings := EnsureSystemSettings(ctx)
+	assert.NoError(t, settings.db.upsert("login", "local_off", "1", settingTypeBool, ""))
+	assert.NoError(t, settings.Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"local_login_off":1`)
+}
+
+// 版本号短路分支同样要下发 local_login_off：system_setting 与 app_config.version
+// 解耦，老客户端命中版本短路也必须看到当前开关，避免被缓存住。
+func TestGetAppConfig_LocalLoginOff_OnVersionShortCircuit(t *testing.T) {
+	enableFullOIDCForTest(t)
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	err := testutil.CleanAllTables(ctx)
+	assert.NoError(t, err)
+	err = f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+
+	settings := EnsureSystemSettings(ctx)
+	assert.NoError(t, settings.db.upsert("login", "local_off", "1", settingTypeBool, ""))
+	assert.NoError(t, settings.Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig?version=99999999", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"local_login_off":1`)
+}
+
+// 安全回退在 appconfig 层同样要体现:DB 写了 local_off=1 但部署没配置任何
+// SSO 时,下发的 local_login_off 必须为 0,否则前端会隐藏本地登录卡片导致
+// 所有人都进不来。这条用例锁定"appconfig 返回的是 effective 值而不是 DB
+// 原始值"这个语义,与 LocalLoginOff() getter 的安全回退一致。
+func TestGetAppConfig_LocalLoginOff_SafetyOverrideWithoutSSO(t *testing.T) {
+	t.Setenv("DM_OIDC_ENABLED", "")
+	s, ctx := testutil.NewTestServer()
+	ctx.GetConfig().Github.ClientID = ""
+	ctx.GetConfig().Github.ClientSecret = ""
+	ctx.GetConfig().Gitee.ClientID = ""
+	ctx.GetConfig().Gitee.ClientSecret = ""
+	f := New(ctx)
+	err := testutil.CleanAllTables(ctx)
+	assert.NoError(t, err)
+	err = f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+
+	settings := EnsureSystemSettings(ctx)
+	assert.NoError(t, settings.db.upsert("login", "local_off", "1", settingTypeBool, ""))
+	assert.NoError(t, settings.Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"local_login_off":0`,
+		"无第三方登录配置 → 自动回退,前端继续显示本地登录")
+}
+
 func TestGetAppConfig_OIDCURLsExplicit(t *testing.T) {
 	t.Setenv("DM_OIDC_ENABLED", "true")
 	t.Setenv("DM_OIDC_ACCOUNT_URL", "https://accounts.example.com/")

--- a/modules/common/api_test.go
+++ b/modules/common/api_test.go
@@ -183,6 +183,46 @@ func TestGetAppConfig_LocalLoginOff_OnVersionShortCircuit(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"local_login_off":1`)
 }
 
+// PR #104 reviewer Jerry-Xin (P0 on commit 72e67c83): DM_OIDC_ENABLED 在
+// appconfig 三个 OIDC 出口(oidc_providers / oidc_account_url /
+// oidc_reset_password_url)上的解析必须与 LocalLoginOff() 安全回退完全一致,
+// 否则会出现"local_login_off=1 但 oidc_providers 为空"的前端死锁组合:
+// 前端按 local_login_off 隐藏本地登录卡片,又因 oidc_providers omitempty
+// 拿不到 SSO 入口,用户无路可走。
+//
+// 触发场景:DM_OIDC_ENABLED=T(或 True / TRUE 等 ParseBool 合法但非 "true"/
+// "1" 字面量) + 完整 OIDC + local_off=1。
+func TestGetAppConfig_OIDCProvidersHonoursParseBoolSpellings(t *testing.T) {
+	for _, spelling := range []string{"t", "T", "True", "TRUE"} {
+		t.Run(spelling, func(t *testing.T) {
+			enableFullOIDCForTest(t)
+			t.Setenv("DM_OIDC_ENABLED", spelling)
+
+			s, ctx := testutil.NewTestServer()
+			f := New(ctx)
+			err := testutil.CleanAllTables(ctx)
+			assert.NoError(t, err)
+			err = f.appConfigDB.insert(&appConfigModel{})
+			assert.NoError(t, err)
+
+			settings := EnsureSystemSettings(ctx)
+			assert.NoError(t, settings.db.upsert("login", "local_off", "1", settingTypeBool, ""))
+			assert.NoError(t, settings.Reload())
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+			req.Header.Set("token", testutil.Token)
+			s.GetRoute().ServeHTTP(w, req)
+			body := w.Body.String()
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Contains(t, body, `"local_login_off":1`,
+				"DM_OIDC_ENABLED=%q + full OIDC + local_off=1 → 应下发 local_login_off=1", spelling)
+			assert.Contains(t, body, `"oidc_providers"`,
+				"同一个 DM_OIDC_ENABLED 值在 oidcEnabled() 与 isOIDCFullyConfigured() 必须解析一致,否则前端拿不到 SSO 入口")
+		})
+	}
+}
+
 // 安全回退在 appconfig 层同样要体现:DB 写了 local_off=1 但部署没配置任何
 // SSO 时,下发的 local_login_off 必须为 0,否则前端会隐藏本地登录卡片导致
 // 所有人都进不来。这条用例锁定"appconfig 返回的是 effective 值而不是 DB

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -44,6 +44,12 @@ var systemSettingSchema = []settingDef{
 	{Category: "register", Key: "email_on", Type: settingTypeBool, Description: "是否开启邮箱注册/登录",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.RegisterEmailOn()) }},
 
+	// Local-account login master toggle — when on, hides local login UI and
+	// rejects /v1/user/login, /v1/user/usernamelogin, /v1/user/emaillogin so
+	// SSO-only deployments can route all users through OIDC/GitHub/Gitee.
+	{Category: "login", Key: "local_off", Type: settingTypeBool, Description: "是否关闭本地账号登录入口",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.LocalLoginOff()) }},
+
 	// Email server config — formerly yaml-only (Support.* in config.go).
 	{Category: "support", Key: "email", Type: settingTypeString, Description: "技术支持邮箱（发件人）",
 		Effective: func(s *SystemSettings) string { return s.SupportEmail() }},

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"os"
+	"regexp"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -302,8 +302,20 @@ func anyThirdPartyLoginConfigured(cfg *config.Config) bool {
 	return false
 }
 
-// isOIDCFullyConfigured mirrors the required-env list inside
-// modules/oidc/config.go:loadProvider (plus the RT encryption key check).
+// oidcProviderIDRe mirrors modules/oidc/config.go:providerIDRe. Kept in sync
+// by the reciprocal comments on both sides (see loadProvider's required block).
+// A literal duplication, not a regex compiled from a shared string, because
+// the alternative (extracting to a leaf package) would touch ~10 files for
+// one shared regex; the maintenance cost is one extra place to update if
+// the rule ever changes.
+var oidcProviderIDRe = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,63}$`)
+
+// isOIDCFullyConfigured mirrors the fatal checks inside
+// modules/oidc/config.go:loadProvider — including the provider-ID regex,
+// because an invalid ID makes LoadConfig fail, leaves oidc.cfg=nil, and
+// causes the OIDC routes to be registered as 404/disabled at request time.
+// Skipping the regex would let local_off=1 + invalid PROVIDER_ID slip past
+// the safety override and lock everyone out.
 //
 // Why duplicated instead of importing modules/oidc:
 //   modules/common ← system_settings.go would need to import modules/oidc,
@@ -315,18 +327,26 @@ func anyThirdPartyLoginConfigured(cfg *config.Config) bool {
 //   prompts updating both places.
 //
 // Mirrored requirements (keep in sync with modules/oidc/config.go):
-//   - DM_OIDC_ENABLED=true|1
+//   - DM_OIDC_ENABLED  parsed by strconv.ParseBool — accepts 1/0/t/T/true/
+//     True/TRUE/f/F/false/etc, matching oidc/config.go:getBool exactly.
+//     Earlier strings.ToLower-style parsing diverged on "t"/"T".
+//   - DM_OIDC_PROVIDER_ID             default "oidc"; must match providerIDRe
 //   - DM_OIDC_PROVIDER_ISSUER         (alias DM_OIDC_AEGIS_ISSUER)
 //   - DM_OIDC_PROVIDER_CLIENT_ID      (alias DM_OIDC_AEGIS_CLIENT_ID)
 //   - DM_OIDC_PROVIDER_CLIENT_SECRET  (alias DM_OIDC_AEGIS_CLIENT_SECRET)
 //   - DM_OIDC_PROVIDER_REDIRECT_URI   (alias DM_OIDC_AEGIS_REDIRECT_URI)
 //   - DM_OIDC_RT_ENC_KEY              (base64, 32 bytes after decode)
 //
-// We intentionally do NOT replicate provider-ID regex / scope / duration
-// checks — those are non-fatal for "is there a working IdP?" guard, only
-// affect specific request paths.
+// We intentionally do NOT replicate non-fatal checks (scope strings,
+// durations) — those don't make LoadConfig fail and don't disable the
+// callback path.
 func isOIDCFullyConfigured() bool {
-	if v := strings.ToLower(os.Getenv("DM_OIDC_ENABLED")); v != "true" && v != "1" {
+	v := os.Getenv("DM_OIDC_ENABLED")
+	if v == "" {
+		return false
+	}
+	enabled, err := strconv.ParseBool(v)
+	if err != nil || !enabled {
 		return false
 	}
 	required := []struct {
@@ -341,6 +361,15 @@ func isOIDCFullyConfigured() bool {
 		if os.Getenv(r.primary) == "" && os.Getenv(r.alias) == "" {
 			return false
 		}
+	}
+	// Provider ID: empty falls back to "oidc" (matches loadProvider default),
+	// non-empty must satisfy the same regex or LoadConfig fails fatally.
+	providerID := os.Getenv("DM_OIDC_PROVIDER_ID")
+	if providerID == "" {
+		providerID = "oidc"
+	}
+	if !oidcProviderIDRe.MatchString(providerID) {
+		return false
 	}
 	// RT key must base64-decode to 32 bytes (AES-256). Just non-empty is not
 	// enough — oidc/config.go rejects wrong-length keys at boot, our guard
@@ -358,19 +387,27 @@ func isOIDCFullyConfigured() bool {
 }
 
 // LogLocalLoginOffSafetyOverrideIfActive emits a single error-level log entry
-// when the DB has login.local_off=1 but no third-party login is configured —
+// when local_off is intended to be on but no third-party login is configured —
 // the exact state where LocalLoginOff() silently returns false to keep the
 // deployment from locking itself. The log is the only signal ops have that
 // the admin's intent is currently being overridden; without it the
 // inconsistency is invisible until someone wonders why local login still
 // works after flipping the switch.
 //
-// Callers: invoke once at server startup (Common.Route) after Load completes.
-// Also called from the manager update handler after a write that touched
-// login.local_off, so the same warning surfaces when the danger is created
-// at runtime — not only across restarts.
-func (s *SystemSettings) LogLocalLoginOffSafetyOverrideIfActive() {
-	if !s.getBool("login", "local_off", false) {
+// Why localOff is a parameter, not read from snapshot here:
+//   Callers know the intended value with stronger guarantees than the
+//   shared snapshot. The manager-write path can pass the just-validated
+//   request value (independent of whether Reload succeeded — PR #104 P2
+//   from yujiawei). Startup passes the freshly-loaded snapshot value.
+//   Reading the snapshot directly inside this method would silently miss
+//   the warning when Reload fails right after a write, exactly when ops
+//   most needs the signal.
+//
+// Callers: invoke once at server startup (Common.Route) after Load
+// completes, and from the manager update handler after a write that
+// touched login.local_off (passing the plan's value).
+func (s *SystemSettings) LogLocalLoginOffSafetyOverrideIfActive(localOff bool) {
+	if !localOff {
 		return
 	}
 	if anyThirdPartyLoginConfigured(s.ctx.GetConfig()) {
@@ -378,6 +415,16 @@ func (s *SystemSettings) LogLocalLoginOffSafetyOverrideIfActive() {
 	}
 	s.Error("login.local_off=1 但未配置任何第三方登录 (OIDC / GitHub / Gitee); " +
 		"已自动回退为允许本地登录,避免锁死;请尽快补齐第三方登录配置后再开启此开关")
+}
+
+// RawLocalLoginOffFromSnapshot returns the snapshot's raw DB value for
+// login.local_off without applying the SSO-safety override. Used by callers
+// that need to feed LogLocalLoginOffSafetyOverrideIfActive at startup (the
+// snapshot has just been loaded, so freshness isn't a concern). Exposed
+// publicly because the field-level `getBool` is package-private and the
+// only external need is this one logging path.
+func (s *SystemSettings) RawLocalLoginOffFromSnapshot() bool {
+	return s.getBool("login", "local_off", false)
 }
 
 // SupportEmail returns the From address used by the SMTP sender.

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -2,7 +2,10 @@ package common
 
 import (
 	"context"
+	"encoding/base64"
+	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -247,6 +250,134 @@ func (s *SystemSettings) RegisterUsernameOn() bool {
 // RegisterEmailOn returns whether email-based registration / login is enabled.
 func (s *SystemSettings) RegisterEmailOn() bool {
 	return s.getBool("register", "email_on", s.ctx.GetConfig().Register.EmailOn)
+}
+
+// LocalLoginOff returns whether local-account login entry points should be
+// disabled. When true, frontend hides the local login UI and backend rejects
+// requests to /v1/user/login, /v1/user/usernamelogin, /v1/user/emaillogin and
+// their companion code-send endpoints. Password-recovery flows and third-party
+// /SSO (GitHub, Gitee, OIDC) are not affected — this toggle is meant for
+// deployments that have adopted SSO and want to force users through it.
+//
+// Default false (no yaml fallback): plain self-hosted deployments without DB
+// override keep the historical "local login enabled" behavior.
+//
+// Safety override: even if the DB says local_off=1, this getter returns false
+// when no third-party login (OIDC / GitHub / Gitee) is actually configured.
+// Without the override an admin who flips the switch before wiring up an IdP
+// would lock everyone — including themselves — out of the system. The
+// override always picks "open" so the deployment stays accessible while ops
+// fixes the missing SSO config. The hazard is surfaced via startup log
+// (logLocalLoginOffSafetyOverride) so it isn't silently swallowed.
+func (s *SystemSettings) LocalLoginOff() bool {
+	if !s.getBool("login", "local_off", false) {
+		return false
+	}
+	return anyThirdPartyLoginConfigured(s.ctx.GetConfig())
+}
+
+// anyThirdPartyLoginConfigured reports whether at least one external login
+// provider has the credentials it needs to handle a real auth round-trip.
+// LocalLoginOff guards on this so flipping the master switch without wiring
+// up an IdP can never brick the deployment.
+//
+// Checked providers:
+//   - OIDC: must be enabled AND all hard-required env present (see
+//     isOIDCFullyConfigured). DM_OIDC_ENABLED=true alone is insufficient —
+//     missing issuer / client_id / etc. makes the callback 4xx/5xx at
+//     runtime, effectively no usable SSO.
+//   - GitHub: client_id AND client_secret in yaml/env (both required for
+//     the OAuth code exchange in api_github.go).
+//   - Gitee:  client_id AND client_secret in yaml/env (same shape).
+func anyThirdPartyLoginConfigured(cfg *config.Config) bool {
+	if isOIDCFullyConfigured() {
+		return true
+	}
+	if cfg.Github.ClientID != "" && cfg.Github.ClientSecret != "" {
+		return true
+	}
+	if cfg.Gitee.ClientID != "" && cfg.Gitee.ClientSecret != "" {
+		return true
+	}
+	return false
+}
+
+// isOIDCFullyConfigured mirrors the required-env list inside
+// modules/oidc/config.go:loadProvider (plus the RT encryption key check).
+//
+// Why duplicated instead of importing modules/oidc:
+//   modules/common ← system_settings.go would need to import modules/oidc,
+//   but modules/oidc transitively imports modules/user → modules/common,
+//   creating a cycle. Extracting oidc.LoadConfig into its own leaf package
+//   was considered and rejected as out-of-scope churn for this PR. The
+//   trade-off is mirroring the required-env list here; modules/oidc/
+//   config.go carries a reciprocal comment so adding a new required env
+//   prompts updating both places.
+//
+// Mirrored requirements (keep in sync with modules/oidc/config.go):
+//   - DM_OIDC_ENABLED=true|1
+//   - DM_OIDC_PROVIDER_ISSUER         (alias DM_OIDC_AEGIS_ISSUER)
+//   - DM_OIDC_PROVIDER_CLIENT_ID      (alias DM_OIDC_AEGIS_CLIENT_ID)
+//   - DM_OIDC_PROVIDER_CLIENT_SECRET  (alias DM_OIDC_AEGIS_CLIENT_SECRET)
+//   - DM_OIDC_PROVIDER_REDIRECT_URI   (alias DM_OIDC_AEGIS_REDIRECT_URI)
+//   - DM_OIDC_RT_ENC_KEY              (base64, 32 bytes after decode)
+//
+// We intentionally do NOT replicate provider-ID regex / scope / duration
+// checks — those are non-fatal for "is there a working IdP?" guard, only
+// affect specific request paths.
+func isOIDCFullyConfigured() bool {
+	if v := strings.ToLower(os.Getenv("DM_OIDC_ENABLED")); v != "true" && v != "1" {
+		return false
+	}
+	required := []struct {
+		primary, alias string
+	}{
+		{"DM_OIDC_PROVIDER_ISSUER", "DM_OIDC_AEGIS_ISSUER"},
+		{"DM_OIDC_PROVIDER_CLIENT_ID", "DM_OIDC_AEGIS_CLIENT_ID"},
+		{"DM_OIDC_PROVIDER_CLIENT_SECRET", "DM_OIDC_AEGIS_CLIENT_SECRET"},
+		{"DM_OIDC_PROVIDER_REDIRECT_URI", "DM_OIDC_AEGIS_REDIRECT_URI"},
+	}
+	for _, r := range required {
+		if os.Getenv(r.primary) == "" && os.Getenv(r.alias) == "" {
+			return false
+		}
+	}
+	// RT key must base64-decode to 32 bytes (AES-256). Just non-empty is not
+	// enough — oidc/config.go rejects wrong-length keys at boot, our guard
+	// should be at least as strict so a deployment that would fail to boot
+	// can't be marked "configured".
+	keyB64 := os.Getenv("DM_OIDC_RT_ENC_KEY")
+	if keyB64 == "" {
+		return false
+	}
+	key, err := base64.StdEncoding.DecodeString(keyB64)
+	if err != nil || len(key) != 32 {
+		return false
+	}
+	return true
+}
+
+// LogLocalLoginOffSafetyOverrideIfActive emits a single error-level log entry
+// when the DB has login.local_off=1 but no third-party login is configured —
+// the exact state where LocalLoginOff() silently returns false to keep the
+// deployment from locking itself. The log is the only signal ops have that
+// the admin's intent is currently being overridden; without it the
+// inconsistency is invisible until someone wonders why local login still
+// works after flipping the switch.
+//
+// Callers: invoke once at server startup (Common.Route) after Load completes.
+// Also called from the manager update handler after a write that touched
+// login.local_off, so the same warning surfaces when the danger is created
+// at runtime — not only across restarts.
+func (s *SystemSettings) LogLocalLoginOffSafetyOverrideIfActive() {
+	if !s.getBool("login", "local_off", false) {
+		return
+	}
+	if anyThirdPartyLoginConfigured(s.ctx.GetConfig()) {
+		return
+	}
+	s.Error("login.local_off=1 但未配置任何第三方登录 (OIDC / GitHub / Gitee); " +
+		"已自动回退为允许本地登录,避免锁死;请尽快补齐第三方登录配置后再开启此开关")
 }
 
 // SupportEmail returns the From address used by the SMTP sender.

--- a/modules/common/system_settings_test.go
+++ b/modules/common/system_settings_test.go
@@ -157,6 +157,50 @@ func TestSystemSettings_LocalLoginOff_AutoFalseWhenOIDCEnabledButMisconfigured(t
 		"OIDC ENABLED 但配置残缺时,等同无可用第三方登录,必须回退避免锁死")
 }
 
+// PR #104 reviewer Jerry-Xin (P0): DM_OIDC_PROVIDER_ID 非法时,
+// modules/oidc/config.go:loadProvider 会 fatal,api.go:119 把 cfg 置 nil,
+// 整套 OIDC handler 被注册为 disabled (api.go:256)。此时 SSO 实际上不可用,
+// 但本镜像如果只看 issuer/client_id/secret/redirect/rt_key 仍会返回 true,
+// 配合 local_off=1 就锁死。镜像必须连 providerIDRe 一起守。
+func TestSystemSettings_LocalLoginOff_AutoFalseWhenOIDCProviderIDInvalid(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	enableFullOIDCForTest(t)
+	// 完整配置之上,把 provider ID 改成正则不允许的值(含 '/')。
+	t.Setenv("DM_OIDC_PROVIDER_ID", "foo/bar")
+	s.ctx.GetConfig().Github.ClientID = ""
+	s.ctx.GetConfig().Github.ClientSecret = ""
+	s.ctx.GetConfig().Gitee.ClientID = ""
+	s.ctx.GetConfig().Gitee.ClientSecret = ""
+
+	require.NoError(t, s.db.upsert("login", "local_off", "1", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+	assert.False(t, s.LocalLoginOff(),
+		"非法 provider ID 让 OIDC handler 被禁用,等同无可用 SSO,必须回退")
+}
+
+// PR #104 reviewer yujiawei (P2): DM_OIDC_ENABLED 解析必须与
+// modules/oidc/config.go:getBool 完全一致 —— 后者用 strconv.ParseBool,
+// 接受 t/T/True/TRUE 等。镜像如果只识别 "true"/"1" 会出现 OIDC 实际在跑
+// 但 isOIDCFullyConfigured 误判为关闭、safety override 错误打开本地登录。
+func TestSystemSettings_LocalLoginOff_AcceptsParseBoolEnabledSpellings(t *testing.T) {
+	for _, spelling := range []string{"t", "T", "True", "TRUE"} {
+		t.Run(spelling, func(t *testing.T) {
+			s := newTestSystemSettings(t, nil)
+			enableFullOIDCForTest(t)
+			t.Setenv("DM_OIDC_ENABLED", spelling)
+			s.ctx.GetConfig().Github.ClientID = ""
+			s.ctx.GetConfig().Github.ClientSecret = ""
+			s.ctx.GetConfig().Gitee.ClientID = ""
+			s.ctx.GetConfig().Gitee.ClientSecret = ""
+
+			require.NoError(t, s.db.upsert("login", "local_off", "1", settingTypeBool, ""))
+			require.NoError(t, s.Reload())
+			assert.True(t, s.LocalLoginOff(),
+				"DM_OIDC_ENABLED=%q 必须与 oidc/config.go 的 ParseBool 一致地识别为开启", spelling)
+		})
+	}
+}
+
 func TestSystemSettings_LocalLoginOff_TrueWhenGitHubConfigured(t *testing.T) {
 	s := newTestSystemSettings(t, nil)
 	t.Setenv("DM_OIDC_ENABLED", "")

--- a/modules/common/system_settings_test.go
+++ b/modules/common/system_settings_test.go
@@ -9,6 +9,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// fullOIDCTestEnv 是测试用的"完整 OIDC 配置最小集",用法是
+// for k, v := range fullOIDCTestEnv { t.Setenv(k, v) }。把 OIDC 切换为
+// "完整可用"状态(对应 modules/oidc/config.go:loadProvider 的所有 required
+// 必填项 + 32 字节 RT 加密 key),从而让 isOIDCFullyConfigured() 返回 true。
+//
+// 这是 system_settings_test.go 和 api_test.go 共用的 fixture。修改
+// modules/oidc 的 required 列表时,这张表也要同步;反之亦然 —— 该常量缺项
+// 会导致原本应通过的守卫用例静默回退,排查路径明显。
+var fullOIDCTestEnv = map[string]string{
+	"DM_OIDC_ENABLED":                "true",
+	"DM_OIDC_PROVIDER_ISSUER":        "https://idp.example.com",
+	"DM_OIDC_PROVIDER_CLIENT_ID":     "test-client",
+	"DM_OIDC_PROVIDER_CLIENT_SECRET": "test-secret",
+	"DM_OIDC_PROVIDER_REDIRECT_URI":  "https://app.example.com/oidc/callback",
+	// 32 字节全零的 base64 编码 —— 仅供测试,不是真实密钥。
+	"DM_OIDC_RT_ENC_KEY": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+}
+
+// enableFullOIDCForTest 调用 t.Setenv 把整张 fullOIDCTestEnv 写进当前测试
+// 的环境,Setenv 在 t.Cleanup 自动复原。先 unset alias(AEGIS_*)防止外部
+// 残留绑定到测试场景,影响断言。
+func enableFullOIDCForTest(t *testing.T) {
+	t.Helper()
+	for _, alias := range []string{
+		"DM_OIDC_AEGIS_ISSUER",
+		"DM_OIDC_AEGIS_CLIENT_ID",
+		"DM_OIDC_AEGIS_CLIENT_SECRET",
+		"DM_OIDC_AEGIS_REDIRECT_URI",
+	} {
+		t.Setenv(alias, "")
+	}
+	for k, v := range fullOIDCTestEnv {
+		t.Setenv(k, v)
+	}
+}
+
 // helper to construct a SystemSettings backed by the test DB plus the given
 // yaml-side defaults applied to the context's config.
 func newTestSystemSettings(t *testing.T, apply func(s *SystemSettings)) *SystemSettings {
@@ -51,6 +87,96 @@ func TestSystemSettings_BoolOverridesYamlWhenSet(t *testing.T) {
 
 	assert.False(t, s.RegisterEmailOn(), "DB 0 must override yaml true")
 	assert.True(t, s.RegisterOff(), "DB 1 must override yaml false")
+}
+
+func TestSystemSettings_LocalLoginOff_DefaultsFalse(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	assert.False(t, s.LocalLoginOff(), "DB 缺字段时默认 false（保持本地登录可用）")
+}
+
+func TestSystemSettings_LocalLoginOff_DBValueWins(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	// 让 OIDC 完整可用,DB local_off=1 才会通过安全回退实际生效。
+	enableFullOIDCForTest(t)
+
+	require.NoError(t, s.db.upsert("login", "local_off", "1", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+	assert.True(t, s.LocalLoginOff(), "DB=1 + OIDC 已配置 → 关闭本地登录")
+
+	require.NoError(t, s.db.upsert("login", "local_off", "0", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+	assert.False(t, s.LocalLoginOff(), "DB=0 → 启用本地登录")
+}
+
+// 安全回退：DB local_off=1 但没有任何第三方登录配置时，LocalLoginOff() 必须
+// 返回 false，否则会把整个系统锁死（前端隐藏本地登录卡片 + 后端拒绝本地登录
+// 请求 = 无人可登录）。守卫此处而不是 panic：让服务能起来，admin 上去看日志
+// 再修复 SSO 配置；管理面写入也按这个语义验证。
+func TestSystemSettings_LocalLoginOff_AutoFalseWhenNoThirdPartyConfigured(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	t.Setenv("DM_OIDC_ENABLED", "")
+	s.ctx.GetConfig().Github.ClientID = ""
+	s.ctx.GetConfig().Github.ClientSecret = ""
+	s.ctx.GetConfig().Gitee.ClientID = ""
+	s.ctx.GetConfig().Gitee.ClientSecret = ""
+
+	require.NoError(t, s.db.upsert("login", "local_off", "1", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+	assert.False(t, s.LocalLoginOff(),
+		"DB=1 但无任何第三方登录配置 → 自动回退为 false，避免锁死")
+}
+
+// DM_OIDC_ENABLED=true 只是 OIDC 的开关位,真正能用还需要 issuer / client_id
+// / client_secret / redirect_uri / rt_enc_key 等一批 env 齐备(详见
+// modules/oidc/config.go:LoadConfig)。任一缺失,callback 在请求时会 404/500,
+// 实际上不存在可用的第三方登录入口 —— 此时若 LocalLoginOff() 仍生效,前端隐藏
+// 本地登录 + 后端拒绝本地登录 + SSO 跑不通 = 全员锁死。安全回退必须看到
+// "OIDC 启用 但 config 残缺" 也算"无可用第三方登录"。
+func TestSystemSettings_LocalLoginOff_AutoFalseWhenOIDCEnabledButMisconfigured(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	t.Setenv("DM_OIDC_ENABLED", "true")
+	// 故意只开 ENABLED,不配 issuer / client_id 等必填项。
+	t.Setenv("DM_OIDC_PROVIDER_ISSUER", "")
+	t.Setenv("DM_OIDC_PROVIDER_CLIENT_ID", "")
+	t.Setenv("DM_OIDC_PROVIDER_CLIENT_SECRET", "")
+	t.Setenv("DM_OIDC_PROVIDER_REDIRECT_URI", "")
+	t.Setenv("DM_OIDC_RT_ENC_KEY", "")
+	// aegis alias 也清掉,避免 alias 兜底。
+	t.Setenv("DM_OIDC_AEGIS_ISSUER", "")
+	t.Setenv("DM_OIDC_AEGIS_CLIENT_ID", "")
+	t.Setenv("DM_OIDC_AEGIS_CLIENT_SECRET", "")
+	t.Setenv("DM_OIDC_AEGIS_REDIRECT_URI", "")
+	s.ctx.GetConfig().Github.ClientID = ""
+	s.ctx.GetConfig().Github.ClientSecret = ""
+	s.ctx.GetConfig().Gitee.ClientID = ""
+	s.ctx.GetConfig().Gitee.ClientSecret = ""
+
+	require.NoError(t, s.db.upsert("login", "local_off", "1", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+	assert.False(t, s.LocalLoginOff(),
+		"OIDC ENABLED 但配置残缺时,等同无可用第三方登录,必须回退避免锁死")
+}
+
+func TestSystemSettings_LocalLoginOff_TrueWhenGitHubConfigured(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	t.Setenv("DM_OIDC_ENABLED", "")
+	s.ctx.GetConfig().Github.ClientID = "gh-client"
+	s.ctx.GetConfig().Github.ClientSecret = "gh-secret"
+
+	require.NoError(t, s.db.upsert("login", "local_off", "1", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+	assert.True(t, s.LocalLoginOff(), "GitHub OAuth 配置齐备 → 守卫生效")
+}
+
+func TestSystemSettings_LocalLoginOff_TrueWhenGiteeConfigured(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	t.Setenv("DM_OIDC_ENABLED", "")
+	s.ctx.GetConfig().Gitee.ClientID = "gitee-client"
+	s.ctx.GetConfig().Gitee.ClientSecret = "gitee-secret"
+
+	require.NoError(t, s.db.upsert("login", "local_off", "1", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+	assert.True(t, s.LocalLoginOff(), "Gitee OAuth 配置齐备 → 守卫生效")
 }
 
 func TestSystemSettings_StringFallsBackOnEmpty(t *testing.T) {

--- a/modules/oidc/config.go
+++ b/modules/oidc/config.go
@@ -138,6 +138,10 @@ func loadProvider() (ProviderConfig, error) {
 
 	// 用 slice 保证检查顺序稳定,缺多个字段时报第一项固定,排查体验更好。
 	// 报错消息用新名,引导运维迁移到 PROVIDER_*。
+	//
+	// NOTE: 此 required 列表在 modules/common/system_settings.go 的
+	// isOIDCFullyConfigured() 有一份镜像副本(避免 common→oidc→user→common
+	// import 循环)。新增/删除必填项时,两处必须同步修改。
 	required := []struct {
 		name string
 		val  string

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -1187,6 +1187,10 @@ func (u *User) wxLogin(c *wkhttp.Context) {
 
 // 登录
 func (u *User) login(c *wkhttp.Context) {
+	if common2.EnsureSystemSettings(u.ctx).LocalLoginOff() {
+		c.ResponseError(errors.New("本地登录已关闭"))
+		return
+	}
 
 	var req loginReq
 	if err := c.BindJSON(&req); err != nil {
@@ -2422,6 +2426,13 @@ func (u *User) closeLockScreenPwd(c *wkhttp.Context) {
 
 // sendLoginCheckPhoneCode 发送登录验证短信
 func (u *User) sendLoginCheckPhoneCode(c *wkhttp.Context) {
+	// 设备验证短信是本地登录二阶段的一部分,local_off=1 时必须连发码也拒,
+	// 否则攻击者跳过 /v1/user/login 直接走二阶段仍能拿到 token,
+	// 同时还把短信通道当作免费枚举/滥发入口。
+	if common2.EnsureSystemSettings(u.ctx).LocalLoginOff() {
+		c.ResponseError(errors.New("本地登录已关闭"))
+		return
+	}
 	var req struct {
 		UID string `json:"uid"`
 	}
@@ -2470,6 +2481,10 @@ func (u *User) sendLoginCheckPhoneCode(c *wkhttp.Context) {
 
 // loginCheckPhone 登录验证设备短信
 func (u *User) loginCheckPhone(c *wkhttp.Context) {
+	if common2.EnsureSystemSettings(u.ctx).LocalLoginOff() {
+		c.ResponseError(errors.New("本地登录已关闭"))
+		return
+	}
 	var req struct {
 		UID  string `json:"uid"`
 		Code string `json:"code"`

--- a/modules/user/api_emaillogin.go
+++ b/modules/user/api_emaillogin.go
@@ -41,6 +41,14 @@ func (u *User) emailSendCode(c *wkhttp.Context) {
 		c.ResponseError(errors.New("注册通道暂不开放"))
 		return
 	}
+	// 邮箱登录验证码与 emailLogin 守卫语义对齐:local_off=1 时连发码也拒,
+	// 不然攻击者绕过 /v1/user/emaillogin 仍能让后端发出真实登录验证码。
+	// 注意范围:只覆盖 CodeTypeEmailLogin —— 忘记密码 / 注册验证码各有
+	// 自己的开关(register.off / 长期保留),不在 local_off 守备范围内。
+	if codeType == commonapi.CodeTypeEmailLogin && settings.LocalLoginOff() {
+		c.ResponseError(errors.New("本地登录已关闭"))
+		return
+	}
 	if !settings.RegisterEmailOn() {
 		switch codeType {
 		case commonapi.CodeTypeRegister:
@@ -201,7 +209,12 @@ func (u *User) emailRegister(c *wkhttp.Context) {
 
 // emailLogin 邮箱登录（验证码方式）
 func (u *User) emailLogin(c *wkhttp.Context) {
-	if !common.EnsureSystemSettings(u.ctx).RegisterEmailOn() {
+	settings := common.EnsureSystemSettings(u.ctx)
+	if settings.LocalLoginOff() {
+		c.ResponseError(errors.New("本地登录已关闭"))
+		return
+	}
+	if !settings.RegisterEmailOn() {
 		c.ResponseError(errors.New("暂不支持邮箱登录"))
 		return
 	}

--- a/modules/user/api_emaillogin_test.go
+++ b/modules/user/api_emaillogin_test.go
@@ -80,6 +80,26 @@ func TestEmailRegisterBlockedByRegisterOff(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "注册通道暂不开放")
 }
 
+func TestEmailLoginBlockedByLocalLoginOff(t *testing.T) {
+	// SSO 必须完整可用,否则安全回退会绕过 local_off=1。见
+	// TestUsernameLoginBlockedByLocalLoginOff 的同款注释。
+	enableFullOIDCForUserTest(t)
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	setSystemSettingForUserTest(t, ctx, "login", "local_off", "1", "bool")
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/user/emaillogin", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+		"email":    "blocked@example.com",
+		"password": "1234567",
+	}))))
+	setPublicIPForUserTest(req, "8.8.4.5")
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.Contains(t, w.Body.String(), "本地登录已关闭")
+}
+
 func TestEmailLoginBlockedByEmailOn(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
@@ -95,6 +115,40 @@ func TestEmailLoginBlockedByEmailOn(t *testing.T) {
 	s.GetRoute().ServeHTTP(w, req)
 
 	assert.Contains(t, w.Body.String(), "暂不支持邮箱登录")
+}
+
+// local_off=1 时邮箱登录验证码必须同步拒绝,否则绕过 /v1/user/emaillogin
+// 入口仍可通过 /v1/user/email/sendcode(CodeTypeEmailLogin) 让后端发出真实
+// 验证码,既滥发邮件,又给攻击路径留口。
+// 同时验证:CodeTypeForgetLoginPWD 不受影响 —— 老用户找回密码渠道必须保留。
+func TestEmailSendCodeForLoginBlockedByLocalLoginOff(t *testing.T) {
+	enableFullOIDCForUserTest(t) // 让 local_off=1 通过安全回退,验证守卫本身
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	setSystemSettingForUserTest(t, ctx, "login", "local_off", "1", "bool")
+	// 把 register.email_on 显式置 1,排除"被另一个开关拦下"的混淆。
+	setSystemSettingForUserTest(t, ctx, "register", "email_on", "1", "bool")
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/user/email/sendcode", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+		"email":     "blocked@example.com",
+		"code_type": int(commonapi.CodeTypeEmailLogin),
+	}))))
+	setPublicIPForUserTest(req, "8.8.4.6")
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Contains(t, w.Body.String(), "本地登录已关闭")
+
+	// 忘记密码验证码不受 local_off 影响 —— 老用户找回入口必须保留。
+	w2 := httptest.NewRecorder()
+	req2, _ := http.NewRequest("POST", "/v1/user/email/sendcode", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+		"email":     "recover@example.com",
+		"code_type": int(commonapi.CodeTypeForgetLoginPWD),
+	}))))
+	setPublicIPForUserTest(req2, "8.8.4.7")
+	s.GetRoute().ServeHTTP(w2, req2)
+	assert.NotContains(t, w2.Body.String(), "本地登录已关闭",
+		"忘记密码渠道不应被 local_off 拦截")
 }
 
 func TestEmailSendCodeBlockedByEmailOnForLoginAndRegister(t *testing.T) {
@@ -179,6 +233,33 @@ func setSystemSettingForUserTest(t *testing.T, ctx *config.Context, category, ke
 			t.Logf("cleanup: reload SystemSettings failed: %v", reloadErr)
 		}
 	})
+}
+
+// enableFullOIDCForUserTest 是 modules/common 同名 helper 的镜像副本。
+// 把 OIDC 切到"完整可用"状态(DM_OIDC_ENABLED + issuer / client_id / secret
+// / redirect_uri / 32 字节 RT key 齐备),让 LocalLoginOff() 的安全回退判定
+// 通过,从而验证下游守卫本身的语义。
+//
+// 镜像而非跨包 import:Go 测试帮助函数定义在 _test.go 中,不属于公共 API,
+// 跨包共享需要把它挪到非测试文件并标 Helper —— 对仅几行的 fixture 不划算。
+// modules/common/system_settings_test.go 的 fullOIDCTestEnv 是单一真源,
+// 这里的字段集必须与之同步。
+func enableFullOIDCForUserTest(t *testing.T) {
+	t.Helper()
+	for _, alias := range []string{
+		"DM_OIDC_AEGIS_ISSUER",
+		"DM_OIDC_AEGIS_CLIENT_ID",
+		"DM_OIDC_AEGIS_CLIENT_SECRET",
+		"DM_OIDC_AEGIS_REDIRECT_URI",
+	} {
+		t.Setenv(alias, "")
+	}
+	t.Setenv("DM_OIDC_ENABLED", "true")
+	t.Setenv("DM_OIDC_PROVIDER_ISSUER", "https://idp.example.com")
+	t.Setenv("DM_OIDC_PROVIDER_CLIENT_ID", "test-client")
+	t.Setenv("DM_OIDC_PROVIDER_CLIENT_SECRET", "test-secret")
+	t.Setenv("DM_OIDC_PROVIDER_REDIRECT_URI", "https://app.example.com/oidc/callback")
+	t.Setenv("DM_OIDC_RT_ENC_KEY", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
 }
 
 func setPublicIPForUserTest(req *http.Request, ip string) {

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -143,7 +143,23 @@ func (m *Manager) online(c *wkhttp.Context) {
 	c.Response(result)
 }
 
-// 用户登录
+// 用户登录(管理后台)。
+//
+// 故意不受 login.local_off 守卫,与 /v1/user/* 的本地登录入口区分对待。
+// 理由(PR #104 P1 from yujiawei):
+//   - login.local_off 的 SSO 安全回退只兜得住"配置错误"(env 缺失/非法),
+//     兜不住 SSO 运行时故障(IdP 宕机、client_secret 过期、callback URL 被
+//     反代意外屏蔽等)。这类场景里普通用户全员锁死可接受 —— 等运维修;
+//     但运维自己也通过 SSO 进不来就成了死锁,只能从 DB 或重启回退。
+//   - 保留 /v1/manager/login 的本地账密入口给 SuperAdmin 当紧急通道,
+//     即使生产部署设了 local_off=1 也能登进管理面把开关关掉。
+//   - 与上游 octo-server 的安全模型一致:manager 路由本来就要求 admin/
+//     SuperAdmin 角色 + 独立速率限制,攻击面是 IdP 入口的子集而非超集。
+//
+// 如果未来要让 SSO 也接管管理面,正确做法是给管理面单独的 SSO 流程(可能
+// 接同一个 IdP 但用不同 client / 不同 scope),而不是把 local_off 扩到这
+// 里 —— 否则会把"屏蔽用户本地登录"和"屏蔽运维紧急入口"绑死,降低可
+// 运维性。
 func (m *Manager) login(c *wkhttp.Context) {
 	var req managerLoginReq
 	if err := c.BindJSON(&req); err != nil {

--- a/modules/user/api_test.go
+++ b/modules/user/api_test.go
@@ -23,6 +23,67 @@ import (
 
 var token = "token122323"
 
+// login.local_off=1 时 /v1/user/login（用户名/手机号 + 密码登录入口）必须
+// 在请求体合法的情况下也被守卫拒绝,而不是继续走到 QueryByUsername / 密码
+// 校验。Reason: 接入 SSO 后所有本地账号密码登录通道都应统一关闭,避免出现
+// "前端隐藏了入口但后端仍接受请求"的绕过路径。
+func TestLoginBlockedByLocalLoginOff(t *testing.T) {
+	enableFullOIDCForUserTest(t) // 让 local_off=1 通过安全回退;验证守卫本身
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	setSystemSettingForUserTest(t, ctx, "login", "local_off", "1", "bool")
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/user/login", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+		"username": "13800000000",
+		"password": "1234567",
+	}))))
+	setPublicIPForUserTest(req, "9.9.9.11")
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.Contains(t, w.Body.String(), "本地登录已关闭")
+}
+
+// login.local_off=1 时设备验证二阶段必须同步关闭,否则攻击者可以绕过
+// /v1/user/login 入口直接调 /v1/user/sms/login_check_phone +
+// /v1/user/login/check_phone 拿到 token。守卫位置必须在 uid 查询和短信
+// 发送之前,避免泄露用户存在性 + 滥发短信。
+func TestSendLoginCheckPhoneCodeBlockedByLocalLoginOff(t *testing.T) {
+	enableFullOIDCForUserTest(t)
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	setSystemSettingForUserTest(t, ctx, "login", "local_off", "1", "bool")
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/user/sms/login_check_phone", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+		"uid": "some-uid",
+	}))))
+	setPublicIPForUserTest(req, "9.9.9.12")
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.Contains(t, w.Body.String(), "本地登录已关闭")
+}
+
+func TestLoginCheckPhoneBlockedByLocalLoginOff(t *testing.T) {
+	enableFullOIDCForUserTest(t)
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	setSystemSettingForUserTest(t, ctx, "login", "local_off", "1", "bool")
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/user/login/check_phone", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+		"uid":  "some-uid",
+		"code": "123456",
+	}))))
+	setPublicIPForUserTest(req, "9.9.9.13")
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.Contains(t, w.Body.String(), "本地登录已关闭")
+}
+
 // 验证 register.only_china=1 时,非 0086 区号在真正注册入口被拦截。
 //
 // 这一道闸门必须在 register 这里,而不仅是在 sendRegisterCode:管理员通过

--- a/modules/user/api_usernamelogin.go
+++ b/modules/user/api_usernamelogin.go
@@ -73,6 +73,10 @@ func (u *User) usernameRegister(c *wkhttp.Context) {
 
 // 用户名登录
 func (u *User) usernameLogin(c *wkhttp.Context) {
+	if common.EnsureSystemSettings(u.ctx).LocalLoginOff() {
+		c.ResponseError(errors.New("本地登录已关闭"))
+		return
+	}
 	var req loginReq
 	if err := c.BindJSON(&req); err != nil {
 		c.ResponseError(errors.New("请求数据格式有误！"))

--- a/modules/user/api_usernamelogin_test.go
+++ b/modules/user/api_usernamelogin_test.go
@@ -13,6 +13,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestUsernameLoginBlockedByLocalLoginOff(t *testing.T) {
+	// 必须先把 OIDC 切到完整可用状态,否则 LocalLoginOff() 的安全回退会把
+	// local_off=1 视为"无 SSO 兜底的危险状态"强行返回 false,守卫就不会触发。
+	// 这条用例只是验证守卫语义,不是验证安全回退本身 —— 后者归 modules/common
+	// 的 TestSystemSettings_LocalLoginOff_AutoFalse* 系列。
+	enableFullOIDCForUserTest(t)
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	setSystemSettingForUserTest(t, ctx, "login", "local_off", "1", "bool")
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/user/usernamelogin", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+		"username": "someuser12345",
+		"password": "1234567",
+	}))))
+	setPublicIPForUserTest(req, "9.9.9.10")
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.Contains(t, w.Body.String(), "本地登录已关闭")
+}
+
 func TestUsernameRegisterBlockedByRegisterOff(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))


### PR DESCRIPTION
## Summary

Adds a `system_setting` toggle `login.local_off` that hides the local-account login UI on the frontend and rejects local-login endpoints on the backend, for deployments that have adopted SSO and want to route all users through it.

Companion of PR #76 (system_setting framework) and PR #93 (`/bind/create` SSO self-service).

## What's gated

Backend guards (all return `本地登录已关闭` when `local_off=1`):

| Endpoint | Reason |
| --- | --- |
| `POST /v1/user/login` | username/phone + password |
| `POST /v1/user/usernamelogin` | username + password |
| `POST /v1/user/emaillogin` | email + password / code |
| `POST /v1/user/sms/login_check_phone` | device-verification SMS (login stage 2) |
| `POST /v1/user/login/check_phone` | device-verification submit (login stage 2) |
| `POST /v1/user/email/sendcode` (`CodeTypeEmailLogin` only) | email login code send |

Intentionally **not** guarded:
- Password-recovery flows (`pwdforget*`, `email/forgetpwd`, `email/sendcode` with `CodeTypeForgetLoginPWD`) — existing users must retain recovery access.
- All `register.*` endpoints — under their own `register.off` family.
- Third-party / SSO / OIDC paths — this toggle is meant to route users there.
- **`POST /v1/manager/login`** — emergency SuperAdmin entry. The safety override below only catches *configuration* mistakes (env missing / invalid); it does **not** cover *runtime* SSO failures (IdP outage, expired client_secret, callback URL blocked by reverse proxy). Keeping a local-password hatch for SuperAdmin avoids the deadlock where ops also can't log in to flip the switch back off. If the management UI should ever go through SSO too, the correct shape is a dedicated SSO flow for the management plane, not extending `local_off` to it. Documented inline at `modules/user/api_manager.go:Manager.login`.

## Frontend gate

Appconfig now returns `local_login_off` (0/1) in both the full and version-shortcircuit branches, so admin changes propagate without an `app_config.version` bump (matches the `system_bot_uids` precedent).

## Safety override against lockout

`LocalLoginOff()` returns true only when at least one third-party login provider is fully configured:

- **OIDC**: must pass every fatal check inside `modules/oidc/config.go:loadProvider`. Mirror in `modules/common/system_settings.go:isOIDCFullyConfigured`:
  - `DM_OIDC_ENABLED` parsed by `strconv.ParseBool` (accepts `1`/`0`/`t`/`T`/`true`/`True`/`TRUE`/`f`/`F`/`false`/... — same as `oidc/config.go:getBool`).
  - `DM_OIDC_PROVIDER_ID` (default `oidc`) must satisfy `^[a-z0-9][a-z0-9_-]{0,63}$`. Invalid ID makes `LoadConfig` fatal and registers disabled OIDC handlers, so a deployment with `local_off=1` + valid issuer/client_id/secret but bad PROVIDER_ID would otherwise lock out without the regex check.
  - `DM_OIDC_PROVIDER_ISSUER` / `CLIENT_ID` / `CLIENT_SECRET` / `REDIRECT_URI` all non-empty (alias `DM_OIDC_AEGIS_*` also accepted).
  - `DM_OIDC_RT_ENC_KEY` non-empty, base64-decodes to exactly 32 bytes.
- **GitHub**: `Github.ClientID` + `Github.ClientSecret` both non-empty.
- **Gitee**: `Gitee.ClientID` + `Gitee.ClientSecret` both non-empty.

Reciprocal comments in `modules/oidc/config.go:loadProvider` and `modules/common/system_settings.go:isOIDCFullyConfigured` bind the two required lists so adding a new required env prompts updating both places.

If none qualify, `LocalLoginOff()` returns false even when DB says `local_off=1` — preventing the case where an admin flips the switch before wiring up an IdP and locks everyone (including themselves) out.

The dangerous state (intent=on but no usable IdP) surfaces as a single ERROR-level log via `LogLocalLoginOffSafetyOverrideIfActive(localOff bool)`, called:
- Once at startup (`Common.Route`) with `RawLocalLoginOffFromSnapshot()` — the snapshot has just been loaded.
- After every admin write touching `login.local_off`, with `plan.value == "1"` — read directly from the validated request payload so the warning fires **independently** of whether `Reload()` succeeded.

Writes are **not** blocked — operators may stage the switch before SSO is configured; the log is the signal that the intent is currently overridden.

## Test plan

- [x] `go vet ./modules/common ./modules/user ./modules/oidc`
- [x] `go test ./modules/common` — full package, including:
  - `TestSystemSettings_LocalLoginOff_DefaultsFalse`
  - `TestSystemSettings_LocalLoginOff_DBValueWins`
  - `TestSystemSettings_LocalLoginOff_AutoFalseWhenNoThirdPartyConfigured`
  - `TestSystemSettings_LocalLoginOff_AutoFalseWhenOIDCEnabledButMisconfigured`
  - `TestSystemSettings_LocalLoginOff_AutoFalseWhenOIDCProviderIDInvalid` *(P0 regression)*
  - `TestSystemSettings_LocalLoginOff_AcceptsParseBoolEnabledSpellings` *(P2 parse-parity)*
  - `TestSystemSettings_LocalLoginOff_TrueWhenGitHubConfigured`
  - `TestSystemSettings_LocalLoginOff_TrueWhenGiteeConfigured`
  - `TestGetAppConfig_LocalLoginOff_DefaultsZero`
  - `TestGetAppConfig_LocalLoginOff_DBOverride`
  - `TestGetAppConfig_LocalLoginOff_OnVersionShortCircuit`
  - `TestGetAppConfig_LocalLoginOff_SafetyOverrideWithoutSSO`
- [x] `go test ./modules/user -run BlockedByLocalLoginOff|...` — six guard cases:
  - `TestLoginBlockedByLocalLoginOff`
  - `TestUsernameLoginBlockedByLocalLoginOff`
  - `TestEmailLoginBlockedByLocalLoginOff`
  - `TestSendLoginCheckPhoneCodeBlockedByLocalLoginOff`
  - `TestLoginCheckPhoneBlockedByLocalLoginOff`
  - `TestEmailSendCodeForLoginBlockedByLocalLoginOff` (also asserts `CodeTypeForgetLoginPWD` is NOT blocked)
- [x] Adjacent `register.*` regression suites pass unchanged.
- [ ] Manual: deploy with OIDC wired up, toggle `login.local_off=1` via manager API, confirm appconfig flips, login endpoints reject, OIDC still works, `/v1/manager/login` still works for SuperAdmin.
- [ ] Manual: same deployment, unset `DM_OIDC_RT_ENC_KEY` (or set `DM_OIDC_PROVIDER_ID=foo/bar`), restart, confirm safety override log fires and local login keeps working.

## Schema row

`/v1/manager/common/system_setting` schema now exposes:

```
category=login key=local_off type=bool description=是否关闭本地账号登录入口
```

Admin UI renders automatically (schema-driven).

## Follow-ups (called out as non-blocking by reviewers)

- Multi-replica safety log: hook `LogLocalLoginOffSafetyOverrideIfActive` into `Reload()` on state-transition so non-writing replicas also surface the warning.
- Cache `isOIDCFullyConfigured` result (env doesn't change at runtime; saves a base64 decode per call).
- Add `t.Cleanup`-style config-mutation restore in tests that mutate `cfg.Github`/`Gitee`.