### PR TITLE
feat: default i18n language to zh-CN

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -86,6 +86,12 @@ to your own path and point each section at your live infra:
 - `minio.*` (or whichever object-storage adapter you use) — your S3
   endpoint, app credentials, and bucket layout
 
+Runtime language fallback is controlled by environment variables rather
+than YAML. Set `OCTO_DEFAULT_LANGUAGE=zh-CN` in deployments so clients
+that do not send `Accept-Language`, `lang`, or `i18n_lang` keep receiving
+Chinese error messages during the i18n rollout. Supported values are
+`zh-CN` and `en-US`; invalid values fail startup.
+
 ### Run
 
 `octo-server` parses the `--config` flag with the stdlib `flag`

--- a/main.go
+++ b/main.go
@@ -95,7 +95,14 @@ func runAPI(ctx *config.Context) {
 	s := server.New(ctx)
 	route := s.GetRoute()
 	ctx.SetHttpRoute(route)
-	route.SetErrorRenderer(octoi18n.NewErrorRenderer(octoi18n.NewLocalizer(os.Getenv("DM_DEFAULT_LANGUAGE"))))
+	defaultLanguage, err := octoi18n.DefaultLanguageFromEnv()
+	if err != nil {
+		panic(err)
+	}
+	if err := octoi18n.ValidateRuntimeLocales(defaultLanguage); err != nil {
+		panic(fmt.Errorf("validate i18n runtime locales: %w", err))
+	}
+	route.SetErrorRenderer(octoi18n.NewErrorRenderer(octoi18n.NewLocalizer(defaultLanguage)))
 	// 替换web下的配置文件
 	replaceWebConfig(ctx.GetConfig())
 	// 初始化api
@@ -104,7 +111,7 @@ func runAPI(ctx *config.Context) {
 		panic(fmt.Errorf("parse DM_TRUSTED_LANG_HEADER_CIDRS: %w", err))
 	}
 	route.UseGin(octoi18n.EarlyMiddleware(octoi18n.MiddlewareOptions{
-		DefaultLanguage:        os.Getenv("DM_DEFAULT_LANGUAGE"),
+		DefaultLanguage:        defaultLanguage,
 		TrustedLangHeaderCIDRs: trustedLangCIDRs,
 	}))
 	route.UseGin(ctx.Tracer().GinMiddle()) // 需要放在 api.Route(s.GetRoute())的前面

--- a/pkg/i18n/config.go
+++ b/pkg/i18n/config.go
@@ -1,0 +1,74 @@
+package i18n
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	// EnvDefaultLanguage controls the runtime fallback language for requests
+	// that carry no explicit language signal.
+	EnvDefaultLanguage = "OCTO_DEFAULT_LANGUAGE"
+
+	// DefaultLanguage preserves the legacy deployment behavior for clients that
+	// do not send Accept-Language yet.
+	DefaultLanguage = "zh-CN"
+)
+
+// DefaultLanguageFromEnv resolves OCTO_DEFAULT_LANGUAGE into a supported BCP-47
+// language tag. Empty env uses DefaultLanguage; invalid values are rejected so
+// rollout misconfiguration fails during startup instead of surfacing per request.
+func DefaultLanguageFromEnv() (string, error) {
+	return ResolveDefaultLanguage(os.Getenv(EnvDefaultLanguage))
+}
+
+// ResolveDefaultLanguage normalizes the configured default language.
+func ResolveDefaultLanguage(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return DefaultLanguage, nil
+	}
+	if lang, ok := MatchSupportedLanguage(raw); ok {
+		return lang, nil
+	}
+	return "", fmt.Errorf("%s must be one of %s, got %q", EnvDefaultLanguage, strings.Join(SupportedLanguages(), ", "), raw)
+}
+
+// SupportedLanguages returns the current runtime language matrix.
+func SupportedLanguages() []string {
+	out := make([]string, 0, len(supportedLanguageTags))
+	for _, tag := range supportedLanguageTags {
+		out = append(out, tag.String())
+	}
+	return out
+}
+
+// ValidateRuntimeLocales checks the locale files required for startup:
+// source language and configured default language must both have active TOML
+// files in the embedded runtime bundle.
+func ValidateRuntimeLocales(defaultLang string) error {
+	normalizedDefault, err := ResolveDefaultLanguage(defaultLang)
+	if err != nil {
+		return err
+	}
+	seen := map[string]bool{}
+	for _, lang := range []string{SourceLanguage, normalizedDefault} {
+		if seen[lang] {
+			continue
+		}
+		seen[lang] = true
+		if !activeLocaleExists(lang) {
+			return fmt.Errorf("i18n active locale for %s is missing", lang)
+		}
+	}
+	if _, err := Bundle(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func activeLocaleExists(lang string) bool {
+	_, err := localesFS.ReadFile("locales/active." + lang + ".toml")
+	return err == nil
+}

--- a/pkg/i18n/config_test.go
+++ b/pkg/i18n/config_test.go
@@ -1,0 +1,80 @@
+package i18n
+
+import "testing"
+
+func TestResolveDefaultLanguage(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty uses runtime default", raw: "", want: DefaultLanguage},
+		{name: "normalizes zh alias", raw: "zh", want: "zh-CN"},
+		{name: "normalizes en alias", raw: "en", want: "en-US"},
+		{name: "rejects unsupported", raw: "fr-FR", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveDefaultLanguage(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("ResolveDefaultLanguage returned nil error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveDefaultLanguage returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("ResolveDefaultLanguage = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultLanguageFromEnv(t *testing.T) {
+	t.Setenv(EnvDefaultLanguage, "")
+	got, err := DefaultLanguageFromEnv()
+	if err != nil {
+		t.Fatalf("DefaultLanguageFromEnv returned error: %v", err)
+	}
+	if got != DefaultLanguage {
+		t.Fatalf("DefaultLanguageFromEnv = %q, want %q", got, DefaultLanguage)
+	}
+
+	t.Setenv(EnvDefaultLanguage, "en-US")
+	got, err = DefaultLanguageFromEnv()
+	if err != nil {
+		t.Fatalf("DefaultLanguageFromEnv returned error: %v", err)
+	}
+	if got != "en-US" {
+		t.Fatalf("DefaultLanguageFromEnv = %q, want en-US", got)
+	}
+}
+
+func TestValidateRuntimeLocales(t *testing.T) {
+	resetBundle()
+	t.Cleanup(resetBundle)
+
+	for _, lang := range []string{DefaultLanguage, SourceLanguage} {
+		t.Run(lang, func(t *testing.T) {
+			if err := ValidateRuntimeLocales(lang); err != nil {
+				t.Fatalf("ValidateRuntimeLocales(%q) returned error: %v", lang, err)
+			}
+		})
+	}
+}
+
+func TestActiveLocaleExists(t *testing.T) {
+	if !activeLocaleExists(SourceLanguage) {
+		t.Fatalf("source locale %q should exist", SourceLanguage)
+	}
+	if !activeLocaleExists(DefaultLanguage) {
+		t.Fatalf("default locale %q should exist", DefaultLanguage)
+	}
+	if activeLocaleExists("fr-FR") {
+		t.Fatal("fr-FR active locale should not exist")
+	}
+}

--- a/pkg/i18n/lang.go
+++ b/pkg/i18n/lang.go
@@ -132,10 +132,10 @@ func IsTrustedLangHeaderRequest(r *http.Request, cidrs []*net.IPNet) bool {
 }
 
 func normalizeDefaultLanguage(raw string) string {
-	if lang, ok := MatchSupportedLanguage(raw); ok {
+	if lang, err := ResolveDefaultLanguage(raw); err == nil {
 		return lang
 	}
-	return SourceLanguage
+	return DefaultLanguage
 }
 
 func matchAcceptLanguage(raw string) (string, bool) {

--- a/pkg/i18n/lang_test.go
+++ b/pkg/i18n/lang_test.go
@@ -122,6 +122,15 @@ func TestNegotiateLanguageSourceOrder(t *testing.T) {
 	}
 }
 
+func TestNegotiateLanguageUsesRuntimeDefaultWhenNoConfiguredDefault(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	got := NegotiateLanguage(req, LanguageNegotiationOptions{})
+	if got.Language != DefaultLanguage || got.Source != LanguageSourceDefault {
+		t.Fatalf("NegotiateLanguage = %#v, want %s from %s", got, DefaultLanguage, LanguageSourceDefault)
+	}
+}
+
 func TestMatchSupportedLanguage(t *testing.T) {
 	tests := []struct {
 		raw  string

--- a/pkg/i18n/localizer.go
+++ b/pkg/i18n/localizer.go
@@ -25,16 +25,17 @@ type Localizer interface {
 	Translate(code, lang string, params Params) string
 }
 
-// NewLocalizer 构造默认 Localizer。fallbackLang 通常对应 DM_DEFAULT_LANGUAGE
-// （主方案 D5），空串则使用 SourceLanguage。
+// NewLocalizer 构造默认 Localizer。fallbackLang 通常对应 OCTO_DEFAULT_LANGUAGE
+// （主方案 D5），空串则使用 DefaultLanguage。
 //
 // Localizer 实例线程安全且无状态——所有数据从 Bundle 单例读取，
 // 多 goroutine 可共享同一实例。
 func NewLocalizer(fallbackLang string) Localizer {
-	if fallbackLang == "" {
-		fallbackLang = SourceLanguage
+	resolved, err := ResolveDefaultLanguage(fallbackLang)
+	if err != nil {
+		resolved = DefaultLanguage
 	}
-	return &defaultLocalizer{fallbackLang: fallbackLang}
+	return &defaultLocalizer{fallbackLang: resolved}
 }
 
 type defaultLocalizer struct {

--- a/pkg/i18n/localizer_test.go
+++ b/pkg/i18n/localizer_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestNewLocalizer_DefaultsFallbackLang(t *testing.T) {
 	l := NewLocalizer("").(*defaultLocalizer)
-	if l.fallbackLang != SourceLanguage {
-		t.Errorf("empty fallback should default to %q, got %q", SourceLanguage, l.fallbackLang)
+	if l.fallbackLang != DefaultLanguage {
+		t.Errorf("empty fallback should default to %q, got %q", DefaultLanguage, l.fallbackLang)
 	}
 }
 
@@ -152,4 +152,3 @@ func TestBuildLangTags(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/i18n/renderer.go
+++ b/pkg/i18n/renderer.go
@@ -19,7 +19,7 @@ type ErrorRenderer struct {
 // NewErrorRenderer creates a wkhttp.ErrorRenderer implementation.
 func NewErrorRenderer(localizer Localizer) *ErrorRenderer {
 	if localizer == nil {
-		localizer = NewLocalizer(SourceLanguage)
+		localizer = NewLocalizer(DefaultLanguage)
 	}
 	return &ErrorRenderer{localizer: localizer}
 }
@@ -32,11 +32,11 @@ func (r *ErrorRenderer) Render(c *wkhttp.Context, spec wkhttp.ErrorSpec) {
 		return
 	}
 
-	lang := LanguageOrDefault(c.Request.Context(), SourceLanguage)
+	lang := LanguageOrDefault(c.Request.Context(), DefaultLanguage)
 	if matched, ok := MatchSupportedLanguage(lang); ok {
 		lang = matched
 	} else {
-		lang = SourceLanguage
+		lang = DefaultLanguage
 	}
 
 	transportStatus := normalizeHTTPStatus(spec.TransportStatus, http.StatusBadRequest)


### PR DESCRIPTION
## Summary
- default empty OCTO_DEFAULT_LANGUAGE to zh-CN for legacy clients without language signals
- validate OCTO_DEFAULT_LANGUAGE and required active locale files during API startup
- document the rollout env in Quickstart and docker/octo env template

## Tests
- go test ./pkg/i18n/... ./pkg/httperr
- go test .