### PR TITLE
feat(user): expose language preference via /v1/user/* API

### DIFF
--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -96,6 +96,7 @@ type User struct {
 	appService               app.IService
 	loginGuard               *LoginGuard
 	verificationDB           *verificationDB
+	languageService          *LanguageService
 }
 
 // New New
@@ -131,6 +132,10 @@ func New(ctx *config.Context) *User {
 		spaceSettingDB:           NewSpaceSettingDB(ctx.DB()),
 		verificationDB:           newVerificationDB(ctx),
 	}
+	// LanguageService 与 main.go 注入到 CacheTokenParser 的实例独立构造，但共享
+	// 底层 *DB session / Redis 连接，因此读写同一份 user.language 列与
+	// user_language:{uid} 热缓存，行为等价。这样 handler 不需要 main.go 反向注入。
+	u.languageService = NewLanguageService(u.db, ctx.Cache())
 	u.pinned = NewPinned(u.pinnedDB, u.friendDB)
 	InitGlobalPinnedDB(ctx) // 初始化全局 PinnedDB 供其他模块调用
 	u.updateSystemUserToken()
@@ -186,6 +191,7 @@ func (u *User) Route(r *wkhttp.WKHttp) {
 		user.GET("/grant_login", u.grantLogin)                     // 授权登录
 		user.GET("/current", u.currentUser)                        // 获取当前登录用户信息（含 self 实名字段）
 		user.PUT("/current", u.userUpdateWithField)                //修改用户信息
+		user.PUT("/language", u.setLanguage)                       // 设置当前用户语言偏好（i18n）
 		user.GET("/qrcode", u.qrcodeMy)                            // 我的二维码
 		user.PUT("/my/setting", u.userUpdateSetting)               // 更新我的设置
 		user.POST("/blacklist/:uid", u.addBlacklist)               //添加黑名单
@@ -717,6 +723,38 @@ func (u *User) currentUser(c *wkhttp.Context) {
 	resp := newLoginUserDetailResp(userInfo, c.GetHeader("token"), u.ctx)
 	u.applyRealnameToLoginResp(resp, userInfo.UID)
 	c.Response(resp)
+}
+
+// setLanguageReq 接收 PUT /v1/user/language 的请求体。Language 为空字符串
+// 表示清空偏好（回到 OCTO_DEFAULT_LANGUAGE 语义）；非空时由 LanguageService
+// 走 MatchSupportedLanguage 严格校验，不在支持矩阵内一律拒绝。
+type setLanguageReq struct {
+	Language string `json:"language"`
+}
+
+// setLanguage 更新当前用户的语言偏好。DB 持久化 + Redis user_language:{uid} 主动
+// DEL 由 LanguageService 处理；其他端的 token 缓存快照不会刷新——见 PR #181 的
+// 设计说明，下次请求由 AuthMiddleware 的 LanguageResolver 自动 hydrate 出
+// 新值，无需强制重新登录。
+func (u *User) setLanguage(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+	if loginUID == "" {
+		c.ResponseError(errors.New("未登录"))
+		return
+	}
+	var req setLanguageReq
+	if err := c.BindJSON(&req); err != nil {
+		u.Error("language 请求体格式错误", zap.Error(err), zap.String("uid", loginUID))
+		c.ResponseError(errors.New("数据格式有误！"))
+		return
+	}
+	if err := u.languageService.SetLanguage(c.Request.Context(), loginUID, req.Language); err != nil {
+		u.Error("设置用户语言偏好失败",
+			zap.Error(err), zap.String("uid", loginUID), zap.String("language", req.Language))
+		c.ResponseError(err)
+		return
+	}
+	c.ResponseOK()
 }
 
 // 修改用户信息
@@ -3429,6 +3467,10 @@ type loginUserDetailResp struct {
 	RSAPublicKey    string  `json:"rsa_public_key"` // 应用公钥做一些消息验证 base64编码
 	ShortStatus     int     `json:"short_status"`
 	MsgExpireSecond int64   `json:"msg_expire_second"` // 消息过期时长
+	// Language 是用户语言偏好（BCP 47，空字符串表示"未显式设置，沿用 OCTO_DEFAULT_LANGUAGE"）。
+	// 客户端读到非空值时应当持久化到本地并随后续请求带 X-Octo-Lang / cookie；
+	// 读到空值时不要本地强行回填一个默认，避免覆盖服务端的"未设置"状态。
+	Language string `json:"language"`
 	// 注销状态提示：仅当账号处于冷静期（is_destroy=1）时下发
 	// DestroyStatus: 0=正常 1=注销申请中
 	// DestroyRemainingDays: 距到期还剩天数（向上取整，最小 0）
@@ -3495,6 +3537,7 @@ func newLoginUserDetailResp(m *Model, token string, ctx *config.Context) *loginU
 		ShortStatus:          m.ShortStatus,
 		RSAPublicKey:         base64.StdEncoding.EncodeToString([]byte(ctx.GetConfig().AppRSAPubKey)),
 		MsgExpireSecond:      m.MsgExpireSecond,
+		Language:             m.Language,
 		Setting: setting{
 			SearchByPhone:     m.SearchByPhone,
 			SearchByShort:     m.SearchByShort,

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -191,7 +191,7 @@ func (u *User) Route(r *wkhttp.WKHttp) {
 		user.GET("/grant_login", u.grantLogin)                     // 授权登录
 		user.GET("/current", u.currentUser)                        // 获取当前登录用户信息（含 self 实名字段）
 		user.PUT("/current", u.userUpdateWithField)                //修改用户信息
-		user.PUT("/language", u.setLanguage)                       // 设置当前用户语言偏好（i18n）
+		user.PUT("/language", u.setLanguage)                       // 设置当前用户语言偏好（i18n）；依赖 group 上的 AuthMiddleware 注入 uid，handler 内仍保留 belt-and-braces 检查
 		user.GET("/qrcode", u.qrcodeMy)                            // 我的二维码
 		user.PUT("/my/setting", u.userUpdateSetting)               // 更新我的设置
 		user.POST("/blacklist/:uid", u.addBlacklist)               //添加黑名单
@@ -720,6 +720,13 @@ func (u *User) currentUser(c *wkhttp.Context) {
 	}
 	// token 回显请求头 token：/user/current 不换发 token,避免干扰现有会话;
 	// 客户端本身就用这个 token 调的接口,回填仅为结构对齐 login response。
+	//
+	// Language 字段直接来自 userInfo.Language（DB SELECT *）——刻意不走
+	// LanguageService.Resolve / user_language:{uid} 热缓存：这里既然已经为
+	// 其他字段拉了完整行，再读 Redis 只会引入"刚 PUT 完语言 → DEL 命中 →
+	// Resolve 反取 DB → 写回热缓存"的多余 RTT，而且会让 GET 在 SetLanguage
+	// 失效窗口里看到 Redis 的旧值（DB 已新但 SET 未到）。热缓存的存在意义
+	// 是保护 AuthMiddleware 那条每请求都走的 hot path；/current 不在此列。
 	resp := newLoginUserDetailResp(userInfo, c.GetHeader("token"), u.ctx)
 	u.applyRealnameToLoginResp(resp, userInfo.UID)
 	c.Response(resp)

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -739,6 +739,13 @@ type setLanguageReq struct {
 	Language string `json:"language"`
 }
 
+// languageMaxLen 上界 BCP 47 tag 在落入服务层 / 日志前的字节长度。即使最长
+// 的合法标签（如 `zh-Hant-HK-x-private-extension`）也不会超过 ~35 字符；
+// DB 列定义 VARCHAR(16)。设 64 留 ~80% 余量，并在 handler 入口短路超长
+// payload，避免任意大小的客户端输入先被 zap.String 写进日志再被拒（PR
+// #182 reviewer 标的 log amplification 面）。
+const languageMaxLen = 64
+
 // setLanguage 更新当前用户的语言偏好。DB 持久化 + Redis user_language:{uid} 主动
 // DEL 由 LanguageService 处理；其他端的 token 缓存快照不会刷新——见 PR #181 的
 // 设计说明，下次请求由 AuthMiddleware 的 LanguageResolver 自动 hydrate 出
@@ -755,10 +762,25 @@ func (u *User) setLanguage(c *wkhttp.Context) {
 		c.ResponseError(errors.New("数据格式有误！"))
 		return
 	}
+	// Length gate runs BEFORE any zap.String("language", req.Language) so an
+	// attacker can't amplify a multi-KB payload into the log pipeline.
+	if len(req.Language) > languageMaxLen {
+		u.Error("language 请求过长", zap.String("uid", loginUID), zap.Int("len", len(req.Language)))
+		c.ResponseError(errors.New("数据格式有误！"))
+		return
+	}
 	if err := u.languageService.SetLanguage(c.Request.Context(), loginUID, req.Language); err != nil {
+		// Always log the wrapped service error server-side; only the
+		// classified user-facing message goes back on the wire so internal
+		// package prefixes / DB driver text don't leak. Matches the local
+		// convention in userUpdateWithField and neighbouring handlers.
 		u.Error("设置用户语言偏好失败",
 			zap.Error(err), zap.String("uid", loginUID), zap.String("language", req.Language))
-		c.ResponseError(err)
+		if errors.Is(err, ErrUnsupportedLanguage) {
+			c.ResponseError(errors.New("不支持的语言"))
+			return
+		}
+		c.ResponseError(errors.New("设置语言偏好失败！"))
 		return
 	}
 	c.ResponseOK()

--- a/modules/user/api_language_test.go
+++ b/modules/user/api_language_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -102,6 +103,67 @@ func TestSetLanguageHandler_RejectsUnsupported(t *testing.T) {
 	}
 	if len(db.updates) != 0 {
 		t.Fatalf("unsupported language must not touch DB, got %v", db.updates)
+	}
+	// User-facing message is the classified "unsupported" copy, not the raw
+	// service-layer error (which contains the `user:` package prefix). Guards
+	// against information disclosure flagged in PR #182 review.
+	respBody := rec.Body.String()
+	if !strings.Contains(respBody, "不支持的语言") {
+		t.Fatalf("response body should carry classified message, got %s", respBody)
+	}
+	if strings.Contains(respBody, "user:") {
+		t.Fatalf("response body must not leak `user:` package prefix, got %s", respBody)
+	}
+}
+
+// TestSetLanguageHandler_LongLanguageRejected pins the 64-char length cap
+// applied at handler entry. The gate runs before any zap.String of the raw
+// body so a multi-KB payload from a misbehaving client can't be amplified
+// into the log pipeline before the supported-matrix gate rejects it (PR #182
+// reviewer log-amplification finding).
+func TestSetLanguageHandler_LongLanguageRejected(t *testing.T) {
+	db := newFakeLangDB()
+	r, _ := newLanguageHandlerHarness(t, db, newFakeLangCache())
+
+	oversized := strings.Repeat("x", languageMaxLen+1)
+	body := strings.NewReader(`{"language":"` + oversized + `"}`)
+	req := httptest.NewRequest(http.MethodPut, "/v1/user/language", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d (want 400), body = %s", rec.Code, rec.Body.String())
+	}
+	if len(db.updates) != 0 {
+		t.Fatalf("oversized language must short-circuit before DB, got %v", db.updates)
+	}
+}
+
+// TestSetLanguageHandler_InternalErrorReturnsGenericMsg verifies the
+// classified user-facing copy for infra errors (DB outage, etc.): the wire
+// response must not surface the wrapped `user: persist language: ...` /
+// driver text. PR #182 reviewer P2 fix.
+func TestSetLanguageHandler_InternalErrorReturnsGenericMsg(t *testing.T) {
+	db := newFakeLangDB()
+	db.updateErr = errors.New("driver: connection refused")
+	r, _ := newLanguageHandlerHarness(t, db, newFakeLangCache())
+
+	body := strings.NewReader(`{"language":"en-US"}`)
+	req := httptest.NewRequest(http.MethodPut, "/v1/user/language", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d (want 400), body = %s", rec.Code, rec.Body.String())
+	}
+	respBody := rec.Body.String()
+	if !strings.Contains(respBody, "设置语言偏好失败") {
+		t.Fatalf("response body should be classified generic message, got %s", respBody)
+	}
+	if strings.Contains(respBody, "driver:") || strings.Contains(respBody, "user: persist") {
+		t.Fatalf("response body must not leak internal error text, got %s", respBody)
 	}
 }
 

--- a/modules/user/api_language_test.go
+++ b/modules/user/api_language_test.go
@@ -1,0 +1,181 @@
+package user
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+)
+
+// Handler-level tests for PUT /v1/user/language. We deliberately don't go
+// through testutil.NewTestServer here — the integration suite is gated on a
+// migration TODO (issue #17) — but we still exercise the real
+// LanguageService against the same fakeLangDB / fakeLangCache used by the
+// service unit tests, so the DB-update + cache-DEL contract is covered
+// end-to-end at the HTTP layer.
+//
+// Tests omit t.Parallel: log.NewTLog wraps zap's global logger, and
+// parallel subtests calling Error() concurrently trip the race detector.
+// This is a pre-existing constraint shared with the rest of
+// modules/user/*_test.go.
+
+func newLanguageHandlerHarness(t *testing.T, db languageReader, c *fakeLangCache) (*wkhttp.WKHttp, *User) {
+	t.Helper()
+	u := &User{Log: log.NewTLog("user-test")}
+	u.languageService = NewLanguageService(db, c)
+	r := wkhttp.New()
+	r.Group("/v1/user").PUT("language", func(ctx *wkhttp.Context) {
+		// Inject the login UID the way octo-lib's AuthMiddleware would.
+		// Bypassing AuthMiddleware keeps the test focused on the handler
+		// branches; auth is exercised by upstream octo-lib tests.
+		ctx.Set("uid", testHandlerUID)
+		u.setLanguage(ctx)
+	})
+	return r, u
+}
+
+const testHandlerUID = "u1"
+
+func TestSetLanguageHandler_HappyPath(t *testing.T) {
+	db := newFakeLangDB()
+	db.lang[testHandlerUID] = "zh-CN" // existing preference; should be overwritten
+	c := newFakeLangCache()
+	_ = c.Set(LanguageCacheKeyPrefix+testHandlerUID, "zh-CN") // hot entry to verify DEL
+
+	r, _ := newLanguageHandlerHarness(t, db, c)
+
+	body := strings.NewReader(`{"language":"en-US"}`)
+	req := httptest.NewRequest(http.MethodPut, "/v1/user/language", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if db.updates[testHandlerUID] != "en-US" {
+		t.Fatalf("db updates = %v, want u1 → en-US", db.updates)
+	}
+	if len(c.deletes) == 0 || c.deletes[0] != LanguageCacheKeyPrefix+testHandlerUID {
+		t.Fatalf("expected hot cache DEL on write, deletes = %v", c.deletes)
+	}
+}
+
+func TestSetLanguageHandler_ClearsPreference(t *testing.T) {
+	db := newFakeLangDB()
+	db.lang[testHandlerUID] = "zh-CN"
+	c := newFakeLangCache()
+	r, _ := newLanguageHandlerHarness(t, db, c)
+
+	body := strings.NewReader(`{"language":""}`)
+	req := httptest.NewRequest(http.MethodPut, "/v1/user/language", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if db.updates[testHandlerUID] != "" {
+		t.Fatalf("expected empty string in db, got %q", db.updates[testHandlerUID])
+	}
+}
+
+func TestSetLanguageHandler_RejectsUnsupported(t *testing.T) {
+	db := newFakeLangDB()
+	r, _ := newLanguageHandlerHarness(t, db, newFakeLangCache())
+
+	body := strings.NewReader(`{"language":"klingon"}`)
+	req := httptest.NewRequest(http.MethodPut, "/v1/user/language", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d (want 400), body = %s", rec.Code, rec.Body.String())
+	}
+	if len(db.updates) != 0 {
+		t.Fatalf("unsupported language must not touch DB, got %v", db.updates)
+	}
+}
+
+func TestSetLanguageHandler_MalformedJSON(t *testing.T) {
+	db := newFakeLangDB()
+	r, _ := newLanguageHandlerHarness(t, db, newFakeLangCache())
+
+	body := bytes.NewReader([]byte(`{"language":`)) // truncated JSON
+	req := httptest.NewRequest(http.MethodPut, "/v1/user/language", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d (want 400), body = %s", rec.Code, rec.Body.String())
+	}
+	if len(db.updates) != 0 {
+		t.Fatalf("malformed JSON must not touch DB, got %v", db.updates)
+	}
+}
+
+func TestSetLanguageHandler_Unauthorized(t *testing.T) {
+	db := newFakeLangDB()
+	u := &User{Log: log.NewTLog("user-test")}
+	u.languageService = NewLanguageService(db, newFakeLangCache())
+	r := wkhttp.New()
+	// No ctx.Set("uid", …) — simulates a request that somehow reached the
+	// handler without AuthMiddleware. The handler's own uid guard must
+	// reject it; SetLanguage must not even be called.
+	r.Group("/v1/user").PUT("language", u.setLanguage)
+
+	body := strings.NewReader(`{"language":"en-US"}`)
+	req := httptest.NewRequest(http.MethodPut, "/v1/user/language", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d (want 400 from ResponseError), body = %s", rec.Code, rec.Body.String())
+	}
+	if len(db.updates) != 0 {
+		t.Fatalf("unauthorized request must not touch DB, got %v", db.updates)
+	}
+}
+
+// TestSetLanguageHandler_RequestContextPropagated guards that the handler
+// forwards c.Request.Context() to LanguageService.SetLanguage — a deadline
+// or cancellation on the inbound request must be honoured by the DB write
+// path. Without this hook a slow caller-aborting client could leave the
+// request blocked on MySQL/Redis.
+func TestSetLanguageHandler_RequestContextPropagated(t *testing.T) {
+	db := newFakeLangDB()
+	c := newFakeLangCache()
+	u := &User{Log: log.NewTLog("user-test")}
+	u.languageService = NewLanguageService(db, c)
+
+	r := wkhttp.New()
+	r.Group("/v1/user").PUT("language", func(ctx *wkhttp.Context) {
+		ctx.Set("uid", testHandlerUID)
+		cancelled, cancel := context.WithCancel(ctx.Request.Context())
+		cancel()
+		ctx.Request = ctx.Request.WithContext(cancelled)
+		u.setLanguage(ctx)
+	})
+
+	body := strings.NewReader(`{"language":"en-US"}`)
+	req := httptest.NewRequest(http.MethodPut, "/v1/user/language", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d (want 400 because cancelled), body = %s", rec.Code, rec.Body.String())
+	}
+	if len(db.updates) != 0 {
+		t.Fatalf("cancelled context must abort before DB write, got %v", db.updates)
+	}
+}

--- a/modules/user/api_language_test.go
+++ b/modules/user/api_language_test.go
@@ -3,6 +3,7 @@ package user
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -151,6 +152,72 @@ func TestSetLanguageHandler_Unauthorized(t *testing.T) {
 // or cancellation on the inbound request must be honoured by the DB write
 // path. Without this hook a slow caller-aborting client could leave the
 // request blocked on MySQL/Redis.
+// TestLoginUserDetailResp_LanguageEncoded guards the JSON contract that
+// loginUserDetailResp emits the `language` field on every response that flows
+// through it (login / current / register-then-auto-login). A struct-level
+// test rather than an HTTP integration one because all the /v1/user/current
+// integration tests in this package are t.Skip'd behind issue #17's
+// migration gate — a struct-level assertion runs in CI today and guards
+// against accidental removal of either the field or the json tag. Tracks
+// the regression-guard ask in PR #182 review.
+func TestLoginUserDetailResp_LanguageEncoded(t *testing.T) {
+	cases := []struct {
+		name string
+		lang string
+	}{
+		{"populated", "zh-CN"},
+		{"empty_means_unset", ""}, // must still be present in JSON, not omitempty
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(&loginUserDetailResp{UID: "u1", Language: tc.lang})
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			var got map[string]interface{}
+			if err := json.Unmarshal(b, &got); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if _, present := got["language"]; !present {
+				t.Fatalf("language field missing from JSON: %s", string(b))
+			}
+			if got["language"] != tc.lang {
+				t.Fatalf("language = %v, want %q", got["language"], tc.lang)
+			}
+		})
+	}
+}
+
+// TestLanguageService_PersistsCanonicalForm pins the contract that
+// LanguageService normalises mixed-case / underscore inputs to the canonical
+// BCP 47 form before persisting. Without this, a client sending "ZH_cn" today
+// and "zh-CN" tomorrow would write two different DB values for the same
+// preference. PR #182 reviewer asked for explicit coverage of this path.
+func TestLanguageService_PersistsCanonicalForm(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"underscore", "zh_CN", "zh-CN"},
+		{"mixed_case", "ZH-cn", "zh-CN"},
+		{"upper_en", "EN-us", "en-US"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			db := newFakeLangDB()
+			c := newFakeLangCache()
+			svc := NewLanguageService(db, c)
+			if err := svc.SetLanguage(context.Background(), "u1", tc.in); err != nil {
+				t.Fatalf("SetLanguage(%q): %v", tc.in, err)
+			}
+			if got := db.updates["u1"]; got != tc.want {
+				t.Fatalf("db value = %q, want canonical %q (input was %q)", got, tc.want, tc.in)
+			}
+		})
+	}
+}
+
 func TestSetLanguageHandler_RequestContextPropagated(t *testing.T) {
 	db := newFakeLangDB()
 	c := newFakeLangCache()

--- a/modules/user/language_service.go
+++ b/modules/user/language_service.go
@@ -28,6 +28,13 @@ const LanguageCacheTTL = 5 * time.Minute
 // '-' is unambiguous because BCP 47 forbids a leading hyphen on any subtag.
 const negativeMarker = "-"
 
+// ErrUnsupportedLanguage is returned by SetLanguage when the input is a
+// well-formed but unsupported BCP 47 tag (i.e. not in the configured
+// supported-language matrix). Callers can errors.Is-match this to choose a
+// 4xx user-facing response, separate from infra errors (DB down, etc.) that
+// should surface as generic 5xx-ish failures.
+var ErrUnsupportedLanguage = errors.New("user: language not in supported matrix")
+
 // languageReader is the read surface LanguageService needs from the user DB
 // layer; defined here (consumer side) so tests can stub it without spinning
 // up dbr. Production code passes *DB which already satisfies the signature.
@@ -118,7 +125,7 @@ func (s *LanguageService) SetLanguage(ctx context.Context, uid, lang string) err
 	}
 	normalized := normalizeLanguageOrEmpty(lang)
 	if lang != "" && normalized == "" {
-		return fmt.Errorf("user: unsupported language %q", lang)
+		return fmt.Errorf("%w: %q", ErrUnsupportedLanguage, lang)
 	}
 	writer, ok := s.db.(languageWriter)
 	if !ok {

--- a/modules/user/language_service_test.go
+++ b/modules/user/language_service_test.go
@@ -257,6 +257,12 @@ func TestLanguageServiceSetLanguageRejectsUnsupported(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unsupported language")
 	}
+	// Sentinel must wrap; handler relies on errors.Is to split user-facing
+	// copy between unsupported (400 with "不支持的语言") and infra error
+	// (generic 400 with "设置语言偏好失败！").
+	if !errors.Is(err, ErrUnsupportedLanguage) {
+		t.Fatalf("err = %v, want wrap of ErrUnsupportedLanguage", err)
+	}
 }
 
 func TestLanguageServiceSetLanguageAcceptsEmptyToClear(t *testing.T) {


### PR DESCRIPTION
## Summary

Final step of the backend i18n track (refs #170; builds on #179 + #181):
expose the user-language preference through the public user API so
clients can read and update it.

`LanguageService.SetLanguage` (shipped in #181) already handles BCP 47
validation, the DB write, and the active hot-cache `DEL` for cross-device
convergence. This PR is the thin HTTP layer on top: a new `PUT
/v1/user/language` endpoint and a `language` field on the existing
`GET /v1/user/current` response.

## Scope

**`PUT /v1/user/language`**
- Auth-gated alongside the rest of `/v1/user/*`.
- Request body: `{"language": "<BCP 47 tag>"}`. An empty string clears
  the preference (reverts to `OCTO_DEFAULT_LANGUAGE` semantics on the
  read side).
- Backed by `LanguageService.SetLanguage` — supported-language matrix
  validation rejects unknown tags with `400`; the DB column is
  parameterised; the hot cache is actively `DEL`'d so other nodes
  observe the new value on their next read instead of waiting up to
  the TTL.
- Other devices' token-cache snapshots are intentionally not refreshed
  on write. `AuthMiddleware`'s injected `LanguageResolver` (from #181)
  hydrates the fresh value on the next authenticated request, so the
  steady state converges within one request per device without a
  forced re-login — matches the design called out in #181.

**`GET /v1/user/current` response**
- `loginUserDetailResp` gains `language` (always emitted, including
  empty string). Clients should treat an empty value as "no explicit
  preference; the server has nothing to assert" and not back-fill a
  local default that would mask the server-side state.

**Dependency wiring**
- `*User` now holds its own `*LanguageService` instance built from
  the same `*DB` session and `ctx.Cache()` that the rest of the user
  module already uses. It shares the underlying connection pool with
  the boot-time instance injected into `CacheTokenParser`, so both
  paths read and write the same `user.language` column and the same
  `user_language:{uid}` hot key. No reverse injection from `main.go`
  is required.

## Out of scope

- Frontend changes (handled in the octo-web / octo-admin tracks).
- Observability counters (`user_language_cache_errors_total{op}` etc.)
  remain on the i18n metrics batch tracked in the project TODOs.
- Thundering-herd protection (singleflight on cold-cache fan-out) is
  still a follow-up — flagged again in #181 review and acceptable for
  the current QPS profile.

## Backward compatibility

- The `language` field on `GET /v1/user/current` is additive. Existing
  clients ignore unknown fields and continue to work; the previously
  missing field made any client-side handling of the user-language
  preference impossible.
- `PUT /v1/user/language` is a brand-new endpoint; no existing handler
  is altered.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./modules/user/...` (after a fresh test DB) — 6
      new handler-level cases cover the happy path, empty-to-clear,
      unsupported-language rejection, malformed JSON, unauthorized
      request (no auth-middleware-set uid), and request-context
      cancellation propagating through to the service layer.
- [ ] CI Build / Test / Vet / Lint / CodeQL on the merged base.
- [ ] Reviewer spot check on a staging-style deploy: confirm that
      `PUT /v1/user/language` from device A with `zh-CN` is observable
      on device B's next authenticated request (via the hot cache DEL).

## Risk

| Risk | Mitigation |
|---|---|
| Client sends an unsupported language tag | Service-layer `MatchSupportedLanguage` gate rejects with `400`; the DB is not touched. Covered by `TestSetLanguageHandler_RejectsUnsupported`. |
| Slow client times out mid-request, request still completes | Handler forwards `c.Request.Context()` to `SetLanguage`; cancellation aborts before the DB write. `TestSetLanguageHandler_RequestContextPropagated` pins this. |
| Other devices keep advertising the old language until they re-login | Resolver hydrates from the hot cache on the next request from any device. The hot cache `DEL` happens before the response, so the next read in the cluster sees DB-fresh data. The token-cache snapshot is intentionally a last-resort fallback only. |
| Existing token-cache writes mint snapshots with a now-stale `Language` | Already handled in #181: `CacheTokenParser` tri-state means an empty resolver result clears the snapshot, so the priority ladder downgrades cleanly to `Accept-Language` / `default`. |