### PR TITLE
fix(message): backfill resolved space_id in sync conversation/sidebar responses (#153)

### DIFF
--- a/modules/message/api_conversation.go
+++ b/modules/message/api_conversation.go
@@ -409,6 +409,22 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 	uids := make([]string, 0, len(conversations))
 	channelIDs := make([]string, 0, len(conversations))
 	threadChannelShortIDMap := make(map[string]string)
+	// groupNoSeen 用于 groupNos 的去重：COMMUNITY_TOPIC 频道除了把自身
+	// channel_id（"{groupNo}____{shortID}"）加入 groupNos 外，还要把解析出
+	// 的 parent groupNo 也加进去，否则当父群本批不在 IM 返回里时，
+	// fillConversationSpaceIDs 拿不到父群的 SpaceID，导致 thread 频道的
+	// SpaceID 被回填为空（GH octo-server#153 Round-2 Critical 1）。
+	groupNoSeen := make(map[string]struct{}, len(conversations))
+	addGroupNo := func(no string) {
+		if no == "" {
+			return
+		}
+		if _, ok := groupNoSeen[no]; ok {
+			return
+		}
+		groupNoSeen[no] = struct{}{}
+		groupNos = append(groupNos, no)
+	}
 	if len(conversations) > 0 {
 		for _, conversation := range conversations {
 			if len(conversation.Recents) == 0 {
@@ -417,12 +433,16 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 			if conversation.ChannelType == common.ChannelTypePerson.Uint8() {
 				uids = append(uids, conversation.ChannelID)
 			} else {
-				groupNos = append(groupNos, conversation.ChannelID)
+				addGroupNo(conversation.ChannelID)
 			}
 			channelIDs = append(channelIDs, conversation.ChannelID)
 			if conversation.ChannelType == common.ChannelTypeCommunityTopic.Uint8() {
-				if _, shortID, err := thread.ParseChannelID(conversation.ChannelID); err == nil {
+				if parentNo, shortID, err := thread.ParseChannelID(conversation.ChannelID); err == nil {
 					threadChannelShortIDMap[conversation.ChannelID] = shortID
+					// 父群可能未出现在 IM 批次里（最近无消息），但 fillConversationSpaceIDs
+					// 需要从 groupMap[parentNo] 取 SpaceID。这里显式合入预取集合，
+					// GetGroupDetails 才会覆盖父群。
+					addGroupNo(parentNo)
 				}
 			}
 		}

--- a/modules/message/api_conversation.go
+++ b/modules/message/api_conversation.go
@@ -682,6 +682,23 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 	// 避免前端 fromHomeSpaceId / fromIsExternal getter 在增量同步路径读到空值。
 	co.enrichConversationExternalMarkers(syncUserConversationResps)
 
+	// GH#153: 把 resolved space_id 回填到 SyncUserConversationResp，
+	// 同时为外部群成员填充 my_source_space_id。
+	// 群聊的 channel_id 是裸 group_no，newSyncUserConversationResp 走
+	// ParseChannelID 拿不到 SpaceID；客户端 WebSocket 收到群消息时若
+	// 没有 conversation-level 的 SpaceID 兜底，就会 fail-open 把消息
+	// 渲染到错误 Space tab。这里用 handler 早已批量查好的 groupMap +
+	// externalGroupMap 一次性补齐，避免客户端再发请求。
+	externalGroupMap, externalErr := co.groupDB.QueryExternalGroupNosForUser(loginUID)
+	if externalErr != nil {
+		// 非致命：缺失 my_source_space_id 不影响 conversation-level
+		// SpaceID 回填；保持空 map 让 fillConversationSpaceIDs 退化为
+		// 仅填 SpaceID。FilterConversationsBySpace 走它自己的失败兜底。
+		co.Warn("查询外部群失败，跳过 my_source_space_id 回填", zap.Error(externalErr))
+		externalGroupMap = make(map[string]string)
+	}
+	fillConversationSpaceIDs(syncUserConversationResps, groupMap, externalGroupMap)
+
 	// 查询通话中的频道
 	// 加入的群聊
 	joinedGroups, err := co.groupService.GetGroupsWithMemberUID(loginUID)
@@ -1247,9 +1264,16 @@ func (u userResp) from(user *user.Detail, avatarPath string) userResp {
 
 // SyncUserConversationResp 最近会话离线返回
 type SyncUserConversationResp struct {
-	ChannelID        string                 `json:"channel_id"`                   // 频道ID
-	ChannelType      uint8                  `json:"channel_type"`                 // 频道类型
-	SpaceID          string                 `json:"space_id,omitempty"`           // Space ID
+	ChannelID   string `json:"channel_id"`             // 频道ID
+	ChannelType uint8  `json:"channel_type"`           // 频道类型
+	SpaceID     string `json:"space_id,omitempty"`     // Space ID
+	// MySourceSpaceID 仅在 GROUP / COMMUNITY_TOPIC 频道且当前用户以外部成员
+	// 身份加入时非空。值取自 group_member.source_space_id，对应"我从哪个
+	// Space 加入了这个外部群"。客户端 WebSocket 收到该群实时消息时，可据此
+	// 把消息归属到当前 user 的 source Space —— 与服务端
+	// FilterConversationsBySpace 对外部群的可见性判定保持同口径，避免
+	// 三端 fail-open 把跨 Space 消息渲染到错误的 Space tab (GH#153)。
+	MySourceSpaceID  string                 `json:"my_source_space_id,omitempty"` // 外部群成员的 source Space ID
 	Thread           *threadMetaResp        `json:"thread,omitempty"`             // 子区元数据（仅 thread 频道）
 	CategoryID       *string                `json:"category_id,omitempty"`        // 用户自定义分类ID（仅群组）
 	CategorySort     int                    `json:"category_sort,omitempty"`      // 分类内排序（仅群组）
@@ -1364,6 +1388,65 @@ func newSyncUserConversationResp(resp *config.SyncUserConversationResp, extra *c
 type threadMetaResp struct {
 	SourceMessageID *int64 `json:"source_message_id,omitempty"` // 源消息ID
 	MessageCount    int64  `json:"message_count"`               // 消息数
+}
+
+// fillConversationSpaceIDs 把 resolved SpaceID + MySourceSpaceID 回填到 group /
+// thread 频道的 SyncUserConversationResp。
+//
+// 背景 (GH octo-server#153)：
+//   - newSyncUserConversationResp 通过 spacepkg.ParseChannelID(channelID) 推导
+//     SpaceID。但群聊和子区的 channel_id 是裸 group_no（或 "{groupNo}____{shortID}"），
+//     ParseChannelID 返回空串，导致客户端在 conversation/sync 响应里拿不到
+//     conversation-level 的 Space 归属。
+//   - 三端客户端收到 WebSocket 实时消息时，会 fallback 到 conversation-level
+//     SpaceID 决定渲染到哪个 Space tab。空字符串触发 fail-open，跨 Space 消息
+//     被错误渲染到当前 tab，构成 P1 信息泄漏（issue #153）。
+//
+// 回填规则：
+//   - GROUP: SpaceID = groupMap[channelID].SpaceID（group 表权威值）。
+//     用户作为外部成员加入时，再读 externalGroupMap 给 MySourceSpaceID 赋值。
+//   - COMMUNITY_TOPIC: SpaceID = parent group 的 SpaceID（与 FilterRawConversationsBySpace
+//     thread 分支的 fail-closed 同口径）。MySourceSpaceID 同样从 parent groupNo 取。
+//   - PERSON: 不动 —— 私聊的 Space 归属在消息级 payload.space_id 上，
+//     conversation 级别保持空，避免误把 DM 锁定到某个 Space。
+//
+// groupMap / externalGroupMap 都是 handler 已经查过的现成数据，本函数纯内存
+// 操作，不发任何 DB 请求。groupMap 缺失（如 thread 父群本批未活跃）时跳过该条
+// —— 客户端拿到空 SpaceID 会自己降级，比写错的值更安全。
+func fillConversationSpaceIDs(
+	resps []*SyncUserConversationResp,
+	groupMap map[string]*group.GroupResp,
+	externalGroupMap map[string]string,
+) {
+	for _, r := range resps {
+		if r == nil {
+			continue
+		}
+		switch r.ChannelType {
+		case common.ChannelTypeGroup.Uint8():
+			if g, ok := groupMap[r.ChannelID]; ok && g != nil {
+				if r.SpaceID == "" {
+					r.SpaceID = g.SpaceID
+				}
+			}
+			if src, ok := externalGroupMap[r.ChannelID]; ok {
+				r.MySourceSpaceID = src
+			}
+		case common.ChannelTypeCommunityTopic.Uint8():
+			parentNo, _, perr := thread.ParseChannelID(r.ChannelID)
+			if perr != nil {
+				continue
+			}
+			if g, ok := groupMap[parentNo]; ok && g != nil {
+				if r.SpaceID == "" {
+					r.SpaceID = g.SpaceID
+				}
+			}
+			if src, ok := externalGroupMap[parentNo]; ok {
+				r.MySourceSpaceID = src
+			}
+		}
+	}
 }
 
 // fillThreadMeta 批量填充子区会话的元数据

--- a/modules/message/api_conversation.go
+++ b/modules/message/api_conversation.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/channel"
 	chservice "github.com/Mininglamp-OSS/octo-server/modules/channel/service"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
@@ -553,6 +554,34 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 		}
 	}
 
+	// ---------- 群原始 space_id（不经 SetEffectiveSpaceID 改写） ----------
+	// Round-3 修复 (GH octo-server#154 Round-2 Finding 1)：
+	// GetGroupDetails 内部走 SetEffectiveSpaceIDFromMap，会把外部成员视角下的
+	// GroupResp.SpaceID 从群表权威值改写成成员的 source Space。
+	// fillConversationSpaceIDs 直接用 groupMap[groupNo].SpaceID 时拿到的就是被
+	// 改写后的 effective 值 → SyncUserConversationResp.SpaceID 与
+	// MySourceSpaceID 同值。响应契约要求 SpaceID 是群表的权威归属 Space，
+	// 必须另起一次 GetGroups(groupNos) 取原始 SpaceID 构建 rawGroupSpaceMap。
+	// GetGroups 返回的 InfoResp.SpaceID 直接来自群表行，不做 effective rewrite。
+	rawGroupSpaceMap := make(map[string]string, len(groupNos))
+	if len(groupNos) > 0 {
+		rawGroups, rawErr := co.groupService.GetGroups(groupNos)
+		if rawErr != nil {
+			// 非致命：缺失 SpaceID 回填会让客户端走"未知 Space"分支，
+			// 与历史 v1 fail-open 行为一致。FilterConversationsBySpace 走它自己
+			// 的 GetGroupSpaceMap 路径，互不影响。
+			co.Warn("查询群原始 SpaceID 失败，跳过 conversation-level SpaceID 回填",
+				zap.Error(rawErr))
+		} else {
+			for _, g := range rawGroups {
+				if g == nil {
+					continue
+				}
+				rawGroupSpaceMap[g.GroupNo] = g.SpaceID
+			}
+		}
+	}
+
 	// ---------- 群组分类  ----------
 	groupCategoryMap := map[string]*GroupCategorySetting{}
 	if len(groupNos) > 0 {
@@ -707,8 +736,14 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 	// 群聊的 channel_id 是裸 group_no，newSyncUserConversationResp 走
 	// ParseChannelID 拿不到 SpaceID；客户端 WebSocket 收到群消息时若
 	// 没有 conversation-level 的 SpaceID 兜底，就会 fail-open 把消息
-	// 渲染到错误 Space tab。这里用 handler 早已批量查好的 groupMap +
+	// 渲染到错误 Space tab。这里用 handler 早已批量查好的 rawGroupSpaceMap +
 	// externalGroupMap 一次性补齐，避免客户端再发请求。
+	//
+	// Round-3 修复 (GH octo-server#154 Round-2)：
+	//   - SpaceID 走 rawGroupSpaceMap（GetGroups 原始值），不用 groupMap
+	//     （GetGroupDetails 已被 SetEffectiveSpaceID 改写）→ Finding 1。
+	//   - 把 defaultSpaceID 传入用于 MySourceSpaceID 空值兜底（旧外部成员行
+	//     source_space_id=""），与 decideConvKeepInSpace 同口径 → Finding 2。
 	externalGroupMap, externalErr := co.groupDB.QueryExternalGroupNosForUser(loginUID)
 	if externalErr != nil {
 		// 非致命：缺失 my_source_space_id 不影响 conversation-level
@@ -717,7 +752,11 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 		co.Warn("查询外部群失败，跳过 my_source_space_id 回填", zap.Error(externalErr))
 		externalGroupMap = make(map[string]string)
 	}
-	fillConversationSpaceIDs(syncUserConversationResps, groupMap, externalGroupMap)
+	// defaultSpaceID 用于外部群 source_space_id="" 的空值兜底。
+	// 查询失败时返回空串，fillConversationSpaceIDs 自然退化为不写
+	// MySourceSpaceID —— omitempty 保持向后兼容。
+	defaultSpaceID := space.GetUserDefaultSpaceID(co.ctx, loginUID)
+	fillConversationSpaceIDs(syncUserConversationResps, rawGroupSpaceMap, externalGroupMap, defaultSpaceID)
 
 	// 查询通话中的频道
 	// 加入的群聊
@@ -1423,20 +1462,35 @@ type threadMetaResp struct {
 //     被错误渲染到当前 tab，构成 P1 信息泄漏（issue #153）。
 //
 // 回填规则：
-//   - GROUP: SpaceID = groupMap[channelID].SpaceID（group 表权威值）。
-//     用户作为外部成员加入时，再读 externalGroupMap 给 MySourceSpaceID 赋值。
+//   - GROUP: SpaceID = rawGroupSpaceMap[channelID]（group 表权威值，未经
+//     SetEffectiveSpaceID 改写）。用户作为外部成员加入时，再读 externalGroupMap
+//     给 MySourceSpaceID 赋值。
 //   - COMMUNITY_TOPIC: SpaceID = parent group 的 SpaceID（与 FilterRawConversationsBySpace
 //     thread 分支的 fail-closed 同口径）。MySourceSpaceID 同样从 parent groupNo 取。
 //   - PERSON: 不动 —— 私聊的 Space 归属在消息级 payload.space_id 上，
 //     conversation 级别保持空，避免误把 DM 锁定到某个 Space。
 //
-// groupMap / externalGroupMap 都是 handler 已经查过的现成数据，本函数纯内存
-// 操作，不发任何 DB 请求。groupMap 缺失（如 thread 父群本批未活跃）时跳过该条
+// Round-3 修复 (GH octo-server#154 Round-2 Finding 1)：
+//   - 之前传 groupMap (来自 GetGroupDetails) 的版本会被 SetEffectiveSpaceIDFromMap
+//     污染：外部成员视角下 group.SpaceID 已被改写成 source Space，导致
+//     SyncUserConversationResp.SpaceID 与 MySourceSpaceID 同值。响应契约要求
+//     SpaceID 是群表权威值，handler 必须额外用 GetGroups 拿原始 space_id 构建
+//     rawGroupSpaceMap 传入。
+//
+// Round-3 修复 (GH octo-server#154 Round-2 Finding 2)：
+//   - externalGroupMap[groupNo] 可能存在但值为空串（旧外部成员行
+//     source_space_id=""）。空串 + omitempty 会让客户端拿不到 my_source_space_id，
+//     无法判断外部群在哪个 Space 下可见。空值兜底到 defaultSpaceID，与
+//     decideConvKeepInSpace 同口径。
+//
+// rawGroupSpaceMap / externalGroupMap 都是 handler 已经查过的现成数据，本函数
+// 纯内存操作，不发任何 DB 请求。map 缺失（如 thread 父群本批未活跃）时跳过该条
 // —— 客户端拿到空 SpaceID 会自己降级，比写错的值更安全。
 func fillConversationSpaceIDs(
 	resps []*SyncUserConversationResp,
-	groupMap map[string]*group.GroupResp,
+	rawGroupSpaceMap map[string]string,
 	externalGroupMap map[string]string,
+	defaultSpaceID string,
 ) {
 	for _, r := range resps {
 		if r == nil {
@@ -1444,29 +1498,42 @@ func fillConversationSpaceIDs(
 		}
 		switch r.ChannelType {
 		case common.ChannelTypeGroup.Uint8():
-			if g, ok := groupMap[r.ChannelID]; ok && g != nil {
+			if sid, ok := rawGroupSpaceMap[r.ChannelID]; ok {
 				if r.SpaceID == "" {
-					r.SpaceID = g.SpaceID
+					r.SpaceID = sid
 				}
 			}
 			if src, ok := externalGroupMap[r.ChannelID]; ok {
-				r.MySourceSpaceID = src
+				r.MySourceSpaceID = resolveMySourceSpaceID(src, defaultSpaceID)
 			}
 		case common.ChannelTypeCommunityTopic.Uint8():
 			parentNo, _, perr := thread.ParseChannelID(r.ChannelID)
 			if perr != nil {
 				continue
 			}
-			if g, ok := groupMap[parentNo]; ok && g != nil {
+			if sid, ok := rawGroupSpaceMap[parentNo]; ok {
 				if r.SpaceID == "" {
-					r.SpaceID = g.SpaceID
+					r.SpaceID = sid
 				}
 			}
 			if src, ok := externalGroupMap[parentNo]; ok {
-				r.MySourceSpaceID = src
+				r.MySourceSpaceID = resolveMySourceSpaceID(src, defaultSpaceID)
 			}
 		}
 	}
+}
+
+// resolveMySourceSpaceID 把 externalGroupMap 的 source_space_id 解析为客户端实际
+// 可见的 Space：
+//   - 非空：直接返回。
+//   - 空串（旧外部成员行 source_space_id=""）：兜底到 defaultSpaceID
+//     （decideConvKeepInSpace 同口径，space_filter.go:171/234）。defaultSpaceID
+//     也是空时回退到空串——保持 omitempty 行为，与历史一致。
+func resolveMySourceSpaceID(sourceSpaceID, defaultSpaceID string) string {
+	if sourceSpaceID != "" {
+		return sourceSpaceID
+	}
+	return defaultSpaceID
 }
 
 // fillThreadMeta 批量填充子区会话的元数据

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -45,6 +45,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
@@ -440,11 +441,17 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 		externalGroupMap = map[string]string{}
 	}
 
+	// 2h. defaultSpaceID：用户最早加入的 Space，用于外部群 source_space_id="" 的
+	//     空值兜底（GH octo-server#154 Round-2 Finding 2，与 decideConvKeepInSpace
+	//     同口径）。查询失败回空串，sidebarMySourceSpaceID 退化为不写
+	//     my_source_space_id —— omitempty 保持向后兼容。
+	defaultSpaceID := space.GetUserDefaultSpaceID(sb.ctx, loginUID)
+
 	// 3. Build tab-specific items
 	var items []*SidebarItem
 	switch req.Tab {
 	case "follow":
-		items = buildFollowItems(conversations, categorySetting, unfollowedGroups, followedDMs, threadExtMap, groupExts, dmCategorySorts, groupSpaceMap, externalGroupMap)
+		items = buildFollowItems(conversations, categorySetting, unfollowedGroups, followedDMs, threadExtMap, groupExts, dmCategorySorts, groupSpaceMap, externalGroupMap, defaultSpaceID)
 		// Append standalone thread ext entries not present in IM result.
 		// Pass categorySetting + unfollowedGroups so parent-follow filter applies
 		// to DB-only thread entries as well (PR review Round-3 Blocking #4).
@@ -452,9 +459,9 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 		if failClosedForFollow("thread last_message_at query", err) {
 			return
 		}
-		items = mergeThreadEntries(items, threadExtRows, lastMsgAtMap, categorySetting, unfollowedGroups, groupSpaceMap, externalGroupMap)
+		items = mergeThreadEntries(items, threadExtRows, lastMsgAtMap, categorySetting, unfollowedGroups, groupSpaceMap, externalGroupMap, defaultSpaceID)
 	case "recent":
-		items = buildRecentItems(conversations, pinnedSet, groupSpaceMap, externalGroupMap)
+		items = buildRecentItems(conversations, pinnedSet, groupSpaceMap, externalGroupMap, defaultSpaceID)
 	}
 
 	// 4. Enrich pinned flag (follow tab items also need it)
@@ -717,6 +724,7 @@ func buildFollowItems(
 	dmCategorySorts map[string]int,
 	groupSpaceMap map[string]string,
 	externalGroupMap map[string]string,
+	defaultSpaceID string,
 ) []*SidebarItem {
 	items := make([]*SidebarItem, 0, len(convs))
 	for _, conv := range convs {
@@ -741,7 +749,7 @@ func buildFollowItems(
 				ChannelType:       conv.ChannelType,
 				ChannelID:         conv.ChannelID,
 				SpaceID:           groupSpaceMap[conv.ChannelID],
-				MySourceSpaceID:   externalGroupMap[conv.ChannelID],
+				MySourceSpaceID:   sidebarMySourceSpaceID(externalGroupMap, conv.ChannelID, defaultSpaceID),
 				Timestamp:         conv.Timestamp,
 				Unread:            conv.Unread,
 				IsFollowed:        true,
@@ -810,7 +818,8 @@ func buildFollowItems(
 				// thread 继承父群 SpaceID（GH octo-server#153）。
 				SpaceID:           groupSpaceMap[groupNo],
 				// thread 同样继承父群的 MySourceSpaceID（GH octo-server#153 Round-2 P1）。
-				MySourceSpaceID:   externalGroupMap[groupNo],
+				// Round-3 (GH#154 Round-2 Finding 2)：父群 source_space_id="" 兜底到 defaultSpaceID。
+				MySourceSpaceID:   sidebarMySourceSpaceID(externalGroupMap, groupNo, defaultSpaceID),
 				Timestamp:         conv.Timestamp,
 				Unread:            conv.Unread,
 				IsFollowed:        true,
@@ -842,6 +851,7 @@ func buildRecentItems(
 	pinnedSet map[string]struct{},
 	groupSpaceMap map[string]string,
 	externalGroupMap map[string]string,
+	defaultSpaceID string,
 ) []*SidebarItem {
 	cutoff := threeDaysAgo()
 	items := make([]*SidebarItem, 0, len(convs))
@@ -859,18 +869,20 @@ func buildRecentItems(
 		// 父群；PERSON 留空（GH octo-server#153，规则与 buildFollowItems 一致）。
 		// mySourceSpaceID 同口径：从 externalGroupMap 查 channelID / parentGroupNo
 		// （GH octo-server#153 Round-2 P1）。
+		// Round-3 (GH#154 Round-2 Finding 2)：externalGroupMap[k]="" 时兜底到
+		// defaultSpaceID，与 decideConvKeepInSpace 同口径。
 		spaceID := ""
 		mySourceSpaceID := ""
 		switch conv.ChannelType {
 		case common.ChannelTypeGroup.Uint8():
 			spaceID = groupSpaceMap[conv.ChannelID]
-			mySourceSpaceID = externalGroupMap[conv.ChannelID]
+			mySourceSpaceID = sidebarMySourceSpaceID(externalGroupMap, conv.ChannelID, defaultSpaceID)
 		case common.ChannelTypeCommunityTopic.Uint8():
 			groupNo, _, err := parseThreadChannelIDSidebar(conv.ChannelID)
 			if err == nil {
 				parentID = groupNo
 				spaceID = groupSpaceMap[groupNo]
-				mySourceSpaceID = externalGroupMap[groupNo]
+				mySourceSpaceID = sidebarMySourceSpaceID(externalGroupMap, groupNo, defaultSpaceID)
 			}
 		}
 		items = append(items, &SidebarItem{
@@ -919,6 +931,7 @@ func mergeThreadEntries(
 	unfollowedGroups map[string]struct{},
 	groupSpaceMap map[string]string,
 	externalGroupMap map[string]string,
+	defaultSpaceID string,
 ) []*SidebarItem {
 	if len(threadExtRows) == 0 {
 		return existing
@@ -968,7 +981,8 @@ func mergeThreadEntries(
 			// thread 继承父群 SpaceID（GH octo-server#153）。
 			SpaceID:           groupSpaceMap[groupNo],
 			// thread 同样继承父群的 MySourceSpaceID（GH octo-server#153 Round-2 P1）。
-			MySourceSpaceID:   externalGroupMap[groupNo],
+			// Round-3 (GH#154 Round-2 Finding 2)：父群 source_space_id="" 兜底到 defaultSpaceID。
+			MySourceSpaceID:   sidebarMySourceSpaceID(externalGroupMap, groupNo, defaultSpaceID),
 			Timestamp:         ts,
 			IsFollowed:        true,
 			FollowSort:        ext.FollowSort,
@@ -979,6 +993,27 @@ func mergeThreadEntries(
 		})
 	}
 	return result
+}
+
+// sidebarMySourceSpaceID 解析 sidebar item 的 my_source_space_id：
+//   - externalGroupMap 没记录该 groupNo（用户不是外部成员）：返回空串，omitempty
+//     让客户端拿不到字段，与历史一致。
+//   - 记录了非空 source_space_id：直接返回。
+//   - 记录了 source_space_id=""（旧外部成员行）：兜底到 defaultSpaceID
+//     （GH octo-server#154 Round-2 Finding 2，与 decideConvKeepInSpace 同口径）。
+//     defaultSpaceID 也空时退化为空串——保持向后兼容。
+func sidebarMySourceSpaceID(externalGroupMap map[string]string, groupNo, defaultSpaceID string) string {
+	if externalGroupMap == nil {
+		return ""
+	}
+	src, ok := externalGroupMap[groupNo]
+	if !ok {
+		return ""
+	}
+	if src != "" {
+		return src
+	}
+	return defaultSpaceID
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -99,6 +99,14 @@ type SidebarItem struct {
 	TargetID    string `json:"target_id"`
 	ChannelType uint8  `json:"channel_type"`
 	ChannelID   string `json:"channel_id"`
+	// SpaceID 是该 sidebar 条目所属 Space 的 ID（GH octo-server#153）。
+	//   - GROUP: group 表的 space_id；
+	//   - COMMUNITY_TOPIC: 父群的 space_id；
+	//   - PERSON: 留空 —— DM 的 Space 归属在消息级 payload.space_id 上，
+	//     conversation 级别保持空避免误锁定。
+	// 客户端 WebSocket 收到群消息时拿这个字段决定渲染到哪个 Space tab，
+	// 与服务端 FilterRawConversationsBySpace 的可见性判定同口径。
+	SpaceID     string `json:"space_id,omitempty"`
 	Timestamp   int64  `json:"timestamp"`
 	Unread      int    `json:"unread"`
 	IsPinned    bool   `json:"is_pinned"`
@@ -393,11 +401,23 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 		pinnedSet = map[string]struct{}{}
 	}
 
+	// 2f. groupNo -> space_id 映射，用于把 group / thread 父群的 SpaceID 回填到
+	//     SidebarItem.SpaceID（GH octo-server#153）。
+	//     使用 conversations（已 Space 过滤）作为输入：当前 Space tab 不会出现
+	//     其他 Space 的群，因此即便 group service 调用失败也只是少填一些字段，
+	//     不会泄露跨 Space 元数据。失败时退化为空 map，fail-open 把 SpaceID
+	//     置空，客户端走"未知 Space"分支（与历史行为一致）。
+	groupSpaceMap, ok := CollectGroupSpaceMap(conversations, sb.groupService)
+	if !ok {
+		sb.Warn("sidebar sync: group space map query failed (non-fatal, SidebarItem.SpaceID will be empty)")
+		groupSpaceMap = map[string]string{}
+	}
+
 	// 3. Build tab-specific items
 	var items []*SidebarItem
 	switch req.Tab {
 	case "follow":
-		items = buildFollowItems(conversations, categorySetting, unfollowedGroups, followedDMs, threadExtMap, groupExts, dmCategorySorts)
+		items = buildFollowItems(conversations, categorySetting, unfollowedGroups, followedDMs, threadExtMap, groupExts, dmCategorySorts, groupSpaceMap)
 		// Append standalone thread ext entries not present in IM result.
 		// Pass categorySetting + unfollowedGroups so parent-follow filter applies
 		// to DB-only thread entries as well (PR review Round-3 Blocking #4).
@@ -405,9 +425,9 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 		if failClosedForFollow("thread last_message_at query", err) {
 			return
 		}
-		items = mergeThreadEntries(items, threadExtRows, lastMsgAtMap, categorySetting, unfollowedGroups)
+		items = mergeThreadEntries(items, threadExtRows, lastMsgAtMap, categorySetting, unfollowedGroups, groupSpaceMap)
 	case "recent":
-		items = buildRecentItems(conversations, pinnedSet)
+		items = buildRecentItems(conversations, pinnedSet, groupSpaceMap)
 	}
 
 	// 4. Enrich pinned flag (follow tab items also need it)
@@ -668,6 +688,7 @@ func buildFollowItems(
 	threadExtMap map[string]*convext.Model,
 	groupExts map[string]*convext.Model,
 	dmCategorySorts map[string]int,
+	groupSpaceMap map[string]string,
 ) []*SidebarItem {
 	items := make([]*SidebarItem, 0, len(convs))
 	for _, conv := range convs {
@@ -691,6 +712,7 @@ func buildFollowItems(
 				TargetID:          conv.ChannelID,
 				ChannelType:       conv.ChannelType,
 				ChannelID:         conv.ChannelID,
+				SpaceID:           groupSpaceMap[conv.ChannelID],
 				Timestamp:         conv.Timestamp,
 				Unread:            conv.Unread,
 				IsFollowed:        true,
@@ -710,10 +732,12 @@ func buildFollowItems(
 				TargetID:    conv.ChannelID,
 				ChannelType: conv.ChannelType,
 				ChannelID:   conv.ChannelID,
-				Timestamp:   conv.Timestamp,
-				Unread:      conv.Unread,
-				IsFollowed:  true,
-				FollowSort:  ext.FollowSort,
+				// PERSON 频道 SpaceID 留空：DM 的 Space 归属在消息级 payload.space_id 上
+				// （GH octo-server#153）。
+				Timestamp:  conv.Timestamp,
+				Unread:     conv.Unread,
+				IsFollowed: true,
+				FollowSort: ext.FollowSort,
 			}
 			// PR #21 Round-6：DMCategoryID 现在已经是 VARCHAR(32) UUID（与 group_category
 			// 共用 namespace），直接透传给客户端即可。
@@ -754,6 +778,8 @@ func buildFollowItems(
 				TargetID:          conv.ChannelID,
 				ChannelType:       conv.ChannelType,
 				ChannelID:         conv.ChannelID,
+				// thread 继承父群 SpaceID（GH octo-server#153）。
+				SpaceID:           groupSpaceMap[groupNo],
 				Timestamp:         conv.Timestamp,
 				Unread:            conv.Unread,
 				IsFollowed:        true,
@@ -783,6 +809,7 @@ func buildFollowItems(
 func buildRecentItems(
 	convs []*config.SyncUserConversationResp,
 	pinnedSet map[string]struct{},
+	groupSpaceMap map[string]string,
 ) []*SidebarItem {
 	cutoff := threeDaysAgo()
 	items := make([]*SidebarItem, 0, len(convs))
@@ -796,10 +823,17 @@ func buildRecentItems(
 			_, pinned = pinnedSet[channelKey(conv.ChannelID, conv.ChannelType)]
 		}
 		parentID := ""
-		if conv.ChannelType == common.ChannelTypeCommunityTopic.Uint8() {
+		// spaceID 取自 groupSpaceMap：GROUP 直接查 channelID；COMMUNITY_TOPIC 取
+		// 父群；PERSON 留空（GH octo-server#153，规则与 buildFollowItems 一致）。
+		spaceID := ""
+		switch conv.ChannelType {
+		case common.ChannelTypeGroup.Uint8():
+			spaceID = groupSpaceMap[conv.ChannelID]
+		case common.ChannelTypeCommunityTopic.Uint8():
 			groupNo, _, err := parseThreadChannelIDSidebar(conv.ChannelID)
 			if err == nil {
 				parentID = groupNo
+				spaceID = groupSpaceMap[groupNo]
 			}
 		}
 		items = append(items, &SidebarItem{
@@ -807,6 +841,7 @@ func buildRecentItems(
 			TargetID:        conv.ChannelID,
 			ChannelType:     conv.ChannelType,
 			ChannelID:       conv.ChannelID,
+			SpaceID:         spaceID,
 			Timestamp:       conv.Timestamp,
 			Unread:          conv.Unread,
 			IsPinned:        pinned,
@@ -844,6 +879,7 @@ func mergeThreadEntries(
 	lastMsgAtMap map[string]*time.Time,
 	categorySetting map[string]*GroupCategorySetting,
 	unfollowedGroups map[string]struct{},
+	groupSpaceMap map[string]string,
 ) []*SidebarItem {
 	if len(threadExtRows) == 0 {
 		return existing
@@ -890,6 +926,8 @@ func mergeThreadEntries(
 			TargetID:          ext.TargetID,
 			ChannelType:       common.ChannelTypeCommunityTopic.Uint8(),
 			ChannelID:         ext.TargetID,
+			// thread 继承父群 SpaceID（GH octo-server#153）。
+			SpaceID:           groupSpaceMap[groupNo],
 			Timestamp:         ts,
 			IsFollowed:        true,
 			FollowSort:        ext.FollowSort,

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -107,6 +107,14 @@ type SidebarItem struct {
 	// 客户端 WebSocket 收到群消息时拿这个字段决定渲染到哪个 Space tab，
 	// 与服务端 FilterRawConversationsBySpace 的可见性判定同口径。
 	SpaceID     string `json:"space_id,omitempty"`
+	// MySourceSpaceID 是当前用户加入该群的"来源 Space"（外部成员场景）。
+	//   - GROUP: externalGroupMap[channelID]，即 group_external_member.source_space_id；
+	//   - COMMUNITY_TOPIC: externalGroupMap[parentGroupNo]（与父群保持同口径）；
+	//   - 其它（PERSON / 内部群成员）: 留空。
+	// 与 v1 SyncUserConversationResp.MySourceSpaceID 字段口径一致
+	// （GH octo-server#153 Round-2 P1）。客户端在 source Space 下用 sidebar 时
+	// 需要这个字段才能识别"我以哪个 Space 身份加入了这个外部群"。
+	MySourceSpaceID string `json:"my_source_space_id,omitempty"`
 	Timestamp   int64  `json:"timestamp"`
 	Unread      int    `json:"unread"`
 	IsPinned    bool   `json:"is_pinned"`
@@ -407,17 +415,36 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 	//     其他 Space 的群，因此即便 group service 调用失败也只是少填一些字段，
 	//     不会泄露跨 Space 元数据。失败时退化为空 map，fail-open 把 SpaceID
 	//     置空，客户端走"未知 Space"分支（与历史行为一致）。
-	groupSpaceMap, ok := CollectGroupSpaceMap(conversations, sb.groupService)
+	//
+	//     额外把 threadExtRows 的父群 groupNo 合入查询集合（GH octo-server#153
+	//     Round-2 Critical 2）：DB-only thread 的父群可能不在 IM 返回里，
+	//     如果不显式带上，mergeThreadEntries 写 SidebarItem.SpaceID 时
+	//     groupSpaceMap[parentGroupNo] 会 miss，space_id 被回填为空。
+	var extraParentGroupNos []string
+	if len(threadExtRows) > 0 {
+		extraParentGroupNos = uniqueThreadParentGroupNos(threadExtRows)
+	}
+	groupSpaceMap, ok := CollectGroupSpaceMap(conversations, extraParentGroupNos, sb.groupService)
 	if !ok {
 		sb.Warn("sidebar sync: group space map query failed (non-fatal, SidebarItem.SpaceID will be empty)")
 		groupSpaceMap = map[string]string{}
+	}
+
+	// 2g. externalGroupMap：当前 user 作为外部成员加入的 (groupNo -> source_space_id)
+	//     映射，用来回填 SidebarItem.MySourceSpaceID（GH octo-server#153 Round-2 P1）。
+	//     与 api_conversation.go syncUserConversation 同口径：非致命错误时降级为
+	//     空 map，仅缺失 my_source_space_id 字段，不影响 SpaceID 回填。
+	externalGroupMap, externalErr := sb.groupDB.QueryExternalGroupNosForUser(loginUID)
+	if externalErr != nil {
+		sb.Warn("sidebar sync: external group map query failed (non-fatal, my_source_space_id will be empty)", zap.Error(externalErr))
+		externalGroupMap = map[string]string{}
 	}
 
 	// 3. Build tab-specific items
 	var items []*SidebarItem
 	switch req.Tab {
 	case "follow":
-		items = buildFollowItems(conversations, categorySetting, unfollowedGroups, followedDMs, threadExtMap, groupExts, dmCategorySorts, groupSpaceMap)
+		items = buildFollowItems(conversations, categorySetting, unfollowedGroups, followedDMs, threadExtMap, groupExts, dmCategorySorts, groupSpaceMap, externalGroupMap)
 		// Append standalone thread ext entries not present in IM result.
 		// Pass categorySetting + unfollowedGroups so parent-follow filter applies
 		// to DB-only thread entries as well (PR review Round-3 Blocking #4).
@@ -425,9 +452,9 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 		if failClosedForFollow("thread last_message_at query", err) {
 			return
 		}
-		items = mergeThreadEntries(items, threadExtRows, lastMsgAtMap, categorySetting, unfollowedGroups, groupSpaceMap)
+		items = mergeThreadEntries(items, threadExtRows, lastMsgAtMap, categorySetting, unfollowedGroups, groupSpaceMap, externalGroupMap)
 	case "recent":
-		items = buildRecentItems(conversations, pinnedSet, groupSpaceMap)
+		items = buildRecentItems(conversations, pinnedSet, groupSpaceMap, externalGroupMap)
 	}
 
 	// 4. Enrich pinned flag (follow tab items also need it)
@@ -689,6 +716,7 @@ func buildFollowItems(
 	groupExts map[string]*convext.Model,
 	dmCategorySorts map[string]int,
 	groupSpaceMap map[string]string,
+	externalGroupMap map[string]string,
 ) []*SidebarItem {
 	items := make([]*SidebarItem, 0, len(convs))
 	for _, conv := range convs {
@@ -713,6 +741,7 @@ func buildFollowItems(
 				ChannelType:       conv.ChannelType,
 				ChannelID:         conv.ChannelID,
 				SpaceID:           groupSpaceMap[conv.ChannelID],
+				MySourceSpaceID:   externalGroupMap[conv.ChannelID],
 				Timestamp:         conv.Timestamp,
 				Unread:            conv.Unread,
 				IsFollowed:        true,
@@ -780,6 +809,8 @@ func buildFollowItems(
 				ChannelID:         conv.ChannelID,
 				// thread 继承父群 SpaceID（GH octo-server#153）。
 				SpaceID:           groupSpaceMap[groupNo],
+				// thread 同样继承父群的 MySourceSpaceID（GH octo-server#153 Round-2 P1）。
+				MySourceSpaceID:   externalGroupMap[groupNo],
 				Timestamp:         conv.Timestamp,
 				Unread:            conv.Unread,
 				IsFollowed:        true,
@@ -810,6 +841,7 @@ func buildRecentItems(
 	convs []*config.SyncUserConversationResp,
 	pinnedSet map[string]struct{},
 	groupSpaceMap map[string]string,
+	externalGroupMap map[string]string,
 ) []*SidebarItem {
 	cutoff := threeDaysAgo()
 	items := make([]*SidebarItem, 0, len(convs))
@@ -825,15 +857,20 @@ func buildRecentItems(
 		parentID := ""
 		// spaceID 取自 groupSpaceMap：GROUP 直接查 channelID；COMMUNITY_TOPIC 取
 		// 父群；PERSON 留空（GH octo-server#153，规则与 buildFollowItems 一致）。
+		// mySourceSpaceID 同口径：从 externalGroupMap 查 channelID / parentGroupNo
+		// （GH octo-server#153 Round-2 P1）。
 		spaceID := ""
+		mySourceSpaceID := ""
 		switch conv.ChannelType {
 		case common.ChannelTypeGroup.Uint8():
 			spaceID = groupSpaceMap[conv.ChannelID]
+			mySourceSpaceID = externalGroupMap[conv.ChannelID]
 		case common.ChannelTypeCommunityTopic.Uint8():
 			groupNo, _, err := parseThreadChannelIDSidebar(conv.ChannelID)
 			if err == nil {
 				parentID = groupNo
 				spaceID = groupSpaceMap[groupNo]
+				mySourceSpaceID = externalGroupMap[groupNo]
 			}
 		}
 		items = append(items, &SidebarItem{
@@ -842,6 +879,7 @@ func buildRecentItems(
 			ChannelType:     conv.ChannelType,
 			ChannelID:       conv.ChannelID,
 			SpaceID:         spaceID,
+			MySourceSpaceID: mySourceSpaceID,
 			Timestamp:       conv.Timestamp,
 			Unread:          conv.Unread,
 			IsPinned:        pinned,
@@ -880,6 +918,7 @@ func mergeThreadEntries(
 	categorySetting map[string]*GroupCategorySetting,
 	unfollowedGroups map[string]struct{},
 	groupSpaceMap map[string]string,
+	externalGroupMap map[string]string,
 ) []*SidebarItem {
 	if len(threadExtRows) == 0 {
 		return existing
@@ -928,6 +967,8 @@ func mergeThreadEntries(
 			ChannelID:         ext.TargetID,
 			// thread 继承父群 SpaceID（GH octo-server#153）。
 			SpaceID:           groupSpaceMap[groupNo],
+			// thread 同样继承父群的 MySourceSpaceID（GH octo-server#153 Round-2 P1）。
+			MySourceSpaceID:   externalGroupMap[groupNo],
 			Timestamp:         ts,
 			IsFollowed:        true,
 			FollowSort:        ext.FollowSort,

--- a/modules/message/api_sidebar_integration_test.go
+++ b/modules/message/api_sidebar_integration_test.go
@@ -146,9 +146,9 @@ func TestIntegration_Sidebar_FollowTab_BasicSmoke(t *testing.T) {
 	}
 
 	// 5. Run the same pure-function pipeline as Sidebar.Sync follow branch.
-	items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, followedDMs, threadExtMap, nil, nil, nil, nil)
+	items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, followedDMs, threadExtMap, nil, nil, nil, nil, "")
 	// mergeThreadEntries: thread is already in IM result, so no new item added.
-	items = mergeThreadEntries(items, threadExtRows, map[string]*time.Time{}, categorySetting, unfollowedGroups, nil, nil)
+	items = mergeThreadEntries(items, threadExtRows, map[string]*time.Time{}, categorySetting, unfollowedGroups, nil, nil, "")
 	sortFollowItems(items)
 
 	// 6. Assert exactly 3 items with correct target_type.
@@ -225,7 +225,7 @@ func TestIntegration_Sidebar_FollowTab_BlacklistedGroupExcluded(t *testing.T) {
 		{ChannelID: groupNo, ChannelType: common.ChannelTypeGroup.Uint8(), Timestamp: 100},
 	}
 
-	items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil, nil)
+	items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil, nil, "")
 	assert.Len(t, items, 0,
 		"blacklisted group (group_unfollowed=1 in DB) must be excluded from follow tab")
 }
@@ -261,7 +261,7 @@ func TestIntegration_Sidebar_FollowTab_NoExtRows_ReturnsEmpty(t *testing.T) {
 	}
 
 	// No category → group excluded; no followed_dm row → DM excluded.
-	items := buildFollowItems(stubConvs, nil /*categorySetting*/, unfollowedGroups, followedDMs, nil, nil, nil, nil, nil)
+	items := buildFollowItems(stubConvs, nil /*categorySetting*/, unfollowedGroups, followedDMs, nil, nil, nil, nil, nil, "")
 	assert.Len(t, items, 0, "follow tab with no ext data must return 0 items")
 }
 
@@ -307,7 +307,7 @@ func TestIntegration_Sidebar_MergeThreadEntries_AddsDBOnlyThreads(t *testing.T) 
 	}
 
 	// buildFollowItems picks up threadInIM (has ext row + parent in follow set).
-	items := buildFollowItems(stubConvs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil)
+	items := buildFollowItems(stubConvs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil, "")
 	require.Len(t, items, 1, "buildFollowItems must include threadInIM")
 
 	// mergeThreadEntries appends threadDBOnly (not yet in items).
@@ -319,7 +319,7 @@ func TestIntegration_Sidebar_MergeThreadEntries_AddsDBOnlyThreads(t *testing.T) 
 		threadInIM:   &alive,
 		threadDBOnly: &alive,
 	}
-	items = mergeThreadEntries(items, threadExtRows, lastMsgAtMap, categorySetting, map[string]struct{}{}, nil, nil)
+	items = mergeThreadEntries(items, threadExtRows, lastMsgAtMap, categorySetting, map[string]struct{}{}, nil, nil, "")
 	require.Len(t, items, 2, "mergeThreadEntries must add the DB-only thread")
 
 	// Both thread IDs must be present.
@@ -414,7 +414,7 @@ func TestIntegration_Sidebar_Issue41_CrossTypeDragSurvivesReload(t *testing.T) {
 
 		// 本 case DM 没绑 category（issue #41 reproduction 的 fileHelper 也没有），
 		// dmCategorySorts 直接传 nil，避免依赖 group_setting 表。
-		items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, followedDMs, nil, groupExts, nil, nil, nil)
+		items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, followedDMs, nil, groupExts, nil, nil, nil, "")
 		sortFollowItems(items)
 		return items
 	}
@@ -492,7 +492,7 @@ func TestIntegration_Sidebar_Issue41_DMCategorySortLoadedFromGroupCategory(t *te
 	stubConvs := []*config.SyncUserConversationResp{
 		{ChannelID: dmID, ChannelType: common.ChannelTypePerson.Uint8(), Timestamp: 100},
 	}
-	items := buildFollowItems(stubConvs, nil, nil, followedDMs, nil, nil, sorts, nil, nil)
+	items := buildFollowItems(stubConvs, nil, nil, followedDMs, nil, nil, sorts, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, catSort, items[0].CategorySort,
 		"带 dm_category_id 的 DM 必须把 group_category.sort 写到 SidebarItem.CategorySort")

--- a/modules/message/api_sidebar_integration_test.go
+++ b/modules/message/api_sidebar_integration_test.go
@@ -146,9 +146,9 @@ func TestIntegration_Sidebar_FollowTab_BasicSmoke(t *testing.T) {
 	}
 
 	// 5. Run the same pure-function pipeline as Sidebar.Sync follow branch.
-	items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, followedDMs, threadExtMap, nil, nil)
+	items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, followedDMs, threadExtMap, nil, nil, nil, nil)
 	// mergeThreadEntries: thread is already in IM result, so no new item added.
-	items = mergeThreadEntries(items, threadExtRows, map[string]*time.Time{}, categorySetting, unfollowedGroups)
+	items = mergeThreadEntries(items, threadExtRows, map[string]*time.Time{}, categorySetting, unfollowedGroups, nil, nil)
 	sortFollowItems(items)
 
 	// 6. Assert exactly 3 items with correct target_type.
@@ -225,7 +225,7 @@ func TestIntegration_Sidebar_FollowTab_BlacklistedGroupExcluded(t *testing.T) {
 		{ChannelID: groupNo, ChannelType: common.ChannelTypeGroup.Uint8(), Timestamp: 100},
 	}
 
-	items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, nil, nil, nil, nil)
+	items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil, nil)
 	assert.Len(t, items, 0,
 		"blacklisted group (group_unfollowed=1 in DB) must be excluded from follow tab")
 }
@@ -261,7 +261,7 @@ func TestIntegration_Sidebar_FollowTab_NoExtRows_ReturnsEmpty(t *testing.T) {
 	}
 
 	// No category → group excluded; no followed_dm row → DM excluded.
-	items := buildFollowItems(stubConvs, nil /*categorySetting*/, unfollowedGroups, followedDMs, nil, nil, nil)
+	items := buildFollowItems(stubConvs, nil /*categorySetting*/, unfollowedGroups, followedDMs, nil, nil, nil, nil, nil)
 	assert.Len(t, items, 0, "follow tab with no ext data must return 0 items")
 }
 
@@ -307,7 +307,7 @@ func TestIntegration_Sidebar_MergeThreadEntries_AddsDBOnlyThreads(t *testing.T) 
 	}
 
 	// buildFollowItems picks up threadInIM (has ext row + parent in follow set).
-	items := buildFollowItems(stubConvs, categorySetting, nil, nil, threadExtMap, nil, nil)
+	items := buildFollowItems(stubConvs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil)
 	require.Len(t, items, 1, "buildFollowItems must include threadInIM")
 
 	// mergeThreadEntries appends threadDBOnly (not yet in items).
@@ -319,7 +319,7 @@ func TestIntegration_Sidebar_MergeThreadEntries_AddsDBOnlyThreads(t *testing.T) 
 		threadInIM:   &alive,
 		threadDBOnly: &alive,
 	}
-	items = mergeThreadEntries(items, threadExtRows, lastMsgAtMap, categorySetting, map[string]struct{}{})
+	items = mergeThreadEntries(items, threadExtRows, lastMsgAtMap, categorySetting, map[string]struct{}{}, nil, nil)
 	require.Len(t, items, 2, "mergeThreadEntries must add the DB-only thread")
 
 	// Both thread IDs must be present.
@@ -414,7 +414,7 @@ func TestIntegration_Sidebar_Issue41_CrossTypeDragSurvivesReload(t *testing.T) {
 
 		// 本 case DM 没绑 category（issue #41 reproduction 的 fileHelper 也没有），
 		// dmCategorySorts 直接传 nil，避免依赖 group_setting 表。
-		items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, followedDMs, nil, groupExts, nil)
+		items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, followedDMs, nil, groupExts, nil, nil, nil)
 		sortFollowItems(items)
 		return items
 	}
@@ -492,7 +492,7 @@ func TestIntegration_Sidebar_Issue41_DMCategorySortLoadedFromGroupCategory(t *te
 	stubConvs := []*config.SyncUserConversationResp{
 		{ChannelID: dmID, ChannelType: common.ChannelTypePerson.Uint8(), Timestamp: 100},
 	}
-	items := buildFollowItems(stubConvs, nil, nil, followedDMs, nil, nil, sorts)
+	items := buildFollowItems(stubConvs, nil, nil, followedDMs, nil, nil, sorts, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, catSort, items[0].CategorySort,
 		"带 dm_category_id 的 DM 必须把 group_category.sort 写到 SidebarItem.CategorySort")

--- a/modules/message/api_sidebar_test.go
+++ b/modules/message/api_sidebar_test.go
@@ -134,7 +134,7 @@ func TestBuildFollowItems_GroupFollowed(t *testing.T) {
 	}
 	unfollowedGroups := map[string]struct{}{} // empty: not unfollowed
 
-	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, "g1", items[0].TargetID)
 	assert.Equal(t, "cat1", *items[0].CategoryID)
@@ -151,7 +151,7 @@ func TestBuildFollowItems_GroupUnfollowed_Excluded(t *testing.T) {
 	}
 	unfollowedGroups := map[string]struct{}{"g1": {}}
 
-	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil, nil)
 	assert.Len(t, items, 0)
 }
 
@@ -163,7 +163,7 @@ func TestBuildFollowItems_GroupWithoutCategory_Excluded(t *testing.T) {
 	categorySetting := map[string]*GroupCategorySetting{} // no entry
 	unfollowedGroups := map[string]struct{}{}
 
-	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil, nil)
 	assert.Len(t, items, 0)
 }
 
@@ -176,7 +176,7 @@ func TestBuildFollowItems_DMFollowed(t *testing.T) {
 		"peer1": {TargetID: "peer1", FollowedDM: 1, FollowSort: 5},
 	}
 
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil)
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, "peer1", items[0].TargetID)
 	assert.Equal(t, 5, items[0].FollowSort)
@@ -188,7 +188,7 @@ func TestBuildFollowItems_DMNotFollowed_Excluded(t *testing.T) {
 	}
 	followedDMs := map[string]*convext.Model{} // no entry for peer2
 
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil)
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil, nil)
 	assert.Len(t, items, 0)
 }
 
@@ -206,7 +206,7 @@ func TestBuildFollowItems_ThreadAsIMEntry_IncludedWhenParentFollowed(t *testing.
 		threadChannelID: {TargetID: threadChannelID, FollowSort: 2},
 	}
 
-	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, threadChannelID, items[0].TargetID)
 	assert.Equal(t, int(common.ChannelTypeCommunityTopic), items[0].TargetType)
@@ -223,7 +223,7 @@ func TestBuildFollowItems_ThreadWithoutExtRow_Excluded(t *testing.T) {
 	}
 	threadExtMap := map[string]*convext.Model{} // no ext for this thread
 
-	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil)
 	assert.Len(t, items, 0)
 }
 
@@ -235,7 +235,7 @@ func TestBuildRecentItems_GroupWithinWindow_Included(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), nowRecent()),
 	}
-	items := buildRecentItems(convs, nil, nil)
+	items := buildRecentItems(convs, nil, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, "g1", items[0].TargetID)
 }
@@ -244,7 +244,7 @@ func TestBuildRecentItems_GroupOutsideWindow_Excluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, nil, nil)
+	items := buildRecentItems(convs, nil, nil, nil)
 	assert.Len(t, items, 0)
 }
 
@@ -253,7 +253,7 @@ func TestBuildRecentItems_DMAlwaysIncluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("peer1", common.ChannelTypePerson.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, nil, nil)
+	items := buildRecentItems(convs, nil, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, "peer1", items[0].TargetID)
 }
@@ -262,7 +262,7 @@ func TestBuildRecentItems_ThreadWithinWindow_Included(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1____th1", common.ChannelTypeCommunityTopic.Uint8(), nowRecent()),
 	}
-	items := buildRecentItems(convs, nil, nil)
+	items := buildRecentItems(convs, nil, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, "g1____th1", items[0].TargetID)
 }
@@ -271,7 +271,7 @@ func TestBuildRecentItems_ThreadOutsideWindow_Excluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1____th1", common.ChannelTypeCommunityTopic.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, nil, nil)
+	items := buildRecentItems(convs, nil, nil, nil)
 	assert.Len(t, items, 0)
 }
 
@@ -283,7 +283,7 @@ func TestBuildRecentItems_PinnedFirst(t *testing.T) {
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), nowRecent()),
 		makeIMConv("g2", common.ChannelTypeGroup.Uint8(), nowRecent()-10),
 	}
-	items := buildRecentItems(convs, pinnedSet, nil)
+	items := buildRecentItems(convs, pinnedSet, nil, nil)
 	require.Len(t, items, 2)
 
 	// buildRecentItems sets IsPinned flag; sorting is done separately
@@ -339,7 +339,7 @@ func TestMergeThreadEntries_AddsNewEntry(t *testing.T) {
 	}
 
 	cat, unfollowed := followedG1()
-	result := mergeThreadEntries(existing, threadExtRows, lastMsgAtMap, cat, unfollowed, nil)
+	result := mergeThreadEntries(existing, threadExtRows, lastMsgAtMap, cat, unfollowed, nil, nil)
 	require.Len(t, result, 2)
 	ids := []string{result[0].TargetID, result[1].TargetID}
 	assert.Contains(t, ids, th2ChannelID)
@@ -354,14 +354,14 @@ func TestMergeThreadEntries_NoDuplicateIfAlreadyPresent(t *testing.T) {
 	}
 	cat, unfollowed := followedG1()
 	// nil map is fine here: presentIDs short-circuits before the alive check.
-	result := mergeThreadEntries(existing, threadExtRows, nil, cat, unfollowed, nil)
+	result := mergeThreadEntries(existing, threadExtRows, nil, cat, unfollowed, nil, nil)
 	assert.Len(t, result, 1) // no duplicate
 }
 
 func TestMergeThreadEntries_EmptyExt(t *testing.T) {
 	existing := []*SidebarItem{}
 	cat, unfollowed := followedG1()
-	result := mergeThreadEntries(existing, nil, nil, cat, unfollowed, nil)
+	result := mergeThreadEntries(existing, nil, nil, cat, unfollowed, nil, nil)
 	assert.Len(t, result, 0)
 }
 
@@ -374,7 +374,7 @@ func TestMergeThreadEntries_SkipWhenThreadDeleted(t *testing.T) {
 	}
 	cat, unfollowed := followedG1()
 	// lastMsgAtMap 为空（thread 已被删除，cleanup 还没清理 ext 行）
-	result := mergeThreadEntries(existing, threadExtRows, map[string]*time.Time{}, cat, unfollowed, nil)
+	result := mergeThreadEntries(existing, threadExtRows, map[string]*time.Time{}, cat, unfollowed, nil, nil)
 	assert.Len(t, result, 0,
 		"thread 已删除时 ext 行必须被 skip，避免 ghost 条目出现在 follow tab")
 }
@@ -388,7 +388,7 @@ func TestMergeThreadEntries_AliveThreadEmitsTimestamp(t *testing.T) {
 		{TargetID: "g1____alive", FollowSort: 3},
 	}
 	cat, unfollowed := followedG1()
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____alive", &now), cat, unfollowed, nil)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____alive", &now), cat, unfollowed, nil, nil)
 	require.Len(t, result, 1)
 	assert.Equal(t, now.Unix(), result[0].Timestamp,
 		"alive thread 的 timestamp 必须从 lastMsgAtMap 正确读取")
@@ -404,7 +404,7 @@ func TestMergeThreadEntries_AliveThreadNilLastMsgAt(t *testing.T) {
 	}
 	cat, unfollowed := followedG1()
 	// 键存在但值为 nil = thread 活跃但还没消息
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____fresh", nil), cat, unfollowed, nil)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____fresh", nil), cat, unfollowed, nil, nil)
 	require.Len(t, result, 1, "活跃 thread 即便 last_message_at=NULL 也必须 emit")
 	assert.Equal(t, int64(0), result[0].Timestamp)
 }
@@ -420,7 +420,7 @@ func TestMergeThreadEntries_SkipWhenParentUnfollowed(t *testing.T) {
 	cat, _ := followedG1()
 	unfollowed := map[string]struct{}{"g1": {}}
 
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____th-orphan", nil), cat, unfollowed, nil)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____th-orphan", nil), cat, unfollowed, nil, nil)
 	assert.Len(t, result, 0,
 		"thread whose parent group is unfollowed must NOT be merged into follow tab")
 }
@@ -434,7 +434,7 @@ func TestMergeThreadEntries_SkipWhenParentHasNoCategory(t *testing.T) {
 	}
 	cat, unfollowed := followedG1() // only g1 is in the follow set, g-noCat is not
 
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g-noCat____th-orphan", nil), cat, unfollowed, nil)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g-noCat____th-orphan", nil), cat, unfollowed, nil, nil)
 	assert.Len(t, result, 0,
 		"thread whose parent group lacks a category (not in follow set) must NOT be merged")
 }
@@ -448,7 +448,7 @@ func TestMergeThreadEntries_SkipMalformedChannelID(t *testing.T) {
 	}
 	cat, unfollowed := followedG1()
 
-	result := mergeThreadEntries(existing, threadExtRows, nil, cat, unfollowed, nil)
+	result := mergeThreadEntries(existing, threadExtRows, nil, cat, unfollowed, nil, nil)
 	assert.Len(t, result, 0,
 		"malformed thread channel id (no separator) must be skipped")
 }
@@ -632,7 +632,7 @@ func TestBuildFollowItems_ThreadInheritsParentCategorySort(t *testing.T) {
 	threadExtMap := map[string]*convext.Model{
 		threadID: {TargetID: threadID, FollowSort: 1},
 	}
-	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil)
 	require.Len(t, items, 2)
 
 	var groupItem, threadItem *SidebarItem
@@ -688,7 +688,7 @@ func TestBuildFollowItems_CategoryGroupSort_Propagates(t *testing.T) {
 			CategoryGroupSort: 42, // group_category.sort       —— 客户端可见 category_sort
 		},
 	}
-	items := buildFollowItems(convs, categorySetting, nil, nil, nil, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, nil, nil, nil, nil, nil, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, 42, items[0].CategorySort, "客户端可见的 category_sort 必须取自 group_category.sort")
 	assert.Equal(t, 7, items[0].intraCategorySort, "intraCategorySort 必须取自 group_setting.category_sort")
@@ -724,12 +724,12 @@ func TestSortRecentItems_MultiplePinned_ByTimestampDesc(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestBuildFollowItems_EmptyConversations(t *testing.T) {
-	items := buildFollowItems(nil, nil, nil, nil, nil, nil, nil, nil)
+	items := buildFollowItems(nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	assert.Len(t, items, 0)
 }
 
 func TestBuildRecentItems_EmptyConversations(t *testing.T) {
-	items := buildRecentItems(nil, nil, nil)
+	items := buildRecentItems(nil, nil, nil, nil)
 	assert.Len(t, items, 0)
 }
 
@@ -759,7 +759,7 @@ func TestBuildFollowItems_MixedTypes(t *testing.T) {
 		"g1____th1": {TargetID: "g1____th1", FollowSort: 1},
 	}
 
-	items := buildFollowItems(convs, categorySetting, nil, followedDMs, threadExtMap, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, nil, followedDMs, threadExtMap, nil, nil, nil, nil)
 	// g1 + peer1 + g1____th1 = 3; peer2 (not followed) and g2 (no category) excluded
 	assert.Len(t, items, 3)
 	ids := make(map[string]bool)
@@ -823,7 +823,7 @@ func TestBuildFollowItems_DMFollowed_WithDMCategory(t *testing.T) {
 	followedDMs := map[string]*convext.Model{
 		"peer1": {TargetID: "peer1", FollowedDM: 1, FollowSort: 3, DMCategoryID: &catID},
 	}
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil)
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil, nil)
 	require.Len(t, items, 1)
 	require.NotNil(t, items[0].CategoryID)
 	assert.Equal(t, catID, *items[0].CategoryID, "DMCategoryID 直接透传 UUID，不再 fmt.Sprintf 转字符串")
@@ -845,7 +845,7 @@ func TestBuildFollowItems_GroupHonorsFollowSort(t *testing.T) {
 	groupExts := map[string]*convext.Model{
 		"g1": {TargetID: "g1", FollowSort: 7},
 	}
-	items := buildFollowItems(convs, categorySetting, nil, nil, nil, groupExts, nil, nil)
+	items := buildFollowItems(convs, categorySetting, nil, nil, nil, groupExts, nil, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, 7, items[0].FollowSort, "group FollowSort 必须取自 user_conversation_ext.follow_sort")
 }
@@ -858,7 +858,7 @@ func TestBuildFollowItems_GroupMissingExtFallsBackToZero(t *testing.T) {
 	categorySetting := map[string]*GroupCategorySetting{
 		"g-noext": {GroupNo: "g-noext", CategoryID: strPtr("cat1"), CategorySort: 1, CategoryGroupSort: 1},
 	}
-	items := buildFollowItems(convs, categorySetting, nil, nil, nil, map[string]*convext.Model{}, nil, nil)
+	items := buildFollowItems(convs, categorySetting, nil, nil, nil, map[string]*convext.Model{}, nil, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, 0, items[0].FollowSort)
 }
@@ -875,7 +875,7 @@ func TestBuildFollowItems_DMLoadsCategorySort(t *testing.T) {
 		"peer1": {TargetID: "peer1", FollowedDM: 1, FollowSort: 4, DMCategoryID: &catID},
 	}
 	dmCategorySorts := map[string]int{catID: 42}
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, dmCategorySorts, nil)
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, dmCategorySorts, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, 42, items[0].CategorySort, "DM 的 CategorySort 必须取自 group_category.sort")
 	require.NotNil(t, items[0].CategoryID)
@@ -890,7 +890,7 @@ func TestBuildFollowItems_DMNoCategory_NoCategorySort(t *testing.T) {
 	followedDMs := map[string]*convext.Model{
 		"peer1": {TargetID: "peer1", FollowedDM: 1, FollowSort: 4},
 	}
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil)
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, 0, items[0].CategorySort)
 	assert.Nil(t, items[0].CategoryID)

--- a/modules/message/api_sidebar_test.go
+++ b/modules/message/api_sidebar_test.go
@@ -134,7 +134,7 @@ func TestBuildFollowItems_GroupFollowed(t *testing.T) {
 	}
 	unfollowedGroups := map[string]struct{}{} // empty: not unfollowed
 
-	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, "g1", items[0].TargetID)
 	assert.Equal(t, "cat1", *items[0].CategoryID)
@@ -151,7 +151,7 @@ func TestBuildFollowItems_GroupUnfollowed_Excluded(t *testing.T) {
 	}
 	unfollowedGroups := map[string]struct{}{"g1": {}}
 
-	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil)
 	assert.Len(t, items, 0)
 }
 
@@ -163,7 +163,7 @@ func TestBuildFollowItems_GroupWithoutCategory_Excluded(t *testing.T) {
 	categorySetting := map[string]*GroupCategorySetting{} // no entry
 	unfollowedGroups := map[string]struct{}{}
 
-	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil)
 	assert.Len(t, items, 0)
 }
 
@@ -176,7 +176,7 @@ func TestBuildFollowItems_DMFollowed(t *testing.T) {
 		"peer1": {TargetID: "peer1", FollowedDM: 1, FollowSort: 5},
 	}
 
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil)
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, "peer1", items[0].TargetID)
 	assert.Equal(t, 5, items[0].FollowSort)
@@ -188,7 +188,7 @@ func TestBuildFollowItems_DMNotFollowed_Excluded(t *testing.T) {
 	}
 	followedDMs := map[string]*convext.Model{} // no entry for peer2
 
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil)
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil)
 	assert.Len(t, items, 0)
 }
 
@@ -206,7 +206,7 @@ func TestBuildFollowItems_ThreadAsIMEntry_IncludedWhenParentFollowed(t *testing.
 		threadChannelID: {TargetID: threadChannelID, FollowSort: 2},
 	}
 
-	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil)
+	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, threadChannelID, items[0].TargetID)
 	assert.Equal(t, int(common.ChannelTypeCommunityTopic), items[0].TargetType)
@@ -223,7 +223,7 @@ func TestBuildFollowItems_ThreadWithoutExtRow_Excluded(t *testing.T) {
 	}
 	threadExtMap := map[string]*convext.Model{} // no ext for this thread
 
-	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil)
+	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil)
 	assert.Len(t, items, 0)
 }
 
@@ -235,7 +235,7 @@ func TestBuildRecentItems_GroupWithinWindow_Included(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), nowRecent()),
 	}
-	items := buildRecentItems(convs, nil)
+	items := buildRecentItems(convs, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, "g1", items[0].TargetID)
 }
@@ -244,7 +244,7 @@ func TestBuildRecentItems_GroupOutsideWindow_Excluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, nil)
+	items := buildRecentItems(convs, nil, nil)
 	assert.Len(t, items, 0)
 }
 
@@ -253,7 +253,7 @@ func TestBuildRecentItems_DMAlwaysIncluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("peer1", common.ChannelTypePerson.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, nil)
+	items := buildRecentItems(convs, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, "peer1", items[0].TargetID)
 }
@@ -262,7 +262,7 @@ func TestBuildRecentItems_ThreadWithinWindow_Included(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1____th1", common.ChannelTypeCommunityTopic.Uint8(), nowRecent()),
 	}
-	items := buildRecentItems(convs, nil)
+	items := buildRecentItems(convs, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, "g1____th1", items[0].TargetID)
 }
@@ -271,7 +271,7 @@ func TestBuildRecentItems_ThreadOutsideWindow_Excluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1____th1", common.ChannelTypeCommunityTopic.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, nil)
+	items := buildRecentItems(convs, nil, nil)
 	assert.Len(t, items, 0)
 }
 
@@ -283,7 +283,7 @@ func TestBuildRecentItems_PinnedFirst(t *testing.T) {
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), nowRecent()),
 		makeIMConv("g2", common.ChannelTypeGroup.Uint8(), nowRecent()-10),
 	}
-	items := buildRecentItems(convs, pinnedSet)
+	items := buildRecentItems(convs, pinnedSet, nil)
 	require.Len(t, items, 2)
 
 	// buildRecentItems sets IsPinned flag; sorting is done separately
@@ -339,7 +339,7 @@ func TestMergeThreadEntries_AddsNewEntry(t *testing.T) {
 	}
 
 	cat, unfollowed := followedG1()
-	result := mergeThreadEntries(existing, threadExtRows, lastMsgAtMap, cat, unfollowed)
+	result := mergeThreadEntries(existing, threadExtRows, lastMsgAtMap, cat, unfollowed, nil)
 	require.Len(t, result, 2)
 	ids := []string{result[0].TargetID, result[1].TargetID}
 	assert.Contains(t, ids, th2ChannelID)
@@ -354,14 +354,14 @@ func TestMergeThreadEntries_NoDuplicateIfAlreadyPresent(t *testing.T) {
 	}
 	cat, unfollowed := followedG1()
 	// nil map is fine here: presentIDs short-circuits before the alive check.
-	result := mergeThreadEntries(existing, threadExtRows, nil, cat, unfollowed)
+	result := mergeThreadEntries(existing, threadExtRows, nil, cat, unfollowed, nil)
 	assert.Len(t, result, 1) // no duplicate
 }
 
 func TestMergeThreadEntries_EmptyExt(t *testing.T) {
 	existing := []*SidebarItem{}
 	cat, unfollowed := followedG1()
-	result := mergeThreadEntries(existing, nil, nil, cat, unfollowed)
+	result := mergeThreadEntries(existing, nil, nil, cat, unfollowed, nil)
 	assert.Len(t, result, 0)
 }
 
@@ -374,7 +374,7 @@ func TestMergeThreadEntries_SkipWhenThreadDeleted(t *testing.T) {
 	}
 	cat, unfollowed := followedG1()
 	// lastMsgAtMap 为空（thread 已被删除，cleanup 还没清理 ext 行）
-	result := mergeThreadEntries(existing, threadExtRows, map[string]*time.Time{}, cat, unfollowed)
+	result := mergeThreadEntries(existing, threadExtRows, map[string]*time.Time{}, cat, unfollowed, nil)
 	assert.Len(t, result, 0,
 		"thread 已删除时 ext 行必须被 skip，避免 ghost 条目出现在 follow tab")
 }
@@ -388,7 +388,7 @@ func TestMergeThreadEntries_AliveThreadEmitsTimestamp(t *testing.T) {
 		{TargetID: "g1____alive", FollowSort: 3},
 	}
 	cat, unfollowed := followedG1()
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____alive", &now), cat, unfollowed)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____alive", &now), cat, unfollowed, nil)
 	require.Len(t, result, 1)
 	assert.Equal(t, now.Unix(), result[0].Timestamp,
 		"alive thread 的 timestamp 必须从 lastMsgAtMap 正确读取")
@@ -404,7 +404,7 @@ func TestMergeThreadEntries_AliveThreadNilLastMsgAt(t *testing.T) {
 	}
 	cat, unfollowed := followedG1()
 	// 键存在但值为 nil = thread 活跃但还没消息
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____fresh", nil), cat, unfollowed)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____fresh", nil), cat, unfollowed, nil)
 	require.Len(t, result, 1, "活跃 thread 即便 last_message_at=NULL 也必须 emit")
 	assert.Equal(t, int64(0), result[0].Timestamp)
 }
@@ -420,7 +420,7 @@ func TestMergeThreadEntries_SkipWhenParentUnfollowed(t *testing.T) {
 	cat, _ := followedG1()
 	unfollowed := map[string]struct{}{"g1": {}}
 
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____th-orphan", nil), cat, unfollowed)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____th-orphan", nil), cat, unfollowed, nil)
 	assert.Len(t, result, 0,
 		"thread whose parent group is unfollowed must NOT be merged into follow tab")
 }
@@ -434,7 +434,7 @@ func TestMergeThreadEntries_SkipWhenParentHasNoCategory(t *testing.T) {
 	}
 	cat, unfollowed := followedG1() // only g1 is in the follow set, g-noCat is not
 
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g-noCat____th-orphan", nil), cat, unfollowed)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g-noCat____th-orphan", nil), cat, unfollowed, nil)
 	assert.Len(t, result, 0,
 		"thread whose parent group lacks a category (not in follow set) must NOT be merged")
 }
@@ -448,7 +448,7 @@ func TestMergeThreadEntries_SkipMalformedChannelID(t *testing.T) {
 	}
 	cat, unfollowed := followedG1()
 
-	result := mergeThreadEntries(existing, threadExtRows, nil, cat, unfollowed)
+	result := mergeThreadEntries(existing, threadExtRows, nil, cat, unfollowed, nil)
 	assert.Len(t, result, 0,
 		"malformed thread channel id (no separator) must be skipped")
 }
@@ -632,7 +632,7 @@ func TestBuildFollowItems_ThreadInheritsParentCategorySort(t *testing.T) {
 	threadExtMap := map[string]*convext.Model{
 		threadID: {TargetID: threadID, FollowSort: 1},
 	}
-	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil)
+	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil)
 	require.Len(t, items, 2)
 
 	var groupItem, threadItem *SidebarItem
@@ -688,7 +688,7 @@ func TestBuildFollowItems_CategoryGroupSort_Propagates(t *testing.T) {
 			CategoryGroupSort: 42, // group_category.sort       —— 客户端可见 category_sort
 		},
 	}
-	items := buildFollowItems(convs, categorySetting, nil, nil, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, nil, nil, nil, nil, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, 42, items[0].CategorySort, "客户端可见的 category_sort 必须取自 group_category.sort")
 	assert.Equal(t, 7, items[0].intraCategorySort, "intraCategorySort 必须取自 group_setting.category_sort")
@@ -724,12 +724,12 @@ func TestSortRecentItems_MultiplePinned_ByTimestampDesc(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestBuildFollowItems_EmptyConversations(t *testing.T) {
-	items := buildFollowItems(nil, nil, nil, nil, nil, nil, nil)
+	items := buildFollowItems(nil, nil, nil, nil, nil, nil, nil, nil)
 	assert.Len(t, items, 0)
 }
 
 func TestBuildRecentItems_EmptyConversations(t *testing.T) {
-	items := buildRecentItems(nil, nil)
+	items := buildRecentItems(nil, nil, nil)
 	assert.Len(t, items, 0)
 }
 
@@ -759,7 +759,7 @@ func TestBuildFollowItems_MixedTypes(t *testing.T) {
 		"g1____th1": {TargetID: "g1____th1", FollowSort: 1},
 	}
 
-	items := buildFollowItems(convs, categorySetting, nil, followedDMs, threadExtMap, nil, nil)
+	items := buildFollowItems(convs, categorySetting, nil, followedDMs, threadExtMap, nil, nil, nil)
 	// g1 + peer1 + g1____th1 = 3; peer2 (not followed) and g2 (no category) excluded
 	assert.Len(t, items, 3)
 	ids := make(map[string]bool)
@@ -823,7 +823,7 @@ func TestBuildFollowItems_DMFollowed_WithDMCategory(t *testing.T) {
 	followedDMs := map[string]*convext.Model{
 		"peer1": {TargetID: "peer1", FollowedDM: 1, FollowSort: 3, DMCategoryID: &catID},
 	}
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil)
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil)
 	require.Len(t, items, 1)
 	require.NotNil(t, items[0].CategoryID)
 	assert.Equal(t, catID, *items[0].CategoryID, "DMCategoryID 直接透传 UUID，不再 fmt.Sprintf 转字符串")
@@ -845,7 +845,7 @@ func TestBuildFollowItems_GroupHonorsFollowSort(t *testing.T) {
 	groupExts := map[string]*convext.Model{
 		"g1": {TargetID: "g1", FollowSort: 7},
 	}
-	items := buildFollowItems(convs, categorySetting, nil, nil, nil, groupExts, nil)
+	items := buildFollowItems(convs, categorySetting, nil, nil, nil, groupExts, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, 7, items[0].FollowSort, "group FollowSort 必须取自 user_conversation_ext.follow_sort")
 }
@@ -858,7 +858,7 @@ func TestBuildFollowItems_GroupMissingExtFallsBackToZero(t *testing.T) {
 	categorySetting := map[string]*GroupCategorySetting{
 		"g-noext": {GroupNo: "g-noext", CategoryID: strPtr("cat1"), CategorySort: 1, CategoryGroupSort: 1},
 	}
-	items := buildFollowItems(convs, categorySetting, nil, nil, nil, map[string]*convext.Model{}, nil)
+	items := buildFollowItems(convs, categorySetting, nil, nil, nil, map[string]*convext.Model{}, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, 0, items[0].FollowSort)
 }
@@ -875,7 +875,7 @@ func TestBuildFollowItems_DMLoadsCategorySort(t *testing.T) {
 		"peer1": {TargetID: "peer1", FollowedDM: 1, FollowSort: 4, DMCategoryID: &catID},
 	}
 	dmCategorySorts := map[string]int{catID: 42}
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, dmCategorySorts)
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, dmCategorySorts, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, 42, items[0].CategorySort, "DM 的 CategorySort 必须取自 group_category.sort")
 	require.NotNil(t, items[0].CategoryID)
@@ -890,7 +890,7 @@ func TestBuildFollowItems_DMNoCategory_NoCategorySort(t *testing.T) {
 	followedDMs := map[string]*convext.Model{
 		"peer1": {TargetID: "peer1", FollowedDM: 1, FollowSort: 4},
 	}
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil)
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, 0, items[0].CategorySort)
 	assert.Nil(t, items[0].CategoryID)

--- a/modules/message/api_sidebar_test.go
+++ b/modules/message/api_sidebar_test.go
@@ -134,7 +134,7 @@ func TestBuildFollowItems_GroupFollowed(t *testing.T) {
 	}
 	unfollowedGroups := map[string]struct{}{} // empty: not unfollowed
 
-	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, "g1", items[0].TargetID)
 	assert.Equal(t, "cat1", *items[0].CategoryID)
@@ -151,7 +151,7 @@ func TestBuildFollowItems_GroupUnfollowed_Excluded(t *testing.T) {
 	}
 	unfollowedGroups := map[string]struct{}{"g1": {}}
 
-	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 
@@ -163,7 +163,7 @@ func TestBuildFollowItems_GroupWithoutCategory_Excluded(t *testing.T) {
 	categorySetting := map[string]*GroupCategorySetting{} // no entry
 	unfollowedGroups := map[string]struct{}{}
 
-	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 
@@ -176,7 +176,7 @@ func TestBuildFollowItems_DMFollowed(t *testing.T) {
 		"peer1": {TargetID: "peer1", FollowedDM: 1, FollowSort: 5},
 	}
 
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil, nil)
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, "peer1", items[0].TargetID)
 	assert.Equal(t, 5, items[0].FollowSort)
@@ -188,7 +188,7 @@ func TestBuildFollowItems_DMNotFollowed_Excluded(t *testing.T) {
 	}
 	followedDMs := map[string]*convext.Model{} // no entry for peer2
 
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil, nil)
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 
@@ -206,7 +206,7 @@ func TestBuildFollowItems_ThreadAsIMEntry_IncludedWhenParentFollowed(t *testing.
 		threadChannelID: {TargetID: threadChannelID, FollowSort: 2},
 	}
 
-	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, threadChannelID, items[0].TargetID)
 	assert.Equal(t, int(common.ChannelTypeCommunityTopic), items[0].TargetType)
@@ -223,7 +223,7 @@ func TestBuildFollowItems_ThreadWithoutExtRow_Excluded(t *testing.T) {
 	}
 	threadExtMap := map[string]*convext.Model{} // no ext for this thread
 
-	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 
@@ -235,7 +235,7 @@ func TestBuildRecentItems_GroupWithinWindow_Included(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), nowRecent()),
 	}
-	items := buildRecentItems(convs, nil, nil, nil)
+	items := buildRecentItems(convs, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, "g1", items[0].TargetID)
 }
@@ -244,7 +244,7 @@ func TestBuildRecentItems_GroupOutsideWindow_Excluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, nil, nil, nil)
+	items := buildRecentItems(convs, nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 
@@ -253,7 +253,7 @@ func TestBuildRecentItems_DMAlwaysIncluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("peer1", common.ChannelTypePerson.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, nil, nil, nil)
+	items := buildRecentItems(convs, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, "peer1", items[0].TargetID)
 }
@@ -262,7 +262,7 @@ func TestBuildRecentItems_ThreadWithinWindow_Included(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1____th1", common.ChannelTypeCommunityTopic.Uint8(), nowRecent()),
 	}
-	items := buildRecentItems(convs, nil, nil, nil)
+	items := buildRecentItems(convs, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, "g1____th1", items[0].TargetID)
 }
@@ -271,7 +271,7 @@ func TestBuildRecentItems_ThreadOutsideWindow_Excluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1____th1", common.ChannelTypeCommunityTopic.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, nil, nil, nil)
+	items := buildRecentItems(convs, nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 
@@ -283,7 +283,7 @@ func TestBuildRecentItems_PinnedFirst(t *testing.T) {
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), nowRecent()),
 		makeIMConv("g2", common.ChannelTypeGroup.Uint8(), nowRecent()-10),
 	}
-	items := buildRecentItems(convs, pinnedSet, nil, nil)
+	items := buildRecentItems(convs, pinnedSet, nil, nil, "")
 	require.Len(t, items, 2)
 
 	// buildRecentItems sets IsPinned flag; sorting is done separately
@@ -339,7 +339,7 @@ func TestMergeThreadEntries_AddsNewEntry(t *testing.T) {
 	}
 
 	cat, unfollowed := followedG1()
-	result := mergeThreadEntries(existing, threadExtRows, lastMsgAtMap, cat, unfollowed, nil, nil)
+	result := mergeThreadEntries(existing, threadExtRows, lastMsgAtMap, cat, unfollowed, nil, nil, "")
 	require.Len(t, result, 2)
 	ids := []string{result[0].TargetID, result[1].TargetID}
 	assert.Contains(t, ids, th2ChannelID)
@@ -354,14 +354,14 @@ func TestMergeThreadEntries_NoDuplicateIfAlreadyPresent(t *testing.T) {
 	}
 	cat, unfollowed := followedG1()
 	// nil map is fine here: presentIDs short-circuits before the alive check.
-	result := mergeThreadEntries(existing, threadExtRows, nil, cat, unfollowed, nil, nil)
+	result := mergeThreadEntries(existing, threadExtRows, nil, cat, unfollowed, nil, nil, "")
 	assert.Len(t, result, 1) // no duplicate
 }
 
 func TestMergeThreadEntries_EmptyExt(t *testing.T) {
 	existing := []*SidebarItem{}
 	cat, unfollowed := followedG1()
-	result := mergeThreadEntries(existing, nil, nil, cat, unfollowed, nil, nil)
+	result := mergeThreadEntries(existing, nil, nil, cat, unfollowed, nil, nil, "")
 	assert.Len(t, result, 0)
 }
 
@@ -374,7 +374,7 @@ func TestMergeThreadEntries_SkipWhenThreadDeleted(t *testing.T) {
 	}
 	cat, unfollowed := followedG1()
 	// lastMsgAtMap 为空（thread 已被删除，cleanup 还没清理 ext 行）
-	result := mergeThreadEntries(existing, threadExtRows, map[string]*time.Time{}, cat, unfollowed, nil, nil)
+	result := mergeThreadEntries(existing, threadExtRows, map[string]*time.Time{}, cat, unfollowed, nil, nil, "")
 	assert.Len(t, result, 0,
 		"thread 已删除时 ext 行必须被 skip，避免 ghost 条目出现在 follow tab")
 }
@@ -388,7 +388,7 @@ func TestMergeThreadEntries_AliveThreadEmitsTimestamp(t *testing.T) {
 		{TargetID: "g1____alive", FollowSort: 3},
 	}
 	cat, unfollowed := followedG1()
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____alive", &now), cat, unfollowed, nil, nil)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____alive", &now), cat, unfollowed, nil, nil, "")
 	require.Len(t, result, 1)
 	assert.Equal(t, now.Unix(), result[0].Timestamp,
 		"alive thread 的 timestamp 必须从 lastMsgAtMap 正确读取")
@@ -404,7 +404,7 @@ func TestMergeThreadEntries_AliveThreadNilLastMsgAt(t *testing.T) {
 	}
 	cat, unfollowed := followedG1()
 	// 键存在但值为 nil = thread 活跃但还没消息
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____fresh", nil), cat, unfollowed, nil, nil)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____fresh", nil), cat, unfollowed, nil, nil, "")
 	require.Len(t, result, 1, "活跃 thread 即便 last_message_at=NULL 也必须 emit")
 	assert.Equal(t, int64(0), result[0].Timestamp)
 }
@@ -420,7 +420,7 @@ func TestMergeThreadEntries_SkipWhenParentUnfollowed(t *testing.T) {
 	cat, _ := followedG1()
 	unfollowed := map[string]struct{}{"g1": {}}
 
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____th-orphan", nil), cat, unfollowed, nil, nil)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____th-orphan", nil), cat, unfollowed, nil, nil, "")
 	assert.Len(t, result, 0,
 		"thread whose parent group is unfollowed must NOT be merged into follow tab")
 }
@@ -434,7 +434,7 @@ func TestMergeThreadEntries_SkipWhenParentHasNoCategory(t *testing.T) {
 	}
 	cat, unfollowed := followedG1() // only g1 is in the follow set, g-noCat is not
 
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g-noCat____th-orphan", nil), cat, unfollowed, nil, nil)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g-noCat____th-orphan", nil), cat, unfollowed, nil, nil, "")
 	assert.Len(t, result, 0,
 		"thread whose parent group lacks a category (not in follow set) must NOT be merged")
 }
@@ -448,7 +448,7 @@ func TestMergeThreadEntries_SkipMalformedChannelID(t *testing.T) {
 	}
 	cat, unfollowed := followedG1()
 
-	result := mergeThreadEntries(existing, threadExtRows, nil, cat, unfollowed, nil, nil)
+	result := mergeThreadEntries(existing, threadExtRows, nil, cat, unfollowed, nil, nil, "")
 	assert.Len(t, result, 0,
 		"malformed thread channel id (no separator) must be skipped")
 }
@@ -632,7 +632,7 @@ func TestBuildFollowItems_ThreadInheritsParentCategorySort(t *testing.T) {
 	threadExtMap := map[string]*convext.Model{
 		threadID: {TargetID: threadID, FollowSort: 1},
 	}
-	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil, "")
 	require.Len(t, items, 2)
 
 	var groupItem, threadItem *SidebarItem
@@ -688,7 +688,7 @@ func TestBuildFollowItems_CategoryGroupSort_Propagates(t *testing.T) {
 			CategoryGroupSort: 42, // group_category.sort       —— 客户端可见 category_sort
 		},
 	}
-	items := buildFollowItems(convs, categorySetting, nil, nil, nil, nil, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, nil, nil, nil, nil, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, 42, items[0].CategorySort, "客户端可见的 category_sort 必须取自 group_category.sort")
 	assert.Equal(t, 7, items[0].intraCategorySort, "intraCategorySort 必须取自 group_setting.category_sort")
@@ -724,12 +724,12 @@ func TestSortRecentItems_MultiplePinned_ByTimestampDesc(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestBuildFollowItems_EmptyConversations(t *testing.T) {
-	items := buildFollowItems(nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	items := buildFollowItems(nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 
 func TestBuildRecentItems_EmptyConversations(t *testing.T) {
-	items := buildRecentItems(nil, nil, nil, nil)
+	items := buildRecentItems(nil, nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 
@@ -759,7 +759,7 @@ func TestBuildFollowItems_MixedTypes(t *testing.T) {
 		"g1____th1": {TargetID: "g1____th1", FollowSort: 1},
 	}
 
-	items := buildFollowItems(convs, categorySetting, nil, followedDMs, threadExtMap, nil, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, nil, followedDMs, threadExtMap, nil, nil, nil, nil, "")
 	// g1 + peer1 + g1____th1 = 3; peer2 (not followed) and g2 (no category) excluded
 	assert.Len(t, items, 3)
 	ids := make(map[string]bool)
@@ -823,7 +823,7 @@ func TestBuildFollowItems_DMFollowed_WithDMCategory(t *testing.T) {
 	followedDMs := map[string]*convext.Model{
 		"peer1": {TargetID: "peer1", FollowedDM: 1, FollowSort: 3, DMCategoryID: &catID},
 	}
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil, nil)
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	require.NotNil(t, items[0].CategoryID)
 	assert.Equal(t, catID, *items[0].CategoryID, "DMCategoryID 直接透传 UUID，不再 fmt.Sprintf 转字符串")
@@ -845,7 +845,7 @@ func TestBuildFollowItems_GroupHonorsFollowSort(t *testing.T) {
 	groupExts := map[string]*convext.Model{
 		"g1": {TargetID: "g1", FollowSort: 7},
 	}
-	items := buildFollowItems(convs, categorySetting, nil, nil, nil, groupExts, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, nil, nil, nil, groupExts, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, 7, items[0].FollowSort, "group FollowSort 必须取自 user_conversation_ext.follow_sort")
 }
@@ -858,7 +858,7 @@ func TestBuildFollowItems_GroupMissingExtFallsBackToZero(t *testing.T) {
 	categorySetting := map[string]*GroupCategorySetting{
 		"g-noext": {GroupNo: "g-noext", CategoryID: strPtr("cat1"), CategorySort: 1, CategoryGroupSort: 1},
 	}
-	items := buildFollowItems(convs, categorySetting, nil, nil, nil, map[string]*convext.Model{}, nil, nil, nil)
+	items := buildFollowItems(convs, categorySetting, nil, nil, nil, map[string]*convext.Model{}, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, 0, items[0].FollowSort)
 }
@@ -875,7 +875,7 @@ func TestBuildFollowItems_DMLoadsCategorySort(t *testing.T) {
 		"peer1": {TargetID: "peer1", FollowedDM: 1, FollowSort: 4, DMCategoryID: &catID},
 	}
 	dmCategorySorts := map[string]int{catID: 42}
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, dmCategorySorts, nil, nil)
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, dmCategorySorts, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, 42, items[0].CategorySort, "DM 的 CategorySort 必须取自 group_category.sort")
 	require.NotNil(t, items[0].CategoryID)
@@ -890,7 +890,7 @@ func TestBuildFollowItems_DMNoCategory_NoCategorySort(t *testing.T) {
 	followedDMs := map[string]*convext.Model{
 		"peer1": {TargetID: "peer1", FollowedDM: 1, FollowSort: 4},
 	}
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil, nil)
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, 0, items[0].CategorySort)
 	assert.Nil(t, items[0].CategoryID)

--- a/modules/message/conversation_space_id_backfill_test.go
+++ b/modules/message/conversation_space_id_backfill_test.go
@@ -4,16 +4,18 @@ import (
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
-	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/stretchr/testify/assert"
 )
 
-// TestSpaceID_FillConversationSpaceIDs_GroupBackfill 验证群聊会话从 groupMap
-// 拿到 resolved space_id 回填到 SyncUserConversationResp.SpaceID。
+// TestSpaceID_FillConversationSpaceIDs_GroupBackfill 验证群聊会话从
+// rawGroupSpaceMap 拿到 resolved space_id 回填到 SyncUserConversationResp.SpaceID。
 //
 // 背景 (GH octo-server#153)：newSyncUserConversationResp 用 ParseChannelID 推
 // SpaceID，群聊 channel_id 是裸 group_no 拿不到，必须用 group 表权威值回填，
 // 客户端才能正确判定 WebSocket 群消息的 Space 归属。
+//
+// Round-3 (GH octo-server#154 Round-2 Finding 1)：rawGroupSpaceMap 必须来自
+// GetGroups（不经 SetEffectiveSpaceID 改写），而不是 GetGroupDetails 的结果。
 func TestSpaceID_FillConversationSpaceIDs_GroupBackfill(t *testing.T) {
 	resps := []*SyncUserConversationResp{
 		{ChannelID: "g_internal", ChannelType: common.ChannelTypeGroup.Uint8()},
@@ -22,16 +24,16 @@ func TestSpaceID_FillConversationSpaceIDs_GroupBackfill(t *testing.T) {
 		// PERSON 频道：保持原 SpaceID 不动。
 		{ChannelID: "u1", ChannelType: common.ChannelTypePerson.Uint8(), SpaceID: ""},
 	}
-	groupMap := map[string]*group.GroupResp{
-		"g_internal": {GroupNo: "g_internal", SpaceID: "spaceA"},
-		"g_external": {GroupNo: "g_external", SpaceID: "spaceB"},
-		"g_legacy":   {GroupNo: "g_legacy", SpaceID: ""}, // 旧群无 space_id
+	rawGroupSpaceMap := map[string]string{
+		"g_internal": "spaceA",
+		"g_external": "spaceB", // 群表权威值，未经 effective rewrite
+		"g_legacy":   "",        // 旧群无 space_id
 	}
 	externalGroupMap := map[string]string{
 		"g_external": "spaceA", // 当前 user 从 spaceA 加入了 g_external
 	}
 
-	fillConversationSpaceIDs(resps, groupMap, externalGroupMap)
+	fillConversationSpaceIDs(resps, rawGroupSpaceMap, externalGroupMap, "")
 
 	assert.Equal(t, "spaceA", resps[0].SpaceID, "internal group: SpaceID 来自 group 表")
 	assert.Equal(t, "", resps[0].MySourceSpaceID, "non-external group: MySourceSpaceID 保持空")
@@ -52,20 +54,20 @@ func TestSpaceID_FillConversationSpaceIDs_ThreadInheritsParent(t *testing.T) {
 		{ChannelID: "g_parent____thread1", ChannelType: common.ChannelTypeCommunityTopic.Uint8()},
 		// 父群在 externalGroupMap，子区也应继承 my_source_space_id。
 		{ChannelID: "g_ext____thread2", ChannelType: common.ChannelTypeCommunityTopic.Uint8()},
-		// 父群不在 groupMap（未活跃，本批没返回）：不补 SpaceID，保留空字符串。
+		// 父群不在 rawGroupSpaceMap（未活跃，本批没返回）：不补 SpaceID，保留空字符串。
 		{ChannelID: "g_missing____thread3", ChannelType: common.ChannelTypeCommunityTopic.Uint8()},
 		// channel_id 形式错误：跳过。
 		{ChannelID: "invalid-no-separator", ChannelType: common.ChannelTypeCommunityTopic.Uint8()},
 	}
-	groupMap := map[string]*group.GroupResp{
-		"g_parent": {GroupNo: "g_parent", SpaceID: "spaceX"},
-		"g_ext":    {GroupNo: "g_ext", SpaceID: "spaceY"},
+	rawGroupSpaceMap := map[string]string{
+		"g_parent": "spaceX",
+		"g_ext":    "spaceY",
 	}
 	externalGroupMap := map[string]string{
 		"g_ext": "spaceX",
 	}
 
-	fillConversationSpaceIDs(resps, groupMap, externalGroupMap)
+	fillConversationSpaceIDs(resps, rawGroupSpaceMap, externalGroupMap, "")
 
 	assert.Equal(t, "spaceX", resps[0].SpaceID, "thread 继承父群 spaceX")
 	assert.Equal(t, "", resps[0].MySourceSpaceID)
@@ -73,24 +75,24 @@ func TestSpaceID_FillConversationSpaceIDs_ThreadInheritsParent(t *testing.T) {
 	assert.Equal(t, "spaceY", resps[1].SpaceID, "external 父群的 thread 仍取父群 SpaceID")
 	assert.Equal(t, "spaceX", resps[1].MySourceSpaceID, "thread 继承父群的 MySourceSpaceID")
 
-	assert.Equal(t, "", resps[2].SpaceID, "父群不在 groupMap：保持空，不猜")
+	assert.Equal(t, "", resps[2].SpaceID, "父群不在 rawGroupSpaceMap：保持空，不猜")
 
 	assert.Equal(t, "", resps[3].SpaceID, "malformed thread channel id：跳过")
 }
 
 // TestSpaceID_FillConversationSpaceIDs_PreservesExistingSpaceID 验证已有非空
 // SpaceID 不被覆盖 —— ParseChannelID 已经能从前缀解出 SpaceID 的情况
-// （Space-prefixed channel）下，我们不应被空 groupMap 项覆盖回空。
+// （Space-prefixed channel）下，我们不应被空 rawGroupSpaceMap 项覆盖回空。
 func TestSpaceID_FillConversationSpaceIDs_PreservesExistingSpaceID(t *testing.T) {
 	resps := []*SyncUserConversationResp{
 		{ChannelID: "g1", ChannelType: common.ChannelTypeGroup.Uint8(), SpaceID: "spaceA"},
 	}
-	// groupMap 给一个不同的值（不该发生，但回填逻辑必须以已 enriched 的 SpaceID 为准）。
-	groupMap := map[string]*group.GroupResp{
-		"g1": {GroupNo: "g1", SpaceID: "spaceB"},
+	// rawGroupSpaceMap 给一个不同的值（不该发生，但回填逻辑必须以已 enriched 的 SpaceID 为准）。
+	rawGroupSpaceMap := map[string]string{
+		"g1": "spaceB",
 	}
 
-	fillConversationSpaceIDs(resps, groupMap, nil)
+	fillConversationSpaceIDs(resps, rawGroupSpaceMap, nil, "")
 
 	assert.Equal(t, "spaceA", resps[0].SpaceID, "不覆盖已 enriched 的 SpaceID")
 }
@@ -103,7 +105,7 @@ func TestSpaceID_FillConversationSpaceIDs_HandlesNilEntries(t *testing.T) {
 		{ChannelID: "g1", ChannelType: common.ChannelTypeGroup.Uint8()},
 	}
 	assert.NotPanics(t, func() {
-		fillConversationSpaceIDs(resps, nil, nil)
+		fillConversationSpaceIDs(resps, nil, nil, "")
 	})
 	assert.Equal(t, "", resps[1].SpaceID)
 }

--- a/modules/message/conversation_space_id_backfill_test.go
+++ b/modules/message/conversation_space_id_backfill_test.go
@@ -1,0 +1,109 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSpaceID_FillConversationSpaceIDs_GroupBackfill 验证群聊会话从 groupMap
+// 拿到 resolved space_id 回填到 SyncUserConversationResp.SpaceID。
+//
+// 背景 (GH octo-server#153)：newSyncUserConversationResp 用 ParseChannelID 推
+// SpaceID，群聊 channel_id 是裸 group_no 拿不到，必须用 group 表权威值回填，
+// 客户端才能正确判定 WebSocket 群消息的 Space 归属。
+func TestSpaceID_FillConversationSpaceIDs_GroupBackfill(t *testing.T) {
+	resps := []*SyncUserConversationResp{
+		{ChannelID: "g_internal", ChannelType: common.ChannelTypeGroup.Uint8()},
+		{ChannelID: "g_external", ChannelType: common.ChannelTypeGroup.Uint8()},
+		{ChannelID: "g_legacy", ChannelType: common.ChannelTypeGroup.Uint8()},
+		// PERSON 频道：保持原 SpaceID 不动。
+		{ChannelID: "u1", ChannelType: common.ChannelTypePerson.Uint8(), SpaceID: ""},
+	}
+	groupMap := map[string]*group.GroupResp{
+		"g_internal": {GroupNo: "g_internal", SpaceID: "spaceA"},
+		"g_external": {GroupNo: "g_external", SpaceID: "spaceB"},
+		"g_legacy":   {GroupNo: "g_legacy", SpaceID: ""}, // 旧群无 space_id
+	}
+	externalGroupMap := map[string]string{
+		"g_external": "spaceA", // 当前 user 从 spaceA 加入了 g_external
+	}
+
+	fillConversationSpaceIDs(resps, groupMap, externalGroupMap)
+
+	assert.Equal(t, "spaceA", resps[0].SpaceID, "internal group: SpaceID 来自 group 表")
+	assert.Equal(t, "", resps[0].MySourceSpaceID, "non-external group: MySourceSpaceID 保持空")
+
+	assert.Equal(t, "spaceB", resps[1].SpaceID, "external group: 群本身 SpaceID 还是 group 表")
+	assert.Equal(t, "spaceA", resps[1].MySourceSpaceID, "external group: MySourceSpaceID 来自 externalGroupMap")
+
+	assert.Equal(t, "", resps[2].SpaceID, "legacy group with empty space_id: 保持空")
+
+	assert.Equal(t, "", resps[3].SpaceID, "PERSON: 不写 conversation-level SpaceID")
+	assert.Equal(t, "", resps[3].MySourceSpaceID, "PERSON: 不填 MySourceSpaceID")
+}
+
+// TestSpaceID_FillConversationSpaceIDs_ThreadInheritsParent 验证子区(thread)会话
+// 的 SpaceID 来自父群（与 FilterRawConversationsBySpace thread 分支同口径）。
+func TestSpaceID_FillConversationSpaceIDs_ThreadInheritsParent(t *testing.T) {
+	resps := []*SyncUserConversationResp{
+		{ChannelID: "g_parent____thread1", ChannelType: common.ChannelTypeCommunityTopic.Uint8()},
+		// 父群在 externalGroupMap，子区也应继承 my_source_space_id。
+		{ChannelID: "g_ext____thread2", ChannelType: common.ChannelTypeCommunityTopic.Uint8()},
+		// 父群不在 groupMap（未活跃，本批没返回）：不补 SpaceID，保留空字符串。
+		{ChannelID: "g_missing____thread3", ChannelType: common.ChannelTypeCommunityTopic.Uint8()},
+		// channel_id 形式错误：跳过。
+		{ChannelID: "invalid-no-separator", ChannelType: common.ChannelTypeCommunityTopic.Uint8()},
+	}
+	groupMap := map[string]*group.GroupResp{
+		"g_parent": {GroupNo: "g_parent", SpaceID: "spaceX"},
+		"g_ext":    {GroupNo: "g_ext", SpaceID: "spaceY"},
+	}
+	externalGroupMap := map[string]string{
+		"g_ext": "spaceX",
+	}
+
+	fillConversationSpaceIDs(resps, groupMap, externalGroupMap)
+
+	assert.Equal(t, "spaceX", resps[0].SpaceID, "thread 继承父群 spaceX")
+	assert.Equal(t, "", resps[0].MySourceSpaceID)
+
+	assert.Equal(t, "spaceY", resps[1].SpaceID, "external 父群的 thread 仍取父群 SpaceID")
+	assert.Equal(t, "spaceX", resps[1].MySourceSpaceID, "thread 继承父群的 MySourceSpaceID")
+
+	assert.Equal(t, "", resps[2].SpaceID, "父群不在 groupMap：保持空，不猜")
+
+	assert.Equal(t, "", resps[3].SpaceID, "malformed thread channel id：跳过")
+}
+
+// TestSpaceID_FillConversationSpaceIDs_PreservesExistingSpaceID 验证已有非空
+// SpaceID 不被覆盖 —— ParseChannelID 已经能从前缀解出 SpaceID 的情况
+// （Space-prefixed channel）下，我们不应被空 groupMap 项覆盖回空。
+func TestSpaceID_FillConversationSpaceIDs_PreservesExistingSpaceID(t *testing.T) {
+	resps := []*SyncUserConversationResp{
+		{ChannelID: "g1", ChannelType: common.ChannelTypeGroup.Uint8(), SpaceID: "spaceA"},
+	}
+	// groupMap 给一个不同的值（不该发生，但回填逻辑必须以已 enriched 的 SpaceID 为准）。
+	groupMap := map[string]*group.GroupResp{
+		"g1": {GroupNo: "g1", SpaceID: "spaceB"},
+	}
+
+	fillConversationSpaceIDs(resps, groupMap, nil)
+
+	assert.Equal(t, "spaceA", resps[0].SpaceID, "不覆盖已 enriched 的 SpaceID")
+}
+
+// TestSpaceID_FillConversationSpaceIDs_HandlesNilEntries 边界：nil entry / nil
+// maps 不应 panic。
+func TestSpaceID_FillConversationSpaceIDs_HandlesNilEntries(t *testing.T) {
+	resps := []*SyncUserConversationResp{
+		nil,
+		{ChannelID: "g1", ChannelType: common.ChannelTypeGroup.Uint8()},
+	}
+	assert.NotPanics(t, func() {
+		fillConversationSpaceIDs(resps, nil, nil)
+	})
+	assert.Equal(t, "", resps[1].SpaceID)
+}

--- a/modules/message/round2_findings_test.go
+++ b/modules/message/round2_findings_test.go
@@ -24,19 +24,19 @@ import (
 // space_id 就被正确回填。Round-2 修复确保 syncUserConversation 在调
 // GetGroupDetails 之前就把 g1 加入 groupNos，从而让 groupMap 真的包含 g1。
 func TestSpaceID_Round2_Finding1_ThreadParentPrefetched(t *testing.T) {
-	// 模拟 Round-2 修复后的状态：thread 的父群已被预取并写入 groupMap，
+	// 模拟 Round-2 修复后的状态：thread 的父群已被预取并写入 rawGroupSpaceMap，
 	// 即便 IM 批次没把父群作为独立 conversation 返回。
 	resps := []*SyncUserConversationResp{
 		{ChannelID: "g1____th1", ChannelType: common.ChannelTypeCommunityTopic.Uint8()},
 	}
-	groupMap := map[string]*group.GroupResp{
-		"g1": {GroupNo: "g1", SpaceID: "spaceA"},
+	rawGroupSpaceMap := map[string]string{
+		"g1": "spaceA",
 	}
 
-	fillConversationSpaceIDs(resps, groupMap, nil)
+	fillConversationSpaceIDs(resps, rawGroupSpaceMap, nil, "")
 
 	assert.Equal(t, "spaceA", resps[0].SpaceID,
-		"thread 的 SpaceID 应继承父群——前提是父群已被预取到 groupMap")
+		"thread 的 SpaceID 应继承父群——前提是父群已被预取到 rawGroupSpaceMap")
 }
 
 // TestSpaceID_Round2_Finding2_DBOnlyThreadParentInGroupSpaceMap 验证 sidebar
@@ -85,7 +85,7 @@ func TestSpaceID_Round2_Finding2_DBOnlyThreadInheritsParentSpace(t *testing.T) {
 	}
 
 	items := mergeThreadEntries(nil, extRows, aliveThread("g_db_parent____th9", nil),
-		categorySetting, nil, groupSpaceMap, nil)
+		categorySetting, nil, groupSpaceMap, nil, "")
 
 	require.Len(t, items, 1)
 	assert.Equal(t, "spaceX", items[0].SpaceID,
@@ -118,7 +118,7 @@ func TestSpaceID_Round2_Finding3_BuildFollowItems_ExternalGroupMySource(t *testi
 		"g_external": "spaceA",
 	}
 
-	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, groupSpaceMap, externalGroupMap)
+	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, groupSpaceMap, externalGroupMap, "")
 
 	byID := map[string]*SidebarItem{}
 	for _, it := range items {
@@ -152,7 +152,7 @@ func TestSpaceID_Round2_Finding3_BuildRecentItems_ExternalGroupMySource(t *testi
 	groupSpaceMap := map[string]string{"g_external": "spaceB"}
 	externalGroupMap := map[string]string{"g_external": "spaceA"}
 
-	items := buildRecentItems(convs, nil, groupSpaceMap, externalGroupMap)
+	items := buildRecentItems(convs, nil, groupSpaceMap, externalGroupMap, "")
 
 	byID := map[string]*SidebarItem{}
 	for _, it := range items {
@@ -182,7 +182,7 @@ func TestSpaceID_Round2_Finding3_MergeThreadEntries_ExternalGroupMySource(t *tes
 
 	result := mergeThreadEntries(nil, threadExtRows,
 		aliveThread("g_external____alive", nil),
-		categorySetting, nil, groupSpaceMap, externalGroupMap)
+		categorySetting, nil, groupSpaceMap, externalGroupMap, "")
 
 	require.Len(t, result, 1)
 	assert.Equal(t, "spaceB", result[0].SpaceID)

--- a/modules/message/round2_findings_test.go
+++ b/modules/message/round2_findings_test.go
@@ -1,0 +1,213 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSpaceID_Round2_Finding1_ThreadParentPrefetched 验证 syncUserConversation
+// 在构建 groupNos 预取列表时，把 COMMUNITY_TOPIC 频道解析出的父群 groupNo 也合入
+// 集合（GH octo-server#153 Round-2 Critical 1）。
+//
+// 修复前：sync 批次只含 thread "g1____th1" 而父群 g1 没出现在 IM 返回里时，
+// groupMap 只会缓存 "g1____th1" 的 GetGroupDetails 结果（实际拿不到任何东西），
+// fillConversationSpaceIDs 走 thread 分支查 groupMap["g1"] 是 miss → space_id
+// 被回填为空。
+//
+// 这里用 fillConversationSpaceIDs 的契约来验证：只要 groupMap 包含父群 g1，
+// space_id 就被正确回填。Round-2 修复确保 syncUserConversation 在调
+// GetGroupDetails 之前就把 g1 加入 groupNos，从而让 groupMap 真的包含 g1。
+func TestSpaceID_Round2_Finding1_ThreadParentPrefetched(t *testing.T) {
+	// 模拟 Round-2 修复后的状态：thread 的父群已被预取并写入 groupMap，
+	// 即便 IM 批次没把父群作为独立 conversation 返回。
+	resps := []*SyncUserConversationResp{
+		{ChannelID: "g1____th1", ChannelType: common.ChannelTypeCommunityTopic.Uint8()},
+	}
+	groupMap := map[string]*group.GroupResp{
+		"g1": {GroupNo: "g1", SpaceID: "spaceA"},
+	}
+
+	fillConversationSpaceIDs(resps, groupMap, nil)
+
+	assert.Equal(t, "spaceA", resps[0].SpaceID,
+		"thread 的 SpaceID 应继承父群——前提是父群已被预取到 groupMap")
+}
+
+// TestSpaceID_Round2_Finding2_DBOnlyThreadParentInGroupSpaceMap 验证 sidebar
+// follow tab 下，DB-only thread（IM 没返回）的父群虽不在 IM conversations 里，
+// 仍能通过 CollectGroupSpaceMap 的 extraGroupNos 入参参与 group service 查询，
+// 最终 groupSpaceMap 里包含该父群（GH octo-server#153 Round-2 Critical 2）。
+//
+// 这里用 CollectGroupSpaceMap 直接验证契约：传入空 conversations + 父群作为
+// extra → fakeService 仍然被调到 → 返回 map 包含父群。
+func TestSpaceID_Round2_Finding2_DBOnlyThreadParentInGroupSpaceMap(t *testing.T) {
+	// IM 返回里没有任何 conversation —— 所有 thread 都是 DB-only。
+	conversations := []*config.SyncUserConversationResp{}
+	extraParentGroupNos := []string{"g_db_parent"}
+
+	stub := &stubGroupService{
+		spaces: map[string]string{"g_db_parent": "spaceX"},
+	}
+
+	m, ok := CollectGroupSpaceMap(conversations, extraParentGroupNos, stub)
+
+	require.True(t, ok, "fake group service 不应失败")
+	assert.Equal(t, "spaceX", m["g_db_parent"],
+		"DB-only thread 父群必须出现在 groupSpaceMap，否则 mergeThreadEntries 拿不到 space_id")
+	assert.Equal(t, []string{"g_db_parent"}, stub.lastCall,
+		"父群必须真的传给 group service 查询")
+}
+
+// TestSpaceID_Round2_Finding2_DBOnlyThreadInheritsParentSpace 端到端验证：
+// CollectGroupSpaceMap → groupSpaceMap → mergeThreadEntries → SidebarItem.SpaceID。
+func TestSpaceID_Round2_Finding2_DBOnlyThreadInheritsParentSpace(t *testing.T) {
+	conversations := []*config.SyncUserConversationResp{}
+	extRows := []*convext.Model{
+		{TargetID: "g_db_parent____th9", FollowSort: 1},
+	}
+	extra := uniqueThreadParentGroupNos(extRows)
+	stub := &stubGroupService{
+		spaces: map[string]string{"g_db_parent": "spaceX"},
+	}
+
+	groupSpaceMap, ok := CollectGroupSpaceMap(conversations, extra, stub)
+	require.True(t, ok)
+
+	cat := "cat-A"
+	categorySetting := map[string]*GroupCategorySetting{
+		"g_db_parent": {GroupNo: "g_db_parent", CategoryID: &cat},
+	}
+
+	items := mergeThreadEntries(nil, extRows, aliveThread("g_db_parent____th9", nil),
+		categorySetting, nil, groupSpaceMap, nil)
+
+	require.Len(t, items, 1)
+	assert.Equal(t, "spaceX", items[0].SpaceID,
+		"DB-only thread 的 space_id 必须从父群继承，即便父群本批不在 IM 返回里")
+}
+
+// TestSpaceID_Round2_Finding3_BuildFollowItems_ExternalGroupMySource 验证
+// follow tab 外部群 SidebarItem 的 my_source_space_id 字段被正确填充
+// （GH octo-server#153 Round-2 P1）。
+func TestSpaceID_Round2_Finding3_BuildFollowItems_ExternalGroupMySource(t *testing.T) {
+	convs := []*config.SyncUserConversationResp{
+		{ChannelID: "g_internal", ChannelType: common.ChannelTypeGroup.Uint8(), Timestamp: 1000},
+		{ChannelID: "g_external", ChannelType: common.ChannelTypeGroup.Uint8(), Timestamp: 1100},
+		{ChannelID: "g_external____th1", ChannelType: common.ChannelTypeCommunityTopic.Uint8(), Timestamp: 1200},
+	}
+	cat := "cat-A"
+	categorySetting := map[string]*GroupCategorySetting{
+		"g_internal": {GroupNo: "g_internal", CategoryID: &cat},
+		"g_external": {GroupNo: "g_external", CategoryID: &cat},
+	}
+	threadExtMap := map[string]*convext.Model{
+		"g_external____th1": {TargetID: "g_external____th1", FollowSort: 5},
+	}
+	groupSpaceMap := map[string]string{
+		"g_internal": "spaceA",
+		"g_external": "spaceB",
+	}
+	externalGroupMap := map[string]string{
+		// 当前用户从 spaceA 加入了 g_external（外部群成员）。
+		"g_external": "spaceA",
+	}
+
+	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, groupSpaceMap, externalGroupMap)
+
+	byID := map[string]*SidebarItem{}
+	for _, it := range items {
+		byID[it.TargetID] = it
+	}
+
+	require.Contains(t, byID, "g_internal")
+	assert.Equal(t, "spaceA", byID["g_internal"].SpaceID, "internal group: SpaceID 来自 group 表")
+	assert.Equal(t, "", byID["g_internal"].MySourceSpaceID, "non-external group: my_source_space_id 留空")
+
+	require.Contains(t, byID, "g_external")
+	assert.Equal(t, "spaceB", byID["g_external"].SpaceID, "external group: SpaceID 仍是群本身的 spaceB")
+	assert.Equal(t, "spaceA", byID["g_external"].MySourceSpaceID,
+		"external group: my_source_space_id = 用户加入时的 source space")
+
+	require.Contains(t, byID, "g_external____th1")
+	assert.Equal(t, "spaceB", byID["g_external____th1"].SpaceID, "thread 继承父群 spaceB")
+	assert.Equal(t, "spaceA", byID["g_external____th1"].MySourceSpaceID,
+		"thread 同样继承父群的 my_source_space_id")
+}
+
+// TestSpaceID_Round2_Finding3_BuildRecentItems_ExternalGroupMySource recent tab
+// 同样要回填 my_source_space_id。
+func TestSpaceID_Round2_Finding3_BuildRecentItems_ExternalGroupMySource(t *testing.T) {
+	now := nowRecent()
+	convs := []*config.SyncUserConversationResp{
+		{ChannelID: "g_external", ChannelType: common.ChannelTypeGroup.Uint8(), Timestamp: now},
+		{ChannelID: "g_external____th1", ChannelType: common.ChannelTypeCommunityTopic.Uint8(), Timestamp: now},
+		{ChannelID: "u1", ChannelType: common.ChannelTypePerson.Uint8(), Timestamp: now},
+	}
+	groupSpaceMap := map[string]string{"g_external": "spaceB"}
+	externalGroupMap := map[string]string{"g_external": "spaceA"}
+
+	items := buildRecentItems(convs, nil, groupSpaceMap, externalGroupMap)
+
+	byID := map[string]*SidebarItem{}
+	for _, it := range items {
+		byID[it.TargetID] = it
+	}
+
+	require.Contains(t, byID, "g_external")
+	assert.Equal(t, "spaceA", byID["g_external"].MySourceSpaceID, "external group recent tab")
+	require.Contains(t, byID, "g_external____th1")
+	assert.Equal(t, "spaceA", byID["g_external____th1"].MySourceSpaceID, "thread 继承 my_source_space_id")
+	require.Contains(t, byID, "u1")
+	assert.Equal(t, "", byID["u1"].MySourceSpaceID, "PERSON: my_source_space_id 留空")
+}
+
+// TestSpaceID_Round2_Finding3_MergeThreadEntries_ExternalGroupMySource DB-only
+// thread 也要继承父群的 my_source_space_id。
+func TestSpaceID_Round2_Finding3_MergeThreadEntries_ExternalGroupMySource(t *testing.T) {
+	cat := "cat-A"
+	categorySetting := map[string]*GroupCategorySetting{
+		"g_external": {GroupNo: "g_external", CategoryID: &cat},
+	}
+	threadExtRows := []*convext.Model{
+		{TargetID: "g_external____alive", FollowSort: 1},
+	}
+	groupSpaceMap := map[string]string{"g_external": "spaceB"}
+	externalGroupMap := map[string]string{"g_external": "spaceA"}
+
+	result := mergeThreadEntries(nil, threadExtRows,
+		aliveThread("g_external____alive", nil),
+		categorySetting, nil, groupSpaceMap, externalGroupMap)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "spaceB", result[0].SpaceID)
+	assert.Equal(t, "spaceA", result[0].MySourceSpaceID,
+		"DB-only thread 必须从父群继承 my_source_space_id")
+}
+
+// stubGroupService 是 group.IService 的最小实现，仅支持 GetGroups。
+// 通过嵌入 group.IService 来满足整个接口签名，未实现的方法被调用时会触发
+// nil pointer panic — 对单元测试足够。
+type stubGroupService struct {
+	group.IService
+	spaces   map[string]string
+	lastCall []string
+}
+
+func (s *stubGroupService) GetGroups(groupNos []string) ([]*group.InfoResp, error) {
+	s.lastCall = append([]string(nil), groupNos...)
+	out := make([]*group.InfoResp, 0, len(groupNos))
+	for _, no := range groupNos {
+		sid, ok := s.spaces[no]
+		if !ok {
+			continue
+		}
+		out = append(out, &group.InfoResp{GroupNo: no, SpaceID: sid})
+	}
+	return out, nil
+}

--- a/modules/message/round3_findings_test.go
+++ b/modules/message/round3_findings_test.go
@@ -1,0 +1,274 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSpaceID_Round3_Finding1_GroupTableAuthoritativeSpaceID 验证：
+//
+// fillConversationSpaceIDs 必须使用群表的权威 space_id 回填
+// SyncUserConversationResp.SpaceID，不能使用 GetGroupDetails 返回的、
+// 已被 SetEffectiveSpaceIDFromMap 改写的 effective 值。
+//
+// 场景 (GH octo-server#154 Round-2 Finding 1)：
+//   - 群 g_external 的群表 space_id = "spaceB"。
+//   - 用户作为外部成员从 spaceA 加入 g_external（externalGroupMap[g_external]=spaceA）。
+//   - GetGroupDetails 在内部会调用 SetEffectiveSpaceIDFromMap，把
+//     GroupResp.SpaceID 从 "spaceB" 改写成 "spaceA"。
+//   - 如果 fillConversationSpaceIDs 直接读 GroupDetails 的结果，
+//     SyncUserConversationResp.SpaceID 就会变成 "spaceA"，与
+//     MySourceSpaceID 一致——客户端无从分辨"群本身在 spaceB"和"我从 spaceA 加入"。
+//
+// Round-3 修复后的契约：handler 必须额外用 GetGroups(groupNos) 拿原始 space_id
+// 构建 rawGroupSpaceMap 传给 fillConversationSpaceIDs；这里直接验证传入
+// rawGroupSpaceMap（== 群表权威值）后，SyncUserConversationResp.SpaceID 是
+// "spaceB" 不是 "spaceA"。
+func TestSpaceID_Round3_Finding1_GroupTableAuthoritativeSpaceID(t *testing.T) {
+	resps := []*SyncUserConversationResp{
+		{ChannelID: "g_external", ChannelType: common.ChannelTypeGroup.Uint8()},
+		{ChannelID: "g_external____th1", ChannelType: common.ChannelTypeCommunityTopic.Uint8()},
+	}
+	// rawGroupSpaceMap = GetGroups 的结果（未经 effective rewrite）。
+	rawGroupSpaceMap := map[string]string{
+		"g_external": "spaceB",
+	}
+	// externalGroupMap = 当前 user 是外部成员（从 spaceA 加入 g_external）。
+	externalGroupMap := map[string]string{
+		"g_external": "spaceA",
+	}
+
+	fillConversationSpaceIDs(resps, rawGroupSpaceMap, externalGroupMap, "")
+
+	// SpaceID 必须是 spaceB（群表权威值），不是 spaceA（effective rewrite 值）。
+	assert.Equal(t, "spaceB", resps[0].SpaceID,
+		"GROUP: SyncUserConversationResp.SpaceID 必须是群表权威值 spaceB，"+
+			"不能是 SetEffectiveSpaceIDFromMap 改写后的 spaceA")
+	assert.Equal(t, "spaceA", resps[0].MySourceSpaceID,
+		"MySourceSpaceID 来自 externalGroupMap，是 spaceA")
+	assert.NotEqual(t, resps[0].SpaceID, resps[0].MySourceSpaceID,
+		"外部群场景下 SpaceID 与 MySourceSpaceID 必须不同——"+
+			"客户端要据此区分'群在哪个 Space'与'我从哪个 Space 看到这个群'")
+
+	assert.Equal(t, "spaceB", resps[1].SpaceID,
+		"COMMUNITY_TOPIC: 父群 SpaceID 同样是权威值 spaceB")
+	assert.Equal(t, "spaceA", resps[1].MySourceSpaceID,
+		"thread 继承父群的 MySourceSpaceID")
+}
+
+// TestSpaceID_Round3_Finding1_GetGroupsNotEffectiveRewrite 通过 group.InfoResp
+// 类型契约验证：GetGroups 返回的 SpaceID 字段直接来自群表行，没有 effective
+// rewrite 路径。
+//
+// 这是上面单测在 stub 层的延伸：确认 stubGroupService.GetGroups 用 InfoResp
+// 而非 GroupResp，意味着永远不会触发 SetEffectiveSpaceIDFromMap。
+func TestSpaceID_Round3_Finding1_GetGroupsNotEffectiveRewrite(t *testing.T) {
+	stub := &stubGroupService{
+		spaces: map[string]string{
+			"g_external": "spaceB", // 群表权威值
+		},
+	}
+	infos, err := stub.GetGroups([]string{"g_external"})
+	require.NoError(t, err)
+	require.Len(t, infos, 1)
+
+	// InfoResp 没有 IsExternalGroup 字段被 SetEffectiveSpaceID 利用的语义；
+	// SpaceID 永远是群表原值。
+	assert.Equal(t, "spaceB", infos[0].SpaceID,
+		"GetGroups 返回 *InfoResp.SpaceID 永远是群表权威值")
+
+	// 以此类型构建 rawGroupSpaceMap 是 Round-3 handler 修复的核心：
+	rawGroupSpaceMap := map[string]string{}
+	for _, g := range infos {
+		rawGroupSpaceMap[g.GroupNo] = g.SpaceID
+	}
+	assert.Equal(t, "spaceB", rawGroupSpaceMap["g_external"])
+}
+
+// TestSpaceID_Round3_Finding2_FillConversation_EmptySourceFallback 验证：
+//
+// 当 externalGroupMap[groupNo] 存在但值为空串（旧外部成员行
+// source_space_id=""）时，fillConversationSpaceIDs 必须把
+// MySourceSpaceID 兜底为 defaultSpaceID（用户最早加入的 Space），
+// 与 decideConvKeepInSpace（space_filter.go:171/234）同口径。
+//
+// 修复前：fillConversationSpaceIDs 直接 r.MySourceSpaceID = src，
+// 客户端拿到空串 + omitempty → 字段缺失，无法判断这个外部群在哪个 Space 下可见。
+func TestSpaceID_Round3_Finding2_FillConversation_EmptySourceFallback(t *testing.T) {
+	resps := []*SyncUserConversationResp{
+		// GROUP：source_space_id="" 兜底到 defaultSpaceID。
+		{ChannelID: "g_legacy_ext", ChannelType: common.ChannelTypeGroup.Uint8()},
+		// COMMUNITY_TOPIC：父群 source_space_id="" 同样兜底。
+		{ChannelID: "g_legacy_ext____th1", ChannelType: common.ChannelTypeCommunityTopic.Uint8()},
+		// GROUP：source_space_id 非空，原值不变。
+		{ChannelID: "g_new_ext", ChannelType: common.ChannelTypeGroup.Uint8()},
+	}
+	rawGroupSpaceMap := map[string]string{
+		"g_legacy_ext": "spaceB",
+		"g_new_ext":    "spaceB",
+	}
+	externalGroupMap := map[string]string{
+		"g_legacy_ext": "",       // 旧外部成员行
+		"g_new_ext":    "spaceA", // 正常外部成员行
+	}
+	defaultSpaceID := "spaceDefault" // 用户最早加入的 Space
+
+	fillConversationSpaceIDs(resps, rawGroupSpaceMap, externalGroupMap, defaultSpaceID)
+
+	assert.Equal(t, "spaceDefault", resps[0].MySourceSpaceID,
+		"GROUP: source_space_id='' 必须兜底到 defaultSpaceID")
+	assert.Equal(t, "spaceB", resps[0].SpaceID,
+		"SpaceID 不受 source_space_id 兜底影响")
+
+	assert.Equal(t, "spaceDefault", resps[1].MySourceSpaceID,
+		"COMMUNITY_TOPIC: 父群 source_space_id='' 同样兜底到 defaultSpaceID")
+	assert.Equal(t, "spaceB", resps[1].SpaceID,
+		"thread SpaceID 继承父群权威值")
+
+	assert.Equal(t, "spaceA", resps[2].MySourceSpaceID,
+		"非空 source_space_id 不被覆盖")
+}
+
+// TestSpaceID_Round3_Finding2_FillConversation_NoFallbackForNonExternal 验证：
+//
+// externalGroupMap 没记录的群（用户不是外部成员）不应被兜底到 defaultSpaceID。
+// 兜底语义只针对"已登记为外部成员但 source_space_id 留空"的旧行。
+func TestSpaceID_Round3_Finding2_FillConversation_NoFallbackForNonExternal(t *testing.T) {
+	resps := []*SyncUserConversationResp{
+		{ChannelID: "g_internal", ChannelType: common.ChannelTypeGroup.Uint8()},
+	}
+	rawGroupSpaceMap := map[string]string{
+		"g_internal": "spaceA",
+	}
+	externalGroupMap := map[string]string{} // 用户不是任何群的外部成员
+	defaultSpaceID := "spaceDefault"
+
+	fillConversationSpaceIDs(resps, rawGroupSpaceMap, externalGroupMap, defaultSpaceID)
+
+	assert.Equal(t, "", resps[0].MySourceSpaceID,
+		"非外部成员：MySourceSpaceID 留空，不被兜底覆盖")
+	assert.Equal(t, "spaceA", resps[0].SpaceID)
+}
+
+// TestSpaceID_Round3_Finding2_Sidebar_EmptySourceFallback 验证 sidebar
+// builders（buildFollowItems / buildRecentItems / mergeThreadEntries）
+// 同样对 source_space_id="" 兜底到 defaultSpaceID。
+func TestSpaceID_Round3_Finding2_Sidebar_EmptySourceFallback(t *testing.T) {
+	cat := "cat-A"
+	categorySetting := map[string]*GroupCategorySetting{
+		"g_legacy_ext": {GroupNo: "g_legacy_ext", CategoryID: &cat},
+	}
+	convs := []*config.SyncUserConversationResp{
+		{ChannelID: "g_legacy_ext", ChannelType: common.ChannelTypeGroup.Uint8(), Timestamp: nowRecent()},
+		{ChannelID: "g_legacy_ext____th1", ChannelType: common.ChannelTypeCommunityTopic.Uint8(), Timestamp: nowRecent()},
+	}
+	threadExtMap := map[string]*convext.Model{
+		"g_legacy_ext____th1": {TargetID: "g_legacy_ext____th1", FollowSort: 0},
+	}
+	groupSpaceMap := map[string]string{"g_legacy_ext": "spaceB"}
+	externalGroupMap := map[string]string{"g_legacy_ext": ""} // 旧外部成员行
+	defaultSpaceID := "spaceDefault"
+
+	t.Run("buildFollowItems", func(t *testing.T) {
+		items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil,
+			groupSpaceMap, externalGroupMap, defaultSpaceID)
+		byID := map[string]*SidebarItem{}
+		for _, it := range items {
+			byID[it.TargetID] = it
+		}
+		require.Contains(t, byID, "g_legacy_ext")
+		assert.Equal(t, "spaceDefault", byID["g_legacy_ext"].MySourceSpaceID,
+			"follow tab GROUP: source='' 兜底到 defaultSpaceID")
+		require.Contains(t, byID, "g_legacy_ext____th1")
+		assert.Equal(t, "spaceDefault", byID["g_legacy_ext____th1"].MySourceSpaceID,
+			"follow tab THREAD: 父群 source='' 兜底到 defaultSpaceID")
+	})
+
+	t.Run("buildRecentItems", func(t *testing.T) {
+		items := buildRecentItems(convs, nil, groupSpaceMap, externalGroupMap, defaultSpaceID)
+		byID := map[string]*SidebarItem{}
+		for _, it := range items {
+			byID[it.TargetID] = it
+		}
+		require.Contains(t, byID, "g_legacy_ext")
+		assert.Equal(t, "spaceDefault", byID["g_legacy_ext"].MySourceSpaceID,
+			"recent tab GROUP: source='' 兜底到 defaultSpaceID")
+		require.Contains(t, byID, "g_legacy_ext____th1")
+		assert.Equal(t, "spaceDefault", byID["g_legacy_ext____th1"].MySourceSpaceID,
+			"recent tab THREAD: source='' 兜底到 defaultSpaceID")
+	})
+
+	t.Run("mergeThreadEntries", func(t *testing.T) {
+		extRows := []*convext.Model{
+			{TargetID: "g_legacy_ext____alive", FollowSort: 1},
+		}
+		result := mergeThreadEntries(nil, extRows,
+			aliveThread("g_legacy_ext____alive", nil),
+			categorySetting, nil, groupSpaceMap, externalGroupMap, defaultSpaceID)
+		require.Len(t, result, 1)
+		assert.Equal(t, "spaceDefault", result[0].MySourceSpaceID,
+			"DB-only thread: 父群 source='' 兜底到 defaultSpaceID")
+	})
+}
+
+// TestSpaceID_Round3_Finding2_DefaultSpaceIDEmpty_StaysEmpty 验证：
+//
+// defaultSpaceID 也为空（极端场景：用户没有任何 space_member 行）时，
+// MySourceSpaceID 退化为空串——保持 omitempty 行为，与历史一致，
+// 不会写入"垃圾值"。
+func TestSpaceID_Round3_Finding2_DefaultSpaceIDEmpty_StaysEmpty(t *testing.T) {
+	resps := []*SyncUserConversationResp{
+		{ChannelID: "g_legacy_ext", ChannelType: common.ChannelTypeGroup.Uint8()},
+	}
+	rawGroupSpaceMap := map[string]string{"g_legacy_ext": "spaceB"}
+	externalGroupMap := map[string]string{"g_legacy_ext": ""}
+
+	fillConversationSpaceIDs(resps, rawGroupSpaceMap, externalGroupMap, "")
+
+	assert.Equal(t, "", resps[0].MySourceSpaceID,
+		"defaultSpaceID 也空时不写垃圾值，omitempty 让客户端拿不到字段")
+}
+
+// 编译期 sanity：确认 resolveMySourceSpaceID helper 行为。
+// 单元测试覆盖三条分支：非空直返、空+default、空+空default。
+func TestSpaceID_Round3_ResolveMySourceSpaceID(t *testing.T) {
+	assert.Equal(t, "spaceA", resolveMySourceSpaceID("spaceA", "spaceDefault"),
+		"non-empty source: 直接返回")
+	assert.Equal(t, "spaceDefault", resolveMySourceSpaceID("", "spaceDefault"),
+		"empty source: 兜底到 defaultSpaceID")
+	assert.Equal(t, "", resolveMySourceSpaceID("", ""),
+		"empty source + empty default: 退化为空串")
+}
+
+// TestSpaceID_Round3_SidebarMySourceSpaceID 覆盖 sidebar helper 三个分支。
+func TestSpaceID_Round3_SidebarMySourceSpaceID(t *testing.T) {
+	t.Run("not external member", func(t *testing.T) {
+		got := sidebarMySourceSpaceID(map[string]string{}, "g1", "spaceDefault")
+		assert.Equal(t, "", got, "非外部成员：返回空，不写 defaultSpaceID")
+	})
+	t.Run("nil map", func(t *testing.T) {
+		got := sidebarMySourceSpaceID(nil, "g1", "spaceDefault")
+		assert.Equal(t, "", got)
+	})
+	t.Run("non-empty source", func(t *testing.T) {
+		got := sidebarMySourceSpaceID(map[string]string{"g1": "spaceA"}, "g1", "spaceDefault")
+		assert.Equal(t, "spaceA", got, "非空 source: 直接返回")
+	})
+	t.Run("empty source falls back", func(t *testing.T) {
+		got := sidebarMySourceSpaceID(map[string]string{"g1": ""}, "g1", "spaceDefault")
+		assert.Equal(t, "spaceDefault", got, "空 source: 兜底 defaultSpaceID")
+	})
+	t.Run("empty source and empty default", func(t *testing.T) {
+		got := sidebarMySourceSpaceID(map[string]string{"g1": ""}, "g1", "")
+		assert.Equal(t, "", got, "都空：退化空串")
+	})
+}
+
+// 防止 unused import: group。这里通过引用 InfoResp 类型让 import 有意义。
+var _ = (*group.InfoResp)(nil)

--- a/modules/message/sidebar_space_id_test.go
+++ b/modules/message/sidebar_space_id_test.go
@@ -31,7 +31,7 @@ func TestSpaceID_BuildFollowItems_GroupAndThreadFilled(t *testing.T) {
 		"g1": "spaceA",
 	}
 
-	items := buildFollowItems(convs, categorySetting, nil, followedDMs, threadExtMap, nil, nil, groupSpaceMap, nil)
+	items := buildFollowItems(convs, categorySetting, nil, followedDMs, threadExtMap, nil, nil, groupSpaceMap, nil, "")
 
 	bySpace := map[string]string{}
 	byTarget := map[string]*SidebarItem{}
@@ -57,7 +57,7 @@ func TestSpaceID_BuildFollowItems_NilGroupSpaceMap(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() {
-		items := buildFollowItems(convs, categorySetting, nil, nil, nil, nil, nil, nil, nil)
+		items := buildFollowItems(convs, categorySetting, nil, nil, nil, nil, nil, nil, nil, "")
 		assert.Len(t, items, 1)
 		assert.Equal(t, "", items[0].SpaceID)
 	})
@@ -78,7 +78,7 @@ func TestSpaceID_BuildRecentItems_GroupAndThreadFilled(t *testing.T) {
 		"g1": "spaceB",
 	}
 
-	items := buildRecentItems(convs, nil, groupSpaceMap, nil)
+	items := buildRecentItems(convs, nil, groupSpaceMap, nil, "")
 
 	bySpace := map[string]string{}
 	for _, it := range items {
@@ -102,7 +102,7 @@ func TestSpaceID_MergeThreadEntries_FillsParentSpaceID(t *testing.T) {
 	}
 	groupSpaceMap := map[string]string{"g1": "spaceC"}
 
-	result := mergeThreadEntries(nil, threadExtRows, aliveThread("g1____alive", nil), categorySetting, nil, groupSpaceMap, nil)
+	result := mergeThreadEntries(nil, threadExtRows, aliveThread("g1____alive", nil), categorySetting, nil, groupSpaceMap, nil, "")
 
 	if assert.Len(t, result, 1) {
 		assert.Equal(t, "g1____alive", result[0].TargetID)

--- a/modules/message/sidebar_space_id_test.go
+++ b/modules/message/sidebar_space_id_test.go
@@ -1,0 +1,111 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSpaceID_BuildFollowItems_GroupAndThreadFilled 验证 buildFollowItems 把
+// groupSpaceMap 里的值回填到 SidebarItem.SpaceID（GH octo-server#153）。
+func TestSpaceID_BuildFollowItems_GroupAndThreadFilled(t *testing.T) {
+	convs := []*config.SyncUserConversationResp{
+		{ChannelID: "g1", ChannelType: common.ChannelTypeGroup.Uint8(), Timestamp: 1000},
+		{ChannelID: "g1____th1", ChannelType: common.ChannelTypeCommunityTopic.Uint8(), Timestamp: 1100},
+		{ChannelID: "u1", ChannelType: common.ChannelTypePerson.Uint8(), Timestamp: 1200},
+	}
+	cat := "cat-A"
+	categorySetting := map[string]*GroupCategorySetting{
+		"g1": {GroupNo: "g1", CategoryID: &cat, CategorySort: 0, CategoryGroupSort: 0},
+	}
+	threadExtMap := map[string]*convext.Model{
+		"g1____th1": {TargetID: "g1____th1", FollowSort: 5},
+	}
+	followedDMs := map[string]*convext.Model{
+		"u1": {TargetID: "u1", FollowSort: 7},
+	}
+	groupSpaceMap := map[string]string{
+		"g1": "spaceA",
+	}
+
+	items := buildFollowItems(convs, categorySetting, nil, followedDMs, threadExtMap, nil, nil, groupSpaceMap)
+
+	bySpace := map[string]string{}
+	byTarget := map[string]*SidebarItem{}
+	for _, it := range items {
+		byTarget[it.TargetID] = it
+		bySpace[it.TargetID] = it.SpaceID
+	}
+	assert.Equal(t, "spaceA", bySpace["g1"], "group SpaceID 来自 groupSpaceMap")
+	assert.Equal(t, "spaceA", bySpace["g1____th1"], "thread 继承父群 spaceA")
+	assert.Equal(t, "", bySpace["u1"], "DM SpaceID 永远留空")
+}
+
+// TestSpaceID_BuildFollowItems_NilGroupSpaceMap 验证 nil map 时不 panic 且字段
+// 留空 —— group service 调用失败的 fail-open 路径（CollectGroupSpaceMap 返回
+// ok=false，handler 退化到空 map）。
+func TestSpaceID_BuildFollowItems_NilGroupSpaceMap(t *testing.T) {
+	convs := []*config.SyncUserConversationResp{
+		{ChannelID: "g1", ChannelType: common.ChannelTypeGroup.Uint8(), Timestamp: 1000},
+	}
+	cat := "cat-A"
+	categorySetting := map[string]*GroupCategorySetting{
+		"g1": {GroupNo: "g1", CategoryID: &cat},
+	}
+
+	assert.NotPanics(t, func() {
+		items := buildFollowItems(convs, categorySetting, nil, nil, nil, nil, nil, nil)
+		assert.Len(t, items, 1)
+		assert.Equal(t, "", items[0].SpaceID)
+	})
+}
+
+// TestSpaceID_BuildRecentItems_GroupAndThreadFilled 验证 buildRecentItems 同
+// 口径回填 SpaceID。
+func TestSpaceID_BuildRecentItems_GroupAndThreadFilled(t *testing.T) {
+	now := nowRecent()
+	convs := []*config.SyncUserConversationResp{
+		{ChannelID: "g1", ChannelType: common.ChannelTypeGroup.Uint8(), Timestamp: now},
+		{ChannelID: "g1____th1", ChannelType: common.ChannelTypeCommunityTopic.Uint8(), Timestamp: now},
+		{ChannelID: "u1", ChannelType: common.ChannelTypePerson.Uint8(), Timestamp: now},
+		// 父群 g_missing 没出现在 groupSpaceMap：thread 应该 SpaceID="" 但仍出现在 recent。
+		{ChannelID: "g_missing____th2", ChannelType: common.ChannelTypeCommunityTopic.Uint8(), Timestamp: now},
+	}
+	groupSpaceMap := map[string]string{
+		"g1": "spaceB",
+	}
+
+	items := buildRecentItems(convs, nil, groupSpaceMap)
+
+	bySpace := map[string]string{}
+	for _, it := range items {
+		bySpace[it.TargetID] = it.SpaceID
+	}
+	assert.Equal(t, "spaceB", bySpace["g1"])
+	assert.Equal(t, "spaceB", bySpace["g1____th1"], "thread 取父群 SpaceID")
+	assert.Equal(t, "", bySpace["u1"], "DM SpaceID 留空")
+	assert.Equal(t, "", bySpace["g_missing____th2"], "groupSpaceMap 缺父群：留空，不猜")
+}
+
+// TestSpaceID_MergeThreadEntries_FillsParentSpaceID 验证 DB-only thread（IM
+// 没返回但 user_conversation_ext 有的）补齐时也回填父群 SpaceID。
+func TestSpaceID_MergeThreadEntries_FillsParentSpaceID(t *testing.T) {
+	cat := "cat-A"
+	categorySetting := map[string]*GroupCategorySetting{
+		"g1": {GroupNo: "g1", CategoryID: &cat},
+	}
+	threadExtRows := []*convext.Model{
+		{TargetID: "g1____alive", FollowSort: 1},
+	}
+	groupSpaceMap := map[string]string{"g1": "spaceC"}
+
+	result := mergeThreadEntries(nil, threadExtRows, aliveThread("g1____alive", nil), categorySetting, nil, groupSpaceMap)
+
+	if assert.Len(t, result, 1) {
+		assert.Equal(t, "g1____alive", result[0].TargetID)
+		assert.Equal(t, "spaceC", result[0].SpaceID, "DB-only thread 应继承父群 SpaceID")
+	}
+}

--- a/modules/message/sidebar_space_id_test.go
+++ b/modules/message/sidebar_space_id_test.go
@@ -31,7 +31,7 @@ func TestSpaceID_BuildFollowItems_GroupAndThreadFilled(t *testing.T) {
 		"g1": "spaceA",
 	}
 
-	items := buildFollowItems(convs, categorySetting, nil, followedDMs, threadExtMap, nil, nil, groupSpaceMap)
+	items := buildFollowItems(convs, categorySetting, nil, followedDMs, threadExtMap, nil, nil, groupSpaceMap, nil)
 
 	bySpace := map[string]string{}
 	byTarget := map[string]*SidebarItem{}
@@ -57,7 +57,7 @@ func TestSpaceID_BuildFollowItems_NilGroupSpaceMap(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() {
-		items := buildFollowItems(convs, categorySetting, nil, nil, nil, nil, nil, nil)
+		items := buildFollowItems(convs, categorySetting, nil, nil, nil, nil, nil, nil, nil)
 		assert.Len(t, items, 1)
 		assert.Equal(t, "", items[0].SpaceID)
 	})
@@ -78,7 +78,7 @@ func TestSpaceID_BuildRecentItems_GroupAndThreadFilled(t *testing.T) {
 		"g1": "spaceB",
 	}
 
-	items := buildRecentItems(convs, nil, groupSpaceMap)
+	items := buildRecentItems(convs, nil, groupSpaceMap, nil)
 
 	bySpace := map[string]string{}
 	for _, it := range items {
@@ -102,7 +102,7 @@ func TestSpaceID_MergeThreadEntries_FillsParentSpaceID(t *testing.T) {
 	}
 	groupSpaceMap := map[string]string{"g1": "spaceC"}
 
-	result := mergeThreadEntries(nil, threadExtRows, aliveThread("g1____alive", nil), categorySetting, nil, groupSpaceMap)
+	result := mergeThreadEntries(nil, threadExtRows, aliveThread("g1____alive", nil), categorySetting, nil, groupSpaceMap, nil)
 
 	if assert.Len(t, result, 1) {
 		assert.Equal(t, "g1____alive", result[0].TargetID)

--- a/modules/message/space_filter.go
+++ b/modules/message/space_filter.go
@@ -438,6 +438,69 @@ func resolveBotFilter(ctx *config.Context, filterSpaceID string, bareDMUIDs []st
 	return
 }
 
+// CollectGroupSpaceMap 是 (groupNo -> spaceID) 的批量推导器：扫描
+// conversation 列表里的群和子区父群，去重后调一次 group service，输出
+// 客户端可见性判定所需的映射表。
+//
+// 调用方：
+//   - FilterRawConversationsBySpace / FilterConversationsBySpace：Space 过滤；
+//   - api_sidebar.go Sidebar.Sync：把 group.SpaceID 回填到 SidebarItem.SpaceID
+//     （GH octo-server#153），让客户端 WebSocket 实时消息能正确路由到当前
+//     Space tab，避免 conversation-level SpaceID 缺失导致 fail-open。
+//
+// 返回 (map, ok)。ok=false 表示底层 group service 调用失败 —— 调用方据此决定
+// fail-open 还是 fail-closed（v2 sidebar 必须 fail-closed，参见
+// decideConvKeepInSpace.failClosedOnUnknownGroupSpace 注释）。
+func CollectGroupSpaceMap(
+	conversations []*config.SyncUserConversationResp,
+	groupService group.IService,
+) (map[string]string, bool) {
+	seen := make(map[string]struct{})
+	var bareGroupNos []string
+	add := func(no string) {
+		if no == "" {
+			return
+		}
+		if _, ok := seen[no]; ok {
+			return
+		}
+		seen[no] = struct{}{}
+		bareGroupNos = append(bareGroupNos, no)
+	}
+	for _, conv := range conversations {
+		if conv == nil {
+			continue
+		}
+		sid, _ := spacepkg.ParseChannelID(conv.ChannelID)
+		if sid == "" && conv.ChannelType == common.ChannelTypeGroup.Uint8() {
+			add(conv.ChannelID)
+		}
+		if conv.ChannelType == common.ChannelTypeCommunityTopic.Uint8() {
+			if parentNo, _, err := thread.ParseChannelID(conv.ChannelID); err == nil {
+				add(parentNo)
+			}
+		}
+	}
+	if len(bareGroupNos) == 0 {
+		return map[string]string{}, true
+	}
+	m, err := spacepkg.GetGroupSpaceMap(bareGroupNos, func(nos []string) ([]spacepkg.GroupSpaceInfo, error) {
+		infos, err := groupService.GetGroups(nos)
+		if err != nil {
+			return nil, err
+		}
+		result := make([]spacepkg.GroupSpaceInfo, 0, len(infos))
+		for _, g := range infos {
+			result = append(result, spacepkg.GroupSpaceInfo{GroupNo: g.GroupNo, SpaceID: g.SpaceID})
+		}
+		return result, nil
+	})
+	if err != nil {
+		return nil, false
+	}
+	return m, true
+}
+
 // FilterRawConversationsBySpace 是 FilterConversationsBySpace 在 v2 sidebar 上的
 // 对应版本：v2 直接操作 IM 返回的 *config.SyncUserConversationResp（没有
 // enriched SpaceID/parsed Payload），所以单独写一个入口，但内部沿用

--- a/modules/message/space_filter.go
+++ b/modules/message/space_filter.go
@@ -442,6 +442,10 @@ func resolveBotFilter(ctx *config.Context, filterSpaceID string, bareDMUIDs []st
 // conversation 列表里的群和子区父群，去重后调一次 group service，输出
 // 客户端可见性判定所需的映射表。
 //
+// extraGroupNos 用于补充 conversations 之外的 groupNo（典型场景：v2 sidebar
+// 的 DB-only thread ext 行的父群可能不在 IM 返回里 —— GH octo-server#153
+// Round-2 Critical 2）。传 nil / 空切片表示纯走 conversations。
+//
 // 调用方：
 //   - FilterRawConversationsBySpace / FilterConversationsBySpace：Space 过滤；
 //   - api_sidebar.go Sidebar.Sync：把 group.SpaceID 回填到 SidebarItem.SpaceID
@@ -453,6 +457,7 @@ func resolveBotFilter(ctx *config.Context, filterSpaceID string, bareDMUIDs []st
 // decideConvKeepInSpace.failClosedOnUnknownGroupSpace 注释）。
 func CollectGroupSpaceMap(
 	conversations []*config.SyncUserConversationResp,
+	extraGroupNos []string,
 	groupService group.IService,
 ) (map[string]string, bool) {
 	seen := make(map[string]struct{})
@@ -480,6 +485,9 @@ func CollectGroupSpaceMap(
 				add(parentNo)
 			}
 		}
+	}
+	for _, no := range extraGroupNos {
+		add(no)
 	}
 	if len(bareGroupNos) == 0 {
 		return map[string]string{}, true


### PR DESCRIPTION
## What

Backfills the resolved Space ID into the conversation sync and sidebar sync responses so realtime WebSocket messages can be routed to the correct Space without a fail-open race.

## Why

`POST /v1/conversation/sync` returned `SyncUserConversationResp.SpaceID = ""` for every group conversation because `ParseChannelID(group_no)` returns `""`. The server resolves the real `space_id` inside `FilterConversationsBySpace` (group table lookup) but throws it away. Three-end clients have nothing to anchor incoming WebSocket group messages to, so a Space A message lands in whatever tab the user has open → P1 cross-Space leak (issue #153).

## Changes

**`modules/message/api_conversation.go`**
- `SyncUserConversationResp`: new field `MySourceSpaceID string` (`json:"my_source_space_id,omitempty"`). Populated from `group.QueryExternalGroupNosForUser` for users who joined a group as external members; honors the same source-Space contract as `FilterConversationsBySpace`.
- `fillConversationSpaceIDs(resps, groupMap, externalGroupMap)` helper: backfills `SpaceID` from the existing `groupMap` (group table authoritative value) for GROUP, and from the parent group for COMMUNITY_TOPIC. PERSON channels left untouched — DM Space lives on message-level `payload.space_id`. Pre-existing non-empty `SpaceID` is preserved.
- Called in `syncUserConversation` right after `enrichConversationExternalMarkers` and before the optional Space filter so the field is set whether or not `X-Space-ID` is provided.

**`modules/message/api_sidebar.go`**
- `SidebarItem`: new field `SpaceID string` (`json:"space_id,omitempty"`).
- `buildFollowItems` / `buildRecentItems` / `mergeThreadEntries` now take a `groupSpaceMap` and fill the field — same rules: GROUP → `groupSpaceMap[channelID]`, COMMUNITY_TOPIC → `groupSpaceMap[parentGroupNo]`, PERSON → empty.
- Handler computes the map once via the new `CollectGroupSpaceMap` helper (extracted from `FilterRawConversationsBySpace`) using the already-Space-filtered `conversations`; fail-open to an empty map on group service error (logged warning) — never leaks the wrong Space.

**`modules/message/space_filter.go`**
- New exported helper `CollectGroupSpaceMap(conversations, groupService) (map[string]string, bool)` — DRYs the group-table batch query previously inlined in `FilterRawConversationsBySpace`. Skips empty input, returns `ok=false` only on the underlying group service error so call sites can choose fail-open / fail-closed.

## Tests

New `modules/message/conversation_space_id_backfill_test.go` and `modules/message/sidebar_space_id_test.go`:

- `TestSpaceID_FillConversationSpaceIDs_GroupBackfill` — internal/external/legacy groups + DM left empty.
- `TestSpaceID_FillConversationSpaceIDs_ThreadInheritsParent` — thread inherits parent SpaceID and parent's `my_source_space_id`; missing-parent and malformed thread IDs degrade safely.
- `TestSpaceID_FillConversationSpaceIDs_PreservesExistingSpaceID` — never overwrites a non-empty `SpaceID` already produced by `ParseChannelID`.
- `TestSpaceID_FillConversationSpaceIDs_HandlesNilEntries` — `nil` map / `nil` entry tolerant.
- `TestSpaceID_BuildFollowItems_GroupAndThreadFilled` / `TestSpaceID_BuildRecentItems_GroupAndThreadFilled` — sidebar fills GROUP/thread, leaves DM empty.
- `TestSpaceID_BuildFollowItems_NilGroupSpaceMap` — fail-open (nil map) leaves SpaceID empty, no panic.
- `TestSpaceID_MergeThreadEntries_FillsParentSpaceID` — DB-only thread path also inherits parent.

```
go test ./modules/message/... -run TestSpaceID    # PASS (8 tests)
go build ./...                                    # PASS
```

## Wire compatibility

All new fields are `omitempty`. Old clients keep working; new clients pick up the field when present.

## Out of scope

- No WuKongIM changes (Space is an octo-server business-layer concept).
- No client changes — client adoption tracked as a separate follow-up issue.

Fixes https://github.com/Mininglamp-OSS/octo-server/issues/153
