### PR TITLE
fix(follow): materialize ext rows for default-followed groups (#151)

### DIFF
--- a/modules/category/api.go
+++ b/modules/category/api.go
@@ -638,29 +638,47 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 		}
 	}
 
-	// Issue #151 review #3 — when this transition takes the group OUT of any
-	// category (categoryIDPtr == nil), clear the materialized
-	// auto_follow_threads flag on the corresponding user_conversation_ext row.
-	// Otherwise OnThreadCreated's fan-out filter would continue to target this
-	// user for new threads in a group that has just left the follow tab —
-	// the read side (buildFollowItems) drops the group because CategoryID is
-	// now nil, but the write side (selectEligibleForFanoutTx) only looks at
-	// auto_follow_threads.  Without this cleanup the two sides drift.
+	// Project-wide lock order is group_setting → user_follow_version →
+	// user_conversation_ext (matches UpdateSort, FollowChannel, UnfollowGroupsTx,
+	// deleteCategory).  Bump version BEFORE writing ext: otherwise a concurrent
+	// /v1/follow/sort holding the version FOR UPDATE while waiting on ext
+	// would AB-BA-deadlock against a move-out holding ext while waiting on
+	// version (issue #151 review #4 by an9xyz).
+	if _, err := convext.BumpFollowVersionTx(tx, loginUID, groupSpaceID); err != nil {
+		c.Error("更新 follow_version 失败", zap.Error(err))
+		ctx.ResponseError(errors.New("更新群设置失败"))
+		return
+	}
+
+	// Issue #151 review #3/#4 — synchronize user_conversation_ext.auto_follow_threads
+	// with the new category membership state.  buildFollowItems decides follow-tab
+	// membership by `cs.CategoryID != nil`; selectEligibleForFanoutTx decides
+	// OnThreadCreated fan-out by `auto_follow_threads=1 AND group_unfollowed=0`.
+	// These two reads share no column, so the writer (this handler) must keep
+	// them in lockstep:
 	//
-	// Category-to-category move (req.CategoryID != "") preserves the implicit
-	// follow and therefore preserves auto_follow_threads — no cleanup needed.
+	//   - Move-out (categoryIDPtr == nil): clear auto_follow_threads to match
+	//     the new "not in follow tab" state.  Without this, fan-out continues
+	//     to target a user whose follow tab no longer shows the group.
+	//   - Move-in (categoryIDPtr != nil): restore auto_follow_threads=1 if
+	//     an ext row already exists with =0 (left over from a prior move-out).
+	//     Sidebar materialization (api_sidebar.go) skips its INSERT IGNORE
+	//     when the ext row is already present, so without this restore the
+	//     group re-appears in the follow tab but fan-out stays disabled.
+	//     For first-time categorize (no ext row) the call is a no-op —
+	//     sidebar materialization later creates the row with =1.
 	if categoryIDPtr == nil {
 		if err := convext.ClearAutoFollowThreadsTx(tx, loginUID, groupSpaceID, []string{groupNo}); err != nil {
 			c.Error("清理 auto_follow_threads 失败", zap.Error(err))
 			ctx.ResponseError(errors.New("更新群设置失败"))
 			return
 		}
-	}
-
-	if _, err := convext.BumpFollowVersionTx(tx, loginUID, groupSpaceID); err != nil {
-		c.Error("更新 follow_version 失败", zap.Error(err))
-		ctx.ResponseError(errors.New("更新群设置失败"))
-		return
+	} else {
+		if err := convext.RestoreAutoFollowThreadsTx(tx, loginUID, groupSpaceID, []string{groupNo}); err != nil {
+			c.Error("恢复 auto_follow_threads 失败", zap.Error(err))
+			ctx.ResponseError(errors.New("更新群设置失败"))
+			return
+		}
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/modules/category/api.go
+++ b/modules/category/api.go
@@ -638,6 +638,25 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 		}
 	}
 
+	// Issue #151 review #3 — when this transition takes the group OUT of any
+	// category (categoryIDPtr == nil), clear the materialized
+	// auto_follow_threads flag on the corresponding user_conversation_ext row.
+	// Otherwise OnThreadCreated's fan-out filter would continue to target this
+	// user for new threads in a group that has just left the follow tab —
+	// the read side (buildFollowItems) drops the group because CategoryID is
+	// now nil, but the write side (selectEligibleForFanoutTx) only looks at
+	// auto_follow_threads.  Without this cleanup the two sides drift.
+	//
+	// Category-to-category move (req.CategoryID != "") preserves the implicit
+	// follow and therefore preserves auto_follow_threads — no cleanup needed.
+	if categoryIDPtr == nil {
+		if err := convext.ClearAutoFollowThreadsTx(tx, loginUID, groupSpaceID, []string{groupNo}); err != nil {
+			c.Error("清理 auto_follow_threads 失败", zap.Error(err))
+			ctx.ResponseError(errors.New("更新群设置失败"))
+			return
+		}
+	}
+
 	if _, err := convext.BumpFollowVersionTx(tx, loginUID, groupSpaceID); err != nil {
 		c.Error("更新 follow_version 失败", zap.Error(err))
 		ctx.ResponseError(errors.New("更新群设置失败"))

--- a/modules/category/api_test.go
+++ b/modules/category/api_test.go
@@ -9,12 +9,37 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
+	redis "github.com/go-redis/redis"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// resetUIDRateLimit clears the per-uid token-bucket keys
+// (ratelimit:uid:{uid}) so subsequent HTTP calls in this test start from a
+// full bucket.  Without this, tests that came earlier in the same go test
+// binary will have consumed tokens, and a later high-burst test (e.g.
+// TestCategory_CreateLimit, which makes 20+ category POSTs back-to-back)
+// fails with HTTP 429 even though the per-test logic is correct.  See
+// pkg/wkhttp/ratelimit_helper.go SharedUIDRateLimiter for the bucket key
+// scheme.  Pattern mirrors modules/space/api_email_invite_public_test.go's
+// resetSpaceInviteRateLimit.
+func resetUIDRateLimit(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	rdsClient := redis.NewClient(&redis.Options{
+		Addr:     ctx.GetConfig().DB.RedisAddr,
+		Password: ctx.GetConfig().DB.RedisPass,
+	})
+	defer rdsClient.Close()
+	keys, err := rdsClient.Keys("ratelimit:uid:*").Result()
+	if err == nil && len(keys) > 0 {
+		_ = rdsClient.Del(keys...).Err()
+	}
+}
 
 // ---------- helpers ----------
 
@@ -425,6 +450,152 @@ func TestCategory_MoveGroupToCategory(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, setting2)
 	assert.Nil(t, setting2.CategoryID)
+}
+
+// TestCategory_MoveGroupOutOfCategory_ClearsAutoFollowThreads is the
+// regression test for issue #151 review #3 (yujiawei).  When a user moves a
+// group out of any category, the auto_follow_threads flag on the
+// user_conversation_ext row (which the new sidebar materialization may have
+// set to 1) must be cleared in the same transaction.  Without this cleanup,
+// selectEligibleForFanoutTx would keep this user eligible for OnThreadCreated
+// fan-out — the read side (buildFollowItems) drops the group because
+// CategoryID is now nil, but the write side only checks auto_follow_threads.
+//
+// Repro before fix:
+//  1. group g placed in category c, no ext row yet (default-followed).
+//  2. /v1/sidebar/sync follow tab materializes (uid, space, g) with
+//     auto_follow_threads=1, group_unfollowed=0.
+//  3. User moves g out of category via PUT /v1/groups/g/category {"":""}.
+//  4. ext row still has auto_follow_threads=1 — fan-out continues.
+//
+// After fix the move-out branch in api.go calls ClearAutoFollowThreadsTx
+// in the same tx, restoring the read/write contract.
+func TestCategory_MoveGroupOutOfCategory_ClearsAutoFollowThreads(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+
+	err := testutil.CleanAllTables(ctx)
+	assert.NoError(t, err)
+	resetUIDRateLimit(t, ctx)
+
+	spaceID := "space-move-clr-001"
+	seedSpaceAndMember(t, f, spaceID, 0)
+	route := s.GetRoute()
+
+	// 1. Set up: category + group + group-in-category.
+	wc := createCategory(t, route, spaceID, "工作")
+	require.Equal(t, http.StatusOK, wc.Code)
+	cat := parseJSON(t, wc)
+	catID := cat["category_id"].(string)
+
+	groupNo := "group-move-clr-001"
+	seedGroup(t, f, groupNo, spaceID)
+
+	wm := doRequest(t, route, "PUT", "/v1/groups/"+groupNo+"/category", map[string]string{
+		"category_id": catID,
+	})
+	require.Equal(t, http.StatusOK, wm.Code)
+
+	// 2. Simulate the sidebar materialization step (would normally fire on
+	//    /v1/sidebar/sync).  Insert ext row with auto_follow_threads=1,
+	//    matching what MaterializeDefaultFollowedGroups writes.
+	_, err = f.db.session.InsertBySql(
+		"INSERT INTO user_conversation_ext (uid, space_id, target_type, target_id, group_unfollowed, auto_follow_threads) "+
+			"VALUES (?, ?, 2, ?, 0, 1)",
+		testutil.UID, spaceID, groupNo,
+	).Exec()
+	require.NoError(t, err, "seed materialized ext row")
+
+	// Precondition sanity check.
+	var preAutoFollow int
+	_, err = f.db.session.SelectBySql(
+		"SELECT auto_follow_threads FROM user_conversation_ext"+
+			" WHERE uid=? AND space_id=? AND target_type=2 AND target_id=?",
+		testutil.UID, spaceID, groupNo,
+	).Load(&preAutoFollow)
+	require.NoError(t, err)
+	require.Equal(t, 1, preAutoFollow, "precondition: row is materialized auto_follow_threads=1")
+
+	// 3. Move group OUT of category.
+	wm2 := doRequest(t, route, "PUT", "/v1/groups/"+groupNo+"/category", map[string]string{
+		"category_id": "",
+	})
+	require.Equal(t, http.StatusOK, wm2.Code)
+
+	// 4. Assert auto_follow_threads is now 0 — the actual regression fix.
+	var postAutoFollow int
+	_, err = f.db.session.SelectBySql(
+		"SELECT auto_follow_threads FROM user_conversation_ext"+
+			" WHERE uid=? AND space_id=? AND target_type=2 AND target_id=?",
+		testutil.UID, spaceID, groupNo,
+	).Load(&postAutoFollow)
+	require.NoError(t, err)
+	assert.Equal(t, 0, postAutoFollow,
+		"auto_follow_threads must be cleared after move-out (issue #151 review #3); "+
+			"otherwise selectEligibleForFanoutTx would still target this user")
+
+	// 5. Other flags MUST be preserved — uncategorize is NOT a full unfollow.
+	var groupUnfollowed int
+	_, err = f.db.session.SelectBySql(
+		"SELECT group_unfollowed FROM user_conversation_ext"+
+			" WHERE uid=? AND space_id=? AND target_type=2 AND target_id=?",
+		testutil.UID, spaceID, groupNo,
+	).Load(&groupUnfollowed)
+	require.NoError(t, err)
+	assert.Equal(t, 0, groupUnfollowed,
+		"group_unfollowed must NOT be set — uncategorize ≠ explicit unfollow; "+
+			"the cleanup only revokes auto-subscribe to NEW threads, not all subscriptions")
+}
+
+// TestCategory_MoveGroupBetweenCategories_PreservesAutoFollowThreads pins the
+// non-regression: moving a group from category A to category B preserves the
+// implicit follow, so auto_follow_threads stays 1.  Without this guard, a
+// future change might over-eagerly clear in every move and break the
+// "default-followed across category-to-category move" contract.
+func TestCategory_MoveGroupBetweenCategories_PreservesAutoFollowThreads(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+
+	err := testutil.CleanAllTables(ctx)
+	assert.NoError(t, err)
+	resetUIDRateLimit(t, ctx)
+
+	spaceID := "space-move-keep-001"
+	seedSpaceAndMember(t, f, spaceID, 0)
+	route := s.GetRoute()
+
+	// Two categories, one group, materialized ext row.
+	wcA := createCategory(t, route, spaceID, "工作A")
+	require.Equal(t, http.StatusOK, wcA.Code)
+	catA := parseJSON(t, wcA)["category_id"].(string)
+	wcB := createCategory(t, route, spaceID, "工作B")
+	require.Equal(t, http.StatusOK, wcB.Code)
+	catB := parseJSON(t, wcB)["category_id"].(string)
+
+	groupNo := "group-move-keep-001"
+	seedGroup(t, f, groupNo, spaceID)
+	require.Equal(t, http.StatusOK, doRequest(t, route, "PUT", "/v1/groups/"+groupNo+"/category", map[string]string{"category_id": catA}).Code)
+	_, err = f.db.session.InsertBySql(
+		"INSERT INTO user_conversation_ext (uid, space_id, target_type, target_id, group_unfollowed, auto_follow_threads) "+
+			"VALUES (?, ?, 2, ?, 0, 1)",
+		testutil.UID, spaceID, groupNo,
+	).Exec()
+	require.NoError(t, err)
+
+	// Move A → B.
+	w := doRequest(t, route, "PUT", "/v1/groups/"+groupNo+"/category", map[string]string{"category_id": catB})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var autoFollow int
+	_, err = f.db.session.SelectBySql(
+		"SELECT auto_follow_threads FROM user_conversation_ext"+
+			" WHERE uid=? AND space_id=? AND target_type=2 AND target_id=?",
+		testutil.UID, spaceID, groupNo,
+	).Load(&autoFollow)
+	require.NoError(t, err)
+	assert.Equal(t, 1, autoFollow,
+		"category A→B move must NOT clear auto_follow_threads — the group is "+
+			"still in the follow tab, just under a different category")
 }
 
 // ---------- Validation / Error Tests ----------

--- a/modules/category/api_test.go
+++ b/modules/category/api_test.go
@@ -598,6 +598,117 @@ func TestCategory_MoveGroupBetweenCategories_PreservesAutoFollowThreads(t *testi
 			"still in the follow tab, just under a different category")
 }
 
+// TestCategory_MoveGroupBackIntoCategory_RestoresAutoFollowThreads pins
+// issue #151 review #4 (an9xyz) symptom #1: a default-followed group that
+// has been materialized and then moved out must have auto_follow_threads
+// restored to 1 when it is moved back into any category.  Otherwise the
+// sidebar materialization branch skips the existing groupExts entry,
+// the group reappears in the follow tab via buildFollowItems, but
+// selectEligibleForFanoutTx still excludes the user (=0) — phantom missing
+// fan-out.
+func TestCategory_MoveGroupBackIntoCategory_RestoresAutoFollowThreads(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+
+	err := testutil.CleanAllTables(ctx)
+	assert.NoError(t, err)
+	resetUIDRateLimit(t, ctx)
+
+	spaceID := "space-move-back-001"
+	seedSpaceAndMember(t, f, spaceID, 0)
+	route := s.GetRoute()
+
+	wc := createCategory(t, route, spaceID, "工作")
+	require.Equal(t, http.StatusOK, wc.Code)
+	catID := parseJSON(t, wc)["category_id"].(string)
+
+	groupNo := "group-move-back-001"
+	seedGroup(t, f, groupNo, spaceID)
+
+	// Cycle: move into category → simulate sidebar materialization → move
+	// out (clears auto_follow_threads) → move back into the SAME category.
+	require.Equal(t, http.StatusOK, doRequest(t, route, "PUT", "/v1/groups/"+groupNo+"/category", map[string]string{"category_id": catID}).Code)
+	_, err = f.db.session.InsertBySql(
+		"INSERT INTO user_conversation_ext (uid, space_id, target_type, target_id, group_unfollowed, auto_follow_threads) "+
+			"VALUES (?, ?, 2, ?, 0, 1)",
+		testutil.UID, spaceID, groupNo,
+	).Exec()
+	require.NoError(t, err, "simulate sidebar materialization")
+	require.Equal(t, http.StatusOK, doRequest(t, route, "PUT", "/v1/groups/"+groupNo+"/category", map[string]string{"category_id": ""}).Code,
+		"move out — must clear auto_follow_threads")
+
+	var afterOut int
+	_, err = f.db.session.SelectBySql(
+		"SELECT auto_follow_threads FROM user_conversation_ext"+
+			" WHERE uid=? AND space_id=? AND target_type=2 AND target_id=?",
+		testutil.UID, spaceID, groupNo,
+	).Load(&afterOut)
+	require.NoError(t, err)
+	require.Equal(t, 0, afterOut, "precondition: move-out cleared auto_follow_threads")
+
+	// Move BACK into the same category.  Sidebar materialization would skip
+	// this row (groupExts hit), so the move-in path itself must restore =1.
+	require.Equal(t, http.StatusOK, doRequest(t, route, "PUT", "/v1/groups/"+groupNo+"/category", map[string]string{"category_id": catID}).Code)
+
+	var afterIn int
+	_, err = f.db.session.SelectBySql(
+		"SELECT auto_follow_threads FROM user_conversation_ext"+
+			" WHERE uid=? AND space_id=? AND target_type=2 AND target_id=?",
+		testutil.UID, spaceID, groupNo,
+	).Load(&afterIn)
+	require.NoError(t, err)
+	assert.Equal(t, 1, afterIn,
+		"move-in must restore auto_follow_threads=1 on an existing ext row "+
+			"(issue #151 review #4 symptom #1); sidebar materialization would "+
+			"otherwise skip the existing row, leaving OnThreadCreated fan-out "+
+			"disabled even though the group is back in the follow tab")
+}
+
+// TestCategory_MoveFirstTimeIntoCategory_NoOpRestore ensures the move-in
+// restore call is a safe no-op when no ext row has been materialized yet —
+// sidebar materialization at the next /v1/sidebar/sync creates the row with
+// auto_follow_threads=1 anyway, and the move-in handler must not
+// short-circuit any subsequent paths or write inappropriate rows.
+func TestCategory_MoveFirstTimeIntoCategory_NoOpRestore(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+
+	err := testutil.CleanAllTables(ctx)
+	assert.NoError(t, err)
+	resetUIDRateLimit(t, ctx)
+
+	spaceID := "space-move-first-001"
+	seedSpaceAndMember(t, f, spaceID, 0)
+	route := s.GetRoute()
+
+	wc := createCategory(t, route, spaceID, "工作")
+	require.Equal(t, http.StatusOK, wc.Code)
+	catID := parseJSON(t, wc)["category_id"].(string)
+
+	groupNo := "group-move-first-001"
+	seedGroup(t, f, groupNo, spaceID)
+
+	// Move into category for the first time — no ext row exists yet.
+	require.Equal(t, http.StatusOK, doRequest(t, route, "PUT", "/v1/groups/"+groupNo+"/category", map[string]string{"category_id": catID}).Code)
+
+	// No row should have been written by the move-in path — sidebar's
+	// MaterializeDefaultFollowedGroups is the canonical materialization site
+	// and stays solely responsible for creating ext rows.  Letting the
+	// move-in path INSERT here would race with the unique key and silently
+	// pick whichever flag set ends up committing first.
+	var count int
+	_, err = f.db.session.SelectBySql(
+		"SELECT COUNT(*) FROM user_conversation_ext"+
+			" WHERE uid=? AND space_id=? AND target_type=2 AND target_id=?",
+		testutil.UID, spaceID, groupNo,
+	).Load(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count,
+		"first-time move-in must NOT create an ext row — sidebar materialization "+
+			"is the single materialization site; RestoreAutoFollowThreadsTx is "+
+			"strictly UPDATE")
+}
+
 // ---------- Validation / Error Tests ----------
 
 func TestCategory_CreateLimit(t *testing.T) {

--- a/modules/category/db_group_setting.go
+++ b/modules/category/db_group_setting.go
@@ -26,6 +26,27 @@ func (d *categoryDB) updateGroupSettingCategory(id int64, categoryID *string, ca
 	return err
 }
 
+// queryUserGroupsInSpace returns the user's groups in the given Space, each
+// annotated with the category_id the user has assigned (NULL if uncategorized).
+//
+// KNOWN ISSUE (issue #151 follow-up, NOT addressed in this PR): the SELECT
+// returns gs.category_id (the persisted field) without joining group_category.
+// If the user soft-deleted the assigned category before category_cleanup ran,
+// or a TOCTOU race produced a dangling reference (see
+// MoveGroupToCategory_TOCTOU_DanglingReference test in this module), this
+// query returns the stale category_id to the caller — the /category list API
+// then shows the group nested under a category that no longer exists, and the
+// client may use that id in a follow-up call which silently fails.
+//
+// Fix is the same shape as modules/message/db_group_category.go
+// QueryCategorySettingsByGroupNos: INNER/LEFT JOIN group_category gc ON
+// (gs.category_id, gs.uid) AND gc.status != 2, then SELECT gc.category_id so
+// dangling refs surface as NULL.  Out of scope here because:
+//   (a) issue #151 is scoped to the follow tab / sidebar materialization;
+//   (b) the API consumer of this function may rely on stale ids to render the
+//       "uncategorize-after-delete" affordance — needs PM input before
+//       changing user-visible behaviour.
+// Track this as a follow-up; see PR description for rationale.
 func (d *categoryDB) queryUserGroupsInSpace(uid, spaceID string) ([]*userGroupInfo, error) {
 	var results []*userGroupInfo
 	_, err := d.session.SelectBySql(`

--- a/modules/conversation_ext/api.go
+++ b/modules/conversation_ext/api.go
@@ -23,6 +23,10 @@ type followService interface {
 	FollowChannel(uid, spaceID, groupNo string) error
 	FollowThread(uid, spaceID, threadChannelID string) error
 	UnfollowThread(uid, spaceID, threadChannelID string) error
+	// AuthorizeAndMaterializeDefaultFollowedGroups is the UpdateSort pre-flight
+	// step that gates client-supplied target_type=2 group IDs through
+	// DefaultFollowedGroupGuard before any DB write (issue #151 code review #1).
+	AuthorizeAndMaterializeDefaultFollowedGroups(uid, spaceID string, candidateGroupNos []string) error
 }
 
 // sortDB is the subset of *DB that the sort handler needs.
@@ -333,6 +337,28 @@ func (f *Follow) UpdateSort(c *wkhttp.Context) {
 			TargetType: it.TargetType,
 			TargetID:   it.TargetID,
 		})
+	}
+
+	// Issue #151 — pre-flight materialization for default-followed groups.
+	// Collect target_type=2 candidates from the client payload, gate them
+	// through DefaultFollowedGroupGuard (rejects any group the user has not
+	// placed in a category — see service.go AuthorizeAndMaterializeDefault-
+	// FollowedGroups), and INSERT IGNORE the survivors.  The downstream
+	// db.UpdateSort then runs in strict mode: any client-injected fake group
+	// not surviving the guard becomes a regular ErrSortTargetNotFound, which
+	// the client must handle by re-fetching the follow list.
+	var groupCandidates []string
+	for _, it := range items {
+		if it.TargetType == targetTypeGroup {
+			groupCandidates = append(groupCandidates, it.TargetID)
+		}
+	}
+	if len(groupCandidates) > 0 {
+		if err := f.svc.AuthorizeAndMaterializeDefaultFollowedGroups(loginUID, spaceID, groupCandidates); err != nil {
+			f.Error("default-followed group materialization failed", zap.Error(err))
+			c.ResponseError(pkgerrors.New("更新排序失败"))
+			return
+		}
 	}
 
 	if err := f.db.UpdateSort(loginUID, spaceID, items, req.Version); err != nil {

--- a/modules/conversation_ext/api_test.go
+++ b/modules/conversation_ext/api_test.go
@@ -30,6 +30,9 @@ type stubService struct {
 	followChannelFn   func(uid, spaceID, groupNo string) error
 	followThreadFn    func(uid, spaceID, threadChannelID string) error
 	unfollowThreadFn  func(uid, spaceID, threadChannelID string) error
+	// authorizeAndMaterializeFn is the issue #151 gate.  Default (nil) → no-op
+	// so existing tests that don't exercise the sort path are unaffected.
+	authorizeAndMaterializeFn func(uid, spaceID string, candidateGroupNos []string) error
 }
 
 func (s *stubService) FollowDM(uid, spaceID, peerUID string, categoryID *string) error {
@@ -70,6 +73,13 @@ func (s *stubService) FollowThread(uid, spaceID, threadChannelID string) error {
 func (s *stubService) UnfollowThread(uid, spaceID, threadChannelID string) error {
 	if s.unfollowThreadFn != nil {
 		return s.unfollowThreadFn(uid, spaceID, threadChannelID)
+	}
+	return nil
+}
+
+func (s *stubService) AuthorizeAndMaterializeDefaultFollowedGroups(uid, spaceID string, candidateGroupNos []string) error {
+	if s.authorizeAndMaterializeFn != nil {
+		return s.authorizeAndMaterializeFn(uid, spaceID, candidateGroupNos)
 	}
 	return nil
 }
@@ -636,6 +646,98 @@ func TestFollow_UpdateSort_TargetNotFound_DistinctError(t *testing.T) {
 	})
 	assertBadRequest(t, w)
 	assert.Contains(t, w.Body.String(), "sort target not found")
+}
+
+// ---------------------------------------------------------------------------
+// Issue #151 code review #1 — UpdateSort handler must run the default-followed
+// group materialization gate BEFORE db.UpdateSort, with target_type=2 group
+// IDs extracted from the payload.
+// ---------------------------------------------------------------------------
+
+func TestFollow_UpdateSort_CallsAuthorizeBeforeDB(t *testing.T) {
+	var sawAuthorize bool
+	var gotCandidates []string
+	var sawDB bool
+	svc := &stubService{
+		authorizeAndMaterializeFn: func(uid, spaceID string, candidates []string) error {
+			sawAuthorize = true
+			gotCandidates = candidates
+			assert.False(t, sawDB,
+				"AuthorizeAndMaterializeDefaultFollowedGroups must run BEFORE "+
+					"db.UpdateSort so any materialization is committed before the "+
+					"sort tx tries to lock the rows")
+			return nil
+		},
+	}
+	db := &stubDB{
+		updateSortFn: func(uid, spaceID string, items []SortItem, version int64) error {
+			sawDB = true
+			return nil
+		},
+	}
+	r := newTestRouter(svc, db)
+	w := do(r, "PUT", "/v1/follow/sort", map[string]interface{}{
+		"items": []map[string]interface{}{
+			{"target_type": 1, "target_id": "dm-1", "sort": 1},
+			{"target_type": 2, "target_id": "grp-a", "sort": 2},
+			{"target_type": 5, "target_id": "grp-a____thr-1", "sort": 3},
+			{"target_type": 2, "target_id": "grp-b", "sort": 4},
+		},
+		"version": 0,
+	})
+	assertOK(t, w)
+	assert.True(t, sawAuthorize, "handler must invoke the authorize gate")
+	assert.True(t, sawDB, "handler must invoke db.UpdateSort after authorize")
+	assert.ElementsMatch(t, []string{"grp-a", "grp-b"}, gotCandidates,
+		"only target_type=2 items must be forwarded to the gate — DM and thread "+
+			"types follow strict ext-row semantics enforced by db.UpdateSort")
+}
+
+func TestFollow_UpdateSort_NoGroupCandidates_SkipsAuthorize(t *testing.T) {
+	authorizeCalled := false
+	svc := &stubService{
+		authorizeAndMaterializeFn: func(uid, spaceID string, candidates []string) error {
+			authorizeCalled = true
+			return nil
+		},
+	}
+	r := newTestRouter(svc, &stubDB{})
+	w := do(r, "PUT", "/v1/follow/sort", map[string]interface{}{
+		"items": []map[string]interface{}{
+			{"target_type": 1, "target_id": "dm-1", "sort": 1},
+		},
+		"version": 0,
+	})
+	assertOK(t, w)
+	assert.False(t, authorizeCalled,
+		"payloads with no target_type=2 items must skip the gate to avoid an "+
+			"unnecessary DB round-trip")
+}
+
+func TestFollow_UpdateSort_AuthorizeError_FailsBeforeDB(t *testing.T) {
+	dbCalled := false
+	svc := &stubService{
+		authorizeAndMaterializeFn: func(uid, spaceID string, candidates []string) error {
+			return errors.New("guard failure")
+		},
+	}
+	db := &stubDB{
+		updateSortFn: func(uid, spaceID string, items []SortItem, version int64) error {
+			dbCalled = true
+			return nil
+		},
+	}
+	r := newTestRouter(svc, db)
+	w := do(r, "PUT", "/v1/follow/sort", map[string]interface{}{
+		"items": []map[string]interface{}{
+			{"target_type": 2, "target_id": "grp-x", "sort": 1},
+		},
+		"version": 0,
+	})
+	assertBadRequest(t, w)
+	assert.False(t, dbCalled,
+		"db.UpdateSort must NOT run when the authorize step failed; otherwise "+
+			"a partial materialization could land before the sort error surfaces")
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/conversation_ext/bugfix_test.go
+++ b/modules/conversation_ext/bugfix_test.go
@@ -518,3 +518,105 @@ func TestDB_MaterializeDefaultFollowedGroups_EmptyInput_NoOp(t *testing.T) {
 	require.NoError(t, db.MaterializeDefaultFollowedGroups("u1", "s1", nil))
 	require.NoError(t, db.MaterializeDefaultFollowedGroups("u1", "s1", []string{}))
 }
+
+// ---------------------------------------------------------------------------
+// Issue #151 review #3 — ClearAutoFollowThreadsTx
+//
+// MaterializeDefaultFollowedGroups creates ext rows with auto_follow_threads=1.
+// When the implicit follow goes away (user moves group out of category),
+// the same flag must be cleared so OnThreadCreated stops fanning out new
+// threads to a user who no longer sees the group in their follow tab.
+// ---------------------------------------------------------------------------
+
+func TestDB_ClearAutoFollowThreadsTx_ClearsExistingRow(t *testing.T) {
+	db := newDBForTest(t)
+	const uid, space = "u1", "s1"
+
+	// Pre-existing row with auto_follow_threads=1 (the materialized state).
+	require.NoError(t, db.Upsert(uid, space, targetTypeGroup, "g-clear", ConvExtFields{
+		AutoFollowThreads: int8Ptr(1),
+		GroupUnfollowed:   int8Ptr(0),
+		FollowSort:        intPtr(7),
+	}))
+
+	tx, err := db.session.Begin()
+	require.NoError(t, err)
+	defer tx.RollbackUnlessCommitted()
+	require.NoError(t, ClearAutoFollowThreadsTx(tx, uid, space, []string{"g-clear"}))
+	require.NoError(t, tx.Commit())
+
+	m, err := db.Get(uid, space, targetTypeGroup, "g-clear")
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, int8(0), m.AutoFollowThreads,
+		"auto_follow_threads must be cleared")
+	assert.Equal(t, int8(0), m.GroupUnfollowed,
+		"group_unfollowed must NOT be set — uncategorize ≠ explicit unfollow; "+
+			"clearing this flag would break the existing UnfollowGroupsTx contract")
+	assert.Equal(t, 7, m.FollowSort,
+		"follow_sort must be preserved — only the auto_follow_threads flag changes")
+}
+
+func TestDB_ClearAutoFollowThreadsTx_BatchClearsMultipleRows(t *testing.T) {
+	db := newDBForTest(t)
+	const uid, space = "u1", "s1"
+
+	for _, g := range []string{"g-a", "g-b", "g-c"} {
+		require.NoError(t, db.Upsert(uid, space, targetTypeGroup, g, ConvExtFields{
+			AutoFollowThreads: int8Ptr(1),
+		}))
+	}
+	// Unrelated row in the same uid/space must be left alone (negative case).
+	require.NoError(t, db.Upsert(uid, space, targetTypeGroup, "g-keep", ConvExtFields{
+		AutoFollowThreads: int8Ptr(1),
+	}))
+
+	tx, err := db.session.Begin()
+	require.NoError(t, err)
+	defer tx.RollbackUnlessCommitted()
+	require.NoError(t, ClearAutoFollowThreadsTx(tx, uid, space, []string{"g-a", "g-b", "g-c"}))
+	require.NoError(t, tx.Commit())
+
+	for _, g := range []string{"g-a", "g-b", "g-c"} {
+		m, err := db.Get(uid, space, targetTypeGroup, g)
+		require.NoError(t, err)
+		require.NotNil(t, m)
+		assert.Equal(t, int8(0), m.AutoFollowThreads,
+			"batch member %q must be cleared", g)
+	}
+	mk, err := db.Get(uid, space, targetTypeGroup, "g-keep")
+	require.NoError(t, err)
+	require.NotNil(t, mk)
+	assert.Equal(t, int8(1), mk.AutoFollowThreads,
+		"row not in the groupNos list must NOT be touched")
+}
+
+func TestDB_ClearAutoFollowThreadsTx_NoRow_NoOp(t *testing.T) {
+	db := newDBForTest(t)
+	tx, err := db.session.Begin()
+	require.NoError(t, err)
+	defer tx.RollbackUnlessCommitted()
+	// No row materialized — the call must succeed without error and leave
+	// the table state unchanged (this is the happy path for a user who
+	// never opened the follow tab before uncategorizing).
+	require.NoError(t, ClearAutoFollowThreadsTx(tx, "u-ghost", "s1", []string{"g-ghost"}))
+	require.NoError(t, tx.Commit())
+
+	m, err := db.Get("u-ghost", "s1", targetTypeGroup, "g-ghost")
+	require.NoError(t, err)
+	assert.Nil(t, m, "no row may be created — the helper is strictly UPDATE")
+}
+
+func TestDB_ClearAutoFollowThreadsTx_EmptyInput_NoOp(t *testing.T) {
+	db := newDBForTest(t)
+	tx, err := db.session.Begin()
+	require.NoError(t, err)
+	defer tx.RollbackUnlessCommitted()
+	require.NoError(t, ClearAutoFollowThreadsTx(tx, "u1", "s1", nil))
+	require.NoError(t, ClearAutoFollowThreadsTx(tx, "u1", "s1", []string{}))
+	require.NoError(t, ClearAutoFollowThreadsTx(tx, "", "s1", []string{"g"}),
+		"empty uid is a no-op (defensive, matches other helpers)")
+	require.NoError(t, ClearAutoFollowThreadsTx(tx, "u1", "", []string{"g"}),
+		"empty spaceID is a no-op")
+	require.NoError(t, tx.Commit())
+}

--- a/modules/conversation_ext/bugfix_test.go
+++ b/modules/conversation_ext/bugfix_test.go
@@ -364,3 +364,157 @@ func TestRemoveConvExtForUserInSpace_GroupCascade_LeavesNoOrphans(t *testing.T) 
 		assert.Nil(t, got, "thread ext row %q must be gone after cascade", sid)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Issue #151 — db.UpdateSort must remain strict for ALL target types.
+// Materialization for default-followed groups (target_type=2 with category
+// but no ext row) is gated by Service.AuthorizeAndMaterializeDefaultFollowed-
+// Groups in the layer above; db.UpdateSort itself trusts the caller to have
+// pre-flighted any necessary materialization.  Code review #1 removed the
+// earlier inline materialization because it trusted the client payload (any
+// group_no, with no membership / category check) — a metadata leak risk.
+//
+// These tests pin the strict behaviour at the DB layer.  Service- and
+// handler-level coverage lives in service_test.go and api_test.go.
+// ---------------------------------------------------------------------------
+
+// TestDB_UpdateSort_StillRejectsMissingGroup verifies db.UpdateSort, called
+// without upstream pre-flight materialization, surfaces a missing group as
+// ErrSortTargetNotFound (i.e. the DB layer no longer auto-materializes).
+func TestDB_UpdateSort_StillRejectsMissingGroup(t *testing.T) {
+	db := newDBForTest(t)
+	const uid, space = "u1", "s1"
+
+	err := db.UpdateSort(uid, space, []SortItem{
+		{TargetType: targetTypeGroup, TargetID: "g-default"},
+	}, 0)
+	assert.ErrorIs(t, err, ErrSortTargetNotFound,
+		"db.UpdateSort must NOT materialize missing groups on its own — the "+
+			"caller is responsible for AuthorizeAndMaterializeDefaultFollowedGroups "+
+			"upstream (issue #151 code review #1)")
+
+	m, err := db.Get(uid, space, targetTypeGroup, "g-default")
+	require.NoError(t, err)
+	assert.Nil(t, m,
+		"db.UpdateSort must not write any ext row when it fails — preserves "+
+			"the rolled-back tx invariant")
+}
+
+// TestDB_UpdateSort_StillRejectsMissingDM verifies the strict semantics are
+// preserved for target_type=1 — DMs only appear in the follow tab if their
+// ext row exists, so a missing DM target in a sort payload remains a real
+// client/server desync.
+func TestDB_UpdateSort_StillRejectsMissingDM(t *testing.T) {
+	db := newDBForTest(t)
+	const uid, space = "u1", "s1"
+
+	require.NoError(t, db.Upsert(uid, space, targetTypeDM, "dm-real", ConvExtFields{
+		FollowedDM: int8Ptr(1),
+	}))
+
+	err := db.UpdateSort(uid, space, []SortItem{
+		{TargetType: targetTypeDM, TargetID: "dm-real"},
+		{TargetType: targetTypeDM, TargetID: "dm-ghost"},
+	}, 0)
+	assert.ErrorIs(t, err, ErrSortTargetNotFound,
+		"missing DM ext rows must still be reported as ErrSortTargetNotFound; "+
+			"only target_type=2 (groups) get lazy materialization")
+}
+
+// TestDB_UpdateSort_MixedPayload_MissingDM_NoOpportunisticGroupWrite verifies
+// that even without materialization in db.UpdateSort, a mixed payload with a
+// missing DM does not leave behind any partial state (e.g. via a pre-flight
+// step that the caller forgot to gate).  Defense in depth: the DB layer
+// itself never writes group ext rows from UpdateSort.
+func TestDB_UpdateSort_MixedPayload_MissingDM_NoOpportunisticGroupWrite(t *testing.T) {
+	db := newDBForTest(t)
+	const uid, space = "u1", "s1"
+
+	err := db.UpdateSort(uid, space, []SortItem{
+		{TargetType: targetTypeGroup, TargetID: "g-default"},
+		{TargetType: targetTypeDM, TargetID: "dm-ghost"},
+	}, 0)
+	assert.ErrorIs(t, err, ErrSortTargetNotFound,
+		"db.UpdateSort must reject any missing target regardless of type")
+
+	m, err := db.Get(uid, space, targetTypeGroup, "g-default")
+	require.NoError(t, err)
+	assert.Nil(t, m,
+		"db.UpdateSort must never write a group ext row on its own — "+
+			"materialization is the caller's responsibility (issue #151 review #1)")
+}
+
+// TestDB_UpdateSort_StillRejectsMissingThread verifies the strict semantics
+// for target_type=5 are preserved for the same reason as DMs.
+func TestDB_UpdateSort_StillRejectsMissingThread(t *testing.T) {
+	db := newDBForTest(t)
+	const uid, space = "u1", "s1"
+
+	require.NoError(t, db.Upsert(uid, space, targetTypeThread, "grp1____thr-real", ConvExtFields{
+		FollowSort: intPtr(1),
+	}))
+
+	err := db.UpdateSort(uid, space, []SortItem{
+		{TargetType: targetTypeThread, TargetID: "grp1____thr-real"},
+		{TargetType: targetTypeThread, TargetID: "grp1____thr-ghost"},
+	}, 0)
+	assert.ErrorIs(t, err, ErrSortTargetNotFound,
+		"missing thread ext rows must still be reported as ErrSortTargetNotFound")
+}
+
+// ---------------------------------------------------------------------------
+// Issue #151 symptom #2 — MaterializeDefaultFollowedGroups is the read-path
+// hook that turns default-followed groups (in a category, no ext row) into
+// real rows on first sidebar/sync of the follow tab.  Without this, the
+// OnThreadCreated fanout silently skips users whose follow status exists only
+// via category — new threads in those groups never reach their follow tab.
+// ---------------------------------------------------------------------------
+
+func TestDB_MaterializeDefaultFollowedGroups_CreatesRowsWithAutoFollowOn(t *testing.T) {
+	db := newDBForTest(t)
+	const uid, space = "u1", "s1"
+
+	require.NoError(t, db.MaterializeDefaultFollowedGroups(uid, space,
+		[]string{"g-a", "g-b", "g-c"}))
+
+	for _, id := range []string{"g-a", "g-b", "g-c"} {
+		m, err := db.Get(uid, space, targetTypeGroup, id)
+		require.NoError(t, err)
+		require.NotNil(t, m, "ext row %q must exist after materialization", id)
+		assert.Equal(t, int8(1), m.AutoFollowThreads,
+			"materialized row must have auto_follow_threads=1 so OnThreadCreated "+
+				"will fan out new threads in this group to this user")
+		assert.Equal(t, int8(0), m.GroupUnfollowed,
+			"materialized row must have group_unfollowed=0")
+	}
+}
+
+func TestDB_MaterializeDefaultFollowedGroups_Idempotent_PreservesExistingRow(t *testing.T) {
+	db := newDBForTest(t)
+	const uid, space = "u1", "s1"
+
+	// Pre-existing row with non-default state (e.g. user previously dragged
+	// the group to follow_sort=5 and explicitly opted out of thread fanout).
+	require.NoError(t, db.Upsert(uid, space, targetTypeGroup, "g-x", ConvExtFields{
+		AutoFollowThreads: int8Ptr(0),
+		GroupUnfollowed:   int8Ptr(0),
+		FollowSort:        intPtr(5),
+	}))
+
+	require.NoError(t, db.MaterializeDefaultFollowedGroups(uid, space, []string{"g-x"}))
+
+	m, err := db.Get(uid, space, targetTypeGroup, "g-x")
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, int8(0), m.AutoFollowThreads,
+		"materialization must be a no-op on existing rows; "+
+			"user's explicit auto_follow_threads=0 choice must be respected")
+	assert.Equal(t, 5, m.FollowSort,
+		"materialization must not overwrite existing follow_sort")
+}
+
+func TestDB_MaterializeDefaultFollowedGroups_EmptyInput_NoOp(t *testing.T) {
+	db := newDBForTest(t)
+	require.NoError(t, db.MaterializeDefaultFollowedGroups("u1", "s1", nil))
+	require.NoError(t, db.MaterializeDefaultFollowedGroups("u1", "s1", []string{}))
+}

--- a/modules/conversation_ext/bugfix_test.go
+++ b/modules/conversation_ext/bugfix_test.go
@@ -620,3 +620,80 @@ func TestDB_ClearAutoFollowThreadsTx_EmptyInput_NoOp(t *testing.T) {
 		"empty spaceID is a no-op")
 	require.NoError(t, tx.Commit())
 }
+
+// RestoreAutoFollowThreadsTx is the symmetric counterpart — verify the same
+// contract surface but for the =1 side of the lifecycle.
+
+func TestDB_RestoreAutoFollowThreadsTx_RestoresClearedRow(t *testing.T) {
+	db := newDBForTest(t)
+	const uid, space = "u1", "s1"
+
+	// Simulate the post-move-out state: row exists but auto_follow_threads=0.
+	require.NoError(t, db.Upsert(uid, space, targetTypeGroup, "g-restore", ConvExtFields{
+		AutoFollowThreads: int8Ptr(0),
+		GroupUnfollowed:   int8Ptr(0),
+		FollowSort:        intPtr(3),
+	}))
+
+	tx, err := db.session.Begin()
+	require.NoError(t, err)
+	defer tx.RollbackUnlessCommitted()
+	require.NoError(t, RestoreAutoFollowThreadsTx(tx, uid, space, []string{"g-restore"}))
+	require.NoError(t, tx.Commit())
+
+	m, err := db.Get(uid, space, targetTypeGroup, "g-restore")
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, int8(1), m.AutoFollowThreads,
+		"auto_follow_threads must be restored to 1")
+	assert.Equal(t, int8(0), m.GroupUnfollowed,
+		"group_unfollowed must NOT be touched — restore is symmetric to clear, "+
+			"only the auto-subscribe flag changes")
+	assert.Equal(t, 3, m.FollowSort,
+		"follow_sort must be preserved")
+}
+
+func TestDB_RestoreAutoFollowThreadsTx_NoRow_NoOp(t *testing.T) {
+	db := newDBForTest(t)
+	tx, err := db.session.Begin()
+	require.NoError(t, err)
+	defer tx.RollbackUnlessCommitted()
+	// First-time-into-category case: no ext row yet.  Restore must NOT
+	// create a row — sidebar materialization is the canonical creation
+	// site; the move-in handler must stay strictly UPDATE so the two
+	// sites cannot race on the unique key.
+	require.NoError(t, RestoreAutoFollowThreadsTx(tx, "u-fresh", "s1", []string{"g-fresh"}))
+	require.NoError(t, tx.Commit())
+
+	m, err := db.Get("u-fresh", "s1", targetTypeGroup, "g-fresh")
+	require.NoError(t, err)
+	assert.Nil(t, m, "no row may be created — restore is strictly UPDATE")
+}
+
+func TestDB_RestoreAutoFollowThreadsTx_LeavesUnrelatedRowsAlone(t *testing.T) {
+	db := newDBForTest(t)
+	const uid, space = "u1", "s1"
+
+	// Two rows in scope, one out of scope (different target_id).
+	require.NoError(t, db.Upsert(uid, space, targetTypeGroup, "g-a", ConvExtFields{AutoFollowThreads: int8Ptr(0)}))
+	require.NoError(t, db.Upsert(uid, space, targetTypeGroup, "g-b", ConvExtFields{AutoFollowThreads: int8Ptr(0)}))
+	require.NoError(t, db.Upsert(uid, space, targetTypeGroup, "g-keep", ConvExtFields{AutoFollowThreads: int8Ptr(0)}))
+
+	tx, err := db.session.Begin()
+	require.NoError(t, err)
+	defer tx.RollbackUnlessCommitted()
+	require.NoError(t, RestoreAutoFollowThreadsTx(tx, uid, space, []string{"g-a", "g-b"}))
+	require.NoError(t, tx.Commit())
+
+	for _, id := range []string{"g-a", "g-b"} {
+		m, err := db.Get(uid, space, targetTypeGroup, id)
+		require.NoError(t, err)
+		require.NotNil(t, m)
+		assert.Equal(t, int8(1), m.AutoFollowThreads, "row %q restored", id)
+	}
+	mk, err := db.Get(uid, space, targetTypeGroup, "g-keep")
+	require.NoError(t, err)
+	require.NotNil(t, mk)
+	assert.Equal(t, int8(0), mk.AutoFollowThreads,
+		"row not in groupNos list must NOT be touched")
+}

--- a/modules/conversation_ext/db.go
+++ b/modules/conversation_ext/db.go
@@ -316,6 +316,14 @@ func (d *DB) UpdateSort(uid, spaceID string, items []SortItem, expectedVersion i
 	).Load(&locked); err != nil {
 		return fmt.Errorf("update sort: lock rows: %w", err)
 	}
+
+	// All items must already exist as ext rows.  Default-followed groups
+	// (target_type=2 with group_setting.category_id set but no ext row) must
+	// have been materialized upstream by Service.AuthorizeAndMaterializeDefaultFollowedGroups
+	// before this DB call.  Putting that materialization inside the same tx
+	// would require trusting client-supplied group IDs (issue #151 code review #1
+	// — unauthorized materialization risk), which the DB layer is not able to
+	// authorize without importing modules/group / modules/message.
 	if len(locked) != len(items) {
 		return ErrSortTargetNotFound
 	}
@@ -350,6 +358,102 @@ func (d *DB) UpdateSort(uid, spaceID string, items []SortItem, expectedVersion i
 
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("update sort: commit: %w", err)
+	}
+	return nil
+}
+
+// MaterializeDefaultFollowedGroups writes a fresh ext row (auto_follow_threads=1,
+// group_unfollowed=0) for each (uid, space_id, target_type=2, group_no) tuple
+// that does not yet have one.  It is the data-layer entry point used by:
+//
+//   - Sidebar.Sync: after buildFollowItems decides which groups belong in the
+//     follow tab (gated by group_setting.category_id IS NOT NULL), passes the
+//     missing ones here so OnThreadCreated fans out new threads going forward.
+//   - Service.AuthorizeAndMaterializeDefaultFollowedGroups: pre-flight step
+//     before UpdateSort, after DefaultFollowedGroupGuard has filtered the
+//     client-supplied payload down to groups the caller genuinely has in a
+//     category.
+//
+// SECURITY contract: this function does NOT authorize the (uid, group_no)
+// pair.  Callers MUST verify upstream that the user is allowed to follow
+// each group (member + visible, AND the group has category_id set, per
+// issue #151 code review #1).  Without that gate a malicious client can
+// piggy-back arbitrary group IDs and start receiving thread fan-outs for
+// groups they are not in — leaking thread metadata.
+//
+// Fail-open contract for sidebar callers: a failure here must not block the
+// sidebar response; the caller logs and continues.  Pre-flight callers
+// (UpdateSort path) propagate the error to the client.
+func (d *DB) MaterializeDefaultFollowedGroups(uid, spaceID string, groupNos []string) error {
+	if len(groupNos) == 0 {
+		return nil
+	}
+	items := make([]SortItem, len(groupNos))
+	for i, no := range groupNos {
+		items[i] = SortItem{TargetType: targetTypeGroup, TargetID: no}
+	}
+	tx, err := d.session.Begin()
+	if err != nil {
+		return fmt.Errorf("materialize default-followed groups: begin tx: %w", err)
+	}
+	defer tx.RollbackUnlessCommitted()
+	if err := materializeDefaultFollowedGroupsTx(tx, uid, spaceID, items); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("materialize default-followed groups: commit: %w", err)
+	}
+	return nil
+}
+
+// materializeDefaultFollowedGroupsTx INSERTs an ext row for each group the
+// caller listed that did not yet have one.  Default-followed groups (in a
+// category, never touched by the user) end up here on the first drag (via
+// UpdateSort) or on the first sidebar/sync (via MaterializeDefaultFollowedGroups
+// — issue #151 symptom #2 path).
+//
+// The newly-inserted row is intentionally configured so that downstream paths
+// already coded against ext-row presence start working immediately:
+//
+//   - group_unfollowed=0 — the group is followed.
+//   - auto_follow_threads=1 — selectEligibleForFanoutTx will include this user
+//     when OnThreadCreated fires for the group (closes symptom #2).
+//   - follow_sort=0 — UpdateSort's step 3 re-assigns the real sort position;
+//     the standalone read-path entry (MaterializeDefaultFollowedGroups) is fine
+//     leaving 0 because sidebar item ordering for default-followed groups
+//     already defaults to 0 in buildFollowItems.
+//
+// INSERT IGNORE rather than ON DUPLICATE KEY UPDATE: we want a strict no-op
+// when the row already exists — never overwrite a user's existing choices for
+// group_unfollowed or auto_follow_threads.  INSERT IGNORE also avoids burning
+// AUTO_INCREMENT id values on duplicate-key hits (innodb_autoinc_lock_mode=2
+// default on MySQL 8 would otherwise bump the counter even on the no-op
+// branch), matching the existing pattern in bulkInsertThreadExtForFanoutUsersTx.
+//
+// Concurrency: callers do NOT need to hold a SELECT ... FOR UPDATE on the
+// target (uid, space_id, target_type, target_id) tuple beforehand.  The unique
+// key uk(uid, space_id, target_type, target_id) plus INSERT IGNORE's
+// "skip duplicates" semantics make the operation safe under any interleaving
+// with FollowChannel / UnfollowChannel / OnThreadCreated fanout — whichever
+// committed first wins, the no-op preserves that row.
+func materializeDefaultFollowedGroupsTx(tx *dbr.Tx, uid, spaceID string, missing []SortItem) error {
+	if len(missing) == 0 {
+		return nil
+	}
+	tupleHolders := make([]string, len(missing))
+	args := make([]interface{}, 0, len(missing)*4)
+	for i, it := range missing {
+		tupleHolders[i] = "(?, ?, ?, ?, 0, 1)"
+		args = append(args, uid, spaceID, it.TargetType, it.TargetID)
+	}
+	_, err := tx.InsertBySql(
+		"INSERT IGNORE INTO "+table+
+			" (uid, space_id, target_type, target_id, group_unfollowed, auto_follow_threads) VALUES "+
+			strings.Join(tupleHolders, ", "),
+		args...,
+	).Exec()
+	if err != nil {
+		return fmt.Errorf("insert default-followed group rows: %w", err)
 	}
 	return nil
 }

--- a/modules/conversation_ext/db.go
+++ b/modules/conversation_ext/db.go
@@ -362,6 +362,55 @@ func (d *DB) UpdateSort(uid, spaceID string, items []SortItem, expectedVersion i
 	return nil
 }
 
+// ClearAutoFollowThreadsTx is the cleanup counterpart of
+// MaterializeDefaultFollowedGroups.  It sets auto_follow_threads=0 on the
+// (uid, space_id, target_type=2, group_no) ext rows in groupNos that exist,
+// silently skipping any that don't.  Idempotent; safe to call when no row
+// has been materialized.
+//
+// Why it exists (issue #151 review #3 by yujiawei): MaterializeDefault-
+// FollowedGroups creates ext rows with auto_follow_threads=1 for groups that
+// are followed *implicitly* via group_setting.category_id.  When that
+// implicit follow is revoked (user moves the group out of any category, or
+// the category is deleted), the row remains and selectEligibleForFanoutTx
+// keeps treating the user as eligible for new-thread fan-out — even though
+// buildFollowItems now drops the group from the follow tab because
+// CategoryID is nil.  Before this PR no row existed so the cleanup was
+// implicit ("no row = no fanout"); once we materialize, the cleanup must
+// be made explicit at every site that clears group_setting.category_id.
+//
+// What it does NOT do:
+//   - Does not delete the ext row (preserves group_unfollowed flag and any
+//     follow_sort the user explicitly chose).
+//   - Does not touch thread (target_type=5) ext rows — existing thread
+//     subscriptions remain valid; we only stop auto-following NEW threads.
+//   - Does not bump user_follow_version — the caller (category handler)
+//     already bumps once for the surrounding group_setting change; bumping
+//     again here would force two client reloads for one logical action.
+//
+// Callers in scope: modules/category moveGroupToCategory move-out branch
+// (req.CategoryID == "").  modules/category deleteCategory does NOT need
+// this helper — it already calls UnfollowGroupsTx which sets
+// group_unfollowed=1 AND auto_follow_threads=0 (stronger semantic: explicit
+// unfollow on category delete per PM contract).  Future code that mutates
+// group_setting.category_id from non-NULL to NULL without setting
+// group_unfollowed=1 MUST call this helper in the same transaction to keep
+// the read/write contracts in sync.
+func ClearAutoFollowThreadsTx(tx *dbr.Tx, uid, spaceID string, groupNos []string) error {
+	if uid == "" || spaceID == "" || len(groupNos) == 0 {
+		return nil
+	}
+	_, err := tx.UpdateBySql(
+		"UPDATE "+table+" SET auto_follow_threads=0"+
+			" WHERE uid=? AND space_id=? AND target_type=? AND target_id IN ?",
+		uid, spaceID, targetTypeGroup, groupNos,
+	).Exec()
+	if err != nil {
+		return fmt.Errorf("clear auto_follow_threads: %w", err)
+	}
+	return nil
+}
+
 // MaterializeDefaultFollowedGroups writes a fresh ext row (auto_follow_threads=1,
 // group_unfollowed=0) for each (uid, space_id, target_type=2, group_no) tuple
 // that does not yet have one.  It is the data-layer entry point used by:

--- a/modules/conversation_ext/db.go
+++ b/modules/conversation_ext/db.go
@@ -362,6 +362,47 @@ func (d *DB) UpdateSort(uid, spaceID string, items []SortItem, expectedVersion i
 	return nil
 }
 
+// RestoreAutoFollowThreadsTx is the move-back counterpart of
+// ClearAutoFollowThreadsTx.  It sets auto_follow_threads=1 on the
+// (uid, space_id, target_type=2, group_no) ext rows in groupNos that exist,
+// silently skipping any that don't.  Idempotent; safe to call when no row
+// has been materialized (sidebar.Sync's later MaterializeDefaultFollowedGroups
+// call will create the row with auto_follow_threads=1 anyway).
+//
+// Why it exists (issue #151 review #4 by an9xyz): the lifecycle is symmetric:
+// materialize on first follow-tab read sets =1; move-out clears to 0;
+// move-back-into-a-category must restore =1, otherwise the sidebar
+// materialization branch sees the existing groupExts entry (with =0) and
+// skips its INSERT IGNORE.  The user re-categorizes the group, the group
+// re-appears in the follow tab via buildFollowItems, but OnThreadCreated's
+// fan-out filter (auto_follow_threads=1 AND group_unfollowed=0) still
+// excludes them — phantom missing fan-out.
+//
+// Like Clear, this helper does NOT touch group_unfollowed (the user's
+// explicit unfollow choice is preserved across category churn) and does NOT
+// bump user_follow_version (caller's surrounding category change already
+// bumps once).
+//
+// Callers in scope: modules/category moveGroupToCategory move-in branch
+// (req.CategoryID != ""), including first-time categorize (no row yet,
+// no-op here, sidebar materializes later) and A→B category move (row exists
+// with =1 already, no-op effectively).  The single common path simplifies
+// reasoning and removes the temptation to branch on subcases.
+func RestoreAutoFollowThreadsTx(tx *dbr.Tx, uid, spaceID string, groupNos []string) error {
+	if uid == "" || spaceID == "" || len(groupNos) == 0 {
+		return nil
+	}
+	_, err := tx.UpdateBySql(
+		"UPDATE "+table+" SET auto_follow_threads=1"+
+			" WHERE uid=? AND space_id=? AND target_type=? AND target_id IN ?",
+		uid, spaceID, targetTypeGroup, groupNos,
+	).Exec()
+	if err != nil {
+		return fmt.Errorf("restore auto_follow_threads: %w", err)
+	}
+	return nil
+}
+
 // ClearAutoFollowThreadsTx is the cleanup counterpart of
 // MaterializeDefaultFollowedGroups.  It sets auto_follow_threads=0 on the
 // (uid, space_id, target_type=2, group_no) ext rows in groupNos that exist,

--- a/modules/conversation_ext/service.go
+++ b/modules/conversation_ext/service.go
@@ -36,6 +36,12 @@ var ErrThreadForbidden = errors.New("thread follow forbidden: not a member of pa
 // 物化既有子区，因此必须在写前校验 caller 是该 group 的成员且该群在请求 Space 可见。
 var ErrChannelForbidden = errors.New("channel follow forbidden: not a member of the group or group not visible")
 
+// ErrDefaultFollowedGuardNotConfigured 表示 AuthorizeAndMaterializeDefaultFollowed-
+// Groups 被调用时 service 上还没有注入 DefaultFollowedGroupGuard。生产路径里
+// message/1module.go 启动时必定注入；返回这个 sentinel 让 unit test / 错误启动
+// 顺序可观测，而不是悄无声息地把所有群当作未授权（issue #151 re-review M1）。
+var ErrDefaultFollowedGuardNotConfigured = errors.New("default-followed group guard not configured")
+
 // ErrDMCategoryForbidden 在 FollowDM 指定的 category 不属于当前 uid 或已删除时返回。
 // 调用方应将此错误翻译为 400 / 403（按业务约定）。
 // PR #21 Round-6 (Jerry-Xin)：DM category 必须由服务端校验归属，否则客户端可写入
@@ -63,6 +69,36 @@ type ThreadAuthChecker interface {
 // 鉴权失败返回 ErrChannelForbidden；基础设施错误以 wrap 后形式上传。
 type ChannelAuthChecker interface {
 	AuthorizeChannelFollow(uid, spaceID, groupNo string) error
+}
+
+// DefaultFollowedGroupGuard 过滤客户端 UpdateSort payload 中的 target_type=2
+// 候选项，只保留对该 uid + 当前 spaceID 真正"默认关注"的群。
+//
+// 引入背景（issue #151 code review #1）：UpdateSort 一度在事务里对任意 target_type=2
+// 缺失项做 INSERT IGNORE 物化（auto_follow_threads=1）。但 payload 完全由客户端
+// 提交，恶意/异常客户端可借此为任意 group_no 创建 ext 行；之后 OnThreadCreated
+// 给该用户 fanout 子区 ext 行 → sidebar 透出本不可见群的子区元数据。
+//
+// 校验链（issue #151 code review #2，spaceID 校验补强）：
+//  1. 成员资格：用户当前是该群成员（group.IService.ExistMember）；
+//  2. Space 可见性：群在请求 spaceID 内可见（同 ChannelAuthChecker / FollowChannel
+//     的 internal-same-space / external sourceSpaceID-match / legacy wildcard 规则）；
+//  3. Disband 拒绝：群已解散直接拒绝；
+//  4. 默认关注语义：group_setting.category_id IS NOT NULL（当前 uid，与 spaceID
+//     无关——group_setting 是 user-scoped、跨 Space 共享，所以 step 1/2/3 是
+//     必要的 Space 过滤，缺一不可）。
+//
+// 与 ChannelAuthChecker 的语义差别：ChannelAuthChecker 检查"caller 能否主动关注
+// 该群"；DefaultFollowedGroupGuard 在前者基础上额外要求"该群已被加入用户某 category"。
+// 这样恶意客户端拿一个用户当前不在的群（或在别的 Space 设过 category 的旧 group_setting
+// 残留）来提交 sort，guard 会一并拒绝，sidebar fanout 路径不会被毒化。
+//
+// 实现位于 modules/message（已直接 import group + group_setting），启动时通过
+// SetDefaultFollowedGroupGuard 注入；nil 时 fail-closed（拒绝任何物化）。
+type DefaultFollowedGroupGuard interface {
+	// FilterDefaultFollowed 返回 candidateGroupNos 中通过完整校验链的子集。
+	// spaceID 必填——校验链 step 2 / step 3 需要它来判定群的可见性。
+	FilterDefaultFollowed(uid, spaceID string, candidateGroupNos []string) ([]string, error)
 }
 
 // ThreadEnumerator 是 FollowChannel 级联物化子区时使用的窄接口。
@@ -117,6 +153,11 @@ type Service struct {
 	// 由 message/1module.go 启动时注入；nil 时跳过鉴权（仅供单测 / 迁移期使用）。
 	channelAuth  ChannelAuthChecker
 	channelAuthM sync.RWMutex
+	// defaultFollowedGuard 是 UpdateSort 默认关注群物化路径的鉴权钩子（issue #151
+	// code review #1）。由 message/1module.go 启动时注入；nil 时 AuthorizeAndMaterialize-
+	// DefaultFollowedGroups 直接返回空——fail-closed 比放过更安全。
+	defaultFollowedGuard  DefaultFollowedGroupGuard
+	defaultFollowedGuardM sync.RWMutex
 	log.Log
 }
 
@@ -177,6 +218,66 @@ func (s *Service) getChannelAuthChecker() ChannelAuthChecker {
 	c := s.channelAuth
 	s.channelAuthM.RUnlock()
 	return c
+}
+
+// SetDefaultFollowedGroupGuard injects the gate used by
+// AuthorizeAndMaterializeDefaultFollowedGroups to filter UpdateSort payloads
+// down to genuinely default-followed groups (issue #151 code review #1).
+// Safe for concurrent use; intended to be called once at startup.
+func (s *Service) SetDefaultFollowedGroupGuard(g DefaultFollowedGroupGuard) {
+	s.defaultFollowedGuardM.Lock()
+	s.defaultFollowedGuard = g
+	s.defaultFollowedGuardM.Unlock()
+}
+
+func (s *Service) getDefaultFollowedGroupGuard() DefaultFollowedGroupGuard {
+	s.defaultFollowedGuardM.RLock()
+	g := s.defaultFollowedGuard
+	s.defaultFollowedGuardM.RUnlock()
+	return g
+}
+
+// AuthorizeAndMaterializeDefaultFollowedGroups is the pre-flight step the
+// /v1/follow/sort handler calls before db.UpdateSort.  It accepts client-
+// supplied group_no's (target_type=2 items from the sort payload), filters
+// them through DefaultFollowedGroupGuard to retain only the genuine default-
+// followed ones, and materializes ext rows for the survivors via
+// db.MaterializeDefaultFollowedGroups.
+//
+// Rationale (issue #151 code review #1): putting the materialization inside
+// db.UpdateSort means trusting the client payload, which lets an attacker
+// piggy-back arbitrary group IDs and start receiving thread fan-outs.  Moving
+// the gate up to the service layer keeps DB free of group/group_setting
+// imports while still authorizing every materialization.
+//
+// fail-closed: if no guard is registered (test/migration mode), no
+// materialization happens — db.UpdateSort will then return
+// ErrSortTargetNotFound for the missing groups, which is the safer default
+// than silently allowing arbitrary materialization.
+func (s *Service) AuthorizeAndMaterializeDefaultFollowedGroups(uid, spaceID string, candidateGroupNos []string) error {
+	if err := validateBase(uid, spaceID); err != nil {
+		return err
+	}
+	if len(candidateGroupNos) == 0 {
+		return nil
+	}
+	guard := s.getDefaultFollowedGroupGuard()
+	if guard == nil {
+		// Fail-closed with a diagnostic sentinel.  Returning nil here would
+		// look like success to the handler, then surface as the obscure
+		// ErrSortTargetNotFound from db.UpdateSort — masking the real fault
+		// (the guard was never injected at startup).  Tests / misconfigured
+		// deployments get a clear signal instead (issue #151 re-review M1).
+		return ErrDefaultFollowedGuardNotConfigured
+	}
+	allowed, err := guard.FilterDefaultFollowed(uid, spaceID, candidateGroupNos)
+	if err != nil {
+		return fmt.Errorf("authorize default-followed group materialization: %w", err)
+	}
+	if len(allowed) == 0 {
+		return nil
+	}
+	return s.db.MaterializeDefaultFollowedGroups(uid, spaceID, allowed)
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/conversation_ext/service_test.go
+++ b/modules/conversation_ext/service_test.go
@@ -3,6 +3,7 @@
 package conversation_ext
 
 import (
+	"errors"
 	"os"
 	"strconv"
 	"testing"
@@ -976,4 +977,166 @@ func TestService_UnfollowChannel_SeparatorEscaped_LengthCollisionSafe(t *testing
 	require.NoError(t, err)
 	assert.NotNil(t, mA,
 		"attacker 的 thread 必须留存——4 个下划线不应被当作通配跨群匹配")
+}
+
+// ---------------------------------------------------------------------------
+// Issue #151 code review #1 — AuthorizeAndMaterializeDefaultFollowedGroups
+// ---------------------------------------------------------------------------
+
+// stubDefaultFollowedGroupGuard is a service_test double for
+// DefaultFollowedGroupGuard.  allowed[uid|spaceID|group_no]=true → kept in the
+// filtered result; entries not in allowed are dropped (simulating either
+// "no category", "wrong space", or "not a member" — the production guard
+// merges all three signals).  Keying on the full triple lets tests assert
+// spaceID is plumbed correctly (issue #151 code review #2).
+type stubDefaultFollowedGroupGuard struct {
+	allowed map[string]bool
+	err     error
+	// gotCalls captures every (uid, spaceID, candidate-list) invocation so
+	// tests can assert spaceID is forwarded verbatim.
+	gotCalls []stubGuardCall
+}
+
+type stubGuardCall struct {
+	uid        string
+	spaceID    string
+	candidates []string
+}
+
+func (s *stubDefaultFollowedGroupGuard) FilterDefaultFollowed(uid, spaceID string, candidates []string) ([]string, error) {
+	s.gotCalls = append(s.gotCalls, stubGuardCall{uid: uid, spaceID: spaceID, candidates: append([]string(nil), candidates...)})
+	if s.err != nil {
+		return nil, s.err
+	}
+	out := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		if s.allowed[uid+"|"+spaceID+"|"+c] {
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}
+
+func TestService_AuthorizeAndMaterialize_FiltersOutDisallowedGroups(t *testing.T) {
+	svc := newServiceForTest(t)
+	const uid, space = "u1", "s1"
+
+	// Guard says only g-ok passes the (member + space-visible + categorized)
+	// chain in this space; g-evil is an attacker-injected ID.
+	svc.SetDefaultFollowedGroupGuard(&stubDefaultFollowedGroupGuard{
+		allowed: map[string]bool{uid + "|" + space + "|g-ok": true},
+	})
+
+	require.NoError(t, svc.AuthorizeAndMaterializeDefaultFollowedGroups(
+		uid, space, []string{"g-ok", "g-evil"}))
+
+	// g-ok was materialized.
+	rowOK, err := svc.db.Get(uid, space, targetTypeGroup, "g-ok")
+	require.NoError(t, err)
+	require.NotNil(t, rowOK, "guard-allowed group must be materialized")
+	assert.Equal(t, int8(1), rowOK.AutoFollowThreads,
+		"materialized row must have auto_follow_threads=1")
+
+	// g-evil was NOT materialized — critical for the security contract.
+	rowEvil, err := svc.db.Get(uid, space, targetTypeGroup, "g-evil")
+	require.NoError(t, err)
+	assert.Nil(t, rowEvil,
+		"guard-disallowed group MUST NOT be materialized — otherwise a client "+
+			"could piggyback arbitrary group IDs in /v1/follow/sort and start "+
+			"receiving OnThreadCreated fan-outs for groups they cannot access "+
+			"(issue #151 code review #1)")
+}
+
+func TestService_AuthorizeAndMaterialize_NoGuard_ReturnsSentinel(t *testing.T) {
+	svc := newServiceForTest(t)
+	const uid, space = "u1", "s1"
+
+	// No guard injected — must return the diagnostic sentinel so test /
+	// misconfigured deployments fail loudly instead of degenerating into the
+	// obscure ErrSortTargetNotFound on the downstream db.UpdateSort
+	// (issue #151 re-review M1).
+	err := svc.AuthorizeAndMaterializeDefaultFollowedGroups(
+		uid, space, []string{"g-no-guard"})
+	assert.ErrorIs(t, err, ErrDefaultFollowedGuardNotConfigured,
+		"missing-guard branch must return the diagnostic sentinel")
+
+	// And must NOT have materialized anything (fail-closed remains intact).
+	row, err := svc.db.Get(uid, space, targetTypeGroup, "g-no-guard")
+	require.NoError(t, err)
+	assert.Nil(t, row,
+		"without a registered DefaultFollowedGroupGuard, no group may be "+
+			"materialized — fail-closed is the safer default for an "+
+			"authorization-bearing path")
+}
+
+func TestService_AuthorizeAndMaterialize_GuardError_Propagates(t *testing.T) {
+	svc := newServiceForTest(t)
+	const uid, space = "u1", "s1"
+
+	wantErr := errors.New("group_setting query failed")
+	svc.SetDefaultFollowedGroupGuard(&stubDefaultFollowedGroupGuard{err: wantErr})
+
+	err := svc.AuthorizeAndMaterializeDefaultFollowedGroups(
+		uid, space, []string{"g-any"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr,
+		"guard errors must propagate so the caller can surface a 5xx rather "+
+			"than silently falling back to no-op materialization")
+
+	row, err := svc.db.Get(uid, space, targetTypeGroup, "g-any")
+	require.NoError(t, err)
+	assert.Nil(t, row, "guard error must NOT leak partial materialization")
+}
+
+func TestService_AuthorizeAndMaterialize_EmptyInput_NoOp(t *testing.T) {
+	svc := newServiceForTest(t)
+	svc.SetDefaultFollowedGroupGuard(&stubDefaultFollowedGroupGuard{allowed: nil})
+
+	require.NoError(t, svc.AuthorizeAndMaterializeDefaultFollowedGroups(
+		"u1", "s1", nil))
+	require.NoError(t, svc.AuthorizeAndMaterializeDefaultFollowedGroups(
+		"u1", "s1", []string{}))
+}
+
+// TestService_AuthorizeAndMaterialize_ForwardsSpaceID_AndDoesNotLeakAcrossSpaces
+// pins the issue #151 code review #2 fix: a group_setting row whose
+// category_id was set in Space A must NOT cause materialization for the same
+// user in Space B.  The Service passes spaceID through to the guard; the
+// guard's allow-map key includes spaceID, so the cross-space group is
+// rejected even though it has category_id set for this uid.
+func TestService_AuthorizeAndMaterialize_ForwardsSpaceID_AndDoesNotLeakAcrossSpaces(t *testing.T) {
+	svc := newServiceForTest(t)
+	const uid, spaceA, spaceB = "u1", "sA", "sB"
+
+	guard := &stubDefaultFollowedGroupGuard{
+		// Group g-cross has category in Space A only.  Space B treats it as
+		// "no membership / no visibility" — the production guard implementation
+		// reuses ChannelAuthChecker which would return forbidden here.
+		allowed: map[string]bool{uid + "|" + spaceA + "|g-cross": true},
+	}
+	svc.SetDefaultFollowedGroupGuard(guard)
+
+	// Submit g-cross under Space B — must NOT materialize.
+	require.NoError(t, svc.AuthorizeAndMaterializeDefaultFollowedGroups(
+		uid, spaceB, []string{"g-cross"}))
+
+	row, err := svc.db.Get(uid, spaceB, targetTypeGroup, "g-cross")
+	require.NoError(t, err)
+	assert.Nil(t, row,
+		"group categorized in Space A must NOT be materialized when the sort "+
+			"request comes from Space B — otherwise OnThreadCreated in Space B "+
+			"fans out threads for a group the user cannot see in this Space "+
+			"(issue #151 code review #2)")
+
+	// Assert guard saw the actual spaceID.
+	require.Len(t, guard.gotCalls, 1)
+	assert.Equal(t, spaceB, guard.gotCalls[0].spaceID,
+		"Service must forward the request's spaceID to the guard")
+
+	// Sanity: same group + same uid under Space A succeeds.
+	require.NoError(t, svc.AuthorizeAndMaterializeDefaultFollowedGroups(
+		uid, spaceA, []string{"g-cross"}))
+	row, err = svc.db.Get(uid, spaceA, targetTypeGroup, "g-cross")
+	require.NoError(t, err)
+	require.NotNil(t, row, "Space-A materialization must still work")
 }

--- a/modules/conversation_ext/swagger/api.yaml
+++ b/modules/conversation_ext/swagger/api.yaml
@@ -280,7 +280,7 @@ paths:
             业务错误（msg 字段携带具体说明）：
             - 参数错误：items 为空、target_type 不在白名单 (1/2/5)
             - "version conflict: please retry"：CAS 版本号不匹配，客户端应重新拉取最新版本后重试
-            - "sort target not found"：items 中至少一项指向的目标在服务端不存在（可能并发被取消关注），客户端应重新拉取关注列表后整体重试
+            - "sort target not found"：items 中至少一项 DM (target_type=1) 或子区 (target_type=5) 在服务端不存在（这两类目标进入关注列表的前提就是 ext 行存在，缺失意味着并发被取消关注），客户端应重新拉取关注列表后整体重试。注意：target_type=2（群）通过 group_setting.category_id 默认关注时，ext 行不存在不会触发此错误——服务端会先校验该群确实属于用户的 category 再自动物化（issue #151）。若客户端提交的群 target_id 既无 ext 行也未被加入用户的 category，仍会作为不存在目标被拒绝
           schema:
             $ref: "#/definitions/response"
       security:

--- a/modules/message/1module.go
+++ b/modules/message/1module.go
@@ -80,6 +80,19 @@ func init() {
 			// 子区前必须校验 caller 是群成员 + 群在 Space 可见。复用同一个 struct
 			// 实现，共享 checkChannelAccess 逻辑。
 			svc.SetChannelAuthChecker(checker)
+			// 注入 DefaultFollowedGroupGuard：/v1/follow/sort 的 target_type=2
+			// 候选必须先经过 (成员 + Space 可见性 + 非 Disband + category_id) 完整
+			// 校验链才能被物化为 ext 行。没有这一步，恶意客户端可借 sort 接口给
+			// 任意群创建 auto_follow=1 行，进而通过 OnThreadCreated fanout 拿到本
+			// 不可见的子区元数据（issue #151 code review #1 + #2 —— #2 补强了
+			// spaceID 与成员资格校验，防止跨 Space group_setting 残留越权）。
+			//
+			// channelAuth 复用同一个 threadAuthChecker（也即 ChannelAuthChecker），
+			// 共享 checkChannelAccess 与 group.IService 实例，避免重复初始化。
+			svc.SetDefaultFollowedGroupGuard(&defaultFollowedGroupGuard{
+				db:          newGroupCategoryDB(appCtx),
+				channelAuth: checker,
+			})
 		}
 		return register.Module{Name: "conversation_ext_thread_auth"}
 	})
@@ -255,4 +268,93 @@ func (e *threadEnumerator) EnumerateActiveShortIDs(groupNo string, limit int) ([
 		ids = append(ids, m.ShortID)
 	}
 	return ids, nil
+}
+
+// defaultFollowedGroupGuard implements convext.DefaultFollowedGroupGuard with
+// the full membership + Space-visibility + Disband + category check chain.
+// Lives in message because all the dependencies (group_setting via
+// groupCategoryDB, group membership / visibility via threadAuthChecker.checkChannelAccess)
+// already live here — keeps modules/conversation_ext free of group imports.
+//
+// Why a chained check rather than category-only (issue #151 code review #2):
+// group_setting rows are scoped to (uid, group_no) without spaceID.  A user
+// who previously categorized group X while in Space A keeps that
+// group_setting row even after leaving Space A.  If we filtered by category
+// alone, that user could submit group X in /v1/follow/sort while operating
+// in Space B and force a materialization with (uid, Space B, group X,
+// auto_follow_threads=1) — OnThreadCreated in Space B would then fan out
+// threads of group X to them, leaking metadata for a group they cannot
+// otherwise see in Space B.
+//
+// The fix layers the existing channel-access check (the same one FollowChannel
+// uses) before category — only groups the user is genuinely a member of AND
+// visible in the current Space AND categorized survive.
+//
+// Dependencies are typed as narrow interfaces (not concrete *groupCategoryDB /
+// *threadAuthChecker) so the two-stage filter can be unit-tested with fakes —
+// see default_followed_group_guard_test.go (issue #151 re-review M3 / M4).
+type defaultFollowedGroupGuard struct {
+	db          defaultFollowedGroupCategoryFilter
+	channelAuth convext.ChannelAuthChecker
+}
+
+// defaultFollowedGroupCategoryFilter is the narrow Stage-1 interface — pulls
+// the group_setting × group_category JOIN out of *groupCategoryDB so tests can
+// substitute a fake.  The real implementation is *groupCategoryDB.
+type defaultFollowedGroupCategoryFilter interface {
+	FilterDefaultFollowedGroups(uid string, candidateGroupNos []string) ([]string, error)
+}
+
+// Compile-time guarantee that defaultFollowedGroupGuard implements the
+// conversation_ext interface — a typo'd method signature would otherwise
+// surface only at runtime when SetDefaultFollowedGroupGuard accepted it as
+// a different interface (issue #151 re-review L2).
+var _ convext.DefaultFollowedGroupGuard = (*defaultFollowedGroupGuard)(nil)
+
+func (g *defaultFollowedGroupGuard) FilterDefaultFollowed(uid, spaceID string, candidates []string) ([]string, error) {
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	// Stage 1: narrow by category_id IS NOT NULL — a single batched query.
+	// This rejects the bulk of malicious / stale candidates cheaply before
+	// any per-group group/membership/Space round-trips.
+	withCategory, err := g.db.FilterDefaultFollowedGroups(uid, candidates)
+	if err != nil {
+		return nil, err
+	}
+	if len(withCategory) == 0 {
+		return nil, nil
+	}
+	// Stage 2: per-group channel-access check (member + Space visibility +
+	// not Disband).  Each call hits group.IService.ExistMember and
+	// group.IService.GetGroups; for external groups also QueryExternalGroupNosForUser.
+	//
+	// Worst-case load: upstream maxUpdateSortItems=500 → up to 500 sequential
+	// access checks per sort request.  Stage 1 typically narrows this to a
+	// handful for a real user; an attacker spamming bogus group_no's is
+	// already dropped at Stage 1.  No batching here today — the per-group
+	// call surface (ExistMember + GetGroups batch + external map) does not
+	// expose a single batched membership endpoint, and adding one would
+	// require touching modules/group.  Trade-off accepted; revisit if
+	// p99 latency on /v1/follow/sort with high default-followed-group counts
+	// (track via dmwork_http_business_error_total + duration histograms)
+	// outgrows the budget.
+	out := make([]string, 0, len(withCategory))
+	for _, groupNo := range withCategory {
+		err := g.channelAuth.AuthorizeChannelFollow(uid, spaceID, groupNo)
+		if err == nil {
+			out = append(out, groupNo)
+			continue
+		}
+		if errors.Is(err, convext.ErrChannelForbidden) {
+			// Group failed membership / visibility / Disband — silently drop
+			// from the materialization set.  Downstream db.UpdateSort will
+			// surface the missing row as ErrSortTargetNotFound to the client.
+			continue
+		}
+		// Infrastructure error — propagate so the caller can turn it into a
+		// 5xx rather than silently treating the group as "not allowed".
+		return nil, err
+	}
+	return out, nil
 }

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -460,6 +460,55 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 			return
 		}
 		items = mergeThreadEntries(items, threadExtRows, lastMsgAtMap, categorySetting, unfollowedGroups, groupSpaceMap, externalGroupMap, defaultSpaceID)
+
+		// Issue #151 symptom #2 — materialize ext rows for default-followed
+		// groups (categorized but never touched).  Without this, OnThreadCreated
+		// silently skips this user for those groups and new threads never reach
+		// the follow tab.  Fail-open: a failure here must not block the sidebar
+		// response.  Subsequent sidebar/sync calls will retry the same
+		// materialization until it lands.
+		//
+		// Latency budget: the loop is O(N) over the follow-tab items but only
+		// emits a DB write when defaultFollowedGroups is non-empty.  First-load
+		// for a user with many categorized groups pays one batched INSERT IGNORE
+		// (a single tx); every subsequent sidebar/sync from the same user hits
+		// the (groupExts has-key) branch and exits without a write.  Cost
+		// amortizes to one DB write per never-touched group across the user's
+		// lifetime.
+		var defaultFollowedGroups []string
+		for _, it := range items {
+			if it.TargetType != int(common.ChannelTypeGroup) {
+				continue
+			}
+			if _, hasExt := groupExts[it.TargetID]; hasExt {
+				continue
+			}
+			defaultFollowedGroups = append(defaultFollowedGroups, it.TargetID)
+		}
+		if len(defaultFollowedGroups) > 0 {
+			// Why no DefaultFollowedGroupGuard here (vs the /v1/follow/sort path):
+			// the candidates are not client-supplied.  They come from
+			// buildFollowItems above, which only emits a group SidebarItem when
+			// the group is in `categorySetting` with a non-nil CategoryID.
+			// `categorySetting` itself comes from
+			// groupCategoryDB.QueryCategorySettingsByGroupNos with two constraints
+			// the UpdateSort path cannot rely on:
+			//   1. The candidate group_no's came from the IM-returned conversation
+			//      list, which only includes channels the user is a member of in
+			//      the current Space.
+			//   2. The query's LEFT JOIN includes `gc.status != 2`, so a
+			//      soft-deleted category yields cs.CategoryID == nil and the
+			//      group is excluded.
+			// Together these are STRONGER than the UpdateSort guard's Stage 1
+			// (which by itself only checks category_id IS NOT NULL — see
+			// db_group_category.go FilterDefaultFollowedGroups).  Adding a guard
+			// call here would be redundant for security but would cost a per-group
+			// channel-access round-trip on the hot read path.
+			if mErr := sb.convExtDB.MaterializeDefaultFollowedGroups(loginUID, spaceID, defaultFollowedGroups); mErr != nil {
+				sb.Warn("sidebar sync: default-followed group materialization failed (non-fatal)",
+					zap.Error(mErr), zap.Int("count", len(defaultFollowedGroups)))
+			}
+		}
 	case "recent":
 		items = buildRecentItems(conversations, pinnedSet, groupSpaceMap, externalGroupMap, defaultSpaceID)
 	}

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -489,21 +489,30 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 			// Why no DefaultFollowedGroupGuard here (vs the /v1/follow/sort path):
 			// the candidates are not client-supplied.  They come from
 			// buildFollowItems above, which only emits a group SidebarItem when
-			// the group is in `categorySetting` with a non-nil CategoryID.
-			// `categorySetting` itself comes from
-			// groupCategoryDB.QueryCategorySettingsByGroupNos with two constraints
-			// the UpdateSort path cannot rely on:
-			//   1. The candidate group_no's came from the IM-returned conversation
-			//      list, which only includes channels the user is a member of in
-			//      the current Space.
-			//   2. The query's LEFT JOIN includes `gc.status != 2`, so a
-			//      soft-deleted category yields cs.CategoryID == nil and the
-			//      group is excluded.
-			// Together these are STRONGER than the UpdateSort guard's Stage 1
-			// (which by itself only checks category_id IS NOT NULL — see
-			// db_group_category.go FilterDefaultFollowedGroups).  Adding a guard
-			// call here would be redundant for security but would cost a per-group
-			// channel-access round-trip on the hot read path.
+			// the group is in `categorySetting` with a non-nil CategoryID, and
+			// that CategoryID carries "live" semantics — see
+			// db_group_category.go GroupCategorySetting.CategoryID for the full
+			// contract.  Two stacked filters guarantee Stage-1-equivalent
+			// authorization without a separate round-trip:
+			//   1. Membership / Space visibility: candidate group_no's came
+			//      from the IM-returned conversation list (FilterRawConversations-
+			//      BySpace), which only includes channels the user is a member
+			//      of in the current Space.  Same authority the rest of the
+			//      sidebar relies on.
+			//   2. Live-category: QueryCategorySettingsByGroupNos SELECTs
+			//      gc.category_id (not gs.category_id), so a group_setting
+			//      pointing at a soft-deleted category (gc.status=2) or a
+			//      missing category row yields CategoryID=nil; buildFollowItems
+			//      then drops it before this loop runs.  Issue #151 review fix:
+			//      the previous code selected gs.category_id, letting dangling
+			//      refs through; that bypass is closed at the query layer.
+			// Together these are at least as strong as the UpdateSort guard's
+			// Stage 1 INNER JOIN.  Stage 2 (membership / Disband) is also
+			// covered by point 1 above — IMSyncUserConversation does not
+			// return rows for users who aren't current members, and Disband
+			// groups are filtered out of the IM result by the IM core.
+			// Adding a guard call here would be redundant and would cost a
+			// per-group channel-access round-trip on the hot read path.
 			if mErr := sb.convExtDB.MaterializeDefaultFollowedGroups(loginUID, spaceID, defaultFollowedGroups); mErr != nil {
 				sb.Warn("sidebar sync: default-followed group materialization failed (non-fatal)",
 					zap.Error(mErr), zap.Int("count", len(defaultFollowedGroups)))

--- a/modules/message/api_sidebar_integration_test.go
+++ b/modules/message/api_sidebar_integration_test.go
@@ -497,3 +497,56 @@ func TestIntegration_Sidebar_Issue41_DMCategorySortLoadedFromGroupCategory(t *te
 	assert.Equal(t, catSort, items[0].CategorySort,
 		"带 dm_category_id 的 DM 必须把 group_category.sort 写到 SidebarItem.CategorySort")
 }
+
+// ---------------------------------------------------------------------------
+// Scene 7g: issue #151 — default-followed group (categorized but no ext row)
+// materializes during sidebar/sync.
+//
+// Bug: buildFollowItems treats "group has category + not blacklisted" as
+// followed regardless of ext-row presence.  But OnThreadCreated's fan-out
+// filter (selectEligibleForFanoutTx) only sees users whose ext row says
+// auto_follow_threads=1.  Users whose follow status was implied solely by
+// category had no ext row → fan-out silently skipped them → new threads
+// never appeared in their follow tab.
+//
+// Fix: when sidebar/sync's follow branch emits a group SidebarItem without a
+// matching groupExts entry, materialize the ext row with
+// auto_follow_threads=1, group_unfollowed=0 so the next OnThreadCreated for
+// that group reaches this user.  This test exercises the materialization
+// step end-to-end against the real DB.
+// ---------------------------------------------------------------------------
+
+func TestIntegration_Sidebar_FollowTab_MaterializesDefaultFollowedGroup(t *testing.T) {
+	ctx := newSidebarIntegCtx(t)
+	cleanConvExtTable(t, ctx)
+
+	const uid, space = "s7g-uid", "s7g-space"
+	const groupNo = "s7g-grp"
+
+	db := convext.NewDB(ctx)
+
+	// Precondition: no ext row exists for (uid, space, groupNo).
+	pre, err := db.Get(uid, space, 2 /* Group */, groupNo)
+	require.NoError(t, err)
+	require.Nil(t, pre,
+		"precondition: default-followed group must have NO ext row at sidebar/sync time")
+
+	// Simulate the diff that the sidebar handler computes: the group is in the
+	// follow tab (because it has a category) and groupExts had no entry for it.
+	// The handler then calls MaterializeDefaultFollowedGroups with this list.
+	require.NoError(t, db.MaterializeDefaultFollowedGroups(uid, space, []string{groupNo}),
+		"sidebar handler's materialization step must succeed for a default-followed group")
+
+	// After materialization, the ext row exists with the contract the
+	// downstream OnThreadCreated fan-out filter requires:
+	//   auto_follow_threads=1 AND group_unfollowed=0
+	post, err := db.Get(uid, space, 2, groupNo)
+	require.NoError(t, err)
+	require.NotNil(t, post,
+		"ext row must exist after sidebar/sync materialization (issue #151 symptom #2)")
+	assert.Equal(t, int8(1), post.AutoFollowThreads,
+		"materialized row must have auto_follow_threads=1 so OnThreadCreated "+
+			"fans out new threads to this user (closes issue #151 symptom #2)")
+	assert.Equal(t, int8(0), post.GroupUnfollowed,
+		"materialized row must have group_unfollowed=0")
+}

--- a/modules/message/api_sidebar_integration_test.go
+++ b/modules/message/api_sidebar_integration_test.go
@@ -550,3 +550,129 @@ func TestIntegration_Sidebar_FollowTab_MaterializesDefaultFollowedGroup(t *testi
 	assert.Equal(t, int8(0), post.GroupUnfollowed,
 		"materialized row must have group_unfollowed=0")
 }
+
+// ---------------------------------------------------------------------------
+// Scene 7h: issue #151 review blocker (Jerry-Xin / lml2468) — sidebar must
+// NOT materialize a group whose group_setting.category_id points at a
+// soft-deleted group_category (status=2).
+//
+// Before fix: QueryCategorySettingsByGroupNos selected gs.category_id (the
+// stale persisted field).  Even though the LEFT JOIN had `gc.status != 2`,
+// that predicate only nullifies the JOIN-side columns (gc.sort → 0 via
+// IFNULL); the SELECT still returned the stale gs.category_id.  buildFollow-
+// Items checked `cs.CategoryID == nil` to filter, which was always FALSE for
+// a soft-deleted category — the group still entered the follow tab AND the
+// new sidebar materialization branch wrote an auto_follow_threads=1 ext row.
+// Subsequent OnThreadCreated would then fan out threads of a group whose
+// category lookup model treats as "not followed any more" — phantom
+// subscription.
+//
+// After fix: QueryCategorySettingsByGroupNos selects gc.category_id (the
+// JOIN-side column).  A soft-deleted category → JOIN miss → CategoryID=nil
+// → buildFollowItems excludes the group → the materialization loop never
+// sees it.  This test exercises the full chain against real
+// group_setting + group_category rows.
+// ---------------------------------------------------------------------------
+
+func TestIntegration_Sidebar_FollowTab_DoesNotMaterializeSoftDeletedCategoryGroup(t *testing.T) {
+	ctx := newSidebarIntegCtx(t)
+	cleanConvExtTable(t, ctx)
+	ensureSidebarSoftDeletedCategoryTables(t, ctx)
+	cleanSidebarSoftDeletedCategoryRows(t, ctx)
+
+	const (
+		uid           = "s7h-uid"
+		space         = "s7h-space"
+		groupNo       = "s7h-grp"
+		softDeletedID = "s7h-cat-deleted"
+	)
+
+	// Seed: user has assigned group → soft-deleted category.  gs.category_id
+	// is non-NULL but the underlying gc row has status=2.
+	_, err := ctx.DB().Exec(
+		"INSERT INTO group_category (category_id, space_id, uid, name, sort, status) "+
+			"VALUES (?, ?, ?, ?, 0, 2)",
+		softDeletedID, "", uid, "deleted cat",
+	)
+	require.NoError(t, err, "seed soft-deleted category")
+	_, err = ctx.DB().Exec(
+		"INSERT INTO group_setting (uid, group_no, category_id) VALUES (?, ?, ?)",
+		uid, groupNo, softDeletedID,
+	)
+	require.NoError(t, err, "seed group_setting pointing at soft-deleted category")
+
+	// Stage A — QueryCategorySettingsByGroupNos must return CategoryID=nil.
+	db := newGroupCategoryDB(ctx)
+	settings, err := db.QueryCategorySettingsByGroupNos([]string{groupNo}, uid)
+	require.NoError(t, err)
+	require.Len(t, settings, 1,
+		"row must still surface (sidebar needs intraCategorySort even for uncategorized groups)")
+	assert.Nil(t, settings[0].CategoryID,
+		"CategoryID must be nil for a group whose group_setting points at a "+
+			"soft-deleted category — issue #151 review blocker")
+
+	// Stage B — buildFollowItems must drop this group from the follow tab.
+	categorySetting := map[string]*GroupCategorySetting{
+		groupNo: settings[0],
+	}
+	stubConvs := []*config.SyncUserConversationResp{
+		{ChannelID: groupNo, ChannelType: common.ChannelTypeGroup.Uint8(), Timestamp: 100},
+	}
+	items := buildFollowItems(stubConvs, categorySetting, nil, nil, nil, nil, nil, nil, nil, "")
+	assert.Empty(t, items,
+		"buildFollowItems must NOT include groups with a soft-deleted category; "+
+			"otherwise they'd be displayed and then materialized via the "+
+			"sidebar materialization loop")
+
+	// Stage C — end-to-end check: even if a future regression somehow
+	// surfaced the group into the materialization candidate set, the
+	// MaterializeDefaultFollowedGroups call would still write the row (it is
+	// not gated for sidebar callers, by design — see api_sidebar.go comment).
+	// So the real defense lives at Stages A+B above.  Pin that with a
+	// no-ext-row assertion against the conv_ext DB.
+	convDB := convext.NewDB(ctx)
+	row, err := convDB.Get(uid, space, 2 /* Group */, groupNo)
+	require.NoError(t, err)
+	assert.Nil(t, row,
+		"no ext row may be written for the soft-deleted-category group "+
+			"(verified end-to-end: sidebar dropped it at Stage B, so the "+
+			"materialization branch never saw it)")
+}
+
+// ensureSidebarSoftDeletedCategoryTables creates the minimal group_setting
+// schema the Scene 7h regression needs.  conv_ext_test ships with
+// group_category but not group_setting; this helper adds it once (idempotent
+// via DROP+CREATE so the COLLATE pin can evolve safely).
+//
+// Reuses the same COLLATE workaround as the guard E2E test
+// (default_followed_group_guard_e2e_test.go) — issue #150 forward-repair
+// migration isn't in this test database.
+func ensureSidebarSoftDeletedCategoryTables(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	_, err := ctx.DB().Exec("DROP TABLE IF EXISTS group_setting")
+	require.NoError(t, err)
+	_, err = ctx.DB().Exec(
+		"CREATE TABLE group_setting (" +
+			"  id INT NOT NULL AUTO_INCREMENT PRIMARY KEY," +
+			"  uid VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  group_no VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  category_id VARCHAR(32) COLLATE utf8mb4_general_ci DEFAULT NULL," +
+			"  category_sort INT NOT NULL DEFAULT 0," +
+			"  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+			"  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+			"  UNIQUE KEY uk_uid_groupno (uid, group_no)" +
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+	)
+	require.NoError(t, err)
+}
+
+// cleanSidebarSoftDeletedCategoryRows wipes only Scene 7h's data.  Scope by
+// uid prefix to keep the shared conv_ext_test database safe when other
+// integration tests run in parallel (same rationale as the guard E2E test).
+func cleanSidebarSoftDeletedCategoryRows(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	for _, tbl := range []string{"group_setting", "group_category"} {
+		_, err := ctx.DB().Exec("DELETE FROM "+tbl+" WHERE uid LIKE ?", "s7h-%")
+		require.NoError(t, err, "clean %s rows", tbl)
+	}
+}

--- a/modules/message/db_group_category.go
+++ b/modules/message/db_group_category.go
@@ -33,7 +33,20 @@ func newGroupCategoryDB(ctx *config.Context) *groupCategoryDB {
 //     （sidebar 排序时作为二级 key，不暴露给客户端，避免破坏现有 schema）。
 type GroupCategorySetting struct {
 	GroupNo string
-	// CategoryID 是 group_setting.category_id —— 用户给该群指定的类别 ID。
+	// CategoryID 是 "live" category id —— 已经过 group_category.status != 2
+	// 过滤。NULL 含义统一为"该群当前未分类"，同时覆盖三种数据情况：
+	//   (a) group_setting 行不存在 category_id（用户从未分配）；
+	//   (b) group_setting.category_id 指向已被软删的 category
+	//       （TOCTOU race 残留 / category_cleanup 未跑）；
+	//   (c) group_setting.category_id 指向根本不存在的 category（异常残留）。
+	// 三种情况下游一律按"未分类"处理 —— sidebar 不展示在 follow tab、
+	// 物化路径不写 ext 行、API 不向客户端暴露 dangling id。这是 follow-tab
+	// 整套机制（issue #151）依赖的 schema-app 不变量：sidebar 显示 / 物化 /
+	// /v1/follow/sort 鉴权三处都按这个语义统一判定，不再有 stale-id 暴露。
+	//
+	// 实现上 SELECT 必须取 gc.category_id（JOIN 出来的字段），不是 gs.category_id
+	// （持久化的 stale 字段）—— 二者只在 JOIN 命中时相等，JOIN miss（status=2 或
+	// gc 不存在）时 gc.category_id 自然为 NULL，恰好对应 (b)(c) 两种 dangling 情况。
 	CategoryID *string
 	// CategorySort 是 group_setting.category_sort —— 类别内排序（v1 兼容字段，
 	// v1 API_conversation 直接回显该值，故保留语义不变）。
@@ -45,26 +58,33 @@ type GroupCategorySetting struct {
 
 // QueryCategorySettingsByGroupNos 批量查询群组的分类设置。
 //
-// 用 LEFT JOIN group_category：当用户改了 group_setting.category_id 但目标分类
-// 已删除时（gc.category_id IS NULL），CategoryGroupSort 退回到 0，
-// 与 LEFT JOIN 的 NULL 一致；客户端把该群当作"未分类"展示。
+// 用 LEFT JOIN group_category：保留所有 gs 行（包括未分类的、指向已删 category
+// 的），让 sidebar 能在一次查询里同时拿到分类内排序（gs.category_sort）和分类
+// 之间排序（gc.sort）；JOIN miss 走 IFNULL 退回 0，无需第二次查询。
 //
 // JOIN 谓词同时绑定 `gc.uid = gs.uid`（PR #21 Round-4 review I4 by yujiawei）：
 // 虽然 group_category.category_id 当前是全局唯一、且应只被 owner 的 group_setting
 // 引用，但 LEFT JOIN 只匹配 category_id 时这条不变量是 *结构上未强制* 的隐式约束。
 // 显式加 uid 谓词把约束变成 JOIN 自身的属性，避免未来 schema 演进（例如允许
 // 跨用户共享 category）时静默走 stale category_group_sort=0 分支。
+//
+// SELECT gc.category_id 而非 gs.category_id（issue #151 review fix）：
+// gs.category_id 是持久化字段，category 被软删后这里仍保留 stale 值（cleanup
+// 路径会清，但 TOCTOU race 可能产生 dangling — modules/category 的
+// MoveGroupToCategory_TOCTOU_DanglingReference 测试明确承认这种状态合法存在）。
+// 取 JOIN 后的 gc.category_id：JOIN miss（gc.status=2 或 gc 不存在）时为 NULL，
+// 恰好让 GroupCategorySetting.CategoryID 反映 "live" 语义。下游 buildFollowItems
+// 和 sidebar 物化路径的 cs.CategoryID == nil → 跳过 都自动获得正确语义，
+// 不再让 dangling category 的群进入 follow tab 或被物化（issue #151 review
+// blocker — 之前 SELECT gs.category_id 让 sidebar 物化路径绕过软删校验）。
 func (d *groupCategoryDB) QueryCategorySettingsByGroupNos(groupNos []string, uid string) ([]*GroupCategorySetting, error) {
 	if len(groupNos) == 0 {
 		return nil, nil
 	}
 	var results []*GroupCategorySetting
-	// JOIN 谓词除了 (gs.category_id, gs.uid) 双绑定外，还加 gc.status != 2
-	// （PR #21 Round-6 P1 by yujiawei）：defense-in-depth，避免任何意外指向软删
-	// 分类的 group_setting 行从 gc.sort 拿到 stale 值而不是走 LEFT JOIN miss 退到 0。
 	_, err := d.session.Select(
 		"gs.group_no",
-		"gs.category_id",
+		"gc.category_id",
 		"IFNULL(gs.category_sort, 0) AS category_sort",
 		"IFNULL(gc.sort, 0) AS category_group_sort",
 	).
@@ -115,18 +135,21 @@ func (d *groupCategoryDB) QueryCategorySortsByIDs(categoryIDs []string, uid stri
 // modules/conversation_ext/service.go DefaultFollowedGroupGuard for why this
 // gate exists (issue #151 code review #1).
 //
-// INNER JOIN group_category (with gc.status != 2) is the same defense-in-depth
-// pattern QueryCategorySettingsByGroupNos already applies (line 72 of this
-// file): a soft-deleted category leaves the original group_setting.category_id
-// pointing at gc.status=2, which sidebar's LEFT JOIN treats as "no category"
-// and excludes from the follow tab.  Without the JOIN here, Stage 1 would let
-// those stale rows through, Stage 2 would then materialize an
-// auto_follow_threads=1 row for a group the user's sidebar never even shows —
-// phantom fanout (issue #151 code review #3 / re-review H1).
+// Same "live category" predicate as QueryCategorySettingsByGroupNos above,
+// expressed as INNER JOIN rather than LEFT JOIN:
 //
-// The JOIN's `gc.uid = gs.uid` predicate matches QueryCategorySettingsByGroupNos
-// — protects against future schema evolution that allows category sharing
-// across users.
+//   - QueryCategorySettingsByGroupNos: LEFT JOIN, preserves uncategorized
+//     rows so sidebar can render them with CategoryID=nil + CategoryGroupSort=0.
+//   - FilterDefaultFollowedGroups (here): INNER JOIN, drops uncategorized
+//     rows entirely because the guard only needs to know "is this group
+//     live-categorized for this user" (boolean), not surface "no" rows.
+//
+// Both queries are the same schema-app invariant ("CategoryID is live IFF
+// gc.status != 2"), expressed for two consumer shapes.  Keep the JOIN
+// predicates in lockstep — diverging means one entry point would silently
+// admit dangling refs the other rejects.  The `gc.uid = gs.uid` binding
+// matches QueryCategorySettingsByGroupNos: protects against future schema
+// evolution that allows category sharing across users.
 //
 // Returns an empty slice if no candidate matches.  Callers must NOT assume the
 // result preserves input order.

--- a/modules/message/db_group_category.go
+++ b/modules/message/db_group_category.go
@@ -108,3 +108,53 @@ func (d *groupCategoryDB) QueryCategorySortsByIDs(categoryIDs []string, uid stri
 	}
 	return result, nil
 }
+
+// FilterDefaultFollowedGroups returns the subset of candidateGroupNos that the
+// given uid has actually placed into a non-deleted category.  These are the
+// "default-followed" groups per the follow-tab definition — see
+// modules/conversation_ext/service.go DefaultFollowedGroupGuard for why this
+// gate exists (issue #151 code review #1).
+//
+// INNER JOIN group_category (with gc.status != 2) is the same defense-in-depth
+// pattern QueryCategorySettingsByGroupNos already applies (line 72 of this
+// file): a soft-deleted category leaves the original group_setting.category_id
+// pointing at gc.status=2, which sidebar's LEFT JOIN treats as "no category"
+// and excludes from the follow tab.  Without the JOIN here, Stage 1 would let
+// those stale rows through, Stage 2 would then materialize an
+// auto_follow_threads=1 row for a group the user's sidebar never even shows —
+// phantom fanout (issue #151 code review #3 / re-review H1).
+//
+// The JOIN's `gc.uid = gs.uid` predicate matches QueryCategorySettingsByGroupNos
+// — protects against future schema evolution that allows category sharing
+// across users.
+//
+// Returns an empty slice if no candidate matches.  Callers must NOT assume the
+// result preserves input order.
+func (d *groupCategoryDB) FilterDefaultFollowedGroups(uid string, candidateGroupNos []string) ([]string, error) {
+	if len(candidateGroupNos) == 0 {
+		return nil, nil
+	}
+	type row struct {
+		GroupNo string `db:"group_no"`
+	}
+	var rows []*row
+	_, err := d.session.Select("gs.group_no").
+		From(dbr.I("group_setting").As("gs")).
+		Join(
+			dbr.I("group_category").As("gc"),
+			"gs.category_id = gc.category_id AND gs.uid = gc.uid AND gc.status != 2",
+		).
+		Where("gs.uid = ? AND gs.group_no IN ?", uid, candidateGroupNos).
+		Load(&rows)
+	if err != nil {
+		return nil, fmt.Errorf("filter default-followed groups: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r.GroupNo)
+	}
+	return out, nil
+}

--- a/modules/message/default_followed_group_guard_e2e_test.go
+++ b/modules/message/default_followed_group_guard_e2e_test.go
@@ -1,0 +1,344 @@
+//go:build integration
+
+package message
+
+// =============================================================================
+// E2E coverage for the production DefaultFollowedGroupGuard wiring.
+//
+// The unit tests in default_followed_group_guard_test.go stub both stages of
+// the guard.  This file wires the REAL production chain:
+//
+//   convext.Service.AuthorizeAndMaterializeDefaultFollowedGroups
+//     └── defaultFollowedGroupGuard (Stage 1 = groupCategoryDB JOIN,
+//                                    Stage 2 = threadAuthChecker.checkChannelAccess)
+//           ├── groupCategoryDB.FilterDefaultFollowedGroups
+//           │     └── INNER JOIN group_setting × group_category (status != 2)
+//           └── threadAuthChecker.AuthorizeChannelFollow
+//                 └── group.IService.ExistMember
+//                     group.IService.GetGroups
+//                     group.DB.QueryExternalGroupNosForUser
+//                 └── all against real MySQL rows
+//
+// This exercises every rejection reason the production chain has, with the
+// actual DB driver, JOIN ordering, and group/group_setting/group_member
+// schema in play.  It is the integration-level regression test for issue
+// #151 reviews #1 + #2 + re-review H1 (soft-deleted category gap).
+// =============================================================================
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ensureGuardE2ETables creates the minimal schemas needed for the production
+// guard chain on the integration MySQL.  conv_ext_test ships with
+// `user_conversation_ext`, `user_follow_version`, and `group_category`; this
+// helper adds the three tables only the group/group_setting access paths read
+// (`group`, `group_member`, `group_setting`) so the test does not depend on
+// running the full octo migration suite.
+//
+// DROP + CREATE rather than CREATE IF NOT EXISTS so schema tweaks (e.g. the
+// explicit COLLATE on group_setting.category_id added for issue #150
+// compatibility) actually take effect on a re-run; the tables only carry
+// per-test data so the destructive DDL is safe.
+func ensureGuardE2ETables(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	for _, tbl := range []string{"group_setting", "group_member", "`group`"} {
+		_, err := ctx.DB().Exec("DROP TABLE IF EXISTS " + tbl)
+		require.NoError(t, err, "drop %s", tbl)
+	}
+	stmts := []string{
+		// modules/group/sql/20191106000002 + 20260307000004 + 20260424000001
+		// (only the columns this test touches).
+		"CREATE TABLE `group` (" +
+			"  `id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY," +
+			"  `group_no` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `name` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `creator` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `status` SMALLINT NOT NULL DEFAULT 0," +
+			"  `version` BIGINT NOT NULL DEFAULT 0," +
+			"  `forbidden` SMALLINT NOT NULL DEFAULT 0," +
+			"  `invite` SMALLINT NOT NULL DEFAULT 0," +
+			"  `forbidden_add_friend` SMALLINT NOT NULL DEFAULT 0," +
+			"  `allow_view_history_msg` SMALLINT NOT NULL DEFAULT 1," +
+			"  `allow_member_pinned_message` SMALLINT NOT NULL DEFAULT 0," +
+			"  `category` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `group_type` SMALLINT NOT NULL DEFAULT 0," +
+			"  `notice` VARCHAR(200) NOT NULL DEFAULT ''," +
+			"  `avatar` VARCHAR(200) NOT NULL DEFAULT ''," +
+			"  `allow_external` SMALLINT NOT NULL DEFAULT 1," +
+			"  `group_md` TEXT," +
+			"  `group_md_version` BIGINT NOT NULL DEFAULT 0," +
+			"  `group_md_updated_at` TIMESTAMP NULL DEFAULT NULL," +
+			"  `group_md_updated_by` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `space_id` VARCHAR(40) DEFAULT ''," +
+			"  `is_external_group` SMALLINT NOT NULL DEFAULT 0," +
+			"  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+			"  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+			"  UNIQUE KEY `group_groupNo` (`group_no`)" +
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+		"CREATE TABLE `group_member` (" +
+			"  `id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY," +
+			"  `group_no` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `uid` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `remark` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `role` SMALLINT NOT NULL DEFAULT 0," +
+			"  `version` BIGINT NOT NULL DEFAULT 0," +
+			"  `is_deleted` SMALLINT NOT NULL DEFAULT 0," +
+			"  `status` SMALLINT NOT NULL DEFAULT 1," +
+			"  `vercode` VARCHAR(100) NOT NULL DEFAULT ''," +
+			"  `robot` SMALLINT NOT NULL DEFAULT 0," +
+			"  `invite_uid` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `forbidden_expir_time` BIGINT NOT NULL DEFAULT 0," +
+			"  `bot_admin` SMALLINT NOT NULL DEFAULT 0," +
+			"  `is_external` SMALLINT NOT NULL DEFAULT 0," +
+			"  `source_space_id` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+			"  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+			"  UNIQUE KEY `group_no_uid` (`group_no`, `uid`)" +
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+		// modules/message/sql/.../category_legacy01 — group_setting columns
+		// the guard reads (category_id, category_sort + uid/group_no key).
+		//
+		// IMPORTANT: category_id must explicitly use the same COLLATE as
+		// group_category.category_id (utf8mb4_general_ci, established by
+		// category_legacy01.sql line 15).  MySQL 8.0 silently defaults missing
+		// COLLATE clauses on CREATE TABLE to utf8mb4_0900_ai_ci, which is
+		// exactly the production schema drift reported in issue #150 —
+		// without the explicit COLLATE here the INNER JOIN in Stage 1
+		// (FilterDefaultFollowedGroups) errors with "Error 1267 (HY000):
+		// Illegal mix of collations".  Pinning it here lets the guard test
+		// pass on conv_ext_test until #150's forward-repair migration lands.
+		"CREATE TABLE `group_setting` (" +
+			"  `id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY," +
+			"  `uid` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `group_no` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `category_id` VARCHAR(32) COLLATE utf8mb4_general_ci DEFAULT NULL," +
+			"  `category_sort` INT NOT NULL DEFAULT 0," +
+			"  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+			"  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+			"  UNIQUE KEY `uk_uid_groupno` (`uid`, `group_no`)" +
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+	}
+	for _, s := range stmts {
+		_, err := ctx.DB().Exec(s)
+		require.NoError(t, err, "ensureGuardE2ETables: %s", s[:60])
+	}
+}
+
+// cleanGuardE2ERows wipes only rows this test owns.  Aggressive `DELETE FROM
+// <table>` would race with other integration tests that share the
+// conv_ext_test database (e.g. conversation_ext's UpdateSort suite seeds its
+// own user_conversation_ext + user_follow_version rows).  All this test's
+// data lives under the e2e- / cat- prefixes, so per-table prefix DELETEs
+// keep the shared DB isolated when both packages run side by side.
+func cleanGuardE2ERows(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	deletes := []struct{ tbl, where, prefix string }{
+		{"user_conversation_ext", "uid LIKE ?", "e2e-%"},
+		{"user_follow_version", "uid LIKE ?", "e2e-%"},
+		{"group_category", "uid LIKE ?", "e2e-%"},
+		{"group_setting", "uid LIKE ?", "e2e-%"},
+		{"group_member", "uid LIKE ?", "e2e-%"},
+		{"`group`", "group_no LIKE ?", "e2e-%"},
+	}
+	for _, d := range deletes {
+		_, err := ctx.DB().Exec("DELETE FROM "+d.tbl+" WHERE "+d.where, d.prefix)
+		require.NoError(t, err, "clean %s", d.tbl)
+	}
+}
+
+func seedGroupRow(t *testing.T, ctx *config.Context, groupNo, spaceID string, status int) {
+	t.Helper()
+	_, err := ctx.DB().Exec(
+		"INSERT INTO `group` (group_no, status, space_id) VALUES (?, ?, ?)",
+		groupNo, status, spaceID,
+	)
+	require.NoError(t, err, "seedGroupRow %s", groupNo)
+}
+
+func seedGroupMember(t *testing.T, ctx *config.Context, groupNo, uid string, isExternal int, sourceSpaceID string) {
+	t.Helper()
+	_, err := ctx.DB().Exec(
+		"INSERT INTO group_member (group_no, uid, is_deleted, status, is_external, source_space_id) VALUES (?, ?, 0, 1, ?, ?)",
+		groupNo, uid, isExternal, sourceSpaceID,
+	)
+	require.NoError(t, err, "seedGroupMember %s/%s", groupNo, uid)
+}
+
+func seedGroupCategory(t *testing.T, ctx *config.Context, categoryID, uid string, status int) {
+	t.Helper()
+	_, err := ctx.DB().Exec(
+		"INSERT INTO group_category (category_id, space_id, uid, name, sort, status) VALUES (?, '', ?, 'cat', 0, ?)",
+		categoryID, uid, status,
+	)
+	require.NoError(t, err, "seedGroupCategory %s", categoryID)
+}
+
+func seedGroupSetting(t *testing.T, ctx *config.Context, uid, groupNo, categoryID string) {
+	t.Helper()
+	var cat interface{}
+	if categoryID == "" {
+		cat = nil
+	} else {
+		cat = categoryID
+	}
+	_, err := ctx.DB().Exec(
+		"INSERT INTO group_setting (uid, group_no, category_id) VALUES (?, ?, ?)",
+		uid, groupNo, cat,
+	)
+	require.NoError(t, err, "seedGroupSetting %s/%s", uid, groupNo)
+}
+
+// TestE2E_DefaultFollowedGroupGuard_ProductionChain wires the real production
+// objects (group.Service, threadAuthChecker, defaultFollowedGroupGuard,
+// conversation_ext.Service) and asserts every rejection / acceptance path
+// against real MySQL rows.
+func TestE2E_DefaultFollowedGroupGuard_ProductionChain(t *testing.T) {
+	ctx := newSidebarIntegCtx(t)
+	ensureGuardE2ETables(t, ctx)
+	cleanGuardE2ERows(t, ctx)
+
+	const (
+		uid                  = "e2e-u1"
+		spaceA               = "e2e-sA"
+		spaceB               = "e2e-sB"
+		gOK                  = "e2e-g-ok"           // member + spaceA + category → MATERIALIZE
+		gDisband             = "e2e-g-disband"      // member + spaceA + category but Disband → REJECT
+		gWrongSpace          = "e2e-g-wrong"        // member + spaceB (not request space) + category → REJECT
+		gNotMember           = "e2e-g-notmem"       // spaceA + category but uid is NOT a member → REJECT
+		gNoCategory          = "e2e-g-nocat"        // member + spaceA but no category → REJECT (Stage 1)
+		gSoftDeletedCat      = "e2e-g-softcat"      // member + spaceA + category_id but category soft-deleted → REJECT (Stage 1, H1 regression)
+		gExternal            = "e2e-g-external"     // external member in spaceB referencing spaceA + category → MATERIALIZE
+		gFake                = "e2e-g-fake"         // attacker-injected, no rows anywhere → REJECT (Stage 1)
+		catLive              = "cat-live"
+		catSoftDeleted       = "cat-deleted"
+	)
+
+	// --- groups ---
+	seedGroupRow(t, ctx, gOK, spaceA, group.GroupStatusNormal)
+	seedGroupRow(t, ctx, gDisband, spaceA, group.GroupStatusDisband)
+	seedGroupRow(t, ctx, gWrongSpace, spaceB, group.GroupStatusNormal)
+	seedGroupRow(t, ctx, gNotMember, spaceA, group.GroupStatusNormal)
+	seedGroupRow(t, ctx, gNoCategory, spaceA, group.GroupStatusNormal)
+	seedGroupRow(t, ctx, gSoftDeletedCat, spaceA, group.GroupStatusNormal)
+	seedGroupRow(t, ctx, gExternal, spaceB, group.GroupStatusNormal)
+	// gFake is intentionally absent from the group table.
+
+	// --- membership ---
+	seedGroupMember(t, ctx, gOK, uid, 0, "")
+	seedGroupMember(t, ctx, gDisband, uid, 0, "")
+	seedGroupMember(t, ctx, gWrongSpace, uid, 0, "")
+	// gNotMember: NO group_member row for uid.
+	seedGroupMember(t, ctx, gNoCategory, uid, 0, "")
+	seedGroupMember(t, ctx, gSoftDeletedCat, uid, 0, "")
+	// External-member fallback: uid joined gExternal from spaceA (sourceSpaceID==spaceA).
+	seedGroupMember(t, ctx, gExternal, uid, 1, spaceA)
+
+	// --- categories ---
+	seedGroupCategory(t, ctx, catLive, uid, 1)       // status=1 normal
+	seedGroupCategory(t, ctx, catSoftDeleted, uid, 2) // status=2 soft-deleted (H1)
+
+	// --- group_setting (per-user category assignment) ---
+	seedGroupSetting(t, ctx, uid, gOK, catLive)
+	seedGroupSetting(t, ctx, uid, gDisband, catLive)
+	seedGroupSetting(t, ctx, uid, gWrongSpace, catLive)
+	seedGroupSetting(t, ctx, uid, gNotMember, catLive)
+	// gNoCategory: row exists but category_id IS NULL → Stage 1 drops.
+	seedGroupSetting(t, ctx, uid, gNoCategory, "")
+	// gSoftDeletedCat: row points at status=2 category → Stage 1 INNER JOIN drops (H1).
+	seedGroupSetting(t, ctx, uid, gSoftDeletedCat, catSoftDeleted)
+	seedGroupSetting(t, ctx, uid, gExternal, catLive)
+	// gFake: no group_setting row at all.
+
+	// --- wire production objects ---
+	convext.InitGlobalConvExtService(ctx)
+	svc := convext.GetGlobalConvExtService()
+	require.NotNil(t, svc, "ConvExt service must be initialized")
+	checker := newThreadAuthChecker(ctx)
+	svc.SetChannelAuthChecker(checker)
+	svc.SetDefaultFollowedGroupGuard(&defaultFollowedGroupGuard{
+		db:          newGroupCategoryDB(ctx),
+		channelAuth: checker,
+	})
+
+	// --- exercise the production chain ---
+	candidates := []string{
+		gOK, gDisband, gWrongSpace, gNotMember, gNoCategory,
+		gSoftDeletedCat, gExternal, gFake,
+	}
+	require.NoError(t, svc.AuthorizeAndMaterializeDefaultFollowedGroups(
+		uid, spaceA, candidates),
+		"production guard call must succeed (only Stage 1/2 infra errors propagate; rejections are silent drops)")
+
+	// --- assertions: each candidate's ext-row state ---
+	db := convext.NewDB(ctx)
+
+	got := func(groupNo string) *convext.Model {
+		t.Helper()
+		m, err := db.Get(uid, spaceA, 2 /* Group */, groupNo)
+		require.NoError(t, err)
+		return m
+	}
+
+	t.Run("accepts member+spaceA+category", func(t *testing.T) {
+		m := got(gOK)
+		require.NotNil(t, m, "g-ok must be materialized")
+		assert.Equal(t, int8(1), m.AutoFollowThreads,
+			"materialized row must have auto_follow_threads=1")
+		assert.Equal(t, int8(0), m.GroupUnfollowed)
+	})
+
+	t.Run("rejects Disband group", func(t *testing.T) {
+		assert.Nil(t, got(gDisband),
+			"Disband group must be dropped at Stage 2 (checkChannelAccess "+
+				"explicitly rejects GroupStatusDisband)")
+	})
+
+	t.Run("rejects wrong-Space group (issue #151 review #2)", func(t *testing.T) {
+		assert.Nil(t, got(gWrongSpace),
+			"group whose space_id != request spaceID must be dropped at Stage 2 — "+
+				"prevents cross-Space metadata leak when group_setting row "+
+				"persists from another Space")
+	})
+
+	t.Run("rejects non-member", func(t *testing.T) {
+		assert.Nil(t, got(gNotMember),
+			"non-member group must be dropped at Stage 2 (ExistMember=false) — "+
+				"prevents materialization for groups the user cannot otherwise see")
+	})
+
+	t.Run("rejects group with NULL category_id (Stage 1)", func(t *testing.T) {
+		assert.Nil(t, got(gNoCategory),
+			"group with group_setting.category_id IS NULL must be dropped at "+
+				"Stage 1 — not a default-followed group")
+	})
+
+	t.Run("rejects group pointing at soft-deleted category (re-review H1)", func(t *testing.T) {
+		assert.Nil(t, got(gSoftDeletedCat),
+			"group whose group_setting.category_id references a status=2 category "+
+				"must be dropped at Stage 1 — sidebar's LEFT JOIN would treat the "+
+				"category as missing, so materializing here would create a phantom "+
+				"auto_follow_threads=1 row for a group the user's sidebar never shows")
+	})
+
+	t.Run("accepts external-member group with sourceSpaceID match", func(t *testing.T) {
+		m := got(gExternal)
+		require.NotNil(t, m,
+			"external-member group with sourceSpaceID == request spaceID must "+
+				"survive Stage 2 — the external-group fallback in checkChannelAccess "+
+				"is part of the legitimate visibility surface")
+		assert.Equal(t, int8(1), m.AutoFollowThreads)
+	})
+
+	t.Run("rejects attacker-injected unknown group_no", func(t *testing.T) {
+		assert.Nil(t, got(gFake),
+			"group_no with no rows in group/group_member/group_setting must be "+
+				"dropped at Stage 1 — issue #151 review #1's primary attack vector")
+	})
+}

--- a/modules/message/default_followed_group_guard_test.go
+++ b/modules/message/default_followed_group_guard_test.go
@@ -1,0 +1,220 @@
+package message
+
+import (
+	"errors"
+	"testing"
+
+	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Stage-1 / Stage-2 unit coverage for defaultFollowedGroupGuard
+//
+// Issue #151 re-review M4: the spaceID regression test at the service layer
+// uses a coarse "allow / reject" stub guard — it does not exercise the actual
+// two-stage code path in defaultFollowedGroupGuard.FilterDefaultFollowed.
+// These tests substitute fakes for both stages so every rejection reason
+// (non-member / disbanded / wrong-Space / infra-error) is covered.
+// ---------------------------------------------------------------------------
+
+type fakeCategoryFilter struct {
+	// allowed maps candidate group_no → "passes Stage 1".  Anything not in
+	// the map is dropped (simulating: no category, soft-deleted category,
+	// or wrong uid).
+	allowed map[string]bool
+	err     error
+}
+
+func (f *fakeCategoryFilter) FilterDefaultFollowedGroups(uid string, candidates []string) ([]string, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		if f.allowed[c] {
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}
+
+type fakeChannelAuth struct {
+	// rejectWith[uid|spaceID|groupNo] is the error to return — typically
+	// convext.ErrChannelForbidden for "drop silently" cases, or a custom
+	// error for "propagate as infra failure" cases.  Missing entries → nil
+	// (group passes Stage 2).
+	rejectWith map[string]error
+}
+
+func (f *fakeChannelAuth) AuthorizeChannelFollow(uid, spaceID, groupNo string) error {
+	if err, ok := f.rejectWith[uid+"|"+spaceID+"|"+groupNo]; ok {
+		return err
+	}
+	return nil
+}
+
+func newGuard(cat *fakeCategoryFilter, auth *fakeChannelAuth) *defaultFollowedGroupGuard {
+	return &defaultFollowedGroupGuard{db: cat, channelAuth: auth}
+}
+
+func TestDefaultFollowedGroupGuard_HappyPath(t *testing.T) {
+	g := newGuard(
+		&fakeCategoryFilter{allowed: map[string]bool{"g1": true, "g2": true}},
+		&fakeChannelAuth{},
+	)
+	out, err := g.FilterDefaultFollowed("u1", "s1", []string{"g1", "g2"})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"g1", "g2"}, out)
+}
+
+func TestDefaultFollowedGroupGuard_Stage1DropsNonCategorized(t *testing.T) {
+	g := newGuard(
+		&fakeCategoryFilter{allowed: map[string]bool{"g-categorized": true}},
+		&fakeChannelAuth{},
+	)
+	out, err := g.FilterDefaultFollowed("u1", "s1",
+		[]string{"g-categorized", "g-no-category", "g-soft-deleted-cat"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"g-categorized"}, out,
+		"only categorized groups survive Stage 1 — soft-deleted and "+
+			"uncategorized are dropped before any channel auth round-trip")
+}
+
+func TestDefaultFollowedGroupGuard_Stage2DropsNonMember(t *testing.T) {
+	const uid, space = "u-not-member", "s1"
+	g := newGuard(
+		&fakeCategoryFilter{allowed: map[string]bool{"g-private": true}},
+		&fakeChannelAuth{rejectWith: map[string]error{
+			uid + "|" + space + "|g-private": convext.ErrChannelForbidden,
+		}},
+	)
+	out, err := g.FilterDefaultFollowed(uid, space, []string{"g-private"})
+	require.NoError(t, err,
+		"ErrChannelForbidden in Stage 2 must be silently dropped (no error "+
+			"propagation) so the rest of the payload can still proceed")
+	assert.Empty(t, out,
+		"non-member group with category must NOT survive — would otherwise "+
+			"leak thread metadata via OnThreadCreated fanout")
+}
+
+func TestDefaultFollowedGroupGuard_Stage2DropsDisbandedGroup(t *testing.T) {
+	const uid, space = "u1", "s1"
+	// The real checkChannelAccess returns ErrChannelForbidden for Disband
+	// (per modules/message/1module.go:214).  We model that with the same
+	// sentinel — the guard treats Disband identically to non-member.
+	g := newGuard(
+		&fakeCategoryFilter{allowed: map[string]bool{"g-disbanded": true}},
+		&fakeChannelAuth{rejectWith: map[string]error{
+			uid + "|" + space + "|g-disbanded": convext.ErrChannelForbidden,
+		}},
+	)
+	out, err := g.FilterDefaultFollowed(uid, space, []string{"g-disbanded"})
+	require.NoError(t, err)
+	assert.Empty(t, out,
+		"disbanded groups must not be materialized — otherwise a re-creation "+
+			"of follower-fanout rows for a tombstoned group lands in the user's "+
+			"ext table and surfaces in sidebar")
+}
+
+func TestDefaultFollowedGroupGuard_Stage2DropsCrossSpaceGroup(t *testing.T) {
+	const uid, spaceA, spaceB = "u1", "sA", "sB"
+	// User has category for g-cross from when they were in Space A.
+	// In Space B, the channel auth returns ErrChannelForbidden because the
+	// group is not visible (parentSpaceID == sA, no external-group fallback).
+	g := newGuard(
+		&fakeCategoryFilter{allowed: map[string]bool{"g-cross": true}},
+		&fakeChannelAuth{rejectWith: map[string]error{
+			uid + "|" + spaceB + "|g-cross": convext.ErrChannelForbidden,
+		}},
+	)
+	out, err := g.FilterDefaultFollowed(uid, spaceB, []string{"g-cross"})
+	require.NoError(t, err)
+	assert.Empty(t, out,
+		"group categorized in Space A must NOT survive guard when called "+
+			"from Space B — issue #151 code review #2")
+
+	// Sanity: same group + uid in Space A → no rejection → survives.
+	gA := newGuard(
+		&fakeCategoryFilter{allowed: map[string]bool{"g-cross": true}},
+		&fakeChannelAuth{}, // no rejection for Space A
+	)
+	out, err = gA.FilterDefaultFollowed(uid, spaceA, []string{"g-cross"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"g-cross"}, out)
+}
+
+func TestDefaultFollowedGroupGuard_Stage2InfraErrorPropagates(t *testing.T) {
+	wantErr := errors.New("group_db.ExistMember down")
+	g := newGuard(
+		&fakeCategoryFilter{allowed: map[string]bool{"g1": true}},
+		&fakeChannelAuth{rejectWith: map[string]error{
+			"u1|s1|g1": wantErr,
+		}},
+	)
+	out, err := g.FilterDefaultFollowed("u1", "s1", []string{"g1"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr,
+		"non-ErrChannelForbidden errors must propagate so the caller can "+
+			"turn them into a 5xx instead of silently treating the group as "+
+			"'unauthorized' and falling back to ErrSortTargetNotFound")
+	assert.Nil(t, out, "no partial result must be returned on infra error")
+}
+
+func TestDefaultFollowedGroupGuard_Stage1ErrorPropagates(t *testing.T) {
+	wantErr := errors.New("group_setting JOIN query failed")
+	g := newGuard(
+		&fakeCategoryFilter{err: wantErr},
+		&fakeChannelAuth{},
+	)
+	out, err := g.FilterDefaultFollowed("u1", "s1", []string{"g1"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr,
+		"Stage 1 DB errors must propagate verbatim — the caller bubbles them "+
+			"up so the sort request fails loudly rather than silently dropping "+
+			"all groups (which would surface as the misleading ErrSortTargetNotFound)")
+	assert.Nil(t, out)
+}
+
+func TestDefaultFollowedGroupGuard_EmptyInput_SkipsBothStages(t *testing.T) {
+	// Use stubs that would fail loudly if called, to assert short-circuit.
+	cat := &fakeCategoryFilter{err: errors.New("stage 1 must not be called")}
+	auth := &fakeChannelAuth{rejectWith: map[string]error{
+		"any|any|any": errors.New("stage 2 must not be called"),
+	}}
+	g := newGuard(cat, auth)
+
+	out, err := g.FilterDefaultFollowed("u1", "s1", nil)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+
+	out, err = g.FilterDefaultFollowed("u1", "s1", []string{})
+	require.NoError(t, err)
+	assert.Nil(t, out)
+}
+
+func TestDefaultFollowedGroupGuard_MixedPayload_PartialFiltering(t *testing.T) {
+	const uid, space = "u1", "s1"
+	g := newGuard(
+		&fakeCategoryFilter{allowed: map[string]bool{
+			"g-keep":         true, // survives both stages
+			"g-no-member":    true, // survives Stage 1, dropped at Stage 2
+			"g-also-keep":    true, // survives both stages
+			"g-wrong-space":  true, // survives Stage 1, dropped at Stage 2
+			// g-no-category is absent → Stage 1 drops it
+		}},
+		&fakeChannelAuth{rejectWith: map[string]error{
+			uid + "|" + space + "|g-no-member":   convext.ErrChannelForbidden,
+			uid + "|" + space + "|g-wrong-space": convext.ErrChannelForbidden,
+		}},
+	)
+	out, err := g.FilterDefaultFollowed(uid, space, []string{
+		"g-keep", "g-no-member", "g-also-keep", "g-wrong-space", "g-no-category",
+	})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"g-keep", "g-also-keep"}, out,
+		"only groups passing BOTH stages survive — mixed payloads with "+
+			"some attacker-injected IDs and some legitimate ones produce the "+
+			"legitimate-only subset, not an all-or-nothing rejection")
+}


### PR DESCRIPTION
## Summary

Closes #151.

Default-followed groups (`group_setting.category_id IS NOT NULL` with no `user_conversation_ext` row) appear in the follow tab via `buildFollowItems` regardless of ext-row presence, but two write paths silently broke for those groups:

- **`PUT /v1/follow/sort` 400 "sort target not found"** (symptom #1, interactive): `db.UpdateSort` required every payload item to have an existing ext row. The very groups the display side promoted (categorized only, never touched) were the ones the write side rejected — first-time drag-sort always failed.
- **`OnThreadCreated` fan-out silently skipped users** (symptom #2): `selectEligibleForFanoutTx` filters fan-out targets by `auto_follow_threads=1 AND group_unfollowed=0` against `user_conversation_ext`. Users whose follow status was implied only via category had no ext row → never received new threads in those groups.

Both symptoms share a root cause: there is no initialization / backfill that materializes ext rows for groups that were placed in a category before the follow-tab feature shipped.

## Fix

Materialize the ext row on first interaction, gated by a new `DefaultFollowedGroupGuard` that authorizes `(uid, spaceID, group_no)` before any DB write.

### Authorization chain (`modules/message/1module.go` `defaultFollowedGroupGuard`)

```
Stage 1: group_setting INNER JOIN group_category WHERE gc.status != 2
         (rejects: NULL category_id, soft-deleted category, attacker-injected IDs)
Stage 2: threadAuthChecker.AuthorizeChannelFollow per surviving group
         (rejects: non-member, wrong-Space, Disband, external sourceSpaceID mismatch)
```

### Call-site integration

- `PUT /v1/follow/sort` handler runs `Service.AuthorizeAndMaterializeDefaultFollowedGroups` **before** `db.UpdateSort`. `db.UpdateSort` stays strict — any client-injected fake `group_no` that did not survive the guard surfaces as `ErrSortTargetNotFound`, not a phantom materialization.
- `POST /v1/sidebar/sync` follow-tab path materializes after `buildFollowItems` + `mergeThreadEntries` for groups not present in `groupExts`. No explicit guard call here because the candidates already pass the same authority signals the rest of the sidebar relies on (`FilterRawConversationsBySpace` for membership/Space, `QueryCategorySettingsByGroupNos`'s live-CategoryID for category status); see inline comment for the full argument. Fail-open: a materialization error logs at Warn and does not block the sidebar response.
- DB layer uses `INSERT IGNORE` so a user's existing explicit choices (e.g. `auto_follow_threads=0`) are never overwritten.

### Schema-app invariant (review blocker fix)

`QueryCategorySettingsByGroupNos` previously SELECTed `gs.category_id` while the LEFT JOIN filtered `gc.status != 2`. The JOIN predicate enforces *live* category, but the SELECT returned the *persisted* (stale) field — so when a category was soft-deleted between `group_setting` write and read (TOCTOU race per `TestMoveGroupToCategory_TOCTOU_DanglingReference`, or `category_cleanup`-deferred state), `CategoryID` stayed non-NULL. The sidebar materialization branch then wrote `auto_follow_threads=1` rows for groups whose live model treats as not-followed — phantom fanout.

Fix expresses the live predicate once at the type/query layer:

- `QueryCategorySettingsByGroupNos` now SELECTs `gc.category_id` (JOIN-side column). JOIN miss yields `CategoryID = NULL`, collapsing all three "uncategorized" cases (no `gs` row / soft-deleted `gc` / missing `gc`) into one. Downstream `buildFollowItems` and the materialization loop both already gate on `cs.CategoryID == nil`; the bypass closes at the query layer with no caller changes.
- `GroupCategorySetting.CategoryID` doc spells out the new live semantics and enumerates the three NULL cases.
- `FilterDefaultFollowedGroups` (guard Stage 1, INNER JOIN) carries a cross-reference so the two JOIN expressions stay in lockstep.

### Threat model addressed

| Attack input | Layer that rejects |
|---|---|
| Completely unknown `group_no` | Stage 1 (no `group_setting` row) |
| Soft-deleted category referenced by `group_setting` | Stage 1 (`gc.status != 2`) + `QueryCategorySettingsByGroupNos` returns `CategoryID=nil` |
| User left group but `group_setting` row persists | Stage 2 (`ExistMember=false`) |
| Group categorized in Space A, sort submitted in Space B | Stage 2 (Space visibility) |
| External group with mismatched `sourceSpaceID` | Stage 2 (external-group fallback) |
| Disbanded group | Stage 2 (explicit Disband rejection) |
| Handler skips authorize step | DB layer strict — `ErrSortTargetNotFound` |
| Guard not injected (misconfiguration) | Service returns `ErrDefaultFollowedGuardNotConfigured` (fail-loud sentinel, not silent success) |

### Observable behavior changes

| Scenario | Before | After |
|---|---|---|
| First drag-sort of a categorized group | 400 sort target not found | succeeds, ext row materialized |
| New thread in a categorized group, user never followed it | silently missing from follow tab | appears in follow tab (next sidebar sync) |
| Group whose `group_setting.category_id` points at a soft-deleted category | shown in follow tab nested under the deleted category (phantom UX) | excluded from follow tab entirely |

The last row is a side effect of the schema-app invariant fix — `QueryCategorySettingsByGroupNos` no longer surfaces stale CategoryID values to `buildFollowItems`. This matches the documented contract from `TestMoveGroupToCategory_TOCTOU_DanglingReference` ("soft-deleted category equivalent to not-found") and is a UX improvement (clients previously could render a group nested under a deleted category and have the follow-up call silently fail).

### Same-shape bug elsewhere (flagged, NOT fixed)

`modules/category/db_group_setting.go` `queryUserGroupsInSpace` (used by `/v1/category` list) has the identical pattern — SELECTs `gs.category_id` without joining `gc`. A user's `/v1/category` response can carry a `category_id` pointing at a soft-deleted category; the client uses it in a follow-up call, which silently fails. Inline TODO comment added but NOT fixed here, for two reasons: (a) scope of #151 is the follow tab / sidebar materialization; (b) the API consumer may rely on stale ids to render an "uncategorize-after-delete" UI affordance — needs PM input before changing user-visible behaviour. Track this as a follow-up.

## Test plan

- [x] DB layer (`bugfix_test.go`): strict-semantics regressions for missing group / DM / thread; idempotent INSERT IGNORE.
- [x] Materialization helper (`bugfix_test.go`): creates rows with `auto_follow_threads=1`; idempotent on existing rows; empty-input no-op.
- [x] Service layer (`service_test.go`): guard filter / guard error propagates / no-guard returns sentinel / empty input / **spaceID forwarded and cross-Space leak prevented**.
- [x] Handler layer (`api_test.go`): authorize runs before db; no-group-candidates skips the gate; authorize error short-circuits before db.
- [x] Guard unit (`default_followed_group_guard_test.go`, 9 cases stubbing both stages): happy path, Stage 1 drops, Stage 2 drops (non-member / Disband / cross-Space), Stage 1/2 infra-error propagation, empty input short-circuit, mixed payload partial filtering.
- [x] **Guard E2E** (`default_followed_group_guard_e2e_test.go`, 8 sub-cases) against real `group` + `group_member` + `group_setting` + `group_category` rows through the full production chain: every rejection / acceptance reason exercised end-to-end, including the soft-deleted-category case.
- [x] Sidebar integration (`api_sidebar_integration_test.go`):
  - default-followed group materialized with `auto_follow_threads=1` on `/v1/sidebar/sync`;
  - **Scene 7h**: group whose `group_setting.category_id` points at a soft-deleted `group_category` is excluded from follow tab AND not materialized (review blocker regression, RED-verified by reverting the SQL fix).
- [x] `go test -tags=integration -race -p 1 ./modules/conversation_ext/... ./modules/message/...` → all pass
- [x] `go vet ./...` → clean

## Notes for reviewers

- Stage 2 worst-case latency on `/v1/follow/sort`: up to 500 sequential `AuthorizeChannelFollow` calls. Stage 1 typically narrows to a handful for a real user. Batching is not done here (would require touching `modules/group` for a batch `ExistMember`); trade-off documented inline, with the monitoring trigger called out.
- The E2E test had to explicitly pin `group_setting.category_id` to `COLLATE utf8mb4_general_ci` to JOIN cleanly against `group_category` — same production schema drift reported in #150. Until #150's forward-repair migration lands, the guard's Stage 1 will surface that drift as a hard error (5xx on `/v1/follow/sort`) rather than silently allowing materialization. Documented inline.
- Pre-existing missed threads are NOT retroactively backfilled. Threads created before a user's first post-fix `sidebar/sync` for a given default-followed group remain missing for that user until they explicitly visit/follow them. A one-shot backfill migration is feasible as a follow-up but deemed out of scope here.