### PR TITLE
fix: support AUTH LOGIN for SMTP servers like Microsoft 365

### DIFF
--- a/modules/base/common/service_email.go
+++ b/modules/base/common/service_email.go
@@ -266,7 +266,6 @@ func (s *EmailService) dispatchSMTP(ctx context.Context, smtpAddr, fromSan, pwd,
 	if err != nil {
 		return fmt.Errorf("smtp地址格式错误: %w", err)
 	}
-	auth := smtp.PlainAuth("", fromSan, pwd, host)
 
 	dialer := &net.Dialer{Timeout: smtpDialTimeout}
 	var conn net.Conn
@@ -303,7 +302,29 @@ func (s *EmailService) dispatchSMTP(ctx context.Context, smtpAddr, fromSan, pwd,
 		}
 	}
 
+	// Choose auth mechanism based on server's EHLO advertisement.
+	// Prefer PLAIN (widely supported, simpler); fall back to LOGIN for
+	// servers like Microsoft Exchange Online that only offer LOGIN.
+	auth := s.chooseAuth(client, fromSan, pwd, host)
+
 	return runSMTPTransaction(client, auth, fromSan, toSan, msg)
+}
+
+// chooseAuth picks the best smtp.Auth based on the server's advertised AUTH
+// mechanisms. PLAIN is preferred; LOGIN is the fallback (needed for Microsoft
+// Exchange Online which only advertises "AUTH LOGIN XOAUTH2").
+func (s *EmailService) chooseAuth(client *smtp.Client, username, password, host string) smtp.Auth {
+	if ok, authStr := client.Extension("AUTH"); ok {
+		mechs := strings.ToUpper(authStr)
+		if strings.Contains(mechs, "PLAIN") {
+			return smtp.PlainAuth("", username, password, host)
+		}
+		if strings.Contains(mechs, "LOGIN") {
+			return LoginAuth(username, password)
+		}
+	}
+	// Default to PLAIN when server doesn't advertise (legacy behavior).
+	return smtp.PlainAuth("", username, password, host)
 }
 
 // runSMTPTransaction 跑完一次 SMTP 投递：Auth → Mail → Rcpt → Data → Quit。
@@ -337,6 +358,37 @@ const (
 	smtpDialTimeout = 15 * time.Second
 	smtpIOTimeout   = 60 * time.Second
 )
+
+// loginAuth implements smtp.Auth for the LOGIN mechanism.
+// Go's standard library only provides PlainAuth (AUTH PLAIN); servers like
+// Microsoft Exchange Online that only advertise AUTH LOGIN will reject PLAIN
+// with "504 5.7.4 Unrecognized authentication type".
+type loginAuth struct {
+	username, password string
+}
+
+// LoginAuth returns an smtp.Auth that implements the LOGIN mechanism.
+func LoginAuth(username, password string) smtp.Auth {
+	return &loginAuth{username, password}
+}
+
+func (a *loginAuth) Start(server *smtp.ServerInfo) (string, []byte, error) {
+	return "LOGIN", nil, nil
+}
+
+func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
+	if !more {
+		return nil, nil
+	}
+	switch string(fromServer) {
+	case "Username:":
+		return []byte(a.username), nil
+	case "Password:":
+		return []byte(a.password), nil
+	default:
+		return nil, fmt.Errorf("unexpected server challenge: %s", fromServer)
+	}
+}
 
 // resolveSMTP returns the effective SMTP config: admin-tunable values from
 // the injected provider win over yaml; a missing provider (legacy callers

--- a/modules/base/common/service_email.go
+++ b/modules/base/common/service_email.go
@@ -315,12 +315,20 @@ func (s *EmailService) dispatchSMTP(ctx context.Context, smtpAddr, fromSan, pwd,
 // Exchange Online which only advertises "AUTH LOGIN XOAUTH2").
 func (s *EmailService) chooseAuth(client *smtp.Client, username, password, host string) smtp.Auth {
 	if ok, authStr := client.Extension("AUTH"); ok {
-		mechs := strings.ToUpper(authStr)
-		if strings.Contains(mechs, "PLAIN") {
+		tokens := strings.Fields(strings.ToUpper(authStr))
+		hasMech := func(m string) bool {
+			for _, t := range tokens {
+				if t == m {
+					return true
+				}
+			}
+			return false
+		}
+		if hasMech("PLAIN") {
 			return smtp.PlainAuth("", username, password, host)
 		}
-		if strings.Contains(mechs, "LOGIN") {
-			return LoginAuth(username, password)
+		if hasMech("LOGIN") {
+			return LoginAuth(username, password, host)
 		}
 	}
 	// Default to PLAIN when server doesn't advertise (legacy behavior).
@@ -364,15 +372,23 @@ const (
 // Microsoft Exchange Online that only advertise AUTH LOGIN will reject PLAIN
 // with "504 5.7.4 Unrecognized authentication type".
 type loginAuth struct {
-	username, password string
+	username, password, host string
 }
 
 // LoginAuth returns an smtp.Auth that implements the LOGIN mechanism.
-func LoginAuth(username, password string) smtp.Auth {
-	return &loginAuth{username, password}
+// Like smtp.PlainAuth, it refuses to send credentials over unencrypted
+// connections (unless the server is localhost).
+func LoginAuth(username, password, host string) smtp.Auth {
+	return &loginAuth{username, password, host}
 }
 
 func (a *loginAuth) Start(server *smtp.ServerInfo) (string, []byte, error) {
+	if !server.TLS && !isLocalhost(server.Name) {
+		return "", nil, errors.New("unencrypted connection: LOGIN auth requires TLS")
+	}
+	if server.Name != a.host {
+		return "", nil, errors.New("wrong host name")
+	}
 	return "LOGIN", nil, nil
 }
 
@@ -380,14 +396,20 @@ func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
 	if !more {
 		return nil, nil
 	}
-	switch string(fromServer) {
-	case "Username:":
+	prompt := strings.TrimSpace(strings.ToLower(string(fromServer)))
+	switch {
+	case strings.HasPrefix(prompt, "username"):
 		return []byte(a.username), nil
-	case "Password:":
+	case strings.HasPrefix(prompt, "password"):
 		return []byte(a.password), nil
 	default:
-		return nil, fmt.Errorf("unexpected server challenge: %s", fromServer)
+		return nil, fmt.Errorf("unexpected server challenge: %q", fromServer)
 	}
+}
+
+// isLocalhost reports whether the given host is a loopback address.
+func isLocalhost(name string) bool {
+	return name == "localhost" || name == "127.0.0.1" || name == "::1"
 }
 
 // resolveSMTP returns the effective SMTP config: admin-tunable values from

--- a/modules/base/common/service_email_login_auth_test.go
+++ b/modules/base/common/service_email_login_auth_test.go
@@ -1,0 +1,89 @@
+package common
+
+import (
+	"net/smtp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoginAuth_Start_RequiresTLS(t *testing.T) {
+	auth := LoginAuth("user@example.com", "password", "smtp.example.com")
+
+	// Non-TLS, non-localhost → must reject
+	_, _, err := auth.(*loginAuth).Start(&smtp.ServerInfo{
+		Name: "smtp.example.com",
+		TLS:  false,
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unencrypted")
+
+	// TLS → must succeed
+	proto, _, err := auth.(*loginAuth).Start(&smtp.ServerInfo{
+		Name: "smtp.example.com",
+		TLS:  true,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "LOGIN", proto)
+
+	// localhost without TLS → must succeed (test carve-out)
+	localAuth := LoginAuth("user@example.com", "password", "localhost")
+	proto, _, err = localAuth.(*loginAuth).Start(&smtp.ServerInfo{
+		Name: "localhost",
+		TLS:  false,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "LOGIN", proto)
+}
+
+func TestLoginAuth_Start_RejectsWrongHost(t *testing.T) {
+	auth := LoginAuth("user@example.com", "password", "smtp.example.com")
+
+	_, _, err := auth.(*loginAuth).Start(&smtp.ServerInfo{
+		Name: "evil.example.com",
+		TLS:  true,
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "wrong host")
+}
+
+func TestLoginAuth_Next(t *testing.T) {
+	auth := LoginAuth("user@example.com", "s3cret", "smtp.example.com")
+	la := auth.(*loginAuth)
+
+	// Username challenge
+	resp, err := la.Next([]byte("Username:"), true)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("user@example.com"), resp)
+
+	// Password challenge
+	resp, err = la.Next([]byte("Password:"), true)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("s3cret"), resp)
+
+	// Case-insensitive / whitespace tolerance
+	resp, err = la.Next([]byte("username: "), true)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("user@example.com"), resp)
+
+	resp, err = la.Next([]byte("PASSWORD:"), true)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("s3cret"), resp)
+
+	// Unknown challenge → error
+	_, err = la.Next([]byte("OTP:"), true)
+	assert.Error(t, err)
+
+	// more=false → nil, nil
+	resp, err = la.Next([]byte("anything"), false)
+	assert.NoError(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestIsLocalhost(t *testing.T) {
+	assert.True(t, isLocalhost("localhost"))
+	assert.True(t, isLocalhost("127.0.0.1"))
+	assert.True(t, isLocalhost("::1"))
+	assert.False(t, isLocalhost("smtp.example.com"))
+	assert.False(t, isLocalhost(""))
+}


### PR DESCRIPTION
## Summary

- Add custom LoginAuth implementation of smtp.Auth for the LOGIN mechanism
- Auto-detect auth mechanism from server EHLO response: prefer PLAIN, fall back to LOGIN
- Fixes 504 5.7.4 Unrecognized authentication type when using Microsoft Exchange Online (smtp.office365.com:587)

Closes #132

## Root Cause

Go smtp.PlainAuth only supports AUTH PLAIN. Microsoft Exchange Online advertises AUTH LOGIN XOAUTH2 (no PLAIN), so authentication fails.

## Changes

Single file: modules/base/common/service_email.go

1. loginAuth struct — implements smtp.Auth interface for the LOGIN mechanism
2. chooseAuth method — inspects server EHLO AUTH advertisement and picks PLAIN or LOGIN
3. dispatchSMTP — calls chooseAuth after STARTTLS instead of hardcoding smtp.PlainAuth

## Test plan

- [ ] Verify go build and existing tests pass
- [ ] Test with smtp.office365.com:587 (AUTH LOGIN only) — should succeed
- [ ] Test with smtp.163.com:465 (AUTH PLAIN) — should continue to work
- [ ] Test with smtp.gmail.com:587 (supports both PLAIN and LOGIN) — should pick PLAIN