### PR TITLE
fix(robot): @所有AI 兼容旧 adapter — 在 ais 广播 fan-out 中给每个 bot 的 payload 副本追加 uid 到 mention.uids

### DIFF
--- a/modules/robot/ais_broadcast.go
+++ b/modules/robot/ais_broadcast.go
@@ -26,6 +26,9 @@
 package robot
 
 import (
+	"bytes"
+	"encoding/json"
+
 	"github.com/tidwall/gjson"
 )
 
@@ -123,6 +126,127 @@ func (rb *Robot) collectGroupRobotIDs(groupNo string) ([]string, error) {
 		return nil, nil
 	}
 	return out, nil
+}
+
+// injectBotUIDIntoMentionUIDs returns a payload byte slice with `botUID`
+// appended to `mention.uids`. It is the per-bot rewrite used by the
+// ais-broadcast fan-out so a legacy adapter (octo-server#137) that only
+// looks at `mention.uids` (and ignores `mention.ais`) still recognises
+// itself as mentioned and replies.
+//
+// Contract (mirrors the constraints called out in the YUJ-1784 issue
+// body — change with care, the unit tests below lock each one):
+//
+//  1. The function is pure: it never mutates the caller's `payload`
+//     byte slice. A new []byte is returned on any successful rewrite.
+//  2. ONLY `mention.uids` is touched. `mention.all`, `mention.humans`,
+//     `mention.ais`, and any sibling keys are preserved exactly as
+//     they appeared in the input — see the explicit
+//     TestInjectBotUIDIntoMentionUIDs_DoesNotTouchMentionAllOrHumans
+//     guard. We rely on this in the dispatcher because:
+//       - `mention.all` participates in adapter-side
+//         `ignoreMentionAll` opt-outs (persona clones, OBO targets),
+//         flipping it on every bot would break those opt-outs.
+//       - `mention.ais` is the very signal that brought us into this
+//         branch; rewriting it would mask the source intent in
+//         downstream logs / audits.
+//  3. Dedup: if `botUID` is already a member of `mention.uids`, the
+//     original byte slice is returned unchanged (no allocation, no
+//     re-serialization). This matters because the same bot can appear
+//     both in `mention.uids` (explicit @bot_x) AND in the ais
+//     broadcast member list; the dispatcher only ever calls this
+//     helper for the broadcast subset, but we still defend in depth.
+//  4. Missing `mention` object: a fresh `mention.uids=[botUID]` is
+//     created. This keeps the helper safe to call on any payload
+//     shape that survives JSON parsing.
+//  5. Best-effort on malformed input: if the payload does not parse,
+//     or `mention` exists but is not an object, or `mention.uids`
+//     exists but is not an array, the original bytes are returned
+//     unchanged. We MUST NOT drop the message — the legacy adapter
+//     would simply fail to recognise the mention (the current bug),
+//     which is no worse than the pre-fix state.
+//  6. Numeric precision: payloads may carry `message_id` int64 values
+//     that exceed the float64 53-bit mantissa range. The decoder uses
+//     `UseNumber()` so the marshal round-trip preserves them.
+//
+// Performance: gjson is used for the fast-path dedup check so the
+// common "already present" case avoids the json.Unmarshal /
+// json.Marshal cycle. Only the "needs append" path pays the round
+// trip, which is amortised against the broadcast fan-out goroutine
+// anyway.
+func injectBotUIDIntoMentionUIDs(payload []byte, botUID string) []byte {
+	if len(payload) == 0 || botUID == "" {
+		return payload
+	}
+
+	// Fast-path: if the bot's UID is already inside mention.uids,
+	// return the original bytes without re-serialising. This is the
+	// defence-in-depth case described in contract clause 3.
+	if uidsResult := gjson.GetBytes(payload, "mention.uids"); uidsResult.IsArray() {
+		for _, u := range uidsResult.Array() {
+			if u.String() == botUID {
+				return payload
+			}
+		}
+	}
+
+	// Slow path: parse, mutate mention.uids only, re-marshal.
+	// UseNumber() preserves int64 fields (e.g. message_id) across the
+	// round trip — see contract clause 6.
+	dec := json.NewDecoder(bytes.NewReader(payload))
+	dec.UseNumber()
+	var doc map[string]interface{}
+	if err := dec.Decode(&doc); err != nil {
+		return payload
+	}
+	if doc == nil {
+		return payload
+	}
+
+	var mention map[string]interface{}
+	if existing, ok := doc["mention"]; ok {
+		m, isObj := existing.(map[string]interface{})
+		if !isObj {
+			// mention exists but is not an object — best-effort skip
+			// (contract clause 5). A malformed mention would already
+			// not be acted on by any sane adapter.
+			return payload
+		}
+		mention = m
+	} else {
+		mention = map[string]interface{}{}
+		doc["mention"] = mention
+	}
+
+	var uids []interface{}
+	if existing, ok := mention["uids"]; ok {
+		switch v := existing.(type) {
+		case []interface{}:
+			uids = v
+		case nil:
+			uids = nil
+		default:
+			// uids exists but is not an array — best-effort skip.
+			return payload
+		}
+		// Re-run the dedup after Unmarshal: the fast-path gjson check
+		// only covered the IsArray() case; if `mention.uids` was the
+		// JSON literal `null` it surfaces here as the typed-nil branch
+		// above and we still want to honour clause 3.
+		for _, u := range uids {
+			if s, ok := u.(string); ok && s == botUID {
+				return payload
+			}
+		}
+	}
+	uids = append(uids, botUID)
+	mention["uids"] = uids
+
+	out, err := json.Marshal(doc)
+	if err != nil {
+		return payload
+	}
+	return out
 }
 
 // appendUniqueRobotIDs returns the concatenation of `existing` and the

--- a/modules/robot/ais_broadcast_test.go
+++ b/modules/robot/ais_broadcast_test.go
@@ -165,3 +165,168 @@ func TestMentionAisTruthy_AfterRewrite(t *testing.T) {
 	assert.True(t, rb.mentionAisTruthy(gjson.ParseBytes(b).Get("mention.ais")),
 		"json.Number(\"1\") MUST survive json.Marshal → gjson round-trip as truthy")
 }
+
+// gjsonStrArray is a tiny helper that materialises a gjson.Result array
+// into a []string so test assertions can compare against literal
+// slices without per-test boilerplate.
+func gjsonStrArray(arr []gjson.Result) []string {
+	out := make([]string, 0, len(arr))
+	for _, v := range arr {
+		out = append(out, v.String())
+	}
+	return out
+}
+
+// TestInjectBotUIDIntoMentionUIDs_AppendsToExistingUIDs — the primary
+// rewrite case described in the YUJ-1784 issue body:
+//
+//	payload has mention.uids=[a,b] → after rewrite uids=[a,b,botX]
+//
+// This is what unblocks the legacy adapter (octo-server#137) for a
+// payload that originally only carried ais=1 plus some explicit @uids.
+func TestInjectBotUIDIntoMentionUIDs_AppendsToExistingUIDs(t *testing.T) {
+	in := []byte(`{"type":1,"content":"hi","mention":{"uids":["bot_a","bot_b"]}}`)
+	out := injectBotUIDIntoMentionUIDs(in, "bot_x")
+
+	got := gjsonStrArray(gjson.GetBytes(out, "mention.uids").Array())
+	assert.Equal(t, []string{"bot_a", "bot_b", "bot_x"}, got)
+}
+
+// TestInjectBotUIDIntoMentionUIDs_DedupSkip — contract clause 3: if the
+// bot's UID is already in mention.uids, the helper returns the original
+// bytes UNCHANGED (same length, byte-identical). The dispatcher relies
+// on this as defence-in-depth for the case where a bot appears both in
+// explicit mention.uids AND in the ais broadcast member set.
+func TestInjectBotUIDIntoMentionUIDs_DedupSkip(t *testing.T) {
+	in := []byte(`{"type":1,"mention":{"uids":["bot_x","bot_b"]}}`)
+	out := injectBotUIDIntoMentionUIDs(in, "bot_x")
+	assert.Equal(t, string(in), string(out), "already present, return unchanged bytes")
+}
+
+// TestInjectBotUIDIntoMentionUIDs_MentionWithoutUIDs — contract clause
+// 4 (mention exists, uids missing): a fresh uids=[botX] is created and
+// every other mention.* field is preserved. This is the most common
+// real-world shape because the rewrite chokepoint
+// (pkg/mentionrewrite/rewrite.go) emits mention.{all,ais}=1 without
+// any uids when the source was a legacy `@所有人`.
+func TestInjectBotUIDIntoMentionUIDs_MentionWithoutUIDs(t *testing.T) {
+	in := []byte(`{"type":1,"mention":{"all":1,"ais":1}}`)
+	out := injectBotUIDIntoMentionUIDs(in, "bot_x")
+
+	uids := gjsonStrArray(gjson.GetBytes(out, "mention.uids").Array())
+	assert.Equal(t, []string{"bot_x"}, uids)
+	assert.Equal(t, int64(1), gjson.GetBytes(out, "mention.all").Int(),
+		"mention.all MUST survive the rewrite unchanged")
+	assert.Equal(t, int64(1), gjson.GetBytes(out, "mention.ais").Int(),
+		"mention.ais MUST survive the rewrite unchanged")
+}
+
+// TestInjectBotUIDIntoMentionUIDs_NoMention — contract clause 4 edge
+// (no mention object at all): the helper creates mention.uids=[botX].
+// Hard to imagine a real payload that reaches the ais branch without
+// any mention object, but the helper is documented as safe to call on
+// any parsable payload and the test pins the contract.
+func TestInjectBotUIDIntoMentionUIDs_NoMention(t *testing.T) {
+	in := []byte(`{"type":1,"content":"hi"}`)
+	out := injectBotUIDIntoMentionUIDs(in, "bot_x")
+
+	uids := gjsonStrArray(gjson.GetBytes(out, "mention.uids").Array())
+	assert.Equal(t, []string{"bot_x"}, uids)
+	// sibling keys preserved
+	assert.Equal(t, int64(1), gjson.GetBytes(out, "type").Int())
+	assert.Equal(t, "hi", gjson.GetBytes(out, "content").String())
+}
+
+// TestInjectBotUIDIntoMentionUIDs_DoesNotTouchMentionAllOrHumans —
+// contract clause 2, the load-bearing invariant of the entire fix:
+// ONLY mention.uids is mutated. mention.all participates in adapter-
+// side `ignoreMentionAll` opt-outs (persona clones / OBO targets) and
+// flipping it would break those opt-outs. mention.humans / mention.ais
+// are likewise preserved verbatim.
+func TestInjectBotUIDIntoMentionUIDs_DoesNotTouchMentionAllOrHumans(t *testing.T) {
+	in := []byte(`{"type":1,"mention":{"all":0,"humans":1,"ais":1,"uids":["a"]}}`)
+	out := injectBotUIDIntoMentionUIDs(in, "bot_x")
+
+	assert.Equal(t, int64(0), gjson.GetBytes(out, "mention.all").Int(),
+		"mention.all=0 must NOT flip to 1 just because we appended a uid")
+	assert.Equal(t, int64(1), gjson.GetBytes(out, "mention.humans").Int())
+	assert.Equal(t, int64(1), gjson.GetBytes(out, "mention.ais").Int())
+	assert.Equal(t, []string{"a", "bot_x"},
+		gjsonStrArray(gjson.GetBytes(out, "mention.uids").Array()))
+}
+
+// TestInjectBotUIDIntoMentionUIDs_EmptyInputs — contract clause 1 fast
+// rejects: empty payload and empty botUID are both no-ops. The
+// dispatcher will not call the helper with these in practice, but
+// keeping the guard explicit avoids a future caller producing a
+// spurious `{"mention":{"uids":[""]}}` payload.
+func TestInjectBotUIDIntoMentionUIDs_EmptyInputs(t *testing.T) {
+	assert.Nil(t, injectBotUIDIntoMentionUIDs(nil, "bot_x"))
+	assert.Empty(t, injectBotUIDIntoMentionUIDs([]byte{}, "bot_x"))
+
+	in := []byte(`{"mention":{"uids":["a"]}}`)
+	assert.Equal(t, string(in), string(injectBotUIDIntoMentionUIDs(in, "")))
+}
+
+// TestInjectBotUIDIntoMentionUIDs_MalformedPayload — contract clause 5:
+// a non-JSON payload returns the original bytes unchanged. Dropping
+// the message here would be strictly worse than the pre-fix state.
+func TestInjectBotUIDIntoMentionUIDs_MalformedPayload(t *testing.T) {
+	in := []byte(`{not json}`)
+	out := injectBotUIDIntoMentionUIDs(in, "bot_x")
+	assert.Equal(t, string(in), string(out))
+}
+
+// TestInjectBotUIDIntoMentionUIDs_MentionWrongType — contract clause 5
+// branch: if mention exists but is not an object (e.g. it was set to a
+// bare string by a buggy client), the helper returns the original
+// bytes unchanged rather than panic-ing or overwriting a typed field.
+func TestInjectBotUIDIntoMentionUIDs_MentionWrongType(t *testing.T) {
+	in := []byte(`{"mention":"@all"}`)
+	out := injectBotUIDIntoMentionUIDs(in, "bot_x")
+	assert.Equal(t, string(in), string(out))
+}
+
+// TestInjectBotUIDIntoMentionUIDs_UIDsWrongType — sibling guard for
+// contract clause 5: mention.uids exists but is e.g. an object, not
+// an array. Best-effort skip.
+func TestInjectBotUIDIntoMentionUIDs_UIDsWrongType(t *testing.T) {
+	in := []byte(`{"mention":{"uids":{"a":1}}}`)
+	out := injectBotUIDIntoMentionUIDs(in, "bot_x")
+	assert.Equal(t, string(in), string(out))
+}
+
+// TestInjectBotUIDIntoMentionUIDs_UIDsNull — `mention.uids: null` must
+// be treated like a missing uids field: create uids=[botX]. This shape
+// can be emitted by some JSON producers that always serialise every
+// declared field.
+func TestInjectBotUIDIntoMentionUIDs_UIDsNull(t *testing.T) {
+	in := []byte(`{"mention":{"ais":1,"uids":null}}`)
+	out := injectBotUIDIntoMentionUIDs(in, "bot_x")
+	uids := gjsonStrArray(gjson.GetBytes(out, "mention.uids").Array())
+	assert.Equal(t, []string{"bot_x"}, uids)
+}
+
+// TestInjectBotUIDIntoMentionUIDs_PreservesMessageIDPrecision —
+// contract clause 6: a near-MAX_INT64 message_id MUST survive the
+// json.Unmarshal → json.Marshal round trip without float64 precision
+// loss. UseNumber() on the decoder is what gives us this guarantee.
+func TestInjectBotUIDIntoMentionUIDs_PreservesMessageIDPrecision(t *testing.T) {
+	in := []byte(`{"message_id":9223372036854775806,"mention":{"ais":1}}`)
+	out := injectBotUIDIntoMentionUIDs(in, "bot_x")
+	assert.Equal(t, int64(9223372036854775806), gjson.GetBytes(out, "message_id").Int(),
+		"int64 fields must NOT be coerced through float64 during the rewrite")
+}
+
+// TestInjectBotUIDIntoMentionUIDs_DoesNotMutateCaller — contract
+// clause 1 hard guarantee: the input byte slice must NOT be mutated.
+// We pass a slice and confirm its bytes are identical after the call.
+// This protects callers that re-use payload bytes for other purposes
+// (e.g. the dispatcher passes the original message.Payload to other
+// non-ais bots in the same loop).
+func TestInjectBotUIDIntoMentionUIDs_DoesNotMutateCaller(t *testing.T) {
+	in := []byte(`{"mention":{"uids":["a"]}}`)
+	snapshot := append([]byte(nil), in...)
+	_ = injectBotUIDIntoMentionUIDs(in, "bot_x")
+	assert.Equal(t, snapshot, in, "input byte slice MUST NOT be mutated")
+}

--- a/modules/robot/event.go
+++ b/modules/robot/event.go
@@ -63,6 +63,23 @@ func (rb *Robot) robotMessageListen(messages []*config.MessageResp) {
 		}
 		var robotID string
 		var robotIDs []string
+		// aisBroadcastSet captures the robotIDs that were added to
+		// `robotIDs` purely because of the `mention.ais=1` broadcast
+		// branch below (i.e. group bots that were NOT already in
+		// `mention.uids`). The fan-out loop uses this set to inject
+		// each such bot's UID into its own per-event payload copy so
+		// legacy adapters (octo-server#137) that only inspect
+		// `mention.uids` still recognise themselves as mentioned and
+		// reply.
+		//
+		// Important invariants (locked by the ais_broadcast tests):
+		//   - bots that came from the explicit `mention.uids` path
+		//     are NOT in this set, and their payload is delivered
+		//     verbatim (no rewrite) — preserving exact-@ semantics.
+		//   - the set is keyed on the SAME string that appears in
+		//     `robotIDs`, so the lookup at fan-out time is O(1) and
+		//     can't drift.
+		var aisBroadcastSet map[string]struct{}
 
 		if message.ChannelType == common.ChannelTypePerson.Uint8() {
 			uid := common.GetToChannelIDWithFakeChannelID(message.ChannelID, message.FromUID)
@@ -199,7 +216,30 @@ func (rb *Robot) robotMessageListen(messages []*config.MessageResp) {
 					if err != nil {
 						rb.Error("查询群机器人成员失败！", zap.Error(err), zap.String("channelID", message.ChannelID))
 					} else {
+						// Snapshot what was already in robotIDs (from
+						// the explicit mention.uids path) so we can
+						// compute the ais-only delta. We rewrite
+						// payload ONLY for the ais-only delta — bots
+						// already targeted via mention.uids already
+						// carry their UID in the payload and must
+						// keep the verbatim message.
+						before := make(map[string]struct{}, len(robotIDs))
+						for _, id := range robotIDs {
+							before[id] = struct{}{}
+						}
 						robotIDs = appendUniqueRobotIDs(robotIDs, groupRobotIDs)
+						if len(groupRobotIDs) > 0 {
+							aisBroadcastSet = make(map[string]struct{}, len(groupRobotIDs))
+							for _, id := range groupRobotIDs {
+								if id == "" {
+									continue
+								}
+								if _, dup := before[id]; dup {
+									continue
+								}
+								aisBroadcastSet[id] = struct{}{}
+							}
+						}
 					}
 				}
 			} else {
@@ -227,6 +267,18 @@ func (rb *Robot) robotMessageListen(messages []*config.MessageResp) {
 			for _, rid := range robotIDs {
 				rb.Info("投递消息到机器人事件队列", zap.String("robotID", rid), zap.String("fromUID", message.FromUID), zap.Int64("messageID", message.MessageID))
 				rid := rid // capture loop variable
+				// Per-bot payload: bots that came in via the ais
+				// broadcast branch get their UID injected into
+				// mention.uids on a SHALLOW COPY of the message so
+				// legacy adapters (octo-server#137) recognise the
+				// mention. Bots that came in via mention.uids keep
+				// the verbatim payload.
+				perBotMsg := message
+				if _, isAis := aisBroadcastSet[rid]; isAis {
+					cp := *message
+					cp.Payload = injectBotUIDIntoMentionUIDs(message.Payload, rid)
+					perBotMsg = &cp
+				}
 				rb.msgSem <- struct{}{}
 				go func() {
 					defer func() {
@@ -235,8 +287,8 @@ func (rb *Robot) robotMessageListen(messages []*config.MessageResp) {
 							rb.Error("panic in robot message goroutine", zap.Any("recover", r), zap.String("robotID", rid))
 						}
 					}()
-					rb.saveRobotMessage(message, rid)
-					rb.autoReadForBot(message, rid)
+					rb.saveRobotMessage(perBotMsg, rid)
+					rb.autoReadForBot(perBotMsg, rid)
 				}()
 			}
 		} else if len(robotID) > 0 {


### PR DESCRIPTION
## Summary

Fix [#137](https://github.com/Mininglamp-OSS/octo-server/issues/137): legacy adapters that only inspect `mention.all` and `mention.uids` were silently dropping `@所有 AI` (`mention.ais=1`) messages. The robot event dispatcher already fans out to every group bot for the ais broadcast, but the delivered payload was verbatim — each legacy adapter still saw an empty `mention.uids` and considered itself not-mentioned.

This PR injects each recipient bot's UID into a **per-bot payload copy** of `mention.uids` for the ais-broadcast subset only, so legacy adapters recognise the mention and reply.

## Approach

- New helper `injectBotUIDIntoMentionUIDs(payload []byte, botUID string) []byte` in `modules/robot/ais_broadcast.go`.
- `modules/robot/event.go`:
  - Track `aisBroadcastSet` = group bots added by the ais branch that were NOT already in `mention.uids`.
  - In the fan-out loop, for bots in that set, shallow-copy `*MessageResp` and override `Payload` with the rewritten bytes; verbatim payload for all other bots.

## Invariants enforced (and locked by unit tests)

- ✅ Original `message.Payload` byte slice is never mutated.
- ✅ Only `mention.uids` is touched. `mention.all`, `mention.humans`, `mention.ais` are preserved verbatim — flipping `mention.all` would break adapter-side `ignoreMentionAll` opt-outs (persona clones / OBO targets).
- ✅ Dedup: if the bot's UID is already in `mention.uids`, the original bytes are returned unchanged.
- ✅ Only applied to the ais-broadcast delta — bots from explicit `mention.uids` keep their original payload (preserves exact-@ semantics).
- ✅ `mention` missing → fresh `mention.uids=[botUID]` is created.
- ✅ Malformed JSON / wrong-type `mention` / wrong-type `mention.uids` → original bytes returned (best-effort, never drop the message).
- ✅ `int64` precision preserved via `json.Decoder.UseNumber()` (e.g. `message_id` near MAX_INT64).

## Out of scope (deliberate)

- `pkg/mentionrewrite` is **not** touched — we do not add `all=1` at rewrite time.
- The `mention.uids` precise-@ path is **not** touched.
- OBO fan-out logic is **not** touched.

## Tests

`go test ./modules/robot/...` — all green.

New tests in `ais_broadcast_test.go`:
- `TestInjectBotUIDIntoMentionUIDs_AppendsToExistingUIDs`
- `TestInjectBotUIDIntoMentionUIDs_DedupSkip`
- `TestInjectBotUIDIntoMentionUIDs_MentionWithoutUIDs`
- `TestInjectBotUIDIntoMentionUIDs_NoMention`
- `TestInjectBotUIDIntoMentionUIDs_DoesNotTouchMentionAllOrHumans`
- `TestInjectBotUIDIntoMentionUIDs_EmptyInputs`
- `TestInjectBotUIDIntoMentionUIDs_MalformedPayload`
- `TestInjectBotUIDIntoMentionUIDs_MentionWrongType`
- `TestInjectBotUIDIntoMentionUIDs_UIDsWrongType`
- `TestInjectBotUIDIntoMentionUIDs_UIDsNull`
- `TestInjectBotUIDIntoMentionUIDs_PreservesMessageIDPrecision`
- `TestInjectBotUIDIntoMentionUIDs_DoesNotMutateCaller`

Fixes #137
