### PR TITLE
fix(oidc): always serialize masked_email/masked_phone in /bind/info

### DIFF
--- a/docs/octo-aegis/oidc-bind-frontend.md
+++ b/docs/octo-aegis/oidc-bind-frontend.md
@@ -114,7 +114,7 @@ bind_token 在 5 分钟 TTL 内：
 }
 ```
 
-- `masked_email` / `masked_phone` 可能为空字符串（IdP 没下发或不可信）
+- `masked_email` / `masked_phone` **始终出现**在响应中；IdP 没下发或不可信时序列化为 `""`（空字符串），前端按 truthy 判断隐藏对应行即可（GH#148）
 - `methods` 来自后端 `cfg.Methods ∩ claims 支持`：claims 无 verified phone 时不会出现 `sms_otp`
 - `support_contact` 来自 env，可空，用于 FR-7 "联系管理员"兜底
 
@@ -224,7 +224,7 @@ bind_token 在 5 分钟 TTL 内：
 - token 在 `/authorize → callback → 签发` 那一刻起算 5 分钟（`OCTO_OIDC_BIND_TOKEN_TTL_SEC`）
 - verify 通过**不会**续 TTL；如果用户在 token 快过期时才点 verify，剩下的时间就是 confirm 必须完成的窗口
 - 已过期的 token 走任何端点都会返 410；前端拿到 410 后应当引导用户重新走 OIDC 登录
-- masked_phone 字段：claims 无手机号时 JSON 里**没有**该字段（不要靠 `=== ""` 判断）；存在时形如 `"****5678"`
+- `masked_email` / `masked_phone` 字段：claims 无对应值时序列化为 `""`(空字符串,字段**始终存在**),存在时形如 `"a***@example.com"` / `"****5678"`;前端按 truthy 判断隐藏对应行(GH#148)
 
 ## 4. 关键约束 / 注意事项
 

--- a/modules/oidc/bind_service.go
+++ b/modules/oidc/bind_service.go
@@ -44,8 +44,13 @@ type BindLocator interface {
 //
 // 不含 sub / issuer / claims 原值,避免社工攻击(SR-7)。
 type BindInfoResp struct {
-	MaskedEmail    string       `json:"masked_email,omitempty"`
-	MaskedPhone    string       `json:"masked_phone,omitempty"`
+	// MaskedEmail / MaskedPhone 协议约定恒在(无 omitempty):空字符串 "" 表示
+	// 该 claim 不存在,前端按 truthy 分支隐藏对应行。omitempty 会让"无 email"
+	// 路径整字段消失,迫使前端把"字段缺失"与"字段为空"当两种状态处理,
+	// 也会触发前端 schema validator 抛出 "masked_email must be string"
+	// 被通用错误处理误报为"网络异常"(GH#148)。
+	MaskedEmail    string       `json:"masked_email"`
+	MaskedPhone    string       `json:"masked_phone"`
 	Name           string       `json:"name,omitempty"`
 	Methods        []BindMethod `json:"methods"`
 	SupportContact string       `json:"support_contact,omitempty"`

--- a/modules/oidc/bind_service_test.go
+++ b/modules/oidc/bind_service_test.go
@@ -2,7 +2,9 @@ package oidc
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -303,6 +305,40 @@ func TestBindService_Info_MasksIdentity(t *testing.T) {
 	// 检测无 sub/issuer 泄漏(以字面搜)
 	if got := info.MaskedEmail + info.MaskedPhone + info.Name; got == "" {
 		t.Fatal("info empty?")
+	}
+}
+
+// TestBindService_Info_MaskedFieldsAlwaysSerialized GH#148:masked_email /
+// masked_phone 必须始终出现在 JSON 中,空 claim 序列化为 ""(而非 omit)。
+// omitempty 会让前端 schema validator 抛 "masked_email must be string",
+// 通用错误映射把它误报为"网络异常",见 issue 148。
+func TestBindService_Info_MaskedFieldsAlwaysSerialized(t *testing.T) {
+	svc, _, _, _ := newTestBindService(t)
+	c := sampleClaims()
+	c.Email = ""
+	c.PhoneNumber = ""
+	c.PhoneVerified = false
+	jti, err := svc.Issue(context.Background(), c, sampleSD())
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	info, err := svc.Info(context.Background(), jti)
+	if err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if info.MaskedEmail != "" || info.MaskedPhone != "" {
+		t.Fatalf("expected empty masks, got email=%q phone=%q", info.MaskedEmail, info.MaskedPhone)
+	}
+	raw, err := json.Marshal(info)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := string(raw)
+	if !strings.Contains(body, `"masked_email":""`) {
+		t.Fatalf("masked_email key missing or non-empty in JSON: %s", body)
+	}
+	if !strings.Contains(body, `"masked_phone":""`) {
+		t.Fatalf("masked_phone key missing or non-empty in JSON: %s", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #148.

`/v1/auth/oidc/{provider}/bind/info` previously used `json:\"masked_email,omitempty\"` and `json:\"masked_phone,omitempty\"`, so SSO identities with no email (e.g. phone-only OIDC login) had `masked_email` omitted from the response. The frontend schema validator treats `masked_email` as a required string and throws a non-HTTP error, which the generic error mapper surfaces as the misleading "网络异常，请检查后重试" with no request error and no console error.

This PR aligns both masked fields with the existing `create_blocked` convention: the key is always present, and an empty string `""` means "no value". Existing frontend render paths (`info.masked_email ? ... : null`) already handle `""` correctly, so no frontend change is required.

## Changes

- `modules/oidc/bind_service.go`: drop `omitempty` from `BindInfoResp.MaskedEmail` and `BindInfoResp.MaskedPhone`; add comment explaining the contract.
- `modules/oidc/bind_service_test.go`: add `TestBindService_Info_MaskedFieldsAlwaysSerialized` asserting both keys appear with `""` when the SSO identity has neither email nor phone.
- `docs/octo-aegis/oidc-bind-frontend.md`: update the frontend contract description — previously documented that `masked_phone` could be absent and warned against `=== ""` checks; now states both fields are always present, empty string means "no value".

## Test plan

- [x] `go test ./modules/oidc -run TestBindService_Info -race -count=1` passes
- [x] `go test ./modules/oidc -run 'TestRedisBindStore_Behavior_Integration|TestBindService_Info' -count=1` passes (after recreating local test DB)
- [ ] Frontend BindPage renders correctly for phone-only SSO identity (no "网络异常" error)