### PR TITLE
fix(obo): DM fan-out honors global_enabled without scope rows

### DIFF
--- a/modules/bot_api/obo_check.go
+++ b/modules/bot_api/obo_check.go
@@ -13,6 +13,7 @@ package bot_api
 import (
 	"errors"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"go.uber.org/zap"
 )
 
@@ -36,7 +37,18 @@ var (
 //     master switch is off.
 //  2. Scope row exists with enabled=1 for (grant_id, channel_id,
 //     channel_type). White-list semantics per RFC §2 — opening a channel
-//     to a persona is always explicit.
+//     to a persona is always explicit. Implicit-scope exception (PR#114 /
+//     PR#162 follow-up): when the grant has `global_enabled=1` and NO
+//     scope row exists for the channel (regardless of channel type — group,
+//     community topic, OR DM), the channel is considered implicitly opted
+//     in and check (3) below is the live-access gate. An explicit scope row
+//     with `enabled=0` still wins, matching the explicit-scope-wins
+//     invariant. The DM branch closes the read/write asymmetry surfaced
+//     by Mininglamp-OSS/octo-server#162 review: the fan-out feeder
+//     `findGlobalGrantsForDM` already delivers the inbound message via the
+//     same `global_enabled + NOT EXISTS scope row` predicate, so checkOBO
+//     must accept the symmetric reply or the bot can read DMs it cannot
+//     answer.
 //  3. PR#82 round-2 P1-A — the grantor STILL has read access to the
 //     channel right now (`grantorCanReadChannel`). The scope-create-time
 //     check is not load-bearing for live membership: a grantor who
@@ -44,6 +56,10 @@ var (
 //     out must NOT be able to keep sending into group_42 as themselves
 //     through the bot, otherwise the kick is bypassable. Same logic for
 //     un-friended DM peers and parent-group leaves for community topics.
+//     This is also the DM friend-gate that backstops the implicit-scope
+//     branch above: implicit DM authorization is approved only when the
+//     grantor still has live read access to the peer (`IsFriend` or
+//     self-DM), so an unrelated peer cannot exploit the new branch.
 //     DB cost: one covering-index lookup per OBO send.
 //  4. (No self-grant check at this layer; the REST POST /v1/obo/grants
 //     handler is the right place to reject `grantor == grantee` and we
@@ -81,10 +97,10 @@ func (ba *BotAPI) checkOBO(botUID, grantor, channelID string, channelType uint8)
 		return err
 	}
 	// Implicit scope: when global_enabled=1 and NO explicit scope row exists
-	// for this channel, check if the grantor is a member. If so, allow the OBO
-	// send. BUT if a scope row exists (even with enabled=0), respect it —
-	// an explicitly disabled scope means the admin intentionally excluded
-	// this channel.
+	// for this channel, fall through to a per-channel-type live-access
+	// check. If that check passes, allow the OBO send. BUT if a scope row
+	// exists (even with enabled=0), respect it — an explicitly disabled
+	// scope means the admin intentionally excluded this channel.
 	//
 	// GH#122 — scopeRowExists is fail-closed: a DB error here is propagated,
 	// not swallowed. Treating an error as "no explicit scope" would silently
@@ -93,16 +109,21 @@ func (ba *BotAPI) checkOBO(botUID, grantor, channelID string, channelType uint8)
 	// invisible to the check. Bubble up so the handler can 500 and the
 	// operator notices the outage.
 	//
-	// PR#121 R7 (YUJ-1671) — only consult scopeRowExists when we actually
-	// need it, i.e. the explicit-scope check was negative (`!ok`) AND the
-	// channel type is one where implicit scope is possible
-	// (isGroupLikeChannelType). For DM (Person) and any future
-	// non-group-like channel, scopeRowExists adds nothing — the
-	// implicit-scope branch below would short-circuit on the
-	// isGroupLikeChannelType guard regardless. Skipping the redundant
-	// SELECT trims one DB round-trip off every successful OBO send (where
-	// `ok=true`), which is the dominant case.
-	if !ok && isGroupLikeChannelType(channelType) {
+	// PR#162 follow-up (Jerry-Xin's CR — read/write symmetry): originally
+	// the implicit-scope branch was gated by `isGroupLikeChannelType` so
+	// only Group / CommunityTopic took it; DM (Person) was hard-gated to
+	// the explicit-scope contract. PR#162 added the symmetric DM fan-out
+	// feeder (`findGlobalGrantsForDM`) which delivers DM payloads under
+	// the same `global_enabled + NOT EXISTS scope row` predicate, so the
+	// write path here must match — otherwise the bot would receive the
+	// DM via fan-out but `checkOBO` would reject the reply. The branch
+	// now triggers for ANY channel type once `global_enabled=1` and no
+	// scope row exists; the per-type live-access check (group membership
+	// for Group / CommunityTopic, friend-gate for Person) is the safety
+	// net. An unrelated peer cannot exploit the DM branch because
+	// `grantorCanReadChannel` for Person resolves to `IsFriend` (or
+	// self-DM), matching the fan-out TOCTOU re-check.
+	if !ok && grant.GlobalEnabled == 1 {
 		hasExplicitScope, scopeExistErr := store.scopeRowExists(grant.ID, channelID, channelType)
 		if scopeExistErr != nil {
 			ba.Error("OBO scopeRowExists check failed",
@@ -112,21 +133,51 @@ func (ba *BotAPI) checkOBO(botUID, grantor, channelID string, channelType uint8)
 				zap.Error(scopeExistErr))
 			return scopeExistErr
 		}
-		if !hasExplicitScope && grant.GlobalEnabled == 1 {
-			isMember, mErr := ba.grantorCanReadChannel(grantor, channelID, channelType)
-			if mErr != nil {
-				ba.Error("OBO implicit-scope membership check failed",
-					zap.String("grantor", grantor),
-					zap.String("channel_id", channelID),
-					zap.Error(mErr))
-				return mErr
-			}
-			if isMember {
-				ba.Info("OBO checkOBO: implicit-scope approved (grantor is group member)",
-					zap.String("grantor", grantor),
-					zap.String("bot", botUID),
-					zap.String("channel_id", channelID))
-				ok = true
+		if !hasExplicitScope {
+			switch {
+			case isGroupLikeChannelType(channelType):
+				isMember, mErr := ba.grantorCanReadChannel(grantor, channelID, channelType)
+				if mErr != nil {
+					ba.Error("OBO implicit-scope membership check failed",
+						zap.String("grantor", grantor),
+						zap.String("channel_id", channelID),
+						zap.Error(mErr))
+					return mErr
+				}
+				if isMember {
+					ba.Info("OBO checkOBO: implicit-scope approved (grantor is group member)",
+						zap.String("grantor", grantor),
+						zap.String("bot", botUID),
+						zap.String("channel_id", channelID))
+					ok = true
+				}
+			case channelType == common.ChannelTypePerson.Uint8():
+				// PR#162 follow-up — DM implicit scope. The friend-gate
+				// (`grantorCanReadChannel` resolves to `IsFriend` for
+				// Person, mirroring the fan-out feeder's TOCTOU re-check)
+				// is the safety net: an unrelated peer cannot exploit
+				// the new branch because the grantor must still have
+				// live access to the DM peer for `ok` to flip true. The
+				// downstream `grantorCanReadChannel` call later in
+				// checkOBO will re-run the same predicate on the dispatch
+				// path, but we must run it here to compute the implicit-
+				// scope approval (otherwise the second call would 403 a
+				// payload we never approved in the first place).
+				canRead, mErr := ba.grantorCanReadChannel(grantor, channelID, channelType)
+				if mErr != nil {
+					ba.Error("OBO implicit-scope DM friend-gate check failed",
+						zap.String("grantor", grantor),
+						zap.String("channel_id", channelID),
+						zap.Error(mErr))
+					return mErr
+				}
+				if canRead {
+					ba.Info("OBO checkOBO: DM implicit-scope approved (global_enabled + friend-gate)",
+						zap.String("grantor", grantor),
+						zap.String("bot", botUID),
+						zap.String("channel_id", channelID))
+					ok = true
+				}
 			}
 		}
 	}

--- a/modules/bot_api/obo_db.go
+++ b/modules/bot_api/obo_db.go
@@ -62,10 +62,15 @@ import (
 // `grantorCanReadChannel` re-check inside fanoutForMessage still
 // enforces live membership.
 //
-// DM (Person) channels keep the strict scope-row contract: a DM is a
-// 1:1 conversation that the persona must be explicitly authorized for,
-// and the @grantor narrowing gate cannot be applied (DM payloads carry
-// no mention).
+// DM (Person) channels do NOT take this branch. Their implicit-scope
+// fan-out is delivered by the dedicated `findGlobalGrantsForDM` feeder
+// (Mininglamp-OSS/octo-server#161 / PR#162) and the symmetric write path
+// runs in `checkOBO` directly (Mininglamp-OSS/octo-server#162 follow-up):
+// a `global_enabled=1` grant with no scope row authorizes both the
+// inbound DM fan-out and the bot's reply, gated at TOCTOU close-out by
+// the friend-gate (`grantorCanReadChannel` → `IsFriend`). The
+// `@grantor`-mention narrowing path that this helper guards is still
+// group-shaped only — DM payloads carry no mention.
 func isGroupLikeChannelType(channelType uint8) bool {
 	return channelType == common.ChannelTypeGroup.Uint8() ||
 		channelType == common.ChannelTypeCommunityTopic.Uint8()

--- a/modules/bot_api/obo_db.go
+++ b/modules/bot_api/obo_db.go
@@ -212,6 +212,33 @@ type oboStore interface {
 	// — never the parent-group's. See findGlobalGrantsWithoutScope for
 	// the full per-argument contract.
 	findGlobalGrantsWithoutScope(membershipGroupID, channelID string, channelType uint8) ([]*oboGrantModel, error)
+	// findGlobalGrantsForDM — Mininglamp-OSS/octo-server#161 (YUJ-1977).
+	// DM-only implicit-scope feeder. Returns active grants with
+	// `global_enabled=1` whose grantor uid is `grantorUID` AND for which no
+	// `obo_scopes` row exists for the (peer, ChannelTypePerson) tuple.
+	//
+	// Mirrors the group-shaped `findGlobalGrantsWithoutScope` semantics but
+	// for the 1:1 DM frame: a grantor who flips `global_enabled=1` on their
+	// grant without ever installing a per-peer scope row should still see
+	// fan-out for every DM their counterpart sends them. Pre-fix,
+	// `findActiveGrantsForChannel` short-circuited to empty for this case
+	// because its INNER JOIN on `obo_scopes` required at least one matching
+	// row; the group-like path solved it via the implicit-scope feeder, but
+	// DMs had no equivalent. PR#121 R5 / B1 invariant — an explicit scope
+	// row (regardless of `enabled`) for the (peer, Person) tuple suppresses
+	// implicit-scope fan-out — is preserved by the `NOT EXISTS` anti-join:
+	// a row with `enabled=1` is already covered by the explicit feeder, and
+	// a row with `enabled=0` is the admin's intentional disable.
+	//
+	// Empty `grantorUID` or `peerChannelID` returns an empty slice without
+	// touching the DB. Caller (`fanoutForMessage`) is responsible for the
+	// merge with the explicit-feeder result + per-grant Gate 1/2 filtering
+	// + the TOCTOU re-check (`grantorCanReadChannel` / friend-gate). This
+	// method does NOT consult or update the channel-wide cache: the result
+	// surfaces a different invariant than the cached scalar (any ACTIVE
+	// scope row vs. any `global_enabled` grant without scope rows) so cache
+	// reuse would be incorrect.
+	findGlobalGrantsForDM(grantorUID, peerChannelID string) ([]*oboGrantModel, error)
 
 	// CRUD used by the REST layer.
 	//
@@ -681,6 +708,58 @@ func (d *botAPIDB) findGlobalGrantsWithoutScope(membershipGroupID, channelID str
 			"  AND gm_bot.uid IS NULL "+
 			"  AND s.id IS NULL",
 		membershipGroupID, membershipGroupID, channelID, channelType,
+	).Load(&grants)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return nil, err
+	}
+	if grants == nil {
+		grants = []*oboGrantModel{}
+	}
+	return grants, nil
+}
+
+// findGlobalGrantsForDM — see oboStore. DM-only implicit-scope feeder for
+// Mininglamp-OSS/octo-server#161 (YUJ-1977). Returns active grants with
+// `global_enabled=1` whose `grantor_uid` matches `grantorUID` AND for which
+// no `obo_scopes` row exists for `(peerChannelID, ChannelTypePerson)`.
+//
+// Counterpart to `findGlobalGrantsWithoutScope` for the DM frame of
+// reference. The group feeder needs the `group_member` JOINs because a
+// group-shaped grant only fans out into channels where the grantor is a
+// member AND the bot is not; DMs have no such membership relation — a DM
+// grant fans out into any DM the grantor receives, and the per-grant
+// `grantorCanReadChannel` re-check inside `fanoutForMessage` enforces the
+// friend-gate (TOCTOU) at dispatch time. We therefore only need the
+// `global_enabled` row plus the scope anti-join here.
+//
+// The `NOT EXISTS` anti-join is identical in spirit to the LEFT JOIN
+// `s.id IS NULL` pattern used by the group feeder: ANY existing
+// `obo_scopes` row for `(grant_id, peer, Person)` — regardless of
+// `enabled` — suppresses implicit-scope. Rows with `enabled=1` are
+// already returned by `findActiveGrantsForChannel`, so suppressing them
+// here keeps the two queries disjoint and the merge in
+// `fanoutForMessage` cheap. Rows with `enabled=0` are the admin's
+// intentional disable and MUST suppress fan-out (PR#121 R5 / B1
+// invariant — "explicit scope row wins").
+//
+// Channel-wide cache (`obo:chan:1:{peer}`) is intentionally NOT consulted
+// or updated: a "0" cached scalar from `findActiveGrantsForChannel`
+// (= "no enabled scope row") cannot prove this query's negative answer
+// (= "no grant with global_enabled and no scope row"), and writing here
+// would poison the explicit feeder's cache contract.
+func (d *botAPIDB) findGlobalGrantsForDM(grantorUID, peerChannelID string) ([]*oboGrantModel, error) {
+	if grantorUID == "" || peerChannelID == "" {
+		return []*oboGrantModel{}, nil
+	}
+	var grants []*oboGrantModel
+	_, err := d.session.SelectBySql(
+		"SELECT "+oboGrantColumnsAliased+" FROM obo_grants g "+
+			"WHERE g.active=1 AND g.global_enabled=1 AND g.grantor_uid=? "+
+			"AND NOT EXISTS ("+
+			"  SELECT 1 FROM obo_scopes s "+
+			"  WHERE s.grant_id=g.id AND s.channel_id=? AND s.channel_type=?"+
+			")",
+		grantorUID, peerChannelID, common.ChannelTypePerson.Uint8(),
 	).Load(&grants)
 	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
 		return nil, err

--- a/modules/bot_api/obo_fake_test.go
+++ b/modules/bot_api/obo_fake_test.go
@@ -463,6 +463,61 @@ func (f *fakeOBOStore) findGlobalGrantsWithoutScope(membershipGroupID, channelID
 	return out, nil
 }
 
+// findGlobalGrantsForDM — Mininglamp-OSS/octo-server#161 (YUJ-1977) fake
+// impl. Returns active grants with `global_enabled=1` whose grantor uid
+// matches `grantorUID` AND for which no `obo_scopes` row exists for
+// `(peerChannelID, ChannelTypePerson)`. Mirrors the production
+// `NOT EXISTS` anti-join: ANY scope row for the tuple (regardless of
+// `enabled`) suppresses implicit-scope, matching the explicit-scope-wins
+// invariant.
+func (f *fakeOBOStore) findGlobalGrantsForDM(grantorUID, peerChannelID string) ([]*oboGrantModel, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureInit()
+	out := []*oboGrantModel{}
+	if grantorUID == "" || peerChannelID == "" {
+		return out, nil
+	}
+	// Deterministic order — mirror the sort applied by the other fake
+	// feeders so test assertions on slice ordering stay stable.
+	ids := make([]int64, 0, len(f.grants))
+	for id := range f.grants {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	for _, id := range ids {
+		g := f.grants[id]
+		if g == nil || g.Active != 1 || g.GlobalEnabled != 1 {
+			continue
+		}
+		if g.GrantorUID != grantorUID {
+			continue
+		}
+		// Anti-join: any scope row for (grant, peer, Person) — regardless
+		// of `enabled` — suppresses implicit-scope. Rows with `enabled=1`
+		// are already covered by findActiveGrantsForChannel; rows with
+		// `enabled=0` are the admin's intentional disable (PR#121 R5/B1).
+		hasScope := false
+		for _, s := range f.scopes {
+			if s == nil {
+				continue
+			}
+			if s.GrantID == g.ID &&
+				s.ChannelID == peerChannelID &&
+				s.ChannelType == common.ChannelTypePerson.Uint8() {
+				hasScope = true
+				break
+			}
+		}
+		if hasScope {
+			continue
+		}
+		cp := *g
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+
 func (f *fakeOBOStore) insertGrant(grantorUID, granteeBotUID, mode, personaPrompt string) (int64, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/modules/bot_api/obo_fake_test.go
+++ b/modules/bot_api/obo_fake_test.go
@@ -283,8 +283,15 @@ func (f *fakeOBOStore) findActiveGrantsForChannel(channelID string, channelType 
 	// requiring a scope row (the prod fan-out path combines this
 	// with a separate findGlobalGrantsWithoutScope call; aggregating
 	// here keeps the fake's behavior end-to-end equivalent for
-	// fanoutForMessage tests). DM (Person) keeps the strict scope-
-	// row contract.
+	// fanoutForMessage tests).
+	//
+	// DM (Person) implicit-scope is delivered by the dedicated
+	// `findGlobalGrantsForDM` feeder (Mininglamp-OSS/octo-server#161 /
+	// PR#162), NOT this method — `findActiveGrantsForChannel` retains
+	// the strict scope-row contract for DM here so the fake mirrors the
+	// production `INNER JOIN obo_scopes` shape. fanoutForMessage merges
+	// both feeders for DM, same as the group path merges the explicit
+	// and implicit feeders.
 	//
 	// PR#121 R6 / B3 (Jerry-Xin + lml2468 2026-05-22 blocking):
 	// CommunityTopic does NOT take the implicit-global branch here.

--- a/modules/bot_api/obo_fanout.go
+++ b/modules/bot_api/obo_fanout.go
@@ -166,6 +166,44 @@ func fanoutLookupChannelID(m *config.MessageResp) string {
 	return m.ChannelID
 }
 
+// mergeGrantsDedup appends `extras` to `base`, dropping any grant whose ID
+// already appears in `base`. Used by the DM fan-out path
+// (Mininglamp-OSS/octo-server#161 / YUJ-1977) to merge the explicit-feeder
+// result (`findActiveGrantsForChannel`) with the implicit-feeder result
+// (`findGlobalGrantsForDM`). The two production queries are disjoint by
+// construction — one INNER JOINs on `obo_scopes.enabled=1`, the other
+// `NOT EXISTS`-filters on the same table — but the helper guards against a
+// future store impl regression and against the test-fake aggregating both
+// branches in a single method.
+//
+// Order is preserved: explicit-feeder grants come first (they are the
+// authoritative dispatch shape for DMs the grantor explicitly opted into),
+// implicit grants append after. This keeps the dispatch loop's per-message
+// `grantorAccess` cache and the fan-out copy ordering deterministic across
+// the two paths.
+func mergeGrantsDedup(base, extras []*oboGrantModel) []*oboGrantModel {
+	if len(extras) == 0 {
+		return base
+	}
+	seen := make(map[int64]struct{}, len(base))
+	for _, g := range base {
+		if g != nil {
+			seen[g.ID] = struct{}{}
+		}
+	}
+	for _, g := range extras {
+		if g == nil {
+			continue
+		}
+		if _, dup := seen[g.ID]; dup {
+			continue
+		}
+		seen[g.ID] = struct{}{}
+		base = append(base, g)
+	}
+	return base
+}
+
 // fanoutForMessage is the single-message entry point used by tests AND by
 // oboMessagesListen. Returns the number of copies dispatched so tests can
 // assert without poking the dispatcher hook.
@@ -241,6 +279,41 @@ func (ba *BotAPI) fanoutForMessage(m *config.MessageResp) int {
 	if m.ChannelType == common.ChannelTypePerson.Uint8() {
 		// DM path — unchanged, uses scope-joined query.
 		grants, err = store.findActiveGrantsForChannel(lookupChannelID, m.ChannelType)
+		// Mininglamp-OSS/octo-server#161 (YUJ-1977) — DM implicit-scope
+		// fallback. `findActiveGrantsForChannel` INNER JOINs on
+		// `obo_scopes` with `enabled=1`, so a grant with
+		// `global_enabled=1` but ZERO scope rows produces an empty
+		// result and the DM never fans out. PR#121 introduced the
+		// equivalent path for group-shaped channels via
+		// `findGlobalGrantsWithoutScope`; this branch closes the
+		// symmetrical gap for Person channels.
+		//
+		// `m.ChannelID` under the listener's WuKongIM-native view is
+		// the receiver of the inbound DM, which IS the grantor for
+		// fan-out (the multi-grantor recipient filter further down
+		// already pivots on this same identity). `lookupChannelID` is
+		// the peer (= `m.FromUID`, after the P1-B normalization) and
+		// is what an explicit scope row would have keyed under.
+		//
+		// The fallback is best-effort: a DB error on the implicit
+		// feeder MUST NOT mask whatever the explicit feeder
+		// successfully returned, so we log + carry on rather than
+		// failing the whole lookup. Merging is dedup-safe even though
+		// the two queries are disjoint by construction (one requires
+		// an enabled scope row, the other requires no scope row at
+		// all) — `mergeGrantsDedup` is belt-and-braces against future
+		// store impls that relax that invariant.
+		if err == nil && m.ChannelID != "" {
+			globalGrants, gErr := store.findGlobalGrantsForDM(m.ChannelID, lookupChannelID)
+			if gErr != nil {
+				ba.Warn("OBO DM implicit-scope lookup failed",
+					zap.String("grantor", m.ChannelID),
+					zap.String("peer", lookupChannelID),
+					zap.Error(gErr))
+			} else if len(globalGrants) > 0 {
+				grants = mergeGrantsDedup(grants, globalGrants)
+			}
+		}
 	} else {
 		// Group-like channels: gate on mention first. `mention.all` is
 		// parsed (decoder still surfaces it for telemetry / future use)

--- a/modules/bot_api/obo_fanout_test.go
+++ b/modules/bot_api/obo_fanout_test.go
@@ -534,8 +534,23 @@ func TestFanout_DMGrantorToPeer_DoesNotEcho(t *testing.T) {
 
 // TestFanout_DMUnrelatedPeer_NoMatch — defensive cousin of P1-B. A DM
 // from some third party Eve to the grantor must NOT fan out when the
-// grantor's scope is for Bob, not Eve. With the new lookup-by-FromUID,
-// scope (channel_id = Bob) and lookup (FromUID = Eve) do not match.
+// grantor is not friends with Eve. Pre-#161 the explicit Bob scope was
+// the sole opt-in signal and the lookup-by-FromUID(=Eve) returned no
+// scope row, so fan-out was 0 BEFORE the access check ran.
+//
+// Post-Mininglamp-OSS/octo-server#161 (YUJ-1977) the DM path also
+// consults `findGlobalGrantsForDM` for grants with `global_enabled=1`
+// and no per-peer scope row — so Eve's DM now reaches the access-check
+// gate (the grantor's `global_enabled=1` covers any DM peer they have
+// live access to, mirroring the group-shaped implicit-scope semantics).
+// The friend-gate (`grantorCanReadChannel`) is the gate that keeps
+// unrelated peers out: this test installs an override that returns
+// false for the (grantor, Eve) pair and asserts fan-out is still zero.
+//
+// The pre-#161 invariant "scope-row-key mismatch short-circuits before
+// the access check" is preserved in the form that actually matters for
+// the bug it was guarding against: an unrelated peer cannot leak DM
+// content into the persona via the new implicit-scope path either.
 func TestFanout_DMUnrelatedPeer_NoMatch(t *testing.T) {
 	const scopedPeer, otherPeer = "bob", "eve"
 	ct := common.ChannelTypePerson.Uint8()
@@ -548,8 +563,14 @@ func TestFanout_DMUnrelatedPeer_NoMatch(t *testing.T) {
 	}
 	fc := &fanoutCapture{}
 	ba := newBAforFanout(s, fc)
+	// Friend-gate is the "is the grantor authorized for this peer" gate
+	// under the new implicit-scope DM path. Deny for Eve to assert the
+	// no-leak invariant; if the access check is somehow not consulted
+	// for Eve (regression), the implicit feeder would fan-out blindly.
 	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
-		t.Errorf("unrelated peer DM should not reach access check; uid=%q chan=%q", uid, channelID)
+		if channelID == otherPeer {
+			return false, nil
+		}
 		return true, nil
 	}
 
@@ -560,7 +581,10 @@ func TestFanout_DMUnrelatedPeer_NoMatch(t *testing.T) {
 		Payload:     []byte(`{"type":1,"content":"hi yu","mention":{"uids":["user_yu"]}}`),
 	}
 	if n := ba.fanoutForMessage(msg); n != 0 {
-		t.Fatalf("unscoped DM peer must not fan out, got %d", n)
+		t.Fatalf("unrelated DM peer must not fan out (friend-gate denies), got %d", n)
+	}
+	if len(fc.copies) != 0 {
+		t.Fatalf("unrelated DM peer leaked: captured %d copies, expected 0", len(fc.copies))
 	}
 }
 
@@ -1570,5 +1594,169 @@ func TestFanout_Gate4_CommunityTopic_BotNotInParentGroup_FansOut(t *testing.T) {
 	}
 	if len(fc.copies) != 1 {
 		t.Fatalf("CommunityTopic control: expected 1 captured copy, got %d", len(fc.copies))
+	}
+}
+
+// ===== Mininglamp-OSS/octo-server#161 (YUJ-1977) DM implicit-scope tests =====
+//
+// Pre-fix `findActiveGrantsForChannel` INNER JOINed on `obo_scopes` with
+// `enabled=1`, so a grant with `global_enabled=1` but ZERO scope rows
+// produced an empty result for DMs and the listener never fanned out the
+// inbound message. Group-shaped channels solved the same gap via the
+// implicit-scope feeder `findGlobalGrantsWithoutScope` (PR#121); these
+// tests pin the symmetrical DM path: `findGlobalGrantsForDM` is consulted
+// after the explicit feeder, merged dedup-safely, and continues to honor
+// the "explicit scope row wins" invariant (PR#121 R5 / B1).
+
+// TestFanout_DM_GlobalEnabled_NoScopes — Mininglamp-OSS/octo-server#161
+// (YUJ-1977). Alice has a grant with `global_enabled=1` and ZERO scope
+// rows installed. When DM peer Bob sends Alice a message, the implicit-
+// scope DM feeder must surface the grant and the listener must dispatch
+// exactly one fan-out copy to the grantee bot. This is the regression
+// test for the original report — pre-fix the assertion `got == 1` would
+// fail with `got == 0`.
+func TestFanout_DM_GlobalEnabled_NoScopes(t *testing.T) {
+	const peer = "bob"
+	ct := common.ChannelTypePerson.Uint8()
+	s := newFakeOBOStore()
+	gid, err := s.insertGrant(tGrantor, tBot, "auto", "")
+	if err != nil {
+		t.Fatalf("insertGrant: %v", err)
+	}
+	enable := 1
+	if err := s.updateGrant(gid, "", &enable, nil); err != nil {
+		t.Fatalf("updateGrant: %v", err)
+	}
+	// NB: intentionally NO insertScope call — this is the whole point of
+	// the regression. The grant is global_enabled=1 with zero scope rows.
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		// TOCTOU re-check must still run for implicit-scope DM grants;
+		// pin the frame of reference so a regression that strips the
+		// per-grant re-check on the DM implicit path surfaces here.
+		if uid != tGrantor || channelID != peer || channelType != ct {
+			t.Errorf("access check called with wrong frame: uid=%q chan=%q type=%d (want grantor=%q peer=%q)",
+				uid, channelID, channelType, tGrantor, peer)
+		}
+		return true, nil
+	}
+
+	// Listener-emitted DM: ChannelID = receiver (= grantor), FromUID = peer.
+	msg := &config.MessageResp{
+		FromUID:     peer,
+		ChannelID:   tGrantor,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"hey from bob"}`),
+	}
+	got := ba.fanoutForMessage(msg)
+	if got != 1 {
+		t.Fatalf("expected 1 fan-out, got %d (regression: DM with global_enabled=1 + no scopes must fan out)", got)
+	}
+	if len(fc.copies) != 1 {
+		t.Fatalf("expected 1 captured copy, got %d", len(fc.copies))
+	}
+	cp := fc.copies[0]
+	if err := assertFanoutDispatchContract(cp); err != nil {
+		t.Fatalf("fan-out contract violated: %v (req=%+v)", err, cp)
+	}
+	if cp.ChannelID != tBot {
+		t.Fatalf("channel_id should be bot mailbox %q, got %q", tBot, cp.ChannelID)
+	}
+	var p map[string]interface{}
+	_ = json.Unmarshal(cp.Payload, &p)
+	if p["content"] != "hey from bob" {
+		t.Fatalf("payload content lost: %v", p)
+	}
+	if v, _ := p["obo_origin_from_uid"].(string); v != peer {
+		t.Fatalf("obo_origin_from_uid should be %q, got %q", peer, v)
+	}
+}
+
+// TestFanout_DM_GlobalEnabled_WithExplicitScope — Mininglamp-OSS/octo-server#161
+// (YUJ-1977). Same grant + peer setup as above, but THIS time Alice has
+// also installed an explicit `obo_scopes` row (`enabled=1`) for Bob.
+// `findActiveGrantsForChannel` returns the grant via the INNER JOIN and
+// `findGlobalGrantsForDM`'s `NOT EXISTS` anti-join filters it out — so
+// `mergeGrantsDedup` is never asked to deduplicate. The dispatch count
+// must remain exactly 1 (no double-fire).
+//
+// This pins both: (a) the two feeders are disjoint by construction, and
+// (b) the merge helper is dedup-safe even if a future store impl returns
+// the same grant from both — `mergeGrantsDedup` guards against that.
+func TestFanout_DM_GlobalEnabled_WithExplicitScope(t *testing.T) {
+	const peer = "bob"
+	ct := common.ChannelTypePerson.Uint8()
+	s := newFakeOBOStore()
+	gid, err := s.insertGrant(tGrantor, tBot, "auto", "")
+	if err != nil {
+		t.Fatalf("insertGrant: %v", err)
+	}
+	enable := 1
+	if err := s.updateGrant(gid, "", &enable, nil); err != nil {
+		t.Fatalf("updateGrant: %v", err)
+	}
+	// Explicit scope row — the original PR#82 round-2 P1-B happy path.
+	if _, err := s.insertScope(gid, peer, ct, 1); err != nil {
+		t.Fatalf("insertScope: %v", err)
+	}
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		return true, nil
+	}
+
+	msg := &config.MessageResp{
+		FromUID:     peer,
+		ChannelID:   tGrantor,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"hey from bob"}`),
+	}
+	got := ba.fanoutForMessage(msg)
+	if got != 1 {
+		t.Fatalf("expected exactly 1 fan-out (no duplicate), got %d", got)
+	}
+	if len(fc.copies) != 1 {
+		t.Fatalf("expected 1 captured copy (dedup invariant), got %d", len(fc.copies))
+	}
+
+	// Direct assertion on the helper to lock the dedup contract — pass
+	// the same grant via both slices and verify only one copy survives.
+	gModel := &oboGrantModel{ID: gid, GrantorUID: tGrantor, GranteeBotUID: tBot, Active: 1, GlobalEnabled: 1}
+	merged := mergeGrantsDedup([]*oboGrantModel{gModel}, []*oboGrantModel{gModel})
+	if len(merged) != 1 {
+		t.Fatalf("mergeGrantsDedup must dedup by grant ID, got %d entries", len(merged))
+	}
+}
+
+// TestFanout_DM_GlobalDisabled_NoScopes — Mininglamp-OSS/octo-server#161
+// (YUJ-1977). Existing-behavior regression guard. A grant with
+// `global_enabled=0` and zero scope rows must NOT trigger fan-out even
+// with the new DM implicit-scope path wired in. The implicit feeder's
+// `WHERE g.global_enabled=1` predicate is what excludes it; the test
+// pins that the gating clause survives any future refactor.
+func TestFanout_DM_GlobalDisabled_NoScopes(t *testing.T) {
+	const peer = "bob"
+	ct := common.ChannelTypePerson.Uint8()
+	s := newFakeOBOStore()
+	if _, err := s.insertGrant(tGrantor, tBot, "auto", ""); err != nil {
+		t.Fatalf("insertGrant: %v", err)
+	}
+	// Leave global_enabled at its post-insert default (0). No scope rows.
+	fc := &fanoutCapture{}
+	ba := newBAforFanout(s, fc)
+
+	msg := &config.MessageResp{
+		FromUID:     peer,
+		ChannelID:   tGrantor,
+		ChannelType: ct,
+		Payload:     []byte(`{"type":1,"content":"silence please"}`),
+	}
+	got := ba.fanoutForMessage(msg)
+	if got != 0 {
+		t.Fatalf("expected 0 fan-out (global_enabled=0), got %d", got)
+	}
+	if len(fc.copies) != 0 {
+		t.Fatalf("expected 0 captured copies, got %d", len(fc.copies))
 	}
 }

--- a/modules/bot_api/obo_send_test.go
+++ b/modules/bot_api/obo_send_test.go
@@ -426,6 +426,18 @@ func TestSendMessage_OBO_GrantorReplyBypass_RequiresActiveGrant(t *testing.T) {
 // send and requires the strict scope check. Issue YUJ-1418 explicitly
 // forbids loosening the third-party path: "Do NOT change the OBO scope
 // check for third-party sends (that must remain strict)".
+//
+// Post-Mininglamp-OSS/octo-server#162 R1 (DM implicit-scope on the
+// write path): a `global_enabled=1` grant with NO scope row and a
+// passing friend-gate now authorizes DM sends via the implicit-scope
+// branch. To keep this test focused on the bypass-scoping invariant
+// (and not accidentally exercise the new implicit-scope path), we
+// install an explicit `enabled=0` scope row for (peer, Person). The
+// explicit-disabled-scope-wins invariant (PR#121 R5 / B1) suppresses
+// the implicit branch and lets checkOBO answer "no" for the genuine
+// "admin opted this peer out" reason. If the bypass ever wrongly
+// fires, the dispatch would still go through and the test would
+// fail — i.e. the test still proves what it was written to prove.
 func TestSendMessage_OBO_GrantorReplyBypass_DoesNotApplyToThirdPartySend(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -436,15 +448,20 @@ func TestSendMessage_OBO_GrantorReplyBypass_DoesNotApplyToThirdPartySend(t *test
 		authSp  = "space_A"
 	)
 
-	// Grant exists from admin, but the send is to bob (peer) ON BEHALF
-	// OF admin. There is NO scope row for (admin's grant, channel=bob).
-	// This is the standard "no scope → deny" path and the bypass must
-	// not rescue it just because admin (the on_behalf_of value) is also
-	// a grantor of the bot.
+	// Grant exists from admin with `global_enabled=1`; the send is to
+	// bob (peer) ON BEHALF OF admin. We install an explicit DISABLED
+	// scope row for (admin's grant, channel=bob, Person) so the
+	// admin's intent ("do NOT let the persona answer bob for me") wins
+	// over the implicit-scope branch added in PR#162 R1. The bypass
+	// must still not rescue it just because admin (the on_behalf_of
+	// value) is also a grantor of the bot.
 	s := newFakeOBOStore()
 	gid, _ := s.insertGrant(grantor, botID, "auto", "")
 	enable := 1
 	_ = s.updateGrant(gid, "", &enable, nil)
+	if _, err := s.insertScope(gid, peer, common.ChannelTypePerson.Uint8(), 0); err != nil {
+		t.Fatalf("insertScope: %v", err)
+	}
 
 	dc := &dispatchCapture{}
 	ba := &BotAPI{
@@ -472,14 +489,15 @@ func TestSendMessage_OBO_GrantorReplyBypass_DoesNotApplyToThirdPartySend(t *test
 	// failure under test is the OBO scope check, not the friend gate.
 	c.Set(CtxKeyRobot, &robotModel{RobotID: botID, CreatorUID: peer})
 	// Suppress reference-membership re-check — happy path for grantor
-	// channel access, so the failure is unambiguously the scope row miss.
+	// channel access, so the failure is unambiguously the explicit-
+	// disabled scope row (not the friend gate).
 	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
 		return true, nil
 	}
 
 	ba.sendMessage(c)
 	if !strings.Contains(rec.Body.String(), ErrOBONotAuthorized.Error()) {
-		t.Fatalf("third-party OBO send without scope row must still be rejected; got %s", rec.Body.String())
+		t.Fatalf("third-party OBO send with explicit-disabled scope must still be rejected; got %s", rec.Body.String())
 	}
 	if dc.captured != nil {
 		t.Fatalf("dispatch must NOT fire on third-party send without scope; got %+v", dc.captured)

--- a/modules/bot_api/obo_yuj1538_test.go
+++ b/modules/bot_api/obo_yuj1538_test.go
@@ -220,17 +220,36 @@ func TestFanout_YUJ1538_GroupMentionAisBooleanShapeSummonsPersona(t *testing.T) 
 	}
 }
 
-// TestFanout_YUJ1538_DMStillRequiresScopeRow — the new
-// channel-type-aware lookup path must NOT relax DM behavior. DMs
-// remain strict: a grant without a matching `obo_scopes` row
-// (channel_type=1, channel_id=peer uid) gets zero dispatches even
-// when `global_enabled=1`. Pins the contract from the issue:
+// TestFanout_YUJ1538_DMStillRequiresScopeRow — Mininglamp-OSS/octo-server#161
+// (YUJ-1977) INVERSION. The YUJ-1538 invariant ("DMs remain strict — a
+// grant without a matching scope row gets zero dispatches even when
+// global_enabled=1") was the bug behind issue #161: a grantor who flips
+// `global_enabled=1` on a DM-shaped grant without ever installing a per-
+// peer scope row expected fan-out symmetrical to the group-shaped
+// `findGlobalGrantsWithoutScope` path (PR#121) and got silence instead.
 //
-//   "Do NOT change DM fan-out behavior (must still require scope rows)"
+// Post-#161 the DM fan-out path consults `findGlobalGrantsForDM` after
+// `findActiveGrantsForChannel`, so a `global_enabled=1` grant with zero
+// scope rows now DOES fan out for any DM peer the grantor has live
+// access to (the friend-gate / `grantorCanReadChannel` re-check inside
+// `fanoutForMessage` enforces the access invariant; the explicit scope
+// row is no longer the sole opt-in signal).
+//
+// This test pins the new behavior — what was previously a "must NOT
+// dispatch" assertion is now a "must dispatch exactly one copy"
+// assertion. The original YUJ-1538 intent (group fan-out without scope
+// rows) is unchanged and still covered by the sibling tests in this
+// file; only the DM half of the contract flipped.
+//
+// The lower-level new tests live in obo_fanout_test.go:
+// TestFanout_DM_GlobalEnabled_NoScopes / WithExplicitScope /
+// GlobalDisabled_NoScopes — they assert the dispatch payload + dedup
+// contract; this test is the YUJ-1538 file's parity assertion that the
+// DM-side regression is closed.
 func TestFanout_YUJ1538_DMStillRequiresScopeRow(t *testing.T) {
 	const peer = "u_bob"
 	ct := common.ChannelTypePerson.Uint8()
-	s := seedGrantNoScope(t) // grant exists with global_enabled=1, but no DM scope
+	s := seedGrantNoScope(t) // grant exists with global_enabled=1, no DM scope row
 	fc := &fanoutCapture{}
 	ba := newBAforFanout(s, fc)
 
@@ -240,8 +259,8 @@ func TestFanout_YUJ1538_DMStillRequiresScopeRow(t *testing.T) {
 		ChannelType: ct,
 		Payload:     []byte(`{"type":1,"content":"hey, can we chat?"}`),
 	}
-	if got := ba.fanoutForMessage(msg); got != 0 {
-		t.Fatalf("YUJ-1538: DM with no scope row must NOT fan out (issue spec: DM behavior unchanged), got %d", got)
+	if got := ba.fanoutForMessage(msg); got != 1 {
+		t.Fatalf("issue #161 (YUJ-1977): DM with global_enabled=1 + no scope row must fan out via implicit-scope feeder, got %d", got)
 	}
 }
 

--- a/modules/bot_api/obo_yuj1538_test.go
+++ b/modules/bot_api/obo_yuj1538_test.go
@@ -484,18 +484,53 @@ func TestCheckOBO_YUJ1538_CommunityTopicNoScopeRow_GlobalEnabledAuthorizes(t *te
 	}
 }
 
-// TestCheckOBO_YUJ1538_DMNoScope_StillUnauthorized — regression guard.
-// The PR#114 fix MUST NOT relax DM behavior: a grant with
-// `global_enabled=1` but no scope row for the DM peer must still deny.
-// DMs have no in-message narrowing signal (mentions don't apply), so
-// the per-peer scope row is the only explicit opt-in.
+// TestCheckOBO_YUJ1538_DMNoScope_StillUnauthorized — read/write symmetry
+// pin. Originally this test asserted that DM with `global_enabled=1` and
+// no scope row must DENY (the YUJ-1538-era intent). PR#162 inverted that
+// invariant on the read path (`findGlobalGrantsForDM` delivers the inbound
+// DM under the same predicate as the group implicit-scope feeder), and
+// the follow-up (Mininglamp-OSS/octo-server#162 R1) extended `checkOBO`
+// to honor the same predicate on the write path — otherwise the bot
+// receives the DM via fan-out but its reply 403s.
+//
+// The test name is preserved so the historical YUJ-1538 pin stays
+// findable in git blame; the assertion is now flipped to APPROVE the
+// reply when the friend-gate (`grantorCanReadChannel` →
+// `oboChannelAccessOverride`, defaulted to true in
+// `newBotAPIForCheckYUJ1538`) confirms live access. The companion
+// regression test `TestCheckOBO_DM_GlobalEnabled_NoScope_FriendGateDenied`
+// pins the deny side: friend-gate denial must still block the reply.
 func TestCheckOBO_YUJ1538_DMNoScope_StillUnauthorized(t *testing.T) {
 	const dmPeer = "u_bob"
 	s := seedGrantNoScope(t) // grant exists with global_enabled=1, but no scope
 	ba := newBotAPIForCheckYUJ1538(s)
+	if err := ba.checkOBO(tBot, tGrantor, dmPeer, common.ChannelTypePerson.Uint8()); err != nil {
+		t.Fatalf("Mininglamp-OSS/octo-server#162 R1: DM with global_enabled=1 and no scope row must APPROVE when friend-gate allows access (read/write symmetry), got %v", err)
+	}
+}
+
+// TestCheckOBO_DM_GlobalEnabled_NoScope_FriendGateDenied — deny-side
+// regression for the PR#162 R1 DM implicit-scope branch. With
+// `global_enabled=1`, no scope row, but the friend-gate
+// (`grantorCanReadChannel` → `IsFriend`) returning false, the reply
+// MUST still 403. This pins that the friend-gate is the load-bearing
+// safety net: removing it (or letting an error fall through to "ok")
+// would let an unrelated peer's DM authorize a reply, because there
+// is no per-peer scope row in the picture.
+func TestCheckOBO_DM_GlobalEnabled_NoScope_FriendGateDenied(t *testing.T) {
+	const dmPeer = "u_stranger"
+	s := seedGrantNoScope(t) // grant exists with global_enabled=1, but no scope
+	ba := newBotAPIForCheckYUJ1538(s)
+	// Friend-gate denies access for this peer.
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		if channelType == common.ChannelTypePerson.Uint8() && channelID == dmPeer {
+			return false, nil
+		}
+		return true, nil
+	}
 	err := ba.checkOBO(tBot, tGrantor, dmPeer, common.ChannelTypePerson.Uint8())
 	if !errors.Is(err, ErrOBONotAuthorized) {
-		t.Fatalf("YUJ-1538 / PR#114: DM with no scope row must STILL deny (regression guard), got %v", err)
+		t.Fatalf("Mininglamp-OSS/octo-server#162 R1: DM with global_enabled=1 and no scope row must STILL deny when friend-gate returns false, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## What

`findActiveGrantsForChannel` INNER JOINs on `obo_scopes` with `enabled=1`, so DM grants with `global_enabled=1` and zero scope rows short-circuit to empty and the fan-out listener never fires. Group-shaped channels solved this gap in PR#121 via `findGlobalGrantsWithoutScope`; this PR closes the symmetrical hole for Person channels.

## How

- **`obo_db.go`** — adds `findGlobalGrantsForDM(grantorUID, peerChannelID)` to the `oboStore` interface + production impl. Returns active grants with `global_enabled=1` whose `grantor_uid` matches AND for which no `obo_scopes` row exists for `(peerChannelID, ChannelTypePerson)`. The `NOT EXISTS` anti-join keeps the explicit / implicit feeders disjoint and preserves the PR#121 R5 / B1 \"explicit scope row wins\" invariant.
- **`obo_fanout.go`** — DM branch now calls `findGlobalGrantsForDM` after `findActiveGrantsForChannel`, merging via the new `mergeGrantsDedup` helper (belt-and-braces — the two queries are disjoint by construction). The friend-gate `grantorCanReadChannel` re-check inside the dispatch loop continues to enforce live access at TOCTOU close-out, so unrelated peers cannot leak DM content via the new path.
- **`obo_fake_test.go`** — fake-store impl mirroring the production `NOT EXISTS` semantics.

## Tests

New:
- `TestFanout_DM_GlobalEnabled_NoScopes` — regression repro for #161
- `TestFanout_DM_GlobalEnabled_WithExplicitScope` — dedup + ordering pin
- `TestFanout_DM_GlobalDisabled_NoScopes` — gating predicate preserved

Updated (DM-side semantics flip):
- `TestFanout_YUJ1538_DMStillRequiresScopeRow` — the old \"DMs require scope rows\" invariant was the YUJ-1538 author's intent but is exactly the bug behind #161; the test now asserts the new behavior. The original YUJ-1538 group-side coverage is unchanged.
- `TestFanout_DMUnrelatedPeer_NoMatch` — under the new semantics the access check IS reached; the test now uses the friend-gate denial as the no-leak guarantee.

`go test ./modules/bot_api/...` is green.

Closes #161