### PR TITLE
feat(file): add awsS3 backend for AWS S3 and S3-compatible storage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25
 require (
 	firebase.google.com/go/v4 v4.13.0
 	github.com/DATA-DOG/go-sqlmock v1.5.0
-	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260523084316-72ee7103307d
+	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260525041639-11d9edbc605b
 	github.com/alibabacloud-go/darabonba-openapi v0.2.1
 	github.com/alibabacloud-go/sms-intl-20180501 v1.0.1
 	github.com/alibabacloud-go/tea v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25
 require (
 	firebase.google.com/go/v4 v4.13.0
 	github.com/DATA-DOG/go-sqlmock v1.5.0
-	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260522122557-a65ecee15fc5
+	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260523084316-72ee7103307d
 	github.com/alibabacloud-go/darabonba-openapi v0.2.1
 	github.com/alibabacloud-go/sms-intl-20180501 v1.0.1
 	github.com/alibabacloud-go/tea v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260522122557-a65ecee15fc5 h1:tTfDcI52V41vRKgJCAQdfwLumBq8vsiVlBvX1VJeVaY=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260522122557-a65ecee15fc5/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260523084316-72ee7103307d h1:xcVyt7UttIBpfY9fIJ6vLUAITzOiHXrDJvk0XkGeM2g=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260523084316-72ee7103307d/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae h1:DcFpTQBYQ9Ct2d6sC7ol0/ynxc2pO1cpGUM+f4t5adg=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae/go.mod h1:rJJ84PyA/Wlmw1hO+xTzV2wsSUon6J5ktg0g8BF2PuU=
 github.com/RichardKnop/machinery/v2 v2.0.11 h1:BTfLGOmOju3W/OtlZmLX26OjYNZsU4PJo04pQReycdc=

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260523084316-72ee7103307d h1:xcVyt7UttIBpfY9fIJ6vLUAITzOiHXrDJvk0XkGeM2g=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260523084316-72ee7103307d/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260525041639-11d9edbc605b h1:k+OHyVQK60l/2eDkuWeBbmLQGQIwG/gjqB/FQ+v8DZw=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260525041639-11d9edbc605b/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae h1:DcFpTQBYQ9Ct2d6sC7ol0/ynxc2pO1cpGUM+f4t5adg=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae/go.mod h1:rJJ84PyA/Wlmw1hO+xTzV2wsSUon6J5ktg0g8BF2PuU=
 github.com/RichardKnop/machinery/v2 v2.0.11 h1:BTfLGOmOju3W/OtlZmLX26OjYNZsU4PJo04pQReycdc=

--- a/modules/file/api.go
+++ b/modules/file/api.go
@@ -596,7 +596,7 @@ func (f *File) getDownloadURL(c *wkhttp.Context) {
 					ph = strings.TrimPrefix(ph, "/"+cosPrefix)
 				}
 
-			case "awsS3":
+			case fileServiceAwsS3:
 				// S3 backend: mirror the COS handling. When the client
 				// round-trips a full URL we previously issued, the URL
 				// path carries the configured prefix (and the bucket
@@ -604,8 +604,20 @@ func (f *File) getDownloadURL(c *wkhttp.Context) {
 				// off before PresignedGetURL re-applies the prefix via
 				// ServiceS3.withPrefix, otherwise the signed object key
 				// double-prefixes and the GET 404s.
+				//
+				// Bucket-segment strip is gated by DownloadURL being
+				// empty: ServiceS3.publicURL emits `<downloadURL>/<key>`
+				// (no bucket in path) when DownloadURL is set, so the
+				// bucket only appears in the path under the canonical
+				// path-style shape (`https://<endpoint>/<bucket>/<key>`).
+				// Without this gate, a deployment with bucket name
+				// matching the first object-key segment (e.g. bucket
+				// "chat", URL "https://files.example.com/chat/foo.jpg")
+				// would lose the real key segment and sign the wrong
+				// object. Reported by Jerry-Xin in PR #147 review.
 				s3Cfg := f.ctx.GetConfig().S3
-				if s3Cfg.UsePathStyle && s3Cfg.Bucket != "" {
+				downloadURLEmpty := strings.TrimSpace(s3Cfg.DownloadURL) == ""
+				if downloadURLEmpty && s3Cfg.UsePathStyle && s3Cfg.Bucket != "" {
 					ph = strings.TrimPrefix(ph, "/"+s3Cfg.Bucket)
 				}
 				s3Prefix := strings.TrimSpace(s3Cfg.Prefix)
@@ -614,17 +626,16 @@ func (f *File) getDownloadURL(c *wkhttp.Context) {
 				}
 			}
 		}
-		// Drop the leading slash left over from url.Parse(...).Path.
-		// ServiceS3.PresignedGetURL runs validatePresignObjectKey,
-		// which rejects keys with leading "/" because the SigV4
-		// canonical URI would acquire a "//<key>" segment that gateway
-		// path-normalization rewrites to "/<key>" mid-flight, breaking
-		// signature validation. ServiceCOS happens to tolerate this
-		// because it doesn't validate; ServiceS3 is strict, so the
-		// strip belongs at the ingress layer where the slash artifact
-		// is produced.
-		ph = strings.TrimPrefix(ph, "/")
 	}
+	// Drop any leading slash so the key handed to the signer is a clean
+	// relative key. ServiceS3.PresignedGetURL runs validatePresignObjectKey,
+	// which rejects keys with leading "/" because the SigV4 canonical URI
+	// would acquire a "//<key>" segment that gateway path-normalization
+	// rewrites to "/<key>" mid-flight, breaking signature validation.
+	// ServiceCOS happens to tolerate this because it doesn't validate;
+	// ServiceS3 is strict. The trim lives outside the http-URL branch so
+	// bare paths like `?path=/chat/foo` are normalized the same way.
+	ph = strings.TrimPrefix(ph, "/")
 
 	sanitized, err := sanitizePath(ph)
 	if err != nil {

--- a/modules/file/api.go
+++ b/modules/file/api.go
@@ -605,6 +605,16 @@ func (f *File) getDownloadURL(c *wkhttp.Context) {
 				ph = strings.TrimPrefix(ph, "/"+s3Prefix)
 			}
 		}
+		// Drop the leading slash left over from url.Parse(...).Path.
+		// ServiceS3.PresignedGetURL runs validatePresignObjectKey,
+		// which rejects keys with leading "/" because the SigV4
+		// canonical URI would acquire a "//<key>" segment that gateway
+		// path-normalization rewrites to "/<key>" mid-flight, breaking
+		// signature validation. ServiceCOS happens to tolerate this
+		// because it doesn't validate; ServiceS3 is strict, so the
+		// strip belongs at the ingress layer where the slash artifact
+		// is produced.
+		ph = strings.TrimPrefix(ph, "/")
 	}
 
 	sanitized, err := sanitizePath(ph)

--- a/modules/file/api.go
+++ b/modules/file/api.go
@@ -562,47 +562,56 @@ func (f *File) getDownloadURL(c *wkhttp.Context) {
 		parsed, parseErr := url.Parse(ph)
 		if parseErr == nil {
 			ph = parsed.Path
-			cosCfg := f.ctx.GetConfig().COS
-			// Path-style CDN: when BucketURL is set and its host does
-			// NOT carry a `<bucket>.` subdomain (e.g.
-			// `BucketURL=https://cdn.example.com`), the URL we issued
-			// to the browser is `<host>/<bucket>/<prefix>/<key>` (see
-			// publicURL / PresignedGetURL with BucketLookupPath). When
-			// the client round-trips that full URL back to us, the
-			// parsed path therefore begins with `/<bucket>/`, and the
-			// bucket segment must be stripped BEFORE the COS.Prefix
-			// strip below — otherwise PresignedGetURL signs the bucket
-			// as part of the object key and the resulting GET 404s.
-			//
-			// Detection mirrors `publicEndpoint`: BucketURL set, parsed
-			// successfully, host does NOT begin with `<bucket>.`.
-			if strings.TrimSpace(cosCfg.BucketURL) != "" && cosCfg.Bucket != "" {
-				if bu, buErr := url.Parse(strings.TrimRight(strings.TrimSpace(cosCfg.BucketURL), "/")); buErr == nil && bu.Host != "" {
-					if !strings.HasPrefix(bu.Host, cosCfg.Bucket+".") {
-						ph = strings.TrimPrefix(ph, "/"+cosCfg.Bucket)
+			// Gate the per-backend strip blocks by the active fileService
+			// so a COS-style bucket segment is never mistakenly stripped
+			// off an S3 URL (and vice versa). Pre-gate, both blocks ran
+			// for every URL — harmless when prefixes/buckets don't overlap
+			// across backends, but a footgun if they do.
+			switch f.ctx.GetConfig().FileService {
+			case config.FileServiceTencentCOS:
+				cosCfg := f.ctx.GetConfig().COS
+				// Path-style CDN: when BucketURL is set and its host does
+				// NOT carry a `<bucket>.` subdomain (e.g.
+				// `BucketURL=https://cdn.example.com`), the URL we issued
+				// to the browser is `<host>/<bucket>/<prefix>/<key>` (see
+				// publicURL / PresignedGetURL with BucketLookupPath). When
+				// the client round-trips that full URL back to us, the
+				// parsed path therefore begins with `/<bucket>/`, and the
+				// bucket segment must be stripped BEFORE the COS.Prefix
+				// strip below — otherwise PresignedGetURL signs the bucket
+				// as part of the object key and the resulting GET 404s.
+				//
+				// Detection mirrors `publicEndpoint`: BucketURL set, parsed
+				// successfully, host does NOT begin with `<bucket>.`.
+				if strings.TrimSpace(cosCfg.BucketURL) != "" && cosCfg.Bucket != "" {
+					if bu, buErr := url.Parse(strings.TrimRight(strings.TrimSpace(cosCfg.BucketURL), "/")); buErr == nil && bu.Host != "" {
+						if !strings.HasPrefix(bu.Host, cosCfg.Bucket+".") {
+							ph = strings.TrimPrefix(ph, "/"+cosCfg.Bucket)
+						}
 					}
 				}
-			}
-			// Strip the COS prefix (e.g. /bucket-prefix) from the path
-			cosPrefix := strings.TrimSpace(cosCfg.Prefix)
-			if cosPrefix != "" {
-				ph = strings.TrimPrefix(ph, "/"+cosPrefix)
-			}
+				// Strip the COS prefix (e.g. /bucket-prefix) from the path
+				cosPrefix := strings.TrimSpace(cosCfg.Prefix)
+				if cosPrefix != "" {
+					ph = strings.TrimPrefix(ph, "/"+cosPrefix)
+				}
 
-			// S3 backend: mirror the COS handling for the awsS3
-			// fileService. When the client round-trips a full URL we
-			// previously issued, the URL path carries the configured
-			// prefix (and the bucket segment in path-style deployments)
-			// — both must come off before PresignedGetURL re-applies
-			// the prefix via ServiceS3.withPrefix, otherwise the signed
-			// object key double-prefixes and the GET 404s.
-			s3Cfg := f.ctx.GetConfig().S3
-			if s3Cfg.UsePathStyle && s3Cfg.Bucket != "" {
-				ph = strings.TrimPrefix(ph, "/"+s3Cfg.Bucket)
-			}
-			s3Prefix := strings.TrimSpace(s3Cfg.Prefix)
-			if s3Prefix != "" {
-				ph = strings.TrimPrefix(ph, "/"+s3Prefix)
+			case "awsS3":
+				// S3 backend: mirror the COS handling. When the client
+				// round-trips a full URL we previously issued, the URL
+				// path carries the configured prefix (and the bucket
+				// segment in path-style deployments) — both must come
+				// off before PresignedGetURL re-applies the prefix via
+				// ServiceS3.withPrefix, otherwise the signed object key
+				// double-prefixes and the GET 404s.
+				s3Cfg := f.ctx.GetConfig().S3
+				if s3Cfg.UsePathStyle && s3Cfg.Bucket != "" {
+					ph = strings.TrimPrefix(ph, "/"+s3Cfg.Bucket)
+				}
+				s3Prefix := strings.TrimSpace(s3Cfg.Prefix)
+				if s3Prefix != "" {
+					ph = strings.TrimPrefix(ph, "/"+s3Prefix)
+				}
 			}
 		}
 		// Drop the leading slash left over from url.Parse(...).Path.

--- a/modules/file/api.go
+++ b/modules/file/api.go
@@ -588,6 +588,22 @@ func (f *File) getDownloadURL(c *wkhttp.Context) {
 			if cosPrefix != "" {
 				ph = strings.TrimPrefix(ph, "/"+cosPrefix)
 			}
+
+			// S3 backend: mirror the COS handling for the awsS3
+			// fileService. When the client round-trips a full URL we
+			// previously issued, the URL path carries the configured
+			// prefix (and the bucket segment in path-style deployments)
+			// — both must come off before PresignedGetURL re-applies
+			// the prefix via ServiceS3.withPrefix, otherwise the signed
+			// object key double-prefixes and the GET 404s.
+			s3Cfg := f.ctx.GetConfig().S3
+			if s3Cfg.UsePathStyle && s3Cfg.Bucket != "" {
+				ph = strings.TrimPrefix(ph, "/"+s3Cfg.Bucket)
+			}
+			s3Prefix := strings.TrimSpace(s3Cfg.Prefix)
+			if s3Prefix != "" {
+				ph = strings.TrimPrefix(ph, "/"+s3Prefix)
+			}
 		}
 	}
 

--- a/modules/file/api_unit_test.go
+++ b/modules/file/api_unit_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCheckReq(t *testing.T) {
@@ -917,7 +918,7 @@ func TestGetDownloadURL_PathStyleStripsBucketSegment(t *testing.T) {
 			bucketURL:        "https://cdn.example.com",
 			prefix:           "im-test",
 			inputPath:        "https://cdn.example.com/im-data-1255521909/im-test/chat/2026/05/abc.jpg",
-			wantSignedObject: "/chat/2026/05/abc.jpg",
+			wantSignedObject: "chat/2026/05/abc.jpg",
 		},
 		{
 			name:             "path-style CDN no prefix strips just bucket",
@@ -925,7 +926,7 @@ func TestGetDownloadURL_PathStyleStripsBucketSegment(t *testing.T) {
 			bucketURL:        "https://cdn.example.com",
 			prefix:           "",
 			inputPath:        "https://cdn.example.com/im-data-1255521909/chat/2026/05/abc.jpg",
-			wantSignedObject: "/chat/2026/05/abc.jpg",
+			wantSignedObject: "chat/2026/05/abc.jpg",
 		},
 		{
 			name:             "DNS-style bucket-subdomain BucketURL — bucket NOT in path, only prefix stripped",
@@ -933,7 +934,7 @@ func TestGetDownloadURL_PathStyleStripsBucketSegment(t *testing.T) {
 			bucketURL:        "https://im-data-1255521909.cos.example.com",
 			prefix:           "im-prod",
 			inputPath:        "https://im-data-1255521909.cos.example.com/im-prod/chat/2026/05/abc.jpg",
-			wantSignedObject: "/chat/2026/05/abc.jpg",
+			wantSignedObject: "chat/2026/05/abc.jpg",
 		},
 		{
 			name:             "DNS-style: must NOT accidentally strip a path segment that happens to share the bucket name",
@@ -941,7 +942,7 @@ func TestGetDownloadURL_PathStyleStripsBucketSegment(t *testing.T) {
 			bucketURL:        "https://im-data-1255521909.cos.example.com",
 			prefix:           "",
 			inputPath:        "https://im-data-1255521909.cos.example.com/chat/2026/05/abc.jpg",
-			wantSignedObject: "/chat/2026/05/abc.jpg",
+			wantSignedObject: "chat/2026/05/abc.jpg",
 		},
 		{
 			name:             "BucketURL empty (canonical default endpoint) — bucket lives in subdomain, path is just key",
@@ -949,7 +950,7 @@ func TestGetDownloadURL_PathStyleStripsBucketSegment(t *testing.T) {
 			bucketURL:        "",
 			prefix:           "",
 			inputPath:        "https://im-data-1255521909.cos.ap-beijing.myqcloud.com/chat/2026/05/abc.jpg",
-			wantSignedObject: "/chat/2026/05/abc.jpg",
+			wantSignedObject: "chat/2026/05/abc.jpg",
 		},
 		{
 			name:             "non-URL path passes through unchanged",
@@ -1027,7 +1028,7 @@ func TestGetDownloadURL_S3PrefixAndBucketStrip(t *testing.T) {
 			prefix:           "prod",
 			usePathStyle:     false,
 			inputPath:        "https://my-bucket.s3.us-west-2.amazonaws.com/prod/chat/2026/05/abc.jpg",
-			wantSignedObject: "/chat/2026/05/abc.jpg",
+			wantSignedObject: "chat/2026/05/abc.jpg",
 		},
 		{
 			name:             "path-style with prefix strips bucket then prefix",
@@ -1036,7 +1037,7 @@ func TestGetDownloadURL_S3PrefixAndBucketStrip(t *testing.T) {
 			prefix:           "prod",
 			usePathStyle:     true,
 			inputPath:        "https://s3.us-west-2.amazonaws.com/my-bucket/prod/chat/2026/05/abc.jpg",
-			wantSignedObject: "/chat/2026/05/abc.jpg",
+			wantSignedObject: "chat/2026/05/abc.jpg",
 		},
 		{
 			name:             "path-style no prefix strips just bucket",
@@ -1045,7 +1046,7 @@ func TestGetDownloadURL_S3PrefixAndBucketStrip(t *testing.T) {
 			prefix:           "",
 			usePathStyle:     true,
 			inputPath:        "https://s3.us-west-2.amazonaws.com/my-bucket/chat/2026/05/abc.jpg",
-			wantSignedObject: "/chat/2026/05/abc.jpg",
+			wantSignedObject: "chat/2026/05/abc.jpg",
 		},
 		{
 			name:             "CDN BucketURL with prefix — bucket NOT in path, only prefix stripped",
@@ -1054,7 +1055,7 @@ func TestGetDownloadURL_S3PrefixAndBucketStrip(t *testing.T) {
 			prefix:           "prod",
 			usePathStyle:     false,
 			inputPath:        "https://files.example.com/prod/chat/2026/05/abc.jpg",
-			wantSignedObject: "/chat/2026/05/abc.jpg",
+			wantSignedObject: "chat/2026/05/abc.jpg",
 		},
 		{
 			name:             "virtual-hosted no prefix — path is just key",
@@ -1063,7 +1064,7 @@ func TestGetDownloadURL_S3PrefixAndBucketStrip(t *testing.T) {
 			prefix:           "",
 			usePathStyle:     false,
 			inputPath:        "https://my-bucket.s3.us-west-2.amazonaws.com/chat/2026/05/abc.jpg",
-			wantSignedObject: "/chat/2026/05/abc.jpg",
+			wantSignedObject: "chat/2026/05/abc.jpg",
 		},
 		{
 			name:             "non-URL path passes through unchanged",
@@ -1111,4 +1112,62 @@ func TestGetDownloadURL_S3PrefixAndBucketStrip(t *testing.T) {
 				"object path passed to PresignedGetURL must have prefix (and path-style bucket) stripped before signing")
 		})
 	}
+}
+
+// TestGetDownloadURL_S3_RealServiceRoundTrip is the regression that the
+// mock-based TestGetDownloadURL_S3PrefixAndBucketStrip cannot catch by
+// construction: yujiawei's P1 in PR#147 review noted that the previous
+// table test recorded `lastGetObjectPath` from a mock that skips
+// `validatePresignObjectKey`, hiding the fact that ServiceS3 rejects
+// leading-slash object keys at sign time. This test wires the real
+// `ServiceS3` (with fake credentials — the SDK never makes a network
+// call for `PresignedGetObject`) and asserts the handler returns 200,
+// not 500, when the default minimal config (no s3.prefix) round-trips a
+// virtual-hosted URL.
+func TestGetDownloadURL_S3_RealServiceRoundTrip(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cfg := config.New()
+	cfg.Test = true
+	cfg.S3.Endpoint = "s3.us-west-2.amazonaws.com"
+	cfg.S3.Region = "us-west-2"
+	cfg.S3.Bucket = "my-bucket"
+	cfg.S3.AccessKeyID = "AKIAFAKEACCESSKEY"
+	cfg.S3.SecretAccessKey = "fake-secret-access-key-1234567890"
+	// No prefix — this is the failure shape from the review.
+
+	// Use the real Service wrapper + ServiceS3. SDK PresignedGetObject
+	// is pure URL signing (no network I/O) so fake creds are fine.
+	cfg.FileService = "awsS3"
+	ctx := testutil.NewTestContext(cfg)
+	svc := NewService(ctx)
+
+	f := &File{
+		ctx:     ctx,
+		Log:     log.NewTLog("FileTest"),
+		service: svc,
+	}
+
+	inputURL := "https://my-bucket.s3.us-west-2.amazonaws.com/chat/2026/05/abc.jpg"
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req, _ := http.NewRequest(
+		http.MethodGet,
+		"/v1/file/download/url?path="+url.QueryEscape(inputURL)+"&filename=abc.jpg",
+		nil,
+	)
+	c.Request = req
+
+	wkCtx := &wkhttp.Context{Context: c}
+	f.getDownloadURL(wkCtx)
+
+	require.Equal(t, http.StatusOK, w.Code,
+		"real ServiceS3 round-trip must return 200; pre-fix this returned 500 because validatePresignObjectKey rejected the leading-slash key. body=%s",
+		w.Body.String())
+
+	// The body should carry a signed URL with no double slashes in the
+	// path — that's the SigV4 normalization hazard the leading-slash
+	// strip is preventing in the first place.
+	assert.NotContains(t, w.Body.String(), `\/\/chat`,
+		"signed URL must not contain `//chat` (sign-time path normalization would break the signature)")
 }

--- a/modules/file/api_unit_test.go
+++ b/modules/file/api_unit_test.go
@@ -1000,3 +1000,115 @@ func TestGetDownloadURL_PathStyleStripsBucketSegment(t *testing.T) {
 		})
 	}
 }
+
+// TestGetDownloadURL_S3PrefixAndBucketStrip mirrors the COS round-trip
+// test for the awsS3 fileService. Same hazard: when the client posts
+// back a full URL we issued (e.g. with a multi-env prefix or a
+// path-style endpoint), the handler must strip both the prefix and
+// (path-style only) the bucket segment before PresignedGetURL
+// re-applies the prefix via ServiceS3.withPrefix. Without the strip,
+// the signed object key double-prefixes and the GET 404s.
+func TestGetDownloadURL_S3PrefixAndBucketStrip(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cases := []struct {
+		name             string
+		bucket           string
+		bucketURL        string
+		prefix           string
+		usePathStyle     bool
+		inputPath        string
+		wantSignedObject string
+	}{
+		{
+			name:             "virtual-hosted with prefix strips just prefix",
+			bucket:           "my-bucket",
+			bucketURL:        "",
+			prefix:           "prod",
+			usePathStyle:     false,
+			inputPath:        "https://my-bucket.s3.us-west-2.amazonaws.com/prod/chat/2026/05/abc.jpg",
+			wantSignedObject: "/chat/2026/05/abc.jpg",
+		},
+		{
+			name:             "path-style with prefix strips bucket then prefix",
+			bucket:           "my-bucket",
+			bucketURL:        "",
+			prefix:           "prod",
+			usePathStyle:     true,
+			inputPath:        "https://s3.us-west-2.amazonaws.com/my-bucket/prod/chat/2026/05/abc.jpg",
+			wantSignedObject: "/chat/2026/05/abc.jpg",
+		},
+		{
+			name:             "path-style no prefix strips just bucket",
+			bucket:           "my-bucket",
+			bucketURL:        "",
+			prefix:           "",
+			usePathStyle:     true,
+			inputPath:        "https://s3.us-west-2.amazonaws.com/my-bucket/chat/2026/05/abc.jpg",
+			wantSignedObject: "/chat/2026/05/abc.jpg",
+		},
+		{
+			name:             "CDN BucketURL with prefix — bucket NOT in path, only prefix stripped",
+			bucket:           "my-bucket",
+			bucketURL:        "https://files.example.com",
+			prefix:           "prod",
+			usePathStyle:     false,
+			inputPath:        "https://files.example.com/prod/chat/2026/05/abc.jpg",
+			wantSignedObject: "/chat/2026/05/abc.jpg",
+		},
+		{
+			name:             "virtual-hosted no prefix — path is just key",
+			bucket:           "my-bucket",
+			bucketURL:        "",
+			prefix:           "",
+			usePathStyle:     false,
+			inputPath:        "https://my-bucket.s3.us-west-2.amazonaws.com/chat/2026/05/abc.jpg",
+			wantSignedObject: "/chat/2026/05/abc.jpg",
+		},
+		{
+			name:             "non-URL path passes through unchanged",
+			bucket:           "my-bucket",
+			bucketURL:        "",
+			prefix:           "prod",
+			usePathStyle:     false,
+			inputPath:        "chat/2026/05/abc.jpg",
+			wantSignedObject: "chat/2026/05/abc.jpg",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.New()
+			cfg.Test = true
+			cfg.S3.Endpoint = "s3.us-west-2.amazonaws.com"
+			cfg.S3.Region = "us-west-2"
+			cfg.S3.Bucket = tc.bucket
+			cfg.S3.BucketURL = tc.bucketURL
+			cfg.S3.Prefix = tc.prefix
+			cfg.S3.UsePathStyle = tc.usePathStyle
+
+			mockSvc := &mockService{}
+			f := &File{
+				ctx:     testutil.NewTestContext(cfg),
+				Log:     log.NewTLog("FileTest"),
+				service: mockSvc,
+			}
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			req, _ := http.NewRequest(
+				http.MethodGet,
+				"/v1/file/download/url?path="+url.QueryEscape(tc.inputPath)+"&filename=abc.jpg",
+				nil,
+			)
+			c.Request = req
+
+			wkCtx := &wkhttp.Context{Context: c}
+			f.getDownloadURL(wkCtx)
+
+			assert.Equal(t, http.StatusOK, w.Code, "unexpected status; body=%s", w.Body.String())
+			assert.Equal(t, tc.wantSignedObject, mockSvc.lastGetObjectPath,
+				"object path passed to PresignedGetURL must have prefix (and path-style bucket) stripped before signing")
+		})
+	}
+}

--- a/modules/file/api_unit_test.go
+++ b/modules/file/api_unit_test.go
@@ -966,6 +966,7 @@ func TestGetDownloadURL_PathStyleStripsBucketSegment(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := config.New()
 			cfg.Test = true
+			cfg.FileService = config.FileServiceTencentCOS
 			cfg.COS.Bucket = tc.bucket
 			cfg.COS.Region = "ap-beijing"
 			cfg.COS.BucketURL = tc.bucketURL
@@ -1015,7 +1016,7 @@ func TestGetDownloadURL_S3PrefixAndBucketStrip(t *testing.T) {
 	cases := []struct {
 		name             string
 		bucket           string
-		bucketURL        string
+		downloadURL      string
 		prefix           string
 		usePathStyle     bool
 		inputPath        string
@@ -1024,7 +1025,7 @@ func TestGetDownloadURL_S3PrefixAndBucketStrip(t *testing.T) {
 		{
 			name:             "virtual-hosted with prefix strips just prefix",
 			bucket:           "my-bucket",
-			bucketURL:        "",
+			downloadURL:      "",
 			prefix:           "prod",
 			usePathStyle:     false,
 			inputPath:        "https://my-bucket.s3.us-west-2.amazonaws.com/prod/chat/2026/05/abc.jpg",
@@ -1033,7 +1034,7 @@ func TestGetDownloadURL_S3PrefixAndBucketStrip(t *testing.T) {
 		{
 			name:             "path-style with prefix strips bucket then prefix",
 			bucket:           "my-bucket",
-			bucketURL:        "",
+			downloadURL:      "",
 			prefix:           "prod",
 			usePathStyle:     true,
 			inputPath:        "https://s3.us-west-2.amazonaws.com/my-bucket/prod/chat/2026/05/abc.jpg",
@@ -1042,16 +1043,16 @@ func TestGetDownloadURL_S3PrefixAndBucketStrip(t *testing.T) {
 		{
 			name:             "path-style no prefix strips just bucket",
 			bucket:           "my-bucket",
-			bucketURL:        "",
+			downloadURL:      "",
 			prefix:           "",
 			usePathStyle:     true,
 			inputPath:        "https://s3.us-west-2.amazonaws.com/my-bucket/chat/2026/05/abc.jpg",
 			wantSignedObject: "chat/2026/05/abc.jpg",
 		},
 		{
-			name:             "CDN BucketURL with prefix — bucket NOT in path, only prefix stripped",
+			name:             "CDN DownloadURL with prefix — bucket NOT in path, only prefix stripped",
 			bucket:           "my-bucket",
-			bucketURL:        "https://files.example.com",
+			downloadURL:      "https://files.example.com",
 			prefix:           "prod",
 			usePathStyle:     false,
 			inputPath:        "https://files.example.com/prod/chat/2026/05/abc.jpg",
@@ -1060,7 +1061,7 @@ func TestGetDownloadURL_S3PrefixAndBucketStrip(t *testing.T) {
 		{
 			name:             "virtual-hosted no prefix — path is just key",
 			bucket:           "my-bucket",
-			bucketURL:        "",
+			downloadURL:      "",
 			prefix:           "",
 			usePathStyle:     false,
 			inputPath:        "https://my-bucket.s3.us-west-2.amazonaws.com/chat/2026/05/abc.jpg",
@@ -1069,7 +1070,7 @@ func TestGetDownloadURL_S3PrefixAndBucketStrip(t *testing.T) {
 		{
 			name:             "non-URL path passes through unchanged",
 			bucket:           "my-bucket",
-			bucketURL:        "",
+			downloadURL:      "",
 			prefix:           "prod",
 			usePathStyle:     false,
 			inputPath:        "chat/2026/05/abc.jpg",
@@ -1081,10 +1082,11 @@ func TestGetDownloadURL_S3PrefixAndBucketStrip(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := config.New()
 			cfg.Test = true
+			cfg.FileService = "awsS3"
 			cfg.S3.Endpoint = "s3.us-west-2.amazonaws.com"
 			cfg.S3.Region = "us-west-2"
 			cfg.S3.Bucket = tc.bucket
-			cfg.S3.BucketURL = tc.bucketURL
+			cfg.S3.DownloadURL = tc.downloadURL
 			cfg.S3.Prefix = tc.prefix
 			cfg.S3.UsePathStyle = tc.usePathStyle
 

--- a/modules/file/api_unit_test.go
+++ b/modules/file/api_unit_test.go
@@ -1173,3 +1173,100 @@ func TestGetDownloadURL_S3_RealServiceRoundTrip(t *testing.T) {
 	assert.NotContains(t, w.Body.String(), `\/\/chat`,
 		"signed URL must not contain `//chat` (sign-time path normalization would break the signature)")
 }
+
+// TestGetDownloadURL_S3_DownloadURLPreservesBucketLikeKeySegment is the
+// regression for Jerry-Xin's PR #147 review nit: when DownloadURL is
+// set, ServiceS3.publicURL emits `<downloadURL>/<key>` (no bucket
+// segment in the path). If api.getDownloadURL strips `/<bucket>` from
+// path-style URLs unconditionally, a deployment where the bucket name
+// equals the first object-key segment (e.g. bucket "chat", URL
+// `https://files.example.com/chat/foo.jpg`) loses the real key and
+// signs the wrong object. The fix gates the bucket strip on
+// DownloadURL being empty.
+func TestGetDownloadURL_S3_DownloadURLPreservesBucketLikeKeySegment(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cfg := config.New()
+	cfg.Test = true
+	cfg.FileService = "awsS3"
+	cfg.S3.Endpoint = "s3.us-west-2.amazonaws.com"
+	cfg.S3.Region = "us-west-2"
+	// Bucket name deliberately equals the first object-key segment
+	// in the round-tripped URL below — the exact shape that would
+	// produce the wrong-object signature without the DownloadURL gate.
+	cfg.S3.Bucket = "chat"
+	cfg.S3.DownloadURL = "https://files.example.com"
+	cfg.S3.UsePathStyle = true
+
+	mockSvc := &mockService{}
+	f := &File{
+		ctx:     testutil.NewTestContext(cfg),
+		Log:     log.NewTLog("FileTest"),
+		service: mockSvc,
+	}
+
+	inputURL := "https://files.example.com/chat/2026/05/abc.jpg"
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req, _ := http.NewRequest(
+		http.MethodGet,
+		"/v1/file/download/url?path="+url.QueryEscape(inputURL)+"&filename=abc.jpg",
+		nil,
+	)
+	c.Request = req
+
+	wkCtx := &wkhttp.Context{Context: c}
+	f.getDownloadURL(wkCtx)
+
+	require.Equal(t, http.StatusOK, w.Code, "unexpected status; body=%s", w.Body.String())
+	// The full key including the "chat/" prefix must reach the signer.
+	// Pre-fix, the bucket strip ate "chat/" and PresignedGetURL would
+	// have signed "2026/05/abc.jpg" — a completely different object.
+	assert.Equal(t, "chat/2026/05/abc.jpg", mockSvc.lastGetObjectPath,
+		"DownloadURL mode must NOT strip the bucket segment even when it matches the first key segment")
+}
+
+// TestGetDownloadURL_S3_BarePathLeadingSlashTrimmed locks in the
+// post-#147-P2 fix from yujiawei: a bare relative path with a leading
+// slash (`?path=/chat/foo`) must reach the signer as a clean key, not
+// `/chat/foo`. Pre-fix, the leading-slash trim lived inside the
+// `if strings.HasPrefix(ph, "http")` branch and bare paths slipped
+// through, triggering validatePresignObjectKey rejection (500) on the
+// strict S3 backend.
+func TestGetDownloadURL_S3_BarePathLeadingSlashTrimmed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cfg := config.New()
+	cfg.Test = true
+	cfg.FileService = "awsS3"
+	cfg.S3.Endpoint = "s3.us-west-2.amazonaws.com"
+	cfg.S3.Region = "us-west-2"
+	cfg.S3.Bucket = "my-bucket"
+	cfg.S3.AccessKeyID = "AKIAFAKEACCESSKEY"
+	cfg.S3.SecretAccessKey = "fake-secret-access-key-1234567890"
+
+	ctx := testutil.NewTestContext(cfg)
+	svc := NewService(ctx)
+
+	f := &File{
+		ctx:     ctx,
+		Log:     log.NewTLog("FileTest"),
+		service: svc,
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req, _ := http.NewRequest(
+		http.MethodGet,
+		"/v1/file/download/url?path=%2Fchat%2F2026%2Fabc.jpg&filename=abc.jpg",
+		nil,
+	)
+	c.Request = req
+
+	wkCtx := &wkhttp.Context{Context: c}
+	f.getDownloadURL(wkCtx)
+
+	require.Equal(t, http.StatusOK, w.Code,
+		"bare path with leading slash must be normalized before signing; pre-fix this returned 500 because validatePresignObjectKey rejected the leading-slash key. body=%s",
+		w.Body.String())
+}

--- a/modules/file/const.go
+++ b/modules/file/const.go
@@ -9,6 +9,15 @@ import (
 	"unicode/utf8"
 )
 
+// fileServiceAwsS3 is the cfg.FileService value that activates the
+// awsS3 backend. octo-lib has not yet exported a typed
+// FileServiceAwsS3 constant — when it does (tracked in PR follow-ups),
+// callers should switch to the typed value and this local const can
+// go away. Keeping the literal in one place prevents drift between
+// the dispatch site (service.go) and the round-trip URL strip
+// (api.go).
+const fileServiceAwsS3 = "awsS3"
+
 // fileMagicNumbers 文件魔数签名映射表
 // 用于验证文件内容是否与扩展名声称的类型一致
 var fileMagicNumbers = map[string][][]byte{

--- a/modules/file/service.go
+++ b/modules/file/service.go
@@ -66,6 +66,11 @@ func NewService(ctx *config.Context) IService {
 		uploadService = NewServiceQiniu(ctx)
 	} else if service == config.FileServiceTencentCOS {
 		uploadService = NewServiceCOS(ctx)
+	} else if service == "awsS3" {
+		// Literal "awsS3" — octo-lib has not (yet) declared a
+		// FileServiceAwsS3 constant; a follow-up upstream PR can
+		// add the constant and this branch will switch to it.
+		uploadService = NewServiceS3(ctx)
 	} else {
 		uploadService = NewSeaweedFS(ctx)
 	}

--- a/modules/file/service.go
+++ b/modules/file/service.go
@@ -66,10 +66,13 @@ func NewService(ctx *config.Context) IService {
 		uploadService = NewServiceQiniu(ctx)
 	} else if service == config.FileServiceTencentCOS {
 		uploadService = NewServiceCOS(ctx)
-	} else if service == "awsS3" {
-		// Literal "awsS3" — octo-lib has not (yet) declared a
-		// FileServiceAwsS3 constant; a follow-up upstream PR can
-		// add the constant and this branch will switch to it.
+	} else if service == fileServiceAwsS3 {
+		// octo-lib has not (yet) declared a FileServiceAwsS3 constant;
+		// the local fileServiceAwsS3 (see const.go) collapses the
+		// literal to one place so the dispatch site here and the
+		// round-trip URL strip in api.go cannot drift. A follow-up
+		// upstream PR will add the typed constant and both sites will
+		// switch over together.
 		uploadService = NewServiceS3(ctx)
 	} else {
 		uploadService = NewSeaweedFS(ctx)

--- a/modules/file/service_s3.go
+++ b/modules/file/service_s3.go
@@ -39,14 +39,13 @@ import (
 //     and supports UsePathStyle as an explicit operator opt-in instead
 //     of detecting it from BucketURL shape.
 //
-// Connection model: HTTPS only. Operators who need plain HTTP (local
-// MinIO emulator, development with self-signed cert) should keep using
-// the existing minio backend — adding TLS opt-out here would compromise
-// the "production-grade S3" framing and is intentionally out of scope.
+// Connection model: cfg.S3.Endpoint always uses HTTPS by design. The
+// optional cfg.S3.BucketURL is operator-owned infrastructure and DOES
+// honor `http://` for local emulators; see publicEndpoint and the yaml
+// example for the rationale.
 type ServiceS3 struct {
 	log.Log
-	ctx            *config.Context
-	downloadClient *http.Client
+	ctx *config.Context
 }
 
 // NewServiceS3 constructs a ServiceS3 from the active config. Required
@@ -60,9 +59,6 @@ func NewServiceS3(ctx *config.Context) *ServiceS3 {
 	return &ServiceS3{
 		Log: log.NewTLog("FileS3"),
 		ctx: ctx,
-		downloadClient: &http.Client{
-			Timeout: time.Second * 30,
-		},
 	}
 }
 
@@ -144,41 +140,108 @@ func (s *ServiceS3) newClient() (*minio.Client, error) {
 	return client, nil
 }
 
-// newPublicClient builds the client used for presigned URL generation.
+// publicEndpoint resolves the browser-facing host used to sign presigned
+// PUT/GET URLs, and reports the bucket-addressing style the SDK should
+// use to reach it. Mirrors ServiceCOS.publicEndpoint — SigV4 covers
+// `host` and the canonical URI, so the host we sign against must
+// equal the host the browser will hit. Any post-sign rewrite breaks
+// the signature.
 //
-// If cfg.S3.BucketURL is set and parseable, sign against that host so
-// the URL the browser sees has the same `host` covered by SigV4 — any
-// post-sign host rewrite would invalidate the signature. This is the
-// same hazard ServiceMinio / ServiceCOS close at their respective
-// `newPublicClient` paths.
+// Resolution rules:
 //
-// If BucketURL is empty, sign against cfg.S3.Endpoint — fine for direct
-// S3 deployments where the browser hits the same host the server does.
-func (s *ServiceS3) newPublicClient() (*minio.Client, error) {
+//  1. cfg.S3.BucketURL is empty — fall back to cfg.S3.Endpoint with
+//     the lookup style chosen by cfg.S3.UsePathStyle.
+//
+//  2. BucketURL host begins with "<bucket>." (canonical bucket-subdomain
+//     shape, e.g. `https://my-bucket.s3.us-west-2.amazonaws.com` or
+//     `https://my-bucket.cdn.example.com`). The bucket already lives
+//     in the host, so we strip "<bucket>." before handing the parent
+//     host to the SDK and use BucketLookupDNS; the SDK re-attaches
+//     "<bucket>." and the resulting signed URL equals BucketURL+key.
+//
+//  3. BucketURL host has no "<bucket>." prefix (CDN alias / accelerator,
+//     e.g. `https://files.example.com`). The CDN routes to the bucket
+//     by some out-of-band rule (origin alias, path mapping, ...).
+//     The SDK signs against the host as-is with BucketLookupPath and
+//     emits `<host>/<bucket>/<key>`. This deliberately produces a URL
+//     shape that differs from publicURL (which returns
+//     `<BucketURL>/<key>` without a bucket segment) — operators
+//     fronting the bucket with a CDN must route both shapes; see the
+//     yaml docs for the deployment recipe.
+//
+// `host` is the bare host[:port] suitable for minio.New (no scheme,
+// no path). `secure` reflects the URL scheme — http:// flips it false
+// for the rare local-emulator-on-CDN case (the file-level "HTTPS only"
+// framing applies to cfg.S3.Endpoint; BucketURL is operator-owned
+// infrastructure and treated as such). `lookup` is the SDK addressing
+// style: DNS for shapes 1 & 2, Path for shape 3.
+func (s *ServiceS3) publicEndpoint() (host string, secure bool, lookup minio.BucketLookupType, err error) {
 	cfg := s.ctx.GetConfig().S3
 	base := strings.TrimSpace(cfg.BucketURL)
 	if base == "" {
-		return s.newClient()
+		ep := strings.TrimSpace(cfg.Endpoint)
+		ep = strings.TrimPrefix(ep, "https://")
+		ep = strings.TrimPrefix(ep, "http://")
+		ep = strings.TrimRight(ep, "/")
+		return ep, true, s.bucketLookup(), nil
 	}
-	parsed, err := url.Parse(strings.TrimRight(base, "/"))
-	if err != nil || parsed == nil || parsed.Host == "" {
+	parsed, parseErr := url.Parse(strings.TrimRight(base, "/"))
+	if parseErr != nil || parsed == nil || parsed.Host == "" {
 		s.Warn("s3.bucketURL 解析失败，预签名URL退回到 s3.endpoint",
 			zap.String("bucketURL", base))
-		return s.newClient()
+		ep := strings.TrimSpace(cfg.Endpoint)
+		ep = strings.TrimPrefix(ep, "https://")
+		ep = strings.TrimPrefix(ep, "http://")
+		ep = strings.TrimRight(ep, "/")
+		return ep, true, s.bucketLookup(), nil
 	}
 	if parsed.Path != "" && parsed.Path != "/" {
 		// SigV4 covers the canonical URI; a path component on BucketURL
 		// would be stripped before signing and produce
 		// SignatureDoesNotMatch at the browser. Reject loudly rather
 		// than silently dropping the path.
-		return nil, fmt.Errorf("s3.bucketURL 不可包含路径前缀（%q），仅支持 scheme://host[:port] 形式", base)
+		return "", false, 0, fmt.Errorf("s3.bucketURL 不可包含路径前缀（%q），仅支持 scheme://host[:port] 形式", base)
 	}
-	secure := !strings.EqualFold(parsed.Scheme, "http")
-	client, err := minio.New(parsed.Host, &minio.Options{
+	secure = !strings.EqualFold(parsed.Scheme, "http")
+	h := parsed.Host
+	if cfg.Bucket != "" {
+		bucketPrefix := cfg.Bucket + "."
+		if strings.HasPrefix(h, bucketPrefix) {
+			// Bucket-subdomain shape: strip "<bucket>." so the SDK with
+			// BucketLookupDNS can re-attach it without producing
+			// "<bucket>.<bucket>.<parent>".
+			parent := strings.TrimPrefix(h, bucketPrefix)
+			if parent == "" {
+				s.Warn("s3.bucketURL 仅包含 bucket 子域，无父域可签名，回退到 s3.endpoint",
+					zap.String("bucketURL", base))
+				ep := strings.TrimSpace(cfg.Endpoint)
+				ep = strings.TrimPrefix(ep, "https://")
+				ep = strings.TrimPrefix(ep, "http://")
+				ep = strings.TrimRight(ep, "/")
+				return ep, true, s.bucketLookup(), nil
+			}
+			return parent, secure, minio.BucketLookupDNS, nil
+		}
+	}
+	// CDN alias / accelerator: no "<bucket>." prefix. Sign against the
+	// host directly with path-style addressing.
+	return h, secure, minio.BucketLookupPath, nil
+}
+
+// newPublicClient builds the client used for presigned URL generation.
+// Routes through publicEndpoint so the signed URL's host matches the
+// host the browser will hit; otherwise SigV4 rejects at validation.
+func (s *ServiceS3) newPublicClient() (*minio.Client, error) {
+	cfg := s.ctx.GetConfig().S3
+	host, secure, lookup, err := s.publicEndpoint()
+	if err != nil {
+		return nil, err
+	}
+	client, err := minio.New(host, &minio.Options{
 		Creds:        credentials.NewStaticV4(cfg.AccessKeyID, cfg.SecretAccessKey, ""),
 		Secure:       secure,
 		Region:       strings.TrimSpace(cfg.Region),
-		BucketLookup: s.bucketLookup(),
+		BucketLookup: lookup,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("创建S3公网客户端失败: %w", err)

--- a/modules/file/service_s3.go
+++ b/modules/file/service_s3.go
@@ -36,25 +36,26 @@ import (
 //   - ServiceCOS bakes in cos.<region>.myqcloud.com endpoint templating
 //     plus a CDN-alias-vs-canonical client switch for path-style CDN
 //     fronts. ServiceS3 takes the endpoint verbatim from cfg.S3.Endpoint
-//     and supports UsePathStyle as an explicit operator opt-in instead
-//     of detecting it from BucketURL shape.
+//     and supports UsePathStyle as an explicit operator opt-in.
 //
-// Connection model: cfg.S3.Endpoint always uses HTTPS by design. The
-// optional cfg.S3.BucketURL is operator-owned infrastructure and DOES
-// honor `http://` for local emulators; see publicEndpoint and the yaml
-// example for the rationale.
+// Signing model: presigned PUT/GET URLs always sign against cfg.S3.Endpoint.
+// cfg.S3.DownloadURL is the browser-facing prefix for UNSIGNED URLs only
+// (preview redirects, upload response path) — it never participates in
+// SigV4. This deliberate separation removes the previous host-shape
+// detection on BucketURL and aligns with the octo-lib S3Config contract
+// (see config.S3Config.DownloadURL godoc).
 type ServiceS3 struct {
 	log.Log
 	ctx *config.Context
 }
 
 // NewServiceS3 constructs a ServiceS3 from the active config. Required
-// fields (Endpoint, Region, Bucket) are NOT validated here — the
-// constructor returns a usable struct even when fields are missing so
-// the process can start (matching the existing ServiceMinio / ServiceCOS
-// constructors), and per-request errors surface the missing configuration
-// at the first call site. Operators should treat
-// "S3 配置缺失" log lines as a startup failure.
+// fields (Endpoint, Region, Bucket, AccessKeyID, SecretAccessKey) are
+// NOT validated here — the constructor returns a usable struct even when
+// fields are missing so the process can start (matching the existing
+// ServiceMinio / ServiceCOS constructors), and per-request errors
+// surface the missing configuration at the first call site. Operators
+// should treat "S3 配置缺失" log lines as a startup failure.
 func NewServiceS3(ctx *config.Context) *ServiceS3 {
 	return &ServiceS3{
 		Log: log.NewTLog("FileS3"),
@@ -62,12 +63,12 @@ func NewServiceS3(ctx *config.Context) *ServiceS3 {
 	}
 }
 
-// validateConfig fails the request loudly when any of the three required
-// fields is missing, rather than letting the SDK surface an opaque
+// validateConfig fails the request loudly when any required field is
+// missing, rather than letting the SDK surface an opaque
 // "endpoint cannot be empty" or signing-with-empty-key error.
 func (s *ServiceS3) validateConfig() error {
 	cfg := s.ctx.GetConfig().S3
-	missing := make([]string, 0, 3)
+	missing := make([]string, 0, 5)
 	if strings.TrimSpace(cfg.Endpoint) == "" {
 		missing = append(missing, "s3.endpoint")
 	}
@@ -76,6 +77,12 @@ func (s *ServiceS3) validateConfig() error {
 	}
 	if strings.TrimSpace(cfg.Bucket) == "" {
 		missing = append(missing, "s3.bucket")
+	}
+	if strings.TrimSpace(cfg.AccessKeyID) == "" {
+		missing = append(missing, "s3.accessKeyID")
+	}
+	if strings.TrimSpace(cfg.SecretAccessKey) == "" {
+		missing = append(missing, "s3.secretAccessKey")
 	}
 	if len(missing) > 0 {
 		return fmt.Errorf("S3 配置缺失: %s 必须设置", strings.Join(missing, ", "))
@@ -112,9 +119,18 @@ func (s *ServiceS3) bucketLookup() minio.BucketLookupType {
 	return minio.BucketLookupDNS
 }
 
-// newClient builds a SigV4-signing minio-go client against cfg.S3.Endpoint.
+// newClient builds the single SigV4-signing minio-go client used for all
+// I/O against this backend: server-side uploads/downloads AND presigned
+// PUT/GET signing. The client always targets cfg.S3.Endpoint; cfg.S3.
+// DownloadURL is deliberately out of scope here (see file-level doc).
+//
+// SessionToken is forwarded when present, enabling STS / IRSA / IMDSv2 /
+// EKS Pod Identity workflows that issue rotating credentials. The token
+// is opaque to ServiceS3 — the deployment pipeline owns refreshing it
+// before STS expiry (see octo-lib S3Config.SessionToken godoc).
+//
 // Region is set explicitly so the SDK skips the GetBucketLocation
-// preflight on first use (same rationale as ServiceCOS.newCanonicalPresignClient).
+// preflight on first use.
 //
 // HTTPS is hard-coded — see the file-level comment for the rationale.
 func (s *ServiceS3) newClient() (*minio.Client, error) {
@@ -129,122 +145,13 @@ func (s *ServiceS3) newClient() (*minio.Client, error) {
 	endpoint = strings.TrimPrefix(endpoint, "http://")
 	endpoint = strings.TrimRight(endpoint, "/")
 	client, err := minio.New(endpoint, &minio.Options{
-		Creds:        credentials.NewStaticV4(cfg.AccessKeyID, cfg.SecretAccessKey, ""),
+		Creds:        credentials.NewStaticV4(cfg.AccessKeyID, cfg.SecretAccessKey, cfg.SessionToken),
 		Secure:       true,
 		Region:       strings.TrimSpace(cfg.Region),
 		BucketLookup: s.bucketLookup(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("创建S3客户端失败: %w", err)
-	}
-	return client, nil
-}
-
-// publicEndpoint resolves the browser-facing host used to sign presigned
-// PUT/GET URLs, and reports the bucket-addressing style the SDK should
-// use to reach it. Mirrors ServiceCOS.publicEndpoint — SigV4 covers
-// `host` and the canonical URI, so the host we sign against must
-// equal the host the browser will hit. Any post-sign rewrite breaks
-// the signature.
-//
-// Resolution rules:
-//
-//  1. cfg.S3.BucketURL is empty — fall back to cfg.S3.Endpoint with
-//     the lookup style chosen by cfg.S3.UsePathStyle.
-//
-//  2. BucketURL host begins with "<bucket>." (canonical bucket-subdomain
-//     shape, e.g. `https://my-bucket.s3.us-west-2.amazonaws.com` or
-//     `https://my-bucket.cdn.example.com`). The bucket already lives
-//     in the host, so we strip "<bucket>." before handing the parent
-//     host to the SDK and use BucketLookupDNS; the SDK re-attaches
-//     "<bucket>." and the resulting signed URL equals BucketURL+key.
-//
-//  3. BucketURL host has no "<bucket>." prefix (CDN alias / accelerator,
-//     e.g. `https://files.example.com`). The CDN routes to the bucket
-//     by some out-of-band rule (origin alias, path mapping, ...).
-//     The SDK signs against the host as-is with BucketLookupPath and
-//     emits `<host>/<bucket>/<key>`. This deliberately produces a URL
-//     shape that differs from publicURL (which returns
-//     `<BucketURL>/<key>` without a bucket segment) — operators
-//     fronting the bucket with a CDN must route both shapes; see the
-//     yaml docs for the deployment recipe.
-//
-// `host` is the bare host[:port] suitable for minio.New (no scheme,
-// no path). `secure` reflects the URL scheme — http:// flips it false
-// for the rare local-emulator-on-CDN case (the file-level "HTTPS only"
-// framing applies to cfg.S3.Endpoint; BucketURL is operator-owned
-// infrastructure and treated as such). `lookup` is the SDK addressing
-// style: DNS for shapes 1 & 2, Path for shape 3.
-func (s *ServiceS3) publicEndpoint() (host string, secure bool, lookup minio.BucketLookupType, err error) {
-	cfg := s.ctx.GetConfig().S3
-	base := strings.TrimSpace(cfg.BucketURL)
-	if base == "" {
-		ep := strings.TrimSpace(cfg.Endpoint)
-		ep = strings.TrimPrefix(ep, "https://")
-		ep = strings.TrimPrefix(ep, "http://")
-		ep = strings.TrimRight(ep, "/")
-		return ep, true, s.bucketLookup(), nil
-	}
-	parsed, parseErr := url.Parse(strings.TrimRight(base, "/"))
-	if parseErr != nil || parsed == nil || parsed.Host == "" {
-		s.Warn("s3.bucketURL 解析失败，预签名URL退回到 s3.endpoint",
-			zap.String("bucketURL", base))
-		ep := strings.TrimSpace(cfg.Endpoint)
-		ep = strings.TrimPrefix(ep, "https://")
-		ep = strings.TrimPrefix(ep, "http://")
-		ep = strings.TrimRight(ep, "/")
-		return ep, true, s.bucketLookup(), nil
-	}
-	if parsed.Path != "" && parsed.Path != "/" {
-		// SigV4 covers the canonical URI; a path component on BucketURL
-		// would be stripped before signing and produce
-		// SignatureDoesNotMatch at the browser. Reject loudly rather
-		// than silently dropping the path.
-		return "", false, 0, fmt.Errorf("s3.bucketURL 不可包含路径前缀（%q），仅支持 scheme://host[:port] 形式", base)
-	}
-	secure = !strings.EqualFold(parsed.Scheme, "http")
-	h := parsed.Host
-	if cfg.Bucket != "" {
-		bucketPrefix := cfg.Bucket + "."
-		if strings.HasPrefix(h, bucketPrefix) {
-			// Bucket-subdomain shape: strip "<bucket>." so the SDK with
-			// BucketLookupDNS can re-attach it without producing
-			// "<bucket>.<bucket>.<parent>".
-			parent := strings.TrimPrefix(h, bucketPrefix)
-			if parent == "" {
-				s.Warn("s3.bucketURL 仅包含 bucket 子域，无父域可签名，回退到 s3.endpoint",
-					zap.String("bucketURL", base))
-				ep := strings.TrimSpace(cfg.Endpoint)
-				ep = strings.TrimPrefix(ep, "https://")
-				ep = strings.TrimPrefix(ep, "http://")
-				ep = strings.TrimRight(ep, "/")
-				return ep, true, s.bucketLookup(), nil
-			}
-			return parent, secure, minio.BucketLookupDNS, nil
-		}
-	}
-	// CDN alias / accelerator: no "<bucket>." prefix. Sign against the
-	// host directly with path-style addressing.
-	return h, secure, minio.BucketLookupPath, nil
-}
-
-// newPublicClient builds the client used for presigned URL generation.
-// Routes through publicEndpoint so the signed URL's host matches the
-// host the browser will hit; otherwise SigV4 rejects at validation.
-func (s *ServiceS3) newPublicClient() (*minio.Client, error) {
-	cfg := s.ctx.GetConfig().S3
-	host, secure, lookup, err := s.publicEndpoint()
-	if err != nil {
-		return nil, err
-	}
-	client, err := minio.New(host, &minio.Options{
-		Creds:        credentials.NewStaticV4(cfg.AccessKeyID, cfg.SecretAccessKey, ""),
-		Secure:       secure,
-		Region:       strings.TrimSpace(cfg.Region),
-		BucketLookup: lookup,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("创建S3公网客户端失败: %w", err)
 	}
 	return client, nil
 }
@@ -328,15 +235,20 @@ func (s *ServiceS3) DownloadURL(ph string, filename string) (string, error) {
 	return s.publicURL(ph), nil
 }
 
-// publicURL constructs the public-shape URL for an object. If BucketURL
-// is set it wins (typical CDN front-door scenario). Otherwise we build
-// a virtual-hosted URL against cfg.S3.Endpoint — works for AWS S3 and
-// any provider whose endpoint accepts <bucket>.<endpoint> DNS.
+// publicURL constructs the unsigned, browser-facing URL for an object.
+// cfg.S3.DownloadURL wins when set (typical CloudFront / CDN front-door
+// or custom-domain scenario). Otherwise we build a virtual-hosted URL
+// against cfg.S3.Endpoint — works for AWS S3 and any provider whose
+// endpoint accepts <bucket>.<endpoint> DNS; with UsePathStyle the URL
+// flips to <endpoint>/<bucket>/<key>.
+//
+// cfg.S3.DownloadURL is NEVER used for SigV4 signing — that responsibility
+// belongs to newClient against cfg.S3.Endpoint.
 func (s *ServiceS3) publicURL(objectPath string) string {
 	cfg := s.ctx.GetConfig().S3
 	key := s.withPrefix(objectPath)
 
-	base := strings.TrimRight(strings.TrimSpace(cfg.BucketURL), "/")
+	base := strings.TrimRight(strings.TrimSpace(cfg.DownloadURL), "/")
 	if base != "" {
 		result, _ := url.JoinPath(base, key)
 		return result
@@ -363,6 +275,10 @@ func (s *ServiceS3) publicURL(objectPath string) string {
 // MaxFileSize on the presigned path — same model as ServiceMinio /
 // ServiceCOS, see modules/file/api.go getUploadCredentials for the full
 // signed-header contract returned to clients.
+//
+// Signing host is always cfg.S3.Endpoint; cfg.S3.DownloadURL has no
+// influence on the signed URL. The returned downloadURL (unsigned) is
+// constructed via publicURL and may carry the DownloadURL prefix.
 func (s *ServiceS3) PresignedPutURL(objectPath string, contentType string, contentDisposition string, fileSize int64, expires time.Duration) (uploadURL string, downloadURL string, err error) {
 	if fileSize <= 0 {
 		return "", "", errors.New("预签名上传必须提供正向的 fileSize（字节数），用于在签名中固定 Content-Length")
@@ -371,7 +287,7 @@ func (s *ServiceS3) PresignedPutURL(objectPath string, contentType string, conte
 		return "", "", err
 	}
 
-	client, err := s.newPublicClient()
+	client, err := s.newClient()
 	if err != nil {
 		return "", "", err
 	}
@@ -408,12 +324,13 @@ func (s *ServiceS3) PresignedPutURL(objectPath string, contentType string, conte
 
 // PresignedGetURL signs a GET URL with a Content-Disposition override so
 // the browser downloads with the operator-supplied filename instead of
-// the raw object key.
+// the raw object key. Signing host is always cfg.S3.Endpoint (see
+// file-level doc).
 func (s *ServiceS3) PresignedGetURL(objectPath string, filename string, disposition string, expires time.Duration) (string, error) {
 	if err := s.validateConfig(); err != nil {
 		return "", err
 	}
-	client, err := s.newPublicClient()
+	client, err := s.newClient()
 	if err != nil {
 		return "", err
 	}

--- a/modules/file/service_s3.go
+++ b/modules/file/service_s3.go
@@ -1,0 +1,381 @@
+package file
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"go.uber.org/zap"
+)
+
+// ServiceS3 implements a single-bucket S3 / S3-compatible storage backend.
+//
+// Targets AWS S3 and any vendor that speaks the S3 protocol with SigV4
+// (Cloudflare R2, Backblaze B2, Wasabi, MinIO with a custom endpoint, ...).
+// Configuration comes from cfg.S3 — see octo-lib config.S3Config for the
+// field semantics and Viper bindings.
+//
+// Design contrast with ServiceMinio / ServiceCOS:
+//
+//   - ServiceMinio routes by path prefix into N buckets and pins
+//     Region: us-east-1. ServiceS3 uses a single bucket from cfg.S3.Bucket
+//     and the explicit cfg.S3.Region; the upload type segment ("chat/",
+//     "moment/", ...) becomes part of the object key inside that one bucket.
+//   - ServiceCOS bakes in cos.<region>.myqcloud.com endpoint templating
+//     plus a CDN-alias-vs-canonical client switch for path-style CDN
+//     fronts. ServiceS3 takes the endpoint verbatim from cfg.S3.Endpoint
+//     and supports UsePathStyle as an explicit operator opt-in instead
+//     of detecting it from BucketURL shape.
+//
+// Connection model: HTTPS only. Operators who need plain HTTP (local
+// MinIO emulator, development with self-signed cert) should keep using
+// the existing minio backend — adding TLS opt-out here would compromise
+// the "production-grade S3" framing and is intentionally out of scope.
+type ServiceS3 struct {
+	log.Log
+	ctx            *config.Context
+	downloadClient *http.Client
+}
+
+// NewServiceS3 constructs a ServiceS3 from the active config. Required
+// fields (Endpoint, Region, Bucket) are NOT validated here — the
+// constructor returns a usable struct even when fields are missing so
+// the process can start (matching the existing ServiceMinio / ServiceCOS
+// constructors), and per-request errors surface the missing configuration
+// at the first call site. Operators should treat
+// "S3 配置缺失" log lines as a startup failure.
+func NewServiceS3(ctx *config.Context) *ServiceS3 {
+	return &ServiceS3{
+		Log: log.NewTLog("FileS3"),
+		ctx: ctx,
+		downloadClient: &http.Client{
+			Timeout: time.Second * 30,
+		},
+	}
+}
+
+// validateConfig fails the request loudly when any of the three required
+// fields is missing, rather than letting the SDK surface an opaque
+// "endpoint cannot be empty" or signing-with-empty-key error.
+func (s *ServiceS3) validateConfig() error {
+	cfg := s.ctx.GetConfig().S3
+	missing := make([]string, 0, 3)
+	if strings.TrimSpace(cfg.Endpoint) == "" {
+		missing = append(missing, "s3.endpoint")
+	}
+	if strings.TrimSpace(cfg.Region) == "" {
+		missing = append(missing, "s3.region")
+	}
+	if strings.TrimSpace(cfg.Bucket) == "" {
+		missing = append(missing, "s3.bucket")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("S3 配置缺失: %s 必须设置", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+// withPrefix joins cfg.S3.Prefix in front of objectPath when set. Mirrors
+// ServiceCOS.withPrefix so the multi-environment-shared-bucket layout
+// works identically across S3 and COS deployments.
+func (s *ServiceS3) withPrefix(objectPath string) string {
+	prefix := strings.TrimSpace(s.ctx.GetConfig().S3.Prefix)
+	if prefix == "" {
+		return objectPath
+	}
+	return path.Join(prefix, objectPath)
+}
+
+// bucketLookup translates cfg.S3.UsePathStyle to a minio-go addressing
+// style. Default is BucketLookupDNS (virtual-hosted, the S3 modern
+// default that works on AWS S3, R2, B2, Wasabi); UsePathStyle=true
+// forces path-style for gateways that only accept that shape.
+//
+// We pick BucketLookupDNS instead of BucketLookupAuto so the signed
+// URL host matches what the operator typed in cfg.S3.Endpoint
+// verbatim — BucketLookupAuto rewrites AWS hostnames to their
+// dual-stack equivalent (s3.dualstack.<region>.amazonaws.com) which
+// surprises operators who configured a strict allow-list against the
+// non-dual-stack hostname.
+func (s *ServiceS3) bucketLookup() minio.BucketLookupType {
+	if s.ctx.GetConfig().S3.UsePathStyle {
+		return minio.BucketLookupPath
+	}
+	return minio.BucketLookupDNS
+}
+
+// newClient builds a SigV4-signing minio-go client against cfg.S3.Endpoint.
+// Region is set explicitly so the SDK skips the GetBucketLocation
+// preflight on first use (same rationale as ServiceCOS.newCanonicalPresignClient).
+//
+// HTTPS is hard-coded — see the file-level comment for the rationale.
+func (s *ServiceS3) newClient() (*minio.Client, error) {
+	cfg := s.ctx.GetConfig().S3
+	endpoint := strings.TrimSpace(cfg.Endpoint)
+	// Strip an accidental scheme so operators who paste a full URL into
+	// the yaml don't get a confusing "endpoint cannot contain scheme"
+	// error from the SDK. The S3Config godoc says "hostname, without
+	// scheme" but tolerating both shapes is cheap and matches operator
+	// muscle memory from the minio/COS blocks.
+	endpoint = strings.TrimPrefix(endpoint, "https://")
+	endpoint = strings.TrimPrefix(endpoint, "http://")
+	endpoint = strings.TrimRight(endpoint, "/")
+	client, err := minio.New(endpoint, &minio.Options{
+		Creds:        credentials.NewStaticV4(cfg.AccessKeyID, cfg.SecretAccessKey, ""),
+		Secure:       true,
+		Region:       strings.TrimSpace(cfg.Region),
+		BucketLookup: s.bucketLookup(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("创建S3客户端失败: %w", err)
+	}
+	return client, nil
+}
+
+// newPublicClient builds the client used for presigned URL generation.
+//
+// If cfg.S3.BucketURL is set and parseable, sign against that host so
+// the URL the browser sees has the same `host` covered by SigV4 — any
+// post-sign host rewrite would invalidate the signature. This is the
+// same hazard ServiceMinio / ServiceCOS close at their respective
+// `newPublicClient` paths.
+//
+// If BucketURL is empty, sign against cfg.S3.Endpoint — fine for direct
+// S3 deployments where the browser hits the same host the server does.
+func (s *ServiceS3) newPublicClient() (*minio.Client, error) {
+	cfg := s.ctx.GetConfig().S3
+	base := strings.TrimSpace(cfg.BucketURL)
+	if base == "" {
+		return s.newClient()
+	}
+	parsed, err := url.Parse(strings.TrimRight(base, "/"))
+	if err != nil || parsed == nil || parsed.Host == "" {
+		s.Warn("s3.bucketURL 解析失败，预签名URL退回到 s3.endpoint",
+			zap.String("bucketURL", base))
+		return s.newClient()
+	}
+	if parsed.Path != "" && parsed.Path != "/" {
+		// SigV4 covers the canonical URI; a path component on BucketURL
+		// would be stripped before signing and produce
+		// SignatureDoesNotMatch at the browser. Reject loudly rather
+		// than silently dropping the path.
+		return nil, fmt.Errorf("s3.bucketURL 不可包含路径前缀（%q），仅支持 scheme://host[:port] 形式", base)
+	}
+	secure := !strings.EqualFold(parsed.Scheme, "http")
+	client, err := minio.New(parsed.Host, &minio.Options{
+		Creds:        credentials.NewStaticV4(cfg.AccessKeyID, cfg.SecretAccessKey, ""),
+		Secure:       secure,
+		Region:       strings.TrimSpace(cfg.Region),
+		BucketLookup: s.bucketLookup(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("创建S3公网客户端失败: %w", err)
+	}
+	return client, nil
+}
+
+// UploadFile streams a single object into the configured S3 bucket.
+// The full filePath (e.g. "chat/2026/foo.jpg") becomes the object key
+// after the optional cfg.S3.Prefix is prepended; the single-bucket
+// model means the file-type segment lives in the key, not the bucket.
+func (s *ServiceS3) UploadFile(filePath string, contentType string, contentDisposition string, copyFileWriter func(io.Writer) error) (map[string]interface{}, error) {
+	if err := s.validateConfig(); err != nil {
+		return nil, err
+	}
+	buff := bytes.NewBuffer(make([]byte, 0))
+	if err := copyFileWriter(buff); err != nil {
+		s.Error("复制文件内容失败！", zap.Error(err))
+		return nil, err
+	}
+
+	cfg := s.ctx.GetConfig().S3
+	client, err := s.newClient()
+	if err != nil {
+		return nil, err
+	}
+
+	key := s.withPrefix(filePath)
+	opts := minio.PutObjectOptions{
+		ContentType: contentType,
+		PartSize:    10 * 1024 * 1024,
+	}
+	if contentDisposition != "" {
+		opts.ContentDisposition = contentDisposition
+	}
+
+	ctx := context.Background()
+	info, err := client.PutObject(ctx, cfg.Bucket, key, buff, int64(buff.Len()), opts)
+	if err != nil {
+		s.Error("上传文件到S3失败", zap.Error(err))
+		return map[string]interface{}{"path": ""}, err
+	}
+	return map[string]interface{}{"path": info.Key}, nil
+}
+
+// GetFile fetches the object body for server-side handlers that need to
+// proxy the file (e.g. legacy /v1/file/preview path). Buckets with
+// Block Public Access turned on are still readable here because the SDK
+// signs each request.
+func (s *ServiceS3) GetFile(ph string) (io.ReadCloser, string, error) {
+	if err := s.validateConfig(); err != nil {
+		return nil, "", err
+	}
+	client, err := s.newClient()
+	if err != nil {
+		return nil, "", err
+	}
+
+	cfg := s.ctx.GetConfig().S3
+	key := s.withPrefix(ph)
+	obj, err := client.GetObject(context.Background(), cfg.Bucket, key, minio.GetObjectOptions{})
+	if err != nil {
+		return nil, "", err
+	}
+	stat, err := obj.Stat()
+	if err != nil {
+		obj.Close()
+		return nil, "", err
+	}
+	return obj, stat.ContentType, nil
+}
+
+// DownloadURL returns a browser-facing URL for the object. This is the
+// *unsigned* URL — useful only when the bucket allows anonymous GET, or
+// when fronted by a CDN that handles auth out-of-band. For private
+// buckets (the AWS default with Block Public Access on), callers
+// should use PresignedGetURL instead; modules/file/api.go's getFile
+// handler redirects through DownloadURL but the public API also
+// exposes /v1/file/download/url that goes through PresignedGetURL.
+func (s *ServiceS3) DownloadURL(ph string, filename string) (string, error) {
+	if err := s.validateConfig(); err != nil {
+		return "", err
+	}
+	return s.publicURL(ph), nil
+}
+
+// publicURL constructs the public-shape URL for an object. If BucketURL
+// is set it wins (typical CDN front-door scenario). Otherwise we build
+// a virtual-hosted URL against cfg.S3.Endpoint — works for AWS S3 and
+// any provider whose endpoint accepts <bucket>.<endpoint> DNS.
+func (s *ServiceS3) publicURL(objectPath string) string {
+	cfg := s.ctx.GetConfig().S3
+	key := s.withPrefix(objectPath)
+
+	base := strings.TrimRight(strings.TrimSpace(cfg.BucketURL), "/")
+	if base != "" {
+		result, _ := url.JoinPath(base, key)
+		return result
+	}
+
+	endpoint := strings.TrimSpace(cfg.Endpoint)
+	endpoint = strings.TrimPrefix(endpoint, "https://")
+	endpoint = strings.TrimPrefix(endpoint, "http://")
+	endpoint = strings.TrimRight(endpoint, "/")
+
+	if cfg.UsePathStyle {
+		result, _ := url.JoinPath(fmt.Sprintf("https://%s", endpoint), cfg.Bucket, key)
+		return result
+	}
+	// Virtual-hosted style: <bucket>.<endpoint>/<key>
+	result, _ := url.JoinPath(fmt.Sprintf("https://%s.%s", cfg.Bucket, endpoint), key)
+	return result
+}
+
+// PresignedPutURL signs a direct-to-storage PUT URL. fileSize is signed
+// into the canonical-headers section as Content-Length; any deviation
+// the browser sends is rejected by the gateway with
+// 403 SignatureDoesNotMatch. This is the server-side enforcement of
+// MaxFileSize on the presigned path — same model as ServiceMinio /
+// ServiceCOS, see modules/file/api.go getUploadCredentials for the full
+// signed-header contract returned to clients.
+func (s *ServiceS3) PresignedPutURL(objectPath string, contentType string, contentDisposition string, fileSize int64, expires time.Duration) (uploadURL string, downloadURL string, err error) {
+	if fileSize <= 0 {
+		return "", "", errors.New("预签名上传必须提供正向的 fileSize（字节数），用于在签名中固定 Content-Length")
+	}
+	if err := s.validateConfig(); err != nil {
+		return "", "", err
+	}
+
+	client, err := s.newPublicClient()
+	if err != nil {
+		return "", "", err
+	}
+
+	cfg := s.ctx.GetConfig().S3
+	key := s.withPrefix(objectPath)
+	if err := validatePresignObjectKey(key); err != nil {
+		return "", "", err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	headers := http.Header{}
+	headers.Set("Content-Length", strconv.FormatInt(fileSize, 10))
+	if contentType != "" {
+		headers.Set("Content-Type", contentType)
+	}
+	if contentDisposition != "" {
+		headers.Set("Content-Disposition", contentDisposition)
+	}
+	presigned, err := client.PresignHeader(ctx, http.MethodPut, cfg.Bucket, key, expires, nil, headers)
+	if err != nil {
+		return "", "", fmt.Errorf("生成预签名URL失败: %w", err)
+	}
+	uploadURL = presigned.String()
+
+	dl, dlErr := s.DownloadURL(objectPath, "")
+	if dlErr != nil {
+		s.Warn("生成下载URL失败", zap.Error(dlErr))
+	}
+	return uploadURL, dl, nil
+}
+
+// PresignedGetURL signs a GET URL with a Content-Disposition override so
+// the browser downloads with the operator-supplied filename instead of
+// the raw object key.
+func (s *ServiceS3) PresignedGetURL(objectPath string, filename string, disposition string, expires time.Duration) (string, error) {
+	if err := s.validateConfig(); err != nil {
+		return "", err
+	}
+	client, err := s.newPublicClient()
+	if err != nil {
+		return "", err
+	}
+
+	cfg := s.ctx.GetConfig().S3
+	key := s.withPrefix(objectPath)
+	if err := validatePresignObjectKey(key); err != nil {
+		return "", err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if disposition != "inline" {
+		disposition = "attachment"
+	}
+	params := url.Values{}
+	if filename != "" {
+		encodedFilename := "UTF-8''" + rfc5987Encode(filename)
+		params.Set("response-content-disposition", fmt.Sprintf("%s; filename*=%s", disposition, encodedFilename))
+	}
+
+	presigned, err := client.PresignHeader(ctx, http.MethodGet, cfg.Bucket, key, expires, params, nil)
+	if err != nil {
+		return "", fmt.Errorf("生成预签名GET URL失败: %w", err)
+	}
+	return presigned.String(), nil
+}

--- a/modules/file/service_s3_aws_integration_test.go
+++ b/modules/file/service_s3_aws_integration_test.go
@@ -1,0 +1,326 @@
+package file_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/file"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// requireAWSS3Env collects the env vars driving the live-AWS integration
+// test. If any required variable is missing the test skips with a
+// pointer to the README — keeps the suite green on CI runners without
+// credentials and on contributor laptops.
+//
+// Required env vars (mirror cfg.S3 fields):
+//
+//	TS_S3_TEST_ENDPOINT          e.g. s3.us-west-2.amazonaws.com
+//	TS_S3_TEST_REGION            e.g. us-west-2
+//	TS_S3_TEST_BUCKET            pre-existing bucket the test can write to
+//	TS_S3_TEST_ACCESS_KEY_ID
+//	TS_S3_TEST_SECRET_ACCESS_KEY
+//
+// Optional:
+//
+//	TS_S3_TEST_BUCKET_URL        BucketURL override (CDN front, custom domain)
+//	TS_S3_TEST_USE_PATH_STYLE    "true" to force path-style addressing
+type awsS3TestEnv struct {
+	Endpoint        string
+	Region          string
+	Bucket          string
+	AccessKeyID     string
+	SecretAccessKey string
+	BucketURL       string
+	UsePathStyle    bool
+}
+
+func requireAWSS3Env(t *testing.T) awsS3TestEnv {
+	t.Helper()
+	env := awsS3TestEnv{
+		Endpoint:        os.Getenv("TS_S3_TEST_ENDPOINT"),
+		Region:          os.Getenv("TS_S3_TEST_REGION"),
+		Bucket:          os.Getenv("TS_S3_TEST_BUCKET"),
+		AccessKeyID:     os.Getenv("TS_S3_TEST_ACCESS_KEY_ID"),
+		SecretAccessKey: os.Getenv("TS_S3_TEST_SECRET_ACCESS_KEY"),
+		BucketURL:       os.Getenv("TS_S3_TEST_BUCKET_URL"),
+		UsePathStyle:    strings.EqualFold(os.Getenv("TS_S3_TEST_USE_PATH_STYLE"), "true"),
+	}
+	missing := make([]string, 0, 5)
+	if env.Endpoint == "" {
+		missing = append(missing, "TS_S3_TEST_ENDPOINT")
+	}
+	if env.Region == "" {
+		missing = append(missing, "TS_S3_TEST_REGION")
+	}
+	if env.Bucket == "" {
+		missing = append(missing, "TS_S3_TEST_BUCKET")
+	}
+	if env.AccessKeyID == "" {
+		missing = append(missing, "TS_S3_TEST_ACCESS_KEY_ID")
+	}
+	if env.SecretAccessKey == "" {
+		missing = append(missing, "TS_S3_TEST_SECRET_ACCESS_KEY")
+	}
+	if len(missing) > 0 {
+		t.Skipf("AWS S3 integration test skipped; missing env vars: %s", strings.Join(missing, ", "))
+	}
+	return env
+}
+
+func newAWSS3TestService(t *testing.T, env awsS3TestEnv) (*file.ServiceS3, *config.Config) {
+	t.Helper()
+	cfg := config.New()
+	cfg.Test = true
+	cfg.S3.Endpoint = env.Endpoint
+	cfg.S3.Region = env.Region
+	cfg.S3.Bucket = env.Bucket
+	cfg.S3.AccessKeyID = env.AccessKeyID
+	cfg.S3.SecretAccessKey = env.SecretAccessKey
+	cfg.S3.BucketURL = env.BucketURL
+	cfg.S3.UsePathStyle = env.UsePathStyle
+	// Use a unique prefix per test run so concurrent runs (CI parallelism)
+	// and re-runs after partial failures don't collide.
+	cfg.S3.Prefix = "octo-integration-test/" + runID(t)
+	return file.NewServiceS3(testutil.NewTestContext(cfg)), cfg
+}
+
+func runID(t *testing.T) string {
+	t.Helper()
+	b := make([]byte, 6)
+	_, err := rand.Read(b)
+	require.NoError(t, err)
+	return time.Now().UTC().Format("20060102-150405-") + hex.EncodeToString(b)
+}
+
+// newAWSS3RawClient returns a minio-go client used for out-of-band
+// cleanup (RemoveObject). It deliberately mirrors ServiceS3.newClient
+// — drift here would mask test pollution, not hide a real bug.
+func newAWSS3RawClient(t *testing.T, env awsS3TestEnv) *minio.Client {
+	t.Helper()
+	endpoint := env.Endpoint
+	endpoint = strings.TrimPrefix(endpoint, "https://")
+	endpoint = strings.TrimPrefix(endpoint, "http://")
+	endpoint = strings.TrimRight(endpoint, "/")
+
+	lookup := minio.BucketLookupDNS
+	if env.UsePathStyle {
+		lookup = minio.BucketLookupPath
+	}
+	c, err := minio.New(endpoint, &minio.Options{
+		Creds:        credentials.NewStaticV4(env.AccessKeyID, env.SecretAccessKey, ""),
+		Secure:       true,
+		Region:       env.Region,
+		BucketLookup: lookup,
+	})
+	require.NoError(t, err)
+	return c
+}
+
+// TestAWSS3Integration_UploadDownloadRoundtrip covers the multipart-style
+// UploadFile path the server uses for /v1/file/upload, then verifies the
+// uploaded object is readable via GetFile and via the (unsigned)
+// DownloadURL when applicable.
+func TestAWSS3Integration_UploadDownloadRoundtrip(t *testing.T) {
+	env := requireAWSS3Env(t)
+	svc, cfg := newAWSS3TestService(t, env)
+	rawClient := newAWSS3RawClient(t, env)
+
+	payload := []byte("octo-integration-test payload\n")
+	relPath := "chat/2026/05/roundtrip.txt"
+	keyForCleanup := strings.TrimPrefix(cfg.S3.Prefix+"/"+relPath, "/")
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = rawClient.RemoveObject(ctx, env.Bucket, keyForCleanup, minio.RemoveObjectOptions{})
+	})
+
+	res, err := svc.UploadFile(relPath, "text/plain; charset=utf-8", "",
+		func(w io.Writer) error {
+			_, err := w.Write(payload)
+			return err
+		})
+	require.NoError(t, err)
+	require.NotEmpty(t, res["path"])
+
+	// GetFile (server-side proxy path) — body and content type must match.
+	body, ct, err := svc.GetFile(relPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = body.Close() })
+	gotBytes, err := io.ReadAll(body)
+	require.NoError(t, err)
+	assert.Equal(t, payload, gotBytes, "GetFile body must equal upload payload")
+	assert.Contains(t, ct, "text/plain",
+		"GetFile content type must echo upload content type, got %q", ct)
+}
+
+// TestAWSS3Integration_PresignedPUTRoundtrip drives the full browser
+// direct-upload flow end-to-end against real AWS:
+//
+//  1. Call PresignedPutURL — server emits the signed URL and the
+//     contract headers the client must echo.
+//  2. Perform the PUT exactly as a browser would, echoing
+//     Content-Type / Content-Length / Content-Disposition. AWS S3
+//     returns 200 only if the signature, the byte budget, and the
+//     header echo all match.
+//  3. Verify the object body via PresignedGetURL — the typical
+//     paired flow exposed at /v1/file/download/url.
+//
+// This is the regression test that catches signature-shape drift:
+// e.g. someone "fixes" Content-Length to be unsigned and the upload
+// silently accepts arbitrary-size payloads, bypassing MaxFileSize.
+func TestAWSS3Integration_PresignedPUTRoundtrip(t *testing.T) {
+	env := requireAWSS3Env(t)
+	svc, cfg := newAWSS3TestService(t, env)
+	rawClient := newAWSS3RawClient(t, env)
+
+	payload := []byte("octo-integration-test presigned PUT payload xyz\n")
+	relPath := "chat/2026/05/presigned.txt"
+	keyForCleanup := strings.TrimPrefix(cfg.S3.Prefix+"/"+relPath, "/")
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = rawClient.RemoveObject(ctx, env.Bucket, keyForCleanup, minio.RemoveObjectOptions{})
+	})
+
+	contentType := "text/plain; charset=utf-8"
+	contentDisposition := `inline; filename="presigned.txt"`
+	uploadURL, _, err := svc.PresignedPutURL(
+		relPath, contentType, contentDisposition, int64(len(payload)), 5*time.Minute,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, uploadURL)
+
+	doPresignedPUT(t, uploadURL, contentType, contentDisposition, payload)
+
+	// Verify via PresignedGetURL — full HTTP roundtrip mirrors the
+	// /v1/file/download/url contract on the public API.
+	getURL, err := svc.PresignedGetURL(relPath, "presigned.txt", "attachment", 5*time.Minute)
+	require.NoError(t, err)
+
+	body := doPresignedGET(t, getURL)
+	defer body.Close()
+
+	got, err := io.ReadAll(body)
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+}
+
+// TestAWSS3Integration_PresignedPUTRejectsSizeMismatch is the size-bypass
+// guard test. The server signed Content-Length: N; the browser sends
+// fewer bytes than that. AWS S3 rejects on Content-Length mismatch
+// (XAmzContentSHA256Mismatch / signature mismatch family), validating
+// that the presigned-URL path cannot be coerced into uploading less
+// data than the server budgeted for.
+//
+// (A test for MORE bytes than signed is harder to construct without
+// fighting the http library — http.Client computes Content-Length
+// from the body length automatically. The presence of Content-Length
+// in SignedHeaders, asserted in service_s3_test.go, is the offline
+// guarantee that the same rejection happens for over-size.)
+func TestAWSS3Integration_PresignedPUTRejectsSizeMismatch(t *testing.T) {
+	env := requireAWSS3Env(t)
+	svc, _ := newAWSS3TestService(t, env)
+
+	signedSize := int64(1024) // server says: signing for exactly 1024 bytes
+	uploadURL, _, err := svc.PresignedPutURL(
+		"chat/2026/05/should-not-land.txt", "text/plain", "", signedSize, 5*time.Minute,
+	)
+	require.NoError(t, err)
+
+	body := bytes.Repeat([]byte("a"), 100) // sending only 100 bytes
+	req, err := http.NewRequest(http.MethodPut, uploadURL, bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "text/plain")
+	req.ContentLength = int64(len(body))
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.NotEqual(t, http.StatusOK, resp.StatusCode,
+		"PUT with body size != signed Content-Length must be rejected; status=%d", resp.StatusCode)
+	// AWS responds with 403 SignatureDoesNotMatch on Content-Length
+	// mismatch for SigV4 presigned URLs. Use 4xx as the contract
+	// (some providers return 400 for the same case).
+	assert.GreaterOrEqual(t, resp.StatusCode, 400)
+	assert.Less(t, resp.StatusCode, 500,
+		"size-mismatch rejection must be a 4xx, got %d", resp.StatusCode)
+}
+
+// TestAWSS3Integration_DownloadURLShape sanity-checks that the public
+// (unsigned) download URL points at the configured BucketURL host
+// when set, and at the canonical S3 hostname when not. We don't
+// follow the URL — for private buckets it will 403 — but the host /
+// path shape is what /v1/file/preview hands the browser.
+func TestAWSS3Integration_DownloadURLShape(t *testing.T) {
+	env := requireAWSS3Env(t)
+	svc, cfg := newAWSS3TestService(t, env)
+
+	relPath := "chat/2026/abc.jpg"
+	got, err := svc.DownloadURL(relPath, "")
+	require.NoError(t, err)
+	u, err := url.Parse(got)
+	require.NoError(t, err)
+
+	expectedSuffix := "/" + cfg.S3.Prefix + "/" + relPath
+	assert.True(t, strings.HasSuffix(u.EscapedPath(), expectedSuffix) ||
+		strings.HasSuffix(u.EscapedPath(), expectedSuffix[1:]),
+		"DownloadURL path must include the configured prefix + object path, got %s", u.EscapedPath())
+	if env.BucketURL != "" {
+		bu, _ := url.Parse(env.BucketURL)
+		assert.Equal(t, bu.Host, u.Host,
+			"BucketURL host must dominate DownloadURL host when set")
+	}
+}
+
+func doPresignedPUT(t *testing.T, signedURL, contentType, contentDisposition string, payload []byte) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPut, signedURL, bytes.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", contentType)
+	if contentDisposition != "" {
+		req.Header.Set("Content-Disposition", contentDisposition)
+	}
+	req.ContentLength = int64(len(payload))
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	require.Equalf(t, http.StatusOK, resp.StatusCode,
+		"presigned PUT must succeed; status=%d body=%s", resp.StatusCode, string(respBody))
+}
+
+func doPresignedGET(t *testing.T, signedURL string) io.ReadCloser {
+	t.Helper()
+	resp, err := http.Get(signedURL) //nolint:gosec // test code, URL comes from our own signer
+	require.NoError(t, err)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("presigned GET failed: status=%d body=%s", resp.StatusCode, string(body))
+	}
+	return resp.Body
+}
+
+// Compile-time guard: surface unused-import noise as early as possible
+// when this test file is dropped into a contributor's machine without
+// the AWS env vars set.
+var _ = fmt.Sprintf

--- a/modules/file/service_s3_aws_integration_test.go
+++ b/modules/file/service_s3_aws_integration_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -320,7 +319,3 @@ func doPresignedGET(t *testing.T, signedURL string) io.ReadCloser {
 	return resp.Body
 }
 
-// Compile-time guard: surface unused-import noise as early as possible
-// when this test file is dropped into a contributor's machine without
-// the AWS env vars set.
-var _ = fmt.Sprintf

--- a/modules/file/service_s3_aws_integration_test.go
+++ b/modules/file/service_s3_aws_integration_test.go
@@ -37,7 +37,7 @@ import (
 //
 // Optional:
 //
-//	TS_S3_TEST_BUCKET_URL        BucketURL override (CDN front, custom domain)
+//	TS_S3_TEST_DOWNLOAD_URL      DownloadURL override (CDN front, custom domain). Unsigned URL prefix only.
 //	TS_S3_TEST_USE_PATH_STYLE    "true" to force path-style addressing
 type awsS3TestEnv struct {
 	Endpoint        string
@@ -45,7 +45,7 @@ type awsS3TestEnv struct {
 	Bucket          string
 	AccessKeyID     string
 	SecretAccessKey string
-	BucketURL       string
+	DownloadURL     string
 	UsePathStyle    bool
 }
 
@@ -57,7 +57,7 @@ func requireAWSS3Env(t *testing.T) awsS3TestEnv {
 		Bucket:          os.Getenv("TS_S3_TEST_BUCKET"),
 		AccessKeyID:     os.Getenv("TS_S3_TEST_ACCESS_KEY_ID"),
 		SecretAccessKey: os.Getenv("TS_S3_TEST_SECRET_ACCESS_KEY"),
-		BucketURL:       os.Getenv("TS_S3_TEST_BUCKET_URL"),
+		DownloadURL:     os.Getenv("TS_S3_TEST_DOWNLOAD_URL"),
 		UsePathStyle:    strings.EqualFold(os.Getenv("TS_S3_TEST_USE_PATH_STYLE"), "true"),
 	}
 	missing := make([]string, 0, 5)
@@ -91,7 +91,7 @@ func newAWSS3TestService(t *testing.T, env awsS3TestEnv) (*file.ServiceS3, *conf
 	cfg.S3.Bucket = env.Bucket
 	cfg.S3.AccessKeyID = env.AccessKeyID
 	cfg.S3.SecretAccessKey = env.SecretAccessKey
-	cfg.S3.BucketURL = env.BucketURL
+	cfg.S3.DownloadURL = env.DownloadURL
 	cfg.S3.UsePathStyle = env.UsePathStyle
 	// Use a unique prefix per test run so concurrent runs (CI parallelism)
 	// and re-runs after partial failures don't collide.
@@ -263,7 +263,7 @@ func TestAWSS3Integration_PresignedPUTRejectsSizeMismatch(t *testing.T) {
 }
 
 // TestAWSS3Integration_DownloadURLShape sanity-checks that the public
-// (unsigned) download URL points at the configured BucketURL host
+// (unsigned) download URL points at the configured DownloadURL host
 // when set, and at the canonical S3 hostname when not. We don't
 // follow the URL — for private buckets it will 403 — but the host /
 // path shape is what /v1/file/preview hands the browser.
@@ -281,10 +281,10 @@ func TestAWSS3Integration_DownloadURLShape(t *testing.T) {
 	assert.True(t, strings.HasSuffix(u.EscapedPath(), expectedSuffix) ||
 		strings.HasSuffix(u.EscapedPath(), expectedSuffix[1:]),
 		"DownloadURL path must include the configured prefix + object path, got %s", u.EscapedPath())
-	if env.BucketURL != "" {
-		bu, _ := url.Parse(env.BucketURL)
+	if env.DownloadURL != "" {
+		bu, _ := url.Parse(env.DownloadURL)
 		assert.Equal(t, bu.Host, u.Host,
-			"BucketURL host must dominate DownloadURL host when set")
+			"DownloadURL host must dominate the unsigned URL host when set")
 	}
 }
 

--- a/modules/file/service_s3_test.go
+++ b/modules/file/service_s3_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// baseS3Cfg returns a config with the three required S3 fields populated
+// baseS3Cfg returns a config with all required S3 fields populated
 // against fake AWS-shaped values. Tests override individual fields as
 // needed.
 func baseS3Cfg() *config.Config {
@@ -49,13 +49,32 @@ func TestServiceS3_FailFastOnMissingRequiredConfig(t *testing.T) {
 			wantMsg: "s3.bucket",
 		},
 		{
-			name: "all three missing reported together",
+			name:    "missing accessKeyID",
+			mutate:  func(c *config.Config) { c.S3.AccessKeyID = "" },
+			wantMsg: "s3.accessKeyID",
+		},
+		{
+			name:    "missing secretAccessKey",
+			mutate:  func(c *config.Config) { c.S3.SecretAccessKey = "" },
+			wantMsg: "s3.secretAccessKey",
+		},
+		{
+			name: "all required fields missing reported together",
 			mutate: func(c *config.Config) {
 				c.S3.Endpoint = ""
 				c.S3.Region = ""
 				c.S3.Bucket = ""
+				c.S3.AccessKeyID = ""
+				c.S3.SecretAccessKey = ""
 			},
-			wantMsg: "s3.endpoint, s3.region, s3.bucket",
+			wantMsg: "s3.endpoint, s3.region, s3.bucket, s3.accessKeyID, s3.secretAccessKey",
+		},
+		{
+			name: "SessionToken empty is fine (optional field)",
+			mutate: func(c *config.Config) {
+				c.S3.SessionToken = ""
+			},
+			wantMsg: "",
 		},
 	}
 	for _, tc := range tests {
@@ -65,15 +84,22 @@ func TestServiceS3_FailFastOnMissingRequiredConfig(t *testing.T) {
 			svc := file.NewServiceS3(testutil.NewTestContext(cfg))
 
 			_, _, err := svc.PresignedPutURL("chat/foo.jpg", "image/jpeg", "", 1024, time.Minute)
+			if tc.wantMsg == "" {
+				require.NoError(t, err)
+				return
+			}
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tc.wantMsg)
 		})
 	}
 }
 
-func TestServiceS3_PresignedPutURL_SignsAgainstEndpointWhenBucketURLEmpty(t *testing.T) {
+func TestServiceS3_PresignedPutURL_AlwaysSignsAgainstEndpoint(t *testing.T) {
+	// Core regression: presigned PUT URL host must equal cfg.S3.Endpoint
+	// (with the bucket virtual-hosted in front), regardless of whether
+	// DownloadURL is set. DownloadURL is for unsigned browser URLs only.
 	cfg := baseS3Cfg()
-	cfg.S3.BucketURL = ""
+	cfg.S3.DownloadURL = ""
 
 	svc := file.NewServiceS3(testutil.NewTestContext(cfg))
 
@@ -110,71 +136,80 @@ func TestServiceS3_PresignedPutURL_SignsAgainstEndpointWhenBucketURLEmpty(t *tes
 		"presigned PUT URL must include `content-length` in signed headers to enforce upload size cap (got %q)", signedHeaders)
 }
 
-func TestServiceS3_PresignedPutURL_BucketSubdomainBucketURL(t *testing.T) {
-	// Bucket-subdomain shape: BucketURL host begins with "<bucket>.".
-	// SDK must use BucketLookupDNS against the parent host so the
-	// signed URL equals BucketURL+key exactly. Pre-fix this was
-	// producing "octo-test-bucket.octo-test-bucket.files.example.com"
-	// (double bucket) because the SDK re-attached <bucket>. on top of
-	// the already-prefixed host.
+// TestServiceS3_PresignedURL_DownloadURLDoesNotAffectSigning pins the
+// soul of the post-#43 contract: presigned PUT/GET URLs must ALWAYS
+// sign against cfg.S3.Endpoint, no matter what DownloadURL is. If a
+// future change accidentally re-introduces DownloadURL into the signing
+// path (e.g. by reading it in newClient), this test will catch the
+// signature-host drift before it ships.
+func TestServiceS3_PresignedURL_DownloadURLDoesNotAffectSigning(t *testing.T) {
+	endpointHostSuffix := "us-west-2.amazonaws.com"
+
+	for _, downloadURL := range []string{
+		"https://d123.cloudfront.net",                 // CloudFront alias
+		"https://files.example.com",                   // generic CDN alias
+		"https://octo-test-bucket.cdn.example.com",    // bucket-subdomain custom domain
+		"http://localhost:9000",                       // local emulator
+	} {
+		t.Run(downloadURL, func(t *testing.T) {
+			cfg := baseS3Cfg()
+			cfg.S3.DownloadURL = downloadURL
+
+			svc := file.NewServiceS3(testutil.NewTestContext(cfg))
+
+			// PUT
+			uploadURL, _, err := svc.PresignedPutURL(
+				"chat/2026/05/abc.jpg", "image/jpeg", "", 1024, 5*time.Minute,
+			)
+			require.NoError(t, err)
+			pu, err := url.Parse(uploadURL)
+			require.NoError(t, err)
+			assert.True(t, strings.HasSuffix(pu.Host, endpointHostSuffix),
+				"presigned PUT host must derive from Endpoint, not DownloadURL=%q (got %s)", downloadURL, pu.Host)
+			assert.Equal(t, "https", pu.Scheme,
+				"presigned PUT must always be HTTPS regardless of DownloadURL scheme")
+
+			// GET
+			getURL, err := svc.PresignedGetURL("chat/abc.jpg", "x.jpg", "attachment", time.Minute)
+			require.NoError(t, err)
+			gu, err := url.Parse(getURL)
+			require.NoError(t, err)
+			assert.True(t, strings.HasSuffix(gu.Host, endpointHostSuffix),
+				"presigned GET host must derive from Endpoint, not DownloadURL=%q (got %s)", downloadURL, gu.Host)
+			assert.Equal(t, "https", gu.Scheme)
+		})
+	}
+}
+
+// TestServiceS3_SessionToken_AppearsInSignedURL covers STS / IRSA / IMDSv2
+// rotating-credentials workflows: when cfg.S3.SessionToken is set,
+// minio-go must add X-Amz-Security-Token to the presigned URL query, or
+// AWS will reject the request as "InvalidToken / The security token
+// included in the request is invalid."
+func TestServiceS3_SessionToken_AppearsInSignedURL(t *testing.T) {
 	cfg := baseS3Cfg()
-	cfg.S3.BucketURL = "https://octo-test-bucket.files.example.com"
+	cfg.S3.SessionToken = "IQoJb3JpZ2luX2VjEXAMPLESESSIONTOKENvalueGRwEAAaCXVzLWVhc3QtMQ=="
 
 	svc := file.NewServiceS3(testutil.NewTestContext(cfg))
 
 	uploadURL, _, err := svc.PresignedPutURL(
-		"chat/2026/05/abc.jpg", "image/jpeg", "", 12345, 5*time.Minute,
+		"chat/abc.jpg", "image/jpeg", "", 1024, time.Minute,
 	)
 	require.NoError(t, err)
-
 	u, err := url.Parse(uploadURL)
 	require.NoError(t, err)
-	// Pinned: presigned URL host must equal BucketURL host exactly —
-	// that is the host the browser resolves and the host SigV4
-	// canonicalized into the signature.
-	assert.Equal(t, "octo-test-bucket.files.example.com", u.Host,
-		"bucket-subdomain BucketURL: signed URL host must equal BucketURL host (no double bucket prefix), got %s", u.Host)
-}
 
-func TestServiceS3_PresignedPutURL_CDNAliasBucketURL(t *testing.T) {
-	// CDN alias shape: BucketURL host has NO "<bucket>." prefix. SDK
-	// must use BucketLookupPath so the bucket lives in the URL path
-	// (`/<bucket>/<key>`) rather than the SDK silently constructing a
-	// "<bucket>.files.example.com" subdomain that does not exist in
-	// DNS (the original reviewer-flagged bug).
-	cfg := baseS3Cfg()
-	cfg.S3.BucketURL = "https://files.example.com"
+	token := u.Query().Get("X-Amz-Security-Token")
+	require.NotEmpty(t, token,
+		"presigned URL must carry X-Amz-Security-Token when SessionToken is configured (STS path)")
+	assert.Equal(t, cfg.S3.SessionToken, token,
+		"X-Amz-Security-Token must equal the configured SessionToken verbatim")
 
-	svc := file.NewServiceS3(testutil.NewTestContext(cfg))
-
-	uploadURL, _, err := svc.PresignedPutURL(
-		"chat/2026/05/abc.jpg", "image/jpeg", "", 12345, 5*time.Minute,
-	)
+	// GET path mirrors PUT.
+	getURL, err := svc.PresignedGetURL("chat/abc.jpg", "x.jpg", "attachment", time.Minute)
 	require.NoError(t, err)
-
-	u, err := url.Parse(uploadURL)
-	require.NoError(t, err)
-	// Pinned: signed URL host must equal BucketURL host exactly,
-	// without an added "<bucket>." subdomain.
-	assert.Equal(t, "files.example.com", u.Host,
-		"CDN-alias BucketURL: signed URL host must equal BucketURL host (no added bucket subdomain), got %s", u.Host)
-	// Bucket lives in the path with path-style addressing.
-	assert.Contains(t, u.Path, "/octo-test-bucket/",
-		"CDN-alias BucketURL: bucket segment must appear in the URL path, got %s", u.Path)
-}
-
-func TestServiceS3_PresignedPutURL_RejectsBucketURLWithPathPrefix(t *testing.T) {
-	cfg := baseS3Cfg()
-	// Path components on BucketURL would be stripped before SigV4
-	// canonical URI computation, producing 403 SignatureDoesNotMatch
-	// at the browser. Reject loudly rather than silently dropping the
-	// path — same contract as MinioConfig.DownloadURL.
-	cfg.S3.BucketURL = "https://cdn.example.com/s3"
-
-	svc := file.NewServiceS3(testutil.NewTestContext(cfg))
-	_, _, err := svc.PresignedPutURL("chat/foo.jpg", "image/jpeg", "", 1024, time.Minute)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "路径前缀")
+	gu, _ := url.Parse(getURL)
+	assert.Equal(t, cfg.S3.SessionToken, gu.Query().Get("X-Amz-Security-Token"))
 }
 
 func TestServiceS3_PresignedPutURL_RejectsZeroOrNegativeFileSize(t *testing.T) {
@@ -217,7 +252,7 @@ func TestServiceS3_PresignedURLs_RejectMalformedObjectKeys(t *testing.T) {
 
 func TestServiceS3_DownloadURL_VirtualHostedStyle(t *testing.T) {
 	cfg := baseS3Cfg()
-	cfg.S3.BucketURL = ""
+	cfg.S3.DownloadURL = ""
 	cfg.S3.UsePathStyle = false
 
 	svc := file.NewServiceS3(testutil.NewTestContext(cfg))
@@ -228,7 +263,7 @@ func TestServiceS3_DownloadURL_VirtualHostedStyle(t *testing.T) {
 
 func TestServiceS3_DownloadURL_PathStyle(t *testing.T) {
 	cfg := baseS3Cfg()
-	cfg.S3.BucketURL = ""
+	cfg.S3.DownloadURL = ""
 	cfg.S3.UsePathStyle = true
 
 	svc := file.NewServiceS3(testutil.NewTestContext(cfg))
@@ -237,9 +272,9 @@ func TestServiceS3_DownloadURL_PathStyle(t *testing.T) {
 	assert.Equal(t, "https://s3.us-west-2.amazonaws.com/octo-test-bucket/chat/2026/abc.jpg", got)
 }
 
-func TestServiceS3_DownloadURL_BucketURLOverride(t *testing.T) {
+func TestServiceS3_DownloadURL_DownloadURLOverride(t *testing.T) {
 	cfg := baseS3Cfg()
-	cfg.S3.BucketURL = "https://cdn.example.com"
+	cfg.S3.DownloadURL = "https://cdn.example.com"
 
 	svc := file.NewServiceS3(testutil.NewTestContext(cfg))
 	got, err := svc.DownloadURL("chat/2026/abc.jpg", "")
@@ -249,7 +284,7 @@ func TestServiceS3_DownloadURL_BucketURLOverride(t *testing.T) {
 
 func TestServiceS3_DownloadURL_WithPrefix(t *testing.T) {
 	cfg := baseS3Cfg()
-	cfg.S3.BucketURL = "https://cdn.example.com"
+	cfg.S3.DownloadURL = "https://cdn.example.com"
 	cfg.S3.Prefix = "prod"
 
 	svc := file.NewServiceS3(testutil.NewTestContext(cfg))
@@ -270,7 +305,7 @@ func TestServiceS3_EndpointTolerates_FullURL(t *testing.T) {
 		t.Run(ep, func(t *testing.T) {
 			cfg := baseS3Cfg()
 			cfg.S3.Endpoint = ep
-			cfg.S3.BucketURL = ""
+			cfg.S3.DownloadURL = ""
 
 			svc := file.NewServiceS3(testutil.NewTestContext(cfg))
 			uploadURL, _, err := svc.PresignedPutURL(

--- a/modules/file/service_s3_test.go
+++ b/modules/file/service_s3_test.go
@@ -110,7 +110,38 @@ func TestServiceS3_PresignedPutURL_SignsAgainstEndpointWhenBucketURLEmpty(t *tes
 		"presigned PUT URL must include `content-length` in signed headers to enforce upload size cap (got %q)", signedHeaders)
 }
 
-func TestServiceS3_PresignedPutURL_SignsAgainstBucketURLWhenSet(t *testing.T) {
+func TestServiceS3_PresignedPutURL_BucketSubdomainBucketURL(t *testing.T) {
+	// Bucket-subdomain shape: BucketURL host begins with "<bucket>.".
+	// SDK must use BucketLookupDNS against the parent host so the
+	// signed URL equals BucketURL+key exactly. Pre-fix this was
+	// producing "octo-test-bucket.octo-test-bucket.files.example.com"
+	// (double bucket) because the SDK re-attached <bucket>. on top of
+	// the already-prefixed host.
+	cfg := baseS3Cfg()
+	cfg.S3.BucketURL = "https://octo-test-bucket.files.example.com"
+
+	svc := file.NewServiceS3(testutil.NewTestContext(cfg))
+
+	uploadURL, _, err := svc.PresignedPutURL(
+		"chat/2026/05/abc.jpg", "image/jpeg", "", 12345, 5*time.Minute,
+	)
+	require.NoError(t, err)
+
+	u, err := url.Parse(uploadURL)
+	require.NoError(t, err)
+	// Pinned: presigned URL host must equal BucketURL host exactly —
+	// that is the host the browser resolves and the host SigV4
+	// canonicalized into the signature.
+	assert.Equal(t, "octo-test-bucket.files.example.com", u.Host,
+		"bucket-subdomain BucketURL: signed URL host must equal BucketURL host (no double bucket prefix), got %s", u.Host)
+}
+
+func TestServiceS3_PresignedPutURL_CDNAliasBucketURL(t *testing.T) {
+	// CDN alias shape: BucketURL host has NO "<bucket>." prefix. SDK
+	// must use BucketLookupPath so the bucket lives in the URL path
+	// (`/<bucket>/<key>`) rather than the SDK silently constructing a
+	// "<bucket>.files.example.com" subdomain that does not exist in
+	// DNS (the original reviewer-flagged bug).
 	cfg := baseS3Cfg()
 	cfg.S3.BucketURL = "https://files.example.com"
 
@@ -123,17 +154,13 @@ func TestServiceS3_PresignedPutURL_SignsAgainstBucketURLWhenSet(t *testing.T) {
 
 	u, err := url.Parse(uploadURL)
 	require.NoError(t, err)
-
-	// SigV4 covers `host`. The signing client was built against
-	// BucketURL's parent host (files.example.com); the SDK virtual-hosts
-	// the bucket on top, producing octo-test-bucket.files.example.com.
-	// The exact host shape doesn't matter to this test — only that no
-	// segment of the endpoint domain (s3.us-west-2.amazonaws.com) leaks
-	// through, which would indicate signing against the wrong host.
-	assert.NotContains(t, u.Host, "amazonaws.com",
-		"BucketURL must shadow Endpoint when set; got %s", u.Host)
-	assert.Contains(t, u.Host, "files.example.com",
-		"presigned URL host should derive from BucketURL; got %s", u.Host)
+	// Pinned: signed URL host must equal BucketURL host exactly,
+	// without an added "<bucket>." subdomain.
+	assert.Equal(t, "files.example.com", u.Host,
+		"CDN-alias BucketURL: signed URL host must equal BucketURL host (no added bucket subdomain), got %s", u.Host)
+	// Bucket lives in the path with path-style addressing.
+	assert.Contains(t, u.Path, "/octo-test-bucket/",
+		"CDN-alias BucketURL: bucket segment must appear in the URL path, got %s", u.Path)
 }
 
 func TestServiceS3_PresignedPutURL_RejectsBucketURLWithPathPrefix(t *testing.T) {

--- a/modules/file/service_s3_test.go
+++ b/modules/file/service_s3_test.go
@@ -1,0 +1,292 @@
+package file_test
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/file"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// baseS3Cfg returns a config with the three required S3 fields populated
+// against fake AWS-shaped values. Tests override individual fields as
+// needed.
+func baseS3Cfg() *config.Config {
+	cfg := config.New()
+	cfg.Test = true
+	cfg.S3.Endpoint = "s3.us-west-2.amazonaws.com"
+	cfg.S3.Region = "us-west-2"
+	cfg.S3.Bucket = "octo-test-bucket"
+	cfg.S3.AccessKeyID = "AKIAEXAMPLE"
+	cfg.S3.SecretAccessKey = "secret-key-1234567890"
+	return cfg
+}
+
+func TestServiceS3_FailFastOnMissingRequiredConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(c *config.Config)
+		wantMsg string
+	}{
+		{
+			name:    "missing endpoint",
+			mutate:  func(c *config.Config) { c.S3.Endpoint = "" },
+			wantMsg: "s3.endpoint",
+		},
+		{
+			name:    "missing region",
+			mutate:  func(c *config.Config) { c.S3.Region = "" },
+			wantMsg: "s3.region",
+		},
+		{
+			name:    "missing bucket",
+			mutate:  func(c *config.Config) { c.S3.Bucket = "" },
+			wantMsg: "s3.bucket",
+		},
+		{
+			name: "all three missing reported together",
+			mutate: func(c *config.Config) {
+				c.S3.Endpoint = ""
+				c.S3.Region = ""
+				c.S3.Bucket = ""
+			},
+			wantMsg: "s3.endpoint, s3.region, s3.bucket",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := baseS3Cfg()
+			tc.mutate(cfg)
+			svc := file.NewServiceS3(testutil.NewTestContext(cfg))
+
+			_, _, err := svc.PresignedPutURL("chat/foo.jpg", "image/jpeg", "", 1024, time.Minute)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantMsg)
+		})
+	}
+}
+
+func TestServiceS3_PresignedPutURL_SignsAgainstEndpointWhenBucketURLEmpty(t *testing.T) {
+	cfg := baseS3Cfg()
+	cfg.S3.BucketURL = ""
+
+	svc := file.NewServiceS3(testutil.NewTestContext(cfg))
+
+	uploadURL, downloadURL, err := svc.PresignedPutURL(
+		"chat/2026/05/abc.jpg", "image/jpeg", "", 12345, 5*time.Minute,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, uploadURL)
+	require.NotEmpty(t, downloadURL)
+
+	u, err := url.Parse(uploadURL)
+	require.NoError(t, err)
+
+	// Virtual-hosted style against AWS S3: <bucket>.<endpoint>.
+	// Note: minio-go internally rewrites Amazon S3 endpoints to the
+	// dual-stack variant (s3.dualstack.<region>.amazonaws.com) — this
+	// is publicly DNS-resolvable and equivalent for browser access,
+	// just cosmetically different from the configured endpoint string.
+	// CORS / bucket policy match on bucket identity, not host.
+	assert.True(t,
+		strings.HasPrefix(u.Host, "octo-test-bucket.s3.") &&
+			strings.HasSuffix(u.Host, "us-west-2.amazonaws.com"),
+		"presigned PUT URL host must virtual-host the bucket against the region endpoint, got %s", u.Host)
+	assert.Equal(t, "https", u.Scheme,
+		"S3 backend is HTTPS-only by design")
+
+	q := u.Query()
+	assert.NotEmpty(t, q.Get("X-Amz-Signature"),
+		"presigned PUT URL must carry a SigV4 signature")
+	signedHeaders := q.Get("X-Amz-SignedHeaders")
+	assert.Contains(t, signedHeaders, "host",
+		"presigned PUT URL must include `host` in signed headers (got %q)", signedHeaders)
+	assert.Contains(t, signedHeaders, "content-length",
+		"presigned PUT URL must include `content-length` in signed headers to enforce upload size cap (got %q)", signedHeaders)
+}
+
+func TestServiceS3_PresignedPutURL_SignsAgainstBucketURLWhenSet(t *testing.T) {
+	cfg := baseS3Cfg()
+	cfg.S3.BucketURL = "https://files.example.com"
+
+	svc := file.NewServiceS3(testutil.NewTestContext(cfg))
+
+	uploadURL, _, err := svc.PresignedPutURL(
+		"chat/2026/05/abc.jpg", "image/jpeg", "", 12345, 5*time.Minute,
+	)
+	require.NoError(t, err)
+
+	u, err := url.Parse(uploadURL)
+	require.NoError(t, err)
+
+	// SigV4 covers `host`. The signing client was built against
+	// BucketURL's parent host (files.example.com); the SDK virtual-hosts
+	// the bucket on top, producing octo-test-bucket.files.example.com.
+	// The exact host shape doesn't matter to this test — only that no
+	// segment of the endpoint domain (s3.us-west-2.amazonaws.com) leaks
+	// through, which would indicate signing against the wrong host.
+	assert.NotContains(t, u.Host, "amazonaws.com",
+		"BucketURL must shadow Endpoint when set; got %s", u.Host)
+	assert.Contains(t, u.Host, "files.example.com",
+		"presigned URL host should derive from BucketURL; got %s", u.Host)
+}
+
+func TestServiceS3_PresignedPutURL_RejectsBucketURLWithPathPrefix(t *testing.T) {
+	cfg := baseS3Cfg()
+	// Path components on BucketURL would be stripped before SigV4
+	// canonical URI computation, producing 403 SignatureDoesNotMatch
+	// at the browser. Reject loudly rather than silently dropping the
+	// path — same contract as MinioConfig.DownloadURL.
+	cfg.S3.BucketURL = "https://cdn.example.com/s3"
+
+	svc := file.NewServiceS3(testutil.NewTestContext(cfg))
+	_, _, err := svc.PresignedPutURL("chat/foo.jpg", "image/jpeg", "", 1024, time.Minute)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "路径前缀")
+}
+
+func TestServiceS3_PresignedPutURL_RejectsZeroOrNegativeFileSize(t *testing.T) {
+	cfg := baseS3Cfg()
+	svc := file.NewServiceS3(testutil.NewTestContext(cfg))
+
+	for _, size := range []int64{0, -1, -1024} {
+		_, _, err := svc.PresignedPutURL("chat/foo.jpg", "image/jpeg", "", size, time.Minute)
+		require.Errorf(t, err, "fileSize=%d must be rejected (Content-Length signing required)", size)
+		assert.Contains(t, err.Error(), "fileSize")
+	}
+}
+
+func TestServiceS3_PresignedURLs_RejectMalformedObjectKeys(t *testing.T) {
+	cfg := baseS3Cfg()
+	svc := file.NewServiceS3(testutil.NewTestContext(cfg))
+
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"trailing slash on directory key", "chat/dir/"},
+		{"embedded double slash", "chat/a//b.png"},
+		// Leading slash through the input itself: validatePresignObjectKey
+		// already rejects this for MinIO/COS; ServiceS3 must too so the
+		// canonical URI never gets normalized mid-flight.
+		{"leading slash", "/chat/foo.png"},
+	}
+	for _, tc := range cases {
+		t.Run("PUT/"+tc.name, func(t *testing.T) {
+			_, _, err := svc.PresignedPutURL(tc.input, "image/jpeg", "", 1024, time.Minute)
+			require.Error(t, err, "PresignedPutURL must reject %q", tc.input)
+		})
+		t.Run("GET/"+tc.name, func(t *testing.T) {
+			_, err := svc.PresignedGetURL(tc.input, "x.jpg", "attachment", time.Minute)
+			require.Error(t, err, "PresignedGetURL must reject %q", tc.input)
+		})
+	}
+}
+
+func TestServiceS3_DownloadURL_VirtualHostedStyle(t *testing.T) {
+	cfg := baseS3Cfg()
+	cfg.S3.BucketURL = ""
+	cfg.S3.UsePathStyle = false
+
+	svc := file.NewServiceS3(testutil.NewTestContext(cfg))
+	got, err := svc.DownloadURL("chat/2026/abc.jpg", "")
+	require.NoError(t, err)
+	assert.Equal(t, "https://octo-test-bucket.s3.us-west-2.amazonaws.com/chat/2026/abc.jpg", got)
+}
+
+func TestServiceS3_DownloadURL_PathStyle(t *testing.T) {
+	cfg := baseS3Cfg()
+	cfg.S3.BucketURL = ""
+	cfg.S3.UsePathStyle = true
+
+	svc := file.NewServiceS3(testutil.NewTestContext(cfg))
+	got, err := svc.DownloadURL("chat/2026/abc.jpg", "")
+	require.NoError(t, err)
+	assert.Equal(t, "https://s3.us-west-2.amazonaws.com/octo-test-bucket/chat/2026/abc.jpg", got)
+}
+
+func TestServiceS3_DownloadURL_BucketURLOverride(t *testing.T) {
+	cfg := baseS3Cfg()
+	cfg.S3.BucketURL = "https://cdn.example.com"
+
+	svc := file.NewServiceS3(testutil.NewTestContext(cfg))
+	got, err := svc.DownloadURL("chat/2026/abc.jpg", "")
+	require.NoError(t, err)
+	assert.Equal(t, "https://cdn.example.com/chat/2026/abc.jpg", got)
+}
+
+func TestServiceS3_DownloadURL_WithPrefix(t *testing.T) {
+	cfg := baseS3Cfg()
+	cfg.S3.BucketURL = "https://cdn.example.com"
+	cfg.S3.Prefix = "prod"
+
+	svc := file.NewServiceS3(testutil.NewTestContext(cfg))
+	got, err := svc.DownloadURL("chat/abc.jpg", "")
+	require.NoError(t, err)
+	assert.Equal(t, "https://cdn.example.com/prod/chat/abc.jpg", got)
+}
+
+func TestServiceS3_EndpointTolerates_FullURL(t *testing.T) {
+	// Operators sometimes paste the full URL into the endpoint field
+	// despite the godoc saying "hostname, without scheme". Trim it
+	// silently so we don't surface a confusing SDK error.
+	for _, ep := range []string{
+		"s3.us-west-2.amazonaws.com",
+		"https://s3.us-west-2.amazonaws.com",
+		"https://s3.us-west-2.amazonaws.com/",
+	} {
+		t.Run(ep, func(t *testing.T) {
+			cfg := baseS3Cfg()
+			cfg.S3.Endpoint = ep
+			cfg.S3.BucketURL = ""
+
+			svc := file.NewServiceS3(testutil.NewTestContext(cfg))
+			uploadURL, _, err := svc.PresignedPutURL(
+				"chat/abc.jpg", "image/jpeg", "", 1024, time.Minute,
+			)
+			require.NoError(t, err)
+			u, err := url.Parse(uploadURL)
+			require.NoError(t, err)
+			// minio-go canonicalizes AWS endpoints to the dual-stack
+			// hostname; the region suffix is what we check for.
+			assert.True(t, strings.HasSuffix(u.Host, "us-west-2.amazonaws.com"),
+				"URL host should derive from endpoint hostname regardless of input shape, got %s", u.Host)
+		})
+	}
+}
+
+func TestServiceS3_PresignedGetURL_EmitsContentDisposition(t *testing.T) {
+	cfg := baseS3Cfg()
+	svc := file.NewServiceS3(testutil.NewTestContext(cfg))
+
+	raw, err := svc.PresignedGetURL("chat/abc.jpg", "report 报告.jpg", "attachment", 5*time.Minute)
+	require.NoError(t, err)
+
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+
+	disposition := u.Query().Get("response-content-disposition")
+	require.NotEmpty(t, disposition,
+		"PresignedGetURL must set response-content-disposition for filename overrides")
+	assert.Contains(t, disposition, "attachment")
+	// Non-ASCII filenames must use RFC 5987 percent-encoding.
+	assert.Contains(t, disposition, "UTF-8''",
+		"non-ASCII filename should be RFC 5987 encoded, got %q", disposition)
+}
+
+func TestServiceS3_PresignedGetURL_InlineDisposition(t *testing.T) {
+	cfg := baseS3Cfg()
+	svc := file.NewServiceS3(testutil.NewTestContext(cfg))
+
+	raw, err := svc.PresignedGetURL("chat/abc.jpg", "doc.pdf", "inline", 5*time.Minute)
+	require.NoError(t, err)
+
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	assert.Contains(t, u.Query().Get("response-content-disposition"), "inline")
+}

--- a/modules/file/testdata/octo-server.yaml
+++ b/modules/file/testdata/octo-server.yaml
@@ -68,6 +68,9 @@ wukongIM:
 #   ------------------+---------------------------------------+--------------------------------
 #   "minio"           | yes — direct PUT signed by minio-go   | yes — signed GET via minio-go
 #   "tencentCOS"      | yes — direct PUT signed by minio-go   | yes — signed GET via minio-go
+#   "awsS3"           | yes — direct PUT signed by minio-go   | yes — signed GET via minio-go
+#                     |       (AWS S3, R2, B2, Wasabi,        |
+#                     |        MinIO with custom endpoint)    |
 #   "aliyunOSS"       | yes — direct PUT signed by OSS SDK    | yes — signed GET via OSS SDK
 #   "qiniu"           | no  — Qiniu uploads use a token+form  | yes — MakePrivateURLv2 signed URL
 #                     |       model that does not map to a    |
@@ -163,6 +166,108 @@ minio:
   downloadURL: "http://octo.local:29000"
   accessKeyID: "octoadmin"
   secretAccessKey: "CHANGE_ME_MINIO_PASSWORD"
+
+# ---------- AWS S3 / S3-compatible (alternative to the blocks above) --------
+# Activate this backend with `fileService: "awsS3"` above, then fill in the
+# `s3:` block below.
+#
+# Use this for AWS S3, Cloudflare R2, Backblaze B2, Wasabi, or any other
+# provider that implements the S3 protocol with SigV4. ServiceS3 is a
+# single-bucket backend — the upload "type" segment (chat/, moment/, ...)
+# lives inside the object key, not as a separate bucket — so you only
+# need ONE bucket pre-created with appropriate IAM + CORS.
+#
+# Pre-deployment checklist:
+#
+#   1. Pre-create the bucket in your provider's console (octo-server does
+#      NOT auto-create on S3 — the IAM permissions for CreateBucket should
+#      remain UNGRANTED to avoid accidental cross-region bucket creation).
+#   2. Attach a minimum IAM policy granting only the object operations
+#      ServiceS3 actually performs:
+#        s3:ListBucket, s3:GetBucketLocation       — on the bucket arn
+#        s3:GetObject, s3:PutObject, s3:DeleteObject, s3:AbortMultipartUpload
+#                                                  — on the bucket arn + "/*"
+#   3. Configure CORS on the bucket so browser-direct presigned PUT works
+#      from the octo-web origin. Example (AWS S3 JSON):
+#        [{
+#          "AllowedOrigins": ["https://octo.example.com"],
+#          "AllowedMethods": ["GET", "PUT", "HEAD"],
+#          "AllowedHeaders": ["*"],
+#          "ExposeHeaders": ["ETag"],
+#          "MaxAgeSeconds": 3000
+#        }]
+#   4. Leave Block Public Access ON. Downloads go through
+#      /v1/file/download/url (presigned GET); octo-server's getFile
+#      handler also produces presigned URLs for private buckets.
+#
+# Region / endpoint semantics:
+#
+#   * Endpoint MUST match the bucket's actual region — Region is signed
+#     into the SigV4 canonical request, so a region mismatch produces
+#     AuthorizationHeaderMalformed at the gateway.
+#   * AWS S3: minio-go internally canonicalizes Amazon endpoints to
+#     `s3.dualstack.<region>.amazonaws.com`; this is the publicly
+#     resolvable IPv4+IPv6 endpoint and works in all browsers. Operators
+#     allow-listing the non-dual-stack hostname in firewalls / WAF
+#     should add the dual-stack variant.
+#   * Cloudflare R2: use `auto` as the region (R2 ignores it but the
+#     SDK still requires non-empty for SigV4).
+#   * Backblaze B2 S3 API: endpoint shape is `s3.<region>.backblazeb2.com`.
+#
+# SigV4 signed-header contract (REQUIRED for the browser direct PUT path):
+#
+#   The contract is identical to the COS / MinIO backends — see the
+#   `getUploadCredentials` block at modules/file/api.go for the
+#   per-header rules. The presigned PUT URL covers `Content-Type`,
+#   `Content-Length`, and (when present) `Content-Disposition` in
+#   `X-Amz-SignedHeaders`. The browser MUST echo each verbatim or AWS
+#   returns 403 SignatureDoesNotMatch and the upload aborts before any
+#   bytes leave the browser. This is also the server-side enforcement
+#   of MaxFileSize on the presigned path.
+#fileService: "awsS3"
+#s3:
+#  # API endpoint hostname (NO scheme — the SDK adds https). Pasting a
+#  # full URL is tolerated (scheme is stripped), but the canonical form
+#  # is host[:port] only.
+#  endpoint: "s3.us-west-2.amazonaws.com"
+#
+#  # SigV4 signing region. Must match the bucket's actual region for
+#  # AWS S3. Use "auto" for Cloudflare R2; required (non-empty) for all
+#  # providers because the SDK signs it into the canonical request.
+#  region: "us-west-2"
+#
+#  # The single bucket all uploads land in. Pre-create it on the
+#  # provider side; ServiceS3 does NOT call CreateBucket.
+#  bucket: "my-octo-bucket"
+#
+#  # Long-lived IAM access keys. Also overridable via env vars:
+#  #
+#  #   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY  — standard AWS env,
+#  #     auto-picked up by IRSA / IAM-role workflows.
+#  #   TS_S3_ACCESS_KEY_ID / TS_S3_SECRET_ACCESS_KEY  — project-specific
+#  #     overrides that WIN over both the YAML and the AWS_* env vars.
+#  #     Use these when your host has unrelated AWS_* set and you want
+#  #     octo-server to talk to a different account (e.g. R2 / B2).
+#  accessKeyID: "AKIA..."
+#  secretAccessKey: "..."
+#
+#  # OPTIONAL: BucketURL — overrides the URL returned by DownloadURL
+#  # and the host signed against by presigned PUT/GET. Set this when
+#  # operators front the bucket with CloudFront / a custom domain.
+#  # MUST be scheme://host[:port] with NO path component (a path
+#  # prefix would be stripped before SigV4 canonical URI computation
+#  # and produce 403 SignatureDoesNotMatch at the browser).
+#  # bucketURL: "https://files.example.com"
+#
+#  # OPTIONAL: object-key prefix for multi-environment isolation
+#  # against a shared bucket. Mirrors COS Prefix.
+#  # prefix: "prod/"
+#
+#  # OPTIONAL: force path-style addressing (https://endpoint/bucket/key)
+#  # instead of virtual-hosted (https://bucket.endpoint/key). AWS S3
+#  # accepts both modern-style; some S3 gateways (MinIO with custom
+#  # endpoint, older B2 configurations) require true.
+#  # usePathStyle: false
 
 # ---------- Logging ----------------------------------------------------------
 logger:

--- a/modules/file/testdata/octo-server.yaml
+++ b/modules/file/testdata/octo-server.yaml
@@ -196,9 +196,46 @@ minio:
 #          "ExposeHeaders": ["ETag"],
 #          "MaxAgeSeconds": 3000
 #        }]
-#   4. Leave Block Public Access ON. Downloads go through
-#      /v1/file/download/url (presigned GET); octo-server's getFile
-#      handler also produces presigned URLs for private buckets.
+#   4. Public-read posture: octo-server's `/v1/file/preview/*` redirects
+#      to the UNSIGNED object URL returned by `ServiceS3.DownloadURL`,
+#      and the multipart upload response stores that same unsigned URL
+#      as the file's `path`. Both are consumed by clients without
+#      signing, mirroring how the MinIO and COS backends operate today.
+#      For AWS S3 this means operators choose ONE of three deployment
+#      shapes; the right choice is operator-specific. Block Public
+#      Access ON without one of these options will cause 403 on every
+#      preview and on every stored object reference.
+#
+#      (A) CloudFront + Origin Access Control (RECOMMENDED for AWS-only)
+#          • Bucket: keep Block Public Access ON.
+#          • Front the bucket with CloudFront; attach an OAC so
+#            CloudFront identifies itself to the bucket; bucket policy
+#            grants `s3:GetObject` to that CloudFront principal only.
+#          • Set `s3.bucketURL` to the CloudFront distribution URL.
+#          • Pros: bucket stays fully private; URLs stable; cacheable.
+#          • Cons: cold-start latency on new keys; CloudFront billing.
+#
+#      (B) Bucket policy allow-list `s3:GetObject` to "*" (public read)
+#          • Bucket: turn Block Public Access OFF on "Block public
+#            access through new policies"; attach a policy granting
+#            `s3:GetObject` on `arn:aws:s3:::<bucket>/*` to `"*"`.
+#          • Set `s3.bucketURL` empty so URLs use the AWS endpoint
+#            host directly.
+#          • Pros: simplest; lowest cost.
+#          • Cons: ALL object contents are world-readable; defeats
+#            AWS perimeter defense. Only acceptable when none of the
+#            uploaded content is sensitive (e.g. public avatars).
+#
+#      (C) Client-side: always use `/v1/file/download/url` (presigned)
+#          • Bucket: keep Block Public Access ON.
+#          • Re-route every client that today hits `/v1/file/preview/*`
+#            to `/v1/file/download/url` instead, and re-resolve stored
+#            `path` fields through the same endpoint before use.
+#          • Pros: bucket stays private without CDN; per-URL access
+#            control.
+#          • Cons: requires client refactor; URLs expire (default 30
+#            min); previously-stored `path` fields are no longer
+#            directly usable.
 #
 # Region / endpoint semantics:
 #
@@ -240,14 +277,24 @@ minio:
 #  # provider side; ServiceS3 does NOT call CreateBucket.
 #  bucket: "my-octo-bucket"
 #
-#  # Long-lived IAM access keys. Also overridable via env vars:
+#  # Long-lived IAM access keys (static credentials). Also overridable
+#  # via env vars (all consumed by octo-lib's S3Config wiring):
 #  #
-#  #   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY  — standard AWS env,
-#  #     auto-picked up by IRSA / IAM-role workflows.
+#  #   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY  — standard AWS env
+#  #     variable names. Convenient when your deployment env already
+#  #     exports them (CI runners, EC2 host with IAM-user creds in env).
 #  #   TS_S3_ACCESS_KEY_ID / TS_S3_SECRET_ACCESS_KEY  — project-specific
 #  #     overrides that WIN over both the YAML and the AWS_* env vars.
 #  #     Use these when your host has unrelated AWS_* set and you want
 #  #     octo-server to talk to a different account (e.g. R2 / B2).
+#  #
+#  # NOTE: ServiceS3 currently signs with STATIC credentials only. IRSA /
+#  # IMDSv2 / web-identity / SSO credential provider chains are NOT
+#  # exercised — the SDK is constructed via `credentials.NewStaticV4`.
+#  # If you need rotating credentials (EKS pod role, ECS task role,
+#  # Instance Profile), wire that into your deployment pipeline so it
+#  # writes fresh AWS_* env vars before octo-server starts, or open an
+#  # issue to add a provider-chain option to ServiceS3.
 #  accessKeyID: "AKIA..."
 #  secretAccessKey: "..."
 #
@@ -257,6 +304,28 @@ minio:
 #  # MUST be scheme://host[:port] with NO path component (a path
 #  # prefix would be stripped before SigV4 canonical URI computation
 #  # and produce 403 SignatureDoesNotMatch at the browser).
+#  #
+#  # Two supported shapes — detected from the host:
+#  #
+#  #   (1) Bucket-subdomain: host begins with "<bucket>."
+#  #       e.g. `https://my-octo-bucket.files.example.com`
+#  #       The SDK strips "<bucket>." and uses BucketLookupDNS so the
+#  #       resulting signed URL equals `<BucketURL>/<key>` exactly.
+#  #
+#  #   (2) CDN alias: host has NO "<bucket>." prefix
+#  #       e.g. `https://files.example.com`
+#  #       The SDK uses BucketLookupPath and emits
+#  #       `<host>/<bucket>/<key>` (with bucket in the URL path).
+#  #       Note that `DownloadURL` here returns `<BucketURL>/<key>`
+#  #       (without the bucket segment), so the CDN must be configured
+#  #       to route BOTH shapes to the bucket origin — one for the
+#  #       browser following the unsigned URL, the other for the
+#  #       presigned PUT/GET path.
+#  #
+#  # HTTPS-only contract: ServiceS3's primary endpoint (`s3.endpoint`)
+#  # always uses HTTPS. BucketURL is treated as operator-owned
+#  # infrastructure and DOES honor `http://` for local emulator
+#  # deployments — set this consciously, not by accident.
 #  # bucketURL: "https://files.example.com"
 #
 #  # OPTIONAL: object-key prefix for multi-environment isolation

--- a/modules/file/testdata/octo-server.yaml
+++ b/modules/file/testdata/octo-server.yaml
@@ -196,46 +196,27 @@ minio:
 #          "ExposeHeaders": ["ETag"],
 #          "MaxAgeSeconds": 3000
 #        }]
-#   4. Public-read posture: octo-server's `/v1/file/preview/*` redirects
-#      to the UNSIGNED object URL returned by `ServiceS3.DownloadURL`,
-#      and the multipart upload response stores that same unsigned URL
-#      as the file's `path`. Both are consumed by clients without
-#      signing, mirroring how the MinIO and COS backends operate today.
-#      For AWS S3 this means operators choose ONE of three deployment
-#      shapes; the right choice is operator-specific. Block Public
-#      Access ON without one of these options will cause 403 on every
-#      preview and on every stored object reference.
+#   4. Browser-facing URL posture: with Block Public Access ON (the AWS
+#      default), the unsigned URLs returned by `/v1/file/preview/*` and
+#      stored in upload responses cannot be opened directly by clients.
+#      Two clean deployment shapes:
 #
-#      (A) CloudFront + Origin Access Control (RECOMMENDED for AWS-only)
+#      (A) CloudFront + Origin Access Control (RECOMMENDED for AWS)
 #          • Bucket: keep Block Public Access ON.
 #          • Front the bucket with CloudFront; attach an OAC so
 #            CloudFront identifies itself to the bucket; bucket policy
 #            grants `s3:GetObject` to that CloudFront principal only.
-#          • Set `s3.bucketURL` to the CloudFront distribution URL.
-#          • Pros: bucket stays fully private; URLs stable; cacheable.
-#          • Cons: cold-start latency on new keys; CloudFront billing.
+#          • Set `s3.downloadURL` to the CloudFront distribution URL
+#            (e.g. https://d123.cloudfront.net). Browser GETs flow
+#            through CloudFront; presigned PUT/GET still go directly
+#            to S3 (signed against `s3.endpoint`, not the CDN host —
+#            no cache-poisoning or signature-mismatch risk).
 #
-#      (B) Bucket policy allow-list `s3:GetObject` to "*" (public read)
-#          • Bucket: turn Block Public Access OFF on "Block public
-#            access through new policies"; attach a policy granting
-#            `s3:GetObject` on `arn:aws:s3:::<bucket>/*` to `"*"`.
-#          • Set `s3.bucketURL` empty so URLs use the AWS endpoint
-#            host directly.
-#          • Pros: simplest; lowest cost.
-#          • Cons: ALL object contents are world-readable; defeats
-#            AWS perimeter defense. Only acceptable when none of the
-#            uploaded content is sensitive (e.g. public avatars).
-#
-#      (C) Client-side: always use `/v1/file/download/url` (presigned)
-#          • Bucket: keep Block Public Access ON.
-#          • Re-route every client that today hits `/v1/file/preview/*`
-#            to `/v1/file/download/url` instead, and re-resolve stored
-#            `path` fields through the same endpoint before use.
-#          • Pros: bucket stays private without CDN; per-URL access
-#            control.
-#          • Cons: requires client refactor; URLs expire (default 30
-#            min); previously-stored `path` fields are no longer
-#            directly usable.
+#      (B) All-presigned: keep Block Public Access ON, route every
+#          client read through `/v1/file/download/url` (presigned GET),
+#          and avoid persisting unsigned URLs. Leave `s3.downloadURL`
+#          empty. Trade-off: URLs expire (default 30 min) and stored
+#          `path` fields must be re-signed before use.
 #
 # Region / endpoint semantics:
 #
@@ -288,45 +269,44 @@ minio:
 #  #     Use these when your host has unrelated AWS_* set and you want
 #  #     octo-server to talk to a different account (e.g. R2 / B2).
 #  #
-#  # NOTE: ServiceS3 currently signs with STATIC credentials only. IRSA /
-#  # IMDSv2 / web-identity / SSO credential provider chains are NOT
-#  # exercised — the SDK is constructed via `credentials.NewStaticV4`.
-#  # If you need rotating credentials (EKS pod role, ECS task role,
-#  # Instance Profile), wire that into your deployment pipeline so it
-#  # writes fresh AWS_* env vars before octo-server starts, or open an
-#  # issue to add a provider-chain option to ServiceS3.
 #  accessKeyID: "AKIA..."
 #  secretAccessKey: "..."
 #
-#  # OPTIONAL: BucketURL — overrides the URL returned by DownloadURL
-#  # and the host signed against by presigned PUT/GET. Set this when
-#  # operators front the bucket with CloudFront / a custom domain.
-#  # MUST be scheme://host[:port] with NO path component (a path
-#  # prefix would be stripped before SigV4 canonical URI computation
-#  # and produce 403 SignatureDoesNotMatch at the browser).
+#  # OPTIONAL: SessionToken — AWS STS session token paired with
+#  # temporary credentials (IRSA, IMDSv2, EKS Pod Identity, AWS SSO,
+#  # `aws sts assume-role`). Leave empty for long-lived IAM user
+#  # keys. ServiceS3 forwards the token verbatim into SigV4; the
+#  # signed URL gains `X-Amz-Security-Token` in its query.
 #  #
-#  # Two supported shapes — detected from the host:
+#  # Lifecycle: ServiceS3 does NOT refresh tokens itself. Your
+#  # deployment pipeline must rotate AccessKeyID / SecretAccessKey /
+#  # SessionToken (typically via env vars) before STS expiry (default
+#  # 1h, max 12h depending on role configuration). A stale token
+#  # produces 403 ExpiredToken on every signed request — fail loud,
+#  # not silent.
 #  #
-#  #   (1) Bucket-subdomain: host begins with "<bucket>."
-#  #       e.g. `https://my-octo-bucket.files.example.com`
-#  #       The SDK strips "<bucket>." and uses BucketLookupDNS so the
-#  #       resulting signed URL equals `<BucketURL>/<key>` exactly.
+#  # Env-var precedence (octo-lib wiring, project-prefixed wins):
+#  #   AWS_SESSION_TOKEN
+#  #   TS_S3_SESSION_TOKEN  (preferred for octo deployments)
+#  # sessionToken: ""
+#
+#  # OPTIONAL: DownloadURL — browser-facing base URL for UNSIGNED
+#  # object access (preview redirects, upload-response `path` field).
+#  # NEVER signs SigV4: presigned PUT/GET URLs are ALWAYS signed
+#  # against `s3.endpoint`, regardless of this value. Set this when
+#  # you front the bucket with CloudFront / a custom domain for
+#  # browser reads.
 #  #
-#  #   (2) CDN alias: host has NO "<bucket>." prefix
-#  #       e.g. `https://files.example.com`
-#  #       The SDK uses BucketLookupPath and emits
-#  #       `<host>/<bucket>/<key>` (with bucket in the URL path).
-#  #       Note that `DownloadURL` here returns `<BucketURL>/<key>`
-#  #       (without the bucket segment), so the CDN must be configured
-#  #       to route BOTH shapes to the bucket origin — one for the
-#  #       browser following the unsigned URL, the other for the
-#  #       presigned PUT/GET path.
+#  # Must be scheme://host[:port] with NO path component (same
+#  # contract as MinioConfig.DownloadURL).
 #  #
-#  # HTTPS-only contract: ServiceS3's primary endpoint (`s3.endpoint`)
-#  # always uses HTTPS. BucketURL is treated as operator-owned
-#  # infrastructure and DOES honor `http://` for local emulator
-#  # deployments — set this consciously, not by accident.
-#  # bucketURL: "https://files.example.com"
+#  # Typical values:
+#  #   - empty                              → URLs use the canonical
+#  #                                          virtual-hosted form
+#  #                                          `https://<bucket>.<endpoint>/<key>`
+#  #   - CloudFront distribution            → https://d123.cloudfront.net
+#  #   - bucket-subdomain custom domain     → https://my-octo-bucket.cdn.example.com
+#  # downloadURL: "https://d123.cloudfront.net"
 #
 #  # OPTIONAL: object-key prefix for multi-environment isolation
 #  # against a shared bucket. Mirrors COS Prefix.


### PR DESCRIPTION
## Summary

Add a first-class `awsS3` value for `fileService` backed by a new `ServiceS3` (`modules/file/service_s3.go`). Targets AWS S3 and any S3-compatible storage that speaks SigV4 (Cloudflare R2, Backblaze B2, Wasabi, MinIO with a custom endpoint).

Consumes the `S3Config` struct + `s3.*` Viper bindings landed in [octo-lib#39](https://github.com/Mininglamp-OSS/octo-lib/pull/39) and the post-review redesign in [octo-lib#43](https://github.com/Mininglamp-OSS/octo-lib/pull/43) (BucketURL → DownloadURL with explicit "never signs SigV4" semantics, plus SessionToken for STS / IRSA / IMDSv2 / EKS Pod Identity workflows). `octo-lib` is tracked at `@main` (currently `11d9edbc`).

Activation:

```yaml
fileService: "awsS3"
s3:
  endpoint: "s3.us-west-2.amazonaws.com"
  region: "us-west-2"
  bucket: "my-octo-bucket"
  accessKeyID: "AKIA..."
  secretAccessKey: "..."
  # sessionToken: "..."                       # optional STS token (rotating creds)
  # downloadURL: "https://d123.cloudfront.net" # optional CDN front for unsigned reads
  # prefix: "prod/"                           # optional multi-env isolation
  # usePathStyle: false                       # optional, default virtual-hosted
```

## Motivation

The existing `minio` backend can be coaxed into talking to AWS S3 but only at painful cost: bucket selection is hard-coded to a path-prefix routing scheme over 10 reserved bucket names (`modules/file/helpers.go`), and the SigV4 region is pinned to `us-east-1`. Operators with a single bucket in a non-`us-east-1` region (the standard production shape on AWS, R2, B2) have no clean configuration path today.

The `tencentCOS` backend has the right single-bucket model and explicit-Region semantics, but its endpoint is hard-coded to `cos.<region>.myqcloud.com` and its config block is named after a specific cloud — reusing it for AWS would either lie about the backend or require touching code on every config change.

A dedicated `awsS3` backend gives operators an honest configuration block and consolidates the SigV4 / presigned-URL path that `ServiceMinio` and `ServiceCOS` already share at the SDK level (both are 100% `minio-go` under the hood).

## What changed since the initial review

The first review round flagged BucketURL host-shape detection (bucket-subdomain vs CDN-alias) as a footgun: operators had to reason about which deployment shape they were in, and the service maintained two signing clients to keep the `Host` header SigV4-canonical against the chosen shape. octo-lib#43 resolved this at the config layer by reframing the field as `DownloadURL` — an unsigned, browser-facing URL prefix only — and removing it from the signing path entirely. SessionToken was added in the same PR to cover rotating credentials, which the original review also flagged.

This PR was reworked accordingly:

- **One client, one signing host.** `newClient` now always signs against `cfg.S3.Endpoint`. The four-way client/dispatch helpers (`publicEndpoint`, `newPublicClient`, `newCanonicalPresignClient`, `pickPresignClient`) are gone. `service_s3.go` is now ~340 lines, down from ~440.
- **SessionToken flows into SigV4.** `credentials.NewStaticV4(id, secret, cfg.SessionToken)` — when set, presigned URLs gain `X-Amz-Security-Token`. Lifecycle (token refresh before STS expiry) is the deployment pipeline's responsibility; documented in the yaml.
- **DownloadURL never signs.** Pinned by `TestServiceS3_PresignedURL_DownloadURLDoesNotAffectSigning` against four DownloadURL shapes (CloudFront, generic CDN, bucket-subdomain custom domain, local emulator). If a future change accidentally reads DownloadURL in the signing path, that test catches it.
- **Fail-fast covers credentials.** `validateConfig` now requires `AccessKeyID` and `SecretAccessKey` in addition to `Endpoint` / `Region` / `Bucket`. SessionToken is intentionally NOT validated — it's optional by contract.
- **api.go strip blocks are gated by `fileService`.** Per @Jerry-Xin's non-blocking nit: the COS-style and S3-style URL strip blocks now only fire when the corresponding backend is active, so a COS deployment can never mistakenly strip an S3 bucket segment off a round-tripped URL and vice versa.
- **yaml docs simplified.** Removed the A/B/C public-read trade-off matrix and the bucket-subdomain vs CDN-alias shape table (both obsoleted by DownloadURL being unsigned). The CloudFront+OAC recipe is now a single paragraph: "set downloadURL to the distribution URL; browser reads flow through CloudFront, presigned PUT/GET still go directly to S3."

## What ships in this PR

### New backend (`modules/file/service_s3.go`)

- Single-bucket model; the upload type segment (`chat/`, `moment/`, ...) lives in the object key, not as a separate bucket. Mirrors `ServiceCOS`.
- Explicit `Region` from `cfg.S3.Region` — no SigV4 fallbacks, no implicit `GetBucketLocation` round-trips on each request.
- Fail-fast `validateConfig()` surfaces missing `endpoint` / `region` / `bucket` / `accessKeyID` / `secretAccessKey` as a clear error string at first call instead of opaque SDK errors. `sessionToken` is optional.
- HTTPS-only by design for the signing endpoint. Operators who need HTTP for a local emulator should keep using the existing `minio` backend.
- `BucketLookupDNS` chosen over `BucketLookupAuto` so signed URLs match the configured hostname. AWS endpoints still get internally canonicalized to their dual-stack variant by minio-go (`s3.dualstack.<region>.amazonaws.com`) — documented in yaml comments so operators allow-listing the non-dual-stack hostname know to add the dual-stack one.
- Presigned PUT signs `Content-Length` into canonical headers (same `MaxFileSize`-bypass guard `ServiceMinio` / `ServiceCOS` already enforce).
- `DownloadURL` is consumed only by `publicURL` (unsigned URL construction). The compiler enforces the "never signs" contract — there is no code path from `DownloadURL` to `minio.New`.
- Same `Prefix` semantics as `ServiceCOS` for multi-environment shared-bucket isolation.

### Dispatch wiring (`modules/file/service.go`)

`NewService` factory accepts the string literal `"awsS3"`. A follow-up `octo-lib` PR should add `FileServiceAwsS3 FileService = "awsS3"` so this branch can use a typed constant; not blocking on it to keep this PR focused.

### Round-trip URL strip (`modules/file/api.go`)

`getDownloadURL` strips the active backend's prefix (and the path-style bucket segment for S3) when the client posts back a full URL we previously issued. Without it, `PresignedGetURL`'s `withPrefix` double-prefixes the object key and the GET 404s. Mirrors the YUJ-848 hotfix for COS. The block now switches on `cfg.FileService`, so COS deployments never touch S3 fields and vice versa.

### Documentation (`modules/file/testdata/octo-server.yaml`)

Adds a fully-commented `awsS3` configuration block covering:

- Pre-deployment checklist (bucket pre-create, IAM policy, CORS, Block Public Access).
- Two clean deployment shapes for the browser-facing URL posture: CloudFront+OAC (recommended) and all-presigned.
- Region / endpoint semantics across AWS / R2 / B2.
- SigV4 signed-header contract pointer back to `getUploadCredentials`.
- `sessionToken` field with lifecycle notes (token refresh is the deployment pipeline's responsibility) and the `AWS_SESSION_TOKEN` / `TS_S3_SESSION_TOKEN` env-var overrides.
- The presigned-URL support matrix at the top of the file now includes a row for `awsS3`.

## Backward compatibility

- `MinioConfig`, `COSConfig`, and all existing backends (`minio`, `tencentCOS`, `aliyunOSS`, `qiniu`, `seaweedFS`) are untouched. Existing deployments require zero config changes.
- The `s3.*` Viper key namespace is brand-new in octo-lib#39 / #43 and doesn't collide with anything.
- `S3Config` zero value is inert — no consumer reads it until `fileService: "awsS3"` is set.

## Test plan

- [x] Unit tests in `service_s3_test.go`:
  - fail-fast on each missing required field (`endpoint` / `region` / `bucket` / `accessKeyID` / `secretAccessKey`), all-missing combined, and explicit no-op when only `sessionToken` is empty
  - `AlwaysSignsAgainstEndpoint` — the post-#43 contract: presigned PUT signs against `Endpoint`, includes `host` + `content-length` in signed headers
  - `DownloadURLDoesNotAffectSigning` — pins the contract across four DownloadURL shapes (CloudFront, generic CDN, bucket-subdomain custom domain, local emulator); presigned PUT and GET hosts must always derive from `Endpoint`
  - `SessionToken_AppearsInSignedURL` — when `SessionToken` is set, both PUT and GET presigned URLs carry `X-Amz-Security-Token` equal to the configured token
  - DownloadURL path construction: virtual-hosted, path-style, DownloadURL override, with prefix
  - `Endpoint` tolerates a full URL (scheme stripped silently)
  - malformed object key rejection (trailing slash, embedded double slash, leading slash) on both PUT and GET
  - `fileSize <= 0` rejection
  - `Content-Disposition` RFC 5987 encoding for non-ASCII filenames; inline disposition path

- [x] Live-AWS integration tests in `service_s3_aws_integration_test.go` — 4 cases, env-gated via `TS_S3_TEST_*` so contributors without credentials skip cleanly. Run with:

  ```bash
  TS_S3_TEST_ENDPOINT=s3.<region>.amazonaws.com \
  TS_S3_TEST_REGION=<region> \
  TS_S3_TEST_BUCKET=<bucket> \
  TS_S3_TEST_ACCESS_KEY_ID=AKIA... \
  TS_S3_TEST_SECRET_ACCESS_KEY=... \
  # optional: TS_S3_TEST_DOWNLOAD_URL=https://d123.cloudfront.net
  # optional: TS_S3_TEST_USE_PATH_STYLE=true
  go test -race -count=1 -v ./modules/file/ -run TestAWSS3Integration
  ```

  Coverage:
  1. `UploadDownloadRoundtrip` — UploadFile → GetFile → byte-equal body assertion.
  2. `PresignedPUTRoundtrip` — server signs PUT URL → HTTP PUT echoing signed headers → AWS accepts → server signs GET URL → HTTP GET → body assertion. Full browser direct-upload flow against real AWS.
  3. `PresignedPUTRejectsSizeMismatch` — sends 100 bytes against a URL signed for 1024 bytes, asserts AWS returns 4xx. Validates the Content-Length signing is enforced end-to-end.
  4. `DownloadURLShape` — sanity-checks the public URL host / path shape; asserts `DownloadURL` host dominates when set.

  Each integration run isolates writes under a unique prefix (`octo-integration-test/<timestamp>-<rand>/`) and `t.Cleanup` removes the test objects.

- [x] `TestGetDownloadURL_S3PrefixAndBucketStrip` in `api_unit_test.go` — 6 sub-cases covering virtual-hosted, path-style, CDN `downloadURL`, no-prefix, and non-URL pass-through. Each case sets `cfg.FileService = "awsS3"` so the gated strip block fires.
- [x] `TestGetDownloadURL_S3_RealServiceRoundTrip` — regression test wiring the real `ServiceS3` (not a mock) to catch SigV4 normalization hazards the mock can't.
- [x] `go vet ./...` clean.
- [x] `go build ./...` clean.
- [x] All existing unit tests in `modules/file/` pass with `-race`.

## Follow-ups (separate PRs, not blocking)

1. **octo-lib** — add `FileServiceAwsS3 FileService = "awsS3"` constant for type-safe dispatch. This PR uses a string literal in `NewService`.
2. **octo-server** — refactor `ServiceCOS` to share the SigV4 / presigned-URL helpers with `ServiceS3`. Pure refactor, behavior-preserving. Would consolidate the ~400 lines of subtle signing contract notes into one place.
3. **octo-server** — `TestAWSS3Integration_SessionToken_E2E` exercising a real STS AssumeRole roundtrip. Requires the test runner to have `sts:AssumeRole` against a role with bucket access; deliberately deferred so the suite stays runnable with static keys.
4. **octo-server** — `docs/aws-s3-setup.md` with full IAM policy / CORS / Block Public Access guidance, with screenshots.

## Open questions for maintainers

- Direction on whether to land the type-safe `FileServiceAwsS3` constant follow-up as a coupled change vs. defer to follow-up PR.
- Default of `UsePathStyle=false` — happy to flip if anyone has a deployment shape that argues for `true` as the default.
