### PR TITLE
feat: add i18n request-side utilities

### DIFF
--- a/pkg/i18n/ctx.go
+++ b/pkg/i18n/ctx.go
@@ -1,0 +1,69 @@
+package i18n
+
+import "context"
+
+type languageContextKey struct{}
+
+// LanguageDecision 记录一次语言协商结果及其来源。
+type LanguageDecision struct {
+	Language string
+	Source   LanguageSource
+}
+
+// WithLanguage 将语言协商结果写入 context.Context。
+func WithLanguage(ctx context.Context, decision LanguageDecision) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, languageContextKey{}, decision)
+}
+
+// WithLanguageIfHigherPriority 仅当新来源优先级高于现有来源时覆盖 context。
+// 这用于 D9 两段式中间件：Auth 后的 user.language 可以覆盖 Accept-Language/default，
+// 但不能覆盖 trusted header、URL 或 cookie 这类显式选择。
+func WithLanguageIfHigherPriority(ctx context.Context, decision LanguageDecision) (context.Context, bool) {
+	current, ok := LanguageFromContext(ctx)
+	if !ok || languageSourcePriority(decision.Source) > languageSourcePriority(current.Source) {
+		return WithLanguage(ctx, decision), true
+	}
+	return ctx, false
+}
+
+// LanguageFromContext 读取 context 中的语言协商结果。
+func LanguageFromContext(ctx context.Context) (LanguageDecision, bool) {
+	if ctx == nil {
+		return LanguageDecision{}, false
+	}
+	decision, ok := ctx.Value(languageContextKey{}).(LanguageDecision)
+	if !ok || decision.Language == "" {
+		return LanguageDecision{}, false
+	}
+	return decision, true
+}
+
+// LanguageOrDefault 返回 context 中的语言；不存在时返回 fallback。
+func LanguageOrDefault(ctx context.Context, fallback string) string {
+	if decision, ok := LanguageFromContext(ctx); ok {
+		return decision.Language
+	}
+	return fallback
+}
+
+func languageSourcePriority(source LanguageSource) int {
+	switch source {
+	case LanguageSourceTrustedHeader:
+		return 60
+	case LanguageSourceQuery:
+		return 50
+	case LanguageSourceCookie:
+		return 40
+	case LanguageSourceUser:
+		return 30
+	case LanguageSourceAccept:
+		return 20
+	case LanguageSourceDefault:
+		return 10
+	default:
+		return 0
+	}
+}

--- a/pkg/i18n/ctx_test.go
+++ b/pkg/i18n/ctx_test.go
@@ -1,0 +1,78 @@
+package i18n
+
+import (
+	"context"
+	"testing"
+)
+
+func TestContextLanguageRoundTrip(t *testing.T) {
+	ctx := WithLanguage(context.Background(), LanguageDecision{
+		Language: "zh-CN",
+		Source:   LanguageSourceCookie,
+	})
+
+	got, ok := LanguageFromContext(ctx)
+	if !ok {
+		t.Fatal("LanguageFromContext ok=false")
+	}
+	if got.Language != "zh-CN" || got.Source != LanguageSourceCookie {
+		t.Fatalf("LanguageFromContext = %#v", got)
+	}
+}
+
+func TestWithLanguageIfHigherPriority(t *testing.T) {
+	ctx := WithLanguage(context.Background(), LanguageDecision{
+		Language: "en-US",
+		Source:   LanguageSourceAccept,
+	})
+
+	ctx, changed := WithLanguageIfHigherPriority(ctx, LanguageDecision{
+		Language: "zh-CN",
+		Source:   LanguageSourceUser,
+	})
+	if !changed {
+		t.Fatal("user language should override Accept-Language")
+	}
+	got, _ := LanguageFromContext(ctx)
+	if got.Language != "zh-CN" || got.Source != LanguageSourceUser {
+		t.Fatalf("after user override = %#v", got)
+	}
+
+	ctx, changed = WithLanguageIfHigherPriority(ctx, LanguageDecision{
+		Language: "en-US",
+		Source:   LanguageSourceCookie,
+	})
+	if !changed {
+		t.Fatal("cookie language should override user language")
+	}
+	got, _ = LanguageFromContext(ctx)
+	if got.Language != "en-US" || got.Source != LanguageSourceCookie {
+		t.Fatalf("after cookie override = %#v", got)
+	}
+
+	ctx, changed = WithLanguageIfHigherPriority(ctx, LanguageDecision{
+		Language: "zh-CN",
+		Source:   LanguageSourceUser,
+	})
+	if changed {
+		t.Fatal("user language must not override explicit cookie language")
+	}
+	got, _ = LanguageFromContext(ctx)
+	if got.Language != "en-US" || got.Source != LanguageSourceCookie {
+		t.Fatalf("after lower-priority override = %#v", got)
+	}
+}
+
+func TestLanguageOrDefault(t *testing.T) {
+	if got := LanguageOrDefault(context.Background(), "zh-CN"); got != "zh-CN" {
+		t.Fatalf("empty context fallback = %q, want zh-CN", got)
+	}
+
+	ctx := WithLanguage(context.Background(), LanguageDecision{
+		Language: "en-US",
+		Source:   LanguageSourceDefault,
+	})
+	if got := LanguageOrDefault(ctx, "zh-CN"); got != "en-US" {
+		t.Fatalf("context language = %q, want en-US", got)
+	}
+}

--- a/pkg/i18n/details.go
+++ b/pkg/i18n/details.go
@@ -1,0 +1,45 @@
+package i18n
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// Details 是客户端可见的错误上下文字段。渲染前必须按 codes.Code.SafeDetailKeys
+// 过滤，避免 uid/token/raw_err 等内部信息泄漏。
+type Details map[string]any
+
+var unsafeDetailsDroppedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "i18n_unsafe_details_dropped_total",
+	Help: "Total number of i18n error detail keys dropped because they were not whitelisted.",
+}, []string{"code", "key"})
+
+// FilterBy 根据 Code.SafeDetailKeys 返回只包含白名单 key 的副本。
+// 所有被丢弃的 key 都记录 i18n_unsafe_details_dropped_total{code,key}。
+func (d Details) FilterBy(code codes.Code) Details {
+	return d.FilterByKeys(code.ID, code.SafeDetailKeys)
+}
+
+// FilterByKeys 根据 safeKeys 返回只包含白名单 key 的副本。
+func (d Details) FilterByKeys(codeID string, safeKeys []string) Details {
+	if d == nil {
+		return nil
+	}
+
+	allowed := make(map[string]struct{}, len(safeKeys))
+	for _, key := range safeKeys {
+		allowed[key] = struct{}{}
+	}
+
+	out := make(Details)
+	for key, value := range d {
+		if _, ok := allowed[key]; ok {
+			out[key] = value
+			continue
+		}
+		unsafeDetailsDroppedTotal.WithLabelValues(codeID, key).Inc()
+	}
+	return out
+}

--- a/pkg/i18n/details_test.go
+++ b/pkg/i18n/details_test.go
@@ -1,0 +1,74 @@
+package i18n
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestDetails_FilterByCodeSafeDetailKeys(t *testing.T) {
+	code, ok := codes.Lookup("err.shared.rate.limited")
+	if !ok {
+		t.Fatal("err.shared.rate.limited not registered")
+	}
+
+	details := Details{
+		"retry_after": "30s",
+		"token":       "secret-token",
+		"raw_err":     "redis down",
+	}
+	tokenBefore := testutil.ToFloat64(unsafeDetailsDroppedTotal.WithLabelValues(code.ID, "token"))
+	rawErrBefore := testutil.ToFloat64(unsafeDetailsDroppedTotal.WithLabelValues(code.ID, "raw_err"))
+
+	filtered := details.FilterBy(code)
+	if len(filtered) != 1 {
+		t.Fatalf("filtered len = %d, want 1: %#v", len(filtered), filtered)
+	}
+	if got := filtered["retry_after"]; got != "30s" {
+		t.Fatalf("retry_after = %v, want 30s", got)
+	}
+	if _, ok := filtered["token"]; ok {
+		t.Fatal("unsafe key token was not dropped")
+	}
+
+	filtered["retry_after"] = "mutated"
+	if got := details["retry_after"]; got != "30s" {
+		t.Fatalf("FilterBy returned alias; original retry_after = %v", got)
+	}
+
+	if got := testutil.ToFloat64(unsafeDetailsDroppedTotal.WithLabelValues(code.ID, "token")) - tokenBefore; got != 1 {
+		t.Fatalf("token dropped metric delta = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(unsafeDetailsDroppedTotal.WithLabelValues(code.ID, "raw_err")) - rawErrBefore; got != 1 {
+		t.Fatalf("raw_err dropped metric delta = %v, want 1", got)
+	}
+}
+
+func TestDetails_FilterByDropsAllWhenNoSafeKeys(t *testing.T) {
+	code, ok := codes.Lookup("err.shared.auth.required")
+	if !ok {
+		t.Fatal("err.shared.auth.required not registered")
+	}
+
+	before := testutil.ToFloat64(unsafeDetailsDroppedTotal.WithLabelValues(code.ID, "field"))
+	filtered := Details{"field": "name"}.FilterBy(code)
+	if len(filtered) != 0 {
+		t.Fatalf("filtered = %#v, want empty", filtered)
+	}
+	if got := testutil.ToFloat64(unsafeDetailsDroppedTotal.WithLabelValues(code.ID, "field")) - before; got != 1 {
+		t.Fatalf("dropped metric delta = %v, want 1", got)
+	}
+}
+
+func TestDetails_NilFilter(t *testing.T) {
+	code, ok := codes.Lookup("err.shared.param.invalid")
+	if !ok {
+		t.Fatal("err.shared.param.invalid not registered")
+	}
+
+	var details Details
+	if got := details.FilterBy(code); got != nil {
+		t.Fatalf("nil FilterBy = %#v, want nil", got)
+	}
+}

--- a/pkg/i18n/lang.go
+++ b/pkg/i18n/lang.go
@@ -1,0 +1,167 @@
+package i18n
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+
+	"golang.org/x/text/language"
+)
+
+const (
+	// HeaderOctoLang 是受信网关/服务间调用使用的语言头。
+	HeaderOctoLang = "X-Octo-Lang"
+	// CookieLanguage 是前端与公开静态页共享的语言 cookie 名。
+	CookieLanguage = "i18n_lang"
+	// QueryLanguage 是 URL 显式语言选择参数。
+	QueryLanguage = "lang"
+)
+
+// LanguageSource 描述命中 D6 语言协商链的哪一级。
+type LanguageSource string
+
+const (
+	LanguageSourceTrustedHeader LanguageSource = "trusted_header"
+	LanguageSourceQuery         LanguageSource = "query"
+	LanguageSourceCookie        LanguageSource = "cookie"
+	LanguageSourceUser          LanguageSource = "user"
+	LanguageSourceAccept        LanguageSource = "accept_language"
+	LanguageSourceDefault       LanguageSource = "default"
+)
+
+var (
+	supportedLanguageTags = []language.Tag{
+		language.MustParse(SourceLanguage),
+		language.MustParse("zh-CN"),
+	}
+	supportedLanguageMatcher = language.NewMatcher(supportedLanguageTags)
+)
+
+// LanguageNegotiationOptions 控制单次语言协商。
+type LanguageNegotiationOptions struct {
+	DefaultLanguage        string
+	TrustedLangHeaderCIDRs []*net.IPNet
+	UserLanguage           string
+}
+
+// NegotiateLanguage 按 D6 优先级协商请求语言：
+// trusted X-Octo-Lang > URL lang > cookie i18n_lang > user.language >
+// Accept-Language > default language。
+//
+// X-Octo-Lang 只根据 TCP RemoteAddr 命中 TrustedLangHeaderCIDRs 时采纳；
+// 本函数不读取 X-Forwarded-For，避免链尾伪造影响信任判定。
+func NegotiateLanguage(r *http.Request, opts LanguageNegotiationOptions) LanguageDecision {
+	defaultLang := normalizeDefaultLanguage(opts.DefaultLanguage)
+	if r == nil {
+		return LanguageDecision{Language: defaultLang, Source: LanguageSourceDefault}
+	}
+
+	if IsTrustedLangHeaderRequest(r, opts.TrustedLangHeaderCIDRs) {
+		if lang, ok := MatchSupportedLanguage(r.Header.Get(HeaderOctoLang)); ok {
+			return LanguageDecision{Language: lang, Source: LanguageSourceTrustedHeader}
+		}
+	}
+	if lang, ok := MatchSupportedLanguage(r.URL.Query().Get(QueryLanguage)); ok {
+		return LanguageDecision{Language: lang, Source: LanguageSourceQuery}
+	}
+	if cookie, err := r.Cookie(CookieLanguage); err == nil {
+		if lang, ok := MatchSupportedLanguage(cookie.Value); ok {
+			return LanguageDecision{Language: lang, Source: LanguageSourceCookie}
+		}
+	}
+	if lang, ok := MatchSupportedLanguage(opts.UserLanguage); ok {
+		return LanguageDecision{Language: lang, Source: LanguageSourceUser}
+	}
+	if lang, ok := matchAcceptLanguage(r.Header.Get("Accept-Language")); ok {
+		return LanguageDecision{Language: lang, Source: LanguageSourceAccept}
+	}
+	return LanguageDecision{Language: defaultLang, Source: LanguageSourceDefault}
+}
+
+// MatchSupportedLanguage 将输入语言规整到首期支持矩阵（en-US / zh-CN）。
+func MatchSupportedLanguage(raw string) (string, bool) {
+	raw = strings.TrimSpace(strings.ReplaceAll(raw, "_", "-"))
+	if raw == "" {
+		return "", false
+	}
+	tag, err := language.Parse(raw)
+	if err != nil {
+		return "", false
+	}
+	_, idx, confidence := supportedLanguageMatcher.Match(tag)
+	if confidence == language.No {
+		return "", false
+	}
+	return supportedLanguageTags[idx].String(), true
+}
+
+// ParseCIDRList 解析逗号分隔 CIDR 列表，例如 "10.0.0.0/8,172.16.0.0/12"。
+func ParseCIDRList(value string) ([]*net.IPNet, error) {
+	parts := strings.Split(value, ",")
+	out := make([]*net.IPNet, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		_, network, err := net.ParseCIDR(part)
+		if err != nil {
+			return nil, fmt.Errorf("parse CIDR %q: %w", part, err)
+		}
+		out = append(out, network)
+	}
+	return out, nil
+}
+
+// IsTrustedLangHeaderRequest 判断请求的 TCP RemoteAddr 是否命中受信语言头 CIDR。
+func IsTrustedLangHeaderRequest(r *http.Request, cidrs []*net.IPNet) bool {
+	if r == nil || len(cidrs) == 0 {
+		return false
+	}
+	ip, ok := remoteAddrIP(r.RemoteAddr)
+	if !ok {
+		return false
+	}
+	for _, cidr := range cidrs {
+		if cidr != nil && cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeDefaultLanguage(raw string) string {
+	if lang, ok := MatchSupportedLanguage(raw); ok {
+		return lang
+	}
+	return SourceLanguage
+}
+
+func matchAcceptLanguage(raw string) (string, bool) {
+	if strings.TrimSpace(raw) == "" {
+		return "", false
+	}
+	tags, _, err := language.ParseAcceptLanguage(raw)
+	if err != nil || len(tags) == 0 {
+		return "", false
+	}
+	_, idx, confidence := supportedLanguageMatcher.Match(tags...)
+	if confidence == language.No {
+		return "", false
+	}
+	return supportedLanguageTags[idx].String(), true
+}
+
+func remoteAddrIP(remoteAddr string) (net.IP, bool) {
+	remoteAddr = strings.TrimSpace(remoteAddr)
+	if remoteAddr == "" {
+		return nil, false
+	}
+	if ip, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		parsed := net.ParseIP(ip)
+		return parsed, parsed != nil
+	}
+	parsed := net.ParseIP(remoteAddr)
+	return parsed, parsed != nil
+}

--- a/pkg/i18n/lang_test.go
+++ b/pkg/i18n/lang_test.go
@@ -1,0 +1,160 @@
+package i18n
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNegotiateLanguagePriority(t *testing.T) {
+	cidrs, err := ParseCIDRList("10.0.0.0/8")
+	if err != nil {
+		t.Fatalf("ParseCIDRList err = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/?lang=en-US", nil)
+	req.RemoteAddr = "10.1.2.3:4321"
+	req.Header.Set(HeaderOctoLang, "zh-CN")
+	req.Header.Set("Accept-Language", "en-US")
+	req.AddCookie(&http.Cookie{Name: CookieLanguage, Value: "en-US"})
+
+	got := NegotiateLanguage(req, LanguageNegotiationOptions{
+		DefaultLanguage:          "en-US",
+		TrustedLangHeaderCIDRs: cidrs,
+		UserLanguage:             "en-US",
+	})
+	if got.Language != "zh-CN" || got.Source != LanguageSourceTrustedHeader {
+		t.Fatalf("NegotiateLanguage = %#v, want trusted zh-CN", got)
+	}
+}
+
+func TestNegotiateLanguageIgnoresUntrustedXOctoLang(t *testing.T) {
+	cidrs, err := ParseCIDRList("10.0.0.0/8")
+	if err != nil {
+		t.Fatalf("ParseCIDRList err = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/?lang=en-US", nil)
+	req.RemoteAddr = "203.0.113.9:4321"
+	req.Header.Set(HeaderOctoLang, "zh-CN")
+	req.Header.Set("X-Forwarded-For", "10.1.2.3")
+
+	got := NegotiateLanguage(req, LanguageNegotiationOptions{
+		DefaultLanguage:          "zh-CN",
+		TrustedLangHeaderCIDRs: cidrs,
+	})
+	if got.Language != "en-US" || got.Source != LanguageSourceQuery {
+		t.Fatalf("NegotiateLanguage = %#v, want query en-US; XFF must not make header trusted", got)
+	}
+}
+
+func TestNegotiateLanguageSourceOrder(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     *http.Request
+		user    string
+		want    string
+		source  LanguageSource
+	}{
+		{
+			name: "query beats cookie user and accept",
+			req: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/?lang=zh-CN", nil)
+				r.AddCookie(&http.Cookie{Name: CookieLanguage, Value: "en-US"})
+				r.Header.Set("Accept-Language", "en-US")
+				return r
+			}(),
+			user:   "en-US",
+			want:   "zh-CN",
+			source: LanguageSourceQuery,
+		},
+		{
+			name: "cookie beats user and accept",
+			req: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/", nil)
+				r.AddCookie(&http.Cookie{Name: CookieLanguage, Value: "zh-CN"})
+				r.Header.Set("Accept-Language", "en-US")
+				return r
+			}(),
+			user:   "en-US",
+			want:   "zh-CN",
+			source: LanguageSourceCookie,
+		},
+		{
+			name: "user beats accept",
+			req: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/", nil)
+				r.Header.Set("Accept-Language", "zh-CN")
+				return r
+			}(),
+			user:   "en-US",
+			want:   "en-US",
+			source: LanguageSourceUser,
+		},
+		{
+			name: "accept beats default",
+			req: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/", nil)
+				r.Header.Set("Accept-Language", "fr-FR, zh-CN;q=0.8, en-US;q=0.5")
+				return r
+			}(),
+			want:   "zh-CN",
+			source: LanguageSourceAccept,
+		},
+		{
+			name:   "default",
+			req:    httptest.NewRequest(http.MethodGet, "/", nil),
+			want:   "zh-CN",
+			source: LanguageSourceDefault,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NegotiateLanguage(tt.req, LanguageNegotiationOptions{
+				DefaultLanguage: "zh-CN",
+				UserLanguage:    tt.user,
+			})
+			if got.Language != tt.want || got.Source != tt.source {
+				t.Fatalf("NegotiateLanguage = %#v, want %s from %s", got, tt.want, tt.source)
+			}
+		})
+	}
+}
+
+func TestMatchSupportedLanguage(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want string
+		ok   bool
+	}{
+		{"zh-CN", "zh-CN", true},
+		{"zh_cn", "zh-CN", true},
+		{"zh", "zh-CN", true},
+		{"en", "en-US", true},
+		{"fr-FR", "", false},
+		{"", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			got, ok := MatchSupportedLanguage(tt.raw)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("MatchSupportedLanguage(%q) = %q, %v; want %q, %v",
+					tt.raw, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestParseCIDRList(t *testing.T) {
+	cidrs, err := ParseCIDRList("10.0.0.0/8, 192.168.1.0/24")
+	if err != nil {
+		t.Fatalf("ParseCIDRList err = %v", err)
+	}
+	if len(cidrs) != 2 {
+		t.Fatalf("ParseCIDRList len = %d, want 2", len(cidrs))
+	}
+	if _, err := ParseCIDRList("10.0.0.1"); err == nil {
+		t.Fatal("ParseCIDRList accepted bare IP; want CIDR error")
+	}
+}

--- a/pkg/i18n/lang_test.go
+++ b/pkg/i18n/lang_test.go
@@ -19,9 +19,9 @@ func TestNegotiateLanguagePriority(t *testing.T) {
 	req.AddCookie(&http.Cookie{Name: CookieLanguage, Value: "en-US"})
 
 	got := NegotiateLanguage(req, LanguageNegotiationOptions{
-		DefaultLanguage:          "en-US",
+		DefaultLanguage:        "en-US",
 		TrustedLangHeaderCIDRs: cidrs,
-		UserLanguage:             "en-US",
+		UserLanguage:           "en-US",
 	})
 	if got.Language != "zh-CN" || got.Source != LanguageSourceTrustedHeader {
 		t.Fatalf("NegotiateLanguage = %#v, want trusted zh-CN", got)
@@ -40,7 +40,7 @@ func TestNegotiateLanguageIgnoresUntrustedXOctoLang(t *testing.T) {
 	req.Header.Set("X-Forwarded-For", "10.1.2.3")
 
 	got := NegotiateLanguage(req, LanguageNegotiationOptions{
-		DefaultLanguage:          "zh-CN",
+		DefaultLanguage:        "zh-CN",
 		TrustedLangHeaderCIDRs: cidrs,
 	})
 	if got.Language != "en-US" || got.Source != LanguageSourceQuery {
@@ -50,11 +50,11 @@ func TestNegotiateLanguageIgnoresUntrustedXOctoLang(t *testing.T) {
 
 func TestNegotiateLanguageSourceOrder(t *testing.T) {
 	tests := []struct {
-		name    string
-		req     *http.Request
-		user    string
-		want    string
-		source  LanguageSource
+		name   string
+		req    *http.Request
+		user   string
+		want   string
+		source LanguageSource
 	}{
 		{
 			name: "query beats cookie user and accept",

--- a/pkg/i18n/localizer.go
+++ b/pkg/i18n/localizer.go
@@ -15,15 +15,14 @@ type Localizer interface {
 	//   - code:   稳定 i18n key，必须在 codes.Register 已登记。
 	//   - lang:   客户端协商出的 BCP-47 标签（"zh-CN" / "en-US"）。
 	//             空字符串表示直接走 fallback chain。
-	//   - params: 翻译模板插值数据（仅 string-safe key/value，敏感字段由
-	//             调用方过滤；见 pkg/i18n/params.go——后续 step 实现）。
+	//   - params: 翻译模板插值数据（仅用于 message，不进入响应 details）。
 	//
 	// fallback chain（D22 六级，简化为四级实测有效路径）：
 	//   1. bundle: requested lang → fallback lang → source lang（go-i18n 自动）
 	//   2. extreme fallback: codes.Code.DefaultMessages[lang]
 	//   3. codes.Code.DefaultMessage（source 原文）
 	//   4. code ID 本身（未注册 code，调用方应记 i18n_unknown_code_total）
-	Translate(code, lang string, params map[string]any) string
+	Translate(code, lang string, params Params) string
 }
 
 // NewLocalizer 构造默认 Localizer。fallbackLang 通常对应 DM_DEFAULT_LANGUAGE
@@ -42,12 +41,13 @@ type defaultLocalizer struct {
 	fallbackLang string
 }
 
-func (l *defaultLocalizer) Translate(code, lang string, params map[string]any) string {
+func (l *defaultLocalizer) Translate(code, lang string, params Params) string {
+	templateData, paramsErr := params.TemplateData()
 	b, err := Bundle()
 	if err != nil || b == nil {
 		// Bundle 加载失败：完全脱离 go-i18n，走 codes registry 兜底。
 		// 此分支理论上只在 embed FS 损坏或 init() 顺序错乱时触发。
-		return fallbackMessage(code, lang, l.fallbackLang)
+		return fallbackMessageWithParams(code, lang, l.fallbackLang, params)
 	}
 
 	tags := buildLangTags(lang, l.fallbackLang)
@@ -55,12 +55,12 @@ func (l *defaultLocalizer) Translate(code, lang string, params map[string]any) s
 
 	msg, lerr := loc.Localize(&i18n.LocalizeConfig{
 		MessageID:    code,
-		TemplateData: params,
+		TemplateData: templateData,
 	})
-	if lerr != nil || msg == "" {
+	if paramsErr != nil || lerr != nil || msg == "" {
 		// go-i18n 找不到对应 message（code 未注册 / TOML 未含）→ 走兜底链。
 		// 不向上抛错：客户端宁可看到 source 文案，也不应看到 500。
-		return fallbackMessage(code, lang, l.fallbackLang)
+		return fallbackMessageWithParams(code, lang, l.fallbackLang, params)
 	}
 	return msg
 }
@@ -91,6 +91,18 @@ func fallbackMessage(code, lang, fallback string) string {
 		}
 	}
 	return c.DefaultMessage
+}
+
+func fallbackMessageWithParams(code, lang, fallback string, params Params) string {
+	msg := fallbackMessage(code, lang, fallback)
+	if params == nil {
+		return msg
+	}
+	rendered, err := params.Render(msg)
+	if err != nil {
+		return msg
+	}
+	return rendered
 }
 
 // buildLangTags 组装 go-i18n Localizer 的语言优先级链：

--- a/pkg/i18n/params.go
+++ b/pkg/i18n/params.go
@@ -1,0 +1,72 @@
+package i18n
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"regexp"
+	"text/template"
+)
+
+// Params 是翻译模板变量，只用于 message interpolation，不进入响应 details。
+// 与 Details 使用不同命名类型，避免调用方把内部字段误放进客户端响应体。
+type Params map[string]any
+
+var (
+	// ErrSensitiveParamKey 表示 Params 中出现了不允许进入翻译模板的数据 key。
+	ErrSensitiveParamKey = errors.New("i18n: sensitive param key")
+
+	sensitiveParamKeyPattern = regexp.MustCompile(`(?i)(uid|token|sql|secret|internal_id|password|raw_err)`)
+)
+
+// SensitiveParamKeyError 记录被拦截的 Params key。
+type SensitiveParamKeyError struct {
+	Key string
+}
+
+func (e SensitiveParamKeyError) Error() string {
+	return fmt.Sprintf("i18n: sensitive param key %q is not allowed", e.Key)
+}
+
+func (e SensitiveParamKeyError) Unwrap() error {
+	return ErrSensitiveParamKey
+}
+
+// IsSensitiveParamKey 返回 key 是否命中 D15/CI 约定的敏感字段正则。
+func IsSensitiveParamKey(key string) bool {
+	return sensitiveParamKeyPattern.MatchString(key)
+}
+
+// TemplateData 校验 Params 并返回深一层 map 副本，供 go-i18n TemplateData 使用。
+// nil Params 返回 nil，便于无模板变量路径零分配传递。
+func (p Params) TemplateData() (map[string]any, error) {
+	if p == nil {
+		return nil, nil
+	}
+	out := make(map[string]any, len(p))
+	for k, v := range p {
+		if IsSensitiveParamKey(k) {
+			return nil, SensitiveParamKeyError{Key: k}
+		}
+		out[k] = v
+	}
+	return out, nil
+}
+
+// Render 用 Params 渲染一个 Go template 字符串。缺失 key 返回错误，由调用方
+// 决定是否回退到未插值文案。
+func (p Params) Render(tmpl string) (string, error) {
+	data, err := p.TemplateData()
+	if err != nil {
+		return "", err
+	}
+	t, err := template.New("i18n_message").Option("missingkey=error").Parse(tmpl)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/pkg/i18n/params_test.go
+++ b/pkg/i18n/params_test.go
@@ -1,0 +1,86 @@
+package i18n
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+func TestParams_TemplateDataCopiesAndRenders(t *testing.T) {
+	params := Params{"Name": "octo", "Count": 3, "PluralCount": 3}
+
+	data, err := params.TemplateData()
+	if err != nil {
+		t.Fatalf("TemplateData err = %v", err)
+	}
+	data["Name"] = "mutated"
+
+	if got := params["Name"]; got != "octo" {
+		t.Fatalf("TemplateData returned alias; Params[Name] = %v", got)
+	}
+
+	got, err := params.Render("{{.Name}} has {{.Count}} items")
+	if err != nil {
+		t.Fatalf("Render err = %v", err)
+	}
+	if want := "octo has 3 items"; got != want {
+		t.Fatalf("Render = %q, want %q", got, want)
+	}
+}
+
+func TestParams_NilTemplateData(t *testing.T) {
+	var params Params
+	data, err := params.TemplateData()
+	if err != nil {
+		t.Fatalf("nil TemplateData err = %v", err)
+	}
+	if data != nil {
+		t.Fatalf("nil TemplateData = %#v, want nil", data)
+	}
+}
+
+func TestParams_BlocksSensitiveKeys(t *testing.T) {
+	tests := []string{
+		"uid",
+		"userUID",
+		"access_token",
+		"SQLQuery",
+		"secret_key",
+		"internal_id",
+		"password",
+		"raw_err",
+	}
+
+	for _, key := range tests {
+		t.Run(key, func(t *testing.T) {
+			_, err := Params{key: "value"}.TemplateData()
+			if !errors.Is(err, ErrSensitiveParamKey) {
+				t.Fatalf("TemplateData err = %v, want ErrSensitiveParamKey", err)
+			}
+		})
+	}
+}
+
+func TestLocalizer_InterpolatesParams(t *testing.T) {
+	const id = "err.shared.template.params"
+	if _, ok := codes.Lookup(id); !ok {
+		codes.Register(codes.Code{
+			ID:             id,
+			HTTPStatus:     400,
+			DefaultMessage: "Field {{.Field}} must be at least {{.Min}} characters.",
+		})
+	}
+
+	resetBundle()
+	t.Cleanup(resetBundle)
+
+	got := NewLocalizer("en-US").Translate(id, "en-US", Params{
+		"Field": "name",
+		"Min":   3,
+	})
+	want := "Field name must be at least 3 characters."
+	if got != want {
+		t.Fatalf("Translate with params = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Implements Phase 0.4 Step 3 request-side i18n utilities:

- `pkg/i18n/params.go`: typed `Params`, template rendering, and sensitive key blocking for `uid|token|sql|secret|internal_id|password|raw_err`.
- `pkg/i18n/details.go`: typed `Details`, `Code.SafeDetailKeys` filtering, and `i18n_unsafe_details_dropped_total{code,key}` metric.
- `pkg/i18n/ctx.go`: context language propagation with source priority, enabling later user-language override after auth without overriding explicit URL/cookie/trusted-header choices.
- `pkg/i18n/lang.go`: D6 language negotiation and D16 trusted `X-Octo-Lang` CIDR checks based on TCP `RemoteAddr` only.
- `Localizer.Translate` now takes `i18n.Params` and renders templates through the new Params path.

## Testing

- ✅ `go test ./pkg/i18n/...`
- ✅ `go test -cover ./pkg/i18n/...`
  - `pkg/i18n`: 82.1%
  - `pkg/i18n/codes`: 94.0%
- ⚠️ `go test ./...` currently fails outside this change due existing `octo-lib/testutil.NewTestServer` migration-plan panics, e.g. unknown migrations `20260427000002_oidc_legacy01.sql`, `20191106000002_group_legacy01.sql`, `20210926000001_robot_legacy01.sql` in modules such as botfather/category/channel/common/group/space/thread/user/workplace.
