### PR TITLE
fix(ci): use _ for unused loop counter to clear shellcheck SC2034

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
         # the database default; using general_ci keeps them aligned with
         # the rest of the schema and avoids "Illegal mix of collations".
         run: |
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             if mysqladmin ping -h 127.0.0.1 -uroot -pdemo --silent; then
               echo "mysql ready"
               exit 0


### PR DESCRIPTION
## Problem

`Workflow Sanity / actionlint` has been failing in this repo since at least 2026-05-19 due to:

```
.github/workflows/ci.yml:165:9: shellcheck reported issue in this script:
SC2034:warning:1:1: i appears unused. Verify use (or export if used externally)
```

The loop variable `i` in the MySQL readiness poll is never referenced in the loop body — it's a pure counter.

## Fix

`for i in $(seq 1 30)` → `for _ in $(seq 1 30)`

`_` is the shellcheck convention for intentionally unused variables (suppresses SC2034 without a disable comment). Zero behaviour change.

## Note

This is a pre-existing issue unrelated to recent CI workflow changes (#100, #106). It was surfaced when reviewing Workflow Sanity check history.