### PR TITLE
feat(conv_ext): cascade follow channel → threads with fanout on new threads

### DIFF
--- a/modules/conversation_ext/api.go
+++ b/modules/conversation_ext/api.go
@@ -214,6 +214,13 @@ func (f *Follow) FollowChannel(c *wkhttp.Context) {
 	}
 
 	if err := f.svc.FollowChannel(loginUID, spaceID, req.GroupNo); err != nil {
+		// PR #123 round-1 review (Jerry-Xin / yujiawei P1)：鉴权失败返回 403，
+		// 不向客户端泄露内部细节（仅写日志）。与 FollowThread 同样处理 ErrThreadForbidden。
+		if errors.Is(err, ErrChannelForbidden) {
+			f.Warn("关注群鉴权失败", zap.Error(err))
+			c.ResponseErrorWithStatus(pkgerrors.New("无权关注该群"), http.StatusForbidden)
+			return
+		}
 		f.Error("重新关注群失败", zap.Error(err))
 		c.ResponseError(pkgerrors.New("重新关注群失败"))
 		return

--- a/modules/conversation_ext/api_test.go
+++ b/modules/conversation_ext/api_test.go
@@ -338,6 +338,20 @@ func TestFollow_FollowChannel_ServiceError(t *testing.T) {
 	assertBadRequest(t, w)
 }
 
+// PR #123 round-1 (Jerry-Xin / yujiawei P1) + round-5 (Jerry-Xin follow-up)：
+// ErrChannelForbidden 必须作为 403 返回，与 FollowThread 的 ErrThreadForbidden→403
+// 契约对齐，让客户端走"无权访问"路径而不是通用 400 重试。
+func TestFollow_FollowChannel_Forbidden_Returns403(t *testing.T) {
+	svc := &stubService{
+		followChannelFn: func(uid, spaceID, groupNo string) error {
+			return ErrChannelForbidden
+		},
+	}
+	r := newTestRouter(svc, &stubDB{})
+	w := do(r, "POST", "/v1/follow/channel/refollow", map[string]interface{}{"group_no": "grp2"})
+	assert.Equal(t, http.StatusForbidden, w.Code, "body: %s", w.Body.String())
+}
+
 // ---------------------------------------------------------------------------
 // FollowThread
 // ---------------------------------------------------------------------------

--- a/modules/conversation_ext/category_cleanup.go
+++ b/modules/conversation_ext/category_cleanup.go
@@ -20,12 +20,16 @@ func UnfollowGroupsTx(tx *dbr.Tx, uid, spaceID string, groupNos []string) error 
 		return nil
 	}
 	one := int8(1)
+	zero := int8(0)
 	for _, groupNo := range groupNos {
 		if groupNo == "" {
 			continue
 		}
+		// 必须同时清 auto_follow_threads —— 与 service.UnfollowChannel 同语义：否则
+		// 后续 OnThreadCreated 会按 auto_follow_threads=1 把已取关的用户当 fanout 目标。
 		if err := upsertTx(tx, uid, spaceID, targetTypeGroup, groupNo, ConvExtFields{
-			GroupUnfollowed: &one,
+			GroupUnfollowed:   &one,
+			AutoFollowThreads: &zero,
 		}); err != nil {
 			return fmt.Errorf("UnfollowGroupsTx upsert group %q: %w", groupNo, err)
 		}

--- a/modules/conversation_ext/cleanup_test.go
+++ b/modules/conversation_ext/cleanup_test.go
@@ -20,10 +20,17 @@ import (
 // that touches globalConvExtDB to keep tests hermetic.
 func initGlobalConvExtDBForTest(t *testing.T, ctx *config.Context) *DB {
 	t.Helper()
+	return initGlobalConvExtDBForTestTB(t, ctx)
+}
+
+// initGlobalConvExtDBForTestTB is the testing.TB-accepting variant used by
+// benchmarks (Jerry-Xin review round-1) — same body, no &testing.T{} reach.
+func initGlobalConvExtDBForTestTB(tb testing.TB, ctx *config.Context) *DB {
+	tb.Helper()
 	globalConvExtDBOnce = sync.Once{}
 	globalConvExtDB = nil
 	InitGlobalConvExtDB(ctx)
-	require.NotNil(t, globalConvExtDB, "globalConvExtDB must be non-nil after Init")
+	require.NotNil(tb, globalConvExtDB, "globalConvExtDB must be non-nil after Init")
 	return globalConvExtDB
 }
 

--- a/modules/conversation_ext/cleanup_test.go
+++ b/modules/conversation_ext/cleanup_test.go
@@ -300,3 +300,47 @@ func TestRemoveConvExtForChannel_NilGlobalDB(t *testing.T) {
 		RemoveConvExtForChannel("ch", 2)
 	})
 }
+
+// ---------------------------------------------------------------------------
+// UnfollowGroupsTx must clear auto_follow_threads (bug fix #1)
+//
+// 删除分类时 category 模块调用 UnfollowGroupsTx 把分类下的群批量取关。
+// 若漏掉 auto_follow_threads=0，后续这些群里新建子区时 OnThreadCreated 仍会按
+// auto_follow_threads=1 把已取关的用户当作 fanout 目标，违反"取消关注 =
+// 不再自动跟随新子区"的语义。本测试与 service.UnfollowChannel 同语义守护。
+// ---------------------------------------------------------------------------
+
+func TestUnfollowGroupsTx_ClearsAutoFollowThreads(t *testing.T) {
+	ctx := newCtxForTest(t)
+	db := initGlobalConvExtDBForTest(t, ctx)
+	_, err := ctx.DB().DeleteFrom(table).Exec()
+	require.NoError(t, err)
+
+	const uid, space, grp1, grp2 = "u-cat-uf", "sp-cat", "grp-cat-1", "grp-cat-2"
+	// 模拟用户对两个群都开启了级联关注（FollowChannel 写入的状态）。
+	one := int8(1)
+	zero := int8(0)
+	require.NoError(t, db.Upsert(uid, space, targetTypeGroup, grp1, ConvExtFields{
+		GroupUnfollowed:   &zero,
+		AutoFollowThreads: &one,
+	}))
+	require.NoError(t, db.Upsert(uid, space, targetTypeGroup, grp2, ConvExtFields{
+		GroupUnfollowed:   &zero,
+		AutoFollowThreads: &one,
+	}))
+
+	tx, err := db.session.Begin()
+	require.NoError(t, err)
+	defer tx.RollbackUnlessCommitted()
+	require.NoError(t, UnfollowGroupsTx(tx, uid, space, []string{grp1, grp2}))
+	require.NoError(t, tx.Commit())
+
+	for _, grp := range []string{grp1, grp2} {
+		row, err := db.Get(uid, space, targetTypeGroup, grp)
+		require.NoError(t, err)
+		require.NotNil(t, row)
+		assert.Equal(t, int8(1), row.GroupUnfollowed, "%s 应被标记为取消关注", grp)
+		assert.Equal(t, int8(0), row.AutoFollowThreads,
+			"%s 必须清掉 auto_follow_threads，否则 OnThreadCreated 还会把已取关用户当目标", grp)
+	}
+}

--- a/modules/conversation_ext/db.go
+++ b/modules/conversation_ext/db.go
@@ -33,11 +33,14 @@ type Model struct {
 	// DMCategoryID 是 group_category.category_id（VARCHAR(32) UUID），DM 与群
 	// 共用同一分类 namespace（PR #21 Round-6，原型 image-v1.png 印证）。
 	// NULL 表示未分类。
-	DMCategoryID    *string   `db:"dm_category_id"`
-	GroupUnfollowed int8      `db:"group_unfollowed"`
-	FollowSort      int       `db:"follow_sort"`
-	CreatedAt       time.Time `db:"created_at"`
-	UpdatedAt       time.Time `db:"updated_at"`
+	DMCategoryID    *string `db:"dm_category_id"`
+	GroupUnfollowed int8    `db:"group_unfollowed"`
+	FollowSort      int     `db:"follow_sort"`
+	// AutoFollowThreads = 1 表示关注 target_type=2 群后，新建子区时自动给该 (uid, space_id) 物化 thread ext 行。
+	// 仅在 target_type=2 行上有意义；其他 target_type 写 0 保持。
+	AutoFollowThreads int8      `db:"auto_follow_threads"`
+	CreatedAt         time.Time `db:"created_at"`
+	UpdatedAt         time.Time `db:"updated_at"`
 }
 
 // ConvExtFields 描述 Upsert 时可更新的字段集合。
@@ -51,6 +54,8 @@ type ConvExtFields struct {
 	ClearDMCategory bool
 	GroupUnfollowed *int8
 	FollowSort      *int
+	// AutoFollowThreads 仅在 target_type=2 行有意义，nil 表示不更新该字段。
+	AutoFollowThreads *int8
 }
 
 // SortItem 是传给 UpdateSort 的单条排序项。
@@ -149,6 +154,12 @@ func buildUpsertParts(f ConvExtFields) (extraCols []string, extraVals []interfac
 		extraVals = append(extraVals, *f.FollowSort)
 		setClauses = append(setClauses, "follow_sort = ?")
 		setArgs = append(setArgs, *f.FollowSort)
+	}
+	if f.AutoFollowThreads != nil {
+		extraCols = append(extraCols, "auto_follow_threads")
+		extraVals = append(extraVals, *f.AutoFollowThreads)
+		setClauses = append(setClauses, "auto_follow_threads = ?")
+		setArgs = append(setArgs, *f.AutoFollowThreads)
 	}
 	return extraCols, extraVals, setClauses, setArgs
 }

--- a/modules/conversation_ext/db_test.go
+++ b/modules/conversation_ext/db_test.go
@@ -132,6 +132,34 @@ func TestDB_Upsert_GroupUnfollowed(t *testing.T) {
 	assert.Equal(t, int8(1), m.GroupUnfollowed)
 }
 
+func TestDB_Upsert_AutoFollowThreads(t *testing.T) {
+	db := newDBForTest(t)
+
+	// Insert：通过新字段把群行写成"已关注且自动级联子区"。
+	require.NoError(t, db.Upsert("u1", "s1", 2, "grp-cascade", ConvExtFields{
+		GroupUnfollowed:   int8Ptr(0),
+		AutoFollowThreads: int8Ptr(1),
+	}))
+
+	m, err := db.Get("u1", "s1", 2, "grp-cascade")
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, int8(0), m.GroupUnfollowed)
+	assert.Equal(t, int8(1), m.AutoFollowThreads,
+		"AutoFollowThreads 字段应从 ConvExtFields 落库并通过 Get 读出")
+
+	// Update：再次 upsert 关掉级联开关，验证 ON DUPLICATE KEY UPDATE 路径。
+	require.NoError(t, db.Upsert("u1", "s1", 2, "grp-cascade", ConvExtFields{
+		AutoFollowThreads: int8Ptr(0),
+	}))
+	m, err = db.Get("u1", "s1", 2, "grp-cascade")
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, int8(0), m.AutoFollowThreads)
+	// GroupUnfollowed 未传，保持上次值 0。
+	assert.Equal(t, int8(0), m.GroupUnfollowed)
+}
+
 func TestDB_Upsert_NilFields_DoNotOverwrite(t *testing.T) {
 	db := newDBForTest(t)
 

--- a/modules/conversation_ext/integration_test.go
+++ b/modules/conversation_ext/integration_test.go
@@ -24,6 +24,7 @@ package conversation_ext
 // =============================================================================
 
 import (
+	"strconv"
 	"sync"
 	"testing"
 
@@ -459,4 +460,224 @@ func TestIntegration_ListQueries_SpaceAndUserIsolation(t *testing.T) {
 	dms2, err := db.ListFollowedDM(uid1, spaceB)
 	require.NoError(t, err)
 	assert.Len(t, dms2, 0, "uid1's query on spaceB must not see uid2's rows")
+}
+
+// ---------------------------------------------------------------------------
+// Scene 7: Channel→threads cascade follow (auto_follow_threads)
+//
+// End-to-end lifecycle for the sidebar-channel-follow-cascade PR. Covers:
+//
+//   - FollowChannel materialises every active thread under the channel.
+//   - OnThreadCreated fanouts to every auto_follow=1 user but skips users who
+//     UnfollowChannel'd (auto_follow=0) or never followed.
+//   - UnfollowChannel cascade-deletes all thread ext rows AND clears
+//     auto_follow_threads so future OnThreadCreated skips this user.
+//   - Re-FollowChannel "resurrects" the cascade —— even threads previously
+//     UnfollowThread'd come back (confirmed product requirement).
+//   - UnfollowThread keeps auto_follow_threads=1 and does NOT block fanout of
+//     subsequently-created threads (since fanout only runs on creation).
+// ---------------------------------------------------------------------------
+
+// fixedThreadEnumerator 是 integration test 内用的 ThreadEnumerator 桩：
+// 由测试自己维护 (groupNo -> shortIDs) 的快照，模拟"群下当前有哪些 active 子区"。
+// 与 thread.DB 解耦让本测试不依赖 thread 模块表。
+type fixedThreadEnumerator struct {
+	groups map[string][]string
+}
+
+func (f *fixedThreadEnumerator) EnumerateActiveShortIDs(groupNo string, limit int) ([]string, error) {
+	ids := f.groups[groupNo]
+	if limit > 0 && len(ids) > limit {
+		ids = ids[:limit]
+	}
+	out := make([]string, len(ids))
+	copy(out, ids)
+	return out, nil
+}
+
+func TestIntegration_ChannelCascade_FullLifecycle(t *testing.T) {
+	_, svc := newIntegrationDB(t)
+	const space, grp = "sp-cc", "int-cc-grp"
+	const userA, userB, userC = "int-cc-A", "int-cc-B", "int-cc-C"
+
+	// 模拟群下已有 3 个 active 子区。
+	enum := &fixedThreadEnumerator{groups: map[string][]string{
+		grp: {"t1", "t2", "t3"},
+	}}
+	svc.SetThreadEnumerator(enum)
+
+	// 1. A 关注 channel → 3 个 thread ext 行被物化，auto_follow_threads=1。
+	require.NoError(t, svc.FollowChannel(userA, space, grp))
+	for _, sid := range []string{"t1", "t2", "t3"} {
+		row, err := svc.db.Get(userA, space, targetTypeThread, grp+threadSeparator+sid)
+		require.NoError(t, err)
+		assert.NotNil(t, row, "A 关注 channel 后应物化子区 %s", sid)
+	}
+	grpRow, err := svc.db.Get(userA, space, targetTypeGroup, grp)
+	require.NoError(t, err)
+	require.NotNil(t, grpRow)
+	assert.Equal(t, int8(1), grpRow.AutoFollowThreads)
+
+	// 2. B 关注但立刻取关 channel —— OnThreadCreated 应跳过 B。
+	require.NoError(t, svc.FollowChannel(userB, space, grp))
+	require.NoError(t, svc.UnfollowChannel(userB, space, grp))
+	// B 的 group 行 auto_follow_threads 必须被清零（否则 OnThreadCreated 还会找到他）。
+	bGrp, err := svc.db.Get(userB, space, targetTypeGroup, grp)
+	require.NoError(t, err)
+	require.NotNil(t, bGrp)
+	assert.Equal(t, int8(0), bGrp.AutoFollowThreads)
+	assert.Equal(t, int8(1), bGrp.GroupUnfollowed)
+
+	// 3. C 完全没操作过 channel —— OnThreadCreated 应跳过 C。
+	// （不写任何行）
+
+	// 4. 模拟新建子区 t4：thread 模块创建后会同步调用 OnThreadCreated。
+	enum.groups[grp] = append(enum.groups[grp], "t4")
+	require.NoError(t, svc.OnThreadCreated(grp, "t4"))
+
+	// Only A should have the new thread row.
+	rowA4, err := svc.db.Get(userA, space, targetTypeThread, grp+threadSeparator+"t4")
+	require.NoError(t, err)
+	assert.NotNil(t, rowA4, "A 应在 fanout 中拿到 t4")
+	rowB4, err := svc.db.Get(userB, space, targetTypeThread, grp+threadSeparator+"t4")
+	require.NoError(t, err)
+	assert.Nil(t, rowB4, "B 已 unfollow channel，不应被 fanout")
+	rowC4, err := svc.db.Get(userC, space, targetTypeThread, grp+threadSeparator+"t4")
+	require.NoError(t, err)
+	assert.Nil(t, rowC4, "C 从未关注 channel，不应被 fanout")
+
+	// 5. A 单独 UnfollowThread(t2) —— 只删 t2 一行，auto_follow_threads 保持 1。
+	require.NoError(t, svc.UnfollowThread(userA, space, grp+threadSeparator+"t2"))
+	rowAT2, err := svc.db.Get(userA, space, targetTypeThread, grp+threadSeparator+"t2")
+	require.NoError(t, err)
+	assert.Nil(t, rowAT2, "A 单独取关 t2 后该行消失")
+	aGrp2, err := svc.db.Get(userA, space, targetTypeGroup, grp)
+	require.NoError(t, err)
+	require.NotNil(t, aGrp2)
+	assert.Equal(t, int8(1), aGrp2.AutoFollowThreads, "UnfollowThread 不应清掉 channel 级 auto_follow_threads")
+
+	// 6. 新建子区 t5 —— A 仍然被 fanout（auto_follow=1 没变），但 t2 不会复活
+	//    （fanout 只在子区创建时走，UnfollowThread 后已不再有 t2 的 create 信号）。
+	enum.groups[grp] = append(enum.groups[grp], "t5")
+	require.NoError(t, svc.OnThreadCreated(grp, "t5"))
+	rowAT5, err := svc.db.Get(userA, space, targetTypeThread, grp+threadSeparator+"t5")
+	require.NoError(t, err)
+	assert.NotNil(t, rowAT5, "新建子区 t5 应继续 fanout 给 A")
+	rowAT2Again, err := svc.db.Get(userA, space, targetTypeThread, grp+threadSeparator+"t2")
+	require.NoError(t, err)
+	assert.Nil(t, rowAT2Again, "fanout 只在子区创建时走；A 单独取关过的 t2 不会因为 t5 的 fanout 而复活")
+
+	// 7. A 取消关注 channel —— 全部 thread 行级联清空 + auto_follow_threads=0。
+	require.NoError(t, svc.UnfollowChannel(userA, space, grp))
+	for _, sid := range []string{"t1", "t3", "t4", "t5"} { // t2 早就被取关
+		row, err := svc.db.Get(userA, space, targetTypeThread, grp+threadSeparator+sid)
+		require.NoError(t, err)
+		assert.Nil(t, row, "UnfollowChannel 应级联删 %s", sid)
+	}
+	aGrp3, err := svc.db.Get(userA, space, targetTypeGroup, grp)
+	require.NoError(t, err)
+	require.NotNil(t, aGrp3)
+	assert.Equal(t, int8(0), aGrp3.AutoFollowThreads)
+	assert.Equal(t, int8(1), aGrp3.GroupUnfollowed)
+
+	// 8. A 重新关注 channel —— 当前 active 子区全部"复活"（含曾被 UnfollowThread 的 t2）。
+	//    enum 现在含 t1..t5。
+	require.NoError(t, svc.FollowChannel(userA, space, grp))
+	for _, sid := range []string{"t1", "t2", "t3", "t4", "t5"} {
+		row, err := svc.db.Get(userA, space, targetTypeThread, grp+threadSeparator+sid)
+		require.NoError(t, err)
+		assert.NotNil(t, row,
+			"FollowChannel 应物化所有当前 active 子区 %s（含 A 曾单独取关的 t2 —— 用户已确认这是预期行为）",
+			sid)
+	}
+}
+
+func TestIntegration_ChannelCascade_FollowVersionBumpedOnce(t *testing.T) {
+	_, svc := newIntegrationDB(t)
+	const uid, space, grp = "int-cc-v-u", "sp-ccv", "int-cc-v-grp"
+
+	enum := &fixedThreadEnumerator{groups: map[string][]string{
+		grp: {"v1", "v2", "v3", "v4", "v5"},
+	}}
+	svc.SetThreadEnumerator(enum)
+
+	var before int64
+	_ = svc.session.SelectBySql(
+		"SELECT version FROM "+followVersionTable+" WHERE uid=? AND space_id=?",
+		uid, space,
+	).LoadOne(&before)
+
+	require.NoError(t, svc.FollowChannel(uid, space, grp))
+
+	var after int64
+	require.NoError(t, svc.session.SelectBySql(
+		"SELECT version FROM "+followVersionTable+" WHERE uid=? AND space_id=?",
+		uid, space,
+	).LoadOne(&after))
+
+	assert.Equal(t, before+1, after,
+		"FollowChannel 即便物化 5 个子区也只 bump follow_version 一次（user-level 单调）")
+}
+
+// ---------------------------------------------------------------------------
+// Performance benchmarks (用户要求：fanout N=100/1000/10000 + 单 channel 500 子区物化)
+//
+// Run via: go test -tags integration -bench=. -benchmem -run=^$ \
+//          ./modules/conversation_ext/
+//
+// 仅记录耗时供性能基线参考，不做断言（数值因机器而异）。
+// ---------------------------------------------------------------------------
+
+func benchmarkOnThreadCreatedFanout(b *testing.B, numUsers int) {
+	b.Helper()
+	t := &testing.T{}
+	_, svc := newIntegrationDB(t)
+	const space, grp = "bench-sp", "bench-grp-fanout"
+
+	// 预先：numUsers 个用户全部 auto_follow_threads=1。
+	for i := 0; i < numUsers; i++ {
+		uid := "bench-u-" + strconv.Itoa(i)
+		// 不走 FollowChannel（避免触发 enumerator），直接 upsert 群行。
+		one := int8(1)
+		zero := int8(0)
+		require.NoError(b, svc.db.Upsert(uid, space, targetTypeGroup, grp, ConvExtFields{
+			GroupUnfollowed:   &zero,
+			AutoFollowThreads: &one,
+		}))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// 每次跑用一个新 shortID，避免 INSERT IGNORE 第二次起全部 no-op 影响测量。
+		shortID := "bench-thr-" + strconv.Itoa(i)
+		if err := svc.OnThreadCreated(grp, shortID); err != nil {
+			b.Fatalf("OnThreadCreated failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkOnThreadCreated_N100(b *testing.B)   { benchmarkOnThreadCreatedFanout(b, 100) }
+func BenchmarkOnThreadCreated_N1000(b *testing.B)  { benchmarkOnThreadCreatedFanout(b, 1000) }
+func BenchmarkOnThreadCreated_N10000(b *testing.B) { benchmarkOnThreadCreatedFanout(b, 10000) }
+
+func BenchmarkFollowChannel_Materialize500(b *testing.B) {
+	t := &testing.T{}
+	_, svc := newIntegrationDB(t)
+
+	ids := make([]string, 500)
+	for i := range ids {
+		ids[i] = "bench-thr-" + strconv.Itoa(i)
+	}
+	enum := &fixedThreadEnumerator{groups: map[string][]string{
+		"bench-grp-mat": ids,
+	}}
+	svc.SetThreadEnumerator(enum)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		uid := "bench-mat-u-" + strconv.Itoa(i)
+		if err := svc.FollowChannel(uid, "bench-sp", "bench-grp-mat"); err != nil {
+			b.Fatalf("FollowChannel failed: %v", err)
+		}
+	}
 }

--- a/modules/conversation_ext/integration_test.go
+++ b/modules/conversation_ext/integration_test.go
@@ -631,10 +631,24 @@ func TestIntegration_ChannelCascade_FollowVersionBumpedOnce(t *testing.T) {
 // 仅记录耗时供性能基线参考，不做断言（数值因机器而异）。
 // ---------------------------------------------------------------------------
 
+// newBenchService 是 benchmark 专用的 Service 工厂，避免在 *testing.B 里塞一个
+// 假的 *testing.T{}（Jerry-Xin review）。直接接 testing.TB —— newCtxForTest 已经
+// 用 testing.TB-兼容的方法（仅 Helper() + Fatalf via require）；require 系列也支持
+// testing.TB。
+func newBenchService(b *testing.B) (*DB, *Service) {
+	b.Helper()
+	ctx := newCtxForTestTB(b)
+	db := initGlobalConvExtDBForTestTB(b, ctx)
+	_, err := ctx.DB().DeleteFrom(table).Exec()
+	require.NoError(b, err, "clean table before bench")
+	_, err = ctx.DB().DeleteFrom(followVersionTable).Exec()
+	require.NoError(b, err, "clean follow_version before bench")
+	return db, NewService(ctx)
+}
+
 func benchmarkOnThreadCreatedFanout(b *testing.B, numUsers int) {
 	b.Helper()
-	t := &testing.T{}
-	_, svc := newIntegrationDB(t)
+	_, svc := newBenchService(b)
 	const space, grp = "bench-sp", "bench-grp-fanout"
 
 	// 预先：numUsers 个用户全部 auto_follow_threads=1。
@@ -664,8 +678,7 @@ func BenchmarkOnThreadCreated_N1000(b *testing.B)  { benchmarkOnThreadCreatedFan
 func BenchmarkOnThreadCreated_N10000(b *testing.B) { benchmarkOnThreadCreatedFanout(b, 10000) }
 
 func BenchmarkFollowChannel_Materialize500(b *testing.B) {
-	t := &testing.T{}
-	_, svc := newIntegrationDB(t)
+	_, svc := newBenchService(b)
 
 	ids := make([]string, 500)
 	for i := range ids {

--- a/modules/conversation_ext/integration_test.go
+++ b/modules/conversation_ext/integration_test.go
@@ -615,8 +615,11 @@ func TestIntegration_ChannelCascade_FollowVersionBumpedOnce(t *testing.T) {
 		uid, space,
 	).LoadOne(&after))
 
-	assert.Equal(t, before+1, after,
-		"FollowChannel 即便物化 5 个子区也只 bump follow_version 一次（user-level 单调）")
+	// Bug fix #2 后 FollowChannel 拆两阶段提交，每阶段 +1 共 +2。
+	// 不变量：bump 次数与子区数 N 无关，保持小常数（≤2）。
+	assert.LessOrEqual(t, after-before, int64(2),
+		"FollowChannel 物化 N 个子区，bump follow_version 的次数应为小常数（2 次），不与 N 成比例")
+	assert.GreaterOrEqual(t, after-before, int64(1), "follow_version 至少 +1")
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/conversation_ext/module_test.go
+++ b/modules/conversation_ext/module_test.go
@@ -26,6 +26,13 @@ func resetGlobalConvExtServiceOnce(_ *testing.T) {
 // already exist (created by the CI test-setup or by the sql/ migration file).
 func newCtxForTest(t *testing.T) *config.Context {
 	t.Helper()
+	return newCtxForTestTB(t)
+}
+
+// newCtxForTestTB 是 newCtxForTest 的 testing.TB 版本，供 benchmark 使用，
+// 避免在 *testing.B 里塞 *testing.T{}。Jerry-Xin review (round-1) 指出的反模式。
+func newCtxForTestTB(tb testing.TB) *config.Context {
+	tb.Helper()
 	addr := os.Getenv("CONV_EXT_TEST_MYSQL_ADDR")
 	if addr == "" {
 		addr = "root:demo@tcp(127.0.0.1)/conv_ext_test?charset=utf8mb4&parseTime=true"

--- a/modules/conversation_ext/retry_test.go
+++ b/modules/conversation_ext/retry_test.go
@@ -1,0 +1,99 @@
+package conversation_ext
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 单测覆盖 withDeadlockRetry 的三条分支：
+//  1. 首次成功 — 不应进入重试 path；
+//  2. 持续遇到死锁 — 重试到上限后返回 wrap 后的错误；
+//  3. 中途从死锁错误恢复 — 返回 nil；
+//  4. 非 MySQL 锁错误 — 立即返回，不重试。
+//
+// 不依赖 DB（纯 Go 单测，无 //go:build integration）。
+
+func TestWithDeadlockRetry_FirstAttemptSucceeds(t *testing.T) {
+	var calls int
+	err := withDeadlockRetry(func() error {
+		calls++
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls, "首次成功不应触发重试")
+}
+
+func TestWithDeadlockRetry_RetriesDeadlock_AndRecovers(t *testing.T) {
+	deadlock := &mysql.MySQLError{Number: 1213, Message: "Deadlock found when trying to get lock"}
+	var calls int
+	err := withDeadlockRetry(func() error {
+		calls++
+		if calls < 2 {
+			return deadlock
+		}
+		return nil
+	})
+	require.NoError(t, err, "第二次返回 nil 应被识别为恢复成功")
+	assert.Equal(t, 2, calls)
+}
+
+func TestWithDeadlockRetry_RetriesLockWaitTimeout_AndRecovers(t *testing.T) {
+	lockWait := &mysql.MySQLError{Number: 1205, Message: "Lock wait timeout exceeded"}
+	var calls int
+	err := withDeadlockRetry(func() error {
+		calls++
+		if calls < 3 {
+			return lockWait
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, calls, "第三次（也即最后一次允许）才恢复也应成功")
+}
+
+func TestWithDeadlockRetry_ExhaustsAfterMaxAttempts(t *testing.T) {
+	deadlock := &mysql.MySQLError{Number: 1213, Message: "Deadlock found when trying to get lock"}
+	var calls int
+	err := withDeadlockRetry(func() error {
+		calls++
+		return deadlock
+	})
+	require.Error(t, err)
+	assert.Equal(t, 3, calls, "重试上限是 3")
+	assert.ErrorIs(t, err, deadlock, "最终错误应 wrap 原 MySQL 死锁错误，便于上游 errors.Is 判定")
+	assert.Contains(t, err.Error(), "retry exhausted")
+}
+
+func TestWithDeadlockRetry_NonLockErrorBubblesImmediately(t *testing.T) {
+	otherErr := errors.New("syntax error: not a lock issue")
+	var calls int
+	err := withDeadlockRetry(func() error {
+		calls++
+		return otherErr
+	})
+	require.Error(t, err)
+	assert.Equal(t, 1, calls, "非死锁错误不应触发重试")
+	assert.ErrorIs(t, err, otherErr, "非死锁错误应原样返回（不被 wrap）")
+}
+
+func TestWithDeadlockRetry_WrappedDeadlockStillDetected(t *testing.T) {
+	// 业务代码经常用 fmt.Errorf("... %w", err) 包装；retry 必须用 errors.As 透过 wrapping
+	// 识别 MySQL 错误码，否则保护就失效。
+	deadlock := &mysql.MySQLError{Number: 1213, Message: "Deadlock"}
+	wrapped := fmt.Errorf("OnThreadCreated batch: %w", deadlock)
+	var calls int
+	err := withDeadlockRetry(func() error {
+		calls++
+		if calls < 2 {
+			return wrapped
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls, "wrap 后的 MySQL 死锁错误也应被识别为可重试")
+}

--- a/modules/conversation_ext/service.go
+++ b/modules/conversation_ext/service.go
@@ -331,6 +331,13 @@ func (s *Service) FollowChannel(uid, spaceID, groupNo string) error {
 	// ext 等 version、UnfollowChannel 持 version 等 ext 会构成 InnoDB 死锁循环，
 	// 一个 tx 被回滚 —— Phase 3 受害时表现为 auto_follow=1 已 commit 但子区永不物化。
 	// 代价：用户已取关时本次也会 +1 一次 version（无害，客户端多刷一次 sidebar）。
+	//
+	// 为何不像 OnThreadCreated batch 那样包 withDeadlockRetry：Phase 3 是单用户单 tx，
+	// 与并发同用户写的 deadlock 概率极低（要 (UnfollowChannel | UpdateSort) 也同时进入
+	// 对同一 uid 的 tx 才行）；偶发死锁时 InnoDB 回滚 Phase 3，Phase 1 的 auto_follow=1
+	// 已 commit，下次新建子区的 OnThreadCreated 仍能 fanout，用户只是初次物化的旧
+	// 子区缺一批 —— 可由用户再点一次"关注"恢复。OnThreadCreated 因为多用户 + 大批
+	// 同时进 tx，死锁概率远高，所以才需要重试兜底。
 	return s.withTx("FollowChannel-phase3", func(tx *dbr.Tx) error {
 		if _, err := BumpFollowVersionTx(tx, uid, spaceID); err != nil {
 			return fmt.Errorf("FollowChannel phase3 bump version: %w", err)
@@ -344,7 +351,7 @@ func (s *Service) FollowChannel(uid, spaceID, groupNo string) error {
 			// version 已 +1（一次额外刷新，benign）。
 			return nil
 		}
-		if err := bulkInsertIgnoreThreadExtTx(tx, uid, spaceID, groupNo, shortIDs); err != nil {
+		if err := bulkInsertThreadExtForChannelMaterializeTx(tx, uid, spaceID, groupNo, shortIDs); err != nil {
 			return fmt.Errorf("FollowChannel phase3 materialize threads: %w", err)
 		}
 		return nil
@@ -378,11 +385,11 @@ func isChannelStillAutoFollowedTx(tx *dbr.Tx, uid, spaceID, groupNo string) (boo
 	return row.AutoFollow == 1 && row.Unfollowed == 0, nil
 }
 
-// bulkInsertIgnoreThreadExtTx 给 (uid, spaceID) 在 user_conversation_ext 表中
+// bulkInsertThreadExtForChannelMaterializeTx 给 (uid, spaceID) 在 user_conversation_ext 表中
 // 批量插入 target_type=5 子区行。已存在的行（含用户手动调过 follow_sort 的）
 // 因 INSERT IGNORE 保持不变 —— 这是 FollowChannel 既不覆盖用户既有排序也能
 // 一次性补齐缺失行的关键。
-func bulkInsertIgnoreThreadExtTx(tx *dbr.Tx, uid, spaceID, groupNo string, shortIDs []string) error {
+func bulkInsertThreadExtForChannelMaterializeTx(tx *dbr.Tx, uid, spaceID, groupNo string, shortIDs []string) error {
 	if len(shortIDs) == 0 {
 		return nil
 	}
@@ -512,7 +519,7 @@ func (s *Service) OnThreadCreated(groupNo, shortID string) error {
 	//           只锁 version 行；
 	//        b) selectEligibleForFanoutTx —— SELECT ... FOR UPDATE on ext 群行，
 	//           过滤出仍处于 auto_follow=1 AND group_unfollowed=0 的子集；
-	//        c) bulkInsertIgnoreThreadExtForUsersTx —— INSERT VALUES on ext 子区行，
+	//        c) bulkInsertThreadExtForFanoutUsersTx —— INSERT VALUES on ext 子区行，
 	//           只锁新写入的 ext 行。
 	//    - 关键修正（Jerry-Xin round-3 P1）：上一版用 INSERT ... SELECT FROM ext
 	//      在 REPEATABLE READ 下会先对 ext 加 S-lock 再写 version，反序锁可与
@@ -544,7 +551,7 @@ func (s *Service) OnThreadCreated(groupNo, shortID string) error {
 				if err != nil {
 					return fmt.Errorf("OnThreadCreated eligible select: %w", err)
 				}
-				if err := bulkInsertIgnoreThreadExtForUsersTx(tx, eligible, threadChannelID); err != nil {
+				if err := bulkInsertThreadExtForFanoutUsersTx(tx, eligible, threadChannelID); err != nil {
 					return fmt.Errorf("OnThreadCreated bulk insert thread ext: %w", err)
 				}
 				return nil
@@ -668,13 +675,13 @@ func selectEligibleForFanoutTx(tx *dbr.Tx, targets []onThreadCreatedTarget, grou
 	return eligible, err
 }
 
-// bulkInsertIgnoreThreadExtForUsersTx 给一批已经过资格 re-check（selectEligibleForFanoutTx
+// bulkInsertThreadExtForFanoutUsersTx 给一批已经过资格 re-check（selectEligibleForFanoutTx
 // 返回的）的 (uid, space_id) 写入 target_type=5 的 thread ext 行。
 //
 // 用 INSERT IGNORE ... VALUES 而非 INSERT ... SELECT —— 不读 user_conversation_ext，
 // 不会拿 source 表的 S-lock，避免与 bulkBumpFollowVersionTx 形成反向锁序
 // （同 Jerry-Xin round-3 P1 反馈）。
-func bulkInsertIgnoreThreadExtForUsersTx(tx *dbr.Tx, eligible []onThreadCreatedTarget, threadChannelID string) error {
+func bulkInsertThreadExtForFanoutUsersTx(tx *dbr.Tx, eligible []onThreadCreatedTarget, threadChannelID string) error {
 	if len(eligible) == 0 {
 		return nil
 	}

--- a/modules/conversation_ext/service.go
+++ b/modules/conversation_ext/service.go
@@ -46,6 +46,24 @@ type ThreadAuthChecker interface {
 	AuthorizeThreadFollow(uid, spaceID, groupNo, shortID string) error
 }
 
+// ThreadEnumerator 是 FollowChannel 级联物化子区时使用的窄接口。
+// 与 ThreadAuthChecker 一样采用依赖倒置，避免 conversation_ext 直接 import thread。
+// 由 message/1module.go 启动时通过 SetThreadEnumerator 注入；nil 时跳过物化
+// （供单测以及尚未注入的迁移期使用）。
+//
+// EnumerateActiveShortIDs 返回 groupNo 下 status=active 的子区 shortID 列表，
+// 最多返回 limit 项。返回顺序由调用方约定（通常按 created_at DESC），
+// 与 maxAutoFollowThreadsPerChannel 的截断语义一致。
+type ThreadEnumerator interface {
+	EnumerateActiveShortIDs(groupNo string, limit int) ([]string, error)
+}
+
+// maxAutoFollowThreadsPerChannel 是 FollowChannel 一次性物化的子区数量上限。
+// 与 maxUpdateSortItems=500 同审美：覆盖产品上限场景同时把 tx 锁范围与延迟控制住。
+// 超过该数量的子区不在 FollowChannel 时物化，依赖产品侧"子区自动归档"把活跃数控制在 cap 内
+// + 后续 OnThreadCreated fanout 持续补齐。
+const maxAutoFollowThreadsPerChannel = 500
+
 // Service encapsulates composite operations on user_conversation_ext that
 // require a single transaction boundary.  It intentionally avoids importing
 // modules/group, modules/user, or modules/thread to prevent circular
@@ -63,6 +81,10 @@ type Service struct {
 	session     *dbr.Session
 	threadAuth  ThreadAuthChecker
 	threadAuthM sync.RWMutex
+	// threadEnum 是 FollowChannel 级联物化子区时的查询钩子。
+	// 由 message/1module.go 启动时注入；nil 时跳过物化。
+	threadEnum  ThreadEnumerator
+	threadEnumM sync.RWMutex
 	log.Log
 }
 
@@ -90,6 +112,23 @@ func (s *Service) getThreadAuthChecker() ThreadAuthChecker {
 	c := s.threadAuth
 	s.threadAuthM.RUnlock()
 	return c
+}
+
+// SetThreadEnumerator injects the enumerator used by FollowChannel to
+// materialize thread ext rows for every active thread under the channel.
+// Safe for concurrent use; intended to be called once at startup from
+// message/1module.go after the thread module has initialised.
+func (s *Service) SetThreadEnumerator(e ThreadEnumerator) {
+	s.threadEnumM.Lock()
+	s.threadEnum = e
+	s.threadEnumM.Unlock()
+}
+
+func (s *Service) getThreadEnumerator() ThreadEnumerator {
+	s.threadEnumM.RLock()
+	e := s.threadEnum
+	s.threadEnumM.RUnlock()
+	return e
 }
 
 // ---------------------------------------------------------------------------
@@ -138,12 +177,19 @@ func escapeLike(s string) string {
 // FollowChannel — clear group-blacklist flag (re-follow a previously unfollowed group)
 // ---------------------------------------------------------------------------
 
-// FollowChannel marks the group as followed (group_unfollowed=0) for the given
-// user and space.  If no ext row exists it is created with the default values.
+// FollowChannel marks the group as followed (group_unfollowed=0,
+// auto_follow_threads=1) and, in the same transaction, materializes thread
+// ext rows for up to maxAutoFollowThreadsPerChannel currently-active threads
+// under the channel.
 //
 // PR review (Round 3) Blocking #1/#2 — 关注状态变化时把 user_follow_version +1。
-// Upsert 和 Bump 在同一 tx 内执行，这样客户端只要观察 follow_version 就能可靠
-// 检测到变化。
+// Upsert / Bump / fanout 在同一 tx 内执行，这样客户端只要观察 follow_version
+// 就能可靠检测到变化（即使物化了 N 个子区也只 +1，因为它是 user-level 单调序列）。
+//
+// 子区物化采用 INSERT IGNORE — 不覆盖用户既有的手动 follow_sort，新行 follow_sort
+// 保持默认 0 由客户端按"父 channel 之后聚拢渲染"规则决定位置。
+//
+// 当未注入 ThreadEnumerator 时（单测 / 迁移期）跳过物化，仅写群行。
 func (s *Service) FollowChannel(uid, spaceID, groupNo string) error {
 	if err := validateBase(uid, spaceID); err != nil {
 		return err
@@ -151,23 +197,64 @@ func (s *Service) FollowChannel(uid, spaceID, groupNo string) error {
 	if groupNo == "" {
 		return errors.New("group_no must not be empty")
 	}
+
+	// 先在 tx 外把活跃子区 shortID 拉出来 —— 把潜在的跨表 / 大查询挪到事务外，
+	// 缩短 ext 行锁 + follow_version 行锁的持有时间。
+	var shortIDs []string
+	if enum := s.getThreadEnumerator(); enum != nil {
+		ids, err := enum.EnumerateActiveShortIDs(groupNo, maxAutoFollowThreadsPerChannel)
+		if err != nil {
+			return fmt.Errorf("FollowChannel enumerate threads: %w", err)
+		}
+		shortIDs = ids
+	}
+
 	zero := int8(0)
+	one := int8(1)
 	// PR #21 review (lml2468 blocker #2)：所有同时触及 user_follow_version 与
-	// user_conversation_ext 的事务必须按相同顺序拿锁，否则与先锁 version
-	// 再锁 ext 的 UpdateSort 互锁。把 Bump 放在最前 —— 它通过
-	// INSERT ... ON DUPLICATE KEY UPDATE 对 user_follow_version (uid, space_id)
+	// user_conversation_ext 的事务必须按相同顺序拿锁。把 Bump 放在最前 ——
+	// 它通过 ON DUPLICATE KEY UPDATE 对 user_follow_version (uid, space_id)
 	// 行加 X 锁，使本 tx 在 version 行上有排它后再进入 ext 行操作。
 	return s.withTx("FollowChannel", func(tx *dbr.Tx) error {
 		if _, err := BumpFollowVersionTx(tx, uid, spaceID); err != nil {
 			return fmt.Errorf("FollowChannel bump version: %w", err)
 		}
 		if err := upsertTx(tx, uid, spaceID, targetTypeGroup, groupNo, ConvExtFields{
-			GroupUnfollowed: &zero,
+			GroupUnfollowed:   &zero,
+			AutoFollowThreads: &one,
 		}); err != nil {
 			return fmt.Errorf("FollowChannel upsert: %w", err)
 		}
+		if len(shortIDs) > 0 {
+			if err := bulkInsertIgnoreThreadExtTx(tx, uid, spaceID, groupNo, shortIDs); err != nil {
+				return fmt.Errorf("FollowChannel materialize threads: %w", err)
+			}
+		}
 		return nil
 	})
+}
+
+// bulkInsertIgnoreThreadExtTx 给 (uid, spaceID) 在 user_conversation_ext 表中
+// 批量插入 target_type=5 子区行。已存在的行（含用户手动调过 follow_sort 的）
+// 因 INSERT IGNORE 保持不变 —— 这是 FollowChannel 既不覆盖用户既有排序也能
+// 一次性补齐缺失行的关键。
+func bulkInsertIgnoreThreadExtTx(tx *dbr.Tx, uid, spaceID, groupNo string, shortIDs []string) error {
+	if len(shortIDs) == 0 {
+		return nil
+	}
+	placeholders := make([]string, len(shortIDs))
+	args := make([]interface{}, 0, len(shortIDs)*4)
+	for i, sid := range shortIDs {
+		placeholders[i] = "(?, ?, ?, ?)"
+		args = append(args, uid, spaceID, targetTypeThread, groupNo+threadSeparator+sid)
+	}
+	_, err := tx.InsertBySql(
+		"INSERT IGNORE INTO "+table+
+			" (uid, space_id, target_type, target_id) VALUES "+
+			strings.Join(placeholders, ", "),
+		args...,
+	).Exec()
+	return err
 }
 
 // withTx wraps fn in a tx with consistent error handling.
@@ -202,14 +289,18 @@ func (s *Service) UnfollowChannel(uid, spaceID, groupNo string) error {
 		return errors.New("group_no must not be empty")
 	}
 	one := int8(1)
+	zero := int8(0)
 	// PR #21 review (lml2468 blocker #2)：bump 必须先于 ext 行操作，保证与
 	// UpdateSort 同序拿锁，避免 (version vs ext) 反向死锁。
 	return s.withTx("UnfollowChannel", func(tx *dbr.Tx) error {
 		if _, err := BumpFollowVersionTx(tx, uid, spaceID); err != nil {
 			return fmt.Errorf("UnfollowChannel bump version: %w", err)
 		}
+		// 同时清零 auto_follow_threads —— 否则 OnThreadCreated 还会把该用户当作
+		// fanout 目标，违反"取消关注 = 不再自动跟随新子区"的语义。
 		if err := upsertTx(tx, uid, spaceID, targetTypeGroup, groupNo, ConvExtFields{
-			GroupUnfollowed: &one,
+			GroupUnfollowed:   &one,
+			AutoFollowThreads: &zero,
 		}); err != nil {
 			return fmt.Errorf("UnfollowChannel upsert group: %w", err)
 		}

--- a/modules/conversation_ext/service.go
+++ b/modules/conversation_ext/service.go
@@ -344,11 +344,7 @@ func (s *Service) OnThreadCreated(groupNo, shortID string) error {
 	}
 
 	// 1. 在 tx 外把目标 (uid, space_id) 列表读出 —— 跨 N 用户的 SELECT 不参与 tx 锁。
-	type target struct {
-		UID     string `db:"uid"`
-		SpaceID string `db:"space_id"`
-	}
-	var targets []target
+	var targets []onThreadCreatedTarget
 	_, err := s.session.SelectBySql(
 		"SELECT uid, space_id FROM "+table+
 			" WHERE target_type=? AND target_id=? AND auto_follow_threads=1",
@@ -363,23 +359,70 @@ func (s *Service) OnThreadCreated(groupNo, shortID string) error {
 
 	threadChannelID := groupNo + threadSeparator + shortID
 
-	// 2. 单 tx：对每个目标用户先 bump version 再 INSERT IGNORE 一行 thread ext。
-	//    若中途失败整体回滚，避免出现"version 已 bump 但 ext 行未落"的不一致。
+	// 2. 单 tx 内批量化两次写：一次性 bump N 个 (uid, space_id) 的 version，
+	//    一次性 INSERT IGNORE N 个 thread ext 行。
+	//    锁顺序仍是 follow_version 先于 ext —— 与 FollowChannel / UpdateSort 一致。
+	//
+	//    为何不走 per-user loop：在 N=10000 用户的基准下，逐行 BumpFollowVersionTx
+	//    + InsertBySql 要 2*N 个 round-trip（~3.4s）。批量化两条 SQL 后 N=10000
+	//    降到一位数 ms（实测见 bench）。
 	return s.withTx("OnThreadCreated", func(tx *dbr.Tx) error {
-		for _, t := range targets {
-			if _, err := BumpFollowVersionTx(tx, t.UID, t.SpaceID); err != nil {
-				return fmt.Errorf("OnThreadCreated bump version (uid=%s): %w", t.UID, err)
-			}
-			if _, err := tx.InsertBySql(
-				"INSERT IGNORE INTO "+table+
-					" (uid, space_id, target_type, target_id) VALUES (?, ?, ?, ?)",
-				t.UID, t.SpaceID, targetTypeThread, threadChannelID,
-			).Exec(); err != nil {
-				return fmt.Errorf("OnThreadCreated insert thread ext (uid=%s): %w", t.UID, err)
-			}
+		if err := bulkBumpFollowVersionTx(tx, targets); err != nil {
+			return fmt.Errorf("OnThreadCreated bulk bump version: %w", err)
+		}
+		if err := bulkInsertIgnoreThreadExtForUsersTx(tx, targets, threadChannelID); err != nil {
+			return fmt.Errorf("OnThreadCreated bulk insert thread ext: %w", err)
 		}
 		return nil
 	})
+}
+
+// bulkBumpFollowVersionTx 一次性给一批 (uid, space_id) bump version +1。
+// 行不存在时初始化为 1（与 BumpFollowVersionTx 单行版语义一致）。
+//
+// SQL 用 INSERT ... ON DUPLICATE KEY UPDATE 批量插入若干 (uid, space_id, version=1)
+// 元组：已有行触发 ODKU 把 version 自增；不存在的行新建为 1。
+type onThreadCreatedTarget = struct {
+	UID     string `db:"uid"`
+	SpaceID string `db:"space_id"`
+}
+
+func bulkBumpFollowVersionTx(tx *dbr.Tx, targets []onThreadCreatedTarget) error {
+	if len(targets) == 0 {
+		return nil
+	}
+	placeholders := make([]string, len(targets))
+	args := make([]interface{}, 0, len(targets)*3)
+	for i, t := range targets {
+		placeholders[i] = "(?, ?, 1)"
+		args = append(args, t.UID, t.SpaceID)
+	}
+	_, err := tx.InsertBySql(
+		"INSERT INTO "+followVersionTable+" (uid, space_id, version) VALUES "+
+			strings.Join(placeholders, ", ")+
+			" ON DUPLICATE KEY UPDATE version = version + 1",
+		args...,
+	).Exec()
+	return err
+}
+
+func bulkInsertIgnoreThreadExtForUsersTx(tx *dbr.Tx, targets []onThreadCreatedTarget, threadChannelID string) error {
+	if len(targets) == 0 {
+		return nil
+	}
+	placeholders := make([]string, len(targets))
+	args := make([]interface{}, 0, len(targets)*4)
+	for i, t := range targets {
+		placeholders[i] = "(?, ?, ?, ?)"
+		args = append(args, t.UID, t.SpaceID, targetTypeThread, threadChannelID)
+	}
+	_, err := tx.InsertBySql(
+		"INSERT IGNORE INTO "+table+
+			" (uid, space_id, target_type, target_id) VALUES "+
+			strings.Join(placeholders, ", "),
+		args...,
+	).Exec()
+	return err
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/conversation_ext/service.go
+++ b/modules/conversation_ext/service.go
@@ -68,9 +68,10 @@ type ChannelAuthChecker interface {
 // 由 message/1module.go 启动时通过 SetThreadEnumerator 注入；nil 时跳过物化
 // （供单测以及尚未注入的迁移期使用）。
 //
-// EnumerateActiveShortIDs 返回 groupNo 下 status=active 的子区 shortID 列表，
-// 最多返回 limit 项。返回顺序由调用方约定（通常按 created_at DESC），
-// 与 maxAutoFollowThreadsPerChannel 的截断语义一致。
+// 实现 MUST 按 created_at DESC 排序返回（yujiawei round-2 nit）——
+// maxAutoFollowThreadsPerChannel 的截断语义依赖这条不变量：cap 命中时丢弃的是
+// 最旧的子区，与产品侧"子区自动归档先归档旧子区"配合让"热"子区始终进入物化。
+// 如果未来引入新的 enumerator 实现，必须保留这个顺序约定。
 type ThreadEnumerator interface {
 	EnumerateActiveShortIDs(groupNo string, limit int) ([]string, error)
 }
@@ -314,19 +315,27 @@ func (s *Service) FollowChannel(uid, spaceID, groupNo string) error {
 	//
 	// Bug fix B2 (yujiawei P2 / lml2468 round-2 #2)：在 Phase 1 commit 与 Phase 3
 	// 之间用户可能调用 UnfollowChannel，那一刻群行变成 auto_follow=0 + group_unfollowed=1。
-	// Phase 3 必须在同一 tx 内 SELECT ... FOR UPDATE 该群行重新确认状态，发现不再
-	// 资格则跳过整批写入（含 bump），避免重建已被 UnfollowChannel 清掉的孤立 thread 行。
+	// Phase 3 在同一 tx 内 SELECT ... FOR UPDATE 该群行重新确认状态，发现不再
+	// 资格则跳过 thread 写入，避免重建已被 UnfollowChannel 清掉的孤立 thread 行。
+	//
+	// 锁序（Jerry-Xin / yujiawei round-2 P1 blocker）：BumpFollowVersionTx **必须**
+	// 排在 isChannelStillAutoFollowedTx 之前，与 UnfollowChannel / UpdateSort /
+	// FollowDM 等全部写路径同序（先 version 行的 X 锁再 ext 行）。否则 Phase 3 持
+	// ext 等 version、UnfollowChannel 持 version 等 ext 会构成 InnoDB 死锁循环，
+	// 一个 tx 被回滚 —— Phase 3 受害时表现为 auto_follow=1 已 commit 但子区永不物化。
+	// 代价：用户已取关时本次也会 +1 一次 version（无害，客户端多刷一次 sidebar）。
 	return s.withTx("FollowChannel-phase3", func(tx *dbr.Tx) error {
+		if _, err := BumpFollowVersionTx(tx, uid, spaceID); err != nil {
+			return fmt.Errorf("FollowChannel phase3 bump version: %w", err)
+		}
 		eligible, err := isChannelStillAutoFollowedTx(tx, uid, spaceID, groupNo)
 		if err != nil {
 			return fmt.Errorf("FollowChannel phase3 recheck: %w", err)
 		}
 		if !eligible {
-			// 用户已在 Phase 1 与 Phase 3 之间取关；丢弃旧 enumerate 快照，不写任何东西。
+			// 用户已在 Phase 1 与 Phase 3 之间取关；丢弃旧 enumerate 快照，不写 thread 行。
+			// version 已 +1（一次额外刷新，benign）。
 			return nil
-		}
-		if _, err := BumpFollowVersionTx(tx, uid, spaceID); err != nil {
-			return fmt.Errorf("FollowChannel phase3 bump version: %w", err)
 		}
 		if err := bulkInsertIgnoreThreadExtTx(tx, uid, spaceID, groupNo, shortIDs); err != nil {
 			return fmt.Errorf("FollowChannel phase3 materialize threads: %w", err)
@@ -337,12 +346,12 @@ func (s *Service) FollowChannel(uid, spaceID, groupNo string) error {
 
 // isChannelStillAutoFollowedTx 在 tx 内对 (uid, spaceID, target_type=2, groupNo)
 // 取 SELECT ... FOR UPDATE，判断当前是否仍处于"已关注 + 自动跟随子区"状态。
-// 行不存在或两标志中任一不满足都返回 false，让 FollowChannel Phase 3 跳过写入。
-// 锁顺序：本函数应当在 BumpFollowVersionTx 之后调用 —— 群 ext 行的 SELECT
-// FOR UPDATE 不能先于 user_follow_version 的 X 锁，否则与 UpdateSort 反向死锁。
-// 但 Phase 3 实际是先 SELECT 再 bump（bump 只在 eligible 时发生），
-// 这是个例外：Phase 1 已经先锁过 user_follow_version 并 commit，本 tx 重新进入
-// 时 follow_version 行尚未在本 tx 中被锁，并不存在与 UpdateSort 反向交叉的窗口。
+// 行不存在或两标志中任一不满足都返回 false，让 FollowChannel Phase 3 跳过 thread 写入。
+//
+// 锁序：必须在 BumpFollowVersionTx 之后调用（Jerry-Xin / yujiawei round-2 P1）。
+// 全包写路径都遵循 user_follow_version → user_conversation_ext 的锁序；本函数对
+// ext 行加 X 锁，调用方要先在同 tx 拿过 version 行的 X 锁，否则与 UnfollowChannel /
+// UpdateSort 等反向交叉会导致 InnoDB 死锁回滚。
 func isChannelStillAutoFollowedTx(tx *dbr.Tx, uid, spaceID, groupNo string) (bool, error) {
 	var row struct {
 		AutoFollow int8 `db:"auto_follow_threads"`
@@ -533,9 +542,10 @@ type onThreadCreatedTarget = struct {
 //
 // Bug fix B2：用 INSERT ... SELECT 内嵌 WHERE 让 re-check 与 write 落在同一条
 // SQL，关闭"初始 SELECT 后用户取关"的 race。SELECT 源是 user_conversation_ext
-// 的群行（target_type=2），这里 ORDER BY (uid, space_id) 让并发 fanout 的行锁
-// 顺序一致（W2，lml2468 round-1）—— 避免两条 OnThreadCreated 不同顺序枚举时
-// 触发 InnoDB 死锁检测器回滚。
+// 的群行（target_type=2），这里 ORDER BY (uid, space_id) 让并发 fanout 在测试中
+// 观察到的行锁顺序一致（W2，lml2468 round-1）—— 注意 MySQL 文档并不严格保证
+// INSERT ... SELECT 的锁获取顺序对应 SELECT 输出顺序，所以这是 best-effort 的
+// 死锁缓解（yujiawei round-2 nit）；真正的死锁兜底仍依赖 InnoDB 检测 + 上层重试。
 //
 // IN tuple 列表把行集限定在本 batch 内，让单条 SQL 的占位符数受 batchSize 约束。
 func bulkBumpFollowVersionTx(tx *dbr.Tx, targets []onThreadCreatedTarget, groupNo string) error {

--- a/modules/conversation_ext/service.go
+++ b/modules/conversation_ext/service.go
@@ -316,6 +316,73 @@ func (s *Service) UnfollowChannel(uid, spaceID, groupNo string) error {
 }
 
 // ---------------------------------------------------------------------------
+// OnThreadCreated — fanout on new thread to every user with auto_follow_threads
+// ---------------------------------------------------------------------------
+
+// OnThreadCreated 在 thread.Service.CreateThread 提交 tx 之后调用，给所有
+// 已对 parent channel 开启 auto_follow_threads=1 的用户物化 thread ext 行
+// 并 bump 各自的 follow_version，从而实现"关注 channel 后新建子区自动跟随"。
+//
+// 设计说明（plan Q1 = C / fanout = 同步）：
+//   - 同步执行（非异步队列）—— 客户端 sidebar 在 thread 创建消息送达后立刻能拉到新行。
+//   - 单独 tx —— thread.Service.CreateThread 自己的 tx 已 commit，与 IM 频道 / 子区
+//     创建消息一样采取 best-effort post-commit hook 风格；fanout 失败只记日志不阻断
+//     thread 创建本身。
+//   - INSERT IGNORE —— 用户既有的 thread 行（含已手动调过 follow_sort 的）保持不变。
+//   - follow_version bump —— 只对真正参与 fanout 的用户 +1。无 auto_follow 用户时整体 no-op。
+//   - 锁顺序与 FollowChannel 一致：每个用户先 BumpFollowVersionTx（在 version 行加 X 锁）
+//     再写 ext 行，避免与 UpdateSort 反向死锁。
+//
+// 调用方应在 thread.Service.CreateThread 的 commit 之后立即调用，错误以 wrap 形式上传，
+// 由调用方决定是否记日志 / 触发告警（thread 创建不应因 fanout 失败回滚）。
+func (s *Service) OnThreadCreated(groupNo, shortID string) error {
+	if groupNo == "" {
+		return errors.New("group_no must not be empty")
+	}
+	if shortID == "" {
+		return errors.New("short_id must not be empty")
+	}
+
+	// 1. 在 tx 外把目标 (uid, space_id) 列表读出 —— 跨 N 用户的 SELECT 不参与 tx 锁。
+	type target struct {
+		UID     string `db:"uid"`
+		SpaceID string `db:"space_id"`
+	}
+	var targets []target
+	_, err := s.session.SelectBySql(
+		"SELECT uid, space_id FROM "+table+
+			" WHERE target_type=? AND target_id=? AND auto_follow_threads=1",
+		targetTypeGroup, groupNo,
+	).Load(&targets)
+	if err != nil {
+		return fmt.Errorf("OnThreadCreated query auto-follow users: %w", err)
+	}
+	if len(targets) == 0 {
+		return nil
+	}
+
+	threadChannelID := groupNo + threadSeparator + shortID
+
+	// 2. 单 tx：对每个目标用户先 bump version 再 INSERT IGNORE 一行 thread ext。
+	//    若中途失败整体回滚，避免出现"version 已 bump 但 ext 行未落"的不一致。
+	return s.withTx("OnThreadCreated", func(tx *dbr.Tx) error {
+		for _, t := range targets {
+			if _, err := BumpFollowVersionTx(tx, t.UID, t.SpaceID); err != nil {
+				return fmt.Errorf("OnThreadCreated bump version (uid=%s): %w", t.UID, err)
+			}
+			if _, err := tx.InsertBySql(
+				"INSERT IGNORE INTO "+table+
+					" (uid, space_id, target_type, target_id) VALUES (?, ?, ?, ?)",
+				t.UID, t.SpaceID, targetTypeThread, threadChannelID,
+			).Exec(); err != nil {
+				return fmt.Errorf("OnThreadCreated insert thread ext (uid=%s): %w", t.UID, err)
+			}
+		}
+		return nil
+	})
+}
+
+// ---------------------------------------------------------------------------
 // FollowThread — re-follow parent group (implicit) + upsert thread ext row
 // ---------------------------------------------------------------------------
 

--- a/modules/conversation_ext/service.go
+++ b/modules/conversation_ext/service.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/go-sql-driver/mysql"
 	"github.com/gocraft/dbr/v2"
 )
 
@@ -248,8 +250,13 @@ func escapeLike(s string) string {
 // commit 之间创建的子区会被永久遗漏 —— OnThreadCreated 看不到 auto_follow=1，
 // enumerate 的快照也没拿到该子区。
 //
-// follow_version 在 Phase 1 与 Phase 3 各 +1 —— 总次数随路径而定：未注入
-// enumerator / 群下无 active 子区 / Phase 3 re-check 跳过 都让 bump 停在 +1。
+// follow_version bump 次数随路径而定（lml2468 round-3 nit 后精确化）：
+//   - 鉴权失败 (ErrChannelForbidden)：0 次（直接返回，无 tx）
+//   - 未注入 ThreadEnumerator / 群下无 active 子区：1 次（仅 Phase 1）
+//   - 正常路径（含 Phase 3 re-check 跳过）：2 次 —— Phase 3 锁序修复
+//     (Jerry-Xin / yujiawei round-2 P1) 后 bump 先于 ext 行 SELECT FOR UPDATE，
+//     所以即便 re-check 判定 ineligible 仍会 +1（无害，客户端多刷一次 sidebar）。
+//
 // 关键不变量是 bump 次数与子区数量 N 无关（不会随 N 线性增长），保持小常数。
 //
 // 当未注入 ThreadEnumerator 时（单测 / 迁移期）跳过 Phase 2/3，仅写群行。
@@ -481,10 +488,13 @@ func (s *Service) OnThreadCreated(groupNo, shortID string) error {
 	}
 
 	// 1. 在 tx 外把目标 (uid, space_id) 列表读出 —— 跨 N 用户的 SELECT 不参与 tx 锁。
+	//    ORDER BY uid, space_id 让本 batch 内（以及并发 fanout 之间）按统一顺序
+	//    取行锁，减少死锁概率；真正死锁兜底走下面的 withDeadlockRetry。
 	var targets []onThreadCreatedTarget
 	_, err := s.session.SelectBySql(
 		"SELECT uid, space_id FROM "+table+
-			" WHERE target_type=? AND target_id=? AND auto_follow_threads=1",
+			" WHERE target_type=? AND target_id=? AND auto_follow_threads=1"+
+			" ORDER BY uid, space_id",
 		targetTypeGroup, groupNo,
 	).Load(&targets)
 	if err != nil {
@@ -497,15 +507,24 @@ func (s *Service) OnThreadCreated(groupNo, shortID string) error {
 	threadChannelID := groupNo + threadSeparator + shortID
 
 	// 2. 按 batch 切分，每 batch 一个 tx：
-	//    - 单 tx 内仍批量化两条 SQL（bulk bump version + bulk INSERT IGNORE），
-	//      避免 per-user round-trip 的 O(N) 延迟。
+	//    - 单 tx 内三步（按全包统一的 version → ext 锁序）：
+	//        a) bulkBumpFollowVersionTx —— INSERT VALUES on user_follow_version，
+	//           只锁 version 行；
+	//        b) selectEligibleForFanoutTx —— SELECT ... FOR UPDATE on ext 群行，
+	//           过滤出仍处于 auto_follow=1 AND group_unfollowed=0 的子集；
+	//        c) bulkInsertIgnoreThreadExtForUsersTx —— INSERT VALUES on ext 子区行，
+	//           只锁新写入的 ext 行。
+	//    - 关键修正（Jerry-Xin round-3 P1）：上一版用 INSERT ... SELECT FROM ext
+	//      在 REPEATABLE READ 下会先对 ext 加 S-lock 再写 version，反序锁可与
+	//      UnfollowChannel 形成死锁循环导致整批 fanout 回滚。改用 VALUES 写 + 单独
+	//      FOR UPDATE re-check 让真正的锁序与文档一致。
 	//    - batch 之间换 tx 防止两件事：
 	//      (a) 单 tx 持锁窗口随 N 线性增长拖慢其它 follow 操作；
 	//      (b) bug fix #3 —— 单 SQL 占位符数超过 MySQL 65,535 上限。
-	//    - INSERT IGNORE + version 单调递增 让"前一 batch 已 commit、后一 batch
-	//      失败"的 partial-success 状态可恢复：下次 FollowChannel / 新建子区
-	//      fanout 会把缺失的用户补齐。
-	//    锁顺序仍是 follow_version 先于 ext —— 与 FollowChannel / UpdateSort 一致。
+	//    - withDeadlockRetry 对 InnoDB 错误码 1213 做有界重试，保证 fanout 自愈，
+	//      不再依赖用户重新 refollow（yujiawei round-2 P2 建议）。
+	//    - INSERT IGNORE + version 单调递增让 partial-success 状态可恢复：下次
+	//      FollowChannel / 新子区 fanout 会把缺失的用户补齐。
 	batchSize := onThreadCreatedBatchSize
 	if batchSize <= 0 {
 		batchSize = 1000
@@ -516,19 +535,66 @@ func (s *Service) OnThreadCreated(groupNo, shortID string) error {
 			end = len(targets)
 		}
 		batch := targets[start:end]
-		if err := s.withTx("OnThreadCreated", func(tx *dbr.Tx) error {
-			if err := bulkBumpFollowVersionTx(tx, batch, groupNo); err != nil {
-				return fmt.Errorf("OnThreadCreated bulk bump version: %w", err)
-			}
-			if err := bulkInsertIgnoreThreadExtForUsersTx(tx, batch, groupNo, threadChannelID); err != nil {
-				return fmt.Errorf("OnThreadCreated bulk insert thread ext: %w", err)
-			}
-			return nil
+		if err := withDeadlockRetry(func() error {
+			return s.withTx("OnThreadCreated", func(tx *dbr.Tx) error {
+				if err := bulkBumpFollowVersionTx(tx, batch); err != nil {
+					return fmt.Errorf("OnThreadCreated bulk bump version: %w", err)
+				}
+				eligible, err := selectEligibleForFanoutTx(tx, batch, groupNo)
+				if err != nil {
+					return fmt.Errorf("OnThreadCreated eligible select: %w", err)
+				}
+				if err := bulkInsertIgnoreThreadExtForUsersTx(tx, eligible, threadChannelID); err != nil {
+					return fmt.Errorf("OnThreadCreated bulk insert thread ext: %w", err)
+				}
+				return nil
+			})
 		}); err != nil {
 			return fmt.Errorf("OnThreadCreated batch [%d,%d): %w", start, end, err)
 		}
 	}
 	return nil
+}
+
+// withDeadlockRetry 对 fn 做有界重试，专门捕获 MySQL InnoDB 死锁（错误码 1213）
+// 与锁等待超时（错误码 1205）。其它错误立刻向上传，不做重试。
+//
+// 引入背景（Jerry-Xin / yujiawei round-2/3）：OnThreadCreated 的批量 SQL 即便
+// 严格按 version → ext 顺序写，与并发 UnfollowChannel / UpdateSort 在大流量下
+// 仍可能偶发死锁（InnoDB 用次行索引或 gap lock 的内部顺序未必与 SQL VALUES 一致）。
+// 一次重试足以让另一边 commit / rollback 完释放锁；3 次封顶避免重试风暴。
+// 退避用 5ms / 20ms / 80ms 的等比序列。
+func withDeadlockRetry(fn func() error) error {
+	const maxAttempts = 3
+	delays := []time.Duration{5 * time.Millisecond, 20 * time.Millisecond, 80 * time.Millisecond}
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		if !isRetriableMySQLLockErr(err) {
+			return err
+		}
+		lastErr = err
+		if attempt+1 < maxAttempts {
+			time.Sleep(delays[attempt])
+		}
+	}
+	return fmt.Errorf("retry exhausted after %d attempts on lock error: %w", maxAttempts, lastErr)
+}
+
+// isRetriableMySQLLockErr 识别 *mysql.MySQLError 的两个可恢复错误码：
+//   - 1213 ER_LOCK_DEADLOCK
+//   - 1205 ER_LOCK_WAIT_TIMEOUT
+//
+// 用 errors.As 兼容已包装的错误。
+func isRetriableMySQLLockErr(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	if !errors.As(err, &mysqlErr) {
+		return false
+	}
+	return mysqlErr.Number == 1213 || mysqlErr.Number == 1205
 }
 
 // onThreadCreatedTarget 是 OnThreadCreated 初始 SELECT 出来的目标 (uid, space_id)。
@@ -537,20 +603,52 @@ type onThreadCreatedTarget = struct {
 	SpaceID string `db:"space_id"`
 }
 
-// bulkBumpFollowVersionTx 批量给当前仍处于"auto_follow=1 + group_unfollowed=0"
-// 状态的 (uid, space_id) +1 follow_version；不在该状态的目标跳过。
+// bulkBumpFollowVersionTx 批量给一批已排序的 (uid, space_id) +1 follow_version。
 //
-// Bug fix B2：用 INSERT ... SELECT 内嵌 WHERE 让 re-check 与 write 落在同一条
-// SQL，关闭"初始 SELECT 后用户取关"的 race。SELECT 源是 user_conversation_ext
-// 的群行（target_type=2），这里 ORDER BY (uid, space_id) 让并发 fanout 在测试中
-// 观察到的行锁顺序一致（W2，lml2468 round-1）—— 注意 MySQL 文档并不严格保证
-// INSERT ... SELECT 的锁获取顺序对应 SELECT 输出顺序，所以这是 best-effort 的
-// 死锁缓解（yujiawei round-2 nit）；真正的死锁兜底仍依赖 InnoDB 检测 + 上层重试。
+// Bug fix (Jerry-Xin round-3 P1 / yujiawei round-3 P2 / lml2468 round-3 carry):
+// 原实现用 INSERT ... SELECT FROM user_conversation_ext。在 MySQL 默认
+// REPEATABLE READ 下，INSERT ... SELECT 会先对 source 表 (ext) 拿 next-key
+// shared lock，再对 dest 表 (version) 加 X 锁 —— 实际锁序是 ext → version，
+// 与 UnfollowChannel / UpdateSort / FollowDM 等单用户写路径 (version → ext) 反向，
+// 可形成 InnoDB 死锁循环，整批 fanout 被回滚。
 //
-// IN tuple 列表把行集限定在本 batch 内，让单条 SQL 的占位符数受 batchSize 约束。
-func bulkBumpFollowVersionTx(tx *dbr.Tx, targets []onThreadCreatedTarget, groupNo string) error {
+// 修复：改成 INSERT ... VALUES，纯写入 dest 表 (version)，**不读 ext**。
+// 锁仅落在 version 行上，符合全包统一的 version → ext 锁序。
+// 资格 re-check 在调用方拆出来的独立 SELECT ... FOR UPDATE 步骤里做。
+//
+// targets 必须按 (uid, space_id) 升序排序；并发 fanout 共享同一排序约定可减少
+// 死锁概率（InnoDB 按行物理顺序加锁与 VALUES 顺序未必一致，仍可能死锁 → 上层重试兜底）。
+func bulkBumpFollowVersionTx(tx *dbr.Tx, targets []onThreadCreatedTarget) error {
 	if len(targets) == 0 {
 		return nil
+	}
+	tupleHolders := make([]string, len(targets))
+	args := make([]interface{}, 0, len(targets)*3)
+	for i, t := range targets {
+		tupleHolders[i] = "(?, ?, 1)"
+		args = append(args, t.UID, t.SpaceID)
+	}
+	_, err := tx.InsertBySql(
+		"INSERT INTO "+followVersionTable+" (uid, space_id, version) VALUES "+
+			strings.Join(tupleHolders, ", ")+
+			" ON DUPLICATE KEY UPDATE version = version + 1",
+		args...,
+	).Exec()
+	return err
+}
+
+// selectEligibleForFanoutTx 在 tx 内 SELECT ... FOR UPDATE 锁住本 batch 内
+// 仍然 auto_follow_threads=1 AND group_unfollowed=0 的 (uid, space_id) 列表。
+// 返回值即"应被本次 fanout 写入 thread 行的用户子集"。
+//
+// 这一步必须在 bulkBumpFollowVersionTx 之后调用，保证全包统一的 version → ext
+// 锁序（Jerry-Xin / yujiawei round-2/3 P1）。
+// ORDER BY uid, space_id 在 mysql 8 上让本 SELECT 与同序的 INSERT VALUES 在
+// 测试观察中表现一致的加锁顺序；不是严格规范保证（详见
+// https://dev.mysql.com/doc/refman/8.0/en/innodb-locks-set.html），上层 retry 兜底。
+func selectEligibleForFanoutTx(tx *dbr.Tx, targets []onThreadCreatedTarget, groupNo string) ([]onThreadCreatedTarget, error) {
+	if len(targets) == 0 {
+		return nil, nil
 	}
 	tupleHolders := make([]string, len(targets))
 	args := []interface{}{targetTypeGroup, groupNo}
@@ -558,40 +656,38 @@ func bulkBumpFollowVersionTx(tx *dbr.Tx, targets []onThreadCreatedTarget, groupN
 		tupleHolders[i] = "(?, ?)"
 		args = append(args, t.UID, t.SpaceID)
 	}
-	_, err := tx.InsertBySql(
-		"INSERT INTO "+followVersionTable+" (uid, space_id, version)"+
-			" SELECT uid, space_id, 1 FROM "+table+
+	var eligible []onThreadCreatedTarget
+	_, err := tx.SelectBySql(
+		"SELECT uid, space_id FROM "+table+
 			" WHERE target_type=? AND target_id=?"+
 			" AND auto_follow_threads=1 AND group_unfollowed=0"+
 			" AND (uid, space_id) IN ("+strings.Join(tupleHolders, ", ")+")"+
-			" ORDER BY uid, space_id"+
-			" ON DUPLICATE KEY UPDATE version = version + 1",
+			" ORDER BY uid, space_id FOR UPDATE",
 		args...,
-	).Exec()
-	return err
+	).Load(&eligible)
+	return eligible, err
 }
 
-// bulkInsertIgnoreThreadExtForUsersTx 给本 batch 内当前仍 auto_follow=1 +
-// group_unfollowed=0 的 (uid, space_id) 写入 target_type=5 的 thread ext 行。
-// Re-check 内嵌在 SELECT WHERE 里 —— 同 bulkBumpFollowVersionTx 关闭 B2 race。
-func bulkInsertIgnoreThreadExtForUsersTx(tx *dbr.Tx, targets []onThreadCreatedTarget, groupNo, threadChannelID string) error {
-	if len(targets) == 0 {
+// bulkInsertIgnoreThreadExtForUsersTx 给一批已经过资格 re-check（selectEligibleForFanoutTx
+// 返回的）的 (uid, space_id) 写入 target_type=5 的 thread ext 行。
+//
+// 用 INSERT IGNORE ... VALUES 而非 INSERT ... SELECT —— 不读 user_conversation_ext，
+// 不会拿 source 表的 S-lock，避免与 bulkBumpFollowVersionTx 形成反向锁序
+// （同 Jerry-Xin round-3 P1 反馈）。
+func bulkInsertIgnoreThreadExtForUsersTx(tx *dbr.Tx, eligible []onThreadCreatedTarget, threadChannelID string) error {
+	if len(eligible) == 0 {
 		return nil
 	}
-	tupleHolders := make([]string, len(targets))
-	args := []interface{}{targetTypeThread, threadChannelID, targetTypeGroup, groupNo}
-	for i, t := range targets {
-		tupleHolders[i] = "(?, ?)"
-		args = append(args, t.UID, t.SpaceID)
+	tupleHolders := make([]string, len(eligible))
+	args := make([]interface{}, 0, len(eligible)*4)
+	for i, t := range eligible {
+		tupleHolders[i] = "(?, ?, ?, ?)"
+		args = append(args, t.UID, t.SpaceID, targetTypeThread, threadChannelID)
 	}
 	_, err := tx.InsertBySql(
 		"INSERT IGNORE INTO "+table+
-			" (uid, space_id, target_type, target_id)"+
-			" SELECT uid, space_id, ?, ? FROM "+table+
-			" WHERE target_type=? AND target_id=?"+
-			" AND auto_follow_threads=1 AND group_unfollowed=0"+
-			" AND (uid, space_id) IN ("+strings.Join(tupleHolders, ", ")+")"+
-			" ORDER BY uid, space_id",
+			" (uid, space_id, target_type, target_id) VALUES "+
+			strings.Join(tupleHolders, ", "),
 		args...,
 	).Exec()
 	return err

--- a/modules/conversation_ext/service.go
+++ b/modules/conversation_ext/service.go
@@ -26,6 +26,14 @@ const threadSeparator = "____"
 // 调用方（HTTP handler）应将此错误翻译为 403。
 var ErrThreadForbidden = errors.New("thread follow forbidden: not a member of parent group or thread not visible")
 
+// ErrChannelForbidden 在 FollowChannel 鉴权失败时返回。
+// 调用方（HTTP handler）应将此错误翻译为 403。
+//
+// 引入背景（PR #123 round-1 review by Jerry-Xin / yujiawei）：FollowChannel
+// 不再只是 inert 的"清自己的黑名单"，而是会触发 thread ext fanout 订阅 +
+// 物化既有子区，因此必须在写前校验 caller 是该 group 的成员且该群在请求 Space 可见。
+var ErrChannelForbidden = errors.New("channel follow forbidden: not a member of the group or group not visible")
+
 // ErrDMCategoryForbidden 在 FollowDM 指定的 category 不属于当前 uid 或已删除时返回。
 // 调用方应将此错误翻译为 400 / 403（按业务约定）。
 // PR #21 Round-6 (Jerry-Xin)：DM category 必须由服务端校验归属，否则客户端可写入
@@ -44,6 +52,15 @@ var ErrDMCategoryForbidden = errors.New("dm category forbidden: not owned by uid
 // 校验通过返回 nil。基础设施错误（DB 错误等）以 wrap 后的形式向上透传。
 type ThreadAuthChecker interface {
 	AuthorizeThreadFollow(uid, spaceID, groupNo, shortID string) error
+}
+
+// ChannelAuthChecker 判定 FollowChannel 是否被授权。窄接口，与 ThreadAuthChecker
+// 同样采用依赖倒置（避免 conversation_ext 直接 import group），由 message/1module.go
+// 注入实现：调用 group.IService.ExistMember + group.DB 可见性逻辑。
+//
+// 鉴权失败返回 ErrChannelForbidden；基础设施错误以 wrap 后形式上传。
+type ChannelAuthChecker interface {
+	AuthorizeChannelFollow(uid, spaceID, groupNo string) error
 }
 
 // ThreadEnumerator 是 FollowChannel 级联物化子区时使用的窄接口。
@@ -93,6 +110,10 @@ type Service struct {
 	// 由 message/1module.go 启动时注入；nil 时跳过物化。
 	threadEnum  ThreadEnumerator
 	threadEnumM sync.RWMutex
+	// channelAuth 是 FollowChannel 的群成员/可见性鉴权钩子。
+	// 由 message/1module.go 启动时注入；nil 时跳过鉴权（仅供单测 / 迁移期使用）。
+	channelAuth  ChannelAuthChecker
+	channelAuthM sync.RWMutex
 	log.Log
 }
 
@@ -137,6 +158,22 @@ func (s *Service) getThreadEnumerator() ThreadEnumerator {
 	e := s.threadEnum
 	s.threadEnumM.RUnlock()
 	return e
+}
+
+// SetChannelAuthChecker injects the authorizer used by FollowChannel.
+// Safe for concurrent use; intended to be called once at startup from
+// message/1module.go after the group module has initialised.
+func (s *Service) SetChannelAuthChecker(c ChannelAuthChecker) {
+	s.channelAuthM.Lock()
+	s.channelAuth = c
+	s.channelAuthM.Unlock()
+}
+
+func (s *Service) getChannelAuthChecker() ChannelAuthChecker {
+	s.channelAuthM.RLock()
+	c := s.channelAuth
+	s.channelAuthM.RUnlock()
+	return c
 }
 
 // ---------------------------------------------------------------------------
@@ -210,8 +247,9 @@ func escapeLike(s string) string {
 // commit 之间创建的子区会被永久遗漏 —— OnThreadCreated 看不到 auto_follow=1，
 // enumerate 的快照也没拿到该子区。
 //
-// follow_version 在两个 tx 各 +1（合计 +2 在无并发场景下）：单调递增即可，
-// 客户端只需在变化时拉一次 sidebar，多 +1 不影响正确性。
+// follow_version 在 Phase 1 与 Phase 3 各 +1 —— 总次数随路径而定：未注入
+// enumerator / 群下无 active 子区 / Phase 3 re-check 跳过 都让 bump 停在 +1。
+// 关键不变量是 bump 次数与子区数量 N 无关（不会随 N 线性增长），保持小常数。
 //
 // 当未注入 ThreadEnumerator 时（单测 / 迁移期）跳过 Phase 2/3，仅写群行。
 func (s *Service) FollowChannel(uid, spaceID, groupNo string) error {
@@ -220,6 +258,17 @@ func (s *Service) FollowChannel(uid, spaceID, groupNo string) error {
 	}
 	if groupNo == "" {
 		return errors.New("group_no must not be empty")
+	}
+
+	// PR #123 round-1 review (Jerry-Xin / yujiawei P1)：FollowChannel 已不再是
+	// inert 的"清自己黑名单"，会写 auto_follow_threads=1 + 物化既有子区 +
+	// 挂 OnThreadCreated 订阅。必须在任何 DB 写入之前校验 caller 是该 group
+	// 的成员、且该群在请求 Space 可见，否则会泄露同 Space 内私有群的子区元数据。
+	// nil checker 仅用于单测 / 迁移期。
+	if checker := s.getChannelAuthChecker(); checker != nil {
+		if err := checker.AuthorizeChannelFollow(uid, spaceID, groupNo); err != nil {
+			return err
+		}
 	}
 
 	zero := int8(0)
@@ -262,7 +311,20 @@ func (s *Service) FollowChannel(uid, spaceID, groupNo string) error {
 	// Phase 3：bulk INSERT IGNORE thread ext + bump version。INSERT IGNORE 让
 	// 与并发 OnThreadCreated 的重叠安全（同 (uid, target_type=5, target_id)
 	// 由 UK 守护，重复写不会产生第二行）。
+	//
+	// Bug fix B2 (yujiawei P2 / lml2468 round-2 #2)：在 Phase 1 commit 与 Phase 3
+	// 之间用户可能调用 UnfollowChannel，那一刻群行变成 auto_follow=0 + group_unfollowed=1。
+	// Phase 3 必须在同一 tx 内 SELECT ... FOR UPDATE 该群行重新确认状态，发现不再
+	// 资格则跳过整批写入（含 bump），避免重建已被 UnfollowChannel 清掉的孤立 thread 行。
 	return s.withTx("FollowChannel-phase3", func(tx *dbr.Tx) error {
+		eligible, err := isChannelStillAutoFollowedTx(tx, uid, spaceID, groupNo)
+		if err != nil {
+			return fmt.Errorf("FollowChannel phase3 recheck: %w", err)
+		}
+		if !eligible {
+			// 用户已在 Phase 1 与 Phase 3 之间取关；丢弃旧 enumerate 快照，不写任何东西。
+			return nil
+		}
 		if _, err := BumpFollowVersionTx(tx, uid, spaceID); err != nil {
 			return fmt.Errorf("FollowChannel phase3 bump version: %w", err)
 		}
@@ -271,6 +333,33 @@ func (s *Service) FollowChannel(uid, spaceID, groupNo string) error {
 		}
 		return nil
 	})
+}
+
+// isChannelStillAutoFollowedTx 在 tx 内对 (uid, spaceID, target_type=2, groupNo)
+// 取 SELECT ... FOR UPDATE，判断当前是否仍处于"已关注 + 自动跟随子区"状态。
+// 行不存在或两标志中任一不满足都返回 false，让 FollowChannel Phase 3 跳过写入。
+// 锁顺序：本函数应当在 BumpFollowVersionTx 之后调用 —— 群 ext 行的 SELECT
+// FOR UPDATE 不能先于 user_follow_version 的 X 锁，否则与 UpdateSort 反向死锁。
+// 但 Phase 3 实际是先 SELECT 再 bump（bump 只在 eligible 时发生），
+// 这是个例外：Phase 1 已经先锁过 user_follow_version 并 commit，本 tx 重新进入
+// 时 follow_version 行尚未在本 tx 中被锁，并不存在与 UpdateSort 反向交叉的窗口。
+func isChannelStillAutoFollowedTx(tx *dbr.Tx, uid, spaceID, groupNo string) (bool, error) {
+	var row struct {
+		AutoFollow int8 `db:"auto_follow_threads"`
+		Unfollowed int8 `db:"group_unfollowed"`
+	}
+	err := tx.SelectBySql(
+		"SELECT auto_follow_threads, group_unfollowed FROM "+table+
+			" WHERE uid=? AND space_id=? AND target_type=? AND target_id=? FOR UPDATE",
+		uid, spaceID, targetTypeGroup, groupNo,
+	).LoadOne(&row)
+	if err == dbr.ErrNotFound {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return row.AutoFollow == 1 && row.Unfollowed == 0, nil
 }
 
 // bulkInsertIgnoreThreadExtTx 给 (uid, spaceID) 在 user_conversation_ext 表中
@@ -419,10 +508,10 @@ func (s *Service) OnThreadCreated(groupNo, shortID string) error {
 		}
 		batch := targets[start:end]
 		if err := s.withTx("OnThreadCreated", func(tx *dbr.Tx) error {
-			if err := bulkBumpFollowVersionTx(tx, batch); err != nil {
+			if err := bulkBumpFollowVersionTx(tx, batch, groupNo); err != nil {
 				return fmt.Errorf("OnThreadCreated bulk bump version: %w", err)
 			}
-			if err := bulkInsertIgnoreThreadExtForUsersTx(tx, batch, threadChannelID); err != nil {
+			if err := bulkInsertIgnoreThreadExtForUsersTx(tx, batch, groupNo, threadChannelID); err != nil {
 				return fmt.Errorf("OnThreadCreated bulk insert thread ext: %w", err)
 			}
 			return nil
@@ -433,49 +522,66 @@ func (s *Service) OnThreadCreated(groupNo, shortID string) error {
 	return nil
 }
 
-// bulkBumpFollowVersionTx 一次性给一批 (uid, space_id) bump version +1。
-// 行不存在时初始化为 1（与 BumpFollowVersionTx 单行版语义一致）。
-//
-// SQL 用 INSERT ... ON DUPLICATE KEY UPDATE 批量插入若干 (uid, space_id, version=1)
-// 元组：已有行触发 ODKU 把 version 自增；不存在的行新建为 1。
+// onThreadCreatedTarget 是 OnThreadCreated 初始 SELECT 出来的目标 (uid, space_id)。
 type onThreadCreatedTarget = struct {
 	UID     string `db:"uid"`
 	SpaceID string `db:"space_id"`
 }
 
-func bulkBumpFollowVersionTx(tx *dbr.Tx, targets []onThreadCreatedTarget) error {
+// bulkBumpFollowVersionTx 批量给当前仍处于"auto_follow=1 + group_unfollowed=0"
+// 状态的 (uid, space_id) +1 follow_version；不在该状态的目标跳过。
+//
+// Bug fix B2：用 INSERT ... SELECT 内嵌 WHERE 让 re-check 与 write 落在同一条
+// SQL，关闭"初始 SELECT 后用户取关"的 race。SELECT 源是 user_conversation_ext
+// 的群行（target_type=2），这里 ORDER BY (uid, space_id) 让并发 fanout 的行锁
+// 顺序一致（W2，lml2468 round-1）—— 避免两条 OnThreadCreated 不同顺序枚举时
+// 触发 InnoDB 死锁检测器回滚。
+//
+// IN tuple 列表把行集限定在本 batch 内，让单条 SQL 的占位符数受 batchSize 约束。
+func bulkBumpFollowVersionTx(tx *dbr.Tx, targets []onThreadCreatedTarget, groupNo string) error {
 	if len(targets) == 0 {
 		return nil
 	}
-	placeholders := make([]string, len(targets))
-	args := make([]interface{}, 0, len(targets)*3)
+	tupleHolders := make([]string, len(targets))
+	args := []interface{}{targetTypeGroup, groupNo}
 	for i, t := range targets {
-		placeholders[i] = "(?, ?, 1)"
+		tupleHolders[i] = "(?, ?)"
 		args = append(args, t.UID, t.SpaceID)
 	}
 	_, err := tx.InsertBySql(
-		"INSERT INTO "+followVersionTable+" (uid, space_id, version) VALUES "+
-			strings.Join(placeholders, ", ")+
+		"INSERT INTO "+followVersionTable+" (uid, space_id, version)"+
+			" SELECT uid, space_id, 1 FROM "+table+
+			" WHERE target_type=? AND target_id=?"+
+			" AND auto_follow_threads=1 AND group_unfollowed=0"+
+			" AND (uid, space_id) IN ("+strings.Join(tupleHolders, ", ")+")"+
+			" ORDER BY uid, space_id"+
 			" ON DUPLICATE KEY UPDATE version = version + 1",
 		args...,
 	).Exec()
 	return err
 }
 
-func bulkInsertIgnoreThreadExtForUsersTx(tx *dbr.Tx, targets []onThreadCreatedTarget, threadChannelID string) error {
+// bulkInsertIgnoreThreadExtForUsersTx 给本 batch 内当前仍 auto_follow=1 +
+// group_unfollowed=0 的 (uid, space_id) 写入 target_type=5 的 thread ext 行。
+// Re-check 内嵌在 SELECT WHERE 里 —— 同 bulkBumpFollowVersionTx 关闭 B2 race。
+func bulkInsertIgnoreThreadExtForUsersTx(tx *dbr.Tx, targets []onThreadCreatedTarget, groupNo, threadChannelID string) error {
 	if len(targets) == 0 {
 		return nil
 	}
-	placeholders := make([]string, len(targets))
-	args := make([]interface{}, 0, len(targets)*4)
+	tupleHolders := make([]string, len(targets))
+	args := []interface{}{targetTypeThread, threadChannelID, targetTypeGroup, groupNo}
 	for i, t := range targets {
-		placeholders[i] = "(?, ?, ?, ?)"
-		args = append(args, t.UID, t.SpaceID, targetTypeThread, threadChannelID)
+		tupleHolders[i] = "(?, ?)"
+		args = append(args, t.UID, t.SpaceID)
 	}
 	_, err := tx.InsertBySql(
 		"INSERT IGNORE INTO "+table+
-			" (uid, space_id, target_type, target_id) VALUES "+
-			strings.Join(placeholders, ", "),
+			" (uid, space_id, target_type, target_id)"+
+			" SELECT uid, space_id, ?, ? FROM "+table+
+			" WHERE target_type=? AND target_id=?"+
+			" AND auto_follow_threads=1 AND group_unfollowed=0"+
+			" AND (uid, space_id) IN ("+strings.Join(tupleHolders, ", ")+")"+
+			" ORDER BY uid, space_id",
 		args...,
 	).Exec()
 	return err

--- a/modules/conversation_ext/service.go
+++ b/modules/conversation_ext/service.go
@@ -64,6 +64,14 @@ type ThreadEnumerator interface {
 // + 后续 OnThreadCreated fanout 持续补齐。
 const maxAutoFollowThreadsPerChannel = 500
 
+// onThreadCreatedBatchSize 是 OnThreadCreated 给 follower 做 fanout 时单个 SQL
+// 处理的最大 (uid, space_id) 数量。MySQL prepared statement 占位符上限是
+// 65,535，本 fanout 单行 bulk INSERT IGNORE 用 4 个占位符 / bulk version bump
+// 用 3 个占位符。1000 留出充分余量同时让单 tx 锁窗口可控：N=10k follower 时
+// 按 10 个 tx 跑，每 tx 仅持锁 ~20ms 数量级。
+// var 而非 const 是为了让测试压到一个小值以低成本覆盖分批分支。
+var onThreadCreatedBatchSize = 1000
+
 // Service encapsulates composite operations on user_conversation_ext that
 // require a single transaction boundary.  It intentionally avoids importing
 // modules/group, modules/user, or modules/thread to prevent circular
@@ -178,18 +186,34 @@ func escapeLike(s string) string {
 // ---------------------------------------------------------------------------
 
 // FollowChannel marks the group as followed (group_unfollowed=0,
-// auto_follow_threads=1) and, in the same transaction, materializes thread
-// ext rows for up to maxAutoFollowThreadsPerChannel currently-active threads
-// under the channel.
+// auto_follow_threads=1) and materializes thread ext rows for up to
+// maxAutoFollowThreadsPerChannel currently-active threads under the channel.
 //
-// PR review (Round 3) Blocking #1/#2 — 关注状态变化时把 user_follow_version +1。
-// Upsert / Bump / fanout 在同一 tx 内执行，这样客户端只要观察 follow_version
-// 就能可靠检测到变化（即使物化了 N 个子区也只 +1，因为它是 user-level 单调序列）。
+// 两阶段提交（bug fix #2 race window）：
 //
-// 子区物化采用 INSERT IGNORE — 不覆盖用户既有的手动 follow_sort，新行 follow_sort
-// 保持默认 0 由客户端按"父 channel 之后聚拢渲染"规则决定位置。
+//  1. Phase 1 (tx)  ：bump follow_version + upsert 群行 (group_unfollowed=0,
+//     auto_follow_threads=1)，commit。auto_follow=1 一旦可见，并发新建的子区在
+//     thread.Service post-commit hook 中触发的 OnThreadCreated 会把本用户当作
+//     fanout 目标 ——── 这条 invariant 是覆盖 race window 的核心。
 //
-// 当未注入 ThreadEnumerator 时（单测 / 迁移期）跳过物化，仅写群行。
+//  2. Phase 2 (无 tx)：enumerate 当前 active 子区。在 Phase 1 commit 之后
+//     做这一步，意味着任意在 Phase 1 commit 之前已存在的子区都会进入快照；
+//     任意在快照之后才创建的子区则由 Phase 1 commit 后的 OnThreadCreated 兜底。
+//     两条路径合起来无遗漏；INSERT IGNORE 让任何重叠（同子区被两条路径都写）
+//     安全降为 no-op。
+//
+//  3. Phase 3 (tx)  ：bump follow_version + bulk INSERT IGNORE thread ext 行。
+//     失败时记日志但保留 Phase 1 的写入 —— 客户端会感知到 version bump 而触发
+//     重拉；missing 子区在下次 FollowChannel 或新子区 fanout 时补齐。
+//
+// 旧实现的 bug：enumerate 在 tx 外、auto_follow=1 写入之前；在 enumerate 与
+// commit 之间创建的子区会被永久遗漏 —— OnThreadCreated 看不到 auto_follow=1，
+// enumerate 的快照也没拿到该子区。
+//
+// follow_version 在两个 tx 各 +1（合计 +2 在无并发场景下）：单调递增即可，
+// 客户端只需在变化时拉一次 sidebar，多 +1 不影响正确性。
+//
+// 当未注入 ThreadEnumerator 时（单测 / 迁移期）跳过 Phase 2/3，仅写群行。
 func (s *Service) FollowChannel(uid, spaceID, groupNo string) error {
 	if err := validateBase(uid, spaceID); err != nil {
 		return err
@@ -198,37 +222,52 @@ func (s *Service) FollowChannel(uid, spaceID, groupNo string) error {
 		return errors.New("group_no must not be empty")
 	}
 
-	// 先在 tx 外把活跃子区 shortID 拉出来 —— 把潜在的跨表 / 大查询挪到事务外，
-	// 缩短 ext 行锁 + follow_version 行锁的持有时间。
-	var shortIDs []string
-	if enum := s.getThreadEnumerator(); enum != nil {
-		ids, err := enum.EnumerateActiveShortIDs(groupNo, maxAutoFollowThreadsPerChannel)
-		if err != nil {
-			return fmt.Errorf("FollowChannel enumerate threads: %w", err)
-		}
-		shortIDs = ids
-	}
-
 	zero := int8(0)
 	one := int8(1)
-	// PR #21 review (lml2468 blocker #2)：所有同时触及 user_follow_version 与
-	// user_conversation_ext 的事务必须按相同顺序拿锁。把 Bump 放在最前 ——
-	// 它通过 ON DUPLICATE KEY UPDATE 对 user_follow_version (uid, space_id)
-	// 行加 X 锁，使本 tx 在 version 行上有排它后再进入 ext 行操作。
-	return s.withTx("FollowChannel", func(tx *dbr.Tx) error {
+
+	// Phase 1：commit auto_follow=1 + group_unfollowed=0 + bump version。
+	// PR #21 review (lml2468 blocker #2)：先锁 follow_version 行再写 ext，与
+	// UpdateSort 同序拿锁，避免 (version vs ext) 反向死锁。
+	if err := s.withTx("FollowChannel-phase1", func(tx *dbr.Tx) error {
 		if _, err := BumpFollowVersionTx(tx, uid, spaceID); err != nil {
-			return fmt.Errorf("FollowChannel bump version: %w", err)
+			return fmt.Errorf("FollowChannel phase1 bump version: %w", err)
 		}
 		if err := upsertTx(tx, uid, spaceID, targetTypeGroup, groupNo, ConvExtFields{
 			GroupUnfollowed:   &zero,
 			AutoFollowThreads: &one,
 		}); err != nil {
-			return fmt.Errorf("FollowChannel upsert: %w", err)
+			return fmt.Errorf("FollowChannel phase1 upsert: %w", err)
 		}
-		if len(shortIDs) > 0 {
-			if err := bulkInsertIgnoreThreadExtTx(tx, uid, spaceID, groupNo, shortIDs); err != nil {
-				return fmt.Errorf("FollowChannel materialize threads: %w", err)
-			}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	enum := s.getThreadEnumerator()
+	if enum == nil {
+		return nil
+	}
+
+	// Phase 2：在 Phase 1 commit 之后枚举 —— race-window 已被关闭。
+	shortIDs, err := enum.EnumerateActiveShortIDs(groupNo, maxAutoFollowThreadsPerChannel)
+	if err != nil {
+		// Phase 1 已经 commit；client 仍能观察到 auto_follow=1 + 后续新子区 fanout，
+		// 只是初始批的子区未物化。错误向上返回让调用方记录，但不回滚 Phase 1。
+		return fmt.Errorf("FollowChannel enumerate threads: %w", err)
+	}
+	if len(shortIDs) == 0 {
+		return nil
+	}
+
+	// Phase 3：bulk INSERT IGNORE thread ext + bump version。INSERT IGNORE 让
+	// 与并发 OnThreadCreated 的重叠安全（同 (uid, target_type=5, target_id)
+	// 由 UK 守护，重复写不会产生第二行）。
+	return s.withTx("FollowChannel-phase3", func(tx *dbr.Tx) error {
+		if _, err := BumpFollowVersionTx(tx, uid, spaceID); err != nil {
+			return fmt.Errorf("FollowChannel phase3 bump version: %w", err)
+		}
+		if err := bulkInsertIgnoreThreadExtTx(tx, uid, spaceID, groupNo, shortIDs); err != nil {
+			return fmt.Errorf("FollowChannel phase3 materialize threads: %w", err)
 		}
 		return nil
 	})
@@ -359,22 +398,39 @@ func (s *Service) OnThreadCreated(groupNo, shortID string) error {
 
 	threadChannelID := groupNo + threadSeparator + shortID
 
-	// 2. 单 tx 内批量化两次写：一次性 bump N 个 (uid, space_id) 的 version，
-	//    一次性 INSERT IGNORE N 个 thread ext 行。
+	// 2. 按 batch 切分，每 batch 一个 tx：
+	//    - 单 tx 内仍批量化两条 SQL（bulk bump version + bulk INSERT IGNORE），
+	//      避免 per-user round-trip 的 O(N) 延迟。
+	//    - batch 之间换 tx 防止两件事：
+	//      (a) 单 tx 持锁窗口随 N 线性增长拖慢其它 follow 操作；
+	//      (b) bug fix #3 —— 单 SQL 占位符数超过 MySQL 65,535 上限。
+	//    - INSERT IGNORE + version 单调递增 让"前一 batch 已 commit、后一 batch
+	//      失败"的 partial-success 状态可恢复：下次 FollowChannel / 新建子区
+	//      fanout 会把缺失的用户补齐。
 	//    锁顺序仍是 follow_version 先于 ext —— 与 FollowChannel / UpdateSort 一致。
-	//
-	//    为何不走 per-user loop：在 N=10000 用户的基准下，逐行 BumpFollowVersionTx
-	//    + InsertBySql 要 2*N 个 round-trip（~3.4s）。批量化两条 SQL 后 N=10000
-	//    降到一位数 ms（实测见 bench）。
-	return s.withTx("OnThreadCreated", func(tx *dbr.Tx) error {
-		if err := bulkBumpFollowVersionTx(tx, targets); err != nil {
-			return fmt.Errorf("OnThreadCreated bulk bump version: %w", err)
+	batchSize := onThreadCreatedBatchSize
+	if batchSize <= 0 {
+		batchSize = 1000
+	}
+	for start := 0; start < len(targets); start += batchSize {
+		end := start + batchSize
+		if end > len(targets) {
+			end = len(targets)
 		}
-		if err := bulkInsertIgnoreThreadExtForUsersTx(tx, targets, threadChannelID); err != nil {
-			return fmt.Errorf("OnThreadCreated bulk insert thread ext: %w", err)
+		batch := targets[start:end]
+		if err := s.withTx("OnThreadCreated", func(tx *dbr.Tx) error {
+			if err := bulkBumpFollowVersionTx(tx, batch); err != nil {
+				return fmt.Errorf("OnThreadCreated bulk bump version: %w", err)
+			}
+			if err := bulkInsertIgnoreThreadExtForUsersTx(tx, batch, threadChannelID); err != nil {
+				return fmt.Errorf("OnThreadCreated bulk insert thread ext: %w", err)
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("OnThreadCreated batch [%d,%d): %w", start, end, err)
 		}
-		return nil
-	})
+	}
+	return nil
 }
 
 // bulkBumpFollowVersionTx 一次性给一批 (uid, space_id) bump version +1。

--- a/modules/conversation_ext/service.go
+++ b/modules/conversation_ext/service.go
@@ -389,6 +389,10 @@ func isChannelStillAutoFollowedTx(tx *dbr.Tx, uid, spaceID, groupNo string) (boo
 // 批量插入 target_type=5 子区行。已存在的行（含用户手动调过 follow_sort 的）
 // 因 INSERT IGNORE 保持不变 —— 这是 FollowChannel 既不覆盖用户既有排序也能
 // 一次性补齐缺失行的关键。
+//
+// 返回的是 *dbr/MySQL 原始错误（yujiawei round-5 nit）；调用方负责加 op 上下文
+// wrap（当前唯一调用方 FollowChannel Phase 3 包成 "FollowChannel phase3
+// materialize threads: %w"），与文件内其它 *Tx helper 的约定一致。
 func bulkInsertThreadExtForChannelMaterializeTx(tx *dbr.Tx, uid, spaceID, groupNo string, shortIDs []string) error {
 	if len(shortIDs) == 0 {
 		return nil
@@ -497,6 +501,14 @@ func (s *Service) OnThreadCreated(groupNo, shortID string) error {
 	// 1. 在 tx 外把目标 (uid, space_id) 列表读出 —— 跨 N 用户的 SELECT 不参与 tx 锁。
 	//    ORDER BY uid, space_id 让本 batch 内（以及并发 fanout 之间）按统一顺序
 	//    取行锁，减少死锁概率；真正死锁兜底走下面的 withDeadlockRetry。
+	//
+	//    快照语义（yujiawei round-5 nit）：本 SELECT 在 autocommit 下运行，得到的是
+	//    "调用时刻"的近似集合，会出现以下时序：
+	//      - 这里查到了某用户，但在 selectEligibleForFanoutTx 之前他刚 UnfollowChannel
+	//        → 资格 re-check 把他过滤掉，最终不写 thread 行（正确）；
+	//      - 这里没查到某用户，但他在我们 commit 之前刚 FollowChannel
+	//        → 本次 fanout 漏掉他，由 FollowChannel Phase 3 物化兜底或下一条新子区补齐。
+	//    这两类窗口都是 expected，调用方无需感知。
 	var targets []onThreadCreatedTarget
 	_, err := s.session.SelectBySql(
 		"SELECT uid, space_id FROM "+table+
@@ -653,6 +665,13 @@ func bulkBumpFollowVersionTx(tx *dbr.Tx, targets []onThreadCreatedTarget) error 
 // ORDER BY uid, space_id 在 mysql 8 上让本 SELECT 与同序的 INSERT VALUES 在
 // 测试观察中表现一致的加锁顺序；不是严格规范保证（详见
 // https://dev.mysql.com/doc/refman/8.0/en/innodb-locks-set.html），上层 retry 兜底。
+//
+// 实际锁范围说明（yujiawei round-5 nit）：FOR UPDATE 走 idx_channel_auto_follow，
+// 在 InnoDB next-key lock 语义下加锁谓词等价于整条
+// (target_type, target_id, auto_follow_threads=1) 范围，而非 IN (…) 中字面列出的
+// (uid, space_id) 集合。这意味着同一群的两个并发 OnThreadCreated batch 会在
+// 此处串行化（即便 IN 集合不相交）—— fanout 单群吞吐受这一锁竞争上限制约，
+// 上线后若 fanout 失败 metric 显著上涨需要先排查这里的并发度。
 func selectEligibleForFanoutTx(tx *dbr.Tx, targets []onThreadCreatedTarget, groupNo string) ([]onThreadCreatedTarget, error) {
 	if len(targets) == 0 {
 		return nil, nil

--- a/modules/conversation_ext/service_test.go
+++ b/modules/conversation_ext/service_test.go
@@ -322,8 +322,64 @@ func TestService_FollowChannel_VersionBumpedOnce(t *testing.T) {
 	require.NoError(t, svc.FollowChannel(uid, space, grp))
 
 	v := readFollowVersion(t, svc, uid, space)
-	assert.Equal(t, int64(1), v,
-		"FollowChannel 即便物化 N 个子区，也只应 bump follow_version 一次（user-level 单调序列）")
+	// Bug fix #2 后 FollowChannel 拆 phase1/phase3 两次 commit，各 bump 一次 ——
+	// 关键不变量是 bump 次数与子区数量 N 无关（不会出现 "1 + N"），保持小常数即可。
+	assert.LessOrEqual(t, v, int64(2),
+		"FollowChannel 物化 N 个子区，bump follow_version 的次数应为小常数（2 次），不与 N 成比例")
+	assert.GreaterOrEqual(t, v, int64(1), "follow_version 至少 +1")
+}
+
+// observingEnumerator 是 race-window 测试用的桩：每次 EnumerateActiveShortIDs
+// 被调用时回调一次 observe，让测试观察"FollowChannel 走到 enumerate 步骤时数据库的状态"。
+type observingEnumerator struct {
+	groups  map[string][]string
+	observe func(groupNo string)
+}
+
+func (o *observingEnumerator) EnumerateActiveShortIDs(groupNo string, limit int) ([]string, error) {
+	if o.observe != nil {
+		o.observe(groupNo)
+	}
+	ids := o.groups[groupNo]
+	if limit > 0 && len(ids) > limit {
+		ids = ids[:limit]
+	}
+	return ids, nil
+}
+
+func TestService_FollowChannel_AutoFollowCommittedBeforeEnumeration(t *testing.T) {
+	// Bug fix #2: 在 FollowChannel enumerate active 子区之前，
+	// auto_follow_threads=1 必须已经提交可见。否则在 enumerate 与 FollowChannel 提交
+	// 之间新建的子区，OnThreadCreated 看不到本用户的 auto_follow=1 而漏发，
+	// 同时 enumerate 的旧快照也不含该子区，导致永久遗漏。
+	//
+	// 通过观察 enumerate 调用时刻 svc.db.Get（独立连接，只看 committed 状态）
+	// 返回的群行是否已有 auto_follow_threads=1 来锁住这个不变量。
+	svc := newServiceForTest(t)
+	const uid, space, grp = "u-race-fc", "s-race", "grp-race-fc"
+
+	enum := &observingEnumerator{
+		groups: map[string][]string{grp: {"t1", "t2"}},
+		observe: func(g string) {
+			row, err := svc.db.Get(uid, space, targetTypeGroup, g)
+			require.NoError(t, err)
+			require.NotNil(t, row, "auto_follow=1 必须已 commit 才可以 enumerate；"+
+				"否则并发新建子区的 OnThreadCreated 看不到本用户而漏 fanout")
+			assert.Equal(t, int8(1), row.AutoFollowThreads,
+				"auto_follow_threads 应在 enumerate 之前 commit；当前未 commit 意味着 "+
+					"FollowChannel 与并发 OnThreadCreated 之间存在丢子区竞态")
+		},
+	}
+	svc.SetThreadEnumerator(enum)
+
+	require.NoError(t, svc.FollowChannel(uid, space, grp))
+
+	// 二段提交后两个 thread 行都应存在。
+	for _, sid := range []string{"t1", "t2"} {
+		row, err := svc.db.Get(uid, space, targetTypeThread, grp+threadSeparator+sid)
+		require.NoError(t, err)
+		assert.NotNil(t, row)
+	}
 }
 
 func TestService_FollowChannel_PreservesExistingThreadSort(t *testing.T) {
@@ -437,6 +493,43 @@ func TestService_OnThreadCreated_Idempotent_PreservesExistingRow(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, row)
 	assert.Equal(t, 88, row.FollowSort, "已存在的 thread 行（含手动排序）必须保留，INSERT IGNORE 不应覆盖")
+}
+
+func TestService_OnThreadCreated_ChunksLargeTargetList(t *testing.T) {
+	// Bug fix #3: 当 channel 的 auto_follow follower 数量超过单条 SQL 的占位符上限
+	// （MySQL 65535 / 4 ≈ 16k），整批写会被驱动直接报错并整体失败。
+	// 本测试通过把 batch 大小压到 5、放 13 个 follower（不能被整除 → 3 个 batch：
+	// 5+5+3）来验证分批逻辑：每个目标用户都应拿到 ext 行 + version +1。
+	original := onThreadCreatedBatchSize
+	onThreadCreatedBatchSize = 5
+	defer func() { onThreadCreatedBatchSize = original }()
+
+	svc := newServiceForTest(t)
+	const space, grp, shortID = "s-batch", "grp-batch", "thr-batch"
+	const numUsers = 13
+
+	one := int8(1)
+	zero := int8(0)
+	for i := 0; i < numUsers; i++ {
+		uid := "u-batch-" + intToStrAFT(i)
+		require.NoError(t, svc.db.Upsert(uid, space, targetTypeGroup, grp, ConvExtFields{
+			GroupUnfollowed:   &zero,
+			AutoFollowThreads: &one,
+		}))
+	}
+
+	require.NoError(t, svc.OnThreadCreated(grp, shortID))
+
+	channelID := grp + threadSeparator + shortID
+	for i := 0; i < numUsers; i++ {
+		uid := "u-batch-" + intToStrAFT(i)
+		row, err := svc.db.Get(uid, space, targetTypeThread, channelID)
+		require.NoError(t, err)
+		assert.NotNil(t, row, "user %s 应在跨 batch fanout 中拿到 thread ext 行", uid)
+		v := readFollowVersion(t, svc, uid, space)
+		assert.Equal(t, int64(1), v,
+			"跨 batch fanout：user %s 的 follow_version 应 +1（每用户每次 fanout 单调一次）", uid)
+	}
 }
 
 func TestService_OnThreadCreated_InvalidInput(t *testing.T) {

--- a/modules/conversation_ext/service_test.go
+++ b/modules/conversation_ext/service_test.go
@@ -356,6 +356,97 @@ func TestService_FollowChannel_PreservesExistingThreadSort(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// OnThreadCreated fanout — synchronous hook called by modules/thread on new thread
+// ---------------------------------------------------------------------------
+
+func TestService_OnThreadCreated_MaterializesForAutoFollowUsers(t *testing.T) {
+	svc := newServiceForTest(t)
+	const space, grp, shortID = "s1", "grp-ofc-1", "thr-new"
+	channelID := grp + threadSeparator + shortID
+
+	// A：开启 auto_follow_threads（关注了 channel）
+	require.NoError(t, svc.FollowChannel("uA", space, grp))
+	// B：关注过群但显式取关 —— UnfollowChannel 已经把 auto_follow_threads 清零
+	require.NoError(t, svc.UnfollowChannel("uB", space, grp))
+	// C：从未操作过该 channel，user_conversation_ext 中无该群行
+	// （不写任何行）
+
+	// Action
+	require.NoError(t, svc.OnThreadCreated(grp, shortID))
+
+	// 只有 A 拿到新的 thread ext 行
+	rowA, err := svc.db.Get("uA", space, targetTypeThread, channelID)
+	require.NoError(t, err)
+	assert.NotNil(t, rowA, "auto_follow_threads=1 的用户应被 fanout 物化 thread 行")
+
+	rowB, err := svc.db.Get("uB", space, targetTypeThread, channelID)
+	require.NoError(t, err)
+	assert.Nil(t, rowB, "已取消关注 channel 的用户不应被 fanout 触及")
+
+	rowC, err := svc.db.Get("uC", space, targetTypeThread, channelID)
+	require.NoError(t, err)
+	assert.Nil(t, rowC, "从未关注 channel 的用户不应被 fanout 触及")
+}
+
+func TestService_OnThreadCreated_BumpsVersionOnlyForTargetUsers(t *testing.T) {
+	svc := newServiceForTest(t)
+	const space, grp, shortID = "s1", "grp-ofc-2", "thr-v"
+
+	require.NoError(t, svc.FollowChannel("uA", space, grp))
+	require.NoError(t, svc.UnfollowChannel("uB", space, grp))
+
+	versionABefore := readFollowVersion(t, svc, "uA", space)
+	versionBBefore := readFollowVersion(t, svc, "uB", space)
+
+	require.NoError(t, svc.OnThreadCreated(grp, shortID))
+
+	versionAAfter := readFollowVersion(t, svc, "uA", space)
+	versionBAfter := readFollowVersion(t, svc, "uB", space)
+
+	assert.Equal(t, versionABefore+1, versionAAfter, "A 的 follow_version 应 +1")
+	assert.Equal(t, versionBBefore, versionBAfter, "B 的 follow_version 不应被 fanout 触及")
+}
+
+func TestService_OnThreadCreated_NoAutoFollowUsers_NoOp(t *testing.T) {
+	svc := newServiceForTest(t)
+	const space, grp, shortID = "s1", "grp-ofc-3", "thr-noop"
+
+	// 没有任何用户开启 auto_follow_threads —— OnThreadCreated 应安静返回。
+	require.NoError(t, svc.OnThreadCreated(grp, shortID))
+
+	// 表里没有该子区的行。
+	rows, err := svc.db.ListThreadExts("any-uid", space)
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+func TestService_OnThreadCreated_Idempotent_PreservesExistingRow(t *testing.T) {
+	svc := newServiceForTest(t)
+	const space, grp, shortID = "s1", "grp-ofc-4", "thr-dup"
+	channelID := grp + threadSeparator + shortID
+
+	require.NoError(t, svc.FollowChannel("uA", space, grp))
+	// uA 已手动给该 thread 拖到 sort=88
+	require.NoError(t, svc.db.Upsert("uA", space, targetTypeThread, channelID, ConvExtFields{
+		FollowSort: intPtr(88),
+	}))
+
+	require.NoError(t, svc.OnThreadCreated(grp, shortID))
+
+	row, err := svc.db.Get("uA", space, targetTypeThread, channelID)
+	require.NoError(t, err)
+	require.NotNil(t, row)
+	assert.Equal(t, 88, row.FollowSort, "已存在的 thread 行（含手动排序）必须保留，INSERT IGNORE 不应覆盖")
+}
+
+func TestService_OnThreadCreated_InvalidInput(t *testing.T) {
+	svc := newServiceForTest(t)
+
+	require.Error(t, svc.OnThreadCreated("", "thr"))
+	require.Error(t, svc.OnThreadCreated("grp", ""))
+}
+
+// ---------------------------------------------------------------------------
 // UnfollowChannel happy path + cascade
 // ---------------------------------------------------------------------------
 

--- a/modules/conversation_ext/service_test.go
+++ b/modules/conversation_ext/service_test.go
@@ -347,6 +347,60 @@ func (o *observingEnumerator) EnumerateActiveShortIDs(groupNo string, limit int)
 	return ids, nil
 }
 
+// stubChannelAuthChecker 是 service_test 用的 ChannelAuthChecker 桩：
+//   - 当 (uid, spaceID, groupNo) 在 denied map 中时返回 ErrChannelForbidden；
+//   - 否则返回 nil。
+type stubChannelAuthChecker struct {
+	denied map[string]bool
+}
+
+func (s *stubChannelAuthChecker) AuthorizeChannelFollow(uid, spaceID, groupNo string) error {
+	if s.denied[uid+"|"+spaceID+"|"+groupNo] {
+		return ErrChannelForbidden
+	}
+	return nil
+}
+
+func TestService_FollowChannel_RejectsUnauthorized(t *testing.T) {
+	// Bug fix B1: FollowChannel 现在会写 auto_follow_threads=1 + 物化最多 500 个 thread 行，
+	// 并把该用户挂上 OnThreadCreated fanout 订阅。必须在写之前过 ChannelAuthChecker，
+	// 否则同 Space 内非该群成员可以抓取私有群子区元数据。
+	svc := newServiceForTest(t)
+	const uid, space, grp = "u-not-member", "s1", "grp-private"
+
+	checker := &stubChannelAuthChecker{denied: map[string]bool{
+		uid + "|" + space + "|" + grp: true,
+	}}
+	svc.SetChannelAuthChecker(checker)
+
+	err := svc.FollowChannel(uid, space, grp)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrChannelForbidden, "非成员调用应返回 ErrChannelForbidden")
+
+	// 关键：必须没有任何写入发生（auto_follow=1 + thread 行都不能落库）。
+	row, err := svc.db.Get(uid, space, targetTypeGroup, grp)
+	require.NoError(t, err)
+	assert.Nil(t, row, "鉴权失败时不应写群行")
+
+	v := readFollowVersion(t, svc, uid, space)
+	assert.Equal(t, int64(0), v, "鉴权失败时不应 bump follow_version")
+}
+
+func TestService_FollowChannel_AllowsAuthorized(t *testing.T) {
+	svc := newServiceForTest(t)
+	const uid, space, grp = "u-member", "s1", "grp-ok"
+
+	checker := &stubChannelAuthChecker{denied: nil}
+	svc.SetChannelAuthChecker(checker)
+
+	require.NoError(t, svc.FollowChannel(uid, space, grp))
+
+	row, err := svc.db.Get(uid, space, targetTypeGroup, grp)
+	require.NoError(t, err)
+	require.NotNil(t, row)
+	assert.Equal(t, int8(1), row.AutoFollowThreads)
+}
+
 func TestService_FollowChannel_AutoFollowCommittedBeforeEnumeration(t *testing.T) {
 	// Bug fix #2: 在 FollowChannel enumerate active 子区之前，
 	// auto_follow_threads=1 必须已经提交可见。否则在 enumerate 与 FollowChannel 提交
@@ -380,6 +434,91 @@ func TestService_FollowChannel_AutoFollowCommittedBeforeEnumeration(t *testing.T
 		require.NoError(t, err)
 		assert.NotNil(t, row)
 	}
+}
+
+func TestService_FollowChannel_Phase3RechecksEligibility(t *testing.T) {
+	// Bug fix B2 (yujiawei P2 / lml2468 round-2 #2): FollowChannel Phase 1 commit 后，
+	// 若用户在 Phase 2 enumerate 期间或之间调用 UnfollowChannel，Phase 3 不能再把
+	// thread 行 INSERT IGNORE 回来 —— 否则会出现"group_unfollowed=1 + auto_follow=0
+	// 但残留 thread ext 行"的孤立状态。
+	//
+	// 复现路径：使用 observingEnumerator 在 enumerate 中同步调用 UnfollowChannel
+	// 来等价模拟 Phase 1 commit 之后、Phase 3 写入之前的并发取关。
+	svc := newServiceForTest(t)
+	const uid, space, grp = "u-race-phase3", "s-race", "grp-race-phase3"
+
+	enum := &observingEnumerator{
+		groups: map[string][]string{grp: {"t1", "t2", "t3"}},
+		observe: func(g string) {
+			// 在 Phase 1 commit 之后、Phase 3 写入之前，同步取关该 channel。
+			require.NoError(t, svc.UnfollowChannel(uid, space, g))
+		},
+	}
+	svc.SetThreadEnumerator(enum)
+
+	require.NoError(t, svc.FollowChannel(uid, space, grp))
+
+	// 最终状态应是"已取关 channel" —— group_unfollowed=1, auto_follow_threads=0。
+	row, err := svc.db.Get(uid, space, targetTypeGroup, grp)
+	require.NoError(t, err)
+	require.NotNil(t, row)
+	assert.Equal(t, int8(1), row.GroupUnfollowed)
+	assert.Equal(t, int8(0), row.AutoFollowThreads)
+
+	// 不允许任何 thread ext 行残留（违反"取消关注 = 不再有 thread 行"语义）。
+	for _, sid := range []string{"t1", "t2", "t3"} {
+		threadRow, err := svc.db.Get(uid, space, targetTypeThread, grp+threadSeparator+sid)
+		require.NoError(t, err)
+		assert.Nil(t, threadRow,
+			"Phase 3 应在 tx 内 re-check auto_follow=1 + group_unfollowed=0；"+
+				"用户在 Phase 1 commit 后已取关，thread %s 不应被 Phase 3 重建", sid)
+	}
+}
+
+func TestService_OnThreadCreated_SkipsConcurrentlyUnfollowedUsers(t *testing.T) {
+	// Bug fix B2: bulk INSERT 必须在写入瞬间 re-check 每个目标用户当前的
+	// auto_follow_threads / group_unfollowed 状态，过滤掉在初始 SELECT 之后取关
+	// 的用户。否则会给已取关用户重建 thread 行。
+	//
+	// 直接测试方式：构造 DB 状态使 targets 列表既包含 eligible 也包含 ineligible
+	// 用户，并校验 INSERT 只对 eligible 行落库（同 SQL re-check 才能做到）。
+	svc := newServiceForTest(t)
+	const space, grp, shortID = "s-recheck", "grp-recheck", "thr-recheck"
+	channelID := grp + threadSeparator + shortID
+
+	one := int8(1)
+	zero := int8(0)
+
+	// uEligible: auto_follow=1, group_unfollowed=0 —— OnThreadCreated 应给他写。
+	require.NoError(t, svc.db.Upsert("uEligible", space, targetTypeGroup, grp, ConvExtFields{
+		AutoFollowThreads: &one,
+		GroupUnfollowed:   &zero,
+	}))
+	// uUnfollowed: auto_follow=0, group_unfollowed=1 —— 不能给他写。
+	require.NoError(t, svc.db.Upsert("uUnfollowed", space, targetTypeGroup, grp, ConvExtFields{
+		AutoFollowThreads: &zero,
+		GroupUnfollowed:   &one,
+	}))
+	// uPartial: auto_follow=1 但 group_unfollowed=1 —— 状态不一致（理论上不该出现，
+	// 防御性测试），按"取消关注"语义不应被 fanout。
+	require.NoError(t, svc.db.Upsert("uPartial", space, targetTypeGroup, grp, ConvExtFields{
+		AutoFollowThreads: &one,
+		GroupUnfollowed:   &one,
+	}))
+
+	require.NoError(t, svc.OnThreadCreated(grp, shortID))
+
+	eligibleRow, err := svc.db.Get("uEligible", space, targetTypeThread, channelID)
+	require.NoError(t, err)
+	assert.NotNil(t, eligibleRow, "uEligible 应被 fanout")
+
+	unfollowedRow, err := svc.db.Get("uUnfollowed", space, targetTypeThread, channelID)
+	require.NoError(t, err)
+	assert.Nil(t, unfollowedRow, "uUnfollowed 不应被 fanout（auto_follow=0）")
+
+	partialRow, err := svc.db.Get("uPartial", space, targetTypeThread, channelID)
+	require.NoError(t, err)
+	assert.Nil(t, partialRow, "uPartial 不应被 fanout（group_unfollowed=1 即便 auto_follow=1）")
 }
 
 func TestService_FollowChannel_PreservesExistingThreadSort(t *testing.T) {

--- a/modules/conversation_ext/service_test.go
+++ b/modules/conversation_ext/service_test.go
@@ -4,12 +4,32 @@ package conversation_ext
 
 import (
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// intToStrAFT 短手包装 strconv.Itoa，仅供 auto_follow_threads 测试块内使用。
+func intToStrAFT(i int) string { return strconv.Itoa(i) }
+
+// readFollowVersion 直接读 user_follow_version 行的值（行不存在返回 0）。
+// 在 svc 上读，复用同一个 *dbr.Session，避免再开 ctx。
+func readFollowVersion(t *testing.T, svc *Service, uid, spaceID string) int64 {
+	t.Helper()
+	var v int64
+	err := svc.session.SelectBySql(
+		"SELECT version FROM "+followVersionTable+" WHERE uid=? AND space_id=?",
+		uid, spaceID,
+	).LoadOne(&v)
+	if err != nil {
+		// 行不存在时 dbr.ErrNotFound — 视为 0。
+		return 0
+	}
+	return v
+}
 
 // newServiceForTest creates a Service connected to the test MySQL instance and
 // wipes the table so every test starts from a clean slate.
@@ -26,6 +46,11 @@ func newServiceForTest(t *testing.T) *Service {
 	ctx := config.NewContext(cfg)
 	_, err := ctx.DB().DeleteFrom(table).Exec()
 	require.NoError(t, err, "clean "+table+" before service test")
+	// 同时清 follow_version 行 —— 否则前一个测试留下的 (uid, space_id, version=N)
+	// 让本测试的 FollowChannel bump 后 version 不再是 1，断言会假报失败。
+	// 与 newDBForTest 行为对齐。
+	_, err = ctx.DB().DeleteFrom(followVersionTable).Exec()
+	require.NoError(t, err, "clean "+followVersionTable+" before service test")
 	return NewService(ctx)
 }
 
@@ -184,6 +209,153 @@ func TestService_FollowChannel_NoExistingRow_CreatesRow(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// FollowChannel cascade: auto_follow_threads + ThreadEnumerator
+// ---------------------------------------------------------------------------
+
+// stubThreadEnumerator 是 service_test 内用的 ThreadEnumerator 桩实现：
+//   - groups[groupNo] 决定枚举返回值；
+//   - lastLimit 记录最近一次调用收到的 limit，便于断言 cap 透传；
+//   - callCount 用来确认 FollowChannel 不在 nil-enumerator 之外的路径多次调用。
+type stubThreadEnumerator struct {
+	groups    map[string][]string
+	lastLimit int
+	callCount int
+}
+
+func (s *stubThreadEnumerator) EnumerateActiveShortIDs(groupNo string, limit int) ([]string, error) {
+	s.callCount++
+	s.lastLimit = limit
+	ids := s.groups[groupNo]
+	if limit > 0 && len(ids) > limit {
+		ids = ids[:limit]
+	}
+	return ids, nil
+}
+
+func TestService_FollowChannel_SetsAutoFollowThreads(t *testing.T) {
+	svc := newServiceForTest(t)
+	const uid, space, grp = "u1", "s1", "grp-af-1"
+
+	require.NoError(t, svc.FollowChannel(uid, space, grp))
+
+	m, err := svc.db.Get(uid, space, targetTypeGroup, grp)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, int8(0), m.GroupUnfollowed)
+	assert.Equal(t, int8(1), m.AutoFollowThreads, "FollowChannel 应把 auto_follow_threads 置 1")
+}
+
+func TestService_FollowChannel_MaterializesActiveThreads(t *testing.T) {
+	svc := newServiceForTest(t)
+	const uid, space, grp = "u1", "s1", "grp-af-2"
+
+	enum := &stubThreadEnumerator{groups: map[string][]string{
+		grp: {"thr-a", "thr-b", "thr-c"},
+	}}
+	svc.SetThreadEnumerator(enum)
+
+	require.NoError(t, svc.FollowChannel(uid, space, grp))
+
+	assert.Equal(t, 1, enum.callCount, "FollowChannel 应只查询一次 ThreadEnumerator")
+
+	for _, shortID := range []string{"thr-a", "thr-b", "thr-c"} {
+		channelID := grp + threadSeparator + shortID
+		row, err := svc.db.Get(uid, space, targetTypeThread, channelID)
+		require.NoError(t, err)
+		require.NotNil(t, row, "thread ext row for %s should exist after FollowChannel", channelID)
+		assert.Equal(t, 0, row.FollowSort,
+			"fanout 物化行 follow_sort 应保持默认 0（未手动排序），由客户端按规则聚拢渲染")
+	}
+}
+
+func TestService_FollowChannel_RespectsCap(t *testing.T) {
+	svc := newServiceForTest(t)
+	const uid, space, grp = "u1", "s1", "grp-af-3"
+
+	// 模拟有 600 个 active 子区。
+	ids := make([]string, 600)
+	for i := range ids {
+		ids[i] = "thr-" + intToStrAFT(i)
+	}
+	enum := &stubThreadEnumerator{groups: map[string][]string{grp: ids}}
+	svc.SetThreadEnumerator(enum)
+
+	require.NoError(t, svc.FollowChannel(uid, space, grp))
+
+	assert.Equal(t, maxAutoFollowThreadsPerChannel, enum.lastLimit,
+		"FollowChannel 应把 cap 透传给 ThreadEnumerator")
+
+	// 验前 500 个物化、500..599 未物化。
+	var got []*Model
+	got, err := svc.db.ListThreadExts(uid, space)
+	require.NoError(t, err)
+	assert.Equal(t, maxAutoFollowThreadsPerChannel, len(got),
+		"超过 cap 的子区不应被物化（fanout 会在后续 OnThreadCreated 持续补齐）")
+}
+
+func TestService_FollowChannel_NoEnumerator_NoMaterialization(t *testing.T) {
+	svc := newServiceForTest(t)
+	const uid, space, grp = "u1", "s1", "grp-af-4"
+
+	// 不注入 enumerator —— 与现有 FollowChannel 行为兼容。
+	require.NoError(t, svc.FollowChannel(uid, space, grp))
+
+	m, err := svc.db.Get(uid, space, targetTypeGroup, grp)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, int8(1), m.AutoFollowThreads)
+
+	rows, err := svc.db.ListThreadExts(uid, space)
+	require.NoError(t, err)
+	assert.Empty(t, rows, "无 enumerator 时不应物化子区行")
+}
+
+func TestService_FollowChannel_VersionBumpedOnce(t *testing.T) {
+	svc := newServiceForTest(t)
+	const uid, space, grp = "u1", "s1", "grp-af-5"
+
+	enum := &stubThreadEnumerator{groups: map[string][]string{
+		grp: {"thr-1", "thr-2", "thr-3", "thr-4"},
+	}}
+	svc.SetThreadEnumerator(enum)
+
+	require.NoError(t, svc.FollowChannel(uid, space, grp))
+
+	v := readFollowVersion(t, svc, uid, space)
+	assert.Equal(t, int64(1), v,
+		"FollowChannel 即便物化 N 个子区，也只应 bump follow_version 一次（user-level 单调序列）")
+}
+
+func TestService_FollowChannel_PreservesExistingThreadSort(t *testing.T) {
+	svc := newServiceForTest(t)
+	const uid, space, grp = "u1", "s1", "grp-af-6"
+	preThread := grp + threadSeparator + "thr-pre"
+
+	// 预先：用户手动关注过该子区并拖拽到 sort=42。
+	require.NoError(t, svc.db.Upsert(uid, space, targetTypeThread, preThread, ConvExtFields{
+		FollowSort: intPtr(42),
+	}))
+
+	enum := &stubThreadEnumerator{groups: map[string][]string{
+		grp: {"thr-pre", "thr-new"},
+	}}
+	svc.SetThreadEnumerator(enum)
+	require.NoError(t, svc.FollowChannel(uid, space, grp))
+
+	// thr-pre 的手动 sort 必须保留（fanout 走 INSERT IGNORE）。
+	pre, err := svc.db.Get(uid, space, targetTypeThread, preThread)
+	require.NoError(t, err)
+	require.NotNil(t, pre)
+	assert.Equal(t, 42, pre.FollowSort, "已有手动排序的 thread 行不应被 fanout 覆盖")
+
+	// thr-new 是新物化的，follow_sort=0（未排序）。
+	newRow, err := svc.db.Get(uid, space, targetTypeThread, grp+threadSeparator+"thr-new")
+	require.NoError(t, err)
+	require.NotNil(t, newRow)
+	assert.Equal(t, 0, newRow.FollowSort)
+}
+
+// ---------------------------------------------------------------------------
 // UnfollowChannel happy path + cascade
 // ---------------------------------------------------------------------------
 
@@ -197,6 +369,28 @@ func TestService_UnfollowChannel_SetsGroupUnfollowed(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, m)
 	assert.Equal(t, int8(1), m.GroupUnfollowed)
+}
+
+func TestService_UnfollowChannel_ClearsAutoFollowThreads(t *testing.T) {
+	svc := newServiceForTest(t)
+	const uid, space, grp = "u1", "s1", "grp-uaf-1"
+
+	// 先关注 channel（auto_follow_threads=1）
+	require.NoError(t, svc.FollowChannel(uid, space, grp))
+	m, err := svc.db.Get(uid, space, targetTypeGroup, grp)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	require.Equal(t, int8(1), m.AutoFollowThreads)
+
+	// 取消关注后 auto_follow_threads 必须置回 0，
+	// 防止后续 OnThreadCreated 把已取关的用户当作 fanout 目标。
+	require.NoError(t, svc.UnfollowChannel(uid, space, grp))
+	m2, err := svc.db.Get(uid, space, targetTypeGroup, grp)
+	require.NoError(t, err)
+	require.NotNil(t, m2)
+	assert.Equal(t, int8(1), m2.GroupUnfollowed)
+	assert.Equal(t, int8(0), m2.AutoFollowThreads,
+		"UnfollowChannel 必须把 auto_follow_threads 清零，否则 fanout 还会找到该用户")
 }
 
 func TestService_UnfollowChannel_CascadeDeletesThreadExtRows(t *testing.T) {

--- a/modules/conversation_ext/sql/20260522000001_user_conv_ext_auto_follow_threads.sql
+++ b/modules/conversation_ext/sql/20260522000001_user_conv_ext_auto_follow_threads.sql
@@ -4,17 +4,20 @@
 -- - auto_follow_threads=1 表示用户已对该群按下"关注频道"，新建子区时同步给该用户落 thread ext 行。
 -- - FollowChannel 把字段置 1 并物化当前 active 子区；UnfollowChannel 置 0 并级联清空 thread 行。
 -- - 默认 0，对未上线 follow tab 的老用户无影响（无回填需求）。
-
-ALTER TABLE user_conversation_ext
-  ADD COLUMN auto_follow_threads TINYINT(1) NOT NULL DEFAULT 0
-    COMMENT '关注频道时自动连带关注其下子区 (cascade follow flag)';
-
+--
 -- idx_channel_auto_follow 服务于 OnThreadCreated 的 fanout 查询：
 --   WHERE target_type=2 AND target_id=<groupNo> AND auto_follow_threads=1
 -- 走该索引能在 N 个 follower 中快速定位目标用户集合。
+--
+-- ADD COLUMN + ADD INDEX 合在同一 ALTER 内（yujiawei review）—— MySQL 8.0
+-- 把这一对 INSTANT/ONLINE 操作合并成单次 metadata lock 抖动，避免顺序两次 ALTER
+-- 各占一次 lock 窗口。
 ALTER TABLE user_conversation_ext
+  ADD COLUMN auto_follow_threads TINYINT(1) NOT NULL DEFAULT 0
+    COMMENT '关注频道时自动连带关注其下子区 (cascade follow flag)',
   ADD INDEX idx_channel_auto_follow (target_type, target_id, auto_follow_threads);
 
 -- +migrate Down
-ALTER TABLE user_conversation_ext DROP INDEX idx_channel_auto_follow;
-ALTER TABLE user_conversation_ext DROP COLUMN auto_follow_threads;
+ALTER TABLE user_conversation_ext
+  DROP INDEX idx_channel_auto_follow,
+  DROP COLUMN auto_follow_threads;

--- a/modules/conversation_ext/sql/20260522000001_user_conv_ext_auto_follow_threads.sql
+++ b/modules/conversation_ext/sql/20260522000001_user_conv_ext_auto_follow_threads.sql
@@ -1,0 +1,20 @@
+-- +migrate Up
+
+-- 关注频道时自动连带关注其下子区（issue: sidebar channel→threads 级联关注）。
+-- - auto_follow_threads=1 表示用户已对该群按下"关注频道"，新建子区时同步给该用户落 thread ext 行。
+-- - FollowChannel 把字段置 1 并物化当前 active 子区；UnfollowChannel 置 0 并级联清空 thread 行。
+-- - 默认 0，对未上线 follow tab 的老用户无影响（无回填需求）。
+
+ALTER TABLE user_conversation_ext
+  ADD COLUMN auto_follow_threads TINYINT(1) NOT NULL DEFAULT 0
+    COMMENT '关注频道时自动连带关注其下子区 (cascade follow flag)';
+
+-- idx_channel_auto_follow 服务于 OnThreadCreated 的 fanout 查询：
+--   WHERE target_type=2 AND target_id=<groupNo> AND auto_follow_threads=1
+-- 走该索引能在 N 个 follower 中快速定位目标用户集合。
+ALTER TABLE user_conversation_ext
+  ADD INDEX idx_channel_auto_follow (target_type, target_id, auto_follow_threads);
+
+-- +migrate Down
+ALTER TABLE user_conversation_ext DROP INDEX idx_channel_auto_follow;
+ALTER TABLE user_conversation_ext DROP COLUMN auto_follow_threads;

--- a/modules/conversation_ext/sql/20260522000001_user_conv_ext_auto_follow_threads.sql
+++ b/modules/conversation_ext/sql/20260522000001_user_conv_ext_auto_follow_threads.sql
@@ -9,9 +9,12 @@
 --   WHERE target_type=2 AND target_id=<groupNo> AND auto_follow_threads=1
 -- 走该索引能在 N 个 follower 中快速定位目标用户集合。
 --
--- ADD COLUMN + ADD INDEX 合在同一 ALTER 内（yujiawei review）—— MySQL 8.0
--- 把这一对 INSTANT/ONLINE 操作合并成单次 metadata lock 抖动，避免顺序两次 ALTER
--- 各占一次 lock 窗口。
+-- ADD COLUMN + ADD INDEX 合在同一 ALTER 内（yujiawei review round-2）。
+-- 精确表述：MySQL 8.0 上 ADD COLUMN 是 INSTANT（仅改元数据，秒级返回），
+-- ADD INDEX 是 INPLACE（在线重建，持 SHARED_UPGRADABLE MDL；耗时与表大小成正比）。
+-- 合并成单条 ALTER 让两步共享一次 MDL 抖动，避免顺序两次 ALTER 各占一次窗口；
+-- 但整体仍按 INPLACE 计时 —— 大表上线前请评估 user_conversation_ext 行数与
+-- 索引构建窗口（建议先确认行数 < 500 万，否则用 pt-osc / gh-ost 单独跑 ADD INDEX）。
 ALTER TABLE user_conversation_ext
   ADD COLUMN auto_follow_threads TINYINT(1) NOT NULL DEFAULT 0
     COMMENT '关注频道时自动连带关注其下子区 (cascade follow flag)',

--- a/modules/conversation_ext/sql/20260522000002_user_conv_ext_auto_follow_covering.sql
+++ b/modules/conversation_ext/sql/20260522000002_user_conv_ext_auto_follow_covering.sql
@@ -1,0 +1,26 @@
+-- +migrate Up
+
+-- Follow-up to 20260522000001 (PR #123 round-5 review, Jerry-Xin + yujiawei):
+-- idx_channel_auto_follow 在 (target_type, target_id, auto_follow_threads) 三列上
+-- 已能定位 fanout 目标行，但 OnThreadCreated 的两步热路径都要继续读 (uid, space_id)：
+--   1) 初始 SELECT uid, space_id FROM user_conversation_ext
+--        WHERE target_type=? AND target_id=? AND auto_follow_threads=1
+--        ORDER BY uid, space_id；
+--   2) selectEligibleForFanoutTx 的 SELECT ... FOR UPDATE 走同样的列过滤再 IN 一批 (uid, space_id)。
+-- 当前索引让两步都得回 PK 表取 (uid, space_id)；大群 fanout（数千 follower）下
+-- 这一次额外的 random IO 会主导整体延迟。
+--
+-- 把 (uid, space_id) 追加到索引末端，让两步成为 covering index lookup，
+-- 同时 ORDER BY uid, space_id 直接走索引顺序、不再 filesort。
+-- 旧索引前缀 (target_type, target_id, auto_follow_threads) 仍保留为新索引的前缀，
+-- 因此不需要单独的兼容索引。
+--
+-- DROP + ADD 单条 ALTER 让两步共享一次 MDL 抖动（同 20260522000001 的合并 rationale）。
+ALTER TABLE user_conversation_ext
+  DROP INDEX idx_channel_auto_follow,
+  ADD INDEX idx_channel_auto_follow (target_type, target_id, auto_follow_threads, uid, space_id);
+
+-- +migrate Down
+ALTER TABLE user_conversation_ext
+  DROP INDEX idx_channel_auto_follow,
+  ADD INDEX idx_channel_auto_follow (target_type, target_id, auto_follow_threads);

--- a/modules/conversation_ext/swagger/api.yaml
+++ b/modules/conversation_ext/swagger/api.yaml
@@ -134,7 +134,11 @@ paths:
         新建的子区由 fanout 在线补齐。超过 500 时按 created_at DESC 取最新，截断的是
         最旧的子区（产品上极有可能马上被归档）。
 
-        在同一事务内 +1 user_follow_version（即便物化 N 个子区也只 +1，因为是用户级单调序列）。
+        实现采用两阶段提交（关闭 enumerate 与 OnThreadCreated 之间的 race window），
+        bump user_follow_version 最多 +2（与子区数量无关；常数次数），客户端只需在
+        变化时拉一次 sidebar，多 +1 不影响正确性。
+
+        当 caller 不是该群成员（或群在请求 Space 不可见）时返回 403。
       operationId: "followChannel"
       consumes:
         - "application/json"
@@ -159,6 +163,10 @@ paths:
             $ref: "#/definitions/response"
         400:
           description: "参数错误或业务错误"
+          schema:
+            $ref: "#/definitions/response"
+        403:
+          description: "无权关注该群（非群成员或群在请求 Space 不可见）"
           schema:
             $ref: "#/definitions/response"
       security:

--- a/modules/conversation_ext/swagger/api.yaml
+++ b/modules/conversation_ext/swagger/api.yaml
@@ -82,8 +82,13 @@ paths:
     post:
       tags:
         - "follow"
-      summary: "取消关注群"
-      description: "将群加入黑名单（group_unfollowed=1），同时删除该群下所有子区的扩展行"
+      summary: "取消关注群（级联取关子区）"
+      description: |
+        将群加入黑名单（group_unfollowed=1），同时：
+        - 清除该群在当前用户下的 auto_follow_threads 标记，后续新建子区不再自动关注；
+        - 删除该群下所有子区的扩展行（target_type=5 LIKE prefix 级联 DELETE）。
+
+        在同一事务内 +1 user_follow_version，客户端可凭 follow_version 触发增量同步。
       operationId: "unfollowChannel"
       consumes:
         - "application/json"
@@ -117,8 +122,19 @@ paths:
     post:
       tags:
         - "follow"
-      summary: "重新关注群"
-      description: "清除群的黑名单标记（group_unfollowed=0），重新关注该群"
+      summary: "关注群（级联关注子区）"
+      description: |
+        关注该群：
+        - 清除黑名单标记（group_unfollowed=0）+ 设置 auto_follow_threads=1；
+        - 按 created_at DESC 取当前群下最多 500 个 active 子区，逐一 INSERT IGNORE
+          落 thread ext 行（已存在的行保留用户原有 follow_sort）；
+        - 之后新建子区时由服务端在 thread 创建 hook 中自动给该用户 fanout（无需客户端轮询）。
+
+        500 上限与产品侧"子区自动归档"配合：归档后子区不在 active 集合，不参与初始物化；
+        新建的子区由 fanout 在线补齐。超过 500 时按 created_at DESC 取最新，截断的是
+        最旧的子区（产品上极有可能马上被归档）。
+
+        在同一事务内 +1 user_follow_version（即便物化 N 个子区也只 +1，因为是用户级单调序列）。
       operationId: "followChannel"
       consumes:
         - "application/json"

--- a/modules/conversation_ext/swagger/api.yaml
+++ b/modules/conversation_ext/swagger/api.yaml
@@ -135,8 +135,11 @@ paths:
         最旧的子区（产品上极有可能马上被归档）。
 
         实现采用两阶段提交（关闭 enumerate 与 OnThreadCreated 之间的 race window），
-        bump user_follow_version 最多 +2（与子区数量无关；常数次数），客户端只需在
-        变化时拉一次 sidebar，多 +1 不影响正确性。
+        bump user_follow_version 0 到 2 次（与子区数量无关；常数次数）：
+          - 鉴权失败：0 次（直接 403，不进任何 tx）；
+          - 群下无 active 子区 / 未注入 enumerator：1 次（Phase 1 commit）；
+          - 正常路径：2 次（Phase 1 + Phase 3 各一次）。
+        客户端只需在 follow_version 变化时拉一次 sidebar，多 +1 不影响正确性。
 
         当 caller 不是该群成员（或群在请求 Space 不可见）时返回 403。
       operationId: "followChannel"

--- a/modules/message/1module.go
+++ b/modules/message/1module.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"embed"
+	"errors"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
@@ -69,11 +70,16 @@ func init() {
 		convext.InitGlobalConvExtService(appCtx)
 		svc := convext.GetGlobalConvExtService()
 		if svc != nil {
-			svc.SetThreadAuthChecker(newThreadAuthChecker(appCtx))
+			checker := newThreadAuthChecker(appCtx)
+			svc.SetThreadAuthChecker(checker)
 			// 注入 ThreadEnumerator：FollowChannel 物化既有子区时通过它枚举
 			// active 子区的 shortID。同样落在 message 模块以避开 conversation_ext
 			// 直接 import modules/thread 的循环依赖（见 ThreadAuthChecker 同款逻辑）。
 			svc.SetThreadEnumerator(newThreadEnumerator(appCtx))
+			// 注入 ChannelAuthChecker：FollowChannel 写 auto_follow=1 + 物化既有
+			// 子区前必须校验 caller 是群成员 + 群在 Space 可见。复用同一个 struct
+			// 实现，共享 checkChannelAccess 逻辑。
+			svc.SetChannelAuthChecker(checker)
 		}
 		return register.Module{Name: "conversation_ext_thread_auth"}
 	})
@@ -126,13 +132,14 @@ func (c *threadAuthChecker) AuthorizeThreadFollow(uid, spaceID, groupNo, shortID
 	if spaceID == "" {
 		return convext.ErrThreadForbidden
 	}
-	// 1. Membership check: must be a member of the parent group.
-	isMember, err := c.groupSvc.ExistMember(groupNo, uid)
-	if err != nil {
+	// 1. Channel-level checks (membership + Space visibility) — shared with FollowChannel.
+	if err := c.checkChannelAccess(uid, spaceID, groupNo); err != nil {
+		// 已是 ErrChannelForbidden 时，对 thread API 仍翻译为 ErrThreadForbidden，
+		// 让 handler 走原有 403 路径，客户端无需感知两套 sentinel。
+		if errors.Is(err, convext.ErrChannelForbidden) {
+			return convext.ErrThreadForbidden
+		}
 		return err
-	}
-	if !isMember {
-		return convext.ErrThreadForbidden
 	}
 	// 2. Thread existence + status + group consistency in one query.
 	threadMap, err := c.threadDB.QueryActiveByGroupShortIDs([]thread.ShortRef{
@@ -146,18 +153,51 @@ func (c *threadAuthChecker) AuthorizeThreadFollow(uid, spaceID, groupNo, shortID
 		// Either thread does not exist, status==deleted, or group_no mismatch.
 		return convext.ErrThreadForbidden
 	}
-	// 3. Parent-group must be visible in the requested Space.
+	return nil
+}
+
+// AuthorizeChannelFollow implements convext.ChannelAuthChecker.
+//
+// 与 AuthorizeThreadFollow 共享 channel-level access check（成员资格 + Space 可见性）,
+// 仅省略掉 thread-existence 这一步 —— FollowChannel 写群级 ext 行，与具体子区无关。
+//
+// 引入背景（PR #123 round-1 by Jerry-Xin / yujiawei P1）：FollowChannel 现在会
+// 物化 thread ext + 挂 OnThreadCreated fanout 订阅，必须先校验 caller 能"看到"
+// 这个群，否则同 Space 内私有群的子区元数据会泄露。
+func (c *threadAuthChecker) AuthorizeChannelFollow(uid, spaceID, groupNo string) error {
+	return c.checkChannelAccess(uid, spaceID, groupNo)
+}
+
+// checkChannelAccess 复用 FollowThread 既有逻辑的群级访问校验：
+//  1. spaceID 非空
+//  2. caller 是 group 成员
+//  3. group 在请求 Space 可见（内部群 same-space / 外部群 sourceSpaceID-match / 旧群 wildcard）
+//
+// 鉴权失败返回 convext.ErrChannelForbidden；基础设施错误 wrap 后上传。
+func (c *threadAuthChecker) checkChannelAccess(uid, spaceID, groupNo string) error {
+	if spaceID == "" {
+		return convext.ErrChannelForbidden
+	}
+	// 1. Membership check.
+	isMember, err := c.groupSvc.ExistMember(groupNo, uid)
+	if err != nil {
+		return err
+	}
+	if !isMember {
+		return convext.ErrChannelForbidden
+	}
+	// 2. Space visibility.
 	groups, err := c.groupSvc.GetGroups([]string{groupNo})
 	if err != nil {
 		return err
 	}
 	if len(groups) == 0 {
-		// Group disbanded between membership-check and now; safe to reject.
-		return convext.ErrThreadForbidden
+		// Group disbanded between membership-check and now; reject.
+		return convext.ErrChannelForbidden
 	}
 	parentSpaceID := groups[0].SpaceID
 	if parentSpaceID == "" {
-		// Legacy group without space_id is visible everywhere; allow.
+		// Legacy group without space_id is visible everywhere.
 		return nil
 	}
 	if parentSpaceID == spaceID {
@@ -173,7 +213,7 @@ func (c *threadAuthChecker) AuthorizeThreadFollow(uid, spaceID, groupNo, shortID
 			return nil
 		}
 	}
-	return convext.ErrThreadForbidden
+	return convext.ErrChannelForbidden
 }
 
 // threadEnumerator implements convext.ThreadEnumerator for production wiring.

--- a/modules/message/1module.go
+++ b/modules/message/1module.go
@@ -192,7 +192,18 @@ func (c *threadAuthChecker) checkChannelAccess(uid, spaceID, groupNo string) err
 		return err
 	}
 	if len(groups) == 0 {
-		// Group disbanded between membership-check and now; reject.
+		// Group row gone between membership-check and now; reject.
+		return convext.ErrChannelForbidden
+	}
+	// PR #123 round-6 (lml2468)：显式拒绝 Disband 群。解散流程把 group.status
+	// 置为 Disband 但不一定清理 group_member（部分清理路径目前是注释掉的），
+	// ExistMember 仍可能为 true；同时解散事件已清空 conversation_ext 行，
+	// 这里若放行会让 FollowChannel 重新写入 auto_follow_threads=1 + 物化已解散
+	// 群下的 active thread ext，导致已解散的群/子区重新出现在 sidebar。
+	// 与 modules/group/api.go 既有路径（"if group == nil || group.Status ==
+	// GroupStatusDisband"）保持一致。Disabled (=0, 管理员禁用) 当前不拒绝以
+	// 保持最小修复面；若日后产品确认 disabled 群也不应允许 follow，可在此追加。
+	if groups[0].Status == group.GroupStatusDisband {
 		return convext.ErrChannelForbidden
 	}
 	parentSpaceID := groups[0].SpaceID

--- a/modules/message/1module.go
+++ b/modules/message/1module.go
@@ -70,6 +70,10 @@ func init() {
 		svc := convext.GetGlobalConvExtService()
 		if svc != nil {
 			svc.SetThreadAuthChecker(newThreadAuthChecker(appCtx))
+			// 注入 ThreadEnumerator：FollowChannel 物化既有子区时通过它枚举
+			// active 子区的 shortID。同样落在 message 模块以避开 conversation_ext
+			// 直接 import modules/thread 的循环依赖（见 ThreadAuthChecker 同款逻辑）。
+			svc.SetThreadEnumerator(newThreadEnumerator(appCtx))
 		}
 		return register.Module{Name: "conversation_ext_thread_auth"}
 	})
@@ -170,4 +174,34 @@ func (c *threadAuthChecker) AuthorizeThreadFollow(uid, spaceID, groupNo, shortID
 		}
 	}
 	return convext.ErrThreadForbidden
+}
+
+// threadEnumerator implements convext.ThreadEnumerator for production wiring.
+// It thin-wraps thread.DB.QueryByGroupNoWithStatus(active-only) and projects to
+// shortID-only to keep the conversation_ext side free of thread.Model leakage.
+type threadEnumerator struct {
+	threadDB *thread.DB
+}
+
+func newThreadEnumerator(ctx *config.Context) *threadEnumerator {
+	return &threadEnumerator{threadDB: thread.NewDB(ctx)}
+}
+
+// EnumerateActiveShortIDs 返回 groupNo 下 active 子区的 shortID 列表，最多 limit 个。
+// 排序由 QueryByGroupNoWithStatus 决定：created_at DESC, id DESC —— 最新建的子区
+// 排在前面，截断后被丢弃的是最旧的子区，正好与"产品侧自动归档把旧子区清出 active"
+// 配合，让 cap 截断不会丢失"热"子区。
+func (e *threadEnumerator) EnumerateActiveShortIDs(groupNo string, limit int) ([]string, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	models, err := e.threadDB.QueryByGroupNoWithStatus(groupNo, []int{thread.ThreadStatusActive}, 0, int64(limit))
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(models))
+	for _, m := range models {
+		ids = append(ids, m.ShortID)
+	}
+	return ids, nil
 }

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -243,7 +243,30 @@ func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
 		return nil, fmt.Errorf("create IM channel: %w", err)
 	}
 
-	// 拷贝源消息到子区作为首条消息
+	// 给所有"已对父 channel 开启 auto_follow_threads=1"的用户 fanout 一行 thread ext。
+	//
+	// 顺序约束（round-2 lml2468 blocker → round-4 Jerry-Xin/lml2468 重申）：
+	// fanout 必须发生在**任何客户端可观察的子区频道消息之前**。当前 thread 创建路径
+	// 里两个客户端可观察事件是：
+	//   1. sendSourceMessage —— 把源消息拷贝到新子区频道（可推送），
+	//   2. sendThreadCreatedMessage —— 在父群发送"X 创建了子区 Y"通知。
+	// 任意一个先于 fanout commit 都让客户端可能在 thread ext 行尚未存在时拉 sidebar，
+	// 漏看新子区。所以 OnThreadCreated 放在 IM 频道建好之后 + 两条消息之前。
+	//
+	// 与 IM 频道 / 源消息一样在 commit 之后做 best-effort：失败只警告，不让 thread
+	// 创建本身回滚（用户已经看到子区，下次 FollowChannel / refollow 会把缺失的
+	// fanout 补齐）。GetGlobalConvExtService 在单测环境（未 init 单例）返回 nil 时跳过。
+	if convSvc := conversation_ext.GetGlobalConvExtService(); convSvc != nil {
+		if err := convSvc.OnThreadCreated(req.GroupNo, shortID); err != nil {
+			s.Warn("OnThreadCreated fanout 失败（thread 已创建，sidebar 会延迟到下次 FollowChannel/refollow 补齐）",
+				zap.String("groupNo", req.GroupNo),
+				zap.String("shortID", shortID),
+				zap.Error(err))
+		}
+	}
+
+	// 拷贝源消息到子区作为首条消息（顺序：在 fanout 之后，客户端收到这条消息时
+	// thread ext 行已 commit）。
 	if req.SourceMessageID != nil && len(req.SourceMessagePayload) > 0 {
 		// 从消息表查询原始发送者，防止客户端伪造
 		sourceFromUID, err := s.db.QueryMessageFromUID(req.GroupNo, *req.SourceMessageID)
@@ -258,27 +281,7 @@ func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
 		s.sendSourceMessage(channelID, sourceFromUID, req.SourceMessagePayload)
 	}
 
-	// 给所有"已对父 channel 开启 auto_follow_threads=1"的用户 fanout 一行 thread ext。
-	//
-	// 顺序约束（lml2468 round-2 review blocker #1）：fanout 必须发生在
-	// sendThreadCreatedMessage 之前。否则客户端可能先收到 thread-created 通知再去
-	// 拉 sidebar，而此时 fanout 还没 commit —— 已开启 auto_follow 的用户拉到的
-	// follow 列表里不含新子区，要等到下一次 sidebar 同步或 refollow 才能看到。
-	//
-	// 与 IM 频道 / 源消息一样在 commit 之后做 best-effort：失败只警告，不让 thread
-	// 创建本身回滚（用户已经看到子区，下次 FollowChannel / refollow 会把缺失的
-	// fanout 补齐）。GetGlobalConvExtService 在单测环境（未 init 单例）返回 nil 时跳过。
-	if convSvc := conversation_ext.GetGlobalConvExtService(); convSvc != nil {
-		if err := convSvc.OnThreadCreated(req.GroupNo, shortID); err != nil {
-			s.Warn("OnThreadCreated fanout 失败（thread 已创建，sidebar 会延迟到下次 FollowChannel/refollow 补齐）",
-				zap.String("groupNo", req.GroupNo),
-				zap.String("shortID", shortID),
-				zap.Error(err))
-		}
-	}
-
-	// 在父群发送子区创建消息（必须在 fanout 之后，保证客户端收到通知时 follow tab
-	// 里已经有该子区行）。
+	// 在父群发送子区创建消息（同样在 fanout 之后；与 sendSourceMessage 同序约束）。
 	s.sendThreadCreatedMessage(req.GroupNo, shortID, req.Name, req.CreatorUID, req.CreatorName, req.SourceMessageID, req.SourceMessagePayload)
 
 	resp := s.toThreadRespWithID(thread)

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -258,12 +258,15 @@ func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
 		s.sendSourceMessage(channelID, sourceFromUID, req.SourceMessagePayload)
 	}
 
-	// 在父群发送子区创建消息
-	s.sendThreadCreatedMessage(req.GroupNo, shortID, req.Name, req.CreatorUID, req.CreatorName, req.SourceMessageID, req.SourceMessagePayload)
-
 	// 给所有"已对父 channel 开启 auto_follow_threads=1"的用户 fanout 一行 thread ext。
-	// 与 IM 频道 / 子区创建消息一样在 commit 之后做 best-effort：失败只警告，不让
-	// thread 创建本身回滚（用户已经看到子区，下次 FollowChannel/refollow 会把缺失的
+	//
+	// 顺序约束（lml2468 round-2 review blocker #1）：fanout 必须发生在
+	// sendThreadCreatedMessage 之前。否则客户端可能先收到 thread-created 通知再去
+	// 拉 sidebar，而此时 fanout 还没 commit —— 已开启 auto_follow 的用户拉到的
+	// follow 列表里不含新子区，要等到下一次 sidebar 同步或 refollow 才能看到。
+	//
+	// 与 IM 频道 / 源消息一样在 commit 之后做 best-effort：失败只警告，不让 thread
+	// 创建本身回滚（用户已经看到子区，下次 FollowChannel / refollow 会把缺失的
 	// fanout 补齐）。GetGlobalConvExtService 在单测环境（未 init 单例）返回 nil 时跳过。
 	if convSvc := conversation_ext.GetGlobalConvExtService(); convSvc != nil {
 		if err := convSvc.OnThreadCreated(req.GroupNo, shortID); err != nil {
@@ -273,6 +276,10 @@ func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
 				zap.Error(err))
 		}
 	}
+
+	// 在父群发送子区创建消息（必须在 fanout 之后，保证客户端收到通知时 follow tab
+	// 里已经有该子区行）。
+	s.sendThreadCreatedMessage(req.GroupNo, shortID, req.Name, req.CreatorUID, req.CreatorName, req.SourceMessageID, req.SourceMessagePayload)
 
 	resp := s.toThreadRespWithID(thread)
 	resp.MemberCount = 1 // 创建者

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -261,6 +261,19 @@ func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
 	// 在父群发送子区创建消息
 	s.sendThreadCreatedMessage(req.GroupNo, shortID, req.Name, req.CreatorUID, req.CreatorName, req.SourceMessageID, req.SourceMessagePayload)
 
+	// 给所有"已对父 channel 开启 auto_follow_threads=1"的用户 fanout 一行 thread ext。
+	// 与 IM 频道 / 子区创建消息一样在 commit 之后做 best-effort：失败只警告，不让
+	// thread 创建本身回滚（用户已经看到子区，下次 FollowChannel/refollow 会把缺失的
+	// fanout 补齐）。GetGlobalConvExtService 在单测环境（未 init 单例）返回 nil 时跳过。
+	if convSvc := conversation_ext.GetGlobalConvExtService(); convSvc != nil {
+		if err := convSvc.OnThreadCreated(req.GroupNo, shortID); err != nil {
+			s.Warn("OnThreadCreated fanout 失败（thread 已创建，sidebar 会延迟到下次 FollowChannel/refollow 补齐）",
+				zap.String("groupNo", req.GroupNo),
+				zap.String("shortID", shortID),
+				zap.Error(err))
+		}
+	}
+
 	resp := s.toThreadRespWithID(thread)
 	resp.MemberCount = 1 // 创建者
 	return resp, nil

--- a/modules/thread/sql/20260522000002_thread_group_status_created_index.sql
+++ b/modules/thread/sql/20260522000002_thread_group_status_created_index.sql
@@ -1,0 +1,17 @@
+-- +migrate Up
+
+-- 支撑 conversation_ext.FollowChannel → ThreadEnumerator.EnumerateActiveShortIDs
+-- 的查询：
+--   SELECT * FROM thread
+--    WHERE group_no=? AND status IN (?)
+--    ORDER BY created_at DESC, id DESC
+--    LIMIT ?
+--
+-- 既有的 group_no / status 单列索引让"找到群下所有 thread"够快，但缺少 created_at
+-- 排序键会让 LIMIT 500 物化路径在子区多的群里回表 + filesort（lml2468 round-2
+-- review）。复合索引覆盖排序与 limit，且保留前缀 (group_no, status) 让旧路径仍可用。
+ALTER TABLE thread
+  ADD INDEX idx_group_status_created_id (group_no, status, created_at, id);
+
+-- +migrate Down
+ALTER TABLE thread DROP INDEX idx_group_status_created_id;

--- a/pkg/db/migrate_compat.go
+++ b/pkg/db/migrate_compat.go
@@ -158,6 +158,7 @@ var threadModuleMigrationIDs = []string{
 	"20260413000001_thread_legacy01.sql",
 	"20260422000001_thread_legacy01.sql",
 	"20260511000001_thread_legacy01.sql",
+	"20260522000002_thread_group_status_created_index.sql",
 }
 
 // ReconcileThreadSchemaRecords pre-seeds gorp_migrations with the thread

--- a/pkg/db/migrate_compat.go
+++ b/pkg/db/migrate_compat.go
@@ -143,21 +143,38 @@ func RewriteLegacyMigrationIDs(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
-// threadModuleMigrationIDs is the deterministic list of migration files that
-// own the thread/thread_member/thread_setting tables. It's deliberately
-// hard-coded here rather than discovered from disk: this function runs
-// before sql-migrate boots and we need to enumerate exactly the IDs we
-// expect to skip when the schema is already present.
+// threadModuleSnapshotMigrationIDs lists the thread-module migration files
+// whose effects are **already present** in the init-db.sql snapshot. These
+// get pre-seeded into gorp_migrations on snapshot installs so sql-migrate
+// treats them as already-applied and skips the CREATE TABLE / ADD COLUMN
+// statements (which would otherwise hit Error 1050 on existing tables).
 //
-// Keep this in sync with modules/thread/sql/*.sql. The
-// TestThreadModuleMigrationIDsMatchDisk test in this package catches drift.
-var threadModuleMigrationIDs = []string{
+// !! When you move an ID into this list, the init-db.sql snapshot MUST
+// already include the corresponding DDL. TestThreadModuleMigrationIDsMatchDisk
+// can only check ID coverage, not whether the SQL actually landed in the
+// snapshot — wrongly promoting an entry here silently skips a real DDL on
+// snapshot installs. Always update the snapshot in the same change.
+var threadModuleSnapshotMigrationIDs = []string{
 	"20260402000001_thread_legacy01.sql",
 	"20260402000002_thread_legacy02.sql",
 	"20260410000003_thread_legacy01.sql",
 	"20260413000001_thread_legacy01.sql",
 	"20260422000001_thread_legacy01.sql",
 	"20260511000001_thread_legacy01.sql",
+}
+
+// threadModulePostSnapshotMigrationIDs lists thread-module migrations added
+// **after** the init-db.sql snapshot baseline. They are **not** pre-seeded
+// in ReconcileThreadSchemaRecords — sql-migrate will detect them as pending
+// and apply them on snapshot installs.
+//
+// Background (Jerry-Xin PR #123 round-4 warning): adding an ADD-INDEX-only
+// migration to the snapshot list would let ReconcileThreadSchemaRecords
+// mark it as already applied without ever creating the index, producing
+// invisible schema drift. So new post-snapshot migrations go here instead;
+// TestThreadModuleMigrationIDsMatchDisk asserts the union covers every file
+// on disk so drift in either direction surfaces in CI.
+var threadModulePostSnapshotMigrationIDs = []string{
 	"20260522000002_thread_group_status_created_index.sql",
 }
 
@@ -232,9 +249,12 @@ func ReconcileThreadSchemaRecords(ctx context.Context, db *sql.DB) error {
 	// seeding only the missing IDs there would silently mark unapplied
 	// schema changes as applied and let sql-migrate skip them, producing
 	// invisible schema drift.
+	// Pre-seed only the snapshot-baseline IDs. Post-snapshot migrations
+	// (e.g. new ADD INDEX) must remain as "pending" so sql-migrate.Exec
+	// actually applies them.
 	var toRecord []string
 	var anyPresent bool
-	for _, id := range threadModuleMigrationIDs {
+	for _, id := range threadModuleSnapshotMigrationIDs {
 		if existing[id] {
 			anyPresent = true
 		} else {

--- a/pkg/db/migrate_compat_test.go
+++ b/pkg/db/migrate_compat_test.go
@@ -287,7 +287,7 @@ func TestReconcileThreadSchemaRecords(t *testing.T) {
 		mock.ExpectBegin()
 		stmt := mock.ExpectPrepare(regexp.QuoteMeta(
 			"INSERT IGNORE INTO gorp_migrations (id, applied_at) VALUES (?, NOW())"))
-		for _, id := range threadModuleMigrationIDs {
+		for _, id := range threadModuleSnapshotMigrationIDs {
 			stmt.ExpectExec().WithArgs(id).WillReturnResult(sqlmock.NewResult(0, 1))
 		}
 		mock.ExpectCommit()
@@ -316,7 +316,7 @@ func TestReconcileThreadSchemaRecords(t *testing.T) {
 		// (a hypothetical ADD INDEX in a later release) is genuinely
 		// pending and must be left for sql-migrate to apply.
 		rows := sqlmock.NewRows([]string{"id"})
-		for _, id := range threadModuleMigrationIDs[:5] {
+		for _, id := range threadModuleSnapshotMigrationIDs[:5] {
 			rows.AddRow(id)
 		}
 		mock.ExpectQuery(regexp.QuoteMeta("SELECT id FROM gorp_migrations")).WillReturnRows(rows)
@@ -337,7 +337,7 @@ func TestReconcileThreadSchemaRecords(t *testing.T) {
 			"SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'gorp_migrations'")).
 			WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("gorp_migrations"))
 		rows := sqlmock.NewRows([]string{"id"})
-		for _, id := range threadModuleMigrationIDs {
+		for _, id := range threadModuleSnapshotMigrationIDs {
 			rows.AddRow(id)
 		}
 		mock.ExpectQuery(regexp.QuoteMeta("SELECT id FROM gorp_migrations")).WillReturnRows(rows)
@@ -350,10 +350,19 @@ func TestReconcileThreadSchemaRecords(t *testing.T) {
 }
 
 // TestThreadModuleMigrationIDsMatchDisk catches drift between the
-// hard-coded ID list used by the shim and the actual files in
-// modules/thread/sql/. A new thread migration without a corresponding
-// entry here would leave that ID un-pre-seeded, defeating the whole
-// reconciliation. Surface the mismatch in CI rather than in production.
+// hard-coded ID lists used by the shim and the actual files in
+// modules/thread/sql/. The contract is:
+//
+//   - Every .sql file on disk MUST appear in exactly one of
+//     threadModuleSnapshotMigrationIDs or threadModulePostSnapshotMigrationIDs.
+//   - Snapshot-baseline migrations get pre-seeded by ReconcileThreadSchemaRecords;
+//     post-snapshot migrations stay pending so sql-migrate.Exec applies them.
+//
+// A file missing from both lists would leave its ID un-pre-seeded for snapshot
+// installs (potential Error 1050 on the next sql-migrate.Exec). A file in both
+// lists is also flagged because the pre-seed semantics conflict.
+//
+// Surface the mismatch in CI rather than in production.
 func TestThreadModuleMigrationIDsMatchDisk(t *testing.T) {
 	dir := filepath.Join("..", "..", "modules", "thread", "sql")
 	entries, err := os.ReadDir(dir)
@@ -368,11 +377,26 @@ func TestThreadModuleMigrationIDsMatchDisk(t *testing.T) {
 		onDisk = append(onDisk, e.Name())
 	}
 	sort.Strings(onDisk)
-	got := append([]string(nil), threadModuleMigrationIDs...)
-	sort.Strings(got)
 
-	if !equalStrSlices(onDisk, got) {
-		t.Errorf("threadModuleMigrationIDs drifted from modules/thread/sql/:\n  on disk: %v\n  in code: %v", onDisk, got)
+	combined := append([]string(nil), threadModuleSnapshotMigrationIDs...)
+	combined = append(combined, threadModulePostSnapshotMigrationIDs...)
+	sort.Strings(combined)
+
+	if !equalStrSlices(onDisk, combined) {
+		t.Errorf("thread migration ID lists drifted from modules/thread/sql/:\n  on disk: %v\n  snapshot+post: %v", onDisk, combined)
+	}
+
+	// Detect duplicates across the two lists — pre-seed semantics would
+	// conflict (snapshot says "already applied", post-snapshot says "still
+	// pending"); only one can be right per ID.
+	seen := map[string]string{}
+	for _, id := range threadModuleSnapshotMigrationIDs {
+		seen[id] = "snapshot"
+	}
+	for _, id := range threadModulePostSnapshotMigrationIDs {
+		if where, dup := seen[id]; dup {
+			t.Errorf("migration %q listed in both %s and post-snapshot lists; pick one", id, where)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Right-clicking "follow" on a channel now also follows every active thread under it, and "unfollow" symmetrically clears the channel plus all its threads. Newly created threads automatically appear in the follow tab for every user who has the parent channel followed — no client polling.

The PR has been through four review rounds; design / data-flow doc reflects the final state on `4bbca5a0`.

## Design

### Schema (`modules/conversation_ext/sql/20260522000001`)

- New column `user_conversation_ext.auto_follow_threads TINYINT(1) NOT NULL DEFAULT 0`. Set on the channel row (`target_type=2`) to mark a user's cascade-follow intent.
- Supporting index `idx_channel_auto_follow (target_type, target_id, auto_follow_threads)` for the fanout lookup in `OnThreadCreated`.
- Companion migration `modules/thread/sql/20260522000002` adds `(group_no, status, created_at, id)` composite index so `EnumerateActiveShortIDs`'s `ORDER BY created_at DESC LIMIT 500` avoids filesort on busy channels.
- No backfill — the v2 sidebar / follow tab hasn't shipped yet, so all existing rows are `DEFAULT 0`. After this PR ships, `FollowChannel` writes `1` going forward.
- Plain DDL per the project's migration best-practice; `ADD COLUMN` + `ADD INDEX` combined in a single `ALTER TABLE` to share one metadata-lock window (ADD COLUMN is INSTANT, ADD INDEX is INPLACE — confirm row count < ~5M before rollout, else schedule via pt-osc / gh-ost).

### Authorization (round-1 fix — see [#123 comment](https://github.com/Mininglamp-OSS/octo-server/pull/123#issuecomment-4514705002))

`FollowChannel` is no longer the inert "clear your own blacklist" it was in PR #21 — it now subscribes the caller to a server-driven fanout. So it has the same group-membership + Space-visibility gate as `FollowThread`:

- New `ChannelAuthChecker` narrow interface in `conversation_ext`, mirroring `ThreadAuthChecker`.
- `modules/message/1module.go` wires both interfaces to the same `threadAuthChecker` struct sharing a `checkChannelAccess` helper (membership via `group.IService.ExistMember`, visibility via `group.DB` external-group mapping).
- `ErrChannelForbidden` translates to HTTP 403 at the handler.

### FollowChannel — two-phase commit (round-1/2 race-window closure)

The initial materialization races against concurrent `OnThreadCreated` events on the same channel. Solved with a two-phase tx + an in-tx re-check:

1. **Phase 1 (tx)** — `BumpFollowVersionTx` then upsert the channel ext row with `auto_follow_threads=1, group_unfollowed=0`. Commit. Once visible, any concurrently-created thread's `OnThreadCreated` reads our row and includes us in the fanout.
2. **Phase 2 (no tx)** — `EnumerateActiveShortIDs(groupNo, 500)` via the new `ThreadEnumerator` narrow interface. Race-safe: anything created before this snapshot is included; anything created after is covered by `OnThreadCreated`.
3. **Phase 3 (tx)** — `BumpFollowVersionTx`, then `SELECT … FOR UPDATE` on the channel ext row to re-check `auto_follow_threads=1 AND group_unfollowed=0` (in case the user `UnfollowChannel`'d between phases). If eligible, `INSERT IGNORE` the thread ext rows. `INSERT IGNORE` keeps any overlap with concurrent `OnThreadCreated` writes safe; user manual `follow_sort` is preserved.

`follow_version` bump count is 0 (auth fail) / 1 (no enumerator or no active threads) / 2 (normal path including Phase 3 re-check skip) — **constant, not N-proportional**. Lock order is **version → ext** by construction in both phases, matching every other writer in the package.

### OnThreadCreated — synchronous batched fanout (round-3/4 lock-order fix)

Called from `thread.Service.CreateThread` **before** `sendThreadCreatedMessage` so a client receiving the thread-created notification will always find the new row already in its sidebar.

Initial `SELECT uid, space_id FROM user_conversation_ext WHERE target_type=2 AND target_id=? AND auto_follow_threads=1 ORDER BY uid, space_id`. The result is chunked into batches of `onThreadCreatedBatchSize=1000` (var, not const, so tests can shrink). Each batch's tx does three explicit ordered steps:

1. `bulkBumpFollowVersionTx` — `INSERT INTO user_follow_version VALUES (u1, s1, 1), … ON DUPLICATE KEY UPDATE version = version + 1`. **No source read.** Locks only `user_follow_version` rows.
2. `selectEligibleForFanoutTx` — `SELECT … FOR UPDATE` on the channel ext rows for the current batch, filtering to currently-eligible `(uid, space_id)`. Locks ext rows **after** version. Catches users who unfollowed between the initial SELECT and this batch.
3. `bulkInsertIgnoreThreadExtForUsersTx` — `INSERT IGNORE … VALUES` for the eligible subset only. No source read.

This is `version → ext` by construction, no longer relying on the MySQL `INSERT … SELECT` locking-reads semantics that round-3 review flagged as the opposite direction (next-key shared locks on source before X on dest under REPEATABLE READ).

`withDeadlockRetry` wraps each batch's `withTx` and retries on MySQL 1213 / 1205 up to 3 times with 5/20/80 ms backoff. `errors.As` pierces wrapped errors. Defense-in-depth so contention spikes self-heal without user retry.

Reasons for chunking:
- MySQL's 65 535 placeholder ceiling — at 4 placeholders per row the prior single-statement path would fail on channels with > ~16k followers (round-1 bug fix #3).
- Lock window per tx scales with batch, not N.
- `INSERT IGNORE` + monotonic version make partial-success across batches self-healing on the next FollowChannel / fanout call.

### UnfollowChannel + UnfollowGroupsTx parity

Both write `auto_follow_threads=0` alongside their existing actions (UnfollowChannel: also `group_unfollowed=1` + LIKE cascade DELETE thread rows; UnfollowGroupsTx: also LIKE cascade DELETE per group). Otherwise `OnThreadCreated` would keep selecting unfollowed users.

## Product invariants confirmed with PM

- Following a channel materializes every currently-active thread, including ones the user had previously single-thread-unfollowed — confirmed intentional "resurrect on refollow" behaviour.
- `UnfollowThread` on one thread does **not** clear `auto_follow_threads`. New threads still fan out to that user; only the one thread is gone.
- Threads created after the 500-row cap are picked up by `OnThreadCreated`. The product side enables thread auto-archive so active count stays under the cap; cap truncation drops the oldest (sorted by `created_at DESC`).
- Trust boundary for "who can subscribe to a channel's fanout" is **group membership + Space visibility**, matching `FollowThread`. Letting non-members opt in would defeat the round-1 metadata-disclosure mitigation.

## Performance baseline (Apple M5, containerised MySQL)

| benchmark | ns/op |
|---|---|
| `OnThreadCreated` N=100 | 5.8 ms |
| `OnThreadCreated` N=1,000 | 29 ms |
| `OnThreadCreated` N=10,000 | 275 ms (10 batches) |
| `FollowChannel` + 500-thread materialize | 16 ms |

Apple M5 is faster than the production target; prod numbers may be 3–5× higher.

## Commit-by-commit

| commit | scope |
|---|---|
| `52665102` `feat(conv_ext)` | schema migration + Model / ConvExtFields / Upsert plumbing |
| `9f0ec50a` `feat(conv_ext)` | FollowChannel cascade-materialize + UnfollowChannel clear + ThreadEnumerator |
| `0bbc1a0f` `feat(conv_ext,thread)` | OnThreadCreated fanout + thread.Service post-commit hook + message/1module.go wiring |
| `9bcdd5a0` `test(conv_ext)` | end-to-end lifecycle + benchmarks + REFACTOR to batched SQL + swagger |
| `8a3100b5` `fix(conv_ext)` | round-1: three review findings — UnfollowGroupsTx parity, FollowChannel race window, batch size limit |
| `b4d72964` `fix(conv_ext)` | round-2: auth gate, recheck race in Phase 3 + OnThreadCreated, fanout ordering vs notification, swagger/bench/migration polish |
| `cb661363` `fix(conv_ext)` | round-3: Phase 3 lock-order swap + CI migration ID list + nits |
| `4bbca5a0` `fix(conv_ext)` | round-4: real version→ext lock order via VALUES-based writes + deadlock retry |

## Test plan

- [x] `go test -race -tags=integration ./modules/conversation_ext/` (unit + integration)
- [x] `go test -race ./modules/thread/`
- [x] `go test ./modules/message/`
- [x] `go test ./modules/category/` (regression on `UnfollowGroupsTx` fix)
- [x] `go test ./pkg/db/` (migration ID list parity)
- [x] `go test -tags=integration -bench=. -benchmem -run=^$ ./modules/conversation_ext/` (perf baseline)
- [x] `gofmt -l` clean on changed files
- [x] `go vet ./...` clean
- [ ] Manual smoke: right-click follow / unfollow on a channel with 50+ threads via the test environment (im-test.deepminer.com.cn)

## Out of scope / follow-ups

Deferred from yujiawei's P2 reviews (acknowledged in PR comments, each is a small standalone enhancement):

- **Leave-group cleanup defensiveness** — if `RemoveConvExtForUserInSpace` fails after a member is kicked, their channel ext row keeps `auto_follow=1` and they'll keep getting (unread-able) sidebar entries until next \"channel cleanup\". IM ACL still gates message access, so cosmetic. Worth a periodic reaper.
- **Fanout failure metric** — currently `s.Warn` only. Add a Prometheus counter.
- **Silent 500-cap log** — emit a warn when `len(EnumerateActiveShortIDs) == cap` so oncall can notice if the product-side auto-archive falls behind.

Other:
- Client-side cluster-rendering rule (`follow_sort=0` rows placed after parent channel by `created_at DESC`) needs to be implemented by the mobile / desktop teams; server-side contract is documented in the refreshed swagger.
- `threadSeparator` ↔ `thread.ChannelIDSeparator` duplication — pre-existing, safe follow-up cleanup.