### PR TITLE
feat(auth): versioned token cache codec + user.language column

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/Mininglamp-OSS/octo-server/internal"
 	commonapi "github.com/Mininglamp-OSS/octo-server/modules/base/common"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
+	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
 	octodb "github.com/Mininglamp-OSS/octo-server/pkg/db"
 	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/Mininglamp-OSS/octo-server/pkg/metrics"
@@ -103,6 +104,9 @@ func runAPI(ctx *config.Context) {
 		panic(fmt.Errorf("validate i18n runtime locales: %w", err))
 	}
 	route.SetErrorRenderer(octoi18n.NewErrorRenderer(octoi18n.NewLocalizer(defaultLanguage)))
+	// 注入自定义 TokenParser，替代 octo-lib legacyTokenParser：以 pkg/auth.Decode
+	// 解析 cache value，支持 v2 JSON envelope 与 "uid@name[@role]" 旧格式（i18n D19/D21）。
+	route.SetTokenParser(auth.NewCacheTokenParser(ctx.Cache(), ctx.GetConfig().Cache.TokenCachePrefix))
 	// 替换web下的配置文件
 	replaceWebConfig(ctx.GetConfig())
 	// 初始化api

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/source"
 	spacemod "github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
@@ -4111,13 +4112,13 @@ func (g *Group) groupInviteDetail(c *wkhttp.Context) {
 	// 预览路径，不破坏未登录访问者的 external_blocked 硬拦截语义。
 	var loginUID string
 	if token := strings.TrimSpace(c.GetHeader("token")); token != "" {
-		uidAndName, cacheErr := g.ctx.Cache().Get(g.ctx.GetConfig().Cache.TokenCachePrefix + token)
-		if cacheErr == nil && strings.TrimSpace(uidAndName) != "" {
-			// AuthMiddleware 的 token value 约定：uid@name[@role]，和
-			// pkg/wkhttp/http.go 的 AuthMiddleware 解析一致，这里只取 uid。
-			parts := strings.SplitN(uidAndName, "@", 3)
-			if len(parts) >= 2 {
-				loginUID = parts[0]
+		raw, cacheErr := g.ctx.Cache().Get(g.ctx.GetConfig().Cache.TokenCachePrefix + token)
+		if cacheErr == nil && strings.TrimSpace(raw) != "" {
+			// AuthMiddleware 的 token value 由 pkg/auth 收口编解码：v2 JSON 或
+			// 灰度期残留的 "uid@name[@role]"。auth.Decode 返回 ErrInvalidToken
+			// 时安全降级为未登录访问者，沿用 external_blocked 硬拦截语义。
+			if info, decodeErr := auth.Decode(raw); decodeErr == nil {
+				loginUID = info.UID
 			}
 		}
 	}

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/robot"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
 	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
@@ -367,22 +368,22 @@ func (m *Message) sendMsg(c *wkhttp.Context) {
 		c.ResponseError(errors.New("消息不能为空"))
 		return
 	}
-	uidAndName, err := m.ctx.Cache().Get(m.ctx.GetConfig().Cache.TokenCachePrefix + req.Token)
+	raw, err := m.ctx.Cache().Get(m.ctx.GetConfig().Cache.TokenCachePrefix + req.Token)
 	if err != nil {
 		m.Error("解析token错误", zap.Error(err))
 		c.ResponseError(errors.New("解析token错误"))
 		return
 	}
-	if strings.TrimSpace(uidAndName) == "" {
+	if strings.TrimSpace(raw) == "" {
 		c.ResponseError(errors.New("请先登录"))
 		return
 	}
-	uidAndNames := strings.Split(uidAndName, "@")
-	if len(uidAndNames) < 2 {
+	info, decodeErr := auth.Decode(raw)
+	if decodeErr != nil {
 		c.ResponseError(errors.New("token错误"))
 		return
 	}
-	uid := uidAndNames[0]
+	uid := info.UID
 	if uid == "" {
 		c.ResponseError(errors.New("发送者不能为空"))
 		return

--- a/modules/qrcode/api.go
+++ b/modules/qrcode/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	spacemod "github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -66,22 +67,22 @@ func (q *QRCode) handleQRCodeInfo(c *wkhttp.Context) {
 		c.ResponseError(errors.New("token不能为空！"))
 		return
 	}
-	uidAndName, err := q.ctx.Cache().Get(q.ctx.GetConfig().Cache.TokenCachePrefix + token)
+	raw, err := q.ctx.Cache().Get(q.ctx.GetConfig().Cache.TokenCachePrefix + token)
 	if err != nil {
 		q.Error("获取登录信息失败！", zap.Error(err))
 		c.ResponseError(errors.New("获取登录信息失败！"))
 		return
 	}
-	if strings.TrimSpace(uidAndName) == "" {
+	if strings.TrimSpace(raw) == "" {
 		c.String(http.StatusOK, fmt.Sprintf("请下载“%s”APP扫码！", q.ctx.GetConfig().AppName))
 		return
 	}
-	uidAndNames := strings.Split(uidAndName, "@")
-	if len(uidAndNames) == 0 {
+	info, decodeErr := auth.Decode(raw)
+	if decodeErr != nil {
 		c.ResponseError(errors.New("登录信息格式错误！"))
 		return
 	}
-	loginUID := uidAndNames[0]
+	loginUID := info.UID
 	code := c.Param("code")
 
 	if strings.HasPrefix(code, "user_") { // 用户资料二维码 格式： user_xxxx

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -39,6 +39,7 @@ import (
 	commonapi "github.com/Mininglamp-OSS/octo-server/modules/base/common"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	common2 "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -848,7 +849,13 @@ func (u *User) userUpdateWithField(c *wkhttp.Context) {
 		}
 		if key == "name" {
 			// 将重新设置token设置到缓存（这里主要是更新登录者的name）
-			err = u.ctx.Cache().Set(u.ctx.GetConfig().Cache.TokenCachePrefix+c.GetHeader("token"), fmt.Sprintf("%s@%v@%s", loginUID, value, c.GetLoginRole()))
+			payload, encErr := auth.Encode(auth.TokenInfo{UID: loginUID, Name: fmt.Sprintf("%v", value), Role: c.GetLoginRole()})
+			if encErr != nil {
+				u.Error("编码token缓存失败！", zap.Error(encErr))
+				c.ResponseError(errors.New("重新设置token缓存失败！"))
+				return
+			}
+			err = u.ctx.Cache().Set(u.ctx.GetConfig().Cache.TokenCachePrefix+c.GetHeader("token"), payload)
 			if err != nil {
 				u.Error("重新设置token缓存失败！", zap.Error(err))
 				c.ResponseError(errors.New("重新设置token缓存失败！"))
@@ -1362,7 +1369,13 @@ func (u *User) execLogin(userInfo *Model, flag config.DeviceFlag, device *device
 		}
 	}
 
-	err = u.ctx.Cache().SetAndExpire(u.ctx.GetConfig().Cache.TokenCachePrefix+token, fmt.Sprintf("%s@%s@%s", userInfo.UID, userInfo.Name, userInfo.Role), u.ctx.GetConfig().Cache.TokenExpire)
+	tokenPayload, err := auth.Encode(auth.TokenInfo{UID: userInfo.UID, Name: userInfo.Name, Role: userInfo.Role})
+	if err != nil {
+		u.Error("编码token缓存失败！", zap.Error(err))
+		tokenSpan.Finish()
+		return nil, errors.New("设置token缓存失败！")
+	}
+	err = u.ctx.Cache().SetAndExpire(u.ctx.GetConfig().Cache.TokenCachePrefix+token, tokenPayload, u.ctx.GetConfig().Cache.TokenExpire)
 	if err != nil {
 		u.Error("设置token缓存失败！", zap.Error(err))
 		tokenSpan.Finish()
@@ -1908,7 +1921,12 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 	}
 
 	// 将token设置到缓存
-	err = u.ctx.Cache().SetAndExpire(u.ctx.GetConfig().Cache.TokenCachePrefix+token, fmt.Sprintf("%s@%s", userModel.UID, userModel.Name), u.ctx.GetConfig().Cache.TokenExpire)
+	tokenPayload, err := auth.Encode(auth.TokenInfo{UID: userModel.UID, Name: userModel.Name})
+	if err != nil {
+		u.Error("编码token缓存失败！", zap.Error(err))
+		return
+	}
+	err = u.ctx.Cache().SetAndExpire(u.ctx.GetConfig().Cache.TokenCachePrefix+token, tokenPayload, u.ctx.GetConfig().Cache.TokenExpire)
 	if err != nil {
 		u.Error("设置token缓存失败！", zap.Error(err))
 		c.ResponseError(errors.New("设置token缓存失败！"))
@@ -2570,7 +2588,13 @@ func (u *User) loginCheckPhone(c *wkhttp.Context) {
 	}
 	token := util.GenerUUID()
 	// 将token设置到缓存
-	err = u.ctx.Cache().SetAndExpire(u.ctx.GetConfig().Cache.TokenCachePrefix+token, fmt.Sprintf("%s@%s", userInfo.UID, userInfo.Name), u.ctx.GetConfig().Cache.TokenExpire)
+	tokenPayload, err := auth.Encode(auth.TokenInfo{UID: userInfo.UID, Name: userInfo.Name})
+	if err != nil {
+		u.Error("编码token缓存失败！", zap.Error(err))
+		c.ResponseError(errors.New("设置token缓存失败！"))
+		return
+	}
+	err = u.ctx.Cache().SetAndExpire(u.ctx.GetConfig().Cache.TokenCachePrefix+token, tokenPayload, u.ctx.GetConfig().Cache.TokenExpire)
 	if err != nil {
 		u.Error("设置token缓存失败！", zap.Error(err))
 		c.ResponseError(errors.New("设置token缓存失败！"))
@@ -3206,7 +3230,12 @@ func (u *User) createUserWithRespAndTx(registerSpanCtx context.Context, createUs
 	u.ctx.EventCommit(eventID)
 	token := util.GenerUUID()
 	// 将token设置到缓存
-	err = u.ctx.Cache().SetAndExpire(u.ctx.GetConfig().Cache.TokenCachePrefix+token, fmt.Sprintf("%s@%s@%s", userModel.UID, userModel.Name, userModel.Role), u.ctx.GetConfig().Cache.TokenExpire)
+	tokenPayload, err := auth.Encode(auth.TokenInfo{UID: userModel.UID, Name: userModel.Name, Role: userModel.Role})
+	if err != nil {
+		u.Error("编码token缓存失败！", zap.Error(err))
+		return nil, err
+	}
+	err = u.ctx.Cache().SetAndExpire(u.ctx.GetConfig().Cache.TokenCachePrefix+token, tokenPayload, u.ctx.GetConfig().Cache.TokenExpire)
 	if err != nil {
 		u.Error("设置token缓存失败！", zap.Error(err))
 		return nil, err
@@ -3602,26 +3631,24 @@ func (u *User) authVerifyToken(c *wkhttp.Context) {
 		return
 	}
 
-	// Same Redis lookup as AuthMiddleware: "token:<value>" → "uid@name@role"
-	uidAndName := wkhttp.GetLoginUID(req.Token, u.ctx.GetConfig().Cache.TokenCachePrefix, u.ctx.Cache())
-	if strings.TrimSpace(uidAndName) == "" {
+	// Same Redis lookup as AuthMiddleware: "token:<value>" → versioned envelope
+	// (v2 JSON) 或 legacy "uid@name[@role]"。auth.Decode 兼容两者。
+	raw, cacheErr := u.ctx.Cache().Get(u.ctx.GetConfig().Cache.TokenCachePrefix + req.Token)
+	if cacheErr != nil || strings.TrimSpace(raw) == "" {
 		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"msg": "invalid or expired token"})
 		return
 	}
-
-	parts := strings.SplitN(uidAndName, "@", 3)
-	if len(parts) < 2 {
+	info, decodeErr := auth.Decode(raw)
+	if decodeErr != nil {
 		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"msg": "malformed token data"})
 		return
 	}
 
 	resp := authVerifyTokenResp{
-		UID:       parts[0],
-		Name:      parts[1],
+		UID:       info.UID,
+		Name:      info.Name,
+		Role:      info.Role,
 		OwnedBots: make([]ownedBot, 0),
-	}
-	if len(parts) > 2 {
-		resp.Role = parts[2]
 	}
 
 	// Query owned bots: robot.creator_uid = uid

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	common2 "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	wkutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
 
@@ -197,7 +198,13 @@ func (m *Manager) login(c *wkhttp.Context) {
 	}
 	token := util.GenerUUID()
 	// 将token设置到缓存
-	err = m.ctx.Cache().SetAndExpire(m.ctx.GetConfig().Cache.TokenCachePrefix+token, fmt.Sprintf("%s@%s@%s", userInfo.UID, userInfo.Name, userInfo.Role), m.ctx.GetConfig().Cache.TokenExpire)
+	tokenPayload, err := auth.Encode(auth.TokenInfo{UID: userInfo.UID, Name: userInfo.Name, Role: userInfo.Role})
+	if err != nil {
+		m.Error("编码token缓存失败！", zap.Error(err))
+		c.ResponseError(errors.New("设置token缓存失败！"))
+		return
+	}
+	err = m.ctx.Cache().SetAndExpire(m.ctx.GetConfig().Cache.TokenCachePrefix+token, tokenPayload, m.ctx.GetConfig().Cache.TokenExpire)
 	if err != nil {
 		m.Error("设置token缓存失败！", zap.Error(err))
 		c.ResponseError(errors.New("设置token缓存失败！"))

--- a/modules/user/db.go
+++ b/modules/user/db.go
@@ -487,6 +487,7 @@ type Model struct {
 	GithubUID         string // github uid
 	Web3PublicKey     string // web3公钥
 	MsgExpireSecond   int64  // 消息过期时长
+	Language          string // 用户语言偏好（BCP 47，空表示沿用 OCTO_DEFAULT_LANGUAGE）
 	db.BaseModel
 }
 

--- a/modules/user/sql/20260527000001_user_language.sql
+++ b/modules/user/sql/20260527000001_user_language.sql
@@ -1,0 +1,8 @@
+-- +migrate Up
+-- 为 user 表新增 language 列，承载多端语言偏好的真相源（i18n 主方案 D10 / TODOS 0.5）。
+-- 与 phone/zone 等历史教训一致，使用 NOT NULL DEFAULT '' 以避免扫描 NULL 到 Go string 失败；
+-- 空串语义为"未显式设置，沿用 OCTO_DEFAULT_LANGUAGE"。长度参考 BCP 47 子标签上限取 16。
+ALTER TABLE `user` ADD COLUMN language VARCHAR(16) NOT NULL DEFAULT '' COMMENT '用户语言偏好（BCP 47，空表示沿用 OCTO_DEFAULT_LANGUAGE）';
+
+-- +migrate Down
+ALTER TABLE `user` DROP COLUMN language;

--- a/pkg/auth/parser.go
+++ b/pkg/auth/parser.go
@@ -1,0 +1,62 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/cache"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+)
+
+// CacheTokenParser implements octo-lib's wkhttp.TokenParser using the shared
+// pkg/auth codec. It supersedes octo-lib's legacyTokenParser so that octo-server
+// can write v2 JSON envelopes while still decoding any legacy uid@name[@role]
+// values left in cache from older binaries.
+//
+// Construct once at boot and register with WKHttp.SetTokenParser; the parser
+// is safe for concurrent use as long as the underlying cache is.
+type CacheTokenParser struct {
+	Cache  cache.Cache
+	Prefix string
+}
+
+// NewCacheTokenParser is a convenience constructor; nil cache is a programmer
+// error and panics rather than silently degrading to a parser that fails every
+// request.
+func NewCacheTokenParser(c cache.Cache, prefix string) *CacheTokenParser {
+	if c == nil {
+		panic("auth: NewCacheTokenParser requires non-nil cache")
+	}
+	return &CacheTokenParser{Cache: c, Prefix: prefix}
+}
+
+// Parse implements wkhttp.TokenParser. The context is currently unused
+// (cache.Cache lookups are synchronous) but kept on the signature for future
+// upgrades — same rationale as octo-lib's legacy parser.
+func (p *CacheTokenParser) Parse(_ context.Context, token string) (wkhttp.UserInfo, error) {
+	if strings.TrimSpace(token) == "" {
+		return wkhttp.UserInfo{}, wkhttp.ErrTokenMissing
+	}
+	raw, err := p.Cache.Get(p.Prefix + token)
+	if err != nil {
+		return wkhttp.UserInfo{}, fmt.Errorf("auth: load token from cache: %w", err)
+	}
+	if strings.TrimSpace(raw) == "" {
+		return wkhttp.UserInfo{}, wkhttp.ErrTokenNotFound
+	}
+	info, err := Decode(raw)
+	if err != nil {
+		if errors.Is(err, ErrEmptyToken) {
+			return wkhttp.UserInfo{}, wkhttp.ErrTokenNotFound
+		}
+		return wkhttp.UserInfo{}, fmt.Errorf("%w: %v", wkhttp.ErrTokenInvalid, err)
+	}
+	return wkhttp.UserInfo{
+		UID:      info.UID,
+		Name:     info.Name,
+		Role:     info.Role,
+		Language: info.Language,
+	}, nil
+}

--- a/pkg/auth/parser_test.go
+++ b/pkg/auth/parser_test.go
@@ -1,0 +1,136 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+)
+
+// fakeCache implements octo-lib cache.Cache for unit tests; nil values map to
+// the "cache miss" behaviour the parser must tolerate.
+type fakeCache struct {
+	store  map[string]string
+	getErr error
+}
+
+func newFakeCache() *fakeCache { return &fakeCache{store: map[string]string{}} }
+
+func (c *fakeCache) Set(key, value string) error { c.store[key] = value; return nil }
+func (c *fakeCache) SetAndExpire(key, value string, _ time.Duration) error {
+	c.store[key] = value
+	return nil
+}
+func (c *fakeCache) Delete(key string) error { delete(c.store, key); return nil }
+func (c *fakeCache) Get(key string) (string, error) {
+	if c.getErr != nil {
+		return "", c.getErr
+	}
+	return c.store[key], nil
+}
+
+const testPrefix = "token:"
+
+func TestCacheTokenParserParseV2(t *testing.T) {
+	t.Parallel()
+	c := newFakeCache()
+	encoded, err := Encode(TokenInfo{UID: "u1", Name: "alice", Role: "admin", Language: "zh-CN"})
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if err := c.Set(testPrefix+"tok1", encoded); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	p := NewCacheTokenParser(c, testPrefix)
+	got, err := p.Parse(context.Background(), "tok1")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	want := wkhttp.UserInfo{UID: "u1", Name: "alice", Role: "admin", Language: "zh-CN"}
+	if got != want {
+		t.Fatalf("Parse = %+v, want %+v", got, want)
+	}
+}
+
+func TestCacheTokenParserParseLegacy(t *testing.T) {
+	t.Parallel()
+	c := newFakeCache()
+	// legacy "uid@name@role" format must keep working during rollout.
+	_ = c.Set(testPrefix+"tok1", "u1@alice@admin")
+	_ = c.Set(testPrefix+"tok2", "u1@alice")
+
+	p := NewCacheTokenParser(c, testPrefix)
+
+	for _, tc := range []struct {
+		token string
+		want  wkhttp.UserInfo
+	}{
+		{"tok1", wkhttp.UserInfo{UID: "u1", Name: "alice", Role: "admin"}},
+		{"tok2", wkhttp.UserInfo{UID: "u1", Name: "alice"}},
+	} {
+		got, err := p.Parse(context.Background(), tc.token)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", tc.token, err)
+		}
+		if got != tc.want {
+			t.Fatalf("Parse(%q) = %+v, want %+v", tc.token, got, tc.want)
+		}
+	}
+}
+
+func TestCacheTokenParserSentinelErrors(t *testing.T) {
+	t.Parallel()
+	c := newFakeCache()
+	_ = c.Set(testPrefix+"bad", "garbage-no-at-sign")
+	p := NewCacheTokenParser(c, testPrefix)
+
+	cases := []struct {
+		name  string
+		token string
+		want  error
+	}{
+		{"empty_token", "   ", wkhttp.ErrTokenMissing},
+		{"cache_miss", "absent", wkhttp.ErrTokenNotFound},
+		{"malformed_payload", "bad", wkhttp.ErrTokenInvalid},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := p.Parse(context.Background(), tc.token)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("Parse(%q): want %v, got %v", tc.token, tc.want, err)
+			}
+		})
+	}
+}
+
+func TestCacheTokenParserPropagatesCacheError(t *testing.T) {
+	t.Parallel()
+	cacheErr := errors.New("redis down")
+	c := &fakeCache{store: map[string]string{}, getErr: cacheErr}
+	p := NewCacheTokenParser(c, testPrefix)
+
+	_, err := p.Parse(context.Background(), "tok1")
+	if !errors.Is(err, cacheErr) {
+		t.Fatalf("Parse should propagate cache error via %%w, got %v", err)
+	}
+	// Cache errors must NOT collapse to ErrTokenNotFound — caller needs to
+	// distinguish "session expired" (login again) from "infra down" (retry).
+	if errors.Is(err, wkhttp.ErrTokenNotFound) || errors.Is(err, wkhttp.ErrTokenInvalid) {
+		t.Fatalf("infra error must not masquerade as auth sentinel, got %v", err)
+	}
+}
+
+func TestNewCacheTokenParserPanicsOnNilCache(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on nil cache")
+		}
+	}()
+	_ = NewCacheTokenParser(nil, testPrefix)
+}

--- a/pkg/auth/tokeninfo.go
+++ b/pkg/auth/tokeninfo.go
@@ -91,6 +91,11 @@ func decodeV2(payload string) (TokenInfo, error) {
 }
 
 func decodeLegacy(raw string) (TokenInfo, error) {
+	// Known limitation of the legacy "uid@name[@role]" wire format: a display
+	// name containing '@' (e.g. an email-style handle) is structurally
+	// ambiguous and rejected here as malformed. The original split-based
+	// readers had the same blind spot — this is not a regression — and the v2
+	// JSON envelope fixes it permanently for any token written after upgrade.
 	parts := strings.Split(raw, "@")
 	if len(parts) < 2 || len(parts) > 3 || parts[0] == "" {
 		return TokenInfo{}, fmt.Errorf("%w: legacy payload must be uid@name[@role]", ErrInvalidToken)

--- a/pkg/auth/tokeninfo.go
+++ b/pkg/auth/tokeninfo.go
@@ -1,0 +1,103 @@
+// Package auth carries the canonical representation of the value stored under
+// the token cache key (TokenCachePrefix+token) and provides versioned
+// encoding helpers.
+//
+// Historically the cache value was a `@`-joined string ("uid@name" or
+// "uid@name@role") split ad-hoc at every call site. i18n 主方案 D10/D21 要求把
+// token cache 真相源收口，并在 payload 中带上用户语言偏好（D20 UserInfo），
+// 因此引入 versioned JSON envelope（v2:）；v1 字符串格式保留为解码 fallback，
+// 灰度期老 token 不会因为升级失效。
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// v2Prefix marks the versioned JSON envelope. Bumping the version means a new
+// prefix (e.g. "v3:") — decoder must keep tolerating older prefixes during the
+// rollout window.
+const v2Prefix = "v2:"
+
+// TokenInfo is the structured payload stored under TokenCachePrefix+token.
+// UID is required; Role/Language may be empty.
+type TokenInfo struct {
+	UID      string
+	Name     string
+	Role     string
+	Language string
+}
+
+// ErrEmptyToken indicates an empty cache value (missing or evicted token).
+var ErrEmptyToken = errors.New("auth: empty token payload")
+
+// ErrInvalidToken indicates a token payload that matches neither v2 JSON nor
+// the legacy "uid@name[@role]" string.
+var ErrInvalidToken = errors.New("auth: invalid token payload")
+
+type tokenInfoV2 struct {
+	UID      string `json:"uid"`
+	Name     string `json:"name,omitempty"`
+	Role     string `json:"role,omitempty"`
+	Language string `json:"lang,omitempty"`
+}
+
+// Encode serializes a TokenInfo as the versioned JSON envelope. The UID is
+// the only required field; callers should populate Name/Role exactly as they
+// did for the legacy "uid@name@role" string, and Language with the value
+// resolved at write time (may be empty if unknown).
+func Encode(info TokenInfo) (string, error) {
+	if info.UID == "" {
+		return "", fmt.Errorf("%w: uid required", ErrInvalidToken)
+	}
+	payload, err := json.Marshal(tokenInfoV2{
+		UID:      info.UID,
+		Name:     info.Name,
+		Role:     info.Role,
+		Language: info.Language,
+	})
+	if err != nil {
+		return "", fmt.Errorf("auth: marshal token payload: %w", err)
+	}
+	return v2Prefix + string(payload), nil
+}
+
+// Decode reverses Encode and tolerates the legacy "uid@name[@role]" string so
+// that tokens written by older binaries (and cached before the upgrade) keep
+// working until they expire. UID emptiness is the only structural check
+// applied here — language validity is enforced at consumption sites via
+// i18n.MatchSupportedLanguage.
+func Decode(raw string) (TokenInfo, error) {
+	if raw == "" {
+		return TokenInfo{}, ErrEmptyToken
+	}
+	if strings.HasPrefix(raw, v2Prefix) {
+		return decodeV2(raw[len(v2Prefix):])
+	}
+	return decodeLegacy(raw)
+}
+
+func decodeV2(payload string) (TokenInfo, error) {
+	var v tokenInfoV2
+	if err := json.Unmarshal([]byte(payload), &v); err != nil {
+		return TokenInfo{}, fmt.Errorf("%w: %v", ErrInvalidToken, err)
+	}
+	if v.UID == "" {
+		return TokenInfo{}, fmt.Errorf("%w: uid missing", ErrInvalidToken)
+	}
+	return TokenInfo{UID: v.UID, Name: v.Name, Role: v.Role, Language: v.Language}, nil
+}
+
+func decodeLegacy(raw string) (TokenInfo, error) {
+	parts := strings.Split(raw, "@")
+	if len(parts) < 2 || len(parts) > 3 || parts[0] == "" {
+		return TokenInfo{}, fmt.Errorf("%w: legacy payload must be uid@name[@role]", ErrInvalidToken)
+	}
+	info := TokenInfo{UID: parts[0], Name: parts[1]}
+	if len(parts) == 3 {
+		info.Role = parts[2]
+	}
+	return info, nil
+}

--- a/pkg/auth/tokeninfo_test.go
+++ b/pkg/auth/tokeninfo_test.go
@@ -1,0 +1,119 @@
+package auth
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestEncodeRoundTrip(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   TokenInfo
+	}{
+		{"full", TokenInfo{UID: "u1", Name: "alice", Role: "admin", Language: "en-US"}},
+		{"no_role", TokenInfo{UID: "u1", Name: "alice", Language: "zh-CN"}},
+		{"no_language", TokenInfo{UID: "u1", Name: "alice", Role: "superAdmin"}},
+		{"only_uid_name", TokenInfo{UID: "u1", Name: "alice"}},
+		{"name_with_at_sign", TokenInfo{UID: "u1", Name: "a@b@c", Role: "admin", Language: "en-US"}},
+		{"unicode_name", TokenInfo{UID: "u1", Name: "张三", Role: "admin", Language: "zh-CN"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			encoded, err := Encode(tc.in)
+			if err != nil {
+				t.Fatalf("Encode: %v", err)
+			}
+			if !strings.HasPrefix(encoded, v2Prefix) {
+				t.Fatalf("encoded value missing v2 prefix: %q", encoded)
+			}
+			got, err := Decode(encoded)
+			if err != nil {
+				t.Fatalf("Decode: %v", err)
+			}
+			if got != tc.in {
+				t.Fatalf("round trip mismatch: got %+v want %+v", got, tc.in)
+			}
+		})
+	}
+}
+
+func TestEncodeRejectsEmptyUID(t *testing.T) {
+	t.Parallel()
+	_, err := Encode(TokenInfo{Name: "alice"})
+	if !errors.Is(err, ErrInvalidToken) {
+		t.Fatalf("want ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestDecodeLegacy(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		raw  string
+		want TokenInfo
+	}{
+		{"uid_name", "u1@alice", TokenInfo{UID: "u1", Name: "alice"}},
+		{"uid_name_role", "u1@alice@admin", TokenInfo{UID: "u1", Name: "alice", Role: "admin"}},
+		{"empty_name_allowed", "u1@", TokenInfo{UID: "u1", Name: ""}},
+		{"superadmin_role", "u1@alice@superAdmin", TokenInfo{UID: "u1", Name: "alice", Role: "superAdmin"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Decode(tc.raw)
+			if err != nil {
+				t.Fatalf("Decode(%q): %v", tc.raw, err)
+			}
+			if got != tc.want {
+				t.Fatalf("Decode(%q) = %+v, want %+v", tc.raw, got, tc.want)
+			}
+			if got.Language != "" {
+				t.Fatalf("legacy payload must not synthesize a language, got %q", got.Language)
+			}
+		})
+	}
+}
+
+func TestDecodeErrors(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		raw  string
+		want error
+	}{
+		{"empty", "", ErrEmptyToken},
+		{"legacy_only_uid", "u1", ErrInvalidToken},
+		{"legacy_empty_uid", "@alice", ErrInvalidToken},
+		{"legacy_too_many_parts", "u1@alice@admin@extra", ErrInvalidToken},
+		{"v2_bad_json", v2Prefix + "{not json}", ErrInvalidToken},
+		{"v2_missing_uid", v2Prefix + `{"name":"alice"}`, ErrInvalidToken},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Decode(tc.raw)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("Decode(%q): want %v, got %v", tc.raw, tc.want, err)
+			}
+		})
+	}
+}
+
+// TestDecodeV2PrefixIsRequired guards against accidental relaxation of the
+// versioning prefix — a future "v3:" envelope must not be silently parsed as
+// v2 (and vice versa). 老消费者拿到未来版本应当显式报错。
+func TestDecodeV2PrefixIsRequired(t *testing.T) {
+	t.Parallel()
+	// 缺少 v2: 前缀 → 走 legacy 分支。带合法 JSON 但没有 @ 分隔会被识别为非法。
+	jsonNoPrefix := `{"uid":"u1","name":"alice"}`
+	_, err := Decode(jsonNoPrefix)
+	if !errors.Is(err, ErrInvalidToken) {
+		t.Fatalf("plain JSON without v2 prefix must fail, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

First step of the backend i18n track (refs #170): introduce a single
versioned codec for the value stored under `TokenCachePrefix+token` in
the auth cache, and add a `language` column to the `user` table to hold
each user's preferred language. The follow-up PR will add the Redis
`user_language:{uid}` layer, the resolve service, and the late-stage
language middleware hook.

The new format is a `v2:` prefixed JSON envelope; the decoder also
accepts the legacy `uid@name[@role]` string so that upgraded binaries
keep working with cache values written by older ones during rollout.

## Scope

**New infrastructure — `pkg/auth/`:**
- `TokenInfo{UID, Name, Role, Language}` with `Encode` / `Decode`
  - `v2:` prefix + JSON envelope as the new wire format
  - Legacy `uid@name[@role]` string accepted as a decode fallback
- `CacheTokenParser` implements `wkhttp.TokenParser` from octo-lib
  - Replaces octo-lib's `legacyTokenParser` for octo-server
  - Cache-layer errors propagate via `%w` instead of being collapsed
    into `ErrTokenNotFound`, so a Redis outage surfaces as 5xx rather
    than a misleading 401

**DB schema:**
- `modules/user/sql/20260527000001_user_language.sql`: add
  `language VARCHAR(16) NOT NULL DEFAULT ''`
  - Follows the project's `NOT NULL DEFAULT ''` convention for string
    columns scanned into Go `string` (same lesson as #54)
  - Empty string means "not explicitly set; fall back to
    `OCTO_DEFAULT_LANGUAGE`"
- `modules/user/db.go`: new `Model.Language` field (dbr snake_case
  mapping picks it up automatically)

**Token write sites switched to `auth.Encode` (6 sites):**
- `modules/user/api.go`: primary login, profile rename, third-party
  login, register-then-auto-login, PC QR-code login
- `modules/user/api_manager.go`: manager-console login

**Business-side token read sites switched to `auth.Decode` (4 sites),
removing ad-hoc `strings.Split("@")`:**
- `modules/qrcode/api.go`: QR-code login info
- `modules/group/api.go`: public-preview loginUID lookup
- `modules/message/api.go`: legacy send-by-token endpoint
- `modules/user/api.go`: `authVerifyToken` (replaces
  `wkhttp.GetLoginUID` + manual split)

**Boot wiring:**
- `main.go`: injects `auth.NewCacheTokenParser` into the octo-lib
  `WKHttp` instance so `AuthMiddleware` decodes the v2 envelope (and
  legacy fallback) instead of relying on the built-in legacy parser.

## Out of scope (follow-up PRs)

- Redis `user_language:{uid}` cache and `ResolveUserLanguage(ctx, uid,
  tokenLang)` service
- Populating `userInfo.Language` at write time (this PR leaves it empty
  until the resolve service lands)
- `pkg/i18n` late-stage middleware hook to override the negotiated
  language using the resolved user language
- `PUT /v1/user/language` endpoint and the `language` field on
  `GET /v1/user`
- A CI lint that blocks new business code from splitting token cache
  values manually

## Backward compatibility

- Existing test fixtures across ~30 sites seed the token cache with
  `"uid@test"` / `"uid@test@role"` strings and **are not modified** —
  `auth.Decode`'s legacy branch covers them. All affected module tests
  continue to pass.
- During rollout, upgraded binaries write `v2:{...}` while older
  binaries keep writing the `@`-joined form. Both reader paths
  (`CacheTokenParser`, `auth.Decode`) accept either format, so
  unexpired cache values written by older binaries remain usable.
- `wkhttp.GetLoginUID` in octo-lib is left untouched; only its single
  call site in octo-server moved to `cache.Get + auth.Decode`.
  Deprecating the helper upstream can be considered separately.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -cover ./pkg/auth/...` (95% coverage)
- [x] `go test -race ./pkg/i18n/... ./pkg/i18n/codes ./pkg/httperr ./pkg/wkhttp`
- [x] `go test ./modules/user ./modules/message ./modules/group
      ./modules/qrcode ./modules/thread ./modules/category
      ./modules/space ./modules/robot ./modules/common
      ./modules/report ./modules/notify` — covers every module that
      seeds the token cache from a test fixture, exercising the legacy
      fallback path end-to-end
- [ ] CI Build / Test / Vet / Lint / CodeQL
- [ ] Reviewer spot check on a staging-style deploy before merging

## Risk

| Risk | Mitigation |
|---|---|
| Mixed read/write during rollout (old `@` strings vs new `v2:` JSON) | `auth.Decode` accepts both; unit tests cover round-trip and legacy decode; every existing module test exercises the legacy seed |
| Redis outage surfacing as 401 instead of 5xx | `CacheTokenParser` wraps the cache error with `%w` rather than mapping it to an auth sentinel; observe 5xx / 401 ratio after deploy |
| `language` column scanning `NULL` into Go `string` | `NOT NULL DEFAULT ''` per the project's existing convention; no backfill needed |
| `language` column length of 16 too small | BCP 47 subtag max length is 8 (e.g. `zh-Hant-HK`); 16 leaves 100% headroom |