### PR TITLE
feat(appconfig): admin-tunable disable_user_create_space toggle

### DIFF
--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -395,9 +395,10 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 	}
 	if versionI64 != 0 && int(versionI64) >= appConfigM.Version {
 		c.JSON(http.StatusOK, &appConfigResp{
-			Version:       appConfigM.Version,
-			SystemBotUIDs: spacepkg.SystemBotList(),
-			LocalLoginOff: boolToFlag(cn.systemSettings.LocalLoginOff()),
+			Version:                appConfigM.Version,
+			SystemBotUIDs:          spacepkg.SystemBotList(),
+			LocalLoginOff:          boolToFlag(cn.systemSettings.LocalLoginOff()),
+			DisableUserCreateSpace: boolToFlag(cn.systemSettings.SpaceDisableUserCreate()),
 		})
 		return
 	}
@@ -433,8 +434,9 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 		OIDCResetPasswordURL:           oidcResetPasswordURL(),
 		OIDCProviders:                  oidcProviders(),
 		// YUJ-219-A / GH#1283：单一真源下发系统 Bot UID 列表，替代三端硬编码。
-		SystemBotUIDs: spacepkg.SystemBotList(),
-		LocalLoginOff: boolToFlag(cn.systemSettings.LocalLoginOff()),
+		SystemBotUIDs:          spacepkg.SystemBotList(),
+		LocalLoginOff:          boolToFlag(cn.systemSettings.LocalLoginOff()),
+		DisableUserCreateSpace: boolToFlag(cn.systemSettings.SpaceDisableUserCreate()),
 	})
 }
 
@@ -735,6 +737,16 @@ type appConfigResp struct {
 	// 与 app_config.version 解耦：即使客户端命中 version 短路分支，也必须能拿到
 	// 最新值，否则 admin 切换开关后老客户端会被本地缓存住。和 SystemBotUIDs 同理。
 	LocalLoginOff int `json:"local_login_off"`
+
+	// DisableUserCreateSpace 控制客户端是否隐藏「创建空间」入口。
+	// 来源 system_setting space.disable_user_create,回退到 env
+	// DM_SPACE_DISABLE_USER_CREATE,默认 0(允许创建)。
+	//
+	// 与 app_config.version 解耦的原因同 LocalLoginOff：admin 在管理台 toggle
+	// 后老客户端命中 version 短路分支仍必须看到最新值，否则被本地缓存住失去
+	// 实时性。后端 POST /v1/space/create 也走同一个 getter 校验,客户端隐藏
+	// 与服务端拒绝由单一真源驱动,不存在前后端漂移。
+	DisableUserCreateSpace int `json:"disable_user_create_space"`
 }
 
 type oidcProviderResp struct {

--- a/modules/common/api_test.go
+++ b/modules/common/api_test.go
@@ -119,6 +119,71 @@ func TestGetAppConfig_SystemBotUIDsOnVersionShortCircuit(t *testing.T) {
 	assert.Contains(t, body, `"fileHelper"`)
 }
 
+// appconfig 必须下发 disable_user_create_space：默认 0（缺 system_setting 行且
+// env 未设置）。客户端据此显示/隐藏「创建空间」入口；缺省必须保持开放。
+func TestGetAppConfig_DisableUserCreateSpace_DefaultsZero(t *testing.T) {
+	t.Setenv("DM_SPACE_DISABLE_USER_CREATE", "")
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	err := testutil.CleanAllTables(ctx)
+	assert.NoError(t, err)
+	err = f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"disable_user_create_space":0`)
+}
+
+// DB 写入 disable_user_create=1 时 appconfig 必须下发 1，admin 在管理台切换
+// 后客户端下次拉配置即可看到入口隐藏 —— 系统级 KV + Reload 路径的实时性保证。
+func TestGetAppConfig_DisableUserCreateSpace_DBOverride(t *testing.T) {
+	t.Setenv("DM_SPACE_DISABLE_USER_CREATE", "")
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	err := testutil.CleanAllTables(ctx)
+	assert.NoError(t, err)
+	err = f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+
+	settings := EnsureSystemSettings(ctx)
+	assert.NoError(t, settings.db.upsert("space", "disable_user_create", "1", settingTypeBool, ""))
+	assert.NoError(t, settings.Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"disable_user_create_space":1`)
+}
+
+// version 短路分支同样要下发 disable_user_create_space：老客户端命中版本
+// 短路也必须看到当前开关，否则被缓存住失去"实时调整"的能力（与 LocalLoginOff
+// 同样的"system_setting 与 app_config.version 解耦"约束）。
+func TestGetAppConfig_DisableUserCreateSpace_OnVersionShortCircuit(t *testing.T) {
+	t.Setenv("DM_SPACE_DISABLE_USER_CREATE", "")
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	err := testutil.CleanAllTables(ctx)
+	assert.NoError(t, err)
+	err = f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+
+	settings := EnsureSystemSettings(ctx)
+	assert.NoError(t, settings.db.upsert("space", "disable_user_create", "1", settingTypeBool, ""))
+	assert.NoError(t, settings.Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig?version=99999999", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"disable_user_create_space":1`)
+}
+
 // appconfig 必须下发 local_login_off：默认 0（缺 system_setting 行）。
 func TestGetAppConfig_LocalLoginOff_DefaultsZero(t *testing.T) {
 	s, ctx := testutil.NewTestServer()

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -50,6 +50,12 @@ var systemSettingSchema = []settingDef{
 	{Category: "login", Key: "local_off", Type: settingTypeBool, Description: "是否关闭本地账号登录入口",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.LocalLoginOff()) }},
 
+	// Space user-facing creation toggle — admin 关闭后客户端隐藏创建入口,
+	// 后端 POST /v1/space/create 直接 403。env DM_SPACE_DISABLE_USER_CREATE
+	// 仍作 fallback,DB 行为单一真源。
+	{Category: "space", Key: "disable_user_create", Type: settingTypeBool, Description: "是否关闭普通用户创建空间入口",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.SpaceDisableUserCreate()) }},
+
 	// Email server config — formerly yaml-only (Support.* in config.go).
 	{Category: "support", Key: "email", Type: settingTypeString, Description: "技术支持邮箱（发件人）",
 		Effective: func(s *SystemSettings) string { return s.SupportEmail() }},

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -437,9 +437,15 @@ const envSpaceDisableUserCreate = "DM_SPACE_DISABLE_USER_CREATE"
 // SpaceDisableUserCreate reports whether the user-facing「创建空间」入口应被
 // 关闭。完整 fallback 链(按优先级):
 //
-//	1. system_setting space.disable_user_create 行的 DB 值(走 getBool 同款解析)
-//	2. 空 DB 行 / DB row 不存在 / DB 写入未知字面量 → env DM_SPACE_DISABLE_USER_CREATE
+//	1. DB 行存在且 value 非空 → 走 getBool 解析(1/true/TRUE → true;
+//	   0/false/FALSE → false; 未知字面量 → false)。**不再回退到 env** —— 与
+//	   其他 bool 设置一致,未知字面量等同 "admin 不希望关闭"。
+//	2. DB 行不存在,或 value="" → env DM_SPACE_DISABLE_USER_CREATE
 //	3. 都缺失 → false (保持开放)
+//
+// 注：manager 写接口对 bool 值已做规范化(只接受 0/1/true/false 及大小写
+// 变体),正常路径不会出现未知字面量;此规则覆盖的是有人绕过 API 直接改 DB
+// 的边缘场景。
 //
 // DB 是单一真源：admin 在管理台显式 toggle 立刻生效（Reload 内存快照），
 // 多实例 60s 内收敛。env 仅作历史部署兼容入口；新部署应直接走 system_setting。

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -425,6 +426,54 @@ func (s *SystemSettings) LogLocalLoginOffSafetyOverrideIfActive(localOff bool) {
 // only external need is this one logging path.
 func (s *SystemSettings) RawLocalLoginOffFromSnapshot() bool {
 	return s.getBool("login", "local_off", false)
+}
+
+// envSpaceDisableUserCreate 与 modules/space/api.go:envDisableUserCreateSpace
+// 保持同名,镜像在 common 包以避免反向依赖 (space 已 import common)。新增/修改
+// env 解析规则时两处同步,语义就是: 1/true/yes/on (任意大小写,允许前后空格)
+// 视为 ON，其余皆 OFF。
+const envSpaceDisableUserCreate = "DM_SPACE_DISABLE_USER_CREATE"
+
+// SpaceDisableUserCreate reports whether the user-facing「创建空间」入口应被
+// 关闭。完整 fallback 链(按优先级):
+//
+//	1. system_setting space.disable_user_create 行的 DB 值(走 getBool 同款解析)
+//	2. 空 DB 行 / DB row 不存在 / DB 写入未知字面量 → env DM_SPACE_DISABLE_USER_CREATE
+//	3. 都缺失 → false (保持开放)
+//
+// DB 是单一真源：admin 在管理台显式 toggle 立刻生效（Reload 内存快照），
+// 多实例 60s 内收敛。env 仅作历史部署兼容入口；新部署应直接走 system_setting。
+//
+// 与 modules/space/api.go:IsUserCreateDisabled 保持等价语义 —— 后者仍是
+// env-only 的低层解析器,留给没有 ctx 的调用方与 yaml 模式;实际请求路径走本
+// 方法（modules/space/api.go:createSpace）。
+//
+// 实现细节：DB 路径委托给 getBool 以与其他 bool 设置共享解析规则,避免双写
+// 字面量集合(reviewer H1)。"DB 行是否存在"由独立 lookup 决定,从而区分
+// "DB 缺行 → env" 与 "DB 值=0 → 强制 false 压制 env" 两个语义。
+func (s *SystemSettings) SpaceDisableUserCreate() bool {
+	if _, ok := s.lookup("space", "disable_user_create"); ok {
+		// 走与所有其他 bool 设置一致的字面量解析;未知字面量会落到 fallback=false,
+		// 与 "DB 显式写了 0" 语义一致 —— 都视为 admin 不希望关闭。
+		return s.getBool("space", "disable_user_create", false)
+	}
+	return parseSpaceDisableUserCreateEnv(os.Getenv(envSpaceDisableUserCreate))
+}
+
+// parseSpaceDisableUserCreateEnv 与 modules/space/api.go:IsUserCreateDisabled
+// 的解析逻辑保持一致(1/true/yes/on,大小写不敏感,允许前后空格)。两处镜像而
+// 非提到 leaf package,理由同 LocalLoginOff/OIDC: 一个 helper 不值得为它引
+// 入一层新包。修改任何一处时两边同步,否则同一开关在两个出口语义会漂移。
+func parseSpaceDisableUserCreateEnv(v string) bool {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return false
+	}
+	switch strings.ToLower(v) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
 }
 
 // SupportEmail returns the From address used by the SMTP sender.

--- a/modules/common/system_settings_test.go
+++ b/modules/common/system_settings_test.go
@@ -223,6 +223,74 @@ func TestSystemSettings_LocalLoginOff_TrueWhenGiteeConfigured(t *testing.T) {
 	assert.True(t, s.LocalLoginOff(), "Gitee OAuth 配置齐备 → 守卫生效")
 }
 
+// SpaceDisableUserCreate 的 fallback 链：DB → env DM_SPACE_DISABLE_USER_CREATE → false。
+// 默认无 DB 行且无 env 时,返回 false（保持历史行为：用户侧可创建空间）。
+func TestSystemSettings_SpaceDisableUserCreate_DefaultsFalse(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	t.Setenv("DM_SPACE_DISABLE_USER_CREATE", "")
+	assert.False(t, s.SpaceDisableUserCreate(),
+		"DB 未配置且 env 未设置时必须保持开放（false）")
+}
+
+// DB 值优先于 env：admin 在管理台显式关闭时,即便 env 未设置也立即生效。
+func TestSystemSettings_SpaceDisableUserCreate_DBTrueWins(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	t.Setenv("DM_SPACE_DISABLE_USER_CREATE", "")
+	require.NoError(t, s.db.upsert("space", "disable_user_create", "1", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+	assert.True(t, s.SpaceDisableUserCreate(),
+		"DB=1 必须关闭用户侧创建入口")
+}
+
+// DB 行存在但值为 0 时必须明确返回 false,即使 env 设置为 true 也不再"漏出去"。
+// 这一条用例固化"DB 是单一真源"的语义：admin 在管理台 toggle 回 0 必须能压住
+// 历史 env 配置；否则运维改了配置却看不到效果。
+func TestSystemSettings_SpaceDisableUserCreate_DBFalseOverridesEnv(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	t.Setenv("DM_SPACE_DISABLE_USER_CREATE", "true")
+	require.NoError(t, s.db.upsert("space", "disable_user_create", "0", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+	assert.False(t, s.SpaceDisableUserCreate(),
+		"DB=0 必须覆盖 env=true（DB 是单一真源）")
+}
+
+// DB 行存在但 value 为空字符串时, lookup 视为"未配置"(与其它所有设置一致),
+// 落回 env fallback —— 不是把 disable_user_create 强制 false。这条用例锁定
+// "DB row 空值 == 未配置" 的语义,与其他 bool 设置(register/login/support)
+// 共享同一回退规则,避免后续维护者误以为空值压制 env。
+func TestSystemSettings_SpaceDisableUserCreate_DBEmptyValueFallsBackToEnv(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	t.Setenv("DM_SPACE_DISABLE_USER_CREATE", "true")
+	require.NoError(t, s.db.upsert("space", "disable_user_create", "", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+	assert.True(t, s.SpaceDisableUserCreate(),
+		"DB 值=\"\" 视为未配置, env=true 必须生效")
+}
+
+// 仅设置了 env 而无 DB 行时,getter 必须回退到 env 解析结果,保持对历史部署的
+// 兼容（envDisableUserCreateSpace 是这个开关的原始入口）。
+func TestSystemSettings_SpaceDisableUserCreate_EnvFallback(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	for _, spelling := range []string{"1", "true", "TRUE", "yes", "on", " true "} {
+		t.Run(spelling, func(t *testing.T) {
+			t.Setenv("DM_SPACE_DISABLE_USER_CREATE", spelling)
+			assert.True(t, s.SpaceDisableUserCreate(),
+				"env=%q 必须被识别为开启", spelling)
+		})
+	}
+}
+
+func TestSystemSettings_SpaceDisableUserCreate_EnvNegativeSpellings(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	for _, spelling := range []string{"0", "false", "FALSE", "no", "random"} {
+		t.Run(spelling, func(t *testing.T) {
+			t.Setenv("DM_SPACE_DISABLE_USER_CREATE", spelling)
+			assert.False(t, s.SpaceDisableUserCreate(),
+				"env=%q 不应被识别为开启", spelling)
+		})
+	}
+}
+
 func TestSystemSettings_StringFallsBackOnEmpty(t *testing.T) {
 	s := newTestSystemSettings(t, nil)
 	s.ctx.GetConfig().Support.EmailSmtp = "smtp.yaml.example:465"

--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkevent"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
+	commonmod "github.com/Mininglamp-OSS/octo-server/modules/common"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	rd "github.com/go-redis/redis"
@@ -121,11 +122,22 @@ func (s *Space) Route(r *wkhttp.WKHttp) {
 	}
 }
 
-// envDisableUserCreateSpace 全局开关：运维通过环境变量 DM_SPACE_DISABLE_USER_CREATE=true
-// 关闭用户侧创建空间入口（POST /v1/space/create）。管理端代建接口不受此开关约束。
+// envDisableUserCreateSpace 全局开关的历史 env 入口：运维通过环境变量
+// DM_SPACE_DISABLE_USER_CREATE=true 关闭用户侧创建空间入口
+// （POST /v1/space/create）。管理端代建接口不受此开关约束。
+//
+// 单一真源已迁移到 system_setting 表的 (space, disable_user_create) 行；
+// 本 env 仍作 fallback 供没有 DB override 的老部署使用,但 admin 在管理台写入
+// DB 后,DB 值优先。详见 modules/common/system_settings.go:SpaceDisableUserCreate。
 const envDisableUserCreateSpace = "DM_SPACE_DISABLE_USER_CREATE"
 
-// IsUserCreateDisabled 是否已通过环境变量关闭用户侧创建空间。
+// IsUserCreateDisabled 是否已通过环境变量关闭用户侧创建空间。env-only 的低层
+// 解析器,语义与 modules/common/system_settings.go:parseSpaceDisableUserCreateEnv
+// 保持一致 —— 后者是 system_setting 查询的 env fallback。修改此函数的解析
+// 规则时必须同步那一处,否则同一开关会在两个出口产生漂移。
+//
+// 调用方应优先走 (*Space).isUserCreateDisabled 以获得 DB → env 完整链路；本
+// 函数保留是为了向前兼容已有 callers / 测试,以及作为最简 env-only 探测点。
 func IsUserCreateDisabled() bool {
 	v := strings.TrimSpace(os.Getenv(envDisableUserCreateSpace))
 	if v == "" {
@@ -136,6 +148,13 @@ func IsUserCreateDisabled() bool {
 		return true
 	}
 	return false
+}
+
+// isUserCreateDisabled 走 system_setting DB → env 完整 fallback 链, 是
+// createSpace handler 的判断入口。SystemSettings snapshot 由 ticker 自动刷新,
+// admin 写 DB → Reload 后 60s 内多实例收敛, 本实例立即生效。
+func (s *Space) isUserCreateDisabled() bool {
+	return commonmod.EnsureSystemSettings(s.ctx).SpaceDisableUserCreate()
 }
 
 // createSpaceParams 创建空间的核心参数。Creator 为目标空间 owner，
@@ -158,7 +177,7 @@ type createSpaceResult struct {
 
 // createSpace 创建空间（用户侧入口）
 func (s *Space) createSpace(c *wkhttp.Context) {
-	if IsUserCreateDisabled() {
+	if s.isUserCreateDisabled() {
 		c.ResponseErrorWithStatus(errors.New("管理员已关闭空间创建功能"), http.StatusForbidden)
 		return
 	}

--- a/modules/space/api_test.go
+++ b/modules/space/api_test.go
@@ -16,8 +16,10 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-lib/server"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	modulescommon "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -1535,6 +1537,54 @@ func TestCreateSpace_AllowedByDefault(t *testing.T) {
 	assert.Equal(t, 2, mem.Role)
 }
 
+// system_setting 写入 space.disable_user_create=1 后, createSpace 必须返回 403,
+// 不依赖任何环境变量。这是「admin 在管理台实时关闭用户侧创建」核心路径的
+// 守卫用例 —— 离开 env 之后,DB 行 + Reload 立刻让本实例生效,多实例由 60s
+// 自动 reload 收敛(参见 SystemSettings.StartAutoReload)。
+func TestCreateSpace_DisabledBySystemSetting(t *testing.T) {
+	s, _, err := setup(t)
+	assert.NoError(t, err)
+	// 显式清空 env, 证明开关纯由 DB 驱动
+	t.Setenv(envDisableUserCreateSpace, "")
+
+	// 直接 DB 写入 + Reload, 模拟 manager API 的写路径但避开 admin token 与
+	// 路由准备 — 这条用例的关注点是 "DB → SystemSettings → createSpace 拒绝"
+	// 这条链路, 不是 manager API 本身(后者在 common 包已有单测覆盖)。
+	_, err = testCtx.DB().InsertInto("system_setting").
+		Pair("category", "space").
+		Pair("key_name", "disable_user_create").
+		Pair("value", "1").
+		Pair("value_type", "bool").
+		Pair("description", "").
+		Exec()
+	assert.NoError(t, err)
+	settings := modulescommon.EnsureSystemSettings(testCtx)
+	assert.NoError(t, settings.Reload())
+	defer func() {
+		_, _ = testCtx.DB().DeleteFrom("system_setting").
+			Where("category=? AND key_name=?", "space", "disable_user_create").
+			Exec()
+		_ = settings.Reload()
+	}()
+
+	body := util.ToJson(map[string]interface{}{
+		"name":      "p2-blocked-by-db",
+		"join_mode": 0,
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/space/create", bytes.NewReader([]byte(body)))
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code, "DB 开关 ON 时应返回 403, body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "已关闭")
+
+	var count int
+	_, err = testCtx.DB().SelectBySql("SELECT COUNT(*) FROM space WHERE name=?", "p2-blocked-by-db").Load(&count)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count, "DB 开关 ON 时不应写入任何 space 记录")
+}
+
 func TestCreateSpace_DisabledByEnv(t *testing.T) {
 	s, _, err := setup(t)
 	assert.NoError(t, err)
@@ -1806,4 +1856,102 @@ func TestRejectJoinApply_DoesNotConsumeInvite(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 2, updated.Status)
 	assert.Equal(t, testutil.UID, updated.ReviewerUID)
+}
+
+// TestE2E_DisableUserCreateSpace_FullChain 串起完整的 admin 实时调控链路:
+//
+//	manager POST /v1/manager/common/system_setting  (写 disable_user_create=1)
+//	    → 客户端 GET /v1/common/appconfig            (看到 disable_user_create_space=1)
+//	    → 用户 POST /v1/space/create                 (403)
+//	    → manager POST 写回 0
+//	    → 用户 POST /v1/space/create                 (200)
+//
+// 这条 e2e 守住 "DB 单一真源 + Reload 即时生效 + 前后端用同一 getter" 的整条链路,
+// 任一节点漂移(写路径未触发 Reload、appconfig 漏字段、createSpace 走老 env-only
+// 路径)都会让本用例失败。
+func TestE2E_DisableUserCreateSpace_FullChain(t *testing.T) {
+	srv, _, err := setup(t)
+	assert.NoError(t, err)
+	t.Setenv(envDisableUserCreateSpace, "")
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+
+	// CleanAllTables 清空了 app_config,/v1/common/appconfig 没拿到行会 400。
+	// 这里灌一行默认 app_config(其余 NOT NULL 列在 schema 里都有 DEFAULT),
+	// 让 appconfig handler 走到我们要验证的字段下发路径。
+	_, err = testCtx.DB().InsertInto("app_config").Pair("version", 1).Exec()
+	assert.NoError(t, err)
+
+	// 给 testutil.Token 升 super admin 角色,以便调用 manager 写接口。
+	// CleanAllTables 不会清缓存里的 token 行,但 setup 内已重置一次,这里覆盖
+	// 上层角色到 SuperAdmin。还原也走 cache.Set,无副作用。
+	cfg := testCtx.GetConfig()
+	tokenKey := cfg.Cache.TokenCachePrefix + testutil.Token
+	origTokenVal, _ := testCtx.Cache().Get(tokenKey)
+	assert.NoError(t, testCtx.Cache().Set(tokenKey,
+		testutil.UID+"@test@"+string(wkhttp.SuperAdmin)))
+	defer func() { _ = testCtx.Cache().Set(tokenKey, origTokenVal) }()
+
+	defer func() {
+		// 不论用例分支如何退出,把 system_setting 行清掉避免污染后续测试。
+		_, _ = testCtx.DB().DeleteFrom("system_setting").
+			Where("category=? AND key_name=?", "space", "disable_user_create").
+			Exec()
+		_ = modulescommon.EnsureSystemSettings(testCtx).Reload()
+	}()
+
+	writeSetting := func(value string) {
+		t.Helper()
+		body := util.ToJson(map[string]interface{}{
+			"items": []map[string]string{{
+				"category": "space",
+				"key":      "disable_user_create",
+				"value":    value,
+			}},
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST",
+			"/v1/manager/common/system_setting",
+			bytes.NewReader([]byte(body)))
+		req.Header.Set("token", testutil.Token)
+		srv.GetRoute().ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code,
+			"manager 写 disable_user_create=%s 应 200, body=%s", value, w.Body.String())
+	}
+
+	getAppconfig := func() string {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+		srv.GetRoute().ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code, "appconfig 应 200, body=%s", w.Body.String())
+		return w.Body.String()
+	}
+
+	createSpace := func(name string) int {
+		t.Helper()
+		body := util.ToJson(map[string]interface{}{
+			"name":      name,
+			"join_mode": 0,
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/v1/space/create",
+			bytes.NewReader([]byte(body)))
+		req.Header.Set("token", testutil.Token)
+		srv.GetRoute().ServeHTTP(w, req)
+		return w.Code
+	}
+
+	// --- Step 1: 关闭 ---
+	writeSetting("1")
+	assert.Contains(t, getAppconfig(), `"disable_user_create_space":1`,
+		"manager 写入后 appconfig 必须立刻下发 1")
+	assert.Equal(t, http.StatusForbidden, createSpace("e2e-off"),
+		"开关 ON 时 createSpace 必须 403")
+
+	// --- Step 2: 重新打开 ---
+	writeSetting("0")
+	assert.Contains(t, getAppconfig(), `"disable_user_create_space":0`,
+		"manager 写回 0 后 appconfig 必须立刻下发 0")
+	assert.Equal(t, http.StatusOK, createSpace("e2e-on"),
+		"开关 OFF 时 createSpace 必须 200")
 }


### PR DESCRIPTION
## Summary

Promotes the "disable user-side space creation" switch from env-only
(`DM_SPACE_DISABLE_USER_CREATE`) to a `system_setting` KV-backed value so
a SuperAdmin can toggle it at runtime without a redeploy. The flag is
also surfaced on `GET /v1/common/appconfig` as `disable_user_create_space`
so clients can hide the "Create Space" entry point in lockstep with the
backend gate.

## Changes

- **modules/common**
  - `SpaceDisableUserCreate()` getter with a `DB → env → false` fallback
    chain. The DB path delegates to `getBool` so literal-parsing stays in
    sync with every other bool setting.
  - Schema entry `(space, disable_user_create, bool)` registered in
    `systemSettingSchema` — no `ALTER TABLE`, admin UI renders it
    automatically.
  - `appConfigResp.disable_user_create_space` populated on both branches
    of the handler (including the `version` short-circuit) so older
    clients hitting the cached path still receive the latest value.
- **modules/space**
  - `createSpace` now consults `SystemSettings` via
    `(*Space).isUserCreateDisabled()`.
  - Legacy `IsUserCreateDisabled()` and the env constant kept as
    fallback / low-level parser for existing callers.

## Design notes

- Single source of truth: DB write → `Reload()` makes this instance see
  the new value immediately; other instances converge within the 60s
  auto-reload tick.
- Read path unchanged in cost: `createSpace` reads from the atomic
  `SystemSettings` snapshot, no extra DB query.
- Backward compatible: existing `DM_SPACE_DISABLE_USER_CREATE` deployments
  continue to work; the DB row simply overrides env when present.

## Client contract

- Client: `GET /v1/common/appconfig` → read `disable_user_create_space`
  (`0` allowed, `1` disabled).
- Admin: `POST /v1/manager/common/system_setting` with item
  `{category: "space", key: "disable_user_create", value: "0|1"}`.

## Test plan

- [x] `go test -race ./modules/common/` passes
- [x] `go test -race ./modules/space/` passes
- [x] Unit tests cover the full getter fallback chain: default, DB=1,
      DB=0 overriding env=true, DB="" falling back to env, positive and
      negative env spellings.
- [x] HTTP tests cover `appconfig` on the default branch, DB override
      branch, and `version` short-circuit branch.
- [x] HTTP test covers `createSpace` returning 403 (and not persisting
      any row) when the DB toggle is on.
- [x] End-to-end test exercises the full chain: manager write →
      `appconfig` read → `createSpace` gate (deny then allow).