### PR TITLE
feat(metrics): add dmwork_http_business_error_total via response body sniffing

### DIFF
--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -1,6 +1,9 @@
 // Package metrics 收集 dmwork 进程级 Prometheus 指标。
 //
-// HTTP 中间件提供 per-route 的延迟直方图和并发请求计数,
+// HTTP 中间件提供 per-route 的延迟直方图、并发请求计数,
+// 以及"业务错误"计数 —— 后者通过解析响应 body 的 envelope `status` 字段
+// 来识别,而不是依赖 HTTP status code(详见 BusinessError 字段的注释)。
+//
 // path label 用 gin.Context.FullPath() 取路由模板而非真实 URI,
 // 防止 uid/orderID 这类高基数值打爆 Prometheus 内存。
 //
@@ -9,6 +12,8 @@
 package metrics
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"strconv"
 	"time"
@@ -32,6 +37,11 @@ const (
 	// methodLabelOther 非标准 HTTP method 的兜底值,
 	// 防止 fuzz 攻击造的奇怪 method 打爆 method label 维度。
 	methodLabelOther = "other"
+
+	// bodyCaptureLimit 业务错误识别只需读响应 body 头部的 envelope 字段,
+	// 1 KiB 足以覆盖 wkhttp 错误信封(典型 < 200 字节);超出后的字节直接透传,
+	// 避免大响应(列表查询、文件流)占用额外内存。
+	bodyCaptureLimit = 1024
 )
 
 // allowedMethods 是 method label 的白名单。任何不在此集合的方法
@@ -54,6 +64,20 @@ type HTTPMetrics struct {
 
 	// InFlight 当前并发处理中的请求数, 用于发现 hang 或慢请求堆积。
 	InFlight prometheus.Gauge
+
+	// BusinessError 业务层显式返回错误的次数, 按 path/code 切分。
+	//
+	// 背景: 业务约定(octo-lib/pkg/wkhttp.ResponseError 与本仓库同名实现)
+	// 把绝大多数服务端错误统一返回 HTTP 400, 导致 Duration{status=~"5.."}
+	// 看到的 5xx 率几乎恒为 0, 无法反映真实故障率。
+	//
+	// 采集方式: 中间件在响应体内解析 envelope JSON 的 `status` 字段
+	// (即 wkhttp 写入的语义错误码) — 与 HTTP status code 解耦,无需要求
+	// handler 显式调用埋点 API,任何 wkhttp 变体(local / octo-lib)只要遵循
+	// `{"status": N, "msg": ...}` 信封就都能采到。
+	// 当未来把服务端错误改回 HTTP 5xx 时(参见 upstream issue #140 阶段 2),
+	// code label 自然反映新分布,不需要再改 dashboard 名字。
+	BusinessError *prometheus.CounterVec
 }
 
 // NewHTTPMetrics 在传入的 Registerer 上注册所有 HTTP 指标。
@@ -77,18 +101,28 @@ func NewHTTPMetrics(reg prometheus.Registerer) *HTTPMetrics {
 			Name:      "requests_in_flight",
 			Help:      "Number of HTTP requests currently being processed.",
 		}),
+		BusinessError: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "business_error_total",
+			Help:      "Count of business-level error responses (envelope status != 2xx) per route template, sniffed from JSON response body.",
+		}, []string{"path", "code"}),
 	}
-	reg.MustRegister(m.Duration, m.InFlight)
+	reg.MustRegister(m.Duration, m.InFlight, m.BusinessError)
 	return m
 }
 
 // GinMiddleware 返回一个 gin 中间件,
-// 在 c.Next() 前后记录延迟、状态码和并发计数。
+// 在 c.Next() 前后记录延迟、状态码、并发计数和业务错误。
 //
 // panic 处理: 上层 gin.Recovery() 是最外层中间件, 它的 defer recover
 // 在本中间件 defer 之后才会执行 — 直接读 c.Writer.Status() 会拿到 200。
 // 因此本中间件自己 recover 一次记录 status=500, 再 re-panic 让外层 Recovery
 // 完成最终响应写出。
+//
+// 业务错误识别: 包一层 ResponseWriter 抓前 1 KiB 响应 body,defer 中解析 JSON
+// envelope 的 `status` 字段;若 >= 400 累加 BusinessError。解析失败时退回
+// HTTP status code(覆盖 AbortWithStatusJSON / 静态文件等非 envelope 的错误)。
 func (m *HTTPMetrics) GinMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// 抓取端点本身不埋点。用 URL.Path 而非 FullPath, 因为 /metrics
@@ -99,21 +133,30 @@ func (m *HTTPMetrics) GinMiddleware() gin.HandlerFunc {
 			return
 		}
 
+		capture := &bodyCapture{ResponseWriter: c.Writer, limit: bodyCaptureLimit}
+		c.Writer = capture
+
 		m.InFlight.Inc()
 		start := time.Now()
 
 		defer func() {
 			r := recover()
-			status := c.Writer.Status()
+			httpStatus := c.Writer.Status()
 			if r != nil {
-				status = http.StatusInternalServerError
+				httpStatus = http.StatusInternalServerError
 			}
+			path := pathLabel(c)
 			m.Duration.WithLabelValues(
 				normalizeMethod(c.Request.Method),
-				pathLabel(c),
-				strconv.Itoa(status),
+				path,
+				strconv.Itoa(httpStatus),
 			).Observe(time.Since(start).Seconds())
 			m.InFlight.Dec()
+
+			if code := businessErrorCode(capture.captured(), httpStatus, r != nil); code > 0 {
+				m.BusinessError.WithLabelValues(path, strconv.Itoa(code)).Inc()
+			}
+
 			if r != nil {
 				panic(r) // 让外层 gin.Recovery 完成 500 响应写出
 			}
@@ -121,6 +164,80 @@ func (m *HTTPMetrics) GinMiddleware() gin.HandlerFunc {
 
 		c.Next()
 	}
+}
+
+// bodyCapture 在不影响下游 ResponseWriter 的前提下抓取前 limit 字节,
+// 供 defer 中解析业务 envelope 用。超出 limit 的字节直接透传,不再缓冲,
+// 避免大响应占用额外内存。
+type bodyCapture struct {
+	gin.ResponseWriter
+	buf   bytes.Buffer
+	limit int
+}
+
+func (b *bodyCapture) Write(p []byte) (int, error) {
+	if remain := b.limit - b.buf.Len(); remain > 0 {
+		take := len(p)
+		if take > remain {
+			take = remain
+		}
+		b.buf.Write(p[:take])
+	}
+	return b.ResponseWriter.Write(p)
+}
+
+func (b *bodyCapture) WriteString(s string) (int, error) {
+	return b.Write([]byte(s))
+}
+
+func (b *bodyCapture) captured() []byte {
+	return b.buf.Bytes()
+}
+
+// businessErrorCode 决定本次响应是否算业务错误,以及对应的 code label。
+//
+// 优先级:
+//  1. panic -> 500(panic 时 body 还没写出,看 HTTP 没意义)
+//  2. JSON body 顶层 `status` 字段(wkhttp envelope 写入的语义错误码)
+//  3. 退回 HTTP status code(覆盖 AbortWithStatusJSON / 静态文件等场景)
+//
+// 返回 0 表示不应累加(2xx 成功或无法判定)。
+func businessErrorCode(body []byte, httpStatus int, panicked bool) int {
+	if panicked {
+		return http.StatusInternalServerError
+	}
+	if code, ok := envelopeStatus(body); ok {
+		if code >= 400 {
+			return code
+		}
+		return 0
+	}
+	if httpStatus >= 400 {
+		return httpStatus
+	}
+	return 0
+}
+
+// envelopeStatus 在 body 中尝试找顶层 `status` 整数字段。
+// 解析失败、不是 JSON 对象、或 status 不是整数时返回 ok=false。
+//
+// 用 json.Unmarshal 到只关心 status 的小结构体 —— 比手撕字符串安全。
+// 截断的 body(超过 bodyCaptureLimit)大概率反序列化失败 ->
+// businessErrorCode 自动退回 HTTP status。
+func envelopeStatus(body []byte) (int, bool) {
+	if len(body) == 0 {
+		return 0, false
+	}
+	var env struct {
+		Status *int `json:"status"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		return 0, false
+	}
+	if env.Status == nil {
+		return 0, false
+	}
+	return *env.Status, true
 }
 
 // pathLabel 返回 path label 的值: 命中路由用模板, 否则用兜底常量。

--- a/pkg/metrics/http_test.go
+++ b/pkg/metrics/http_test.go
@@ -254,9 +254,10 @@ func TestNewHTTPMetrics_RegistersOnProvidedRegistry(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	m := metrics.NewHTTPMetrics(reg)
 
-	// HistogramVec 在未观测前不会被 Gather() 报告(prometheus 库行为),
-	// 先打一个样本让 family 出现, 再断言两个指标都注册成功。
+	// HistogramVec / CounterVec 在未观测前不会被 Gather() 报告(prometheus 库行为),
+	// 先打样本让 family 出现, 再断言三个指标都注册成功。
 	m.Duration.WithLabelValues("GET", "/probe", "200").Observe(0.001)
+	m.BusinessError.WithLabelValues("/probe", "400").Inc()
 
 	families, err := reg.Gather()
 	if err != nil {
@@ -265,6 +266,7 @@ func TestNewHTTPMetrics_RegistersOnProvidedRegistry(t *testing.T) {
 	want := map[string]bool{
 		"dmwork_http_request_duration_seconds": false,
 		"dmwork_http_requests_in_flight":       false,
+		"dmwork_http_business_error_total":     false,
 	}
 	for _, mf := range families {
 		if _, ok := want[mf.GetName()]; ok {
@@ -275,6 +277,217 @@ func TestNewHTTPMetrics_RegistersOnProvidedRegistry(t *testing.T) {
 		if !found {
 			t.Errorf("expected metric %q to be registered", name)
 		}
+	}
+}
+
+// counterValue 通过 Gather 严格读取 CounterVec 指定 label 组合的累加值。
+// 不用 WithLabelValues / GetMetricWithLabelValues, 与 histogramSampleCount
+// 同样的原因 —— 那两个 API 会"静默创建 0 子项", 让断言失败变成假成功。
+func counterValue(
+	t *testing.T,
+	reg prometheus.Gatherer,
+	name string,
+	wantLabels map[string]string,
+) float64 {
+	t.Helper()
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, mf := range families {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			if labelsEqual(m.GetLabel(), wantLabels) {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+// TestBusinessError_FromEnvelopeStatus 覆盖核心采集路径:wkhttp.ResponseError
+// 写出的 envelope `{"msg": "...", "status": 400}`,HTTP status 也是 400 —— 但
+// code label 必须来自 envelope 字段(为阶段 2 解耦 HTTP/业务 status 做准备)。
+func TestBusinessError_FromEnvelopeStatus(t *testing.T) {
+	cases := []struct {
+		name         string
+		body         gin.H
+		httpStatus   int
+		wantPath     string
+		wantCode     string
+		wantIncrease bool
+	}{
+		{
+			name:         "ResponseError envelope: status=400",
+			body:         gin.H{"msg": "bad input", "status": 400},
+			httpStatus:   http.StatusBadRequest,
+			wantPath:     "/v1/users/:uid/im",
+			wantCode:     "400",
+			wantIncrease: true,
+		},
+		{
+			name:         "ResponseErrorWithStatus(500): envelope status=500 even when HTTP also 500",
+			body:         gin.H{"msg": "db down", "status": 500},
+			httpStatus:   http.StatusInternalServerError,
+			wantPath:     "/v1/groups/:gid",
+			wantCode:     "500",
+			wantIncrease: true,
+		},
+		{
+			name:         "future: handler returns HTTP 400 but envelope says 500 (post-phase-2)",
+			body:         gin.H{"msg": "fake", "status": 500},
+			httpStatus:   http.StatusBadRequest,
+			wantPath:     "/v1/x",
+			wantCode:     "500", // envelope 优先于 HTTP
+			wantIncrease: true,
+		},
+		{
+			name:         "ResponseOK envelope status=200 -> no increment",
+			body:         gin.H{"status": 200},
+			httpStatus:   http.StatusOK,
+			wantPath:     "/v1/ok",
+			wantIncrease: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			r, _, reg := newRouterWithMetrics(t)
+			r.GET(tc.wantPath, func(c *gin.Context) {
+				c.JSON(tc.httpStatus, tc.body)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, tc.wantPath, nil)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if tc.wantIncrease {
+				got := counterValue(t, reg, "dmwork_http_business_error_total",
+					map[string]string{"path": tc.wantPath, "code": tc.wantCode})
+				if got != 1 {
+					t.Errorf("expected counter=1 for {path=%s, code=%s}, got %v",
+						tc.wantPath, tc.wantCode, got)
+				}
+			} else {
+				families, _ := reg.Gather()
+				for _, mf := range families {
+					if mf.GetName() == "dmwork_http_business_error_total" && len(mf.GetMetric()) > 0 {
+						t.Errorf("expected no business_error_total samples, got %d series",
+							len(mf.GetMetric()))
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestBusinessError_FallbackToHTTPStatus 覆盖非 envelope 错误路径,例如
+// gin.Context.AbortWithStatusJSON(401, {"msg": "..."}) 没有 status 字段,
+// 或纯文本错误响应 —— 退回用 HTTP status 作为 code。
+func TestBusinessError_FallbackToHTTPStatus(t *testing.T) {
+	r, _, reg := newRouterWithMetrics(t)
+	// 模拟 wkhttp.AuthMiddleware: AbortWithStatusJSON(401, {"msg": ...})
+	// body 没有 "status" 字段,必须靠 HTTP status 兜底。
+	r.GET("/v1/auth", func(c *gin.Context) {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"msg": "please login"})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	got := counterValue(t, reg, "dmwork_http_business_error_total",
+		map[string]string{"path": "/v1/auth", "code": "401"})
+	if got != 1 {
+		t.Errorf("expected counter=1 for {path=/v1/auth, code=401}, got %v", got)
+	}
+}
+
+// TestBusinessError_PanicCountedAs500 panic 时 body 通常未写出,
+// 应当走 panic 分支按 500 计入,且 path label 仍是路由模板。
+func TestBusinessError_PanicCountedAs500(t *testing.T) {
+	r, _, reg := newRouterWithMetrics(t)
+	r.GET("/v1/panic", func(c *gin.Context) { panic("boom") })
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/panic", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	got := counterValue(t, reg, "dmwork_http_business_error_total",
+		map[string]string{"path": "/v1/panic", "code": "500"})
+	if got != 1 {
+		t.Errorf("expected counter=1 for {path=/v1/panic, code=500}, got %v", got)
+	}
+}
+
+// TestBusinessError_SuccessPathNotCounted 普通 200 响应(无 envelope status 或
+// envelope status=200)不应触发计数 —— 防止误报。
+func TestBusinessError_SuccessPathNotCounted(t *testing.T) {
+	r, _, reg := newRouterWithMetrics(t)
+	r.GET("/v1/list", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": []string{"a", "b"}}) // 无 status 字段
+	})
+
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/v1/list", nil)
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+	}
+
+	families, _ := reg.Gather()
+	for _, mf := range families {
+		if mf.GetName() == "dmwork_http_business_error_total" && len(mf.GetMetric()) > 0 {
+			t.Errorf("expected no business_error_total samples on 200, got %d series",
+				len(mf.GetMetric()))
+		}
+	}
+}
+
+// TestBusinessError_TruncatedBodyFallsBack 当 body 超过 bodyCaptureLimit
+// 被截断时, JSON 解析失败 -> 用 HTTP status 兜底, 不应漏报或误报。
+func TestBusinessError_TruncatedBodyFallsBack(t *testing.T) {
+	r, _, reg := newRouterWithMetrics(t)
+	r.GET("/v1/big", func(c *gin.Context) {
+		// 构造 > 1 KiB 的错误响应,且把 status 字段塞到末尾(map 顺序不定也
+		// 大概率被截断), HTTP 状态显式 400 提供兜底信号。
+		big := make([]string, 200)
+		for i := range big {
+			big[i] = "padpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpad"
+		}
+		c.JSON(http.StatusBadRequest, gin.H{
+			"items":  big,
+			"msg":    "validation failed",
+			"status": 400,
+		})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/big", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	got := counterValue(t, reg, "dmwork_http_business_error_total",
+		map[string]string{"path": "/v1/big", "code": "400"})
+	if got != 1 {
+		t.Errorf("expected fallback counter=1 for truncated body, got %v", got)
+	}
+}
+
+// TestBusinessError_UnmatchedRouteUses404 未匹配路由 gin 返回 404,
+// path label 应走 "unmatched", code 走 HTTP status 兜底。
+func TestBusinessError_UnmatchedRouteUses404(t *testing.T) {
+	r, _, reg := newRouterWithMetrics(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/never-registered", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	got := counterValue(t, reg, "dmwork_http_business_error_total",
+		map[string]string{"path": "unmatched", "code": "404"})
+	if got != 1 {
+		t.Errorf("expected counter=1 for {path=unmatched, code=404}, got %v", got)
 	}
 }
 


### PR DESCRIPTION
Closes #140 (phase 1).

## Summary / 概述

**EN** — Adds a new counter `dmwork_http_business_error_total{path, code}` that captures business-level errors regardless of the HTTP status code. The middleware wraps `gin.ResponseWriter` and parses the response envelope's `status` field, so the metric tracks "the handler returned an error to the client" instead of "HTTP status happened to be 4xx/5xx". Today this fires for every `wkhttp.ResponseError` call (HTTP 400, envelope status=400); after phase 2 of #140 lands and server-side errors return true 5xx, the same metric automatically reflects the corrected distribution without dashboard changes.

**中文** — 新增 `dmwork_http_business_error_total{path, code}` 计数器,捕获业务层错误,与 HTTP status code 解耦。中间件包一层 `gin.ResponseWriter`,读响应 envelope 的 `status` 字段。指标语义是"handler 决定返回错误",而不是"HTTP status 恰好是 4xx/5xx"。当前对每次 `wkhttp.ResponseError`(HTTP 400, envelope status=400)都会触发;等 #140 阶段 2 把服务端错误改回真正的 5xx 后,这条指标自然反映新分布,看板不用改。

## Design / 设计

Instrumentation lives in `pkg/metrics/http.go` (the middleware), **not** in `pkg/wkhttp`. Reason: production handlers across `modules/*` use `octo-lib/pkg/wkhttp.Context` (an external module), not the in-repo `pkg/wkhttp.Context`. Patching only the in-repo helpers would have missed essentially all real traffic. Sniffing the response body at the middleware layer works for any helper — local `wkhttp`, `octo-lib/pkg/wkhttp`, or even direct `c.JSON(...)` — as long as it uses the project-wide `{"status": N, "msg": ...}` envelope. / 埋点放在 metrics 中间件层(`pkg/metrics/http.go`),而**不是** `pkg/wkhttp`。原因:`modules/*` 下的生产 handler 用的是外部模块 `octo-lib/pkg/wkhttp.Context`,不是本仓库的 `pkg/wkhttp.Context`,改本仓库 wkhttp 会错过几乎所有真实流量。在中间件层读 body 对任何来源(local wkhttp / octo-lib / 直接 `c.JSON`)都生效,只要遵循 `{"status": N, "msg": ...}` 信封。

Decision order in `businessErrorCode` / 判定优先级:

1. **panic** → `500` (body never written, HTTP status meaningless / body 没写出,看 HTTP 没意义)
2. **envelope `status` field** (wkhttp helpers write this) → use envelope value when ≥ 400 / envelope `status` 字段(wkhttp 写入的语义错误码),≥ 400 时直接用
3. **HTTP status fallback** for non-envelope error paths like `AbortWithStatusJSON(401, ...)`, `NoRoute` 404s, static file errors / HTTP status 兜底,覆盖 `AbortWithStatusJSON`、未匹配路由、静态文件等没有 envelope 的场景
4. Otherwise no increment (2xx success or undetermined) / 否则不计数(2xx 成功或无法判定)

Cost: ~1 KiB capture buffer per in-flight request, bytes beyond the limit are pass-through, no extra allocation on the hot write path beyond the bytes.Buffer header. / 成本:每个在飞请求约 1 KiB 缓冲,超出部分直接透传,热路径写入除 `bytes.Buffer` 头部外无额外分配。

## PromQL examples

```promql
# Overall business error rate / 总业务错误速率
sum(rate(dmwork_http_business_error_total[5m]))

# Top offenders by route / 错误率 TopN 路由
topk(10, sum by (path) (rate(dmwork_http_business_error_total[5m])))

# Distribution by code (becomes interesting after phase 2 of #140)
# 按错误码分布(#140 阶段 2 落地后会变有用)
sum by (code) (rate(dmwork_http_business_error_total[5m]))

# Error ratio relative to total traffic / 相对全量流量的错误率
sum(rate(dmwork_http_business_error_total[5m]))
  / sum(rate(dmwork_http_request_duration_seconds_count[5m]))
```

## Test plan

- [x] `go build ./...` clean / 构建干净
- [x] `go vet ./pkg/metrics/... ./pkg/wkhttp/...` clean / vet 干净
- [x] `go test -race -count=1 ./pkg/metrics/... ./pkg/wkhttp/...` passes / 全部通过,含 race detector
- [x] New table-driven test `TestBusinessError_FromEnvelopeStatus` covers: envelope status=400 increments code=400; envelope status=500 with HTTP=500 (current `ResponseErrorWithStatus(500)`); envelope status=500 with HTTP=400 (forward-compat for phase 2); envelope status=200 → no increment.
- [x] `TestBusinessError_FallbackToHTTPStatus` — `AbortWithStatusJSON(401, ...)` (no envelope status field) → code=401 via HTTP fallback.
- [x] `TestBusinessError_PanicCountedAs500` — handler panic counted under code=500, path=route template.
- [x] `TestBusinessError_SuccessPathNotCounted` — `c.JSON(200, {"data": ...})` does not increment.
- [x] `TestBusinessError_TruncatedBodyFallsBack` — > 1 KiB body where envelope is truncated → JSON parse fails → HTTP status fallback still increments.
- [x] `TestBusinessError_UnmatchedRouteUses404` — unregistered route → `path="unmatched", code="404"`.
- [ ] Manual: scrape `/metrics` on a dev deployment, confirm new metric family appears and lights up under deliberate failure injection.

## Out of scope

- Phase 2 of #140 (auditing `ResponseError` call sites to return true HTTP 5xx for server-side failures) — separate, per-module PR.
- Dashboard updates — to be done once the metric has accumulated samples in staging.