### PR TITLE
feat(space): align user-side PUT /v1/space/:space_id with manager endpoint (#163)

### DIFF
--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -327,7 +328,16 @@ func (s *Space) getSpace(c *wkhttp.Context) {
 	})
 }
 
-// updateSpace 更新空间信息
+// userSpacePresetGroupIdsMaxBytes preset_group_ids 列为 TEXT (≤65535 字节)。
+// 校验取整数 sanity cap，超过即拒，避免把 driver-level 错误透传给用户。
+const userSpacePresetGroupIdsMaxBytes = 65535
+
+// updateSpace 用户侧修改空间基础信息（owner / admin 自服务）。
+//
+// 全字段部分更新：nil 字段不变更；至少需要提供一个字段。
+// 复用管理端 managerDB.updateSpaceProfile 的事务 + SELECT ... FOR UPDATE 实现
+// 保证存在性 / 状态校验与 UPDATE 同事务串行化，关闭 handler guard 与并发解散之间的
+// TOCTOU 窗口；max_users 不在用户侧暴露（仍由管理端控制）。
 func (s *Space) updateSpace(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	spaceId := c.Param("space_id")
@@ -351,17 +361,143 @@ func (s *Space) updateSpace(c *wkhttp.Context) {
 		c.ResponseError(errors.New("请求参数错误"))
 		return
 	}
+	if req.Name == nil && req.Description == nil && req.Logo == nil && req.JoinMode == nil && req.PresetGroupIds == nil {
+		c.ResponseError(errors.New("至少需要提供 name / description / logo / join_mode / preset_group_ids 之一"))
+		return
+	}
+
+	// 字段级校验：长度单位为字符（rune），与 MySQL VARCHAR(N) 的字符语义一致。
+	// 复用管理端常量（同包，含义完全相同），避免双写漂移。
+	if req.Name != nil {
+		trimmed := strings.TrimSpace(*req.Name)
+		if trimmed == "" {
+			c.ResponseError(errors.New("空间名称不能为空"))
+			return
+		}
+		if utf8.RuneCountInString(trimmed) > managerSpaceNameMaxChars {
+			c.ResponseError(fmt.Errorf("空间名称不能超过 %d 个字符", managerSpaceNameMaxChars))
+			return
+		}
+		req.Name = &trimmed
+	}
+	if req.Description != nil {
+		trimmed := strings.TrimSpace(*req.Description)
+		if utf8.RuneCountInString(trimmed) > managerSpaceDescriptionMaxChars {
+			c.ResponseError(fmt.Errorf("空间描述不能超过 %d 个字符", managerSpaceDescriptionMaxChars))
+			return
+		}
+		req.Description = &trimmed
+	}
+	if req.Logo != nil && utf8.RuneCountInString(*req.Logo) > managerSpaceLogoMaxChars {
+		c.ResponseError(fmt.Errorf("Logo 不能超过 %d 个字符", managerSpaceLogoMaxChars))
+		return
+	}
 	if req.JoinMode != nil && (*req.JoinMode < JoinModeDirect || *req.JoinMode > JoinModeApproval) {
 		c.ResponseError(errors.New("无效的加入模式，仅支持 0(直接加入) 或 1(需要审批)"))
 		return
 	}
+	if req.PresetGroupIds != nil {
+		if err := validatePresetGroupIds(*req.PresetGroupIds); err != nil {
+			c.ResponseError(err)
+			return
+		}
+	}
 
-	err = s.db.updateSpace(spaceId, req.Name, req.Description, req.Logo, req.PresetGroupIds, req.JoinMode)
+	before, err := s.mdb.updateSpaceProfile(spaceId, req.Name, req.Description, req.Logo, req.JoinMode, nil, req.PresetGroupIds)
 	if err != nil {
-		c.ResponseError(errors.New("更新空间失败"))
+		// 复用管理端 sentinel，并发解散与 active 检查之间的 race 由事务侧裁决。
+		if errors.Is(err, ErrSpaceNotFound) {
+			c.ResponseError(errors.New("空间不存在"))
+			return
+		}
+		if errors.Is(err, ErrSpaceDisbandedForUpdate) {
+			c.ResponseError(errors.New("空间已解散，无法修改空间信息"))
+			return
+		}
+		s.Error("用户修改空间信息失败", zap.Error(err), zap.String("spaceId", spaceId), zap.String("operator", loginUID))
+		c.ResponseError(errors.New("更新空间信息失败"))
 		return
 	}
+
+	// 审计日志：from 取自事务内锁定时刻的快照，避免并发更新导致 stale；
+	// 字段命名与管理端 m.Info("管理员修改空间信息", ...) 对齐，便于运维统一查询。
+	fields := []zap.Field{
+		zap.String("spaceId", spaceId),
+		zap.String("operator", loginUID),
+		zap.Int("role", member.Role),
+	}
+	if req.Name != nil {
+		fields = append(fields, zap.String("nameFrom", before.Name), zap.String("nameTo", *req.Name))
+	}
+	if req.Description != nil {
+		fields = append(fields, zap.String("descFrom", before.Description), zap.String("descTo", *req.Description))
+	}
+	if req.Logo != nil {
+		fields = append(fields, zap.String("logoFrom", before.Logo), zap.String("logoTo", *req.Logo))
+	}
+	if req.JoinMode != nil {
+		fields = append(fields, zap.Int("joinModeFrom", before.JoinMode), zap.Int("joinModeTo", *req.JoinMode))
+	}
+	if req.PresetGroupIds != nil {
+		fields = append(fields,
+			zap.String("presetGroupIdsFrom", derefStringOr(before.PresetGroupIds, "")),
+			zap.String("presetGroupIdsTo", *req.PresetGroupIds),
+		)
+	}
+	s.Info("用户修改空间信息", fields...)
 	c.ResponseOK()
+}
+
+// derefStringOr 安全解引用 *string，nil 时返回 fallback。
+// 审计日志专用：preset_group_ids 是 *string，from 值可能为 nil。
+func derefStringOr(p *string, fallback string) string {
+	if p == nil {
+		return fallback
+	}
+	return *p
+}
+
+// validatePresetGroupIds 校验 preset_group_ids 的字符串载荷。
+//
+// 合法输入：
+//   - 空字符串 ""           → 表示清空预设群组列表
+//   - JSON 字符串数组 "[...]" → 元素必须严格为 JSON 字符串（含空数组 "[]"）
+//
+// 拒绝（之前用 json.Unmarshal 到 []string 会静默放过的坑）：
+//   - 顶层 "null"            → Go 解码到 []string 得 nil slice 不报错
+//   - 数组含 null：[null]     → Go 解码到 []string 把 null 写成 ""，不报错
+//   - 数组含非字符串：[1,{}]  → 同上，会被解码失败拦下，但单测显式覆盖
+//
+// 实现：先按 []json.RawMessage 切片解，再逐元素校验首字节是 '"'，
+// 这样能区分 JSON 字符串和 null/number/object/array。
+func validatePresetGroupIds(raw string) error {
+	if len(raw) > userSpacePresetGroupIdsMaxBytes {
+		return fmt.Errorf("preset_group_ids 不能超过 %d 字节", userSpacePresetGroupIdsMaxBytes)
+	}
+	if raw == "" {
+		return nil
+	}
+	// 用 *[]json.RawMessage 区分 "[...]" 与 "null"：top-level null 解到 *T 会得 nil 指针。
+	var arr *[]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &arr); err != nil {
+		return errors.New("preset_group_ids 必须为 JSON 字符串数组")
+	}
+	if arr == nil {
+		return errors.New("preset_group_ids 不能为 null，请用空字符串表示清空")
+	}
+	for i, elem := range *arr {
+		// json.RawMessage 不包含前后空白（json.Decoder 已剥离），直接判首字节即可。
+		// 字符串必以 '"' 开头；其余（null/数字/对象/数组）一律拒。
+		if len(elem) == 0 || elem[0] != '"' {
+			return fmt.Errorf("preset_group_ids[%d] 必须为字符串", i)
+		}
+		// 复活解到 string 以确保转义合法（如 "\uXXXX" 完整、引号闭合）。
+		var s string
+		if err := json.Unmarshal(elem, &s); err != nil {
+			return fmt.Errorf("preset_group_ids[%d] 解析失败: %w", i, err)
+		}
+	}
+	return nil
 }
 
 // disbandSpace 解散空间

--- a/modules/space/api_manager.go
+++ b/modules/space/api_manager.go
@@ -547,7 +547,8 @@ func (m *Manager) updateSpaceProfile(c *wkhttp.Context) {
 		}
 	}
 
-	before, err := m.managerDB.updateSpaceProfile(spaceId, req.Name, req.Description, req.Logo, req.JoinMode, req.MaxUsers)
+	// presetGroupIds 仅由用户侧 PUT /v1/space/:space_id 使用，管理端固定传 nil。
+	before, err := m.managerDB.updateSpaceProfile(spaceId, req.Name, req.Description, req.Logo, req.JoinMode, req.MaxUsers, nil)
 	if err != nil {
 		// 事务内 SELECT FOR UPDATE 用 sentinel error 报告并发场景；HTTP 层映射为 4xx 提示。
 		// 不能依赖 RowsAffected 区分：MySQL 默认返回变更行数而非匹配行数，

--- a/modules/space/api_manager_test.go
+++ b/modules/space/api_manager_test.go
@@ -1451,7 +1451,7 @@ func TestManagerDB_UpdateSpaceProfile_TOCTOU(t *testing.T) {
 
 	t.Run("returns ErrSpaceNotFound for missing space", func(t *testing.T) {
 		name := "x"
-		before, err := mdb.updateSpaceProfile("nope-not-exists", &name, nil, nil, nil, nil)
+		before, err := mdb.updateSpaceProfile("nope-not-exists", &name, nil, nil, nil, nil, nil)
 		assert.ErrorIs(t, err, ErrSpaceNotFound)
 		assert.Nil(t, before)
 	})
@@ -1461,7 +1461,7 @@ func TestManagerDB_UpdateSpaceProfile_TOCTOU(t *testing.T) {
 		// 调用 DB 方法应被事务内的 status 校验拦下。
 		seedSpace(t, "mgr-upd-toctou", "dying", "u-o-toc", SpaceStatusDisbanded)
 		name := "new name"
-		before, err := mdb.updateSpaceProfile("mgr-upd-toctou", &name, nil, nil, nil, nil)
+		before, err := mdb.updateSpaceProfile("mgr-upd-toctou", &name, nil, nil, nil, nil, nil)
 		assert.ErrorIs(t, err, ErrSpaceDisbandedForUpdate)
 		assert.Nil(t, before)
 
@@ -1475,7 +1475,7 @@ func TestManagerDB_UpdateSpaceProfile_TOCTOU(t *testing.T) {
 
 	t.Run("no-op when all fields are nil on existing space", func(t *testing.T) {
 		seedSpace(t, "mgr-upd-noop", "untouched", "u-o-noop", SpaceStatusNormal)
-		before, err := mdb.updateSpaceProfile("mgr-upd-noop", nil, nil, nil, nil, nil)
+		before, err := mdb.updateSpaceProfile("mgr-upd-noop", nil, nil, nil, nil, nil, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, before)
 		assert.Equal(t, "untouched", before.Name, "no-op 仍应返回 pre-update 快照")
@@ -1489,7 +1489,7 @@ func TestManagerDB_UpdateSpaceProfile_TOCTOU(t *testing.T) {
 		// 不再使用 tx 外的 sp，避免并发更新窗口下旧值 stale。
 		seedSpace(t, "mgr-upd-snap", "original", "u-o-snap", SpaceStatusNormal)
 		newName := "renamed"
-		before, err := mdb.updateSpaceProfile("mgr-upd-snap", &newName, nil, nil, nil, nil)
+		before, err := mdb.updateSpaceProfile("mgr-upd-snap", &newName, nil, nil, nil, nil, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, before)
 		assert.Equal(t, "original", before.Name, "before 应为 UPDATE 前的值")

--- a/modules/space/api_update_space_test.go
+++ b/modules/space/api_update_space_test.go
@@ -1,0 +1,417 @@
+package space
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+// 用户侧 PUT /v1/space/:space_id 测试。
+//
+// 复用 manager 端测试基础设施（seedSpace / readSpace / testutil.Token），
+// 重点覆盖 issue #163 acceptance：partial update 不再误清空、字段级校验、
+// preset_group_ids JSON 校验、auth、disbanded 拒绝、幂等重放、审计日志路径。
+//
+// TOCTOU 已由 TestManagerDB_UpdateSpaceProfile_TOCTOU 覆盖，本文件不再重复。
+
+// seedUserSpace 为当前测试用户（testutil.UID）创建一个 spaceId + member 行。
+// role: 0=普通成员 / 1=admin / 2=owner。
+func seedUserSpace(t *testing.T, spaceId, name string, callerRole int, status int) {
+	t.Helper()
+	err := testSpaceDB.insertSpaceNoTx(&SpaceModel{
+		SpaceId: spaceId,
+		Name:    name,
+		Creator: testutil.UID,
+		Status:  status,
+	})
+	assert.NoError(t, err)
+	err = testSpaceDB.insertMemberNoTx(&MemberModel{
+		SpaceId: spaceId,
+		UID:     testutil.UID,
+		Role:    callerRole,
+		Status:  1,
+	})
+	assert.NoError(t, err)
+}
+
+func putSpace(t *testing.T, spaceId, body, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("PUT", "/v1/space/"+spaceId, bytes.NewReader([]byte(body)))
+	assert.NoError(t, err)
+	if token != "" {
+		req.Header.Set("token", token)
+	}
+	testSrv.GetRoute().ServeHTTP(w, req)
+	return w
+}
+
+func TestUserUpdateSpace_PartialUpdate(t *testing.T) {
+	_, _, err := setup(t)
+	assert.NoError(t, err)
+
+	t.Run("update name only leaves other fields untouched", func(t *testing.T) {
+		spaceId := "usr-upd-name"
+		seedUserSpace(t, spaceId, "old name", 2, SpaceStatusNormal)
+		// 给空间补一些初始非默认值，便于验证未变更字段
+		_, err := testCtx.DB().Update("space").
+			Set("description", "orig desc").
+			Set("logo", "orig-logo").
+			Set("join_mode", JoinModeApproval).
+			Set("preset_group_ids", `["g_old"]`).
+			Where("space_id=?", spaceId).Exec()
+		assert.NoError(t, err)
+
+		w := putSpace(t, spaceId, util.ToJson(map[string]interface{}{"name": "new shiny name"}), testutil.Token)
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		sp := readSpace(t, spaceId)
+		assert.Equal(t, "new shiny name", sp.Name)
+		assert.Equal(t, "orig desc", sp.Description, "description 未提供时不应被覆盖为空（回归 issue #163 第 1 点）")
+		assert.Equal(t, "orig-logo", sp.Logo, "logo 未提供时不应被覆盖为空")
+		assert.Equal(t, JoinModeApproval, sp.JoinMode)
+		assert.NotNil(t, sp.PresetGroupIds)
+		assert.Equal(t, `["g_old"]`, *sp.PresetGroupIds)
+	})
+
+	t.Run("update description only", func(t *testing.T) {
+		spaceId := "usr-upd-desc"
+		seedUserSpace(t, spaceId, "keep me", 2, SpaceStatusNormal)
+		w := putSpace(t, spaceId, util.ToJson(map[string]interface{}{"description": "new desc"}), testutil.Token)
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		sp := readSpace(t, spaceId)
+		assert.Equal(t, "keep me", sp.Name)
+		assert.Equal(t, "new desc", sp.Description)
+	})
+
+	t.Run("update logo only", func(t *testing.T) {
+		spaceId := "usr-upd-logo"
+		seedUserSpace(t, spaceId, "keep me", 2, SpaceStatusNormal)
+		w := putSpace(t, spaceId, util.ToJson(map[string]interface{}{"logo": "https://cdn.example/x.png"}), testutil.Token)
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		assert.Equal(t, "https://cdn.example/x.png", readSpace(t, spaceId).Logo)
+	})
+
+	t.Run("update join_mode only", func(t *testing.T) {
+		spaceId := "usr-upd-jm"
+		seedUserSpace(t, spaceId, "keep", 2, SpaceStatusNormal)
+		w := putSpace(t, spaceId, util.ToJson(map[string]interface{}{"join_mode": JoinModeApproval}), testutil.Token)
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		assert.Equal(t, JoinModeApproval, readSpace(t, spaceId).JoinMode)
+	})
+
+	t.Run("update preset_group_ids only", func(t *testing.T) {
+		spaceId := "usr-upd-pgi"
+		seedUserSpace(t, spaceId, "keep", 2, SpaceStatusNormal)
+		w := putSpace(t, spaceId, util.ToJson(map[string]interface{}{"preset_group_ids": `["g_new1","g_new2"]`}), testutil.Token)
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		sp := readSpace(t, spaceId)
+		assert.NotNil(t, sp.PresetGroupIds)
+		assert.Equal(t, `["g_new1","g_new2"]`, *sp.PresetGroupIds)
+	})
+
+	t.Run("preset_group_ids JSON null is treated as no-change", func(t *testing.T) {
+		// 区分两种"未提供"语义：
+		//   - 字段缺省 → req.PresetGroupIds == nil → 不变更
+		//   - JSON null → Go 解码也得 nil → 不变更（不应被当成"清空"）
+		// 客户端要清空请显式传空字符串 ""。
+		spaceId := "usr-upd-pgi-null"
+		seedUserSpace(t, spaceId, "keep", 2, SpaceStatusNormal)
+		_, err := testCtx.DB().Update("space").
+			Set("preset_group_ids", `["g_keep"]`).
+			Where("space_id=?", spaceId).Exec()
+		assert.NoError(t, err)
+
+		// 拼一个带有其他字段的 body（仅 null preset_group_ids 会被 handler 拒为 all-nil），
+		// 验证 null 不会触发"清空"行为。
+		body := `{"name":"renamed","preset_group_ids":null}`
+		w := putSpace(t, spaceId, body, testutil.Token)
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		sp := readSpace(t, spaceId)
+		assert.Equal(t, "renamed", sp.Name)
+		assert.NotNil(t, sp.PresetGroupIds)
+		assert.Equal(t, `["g_keep"]`, *sp.PresetGroupIds, "JSON null 不应清空 preset_group_ids")
+	})
+
+	t.Run("preset_group_ids empty string clears the list", func(t *testing.T) {
+		spaceId := "usr-upd-pgi-clr"
+		seedUserSpace(t, spaceId, "keep", 2, SpaceStatusNormal)
+		_, err := testCtx.DB().Update("space").
+			Set("preset_group_ids", `["g_old"]`).
+			Where("space_id=?", spaceId).Exec()
+		assert.NoError(t, err)
+
+		w := putSpace(t, spaceId, util.ToJson(map[string]interface{}{"preset_group_ids": ""}), testutil.Token)
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		sp := readSpace(t, spaceId)
+		assert.NotNil(t, sp.PresetGroupIds)
+		assert.Equal(t, "", *sp.PresetGroupIds, "空字符串应落地为空值，表示清空预设群组")
+	})
+}
+
+func TestUserUpdateSpace_CombinedUpdate(t *testing.T) {
+	_, _, err := setup(t)
+	assert.NoError(t, err)
+
+	spaceId := "usr-upd-combo"
+	seedUserSpace(t, spaceId, "old", 2, SpaceStatusNormal)
+
+	body := util.ToJson(map[string]interface{}{
+		"name":             "new name",
+		"description":      "new desc",
+		"logo":             "https://cdn.example/y.png",
+		"join_mode":        JoinModeApproval,
+		"preset_group_ids": `["g_a","g_b"]`,
+	})
+	w := putSpace(t, spaceId, body, testutil.Token)
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	sp := readSpace(t, spaceId)
+	assert.Equal(t, "new name", sp.Name)
+	assert.Equal(t, "new desc", sp.Description)
+	assert.Equal(t, "https://cdn.example/y.png", sp.Logo)
+	assert.Equal(t, JoinModeApproval, sp.JoinMode)
+	assert.NotNil(t, sp.PresetGroupIds)
+	assert.Equal(t, `["g_a","g_b"]`, *sp.PresetGroupIds)
+}
+
+func TestUserUpdateSpace_TrimsWhitespace(t *testing.T) {
+	_, _, err := setup(t)
+	assert.NoError(t, err)
+
+	t.Run("trim name and persist trimmed", func(t *testing.T) {
+		spaceId := "usr-upd-trim-n"
+		seedUserSpace(t, spaceId, "old", 2, SpaceStatusNormal)
+		w := putSpace(t, spaceId, util.ToJson(map[string]interface{}{"name": "   padded   "}), testutil.Token)
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		assert.Equal(t, "padded", readSpace(t, spaceId).Name)
+	})
+
+	t.Run("trim description and persist trimmed", func(t *testing.T) {
+		spaceId := "usr-upd-trim-d"
+		seedUserSpace(t, spaceId, "old", 2, SpaceStatusNormal)
+		w := putSpace(t, spaceId, util.ToJson(map[string]interface{}{"description": "  hi  "}), testutil.Token)
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		assert.Equal(t, "hi", readSpace(t, spaceId).Description)
+	})
+}
+
+func TestUserUpdateSpace_Validation(t *testing.T) {
+	_, _, err := setup(t)
+	assert.NoError(t, err)
+
+	spaceId := "usr-upd-v"
+	seedUserSpace(t, spaceId, "v space", 2, SpaceStatusNormal)
+
+	t.Run("reject empty body / all-nil", func(t *testing.T) {
+		w := putSpace(t, spaceId, `{}`, testutil.Token)
+		assert.NotEqual(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("reject empty/whitespace name", func(t *testing.T) {
+		for _, name := range []string{"", "   "} {
+			w := putSpace(t, spaceId, util.ToJson(map[string]interface{}{"name": name}), testutil.Token)
+			assert.NotEqual(t, http.StatusOK, w.Code, "empty name %q should be rejected", name)
+		}
+	})
+
+	t.Run("reject name longer than 100 chars (ASCII)", func(t *testing.T) {
+		long := strings.Repeat("a", 101)
+		w := putSpace(t, spaceId, util.ToJson(map[string]interface{}{"name": long}), testutil.Token)
+		assert.NotEqual(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("accept 100 CJK chars but reject 101", func(t *testing.T) {
+		// 与 manager 端 utf8 长度修复对齐：100 个汉字（300 字节）应通过，101 个被拒。
+		spaceIdOK := "usr-upd-cjk-ok"
+		seedUserSpace(t, spaceIdOK, "old", 2, SpaceStatusNormal)
+		nameOK := strings.Repeat("空", 100)
+		w := putSpace(t, spaceIdOK, util.ToJson(map[string]interface{}{"name": nameOK}), testutil.Token)
+		assert.Equal(t, http.StatusOK, w.Code, "100 个汉字应被接受")
+		assert.Equal(t, nameOK, readSpace(t, spaceIdOK).Name)
+
+		nameBad := strings.Repeat("空", 101)
+		w = putSpace(t, spaceId, util.ToJson(map[string]interface{}{"name": nameBad}), testutil.Token)
+		assert.NotEqual(t, http.StatusOK, w.Code, "101 个汉字应被拒")
+	})
+
+	t.Run("reject description longer than 500 chars", func(t *testing.T) {
+		w := putSpace(t, spaceId, util.ToJson(map[string]interface{}{"description": strings.Repeat("d", 501)}), testutil.Token)
+		assert.NotEqual(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("reject logo longer than 200 chars", func(t *testing.T) {
+		w := putSpace(t, spaceId, util.ToJson(map[string]interface{}{"logo": strings.Repeat("l", 201)}), testutil.Token)
+		assert.NotEqual(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("reject invalid join_mode", func(t *testing.T) {
+		for _, jm := range []int{-1, 2, 99} {
+			w := putSpace(t, spaceId, util.ToJson(map[string]interface{}{"join_mode": jm}), testutil.Token)
+			assert.NotEqual(t, http.StatusOK, w.Code, "join_mode=%d should be rejected", jm)
+		}
+	})
+
+	t.Run("reject preset_group_ids not a JSON array of strings", func(t *testing.T) {
+		// 覆盖 json.Unmarshal 到 []string 时静默放过的坑：
+		//   - top-level "null"   → 解到 []string 得 nil slice，无 error
+		//   - ["a", null]        → 解到 []string 把 null 写成 ""，无 error
+		// 必须显式拒绝，否则会把无效配置写入 DB，后续 joinPresetGroups 静默跳过。
+		cases := []string{
+			`{"not":"array"}`, // object
+			`["ok", 123]`,     // 混合类型
+			`"just a string"`, // 裸字符串
+			`12345`,           // number
+			`[`,               // 非法 JSON
+			`null`,            // top-level null（旧实现会放过）
+			`[null]`,          // 数组含 null（旧实现会放过并落库 [""]）
+			`["a", null, "b"]`,
+			`[{}]`,            // 数组含对象
+			`[[]]`,            // 数组含数组
+			`[true]`,          // 数组含布尔
+		}
+		for _, raw := range cases {
+			w := putSpace(t, spaceId, util.ToJson(map[string]interface{}{"preset_group_ids": raw}), testutil.Token)
+			assert.NotEqual(t, http.StatusOK, w.Code, "preset_group_ids=%q should be rejected", raw)
+		}
+	})
+
+	t.Run("accept empty array as valid (semantically equal to empty string)", func(t *testing.T) {
+		spaceIdOK := "usr-upd-pgi-empty-arr"
+		seedUserSpace(t, spaceIdOK, "keep", 2, SpaceStatusNormal)
+		w := putSpace(t, spaceIdOK, util.ToJson(map[string]interface{}{"preset_group_ids": `[]`}), testutil.Token)
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		sp := readSpace(t, spaceIdOK)
+		assert.NotNil(t, sp.PresetGroupIds)
+		assert.Equal(t, `[]`, *sp.PresetGroupIds)
+	})
+
+	t.Run("reject preset_group_ids exceeding sanity cap", func(t *testing.T) {
+		// 构造一个超过 65535 字节的字符串
+		raw := `["` + strings.Repeat("x", userSpacePresetGroupIdsMaxBytes+10) + `"]`
+		w := putSpace(t, spaceId, util.ToJson(map[string]interface{}{"preset_group_ids": raw}), testutil.Token)
+		assert.NotEqual(t, http.StatusOK, w.Code)
+	})
+}
+
+func TestUserUpdateSpace_Auth(t *testing.T) {
+	_, _, err := setup(t)
+	assert.NoError(t, err)
+
+	body := util.ToJson(map[string]interface{}{"name": "x"})
+
+	t.Run("non-member is rejected", func(t *testing.T) {
+		spaceId := "usr-upd-auth-nm"
+		// 空间存在但 testutil.UID 不是成员
+		err := testSpaceDB.insertSpaceNoTx(&SpaceModel{
+			SpaceId: spaceId,
+			Name:    "no-member",
+			Creator: "other-user",
+			Status:  SpaceStatusNormal,
+		})
+		assert.NoError(t, err)
+
+		w := putSpace(t, spaceId, body, testutil.Token)
+		assert.NotEqual(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "无权限")
+	})
+
+	t.Run("role=0 plain member is rejected", func(t *testing.T) {
+		spaceId := "usr-upd-auth-mem"
+		err := testSpaceDB.insertSpaceNoTx(&SpaceModel{
+			SpaceId: spaceId,
+			Name:    "plain-member",
+			Creator: "other-user",
+			Status:  SpaceStatusNormal,
+		})
+		assert.NoError(t, err)
+		err = testSpaceDB.insertMemberNoTx(&MemberModel{
+			SpaceId: spaceId,
+			UID:     testutil.UID,
+			Role:    0,
+			Status:  1,
+		})
+		assert.NoError(t, err)
+
+		w := putSpace(t, spaceId, body, testutil.Token)
+		assert.NotEqual(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "无权限")
+	})
+
+	t.Run("role=1 admin is accepted", func(t *testing.T) {
+		spaceId := "usr-upd-auth-adm"
+		err := testSpaceDB.insertSpaceNoTx(&SpaceModel{
+			SpaceId: spaceId,
+			Name:    "admin-space",
+			Creator: "other-user",
+			Status:  SpaceStatusNormal,
+		})
+		assert.NoError(t, err)
+		err = testSpaceDB.insertMemberNoTx(&MemberModel{
+			SpaceId: spaceId,
+			UID:     testutil.UID,
+			Role:    1,
+			Status:  1,
+		})
+		assert.NoError(t, err)
+
+		w := putSpace(t, spaceId, util.ToJson(map[string]interface{}{"name": "admin-renamed"}), testutil.Token)
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		assert.Equal(t, "admin-renamed", readSpace(t, spaceId).Name)
+	})
+
+	t.Run("role=2 owner is accepted", func(t *testing.T) {
+		spaceId := "usr-upd-auth-own"
+		seedUserSpace(t, spaceId, "owner-space", 2, SpaceStatusNormal)
+		w := putSpace(t, spaceId, util.ToJson(map[string]interface{}{"name": "owner-renamed"}), testutil.Token)
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		assert.Equal(t, "owner-renamed", readSpace(t, spaceId).Name)
+	})
+}
+
+func TestUserUpdateSpace_ActiveGuard(t *testing.T) {
+	_, _, err := setup(t)
+	assert.NoError(t, err)
+	body := util.ToJson(map[string]interface{}{"name": "x"})
+
+	t.Run("rejects disbanded space at active guard", func(t *testing.T) {
+		spaceId := "usr-upd-dead"
+		seedUserSpace(t, spaceId, "dead", 2, SpaceStatusDisbanded)
+		w := putSpace(t, spaceId, body, testutil.Token)
+		assert.NotEqual(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "解散")
+	})
+
+	t.Run("rejects banned space at active guard", func(t *testing.T) {
+		spaceId := "usr-upd-ban"
+		seedUserSpace(t, spaceId, "ban", 2, SpaceStatusBanned)
+		w := putSpace(t, spaceId, body, testutil.Token)
+		assert.NotEqual(t, http.StatusOK, w.Code)
+		// banned 走 checkSpaceActive，返回"空间不存在或已解散"提示
+	})
+}
+
+func TestUserUpdateSpace_IdempotentReplay(t *testing.T) {
+	// 回归：MySQL 默认 RowsAffected = 实际变更行数。
+	// helper 走 SELECT ... FOR UPDATE + sentinel，不依赖 RowsAffected，
+	// 字段值完全相同的重放仍应返回 200。
+	_, _, err := setup(t)
+	assert.NoError(t, err)
+
+	spaceId := "usr-upd-idem"
+	seedUserSpace(t, spaceId, "same name", 2, SpaceStatusNormal)
+	body := util.ToJson(map[string]interface{}{"name": "same name"})
+
+	for i := 0; i < 2; i++ {
+		w := putSpace(t, spaceId, body, testutil.Token)
+		assert.Equal(t, http.StatusOK, w.Code, fmt.Sprintf("第 %d 次重放应仍为 200", i+1))
+		assert.NotContains(t, w.Body.String(), "不存在")
+	}
+}

--- a/modules/space/db.go
+++ b/modules/space/db.go
@@ -53,21 +53,9 @@ func (d *DB) querySpaceByID(spaceId string) (*SpaceModel, error) {
 	return &m, err
 }
 
-func (d *DB) updateSpace(spaceId string, name string, description string, logo string, presetGroupIds *string, joinMode *int) error {
-	builder := d.session.Update("space").
-		Set("name", name).
-		Set("description", description).
-		Set("logo", logo).
-		Set("updated_at", time.Now())
-	if presetGroupIds != nil {
-		builder = builder.Set("preset_group_ids", *presetGroupIds)
-	}
-	if joinMode != nil {
-		builder = builder.Set("join_mode", *joinMode)
-	}
-	_, err := builder.Where("space_id=?", spaceId).Exec()
-	return err
-}
+// updateSpace 用户侧部分更新空间基础信息已迁移到 managerDB.updateSpaceProfile：
+// 该 helper 提供事务 + SELECT ... FOR UPDATE + sentinel error 的 TOCTOU 安全语义，
+// 用户侧 handler 通过 Space.mdb 直接调用，无需在 DB 层另起一份。
 
 func (d *DB) disbandSpace(spaceId string) error {
 	_, err := d.session.Update("space").Set("status", 0).Set("updated_at", time.Now()).Where("space_id=?", spaceId).Exec()

--- a/modules/space/db_manager.go
+++ b/modules/space/db_manager.go
@@ -230,6 +230,17 @@ var ErrSpaceDisbandedForUpdate = errors.New("space already disbanded")
 // 由于读取与 UPDATE 在同一事务内串行化，并发更新场景下的 from 值不会 stale。
 //
 // nil 参数不变更；调用方需保证至少有一个非 nil（否则 no-op，但仍返回快照）。
+//
+// presetGroupIds 与其他字段一致用 *string 表达"是否变更"，传入字符串作为整体写入
+// preset_group_ids 列（运行期解析见 api.go 的 joinPresetGroups）；
+// 该参数仅由用户侧 PUT /v1/space/:space_id 使用，管理端目前传 nil。
+//
+// 状态守卫契约：本函数仅拦截 SpaceStatusDisbanded（return ErrSpaceDisbandedForUpdate），
+// 不拦截 SpaceStatusBanned —— manager 端有意允许对 banned 空间执行修复性更新。
+// 因此调用方必须自行决定是否拒绝 banned：
+//   - 管理端 handler 故意放行；
+//   - 用户端 handler 通过 checkSpaceActive (status=1 才放行) 在入口就拒绝 banned。
+// 不要假设 helper 会替你挡 banned。
 func (d *managerDB) updateSpaceProfile(
 	spaceId string,
 	name *string,
@@ -237,6 +248,7 @@ func (d *managerDB) updateSpaceProfile(
 	logo *string,
 	joinMode *int,
 	maxUsers *int,
+	presetGroupIds *string,
 ) (*SpaceModel, error) {
 	tx, err := d.session.Begin()
 	if err != nil {
@@ -280,6 +292,10 @@ func (d *managerDB) updateSpaceProfile(
 	}
 	if maxUsers != nil {
 		builder = builder.Set("max_users", *maxUsers)
+		changed = true
+	}
+	if presetGroupIds != nil {
+		builder = builder.Set("preset_group_ids", *presetGroupIds)
 		changed = true
 	}
 	if !changed {

--- a/modules/space/model.go
+++ b/modules/space/model.go
@@ -122,12 +122,15 @@ type createSpaceReq struct {
 	JoinMode    int    `json:"join_mode"` // 0=直接加入(默认) 1=需要审批
 }
 
+// updateSpaceReq 用户侧 PUT /v1/space/:space_id 请求体。
+// 所有字段均为可选指针；nil 表示不变更。handler 拒空 body / all-nil。
+// 注意：max_users 仍是管理端专属，本结构不暴露。
 type updateSpaceReq struct {
-	Name           string  `json:"name"`
-	Description    string  `json:"description"`
-	Logo           string  `json:"logo"`
-	PresetGroupIds *string `json:"preset_group_ids"`
+	Name           *string `json:"name"`
+	Description    *string `json:"description"`
+	Logo           *string `json:"logo"`
 	JoinMode       *int    `json:"join_mode"`
+	PresetGroupIds *string `json:"preset_group_ids"`
 }
 
 type addMemberReq struct {


### PR DESCRIPTION
## Summary

Closes #163. Brings the user-side `PUT /v1/space/:space_id` endpoint
(accessible to owners and admins) to feature parity with the manager
endpoint added in #158: pointer-based partial update, full validation,
TOCTOU-safe transactional writes, and per-field audit logging.

The previous implementation had four issues called out in #163:

1. Bare `string` fields silently clobbered `description` / `logo` to `""`
   when callers sent only `{"name": "x"}`.
2. No length / whitespace / enum / JSON-shape validation.
3. No transactional guard — concurrent disband could race with the write.
4. No audit log.

## Approach

Reuse the shared DB helper `managerDB.updateSpaceProfile` introduced in
#158 (already provides `SELECT ... FOR UPDATE` + sentinel errors +
pre-update snapshot). The user-side handler calls it via the existing
`Space.mdb` field (whose package-level comment already documents this
reuse pattern).

The only signature change to the shared helper is a new
`presetGroupIds *string` parameter. The manager handler passes `nil`
(no behavior change on that side).

## Changes

- `model.go` — `updateSpaceReq` fields all become `*T`; nil = no change.
- `api.go` — handler fully rewritten: pointer binding, trim + rune-count
  validation (reuses manager's char-count constants), preset_group_ids
  JSON validation, sentinel-error → 4xx mapping, audit log "用户修改空间
  信息" with `fromX`/`toX` fields aligned to manager-side naming.
- `db_manager.go` — `updateSpaceProfile` gains `presetGroupIds *string`;
  godoc clarifies the caller-guard contract for `SpaceStatusBanned`.
- `api_manager.go` — call site passes `nil` for the new parameter.
- `db.go` — old `DB.updateSpace` removed (sole caller was the rewritten
  handler).
- `api_update_space_test.go` — new file, 18 sub-tests covering the full
  #163 acceptance list.
- `api_manager_test.go` — four existing TOCTOU test calls updated for
  the new helper signature.

## Stricter `preset_group_ids` validation

A naive `json.Unmarshal` to `[]string` silently accepts:

- top-level `null` (decodes to nil slice without error)
- `[null]` (decodes to `[""]` without error)
- mixed-type arrays containing nulls / numbers / objects

This would land invalid configuration in `preset_group_ids` that the
downstream `joinPresetGroups` then silently skips. The new
`validatePresetGroupIds` helper decodes as `*[]json.RawMessage` and
checks each element's first byte is `"`, rejecting non-string elements
including JSON null. Empty array `[]` and empty string `""` both remain
valid (both mean "clear the list").

## Breaking change

Clients that previously sent `PUT` with only `{"name": "x"}` and relied
on `description` / `logo` being clobbered to `""` will need to migrate.
The clobber was a latent bug (documented in #163).

## Test plan

- [x] `go test -race ./modules/space/...` clean
- [x] Partial update of each field alone leaves other fields untouched
- [x] Combined update of all five fields
- [x] Whitespace trim on name and description
- [x] Length caps: ASCII boundary + CJK 100/101 char boundary
- [x] Invalid `join_mode` (-1, 2, 99) rejected
- [x] `preset_group_ids` rejects: `null`, `[null]`, mixed types, objects,
      arrays, booleans, malformed JSON, oversize
- [x] `preset_group_ids` accepts: empty string (clear), empty array, valid
      string arrays; JSON null treated as no-change (not clear)
- [x] Auth: non-member / role=0 rejected; role=1 admin / role=2 owner
      accepted
- [x] Disbanded and banned spaces rejected at active guard
- [x] Idempotent replay returns 200 (regression for `RowsAffected==0`
      misclassification)
- [ ] Deployed smoke test against staging — pending merge

TOCTOU regression at the DB layer is already covered by
`TestManagerDB_UpdateSpaceProfile_TOCTOU` (added in #158) and is not
duplicated here.