### PR TITLE
refactor(voice_adapter): X-Space-ID header-only + local ASR proxy

### DIFF
--- a/modules/voice_adapter/adapter.go
+++ b/modules/voice_adapter/adapter.go
@@ -36,7 +36,14 @@ func (a *VoiceAdapter) Route(r *wkhttp.WKHttp) {
 		auth.GET("/config", a.getConfig)
 		auth.GET("/context", a.getContext)
 		auth.GET("/document/asr_service_doc", a.getDocument)
+		auth.PUT("/local-config", a.putLocalConfig)
+		auth.GET("/local-config", a.getLocalConfig)
+		auth.DELETE("/local-config", a.deleteLocalConfig)
 	}
+}
+
+func getSpaceID(c *wkhttp.Context) string {
+	return c.GetHeader("X-Space-ID")
 }
 
 func (a *VoiceAdapter) transcribe(c *wkhttp.Context) {
@@ -64,7 +71,28 @@ func (a *VoiceAdapter) transcribe(c *wkhttp.Context) {
 }
 
 func (a *VoiceAdapter) getConfig(c *wkhttp.Context) {
-	resp, err := a.client.GetConfig(c.Request.Context())
+	loginUID := c.GetLoginUID()
+	spaceID := getSpaceID(c)
+	if spaceID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "X-Space-ID header is required"})
+		return
+	}
+
+	isMember, err := space.CheckMembership(a.ctx.DB(), spaceID, loginUID)
+	if err != nil {
+		a.Error("check space membership failed", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"status": http.StatusInternalServerError, "msg": "check space membership failed"})
+		return
+	}
+	if !isMember {
+		c.JSON(http.StatusForbidden, gin.H{"status": http.StatusForbidden, "msg": "not a member of this space"})
+		return
+	}
+
+	scopeType := "space"
+	scopeID := spaceID
+
+	resp, err := a.client.GetConfig(c.Request.Context(), loginUID, scopeType, scopeID)
 	if err != nil {
 		var svcErr *SpeechServiceError
 		if errors.As(err, &svcErr) && (svcErr.StatusCode == 401 || svcErr.StatusCode == 403) {
@@ -92,9 +120,9 @@ func (a *VoiceAdapter) getConfig(c *wkhttp.Context) {
 
 func (a *VoiceAdapter) getContext(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
-	spaceID := c.Query("space_id")
+	spaceID := getSpaceID(c)
 	if spaceID == "" {
-		c.ResponseErrorWithStatus(errors.New("space_id is required"), http.StatusBadRequest)
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "X-Space-ID header is required"})
 		return
 	}
 
@@ -144,4 +172,129 @@ func (a *VoiceAdapter) getDocument(c *wkhttp.Context) {
 		"version":    "2.0",
 		"updated_at": "2026-05-25",
 	})
+}
+
+func (a *VoiceAdapter) putLocalConfig(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, 64*1024)
+
+	var req struct {
+		Enabled       *bool   `json:"enabled"`
+		TimeoutMs     *int    `json:"timeout_ms"`
+		ProbeURL      *string `json:"probe_url"`
+		TranscribeURL *string `json:"transcribe_url"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"status": http.StatusRequestEntityTooLarge, "msg": "request body too large"})
+			return
+		}
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "invalid request body"})
+		return
+	}
+
+	spaceID := getSpaceID(c)
+	if spaceID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "X-Space-ID header is required"})
+		return
+	}
+
+	if req.Enabled == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "enabled is required"})
+		return
+	}
+
+	isMember, err := space.CheckMembership(a.ctx.DB(), spaceID, loginUID)
+	if err != nil {
+		a.Error("check space membership failed", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"status": http.StatusInternalServerError, "msg": "check space membership failed"})
+		return
+	}
+	if !isMember {
+		c.JSON(http.StatusForbidden, gin.H{"status": http.StatusForbidden, "msg": "not a member of this space"})
+		return
+	}
+
+	err = a.client.PutLocalConfig(c.Request.Context(), loginUID, "space", spaceID, *req.Enabled, req.TimeoutMs, req.ProbeURL, req.TranscribeURL)
+	if err != nil {
+		var svcErr *SpeechServiceError
+		if errors.As(err, &svcErr) && svcErr.StatusCode >= 400 && svcErr.StatusCode < 500 {
+			c.JSON(svcErr.StatusCode, gin.H{"status": svcErr.StatusCode, "msg": svcErr.Body})
+			return
+		}
+		a.Error("put local config failed", zap.Error(err))
+		c.JSON(http.StatusBadGateway, gin.H{"status": http.StatusBadGateway, "msg": "speech service unavailable"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": http.StatusOK, "msg": "ok"})
+}
+
+func (a *VoiceAdapter) getLocalConfig(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+
+	spaceID := getSpaceID(c)
+	if spaceID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "X-Space-ID header is required"})
+		return
+	}
+
+	isMember, err := space.CheckMembership(a.ctx.DB(), spaceID, loginUID)
+	if err != nil {
+		a.Error("check space membership failed", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"status": http.StatusInternalServerError, "msg": "check space membership failed"})
+		return
+	}
+	if !isMember {
+		c.JSON(http.StatusForbidden, gin.H{"status": http.StatusForbidden, "msg": "not a member of this space"})
+		return
+	}
+
+	resp, err := a.client.GetLocalConfig(c.Request.Context(), loginUID, "space", spaceID)
+	if err != nil {
+		var svcErr *SpeechServiceError
+		if errors.As(err, &svcErr) && svcErr.StatusCode >= 400 && svcErr.StatusCode < 500 {
+			c.JSON(svcErr.StatusCode, gin.H{"status": svcErr.StatusCode, "msg": svcErr.Body})
+			return
+		}
+		a.Error("get local config failed", zap.Error(err))
+		c.JSON(http.StatusBadGateway, gin.H{"status": http.StatusBadGateway, "msg": "speech service unavailable"})
+		return
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+func (a *VoiceAdapter) deleteLocalConfig(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+
+	spaceID := getSpaceID(c)
+	if spaceID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "X-Space-ID header is required"})
+		return
+	}
+
+	isMember, err := space.CheckMembership(a.ctx.DB(), spaceID, loginUID)
+	if err != nil {
+		a.Error("check space membership failed", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"status": http.StatusInternalServerError, "msg": "check space membership failed"})
+		return
+	}
+	if !isMember {
+		c.JSON(http.StatusForbidden, gin.H{"status": http.StatusForbidden, "msg": "not a member of this space"})
+		return
+	}
+
+	err = a.client.DeleteLocalConfig(c.Request.Context(), loginUID, "space", spaceID)
+	if err != nil {
+		var svcErr *SpeechServiceError
+		if errors.As(err, &svcErr) && svcErr.StatusCode >= 400 && svcErr.StatusCode < 500 {
+			c.JSON(svcErr.StatusCode, gin.H{"status": svcErr.StatusCode, "msg": svcErr.Body})
+			return
+		}
+		a.Error("delete local config failed", zap.Error(err))
+		c.JSON(http.StatusBadGateway, gin.H{"status": http.StatusBadGateway, "msg": "speech service unavailable"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": http.StatusOK, "msg": "ok"})
 }

--- a/modules/voice_adapter/adapter_test.go
+++ b/modules/voice_adapter/adapter_test.go
@@ -1,18 +1,27 @@
 package voice_adapter
 
 import (
+	"bytes"
 	"encoding/json"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
 	"testing"
 	"time"
+	"unsafe"
 
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/gin-gonic/gin"
+	"github.com/gocraft/dbr/v2"
+	"github.com/gocraft/dbr/v2/dialect"
 )
 
 func TestNewAdapterConfigFromEnv_Defaults(t *testing.T) {
@@ -64,11 +73,58 @@ func newTestAdapter(speechURL string) *VoiceAdapter {
 	}
 }
 
-func callGetConfig(a *VoiceAdapter) *httptest.ResponseRecorder {
+func newTestAdapterWithDB(speechURL string, ctx *config.Context) *VoiceAdapter {
+	return &VoiceAdapter{
+		ctx:    ctx,
+		client: NewSpeechClient(speechURL, "test-key", 2*time.Second),
+		cfg:    &AdapterConfig{},
+		Log:    log.NewTLog("VoiceAdapterTest"),
+	}
+}
+
+func newMockedDBSession(t *testing.T) (*dbr.Session, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	rawDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	conn := &dbr.Connection{DB: rawDB, EventReceiver: &dbr.NullEventReceiver{}, Dialect: dialect.MySQL}
+	session := conn.NewSession(nil)
+	return session, mock, func() { _ = rawDB.Close() }
+}
+
+func injectMockDBIntoContext(t *testing.T, ctx *config.Context, session *dbr.Session) {
+	t.Helper()
+	ctxVal := reflect.ValueOf(ctx).Elem()
+
+	onceField := ctxVal.FieldByName("mysqlOnce")
+	once := (*sync.Once)(unsafe.Pointer(onceField.UnsafeAddr()))
+	once.Do(func() {})
+
+	sessionField := ctxVal.FieldByName("mySQLSession")
+	reflect.NewAt(sessionField.Type(), unsafe.Pointer(sessionField.UnsafeAddr())).
+		Elem().Set(reflect.ValueOf(session))
+}
+
+func newTestContextWithMockDB(t *testing.T) (*config.Context, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	cfg := config.New()
+	cfg.Test = true
+	ctx := config.NewContext(cfg)
+
+	session, mock, cleanup := newMockedDBSession(t)
+	injectMockDBIntoContext(t, ctx, session)
+	return ctx, mock, cleanup
+}
+
+func callGetConfig(a *VoiceAdapter, mock sqlmock.Sqlmock) *httptest.ResponseRecorder {
+	mock.ExpectQuery("SELECT COUNT").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
 	gc, _ := gin.CreateTestContext(rec)
 	gc.Request = httptest.NewRequest(http.MethodGet, "/v1/voice/config", nil)
+	gc.Request.Header.Set("X-Space-ID", "test-space")
+	gc.Set("uid", "test-user")
 	ctx := &wkhttp.Context{Context: gc}
 	a.getConfig(ctx)
 	return rec
@@ -84,8 +140,10 @@ func TestGetConfigHandler_Healthy(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	a := newTestAdapter(srv.URL)
-	rec := callGetConfig(a)
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	a := newTestAdapterWithDB(srv.URL, ctx)
+	rec := callGetConfig(a, mock)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rec.Code)
@@ -110,8 +168,10 @@ func TestGetConfigHandler_HTTPError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	a := newTestAdapter(srv.URL)
-	rec := callGetConfig(a)
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	a := newTestAdapterWithDB(srv.URL, ctx)
+	rec := callGetConfig(a, mock)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200 (graceful fallback), got %d", rec.Code)
@@ -134,8 +194,10 @@ func TestGetConfigHandler_ConnectionRefused(t *testing.T) {
 	addr := ln.Addr().String()
 	ln.Close()
 
-	a := newTestAdapter("http://" + addr)
-	rec := callGetConfig(a)
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	a := newTestAdapterWithDB("http://"+addr, ctx)
+	rec := callGetConfig(a, mock)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200 (graceful fallback), got %d", rec.Code)
@@ -157,12 +219,15 @@ func TestGetConfigHandler_Timeout(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
 	a := &VoiceAdapter{
+		ctx:    ctx,
 		client: NewSpeechClient(srv.URL, "test-key", 100*time.Millisecond),
 		cfg:    &AdapterConfig{},
 		Log:    log.NewTLog("VoiceAdapterTest"),
 	}
-	rec := callGetConfig(a)
+	rec := callGetConfig(a, mock)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200 (graceful fallback), got %d", rec.Code)
@@ -212,12 +277,15 @@ func TestGetConfigHandler_InjectsFeedbackPrivacyURL(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
 	a := &VoiceAdapter{
+		ctx:    ctx,
 		client: NewSpeechClient(srv.URL, "test-key", 2*time.Second),
 		cfg:    &AdapterConfig{FeedbackPrivacyURL: "https://example.com/privacy"},
 		Log:    log.NewTLog("VoiceAdapterTest"),
 	}
-	rec := callGetConfig(a)
+	rec := callGetConfig(a, mock)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rec.Code)
@@ -243,12 +311,15 @@ func TestGetConfigHandler_NoFeedbackPrivacyURLWhenEmpty(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
 	a := &VoiceAdapter{
+		ctx:    ctx,
 		client: NewSpeechClient(srv.URL, "test-key", 2*time.Second),
 		cfg:    &AdapterConfig{FeedbackPrivacyURL: ""},
 		Log:    log.NewTLog("VoiceAdapterTest"),
 	}
-	rec := callGetConfig(a)
+	rec := callGetConfig(a, mock)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rec.Code)
@@ -304,7 +375,10 @@ func TestGetConfigHandler_InjectsNewURLs(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
 	a := &VoiceAdapter{
+		ctx:    ctx,
 		client: NewSpeechClient(srv.URL, "test-key", 2*time.Second),
 		cfg: &AdapterConfig{
 			FeedbackPrivacyURL: "https://example.com/privacy",
@@ -312,7 +386,7 @@ func TestGetConfigHandler_InjectsNewURLs(t *testing.T) {
 		},
 		Log: log.NewTLog("VoiceAdapterTest"),
 	}
-	rec := callGetConfig(a)
+	rec := callGetConfig(a, mock)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rec.Code)
@@ -338,12 +412,15 @@ func TestGetConfigHandler_NoNewURLsWhenEmpty(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
 	a := &VoiceAdapter{
+		ctx:    ctx,
 		client: NewSpeechClient(srv.URL, "test-key", 2*time.Second),
 		cfg:    &AdapterConfig{},
 		Log:    log.NewTLog("VoiceAdapterTest"),
 	}
-	rec := callGetConfig(a)
+	rec := callGetConfig(a, mock)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rec.Code)
@@ -417,5 +494,554 @@ func TestGetDocument_NotFound(t *testing.T) {
 	}
 	if body["msg"] != "document not available" {
 		t.Errorf("expected msg='document not available', got %v", body["msg"])
+	}
+}
+
+func TestGetConfigHandler_WithSpaceID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("subject_id") != "user1" {
+			t.Errorf("expected subject_id=user1, got %s", r.URL.Query().Get("subject_id"))
+		}
+		if r.URL.Query().Get("scope_type") != "space" {
+			t.Errorf("expected scope_type=space, got %s", r.URL.Query().Get("scope_type"))
+		}
+		if r.URL.Query().Get("scope_id") != "space123" {
+			t.Errorf("expected scope_id=space123, got %s", r.URL.Query().Get("scope_id"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"enabled":       true,
+			"local_enabled": false,
+		})
+	}))
+	defer srv.Close()
+
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT COUNT").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	a := newTestAdapterWithDB(srv.URL, ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest(http.MethodGet, "/v1/voice/config", nil)
+	gc.Request.Header.Set("X-Space-ID", "space123")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.getConfig(wkCtx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["local_enabled"] != false {
+		t.Errorf("expected local_enabled=false, got %v", body["local_enabled"])
+	}
+}
+
+func TestGetConfigHandler_MissingSpaceIDHeader(t *testing.T) {
+	a := newTestAdapter("http://unused")
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest(http.MethodGet, "/v1/voice/config", nil)
+	gc.Set("uid", "user1")
+	ctx := &wkhttp.Context{Context: gc}
+	a.getConfig(ctx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["msg"] != "X-Space-ID header is required" {
+		t.Errorf("expected msg='X-Space-ID header is required', got %v", body["msg"])
+	}
+}
+
+func TestGetConfigHandler_QuerySpaceIDIgnored(t *testing.T) {
+	a := newTestAdapter("http://unused")
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest(http.MethodGet, "/v1/voice/config?space_id=space123", nil)
+	gc.Set("uid", "user1")
+	ctx := &wkhttp.Context{Context: gc}
+	a.getConfig(ctx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 (query param ignored), got %d", rec.Code)
+	}
+}
+
+func TestPutLocalConfigHandler_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("expected PATCH, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/speech/local-config" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":200,"msg":"ok"}`))
+	}))
+	defer srv.Close()
+
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT COUNT").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	a := newTestAdapterWithDB(srv.URL, ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	reqBody := `{"enabled":true}`
+	gc.Request = httptest.NewRequest(http.MethodPut, "/v1/voice/local-config", bytes.NewBufferString(reqBody))
+	gc.Request.Header.Set("Content-Type", "application/json")
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.putLocalConfig(wkCtx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestPutLocalConfigHandler_MissingEnabled(t *testing.T) {
+	ctx, _, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+
+	a := newTestAdapterWithDB("http://unused", ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	reqBody := `{}`
+	gc.Request = httptest.NewRequest(http.MethodPut, "/v1/voice/local-config", bytes.NewBufferString(reqBody))
+	gc.Request.Header.Set("Content-Type", "application/json")
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.putLocalConfig(wkCtx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestPutLocalConfigHandler_MissingSpaceIDHeader(t *testing.T) {
+	a := newTestAdapter("http://unused")
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	reqBody := `{"enabled":true}`
+	gc.Request = httptest.NewRequest(http.MethodPut, "/v1/voice/local-config", bytes.NewBufferString(reqBody))
+	gc.Request.Header.Set("Content-Type", "application/json")
+	gc.Set("uid", "user1")
+	ctx := &wkhttp.Context{Context: gc}
+	a.putLocalConfig(ctx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["msg"] != "X-Space-ID header is required" {
+		t.Errorf("expected msg='X-Space-ID header is required', got %v", body["msg"])
+	}
+}
+
+func TestPutLocalConfigHandler_QuerySpaceIDIgnored(t *testing.T) {
+	a := newTestAdapter("http://unused")
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	reqBody := `{"enabled":true}`
+	gc.Request = httptest.NewRequest(http.MethodPut, "/v1/voice/local-config?space_id=space1", bytes.NewBufferString(reqBody))
+	gc.Request.Header.Set("Content-Type", "application/json")
+	gc.Set("uid", "user1")
+	ctx := &wkhttp.Context{Context: gc}
+	a.putLocalConfig(ctx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 (query param ignored), got %d", rec.Code)
+	}
+}
+
+func TestPutLocalConfigHandler_4xxPassthrough(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.Write([]byte("validation failed"))
+	}))
+	defer srv.Close()
+
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT COUNT").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	a := newTestAdapterWithDB(srv.URL, ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	reqBody := `{"enabled":true}`
+	gc.Request = httptest.NewRequest(http.MethodPut, "/v1/voice/local-config", bytes.NewBufferString(reqBody))
+	gc.Request.Header.Set("Content-Type", "application/json")
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.putLocalConfig(wkCtx)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d", rec.Code)
+	}
+}
+
+func TestPutLocalConfigHandler_5xxReturnsBadGateway(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer srv.Close()
+
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT COUNT").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	a := newTestAdapterWithDB(srv.URL, ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	reqBody := `{"enabled":false}`
+	gc.Request = httptest.NewRequest(http.MethodPut, "/v1/voice/local-config", bytes.NewBufferString(reqBody))
+	gc.Request.Header.Set("Content-Type", "application/json")
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.putLocalConfig(wkCtx)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d", rec.Code)
+	}
+}
+
+func TestPutLocalConfigHandler_NetworkErrorReturnsBadGateway(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT COUNT").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	a := newTestAdapterWithDB("http://"+addr, ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	reqBody := `{"enabled":true}`
+	gc.Request = httptest.NewRequest(http.MethodPut, "/v1/voice/local-config", bytes.NewBufferString(reqBody))
+	gc.Request.Header.Set("Content-Type", "application/json")
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.putLocalConfig(wkCtx)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d", rec.Code)
+	}
+}
+
+func TestGetLocalConfigHandler_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"enabled":    true,
+			"timeout_ms": 5000,
+		})
+	}))
+	defer srv.Close()
+
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT COUNT").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	a := newTestAdapterWithDB(srv.URL, ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest(http.MethodGet, "/v1/voice/local-config", nil)
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.getLocalConfig(wkCtx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["enabled"] != true {
+		t.Errorf("expected enabled=true, got %v", body["enabled"])
+	}
+}
+
+func TestGetLocalConfigHandler_MissingSpaceIDHeader(t *testing.T) {
+	a := newTestAdapter("http://unused")
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest(http.MethodGet, "/v1/voice/local-config", nil)
+	gc.Set("uid", "user1")
+	ctx := &wkhttp.Context{Context: gc}
+	a.getLocalConfig(ctx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["msg"] != "X-Space-ID header is required" {
+		t.Errorf("expected msg='X-Space-ID header is required', got %v", body["msg"])
+	}
+}
+
+func TestGetLocalConfigHandler_QuerySpaceIDIgnored(t *testing.T) {
+	a := newTestAdapter("http://unused")
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest(http.MethodGet, "/v1/voice/local-config?scope_type=space&scope_id=space1", nil)
+	gc.Set("uid", "user1")
+	ctx := &wkhttp.Context{Context: gc}
+	a.getLocalConfig(ctx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 (query params ignored), got %d", rec.Code)
+	}
+}
+
+func TestGetLocalConfigHandler_4xxPassthrough(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte("not found"))
+	}))
+	defer srv.Close()
+
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT COUNT").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	a := newTestAdapterWithDB(srv.URL, ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest(http.MethodGet, "/v1/voice/local-config", nil)
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.getLocalConfig(wkCtx)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestDeleteLocalConfigHandler_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":200,"msg":"ok"}`))
+	}))
+	defer srv.Close()
+
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT COUNT").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	a := newTestAdapterWithDB(srv.URL, ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest(http.MethodDelete, "/v1/voice/local-config", nil)
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.deleteLocalConfig(wkCtx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestDeleteLocalConfigHandler_MissingSpaceIDHeader(t *testing.T) {
+	a := newTestAdapter("http://unused")
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest(http.MethodDelete, "/v1/voice/local-config", nil)
+	gc.Set("uid", "user1")
+	ctx := &wkhttp.Context{Context: gc}
+	a.deleteLocalConfig(ctx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["msg"] != "X-Space-ID header is required" {
+		t.Errorf("expected msg='X-Space-ID header is required', got %v", body["msg"])
+	}
+}
+
+func TestDeleteLocalConfigHandler_5xxReturnsBadGateway(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer srv.Close()
+
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT COUNT").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	a := newTestAdapterWithDB(srv.URL, ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest(http.MethodDelete, "/v1/voice/local-config", nil)
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.deleteLocalConfig(wkCtx)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d", rec.Code)
+	}
+}
+
+func TestGetConfig_NonMember(t *testing.T) {
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT COUNT").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	a := newTestAdapterWithDB("http://unused", ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest(http.MethodGet, "/v1/voice/config", nil)
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.getConfig(wkCtx)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["msg"] != "not a member of this space" {
+		t.Errorf("expected msg='not a member of this space', got %v", body["msg"])
+	}
+}
+
+func TestGetConfig_MembershipCheckError(t *testing.T) {
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT COUNT").WillReturnError(sqlmock.ErrCancelled)
+
+	a := newTestAdapterWithDB("http://unused", ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest(http.MethodGet, "/v1/voice/config", nil)
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.getConfig(wkCtx)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["msg"] != "check space membership failed" {
+		t.Errorf("expected msg='check space membership failed', got %v", body["msg"])
+	}
+}
+
+func TestPutLocalConfig_BodyTooLarge(t *testing.T) {
+	ctx, _, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+
+	a := newTestAdapterWithDB("http://unused", ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	largeBody := `{"enabled":true,"probe_url":"` + strings.Repeat("a", 65*1024) + `"}`
+	gc.Request = httptest.NewRequest(http.MethodPut, "/v1/voice/local-config", bytes.NewBufferString(largeBody))
+	gc.Request.Header.Set("Content-Type", "application/json")
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.putLocalConfig(wkCtx)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["msg"] != "request body too large" {
+		t.Errorf("expected msg='request body too large', got %v", body["msg"])
+	}
+}
+
+func TestGetContext_QuerySpaceIDIgnored(t *testing.T) {
+	ctx, _, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+
+	a := newTestAdapterWithDB("http://unused", ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest(http.MethodGet, "/v1/voice/context?space_id=space1", nil)
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.getContext(wkCtx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 (query param ignored), got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["msg"] != "X-Space-ID header is required" {
+		t.Errorf("expected msg='X-Space-ID header is required', got %v", body["msg"])
 	}
 }

--- a/modules/voice_adapter/client.go
+++ b/modules/voice_adapter/client.go
@@ -149,8 +149,24 @@ func (c *SpeechClient) DeleteVocabulary(ctx context.Context, subjectID, scopeTyp
 	return nil
 }
 
-func (c *SpeechClient) GetConfig(ctx context.Context) (map[string]interface{}, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/speech/config", nil)
+func (c *SpeechClient) GetConfig(ctx context.Context, subjectID, scopeType, scopeID string) (map[string]interface{}, error) {
+	params := url.Values{}
+	if subjectID != "" {
+		params.Set("subject_id", subjectID)
+	}
+	if scopeType != "" {
+		params.Set("scope_type", scopeType)
+	}
+	if scopeID != "" {
+		params.Set("scope_id", scopeID)
+	}
+
+	reqURL := c.baseURL + "/v1/speech/config"
+	if encoded := params.Encode(); encoded != "" {
+		reqURL += "?" + encoded
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
@@ -172,4 +188,103 @@ func (c *SpeechClient) GetConfig(ctx context.Context) (map[string]interface{}, e
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	return result, nil
+}
+
+func (c *SpeechClient) PutLocalConfig(ctx context.Context, subjectID, scopeType, scopeID string, enabled bool, timeoutMs *int, probeURL, transcribeURL *string) error {
+	payload := map[string]interface{}{
+		"subject_id": subjectID,
+		"scope_type": scopeType,
+		"scope_id":   scopeID,
+		"enabled":    enabled,
+	}
+	if timeoutMs != nil {
+		payload["timeout_ms"] = *timeoutMs
+	}
+	if probeURL != nil {
+		payload["probe_url"] = *probeURL
+	}
+	if transcribeURL != nil {
+		payload["transcribe_url"] = *transcribeURL
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, c.baseURL+"/v1/speech/local-config", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return &SpeechServiceError{StatusCode: resp.StatusCode, Body: string(respBody)}
+	}
+	return nil
+}
+
+func (c *SpeechClient) GetLocalConfig(ctx context.Context, subjectID, scopeType, scopeID string) (map[string]interface{}, error) {
+	params := url.Values{}
+	params.Set("subject_id", subjectID)
+	params.Set("scope_type", scopeType)
+	params.Set("scope_id", scopeID)
+	reqURL := c.baseURL + "/v1/speech/local-config?" + params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, &SpeechServiceError{StatusCode: resp.StatusCode, Body: string(body)}
+	}
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return result, nil
+}
+
+func (c *SpeechClient) DeleteLocalConfig(ctx context.Context, subjectID, scopeType, scopeID string) error {
+	params := url.Values{}
+	params.Set("subject_id", subjectID)
+	params.Set("scope_type", scopeType)
+	params.Set("scope_id", scopeID)
+	reqURL := c.baseURL + "/v1/speech/local-config?" + params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return &SpeechServiceError{StatusCode: resp.StatusCode, Body: string(body)}
+	}
+	return nil
 }

--- a/modules/voice_adapter/client_test.go
+++ b/modules/voice_adapter/client_test.go
@@ -3,6 +3,7 @@ package voice_adapter
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -202,7 +203,7 @@ func TestGetConfig(t *testing.T) {
 	defer srv.Close()
 
 	client := NewSpeechClient(srv.URL, "test-key", 5*time.Second)
-	cfg, err := client.GetConfig(context.Background())
+	cfg, err := client.GetConfig(context.Background(), "", "", "")
 	if err != nil {
 		t.Fatalf("GetConfig failed: %v", err)
 	}
@@ -214,6 +215,35 @@ func TestGetConfig(t *testing.T) {
 	}
 }
 
+func TestGetConfig_WithScopeParams(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("subject_id") != "user1" {
+			t.Errorf("unexpected subject_id: %s", r.URL.Query().Get("subject_id"))
+		}
+		if r.URL.Query().Get("scope_type") != "space" {
+			t.Errorf("unexpected scope_type: %s", r.URL.Query().Get("scope_type"))
+		}
+		if r.URL.Query().Get("scope_id") != "space1" {
+			t.Errorf("unexpected scope_id: %s", r.URL.Query().Get("scope_id"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"enabled":       true,
+			"local_enabled": false,
+		})
+	}))
+	defer srv.Close()
+
+	client := NewSpeechClient(srv.URL, "test-key", 5*time.Second)
+	cfg, err := client.GetConfig(context.Background(), "user1", "space", "space1")
+	if err != nil {
+		t.Fatalf("GetConfig with scope params failed: %v", err)
+	}
+	if cfg["local_enabled"] != false {
+		t.Errorf("expected local_enabled=false, got %v", cfg["local_enabled"])
+	}
+}
+
 func TestGetConfigError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -222,7 +252,7 @@ func TestGetConfigError(t *testing.T) {
 	defer srv.Close()
 
 	client := NewSpeechClient(srv.URL, "test-key", 5*time.Second)
-	_, err := client.GetConfig(context.Background())
+	_, err := client.GetConfig(context.Background(), "", "", "")
 	if err == nil {
 		t.Fatal("expected error for 503 response")
 	}
@@ -237,7 +267,7 @@ func TestGetConfig_ConnectionRefused(t *testing.T) {
 	ln.Close()
 
 	client := NewSpeechClient("http://"+addr, "test-key", 2*time.Second)
-	_, err = client.GetConfig(context.Background())
+	_, err = client.GetConfig(context.Background(), "", "", "")
 	if err == nil {
 		t.Fatal("expected error for unreachable server")
 	}
@@ -313,5 +343,207 @@ func TestForwardTranscribeBody(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestPutLocalConfig(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("expected PATCH, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/speech/local-config" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected application/json, got %s", r.Header.Get("Content-Type"))
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Errorf("expected Bearer test-key, got %q", r.Header.Get("Authorization"))
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var payload map[string]interface{}
+		json.Unmarshal(body, &payload)
+		if payload["subject_id"] != "user1" {
+			t.Errorf("unexpected subject_id: %v", payload["subject_id"])
+		}
+		if payload["scope_type"] != "space" {
+			t.Errorf("unexpected scope_type: %v", payload["scope_type"])
+		}
+		if payload["scope_id"] != "space1" {
+			t.Errorf("unexpected scope_id: %v", payload["scope_id"])
+		}
+		if payload["enabled"] != true {
+			t.Errorf("unexpected enabled: %v", payload["enabled"])
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":200,"msg":"ok"}`))
+	}))
+	defer srv.Close()
+
+	client := NewSpeechClient(srv.URL, "test-key", 5*time.Second)
+	err := client.PutLocalConfig(context.Background(), "user1", "space", "space1", true, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("PutLocalConfig failed: %v", err)
+	}
+}
+
+func TestPutLocalConfig_WithOptionalFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload map[string]interface{}
+		json.Unmarshal(body, &payload)
+		if payload["timeout_ms"] != float64(5000) {
+			t.Errorf("unexpected timeout_ms: %v", payload["timeout_ms"])
+		}
+		if payload["probe_url"] != "http://probe" {
+			t.Errorf("unexpected probe_url: %v", payload["probe_url"])
+		}
+		if payload["transcribe_url"] != "http://transcribe" {
+			t.Errorf("unexpected transcribe_url: %v", payload["transcribe_url"])
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":200,"msg":"ok"}`))
+	}))
+	defer srv.Close()
+
+	client := NewSpeechClient(srv.URL, "test-key", 5*time.Second)
+	timeout := 5000
+	probe := "http://probe"
+	transcribe := "http://transcribe"
+	err := client.PutLocalConfig(context.Background(), "user1", "space", "space1", false, &timeout, &probe, &transcribe)
+	if err != nil {
+		t.Fatalf("PutLocalConfig with optional fields failed: %v", err)
+	}
+}
+
+func TestPutLocalConfig_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("bad request"))
+	}))
+	defer srv.Close()
+
+	client := NewSpeechClient(srv.URL, "test-key", 5*time.Second)
+	err := client.PutLocalConfig(context.Background(), "user1", "space", "space1", true, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for 400 response")
+	}
+	var svcErr *SpeechServiceError
+	if !errors.As(err, &svcErr) {
+		t.Fatalf("expected SpeechServiceError, got %T", err)
+	}
+	if svcErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", svcErr.StatusCode)
+	}
+}
+
+func TestGetLocalConfig(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/speech/local-config" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("subject_id") != "user1" {
+			t.Errorf("unexpected subject_id: %s", r.URL.Query().Get("subject_id"))
+		}
+		if r.URL.Query().Get("scope_type") != "space" {
+			t.Errorf("unexpected scope_type: %s", r.URL.Query().Get("scope_type"))
+		}
+		if r.URL.Query().Get("scope_id") != "space1" {
+			t.Errorf("unexpected scope_id: %s", r.URL.Query().Get("scope_id"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"enabled":    false,
+			"timeout_ms": 3000,
+		})
+	}))
+	defer srv.Close()
+
+	client := NewSpeechClient(srv.URL, "test-key", 5*time.Second)
+	cfg, err := client.GetLocalConfig(context.Background(), "user1", "space", "space1")
+	if err != nil {
+		t.Fatalf("GetLocalConfig failed: %v", err)
+	}
+	if cfg["enabled"] != false {
+		t.Errorf("expected enabled=false, got %v", cfg["enabled"])
+	}
+	if cfg["timeout_ms"] != float64(3000) {
+		t.Errorf("expected timeout_ms=3000, got %v", cfg["timeout_ms"])
+	}
+}
+
+func TestGetLocalConfig_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte("not found"))
+	}))
+	defer srv.Close()
+
+	client := NewSpeechClient(srv.URL, "test-key", 5*time.Second)
+	_, err := client.GetLocalConfig(context.Background(), "user1", "space", "space1")
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+	var svcErr *SpeechServiceError
+	if !errors.As(err, &svcErr) {
+		t.Fatalf("expected SpeechServiceError, got %T", err)
+	}
+	if svcErr.StatusCode != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", svcErr.StatusCode)
+	}
+}
+
+func TestDeleteLocalConfig(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/speech/local-config" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("subject_id") != "user1" {
+			t.Errorf("unexpected subject_id: %s", r.URL.Query().Get("subject_id"))
+		}
+		if r.URL.Query().Get("scope_type") != "space" {
+			t.Errorf("unexpected scope_type: %s", r.URL.Query().Get("scope_type"))
+		}
+		if r.URL.Query().Get("scope_id") != "space1" {
+			t.Errorf("unexpected scope_id: %s", r.URL.Query().Get("scope_id"))
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":200,"msg":"ok"}`))
+	}))
+	defer srv.Close()
+
+	client := NewSpeechClient(srv.URL, "test-key", 5*time.Second)
+	err := client.DeleteLocalConfig(context.Background(), "user1", "space", "space1")
+	if err != nil {
+		t.Fatalf("DeleteLocalConfig failed: %v", err)
+	}
+}
+
+func TestDeleteLocalConfig_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer srv.Close()
+
+	client := NewSpeechClient(srv.URL, "test-key", 5*time.Second)
+	err := client.DeleteLocalConfig(context.Background(), "user1", "space", "space1")
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+	var svcErr *SpeechServiceError
+	if !errors.As(err, &svcErr) {
+		t.Fatalf("expected SpeechServiceError, got %T", err)
+	}
+	if svcErr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected status 500, got %d", svcErr.StatusCode)
 	}
 }


### PR DESCRIPTION
## Summary

Proxy octo-speech local-config CRUD API for per-user ASR toggle, with security hardening.

Closes #166

## Changes

- `PUT /v1/voice/local-config`: Create/update per-user local ASR config (proxies to speech PATCH)
- `GET /v1/voice/local-config`: Read per-user config
- `DELETE /v1/voice/local-config`: Remove per-user config
- All endpoints: X-Space-ID header-only (query param removed)
- `getConfig`: Added `space.CheckMembership` (fixes authz bypass)
- `putLocalConfig`: Added `MaxBytesReader(64KB)` (fixes DoS)
- `getContext`: Migrated from `c.Query("space_id")` to `getSpaceID(c)` (header consistency)

## Security Fixes

| Endpoint | Fix | Risk |
|----------|-----|------|
| `getConfig` | Added CheckMembership before proxy call | Was IDOR — any user could read any space config |
| `putLocalConfig` | Added 64KB body size limit | Was DoS — unbounded body → memory exhaustion |
| `getContext` | Migrated to X-Space-ID header | Was inconsistent with other handlers |

## API Contract

All `/v1/voice/*` endpoints now require `X-Space-ID` header (not query param):
- Missing header → 400
- Non-member of space → 403
- Body too large (putLocalConfig) → 413

Frontend `APIClient` already auto-injects `X-Space-Id` header via request interceptor, so this is backward-compatible.
