### PR TITLE
fix(mention): expand mention.ais=1 into mention.uids at ingress chokepoint (#144)

### DIFF
--- a/modules/bot_api/mention_expand.go
+++ b/modules/bot_api/mention_expand.go
@@ -1,0 +1,46 @@
+// Module-side composer that wires bot_api.groupService.GetMembers +
+// bot_api.robotService.ExistRobot into the
+// pkg/mentionrewrite.ExpandAisToBotUIDs callback shape.
+//
+// See modules/message/mention_expand.go for the design rationale —
+// the leaf helper stays free of any modules/* dependency to preserve
+// the import-cycle-free invariant called out in
+// pkg/mentionrewrite/rewrite.go. Each ingress chokepoint owns its
+// own thin composer.
+package bot_api
+
+import (
+	"go.uber.org/zap"
+)
+
+// fetchBotMemberUIDs enumerates the bot members of `groupNo` for the
+// ExpandAisToBotUIDs chokepoint. Contract is identical to
+// (*Message).fetchBotMemberUIDs — see that file for the
+// best-effort / per-row error rationale.
+func (ba *BotAPI) fetchBotMemberUIDs(groupNo string) ([]string, error) {
+	members, err := ba.groupService.GetMembers(groupNo)
+	if err != nil {
+		return nil, err
+	}
+	if len(members) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(members))
+	for _, mem := range members {
+		if mem == nil || mem.UID == "" {
+			continue
+		}
+		ok, existErr := ba.robotService.ExistRobot(mem.UID)
+		if existErr != nil {
+			ba.Warn("ExistRobot lookup failed during mention.ais expansion; treating member as non-bot",
+				zap.String("group_no", groupNo),
+				zap.String("uid", mem.UID),
+				zap.Error(existErr))
+			continue
+		}
+		if ok {
+			out = append(out, mem.UID)
+		}
+	}
+	return out, nil
+}

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -199,18 +199,6 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 	// Helper is idempotent and safe on nil — see pkg/mentionrewrite.
 	payload = mentionrewrite.RewriteMention(payload)
 
-	// Mininglamp-OSS/octo-server#144 — second-pass mention chokepoint
-	// (sister call to the user and robot ingresses). When mention.ais=1
-	// in a GROUP channel, expand mention.uids to every bot member of
-	// the channel so legacy adapter bots (#137) on the WuKongIM
-	// websocket recognise the broadcast. PR #138 only rewrites the
-	// /v1/bot/events queue path; this helper covers the websocket
-	// dispatch path. Idempotent + dedups with PR #138 — see
-	// pkg/mentionrewrite/expand_ais.go. channelID uses the
-	// space-resolved value so a multi-Space group still hits the right
-	// member roster.
-	payload = mentionrewrite.ExpandAisToBotUIDs(payload, req.ChannelType, channelID, ba.fetchBotMemberUIDs)
-
 	// YUJ-1166 fan-out loop guard #3: mark this message so the fan-out
 	// listener (see obo_fanout.go) skips it on the way back through the
 	// listener pipeline. Marker key lives in the reserved `__obo_*`
@@ -225,6 +213,30 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 		payload["actual_sender_uid"] = robotID
 	}
 
+	// Mininglamp-OSS/octo-server#144 + PR#145 review follow-up:
+	// second-pass mention chokepoint (sister call to the user and
+	// robot ingresses). When mention.ais=1 in a GROUP channel, expand
+	// mention.uids to every bot member of the channel so legacy
+	// adapter bots (#137) on the WuKongIM websocket recognise the
+	// broadcast. PR #138 only rewrites the /v1/bot/events queue path;
+	// this helper covers the websocket dispatch path. channelID uses
+	// the space-resolved value so a multi-Space group still hits the
+	// right member roster.
+	//
+	// ⚠️ PR#145 review (Jerry-Xin / lml2468 / yujiawei 2026-05-23):
+	// the expansion MUST run on a clone of `payload`, not on `payload`
+	// itself. ExpandAisToBotUIDs mutates the inner `mention` sub-map
+	// in place, and the in-memory `payload` flows into the persisted
+	// MessageResp + the listener pipeline (obo_fanout, reminder
+	// writer at modules/message/api_reminders.go) — mutating it here
+	// would create one human-visible `[有人@我]` reminder per
+	// server-expanded bot member of the group. The clone is used ONLY
+	// for the wire bytes; `payload` retains the original
+	// caller-supplied `mention.uids`. See pkg/mentionrewrite/clone.go
+	// for the clone contract.
+	wirePayload := mentionrewrite.CloneForExpansion(payload)
+	wirePayload = mentionrewrite.ExpandAisToBotUIDs(wirePayload, req.ChannelType, channelID, ba.fetchBotMemberUIDs)
+
 	msgReq := &config.MsgSendReq{
 		Header: config.MsgHeader{
 			RedDot: 1,
@@ -233,7 +245,7 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 		ChannelID:   channelID,
 		ChannelType: req.ChannelType,
 		FromUID:     fromUID,
-		Payload:     []byte(util.ToJson(payload)),
+		Payload:     []byte(util.ToJson(wirePayload)),
 	}
 	result, err := ba.dispatchMsgSendReq(msgReq)
 	if err != nil {

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -199,6 +199,18 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 	// Helper is idempotent and safe on nil — see pkg/mentionrewrite.
 	payload = mentionrewrite.RewriteMention(payload)
 
+	// Mininglamp-OSS/octo-server#144 — second-pass mention chokepoint
+	// (sister call to the user and robot ingresses). When mention.ais=1
+	// in a GROUP channel, expand mention.uids to every bot member of
+	// the channel so legacy adapter bots (#137) on the WuKongIM
+	// websocket recognise the broadcast. PR #138 only rewrites the
+	// /v1/bot/events queue path; this helper covers the websocket
+	// dispatch path. Idempotent + dedups with PR #138 — see
+	// pkg/mentionrewrite/expand_ais.go. channelID uses the
+	// space-resolved value so a multi-Space group still hits the right
+	// member roster.
+	payload = mentionrewrite.ExpandAisToBotUIDs(payload, req.ChannelType, channelID, ba.fetchBotMemberUIDs)
+
 	// YUJ-1166 fan-out loop guard #3: mark this message so the fan-out
 	// listener (see obo_fanout.go) skips it on the way back through the
 	// listener pipeline. Marker key lives in the reserved `__obo_*`

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -475,16 +475,6 @@ func (m *Message) sendMessage(channelID string, channelType uint8, fromUID strin
 	// nil / malformed mention shapes — see pkg/mentionrewrite/rewrite.go
 	// for the contract.
 	payload = RewriteMention(payload)
-	// Mininglamp-OSS/octo-server#144 — second-pass mention chokepoint.
-	// When mention.ais=1 in a GROUP channel, expand mention.uids to
-	// include every bot member of the channel so legacy adapter bots
-	// (octo-server#137) that only inspect mention.uids over the
-	// WuKongIM websocket still recognise the `@所有 AI` broadcast.
-	// PR #138's per-bot UID injection only reaches the bot event
-	// queue (/v1/bot/events); the WuKongIM dispatch path needs this
-	// helper. Helper is idempotent + dedups with PR #138 — see
-	// pkg/mentionrewrite/expand_ais.go for the full contract.
-	payload = mentionrewrite.ExpandAisToBotUIDs(payload, channelType, channelID, m.fetchBotMemberUIDs)
 	// YUJ-219-A / GH#1283 (analysis-report.md §4.5 / §7.4)：
 	// 派发前为消息 payload 注入权威 space_id，让客户端 SpaceFilter 拿到可信字段，
 	// race 窗口的 fail-open 语义可降级为 fail-closed。
@@ -492,6 +482,29 @@ func (m *Message) sendMessage(channelID string, channelType uint8, fromUID strin
 	// 直接覆盖客户端 payload.space_id，跨 Space 推送时收端 SpaceFilter 拿到权威值
 	// 立刻丢弃，不再依赖 channelInfo 缓存命中。
 	payload = m.enrichPayloadWithSpaceID(channelID, channelType, payload, senderSpaceID)
+	// Mininglamp-OSS/octo-server#144 + PR#145 review follow-up:
+	// second-pass mention chokepoint. When mention.ais=1 in a GROUP
+	// channel, expand mention.uids to include every bot member of the
+	// channel so legacy adapter bots (octo-server#137) that only
+	// inspect mention.uids over the WuKongIM websocket still recognise
+	// the `@所有 AI` broadcast. PR #138's per-bot UID injection only
+	// reaches the bot event queue (/v1/bot/events); this helper covers
+	// the WuKongIM dispatch path.
+	//
+	// ⚠️ PR#145 review (Jerry-Xin / lml2468 / yujiawei 2026-05-23):
+	// the expansion MUST run on a clone of `payload`, not on `payload`
+	// itself. ExpandAisToBotUIDs mutates the inner `mention` sub-map
+	// in place, and the in-memory `payload` is shared with the
+	// reminder writer (modules/message/api_reminders.go iterates
+	// `mention.uids` to emit one ReminderTypeMentionMe row per UID) —
+	// so mutating `payload` here would create one human-visible
+	// `[有人@我]` red-dot per server-expanded bot member. The clone is
+	// used ONLY for the wire bytes; `payload` retains the original
+	// caller-supplied `mention.uids`. See
+	// pkg/mentionrewrite/clone.go for the clone contract and
+	// pkg/mentionrewrite/expand_ais.go for the expansion contract.
+	wirePayload := mentionrewrite.CloneForExpansion(payload)
+	wirePayload = mentionrewrite.ExpandAisToBotUIDs(wirePayload, channelType, channelID, m.fetchBotMemberUIDs)
 	err := m.ctx.SendMessage(&config.MsgSendReq{
 		Header: config.MsgHeader{
 			RedDot: 1,
@@ -499,7 +512,7 @@ func (m *Message) sendMessage(channelID string, channelType uint8, fromUID strin
 		ChannelID:   channelID,
 		ChannelType: channelType,
 		FromUID:     fromUID,
-		Payload:     []byte(util.ToJson(payload)),
+		Payload:     []byte(util.ToJson(wirePayload)),
 	})
 	if err != nil {
 		m.Error("发送消息错误", zap.Error(err))

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/robot"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"github.com/gocraft/dbr/v2"
@@ -474,6 +475,16 @@ func (m *Message) sendMessage(channelID string, channelType uint8, fromUID strin
 	// nil / malformed mention shapes — see pkg/mentionrewrite/rewrite.go
 	// for the contract.
 	payload = RewriteMention(payload)
+	// Mininglamp-OSS/octo-server#144 — second-pass mention chokepoint.
+	// When mention.ais=1 in a GROUP channel, expand mention.uids to
+	// include every bot member of the channel so legacy adapter bots
+	// (octo-server#137) that only inspect mention.uids over the
+	// WuKongIM websocket still recognise the `@所有 AI` broadcast.
+	// PR #138's per-bot UID injection only reaches the bot event
+	// queue (/v1/bot/events); the WuKongIM dispatch path needs this
+	// helper. Helper is idempotent + dedups with PR #138 — see
+	// pkg/mentionrewrite/expand_ais.go for the full contract.
+	payload = mentionrewrite.ExpandAisToBotUIDs(payload, channelType, channelID, m.fetchBotMemberUIDs)
 	// YUJ-219-A / GH#1283 (analysis-report.md §4.5 / §7.4)：
 	// 派发前为消息 payload 注入权威 space_id，让客户端 SpaceFilter 拿到可信字段，
 	// race 窗口的 fail-open 语义可降级为 fail-closed。

--- a/modules/message/api_reminders.go
+++ b/modules/message/api_reminders.go
@@ -170,6 +170,43 @@ func (m *Message) nextReminderSeq() (int64, error) {
 	return m.ctx.GenSeq(common.RemindersKey)
 }
 
+// isBotUID reports whether `uid` belongs to a bot in the robot
+// registry. Used by getReminders to filter out bot UIDs from the
+// per-uid reminder fan-out (PR#145 R3 / YUJ-1810): the persisted
+// payload that the WuKongIM listener replays already contains the
+// server-expanded `mention.ais` → `mention.uids` bot UIDs, and bots
+// must never receive a `[有人@我]` reminder row regardless of how
+// the UID landed in the mention list (server-expanded `ais=1` or
+// explicit user-typed `@bot_x`).
+//
+// Best-effort semantics:
+//
+//   - robotService unwired (unit tests that build &Message{} without
+//     ctor) → returns false; no filter is applied. Existing
+//     getReminders fan-out matrix tests (TestGetReminders_FanoutMatrix)
+//     supply human-only UIDs and don't wire robotService, so they keep
+//     working unchanged.
+//   - ExistRobot returns an error (transient robot-row corruption,
+//     DB blip) → log warn and treat the UID as not-a-bot. We err on
+//     the side of EMITTING the reminder for a human rather than
+//     SILENTLY DROPPING a reminder. The alternative (drop on error)
+//     would lose legitimate human notifications whenever the robot
+//     table hiccups, which is a worse failure mode than the
+//     temporary noise this guards against.
+func (m *Message) isBotUID(uid string) bool {
+	if m.robotService == nil {
+		return false
+	}
+	ok, err := m.robotService.ExistRobot(uid)
+	if err != nil {
+		m.Warn("ExistRobot lookup failed during reminder emission; treating UID as not-a-bot",
+			zap.String("uid", uid),
+			zap.Error(err))
+		return false
+	}
+	return ok
+}
+
 func (m *Message) getReminders(messages []*config.MessageResp) []*remindersModel {
 	reminders := make([]*remindersModel, 0, len(messages))
 	for _, message := range messages {
@@ -222,6 +259,31 @@ func (m *Message) getReminders(messages []*config.MessageResp) []*remindersModel
 			}
 			if len(uids) > 0 {
 				for _, uid := range uids {
+					// PR#145 R3 blocker (YUJ-1810): the persisted payload
+					// that lands here on the WuKongIM listener callback
+					// already contains the server-side
+					// ExpandAisToBotUIDs expansion (the wire bytes carry
+					// the expanded UIDs even though CloneForExpansion
+					// keeps the send-side in-memory map clean — the
+					// reminder writer runs on the persisted-payload path,
+					// not the in-memory one). Without filtering here,
+					// every `@所有 AI` broadcast writes one
+					// `[有人@我]` reminder row per bot member of the
+					// group, which (a) pollutes the reminders table and
+					// (b) violates the `ais=1` contract that bots
+					// respond via the delivery path and MUST NOT trigger
+					// human-visible red-dots.
+					//
+					// The filter also covers user-typed explicit
+					// `@bot_x` mentions — bots never need reminder rows
+					// regardless of how their UID landed in
+					// `mention.uids`. Skipping a bot here is the
+					// single source of truth for "no reminders for
+					// bots", complementing CloneForExpansion (which
+					// only protects the send-side map).
+					if m.isBotUID(uid) {
+						continue
+					}
 					version, err := m.nextReminderSeq()
 					if err != nil {
 						m.Warn("GenSeq failed", zap.Error(err))

--- a/modules/message/api_reminders_test.go
+++ b/modules/message/api_reminders_test.go
@@ -525,41 +525,44 @@ func TestReminderSync_SenderExcludedFromBroadcast(t *testing.T) {
 }
 
 // TestGetReminders_AisExpansionDoesNotPolluteReminderRows is the
-// PR#145 review-blocker regression. The chokepoint at
-// (*Message).sendMessage is supposed to expand `mention.ais=1`
-// into `mention.uids` on a CLONE of the payload (the wire-only
-// representation) so the in-memory `payload` map — which feeds the
-// persisted MessageResp and downstream consumers like the reminder
-// writer below — keeps the original caller-supplied
-// `mention.uids` untouched.
+// PR#145 review-blocker regression (R3, YUJ-1810).
 //
-// Bug we are guarding against
-// ===========================
-// Before this fix the chokepoint mutated `payload` in place. The
-// reminder writer at modules/message/api_reminders.go:223-243
-// iterates `mention.uids` and emits one ReminderTypeMentionMe row
-// per UID — so every `ais=1` broadcast created one human-visible
-// `[有人@我]` red-dot per bot member of the group. DB pollution AND
-// a contract violation (`ais=1` is supposed to mean "bots respond
-// via the delivery path; do NOT create human-visible reminders").
+// Production flow we are pinning
+// ==============================
+//  1. sendMessage builds the in-memory `payload`.
+//  2. wirePayload = CloneForExpansion(payload) →
+//     ExpandAisToBotUIDs(wirePayload) stamps bot UIDs into
+//     wirePayload["mention"]["uids"].
+//  3. MsgSendReq.Payload = util.ToJson(wirePayload) — WuKongIM
+//     persists the EXPANDED bytes.
+//  4. WuKongIM webhooks back → listenerMessages → getReminders, which
+//     decodes the persisted (expanded) bytes via
+//     config.MessageResp.GetPayloadMap.
+//
+// So `getReminders` sees `mention.uids = [u_alice, bot_a, bot_b]` —
+// NOT the original `[u_alice]`. CloneForExpansion alone is
+// insufficient: it only protects the send-side in-memory map; the
+// listener path doesn't touch that map at all.
+//
+// Required guard
+// ==============
+// getReminders must call robotService.ExistRobot for each UID and
+// skip bots — that's the single source of truth for "no reminder
+// rows for bots", and it covers both server-expanded ais UIDs AND
+// user-typed explicit @bot_x mentions (bots never need a red-dot).
 //
 // What this test pins
 // ===================
-// We replicate the chokepoint composition (CloneForExpansion →
-// ExpandAisToBotUIDs) and then assert two things:
+//  1. Wire bytes carry the expansion (legacy-adapter compat —
+//     same assertion as before).
+//  2. When the PERSISTED (= expanded) bytes are fed to getReminders
+//     with a robotService that knows {bot_a, bot_b} are bots, the
+//     emitted reminder set contains exactly ONE row for `u_alice`.
+//     Zero rows for `bot_a`, zero for `bot_b`, zero channel-level
+//     (no `humans=1`).
 //
-//  1. The wire-only payload bytes (what WuKongIM dispatches and
-//     legacy adapter bots inspect) DO carry the expanded bot UIDs.
-//
-//  2. The original in-memory `payload` map, when fed into
-//     getReminders the way the persistence + listener pipeline
-//     does, produces reminder rows ONLY for the explicit human
-//     UIDs that the caller supplied — NEVER for the expanded bot
-//     UIDs.
-//
-// If a future refactor reverts the chokepoint to mutate `payload`
-// directly, this test fails on the second assertion (bot UIDs
-// would leak into the reminder set).
+// If a future refactor removes the ExistRobot filter, this test
+// fails on bot_a / bot_b leaking into the reminder set.
 func TestGetReminders_AisExpansionDoesNotPolluteReminderRows(t *testing.T) {
 	const channelID = "ch_team"
 
@@ -595,12 +598,20 @@ func TestGetReminders_AisExpansionDoesNotPolluteReminderRows(t *testing.T) {
 		wireUIDs,
 		"wire payload must include expanded bot UIDs for legacy adapter compat")
 
-	// Assertion #2: the in-memory payload is unmutated. We feed it
-	// into getReminders the way the persistence + listener pipeline
-	// does (config.MessageResp.GetPayloadMap decodes the persisted
-	// bytes with UseNumber — see payloadJSON above for the same
-	// re-decode pattern).
+	// Assertion #2: feed the EXPANDED wire payload bytes into
+	// getReminders (this is exactly what the listener path sees —
+	// WuKongIM persists the expanded bytes and webhooks them back via
+	// config.MessageResp.GetPayloadMap). The robotService recognizes
+	// bot_a / bot_b as bots, so getReminders' new ExistRobot guard
+	// must filter them out and emit ONLY the row for u_alice.
 	m := newReminderTestMessage(t)
+	m.robotService = &fakeExpandRobotService{
+		exist: map[string]bool{
+			"bot_a":   true,
+			"bot_b":   true,
+			"u_alice": false,
+		},
+	}
 	msg := &config.MessageResp{
 		ChannelID:   channelID,
 		ChannelType: common.ChannelTypeGroup.Uint8(),
@@ -608,7 +619,7 @@ func TestGetReminders_AisExpansionDoesNotPolluteReminderRows(t *testing.T) {
 		MessageID:   2024,
 		MessageSeq:  42,
 		ClientMsgNo: "cmn_pr145",
-		Payload:     payloadJSON(t, original),
+		Payload:     payloadJSON(t, wire),
 	}
 	got := m.getReminders([]*config.MessageResp{msg})
 

--- a/modules/message/api_reminders_test.go
+++ b/modules/message/api_reminders_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -521,4 +522,105 @@ func TestReminderSync_SenderExcludedFromBroadcast(t *testing.T) {
 	// And a third party sees both.
 	got = filterChannelLevelByPublisher(rows, "u_bystander")
 	assert.Len(t, got, 2)
+}
+
+// TestGetReminders_AisExpansionDoesNotPolluteReminderRows is the
+// PR#145 review-blocker regression. The chokepoint at
+// (*Message).sendMessage is supposed to expand `mention.ais=1`
+// into `mention.uids` on a CLONE of the payload (the wire-only
+// representation) so the in-memory `payload` map — which feeds the
+// persisted MessageResp and downstream consumers like the reminder
+// writer below — keeps the original caller-supplied
+// `mention.uids` untouched.
+//
+// Bug we are guarding against
+// ===========================
+// Before this fix the chokepoint mutated `payload` in place. The
+// reminder writer at modules/message/api_reminders.go:223-243
+// iterates `mention.uids` and emits one ReminderTypeMentionMe row
+// per UID — so every `ais=1` broadcast created one human-visible
+// `[有人@我]` red-dot per bot member of the group. DB pollution AND
+// a contract violation (`ais=1` is supposed to mean "bots respond
+// via the delivery path; do NOT create human-visible reminders").
+//
+// What this test pins
+// ===================
+// We replicate the chokepoint composition (CloneForExpansion →
+// ExpandAisToBotUIDs) and then assert two things:
+//
+//  1. The wire-only payload bytes (what WuKongIM dispatches and
+//     legacy adapter bots inspect) DO carry the expanded bot UIDs.
+//
+//  2. The original in-memory `payload` map, when fed into
+//     getReminders the way the persistence + listener pipeline
+//     does, produces reminder rows ONLY for the explicit human
+//     UIDs that the caller supplied — NEVER for the expanded bot
+//     UIDs.
+//
+// If a future refactor reverts the chokepoint to mutate `payload`
+// directly, this test fails on the second assertion (bot UIDs
+// would leak into the reminder set).
+func TestGetReminders_AisExpansionDoesNotPolluteReminderRows(t *testing.T) {
+	const channelID = "ch_team"
+
+	// Caller-supplied payload: `@所有 AI + @alice` in a GROUP channel.
+	// The explicit human mention (`u_alice`) MUST still get a per-user
+	// reminder row; the broadcast (`ais=1`) MUST NOT — bots will
+	// respond via the delivery path.
+	original := map[string]interface{}{
+		"type":    1,
+		"content": "@所有 AI plus @alice",
+		"mention": map[string]interface{}{
+			"ais":  json.Number("1"),
+			"uids": []interface{}{"u_alice"},
+		},
+	}
+
+	// Simulate the chokepoint at sendMessage(): clone, expand on the
+	// clone, serialize the clone for the wire. Same shape as the
+	// production code at modules/message/api.go.
+	wire := mentionrewrite.CloneForExpansion(original)
+	wire = mentionrewrite.ExpandAisToBotUIDs(wire, common.ChannelTypeGroup.Uint8(), channelID,
+		func(string) ([]string, error) {
+			return []string{"bot_a", "bot_b"}, nil
+		})
+
+	// Assertion #1: wire bytes carry the expansion so legacy adapter
+	// bots that only inspect `mention.uids` on the WuKongIM payload
+	// still see the `@所有 AI` broadcast.
+	wireMention := wire["mention"].(map[string]interface{})
+	wireUIDs, _ := wireMention["uids"].([]interface{})
+	assert.ElementsMatch(t,
+		[]interface{}{"u_alice", "bot_a", "bot_b"},
+		wireUIDs,
+		"wire payload must include expanded bot UIDs for legacy adapter compat")
+
+	// Assertion #2: the in-memory payload is unmutated. We feed it
+	// into getReminders the way the persistence + listener pipeline
+	// does (config.MessageResp.GetPayloadMap decodes the persisted
+	// bytes with UseNumber — see payloadJSON above for the same
+	// re-decode pattern).
+	m := newReminderTestMessage(t)
+	msg := &config.MessageResp{
+		ChannelID:   channelID,
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		FromUID:     "u_sender",
+		MessageID:   2024,
+		MessageSeq:  42,
+		ClientMsgNo: "cmn_pr145",
+		Payload:     payloadJSON(t, original),
+	}
+	got := m.getReminders([]*config.MessageResp{msg})
+
+	// Exactly one reminder, for the human `u_alice`. Zero reminders
+	// for `bot_a` / `bot_b` / the channel-level broadcast (no
+	// `humans=1`, so no `[有人@我]` red-dot either).
+	assert.Len(t, got, 1, "exactly one reminder row, for the explicit human mention")
+	assert.Equal(t, "u_alice", got[0].UID,
+		"reminder must be for the explicit human UID, NOT a server-expanded bot UID")
+	for _, r := range got {
+		assert.NotEqual(t, "bot_a", r.UID, "bot_a must not receive a reminder row")
+		assert.NotEqual(t, "bot_b", r.UID, "bot_b must not receive a reminder row")
+		assert.NotEqual(t, "", r.UID, "no channel-level [有人@我] red-dot for ais-only broadcast")
+	}
 }

--- a/modules/message/mention_expand.go
+++ b/modules/message/mention_expand.go
@@ -1,0 +1,61 @@
+// Module-side composer that wires (*Message).groupService.GetMembers
+// + (*Message).robotService.ExistRobot into the
+// pkg/mentionrewrite.ExpandAisToBotUIDs callback shape.
+//
+// Mininglamp-OSS/octo-server#144: the leaf helper in
+// pkg/mentionrewrite stays free of any modules/* dependency to
+// preserve the leaf invariant called out in
+// pkg/mentionrewrite/rewrite.go (the historical
+// `robot → message → robot` import cycle). Each ingress chokepoint
+// owns its own thin composer instead. This is the message-ingress
+// version; modules/bot_api/mention_expand.go and the equivalent
+// inline helper in modules/robot/api.go are its peers.
+package message
+
+import (
+	"go.uber.org/zap"
+)
+
+// fetchBotMemberUIDs enumerates the bot members of `groupNo` for the
+// ExpandAisToBotUIDs chokepoint. Returns an empty slice (no error)
+// when the lookup succeeds but the group has no bot members, so the
+// helper can no-op cleanly. A non-nil error degrades the expansion
+// to a no-op upstream (see pkg/mentionrewrite/expand_ais.go clause 5)
+// — we MUST NOT drop the inbound message just because the bot-set
+// lookup failed.
+//
+// Implementation note: a single failed ExistRobot lookup for one
+// member is treated as "this member is not a bot" (best effort)
+// rather than aborting the whole expansion. Aborting on a transient
+// per-row error would silently disable broadcast expansion for an
+// entire group whenever one robot row is corrupt — the legacy
+// adapter would then miss the @所有 AI, which is the exact bug
+// Mininglamp-OSS/octo-server#144 is fixing. Logging at warn keeps
+// the failure observable without spamming on the happy path.
+func (m *Message) fetchBotMemberUIDs(groupNo string) ([]string, error) {
+	members, err := m.groupService.GetMembers(groupNo)
+	if err != nil {
+		return nil, err
+	}
+	if len(members) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(members))
+	for _, mem := range members {
+		if mem == nil || mem.UID == "" {
+			continue
+		}
+		ok, existErr := m.robotService.ExistRobot(mem.UID)
+		if existErr != nil {
+			m.Warn("ExistRobot lookup failed during mention.ais expansion; treating member as non-bot",
+				zap.String("group_no", groupNo),
+				zap.String("uid", mem.UID),
+				zap.Error(existErr))
+			continue
+		}
+		if ok {
+			out = append(out, mem.UID)
+		}
+	}
+	return out, nil
+}

--- a/modules/message/mention_expand_test.go
+++ b/modules/message/mention_expand_test.go
@@ -1,0 +1,142 @@
+// Composer-level unit test for (*Message).fetchBotMemberUIDs — the
+// modules/message-side wrapper that wires group.GetMembers +
+// robot.ExistRobot into the pkg/mentionrewrite.ExpandAisToBotUIDs
+// callback shape.
+//
+// Why this test exists
+// ====================
+// Mininglamp-OSS/octo-server#144 PR#145 review (yujiawei 2026-05-23):
+// the composer's per-row best-effort policy — "if ExistRobot fails
+// for one member, treat that member as not-a-bot and KEEP scanning"
+// — was previously only asserted in prose comments. This test pins
+// it as code. The alternative (abort the whole expansion on a
+// single corrupt robot row) would silently disable `@所有 AI`
+// expansion for an entire group whenever ONE robot DB row was
+// transiently bad — the exact regression #144 set out to prevent.
+package message
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/robot"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeExpandRobotService is a robot.IService stub that drives the
+// per-row ExistRobot result from a UID-keyed table. UIDs absent from
+// the table return (false, nil). UIDs whose value is a non-nil
+// errResult return that error verbatim.
+type fakeExpandRobotService struct {
+	robot.IService
+
+	exist map[string]bool
+	errs  map[string]error
+}
+
+func (f *fakeExpandRobotService) ExistRobot(uid string) (bool, error) {
+	if err, ok := f.errs[uid]; ok && err != nil {
+		return false, err
+	}
+	return f.exist[uid], nil
+}
+
+// fakeExpandGroupService returns a static member roster for any
+// groupNo. Only GetMembers is exercised by fetchBotMemberUIDs.
+type fakeExpandGroupService struct {
+	group.IService
+	members []*group.MemberResp
+	err     error
+}
+
+func (f *fakeExpandGroupService) GetMembers(groupNo string) ([]*group.MemberResp, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.members, nil
+}
+
+func newExpandTestMessage(robotSvc robot.IService, groupSvc group.IService) *Message {
+	return &Message{
+		Log:          log.NewTLog("expand-test"),
+		robotService: robotSvc,
+		groupService: groupSvc,
+	}
+}
+
+// TestFetchBotMemberUIDs_PerRowExistRobotFailureDegrades is the
+// per-row best-effort policy clause. The roster has three members:
+// bot_a (ExistRobot → true), bot_b (ExistRobot → transient error),
+// bot_c (ExistRobot → true). bot_b MUST be skipped (treated as
+// not-a-bot) and the scan MUST continue, so the returned bot UID
+// set is {bot_a, bot_c}. The whole expansion MUST NOT abort, and
+// fetchBotMemberUIDs MUST NOT return an error (the composer's
+// contract is "no error" so ExpandAisToBotUIDs treats the result
+// as authoritative — see pkg/mentionrewrite/expand_ais.go clause 5).
+func TestFetchBotMemberUIDs_PerRowExistRobotFailureDegrades(t *testing.T) {
+	gs := &fakeExpandGroupService{
+		members: []*group.MemberResp{
+			{UID: "bot_a"},
+			{UID: "bot_b"},
+			{UID: "bot_c"},
+			{UID: "u_human"},
+		},
+	}
+	rs := &fakeExpandRobotService{
+		exist: map[string]bool{
+			"bot_a":   true,
+			"bot_c":   true,
+			"u_human": false,
+		},
+		errs: map[string]error{
+			"bot_b": errors.New("transient robot row corrupt"),
+		},
+	}
+	m := newExpandTestMessage(rs, gs)
+
+	got, err := m.fetchBotMemberUIDs("group_1")
+	assert.NoError(t, err, "per-row ExistRobot failure must NOT propagate as a composer error")
+	assert.ElementsMatch(t, []string{"bot_a", "bot_c"}, got,
+		"the failing row (bot_b) must be skipped and the scan must continue past it")
+}
+
+// TestFetchBotMemberUIDs_GroupGetMembersErrorPropagates is the sister
+// clause: a GetMembers error IS propagated (ExpandAisToBotUIDs then
+// short-circuits to a no-op per clause 5). This is the
+// "lookup failed entirely" path, distinct from the per-row failure
+// above.
+func TestFetchBotMemberUIDs_GroupGetMembersErrorPropagates(t *testing.T) {
+	gs := &fakeExpandGroupService{err: errors.New("group db down")}
+	rs := &fakeExpandRobotService{}
+	m := newExpandTestMessage(rs, gs)
+
+	got, err := m.fetchBotMemberUIDs("group_1")
+	assert.Error(t, err, "a group-level lookup failure must propagate so ExpandAisToBotUIDs can no-op")
+	assert.Nil(t, got)
+}
+
+// TestFetchBotMemberUIDs_NilAndEmptyMembersSafe pins the
+// "no panic on nil/empty roster" clause. fetchBotMemberUIDs is
+// invoked inside an HTTP handler critical path — a panic on an
+// empty group would 500 the send.
+func TestFetchBotMemberUIDs_NilAndEmptyMembersSafe(t *testing.T) {
+	rs := &fakeExpandRobotService{}
+	for _, tc := range []struct {
+		name    string
+		members []*group.MemberResp
+	}{
+		{"nil roster", nil},
+		{"empty roster", []*group.MemberResp{}},
+		{"nil member in roster", []*group.MemberResp{nil, {UID: ""}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gs := &fakeExpandGroupService{members: tc.members}
+			m := newExpandTestMessage(rs, gs)
+			got, err := m.fetchBotMemberUIDs("group_1")
+			assert.NoError(t, err)
+			assert.Empty(t, got)
+		})
+	}
+}

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -63,6 +63,18 @@ type IService interface {
 	// synthetic events transparently. Returns an error only when the
 	// Redis ZADD / GenSeq call fails.
 	EnqueueBotEvent(robotID string, message *config.MessageResp) error
+	// ExistRobot reports whether `uid` identifies an active robot
+	// (robot.status=1). Mininglamp-OSS/octo-server#144: the ingress
+	// chokepoint that expands `mention.ais=1` into `mention.uids` uses
+	// this to filter the channel's group-member list down to the bot
+	// subset, so legacy adapter bots that only inspect `mention.uids`
+	// still receive the `@所有 AI` broadcast over the WuKongIM payload.
+	//
+	// Returns false (no error) for unknown / disabled robots — callers
+	// can treat any non-nil error as a "lookup failed" and skip the
+	// expansion best-effort (an unexpanded broadcast is no worse than
+	// the pre-#144 state).
+	ExistRobot(uid string) (bool, error)
 }
 
 // Service robot 模块对外暴露的只读服务实现，供其它模块注入使用。
@@ -130,6 +142,27 @@ func (s *Service) EnqueueBotEvent(robotID string, message *config.MessageResp) e
 // the cross-module synthetic path.
 func (rb *Robot) EnqueueBotEvent(robotID string, message *config.MessageResp) error {
 	return enqueueBotEventGeneric(rb.ctx, robotID, message)
+}
+
+// ExistRobot — IService — Service variant. Delegates to the same
+// robotDB.exist helper used by /v1/manager/robots etc., scoped to
+// `status=1` (active robots only). See the IService docstring for the
+// Mininglamp-OSS/octo-server#144 rationale.
+func (s *Service) ExistRobot(uid string) (bool, error) {
+	if strings.TrimSpace(uid) == "" {
+		return false, nil
+	}
+	return s.db.exist(uid)
+}
+
+// ExistRobot — IService — *Robot variant. Delegates to the embedded
+// robotDB.exist so existing *Robot instances satisfy the wider
+// IService surface introduced for Mininglamp-OSS/octo-server#144.
+func (rb *Robot) ExistRobot(uid string) (bool, error) {
+	if strings.TrimSpace(uid) == "" {
+		return false, nil
+	}
+	return rb.db.exist(uid)
 }
 
 // enqueueBotEventGeneric is the shared write-to-bot-event-queue helper
@@ -451,6 +484,17 @@ func (rb *Robot) sendMessage(c *wkhttp.Context) {
 	// the chokepoint. Helper is idempotent and safe on nil —
 	// see pkg/mentionrewrite.
 	payload = mentionrewrite.RewriteMention(payload)
+
+	// Mininglamp-OSS/octo-server#144 — second-pass mention chokepoint
+	// (sister call to the user and bot ingresses). When mention.ais=1
+	// in a GROUP channel, expand mention.uids to include every bot
+	// member of the channel so legacy adapter bots (#137) on the
+	// WuKongIM websocket recognise the `@所有 AI` broadcast. PR #138
+	// only rewrites the /v1/bot/events queue path; this helper covers
+	// the websocket dispatch path. Idempotent and dedups with PR
+	// #138's injectBotUIDIntoMentionUIDs — see
+	// pkg/mentionrewrite/expand_ais.go for the full contract.
+	payload = mentionrewrite.ExpandAisToBotUIDs(payload, messageReq.ChannelType, messageReq.ChannelID, rb.fetchBotMemberUIDs)
 
 	result, err := rb.ctx.SendMessageWithResult(&config.MsgSendReq{
 		StreamNo:    messageReq.StreamNo,

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -485,23 +485,36 @@ func (rb *Robot) sendMessage(c *wkhttp.Context) {
 	// see pkg/mentionrewrite.
 	payload = mentionrewrite.RewriteMention(payload)
 
-	// Mininglamp-OSS/octo-server#144 — second-pass mention chokepoint
-	// (sister call to the user and bot ingresses). When mention.ais=1
-	// in a GROUP channel, expand mention.uids to include every bot
-	// member of the channel so legacy adapter bots (#137) on the
-	// WuKongIM websocket recognise the `@所有 AI` broadcast. PR #138
-	// only rewrites the /v1/bot/events queue path; this helper covers
-	// the websocket dispatch path. Idempotent and dedups with PR
-	// #138's injectBotUIDIntoMentionUIDs — see
-	// pkg/mentionrewrite/expand_ais.go for the full contract.
-	payload = mentionrewrite.ExpandAisToBotUIDs(payload, messageReq.ChannelType, messageReq.ChannelID, rb.fetchBotMemberUIDs)
+	// Mininglamp-OSS/octo-server#144 + PR#145 review follow-up:
+	// second-pass mention chokepoint (sister call to the user and bot
+	// ingresses). When mention.ais=1 in a GROUP channel, expand
+	// mention.uids to include every bot member of the channel so
+	// legacy adapter bots (#137) on the WuKongIM websocket recognise
+	// the `@所有 AI` broadcast. PR #138 only rewrites the
+	// /v1/bot/events queue path; this helper covers the websocket
+	// dispatch path.
+	//
+	// ⚠️ PR#145 review (Jerry-Xin / lml2468 / yujiawei 2026-05-23):
+	// the expansion MUST run on a clone of `payload`, not on `payload`
+	// itself. ExpandAisToBotUIDs mutates the inner `mention` sub-map
+	// in place, and the in-memory `payload` is shared with the
+	// persisted message_extra row + the reminder writer at
+	// modules/message/api_reminders.go (which iterates `mention.uids`
+	// to emit one ReminderTypeMentionMe row per UID) — mutating it
+	// here would create one human-visible `[有人@我]` reminder per
+	// server-expanded bot member. The clone is used ONLY for the wire
+	// bytes; `payload` retains the original caller-supplied
+	// `mention.uids`. See pkg/mentionrewrite/clone.go for the clone
+	// contract.
+	wirePayload := mentionrewrite.CloneForExpansion(payload)
+	wirePayload = mentionrewrite.ExpandAisToBotUIDs(wirePayload, messageReq.ChannelType, messageReq.ChannelID, rb.fetchBotMemberUIDs)
 
 	result, err := rb.ctx.SendMessageWithResult(&config.MsgSendReq{
 		StreamNo:    messageReq.StreamNo,
 		ChannelID:   messageReq.ChannelID,
 		ChannelType: messageReq.ChannelType,
 		FromUID:     robotID,
-		Payload:     []byte(util.ToJson(payload)),
+		Payload:     []byte(util.ToJson(wirePayload)),
 	})
 	if err != nil {
 		rb.Error("发送robot消息失败！", zap.Error(err))

--- a/modules/robot/mention_expand.go
+++ b/modules/robot/mention_expand.go
@@ -1,0 +1,49 @@
+// Module-side composer that wires (*Robot).groupService.GetMembers +
+// (*Robot).db.exist into the pkg/mentionrewrite.ExpandAisToBotUIDs
+// callback shape.
+//
+// Mininglamp-OSS/octo-server#144: see modules/message/mention_expand.go
+// for the design rationale (leaf-package invariant + per-row best-
+// effort error handling). The robot ingress uses rb.db.exist directly
+// rather than going back through rb.IService.ExistRobot to keep the
+// dependency tree obvious — *Robot already owns the robotDB, and the
+// IService surface is for cross-module callers.
+package robot
+
+import (
+	"go.uber.org/zap"
+)
+
+// fetchBotMemberUIDs enumerates the bot members of `groupNo` for the
+// ExpandAisToBotUIDs chokepoint. See
+// (*Message).fetchBotMemberUIDs / (*BotAPI).fetchBotMemberUIDs for
+// the shared contract; this version exists to give modules/robot a
+// hook free of any cross-module robot.IService indirection (which
+// would just delegate to db.exist anyway).
+func (rb *Robot) fetchBotMemberUIDs(groupNo string) ([]string, error) {
+	members, err := rb.groupService.GetMembers(groupNo)
+	if err != nil {
+		return nil, err
+	}
+	if len(members) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(members))
+	for _, mem := range members {
+		if mem == nil || mem.UID == "" {
+			continue
+		}
+		ok, existErr := rb.db.exist(mem.UID)
+		if existErr != nil {
+			rb.Warn("ExistRobot lookup failed during mention.ais expansion; treating member as non-bot",
+				zap.String("group_no", groupNo),
+				zap.String("uid", mem.UID),
+				zap.Error(existErr))
+			continue
+		}
+		if ok {
+			out = append(out, mem.UID)
+		}
+	}
+	return out, nil
+}

--- a/pkg/mentionrewrite/clone.go
+++ b/pkg/mentionrewrite/clone.go
@@ -1,0 +1,115 @@
+// Helper for Mininglamp-OSS/octo-server PR#145 follow-up
+// (Jerry-Xin / lml2468 / yujiawei review): isolate the in-memory
+// `payload` map from the wire-bytes representation so
+// ExpandAisToBotUIDs can stamp expanded bot UIDs onto the bytes
+// dispatched to WuKongIM WITHOUT polluting the in-memory payload
+// the caller may still reference for persistence, listener fan-out,
+// or downstream reminders.
+//
+// The bug this guards against
+// ===========================
+// Before this fix, every ingress chokepoint called
+// ExpandAisToBotUIDs(payload, …) directly on the per-request
+// `payload map[string]interface{}` and then serialized that same
+// map for `MsgSendReq.Payload`. The expansion mutates the inner
+// `mention` sub-map in place, so any subsequent code path that
+// inspects the same `payload` (the reminder writer at
+// modules/message/api_reminders.go iterates `mention.uids` to emit
+// one ReminderTypeMentionMe row per UID) would see the
+// server-injected bot UIDs and write a reminder per bot member.
+// That's a contract violation — `ais=1` is supposed to mean "bots
+// fan out via the delivery path; do NOT create human-visible
+// `[有人@我]` red-dots" — and a flat-out DB pollution: one bot row
+// per group member per broadcast.
+//
+// The fix is "Option B" from the PR#145 review: keep the helper
+// itself unchanged, but call it on a clone of the payload that
+// only feeds the wire bytes. This file owns that clone.
+//
+// Why a hand-rolled clone instead of json round-trip
+// ==================================================
+// (a) json.Marshal/json.Unmarshal would lose `json.Number` typing
+//     (UseNumber is decoder-side, not present on a fresh decode of
+//     re-marshalled bytes by default), and the rest of the
+//     mentionrewrite contract is built around the `json.Number`
+//     truthy gate (see isTruthyOne / RewriteMention). Round-tripping
+//     would break that invariant.
+// (b) ExpandAisToBotUIDs only ever mutates the `mention` sub-map's
+//     `uids` key — it never touches sibling keys, never replaces
+//     the outer map, never recurses. So we only need to clone what
+//     might be mutated: the outer payload map (so a future helper
+//     replacing payload[MentionKey] cannot leak), the `mention`
+//     sub-map (so the in-place `mention[UIDsKey] = …` write doesn't
+//     reach the original), and the `mention.uids` slice (defensive,
+//     so an `existing = append(existing, …)` that doesn't grow the
+//     backing array still cannot perturb the original slice header).
+//     Everything else is shared by reference, which is fine because
+//     ExpandAisToBotUIDs cannot reach it.
+package mentionrewrite
+
+// CloneForExpansion returns a wire-only copy of `payload` suitable
+// for passing to ExpandAisToBotUIDs. The original `payload` and
+// every key it transitively shares with the returned map remain
+// untouched after the helper mutates the copy.
+//
+// Cloning is intentionally minimal — only the keys ExpandAisToBotUIDs
+// can reach are duplicated:
+//
+//   - the outer `map[string]interface{}` (so a future helper that
+//     replaces payload[MentionKey] cannot leak through the alias);
+//   - the `mention` sub-map (so the in-place
+//     `mention[UIDsKey] = newSlice` write in ExpandAisToBotUIDs
+//     stays inside the wire copy);
+//   - the `mention.uids` slice when present and well-formed (so an
+//     append that fits the backing array's existing capacity still
+//     cannot perturb the original slice's view of the data).
+//
+// All sibling keys (e.g. `type`, `content`, `space_id`,
+// `__obo_processed`) are shared by reference — they are read-only
+// from this package's perspective, and the caller is the only one
+// that may mutate them via paths outside this helper.
+//
+// Contract:
+//
+//   - nil → nil (matches ExpandAisToBotUIDs' nil-payload behavior).
+//   - payload with no `mention` key → shallow clone of the outer
+//     map; sibling values shared by reference.
+//   - payload[MentionKey] not a map → shallow clone of the outer
+//     map; the malformed value is forwarded by reference (the
+//     caller's defensive contract still applies).
+//   - mention[UIDsKey] not a slice → shallow clone of the mention
+//     sub-map; the malformed value is forwarded by reference.
+//
+// CloneForExpansion is safe to call repeatedly and is idempotent
+// in the sense that cloning a clone produces an equivalent
+// (separately-allocated) copy.
+func CloneForExpansion(payload map[string]interface{}) map[string]interface{} {
+	if payload == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(payload))
+	for k, v := range payload {
+		out[k] = v
+	}
+	raw, ok := out[MentionKey]
+	if !ok || raw == nil {
+		return out
+	}
+	mention, ok := raw.(map[string]interface{})
+	if !ok {
+		return out
+	}
+	mentionCopy := make(map[string]interface{}, len(mention))
+	for k, v := range mention {
+		mentionCopy[k] = v
+	}
+	if rawUIDs, hasUIDs := mentionCopy[UIDsKey]; hasUIDs && rawUIDs != nil {
+		if arr, isArr := rawUIDs.([]interface{}); isArr {
+			cp := make([]interface{}, len(arr))
+			copy(cp, arr)
+			mentionCopy[UIDsKey] = cp
+		}
+	}
+	out[MentionKey] = mentionCopy
+	return out
+}

--- a/pkg/mentionrewrite/clone_test.go
+++ b/pkg/mentionrewrite/clone_test.go
@@ -1,0 +1,171 @@
+// Unit tests for CloneForExpansion — the wire-only payload clone
+// introduced for the PR#145 follow-up (do not mutate the in-memory
+// payload during the ExpandAisToBotUIDs chokepoint).
+//
+// Each test pins one clause from the helper's contract. The
+// end-to-end "expansion runs on the clone, the original payload is
+// unmutated" assertion is in TestExpand_DoesNotMutateOriginal — the
+// regression the PR#145 review flagged.
+package mentionrewrite
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCloneForExpansion_NilPayload — nil-in, nil-out (matches
+// ExpandAisToBotUIDs' nil-payload behavior so the two helpers
+// compose cleanly).
+func TestCloneForExpansion_NilPayload(t *testing.T) {
+	assert.Nil(t, CloneForExpansion(nil))
+}
+
+// TestCloneForExpansion_NoMention — shallow clone of the outer map
+// when no `mention` key is present. Sibling values are shared by
+// reference (correct: ExpandAisToBotUIDs cannot reach them).
+func TestCloneForExpansion_NoMention(t *testing.T) {
+	src := map[string]interface{}{"type": 1, "content": "hi"}
+	out := CloneForExpansion(src)
+
+	assert.NotSame(t, &src, &out, "must return a different outer map")
+	assert.Equal(t, src, out, "values must match")
+
+	// Mutating the clone's outer map must NOT affect the source.
+	out["type"] = 99
+	assert.Equal(t, 1, src["type"], "outer-map mutation must not leak")
+}
+
+// TestCloneForExpansion_MentionMapIsolated — the critical clause.
+// Mutating `mention.uids` on the clone (the exact write
+// ExpandAisToBotUIDs performs) must NOT alter the source payload.
+func TestCloneForExpansion_MentionMapIsolated(t *testing.T) {
+	src := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"ais":  json.Number("1"),
+			"uids": []interface{}{"u_alice"},
+		},
+	}
+	out := CloneForExpansion(src)
+
+	// Replicate the ExpandAisToBotUIDs mutation against the clone.
+	outMention := out["mention"].(map[string]interface{})
+	outMention["uids"] = []interface{}{"u_alice", "bot_a", "bot_b"}
+
+	srcMention := src["mention"].(map[string]interface{})
+	srcUIDs, _ := srcMention["uids"].([]interface{})
+	assert.Equal(t, []interface{}{"u_alice"}, srcUIDs,
+		"source mention.uids must be untouched after clone mutation")
+	// And the truthy `ais` flag is still preserved on both sides.
+	assert.Equal(t, json.Number("1"), srcMention["ais"])
+	assert.Equal(t, json.Number("1"), outMention["ais"])
+}
+
+// TestCloneForExpansion_UIDsSliceIsolated — append on the clone's
+// uids slice must NOT perturb the source's view, even if the source
+// slice's backing array still had capacity to grow.
+func TestCloneForExpansion_UIDsSliceIsolated(t *testing.T) {
+	// Allocate the source uids slice with extra capacity so a naive
+	// (non-cloning) append on the clone would write through the
+	// shared backing array.
+	uids := make([]interface{}, 1, 8)
+	uids[0] = "u_alice"
+	src := map[string]interface{}{
+		"mention": map[string]interface{}{"uids": uids},
+	}
+	out := CloneForExpansion(src)
+	outMention := out["mention"].(map[string]interface{})
+	cloneUIDs := outMention["uids"].([]interface{})
+	cloneUIDs = append(cloneUIDs, "bot_a")
+	outMention["uids"] = cloneUIDs
+
+	srcMention := src["mention"].(map[string]interface{})
+	srcUIDs := srcMention["uids"].([]interface{})
+	assert.Equal(t, 1, len(srcUIDs), "source uids slice length must not grow")
+	assert.Equal(t, "u_alice", srcUIDs[0], "source uids[0] must be unchanged")
+}
+
+// TestCloneForExpansion_MalformedMentionForwardedByReference — the
+// non-map `mention` value is intentionally passed through by
+// reference. The helper's job is to make ExpandAisToBotUIDs safe;
+// the defensive non-map shape gate inside ExpandAisToBotUIDs handles
+// the rest.
+func TestCloneForExpansion_MalformedMentionForwardedByReference(t *testing.T) {
+	src := map[string]interface{}{"mention": "not-a-map"}
+	out := CloneForExpansion(src)
+	assert.Equal(t, "not-a-map", out["mention"])
+	// Outer map is still a fresh allocation.
+	out["other"] = true
+	_, hasOther := src["other"]
+	assert.False(t, hasOther)
+}
+
+// TestCloneForExpansion_MalformedUIDsForwardedByReference — same
+// reasoning as the mention-shape case; mention sub-map IS cloned,
+// but the malformed inner uids value (string here) is forwarded.
+func TestCloneForExpansion_MalformedUIDsForwardedByReference(t *testing.T) {
+	src := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"ais":  json.Number("1"),
+			"uids": "not-an-array",
+		},
+	}
+	out := CloneForExpansion(src)
+	outMention := out["mention"].(map[string]interface{})
+	assert.Equal(t, "not-an-array", outMention["uids"])
+	// Mutating the clone's mention map sibling key must not leak.
+	outMention["new"] = "x"
+	srcMention := src["mention"].(map[string]interface{})
+	_, hasNew := srcMention["new"]
+	assert.False(t, hasNew, "clone's mention sub-map must be a fresh allocation")
+}
+
+// TestExpand_DoesNotMutateOriginal is the regression the PR#145
+// review surfaced: the chokepoint must keep the in-memory payload's
+// `mention.uids` free of server-expanded bot UIDs so the reminder
+// writer (modules/message/api_reminders.go) does NOT create one
+// reminder row per bot member of the group. Explicit
+// human-mentioned UIDs (`@alice`) MUST still flow into the
+// in-memory payload.
+//
+// This test composes CloneForExpansion with ExpandAisToBotUIDs the
+// way the three ingress chokepoints will compose them, and asserts
+// the original payload is bit-for-bit identical to its input.
+func TestExpand_DoesNotMutateOriginal(t *testing.T) {
+	original := map[string]interface{}{
+		"type":    1,
+		"content": "@所有 AI plus @alice",
+		"mention": map[string]interface{}{
+			"ais":  json.Number("1"),
+			"uids": []interface{}{"u_alice"},
+		},
+	}
+
+	// Build the wire copy the exact way the ingress chokepoint will:
+	// clone, then expand.
+	wire := CloneForExpansion(original)
+	wire = ExpandAisToBotUIDs(wire, channelTypeGroup, "ch_1", func(string) ([]string, error) {
+		return []string{"bot_a", "bot_b"}, nil
+	})
+
+	// Wire payload carries the expansion.
+	wireMention := wire["mention"].(map[string]interface{})
+	wireUIDs, _ := wireMention["uids"].([]interface{})
+	assert.ElementsMatch(t,
+		[]interface{}{"u_alice", "bot_a", "bot_b"},
+		wireUIDs,
+		"wire bytes must include expanded bot UIDs for legacy adapter compat")
+
+	// Original payload is unchanged: only the explicit human UID
+	// remains in mention.uids. Reminder writer reading this map
+	// will create exactly one row for `u_alice` and ZERO rows for
+	// the expanded bot UIDs.
+	origMention := original["mention"].(map[string]interface{})
+	origUIDs, _ := origMention["uids"].([]interface{})
+	assert.Equal(t,
+		[]interface{}{"u_alice"},
+		origUIDs,
+		"in-memory payload's mention.uids must NOT be polluted by server-expanded bot UIDs")
+	assert.Equal(t, json.Number("1"), origMention["ais"], "ais flag must be preserved on original")
+}

--- a/pkg/mentionrewrite/expand_ais.go
+++ b/pkg/mentionrewrite/expand_ais.go
@@ -1,0 +1,189 @@
+// Helper for Mininglamp-OSS/octo-server#144: expand `mention.ais=1`
+// (the `@所有 AI` broadcast signal) into an explicit `mention.uids`
+// list of every bot member of a GROUP channel, at the same three
+// inbound chokepoints as RewriteMention.
+//
+// Why this lives next to RewriteMention
+// =====================================
+// RewriteMention (rewrite.go) is the existing inbound contract for the
+// `mention` sub-map and is invoked at exactly the three message
+// ingresses we need to extend (modules/message/api.go,
+// modules/bot_api/send.go, modules/robot/api.go). Putting the new
+// helper in the same package keeps the chokepoint-normalization
+// surface in one file tree and means any future change to
+// `mention.uids` semantics has a single home.
+//
+// pkg/mentionrewrite must remain a leaf package
+// =============================================
+// rewrite.go's package docstring spells out the historical
+// `robot → message → robot` import cycle that motivated putting the
+// inbound helper here in the first place. The new expansion needs
+//
+//   - group.IService.GetMembers(channelID) — list group members
+//   - robot.IService.ExistRobot(uid)       — filter to bot members
+//
+// but importing either modules/group or modules/robot from pkg would
+// re-introduce the cycle (modules/robot already imports modules/group,
+// and modules/message imports modules/robot). So this helper accepts
+// a pure-function callback `fetchBotUIDs(channelID) ([]string, error)`
+// instead. Each call site composes the callback from the services it
+// already holds. Keeping the helper free of module imports also lets
+// the unit tests below pin every behavioral clause without the gocraft
+// /dbr session and Redis machinery a real robot.IService would drag in.
+package mentionrewrite
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/common"
+)
+
+// UIDsKey is the per-user mention list inside the `mention` sub-map.
+// Exposed alongside MentionKey / AllKey / HumansKey / AIsKey so the
+// constant set used by the chokepoint helpers is visible at a glance.
+const UIDsKey = "uids"
+
+// ExpandAisToBotUIDs is the second-pass mention chokepoint helper.
+// When the inbound payload signals an AI broadcast (`mention.ais=1`)
+// in a GROUP channel, it appends every bot UID returned by
+// `fetchBotUIDs` to `mention.uids` (deduplicated). This makes the
+// WuKongIM-delivered payload itself carry the bot UIDs, so legacy
+// adapter bots (Mininglamp-OSS/octo-server#137) that connect via the
+// websocket and only inspect `mention.uids` still recognise the
+// broadcast — PR #138's per-bot UID injection only reaches the bot
+// event queue (/v1/bot/events) and never the websocket dispatch path.
+//
+// The helper intentionally mirrors RewriteMention's defensive posture:
+// it is safe on nil / empty / malformed `mention` shapes and never
+// drops the message. An error or empty result from `fetchBotUIDs`
+// degrades to a no-op (passing the original payload through), which is
+// no worse than the pre-#144 state.
+//
+// Contract (each clause is locked by a unit test in expand_ais_test.go):
+//
+//  1. No-op unless `mention.ais` is truthy AND channelType == GROUP.
+//     PERSONAL DMs (ChannelTypePerson) and COMMUNITY_TOPIC are out of
+//     scope per the issue body — bots in DMs have a different
+//     dispatch path, and community-topic bots are out of v0.
+//  2. ONLY `mention.uids` is touched. `mention.all`, `mention.humans`,
+//     and `mention.ais` are forwarded untouched. The issue body
+//     constraint "Do NOT modify mention.all, mention.humans, or
+//     mention.ais — only mention.uids" is intentional: those fields
+//     drive other read-side behaviors (legacy `@所有人` rendering,
+//     human-broadcast reminders, downstream audits) and any
+//     server-side rewrite of them would mask the original client
+//     intent.
+//  3. Idempotent: a UID already present in `mention.uids` is not
+//     duplicated, and a second call is a no-op. This dedups in two
+//     directions:
+//       - within a single call (the same bot returned twice by
+//         fetchBotUIDs, or already explicitly @-mentioned by the
+//         user);
+//       - across the broadcast pipeline — PR #138's
+//         injectBotUIDIntoMentionUIDs (modules/robot/ais_broadcast.go)
+//         also appends per-bot UIDs on the fan-out path; if a payload
+//         passes through both helpers no UID will be duplicated.
+//  4. Safe on nil payload (returns nil), missing `mention` key
+//     (returns payload), non-map `mention` value (returns payload),
+//     non-array `mention.uids` value (returns payload). Same
+//     defensive shape as RewriteMention.
+//  5. fetchBotUIDs error → original payload returned untouched. We
+//     log nothing here (the call site already runs inside an HTTP
+//     handler with its own logger); a failed lookup degrades to the
+//     pre-#144 behaviour.
+//  6. Empty channelID → no-op. The caller's request validation
+//     already rejects empty channel_id, but defending here keeps the
+//     helper safe to drop into future ingresses.
+//
+// fetchBotUIDs is expected to enumerate the active robot member UIDs
+// of channelID (i.e. group.IService.GetMembers(channelID) filtered by
+// robot.IService.ExistRobot). The shape is a callback rather than two
+// service interfaces so this package stays a leaf — see the package
+// docstring for the import-cycle background.
+func ExpandAisToBotUIDs(
+	payload map[string]interface{},
+	channelType uint8,
+	channelID string,
+	fetchBotUIDs func(channelID string) ([]string, error),
+) map[string]interface{} {
+	// Clause 4: safe on nil payload (matches RewriteMention).
+	if payload == nil {
+		return nil
+	}
+	// Clause 1: GROUP-only — PERSONAL / COMMUNITY_TOPIC are out of
+	// scope per the issue body.
+	if channelType != common.ChannelTypeGroup.Uint8() {
+		return payload
+	}
+	// Clause 6: defensive on empty channelID.
+	if channelID == "" {
+		return payload
+	}
+	// Clause 4: missing mention / non-map mention → no-op.
+	raw, ok := payload[MentionKey]
+	if !ok || raw == nil {
+		return payload
+	}
+	mention, ok := raw.(map[string]interface{})
+	if !ok {
+		return payload
+	}
+	// Clause 1: ais must be truthy. isTruthyOne handles json.Number,
+	// float64, int*, uint*, bool — the same JSON-decoded grab-bag
+	// RewriteMention defends against.
+	if !isTruthyOne(mention[AIsKey]) {
+		return payload
+	}
+	// Clause 5: nil callback or lookup error → no-op (best effort).
+	if fetchBotUIDs == nil {
+		return payload
+	}
+	botUIDs, err := fetchBotUIDs(channelID)
+	if err != nil || len(botUIDs) == 0 {
+		return payload
+	}
+
+	// Clause 4: only mutate when uids is absent or already a
+	// []interface{}. Any other shape (string, map, number) means a
+	// malformed inbound payload and we forward untouched — same
+	// defensive contract injectBotUIDIntoMentionUIDs follows on the
+	// outbound side.
+	var existing []interface{}
+	if rawUIDs, hasUIDs := mention[UIDsKey]; hasUIDs && rawUIDs != nil {
+		arr, isArr := rawUIDs.([]interface{})
+		if !isArr {
+			return payload
+		}
+		existing = arr
+	}
+
+	// Build a string-set for clause 3 dedup. Pre-allocate to the
+	// maximum possible final size so the common all-new case avoids
+	// any rehash.
+	seen := make(map[string]struct{}, len(existing)+len(botUIDs))
+	for _, v := range existing {
+		if s, ok := v.(string); ok && s != "" {
+			seen[s] = struct{}{}
+		}
+	}
+
+	appended := false
+	for _, uid := range botUIDs {
+		if uid == "" {
+			continue
+		}
+		if _, dup := seen[uid]; dup {
+			continue
+		}
+		seen[uid] = struct{}{}
+		existing = append(existing, uid)
+		appended = true
+	}
+	if !appended {
+		// Clause 3: every bot UID was already in mention.uids — return
+		// the payload untouched so a second call is observably a
+		// no-op and downstream consumers that hash on payload bytes
+		// are not perturbed.
+		return payload
+	}
+	mention[UIDsKey] = existing
+	return payload
+}

--- a/pkg/mentionrewrite/expand_ais.go
+++ b/pkg/mentionrewrite/expand_ais.go
@@ -132,20 +132,19 @@ func ExpandAisToBotUIDs(
 	if !isTruthyOne(mention[AIsKey]) {
 		return payload
 	}
-	// Clause 5: nil callback or lookup error → no-op (best effort).
-	if fetchBotUIDs == nil {
-		return payload
-	}
-	botUIDs, err := fetchBotUIDs(channelID)
-	if err != nil || len(botUIDs) == 0 {
-		return payload
-	}
-
 	// Clause 4: only mutate when uids is absent or already a
 	// []interface{}. Any other shape (string, map, number) means a
 	// malformed inbound payload and we forward untouched — same
 	// defensive contract injectBotUIDIntoMentionUIDs follows on the
 	// outbound side.
+	//
+	// P2 (PR#145 review, yujiawei 2026-05-23): this shape gate runs
+	// BEFORE the fetchBotUIDs callback so a malformed `mention.uids`
+	// value cannot trigger an unnecessary DB roundtrip
+	// (group.GetMembers + per-member robot.ExistRobot). The previous
+	// ordering called fetchBotUIDs first and then discarded the
+	// result on a non-array uids — wasted IO on a payload we know we
+	// will not mutate.
 	var existing []interface{}
 	if rawUIDs, hasUIDs := mention[UIDsKey]; hasUIDs && rawUIDs != nil {
 		arr, isArr := rawUIDs.([]interface{})
@@ -153,6 +152,14 @@ func ExpandAisToBotUIDs(
 			return payload
 		}
 		existing = arr
+	}
+	// Clause 5: nil callback or lookup error → no-op (best effort).
+	if fetchBotUIDs == nil {
+		return payload
+	}
+	botUIDs, err := fetchBotUIDs(channelID)
+	if err != nil || len(botUIDs) == 0 {
+		return payload
 	}
 
 	// Build a string-set for clause 3 dedup. Pre-allocate to the

--- a/pkg/mentionrewrite/expand_ais_test.go
+++ b/pkg/mentionrewrite/expand_ais_test.go
@@ -1,0 +1,415 @@
+// Unit tests for ExpandAisToBotUIDs — the second-pass mention
+// chokepoint helper introduced for Mininglamp-OSS/octo-server#144.
+// Each test pins one clause from the function's contract docstring.
+package mentionrewrite
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/stretchr/testify/assert"
+)
+
+// channelTypeGroup mirrors common.ChannelTypeGroup.Uint8() but as a
+// local literal so the table-driven tests below don't have to wrap
+// every expected value in a type-conversion. Spot-checked once here
+// against the live constant so a future renumbering of common.ChannelType
+// fails fast.
+const channelTypeGroup = uint8(2)
+
+func init() {
+	if got := common.ChannelTypeGroup.Uint8(); got != channelTypeGroup {
+		panic("expand_ais_test: common.ChannelTypeGroup.Uint8() drifted from the value the tests pin (2). Update channelTypeGroup or audit which ChannelType this helper actually targets.")
+	}
+}
+
+// successFetcher returns a deterministic bot UID slice and records
+// whether it was invoked. Use this when a test wants to assert the
+// expansion path ran (or did NOT run) without simulating a DB failure.
+type successFetcher struct {
+	uids   []string
+	called int
+}
+
+func (f *successFetcher) fetch(channelID string) ([]string, error) {
+	f.called++
+	return f.uids, nil
+}
+
+// TestExpandAis_GroupChannelExpands — the happy path. mention.ais=1
+// in a GROUP channel must produce mention.uids = bots, untouched
+// other fields, and exactly one fetchBotUIDs call.
+func TestExpandAis_GroupChannelExpands(t *testing.T) {
+	payload := map[string]interface{}{
+		"type":    1,
+		"content": "@所有 AI hi",
+		"mention": map[string]interface{}{
+			"ais": json.Number("1"),
+		},
+	}
+	f := &successFetcher{uids: []string{"bot_a", "bot_b"}}
+
+	out := ExpandAisToBotUIDs(payload, channelTypeGroup, "group_1", f.fetch)
+
+	assert.Equal(t, 1, f.called, "fetchBotUIDs must be invoked exactly once for an ais=1 GROUP payload")
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["ais"], "ais must be preserved untouched (clause 2)")
+	uids, _ := mention["uids"].([]interface{})
+	assert.ElementsMatch(t, []interface{}{"bot_a", "bot_b"}, uids,
+		"mention.uids must contain every bot UID returned by fetchBotUIDs")
+}
+
+// TestExpandAis_PersonalChannelNoop — channelType != GROUP must skip
+// the expansion entirely (no DB call, no mention.uids mutation).
+// This is the explicit out-of-scope constraint from the issue body.
+func TestExpandAis_PersonalChannelNoop(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"ais": json.Number("1"),
+		},
+	}
+	f := &successFetcher{uids: []string{"bot_a"}}
+
+	out := ExpandAisToBotUIDs(payload, common.ChannelTypePerson.Uint8(), "user_1", f.fetch)
+
+	assert.Equal(t, 0, f.called, "fetchBotUIDs MUST NOT be invoked for PERSONAL channels")
+	mention := out["mention"].(map[string]interface{})
+	_, hasUIDs := mention["uids"]
+	assert.False(t, hasUIDs, "mention.uids must not be created in PERSONAL channels")
+}
+
+// TestExpandAis_CommunityTopicNoop — COMMUNITY_TOPIC (or any
+// non-GROUP channel type) is explicitly out of scope per the issue
+// body's "GROUP channels only" constraint. Locked to keep a future
+// channel-type expansion from accidentally enabling it.
+func TestExpandAis_CommunityTopicNoop(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"ais": json.Number("1"),
+		},
+	}
+	f := &successFetcher{uids: []string{"bot_a"}}
+
+	// communityTopic = whatever is currently used for community topics;
+	// in this codebase it sits at ChannelTypeCommunity or beyond — using
+	// a clearly-not-GROUP value (255) is enough to lock the contract
+	// without coupling to a specific community-topic numeric value.
+	out := ExpandAisToBotUIDs(payload, uint8(255), "topic_1", f.fetch)
+
+	assert.Equal(t, 0, f.called, "fetchBotUIDs MUST NOT be invoked for non-GROUP channels")
+	mention := out["mention"].(map[string]interface{})
+	_, hasUIDs := mention["uids"]
+	assert.False(t, hasUIDs)
+}
+
+// TestExpandAis_AllOnlyNoop — legacy `@所有人` (mention.all=1) without
+// an explicit mention.ais MUST NOT trigger bot expansion. This is the
+// product-intent restated in Mininglamp-OSS/octo-server#142: legacy
+// `@所有人` no longer triggers bots. The pass-through RewriteMention
+// already preserves this, and ExpandAis must not undo it.
+func TestExpandAis_AllOnlyNoop(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"all": json.Number("1"),
+		},
+	}
+	f := &successFetcher{uids: []string{"bot_a"}}
+
+	out := ExpandAisToBotUIDs(payload, channelTypeGroup, "group_1", f.fetch)
+
+	assert.Equal(t, 0, f.called, "fetchBotUIDs MUST NOT be invoked when ais is not truthy (all=1 alone)")
+	mention := out["mention"].(map[string]interface{})
+	_, hasUIDs := mention["uids"]
+	assert.False(t, hasUIDs)
+	assert.Equal(t, json.Number("1"), mention["all"], "all=1 must be preserved")
+}
+
+// TestExpandAis_HumansOnlyNoop — `mention.humans=1` without ais is a
+// human-broadcast-only signal and must not trigger bot expansion.
+// Same clause 1 lock as the all-only case but exercising the humans
+// path to make sure the truthy-one check on `ais` is the only gate.
+func TestExpandAis_HumansOnlyNoop(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"humans": json.Number("1"),
+		},
+	}
+	f := &successFetcher{uids: []string{"bot_a"}}
+
+	out := ExpandAisToBotUIDs(payload, channelTypeGroup, "group_1", f.fetch)
+
+	assert.Equal(t, 0, f.called)
+	mention := out["mention"].(map[string]interface{})
+	_, hasUIDs := mention["uids"]
+	assert.False(t, hasUIDs)
+}
+
+// TestExpandAis_Dedup — bot UIDs already present in mention.uids
+// (e.g. the user explicitly @-mentioned the bot in addition to
+// `@所有 AI`) must not be duplicated. Clause 3.
+func TestExpandAis_Dedup(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"ais":  json.Number("1"),
+			"uids": []interface{}{"bot_a", "user_x"},
+		},
+	}
+	f := &successFetcher{uids: []string{"bot_a", "bot_b", "bot_a"}}
+
+	out := ExpandAisToBotUIDs(payload, channelTypeGroup, "group_1", f.fetch)
+
+	mention := out["mention"].(map[string]interface{})
+	uids, _ := mention["uids"].([]interface{})
+	assert.ElementsMatch(t, []interface{}{"bot_a", "user_x", "bot_b"}, uids,
+		"bot_a must not be duplicated; pre-existing user_x must be preserved")
+}
+
+// TestExpandAis_Idempotent — calling the helper twice on the same
+// payload must produce exactly the same mention.uids slice. This is
+// the cross-call dedup clause that lets PR #138's
+// injectBotUIDIntoMentionUIDs and this helper coexist without
+// double-appending.
+func TestExpandAis_Idempotent(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"ais": json.Number("1"),
+		},
+	}
+	f := &successFetcher{uids: []string{"bot_a", "bot_b"}}
+
+	out := ExpandAisToBotUIDs(payload, channelTypeGroup, "group_1", f.fetch)
+	out = ExpandAisToBotUIDs(out, channelTypeGroup, "group_1", f.fetch)
+
+	mention := out["mention"].(map[string]interface{})
+	uids, _ := mention["uids"].([]interface{})
+	assert.ElementsMatch(t, []interface{}{"bot_a", "bot_b"}, uids,
+		"second call must not duplicate any UID")
+}
+
+// TestExpandAis_NilPayload — clause 4: nil payload must return nil
+// without panicking. Mirrors RewriteMention's defensive shape so the
+// three chokepoint call sites can chain the two helpers without
+// per-call nil guards.
+func TestExpandAis_NilPayload(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ExpandAisToBotUIDs panicked on nil payload: %v", r)
+		}
+	}()
+	assert.Nil(t, ExpandAisToBotUIDs(nil, channelTypeGroup, "group_1", func(string) ([]string, error) {
+		return []string{"bot_a"}, nil
+	}))
+}
+
+// TestExpandAis_EmptyMention — payload has no `mention` key. Must
+// return the payload untouched (clause 4) and never invoke the
+// fetcher.
+func TestExpandAis_EmptyMention(t *testing.T) {
+	payload := map[string]interface{}{"type": 1}
+	f := &successFetcher{uids: []string{"bot_a"}}
+
+	out := ExpandAisToBotUIDs(payload, channelTypeGroup, "group_1", f.fetch)
+
+	assert.Equal(t, 0, f.called)
+	_, hasMention := out["mention"]
+	assert.False(t, hasMention)
+}
+
+// TestExpandAis_NonMapMention — mention exists but is not a map
+// (string / array / number). Must forward untouched (clause 4) — same
+// defensive posture as RewriteMention.
+func TestExpandAis_NonMapMention(t *testing.T) {
+	payload := map[string]interface{}{"mention": "not-a-map"}
+	f := &successFetcher{uids: []string{"bot_a"}}
+
+	out := ExpandAisToBotUIDs(payload, channelTypeGroup, "group_1", f.fetch)
+
+	assert.Equal(t, 0, f.called)
+	assert.Equal(t, "not-a-map", out["mention"])
+}
+
+// TestExpandAis_NonArrayUIDs — mention exists, ais=1, but
+// mention.uids is a malformed shape (e.g. a string). Must forward
+// untouched (clause 4) without mutating the malformed field.
+func TestExpandAis_NonArrayUIDs(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"ais":  json.Number("1"),
+			"uids": "bot_a",
+		},
+	}
+	f := &successFetcher{uids: []string{"bot_b"}}
+
+	out := ExpandAisToBotUIDs(payload, channelTypeGroup, "group_1", f.fetch)
+
+	// The fetcher MAY have been called (ais gate passed); the
+	// important contract is that the malformed uids field is left
+	// untouched rather than overwritten with an []interface{} value.
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, "bot_a", mention["uids"],
+		"malformed mention.uids must be forwarded untouched, not overwritten")
+}
+
+// TestExpandAis_FetcherError — clause 5: fetchBotUIDs returning an
+// error degrades to a no-op so a transient DB failure can't drop the
+// inbound message.
+func TestExpandAis_FetcherError(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"ais": json.Number("1"),
+		},
+	}
+	bad := func(string) ([]string, error) { return nil, errors.New("db down") }
+
+	out := ExpandAisToBotUIDs(payload, channelTypeGroup, "group_1", bad)
+
+	mention := out["mention"].(map[string]interface{})
+	_, hasUIDs := mention["uids"]
+	assert.False(t, hasUIDs, "fetcher error must leave mention.uids absent")
+}
+
+// TestExpandAis_NoBotMembers — fetcher succeeds but returns an
+// empty list (no bots in the channel). Must be a no-op so we don't
+// allocate an empty mention.uids slice that downstream consumers
+// would interpret as "0 mentions explicitly".
+func TestExpandAis_NoBotMembers(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"ais": json.Number("1"),
+		},
+	}
+	f := &successFetcher{uids: nil}
+
+	out := ExpandAisToBotUIDs(payload, channelTypeGroup, "group_1", f.fetch)
+
+	mention := out["mention"].(map[string]interface{})
+	_, hasUIDs := mention["uids"]
+	assert.False(t, hasUIDs)
+}
+
+// TestExpandAis_NilFetcher — a nil callback (programming error at a
+// call site) must be a no-op, not a panic. Defence-in-depth against a
+// future chokepoint that wires the helper before its fetcher is
+// ready.
+func TestExpandAis_NilFetcher(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"ais": json.Number("1"),
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ExpandAisToBotUIDs panicked on nil fetcher: %v", r)
+		}
+	}()
+	out := ExpandAisToBotUIDs(payload, channelTypeGroup, "group_1", nil)
+	mention := out["mention"].(map[string]interface{})
+	_, hasUIDs := mention["uids"]
+	assert.False(t, hasUIDs)
+}
+
+// TestExpandAis_EmptyChannelID — clause 6: defensive on empty
+// channel_id. The HTTP handlers already reject empty channel_id, but
+// the helper must stay safe to drop into future ingresses.
+func TestExpandAis_EmptyChannelID(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"ais": json.Number("1"),
+		},
+	}
+	f := &successFetcher{uids: []string{"bot_a"}}
+
+	out := ExpandAisToBotUIDs(payload, channelTypeGroup, "", f.fetch)
+
+	assert.Equal(t, 0, f.called)
+	mention := out["mention"].(map[string]interface{})
+	_, hasUIDs := mention["uids"]
+	assert.False(t, hasUIDs)
+}
+
+// TestExpandAis_PreservesOtherMentionKeys — clause 2: only
+// mention.uids is touched. all / humans / ais / entities and any
+// future sibling keys must be forwarded byte-identical.
+func TestExpandAis_PreservesOtherMentionKeys(t *testing.T) {
+	entities := []interface{}{
+		map[string]interface{}{"type": "ai_all", "offset": 0, "length": 5},
+	}
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"all":      json.Number("1"),
+			"humans":   json.Number("1"),
+			"ais":      json.Number("1"),
+			"entities": entities,
+		},
+	}
+	f := &successFetcher{uids: []string{"bot_a"}}
+
+	out := ExpandAisToBotUIDs(payload, channelTypeGroup, "group_1", f.fetch)
+
+	mention := out["mention"].(map[string]interface{})
+	assert.Equal(t, json.Number("1"), mention["all"], "all must be preserved")
+	assert.Equal(t, json.Number("1"), mention["humans"], "humans must be preserved")
+	assert.Equal(t, json.Number("1"), mention["ais"], "ais must be preserved")
+	assert.Equal(t, entities, mention["entities"], "entities must be preserved verbatim")
+	uids, _ := mention["uids"].([]interface{})
+	assert.ElementsMatch(t, []interface{}{"bot_a"}, uids)
+}
+
+// TestExpandAis_BoolAisAlsoTruthy — clients sometimes serialize the
+// truthy signal as a JSON boolean (`"ais": true`) rather than `1`.
+// The shared isTruthyOne helper accepts bool, and we want to confirm
+// the expansion path runs for that shape too.
+func TestExpandAis_BoolAisAlsoTruthy(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"ais": true,
+		},
+	}
+	f := &successFetcher{uids: []string{"bot_a"}}
+
+	out := ExpandAisToBotUIDs(payload, channelTypeGroup, "group_1", f.fetch)
+
+	assert.Equal(t, 1, f.called)
+	mention := out["mention"].(map[string]interface{})
+	uids, _ := mention["uids"].([]interface{})
+	assert.ElementsMatch(t, []interface{}{"bot_a"}, uids)
+}
+
+// TestExpandAis_AisZeroNoop — `ais=0` must NOT trigger expansion.
+// Same gate as ais-absent (clause 1).
+func TestExpandAis_AisZeroNoop(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"ais": json.Number("0"),
+		},
+	}
+	f := &successFetcher{uids: []string{"bot_a"}}
+
+	out := ExpandAisToBotUIDs(payload, channelTypeGroup, "group_1", f.fetch)
+
+	assert.Equal(t, 0, f.called)
+	mention := out["mention"].(map[string]interface{})
+	_, hasUIDs := mention["uids"]
+	assert.False(t, hasUIDs)
+}
+
+// TestExpandAis_EmptyBotUID — fetcher returns a list containing the
+// empty string (defensive shape if a malformed member row sneaks
+// through). Empty strings must be skipped, not appended to
+// mention.uids.
+func TestExpandAis_EmptyBotUID(t *testing.T) {
+	payload := map[string]interface{}{
+		"mention": map[string]interface{}{
+			"ais": json.Number("1"),
+		},
+	}
+	f := &successFetcher{uids: []string{"", "bot_a", ""}}
+
+	out := ExpandAisToBotUIDs(payload, channelTypeGroup, "group_1", f.fetch)
+
+	mention := out["mention"].(map[string]interface{})
+	uids, _ := mention["uids"].([]interface{})
+	assert.ElementsMatch(t, []interface{}{"bot_a"}, uids)
+}


### PR DESCRIPTION
## What

When `mention.ais=1` in a GROUP channel, expand `mention.uids` to include every bot member of the channel — applied at the three message ingress chokepoints (`modules/message/api.go`, `modules/bot_api/send.go`, `modules/robot/api.go`), immediately after `RewriteMention`.

## Why

Old adapter bots (#137) connected via the WuKongIM websocket only inspect `mention.uids` and ignore `mention.ais`. PR #138's per-bot UID injection (`injectBotUIDIntoMentionUIDs`) only rewrites the payload that reaches the bot event queue (`/v1/bot/events`), never the websocket dispatch path. Expanding at the ingress makes the WuKongIM payload itself carry the bot UIDs, so legacy adapters recognise the `@所有 AI` broadcast.

## Changes

- `robot.IService` gains `ExistRobot(uid) (bool, error)` — backed by the existing `robotDB.exist` `status=1` lookup, implemented on both `Service` and `*Robot`.
- New `pkg/mentionrewrite.ExpandAisToBotUIDs` helper. Pure / idempotent / defensive on `nil` & malformed shapes. Takes a `fetchBotUIDs` callback so `pkg/mentionrewrite` stays a leaf package (preserves the historical `robot → message → robot` cycle-free invariant called out in `pkg/mentionrewrite/rewrite.go`).
- Each of the three chokepoints composes `group.GetMembers + robot.ExistRobot` into the callback shape via a tiny module-local `mention_expand.go` helper, invoked AFTER `RewriteMention`.
- PERSONAL DMs and COMMUNITY_TOPIC channels are out of scope (no-op).
- `mention.all` / `mention.humans` / `mention.ais` are forwarded untouched — only `mention.uids` is mutated.
- Dedups within a single call AND with PR #138's `injectBotUIDIntoMentionUIDs` so a payload cannot accumulate duplicates.

## Tests

`pkg/mentionrewrite/expand_ais_test.go` pins every clause from the helper's contract:

- `ais+GROUP` expands · `ais+PERSONAL` no-op · `ais+COMMUNITY_TOPIC` no-op
- `all`-only no-op · `humans`-only no-op · `ais=0` no-op
- dedup (bot already in `uids`, fetcher returns dup, mixed bots+humans)
- idempotency (second call is observably a no-op)
- `nil` payload / empty mention / non-map mention / non-array uids — all safe
- fetcher-error degradation, no-bot-members no-op, empty channel_id no-op, nil fetcher no-op
- bool-`ais` truthy, empty bot UID skipped
- `preserves all sibling mention keys` (all/humans/ais/entities)

All `pkg/mentionrewrite/...`, `modules/bot_api/...`, `modules/robot/...` test packages green; `modules/message` infrastructure tests need a live Redis (pre-existing, unrelated).

Closes Mininglamp-OSS/octo-server#144