### PR TITLE
fix: seed default Space for superAdmin on first boot (#105)

### DIFF
--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -200,6 +200,19 @@ func (s *Space) createSpace(c *wkhttp.Context) {
 	})
 }
 
+// CreateDefaultSpace 为指定用户创建一个默认 Space，供系统引导路径调用
+// （如 SuperAdmin 首次启动时由 user 模块兜底创建，避免登录后无 Space 的死锁）。
+// JoinMode=0(直接加入)、MaxUsers=0(不限制)，与用户侧 createSpace 默认值一致。
+func (s *Space) CreateDefaultSpace(creatorUID, name string) error {
+	_, err := s.createSpaceCore(createSpaceParams{
+		Creator:  creatorUID,
+		Name:     name,
+		JoinMode: JoinModeDirect,
+		MaxUsers: 0,
+	})
+	return err
+}
+
 // createSpaceCore 创建空间事务核心（供用户侧与管理端代建复用）。
 //
 // 事务内写 space + owner 成员；事务外建邀请码、BotFather 入驻、刷新 ParseChannelID 缓存、

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	common2 "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/modules/space"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	wkutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
 
@@ -34,6 +35,7 @@ type Manager struct {
 	friendDB      *friendDB
 	onlineService IOnlineService
 	commonService common2.IService
+	spaceAPI      *space.Space
 }
 
 // NewManager NewManager
@@ -48,6 +50,7 @@ func NewManager(ctx *config.Context) *Manager {
 		userSettingDB: NewSettingDB(ctx.DB()),
 		onlineService: NewOnlineService(ctx),
 		commonService: common2.NewService(ctx),
+		spaceAPI:      space.New(ctx),
 	}
 	m.createManagerAccount()
 	return m
@@ -1183,6 +1186,26 @@ func (m *Manager) createManagerAccount() {
 	if err != nil {
 		m.Error("新增系统管理员错误", zap.Error(err))
 		return
+	}
+	m.ensureAdminDefaultSpace()
+}
+
+// ensureAdminDefaultSpace 为 SuperAdmin 兜底创建默认 Space。
+//
+// 背景(issue #105)：createManagerAccount 仅写 user 行，未建 Space + owner 成员。
+// SuperAdmin 首次登录时 GET /v1/space/my 返回 [] 触发 web 跳邀请码页，joinSpace
+// 又因"已是成员"被拒——形成死锁。该方法在首次引导（已有 Space 时跳过，保持幂等）
+// 时补建一个默认 Space，让 SuperAdmin 进入正常的 my-spaces 流程。
+//
+// 失败仅记 Warn 不阻塞主流程：主流程是用户账号创建，已经成功落库；Space 缺失
+// 可以由运维事后修复，让进程能起来比卡在 init 更重要。
+func (m *Manager) ensureAdminDefaultSpace() {
+	adminUID := m.ctx.GetConfig().Account.AdminUID
+	if spaceID := space.GetUserDefaultSpaceID(m.ctx, adminUID); spaceID != "" {
+		return
+	}
+	if err := m.spaceAPI.CreateDefaultSpace(adminUID, "默认空间"); err != nil {
+		m.Warn("创建管理员默认空间失败", zap.Error(err), zap.String("uid", adminUID))
 	}
 }
 func getShowPhoneNum(mobile string) string {


### PR DESCRIPTION
## Problem

Fixes #105

`createManagerAccount()` only inserts a user row. On a fresh deployment `GET /v1/space/my` returns `[]` for superAdmin, the web client redirects to the invite-code page, and `joinSpace` then rejects with "你已经是该空间成员" — a catch-22 that completely blocks first login.

## Fix

Two minimal changes:

**`modules/space/api.go`** — expose `CreateDefaultSpace(creatorUID, name string) error` as a thin wrapper around the existing `createSpaceCore` path (JoinMode=direct, MaxUsers=0).

**`modules/user/api_manager.go`** — after `userDB.Insert` succeeds, call `ensureAdminDefaultSpace()` which:
1. Checks `space.GetUserDefaultSpaceID` — skips if a Space already exists (idempotent).
2. Calls `spaceAPI.CreateDefaultSpace` to create a default Space with superAdmin as owner.
3. On failure logs Warn only — does not block the user-creation path.

## Testing

- `go build ./...` ✅ (0 errors)
- `go test ./pkg/...` ✅ (all pass)
- Integration tests require a live MySQL — skipped locally, rely on CI.