### PR TITLE
feat(obo): add GET /v1/bot/obo-grant for adapter-side persona pull

### DIFF
--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -247,6 +247,14 @@ func (ba *BotAPI) Route(r *wkhttp.WKHttp) {
 		botAPI.GET("/voice/context", ba.botGetVoiceContext)
 		botAPI.DELETE("/voice/context", ba.botDeleteVoiceContext)
 		botAPI.POST("/voice/transcribe", ba.botTranscribe)
+		// OBO bot-token read (Mininglamp-OSS/octo-server#135 / YUJ-1762).
+		// Adapter-facing endpoint that returns the active grant whose
+		// grantee is the calling bot, including `persona_prompt`. Kept
+		// inside the bot-token group (not /v1/obo/*) because the auth
+		// posture is "the bot is asking about itself" — fundamentally
+		// different from the user-token /v1/obo/* CRUD which mutates
+		// grants on behalf of a logged-in grantor.
+		botAPI.GET("/obo-grant", ba.oboBotGetGrant)
 	}
 
 	// Bot File API (separate group for wildcard conflict avoidance)

--- a/modules/bot_api/obo_api.go
+++ b/modules/bot_api/obo_api.go
@@ -591,6 +591,80 @@ func (ba *BotAPI) oboListScopes(c *wkhttp.Context) {
 	c.Response(map[string]interface{}{"items": scopes})
 }
 
+// ==================== Bot-token endpoint (issue #135) ====================
+
+// oboBotGetGrantResp is the wire shape for GET /v1/bot/obo-grant.
+// Field set is intentionally narrow — the adapter only needs the four
+// values listed in the issue (grantor uid + the persona prompt + the
+// two booleans that gate "should I apply the persona right now?").
+// We do not surface the grant id, timestamps, or any scope rows: a bot
+// authenticated by its own token has no use for grant-management
+// metadata, and leaking it would expand the blast radius if the token
+// is exfiltrated.
+type oboBotGetGrantResp struct {
+	GrantorUID    string `json:"grantor_uid"`
+	PersonaPrompt string `json:"persona_prompt"`
+	Active        bool   `json:"active"`
+	GlobalEnabled bool   `json:"global_enabled"`
+}
+
+// oboBotGetGrant — GET /v1/bot/obo-grant.
+// Mininglamp-OSS/octo-server#135 (YUJ-1762). Bot-token authenticated;
+// returns the active OBO grant where the calling bot is the grantee so
+// the adapter can pull `persona_prompt` at runtime without keeping a
+// local copy.
+//
+// Auth posture: this handler intentionally reads the bot UID from the
+// authenticated context (CtxKeyRobotID set by ba.authBot()), NOT from
+// the URL or body. The endpoint never accepts a bot uid as input — a
+// compromised bot can only ever read its OWN grant, never probe for
+// someone else's persona by spoofing a path parameter.
+//
+// Status code map:
+//   - 200 — grant found; body is oboBotGetGrantResp.
+//   - 401 — handled by ba.authBot() upstream (this handler only runs
+//           on authenticated requests; the defensive empty-uid branch
+//           below 500s because reaching it means the middleware broke
+//           its invariant and a 401 would mask that).
+//   - 404 — no active grant for this bot. Note: "no active grant"
+//           covers both "grant never existed" and "grant was paused
+//           or revoked"; the adapter should treat 404 as "do not
+//           apply a persona" without distinguishing the cause.
+//   - 500 — store error.
+//
+// `persona_prompt` round-trips as an empty string when the column is
+// NULL, courtesy of the COALESCE wrapper in oboGrantColumns (issue
+// requirement: "persona_prompt 为 NULL 时返回空串").
+func (ba *BotAPI) oboBotGetGrant(c *wkhttp.Context) {
+	botUID := getRobotIDFromContext(c)
+	if botUID == "" {
+		// authBot middleware should have populated this. Treat as 500
+		// rather than 401 so the misconfiguration is noisy upstream
+		// instead of being silently mis-attributed to an auth failure.
+		ba.Error("oboBotGetGrant: empty robot id from auth context")
+		c.ResponseError(errors.New("内部错误"))
+		return
+	}
+	grant, err := ba.oboStoreOrDefault().findActiveGrantByBot(botUID)
+	if err != nil {
+		ba.Error("findActiveGrantByBot failed",
+			zap.Error(err),
+			zap.String("bot", botUID))
+		c.ResponseError(errors.New("内部错误"))
+		return
+	}
+	if grant == nil {
+		c.JSON(http.StatusNotFound, gin404("no active grant"))
+		return
+	}
+	c.Response(oboBotGetGrantResp{
+		GrantorUID:    grant.GrantorUID,
+		PersonaPrompt: grant.PersonaPrompt,
+		Active:        grant.Active == 1,
+		GlobalEnabled: grant.GlobalEnabled == 1,
+	})
+}
+
 // ==================== Helpers ====================
 
 // requireOwnedGrant resolves the grant and verifies the caller owns it.

--- a/modules/bot_api/obo_bot_grant_test.go
+++ b/modules/bot_api/obo_bot_grant_test.go
@@ -1,0 +1,271 @@
+// Package bot_api · Mininglamp-OSS/octo-server#135 (YUJ-1762) — Unit
+// tests for the bot-token endpoint GET /v1/bot/obo-grant.
+//
+// The endpoint sits behind ba.authBot() in production, but these tests
+// drive the handler directly with a fake bot-id context (same shape the
+// middleware sets) so we can exercise the three branches mandated by
+// the issue spec — grant present, no active grant, empty
+// persona_prompt — without standing up MySQL or the auth middleware.
+package bot_api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/gin-gonic/gin"
+)
+
+// makeBotCtx — bot-token analogue of makeCtx. The auth middleware sets
+// CtxKeyRobotID after authenticating; tests skip the middleware and set
+// the value directly so the handler observes the same context shape it
+// would in production.
+func makeBotCtx(t *testing.T, botUID string) (*wkhttp.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodGet, "/v1/bot/obo-grant", nil)
+	gc.Request = req
+	c := &wkhttp.Context{Context: gc}
+	if botUID != "" {
+		c.Set(CtxKeyRobotID, botUID)
+	}
+	return c, rec
+}
+
+// decodeBotGrantResp — wkhttp's `c.Response(...)` writes the payload
+// straight to the body without an envelope, so we unmarshal directly
+// into the response struct.
+func decodeBotGrantResp(t *testing.T, body []byte) oboBotGetGrantResp {
+	t.Helper()
+	var resp oboBotGetGrantResp
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode response: %v / body=%s", err, string(body))
+	}
+	return resp
+}
+
+// TestOBO_BotGetGrant_Happy — issue requirement #1: when an active
+// grant exists for the calling bot, return 200 with grantor_uid,
+// persona_prompt, active=true, and global_enabled mirroring the row.
+func TestOBO_BotGetGrant_Happy(t *testing.T) {
+	const (
+		grantor = "admin"
+		botUID  = "bot_clone_135"
+		prompt  = "始终使用英语来回复"
+	)
+	s := newFakeOBOStore()
+	s.seedBot(botUID, grantor)
+	id, err := s.insertGrant(grantor, botUID, "auto", prompt)
+	if err != nil {
+		t.Fatalf("insertGrant: %v", err)
+	}
+	// insertGrant defaults global_enabled=0; flip it to 1 so the
+	// response demonstrates both booleans round-tripping faithfully.
+	one := 1
+	if err := s.updateGrant(id, "", &one, nil); err != nil {
+		t.Fatalf("updateGrant: %v", err)
+	}
+
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-test"),
+		oboStoreOverride: s,
+	}
+	c, rec := makeBotCtx(t, botUID)
+	ba.oboBotGetGrant(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	got := decodeBotGrantResp(t, rec.Body.Bytes())
+	if got.GrantorUID != grantor {
+		t.Errorf("GrantorUID = %q, want %q", got.GrantorUID, grantor)
+	}
+	if got.PersonaPrompt != prompt {
+		t.Errorf("PersonaPrompt = %q, want %q", got.PersonaPrompt, prompt)
+	}
+	if !got.Active {
+		t.Errorf("Active = false, want true")
+	}
+	if !got.GlobalEnabled {
+		t.Errorf("GlobalEnabled = false, want true")
+	}
+}
+
+// TestOBO_BotGetGrant_NoGrant — issue requirement #2: 404 when there
+// is no active grant for the calling bot. Covers both "grant never
+// existed" (this test) and "grant was revoked" (the revoked variant
+// below) — both paths surface the same 404 so the adapter does not
+// need to distinguish the cause.
+func TestOBO_BotGetGrant_NoGrant(t *testing.T) {
+	s := newFakeOBOStore()
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-test"),
+		oboStoreOverride: s,
+	}
+	c, rec := makeBotCtx(t, "bot_with_no_grants")
+	ba.oboBotGetGrant(c)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+}
+
+// TestOBO_BotGetGrant_RevokedGrant — the 404 path must also cover
+// grants that exist but have been revoked. `revokeGrant` flips
+// active=0 / global_enabled=0 / sets revoked_at, and our
+// findActiveGrantByBot SELECT filters on `active=1`, so the row must
+// not surface.
+func TestOBO_BotGetGrant_RevokedGrant(t *testing.T) {
+	const (
+		grantor = "admin"
+		botUID  = "bot_revoked_135"
+	)
+	s := newFakeOBOStore()
+	s.seedBot(botUID, grantor)
+	id, err := s.insertGrant(grantor, botUID, "auto", "previous prompt")
+	if err != nil {
+		t.Fatalf("insertGrant: %v", err)
+	}
+	if err := s.revokeGrant(id); err != nil {
+		t.Fatalf("revokeGrant: %v", err)
+	}
+
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-test"),
+		oboStoreOverride: s,
+	}
+	c, rec := makeBotCtx(t, botUID)
+	ba.oboBotGetGrant(c)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%s, want 404 for revoked grant",
+			rec.Code, rec.Body.String())
+	}
+}
+
+// TestOBO_BotGetGrant_EmptyPersonaPrompt — issue requirement #3:
+// when the grant was created without a persona_prompt the response
+// must surface an empty string (NOT a null / missing field).
+// `insertGrant` writes "" when called with an empty prompt; the
+// production SQL relies on COALESCE(persona_prompt,'') for legacy NULL
+// rows, so the fake's "" matches the prod wire shape.
+func TestOBO_BotGetGrant_EmptyPersonaPrompt(t *testing.T) {
+	const (
+		grantor = "admin"
+		botUID  = "bot_no_prompt_135"
+	)
+	s := newFakeOBOStore()
+	s.seedBot(botUID, grantor)
+	if _, err := s.insertGrant(grantor, botUID, "auto", ""); err != nil {
+		t.Fatalf("insertGrant: %v", err)
+	}
+
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-test"),
+		oboStoreOverride: s,
+	}
+	c, rec := makeBotCtx(t, botUID)
+	ba.oboBotGetGrant(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	got := decodeBotGrantResp(t, rec.Body.Bytes())
+	if got.PersonaPrompt != "" {
+		t.Errorf("PersonaPrompt = %q, want empty string", got.PersonaPrompt)
+	}
+	// Defensive: the JSON itself must contain `"persona_prompt":""`,
+	// not `"persona_prompt":null` — encoding/json on a `string` field
+	// emits an explicit empty string, but if a future refactor swaps
+	// to `*string` to model NULL we want the test to fail loudly.
+	if !containsBytes(rec.Body.Bytes(), []byte(`"persona_prompt":""`)) {
+		t.Errorf("response body must contain `\"persona_prompt\":\"\"`, got %s",
+			rec.Body.String())
+	}
+	if !got.Active {
+		t.Errorf("Active = false, want true (insertGrant defaults active=1)")
+	}
+	// insertGrant defaults global_enabled=0 — the response must report
+	// that faithfully so the adapter knows the persona is paused at the
+	// global switch even though the row is active.
+	if got.GlobalEnabled {
+		t.Errorf("GlobalEnabled = true, want false (insertGrant default)")
+	}
+}
+
+// TestOBO_BotGetGrant_DeterministicMultiGrantor — when a bot is the
+// grantee of multiple grantors' active grants (rare, but possible),
+// the response must be deterministic across polls. Pins down the
+// `ORDER BY id ASC LIMIT 1` contract documented on findActiveGrantByBot:
+// the smallest-ID active row wins.
+func TestOBO_BotGetGrant_DeterministicMultiGrantor(t *testing.T) {
+	const botUID = "bot_multi_grantor_135"
+	s := newFakeOBOStore()
+	s.seedBot(botUID, "first_grantor")
+	first, err := s.insertGrant("first_grantor", botUID, "auto", "first")
+	if err != nil {
+		t.Fatalf("insertGrant first: %v", err)
+	}
+	second, err := s.insertGrant("second_grantor", botUID, "auto", "second")
+	if err != nil {
+		t.Fatalf("insertGrant second: %v", err)
+	}
+	if first >= second {
+		t.Fatalf("test setup: expected first.id (%d) < second.id (%d)", first, second)
+	}
+
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-test"),
+		oboStoreOverride: s,
+	}
+	for i := 0; i < 3; i++ {
+		c, rec := makeBotCtx(t, botUID)
+		ba.oboBotGetGrant(c)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("iteration %d: status=%d", i, rec.Code)
+		}
+		got := decodeBotGrantResp(t, rec.Body.Bytes())
+		if got.GrantorUID != "first_grantor" {
+			t.Errorf("iteration %d: GrantorUID = %q, want %q (smallest-id wins)",
+				i, got.GrantorUID, "first_grantor")
+		}
+	}
+}
+
+// TestOBO_BotGetGrant_NoBotID — defensive: if the auth middleware ever
+// drops the robot id, the handler must surface an internal-error
+// response rather than silently returning someone else's grant.
+func TestOBO_BotGetGrant_NoBotID(t *testing.T) {
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-test"),
+		oboStoreOverride: newFakeOBOStore(),
+	}
+	c, rec := makeBotCtx(t, "") // no CtxKeyRobotID set
+	ba.oboBotGetGrant(c)
+	if rec.Code == http.StatusOK {
+		t.Fatalf("status=%d, want non-200 when bot id is missing", rec.Code)
+	}
+}
+
+// containsBytes is a tiny inline contains check — kept private so it
+// does not collide with helpers in other test files.
+func containsBytes(haystack, needle []byte) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		ok := true
+		for j := range needle {
+			if haystack[i+j] != needle[j] {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return true
+		}
+	}
+	return false
+}

--- a/modules/bot_api/obo_db.go
+++ b/modules/bot_api/obo_db.go
@@ -155,6 +155,33 @@ type oboStore interface {
 	// not the system-wide fan-out path, so the per-call MySQL probe
 	// is acceptable.
 	findGrantByGrantorBotActiveOnly(grantorUID, granteeBotUID string) (*oboGrantModel, error)
+	// findActiveGrantByBot — Mininglamp-OSS/octo-server#135 (YUJ-1762).
+	// Bot-side lookup: returns the active grant where `botUID` is the
+	// grantee, with no grantor predicate. Used by the bot-token endpoint
+	// GET /v1/bot/obo-grant so an adapter can pull its `persona_prompt`
+	// at runtime without storing a local copy.
+	//
+	// Contract:
+	//   - Filters on `active=1` ONLY (the `global_enabled` master switch
+	//     is intentionally NOT consulted — the response surfaces that
+	//     bit as a separate field so the adapter can decide whether to
+	//     apply the persona). This matches the spec on #135 which expects
+	//     both `active` and `global_enabled` to be returned independently.
+	//   - Returns (nil, nil) when no active row matches; the caller maps
+	//     that to a 404. Returning ErrNotFound was rejected to keep
+	//     callers free of `dbr` imports (mirrors findActiveGrantByGrantorBot).
+	//   - When multiple grantors have an active grant pointing at the
+	//     same bot (rare; a single bot rented out to multiple personas),
+	//     the row with the smallest ID wins. The ordering is deterministic
+	//     so repeated polls return the same persona until grant state
+	//     changes; the "at most one active grant per grantor" invariant
+	//     elsewhere in this package keeps the multi-row case bounded by
+	//     the number of distinct grantors who installed the same bot.
+	//   - Does NOT consult the `obo:grantor:{uid}` negative cache: that
+	//     cache is keyed by grantor, and this lookup has no grantor to
+	//     hash on. The query hits the same `(grantee_bot_uid, active)`
+	//     covering index used by the fan-out feeders.
+	findActiveGrantByBot(botUID string) (*oboGrantModel, error)
 	scopeEnabled(grantID int64, channelID string, channelType uint8) (bool, error)
 	scopeRowExists(grantID int64, channelID string, channelType uint8) (bool, error)
 	findActiveGrantsForChannel(channelID string, channelType uint8) ([]*oboGrantModel, error)
@@ -390,6 +417,36 @@ func (d *botAPIDB) findGrantByGrantorBotActiveOnly(grantorUID, granteeBotUID str
 		"SELECT "+oboGrantColumns+" FROM obo_grants "+
 			"WHERE grantor_uid=? AND grantee_bot_uid=? AND active=1",
 		grantorUID, granteeBotUID,
+	).Load(&m)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return nil, err
+	}
+	return m, nil
+}
+
+// findActiveGrantByBot — see oboStore for the contract.
+// Mininglamp-OSS/octo-server#135 (YUJ-1762). Bot-side lookup that
+// powers GET /v1/bot/obo-grant. Selects the active grant whose
+// `grantee_bot_uid` matches the calling bot, with no grantor predicate.
+//
+// `ORDER BY id ASC LIMIT 1` keeps the response deterministic when a bot
+// is somehow the grantee of multiple grantors' active grants. We do
+// NOT consult the `obo:grantor:{uid}` negative cache — it is keyed by
+// grantor and there is no grantor to hash on at this call site. The
+// `(grantee_bot_uid, active)` covering index keeps the per-call cost
+// comparable to the cache-miss path of findActiveGrantByGrantorBot.
+// `persona_prompt` arrives wrapped in COALESCE(..., '') via
+// oboGrantColumns so NULL columns load as the empty string.
+func (d *botAPIDB) findActiveGrantByBot(botUID string) (*oboGrantModel, error) {
+	if botUID == "" {
+		return nil, nil
+	}
+	var m *oboGrantModel
+	_, err := d.session.SelectBySql(
+		"SELECT "+oboGrantColumns+" FROM obo_grants "+
+			"WHERE grantee_bot_uid=? AND active=1 "+
+			"ORDER BY id ASC LIMIT 1",
+		botUID,
 	).Load(&m)
 	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
 		return nil, err

--- a/modules/bot_api/obo_fake_test.go
+++ b/modules/bot_api/obo_fake_test.go
@@ -205,6 +205,40 @@ func (f *fakeOBOStore) findGrantByGrantorBotActiveOnly(grantorUID, granteeBotUID
 	return nil, nil
 }
 
+// findActiveGrantByBot — Mininglamp-OSS/octo-server#135 (YUJ-1762). Fake
+// analogue of the prod bot-side lookup. Iterates by sorted grant ID so
+// the deterministic-row guarantee tests rely on (and the prod
+// `ORDER BY id ASC LIMIT 1` clause) holds in the in-memory store too.
+// Shares failFindActiveGrant because the same DB-class injection is
+// what tests want to surface from any "find active grant" path.
+func (f *fakeOBOStore) findActiveGrantByBot(botUID string) (*oboGrantModel, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failFindActiveGrant != nil {
+		return nil, f.failFindActiveGrant
+	}
+	f.ensureInit()
+	if botUID == "" {
+		return nil, nil
+	}
+	ids := make([]int64, 0, len(f.grants))
+	for id := range f.grants {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	for _, id := range ids {
+		g := f.grants[id]
+		if g == nil {
+			continue
+		}
+		if g.GranteeBotUID == botUID && g.Active == 1 {
+			cp := *g
+			return &cp, nil
+		}
+	}
+	return nil, nil
+}
+
 func (f *fakeOBOStore) scopeEnabled(grantID int64, channelID string, channelType uint8) (bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()


### PR DESCRIPTION
## Summary

Adds `GET /v1/bot/obo-grant` so adapters can pull the active grant's `persona_prompt` at runtime over their own bot token, without keeping a local copy.

The existing `/v1/obo/*` CRUD lives behind user-token auth — the grantor manages their own grants. A bot has no user token, so it had no way to read its own persona; this PR closes that gap.

## Behaviour

- Auth: bot-token `authBot()` middleware (same group as `/v1/bot/sendMessage`).
- Bot UID is read from the authenticated context (`CtxKeyRobotID`) — the endpoint never accepts a bot uid as input, so a compromised token can only ever read its own grant.
- Lookup filters on `active = 1` only; `global_enabled` is surfaced as a separate response field so the adapter decides whether to apply the persona.
- 200 → `{ grantor_uid, persona_prompt, active, global_enabled }`.
- 404 → no active grant for this bot (covers "never existed", "paused", and "revoked").
- `persona_prompt` is wrapped in `COALESCE(..., '')` at the SQL layer (matching `oboGrantColumns`), so legacy NULL columns load as the empty string.
- Multi-grantor ordering pinned via `ORDER BY id ASC LIMIT 1` so repeated polls return the same persona until grant state changes.

## Implementation notes

- New store method `findActiveGrantByBot(botUID string)` on the `oboStore` interface, with prod (`*botAPIDB`) and fake (`*fakeOBOStore`) impls. Reuses the existing `oboGrantColumns` so `persona_prompt` round-trips through `COALESCE`.
- Handler `oboBotGetGrant` lives in `modules/bot_api/obo_api.go`; route registered alongside the other bot-token handlers in `bot_api.go`.
- Did **not** modify `/v1/obo/*`, fan-out logic, or the `oboGrantModel` struct (禁改清单).

## Tests

`modules/bot_api/obo_bot_grant_test.go` covers the three branches in the spec plus extras:

- `TestOBO_BotGetGrant_Happy` — 200 with all four fields populated.
- `TestOBO_BotGetGrant_NoGrant` — 404 when the bot has no grants.
- `TestOBO_BotGetGrant_RevokedGrant` — 404 when the only grant is revoked.
- `TestOBO_BotGetGrant_EmptyPersonaPrompt` — empty string round-trips on the wire (asserts `"persona_prompt":""` is in the body, not `null`).
- `TestOBO_BotGetGrant_DeterministicMultiGrantor` — pins the `ORDER BY id ASC LIMIT 1` contract.
- `TestOBO_BotGetGrant_NoBotID` — defensive: missing `CtxKeyRobotID` does not silently return someone else's grant.

`go test ./modules/bot_api/` is green.

Fixes #135
