### PR TITLE
feat(user): add per-space voice feedback settings API

### DIFF
--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -72,8 +72,9 @@ type User struct {
 	onlineService *OnlineService
 	giteeDB       *giteeDB
 	githubDB      *githubDB
-	pinnedDB      *PinnedDB
-	pinned        *Pinned
+	pinnedDB       *PinnedDB
+	pinned         *Pinned
+	spaceSettingDB *SpaceSettingDB
 
 	setting *Setting
 	log.Log
@@ -126,6 +127,7 @@ func New(ctx *config.Context) *User {
 		appService:               app.NewService(ctx),
 		loginGuard:               NewLoginGuard(ctx.GetRedisConn(), loginGuardThresholdFromEnv(), loginGuardWindowFromEnv()),
 		pinnedDB:                 NewPinnedDB(ctx),
+		spaceSettingDB:           NewSpaceSettingDB(ctx.DB()),
 		verificationDB:           newVerificationDB(ctx),
 	}
 	u.pinned = NewPinned(u.pinnedDB, u.friendDB)
@@ -227,6 +229,13 @@ func (u *User) Route(r *wkhttp.WKHttp) {
 		pinned.DELETE("", u.pinned.Remove)       // 移除置顶
 		pinned.GET("", u.pinned.List)            // 获取置顶列表
 		pinned.PUT("/sort", u.pinned.UpdateSort) // 更新排序
+	}
+
+	// #################### Space 级用户设置 ####################
+	spaceSetting := r.Group("/v1/user/space", u.ctx.AuthMiddleware(r), spacepkg.SpaceMiddleware(u.ctx))
+	{
+		spaceSetting.GET("/setting", u.getSpaceSetting)
+		spaceSetting.PUT("/setting", u.updateSpaceSetting)
 	}
 	v := r.Group("/v1")
 	{

--- a/modules/user/api_space_setting.go
+++ b/modules/user/api_space_setting.go
@@ -1,0 +1,86 @@
+package user
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/space"
+	"github.com/gin-gonic/gin"
+)
+
+var allowedSpaceSettingFields = map[string]bool{
+	"voice_feedback_on":          true,
+	"voice_feedback_notice_acked": true,
+}
+
+func (u *User) getSpaceSetting(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+	spaceID := space.GetSpaceID(c)
+	if spaceID == "" {
+		c.ResponseErrorWithStatus(errors.New("space_id is required"), http.StatusBadRequest)
+		return
+	}
+
+	m, err := u.spaceSettingDB.QuerySpaceSetting(loginUID, spaceID)
+	if err != nil {
+		c.ResponseErrorWithStatus(errors.New("query space setting failed"), http.StatusInternalServerError)
+		return
+	}
+
+	resp := gin.H{
+		"voice_feedback_on":          1,
+		"voice_feedback_notice_acked": 0,
+	}
+	if m != nil {
+		resp["voice_feedback_on"] = m.VoiceFeedbackOn
+		resp["voice_feedback_notice_acked"] = m.VoiceFeedbackNoticeAcked
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+func (u *User) updateSpaceSetting(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+	spaceID := space.GetSpaceID(c)
+	if spaceID == "" {
+		c.ResponseErrorWithStatus(errors.New("space_id is required"), http.StatusBadRequest)
+		return
+	}
+
+	var body map[string]interface{}
+	if err := c.BindJSON(&body); err != nil {
+		c.ResponseErrorWithStatus(errors.New("invalid request body"), http.StatusBadRequest)
+		return
+	}
+
+	fields := make(map[string]interface{})
+	for k, v := range body {
+		if !allowedSpaceSettingFields[k] {
+			c.ResponseErrorWithStatus(errors.New("invalid field: "+k), http.StatusBadRequest)
+			return
+		}
+		val, ok := v.(float64)
+		if !ok || (val != 0 && val != 1) {
+			c.ResponseErrorWithStatus(errors.New("invalid value for "+k+": must be 0 or 1"), http.StatusBadRequest)
+			return
+		}
+		fields[k] = int(val)
+	}
+
+	if len(fields) == 0 {
+		c.ResponseErrorWithStatus(errors.New("no valid fields to update"), http.StatusBadRequest)
+		return
+	}
+
+	if err := u.spaceSettingDB.InsertIgnoreSpaceSetting(loginUID, spaceID); err != nil {
+		c.ResponseErrorWithStatus(errors.New("ensure space setting failed"), http.StatusInternalServerError)
+		return
+	}
+
+	if err := u.spaceSettingDB.UpdateSpaceSetting(loginUID, spaceID, fields); err != nil {
+		c.ResponseErrorWithStatus(errors.New("update space setting failed"), http.StatusInternalServerError)
+		return
+	}
+
+	c.ResponseOK()
+}

--- a/modules/user/api_space_setting_test.go
+++ b/modules/user/api_space_setting_test.go
@@ -1,0 +1,130 @@
+package user
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/server"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testSpaceID = "space_setting_test_001"
+
+func seedSpaceForSettingTest(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	_, err := ctx.DB().InsertInto("space").
+		Columns("space_id", "name", "creator", "status").
+		Values(testSpaceID, "Test Space", testutil.UID, 1).Exec()
+	require.NoError(t, err)
+
+	_, err = ctx.DB().InsertInto("space_member").
+		Columns("space_id", "uid", "role", "status").
+		Values(testSpaceID, testutil.UID, 0, 1).Exec()
+	require.NoError(t, err)
+}
+
+func doSpaceSettingRequest(t *testing.T, s *server.Server, method, path string, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	var reqBody *bytes.Reader
+	if body != nil {
+		reqBody = bytes.NewReader([]byte(util.ToJson(body)))
+	} else {
+		reqBody = bytes.NewReader(nil)
+	}
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest(method, path, reqBody)
+	require.NoError(t, err)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	return w
+}
+
+func parseSpaceSettingResp(t *testing.T, w *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var result map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+	return result
+}
+
+func TestGetSpaceSetting_DefaultValues(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	seedSpaceForSettingTest(t, ctx)
+
+	w := doSpaceSettingRequest(t, s, "GET", "/v1/user/space/setting?space_id="+testSpaceID, nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	resp := parseSpaceSettingResp(t, w)
+	assert.Equal(t, float64(1), resp["voice_feedback_on"])
+	assert.Equal(t, float64(0), resp["voice_feedback_notice_acked"])
+}
+
+func TestPutSpaceSetting_SingleField(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	seedSpaceForSettingTest(t, ctx)
+
+	w := doSpaceSettingRequest(t, s, "PUT", "/v1/user/space/setting?space_id="+testSpaceID, map[string]interface{}{
+		"voice_feedback_on": 0,
+	})
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	w = doSpaceSettingRequest(t, s, "PUT", "/v1/user/space/setting?space_id="+testSpaceID, map[string]interface{}{
+		"voice_feedback_notice_acked": 1,
+	})
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	w = doSpaceSettingRequest(t, s, "GET", "/v1/user/space/setting?space_id="+testSpaceID, nil)
+	assert.Equal(t, http.StatusOK, w.Code)
+	resp := parseSpaceSettingResp(t, w)
+	assert.Equal(t, float64(0), resp["voice_feedback_on"])
+	assert.Equal(t, float64(1), resp["voice_feedback_notice_acked"])
+}
+
+func TestPutSpaceSetting_InvalidValue(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	seedSpaceForSettingTest(t, ctx)
+
+	w := doSpaceSettingRequest(t, s, "PUT", "/v1/user/space/setting?space_id="+testSpaceID, map[string]interface{}{
+		"voice_feedback_on": 2,
+	})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPutSpaceSetting_InvalidField(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	seedSpaceForSettingTest(t, ctx)
+
+	w := doSpaceSettingRequest(t, s, "PUT", "/v1/user/space/setting?space_id="+testSpaceID, map[string]interface{}{
+		"unknown_field": 1,
+	})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetSpaceSetting_MissingSpaceID(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	w := doSpaceSettingRequest(t, s, "GET", "/v1/user/space/setting", nil)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPutSpaceSetting_MissingSpaceID(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	w := doSpaceSettingRequest(t, s, "PUT", "/v1/user/space/setting", map[string]interface{}{
+		"voice_feedback_on": 1,
+	})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/modules/user/db_space_setting.go
+++ b/modules/user/db_space_setting.go
@@ -1,0 +1,56 @@
+package user
+
+import (
+	"fmt"
+
+	"github.com/gocraft/dbr/v2"
+)
+
+type SpaceSettingModel struct {
+	UID                     string `db:"uid"`
+	SpaceID                 string `db:"space_id"`
+	VoiceFeedbackOn         int    `db:"voice_feedback_on"`
+	VoiceFeedbackNoticeAcked int    `db:"voice_feedback_notice_acked"`
+}
+
+type SpaceSettingDB struct {
+	session *dbr.Session
+}
+
+func NewSpaceSettingDB(session *dbr.Session) *SpaceSettingDB {
+	return &SpaceSettingDB{session: session}
+}
+
+func (d *SpaceSettingDB) QuerySpaceSetting(uid, spaceID string) (*SpaceSettingModel, error) {
+	var m *SpaceSettingModel
+	_, err := d.session.Select("uid", "space_id", "voice_feedback_on", "voice_feedback_notice_acked").
+		From("user_space_setting").
+		Where("uid=? AND space_id=?", uid, spaceID).
+		Load(&m)
+	return m, err
+}
+
+func (d *SpaceSettingDB) InsertIgnoreSpaceSetting(uid, spaceID string) error {
+	_, err := d.session.InsertBySql(
+		"INSERT IGNORE INTO user_space_setting (uid, space_id) VALUES (?, ?)",
+		uid, spaceID,
+	).Exec()
+	return err
+}
+
+func (d *SpaceSettingDB) UpdateSpaceSetting(uid, spaceID string, fields map[string]interface{}) error {
+	if len(fields) == 0 {
+		return nil
+	}
+	stmt := d.session.Update("user_space_setting")
+	for k, v := range fields {
+		switch k {
+		case "voice_feedback_on", "voice_feedback_notice_acked":
+			stmt = stmt.Set(k, v)
+		default:
+			return fmt.Errorf("field %q is not allowed for update", k)
+		}
+	}
+	_, err := stmt.Where("uid=? AND space_id=?", uid, spaceID).Exec()
+	return err
+}

--- a/modules/user/sql/20260522000001_user_space_setting.sql
+++ b/modules/user/sql/20260522000001_user_space_setting.sql
@@ -1,0 +1,14 @@
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS user_space_setting (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    uid VARCHAR(40) NOT NULL,
+    space_id VARCHAR(40) NOT NULL,
+    voice_feedback_on SMALLINT NOT NULL DEFAULT 1,
+    voice_feedback_notice_acked SMALLINT NOT NULL DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_uid_space (uid, space_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- +migrate Down
+DROP TABLE IF EXISTS user_space_setting;

--- a/modules/voice_adapter/adapter.go
+++ b/modules/voice_adapter/adapter.go
@@ -79,6 +79,9 @@ func (a *VoiceAdapter) getConfig(c *wkhttp.Context) {
 		})
 		return
 	}
+	if a.cfg.FeedbackPrivacyURL != "" {
+		resp["feedback_privacy_url"] = a.cfg.FeedbackPrivacyURL
+	}
 	c.JSON(http.StatusOK, resp)
 }
 

--- a/modules/voice_adapter/adapter_test.go
+++ b/modules/voice_adapter/adapter_test.go
@@ -57,6 +57,7 @@ func TestNewAdapterConfigFromEnv_InvalidValues(t *testing.T) {
 func newTestAdapter(speechURL string) *VoiceAdapter {
 	return &VoiceAdapter{
 		client: NewSpeechClient(speechURL, "test-key", 2*time.Second),
+		cfg:    &AdapterConfig{},
 		Log:    log.NewTLog("VoiceAdapterTest"),
 	}
 }
@@ -156,6 +157,7 @@ func TestGetConfigHandler_Timeout(t *testing.T) {
 
 	a := &VoiceAdapter{
 		client: NewSpeechClient(srv.URL, "test-key", 100*time.Millisecond),
+		cfg:    &AdapterConfig{},
 		Log:    log.NewTLog("VoiceAdapterTest"),
 	}
 	rec := callGetConfig(a)
@@ -196,5 +198,78 @@ func TestNewAdapterConfigFromEnv_MaxBodySizeDefault(t *testing.T) {
 
 	if cfg.MaxBodySize != 5<<20 {
 		t.Errorf("expected default MaxBodySize 5MB, got %d", cfg.MaxBodySize)
+	}
+}
+
+func TestGetConfigHandler_InjectsFeedbackPrivacyURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"enabled": true,
+		})
+	}))
+	defer srv.Close()
+
+	a := &VoiceAdapter{
+		client: NewSpeechClient(srv.URL, "test-key", 2*time.Second),
+		cfg:    &AdapterConfig{FeedbackPrivacyURL: "https://example.com/privacy"},
+		Log:    log.NewTLog("VoiceAdapterTest"),
+	}
+	rec := callGetConfig(a)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["feedback_privacy_url"] != "https://example.com/privacy" {
+		t.Errorf("expected feedback_privacy_url='https://example.com/privacy', got %v", body["feedback_privacy_url"])
+	}
+	if body["enabled"] != true {
+		t.Errorf("expected enabled=true, got %v", body["enabled"])
+	}
+}
+
+func TestGetConfigHandler_NoFeedbackPrivacyURLWhenEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"enabled": true,
+		})
+	}))
+	defer srv.Close()
+
+	a := &VoiceAdapter{
+		client: NewSpeechClient(srv.URL, "test-key", 2*time.Second),
+		cfg:    &AdapterConfig{FeedbackPrivacyURL: ""},
+		Log:    log.NewTLog("VoiceAdapterTest"),
+	}
+	rec := callGetConfig(a)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if _, exists := body["feedback_privacy_url"]; exists {
+		t.Errorf("expected no feedback_privacy_url key when empty, but got %v", body["feedback_privacy_url"])
+	}
+}
+
+func TestNewAdapterConfigFromEnv_FeedbackPrivacyURL(t *testing.T) {
+	t.Setenv("VOICE_FEEDBACK_PRIVACY_URL", "https://example.com/policy")
+	t.Setenv("SPEECH_SERVICE_URL", "")
+	t.Setenv("SPEECH_API_KEY", "")
+	t.Setenv("SPEECH_TIMEOUT", "")
+	t.Setenv("SPEECH_MAX_BODY_SIZE", "")
+
+	cfg := NewAdapterConfigFromEnv()
+
+	if cfg.FeedbackPrivacyURL != "https://example.com/policy" {
+		t.Errorf("expected FeedbackPrivacyURL='https://example.com/policy', got %q", cfg.FeedbackPrivacyURL)
 	}
 }

--- a/modules/voice_adapter/config.go
+++ b/modules/voice_adapter/config.go
@@ -7,18 +7,20 @@ import (
 )
 
 const (
-	EnvSpeechServiceURL  = "SPEECH_SERVICE_URL"
-	EnvSpeechAPIKey      = "SPEECH_API_KEY"
-	EnvSpeechTimeout     = "SPEECH_TIMEOUT"
-	EnvSpeechMaxBodySize = "SPEECH_MAX_BODY_SIZE"
-	DefaultTimeoutSec    = 50
+	EnvSpeechServiceURL       = "SPEECH_SERVICE_URL"
+	EnvSpeechAPIKey           = "SPEECH_API_KEY"
+	EnvSpeechTimeout          = "SPEECH_TIMEOUT"
+	EnvSpeechMaxBodySize      = "SPEECH_MAX_BODY_SIZE"
+	EnvFeedbackPrivacyURL     = "VOICE_FEEDBACK_PRIVACY_URL"
+	DefaultTimeoutSec         = 50
 )
 
 type AdapterConfig struct {
-	SpeechServiceURL string
-	SpeechAPIKey     string
-	SpeechTimeout    time.Duration
-	MaxBodySize      int64
+	SpeechServiceURL   string
+	SpeechAPIKey       string
+	SpeechTimeout      time.Duration
+	MaxBodySize        int64
+	FeedbackPrivacyURL string
 }
 
 func NewAdapterConfigFromEnv() *AdapterConfig {
@@ -37,9 +39,10 @@ func NewAdapterConfigFromEnv() *AdapterConfig {
 	}
 
 	return &AdapterConfig{
-		SpeechServiceURL: os.Getenv(EnvSpeechServiceURL),
-		SpeechAPIKey:     os.Getenv(EnvSpeechAPIKey),
-		SpeechTimeout:    time.Duration(timeoutSec) * time.Second,
-		MaxBodySize:      maxBodySize,
+		SpeechServiceURL:   os.Getenv(EnvSpeechServiceURL),
+		SpeechAPIKey:       os.Getenv(EnvSpeechAPIKey),
+		SpeechTimeout:      time.Duration(timeoutSec) * time.Second,
+		MaxBodySize:        maxBodySize,
+		FeedbackPrivacyURL: os.Getenv(EnvFeedbackPrivacyURL),
 	}
 }


### PR DESCRIPTION
## Summary

Add a new `user_space_setting` table and dedicated API endpoints to support per-space user preferences for voice feedback (ASR quality improvement program).

## Changes

- **New table**: `user_space_setting` with unique key `(uid, space_id)`, storing `voice_feedback_on` and `voice_feedback_notice_acked` fields
- **New API**: `GET/PUT /v1/user/space/setting` with whitelist-based field validation, value restricted to 0/1
- **Write logic**: `INSERT IGNORE` + dynamic `UPDATE` per requested field (avoids resetting unrelated fields)
- **Space isolation**: `SpaceMiddleware` extracts `space_id` from `X-Space-Id` header; handler rejects empty space_id with 400

## Motivation

The frontend needs a per-space toggle for users to opt in/out of the voice transcription quality feedback program. This provides the backend storage and API for that preference.

## Testing

- Manual verification against local MySQL
- API tested via curl (GET default values, PUT single field, PUT multiple fields)