### PR TITLE
feat: migrate thread errors to localized envelope

### DIFF
--- a/modules/thread/api.go
+++ b/modules/thread/api.go
@@ -3,7 +3,6 @@ package thread
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strings"
 	"time"
 
@@ -13,6 +12,10 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
 	"go.uber.org/zap"
 )
 
@@ -82,6 +85,70 @@ func (t *Thread) onMessages(messages []*config.MessageResp) {
 	}
 }
 
+func respondThreadError(c *wkhttp.Context, code codes.Code, details i18n.Details) {
+	httperr.ResponseErrorL(c, code, nil, details)
+}
+
+func respondThreadInvalidGroupNo(c *wkhttp.Context) {
+	respondThreadError(c, errcode.ErrThreadGroupNoInvalid, i18n.Details{"field": "group_no"})
+}
+
+func respondThreadInvalidShortID(c *wkhttp.Context) {
+	respondThreadError(c, errcode.ErrThreadShortIDInvalid, i18n.Details{"field": "short_id"})
+}
+
+func respondThreadInvalidName(c *wkhttp.Context) {
+	respondThreadError(c, errcode.ErrThreadNameInvalid, i18n.Details{
+		"field":      "name",
+		"max_length": 100,
+	})
+}
+
+func respondThreadInvalidRequest(c *wkhttp.Context, field string) {
+	details := i18n.Details{}
+	if field != "" {
+		details["field"] = field
+	}
+	respondThreadError(c, errcode.ErrThreadRequestInvalid, details)
+}
+
+func respondThreadSourceMessageInvalid(c *wkhttp.Context, details i18n.Details) {
+	respondThreadError(c, errcode.ErrThreadSourceMessageInvalid, details)
+}
+
+func respondThreadServiceError(c *wkhttp.Context, err error) {
+	respondThreadError(c, classifyThreadError(err), nil)
+}
+
+func classifyThreadError(err error) codes.Code {
+	if err == nil {
+		return errcode.ErrThreadStoreFailed
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "not a group member"):
+		return errcode.ErrThreadNotGroupMember
+	case strings.Contains(msg, "no permission"):
+		return errcode.ErrThreadPermissionDenied
+	case strings.Contains(msg, "creator cannot leave"):
+		return errcode.ErrThreadCreatorCannotLeave
+	case strings.Contains(msg, "thread status changed concurrently"):
+		return errcode.ErrThreadStatusChanged
+	case strings.Contains(msg, "thread is not active"):
+		return errcode.ErrThreadNotActive
+	case strings.Contains(msg, "thread has been deleted"), strings.Contains(msg, "already deleted"):
+		return errcode.ErrThreadDeleted
+	case strings.Contains(msg, "thread not found"), strings.Contains(msg, "not found or already deleted"):
+		return errcode.ErrThreadNotFound
+	case strings.Contains(msg, "name is required"):
+		return errcode.ErrThreadNameInvalid
+	case strings.Contains(msg, "invalid mute"), strings.Contains(msg, "mute must"):
+		return errcode.ErrThreadSettingInvalid
+	default:
+		return errcode.ErrThreadStoreFailed
+	}
+}
+
 // Route 注册路由
 func (t *Thread) Route(r *wkhttp.WKHttp) {
 	threads := r.Group("/v1/groups/:group_no/threads", t.ctx.AuthMiddleware(r))
@@ -120,7 +187,7 @@ func (t *Thread) createThread(c *wkhttp.Context) {
 
 	// 验证 groupNo 格式
 	if !IsValidGroupNo(groupNo) {
-		c.ResponseError(errors.New("invalid group_no format"))
+		respondThreadInvalidGroupNo(c)
 		return
 	}
 
@@ -131,22 +198,25 @@ func (t *Thread) createThread(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		t.Error("参数错误", zap.Error(err))
-		c.ResponseError(errors.New("invalid request: name is required"))
+		respondThreadInvalidName(c)
 		return
 	}
 
 	// 校验 source_message_payload
 	if len(req.SourceMessagePayload) > 0 {
 		if req.SourceMessageID == nil {
-			c.ResponseError(errors.New("source_message_payload requires source_message_id"))
+			respondThreadSourceMessageInvalid(c, i18n.Details{"field": "source_message_id"})
 			return
 		}
 		if len(req.SourceMessagePayload) > maxSourcePayloadBytes {
-			c.ResponseError(errors.New("source_message_payload too large"))
+			respondThreadSourceMessageInvalid(c, i18n.Details{
+				"field":    "source_message_payload",
+				"max_size": maxSourcePayloadBytes,
+			})
 			return
 		}
 		if !json.Valid(req.SourceMessagePayload) || string(req.SourceMessagePayload) == "null" {
-			c.ResponseError(errors.New("invalid source_message_payload"))
+			respondThreadSourceMessageInvalid(c, i18n.Details{"field": "source_message_payload"})
 			return
 		}
 	}
@@ -161,7 +231,7 @@ func (t *Thread) createThread(c *wkhttp.Context) {
 	})
 	if err != nil {
 		t.Error("创建子区失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("uid", loginUID))
-		c.ResponseError(err)
+		respondThreadServiceError(c, err)
 		return
 	}
 	c.Response(resp)
@@ -175,11 +245,11 @@ func (t *Thread) updateThread(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 
 	if !IsValidGroupNo(groupNo) {
-		c.ResponseError(errors.New("invalid group_no format"))
+		respondThreadInvalidGroupNo(c)
 		return
 	}
 	if !IsValidShortID(shortID) {
-		c.ResponseError(errors.New("invalid short_id format"))
+		respondThreadInvalidShortID(c)
 		return
 	}
 
@@ -188,14 +258,14 @@ func (t *Thread) updateThread(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		t.Error("参数错误", zap.Error(err))
-		c.ResponseError(errors.New("invalid request: name is required and must not exceed 100 characters"))
+		respondThreadInvalidName(c)
 		return
 	}
 
 	err := t.service.UpdateName(groupNo, shortID, loginUID, req.Name)
 	if err != nil {
 		t.Error("修改子区名称失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("shortID", shortID))
-		c.ResponseError(err)
+		respondThreadServiceError(c, err)
 		return
 	}
 	c.ResponseOK()
@@ -209,18 +279,18 @@ func (t *Thread) updateSetting(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 
 	if !IsValidGroupNo(groupNo) {
-		c.ResponseError(errors.New("invalid group_no format"))
+		respondThreadInvalidGroupNo(c)
 		return
 	}
 	if !IsValidShortID(shortID) {
-		c.ResponseError(errors.New("invalid short_id format"))
+		respondThreadInvalidShortID(c)
 		return
 	}
 
 	var req map[string]interface{}
 	if err := c.BindJSON(&req); err != nil {
 		t.Error("参数错误", zap.Error(err))
-		c.ResponseError(errors.New("invalid request"))
+		respondThreadInvalidRequest(c, "body")
 		return
 	}
 	if len(req) == 0 {
@@ -230,7 +300,7 @@ func (t *Thread) updateSetting(c *wkhttp.Context) {
 
 	if err := t.service.UpdateSetting(groupNo, shortID, loginUID, req); err != nil {
 		t.Error("更新子区设置失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("shortID", shortID))
-		c.ResponseError(err)
+		respondThreadServiceError(c, err)
 		return
 	}
 	c.ResponseOK()
@@ -244,7 +314,7 @@ func (t *Thread) listThreads(c *wkhttp.Context) {
 
 	// 验证 groupNo 格式
 	if !IsValidGroupNo(groupNo) {
-		c.ResponseError(errors.New("invalid group_no format"))
+		respondThreadInvalidGroupNo(c)
 		return
 	}
 
@@ -252,11 +322,11 @@ func (t *Thread) listThreads(c *wkhttp.Context) {
 	isMember, err := t.groupService.ExistMember(groupNo, loginUID)
 	if err != nil {
 		t.Error("检查群成员失败", zap.Error(err))
-		c.ResponseError(err)
+		respondThreadServiceError(c, err)
 		return
 	}
 	if !isMember {
-		c.ResponseError(errors.New("not a group member"))
+		respondThreadError(c, errcode.ErrThreadNotGroupMember, nil)
 		return
 	}
 
@@ -274,14 +344,14 @@ func (t *Thread) listThreads(c *wkhttp.Context) {
 	// all=活跃+已归档（不含 deleted）。前端"已归档"入口走 status=archived。
 	statuses, err := parseListThreadStatuses(c.Query("status"))
 	if err != nil {
-		c.ResponseError(err)
+		respondThreadError(c, errcode.ErrThreadStatusInvalid, i18n.Details{"field": "status"})
 		return
 	}
 
 	threads, total, err := t.service.GetThreads(groupNo, statuses, pageIndex, pageSize)
 	if err != nil {
 		t.Error("获取子区列表失败", zap.Error(err), zap.String("groupNo", groupNo))
-		c.ResponseError(err)
+		respondThreadServiceError(c, err)
 		return
 	}
 	if !hasPageParam {
@@ -320,11 +390,11 @@ func (t *Thread) getThread(c *wkhttp.Context) {
 
 	// 验证参数格式
 	if !IsValidGroupNo(groupNo) {
-		c.ResponseError(errors.New("invalid group_no format"))
+		respondThreadInvalidGroupNo(c)
 		return
 	}
 	if !IsValidShortID(shortID) {
-		c.ResponseError(errors.New("invalid short_id format"))
+		respondThreadInvalidShortID(c)
 		return
 	}
 
@@ -332,18 +402,18 @@ func (t *Thread) getThread(c *wkhttp.Context) {
 	isMember, err := t.groupService.ExistMember(groupNo, loginUID)
 	if err != nil {
 		t.Error("检查群成员失败", zap.Error(err))
-		c.ResponseError(err)
+		respondThreadServiceError(c, err)
 		return
 	}
 	if !isMember {
-		c.ResponseError(errors.New("not a group member"))
+		respondThreadError(c, errcode.ErrThreadNotGroupMember, nil)
 		return
 	}
 
 	thread, err := t.service.GetThread(groupNo, shortID, loginUID)
 	if err != nil {
 		t.Error("获取子区详情失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("shortID", shortID))
-		c.ResponseError(err)
+		respondThreadServiceError(c, err)
 		return
 	}
 	c.Response(thread)
@@ -358,18 +428,18 @@ func (t *Thread) archiveThread(c *wkhttp.Context) {
 
 	// 验证参数格式
 	if !IsValidGroupNo(groupNo) {
-		c.ResponseError(errors.New("invalid group_no format"))
+		respondThreadInvalidGroupNo(c)
 		return
 	}
 	if !IsValidShortID(shortID) {
-		c.ResponseError(errors.New("invalid short_id format"))
+		respondThreadInvalidShortID(c)
 		return
 	}
 
 	err := t.service.ArchiveThread(groupNo, shortID, loginUID)
 	if err != nil {
 		t.Error("归档子区失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("shortID", shortID))
-		c.ResponseError(err)
+		respondThreadServiceError(c, err)
 		return
 	}
 	c.ResponseOK()
@@ -384,18 +454,18 @@ func (t *Thread) unarchiveThread(c *wkhttp.Context) {
 
 	// 验证参数格式
 	if !IsValidGroupNo(groupNo) {
-		c.ResponseError(errors.New("invalid group_no format"))
+		respondThreadInvalidGroupNo(c)
 		return
 	}
 	if !IsValidShortID(shortID) {
-		c.ResponseError(errors.New("invalid short_id format"))
+		respondThreadInvalidShortID(c)
 		return
 	}
 
 	err := t.service.UnarchiveThread(groupNo, shortID, loginUID)
 	if err != nil {
 		t.Error("取消归档失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("shortID", shortID))
-		c.ResponseError(err)
+		respondThreadServiceError(c, err)
 		return
 	}
 	c.ResponseOK()
@@ -410,11 +480,11 @@ func (t *Thread) listMembers(c *wkhttp.Context) {
 
 	// 验证参数格式
 	if !IsValidGroupNo(groupNo) {
-		c.ResponseError(errors.New("invalid group_no format"))
+		respondThreadInvalidGroupNo(c)
 		return
 	}
 	if !IsValidShortID(shortID) {
-		c.ResponseError(errors.New("invalid short_id format"))
+		respondThreadInvalidShortID(c)
 		return
 	}
 
@@ -422,18 +492,18 @@ func (t *Thread) listMembers(c *wkhttp.Context) {
 	isMember, err := t.groupService.ExistMember(groupNo, loginUID)
 	if err != nil {
 		t.Error("检查群成员失败", zap.Error(err))
-		c.ResponseError(err)
+		respondThreadServiceError(c, err)
 		return
 	}
 	if !isMember {
-		c.ResponseError(errors.New("not a group member"))
+		respondThreadError(c, errcode.ErrThreadNotGroupMember, nil)
 		return
 	}
 
 	members, err := t.service.GetMembers(groupNo, shortID)
 	if err != nil {
 		t.Error("获取成员列表失败", zap.Error(err), zap.String("groupNo", groupNo))
-		c.ResponseError(err)
+		respondThreadServiceError(c, err)
 		return
 	}
 	c.Response(members)
@@ -448,18 +518,18 @@ func (t *Thread) joinThread(c *wkhttp.Context) {
 
 	// 验证参数格式
 	if !IsValidGroupNo(groupNo) {
-		c.ResponseError(errors.New("invalid group_no format"))
+		respondThreadInvalidGroupNo(c)
 		return
 	}
 	if !IsValidShortID(shortID) {
-		c.ResponseError(errors.New("invalid short_id format"))
+		respondThreadInvalidShortID(c)
 		return
 	}
 
 	err := t.service.JoinThread(groupNo, shortID, loginUID)
 	if err != nil {
 		t.Error("加入子区失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("shortID", shortID))
-		c.ResponseError(err)
+		respondThreadServiceError(c, err)
 		return
 	}
 	c.ResponseOK()
@@ -474,18 +544,18 @@ func (t *Thread) leaveThread(c *wkhttp.Context) {
 
 	// 验证参数格式
 	if !IsValidGroupNo(groupNo) {
-		c.ResponseError(errors.New("invalid group_no format"))
+		respondThreadInvalidGroupNo(c)
 		return
 	}
 	if !IsValidShortID(shortID) {
-		c.ResponseError(errors.New("invalid short_id format"))
+		respondThreadInvalidShortID(c)
 		return
 	}
 
 	err := t.service.LeaveThread(groupNo, shortID, loginUID)
 	if err != nil {
 		t.Error("离开子区失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("shortID", shortID))
-		c.ResponseError(err)
+		respondThreadServiceError(c, err)
 		return
 	}
 	c.ResponseOK()
@@ -500,18 +570,18 @@ func (t *Thread) deleteThread(c *wkhttp.Context) {
 
 	// 验证参数格式
 	if !IsValidGroupNo(groupNo) {
-		c.ResponseError(errors.New("invalid group_no format"))
+		respondThreadInvalidGroupNo(c)
 		return
 	}
 	if !IsValidShortID(shortID) {
-		c.ResponseError(errors.New("invalid short_id format"))
+		respondThreadInvalidShortID(c)
 		return
 	}
 
 	err := t.service.DeleteThread(groupNo, shortID, loginUID)
 	if err != nil {
 		t.Error("删除子区失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("shortID", shortID))
-		c.ResponseError(err)
+		respondThreadServiceError(c, err)
 		return
 	}
 	c.ResponseOK()
@@ -534,11 +604,11 @@ func (t *Thread) threadMdGet(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 
 	if !IsValidGroupNo(groupNo) {
-		c.ResponseError(errors.New("invalid group_no format"))
+		respondThreadInvalidGroupNo(c)
 		return
 	}
 	if !IsValidShortID(shortID) {
-		c.ResponseError(errors.New("invalid short_id format"))
+		respondThreadInvalidShortID(c)
 		return
 	}
 
@@ -546,18 +616,18 @@ func (t *Thread) threadMdGet(c *wkhttp.Context) {
 	isMember, err := t.groupService.ExistMember(groupNo, loginUID)
 	if err != nil {
 		t.Error("check group member failed", zap.Error(err))
-		c.ResponseError(errors.New("check group member failed"))
+		respondThreadError(c, errcode.ErrThreadStoreFailed, nil)
 		return
 	}
 	if !isMember {
-		c.ResponseError(errors.New("no permission"))
+		respondThreadError(c, errcode.ErrThreadPermissionDenied, nil)
 		return
 	}
 
 	result, err := t.service.GetThreadMd(groupNo, shortID)
 	if err != nil {
 		t.Error("query thread GROUP.md failed", zap.Error(err))
-		c.ResponseError(errors.New("query thread GROUP.md failed"))
+		respondThreadServiceError(c, err)
 		return
 	}
 	if result == nil {
@@ -584,11 +654,11 @@ func (t *Thread) threadMdUpdate(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 
 	if !IsValidGroupNo(groupNo) {
-		c.ResponseError(errors.New("invalid group_no format"))
+		respondThreadInvalidGroupNo(c)
 		return
 	}
 	if !IsValidShortID(shortID) {
-		c.ResponseError(errors.New("invalid short_id format"))
+		respondThreadInvalidShortID(c)
 		return
 	}
 
@@ -596,19 +666,22 @@ func (t *Thread) threadMdUpdate(c *wkhttp.Context) {
 		Content string `json:"content"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("invalid request body"))
+		respondThreadInvalidRequest(c, "body")
 		return
 	}
 
 	// 校验空内容
 	if strings.TrimSpace(req.Content) == "" {
-		c.ResponseError(errors.New("content must not be empty"))
+		respondThreadError(c, errcode.ErrThreadGroupMDContentEmpty, i18n.Details{"field": "content"})
 		return
 	}
 
 	maxSize := group.GetGroupMdMaxSize()
 	if len(req.Content) > maxSize {
-		c.ResponseError(fmt.Errorf("GROUP.md content exceeds max size %d bytes", maxSize))
+		respondThreadError(c, errcode.ErrThreadGroupMDContentTooLarge, i18n.Details{
+			"field":    "content",
+			"max_size": maxSize,
+		})
 		return
 	}
 
@@ -616,11 +689,11 @@ func (t *Thread) threadMdUpdate(c *wkhttp.Context) {
 	existThread, err := t.service.ExistThread(groupNo, shortID)
 	if err != nil {
 		t.Error("check thread existence failed", zap.Error(err))
-		c.ResponseError(errors.New("check thread existence failed"))
+		respondThreadError(c, errcode.ErrThreadStoreFailed, nil)
 		return
 	}
 	if !existThread {
-		c.ResponseError(errors.New("thread not found"))
+		respondThreadError(c, errcode.ErrThreadNotFound, nil)
 		return
 	}
 
@@ -628,11 +701,11 @@ func (t *Thread) threadMdUpdate(c *wkhttp.Context) {
 	canEdit, err := t.service.CanEditThreadMd(groupNo, shortID, loginUID)
 	if err != nil {
 		t.Error("check edit permission failed", zap.Error(err))
-		c.ResponseError(errors.New("check edit permission failed"))
+		respondThreadError(c, errcode.ErrThreadStoreFailed, nil)
 		return
 	}
 	if !canEdit {
-		c.ResponseError(errors.New("no permission to edit thread GROUP.md"))
+		respondThreadError(c, errcode.ErrThreadPermissionDenied, nil)
 		return
 	}
 
@@ -640,7 +713,7 @@ func (t *Thread) threadMdUpdate(c *wkhttp.Context) {
 	newVersion, err := t.service.UpdateThreadMd(groupNo, shortID, req.Content, loginUID)
 	if err != nil {
 		t.Error("update thread GROUP.md failed", zap.Error(err))
-		c.ResponseError(errors.New("update thread GROUP.md failed"))
+		respondThreadError(c, errcode.ErrThreadStoreFailed, nil)
 		return
 	}
 
@@ -666,11 +739,11 @@ func (t *Thread) threadMdDelete(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 
 	if !IsValidGroupNo(groupNo) {
-		c.ResponseError(errors.New("invalid group_no format"))
+		respondThreadInvalidGroupNo(c)
 		return
 	}
 	if !IsValidShortID(shortID) {
-		c.ResponseError(errors.New("invalid short_id format"))
+		respondThreadInvalidShortID(c)
 		return
 	}
 
@@ -678,11 +751,11 @@ func (t *Thread) threadMdDelete(c *wkhttp.Context) {
 	existThread, err := t.service.ExistThread(groupNo, shortID)
 	if err != nil {
 		t.Error("check thread existence failed", zap.Error(err))
-		c.ResponseError(errors.New("check thread existence failed"))
+		respondThreadError(c, errcode.ErrThreadStoreFailed, nil)
 		return
 	}
 	if !existThread {
-		c.ResponseError(errors.New("thread not found"))
+		respondThreadError(c, errcode.ErrThreadNotFound, nil)
 		return
 	}
 
@@ -690,11 +763,11 @@ func (t *Thread) threadMdDelete(c *wkhttp.Context) {
 	canEdit, err := t.service.CanEditThreadMd(groupNo, shortID, loginUID)
 	if err != nil {
 		t.Error("check edit permission failed", zap.Error(err))
-		c.ResponseError(errors.New("check edit permission failed"))
+		respondThreadError(c, errcode.ErrThreadStoreFailed, nil)
 		return
 	}
 	if !canEdit {
-		c.ResponseError(errors.New("no permission to delete thread GROUP.md"))
+		respondThreadError(c, errcode.ErrThreadPermissionDenied, nil)
 		return
 	}
 
@@ -702,7 +775,7 @@ func (t *Thread) threadMdDelete(c *wkhttp.Context) {
 	newVersion, err := t.service.DeleteThreadMd(groupNo, shortID, loginUID)
 	if err != nil {
 		t.Error("delete thread GROUP.md failed", zap.Error(err))
-		c.ResponseError(errors.New("delete thread GROUP.md failed"))
+		respondThreadError(c, errcode.ErrThreadStoreFailed, nil)
 		return
 	}
 
@@ -769,7 +842,7 @@ func (t *Thread) joinThreadSimple(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 
 	if !IsValidShortID(shortID) {
-		c.ResponseError(errors.New("invalid short_id format"))
+		respondThreadInvalidShortID(c)
 		return
 	}
 
@@ -777,18 +850,18 @@ func (t *Thread) joinThreadSimple(c *wkhttp.Context) {
 	thread, err := t.db.QueryByShortID(shortID)
 	if err != nil {
 		t.Error("查询子区失败", zap.Error(err))
-		c.ResponseError(errors.New("thread not found"))
+		respondThreadError(c, errcode.ErrThreadNotFound, nil)
 		return
 	}
 	if thread == nil {
-		c.ResponseError(errors.New("thread not found"))
+		respondThreadError(c, errcode.ErrThreadNotFound, nil)
 		return
 	}
 
 	err = t.service.JoinThread(thread.GroupNo, shortID, loginUID)
 	if err != nil {
 		t.Error("加入子区失败", zap.Error(err), zap.String("shortID", shortID))
-		c.ResponseError(err)
+		respondThreadServiceError(c, err)
 		return
 	}
 	c.ResponseOK()
@@ -801,20 +874,20 @@ func (t *Thread) leaveThreadSimple(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 
 	if !IsValidShortID(shortID) {
-		c.ResponseError(errors.New("invalid short_id format"))
+		respondThreadInvalidShortID(c)
 		return
 	}
 
 	thread, err := t.db.QueryByShortID(shortID)
 	if err != nil || thread == nil {
-		c.ResponseError(errors.New("thread not found"))
+		respondThreadError(c, errcode.ErrThreadNotFound, nil)
 		return
 	}
 
 	err = t.service.LeaveThread(thread.GroupNo, shortID, loginUID)
 	if err != nil {
 		t.Error("离开子区失败", zap.Error(err), zap.String("shortID", shortID))
-		c.ResponseError(err)
+		respondThreadServiceError(c, err)
 		return
 	}
 	c.ResponseOK()
@@ -827,30 +900,30 @@ func (t *Thread) getThreadSimple(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 
 	if !IsValidShortID(shortID) {
-		c.ResponseError(errors.New("invalid short_id format"))
+		respondThreadInvalidShortID(c)
 		return
 	}
 
 	thread, err := t.db.QueryByShortID(shortID)
 	if err != nil || thread == nil {
-		c.ResponseError(errors.New("thread not found"))
+		respondThreadError(c, errcode.ErrThreadNotFound, nil)
 		return
 	}
 
 	// 验证是父群成员
 	isMember, err := t.groupService.ExistMember(thread.GroupNo, loginUID)
 	if err != nil {
-		c.ResponseError(err)
+		respondThreadServiceError(c, err)
 		return
 	}
 	if !isMember {
-		c.ResponseError(errors.New("not a group member"))
+		respondThreadError(c, errcode.ErrThreadNotGroupMember, nil)
 		return
 	}
 
 	resp, err := t.service.GetThread(thread.GroupNo, shortID, loginUID)
 	if err != nil {
-		c.ResponseError(err)
+		respondThreadServiceError(c, err)
 		return
 	}
 	c.Response(resp)

--- a/modules/thread/api.go
+++ b/modules/thread/api.go
@@ -136,10 +136,14 @@ func classifyThreadError(err error) codes.Code {
 		return errcode.ErrThreadStatusChanged
 	case strings.Contains(msg, "thread is not active"):
 		return errcode.ErrThreadNotActive
-	case strings.Contains(msg, "thread has been deleted"), strings.Contains(msg, "already deleted"):
-		return errcode.ErrThreadDeleted
-	case strings.Contains(msg, "thread not found"), strings.Contains(msg, "not found or already deleted"):
+	// Check "not found" before "deleted": the DB layer returns the ambiguous
+	// "thread not found or already deleted" when affected=0, which we map to
+	// 404 NotFound (the more accurate default for clients hitting unknown IDs).
+	// The explicit service-layer "thread has been deleted" still maps to 410.
+	case strings.Contains(msg, "thread not found"):
 		return errcode.ErrThreadNotFound
+	case strings.Contains(msg, "thread has been deleted"):
+		return errcode.ErrThreadDeleted
 	case strings.Contains(msg, "name is required"):
 		return errcode.ErrThreadNameInvalid
 	case strings.Contains(msg, "invalid mute"), strings.Contains(msg, "mute must"):

--- a/modules/thread/api_i18n_test.go
+++ b/modules/thread/api_i18n_test.go
@@ -1,0 +1,61 @@
+package thread
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+func TestThreadAPINoLegacyResponseError(t *testing.T) {
+	data, err := os.ReadFile("api.go")
+	if err != nil {
+		t.Fatalf("read api.go: %v", err)
+	}
+	if strings.Contains(string(data), ".ResponseError(") {
+		t.Fatal("modules/thread/api.go must use httperr.ResponseErrorL instead of legacy ResponseError")
+	}
+}
+
+func TestThreadAPIInvalidGroupNoUsesLocalizedEnvelope(t *testing.T) {
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	th := &Thread{}
+	r.POST("/v1/groups/:group_no/threads", th.createThread)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/groups/not-a-group/threads", strings.NewReader(`{"name":"topic"}`))
+	req.Header.Set("Accept-Language", "zh-CN")
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("HTTP status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Language"); got != "zh-CN" {
+		t.Fatalf("Content-Language = %q, want zh-CN", got)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	errObj, ok := body["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("localized error object missing: %#v", body)
+	}
+	if got := errObj["code"]; got != errcode.ErrThreadGroupNoInvalid.ID {
+		t.Fatalf("error.code = %q, want %q", got, errcode.ErrThreadGroupNoInvalid.ID)
+	}
+	if got := errObj["message"]; got != "群编号无效。" {
+		t.Fatalf("error.message = %q", got)
+	}
+	if got := body["msg"]; got != errObj["message"] {
+		t.Fatalf("legacy msg = %q, want %q", got, errObj["message"])
+	}
+}

--- a/modules/thread/api_i18n_test.go
+++ b/modules/thread/api_i18n_test.go
@@ -2,6 +2,7 @@ package thread
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
 )
 
 func TestThreadAPINoLegacyResponseError(t *testing.T) {
@@ -20,6 +22,50 @@ func TestThreadAPINoLegacyResponseError(t *testing.T) {
 	}
 	if strings.Contains(string(data), ".ResponseError(") {
 		t.Fatal("modules/thread/api.go must use httperr.ResponseErrorL instead of legacy ResponseError")
+	}
+}
+
+// TestClassifyThreadError pins the current substring-based contract between
+// service.go / db.go error strings and the corresponding errcode. If a service
+// error message changes, this test should fail loudly rather than letting the
+// classifier silently fall through to ErrThreadStoreFailed (500).
+func TestClassifyThreadError(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want codes.Code
+	}{
+		{"nil", "", errcode.ErrThreadStoreFailed},
+		{"not a group member", "not a group member", errcode.ErrThreadNotGroupMember},
+		{"no permission", "no permission to edit", errcode.ErrThreadPermissionDenied},
+		{"creator cannot leave", "creator cannot leave thread", errcode.ErrThreadCreatorCannotLeave},
+		{"status changed concurrently", "thread status changed concurrently", errcode.ErrThreadStatusChanged},
+		{"thread is not active", "thread is not active", errcode.ErrThreadNotActive},
+		{"thread has been deleted", "thread has been deleted", errcode.ErrThreadDeleted},
+		{"thread not found", "thread not found", errcode.ErrThreadNotFound},
+		// DB layer ambiguous string maps to 404 NotFound (the more accurate
+		// default for clients hitting an unknown shortID).
+		{"db ambiguous not found or already deleted", "thread not found or already deleted", errcode.ErrThreadNotFound},
+		{"name required", "name is required and must not exceed 100 characters", errcode.ErrThreadNameInvalid},
+		{"invalid mute value", "invalid mute value type", errcode.ErrThreadSettingInvalid},
+		{"mute must", "mute must be 0 or 1", errcode.ErrThreadSettingInvalid},
+		// Mixed case input must still classify — classifier lowercases first.
+		{"mixed case still matches", "Thread Not Found", errcode.ErrThreadNotFound},
+		// Anything unrecognised falls through to a 500 store failure.
+		{"unknown driver error", "driver: bad connection", errcode.ErrThreadStoreFailed},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+			if tc.in != "" {
+				err = errors.New(tc.in)
+			}
+			got := classifyThreadError(err)
+			if got.ID != tc.want.ID {
+				t.Fatalf("classifyThreadError(%q) = %s, want %s", tc.in, got.ID, tc.want.ID)
+			}
+		})
 	}
 }
 

--- a/pkg/errcode/server.go
+++ b/pkg/errcode/server.go
@@ -38,6 +38,12 @@ var (
 		DefaultMessage: "Invalid source message payload.",
 		SafeDetailKeys: []string{"field", "max_size"},
 	})
+	ErrThreadStatusInvalid = register(codes.Code{
+		ID:             "err.server.thread.status_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid thread status.",
+		SafeDetailKeys: []string{"field"},
+	})
 	ErrThreadNotGroupMember = register(codes.Code{
 		ID:             "err.server.thread.not_group_member",
 		HTTPStatus:     http.StatusForbidden,
@@ -52,6 +58,26 @@ var (
 		ID:             "err.server.thread.not_found",
 		HTTPStatus:     http.StatusNotFound,
 		DefaultMessage: "Thread not found.",
+	})
+	ErrThreadDeleted = register(codes.Code{
+		ID:             "err.server.thread.deleted",
+		HTTPStatus:     http.StatusGone,
+		DefaultMessage: "Thread has been deleted.",
+	})
+	ErrThreadNotActive = register(codes.Code{
+		ID:             "err.server.thread.not_active",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "Thread is not active.",
+	})
+	ErrThreadStatusChanged = register(codes.Code{
+		ID:             "err.server.thread.status_changed",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "Thread status changed concurrently.",
+	})
+	ErrThreadCreatorCannotLeave = register(codes.Code{
+		ID:             "err.server.thread.creator_cannot_leave",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Thread creator cannot leave the thread.",
 	})
 	ErrThreadGroupMDNotFound = register(codes.Code{
 		ID:             "err.server.thread.group_md_not_found",
@@ -69,6 +95,12 @@ var (
 		HTTPStatus:     http.StatusBadRequest,
 		DefaultMessage: "GROUP.md content exceeds the maximum size.",
 		SafeDetailKeys: []string{"field", "max_size"},
+	})
+	ErrThreadSettingInvalid = register(codes.Code{
+		ID:             "err.server.thread.setting_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid thread setting.",
+		SafeDetailKeys: []string{"field"},
 	})
 	ErrThreadStoreFailed = register(codes.Code{
 		ID:             "err.server.thread.store_failed",

--- a/pkg/errcode/server_test.go
+++ b/pkg/errcode/server_test.go
@@ -1,0 +1,46 @@
+package errcode
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+func TestThreadCodesHaveZhCNTranslations(t *testing.T) {
+	localizer := i18n.NewLocalizer(i18n.DefaultLanguage)
+	for _, code := range []struct {
+		id     string
+		source string
+		zhCN   string
+	}{
+		{ErrThreadGroupNoInvalid.ID, ErrThreadGroupNoInvalid.DefaultMessage, "群编号无效。"},
+		{ErrThreadShortIDInvalid.ID, ErrThreadShortIDInvalid.DefaultMessage, "子区短 ID 无效。"},
+		{ErrThreadRequestInvalid.ID, ErrThreadRequestInvalid.DefaultMessage, "请求无效。"},
+		{ErrThreadNameInvalid.ID, ErrThreadNameInvalid.DefaultMessage, "子区名称不能为空，且不能超过 100 个字符。"},
+		{ErrThreadSourceMessageInvalid.ID, ErrThreadSourceMessageInvalid.DefaultMessage, "来源消息内容无效。"},
+		{ErrThreadStatusInvalid.ID, ErrThreadStatusInvalid.DefaultMessage, "子区状态无效。"},
+		{ErrThreadNotGroupMember.ID, ErrThreadNotGroupMember.DefaultMessage, "你不是群成员。"},
+		{ErrThreadPermissionDenied.ID, ErrThreadPermissionDenied.DefaultMessage, "无权执行此子区操作。"},
+		{ErrThreadNotFound.ID, ErrThreadNotFound.DefaultMessage, "子区不存在。"},
+		{ErrThreadDeleted.ID, ErrThreadDeleted.DefaultMessage, "子区已被删除。"},
+		{ErrThreadNotActive.ID, ErrThreadNotActive.DefaultMessage, "子区不是活跃状态。"},
+		{ErrThreadStatusChanged.ID, ErrThreadStatusChanged.DefaultMessage, "子区状态已变化，请重试。"},
+		{ErrThreadCreatorCannotLeave.ID, ErrThreadCreatorCannotLeave.DefaultMessage, "子区创建者不能退出子区。"},
+		{ErrThreadGroupMDNotFound.ID, ErrThreadGroupMDNotFound.DefaultMessage, "子区 GROUP.md 不存在。"},
+		{ErrThreadGroupMDContentEmpty.ID, ErrThreadGroupMDContentEmpty.DefaultMessage, "GROUP.md 内容不能为空。"},
+		{ErrThreadGroupMDContentTooLarge.ID, ErrThreadGroupMDContentTooLarge.DefaultMessage, "GROUP.md 内容超过大小限制。"},
+		{ErrThreadSettingInvalid.ID, ErrThreadSettingInvalid.DefaultMessage, "子区设置无效。"},
+		{ErrThreadStoreFailed.ID, ErrThreadStoreFailed.DefaultMessage, "子区存储操作失败。"},
+	} {
+		t.Run(code.id, func(t *testing.T) {
+			got := localizer.Translate(code.id, "zh-CN", nil)
+			if got != code.zhCN {
+				t.Fatalf("zh-CN translation = %q, want %q", got, code.zhCN)
+			}
+			if got == code.id || strings.EqualFold(got, code.source) {
+				t.Fatalf("zh-CN translation for %s fell back to %q", code.id, got)
+			}
+		})
+	}
+}

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -38,3 +38,57 @@ other = "资源不存在。"
 
 ["err.shared.internal"]
 other = "服务器内部错误。"
+
+["err.server.thread.group_no_invalid"]
+other = "群编号无效。"
+
+["err.server.thread.short_id_invalid"]
+other = "子区短 ID 无效。"
+
+["err.server.thread.request_invalid"]
+other = "请求无效。"
+
+["err.server.thread.name_invalid"]
+other = "子区名称不能为空，且不能超过 100 个字符。"
+
+["err.server.thread.source_message_invalid"]
+other = "来源消息内容无效。"
+
+["err.server.thread.status_invalid"]
+other = "子区状态无效。"
+
+["err.server.thread.not_group_member"]
+other = "你不是群成员。"
+
+["err.server.thread.permission_denied"]
+other = "无权执行此子区操作。"
+
+["err.server.thread.not_found"]
+other = "子区不存在。"
+
+["err.server.thread.deleted"]
+other = "子区已被删除。"
+
+["err.server.thread.not_active"]
+other = "子区不是活跃状态。"
+
+["err.server.thread.status_changed"]
+other = "子区状态已变化，请重试。"
+
+["err.server.thread.creator_cannot_leave"]
+other = "子区创建者不能退出子区。"
+
+["err.server.thread.group_md_not_found"]
+other = "子区 GROUP.md 不存在。"
+
+["err.server.thread.group_md_content_empty"]
+other = "GROUP.md 内容不能为空。"
+
+["err.server.thread.group_md_content_too_large"]
+other = "GROUP.md 内容超过大小限制。"
+
+["err.server.thread.setting_invalid"]
+other = "子区设置无效。"
+
+["err.server.thread.store_failed"]
+other = "子区存储操作失败。"


### PR DESCRIPTION
## Summary
- migrate modules/thread API errors from legacy ResponseError to httperr.ResponseErrorL
- add missing err.server.thread.* codes and zh-CN runtime translations
- add thread i18n guard/handler coverage and errcode translation coverage

## Tests
- go test ./modules/thread -run 'TestThreadAPI|TestParseListThreadStatuses' -count=1
- go test ./pkg/errcode ./pkg/i18n/... ./pkg/httperr
- go test ./pkg/...
- go test .

## Note
- Full go test ./modules/thread is still blocked locally by the existing test DB migration state: unknown migration in database (20210926000001_robot_legacy01.sql).