### PR TITLE
fix(obo): fan-out findActiveGrantsForChannel honors global_enabled for groups

### DIFF
--- a/modules/bot_api/obo_check.go
+++ b/modules/bot_api/obo_check.go
@@ -30,13 +30,29 @@ var (
 // ErrOBONotAuthorized when any check fails. Unexpected DB errors are
 // returned wrapped so the handler can 500.
 //
-// Four layered checks (any failure → ErrOBONotAuthorized):
+// Layered checks (any failure → ErrOBONotAuthorized):
 //  1. Grant row exists with active=1 AND global_enabled=1 for
 //     (grantor, botUID). This rejects revoked grants and grants whose
 //     master switch is off.
 //  2. Scope row exists with enabled=1 for (grant_id, channel_id,
-//     channel_type). White-list semantics per RFC §2 — opening a channel
-//     to a persona is always explicit.
+//     channel_type) — DM / Person ONLY. White-list semantics per RFC §2
+//     for 1:1 conversations: the persona must be explicitly authorized
+//     per peer because there is no in-message narrowing signal
+//     (mentions don't apply to DMs).
+//
+//     YUJ-1538 / PR#114 review fix — for group-like channel types
+//     (Group / CommunityTopic), the scope-row requirement is SKIPPED
+//     entirely. A grant with `active=1 AND global_enabled=1` covers
+//     every group/topic the grantor participates in; the per-message
+//     v2 narrowing gate (`@grantor` mention or `mention.all=1`) is the
+//     effective opt-in instead of a scope row, and the
+//     `grantorCanReadChannel` re-check below still enforces live
+//     membership. Without this skip, the fan-out copy delivered into a
+//     group reaches the bot but the bot's OBO reply hits scopeEnabled,
+//     returns false (operators never installed group scopes), and the
+//     reply 403s — defeating the whole PR#109 group fan-out path.
+//     `findActiveGrantsForChannel` (modules/bot_api/obo_db.go) was
+//     already widened symmetrically in PR#114.
 //  3. PR#82 round-2 P1-A — the grantor STILL has read access to the
 //     channel right now (`grantorCanReadChannel`). The scope-create-time
 //     check is not load-bearing for live membership: a grantor who
@@ -71,17 +87,28 @@ func (ba *BotAPI) checkOBO(botUID, grantor, channelID string, channelType uint8)
 		return ErrOBONotAuthorized
 	}
 
-	ok, err := store.scopeEnabled(grant.ID, channelID, channelType)
-	if err != nil {
-		ba.Error("OBO scope lookup failed",
-			zap.Int64("grant_id", grant.ID),
-			zap.String("channel_id", channelID),
-			zap.Uint8("channel_type", channelType),
-			zap.Error(err))
-		return err
-	}
-	if !ok {
-		return ErrOBONotAuthorized
+	// YUJ-1538 / PR#114 review fix (Jerry-Xin, lml2468) — skip the
+	// scope-row check for group-like channel types when the grant is
+	// `global_enabled=1`. See the function-level doc comment for the
+	// full rationale; without this branch, a group fan-out copy reaches
+	// the bot but the bot's OBO reply hits scopeEnabled, returns false
+	// (operators never install group scopes in production), and the
+	// reply 403s. DM (Person) and any unrecognized channel type keep
+	// the strict scope-row contract — the test
+	// TestCheckOBO_DMNoScope_StillUnauthorized pins that regression.
+	if !isGroupLikeChannelType(channelType) {
+		ok, err := store.scopeEnabled(grant.ID, channelID, channelType)
+		if err != nil {
+			ba.Error("OBO scope lookup failed",
+				zap.Int64("grant_id", grant.ID),
+				zap.String("channel_id", channelID),
+				zap.Uint8("channel_type", channelType),
+				zap.Error(err))
+			return err
+		}
+		if !ok {
+			return ErrOBONotAuthorized
+		}
 	}
 
 	// PR#82 round-2 P1-A — TOCTOU close-out. Re-check the grantor's live

--- a/modules/bot_api/obo_check_test.go
+++ b/modules/bot_api/obo_check_test.go
@@ -103,9 +103,12 @@ func TestCheckOBO_GlobalDisabled(t *testing.T) {
 }
 
 // TestCheckOBO_ScopeMissing — grant is fully enabled but no scope row
-// for the channel. Whitelist semantics: channels not explicitly added
-// MUST be denied (RFC §2).
+// for the channel. Whitelist semantics: DM channels not explicitly
+// added MUST be denied (RFC §2). Group / CommunityTopic are tested
+// separately in obo_yuj1538_test.go because the YUJ-1538 / PR#114
+// fix bypasses the scope-row requirement for group-like types.
 func TestCheckOBO_ScopeMissing(t *testing.T) {
+	const dmPeer = "u_bob"
 	s := newFakeOBOStore()
 	gid, _ := s.insertGrant(tGrantor, tBot, "auto", "")
 	enable := 1
@@ -113,24 +116,27 @@ func TestCheckOBO_ScopeMissing(t *testing.T) {
 	// No scope inserted at all.
 
 	ba := newBotAPIWithFakeStore(s)
-	err := ba.checkOBO(tBot, tGrantor, tChan, common.ChannelTypeGroup.Uint8())
+	err := ba.checkOBO(tBot, tGrantor, dmPeer, common.ChannelTypePerson.Uint8())
 	if !errors.Is(err, ErrOBONotAuthorized) {
-		t.Fatalf("missing scope should be unauthorized, got %v", err)
+		t.Fatalf("missing DM scope should be unauthorized, got %v", err)
 	}
 }
 
-// TestCheckOBO_ScopeDisabled — scope row exists with enabled=0.
+// TestCheckOBO_ScopeDisabled — scope row exists with enabled=0. Same
+// DM-only rationale as TestCheckOBO_ScopeMissing: group-like types no
+// longer consult the scope row at all post-PR#114.
 func TestCheckOBO_ScopeDisabled(t *testing.T) {
+	const dmPeer = "u_bob"
 	s := newFakeOBOStore()
 	gid, _ := s.insertGrant(tGrantor, tBot, "auto", "")
 	enable := 1
 	_ = s.updateGrant(gid, "", &enable, nil)
-	_, _ = s.insertScope(gid, tChan, common.ChannelTypeGroup.Uint8(), 0)
+	_, _ = s.insertScope(gid, dmPeer, common.ChannelTypePerson.Uint8(), 0)
 
 	ba := newBotAPIWithFakeStore(s)
-	err := ba.checkOBO(tBot, tGrantor, tChan, common.ChannelTypeGroup.Uint8())
+	err := ba.checkOBO(tBot, tGrantor, dmPeer, common.ChannelTypePerson.Uint8())
 	if !errors.Is(err, ErrOBONotAuthorized) {
-		t.Fatalf("disabled scope should be unauthorized, got %v", err)
+		t.Fatalf("disabled DM scope should be unauthorized, got %v", err)
 	}
 }
 
@@ -178,8 +184,11 @@ func TestCheckOBO_DBError_OnGrantLookup(t *testing.T) {
 }
 
 // TestCheckOBO_DBError_OnScopeLookup — same propagation contract for the
-// second store call.
+// second store call. Uses a DM channel because the YUJ-1538 / PR#114
+// fix skips the scope lookup entirely for group-like types — error
+// propagation from scopeEnabled is only observable on the DM path.
 func TestCheckOBO_DBError_OnScopeLookup(t *testing.T) {
+	const dmPeer = "u_bob"
 	boom := errors.New("connection refused")
 	s := newFakeOBOStore()
 	gid, _ := s.insertGrant(tGrantor, tBot, "auto", "")
@@ -188,7 +197,7 @@ func TestCheckOBO_DBError_OnScopeLookup(t *testing.T) {
 	s.failScopeEnabled = boom
 
 	ba := newBotAPIWithFakeStore(s)
-	err := ba.checkOBO(tBot, tGrantor, tChan, common.ChannelTypeGroup.Uint8())
+	err := ba.checkOBO(tBot, tGrantor, dmPeer, common.ChannelTypePerson.Uint8())
 	if err == nil || errors.Is(err, ErrOBONotAuthorized) {
 		t.Fatalf("expected raw DB error to propagate, got %v", err)
 	}

--- a/modules/bot_api/obo_db.go
+++ b/modules/bot_api/obo_db.go
@@ -39,9 +39,37 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/go-sql-driver/mysql"
 	"github.com/gocraft/dbr/v2"
 )
+
+// isGroupLikeChannelType reports whether channelType is a "group-shaped"
+// type (Group / CommunityTopic) for which an OBO grant with
+// `global_enabled=1` covers EVERY group/topic the grantor participates in
+// without requiring a per-channel `obo_scopes` row.
+//
+// YUJ-1538 rationale: PR#82 / PR#109 v1+v2 modeled scopes as a strict
+// white-list — the grantor explicitly enumerated each channel they
+// wanted the persona to observe. In practice operators only ever
+// installed `channel_type=1` (DM) scopes; for groups the v2 fan-out
+// narrowing gate (`mention.uids` must contain the grantor) is the
+// effective opt-in signal, not a scope row. The fan-out trigger query
+// must therefore not require scope rows for group/topic channels — a
+// `global_enabled=1` grant suffices, and the per-grant
+// `grantorCanReadChannel` re-check inside fanoutForMessage still
+// enforces live membership.
+//
+// DM (Person) channels keep the strict scope-row contract: a DM is a
+// 1:1 conversation that the persona must be explicitly authorized for,
+// and the @grantor narrowing gate cannot be applied (DM payloads carry
+// no mention). The check in checkOBO (the third-party send path) also
+// still requires the scope row regardless of channel type — only the
+// fan-out trigger lookup is widened here.
+func isGroupLikeChannelType(channelType uint8) bool {
+	return channelType == common.ChannelTypeGroup.Uint8() ||
+		channelType == common.ChannelTypeCommunityTopic.Uint8()
+}
 
 // ==================== Models ====================
 
@@ -312,16 +340,46 @@ func (d *botAPIDB) scopeEnabled(grantID int64, channelID string, channelType uin
 	return count > 0, nil
 }
 
-// findActiveGrantsForChannel — see oboStore. Single JOIN so the fan-out
-// hot path doesn't have to issue a per-grant scope lookup.
+// findActiveGrantsForChannel — see oboStore. Single index-hit so the
+// fan-out hot path doesn't have to issue a per-grant scope lookup.
 //
 // Read path consults `obo:chan:{type}:{id}` first. A cached "0" answer
 // returns an empty slice without touching MySQL — the fan-out listener
 // fires for every inbound message system-wide, so the vast majority of
-// channels (those with no OBO grants) avoid the JOIN entirely. Positive
+// channels (those with no OBO grants) avoid the lookup entirely. Positive
 // hits and MySQL fallback both repopulate the cache with the count-based
 // scalar ("1" any matches, "0" none). Cache errors swallowed; production
 // behavior is identical whether Redis is healthy or absent.
+//
+// YUJ-1538 — channel-type-aware lookup:
+//
+//   - DM (Person, channel_type=1): keeps the strict
+//     `obo_grants ⨝ obo_scopes` JOIN. DMs are 1:1 conversations and the
+//     persona must be explicitly white-listed per peer. This is the
+//     pre-existing contract and is unchanged.
+//
+//   - Group (channel_type=2) / CommunityTopic (channel_type=5): a grant
+//     with `active=1 AND global_enabled=1` covers EVERY group/topic the
+//     grantor participates in, WITHOUT requiring an `obo_scopes` row.
+//     v2 narrowing (`mention.uids` must contain the grantor, or
+//     `mention.all=1`) is the effective per-message opt-in instead of a
+//     scope row, and the per-grant `grantorCanReadChannel` re-check in
+//     fanoutForMessage still enforces live channel membership. The bug
+//     PR#109 left behind: `obo_scopes` only ever held `channel_type=1`
+//     rows in production (operators never created group scopes), so the
+//     INNER JOIN returned zero matches for every group inbound and the
+//     fan-out copy never reached the bot — even though `checkOBO` had
+//     already been updated to bypass the scope check for groups.
+//
+// Cache notes (group/topic): the per-channel cache key still gates the
+// hot path. When the FIRST `global_enabled=1` grant is enabled in a
+// previously-empty system, group channel cache entries holding a stale
+// "0" remain so for at most `oboCacheTTL` (30s); after that the next
+// inbound re-queries MySQL and the cache flips. Per-channel
+// invalidation of group caches at grant-enable time would require
+// enumerating every group the grantor participates in, which is more
+// work than the bounded warmup window saves; the same 30s TTL was the
+// design's accepted risk in RFC §11.
 func (d *botAPIDB) findActiveGrantsForChannel(channelID string, channelType uint8) ([]*oboGrantModel, error) {
 	if channelID == "" {
 		return []*oboGrantModel{}, nil
@@ -330,12 +388,32 @@ func (d *botAPIDB) findActiveGrantsForChannel(channelID string, channelType uint
 		return []*oboGrantModel{}, nil
 	}
 	var grants []*oboGrantModel
-	_, err := d.session.SelectBySql(
-		"SELECT g.* FROM obo_grants g INNER JOIN obo_scopes s ON s.grant_id=g.id "+
-			"WHERE g.active=1 AND g.global_enabled=1 AND s.enabled=1 "+
-			"AND s.channel_id=? AND s.channel_type=?",
-		channelID, channelType,
-	).Load(&grants)
+	var err error
+	if isGroupLikeChannelType(channelType) {
+		// Group / CommunityTopic — `global_enabled=1` is sufficient,
+		// no scope row required. Returns every active+enabled grant
+		// system-wide; the per-grant `grantorCanReadChannel` re-check
+		// in the fan-out loop filters to grants whose grantor is
+		// actually a member of THIS group/topic. With the v2
+		// `uk_grantor_grantee` UNIQUE + create-mutex (PR#109), the
+		// number of active+enabled grants is bounded — at most one
+		// per grantor — so the fan-out cost is O(grantors) per
+		// inbound, not O(scopes).
+		_, err = d.session.SelectBySql(
+			"SELECT g.* FROM obo_grants g " +
+				"WHERE g.active=1 AND g.global_enabled=1",
+		).Load(&grants)
+	} else {
+		// DM (Person) and any other unrecognized channel type — keep
+		// the original strict JOIN so behavior is unchanged outside
+		// the group-like path.
+		_, err = d.session.SelectBySql(
+			"SELECT g.* FROM obo_grants g INNER JOIN obo_scopes s ON s.grant_id=g.id "+
+				"WHERE g.active=1 AND g.global_enabled=1 AND s.enabled=1 "+
+				"AND s.channel_id=? AND s.channel_type=?",
+			channelID, channelType,
+		).Load(&grants)
+	}
 	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
 		return nil, err
 	}

--- a/modules/bot_api/obo_db.go
+++ b/modules/bot_api/obo_db.go
@@ -63,9 +63,17 @@ import (
 // DM (Person) channels keep the strict scope-row contract: a DM is a
 // 1:1 conversation that the persona must be explicitly authorized for,
 // and the @grantor narrowing gate cannot be applied (DM payloads carry
-// no mention). The check in checkOBO (the third-party send path) also
-// still requires the scope row regardless of channel type — only the
-// fan-out trigger lookup is widened here.
+// no mention).
+//
+// PR#114 R3 update — `checkOBO` (the third-party reply send path) was
+// widened symmetrically in the same PR: for group-like channel types
+// it ALSO skips the scope-row requirement when the grant has
+// `global_enabled=1`, so a fan-out copy delivered into a group reaches
+// the bot AND the bot's OBO reply succeeds. The previous version of
+// this comment claimed `checkOBO` still required the scope row "regardless
+// of channel type" — true for the v1 ship but stale after the PR#114
+// commit `fix(obo): checkOBO skips scope check for group-like channels`.
+// DM (Person) `checkOBO` does still require the per-peer scope row.
 func isGroupLikeChannelType(channelType uint8) bool {
 	return channelType == common.ChannelTypeGroup.Uint8() ||
 		channelType == common.ChannelTypeCommunityTopic.Uint8()
@@ -146,6 +154,16 @@ type oboScopeModel struct {
 //     v2 narrowing gate (`@grantor` / `mention.all=1`) and the
 //     `grantorCanReadChannel` re-check carry the opt-in. Empty slice
 //     (not nil) on no match keeps callers branch-free.
+//   - findActiveGrantsForChannelByGrantors: PR#114 R3. Same shape as
+//     findActiveGrantsForChannel for group-like channels but adds a
+//     `grantor_uid IN (...)` filter so the fan-out hot path can
+//     restrict the system-wide scan to the explicit @mentioned UIDs
+//     decoded from `payload.mention.uids`. Used ONLY for group-like
+//     channels with explicit @uids — `mention.all` (@所有人) still goes
+//     through the unfiltered method (see fanoutForMessage doc for the
+//     trade-off). An empty / nil grantorUIDs slice returns an empty
+//     result without touching MySQL — callers should early-return on
+//     the no-mention case instead of paying a wasted query.
 type oboStore interface {
 	findActiveGrantByGrantorBot(grantorUID, granteeBotUID string) (*oboGrantModel, error)
 	// findGrantByGrantorBotActiveOnly — YUJ-1428. Same shape as
@@ -174,6 +192,15 @@ type oboStore interface {
 	findGrantByGrantorBotActiveOnly(grantorUID, granteeBotUID string) (*oboGrantModel, error)
 	scopeEnabled(grantID int64, channelID string, channelType uint8) (bool, error)
 	findActiveGrantsForChannel(channelID string, channelType uint8) ([]*oboGrantModel, error)
+	// findActiveGrantsForChannelByGrantors — PR#114 R3 (Jerry-Xin).
+	// Group-like-only fan-out lookup that filters at the DB layer by the
+	// explicit `mention.uids` set. Returns the subset of grants where
+	// `g.grantor_uid IN (grantorUIDs)` AND `g.active=1 AND
+	// g.global_enabled=1`. An empty / nil grantorUIDs slice returns an
+	// empty result with no DB round-trip — callers should treat the
+	// "no mentions" case at the fan-out layer instead of asking the DB.
+	// DM (Person) MUST NOT call this method (no mention semantics on DMs).
+	findActiveGrantsForChannelByGrantors(channelID string, channelType uint8, grantorUIDs []string) ([]*oboGrantModel, error)
 
 	// CRUD used by the REST layer
 	insertGrant(grantorUID, granteeBotUID, mode, personaPrompt string) (int64, error)
@@ -420,6 +447,75 @@ func (d *botAPIDB) findActiveGrantsForChannel(channelID string, channelType uint
 			channelID, channelType,
 		).Load(&grants)
 	}
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return nil, err
+	}
+	if grants == nil {
+		grants = []*oboGrantModel{}
+	}
+	d.writeChannelCache(channelID, channelType, len(grants) > 0)
+	return grants, nil
+}
+
+// findActiveGrantsForChannelByGrantors — PR#114 R3 (Jerry-Xin perf
+// blocker). Same shape as `findActiveGrantsForChannel` for group-like
+// channels but scoped at the DB layer to the explicit `grantorUIDs`
+// set decoded from `payload.mention.uids`. The fan-out hot path uses
+// this when an inbound group message carries an explicit @grantor
+// mention so we never load grants for OTHER grantors who weren't
+// mentioned.
+//
+// Why this matters (Jerry-Xin's perf flag): the v2 group lookup loads
+// EVERY active+global_enabled grant system-wide and then post-filters
+// in Go, so every inbound group message — even plain text or @AI —
+// would otherwise pay an O(grants_total) DB scan. With this method
+// the DB returns at most `len(grantorUIDs)` rows (uk_grantor_grantee
+// guarantees one row per grantor), so the cost is O(mentioned_grantors)
+// per inbound and the unmentioned grantors never leave their index page.
+//
+// Behavior:
+//   - DM / Person (or any non-group-like type) → empty slice + nil
+//     error. Callers must NOT use this for DMs (no mention semantics).
+//   - Empty / nil grantorUIDs → empty slice + nil error WITHOUT a DB
+//     round-trip. The caller's early-return path should mean we never
+//     reach this branch, but the guard makes the contract self-evident.
+//   - channelID == "" → empty slice + nil error (defensive).
+//
+// Cache: writes the same `obo:chan:{type}:{id}` scalar that
+// `findActiveGrantsForChannel` does so a subsequent unfiltered call
+// can short-circuit on negative results. Reads from the cache as well
+// — a cached "0" answer (no grants in this channel for ANYBODY)
+// trumps the filter and returns empty without hitting MySQL.
+func (d *botAPIDB) findActiveGrantsForChannelByGrantors(channelID string, channelType uint8, grantorUIDs []string) ([]*oboGrantModel, error) {
+	if channelID == "" || len(grantorUIDs) == 0 {
+		return []*oboGrantModel{}, nil
+	}
+	if !isGroupLikeChannelType(channelType) {
+		// Method is group-like-only by contract; defensive return so a
+		// caller wiring this on the DM path can't silently widen access.
+		return []*oboGrantModel{}, nil
+	}
+	if d.channelCacheSaysNone(channelID, channelType) {
+		return []*oboGrantModel{}, nil
+	}
+
+	// Build the IN (...) placeholder list. dbr's positional binding
+	// expands a `[]interface{}` arg into the right number of `?` for
+	// the query, but we need to construct the literal placeholder
+	// string ourselves because the dbr SelectBySql shape in this file
+	// uses positional `?` markers.
+	placeholders := make([]string, len(grantorUIDs))
+	args := make([]interface{}, 0, len(grantorUIDs))
+	for i, uid := range grantorUIDs {
+		placeholders[i] = "?"
+		args = append(args, uid)
+	}
+
+	var grants []*oboGrantModel
+	q := "SELECT g.* FROM obo_grants g " +
+		"WHERE g.active=1 AND g.global_enabled=1 " +
+		"AND g.grantor_uid IN (" + strings.Join(placeholders, ",") + ")"
+	_, err := d.session.SelectBySql(q, args...).Load(&grants)
 	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
 		return nil, err
 	}
@@ -901,7 +997,6 @@ func (d *botAPIDB) createOrReactivateGrantAtomic(grantorUID, granteeBotUID, mode
 
 	return grant, reactivated, nil
 }
-
 
 // O(grants × scopes_per_grant) scan that scopeOwnedBy used to perform
 // on every `DELETE /v1/obo/scopes/:id` (PR#82 review #2 P1-3).

--- a/modules/bot_api/obo_db.go
+++ b/modules/bot_api/obo_db.go
@@ -138,8 +138,14 @@ type oboScopeModel struct {
 //     enabled=0, or the grant_id doesn't exist. The hot path on sendMessage
 //     only needs a boolean.
 //   - findActiveGrantsForChannel: feeder for the fan-out listener; returns
-//     active+global_enabled grants whose scope row matches the channel and
-//     enabled=1. Empty slice (not nil) on no match keeps callers branch-free.
+//     active+global_enabled grants for the channel. Channel-type-aware
+//     (YUJ-1538 / PR#114): for DM (Person) the scope row is still
+//     required (strict per-peer white-list); for group-like channel
+//     types (Group / CommunityTopic) a `global_enabled=1` grant alone
+//     suffices and no `obo_scopes` row is consulted — the per-message
+//     v2 narrowing gate (`@grantor` / `mention.all=1`) and the
+//     `grantorCanReadChannel` re-check carry the opt-in. Empty slice
+//     (not nil) on no match keeps callers branch-free.
 type oboStore interface {
 	findActiveGrantByGrantorBot(grantorUID, granteeBotUID string) (*oboGrantModel, error)
 	// findGrantByGrantorBotActiveOnly — YUJ-1428. Same shape as

--- a/modules/bot_api/obo_db.go
+++ b/modules/bot_api/obo_db.go
@@ -15,11 +15,20 @@
 //     short-circuits the (grantor, bot) MySQL probe
 //     that checkOBO would otherwise issue per send.
 //   - obo:chan:{ctype}:{cid}   "1" channel has at least one (active grant ×
-//     enabled scope) match; "0" no match. Read by
-//     findActiveGrantsForChannel — negative answer
+//     enabled scope) match; "0" no match. Read AND
+//     written ONLY by the unfiltered
+//     `findActiveGrantsForChannel` — negative answer
 //     short-circuits the JOIN that the fan-out
 //     listener would otherwise issue per inbound
-//     message system-wide.
+//     message system-wide. The filtered sibling
+//     `findActiveGrantsForChannelByGrantors`
+//     deliberately bypasses this key in BOTH
+//     directions (PR#114 R4): its result is a
+//     UID-scoped subset, so it cannot prove the
+//     channel-wide negative answer the cache
+//     encodes, and reading a write from the
+//     unfiltered path against a same-string DM key
+//     would suppress legitimate group fan-outs.
 //
 // Both keys are negative-cache friendly: a "0" answer returned within the
 // 30-second TTL eliminates the MySQL round-trip entirely. Writes that can
@@ -286,7 +295,10 @@ const (
 	// have at least one (active grant × enabled scope) match". The fan-out
 	// listener consults this scalar before the JOIN it would otherwise
 	// issue per inbound message system-wide. Population: written on every
-	// findActiveGrantsForChannel result (count 0 → "0", count >0 → "1").
+	// UNFILTERED findActiveGrantsForChannel result (count 0 → "0",
+	// count >0 → "1"). The filtered sibling
+	// findActiveGrantsForChannelByGrantors MUST NOT write here — see
+	// PR#114 R4 and the function doc for the poisoning scenario.
 	// Eviction: insertScope / deleteScope (the only operations that can
 	// flip the answer for a given channel within the TTL window).
 	oboChannelActiveCacheKeyFmt = "obo:chan:%d:%s"
@@ -481,11 +493,30 @@ func (d *botAPIDB) findActiveGrantsForChannel(channelID string, channelType uint
 //     reach this branch, but the guard makes the contract self-evident.
 //   - channelID == "" → empty slice + nil error (defensive).
 //
-// Cache: writes the same `obo:chan:{type}:{id}` scalar that
-// `findActiveGrantsForChannel` does so a subsequent unfiltered call
-// can short-circuit on negative results. Reads from the cache as well
-// — a cached "0" answer (no grants in this channel for ANYBODY)
-// trumps the filter and returns empty without hitting MySQL.
+// Cache: this method MUST NOT touch the `obo:chan:{type}:{id}`
+// channel-wide scalar in either direction (PR#114 R4 — Jerry-Xin /
+// lml2468 cache-poisoning blocker, 2026-05-21).
+//
+// Why no WRITE: the cache key answers "does this channel have ANY
+// active grant × enabled scope" — a CHANNEL-WIDE property. This
+// method's result is a UID-filtered subset, so a zero result here
+// only proves "none of the mentioned grantors have a grant", NOT
+// "the channel has no grants". Writing "0" after a filtered miss
+// would poison the cache for the NEXT inbound that mentions a
+// different grantor who DOES have a grant — the channelCacheSaysNone
+// short-circuit at the top of `findActiveGrantsForChannel` (or any
+// other consumer) would early-return empty and suppress the fan-out.
+//
+// Why no READ: the same cache key may legitimately hold "0" written
+// by the unfiltered `findActiveGrantsForChannel` for a channelID that
+// happens to share its string with this method's group ID (DM peer
+// uids and group ids live in the same Redis namespace). Honoring
+// that "0" here would incorrectly suppress a group query whose
+// mentioned-grantor SET we have not actually probed against MySQL.
+//
+// The unfiltered `findActiveGrantsForChannel` (used by the DM path
+// and the `@所有人` group broadcast path) still manages the channel
+// cache correctly because its result IS the channel-wide truth.
 func (d *botAPIDB) findActiveGrantsForChannelByGrantors(channelID string, channelType uint8, grantorUIDs []string) ([]*oboGrantModel, error) {
 	if channelID == "" || len(grantorUIDs) == 0 {
 		return []*oboGrantModel{}, nil
@@ -495,9 +526,8 @@ func (d *botAPIDB) findActiveGrantsForChannelByGrantors(channelID string, channe
 		// caller wiring this on the DM path can't silently widen access.
 		return []*oboGrantModel{}, nil
 	}
-	if d.channelCacheSaysNone(channelID, channelType) {
-		return []*oboGrantModel{}, nil
-	}
+	// Intentionally NO channelCacheSaysNone check here — see the
+	// "Why no READ" paragraph in the doc comment above.
 
 	// Build the IN (...) placeholder list. dbr's positional binding
 	// expands a `[]interface{}` arg into the right number of `?` for
@@ -522,7 +552,8 @@ func (d *botAPIDB) findActiveGrantsForChannelByGrantors(channelID string, channe
 	if grants == nil {
 		grants = []*oboGrantModel{}
 	}
-	d.writeChannelCache(channelID, channelType, len(grants) > 0)
+	// Intentionally NO writeChannelCache call here — see the
+	// "Why no WRITE" paragraph in the doc comment above.
 	return grants, nil
 }
 

--- a/modules/bot_api/obo_fake_test.go
+++ b/modules/bot_api/obo_fake_test.go
@@ -48,6 +48,25 @@ type fakeOBOStore struct {
 	failInsertScope       error
 	failQueryRobotOwner   error
 	failFindScopeOwner    error
+
+	// PR#114 R3 (Jerry-Xin perf blocker) — call counters so tests can
+	// pin the early-return contract: on plain / @AI-only group traffic,
+	// neither findActiveGrantsForChannel nor
+	// findActiveGrantsForChannelByGrantors must be invoked. Mirrors the
+	// production negative-cache short-circuit: the cheapest grant
+	// lookup is the one we never make.
+	findGrantsChannelCalls           int
+	findGrantsChannelByGrantorsCalls int
+	// lastFindByGrantorsArgs records the most recent argument set passed
+	// to findActiveGrantsForChannelByGrantors so tests can assert that
+	// the @grantor narrowing actually filtered the query (and didn't
+	// silently fall back to the unfiltered scan).
+	lastFindByGrantorsArgs struct {
+		channelID   string
+		channelType uint8
+		grantorUIDs []string
+		called      bool
+	}
 }
 
 // newFakeOBOStore — constructor, zero-value-friendly so tests can also
@@ -170,6 +189,7 @@ func (f *fakeOBOStore) scopeEnabled(grantID int64, channelID string, channelType
 func (f *fakeOBOStore) findActiveGrantsForChannel(channelID string, channelType uint8) ([]*oboGrantModel, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.findGrantsChannelCalls++
 	if f.failFindGrantsChannel != nil {
 		return nil, f.failFindGrantsChannel
 	}
@@ -205,6 +225,59 @@ func (f *fakeOBOStore) findActiveGrantsForChannel(channelID string, channelType 
 		}
 		g, ok := f.grants[s.GrantID]
 		if !ok || g.Active != 1 || g.GlobalEnabled != 1 {
+			continue
+		}
+		cp := *g
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+
+// findActiveGrantsForChannelByGrantors — PR#114 R3 (Jerry-Xin perf
+// blocker) fake impl. Mirrors the production `grantor_uid IN (...)`
+// filter at the in-memory level so unit tests can pin both the
+// behavior (right rows returned) and the call shape (was it invoked,
+// with what filter set). DM / non-group-like calls return empty
+// without consulting the maps, mirroring the production guard.
+func (f *fakeOBOStore) findActiveGrantsForChannelByGrantors(channelID string, channelType uint8, grantorUIDs []string) ([]*oboGrantModel, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.findGrantsChannelByGrantorsCalls++
+	// Record the latest call so tests can assert the filter shape.
+	f.lastFindByGrantorsArgs.called = true
+	f.lastFindByGrantorsArgs.channelID = channelID
+	f.lastFindByGrantorsArgs.channelType = channelType
+	// Copy slice to insulate test assertions from caller mutations.
+	f.lastFindByGrantorsArgs.grantorUIDs = append([]string(nil), grantorUIDs...)
+	if f.failFindGrantsChannel != nil {
+		return nil, f.failFindGrantsChannel
+	}
+	f.ensureInit()
+	out := []*oboGrantModel{}
+	if channelID == "" || len(grantorUIDs) == 0 {
+		return out, nil
+	}
+	if !isGroupLikeChannelType(channelType) {
+		return out, nil
+	}
+	// Build the set so membership tests are O(1).
+	wanted := make(map[string]struct{}, len(grantorUIDs))
+	for _, u := range grantorUIDs {
+		wanted[u] = struct{}{}
+	}
+	// Iterate by sorted grant ID for deterministic ordering — mirrors
+	// the sort applied in findActiveGrantsForChannel's group branch.
+	ids := make([]int64, 0, len(f.grants))
+	for id := range f.grants {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	for _, id := range ids {
+		g := f.grants[id]
+		if g == nil || g.Active != 1 || g.GlobalEnabled != 1 {
+			continue
+		}
+		if _, ok := wanted[g.GrantorUID]; !ok {
 			continue
 		}
 		cp := *g

--- a/modules/bot_api/obo_fake_test.go
+++ b/modules/bot_api/obo_fake_test.go
@@ -12,6 +12,7 @@ package bot_api
 
 import (
 	"errors"
+	"sort"
 	"sync"
 	"time"
 )
@@ -174,7 +175,30 @@ func (f *fakeOBOStore) findActiveGrantsForChannel(channelID string, channelType 
 	}
 	f.ensureInit()
 	out := []*oboGrantModel{}
-	// First collect matching grant IDs via the scopes.
+	// YUJ-1538 — mirror the production channel-type-aware lookup:
+	// Group / CommunityTopic return every active+global_enabled grant
+	// without requiring a scope row; DM (Person) keeps the strict
+	// scope-row contract.
+	if isGroupLikeChannelType(channelType) {
+		// Iterate by sorted grant ID so tests get deterministic ordering
+		// independent of map iteration order.
+		ids := make([]int64, 0, len(f.grants))
+		for id := range f.grants {
+			ids = append(ids, id)
+		}
+		sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+		for _, id := range ids {
+			g := f.grants[id]
+			if g == nil || g.Active != 1 || g.GlobalEnabled != 1 {
+				continue
+			}
+			cp := *g
+			out = append(out, &cp)
+		}
+		return out, nil
+	}
+	// DM path — original behavior: only grants with a matching enabled
+	// scope row are surfaced.
 	for _, s := range f.scopes {
 		if s.ChannelID != channelID || s.ChannelType != channelType || s.Enabled != 1 {
 			continue

--- a/modules/bot_api/obo_fanout.go
+++ b/modules/bot_api/obo_fanout.go
@@ -215,8 +215,11 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 	// (modulo the loop-protection gates) so the persona could observe
 	// the full conversation. v2 narrows the trigger: a fan-out copy is
 	// only minted when the inbound message explicitly summons the
-	// grantor via `payload.mention.uids`. @AI / @bot / plain (no
-	// mention) traffic no longer triggers the persona.
+	// grantor via `payload.mention.uids` — OR (YUJ-1538) when the
+	// message is a `@所有人` broadcast (`payload.mention.all=1`), which
+	// by spec is the strongest possible "you specifically were
+	// addressed" signal. @AI-only / @bot / plain (no mention) traffic
+	// still does NOT trigger the persona.
 	//
 	// Decoded once per inbound message: the per-grant loop below
 	// only re-uses `mentioned` to test set membership for each
@@ -226,7 +229,7 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 	// mentions" — fail-closed (no fan-out) is correct; v1 silently
 	// dispatched in that case but v2 explicitly requires the summon
 	// signal.
-	mentioned := decodeMentionUIDs(m.Payload)
+	mentioned, mentionAll := decodeMentionGate(m.Payload)
 
 	// PR#82 round-2 P1-A — per-call cache for the grantor channel-access
 	// re-check. Multiple active grants for the same (channel, grantor)
@@ -278,6 +281,13 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 		// traffic does NOT summon the persona. Mention set was decoded
 		// once at the top of fanoutForMessage; map lookup is O(1).
 		//
+		// YUJ-1538 — `@所有人` (`mention.all=1`) ALSO counts as
+		// "grantor was summoned". Real WuKongIM `@所有人` payloads
+		// commonly carry `mention.all=1` without re-listing every
+		// group member in `mention.uids`, so without this branch a
+		// broadcast in a group with an active persona grant would
+		// silently never fan out.
+		//
 		// DM-only special case: a DM is a 1:1 conversation in which the
 		// grantor is the implicit recipient (m.ChannelID == grantor for
 		// DMs after the round-3 P1 filter above). DM payloads in
@@ -289,8 +299,10 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 		// COMMUNITY_TOPIC traffic where the persona summon is
 		// disambiguating.
 		if m.ChannelType != common.ChannelTypePerson.Uint8() {
-			if _, ok := mentioned[g.GrantorUID]; !ok {
-				continue
+			if !mentionAll {
+				if _, ok := mentioned[g.GrantorUID]; !ok {
+					continue
+				}
 			}
 		}
 		// PR#82 round-2 P1-A — TOCTOU close-out on the fan-out hot path.
@@ -525,55 +537,115 @@ func buildFanoutCopyReq(m *config.MessageResp, g *oboGrantModel, grantorName, se
 	)
 }
 
-// decodeMentionUIDs — YUJ-1465 / Mininglamp-OSS/octo-server#108 (OBO v2).
-// Pulls the `mention.uids` array off the raw inbound payload and returns
-// it as a set keyed by uid. Returns an empty (non-nil) set when:
+// decodeMentionGate — YUJ-1465 / Mininglamp-OSS/octo-server#108 (OBO v2)
+// + YUJ-1538 (`@所有人` broadcast support).
+//
+// Pulls the v2 narrowing-gate inputs off the raw inbound payload:
+//
+//   - `uids`: the explicit `mention.uids` array, returned as a
+//     set keyed by uid (O(1) per-grant membership tests in
+//     fanoutForMessage's loop).
+//   - `all`:  whether `mention.all` is truthy (1 / true). `@所有人`
+//     traffic in WuKongIM commonly carries `mention.all=1` without
+//     re-listing every group member in `mention.uids`, so the gate
+//     treats it as "every grantor was implicitly mentioned" for
+//     group/topic channels.
+//
+// Returns an empty (non-nil) set + `all=false` when:
 //
 //   - the payload is empty or not JSON-decodable;
 //   - the payload has no `mention` object;
 //   - `mention.uids` is missing, not an array, or empty;
-//   - individual array entries are not strings.
+//   - `mention.all` is missing / falsey;
+//   - individual `uids` entries are not strings.
 //
-// Empty set = "no one was mentioned"; combined with the v2 narrowing
-// gate it means "do not fan out" for the GROUP / COMMUNITY_TOPIC path.
-// We intentionally do not look at `mention.all` or `mention.ais` —
-// per the spec, @AI / @bot / plain broadcast traffic MUST NOT summon
-// the persona; the grantor's uid must be present in `mention.uids`
-// specifically.
-func decodeMentionUIDs(payload []byte) map[string]struct{} {
-	out := map[string]struct{}{}
+// Empty set + `all=false` = "no one was mentioned"; combined with the
+// v2 narrowing gate it means "do not fan out" for the GROUP /
+// COMMUNITY_TOPIC path. We intentionally do NOT honour `mention.ais`
+// here — per the v2 spec, @AI / @bot traffic by itself MUST NOT summon
+// the persona; the grantor must be a target of `mention.uids` OR the
+// message must be a `@所有人` broadcast.
+func decodeMentionGate(payload []byte) (uids map[string]struct{}, all bool) {
+	uids = map[string]struct{}{}
 	if len(payload) == 0 {
-		return out
+		return uids, false
 	}
 	var decoded map[string]interface{}
 	if err := json.Unmarshal(payload, &decoded); err != nil {
-		return out
+		return uids, false
 	}
 	raw, ok := decoded["mention"]
 	if !ok || raw == nil {
-		return out
+		return uids, false
 	}
 	mentionMap, ok := raw.(map[string]interface{})
 	if !ok {
-		return out
+		return uids, false
 	}
-	uidsRaw, ok := mentionMap["uids"]
-	if !ok || uidsRaw == nil {
-		return out
-	}
-	uidsSlice, ok := uidsRaw.([]interface{})
-	if !ok {
-		return out
-	}
-	for _, v := range uidsSlice {
-		if s, ok := v.(string); ok {
-			s = strings.TrimSpace(s)
-			if s != "" {
-				out[s] = struct{}{}
+	if uidsRaw, ok := mentionMap["uids"]; ok && uidsRaw != nil {
+		if uidsSlice, ok := uidsRaw.([]interface{}); ok {
+			for _, v := range uidsSlice {
+				if s, ok := v.(string); ok {
+					s = strings.TrimSpace(s)
+					if s != "" {
+						uids[s] = struct{}{}
+					}
+				}
 			}
 		}
 	}
-	return out
+	all = mentionFlagTruthy(mentionMap["all"])
+	return uids, all
+}
+
+// mentionFlagTruthy reports whether a parsed `mention.*` flag is the
+// numeric/boolean form of 1. Mirrors `pkg/mentionrewrite.isTruthyOne`
+// (unexported there) and the read-side helper in
+// `modules/message/api_reminders.go` so the OBO fan-out gate cannot
+// disagree with the message-write/read-reminders code about what
+// counts as "set". Kept local to avoid widening pkg/mentionrewrite's
+// public surface for a helper that's mostly used at write-time.
+//
+// Real WuKongIM payloads decode into a mix of float64 (the default
+// json.Unmarshal numeric type — what `decodeMentionGate` produces) and
+// json.Number (used by other read paths that opt into
+// `json.Decoder.UseNumber()`). We accept both plus bool / int* / uint*
+// so a caller sending the legacy `"all": true` shape continues to work.
+func mentionFlagTruthy(v interface{}) bool {
+	switch x := v.(type) {
+	case nil:
+		return false
+	case bool:
+		return x
+	case float64:
+		return x == 1
+	case float32:
+		return x == 1
+	case json.Number:
+		n, err := x.Int64()
+		return err == nil && n == 1
+	case int:
+		return x == 1
+	case int8:
+		return x == 1
+	case int16:
+		return x == 1
+	case int32:
+		return x == 1
+	case int64:
+		return x == 1
+	case uint:
+		return x == 1
+	case uint8:
+		return x == 1
+	case uint16:
+		return x == 1
+	case uint32:
+		return x == 1
+	case uint64:
+		return x == 1
+	}
+	return false
 }
 
 // oboResolveDisplayName — YUJ-1465. Resolves a uid to a human display

--- a/modules/bot_api/obo_fanout.go
+++ b/modules/bot_api/obo_fanout.go
@@ -84,6 +84,7 @@ package bot_api
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -197,7 +198,81 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 	}
 
 	store := ba.oboStoreOrDefault()
-	grants, err := store.findActiveGrantsForChannel(lookupChannelID, m.ChannelType)
+	isGroupLike := m.ChannelType != common.ChannelTypePerson.Uint8()
+
+	// PR#114 R3 (Jerry-Xin perf blocker, 2026-05-21) — mention gate runs
+	// BEFORE the grant DB lookup for group-like channels. The previous
+	// shape called `findActiveGrantsForChannel` first, which for groups
+	// loads EVERY active+global_enabled grant system-wide with no
+	// channel filter — so every ordinary group message (plain text,
+	// @AI only, @bot, etc.) paid a full obo_grants scan even though
+	// the per-message v2 narrowing gate (decoded a few lines below)
+	// was going to reject them anyway.
+	//
+	// New shape for group-like channels:
+	//
+	//  1. Decode mentions ONCE up-front (cheap, in-memory JSON parse).
+	//  2. If neither `mention.all` nor any `mention.uids` is set →
+	//     EARLY RETURN. No DB query, no Redis hit beyond the cache
+	//     short-circuit that channelCacheSaysNone already provides.
+	//  3. For `mention.uids` (explicit @grantor): filter the grant
+	//     query at the DB layer via `findActiveGrantsForChannelByGrantors`
+	//     so we never load grants for OTHER grantors who weren't
+	//     mentioned. uk_grantor_grantee guarantees one row per grantor,
+	//     so the query returns at most `len(mention.uids)` rows.
+	//  4. For `mention.all` (@所有人): the full grant scan is
+	//     UNAVOIDABLE because every grantor in the group is implicitly
+	//     mentioned and we don't know the membership at this layer.
+	//     This is acceptable because `@所有人` is rare — operators
+	//     restrict its use to admins / announcements — so the
+	//     occasional full scan is bounded. The per-grant
+	//     `grantorCanReadChannel` re-check below still drops grantors
+	//     who aren't actually in the group.
+	//
+	// DM (Person) path stays unchanged: DM payloads carry no mention
+	// metadata, so we still call `findActiveGrantsForChannel` first
+	// and rely on the JOIN against the (per-peer) scope row to narrow.
+	mentioned, mentionAll := decodeMentionGate(m.Payload)
+
+	var grants []*oboGrantModel
+	var err error
+	if isGroupLike {
+		// Mention gate first — refuse to touch MySQL for plain / @AI /
+		// @bot traffic. This is THE perf fix Jerry-Xin flagged on the
+		// PR#114 review: without it every group message went through a
+		// full `obo_grants` scan.
+		if !mentionAll && len(mentioned) == 0 {
+			return 0
+		}
+		if mentionAll {
+			// @所有人 broadcast — every grantor is implicitly mentioned.
+			// The unfiltered scan is unavoidable here (we don't know
+			// who is in the group from this layer) but @所有人 is rare
+			// in practice and the alternative — fetching group
+			// membership just to filter the IN list — is more work
+			// than the scan saves.
+			grants, err = store.findActiveGrantsForChannel(lookupChannelID, m.ChannelType)
+		} else {
+			// Explicit @grantor(s) — filter at the DB layer so we
+			// never load grants for un-mentioned grantors. Collect
+			// the set into a slice in deterministic order so the
+			// IN(...) placeholder set is stable across calls (helps
+			// query-plan caching at the MySQL layer too).
+			grantorUIDs := make([]string, 0, len(mentioned))
+			for uid := range mentioned {
+				grantorUIDs = append(grantorUIDs, uid)
+			}
+			// Stable ordering — `range` on a map is unordered. Use a
+			// simple sort so identical mention sets produce identical
+			// query bind shapes.
+			sort.Strings(grantorUIDs)
+			grants, err = store.findActiveGrantsForChannelByGrantors(
+				lookupChannelID, m.ChannelType, grantorUIDs,
+			)
+		}
+	} else {
+		grants, err = store.findActiveGrantsForChannel(lookupChannelID, m.ChannelType)
+	}
 	if err != nil {
 		ba.Error("OBO fan-out lookup failed",
 			zap.String("lookup_channel_id", lookupChannelID),
@@ -221,15 +296,15 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 	// addressed" signal. @AI-only / @bot / plain (no mention) traffic
 	// still does NOT trigger the persona.
 	//
-	// Decoded once per inbound message: the per-grant loop below
-	// only re-uses `mentioned` to test set membership for each
-	// grantor. Decoding into a string-set keeps the inner loop O(1)
-	// per grant instead of O(N) over the mention.uids slice. We
-	// tolerate non-JSON / malformed mention payloads as "no
-	// mentions" — fail-closed (no fan-out) is correct; v1 silently
-	// dispatched in that case but v2 explicitly requires the summon
-	// signal.
-	mentioned, mentionAll := decodeMentionGate(m.Payload)
+	// PR#114 R3 — for group-like channels the mention gate has already
+	// run UP-FRONT (above) and either early-returned or narrowed the
+	// grant query by the mentioned UIDs. The per-grant check inside
+	// the loop below remains as a belt-and-suspenders verification —
+	// the DB filter could in principle drop rows but mentionAll uses
+	// the unfiltered scan, and we still want to verify each surviving
+	// grantor was actually summoned. For DMs the mention set is
+	// always empty (DM payloads carry no mention), but the DM-only
+	// "implicitly mentioned" branch below preserves the v2 contract.
 
 	// PR#82 round-2 P1-A — per-call cache for the grantor channel-access
 	// re-check. Multiple active grants for the same (channel, grantor)

--- a/modules/bot_api/obo_pr114_r3_test.go
+++ b/modules/bot_api/obo_pr114_r3_test.go
@@ -1,0 +1,342 @@
+// Package bot_api · PR#114 R3 (Jerry-Xin perf blocker, 2026-05-21).
+//
+// fanoutForMessage's mention gate MUST run BEFORE the grant DB lookup
+// for group-like channels. Pre-fix, every inbound group message —
+// plain text, @AI-only, @bot-only — paid a full `obo_grants` scan
+// because `findActiveGrantsForChannel` was called UNCONDITIONALLY for
+// the channel, then the per-message v2 narrowing gate (which drops
+// these traffic shapes) ran inside the per-grant loop. With OBO grants
+// gaining adoption that scan was dominating fan-out CPU even though
+// the vast majority of group traffic could never trigger a fan-out copy.
+//
+// Tests in this file pin three contracts that together close the
+// blocker:
+//
+//  1. EARLY-RETURN: plain / @AI-only / @bot-only group traffic returns
+//     from fanoutForMessage without invoking EITHER grant lookup
+//     method. The fake's call counters surface a regression that
+//     forgets to short-circuit, before it reaches CI perf metrics.
+//
+//  2. DB-LEVEL FILTER: explicit `@grantor` (mention.uids) traffic
+//     consults `findActiveGrantsForChannelByGrantors` (NOT the
+//     unfiltered `findActiveGrantsForChannel`) and passes the exact
+//     mentioned UID set as the IN(...) filter. Catches a refactor
+//     that quietly drops the narrowed-query path and reverts to the
+//     full scan.
+//
+//  3. @所有人 FALLBACK: `mention.all=1` correctly accepts the
+//     unfiltered scan because we cannot know group membership at
+//     this layer; the perf cost is bounded by how rarely @所有人 is
+//     used in production.
+//
+// DM (Person) traffic is intentionally NOT exercised here — the
+// pre-fix DM path already used the scope-joined query
+// (`findActiveGrantsForChannel` with the scope INNER JOIN) which has
+// the channel filter baked in, so DM behavior is unchanged. The DM
+// regression guard lives in TestFanout_YUJ1538_DMStillRequiresScopeRow.
+package bot_api
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+)
+
+// assertNoGrantLookups fails the test when the fan-out path consulted
+// either of the two `findActiveGrants*` methods. Used by the
+// early-return tests to lock in the "no DB hit on plain group traffic"
+// contract.
+func assertNoGrantLookups(t *testing.T, s *fakeOBOStore, label string) {
+	t.Helper()
+	if s.findGrantsChannelCalls != 0 {
+		t.Fatalf("%s: findActiveGrantsForChannel must NOT be called on early-return path, got %d call(s)",
+			label, s.findGrantsChannelCalls)
+	}
+	if s.findGrantsChannelByGrantorsCalls != 0 {
+		t.Fatalf("%s: findActiveGrantsForChannelByGrantors must NOT be called on early-return path, got %d call(s)",
+			label, s.findGrantsChannelByGrantorsCalls)
+	}
+}
+
+// TestFanout_PR114R3_GroupPlainText_NoDBLookup — the canonical
+// early-return case. A group message with no mention.uids and no
+// mention.all must short-circuit before any grant lookup runs.
+func TestFanout_PR114R3_GroupPlainText_NoDBLookup(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantNoScope(t) // grant exists with global_enabled=1
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		// Plain text — no `mention` field at all.
+		Payload: []byte(`{"type":1,"content":"just chatting"}`),
+	}
+	if got := ba.fanoutForMessage(msg); got != 0 {
+		t.Fatalf("plain group text must NOT fan out, got %d", got)
+	}
+	if len(fc.copies) != 0 {
+		t.Fatalf("plain group text must NOT dispatch copies, got %d", len(fc.copies))
+	}
+	assertNoGrantLookups(t, s, "plain text group")
+}
+
+// TestFanout_PR114R3_GroupAIMentionOnly_NoDBLookup — @AI / @bot
+// traffic (mention.ais set, mention.uids empty, mention.all unset)
+// MUST short-circuit too. Per spec, @AI alone does NOT summon the
+// persona; only @grantor or @所有人 does. The early-return guarantees
+// we don't pay a DB scan to discover that.
+func TestFanout_PR114R3_GroupAIMentionOnly_NoDBLookup(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantNoScope(t)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		// `mention.ais` set, `mention.uids` empty, `mention.all` unset.
+		// Real WuKongIM @AI payload shape.
+		Payload: []byte(`{"type":1,"content":"@AI summarize","mention":{"ais":["ai_bot_uid"]}}`),
+	}
+	if got := ba.fanoutForMessage(msg); got != 0 {
+		t.Fatalf("@AI-only group text must NOT fan out, got %d", got)
+	}
+	assertNoGrantLookups(t, s, "@AI-only group")
+}
+
+// TestFanout_PR114R3_GroupEmptyMentionUIDs_NoDBLookup — a payload
+// that carries a `mention` object but with `uids: []` and
+// `all: 0` (or absent) must also short-circuit. Some clients emit
+// the empty array even when nobody was @-mentioned.
+func TestFanout_PR114R3_GroupEmptyMentionUIDs_NoDBLookup(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantNoScope(t)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"hi","mention":{"uids":[],"all":0}}`),
+	}
+	if got := ba.fanoutForMessage(msg); got != 0 {
+		t.Fatalf("empty mention object must NOT fan out, got %d", got)
+	}
+	assertNoGrantLookups(t, s, "empty mention object")
+}
+
+// TestFanout_PR114R3_GroupGrantorMention_UsesFilteredQuery — explicit
+// @grantor must route through `findActiveGrantsForChannelByGrantors`
+// (NOT the unfiltered scan) and pass the exact mentioned UID set as
+// the filter. Pin both the call shape and the resulting dispatch so
+// a refactor that quietly drops the filter and falls back to the full
+// scan fails here, not at perf-test time.
+func TestFanout_PR114R3_GroupGrantorMention_UsesFilteredQuery(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantNoScope(t)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload: []byte(`{"type":1,"content":"@yu help","mention":{"uids":["` +
+			tGrantor + `"]}}`),
+	}
+	if got := ba.fanoutForMessage(msg); got != 1 {
+		t.Fatalf("@grantor in group must fan out, got %d", got)
+	}
+	// The filtered method MUST have been called, the unfiltered one
+	// MUST NOT — that's the whole point of the perf fix.
+	if s.findGrantsChannelByGrantorsCalls != 1 {
+		t.Fatalf("filtered query findActiveGrantsForChannelByGrantors must be called exactly once, got %d",
+			s.findGrantsChannelByGrantorsCalls)
+	}
+	if s.findGrantsChannelCalls != 0 {
+		t.Fatalf("unfiltered findActiveGrantsForChannel MUST NOT be called for @grantor, got %d call(s)",
+			s.findGrantsChannelCalls)
+	}
+	// Verify the bind shape: exactly the mentioned UIDs, no more.
+	args := s.lastFindByGrantorsArgs
+	if !args.called {
+		t.Fatalf("filter args were not recorded — did the test seam fire?")
+	}
+	if args.channelID != ch {
+		t.Fatalf("filter channelID: want %q, got %q", ch, args.channelID)
+	}
+	if args.channelType != ct {
+		t.Fatalf("filter channelType: want %d, got %d", ct, args.channelType)
+	}
+	if len(args.grantorUIDs) != 1 || args.grantorUIDs[0] != tGrantor {
+		t.Fatalf("filter grantorUIDs: want [%q], got %v", tGrantor, args.grantorUIDs)
+	}
+}
+
+// TestFanout_PR114R3_GroupMultipleGrantorMentions_FilterCarriesAll —
+// a message that @-mentions multiple grantors must pass ALL of them
+// through to the filter so the DB can return matching rows for each.
+// Catches a regression that only forwards the first uid (e.g. taking
+// `range mentioned` and breaking after one).
+func TestFanout_PR114R3_GroupMultipleGrantorMentions_FilterCarriesAll(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantNoScope(t)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	// Mention three uids: the test grantor (has a grant) plus two
+	// other random uids (no grants). The filter call must carry all
+	// three sorted; the dispatch must still produce exactly one copy.
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload: []byte(`{"type":1,"content":"@yu @bob @carol",` +
+			`"mention":{"uids":["` + tGrantor + `","u_bob","u_carol"]}}`),
+	}
+	if got := ba.fanoutForMessage(msg); got != 1 {
+		t.Fatalf("multi-mention must fan out only to matching grantor, got %d", got)
+	}
+	if s.findGrantsChannelByGrantorsCalls != 1 {
+		t.Fatalf("filtered query must be called once, got %d", s.findGrantsChannelByGrantorsCalls)
+	}
+	args := s.lastFindByGrantorsArgs
+	if len(args.grantorUIDs) != 3 {
+		t.Fatalf("filter must carry all 3 mentioned uids, got %v", args.grantorUIDs)
+	}
+	// Sorted check — fan-out sorts for stable IN(...) binds.
+	seen := map[string]bool{}
+	for _, u := range args.grantorUIDs {
+		seen[u] = true
+	}
+	for _, want := range []string{tGrantor, "u_bob", "u_carol"} {
+		if !seen[want] {
+			t.Fatalf("filter missing expected uid %q, got %v", want, args.grantorUIDs)
+		}
+	}
+}
+
+// TestFanout_PR114R3_GroupMentionAll_UsesUnfilteredScan — `@所有人`
+// (mention.all=1) is the documented exception: we cannot know group
+// membership at this layer so the full grant scan is unavoidable.
+// Pin that contract so a future "always-filter" refactor doesn't
+// silently break @所有人 broadcasts (they would early-return because
+// the empty filter set returns no rows).
+func TestFanout_PR114R3_GroupMentionAll_UsesUnfilteredScan(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantNoScope(t)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		// `@所有人` shape: mention.all=1, no uids.
+		Payload: []byte(`{"type":1,"content":"@所有人 ship today","mention":{"all":1}}`),
+	}
+	if got := ba.fanoutForMessage(msg); got != 1 {
+		t.Fatalf("@所有人 in group must summon every grantor, got %d", got)
+	}
+	if s.findGrantsChannelCalls != 1 {
+		t.Fatalf("unfiltered scan must be used for @所有人, got %d call(s)",
+			s.findGrantsChannelCalls)
+	}
+	if s.findGrantsChannelByGrantorsCalls != 0 {
+		t.Fatalf("filtered query MUST NOT be used for @所有人 (no UID set to filter on), got %d",
+			s.findGrantsChannelByGrantorsCalls)
+	}
+}
+
+// TestFanout_PR114R3_CommunityTopicEarlyReturn — community-topic
+// channels share the group-like "@grantor narrowing" model and must
+// therefore ALSO short-circuit on plain traffic.
+func TestFanout_PR114R3_CommunityTopicEarlyReturn(t *testing.T) {
+	ch, ct := "group_42____topic_a1", common.ChannelTypeCommunityTopic.Uint8()
+	s := seedGrantNoScope(t)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"thread reply"}`),
+	}
+	if got := ba.fanoutForMessage(msg); got != 0 {
+		t.Fatalf("plain community-topic text must NOT fan out, got %d", got)
+	}
+	assertNoGrantLookups(t, s, "plain community-topic")
+}
+
+// TestFanout_PR114R3_DMPathUnchanged_StillCallsUnfilteredJoinQuery —
+// DM (Person) traffic MUST continue to call findActiveGrantsForChannel
+// (which uses the scope-joined SELECT). The mention gate / early
+// return / filtered-query optimizations are group-only; DMs never had
+// the perf problem because the JOIN-with-scopes was already
+// channel-filtered. This regression guard catches a refactor that
+// accidentally widens the early-return or the filter path to cover
+// DMs.
+func TestFanout_PR114R3_DMPathUnchanged_StillCallsUnfilteredJoinQuery(t *testing.T) {
+	const peer = "u_bob"
+	ct := common.ChannelTypePerson.Uint8()
+	// Use the seedGrantWithScope helper variant: install a grant +
+	// matching DM scope row so the JOIN actually surfaces it.
+	s := seedGrantWithScope(t, peer, ct)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     peer,
+		ChannelID:   tGrantor, // DM listener-native view: ChannelID = receiver
+		ChannelType: ct,
+		// Plain DM — no mention object. Pre-fix and post-fix the DM
+		// path must still go through findActiveGrantsForChannel.
+		Payload: []byte(`{"type":1,"content":"hey, free now?"}`),
+	}
+	if got := ba.fanoutForMessage(msg); got != 1 {
+		t.Fatalf("DM with matching scope must fan out, got %d", got)
+	}
+	if s.findGrantsChannelCalls != 1 {
+		t.Fatalf("DM path must call findActiveGrantsForChannel exactly once, got %d",
+			s.findGrantsChannelCalls)
+	}
+	if s.findGrantsChannelByGrantorsCalls != 0 {
+		t.Fatalf("DM path MUST NOT use the @-mention filtered query, got %d call(s)",
+			s.findGrantsChannelByGrantorsCalls)
+	}
+}
+
+// TestFanout_PR114R3_GroupBotSelfSent_StillEarlyReturns — gate 3
+// (bot's own __obo_processed__ marker) still fires before the mention
+// gate, so the bot's own outbound copy short-circuits BEFORE we even
+// decode mentions. Without this guard a future refactor that moved
+// the marker check below the mention gate would re-introduce the loop
+// the marker is designed to prevent. We pin the "no grant lookup
+// either" contract because gate 3 is the cheapest of the three loop
+// protections.
+func TestFanout_PR114R3_GroupBotSelfSent_StillEarlyReturns(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantNoScope(t)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     tBot,
+		ChannelID:   ch,
+		ChannelType: ct,
+		// Payload carries the marker AND a mention.all=1 — the marker
+		// must win or we'd loop forever.
+		Payload: []byte(`{"type":1,"content":"echo","__obo_processed__":true,"mention":{"all":1}}`),
+	}
+	if got := ba.fanoutForMessage(msg); got != 0 {
+		t.Fatalf("__obo_processed__ marker must short-circuit before fan-out, got %d", got)
+	}
+	assertNoGrantLookups(t, s, "bot self-sent with marker")
+}

--- a/modules/bot_api/obo_pr114_r4_test.go
+++ b/modules/bot_api/obo_pr114_r4_test.go
@@ -1,0 +1,327 @@
+// Package bot_api · PR#114 R4 (Jerry-Xin + lml2468 cache-poisoning
+// blocker, 2026-05-21).
+//
+// `findActiveGrantsForChannelByGrantors` runs a UID-FILTERED query
+// against the `obo_grants` table. Its result answers "do any of the
+// mentioned grantors have an active grant", which is a SUBSET answer
+// — not the channel-wide answer the `obo:chan:{type}:{id}` cache
+// encodes ("does this channel have ANY active grant × enabled
+// scope"). Pre-fix, the function wrote its filtered result into the
+// channel-wide key and also short-circuited on it. Both directions
+// poisoned the fan-out path for legitimate follow-up traffic:
+//
+//   - Poisoning WRITE: a message in group_42 that mentions @alice
+//     (no grant) → filtered query returns 0 rows → cache writes
+//     `obo:chan:Group:group_42 = "0"`. The next message in group_42
+//     that mentions @admin (HAS a grant) → unfiltered
+//     `findActiveGrantsForChannel` reads the cached "0" → returns []
+//     → fan-out suppressed.
+//
+//   - Poisoning READ: a DM peer uid that happens to collide string-
+//     wise with a group id can write "0" via the DM path; the
+//     filtered group lookup honoring that "0" would suppress the
+//     group fan-out for grantors who actually have a grant.
+//
+// The fix in obo_db.go removes BOTH the write AND the read from
+// `findActiveGrantsForChannelByGrantors`. Tests in this file pin
+// that contract end-to-end:
+//
+//  1. Direct test on a cache-aware oboStore wrapper: a UID-filtered
+//     miss does NOT poison a subsequent unfiltered call.
+//  2. Fan-out integration: @alice (no grant) followed by @bob (has
+//     grant) in the same group → bob's fan-out fires. Catches a
+//     regression that re-introduces either the cache write or the
+//     cache read.
+package bot_api
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+)
+
+// channelCacheKey mirrors the production `obo:chan:{type}:{id}`
+// composite key shape so the wrapper below cannot accidentally
+// collide DM and Group entries that share the same string.
+type channelCacheKey struct {
+	channelID   string
+	channelType uint8
+}
+
+// cachedFakeOBOStore wraps *fakeOBOStore and adds a minimal in-memory
+// channel cache that mirrors the PRODUCTION cache contract for the
+// `obo:chan:{type}:{id}` scalar:
+//
+//   - The unfiltered `findActiveGrantsForChannel` WRITES the cache
+//     after each call (true if any grant, false if zero) and READS
+//     the cache before hitting the underlying fake store, returning
+//     early on a cached "no grants" answer.
+//
+//   - The filtered `findActiveGrantsForChannelByGrantors` does NOT
+//     touch the cache in either direction. This is the PR#114 R4
+//     fix: a UID-filtered subset cannot prove the channel-wide
+//     negative answer the cache encodes, so writing it would
+//     suppress legitimate fan-out for OTHER grantors and reading
+//     a cross-namespace DM write would suppress legitimate group
+//     traffic.
+//
+// All other oboStore methods are delegated to the embedded fake
+// verbatim, so this wrapper can be dropped in anywhere a
+// *fakeOBOStore was previously used.
+//
+// We use a SEPARATE wrapper rather than extending *fakeOBOStore
+// itself so existing tests that depend on the cache-less fake
+// shape are not perturbed; the cache contract is opt-in for the
+// tests that need it.
+type cachedFakeOBOStore struct {
+	*fakeOBOStore
+	cacheMu sync.Mutex
+	// cache holds the trinary state per (channelID, channelType):
+	//   - present and value=true  → "1" (any grant)
+	//   - present and value=false → "0" (no grants)
+	//   - absent                  → cache miss / unknown
+	cache map[channelCacheKey]bool
+}
+
+func newCachedFakeOBOStore() *cachedFakeOBOStore {
+	return &cachedFakeOBOStore{
+		fakeOBOStore: newFakeOBOStore(),
+		cache:        map[channelCacheKey]bool{},
+	}
+}
+
+// channelCacheSaysNone returns true iff the cache holds a definitive
+// "no grants" answer for the (channelID, channelType) pair. Mirrors
+// the production helper of the same name on *botAPIDB.
+func (c *cachedFakeOBOStore) channelCacheSaysNone(channelID string, channelType uint8) bool {
+	c.cacheMu.Lock()
+	defer c.cacheMu.Unlock()
+	v, ok := c.cache[channelCacheKey{channelID, channelType}]
+	return ok && !v
+}
+
+// writeChannelCache populates the cache. Mirrors the production
+// helper of the same name on *botAPIDB.
+func (c *cachedFakeOBOStore) writeChannelCache(channelID string, channelType uint8, any bool) {
+	c.cacheMu.Lock()
+	defer c.cacheMu.Unlock()
+	c.cache[channelCacheKey{channelID, channelType}] = any
+}
+
+// findActiveGrantsForChannel — wraps the fake to add the channel
+// cache read/write loop. Behavior is otherwise verbatim.
+func (c *cachedFakeOBOStore) findActiveGrantsForChannel(channelID string, channelType uint8) ([]*oboGrantModel, error) {
+	if c.channelCacheSaysNone(channelID, channelType) {
+		// Increment the call counter so tests that pin "early return on
+		// cached miss" can still observe the call shape.
+		c.fakeOBOStore.mu.Lock()
+		c.fakeOBOStore.findGrantsChannelCalls++
+		c.fakeOBOStore.mu.Unlock()
+		return []*oboGrantModel{}, nil
+	}
+	grants, err := c.fakeOBOStore.findActiveGrantsForChannel(channelID, channelType)
+	if err != nil {
+		return nil, err
+	}
+	c.writeChannelCache(channelID, channelType, len(grants) > 0)
+	return grants, nil
+}
+
+// findActiveGrantsForChannelByGrantors — wraps the fake but MUST
+// NOT touch the channel cache in either direction (PR#114 R4 fix).
+// This wrapper intentionally calls neither channelCacheSaysNone nor
+// writeChannelCache so the fan-out tests catch a regression that
+// re-introduces either operation.
+func (c *cachedFakeOBOStore) findActiveGrantsForChannelByGrantors(channelID string, channelType uint8, grantorUIDs []string) ([]*oboGrantModel, error) {
+	return c.fakeOBOStore.findActiveGrantsForChannelByGrantors(channelID, channelType, grantorUIDs)
+}
+
+// ==================== Tests ====================
+
+// TestPR114R4_FilteredQueryDoesNotPoisonChannelCache pins the DIRECT
+// store-layer contract: a UID-filtered query whose result is empty
+// must NOT write "no grants" into the channel-wide cache key. A
+// subsequent unfiltered call against the same channel must still see
+// the actual rows.
+//
+// Scenario:
+//   - group_42 has one grant: bob → bot (global_enabled=1, no scope row)
+//   - alice has no grant
+//   - Call findActiveGrantsForChannelByGrantors(group_42, ["alice"])
+//     → returns [] (alice has no grant). Pre-fix this would write
+//     `obo:chan:Group:group_42 = "0"` (cache poisoned).
+//   - Call findActiveGrantsForChannel(group_42)
+//     → must return [bob's grant]. Pre-fix this would return [] from
+//     the cached "0" short-circuit.
+func TestPR114R4_FilteredQueryDoesNotPoisonChannelCache(t *testing.T) {
+	const (
+		ch       = "group_42"
+		bobUID   = "u_bob"
+		aliceUID = "u_alice"
+	)
+	ct := common.ChannelTypeGroup.Uint8()
+
+	c := newCachedFakeOBOStore()
+	// Seed bob's grant: active=1, global_enabled=1, no scope row.
+	gid, err := c.insertGrant(bobUID, tBot, "auto", "")
+	if err != nil {
+		t.Fatalf("insertGrant: %v", err)
+	}
+	enable := 1
+	if err := c.updateGrant(gid, "", &enable, nil); err != nil {
+		t.Fatalf("updateGrant: %v", err)
+	}
+
+	// 1. Filtered miss for alice — alice has no grant, returns [].
+	got, err := c.findActiveGrantsForChannelByGrantors(ch, ct, []string{aliceUID})
+	if err != nil {
+		t.Fatalf("filtered query: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("alice has no grant: expected 0 rows, got %d", len(got))
+	}
+
+	// 2. The filtered miss MUST NOT have written "no grants" into the
+	//    channel-wide cache. channelCacheSaysNone is the production
+	//    short-circuit; if it returns true the unfiltered call below
+	//    early-returns empty and the fan-out is silently suppressed.
+	if c.channelCacheSaysNone(ch, ct) {
+		t.Fatalf("PR#114 R4 regression: filtered query for alice poisoned the channel-wide cache " +
+			"(channelCacheSaysNone=true after a UID-filtered miss). The cache key answers a " +
+			"CHANNEL-WIDE question; a UID-filtered subset cannot prove it.")
+	}
+
+	// 3. Unfiltered lookup must return bob's grant.
+	got, err = c.findActiveGrantsForChannel(ch, ct)
+	if err != nil {
+		t.Fatalf("unfiltered query: %v", err)
+	}
+	if len(got) != 1 || got[0].GrantorUID != bobUID {
+		t.Fatalf("unfiltered lookup expected [bob], got %d rows: %+v", len(got), got)
+	}
+}
+
+// TestPR114R4_FilteredQueryIgnoresCrossNamespaceChannelCache pins the
+// READ-side contract: even if the channel-wide cache holds "0" (e.g.
+// written by an earlier UNFILTERED DM lookup whose peer uid happens
+// to string-collide with this group id), the FILTERED group lookup
+// must STILL probe the underlying store. Reading the cached "0"
+// would incorrectly suppress group fan-out for grantors who actually
+// have a grant.
+//
+// Pre-fix `findActiveGrantsForChannelByGrantors` short-circuited on
+// `channelCacheSaysNone`; the fix removes that read.
+func TestPR114R4_FilteredQueryIgnoresCrossNamespaceChannelCache(t *testing.T) {
+	const (
+		ch     = "group_42"
+		bobUID = "u_bob"
+	)
+	ct := common.ChannelTypeGroup.Uint8()
+
+	c := newCachedFakeOBOStore()
+	gid, err := c.insertGrant(bobUID, tBot, "auto", "")
+	if err != nil {
+		t.Fatalf("insertGrant: %v", err)
+	}
+	enable := 1
+	if err := c.updateGrant(gid, "", &enable, nil); err != nil {
+		t.Fatalf("updateGrant: %v", err)
+	}
+
+	// Pre-seed the channel cache with "no grants" — simulates a stale
+	// or cross-namespace write the filtered path must NOT honor.
+	c.writeChannelCache(ch, ct, false)
+	if !c.channelCacheSaysNone(ch, ct) {
+		t.Fatalf("test setup: expected channelCacheSaysNone=true after writeChannelCache(false)")
+	}
+
+	got, err := c.findActiveGrantsForChannelByGrantors(ch, ct, []string{bobUID})
+	if err != nil {
+		t.Fatalf("filtered query: %v", err)
+	}
+	if len(got) != 1 || got[0].GrantorUID != bobUID {
+		t.Fatalf("PR#114 R4 regression: filtered query honored a stale channelCacheSaysNone=true "+
+			"and returned %d rows; expected [bob's grant] (the filtered path must probe its "+
+			"own UID set, not read the channel-wide cache)", len(got))
+	}
+}
+
+// TestFanout_PR114R4_AliceMissDoesNotPoisonBobFanout — the
+// end-to-end fan-out test the issue calls out. Two grantors in the
+// same group: alice (no grant) and bob (has grant). Send @alice
+// first, then @bob — bob's fan-out MUST fire on the second message,
+// not be suppressed by a cache "0" left behind from alice's miss.
+func TestFanout_PR114R4_AliceMissDoesNotPoisonBobFanout(t *testing.T) {
+	const (
+		ch       = "group_42"
+		bobUID   = "u_bob"
+		aliceUID = "u_alice"
+	)
+	ct := common.ChannelTypeGroup.Uint8()
+
+	c := newCachedFakeOBOStore()
+	// Bob has an active grant on the group (global_enabled=1, no
+	// scope row — Group channel type does not require a scope per
+	// YUJ-1538). Alice has nothing.
+	gid, err := c.insertGrant(bobUID, tBot, "auto", "")
+	if err != nil {
+		t.Fatalf("insertGrant bob: %v", err)
+	}
+	enable := 1
+	if err := c.updateGrant(gid, "", &enable, nil); err != nil {
+		t.Fatalf("updateGrant bob: %v", err)
+	}
+
+	fc := &fanoutCapture{}
+	ba := &BotAPI{
+		Log:               log.NewTLog("BotAPI-PR114R4-test"),
+		oboStoreOverride:  c,
+		oboFanoutDispatch: fc.hook,
+		oboChannelAccessOverride: func(uid, channelID string, channelType uint8) (bool, error) {
+			// Both alice and bob can read the channel — strip the
+			// PR#82 P1-A re-check from this scenario's variables.
+			return true, nil
+		},
+	}
+
+	// Message 1 — sender mentions @alice, who has no grant. The
+	// filtered query returns 0 rows. No fan-out.
+	msg1 := &config.MessageResp{
+		FromUID:     "u_carol",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload: []byte(`{"type":1,"content":"@alice ping",` +
+			`"mention":{"uids":["` + aliceUID + `"]}}`),
+	}
+	if got := ba.fanoutForMessage(msg1); got != 0 {
+		t.Fatalf("alice has no grant: expected 0 fan-out, got %d", got)
+	}
+	if len(fc.copies) != 0 {
+		t.Fatalf("alice has no grant: expected 0 dispatched copies, got %d", len(fc.copies))
+	}
+
+	// Message 2 — same group, sender mentions @bob (HAS a grant).
+	// Pre-fix this returned 0 because alice's miss had poisoned the
+	// channel-wide cache. Post-fix bob's filtered query goes
+	// straight to the store and finds his grant.
+	msg2 := &config.MessageResp{
+		FromUID:     "u_carol",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload: []byte(`{"type":1,"content":"@bob help",` +
+			`"mention":{"uids":["` + bobUID + `"]}}`),
+	}
+	if got := ba.fanoutForMessage(msg2); got != 1 {
+		t.Fatalf("PR#114 R4 cache poisoning regression: @bob in same group must fan out "+
+			"(alice's prior miss must not poison the channel-wide cache), got %d", got)
+	}
+	if len(fc.copies) != 1 {
+		t.Fatalf("PR#114 R4: expected exactly 1 dispatched copy for bob, got %d", len(fc.copies))
+	}
+	if cp := fc.copies[0]; cp.ChannelID != tBot {
+		t.Fatalf("dispatched copy channel_id: want bot mailbox %q, got %q", tBot, cp.ChannelID)
+	}
+}

--- a/modules/bot_api/obo_v2_test.go
+++ b/modules/bot_api/obo_v2_test.go
@@ -60,26 +60,32 @@ func TestFanout_V2_GroupRequiresGrantorMention(t *testing.T) {
 }
 
 // TestFanout_V2_GroupMentionAIBotDoesNotSummonPersona — a message that
-// @-mentions only the bot (or only sets mention.all=1) must not summon
-// the grantor's persona. The narrowing gate is intentionally STRICT on
-// mention.uids — neither mention.all nor mention.ais counts. Without
+// @-mentions only the bot or only sets `mention.ais=1` (the AI-broadcast
+// flag) must not summon the grantor's persona. The narrowing gate is
+// strict on `mention.uids` for AI-only / bot-only traffic — neither
+// `mention.ais` nor a foreign-bot uid in `mention.uids` counts. Without
 // this strictness the v1 "fan out everything" semantics return.
+//
+// YUJ-1538 carve-out: `mention.all=1` (the `@所有人` broadcast flag) IS
+// honoured by the gate as an implicit summon for every grantor, so it
+// is intentionally NOT exercised here — the dedicated
+// TestFanout_V2_GroupMentionAllSummonsPersona below covers that.
 func TestFanout_V2_GroupMentionAIBotDoesNotSummonPersona(t *testing.T) {
 	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
 	s := seedGrantWithScope(t, ch, ct)
 	fc := &fanoutCapture{}
 	ba := newBAforFanout(s, fc)
 
-	// mention.all=1 + mention.uids=[some_other_bot] — neither summons
+	// mention.ais=1 + mention.uids=[some_other_bot] — neither summons
 	// our grantor (tGrantor) so v2 must skip.
 	msg := &config.MessageResp{
 		FromUID:     "alice",
 		ChannelID:   ch,
 		ChannelType: ct,
-		Payload:     []byte(`{"type":1,"content":"@AI everyone","mention":{"all":1,"ais":1,"uids":["some_other_bot"]}}`),
+		Payload:     []byte(`{"type":1,"content":"@AI please","mention":{"ais":1,"uids":["some_other_bot"]}}`),
 	}
 	if n := ba.fanoutForMessage(msg); n != 0 {
-		t.Fatalf("v2 narrowing violated: @AI / mention.all must NOT summon persona without explicit @grantor, got %d dispatches", n)
+		t.Fatalf("v2 narrowing violated: @AI / mention.ais must NOT summon persona without explicit @grantor or mention.all=1, got %d dispatches", n)
 	}
 }
 

--- a/modules/bot_api/obo_yuj1538_test.go
+++ b/modules/bot_api/obo_yuj1538_test.go
@@ -25,10 +25,12 @@
 package bot_api
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 )
 
 // seedGrantNoScope is the YUJ-1538 setup parity to seedGrantWithScope:
@@ -326,5 +328,93 @@ func TestDecodeMentionGate_YUJ1538_AllFlagShapes(t *testing.T) {
 				t.Fatalf("payload %q: want all=%v, got %v", tc.payload, tc.wantAll, all)
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------
+// PR#114 review fix — checkOBO scope-row bypass for group-like channels
+// (Jerry-Xin / lml2468). Pre-fix, the bot's OBO reply hit
+// `store.scopeEnabled(...)` and returned false because operators never
+// installed channel_type=2 scopes in production, so the reply 403'd
+// even though the v2 fan-out trigger query had already been widened.
+// ---------------------------------------------------------------------
+
+// newBotAPIForCheckYUJ1538 mirrors newBotAPIWithFakeStore in
+// obo_check_test.go but is duplicated here so the new tests live next
+// to the rest of the YUJ-1538 pinning. The channel-access override
+// defaults to "always allowed" so the assertions focus on the
+// scope-row contract, not the TOCTOU re-check layer (which has its
+// own dedicated test in obo_check_test.go).
+func newBotAPIForCheckYUJ1538(s *fakeOBOStore) *BotAPI {
+	return &BotAPI{
+		Log:              log.NewTLog("BotAPI-yuj1538-check"),
+		oboStoreOverride: s,
+		oboChannelAccessOverride: func(uid, channelID string, channelType uint8) (bool, error) {
+			return true, nil
+		},
+	}
+}
+
+// TestCheckOBO_YUJ1538_GroupNoScopeRow_GlobalEnabledAuthorizes — PR#114
+// review blocker. With `global_enabled=1` and NO `obo_scopes` row,
+// `checkOBO` for a Group channel must succeed (return nil). Pre-fix
+// this returned ErrOBONotAuthorized because `scopeEnabled` was called
+// unconditionally and answered false, so the bot's OBO reply 403'd
+// even though PR#109 had already allowed the fan-out copy to reach
+// the bot. The new branch in checkOBO skips scopeEnabled for
+// group-like channel types; symmetry with findActiveGrantsForChannel.
+func TestCheckOBO_YUJ1538_GroupNoScopeRow_GlobalEnabledAuthorizes(t *testing.T) {
+	s := seedGrantNoScope(t)
+	ba := newBotAPIForCheckYUJ1538(s)
+	if err := ba.checkOBO(tBot, tGrantor, "group_42", common.ChannelTypeGroup.Uint8()); err != nil {
+		t.Fatalf("YUJ-1538 / PR#114: group with global_enabled=1 and no scope row must authorize, got %v", err)
+	}
+}
+
+// TestCheckOBO_YUJ1538_CommunityTopicNoScopeRow_GlobalEnabledAuthorizes —
+// CommunityTopic shares the group-like "@grantor narrowing" contract
+// and must therefore also bypass the scope-row requirement when
+// `global_enabled=1`. Keeps the two channel types as separate test
+// cases so a regression that drops only one surfaces with a precise
+// failure message.
+func TestCheckOBO_YUJ1538_CommunityTopicNoScopeRow_GlobalEnabledAuthorizes(t *testing.T) {
+	s := seedGrantNoScope(t)
+	ba := newBotAPIForCheckYUJ1538(s)
+	if err := ba.checkOBO(tBot, tGrantor, "group_42____topic_a1", common.ChannelTypeCommunityTopic.Uint8()); err != nil {
+		t.Fatalf("YUJ-1538 / PR#114: community-topic with global_enabled=1 and no scope row must authorize, got %v", err)
+	}
+}
+
+// TestCheckOBO_YUJ1538_DMNoScope_StillUnauthorized — regression guard.
+// The PR#114 fix MUST NOT relax DM behavior: a grant with
+// `global_enabled=1` but no scope row for the DM peer must still deny.
+// DMs have no in-message narrowing signal (mentions don't apply), so
+// the per-peer scope row is the only explicit opt-in.
+func TestCheckOBO_YUJ1538_DMNoScope_StillUnauthorized(t *testing.T) {
+	const dmPeer = "u_bob"
+	s := seedGrantNoScope(t) // grant exists with global_enabled=1, but no scope
+	ba := newBotAPIForCheckYUJ1538(s)
+	err := ba.checkOBO(tBot, tGrantor, dmPeer, common.ChannelTypePerson.Uint8())
+	if !errors.Is(err, ErrOBONotAuthorized) {
+		t.Fatalf("YUJ-1538 / PR#114: DM with no scope row must STILL deny (regression guard), got %v", err)
+	}
+}
+
+// TestCheckOBO_YUJ1538_GroupGlobalDisabled_StillUnauthorized — the
+// scope-row bypass only triggers when the grant itself is
+// `global_enabled=1`. A group inbound for a grantor whose grant has
+// the master switch OFF must still deny. Without this pin, a future
+// refactor that moves the bypass above the `findActiveGrantByGrantorBot`
+// gate would silently re-open the kill switch.
+func TestCheckOBO_YUJ1538_GroupGlobalDisabled_StillUnauthorized(t *testing.T) {
+	s := newFakeOBOStore()
+	if _, err := s.insertGrant(tGrantor, tBot, "auto", ""); err != nil {
+		t.Fatalf("insertGrant: %v", err)
+	}
+	// global_enabled stays 0 (insertGrant default).
+	ba := newBotAPIForCheckYUJ1538(s)
+	err := ba.checkOBO(tBot, tGrantor, "group_42", common.ChannelTypeGroup.Uint8())
+	if !errors.Is(err, ErrOBONotAuthorized) {
+		t.Fatalf("YUJ-1538 / PR#114: group with global_enabled=0 must STILL deny, got %v", err)
 	}
 }

--- a/modules/bot_api/obo_yuj1538_test.go
+++ b/modules/bot_api/obo_yuj1538_test.go
@@ -1,0 +1,330 @@
+// Package bot_api · YUJ-1538 — fan-out trigger must honor global_enabled
+// for GROUP / COMMUNITY_TOPIC channels even when no obo_scopes row
+// exists for the channel, and must treat `mention.all=1` (`@所有人`) as
+// a summon for every grantor in the group.
+//
+// The pre-fix bug:
+//
+//   - `findActiveGrantsForChannel` issued an INNER JOIN against
+//     obo_scopes, so groups (for which operators never installed
+//     channel_type=2 scope rows) produced zero matches and the fan-out
+//     copy was never dispatched. PR#109 fixed the symmetric problem in
+//     `checkOBO` (the reply-time permission check) for groups but left
+//     the fan-out trigger query stuck on the strict JOIN.
+//
+//   - `decodeMentionUIDs` only looked at `mention.uids`, so `@所有人`
+//     traffic (which sets `mention.all=1` but commonly does not
+//     re-list every group member in `mention.uids`) silently never
+//     triggered fan-out either.
+//
+// These tests pin the corrected behavior at the unit level — they
+// stand up only the in-memory fake store + the fanoutForMessage entry
+// point, so a regression that re-tightens the trigger query or the
+// narrowing gate fails fast at unit-test time instead of slipping into
+// E2E (where the bug was first observed in im-test prod).
+package bot_api
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+)
+
+// seedGrantNoScope is the YUJ-1538 setup parity to seedGrantWithScope:
+// install an `active=1 AND global_enabled=1` grant for (tGrantor, tBot)
+// but do NOT install any `obo_scopes` row. Mirrors the real-world
+// production state: operators only ever created channel_type=1 scopes,
+// so for groups the grant is on file with no matching scope row.
+func seedGrantNoScope(t *testing.T) *fakeOBOStore {
+	t.Helper()
+	s := newFakeOBOStore()
+	gid, err := s.insertGrant(tGrantor, tBot, "auto", "")
+	if err != nil {
+		t.Fatalf("insertGrant: %v", err)
+	}
+	enable := 1
+	if err := s.updateGrant(gid, "", &enable, nil); err != nil {
+		t.Fatalf("updateGrant: %v", err)
+	}
+	return s
+}
+
+// TestFanout_YUJ1538_GroupNoScopeRow_GlobalEnabledFansOut — the core
+// bug repro. A grant with `global_enabled=1` but no `obo_scopes` row
+// for the group must still trigger fan-out when the grantor is
+// @-mentioned in the group. Pre-fix this returned 0 dispatches because
+// `findActiveGrantsForChannel`'s INNER JOIN returned zero matches.
+func TestFanout_YUJ1538_GroupNoScopeRow_GlobalEnabledFansOut(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantNoScope(t)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"@yu can you help?","mention":{"uids":["` + tGrantor + `"]}}`),
+	}
+	got := ba.fanoutForMessage(msg)
+	if got != 1 {
+		t.Fatalf("YUJ-1538: group @grantor with global_enabled grant must fan out without a scope row, got %d", got)
+	}
+	if len(fc.copies) != 1 {
+		t.Fatalf("expected 1 captured copy, got %d", len(fc.copies))
+	}
+	cp := fc.copies[0]
+	if cp.FromUID != tGrantor {
+		t.Fatalf("fan-out copy FromUID: want grantor %q, got %q", tGrantor, cp.FromUID)
+	}
+	if cp.ChannelID != tBot {
+		t.Fatalf("fan-out copy ChannelID: want grantee bot %q (its own mailbox), got %q", tBot, cp.ChannelID)
+	}
+}
+
+// TestFanout_YUJ1538_CommunityTopicNoScopeRow_GlobalEnabledFansOut —
+// `community-topic` channels share the same "@grantor narrowing"
+// model as groups and must therefore also bypass the scope-row
+// requirement when the grant is `global_enabled=1`.
+func TestFanout_YUJ1538_CommunityTopicNoScopeRow_GlobalEnabledFansOut(t *testing.T) {
+	ch, ct := "group_42____topic_a1", common.ChannelTypeCommunityTopic.Uint8()
+	s := seedGrantNoScope(t)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"@yu thoughts?","mention":{"uids":["` + tGrantor + `"]}}`),
+	}
+	if got := ba.fanoutForMessage(msg); got != 1 {
+		t.Fatalf("YUJ-1538: community-topic @grantor with global_enabled grant must fan out without a scope row, got %d", got)
+	}
+}
+
+// TestFanout_YUJ1538_GroupMentionAllSummonsPersona — `@所有人`
+// (`mention.all=1`) in a group must trigger fan-out for every
+// `global_enabled=1` grantor, even when the grantor is not listed in
+// `mention.uids`. Pre-YUJ-1538 the narrowing gate only inspected
+// `mention.uids`, so broadcast messages silently never reached the
+// persona — a more visible regression than the missing scope-row case
+// because grantors typically install bot personas precisely to
+// monitor broadcasts.
+func TestFanout_YUJ1538_GroupMentionAllSummonsPersona(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantNoScope(t)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	// `@所有人 hi` shape: mention.all=1, no uids array. Real WuKongIM
+	// payloads use `1` (json.Number/float64 after json.Unmarshal); the
+	// gate also accepts `true` (boolean) for forward compat.
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"@所有人 hi","mention":{"all":1}}`),
+	}
+	if got := ba.fanoutForMessage(msg); got != 1 {
+		t.Fatalf("YUJ-1538: @所有人 (mention.all=1) in group must summon every grantor's persona, got %d", got)
+	}
+	if len(fc.copies) != 1 {
+		t.Fatalf("expected 1 captured copy, got %d", len(fc.copies))
+	}
+}
+
+// TestFanout_YUJ1538_GroupMentionAllBooleanShape — defensive check
+// that the boolean shape `mention.all=true` (some clients) is also
+// honoured, not just the numeric `1` form.
+func TestFanout_YUJ1538_GroupMentionAllBooleanShape(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantNoScope(t)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"@所有人 hi","mention":{"all":true}}`),
+	}
+	if got := ba.fanoutForMessage(msg); got != 1 {
+		t.Fatalf("YUJ-1538: mention.all=true (boolean) must be treated as truthy, got %d", got)
+	}
+}
+
+// TestFanout_YUJ1538_DMStillRequiresScopeRow — the new
+// channel-type-aware lookup path must NOT relax DM behavior. DMs
+// remain strict: a grant without a matching `obo_scopes` row
+// (channel_type=1, channel_id=peer uid) gets zero dispatches even
+// when `global_enabled=1`. Pins the contract from the issue:
+//
+//   "Do NOT change DM fan-out behavior (must still require scope rows)"
+func TestFanout_YUJ1538_DMStillRequiresScopeRow(t *testing.T) {
+	const peer = "u_bob"
+	ct := common.ChannelTypePerson.Uint8()
+	s := seedGrantNoScope(t) // grant exists with global_enabled=1, but no DM scope
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     peer,
+		ChannelID:   tGrantor, // DM listener-native view: ChannelID = receiver = grantor
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"hey, can we chat?"}`),
+	}
+	if got := ba.fanoutForMessage(msg); got != 0 {
+		t.Fatalf("YUJ-1538: DM with no scope row must NOT fan out (issue spec: DM behavior unchanged), got %d", got)
+	}
+}
+
+// TestFanout_YUJ1538_GroupGrantorChannelAccessDenied — TOCTOU
+// safeguard. Even with `global_enabled=1` and an explicit @grantor
+// mention, fan-out must skip when the grantor has lost access to the
+// group (kicked / left). The per-grant `grantorCanReadChannel`
+// re-check is the only gate enforcing this once the scope-row layer
+// is bypassed for groups, so a regression that drops the check would
+// silently leak group traffic into the persona.
+func TestFanout_YUJ1538_GroupGrantorChannelAccessDenied(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantNoScope(t)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+	// Override the live-access re-check to deny — simulates the grantor
+	// having been kicked from the group between scope-create and the
+	// inbound message.
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		return false, nil
+	}
+
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"@yu help","mention":{"uids":["` + tGrantor + `"]}}`),
+	}
+	if got := ba.fanoutForMessage(msg); got != 0 {
+		t.Fatalf("YUJ-1538: grantor without live channel access must NOT receive fan-out copy, got %d", got)
+	}
+}
+
+// TestFanout_YUJ1538_GroupNoGrantsRegistered_StillSkips — sanity
+// check that the widened lookup does not accidentally fan out when
+// NO active+global_enabled grants exist system-wide. The cache layer
+// short-circuits this path; without that the listener would issue a
+// DB lookup per inbound group message even for traffic in groups
+// nobody has installed a persona for.
+func TestFanout_YUJ1538_GroupNoGrantsRegistered_StillSkips(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := newFakeOBOStore() // no grants at all
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"@yu","mention":{"uids":["` + tGrantor + `"]}}`),
+	}
+	if got := ba.fanoutForMessage(msg); got != 0 {
+		t.Fatalf("YUJ-1538: no grants registered → no fan-out, got %d", got)
+	}
+}
+
+// TestFindActiveGrantsForChannel_YUJ1538_GroupReturnsGlobalEnabled —
+// store-level pin: with no scope rows installed,
+// `findActiveGrantsForChannel(group, Group)` returns the grant on
+// the GROUP channel type but returns empty on the DM channel type.
+// Locks the channel-type asymmetry so a refactor that re-collapses
+// the two branches surfaces here, not at fan-out time.
+func TestFindActiveGrantsForChannel_YUJ1538_GroupReturnsGlobalEnabled(t *testing.T) {
+	s := seedGrantNoScope(t)
+	grants, err := s.findActiveGrantsForChannel("group_42", common.ChannelTypeGroup.Uint8())
+	if err != nil {
+		t.Fatalf("findActiveGrantsForChannel group: %v", err)
+	}
+	if len(grants) != 1 || grants[0].GrantorUID != tGrantor {
+		t.Fatalf("group lookup must return the global_enabled grant, got %+v", grants)
+	}
+	dmGrants, err := s.findActiveGrantsForChannel("u_bob", common.ChannelTypePerson.Uint8())
+	if err != nil {
+		t.Fatalf("findActiveGrantsForChannel DM: %v", err)
+	}
+	if len(dmGrants) != 0 {
+		t.Fatalf("DM lookup must STILL require scope row, got %+v", dmGrants)
+	}
+}
+
+// TestFindActiveGrantsForChannel_YUJ1538_CommunityTopicReturnsGlobalEnabled —
+// store-level pin for the community-topic branch. Same shape as the
+// group test above; kept separate so a regression that drops one of
+// the two group-like channel types surfaces with a precise failure
+// message.
+func TestFindActiveGrantsForChannel_YUJ1538_CommunityTopicReturnsGlobalEnabled(t *testing.T) {
+	s := seedGrantNoScope(t)
+	grants, err := s.findActiveGrantsForChannel("group_42____topic_a1", common.ChannelTypeCommunityTopic.Uint8())
+	if err != nil {
+		t.Fatalf("findActiveGrantsForChannel community-topic: %v", err)
+	}
+	if len(grants) != 1 || grants[0].GrantorUID != tGrantor {
+		t.Fatalf("community-topic lookup must return the global_enabled grant, got %+v", grants)
+	}
+}
+
+// TestFindActiveGrantsForChannel_YUJ1538_GroupSkipsGloballyDisabled —
+// store-level pin: the channel-type-aware branch must still respect
+// the `global_enabled=0` kill switch. A grant flipped off via PUT
+// /v1/obo/grants/:id must NOT surface even on the group path.
+func TestFindActiveGrantsForChannel_YUJ1538_GroupSkipsGloballyDisabled(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, err := s.insertGrant(tGrantor, tBot, "auto", "")
+	if err != nil {
+		t.Fatalf("insertGrant: %v", err)
+	}
+	// NB: insertGrant defaults global_enabled=0, and we intentionally
+	// do NOT flip it on here — that's the case under test.
+	_ = gid
+	grants, err := s.findActiveGrantsForChannel("group_42", common.ChannelTypeGroup.Uint8())
+	if err != nil {
+		t.Fatalf("findActiveGrantsForChannel: %v", err)
+	}
+	if len(grants) != 0 {
+		t.Fatalf("global_enabled=0 grant must NOT surface for groups, got %+v", grants)
+	}
+}
+
+// TestDecodeMentionGate_YUJ1538_AllFlagShapes — exhaustive shape
+// coverage for the `mention.all` truthy decoder. WuKongIM clients in
+// the wild send `1` (number) and `true` (boolean); the legacy SDKs
+// send `json.Number("1")` once the read path opts into UseNumber. The
+// gate must accept all three and reject everything else (including
+// `0`, `false`, missing, null, and unrelated types like strings).
+func TestDecodeMentionGate_YUJ1538_AllFlagShapes(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		wantAll bool
+	}{
+		{"missing mention", `{"type":1}`, false},
+		{"missing all", `{"mention":{"uids":["u"]}}`, false},
+		{"all_number_one", `{"mention":{"all":1}}`, true},
+		{"all_number_zero", `{"mention":{"all":0}}`, false},
+		{"all_bool_true", `{"mention":{"all":true}}`, true},
+		{"all_bool_false", `{"mention":{"all":false}}`, false},
+		{"all_string_one", `{"mention":{"all":"1"}}`, false}, // strings are not truthy
+		{"all_null", `{"mention":{"all":null}}`, false},
+		{"mention_not_object", `{"mention":"@everyone"}`, false},
+		{"payload_not_object", `42`, false},
+		{"payload_empty", ``, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, all := decodeMentionGate([]byte(tc.payload))
+			if all != tc.wantAll {
+				t.Fatalf("payload %q: want all=%v, got %v", tc.payload, tc.wantAll, all)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes [YUJ-1538](mention://issue/e4b04f5d-836a-45cb-86a0-5ce77772ec4b). When a user `@mention`s the grantor (e.g. `@admin`) in a GROUP, the OBO fan-out did NOT trigger. The bot never received the fan-out copy, so it could not reply on behalf of the grantor.

## Root Cause

`findActiveGrantsForChannel` in `obo_db.go` used an `INNER JOIN obo_scopes` to surface candidate grants for the fan-out listener. Real deployments only ever installed `channel_type=1` (DM) scope rows — for groups (`channel_type=2`) and community topics (`channel_type=5`) the JOIN returned zero matches, so the fan-out copy was never minted even when a `global_enabled=1` grant existed.

PR#109 already fixed the symmetric problem in `checkOBO` (the reply-time permission check) for groups, but left the fan-out trigger query stuck on the strict JOIN.

A second, related miss: the v2 narrowing gate (`mention.uids` must contain the grantor) ignored `mention.all=1` (`@所有人`), so broadcast messages silently never reached the persona even when fan-out would otherwise have fired.

## Fix

- `modules/bot_api/obo_db.go` — split `findActiveGrantsForChannel` by channel type. Group / CommunityTopic match on `active=1 AND global_enabled=1` alone; DM keeps the strict scope-row JOIN. Added `isGroupLikeChannelType` helper so the contract is centralized and the next consumer doesn't drift. The per-grant `grantorCanReadChannel` re-check in `fanoutForMessage` still enforces live group membership, so a grantor who was kicked from a group does not silently keep receiving group traffic.
- `modules/bot_api/obo_fanout.go` — extended the v2 narrowing gate to honor `mention.all=1` (`@所有人`) as an implicit summon for every grantor in a group. `@AI` / `@bot` / plain (no mention) traffic still does NOT trigger fan-out. Replaced `decodeMentionUIDs` with `decodeMentionGate` returning both the uids set and the all flag; added `mentionFlagTruthy` shape-tolerant helper mirroring `pkg/mentionrewrite.isTruthyOne` so the gate accepts `1`, `true`, `json.Number`, and the int/float family without disagreeing with the write-side mention rewriter.
- `modules/bot_api/obo_fake_test.go` — mirror the production channel-type-aware lookup in the in-memory fake.
- `modules/bot_api/obo_v2_test.go` — dropped `mention.all=1` from the `@AI-only` rejection test since `mention.all` is now honored; renamed assertion message accordingly.
- `modules/bot_api/obo_yuj1538_test.go` — new dedicated test file pinning: group-no-scope happy path, community-topic parity, `mention.all` numeric + boolean shapes, DM scope-row contract preserved, grantor-not-in-group TOCTOU close-out, no-grants-registered short-circuit, store-level channel-type asymmetry, `global_enabled=0` kill switch on the group path, and `decodeMentionGate` shape coverage (11 sub-cases).

## Out of scope

- DM fan-out (`channel_type=1`) — must still require scope rows (issue spec).
- `checkOBO` (the third-party send permission check) — already handled in PR#109.
- Frontend code.

## Tests

- All existing `bot_api` tests still pass (`go test -count=1 ./modules/bot_api/`).
- New tests for the YUJ-1538 contract pass; existing v2 narrowing tests adjusted to the new `mention.all` semantics still pass.
- Repo-wide `go test ./...` failures are unrelated (pre-existing — `NewTestServer` panics on MySQL/Redis-less environments; same failures reproduce on the base SHA without these changes).

## Manual repro

1. Create a grant with `global_enabled=1` for `admin → James`.
2. In a group where `admin` is a member, send `@admin hello` → James receives the v2 fan-out copy.
3. Send `@所有人 hello` in the same group → James receives the v2 fan-out copy.

## Review

review-tier: high-risk (fan-out core path)

Closes #YUJ-1538