### PR TITLE
feat(i18n): migrate modules/user/api.go to ResponseErrorL (Phase 2.1)

### DIFF
--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -670,7 +670,8 @@ func (u *User) userIM(c *wkhttp.Context) {
 func (u *User) qrcodeMy(c *wkhttp.Context) {
 	userModel, err := u.db.QueryByUID(c.GetLoginUID())
 	if err != nil {
-		c.ResponseErrorf("查询当前用户信息失败！", err)
+		u.Error("查询当前用户信息失败！", zap.String("uid", c.GetLoginUID()), zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userModel == nil {
@@ -1178,12 +1179,14 @@ func (u *User) wxLogin(c *wkhttp.Context) {
 		return
 	}
 	if accessTokenResp.StatusCode != http.StatusOK {
-		c.ResponseErrorf("请求验证微信access_token错误", fmt.Errorf("错误代码-> %d", accessTokenResp.StatusCode))
+		u.Error("请求验证微信access_token错误", zap.Int("status", accessTokenResp.StatusCode))
+		respondUserError(c, errcode.ErrUserWeChatExchangeFailed)
 		return
 	}
 	var bodyMap map[string]interface{}
 	if err = util.ReadJsonByByte([]byte(accessTokenResp.Body), &bodyMap); err != nil {
-		c.ResponseErrorf("解码微信access_token返回数据失败！", err)
+		u.Error("解码微信access_token返回数据失败！", zap.Error(err))
+		respondUserError(c, errcode.ErrUserDecodeFailed)
 		return
 	}
 	accessToken, ok := bodyMap["access_token"].(string)
@@ -1207,13 +1210,15 @@ func (u *User) wxLogin(c *wkhttp.Context) {
 	}
 
 	if wxUserInfoResp.StatusCode != http.StatusOK {
-		c.ResponseErrorf("获取微信用户资料请求错误", fmt.Errorf("错误代码-> %d", wxUserInfoResp.StatusCode))
+		u.Error("获取微信用户资料请求错误", zap.Int("status", wxUserInfoResp.StatusCode))
+		respondUserError(c, errcode.ErrUserWeChatProfileFailed)
 		return
 	}
 
 	var wxUserInfoBodyMap map[string]interface{}
 	if err = util.ReadJsonByByte([]byte(wxUserInfoResp.Body), &wxUserInfoBodyMap); err != nil {
-		c.ResponseErrorf("解码微信用户信息返回数据失败！", err)
+		u.Error("解码微信用户信息返回数据失败！", zap.Error(err))
+		respondUserError(c, errcode.ErrUserDecodeFailed)
 		return
 	}
 
@@ -2588,10 +2593,8 @@ func (u *User) sendLoginCheckPhoneCode(c *wkhttp.Context) {
 
 	userinfo, err := u.db.QueryByUID(req.UID)
 	if err != nil {
-		// PR #188 reviewer fix: legacy code used ErrUserChatPwdUpdateFailed
-		// for a user-lookup failure (wrong copy carried over from a copy-paste
-		// of setChatPwd). Both are Internal=true so the client wire message is
-		// unchanged, but ops dashboards keyed on error.code would mis-attribute.
+		// User-lookup failure here is a DB query error, NOT a chat-password
+		// update failure (mirror this code with loginCheckPhone below).
 		u.Error("查询用户信息失败！", zap.Error(err))
 		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
@@ -2648,7 +2651,7 @@ func (u *User) loginCheckPhone(c *wkhttp.Context) {
 
 	userInfo, err := u.db.QueryByUID(req.UID)
 	if err != nil {
-		// Same legacy mis-mapping as sendLoginCheckPhoneCode above; see comment there.
+		// User-lookup failure is a DB query error; mirror sendLoginCheckPhoneCode.
 		u.Error("查询用户信息失败！", zap.Error(err))
 		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
@@ -3753,7 +3756,8 @@ type authVerifyTokenResp struct {
 func (u *User) authVerifyToken(c *wkhttp.Context) {
 	var req authVerifyTokenReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseErrorf("invalid request: %v", err)
+		u.Warn("authVerifyToken 请求体格式错误", zap.Error(err))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if req.Token == "" {
@@ -3817,7 +3821,8 @@ type authVerifyBotResp struct {
 func (u *User) authVerifyBot(c *wkhttp.Context) {
 	var req authVerifyBotReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseErrorf("invalid request: %v", err)
+		u.Warn("authVerifyBot 请求体格式错误", zap.Error(err))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if req.BotToken == "" {

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -40,6 +40,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	common2 "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -319,21 +320,21 @@ func (u *User) quit(c *wkhttp.Context) {
 	err := u.ctx.QuitUserDevice(loginUID, int(config.Web)) // 退出web
 	if err != nil {
 		u.Error("退出web设备失败", zap.Error(err))
-		c.ResponseError(errors.New("退出web设备失败"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 
 	err = u.ctx.QuitUserDevice(loginUID, int(config.PC))
 	if err != nil {
 		u.Error("退出PC设备失败", zap.Error(err))
-		c.ResponseError(errors.New("退出PC设备失败"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 
 	err = u.ctx.GetRedisConn().Del(fmt.Sprintf("%s%s", u.userDeviceTokenPrefix, loginUID))
 	if err != nil {
 		u.Error("删除设备token失败！", zap.Error(err))
-		c.ResponseError(errors.New("删除设备token失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	c.ResponseOK()
@@ -344,13 +345,13 @@ func (u *User) clearRedDot(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	category := c.Param("category")
 	if category == "" {
-		c.ResponseError(errors.New("分类不能为空"))
+		respondUserRequestInvalid(c, "category")
 		return
 	}
 	userRedDot, err := u.db.queryUserRedDot(loginUID, category)
 	if err != nil {
 		u.Error("查询用户红点错误", zap.Error(err))
-		c.ResponseError(errors.New("查询用户红点错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userRedDot != nil {
@@ -358,7 +359,7 @@ func (u *User) clearRedDot(c *wkhttp.Context) {
 		err = u.db.updateUserRedDot(userRedDot)
 		if err != nil {
 			u.Error("修改用户红点错误", zap.Error(err))
-			c.ResponseError(errors.New("查询用户红点错误"))
+			respondUserError(c, errcode.ErrUserQueryFailed)
 			return
 		}
 	}
@@ -370,13 +371,13 @@ func (u *User) getRedDot(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	category := c.Param("category")
 	if category == "" {
-		c.ResponseError(errors.New("分类不能为空"))
+		respondUserRequestInvalid(c, "category")
 		return
 	}
 	userRedDot, err := u.db.queryUserRedDot(loginUID, UserRedDotCategoryFriendApply)
 	if err != nil {
 		u.Error("查询用户红点错误", zap.Error(err))
-		c.ResponseError(errors.New("查询用户红点错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	count := 0
@@ -589,14 +590,14 @@ func (u *User) uploadAvatar(c *wkhttp.Context) {
 		err := c.Request.ParseMultipartForm(1024 * 1024 * 20) // 20M
 		if err != nil {
 			u.Error("数据格式不正确！", zap.Error(err))
-			c.ResponseError(errors.New("数据格式不正确！"))
+			respondUserRequestInvalid(c, "")
 			return
 		}
 	}
 	file, _, err := c.Request.FormFile("file")
 	if err != nil {
 		u.Error("读取文件失败！", zap.Error(err))
-		c.ResponseError(errors.New("读取文件失败！"))
+		respondUserError(c, errcode.ErrUserFileOperationFailed)
 		return
 	}
 	avatarID := crc32.ChecksumIEEE([]byte(targetUID)) % uint32(u.ctx.GetConfig().Avatar.Partition)
@@ -607,7 +608,7 @@ func (u *User) uploadAvatar(c *wkhttp.Context) {
 	defer file.Close()
 	if err != nil {
 		u.Error("上传文件失败！", zap.Error(err))
-		c.ResponseError(errors.New("上传文件失败！"))
+		respondUserError(c, errcode.ErrUserFileOperationFailed)
 		return
 	}
 	friends, err := u.friendDB.QueryFriends(targetUID)
@@ -637,7 +638,7 @@ func (u *User) uploadAvatar(c *wkhttp.Context) {
 	err = u.db.UpdateUsersWithField("is_upload_avatar", "1", targetUID)
 	if err != nil {
 		u.Error("修改用户是否修改头像错误！", zap.Error(err))
-		c.ResponseError(errors.New("修改用户是否修改头像错误！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	c.ResponseOK()
@@ -653,13 +654,13 @@ func (u *User) userIM(c *wkhttp.Context) {
 	resp, err := network.Get(fmt.Sprintf("%s/route?uid=%s", u.ctx.GetConfig().WuKongIM.APIURL, uid), nil, headers)
 	if err != nil {
 		u.Error("调用IM服务失败！", zap.Error(err))
-		c.ResponseError(errors.New("调用IM服务失败！"))
+		respondUserError(c, errcode.ErrUserIMCallFailed)
 		return
 	}
 	var resultMap map[string]interface{}
 	err = util.ReadJsonByByte([]byte(resp.Body), &resultMap)
 	if err != nil {
-		c.ResponseError(err)
+		respondUserServiceError(c)
 		return
 	}
 	c.JSON(resp.StatusCode, resultMap)
@@ -672,11 +673,11 @@ func (u *User) qrcodeMy(c *wkhttp.Context) {
 		return
 	}
 	if userModel == nil {
-		c.ResponseError(errors.New("登录用户不存在！"))
+		respondUserError(c, errcode.ErrUserCurrentNotFound)
 		return
 	}
 	if userModel.QRVercode == "" {
-		c.ResponseError(errors.New("用户没有QRVercode，非法操作！"))
+		respondUserError(c, errcode.ErrUserQRVerCodeMissing)
 		return
 	}
 	path := strings.ReplaceAll(u.ctx.GetConfig().QRCodeInfoURL, ":code", fmt.Sprintf("vercode_%s", userModel.QRVercode))
@@ -705,17 +706,17 @@ func (u *User) qrcodeMy(c *wkhttp.Context) {
 func (u *User) currentUser(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	if loginUID == "" {
-		c.ResponseError(errors.New("未登录"))
+		respondUserNotLoggedIn(c)
 		return
 	}
 	userInfo, err := u.db.QueryByUID(loginUID)
 	if err != nil {
 		u.Error("查询当前用户信息失败", zap.Error(err), zap.String("uid", loginUID))
-		c.ResponseError(errors.New("查询当前用户信息失败"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userInfo == nil {
-		c.ResponseError(errors.New("当前用户不存在"))
+		respondUserError(c, errcode.ErrUserCurrentNotFound)
 		return
 	}
 	// token 回显请求头 token：/user/current 不换发 token,避免干扰现有会话;
@@ -753,20 +754,20 @@ const languageMaxLen = 64
 func (u *User) setLanguage(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	if loginUID == "" {
-		c.ResponseError(errors.New("未登录"))
+		respondUserNotLoggedIn(c)
 		return
 	}
 	var req setLanguageReq
 	if err := c.BindJSON(&req); err != nil {
 		u.Error("language 请求体格式错误", zap.Error(err), zap.String("uid", loginUID))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	// Length gate runs BEFORE any zap.String("language", req.Language) so an
 	// attacker can't amplify a multi-KB payload into the log pipeline.
 	if len(req.Language) > languageMaxLen {
 		u.Error("language 请求过长", zap.String("uid", loginUID), zap.Int("len", len(req.Language)))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if err := u.languageService.SetLanguage(c.Request.Context(), loginUID, req.Language); err != nil {
@@ -777,10 +778,10 @@ func (u *User) setLanguage(c *wkhttp.Context) {
 		u.Error("设置用户语言偏好失败",
 			zap.Error(err), zap.String("uid", loginUID), zap.String("language", req.Language))
 		if errors.Is(err, ErrUnsupportedLanguage) {
-			c.ResponseError(errors.New("不支持的语言"))
+			respondUserError(c, errcode.ErrUserLanguageUnsupported)
 			return
 		}
-		c.ResponseError(errors.New("设置语言偏好失败！"))
+		respondUserError(c, errcode.ErrUserLanguageSetFailed)
 		return
 	}
 	c.ResponseOK()
@@ -793,37 +794,37 @@ func (u *User) userUpdateWithField(c *wkhttp.Context) {
 	var reqMap map[string]interface{}
 	if err := c.BindJSON(&reqMap); err != nil {
 		u.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	// 查询用户信息
 	users, err := u.db.QueryByUID(loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("查询用户信息出错！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if users == nil {
-		c.ResponseError(errors.New("用户信息不存在！"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 
 	for key, value := range reqMap {
 		//是否允许更新此field
 		if !allowUpdateUserField(key) {
-			c.ResponseError(errors.New("不允许更新【" + key + "】"))
+			respondUserUpdateNotAllowed(c, key)
 			return
 		}
 		if key == "short_no" {
 			if u.ctx.GetConfig().ShortNo.EditOff {
-				c.ResponseError(errors.New("不允许编辑！"))
+				respondUserUpdateNotAllowed(c, "")
 				return
 			}
 			if users.ShortStatus == 1 {
-				c.ResponseError(errors.New("用户短编号只能修改一次"))
+				respondUserError(c, errcode.ErrUserShortNoAlreadyChanged)
 				return
 			}
 			if len(fmt.Sprintf("%v", value)) < 6 || len(fmt.Sprintf("%v", value)) > 20 {
-				c.ResponseError(errors.New("短号须以字母开头，仅支持使用6～20个字母、数字、下划线、减号自由组合"))
+				respondUserError(c, errcode.ErrUserShortNoFormatInvalid)
 				return
 			}
 			isLetter := true
@@ -846,24 +847,24 @@ func (u *User) userUpdateWithField(c *wkhttp.Context) {
 				}
 			}
 			if !isLetter || !isIncludeNum {
-				c.ResponseError(errors.New("短号须以字母开头，仅支持使用6～20个字母、数字、下划线、减号自由组合"))
+				respondUserError(c, errcode.ErrUserShortNoFormatInvalid)
 				return
 			}
 			users, err = u.db.QueryUserWithOnlyShortNo(fmt.Sprintf("%v", value))
 			if err != nil {
 				u.Error("通过short_no查询用户失败！", zap.Error(err), zap.String("shortNo", key))
-				c.ResponseError(errors.New("通过short_no查询用户失败！"))
+				respondUserError(c, errcode.ErrUserQueryFailed)
 				return
 			}
 			if users != nil {
-				c.ResponseError(errors.New("已存在，请换一个！"))
+				respondUserError(c, errcode.ErrUserAlreadyExists)
 				return
 			}
 
 			tx, err := u.db.session.Begin()
 			if err != nil {
 				u.Error("创建事务失败！", zap.Error(err))
-				c.ResponseError(errors.New("创建事务失败！"))
+				respondUserError(c, errcode.ErrUserStoreFailed)
 				return
 			}
 			defer func() {
@@ -874,21 +875,21 @@ func (u *User) userUpdateWithField(c *wkhttp.Context) {
 			}()
 			err = u.db.UpdateUsersWithFieldTx(key, fmt.Sprintf("%v", value), loginUID, tx)
 			if err != nil {
-				c.ResponseError(errors.New("修改用户资料失败"))
+				respondUserError(c, errcode.ErrUserStoreFailed)
 				tx.Rollback()
 				return
 			}
 			err = u.db.UpdateUsersWithFieldTx("short_status", "1", loginUID, tx)
 			if err != nil {
 				u.Error("修改用户资料失败", zap.Error(err), zap.Any(key, value))
-				c.ResponseError(errors.New("修改用户资料失败"))
+				respondUserError(c, errcode.ErrUserStoreFailed)
 				tx.Rollback()
 				return
 			}
 			err = tx.Commit()
 			if err != nil {
 				u.Error("数据库事物提交失败", zap.Error(err))
-				c.ResponseError(errors.New("数据库事物提交失败"))
+				respondUserError(c, errcode.ErrUserStoreFailed)
 				tx.Rollback()
 				return
 			}
@@ -899,11 +900,11 @@ func (u *User) userUpdateWithField(c *wkhttp.Context) {
 		if key == "name" {
 			nameStr := fmt.Sprintf("%s", value)
 			if nameStr == "" {
-				c.ResponseError(errors.New("名字不能为空！"))
+				respondUserRequestInvalid(c, "name")
 				return
 			}
 			if err := ValidateName(nameStr); err != nil {
-				c.ResponseError(err)
+				respondUserServiceError(c)
 				return
 			}
 		}
@@ -911,7 +912,7 @@ func (u *User) userUpdateWithField(c *wkhttp.Context) {
 		err = u.db.UpdateUsersWithField(key, fmt.Sprintf("%v", value), loginUID)
 		if err != nil {
 			u.Error("修改用户资料失败", zap.Error(err))
-			c.ResponseError(errors.New("修改用户资料失败"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 		if key == "name" {
@@ -934,13 +935,13 @@ func (u *User) userUpdateWithField(c *wkhttp.Context) {
 			})
 			if encErr != nil {
 				u.Error("编码token缓存失败！", zap.Error(encErr))
-				c.ResponseError(errors.New("重新设置token缓存失败！"))
+				respondUserError(c, errcode.ErrUserStoreFailed)
 				return
 			}
 			err = u.ctx.Cache().Set(u.ctx.GetConfig().Cache.TokenCachePrefix+loginToken, payload)
 			if err != nil {
 				u.Error("重新设置token缓存失败！", zap.Error(err))
-				c.ResponseError(errors.New("重新设置token缓存失败！"))
+				respondUserError(c, errcode.ErrUserStoreFailed)
 				return
 			}
 		}
@@ -949,7 +950,7 @@ func (u *User) userUpdateWithField(c *wkhttp.Context) {
 	friends, err := u.friendDB.QueryFriends(loginUID)
 	if err != nil {
 		u.Error("查询用户好友错误", zap.Error(err))
-		c.ResponseError(errors.New("查询用户好友错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if len(friends) > 0 {
@@ -967,7 +968,7 @@ func (u *User) userUpdateWithField(c *wkhttp.Context) {
 		})
 		if err != nil {
 			u.Error("发送频道更改消息错误！", zap.Error(err))
-			c.ResponseError(errors.New("发送频道更改消息错误！"))
+			respondUserError(c, errcode.ErrUserIMCallFailed)
 			return
 		}
 	}
@@ -981,17 +982,17 @@ func (u *User) userUpdateSetting(c *wkhttp.Context) {
 	var reqMap map[string]interface{}
 	if err := c.BindJSON(&reqMap); err != nil {
 		u.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	// 查询用户信息
 	users, err := u.db.QueryByUID(loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("查询用户信息出错！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if users == nil {
-		c.ResponseError(errors.New("用户信息不存在！"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 	for key, value := range reqMap {
@@ -1006,7 +1007,7 @@ func (u *User) userUpdateSetting(c *wkhttp.Context) {
 			key == "mute_of_app" {
 			if key == "device_lock" && fmt.Sprintf("%v", value) == "1" {
 				if users.Phone == "15900000002" || users.Phone == "15900000003" || users.Phone == "15900000004" || users.Phone == "15900000005" || users.Phone == "15900000006" {
-					c.ResponseError(errors.New("演示账号不支持开启设备锁"))
+					respondUserError(c, errcode.ErrUserDemoLockUnsupported)
 					return
 				}
 
@@ -1014,7 +1015,7 @@ func (u *User) userUpdateSetting(c *wkhttp.Context) {
 			err = u.db.UpdateUsersWithField(key, fmt.Sprintf("%v", value), loginUID)
 			if err != nil {
 				u.Error("修改用户资料失败", zap.Error(err))
-				c.ResponseError(errors.New("修改用户资料失败"))
+				respondUserError(c, errcode.ErrUserStoreFailed)
 				return
 			}
 		}
@@ -1037,11 +1038,11 @@ func (u *User) get(c *wkhttp.Context) {
 	userDetailResp, err := u.userService.GetUserDetail(uid, loginUID)
 	if err != nil {
 		u.Error("获取用户详情失败！", zap.Error(err))
-		c.ResponseError(errors.New("获取用户详情失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userDetailResp == nil {
-		c.ResponseError(errors.New("用户不存在！"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 	isShowShortNo := false
@@ -1156,11 +1157,11 @@ func (u *User) wxLogin(c *wkhttp.Context) {
 	}
 	var req wxLoginReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if req.Code == "" {
-		c.ResponseError(errors.New("微信code不能为空"))
+		respondUserRequestInvalid(c, "code")
 		return
 	}
 	accessTokenResp, err := network.Get("https://api.weixin.qq.com/sns/oauth2/access_token", map[string]string{
@@ -1171,7 +1172,7 @@ func (u *User) wxLogin(c *wkhttp.Context) {
 	}, nil)
 	if err != nil {
 		u.Error("获取微信access_token错误", zap.Error(err))
-		c.ResponseError(errors.New("获取微信access_token错误"))
+		respondUserError(c, errcode.ErrUserWeChatExchangeFailed)
 		return
 	}
 	if accessTokenResp.StatusCode != http.StatusOK {
@@ -1185,12 +1186,12 @@ func (u *User) wxLogin(c *wkhttp.Context) {
 	}
 	accessToken, ok := bodyMap["access_token"].(string)
 	if !ok {
-		c.ResponseError(errors.New("微信返回数据格式错误：缺少access_token"))
+		respondUserError(c, errcode.ErrUserWeChatResponseInvalid)
 		return
 	}
 	openid, ok := bodyMap["openid"].(string)
 	if !ok {
-		c.ResponseError(errors.New("微信返回数据格式错误：缺少openid"))
+		respondUserError(c, errcode.ErrUserWeChatResponseInvalid)
 		return
 	}
 	wxUserInfoResp, err := network.Get("https://api.weixin.qq.com/sns/userinfo", map[string]string{
@@ -1199,7 +1200,7 @@ func (u *User) wxLogin(c *wkhttp.Context) {
 	}, nil)
 	if err != nil {
 		u.Error("获取微信用户资料错误", zap.Error(err))
-		c.ResponseError(errors.New("获取微信用户资料错误"))
+		respondUserError(c, errcode.ErrUserWeChatProfileFailed)
 		return
 	}
 
@@ -1233,12 +1234,12 @@ func (u *User) wxLogin(c *wkhttp.Context) {
 	userInfo, err := u.db.queryWithWXOpenIDAndWxUnionidCtx(loginSpanCtx, openid, unionid)
 	if err != nil {
 		u.Error("通过微信openid查询用户是否存在错误", zap.Error(err))
-		c.ResponseError(errors.New("通过微信openid查询用户是否存在错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userInfo != nil {
 		if userInfo.IsDestroy == IsDestroyDone {
-			c.ResponseError(errors.New("用户不存在"))
+			respondUserError(c, errcode.ErrUserNotFound)
 			return
 		}
 		u.execLoginAndRespose(userInfo, config.DeviceFlag(req.Flag), req.Device, loginSpanCtx, c)
@@ -1284,22 +1285,22 @@ func (u *User) wxLogin(c *wkhttp.Context) {
 // 登录
 func (u *User) login(c *wkhttp.Context) {
 	if common2.EnsureSystemSettings(u.ctx).LocalLoginOff() {
-		c.ResponseError(errors.New("本地登录已关闭"))
+		respondUserError(c, errcode.ErrUserLocalLoginDisabled)
 		return
 	}
 
 	var req loginReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if err := req.Check(); err != nil {
-		c.ResponseError(err)
+		respondUserServiceError(c)
 		return
 	}
 	if err := u.loginGuard.Check(req.Username); err != nil {
 		u.Warn("登录被临时锁定", zap.String("username", req.Username), zap.Error(err))
-		c.ResponseError(err)
+		respondUserServiceError(c)
 		return
 	}
 	loginSpan := u.ctx.Tracer().StartSpan(
@@ -1313,26 +1314,26 @@ func (u *User) login(c *wkhttp.Context) {
 	userInfo, err := u.db.QueryByUsernameCxt(loginSpanCtx, req.Username)
 	if err != nil {
 		u.Error("查询用户信息失败！", zap.String("username", req.Username))
-		c.ResponseError(err)
+		respondUserServiceError(c)
 		return
 	}
 	// 已注销 / 被禁用账号统一拒绝；与 emailLogin / usernameLogin 行为对齐
 	if userInfo == nil || userInfo.IsDestroy == IsDestroyDone || userInfo.Status == 0 {
 		u.loginGuard.RecordFailureLogged(req.Username)
 		// 统一错误消息，避免攻击者通过响应差异枚举有效账号
-		c.ResponseError(errors.New("用户名或密码错误"))
+		respondUserError(c, errcode.ErrUserInvalidCredentials)
 		return
 	}
 	if userInfo.Password == "" {
 		// 同样走失败计数 + 通用错误消息，避免攻击者区分"账号不允许登录"与"密码错误"
 		u.loginGuard.RecordFailureLogged(req.Username)
-		c.ResponseError(errors.New("用户名或密码错误"))
+		respondUserError(c, errcode.ErrUserInvalidCredentials)
 		return
 	}
 	matched, needsMigration := CheckPassword(req.Password, userInfo.Password)
 	if !matched {
 		u.loginGuard.RecordFailureLogged(req.Username)
-		c.ResponseError(errors.New("用户名或密码错误"))
+		respondUserError(c, errcode.ErrUserInvalidCredentials)
 		return
 	}
 	u.loginGuard.ResetLogged(req.Username)
@@ -1363,7 +1364,7 @@ func (u *User) execLoginAndRespose(userInfo *Model, flag config.DeviceFlag, devi
 			})
 			return
 		}
-		c.ResponseError(err)
+		respondUserServiceError(c)
 		return
 	}
 
@@ -1552,16 +1553,16 @@ func (u *User) sentWelcomeMsg(publicIP, uid string) {
 func (u *User) register(c *wkhttp.Context) {
 	var req registerReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if err := req.CheckRegister(); err != nil {
-		c.ResponseError(err)
+		respondUserServiceError(c)
 		return
 	}
 
 	if common2.EnsureSystemSettings(u.ctx).RegisterOff() {
-		c.ResponseError(errors.New("注册通道暂不开放，请长按标题使用官网上演示账号登录"))
+		respondUserError(c, errcode.ErrUserRegistrationClosed)
 		return
 	}
 	// 仅中国号码闸门必须在 register 这里再判一次：sendRegisterCode 处的
@@ -1571,13 +1572,13 @@ func (u *User) register(c *wkhttp.Context) {
 	// 闭合 time-of-check vs time-of-use 缺口。
 	if common2.EnsureSystemSettings(u.ctx).RegisterOnlyChina() &&
 		strings.TrimSpace(req.Zone) != "0086" {
-		c.ResponseError(errors.New("仅仅支持中国大陆手机号注册！"))
+		respondUserError(c, errcode.ErrUserPhoneRegionUnsupported)
 		return
 	}
 	appConfig, err := u.commonService.GetAppConfig()
 	if err != nil {
 		u.Error("查询应用设置错误", zap.Error(err))
-		c.ResponseError(err)
+		respondUserServiceError(c)
 		return
 	}
 	var registerInviteOn = 0
@@ -1587,7 +1588,7 @@ func (u *User) register(c *wkhttp.Context) {
 	var invite *model.Invite
 	if registerInviteOn == 1 {
 		if req.InviteCode == "" {
-			c.ResponseError(errors.New("邀请码不能为空"))
+			respondUserRequestInvalid(c, "invite_code")
 			return
 		}
 		var inviteCodeIsExist = false
@@ -1602,7 +1603,7 @@ func (u *User) register(c *wkhttp.Context) {
 			}
 		}
 		if !inviteCodeIsExist {
-			c.ResponseError(errors.New("邀请码不存在"))
+			respondUserError(c, errcode.ErrUserInviteCodeNotFound)
 			return
 		}
 	}
@@ -1618,24 +1619,24 @@ func (u *User) register(c *wkhttp.Context) {
 	userInfo, err := u.db.QueryByUsernameCxt(registerSpanCtx, fmt.Sprintf("%s%s", req.Zone, req.Phone))
 	if err != nil {
 		u.Error("查询用户信息失败！", zap.String("username", req.Phone))
-		c.ResponseError(err)
+		respondUserServiceError(c)
 		return
 	}
 	if userInfo != nil {
-		c.ResponseError(errors.New("该用户已存在"))
+		respondUserError(c, errcode.ErrUserAlreadyExists)
 		return
 	}
 	//测试模式（仅非 release 生效）
 	if commonapi.IsTestCodeEnabled(u.ctx.GetConfig()) {
 		if !commonapi.MatchTestCode(u.ctx.GetConfig(), req.Code) {
-			c.ResponseError(errors.New("验证码错误"))
+			respondUserError(c, errcode.ErrUserCodeInvalid)
 			return
 		}
 	} else {
 		//线上验证短信验证码
 		err = u.smsServie.Verify(registerSpanCtx, req.Zone, req.Phone, req.Code, commonapi.CodeTypeRegister)
 		if err != nil {
-			c.ResponseError(err)
+			respondUserServiceError(c)
 			return
 		}
 	}
@@ -1660,7 +1661,7 @@ func (u *User) search(c *wkhttp.Context) {
 	useModel, err := u.db.QueryByKeyword(keyword)
 	if err != nil {
 		u.Error("查询用户信息失败！", zap.Error(err), zap.String("keyword", keyword))
-		c.ResponseError(errors.New("查询用户信息失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if useModel == nil {
@@ -1674,7 +1675,7 @@ func (u *User) search(c *wkhttp.Context) {
 		isMember, err := spacepkg.CheckMembership(u.ctx.DB(), spaceID, useModel.UID)
 		if err != nil {
 			u.Error("校验 Space 成员错误", zap.Error(err))
-			c.ResponseError(errors.New("校验成员关系错误"))
+			respondUserError(c, errcode.ErrUserQueryFailed)
 			return
 		}
 		if !isMember {
@@ -1691,7 +1692,7 @@ func (u *User) search(c *wkhttp.Context) {
 			shared, err := spacepkg.HaveCommonSpace(u.ctx.DB(), loginUID, useModel.UID)
 			if err != nil {
 				u.Error("校验共同 Space 错误", zap.Error(err))
-				c.ResponseError(errors.New("校验共同 Space 错误"))
+				respondUserError(c, errcode.ErrUserQueryFailed)
 				return
 			}
 			if !shared {
@@ -1739,25 +1740,25 @@ func (u *User) registerUserDeviceToken(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		u.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if strings.TrimSpace(req.DeviceToken) == "" {
-		c.ResponseError(errors.New("设备token不能为空！"))
+		respondUserRequestInvalid(c, "device_token")
 		return
 	}
 	if strings.TrimSpace(req.DeviceType) == "" {
-		c.ResponseError(errors.New("设备类型不能为空！"))
+		respondUserRequestInvalid(c, "device_type")
 		return
 	}
 	if strings.TrimSpace(req.BundleID) == "" {
-		c.ResponseError(errors.New("bundleID不能为空！"))
+		respondUserRequestInvalid(c, "bundle_id")
 		return
 	}
 	err := u.ctx.GetRedisConn().Hmset(fmt.Sprintf("%s%s", u.userDeviceTokenPrefix, loginUID), "device_type", req.DeviceType, "device_token", req.DeviceToken, "bundle_id", req.BundleID)
 	if err != nil {
 		u.Error("存储用户设备token失败！", zap.Error(err))
-		c.ResponseError(errors.New("存储用户设备token失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	c.ResponseOK()
@@ -1771,13 +1772,13 @@ func (u *User) registerUserDeviceBadge(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		u.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	err := u.setUserBadge(loginUID, int64(req.Badge))
 	if err != nil {
 		u.Error("存储用户红点失败！", zap.Error(err))
-		c.ResponseError(errors.New("存储用户红点失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	c.ResponseOK()
@@ -1798,7 +1799,7 @@ func (u *User) unregisterUserDeviceToken(c *wkhttp.Context) {
 	err := u.ctx.GetRedisConn().Del(fmt.Sprintf("%s%s", u.userDeviceTokenPrefix, loginUID))
 	if err != nil {
 		u.Error("删除设备token失败！", zap.Error(err))
-		c.ResponseError(errors.New("删除设备token失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	c.ResponseOK()
@@ -1817,7 +1818,7 @@ func (u *User) getLoginUUID(c *wkhttp.Context) {
 	})), time.Minute*1)
 	if err != nil {
 		u.Error("设置登录uuid失败！", zap.Error(err))
-		c.ResponseError(errors.New("设置登录uuid失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	// 缓存设备信息
@@ -1829,7 +1830,7 @@ func (u *User) getLoginUUID(c *wkhttp.Context) {
 		}), time.Minute*2)
 		if err != nil {
 			u.Error("设置登录设备信息失败！", zap.Error(err))
-			c.ResponseError(errors.New("设置登录设备信息失败！"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 	}
@@ -1845,7 +1846,7 @@ func (u *User) getloginStatus(c *wkhttp.Context) {
 	qrcodeInfo, err := u.ctx.GetRedisConn().GetString(fmt.Sprintf("%s%s", common.QRCodeCachePrefix, uuid))
 	if err != nil {
 		u.Error("获取uuid绑定的二维码信息失败！", zap.Error(err))
-		c.ResponseError(errors.New("获取uuid绑定的二维码信息失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if qrcodeInfo == "" {
@@ -1858,7 +1859,7 @@ func (u *User) getloginStatus(c *wkhttp.Context) {
 	err = util.ReadJsonByByte([]byte(qrcodeInfo), &qrcodeModel)
 	if err != nil {
 		u.Error("解码二维码信息失败！", zap.Error(err))
-		c.ResponseError(errors.New("解码二维码信息失败！"))
+		respondUserError(c, errcode.ErrUserDecodeFailed)
 		return
 	}
 	if qrcodeModel == nil {
@@ -1898,39 +1899,39 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 	authInfo, err := u.ctx.GetRedisConn().GetString(authCodeKey)
 	if err != nil {
 		u.Error("获取授权信息失败！", zap.Error(err))
-		c.ResponseError(errors.New("获取授权信息失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if authInfo == "" {
-		c.ResponseError(errors.New("授权码失效或不存在！"))
+		respondUserError(c, errcode.ErrUserAuthCodeNotFound)
 		return
 	}
 	var authInfoMap map[string]interface{}
 	err = util.ReadJsonByByte([]byte(authInfo), &authInfoMap)
 	if err != nil {
 		u.Error("解码授权信息失败！", zap.Error(err))
-		c.ResponseError(errors.New("解码授权信息失败！"))
+		respondUserError(c, errcode.ErrUserDecodeFailed)
 		return
 	}
 	authType, ok := authInfoMap["type"].(string)
 	if !ok {
-		c.ResponseError(errors.New("授权信息格式错误：缺少type"))
+		respondUserAuthInfoInvalid(c, "type")
 		return
 	}
 	if authType != string(common.AuthCodeTypeScanLogin) {
-		c.ResponseError(errors.New("授权码不是登录授权码！"))
+		respondUserError(c, errcode.ErrUserAuthCodeWrongType)
 		return
 	}
 	scaner, ok := authInfoMap["scaner"].(string)
 	if !ok {
-		c.ResponseError(errors.New("授权信息格式错误：缺少scaner"))
+		respondUserAuthInfoInvalid(c, "scaner")
 		return
 	}
 	// 获取老的token
 	token, err := u.ctx.Cache().Get(fmt.Sprintf("%s%d%s", u.ctx.GetConfig().Cache.UIDTokenCachePrefix, flag, scaner))
 	if err != nil {
 		u.Error("获取旧token错误", zap.Error(err))
-		c.ResponseError(errors.New("获取旧token错误"))
+		respondUserError(c, errcode.ErrUserIMCallFailed)
 		return
 	}
 	if strings.TrimSpace(token) == "" {
@@ -1940,12 +1941,12 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 	userModel, err := u.db.QueryByUID(scaner)
 	if err != nil {
 		u.Error("查询用户信息失败", zap.String("uid", scaner), zap.Error(err))
-		c.ResponseError(errors.New("查询用户信息失败"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	// 已注销账号拒绝授权登录；冷静期账号允许（与其他登录路径一致）
 	if userModel == nil || userModel.IsDestroy == IsDestroyDone {
-		c.ResponseError(errors.New("用户不存在"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 	// 获取缓存设备
@@ -1954,7 +1955,7 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 		deviceCache, err := u.ctx.GetRedisConn().GetString(fmt.Sprintf("%s%s", common.DeviceCacheUUIDPrefix, uuid))
 		if err != nil {
 			u.Error("获取登录设备信息失败！", zap.Error(err))
-			c.ResponseError(errors.New("获取登录设备信息失败！"))
+			respondUserError(c, errcode.ErrUserQueryFailed)
 			return
 		}
 		if deviceCache != "" {
@@ -1962,7 +1963,7 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 			err = util.ReadJsonByByte([]byte(deviceCache), &deviceInfoMap)
 			if err != nil {
 				u.Error("解码设备信息失败！", zap.Error(err))
-				c.ResponseError(errors.New("解码设备信息失败！"))
+				respondUserError(c, errcode.ErrUserDecodeFailed)
 				return
 			}
 			deviceId, _ := deviceInfoMap["device_id"].(string)
@@ -1985,7 +1986,7 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 				})
 				if err != nil {
 					u.Error("更新用户登录设备失败", zap.Error(err))
-					c.ResponseError(errors.New("更新用户登录设备失败"))
+					respondUserError(c, errcode.ErrUserStoreFailed)
 					return
 				}
 			}
@@ -1999,11 +2000,11 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 	})
 	if err != nil {
 		u.Error("更新IM的token失败！", zap.Error(err))
-		c.ResponseError(errors.New("更新IM的token失败！"))
+		respondUserError(c, errcode.ErrUserIMCallFailed)
 		return
 	}
 	if imResp.Status == config.UpdateTokenStatusBan {
-		c.ResponseError(errors.New("此账号已经被封禁！"))
+		respondUserError(c, errcode.ErrUserAccountBanned)
 		return
 	}
 
@@ -2020,20 +2021,20 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 	err = u.ctx.Cache().SetAndExpire(u.ctx.GetConfig().Cache.TokenCachePrefix+token, tokenPayload, u.ctx.GetConfig().Cache.TokenExpire)
 	if err != nil {
 		u.Error("设置token缓存失败！", zap.Error(err))
-		c.ResponseError(errors.New("设置token缓存失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	err = u.ctx.GetRedisConn().Del(authCodeKey)
 	if err != nil {
 		u.Error("删除授权码失败！", zap.Error(err))
-		c.ResponseError(errors.New("删除授权码失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 
 	err = u.ctx.Cache().SetAndExpire(fmt.Sprintf("%s%d%s", u.ctx.GetConfig().Cache.UIDTokenCachePrefix, flag, userModel.UID), token, u.ctx.GetConfig().Cache.TokenExpire)
 	if err != nil {
 		u.Error("设置uidtoken缓存失败！", zap.Error(err))
-		c.ResponseError(errors.New("设置uidtoken缓存失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 
@@ -2093,42 +2094,42 @@ func (u *User) grantLogin(c *wkhttp.Context) {
 	loginUID := c.MustGet("uid").(string)
 	encrypt := c.Query("encrypt") // signal相关密钥
 	if authCode == "" {
-		c.ResponseError(errors.New("授权码不能为空！"))
+		respondUserRequestInvalid(c, "auth_code")
 		return
 	}
 	authInfo, err := u.ctx.GetRedisConn().GetString(fmt.Sprintf("%s%s", common.AuthCodeCachePrefix, authCode))
 	if err != nil {
 		u.Error("获取授权信息失败！", zap.Error(err))
-		c.ResponseError(errors.New("获取授权信息失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if authInfo == "" {
-		c.ResponseError(errors.New("授权码失效或不存在！"))
+		respondUserError(c, errcode.ErrUserAuthCodeNotFound)
 		return
 	}
 	var authInfoMap map[string]interface{}
 	err = util.ReadJsonByByte([]byte(authInfo), &authInfoMap)
 	if err != nil {
 		u.Error("解码授权信息失败！", zap.Error(err))
-		c.ResponseError(errors.New("解码授权信息失败！"))
+		respondUserError(c, errcode.ErrUserDecodeFailed)
 		return
 	}
 	authType, ok := authInfoMap["type"].(string)
 	if !ok {
-		c.ResponseError(errors.New("授权信息格式错误：缺少type"))
+		respondUserAuthInfoInvalid(c, "type")
 		return
 	}
 	if authType != string(common.AuthCodeTypeScanLogin) {
-		c.ResponseError(errors.New("授权码不是登录授权码！"))
+		respondUserError(c, errcode.ErrUserAuthCodeWrongType)
 		return
 	}
 	scaner, ok := authInfoMap["scaner"].(string)
 	if !ok {
-		c.ResponseError(errors.New("授权信息格式错误：缺少scaner"))
+		respondUserAuthInfoInvalid(c, "scaner")
 		return
 	}
 	if scaner != loginUID {
-		c.ResponseError(errors.New("扫描者与授权者不是同一个用户！"))
+		respondUserError(c, errcode.ErrUserAuthScannerMismatch)
 		return
 	}
 	uuid, _ := authInfoMap["uuid"].(string)
@@ -2142,7 +2143,7 @@ func (u *User) grantLogin(c *wkhttp.Context) {
 	err = u.ctx.GetRedisConn().SetAndExpire(fmt.Sprintf("%s%s", common.QRCodeCachePrefix, uuid), util.ToJson(qrcodeInfo), time.Minute*5)
 	if err != nil {
 		u.Error("更新二维码信息失败！", zap.Error(err))
-		c.ResponseError(errors.New("更新二维码信息失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	SendQRCodeInfo(uuid, qrcodeInfo)
@@ -2154,13 +2155,13 @@ func (u *User) addBlacklist(c *wkhttp.Context) {
 	loginUID := c.MustGet("uid").(string)
 	uid := c.Param("uid")
 	if strings.TrimSpace(uid) == "" {
-		c.ResponseError(errors.New("添加黑名单的用户ID不能空！"))
+		respondUserRequestInvalid(c, "uid")
 		return
 	}
 	model, err := u.settingDB.QueryUserSettingModel(uid, loginUID)
 	if err != nil {
 		u.Error("查询用户设置失败", zap.Error(err))
-		c.ResponseError(errors.New("查询用户设置失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	//如果没有设置记录先添加一条记录
@@ -2172,7 +2173,7 @@ func (u *User) addBlacklist(c *wkhttp.Context) {
 		err = u.settingDB.InsertUserSettingModel(userSettingModel)
 		if err != nil {
 			u.Error("添加用户设置失败", zap.Error(err))
-			c.ResponseError(errors.New("添加用户设置失败！"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 	}
@@ -2180,18 +2181,18 @@ func (u *User) addBlacklist(c *wkhttp.Context) {
 	//添加黑名单
 	version, err := u.ctx.GenSeq(common.UserSettingSeqKey)
 	if err != nil {
-		c.ResponseError(err)
+		respondUserServiceError(c)
 		return
 	}
 	friendVersion, err := u.ctx.GenSeq(common.FriendSeqKey)
 	if err != nil {
-		c.ResponseError(err)
+		respondUserServiceError(c)
 		return
 	}
 	tx, err := u.ctx.DB().Begin()
 	if err != nil {
 		u.Error("开启事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("开启事务失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	defer func() {
@@ -2204,20 +2205,20 @@ func (u *User) addBlacklist(c *wkhttp.Context) {
 	if err != nil {
 		tx.Rollback()
 		u.Error("添加黑名单失败！", zap.Error(err))
-		c.ResponseError(errors.New("添加黑名单失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	err = u.friendDB.updateVersionTx(friendVersion, loginUID, uid, tx)
 	if err != nil {
 		tx.Rollback()
 		u.Error("更新好友的版本号失败！", zap.Error(err))
-		c.ResponseError(errors.New("更新好友的版本号失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	if err := tx.Commit(); err != nil {
 		tx.Rollback()
 		u.Error("提交数据库失败！", zap.Error(err))
-		c.ResponseError(errors.New("提交数据库失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 
@@ -2265,25 +2266,25 @@ func (u *User) removeBlacklist(c *wkhttp.Context) {
 	loginUID := c.MustGet("uid").(string)
 	uid := c.Param("uid")
 	if strings.TrimSpace(uid) == "" {
-		c.ResponseError(errors.New("移除黑名单的用户ID不能空！"))
+		respondUserRequestInvalid(c, "uid")
 		return
 	}
 
 	version, err := u.ctx.GenSeq(common.UserSettingSeqKey)
 	if err != nil {
-		c.ResponseError(err)
+		respondUserServiceError(c)
 		return
 	}
 	friendVersion, err := u.ctx.GenSeq(common.FriendSeqKey)
 	if err != nil {
-		c.ResponseError(err)
+		respondUserServiceError(c)
 		return
 	}
 
 	tx, err := u.ctx.DB().Begin()
 	if err != nil {
 		u.Error("开启事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("开启事务失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	defer func() {
@@ -2296,20 +2297,20 @@ func (u *User) removeBlacklist(c *wkhttp.Context) {
 	if err != nil {
 		tx.Rollback()
 		u.Error("移除黑名单失败！", zap.Error(err))
-		c.ResponseError(errors.New("移除黑名单失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	err = u.friendDB.updateVersionTx(friendVersion, loginUID, uid, tx)
 	if err != nil {
 		tx.Rollback()
 		u.Error("更新好友的版本号失败！", zap.Error(err))
-		c.ResponseError(errors.New("更新好友的版本号失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	if err := tx.Commit(); err != nil {
 		tx.Rollback()
 		u.Error("提交数据库失败！", zap.Error(err))
-		c.ResponseError(errors.New("提交数据库失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 
@@ -2358,7 +2359,7 @@ func (u *User) blacklists(c *wkhttp.Context) {
 	list, err := u.db.Blacklists(loginUID)
 	if err != nil {
 		u.Error("查询黑名单列表失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询黑名单列表失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	blacklists := []*blacklistResp{}
@@ -2375,25 +2376,25 @@ func (u *User) blacklists(c *wkhttp.Context) {
 // sendRegisterCode 发送注册短信
 func (u *User) sendRegisterCode(c *wkhttp.Context) {
 	if common2.EnsureSystemSettings(u.ctx).RegisterOff() {
-		c.ResponseError(errors.New("注册通道暂不开放，请长按标题使用官网上演示账号登录"))
+		respondUserError(c, errcode.ErrUserRegistrationClosed)
 		return
 	}
 	var req codeReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if strings.TrimSpace(req.Zone) == "" {
-		c.ResponseError(errors.New("区号不能为空！"))
+		respondUserRequestInvalid(c, "zone")
 		return
 	}
 	if strings.TrimSpace(req.Phone) == "" {
-		c.ResponseError(errors.New("手机号不能为空！"))
+		respondUserRequestInvalid(c, "phone")
 		return
 	}
 	if common2.EnsureSystemSettings(u.ctx).RegisterOnlyChina() {
 		if strings.TrimSpace(req.Zone) != "0086" {
-			c.ResponseError(errors.New("仅仅支持中国大陆手机号注册！"))
+			respondUserError(c, errcode.ErrUserPhoneRegionUnsupported)
 			return
 		}
 	}
@@ -2408,7 +2409,7 @@ func (u *User) sendRegisterCode(c *wkhttp.Context) {
 	model, err := u.db.QueryByPhone(req.Zone, req.Phone)
 	if err != nil {
 		u.Error("查询用户信息失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询用户信息失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if model != nil {
@@ -2420,7 +2421,7 @@ func (u *User) sendRegisterCode(c *wkhttp.Context) {
 	err = u.smsServie.SendVerifyCode(spanCtx, req.Zone, req.Phone, commonapi.CodeTypeRegister)
 	if err != nil {
 		u.Error("发送短信验证码失败", zap.Error(err))
-		c.ResponseError(errors.New("发送短信验证码失败！"))
+		respondUserError(c, errcode.ErrUserSMSSendFailed)
 		return
 	}
 	c.Response(map[string]interface{}{
@@ -2432,40 +2433,40 @@ func (u *User) sendRegisterCode(c *wkhttp.Context) {
 func (u *User) setChatPwd(c *wkhttp.Context) {
 	var req chatPwdReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if strings.TrimSpace(req.ChatPwd) == "" {
-		c.ResponseError(errors.New("聊天密码不能为空"))
+		respondUserRequestInvalid(c, "chat_pwd")
 		return
 	}
 	if strings.TrimSpace(req.LoginPwd) == "" {
-		c.ResponseError(errors.New("登录密码不能为空！"))
+		respondUserRequestInvalid(c, "login_pwd")
 		return
 	}
 	loginUID := c.MustGet("uid").(string)
 	user, err := u.db.QueryByUID(loginUID)
 	if err != nil {
 		u.Error("查询用户信息失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询用户信息失败"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	pwdMatched, _ := CheckPassword(req.LoginPwd, user.Password)
 	if !pwdMatched {
-		c.ResponseError(errors.New("登录密码错误"))
+		respondUserError(c, errcode.ErrUserInvalidCredentials)
 		return
 	}
 	//修改用户聊天密码
 	hashedChatPwd, err := HashPassword(req.ChatPwd)
 	if err != nil {
 		u.Error("哈希聊天密码失败！", zap.Error(err))
-		c.ResponseError(errors.New("修改聊天密码失败"))
+		respondUserError(c, errcode.ErrUserChatPwdUpdateFailed)
 		return
 	}
 	err = u.db.UpdateUsersWithField("chat_pwd", hashedChatPwd, loginUID)
 	if err != nil {
 		u.Error("查询用户信息失败！", zap.Error(err))
-		c.ResponseError(errors.New("修改聊天密码失败"))
+		respondUserError(c, errcode.ErrUserChatPwdUpdateFailed)
 		return
 	}
 	c.ResponseOK()
@@ -2477,22 +2478,22 @@ func (u *User) lockScreenAfterMinuteSet(c *wkhttp.Context) {
 		LockAfterMinute int `json:"lock_after_minute"` // 在几分钟后锁屏
 	}
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if req.LockAfterMinute < 0 {
-		c.ResponseError(errors.New("锁屏时间不能小于0"))
+		respondUserLockMinuteOutOfRange(c)
 		return
 	}
 	if req.LockAfterMinute > 60 {
-		c.ResponseError(errors.New("锁屏时间不能大于60分钟"))
+		respondUserLockMinuteOutOfRange(c)
 		return
 	}
 	loginUID := c.GetLoginUID()
 	err := u.db.UpdateUsersWithField("lock_after_minute", strconv.FormatInt(int64(req.LockAfterMinute), 10), loginUID)
 	if err != nil {
 		u.Error("修改用户锁屏密码错误", zap.Error(err))
-		c.ResponseError(errors.New("修改用户锁屏密码错误"))
+		respondUserError(c, errcode.ErrUserLockScreenPwdUpdateFailed)
 		return
 	}
 	c.ResponseOK()
@@ -2504,11 +2505,11 @@ func (u *User) setLockScreenPwd(c *wkhttp.Context) {
 		LockScreenPwd string `json:"lock_screen_pwd"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if strings.TrimSpace(req.LockScreenPwd) == "" {
-		c.ResponseError(errors.New("锁屏密码不能为空"))
+		respondUserRequestInvalid(c, "lock_screen_pwd")
 		return
 	}
 
@@ -2516,13 +2517,13 @@ func (u *User) setLockScreenPwd(c *wkhttp.Context) {
 	hashedLockPwd, err := HashPassword(req.LockScreenPwd)
 	if err != nil {
 		u.Error("哈希锁屏密码失败！", zap.Error(err))
-		c.ResponseError(errors.New("修改锁屏密码失败"))
+		respondUserError(c, errcode.ErrUserLockScreenPwdUpdateFailed)
 		return
 	}
 	err = u.db.UpdateUsersWithField("lock_screen_pwd", hashedLockPwd, loginUID)
 	if err != nil {
 		u.Error("修改用户锁屏密码错误", zap.Error(err))
-		c.ResponseError(errors.New("修改用户锁屏密码错误"))
+		respondUserError(c, errcode.ErrUserLockScreenPwdUpdateFailed)
 		return
 	}
 	c.ResponseOK()
@@ -2534,7 +2535,7 @@ func (u *User) closeLockScreenPwd(c *wkhttp.Context) {
 	err := u.db.UpdateUsersWithField("lock_screen_pwd", "", loginUID)
 	if err != nil {
 		u.Error("修改用户锁屏密码错误", zap.Error(err))
-		c.ResponseError(errors.New("修改用户锁屏密码错误"))
+		respondUserError(c, errcode.ErrUserLockScreenPwdUpdateFailed)
 		return
 	}
 	c.ResponseOK()
@@ -2546,7 +2547,7 @@ func (u *User) sendLoginCheckPhoneCode(c *wkhttp.Context) {
 	// 否则攻击者跳过 /v1/user/login 直接走二阶段仍能拿到 token,
 	// 同时还把短信通道当作免费枚举/滥发入口。
 	if common2.EnsureSystemSettings(u.ctx).LocalLoginOff() {
-		c.ResponseError(errors.New("本地登录已关闭"))
+		respondUserError(c, errcode.ErrUserLocalLoginDisabled)
 		return
 	}
 	var req struct {
@@ -2554,11 +2555,11 @@ func (u *User) sendLoginCheckPhoneCode(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		u.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if req.UID == "" {
-		c.ResponseError(errors.New("uid不能为空！"))
+		respondUserRequestInvalid(c, "uid")
 		return
 	}
 
@@ -2572,12 +2573,12 @@ func (u *User) sendLoginCheckPhoneCode(c *wkhttp.Context) {
 	userinfo, err := u.db.QueryByUID(req.UID)
 	if err != nil {
 		u.Error("查询用户信息失败！", zap.Error(err))
-		c.ResponseError(errors.New("修改聊天密码失败"))
+		respondUserError(c, errcode.ErrUserChatPwdUpdateFailed)
 		return
 	}
 	if userinfo == nil {
 		u.Error("该用户不存在", zap.Error(err))
-		c.ResponseError(errors.New("该用户不存在"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 	//发送短信
@@ -2589,7 +2590,7 @@ func (u *User) sendLoginCheckPhoneCode(c *wkhttp.Context) {
 	if err != nil {
 		u.Error("发送短信失败", zap.Error(err))
 		ext.LogError(span, err)
-		c.ResponseError(errors.New("发送短信失败"))
+		respondUserError(c, errcode.ErrUserSMSSendFailed)
 		return
 	}
 	c.ResponseOK()
@@ -2598,7 +2599,7 @@ func (u *User) sendLoginCheckPhoneCode(c *wkhttp.Context) {
 // loginCheckPhone 登录验证设备短信
 func (u *User) loginCheckPhone(c *wkhttp.Context) {
 	if common2.EnsureSystemSettings(u.ctx).LocalLoginOff() {
-		c.ResponseError(errors.New("本地登录已关闭"))
+		respondUserError(c, errcode.ErrUserLocalLoginDisabled)
 		return
 	}
 	var req struct {
@@ -2607,15 +2608,15 @@ func (u *User) loginCheckPhone(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		u.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if req.UID == "" {
-		c.ResponseError(errors.New("uid不能为空！"))
+		respondUserRequestInvalid(c, "uid")
 		return
 	}
 	if req.Code == "" {
-		c.ResponseError(errors.New("验证码不能为空！"))
+		respondUserRequestInvalid(c, "code")
 		return
 	}
 	span := u.ctx.Tracer().StartSpan(
@@ -2628,41 +2629,41 @@ func (u *User) loginCheckPhone(c *wkhttp.Context) {
 	userInfo, err := u.db.QueryByUID(req.UID)
 	if err != nil {
 		u.Error("查询用户信息失败！", zap.Error(err))
-		c.ResponseError(errors.New("修改聊天密码失败"))
+		respondUserError(c, errcode.ErrUserChatPwdUpdateFailed)
 		return
 	}
 	if userInfo == nil {
 		u.Error("该用户不存在", zap.Error(err))
-		c.ResponseError(errors.New("该用户不存在"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 	// 已注销账号拒绝设备验证登录；冷静期账号允许
 	if userInfo.IsDestroy == IsDestroyDone {
-		c.ResponseError(errors.New("该用户不存在"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 	err = u.smsServie.Verify(spanCtx, userInfo.Zone, userInfo.Phone, req.Code, commonapi.CodeTypeCheckMobile)
 	if err != nil {
 		u.Error("验证短信失败", zap.Error(err))
-		c.ResponseError(err)
+		respondUserServiceError(c)
 		return
 	}
 
 	loginDeviceJsonStr, err := u.ctx.GetRedisConn().GetString(fmt.Sprintf("%s%s", u.ctx.GetConfig().Cache.LoginDeviceCachePrefix, req.UID))
 	if err != nil {
 		u.Error("获取登录设备缓存失败！", zap.Error(err))
-		c.ResponseError(errors.New("获取登录设备缓存失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if loginDeviceJsonStr == "" {
-		c.ResponseError(errors.New("登录设备已过期，请重新登录"))
+		respondUserError(c, errcode.ErrUserLoginDeviceExpired)
 		return
 	}
 	var loginDeivce *deviceReq
 	err = util.ReadJsonByByte([]byte(loginDeviceJsonStr), &loginDeivce)
 	if err != nil {
 		u.Error("解码登录设备信息失败！", zap.Error(err), zap.String("uid", req.UID))
-		c.ResponseError(errors.New("解码登录设备信息失败！"))
+		respondUserError(c, errcode.ErrUserDecodeFailed)
 		return
 	}
 	err = u.deviceDB.insertOrUpdateDeviceCtx(spanCtx, &deviceModel{
@@ -2674,7 +2675,7 @@ func (u *User) loginCheckPhone(c *wkhttp.Context) {
 	})
 	if err != nil {
 		u.Error("添加或更新登录设备信息失败！", zap.Error(err))
-		c.ResponseError(errors.New("添加或更新登录设备信息失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	token := util.GenerUUID()
@@ -2686,13 +2687,13 @@ func (u *User) loginCheckPhone(c *wkhttp.Context) {
 	})
 	if err != nil {
 		u.Error("编码token缓存失败！", zap.Error(err))
-		c.ResponseError(errors.New("设置token缓存失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	err = u.ctx.Cache().SetAndExpire(u.ctx.GetConfig().Cache.TokenCachePrefix+token, tokenPayload, u.ctx.GetConfig().Cache.TokenExpire)
 	if err != nil {
 		u.Error("设置token缓存失败！", zap.Error(err))
-		c.ResponseError(errors.New("设置token缓存失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	// err = u.ctx.UpdateIMToken(userInfo.UID, token, config.DeviceFlag(0), config.DeviceLevelMaster)
@@ -2704,11 +2705,11 @@ func (u *User) loginCheckPhone(c *wkhttp.Context) {
 	})
 	if err != nil {
 		u.Error("更新IM的token失败！", zap.Error(err))
-		c.ResponseError(errors.New("更新IM的token失败！"))
+		respondUserError(c, errcode.ErrUserIMCallFailed)
 		return
 	}
 	if imResp.Status == config.UpdateTokenStatusBan {
-		c.ResponseError(errors.New("此账号已经被封禁！"))
+		respondUserError(c, errcode.ErrUserAccountBanned)
 		return
 	}
 	resp := newLoginUserDetailResp(userInfo, token, u.ctx)
@@ -2721,7 +2722,7 @@ func (u *User) customerservices(c *wkhttp.Context) {
 	list, err := u.db.QueryByCategory(CategoryCustomerService)
 	if err != nil {
 		u.Error("查询客服列表失败", zap.Error(err))
-		c.ResponseError(errors.New("查询客服列表失败"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	results := []*customerservicesResp{}
@@ -2742,24 +2743,24 @@ func (u *User) sendDestroyCode(c *wkhttp.Context) {
 	userInfo, err := u.db.QueryByUID(loginUID)
 	if err != nil {
 		u.Error("查询登录用户信息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询登录用户信息错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userInfo == nil {
-		c.ResponseError(errors.New("登录用户不存在"))
+		respondUserError(c, errcode.ErrUserCurrentNotFound)
 		return
 	}
 	switch userInfo.IsDestroy {
 	case IsDestroyApplying:
-		c.ResponseError(errors.New("账号已在注销冷静期中，请使用新版客户端撤销或查询状态"))
+		respondUserError(c, errcode.ErrUserAccountDestroying)
 		return
 	case IsDestroyDone:
-		c.ResponseError(errors.New("账号已注销"))
+		respondUserError(c, errcode.ErrUserAccountDestroyed)
 		return
 	}
 	err = u.smsServie.SendVerifyCode(c.Context, userInfo.Zone, userInfo.Phone, commonapi.CodeTypeDestroyAccount)
 	if err != nil {
-		c.ResponseError(err)
+		respondUserServiceError(c)
 		return
 	}
 	c.ResponseOK()
@@ -2770,31 +2771,31 @@ func (u *User) destroyAccount(c *wkhttp.Context) {
 	code := c.Param("code")
 	loginUID := c.GetLoginUID()
 	if code == "" {
-		c.ResponseError(errors.New("验证码不能为空"))
+		respondUserRequestInvalid(c, "code")
 		return
 	}
 	userInfo, err := u.db.QueryByUID(loginUID)
 	if err != nil {
 		u.Error("查询登录用户信息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询登录用户信息错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userInfo == nil {
-		c.ResponseError(errors.New("登录用户不存在"))
+		respondUserError(c, errcode.ErrUserCurrentNotFound)
 		return
 	}
 	switch userInfo.IsDestroy {
 	case IsDestroyApplying:
-		c.ResponseError(errors.New("账号已在注销冷静期中，请使用新版客户端撤销或查询状态"))
+		respondUserError(c, errcode.ErrUserAccountDestroying)
 		return
 	case IsDestroyDone:
-		c.ResponseError(errors.New("账号已注销"))
+		respondUserError(c, errcode.ErrUserAccountDestroyed)
 		return
 	}
 	//测试模式（仅非 release 生效）
 	if commonapi.IsTestCodeEnabled(u.ctx.GetConfig()) {
 		if !commonapi.MatchTestCode(u.ctx.GetConfig(), code) {
-			c.ResponseError(errors.New("验证码错误"))
+			respondUserError(c, errcode.ErrUserCodeInvalid)
 			return
 		}
 	} else {
@@ -2802,7 +2803,7 @@ func (u *User) destroyAccount(c *wkhttp.Context) {
 		// 校验验证码
 		err = u.smsServie.Verify(c.Context, userInfo.Zone, userInfo.Phone, code, commonapi.CodeTypeDestroyAccount)
 		if err != nil {
-			c.ResponseError(err)
+			respondUserServiceError(c)
 			return
 		}
 	}
@@ -2815,13 +2816,13 @@ func (u *User) destroyAccount(c *wkhttp.Context) {
 	err = u.db.destroyAccount(loginUID, username, phone)
 	if err != nil {
 		u.Error("注销账号错误", zap.Error(err))
-		c.ResponseError(errors.New("注销账号错误"))
+		respondUserError(c, errcode.ErrUserDestroyFailed)
 		return
 	}
 	err = u.ctx.QuitUserDevice(c.GetLoginUID(), -1) // 退出全部登陆设备
 	if err != nil {
 		u.Error("退出登陆设备失败", zap.Error(err))
-		c.ResponseError(errors.New("退出登陆设备失败"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 
@@ -3039,46 +3040,46 @@ func (u *User) addSystemFriend(uid string) error {
 func (u *User) pwdforget(c *wkhttp.Context) {
 	var req resetPwdReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if strings.TrimSpace(req.Zone) == "" {
-		c.ResponseError(errors.New("区号不能为空！"))
+		respondUserRequestInvalid(c, "zone")
 		return
 	}
 	if strings.TrimSpace(req.Phone) == "" {
-		c.ResponseError(errors.New("手机号不能为空！"))
+		respondUserRequestInvalid(c, "phone")
 		return
 	}
 	if strings.TrimSpace(req.Code) == "" {
-		c.ResponseError(errors.New("验证码不能为空！"))
+		respondUserRequestInvalid(c, "code")
 		return
 	}
 	if strings.TrimSpace(req.Pwd) == "" {
-		c.ResponseError(errors.New("密码不能为空！"))
+		respondUserRequestInvalid(c, "password")
 		return
 	}
 	userInfo, err := u.db.QueryByPhone(req.Zone, req.Phone)
 	if err != nil {
 		u.Error("查询用户信息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询用户信息错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userInfo == nil {
-		c.ResponseError(errors.New("该账号不存在"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 	//测试模式（仅非 release 生效）
 	if commonapi.IsTestCodeEnabled(u.ctx.GetConfig()) {
 		if !commonapi.MatchTestCode(u.ctx.GetConfig(), req.Code) {
-			c.ResponseError(errors.New("验证码错误"))
+			respondUserError(c, errcode.ErrUserCodeInvalid)
 			return
 		}
 	} else {
 		//线上验证短信验证码
 		err = u.smsServie.Verify(context.Background(), req.Zone, req.Phone, req.Code, commonapi.CodeTypeForgetLoginPWD)
 		if err != nil {
-			c.ResponseError(err)
+			respondUserServiceError(c)
 			return
 		}
 	}
@@ -3086,13 +3087,13 @@ func (u *User) pwdforget(c *wkhttp.Context) {
 	hashedPassword, hashErr := HashPassword(req.Pwd)
 	if hashErr != nil {
 		u.Error("密码哈希失败", zap.Error(hashErr))
-		c.ResponseError(errors.New("密码处理失败"))
+		respondUserError(c, errcode.ErrUserPasswordProcessFailed)
 		return
 	}
 	err = u.db.UpdateUsersWithField("password", hashedPassword, userInfo.UID)
 	if err != nil {
 		u.Error("修改登录密码错误", zap.Error(err))
-		c.ResponseError(errors.New("修改登录密码错误"))
+		respondUserError(c, errcode.ErrUserLoginPwdUpdateFailed)
 		return
 	}
 	c.ResponseOK()
@@ -3102,15 +3103,15 @@ func (u *User) pwdforget(c *wkhttp.Context) {
 func (u *User) getForgetPwdSMS(c *wkhttp.Context) {
 	var req codeReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if strings.TrimSpace(req.Zone) == "" {
-		c.ResponseError(errors.New("区号不能为空！"))
+		respondUserRequestInvalid(c, "zone")
 		return
 	}
 	if strings.TrimSpace(req.Phone) == "" {
-		c.ResponseError(errors.New("手机号不能为空！"))
+		respondUserRequestInvalid(c, "phone")
 		return
 	}
 
@@ -3124,17 +3125,17 @@ func (u *User) getForgetPwdSMS(c *wkhttp.Context) {
 	model, err := u.db.QueryByPhone(req.Zone, req.Phone)
 	if err != nil {
 		u.Error("查询用户信息失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询用户信息失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if model == nil {
-		c.ResponseError(errors.New("该手机号未注册"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 	err = u.smsServie.SendVerifyCode(spanCtx, req.Zone, req.Phone, commonapi.CodeTypeForgetLoginPWD)
 	if err != nil {
 		u.Error("发送短信验证码失败", zap.Error(err))
-		c.ResponseError(errors.New("发送短信验证码失败！"))
+		respondUserError(c, errcode.ErrUserSMSSendFailed)
 		return
 	}
 	c.ResponseOK()
@@ -3155,7 +3156,7 @@ func (u *User) createUser(registerSpanCtx context.Context, createUser *createUse
 	tx, err := u.db.session.Begin()
 	if err != nil {
 		u.Error("创建数据库事物失败", zap.Error(err))
-		c.ResponseError(errors.New("创建数据库事物失败"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	defer func() {
@@ -3170,14 +3171,14 @@ func (u *User) createUser(registerSpanCtx context.Context, createUser *createUse
 		if err != nil {
 			tx.Rollback()
 			u.Error("数据库事物提交失败", zap.Error(err))
-			c.ResponseError(errors.New("数据库事物提交失败"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return nil
 		}
 		return nil
 	})
 	if err != nil {
 		tx.Rollback()
-		c.ResponseError(errors.New("注册失败！"))
+		respondUserError(c, errcode.ErrUserRegisterFailed)
 		return
 	}
 	c.Response(resp)
@@ -3187,7 +3188,7 @@ func (u *User) createUserTx(registerSpanCtx context.Context, createUser *createU
 	publicIP := util.GetClientPublicIP(c.Request)
 	resp, err := u.createUserWithRespAndTx(registerSpanCtx, createUser, publicIP, invite, tx, commitCallback)
 	if err != nil {
-		c.ResponseError(errors.New("注册失败！"))
+		respondUserError(c, errcode.ErrUserRegisterFailed)
 		return
 	}
 	c.Response(resp)
@@ -3732,7 +3733,7 @@ func (u *User) authVerifyToken(c *wkhttp.Context) {
 		return
 	}
 	if req.Token == "" {
-		c.ResponseError(errors.New("token is required"))
+		respondUserTokenRequired(c, "token")
 		return
 	}
 
@@ -3796,7 +3797,7 @@ func (u *User) authVerifyBot(c *wkhttp.Context) {
 		return
 	}
 	if req.BotToken == "" {
-		c.ResponseError(errors.New("bot_token is required"))
+		respondUserTokenRequired(c, "bot_token")
 		return
 	}
 

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -660,6 +660,7 @@ func (u *User) userIM(c *wkhttp.Context) {
 	var resultMap map[string]interface{}
 	err = util.ReadJsonByByte([]byte(resp.Body), &resultMap)
 	if err != nil {
+		u.Error("解析 IM 响应失败", zap.Error(err))
 		respondUserServiceError(c)
 		return
 	}
@@ -904,7 +905,8 @@ func (u *User) userUpdateWithField(c *wkhttp.Context) {
 				return
 			}
 			if err := ValidateName(nameStr); err != nil {
-				respondUserServiceError(c)
+				u.Warn("用户名格式校验失败", zap.String("uid", loginUID), zap.Error(err))
+				respondUserRequestInvalid(c, "name")
 				return
 			}
 		}
@@ -1295,12 +1297,16 @@ func (u *User) login(c *wkhttp.Context) {
 		return
 	}
 	if err := req.Check(); err != nil {
-		respondUserServiceError(c)
+		// loginReq.Check returns one of "用户名不能为空 / 密码不能为空"; both are
+		// pure client-side input gaps. Field detail is left blank because the
+		// helper string-matches the message rather than tagging the offending
+		// field — fix-up follows the broader sentinel extraction (TODOS L219).
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if err := u.loginGuard.Check(req.Username); err != nil {
 		u.Warn("登录被临时锁定", zap.String("username", req.Username), zap.Error(err))
-		respondUserServiceError(c)
+		respondUserError(c, errcode.ErrUserLoginLocked)
 		return
 	}
 	loginSpan := u.ctx.Tracer().StartSpan(
@@ -1313,8 +1319,8 @@ func (u *User) login(c *wkhttp.Context) {
 
 	userInfo, err := u.db.QueryByUsernameCxt(loginSpanCtx, req.Username)
 	if err != nil {
-		u.Error("查询用户信息失败！", zap.String("username", req.Username))
-		respondUserServiceError(c)
+		u.Error("查询用户信息失败！", zap.String("username", req.Username), zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	// 已注销 / 被禁用账号统一拒绝；与 emailLogin / usernameLogin 行为对齐
@@ -1364,6 +1370,7 @@ func (u *User) execLoginAndRespose(userInfo *Model, flag config.DeviceFlag, devi
 			})
 			return
 		}
+		u.Error("登录执行失败", zap.String("uid", userInfo.UID), zap.Error(err))
 		respondUserServiceError(c)
 		return
 	}
@@ -1557,7 +1564,11 @@ func (u *User) register(c *wkhttp.Context) {
 		return
 	}
 	if err := req.CheckRegister(); err != nil {
-		respondUserServiceError(c)
+		// CheckRegister returns "用户名不能为空 / 区号不能为空 / 手机号不能为空 /
+		// 验证码不能为空 / 密码不能为空 / 密码长度必须大于6位 / 名字格式错误".
+		// All client-side input failures. Field-level detail left empty for
+		// the same reason as login.Check (TODOS L219 sentinel follow-up).
+		respondUserRequestInvalid(c, "")
 		return
 	}
 
@@ -1578,7 +1589,7 @@ func (u *User) register(c *wkhttp.Context) {
 	appConfig, err := u.commonService.GetAppConfig()
 	if err != nil {
 		u.Error("查询应用设置错误", zap.Error(err))
-		respondUserServiceError(c)
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	var registerInviteOn = 0
@@ -1618,8 +1629,8 @@ func (u *User) register(c *wkhttp.Context) {
 	//验证手机号是否注册
 	userInfo, err := u.db.QueryByUsernameCxt(registerSpanCtx, fmt.Sprintf("%s%s", req.Zone, req.Phone))
 	if err != nil {
-		u.Error("查询用户信息失败！", zap.String("username", req.Phone))
-		respondUserServiceError(c)
+		u.Error("查询用户信息失败！", zap.String("username", req.Phone), zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userInfo != nil {
@@ -1636,7 +1647,8 @@ func (u *User) register(c *wkhttp.Context) {
 		//线上验证短信验证码
 		err = u.smsServie.Verify(registerSpanCtx, req.Zone, req.Phone, req.Code, commonapi.CodeTypeRegister)
 		if err != nil {
-			respondUserServiceError(c)
+			u.Warn("注册短信校验失败", zap.String("phone", req.Phone), zap.Error(err))
+			respondUserError(c, errcode.ErrUserCodeInvalid)
 			return
 		}
 	}
@@ -2181,11 +2193,13 @@ func (u *User) addBlacklist(c *wkhttp.Context) {
 	//添加黑名单
 	version, err := u.ctx.GenSeq(common.UserSettingSeqKey)
 	if err != nil {
+		u.Error("生成用户设置版本号失败", zap.String("uid", loginUID), zap.Error(err))
 		respondUserServiceError(c)
 		return
 	}
 	friendVersion, err := u.ctx.GenSeq(common.FriendSeqKey)
 	if err != nil {
+		u.Error("生成好友版本号失败", zap.String("uid", loginUID), zap.Error(err))
 		respondUserServiceError(c)
 		return
 	}
@@ -2272,11 +2286,13 @@ func (u *User) removeBlacklist(c *wkhttp.Context) {
 
 	version, err := u.ctx.GenSeq(common.UserSettingSeqKey)
 	if err != nil {
+		u.Error("生成用户设置版本号失败", zap.String("uid", loginUID), zap.Error(err))
 		respondUserServiceError(c)
 		return
 	}
 	friendVersion, err := u.ctx.GenSeq(common.FriendSeqKey)
 	if err != nil {
+		u.Error("生成好友版本号失败", zap.String("uid", loginUID), zap.Error(err))
 		respondUserServiceError(c)
 		return
 	}
@@ -2572,8 +2588,12 @@ func (u *User) sendLoginCheckPhoneCode(c *wkhttp.Context) {
 
 	userinfo, err := u.db.QueryByUID(req.UID)
 	if err != nil {
+		// PR #188 reviewer fix: legacy code used ErrUserChatPwdUpdateFailed
+		// for a user-lookup failure (wrong copy carried over from a copy-paste
+		// of setChatPwd). Both are Internal=true so the client wire message is
+		// unchanged, but ops dashboards keyed on error.code would mis-attribute.
 		u.Error("查询用户信息失败！", zap.Error(err))
-		respondUserError(c, errcode.ErrUserChatPwdUpdateFailed)
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userinfo == nil {
@@ -2628,8 +2648,9 @@ func (u *User) loginCheckPhone(c *wkhttp.Context) {
 
 	userInfo, err := u.db.QueryByUID(req.UID)
 	if err != nil {
+		// Same legacy mis-mapping as sendLoginCheckPhoneCode above; see comment there.
 		u.Error("查询用户信息失败！", zap.Error(err))
-		respondUserError(c, errcode.ErrUserChatPwdUpdateFailed)
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userInfo == nil {
@@ -2645,7 +2666,7 @@ func (u *User) loginCheckPhone(c *wkhttp.Context) {
 	err = u.smsServie.Verify(spanCtx, userInfo.Zone, userInfo.Phone, req.Code, commonapi.CodeTypeCheckMobile)
 	if err != nil {
 		u.Error("验证短信失败", zap.Error(err))
-		respondUserServiceError(c)
+		respondUserError(c, errcode.ErrUserCodeInvalid)
 		return
 	}
 
@@ -2760,7 +2781,8 @@ func (u *User) sendDestroyCode(c *wkhttp.Context) {
 	}
 	err = u.smsServie.SendVerifyCode(c.Context, userInfo.Zone, userInfo.Phone, commonapi.CodeTypeDestroyAccount)
 	if err != nil {
-		respondUserServiceError(c)
+		u.Error("注销验证码短信发送失败", zap.String("uid", loginUID), zap.Error(err))
+		respondUserError(c, errcode.ErrUserSMSSendFailed)
 		return
 	}
 	c.ResponseOK()
@@ -2803,7 +2825,8 @@ func (u *User) destroyAccount(c *wkhttp.Context) {
 		// 校验验证码
 		err = u.smsServie.Verify(c.Context, userInfo.Zone, userInfo.Phone, code, commonapi.CodeTypeDestroyAccount)
 		if err != nil {
-			respondUserServiceError(c)
+			u.Warn("注销验证码校验失败", zap.String("uid", loginUID), zap.Error(err))
+			respondUserError(c, errcode.ErrUserCodeInvalid)
 			return
 		}
 	}
@@ -3079,7 +3102,8 @@ func (u *User) pwdforget(c *wkhttp.Context) {
 		//线上验证短信验证码
 		err = u.smsServie.Verify(context.Background(), req.Zone, req.Phone, req.Code, commonapi.CodeTypeForgetLoginPWD)
 		if err != nil {
-			respondUserServiceError(c)
+			u.Warn("忘记密码验证码校验失败", zap.String("phone", req.Phone), zap.Error(err))
+			respondUserError(c, errcode.ErrUserCodeInvalid)
 			return
 		}
 	}

--- a/modules/user/api_emaillogin_test.go
+++ b/modules/user/api_emaillogin_test.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/server"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	commonapi "github.com/Mininglamp-OSS/octo-server/modules/base/common"
 	commonsettings "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -266,6 +268,18 @@ func setPublicIPForUserTest(req *http.Request, ip string) {
 	req.Header.Set("X-Forwarded-For", ip)
 	req.Header.Set("X-Real-IP", ip)
 	req.RemoteAddr = ip + ":12345"
+}
+
+// wireI18nRendererForUserTest injects the i18n ErrorRenderer onto the
+// route returned by testutil.NewTestServer, mirroring what main.go does at
+// boot. Post-Phase 2.1, modules/user handlers respond via
+// httperr.ResponseErrorL → c.RenderError; without a renderer wired the
+// route falls back to the legacy {msg,status} envelope carrying the
+// English source DefaultMessage instead of the localized zh-CN copy
+// production clients receive. testutil.NewTestServer lives in octo-lib and
+// is intentionally not touched from this PR to keep the migration scoped.
+func wireI18nRendererForUserTest(s *server.Server) {
+	s.GetRoute().SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
 }
 
 // TestCallbackErrorHandling verifies the pattern where callback errors

--- a/modules/user/api_i18n.go
+++ b/modules/user/api_i18n.go
@@ -63,6 +63,28 @@ func respondUserLockMinuteOutOfRange(c *wkhttp.Context) {
 	})
 }
 
+// errSharedAuthRequired caches the shared "auth required" code so the
+// per-handler "未登录" guards do not pay a registry lookup on every miss.
+// Looked up at package init; a missing registration panics loudly rather
+// than silently rendering an empty envelope at request time.
+var errSharedAuthRequired = mustLookupSharedCode("err.shared.auth.required")
+
+func mustLookupSharedCode(id string) codes.Code {
+	c, ok := codes.Lookup(id)
+	if !ok {
+		panic("modules/user: shared code not registered: " + id)
+	}
+	return c
+}
+
+// respondUserNotLoggedIn responds with the shared err.shared.auth.required
+// code. Handlers protected by AuthMiddleware still keep a belt-and-braces
+// `loginUID == ""` check for legacy public routes; this helper renders
+// the consistent 401 envelope for that fallthrough.
+func respondUserNotLoggedIn(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errSharedAuthRequired, nil, nil)
+}
+
 // respondUserServiceError responds with the generic ErrUserStoreFailed
 // (Internal=true). Callers MUST log the underlying err with full handler
 // context via the module's zap logger before invoking this helper —

--- a/modules/user/api_i18n.go
+++ b/modules/user/api_i18n.go
@@ -1,0 +1,77 @@
+package user
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// respondUserError is the base wrapper for legacy c.ResponseError sites that
+// migrate to a localized error envelope. For codes that carry detail fields
+// (field / missing_field / lock bounds), call the more specific helpers
+// below instead so the SafeDetailKeys contract stays in one place.
+func respondUserError(c *wkhttp.Context, code codes.Code) {
+	httperr.ResponseErrorL(c, code, nil, nil)
+}
+
+// respondUserRequestInvalid covers the common "X 不能为空" / "数据格式有误"
+// shape — one code, one optional field detail. An empty field is omitted
+// so the renderer does not surface a noisy empty key to clients.
+func respondUserRequestInvalid(c *wkhttp.Context, field string) {
+	details := i18n.Details{}
+	if field != "" {
+		details["field"] = field
+	}
+	httperr.ResponseErrorL(c, errcode.ErrUserRequestInvalid, nil, details)
+}
+
+// respondUserUpdateNotAllowed tags the field the caller tried to mutate
+// (mirrors the legacy "不允许更新【x】" message). field MUST be non-empty;
+// pass the JSON / form key, not a user-facing label, so clients can
+// programmatically highlight the input.
+func respondUserUpdateNotAllowed(c *wkhttp.Context, field string) {
+	httperr.ResponseErrorL(c, errcode.ErrUserUpdateNotAllowed, nil, i18n.Details{"field": field})
+}
+
+// respondUserAuthInfoInvalid surfaces which field of the scanned QR-code
+// payload was missing or malformed. An empty missingField is omitted.
+func respondUserAuthInfoInvalid(c *wkhttp.Context, missingField string) {
+	details := i18n.Details{}
+	if missingField != "" {
+		details["missing_field"] = missingField
+	}
+	httperr.ResponseErrorL(c, errcode.ErrUserAuthInfoInvalid, nil, details)
+}
+
+// respondUserTokenRequired tags which token parameter was omitted. Used by
+// the verifyToken / verifyBot endpoints whose legacy English messages
+// (`token is required`, `bot_token is required`) third-party callers may
+// have keyed off — they are migrated to error.code keying.
+func respondUserTokenRequired(c *wkhttp.Context, field string) {
+	httperr.ResponseErrorL(c, errcode.ErrUserTokenRequired, nil, i18n.Details{"field": field})
+}
+
+// respondUserLockMinuteOutOfRange returns the lock-screen delay bounds so
+// the client can render a localized hint without hard-coding the limits.
+func respondUserLockMinuteOutOfRange(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errcode.ErrUserLockMinuteOutOfRange, nil, i18n.Details{
+		"field": "lock_after_minute",
+		"min":   0,
+		"max":   60,
+	})
+}
+
+// respondUserServiceError responds with the generic ErrUserStoreFailed
+// (Internal=true). Callers MUST log the underlying err with full handler
+// context via the module's zap logger before invoking this helper —
+// Internal=true means the wire response carries no error message and ops
+// debug entirely from logs.
+//
+// For known sentinel errors (e.g. ErrUnsupportedLanguage) callers branch
+// explicitly to a more specific code BEFORE falling through here. Service
+// layer sentinel extraction is deferred (TODOS L219 follow-up).
+func respondUserServiceError(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errcode.ErrUserStoreFailed, nil, nil)
+}

--- a/modules/user/api_i18n.go
+++ b/modules/user/api_i18n.go
@@ -28,11 +28,16 @@ func respondUserRequestInvalid(c *wkhttp.Context, field string) {
 }
 
 // respondUserUpdateNotAllowed tags the field the caller tried to mutate
-// (mirrors the legacy "不允许更新【x】" message). field MUST be non-empty;
-// pass the JSON / form key, not a user-facing label, so clients can
-// programmatically highlight the input.
+// (mirrors the legacy "不允许更新【x】" / "不允许编辑！" messages). An empty
+// field is omitted from details — the legacy "不允许编辑！" branch has no
+// field context to surface — matching the convention of
+// respondUserRequestInvalid so clients never see structured empty keys.
 func respondUserUpdateNotAllowed(c *wkhttp.Context, field string) {
-	httperr.ResponseErrorL(c, errcode.ErrUserUpdateNotAllowed, nil, i18n.Details{"field": field})
+	details := i18n.Details{}
+	if field != "" {
+		details["field"] = field
+	}
+	httperr.ResponseErrorL(c, errcode.ErrUserUpdateNotAllowed, nil, details)
 }
 
 // respondUserAuthInfoInvalid surfaces which field of the scanned QR-code

--- a/modules/user/api_i18n_test.go
+++ b/modules/user/api_i18n_test.go
@@ -14,9 +14,11 @@ import (
 )
 
 // TestUserAPINoLegacyResponseError pins the post-Phase-2.1 contract that
-// modules/user/api.go does not regress to legacy c.ResponseError. Phase 2
-// PR reviewers can rely on this guard catching reintroduced legacy calls
-// before the broader CI lint suite (0.10) is wired.
+// modules/user/api.go does not regress to legacy octo-lib error responses.
+// Catches both `.ResponseError(...)` and `.ResponseErrorf(...)` — the latter
+// is the formatted variant that bypasses the renderer just as completely,
+// so the guard must look for it too even though it never matches the
+// plain `.ResponseError(` substring (the `f` intervenes).
 func TestUserAPINoLegacyResponseError(t *testing.T) {
 	data, err := os.ReadFile("api.go")
 	if err != nil {
@@ -34,8 +36,11 @@ func TestUserAPINoLegacyResponseError(t *testing.T) {
 		clean.WriteString(line)
 		clean.WriteByte('\n')
 	}
-	if strings.Contains(clean.String(), ".ResponseError(") {
-		t.Fatal("modules/user/api.go must use httperr.ResponseErrorL via respondUser* helpers instead of legacy ResponseError")
+	cleaned := clean.String()
+	for _, banned := range []string{".ResponseError(", ".ResponseErrorf("} {
+		if strings.Contains(cleaned, banned) {
+			t.Fatalf("modules/user/api.go must use httperr.ResponseErrorL via respondUser* helpers instead of legacy %s", banned)
+		}
 	}
 }
 

--- a/modules/user/api_i18n_test.go
+++ b/modules/user/api_i18n_test.go
@@ -195,6 +195,14 @@ func TestRespondUserHelpers(t *testing.T) {
 			wantContains:    "已被封禁",
 		},
 		{
+			name:            "ErrUserLoginLocked surfaces 429 + user-facing zh-CN copy",
+			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserLoginLocked) },
+			wantCodeID:      "err.server.user.login_locked",
+			wantSemStatus:   http.StatusTooManyRequests,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "登录失败次数过多",
+		},
+		{
 			name:            "ErrUserWeChatExchangeFailed (Internal=true, 502) collapses to shared internal copy",
 			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserWeChatExchangeFailed) },
 			wantCodeID:      "err.server.user.wechat_exchange_failed",

--- a/modules/user/api_i18n_test.go
+++ b/modules/user/api_i18n_test.go
@@ -1,0 +1,257 @@
+package user
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+// TestUserAPINoLegacyResponseError pins the post-Phase-2.1 contract that
+// modules/user/api.go does not regress to legacy c.ResponseError. Phase 2
+// PR reviewers can rely on this guard catching reintroduced legacy calls
+// before the broader CI lint suite (0.10) is wired.
+func TestUserAPINoLegacyResponseError(t *testing.T) {
+	data, err := os.ReadFile("api.go")
+	if err != nil {
+		t.Fatalf("read api.go: %v", err)
+	}
+	source := string(data)
+	// Strip line comments so commented-out legacy snippets don't fail the
+	// guard. The Phase 0 inventory left a couple of commented references
+	// in wxLogin / uploadAvatar deliberately as TODO breadcrumbs.
+	var clean strings.Builder
+	for _, line := range strings.Split(source, "\n") {
+		if idx := strings.Index(line, "//"); idx >= 0 {
+			line = line[:idx]
+		}
+		clean.WriteString(line)
+		clean.WriteByte('\n')
+	}
+	if strings.Contains(clean.String(), ".ResponseError(") {
+		t.Fatal("modules/user/api.go must use httperr.ResponseErrorL via respondUser* helpers instead of legacy ResponseError")
+	}
+}
+
+// helperHarness mounts a single GET /probe route that invokes the supplied
+// helper. Tests exercise the helper directly without paying the DB / auth
+// setup cost — the contract we care about is what the wkhttp envelope
+// looks like once the renderer has run.
+func helperHarness(probe func(c *wkhttp.Context)) *wkhttp.WKHttp {
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	r.GET("/probe", probe)
+	return r
+}
+
+// envelope is the partial shape of an httperr.ResponseErrorL response that
+// these tests assert on. All fields are present on every error response
+// (the renderer emits both legacy {msg,status} and v2 {error.{...}}
+// unconditionally — v7.2 contract).
+type envelope struct {
+	Error struct {
+		Code       string         `json:"code"`
+		Message    string         `json:"message"`
+		Details    map[string]any `json:"details"`
+		HTTPStatus int            `json:"http_status"`
+	} `json:"error"`
+	Msg    string `json:"msg"`
+	Status int    `json:"status"`
+}
+
+func decodeEnvelope(t *testing.T, body []byte) envelope {
+	t.Helper()
+	var env envelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("decode envelope: %v\nbody: %s", err, body)
+	}
+	return env
+}
+
+func TestRespondUserHelpers(t *testing.T) {
+	cases := []struct {
+		name            string
+		probe           func(c *wkhttp.Context)
+		wantCodeID      string
+		wantSemStatus   int
+		wantTransStatus int    // always 400 for legacy compat (D14)
+		wantContains    string // zh-CN substring expected in error.message
+		wantNotContains string // forbid leaked DefaultMessage when Internal=true
+		wantDetails     map[string]any
+	}{
+		{
+			name:            "ErrUserNotFound surfaces zh-CN copy",
+			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserNotFound) },
+			wantCodeID:      "err.server.user.not_found",
+			wantSemStatus:   http.StatusNotFound,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "用户不存在",
+		},
+		{
+			name: "ErrUserStoreFailed (Internal=true) collapses to shared internal copy",
+			probe: func(c *wkhttp.Context) {
+				respondUserError(c, errcode.ErrUserStoreFailed)
+			},
+			wantCodeID:      "err.server.user.store_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "Failed to persist user data",
+		},
+		{
+			name:            "respondUserServiceError defaults to store_failed",
+			probe:           func(c *wkhttp.Context) { respondUserServiceError(c) },
+			wantCodeID:      "err.server.user.store_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+		},
+		{
+			name:            "respondUserNotLoggedIn routes to shared.auth.required",
+			probe:           func(c *wkhttp.Context) { respondUserNotLoggedIn(c) },
+			wantCodeID:      "err.shared.auth.required",
+			wantSemStatus:   http.StatusUnauthorized,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "请先登录",
+		},
+		{
+			name:            "respondUserRequestInvalid carries the field detail",
+			probe:           func(c *wkhttp.Context) { respondUserRequestInvalid(c, "phone") },
+			wantCodeID:      "err.server.user.request_invalid",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "请求数据格式有误",
+			wantDetails:     map[string]any{"field": "phone"},
+		},
+		{
+			name:            "respondUserRequestInvalid drops empty field key",
+			probe:           func(c *wkhttp.Context) { respondUserRequestInvalid(c, "") },
+			wantCodeID:      "err.server.user.request_invalid",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "请求数据格式有误",
+			wantDetails:     map[string]any{},
+		},
+		{
+			name:            "respondUserUpdateNotAllowed carries the field detail",
+			probe:           func(c *wkhttp.Context) { respondUserUpdateNotAllowed(c, "short_no") },
+			wantCodeID:      "err.server.user.update_not_allowed",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "不允许修改",
+			wantDetails:     map[string]any{"field": "short_no"},
+		},
+		{
+			name:            "respondUserAuthInfoInvalid carries missing_field",
+			probe:           func(c *wkhttp.Context) { respondUserAuthInfoInvalid(c, "type") },
+			wantCodeID:      "err.server.user.auth_info_invalid",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "授权信息格式错误",
+			wantDetails:     map[string]any{"missing_field": "type"},
+		},
+		{
+			name:            "respondUserTokenRequired carries the field detail",
+			probe:           func(c *wkhttp.Context) { respondUserTokenRequired(c, "bot_token") },
+			wantCodeID:      "err.server.user.token_required",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "Token 不能为空",
+			wantDetails:     map[string]any{"field": "bot_token"},
+		},
+		{
+			name:            "respondUserLockMinuteOutOfRange surfaces bounds",
+			probe:           func(c *wkhttp.Context) { respondUserLockMinuteOutOfRange(c) },
+			wantCodeID:      "err.server.user.lock_minute_out_of_range",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "0 到 60 分钟",
+			wantDetails: map[string]any{
+				"field": "lock_after_minute",
+				"min":   float64(0),
+				"max":   float64(60),
+			},
+		},
+		{
+			name:            "ErrUserLanguageUnsupported surfaces zh-CN copy",
+			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserLanguageUnsupported) },
+			wantCodeID:      "err.server.user.language_unsupported",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "不支持的语言",
+		},
+		{
+			name:            "ErrUserAccountBanned surfaces zh-CN copy",
+			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserAccountBanned) },
+			wantCodeID:      "err.server.user.account_banned",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "已被封禁",
+		},
+		{
+			name:            "ErrUserWeChatExchangeFailed (Internal=true, 502) collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserWeChatExchangeFailed) },
+			wantCodeID:      "err.server.user.wechat_exchange_failed",
+			wantSemStatus:   http.StatusBadGateway,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "WeChat",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := helperHarness(tc.probe)
+			req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+			req.Header.Set("Accept-Language", "zh-CN")
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantTransStatus {
+				t.Fatalf("HTTP status = %d, want %d; body=%s", rec.Code, tc.wantTransStatus, rec.Body.String())
+			}
+			if got := rec.Header().Get("Content-Language"); got != "zh-CN" {
+				t.Fatalf("Content-Language = %q, want zh-CN", got)
+			}
+			env := decodeEnvelope(t, rec.Body.Bytes())
+			if env.Error.Code != tc.wantCodeID {
+				t.Fatalf("error.code = %q, want %q", env.Error.Code, tc.wantCodeID)
+			}
+			if env.Error.HTTPStatus != tc.wantSemStatus {
+				t.Fatalf("error.http_status = %d, want %d", env.Error.HTTPStatus, tc.wantSemStatus)
+			}
+			if env.Status != tc.wantTransStatus {
+				t.Fatalf("legacy status = %d, want %d (D14 transport=400 compat)", env.Status, tc.wantTransStatus)
+			}
+			if env.Msg != env.Error.Message {
+				t.Fatalf("legacy msg %q != error.message %q (dual envelope must agree)", env.Msg, env.Error.Message)
+			}
+			if !strings.Contains(env.Error.Message, tc.wantContains) {
+				t.Fatalf("error.message = %q, want substring %q", env.Error.Message, tc.wantContains)
+			}
+			if tc.wantNotContains != "" && strings.Contains(env.Error.Message, tc.wantNotContains) {
+				t.Fatalf("error.message = %q must not contain %q (Internal leak)", env.Error.Message, tc.wantNotContains)
+			}
+			if tc.wantDetails != nil {
+				gotDetails := env.Error.Details
+				if gotDetails == nil {
+					gotDetails = map[string]any{}
+				}
+				if len(gotDetails) != len(tc.wantDetails) {
+					t.Fatalf("error.details = %#v, want %#v", gotDetails, tc.wantDetails)
+				}
+				for k, v := range tc.wantDetails {
+					if gotDetails[k] != v {
+						t.Fatalf("error.details[%q] = %#v, want %#v", k, gotDetails[k], v)
+					}
+				}
+			}
+		})
+	}
+}

--- a/modules/user/api_i18n_test.go
+++ b/modules/user/api_i18n_test.go
@@ -153,6 +153,15 @@ func TestRespondUserHelpers(t *testing.T) {
 			wantDetails:     map[string]any{"field": "short_no"},
 		},
 		{
+			name:            "respondUserUpdateNotAllowed drops empty field key",
+			probe:           func(c *wkhttp.Context) { respondUserUpdateNotAllowed(c, "") },
+			wantCodeID:      "err.server.user.update_not_allowed",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "不允许修改",
+			wantDetails:     map[string]any{},
+		},
+		{
 			name:            "respondUserAuthInfoInvalid carries missing_field",
 			probe:           func(c *wkhttp.Context) { respondUserAuthInfoInvalid(c, "type") },
 			wantCodeID:      "err.server.user.auth_info_invalid",

--- a/modules/user/api_language_test.go
+++ b/modules/user/api_language_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 )
 
 // Handler-level tests for PUT /v1/user/language. We deliberately don't go
@@ -31,6 +32,12 @@ func newLanguageHandlerHarness(t *testing.T, db languageReader, c *fakeLangCache
 	u := &User{Log: log.NewTLog("user-test")}
 	u.languageService = NewLanguageService(db, c)
 	r := wkhttp.New()
+	// The handler now responds via httperr.ResponseErrorL, which delegates to
+	// the wkhttp ErrorRenderer. Wire the i18n renderer so the test exercises
+	// the same envelope path production hits — without this the renderer
+	// falls back to legacy {msg,status} with the unsuppressed English source
+	// message, defeating the Internal=true contract.
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
 	r.Group("/v1/user").PUT("language", func(ctx *wkhttp.Context) {
 		// Inject the login UID the way octo-lib's AuthMiddleware would.
 		// Bypassing AuthMiddleware keeps the test focused on the handler
@@ -141,9 +148,12 @@ func TestSetLanguageHandler_LongLanguageRejected(t *testing.T) {
 }
 
 // TestSetLanguageHandler_InternalErrorReturnsGenericMsg verifies the
-// classified user-facing copy for infra errors (DB outage, etc.): the wire
-// response must not surface the wrapped `user: persist language: ...` /
-// driver text. PR #182 reviewer P2 fix.
+// Internal=true contract for infra errors (DB outage, etc.): the wire
+// response collapses to the shared internal copy ("服务器内部错误。")
+// regardless of which err.server.user.* code the handler picked, and the
+// wrapped `user: persist language: ...` / driver text never leaves the
+// process. PR #182 reviewer P2 finding, adapted for Phase 2.1
+// httperr.ResponseErrorL migration.
 func TestSetLanguageHandler_InternalErrorReturnsGenericMsg(t *testing.T) {
 	db := newFakeLangDB()
 	db.updateErr = errors.New("driver: connection refused")
@@ -159,11 +169,15 @@ func TestSetLanguageHandler_InternalErrorReturnsGenericMsg(t *testing.T) {
 		t.Fatalf("status = %d (want 400), body = %s", rec.Code, rec.Body.String())
 	}
 	respBody := rec.Body.String()
-	if !strings.Contains(respBody, "设置语言偏好失败") {
-		t.Fatalf("response body should be classified generic message, got %s", respBody)
+	if !strings.Contains(respBody, "服务器内部错误") {
+		t.Fatalf("response body should carry shared internal copy, got %s", respBody)
 	}
-	if strings.Contains(respBody, "driver:") || strings.Contains(respBody, "user: persist") {
-		t.Fatalf("response body must not leak internal error text, got %s", respBody)
+	if !strings.Contains(respBody, "err.server.user.language_set_failed") {
+		t.Fatalf("response body should still carry the specific error.code for ops dashboards, got %s", respBody)
+	}
+	if strings.Contains(respBody, "driver:") || strings.Contains(respBody, "user: persist") ||
+		strings.Contains(respBody, "Failed to set language preference") {
+		t.Fatalf("response body must not leak internal error text or source DefaultMessage, got %s", respBody)
 	}
 }
 

--- a/modules/user/api_language_test.go
+++ b/modules/user/api_language_test.go
@@ -204,6 +204,10 @@ func TestSetLanguageHandler_Unauthorized(t *testing.T) {
 	u := &User{Log: log.NewTLog("user-test")}
 	u.languageService = NewLanguageService(db, newFakeLangCache())
 	r := wkhttp.New()
+	// Wire the i18n renderer so the unauthorized path exercises the same
+	// envelope production hits — every other handler test in this file goes
+	// through newLanguageHandlerHarness which already wires it.
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
 	// No ctx.Set("uid", …) — simulates a request that somehow reached the
 	// handler without AuthMiddleware. The handler's own uid guard must
 	// reject it; SetLanguage must not even be called.

--- a/modules/user/api_test.go
+++ b/modules/user/api_test.go
@@ -30,6 +30,7 @@ var token = "token122323"
 func TestLoginBlockedByLocalLoginOff(t *testing.T) {
 	enableFullOIDCForUserTest(t) // 让 local_off=1 通过安全回退;验证守卫本身
 	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	setSystemSettingForUserTest(t, ctx, "login", "local_off", "1", "bool")
 	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
@@ -52,6 +53,7 @@ func TestLoginBlockedByLocalLoginOff(t *testing.T) {
 func TestSendLoginCheckPhoneCodeBlockedByLocalLoginOff(t *testing.T) {
 	enableFullOIDCForUserTest(t)
 	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	setSystemSettingForUserTest(t, ctx, "login", "local_off", "1", "bool")
 	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
@@ -69,6 +71,7 @@ func TestSendLoginCheckPhoneCodeBlockedByLocalLoginOff(t *testing.T) {
 func TestLoginCheckPhoneBlockedByLocalLoginOff(t *testing.T) {
 	enableFullOIDCForUserTest(t)
 	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	setSystemSettingForUserTest(t, ctx, "login", "local_off", "1", "bool")
 	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
@@ -94,6 +97,7 @@ func TestLoginCheckPhoneBlockedByLocalLoginOff(t *testing.T) {
 // gate 命中点在 sms.Verify / createUser 之前,所以这条用例不需要 mock SMS。
 func TestPhoneRegisterBlockedByOnlyChina(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	setSystemSettingForUserTest(t, ctx, "register", "only_china", "1", "bool")
 	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
@@ -108,7 +112,10 @@ func TestPhoneRegisterBlockedByOnlyChina(t *testing.T) {
 	}))))
 	s.GetRoute().ServeHTTP(w, req)
 
-	assert.Contains(t, w.Body.String(), "仅仅支持中国大陆手机号注册",
+	// Phase 2.1 migrated the gate to err.server.user.phone_region_unsupported;
+	// the zh-CN copy elided the legacy "仅仅" / "注册" suffix, so assert on the
+	// stable error.code to avoid future copy churn breaking the security gate.
+	assert.Contains(t, w.Body.String(), "err.server.user.phone_region_unsupported",
 		"register handler must enforce only_china before sms verify; "+
 			"sendRegisterCode-only gate leaks a TTL-window bypass when admins flip the toggle at runtime")
 }

--- a/pkg/errcode/user.go
+++ b/pkg/errcode/user.go
@@ -71,6 +71,16 @@ var (
 		HTTPStatus:     http.StatusUnauthorized,
 		DefaultMessage: "Login device session expired, please sign in again.",
 	})
+	// ErrUserLoginLocked maps the anti-brute-force lockout returned by
+	// LoginGuard.Check (ErrLoginLocked). Not Internal=true: the wire message
+	// is the user-actionable explanation. 429 is the standard HTTP status
+	// for rate-limited / lockout states even though the count window is
+	// per-account rather than per-IP.
+	ErrUserLoginLocked = register(codes.Code{
+		ID:             "err.server.user.login_locked",
+		HTTPStatus:     http.StatusTooManyRequests,
+		DefaultMessage: "Too many failed login attempts, account temporarily locked. Please try again later.",
+	})
 
 	// Existence.
 

--- a/pkg/errcode/user.go
+++ b/pkg/errcode/user.go
@@ -1,0 +1,281 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// User module error codes. Migrated from modules/user/api.go legacy
+// c.ResponseError sites in Phase 2.1 (~244 sites collapsed to ~42 codes).
+//
+// SafeDetailKeys are intentionally minimal: `field` for parameter / state
+// guards so the client can highlight the offending input, plus a handful of
+// per-code keys where the message inherently needs more context (lock-screen
+// minute bounds, WeChat response missing field).
+//
+// Internal=true is set on 5xx failures so the renderer suppresses the
+// DefaultMessage / params / details on the wire — operators still get the
+// underlying error in zap logs.
+var (
+	// Parameter / format guards.
+
+	ErrUserRequestInvalid = register(codes.Code{
+		ID:             "err.server.user.request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid request.",
+		SafeDetailKeys: []string{"field"},
+	})
+	ErrUserLockMinuteOutOfRange = register(codes.Code{
+		ID:             "err.server.user.lock_minute_out_of_range",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Lock screen delay must be between 0 and 60 minutes.",
+		SafeDetailKeys: []string{"field", "min", "max"},
+	})
+	ErrUserShortNoFormatInvalid = register(codes.Code{
+		ID:             "err.server.user.short_no_format_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Short ID must start with a letter and contain 6-20 letters, digits, underscores or hyphens.",
+	})
+	ErrUserLanguageUnsupported = register(codes.Code{
+		ID:             "err.server.user.language_unsupported",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Unsupported language.",
+	})
+	ErrUserTokenRequired = register(codes.Code{
+		ID:             "err.server.user.token_required",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Token is required.",
+		SafeDetailKeys: []string{"field"},
+	})
+
+	// Auth credentials & session.
+
+	ErrUserInvalidCredentials = register(codes.Code{
+		ID:             "err.server.user.invalid_credentials",
+		HTTPStatus:     http.StatusUnauthorized,
+		DefaultMessage: "Invalid username or password.",
+	})
+	ErrUserCodeInvalid = register(codes.Code{
+		ID:             "err.server.user.code_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid verification code.",
+	})
+	ErrUserAccountBanned = register(codes.Code{
+		ID:             "err.server.user.account_banned",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "This account has been banned.",
+	})
+	ErrUserLoginDeviceExpired = register(codes.Code{
+		ID:             "err.server.user.login_device_expired",
+		HTTPStatus:     http.StatusUnauthorized,
+		DefaultMessage: "Login device session expired, please sign in again.",
+	})
+
+	// Existence.
+
+	ErrUserNotFound = register(codes.Code{
+		ID:             "err.server.user.not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "User not found.",
+	})
+	ErrUserCurrentNotFound = register(codes.Code{
+		ID:             "err.server.user.current_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Current user not found.",
+	})
+	ErrUserAlreadyExists = register(codes.Code{
+		ID:             "err.server.user.already_exists",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "User already exists.",
+	})
+
+	// Registration / login policy.
+
+	ErrUserRegistrationClosed = register(codes.Code{
+		ID:             "err.server.user.registration_closed",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Registration is currently closed.",
+	})
+	ErrUserLocalLoginDisabled = register(codes.Code{
+		ID:             "err.server.user.local_login_disabled",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Local login is disabled.",
+	})
+	ErrUserPhoneRegionUnsupported = register(codes.Code{
+		ID:             "err.server.user.phone_region_unsupported",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Only mainland China phone numbers are supported.",
+	})
+	ErrUserInviteCodeNotFound = register(codes.Code{
+		ID:             "err.server.user.invite_code_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Invite code does not exist.",
+	})
+
+	// Account destroy lifecycle.
+
+	ErrUserAccountDestroyed = register(codes.Code{
+		ID:             "err.server.user.account_destroyed",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "This account has been deactivated.",
+	})
+	ErrUserAccountDestroying = register(codes.Code{
+		ID:             "err.server.user.account_destroying",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Account is in the deactivation cooldown period, please use a newer client to revoke or check status.",
+	})
+
+	// Profile update guards.
+
+	ErrUserUpdateNotAllowed = register(codes.Code{
+		ID:             "err.server.user.update_not_allowed",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "This field cannot be updated.",
+		SafeDetailKeys: []string{"field"},
+	})
+	ErrUserShortNoAlreadyChanged = register(codes.Code{
+		ID:             "err.server.user.short_no_already_changed",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Short ID can only be changed once.",
+	})
+	ErrUserDemoLockUnsupported = register(codes.Code{
+		ID:             "err.server.user.demo_lock_unsupported",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Demo accounts cannot enable device lock.",
+	})
+
+	// QR-code-based login.
+
+	ErrUserAuthCodeNotFound = register(codes.Code{
+		ID:             "err.server.user.auth_code_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Authorization code is invalid or has expired.",
+	})
+	ErrUserAuthCodeWrongType = register(codes.Code{
+		ID:             "err.server.user.auth_code_wrong_type",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Authorization code is not a login code.",
+	})
+	ErrUserAuthInfoInvalid = register(codes.Code{
+		ID:             "err.server.user.auth_info_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Authorization payload is invalid.",
+		SafeDetailKeys: []string{"missing_field"},
+	})
+	ErrUserAuthScannerMismatch = register(codes.Code{
+		ID:             "err.server.user.auth_scanner_mismatch",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Scanner and authorizer are not the same user.",
+	})
+	ErrUserQRVerCodeMissing = register(codes.Code{
+		ID:             "err.server.user.qr_ver_code_missing",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "User has no QR verification code.",
+	})
+
+	// WeChat third-party integration (502 Bad Gateway, Internal=true).
+
+	ErrUserWeChatExchangeFailed = register(codes.Code{
+		ID:             "err.server.user.wechat_exchange_failed",
+		HTTPStatus:     http.StatusBadGateway,
+		DefaultMessage: "Failed to exchange WeChat access token.",
+		Internal:       true,
+	})
+	ErrUserWeChatProfileFailed = register(codes.Code{
+		ID:             "err.server.user.wechat_profile_failed",
+		HTTPStatus:     http.StatusBadGateway,
+		DefaultMessage: "Failed to fetch WeChat user profile.",
+		Internal:       true,
+	})
+	ErrUserWeChatResponseInvalid = register(codes.Code{
+		ID:             "err.server.user.wechat_response_invalid",
+		HTTPStatus:     http.StatusBadGateway,
+		DefaultMessage: "WeChat response is malformed.",
+		Internal:       true,
+	})
+
+	// User-visible password / lock-screen operations (distinguished for ops monitoring).
+
+	ErrUserChatPwdUpdateFailed = register(codes.Code{
+		ID:             "err.server.user.chat_pwd_update_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to update chat password.",
+		Internal:       true,
+	})
+	ErrUserLoginPwdUpdateFailed = register(codes.Code{
+		ID:             "err.server.user.login_pwd_update_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to update login password.",
+		Internal:       true,
+	})
+	ErrUserLockScreenPwdUpdateFailed = register(codes.Code{
+		ID:             "err.server.user.lock_screen_pwd_update_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to update lock-screen password.",
+		Internal:       true,
+	})
+	ErrUserPasswordProcessFailed = register(codes.Code{
+		ID:             "err.server.user.password_process_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to process password.",
+		Internal:       true,
+	})
+
+	// Internal failures (500, Internal=true).
+
+	ErrUserQueryFailed = register(codes.Code{
+		ID:             "err.server.user.query_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to query user data.",
+		Internal:       true,
+	})
+	ErrUserStoreFailed = register(codes.Code{
+		ID:             "err.server.user.store_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to persist user data.",
+		Internal:       true,
+	})
+	ErrUserIMCallFailed = register(codes.Code{
+		ID:             "err.server.user.im_call_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to call IM service.",
+		Internal:       true,
+	})
+	ErrUserDecodeFailed = register(codes.Code{
+		ID:             "err.server.user.decode_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to decode internal payload.",
+		Internal:       true,
+	})
+	ErrUserFileOperationFailed = register(codes.Code{
+		ID:             "err.server.user.file_operation_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to process file.",
+		Internal:       true,
+	})
+	ErrUserSMSSendFailed = register(codes.Code{
+		ID:             "err.server.user.sms_send_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to send SMS.",
+		Internal:       true,
+	})
+	ErrUserDestroyFailed = register(codes.Code{
+		ID:             "err.server.user.destroy_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to deactivate account.",
+		Internal:       true,
+	})
+	ErrUserRegisterFailed = register(codes.Code{
+		ID:             "err.server.user.register_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to register user.",
+		Internal:       true,
+	})
+	ErrUserLanguageSetFailed = register(codes.Code{
+		ID:             "err.server.user.language_set_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to set language preference.",
+		Internal:       true,
+	})
+)

--- a/pkg/errcode/user_test.go
+++ b/pkg/errcode/user_test.go
@@ -23,6 +23,7 @@ func TestUserCodesHaveZhCNTranslations(t *testing.T) {
 		{ErrUserCodeInvalid.ID, ErrUserCodeInvalid.DefaultMessage, "验证码错误。"},
 		{ErrUserAccountBanned.ID, ErrUserAccountBanned.DefaultMessage, "此账号已被封禁。"},
 		{ErrUserLoginDeviceExpired.ID, ErrUserLoginDeviceExpired.DefaultMessage, "登录设备已过期，请重新登录。"},
+		{ErrUserLoginLocked.ID, ErrUserLoginLocked.DefaultMessage, "登录失败次数过多，账号已被临时锁定，请稍后再试。"},
 		{ErrUserNotFound.ID, ErrUserNotFound.DefaultMessage, "用户不存在。"},
 		{ErrUserCurrentNotFound.ID, ErrUserCurrentNotFound.DefaultMessage, "当前登录用户不存在。"},
 		{ErrUserAlreadyExists.ID, ErrUserAlreadyExists.DefaultMessage, "该用户已存在。"},

--- a/pkg/errcode/user_test.go
+++ b/pkg/errcode/user_test.go
@@ -1,0 +1,70 @@
+package errcode
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+func TestUserCodesHaveZhCNTranslations(t *testing.T) {
+	localizer := i18n.NewLocalizer(i18n.DefaultLanguage)
+	for _, code := range []struct {
+		id     string
+		source string
+		zhCN   string
+	}{
+		{ErrUserRequestInvalid.ID, ErrUserRequestInvalid.DefaultMessage, "请求数据格式有误。"},
+		{ErrUserLockMinuteOutOfRange.ID, ErrUserLockMinuteOutOfRange.DefaultMessage, "锁屏时长必须在 0 到 60 分钟之间。"},
+		{ErrUserShortNoFormatInvalid.ID, ErrUserShortNoFormatInvalid.DefaultMessage, "短号必须以字母开头，长度 6-20 位，仅支持字母、数字、下划线或减号。"},
+		{ErrUserLanguageUnsupported.ID, ErrUserLanguageUnsupported.DefaultMessage, "不支持的语言。"},
+		{ErrUserTokenRequired.ID, ErrUserTokenRequired.DefaultMessage, "Token 不能为空。"},
+		{ErrUserInvalidCredentials.ID, ErrUserInvalidCredentials.DefaultMessage, "用户名或密码错误。"},
+		{ErrUserCodeInvalid.ID, ErrUserCodeInvalid.DefaultMessage, "验证码错误。"},
+		{ErrUserAccountBanned.ID, ErrUserAccountBanned.DefaultMessage, "此账号已被封禁。"},
+		{ErrUserLoginDeviceExpired.ID, ErrUserLoginDeviceExpired.DefaultMessage, "登录设备已过期，请重新登录。"},
+		{ErrUserNotFound.ID, ErrUserNotFound.DefaultMessage, "用户不存在。"},
+		{ErrUserCurrentNotFound.ID, ErrUserCurrentNotFound.DefaultMessage, "当前登录用户不存在。"},
+		{ErrUserAlreadyExists.ID, ErrUserAlreadyExists.DefaultMessage, "该用户已存在。"},
+		{ErrUserRegistrationClosed.ID, ErrUserRegistrationClosed.DefaultMessage, "注册通道暂未开放。"},
+		{ErrUserLocalLoginDisabled.ID, ErrUserLocalLoginDisabled.DefaultMessage, "本地登录已关闭。"},
+		{ErrUserPhoneRegionUnsupported.ID, ErrUserPhoneRegionUnsupported.DefaultMessage, "仅支持中国大陆手机号。"},
+		{ErrUserInviteCodeNotFound.ID, ErrUserInviteCodeNotFound.DefaultMessage, "邀请码不存在。"},
+		{ErrUserAccountDestroyed.ID, ErrUserAccountDestroyed.DefaultMessage, "该账号已注销。"},
+		{ErrUserAccountDestroying.ID, ErrUserAccountDestroying.DefaultMessage, "账号正处于注销冷静期，请使用新版客户端撤销或查询状态。"},
+		{ErrUserUpdateNotAllowed.ID, ErrUserUpdateNotAllowed.DefaultMessage, "该字段不允许修改。"},
+		{ErrUserShortNoAlreadyChanged.ID, ErrUserShortNoAlreadyChanged.DefaultMessage, "短号仅可修改一次。"},
+		{ErrUserDemoLockUnsupported.ID, ErrUserDemoLockUnsupported.DefaultMessage, "演示账号不支持开启设备锁。"},
+		{ErrUserAuthCodeNotFound.ID, ErrUserAuthCodeNotFound.DefaultMessage, "授权码无效或已过期。"},
+		{ErrUserAuthCodeWrongType.ID, ErrUserAuthCodeWrongType.DefaultMessage, "授权码类型不是登录授权码。"},
+		{ErrUserAuthInfoInvalid.ID, ErrUserAuthInfoInvalid.DefaultMessage, "授权信息格式错误。"},
+		{ErrUserAuthScannerMismatch.ID, ErrUserAuthScannerMismatch.DefaultMessage, "扫描者与授权者不是同一用户。"},
+		{ErrUserQRVerCodeMissing.ID, ErrUserQRVerCodeMissing.DefaultMessage, "用户没有 QR 验证码。"},
+		{ErrUserWeChatExchangeFailed.ID, ErrUserWeChatExchangeFailed.DefaultMessage, "获取微信 access_token 失败。"},
+		{ErrUserWeChatProfileFailed.ID, ErrUserWeChatProfileFailed.DefaultMessage, "获取微信用户资料失败。"},
+		{ErrUserWeChatResponseInvalid.ID, ErrUserWeChatResponseInvalid.DefaultMessage, "微信返回数据格式错误。"},
+		{ErrUserChatPwdUpdateFailed.ID, ErrUserChatPwdUpdateFailed.DefaultMessage, "修改聊天密码失败。"},
+		{ErrUserLoginPwdUpdateFailed.ID, ErrUserLoginPwdUpdateFailed.DefaultMessage, "修改登录密码失败。"},
+		{ErrUserLockScreenPwdUpdateFailed.ID, ErrUserLockScreenPwdUpdateFailed.DefaultMessage, "修改锁屏密码失败。"},
+		{ErrUserPasswordProcessFailed.ID, ErrUserPasswordProcessFailed.DefaultMessage, "密码处理失败。"},
+		{ErrUserQueryFailed.ID, ErrUserQueryFailed.DefaultMessage, "查询用户数据失败。"},
+		{ErrUserStoreFailed.ID, ErrUserStoreFailed.DefaultMessage, "存储用户数据失败。"},
+		{ErrUserIMCallFailed.ID, ErrUserIMCallFailed.DefaultMessage, "调用 IM 服务失败。"},
+		{ErrUserDecodeFailed.ID, ErrUserDecodeFailed.DefaultMessage, "解码内部数据失败。"},
+		{ErrUserFileOperationFailed.ID, ErrUserFileOperationFailed.DefaultMessage, "文件处理失败。"},
+		{ErrUserSMSSendFailed.ID, ErrUserSMSSendFailed.DefaultMessage, "短信发送失败。"},
+		{ErrUserDestroyFailed.ID, ErrUserDestroyFailed.DefaultMessage, "注销账号失败。"},
+		{ErrUserRegisterFailed.ID, ErrUserRegisterFailed.DefaultMessage, "注册失败。"},
+		{ErrUserLanguageSetFailed.ID, ErrUserLanguageSetFailed.DefaultMessage, "设置语言偏好失败。"},
+	} {
+		t.Run(code.id, func(t *testing.T) {
+			got := localizer.Translate(code.id, "zh-CN", nil)
+			if got != code.zhCN {
+				t.Fatalf("zh-CN translation = %q, want %q", got, code.zhCN)
+			}
+			if got == code.id || strings.EqualFold(got, code.source) {
+				t.Fatalf("zh-CN translation for %s fell back to %q", code.id, got)
+			}
+		})
+	}
+}

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -122,6 +122,9 @@ other = "此账号已被封禁。"
 ["err.server.user.login_device_expired"]
 other = "登录设备已过期，请重新登录。"
 
+["err.server.user.login_locked"]
+other = "登录失败次数过多，账号已被临时锁定，请稍后再试。"
+
 ["err.server.user.not_found"]
 other = "用户不存在。"
 

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -92,3 +92,131 @@ other = "子区设置无效。"
 
 ["err.server.thread.store_failed"]
 other = "子区存储操作失败。"
+
+# ---- err.server.user.* (Phase 2.1 modules/user/api.go migration) ----
+
+["err.server.user.request_invalid"]
+other = "请求数据格式有误。"
+
+["err.server.user.lock_minute_out_of_range"]
+other = "锁屏时长必须在 0 到 60 分钟之间。"
+
+["err.server.user.short_no_format_invalid"]
+other = "短号必须以字母开头，长度 6-20 位，仅支持字母、数字、下划线或减号。"
+
+["err.server.user.language_unsupported"]
+other = "不支持的语言。"
+
+["err.server.user.token_required"]
+other = "Token 不能为空。"
+
+["err.server.user.invalid_credentials"]
+other = "用户名或密码错误。"
+
+["err.server.user.code_invalid"]
+other = "验证码错误。"
+
+["err.server.user.account_banned"]
+other = "此账号已被封禁。"
+
+["err.server.user.login_device_expired"]
+other = "登录设备已过期，请重新登录。"
+
+["err.server.user.not_found"]
+other = "用户不存在。"
+
+["err.server.user.current_not_found"]
+other = "当前登录用户不存在。"
+
+["err.server.user.already_exists"]
+other = "该用户已存在。"
+
+["err.server.user.registration_closed"]
+other = "注册通道暂未开放。"
+
+["err.server.user.local_login_disabled"]
+other = "本地登录已关闭。"
+
+["err.server.user.phone_region_unsupported"]
+other = "仅支持中国大陆手机号。"
+
+["err.server.user.invite_code_not_found"]
+other = "邀请码不存在。"
+
+["err.server.user.account_destroyed"]
+other = "该账号已注销。"
+
+["err.server.user.account_destroying"]
+other = "账号正处于注销冷静期，请使用新版客户端撤销或查询状态。"
+
+["err.server.user.update_not_allowed"]
+other = "该字段不允许修改。"
+
+["err.server.user.short_no_already_changed"]
+other = "短号仅可修改一次。"
+
+["err.server.user.demo_lock_unsupported"]
+other = "演示账号不支持开启设备锁。"
+
+["err.server.user.auth_code_not_found"]
+other = "授权码无效或已过期。"
+
+["err.server.user.auth_code_wrong_type"]
+other = "授权码类型不是登录授权码。"
+
+["err.server.user.auth_info_invalid"]
+other = "授权信息格式错误。"
+
+["err.server.user.auth_scanner_mismatch"]
+other = "扫描者与授权者不是同一用户。"
+
+["err.server.user.qr_ver_code_missing"]
+other = "用户没有 QR 验证码。"
+
+["err.server.user.wechat_exchange_failed"]
+other = "获取微信 access_token 失败。"
+
+["err.server.user.wechat_profile_failed"]
+other = "获取微信用户资料失败。"
+
+["err.server.user.wechat_response_invalid"]
+other = "微信返回数据格式错误。"
+
+["err.server.user.chat_pwd_update_failed"]
+other = "修改聊天密码失败。"
+
+["err.server.user.login_pwd_update_failed"]
+other = "修改登录密码失败。"
+
+["err.server.user.lock_screen_pwd_update_failed"]
+other = "修改锁屏密码失败。"
+
+["err.server.user.password_process_failed"]
+other = "密码处理失败。"
+
+["err.server.user.query_failed"]
+other = "查询用户数据失败。"
+
+["err.server.user.store_failed"]
+other = "存储用户数据失败。"
+
+["err.server.user.im_call_failed"]
+other = "调用 IM 服务失败。"
+
+["err.server.user.decode_failed"]
+other = "解码内部数据失败。"
+
+["err.server.user.file_operation_failed"]
+other = "文件处理失败。"
+
+["err.server.user.sms_send_failed"]
+other = "短信发送失败。"
+
+["err.server.user.destroy_failed"]
+other = "注销账号失败。"
+
+["err.server.user.register_failed"]
+other = "注册失败。"
+
+["err.server.user.language_set_failed"]
+other = "设置语言偏好失败。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -132,6 +132,9 @@ other = "Failed to update lock-screen password."
 ["err.server.user.login_device_expired"]
 other = "Login device session expired, please sign in again."
 
+["err.server.user.login_locked"]
+other = "Too many failed login attempts, account temporarily locked. Please try again later."
+
 ["err.server.user.login_pwd_update_failed"]
 other = "Failed to update login password."
 

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -59,3 +59,129 @@ other = "Invalid thread status."
 
 ["err.server.thread.store_failed"]
 other = "Thread storage operation failed."
+
+["err.server.user.account_banned"]
+other = "This account has been banned."
+
+["err.server.user.account_destroyed"]
+other = "This account has been deactivated."
+
+["err.server.user.account_destroying"]
+other = "Account is in the deactivation cooldown period, please use a newer client to revoke or check status."
+
+["err.server.user.already_exists"]
+other = "User already exists."
+
+["err.server.user.auth_code_not_found"]
+other = "Authorization code is invalid or has expired."
+
+["err.server.user.auth_code_wrong_type"]
+other = "Authorization code is not a login code."
+
+["err.server.user.auth_info_invalid"]
+other = "Authorization payload is invalid."
+
+["err.server.user.auth_scanner_mismatch"]
+other = "Scanner and authorizer are not the same user."
+
+["err.server.user.chat_pwd_update_failed"]
+other = "Failed to update chat password."
+
+["err.server.user.code_invalid"]
+other = "Invalid verification code."
+
+["err.server.user.current_not_found"]
+other = "Current user not found."
+
+["err.server.user.decode_failed"]
+other = "Failed to decode internal payload."
+
+["err.server.user.demo_lock_unsupported"]
+other = "Demo accounts cannot enable device lock."
+
+["err.server.user.destroy_failed"]
+other = "Failed to deactivate account."
+
+["err.server.user.file_operation_failed"]
+other = "Failed to process file."
+
+["err.server.user.im_call_failed"]
+other = "Failed to call IM service."
+
+["err.server.user.invalid_credentials"]
+other = "Invalid username or password."
+
+["err.server.user.invite_code_not_found"]
+other = "Invite code does not exist."
+
+["err.server.user.language_set_failed"]
+other = "Failed to set language preference."
+
+["err.server.user.language_unsupported"]
+other = "Unsupported language."
+
+["err.server.user.local_login_disabled"]
+other = "Local login is disabled."
+
+["err.server.user.lock_minute_out_of_range"]
+other = "Lock screen delay must be between 0 and 60 minutes."
+
+["err.server.user.lock_screen_pwd_update_failed"]
+other = "Failed to update lock-screen password."
+
+["err.server.user.login_device_expired"]
+other = "Login device session expired, please sign in again."
+
+["err.server.user.login_pwd_update_failed"]
+other = "Failed to update login password."
+
+["err.server.user.not_found"]
+other = "User not found."
+
+["err.server.user.password_process_failed"]
+other = "Failed to process password."
+
+["err.server.user.phone_region_unsupported"]
+other = "Only mainland China phone numbers are supported."
+
+["err.server.user.qr_ver_code_missing"]
+other = "User has no QR verification code."
+
+["err.server.user.query_failed"]
+other = "Failed to query user data."
+
+["err.server.user.register_failed"]
+other = "Failed to register user."
+
+["err.server.user.registration_closed"]
+other = "Registration is currently closed."
+
+["err.server.user.request_invalid"]
+other = "Invalid request."
+
+["err.server.user.short_no_already_changed"]
+other = "Short ID can only be changed once."
+
+["err.server.user.short_no_format_invalid"]
+other = "Short ID must start with a letter and contain 6-20 letters, digits, underscores or hyphens."
+
+["err.server.user.sms_send_failed"]
+other = "Failed to send SMS."
+
+["err.server.user.store_failed"]
+other = "Failed to persist user data."
+
+["err.server.user.token_required"]
+other = "Token is required."
+
+["err.server.user.update_not_allowed"]
+other = "This field cannot be updated."
+
+["err.server.user.wechat_exchange_failed"]
+other = "Failed to exchange WeChat access token."
+
+["err.server.user.wechat_profile_failed"]
+other = "Failed to fetch WeChat user profile."
+
+["err.server.user.wechat_response_invalid"]
+other = "WeChat response is malformed."


### PR DESCRIPTION
## Summary

Second Phase-2 i18n pilot after `modules/thread`. Migrates the largest single file in the codebase (`modules/user/api.go`, 3848 lines) from legacy `c.ResponseError(errors.New(...))` to the localized envelope via `httperr.ResponseErrorL` → `wkhttp.ErrorRenderer`.

- **244** `c.ResponseError` sites surveyed → **221** active sites migrated (3 commented-out breadcrumbs left in place).
- **42** new `err.server.user.*` codes registered in `pkg/errcode/user.go` with matching zh-CN translations.
- **7** `respondUser*` helpers cover the five detail-bearing shapes (`field` / `missing_field` / lock bounds) plus a `respondUserServiceError` fallback wrapping `ErrUserStoreFailed` (Internal=true) for bare `c.ResponseError(err)` sites that have no service-layer sentinel to branch on.
- `respondUserNotLoggedIn` looks up `err.shared.auth.required` at package init so the belt-and-braces `loginUID == ""` guards in legacy public routes render the consistent 401 envelope.

## Why 42 codes (vs `modules/thread`'s 17)

User module spans login, registration, device tokens, QR-code scan login, WeChat third-party, blacklist, lock-screen password, chat password, account deactivation, password recovery and verification endpoints — eight unrelated subsystems sharing one file. Code-level granularity matches the operational dashboards we expect to alert on (e.g. SMS send failures vs. IM service failures vs. WeChat exchange failures), without collapsing every internal failure to a single bucket. 5xx codes all carry `Internal=true` so the renderer suppresses `DefaultMessage` / `Params` / `Details` on the wire.

## Commit layout (4 commits, each independently reviewable)

1. **`feat(i18n): register err.server.user.* codes and zh-CN translations`** — `pkg/errcode/user.go` + `pkg/i18n/locales/active.zh-CN.toml` + `pkg/errcode/user_test.go` (table-driven translation assertion + AST extractor marker refresh).
2. **`feat(i18n): add respond helpers for modules/user`** — `modules/user/api_i18n.go` with the seven helpers (no handler diff).
3. **`feat(i18n): migrate modules/user/api.go handlers to ResponseErrorL`** — the bulk handler diff (+287/-229 in `api.go`) plus three small test infrastructure repairs (wire the i18n renderer onto the existing `testutil.NewTestServer`-based security guard tests, adjust two assertions that depended on the legacy envelope's exact copy).
4. **`test(i18n): add modules/user respond-helper + legacy-guard coverage`** — `modules/user/api_i18n_test.go` with `TestUserAPINoLegacyResponseError` (guards against regressions) and `TestRespondUserHelpers` (13 cases covering every helper and the Internal=true contract).

## Test plan

- [x] `go test -race -count=1 -timeout 120s ./modules/user/... ./pkg/errcode/... ./pkg/i18n/...` — all green
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `make i18n-extract-check` — clean (markers regenerated from the new code registrations; 60 server markers = 18 thread + 42 user)
- [x] Manual harness coverage of every helper through the real renderer with `Accept-Language: zh-CN`, asserting `error.code` / `error.http_status` / dual-envelope agreement / Internal=true suppression

## Known follow-ups (out of scope, tracked separately)

- Service-layer sentinel error extraction (same `thread` reviewer P2 follow-up; lets us classify the 18 bare `c.ResponseError(err)` sites more precisely than the current generic `store_failed`).
- `testutil.NewTestServer` in `octo-lib` does not wire the i18n renderer; this PR adds a thin `wireI18nRendererForUserTest` helper in `modules/user/_test` files. A small `octo-lib` PR can fold this into `testutil` itself once the i18n renderer is stable across modules.
- `modules/user/api_manager.go` (~95 sites) and `modules/user/api_friend.go` + remainder (~308 sites) follow as sub-PR 2 and sub-PR 3 of the `modules/user` track (TODOS Phase 2.1).