### PR TITLE
feat(manager): add PUT /spaces/:space_id to update space profile

### DIFF
--- a/modules/space/api_manager.go
+++ b/modules/space/api_manager.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/db"
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -14,11 +15,14 @@ import (
 	"go.uber.org/zap"
 )
 
-// 空间基础字段长度上限，与 sql/20260307000002_space_legacy01.sql 中的 VARCHAR 一致。
+// 空间基础字段长度上限，单位为**字符（rune）**，与 sql/20260307000002_space_legacy01.sql
+// 中的 VARCHAR(N) 语义一致 —— MySQL VARCHAR(N) 限制的是字符数而非字节数（utf8mb4
+// 下一个汉字仍计为 1）。因此校验必须用 utf8.RuneCountInString 而非 len()，
+// 否则 34 个汉字（102 字节）会被误拒，但 schema 完全能容纳。
 const (
-	managerSpaceNameMaxLen        = 100
-	managerSpaceDescriptionMaxLen = 500
-	managerSpaceLogoMaxLen        = 200
+	managerSpaceNameMaxChars        = 100
+	managerSpaceDescriptionMaxChars = 500
+	managerSpaceLogoMaxChars        = 200
 )
 
 // 管理端分页上限，防止恶意/误操作的大页请求把全表拉出来。
@@ -478,28 +482,29 @@ func (m *Manager) updateSpaceProfile(c *wkhttp.Context) {
 	}
 
 	// 字段级校验：在查 DB 前先把请求侧问题拦下。
+	// 长度单位为字符（rune），与 MySQL VARCHAR(N) 的字符语义一致。
 	if req.Name != nil {
 		trimmed := strings.TrimSpace(*req.Name)
 		if trimmed == "" {
 			c.ResponseError(errors.New("空间名称不能为空"))
 			return
 		}
-		if len(trimmed) > managerSpaceNameMaxLen {
-			c.ResponseError(fmt.Errorf("空间名称不能超过 %d 个字节", managerSpaceNameMaxLen))
+		if utf8.RuneCountInString(trimmed) > managerSpaceNameMaxChars {
+			c.ResponseError(fmt.Errorf("空间名称不能超过 %d 个字符", managerSpaceNameMaxChars))
 			return
 		}
 		req.Name = &trimmed
 	}
 	if req.Description != nil {
 		trimmed := strings.TrimSpace(*req.Description)
-		if len(trimmed) > managerSpaceDescriptionMaxLen {
-			c.ResponseError(fmt.Errorf("空间描述不能超过 %d 个字节", managerSpaceDescriptionMaxLen))
+		if utf8.RuneCountInString(trimmed) > managerSpaceDescriptionMaxChars {
+			c.ResponseError(fmt.Errorf("空间描述不能超过 %d 个字符", managerSpaceDescriptionMaxChars))
 			return
 		}
 		req.Description = &trimmed
 	}
-	if req.Logo != nil && len(*req.Logo) > managerSpaceLogoMaxLen {
-		c.ResponseError(fmt.Errorf("Logo 不能超过 %d 个字节", managerSpaceLogoMaxLen))
+	if req.Logo != nil && utf8.RuneCountInString(*req.Logo) > managerSpaceLogoMaxChars {
+		c.ResponseError(fmt.Errorf("Logo 不能超过 %d 个字符", managerSpaceLogoMaxChars))
 		return
 	}
 	if req.JoinMode != nil && (*req.JoinMode < JoinModeDirect || *req.JoinMode > JoinModeApproval) {
@@ -542,7 +547,8 @@ func (m *Manager) updateSpaceProfile(c *wkhttp.Context) {
 		}
 	}
 
-	if err = m.managerDB.updateSpaceProfile(spaceId, req.Name, req.Description, req.Logo, req.JoinMode, req.MaxUsers); err != nil {
+	before, err := m.managerDB.updateSpaceProfile(spaceId, req.Name, req.Description, req.Logo, req.JoinMode, req.MaxUsers)
+	if err != nil {
 		// 事务内 SELECT FOR UPDATE 用 sentinel error 报告并发场景；HTTP 层映射为 4xx 提示。
 		// 不能依赖 RowsAffected 区分：MySQL 默认返回变更行数而非匹配行数，
 		// 字段值与现值完全相同的幂等请求会被误判为"行不存在"。
@@ -558,25 +564,25 @@ func (m *Manager) updateSpaceProfile(c *wkhttp.Context) {
 		c.ResponseError(errors.New("更新空间信息失败"))
 		return
 	}
-	// 审计日志：记录 spaceId、操作人，及每个字段的旧→新值（仅记录请求中显式修改的字段）。
+	// 审计日志：from 值取自事务内锁定时的快照（before），避免并发更新窗口下 tx 外读到 stale 旧值。
 	fields := []zap.Field{
 		zap.String("spaceId", spaceId),
 		zap.String("operator", c.GetLoginUID()),
 	}
 	if req.Name != nil {
-		fields = append(fields, zap.String("nameFrom", sp.Name), zap.String("nameTo", *req.Name))
+		fields = append(fields, zap.String("nameFrom", before.Name), zap.String("nameTo", *req.Name))
 	}
 	if req.Description != nil {
-		fields = append(fields, zap.String("descFrom", sp.Description), zap.String("descTo", *req.Description))
+		fields = append(fields, zap.String("descFrom", before.Description), zap.String("descTo", *req.Description))
 	}
 	if req.Logo != nil {
-		fields = append(fields, zap.String("logoFrom", sp.Logo), zap.String("logoTo", *req.Logo))
+		fields = append(fields, zap.String("logoFrom", before.Logo), zap.String("logoTo", *req.Logo))
 	}
 	if req.JoinMode != nil {
-		fields = append(fields, zap.Int("joinModeFrom", sp.JoinMode), zap.Int("joinModeTo", *req.JoinMode))
+		fields = append(fields, zap.Int("joinModeFrom", before.JoinMode), zap.Int("joinModeTo", *req.JoinMode))
 	}
 	if req.MaxUsers != nil {
-		fields = append(fields, zap.Int("maxUsersFrom", sp.MaxUsers), zap.Int("maxUsersTo", *req.MaxUsers))
+		fields = append(fields, zap.Int("maxUsersFrom", before.MaxUsers), zap.Int("maxUsersTo", *req.MaxUsers))
 	}
 	m.Info("管理员修改空间信息", fields...)
 	c.ResponseOK()

--- a/modules/space/api_manager.go
+++ b/modules/space/api_manager.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/db"
@@ -11,6 +12,13 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"go.uber.org/zap"
+)
+
+// 空间基础字段长度上限，与 sql/20260307000002_space_legacy01.sql 中的 VARCHAR 一致。
+const (
+	managerSpaceNameMaxLen        = 100
+	managerSpaceDescriptionMaxLen = 500
+	managerSpaceLogoMaxLen        = 200
 )
 
 // 管理端分页上限，防止恶意/误操作的大页请求把全表拉出来。
@@ -72,6 +80,7 @@ func (m *Manager) Route(r *wkhttp.WKHttp) {
 
 		// 空间单体
 		auth.GET("/spaces/:space_id", m.detail)                      // 空间详情
+		auth.PUT("/spaces/:space_id", m.updateSpaceProfile)          // 修改基础信息（名称/加入方式/成员上限等）
 		auth.DELETE("/spaces/:space_id", m.forceDisband)             // 强制解散
 		auth.PUT("/spaces/:space_id/status/:status", m.liftBan)      // 封禁(2) / 解禁(1)
 
@@ -428,6 +437,148 @@ func (m *Manager) liftBan(c *wkhttp.Context) {
 	// 刷新 ParseChannelID 缓存：loadKnownSpaceIDs 只加载 status=1 的空间，
 	// 封禁 1→2 需要把该 spaceId 从缓存中剔除，解禁 2→1 需要加回去，否则路由会走偏。
 	go m.space.loadKnownSpaceIDs()
+	c.ResponseOK()
+}
+
+// managerUpdateSpaceProfileReq 管理端修改空间基础信息请求体。
+// 所有字段可选，但至少需要提供一个；未提供（nil）的字段保持不变。
+type managerUpdateSpaceProfileReq struct {
+	Name        *string `json:"name"`
+	Description *string `json:"description"`
+	Logo        *string `json:"logo"`
+	JoinMode    *int    `json:"join_mode"`
+	MaxUsers    *int    `json:"max_users"`
+}
+
+// updateSpaceProfile 管理端修改空间基础信息：名称、描述、Logo、加入方式、成员上限。
+//
+// 已解散空间禁止修改；max_users 若 > 0 则与当前活跃成员数对比拒绝低于的请求。
+// 该 max_users 校验是**尽力而为**：成员计数与最终 UPDATE 不在同一事务，
+// 若并发 addMembers / 用户加入挤进窗口，可能出现 active > max_users 的瞬时不一致。
+// 这与现有 addMembers 主动绕过 max_users 的设计取舍一致，且本接口仅由管理员调用、频率极低。
+// max_users == 0 表示不限，规则上始终允许。
+func (m *Manager) updateSpaceProfile(c *wkhttp.Context) {
+	if !m.requireAdmin(c) {
+		return
+	}
+	spaceId := c.Param("space_id")
+	if spaceId == "" {
+		c.ResponseError(errors.New("空间ID不能为空"))
+		return
+	}
+
+	var req managerUpdateSpaceProfileReq
+	if err := c.BindJSON(&req); err != nil {
+		c.ResponseError(errors.New("请求参数错误"))
+		return
+	}
+	if req.Name == nil && req.Description == nil && req.Logo == nil && req.JoinMode == nil && req.MaxUsers == nil {
+		c.ResponseError(errors.New("至少需要提供 name / description / logo / join_mode / max_users 之一"))
+		return
+	}
+
+	// 字段级校验：在查 DB 前先把请求侧问题拦下。
+	if req.Name != nil {
+		trimmed := strings.TrimSpace(*req.Name)
+		if trimmed == "" {
+			c.ResponseError(errors.New("空间名称不能为空"))
+			return
+		}
+		if len(trimmed) > managerSpaceNameMaxLen {
+			c.ResponseError(fmt.Errorf("空间名称不能超过 %d 个字节", managerSpaceNameMaxLen))
+			return
+		}
+		req.Name = &trimmed
+	}
+	if req.Description != nil {
+		trimmed := strings.TrimSpace(*req.Description)
+		if len(trimmed) > managerSpaceDescriptionMaxLen {
+			c.ResponseError(fmt.Errorf("空间描述不能超过 %d 个字节", managerSpaceDescriptionMaxLen))
+			return
+		}
+		req.Description = &trimmed
+	}
+	if req.Logo != nil && len(*req.Logo) > managerSpaceLogoMaxLen {
+		c.ResponseError(fmt.Errorf("Logo 不能超过 %d 个字节", managerSpaceLogoMaxLen))
+		return
+	}
+	if req.JoinMode != nil && (*req.JoinMode < JoinModeDirect || *req.JoinMode > JoinModeApproval) {
+		c.ResponseError(errors.New("无效的加入模式，仅支持 0(直接加入) 或 1(需要审批)"))
+		return
+	}
+	if req.MaxUsers != nil && *req.MaxUsers < 0 {
+		c.ResponseError(errors.New("max_users 不能为负"))
+		return
+	}
+
+	sp, err := m.managerDB.querySpaceIncludeDisbanded(spaceId)
+	if err != nil {
+		m.Error("查询空间失败", zap.Error(err), zap.String("spaceId", spaceId))
+		c.ResponseError(errors.New("查询空间失败"))
+		return
+	}
+	if sp == nil {
+		c.ResponseError(errors.New("空间不存在"))
+		return
+	}
+	if sp.Status == SpaceStatusDisbanded {
+		c.ResponseError(errors.New("空间已解散，无法修改空间信息"))
+		return
+	}
+
+	// max_users > 0 时不得低于当前活跃成员数；0 表示不限，跳过校验。
+	// countActiveMembers 走的是 m.db（业务侧 session）而非 m.managerDB，与本文件其他 handler 一致；
+	// 两个 session 共享同一 *sql.DB 连接池，差异仅在 builder 包装，无功能性影响。
+	if req.MaxUsers != nil && *req.MaxUsers > 0 {
+		active, err := m.db.countActiveMembers(spaceId)
+		if err != nil {
+			m.Error("查询空间成员数失败", zap.Error(err), zap.String("spaceId", spaceId))
+			c.ResponseError(errors.New("查询空间成员数失败"))
+			return
+		}
+		if *req.MaxUsers < active {
+			c.ResponseError(fmt.Errorf("max_users (%d) 不能低于当前活跃成员数 (%d)", *req.MaxUsers, active))
+			return
+		}
+	}
+
+	if err = m.managerDB.updateSpaceProfile(spaceId, req.Name, req.Description, req.Logo, req.JoinMode, req.MaxUsers); err != nil {
+		// 事务内 SELECT FOR UPDATE 用 sentinel error 报告并发场景；HTTP 层映射为 4xx 提示。
+		// 不能依赖 RowsAffected 区分：MySQL 默认返回变更行数而非匹配行数，
+		// 字段值与现值完全相同的幂等请求会被误判为"行不存在"。
+		if errors.Is(err, ErrSpaceNotFound) {
+			c.ResponseError(errors.New("空间不存在"))
+			return
+		}
+		if errors.Is(err, ErrSpaceDisbandedForUpdate) {
+			c.ResponseError(errors.New("空间已解散，无法修改空间信息"))
+			return
+		}
+		m.Error("更新空间信息失败", zap.Error(err), zap.String("spaceId", spaceId))
+		c.ResponseError(errors.New("更新空间信息失败"))
+		return
+	}
+	// 审计日志：记录 spaceId、操作人，及每个字段的旧→新值（仅记录请求中显式修改的字段）。
+	fields := []zap.Field{
+		zap.String("spaceId", spaceId),
+		zap.String("operator", c.GetLoginUID()),
+	}
+	if req.Name != nil {
+		fields = append(fields, zap.String("nameFrom", sp.Name), zap.String("nameTo", *req.Name))
+	}
+	if req.Description != nil {
+		fields = append(fields, zap.String("descFrom", sp.Description), zap.String("descTo", *req.Description))
+	}
+	if req.Logo != nil {
+		fields = append(fields, zap.String("logoFrom", sp.Logo), zap.String("logoTo", *req.Logo))
+	}
+	if req.JoinMode != nil {
+		fields = append(fields, zap.Int("joinModeFrom", sp.JoinMode), zap.Int("joinModeTo", *req.JoinMode))
+	}
+	if req.MaxUsers != nil {
+		fields = append(fields, zap.Int("maxUsersFrom", sp.MaxUsers), zap.Int("maxUsersTo", *req.MaxUsers))
+	}
+	m.Info("管理员修改空间信息", fields...)
 	c.ResponseOK()
 }
 

--- a/modules/space/api_manager_test.go
+++ b/modules/space/api_manager_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -1272,4 +1273,312 @@ func TestManager_ListKeywordLikeEscape(t *testing.T) {
 	if len(resp.List) == 1 {
 		assert.Equal(t, "foo_bar", resp.List[0].Name)
 	}
+}
+
+// ==================== Update space profile ====================
+
+// readSpace 读取空间当前持久化的基础字段（绕过业务过滤，仅用于断言）。
+func readSpace(t *testing.T, spaceId string) *SpaceModel {
+	t.Helper()
+	sp, err := testSpaceDB.querySpaceByID(spaceId)
+	assert.NoError(t, err)
+	return sp
+}
+
+func TestManager_UpdateSpaceProfile(t *testing.T) {
+	s, _, err := setup(t)
+	assert.NoError(t, err)
+	token := adminToken(t)
+
+	t.Run("partial update of name only leaves other fields unchanged", func(t *testing.T) {
+		seedSpace(t, "mgr-upd-name", "old name", "u-owner", SpaceStatusNormal)
+		// 给空间补一些初始非默认值，便于断言"未变更"
+		_, err := testCtx.DB().Update("space").
+			Set("description", "orig desc").
+			Set("logo", "orig-logo").
+			Set("join_mode", JoinModeApproval).
+			Set("max_users", 50).
+			Where("space_id=?", "mgr-upd-name").Exec()
+		assert.NoError(t, err)
+
+		body := util.ToJson(map[string]interface{}{"name": "shiny new name"})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/v1/manager/spaces/mgr-upd-name", bytes.NewReader([]byte(body)))
+		req.Header.Set("token", token)
+		s.GetRoute().ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		sp := readSpace(t, "mgr-upd-name")
+		assert.NotNil(t, sp)
+		assert.Equal(t, "shiny new name", sp.Name)
+		assert.Equal(t, "orig desc", sp.Description)
+		assert.Equal(t, "orig-logo", sp.Logo)
+		assert.Equal(t, JoinModeApproval, sp.JoinMode)
+		assert.Equal(t, 50, sp.MaxUsers)
+	})
+
+	t.Run("update join_mode 0 -> 1", func(t *testing.T) {
+		seedSpace(t, "mgr-upd-jm", "jm space", "u-o-jm", SpaceStatusNormal)
+		body := util.ToJson(map[string]interface{}{"join_mode": JoinModeApproval})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/v1/manager/spaces/mgr-upd-jm", bytes.NewReader([]byte(body)))
+		req.Header.Set("token", token)
+		s.GetRoute().ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, JoinModeApproval, readSpace(t, "mgr-upd-jm").JoinMode)
+	})
+
+	t.Run("update max_users (member limit)", func(t *testing.T) {
+		seedSpace(t, "mgr-upd-cap", "cap space", "u-o-cap", SpaceStatusNormal)
+		body := util.ToJson(map[string]interface{}{"max_users": 200})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/v1/manager/spaces/mgr-upd-cap", bytes.NewReader([]byte(body)))
+		req.Header.Set("token", token)
+		s.GetRoute().ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, 200, readSpace(t, "mgr-upd-cap").MaxUsers)
+	})
+
+	t.Run("max_users = 0 means unlimited and is allowed regardless of current count", func(t *testing.T) {
+		seedSpace(t, "mgr-upd-zero", "zero cap", "u-o-z", SpaceStatusNormal)
+		// 当前有 5 个成员
+		for i := 0; i < 4; i++ {
+			assert.NoError(t, testSpaceDB.insertMemberNoTx(&MemberModel{
+				SpaceId: "mgr-upd-zero", UID: fmt.Sprintf("m-z-%d", i), Role: 0, Status: 1,
+			}))
+		}
+		body := util.ToJson(map[string]interface{}{"max_users": 0})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/v1/manager/spaces/mgr-upd-zero", bytes.NewReader([]byte(body)))
+		req.Header.Set("token", token)
+		s.GetRoute().ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, 0, readSpace(t, "mgr-upd-zero").MaxUsers)
+	})
+
+	t.Run("max_users equal to current active members is allowed", func(t *testing.T) {
+		seedSpace(t, "mgr-upd-eq", "eq cap", "u-o-eq", SpaceStatusNormal)
+		for i := 0; i < 2; i++ {
+			assert.NoError(t, testSpaceDB.insertMemberNoTx(&MemberModel{
+				SpaceId: "mgr-upd-eq", UID: fmt.Sprintf("m-eq-%d", i), Role: 0, Status: 1,
+			}))
+		}
+		// owner + 2 = 3 active members
+		body := util.ToJson(map[string]interface{}{"max_users": 3})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/v1/manager/spaces/mgr-upd-eq", bytes.NewReader([]byte(body)))
+		req.Header.Set("token", token)
+		s.GetRoute().ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, 3, readSpace(t, "mgr-upd-eq").MaxUsers)
+	})
+
+	t.Run("combined update of name + join_mode + max_users", func(t *testing.T) {
+		seedSpace(t, "mgr-upd-combo", "combo old", "u-o-c", SpaceStatusNormal)
+		body := util.ToJson(map[string]interface{}{
+			"name":      "combo new",
+			"join_mode": JoinModeApproval,
+			"max_users": 123,
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/v1/manager/spaces/mgr-upd-combo", bytes.NewReader([]byte(body)))
+		req.Header.Set("token", token)
+		s.GetRoute().ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		sp := readSpace(t, "mgr-upd-combo")
+		assert.Equal(t, "combo new", sp.Name)
+		assert.Equal(t, JoinModeApproval, sp.JoinMode)
+		assert.Equal(t, 123, sp.MaxUsers)
+	})
+
+	t.Run("update description and logo", func(t *testing.T) {
+		seedSpace(t, "mgr-upd-dl", "dl space", "u-o-dl", SpaceStatusNormal)
+		body := util.ToJson(map[string]interface{}{
+			"description": "shiny description",
+			"logo":        "https://cdn.example/logo.png",
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/v1/manager/spaces/mgr-upd-dl", bytes.NewReader([]byte(body)))
+		req.Header.Set("token", token)
+		s.GetRoute().ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		sp := readSpace(t, "mgr-upd-dl")
+		assert.Equal(t, "shiny description", sp.Description)
+		assert.Equal(t, "https://cdn.example/logo.png", sp.Logo)
+	})
+
+	t.Run("idempotent update with identical values returns 200 not 404", func(t *testing.T) {
+		// 回归 #2：MySQL 默认 RowsAffected = 实际变更行数，
+		// 旧实现把 0 当作"空间不存在"会导致幂等重放被误判为失败。
+		seedSpace(t, "mgr-upd-idem", "same name", "u-o-idem", SpaceStatusNormal)
+		body := util.ToJson(map[string]interface{}{"name": "same name"})
+
+		// 第一次请求：可能落到 updated_at 变更（不同秒），任意结果都应是 200
+		w1 := httptest.NewRecorder()
+		req1, _ := http.NewRequest("PUT", "/v1/manager/spaces/mgr-upd-idem", bytes.NewReader([]byte(body)))
+		req1.Header.Set("token", token)
+		s.GetRoute().ServeHTTP(w1, req1)
+		assert.Equal(t, http.StatusOK, w1.Code)
+
+		// 第二次：同一秒内重放，所有字段都和现值一致，affected_rows 极可能为 0
+		w2 := httptest.NewRecorder()
+		req2, _ := http.NewRequest("PUT", "/v1/manager/spaces/mgr-upd-idem", bytes.NewReader([]byte(body)))
+		req2.Header.Set("token", token)
+		s.GetRoute().ServeHTTP(w2, req2)
+		assert.Equal(t, http.StatusOK, w2.Code, "幂等重放不应被误判为不存在")
+		assert.NotContains(t, w2.Body.String(), "不存在")
+	})
+
+	t.Run("trim whitespace on name and persist trimmed value", func(t *testing.T) {
+		seedSpace(t, "mgr-upd-trim", "trim before", "u-o-t", SpaceStatusNormal)
+		body := util.ToJson(map[string]interface{}{"name": "   padded   "})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/v1/manager/spaces/mgr-upd-trim", bytes.NewReader([]byte(body)))
+		req.Header.Set("token", token)
+		s.GetRoute().ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "padded", readSpace(t, "mgr-upd-trim").Name)
+	})
+}
+
+// TestManagerDB_UpdateSpaceProfile_TOCTOU 回归 #1：
+// 事务内 SELECT FOR UPDATE 应在空间解散后拒绝继续 UPDATE，
+// 而不是依赖 handler 层 guard——guard 与 UPDATE 之间的窗口必须被 DB 关掉。
+func TestManagerDB_UpdateSpaceProfile_TOCTOU(t *testing.T) {
+	_, _, err := setup(t)
+	assert.NoError(t, err)
+	mdb := newManagerDB(testCtx.DB())
+
+	t.Run("returns ErrSpaceNotFound for missing space", func(t *testing.T) {
+		name := "x"
+		err := mdb.updateSpaceProfile("nope-not-exists", &name, nil, nil, nil, nil)
+		assert.ErrorIs(t, err, ErrSpaceNotFound)
+	})
+
+	t.Run("returns ErrSpaceDisbandedForUpdate when space is already disbanded", func(t *testing.T) {
+		// 模拟 handler guard 通过后被并发解散：直接 seed 一个已解散空间，
+		// 调用 DB 方法应被事务内的 status 校验拦下。
+		seedSpace(t, "mgr-upd-toctou", "dying", "u-o-toc", SpaceStatusDisbanded)
+		name := "new name"
+		err := mdb.updateSpaceProfile("mgr-upd-toctou", &name, nil, nil, nil, nil)
+		assert.ErrorIs(t, err, ErrSpaceDisbandedForUpdate)
+
+		// 关键断言：UPDATE 必须没有真的执行，name 仍是原值
+		// querySpaceByID 过滤掉 disbanded，这里用 manager 查询绕过过滤。
+		sp, qErr := mdb.querySpaceIncludeDisbanded("mgr-upd-toctou")
+		assert.NoError(t, qErr)
+		assert.NotNil(t, sp)
+		assert.Equal(t, "dying", sp.Name, "事务内拒绝后字段不应被改写")
+	})
+
+	t.Run("no-op when all fields are nil on existing space", func(t *testing.T) {
+		seedSpace(t, "mgr-upd-noop", "untouched", "u-o-noop", SpaceStatusNormal)
+		err := mdb.updateSpaceProfile("mgr-upd-noop", nil, nil, nil, nil, nil)
+		assert.NoError(t, err)
+		sp, qErr := testSpaceDB.querySpaceByID("mgr-upd-noop")
+		assert.NoError(t, qErr)
+		assert.Equal(t, "untouched", sp.Name)
+	})
+}
+
+func TestManager_UpdateSpaceProfile_Validation(t *testing.T) {
+	s, _, err := setup(t)
+	assert.NoError(t, err)
+	token := adminToken(t)
+
+	seedSpace(t, "mgr-upd-v", "v space", "u-o-v", SpaceStatusNormal)
+
+	doPUT := func(body string) *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/v1/manager/spaces/mgr-upd-v", bytes.NewReader([]byte(body)))
+		req.Header.Set("token", token)
+		s.GetRoute().ServeHTTP(w, req)
+		return w
+	}
+
+	t.Run("reject empty body (no fields)", func(t *testing.T) {
+		w := doPUT(`{}`)
+		assert.NotEqual(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("reject empty/whitespace name", func(t *testing.T) {
+		for _, name := range []string{"", "   "} {
+			w := doPUT(util.ToJson(map[string]interface{}{"name": name}))
+			assert.NotEqual(t, http.StatusOK, w.Code, "empty name %q should be rejected", name)
+		}
+	})
+
+	t.Run("reject name longer than 100 chars", func(t *testing.T) {
+		long := ""
+		for i := 0; i < 101; i++ {
+			long += "a"
+		}
+		w := doPUT(util.ToJson(map[string]interface{}{"name": long}))
+		assert.NotEqual(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("reject description longer than 500 chars", func(t *testing.T) {
+		long := strings.Repeat("d", 501)
+		w := doPUT(util.ToJson(map[string]interface{}{"description": long}))
+		assert.NotEqual(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("reject logo longer than 200 chars", func(t *testing.T) {
+		long := strings.Repeat("l", 201)
+		w := doPUT(util.ToJson(map[string]interface{}{"logo": long}))
+		assert.NotEqual(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("reject invalid join_mode", func(t *testing.T) {
+		for _, jm := range []int{-1, 2, 99} {
+			w := doPUT(util.ToJson(map[string]interface{}{"join_mode": jm}))
+			assert.NotEqual(t, http.StatusOK, w.Code, "join_mode=%d should be rejected", jm)
+		}
+	})
+
+	t.Run("reject negative max_users", func(t *testing.T) {
+		w := doPUT(util.ToJson(map[string]interface{}{"max_users": -1}))
+		assert.NotEqual(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("reject max_users below current active member count", func(t *testing.T) {
+		// 把空间塞到 5 个活跃成员
+		for i := 0; i < 4; i++ {
+			assert.NoError(t, testSpaceDB.insertMemberNoTx(&MemberModel{
+				SpaceId: "mgr-upd-v", UID: fmt.Sprintf("under-%d", i), Role: 0, Status: 1,
+			}))
+		}
+		w := doPUT(util.ToJson(map[string]interface{}{"max_users": 2}))
+		assert.NotEqual(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "成员")
+	})
+
+	t.Run("reject when space does not exist", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		body := util.ToJson(map[string]interface{}{"name": "x"})
+		req, _ := http.NewRequest("PUT", "/v1/manager/spaces/does-not-exist", bytes.NewReader([]byte(body)))
+		req.Header.Set("token", token)
+		s.GetRoute().ServeHTTP(w, req)
+		assert.NotEqual(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("reject on disbanded space", func(t *testing.T) {
+		seedSpace(t, "mgr-upd-dead", "dead", "u-o-d", SpaceStatusDisbanded)
+		w := httptest.NewRecorder()
+		body := util.ToJson(map[string]interface{}{"name": "x"})
+		req, _ := http.NewRequest("PUT", "/v1/manager/spaces/mgr-upd-dead", bytes.NewReader([]byte(body)))
+		req.Header.Set("token", token)
+		s.GetRoute().ServeHTTP(w, req)
+		assert.NotEqual(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "解散")
+	})
+
+	t.Run("reject without admin token", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		body := util.ToJson(map[string]interface{}{"name": "x"})
+		req, _ := http.NewRequest("PUT", "/v1/manager/spaces/mgr-upd-v", bytes.NewReader([]byte(body)))
+		// 无 token
+		s.GetRoute().ServeHTTP(w, req)
+		assert.NotEqual(t, http.StatusOK, w.Code)
+	})
 }

--- a/modules/space/api_manager_test.go
+++ b/modules/space/api_manager_test.go
@@ -1451,8 +1451,9 @@ func TestManagerDB_UpdateSpaceProfile_TOCTOU(t *testing.T) {
 
 	t.Run("returns ErrSpaceNotFound for missing space", func(t *testing.T) {
 		name := "x"
-		err := mdb.updateSpaceProfile("nope-not-exists", &name, nil, nil, nil, nil)
+		before, err := mdb.updateSpaceProfile("nope-not-exists", &name, nil, nil, nil, nil)
 		assert.ErrorIs(t, err, ErrSpaceNotFound)
+		assert.Nil(t, before)
 	})
 
 	t.Run("returns ErrSpaceDisbandedForUpdate when space is already disbanded", func(t *testing.T) {
@@ -1460,8 +1461,9 @@ func TestManagerDB_UpdateSpaceProfile_TOCTOU(t *testing.T) {
 		// 调用 DB 方法应被事务内的 status 校验拦下。
 		seedSpace(t, "mgr-upd-toctou", "dying", "u-o-toc", SpaceStatusDisbanded)
 		name := "new name"
-		err := mdb.updateSpaceProfile("mgr-upd-toctou", &name, nil, nil, nil, nil)
+		before, err := mdb.updateSpaceProfile("mgr-upd-toctou", &name, nil, nil, nil, nil)
 		assert.ErrorIs(t, err, ErrSpaceDisbandedForUpdate)
+		assert.Nil(t, before)
 
 		// 关键断言：UPDATE 必须没有真的执行，name 仍是原值
 		// querySpaceByID 过滤掉 disbanded，这里用 manager 查询绕过过滤。
@@ -1473,11 +1475,30 @@ func TestManagerDB_UpdateSpaceProfile_TOCTOU(t *testing.T) {
 
 	t.Run("no-op when all fields are nil on existing space", func(t *testing.T) {
 		seedSpace(t, "mgr-upd-noop", "untouched", "u-o-noop", SpaceStatusNormal)
-		err := mdb.updateSpaceProfile("mgr-upd-noop", nil, nil, nil, nil, nil)
+		before, err := mdb.updateSpaceProfile("mgr-upd-noop", nil, nil, nil, nil, nil)
 		assert.NoError(t, err)
+		assert.NotNil(t, before)
+		assert.Equal(t, "untouched", before.Name, "no-op 仍应返回 pre-update 快照")
 		sp, qErr := testSpaceDB.querySpaceByID("mgr-upd-noop")
 		assert.NoError(t, qErr)
 		assert.Equal(t, "untouched", sp.Name)
+	})
+
+	t.Run("returns pre-update snapshot for audit logging", func(t *testing.T) {
+		// 回归 Jerry-Xin 的 warning：handler 用返回的 before 快照写 audit log，
+		// 不再使用 tx 外的 sp，避免并发更新窗口下旧值 stale。
+		seedSpace(t, "mgr-upd-snap", "original", "u-o-snap", SpaceStatusNormal)
+		newName := "renamed"
+		before, err := mdb.updateSpaceProfile("mgr-upd-snap", &newName, nil, nil, nil, nil)
+		assert.NoError(t, err)
+		assert.NotNil(t, before)
+		assert.Equal(t, "original", before.Name, "before 应为 UPDATE 前的值")
+		assert.Equal(t, SpaceStatusNormal, before.Status)
+
+		// 落库值应是新值
+		sp, qErr := testSpaceDB.querySpaceByID("mgr-upd-snap")
+		assert.NoError(t, qErr)
+		assert.Equal(t, "renamed", sp.Name)
 	})
 }
 
@@ -1509,11 +1530,29 @@ func TestManager_UpdateSpaceProfile_Validation(t *testing.T) {
 	})
 
 	t.Run("reject name longer than 100 chars", func(t *testing.T) {
-		long := ""
-		for i := 0; i < 101; i++ {
-			long += "a"
-		}
+		long := strings.Repeat("a", 101)
 		w := doPUT(util.ToJson(map[string]interface{}{"name": long}))
+		assert.NotEqual(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("accept CJK name up to 100 characters (~300 bytes utf8mb4)", func(t *testing.T) {
+		// 回归 Jerry-Xin 的 Critical：旧实现用 len() 按字节算，100 个汉字 = 300 字节会被误拒。
+		// MySQL VARCHAR(100) 在 utf8mb4 下是 100 个字符，应该接受。
+		seedSpace(t, "mgr-upd-cjk-ok", "old", "u-o-cjk", SpaceStatusNormal)
+		name := strings.Repeat("空", 100) // 100 chars, 300 bytes
+		w := httptest.NewRecorder()
+		body := util.ToJson(map[string]interface{}{"name": name})
+		req, _ := http.NewRequest("PUT", "/v1/manager/spaces/mgr-upd-cjk-ok", bytes.NewReader([]byte(body)))
+		req.Header.Set("token", token)
+		s.GetRoute().ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code, "100 个汉字应该被接受")
+		assert.Equal(t, name, readSpace(t, "mgr-upd-cjk-ok").Name)
+	})
+
+	t.Run("reject CJK name longer than 100 characters", func(t *testing.T) {
+		// 边界：101 个汉字应该被拒（字符数超限）。
+		name := strings.Repeat("空", 101)
+		w := doPUT(util.ToJson(map[string]interface{}{"name": name}))
 		assert.NotEqual(t, http.StatusOK, w.Code)
 	})
 

--- a/modules/space/db_manager.go
+++ b/modules/space/db_manager.go
@@ -209,6 +209,85 @@ func (d *managerDB) updateSpaceStatus(spaceId string, status int) error {
 	return err
 }
 
+// ErrSpaceNotFound 空间不存在（事务内 SELECT FOR UPDATE 未命中）
+var ErrSpaceNotFound = errors.New("space not found")
+
+// ErrSpaceDisbandedForUpdate 事务内发现空间已解散，禁止更新基础信息
+var ErrSpaceDisbandedForUpdate = errors.New("space already disbanded")
+
+// updateSpaceProfile 管理端部分更新空间基础字段。
+//
+// 用 SELECT ... FOR UPDATE 在事务内锁定 space 行并原子校验存在性 + 非 Disbanded 状态，
+// 关闭 handler 层 guard 与 UPDATE 之间的 TOCTOU 窗口：
+// 即便 forceDisbandSpace 在 handler 通过 guard 后并发执行，它会阻塞到本事务结束，
+// 或本事务的 SELECT 看到 status=Disbanded 并直接返回 ErrSpaceDisbandedForUpdate。
+//
+// 存在性 / 已解散用 sentinel error 表达，**不依赖 RowsAffected**：
+// MySQL 默认 affected_rows 是「真正变更的行数」，对于"新值与旧值完全相同"的幂等请求
+// 会返回 0，与"行不存在"无法区分。强制走事务 + 显式校验消除歧义。
+//
+// nil 参数不变更；调用方需保证至少有一个非 nil（否则 no-op 直接返回 nil）。
+func (d *managerDB) updateSpaceProfile(
+	spaceId string,
+	name *string,
+	description *string,
+	logo *string,
+	joinMode *int,
+	maxUsers *int,
+) error {
+	tx, err := d.session.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	var status int
+	found, err := tx.SelectBySql(
+		"SELECT status FROM space WHERE space_id=? FOR UPDATE",
+		spaceId,
+	).Load(&status)
+	if err != nil {
+		return fmt.Errorf("lock space row: %w", err)
+	}
+	if found == 0 {
+		return ErrSpaceNotFound
+	}
+	if status == SpaceStatusDisbanded {
+		return ErrSpaceDisbandedForUpdate
+	}
+
+	builder := tx.Update("space")
+	changed := false
+	if name != nil {
+		builder = builder.Set("name", *name)
+		changed = true
+	}
+	if description != nil {
+		builder = builder.Set("description", *description)
+		changed = true
+	}
+	if logo != nil {
+		builder = builder.Set("logo", *logo)
+		changed = true
+	}
+	if joinMode != nil {
+		builder = builder.Set("join_mode", *joinMode)
+		changed = true
+	}
+	if maxUsers != nil {
+		builder = builder.Set("max_users", *maxUsers)
+		changed = true
+	}
+	if !changed {
+		return tx.Commit()
+	}
+	builder = builder.Set("updated_at", time.Now())
+	if _, err := builder.Where("space_id=?", spaceId).Exec(); err != nil {
+		return fmt.Errorf("update space profile: %w", err)
+	}
+	return tx.Commit()
+}
+
 // upsertMembers 批量添加/重新激活成员（单一事务，部分失败则全部回滚）
 func (d *managerDB) upsertMembers(spaceId string, uids []string) error {
 	if len(uids) == 0 {

--- a/modules/space/db_manager.go
+++ b/modules/space/db_manager.go
@@ -226,7 +226,10 @@ var ErrSpaceDisbandedForUpdate = errors.New("space already disbanded")
 // MySQL 默认 affected_rows 是「真正变更的行数」，对于"新值与旧值完全相同"的幂等请求
 // 会返回 0，与"行不存在"无法区分。强制走事务 + 显式校验消除歧义。
 //
-// nil 参数不变更；调用方需保证至少有一个非 nil（否则 no-op 直接返回 nil）。
+// 返回 tx 内锁定时刻读到的 pre-update 快照，供调用方做"旧值→新值"的审计日志；
+// 由于读取与 UPDATE 在同一事务内串行化，并发更新场景下的 from 值不会 stale。
+//
+// nil 参数不变更；调用方需保证至少有一个非 nil（否则 no-op，但仍返回快照）。
 func (d *managerDB) updateSpaceProfile(
 	spaceId string,
 	name *string,
@@ -234,26 +237,27 @@ func (d *managerDB) updateSpaceProfile(
 	logo *string,
 	joinMode *int,
 	maxUsers *int,
-) error {
+) (*SpaceModel, error) {
 	tx, err := d.session.Begin()
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return nil, fmt.Errorf("begin tx: %w", err)
 	}
 	defer tx.RollbackUnlessCommitted()
 
-	var status int
+	// SELECT ... FOR UPDATE 锁定整行并取得稳定快照（供审计 from 字段使用）。
+	var before SpaceModel
 	found, err := tx.SelectBySql(
-		"SELECT status FROM space WHERE space_id=? FOR UPDATE",
+		"SELECT * FROM space WHERE space_id=? FOR UPDATE",
 		spaceId,
-	).Load(&status)
+	).Load(&before)
 	if err != nil {
-		return fmt.Errorf("lock space row: %w", err)
+		return nil, fmt.Errorf("lock space row: %w", err)
 	}
 	if found == 0 {
-		return ErrSpaceNotFound
+		return nil, ErrSpaceNotFound
 	}
-	if status == SpaceStatusDisbanded {
-		return ErrSpaceDisbandedForUpdate
+	if before.Status == SpaceStatusDisbanded {
+		return nil, ErrSpaceDisbandedForUpdate
 	}
 
 	builder := tx.Update("space")
@@ -279,13 +283,19 @@ func (d *managerDB) updateSpaceProfile(
 		changed = true
 	}
 	if !changed {
-		return tx.Commit()
+		if err := tx.Commit(); err != nil {
+			return nil, err
+		}
+		return &before, nil
 	}
 	builder = builder.Set("updated_at", time.Now())
 	if _, err := builder.Where("space_id=?", spaceId).Exec(); err != nil {
-		return fmt.Errorf("update space profile: %w", err)
+		return nil, fmt.Errorf("update space profile: %w", err)
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return &before, nil
 }
 
 // upsertMembers 批量添加/重新激活成员（单一事务，部分失败则全部回滚）


### PR DESCRIPTION
## Summary

- Add `PUT /v1/manager/spaces/:space_id` endpoint for admin-side partial update of space basic settings: **name**, **description**, **logo**, **join_mode**, and **max_users** (member limit).
- Use `SELECT ... FOR UPDATE` inside a transaction to prevent TOCTOU between the handler guard and the actual UPDATE (mirrors `transferOwnerAdmin` / `removeMembersForce` patterns).
- Return sentinel errors (`ErrSpaceNotFound` / `ErrSpaceDisbandedForUpdate`) instead of relying on `RowsAffected`, which would misclassify idempotent replays as "not found" under MySQL's default changed-rows semantics.
- Reject `max_users` below current active member count (best-effort, non-transactional — documented).

## Test plan

- [x] 21 HTTP-level integration sub-cases against real MySQL
- [x] Happy paths: partial update (name only, join_mode, max_users, description+logo, combined), trim whitespace, max_users=0 (unlimited), max_users == active count (boundary)
- [x] **Idempotent replay**: same values twice in same second → both return 200 (regression for RowsAffected bug)
- [x] **TOCTOU regression** (DB-level): `updateSpaceProfile` on disbanded space returns sentinel, fields unchanged
- [x] Validation: empty body, empty/whitespace name, name >100, description >500, logo >200, invalid join_mode, negative max_users, max_users < active members
- [x] Auth: no token rejected
- [x] Existence: missing space, disbanded space
- [x] `go test -race` clean, `go vet` clean
- [x] Full `modules/space/...` suite passes (no regressions)

Closes #157