### PR TITLE
feat(voice): add POST /local-config/reset proxy + fix 404 handling

### DIFF
--- a/modules/voice_adapter/adapter.go
+++ b/modules/voice_adapter/adapter.go
@@ -1,6 +1,7 @@
 package voice_adapter
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"os"
@@ -288,9 +289,20 @@ func (a *VoiceAdapter) deleteLocalConfig(c *wkhttp.Context) {
 	err = a.client.DeleteLocalConfig(c.Request.Context(), loginUID, "space", spaceID)
 	if err != nil {
 		var svcErr *SpeechServiceError
-		if errors.As(err, &svcErr) && svcErr.StatusCode >= 400 && svcErr.StatusCode < 500 {
-			c.JSON(svcErr.StatusCode, gin.H{"status": svcErr.StatusCode, "msg": svcErr.Body})
-			return
+		if errors.As(err, &svcErr) {
+			if svcErr.StatusCode == 404 {
+				var parsed struct {
+					Status int `json:"status"`
+				}
+				if json.Unmarshal([]byte(svcErr.Body), &parsed) == nil && parsed.Status == 404 {
+					c.JSON(http.StatusOK, gin.H{"status": http.StatusOK, "msg": "ok"})
+					return
+				}
+			}
+			if svcErr.StatusCode >= 400 && svcErr.StatusCode < 500 {
+				c.JSON(svcErr.StatusCode, gin.H{"status": svcErr.StatusCode, "msg": svcErr.Body})
+				return
+			}
 		}
 		a.Error("delete local config failed", zap.Error(err))
 		c.JSON(http.StatusBadGateway, gin.H{"status": http.StatusBadGateway, "msg": "speech service unavailable"})

--- a/modules/voice_adapter/adapter.go
+++ b/modules/voice_adapter/adapter.go
@@ -40,6 +40,7 @@ func (a *VoiceAdapter) Route(r *wkhttp.WKHttp) {
 		auth.PUT("/local-config", a.putLocalConfig)
 		auth.GET("/local-config", a.getLocalConfig)
 		auth.DELETE("/local-config", a.deleteLocalConfig)
+		auth.POST("/local-config/reset", a.resetLocalConfig)
 	}
 }
 
@@ -264,6 +265,60 @@ func (a *VoiceAdapter) getLocalConfig(c *wkhttp.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, resp)
+}
+
+func (a *VoiceAdapter) resetLocalConfig(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, 64*1024)
+
+	var req struct {
+		Enabled *bool `json:"enabled"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"status": http.StatusRequestEntityTooLarge, "msg": "request body too large"})
+			return
+		}
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "invalid request body"})
+		return
+	}
+
+	spaceID := getSpaceID(c)
+	if spaceID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "X-Space-ID header is required"})
+		return
+	}
+
+	if req.Enabled == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "enabled is required"})
+		return
+	}
+
+	isMember, err := space.CheckMembership(a.ctx.DB(), spaceID, loginUID)
+	if err != nil {
+		a.Error("check space membership failed", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"status": http.StatusInternalServerError, "msg": "check space membership failed"})
+		return
+	}
+	if !isMember {
+		c.JSON(http.StatusForbidden, gin.H{"status": http.StatusForbidden, "msg": "not a member of this space"})
+		return
+	}
+
+	err = a.client.ResetLocalConfig(c.Request.Context(), loginUID, "space", spaceID, *req.Enabled)
+	if err != nil {
+		var svcErr *SpeechServiceError
+		if errors.As(err, &svcErr) && svcErr.StatusCode >= 400 && svcErr.StatusCode < 500 {
+			c.JSON(svcErr.StatusCode, gin.H{"status": svcErr.StatusCode, "msg": svcErr.Body})
+			return
+		}
+		a.Error("reset local config failed", zap.Error(err))
+		c.JSON(http.StatusBadGateway, gin.H{"status": http.StatusBadGateway, "msg": "speech service unavailable"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": http.StatusOK, "msg": "ok"})
 }
 
 func (a *VoiceAdapter) deleteLocalConfig(c *wkhttp.Context) {

--- a/modules/voice_adapter/adapter_test.go
+++ b/modules/voice_adapter/adapter_test.go
@@ -1106,6 +1106,229 @@ func TestPutLocalConfig_BodyTooLarge(t *testing.T) {
 	}
 }
 
+func TestResetLocalConfig_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/speech/local-config/reset" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		if body["subject_id"] != "user1" {
+			t.Errorf("expected subject_id=user1, got %v", body["subject_id"])
+		}
+		if body["scope_type"] != "space" {
+			t.Errorf("expected scope_type=space, got %v", body["scope_type"])
+		}
+		if body["scope_id"] != "space1" {
+			t.Errorf("expected scope_id=space1, got %v", body["scope_id"])
+		}
+		if body["enabled"] != true {
+			t.Errorf("expected enabled=true, got %v", body["enabled"])
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":200,"msg":"ok"}`))
+	}))
+	defer srv.Close()
+
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT COUNT").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	a := newTestAdapterWithDB(srv.URL, ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	reqBody := `{"enabled":true}`
+	gc.Request = httptest.NewRequest(http.MethodPost, "/v1/voice/local-config/reset", bytes.NewBufferString(reqBody))
+	gc.Request.Header.Set("Content-Type", "application/json")
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.resetLocalConfig(wkCtx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["msg"] != "ok" {
+		t.Errorf("expected msg='ok', got %v", body["msg"])
+	}
+}
+
+func TestResetLocalConfig_MissingSpaceID(t *testing.T) {
+	a := newTestAdapter("http://unused")
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	reqBody := `{"enabled":true}`
+	gc.Request = httptest.NewRequest(http.MethodPost, "/v1/voice/local-config/reset", bytes.NewBufferString(reqBody))
+	gc.Request.Header.Set("Content-Type", "application/json")
+	gc.Set("uid", "user1")
+	ctx := &wkhttp.Context{Context: gc}
+	a.resetLocalConfig(ctx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["msg"] != "X-Space-ID header is required" {
+		t.Errorf("expected msg='X-Space-ID header is required', got %v", body["msg"])
+	}
+}
+
+func TestResetLocalConfig_MissingEnabled(t *testing.T) {
+	ctx, _, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+
+	a := newTestAdapterWithDB("http://unused", ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	reqBody := `{}`
+	gc.Request = httptest.NewRequest(http.MethodPost, "/v1/voice/local-config/reset", bytes.NewBufferString(reqBody))
+	gc.Request.Header.Set("Content-Type", "application/json")
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.resetLocalConfig(wkCtx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["msg"] != "enabled is required" {
+		t.Errorf("expected msg='enabled is required', got %v", body["msg"])
+	}
+}
+
+func TestResetLocalConfig_NotMember(t *testing.T) {
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT COUNT").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	a := newTestAdapterWithDB("http://unused", ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	reqBody := `{"enabled":true}`
+	gc.Request = httptest.NewRequest(http.MethodPost, "/v1/voice/local-config/reset", bytes.NewBufferString(reqBody))
+	gc.Request.Header.Set("Content-Type", "application/json")
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.resetLocalConfig(wkCtx)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["msg"] != "not a member of this space" {
+		t.Errorf("expected msg='not a member of this space', got %v", body["msg"])
+	}
+}
+
+func TestResetLocalConfig_SpeechError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer srv.Close()
+
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT COUNT").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	a := newTestAdapterWithDB(srv.URL, ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	reqBody := `{"enabled":false}`
+	gc.Request = httptest.NewRequest(http.MethodPost, "/v1/voice/local-config/reset", bytes.NewBufferString(reqBody))
+	gc.Request.Header.Set("Content-Type", "application/json")
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.resetLocalConfig(wkCtx)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d", rec.Code)
+	}
+}
+
+func TestResetLocalConfig_BodyTooLarge(t *testing.T) {
+	ctx, _, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+
+	a := newTestAdapterWithDB("http://unused", ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	largeBody := `{"enabled":true,"extra":"` + strings.Repeat("a", 65*1024) + `"}`
+	gc.Request = httptest.NewRequest(http.MethodPost, "/v1/voice/local-config/reset", bytes.NewBufferString(largeBody))
+	gc.Request.Header.Set("Content-Type", "application/json")
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.resetLocalConfig(wkCtx)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["msg"] != "request body too large" {
+		t.Errorf("expected msg='request body too large', got %v", body["msg"])
+	}
+}
+
+func TestResetLocalConfig_MembershipDBError(t *testing.T) {
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT COUNT").WillReturnError(sqlmock.ErrCancelled)
+
+	a := newTestAdapterWithDB("http://unused", ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	reqBody := `{"enabled":true}`
+	gc.Request = httptest.NewRequest(http.MethodPost, "/v1/voice/local-config/reset", bytes.NewBufferString(reqBody))
+	gc.Request.Header.Set("Content-Type", "application/json")
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.resetLocalConfig(wkCtx)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["msg"] != "check space membership failed" {
+		t.Errorf("expected msg='check space membership failed', got %v", body["msg"])
+	}
+}
+
 func TestGetContext_QuerySpaceIDIgnored(t *testing.T) {
 	ctx, _, cleanup := newTestContextWithMockDB(t)
 	defer cleanup()

--- a/modules/voice_adapter/adapter_test.go
+++ b/modules/voice_adapter/adapter_test.go
@@ -939,6 +939,91 @@ func TestDeleteLocalConfigHandler_5xxReturnsBadGateway(t *testing.T) {
 	}
 }
 
+func TestDeleteLocalConfigHandler_Speech404ConfigNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"msg":"config not found","status":404}`))
+	}))
+	defer srv.Close()
+
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT COUNT").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	a := newTestAdapterWithDB(srv.URL, ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest(http.MethodDelete, "/v1/voice/local-config", nil)
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.deleteLocalConfig(wkCtx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["msg"] != "ok" {
+		t.Errorf("expected msg='ok', got %v", body["msg"])
+	}
+}
+
+func TestDeleteLocalConfigHandler_Speech404InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`not json at all`))
+	}))
+	defer srv.Close()
+
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT COUNT").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	a := newTestAdapterWithDB(srv.URL, ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest(http.MethodDelete, "/v1/voice/local-config", nil)
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.deleteLocalConfig(wkCtx)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestDeleteLocalConfigHandler_Speech404WrongStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"msg":"error","status":500}`))
+	}))
+	defer srv.Close()
+
+	ctx, mock, cleanup := newTestContextWithMockDB(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT COUNT").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	a := newTestAdapterWithDB(srv.URL, ctx)
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest(http.MethodDelete, "/v1/voice/local-config", nil)
+	gc.Request.Header.Set("X-Space-ID", "space1")
+	gc.Set("uid", "user1")
+	wkCtx := &wkhttp.Context{Context: gc}
+	a.deleteLocalConfig(wkCtx)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
 func TestGetConfig_NonMember(t *testing.T) {
 	ctx, mock, cleanup := newTestContextWithMockDB(t)
 	defer cleanup()

--- a/modules/voice_adapter/client.go
+++ b/modules/voice_adapter/client.go
@@ -263,6 +263,39 @@ func (c *SpeechClient) GetLocalConfig(ctx context.Context, subjectID, scopeType,
 	return result, nil
 }
 
+func (c *SpeechClient) ResetLocalConfig(ctx context.Context, subjectID, scopeType, scopeID string, enabled bool) error {
+	payload := map[string]interface{}{
+		"subject_id": subjectID,
+		"scope_type": scopeType,
+		"scope_id":   scopeID,
+		"enabled":    enabled,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/speech/local-config/reset", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return &SpeechServiceError{StatusCode: resp.StatusCode, Body: string(respBody)}
+	}
+	return nil
+}
+
 func (c *SpeechClient) DeleteLocalConfig(ctx context.Context, subjectID, scopeType, scopeID string) error {
 	params := url.Values{}
 	params.Set("subject_id", subjectID)


### PR DESCRIPTION
Two changes for local ASR config reset flow:

1. **Add POST /local-config/reset proxy endpoint** - proxies reset request to octo-speech service, preserving enabled state while resetting other fields to defaults.

2. **Fix 404 handling** - when octo-speech returns 404 (config not found), voice adapter now returns 200 with empty/default response instead of propagating the error, since 'not found' means 'using defaults'.


Closes #185
