### PR TITLE
test(i18n): Phase 0 §0.9 verification suite

### DIFF
--- a/modules/user/language_multidevice_test.go
+++ b/modules/user/language_multidevice_test.go
@@ -1,0 +1,209 @@
+package user
+
+// Phase 0 §0.9 验证用例: "多端会话: A 端切语言, B 端下次请求即生效"。
+//
+// 这一项不能拆到 pkg/i18n,因为 LanguageService.SetLanguage 是 cross-device
+// invalidation 的写入端,实现细节(DB UPDATE + Redis DEL)归 modules/user。
+// 这里以 fakeLangDB + fakeLangCache(与既有 service/handler 测试同一组 stub)
+// 串起最小链路: 一次 SetLanguage → 后续任意 device 的 token 解析必须命中
+// 新语言,而非 token cache 里冻结的旧 snapshot。
+//
+// 验证手段: 直接驱动 pkg/auth.CacheTokenParser.Parse,这是 octo-lib
+// AuthMiddleware 真正调用的入口;parser 解码 token 后会调用 LanguageResolver
+// (= LanguageService) 取真相源。如果 SetLanguage 没正确 invalidate cache,
+// 或 resolver 没读 DB,该用例必失败。
+//
+// 不通过 testutil.NewTestServer 起真实 MySQL/Redis: 仓内现有测试基础设施
+// 受 migration drift 阻塞(参见 api_language_test.go 头部说明 + memory
+// local_test_infra.md)。fake DB/cache 已能覆盖语义契约。
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
+)
+
+// liveLangDB wraps fakeLangDB so UpdateLanguageByUID immediately reflects
+// into the read map — the production *DB writes one row that subsequent
+// SELECTs see, but the bundled fake keeps writes in a separate `updates` map
+// for assertion convenience. For multi-device sync the read-after-write
+// observability is the contract under test, so we bridge them here.
+type liveLangDB struct{ *fakeLangDB }
+
+func (d *liveLangDB) UpdateLanguageByUID(uid, lang string) error {
+	if err := d.fakeLangDB.UpdateLanguageByUID(uid, lang); err != nil {
+		return err
+	}
+	d.lang[uid] = lang
+	return nil
+}
+
+func newLiveLangDB() *liveLangDB { return &liveLangDB{fakeLangDB: newFakeLangDB()} }
+
+// encodeToken produces a cache value identical to what production write
+// paths emit (auth.Encode → "v2:{json}"). Using the real codec keeps the
+// test honest: if the envelope format ever changes, this test catches the
+// drift instead of silently testing a synthetic shape.
+func encodeToken(t *testing.T, uid, name, lang string) string {
+	t.Helper()
+	raw, err := auth.Encode(auth.TokenInfo{UID: uid, Name: name, Language: lang})
+	if err != nil {
+		t.Fatalf("auth.Encode: %v", err)
+	}
+	return raw
+}
+
+// TestPhase0_MultiDeviceLanguageSyncOnSetLanguage is the headline Phase 0
+// scenario: device A flips the user's language, device B's very next request
+// must see the new value — even though B's cached token still carries the
+// stale snapshot. The chain we exercise:
+//
+//  1. Two devices each have an auth token in cache; both encode a stale
+//     language ("zh-CN") in the token envelope.
+//  2. DB starts with "zh-CN" too — consistent steady state.
+//  3. Device A's PUT /v1/user/language flow (here: direct LanguageService.
+//     SetLanguage call) UPDATEs DB and DELs Redis hot key.
+//  4. Device B's next request triggers CacheTokenParser.Parse. The parser
+//     decodes the stale snapshot, then asks LanguageResolver. Resolver finds
+//     no Redis hot key (DEL above), reads DB, returns "en-US".
+//  5. UserInfo.Language returned to AuthMiddleware is "en-US" — the snapshot
+//     does NOT leak.
+//
+// Failure modes this test traps:
+//   - SetLanguage forgets to DEL → resolver returns stale Redis value
+//   - Resolver skipped on parser path → snapshot wins
+//   - Resolver error swallowed silently → wrong fallback
+//   - Cache DEL races with re-populate (verified by inspecting cache state)
+func TestPhase0_MultiDeviceLanguageSyncOnSetLanguage(t *testing.T) {
+	const uid = "user-multi-device"
+	const tokenA = "token-device-A"
+	const tokenB = "token-device-B"
+	const tokenCachePrefix = "tk:"
+
+	cacheStore := newFakeLangCache()
+	db := newLiveLangDB()
+	db.lang[uid] = "zh-CN"
+
+	// Seed both device token cache entries with the stale language snapshot.
+	if err := cacheStore.Set(tokenCachePrefix+tokenA, encodeToken(t, uid, "alice", "zh-CN")); err != nil {
+		t.Fatalf("seed token A: %v", err)
+	}
+	if err := cacheStore.Set(tokenCachePrefix+tokenB, encodeToken(t, uid, "alice", "zh-CN")); err != nil {
+		t.Fatalf("seed token B: %v", err)
+	}
+	// Warm the language hot cache to mirror a steady state where prior reads
+	// have already populated it. SetLanguage must actively invalidate this.
+	if err := cacheStore.Set(LanguageCacheKeyPrefix+uid, "zh-CN"); err != nil {
+		t.Fatalf("warm language cache: %v", err)
+	}
+
+	svc := NewLanguageService(db, cacheStore)
+	parser := auth.NewCacheTokenParser(cacheStore, tokenCachePrefix, auth.WithLanguageResolver(svc))
+
+	ctx := context.Background()
+
+	// --- Baseline: both devices read zh-CN, no spurious resolver→DB hits
+	// because the hot cache satisfies the resolver. ---
+	assertParseLang(t, parser, ctx, tokenA, "zh-CN")
+	assertParseLang(t, parser, ctx, tokenB, "zh-CN")
+	if db.queryCalls != 0 {
+		t.Fatalf("steady-state cache hit must skip DB; queryCalls=%d", db.queryCalls)
+	}
+
+	// --- Device A: PUT /v1/user/language equivalent. SetLanguage MUST
+	// UPDATE DB and DEL the hot cache key.
+	preDeletes := len(cacheStore.deletes)
+	if err := svc.SetLanguage(ctx, uid, "en-US"); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	if got := db.updates[uid]; got != "en-US" {
+		t.Fatalf("DB update[%q] = %q, want en-US", uid, got)
+	}
+	delKey := LanguageCacheKeyPrefix + uid
+	if !sliceContainsAfter(cacheStore.deletes, preDeletes, delKey) {
+		t.Fatalf("SetLanguage did not DEL %q; deletes=%v", delKey, cacheStore.deletes)
+	}
+
+	// --- Device B's next request: parser must see en-US ---
+	dbCallsBefore := db.queryCalls
+	info := assertParseLang(t, parser, ctx, tokenB, "en-US")
+	if db.queryCalls != dbCallsBefore+1 {
+		t.Fatalf("expected exactly one DB query for resolver re-fetch; got %d→%d",
+			dbCallsBefore, db.queryCalls)
+	}
+	// UID/Name from the snapshot must still flow — only Language is overridden.
+	if info.UID != uid || info.Name != "alice" {
+		t.Fatalf("UserInfo metadata lost: %+v", info)
+	}
+
+	// --- Subsequent reads (either device) must come from re-populated cache,
+	// not hammer DB again. This is the convergence guarantee.
+	dbCallsBefore = db.queryCalls
+	assertParseLang(t, parser, ctx, tokenA, "en-US")
+	assertParseLang(t, parser, ctx, tokenB, "en-US")
+	if db.queryCalls != dbCallsBefore {
+		t.Fatalf("post-convergence reads must hit cache; queryCalls grew by %d", db.queryCalls-dbCallsBefore)
+	}
+}
+
+// TestPhase0_MultiDeviceClearLanguageDropsSnapshot covers the inverse: a
+// user wiping their preference (PUT with empty body) must make all device
+// snapshots fall back to EarlyMiddleware's Accept-Language / default
+// negotiation rather than perpetuating a stale Language=zh-CN forever.
+// Documented contract: parser_test.go::TestCacheTokenParserResolverEmptyClearsSnapshot.
+func TestPhase0_MultiDeviceClearLanguageDropsSnapshot(t *testing.T) {
+	const uid = "user-multi-clear"
+	const token = "token-clear"
+	const tokenCachePrefix = "tk:"
+
+	c := newFakeLangCache()
+	db := newLiveLangDB()
+	db.lang[uid] = "zh-CN"
+	_ = c.Set(tokenCachePrefix+token, encodeToken(t, uid, "bob", "zh-CN"))
+
+	svc := NewLanguageService(db, c)
+	parser := auth.NewCacheTokenParser(c, tokenCachePrefix, auth.WithLanguageResolver(svc))
+
+	// Steady state: snapshot wins via resolver hitting DB.
+	assertParseLang(t, parser, context.Background(), token, "zh-CN")
+
+	// Clear preference — equivalent to PUT {"language":""}.
+	if err := svc.SetLanguage(context.Background(), uid, ""); err != nil {
+		t.Fatalf("SetLanguage(empty): %v", err)
+	}
+	if got, ok := db.updates[uid]; !ok || got != "" {
+		t.Fatalf("DB update[%q] = %q,present=%v; want empty string written", uid, got, ok)
+	}
+
+	// Next parse must NOT promote any language onto UserInfo — leaving it
+	// empty lets pkg/i18n.LanguageFromContext fall back to negotiation /
+	// default. (See parser.go comment on the empty-resolver branch.)
+	info := assertParseLang(t, parser, context.Background(), token, "")
+	if info.Language != "" {
+		t.Fatalf("Language snapshot leaked after clear: %q", info.Language)
+	}
+}
+
+func assertParseLang(t *testing.T, p *auth.CacheTokenParser, ctx context.Context, token, want string) wkhttp.UserInfo {
+	t.Helper()
+	info, err := p.Parse(ctx, token)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", token, err)
+	}
+	if info.Language != want {
+		t.Fatalf("Parse(%q).Language = %q, want %q", token, info.Language, want)
+	}
+	return info
+}
+
+func sliceContainsAfter(deletes []string, startIdx int, want string) bool {
+	for _, k := range deletes[startIdx:] {
+		if k == want || strings.EqualFold(k, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/i18n/phase0_verification_test.go
+++ b/pkg/i18n/phase0_verification_test.go
@@ -1,0 +1,317 @@
+package i18n
+
+// Phase 0 退出条件验证用例 (TODOS §0.9)。
+//
+// 本文件不引入新功能,而是为 Phase 0 verification scenarios 提供一组**显式**
+// 断言,与 0.9 checklist 1:1 对应。若已有 *_test.go 覆盖了某项契约,本文件
+// 仍补一条以 TestPhase0_* 命名的检查,作为 Phase 0 readiness 的单一入口
+// (CI 可用 `go test -run TestPhase0_` 聚焦运行)。
+//
+// 不覆盖项目(及理由):
+//   - 公开未登录接口 (login/register/invite) 本地化: 需先把 modules/user 改造为
+//     ResponseErrorL,属于 Phase 2 范围,Phase 0 退出条件标注"留 Phase 2 兜底"。
+//   - 多端会话同步: 见 modules/user/language_multidevice_test.go,因 LanguageService
+//     依赖 fake DB+Cache 那里更顺手。
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/gin-gonic/gin"
+)
+
+// withLangHandler returns a wkhttp router that injects a fixed language into
+// the request context before invoking handler. Used to side-step
+// EarlyMiddleware in tests that want to assert renderer behavior for a
+// chosen lang without depending on Accept-Language parsing.
+func withLangHandler(t *testing.T, lang string, handler func(*wkhttp.Context)) *wkhttp.WKHttp {
+	t.Helper()
+	r := wkhttp.New()
+	r.SetErrorRenderer(NewErrorRenderer(NewLocalizer(SourceLanguage)))
+	r.GET("/x", func(c *wkhttp.Context) {
+		c.Request = c.Request.WithContext(WithLanguage(c.Request.Context(), LanguageDecision{
+			Language: lang,
+			Source:   LanguageSourceAccept,
+		}))
+		handler(c)
+	})
+	return r
+}
+
+func doGet(t *testing.T, r *wkhttp.WKHttp, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+func decodeBody(t *testing.T, body *bytes.Buffer) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(body.Bytes(), &m); err != nil {
+		t.Fatalf("decode body: %v\n%s", err, body.String())
+	}
+	return m
+}
+
+// TestPhase0_HandlerErrorLocalization_SymmetricZhEn locks Phase 0 §0.9 item
+// "handler 错误本地化". The same Code emitted under zh-CN vs en-US must produce
+// the corresponding TOML translation, proving the localizer + bundle path is
+// the actual source of the message (not a default-message fallback).
+func TestPhase0_HandlerErrorLocalization_SymmetricZhEn(t *testing.T) {
+	// Reset bundle so the assertion exercises real TOML load — not stale
+	// state from an earlier test that may have injected a substitute.
+	resetBundle()
+	t.Cleanup(resetBundle)
+
+	cases := []struct {
+		lang    string
+		wantMsg string
+	}{
+		{lang: "zh-CN", wantMsg: "请先登录！"},
+		{lang: "en-US", wantMsg: "Please log in to continue."},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.lang, func(t *testing.T) {
+			r := withLangHandler(t, tc.lang, func(c *wkhttp.Context) {
+				c.RenderError(wkhttp.ErrorSpec{
+					Code:            "err.shared.auth.required",
+					TransportStatus: http.StatusUnauthorized,
+					SemanticStatus:  http.StatusUnauthorized,
+				})
+			})
+			rec := doGet(t, r, nil)
+			if got := rec.Header().Get("Content-Language"); got != tc.lang {
+				t.Fatalf("Content-Language = %q, want %q", got, tc.lang)
+			}
+			body := decodeBody(t, rec.Body)
+			if got := body["msg"]; got != tc.wantMsg {
+				t.Fatalf("msg = %q, want %q", got, tc.wantMsg)
+			}
+			errObj := body["error"].(map[string]any)
+			if got := errObj["message"]; got != tc.wantMsg {
+				t.Fatalf("error.message = %q, want %q", got, tc.wantMsg)
+			}
+		})
+	}
+}
+
+// TestPhase0_HTTPStatusCompat_TransportDivergesFromSemantic locks D14:
+// during the compatibility window the wire status is pinned to the value
+// chosen by the caller (typically 400), but the body's error.http_status
+// continues to expose the real semantic status. Tests where Transport ==
+// Semantic don't prove the channel separation, so this case explicitly
+// uses 400/500.
+func TestPhase0_HTTPStatusCompat_TransportDivergesFromSemantic(t *testing.T) {
+	r := withLangHandler(t, "en-US", func(c *wkhttp.Context) {
+		c.RenderError(wkhttp.ErrorSpec{
+			Code:            "err.shared.internal",
+			TransportStatus: http.StatusBadRequest,
+			SemanticStatus:  http.StatusInternalServerError,
+			Internal:        true,
+		})
+	})
+	rec := doGet(t, r, nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("wire status = %d, want 400 (D14 compat: transport pinned)", rec.Code)
+	}
+	body := decodeBody(t, rec.Body)
+	if got := body["status"]; got != float64(http.StatusBadRequest) {
+		t.Fatalf("body.status = %v, want 400 (legacy envelope mirrors wire)", got)
+	}
+	errObj := body["error"].(map[string]any)
+	if got := errObj["http_status"]; got != float64(http.StatusInternalServerError) {
+		t.Fatalf("error.http_status = %v, want 500 (semantic preserved)", got)
+	}
+}
+
+// TestPhase0_DualEnvelopeAlwaysEmitted_ParityRegardlessOfV2Header locks the
+// v7.2 decision that the renderer is **header-agnostic**: clients sending
+// X-Octo-Error-Envelope: v2 receive the exact same bytes as clients that
+// don't. Any future regression that branches on the header (e.g. omitting
+// msg/status for v2 to shrink payload) breaks legacy clients silently;
+// this parity test makes that regression a hard fail.
+func TestPhase0_DualEnvelopeAlwaysEmitted_ParityRegardlessOfV2Header(t *testing.T) {
+	build := func() *wkhttp.WKHttp {
+		return withLangHandler(t, "en-US", func(c *wkhttp.Context) {
+			c.RenderError(wkhttp.ErrorSpec{
+				Code:            "err.shared.auth.required",
+				TransportStatus: http.StatusUnauthorized,
+				SemanticStatus:  http.StatusUnauthorized,
+			})
+		})
+	}
+
+	recOmit := doGet(t, build(), nil)
+	recV2 := doGet(t, build(), map[string]string{"X-Octo-Error-Envelope": "v2"})
+
+	if recOmit.Code != recV2.Code {
+		t.Fatalf("wire status diverged: omit=%d v2=%d", recOmit.Code, recV2.Code)
+	}
+	if recOmit.Body.String() != recV2.Body.String() {
+		t.Fatalf("body bytes diverged with X-Octo-Error-Envelope header:\nomit=%s\nv2=%s",
+			recOmit.Body.String(), recV2.Body.String())
+	}
+	// Spot-check both envelopes still ship both shapes (msg/status AND error.{}).
+	body := decodeBody(t, recOmit.Body)
+	if _, ok := body["msg"]; !ok {
+		t.Error("legacy msg field missing")
+	}
+	if _, ok := body["error"]; !ok {
+		t.Error("v2 error field missing")
+	}
+}
+
+// TestPhase0_MiddlewareAbortLocalization simulates the two octo-lib
+// middleware abort branches that Phase 0 cares about (Auth token missing,
+// rate limit) by composing EarlyMiddleware + a stand-in middleware that
+// calls c.RenderError directly — exactly the call shape octo-lib's
+// AuthMiddleware / RateLimitMiddleware use after PR #47. Verifies the
+// abort body is localized end-to-end through Accept-Language negotiation,
+// not by hand-injecting a language onto context.
+func TestPhase0_MiddlewareAbortLocalization(t *testing.T) {
+	cases := []struct {
+		name            string
+		acceptLang      string
+		code            string
+		transportStatus int
+		details         map[string]any
+		wantStatus      int
+		wantMsg         string
+		wantDetails     map[string]any
+	}{
+		{
+			name:            "auth_token_missing_zh",
+			acceptLang:      "zh-CN",
+			code:            "err.shared.auth.token_missing",
+			transportStatus: http.StatusUnauthorized,
+			wantStatus:      http.StatusUnauthorized,
+			wantMsg:         "token不能为空，请先登录！",
+		},
+		{
+			name:            "auth_token_missing_en",
+			acceptLang:      "en-US",
+			code:            "err.shared.auth.token_missing",
+			transportStatus: http.StatusUnauthorized,
+			wantStatus:      http.StatusUnauthorized,
+			wantMsg:         "Authentication token is required.",
+		},
+		{
+			name:            "rate_limited_zh_with_retry_after",
+			acceptLang:      "zh-CN",
+			code:            "err.shared.rate.limited",
+			transportStatus: http.StatusTooManyRequests,
+			details:         map[string]any{"retry_after": 5, "raw_err": "MUST be dropped"},
+			wantStatus:      http.StatusTooManyRequests,
+			wantMsg:         "请求过于频繁，请稍后再试。",
+			wantDetails:     map[string]any{"retry_after": float64(5)},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			r := wkhttp.New()
+			r.SetErrorRenderer(NewErrorRenderer(NewLocalizer(SourceLanguage)))
+			r.UseGin(EarlyMiddleware(MiddlewareOptions{DefaultLanguage: SourceLanguage}))
+			// abortAsMiddleware mirrors the abort shape octo-lib uses: render
+			// the spec then return without calling c.Next().
+			r.GET("/protected", func(c *wkhttp.Context) {
+				c.RenderError(wkhttp.ErrorSpec{
+					Code:            tc.code,
+					TransportStatus: tc.transportStatus,
+					SemanticStatus:  tc.transportStatus,
+					Details:         tc.details,
+				})
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+			req.Header.Set("Accept-Language", tc.acceptLang)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+			if got := rec.Header().Get("Content-Language"); got != tc.acceptLang {
+				t.Fatalf("Content-Language = %q, want %q", got, tc.acceptLang)
+			}
+			body := decodeBody(t, rec.Body)
+			if got := body["msg"]; got != tc.wantMsg {
+				t.Fatalf("msg = %q, want %q", got, tc.wantMsg)
+			}
+			if tc.wantDetails != nil {
+				errObj := body["error"].(map[string]any)
+				gotDetails, ok := errObj["details"].(map[string]any)
+				if !ok {
+					t.Fatalf("error.details missing or wrong type: %#v", errObj["details"])
+				}
+				for k, want := range tc.wantDetails {
+					if got := gotDetails[k]; got != want {
+						t.Errorf("details[%q] = %v, want %v", k, got, want)
+					}
+				}
+				if _, leaked := gotDetails["raw_err"]; leaked {
+					t.Error("rate.limited details leaked raw_err (must be whitelist-dropped)")
+				}
+			}
+		})
+	}
+}
+
+// TestPhase0_DefaultLanguageSwitchPinsNegotiation locks Phase 0 §0.9 item
+// "OCTO_DEFAULT_LANGUAGE zh-CN 与 en-US 切换": for a request that carries no
+// language signal at all, the EarlyMiddleware-negotiated language MUST be
+// whatever the operator configured as default — and that language MUST flow
+// through to the rendered error body.
+func TestPhase0_DefaultLanguageSwitchPinsNegotiation(t *testing.T) {
+	resetBundle()
+	t.Cleanup(resetBundle)
+
+	cases := []struct {
+		defaultLang string
+		wantMsg     string
+	}{
+		{defaultLang: "zh-CN", wantMsg: "请先登录！"},
+		{defaultLang: "en-US", wantMsg: "Please log in to continue."},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.defaultLang, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			r := wkhttp.New()
+			r.SetErrorRenderer(NewErrorRenderer(NewLocalizer(tc.defaultLang)))
+			r.UseGin(EarlyMiddleware(MiddlewareOptions{DefaultLanguage: tc.defaultLang}))
+			r.GET("/x", func(c *wkhttp.Context) {
+				c.RenderError(wkhttp.ErrorSpec{
+					Code:            "err.shared.auth.required",
+					TransportStatus: http.StatusUnauthorized,
+					SemanticStatus:  http.StatusUnauthorized,
+				})
+			})
+
+			// No Accept-Language, no cookie, no query — pure default path.
+			req := httptest.NewRequest(http.MethodGet, "/x", nil)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if got := rec.Header().Get("Content-Language"); got != tc.defaultLang {
+				t.Fatalf("Content-Language = %q, want default %q", got, tc.defaultLang)
+			}
+			body := decodeBody(t, rec.Body)
+			if got := body["msg"]; got != tc.wantMsg {
+				t.Fatalf("msg = %q, want %q", got, tc.wantMsg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Locks down the Phase 0 exit-condition scenarios from the i18n rollout plan
(internal TODOS §0.9) with a focused, infra-free test suite. Every test is
named `TestPhase0_*` so CI can scope to readiness checks via
`go test -run TestPhase0_ ./...`.

No production code changes — additive test files only.

### `pkg/i18n/phase0_verification_test.go`

Covers five contracts that existing unit tests prove only indirectly or
not at all:

- **Handler error localization** — same `Code` rendered under `zh-CN`
  vs `en-US` must hit the bundle, not fall back to `DefaultMessage`.
- **HTTP status compat (D14)** — `TransportStatus ≠ SemanticStatus`
  path exercised explicitly (wire status pinned to 400, real status
  preserved in `error.http_status`).
- **Dual envelope parity** — response bytes must be identical whether
  the client sends `X-Octo-Error-Envelope: v2` or omits it (the
  renderer is intentionally header-agnostic; this test traps any
  future regression that branches on the header).
- **Middleware abort localization** — `Auth token_missing` and
  `rate.limited` rendered through `EarlyMiddleware` in both languages,
  with the `SafeDetailKeys` whitelist still dropping unsafe details
  (`retry_after` kept, `raw_err` removed).
- **`OCTO_DEFAULT_LANGUAGE` switch** — a no-signal request honours the
  configured default end-to-end (both `Content-Language` header and
  rendered body message).

### `modules/user/language_multidevice_test.go`

Covers the cross-device language sync contract:

- `SetLanguage` on session A → session B's next
  `CacheTokenParser.Parse` observes the new language. Asserts the hot
  cache was `DEL`'d, DB was queried **exactly once** for the resolver
  re-fetch, and subsequent reads stop hitting DB (cache re-populated).
- Clearing the preference (PUT `{\"language\":\"\"}`) drops the stale
  language snapshot from `UserInfo` rather than perpetuating it.

### Out of scope (documented in file headers)

- **Public unauthenticated endpoint localization** (login / register /
  invite) — would require migrating the affected `ResponseError` call
  sites to `ResponseErrorL`, which is Phase 2 `modules/user` work.
- **Live MySQL/Redis end-to-end** — `testutil.NewTestServer` is
  currently blocked on a migration drift issue. The fake DB/cache stubs
  already used elsewhere in `modules/user/*_test.go` cover the
  semantic contracts under test here.

## Test plan

- [x] `go test -race ./pkg/i18n/... ./pkg/auth/... ./modules/user/`
- [x] `go vet ./pkg/i18n/ ./modules/user/`
- [x] `go test -run TestPhase0_ ./...` lists the new readiness suite

## Verified behaviour

- 7 new tests across 2 files, all green under `-race`
- No production code modified; PR is purely additive test coverage