### PR TITLE
test+ci(i18n): close Phase 0 verification gaps and wire 0.10 migration gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,3 +263,54 @@ jobs:
 
       - name: Reject direct PERSONAL MsgSendReq literals
         run: go run ./tools/lint-personal-msgsendreq ./modules
+
+  i18n-extract-check:
+    needs: [changes]
+    if: |
+      (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
+      needs.changes.outputs.code == 'true'
+    # Phase 0.8/0.10 #1: the committed i18n marker files
+    # (tools/i18nmarkers/{shared,server}/active.en-US.toml) must stay in sync
+    # with the codes.Register / errcode.register call sites. A PR that adds or
+    # edits a Code without re-running `make i18n-extract` would otherwise ship
+    # a code with no translation marker (runtime DefaultMessage fallback). The
+    # extractor's -check mode exits non-zero when on-disk markers diverge from
+    # what extraction would emit.
+    name: i18n Extract Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Verify i18n markers are up to date
+        run: make i18n-extract-check
+
+  i18n-lint:
+    needs: [changes]
+    if: |
+      (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
+      needs.changes.outputs.code == 'true'
+    # Phase 0.10 i18n migration gates:
+    #   #5 (D23): no NEW c.AbortWithStatusJSON / c.AbortWithStatus beyond the
+    #             committed per-file baseline — a ratchet toward zero as
+    #             modules migrate to httperr.ResponseErrorL.
+    #   #3:       no inline codes.Code{...} literals passed to ResponseErrorL,
+    #             which would bypass the registry (no translation marker, silent
+    #             runtime downgrade to err.shared.internal).
+    name: i18n Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: No new direct error responses (D23)
+        run: go run ./tools/lint-direct-error-response
+
+      - name: No unregistered codes in ResponseErrorL
+        run: go run ./tools/lint-unregistered-code

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,21 @@ env-test:
 #                 expected once translators adopt the goi18n workflow; hashes
 #                 are how goi18n detects source drift requiring re-translation.
 
-.PHONY: i18n-extract i18n-extract-check i18n-merge
+# i18n-lint     : run the Phase 0.10 migration gates locally (the same checks
+#                 CI runs in the "i18n Lint" job):
+#                   - lint-direct-error-response: D23 no-new-AbortWithStatusJSON
+#                     ratchet vs tools/lint-direct-error-response/baseline.txt
+#                   - lint-unregistered-code: no inline codes.Code{} literals
+#                     passed to httperr.ResponseErrorL (registry bypass)
+
+.PHONY: i18n-extract i18n-extract-check i18n-merge i18n-lint
 
 i18n-extract:
 	go run ./pkg/i18n/cmd/octo-i18n-extract
+
+i18n-lint:
+	go run ./tools/lint-direct-error-response
+	go run ./tools/lint-unregistered-code
 
 i18n-extract-check:
 	go run ./pkg/i18n/cmd/octo-i18n-extract -check

--- a/modules/user/language_multidevice_test.go
+++ b/modules/user/language_multidevice_test.go
@@ -1,0 +1,112 @@
+package user
+
+import (
+	"context"
+	"testing"
+)
+
+// Multi-device language convergence (Phase 0 §0.9 verification scenario:
+// "A 端切语言，B 端下次请求即生效").
+//
+// Models two devices / API nodes sharing one MySQL row and one Redis hot
+// cache — the production topology. The convergence guarantee under test is:
+// a PUT /v1/user/language on device A (LanguageService.SetLanguage) must make
+// device B observe the new value on its *next* Resolve, without waiting out
+// LanguageCacheTTL. The mechanism is the active DEL in SetLanguage; this test
+// fails if that invalidation regresses (e.g. someone switches it to a
+// write-through that leaves a stale entry, or drops the DEL entirely).
+//
+// Both devices share the same db + cache instances precisely because in
+// production they hit the same backing stores. A single LanguageService
+// instance is used for both because LanguageService is stateless beyond its
+// injected db/cache; per-node instances would be byte-identical.
+func TestLanguageService_MultiDeviceConvergence(t *testing.T) {
+	const uid = "u-multidevice"
+	db := newFakeLangDB()
+	c := newFakeLangCache()
+	svc := NewLanguageService(db, c)
+	ctx := context.Background()
+
+	// Device B reads first with no preference set → "" and a negative cache
+	// entry is written so subsequent reads skip the DB.
+	if got, err := svc.Resolve(ctx, uid); err != nil || got != "" {
+		t.Fatalf("initial Resolve = (%q, %v), want (\"\", nil)", got, err)
+	}
+	if c.store[LanguageCacheKeyPrefix+uid] != negativeMarker {
+		t.Fatalf("expected negative cache marker after empty resolve, got %q", c.store[LanguageCacheKeyPrefix+uid])
+	}
+
+	// Device A switches the language. This must DEL the hot key, not just
+	// overwrite the DB — otherwise B keeps serving the stale negative marker
+	// until TTL expiry.
+	if err := svc.SetLanguage(ctx, uid, "en-US"); err != nil {
+		t.Fatalf("device A SetLanguage: %v", err)
+	}
+	if db.updates[uid] != "en-US" {
+		t.Fatalf("DB not updated by device A: %v", db.updates)
+	}
+	if _, present := c.store[LanguageCacheKeyPrefix+uid]; present {
+		t.Fatalf("hot key must be invalidated (DEL) on cross-device switch, still present: %q", c.store[LanguageCacheKeyPrefix+uid])
+	}
+
+	// Device B's next read converges immediately: cache miss → DB → "en-US".
+	queriesBefore := db.queryCalls
+	got, err := svc.Resolve(ctx, uid)
+	if err != nil {
+		t.Fatalf("device B Resolve after switch: %v", err)
+	}
+	if got != "en-US" {
+		t.Fatalf("device B sees %q after device A switched to en-US; convergence broken", got)
+	}
+	if db.queryCalls != queriesBefore+1 {
+		t.Fatalf("expected exactly one DB re-query on the post-invalidation read, got %d", db.queryCalls-queriesBefore)
+	}
+
+	// And the fresh value is re-cached so a third read on either device is a
+	// cache hit (no further DB load).
+	if c.store[LanguageCacheKeyPrefix+uid] != "en-US" {
+		t.Fatalf("post-convergence cache = %q, want en-US", c.store[LanguageCacheKeyPrefix+uid])
+	}
+	queriesBeforeHit := db.queryCalls
+	if got, err := svc.Resolve(ctx, uid); err != nil || got != "en-US" {
+		t.Fatalf("cached Resolve = (%q, %v), want (en-US, nil)", got, err)
+	}
+	if db.queryCalls != queriesBeforeHit {
+		t.Fatalf("third read should be a cache hit, but DB was queried again")
+	}
+}
+
+// TestLanguageService_ClearConvergesToDefault covers the inverse direction:
+// device A clears its preference (empty string), device B must converge to
+// "" (the OCTO_DEFAULT_LANGUAGE fallback semantic) rather than keep serving
+// the previously-cached explicit value.
+func TestLanguageService_ClearConvergesToDefault(t *testing.T) {
+	const uid = "u-clear"
+	db := newFakeLangDB()
+	db.lang[uid] = "en-US"
+	c := newFakeLangCache()
+	svc := NewLanguageService(db, c)
+	ctx := context.Background()
+
+	// Warm both devices to the explicit en-US preference.
+	if got, _ := svc.Resolve(ctx, uid); got != "en-US" {
+		t.Fatalf("warm Resolve = %q, want en-US", got)
+	}
+
+	// Device A clears the preference.
+	if err := svc.SetLanguage(ctx, uid, ""); err != nil {
+		t.Fatalf("device A clear: %v", err)
+	}
+	if db.updates[uid] != "" {
+		t.Fatalf("DB clear not persisted: %q", db.updates[uid])
+	}
+
+	// Device B converges to "" (not the stale en-US).
+	got, err := svc.Resolve(ctx, uid)
+	if err != nil {
+		t.Fatalf("device B Resolve after clear: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("device B sees %q after clear; want \"\" (default fallback)", got)
+	}
+}

--- a/modules/user/language_service_test.go
+++ b/modules/user/language_service_test.go
@@ -82,6 +82,12 @@ func (d *fakeLangDB) UpdateLanguageByUID(uid, lang string) error {
 		return d.updateErr
 	}
 	d.updates[uid] = lang
+	// Write through to the read map so a subsequent QueryLanguageByUID
+	// observes the new value — models the single DB row that both the
+	// write and read paths hit in production. Existing tests assert on
+	// `updates` (what was written); this keeps those assertions intact
+	// while letting read-after-write convergence tests see the change.
+	d.lang[uid] = lang
 	return nil
 }
 

--- a/pkg/i18n/renderer_test.go
+++ b/pkg/i18n/renderer_test.go
@@ -76,6 +76,109 @@ func TestErrorRenderer_RendersLocalizedDualEnvelope(t *testing.T) {
 	}
 }
 
+// TestErrorRenderer_TransportStatusDivergesFromSemantic pins the D14
+// compatibility contract: on the standard path the wire HTTP status and the
+// legacy body `status` are fixed at TransportStatus (400 during the
+// compatibility window) while `error.http_status` carries the real
+// SemanticStatus. Every other test in this file uses Transport==Semantic, so
+// without this case the divergence is never exercised — a renderer regression
+// that accidentally emitted SemanticStatus on the wire would go unnoticed and
+// break legacy clients that branch on HTTP status.
+func TestErrorRenderer_TransportStatusDivergesFromSemantic(t *testing.T) {
+	r := wkhttp.New()
+	r.SetErrorRenderer(NewErrorRenderer(NewLocalizer(SourceLanguage)))
+	r.GET("/diverge", func(c *wkhttp.Context) {
+		c.Request = c.Request.WithContext(WithLanguage(c.Request.Context(), LanguageDecision{
+			Language: "zh-CN",
+			Source:   LanguageSourceAccept,
+		}))
+		c.RenderError(wkhttp.ErrorSpec{
+			Code:            "err.server.user.not_found",
+			DefaultMessage:  "User not found.",
+			TransportStatus: http.StatusBadRequest,       // wire + legacy body status
+			SemanticStatus:  http.StatusNotFound,          // real semantics, only in error.http_status
+		})
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/diverge", nil)
+	r.ServeHTTP(rec, req)
+
+	// Wire status fixed at TransportStatus (400), NOT the 404 semantic status.
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("wire HTTP status = %d, want %d (D14 transport fixed)", rec.Code, http.StatusBadRequest)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got := body["status"]; got != float64(http.StatusBadRequest) {
+		t.Fatalf("legacy body status = %v, want %d (must equal transport)", got, http.StatusBadRequest)
+	}
+	errObj := body["error"].(map[string]any)
+	if got := errObj["http_status"]; got != float64(http.StatusNotFound) {
+		t.Fatalf("error.http_status = %v, want %d (must equal semantic)", got, http.StatusNotFound)
+	}
+	// The non-internal message is still localized (not suppressed).
+	if got := errObj["message"]; got != "用户不存在。" {
+		t.Fatalf("error.message = %q, want localized copy", got)
+	}
+}
+
+// TestErrorRenderer_DualEnvelopeParityRegardlessOfClientHeader pins the v7.2
+// contract that the renderer ALWAYS emits both the v2 error.{} object and the
+// legacy {msg,status} pair, with no differentiation on the
+// X-Octo-Error-Envelope request header. A client that does NOT advertise v2
+// must receive the exact same body as one that does — the header is a
+// sunset-statistics signal only (D12), never a content switch.
+func TestErrorRenderer_DualEnvelopeParityRegardlessOfClientHeader(t *testing.T) {
+	render := func(withV2Header bool) string {
+		r := wkhttp.New()
+		r.SetErrorRenderer(NewErrorRenderer(NewLocalizer(SourceLanguage)))
+		r.GET("/parity", func(c *wkhttp.Context) {
+			c.Request = c.Request.WithContext(WithLanguage(c.Request.Context(), LanguageDecision{
+				Language: "zh-CN",
+				Source:   LanguageSourceAccept,
+			}))
+			c.RenderError(wkhttp.ErrorSpec{
+				Code:            "err.shared.not_found",
+				DefaultMessage:  "Resource not found.",
+				TransportStatus: http.StatusBadRequest,
+				SemanticStatus:  http.StatusNotFound,
+			})
+		})
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/parity", nil)
+		if withV2Header {
+			req.Header.Set("X-Octo-Error-Envelope", "v2")
+		}
+		r.ServeHTTP(rec, req)
+		return rec.Body.String()
+	}
+
+	withHeader := render(true)
+	withoutHeader := render(false)
+	if withHeader != withoutHeader {
+		t.Fatalf("envelope differs on X-Octo-Error-Envelope header:\n  with v2:    %s\n  without v2: %s", withHeader, withoutHeader)
+	}
+
+	// Sanity: both forms carry BOTH envelopes, not just one.
+	var body map[string]any
+	if err := json.Unmarshal([]byte(withoutHeader), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if _, ok := body["error"].(map[string]any); !ok {
+		t.Fatalf("v2 error object missing without header: %s", withoutHeader)
+	}
+	if _, ok := body["msg"]; !ok {
+		t.Fatalf("legacy msg missing: %s", withoutHeader)
+	}
+	if _, ok := body["status"]; !ok {
+		t.Fatalf("legacy status missing: %s", withoutHeader)
+	}
+}
+
 func TestErrorRenderer_InternalDoesNotExposeSpecData(t *testing.T) {
 	r := wkhttp.New()
 	r.SetErrorRenderer(NewErrorRenderer(NewLocalizer(SourceLanguage)))

--- a/tools/lint-direct-error-response/baseline.txt
+++ b/tools/lint-direct-error-response/baseline.txt
@@ -1,0 +1,33 @@
+# D23 direct-error-response baseline (lint-direct-error-response).
+#
+# Format: "<count> <relative-slash-path>" — the number of
+# c.AbortWithStatusJSON(...) / c.AbortWithStatus(...) calls the file is
+# currently allowed to contain. The lint fails when a file exceeds its
+# count or a new file introduces any. As each module migrates to
+# httperr.ResponseErrorL, drop its count here (the lint emits a
+# tighten-advisory once a file falls below its recorded number).
+#
+# Snapshot date: 2026-05-29 (Phase 0.10). Source: Phase 0.1 inventory
+# (.context/inventory_direct_error_responses.md). Totals here cover only
+# non-test files under modules/ and pkg/.
+#
+# Permanently-exempt rows (no i18n value — external/infra consumers that
+# never read the localized envelope) are tagged EXEMPT so future
+# migrations don't try to zero them:
+9 modules/app_bot/app_bot.go
+6 modules/bot_api/auth.go
+9 modules/bot_api/groups.go
+5 modules/bot_api/obo_api.go
+1 modules/bot_api/threads.go
+3 modules/bot_api/voice_adapter.go
+3 modules/botfather/api.go
+9 modules/botfather/api_bot.go
+1 modules/botfather/api_bot_thread.go
+9 modules/botfather/api_user.go
+2 modules/notify/api.go
+14 modules/oidc/api.go
+37 modules/oidc/api_bind.go
+6 modules/robot/api.go
+8 modules/user/api.go
+4 modules/webhook/github.go
+4 pkg/space/middleware.go

--- a/tools/lint-direct-error-response/baseline.txt
+++ b/tools/lint-direct-error-response/baseline.txt
@@ -11,9 +11,10 @@
 # (.context/inventory_direct_error_responses.md). Totals here cover only
 # non-test files under modules/ and pkg/.
 #
-# Permanently-exempt rows (no i18n value — external/infra consumers that
-# never read the localized envelope) are tagged EXEMPT so future
-# migrations don't try to zero them:
+# Rows may carry a trailing "# <note>" comment. Permanently-exempt rows (no
+# i18n value — external/infra consumers that never read the localized
+# envelope) are tagged "# EXEMPT: <why>" so future migrations don't try to
+# zero them; all other rows are migration debt and should ratchet to 0.
 9 modules/app_bot/app_bot.go
 6 modules/bot_api/auth.go
 9 modules/bot_api/groups.go
@@ -29,5 +30,5 @@
 37 modules/oidc/api_bind.go
 6 modules/robot/api.go
 8 modules/user/api.go
-4 modules/webhook/github.go
+4 modules/webhook/github.go  # EXEMPT: GitHub webhook signature errors — external GH never reads the localized envelope
 4 pkg/space/middleware.go

--- a/tools/lint-direct-error-response/main.go
+++ b/tools/lint-direct-error-response/main.go
@@ -181,11 +181,19 @@ func loadBaseline(path string) (map[string]int, error) {
 	for sc.Scan() {
 		lineNo++
 		line := strings.TrimSpace(sc.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
+		// Strip a trailing inline comment so rows may carry annotations, e.g.
+		//   4 modules/webhook/github.go  # EXEMPT: external GH webhook
+		if i := strings.Index(line, "#"); i >= 0 {
+			line = strings.TrimSpace(line[:i])
+		}
+		if line == "" {
 			continue
 		}
 		fields := strings.Fields(line)
-		if len(fields) != 2 {
+		// Require at least "<count> <path>"; tolerate trailing tokens (e.g. a
+		// bare EXEMPT marker) so the format can grow annotations without
+		// turning a documentation convention into a CI footgun (PR #193 review).
+		if len(fields) < 2 {
 			return nil, fmt.Errorf("malformed baseline line %d: %q (want '<count> <path>')", lineNo, line)
 		}
 		n, convErr := strconv.Atoi(fields[0])

--- a/tools/lint-direct-error-response/main.go
+++ b/tools/lint-direct-error-response/main.go
@@ -1,0 +1,201 @@
+// Command lint-direct-error-response is the D23 "no new direct error response"
+// gate. It AST-counts c.AbortWithStatusJSON(...) and c.AbortWithStatus(...)
+// calls per file and compares against a committed baseline, failing CI only
+// when a file gains new sites (or a brand-new file introduces any).
+//
+// Why a baseline ratchet rather than a hard block:
+//
+//	The Phase 0.1 inventory found ~120 pre-existing direct-error sites across
+//	modules that have not yet been migrated to httperr.ResponseErrorL (Phase 2
+//	is incremental, by module). A hard "zero AbortWithStatusJSON" gate would
+//	red-light main today. Instead we snapshot the current counts in
+//	baseline.txt and forbid REGRESSIONS: a PR may not add a direct error
+//	response to any file beyond what the baseline already tolerates. As each
+//	module migrates, its count drops and the baseline is tightened — a
+//	monotonic ratchet toward zero.
+//
+// Counting is per-file rather than per-line because line numbers churn on
+// every edit. The known limitation: removing one site and adding another in
+// the same file is net-zero and slips the gate; that is acceptable for a
+// migration ratchet (net-zero churn in an actively-migrated file is rare and
+// caught in human review) and is documented so reviewers know to watch for it.
+//
+// Usage:
+//
+//	go run ./tools/lint-direct-error-response [root...]
+//
+// Defaults to scanning ./modules and ./pkg. Test files (*_test.go) are
+// skipped — tests legitimately construct adversarial responses directly.
+//
+// Exit codes: 0 (clean, possibly with tighten-advisory), 1 (regression),
+// 2 (walk/baseline error).
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// baselineFile lives next to this command so `go run ./tools/...` finds it
+// regardless of the working directory the CI step uses.
+const baselineRelPath = "tools/lint-direct-error-response/baseline.txt"
+
+func main() {
+	roots := os.Args[1:]
+	if len(roots) == 0 {
+		roots = []string{"modules", "pkg"}
+	}
+
+	baseline, err := loadBaseline(baselineRelPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load baseline %q: %v\n", baselineRelPath, err)
+		os.Exit(2)
+	}
+
+	counts, err := countSites(roots)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(2)
+	}
+
+	var regressions, advisories []string
+
+	// Regressions: current count exceeds the tolerated baseline (or a new
+	// file appeared with any direct error responses).
+	for file, n := range counts {
+		allowed := baseline[file]
+		if n > allowed {
+			if allowed == 0 {
+				regressions = append(regressions,
+					fmt.Sprintf("%s: %d direct error response(s) in a file not on the baseline", file, n))
+			} else {
+				regressions = append(regressions,
+					fmt.Sprintf("%s: %d direct error response(s), baseline tolerates %d (+%d new)", file, n, allowed, n-allowed))
+			}
+		}
+	}
+
+	// Advisories: a file dropped below its baseline (a module migrated). Not
+	// fatal, but the baseline should be tightened so the ratchet holds.
+	for file, allowed := range baseline {
+		if counts[file] < allowed {
+			advisories = append(advisories,
+				fmt.Sprintf("%s: now %d, baseline %d — tighten baseline.txt to lock in the reduction", file, counts[file], allowed))
+		}
+	}
+
+	sort.Strings(regressions)
+	sort.Strings(advisories)
+
+	for _, a := range advisories {
+		fmt.Printf("advisory: %s\n", a)
+	}
+
+	if len(regressions) > 0 {
+		for _, r := range regressions {
+			fmt.Println(r)
+		}
+		fmt.Printf("\nFound %d file(s) with new direct error responses (D23).\n", len(regressions))
+		fmt.Println("Use httperr.ResponseErrorL(c, code, params, details) or c.RenderError(spec) instead of")
+		fmt.Println("c.AbortWithStatusJSON / c.AbortWithStatus. If a new direct response is genuinely")
+		fmt.Println("exempt (health/debug/metrics), raise the file's count in " + baselineRelPath + " with a comment.")
+		os.Exit(1)
+	}
+
+	fmt.Printf("OK: no new direct error responses (%d baseline file(s) tracked).\n", len(baseline))
+}
+
+// countSites walks the roots and returns a map of relative-slash file path →
+// number of AbortWithStatusJSON / AbortWithStatus call expressions.
+func countSites(roots []string) (map[string]int, error) {
+	fset := token.NewFileSet()
+	counts := map[string]int{}
+
+	for _, root := range roots {
+		walkErr := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				if name := info.Name(); name == "vendor" || name == "tools" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			f, perr := parser.ParseFile(fset, path, nil, 0)
+			if perr != nil {
+				// go build / go vet is the canonical syntax gate; skip
+				// unparseable files rather than failing the lint on them.
+				return nil
+			}
+			n := 0
+			ast.Inspect(f, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel == nil {
+					return true
+				}
+				if sel.Sel.Name == "AbortWithStatusJSON" || sel.Sel.Name == "AbortWithStatus" {
+					n++
+				}
+				return true
+			})
+			if n > 0 {
+				counts[filepath.ToSlash(path)] = n
+			}
+			return nil
+		})
+		if walkErr != nil {
+			return nil, fmt.Errorf("walk %q: %w", root, walkErr)
+		}
+	}
+	return counts, nil
+}
+
+// loadBaseline parses baseline.txt. Format: one "<count> <path>" per line;
+// blank lines and lines starting with '#' are ignored.
+func loadBaseline(path string) (map[string]int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	baseline := map[string]int{}
+	sc := bufio.NewScanner(f)
+	lineNo := 0
+	for sc.Scan() {
+		lineNo++
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("malformed baseline line %d: %q (want '<count> <path>')", lineNo, line)
+		}
+		n, convErr := strconv.Atoi(fields[0])
+		if convErr != nil {
+			return nil, fmt.Errorf("malformed count on baseline line %d: %q", lineNo, fields[0])
+		}
+		baseline[filepath.ToSlash(fields[1])] = n
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return baseline, nil
+}

--- a/tools/lint-direct-error-response/main_test.go
+++ b/tools/lint-direct-error-response/main_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, name, src string) {
+	t.Helper()
+	full := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCountSites(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "modules/a/api.go", `package a
+func h(c *Ctx) {
+	c.AbortWithStatusJSON(401, nil)
+	c.AbortWithStatus(403)
+	c.JSON(200, nil) // not counted
+}
+`)
+	// _test.go must be skipped entirely.
+	writeFile(t, dir, "modules/a/api_test.go", `package a
+func TestX() { c.AbortWithStatusJSON(500, nil) }
+`)
+	// A file with no direct responses must not appear in the map.
+	writeFile(t, dir, "modules/b/clean.go", `package b
+func ok(c *Ctx) { c.RenderError(spec) }
+`)
+	// tools/ subtree must be skipped.
+	writeFile(t, dir, "modules/tools/x.go", `package tools
+func z(c *Ctx) { c.AbortWithStatusJSON(400, nil) }
+`)
+
+	counts, err := countSites([]string{filepath.Join(dir, "modules")})
+	if err != nil {
+		t.Fatalf("countSites: %v", err)
+	}
+
+	aPath := filepath.ToSlash(filepath.Join(dir, "modules/a/api.go"))
+	if counts[aPath] != 2 {
+		t.Fatalf("api.go count = %d, want 2 (AbortWithStatusJSON + AbortWithStatus, not c.JSON)", counts[aPath])
+	}
+	if len(counts) != 1 {
+		t.Fatalf("expected only api.go in counts, got %d entries: %#v", len(counts), counts)
+	}
+}
+
+func TestLoadBaseline(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "baseline.txt")
+	writeFile(t, dir, "baseline.txt", `# comment
+8 modules/user/api.go
+
+37 modules/oidc/api_bind.go
+`)
+	b, err := loadBaseline(path)
+	if err != nil {
+		t.Fatalf("loadBaseline: %v", err)
+	}
+	if b["modules/user/api.go"] != 8 {
+		t.Fatalf("user baseline = %d, want 8", b["modules/user/api.go"])
+	}
+	if b["modules/oidc/api_bind.go"] != 37 {
+		t.Fatalf("oidc baseline = %d, want 37", b["modules/oidc/api_bind.go"])
+	}
+	if len(b) != 2 {
+		t.Fatalf("baseline entries = %d, want 2 (comment + blank ignored)", len(b))
+	}
+}
+
+func TestLoadBaseline_Malformed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "baseline.txt")
+	writeFile(t, dir, "baseline.txt", "notanumber modules/x.go\n")
+	if _, err := loadBaseline(path); err == nil {
+		t.Fatal("expected error on malformed count, got nil")
+	}
+}
+
+// classify mirrors the main() decision logic so the regression / advisory
+// split can be unit-tested without spawning a subprocess.
+func classify(counts, baseline map[string]int) (regressions, advisories int) {
+	for file, n := range counts {
+		if n > baseline[file] {
+			regressions++
+		}
+	}
+	for file, allowed := range baseline {
+		if counts[file] < allowed {
+			advisories++
+		}
+	}
+	return
+}
+
+func TestRatchetDecisions(t *testing.T) {
+	baseline := map[string]int{
+		"modules/user/api.go": 8,
+		"modules/oidc/api.go": 14,
+	}
+
+	t.Run("equal counts pass", func(t *testing.T) {
+		r, a := classify(map[string]int{"modules/user/api.go": 8, "modules/oidc/api.go": 14}, baseline)
+		if r != 0 || a != 0 {
+			t.Fatalf("regressions=%d advisories=%d, want 0/0", r, a)
+		}
+	})
+
+	t.Run("increase is a regression", func(t *testing.T) {
+		r, _ := classify(map[string]int{"modules/user/api.go": 9}, baseline)
+		if r != 1 {
+			t.Fatalf("regressions=%d, want 1", r)
+		}
+	})
+
+	t.Run("brand-new file is a regression", func(t *testing.T) {
+		r, _ := classify(map[string]int{"modules/new/api.go": 1}, baseline)
+		if r != 1 {
+			t.Fatalf("regressions=%d, want 1 (new file off baseline)", r)
+		}
+	})
+
+	t.Run("decrease is an advisory not a regression", func(t *testing.T) {
+		r, a := classify(map[string]int{"modules/user/api.go": 0, "modules/oidc/api.go": 14}, baseline)
+		if r != 0 {
+			t.Fatalf("regressions=%d, want 0 (migration reduced count)", r)
+		}
+		if a != 1 {
+			t.Fatalf("advisories=%d, want 1 (baseline should tighten)", a)
+		}
+	})
+}

--- a/tools/lint-direct-error-response/main_test.go
+++ b/tools/lint-direct-error-response/main_test.go
@@ -77,6 +77,29 @@ func TestLoadBaseline(t *testing.T) {
 	}
 }
 
+func TestLoadBaseline_TrailingAnnotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "baseline.txt")
+	// PR #193 review: rows may carry a trailing EXEMPT note / inline comment.
+	writeFile(t, dir, "baseline.txt", `4 modules/webhook/github.go  # EXEMPT: external GH
+9 modules/app_bot/app_bot.go EXEMPT
+8 modules/user/api.go
+`)
+	b, err := loadBaseline(path)
+	if err != nil {
+		t.Fatalf("loadBaseline with annotations: %v", err)
+	}
+	if b["modules/webhook/github.go"] != 4 {
+		t.Fatalf("inline-comment row = %d, want 4", b["modules/webhook/github.go"])
+	}
+	if b["modules/app_bot/app_bot.go"] != 9 {
+		t.Fatalf("trailing-token row = %d, want 9", b["modules/app_bot/app_bot.go"])
+	}
+	if b["modules/user/api.go"] != 8 {
+		t.Fatalf("plain row = %d, want 8", b["modules/user/api.go"])
+	}
+}
+
 func TestLoadBaseline_Malformed(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "baseline.txt")

--- a/tools/lint-unregistered-code/main.go
+++ b/tools/lint-unregistered-code/main.go
@@ -1,0 +1,173 @@
+// Command lint-unregistered-code is the 0.10 #3 gate guarding
+// httperr.ResponseErrorL against codes that bypass the pkg/i18n/codes
+// registry.
+//
+// Contract: ResponseErrorL's second argument (the codes.Code) MUST be a
+// reference to a registered code — i.e. an errcode.ErrXxx selector, a shared
+// code var looked up at init, a local variable, or a function parameter that
+// ultimately traces to one of those. The ONE shape it must never be is an
+// inline composite literal:
+//
+//	httperr.ResponseErrorL(c, codes.Code{ID: "err.server.foo"}, nil, nil)  // BANNED
+//
+// An inline codes.Code{...} is a code that was never passed through
+// codes.Register, so:
+//   - the 0.8 AST extractor never emits a TOML marker for it (no translation),
+//   - pkg/httperr/respond.go's Lookup fails and silently downgrades it to
+//     err.shared.internal at runtime.
+//
+// Catching the literal at CI time turns that silent runtime downgrade into a
+// loud compile-time failure, which is the whole point of the registry.
+//
+// Scope / limitation: this is a single-file AST check, not a type/dataflow
+// analysis. A two-step smuggle (`x := codes.Code{...}; ResponseErrorL(c, x,
+// …)`) is not flagged here — that residual case is still caught at runtime by
+// respond.go's fallback+log and by the 0.8 recall check (every registered code
+// must have a marker). The inline literal is the common, test-demonstrated
+// vector and the one worth a hard gate.
+//
+// Usage:
+//
+//	go run ./tools/lint-unregistered-code [root...]
+//
+// Defaults to ./modules and ./pkg. Test files are skipped — respond_test.go
+// deliberately constructs an inline literal to exercise the runtime fallback.
+//
+// Exit codes: 0 (clean), 1 (violations), 2 (walk error).
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const respondFunc = "ResponseErrorL"
+
+func main() {
+	roots := os.Args[1:]
+	if len(roots) == 0 {
+		roots = []string{"modules", "pkg"}
+	}
+
+	violations, err := scanRoots(roots)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(2)
+	}
+
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		for _, v := range violations {
+			fmt.Println(v)
+		}
+		fmt.Printf("\nFound %d inline error code(s) bypassing the registry.\n", len(violations))
+		fmt.Println("Every code must be registered via register() in pkg/errcode (or codes.Register)")
+		fmt.Println("so the AST extractor emits a translation marker and the renderer can localize it.")
+		fmt.Println("Replace the inline literal with a registered errcode.ErrXxx reference.")
+		os.Exit(1)
+	}
+	fmt.Println("OK: no inline codes passed to ResponseErrorL.")
+}
+
+// scanRoots walks the roots and returns one violation message per inline
+// codes.Code{...} literal passed as the ResponseErrorL code argument.
+func scanRoots(roots []string) ([]string, error) {
+	fset := token.NewFileSet()
+	var violations []string
+	for _, root := range roots {
+		walkErr := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				if name := info.Name(); name == "vendor" || name == "tools" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			f, perr := parser.ParseFile(fset, path, nil, 0)
+			if perr != nil {
+				return nil
+			}
+			violations = append(violations, violationsInFile(fset, f)...)
+			return nil
+		})
+		if walkErr != nil {
+			return nil, fmt.Errorf("walk %q: %w", root, walkErr)
+		}
+	}
+	return violations, nil
+}
+
+// violationsInFile inspects one parsed file for inline-literal codes passed to
+// ResponseErrorL.
+func violationsInFile(fset *token.FileSet, f *ast.File) []string {
+	var out []string
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if !isResponseErrorL(call.Fun) {
+			return true
+		}
+		// Signature: ResponseErrorL(c, code, params, details). The code is
+		// the second positional argument.
+		if len(call.Args) < 2 {
+			return true
+		}
+		if isCodeCompositeLit(call.Args[1]) {
+			pos := fset.Position(call.Args[1].Pos())
+			out = append(out,
+				fmt.Sprintf("%s:%d: inline codes.Code{...} passed to %s — register it in pkg/errcode and pass the var",
+					filepath.ToSlash(pos.Filename), pos.Line, respondFunc))
+		}
+		return true
+	})
+	return out
+}
+
+// isResponseErrorL matches both httperr.ResponseErrorL(...) and a bare
+// ResponseErrorL(...) (in case a future caller dot-imports or aliases).
+func isResponseErrorL(e ast.Expr) bool {
+	switch t := e.(type) {
+	case *ast.SelectorExpr:
+		return t.Sel != nil && t.Sel.Name == respondFunc
+	case *ast.Ident:
+		return t.Name == respondFunc
+	}
+	return false
+}
+
+// isCodeCompositeLit reports whether the expression is an inline composite
+// literal of type Code / codes.Code (optionally pointer-wrapped).
+func isCodeCompositeLit(e ast.Expr) bool {
+	cl, ok := e.(*ast.CompositeLit)
+	if !ok {
+		// Also catch &codes.Code{...}.
+		if u, ok := e.(*ast.UnaryExpr); ok {
+			return isCodeCompositeLit(u.X)
+		}
+		return false
+	}
+	return isCodeType(cl.Type)
+}
+
+func isCodeType(e ast.Expr) bool {
+	switch t := e.(type) {
+	case *ast.SelectorExpr:
+		return t.Sel != nil && t.Sel.Name == "Code"
+	case *ast.Ident:
+		return t.Name == "Code"
+	}
+	return false
+}

--- a/tools/lint-unregistered-code/main.go
+++ b/tools/lint-unregistered-code/main.go
@@ -149,19 +149,28 @@ func isResponseErrorL(e ast.Expr) bool {
 }
 
 // isCodeCompositeLit reports whether the expression is an inline composite
-// literal of type Code / codes.Code (optionally pointer-wrapped).
+// literal of type Code / codes.Code, unwrapping the equivalent forms a caller
+// might use to express the same literal:
+//   - &codes.Code{...}      (*ast.UnaryExpr, address-of)
+//   - (codes.Code{...})     (*ast.ParenExpr, parenthesized — would otherwise
+//                            slip the gate, PR #193 review)
 func isCodeCompositeLit(e ast.Expr) bool {
-	cl, ok := e.(*ast.CompositeLit)
-	if !ok {
-		// Also catch &codes.Code{...}.
-		if u, ok := e.(*ast.UnaryExpr); ok {
-			return isCodeCompositeLit(u.X)
-		}
-		return false
+	switch t := e.(type) {
+	case *ast.ParenExpr:
+		return isCodeCompositeLit(t.X)
+	case *ast.UnaryExpr:
+		return isCodeCompositeLit(t.X)
+	case *ast.CompositeLit:
+		return isCodeType(t.Type)
 	}
-	return isCodeType(cl.Type)
+	return false
 }
 
+// isCodeType matches any type named Code (bare Code or pkg.Code). The match is
+// intentionally loose on the package qualifier: at the only call site
+// (ResponseErrorL's second argument, whose declared type is codes.Code) a
+// composite literal named Code can only be codes.Code, so a false positive is
+// not reachable in practice.
 func isCodeType(e ast.Expr) bool {
 	switch t := e.(type) {
 	case *ast.SelectorExpr:

--- a/tools/lint-unregistered-code/main_test.go
+++ b/tools/lint-unregistered-code/main_test.go
@@ -52,6 +52,8 @@ func TestIsCodeCompositeLit(t *testing.T) {
 		`codes.Code{ID: "x"}`:        true,
 		`Code{ID: "x"}`:              true,
 		`&codes.Code{ID: "x"}`:       true,
+		`(codes.Code{ID: "x"})`:      true, // parenthesized — must not slip the gate
+		`(&codes.Code{ID: "x"})`:     true,
 		"errcode.ErrUserStoreFailed": false,
 		"code":                       false,
 		"someStruct{A: 1}":           false,
@@ -111,6 +113,15 @@ func h(c *Ctx) { httperr.ResponseErrorL(c, codes.Code{ID: "err.server.foo"}, nil
 func h(c *Ctx) { httperr.ResponseErrorL(c, &codes.Code{ID: "x"}, nil, nil) }
 `); n != 1 {
 			t.Fatalf("violations=%d, want 1 (&codes.Code literal)", n)
+		}
+	})
+
+	t.Run("parenthesized inline literal flagged", func(t *testing.T) {
+		// PR #193 review: parens must not let a literal slip the gate.
+		if n := scanSrc(t, `package x
+func h(c *Ctx) { httperr.ResponseErrorL(c, (codes.Code{ID: "x"}), nil, nil) }
+`); n != 1 {
+			t.Fatalf("violations=%d, want 1 (parenthesized literal)", n)
 		}
 	})
 

--- a/tools/lint-unregistered-code/main_test.go
+++ b/tools/lint-unregistered-code/main_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func parseExpr(t *testing.T, src string) ast.Expr {
+	t.Helper()
+	e, err := parser.ParseExpr(src)
+	if err != nil {
+		t.Fatalf("parse %q: %v", src, err)
+	}
+	return e
+}
+
+// scanSrc writes src to a temp .go file and returns the violation count.
+func scanSrc(t *testing.T, src string) int {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.go")
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	v, err := scanRoots([]string{dir})
+	if err != nil {
+		t.Fatalf("scanRoots: %v", err)
+	}
+	return len(v)
+}
+
+func TestIsResponseErrorL(t *testing.T) {
+	cases := map[string]bool{
+		"httperr.ResponseErrorL": true,
+		"ResponseErrorL":         true,
+		"ResponseError":          false,
+		"ResponseErrorf":         false,
+		"foo.ResponseErrorL":     true,
+	}
+	for expr, want := range cases {
+		if got := isResponseErrorL(parseExpr(t, expr)); got != want {
+			t.Errorf("isResponseErrorL(%q) = %v, want %v", expr, got, want)
+		}
+	}
+}
+
+func TestIsCodeCompositeLit(t *testing.T) {
+	cases := map[string]bool{
+		`codes.Code{ID: "x"}`:        true,
+		`Code{ID: "x"}`:              true,
+		`&codes.Code{ID: "x"}`:       true,
+		"errcode.ErrUserStoreFailed": false,
+		"code":                       false,
+		"someStruct{A: 1}":           false,
+	}
+	for expr, want := range cases {
+		if got := isCodeCompositeLit(parseExpr(t, expr)); got != want {
+			t.Errorf("isCodeCompositeLit(%q) = %v, want %v", expr, got, want)
+		}
+	}
+}
+
+func TestScanRoots_SkipsTestFiles(t *testing.T) {
+	dir := t.TempDir()
+	// A _test.go file with an inline literal must be ignored (respond_test.go
+	// legitimately exercises the runtime fallback this way).
+	if err := os.WriteFile(filepath.Join(dir, "x_test.go"), []byte(`package x
+func TestY() { httperr.ResponseErrorL(c, codes.Code{ID: "x"}, nil, nil) }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	v, err := scanRoots([]string{dir})
+	if err != nil {
+		t.Fatalf("scanRoots: %v", err)
+	}
+	if len(v) != 0 {
+		t.Fatalf("violations=%d, want 0 (_test.go skipped)", len(v))
+	}
+}
+
+func TestViolationDetection(t *testing.T) {
+	t.Run("registered reference passes", func(t *testing.T) {
+		if n := scanSrc(t, `package x
+func h(c *Ctx) { httperr.ResponseErrorL(c, errcode.ErrUserStoreFailed, nil, nil) }
+`); n != 0 {
+			t.Fatalf("violations=%d, want 0 (registered ref)", n)
+		}
+	})
+
+	t.Run("local var / param passes", func(t *testing.T) {
+		if n := scanSrc(t, `package x
+func h(c *Ctx, code codes.Code) { httperr.ResponseErrorL(c, code, nil, nil) }
+`); n != 0 {
+			t.Fatalf("violations=%d, want 0 (param ref)", n)
+		}
+	})
+
+	t.Run("inline literal flagged", func(t *testing.T) {
+		if n := scanSrc(t, `package x
+func h(c *Ctx) { httperr.ResponseErrorL(c, codes.Code{ID: "err.server.foo"}, nil, nil) }
+`); n != 1 {
+			t.Fatalf("violations=%d, want 1 (inline literal)", n)
+		}
+	})
+
+	t.Run("pointer inline literal flagged", func(t *testing.T) {
+		if n := scanSrc(t, `package x
+func h(c *Ctx) { httperr.ResponseErrorL(c, &codes.Code{ID: "x"}, nil, nil) }
+`); n != 1 {
+			t.Fatalf("violations=%d, want 1 (&codes.Code literal)", n)
+		}
+	})
+
+	t.Run("unrelated call ignored", func(t *testing.T) {
+		if n := scanSrc(t, `package x
+func h(c *Ctx) { other.DoThing(c, codes.Code{ID: "x"}) }
+`); n != 0 {
+			t.Fatalf("violations=%d, want 0 (not ResponseErrorL)", n)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Phase 0 close-out: fills the three remaining §0.9 verification scenarios that lacked explicit coverage, and lands the first batch of §0.10 CI gates that Phase 2 module migrations depend on. No runtime code changes — everything is tests, two AST lint tools under `tools/`, and CI wiring.

This is a follow-up to the i18n migration pilots (`modules/thread` PR #176, `modules/user/api.go` PR #188).

## Commits

1. **`test(i18n): close Phase 0 §0.9 verification gaps`**
   - `pkg/i18n/renderer_test.go`: TransportStatus≠SemanticStatus divergence (D14 — wire/body status fixed at 400, `error.http_status` carries the real semantic status); dual-envelope parity regardless of the `X-Octo-Error-Envelope` request header (v7.2/D12 — byte-identical body with and without the header).
   - `modules/user/language_multidevice_test.go`: multi-device language convergence (§0.9 "A 端切语言 B 端下次请求即生效") plus the clear-to-default inverse. `fakeLangDB.UpdateLanguageByUID` now writes through to its read map so read-after-write is observable; existing tests assert on the separate `updates` map and are unaffected.

2. **`feat(lint): add D23 direct-error-response ratchet (0.10 #5)`**
   - `tools/lint-direct-error-response`: AST-counts `c.AbortWithStatusJSON` / `c.AbortWithStatus` per non-test file and compares against a committed `baseline.txt`. **Baseline ratchet, not a hard block** — the Phase 0.1 inventory found ~120 pre-existing sites in unmigrated modules, so a zero-gate would red-light main. The lint fails only on regressions (a file exceeding its count, or a new file introducing any) and emits a tighten-advisory when a migrated file drops below baseline. Per-file counts (not line numbers, which churn); documented net-zero-churn limitation.

3. **`feat(lint): block inline codes bypassing the registry (0.10 #3)`**
   - `tools/lint-unregistered-code`: forbids inline `codes.Code{...}` literals as the `httperr.ResponseErrorL` code argument. Such a literal never passes `codes.Register`, so the 0.8 extractor emits no marker and `respond.go` silently downgrades it to `err.shared.internal`. Single-file AST scope is documented (two-step var smuggle is still caught at runtime + by the 0.8 recall check).

4. **`ci(i18n): wire Phase 0.10 extract-check + lint gates`**
   - Two CI jobs following the existing `personal-msgsendreq-lint` template: "i18n Extract Check" (`make i18n-extract-check`, closes the last open Phase 0.8 item) and "i18n Lint" (the two new gates). Adds a `make i18n-lint` target for local runs.

## Phase 0.10 scope note

This PR lands lint **#1 (extract diff)**, **#3 (unregistered code)**, **#5 (AbortWithStatusJSON)**. The remaining 0.10 gates — #4 (Params sensitive-key), #6 (token-cache split), #2 (bare-string) — and the Prometheus counters follow in a sibling PR, to keep this reviewable in one sitting.

## Test plan

- [x] `go test -race -count=1 ./pkg/i18n/ ./tools/lint-direct-error-response/ ./tools/lint-unregistered-code/` — pass
- [x] `go test -race -count=1 ./modules/user/` (full DB E2E, drop+recreate test DB + FLUSHALL) — pass
- [x] `make i18n-extract-check` / `make i18n-lint` — all green against current tree
- [x] `go build ./...` / `go vet ./tools/... ./pkg/i18n/...` — clean
- [x] CI YAML validated

## Baseline note for reviewers

`tools/lint-direct-error-response/baseline.txt` is seeded from the 2026-05-29 snapshot (17 files). It deliberately still tolerates the 8 `AbortWithStatusJSON` sites in `modules/user/api.go` — those are the avatar-permission / bot-token direct responses that PR #188 left as a documented follow-up (PR #188 migrated `ResponseError`/`ResponseErrorf`, not `AbortWithStatusJSON`). As each module migrates, drop its row.