### PR TITLE
feat: use OCTO trusted header envs

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -94,7 +94,10 @@ Chinese error messages during the i18n rollout. Supported values are
 
 Trusted service-to-service language propagation is configured with
 `OCTO_TRUSTED_LANG_HEADER_CIDRS`, a comma-separated CIDR list of direct
-peer addresses allowed to supply `X-Octo-Lang`.
+peer addresses allowed to supply `X-Octo-Lang`. If OCTO runs behind
+trusted reverse proxies, also set `OCTO_TRUSTED_PROXY_CIDRS`; the server
+will peel `X-Forwarded-For` from right to left through those proxies
+before applying the trusted language CIDR check.
 
 ### Run
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -94,10 +94,11 @@ Chinese error messages during the i18n rollout. Supported values are
 
 Trusted service-to-service language propagation is configured with
 `OCTO_TRUSTED_LANG_HEADER_CIDRS`, a comma-separated CIDR list of direct
-peer addresses allowed to supply `X-Octo-Lang`. If OCTO runs behind
-trusted reverse proxies, also set `OCTO_TRUSTED_PROXY_CIDRS`; the server
-will peel `X-Forwarded-For` from right to left through those proxies
-before applying the trusted language CIDR check.
+peer addresses allowed to supply `X-Octo-Lang`. When unset or empty, no
+peer is trusted to set `X-Octo-Lang` and the header is ignored. If OCTO
+runs behind trusted reverse proxies, also set `OCTO_TRUSTED_PROXY_CIDRS`;
+the server will peel `X-Forwarded-For` from right to left through those
+proxies before applying the trusted language CIDR check.
 
 ### Run
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -92,6 +92,10 @@ that do not send `Accept-Language`, `lang`, or `i18n_lang` keep receiving
 Chinese error messages during the i18n rollout. Supported values are
 `zh-CN` and `en-US`; invalid values fail startup.
 
+Trusted service-to-service language propagation is configured with
+`OCTO_TRUSTED_LANG_HEADER_CIDRS`, a comma-separated CIDR list of direct
+peer addresses allowed to supply `X-Octo-Lang`.
+
 ### Run
 
 `octo-server` parses the `--config` flag with the stdlib `flag`

--- a/main.go
+++ b/main.go
@@ -110,9 +110,14 @@ func runAPI(ctx *config.Context) {
 	if err != nil {
 		panic(err)
 	}
+	trustedProxyCIDRs, err := octoi18n.TrustedProxyCIDRsFromEnv()
+	if err != nil {
+		panic(err)
+	}
 	route.UseGin(octoi18n.EarlyMiddleware(octoi18n.MiddlewareOptions{
 		DefaultLanguage:        defaultLanguage,
 		TrustedLangHeaderCIDRs: trustedLangCIDRs,
+		TrustedProxyCIDRs:      trustedProxyCIDRs,
 	}))
 	route.UseGin(ctx.Tracer().GinMiddle()) // 需要放在 api.Route(s.GetRoute())的前面
 	// HTTP 入口指标(per-route latency / status / in-flight)。

--- a/main.go
+++ b/main.go
@@ -106,9 +106,9 @@ func runAPI(ctx *config.Context) {
 	// 替换web下的配置文件
 	replaceWebConfig(ctx.GetConfig())
 	// 初始化api
-	trustedLangCIDRs, err := octoi18n.ParseCIDRList(os.Getenv("DM_TRUSTED_LANG_HEADER_CIDRS"))
+	trustedLangCIDRs, err := octoi18n.TrustedLangHeaderCIDRsFromEnv()
 	if err != nil {
-		panic(fmt.Errorf("parse DM_TRUSTED_LANG_HEADER_CIDRS: %w", err))
+		panic(err)
 	}
 	route.UseGin(octoi18n.EarlyMiddleware(octoi18n.MiddlewareOptions{
 		DefaultLanguage:        defaultLanguage,

--- a/pkg/i18n/config.go
+++ b/pkg/i18n/config.go
@@ -2,6 +2,7 @@ package i18n
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"strings"
 )
@@ -10,6 +11,10 @@ const (
 	// EnvDefaultLanguage controls the runtime fallback language for requests
 	// that carry no explicit language signal.
 	EnvDefaultLanguage = "OCTO_DEFAULT_LANGUAGE"
+
+	// EnvTrustedLangHeaderCIDRs controls which direct peer CIDRs may supply
+	// X-Octo-Lang for service-to-service calls.
+	EnvTrustedLangHeaderCIDRs = "OCTO_TRUSTED_LANG_HEADER_CIDRS"
 
 	// DefaultLanguage preserves the legacy deployment behavior for clients that
 	// do not send Accept-Language yet.
@@ -21,6 +26,15 @@ const (
 // rollout misconfiguration fails during startup instead of surfacing per request.
 func DefaultLanguageFromEnv() (string, error) {
 	return ResolveDefaultLanguage(os.Getenv(EnvDefaultLanguage))
+}
+
+// TrustedLangHeaderCIDRsFromEnv parses OCTO_TRUSTED_LANG_HEADER_CIDRS.
+func TrustedLangHeaderCIDRsFromEnv() ([]*net.IPNet, error) {
+	cidrs, err := ParseCIDRList(os.Getenv(EnvTrustedLangHeaderCIDRs))
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", EnvTrustedLangHeaderCIDRs, err)
+	}
+	return cidrs, nil
 }
 
 // ResolveDefaultLanguage normalizes the configured default language.

--- a/pkg/i18n/config.go
+++ b/pkg/i18n/config.go
@@ -16,6 +16,10 @@ const (
 	// X-Octo-Lang for service-to-service calls.
 	EnvTrustedLangHeaderCIDRs = "OCTO_TRUSTED_LANG_HEADER_CIDRS"
 
+	// EnvTrustedProxyCIDRs controls which direct peer CIDRs are trusted
+	// reverse proxies for X-Forwarded-For peeling.
+	EnvTrustedProxyCIDRs = "OCTO_TRUSTED_PROXY_CIDRS"
+
 	// DefaultLanguage preserves the legacy deployment behavior for clients that
 	// do not send Accept-Language yet.
 	DefaultLanguage = "zh-CN"
@@ -33,6 +37,15 @@ func TrustedLangHeaderCIDRsFromEnv() ([]*net.IPNet, error) {
 	cidrs, err := ParseCIDRList(os.Getenv(EnvTrustedLangHeaderCIDRs))
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", EnvTrustedLangHeaderCIDRs, err)
+	}
+	return cidrs, nil
+}
+
+// TrustedProxyCIDRsFromEnv parses OCTO_TRUSTED_PROXY_CIDRS.
+func TrustedProxyCIDRsFromEnv() ([]*net.IPNet, error) {
+	cidrs, err := ParseCIDRList(os.Getenv(EnvTrustedProxyCIDRs))
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", EnvTrustedProxyCIDRs, err)
 	}
 	return cidrs, nil
 }

--- a/pkg/i18n/config_test.go
+++ b/pkg/i18n/config_test.go
@@ -71,7 +71,10 @@ func TestTrustedLangHeaderCIDRsFromEnvPrefersOctoName(t *testing.T) {
 
 func TestTrustedLangHeaderCIDRsFromEnvIgnoresLegacyName(t *testing.T) {
 	t.Setenv(EnvTrustedLangHeaderCIDRs, "")
-	t.Setenv("DM_TRUSTED_LANG_HEADER_CIDRS", "192.168.0.0/16")
+	// Set legacy env to an INVALID CIDR: if the helper still consulted it,
+	// ParseCIDRList would surface a parse error. A nil error therefore proves
+	// the legacy var is never read.
+	t.Setenv("DM_TRUSTED_LANG_HEADER_CIDRS", "not-cidr")
 
 	got, err := TrustedLangHeaderCIDRsFromEnv()
 	if err != nil {

--- a/pkg/i18n/config_test.go
+++ b/pkg/i18n/config_test.go
@@ -94,6 +94,32 @@ func TestTrustedLangHeaderCIDRsFromEnvReportsOctoName(t *testing.T) {
 	}
 }
 
+func TestTrustedProxyCIDRsFromEnv(t *testing.T) {
+	t.Setenv(EnvTrustedProxyCIDRs, "172.16.0.0/12")
+	t.Setenv("DM_TRUSTED_PROXY_CIDRS", "192.168.0.0/16")
+
+	got, err := TrustedProxyCIDRsFromEnv()
+	if err != nil {
+		t.Fatalf("TrustedProxyCIDRsFromEnv returned error: %v", err)
+	}
+	if len(got) != 1 || got[0].String() != "172.16.0.0/12" {
+		t.Fatalf("TrustedProxyCIDRsFromEnv = %v, want OCTO proxy CIDR", got)
+	}
+}
+
+func TestTrustedProxyCIDRsFromEnvIgnoresLegacyName(t *testing.T) {
+	t.Setenv(EnvTrustedProxyCIDRs, "")
+	t.Setenv("DM_TRUSTED_PROXY_CIDRS", "192.168.0.0/16")
+
+	got, err := TrustedProxyCIDRsFromEnv()
+	if err != nil {
+		t.Fatalf("TrustedProxyCIDRsFromEnv returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("TrustedProxyCIDRsFromEnv = %v, want empty list", got)
+	}
+}
+
 func TestValidateRuntimeLocales(t *testing.T) {
 	resetBundle()
 	t.Cleanup(resetBundle)

--- a/pkg/i18n/config_test.go
+++ b/pkg/i18n/config_test.go
@@ -1,6 +1,9 @@
 package i18n
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestResolveDefaultLanguage(t *testing.T) {
 	tests := []struct {
@@ -51,6 +54,43 @@ func TestDefaultLanguageFromEnv(t *testing.T) {
 	}
 	if got != "en-US" {
 		t.Fatalf("DefaultLanguageFromEnv = %q, want en-US", got)
+	}
+}
+
+func TestTrustedLangHeaderCIDRsFromEnvPrefersOctoName(t *testing.T) {
+	t.Setenv(EnvTrustedLangHeaderCIDRs, "10.0.0.0/8")
+
+	got, err := TrustedLangHeaderCIDRsFromEnv()
+	if err != nil {
+		t.Fatalf("TrustedLangHeaderCIDRsFromEnv returned error: %v", err)
+	}
+	if len(got) != 1 || got[0].String() != "10.0.0.0/8" {
+		t.Fatalf("TrustedLangHeaderCIDRsFromEnv = %v, want OCTO env CIDR", got)
+	}
+}
+
+func TestTrustedLangHeaderCIDRsFromEnvIgnoresLegacyName(t *testing.T) {
+	t.Setenv(EnvTrustedLangHeaderCIDRs, "")
+	t.Setenv("DM_TRUSTED_LANG_HEADER_CIDRS", "192.168.0.0/16")
+
+	got, err := TrustedLangHeaderCIDRsFromEnv()
+	if err != nil {
+		t.Fatalf("TrustedLangHeaderCIDRsFromEnv returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("TrustedLangHeaderCIDRsFromEnv = %v, want empty list", got)
+	}
+}
+
+func TestTrustedLangHeaderCIDRsFromEnvReportsOctoName(t *testing.T) {
+	t.Setenv(EnvTrustedLangHeaderCIDRs, "not-cidr")
+
+	_, err := TrustedLangHeaderCIDRsFromEnv()
+	if err == nil {
+		t.Fatal("TrustedLangHeaderCIDRsFromEnv returned nil error")
+	}
+	if want := EnvTrustedLangHeaderCIDRs; !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %q, want env name %q", err.Error(), want)
 	}
 }
 

--- a/pkg/i18n/lang.go
+++ b/pkg/i18n/lang.go
@@ -42,6 +42,7 @@ var (
 type LanguageNegotiationOptions struct {
 	DefaultLanguage        string
 	TrustedLangHeaderCIDRs []*net.IPNet
+	TrustedProxyCIDRs      []*net.IPNet
 	UserLanguage           string
 }
 
@@ -49,15 +50,16 @@ type LanguageNegotiationOptions struct {
 // trusted X-Octo-Lang > URL lang > cookie i18n_lang > user.language >
 // Accept-Language > default language。
 //
-// X-Octo-Lang 只根据 TCP RemoteAddr 命中 TrustedLangHeaderCIDRs 时采纳；
-// 本函数不读取 X-Forwarded-For，避免链尾伪造影响信任判定。
+// X-Octo-Lang 默认根据 TCP RemoteAddr 命中 TrustedLangHeaderCIDRs 时采纳；
+// 配置 TrustedProxyCIDRs 时，先对 X-Forwarded-For + RemoteAddr 从右向左
+// 剥离可信反代，再用剥离后的调用方 IP 判定 TrustedLangHeaderCIDRs。
 func NegotiateLanguage(r *http.Request, opts LanguageNegotiationOptions) LanguageDecision {
 	defaultLang := normalizeDefaultLanguage(opts.DefaultLanguage)
 	if r == nil {
 		return LanguageDecision{Language: defaultLang, Source: LanguageSourceDefault}
 	}
 
-	if IsTrustedLangHeaderRequest(r, opts.TrustedLangHeaderCIDRs) {
+	if IsTrustedLangHeaderRequest(r, opts.TrustedLangHeaderCIDRs, opts.TrustedProxyCIDRs) {
 		if lang, ok := MatchSupportedLanguage(r.Header.Get(HeaderOctoLang)); ok {
 			return LanguageDecision{Language: lang, Source: LanguageSourceTrustedHeader}
 		}
@@ -114,13 +116,65 @@ func ParseCIDRList(value string) ([]*net.IPNet, error) {
 	return out, nil
 }
 
-// IsTrustedLangHeaderRequest 判断请求的 TCP RemoteAddr 是否命中受信语言头 CIDR。
-func IsTrustedLangHeaderRequest(r *http.Request, cidrs []*net.IPNet) bool {
+// IsTrustedLangHeaderRequest 判断请求调用方 IP 是否命中受信语言头 CIDR。
+func IsTrustedLangHeaderRequest(r *http.Request, cidrs []*net.IPNet, trustedProxyCIDRs ...[]*net.IPNet) bool {
 	if r == nil || len(cidrs) == 0 {
 		return false
 	}
-	ip, ok := remoteAddrIP(r.RemoteAddr)
+	var proxyCIDRs []*net.IPNet
+	if len(trustedProxyCIDRs) > 0 {
+		proxyCIDRs = trustedProxyCIDRs[0]
+	}
+	ip, ok := trustedCallerIP(r, proxyCIDRs)
 	if !ok {
+		return false
+	}
+	for _, cidr := range cidrs {
+		if cidr != nil && cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func trustedCallerIP(r *http.Request, trustedProxyCIDRs []*net.IPNet) (net.IP, bool) {
+	remoteIP, ok := remoteAddrIP(r.RemoteAddr)
+	if !ok {
+		return nil, false
+	}
+	if len(trustedProxyCIDRs) == 0 || !cidrListContains(trustedProxyCIDRs, remoteIP) {
+		return remoteIP, true
+	}
+
+	chain := forwardedForIPs(r.Header.Get("X-Forwarded-For"))
+	chain = append(chain, remoteIP)
+	for len(chain) > 1 && cidrListContains(trustedProxyCIDRs, chain[len(chain)-1]) {
+		chain = chain[:len(chain)-1]
+	}
+	if len(chain) == 0 {
+		return remoteIP, true
+	}
+	return chain[len(chain)-1], true
+}
+
+func forwardedForIPs(raw string) []net.IP {
+	parts := strings.Split(raw, ",")
+	out := make([]net.IP, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		ip := net.ParseIP(part)
+		if ip != nil {
+			out = append(out, ip)
+		}
+	}
+	return out
+}
+
+func cidrListContains(cidrs []*net.IPNet, ip net.IP) bool {
+	if ip == nil {
 		return false
 	}
 	for _, cidr := range cidrs {

--- a/pkg/i18n/lang_test.go
+++ b/pkg/i18n/lang_test.go
@@ -48,6 +48,58 @@ func TestNegotiateLanguageIgnoresUntrustedXOctoLang(t *testing.T) {
 	}
 }
 
+func TestNegotiateLanguageTrustsXOctoLangThroughTrustedProxy(t *testing.T) {
+	langCIDRs, err := ParseCIDRList("10.0.0.0/8")
+	if err != nil {
+		t.Fatalf("ParseCIDRList lang err = %v", err)
+	}
+	proxyCIDRs, err := ParseCIDRList("172.16.0.0/12")
+	if err != nil {
+		t.Fatalf("ParseCIDRList proxy err = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "172.16.1.10:4321"
+	req.Header.Set("X-Forwarded-For", "198.51.100.9, 10.1.2.3")
+	req.Header.Set(HeaderOctoLang, "zh-CN")
+	req.Header.Set("Accept-Language", "en-US")
+
+	got := NegotiateLanguage(req, LanguageNegotiationOptions{
+		DefaultLanguage:        "en-US",
+		TrustedLangHeaderCIDRs: langCIDRs,
+		TrustedProxyCIDRs:      proxyCIDRs,
+	})
+	if got.Language != "zh-CN" || got.Source != LanguageSourceTrustedHeader {
+		t.Fatalf("NegotiateLanguage = %#v, want trusted proxy zh-CN", got)
+	}
+}
+
+func TestNegotiateLanguageIgnoresSpoofedXFFBeforeUntrustedClient(t *testing.T) {
+	langCIDRs, err := ParseCIDRList("10.0.0.0/8")
+	if err != nil {
+		t.Fatalf("ParseCIDRList lang err = %v", err)
+	}
+	proxyCIDRs, err := ParseCIDRList("172.16.0.0/12")
+	if err != nil {
+		t.Fatalf("ParseCIDRList proxy err = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "172.16.1.10:4321"
+	req.Header.Set("X-Forwarded-For", "10.1.2.3, 198.51.100.9")
+	req.Header.Set(HeaderOctoLang, "zh-CN")
+	req.Header.Set("Accept-Language", "en-US")
+
+	got := NegotiateLanguage(req, LanguageNegotiationOptions{
+		DefaultLanguage:        "zh-CN",
+		TrustedLangHeaderCIDRs: langCIDRs,
+		TrustedProxyCIDRs:      proxyCIDRs,
+	})
+	if got.Language != "en-US" || got.Source != LanguageSourceAccept {
+		t.Fatalf("NegotiateLanguage = %#v, want Accept-Language en-US; spoofed XFF must not be trusted", got)
+	}
+}
+
 func TestNegotiateLanguageSourceOrder(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pkg/i18n/middleware.go
+++ b/pkg/i18n/middleware.go
@@ -10,6 +10,7 @@ import (
 type MiddlewareOptions struct {
 	DefaultLanguage        string
 	TrustedLangHeaderCIDRs []*net.IPNet
+	TrustedProxyCIDRs      []*net.IPNet
 }
 
 // EarlyMiddleware negotiates language before auth and stores the decision in
@@ -20,6 +21,7 @@ func EarlyMiddleware(opts MiddlewareOptions) gin.HandlerFunc {
 		decision := NegotiateLanguage(c.Request, LanguageNegotiationOptions{
 			DefaultLanguage:        opts.DefaultLanguage,
 			TrustedLangHeaderCIDRs: opts.TrustedLangHeaderCIDRs,
+			TrustedProxyCIDRs:      opts.TrustedProxyCIDRs,
 		})
 		c.Request = c.Request.WithContext(WithLanguage(c.Request.Context(), decision))
 		c.Writer.Header().Set("Content-Language", decision.Language)


### PR DESCRIPTION
## Summary
- rename trusted language header env to OCTO_TRUSTED_LANG_HEADER_CIDRS
- add OCTO_TRUSTED_PROXY_CIDRS for trusted reverse proxy X-Forwarded-For peeling
- remove DM_TRUSTED_* runtime fallback; old env names are intentionally ignored
- document trusted language/proxy propagation envs in Quickstart

## Tests
- go test ./pkg/i18n -run 'TestTrusted.*CIDRsFromEnv|TestNegotiateLanguageTrustsXOctoLangThroughTrustedProxy|TestNegotiateLanguageIgnoresSpoofedXFFBeforeUntrustedClient|TestNegotiateLanguageIgnoresUntrustedXOctoLang' -count=1
- go test ./pkg/...
- go test .