### PR TITLE
fix(ci): use pull_request_target in octo-pr-feed to fix fork PR notifications

### DIFF
--- a/.github/workflows/octo-pr-feed.yml
+++ b/.github/workflows/octo-pr-feed.yml
@@ -1,7 +1,7 @@
 name: Octo PR Feed
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, closed, reopened, ready_for_review, review_requested]
 
 permissions: {}


### PR DESCRIPTION
## Problem

`octo-pr-feed` has been silently failing for **all fork PRs** because it uses the `pull_request` event. GitHub runs `pull_request` workflows in the fork's sandboxed context, where `secrets.OCTO_BOT_TOKEN` is always empty. Every fork PR silently gets no Octo IM notification.

Confirmed via run logs:
```
OCTO_BOT_TOKEN: [empty]
ERROR: required environment variable OCTO_BOT_TOKEN is missing or empty
```

Example: PR #104 (`an9xyz` from fork `dmwork-org/octo-server`) — all runs failing.

## Fix

Change trigger from `pull_request` → `pull_request_target`.

`pull_request_target` runs in the **base repo's context** and has access to secrets even for fork PRs.

## Security note

`pull_request_target` is safe here because `octo-pr-feed` (the reusable workflow) **does NOT checkout any PR head code**. It only reads PR metadata from `github.event` and sends an HTTP notification to Octo IM. There is no code execution from the fork — the classic `pull_request_target` injection risk does not apply.

The 6 other repos (octo-web, octo-matter, octo-smart-summary, octo-admin, octo-lib, octo-deployment) already correctly use `pull_request_target` for this workflow.