### PR TITLE
fix(category): allow external-group follow into current-space category

### DIFF
--- a/modules/category/api.go
+++ b/modules/category/api.go
@@ -522,6 +522,9 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 		IsExternal    int    `db:"is_external"`
 		SourceSpaceID string `db:"source_space_id"`
 	}
+	// IFNULL + Limit(1) 都是防御性写法：source_space_id 列是 NOT NULL DEFAULT ''
+	// （见 group/sql/20260424000001_group_legacy01.sql），(group_no, uid) 也有唯一约束、
+	// LoadOne 至多命中一行——这里并非暗示该列可空或可能多行，仅作 belt-and-suspenders。
 	err := c.db.session.Select("is_external", "IFNULL(source_space_id,'') AS source_space_id").
 		From("group_member").
 		Where("group_no=? and uid=? and is_deleted=0", groupNo, loginUID).
@@ -562,6 +565,12 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 	// 对外部群的 `eff == "" → defaultSpaceID`、api_sidebar.sidebarMySourceSpaceID
 	// 同口径。否则这些 legacy 行仍无法归类，且 follow_version / auto_follow_threads
 	// 会写到群归属 Space，与侧边栏读取的默认 Space 不一致——正是 #191 想消灭的漂移。
+	//
+	// 注意 corner case：source_space_id 为空且用户连默认 Space 都没有（无任何
+	// space_member 行，如未绑定 Space 的 bot）时，下面保留 effectiveSpaceID =
+	// groupSpaceID（旧行为），而非像 sidebarMySourceSpaceID 那样解析为 ""。这不是
+	// 严格对齐——但 "" 不会匹配任何分类 Space、等于无法归类，保留旧行为是更宽松且
+	// 不引入回归的选择。读到此处不要误以为这里与 sidebar 解析逐字一致。
 	effectiveSpaceID := groupSpaceID
 	if member.IsExternal == 1 {
 		if member.SourceSpaceID != "" {

--- a/modules/category/api.go
+++ b/modules/category/api.go
@@ -513,18 +513,26 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 		return
 	}
 
-	// 校验群成员身份
-	var memberCount int
-	_, err := c.db.session.Select("count(*)").From("group_member").
+	// 校验群成员身份，并取出 is_external / source_space_id 用于计算用户视角空间。
+	// Issue #191：外部群（群归属 Space 与用户所在 Space 不同）场景下，用户是该群的
+	// 外部成员（is_external=1, source_space_id=用户当前 Space），关注/归类是个人维度
+	// 操作，应以用户来源 Space 而非群归属 Space 作为空间维度。
+	var member struct {
+		IsExternal    int    `db:"is_external"`
+		SourceSpaceID string `db:"source_space_id"`
+	}
+	err := c.db.session.Select("is_external", "IFNULL(source_space_id,'') AS source_space_id").
+		From("group_member").
 		Where("group_no=? and uid=? and is_deleted=0", groupNo, loginUID).
-		Load(&memberCount)
+		Limit(1).
+		LoadOne(&member)
 	if err != nil {
+		if errors.Is(err, dbr.ErrNotFound) {
+			ctx.ResponseError(errors.New("你不是该群成员"))
+			return
+		}
 		c.Error("查询群成员失败", zap.Error(err))
 		ctx.ResponseError(errors.New("查询群成员失败"))
-		return
-	}
-	if memberCount == 0 {
-		ctx.ResponseError(errors.New("你不是该群成员"))
 		return
 	}
 
@@ -541,6 +549,14 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 	if groupSpaceID == "" {
 		ctx.ResponseError(errors.New("该群组不属于任何空间"))
 		return
+	}
+
+	// 用户视角的有效空间：外部成员以来源 Space 为准，内部成员等同于群归属 Space。
+	// 后续的同空间校验、follow_version bump、auto_follow_threads 同步都以此为空间维度，
+	// 保证外部群被归类后能正确出现在用户当前 Space 的关注 tab（侧边栏按当前 Space 查询）。
+	effectiveSpaceID := groupSpaceID
+	if member.IsExternal == 1 && member.SourceSpaceID != "" {
+		effectiveSpaceID = member.SourceSpaceID
 	}
 
 	var categoryIDPtr *string
@@ -605,7 +621,7 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 			ctx.ResponseError(errors.New("无权限使用此分类"))
 			return
 		}
-		if groupSpaceID != locked.SpaceID {
+		if effectiveSpaceID != locked.SpaceID {
 			ctx.ResponseError(errors.New("群组和分类不在同一空间"))
 			return
 		}
@@ -644,7 +660,7 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 	// /v1/follow/sort holding the version FOR UPDATE while waiting on ext
 	// would AB-BA-deadlock against a move-out holding ext while waiting on
 	// version (issue #151 review #4 by an9xyz).
-	if _, err := convext.BumpFollowVersionTx(tx, loginUID, groupSpaceID); err != nil {
+	if _, err := convext.BumpFollowVersionTx(tx, loginUID, effectiveSpaceID); err != nil {
 		c.Error("更新 follow_version 失败", zap.Error(err))
 		ctx.ResponseError(errors.New("更新群设置失败"))
 		return
@@ -668,13 +684,13 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 	//     For first-time categorize (no ext row) the call is a no-op —
 	//     sidebar materialization later creates the row with =1.
 	if categoryIDPtr == nil {
-		if err := convext.ClearAutoFollowThreadsTx(tx, loginUID, groupSpaceID, []string{groupNo}); err != nil {
+		if err := convext.ClearAutoFollowThreadsTx(tx, loginUID, effectiveSpaceID, []string{groupNo}); err != nil {
 			c.Error("清理 auto_follow_threads 失败", zap.Error(err))
 			ctx.ResponseError(errors.New("更新群设置失败"))
 			return
 		}
 	} else {
-		if err := convext.RestoreAutoFollowThreadsTx(tx, loginUID, groupSpaceID, []string{groupNo}); err != nil {
+		if err := convext.RestoreAutoFollowThreadsTx(tx, loginUID, effectiveSpaceID, []string{groupNo}); err != nil {
 			c.Error("恢复 auto_follow_threads 失败", zap.Error(err))
 			ctx.ResponseError(errors.New("更新群设置失败"))
 			return

--- a/modules/category/api.go
+++ b/modules/category/api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
+	spacemod "github.com/Mininglamp-OSS/octo-server/modules/space"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"github.com/gocraft/dbr/v2"
@@ -554,9 +555,25 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 	// 用户视角的有效空间：外部成员以来源 Space 为准，内部成员等同于群归属 Space。
 	// 后续的同空间校验、follow_version bump、auto_follow_threads 同步都以此为空间维度，
 	// 保证外部群被归类后能正确出现在用户当前 Space 的关注 tab（侧边栏按当前 Space 查询）。
+	//
+	// 外部成员但 source_space_id 为空是合法历史状态（如未绑定 Space 的用户/bot，
+	// 见 modules/group/service.go 注释）。必须与 sidebar / space_filter 的解析口径
+	// 一致回退到用户默认 Space（最早加入的 Space）：space_filter.decideConvKeepInSpace
+	// 对外部群的 `eff == "" → defaultSpaceID`、api_sidebar.sidebarMySourceSpaceID
+	// 同口径。否则这些 legacy 行仍无法归类，且 follow_version / auto_follow_threads
+	// 会写到群归属 Space，与侧边栏读取的默认 Space 不一致——正是 #191 想消灭的漂移。
 	effectiveSpaceID := groupSpaceID
-	if member.IsExternal == 1 && member.SourceSpaceID != "" {
-		effectiveSpaceID = member.SourceSpaceID
+	if member.IsExternal == 1 {
+		if member.SourceSpaceID != "" {
+			effectiveSpaceID = member.SourceSpaceID
+		} else if defaultSpaceID, derr := spacemod.GetUserDefaultSpaceIDE(c.ctx, loginUID); derr != nil {
+			// fail-closed：DB 查询失败时不要静默落到群 Space（会复现 #191），直接报错。
+			c.Error("查询用户默认空间失败", zap.Error(derr))
+			ctx.ResponseError(errors.New("查询用户默认空间失败"))
+			return
+		} else if defaultSpaceID != "" {
+			effectiveSpaceID = defaultSpaceID
+		}
 	}
 
 	var categoryIDPtr *string

--- a/modules/category/api_test.go
+++ b/modules/category/api_test.go
@@ -1134,6 +1134,132 @@ func TestCategory_MoveExternalGroupToCurrentSpaceCategory(t *testing.T) {
 	assert.Equal(t, 0, groupSpaceVer)
 }
 
+// TestCategory_MoveExternalGroupEmptySourceSpaceFallsBackToDefaultSpace covers
+// the legacy external-member path flagged in PR #192 review: an external member
+// row with is_external=1 but empty source_space_id is a legitimate state (e.g.
+// users/bots not bound to a Space). The rest of the codebase
+// (space_filter.decideConvKeepInSpace, api_sidebar.sidebarMySourceSpaceID)
+// resolves that state to the user's default Space, so categorize must do the
+// same — otherwise these groups stay un-categorizable and follow_version /
+// auto_follow_threads writes land in the group's owning Space.
+func TestCategory_MoveExternalGroupEmptySourceSpaceFallsBackToDefaultSpace(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+
+	err := testutil.CleanAllTables(ctx)
+	assert.NoError(t, err)
+	resetUIDRateLimit(t, ctx)
+
+	// The user's only Space membership → resolves as their default Space.
+	defaultSpace := "space-ext191-default"
+	groupSpace := "space-ext191-group2"
+	seedSpaceAndMember(t, f, defaultSpace, 0)
+	route := s.GetRoute()
+
+	wc := createCategory(t, route, defaultSpace, "外部群关注-legacy")
+	assert.Equal(t, http.StatusOK, wc.Code)
+	catID := parseJSON(t, wc)["category_id"].(string)
+
+	// External member with EMPTY source_space_id (legacy row).
+	groupNo := "group-ext191-legacy-001"
+	_, err = f.db.session.InsertBySql("INSERT INTO `group` (group_no, name, creator, status, space_id) VALUES (?, ?, ?, ?, ?)",
+		groupNo, "外部群legacy", "owner-uid", 1, groupSpace).Exec()
+	assert.NoError(t, err)
+	_, err = f.db.session.InsertInto("group_member").
+		Columns("group_no", "uid", "role", "is_deleted", "status", "is_external", "source_space_id").
+		Values(groupNo, testutil.UID, 0, 0, 1, 1, "").Exec()
+	assert.NoError(t, err)
+
+	// Must succeed by falling back to the user's default Space.
+	wm := doRequest(t, route, "PUT", "/v1/groups/"+groupNo+"/category", map[string]string{
+		"category_id": catID,
+	})
+	assert.Equal(t, http.StatusOK, wm.Code)
+
+	setting, err := f.db.queryGroupSettingForCategory(groupNo, testutil.UID)
+	assert.NoError(t, err)
+	assert.NotNil(t, setting)
+	assert.NotNil(t, setting.CategoryID)
+	assert.Equal(t, catID, *setting.CategoryID)
+
+	// follow_version bumped under the default Space, not the group's owning Space.
+	var defVer int
+	_, err = f.db.session.Select("IFNULL(MAX(version),0)").From("user_follow_version").
+		Where("uid=? and space_id=?", testutil.UID, defaultSpace).Load(&defVer)
+	assert.NoError(t, err)
+	assert.Greater(t, defVer, 0)
+
+	var groupVer int
+	_, err = f.db.session.Select("IFNULL(MAX(version),0)").From("user_follow_version").
+		Where("uid=? and space_id=?", testutil.UID, groupSpace).Load(&groupVer)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, groupVer)
+}
+
+// TestCategory_MoveExternalGroupOutClearsAutoFollowThreadsInSourceSpace pins the
+// move-out (categoryIDPtr == nil) branch for an external group: the
+// ClearAutoFollowThreadsTx write must target the user's source Space, where the
+// sidebar materialized the ext row — not the group's owning Space. Without the
+// effectiveSpaceID fix this clear would miss the row entirely.
+func TestCategory_MoveExternalGroupOutClearsAutoFollowThreadsInSourceSpace(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+
+	err := testutil.CleanAllTables(ctx)
+	assert.NoError(t, err)
+	resetUIDRateLimit(t, ctx)
+
+	userSpace := "space-ext191-mo-user"
+	groupSpace := "space-ext191-mo-group"
+	seedSpaceAndMember(t, f, userSpace, 0)
+	route := s.GetRoute()
+
+	wc := createCategory(t, route, userSpace, "外部群关注-moveout")
+	require.Equal(t, http.StatusOK, wc.Code)
+	catID := parseJSON(t, wc)["category_id"].(string)
+
+	groupNo := "group-ext191-mo-001"
+	_, err = f.db.session.InsertBySql("INSERT INTO `group` (group_no, name, creator, status, space_id) VALUES (?, ?, ?, ?, ?)",
+		groupNo, "外部群moveout", "owner-uid", 1, groupSpace).Exec()
+	require.NoError(t, err)
+	_, err = f.db.session.InsertInto("group_member").
+		Columns("group_no", "uid", "role", "is_deleted", "status", "is_external", "source_space_id").
+		Values(groupNo, testutil.UID, 0, 0, 1, 1, userSpace).Exec()
+	require.NoError(t, err)
+
+	// Move IN.
+	wm := doRequest(t, route, "PUT", "/v1/groups/"+groupNo+"/category", map[string]string{
+		"category_id": catID,
+	})
+	require.Equal(t, http.StatusOK, wm.Code)
+
+	// Simulate sidebar materialization in the SOURCE space (where the follow tab
+	// is). target_type=2 → group.
+	_, err = f.db.session.InsertBySql(
+		"INSERT INTO user_conversation_ext (uid, space_id, target_type, target_id, group_unfollowed, auto_follow_threads) "+
+			"VALUES (?, ?, 2, ?, 0, 1)",
+		testutil.UID, userSpace, groupNo,
+	).Exec()
+	require.NoError(t, err, "seed materialized ext row in source space")
+
+	// Move OUT.
+	wm2 := doRequest(t, route, "PUT", "/v1/groups/"+groupNo+"/category", map[string]string{
+		"category_id": "",
+	})
+	require.Equal(t, http.StatusOK, wm2.Code)
+
+	// auto_follow_threads must be cleared on the row in the SOURCE space.
+	var postAutoFollow int
+	_, err = f.db.session.SelectBySql(
+		"SELECT auto_follow_threads FROM user_conversation_ext"+
+			" WHERE uid=? AND space_id=? AND target_type=2 AND target_id=?",
+		testutil.UID, userSpace, groupNo,
+	).Load(&postAutoFollow)
+	require.NoError(t, err)
+	assert.Equal(t, 0, postAutoFollow,
+		"move-out must clear auto_follow_threads on the ext row under the source Space")
+}
+
 func TestCategory_ListEmpty(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	s, ctx := testutil.NewTestServer()

--- a/modules/category/api_test.go
+++ b/modules/category/api_test.go
@@ -1082,7 +1082,7 @@ func TestCategory_MoveExternalGroupToCurrentSpaceCategory(t *testing.T) {
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	resetUIDRateLimit(t, ctx)
 
 	// userSpace = where the current user lives and owns categories.
@@ -1094,7 +1094,7 @@ func TestCategory_MoveExternalGroupToCurrentSpaceCategory(t *testing.T) {
 
 	// category lives under the user's current Space.
 	wc := createCategory(t, route, userSpace, "外部群关注")
-	assert.Equal(t, http.StatusOK, wc.Code)
+	require.Equal(t, http.StatusOK, wc.Code)
 	catID := parseJSON(t, wc)["category_id"].(string)
 
 	// group lives in groupSpace; the current user joined as an external member
@@ -1102,17 +1102,17 @@ func TestCategory_MoveExternalGroupToCurrentSpaceCategory(t *testing.T) {
 	groupNo := "group-ext191-001"
 	_, err = f.db.session.InsertBySql("INSERT INTO `group` (group_no, name, creator, status, space_id) VALUES (?, ?, ?, ?, ?)",
 		groupNo, "外部群", "owner-uid", 1, groupSpace).Exec()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = f.db.session.InsertInto("group_member").
 		Columns("group_no", "uid", "role", "is_deleted", "status", "is_external", "source_space_id").
 		Values(groupNo, testutil.UID, 0, 0, 1, 1, userSpace).Exec()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// categorizing the external group into the user-Space category must succeed.
 	wm := doRequest(t, route, "PUT", "/v1/groups/"+groupNo+"/category", map[string]string{
 		"category_id": catID,
 	})
-	assert.Equal(t, http.StatusOK, wm.Code)
+	require.Equal(t, http.StatusOK, wm.Code)
 
 	setting, err := f.db.queryGroupSettingForCategory(groupNo, testutil.UID)
 	assert.NoError(t, err)
@@ -1147,7 +1147,7 @@ func TestCategory_MoveExternalGroupEmptySourceSpaceFallsBackToDefaultSpace(t *te
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	resetUIDRateLimit(t, ctx)
 
 	// The user's only Space membership → resolves as their default Space.
@@ -1157,24 +1157,24 @@ func TestCategory_MoveExternalGroupEmptySourceSpaceFallsBackToDefaultSpace(t *te
 	route := s.GetRoute()
 
 	wc := createCategory(t, route, defaultSpace, "外部群关注-legacy")
-	assert.Equal(t, http.StatusOK, wc.Code)
+	require.Equal(t, http.StatusOK, wc.Code)
 	catID := parseJSON(t, wc)["category_id"].(string)
 
 	// External member with EMPTY source_space_id (legacy row).
 	groupNo := "group-ext191-legacy-001"
 	_, err = f.db.session.InsertBySql("INSERT INTO `group` (group_no, name, creator, status, space_id) VALUES (?, ?, ?, ?, ?)",
 		groupNo, "外部群legacy", "owner-uid", 1, groupSpace).Exec()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = f.db.session.InsertInto("group_member").
 		Columns("group_no", "uid", "role", "is_deleted", "status", "is_external", "source_space_id").
 		Values(groupNo, testutil.UID, 0, 0, 1, 1, "").Exec()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Must succeed by falling back to the user's default Space.
 	wm := doRequest(t, route, "PUT", "/v1/groups/"+groupNo+"/category", map[string]string{
 		"category_id": catID,
 	})
-	assert.Equal(t, http.StatusOK, wm.Code)
+	require.Equal(t, http.StatusOK, wm.Code)
 
 	setting, err := f.db.queryGroupSettingForCategory(groupNo, testutil.UID)
 	assert.NoError(t, err)

--- a/modules/category/api_test.go
+++ b/modules/category/api_test.go
@@ -1067,6 +1067,73 @@ func TestCategory_MoveGroupCrossSpace(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "群组和分类不在同一空间")
 }
 
+// TestCategory_MoveExternalGroupToCurrentSpaceCategory is the regression test
+// for issue #191. A user who is an external member of a group (the group lives
+// in another Space) follows/categorizes it into a category under the user's own
+// current Space. The space-consistency check must use the user's source Space
+// (group_member.source_space_id), not the group's owning Space, otherwise the
+// request is wrongly rejected with "群组和分类不在同一空间".
+//
+// It also asserts the follow_version is bumped under the user's source Space
+// (not the group's owning Space) so the group surfaces in the follow tab the
+// sidebar queries for the user's current Space.
+func TestCategory_MoveExternalGroupToCurrentSpaceCategory(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+
+	err := testutil.CleanAllTables(ctx)
+	assert.NoError(t, err)
+	resetUIDRateLimit(t, ctx)
+
+	// userSpace = where the current user lives and owns categories.
+	// groupSpace = the external group's owning Space (a different Space).
+	userSpace := "space-ext191-user"
+	groupSpace := "space-ext191-group"
+	seedSpaceAndMember(t, f, userSpace, 0)
+	route := s.GetRoute()
+
+	// category lives under the user's current Space.
+	wc := createCategory(t, route, userSpace, "外部群关注")
+	assert.Equal(t, http.StatusOK, wc.Code)
+	catID := parseJSON(t, wc)["category_id"].(string)
+
+	// group lives in groupSpace; the current user joined as an external member
+	// whose source_space_id points back to their own (user) Space.
+	groupNo := "group-ext191-001"
+	_, err = f.db.session.InsertBySql("INSERT INTO `group` (group_no, name, creator, status, space_id) VALUES (?, ?, ?, ?, ?)",
+		groupNo, "外部群", "owner-uid", 1, groupSpace).Exec()
+	assert.NoError(t, err)
+	_, err = f.db.session.InsertInto("group_member").
+		Columns("group_no", "uid", "role", "is_deleted", "status", "is_external", "source_space_id").
+		Values(groupNo, testutil.UID, 0, 0, 1, 1, userSpace).Exec()
+	assert.NoError(t, err)
+
+	// categorizing the external group into the user-Space category must succeed.
+	wm := doRequest(t, route, "PUT", "/v1/groups/"+groupNo+"/category", map[string]string{
+		"category_id": catID,
+	})
+	assert.Equal(t, http.StatusOK, wm.Code)
+
+	setting, err := f.db.queryGroupSettingForCategory(groupNo, testutil.UID)
+	assert.NoError(t, err)
+	assert.NotNil(t, setting)
+	assert.NotNil(t, setting.CategoryID)
+	assert.Equal(t, catID, *setting.CategoryID)
+
+	// follow_version must be bumped under the user's source Space, not groupSpace.
+	var userSpaceVer int
+	_, err = f.db.session.Select("IFNULL(MAX(version),0)").From("user_follow_version").
+		Where("uid=? and space_id=?", testutil.UID, userSpace).Load(&userSpaceVer)
+	assert.NoError(t, err)
+	assert.Greater(t, userSpaceVer, 0)
+
+	var groupSpaceVer int
+	_, err = f.db.session.Select("IFNULL(MAX(version),0)").From("user_follow_version").
+		Where("uid=? and space_id=?", testutil.UID, groupSpace).Load(&groupSpaceVer)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, groupSpaceVer)
+}
+
 func TestCategory_ListEmpty(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	s, ctx := testutil.NewTestServer()


### PR DESCRIPTION
## Summary

Fixes #191. Categorizing (i.e. "following") an **external group** returned `400 群组和分类不在同一空间`.

`moveGroupToCategory` (`PUT /api/v1/groups/{group_no}/category`) compared the group's owning Space against the category's Space **unconditionally**, ignoring that the requesting user is an *external member* of the group. For an external group the group's `space_id` is its owning Space (e.g. space A) while the user follows it from their own Space (e.g. `minglue_default`), so the check always rejected the request.

A second, latent issue: the handler also used the group's owning Space as the key for `BumpFollowVersionTx` / `ClearAutoFollowThreadsTx` / `RestoreAutoFollowThreadsTx`. The sidebar follow tab queries those by the user's **current** Space, so even if the check were merely skipped, the group would not surface in the follow tab. Both are addressed.

## Change

Derive a user-perspective **effective Space** from `group_member`:

- external member (`is_external = 1` with a non-empty `source_space_id`) → their source Space
- internal member → the group's owning Space (unchanged)

The effective Space is then used for the same-Space check **and** for the `follow_version` bump and `auto_follow_threads` sync, so a followed external group lands in the follow tab of the user's current Space.

## Behavior / compatibility

- **No behavior change for internal groups**: effective Space == group Space, every branch is byte-for-byte equivalent to before.
- **Ordinary cross-Space attempts are still rejected** — only external membership relaxes the check (regression test `TestCategory_MoveGroupCrossSpace` still asserts the 400).
- Reads two already-existing columns (`group_member.is_external`, `group_member.source_space_id`); **no migration, no API signature change**.
- Out of scope: external members with an empty `source_space_id` (legacy data) still fall back to the group Space, matching current behavior.

## Test plan

Ran against a real MySQL 8.0 + Redis (same setup as CI):

- New regression test `TestCategory_MoveExternalGroupToCurrentSpaceCategory` reproduces #191 — external member, group in space A, category in space B — and asserts `200`, the persisted `group_setting.category_id`, and that `follow_version` is bumped under the user's source Space (not the group's Space).
- Full `modules/category` package test suite passes.

Closes #191