### PR TITLE
feat(redis): wire RedisTLS config into direct go-redis NewClient sites

### DIFF
--- a/configs/tsdd.yaml
+++ b/configs/tsdd.yaml
@@ -28,6 +28,9 @@ mode: "debug" #   运行模式 debug or release
 #  mysqlAddr: "root:demo@tcp(127.0.0.1:3306)/test?charset=utf8mb4&parseTime=true" # mysql连接地址
 #  redisAddr: "" # redis地址
 #  redisPass: "" # redis密码
+#  redisTLS: false # 启用 TLS（rediss://），用于 AWS ElastiCache / Azure Cache 等托管服务
+#  redisTLSInsecureSkipVerify: false # 跳过 TLS 证书校验（仅用于测试 / 自签名证书）
+#  redisTLSCAFile: "" # 自定义 CA 证书路径（可选，留空走系统 CA 池）
 #  asynctaskRedisAddr: "" # 异步任务的redis地址 不写默认为RedisAddr的地址
 
 ##################### 外网配置 ####################

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25
 require (
 	firebase.google.com/go/v4 v4.13.0
 	github.com/DATA-DOG/go-sqlmock v1.5.0
-	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260515014003-2cdafe082b88
+	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260522122557-a65ecee15fc5
 	github.com/alibabacloud-go/darabonba-openapi v0.2.1
 	github.com/alibabacloud-go/sms-intl-20180501 v1.0.1
 	github.com/alibabacloud-go/tea v1.2.1
@@ -54,7 +54,6 @@ require (
 	google.golang.org/protobuf v1.31.0
 	gopkg.in/go-playground/assert.v1 v1.2.1
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -174,4 +173,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260515014003-2cdafe082b88 h1:vPmjG30TUCzF46/sb/JqUWf0y1Lqey9w9cJuzicj3dU=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260515014003-2cdafe082b88/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260522122557-a65ecee15fc5 h1:tTfDcI52V41vRKgJCAQdfwLumBq8vsiVlBvX1VJeVaY=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260522122557-a65ecee15fc5/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae h1:DcFpTQBYQ9Ct2d6sC7ol0/ynxc2pO1cpGUM+f4t5adg=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae/go.mod h1:rJJ84PyA/Wlmw1hO+xTzV2wsSUon6J5ktg0g8BF2PuU=
 github.com/RichardKnop/machinery/v2 v2.0.11 h1:BTfLGOmOju3W/OtlZmLX26OjYNZsU4PJo04pQReycdc=

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	octodb "github.com/Mininglamp-OSS/octo-server/pkg/db"
 	"github.com/Mininglamp-OSS/octo-server/pkg/metrics"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	"github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"github.com/gin-gonic/gin"
 	rd "github.com/go-redis/redis"
@@ -124,12 +125,10 @@ func runAPI(ctx *config.Context) {
 	// 生命周期：跟随进程存续，不显式 Close——与 lib 自身的 redis.Conn 处理方式一致。
 	// PoolSize 显式设 10：令牌桶 Lua 脚本是短事务，Redis 端 <1ms，不需要大池；
 	// go-redis v6 默认 10*NumCPU 在大核机上会失控（多副本 × 多 client 连接数叠加）。
-	rlRedis := rd.NewClient(&rd.Options{
-		Addr:       ctx.GetConfig().DB.RedisAddr,
-		Password:   ctx.GetConfig().DB.RedisPass,
-		MaxRetries: 1,
-		PoolSize:   10,
-	})
+	rlRedis := rd.NewClient(octoredis.MustBuildOptions(ctx.GetConfig(), func(o *rd.Options) {
+		o.MaxRetries = 1
+		o.PoolSize = 10
+	}))
 	s.GetRoute().UseGin(wkhttp.RateLimitMiddleware(context.Background(), rlRedis, rps, burst, "/v1/ping"))
 	// CORS 白名单覆盖：dmwork-lib 的 server.New 默认注入 "*" + Credentials:true，
 	// 本中间件在其后执行，按 DM_CORS_ALLOWED_ORIGINS 重写/剥离 Allow-Origin/Credentials。

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/source"
 	spacemod "github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"github.com/gin-gonic/gin"
@@ -143,12 +144,10 @@ func (g *Group) Route(r *wkhttp.WKHttp) {
 	//   - DM_API_GROUP_INVITE_RPS   每秒填充速率（float，缺省 60.0）
 	//   - DM_API_GROUP_INVITE_BURST 桶容量（int，缺省 200）
 	// 生产环境如需收紧，在部署时设置 env（如 RPS=0.1667 / BURST=5 恢复到 10 req/min）。
-	rlRedis := redis.NewClient(&redis.Options{
-		Addr:       g.ctx.GetConfig().DB.RedisAddr,
-		Password:   g.ctx.GetConfig().DB.RedisPass,
-		MaxRetries: 1,
-		PoolSize:   10,
-	})
+	rlRedis := redis.NewClient(octoredis.MustBuildOptions(g.ctx.GetConfig(), func(o *redis.Options) {
+		o.MaxRetries = 1
+		o.PoolSize = 10
+	}))
 	inviteRPS := appwkhttp.ParseRPSFromEnv("DM_API_GROUP_INVITE_RPS", 60.0) // 默认 60 rps ≈ 3600 req/min
 	inviteBurst := appwkhttp.ParseBurstFromEnv("DM_API_GROUP_INVITE_BURST", 200)
 	groupInviteLimit := appwkhttp.StrictIPRateLimitMiddleware(context.Background(), rlRedis, "group_invite", inviteRPS, inviteBurst)

--- a/modules/oidc/bind_store_redis.go
+++ b/modules/oidc/bind_store_redis.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	rd "github.com/go-redis/redis"
 )
 
@@ -68,15 +69,12 @@ type redisBindStore struct {
 }
 
 func newRedisBindStore(ctx *config.Context) *redisBindStore {
-	cfg := ctx.GetConfig()
-	client := rd.NewClient(&rd.Options{
-		Addr:         cfg.DB.RedisAddr,
-		Password:     cfg.DB.RedisPass,
-		MaxRetries:   3,
-		ReadTimeout:  3 * time.Second,
-		WriteTimeout: 3 * time.Second,
-		DialTimeout:  3 * time.Second,
-	})
+	client := rd.NewClient(octoredis.MustBuildOptions(ctx.GetConfig(), func(o *rd.Options) {
+		o.MaxRetries = 3
+		o.ReadTimeout = 3 * time.Second
+		o.WriteTimeout = 3 * time.Second
+		o.DialTimeout = 3 * time.Second
+	}))
 	return &redisBindStore{client: client}
 }
 

--- a/modules/oidc/state_store_redis.go
+++ b/modules/oidc/state_store_redis.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	rd "github.com/go-redis/redis"
 )
 
@@ -35,15 +36,12 @@ type redisStateStore struct {
 }
 
 func newRedisStateStore(ctx *config.Context) *redisStateStore {
-	cfg := ctx.GetConfig()
-	client := rd.NewClient(&rd.Options{
-		Addr:         cfg.DB.RedisAddr,
-		Password:     cfg.DB.RedisPass,
-		MaxRetries:   3,
-		ReadTimeout:  3 * time.Second,
-		WriteTimeout: 3 * time.Second,
-		DialTimeout:  3 * time.Second,
-	})
+	client := rd.NewClient(octoredis.MustBuildOptions(ctx.GetConfig(), func(o *rd.Options) {
+		o.MaxRetries = 3
+		o.ReadTimeout = 3 * time.Second
+		o.WriteTimeout = 3 * time.Second
+		o.DialTimeout = 3 * time.Second
+	}))
 	return &redisStateStore{client: client}
 }
 

--- a/modules/oidc/sync_lock.go
+++ b/modules/oidc/sync_lock.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	rd "github.com/go-redis/redis"
 )
 
@@ -51,15 +52,12 @@ type RedisTickLock struct {
 }
 
 func newRedisTickLock(ctx *config.Context) *RedisTickLock {
-	cfg := ctx.GetConfig()
-	client := rd.NewClient(&rd.Options{
-		Addr:         cfg.DB.RedisAddr,
-		Password:     cfg.DB.RedisPass,
-		MaxRetries:   3,
-		ReadTimeout:  3 * time.Second,
-		WriteTimeout: 3 * time.Second,
-		DialTimeout:  3 * time.Second,
-	})
+	client := rd.NewClient(octoredis.MustBuildOptions(ctx.GetConfig(), func(o *rd.Options) {
+		o.MaxRetries = 3
+		o.ReadTimeout = 3 * time.Second
+		o.WriteTimeout = 3 * time.Second
+		o.DialTimeout = 3 * time.Second
+	}))
 	return &RedisTickLock{client: client}
 }
 

--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkevent"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	rd "github.com/go-redis/redis"
@@ -96,12 +97,10 @@ func (s *Space) Route(r *wkhttp.WKHttp) {
 	// 两个端点共享同一 limiter，使同一 IP 跨端点总配额受控。
 	// 阈值与 user 模块 login 同档（10 req/min, burst 5），详见 PR #1090。
 	// PoolSize=10：Lua 脚本短事务，与 user 模块 / main.go 保持一致。
-	rlRedis := rd.NewClient(&rd.Options{
-		Addr:       s.ctx.GetConfig().DB.RedisAddr,
-		Password:   s.ctx.GetConfig().DB.RedisPass,
-		MaxRetries: 1,
-		PoolSize:   10,
-	})
+	rlRedis := rd.NewClient(octoredis.MustBuildOptions(s.ctx.GetConfig(), func(o *rd.Options) {
+		o.MaxRetries = 1
+		o.PoolSize = 10
+	}))
 	invitePreviewLimit := appwkhttp.StrictIPRateLimitMiddleware(context.Background(), rlRedis, "space_invite", 10.0/60, 5)
 
 	open := r.Group("/v1/space")

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/model"
 	"github.com/Mininglamp-OSS/octo-server/modules/file"
 	"github.com/Mininglamp-OSS/octo-server/modules/source"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	rd "github.com/go-redis/redis"
@@ -153,12 +154,10 @@ func (u *User) Route(r *wkhttp.WKHttp) {
 	rlCtx := context.Background()
 	// 限流状态存 Redis，多副本共享配额；生命周期跟随进程，与 main.go 的做法一致
 	// PoolSize 显式设 10：理由同 main.go——限流 Lua 脚本短事务，不需要大池。
-	rlRedis := rd.NewClient(&rd.Options{
-		Addr:       u.ctx.GetConfig().DB.RedisAddr,
-		Password:   u.ctx.GetConfig().DB.RedisPass,
-		MaxRetries: 1,
-		PoolSize:   10,
-	})
+	rlRedis := rd.NewClient(octoredis.MustBuildOptions(u.ctx.GetConfig(), func(o *rd.Options) {
+		o.MaxRetries = 1
+		o.PoolSize = 10
+	}))
 	// burst 取小值：人类正常重试容忍 + 不给攻击者初始白嫖窗口
 	// tag 用稳定字符串分离 keyspace；注意 register 和 sms 参数相同但语义不同，必须分开
 	loginLimit := appwkhttp.StrictIPRateLimitMiddleware(rlCtx, rlRedis, "login", 10.0/60, 5)       // 10 req/min, burst 5

--- a/pkg/db/redis.go
+++ b/pkg/db/redis.go
@@ -1,7 +1,17 @@
 package db
 
-import "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+import (
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/pkg/redis"
+)
 
+// NewRedis 兼容旧调用方，不会启用 TLS。
+// 新代码应优先用 NewRedisFromConfig 以自动应用 TLS 等公共配置。
 func NewRedis(addr string, password string) *redis.Conn {
 	return redis.New(addr, password)
+}
+
+// NewRedisFromConfig 从 cfg 构造 Redis 连接，自动应用 RedisTLS / CA 等设置。
+func NewRedisFromConfig(cfg *config.Config) *redis.Conn {
+	return redis.NewWithOptions(redis.MustBuildOptions(cfg))
 }

--- a/pkg/redis/options.go
+++ b/pkg/redis/options.go
@@ -1,0 +1,56 @@
+package redis
+
+import (
+	"fmt"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	liboredis "github.com/Mininglamp-OSS/octo-lib/pkg/redis"
+	rd "github.com/go-redis/redis"
+)
+
+// OptionsOverride 允许调用方覆盖 BuildOptions 默认值。
+// Addr / Password / TLSConfig 由 cfg 决定，不在此处暴露，避免绕过 TLS 设置。
+type OptionsOverride func(*rd.Options)
+
+// BuildOptions 根据 cfg.DB 中的 Redis 相关字段构造 *redis.Options。
+//
+// 统一处理 Addr / Password / TLSConfig，所有在 octo-server 内直接使用
+// rd.NewClient 的位置（限流、OIDC、模块级 NewClient 等）都应通过本函数构造
+// 参数，确保 TLS 配置不会被遗漏。其它字段（PoolSize / Timeout 等）通过
+// override 函数传入。
+//
+// TLS 构造逻辑复用 octo-lib/pkg/redis.BuildTLSConfig，与 ctx.GetRedisConn()
+// 链路保持一致。
+func BuildOptions(cfg *config.Config, overrides ...OptionsOverride) (*rd.Options, error) {
+	opts := &rd.Options{
+		Addr:     cfg.DB.RedisAddr,
+		Password: cfg.DB.RedisPass,
+	}
+	if cfg.DB.RedisTLS {
+		tlsCfg, err := liboredis.BuildTLSConfig(
+			cfg.DB.RedisTLSInsecureSkipVerify,
+			cfg.DB.RedisTLSCAFile,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("redis: build tls config: %w", err)
+		}
+		opts.TLSConfig = tlsCfg
+	}
+	for _, o := range overrides {
+		if o != nil {
+			o(opts)
+		}
+	}
+	return opts, nil
+}
+
+// MustBuildOptions 在 BuildOptions 失败时 panic。
+// 仅用于启动期初始化场景 —— TLS CA 文件读取 / 解析失败属于配置错误，
+// 进程应立即终止而非带病运行。
+func MustBuildOptions(cfg *config.Config, overrides ...OptionsOverride) *rd.Options {
+	opts, err := BuildOptions(cfg, overrides...)
+	if err != nil {
+		panic(err)
+	}
+	return opts
+}

--- a/pkg/redis/options_test.go
+++ b/pkg/redis/options_test.go
@@ -1,0 +1,156 @@
+package redis
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	rd "github.com/go-redis/redis"
+)
+
+// newConfig 构造一个带默认 RedisAddr 的 config，方便测试场景里只覆盖 TLS 相关字段。
+func newConfig() *config.Config {
+	cfg := config.New()
+	cfg.DB.RedisAddr = "127.0.0.1:6379"
+	cfg.DB.RedisPass = "secret"
+	return cfg
+}
+
+func TestBuildOptions_PlaintextDefaults(t *testing.T) {
+	cfg := newConfig()
+	opts, err := BuildOptions(cfg)
+	if err != nil {
+		t.Fatalf("BuildOptions: %v", err)
+	}
+	if opts.Addr != "127.0.0.1:6379" {
+		t.Errorf("Addr = %q, want 127.0.0.1:6379", opts.Addr)
+	}
+	if opts.Password != "secret" {
+		t.Errorf("Password = %q, want secret", opts.Password)
+	}
+	if opts.TLSConfig != nil {
+		t.Errorf("TLSConfig should be nil when RedisTLS=false, got %+v", opts.TLSConfig)
+	}
+}
+
+func TestBuildOptions_TLSInsecureSkipVerify(t *testing.T) {
+	cfg := newConfig()
+	cfg.DB.RedisTLS = true
+	cfg.DB.RedisTLSInsecureSkipVerify = true
+
+	opts, err := BuildOptions(cfg)
+	if err != nil {
+		t.Fatalf("BuildOptions: %v", err)
+	}
+	if opts.TLSConfig == nil {
+		t.Fatal("TLSConfig should be set when RedisTLS=true")
+	}
+	if !opts.TLSConfig.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify should be true")
+	}
+	if opts.TLSConfig.RootCAs != nil {
+		t.Error("RootCAs should be nil when no CA file supplied")
+	}
+}
+
+func TestBuildOptions_TLSWithValidCAFile(t *testing.T) {
+	caPath := writeSelfSignedCA(t)
+	cfg := newConfig()
+	cfg.DB.RedisTLS = true
+	cfg.DB.RedisTLSCAFile = caPath
+
+	opts, err := BuildOptions(cfg)
+	if err != nil {
+		t.Fatalf("BuildOptions: %v", err)
+	}
+	if opts.TLSConfig == nil || opts.TLSConfig.RootCAs == nil {
+		t.Fatal("RootCAs should be populated from CA file")
+	}
+}
+
+func TestBuildOptions_TLSWithMissingCAFile(t *testing.T) {
+	cfg := newConfig()
+	cfg.DB.RedisTLS = true
+	cfg.DB.RedisTLSCAFile = "/nonexistent/path/ca.pem"
+
+	if _, err := BuildOptions(cfg); err == nil {
+		t.Fatal("expected error for missing CA file, got nil")
+	} else if !strings.Contains(err.Error(), "tls") {
+		t.Errorf("error should mention tls context: %v", err)
+	}
+}
+
+func TestBuildOptions_OverridesApplied(t *testing.T) {
+	cfg := newConfig()
+	opts, err := BuildOptions(cfg, func(o *rd.Options) {
+		o.MaxRetries = 7
+		o.PoolSize = 42
+	})
+	if err != nil {
+		t.Fatalf("BuildOptions: %v", err)
+	}
+	if opts.MaxRetries != 7 {
+		t.Errorf("MaxRetries = %d, want 7", opts.MaxRetries)
+	}
+	if opts.PoolSize != 42 {
+		t.Errorf("PoolSize = %d, want 42", opts.PoolSize)
+	}
+}
+
+func TestBuildOptions_NilOverrideTolerated(t *testing.T) {
+	cfg := newConfig()
+	if _, err := BuildOptions(cfg, nil); err != nil {
+		t.Fatalf("nil override should be tolerated, got: %v", err)
+	}
+}
+
+func TestMustBuildOptions_PanicsOnCAFailure(t *testing.T) {
+	cfg := newConfig()
+	cfg.DB.RedisTLS = true
+	cfg.DB.RedisTLSCAFile = "/nonexistent/path/ca.pem"
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("MustBuildOptions should panic on CA load failure")
+		}
+	}()
+	MustBuildOptions(cfg)
+}
+
+// writeSelfSignedCA 在临时目录生成一个自签 CA 证书 PEM，用于 RedisTLSCAFile 测试。
+// 走运行时生成是为了避免落 fixture 文件 + 避免证书过期。
+func writeSelfSignedCA(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	tpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "octo-redis-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tpl, tpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600); err != nil {
+		t.Fatalf("write ca: %v", err)
+	}
+	return path
+}

--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -17,13 +17,21 @@ type Conn struct {
 }
 
 func New(addr string, password string) *Conn {
-	c := &Conn{}
-	c.client = rd.NewClient(&rd.Options{
+	return NewWithOptions(&rd.Options{
 		Addr:       addr,
-		MaxRetries: 3, // 失败重试次数
+		MaxRetries: 3,
 		Password:   password,
 	})
-	return c
+}
+
+// NewWithOptions 用调用方构造的 *redis.Options 建立连接。
+// 调用方应当先用 BuildOptions/MustBuildOptions 从 cfg 构造 Options，
+// 以便 TLS 等公共配置被统一应用。
+func NewWithOptions(opts *rd.Options) *Conn {
+	if opts.MaxRetries == 0 {
+		opts.MaxRetries = 3
+	}
+	return &Conn{client: rd.NewClient(opts)}
 }
 
 func (rc *Conn) Ping() (string, error) {

--- a/pkg/wkhttp/ratelimit_helper.go
+++ b/pkg/wkhttp/ratelimit_helper.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	libwkhttp "github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	rd "github.com/go-redis/redis"
 	"go.uber.org/zap"
 )
@@ -67,12 +68,10 @@ func SharedUIDRateLimiter(ctx *config.Context) libwkhttp.HandlerFunc {
 	// Eval/Script 接口，令牌桶 Lua 脚本必须走原生 go-redis。生命周期跟随进程。
 	// ctx 传 context.Background()：go-redis v6 的 Script.Run 不接受 context；
 	// 即便未来升级到 v8+ 也不应传请求 ctx（token 消耗不可因客户端断连回退）。
-	client := rd.NewClient(&rd.Options{
-		Addr:       ctx.GetConfig().DB.RedisAddr,
-		Password:   ctx.GetConfig().DB.RedisPass,
-		MaxRetries: 1,
-		PoolSize:   uidRateLimitPoolSize,
-	})
+	client := rd.NewClient(octoredis.MustBuildOptions(ctx.GetConfig(), func(o *rd.Options) {
+		o.MaxRetries = 1
+		o.PoolSize = uidRateLimitPoolSize
+	}))
 	uidRateLimitMW = UIDRateLimitMiddleware(context.Background(), client, rps, burst)
 	uidRateLimitReady = true
 	return uidRateLimitMW


### PR DESCRIPTION
## Summary

Follow-up to [octo-lib#35](https://github.com/Mininglamp-OSS/octo-lib/pull/35) and [octo-lib#37](https://github.com/Mininglamp-OSS/octo-lib/pull/37).

`octo-lib#35` added `DB.RedisTLS` / `RedisTLSInsecureSkipVerify` / `RedisTLSCAFile` fields. `octo-lib#37` wired them into `ctx.GetRedisConn()` — covering the dominant ~188 main-path call sites.

This PR covers the **remaining 8 direct `rd.NewClient` sites** in `octo-server` (rate limiters, OIDC stores, sync lock). After this merges, the entire project's Redis traffic respects `RedisTLS` — unblocking AWS ElastiCache / Azure Cache for Redis migrations.

## Changes

### New shared helper

- **`pkg/redis/options.go`**: `BuildOptions(cfg, overrides...)` / `MustBuildOptions(cfg, overrides...)` construct `*redis.Options` with `Addr`/`Password`/`TLSConfig` from `cfg.DB.Redis*`. TLS construction delegates to octo-lib's `redis.BuildTLSConfig`, so behavior matches the `ctx.GetRedisConn()` path. Functional overrides handle non-TLS fields (`PoolSize`, `MaxRetries`, timeouts).
- **`pkg/redis/redis.go`**: add `NewWithOptions(*rd.Options) *Conn`; existing `New(addr, password)` unchanged.
- **`pkg/db/redis.go`**: add `NewRedisFromConfig(cfg)`; existing `NewRedis(addr, password)` unchanged.

### 8 direct call sites refactored

Replaced inline `&rd.Options{Addr: cfg.DB.RedisAddr, Password: cfg.DB.RedisPass, ...}` with `octoredis.MustBuildOptions(cfg, func(o *rd.Options) { ... })`:

| File | Purpose |
|------|---------|
| `main.go` | Global per-IP rate limiter |
| `pkg/wkhttp/ratelimit_helper.go` | Shared UID rate limiter |
| `modules/user/api.go` | Login / SMS / register endpoint limiters |
| `modules/space/api.go` | Invite preview limiter |
| `modules/group/api.go` | Group invite limiter |
| `modules/oidc/state_store_redis.go` | OIDC state store |
| `modules/oidc/sync_lock.go` | OIDC sync tick lock |
| `modules/oidc/bind_store_redis.go` | OIDC bind session store |

### Config example

- **`configs/tsdd.yaml`**: documented `redisTLS` / `redisTLSInsecureSkipVerify` / `redisTLSCAFile` example commented-out entries.

### Dependency bump

- `octo-lib` → `v0.0.0-20260522122557-a65ecee15fc5` (includes both TLS-related PRs).

## Backward compatibility

With `RedisTLS=false` (the default), the produced `*redis.Options` is byte-equivalent to the previous hand-written struct literals — no behavior change for existing deployments. TLS only activates when operators set `db.redisTLS: true`.

## TLS / non-TLS paths

| Config | Behavior |
|--------|----------|
| `redisTLS: false` (default) | `opts.TLSConfig = nil`, plaintext, identical to pre-PR |
| `redisTLS: true` + `redisTLSInsecureSkipVerify: true` | TLS handshake, skips cert verification (self-signed / test) |
| `redisTLS: true` + `redisTLSCAFile: /path` | TLS handshake with custom CA pool |
| `redisTLS: true` (no CA) | TLS handshake with system CA pool (standard AWS ElastiCache) |

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race ./pkg/redis/...` — 7/7 pass:
  - `TestBuildOptions_PlaintextDefaults`
  - `TestBuildOptions_TLSInsecureSkipVerify`
  - `TestBuildOptions_TLSWithValidCAFile` (self-signed cert generated at runtime via `ecdsa.GenerateKey` — no fixture files)
  - `TestBuildOptions_TLSWithMissingCAFile`
  - `TestBuildOptions_OverridesApplied`
  - `TestBuildOptions_NilOverrideTolerated`
  - `TestMustBuildOptions_PanicsOnCAFailure`
- [x] End-to-end TLS dialer path was already integration-verified in octo-lib#35 (PONG over `rediss://` against a local TLS Redis container with self-signed cert); this PR only adds wiring, runtime path inherited.

## Follow-ups (separate tickets recommended)

- `AsynctaskRedisAddr` TLS support (octo-lib side, currently deferred).
- `RedisTLSServerName` for SNI override.
- Optional mTLS (`RedisTLSCertFile` / `RedisTLSKeyFile`).