### PR TITLE
fix: pr-contributor-welcome permission pull-requests:write → issues:write

### DIFF
--- a/.github/workflows/pr-contributor-welcome.yml
+++ b/.github/workflows/pr-contributor-welcome.yml
@@ -1,12 +1,6 @@
 name: PR Contributor Welcome
 
 on:
-  # pull_request_target runs in the context of the base repo so the GITHUB_TOKEN
-  # has write access even for fork PRs — required to post a welcome comment.
-  #
-  # SECURITY: the called reusable workflow does NOT check out any PR branch code;
-  # it only reads PR metadata via the GitHub API. This matches the pattern used
-  # by auto-add-to-project.yml and labeler.yml.
   pull_request_target: # zizmor: ignore[dangerous-triggers] metadata-only automation; no PR code executed
     types: [opened]
 
@@ -16,4 +10,4 @@ jobs:
   welcome:
     uses: Mininglamp-OSS/.github/.github/workflows/reusable-pr-contributor-welcome.yml@main
     permissions:
-      pull-requests: write
+      issues: write


### PR DESCRIPTION
The reusable workflow (`reusable-pr-contributor-welcome.yml`) posts welcome comments via `issues.createComment` API, which requires `issues: write` permission.

Current `pull-requests: write` does not grant access to the Issues comment API, causing the welcome step to fail with insufficient permissions.

## Change
```diff
-      pull-requests: write
+      issues: write
```

This aligns with the fix already applied to all other org repos during Phase 3 governance hardening.