### PR TITLE
refactor(mentionrewrite): remove all→ais rewrite (GH#142)

### DIFF
--- a/modules/bot_api/obo_fanout.go
+++ b/modules/bot_api/obo_fanout.go
@@ -206,9 +206,23 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 	// (modulo the loop-protection gates) so the persona could observe
 	// the full conversation. v2 narrows the trigger: a fan-out copy is
 	// only minted when the inbound message explicitly summons the
-	// grantor via `payload.mention.uids`, OR sets `mention.all=1` /
-	// `mention.humans=1` (`@所有人` broadcast — legacy WuKongIM uses
-	// `all`; Plan X web client uses `humans`, see YUJ-1709 / #125).
+	// grantor via `payload.mention.uids`, OR sets `mention.ais=1`
+	// (`@所有 AI` — Plan X broadcast that summons every AI/bot), OR
+	// sets `mention.humans=1` (`@所有人` — Plan X web client human
+	// broadcast that fans out to every persona clone of in-channel
+	// grantors; see YUJ-1709 / #125).
+	//
+	// IMPORTANT (Mininglamp-OSS/octo-server#142 review follow-up):
+	// legacy `mention.all=1` (old WuKongIM `@所有人` shape) MUST NOT
+	// trigger OBO bot / persona dispatch. The historical `all → ais`
+	// rewrite chokepoint was removed by #143, but this fan-out gate
+	// still treated `mention.all=1` as equivalent to the persona-
+	// summon broadcast. With the rewrite gone, accepting `all=1` here
+	// would re-create the implicit inference one layer deeper and
+	// silently fan-out legacy `@所有人` traffic to every persona
+	// clone. The gate therefore now requires an EXPLICIT `mention.ais=1`
+	// or `mention.humans=1` signal; bare `mention.all=1` (with no ais /
+	// humans / uids) is treated as plain traffic and short-circuits.
 	//
 	// PR#114 R3 (Jerry-Xin perf blocker) — the per-message mention gate
 	// runs BEFORE the grant DB lookup for group-like channels, so plain
@@ -220,7 +234,7 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 	// scope-joined query.
 	var (
 		mentionedUIDs []string
-		mentionAll    bool
+		summonAll     bool
 		grants        []*oboGrantModel
 		err           error
 	)
@@ -228,10 +242,19 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 		// DM path — unchanged, uses scope-joined query.
 		grants, err = store.findActiveGrantsForChannel(lookupChannelID, m.ChannelType)
 	} else {
-		// Group-like channels: gate on mention first.
-		mentionedUIDs, mentionAll = decodeMentionGate(m.Payload)
-		if mentionAll {
-			// @所有人 — summon every grantor in the channel. Use the
+		// Group-like channels: gate on mention first. `mention.all` is
+		// parsed (decoder still surfaces it for telemetry / future use)
+		// but intentionally NOT consulted at the fan-out branch — see
+		// the rationale block above and Mininglamp-OSS/octo-server#142.
+		var (
+			mentionAis    bool
+			mentionHumans bool
+		)
+		mentionedUIDs, _, mentionAis, mentionHumans = decodeMentionGate(m.Payload)
+		summonAll = mentionAis || mentionHumans
+		if summonAll {
+			// @所有 AI (mention.ais=1) or @所有人 (mention.humans=1) —
+			// summon every grantor's persona in the channel. Use the
 			// unfiltered channel-wide query (the only way to enumerate
 			// "every grant in this channel" without knowing membership).
 			grants, err = store.findActiveGrantsForChannel(lookupChannelID, m.ChannelType)
@@ -242,7 +265,9 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 			// R4) so the filtered miss cannot poison the unfiltered hit.
 			grants, err = store.findActiveGrantsForChannelByGrantors(lookupChannelID, m.ChannelType, mentionedUIDs)
 		} else {
-			// Plain / @AI / @bot only — no fan-out trigger for v2.
+			// Plain / @AI-text-only / @bot-only / bare mention.all=1
+			// (legacy `@所有人`, post-#142 + this PR no longer a fan-out
+			// trigger) — no fan-out trigger for v2.
 			return 0
 		}
 	}
@@ -278,16 +303,17 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 	//
 	// PR#121 R9 (YUJ-1676 / Jerry-Xin + lml2468 blocking) — extended
 	// from GROUP-only to also cover CommunityTopic. Without the topic
-	// branch, a `mention.all=1` topic message from a non-grantor whose
-	// parent group has a global_enabled grant on file (and bot NOT in
-	// the parent group) produced ZERO fan-out copies — even though
-	// checkOBO already authorized the symmetric reply path for topics
-	// (obo_check.go:105) and Gate 4 / send-permission bypass / explicit-
-	// mention feeder all already supported topics. The asymmetry meant
-	// the bot could authorize a reply but never receive the message in
-	// the first place. For topics we extract the parent group id (split
-	// on threadChannelIDSeparator, mirroring grantorCanReadChannel) and
-	// pass it to the store as `membershipGroupID`; the scope anti-join
+	// branch, a `mention.ais=1` / `mention.humans=1` topic message
+	// from a non-grantor whose parent group has a global_enabled grant
+	// on file (and bot NOT in the parent group) produced ZERO fan-out
+	// copies — even though checkOBO already authorized the symmetric
+	// reply path for topics (obo_check.go:105) and Gate 4 / send-
+	// permission bypass / explicit-mention feeder all already supported
+	// topics. The asymmetry meant the bot could authorize a reply but
+	// never receive the message in the first place. For topics we
+	// extract the parent group id (split on threadChannelIDSeparator,
+	// mirroring grantorCanReadChannel) and pass it to the store as
+	// `membershipGroupID`; the scope anti-join
 	// keeps using the topic's own (channel_id, channel_type) so an
 	// `enabled=0` row on the topic still wins.
 	//
@@ -317,9 +343,10 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 			} else {
 				// PR#121 R6 / B2 (Jerry-Xin + lml2468 2026-05-22 blocking)
 				// — when only specific grantors were @-mentioned (i.e.
-				// `mention.uids` is set and `mention.all` is NOT), the
-				// implicit-scope feeder MUST be filtered to those uids
-				// before being merged with the explicit-scope set above.
+				// `mention.uids` is set and neither `mention.ais` nor
+				// `mention.humans` are), the implicit-scope feeder MUST
+				// be filtered to those uids before being merged with the
+				// explicit-scope set above.
 				//
 				// Without this filter, a message that mentions only Alice
 				// (`mention.uids = [alice_uid]`) would silently pull in
@@ -328,15 +355,18 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 				// the group, with no awareness of the mention gate. That
 				// directly violates the documented v2 mention contract:
 				// `mention.uids` summons ONLY the mentioned grantor(s);
-				// only `mention.all` summons everyone.
+				// only `mention.ais=1` / `mention.humans=1` summon
+				// everyone (mention.all=1 alone no longer summons —
+				// see Mininglamp-OSS/octo-server#142 / #143 follow-up).
 				//
-				// The mentionAll branch passes through unfiltered (matches
-				// the explicit-path behavior — `@所有人` summons every
-				// grantor in the channel). The DM branch never reaches
-				// this block (gated above on isGroupLikeChannelType) and
-				// therefore needs no symmetrical filter.
+				// The summonAll branch passes through unfiltered (matches
+				// the explicit-path behavior — `@所有 AI` / `@所有人`
+				// summons every grantor in the channel). The DM branch
+				// never reaches this block (gated above on
+				// isGroupLikeChannelType) and therefore needs no
+				// symmetrical filter.
 				var mentionFilter map[string]struct{}
-				if !mentionAll && len(mentionedUIDs) > 0 {
+				if !summonAll && len(mentionedUIDs) > 0 {
 					mentionFilter = make(map[string]struct{}, len(mentionedUIDs))
 					for _, u := range mentionedUIDs {
 						mentionFilter[u] = struct{}{}
@@ -724,40 +754,48 @@ func buildFanoutCopyReq(m *config.MessageResp, g *oboGrantModel, grantorName, se
 	)
 }
 
-// decodeMentionGate — YUJ-1465 / YUJ-1538 / YUJ-1709 (octo-server#125).
-// Pulls `mention.uids`, `mention.all`, and `mention.humans` off the raw
-// payload. Returns:
+// decodeMentionGate — YUJ-1465 / YUJ-1538 / YUJ-1709 / #142 follow-up.
+// Pulls `mention.uids`, `mention.all`, `mention.ais`, and
+// `mention.humans` off the raw payload. Returns:
 //   - mentionedUIDs: slice of distinct UIDs (sorted ascending for
 //     stable IN(...) bind ordering); empty when payload has no
 //     mention.uids or it is empty / malformed.
-//   - mentionAll: true iff `mention.all` OR `mention.humans` is the
-//     integer 1 (numeric form) OR boolean true. The legacy WuKongIM
-//     clients emit `mention.all` (PR#114 R3 + YUJ-1538); the Plan X
-//     web client emits `mention.humans` (YUJ-1709 / #125) instead and
-//     never sets `mention.all`. Both shapes carry identical "@所有人"
-//     semantics from the user's POV, so the fan-out gate treats them
-//     equivalently. Downstream safety is unchanged: this only widens
-//     the gate's entry condition; the grant DB lookup + Gate 1/2/3 +
-//     scope/access checks all run as before.
+//   - mentionAll: true iff `mention.all` is the integer 1 (numeric
+//     form) OR boolean true. The legacy WuKongIM clients emit
+//     `mention.all=1` for `@所有人` (PR#114 R3 + YUJ-1538). After
+//     Mininglamp-OSS/octo-server#142 / #143 this flag is parsed for
+//     telemetry / future use but is NOT consumed by the OBO fan-out
+//     gate — see fanoutForMessage above for the rationale: the
+//     `all → ais` rewrite chokepoint was removed by #142, and
+//     accepting `all=1` here would re-create the implicit inference
+//     one layer deeper. Callers MUST gate fan-out on
+//     `mentionAis || mentionHumans`.
+//   - mentionAis: true iff `mention.ais` is truthy (numeric 1 or
+//     boolean true). `@所有 AI` (Plan X / YUJ-1389) — summons every
+//     bot/persona clone in the channel.
+//   - mentionHumans: true iff `mention.humans` is truthy. The Plan X
+//     web client emits `mention.humans=1` for `@所有人` (YUJ-1709 /
+//     #125) and never sets `mention.all`. The OBO fan-out gate
+//     treats this as a persona-clone summon.
 //
-// Returns (nil, false) on any decode error or absent `mention` field.
-// The fan-out narrowing gate treats (no uids, no all, no humans) as
-// "no summon".
-func decodeMentionGate(payload []byte) ([]string, bool) {
+// Returns (nil, false, false, false) on any decode error or absent
+// `mention` field. The fan-out narrowing gate treats (no uids, no
+// ais, no humans) as "no summon".
+func decodeMentionGate(payload []byte) ([]string, bool, bool, bool) {
 	if len(payload) == 0 {
-		return nil, false
+		return nil, false, false, false
 	}
 	var decoded map[string]interface{}
 	if err := json.Unmarshal(payload, &decoded); err != nil {
-		return nil, false
+		return nil, false, false, false
 	}
 	raw, ok := decoded["mention"]
 	if !ok || raw == nil {
-		return nil, false
+		return nil, false, false, false
 	}
 	mentionMap, ok := raw.(map[string]interface{})
 	if !ok {
-		return nil, false
+		return nil, false, false, false
 	}
 	// truthy1 — accept both numeric 1 and boolean true. Mirrors the
 	// two shapes real WuKongIM / Plan X clients emit. Strings, null,
@@ -774,20 +812,26 @@ func decodeMentionGate(payload []byte) ([]string, bool) {
 		}
 		return false
 	}
-	// mention.all (legacy WuKongIM clients) — YUJ-1538.
+	// mention.all (legacy WuKongIM clients) — YUJ-1538. Parsed but
+	// NOT consumed by the OBO fan-out gate (see #142 / #143).
 	var all bool
 	if v, ok := mentionMap["all"]; ok && v != nil {
 		all = truthy1(v)
 	}
-	// mention.humans (Plan X web client @所有人) — YUJ-1709 / #125.
+	// mention.ais (Plan X / YUJ-1389) — `@所有 AI`. Triggers the
+	// unfiltered fan-out branch in fanoutForMessage.
+	var ais bool
+	if v, ok := mentionMap["ais"]; ok && v != nil {
+		ais = truthy1(v)
+	}
+	// mention.humans (Plan X web client `@所有人`) — YUJ-1709 / #125.
 	// Plan X never co-emits `mention.all`, so without this branch the
 	// fan-out gate early-returns and any grantee bot for a grantor in
-	// the channel silently misses the OBO DM. Treated as identical to
-	// `mention.all` for gate purposes.
-	if !all {
-		if v, ok := mentionMap["humans"]; ok && v != nil {
-			all = truthy1(v)
-		}
+	// the channel silently misses the OBO DM. Treated as a persona-
+	// clone summon at the gate.
+	var humans bool
+	if v, ok := mentionMap["humans"]; ok && v != nil {
+		humans = truthy1(v)
 	}
 	// mention.uids — distinct, trim whitespace, drop empties.
 	var uids []string
@@ -819,7 +863,7 @@ func decodeMentionGate(payload []byte) ([]string, bool) {
 			}
 		}
 	}
-	return uids, all
+	return uids, all, ais, humans
 }
 
 // oboResolveDisplayName — YUJ-1465. Resolves a uid to a human display

--- a/modules/bot_api/obo_fanout_test.go
+++ b/modules/bot_api/obo_fanout_test.go
@@ -1380,12 +1380,23 @@ func TestFanout_PR121R6_ImplicitScopeRespectsMentionFilter(t *testing.T) {
 	}
 }
 
-// TestFanout_PR121R6_ImplicitScopeMentionAllSummonsEveryone — companion
-// to the filter test above. `mention.all=1` (= `@所有人`) summons every
-// grantor in the channel, so BOTH implicit-scope candidates must fan
-// out. This locks the symmetry: filter when `mention.uids` is the only
-// signal, pass through when `mention.all` is set.
-func TestFanout_PR121R6_ImplicitScopeMentionAllSummonsEveryone(t *testing.T) {
+// TestFanout_PR121R6_ImplicitScopeMentionAllDoesNotSummonAnyone —
+// post-#143 review follow-up companion to the mention-filter test
+// above. Bare `mention.all=1` (legacy `@所有人` shape) no longer
+// triggers the unfiltered fan-out branch — the `pkg/mentionrewrite`
+// `all → ais` chokepoint was removed by #142 and the OBO fan-out gate
+// must not re-create the inference one layer deeper. With two
+// global-enabled grants in the same group, a bare `mention.all=1`
+// payload must produce ZERO fan-out copies. The persona-summon
+// trigger now requires an EXPLICIT `mention.ais=1` or
+// `mention.humans=1` signal — see the `mention.ais=1` companion test
+// below for the happy path.
+//
+// Pre-#143 follow-up this test asserted the OPPOSITE (`mention.all=1`
+// summons both grantors). The reversal pins the new contract: filter
+// when `mention.uids` is the only signal, summon everyone only when
+// the explicit ais/humans signal is set.
+func TestFanout_PR121R6_ImplicitScopeMentionAllDoesNotSummonAnyone(t *testing.T) {
 	const (
 		groupNo   = "group_pr121_r6_all"
 		grantorA  = "user_alice"
@@ -1414,15 +1425,61 @@ func TestFanout_PR121R6_ImplicitScopeMentionAllSummonsEveryone(t *testing.T) {
 		Payload:     []byte(`{"type":1,"content":"@everyone","mention":{"all":1}}`),
 	}
 	n := ba.fanoutForMessage(msg)
+	if n != 0 {
+		t.Fatalf("#142/#143: bare mention.all=1 must NOT summon any grantor (rewrite chokepoint is gone, gate must not re-infer), got %d (copies=%+v)", n, fc.copies)
+	}
+	if len(fc.copies) != 0 {
+		t.Fatalf("expected 0 captured copies, got %+v", fc.copies)
+	}
+}
+
+// TestFanout_PR121R6_ImplicitScopeMentionAisSummonsEveryone — post-#143
+// follow-up positive companion to ...DoesNotSummonAnyone above. The
+// new persona-summon trigger is `mention.ais=1` (Plan X `@所有 AI`).
+// With the same two-grantor setup, an explicit `mention.ais=1` must
+// summon BOTH grantors' personas via the implicit-scope feeder. Pins
+// that the unfiltered branch keeps working through the implicit-scope
+// codepath; a regression that drops the ais branch from
+// `fanoutForMessage` would fail this test rather than silently leaking
+// `mention.all=1` traffic back into the fan-out.
+func TestFanout_PR121R6_ImplicitScopeMentionAisSummonsEveryone(t *testing.T) {
+	const (
+		groupNo   = "group_pr121_r6_ais"
+		grantorA  = "user_alice"
+		botCloneA = "bot_clone_alice"
+		grantorB  = "user_bob"
+		botCloneB = "bot_clone_bob"
+	)
+	ct := common.ChannelTypeGroup.Uint8()
+
+	s := newFakeOBOStore()
+	gidA, _ := s.insertGrant(grantorA, botCloneA, "auto", "")
+	gidB, _ := s.insertGrant(grantorB, botCloneB, "auto", "")
+	enable := 1
+	_ = s.updateGrant(gidA, "", &enable, nil)
+	_ = s.updateGrant(gidB, "", &enable, nil)
+	s.seedGroupMember(groupNo, grantorA)
+	s.seedGroupMember(groupNo, grantorB)
+
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     "u_carol",
+		ChannelID:   groupNo,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"@所有 AI","mention":{"ais":1}}`),
+	}
+	n := ba.fanoutForMessage(msg)
 	if n != 2 {
-		t.Fatalf("mention.all must summon both grantors, got %d (copies=%+v)", n, fc.copies)
+		t.Fatalf("mention.ais=1 must summon both grantors via implicit-scope, got %d (copies=%+v)", n, fc.copies)
 	}
 	seen := map[string]bool{}
 	for _, c := range fc.copies {
 		seen[c.ChannelID] = true
 	}
 	if !seen[botCloneA] || !seen[botCloneB] {
-		t.Fatalf("mention.all must reach both bot mailboxes, got %+v", seen)
+		t.Fatalf("mention.ais=1 must reach both bot mailboxes, got %+v", seen)
 	}
 }
 

--- a/modules/bot_api/obo_pr114_r3_test.go
+++ b/modules/bot_api/obo_pr114_r3_test.go
@@ -222,13 +222,22 @@ func TestFanout_PR114R3_GroupMultipleGrantorMentions_FilterCarriesAll(t *testing
 	}
 }
 
-// TestFanout_PR114R3_GroupMentionAll_UsesUnfilteredScan — `@所有人`
-// (mention.all=1) is the documented exception: we cannot know group
-// membership at this layer so the full grant scan is unavoidable.
-// Pin that contract so a future "always-filter" refactor doesn't
-// silently break @所有人 broadcasts (they would early-return because
-// the empty filter set returns no rows).
-func TestFanout_PR114R3_GroupMentionAll_UsesUnfilteredScan(t *testing.T) {
+// TestFanout_PR114R3_GroupMentionAll_NoDispatch — post-#143 review
+// follow-up. Bare `mention.all=1` is no longer the documented "summon
+// everyone" trigger: the `pkg/mentionrewrite` `all → ais` chokepoint
+// was removed by #142, and accepting `mention.all=1` at the fan-out
+// gate would re-create the implicit inference one layer deeper.
+// `@所有 AI` now requires the explicit `mention.ais=1` signal — see
+// the companion test below for the unfiltered-scan happy path. Pin
+// the new contract so a future "always-fan-out-on-all" regression
+// fails immediately rather than silently leaking legacy `@所有人`
+// traffic to every persona clone.
+//
+// Pre-#143 follow-up this test asserted the OPPOSITE — that
+// `mention.all=1` MUST trigger the unfiltered scan. The reversal
+// pins the corrected fan-out gate (see fanoutForMessage's branch
+// rationale in modules/bot_api/obo_fanout.go).
+func TestFanout_PR114R3_GroupMentionAll_NoDispatch(t *testing.T) {
 	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
 	s := seedGrantNoScope(t)
 	fc := &fanoutCapture{}
@@ -238,18 +247,52 @@ func TestFanout_PR114R3_GroupMentionAll_UsesUnfilteredScan(t *testing.T) {
 		FromUID:     "alice",
 		ChannelID:   ch,
 		ChannelType: ct,
-		// `@所有人` shape: mention.all=1, no uids.
+		// `@所有人` legacy shape: mention.all=1, no uids, no ais, no humans.
 		Payload: []byte(`{"type":1,"content":"@所有人 ship today","mention":{"all":1}}`),
 	}
-	if got := ba.fanoutForMessage(msg); got != 1 {
-		t.Fatalf("@所有人 in group must summon every grantor, got %d", got)
+	if got := ba.fanoutForMessage(msg); got != 0 {
+		t.Fatalf("#142/#143: bare mention.all=1 must NOT dispatch (gate must not re-infer `all → ais`), got %d", got)
 	}
-	if s.findGrantsChannelCalls != 1 {
-		t.Fatalf("unfiltered scan must be used for @所有人, got %d call(s)",
+	if s.findGrantsChannelCalls != 0 {
+		t.Fatalf("bare mention.all=1 must short-circuit BEFORE the unfiltered scan (no rewrite, no fan-out), got %d call(s)",
 			s.findGrantsChannelCalls)
 	}
 	if s.findGrantsChannelByGrantorsCalls != 0 {
-		t.Fatalf("filtered query MUST NOT be used for @所有人 (no UID set to filter on), got %d",
+		t.Fatalf("bare mention.all=1 must short-circuit BEFORE the @-mention filtered scan too, got %d call(s)",
+			s.findGrantsChannelByGrantorsCalls)
+	}
+}
+
+// TestFanout_PR114R3_GroupMentionAis_UsesUnfilteredScan — post-#143
+// follow-up positive companion. The explicit `mention.ais=1`
+// (`@所有 AI`) signal MUST hit the unfiltered channel-wide scan — we
+// cannot know group membership at this layer so the full grant scan
+// is unavoidable, mirroring the historical `mention.all=1` rationale.
+// Pin that contract so a future "always-filter" refactor doesn't
+// silently break `@所有 AI` broadcasts (they would early-return
+// because the empty filter set returns no rows).
+func TestFanout_PR114R3_GroupMentionAis_UsesUnfilteredScan(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantNoScope(t)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		// `@所有 AI` Plan X shape: mention.ais=1, no uids.
+		Payload: []byte(`{"type":1,"content":"@所有 AI ship today","mention":{"ais":1}}`),
+	}
+	if got := ba.fanoutForMessage(msg); got != 1 {
+		t.Fatalf("@所有 AI (mention.ais=1) in group must summon every grantor, got %d", got)
+	}
+	if s.findGrantsChannelCalls != 1 {
+		t.Fatalf("unfiltered scan must be used for @所有 AI, got %d call(s)",
+			s.findGrantsChannelCalls)
+	}
+	if s.findGrantsChannelByGrantorsCalls != 0 {
+		t.Fatalf("filtered query MUST NOT be used for @所有 AI (no UID set to filter on), got %d",
 			s.findGrantsChannelByGrantorsCalls)
 	}
 }
@@ -331,9 +374,13 @@ func TestFanout_PR114R3_GroupBotSelfSent_StillEarlyReturns(t *testing.T) {
 		FromUID:     tBot,
 		ChannelID:   ch,
 		ChannelType: ct,
-		// Payload carries the marker AND a mention.all=1 — the marker
-		// must win or we'd loop forever.
-		Payload: []byte(`{"type":1,"content":"echo","__obo_processed__":true,"mention":{"all":1}}`),
+		// Payload carries the marker AND a mention.ais=1 — the marker
+		// must win or we'd loop forever. (Pre-#143 follow-up this used
+		// `mention.all=1`, but that is no longer a fan-out trigger so
+		// the test no longer exercised the marker-vs-mention-gate
+		// ordering it was written to pin; switched to `mention.ais=1`
+		// which IS the post-#143 unfiltered-scan trigger.)
+		Payload: []byte(`{"type":1,"content":"echo","__obo_processed__":true,"mention":{"ais":1}}`),
 	}
 	if got := ba.fanoutForMessage(msg); got != 0 {
 		t.Fatalf("__obo_processed__ marker must short-circuit before fan-out, got %d", got)

--- a/modules/bot_api/obo_pr121_r9_test.go
+++ b/modules/bot_api/obo_pr121_r9_test.go
@@ -36,23 +36,19 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 )
 
-// TestFanout_PR121R9_CommunityTopic_MentionAll_ImplicitScope_FansOut
-// — the headline R9 repro. CommunityTopic + mention.all=1 +
-// global_enabled=1 + NO explicit scope row + grantor in parent group
-// + bot NOT in parent group → fan-out copy IS dispatched.
+// TestFanout_PR121R9_CommunityTopic_MentionAll_NoDispatch — post-#143
+// review follow-up. Bare `mention.all=1` (legacy `@所有人` shape) on a
+// CommunityTopic must NOT trigger fan-out, mirroring the Group case.
+// The `pkg/mentionrewrite` `all → ais` chokepoint was removed by #142
+// and the OBO fan-out gate (incl. the R9 implicit-scope topic feeder)
+// must not re-create the inference one layer deeper. The post-#143
+// trigger for the R9 topic implicit-scope path is `mention.ais=1` —
+// see the companion test below for the happy path.
 //
-// Pre-R9 this returned 0 because:
-//
-//   - The mention.all branch in fanoutForMessage uses
-//     findActiveGrantsForChannel, which INNER JOINs obo_scopes and
-//     returns 0 rows when no scope exists.
-//   - findGlobalGrantsWithoutScope (the implicit-scope feeder) was
-//     gated to ChannelTypeGroup only and returned [] for topics.
-//
-// R9 wires CommunityTopic through the feeder using the parent group
-// for membership; the anti-join still uses the topic's own channel id
-// so per-topic admin disables are respected.
-func TestFanout_PR121R9_CommunityTopic_MentionAll_ImplicitScope_FansOut(t *testing.T) {
+// Pre-#143 follow-up this test asserted the OPPOSITE (CommunityTopic
+// + mention.all=1 + implicit-scope MUST fan out). The reversal pins
+// the corrected gate.
+func TestFanout_PR121R9_CommunityTopic_MentionAll_NoDispatch(t *testing.T) {
 	const parentGroup = "group_topic_parent_pr121r9"
 	const topicChan = parentGroup + "____topic_pr121r9"
 	ct := common.ChannelTypeCommunityTopic.Uint8()
@@ -60,11 +56,47 @@ func TestFanout_PR121R9_CommunityTopic_MentionAll_ImplicitScope_FansOut(t *testi
 	// Active+global_enabled grant, NO explicit scope row for the topic
 	// (matches operator reality: scopes are only ever installed for DMs).
 	s := seedGrantNoScope(t)
-	// Grantor is in the parent group → satisfies the implicit-scope
-	// grantor-membership predicate (the bot must inherit the grantor's
-	// read access). Bot is intentionally NOT seeded → satisfies Gate 4
-	// (bot not in parent group, so the OBO copy is the sole delivery
-	// path to the bot).
+	// Grantor is in the parent group; bot intentionally NOT seeded —
+	// the same shape that produced fan-out under the pre-#143 contract.
+	// Post-#143, the gate short-circuits BEFORE the feeder runs because
+	// `mention.all=1` alone no longer opens the unfiltered branch.
+	s.seedGroupMember(parentGroup, tGrantor)
+
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		t.Errorf("post-#143: bare mention.all=1 must short-circuit BEFORE access checks (uid=%q chan=%q)", uid, channelID)
+		return true, nil
+	}
+
+	msg := &config.MessageResp{
+		FromUID:     "u_alice", // not bot, not grantor
+		ChannelID:   topicChan,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"@所有人 heads up","mention":{"all":1}}`),
+	}
+	if n := ba.fanoutForMessage(msg); n != 0 {
+		t.Fatalf("#142/#143: CommunityTopic + bare mention.all=1 must NOT dispatch, got %d", n)
+	}
+	if len(fc.copies) != 0 {
+		t.Fatalf("expected 0 captured copies, got %d", len(fc.copies))
+	}
+}
+
+// TestFanout_PR121R9_CommunityTopic_MentionAis_ImplicitScope_FansOut
+// — post-#143 follow-up positive companion. The R9 implicit-scope
+// codepath for CommunityTopic still needs to fire when an explicit
+// `mention.ais=1` (`@所有 AI`) signal is present. Same setup as the
+// pre-#143 headline R9 repro, just swapped to the post-#143 trigger:
+// CommunityTopic + mention.ais=1 + global_enabled=1 + NO explicit
+// scope row + grantor in parent group + bot NOT in parent group →
+// fan-out copy IS dispatched via the implicit-scope feeder.
+func TestFanout_PR121R9_CommunityTopic_MentionAis_ImplicitScope_FansOut(t *testing.T) {
+	const parentGroup = "group_topic_parent_pr121r9_ais"
+	const topicChan = parentGroup + "____topic_pr121r9_ais"
+	ct := common.ChannelTypeCommunityTopic.Uint8()
+
+	s := seedGrantNoScope(t)
 	s.seedGroupMember(parentGroup, tGrantor)
 
 	fc := &fanoutCapture{}
@@ -84,20 +116,20 @@ func TestFanout_PR121R9_CommunityTopic_MentionAll_ImplicitScope_FansOut(t *testi
 		FromUID:     "u_alice", // not bot, not grantor
 		ChannelID:   topicChan,
 		ChannelType: ct,
-		Payload:     []byte(`{"type":1,"content":"@所有人 heads up","mention":{"all":1}}`),
+		Payload:     []byte(`{"type":1,"content":"@所有 AI heads up","mention":{"ais":1}}`),
 	}
 	if n := ba.fanoutForMessage(msg); n != 1 {
-		t.Fatalf("PR#121 R9: CommunityTopic + mention.all + implicit-scope must fan out, got %d", n)
+		t.Fatalf("PR#121 R9 + #143: CommunityTopic + mention.ais=1 + implicit-scope must fan out, got %d", n)
 	}
 	if len(fc.copies) != 1 {
-		t.Fatalf("PR#121 R9: expected exactly 1 captured copy, got %d", len(fc.copies))
+		t.Fatalf("PR#121 R9 + #143: expected exactly 1 captured copy, got %d", len(fc.copies))
 	}
 	cp := fc.copies[0]
 	if cp.FromUID != tGrantor {
-		t.Fatalf("PR#121 R9: fan-out copy FromUID must be grantor %q, got %q", tGrantor, cp.FromUID)
+		t.Fatalf("PR#121 R9 + #143: fan-out copy FromUID must be grantor %q, got %q", tGrantor, cp.FromUID)
 	}
 	if cp.ChannelID != tBot {
-		t.Fatalf("PR#121 R9: fan-out copy ChannelID must be bot mailbox %q, got %q", tBot, cp.ChannelID)
+		t.Fatalf("PR#121 R9 + #143: fan-out copy ChannelID must be bot mailbox %q, got %q", tBot, cp.ChannelID)
 	}
 }
 
@@ -113,6 +145,13 @@ func TestFanout_PR121R9_CommunityTopic_MentionAll_ImplicitScope_FansOut(t *testi
 // fired for topics) but it MUST be safe after the extension —
 // otherwise R9 reintroduces the duplicate-fan-out bug Gate 4 was
 // created to prevent.
+//
+// Post-#143 follow-up: switched the trigger payload from
+// `mention.all=1` to `mention.ais=1`. The previous shape no longer
+// opens the unfiltered branch, so the original test would still pass
+// (zero fan-out) but for the wrong reason and would no longer
+// exercise Gate 4. Using `mention.ais=1` keeps Gate 4 the load-
+// bearing check.
 func TestFanout_PR121R9_CommunityTopic_MentionAll_BotInParentGroup_NoFanout(t *testing.T) {
 	const parentGroup = "group_topic_parent_pr121r9_gate4"
 	const topicChan = parentGroup + "____topic_pr121r9_gate4"
@@ -130,7 +169,7 @@ func TestFanout_PR121R9_CommunityTopic_MentionAll_BotInParentGroup_NoFanout(t *t
 		FromUID:     "u_alice",
 		ChannelID:   topicChan,
 		ChannelType: ct,
-		Payload:     []byte(`{"type":1,"content":"@所有人 heads up","mention":{"all":1}}`),
+		Payload:     []byte(`{"type":1,"content":"@所有 AI heads up","mention":{"ais":1}}`),
 	}
 	if n := ba.fanoutForMessage(msg); n != 0 {
 		t.Fatalf("PR#121 R9: bot in parent group → implicit-scope SQL Gate 4 must suppress fan-out, got %d", n)
@@ -179,7 +218,11 @@ func TestFanout_PR121R9_CommunityTopic_MentionAll_ExplicitDisableWins(t *testing
 		FromUID:     "u_alice",
 		ChannelID:   topicChan,
 		ChannelType: ct,
-		Payload:     []byte(`{"type":1,"content":"@所有人 hi","mention":{"all":1}}`),
+		// Post-#143: switched from `mention.all=1` to `mention.ais=1`
+		// so the unfiltered branch is opened and the explicit-disable
+		// scope row remains the load-bearing suppression — see the
+		// pre-#143 follow-up commit for rationale.
+		Payload: []byte(`{"type":1,"content":"@所有 AI hi","mention":{"ais":1}}`),
 	}
 	if n := ba.fanoutForMessage(msg); n != 0 {
 		t.Fatalf("PR#121 R9: explicit enabled=0 scope on topic must suppress implicit-scope fan-out, got %d", n)
@@ -212,7 +255,12 @@ func TestFanout_PR121R9_CommunityTopic_MalformedThreadID_NoFanout(t *testing.T) 
 		FromUID:     "u_alice",
 		ChannelID:   malformed,
 		ChannelType: ct,
-		Payload:     []byte(`{"type":1,"content":"@所有人 hi","mention":{"all":1}}`),
+		// Post-#143: switched from `mention.all=1` to `mention.ais=1`
+		// so the unfiltered branch is opened and the malformed thread
+		// id remains the load-bearing fail-closed signal — otherwise
+		// the test passes for the wrong reason (bare mention.all=1 no
+		// longer triggers fan-out under the post-#143 gate).
+		Payload: []byte(`{"type":1,"content":"@所有 AI hi","mention":{"ais":1}}`),
 	}
 	if n := ba.fanoutForMessage(msg); n != 0 {
 		t.Fatalf("PR#121 R9: malformed thread id must fail-closed, got %d", n)

--- a/modules/bot_api/obo_v2_test.go
+++ b/modules/bot_api/obo_v2_test.go
@@ -59,33 +59,47 @@ func TestFanout_V2_GroupRequiresGrantorMention(t *testing.T) {
 	}
 }
 
-// TestFanout_V2_GroupMentionAIBotDoesNotSummonPersona — a message that
-// @-mentions only the bot or only sets `mention.ais=1` (the AI-broadcast
-// flag) must not summon the grantor's persona. The narrowing gate is
-// strict on `mention.uids` for AI-only / bot-only traffic — neither
-// `mention.ais` nor a foreign-bot uid in `mention.uids` counts. Without
-// this strictness the v1 "fan out everything" semantics return.
+// TestFanout_V2_GroupMentionAIBotSummonsPersona — post-#143 review
+// follow-up. A message that sets `mention.ais=1` (the `@所有 AI`
+// broadcast flag, Plan X / YUJ-1389) MUST summon every grantor's
+// persona via the unfiltered scan branch. This pins the post-#143
+// contract: with the `pkg/mentionrewrite` `all → ais` chokepoint
+// removed (octo-server#142) AND the OBO fan-out gate corrected so
+// `mention.all=1` no longer triggers (octo-server#143 follow-up),
+// `mention.ais=1` becomes the single explicit signal for an "every
+// bot persona in the channel responds" broadcast.
 //
-// YUJ-1538 carve-out: `mention.all=1` (the `@所有人` broadcast flag) IS
-// honoured by the gate as an implicit summon for every grantor, so it
-// is intentionally NOT exercised here — the dedicated
-// TestFanout_V2_GroupMentionAllSummonsPersona below covers that.
-func TestFanout_V2_GroupMentionAIBotDoesNotSummonPersona(t *testing.T) {
+// Pre-#143 follow-up this test asserted the OPPOSITE: that
+// `mention.ais=1` (and `mention.uids=[foreign_bot]`) must NOT
+// summon the grantor's persona. That contract was specific to the
+// pre-#143 world where the rewrite chokepoint already widened
+// legacy `mention.all=1` into `mention.ais=1` at the boundary, so
+// the OBO gate treated `mention.ais` as plain "AI broadcast" noise
+// rather than a persona-summon signal. With the chokepoint gone,
+// `mention.ais=1` is now the load-bearing summon trigger and this
+// test is reversed.
+//
+// The presence of an unrelated `mention.uids=[some_other_bot]` does
+// NOT narrow the summon — `mention.ais=1` is itself a sufficient
+// trigger for the unfiltered scan, mirroring the legacy
+// `mention.all=1` semantics that the chokepoint used to materialize.
+func TestFanout_V2_GroupMentionAIBotSummonsPersona(t *testing.T) {
 	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
 	s := seedGrantWithScope(t, ch, ct)
 	fc := &fanoutCapture{}
 	ba := newBAforFanout(s, fc)
 
-	// mention.ais=1 + mention.uids=[some_other_bot] — neither summons
-	// our grantor (tGrantor) so v2 must skip.
+	// mention.ais=1 + mention.uids=[some_other_bot] — under the
+	// post-#143 contract `ais=1` summons every grantor regardless of
+	// the foreign uid in `mention.uids`.
 	msg := &config.MessageResp{
 		FromUID:     "alice",
 		ChannelID:   ch,
 		ChannelType: ct,
 		Payload:     []byte(`{"type":1,"content":"@AI please","mention":{"ais":1,"uids":["some_other_bot"]}}`),
 	}
-	if n := ba.fanoutForMessage(msg); n != 0 {
-		t.Fatalf("v2 narrowing violated: @AI / mention.ais must NOT summon persona without explicit @grantor or mention.all=1, got %d dispatches", n)
+	if n := ba.fanoutForMessage(msg); n != 1 {
+		t.Fatalf("post-#143: mention.ais=1 MUST summon grantor persona via unfiltered scan, got %d dispatches", n)
 	}
 }
 

--- a/modules/bot_api/obo_yuj1538_test.go
+++ b/modules/bot_api/obo_yuj1538_test.go
@@ -106,41 +106,82 @@ func TestFanout_YUJ1538_CommunityTopicNoScopeRow_GlobalEnabledFansOut(t *testing
 	}
 }
 
-// TestFanout_YUJ1538_GroupMentionAllSummonsPersona — `@所有人`
-// (`mention.all=1`) in a group must trigger fan-out for every
-// `global_enabled=1` grantor, even when the grantor is not listed in
-// `mention.uids`. Pre-YUJ-1538 the narrowing gate only inspected
-// `mention.uids`, so broadcast messages silently never reached the
-// persona — a more visible regression than the missing scope-row case
-// because grantors typically install bot personas precisely to
-// monitor broadcasts.
-func TestFanout_YUJ1538_GroupMentionAllSummonsPersona(t *testing.T) {
+// TestFanout_YUJ1538_GroupMentionAllDoesNotSummonPersona —
+// Mininglamp-OSS/octo-server#142 / #143 follow-up. Legacy
+// `@所有人` (`mention.all=1`) MUST NOT trigger OBO bot / persona
+// fan-out. Pre-#143 the `pkg/mentionrewrite` chokepoint silently
+// rewrote `all=1` to `ais=1` so legacy traffic auto-fanned-out to
+// every persona clone; #142 reverted that rewrite, and this gate
+// (`decodeMentionGate` + the `fanoutForMessage` branch) must enforce
+// the same contract one layer deeper. With the rewrite gone, a bare
+// `mention.all=1` is treated as plain traffic — the persona summon
+// path requires an EXPLICIT `mention.ais=1` (`@所有 AI`) or
+// `mention.humans=1` (`@所有人` Plan X shape) signal.
+//
+// Pre-#143 follow-up this test asserted the OPPOSITE behavior
+// (`mention.all=1` SHOULD summon every persona). That was the bug:
+// the rewrite chokepoint above the gate was load-bearing, and once
+// removed, this gate continued the implicit inference. The new
+// expectation pins the corrected behavior: zero dispatches for bare
+// `mention.all=1`.
+func TestFanout_YUJ1538_GroupMentionAllDoesNotSummonPersona(t *testing.T) {
 	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
 	s := seedGrantNoScope(t)
 	fc := &fanoutCapture{}
 	ba := newBAforFanout(s, fc)
 
-	// `@所有人 hi` shape: mention.all=1, no uids array. Real WuKongIM
-	// payloads use `1` (json.Number/float64 after json.Unmarshal); the
-	// gate also accepts `true` (boolean) for forward compat.
+	// `@所有人 hi` legacy WuKongIM shape: mention.all=1, no uids array,
+	// no ais, no humans. The post-#143 contract: NO fan-out.
 	msg := &config.MessageResp{
 		FromUID:     "alice",
 		ChannelID:   ch,
 		ChannelType: ct,
 		Payload:     []byte(`{"type":1,"content":"@所有人 hi","mention":{"all":1}}`),
 	}
+	if got := ba.fanoutForMessage(msg); got != 0 {
+		t.Fatalf("#142/#143: bare mention.all=1 must NOT summon any persona (rewrite chokepoint is gone — gate must not re-create the inference), got %d", got)
+	}
+	if len(fc.copies) != 0 {
+		t.Fatalf("expected 0 captured copies, got %d", len(fc.copies))
+	}
+}
+
+// TestFanout_YUJ1538_GroupMentionAisSummonsPersona — positive
+// companion to TestFanout_YUJ1538_GroupMentionAllDoesNotSummonPersona.
+// The post-#143 trigger for "summon every persona in the channel" is
+// `mention.ais=1` (Plan X / YUJ-1389 `@所有 AI` broadcast). Pins the
+// happy path so a regression that drops the ais branch from
+// `decodeMentionGate` / `fanoutForMessage` fails immediately rather
+// than silently reverting to the pre-#143 implicit-inference behavior.
+func TestFanout_YUJ1538_GroupMentionAisSummonsPersona(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantNoScope(t)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	// `@所有 AI` Plan X shape: mention.ais=1, no uids, no all, no humans.
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"@所有 AI hi","mention":{"ais":1}}`),
+	}
 	if got := ba.fanoutForMessage(msg); got != 1 {
-		t.Fatalf("YUJ-1538: @所有人 (mention.all=1) in group must summon every grantor's persona, got %d", got)
+		t.Fatalf("YUJ-1538 + #143: @所有 AI (mention.ais=1) in group must summon every grantor's persona, got %d", got)
 	}
 	if len(fc.copies) != 1 {
 		t.Fatalf("expected 1 captured copy, got %d", len(fc.copies))
 	}
 }
 
-// TestFanout_YUJ1538_GroupMentionAllBooleanShape — defensive check
-// that the boolean shape `mention.all=true` (some clients) is also
-// honoured, not just the numeric `1` form.
-func TestFanout_YUJ1538_GroupMentionAllBooleanShape(t *testing.T) {
+// TestFanout_YUJ1538_GroupMentionAllBooleanShapeDoesNotSummon —
+// the boolean shape (`mention.all=true`) of the legacy WuKongIM
+// `@所有人` payload must follow the same post-#143 contract: NO
+// fan-out. Mirrors TestFanout_YUJ1538_GroupMentionAllDoesNotSummonPersona
+// but pins the alternative wire shape. Pre-#143 this asserted the
+// opposite (boolean true must summon every persona) and has been
+// reversed alongside the rewrite removal.
+func TestFanout_YUJ1538_GroupMentionAllBooleanShapeDoesNotSummon(t *testing.T) {
 	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
 	s := seedGrantNoScope(t)
 	fc := &fanoutCapture{}
@@ -152,8 +193,30 @@ func TestFanout_YUJ1538_GroupMentionAllBooleanShape(t *testing.T) {
 		ChannelType: ct,
 		Payload:     []byte(`{"type":1,"content":"@所有人 hi","mention":{"all":true}}`),
 	}
+	if got := ba.fanoutForMessage(msg); got != 0 {
+		t.Fatalf("#142/#143: mention.all=true (boolean) must NOT summon any persona either, got %d", got)
+	}
+}
+
+// TestFanout_YUJ1538_GroupMentionAisBooleanShapeSummonsPersona —
+// boolean-shape positive companion. Some clients emit
+// `mention.ais=true` instead of the numeric `1`. The gate must honor
+// both shapes for the ais summon path (parity with the legacy
+// boolean-shape coverage on `mention.all`).
+func TestFanout_YUJ1538_GroupMentionAisBooleanShapeSummonsPersona(t *testing.T) {
+	ch, ct := "group_42", common.ChannelTypeGroup.Uint8()
+	s := seedGrantNoScope(t)
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     "alice",
+		ChannelID:   ch,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"@所有 AI hi","mention":{"ais":true}}`),
+	}
 	if got := ba.fanoutForMessage(msg); got != 1 {
-		t.Fatalf("YUJ-1538: mention.all=true (boolean) must be treated as truthy, got %d", got)
+		t.Fatalf("YUJ-1538 + #143: mention.ais=true (boolean) must be treated as truthy summon, got %d", got)
 	}
 }
 
@@ -340,7 +403,7 @@ func TestDecodeMentionGate_YUJ1538_AllFlagShapes(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, all := decodeMentionGate([]byte(tc.payload))
+			_, all, _, _ := decodeMentionGate([]byte(tc.payload))
 			if all != tc.wantAll {
 				t.Fatalf("payload %q: want all=%v, got %v", tc.payload, tc.wantAll, all)
 			}

--- a/modules/bot_api/obo_yuj1709_test.go
+++ b/modules/bot_api/obo_yuj1709_test.go
@@ -37,15 +37,21 @@ import (
 )
 
 // TestDecodeMentionGate_YUJ1709_HumansFlagShapes — exhaustive shape
-// coverage for the new `mention.humans` truthy decoder. Mirrors the
+// coverage for the `mention.humans` truthy decoder. Mirrors the
 // YUJ-1538 `mention.all` shape table so the two flags stay in lock-step:
 // numeric `1` and boolean `true` are truthy, everything else (`0`,
 // `false`, missing, null, strings, unrelated types) is not.
+//
+// Post-#142 / #143 follow-up: the decoder now returns `mentionAll`,
+// `mentionAis`, and `mentionHumans` as three independent slots rather
+// than the historical conflated `all || humans` boolean. This test
+// asserts on `mentionHumans` specifically — `mention.all` no longer
+// participates in the humans gate.
 func TestDecodeMentionGate_YUJ1709_HumansFlagShapes(t *testing.T) {
 	cases := []struct {
-		name    string
-		payload string
-		wantAll bool
+		name       string
+		payload    string
+		wantHumans bool
 	}{
 		{"humans_number_one", `{"mention":{"humans":1}}`, true},
 		{"humans_number_zero", `{"mention":{"humans":0}}`, false},
@@ -53,23 +59,24 @@ func TestDecodeMentionGate_YUJ1709_HumansFlagShapes(t *testing.T) {
 		{"humans_bool_false", `{"mention":{"humans":false}}`, false},
 		{"humans_string_one", `{"mention":{"humans":"1"}}`, false},
 		{"humans_null", `{"mention":{"humans":null}}`, false},
-		// Co-presence: all=0 + humans=1 → still truthy (Plan X never
-		// co-emits but we must not let an explicit `all:0` veto a
-		// truthy `humans`).
+		// Co-presence: all=0 + humans=1 → mentionHumans=true (an
+		// explicit `all:0` must not veto a truthy `humans`; Plan X
+		// never co-emits but be defensive).
 		{"all_zero_humans_one", `{"mention":{"all":0,"humans":1}}`, true},
-		// Co-presence: all=1 + humans=0 → still truthy (legacy clients
-		// that happen to also emit humans=0 must keep working).
-		{"all_one_humans_zero", `{"mention":{"all":1,"humans":0}}`, true},
+		// Co-presence: all=1 + humans=0 → mentionHumans=false. After
+		// #142 / #143 `mention.all` no longer rolls into the humans
+		// slot; `humans=0` is the controlling signal here.
+		{"all_one_humans_zero", `{"mention":{"all":1,"humans":0}}`, false},
 		// Plain `@AI` style payload: neither flag set, just uids →
-		// mentionAll must remain false (the uid-narrowed query handles
-		// dispatch).
+		// mentionHumans must remain false (the uid-narrowed query
+		// handles dispatch).
 		{"only_uids", `{"mention":{"uids":["u_alice"]}}`, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, all := decodeMentionGate([]byte(tc.payload))
-			if all != tc.wantAll {
-				t.Fatalf("payload %q: want all=%v, got %v", tc.payload, tc.wantAll, all)
+			_, _, _, humans := decodeMentionGate([]byte(tc.payload))
+			if humans != tc.wantHumans {
+				t.Fatalf("payload %q: want humans=%v, got %v", tc.payload, tc.wantHumans, humans)
 			}
 		})
 	}

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -183,20 +183,20 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 		payload = ba.enrichBotPayloadWithSpaceID(c, robotID, payload)
 	}
 
-	// YUJ-202 / Mininglamp-OSS#94 / YUJ-1389 (Plan X) — mention
-	// three-state rewrite. Same chokepoint contract as
-	// modules/message/api.go: legacy `mention.all=1` is normalized to
-	// also carry `mention.ais=1` so legacy `@所有人` traffic auto-fans-
-	// out to all AI bots without requiring an SDK update on the
-	// sender side (outbound double-write keeps `all=1` for old
-	// read-side clients that only understand the legacy field).
-	// `mention.humans=1` remains an explicit, opt-in human-
-	// notification signal — it is NEVER inferred from `all=1`.
-	// ⚠️ F2 (PR#70 Jerry-Xin correctness-critical review): this MUST
-	// be placed OUTSIDE the `ChannelTypePerson` conditional above —
-	// otherwise group / community-topic `@所有人` traffic (the main
-	// pain-point being fixed) would bypass the rewrite. Helper is
-	// idempotent and safe on nil — see pkg/mentionrewrite.
+	// YUJ-202 / Mininglamp-OSS#94 / #142 — mention pass-through
+	// chokepoint. Same contract as modules/message/api.go: post-#142
+	// the helper no longer infers `mention.ais=1` from legacy
+	// `mention.all=1` (legacy `@所有人` MUST NOT trigger bots). The
+	// helper is now a pass-through that forwards `mention.all`,
+	// `mention.humans`, `mention.ais`, and `mention.uids` untouched.
+	// The call site is preserved so any future re-introduction of
+	// chokepoint normalization (and the symmetric ingress on
+	// modules/message/api.go + modules/robot/api.go) lands in one
+	// place. ⚠️ F2 (PR#70 Jerry-Xin correctness-critical review): this
+	// MUST stay OUTSIDE the `ChannelTypePerson` conditional above —
+	// otherwise group / community-topic mention payloads would bypass
+	// the chokepoint should we ever need to reinstate the rewrite.
+	// Helper is idempotent and safe on nil — see pkg/mentionrewrite.
 	payload = mentionrewrite.RewriteMention(payload)
 
 	// YUJ-1166 fan-out loop guard #3: mark this message so the fan-out

--- a/modules/bot_api/send_test.go
+++ b/modules/bot_api/send_test.go
@@ -301,23 +301,29 @@ func TestSendMessage_PersonalDM_DBError_ForgedClientSpaceID_Stripped(t *testing.
 		"DB error + forged client space_id MUST be stripped from dispatched payload — attackers cannot use transient DB failure to bypass authoritative override")
 }
 
-// TestSendMessage_MentionAllRewritten_HandlerIntegration is the YUJ-1343 /
-// Mininglamp-OSS/octo-server#94 acceptance test for the mention three-state
-// rewrite on the /v1/bot/sendMessage handler path, updated for Plan X
-// (YUJ-1389).
+// TestSendMessage_MentionAllPassThrough_HandlerIntegration is the
+// YUJ-1343 / Mininglamp-OSS/octo-server#94 acceptance test for the
+// mention three-state rewrite on the /v1/bot/sendMessage handler
+// path, updated for Mininglamp-OSS/octo-server#142.
 //
-// This is the "handler-level integration test" the issue calls out: drive
-// BotAPI.sendMessage end-to-end with a `payload.mention.all=1` body and
-// assert the captured MsgSendReq carries `mention.ais=1` (Plan X
-// chokepoint rewrite ran — legacy `@所有人` auto-fans-out to all AI bots
-// without an SDK update) AND still carries `mention.all=1` (outbound
-// double-write preserved for legacy read-side clients). humans MUST
-// stay absent — humans is the explicit human-notification signal and is
-// never inferred from a legacy `all=1`. Lesson from PR#82 OBO fan-out:
-// when an external-service shape constraint matters, the test MUST go
-// through the real handler stack — not call the helper in isolation —
-// otherwise a wiring regression (e.g. someone deletes the call site by
-// mistake) slips past unit coverage.
+// This is the "handler-level integration test" the issue calls out:
+// drive BotAPI.sendMessage end-to-end with a `payload.mention.all=1`
+// body and assert the captured MsgSendReq carries `mention.all=1`
+// untouched, with NO implicit `mention.ais=1` and NO implicit
+// `mention.humans=1`.
+//
+// History: under Plan X (YUJ-1389) this test asserted that the
+// chokepoint rewrote `all=1` to also carry `ais=1` so legacy
+// `@所有人` traffic auto-fanned-out to all AI bots without an SDK
+// update. Product intent was corrected in #142 — legacy `@所有人`
+// MUST NOT trigger bots — so the rewrite is now a pass-through and
+// the test asserts the pass-through invariant. Lesson from PR#82 OBO
+// fan-out remains: when an external-service shape constraint matters,
+// the test MUST go through the real handler stack — not call the
+// helper in isolation — otherwise a wiring regression (e.g. someone
+// deletes the call site by mistake) slips past unit coverage. The
+// chokepoint call site is preserved for that exact reason; only its
+// behavior changed.
 //
 // Uses the existing creator-DM path (BotKindUser whose CreatorUID ==
 // channel_id) so the test does not need a live IsFriend / group_member
@@ -325,7 +331,7 @@ func TestSendMessage_PersonalDM_DBError_ForgedClientSpaceID_Stripped(t *testing.
 // `ChannelTypePerson` conditional (F2 — see modules/bot_api/send.go), so
 // even though this test drives a DM, the helper still runs; the same
 // helper would run on the group / community-topic path by inspection.
-func TestSendMessage_MentionAllRewritten_HandlerIntegration(t *testing.T) {
+func TestSendMessage_MentionAllPassThrough_HandlerIntegration(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	const (
@@ -386,18 +392,18 @@ func TestSendMessage_MentionAllRewritten_HandlerIntegration(t *testing.T) {
 	if !assert.True(t, ok, "dispatched payload must keep mention map; got %T", dispatchedPayload["mention"]) {
 		return
 	}
-	// Plan X chokepoint rewrite ran — ais=1 is now present (legacy
-	// `@所有人` auto-fans-out to all AI bots without an SDK update).
-	ais, _ := mention["ais"].(json.Number)
-	assert.Equal(t, "1", ais.String(),
-		"Plan X: BotAPI.sendMessage must invoke mentionrewrite.RewriteMention so mention.ais=1 reaches the dispatcher")
-	// Outbound double-write — legacy all=1 still present so old read-side
-	// clients keep rendering the @所有人 pill until they roll out support
-	// for the humans/ais fields.
+	// Post-#142 the chokepoint is a pass-through — ais MUST stay absent
+	// (the historical Plan X `all → also ais` inference was removed
+	// because legacy `@所有人` must not auto-trigger bots).
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAIs,
+		"#142: BotAPI.sendMessage rewrite must NOT infer mention.ais from legacy mention.all=1 — bots only fire on explicit ais=1")
+	// Legacy all=1 still present on the dispatched payload — old
+	// read-side clients keep rendering the @所有人 pill.
 	all, _ := mention["all"].(json.Number)
 	assert.Equal(t, "1", all.String(),
-		"legacy mention.all=1 MUST be preserved on the dispatched payload (outbound double-write)")
-	// humans MUST stay absent — Plan X: humans is the explicit human-
+		"legacy mention.all=1 MUST be preserved on the dispatched payload (pass-through)")
+	// humans MUST stay absent — humans is the explicit human-
 	// notification signal and is NEVER inferred from a legacy `all=1`.
 	// Only the sender may set humans, and only when they want a
 	// channel-level "[有人@我]" reminder for human members.
@@ -408,9 +414,9 @@ func TestSendMessage_MentionAllRewritten_HandlerIntegration(t *testing.T) {
 
 // TestSendMessage_MentionAisPassthrough_HandlerIntegration verifies the
 // other end of the matrix: an explicit `mention.ais=1` from a new client
-// passes through the chokepoint untouched (the Plan X rewrite is a
-// one-way "all → also ais" rule, never adds humans/ais from thin air
-// when the inbound shape did not request the broadcast via all=1).
+// passes through the chokepoint untouched. Post-#142 the chokepoint is
+// a strict pass-through for every shape, so the helper also never adds
+// `humans` or `all` from thin air.
 func TestSendMessage_MentionAisPassthrough_HandlerIntegration(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -458,19 +458,21 @@ func (m *Message) sendMessage(channelID string, channelType uint8, fromUID strin
 	// BEFORE persistence/dispatch. See sanitizeUserIngressPayload below
 	// for the full rationale and unit test surface.
 	sanitizeUserIngressPayload(payload, channelID, channelType, fromUID, m.Warn)
-	// YUJ-202 / Mininglamp-OSS#94 — mention three-state rewrite
-	// (方案 X step §5 of docs/2026-05-mention-all-chokepoint-audit.md).
-	// Legacy clients still send `mention.all=1` for "@所有人"; the
-	// chokepoint normalizes that to also carry `mention.ais=1` (Plan X
-	// / YUJ-1389) so legacy `@所有人` automatically fans out to all AI
-	// bots without an SDK update, AND keeps `all=1` in place as an
-	// outbound double-write for old read-side clients that only
-	// understand `all`. `mention.humans=1` is NEVER inferred from
-	// legacy `all=1` — humans is the explicit human-notification signal
-	// and must be set by the client (Yu D1 — legacy "@所有人" must NOT
-	// auto-tag humans). Helper is idempotent and safe on nil /
-	// malformed mention shapes — see pkg/mentionrewrite/rewrite.go for
-	// the contract.
+	// YUJ-202 / Mininglamp-OSS#94 / #142 — mention pass-through chokepoint.
+	// The original Plan X §5 design (docs/2026-05-mention-all-chokepoint-audit.md)
+	// rewrote legacy `mention.all=1` to also carry `mention.ais=1` so
+	// legacy `@所有人` traffic auto-fanned-out to every AI bot without
+	// an SDK update. Mininglamp-OSS/octo-server#142 reverted that
+	// inference: legacy `@所有人` MUST NOT trigger bots, so the helper
+	// is now a pass-through that preserves whatever `mention.*` shape
+	// the client sent. `mention.all`, `mention.humans`, `mention.ais`,
+	// and `mention.uids` are all forwarded untouched. The call site is
+	// preserved (rather than removed) so any future re-introduction of
+	// chokepoint normalization has a single home, and downstream
+	// consumers (OBO fan-out, robot dispatch, reminder fan-in) keep the
+	// same payload-shape contract. Helper is idempotent and safe on
+	// nil / malformed mention shapes — see pkg/mentionrewrite/rewrite.go
+	// for the contract.
 	payload = RewriteMention(payload)
 	// YUJ-219-A / GH#1283 (analysis-report.md §4.5 / §7.4)：
 	// 派发前为消息 payload 注入权威 space_id，让客户端 SpaceFilter 拿到可信字段，

--- a/modules/message/api_reminders.go
+++ b/modules/message/api_reminders.go
@@ -184,12 +184,17 @@ func (m *Message) getReminders(messages []*config.MessageResp) []*remindersModel
 		if m.hasMention(payloadMap) {
 			all, uids := m.getMention(payloadMap)
 			if all {
-				// Plan X (YUJ-1389): only create a channel-level
-				// reminder when humans=1 is explicitly set. ais-only
-				// broadcasts (including legacy all=1 → rewritten to
-				// ais=1) do NOT create human-visible reminders. Bots
-				// respond via the message delivery path, so a
-				// "[有人@我]" red-dot for human members would be noise.
+				// Plan X (YUJ-1389) + #142 follow-up: only create a
+				// channel-level reminder when humans=1 is explicitly
+				// set. ais-only broadcasts do NOT create human-visible
+				// reminders (bots respond via the message delivery
+				// path, so a "[有人@我]" red-dot for human members
+				// would be noise). Post-#142 there is no longer a
+				// rewrite chokepoint that turns legacy `all=1` into
+				// `ais=1` — `all=1` is treated as plain `@所有人`
+				// rendering metadata for legacy read-side clients and
+				// likewise does NOT trigger a reminder. `humans=1` is
+				// the single human-notification signal here.
 				mentionMap2, _ := payloadMap["mention"].(map[string]interface{})
 				hasHumans := mentionFlagTruthy(mentionMap2["humans"])
 				if hasHumans {
@@ -364,16 +369,19 @@ func (m *Message) getMention(payloadMap map[string]interface{}) (all bool, uids 
 	if !ok {
 		return false, nil
 	}
-	// YUJ-202 / Mininglamp-OSS#94 / YUJ-1389 (Plan X) — mention
-	// three-state read side. The chokepoint rewrite
-	// (pkg/mentionrewrite.RewriteMention) double-writes legacy
-	// `mention.all=1` into `mention.ais=1` (Plan X: legacy `@所有人`
-	// auto-fans-out to all AI bots without an SDK update), and a new
-	// client can also send `mention.humans=1` independently. getMention
-	// here returns all=true if ANY of {humans, ais, all} = 1 so the
-	// caller (getReminders) can then gate the channel-level reminder on
-	// the explicit `humans=1` signal — see the call site for the
-	// reminder-emission logic. Reasoning matrix (Plan X, YUJ-1389):
+	// YUJ-202 / Mininglamp-OSS#94 / YUJ-1389 / #142 — mention three-
+	// state read side. The chokepoint (pkg/mentionrewrite.RewriteMention)
+	// is now a pass-through after Mininglamp-OSS/octo-server#142: legacy
+	// `mention.all=1` is no longer auto-rewritten into `mention.ais=1`,
+	// and the read side must treat `all`, `ais`, and `humans` as three
+	// independent client-emitted signals. A new client can send any
+	// combination (`humans=1` for a human-only ping, `ais=1` for an AI
+	// broadcast, both for `@所有人 + @所有 AI`, neither + uids for a
+	// targeted mention). getMention here returns all=true if ANY of
+	// {humans, ais, all} = 1 so the caller (getReminders) can then gate
+	// the channel-level reminder on the explicit `humans=1` signal —
+	// see the call site for the reminder-emission logic. Reasoning
+	// matrix (Plan X + post-#142 pass-through):
 	//
 	//   humans=1                       → human members see reminder,
 	//                                    bots silent (humans-only path)
@@ -382,11 +390,14 @@ func (m *Message) getMention(payloadMap map[string]interface{}) (all bool, uids 
 	//                                    level reminder is created
 	//   humans=1 AND ais=1             → humans see reminder, bots
 	//                                    respond via delivery
-	//   all=1 (post-rewrite has ais=1) → same as ais=1, NO human
-	//                                    reminder — legacy `@所有人`
-	//                                    behaves as a bot broadcast
-	//                                    unless the client ALSO sets
-	//                                    humans=1 explicitly
+	//   all=1 (legacy `@所有人`, no    → render-only metadata for old
+	//   ais / humans set by client)      read-side clients; NO human
+	//                                    reminder AND NO bot summon —
+	//                                    post-#142 the legacy field is
+	//                                    NOT auto-promoted to ais=1.
+	//                                    See pkg/mentionrewrite/rewrite.go
+	//                                    + modules/bot_api/obo_fanout.go
+	//                                    for the matching pass-through.
 	//
 	// getMention itself stays "any broadcast → all=true"; the
 	// humans-gate lives at the call site so we never lose the per-uid

--- a/modules/message/api_reminders_test.go
+++ b/modules/message/api_reminders_test.go
@@ -320,13 +320,16 @@ func TestGetReminders_FanoutMatrix(t *testing.T) {
 }
 
 // TestGetReminders_LegacyAllRoundTripThroughRewrite is the end-to-end
-// matrix cell that ties the chokepoint and the reader together under
-// Plan X (YUJ-1389): a legacy `mention.all=1` payload, after passing
-// through the chokepoint rewrite, produces ZERO channel-level
-// reminders — the post-rewrite payload is `{all:1, ais:1}`, which is
-// ais-only semantics and must NOT create a "[有人@我]" red-dot.
-// Bots receive the message via the delivery path; humans see nothing
-// in the reminder pane (which is the desired Plan X behavior).
+// matrix cell that ties the chokepoint and the reader together. Under
+// Mininglamp-OSS/octo-server#142 the chokepoint helper is now a strict
+// pass-through (the historical Plan X / YUJ-1389 `all→ais` inference
+// was removed because legacy `@所有人` must not auto-trigger bots), so
+// the post-rewrite payload is still `{all:1}` with no `ais` and no
+// `humans`. The reader-side outcome is unchanged: legacy `all=1` alone
+// produces ZERO channel-level reminders (no humans gate trips), bots
+// do NOT fan out (no explicit ais=1), and the legacy `all=1` field
+// stays on the wire so old read-side clients keep rendering the
+// `@所有人` pill.
 func TestGetReminders_LegacyAllRoundTripThroughRewrite(t *testing.T) {
 	m := newReminderTestMessage(t)
 
@@ -337,15 +340,19 @@ func TestGetReminders_LegacyAllRoundTripThroughRewrite(t *testing.T) {
 			"all": json.Number("1"),
 		},
 	}
-	// Chokepoint rewrite.
+	// Chokepoint rewrite (post-#142: pass-through).
 	rewritten := RewriteMention(inbound)
 	mention := rewritten["mention"].(map[string]interface{})
-	assert.Equal(t, json.Number("1"), mention["all"], "all preserved (outbound double-write)")
-	assert.Equal(t, json.Number("1"), mention["ais"], "Plan X: ais added by rewrite")
+	assert.Equal(t, json.Number("1"), mention["all"],
+		"all preserved verbatim (legacy read-side clients render @所有人 from it)")
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAIs,
+		"#142: ais MUST NOT be inferred from legacy all=1 — bots only fire on explicit ais=1")
 	_, hasHumans := mention["humans"]
-	assert.False(t, hasHumans, "Plan X: humans is NOT auto-set by rewrite")
+	assert.False(t, hasHumans,
+		"humans MUST NOT be auto-set by rewrite — only the sender may set it")
 
-	// Reader sees the rewritten payload.
+	// Reader sees the rewritten (pass-through) payload.
 	msg := &config.MessageResp{
 		ChannelID:   "ch_roundtrip",
 		ChannelType: common.ChannelTypeGroup.Uint8(),
@@ -357,15 +364,15 @@ func TestGetReminders_LegacyAllRoundTripThroughRewrite(t *testing.T) {
 	}
 	rems := m.getReminders([]*config.MessageResp{msg})
 	assert.Len(t, rems, 0,
-		"Plan X: legacy all=1 (rewritten to all+ais) must produce ZERO channel-level reminders")
+		"#142: legacy all=1 alone produces ZERO channel-level reminders (no humans gate trips)")
 }
 
-// TestGetReminders_HumansPlusAllRoundTrip — a future client that wants
-// BOTH the legacy `all=1` pill on old read-side clients AND a human-
-// visible reminder sends `{all:1, humans:1}` inbound. The chokepoint
-// rewrite ALSO adds `ais=1` (Plan X), so the dispatched payload is
-// `{all:1, humans:1, ais:1}`. Reader must emit exactly ONE channel-
-// level reminder (humans=1 is the gate).
+// TestGetReminders_HumansPlusAllRoundTrip — a client that wants BOTH
+// the legacy `all=1` pill on old read-side clients AND a human-visible
+// reminder sends `{all:1, humans:1}` inbound. Post-#142 the chokepoint
+// is a pass-through, so the dispatched payload is still `{all:1,
+// humans:1}` (no implicit `ais=1`). Reader must emit exactly ONE
+// channel-level reminder (humans=1 is the gate).
 func TestGetReminders_HumansPlusAllRoundTrip(t *testing.T) {
 	m := newReminderTestMessage(t)
 
@@ -380,7 +387,9 @@ func TestGetReminders_HumansPlusAllRoundTrip(t *testing.T) {
 	mention := rewritten["mention"].(map[string]interface{})
 	assert.Equal(t, json.Number("1"), mention["all"])
 	assert.Equal(t, json.Number("1"), mention["humans"])
-	assert.Equal(t, json.Number("1"), mention["ais"], "Plan X: rewrite always adds ais=1 for all=1")
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAIs,
+		"#142: rewrite no longer infers ais=1 from legacy all=1")
 
 	msg := &config.MessageResp{
 		ChannelID:   "ch_humans_plus_all",

--- a/modules/message/mention_rewrite_test.go
+++ b/modules/message/mention_rewrite_test.go
@@ -17,16 +17,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestMessagePackage_RewriteMention_AllRewrittenToAIsDoubleWrite is
-// the canonical regression guard for the message-package shim under
-// Plan X (YUJ-1389): inbound `mention.all=1` must be rewritten to
-// also carry `mention.ais=1` (so legacy `@所有人` auto-fans-out to
-// all AI bots without an SDK update), while preserving the legacy
-// `all=1` on the outbound payload for old read-side clients. humans
-// MUST NOT be auto-set — humans is the explicit human-notification
-// signal and only the sender may set it. If someone deletes the
-// import or breaks the wiring this test fails.
-func TestMessagePackage_RewriteMention_AllRewrittenToAIsDoubleWrite(t *testing.T) {
+// TestMessagePackage_RewriteMention_AllPassThrough is the regression
+// guard for the message-package shim under
+// Mininglamp-OSS/octo-server#142: the historical Plan X (YUJ-1389)
+// rewrite that turned inbound `mention.all=1` into `all=1 + ais=1` was
+// removed because legacy `@所有人` must not auto-trigger bots. The
+// shim must now pass the inbound mention map through untouched — `all`
+// preserved, NO implicit `ais`, NO implicit `humans`. If someone
+// reintroduces the rewrite or breaks the wiring this test fails.
+func TestMessagePackage_RewriteMention_AllPassThrough(t *testing.T) {
 	payload := map[string]interface{}{
 		"type":    1,
 		"content": "@所有人 ping",
@@ -37,9 +36,10 @@ func TestMessagePackage_RewriteMention_AllRewrittenToAIsDoubleWrite(t *testing.T
 	out := RewriteMention(payload)
 	mention := out["mention"].(map[string]interface{})
 	assert.Equal(t, json.Number("1"), mention["all"],
-		"all=1 outbound double-write must be preserved")
-	assert.Equal(t, json.Number("1"), mention["ais"],
-		"Plan X: all=1 inbound must rewrite to add ais=1 (auto-fan-out to bots)")
+		"all=1 must be preserved (legacy read-side clients render @所有人 from it)")
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAIs,
+		"#142: ais MUST NOT be inferred from legacy all=1 — bots only fire on explicit ais=1")
 	_, hasHumans := mention["humans"]
 	assert.False(t, hasHumans,
 		"humans MUST NOT be auto-set — only the sender may set the human-notification signal")

--- a/modules/robot/ais_broadcast.go
+++ b/modules/robot/ais_broadcast.go
@@ -38,12 +38,16 @@ import (
 // side (reminders) and the dispatch side (robot events) agree on what
 // counts as `@所有 AI`.
 //
-// The send-side rewrite chokepoint (pkg/mentionrewrite/rewrite.go)
-// writes json.Number("1") which gjson surfaces as a Number with
-// Int() == 1, so that's the hot path. We also accept the JSON `true`
+// Post-Mininglamp-OSS/octo-server#142 the send-side chokepoint
+// (pkg/mentionrewrite/rewrite.go) is a pass-through — legacy
+// `mention.all=1` is NOT auto-promoted into `mention.ais=1` anymore,
+// so a client that wants its broadcast to summon group bots must set
+// `mention.ais=1` explicitly. The numeric `1` shape (json.Number from
+// the upstream UseNumber decoder, surfaced by gjson as a Number with
+// Int() == 1) is still the hot path; we also accept the JSON `true`
 // form and the string "1" form defensively — a future client / proxy
-// rewrite might canonicalize the field differently and we don't want
-// a quiet broadcast regression because of it.
+// might canonicalize the field differently and we don't want a quiet
+// broadcast regression because of it.
 //
 // Exposed as a method on *Robot purely so the dispatcher's call site
 // reads `rb.mentionAisTruthy(...)`, matching the surrounding

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -438,17 +438,17 @@ func (rb *Robot) sendMessage(c *wkhttp.Context) {
 		payload = rb.enrichBotPayloadWithSpaceID(robotID, payload)
 	}
 
-	// YUJ-202 / Mininglamp-OSS#94 — mention three-state rewrite. Same
-	// chokepoint contract as the user and bot API ingresses: legacy
-	// `mention.all=1` is normalized (Plan X / YUJ-1389) to also carry
-	// `mention.ais=1`, with `all=1` preserved on the outbound payload
-	// for old read-side clients (double-write). `mention.humans=1` is
-	// NEVER inferred from legacy `all=1` — humans is the explicit human-
-	// notification signal and must be set by the client. ⚠️ F2 (PR#70
-	// Jerry-Xin correctness-critical review): MUST stay OUTSIDE the
-	// `ChannelTypePerson` conditional above so group / community-topic
-	// `@所有人` traffic (the main pain-point) actually goes through the
-	// chokepoint. Helper is idempotent and safe on nil —
+	// YUJ-202 / Mininglamp-OSS#94 / #142 — mention pass-through
+	// chokepoint. Same contract as the user and bot API ingresses:
+	// post-#142 the helper no longer infers `mention.ais=1` from
+	// legacy `mention.all=1` (legacy `@所有人` MUST NOT trigger bots);
+	// it now forwards `mention.all`, `mention.humans`, `mention.ais`,
+	// and `mention.uids` untouched. The call site is preserved so any
+	// future chokepoint normalization lands in one place across the
+	// three ingresses. ⚠️ F2 (PR#70 Jerry-Xin correctness-critical
+	// review): MUST stay OUTSIDE the `ChannelTypePerson` conditional
+	// above so group / community-topic mention payloads always reach
+	// the chokepoint. Helper is idempotent and safe on nil —
 	// see pkg/mentionrewrite.
 	payload = mentionrewrite.RewriteMention(payload)
 

--- a/modules/robot/event.go
+++ b/modules/robot/event.go
@@ -186,17 +186,25 @@ func (rb *Robot) robotMessageListen(messages []*config.MessageResp) {
 						}
 					}
 				}
-				// YUJ-1393 / PR#82 review #2 R2 (Jerry-Xin 2026-05-19
-				// follow-up): mention.ais=1 means "@所有 AI" (Plan X /
-				// YUJ-1389). The robot event dispatcher previously only
-				// considered robot_id / mention.uids / @username text,
-				// so a payload carrying only mention.ais=1 (no uids,
-				// no @username) silently skipped the robot event queue
-				// and group bots never received the "@所有 AI" broadcast
-				// — including the very common legacy `mention.all=1`
-				// case, which the send-side rewrite chokepoints
-				// (pkg/mentionrewrite/rewrite.go) normalize to also
-				// carry `mention.ais=1`.
+				// YUJ-1393 / PR#82 review #2 R2 / #142 follow-up:
+				// mention.ais=1 means "@所有 AI" (Plan X / YUJ-1389).
+				// The robot event dispatcher previously only considered
+				// robot_id / mention.uids / @username text, so a payload
+				// carrying only mention.ais=1 (no uids, no @username)
+				// silently skipped the robot event queue and group bots
+				// never received the "@所有 AI" broadcast.
+				//
+				// Post-#142 (`pkg/mentionrewrite` reverted to pass-
+				// through): legacy `mention.all=1` is NO LONGER
+				// auto-promoted to `mention.ais=1` by the send-side
+				// chokepoint. New clients that want their `@所有 AI`
+				// broadcast to summon group bots MUST set
+				// `mention.ais=1` explicitly. Legacy clients that only
+				// emit `mention.all=1` will not trigger this branch —
+				// that is intentional and matches the OBO fan-out
+				// gate's post-#142 contract (see modules/bot_api/
+				// obo_fanout.go: `mention.all` alone is not a bot
+				// summon).
 				//
 				// Scope: GROUP channels only. PERSONAL DMs are already
 				// dispatched via the realUID branch above and have no

--- a/pkg/mentionrewrite/rewrite.go
+++ b/pkg/mentionrewrite/rewrite.go
@@ -1,8 +1,7 @@
-// Package mentionrewrite owns the inbound rewrite + outbound double-write
-// contract for the `mention.{all,humans,ais}` payload field
-// (YUJ-202 / Mininglamp-OSS/octo-server#94 — 方案 X "dead-field" strategy
-// for `@所有人`, three-state implementation of the PR#70 audit §5
-// recommendation).
+// Package mentionrewrite owns the (now pass-through) inbound contract
+// for the `mention.{all,humans,ais}` payload field
+// (YUJ-202 / Mininglamp-OSS/octo-server#94 — three-state implementation
+// of the PR#70 audit §5 recommendation).
 //
 // Why a separate pkg/
 // ===================
@@ -21,33 +20,31 @@
 // symbol and so the issue spec's "modules/message/mention_rewrite.go is
 // the helper file" expectation is preserved.
 //
-// Inbound rewrite (CALL from message ingress chokepoints)
-// =======================================================
-// Legacy clients still emit `mention.all=1` for `@所有人`. Plan X
-// (YUJ-1389) assigns `all=1` the **ais broadcast** semantics: legacy
-// `@所有人` traffic automatically fans out to all AI bots without
-// requiring an SDK update on the sender side. So inbound
-// `mention.all=1` is rewritten to also carry `mention.ais=1`. A NEW
-// field `mention.humans=1` is the explicit human-notification signal
-// — it is the only way a client can request a channel-level reminder
-// for the human members of a channel. The legacy `mention.all=1` field
-// is INTENTIONALLY preserved on the outbound payload (double-write) so
-// old read-side clients that only understand `all` keep rendering the
-// "@所有人" pill until their roll-out catches up. New read-side clients
-// prefer `humans` / `ais` and IGNORE `all` when either of the new
-// fields is set — see the read-side change in Message.getMention
-// (modules/message/api_reminders.go).
+// Pass-through behavior (Mininglamp-OSS/octo-server#142)
+// ======================================================
+// Earlier (Plan X / YUJ-1389) the helper rewrote inbound `mention.all=1`
+// to also carry `mention.ais=1`, so legacy `@所有人` traffic auto-
+// fanned-out to all AI bots without an SDK update on the sender side.
+// Product intent has since been corrected: legacy `@所有人` MUST NOT
+// trigger bots. The rewrite block has been removed; the helper is now
+// a strict pass-through that leaves the inbound `mention` map untouched
+// (modulo nil / non-map defenses). The function signature, the three
+// ingress call sites, and the ais broadcast fan-out path
+// (modules/robot/event.go, modules/robot/ais_broadcast.go) are
+// intentionally unchanged — only the implicit `all → ais` inference is
+// gone. New clients still set `mention.ais=1` explicitly to broadcast
+// to bots, and `mention.humans=1` explicitly to notify humans.
 //
-// `mention.humans=1` is left untouched. `mention.ais=1` is left
-// untouched. `mention.uids` / `mention.entities` are left untouched.
+// `mention.all`, `mention.humans`, `mention.ais`, `mention.uids`, and
+// `mention.entities` are all left untouched.
 //
-// The helper is idempotent: RewriteMention(RewriteMention(p)) ==
-// RewriteMention(p) for every input. Idempotency lets callers invoke it
-// at every chokepoint without worrying about re-entry from listeners /
-// fan-out / future relay paths.
+// The helper is trivially idempotent: RewriteMention(RewriteMention(p))
+// == RewriteMention(p) for every input. Idempotency lets callers invoke
+// it at every chokepoint without worrying about re-entry from listeners
+// / fan-out / future relay paths.
 //
 // Safe on nil / empty / non-map `mention` payloads (no panic, no
-// mutation beyond the strict double-write).
+// mutation).
 package mentionrewrite
 
 import "encoding/json"
@@ -56,51 +53,45 @@ import "encoding/json"
 // mention state lives. Exposed so callers and tests share one constant.
 const MentionKey = "mention"
 
-// AllKey is the legacy `@所有人` field. Inbound `all=1` is rewritten
-// (Plan X / YUJ-1389) to also carry `ais=1` so legacy clients
-// automatically trigger all AI bots without an SDK update; the `all`
-// field itself is preserved on the dispatched payload (outbound
-// double-write) for backward compat with old read-side clients that
-// only understand `all`.
+// AllKey is the legacy `@所有人` field. Historically (Plan X /
+// YUJ-1389) inbound `all=1` was rewritten to also carry `ais=1` so
+// legacy clients auto-triggered all AI bots; that inference was
+// reverted (Mininglamp-OSS/octo-server#142) because the product intent
+// is that legacy `@所有人` MUST NOT trigger bots. The field itself is
+// still part of the wire contract (old read-side clients render the
+// `@所有人` pill from it) and is passed through untouched by this
+// helper.
 const AllKey = "all"
 
 // HumansKey signals a human-only broadcast (`@所有真人`). New read-side
 // clients render the "@所有人" pill from this field and IGNORE `all`.
-// Plan X: this is the ONLY signal that produces a channel-level
-// human-visible reminder — bots respond via the message delivery path
-// without needing a reminder row.
+// This is the only signal that produces a channel-level human-visible
+// reminder — bots respond via the message delivery path without
+// needing a reminder row.
 const HumansKey = "humans"
 
 // AIsKey signals a bot broadcast (`@所有 AI`). Independent of `humans`
-// — both can be set on the same message (`@所有人 + @所有 AI`). Plan X:
-// inbound legacy `all=1` is rewritten to carry `ais=1` so all bots
-// fan out by default for the legacy `@所有人` shape.
+// — both can be set on the same message (`@所有人 + @所有 AI`). After
+// Mininglamp-OSS/octo-server#142 this MUST be set explicitly by the
+// client; it is no longer inferred from legacy `all=1`.
 const AIsKey = "ais"
 
-// RewriteMention normalizes the payload's `mention` sub-map per the
-// three-state contract. Mutates the inner map in place when the inbound
-// shape calls for a rewrite, and returns the (possibly same) outer map
-// so callers can keep the `payload = RewriteMention(payload)` assign-
-// back pattern used elsewhere in the message dispatch stack (mirrors
-// `enrichPayloadWithSpaceID`).
+// RewriteMention is the (now pass-through) normalizer for the
+// payload's `mention` sub-map. The signature is preserved so all three
+// ingress chokepoints (modules/message/api.go, modules/bot_api/send.go,
+// modules/robot/api.go) can keep the `payload = RewriteMention(payload)`
+// assign-back pattern without code churn — see
+// Mininglamp-OSS/octo-server#142 for why the implicit `all → ais`
+// inference was removed.
 //
-// Behavior (Plan X / YUJ-1389):
+// Behavior:
 //   - payload == nil → returns nil (no allocation).
 //   - payload has no `mention` key, or `mention` is not a
 //     map[string]interface{} → returned untouched.
-//   - mention.all is truthy (==1 in either json.Number, float64, int,
-//     int64, uint64, or bool form) → mention.ais is set to the
-//     canonical json.Number("1"). mention.all is preserved.
-//   - mention.ais is already truthy → no-op on ais (preserves
-//     whatever numeric/bool form the caller sent).
-//   - mention.humans is left untouched in every branch — humans is the
-//     explicit human-notification signal and must NEVER be inferred
-//     from a legacy `all=1`.
-//   - mention.uids / mention.entities / any other key inside mention is
-//     left untouched.
+//   - otherwise the mention map and all its keys (all / humans / ais /
+//     uids / entities / anything else) are returned untouched.
 //
-// Idempotent by construction: a second pass over an already-rewritten
-// payload sees ais truthy and does nothing.
+// Trivially idempotent: a second pass is a no-op.
 func RewriteMention(payload map[string]interface{}) map[string]interface{} {
 	if payload == nil {
 		return nil
@@ -109,36 +100,26 @@ func RewriteMention(payload map[string]interface{}) map[string]interface{} {
 	if !ok || raw == nil {
 		return payload
 	}
-	mention, ok := raw.(map[string]interface{})
-	if !ok {
+	if _, ok := raw.(map[string]interface{}); !ok {
 		// Defensive: malformed mention (string / int / array) — never
 		// the shape a real client sends. Leave untouched so the read
 		// side / validation tests can keep asserting on the original
 		// payload.
 		return payload
 	}
-	if !isTruthyOne(mention[AllKey]) {
-		return payload
-	}
-	// Plan X / YUJ-1389: inbound `all=1` → make sure ais=1 is also
-	// present so legacy `@所有人` automatically fans out to all AI bots
-	// without requiring an SDK update on the sender side. Don't
-	// overwrite an ais value the client already supplied (might be a
-	// new client that explicitly set ais in addition to legacy all for
-	// forward+backward compat).
-	if !isTruthyOne(mention[AIsKey]) {
-		mention[AIsKey] = json.Number("1")
-	}
-	// `all` is INTENTIONALLY preserved — see package godoc on the
-	// outbound double-write rationale.
+	// Mininglamp-OSS/octo-server#142: the historical `all=1 → ais=1`
+	// inference was removed. Pass through untouched.
 	return payload
 }
 
 // isTruthyOne reports whether v is the numeric/boolean form of 1. The
 // `mention.*` fields arrive from `json.Decoder.UseNumber()` so the
 // hot path is json.Number, but client/test code may also send float64,
-// int, int64, uint64, or bool — handle all of them defensively so a
-// caller does not have to pre-normalize before calling RewriteMention.
+// int, int64, uint64, or bool — handle all of them defensively. The
+// helper is no longer used by RewriteMention itself (the `all → ais`
+// rewrite was reverted in Mininglamp-OSS/octo-server#142) but is kept
+// for other call sites that need the same truthy-one semantics over
+// the JSON-decoded numeric grab-bag.
 func isTruthyOne(v interface{}) bool {
 	switch x := v.(type) {
 	case nil:

--- a/pkg/mentionrewrite/rewrite_test.go
+++ b/pkg/mentionrewrite/rewrite_test.go
@@ -1,15 +1,21 @@
-// Unit tests for the pure RewriteMention helper.
+// Unit tests for the (now pass-through) RewriteMention helper.
 //
-// These cover the spec contract from Mininglamp-OSS/octo-server#94 and
-// the issue YUJ-1343 acceptance list, updated for Plan X (YUJ-1389):
-// inbound `mention.all=1` now rewrites to carry `mention.ais=1` (not
-// `humans=1`) so legacy `@所有人` traffic automatically fans out to
-// all AI bots without requiring an SDK update. The companion thin
-// re-export in modules/message/mention_rewrite.go has its own
-// colocated test file that exercises the same shapes through the
-// message-package symbol, so a future refactor moving the helper
-// does not have to update two suites in lockstep — the contract is
-// asserted here and the shim test only verifies the shim is not a stub.
+// Originally these tests pinned a Plan X (YUJ-1389) inbound rewrite:
+// `mention.all=1` was rewritten to also carry `mention.ais=1` so
+// legacy `@所有人` traffic auto-fanned-out to all AI bots without an
+// SDK update. Product intent was corrected in
+// Mininglamp-OSS/octo-server#142 — legacy `@所有人` MUST NOT trigger
+// bots — so the rewrite block was removed and the helper is now a
+// strict pass-through. These tests have been updated to assert the
+// pass-through contract: the inbound mention map is returned untouched
+// (modulo nil / non-map defenses).
+//
+// The companion thin re-export in modules/message/mention_rewrite.go
+// has its own colocated test file that exercises the same shapes
+// through the message-package symbol, so a future refactor moving the
+// helper does not have to update two suites in lockstep — the contract
+// is asserted here and the shim test only verifies the shim is not a
+// stub.
 package mentionrewrite
 
 import (
@@ -20,13 +26,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestRewriteMention_AllOnly — the canonical legacy-client shape. An
-// inbound `mention.all=1` MUST gain a `mention.ais=1` companion (Plan
-// X: legacy @所有人 → fan out to bots automatically) and MUST keep the
-// `all=1` field on the outbound payload (double-write for old
-// read-side clients that only understand `all`). humans MUST NOT be
-// set as a side effect — humans is the explicit human-notification
-// signal and must only be set by the sender.
+// TestRewriteMention_AllOnly — the canonical legacy-client shape. After
+// Mininglamp-OSS/octo-server#142 the inbound `mention.all=1` MUST be
+// passed through untouched: `all=1` is preserved (legacy read-side
+// clients still render `@所有人` from it) and NEITHER `ais` NOR
+// `humans` is auto-set. The product intent is that legacy `@所有人`
+// no longer triggers bots — bots are only triggered by an explicit
+// client-supplied `ais=1`.
 func TestRewriteMention_AllOnly(t *testing.T) {
 	payload := map[string]interface{}{
 		"type":    1,
@@ -40,9 +46,10 @@ func TestRewriteMention_AllOnly(t *testing.T) {
 
 	mention := out["mention"].(map[string]interface{})
 	assert.Equal(t, json.Number("1"), mention["all"],
-		"all=1 must be preserved (outbound double-write for legacy clients)")
-	assert.Equal(t, json.Number("1"), mention["ais"],
-		"Plan X: all=1 inbound must set ais=1 so legacy @所有人 fans out to bots")
+		"all=1 must be preserved (legacy read-side clients render @所有人 from it)")
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAIs,
+		"#142: ais MUST NOT be inferred from legacy all=1 — bots only fire on explicit ais=1")
 	_, hasHumans := mention["humans"]
 	assert.False(t, hasHumans,
 		"humans must NOT be auto-set — humans is the explicit human-notification signal")
@@ -103,8 +110,8 @@ func TestRewriteMention_HumansAndAIs(t *testing.T) {
 }
 
 // TestRewriteMention_AllPlusUIDs — legacy `@所有人 + @alice + @bob`. The
-// uids array MUST be preserved (the rewrite is only about the broadcast
-// flag, not about individual mentions).
+// uids array MUST be preserved verbatim. Post-#142 there is also no
+// implicit ais=1 — the rewrite is a strict pass-through.
 func TestRewriteMention_AllPlusUIDs(t *testing.T) {
 	payload := map[string]interface{}{
 		"mention": map[string]interface{}{
@@ -115,7 +122,8 @@ func TestRewriteMention_AllPlusUIDs(t *testing.T) {
 	out := RewriteMention(payload)
 	mention := out["mention"].(map[string]interface{})
 	assert.Equal(t, json.Number("1"), mention["all"], "all preserved")
-	assert.Equal(t, json.Number("1"), mention["ais"], "Plan X: ais added")
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAIs, "#142: no implicit ais from legacy all=1")
 	assert.Equal(t,
 		[]interface{}{"uid_alice", "uid_bob"},
 		mention["uids"],
@@ -125,7 +133,8 @@ func TestRewriteMention_AllPlusUIDs(t *testing.T) {
 // TestRewriteMention_AllPlusEntities — v2 client shape (mention.entities
 // is the new-format inline-mention metadata, see
 // modules/message/validation_test.go:885+). RewriteMention must NOT
-// drop or mutate the entities array.
+// drop or mutate the entities array. Post-#142 there is also no
+// implicit ais=1.
 func TestRewriteMention_AllPlusEntities(t *testing.T) {
 	entities := []interface{}{
 		map[string]interface{}{"uid": "__all__", "offset": json.Number("0"), "length": json.Number("4")},
@@ -140,7 +149,8 @@ func TestRewriteMention_AllPlusEntities(t *testing.T) {
 	out := RewriteMention(payload)
 	mention := out["mention"].(map[string]interface{})
 	assert.Equal(t, json.Number("1"), mention["all"])
-	assert.Equal(t, json.Number("1"), mention["ais"], "Plan X: ais added")
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAIs, "#142: no implicit ais from legacy all=1")
 	assert.True(t, reflect.DeepEqual(entities, mention["entities"]),
 		"entities array must survive the rewrite untouched")
 }
@@ -220,9 +230,9 @@ func TestRewriteMention_MentionIsNonMap(t *testing.T) {
 }
 
 // TestRewriteMention_AllAsFloat — json.Decoder *without* UseNumber will
-// produce float64. Even though the message pipeline uses UseNumber, the
-// helper accepts the float form defensively so callers that decode with
-// the standard library default don't silently miss the rewrite.
+// produce float64. Post-#142 the helper is a pass-through, so a
+// float-encoded `all=1` survives verbatim and no `ais` field is
+// synthesized.
 func TestRewriteMention_AllAsFloat(t *testing.T) {
 	payload := map[string]interface{}{
 		"mention": map[string]interface{}{
@@ -231,12 +241,15 @@ func TestRewriteMention_AllAsFloat(t *testing.T) {
 	}
 	out := RewriteMention(payload)
 	mention := out["mention"].(map[string]interface{})
-	assert.Equal(t, json.Number("1"), mention["ais"], "float64 all=1 must trigger rewrite to ais=1")
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAIs, "#142: no implicit ais from legacy all=1 (any numeric form)")
 	assert.Equal(t, float64(1), mention["all"], "original all value preserved verbatim")
 }
 
 // TestRewriteMention_AllAsBool — defensive: some Go callers might
-// construct payloads with `all: true`. Treat truthy bool as 1.
+// construct payloads with `all: true`. Post-#142 the helper is a
+// pass-through; the bool form survives verbatim and no `ais` field is
+// synthesized.
 func TestRewriteMention_AllAsBool(t *testing.T) {
 	payload := map[string]interface{}{
 		"mention": map[string]interface{}{
@@ -245,12 +258,13 @@ func TestRewriteMention_AllAsBool(t *testing.T) {
 	}
 	out := RewriteMention(payload)
 	mention := out["mention"].(map[string]interface{})
-	assert.Equal(t, json.Number("1"), mention["ais"])
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAIs, "#142: no implicit ais from legacy all=true")
 	assert.Equal(t, true, mention["all"])
 }
 
 // TestRewriteMention_AllZero — `all=0` is the "no @所有人" sentinel; the
-// rewrite must NOT add an ais field.
+// rewrite is a pass-through and must NOT add ais / humans fields.
 func TestRewriteMention_AllZero(t *testing.T) {
 	payload := map[string]interface{}{
 		"mention": map[string]interface{}{
@@ -266,9 +280,9 @@ func TestRewriteMention_AllZero(t *testing.T) {
 }
 
 // TestRewriteMention_AllAndAIsBothSet — a forward-compat new client
-// might already set BOTH all and ais. The rewrite must NOT clobber
-// the client-supplied ais value (e.g. some future "ais=2" semantic
-// would be silently overwritten by a blind set).
+// might already set BOTH all and ais. Post-#142 the helper is a
+// pass-through, so both keys survive verbatim and humans is not
+// inferred.
 func TestRewriteMention_AllAndAIsBothSet(t *testing.T) {
 	payload := map[string]interface{}{
 		"mention": map[string]interface{}{
@@ -288,8 +302,8 @@ func TestRewriteMention_AllAndAIsBothSet(t *testing.T) {
 
 // TestRewriteMention_AllPlusHumans — a client that explicitly wants to
 // notify humans alongside legacy `@所有人` sets both `all=1` and
-// `humans=1`. The rewrite still adds `ais=1` (Plan X) but must NOT
-// touch the existing humans field.
+// `humans=1`. Post-#142 both keys pass through untouched and no
+// implicit `ais=1` is inserted.
 func TestRewriteMention_AllPlusHumans(t *testing.T) {
 	payload := map[string]interface{}{
 		"mention": map[string]interface{}{
@@ -301,14 +315,15 @@ func TestRewriteMention_AllPlusHumans(t *testing.T) {
 	mention := out["mention"].(map[string]interface{})
 	assert.Equal(t, json.Number("1"), mention["all"], "all preserved")
 	assert.Equal(t, json.Number("1"), mention["humans"], "client-supplied humans untouched")
-	assert.Equal(t, json.Number("1"), mention["ais"], "Plan X: ais added")
+	_, hasAIs := mention["ais"]
+	assert.False(t, hasAIs, "#142: no implicit ais from legacy all=1")
 }
 
 // TestRewriteMention_Idempotent — RewriteMention(RewriteMention(p))
-// must equal RewriteMention(p) for every input shape. Idempotency is
-// the property that lets us drop the helper at three independent
-// chokepoints + any future listener / relay without worrying about
-// repeated rewrites.
+// must equal RewriteMention(p) for every input shape. Trivially true
+// for a pass-through helper, but the property is the contract that
+// lets us drop the helper at three independent chokepoints + any
+// future listener / relay without worrying about repeated rewrites.
 func TestRewriteMention_Idempotent(t *testing.T) {
 	inputs := []map[string]interface{}{
 		nil,


### PR DESCRIPTION
# refactor(mentionrewrite): remove implicit all=1 → ais=1 inference

Fixes Mininglamp-OSS/octo-server#142

## Why

Previously (Plan X / YUJ-1389) the `RewriteMention` chokepoint helper rewrote inbound `mention.all=1` to also carry `mention.ais=1`, so legacy `@所有人` traffic auto-fanned-out to all AI bots without an SDK update on the sender side. Product intent has been corrected: **legacy `@所有人` must NOT trigger bots**. Bots are now only summoned when the sender explicitly sets `mention.ais=1`.

## What changed

Small and surgical:

- **`pkg/mentionrewrite/rewrite.go`** — `RewriteMention` is now a strict pass-through. The nil / non-map defensive guards stay; the `all → ais` inference block is gone. The function signature, the three ingress call sites (`modules/message/api.go`, `modules/bot_api/send.go`, `modules/robot/api.go`), and the ais broadcast fan-out path (`modules/robot/event.go`, `modules/robot/ais_broadcast.go`) are intentionally **unchanged**. Only the implicit inference is removed. `isTruthyOne` helper is retained.
- **`pkg/mentionrewrite/rewrite_test.go`** — every `all=1` test now asserts pass-through: `all` is preserved and `ais` MUST NOT be auto-set.
- **`modules/message/mention_rewrite_test.go`** — shim test updated to pin the pass-through invariant.
- **`modules/message/api_reminders_test.go`** — the two RoundTrip tests that drove inputs through `RewriteMention` and asserted `ais=1` afterwards now assert `ais` is absent. The reader-side reminder fan-out outcomes are **unchanged** (legacy `all=1` alone still produces zero channel-level reminders; `all + humans=1` still produces one).
- **`modules/bot_api/send_test.go`** — handler-integration test renamed from `MentionAllRewritten` to `MentionAllPassThrough` and updated to assert the dispatched payload still carries `mention.all=1` but NOT `mention.ais` and NOT `mention.humans`. The integration stack stays in place so a future wiring regression at the chokepoint still trips the test.

## Out of scope

- `modules/robot/event.go` (ais fan-out path unchanged)
- `modules/robot/ais_broadcast.go` (downstream of the chokepoint, unaffected)
- reminder / push layer
- the three ingress call sites (signature unchanged)

## Verification

```bash
go test ./pkg/mentionrewrite/... -v           # PASS (18 tests)
go test ./modules/message/ -run "TestMessagePackage_RewriteMention|TestGetMention_ThreeStateMatrix|TestGetReminders_FanoutMatrix|TestGetReminders_LegacyAllRoundTrip|TestGetReminders_HumansPlusAll" -v   # PASS
go test ./modules/bot_api/ ./modules/robot/   # PASS
go vet ./...                                  # clean
```

Repo-wide `go test ./...` shows the usual infrastructure-bound failures (Redis / MySQL connection refused in this sandbox); none touch the rewrite path.
