### PR TITLE
fix(space): close banned-status TOCTOU on user-side PUT /v1/space/:space_id

### DIFF
--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -403,15 +403,22 @@ func (s *Space) updateSpace(c *wkhttp.Context) {
 		}
 	}
 
-	before, err := s.mdb.updateSpaceProfile(spaceId, req.Name, req.Description, req.Logo, req.JoinMode, nil, req.PresetGroupIds)
+	// allowBanned=false：用户端绝不能更新封禁空间。事务侧二次校验关闭了
+	// "checkSpaceActive 通过 → 管理员并发 ban → 用户事务仍 UPDATE 落地" 的 TOCTOU race
+	// （Jerry-Xin 在 PR #164 review 中指出的 Critical 问题）。
+	before, err := s.mdb.updateSpaceProfile(spaceId, req.Name, req.Description, req.Logo, req.JoinMode, nil, req.PresetGroupIds, false)
 	if err != nil {
-		// 复用管理端 sentinel，并发解散与 active 检查之间的 race 由事务侧裁决。
+		// 复用管理端 sentinel，并发解散 / 封禁与 active 检查之间的 race 由事务侧裁决。
 		if errors.Is(err, ErrSpaceNotFound) {
 			c.ResponseError(errors.New("空间不存在"))
 			return
 		}
 		if errors.Is(err, ErrSpaceDisbandedForUpdate) {
 			c.ResponseError(errors.New("空间已解散，无法修改空间信息"))
+			return
+		}
+		if errors.Is(err, ErrSpaceBannedForUpdate) {
+			c.ResponseError(errors.New("空间已封禁，无法修改空间信息"))
 			return
 		}
 		s.Error("用户修改空间信息失败", zap.Error(err), zap.String("spaceId", spaceId), zap.String("operator", loginUID))

--- a/modules/space/api_manager.go
+++ b/modules/space/api_manager.go
@@ -548,7 +548,8 @@ func (m *Manager) updateSpaceProfile(c *wkhttp.Context) {
 	}
 
 	// presetGroupIds 仅由用户侧 PUT /v1/space/:space_id 使用，管理端固定传 nil。
-	before, err := m.managerDB.updateSpaceProfile(spaceId, req.Name, req.Description, req.Logo, req.JoinMode, req.MaxUsers, nil)
+	// allowBanned=true：管理端有意允许对封禁空间执行修复性基础信息更新（不解禁）。
+	before, err := m.managerDB.updateSpaceProfile(spaceId, req.Name, req.Description, req.Logo, req.JoinMode, req.MaxUsers, nil, true)
 	if err != nil {
 		// 事务内 SELECT FOR UPDATE 用 sentinel error 报告并发场景；HTTP 层映射为 4xx 提示。
 		// 不能依赖 RowsAffected 区分：MySQL 默认返回变更行数而非匹配行数，

--- a/modules/space/api_manager_test.go
+++ b/modules/space/api_manager_test.go
@@ -1451,7 +1451,7 @@ func TestManagerDB_UpdateSpaceProfile_TOCTOU(t *testing.T) {
 
 	t.Run("returns ErrSpaceNotFound for missing space", func(t *testing.T) {
 		name := "x"
-		before, err := mdb.updateSpaceProfile("nope-not-exists", &name, nil, nil, nil, nil, nil)
+		before, err := mdb.updateSpaceProfile("nope-not-exists", &name, nil, nil, nil, nil, nil, true)
 		assert.ErrorIs(t, err, ErrSpaceNotFound)
 		assert.Nil(t, before)
 	})
@@ -1461,7 +1461,7 @@ func TestManagerDB_UpdateSpaceProfile_TOCTOU(t *testing.T) {
 		// 调用 DB 方法应被事务内的 status 校验拦下。
 		seedSpace(t, "mgr-upd-toctou", "dying", "u-o-toc", SpaceStatusDisbanded)
 		name := "new name"
-		before, err := mdb.updateSpaceProfile("mgr-upd-toctou", &name, nil, nil, nil, nil, nil)
+		before, err := mdb.updateSpaceProfile("mgr-upd-toctou", &name, nil, nil, nil, nil, nil, true)
 		assert.ErrorIs(t, err, ErrSpaceDisbandedForUpdate)
 		assert.Nil(t, before)
 
@@ -1475,7 +1475,7 @@ func TestManagerDB_UpdateSpaceProfile_TOCTOU(t *testing.T) {
 
 	t.Run("no-op when all fields are nil on existing space", func(t *testing.T) {
 		seedSpace(t, "mgr-upd-noop", "untouched", "u-o-noop", SpaceStatusNormal)
-		before, err := mdb.updateSpaceProfile("mgr-upd-noop", nil, nil, nil, nil, nil, nil)
+		before, err := mdb.updateSpaceProfile("mgr-upd-noop", nil, nil, nil, nil, nil, nil, true)
 		assert.NoError(t, err)
 		assert.NotNil(t, before)
 		assert.Equal(t, "untouched", before.Name, "no-op 仍应返回 pre-update 快照")
@@ -1489,7 +1489,7 @@ func TestManagerDB_UpdateSpaceProfile_TOCTOU(t *testing.T) {
 		// 不再使用 tx 外的 sp，避免并发更新窗口下旧值 stale。
 		seedSpace(t, "mgr-upd-snap", "original", "u-o-snap", SpaceStatusNormal)
 		newName := "renamed"
-		before, err := mdb.updateSpaceProfile("mgr-upd-snap", &newName, nil, nil, nil, nil, nil)
+		before, err := mdb.updateSpaceProfile("mgr-upd-snap", &newName, nil, nil, nil, nil, nil, true)
 		assert.NoError(t, err)
 		assert.NotNil(t, before)
 		assert.Equal(t, "original", before.Name, "before 应为 UPDATE 前的值")

--- a/modules/space/api_update_space_test.go
+++ b/modules/space/api_update_space_test.go
@@ -398,6 +398,49 @@ func TestUserUpdateSpace_ActiveGuard(t *testing.T) {
 	})
 }
 
+// TestUserUpdateSpace_BannedTOCTOURegression 回归 PR #164 Jerry-Xin 指出的 Critical：
+// 用户端 checkSpaceActive（status=1 才放行）与事务内 UPDATE 之间存在 race 窗口 ——
+// 若管理员在 checkSpaceActive 通过后并发把空间置为 banned (status=2)，旧实现的
+// 事务内 status 检查只挡 disbanded，banned 行仍会被 UPDATE 写入。
+//
+// 该测试在 DB 层直接调用 updateSpaceProfile(..., allowBanned=false) on 一个 banned
+// 空间，模拟 race 时事务获取锁后看到的"已被 ban"状态，验证 helper 现在能拒。
+func TestUserUpdateSpace_BannedTOCTOURegression(t *testing.T) {
+	_, _, err := setup(t)
+	assert.NoError(t, err)
+	mdb := newManagerDB(testCtx.DB())
+
+	// seed 一个已被 ban 的空间（模拟 race 中"事务获取锁那一刻"的状态）
+	spaceId := "usr-upd-banned-race"
+	seedSpace(t, spaceId, "victim", "u-o-ban", SpaceStatusBanned)
+
+	t.Run("user-side call (allowBanned=false) rejects banned with ErrSpaceBannedForUpdate", func(t *testing.T) {
+		newName := "attacker-rename"
+		before, err := mdb.updateSpaceProfile(spaceId, &newName, nil, nil, nil, nil, nil, false)
+		assert.ErrorIs(t, err, ErrSpaceBannedForUpdate, "封禁空间 + 用户端调用应被事务侧拦下")
+		assert.Nil(t, before)
+
+		// 关键：UPDATE 必须没有真的执行
+		sp, qErr := mdb.querySpaceIncludeDisbanded(spaceId)
+		assert.NoError(t, qErr)
+		assert.Equal(t, "victim", sp.Name, "事务拒绝后 name 不应被改写")
+		assert.Equal(t, SpaceStatusBanned, sp.Status, "status 不应被影响")
+	})
+
+	t.Run("manager-side call (allowBanned=true) still allows banned (修复性更新)", func(t *testing.T) {
+		newName := "manager-fix-name"
+		before, err := mdb.updateSpaceProfile(spaceId, &newName, nil, nil, nil, nil, nil, true)
+		assert.NoError(t, err, "管理端对 banned 空间的修复性更新应被允许")
+		assert.NotNil(t, before)
+		assert.Equal(t, "victim", before.Name)
+
+		sp, qErr := mdb.querySpaceIncludeDisbanded(spaceId)
+		assert.NoError(t, qErr)
+		assert.Equal(t, "manager-fix-name", sp.Name, "管理端 UPDATE 应落库")
+		assert.Equal(t, SpaceStatusBanned, sp.Status, "status 不变")
+	})
+}
+
 func TestUserUpdateSpace_IdempotentReplay(t *testing.T) {
 	// 回归：MySQL 默认 RowsAffected = 实际变更行数。
 	// helper 走 SELECT ... FOR UPDATE + sentinel，不依赖 RowsAffected，

--- a/modules/space/db_manager.go
+++ b/modules/space/db_manager.go
@@ -215,6 +215,11 @@ var ErrSpaceNotFound = errors.New("space not found")
 // ErrSpaceDisbandedForUpdate 事务内发现空间已解散，禁止更新基础信息
 var ErrSpaceDisbandedForUpdate = errors.New("space already disbanded")
 
+// ErrSpaceBannedForUpdate 事务内发现空间已封禁，且调用方未授权对封禁空间执行更新。
+// 用户端 PUT 应映射为 4xx；管理端调用 updateSpaceProfile 时 allowBanned=true，
+// 该 sentinel 不会被触发。
+var ErrSpaceBannedForUpdate = errors.New("space is banned and caller disallowed banned updates")
+
 // updateSpaceProfile 管理端部分更新空间基础字段。
 //
 // 用 SELECT ... FOR UPDATE 在事务内锁定 space 行并原子校验存在性 + 非 Disbanded 状态，
@@ -235,12 +240,14 @@ var ErrSpaceDisbandedForUpdate = errors.New("space already disbanded")
 // preset_group_ids 列（运行期解析见 api.go 的 joinPresetGroups）；
 // 该参数仅由用户侧 PUT /v1/space/:space_id 使用，管理端目前传 nil。
 //
-// 状态守卫契约：本函数仅拦截 SpaceStatusDisbanded（return ErrSpaceDisbandedForUpdate），
-// 不拦截 SpaceStatusBanned —— manager 端有意允许对 banned 空间执行修复性更新。
-// 因此调用方必须自行决定是否拒绝 banned：
-//   - 管理端 handler 故意放行；
-//   - 用户端 handler 通过 checkSpaceActive (status=1 才放行) 在入口就拒绝 banned。
-// 不要假设 helper 会替你挡 banned。
+// 状态守卫契约（事务内强制，关闭 handler 层 guard 与 UPDATE 之间的 TOCTOU 窗口）：
+//   - SpaceStatusDisbanded 永远拒绝（ErrSpaceDisbandedForUpdate）
+//   - SpaceStatusBanned 由 allowBanned 控制：
+//       allowBanned=true（管理端）  → 放行，允许对封禁空间执行修复性更新
+//       allowBanned=false（用户端）→ 拒绝（ErrSpaceBannedForUpdate）
+//
+// 用户端 handler 必须传 allowBanned=false：仅在入口用 checkSpaceActive 挡 banned 不够，
+// 入口检查与事务之间存在 race 窗口（manager 并发 ban），事务侧必须再挡一次才闭环。
 func (d *managerDB) updateSpaceProfile(
 	spaceId string,
 	name *string,
@@ -249,6 +256,7 @@ func (d *managerDB) updateSpaceProfile(
 	joinMode *int,
 	maxUsers *int,
 	presetGroupIds *string,
+	allowBanned bool,
 ) (*SpaceModel, error) {
 	tx, err := d.session.Begin()
 	if err != nil {
@@ -270,6 +278,9 @@ func (d *managerDB) updateSpaceProfile(
 	}
 	if before.Status == SpaceStatusDisbanded {
 		return nil, ErrSpaceDisbandedForUpdate
+	}
+	if !allowBanned && before.Status == SpaceStatusBanned {
+		return nil, ErrSpaceBannedForUpdate
 	}
 
 	builder := tx.Update("space")


### PR DESCRIPTION
Follow-up to #164. Addresses the blocking Critical raised by @Jerry-Xin
post-merge in https://github.com/Mininglamp-OSS/octo-server/pull/164#pullrequestreview-4360352861.

## The race

The user-side handler checks `checkSpaceActive` (which rejects any
`space.status != 1`) *outside* the transaction, then enters
`managerDB.updateSpaceProfile` which only rejected `SpaceStatusDisbanded`
inside the lock. Sequence:

1. user request passes `checkSpaceActive` while `space.status == 1`
2. manager concurrently bans the space (`status -> 2`)
3. user transaction acquires `SELECT ... FOR UPDATE` on the now-banned row
4. helper saw `status == 2` but only blocked `status == 0`, so the
   `UPDATE` still landed on a banned space

This defeats the active-space contract of the user endpoint and
re-introduces exactly the TOCTOU class that #158's transactional helper
was built to eliminate.

## Fix

Parameterize the helper rather than fork it. Caller declares whether
banned is an acceptable target:

- `managerDB.updateSpaceProfile` gains `allowBanned bool`.
- New sentinel `ErrSpaceBannedForUpdate` emitted when `allowBanned=false`
  and the locked snapshot is in `SpaceStatusBanned`.
- Manager handler passes `allowBanned=true` (preserves the intentional
  semantics that admins can fix banned-space metadata without un-banning).
- User handler passes `allowBanned=false` and maps the sentinel to a
  4xx "空间已封禁，无法修改空间信息" response.

`SpaceStatusDisbanded` is still always rejected for both callers.

## Tests

- New `TestUserUpdateSpace_BannedTOCTOURegression` seeds a banned space
  and calls `updateSpaceProfile(..., allowBanned=false)` directly,
  simulating the moment the user transaction acquires its lock during
  the race. Asserts `ErrSpaceBannedForUpdate` and verifies the UPDATE
  was never executed (name and status unchanged).
- Same test also exercises `allowBanned=true` on the same banned row
  to lock in the manager semantics (banned → still updatable by manager).
- The four existing `TestManagerDB_UpdateSpaceProfile_TOCTOU` subtests
  updated to pass `true` for the new parameter (manager call-shape
  unchanged).

`go test -race ./modules/space/...` clean.

## Non-blocking item acknowledged

@Jerry-Xin also flagged a Warning that the role check happens outside
the transaction, so a concurrent demotion/removal can still allow one
final update after the caller is no longer admin/owner. This is the
same TOCTOU class but is pre-existing and matches the manager-side
`requireAdmin` shape used throughout this module. Left for a separate
PR — out of scope here, where the goal is the smallest possible fix
that closes the banned-status hole.

## Test plan

- [x] `go test -race ./modules/space/...` clean locally
- [x] `go vet ./modules/space/...` clean
- [ ] CI checks
- [ ] Smoke against staging after merge: confirm user PUT on a banned
      space returns 4xx with the banned-specific message