### PR TITLE
feat(i18n): complete modules/user migration to ResponseErrorL (manager + friend + login + …)

### DIFF
--- a/modules/base/common/service_email.go
+++ b/modules/base/common/service_email.go
@@ -68,6 +68,12 @@ func NewEmailService(ctx *config.Context, settings SMTPSettingsProvider) *EmailS
 	}
 }
 
+// ErrEmailSendRateLimited is returned by SendVerifyCode when the per-address
+// 1-minute resend cooldown is still active. It is a client-actionable condition
+// (HTTP 429), not an internal failure — callers should branch on it with
+// errors.Is rather than collapsing it onto a generic send-failure code.
+var ErrEmailSendRateLimited = errors.New("发送过于频繁，请1分钟后再试")
+
 // SendVerifyCode 发送验证码
 func (s *EmailService) SendVerifyCode(ctx context.Context, email string, codeType CodeType) error {
 	// 检查发送频率限制
@@ -77,7 +83,7 @@ func (s *EmailService) SendVerifyCode(ctx context.Context, email string, codeTyp
 		return err
 	}
 	if exists != "" {
-		return errors.New("发送过于频繁，请1分钟后再试")
+		return ErrEmailSendRateLimited
 	}
 
 	// 生成6位验证码

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -48,6 +48,13 @@ import (
 
 var (
 	ErrUserNeedVerification = errors.New("user need verification") // 用户需要验证
+	// ErrUserDisabled / ErrUserDeviceInfoRequired are execLogin's client-facing
+	// sentinels so every login entry point (main / OAuth / email / username) can
+	// classify them uniformly: a disabled account is 403, a missing device info
+	// is 400 — not a generic 500. errors.Is on these at the call site (see
+	// respondExecLoginError) keeps the classification in one place.
+	ErrUserDisabled           = errors.New("该用户已被禁用")
+	ErrUserDeviceInfoRequired = errors.New("登录设备信息不能为空！")
 )
 
 // qrcodeChanMap stores channels for QR code login long-polling.
@@ -1362,21 +1369,7 @@ func (u *User) execLoginAndRespose(userInfo *Model, flag config.DeviceFlag, devi
 
 	result, err := u.execLogin(userInfo, flag, device, loginSpanCtx)
 	if err != nil {
-		if errors.Is(err, ErrUserNeedVerification) {
-			phone := ""
-			if len(userInfo.Phone) > 5 {
-				phone = fmt.Sprintf("%s******%s", userInfo.Phone[0:3], userInfo.Phone[len(userInfo.Phone)-2:])
-			}
-			c.ResponseWithStatus(http.StatusBadRequest, map[string]interface{}{
-				"status": 110,
-				"msg":    "需要验证手机号码！",
-				"uid":    userInfo.UID,
-				"phone":  phone,
-			})
-			return
-		}
-		u.Error("登录执行失败", zap.String("uid", userInfo.UID), zap.Error(err))
-		respondUserServiceError(c)
+		u.respondExecLoginError(c, err, userInfo)
 		return
 	}
 
@@ -1386,9 +1379,43 @@ func (u *User) execLoginAndRespose(userInfo *Model, flag config.DeviceFlag, devi
 	go u.sentWelcomeMsg(publicIP, userInfo.UID)
 }
 
+// respondExecLoginError is the single classifier for execLogin's returned error,
+// shared by every login entry point (main / OAuth / email / username) so the
+// same condition always yields the same status:
+//   - ErrUserNeedVerification → the bespoke 110 "需要验证手机号码" response;
+//   - ErrUserDisabled         → 403 (account banned);
+//   - ErrUserDeviceInfoRequired → 400 (missing device info);
+//   - anything else           → logged + generic 500 (genuine internal failure).
+//
+// Before this existed, the OAuth/email/username paths collapsed all of these
+// onto a single 500, so a disabled account or a missing-device request looked
+// like a server outage. Keeping the mapping here avoids that divergence.
+func (u *User) respondExecLoginError(c *wkhttp.Context, err error, userInfo *Model) {
+	switch {
+	case errors.Is(err, ErrUserNeedVerification):
+		phone := ""
+		if len(userInfo.Phone) > 5 {
+			phone = fmt.Sprintf("%s******%s", userInfo.Phone[0:3], userInfo.Phone[len(userInfo.Phone)-2:])
+		}
+		c.ResponseWithStatus(http.StatusBadRequest, map[string]interface{}{
+			"status": 110,
+			"msg":    "需要验证手机号码！",
+			"uid":    userInfo.UID,
+			"phone":  phone,
+		})
+	case errors.Is(err, ErrUserDisabled):
+		respondUserError(c, errcode.ErrUserAccountBanned)
+	case errors.Is(err, ErrUserDeviceInfoRequired):
+		respondUserRequestInvalid(c, "device")
+	default:
+		u.Error("登录执行失败", zap.String("uid", userInfo.UID), zap.Error(err))
+		respondUserServiceError(c)
+	}
+}
+
 func (u *User) execLogin(userInfo *Model, flag config.DeviceFlag, device *deviceReq, loginSpanCtx context.Context) (*loginUserDetailResp, error) {
 	if userInfo.Status == int(common.UserDisable) {
-		return nil, errors.New("该用户已被禁用")
+		return nil, ErrUserDisabled
 	}
 	deviceLevel := config.DeviceLevelSlave
 	if flag == config.APP {
@@ -1397,7 +1424,7 @@ func (u *User) execLogin(userInfo *Model, flag config.DeviceFlag, device *device
 	//app登录验证设备锁
 	if flag == 0 && userInfo.DeviceLock == 1 {
 		if device == nil {
-			return nil, errors.New("登录设备信息不能为空！")
+			return nil, ErrUserDeviceInfoRequired
 		}
 		var existDevice bool
 		var err error

--- a/modules/user/api_destroy.go
+++ b/modules/user/api_destroy.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
-	"github.com/pkg/errors"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"go.uber.org/zap"
 )
 
@@ -23,11 +23,11 @@ func (u *User) destroyApply(c *wkhttp.Context) {
 		Password string `json:"password"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if req.Password == "" {
-		c.ResponseError(errors.New("密码不能为空"))
+		respondUserRequestInvalid(c, "password")
 		return
 	}
 
@@ -37,31 +37,31 @@ func (u *User) destroyApply(c *wkhttp.Context) {
 	guardKey := "destroy:" + loginUID
 	if err := u.loginGuard.Check(guardKey); err != nil {
 		u.Warn("注销申请被临时锁定", zap.String("uid", loginUID), zap.Error(err))
-		c.ResponseError(err)
+		respondUserError(c, errcode.ErrUserLoginLocked)
 		return
 	}
 
 	userInfo, err := u.db.QueryByUID(loginUID)
 	if err != nil {
 		u.Error("查询登录用户信息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询登录用户信息错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userInfo == nil {
-		c.ResponseError(errors.New("登录用户不存在"))
+		respondUserError(c, errcode.ErrUserCurrentNotFound)
 		return
 	}
 	switch userInfo.IsDestroy {
 	case IsDestroyApplying:
-		c.ResponseError(errors.New("账号已在注销冷静期中"))
+		respondUserError(c, errcode.ErrUserAccountDestroying)
 		return
 	case IsDestroyDone:
-		c.ResponseError(errors.New("账号已注销"))
+		respondUserError(c, errcode.ErrUserAccountDestroyed)
 		return
 	}
 
 	if userInfo.Password == "" {
-		c.ResponseError(errors.New("当前账号未设置密码，无法验证身份"))
+		respondUserError(c, errcode.ErrUserPasswordNotSet)
 		return
 	}
 	// 注销路径丢弃 needsMigration 是有意为之：账号即将进入冷静期，
@@ -69,7 +69,7 @@ func (u *User) destroyApply(c *wkhttp.Context) {
 	matched, _ := CheckPassword(req.Password, userInfo.Password)
 	if !matched {
 		u.loginGuard.RecordFailureLogged(guardKey)
-		c.ResponseError(errors.New("密码错误"))
+		respondUserError(c, errcode.ErrUserPasswordIncorrect)
 		return
 	}
 	u.loginGuard.ResetLogged(guardKey)
@@ -82,11 +82,11 @@ func (u *User) destroyApply(c *wkhttp.Context) {
 		// 落库成功
 	case ErrDestroyStateConflict:
 		// 并发：另一请求已改变状态。返回业务冲突，避免给客户端假成功。
-		c.ResponseError(errors.New("账号状态已变化，请刷新后重试"))
+		respondUserError(c, errcode.ErrUserAccountStateChanged)
 		return
 	default:
 		u.Error("申请注销失败", zap.Error(err))
-		c.ResponseError(errors.New("申请注销失败"))
+		respondUserError(c, errcode.ErrUserDestroyFailed)
 		return
 	}
 	u.Info("用户申请注销", zap.String("uid", loginUID), zap.Time("expire_at", expireAt))
@@ -106,25 +106,25 @@ func (u *User) destroyCancel(c *wkhttp.Context) {
 	userInfo, err := u.db.QueryByUID(loginUID)
 	if err != nil {
 		u.Error("查询登录用户信息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询登录用户信息错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userInfo == nil {
-		c.ResponseError(errors.New("登录用户不存在"))
+		respondUserError(c, errcode.ErrUserCurrentNotFound)
 		return
 	}
 	if userInfo.IsDestroy != IsDestroyApplying {
-		c.ResponseError(errors.New("账号未在注销中"))
+		respondUserError(c, errcode.ErrUserNotDestroying)
 		return
 	}
 	switch err := u.db.cancelDestroy(loginUID); err {
 	case nil:
 	case ErrDestroyStateConflict:
-		c.ResponseError(errors.New("账号状态已变化，请刷新后重试"))
+		respondUserError(c, errcode.ErrUserAccountStateChanged)
 		return
 	default:
 		u.Error("撤销注销失败", zap.Error(err))
-		c.ResponseError(errors.New("撤销注销失败"))
+		respondUserError(c, errcode.ErrUserDestroyFailed)
 		return
 	}
 	u.Info("用户撤销注销", zap.String("uid", loginUID))
@@ -139,11 +139,11 @@ func (u *User) destroyStatus(c *wkhttp.Context) {
 	userInfo, err := u.db.QueryByUID(loginUID)
 	if err != nil {
 		u.Error("查询登录用户信息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询登录用户信息错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userInfo == nil {
-		c.ResponseError(errors.New("登录用户不存在"))
+		respondUserError(c, errcode.ErrUserCurrentNotFound)
 		return
 	}
 	// 注意：cooling_off_days 不下发——管理员事后调整该值会和用户实际 expire_at 不一致，引发歧义。

--- a/modules/user/api_destroy.go
+++ b/modules/user/api_destroy.go
@@ -91,9 +91,9 @@ func (u *User) destroyApply(c *wkhttp.Context) {
 	}
 	u.Info("用户申请注销", zap.String("uid", loginUID), zap.Time("expire_at", expireAt))
 	c.Response(map[string]interface{}{
-		"destroy_status": IsDestroyApplying,
-		"apply_at":       now.Unix(),
-		"expire_at":      expireAt.Unix(),
+		"destroy_status":   IsDestroyApplying,
+		"apply_at":         now.Unix(),
+		"expire_at":        expireAt.Unix(),
 		"cooling_off_days": days,
 	})
 }
@@ -247,4 +247,3 @@ func remainingDays(expireAt time.Time) int {
 	}
 	return days
 }
-

--- a/modules/user/api_destroy_test.go
+++ b/modules/user/api_destroy_test.go
@@ -59,6 +59,7 @@ func TestDestroyApply_OK(t *testing.T) {
 
 func TestDestroyApply_WrongPassword(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
 	u := New(ctx)
 
 	seedDestroyTestUser(t, u, "Pwd@12345")
@@ -75,6 +76,7 @@ func TestDestroyApply_WrongPassword(t *testing.T) {
 
 func TestDestroyApply_AlreadyApplying(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
 	u := New(ctx)
 
 	password := "Pwd@12345"
@@ -113,6 +115,7 @@ func TestDestroyCancel_OK(t *testing.T) {
 
 func TestDestroyCancel_NotApplying(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
 	u := New(ctx)
 
 	seedDestroyTestUser(t, u, "Pwd@12345")
@@ -202,6 +205,7 @@ func TestUsernameLogin_BlocksDestroyed(t *testing.T) {
 
 func TestDestroyApply_NoPasswordSet(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
 	u := New(ctx)
 
 	// 模拟仅第三方登录、未设置密码的账号
@@ -245,6 +249,7 @@ func TestAnonymizeUsername_FitsColumnLimit(t *testing.T) {
 
 func TestDestroyApply_AlreadyDestroyed(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
 	u := New(ctx)
 
 	password := "Pwd@12345"
@@ -312,6 +317,7 @@ func TestFinalizeDestroy_RaceWithCancel(t *testing.T) {
 
 func TestDestroyCancel_AfterFinalized(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
 	u := New(ctx)
 
 	hashed, _ := HashPassword("Pwd@12345")

--- a/modules/user/api_device.go
+++ b/modules/user/api_device.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
-	"github.com/pkg/errors"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"go.uber.org/zap"
 )
 
@@ -17,11 +17,11 @@ func (u *User) getDevice(c *wkhttp.Context) {
 	device, err := u.deviceDB.queryDeviceWithUIDAndDeviceID(deviceID, loginUID)
 	if err != nil {
 		u.Error("获取设备信息失败！", zap.Error(err))
-		c.ResponseError(errors.New("获取设备信息失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if device == nil {
-		c.ResponseError(errors.New("未查询到该设备"))
+		respondUserError(c, errcode.ErrUserDeviceNotFound)
 		return
 	}
 	c.Response(&deviceResp{
@@ -38,7 +38,7 @@ func (u *User) deviceDelete(c *wkhttp.Context) {
 	err := u.deviceDB.deleteDeviceWithDeviceIDAndUID(deviceID, c.GetLoginUID())
 	if err != nil {
 		u.Error("删除设备失败！", zap.Error(err))
-		c.ResponseError(errors.New("删除设备失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	c.ResponseOK()
@@ -62,7 +62,7 @@ func (u *User) deviceList(c *wkhttp.Context) {
 
 	if err != nil {
 		u.Error("查询设备列表失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询设备列表失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 

--- a/modules/user/api_emaillogin.go
+++ b/modules/user/api_emaillogin.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"context"
+	"errors"
 	"runtime/debug"
 	"strings"
 
@@ -65,6 +66,13 @@ func (u *User) emailSendCode(c *wkhttp.Context) {
 
 	emailService := commonapi.NewEmailService(u.ctx, common.EnsureSystemSettings(u.ctx))
 	if err := emailService.SendVerifyCode(context.Background(), req.Email, commonapi.CodeType(req.CodeType)); err != nil {
+		// 1 分钟重发冷却是客户端可处理状态 → 429（文案可见），其余（Redis/SMTP）
+		// 才是 5xx 内部故障。
+		if errors.Is(err, commonapi.ErrEmailSendRateLimited) {
+			u.Warn("邮箱验证码发送过于频繁", zap.String("email", req.Email))
+			respondUserError(c, errcode.ErrUserEmailRateLimited)
+			return
+		}
 		u.Error("发送邮箱验证码失败", zap.String("email", req.Email), zap.Error(err))
 		respondUserError(c, errcode.ErrUserEmailSendFailed)
 		return
@@ -310,8 +318,7 @@ func (u *User) emailLogin(c *wkhttp.Context) {
 
 	result, err := u.execLogin(userInfo, config.DeviceFlag(req.Flag), req.Device, loginSpanCtx)
 	if err != nil {
-		u.Error("邮箱登录 execLogin 失败", zap.String("email", req.Email), zap.Error(err))
-		respondUserError(c, errcode.ErrUserStoreFailed)
+		u.respondExecLoginError(c, err, userInfo)
 		return
 	}
 	c.Response(result)

--- a/modules/user/api_emaillogin.go
+++ b/modules/user/api_emaillogin.go
@@ -10,8 +10,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	commonapi "github.com/Mininglamp-OSS/octo-server/modules/base/common"
 	common "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -23,22 +23,22 @@ func (u *User) emailSendCode(c *wkhttp.Context) {
 	}
 	var req reqVO
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	req.Email = strings.TrimSpace(strings.ToLower(req.Email))
 	if req.Email == "" {
-		c.ResponseError(errors.New("邮箱不能为空"))
+		respondUserRequestInvalid(c, "email")
 		return
 	}
 	if !isValidEmail(req.Email) {
-		c.ResponseError(errors.New("邮箱格式不正确"))
+		respondUserError(c, errcode.ErrUserEmailInvalid)
 		return
 	}
 	settings := common.EnsureSystemSettings(u.ctx)
 	codeType := commonapi.CodeType(req.CodeType)
 	if codeType == commonapi.CodeTypeRegister && settings.RegisterOff() {
-		c.ResponseError(errors.New("注册通道暂不开放"))
+		respondUserError(c, errcode.ErrUserRegistrationClosed)
 		return
 	}
 	// 邮箱登录验证码与 emailLogin 守卫语义对齐:local_off=1 时连发码也拒,
@@ -46,16 +46,16 @@ func (u *User) emailSendCode(c *wkhttp.Context) {
 	// 注意范围:只覆盖 CodeTypeEmailLogin —— 忘记密码 / 注册验证码各有
 	// 自己的开关(register.off / 长期保留),不在 local_off 守备范围内。
 	if codeType == commonapi.CodeTypeEmailLogin && settings.LocalLoginOff() {
-		c.ResponseError(errors.New("本地登录已关闭"))
+		respondUserError(c, errcode.ErrUserLocalLoginDisabled)
 		return
 	}
 	if !settings.RegisterEmailOn() {
 		switch codeType {
 		case commonapi.CodeTypeRegister:
-			c.ResponseError(errors.New("暂不支持邮箱注册"))
+			respondUserError(c, errcode.ErrUserEmailRegisterDisabled)
 			return
 		case commonapi.CodeTypeEmailLogin:
-			c.ResponseError(errors.New("暂不支持邮箱登录"))
+			respondUserError(c, errcode.ErrUserEmailLoginDisabled)
 			return
 		default:
 			// RegisterEmailOn controls email registration/login only. Password
@@ -66,7 +66,7 @@ func (u *User) emailSendCode(c *wkhttp.Context) {
 	emailService := commonapi.NewEmailService(u.ctx, common.EnsureSystemSettings(u.ctx))
 	if err := emailService.SendVerifyCode(context.Background(), req.Email, commonapi.CodeType(req.CodeType)); err != nil {
 		u.Error("发送邮箱验证码失败", zap.String("email", req.Email), zap.Error(err))
-		c.ResponseError(err)
+		respondUserError(c, errcode.ErrUserEmailSendFailed)
 		return
 	}
 	c.ResponseOK()
@@ -76,11 +76,11 @@ func (u *User) emailSendCode(c *wkhttp.Context) {
 func (u *User) emailRegister(c *wkhttp.Context) {
 	settings := common.EnsureSystemSettings(u.ctx)
 	if settings.RegisterOff() {
-		c.ResponseError(errors.New("注册通道暂不开放"))
+		respondUserError(c, errcode.ErrUserRegistrationClosed)
 		return
 	}
 	if !settings.RegisterEmailOn() {
-		c.ResponseError(errors.New("暂不支持邮箱注册"))
+		respondUserError(c, errcode.ErrUserEmailRegisterDisabled)
 		return
 	}
 	type reqVO struct {
@@ -93,46 +93,46 @@ func (u *User) emailRegister(c *wkhttp.Context) {
 	}
 	var req reqVO
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	req.Email = strings.TrimSpace(strings.ToLower(req.Email))
 	if req.Email == "" {
-		c.ResponseError(errors.New("邮箱不能为空"))
+		respondUserRequestInvalid(c, "email")
 		return
 	}
 	if !isValidEmail(req.Email) {
-		c.ResponseError(errors.New("邮箱格式不正确"))
+		respondUserError(c, errcode.ErrUserEmailInvalid)
 		return
 	}
 	if strings.TrimSpace(req.Password) == "" {
-		c.ResponseError(errors.New("密码不能为空"))
+		respondUserRequestInvalid(c, "password")
 		return
 	}
 	if len(strings.TrimSpace(req.Password)) < 6 {
-		c.ResponseError(errors.New("密码长度不能少于6位"))
+		respondUserError(c, errcode.ErrUserPasswordTooShort)
 		return
 	}
 
 	// 验证邮箱验证码（仅非 release 模式且配置了 SMSCode 时走测试分支）
 	if commonapi.IsTestCodeEnabled(u.ctx.GetConfig()) {
 		if strings.TrimSpace(req.Code) == "" {
-			c.ResponseError(errors.New("验证码不能为空"))
+			respondUserRequestInvalid(c, "code")
 			return
 		}
 		if !commonapi.MatchTestCode(u.ctx.GetConfig(), req.Code) {
-			c.ResponseError(errors.New("验证码错误"))
+			respondUserError(c, errcode.ErrUserCodeInvalid)
 			return
 		}
 	} else {
 		// 线上模式：必须提供验证码
 		if strings.TrimSpace(req.Code) == "" {
-			c.ResponseError(errors.New("验证码不能为空"))
+			respondUserRequestInvalid(c, "code")
 			return
 		}
 		emailService := commonapi.NewEmailService(u.ctx, common.EnsureSystemSettings(u.ctx))
 		if err := emailService.Verify(context.Background(), req.Email, req.Code, commonapi.CodeTypeRegister); err != nil {
-			c.ResponseError(err)
+			respondUserError(c, errcode.ErrUserCodeInvalid)
 			return
 		}
 	}
@@ -141,16 +141,16 @@ func (u *User) emailRegister(c *wkhttp.Context) {
 	existUser, err := u.db.QueryByEmail(req.Email)
 	if err != nil {
 		u.Error("查询用户信息失败", zap.String("email", req.Email), zap.Error(err))
-		c.ResponseError(errors.New("查询用户信息失败"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if existUser != nil {
-		c.ResponseError(errors.New("该邮箱已被注册"))
+		respondUserError(c, errcode.ErrUserAlreadyExists)
 		return
 	}
 
 	if err := ValidateName(req.Name); err != nil {
-		c.ResponseError(err)
+		respondUserRequestInvalid(c, "name")
 		return
 	}
 
@@ -169,7 +169,7 @@ func (u *User) emailRegister(c *wkhttp.Context) {
 	tx, err := u.db.session.Begin()
 	if err != nil {
 		u.Error("创建事务失败", zap.Error(err))
-		c.ResponseError(errors.New("创建事务失败"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	defer func() {
@@ -178,7 +178,7 @@ func (u *User) emailRegister(c *wkhttp.Context) {
 			u.Error("emailRegister panic recovered",
 				zap.Any("recover", r),
 				zap.String("stack", string(debug.Stack())))
-			c.ResponseError(errors.New("注册失败，请重试"))
+			respondUserError(c, errcode.ErrUserRegisterFailed)
 		}
 	}()
 
@@ -194,14 +194,14 @@ func (u *User) emailRegister(c *wkhttp.Context) {
 		if err := tx.Commit(); err != nil {
 			tx.Rollback()
 			u.Error("数据库事务提交失败", zap.Error(err))
-			c.ResponseError(errors.New("数据库事务提交失败"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return err
 		}
 		return nil
 	})
 	if err != nil {
 		tx.Rollback()
-		c.ResponseError(errors.New("注册失败！"))
+		respondUserError(c, errcode.ErrUserRegisterFailed)
 		return
 	}
 	c.Response(result)
@@ -211,11 +211,11 @@ func (u *User) emailRegister(c *wkhttp.Context) {
 func (u *User) emailLogin(c *wkhttp.Context) {
 	settings := common.EnsureSystemSettings(u.ctx)
 	if settings.LocalLoginOff() {
-		c.ResponseError(errors.New("本地登录已关闭"))
+		respondUserError(c, errcode.ErrUserLocalLoginDisabled)
 		return
 	}
 	if !settings.RegisterEmailOn() {
-		c.ResponseError(errors.New("暂不支持邮箱登录"))
+		respondUserError(c, errcode.ErrUserEmailLoginDisabled)
 		return
 	}
 	type reqVO struct {
@@ -227,27 +227,27 @@ func (u *User) emailLogin(c *wkhttp.Context) {
 	}
 	var req reqVO
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	req.Email = strings.TrimSpace(strings.ToLower(req.Email))
 	if req.Email == "" {
-		c.ResponseError(errors.New("邮箱不能为空"))
+		respondUserRequestInvalid(c, "email")
 		return
 	}
 	if !isValidEmail(req.Email) {
-		c.ResponseError(errors.New("邮箱格式不正确"))
+		respondUserError(c, errcode.ErrUserEmailInvalid)
 		return
 	}
 	if req.Code == "" && req.Password == "" {
-		c.ResponseError(errors.New("验证码或密码不能为空"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	// 仅密码登录走 guard；验证码登录有独立的发送频控 + 验证次数限制，不纳入 guard 计数。
 	if req.Password != "" {
 		if err := u.loginGuard.Check(req.Email); err != nil {
 			u.Warn("邮箱登录被临时锁定", zap.String("email", req.Email), zap.Error(err))
-			c.ResponseError(err)
+			respondUserError(c, errcode.ErrUserLoginLocked)
 			return
 		}
 	}
@@ -262,27 +262,27 @@ func (u *User) emailLogin(c *wkhttp.Context) {
 	userInfo, err := u.db.QueryByEmail(req.Email)
 	if err != nil {
 		u.Error("查询用户信息失败", zap.String("email", req.Email), zap.Error(err))
-		c.ResponseError(errors.New("查询用户信息失败"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userInfo == nil {
 		// 密码登录路径统一返回通用错误消息避免枚举；验证码登录路径不涉及密码，保留原提示。
 		if req.Password != "" {
 			u.loginGuard.RecordFailureLogged(req.Email)
-			c.ResponseError(errors.New("邮箱或密码错误"))
+			respondUserError(c, errcode.ErrUserInvalidCredentials)
 			return
 		}
-		c.ResponseError(errors.New("该邮箱未注册"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 	if userInfo.IsDestroy == IsDestroyDone || userInfo.Status == 0 {
 		// 密码路径同样泄露账号状态，统一为通用错误 + 计入失败计数
 		if req.Password != "" {
 			u.loginGuard.RecordFailureLogged(req.Email)
-			c.ResponseError(errors.New("邮箱或密码错误"))
+			respondUserError(c, errcode.ErrUserInvalidCredentials)
 			return
 		}
-		c.ResponseError(errors.New("该账号已注销或被禁用"))
+		respondUserError(c, errcode.ErrUserAccountUnavailable)
 		return
 	}
 
@@ -290,14 +290,14 @@ func (u *User) emailLogin(c *wkhttp.Context) {
 	if req.Code != "" {
 		emailService := commonapi.NewEmailService(u.ctx, common.EnsureSystemSettings(u.ctx))
 		if err := emailService.Verify(loginSpanCtx, req.Email, req.Code, commonapi.CodeTypeEmailLogin); err != nil {
-			c.ResponseError(err)
+			respondUserError(c, errcode.ErrUserCodeInvalid)
 			return
 		}
 	} else {
 		matched, needsMigration := CheckPassword(req.Password, userInfo.Password)
 		if !matched {
 			u.loginGuard.RecordFailureLogged(req.Email)
-			c.ResponseError(errors.New("邮箱或密码错误"))
+			respondUserError(c, errcode.ErrUserInvalidCredentials)
 			return
 		}
 		u.loginGuard.ResetLogged(req.Email)
@@ -310,7 +310,8 @@ func (u *User) emailLogin(c *wkhttp.Context) {
 
 	result, err := u.execLogin(userInfo, config.DeviceFlag(req.Flag), req.Device, loginSpanCtx)
 	if err != nil {
-		c.ResponseError(err)
+		u.Error("邮箱登录 execLogin 失败", zap.String("email", req.Email), zap.Error(err))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	c.Response(result)
@@ -327,54 +328,54 @@ func (u *User) emailForgetPwd(c *wkhttp.Context) {
 	}
 	var req reqVO
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	req.Email = strings.TrimSpace(strings.ToLower(req.Email))
 	if req.Email == "" {
-		c.ResponseError(errors.New("邮箱不能为空"))
+		respondUserRequestInvalid(c, "email")
 		return
 	}
 	if strings.TrimSpace(req.Code) == "" {
-		c.ResponseError(errors.New("验证码不能为空"))
+		respondUserRequestInvalid(c, "code")
 		return
 	}
 	if strings.TrimSpace(req.Password) == "" {
-		c.ResponseError(errors.New("新密码不能为空"))
+		respondUserRequestInvalid(c, "new_password")
 		return
 	}
 	if len(strings.TrimSpace(req.Password)) < 6 {
-		c.ResponseError(errors.New("密码长度不能少于6位"))
+		respondUserError(c, errcode.ErrUserPasswordTooShort)
 		return
 	}
 
 	// 验证验证码
 	emailService := commonapi.NewEmailService(u.ctx, common.EnsureSystemSettings(u.ctx))
 	if err := emailService.Verify(context.Background(), req.Email, req.Code, commonapi.CodeTypeForgetLoginPWD); err != nil {
-		c.ResponseError(err)
+		respondUserError(c, errcode.ErrUserCodeInvalid)
 		return
 	}
 
 	userInfo, err := u.db.QueryByEmail(req.Email)
 	if err != nil {
 		u.Error("查询用户信息失败", zap.String("email", req.Email), zap.Error(err))
-		c.ResponseError(errors.New("查询用户信息失败"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userInfo == nil {
-		c.ResponseError(errors.New("该邮箱未注册"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 
 	newHash, err := HashPassword(req.Password)
 	if err != nil {
 		u.Error("密码哈希失败", zap.Error(err))
-		c.ResponseError(errors.New("密码处理失败"))
+		respondUserError(c, errcode.ErrUserPasswordProcessFailed)
 		return
 	}
 	if err := u.db.updatePassword(newHash, userInfo.UID); err != nil {
 		u.Error("更新密码失败", zap.Error(err))
-		c.ResponseError(errors.New("重置密码失败"))
+		respondUserError(c, errcode.ErrUserLoginPwdUpdateFailed)
 		return
 	}
 	c.ResponseOK()

--- a/modules/user/api_emaillogin_test.go
+++ b/modules/user/api_emaillogin_test.go
@@ -64,6 +64,7 @@ func simulateCommitFailure() error {
 
 func TestEmailRegisterBlockedByRegisterOff(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	setSystemSettingForUserTest(t, ctx, "register", "off", "1", "bool")
 	setSystemSettingForUserTest(t, ctx, "register", "email_on", "1", "bool")
@@ -79,7 +80,7 @@ func TestEmailRegisterBlockedByRegisterOff(t *testing.T) {
 	setPublicIPForUserTest(req, "8.8.8.8")
 	s.GetRoute().ServeHTTP(w, req)
 
-	assert.Contains(t, w.Body.String(), "注册通道暂不开放")
+	assert.Contains(t, w.Body.String(), "err.server.user.registration_closed")
 }
 
 func TestEmailLoginBlockedByLocalLoginOff(t *testing.T) {
@@ -87,6 +88,7 @@ func TestEmailLoginBlockedByLocalLoginOff(t *testing.T) {
 	// TestUsernameLoginBlockedByLocalLoginOff 的同款注释。
 	enableFullOIDCForUserTest(t)
 	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	setSystemSettingForUserTest(t, ctx, "login", "local_off", "1", "bool")
 	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
@@ -104,6 +106,7 @@ func TestEmailLoginBlockedByLocalLoginOff(t *testing.T) {
 
 func TestEmailLoginBlockedByEmailOn(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	setSystemSettingForUserTest(t, ctx, "register", "email_on", "0", "bool")
 	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
@@ -126,6 +129,7 @@ func TestEmailLoginBlockedByEmailOn(t *testing.T) {
 func TestEmailSendCodeForLoginBlockedByLocalLoginOff(t *testing.T) {
 	enableFullOIDCForUserTest(t) // 让 local_off=1 通过安全回退,验证守卫本身
 	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	setSystemSettingForUserTest(t, ctx, "login", "local_off", "1", "bool")
 	// 把 register.email_on 显式置 1,排除"被另一个开关拦下"的混淆。
@@ -155,6 +159,7 @@ func TestEmailSendCodeForLoginBlockedByLocalLoginOff(t *testing.T) {
 
 func TestEmailSendCodeBlockedByEmailOnForLoginAndRegister(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	setSystemSettingForUserTest(t, ctx, "register", "email_on", "0", "bool")
 	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
@@ -174,6 +179,7 @@ func TestEmailSendCodeBlockedByEmailOnForLoginAndRegister(t *testing.T) {
 
 func TestEmailSendRegisterCodeBlockedByRegisterOff(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	setSystemSettingForUserTest(t, ctx, "register", "off", "1", "bool")
 	setSystemSettingForUserTest(t, ctx, "register", "email_on", "1", "bool")
@@ -187,11 +193,12 @@ func TestEmailSendRegisterCodeBlockedByRegisterOff(t *testing.T) {
 	setPublicIPForUserTest(req, "1.0.0.1")
 	s.GetRoute().ServeHTTP(w, req)
 
-	assert.Contains(t, w.Body.String(), "注册通道暂不开放")
+	assert.Contains(t, w.Body.String(), "err.server.user.registration_closed")
 }
 
 func TestEmailForgetPasswordCodeAllowedWhenEmailLoginDisabled(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	setSystemSettingForUserTest(t, ctx, "register", "email_on", "0", "bool")
 	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())

--- a/modules/user/api_friend.go
+++ b/modules/user/api_friend.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
 	"github.com/Mininglamp-OSS/octo-server/modules/source"
 	"github.com/Mininglamp-OSS/octo-server/modules/space"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	wkutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
@@ -79,25 +80,25 @@ func (f *Friend) refuseApply(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	toUid := c.Param("to_uid")
 	if toUid == "" {
-		c.ResponseError(errors.New("好友ID不能为空"))
+		respondUserRequestInvalid(c, "uid")
 		return
 	}
 
 	apply, err := f.db.queryApplyWithUidAndToUid(loginUID, toUid)
 	if err != nil {
 		f.Error("查询申请记录错误", zap.Error(err))
-		c.ResponseError(errors.New("查询申请记录错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if apply == nil || apply.UID != loginUID {
-		c.ResponseError(errors.New("申请记录不存在"))
+		respondUserError(c, errcode.ErrUserFriendApplyNotFound)
 		return
 	}
 	apply.Status = 2
 	err = f.db.updateApply(apply)
 	if err != nil {
 		f.Error("修改申请记录错误", zap.Error(err))
-		c.ResponseError(errors.New("修改申请记录错误"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	c.ResponseOK()
@@ -108,13 +109,13 @@ func (f *Friend) deleteApply(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	toUid := c.Param("to_uid")
 	if toUid == "" {
-		c.ResponseError(errors.New("id不能为空"))
+		respondUserRequestInvalid(c, "id")
 		return
 	}
 	err := f.db.deleteApplyWithUidAndToUid(loginUID, toUid)
 	if err != nil {
 		f.Error("删除申请记录错误", zap.Error(err))
-		c.ResponseError(errors.New("删除申请记录错误"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	c.ResponseOK()
@@ -130,7 +131,7 @@ func (f *Friend) apply(c *wkhttp.Context) {
 	applys, err := f.db.queryApplysWithPage(loginUID, uint64(pageSize), uint64(pageIndex))
 	if err != nil {
 		f.Error("查询好友申请列表错误", zap.Error(err))
-		c.ResponseError(errors.New("查询好友申请列表错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	list := make([]*friendApplyResp, 0)
@@ -142,11 +143,11 @@ func (f *Friend) apply(c *wkhttp.Context) {
 		users, err := f.userService.GetUsers(uids)
 		if err != nil {
 			f.Error("查询申请用户信息错误", zap.Error(err))
-			c.ResponseError(errors.New("查询申请用户信息错误"))
+			respondUserError(c, errcode.ErrUserQueryFailed)
 			return
 		}
 		if len(users) == 0 {
-			c.ResponseError(errors.New("申请者不存在"))
+			respondUserError(c, errcode.ErrUserNotFound)
 			return
 		}
 		userMap := make(map[string]string, len(users))
@@ -174,13 +175,13 @@ func (f *Friend) delete(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	uid := c.Param("uid")
 	if uid == "" {
-		c.ResponseError(errors.New("用户uid不能为空"))
+		respondUserRequestInvalid(c, "uid")
 		return
 	}
 	tx, err := f.ctx.DB().Begin()
 	if err != nil {
 		f.Error("开启事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("开启事务失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	defer func() {
@@ -191,7 +192,8 @@ func (f *Friend) delete(c *wkhttp.Context) {
 	}()
 	version, err := f.ctx.GenSeq(common.FriendSeqKey)
 	if err != nil {
-		c.ResponseError(err)
+		f.Error("生成好友关系序列号失败", zap.Error(err))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	// err = f.db.updateRelationshipTx(loginUID, uid, 1, 1, "", version, tx) // 不能删除sourceVercode 如果删除了 已有会话发起加好友会提示验证码不为空
@@ -199,14 +201,14 @@ func (f *Friend) delete(c *wkhttp.Context) {
 	if err != nil {
 		util.CheckErr(tx.Rollback())
 		f.Error("删除好友错误", zap.Error(err))
-		c.ResponseError(errors.New("删除好友错误"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	err = f.db.updateAloneTx(uid, loginUID, 1, tx)
 	if err != nil {
 		util.CheckErr(tx.Rollback())
 		f.Error("修改好友单项关系错误", zap.Error(err))
-		c.ResponseError(errors.New("修改好友单项关系错误"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	// 发布删除好友事件
@@ -221,14 +223,14 @@ func (f *Friend) delete(c *wkhttp.Context) {
 	if err != nil {
 		f.Error("发送删除好友事件失败", zap.Error(err))
 		tx.Rollback()
-		c.ResponseError(errors.New("发送删除好友事件失败"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	userSetting, err := f.settingDB.querySettingByUIDAndToUID(loginUID, uid)
 	if err != nil {
 		tx.Rollback()
 		f.Error("查询用户好友设置错误", zap.Error(err))
-		c.ResponseError(errors.New("查询用户好友设置错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userSetting != nil {
@@ -245,14 +247,14 @@ func (f *Friend) delete(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			f.Error("重置好友设置错误", zap.Error(err))
-			c.ResponseError(errors.New("重置好友设置错误"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 	}
 	if err := tx.Commit(); err != nil {
 		tx.RollbackUnlessCommitted()
 		f.Error("提交事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("提交事务失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	f.ctx.EventCommit(eventID)
@@ -294,55 +296,57 @@ func (f *Friend) friendApply(c *wkhttp.Context) {
 	var req applyReq
 	if err := c.BindJSON(&req); err != nil {
 		f.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(common.ErrData)
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if err := req.Check(); err != nil {
-		c.ResponseError(err)
+		// applyReq/sureReq.Check 返回"X 不能为空"类输入校验错误，统一走
+		// request_invalid（不做 per-field 标注，与 /v1/user login 一致）。
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if fromUID == req.ToUID {
-		c.ResponseError(errors.New("不能添加自己为好友！"))
+		respondUserError(c, errcode.ErrUserCannotAddSelf)
 		return
 	}
 	loginUserInfo, err := f.userDB.QueryByUID(fromUID)
 	if err != nil {
 		f.Error("查询用户信息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询用户信息错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if loginUserInfo == nil || loginUserInfo.IsDestroy == IsDestroyDone || loginUserInfo.Status != 1 {
 		f.Error("登录用户不存在！", zap.String("uid", fromUID))
-		c.ResponseError(errors.New("登录用户不存在！"))
+		respondUserError(c, errcode.ErrUserCurrentNotFound)
 		return
 	}
 	// 是否是好友
 	isFriendLoginUser, err := f.db.IsFriend(fromUID, req.ToUID)
 	if err != nil {
 		f.Error("查询是否是好友失败！", zap.Error(err), zap.String("uid", fromUID), zap.String("toUid", req.ToUID))
-		c.ResponseError(errors.New("查询是否是好友失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	isFriendToUser, err := f.db.IsFriend(req.ToUID, fromUID)
 	if err != nil {
 		f.Error("查询是否是好友失败！", zap.Error(err), zap.String("uid", fromUID), zap.String("toUid", req.ToUID))
-		c.ResponseError(errors.New("查询是否是好友失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if isFriendLoginUser && isFriendToUser {
-		c.ResponseError(errors.New("已经是好友，不能再申请！"))
+		respondUserError(c, errcode.ErrUserAlreadyFriend)
 		return
 	}
 
 	toUser, err := f.userDB.QueryByUID(req.ToUID)
 	if err != nil {
 		f.Error("查询接收者用户信息失败！", zap.Error(err), zap.String("uid", fromUID))
-		c.ResponseError(errors.New("查询用户信息失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if toUser == nil || toUser.IsDestroy == IsDestroyDone {
 		f.Error("接收好友请求的用户不存在！", zap.String("to_uid", req.ToUID))
-		c.ResponseError(errors.New("接收好友请求的用户不存在！"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 	// Bot 用户（robot=1）：检查 Space 隔离，跳过 vercode 验证
@@ -351,7 +355,7 @@ func (f *Friend) friendApply(c *wkhttp.Context) {
 	if isBotTarget && !systemBots[req.ToUID] {
 		commonSpace := space.GetCommonSpaceID(f.ctx, fromUID, req.ToUID)
 		if commonSpace == "" {
-			c.ResponseError(errors.New("该 Bot 不在当前 Space 中，无法添加"))
+			respondUserError(c, errcode.ErrUserBotNotInSpace)
 			return
 		}
 	}
@@ -365,17 +369,17 @@ func (f *Friend) friendApply(c *wkhttp.Context) {
 			friend, err := f.db.queryWithUID(fromUID, req.ToUID)
 			if err != nil {
 				f.Error("查询好友信息错误", zap.String("to_uid", req.ToUID))
-				c.ResponseError(errors.New("查询好友信息错误"))
+				respondUserError(c, errcode.ErrUserQueryFailed)
 				return
 			}
 			if friend == nil {
 				f.Error("好友信息不存在", zap.String("to_uid", req.ToUID))
-				c.ResponseError(errors.New("好友信息不存在"))
+				respondUserError(c, errcode.ErrUserFriendNotFound)
 				return
 			}
 			if friend.SourceVercode == "" {
 				f.Error("验证码不能为空", zap.String("to_uid", req.ToUID))
-				c.ResponseError(errors.New("验证码不能为空"))
+				respondUserRequestInvalid(c, "vercode")
 				return
 			}
 			req.Vercode = friend.SourceVercode
@@ -387,7 +391,7 @@ func (f *Friend) friendApply(c *wkhttp.Context) {
 		//验证code是否有效
 		err = source.CheckRequestAddFriendCode(req.Vercode, fromUID)
 		if err != nil {
-			c.ResponseError(err)
+			respondUserError(c, errcode.ErrUserCodeInvalid)
 			return
 		}
 	}
@@ -433,27 +437,27 @@ func (f *Friend) friendApply(c *wkhttp.Context) {
 	}), f.ctx.GetConfig().Cache.FriendApplyExpire)
 	if err != nil {
 		f.Error("设置申请token失败！", zap.Error(err))
-		c.ResponseError(errors.New("设置申请token失败！"))
+		respondUserError(c, errcode.ErrUserTokenCacheFailed)
 		return
 	}
 	// 查询好友申请记录
 	apply, err := f.db.queryApplyWithUidAndToUid(req.ToUID, fromUID)
 	if err != nil {
 		f.Error("查询好友申请记录错误", zap.String("to_uid", req.ToUID))
-		c.ResponseError(errors.New("查询好友申请记录错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	// 查询用户红点
 	userRedDot, err := f.userDB.queryUserRedDot(req.ToUID, UserRedDotCategoryFriendApply)
 	if err != nil {
 		f.Error("查询用户通讯录红点信息错误", zap.String("to_uid", req.ToUID))
-		c.ResponseError(errors.New("查询用户通讯录红点信息错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	tx, err := f.ctx.DB().Begin()
 	if err != nil {
 		f.Error("开启事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("开启事务失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	defer func() {
@@ -474,7 +478,7 @@ func (f *Friend) friendApply(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			f.Error("新增好友申请记录错误", zap.String("to_uid", req.ToUID))
-			c.ResponseError(errors.New("新增好友申请记录错误"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 	} else {
@@ -486,7 +490,7 @@ func (f *Friend) friendApply(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			f.Error("修改好友申请记录错误", zap.String("to_uid", req.ToUID))
-			c.ResponseError(errors.New("修改好友申请记录错误"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 		// }
@@ -503,7 +507,7 @@ func (f *Friend) friendApply(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			f.Error("新增用户通讯录红点信息错误", zap.String("to_uid", req.ToUID))
-			c.ResponseError(errors.New("新增用户通讯录红点信息错误"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 	} else {
@@ -513,7 +517,7 @@ func (f *Friend) friendApply(c *wkhttp.Context) {
 			if err != nil {
 				tx.Rollback()
 				f.Error("修改用户通讯录红点信息错误", zap.String("to_uid", req.ToUID))
-				c.ResponseError(errors.New("修改用户通讯录红点信息错误"))
+				respondUserError(c, errcode.ErrUserStoreFailed)
 				return
 			}
 		}
@@ -522,7 +526,7 @@ func (f *Friend) friendApply(c *wkhttp.Context) {
 	if err = tx.Commit(); err != nil {
 		tx.Rollback()
 		f.Error("提交事物错误", zap.Error(err))
-		c.ResponseError(errors.New("提交事物错误"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	// 发送消息
@@ -544,7 +548,7 @@ func (f *Friend) friendApply(c *wkhttp.Context) {
 	})
 	if err != nil {
 		f.Error("发送好友申请失败！", zap.Error(err))
-		c.ResponseError(errors.New("发送好友申请失败！"))
+		respondUserError(c, errcode.ErrUserIMCallFailed)
 		return
 	}
 
@@ -679,11 +683,13 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 	var req sureReq
 	if err := c.BindJSON(&req); err != nil {
 		f.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(common.ErrData)
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if err := req.Check(); err != nil {
-		c.ResponseError(err)
+		// applyReq/sureReq.Check 返回"X 不能为空"类输入校验错误，统一走
+		// request_invalid（不做 per-field 标注，与 /v1/user login 一致）。
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	// 提取 space_id：body > query > header
@@ -718,38 +724,38 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 	tokenVaule, err := f.ctx.Cache().Get(key) // 获取申请人的uid
 	if err != nil {
 		f.Error("获取好友申请token的信息失败！", zap.Error(err), zap.String("key", key))
-		c.ResponseError(errors.New("获取好友申请token的信息失败！"))
+		respondUserError(c, errcode.ErrUserDecodeFailed)
 		return
 	}
 	valueMap, err := util.JsonToMap(tokenVaule)
 	if err != nil {
 		f.Error("获取token信息错误", zap.Error(err), zap.String("key", key))
-		c.ResponseError(errors.New("获取token信息错误"))
+		respondUserError(c, errcode.ErrUserDecodeFailed)
 		return
 	}
 
 	loginUser, err := f.userDB.QueryByUID(loginUID)
 	if err != nil {
 		f.Error("查询用户信息失败！", zap.Error(err), zap.String("uid", loginUID))
-		c.ResponseError(errors.New("查询用户信息失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if loginUser == nil || loginUser.IsDestroy == IsDestroyDone {
 		f.Error("当前用户不存在或已注销！", zap.String("uid", loginUID))
-		c.ResponseError(errors.New("当前用户不存在或已注销！"))
+		respondUserError(c, errcode.ErrUserCurrentNotFound)
 		return
 	}
 
 	applyUID, ok := valueMap["from_uid"].(string)
 	if !ok {
 		f.Error("好友申请数据无效：from_uid 类型错误或不存在", zap.Any("from_uid", valueMap["from_uid"]))
-		c.ResponseError(errors.New("好友申请数据无效"))
+		respondUserError(c, errcode.ErrUserFriendApplyInvalid)
 		return
 	}
 	vercode, ok := valueMap["vercode"].(string)
 	if !ok {
 		f.Error("好友申请数据无效：vercode 类型错误或不存在", zap.Any("vercode", valueMap["vercode"]))
-		c.ResponseError(errors.New("好友申请数据无效"))
+		respondUserError(c, errcode.ErrUserFriendApplyInvalid)
 		return
 	}
 	remark := ""
@@ -768,19 +774,19 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 	applyUser, err := f.userDB.QueryByUID(applyUID)
 	if err != nil {
 		f.Error("查询申请人用户信息失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询申请人用户信息失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if applyUser == nil || applyUser.IsDestroy == IsDestroyDone {
 		f.Error("申请人不存在或已注销！", zap.String("uid", applyUID))
-		c.ResponseError(errors.New("申请人不存在"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 	if remark == "" {
 		remark = fmt.Sprintf("我是%s", applyUser.Name)
 	}
 	if strings.TrimSpace(applyUID) == "" || strings.TrimSpace(vercode) == "" {
-		c.ResponseError(errors.New("好友申请无效或已过期！"))
+		respondUserError(c, errcode.ErrUserFriendApplyInvalid)
 		return
 	}
 	channelServiceObj := register.GetService(ChannelServiceName)
@@ -800,14 +806,14 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 	applyFriendModel, err := f.db.queryWithUID(loginUID, applyUID)
 	if err != nil {
 		f.Error("查询是否是好友失败！", zap.Error(err), zap.String("uid", loginUID), zap.String("toUid", applyUID))
-		c.ResponseError(errors.New("查询是否是好友失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	// 添加好友到数据库
 	tx, err := f.ctx.DB().Begin()
 	if err != nil {
 		f.Error("开启事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("开启事务失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	defer func() {
@@ -818,14 +824,15 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 	}()
 	version, err := f.ctx.GenSeq(common.FriendSeqKey)
 	if err != nil {
-		c.ResponseError(err)
+		f.Error("生成好友关系序列号失败", zap.Error(err))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	if applyFriendModel == nil {
 		// 验证code
 		err = source.CheckSource(vercode)
 		if err != nil {
-			c.ResponseError(err)
+			respondUserError(c, errcode.ErrUserCodeInvalid)
 			return
 		}
 
@@ -841,14 +848,14 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 		}, tx)
 		if err != nil {
 			tx.Rollback()
-			c.ResponseError(errors.New("添加好友失败！"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 	} else {
 		err = f.db.updateRelationshipTx(loginUID, applyUID, 0, 0, vercode, version, tx)
 		if err != nil {
 			tx.Rollback()
-			c.ResponseError(errors.New("修改好友关系失败"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 	}
@@ -858,7 +865,7 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 	if err != nil {
 		tx.Rollback()
 		f.Error("查询被添加者是否是好友失败！", zap.Error(err), zap.String("uid", loginUID), zap.String("toUid", applyUID))
-		c.ResponseError(errors.New("查询被添加者是否是好友失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if loginFriendModel == nil {
@@ -873,14 +880,14 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 		}, tx)
 		if err != nil {
 			tx.Rollback()
-			c.ResponseError(errors.New("添加好友失败！"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 	} else {
 		err = f.db.updateRelationshipTx(applyUID, loginUID, 0, 0, vercode, version, tx)
 		if err != nil {
 			tx.Rollback()
-			c.ResponseError(errors.New("修改好友关系失败"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 	}
@@ -896,7 +903,7 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 	if err != nil {
 		f.Error("发送好友确认事件失败", zap.Error(err))
 		tx.Rollback()
-		c.ResponseError(errors.New("发送好友确认事件失败"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	// 查询好友申请记录
@@ -904,7 +911,7 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 	if err != nil {
 		f.Error("查询好友申请记录错误", zap.Error(err))
 		tx.Rollback()
-		c.ResponseError(errors.New("查询好友申请记录错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if apply != nil {
@@ -913,13 +920,13 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 		if err != nil {
 			f.Error("修改好友申请记录错误", zap.Error(err))
 			tx.Rollback()
-			c.ResponseError(errors.New("修改好友申请记录错误"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 	}
 	if err := tx.Commit(); err != nil {
 		f.Error("提交事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("提交事务失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	f.ctx.EventCommit(eventID)
@@ -940,7 +947,7 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 	})
 	if err != nil {
 		f.Error("发送消息失败！", zap.Error(err))
-		c.ResponseError(errors.New("发送消息失败！"))
+		respondUserError(c, errcode.ErrUserIMCallFailed)
 		return
 	}
 	content := "我们已经是好友了，可以愉快的聊天了！"
@@ -964,7 +971,7 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 	))
 	if err != nil {
 		f.Error("发送通过好友请求消息失败！", zap.Error(err))
-		c.ResponseError(errors.New("发送通过好友请求消息失败！"))
+		respondUserError(c, errcode.ErrUserIMCallFailed)
 		return
 	}
 
@@ -981,14 +988,14 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 	))
 	if err != nil {
 		f.Error("发送接受好友请求消息失败！", zap.Error(err))
-		c.ResponseError(errors.New("发送接受好友请求消息失败！"))
+		respondUserError(c, errcode.ErrUserIMCallFailed)
 		return
 	}
 
 	err = f.ctx.Cache().Delete(key)
 	if err != nil {
 		f.Error("删除缓存数据错误", zap.Error(err))
-		c.ResponseError(errors.New("删除缓存数据错误"))
+		respondUserError(c, errcode.ErrUserTokenCacheFailed)
 		return
 	}
 	c.ResponseOK()
@@ -1019,7 +1026,7 @@ func (f *Friend) friendSync(c *wkhttp.Context) {
 		memberUIDs, err := space.GetSpaceMemberUIDs(f.ctx, defaultSpaceID)
 		if err != nil {
 			f.Error("获取 Space 成员失败！", zap.Error(err))
-			c.ResponseError(errors.New("获取 Space 成员失败！"))
+			respondUserError(c, errcode.ErrUserQueryFailed)
 			return
 		}
 		// 排除自己
@@ -1032,7 +1039,7 @@ func (f *Friend) friendSync(c *wkhttp.Context) {
 		userDetails, err := f.userService.GetUserDetails(filteredUIDs, c.GetLoginUID())
 		if err != nil {
 			f.Error("获取用户详情失败！", zap.Error(err))
-			c.ResponseError(errors.New("获取用户详情失败！"))
+			respondUserError(c, errcode.ErrUserQueryFailed)
 			return
 		}
 		resps := make([]*friendResp, 0, len(userDetails))
@@ -1052,7 +1059,7 @@ func (f *Friend) friendSync(c *wkhttp.Context) {
 	friends, err = f.db.SyncFriends(version, uid, limit)
 	if err != nil {
 		f.Error("同步好友信息错误！", zap.Error(err))
-		c.ResponseError(errors.New("同步好友信息错误！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 
@@ -1065,7 +1072,7 @@ func (f *Friend) friendSync(c *wkhttp.Context) {
 	userDetails, err := f.userService.GetUserDetails(friendUIDs, c.GetLoginUID())
 	if err != nil {
 		f.Error("获取用户详情失败！", zap.Error(err))
-		c.ResponseError(errors.New("获取用户详情失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	userDetailMap := map[string]*UserDetailResp{}
@@ -1101,7 +1108,7 @@ func (f *Friend) friendSearch(c *wkhttp.Context) {
 		memberUIDs, err := space.GetSpaceMemberUIDs(f.ctx, spaceID)
 		if err != nil {
 			f.Error("获取 Space 成员失败！", zap.Error(err))
-			c.ResponseError(errors.New("获取 Space 成员失败！"))
+			respondUserError(c, errcode.ErrUserQueryFailed)
 			return
 		}
 		// 排除自己
@@ -1114,7 +1121,7 @@ func (f *Friend) friendSearch(c *wkhttp.Context) {
 		userDetails, err := f.userService.GetUserDetails(filteredUIDs, c.GetLoginUID())
 		if err != nil {
 			f.Error("获取用户详情失败！", zap.Error(err))
-			c.ResponseError(errors.New("获取用户详情失败！"))
+			respondUserError(c, errcode.ErrUserQueryFailed)
 			return
 		}
 		resps := make([]*friendResp, 0, len(userDetails))
@@ -1136,7 +1143,7 @@ func (f *Friend) friendSearch(c *wkhttp.Context) {
 	friends, err := f.db.QueryFriendsWithKeyword(uid, keyword)
 	if err != nil {
 		f.Error("查询好友数据失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询好友数据失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	resps := make([]*friendResp, 0)
@@ -1160,17 +1167,17 @@ func (f *Friend) remark(c *wkhttp.Context) {
 	var req remarkReq
 	if err := c.BindJSON(&req); err != nil {
 		f.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(common.ErrData)
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if req.UID == "" {
-		c.ResponseError(errors.New("用户uid不能为空"))
+		respondUserRequestInvalid(c, "uid")
 		return
 	}
 	settingM, err := f.settingDB.querySettingByUIDAndToUID(loginUID, req.UID)
 	if err != nil {
 		f.Error("查询设置信息失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询设置信息失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if settingM == nil {
@@ -1181,7 +1188,7 @@ func (f *Friend) remark(c *wkhttp.Context) {
 		err = f.settingDB.InsertUserSettingModel(settingM)
 		if err != nil {
 			f.Error("添加用户设置失败！", zap.Error(err))
-			c.ResponseError(errors.New("添加用户设置失败！"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 	} else {
@@ -1189,7 +1196,7 @@ func (f *Friend) remark(c *wkhttp.Context) {
 		err = f.settingDB.UpdateUserSettingModel(settingM)
 		if err != nil {
 			f.Error("修改用户备注错误", zap.Error(err))
-			c.ResponseError(errors.New("修改用户备注错误"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 	}

--- a/modules/user/api_friend.go
+++ b/modules/user/api_friend.go
@@ -725,14 +725,18 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 	key := f.ctx.GetConfig().Cache.FriendApplyTokenCachePrefix + req.Token + loginUID
 	tokenVaule, err := f.ctx.Cache().Get(key) // 获取申请人的uid
 	if err != nil {
+		// 真正的 Redis 读取故障 → 5xx；token 过期/缺失走的是 ("", nil)，由下方
+		// JsonToMap 分支按客户端错误处理。
 		f.Error("获取好友申请token的信息失败！", zap.Error(err), zap.String("key", key))
-		respondUserError(c, errcode.ErrUserDecodeFailed)
+		respondUserError(c, errcode.ErrUserTokenCacheFailed)
 		return
 	}
 	valueMap, err := util.JsonToMap(tokenVaule)
 	if err != nil {
-		f.Error("获取token信息错误", zap.Error(err), zap.String("key", key))
-		respondUserError(c, errcode.ErrUserDecodeFailed)
+		// 过期/缺失的 token 表现为空串或非法 payload —— 属客户端态（链接失效），
+		// 返回 400 而非 500，避免把"好友申请已过期"误报成服务器故障。
+		f.Warn("好友申请 token 无效或已过期", zap.Error(err), zap.String("key", key))
+		respondUserError(c, errcode.ErrUserFriendApplyInvalid)
 		return
 	}
 

--- a/modules/user/api_friend.go
+++ b/modules/user/api_friend.go
@@ -192,6 +192,7 @@ func (f *Friend) delete(c *wkhttp.Context) {
 	}()
 	version, err := f.ctx.GenSeq(common.FriendSeqKey)
 	if err != nil {
+		tx.Rollback()
 		f.Error("生成好友关系序列号失败", zap.Error(err))
 		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
@@ -368,7 +369,7 @@ func (f *Friend) friendApply(c *wkhttp.Context) {
 		} else {
 			friend, err := f.db.queryWithUID(fromUID, req.ToUID)
 			if err != nil {
-				f.Error("查询好友信息错误", zap.String("to_uid", req.ToUID))
+				f.Error("查询好友信息错误", zap.Error(err), zap.String("to_uid", req.ToUID))
 				respondUserError(c, errcode.ErrUserQueryFailed)
 				return
 			}
@@ -391,6 +392,7 @@ func (f *Friend) friendApply(c *wkhttp.Context) {
 		//验证code是否有效
 		err = source.CheckRequestAddFriendCode(req.Vercode, fromUID)
 		if err != nil {
+			f.Warn("好友申请验证码校验失败", zap.Error(err), zap.String("uid", fromUID), zap.String("toUid", req.ToUID))
 			respondUserError(c, errcode.ErrUserCodeInvalid)
 			return
 		}
@@ -443,14 +445,14 @@ func (f *Friend) friendApply(c *wkhttp.Context) {
 	// 查询好友申请记录
 	apply, err := f.db.queryApplyWithUidAndToUid(req.ToUID, fromUID)
 	if err != nil {
-		f.Error("查询好友申请记录错误", zap.String("to_uid", req.ToUID))
+		f.Error("查询好友申请记录错误", zap.Error(err), zap.String("to_uid", req.ToUID))
 		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	// 查询用户红点
 	userRedDot, err := f.userDB.queryUserRedDot(req.ToUID, UserRedDotCategoryFriendApply)
 	if err != nil {
-		f.Error("查询用户通讯录红点信息错误", zap.String("to_uid", req.ToUID))
+		f.Error("查询用户通讯录红点信息错误", zap.Error(err), zap.String("to_uid", req.ToUID))
 		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
@@ -477,7 +479,7 @@ func (f *Friend) friendApply(c *wkhttp.Context) {
 		}, tx)
 		if err != nil {
 			tx.Rollback()
-			f.Error("新增好友申请记录错误", zap.String("to_uid", req.ToUID))
+			f.Error("新增好友申请记录错误", zap.Error(err), zap.String("to_uid", req.ToUID))
 			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
@@ -489,7 +491,7 @@ func (f *Friend) friendApply(c *wkhttp.Context) {
 		err = f.db.updateApplyTx(apply, tx)
 		if err != nil {
 			tx.Rollback()
-			f.Error("修改好友申请记录错误", zap.String("to_uid", req.ToUID))
+			f.Error("修改好友申请记录错误", zap.Error(err), zap.String("to_uid", req.ToUID))
 			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
@@ -506,7 +508,7 @@ func (f *Friend) friendApply(c *wkhttp.Context) {
 		}, tx)
 		if err != nil {
 			tx.Rollback()
-			f.Error("新增用户通讯录红点信息错误", zap.String("to_uid", req.ToUID))
+			f.Error("新增用户通讯录红点信息错误", zap.Error(err), zap.String("to_uid", req.ToUID))
 			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
@@ -516,7 +518,7 @@ func (f *Friend) friendApply(c *wkhttp.Context) {
 			err = f.userDB.updateUserRedDotTx(userRedDot, tx)
 			if err != nil {
 				tx.Rollback()
-				f.Error("修改用户通讯录红点信息错误", zap.String("to_uid", req.ToUID))
+				f.Error("修改用户通讯录红点信息错误", zap.Error(err), zap.String("to_uid", req.ToUID))
 				respondUserError(c, errcode.ErrUserStoreFailed)
 				return
 			}
@@ -824,6 +826,7 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 	}()
 	version, err := f.ctx.GenSeq(common.FriendSeqKey)
 	if err != nil {
+		tx.Rollback()
 		f.Error("生成好友关系序列号失败", zap.Error(err))
 		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
@@ -832,6 +835,8 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 		// 验证code
 		err = source.CheckSource(vercode)
 		if err != nil {
+			tx.Rollback()
+			f.Warn("好友确认验证码校验失败", zap.Error(err), zap.String("uid", loginUID), zap.String("toUid", applyUID))
 			respondUserError(c, errcode.ErrUserCodeInvalid)
 			return
 		}
@@ -848,6 +853,7 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 		}, tx)
 		if err != nil {
 			tx.Rollback()
+			f.Error("保存好友关系失败", zap.Error(err), zap.String("uid", loginUID), zap.String("toUid", applyUID))
 			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
@@ -855,6 +861,7 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 		err = f.db.updateRelationshipTx(loginUID, applyUID, 0, 0, vercode, version, tx)
 		if err != nil {
 			tx.Rollback()
+			f.Error("保存好友关系失败", zap.Error(err), zap.String("uid", loginUID), zap.String("toUid", applyUID))
 			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
@@ -880,6 +887,7 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 		}, tx)
 		if err != nil {
 			tx.Rollback()
+			f.Error("保存好友关系失败", zap.Error(err), zap.String("uid", loginUID), zap.String("toUid", applyUID))
 			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
@@ -887,6 +895,7 @@ func (f *Friend) friendSure(c *wkhttp.Context) {
 		err = f.db.updateRelationshipTx(applyUID, loginUID, 0, 0, vercode, version, tx)
 		if err != nil {
 			tx.Rollback()
+			f.Error("保存好友关系失败", zap.Error(err), zap.String("uid", loginUID), zap.String("toUid", applyUID))
 			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}

--- a/modules/user/api_gitee.go
+++ b/modules/user/api_gitee.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	common "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/gin-gonic/gin"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -32,7 +33,7 @@ func (u *User) thirdAuthcode(c *wkhttp.Context) {
 	err := u.ctx.GetRedisConn().SetAndExpire(fmt.Sprintf("%s%s", ThirdAuthcodePrefix, authcode), "1", time.Minute*5)
 	if err != nil {
 		u.Error("redis set error", zap.Error(err))
-		c.ResponseError(errors.New("redis set error"))
+		respondUserError(c, errcode.ErrUserTokenCacheFailed)
 		return
 	}
 
@@ -47,11 +48,11 @@ func (u *User) thirdAuthStatus(c *wkhttp.Context) {
 	result, err := u.ctx.GetRedisConn().GetString(key)
 	if err != nil {
 		u.Error("获取登录状态失败！", zap.Error(err))
-		c.ResponseError(errors.New("获取登录状态失败！"))
+		respondUserError(c, errcode.ErrUserTokenCacheFailed)
 		return
 	}
 	if len(result) == 0 {
-		c.ResponseError(errors.New("登录状态已过期！"))
+		respondUserError(c, errcode.ErrUserOAuthStateExpired)
 		return
 	}
 	if result == "1" {
@@ -75,7 +76,8 @@ func (u *User) thirdAuthStatus(c *wkhttp.Context) {
 	var loginResp *loginUserDetailResp
 	err = util.ReadJsonByByte([]byte(result), &loginResp)
 	if err != nil {
-		c.ResponseError(err)
+		u.Error("解码第三方登录结果失败", zap.Error(err))
+		respondUserError(c, errcode.ErrUserDecodeFailed)
 		return
 	}
 	c.Response(gin.H{
@@ -97,28 +99,30 @@ func (u *User) gitee(c *wkhttp.Context) {
 func (u *User) giteeOAuth(c *wkhttp.Context) {
 	code := c.Query("code")
 	if len(code) == 0 {
-		c.ResponseError(errors.New("code不能为空"))
+		respondUserRequestInvalid(c, "code")
 		return
 	}
 	authcode := c.Query("state")
 	accessToken, err := u.requestGiteeAccessToken(code)
 	if err != nil {
-		c.ResponseError(err)
+		u.Error("获取 gitee access_token 失败", zap.Error(err))
+		respondUserError(c, errcode.ErrUserOAuthExchangeFailed)
 		return
 	}
 	userInfo, err := u.requestGiteeUserInfo(accessToken)
 	if err != nil {
-		c.ResponseError(err)
+		u.Error("获取 gitee 用户信息失败", zap.Error(err))
+		respondUserError(c, errcode.ErrUserOAuthProfileFailed)
 		return
 	}
 	if userInfo == nil {
-		c.ResponseError(errors.New("获取gitee用户信息失败"))
+		respondUserError(c, errcode.ErrUserOAuthProfileFailed)
 		return
 	}
 	userInfoM, err := u.db.queryWithGiteeUID(userInfo.Login)
 	if err != nil {
-		u.Error("查询gitee用户信息失败！", zap.String("login", userInfo.Login))
-		c.ResponseError(errors.New("查询gitee用户信息失败！"))
+		u.Error("查询gitee用户信息失败！", zap.String("login", userInfo.Login), zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	loginSpan := u.ctx.Tracer().StartSpan(
@@ -134,12 +138,13 @@ func (u *User) giteeOAuth(c *wkhttp.Context) {
 	var loginResp *loginUserDetailResp
 	if userInfoM != nil { // 存在就登录
 		if userInfoM.IsDestroy == IsDestroyDone {
-			c.ResponseError(errors.New("用户不存在"))
+			respondUserError(c, errcode.ErrUserNotFound)
 			return
 		}
 		loginResp, err = u.execLogin(userInfoM, deviceFlag, nil, loginSpanCtx)
 		if err != nil {
-			c.ResponseError(err)
+			u.Error("gitee 登录失败", zap.Error(err))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 		// 发送登录消息
@@ -157,7 +162,7 @@ func (u *User) giteeOAuth(c *wkhttp.Context) {
 			); redisErr != nil {
 				u.Error("write authcode failure marker after RegisterOff", zap.Error(redisErr))
 			}
-			c.ResponseError(errors.New("注册通道暂不开放"))
+			respondUserError(c, errcode.ErrUserRegistrationClosed)
 			return
 		}
 		// 创建用户
@@ -195,7 +200,7 @@ func (u *User) giteeOAuth(c *wkhttp.Context) {
 		tx, err := u.ctx.DB().Begin()
 		if err != nil {
 			u.Error("开启事务失败！", zap.Error(err))
-			c.ResponseError(errors.New("开启事务失败！"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 		defer func() {
@@ -209,7 +214,7 @@ func (u *User) giteeOAuth(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			u.Error("插入gitee user失败！", zap.Error(err))
-			c.ResponseError(errors.New("插入gitee user失败！"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 		// 发送登录消息
@@ -219,14 +224,15 @@ func (u *User) giteeOAuth(c *wkhttp.Context) {
 			if err != nil {
 				tx.Rollback()
 				u.Error("数据库事物提交失败", zap.Error(err))
-				c.ResponseError(errors.New("数据库事物提交失败"))
+				respondUserError(c, errcode.ErrUserStoreFailed)
 				return nil
 			}
 			return nil
 		})
 		if err != nil {
 			tx.Rollback()
-			c.ResponseError(err)
+			u.Error("创建 gitee 用户失败", zap.Error(err))
+			respondUserError(c, errcode.ErrUserRegisterFailed)
 			return
 		}
 	}
@@ -239,7 +245,7 @@ func (u *User) giteeOAuth(c *wkhttp.Context) {
 	err = u.ctx.GetRedisConn().SetAndExpire(fmt.Sprintf("%s%s", ThirdAuthcodePrefix, authcode), loginRespStr, time.Minute*1)
 	if err != nil {
 		u.Error("redis set error", zap.Error(err))
-		c.ResponseError(errors.New("redis set error"))
+		respondUserError(c, errcode.ErrUserTokenCacheFailed)
 		return
 	}
 	// 认证结果已存入 Redis，前端通过轮询获取，无需延迟响应

--- a/modules/user/api_gitee.go
+++ b/modules/user/api_gitee.go
@@ -143,8 +143,7 @@ func (u *User) giteeOAuth(c *wkhttp.Context) {
 		}
 		loginResp, err = u.execLogin(userInfoM, deviceFlag, nil, loginSpanCtx)
 		if err != nil {
-			u.Error("gitee 登录失败", zap.Error(err))
-			respondUserError(c, errcode.ErrUserStoreFailed)
+			u.respondExecLoginError(c, err, userInfoM)
 			return
 		}
 		// 发送登录消息

--- a/modules/user/api_github.go
+++ b/modules/user/api_github.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	common "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -34,28 +35,30 @@ func (u *User) github(c *wkhttp.Context) {
 func (u *User) githubOAuth(c *wkhttp.Context) {
 	code := c.Query("code")
 	if len(code) == 0 {
-		c.ResponseError(errors.New("code不能为空"))
+		respondUserRequestInvalid(c, "code")
 		return
 	}
 	authcode := c.Query("state")
 	accessToken, err := u.requestGithubAccessToken(code)
 	if err != nil {
-		c.ResponseError(err)
+		u.Error("获取 github access_token 失败", zap.Error(err))
+		respondUserError(c, errcode.ErrUserOAuthExchangeFailed)
 		return
 	}
 	userInfo, err := u.requestGithubUserInfo(accessToken)
 	if err != nil {
-		c.ResponseError(err)
+		u.Error("获取 github 用户信息失败", zap.Error(err))
+		respondUserError(c, errcode.ErrUserOAuthProfileFailed)
 		return
 	}
 	if userInfo == nil {
-		c.ResponseError(errors.New("获取github用户信息失败"))
+		respondUserError(c, errcode.ErrUserOAuthProfileFailed)
 		return
 	}
 	userInfoM, err := u.db.queryWithGithubUID(userInfo.Login)
 	if err != nil {
-		u.Error("查询github用户信息失败！", zap.String("login", userInfo.Login))
-		c.ResponseError(errors.New("查询github用户信息失败！"))
+		u.Error("查询github用户信息失败！", zap.String("login", userInfo.Login), zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	loginSpan := u.ctx.Tracer().StartSpan(
@@ -71,12 +74,13 @@ func (u *User) githubOAuth(c *wkhttp.Context) {
 	var loginResp *loginUserDetailResp
 	if userInfoM != nil { // 存在就登录
 		if userInfoM.IsDestroy == IsDestroyDone {
-			c.ResponseError(errors.New("用户不存在"))
+			respondUserError(c, errcode.ErrUserNotFound)
 			return
 		}
 		loginResp, err = u.execLogin(userInfoM, deviceFlag, nil, loginSpanCtx)
 		if err != nil {
-			c.ResponseError(err)
+			u.Error("github 登录失败", zap.Error(err))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 		// 发送登录消息
@@ -93,7 +97,7 @@ func (u *User) githubOAuth(c *wkhttp.Context) {
 			); redisErr != nil {
 				u.Error("write authcode failure marker after RegisterOff", zap.Error(redisErr))
 			}
-			c.ResponseError(errors.New("注册通道暂不开放"))
+			respondUserError(c, errcode.ErrUserRegistrationClosed)
 			return
 		}
 		// 创建用户
@@ -131,7 +135,7 @@ func (u *User) githubOAuth(c *wkhttp.Context) {
 		tx, err := u.ctx.DB().Begin()
 		if err != nil {
 			u.Error("开启事务失败！", zap.Error(err))
-			c.ResponseError(errors.New("开启事务失败！"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 		defer func() {
@@ -145,7 +149,7 @@ func (u *User) githubOAuth(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			u.Error("插入gitee user失败！", zap.Error(err))
-			c.ResponseError(errors.New("插入gitee user失败！"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 		// 发送登录消息
@@ -155,14 +159,15 @@ func (u *User) githubOAuth(c *wkhttp.Context) {
 			if err != nil {
 				tx.Rollback()
 				u.Error("数据库事物提交失败", zap.Error(err))
-				c.ResponseError(errors.New("数据库事物提交失败"))
+				respondUserError(c, errcode.ErrUserStoreFailed)
 				return nil
 			}
 			return nil
 		})
 		if err != nil {
 			tx.Rollback()
-			c.ResponseError(err)
+			u.Error("创建 github 用户失败", zap.Error(err))
+			respondUserError(c, errcode.ErrUserRegisterFailed)
 			return
 		}
 	}
@@ -175,7 +180,7 @@ func (u *User) githubOAuth(c *wkhttp.Context) {
 	err = u.ctx.GetRedisConn().SetAndExpire(fmt.Sprintf("%s%s", ThirdAuthcodePrefix, authcode), loginRespStr, time.Minute*1)
 	if err != nil {
 		u.Error("redis set error", zap.Error(err))
-		c.ResponseError(errors.New("redis set error"))
+		respondUserError(c, errcode.ErrUserTokenCacheFailed)
 		return
 	}
 	// 认证结果已存入 Redis，前端通过轮询获取，无需延迟响应

--- a/modules/user/api_github.go
+++ b/modules/user/api_github.go
@@ -79,8 +79,7 @@ func (u *User) githubOAuth(c *wkhttp.Context) {
 		}
 		loginResp, err = u.execLogin(userInfoM, deviceFlag, nil, loginSpanCtx)
 		if err != nil {
-			u.Error("github 登录失败", zap.Error(err))
-			respondUserError(c, errcode.ErrUserStoreFailed)
+			u.respondExecLoginError(c, err, userInfoM)
 			return
 		}
 		// 发送登录消息

--- a/modules/user/api_i18n.go
+++ b/modules/user/api_i18n.go
@@ -74,6 +74,10 @@ func respondUserLockMinuteOutOfRange(c *wkhttp.Context) {
 // than silently rendering an empty envelope at request time.
 var errSharedAuthRequired = mustLookupSharedCode("err.shared.auth.required")
 
+// errSharedForbidden caches the shared 403 code used by the manager role
+// guards (CheckLoginRole / CheckLoginRoleIsSuperAdmin).
+var errSharedForbidden = mustLookupSharedCode("err.shared.auth.forbidden")
+
 func mustLookupSharedCode(id string) codes.Code {
 	c, ok := codes.Lookup(id)
 	if !ok {
@@ -101,4 +105,26 @@ func respondUserNotLoggedIn(c *wkhttp.Context) {
 // layer sentinel extraction is deferred (TODOS L219 follow-up).
 func respondUserServiceError(c *wkhttp.Context) {
 	httperr.ResponseErrorL(c, errcode.ErrUserStoreFailed, nil, nil)
+}
+
+// respondManagerForbidden renders the shared 403 envelope for the management
+// console role guards. wkhttp's CheckLoginRole / CheckLoginRoleIsSuperAdmin
+// return a plain Chinese error ("登录用户角色错误" / "该用户无权执行此操作");
+// both are authorization failures, so they collapse to err.shared.auth.forbidden
+// rather than leaking the raw framework string on the wire. This raises the
+// legacy HTTP 400 to a semantically-correct 403 (consistent with the rest of
+// the Phase 2.1 status-code migration).
+func respondManagerForbidden(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errSharedForbidden, nil, nil)
+}
+
+// respondUserListFilterConflict reports a pair of mutually-exclusive list
+// filters (e.g. bot_only + exclude_bot). The offending filter and the one it
+// conflicts with are surfaced as details so a frontend dev can spot the bad
+// query construction.
+func respondUserListFilterConflict(c *wkhttp.Context, filter, conflictsWith string) {
+	httperr.ResponseErrorL(c, errcode.ErrUserListFilterConflict, nil, i18n.Details{
+		"filter":         filter,
+		"conflicts_with": conflictsWith,
+	})
 }

--- a/modules/user/api_i18n.go
+++ b/modules/user/api_i18n.go
@@ -118,6 +118,12 @@ func respondManagerForbidden(c *wkhttp.Context) {
 	httperr.ResponseErrorL(c, errSharedForbidden, nil, nil)
 }
 
+// respondUserPinnedLimitExceeded surfaces the per-space pinned-channel cap so
+// the client can render a localized hint without hard-coding the limit.
+func respondUserPinnedLimitExceeded(c *wkhttp.Context, max int) {
+	httperr.ResponseErrorL(c, errcode.ErrUserPinnedLimitExceeded, nil, i18n.Details{"max": max})
+}
+
 // respondUserListFilterConflict reports a pair of mutually-exclusive list
 // filters (e.g. bot_only + exclude_bot). The offending filter and the one it
 // conflicts with are surfaced as details so a frontend dev can spot the bad

--- a/modules/user/api_i18n_test.go
+++ b/modules/user/api_i18n_test.go
@@ -44,6 +44,33 @@ func TestUserAPINoLegacyResponseError(t *testing.T) {
 	}
 }
 
+// TestManagerAPINoLegacyResponseError pins the post-Phase-2.1 contract that
+// modules/user/api_manager.go does not regress to legacy octo-lib error
+// responses (the management console migration). Mirrors the api.go guard
+// above; also forbids the `c.Response("<string>")` shape that two handlers
+// used to (mis)use as an error path — those returned HTTP 200 with a bare
+// string body and are now proper httperr.ResponseErrorL envelopes.
+func TestManagerAPINoLegacyResponseError(t *testing.T) {
+	data, err := os.ReadFile("api_manager.go")
+	if err != nil {
+		t.Fatalf("read api_manager.go: %v", err)
+	}
+	var clean strings.Builder
+	for _, line := range strings.Split(string(data), "\n") {
+		if idx := strings.Index(line, "//"); idx >= 0 {
+			line = line[:idx]
+		}
+		clean.WriteString(line)
+		clean.WriteByte('\n')
+	}
+	cleaned := clean.String()
+	for _, banned := range []string{".ResponseError(", ".ResponseErrorf("} {
+		if strings.Contains(cleaned, banned) {
+			t.Fatalf("modules/user/api_manager.go must use httperr.ResponseErrorL via respond* helpers instead of legacy %s", banned)
+		}
+	}
+}
+
 // helperHarness mounts a single GET /probe route that invokes the supplied
 // helper. Tests exercise the helper directly without paying the DB / auth
 // setup cost — the contract we care about is what the wkhttp envelope
@@ -224,6 +251,77 @@ func TestRespondUserHelpers(t *testing.T) {
 			wantTransStatus: http.StatusBadRequest,
 			wantContains:    "服务器内部错误",
 			wantNotContains: "WeChat",
+		},
+
+		// ---- Phase 2.1 api_manager.go migration helpers / codes ----
+		{
+			name:            "respondManagerForbidden routes to shared.auth.forbidden",
+			probe:           func(c *wkhttp.Context) { respondManagerForbidden(c) },
+			wantCodeID:      "err.shared.auth.forbidden",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "无权执行此操作",
+		},
+		{
+			name: "respondUserListFilterConflict carries both filter names",
+			probe: func(c *wkhttp.Context) {
+				respondUserListFilterConflict(c, "bot_only", "exclude_bot")
+			},
+			wantCodeID:      "err.server.user.list_filter_conflict",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "互斥",
+			wantDetails:     map[string]any{"filter": "bot_only", "conflicts_with": "exclude_bot"},
+		},
+		{
+			name:            "ErrUserManagerPermissionRequired surfaces zh-CN copy",
+			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserManagerPermissionRequired) },
+			wantCodeID:      "err.server.user.manager_permission_required",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "未开通管理权限",
+		},
+		{
+			name:            "ErrUserPasswordTooShort surfaces zh-CN copy",
+			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserPasswordTooShort) },
+			wantCodeID:      "err.server.user.password_too_short",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "密码长度必须大于",
+		},
+		{
+			name:            "ErrUserOldPasswordIncorrect surfaces zh-CN copy",
+			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserOldPasswordIncorrect) },
+			wantCodeID:      "err.server.user.old_password_incorrect",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "原密码错误",
+		},
+		{
+			name:            "ErrUserCannotDeleteSuperAdmin surfaces zh-CN copy",
+			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserCannotDeleteSuperAdmin) },
+			wantCodeID:      "err.server.user.cannot_delete_super_admin",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "超级管理员账号不能删除",
+		},
+		{
+			name:            "ErrUserTokenCacheFailed (Internal=true) collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserTokenCacheFailed) },
+			wantCodeID:      "err.server.user.token_cache_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "session token",
+		},
+		{
+			name:            "ErrUserShortNoGenFailed (Internal=true) collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserShortNoGenFailed) },
+			wantCodeID:      "err.server.user.short_no_gen_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "short ID",
 		},
 	}
 

--- a/modules/user/api_i18n_test.go
+++ b/modules/user/api_i18n_test.go
@@ -437,6 +437,14 @@ func TestRespondUserHelpers(t *testing.T) {
 			wantTransStatus: http.StatusBadRequest,
 			wantContains:    "已注销或被禁用",
 		},
+		{
+			name:            "ErrUserEmailRateLimited surfaces 429 client-actionable copy (not Internal)",
+			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserEmailRateLimited) },
+			wantCodeID:      "err.server.user.email_rate_limited",
+			wantSemStatus:   http.StatusTooManyRequests,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "发送过于频繁",
+		},
 	}
 
 	for _, tc := range cases {

--- a/modules/user/api_i18n_test.go
+++ b/modules/user/api_i18n_test.go
@@ -71,6 +71,42 @@ func TestManagerAPINoLegacyResponseError(t *testing.T) {
 	}
 }
 
+// TestMigratedUserFilesNoLegacyResponseError pins the Phase 2.1 contract that
+// the remaining migrated modules/user handlers do not regress to legacy
+// octo-lib error responses. Comments are stripped first so commented-out
+// breadcrumbs do not trip the guard. New handler files that still rely on
+// c.ResponseError / c.ResponseErrorf must NOT be added to this list — migrate
+// them instead.
+func TestMigratedUserFilesNoLegacyResponseError(t *testing.T) {
+	files := []string{
+		"api_friend.go", "api_online.go", "api_setting.go", "api_maillist.go",
+		"api_device.go", "api_destroy.go", "api_pinned.go", "api_gitee.go",
+		"api_github.go", "api_emaillogin.go", "api_usernamelogin.go",
+	}
+	for _, f := range files {
+		t.Run(f, func(t *testing.T) {
+			data, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+			var clean strings.Builder
+			for _, line := range strings.Split(string(data), "\n") {
+				if idx := strings.Index(line, "//"); idx >= 0 {
+					line = line[:idx]
+				}
+				clean.WriteString(line)
+				clean.WriteByte('\n')
+			}
+			cleaned := clean.String()
+			for _, banned := range []string{".ResponseError(", ".ResponseErrorf("} {
+				if strings.Contains(cleaned, banned) {
+					t.Fatalf("modules/user/%s must use httperr.ResponseErrorL via respond* helpers instead of legacy %s", f, banned)
+				}
+			}
+		})
+	}
+}
+
 // helperHarness mounts a single GET /probe route that invokes the supplied
 // helper. Tests exercise the helper directly without paying the DB / auth
 // setup cost — the contract we care about is what the wkhttp envelope
@@ -322,6 +358,84 @@ func TestRespondUserHelpers(t *testing.T) {
 			wantTransStatus: http.StatusBadRequest,
 			wantContains:    "服务器内部错误",
 			wantNotContains: "short ID",
+		},
+
+		// ---- Phase 2.1 pinned / oauth / web3 / email codes ----
+		{
+			name: "respondUserPinnedLimitExceeded carries the max detail",
+			probe: func(c *wkhttp.Context) {
+				respondUserPinnedLimitExceeded(c, 7)
+			},
+			wantCodeID:      "err.server.user.pinned_limit_exceeded",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "置顶频道数量已达上限",
+			wantDetails:     map[string]any{"max": float64(7)},
+		},
+		{
+			name:            "ErrUserChannelAccessDenied surfaces 403 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserChannelAccessDenied) },
+			wantCodeID:      "err.server.user.channel_access_denied",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "无权访问该频道",
+		},
+		{
+			name:            "ErrUserOAuthStateExpired surfaces zh-CN copy",
+			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserOAuthStateExpired) },
+			wantCodeID:      "err.server.user.oauth_state_expired",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "登录状态已过期",
+		},
+		{
+			name:            "ErrUserOAuthExchangeFailed (Internal=true, 502) collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserOAuthExchangeFailed) },
+			wantCodeID:      "err.server.user.oauth_exchange_failed",
+			wantSemStatus:   http.StatusBadGateway,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "OAuth",
+		},
+		{
+			name:            "ErrUserUsernameFormatInvalid surfaces zh-CN copy",
+			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserUsernameFormatInvalid) },
+			wantCodeID:      "err.server.user.username_format_invalid",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "用户名必须为",
+		},
+		{
+			name:            "ErrUserPublicKeyNotFound surfaces zh-CN copy",
+			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserPublicKeyNotFound) },
+			wantCodeID:      "err.server.user.public_key_not_found",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "未上传公钥",
+		},
+		{
+			name:            "ErrUserSignatureInvalid surfaces zh-CN copy",
+			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserSignatureInvalid) },
+			wantCodeID:      "err.server.user.signature_invalid",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "签名校验失败",
+		},
+		{
+			name:            "ErrUserEmailInvalid surfaces zh-CN copy",
+			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserEmailInvalid) },
+			wantCodeID:      "err.server.user.email_invalid",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "邮箱格式不正确",
+		},
+		{
+			name:            "ErrUserAccountUnavailable surfaces 403 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserAccountUnavailable) },
+			wantCodeID:      "err.server.user.account_unavailable",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "已注销或被禁用",
 		},
 	}
 

--- a/modules/user/api_i18n_test.go
+++ b/modules/user/api_i18n_test.go
@@ -37,7 +37,7 @@ func TestUserAPINoLegacyResponseError(t *testing.T) {
 		clean.WriteByte('\n')
 	}
 	cleaned := clean.String()
-	for _, banned := range []string{".ResponseError(", ".ResponseErrorf("} {
+	for _, banned := range []string{".ResponseError(", ".ResponseErrorf(", "c.Response(\""} {
 		if strings.Contains(cleaned, banned) {
 			t.Fatalf("modules/user/api.go must use httperr.ResponseErrorL via respondUser* helpers instead of legacy %s", banned)
 		}
@@ -64,7 +64,7 @@ func TestManagerAPINoLegacyResponseError(t *testing.T) {
 		clean.WriteByte('\n')
 	}
 	cleaned := clean.String()
-	for _, banned := range []string{".ResponseError(", ".ResponseErrorf("} {
+	for _, banned := range []string{".ResponseError(", ".ResponseErrorf(", "c.Response(\""} {
 		if strings.Contains(cleaned, banned) {
 			t.Fatalf("modules/user/api_manager.go must use httperr.ResponseErrorL via respond* helpers instead of legacy %s", banned)
 		}
@@ -98,7 +98,7 @@ func TestMigratedUserFilesNoLegacyResponseError(t *testing.T) {
 				clean.WriteByte('\n')
 			}
 			cleaned := clean.String()
-			for _, banned := range []string{".ResponseError(", ".ResponseErrorf("} {
+			for _, banned := range []string{".ResponseError(", ".ResponseErrorf(", "c.Response(\""} {
 				if strings.Contains(cleaned, banned) {
 					t.Fatalf("modules/user/%s must use httperr.ResponseErrorL via respond* helpers instead of legacy %s", f, banned)
 				}

--- a/modules/user/api_maillist.go
+++ b/modules/user/api_maillist.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
-	"github.com/pkg/errors"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"go.uber.org/zap"
 )
 
@@ -18,7 +18,7 @@ func (u *User) addMaillist(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	var req []*mailListReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	result := make([]*mailListResp, 0)
@@ -28,13 +28,14 @@ func (u *User) addMaillist(c *wkhttp.Context) {
 	}
 	loginUser, err := u.db.QueryByUID(loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("查询登录用户信息错误"))
+		u.Error("查询登录用户信息错误", zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	tx, err := u.db.session.Begin()
 	if err != nil {
 		u.Error("数据库事物开启失败", zap.Error(err))
-		c.ResponseError(errors.New("数据库事物开启失败"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	defer func() {
@@ -58,8 +59,8 @@ func (u *User) addMaillist(c *wkhttp.Context) {
 		}, tx)
 		if err != nil {
 			tx.RollbackUnlessCommitted()
-			u.Error("添加用户通讯录联系人错误")
-			c.ResponseError(errors.New("添加用户通讯录联系人错误"))
+			u.Error("添加用户通讯录联系人错误", zap.Error(err))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 	}
@@ -67,7 +68,7 @@ func (u *User) addMaillist(c *wkhttp.Context) {
 	if err != nil {
 		tx.Rollback()
 		u.Error("数据库事物提交失败", zap.Error(err))
-		c.ResponseError(errors.New("数据库事物提交失败"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	c.ResponseOK()
@@ -79,8 +80,8 @@ func (u *User) getMailList(c *wkhttp.Context) {
 	result := make([]*mailListResp, 0)
 	mailLists, err := u.maillistDB.query(loginUID)
 	if err != nil {
-		u.Error("查询用户通讯录数据错误")
-		c.ResponseError(errors.New("查询用户通讯录数据错误"))
+		u.Error("查询用户通讯录数据错误", zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if mailLists == nil {
@@ -93,14 +94,14 @@ func (u *User) getMailList(c *wkhttp.Context) {
 	}
 	users, err := u.db.QueryByPhones(phones)
 	if err != nil {
-		u.Error("批量查询用户信息错误")
-		c.ResponseError(errors.New("批量查询用户信息错误"))
+		u.Error("批量查询用户信息错误", zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	friends, err := u.friendDB.QueryFriends(loginUID)
 	if err != nil {
-		u.Error("查询用户好友错误")
-		c.ResponseError(errors.New("查询用户好友错误"))
+		u.Error("查询用户好友错误", zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	for _, m := range mailLists {

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -514,6 +514,7 @@ func (m *Manager) addUser(c *wkhttp.Context) {
 	userModel.Zone = req.Zone
 	hashedPassword, err := HashPassword(req.Password)
 	if err != nil {
+		tx.Rollback()
 		m.Error("密码哈希失败", zap.Error(err))
 		respondUserError(c, errcode.ErrUserPasswordProcessFailed)
 		return

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	common2 "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	wkutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
 
@@ -81,18 +82,18 @@ func (m *Manager) Route(r *wkhttp.WKHttp) {
 func (m *Manager) devices(c *wkhttp.Context) {
 	err := c.CheckLoginRole()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 	uid := c.Query("uid")
 	if uid == "" {
-		c.ResponseError(errors.New("请求用户uid不能为空"))
+		respondUserRequestInvalid(c, "uid")
 		return
 	}
 	devices, err := m.deviceDB.queryDeviceWithUID(uid)
 	if err != nil {
 		m.Error("查询用户设备列表错误", zap.Error(err))
-		c.ResponseError(errors.New("查询用户设备列表错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	list := make([]*managerDeviceResp, 0)
@@ -115,18 +116,18 @@ func (m *Manager) devices(c *wkhttp.Context) {
 func (m *Manager) online(c *wkhttp.Context) {
 	err := c.CheckLoginRole()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 	uid := c.Query("uid")
 	if uid == "" {
-		c.ResponseError(errors.New("请求用户uid不能为空"))
+		respondUserRequestInvalid(c, "uid")
 		return
 	}
 	list, err := m.db.queryUserOnline(uid)
 	if err != nil {
 		m.Error("查询用户在线设备信息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询用户在线设备信息错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	result := make([]*userOnlineResp, 0)
@@ -164,26 +165,30 @@ func (m *Manager) online(c *wkhttp.Context) {
 func (m *Manager) login(c *wkhttp.Context) {
 	var req managerLoginReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if err := req.Check(); err != nil {
-		c.ResponseError(err)
+		// managerLoginReq.Check returns "用户名/密码不能为空"; both are pure
+		// client-side input gaps with no field tagging (matches /v1/user login).
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	userInfo, err := m.db.queryUserInfoWithNameAndPwd(req.Username)
 	if err != nil {
 		m.Error("登录错误", zap.Error(err))
-		c.ResponseError(errors.New("登录错误！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
+	// 登录失败统一返回 ErrUserInvalidCredentials，避免攻击者通过"用户不存在"
+	// 与"密码错误"的响应差异枚举有效管理账号（与 /v1/user login 反枚举一致）。
 	if userInfo == nil || userInfo.UID == "" {
-		c.ResponseError(errors.New("登录用户不存在"))
+		respondUserError(c, errcode.ErrUserInvalidCredentials)
 		return
 	}
 	matched, needsMigration := CheckPassword(req.Password, userInfo.Password)
 	if !matched {
-		c.ResponseError(errors.New("用户名或密码错误"))
+		respondUserError(c, errcode.ErrUserInvalidCredentials)
 		return
 	}
 	// 自动将旧 MD5 密码迁移到 bcrypt
@@ -193,7 +198,7 @@ func (m *Manager) login(c *wkhttp.Context) {
 		}
 	}
 	if userInfo.Role != string(wkhttp.Admin) && userInfo.Role != string(wkhttp.SuperAdmin) {
-		c.ResponseError(errors.New("登录账号未开通管理权限"))
+		respondUserError(c, errcode.ErrUserManagerPermissionRequired)
 		return
 	}
 	token := util.GenerUUID()
@@ -206,20 +211,20 @@ func (m *Manager) login(c *wkhttp.Context) {
 	})
 	if err != nil {
 		m.Error("编码token缓存失败！", zap.Error(err))
-		c.ResponseError(errors.New("设置token缓存失败！"))
+		respondUserError(c, errcode.ErrUserTokenCacheFailed)
 		return
 	}
 	err = m.ctx.Cache().SetAndExpire(m.ctx.GetConfig().Cache.TokenCachePrefix+token, tokenPayload, m.ctx.GetConfig().Cache.TokenExpire)
 	if err != nil {
 		m.Error("设置token缓存失败！", zap.Error(err))
-		c.ResponseError(errors.New("设置token缓存失败！"))
+		respondUserError(c, errcode.ErrUserTokenCacheFailed)
 		return
 	}
 
 	err = m.ctx.Cache().SetAndExpire(fmt.Sprintf("%s%d%s", m.ctx.GetConfig().Cache.UIDTokenCachePrefix, config.Web, userInfo.UID), token, m.ctx.GetConfig().Cache.TokenExpire)
 	if err != nil {
 		m.Error("设置uidtoken缓存失败！", zap.Error(err))
-		c.ResponseError(errors.New("设置token缓存失败！"))
+		respondUserError(c, errcode.ErrUserTokenCacheFailed)
 		return
 	}
 
@@ -235,7 +240,7 @@ func (m *Manager) login(c *wkhttp.Context) {
 func (m *Manager) resetUserPassword(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 
@@ -246,42 +251,42 @@ func (m *Manager) resetUserPassword(c *wkhttp.Context) {
 	}
 	var req reqRUP
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if len(req.NewPassword) < 6 {
-		c.ResponseError(errors.New("密码长度必须大于6位"))
+		respondUserError(c, errcode.ErrUserPasswordTooShort)
 		return
 	}
 	if req.NewPassword != req.NewPassswordConfirmation {
-		c.ResponseError(errors.New("两次密码不一致！"))
+		respondUserError(c, errcode.ErrUserPasswordMismatch)
 		return
 	}
 	if req.Uid == "" {
-		c.ResponseError(errors.New("用户uid不能为空！"))
+		respondUserRequestInvalid(c, "uid")
 		return
 	}
 	user, err := m.userDB.QueryByUID(req.Uid)
 	if err != nil {
 		m.Error("查询用户信息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询用户信息错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if user == nil {
-		c.ResponseError(errors.New("操作用户不存在"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 
 	newHash, hashErr := HashPassword(req.NewPassword)
 	if hashErr != nil {
 		m.Error("密码哈希失败", zap.Error(hashErr))
-		c.ResponseError(errors.New("密码处理失败"))
+		respondUserError(c, errcode.ErrUserPasswordProcessFailed)
 		return
 	}
 	err = m.userDB.UpdateUsersWithField("password", newHash, req.Uid)
 	if err != nil {
 		m.Error("重置用户密码错误", zap.Error(err))
-		c.Response("重置用户密码错误")
+		respondUserError(c, errcode.ErrUserLoginPwdUpdateFailed)
 		return
 	}
 	c.ResponseOK()
@@ -291,49 +296,49 @@ func (m *Manager) resetUserPassword(c *wkhttp.Context) {
 func (m *Manager) deleteAdminUsers(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 	uid := c.Query("uid")
 	if uid == "" {
-		c.ResponseError(errors.New("删除用户uid不能为空"))
+		respondUserRequestInvalid(c, "uid")
 		return
 	}
 	user, err := m.userDB.QueryByUID(uid)
 	if err != nil {
 		m.Error("查询管理员用户错误", zap.Error(err))
-		c.ResponseError(errors.New("查询管理员用户错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if user == nil || len(user.UID) == 0 {
-		c.ResponseError(errors.New("该用户不存在"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 	if user.Role == "" {
-		c.ResponseError(errors.New("该用户不是管理员账号不能删除"))
+		respondUserError(c, errcode.ErrUserNotAdminAccount)
 		return
 	}
 	if user.Role == string(wkhttp.SuperAdmin) {
-		c.ResponseError(errors.New("超级管理员账号不能删除"))
+		respondUserError(c, errcode.ErrUserCannotDeleteSuperAdmin)
 		return
 	}
 	err = m.db.deleteUserWithUIDAndRole(uid, string(wkhttp.Admin))
 	if err != nil {
 		m.Error("删除管理员错误", zap.Error(err))
-		c.ResponseError(errors.New("删除管理员错误"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	oldToken, err := m.ctx.Cache().Get(fmt.Sprintf("%s%d%s", m.ctx.GetConfig().Cache.UIDTokenCachePrefix, config.Web, user.UID))
 	if err != nil {
 		m.Error("获取旧token错误", zap.Error(err))
-		c.ResponseError(errors.New("获取旧token错误"))
+		respondUserError(c, errcode.ErrUserTokenCacheFailed)
 		return
 	}
 	if oldToken != "" {
 		err = m.ctx.Cache().Delete(m.ctx.GetConfig().Cache.TokenCachePrefix + oldToken)
 		if err != nil {
 			m.Error("清除旧token数据错误", zap.Error(err))
-			c.ResponseError(errors.New("清除旧token数据错误"))
+			respondUserError(c, errcode.ErrUserTokenCacheFailed)
 			return
 		}
 	}
@@ -344,13 +349,13 @@ func (m *Manager) deleteAdminUsers(c *wkhttp.Context) {
 func (m *Manager) getAdminUsers(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 	users, err := m.db.queryUsersWithRole(string(wkhttp.Admin))
 	if err != nil {
 		m.Error("查询管理员用户错误", zap.Error(err))
-		c.ResponseError(errors.New("查询管理员用户错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	list := make([]*adminUserResp, 0)
@@ -371,7 +376,7 @@ func (m *Manager) getAdminUsers(c *wkhttp.Context) {
 func (m *Manager) addAdminUser(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 	type reqVO struct {
@@ -381,33 +386,33 @@ func (m *Manager) addAdminUser(c *wkhttp.Context) {
 	}
 	var req reqVO
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if req.LoginName == "" {
-		c.ResponseError(errors.New("登录用户名不能为空"))
+		respondUserRequestInvalid(c, "login_name")
 		return
 	}
 	if req.Name == "" {
-		c.ResponseError(errors.New("用户名不能为空"))
+		respondUserRequestInvalid(c, "name")
 		return
 	}
 	if err := ValidateName(req.Name); err != nil {
-		c.ResponseError(err)
+		respondUserRequestInvalid(c, "name")
 		return
 	}
 	if req.Password == "" {
-		c.ResponseError(errors.New("密码不能为空"))
+		respondUserRequestInvalid(c, "password")
 		return
 	}
 	user, err := m.db.queryUserWithNameAndRole(req.LoginName, string(wkhttp.Admin))
 	if err != nil {
 		m.Error("查询用户是否存在错误", zap.String("username", req.LoginName))
-		c.ResponseError(errors.New("查询用户是否存在错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if user != nil && len(user.UID) > 0 {
-		c.ResponseError(errors.New("该用户名已存在"))
+		respondUserError(c, errcode.ErrUserAlreadyExists)
 		return
 	}
 	userModel := &Model{}
@@ -422,7 +427,7 @@ func (m *Manager) addAdminUser(c *wkhttp.Context) {
 	hashedPassword, err := HashPassword(req.Password)
 	if err != nil {
 		m.Error("密码哈希失败", zap.Error(err))
-		c.ResponseError(errors.New("密码处理失败"))
+		respondUserError(c, errcode.ErrUserPasswordProcessFailed)
 		return
 	}
 	userModel.Password = hashedPassword
@@ -438,8 +443,8 @@ func (m *Manager) addAdminUser(c *wkhttp.Context) {
 	userModel.Status = int(common.UserAvailable)
 	err = m.userDB.Insert(userModel)
 	if err != nil {
-		m.Error("添加管理员错误", zap.String("username", req.Name))
-		c.ResponseError(err)
+		m.Error("添加管理员错误", zap.String("username", req.Name), zap.Error(err))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	c.ResponseOK()
@@ -449,26 +454,26 @@ func (m *Manager) addAdminUser(c *wkhttp.Context) {
 func (m *Manager) addUser(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 	var req managerAddUserReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if err := req.checkAddUserReq(); err != nil {
-		c.ResponseError(err)
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	userInfo, err := m.userDB.QueryByUsername(fmt.Sprintf("%s%s", req.Zone, req.Phone))
 	if err != nil {
-		m.Error("查询用户信息失败！", zap.String("username", req.Phone))
-		c.ResponseError(err)
+		m.Error("查询用户信息失败！", zap.String("username", req.Phone), zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userInfo != nil {
-		c.ResponseError(errors.New("该用户已存在"))
+		respondUserError(c, errcode.ErrUserAlreadyExists)
 		return
 	}
 	uid := util.GenerUUID()
@@ -478,7 +483,7 @@ func (m *Manager) addUser(c *wkhttp.Context) {
 		shortNo, err = m.commonService.GetShortno()
 		if err != nil {
 			m.Error("获取短编号失败！", zap.Error(err))
-			c.ResponseError(errors.New("获取短编号失败！"))
+			respondUserError(c, errcode.ErrUserShortNoGenFailed)
 			return
 		}
 	} else {
@@ -490,7 +495,7 @@ func (m *Manager) addUser(c *wkhttp.Context) {
 	tx, err := m.db.session.Begin()
 	if err != nil {
 		m.Error("开启事物错误", zap.Error(err))
-		c.ResponseError(errors.New("开启事物错误"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	defer func() {
@@ -510,7 +515,7 @@ func (m *Manager) addUser(c *wkhttp.Context) {
 	hashedPassword, err := HashPassword(req.Password)
 	if err != nil {
 		m.Error("密码哈希失败", zap.Error(err))
-		c.ResponseError(errors.New("密码处理失败"))
+		respondUserError(c, errcode.ErrUserPasswordProcessFailed)
 		return
 	}
 	userModel.Password = hashedPassword
@@ -528,21 +533,23 @@ func (m *Manager) addUser(c *wkhttp.Context) {
 	err = m.userDB.insertTx(userModel, tx)
 	if err != nil {
 		tx.Rollback()
-		m.Error("添加用户错误", zap.String("username", req.Phone))
-		c.ResponseError(err)
+		m.Error("添加用户错误", zap.String("username", req.Phone), zap.Error(err))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 
 	err = m.addSystemFriend(uid)
 	if err != nil {
 		tx.Rollback()
-		c.ResponseError(errors.New("添加后台生成用户和系统账号为好友关系失败"))
+		m.Error("添加后台生成用户和系统账号为好友关系失败", zap.Error(err))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	err = m.addFileHelperFriend(uid)
 	if err != nil {
 		tx.Rollback()
-		c.ResponseError(errors.New("添加后台生成用户和文件助手为好友关系失败"))
+		m.Error("添加后台生成用户和文件助手为好友关系失败", zap.Error(err))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	//发送用户注册事件
@@ -556,14 +563,14 @@ func (m *Manager) addUser(c *wkhttp.Context) {
 	if err != nil {
 		tx.RollbackUnlessCommitted()
 		m.Error("开启事件失败！", zap.Error(err))
-		c.ResponseError(errors.New("开启事件失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	err = tx.Commit()
 	if err != nil {
 		tx.Rollback()
 		m.Error("数据库事物提交失败", zap.Error(err))
-		c.ResponseError(errors.New("数据库事物提交失败"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	m.ctx.EventCommit(eventID)
@@ -574,7 +581,7 @@ func (m *Manager) addUser(c *wkhttp.Context) {
 func (m *Manager) list(c *wkhttp.Context) {
 	err := c.CheckLoginRole()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 	keyword := c.Query("keyword")
@@ -596,11 +603,11 @@ func (m *Manager) list(c *wkhttp.Context) {
 	// 是逻辑矛盾，会得到空结果集。返回 400 让前端及早发现 query 构造 bug，
 	// 比静默返回空更好。允许 bot_only + system_only（交集语义清晰）。
 	if filter.BotOnly && filter.ExcludeBot {
-		c.ResponseError(errors.New("bot_only 与 exclude_bot 互斥"))
+		respondUserListFilterConflict(c, "bot_only", "exclude_bot")
 		return
 	}
 	if filter.SystemOnly && filter.ExcludeSystem {
-		c.ResponseError(errors.New("system_only 与 exclude_system 互斥"))
+		respondUserListFilterConflict(c, "system_only", "exclude_system")
 		return
 	}
 	pageIndex, pageSize := c.GetPage()
@@ -610,28 +617,28 @@ func (m *Manager) list(c *wkhttp.Context) {
 		userList, err = m.db.queryUserListWithPage(uint64(pageSize), uint64(pageIndex), filter)
 		if err != nil {
 			m.Error("查询用户列表报错", zap.Error(err))
-			c.ResponseError(err)
+			respondUserError(c, errcode.ErrUserQueryFailed)
 			return
 		}
 
 		count, err = m.db.queryUserCount(filter)
 		if err != nil {
 			m.Error("查询用户数量错误", zap.Error(err))
-			c.ResponseError(errors.New("查询用户数量错误"))
+			respondUserError(c, errcode.ErrUserQueryFailed)
 			return
 		}
 	} else {
 		userList, err = m.db.queryUserListWithPageAndKeyword(keyword, uint64(pageSize), uint64(pageIndex), filter)
 		if err != nil {
 			m.Error("查询用户列表报错", zap.Error(err))
-			c.ResponseError(err)
+			respondUserError(c, errcode.ErrUserQueryFailed)
 			return
 		}
 
 		count, err = m.db.queryUserCountWithKeyWord(keyword, filter)
 		if err != nil {
 			m.Error("查询用户数量错误", zap.Error(err))
-			c.ResponseError(errors.New("查询用户数量错误"))
+			respondUserError(c, errcode.ErrUserQueryFailed)
 			return
 		}
 	}
@@ -651,13 +658,13 @@ func (m *Manager) list(c *wkhttp.Context) {
 		}
 		if err != nil {
 			m.Error("查询用户在线状态失败", zap.Error(err))
-			c.ResponseError(errors.New("查询用户在线状态失败"))
+			respondUserError(c, errcode.ErrUserQueryFailed)
 			return
 		}
 		devices, err := m.deviceDB.queryDeviceLastLoginWithUids(uids)
 		if err != nil {
 			m.Error("查询用户最后一次登录设备信息错误", zap.Error(err))
-			c.ResponseError(errors.New("查询用户最后一次登录设备信息错误"))
+			respondUserError(c, errcode.ErrUserQueryFailed)
 			return
 		}
 		var i = 0
@@ -730,12 +737,12 @@ func (m *Manager) list(c *wkhttp.Context) {
 func (m *Manager) friends(c *wkhttp.Context) {
 	err := c.CheckLoginRole()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 	uid := c.Query("uid")
 	if uid == "" {
-		c.ResponseError(errors.New("查询用户ID不能为空"))
+		respondUserRequestInvalid(c, "uid")
 		return
 	}
 	sortType := c.Query("sort_type")
@@ -745,8 +752,8 @@ func (m *Manager) friends(c *wkhttp.Context) {
 	sortTypeInt := wkutil.AtoiOrDefault(sortType, 0)
 	list, err := m.friendDB.QueryFriends(uid)
 	if err != nil {
-		m.Error("查询用户好友错误", zap.String("uid", uid))
-		c.ResponseError(err)
+		m.Error("查询用户好友错误", zap.String("uid", uid), zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	result := make([]*managerFriendResp, 0)
@@ -770,7 +777,7 @@ func (m *Manager) friends(c *wkhttp.Context) {
 	conversations, err := m.ctx.IMSyncUserConversation(uid, 0, 1, "", nil)
 	if err != nil {
 		m.Error("同步离线后的最近会话失败！", zap.Error(err), zap.String("loginUID", uid))
-		c.ResponseError(errors.New("同步离线后的最近会话失败！"))
+		respondUserError(c, errcode.ErrUserIMCallFailed)
 		return
 	}
 	if len(conversations) == 0 {
@@ -832,18 +839,18 @@ func (m *Manager) friends(c *wkhttp.Context) {
 func (m *Manager) blacklist(c *wkhttp.Context) {
 	err := c.CheckLoginRole()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 	uid := c.Query("uid")
 	if uid == "" {
-		c.ResponseError(errors.New("查询用户ID不能为空"))
+		respondUserRequestInvalid(c, "uid")
 		return
 	}
 	list, err := m.db.queryUserBlacklists(uid)
 	if err != nil {
 		m.Error("查询黑名单列表失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询黑名单列表失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	blacklists := []*managerBlackUserResp{}
@@ -861,20 +868,20 @@ func (m *Manager) blacklist(c *wkhttp.Context) {
 func (m *Manager) disableUsers(c *wkhttp.Context) {
 	err := c.CheckLoginRole()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 	pageIndex, pageSize := c.GetPage()
 	list, err := m.db.queryUserListWithStatus(int(common.UserDisable), uint64(pageSize), uint64(pageIndex))
 	if err != nil {
 		m.Error("通过状态查询用户列表错误", zap.Error(err))
-		c.ResponseError(errors.New("通过状态查询用户列表错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	count, err := m.db.queryUserCountWithStatus(int(common.UserDisable))
 	if err != nil {
 		m.Error("查询用户数量错误", zap.Error(err))
-		c.ResponseError(errors.New("查询用户数量错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	result := make([]*managerDisableUserResp, 0)
@@ -901,32 +908,32 @@ func (m *Manager) disableUsers(c *wkhttp.Context) {
 func (m *Manager) liftBanUser(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 	uid := c.Param("uid")
 	status := c.Param("status")
 	if uid == "" {
-		c.ResponseError(errors.New("操作用户id不能为空"))
+		respondUserRequestInvalid(c, "uid")
 		return
 	}
 	if status == "" {
-		c.ResponseError(errors.New("修改状态类型不能为空"))
+		respondUserRequestInvalid(c, "status")
 		return
 	}
 	userStatus := wkutil.AtoiOrDefault(status, 0)
 	if userStatus != int(common.UserAvailable) && userStatus != int(common.UserDisable) {
-		c.ResponseError(errors.New("修改状态类型不匹配"))
+		respondUserRequestInvalid(c, "status")
 		return
 	}
 	userInfo, err := m.userDB.QueryByUID(uid)
 	if err != nil {
 		m.Error("查询用户信息失败！", zap.String("uid", uid))
-		c.ResponseError(errors.New("查询用户信息错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userInfo == nil {
-		c.ResponseError(errors.New("操作用户不存在"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 	if userInfo.Status == userStatus {
@@ -936,7 +943,7 @@ func (m *Manager) liftBanUser(c *wkhttp.Context) {
 	err = m.userDB.UpdateUsersWithField("status", status, uid)
 	if err != nil {
 		m.Error("修改用户状态错误", zap.Error(err))
-		c.ResponseError(errors.New("修改用户状态错误"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 
@@ -952,13 +959,13 @@ func (m *Manager) liftBanUser(c *wkhttp.Context) {
 	})
 	if err != nil {
 		m.Error("更新WebIM的token失败！", zap.Error(err))
-		c.ResponseError(errors.New("更新IM的token失败！"))
+		respondUserError(c, errcode.ErrUserIMCallFailed)
 		return
 	}
 	err = m.ctx.QuitUserDevice(userInfo.UID, -1)
 	if err != nil {
 		m.Error("下线用户所有登录设备错误", zap.Error(err), zap.String("uid", uid))
-		c.ResponseError(errors.New("下线用户所有登录设备错误"))
+		respondUserError(c, errcode.ErrUserIMCallFailed)
 		return
 	}
 	c.ResponseOK()
@@ -968,7 +975,7 @@ func (m *Manager) liftBanUser(c *wkhttp.Context) {
 func (m *Manager) updatePwd(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 	loginUID := c.GetLoginUID()
@@ -978,60 +985,60 @@ func (m *Manager) updatePwd(c *wkhttp.Context) {
 	}
 	var req updatePwdReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if req.Password == "" || req.NewPassword == "" {
-		c.ResponseError(errors.New("密码不能为空"))
+		respondUserRequestInvalid(c, "password")
 		return
 	}
 	user, err := m.userDB.QueryByUID(loginUID)
 	if err != nil {
 		m.Error("查询用户信息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询用户信息错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if user == nil {
-		c.ResponseError(errors.New("操作用户不存在"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 	matched, _ := CheckPassword(req.Password, user.Password)
 	if !matched {
-		c.ResponseError(errors.New("原密码错误"))
+		respondUserError(c, errcode.ErrUserOldPasswordIncorrect)
 		return
 	}
 	if len(req.NewPassword) < 6 {
-		c.ResponseError(errors.New("密码长度必须大于6位"))
+		respondUserError(c, errcode.ErrUserPasswordTooShort)
 		return
 	}
 	if req.Password == req.NewPassword {
-		c.ResponseError(errors.New("新密码不能和旧密码一样"))
+		respondUserError(c, errcode.ErrUserNewPasswordSameAsOld)
 		return
 	}
 	newHashedPassword, err := HashPassword(req.NewPassword)
 	if err != nil {
 		m.Error("密码哈希失败", zap.Error(err))
-		c.ResponseError(errors.New("密码处理失败"))
+		respondUserError(c, errcode.ErrUserPasswordProcessFailed)
 		return
 	}
 	err = m.userDB.UpdateUsersWithField("password", newHashedPassword, loginUID)
 	if err != nil {
 		m.Error("修改用户密码错误", zap.Error(err))
-		c.Response("修改用户密码错误")
+		respondUserError(c, errcode.ErrUserLoginPwdUpdateFailed)
 		return
 	}
 	// 清除token缓存
 	oldToken, err := m.ctx.Cache().Get(fmt.Sprintf("%s%d%s", m.ctx.GetConfig().Cache.UIDTokenCachePrefix, config.Web, user.UID))
 	if err != nil {
 		m.Error("获取旧token错误", zap.Error(err))
-		c.ResponseError(errors.New("获取旧token错误"))
+		respondUserError(c, errcode.ErrUserTokenCacheFailed)
 		return
 	}
 	if oldToken != "" {
 		err = m.ctx.Cache().Delete(m.ctx.GetConfig().Cache.TokenCachePrefix + oldToken)
 		if err != nil {
 			m.Error("清除旧token数据错误", zap.Error(err))
-			c.ResponseError(errors.New("清除旧token数据错误"))
+			respondUserError(c, errcode.ErrUserTokenCacheFailed)
 			return
 		}
 	}

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -929,7 +929,7 @@ func (m *Manager) liftBanUser(c *wkhttp.Context) {
 	}
 	userInfo, err := m.userDB.QueryByUID(uid)
 	if err != nil {
-		m.Error("查询用户信息失败！", zap.String("uid", uid))
+		m.Error("查询用户信息失败！", zap.String("uid", uid), zap.Error(err))
 		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}

--- a/modules/user/api_manager_test.go
+++ b/modules/user/api_manager_test.go
@@ -533,7 +533,7 @@ func TestUserListBotAndSystemFlags(t *testing.T) {
 // 两列出现 NULL，进而让 /v1/manager/user/list 等所有 SELECT phone/zone 到
 // string 字段的接口因 "converting NULL to string is unsupported" 报 400。
 //
-// 修复迁移 20260516000001_user_legacy01.sql 把列改回 NOT NULL DEFAULT ''。
+// 修复迁移 20260516000001_user_legacy01.sql 把列改回 NOT NULL DEFAULT ”。
 // 本测试通过 INFORMATION_SCHEMA 校验 schema、并直接走 raw SQL 尝试 NULL
 // 写入来验证约束是否真生效（修复前是 NULL 通过、读取报错；修复后是写入直接被
 // 拒，读取永远安全）。
@@ -544,15 +544,15 @@ func TestUserTablePhoneZoneNotNullable(t *testing.T) {
 
 	// 1. INFORMATION_SCHEMA 直接校验 schema。
 	type colMeta struct {
-		ColumnName    string `db:"COLUMN_NAME"`
-		IsNullable    string `db:"IS_NULLABLE"`
+		ColumnName    string         `db:"COLUMN_NAME"`
+		IsNullable    string         `db:"IS_NULLABLE"`
 		ColumnDefault sql.NullString `db:"COLUMN_DEFAULT"`
 	}
 	var cols []*colMeta
 	_, err = ctx.DB().SelectBySql(
-		"SELECT COLUMN_NAME, IS_NULLABLE, COLUMN_DEFAULT "+
-			"FROM INFORMATION_SCHEMA.COLUMNS "+
-			"WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME='user' "+
+		"SELECT COLUMN_NAME, IS_NULLABLE, COLUMN_DEFAULT " +
+			"FROM INFORMATION_SCHEMA.COLUMNS " +
+			"WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME='user' " +
 			"AND COLUMN_NAME IN ('phone','zone') ORDER BY COLUMN_NAME",
 	).Load(&cols)
 	assert.NoError(t, err)

--- a/modules/user/api_manager_test.go
+++ b/modules/user/api_manager_test.go
@@ -505,6 +505,11 @@ func TestUserListBotAndSystemFlags(t *testing.T) {
 
 	// 互斥校验：bot_only 与 exclude_bot、system_only 与 exclude_system 同时为 1
 	// 是逻辑矛盾，返回 400 比静默返回空更利于前端发现 bug。
+	//
+	// Phase 2.1 迁移后该 400 走 i18n 错误信封（err.server.user.list_filter_conflict）。
+	// 这里只校验 HTTP 状态码不变（回归保护）——此 testutil 服务未装 i18n
+	// ErrorRenderer，故仅输出 legacy {msg,status}；error.code / details 的 v2
+	// 信封与 zh-CN 文案由 TestRespondUserHelpers（helperHarness 装了 renderer）覆盖。
 	conflictCases := []struct {
 		name  string
 		query string

--- a/modules/user/api_online.go
+++ b/modules/user/api_online.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
-	"github.com/pkg/errors"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"go.uber.org/zap"
 )
 
@@ -20,14 +20,14 @@ func (u *User) pcQuit(c *wkhttp.Context) {
 	err := u.ctx.QuitUserDevice(c.GetLoginUID(), int(config.Web)) // 退出web
 	if err != nil {
 		u.Error("退出web设备失败", zap.Error(err))
-		c.ResponseError(errors.New("退出web设备失败"))
+		respondUserError(c, errcode.ErrUserIMCallFailed)
 		return
 	}
 
 	err = u.ctx.QuitUserDevice(c.GetLoginUID(), int(config.PC))
 	if err != nil {
 		u.Error("退出PC设备失败", zap.Error(err))
-		c.ResponseError(errors.New("退出PC设备失败"))
+		respondUserError(c, errcode.ErrUserIMCallFailed)
 		return
 	}
 
@@ -38,7 +38,8 @@ func (u *User) pcQuit(c *wkhttp.Context) {
 		CMD:         common.CMDPCQuit,
 	})
 	if err != nil {
-		c.ResponseErrorf("发送指令失败！", err)
+		u.Error("发送指令失败！", zap.Error(err))
+		respondUserError(c, errcode.ErrUserIMCallFailed)
 		return
 	}
 
@@ -48,7 +49,7 @@ func (u *User) pcQuit(c *wkhttp.Context) {
 func (u *User) onlinelistWithUIDs(c *wkhttp.Context) {
 	var uids []string
 	if err := c.BindJSON(&uids); err != nil {
-		c.ResponseError(err)
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	onlineResps := make([]*userOnlineResp, 0)
@@ -56,7 +57,7 @@ func (u *User) onlinelistWithUIDs(c *wkhttp.Context) {
 		onlines, err := u.onlineDB.queryUserOnlineRecets(uids)
 		if err != nil {
 			u.Error("查询用户在线状态失败！", zap.Error(err))
-			c.ResponseError(errors.New("查询用户在线状态失败！"))
+			respondUserError(c, errcode.ErrUserQueryFailed)
 			return
 		}
 		if len(onlines) > 0 {
@@ -81,7 +82,7 @@ func (u *User) onlineList(c *wkhttp.Context) {
 	friends, err := u.friendDB.QueryFriends(loginUID)
 	if err != nil {
 		u.Error("查询用户好友失败", zap.Error(err))
-		c.ResponseError(errors.New("查询用户好友失败"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	uids := make([]string, 0, len(friends))
@@ -90,19 +91,22 @@ func (u *User) onlineList(c *wkhttp.Context) {
 	}
 	resps, err := u.onlineService.GetUserLastOnlineStatus(uids)
 	if err != nil {
-		c.ResponseErrorf("获取用户在线状态失败！", err)
+		u.Error("获取用户在线状态失败！", zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	pcOnlineB, err := u.onlineDB.exist(c.GetLoginUID(), config.PC.Uint8(), 1)
 	if err != nil {
-		c.ResponseErrorf("查询指定在线设备失败！", err)
+		u.Error("查询指定在线设备失败！", zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	webOnline := 0
 	if !pcOnlineB {
 		webOnlineB, err := u.onlineDB.exist(c.GetLoginUID(), config.Web.Uint8(), 1)
 		if err != nil {
-			c.ResponseErrorf("查询指定在线设备失败！", err)
+			u.Error("查询指定在线设备失败！", zap.Error(err))
+			respondUserError(c, errcode.ErrUserQueryFailed)
 			return
 		}
 		if webOnlineB {
@@ -113,7 +117,8 @@ func (u *User) onlineList(c *wkhttp.Context) {
 	if pcOnlineB || webOnline == 1 {
 		myM, err := u.db.QueryByUID(c.GetLoginUID())
 		if err != nil {
-			c.ResponseErrorf("获取我的个人数据失败！", err)
+			u.Error("获取我的个人数据失败！", zap.Error(err))
+			respondUserError(c, errcode.ErrUserQueryFailed)
 			return
 		}
 		deviceFlag := config.Web

--- a/modules/user/api_online.go
+++ b/modules/user/api_online.go
@@ -1,8 +1,8 @@
 package user
 
 import (
-	"net/http"
 	"fmt"
+	"net/http"
 	"os"
 	"runtime/debug"
 	"time"

--- a/modules/user/api_pinned.go
+++ b/modules/user/api_pinned.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	pkgerrors "github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -81,44 +82,47 @@ func (p *Pinned) Add(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	spaceID := spacepkg.GetSpaceID(c)
 	if spaceID == "" {
-		c.ResponseError(pkgerrors.New("space_id 不能为空"))
+		respondUserRequestInvalid(c, "space_id")
 		return
 	}
 
 	var req addPinnedReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(pkgerrors.New("参数错误"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 
 	if req.ChannelID == "" {
-		c.ResponseError(pkgerrors.New("channel_id 不能为空"))
+		respondUserRequestInvalid(c, "channel_id")
 		return
 	}
 
 	if !validChannelTypes[req.ChannelType] {
-		c.ResponseError(pkgerrors.New("无效的频道类型"))
+		respondUserRequestInvalid(c, "channel_type")
 		return
 	}
 
 	// 校验用户是否有权访问该频道
 	if err := p.validateChannelAccess(loginUID, spaceID, req.ChannelID, req.ChannelType); err != nil {
-		c.ResponseError(err)
+		// validateChannelAccess logs its own internal failures; on the wire all
+		// branches collapse to a single 403 (not-a-friend / not-a-member / bot
+		// not added). Splitting internal check failures into a 5xx is a follow-up.
+		respondUserError(c, errcode.ErrUserChannelAccessDenied)
 		return
 	}
 
 	err := p.db.Add(loginUID, spaceID, req.ChannelID, req.ChannelType, pinnedMaxPerSpace)
 	if err != nil {
 		if errors.Is(err, ErrPinnedAlreadyExists) {
-			c.ResponseError(err)
+			respondUserError(c, errcode.ErrUserPinnedAlreadyExists)
 			return
 		}
 		if errors.Is(err, ErrPinnedLimitExceeded) {
-			c.ResponseError(pkgerrors.Errorf("最多只能置顶 %d 个频道", pinnedMaxPerSpace))
+			respondUserPinnedLimitExceeded(c, pinnedMaxPerSpace)
 			return
 		}
 		p.Error("添加置顶失败", zap.Error(err))
-		c.ResponseError(pkgerrors.New("添加置顶失败"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 
@@ -131,31 +135,31 @@ func (p *Pinned) Remove(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	spaceID := spacepkg.GetSpaceID(c)
 	if spaceID == "" {
-		c.ResponseError(pkgerrors.New("space_id 不能为空"))
+		respondUserRequestInvalid(c, "space_id")
 		return
 	}
 
 	channelID := c.Query("channel_id")
 	if channelID == "" {
-		c.ResponseError(pkgerrors.New("channel_id 不能为空"))
+		respondUserRequestInvalid(c, "channel_id")
 		return
 	}
 
 	channelTypeStr := c.Query("channel_type")
 	channelType, err := strconv.ParseUint(channelTypeStr, 10, 8)
 	if err != nil {
-		c.ResponseError(pkgerrors.New("channel_type 参数无效"))
+		respondUserRequestInvalid(c, "channel_type")
 		return
 	}
 
 	if !validChannelTypes[uint8(channelType)] {
-		c.ResponseError(pkgerrors.New("无效的频道类型"))
+		respondUserRequestInvalid(c, "channel_type")
 		return
 	}
 
 	if err := p.db.Remove(loginUID, spaceID, channelID, uint8(channelType)); err != nil {
 		p.Error("移除置顶失败", zap.Error(err))
-		c.ResponseError(pkgerrors.New("移除置顶失败"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 
@@ -175,14 +179,14 @@ func (p *Pinned) List(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	spaceID := spacepkg.GetSpaceID(c)
 	if spaceID == "" {
-		c.ResponseError(pkgerrors.New("space_id 不能为空"))
+		respondUserRequestInvalid(c, "space_id")
 		return
 	}
 
 	list, err := p.db.List(loginUID, spaceID)
 	if err != nil {
 		p.Error("获取置顶列表失败", zap.Error(err))
-		c.ResponseError(pkgerrors.New("获取置顶列表失败"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 
@@ -209,24 +213,24 @@ func (p *Pinned) UpdateSort(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	spaceID := spacepkg.GetSpaceID(c)
 	if spaceID == "" {
-		c.ResponseError(pkgerrors.New("space_id 不能为空"))
+		respondUserRequestInvalid(c, "space_id")
 		return
 	}
 
 	var req updatePinnedSortReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(pkgerrors.New("参数错误"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 
 	if len(req.Items) == 0 {
-		c.ResponseError(pkgerrors.New("items 不能为空"))
+		respondUserRequestInvalid(c, "items")
 		return
 	}
 
 	// 限制 items 数量
 	if len(req.Items) > pinnedMaxPerSpace {
-		c.ResponseError(pkgerrors.Errorf("items 数量不能超过 %d", pinnedMaxPerSpace))
+		respondUserPinnedLimitExceeded(c, pinnedMaxPerSpace)
 		return
 	}
 
@@ -234,11 +238,14 @@ func (p *Pinned) UpdateSort(c *wkhttp.Context) {
 		// 参数校验错误属于客户端问题，原始消息透传给调用方。
 		var ve *PinnedSortError
 		if errors.As(err, &ve) {
-			c.ResponseError(ve)
+			// PinnedSortError is a client-side validation error; its specific
+			// detail is logged for ops, the wire carries the localized code.
+			p.Error("置顶排序参数无效", zap.Error(err))
+			respondUserError(c, errcode.ErrUserPinnedSortInvalid)
 			return
 		}
 		p.Error("更新排序失败", zap.Error(err))
-		c.ResponseError(pkgerrors.New("更新排序失败"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 

--- a/modules/user/api_setting.go
+++ b/modules/user/api_setting.go
@@ -48,40 +48,40 @@ func (u *Setting) userSettingUpdate(c *wkhttp.Context) {
 		switch key {
 		case "mute":
 			if f, ok := value.(float64); ok {
-			model.Mute = int(f)
-		}
+				model.Mute = int(f)
+			}
 		case "top":
 			if f, ok := value.(float64); ok {
-			model.Top = int(f)
-		}
+				model.Top = int(f)
+			}
 		case "chat_pwd_on":
 			if f, ok := value.(float64); ok {
-			model.ChatPwdOn = int(f)
-		}
+				model.ChatPwdOn = int(f)
+			}
 		case "screenshot":
 			if f, ok := value.(float64); ok {
-			model.Screenshot = int(f)
-		}
+				model.Screenshot = int(f)
+			}
 		case "revoke_remind":
 			if f, ok := value.(float64); ok {
-			model.RevokeRemind = int(f)
-		}
+				model.RevokeRemind = int(f)
+			}
 		case "receipt":
 			if f, ok := value.(float64); ok {
-			model.Receipt = int(f)
-		}
+				model.Receipt = int(f)
+			}
 		case "flame":
 			if f, ok := value.(float64); ok {
-			model.Flame = int(f)
-		}
+				model.Flame = int(f)
+			}
 		case "flame_second":
 			if f, ok := value.(float64); ok {
-			model.FlameSecond = int(f)
-		}
+				model.FlameSecond = int(f)
+			}
 		case "remark":
 			if s, ok := value.(string); ok {
-			model.Remark = s
-		}
+				model.Remark = s
+			}
 		}
 	}
 	version, err := u.ctx.GenSeq(common.UserSettingSeqKey)

--- a/modules/user/api_setting.go
+++ b/modules/user/api_setting.go
@@ -5,7 +5,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
-	"github.com/pkg/errors"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"go.uber.org/zap"
 )
 
@@ -28,13 +28,13 @@ func (u *Setting) userSettingUpdate(c *wkhttp.Context) {
 	var settingMap map[string]interface{}
 	if err := c.BindJSON(&settingMap); err != nil {
 		u.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	model, err := u.db.QueryUserSettingModel(toUID, loginUID)
 	if err != nil {
 		u.Error("查询用户设置失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询用户设置失败！"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	insert := false // 是否是插入操作
@@ -86,7 +86,8 @@ func (u *Setting) userSettingUpdate(c *wkhttp.Context) {
 	}
 	version, err := u.ctx.GenSeq(common.UserSettingSeqKey)
 	if err != nil {
-		c.ResponseError(err)
+		u.Error("生成用户设置序列号失败", zap.Error(err))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	model.Version = version
@@ -94,14 +95,14 @@ func (u *Setting) userSettingUpdate(c *wkhttp.Context) {
 		err = u.db.InsertUserSettingModel(model)
 		if err != nil {
 			u.Error("添加设置失败！", zap.Error(err))
-			c.ResponseError(errors.New("添加设置失败！"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 	} else {
 		err = u.db.UpdateUserSettingModel(model)
 		if err != nil {
 			u.Error("修改设置失败！", zap.Error(err))
-			c.ResponseError(errors.New("修改设置失败！"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
 	}
@@ -117,7 +118,7 @@ func (u *Setting) userSettingUpdate(c *wkhttp.Context) {
 	})
 	if err != nil {
 		u.Error("发送频道更新命令失败！", zap.Error(err))
-		c.ResponseError(errors.New("发送频道更新命令失败！"))
+		respondUserError(c, errcode.ErrUserIMCallFailed)
 		return
 	}
 	c.ResponseOK()

--- a/modules/user/api_usernamelogin.go
+++ b/modules/user/api_usernamelogin.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	event "github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	common "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -25,46 +26,46 @@ import (
 func (u *User) usernameRegister(c *wkhttp.Context) {
 	settings := common.EnsureSystemSettings(u.ctx)
 	if settings.RegisterOff() {
-		c.ResponseError(errors.New("注册通道暂不开放"))
+		respondUserError(c, errcode.ErrUserRegistrationClosed)
 		return
 	}
 	if !settings.RegisterUsernameOn() {
-		c.ResponseError(errors.New("暂不支持用户名注册"))
+		respondUserError(c, errcode.ErrUserUsernameRegisterDisabled)
 		return
 	}
 	var req usernameRegisterReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if req.Username == "" {
-		c.ResponseError(errors.New("用户名不能为空"))
+		respondUserRequestInvalid(c, "username")
 		return
 	}
 	if strings.TrimSpace(req.Password) == "" {
-		c.Response(errors.New("密码不能为空！"))
+		respondUserRequestInvalid(c, "password")
 		return
 	}
 	if len(req.Password) < 6 {
-		c.ResponseError(errors.New("密码不能少于6位"))
+		respondUserError(c, errcode.ErrUserPasswordTooShort)
 		return
 	}
 	if len(req.Username) < 8 || len(req.Username) > 22 {
-		c.ResponseError(errors.New("用户名必须在8-22位"))
+		respondUserError(c, errcode.ErrUserUsernameFormatInvalid)
 		return
 	}
 	userInfo, err := u.db.QueryByUsername(req.Username)
 	if err != nil {
-		u.Error("查询用户信息失败！", zap.String("username", req.Username))
-		c.ResponseError(err)
+		u.Error("查询用户信息失败！", zap.String("username", req.Username), zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userInfo != nil {
-		c.ResponseError(errors.New("该用户名已存在"))
+		respondUserError(c, errcode.ErrUserAlreadyExists)
 		return
 	}
 	if err := ValidateName(req.Name); err != nil {
-		c.ResponseError(err)
+		respondUserRequestInvalid(c, "name")
 		return
 	}
 	// 通过用户名注册
@@ -74,25 +75,25 @@ func (u *User) usernameRegister(c *wkhttp.Context) {
 // 用户名登录
 func (u *User) usernameLogin(c *wkhttp.Context) {
 	if common.EnsureSystemSettings(u.ctx).LocalLoginOff() {
-		c.ResponseError(errors.New("本地登录已关闭"))
+		respondUserError(c, errcode.ErrUserLocalLoginDisabled)
 		return
 	}
 	var req loginReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if err := req.Check(); err != nil {
-		c.ResponseError(err)
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if len(req.Username) < 8 || len(req.Username) > 22 {
-		c.ResponseError(errors.New("用户名必须在8-22位"))
+		respondUserError(c, errcode.ErrUserUsernameFormatInvalid)
 		return
 	}
 	if err := u.loginGuard.Check(req.Username); err != nil {
 		u.Warn("登录被临时锁定", zap.String("username", req.Username), zap.Error(err))
-		c.ResponseError(err)
+		respondUserError(c, errcode.ErrUserLoginLocked)
 		return
 	}
 	loginSpan := u.ctx.Tracer().StartSpan(
@@ -105,27 +106,27 @@ func (u *User) usernameLogin(c *wkhttp.Context) {
 
 	userInfo, err := u.db.QueryByUsernameCxt(loginSpanCtx, req.Username)
 	if err != nil {
-		u.Error("查询用户信息失败！", zap.String("username", req.Username))
-		c.ResponseError(err)
+		u.Error("查询用户信息失败！", zap.String("username", req.Username), zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userInfo == nil {
 		u.loginGuard.RecordFailureLogged(req.Username)
 		// 统一错误消息，避免枚举账号
-		c.ResponseError(errors.New("用户名或密码错误"))
+		respondUserError(c, errcode.ErrUserInvalidCredentials)
 		return
 	}
 	// 已注销账号拒绝登录；冷静期账号允许登录（响应中附带注销状态提示）
 	if userInfo.IsDestroy == IsDestroyDone || userInfo.Status == 0 {
 		u.loginGuard.RecordFailureLogged(req.Username)
-		c.ResponseError(errors.New("用户名或密码错误"))
+		respondUserError(c, errcode.ErrUserInvalidCredentials)
 		return
 	}
 
 	matched, needsMigration := CheckPassword(req.Password, userInfo.Password)
 	if !matched {
 		u.loginGuard.RecordFailureLogged(req.Username)
-		c.ResponseError(errors.New("用户名或密码错误"))
+		respondUserError(c, errcode.ErrUserInvalidCredentials)
 		return
 	}
 	u.loginGuard.ResetLogged(req.Username)
@@ -138,7 +139,8 @@ func (u *User) usernameLogin(c *wkhttp.Context) {
 
 	result, err := u.execLogin(userInfo, config.DeviceFlag(req.Flag), req.Device, loginSpanCtx)
 	if err != nil {
-		c.ResponseError(err)
+		u.Error("用户名登录 execLogin 失败", zap.String("username", req.Username), zap.Error(err))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	needUploadWeb3PublicKey := 0
@@ -177,7 +179,7 @@ func (u *User) registerWithUsername(username string, name string, password strin
 	tx, err := u.db.session.Begin()
 	if err != nil {
 		u.Error("创建事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("创建事务失败！"))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	defer func() {
@@ -192,14 +194,14 @@ func (u *User) registerWithUsername(username string, name string, password strin
 		if err != nil {
 			tx.Rollback()
 			u.Error("数据库事务提交失败", zap.Error(err))
-			c.ResponseError(errors.New("数据库事务提交失败"))
+			respondUserError(c, errcode.ErrUserStoreFailed)
 			return nil
 		}
 		return nil
 	})
 	if err != nil {
 		tx.Rollback()
-		c.ResponseError(errors.New("注册失败！"))
+		respondUserError(c, errcode.ErrUserRegisterFailed)
 		return
 	}
 	c.Response(map[string]interface{}{
@@ -218,37 +220,37 @@ func (u *User) resetPwdWithWeb3PublicKey(c *wkhttp.Context) {
 	}
 	var req reqVO
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if req.Username == "" {
-		c.ResponseError(errors.New("用户名不能为空"))
+		respondUserRequestInvalid(c, "username")
 		return
 	}
 	if req.Password == "" {
-		c.ResponseError(errors.New("密码不能为空"))
+		respondUserRequestInvalid(c, "password")
 		return
 	}
 	if req.VerifyText == "" {
-		c.ResponseError(errors.New("校验字符不能为空"))
+		respondUserRequestInvalid(c, "verify_text")
 		return
 	}
 	if req.SignText == "" {
-		c.ResponseError(errors.New("签名字符不能为空"))
+		respondUserRequestInvalid(c, "sign_text")
 		return
 	}
 	user, err := u.db.QueryByUsername(req.Username)
 	if err != nil {
 		u.Error("查询用户信息错误", zap.Error(err))
-		c.ResponseError(err)
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if user == nil {
-		c.ResponseError(errors.New("该用户不存在"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 	if user.Web3PublicKey == "" {
-		c.ResponseError(errors.New("该用户未上传公钥"))
+		respondUserError(c, errcode.ErrUserPublicKeyNotFound)
 		return
 	}
 	// 判断签名明文是否存在
@@ -256,28 +258,28 @@ func (u *User) resetPwdWithWeb3PublicKey(c *wkhttp.Context) {
 	verifyText, err := u.ctx.GetRedisConn().GetString(cacheKey)
 	if err != nil {
 		u.Error("获取签名信息错误", zap.Error(err))
-		c.ResponseError(err)
+		respondUserError(c, errcode.ErrUserTokenCacheFailed)
 		return
 	}
 	if verifyText == "" || req.VerifyText != verifyText {
-		c.ResponseError(errors.New("签名信息不存在"))
+		respondUserError(c, errcode.ErrUserSignatureNotFound)
 		return
 	}
 
 	verify, err := u.verifySignature(user.Web3PublicKey, req.VerifyText, req.SignText)
 	if err != nil {
-		c.ResponseError(errors.New("校验签名错误"))
+		respondUserError(c, errcode.ErrUserSignatureInvalid)
 		return
 	}
 	if !verify {
-		c.ResponseError(errors.New("签名错误"))
+		respondUserError(c, errcode.ErrUserSignatureInvalid)
 		return
 	}
 
 	newHash, err := HashPassword(req.Password)
 	if err != nil {
 		u.Error("密码哈希失败", zap.Error(err))
-		c.ResponseError(errors.New("密码处理失败"))
+		respondUserError(c, errcode.ErrUserPasswordProcessFailed)
 		return
 	}
 	updateMap := map[string]interface{}{}
@@ -285,7 +287,7 @@ func (u *User) resetPwdWithWeb3PublicKey(c *wkhttp.Context) {
 	err = u.db.updateUser(updateMap, user.UID)
 	if err != nil {
 		u.Error("修改用户密码错误", zap.Error(err))
-		c.ResponseError(err)
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	err = u.ctx.GetRedisConn().Del(cacheKey)
@@ -333,26 +335,26 @@ func (u *User) uploadWeb3PublicKey(c *wkhttp.Context) {
 	}
 	var req reqVO
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 
 	if req.Web3PublicKey == "" {
-		c.ResponseError(errors.New("公钥不能为空"))
+		respondUserRequestInvalid(c, "web3_public_key")
 		return
 	}
 	userInfo, err := u.db.QueryByUID(loginUID)
 	if err != nil {
-		u.Error("查询用户信息失败！", zap.String("uid", loginUID))
-		c.ResponseError(err)
+		u.Error("查询用户信息失败！", zap.String("uid", loginUID), zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userInfo == nil || userInfo.Status == 0 || userInfo.IsDestroy == IsDestroyDone {
-		c.ResponseError(errors.New("该用户不存在或被封禁"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 	if userInfo.Web3PublicKey != "" {
-		c.ResponseError(errors.New("该用户已上传过公钥信息"))
+		respondUserError(c, errcode.ErrUserPublicKeyAlreadyExists)
 		return
 	}
 
@@ -361,7 +363,7 @@ func (u *User) uploadWeb3PublicKey(c *wkhttp.Context) {
 	err = u.db.updateUser(updateMap, loginUID)
 	if err != nil {
 		u.Error("修改用户公钥错误", zap.Error(err))
-		c.ResponseError(err)
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	c.ResponseOK()
@@ -377,38 +379,38 @@ func (u *User) web3verifySignature(c *wkhttp.Context) {
 	}
 	var req reqVO
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if req.Username == "" {
-		c.ResponseError(errors.New("用户名不能为空"))
+		respondUserRequestInvalid(c, "username")
 		return
 	}
 	if req.VerifyText == "" {
-		c.ResponseError(errors.New("校验字符不能为空"))
+		respondUserRequestInvalid(c, "verify_text")
 		return
 	}
 	if req.SignText == "" {
-		c.ResponseError(errors.New("签名字符不能为空"))
+		respondUserRequestInvalid(c, "sign_text")
 		return
 	}
 	if req.Type == "" || (req.Type != Web3VerifyLogin && req.Type != Web3VerifyPassword) {
-		c.ResponseError(errors.New("验证类型不匹配"))
+		respondUserError(c, errcode.ErrUserVerifyTypeInvalid)
 		return
 	}
 
 	user, err := u.db.QueryByUsername(req.Username)
 	if err != nil {
 		u.Error("查询用户信息错误", zap.Error(err))
-		c.ResponseError(err)
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if user == nil {
-		c.ResponseError(errors.New("该用户不存在"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 	if user.Web3PublicKey == "" {
-		c.ResponseError(errors.New("该用户未上传公钥"))
+		respondUserError(c, errcode.ErrUserPublicKeyNotFound)
 		return
 	}
 	// 判断签名明文是否存在
@@ -416,21 +418,21 @@ func (u *User) web3verifySignature(c *wkhttp.Context) {
 	verifyText, err := u.ctx.GetRedisConn().GetString(cacheKey)
 	if err != nil {
 		u.Error("获取签名信息错误", zap.Error(err))
-		c.ResponseError(err)
+		respondUserError(c, errcode.ErrUserTokenCacheFailed)
 		return
 	}
 	if verifyText == "" || req.VerifyText != verifyText {
-		c.ResponseError(errors.New("签名信息不存在"))
+		respondUserError(c, errcode.ErrUserSignatureNotFound)
 		return
 	}
 
 	verify, err := u.verifySignature(user.Web3PublicKey, req.VerifyText, req.SignText)
 	if err != nil {
-		c.ResponseError(errors.New("校验签名错误"))
+		respondUserError(c, errcode.ErrUserSignatureInvalid)
 		return
 	}
 	if !verify {
-		c.ResponseError(errors.New("签名错误"))
+		respondUserError(c, errcode.ErrUserSignatureInvalid)
 		return
 	}
 	err = u.ctx.GetRedisConn().Del(cacheKey)
@@ -445,25 +447,25 @@ func (u *User) getVerifyText(c *wkhttp.Context) {
 	username := c.Query("username")
 	verifyType := c.Query("type")
 	if username == "" {
-		c.ResponseError(errors.New("用户名不能为空"))
+		respondUserRequestInvalid(c, "username")
 		return
 	}
 	if verifyType == "" || (verifyType != Web3VerifyLogin && verifyType != Web3VerifyPassword) {
-		c.ResponseError(errors.New("验证类型不匹配"))
+		respondUserError(c, errcode.ErrUserVerifyTypeInvalid)
 		return
 	}
 	user, err := u.db.QueryByUsername(username)
 	if err != nil {
 		u.Error("查询用户信息错误", zap.Error(err))
-		c.ResponseError(err)
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if user == nil || user.IsDestroy == IsDestroyDone || user.Status == 0 {
-		c.ResponseError(errors.New("该用户不存在或被禁用"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 	if user.Web3PublicKey == "" {
-		c.ResponseError(errors.New("该用户尚未上传公钥"))
+		respondUserError(c, errcode.ErrUserPublicKeyNotFound)
 		return
 	}
 	// 使用足够长的随机字符串，不包含可预测的时间戳
@@ -473,7 +475,7 @@ func (u *User) getVerifyText(c *wkhttp.Context) {
 	err = u.ctx.GetRedisConn().SetAndExpire(cacheKey, verifyText, time.Minute*5)
 	if err != nil {
 		u.Error("缓存校验信息错误", zap.Error(err))
-		c.ResponseError(err)
+		respondUserError(c, errcode.ErrUserTokenCacheFailed)
 		return
 	}
 	c.Response(map[string]interface{}{
@@ -491,42 +493,42 @@ func (u *User) updatePwd(c *wkhttp.Context) {
 	}
 	var req reqVO
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondUserRequestInvalid(c, "")
 		return
 	}
 	if req.Password == "" || req.NewPassword == "" {
-		c.ResponseError(errors.New("密码不能为空"))
+		respondUserRequestInvalid(c, "password")
 		return
 	}
 	if req.Password == req.NewPassword {
-		c.ResponseError(errors.New("新密码不能和旧密码相同"))
+		respondUserError(c, errcode.ErrUserNewPasswordSameAsOld)
 		return
 	}
 	userInfo, err := u.db.QueryByUID(loginUID)
 	if err != nil {
 		u.Error("查询用户资料错误", zap.Error(err))
-		c.ResponseError(errors.New("查询用户资料错误"))
+		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userInfo == nil {
-		c.ResponseError(errors.New("该用户不存在"))
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 	matched, _ := CheckPassword(req.Password, userInfo.Password)
 	if !matched {
-		c.ResponseError(errors.New("旧密码错误"))
+		respondUserError(c, errcode.ErrUserOldPasswordIncorrect)
 		return
 	}
 	newHash, err := HashPassword(req.NewPassword)
 	if err != nil {
 		u.Error("密码哈希失败", zap.Error(err))
-		c.ResponseError(errors.New("密码处理失败"))
+		respondUserError(c, errcode.ErrUserPasswordProcessFailed)
 		return
 	}
 	err = u.db.UpdateUsersWithField("password", newHash, userInfo.UID)
 	if err != nil {
 		u.Error("修改登录密码错误", zap.Error(err))
-		c.ResponseError(errors.New("修改登录密码错误"))
+		respondUserError(c, errcode.ErrUserLoginPwdUpdateFailed)
 		return
 	}
 	c.ResponseOK()

--- a/modules/user/api_usernamelogin.go
+++ b/modules/user/api_usernamelogin.go
@@ -139,8 +139,7 @@ func (u *User) usernameLogin(c *wkhttp.Context) {
 
 	result, err := u.execLogin(userInfo, config.DeviceFlag(req.Flag), req.Device, loginSpanCtx)
 	if err != nil {
-		u.Error("用户名登录 execLogin 失败", zap.String("username", req.Username), zap.Error(err))
-		respondUserError(c, errcode.ErrUserStoreFailed)
+		u.respondExecLoginError(c, err, userInfo)
 		return
 	}
 	needUploadWeb3PublicKey := 0

--- a/modules/user/api_usernamelogin_test.go
+++ b/modules/user/api_usernamelogin_test.go
@@ -20,6 +20,7 @@ func TestUsernameLoginBlockedByLocalLoginOff(t *testing.T) {
 	// 的 TestSystemSettings_LocalLoginOff_AutoFalse* 系列。
 	enableFullOIDCForUserTest(t)
 	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	setSystemSettingForUserTest(t, ctx, "login", "local_off", "1", "bool")
 	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
@@ -37,6 +38,7 @@ func TestUsernameLoginBlockedByLocalLoginOff(t *testing.T) {
 
 func TestUsernameRegisterBlockedByRegisterOff(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	setSystemSettingForUserTest(t, ctx, "register", "off", "1", "bool")
 	setSystemSettingForUserTest(t, ctx, "register", "username_on", "1", "bool")
@@ -51,5 +53,5 @@ func TestUsernameRegisterBlockedByRegisterOff(t *testing.T) {
 	setPublicIPForUserTest(req, "9.9.9.9")
 	s.GetRoute().ServeHTTP(w, req)
 
-	assert.Contains(t, w.Body.String(), "注册通道暂不开放")
+	assert.Contains(t, w.Body.String(), "err.server.user.registration_closed")
 }

--- a/modules/user/api_usernamelogin_test.go
+++ b/modules/user/api_usernamelogin_test.go
@@ -2,16 +2,53 @@ package user
 
 import (
 	"bytes"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	commonsettings "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestRespondExecLoginError pins the shared execLogin error classifier: a
+// disabled account is 403, a missing device info is 400, the phone-verification
+// sentinel keeps its bespoke 110 response, and any other (genuine internal)
+// error collapses to the shared 500 — instead of every login path reporting
+// these client states as a server failure.
+func TestRespondExecLoginError(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
+	u := New(ctx)
+	byKind := map[string]error{
+		"disabled": ErrUserDisabled,
+		"device":   ErrUserDeviceInfoRequired,
+		"verify":   ErrUserNeedVerification,
+		"internal": errors.New("boom"),
+	}
+	s.GetRoute().GET("/_test/execloginerr", func(c *wkhttp.Context) {
+		u.respondExecLoginError(c, byKind[c.Query("kind")], &Model{UID: "u1", Phone: "13800001234"})
+	})
+
+	cases := []struct{ kind, wantContains string }{
+		{"disabled", `"code":"err.server.user.account_banned"`},
+		{"device", `"code":"err.server.user.request_invalid"`},
+		{"verify", `"status":110`},
+		{"internal", `"code":"err.server.user.store_failed"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/_test/execloginerr?kind="+tc.kind, nil)
+			s.GetRoute().ServeHTTP(w, req)
+			assert.Contains(t, w.Body.String(), tc.wantContains, "body=%s", w.Body.String())
+		})
+	}
+}
 
 func TestUsernameLoginBlockedByLocalLoginOff(t *testing.T) {
 	// 必须先把 OIDC 切到完整可用状态,否则 LocalLoginOff() 的安全回退会把

--- a/pkg/errcode/user.go
+++ b/pkg/errcode/user.go
@@ -407,4 +407,80 @@ var (
 		HTTPStatus:     http.StatusBadRequest,
 		DefaultMessage: "Friend request is invalid or has expired.",
 	})
+
+	// Account deactivation (modules/user/api_destroy.go) codes. Reuse
+	// account_destroying / account_destroyed / destroy_failed above; the codes
+	// below cover the destroy-specific guards.
+
+	ErrUserPasswordNotSet = register(codes.Code{
+		ID:             "err.server.user.password_not_set",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "This account has no password set; identity cannot be verified.",
+	})
+	ErrUserPasswordIncorrect = register(codes.Code{
+		ID:             "err.server.user.password_incorrect",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Incorrect password.",
+	})
+	// ErrUserAccountStateChanged maps the optimistic-lock conflict
+	// (ErrDestroyStateConflict) when a concurrent request changed the
+	// deactivation state out from under this one.
+	ErrUserAccountStateChanged = register(codes.Code{
+		ID:             "err.server.user.account_state_changed",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "Account status has changed, please refresh and try again.",
+	})
+	ErrUserNotDestroying = register(codes.Code{
+		ID:             "err.server.user.not_destroying",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Account is not pending deactivation.",
+	})
+
+	// Pinned channels (modules/user/api_pinned.go) codes.
+
+	ErrUserPinnedAlreadyExists = register(codes.Code{
+		ID:             "err.server.user.pinned_already_exists",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "This channel is already pinned.",
+	})
+	ErrUserPinnedLimitExceeded = register(codes.Code{
+		ID:             "err.server.user.pinned_limit_exceeded",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The pinned channel limit has been reached.",
+		SafeDetailKeys: []string{"max"},
+	})
+	// ErrUserChannelAccessDenied collapses the validateChannelAccess guard
+	// rejections (not a friend / not a group member / bot not added). Internal
+	// check failures inside that helper are logged server-side and also surface
+	// here; splitting them into a 5xx is a follow-up.
+	ErrUserChannelAccessDenied = register(codes.Code{
+		ID:             "err.server.user.channel_access_denied",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You do not have access to this channel.",
+	})
+	ErrUserPinnedSortInvalid = register(codes.Code{
+		ID:             "err.server.user.pinned_sort_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid pinned sort request.",
+	})
+
+	// Third-party OAuth login (modules/user/api_gitee.go, api_github.go) codes.
+
+	ErrUserOAuthStateExpired = register(codes.Code{
+		ID:             "err.server.user.oauth_state_expired",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Login session has expired, please try again.",
+	})
+	ErrUserOAuthExchangeFailed = register(codes.Code{
+		ID:             "err.server.user.oauth_exchange_failed",
+		HTTPStatus:     http.StatusBadGateway,
+		DefaultMessage: "Failed to exchange the OAuth access token.",
+		Internal:       true,
+	})
+	ErrUserOAuthProfileFailed = register(codes.Code{
+		ID:             "err.server.user.oauth_profile_failed",
+		HTTPStatus:     http.StatusBadGateway,
+		DefaultMessage: "Failed to fetch the OAuth user profile.",
+		Internal:       true,
+	})
 )

--- a/pkg/errcode/user.go
+++ b/pkg/errcode/user.go
@@ -518,6 +518,14 @@ var (
 		DefaultMessage: "Failed to send the email verification code.",
 		Internal:       true,
 	})
+	// ErrUserEmailRateLimited is the client-actionable resend cooldown (the
+	// 1-minute throttle in EmailService.SendVerifyCode). 429, not Internal, so
+	// the actionable "try again shortly" message reaches the client.
+	ErrUserEmailRateLimited = register(codes.Code{
+		ID:             "err.server.user.email_rate_limited",
+		HTTPStatus:     http.StatusTooManyRequests,
+		DefaultMessage: "Verification codes are being sent too frequently, please try again in a minute.",
+	})
 
 	// Username / Web3 signature login (modules/user/api_usernamelogin.go) codes.
 	// Reuse registration_closed / local_login_disabled / invalid_credentials /

--- a/pkg/errcode/user.go
+++ b/pkg/errcode/user.go
@@ -483,4 +483,84 @@ var (
 		DefaultMessage: "Failed to fetch the OAuth user profile.",
 		Internal:       true,
 	})
+
+	// Email login / registration (modules/user/api_emaillogin.go) codes. Reuse
+	// registration_closed / local_login_disabled / invalid_credentials /
+	// already_exists / not_found / password_too_short / code_invalid /
+	// register_failed / login_pwd_update_failed / password_process_failed above.
+
+	ErrUserEmailInvalid = register(codes.Code{
+		ID:             "err.server.user.email_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid email address.",
+	})
+	ErrUserEmailRegisterDisabled = register(codes.Code{
+		ID:             "err.server.user.email_register_disabled",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Email registration is not available.",
+	})
+	ErrUserEmailLoginDisabled = register(codes.Code{
+		ID:             "err.server.user.email_login_disabled",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Email login is not available.",
+	})
+	// ErrUserAccountUnavailable covers the code-login branch that surfaces a
+	// deactivated-or-banned account (the password branch unifies onto
+	// invalid_credentials to avoid enumeration).
+	ErrUserAccountUnavailable = register(codes.Code{
+		ID:             "err.server.user.account_unavailable",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "This account has been deactivated or disabled.",
+	})
+	ErrUserEmailSendFailed = register(codes.Code{
+		ID:             "err.server.user.email_send_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to send the email verification code.",
+		Internal:       true,
+	})
+
+	// Username / Web3 signature login (modules/user/api_usernamelogin.go) codes.
+	// Reuse registration_closed / local_login_disabled / invalid_credentials /
+	// already_exists / not_found / current_not_found / login_locked /
+	// password_too_short / old_password_incorrect / new_password_same_as_old /
+	// password_process_failed / login_pwd_update_failed / register_failed /
+	// query_failed / store_failed / token_cache_failed above.
+
+	ErrUserUsernameRegisterDisabled = register(codes.Code{
+		ID:             "err.server.user.username_register_disabled",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Username registration is not available.",
+	})
+	ErrUserUsernameFormatInvalid = register(codes.Code{
+		ID:             "err.server.user.username_format_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Username must be 8-22 characters.",
+	})
+	ErrUserPublicKeyNotFound = register(codes.Code{
+		ID:             "err.server.user.public_key_not_found",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "This user has not uploaded a public key.",
+	})
+	ErrUserPublicKeyAlreadyExists = register(codes.Code{
+		ID:             "err.server.user.public_key_already_exists",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "A public key has already been uploaded for this user.",
+	})
+	// ErrUserSignatureNotFound covers a missing / expired Web3 verify-text
+	// challenge (the cached nonce the client must sign is gone or mismatched).
+	ErrUserSignatureNotFound = register(codes.Code{
+		ID:             "err.server.user.signature_not_found",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Signature challenge does not exist or has expired.",
+	})
+	ErrUserSignatureInvalid = register(codes.Code{
+		ID:             "err.server.user.signature_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Signature verification failed.",
+	})
+	ErrUserVerifyTypeInvalid = register(codes.Code{
+		ID:             "err.server.user.verify_type_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid verification type.",
+	})
 )

--- a/pkg/errcode/user.go
+++ b/pkg/errcode/user.go
@@ -94,6 +94,11 @@ var (
 		HTTPStatus:     http.StatusNotFound,
 		DefaultMessage: "Current user not found.",
 	})
+	ErrUserDeviceNotFound = register(codes.Code{
+		ID:             "err.server.user.device_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Device not found.",
+	})
 	ErrUserAlreadyExists = register(codes.Code{
 		ID:             "err.server.user.already_exists",
 		HTTPStatus:     http.StatusConflict,
@@ -287,5 +292,119 @@ var (
 		HTTPStatus:     http.StatusInternalServerError,
 		DefaultMessage: "Failed to set language preference.",
 		Internal:       true,
+	})
+
+	// Management-console (modules/user/api_manager.go) codes. Migrated from
+	// the legacy c.ResponseError(errors.New("中文")) sites in Phase 2.1. Shared
+	// auth/param/internal cases reuse err.shared.* (forbidden / param.invalid)
+	// and the generic ErrUser* codes above; the codes below cover the
+	// manager-specific guards that had no existing equivalent.
+
+	// ErrUserManagerPermissionRequired fires at /v1/manager/login after the
+	// password check succeeds but the account carries no admin/superAdmin role.
+	// Distinct from err.shared.auth.forbidden (a route-level role guard) so the
+	// login page can show a login-specific hint.
+	ErrUserManagerPermissionRequired = register(codes.Code{
+		ID:             "err.server.user.manager_permission_required",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "This account does not have management permission.",
+	})
+	ErrUserPasswordTooShort = register(codes.Code{
+		ID:             "err.server.user.password_too_short",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Password must be at least 6 characters.",
+	})
+	ErrUserPasswordMismatch = register(codes.Code{
+		ID:             "err.server.user.password_mismatch",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The two passwords do not match.",
+	})
+	ErrUserOldPasswordIncorrect = register(codes.Code{
+		ID:             "err.server.user.old_password_incorrect",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The current password is incorrect.",
+	})
+	ErrUserNewPasswordSameAsOld = register(codes.Code{
+		ID:             "err.server.user.new_password_same_as_old",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The new password must be different from the current one.",
+	})
+	// ErrUserNotAdminAccount guards the delete-admin endpoint: the target user
+	// exists but is not an administrator account, so it cannot be deleted here.
+	ErrUserNotAdminAccount = register(codes.Code{
+		ID:             "err.server.user.not_admin_account",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "This user is not an administrator account and cannot be deleted.",
+	})
+	ErrUserCannotDeleteSuperAdmin = register(codes.Code{
+		ID:             "err.server.user.cannot_delete_super_admin",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "The super administrator account cannot be deleted.",
+	})
+	// ErrUserListFilterConflict reports mutually-exclusive list filters
+	// (bot_only + exclude_bot, system_only + exclude_system). The conflicting
+	// filter names are surfaced so a frontend dev can spot the bad query.
+	ErrUserListFilterConflict = register(codes.Code{
+		ID:             "err.server.user.list_filter_conflict",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Conflicting list filters.",
+		SafeDetailKeys: []string{"filter", "conflicts_with"},
+	})
+
+	// Internal failures (500, Internal=true).
+
+	// ErrUserTokenCacheFailed covers the session-token cache read/write/delete
+	// failures in the manager login / password-change / delete-admin flows.
+	ErrUserTokenCacheFailed = register(codes.Code{
+		ID:             "err.server.user.token_cache_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to update the session token cache.",
+		Internal:       true,
+	})
+	ErrUserShortNoGenFailed = register(codes.Code{
+		ID:             "err.server.user.short_no_gen_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to generate a short ID.",
+		Internal:       true,
+	})
+
+	// Friend / contact (modules/user/api_friend.go) codes. Most legacy sites
+	// there are internal DB / IM / cache failures that collapse to the generic
+	// ErrUserQueryFailed / ErrUserStoreFailed / ErrUserIMCallFailed /
+	// ErrUserTokenCacheFailed / ErrUserDecodeFailed codes above; the codes
+	// below cover the friend-specific user-facing business guards.
+
+	ErrUserCannotAddSelf = register(codes.Code{
+		ID:             "err.server.user.cannot_add_self",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "You cannot add yourself as a friend.",
+	})
+	ErrUserAlreadyFriend = register(codes.Code{
+		ID:             "err.server.user.already_friend",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "You are already friends.",
+	})
+	ErrUserBotNotInSpace = register(codes.Code{
+		ID:             "err.server.user.bot_not_in_space",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "This bot is not in the current space and cannot be added.",
+	})
+	ErrUserFriendApplyNotFound = register(codes.Code{
+		ID:             "err.server.user.friend_apply_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Friend request not found.",
+	})
+	ErrUserFriendNotFound = register(codes.Code{
+		ID:             "err.server.user.friend_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Friend not found.",
+	})
+	// ErrUserFriendApplyInvalid covers an expired / malformed friend-request
+	// token or payload (the apply token decoded but its referenced records are
+	// gone or inconsistent).
+	ErrUserFriendApplyInvalid = register(codes.Code{
+		ID:             "err.server.user.friend_apply_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Friend request is invalid or has expired.",
 	})
 )

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -280,3 +280,38 @@ other = "好友申请无效或已过期。"
 
 ["err.server.user.device_not_found"]
 other = "未查询到该设备。"
+
+# ---- err.server.user.* (Phase 2.1 destroy / pinned / oauth migration) ----
+
+["err.server.user.password_not_set"]
+other = "当前账号未设置密码，无法验证身份。"
+
+["err.server.user.password_incorrect"]
+other = "密码错误。"
+
+["err.server.user.account_state_changed"]
+other = "账号状态已变化，请刷新后重试。"
+
+["err.server.user.not_destroying"]
+other = "账号未在注销中。"
+
+["err.server.user.pinned_already_exists"]
+other = "该频道已置顶。"
+
+["err.server.user.pinned_limit_exceeded"]
+other = "置顶频道数量已达上限。"
+
+["err.server.user.channel_access_denied"]
+other = "你无权访问该频道。"
+
+["err.server.user.pinned_sort_invalid"]
+other = "置顶排序参数无效。"
+
+["err.server.user.oauth_state_expired"]
+other = "登录状态已过期，请重试。"
+
+["err.server.user.oauth_exchange_failed"]
+other = "获取第三方授权令牌失败。"
+
+["err.server.user.oauth_profile_failed"]
+other = "获取第三方用户信息失败。"

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -333,6 +333,9 @@ other = "该账号已注销或被禁用。"
 ["err.server.user.email_send_failed"]
 other = "发送邮箱验证码失败。"
 
+["err.server.user.email_rate_limited"]
+other = "验证码发送过于频繁，请 1 分钟后再试。"
+
 # ---- err.server.user.* (Phase 2.1 modules/user/api_usernamelogin.go migration) ----
 
 ["err.server.user.username_register_disabled"]

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -315,3 +315,43 @@ other = "获取第三方授权令牌失败。"
 
 ["err.server.user.oauth_profile_failed"]
 other = "获取第三方用户信息失败。"
+
+# ---- err.server.user.* (Phase 2.1 modules/user/api_emaillogin.go migration) ----
+
+["err.server.user.email_invalid"]
+other = "邮箱格式不正确。"
+
+["err.server.user.email_register_disabled"]
+other = "暂不支持邮箱注册。"
+
+["err.server.user.email_login_disabled"]
+other = "暂不支持邮箱登录。"
+
+["err.server.user.account_unavailable"]
+other = "该账号已注销或被禁用。"
+
+["err.server.user.email_send_failed"]
+other = "发送邮箱验证码失败。"
+
+# ---- err.server.user.* (Phase 2.1 modules/user/api_usernamelogin.go migration) ----
+
+["err.server.user.username_register_disabled"]
+other = "暂不支持用户名注册。"
+
+["err.server.user.username_format_invalid"]
+other = "用户名必须为 8-22 位。"
+
+["err.server.user.public_key_not_found"]
+other = "该用户未上传公钥。"
+
+["err.server.user.public_key_already_exists"]
+other = "该用户已上传过公钥信息。"
+
+["err.server.user.signature_not_found"]
+other = "签名校验信息不存在或已过期。"
+
+["err.server.user.signature_invalid"]
+other = "签名校验失败。"
+
+["err.server.user.verify_type_invalid"]
+other = "验证类型不匹配。"

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -223,3 +223,60 @@ other = "注册失败。"
 
 ["err.server.user.language_set_failed"]
 other = "设置语言偏好失败。"
+
+# ---- err.server.user.* (Phase 2.1 modules/user/api_manager.go migration) ----
+
+["err.server.user.manager_permission_required"]
+other = "该账号未开通管理权限。"
+
+["err.server.user.password_too_short"]
+other = "密码长度必须大于 6 位。"
+
+["err.server.user.password_mismatch"]
+other = "两次输入的密码不一致。"
+
+["err.server.user.old_password_incorrect"]
+other = "原密码错误。"
+
+["err.server.user.new_password_same_as_old"]
+other = "新密码不能与原密码相同。"
+
+["err.server.user.not_admin_account"]
+other = "该用户不是管理员账号，无法删除。"
+
+["err.server.user.cannot_delete_super_admin"]
+other = "超级管理员账号不能删除。"
+
+["err.server.user.list_filter_conflict"]
+other = "用户列表筛选条件互斥。"
+
+["err.server.user.token_cache_failed"]
+other = "更新登录令牌缓存失败。"
+
+["err.server.user.short_no_gen_failed"]
+other = "生成短编号失败。"
+
+# ---- err.server.user.* (Phase 2.1 modules/user/api_friend.go migration) ----
+
+["err.server.user.cannot_add_self"]
+other = "不能添加自己为好友。"
+
+["err.server.user.already_friend"]
+other = "已经是好友，无需重复申请。"
+
+["err.server.user.bot_not_in_space"]
+other = "该机器人不在当前空间中，无法添加。"
+
+["err.server.user.friend_apply_not_found"]
+other = "好友申请记录不存在。"
+
+["err.server.user.friend_not_found"]
+other = "好友信息不存在。"
+
+["err.server.user.friend_apply_invalid"]
+other = "好友申请无效或已过期。"
+
+# ---- err.server.user.* (Phase 2.1 modules/user/api_device.go etc.) ----
+
+["err.server.user.device_not_found"]
+other = "未查询到该设备。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -69,6 +69,9 @@ other = "This account has been deactivated."
 ["err.server.user.account_destroying"]
 other = "Account is in the deactivation cooldown period, please use a newer client to revoke or check status."
 
+["err.server.user.account_state_changed"]
+other = "Account status has changed, please refresh and try again."
+
 ["err.server.user.already_exists"]
 other = "User already exists."
 
@@ -95,6 +98,9 @@ other = "You cannot add yourself as a friend."
 
 ["err.server.user.cannot_delete_super_admin"]
 other = "The super administrator account cannot be deleted."
+
+["err.server.user.channel_access_denied"]
+other = "You do not have access to this channel."
 
 ["err.server.user.chat_pwd_update_failed"]
 other = "Failed to update chat password."
@@ -174,14 +180,32 @@ other = "The new password must be different from the current one."
 ["err.server.user.not_admin_account"]
 other = "This user is not an administrator account and cannot be deleted."
 
+["err.server.user.not_destroying"]
+other = "Account is not pending deactivation."
+
 ["err.server.user.not_found"]
 other = "User not found."
+
+["err.server.user.oauth_exchange_failed"]
+other = "Failed to exchange the OAuth access token."
+
+["err.server.user.oauth_profile_failed"]
+other = "Failed to fetch the OAuth user profile."
+
+["err.server.user.oauth_state_expired"]
+other = "Login session has expired, please try again."
 
 ["err.server.user.old_password_incorrect"]
 other = "The current password is incorrect."
 
+["err.server.user.password_incorrect"]
+other = "Incorrect password."
+
 ["err.server.user.password_mismatch"]
 other = "The two passwords do not match."
+
+["err.server.user.password_not_set"]
+other = "This account has no password set; identity cannot be verified."
 
 ["err.server.user.password_process_failed"]
 other = "Failed to process password."
@@ -191,6 +215,15 @@ other = "Password must be at least 6 characters."
 
 ["err.server.user.phone_region_unsupported"]
 other = "Only mainland China phone numbers are supported."
+
+["err.server.user.pinned_already_exists"]
+other = "This channel is already pinned."
+
+["err.server.user.pinned_limit_exceeded"]
+other = "The pinned channel limit has been reached."
+
+["err.server.user.pinned_sort_invalid"]
+other = "Invalid pinned sort request."
 
 ["err.server.user.qr_ver_code_missing"]
 other = "User has no QR verification code."

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -72,6 +72,9 @@ other = "Account is in the deactivation cooldown period, please use a newer clie
 ["err.server.user.account_state_changed"]
 other = "Account status has changed, please refresh and try again."
 
+["err.server.user.account_unavailable"]
+other = "This account has been deactivated or disabled."
+
 ["err.server.user.already_exists"]
 other = "User already exists."
 
@@ -122,6 +125,18 @@ other = "Failed to deactivate account."
 
 ["err.server.user.device_not_found"]
 other = "Device not found."
+
+["err.server.user.email_invalid"]
+other = "Invalid email address."
+
+["err.server.user.email_login_disabled"]
+other = "Email login is not available."
+
+["err.server.user.email_register_disabled"]
+other = "Email registration is not available."
+
+["err.server.user.email_send_failed"]
+other = "Failed to send the email verification code."
 
 ["err.server.user.file_operation_failed"]
 other = "Failed to process file."
@@ -225,6 +240,12 @@ other = "The pinned channel limit has been reached."
 ["err.server.user.pinned_sort_invalid"]
 other = "Invalid pinned sort request."
 
+["err.server.user.public_key_already_exists"]
+other = "A public key has already been uploaded for this user."
+
+["err.server.user.public_key_not_found"]
+other = "This user has not uploaded a public key."
+
 ["err.server.user.qr_ver_code_missing"]
 other = "User has no QR verification code."
 
@@ -249,6 +270,12 @@ other = "Short ID must start with a letter and contain 6-20 letters, digits, und
 ["err.server.user.short_no_gen_failed"]
 other = "Failed to generate a short ID."
 
+["err.server.user.signature_invalid"]
+other = "Signature verification failed."
+
+["err.server.user.signature_not_found"]
+other = "Signature challenge does not exist or has expired."
+
 ["err.server.user.sms_send_failed"]
 other = "Failed to send SMS."
 
@@ -263,6 +290,15 @@ other = "Token is required."
 
 ["err.server.user.update_not_allowed"]
 other = "This field cannot be updated."
+
+["err.server.user.username_format_invalid"]
+other = "Username must be 8-22 characters."
+
+["err.server.user.username_register_disabled"]
+other = "Username registration is not available."
+
+["err.server.user.verify_type_invalid"]
+other = "Invalid verification type."
 
 ["err.server.user.wechat_exchange_failed"]
 other = "Failed to exchange WeChat access token."

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -132,6 +132,9 @@ other = "Invalid email address."
 ["err.server.user.email_login_disabled"]
 other = "Email login is not available."
 
+["err.server.user.email_rate_limited"]
+other = "Verification codes are being sent too frequently, please try again in a minute."
+
 ["err.server.user.email_register_disabled"]
 other = "Email registration is not available."
 

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -72,6 +72,9 @@ other = "Account is in the deactivation cooldown period, please use a newer clie
 ["err.server.user.already_exists"]
 other = "User already exists."
 
+["err.server.user.already_friend"]
+other = "You are already friends."
+
 ["err.server.user.auth_code_not_found"]
 other = "Authorization code is invalid or has expired."
 
@@ -83,6 +86,15 @@ other = "Authorization payload is invalid."
 
 ["err.server.user.auth_scanner_mismatch"]
 other = "Scanner and authorizer are not the same user."
+
+["err.server.user.bot_not_in_space"]
+other = "This bot is not in the current space and cannot be added."
+
+["err.server.user.cannot_add_self"]
+other = "You cannot add yourself as a friend."
+
+["err.server.user.cannot_delete_super_admin"]
+other = "The super administrator account cannot be deleted."
 
 ["err.server.user.chat_pwd_update_failed"]
 other = "Failed to update chat password."
@@ -102,8 +114,20 @@ other = "Demo accounts cannot enable device lock."
 ["err.server.user.destroy_failed"]
 other = "Failed to deactivate account."
 
+["err.server.user.device_not_found"]
+other = "Device not found."
+
 ["err.server.user.file_operation_failed"]
 other = "Failed to process file."
+
+["err.server.user.friend_apply_invalid"]
+other = "Friend request is invalid or has expired."
+
+["err.server.user.friend_apply_not_found"]
+other = "Friend request not found."
+
+["err.server.user.friend_not_found"]
+other = "Friend not found."
 
 ["err.server.user.im_call_failed"]
 other = "Failed to call IM service."
@@ -119,6 +143,9 @@ other = "Failed to set language preference."
 
 ["err.server.user.language_unsupported"]
 other = "Unsupported language."
+
+["err.server.user.list_filter_conflict"]
+other = "Conflicting list filters."
 
 ["err.server.user.local_login_disabled"]
 other = "Local login is disabled."
@@ -138,11 +165,29 @@ other = "Too many failed login attempts, account temporarily locked. Please try 
 ["err.server.user.login_pwd_update_failed"]
 other = "Failed to update login password."
 
+["err.server.user.manager_permission_required"]
+other = "This account does not have management permission."
+
+["err.server.user.new_password_same_as_old"]
+other = "The new password must be different from the current one."
+
+["err.server.user.not_admin_account"]
+other = "This user is not an administrator account and cannot be deleted."
+
 ["err.server.user.not_found"]
 other = "User not found."
 
+["err.server.user.old_password_incorrect"]
+other = "The current password is incorrect."
+
+["err.server.user.password_mismatch"]
+other = "The two passwords do not match."
+
 ["err.server.user.password_process_failed"]
 other = "Failed to process password."
+
+["err.server.user.password_too_short"]
+other = "Password must be at least 6 characters."
 
 ["err.server.user.phone_region_unsupported"]
 other = "Only mainland China phone numbers are supported."
@@ -168,11 +213,17 @@ other = "Short ID can only be changed once."
 ["err.server.user.short_no_format_invalid"]
 other = "Short ID must start with a letter and contain 6-20 letters, digits, underscores or hyphens."
 
+["err.server.user.short_no_gen_failed"]
+other = "Failed to generate a short ID."
+
 ["err.server.user.sms_send_failed"]
 other = "Failed to send SMS."
 
 ["err.server.user.store_failed"]
 other = "Failed to persist user data."
+
+["err.server.user.token_cache_failed"]
+other = "Failed to update the session token cache."
 
 ["err.server.user.token_required"]
 other = "Token is required."


### PR DESCRIPTION
## Summary

Completes the `modules/user` i18n migration (Phase 2.1): every handler in `modules/user` is moved off the legacy `c.ResponseError` / `c.ResponseErrorf` / `c.Response("<string>")` paths onto the localized `httperr.ResponseErrorL` envelope. `api.go` landed in #188; this PR covers the remaining **11 handler files** (~385 sites) and touches `api.go` only to add the shared execLogin error classifier.

`TestMigratedUserFilesNoLegacyResponseError` + the api.go / api_manager guards pin the module against regressing to legacy response calls (including the `c.Response("<string>")`-as-error shape).

## Files

| File | Sites | Domain |
|---|---|---|
| `api_manager.go` | 86 | management console (2 `c.Response("...")` bug fixes) |
| `api_friend.go` | 83 | friends / contacts |
| `api_online.go` / `api_setting.go` / `api_maillist.go` / `api_device.go` | 28 | online / settings / address book / devices |
| `api_destroy.go` | 18 | account deactivation |
| `api_pinned.go` | 21 | pinned channels |
| `api_gitee.go` / `api_github.go` | 30 | OAuth login |
| `api_emaillogin.go` | 51 | email login / register / forgot-password |
| `api_usernamelogin.go` | 68 | username + Web3-signature login (1 `c.Response(errors.New(...))` bug fix) |

- **41 new `err.server.user.*` codes** (+ reuse of the #188 set and shared `auth.forbidden`).
- Helpers: `respondManagerForbidden`, `respondUserListFilterConflict`, `respondUserPinnedLimitExceeded`.
- zh-CN translations added; extractor markers regenerated.

## Error classification (status semantics)

The migration's goal is **semantic status codes**, so client-actionable states stay 4xx and only genuine internal faults are 5xx:

- Role guards → `403`; validation / `BindJSON` → `400`; service/DB/third-party errors are **logged server-side** and never put `err.Error()` on the wire.
- **Login is the same mechanical swap as the rest** — the pre-existing anti-enumeration logic (password path → `invalid_credentials`, code path → original semantics) is preserved unchanged; `loginGuard.Check` → `login_locked` (429), closing the 3 sites @yujiawei flagged (destroy/email/username).
- **`execLogin` errors are now classified in one place** (`respondExecLoginError`, shared by main / OAuth / email / username): disabled account → `403`, missing device info → `400`, `ErrUserNeedVerification` keeps its `110` response, genuine internal failure → `500`. This also fixes the main login path (`execLoginAndRespose`) which previously collapsed disabled/device onto `500`.
- Email verify-code resend cooldown → `429` (`ErrUserEmailRateLimited`, via a typed `ErrEmailSendRateLimited` sentinel), not a `500` send-failure.
- Expired/missing friend-apply token → `400` (`ErrUserFriendApplyInvalid`); only a real Redis fault → `500`.

## ⚠️ Behavior change

Statuses move from a uniform 400 to semantic values (401/403/404/409/429/500), consistent with the `/v1/user/*` migration in #188. The dual envelope still emits `{msg,status}` for legacy compatibility; clients read `error.code`. The execLogin classifier additionally changes the **main** login's disabled-account response from 500 → 403 (a correctness improvement, aligned with #188's stated goal).

## Tests & gates

- `TestRespondUserHelpers` (helper/code coverage), `TestRespondExecLoginError` (4-way execLogin classification), `TestMigratedUserFilesNoLegacyResponseError` (legacy-call guard over all 11 files).
- `go build ./...`, `go vet`, `make i18n-extract-check`, `make i18n-lint` (D23 + unregistered-code) green; `go test ./modules/user/ ./modules/base/common/ ./pkg/i18n/... ./pkg/errcode/...` passes (DB-backed included).

## Review rounds resolved

- **Round 1** (tx-leak / gofmt / logging): `tx.Rollback()` added to all early returns after `Begin()` in `friendSure` / `delete` / `addUser`; gofmt on touched files; `zap.Error` added to internal-error logs.
- **Round 2** (status-semantics): the execLogin / email-rate-limit / friend-token / liftBanUser classification fixes above.

## Follow-up (not blocking)

- Service-layer sentinel extraction for the remaining `EmailService.Verify` / `source.Check*` paths (internal-vs-validation), and the SMS resend cooldown (`service_sms.go`) reusing the same sentinel pattern.
- `addSystemFriend` helper tx-rollback (untouched by this PR; returns `error`, not a response).
- `api_pinned.go` `validateChannelAccess` internal failures collapse to 403 (logged) — splitting to 5xx deferred.
