### PR TITLE
feat(i18n): user language resolver + hot cache + late-stage merge

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/Mininglamp-OSS/octo-server/internal"
 	commonapi "github.com/Mininglamp-OSS/octo-server/modules/base/common"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
 	octodb "github.com/Mininglamp-OSS/octo-server/pkg/db"
 	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
@@ -106,7 +107,14 @@ func runAPI(ctx *config.Context) {
 	route.SetErrorRenderer(octoi18n.NewErrorRenderer(octoi18n.NewLocalizer(defaultLanguage)))
 	// 注入自定义 TokenParser，替代 octo-lib legacyTokenParser：以 pkg/auth.Decode
 	// 解析 cache value，支持 v2 JSON envelope 与 "uid@name[@role]" 旧格式（i18n D19/D21）。
-	route.SetTokenParser(auth.NewCacheTokenParser(ctx.Cache(), ctx.GetConfig().Cache.TokenCachePrefix))
+	// 同时注入 LanguageResolver，让 AuthMiddleware 把 user_language:{uid} → DB 的
+	// 真相源结果写到 UserInfo.Language 上，供 i18n.LanguageFromContext 读侧合并。
+	userLangSvc := user.NewLanguageService(user.NewDB(ctx), ctx.Cache())
+	route.SetTokenParser(auth.NewCacheTokenParser(
+		ctx.Cache(),
+		ctx.GetConfig().Cache.TokenCachePrefix,
+		auth.WithLanguageResolver(userLangSvc),
+	))
 	// 替换web下的配置文件
 	replaceWebConfig(ctx.GetConfig())
 	// 初始化api

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -848,14 +848,29 @@ func (u *User) userUpdateWithField(c *wkhttp.Context) {
 			return
 		}
 		if key == "name" {
-			// 将重新设置token设置到缓存（这里主要是更新登录者的name）
-			payload, encErr := auth.Encode(auth.TokenInfo{UID: loginUID, Name: fmt.Sprintf("%v", value), Role: c.GetLoginRole()})
+			// 将重新设置token设置到缓存（这里主要是更新登录者的name）。
+			// 保留原有 Language 快照：从既存 cache value 解码后只换 Name，
+			// 避免 rename 把语言偏好抹空；Redis miss 时回退到无快照（由
+			// AuthMiddleware 上的 LanguageResolver 在下次请求重建）。
+			loginToken := c.GetHeader("token")
+			preservedLang := ""
+			if oldRaw, getErr := u.ctx.Cache().Get(u.ctx.GetConfig().Cache.TokenCachePrefix + loginToken); getErr == nil && oldRaw != "" {
+				if oldInfo, decErr := auth.Decode(oldRaw); decErr == nil {
+					preservedLang = oldInfo.Language
+				}
+			}
+			payload, encErr := auth.Encode(auth.TokenInfo{
+				UID:      loginUID,
+				Name:     fmt.Sprintf("%v", value),
+				Role:     c.GetLoginRole(),
+				Language: preservedLang,
+			})
 			if encErr != nil {
 				u.Error("编码token缓存失败！", zap.Error(encErr))
 				c.ResponseError(errors.New("重新设置token缓存失败！"))
 				return
 			}
-			err = u.ctx.Cache().Set(u.ctx.GetConfig().Cache.TokenCachePrefix+c.GetHeader("token"), payload)
+			err = u.ctx.Cache().Set(u.ctx.GetConfig().Cache.TokenCachePrefix+loginToken, payload)
 			if err != nil {
 				u.Error("重新设置token缓存失败！", zap.Error(err))
 				c.ResponseError(errors.New("重新设置token缓存失败！"))
@@ -1369,7 +1384,12 @@ func (u *User) execLogin(userInfo *Model, flag config.DeviceFlag, device *device
 		}
 	}
 
-	tokenPayload, err := auth.Encode(auth.TokenInfo{UID: userInfo.UID, Name: userInfo.Name, Role: userInfo.Role})
+	tokenPayload, err := auth.Encode(auth.TokenInfo{
+		UID:      userInfo.UID,
+		Name:     userInfo.Name,
+		Role:     userInfo.Role,
+		Language: userInfo.Language,
+	})
 	if err != nil {
 		u.Error("编码token缓存失败！", zap.Error(err))
 		tokenSpan.Finish()
@@ -1921,7 +1941,11 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 	}
 
 	// 将token设置到缓存
-	tokenPayload, err := auth.Encode(auth.TokenInfo{UID: userModel.UID, Name: userModel.Name})
+	tokenPayload, err := auth.Encode(auth.TokenInfo{
+		UID:      userModel.UID,
+		Name:     userModel.Name,
+		Language: userModel.Language,
+	})
 	if err != nil {
 		u.Error("编码token缓存失败！", zap.Error(err))
 		return
@@ -2588,7 +2612,11 @@ func (u *User) loginCheckPhone(c *wkhttp.Context) {
 	}
 	token := util.GenerUUID()
 	// 将token设置到缓存
-	tokenPayload, err := auth.Encode(auth.TokenInfo{UID: userInfo.UID, Name: userInfo.Name})
+	tokenPayload, err := auth.Encode(auth.TokenInfo{
+		UID:      userInfo.UID,
+		Name:     userInfo.Name,
+		Language: userInfo.Language,
+	})
 	if err != nil {
 		u.Error("编码token缓存失败！", zap.Error(err))
 		c.ResponseError(errors.New("设置token缓存失败！"))
@@ -3230,7 +3258,12 @@ func (u *User) createUserWithRespAndTx(registerSpanCtx context.Context, createUs
 	u.ctx.EventCommit(eventID)
 	token := util.GenerUUID()
 	// 将token设置到缓存
-	tokenPayload, err := auth.Encode(auth.TokenInfo{UID: userModel.UID, Name: userModel.Name, Role: userModel.Role})
+	tokenPayload, err := auth.Encode(auth.TokenInfo{
+		UID:      userModel.UID,
+		Name:     userModel.Name,
+		Role:     userModel.Role,
+		Language: userModel.Language,
+	})
 	if err != nil {
 		u.Error("编码token缓存失败！", zap.Error(err))
 		return nil, err

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -198,7 +198,12 @@ func (m *Manager) login(c *wkhttp.Context) {
 	}
 	token := util.GenerUUID()
 	// 将token设置到缓存
-	tokenPayload, err := auth.Encode(auth.TokenInfo{UID: userInfo.UID, Name: userInfo.Name, Role: userInfo.Role})
+	tokenPayload, err := auth.Encode(auth.TokenInfo{
+		UID:      userInfo.UID,
+		Name:     userInfo.Name,
+		Role:     userInfo.Role,
+		Language: userInfo.Language,
+	})
 	if err != nil {
 		m.Error("编码token缓存失败！", zap.Error(err))
 		c.ResponseError(errors.New("设置token缓存失败！"))

--- a/modules/user/db.go
+++ b/modules/user/db.go
@@ -111,6 +111,24 @@ func (d *DB) QueryByUID(uid string) (*Model, error) {
 	return model, err
 }
 
+// QueryLanguageByUID returns the user's language preference column only.
+// 用作 LanguageService 的真相源读取——只 SELECT 单列以保持 hot path 轻量，
+// 避免 5min TTL 的 Redis 缓存 miss 把整行 Model 拉到内存。
+// (uid 不存在时返回 ("", nil)；空串语义为"未显式设置"。)
+func (d *DB) QueryLanguageByUID(uid string) (string, error) {
+	var lang string
+	_, err := d.session.Select("language").From("user").Where("uid=?", uid).Load(&lang)
+	return lang, err
+}
+
+// UpdateLanguageByUID 持久化用户语言偏好。空字符串表示清空（回到
+// OCTO_DEFAULT_LANGUAGE 语义）；调用方负责在入库前完成 BCP 47 校验
+// （通常走 LanguageService.SetLanguage），这里不做二次校验。
+func (d *DB) UpdateLanguageByUID(uid, language string) error {
+	_, err := d.session.Update("user").Set("language", language).Where("uid=?", uid).Exec()
+	return err
+}
+
 // QueryByVercode 通过用户vercode查询用户信息
 func (d *DB) QueryByVercode(vercode string) (*Model, error) {
 	var model *Model

--- a/modules/user/db_manager.go
+++ b/modules/user/db_manager.go
@@ -165,6 +165,7 @@ type managerLoginModel struct {
 	Name     string
 	Password string
 	Role     string
+	Language string // 偏好语言快照——AuthMiddleware 上的 LanguageResolver 在 Parse 时会刷新成最新值
 }
 
 type managerUserModel struct {

--- a/modules/user/language_service.go
+++ b/modules/user/language_service.go
@@ -1,0 +1,167 @@
+package user
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/cache"
+	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+// LanguageCacheKeyPrefix is the Redis key prefix for the
+// `user_language:{uid}` hot cache. Exported so external infra (e.g. ops
+// scripts that need to invalidate a hot key) can construct the key without
+// duplicating the literal.
+const LanguageCacheKeyPrefix = "user_language:"
+
+// LanguageCacheTTL bounds the staleness of cross-device language switches:
+// after a PUT /v1/user/language the resolver writes through the cache, but
+// if another node skipped that invalidation the next read converges within
+// this window.
+const LanguageCacheTTL = 5 * time.Minute
+
+// negativeMarker is the sentinel stored when DB returns an empty preference.
+// We need to distinguish "no entry in cache" (cache miss → query DB) from
+// "user has no explicit preference" (negative cache hit → skip DB). A bare
+// '-' is unambiguous because BCP 47 forbids a leading hyphen on any subtag.
+const negativeMarker = "-"
+
+// languageReader is the read surface LanguageService needs from the user DB
+// layer; defined here (consumer side) so tests can stub it without spinning
+// up dbr. Production code passes *DB which already satisfies the signature.
+type languageReader interface {
+	QueryLanguageByUID(uid string) (string, error)
+}
+
+// LanguageService resolves the authoritative language preference for a user.
+// It satisfies both pkg/auth.LanguageResolver (consumed by CacheTokenParser)
+// and pkg/i18n.UserLanguageResolver (documentation interface for the i18n
+// contract).
+//
+// Lookup order: Redis `user_language:{uid}` → DB `user.language` → "".
+// DB results are written back to Redis with a negative marker for empty
+// values so subsequent requests for users without a preference don't
+// hammer MySQL. SetLanguage handles cross-device invalidation by deleting
+// the hot key on writes; absent a delete the entry expires within
+// LanguageCacheTTL.
+type LanguageService struct {
+	db    languageReader
+	cache cache.Cache
+	ttl   time.Duration
+}
+
+// NewLanguageService constructs a LanguageService with the canonical 5-minute
+// hot cache TTL. cache and db must be non-nil; nil is a programmer error and
+// panics on construction rather than silently degrading at request time.
+func NewLanguageService(db languageReader, c cache.Cache) *LanguageService {
+	if db == nil {
+		panic("user: NewLanguageService requires non-nil db reader")
+	}
+	if c == nil {
+		panic("user: NewLanguageService requires non-nil cache")
+	}
+	return &LanguageService{db: db, cache: c, ttl: LanguageCacheTTL}
+}
+
+// Resolve returns the user's language preference or "" if none is set.
+// Errors are returned to the caller; pkg/auth.CacheTokenParser specifically
+// keeps the token snapshot on resolver error so an outage doesn't 5xx
+// authentication.
+func (s *LanguageService) Resolve(ctx context.Context, uid string) (string, error) {
+	if uid == "" {
+		return "", nil
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	key := LanguageCacheKeyPrefix + uid
+	cached, cacheErr := s.cache.Get(key)
+	if cacheErr == nil {
+		switch cached {
+		case "":
+			// fall through to DB on cache miss
+		case negativeMarker:
+			return "", nil
+		default:
+			if _, ok := octoi18n.MatchSupportedLanguage(cached); ok {
+				return cached, nil
+			}
+			// Cached value drifted from the supported language matrix
+			// (e.g. matrix narrowed between releases). Drop the stale
+			// entry and re-query DB instead of returning garbage.
+			_ = s.cache.Delete(key)
+		}
+	}
+
+	lang, dbErr := s.db.QueryLanguageByUID(uid)
+	if dbErr != nil {
+		return "", fmt.Errorf("user: read language from db: %w", dbErr)
+	}
+	normalized := normalizeLanguageOrEmpty(lang)
+	s.writeCache(key, normalized)
+	return normalized, nil
+}
+
+// SetLanguage validates the incoming preference, persists it to the DB and
+// invalidates the hot cache so the next read on any node observes the new
+// value within one round-trip. The empty string is accepted and clears the
+// preference (back to "use OCTO_DEFAULT_LANGUAGE" semantics).
+//
+// The DB write is performed via the embedded reader's underlying *DB when
+// available; tests that supply a stub reader without a writer get an
+// explicit error rather than a silent drop.
+func (s *LanguageService) SetLanguage(ctx context.Context, uid, lang string) error {
+	if uid == "" {
+		return errors.New("user: empty uid")
+	}
+	normalized := normalizeLanguageOrEmpty(lang)
+	if lang != "" && normalized == "" {
+		return fmt.Errorf("user: unsupported language %q", lang)
+	}
+	writer, ok := s.db.(languageWriter)
+	if !ok {
+		return errors.New("user: language service backend does not support writes")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := writer.UpdateLanguageByUID(uid, normalized); err != nil {
+		return fmt.Errorf("user: persist language: %w", err)
+	}
+	// Active invalidation: DEL beats waiting for TTL on cross-device switches.
+	// Failure here is logged-only in callers; the worst case is up to TTL of
+	// staleness on other nodes, which is acceptable for a UX-only preference.
+	_ = s.cache.Delete(LanguageCacheKeyPrefix + uid)
+	return nil
+}
+
+// languageWriter is the optional write surface; *DB satisfies it via
+// UpdateLanguageByUID (added in this commit).
+type languageWriter interface {
+	UpdateLanguageByUID(uid, language string) error
+}
+
+func (s *LanguageService) writeCache(key, lang string) {
+	value := lang
+	if value == "" {
+		value = negativeMarker
+	}
+	// Best-effort write — a Redis outage degrades to "no negative cache",
+	// not a request failure.
+	_ = s.cache.SetAndExpire(key, value, s.ttl)
+}
+
+// normalizeLanguageOrEmpty returns a supported language tag in canonical
+// form, or "" if the input is empty / unsupported. Putting the gate here
+// keeps both Resolve (read side) and SetLanguage (write side) consistent.
+func normalizeLanguageOrEmpty(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	if normalized, ok := octoi18n.MatchSupportedLanguage(raw); ok {
+		return normalized
+	}
+	return ""
+}

--- a/modules/user/language_service_test.go
+++ b/modules/user/language_service_test.go
@@ -1,0 +1,312 @@
+package user
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeLangCache implements octo-lib cache.Cache for LanguageService tests
+// without spinning up Redis. The struct also records Set/Delete calls so
+// negative-cache and invalidation assertions can fire without timing tricks.
+type fakeLangCache struct {
+	store     map[string]string
+	expire    map[string]time.Duration
+	getErr    error
+	setErr    error
+	delErr    error
+	deletes   []string
+	setCalls  int
+}
+
+func newFakeLangCache() *fakeLangCache {
+	return &fakeLangCache{store: map[string]string{}, expire: map[string]time.Duration{}}
+}
+
+func (c *fakeLangCache) Set(key, value string) error {
+	if c.setErr != nil {
+		return c.setErr
+	}
+	c.store[key] = value
+	c.setCalls++
+	return nil
+}
+func (c *fakeLangCache) SetAndExpire(key, value string, exp time.Duration) error {
+	if c.setErr != nil {
+		return c.setErr
+	}
+	c.store[key] = value
+	c.expire[key] = exp
+	c.setCalls++
+	return nil
+}
+func (c *fakeLangCache) Get(key string) (string, error) {
+	if c.getErr != nil {
+		return "", c.getErr
+	}
+	return c.store[key], nil
+}
+func (c *fakeLangCache) Delete(key string) error {
+	c.deletes = append(c.deletes, key)
+	if c.delErr != nil {
+		return c.delErr
+	}
+	delete(c.store, key)
+	return nil
+}
+
+// fakeLangDB stubs the read+write surface so the service can be exercised
+// without a real *DB.
+type fakeLangDB struct {
+	lang    map[string]string
+	queryErr error
+	updates map[string]string
+	updateErr error
+	queryCalls int
+}
+
+func newFakeLangDB() *fakeLangDB {
+	return &fakeLangDB{lang: map[string]string{}, updates: map[string]string{}}
+}
+
+func (d *fakeLangDB) QueryLanguageByUID(uid string) (string, error) {
+	d.queryCalls++
+	if d.queryErr != nil {
+		return "", d.queryErr
+	}
+	return d.lang[uid], nil
+}
+func (d *fakeLangDB) UpdateLanguageByUID(uid, lang string) error {
+	if d.updateErr != nil {
+		return d.updateErr
+	}
+	d.updates[uid] = lang
+	return nil
+}
+
+// readOnlyLangDB intentionally omits UpdateLanguageByUID so SetLanguage can
+// assert the explicit "no write surface" path.
+type readOnlyLangDB struct{ lang map[string]string }
+
+func (d *readOnlyLangDB) QueryLanguageByUID(uid string) (string, error) {
+	return d.lang[uid], nil
+}
+
+func TestLanguageServiceResolveCacheHit(t *testing.T) {
+	t.Parallel()
+	c := newFakeLangCache()
+	_ = c.Set(LanguageCacheKeyPrefix+"u1", "zh-CN")
+	db := newFakeLangDB()
+	db.lang["u1"] = "en-US" // intentionally different to prove cache wins
+	svc := NewLanguageService(db, c)
+
+	got, err := svc.Resolve(context.Background(), "u1")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "zh-CN" {
+		t.Fatalf("want zh-CN from cache, got %q", got)
+	}
+	if db.queryCalls != 0 {
+		t.Fatalf("cache hit must not hit DB, but DB was queried %d times", db.queryCalls)
+	}
+}
+
+func TestLanguageServiceResolveNegativeCache(t *testing.T) {
+	t.Parallel()
+	c := newFakeLangCache()
+	_ = c.Set(LanguageCacheKeyPrefix+"u1", negativeMarker)
+	db := newFakeLangDB()
+	db.lang["u1"] = "zh-CN" // also intentional: negative cache must win
+	svc := NewLanguageService(db, c)
+
+	got, err := svc.Resolve(context.Background(), "u1")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("negative marker must return empty, got %q", got)
+	}
+	if db.queryCalls != 0 {
+		t.Fatalf("negative marker hit must not hit DB, got %d calls", db.queryCalls)
+	}
+}
+
+func TestLanguageServiceResolveCacheMissPopulatesCache(t *testing.T) {
+	t.Parallel()
+	c := newFakeLangCache()
+	db := newFakeLangDB()
+	db.lang["u1"] = "zh-CN"
+	svc := NewLanguageService(db, c)
+
+	got, err := svc.Resolve(context.Background(), "u1")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "zh-CN" {
+		t.Fatalf("want zh-CN, got %q", got)
+	}
+	if cached, _ := c.Get(LanguageCacheKeyPrefix + "u1"); cached != "zh-CN" {
+		t.Fatalf("cache should be populated with zh-CN, got %q", cached)
+	}
+	if c.expire[LanguageCacheKeyPrefix+"u1"] != LanguageCacheTTL {
+		t.Fatalf("expected TTL %s, got %s", LanguageCacheTTL, c.expire[LanguageCacheKeyPrefix+"u1"])
+	}
+}
+
+func TestLanguageServiceResolveCacheMissEmptyPopulatesNegativeMarker(t *testing.T) {
+	t.Parallel()
+	c := newFakeLangCache()
+	db := newFakeLangDB() // db has no preference for u1
+	svc := NewLanguageService(db, c)
+
+	got, err := svc.Resolve(context.Background(), "u1")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("want empty for no preference, got %q", got)
+	}
+	if cached, _ := c.Get(LanguageCacheKeyPrefix + "u1"); cached != negativeMarker {
+		t.Fatalf("cache should be populated with negative marker, got %q", cached)
+	}
+}
+
+func TestLanguageServiceResolveUnsupportedCacheValueDrops(t *testing.T) {
+	t.Parallel()
+	c := newFakeLangCache()
+	_ = c.Set(LanguageCacheKeyPrefix+"u1", "klingon")
+	db := newFakeLangDB()
+	db.lang["u1"] = "en-US"
+	svc := NewLanguageService(db, c)
+
+	got, err := svc.Resolve(context.Background(), "u1")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "en-US" {
+		t.Fatalf("want en-US from DB after dropping stale cache, got %q", got)
+	}
+	if len(c.deletes) == 0 || c.deletes[0] != LanguageCacheKeyPrefix+"u1" {
+		t.Fatalf("expected stale cache to be deleted, deletes=%v", c.deletes)
+	}
+}
+
+func TestLanguageServiceResolvePropagatesDBError(t *testing.T) {
+	t.Parallel()
+	c := newFakeLangCache()
+	db := newFakeLangDB()
+	db.queryErr = errors.New("connection refused")
+	svc := NewLanguageService(db, c)
+
+	got, err := svc.Resolve(context.Background(), "u1")
+	if err == nil {
+		t.Fatalf("expected DB error to propagate, got nil")
+	}
+	if !errors.Is(err, db.queryErr) {
+		t.Fatalf("err = %v, want wrap of %v", err, db.queryErr)
+	}
+	if got != "" {
+		t.Fatalf("on error result must be empty, got %q", got)
+	}
+}
+
+func TestLanguageServiceResolveEmptyUID(t *testing.T) {
+	t.Parallel()
+	svc := NewLanguageService(newFakeLangDB(), newFakeLangCache())
+	got, err := svc.Resolve(context.Background(), "")
+	if err != nil || got != "" {
+		t.Fatalf("empty uid must short-circuit, got (%q, %v)", got, err)
+	}
+}
+
+func TestLanguageServiceResolveContextCancelled(t *testing.T) {
+	t.Parallel()
+	svc := NewLanguageService(newFakeLangDB(), newFakeLangCache())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := svc.Resolve(ctx, "u1")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected ctx.Canceled, got %v", err)
+	}
+}
+
+func TestLanguageServiceSetLanguageHappyPath(t *testing.T) {
+	t.Parallel()
+	c := newFakeLangCache()
+	_ = c.Set(LanguageCacheKeyPrefix+"u1", "zh-CN") // existing hot entry
+	db := newFakeLangDB()
+	svc := NewLanguageService(db, c)
+
+	if err := svc.SetLanguage(context.Background(), "u1", "en-US"); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	if db.updates["u1"] != "en-US" {
+		t.Fatalf("db not updated, got %v", db.updates)
+	}
+	if len(c.deletes) == 0 || c.deletes[0] != LanguageCacheKeyPrefix+"u1" {
+		t.Fatalf("cache invalidation missed, deletes=%v", c.deletes)
+	}
+}
+
+func TestLanguageServiceSetLanguageRejectsUnsupported(t *testing.T) {
+	t.Parallel()
+	svc := NewLanguageService(newFakeLangDB(), newFakeLangCache())
+	err := svc.SetLanguage(context.Background(), "u1", "klingon")
+	if err == nil {
+		t.Fatal("expected error for unsupported language")
+	}
+}
+
+func TestLanguageServiceSetLanguageAcceptsEmptyToClear(t *testing.T) {
+	t.Parallel()
+	db := newFakeLangDB()
+	db.lang["u1"] = "zh-CN"
+	svc := NewLanguageService(db, newFakeLangCache())
+	if err := svc.SetLanguage(context.Background(), "u1", ""); err != nil {
+		t.Fatalf("SetLanguage with empty should clear: %v", err)
+	}
+	if db.updates["u1"] != "" {
+		t.Fatalf("expected DB to be cleared, got %q", db.updates["u1"])
+	}
+}
+
+func TestLanguageServiceSetLanguageWithoutWriteSurface(t *testing.T) {
+	t.Parallel()
+	svc := NewLanguageService(&readOnlyLangDB{lang: map[string]string{}}, newFakeLangCache())
+	err := svc.SetLanguage(context.Background(), "u1", "en-US")
+	if err == nil {
+		t.Fatal("expected error when underlying DB does not implement languageWriter")
+	}
+}
+
+func TestLanguageServiceSetLanguageEmptyUID(t *testing.T) {
+	t.Parallel()
+	svc := NewLanguageService(newFakeLangDB(), newFakeLangCache())
+	if err := svc.SetLanguage(context.Background(), "", "zh-CN"); err == nil {
+		t.Fatal("empty uid must error")
+	}
+}
+
+func TestNewLanguageServicePanicsOnNilDeps(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		fn   func()
+	}{
+		{"nil_db", func() { _ = NewLanguageService(nil, newFakeLangCache()) }},
+		{"nil_cache", func() { _ = NewLanguageService(newFakeLangDB(), nil) }},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("expected panic")
+				}
+			}()
+			tc.fn()
+		})
+	}
+}

--- a/pkg/auth/parser.go
+++ b/pkg/auth/parser.go
@@ -90,15 +90,22 @@ func (p *CacheTokenParser) Parse(ctx context.Context, token string) (wkhttp.User
 	}
 	language := info.Language
 	if p.resolver != nil {
-		// Resolver upgrades the token-cache snapshot to the authoritative
-		// preference (Redis/DB). Lookup failures keep the snapshot —
-		// authentication must not 5xx because user_language cache is
-		// momentarily unreachable. Empty resolver result is treated as
-		// "no explicit preference" and also leaves the snapshot intact;
-		// callers that want to clear a stale snapshot should write an
-		// empty value back to the cache instead of relying on the
-		// resolver's return.
-		if resolved, rerr := p.resolver.Resolve(ctx, info.UID); rerr == nil && resolved != "" {
+		// Resolver is the authoritative source per UserLanguageResolver's
+		// documented contract:
+		//   * rerr != nil  → keep the token-cache snapshot. Authentication
+		//     must not 5xx because user_language cache is momentarily
+		//     unreachable; the snapshot is the agreed last-resort fallback.
+		//   * resolved == "" (no error) → user has no explicit preference
+		//     right now (DB was cleared, negative-cache hit, or stored
+		//     value normalised away). Drop the snapshot so EarlyMiddleware's
+		//     Accept-Language / default decision wins downstream. Otherwise
+		//     a token minted earlier with a real language tag would keep
+		//     promoting LanguageSourceUser long after the user opted out
+		//     — a stale-read regression worth a dedicated test, see
+		//     parser_test.go::TestCacheTokenParserResolverEmptyClearsSnapshot.
+		//   * resolved != ""  → use the fresh authoritative value.
+		resolved, rerr := p.resolver.Resolve(ctx, info.UID)
+		if rerr == nil {
 			language = resolved
 		}
 	}

--- a/pkg/auth/parser.go
+++ b/pkg/auth/parser.go
@@ -10,32 +10,67 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 )
 
+// LanguageResolver hydrates UserInfo.Language with the freshest user-language
+// preference (Redis cache → DB → ""). It is intentionally a tiny interface
+// shaped at the consumer side so pkg/auth does not need to import the i18n
+// package or know about Redis / DB primitives. The concrete implementation
+// lives in modules/user.
+type LanguageResolver interface {
+	Resolve(ctx context.Context, uid string) (string, error)
+}
+
 // CacheTokenParser implements octo-lib's wkhttp.TokenParser using the shared
 // pkg/auth codec. It supersedes octo-lib's legacyTokenParser so that octo-server
 // can write v2 JSON envelopes while still decoding any legacy uid@name[@role]
 // values left in cache from older binaries.
 //
+// When a LanguageResolver is injected via WithLanguageResolver, Parse hits the
+// resolver after Decode to upgrade the token-cache language snapshot to the
+// authoritative value before octo-lib's AuthMiddleware stores UserInfo on the
+// request context. Resolver failures are non-fatal — the decoded snapshot is
+// preserved so a Redis/DB outage degrades to "stale language" rather than
+// "authentication failure".
+//
 // Construct once at boot and register with WKHttp.SetTokenParser; the parser
-// is safe for concurrent use as long as the underlying cache is.
+// is safe for concurrent use as long as the underlying cache + resolver are.
 type CacheTokenParser struct {
-	Cache  cache.Cache
-	Prefix string
+	Cache    cache.Cache
+	Prefix   string
+	resolver LanguageResolver
+}
+
+// ParserOption configures optional CacheTokenParser behaviour.
+type ParserOption func(*CacheTokenParser)
+
+// WithLanguageResolver wires a LanguageResolver into the parser; nil resolver
+// is a no-op so callers can pass an interface value that may be unset in test
+// environments without an extra guard.
+func WithLanguageResolver(r LanguageResolver) ParserOption {
+	return func(p *CacheTokenParser) {
+		if r != nil {
+			p.resolver = r
+		}
+	}
 }
 
 // NewCacheTokenParser is a convenience constructor; nil cache is a programmer
 // error and panics rather than silently degrading to a parser that fails every
 // request.
-func NewCacheTokenParser(c cache.Cache, prefix string) *CacheTokenParser {
+func NewCacheTokenParser(c cache.Cache, prefix string, opts ...ParserOption) *CacheTokenParser {
 	if c == nil {
 		panic("auth: NewCacheTokenParser requires non-nil cache")
 	}
-	return &CacheTokenParser{Cache: c, Prefix: prefix}
+	p := &CacheTokenParser{Cache: c, Prefix: prefix}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
 }
 
-// Parse implements wkhttp.TokenParser. The context is currently unused
-// (cache.Cache lookups are synchronous) but kept on the signature for future
-// upgrades — same rationale as octo-lib's legacy parser.
-func (p *CacheTokenParser) Parse(_ context.Context, token string) (wkhttp.UserInfo, error) {
+// Parse implements wkhttp.TokenParser. ctx is propagated to the optional
+// LanguageResolver so resolver implementations can honour deadlines /
+// cancellation set by the surrounding request.
+func (p *CacheTokenParser) Parse(ctx context.Context, token string) (wkhttp.UserInfo, error) {
 	if strings.TrimSpace(token) == "" {
 		return wkhttp.UserInfo{}, wkhttp.ErrTokenMissing
 	}
@@ -53,10 +88,24 @@ func (p *CacheTokenParser) Parse(_ context.Context, token string) (wkhttp.UserIn
 		}
 		return wkhttp.UserInfo{}, fmt.Errorf("%w: %v", wkhttp.ErrTokenInvalid, err)
 	}
+	language := info.Language
+	if p.resolver != nil {
+		// Resolver upgrades the token-cache snapshot to the authoritative
+		// preference (Redis/DB). Lookup failures keep the snapshot —
+		// authentication must not 5xx because user_language cache is
+		// momentarily unreachable. Empty resolver result is treated as
+		// "no explicit preference" and also leaves the snapshot intact;
+		// callers that want to clear a stale snapshot should write an
+		// empty value back to the cache instead of relying on the
+		// resolver's return.
+		if resolved, rerr := p.resolver.Resolve(ctx, info.UID); rerr == nil && resolved != "" {
+			language = resolved
+		}
+	}
 	return wkhttp.UserInfo{
 		UID:      info.UID,
 		Name:     info.Name,
 		Role:     info.Role,
-		Language: info.Language,
+		Language: language,
 	}, nil
 }

--- a/pkg/auth/parser_test.go
+++ b/pkg/auth/parser_test.go
@@ -175,7 +175,14 @@ func TestCacheTokenParserResolverFailureKeepsSnapshot(t *testing.T) {
 	}
 }
 
-func TestCacheTokenParserResolverEmptyKeepsSnapshot(t *testing.T) {
+// TestCacheTokenParserResolverEmptyClearsSnapshot pins the documented
+// UserLanguageResolver contract: an empty (no-error) resolver result is
+// authoritative "no explicit preference" and must drop the token-cache
+// snapshot so EarlyMiddleware's Accept-Language / default wins. Without
+// this, clearing user.language in the DB would not free a previously
+// minted token from a stale language until the next login — the very
+// stale-read regression flagged in PR #181 review.
+func TestCacheTokenParserResolverEmptyClearsSnapshot(t *testing.T) {
 	t.Parallel()
 	c := newFakeCache()
 	encoded, _ := Encode(TokenInfo{UID: "u1", Name: "alice", Language: "zh-CN"})
@@ -183,9 +190,12 @@ func TestCacheTokenParserResolverEmptyKeepsSnapshot(t *testing.T) {
 
 	resolver := &stubResolver{lang: ""}
 	p := NewCacheTokenParser(c, testPrefix, WithLanguageResolver(resolver))
-	got, _ := p.Parse(context.Background(), "tok1")
-	if got.Language != "zh-CN" {
-		t.Fatalf("Language = %q, want snapshot zh-CN (resolver returned empty)", got.Language)
+	got, err := p.Parse(context.Background(), "tok1")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got.Language != "" {
+		t.Fatalf("Language = %q, want \"\" (resolver authoritative empty must drop snapshot)", got.Language)
 	}
 }
 

--- a/pkg/auth/parser_test.go
+++ b/pkg/auth/parser_test.go
@@ -125,6 +125,85 @@ func TestCacheTokenParserPropagatesCacheError(t *testing.T) {
 	}
 }
 
+// stubResolver is used to exercise the LanguageResolver hook without pulling
+// modules/user into pkg/auth's test deps.
+type stubResolver struct {
+	lang string
+	err  error
+	gotUID string
+}
+
+func (s *stubResolver) Resolve(_ context.Context, uid string) (string, error) {
+	s.gotUID = uid
+	return s.lang, s.err
+}
+
+func TestCacheTokenParserResolverUpgradesLanguage(t *testing.T) {
+	t.Parallel()
+	c := newFakeCache()
+	encoded, _ := Encode(TokenInfo{UID: "u1", Name: "alice", Role: "admin", Language: "zh-CN"})
+	_ = c.Set(testPrefix+"tok1", encoded)
+
+	resolver := &stubResolver{lang: "en-US"}
+	p := NewCacheTokenParser(c, testPrefix, WithLanguageResolver(resolver))
+	got, err := p.Parse(context.Background(), "tok1")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got.Language != "en-US" {
+		t.Fatalf("Language = %q, want resolver value en-US", got.Language)
+	}
+	if resolver.gotUID != "u1" {
+		t.Fatalf("resolver got uid %q, want u1", resolver.gotUID)
+	}
+}
+
+func TestCacheTokenParserResolverFailureKeepsSnapshot(t *testing.T) {
+	t.Parallel()
+	c := newFakeCache()
+	encoded, _ := Encode(TokenInfo{UID: "u1", Name: "alice", Language: "zh-CN"})
+	_ = c.Set(testPrefix+"tok1", encoded)
+
+	resolver := &stubResolver{err: errors.New("redis down")}
+	p := NewCacheTokenParser(c, testPrefix, WithLanguageResolver(resolver))
+	got, err := p.Parse(context.Background(), "tok1")
+	if err != nil {
+		t.Fatalf("Parse must not surface resolver failure, got %v", err)
+	}
+	if got.Language != "zh-CN" {
+		t.Fatalf("Language = %q, want snapshot zh-CN (resolver failed)", got.Language)
+	}
+}
+
+func TestCacheTokenParserResolverEmptyKeepsSnapshot(t *testing.T) {
+	t.Parallel()
+	c := newFakeCache()
+	encoded, _ := Encode(TokenInfo{UID: "u1", Name: "alice", Language: "zh-CN"})
+	_ = c.Set(testPrefix+"tok1", encoded)
+
+	resolver := &stubResolver{lang: ""}
+	p := NewCacheTokenParser(c, testPrefix, WithLanguageResolver(resolver))
+	got, _ := p.Parse(context.Background(), "tok1")
+	if got.Language != "zh-CN" {
+		t.Fatalf("Language = %q, want snapshot zh-CN (resolver returned empty)", got.Language)
+	}
+}
+
+func TestWithLanguageResolverNilIsNoOp(t *testing.T) {
+	t.Parallel()
+	c := newFakeCache()
+	encoded, _ := Encode(TokenInfo{UID: "u1", Name: "alice"})
+	_ = c.Set(testPrefix+"tok1", encoded)
+
+	p := NewCacheTokenParser(c, testPrefix, WithLanguageResolver(nil))
+	if p.resolver != nil {
+		t.Fatal("nil resolver option must not set the field")
+	}
+	if _, err := p.Parse(context.Background(), "tok1"); err != nil {
+		t.Fatalf("Parse should still succeed without a resolver, got %v", err)
+	}
+}
+
 func TestNewCacheTokenParserPanicsOnNilCache(t *testing.T) {
 	t.Parallel()
 	defer func() {

--- a/pkg/i18n/ctx.go
+++ b/pkg/i18n/ctx.go
@@ -1,6 +1,10 @@
 package i18n
 
-import "context"
+import (
+	"context"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+)
 
 type languageContextKey struct{}
 
@@ -30,12 +34,31 @@ func WithLanguageIfHigherPriority(ctx context.Context, decision LanguageDecision
 }
 
 // LanguageFromContext 读取 context 中的语言协商结果。
+//
+// 除了 EarlyMiddleware 在 ctx 中写入的早期协商决策（trusted header / query /
+// cookie / Accept-Language / default），本函数还会顺带读取
+// wkhttp.UserFromCtx() 注入的 UserInfo.Language——它是 AuthMiddleware 经由
+// CacheTokenParser + UserLanguageResolver 解析出的"用户偏好真相源"。
+//
+// D9 两段式协商：EarlyMiddleware 不能在 Auth 前知道 user.language，所以这里把
+// "用户偏好覆盖" 做成读侧延迟合并。只有当 user.language 非空且来源优先级
+// （LanguageSourceUser=30）严格高于 ctx 中现有决策时（典型场景：现有为
+// LanguageSourceAccept=20 或 LanguageSourceDefault=10），才让用户偏好生效。
+// trusted header / query / cookie 这类显式选择仍然胜出（D6 优先级顺序）。
 func LanguageFromContext(ctx context.Context) (LanguageDecision, bool) {
 	if ctx == nil {
 		return LanguageDecision{}, false
 	}
 	decision, ok := ctx.Value(languageContextKey{}).(LanguageDecision)
-	if !ok || decision.Language == "" {
+	if ok && decision.Language == "" {
+		ok = false
+	}
+	if user, hasUser := wkhttp.UserFromCtx(ctx); hasUser && user.Language != "" {
+		if !ok || languageSourcePriority(LanguageSourceUser) > languageSourcePriority(decision.Source) {
+			return LanguageDecision{Language: user.Language, Source: LanguageSourceUser}, true
+		}
+	}
+	if !ok {
 		return LanguageDecision{}, false
 	}
 	return decision, true

--- a/pkg/i18n/ctx_test.go
+++ b/pkg/i18n/ctx_test.go
@@ -3,6 +3,8 @@ package i18n
 import (
 	"context"
 	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 )
 
 func TestContextLanguageRoundTrip(t *testing.T) {
@@ -60,6 +62,96 @@ func TestWithLanguageIfHigherPriority(t *testing.T) {
 	got, _ = LanguageFromContext(ctx)
 	if got.Language != "en-US" || got.Source != LanguageSourceCookie {
 		t.Fatalf("after lower-priority override = %#v", got)
+	}
+}
+
+// TestLanguageFromContextPromotesUserLanguage 验证 D9 两段式协商的读侧合并：
+// 当 ctx 中早期协商结果优先级低于 LanguageSourceUser 时，UserInfo.Language
+// 应在读取时被提升为最终决策。
+func TestLanguageFromContextPromotesUserLanguage(t *testing.T) {
+	cases := []struct {
+		name        string
+		existing    *LanguageDecision
+		userLang    string
+		wantLang    string
+		wantSource  LanguageSource
+		wantPresent bool
+	}{
+		{
+			name:        "promotes_over_accept",
+			existing:    &LanguageDecision{Language: "en-US", Source: LanguageSourceAccept},
+			userLang:    "zh-CN",
+			wantLang:    "zh-CN",
+			wantSource:  LanguageSourceUser,
+			wantPresent: true,
+		},
+		{
+			name:        "promotes_over_default",
+			existing:    &LanguageDecision{Language: "en-US", Source: LanguageSourceDefault},
+			userLang:    "zh-CN",
+			wantLang:    "zh-CN",
+			wantSource:  LanguageSourceUser,
+			wantPresent: true,
+		},
+		{
+			name:        "cookie_wins_over_user",
+			existing:    &LanguageDecision{Language: "en-US", Source: LanguageSourceCookie},
+			userLang:    "zh-CN",
+			wantLang:    "en-US",
+			wantSource:  LanguageSourceCookie,
+			wantPresent: true,
+		},
+		{
+			name:        "trusted_header_wins_over_user",
+			existing:    &LanguageDecision{Language: "en-US", Source: LanguageSourceTrustedHeader},
+			userLang:    "zh-CN",
+			wantLang:    "en-US",
+			wantSource:  LanguageSourceTrustedHeader,
+			wantPresent: true,
+		},
+		{
+			name:        "empty_user_language_no_promotion",
+			existing:    &LanguageDecision{Language: "en-US", Source: LanguageSourceAccept},
+			userLang:    "",
+			wantLang:    "en-US",
+			wantSource:  LanguageSourceAccept,
+			wantPresent: true,
+		},
+		{
+			name:        "no_existing_decision_user_promotes",
+			existing:    nil,
+			userLang:    "zh-CN",
+			wantLang:    "zh-CN",
+			wantSource:  LanguageSourceUser,
+			wantPresent: true,
+		},
+		{
+			name:        "no_existing_no_user",
+			existing:    nil,
+			userLang:    "",
+			wantPresent: false,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.existing != nil {
+				ctx = WithLanguage(ctx, *tc.existing)
+			}
+			ctx = wkhttp.WithUser(ctx, wkhttp.UserInfo{UID: "u1", Language: tc.userLang})
+
+			got, ok := LanguageFromContext(ctx)
+			if ok != tc.wantPresent {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantPresent)
+			}
+			if !tc.wantPresent {
+				return
+			}
+			if got.Language != tc.wantLang || got.Source != tc.wantSource {
+				t.Fatalf("got %+v, want lang=%q source=%q", got, tc.wantLang, tc.wantSource)
+			}
+		})
 	}
 }
 

--- a/pkg/i18n/middleware.go
+++ b/pkg/i18n/middleware.go
@@ -14,8 +14,12 @@ type MiddlewareOptions struct {
 }
 
 // EarlyMiddleware negotiates language before auth and stores the decision in
-// request context. User-language override is intentionally left for a later
-// late-stage middleware once the DB/Redis/token source of truth is available.
+// request context. The user-language override is applied lazily on the read
+// side by LanguageFromContext (see ctx.go) so handlers and renderers see the
+// merged decision without per-route post-auth middleware. The wrapped
+// response writer keeps the Content-Language header consistent with that
+// merged decision for successful responses (the ErrorRenderer path already
+// re-evaluates at render time).
 func EarlyMiddleware(opts MiddlewareOptions) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		decision := NegotiateLanguage(c.Request, LanguageNegotiationOptions{
@@ -26,6 +30,7 @@ func EarlyMiddleware(opts MiddlewareOptions) gin.HandlerFunc {
 		c.Request = c.Request.WithContext(WithLanguage(c.Request.Context(), decision))
 		c.Writer.Header().Set("Content-Language", decision.Language)
 		addVary(c.Writer.Header(), "Accept-Language", HeaderOctoLang, "Cookie")
+		c.Writer = newContentLanguageWriter(c, decision.Language)
 		c.Next()
 	}
 }

--- a/pkg/i18n/middleware_test.go
+++ b/pkg/i18n/middleware_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/gin-gonic/gin"
 )
 
@@ -33,6 +34,131 @@ func TestEarlyMiddlewareNegotiatesLanguageIntoRequestContext(t *testing.T) {
 
 	if got := rec.Header().Get("Content-Language"); got != "zh-CN" {
 		t.Fatalf("Content-Language = %q, want zh-CN", got)
+	}
+}
+
+// TestEarlyMiddlewareContentLanguageReflectsUserMerge covers the deferred
+// Content-Language refresh: after AuthMiddleware-like code injects a
+// UserInfo whose Language outranks the pre-auth decision, the response
+// header must advertise the merged language regardless of how the handler
+// writes the body. This guards against the regression flagged in PR #181
+// review where success responses kept the pre-auth Content-Language even
+// when LanguageFromContext promoted to LanguageSourceUser.
+func TestEarlyMiddlewareContentLanguageReflectsUserMerge(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// simulateAuth stands in for octo-lib AuthMiddleware: it replaces
+	// c.Request with one carrying UserInfo on the context. The writer
+	// wrapper must read the *latest* request context, not a snapshot
+	// captured at wrap time.
+	simulateAuth := func(lang string) gin.HandlerFunc {
+		return func(c *gin.Context) {
+			c.Request = c.Request.WithContext(
+				wkhttp.WithUser(c.Request.Context(), wkhttp.UserInfo{UID: "u1", Language: lang}),
+			)
+			c.Next()
+		}
+	}
+
+	cases := []struct {
+		name       string
+		earlyLang  string // negotiated language hint via Accept-Language
+		userLang   string
+		write      func(*gin.Context)
+		wantHeader string
+	}{
+		{
+			name:      "Write_json_promotes",
+			earlyLang: "en-US",
+			userLang:  "zh-CN",
+			write: func(c *gin.Context) {
+				c.JSON(http.StatusOK, gin.H{"ok": true})
+			},
+			wantHeader: "zh-CN",
+		},
+		{
+			name:      "WriteString_promotes",
+			earlyLang: "en-US",
+			userLang:  "zh-CN",
+			write: func(c *gin.Context) {
+				c.String(http.StatusOK, "hello")
+			},
+			wantHeader: "zh-CN",
+		},
+		{
+			name:      "WriteHeaderNow_noBody_promotes",
+			earlyLang: "en-US",
+			userLang:  "zh-CN",
+			write: func(c *gin.Context) {
+				c.Status(http.StatusNoContent)
+				c.Writer.WriteHeaderNow()
+			},
+			wantHeader: "zh-CN",
+		},
+		{
+			name:      "user_lang_matches_early_no_op",
+			earlyLang: "en-US",
+			userLang:  "en-US",
+			write: func(c *gin.Context) {
+				c.JSON(http.StatusOK, gin.H{"ok": true})
+			},
+			wantHeader: "en-US",
+		},
+		{
+			name:      "empty_user_lang_keeps_early",
+			earlyLang: "en-US",
+			userLang:  "",
+			write: func(c *gin.Context) {
+				c.JSON(http.StatusOK, gin.H{"ok": true})
+			},
+			wantHeader: "en-US",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			r := gin.New()
+			r.Use(EarlyMiddleware(MiddlewareOptions{DefaultLanguage: SourceLanguage}))
+			r.Use(simulateAuth(tc.userLang))
+			r.GET("/x", tc.write)
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/x", nil)
+			req.Header.Set("Accept-Language", tc.earlyLang)
+			r.ServeHTTP(rec, req)
+
+			if got := rec.Header().Get("Content-Language"); got != tc.wantHeader {
+				t.Fatalf("Content-Language = %q, want %q", got, tc.wantHeader)
+			}
+		})
+	}
+}
+
+// TestEarlyMiddlewareContentLanguageDoesNotDowngrade ensures explicit
+// cookie / trusted-header / query selections continue to win over the
+// user preference at the merge stage — the read-side merge must respect
+// the same priority ladder applied at NegotiateLanguage time.
+func TestEarlyMiddlewareContentLanguageDoesNotDowngrade(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(EarlyMiddleware(MiddlewareOptions{DefaultLanguage: SourceLanguage}))
+	r.Use(func(c *gin.Context) {
+		c.Request = c.Request.WithContext(
+			wkhttp.WithUser(c.Request.Context(), wkhttp.UserInfo{UID: "u1", Language: "en-US"}),
+		)
+		c.Next()
+	})
+	r.GET("/x", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.AddCookie(&http.Cookie{Name: CookieLanguage, Value: "zh-CN"})
+	r.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Content-Language"); got != "zh-CN" {
+		t.Fatalf("Content-Language = %q, want zh-CN (cookie must outrank user)", got)
 	}
 }
 

--- a/pkg/i18n/response_writer.go
+++ b/pkg/i18n/response_writer.go
@@ -1,0 +1,68 @@
+package i18n
+
+import "github.com/gin-gonic/gin"
+
+// contentLanguageWriter is a gin.ResponseWriter shim that refreshes the
+// Content-Language header right before the response is committed.
+//
+// EarlyMiddleware writes a tentative Content-Language based on the pre-auth
+// negotiation (Accept-Language / default). AuthMiddleware later hydrates
+// wkhttp.UserInfo on the request context, after which LanguageFromContext
+// performs the read-side late-stage merge and may return a higher-priority
+// LanguageSourceUser decision (D9). Without this wrapper, success responses
+// would keep advertising the pre-auth Content-Language even when the body
+// was already localised to the user's preferred language — observably wrong
+// per RFC 9110 and inconsistent with ErrorRenderer, which already
+// re-evaluates the language at render time.
+//
+// Why a writer wrapper rather than a post-auth gin middleware: AuthMiddleware
+// is mounted per route group, not globally, and there are ~36 mount sites.
+// Wrapping the writer once in EarlyMiddleware avoids touching every group
+// and keeps the late-merge invariant local to pkg/i18n.
+//
+// Header mutation timing: gin's responseWriter buffers headers until
+// WriteHeaderNow is called (either explicitly or via Write/WriteString).
+// Overriding those three methods to first stamp Content-Language guarantees
+// the header reflects the final merged decision regardless of how the
+// handler writes the body (c.JSON, c.String, c.Data, …).
+type contentLanguageWriter struct {
+	gin.ResponseWriter
+	c         *gin.Context
+	earlyLang string
+}
+
+func newContentLanguageWriter(c *gin.Context, earlyLang string) *contentLanguageWriter {
+	return &contentLanguageWriter{ResponseWriter: c.Writer, c: c, earlyLang: earlyLang}
+}
+
+// applyLanguage stamps the late-merged Content-Language onto the response.
+// Idempotent and best-effort: once Written() is true the header has already
+// shipped and any update would be silently ignored, so the method short-
+// circuits. Reading LanguageFromContext lazily — rather than capturing a
+// snapshot at wrap time — is essential because AuthMiddleware replaces
+// c.Request to inject the UserInfo-bearing context.
+func (w *contentLanguageWriter) applyLanguage() {
+	if w.Written() {
+		return
+	}
+	decision, ok := LanguageFromContext(w.c.Request.Context())
+	if !ok || decision.Language == "" || decision.Language == w.earlyLang {
+		return
+	}
+	w.Header().Set("Content-Language", decision.Language)
+}
+
+func (w *contentLanguageWriter) Write(data []byte) (int, error) {
+	w.applyLanguage()
+	return w.ResponseWriter.Write(data)
+}
+
+func (w *contentLanguageWriter) WriteString(s string) (int, error) {
+	w.applyLanguage()
+	return w.ResponseWriter.WriteString(s)
+}
+
+func (w *contentLanguageWriter) WriteHeaderNow() {
+	w.applyLanguage()
+	w.ResponseWriter.WriteHeaderNow()
+}

--- a/pkg/i18n/user_resolver.go
+++ b/pkg/i18n/user_resolver.go
@@ -1,0 +1,27 @@
+package i18n
+
+import "context"
+
+// UserLanguageResolver returns the authoritative language preference for an
+// authenticated user. Implementations are expected to consult a hot cache
+// (e.g. Redis `user_language:{uid}`) first and fall back to the persistent
+// store (`user.language` column) on cache miss, then write the result back
+// to the cache.
+//
+// Contract:
+//   - An empty return string means "no explicit preference"; callers must
+//     then fall back to the language already negotiated by EarlyMiddleware
+//     (Accept-Language / default).
+//   - A non-nil error means the lookup itself failed (cache + DB both
+//     unreachable). Callers should keep going with the snapshot value
+//     already carried by the token rather than 5xx-ing the request.
+//   - Implementations are responsible for input/output validation; if a
+//     stored value isn't a supported language tag, returning "" is the
+//     safe default.
+//
+// The resolver is hooked into pkg/auth.CacheTokenParser so the resolved
+// language ends up on wkhttp.UserInfo.Language, which LanguageFromContext
+// then merges into the i18n language decision (LanguageSourceUser priority).
+type UserLanguageResolver interface {
+	Resolve(ctx context.Context, uid string) (string, error)
+}


### PR DESCRIPTION
## Summary

Builds on #179 (now merged): wires the user-language source of truth into
the i18n stack. `AuthMiddleware` now hydrates `wkhttp.UserInfo.Language`
from a Redis-backed `user_language:{uid}` hot cache that falls back to
the new `user.language` column. `LanguageFromContext` merges that value
into the language decision at read time, so any subsequent handler or
renderer sees the user's preference without per-route-group middleware
changes.

Token writes also stamp the resolved language into the v2 envelope as a
last-resort snapshot. The user-facing `PUT /v1/user/language` and the
`language` field on `GET /v1/user` are deliberately deferred to the
follow-up PR so this change stays infrastructure-only.

## Scope

**`pkg/i18n`**
- `LanguageFromContext` now reads `wkhttp.UserFromCtx`. If `UserInfo.Language`
  is non-empty AND the existing in-context decision is at most
  `LanguageSourceAccept` / `LanguageSourceDefault`, the merge promotes the
  decision to `LanguageSourceUser`. Explicit user choices via trusted header,
  query, or cookie continue to win — same priority ladder as before.
- New `UserLanguageResolver` interface documents the cache + DB contract
  that the concrete implementation must satisfy.

**`pkg/auth.CacheTokenParser`**
- New `LanguageResolver` extension point (tiny consumer-side interface, no
  reverse dependency on `modules/user` or `pkg/i18n`).
- Wired via the functional option `WithLanguageResolver`; nil resolver is
  a no-op so older boot wiring keeps working unchanged.
- `Parse` propagates the request context to the resolver and falls back to
  the token-cache snapshot on resolver error or empty result. A Redis or
  DB outage degrades to "language is stale" rather than "authentication
  failed".

**`modules/user.LanguageService`**
- Implements both `pkg/auth.LanguageResolver` and the documented
  `pkg/i18n.UserLanguageResolver` contract (structural duck typing — no
  import cycle).
- Read path: Redis `user_language:{uid}` → `user.language` column → "".
- Write-through caches the DB result (5-minute TTL). A `-` sentinel value
  marks "user has no explicit preference" so users without a saved
  preference don't hit the DB on every request — the marker is unambiguous
  because BCP 47 forbids a hyphen as the first character of any subtag.
- `SetLanguage` validates against the supported language matrix, persists
  to the DB, and actively `DEL`s the hot cache so a cross-device language
  switch converges on the next request anywhere in the cluster.
- New DB helpers: `QueryLanguageByUID` (single-column SELECT for the hot
  path) and `UpdateLanguageByUID`.

**Boot wiring (`main.go`)**
- Constructs `LanguageService` with `user.NewDB(ctx)` + `ctx.Cache()` and
  passes it to `CacheTokenParser` via the new option.

**Token write sites populate `Language`**
- The six write sites switched to `auth.Encode` in #179 now stamp the
  user's current language into the v2 envelope (snapshot fallback).
- `modules/user/api.go` profile-rename specifically decodes the old token,
  preserves `Language`, and re-encodes — renaming no longer wipes the
  language preference snapshot.
- `managerLoginModel` gains a `Language` field; `Select("*")` already
  returns the column so no query change was needed.

## Out of scope (follow-up)

- `PUT /v1/user/language` HTTP endpoint
- `language` field on `GET /v1/user` response
- CI lint that bans new ad-hoc `strings.Split("@")` on token-cache values

## Backward compatibility

- `LanguageService` is purely additive infrastructure. Without an injected
  resolver, `CacheTokenParser` retains the exact PR #179 behaviour.
- Tokens written before this change carry an empty `Language` field; the
  resolver fills it on first authenticated request and writes the
  result back to the hot cache, so the steady state converges within one
  request per user without a forced re-login.
- The negative cache sentinel `-` is read-only for now; if a future
  release relaxes the supported language matrix, a stored `-` is still
  understood as "no preference".

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -cover ./pkg/auth/...` — 96.0% coverage; new tests
      cover resolver upgrade, resolver-error fallback, empty resolver
      result, and the `nil` option no-op.
- [x] `go test -race -cover ./pkg/i18n/...` — 82.6%; 8-case table covers
      promote-over-accept, promote-over-default, cookie/trusted-header
      override, empty user language, and missing existing decision.
- [x] `go test -race -cover ./modules/user/...` — 14-case table covers
      cache hit / negative marker / cache miss / stale-cache-drop / DB
      error / empty UID / cancelled context / SetLanguage happy path /
      unsupported language / clear-to-empty / read-only backend / nil
      dependency panic.
- [x] Reset and re-run the module suites that seed legacy token cache
      values (user / message / group / qrcode / thread / category / space
      / robot / common) — all green; the legacy `uid@test` fixtures still
      decode correctly because the resolver does not break the snapshot
      path.
- [ ] CI Build / Test / Vet / Lint / CodeQL on the merged base.
- [ ] Reviewer spot check on a staging-style deploy: confirm a
      cross-device language switch is visible on the second device within
      one request after `SetLanguage` (the active `DEL` on the hot key).

## Risk

| Risk | Mitigation |
|---|---|
| Redis outage knocks out authentication | Resolver errors are swallowed at the parser; auth continues with the token-cache snapshot, just with stale language. Unit test `TestCacheTokenParserResolverFailureKeepsSnapshot` guards this. |
| DB load spike from "no preference" users | Negative cache (`-` sentinel, 5-minute TTL) — verified in `TestLanguageServiceResolveCacheMissEmptyPopulatesNegativeMarker`. |
| Cross-device language switch lag | `SetLanguage` actively `DEL`s the hot key, so other nodes pick the new value up on their next read instead of waiting the full TTL. Worst case after a missed `DEL` is one TTL of staleness. |
| `LanguageFromContext` accidentally downgrading explicit choices | Priority ladder enforced in the merge: only `Accept` / `default` get promoted; `cookie`, `query`, `trusted_header` still win. Table tests cover both directions. |
| Stale cache survives a language-matrix narrowing | Resolver re-validates cached values via `MatchSupportedLanguage` and deletes anything that no longer matches before falling back to DB. |