### PR TITLE
feat(i18n): migrate modules/message to ResponseErrorL (Phase 2.1)

### DIFF
--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -2243,8 +2243,7 @@ func (m *Message) revoke(c *wkhttp.Context) {
 		ClientMsgNos: cliengMsgNos,
 	})
 	if err != nil {
-		m.Error("查询IM消息错误", zap.String("fakeChannelID", fakeChannelID), zap.String("clientMsgNo", clientMsgNo), zap.String("loginUID", c.GetLoginUID()))
-		m.Error("查询IM消息错误", zap.Error(err))
+		m.Error("查询IM消息错误", zap.String("fakeChannelID", fakeChannelID), zap.String("clientMsgNo", clientMsgNo), zap.String("loginUID", c.GetLoginUID()), zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -30,6 +30,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
@@ -343,7 +345,7 @@ func (m *Message) Route(r *wkhttp.WKHttp) {
 
 func (m *Message) sendMsg(c *wkhttp.Context) {
 	if !m.ctx.GetConfig().Message.SendMessageOn {
-		c.ResponseError(errors.New("不支持代发消息"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageProxySendUnsupported, nil, nil)
 		return
 	}
 	var req struct {
@@ -353,39 +355,39 @@ func (m *Message) sendMsg(c *wkhttp.Context) {
 		Payload            map[string]interface{} `json:"payload"`              // 消息体
 	}
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseErrorf("数据格式有误！", err)
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	if req.Token == "" {
-		c.ResponseError(errors.New("发送者token不能为空"))
+		respondMessageRequestInvalid(c, "token")
 		return
 	}
 	if req.ReceiveChannelID == "" {
-		c.ResponseError(errors.New("接受channelID不能为空"))
+		respondMessageRequestInvalid(c, "channel_id")
 		return
 	}
 	if req.Payload == nil {
-		c.ResponseError(errors.New("消息不能为空"))
+		respondMessageRequestInvalid(c, "payload")
 		return
 	}
 	raw, err := m.ctx.Cache().Get(m.ctx.GetConfig().Cache.TokenCachePrefix + req.Token)
 	if err != nil {
 		m.Error("解析token错误", zap.Error(err))
-		c.ResponseError(errors.New("解析token错误"))
+		respondMessageTokenInvalid(c)
 		return
 	}
 	if strings.TrimSpace(raw) == "" {
-		c.ResponseError(errors.New("请先登录"))
+		respondMessageNotLoggedIn(c)
 		return
 	}
 	info, decodeErr := auth.Decode(raw)
 	if decodeErr != nil {
-		c.ResponseError(errors.New("token错误"))
+		respondMessageTokenInvalid(c)
 		return
 	}
 	uid := info.UID
 	if uid == "" {
-		c.ResponseError(errors.New("发送者不能为空"))
+		respondMessageRequestInvalid(c, "from_uid")
 		return
 	}
 
@@ -396,11 +398,11 @@ func (m *Message) sendMsg(c *wkhttp.Context) {
 			bothOk, err := spacepkg.CheckBothMembers(m.ctx.DB(), spaceID, uid, peerID)
 			if err != nil {
 				m.Error("校验 Space 成员关系错误", zap.Error(err))
-				c.ResponseError(errors.New("校验成员关系错误"))
+				httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 				return
 			}
 			if !bothOk {
-				c.ResponseError(errors.New("对方不在该 Space 内"))
+				httperr.ResponseErrorL(c, errcode.ErrMessagePeerNotInSpace, nil, nil)
 				return
 			}
 		} else {
@@ -408,21 +410,21 @@ func (m *Message) sendMsg(c *wkhttp.Context) {
 			sendUserIsFriend, err := m.userService.IsFriend(uid, req.ReceiveChannelID)
 			if err != nil {
 				m.Error("查询发送者与接受者好友关系错误", zap.Error(err))
-				c.ResponseError(errors.New("查询好友关系错误"))
+				httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 				return
 			}
 			if !sendUserIsFriend {
-				c.ResponseError(errors.New("发送者与接受者不是好友"))
+				httperr.ResponseErrorL(c, errcode.ErrMessageNotFriend, nil, nil)
 				return
 			}
 			recvUserIsFriend, err := m.userService.IsFriend(req.ReceiveChannelID, uid)
 			if err != nil {
 				m.Error("查询接受者与发送者好友关系错误", zap.Error(err))
-				c.ResponseError(errors.New("查询接受者与发送者好友关系错误"))
+				httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 				return
 			}
 			if !recvUserIsFriend {
-				c.ResponseError(errors.New("接受者与发送者不是好友"))
+				httperr.ResponseErrorL(c, errcode.ErrMessageNotFriend, nil, nil)
 				return
 			}
 		}
@@ -431,11 +433,11 @@ func (m *Message) sendMsg(c *wkhttp.Context) {
 		isExist, err := m.groupService.ExistMember(req.ReceiveChannelID, uid)
 		if err != nil {
 			m.Error("查询发送者是否在群内错误", zap.Error(err))
-			c.ResponseError(errors.New("查询发送者是否在群内错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if !isExist {
-			c.ResponseError(errors.New("未在群内"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageNotGroupMember, nil, nil)
 			return
 		}
 	}
@@ -444,7 +446,8 @@ func (m *Message) sendMsg(c *wkhttp.Context) {
 	senderSpaceID := spacepkg.GetSpaceID(c)
 	err = m.sendMessage(req.ReceiveChannelID, req.ReceiveChannelType, uid, req.Payload, senderSpaceID)
 	if err != nil {
-		c.ResponseError(err)
+		m.Error("发送消息失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -675,19 +678,19 @@ func (m *Message) messageEdit(c *wkhttp.Context) {
 		ContentEdit string `json:"content_edit"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseErrorf("数据格式有误！", err)
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	if req.MessageID == "" {
-		c.ResponseError(errors.New("消息ID不能为空！"))
+		respondMessageRequestInvalid(c, "message_id")
 		return
 	}
 	if req.MessageSeq == 0 {
-		c.ResponseError(errors.New("消息序号不能为空！"))
+		respondMessageRequestInvalid(c, "message_seq")
 		return
 	}
 	if req.ChannelID == "" {
-		c.ResponseError(errors.New("频道ID不能为空！"))
+		respondMessageRequestInvalid(c, "channel_id")
 		return
 	}
 
@@ -697,20 +700,20 @@ func (m *Message) messageEdit(c *wkhttp.Context) {
 	resp, err := m.ctx.IMGetWithChannelAndSeqs(req.ChannelID, req.ChannelType, loginUID, messageSeqs)
 	if err != nil {
 		m.Error("查询消息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询消息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	if resp == nil || len(resp.Messages) == 0 {
-		c.ResponseError(errors.New("消息不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
 		return
 	}
 	if resp.Messages[0].FromUID != loginUID {
-		c.ResponseError(errors.New("只能编辑自己发送的消息"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageEditOwnOnly, nil, nil)
 		return
 	}
 	// TOCTOU 交叉校验：确保权限检查的消息与待编辑的消息是同一条
 	if req.MessageID != strconv.FormatInt(resp.Messages[0].MessageID, 10) {
-		c.ResponseError(errors.New("消息ID与消息序号不匹配"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageIDSeqMismatch, nil, nil)
 		return
 	}
 
@@ -720,7 +723,7 @@ func (m *Message) messageEdit(c *wkhttp.Context) {
 	exist, err := m.messageExtraDB.existContentEdit(req.MessageID, contentMD5)
 	if err != nil {
 		m.Error("查询是否存在相同正文失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询是否存在相同正文失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	if exist {
@@ -732,7 +735,7 @@ func (m *Message) messageEdit(c *wkhttp.Context) {
 	tx, err := m.db.session.Begin()
 	if err != nil {
 		m.Error("开启事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("开启事务失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	defer tx.RollbackUnlessCommitted()
@@ -749,7 +752,7 @@ func (m *Message) messageEdit(c *wkhttp.Context) {
 	version, err := m.genMessageExtraSeq(fakeChannelID)
 	if err != nil {
 		m.Error("生成消息扩展序列号失败！", zap.Error(err))
-		c.ResponseError(errors.New("生成消息扩展序列号失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	err = m.messageExtraDB.insertOrUpdateContentEditTx(&messageExtraModel{
@@ -764,7 +767,7 @@ func (m *Message) messageEdit(c *wkhttp.Context) {
 	}, tx)
 	if err != nil {
 		m.Error("添加或修改编辑内容失败！", zap.Error(err))
-		c.ResponseError(errors.New("添加或修改编辑内容失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	msgIds := make([]string, 0)
@@ -783,13 +786,14 @@ func (m *Message) messageEdit(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			m.Error("开启事件失败！", zap.Error(err))
-			c.ResponseError(errors.New("开启事件失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 	}
 	if err := tx.Commit(); err != nil {
 		tx.Rollback()
-		c.ResponseErrorf("事务提交失败！", err)
+		m.Error("事务提交失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	if eventID > 0 {
@@ -806,7 +810,7 @@ func (m *Message) messageEdit(c *wkhttp.Context) {
 
 	if err != nil {
 		m.Error("发送cmd失败！", zap.Error(err))
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -821,11 +825,11 @@ func (m *Message) messageReaded(c *wkhttp.Context) {
 		ChannelType uint8    `json:"channel_type"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseErrorf("数据格式有误！", err)
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	if len(req.MessageIDs) == 0 {
-		c.ResponseError(errors.New("message_ids不能为空！"))
+		respondMessageRequestInvalid(c, "message_ids")
 		return
 	}
 	// var cloneNo string
@@ -850,18 +854,19 @@ func (m *Message) messageReaded(c *wkhttp.Context) {
 		LoginUID:    loginUID,
 	})
 	if err != nil {
-		c.ResponseErrorf("查询消息失败！", err)
+		m.Error("查询消息失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	if syncMsg == nil || len(syncMsg.Messages) <= 0 {
 		m.Warn("没有读取到消息！", zap.Strings("messages", req.MessageIDs))
-		c.ResponseError(errors.New("没有读取到消息！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
 		return
 	}
 	tx, err := m.ctx.DB().Begin()
 	if err != nil {
 		m.Error("开启事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("开启事务失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	defer func() {
@@ -885,12 +890,14 @@ func (m *Message) messageReaded(c *wkhttp.Context) {
 	err = m.memberReadedDB.batchInsertOrUpdateTx(readedModels, tx)
 	if err != nil {
 		tx.Rollback()
-		c.ResponseErrorf("添加已读数据失败！", err)
+		m.Error("添加已读数据失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	if err := tx.Commit(); err != nil {
 		tx.Rollback()
-		c.ResponseErrorf("提交事务失败！", err)
+		m.Error("提交事务失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	// 异步处理 Redis 缓存
@@ -953,7 +960,8 @@ func (m *Message) messageReceiptList(c *wkhttp.Context) {
 	if readed == "1" {
 		memberReadedModels, err := m.memberReadedDB.queryWithMessageIDAndPage(messageIDStr, uint64(pIndex), uint64(pSize))
 		if err != nil {
-			c.ResponseErrorf("查询已读列表失败！", err)
+			m.Error("查询已读列表失败", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if len(memberReadedModels) > 0 {
@@ -964,7 +972,8 @@ func (m *Message) messageReceiptList(c *wkhttp.Context) {
 	}
 	userResps, err := m.userService.GetUsers(uids)
 	if err != nil {
-		c.ResponseErrorf("查询用户数据失败！", err)
+		m.Error("查询用户数据失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	userMap := map[string]*user.Resp{}
@@ -1031,7 +1040,7 @@ func (m *Message) syncMessageExtra(c *wkhttp.Context) {
 		Limit        int    `json:"limit"`  // 数据限制
 	}
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseErrorf("数据格式有误！", err)
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 
@@ -1040,7 +1049,7 @@ func (m *Message) syncMessageExtra(c *wkhttp.Context) {
 		exist, err := m.groupService.ExistMember(req.ChannelID, c.GetLoginUID())
 		if err != nil {
 			m.Error("查询是否在群内存在失败！", zap.Error(err))
-			c.ResponseError(errors.New("查询是否在群内存在失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if !exist {
@@ -1055,7 +1064,8 @@ func (m *Message) syncMessageExtra(c *wkhttp.Context) {
 	}
 	cacheExtraVersion, err := m.getMessageExtraVersion(c.GetLoginUID(), req.Source, fakeChannelID, req.ChannelType)
 	if err != nil {
-		c.ResponseErrorf("从缓存中获取消息扩展版本失败！", err)
+		m.Error("从缓存中获取消息扩展版本失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	extraVersion := req.ExtraVersion
@@ -1064,7 +1074,8 @@ func (m *Message) syncMessageExtra(c *wkhttp.Context) {
 	} else {
 		err = m.setMessageExtraVersion(c.GetLoginUID(), fakeChannelID, req.ChannelType, req.Source, extraVersion)
 		if err != nil {
-			c.ResponseErrorf("缓存最大的消息扩展版本失败！", err)
+			m.Error("缓存最大的消息扩展版本失败", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 
@@ -1077,12 +1088,13 @@ func (m *Message) syncMessageExtra(c *wkhttp.Context) {
 		limit = 10000
 	}
 	if strings.TrimSpace(req.ChannelID) == "" {
-		c.ResponseError(errors.New("频道ID不能为空！"))
+		respondMessageRequestInvalid(c, "channel_id")
 		return
 	}
 	extraModels, err := m.messageExtraDB.sync(extraVersion, fakeChannelID, req.ChannelType, uint64(limit), c.GetLoginUID())
 	if err != nil {
-		c.ResponseErrorf("同步消息扩展数据失败！", err)
+		m.Error("同步消息扩展数据失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	resps := make([]*messageExtraResp, 0, len(extraModels))
@@ -1099,7 +1111,7 @@ func (m *Message) syncChannelMessage(c *wkhttp.Context) {
 	var req config.SyncChannelMessageReq
 	if err := c.BindJSON(&req); err != nil {
 		m.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 
@@ -1108,7 +1120,7 @@ func (m *Message) syncChannelMessage(c *wkhttp.Context) {
 		exist, err := m.groupService.ExistMember(req.ChannelID, c.GetLoginUID())
 		if err != nil {
 			m.Error("查询是否在群内存在失败！", zap.Error(err))
-			c.ResponseError(errors.New("查询是否在群内存在失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if !exist {
@@ -1125,7 +1137,7 @@ func (m *Message) syncChannelMessage(c *wkhttp.Context) {
 	resp, err := m.ctx.IMSyncChannelMessage(req)
 	if err != nil {
 		m.Error("同步频道内的消息失败！", zap.Error(err), zap.String("req", util.ToJson(req)))
-		c.ResponseError(errors.New("同步频道内的消息失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	fakeChannelID := req.ChannelID
@@ -1137,7 +1149,7 @@ func (m *Message) syncChannelMessage(c *wkhttp.Context) {
 	channelSettings, err := m.channelService.GetChannelSettings(channelIds)
 	if err != nil {
 		m.Error("查询频道设置错误", zap.Error(err), zap.String("req", util.ToJson(req)))
-		c.ResponseError(errors.New("查询频道设置错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	var channelOffsetMessageSeq uint32 = 0
@@ -1184,7 +1196,7 @@ func (m *Message) typing(c *wkhttp.Context) {
 		ChannelType uint8  `json:"channel_type"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(err)
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	channelID := req.ChannelID
@@ -1206,7 +1218,8 @@ func (m *Message) typing(c *wkhttp.Context) {
 		},
 	})
 	if err != nil {
-		c.ResponseError(err)
+		m.Error("发送cmd失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -1224,7 +1237,7 @@ func (m *Message) search(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		m.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(err)
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	uid := c.MustGet("uid").(string)
@@ -1246,20 +1259,20 @@ func (m *Message) search(c *wkhttp.Context) {
 	resp, err := network.Post(fmt.Sprintf("%s/message/search", m.ctx.GetConfig().WuKongIM.APIURL), []byte(util.ToJson(req)), headers)
 	if err != nil {
 		m.Error("调用搜索失败！", zap.Error(err))
-		c.ResponseError(errors.New("调用搜索失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageSearchFailed, nil, nil)
 		return
 	}
 	err = m.handlerIMError(resp)
 	if err != nil {
 		m.Error("调用搜索错误！", zap.Error(err))
-		c.ResponseError(errors.New("调用搜索错误！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageSearchFailed, nil, nil)
 		return
 	}
 	var results []map[string]interface{}
 	err = util.ReadJsonByByte([]byte(resp.Body), &results)
 	if err != nil {
 		m.Error("解析搜索数据失败！", zap.Error(err))
-		c.ResponseError(errors.New("解析搜索数据失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageSearchFailed, nil, nil)
 		return
 	}
 
@@ -1268,7 +1281,7 @@ func (m *Message) search(c *wkhttp.Context) {
 		results, err = m.filterResultsBySpace(results, spaceID)
 		if err != nil {
 			m.Error("Space 过滤失败！", zap.Error(err))
-			c.ResponseError(errors.New("Space 过滤失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageSearchFailed, nil, nil)
 			return
 		}
 	}
@@ -1353,11 +1366,11 @@ func (m *Message) matchPayloadSpaceID(msg map[string]interface{}, spaceID string
 func (m *Message) voiceReaded(c *wkhttp.Context) {
 	var req *voiceReadedReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseErrorf("数据格式有误！", err)
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	if err := req.check(); err != nil {
-		c.ResponseError(err)
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	loginUID := c.GetLoginUID()
@@ -1371,7 +1384,8 @@ func (m *Message) voiceReaded(c *wkhttp.Context) {
 		VoiceReaded: 1,
 	})
 	if err != nil {
-		c.ResponseErrorf("修改语音已读状态失败！", err)
+		m.Error("修改语音已读状态失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -1388,7 +1402,7 @@ func (m *Message) syncReaction(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		m.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	// Verify channel membership before syncing reaction data
@@ -1396,11 +1410,11 @@ func (m *Message) syncReaction(c *wkhttp.Context) {
 		isMember, err := m.groupService.ExistMember(req.ChannelID, loginUID)
 		if err != nil {
 			m.Error("查询群成员关系错误", zap.Error(err))
-			c.ResponseError(errors.New("查询群成员关系错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if !isMember {
-			c.ResponseError(errors.New("没有权限同步此频道的回应数据"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageChannelAccessDenied, nil, nil)
 			return
 		}
 	} else if req.ChannelType == common.ChannelTypePerson.Uint8() {
@@ -1408,11 +1422,11 @@ func (m *Message) syncReaction(c *wkhttp.Context) {
 			isFriend, err := m.userService.IsFriend(loginUID, req.ChannelID)
 			if err != nil {
 				m.Error("查询好友关系错误", zap.Error(err))
-				c.ResponseError(errors.New("查询好友关系错误"))
+				httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 				return
 			}
 			if !isFriend {
-				c.ResponseError(errors.New("没有权限同步此频道的回应数据"))
+				httperr.ResponseErrorL(c, errcode.ErrMessageChannelAccessDenied, nil, nil)
 				return
 			}
 		}
@@ -1443,7 +1457,7 @@ func (m *Message) syncReaction(c *wkhttp.Context) {
 	list, err := m.messageReactionDB.queryReactionWithChannelAndSeq(fakeChannelID, req.ChannelType, req.Seq, limit)
 	if err != nil {
 		m.Error("获取缓存seq错误", zap.Error(err))
-		c.ResponseError(errors.New("获取缓存seq错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 
@@ -1480,7 +1494,7 @@ func (m *Message) addOrCancelReaction(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		m.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	// Verify channel membership before allowing reaction
@@ -1488,11 +1502,11 @@ func (m *Message) addOrCancelReaction(c *wkhttp.Context) {
 		isMember, err := m.groupService.ExistMember(req.ChannelID, loginUID)
 		if err != nil {
 			m.Error("查询群成员关系错误", zap.Error(err))
-			c.ResponseError(errors.New("查询群成员关系错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if !isMember {
-			c.ResponseError(errors.New("没有权限操作此频道"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageChannelAccessDenied, nil, nil)
 			return
 		}
 	} else if req.ChannelType == common.ChannelTypePerson.Uint8() {
@@ -1500,11 +1514,11 @@ func (m *Message) addOrCancelReaction(c *wkhttp.Context) {
 			isFriend, err := m.userService.IsFriend(loginUID, req.ChannelID)
 			if err != nil {
 				m.Error("查询好友关系错误", zap.Error(err))
-				c.ResponseError(errors.New("查询好友关系错误"))
+				httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 				return
 			}
 			if !isFriend {
-				c.ResponseError(errors.New("没有权限操作此频道"))
+				httperr.ResponseErrorL(c, errcode.ErrMessageChannelAccessDenied, nil, nil)
 				return
 			}
 		}
@@ -1513,7 +1527,7 @@ func (m *Message) addOrCancelReaction(c *wkhttp.Context) {
 	model, err := m.messageReactionDB.queryReactionWithUIDAndMessageID(loginUID, req.MessageID)
 	if err != nil {
 		m.Error("查询登录用户是否回应消息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询登录用户是否回应消息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	fakeChannelID := req.ChannelID
@@ -1522,7 +1536,8 @@ func (m *Message) addOrCancelReaction(c *wkhttp.Context) {
 	}
 	seq, err := m.genMessageReactionSeq(fakeChannelID) // 下次回复seq
 	if err != nil {
-		c.ResponseError(err)
+		m.Error("生成消息回应序列号失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	if model == nil {
@@ -1539,7 +1554,7 @@ func (m *Message) addOrCancelReaction(c *wkhttp.Context) {
 		})
 		if err != nil {
 			m.Error("新增消息回应错误", zap.Error(err))
-			c.ResponseError(errors.New("新增消息回应错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 	} else {
@@ -1559,7 +1574,7 @@ func (m *Message) addOrCancelReaction(c *wkhttp.Context) {
 		err = m.messageReactionDB.updateReactionStatus(model)
 		if err != nil {
 			m.Error("修改消息回应错误", zap.Error(err))
-			c.ResponseError(errors.New("修改消息回应错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 	}
@@ -1574,7 +1589,8 @@ func (m *Message) addOrCancelReaction(c *wkhttp.Context) {
 	})
 	if err != nil {
 		m.Error("发送同步命令失败！", zap.Error(err))
-		c.ResponseErrorf("发送同步命令失败！", err)
+		m.Error("发送同步命令失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
 		return
 	}
 
@@ -1603,7 +1619,7 @@ func (m *Message) syncack(c *wkhttp.Context) {
 	lastMessageSeq, err := strconv.ParseUint(lastMessageSeqStr, 10, 64)
 	if err != nil {
 		m.Error("last_message_seq格式有误！", zap.String("last_message_seq", lastMessageSeqStr))
-		c.ResponseError(errors.New("last_message_seq格式有误！"))
+		respondMessageRequestInvalid(c, "last_message_seq")
 		return
 	}
 	err = m.ctx.IMSyncMessageAck(&config.SyncackReq{
@@ -1612,7 +1628,7 @@ func (m *Message) syncack(c *wkhttp.Context) {
 	})
 	if err != nil {
 		m.Error("同步消息回执失败！", zap.Error(err), zap.String("uid", uid), zap.String("last_message_seq", lastMessageSeqStr))
-		c.ResponseError(errors.New("同步消息回执失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -1624,7 +1640,7 @@ func (m *Message) sync(c *wkhttp.Context) {
 	var req syncReq
 	if err := c.BindJSON(&req); err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(common.ErrData)
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	resps, err := m.ctx.IMSyncMessage(&config.MsgSyncReq{
@@ -1634,7 +1650,7 @@ func (m *Message) sync(c *wkhttp.Context) {
 	})
 	if err != nil {
 		m.Error("同步消息失败！", zap.Error(err), zap.String("uid", uid))
-		c.ResponseError(errors.New("同步消息失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	messageIDs := make([]string, 0, len(resps))
@@ -1668,7 +1684,7 @@ func (m *Message) sync(c *wkhttp.Context) {
 	channelOffsetM, err := m.channelOffsetDB.queryWithUIDAndChannel(c.GetLoginUID(), req.ChannelID, req.ChannelType)
 	if err != nil {
 		m.Error("查询偏移量失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询偏移量失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	// 频道偏移
@@ -1681,7 +1697,7 @@ func (m *Message) sync(c *wkhttp.Context) {
 	channelSettings, err := m.channelService.GetChannelSettings(channelIds)
 	if err != nil {
 		m.Error("查询频道设置错误", zap.Error(err), zap.String("req", util.ToJson(req)))
-		c.ResponseError(errors.New("查询频道设置错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	var channelOffsetMessageSeq uint32 = 0
@@ -1717,11 +1733,11 @@ func (m *Message) mutualDelete(c *wkhttp.Context) {
 	var req deleteReq
 	if err := c.BindJSON(&req); err != nil {
 		m.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	if err := req.check(); err != nil {
-		c.ResponseError(err)
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	messageSeqs := make([]uint32, 0)
@@ -1733,12 +1749,12 @@ func (m *Message) mutualDelete(c *wkhttp.Context) {
 	resp, err := m.ctx.IMGetWithChannelAndSeqs(req.ChannelID, req.ChannelType, loginUID, messageSeqs)
 	if err != nil {
 		m.Error("查询消息错误", zap.Error(err), zap.String("req", util.ToJson(req)))
-		c.ResponseError(errors.New("查询消息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 
 	if resp == nil || len(resp.Messages) == 0 {
-		c.ResponseError(errors.New("消息不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
 		return
 	}
 	var (
@@ -1752,14 +1768,14 @@ func (m *Message) mutualDelete(c *wkhttp.Context) {
 		isGroupMember, err = m.groupService.ExistMember(req.ChannelID, loginUID)
 		if err != nil {
 			m.Error("查询群成员关系失败", zap.Error(err))
-			c.ResponseError(errors.New("查询群成员关系失败"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if isGroupMember {
 			isGroupManager, err = m.groupService.IsCreatorOrManager(req.ChannelID, loginUID)
 			if err != nil {
 				m.Error("查询登录用户群内权限错误", zap.Error(err))
-				c.ResponseError(errors.New("查询登录用户群内权限错误"))
+				httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 				return
 			}
 		}
@@ -1767,20 +1783,20 @@ func (m *Message) mutualDelete(c *wkhttp.Context) {
 		parentGroupNo, _, perr := thread.ParseChannelID(req.ChannelID)
 		if perr != nil {
 			m.Error("解析子区频道ID失败", zap.Error(perr), zap.String("channelID", req.ChannelID))
-			c.ResponseError(errors.New("用户无权删除此消息"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageDeleteForbidden, nil, nil)
 			return
 		}
 		isParentGroupMember, err = m.groupService.ExistMember(parentGroupNo, loginUID)
 		if err != nil {
 			m.Error("查询父群成员关系失败", zap.Error(err))
-			c.ResponseError(errors.New("查询父群成员关系失败"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if isParentGroupMember {
 			isParentGroupManager, err = m.groupService.IsCreatorOrManager(parentGroupNo, loginUID)
 			if err != nil {
 				m.Error("查询父群管理员身份失败", zap.Error(err))
-				c.ResponseError(errors.New("查询父群管理员身份失败"))
+				httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 				return
 			}
 		}
@@ -1794,19 +1810,19 @@ func (m *Message) mutualDelete(c *wkhttp.Context) {
 		isParentGroupMember,
 		isParentGroupManager,
 	); err != nil {
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrMessageDeleteForbidden, nil, nil)
 		return
 	}
 	// TOCTOU 交叉校验：确保权限检查的消息与待删除的消息是同一条
 	resolvedMessageID := strconv.FormatInt(resp.Messages[0].MessageID, 10)
 	if req.MessageID != resolvedMessageID {
-		c.ResponseError(errors.New("消息ID与消息序号不匹配"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageIDSeqMismatch, nil, nil)
 		return
 	}
 	version, err := m.genMessageExtraSeq(fakeChannelID)
 	if err != nil {
 		m.Error("生成消息扩展序列号失败！", zap.Error(err))
-		c.ResponseError(errors.New("生成消息扩展序列号失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	err = m.messageExtraDB.insertOrUpdateDeleted(&messageExtraModel{
@@ -1818,7 +1834,7 @@ func (m *Message) mutualDelete(c *wkhttp.Context) {
 	})
 	if err != nil {
 		m.Error("删除消息错误", zap.Error(err))
-		c.ResponseError(errors.New("删除消息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	err = m.ctx.SendCMD(config.MsgCMDReq{
@@ -1831,7 +1847,7 @@ func (m *Message) mutualDelete(c *wkhttp.Context) {
 
 	if err != nil {
 		m.Error("发送cmd失败！", zap.Error(err))
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -1843,16 +1859,16 @@ func (m *Message) delete(c *wkhttp.Context) {
 	var reqs []*deleteReq
 	if err := c.BindJSON(&reqs); err != nil {
 		m.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	if len(reqs) == 0 {
-		c.ResponseError(errors.New("参数不能为空！"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	for _, req := range reqs {
 		if err := req.check(); err != nil {
-			c.ResponseError(err)
+			respondMessageRequestInvalid(c, "")
 			return
 		}
 	}
@@ -1870,11 +1886,11 @@ func (m *Message) delete(c *wkhttp.Context) {
 			isMember, err := m.groupService.ExistMember(req.ChannelID, loginUID)
 			if err != nil {
 				m.Error("查询群成员失败", zap.Error(err))
-				c.ResponseError(errors.New("查询群成员失败"))
+				httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 				return
 			}
 			if !isMember {
-				c.ResponseError(errors.New("非频道成员，无权操作"))
+				httperr.ResponseErrorL(c, errcode.ErrMessageChannelAccessDenied, nil, nil)
 				return
 			}
 		}
@@ -1883,7 +1899,7 @@ func (m *Message) delete(c *wkhttp.Context) {
 	tx, err := m.ctx.DB().Begin()
 	if err != nil {
 		m.Error("开启事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("开启事务失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	defer func() {
@@ -1904,14 +1920,14 @@ func (m *Message) delete(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			m.Error("删除消息失败！", zap.Error(err))
-			c.ResponseError(errors.New("删除消息失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 	}
 	if err := tx.Commit(); err != nil {
 		tx.Rollback()
 		m.Error("提交事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("提交事务失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 
@@ -1926,7 +1942,7 @@ func (m *Message) delete(c *wkhttp.Context) {
 	})
 	if err != nil {
 		m.Error("发送命令失败", zap.Error(err))
-		c.ResponseError(errors.New("发送命令失败"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
 		return
 	}
 
@@ -1950,13 +1966,13 @@ func (m *Message) offset(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		m.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	channelOffsetM, err := m.channelOffsetDB.queryWithUIDAndChannel(c.GetLoginUID(), req.ChannelID, req.ChannelType)
 	if err != nil {
 		m.Error("查询频道偏移数据失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询频道偏移数据失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	if channelOffsetM != nil {
@@ -1974,7 +1990,7 @@ func (m *Message) offset(c *wkhttp.Context) {
 	})
 	if err != nil {
 		m.Error("清除失败！", zap.Error(err))
-		c.ResponseError(errors.New("清除失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	// 清除最近会话的未读数（这里不管有没有未读数都调用清除）
@@ -1992,7 +2008,7 @@ func (m *Message) offset(c *wkhttp.Context) {
 	reminders, err := m.remindersDB.queryWithUIDAndChannel(loginUID, req.ChannelID, req.ChannelType, req.MessageSeq)
 	if err != nil {
 		m.Error("查询用户提醒项失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询用户提醒项失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	reminderIds := make([]int64, 0)
@@ -2008,7 +2024,7 @@ func (m *Message) offset(c *wkhttp.Context) {
 		tx, err := m.ctx.DB().Begin()
 		if err != nil {
 			m.Error("开启事务失败！", zap.Error(err))
-			c.ResponseError(errors.New("开启事务失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 		defer tx.RollbackUnlessCommitted()
@@ -2021,27 +2037,28 @@ func (m *Message) offset(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			m.Error("更新提醒项状态失败！", zap.Error(err))
-			c.ResponseError(errors.New("更新提醒项状态失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 		for _, id := range reminderIds {
 			version, err := m.ctx.GenSeq(common.RemindersKey)
 			if err != nil {
-				c.ResponseError(err)
+				m.Error("生成提醒项序列号失败", zap.Error(err))
+				httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 				return
 			}
 			err = m.remindersDB.updateVersionTx(version, id, tx)
 			if err != nil {
 				tx.Rollback()
 				m.Error("更新提醒项版本失败！", zap.Error(err))
-				c.ResponseError(errors.New("更新提醒项版本失败！"))
+				httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 				return
 			}
 		}
 		if err := tx.Commit(); err != nil {
 			tx.Rollback()
 			m.Error("提交事务失败！", zap.Error(err))
-			c.ResponseError(errors.New("提交事务失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 		err = m.ctx.SendCMD(config.MsgCMDReq{
@@ -2206,7 +2223,7 @@ func (m *Message) revoke(c *wkhttp.Context) {
 	channelType := c.Query("channel_type")
 
 	if strings.TrimSpace(clientMsgNo) == "" {
-		c.ResponseError(errors.New("撤回主键参数错误！"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 
@@ -2227,18 +2244,19 @@ func (m *Message) revoke(c *wkhttp.Context) {
 	})
 	if err != nil {
 		m.Error("查询IM消息错误", zap.String("fakeChannelID", fakeChannelID), zap.String("clientMsgNo", clientMsgNo), zap.String("loginUID", c.GetLoginUID()))
-		c.ResponseErrorf("查询IM消息错误", err)
+		m.Error("查询IM消息错误", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	if syncMsgs == nil || len(syncMsgs.Messages) == 0 {
-		c.ResponseErrorf("未查询到撤回消息！", err)
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
 		return
 	}
 	syncMsg := syncMsgs.Messages[0]
 	// TOCTOU 交叉校验：若用户传入了 message_id，必须与 clientMsgNo 反查到的 messageID 一致，
 	// 防止通过自己消息的 clientMsgNo 配合他人消息的 messageID 撤回任意消息（issue #1048）。
 	if err := verifyRevokeMessageID(messageID, syncMsg.MessageID); err != nil {
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrMessageIDSeqMismatch, nil, nil)
 		return
 	}
 	// 下游操作统一改用 IM 反查到的可信 channelID / channelType，
@@ -2262,11 +2280,11 @@ func (m *Message) revoke(c *wkhttp.Context) {
 	allow, err := m.hasRevokePermission(message, c.GetLoginUID())
 	if err != nil {
 		m.Error("权限判断失败！", zap.Error(err))
-		c.ResponseError(errors.New("权限判断失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	if !allow {
-		c.ResponseError(errors.New("无权限撤回此消息！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageRecallForbidden, nil, nil)
 		return
 	}
 
@@ -2276,7 +2294,7 @@ func (m *Message) revoke(c *wkhttp.Context) {
 		messageTime := time.Unix(int64(syncMsg.Timestamp), 0)
 		elapsed := time.Since(messageTime)
 		if elapsed.Seconds() > DefaultRevokeTimeout {
-			c.ResponseError(errors.New("消息已超过撤回时限！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageRecallTimeExceeded, nil, nil)
 			return
 		}
 	}
@@ -2288,13 +2306,13 @@ func (m *Message) revoke(c *wkhttp.Context) {
 	messageExtra, err := m.messageExtraDB.queryWithMessageID(messageIDStr)
 	if err != nil {
 		m.Error("查询消息扩展错误", zap.Error(err))
-		c.ResponseError(errors.New("查询消息扩展错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	tx, err := m.db.session.Begin()
 	if err != nil {
 		m.Error("开启事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("开启事务失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	defer func() {
@@ -2306,7 +2324,7 @@ func (m *Message) revoke(c *wkhttp.Context) {
 	version, err := m.genMessageExtraSeq(fakeChannelID)
 	if err != nil {
 		m.Error("生成消息扩展序列号失败！", zap.Error(err), zap.String("channelID", fakeChannelID))
-		c.ResponseError(errors.New("生成消息扩展序列号失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	if messageExtra != nil {
@@ -2317,7 +2335,8 @@ func (m *Message) revoke(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			m.Error("更新消息扩展数据失败！", zap.Error(err), zap.String("messageID", messageIDStr), zap.String("channelID", fakeChannelID))
-			c.ResponseErrorf("更新消息为撤回状态失败！", err)
+			m.Error("更新消息为撤回状态失败", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 	} else {
@@ -2335,7 +2354,8 @@ func (m *Message) revoke(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			m.Error("新增消息扩展数据失败！", zap.Error(err), zap.String("messageID", messageIDStr), zap.String("channelID", fakeChannelID))
-			c.ResponseErrorf("新增消息为撤回状态失败！", err)
+			m.Error("新增消息为撤回状态失败", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 	}
@@ -2355,18 +2375,20 @@ func (m *Message) revoke(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			m.Error("开启事件失败！", zap.Error(err))
-			c.ResponseError(errors.New("开启事件失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 	}
 	err = m.deletePinnedMessage(channelID, uint8(channelTypeI), msgIds, loginUID, tx)
 	if err != nil {
-		c.ResponseError(err)
+		m.Error("删除置顶消息失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	if err := tx.Commit(); err != nil {
 		tx.Rollback()
-		c.ResponseErrorf("事务提交失败！", err)
+		m.Error("事务提交失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	if eventID > 0 {
@@ -2385,7 +2407,7 @@ func (m *Message) revoke(c *wkhttp.Context) {
 		})
 		if err != nil {
 			m.Error("发送撤回消息失败！", zap.Error(err))
-			c.ResponseError(errors.New("发送撤回消息失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
 			return
 		}
 	}
@@ -2401,7 +2423,7 @@ func (m *Message) syncProhibitWords(c *wkhttp.Context) {
 	list, err := m.db.queryProhibitWordsWithVersion(maxVersion)
 	if err != nil {
 		m.Error("同步违禁词错误", zap.Error(err))
-		c.ResponseError(errors.New("同步违禁词错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	result := make([]*ProhibitWordResp, 0)

--- a/modules/message/api_channel_files.go
+++ b/modules/message/api_channel_files.go
@@ -7,10 +7,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"go.uber.org/zap"
 )
 
@@ -137,11 +139,11 @@ func (m *Message) channelFiles(c *wkhttp.Context) {
 	var req channelFilesReq
 	if err := c.BindJSON(&req); err != nil {
 		m.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	if err := req.check(); err != nil {
-		c.ResponseError(err)
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	if req.Page <= 0 {
@@ -166,7 +168,7 @@ func (m *Message) channelFiles(c *wkhttp.Context) {
 		if req.ChannelType == common.ChannelTypeCommunityTopic.Uint8() {
 			parentGroupNo, _, perr := thread.ParseChannelID(req.ChannelID)
 			if perr != nil {
-				c.ResponseError(errors.New("无效的话题频道ID"))
+				respondMessageRequestInvalid(c, "channel_id")
 				return
 			}
 			groupNo = parentGroupNo
@@ -174,11 +176,11 @@ func (m *Message) channelFiles(c *wkhttp.Context) {
 		isMember, err := m.groupService.ExistMember(groupNo, loginUID)
 		if err != nil {
 			m.Error("查询群成员关系错误", zap.Error(err))
-			c.ResponseError(errors.New("查询群成员关系错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if !isMember {
-			c.ResponseError(errors.New("非群成员无法查看文件"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageNotGroupMember, nil, nil)
 			return
 		}
 	} else if req.ChannelType == common.ChannelTypePerson.Uint8() {
@@ -186,16 +188,16 @@ func (m *Message) channelFiles(c *wkhttp.Context) {
 			isFriend, err := m.userService.IsFriend(loginUID, req.ChannelID)
 			if err != nil {
 				m.Error("查询好友关系错误", zap.Error(err))
-				c.ResponseError(errors.New("查询好友关系错误"))
+				httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 				return
 			}
 			if !isFriend {
-				c.ResponseError(errors.New("非好友无法查看文件"))
+				httperr.ResponseErrorL(c, errcode.ErrMessageNotFriend, nil, nil)
 				return
 			}
 		}
 	} else {
-		c.ResponseError(errors.New("不支持的频道类型"))
+		respondMessageRequestInvalid(c, "channel_type")
 		return
 	}
 
@@ -210,7 +212,7 @@ func (m *Message) channelFiles(c *wkhttp.Context) {
 	channelOffsets, err := m.channelOffsetDB.queryWithUIDAndChannelIDs(loginUID, []string{req.ChannelID})
 	if err != nil {
 		m.Error("查询清空消息标记错误", zap.Error(err))
-		c.ResponseError(errors.New("查询消息状态失败"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	var offsetSeq uint32
@@ -251,7 +253,7 @@ func (m *Message) channelFiles(c *wkhttp.Context) {
 		})
 		if err != nil {
 			m.Error("查询文件消息失败", zap.Error(err))
-			c.ResponseError(errors.New("查询文件消息失败"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if msgResp == nil || len(msgResp.Messages) == 0 {
@@ -262,7 +264,7 @@ func (m *Message) channelFiles(c *wkhttp.Context) {
 		filtered, err := m.filterMessages(msgResp.Messages, loginUID, offsetSeq)
 		if err != nil {
 			m.Error("过滤消息状态失败", zap.Error(err))
-			c.ResponseError(errors.New("查询消息状态失败"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 

--- a/modules/message/api_conversation.go
+++ b/modules/message/api_conversation.go
@@ -1075,13 +1075,13 @@ func (co *Conversation) getConversations(c *wkhttp.Context) {
 		}
 		userDetails, err := co.userDB.QueryDetailByUIDs(userUIDs, loginUID)
 		if err != nil {
-			co.Error("查询用户详情失败！")
+			co.Error("查询用户详情失败！", zap.Error(err))
 			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		groupDetails, err := co.groupDB.QueryDetailWithGroupNos(groupNos, loginUID)
 		if err != nil {
-			co.Error("查询用户详情失败！")
+			co.Error("查询用户详情失败！", zap.Error(err))
 			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}

--- a/modules/message/api_conversation.go
+++ b/modules/message/api_conversation.go
@@ -758,7 +758,7 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 		// 与同 handler 下 GetGroupsWithMemberUID 失败的处理对称（一次 DB 抖动 →
 		// 500 → 客户端重试），保证 200 响应里的 space_memberships 行级完整。
 		co.Error("查询外部群失败！", zap.Error(externalErr))
-		c.ResponseErrorWithStatus(errors.New("查询外部群失败！"), http.StatusInternalServerError)
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	// defaultSpaceID 是外部群 source_space_id="" 的空值兜底（legacy 外部成员行）。
@@ -772,7 +772,7 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 	defaultSpaceID, defaultSpaceErr := space.GetUserDefaultSpaceIDE(co.ctx, loginUID)
 	if defaultSpaceErr != nil {
 		co.Error("查询用户默认 Space 失败！", zap.Error(defaultSpaceErr))
-		c.ResponseErrorWithStatus(errors.New("查询用户默认 Space 失败！"), http.StatusInternalServerError)
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	fillConversationSpaceIDs(syncUserConversationResps, rawGroupSpaceMap, externalGroupMap, defaultSpaceID)
@@ -782,7 +782,7 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 	joinedGroups, err := co.groupService.GetGroupsWithMemberUID(loginUID)
 	if err != nil {
 		co.Error("查询加入的群聊错误", zap.Error(err))
-		c.ResponseErrorWithStatus(errors.New("查询加入的群聊错误"), http.StatusInternalServerError)
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	callChannelIDs := make([]string, 0)

--- a/modules/message/api_conversation.go
+++ b/modules/message/api_conversation.go
@@ -24,6 +24,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"github.com/gin-gonic/gin"
@@ -152,7 +154,7 @@ func (co *Conversation) conversationExtraSync(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		co.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	loginUID := c.GetLoginUID()
@@ -160,7 +162,7 @@ func (co *Conversation) conversationExtraSync(c *wkhttp.Context) {
 	conversationExtraModels, err := co.conversationExtraDB.sync(loginUID, req.Version)
 	if err != nil {
 		co.Error("同步消息扩展失败！", zap.Error(err))
-		c.ResponseError(errors.New("同步消息扩展失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	resps := make([]*conversationExtraResp, 0, len(conversationExtraModels))
@@ -180,7 +182,7 @@ func (co *Conversation) conversationExtraUpdate(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		co.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	channelID := c.Param("channel_id")
@@ -191,7 +193,8 @@ func (co *Conversation) conversationExtraUpdate(c *wkhttp.Context) {
 
 	version, err := co.ctx.GenSeq(common.SyncConversationExtraKey)
 	if err != nil {
-		c.ResponseError(err)
+		co.Error("生成会话扩展序列号失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 
@@ -207,7 +210,7 @@ func (co *Conversation) conversationExtraUpdate(c *wkhttp.Context) {
 	})
 	if err != nil {
 		co.Error("添加或更新最近会话扩展失败！", zap.Error(err))
-		c.ResponseError(errors.New("添加或更新最近会话扩展失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	err = co.ctx.SendCMD(config.MsgCMDReq{
@@ -218,7 +221,7 @@ func (co *Conversation) conversationExtraUpdate(c *wkhttp.Context) {
 	})
 	if err != nil {
 		co.Error("发送同步扩展会话cmd失败！", zap.Error(err))
-		c.ResponseError(errors.New("发送同步扩展会话cmd失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{
@@ -232,11 +235,11 @@ func (co *Conversation) deleteConversation(c *wkhttp.Context) {
 	channelID := c.Param("channel_id")
 	channelType, err := strconv.ParseInt(c.Param("channel_type"), 10, 64)
 	if err != nil {
-		c.ResponseError(errors.New("频道类型格式错误"))
+		respondMessageRequestInvalid(c, "channel_type")
 		return
 	}
 	if strings.TrimSpace(channelID) == "" {
-		c.ResponseError(errors.New("频道ID不能为空"))
+		respondMessageRequestInvalid(c, "channel_id")
 		return
 	}
 
@@ -246,27 +249,27 @@ func (co *Conversation) deleteConversation(c *wkhttp.Context) {
 		isMember, err := co.groupService.ExistMember(channelID, loginUID)
 		if err != nil {
 			co.Error("查询群成员失败", zap.Error(err))
-			c.ResponseError(errors.New("操作失败"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 		if !isMember {
-			c.ResponseError(errors.New("无权删除此会话"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageConversationForbidden, nil, nil)
 			return
 		}
 	} else if uint8(channelType) == common.ChannelTypePerson.Uint8() {
 		// For person channels, verify channelID is a valid user
 		if channelID == loginUID {
-			c.ResponseError(errors.New("无法删除与自己的会话"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageCannotDeleteSelfConversation, nil, nil)
 			return
 		}
 		userInfo, err := co.userService.GetUser(channelID)
 		if err != nil {
 			co.Error("查询用户信息失败", zap.Error(err))
-			c.ResponseError(errors.New("操作失败"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 		if userInfo == nil {
-			c.ResponseError(errors.New("会话不存在或无权删除"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageConversationForbidden, nil, nil)
 			return
 		}
 	}
@@ -274,7 +277,7 @@ func (co *Conversation) deleteConversation(c *wkhttp.Context) {
 	err = co.service.DeleteConversation(loginUID, channelID, uint8(channelType))
 	if err != nil {
 		co.Error("删除最近会话失败！", zap.Error(err))
-		c.ResponseError(errors.New("删除最近会话失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -290,7 +293,7 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		co.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 
@@ -311,21 +314,21 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 		cacheVersion, err := co.getDeviceConversationMaxVersion(loginUID, req.DeviceUUID)
 		if err != nil {
 			co.Error("获取缓存的最近会话版本号失败！", zap.Error(err), zap.String("loginUID", loginUID), zap.String("deviceUUID", req.DeviceUUID))
-			c.ResponseError(errors.New("获取缓存的最近会话版本号失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if cacheVersion == 0 {
 			userMaxVersion, err := co.getUserConversationMaxVersion(loginUID)
 			if err != nil {
 				co.Error("获取用户最近会很最大版本失败！", zap.Error(err))
-				c.ResponseError(errors.New("获取用户最近会很最大版本失败！"))
+				httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 				return
 			}
 			if userMaxVersion > 0 {
 				err = co.setDeviceConversationMaxVersion(loginUID, req.DeviceUUID, userMaxVersion)
 				if err != nil {
 					co.Error("设置设备最近会话最大版本号失败！", zap.Error(err))
-					c.ResponseError(errors.New("设置设备最近会话最大版本号失败！"))
+					httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 					return
 				}
 			}
@@ -344,7 +347,7 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 			deviceOffsetModels, err := co.deviceOffsetDB.queryWithUIDAndDeviceUUID(loginUID, req.DeviceUUID)
 			if err != nil {
 				co.Error("查询用户设备偏移量失败！", zap.Error(err))
-				c.ResponseError(errors.New("查询用户设备偏移量失败！"))
+				httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 				return
 			}
 			if len(deviceOffsetModels) > 0 {
@@ -356,7 +359,7 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 				userLastOffsetModels, err := co.userLastOffsetDB.queryWithUID(loginUID)
 				if err != nil {
 					co.Error("查询用户偏移量失败！", zap.Error(err))
-					c.ResponseError(errors.New("查询用户偏移量失败！"))
+					httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 					return
 				}
 				if len(userLastOffsetModels) > 0 {
@@ -373,7 +376,7 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 					}
 					err := co.insertDeviceOffsets(deviceOffsetList)
 					if err != nil {
-						c.ResponseError(errors.New("插入设备偏移数据失败！"))
+						httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 						return
 					}
 				}
@@ -388,7 +391,7 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 	largeGroupInfos, err := co.groupService.GetUserSupers(loginUID)
 	if err != nil {
 		co.Error("获取用户超大群失败！", zap.Error(err))
-		c.ResponseError(errors.New("获取用户超大群失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	largeChannels := make([]*config.Channel, 0)
@@ -403,7 +406,7 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 	conversations, err := co.ctx.IMSyncUserConversation(loginUID, version, req.MsgCount, lastMsgSeqs, largeChannels)
 	if err != nil {
 		co.Error("同步离线后的最近会话失败！", zap.Error(err), zap.String("loginUID", loginUID))
-		c.ResponseError(errors.New("同步离线后的最近会话失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	groupNos := make([]string, 0, len(conversations))
@@ -460,7 +463,7 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 		groupVailds, err = co.groupService.ExistMembers(groupNos, loginUID)
 		if err != nil {
 			co.Error("查询有效群失败！", zap.Error(err))
-			c.ResponseError(errors.New("查询有效群失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 
@@ -494,7 +497,7 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 	conversationExtras, err := co.conversationExtraDB.queryWithChannelIDs(loginUID, channelIDs)
 	if err != nil {
 		co.Error("查询最近会话扩展失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询最近会话扩展失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	if len(conversationExtras) > 0 {
@@ -509,7 +512,7 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 		users, err = co.userService.GetUserDetails(uids, c.GetLoginUID())
 		if err != nil {
 			co.Error("查询用户信息失败！", zap.Error(err))
-			c.ResponseError(errors.New("查询用户信息失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if len(users) > 0 {
@@ -541,7 +544,7 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 		groups, err = co.groupService.GetGroupDetails(groupNos, c.GetLoginUID())
 		if err != nil {
 			co.Error("查询群设置信息失败！", zap.Error(err))
-			c.ResponseError(errors.New("查询群设置信息失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if groups == nil {
@@ -602,7 +605,7 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 		channelOffsetModels, err := co.channelOffsetDB.queryWithUIDAndChannelIDs(loginUID, channelIDs)
 		if err != nil {
 			co.Error("查询用户频道偏移量失败！", zap.Error(err))
-			c.ResponseError(errors.New("查询用户频道偏移量失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if len(channelOffsetModels) > 0 {
@@ -616,7 +619,7 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 	channelSettings, err := co.channelService.GetChannelSettings(channelIDs)
 	if err != nil {
 		co.Error("查询频道设置失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询频道设置失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	channelSettingMessageOffsetMap := make(map[string]uint32)
@@ -793,7 +796,7 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 	friends, err := co.userService.GetFriends(loginUID)
 	if err != nil {
 		co.Error("查询好友错误", zap.Error(err))
-		c.ResponseError(errors.New("查询好友错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	if len(friends) > 0 {
@@ -870,7 +873,7 @@ func (co *Conversation) syncUserConversationAck(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		co.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	if co.ctx.GetConfig().MessageSaveAcrossDevice {
@@ -913,7 +916,7 @@ func (co *Conversation) syncUserConversationAck(c *wkhttp.Context) {
 	if len(userLastOffsetModels) > 0 {
 		err := co.insertUserLastOffsets(userLastOffsetModels)
 		if err != nil {
-			c.ResponseError(errors.New("插入设备偏移数据失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 	}
@@ -925,7 +928,7 @@ func (co *Conversation) syncUserConversationAck(c *wkhttp.Context) {
 		err := co.setUserConversationMaxVersion(loginUID, version)
 		if err != nil {
 			co.Error("设置设备最近会话最大版本号失败！", zap.Error(err))
-			c.ResponseError(errors.New("设置设备最近会话最大版本号失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 	}
@@ -1022,7 +1025,7 @@ func (co *Conversation) getConversations(c *wkhttp.Context) {
 	resps, err := co.ctx.IMGetConversations(loginUID)
 	if err != nil {
 		co.Error("获取最近会话失败！", zap.Error(err))
-		c.ResponseError(errors.New("获取最近会话失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	conversationResps := make([]conversationResp, 0, len(resps))
@@ -1044,7 +1047,7 @@ func (co *Conversation) getConversations(c *wkhttp.Context) {
 		channelSettings, err := co.channelService.GetChannelSettings(channelIds)
 		if err != nil {
 			co.Error("查询频道设置错误！", zap.Error(err))
-			c.ResponseError(errors.New("查询频道设置错误！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		channelSettingMessageOffsetMap := make(map[string]uint32)
@@ -1073,13 +1076,13 @@ func (co *Conversation) getConversations(c *wkhttp.Context) {
 		userDetails, err := co.userDB.QueryDetailByUIDs(userUIDs, loginUID)
 		if err != nil {
 			co.Error("查询用户详情失败！")
-			c.ResponseError(errors.New("查询用户详情失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		groupDetails, err := co.groupDB.QueryDetailWithGroupNos(groupNos, loginUID)
 		if err != nil {
 			co.Error("查询用户详情失败！")
-			c.ResponseError(errors.New("查询用户详情失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 
@@ -1113,7 +1116,7 @@ func (co *Conversation) clearConversationUnread(c *wkhttp.Context) {
 	var req clearConversationUnreadReq
 	if err := c.BindJSON(&req); err != nil {
 		co.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(common.ErrData)
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	// if co.ctx.GetConfig().IsVisitorChannel(req.ChannelID) {
@@ -1126,7 +1129,7 @@ func (co *Conversation) clearConversationUnread(c *wkhttp.Context) {
 		groupInfo, err := co.groupService.GetGroupWithGroupNo(req.ChannelID)
 		if err != nil {
 			co.Error("查询群聊信息失败！", zap.Error(err))
-			c.ResponseError(errors.New("查询群聊信息失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if groupInfo != nil && groupInfo.GroupType == group.GroupTypeSuper {
@@ -1142,7 +1145,8 @@ func (co *Conversation) clearConversationUnread(c *wkhttp.Context) {
 		MessageSeq:  messageSeq,
 	})
 	if err != nil {
-		c.ResponseError(err)
+		co.Error("清空会话红点失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
 		return
 	}
 	// 发送清空红点的命令
@@ -1159,7 +1163,7 @@ func (co *Conversation) clearConversationUnread(c *wkhttp.Context) {
 	})
 	if err != nil {
 		co.Error("命令发送失败！", zap.String("cmd", common.CMDConversationUnreadClear))
-		c.ResponseError(errors.New("命令发送失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()

--- a/modules/message/api_i18n.go
+++ b/modules/message/api_i18n.go
@@ -42,6 +42,7 @@ func respondMessagePinnedLimitExceeded(c *wkhttp.Context, max int) {
 var (
 	errSharedAuthRequired = mustLookupSharedCode("err.shared.auth.required")
 	errSharedTokenInvalid = mustLookupSharedCode("err.shared.auth.token_invalid")
+	errSharedForbidden    = mustLookupSharedCode("err.shared.auth.forbidden")
 )
 
 func mustLookupSharedCode(id string) codes.Code {
@@ -63,4 +64,11 @@ func respondMessageNotLoggedIn(c *wkhttp.Context) {
 // proxy-send token-parse guards ("token错误" / "解析token错误").
 func respondMessageTokenInvalid(c *wkhttp.Context) {
 	httperr.ResponseErrorL(c, errSharedTokenInvalid, nil, nil)
+}
+
+// respondMessageForbidden renders the shared 403 envelope for the management
+// console role guards (CheckLoginRoleIsSuperAdmin), mirroring the user/group
+// manager-forbidden mapping.
+func respondMessageForbidden(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errSharedForbidden, nil, nil)
 }

--- a/modules/message/api_i18n.go
+++ b/modules/message/api_i18n.go
@@ -1,0 +1,66 @@
+package message
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// respond helpers for modules/message. Most migrated sites call
+// httperr.ResponseErrorL(c, errcode.ErrMessageXxx, nil, nil) directly; the
+// helpers below cover the high-frequency shapes that carry a Detail field or
+// resolve a shared err.shared.* code at init.
+//
+// Internal=true codes (ErrMessageQueryFailed / ErrMessageStoreFailed /
+// ErrMessageNotifyFailed / ErrMessageSearchFailed) are called directly at each
+// site, which keeps its existing m.Error(..., zap.Error(err)) log so ops can
+// debug from logs while the wire response carries no message.
+
+// respondMessageRequestInvalid covers the common "X 不能为空" / "数据格式有误" /
+// bad-format / BindJSON-failure shape — one code, one optional field detail. An
+// empty field is omitted so the renderer does not surface a noisy empty key.
+func respondMessageRequestInvalid(c *wkhttp.Context, field string) {
+	details := i18n.Details{}
+	if field != "" {
+		details["field"] = field
+	}
+	httperr.ResponseErrorL(c, errcode.ErrMessageRequestInvalid, nil, details)
+}
+
+// respondMessagePinnedLimitExceeded surfaces the pinned-message cap so the
+// client can render a localized hint without hard-coding the limit.
+func respondMessagePinnedLimitExceeded(c *wkhttp.Context, max int) {
+	httperr.ResponseErrorL(c, errcode.ErrMessagePinnedLimitExceeded, nil, i18n.Details{"max": max})
+}
+
+// errSharedAuthRequired / errSharedTokenInvalid cache the shared auth codes so
+// the per-handler login / token guards do not pay a registry lookup on every
+// miss. Looked up at package init; a missing registration panics loudly rather
+// than silently rendering an empty envelope at request time.
+var (
+	errSharedAuthRequired = mustLookupSharedCode("err.shared.auth.required")
+	errSharedTokenInvalid = mustLookupSharedCode("err.shared.auth.token_invalid")
+)
+
+func mustLookupSharedCode(id string) codes.Code {
+	c, ok := codes.Lookup(id)
+	if !ok {
+		panic("modules/message: shared code not registered: " + id)
+	}
+	return c
+}
+
+// respondMessageNotLoggedIn renders the shared 401 envelope for the public
+// proxy-send path whose legacy "请先登录" guard runs before AuthMiddleware would
+// reject the request.
+func respondMessageNotLoggedIn(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errSharedAuthRequired, nil, nil)
+}
+
+// respondMessageTokenInvalid renders the shared token-invalid envelope for the
+// proxy-send token-parse guards ("token错误" / "解析token错误").
+func respondMessageTokenInvalid(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errSharedTokenInvalid, nil, nil)
+}

--- a/modules/message/api_i18n_test.go
+++ b/modules/message/api_i18n_test.go
@@ -47,6 +47,14 @@ func TestMessageNoLegacyResponseError(t *testing.T) {
 					t.Fatalf("modules/message/%s must use httperr.ResponseErrorL via respondMessage* helpers / errcode.ErrMessage* instead of legacy %s", f, b)
 				}
 			}
+			// Also forbid raw non-OK c.JSON(http.Status…) error responses — these
+			// bypass the i18n envelope just as completely as c.ResponseError but
+			// don't match the substrings above (reviewer finding on api_message_get.go).
+			for _, line := range strings.Split(cleaned, "\n") {
+				if strings.Contains(line, "c.JSON(http.Status") && !strings.Contains(line, "c.JSON(http.StatusOK") {
+					t.Fatalf("modules/message/%s must not emit raw non-OK c.JSON(http.Status…) error responses; use httperr.ResponseErrorL: %s", f, strings.TrimSpace(line))
+				}
+			}
 		})
 	}
 }

--- a/modules/message/api_i18n_test.go
+++ b/modules/message/api_i18n_test.go
@@ -1,0 +1,252 @@
+package message
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/server"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// TestMessageNoLegacyResponseError pins the Phase 2.1 contract that the
+// migrated modules/message handlers do not regress to legacy octo-lib error
+// responses. Comments are stripped first so commented-out breadcrumbs do not
+// trip the guard, and the m.Error(common.ErrData.Error(), ...) log calls are
+// not responses (they match none of the banned tokens).
+func TestMessageNoLegacyResponseError(t *testing.T) {
+	files := []string{
+		"api.go", "api_manager.go", "api_pinned.go", "api_conversation.go",
+		"api_message_get.go", "api_reminders.go", "api_channel_files.go", "api_sidebar.go",
+	}
+	banned := []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(", "c.Response(\""}
+	for _, f := range files {
+		t.Run(f, func(t *testing.T) {
+			data, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+			var clean strings.Builder
+			for _, line := range strings.Split(string(data), "\n") {
+				if idx := strings.Index(line, "//"); idx >= 0 {
+					line = line[:idx]
+				}
+				clean.WriteString(line)
+				clean.WriteByte('\n')
+			}
+			cleaned := clean.String()
+			for _, b := range banned {
+				if strings.Contains(cleaned, b) {
+					t.Fatalf("modules/message/%s must use httperr.ResponseErrorL via respondMessage* helpers / errcode.ErrMessage* instead of legacy %s", f, b)
+				}
+			}
+		})
+	}
+}
+
+// wireI18nRendererForMessageTest injects the i18n ErrorRenderer onto the route
+// returned by testutil.NewTestServer, mirroring what main.go does at boot.
+// Without it the route falls back to the legacy {msg,status} envelope carrying
+// the English source DefaultMessage instead of the localized zh-CN copy.
+func wireI18nRendererForMessageTest(s *server.Server) {
+	s.GetRoute().SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+}
+
+type envelope struct {
+	Error struct {
+		Code       string         `json:"code"`
+		Message    string         `json:"message"`
+		Details    map[string]any `json:"details"`
+		HTTPStatus int            `json:"http_status"`
+	} `json:"error"`
+	Msg    string `json:"msg"`
+	Status int    `json:"status"`
+}
+
+func decodeEnvelope(t *testing.T, body []byte) envelope {
+	t.Helper()
+	var env envelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("decode envelope: %v\nbody: %s", err, body)
+	}
+	return env
+}
+
+func helperHarness(probe func(c *wkhttp.Context)) *wkhttp.WKHttp {
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	r.GET("/probe", probe)
+	return r
+}
+
+func httperrL(c *wkhttp.Context, code codes.Code) {
+	httperr.ResponseErrorL(c, code, nil, nil)
+}
+
+func TestRespondMessageHelpers(t *testing.T) {
+	cases := []struct {
+		name            string
+		probe           func(c *wkhttp.Context)
+		wantCodeID      string
+		wantSemStatus   int
+		wantTransStatus int
+		wantContains    string
+		wantNotContains string
+		wantDetails     map[string]any
+	}{
+		{
+			name:            "respondMessageRequestInvalid carries the field detail",
+			probe:           func(c *wkhttp.Context) { respondMessageRequestInvalid(c, "channel_id") },
+			wantCodeID:      "err.server.message.request_invalid",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "请求参数有误",
+			wantDetails:     map[string]any{"field": "channel_id"},
+		},
+		{
+			name:            "respondMessageRequestInvalid drops empty field",
+			probe:           func(c *wkhttp.Context) { respondMessageRequestInvalid(c, "") },
+			wantCodeID:      "err.server.message.request_invalid",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "请求参数有误",
+			wantDetails:     map[string]any{},
+		},
+		{
+			name:            "respondMessageNotLoggedIn → shared.auth.required",
+			probe:           func(c *wkhttp.Context) { respondMessageNotLoggedIn(c) },
+			wantCodeID:      "err.shared.auth.required",
+			wantSemStatus:   http.StatusUnauthorized,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "请先登录",
+		},
+		{
+			name:            "respondMessageTokenInvalid → shared.auth.token_invalid",
+			probe:           func(c *wkhttp.Context) { respondMessageTokenInvalid(c) },
+			wantCodeID:      "err.shared.auth.token_invalid",
+			wantSemStatus:   http.StatusUnauthorized,
+			wantTransStatus: http.StatusBadRequest,
+		},
+		{
+			name:            "respondMessageForbidden → shared.auth.forbidden",
+			probe:           func(c *wkhttp.Context) { respondMessageForbidden(c) },
+			wantCodeID:      "err.shared.auth.forbidden",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "无权执行此操作",
+		},
+		{
+			name:            "respondMessagePinnedLimitExceeded carries max",
+			probe:           func(c *wkhttp.Context) { respondMessagePinnedLimitExceeded(c, 10) },
+			wantCodeID:      "err.server.message.pinned_limit_exceeded",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "置顶消息数量已达上限",
+			wantDetails:     map[string]any{"max": float64(10)},
+		},
+		{
+			name:            "ErrMessageNotFriend → 403 zh-CN",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrMessageNotFriend) },
+			wantCodeID:      "err.server.message.not_friend",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "好友",
+		},
+		{
+			name:            "ErrMessageConversationForbidden → 403 zh-CN",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrMessageConversationForbidden) },
+			wantCodeID:      "err.server.message.conversation_forbidden",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "会话",
+		},
+		{
+			name:            "ErrMessageNotFound → 404 zh-CN",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrMessageNotFound) },
+			wantCodeID:      "err.server.message.not_found",
+			wantSemStatus:   http.StatusNotFound,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "消息不存在",
+		},
+		{
+			name:            "ErrMessageRecallTimeExceeded → 400 zh-CN",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrMessageRecallTimeExceeded) },
+			wantCodeID:      "err.server.message.recall_time_exceeded",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "撤回",
+		},
+		{
+			name:            "ErrMessageQueryFailed (Internal) collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrMessageQueryFailed) },
+			wantCodeID:      "err.server.message.query_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "query message data",
+		},
+		{
+			name:            "ErrMessageSearchFailed (Internal) collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrMessageSearchFailed) },
+			wantCodeID:      "err.server.message.search_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "search failed",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := helperHarness(tc.probe)
+			req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+			req.Header.Set("Accept-Language", "zh-CN")
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantTransStatus {
+				t.Fatalf("HTTP status = %d, want %d; body=%s", rec.Code, tc.wantTransStatus, rec.Body.String())
+			}
+			env := decodeEnvelope(t, rec.Body.Bytes())
+			if env.Error.Code != tc.wantCodeID {
+				t.Fatalf("error.code = %q, want %q", env.Error.Code, tc.wantCodeID)
+			}
+			if env.Error.HTTPStatus != tc.wantSemStatus {
+				t.Fatalf("error.http_status = %d, want %d", env.Error.HTTPStatus, tc.wantSemStatus)
+			}
+			if env.Status != tc.wantTransStatus {
+				t.Fatalf("legacy status = %d, want %d (D14 transport=400 compat)", env.Status, tc.wantTransStatus)
+			}
+			if env.Msg != env.Error.Message {
+				t.Fatalf("legacy msg %q != error.message %q", env.Msg, env.Error.Message)
+			}
+			if tc.wantContains != "" && !strings.Contains(env.Error.Message, tc.wantContains) {
+				t.Fatalf("error.message = %q, want substring %q", env.Error.Message, tc.wantContains)
+			}
+			if tc.wantNotContains != "" && strings.Contains(env.Error.Message, tc.wantNotContains) {
+				t.Fatalf("error.message = %q must not contain %q (Internal leak)", env.Error.Message, tc.wantNotContains)
+			}
+			if tc.wantDetails != nil {
+				got := env.Error.Details
+				if got == nil {
+					got = map[string]any{}
+				}
+				if len(got) != len(tc.wantDetails) {
+					t.Fatalf("error.details = %#v, want %#v", got, tc.wantDetails)
+				}
+				for k, v := range tc.wantDetails {
+					if got[k] != v {
+						t.Fatalf("error.details[%q] = %#v, want %#v", k, got[k], v)
+					}
+				}
+			}
+		})
+	}
+}

--- a/modules/message/api_manager.go
+++ b/modules/message/api_manager.go
@@ -8,9 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
-	"github.com/Mininglamp-OSS/octo-server/modules/group"
-	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/model"
@@ -19,6 +16,11 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkevent"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
@@ -64,7 +66,7 @@ func (m *Manager) Route(r *wkhttp.WKHttp) {
 func (m *Manager) sendMsgToFriends(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondMessageForbidden(c)
 		return
 	}
 	type ReqVO struct {
@@ -75,19 +77,19 @@ func (m *Manager) sendMsgToFriends(c *wkhttp.Context) {
 	var req ReqVO
 	if err := c.BindJSON(&req); err != nil {
 		m.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	if req.UID == "" {
-		c.ResponseError(errors.New("发送者不能为空"))
+		respondMessageRequestInvalid(c, "from_uid")
 		return
 	}
 	if req.Content == "" {
-		c.ResponseError(errors.New("发送内容不能为空"))
+		respondMessageRequestInvalid(c, "content")
 		return
 	}
 	if len(req.ToUIDs) == 0 {
-		c.ResponseError(errors.New("发送消息的订阅者不能为空"))
+		respondMessageRequestInvalid(c, "subscribers")
 		return
 	}
 	go m.sendMessageToFriends(req.ToUIDs, req.UID, req.Content)
@@ -116,7 +118,7 @@ func (m *Manager) delete(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondMessageForbidden(c)
 		return
 	}
 	type msgVO struct {
@@ -132,15 +134,15 @@ func (m *Manager) delete(c *wkhttp.Context) {
 	var req reqVO
 	if err := c.BindJSON(&req); err != nil {
 		m.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	if len(req.List) == 0 {
-		c.ResponseError(errors.New("删除的msgIds不能为空"))
+		respondMessageRequestInvalid(c, "msg_ids")
 		return
 	}
 	if req.ChannelType == uint8(common.ChannelTypePerson) && (req.FromUID == "" || req.ChannelID == req.FromUID) {
-		c.ResponseError(errors.New("单聊fromuid不能为空且不能和channelId一致"))
+		respondMessageRequestInvalid(c, "from_uid")
 		return
 	}
 	fakeChannelID := req.ChannelID
@@ -150,7 +152,7 @@ func (m *Manager) delete(c *wkhttp.Context) {
 	tx, err := m.ctx.DB().Begin()
 	if err != nil {
 		m.Error("开启事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("开启事务失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	defer func() {
@@ -163,7 +165,8 @@ func (m *Manager) delete(c *wkhttp.Context) {
 	for _, msg := range req.List {
 		version, err := m.genMessageExtraSeq(fakeChannelID)
 		if err != nil {
-			c.ResponseError(err)
+			m.Error("生成消息扩展序列号失败", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 		msgIds = append(msgIds, msg.MessageID)
@@ -178,7 +181,7 @@ func (m *Manager) delete(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			m.Error(common.ErrData.Error(), zap.Error(err))
-			c.ResponseError(errors.New("删除消息错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 	}
@@ -186,7 +189,7 @@ func (m *Manager) delete(c *wkhttp.Context) {
 	if err != nil {
 		tx.Rollback()
 		m.Error("查询置顶消息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询置顶消息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	isSendSyncPinnedMsgCMD := false
@@ -200,7 +203,7 @@ func (m *Manager) delete(c *wkhttp.Context) {
 				if err != nil {
 					tx.Rollback()
 					m.Error("删除置顶消息错误", zap.Error(err))
-					c.ResponseError(errors.New("删除置顶消息错误"))
+					httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 					return
 				}
 			}
@@ -232,14 +235,14 @@ func (m *Manager) delete(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			m.Error("开启事件失败！", zap.Error(err))
-			c.ResponseError(errors.New("开启事件失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 	}
 	if err := tx.Commit(); err != nil {
 		tx.Rollback()
 		m.Error("提交事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("提交事务失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	if eventID > 0 {
@@ -272,7 +275,7 @@ func (m *Manager) delete(c *wkhttp.Context) {
 
 	if err != nil {
 		m.Error("发送cmd失败！", zap.Error(err))
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -280,39 +283,40 @@ func (m *Manager) delete(c *wkhttp.Context) {
 func (m *Manager) deleteProhibitWords(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondMessageForbidden(c)
 		return
 	}
 	is_deleted := c.Query("is_deleted")
 	isDeleted, _ := strconv.Atoi(is_deleted)
 	id := c.Query("id")
 	if id == "" || (isDeleted != 0 && isDeleted != 1) {
-		c.ResponseError(errors.New("参数错误"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	tempID, _ := strconv.Atoi(id)
 	words, err := m.managerDB.queryProhibitWordsWithID(tempID)
 	if err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(errors.New("查询违禁词错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	if words == nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(errors.New("操作的违禁词不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageBanwordNotFound, nil, nil)
 		return
 	}
 	words.IsDeleted = isDeleted
 	genSeqVal, err := m.ctx.GenSeq(common.ProhibitWordKey)
 	if err != nil {
-		c.ResponseError(err)
+		m.Error("生成违禁词序列号失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	words.Version = genSeqVal
 	err = m.managerDB.updateProhibitWord(words)
 	if err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(errors.New("修改违禁词错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -321,7 +325,7 @@ func (m *Manager) deleteProhibitWords(c *wkhttp.Context) {
 func (m *Manager) prohibitWords(c *wkhttp.Context) {
 	err := c.CheckLoginRole()
 	if err != nil {
-		c.ResponseError(err)
+		respondMessageForbidden(c)
 		return
 	}
 	pageIndex, pageSize := c.GetPage()
@@ -332,27 +336,27 @@ func (m *Manager) prohibitWords(c *wkhttp.Context) {
 		result, err = m.managerDB.queryProhibitWords(uint64(pageIndex), uint64(pageSize))
 		if err != nil {
 			m.Error(common.ErrData.Error(), zap.Error(err))
-			c.ResponseError(errors.New("查询违禁词列表错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		count, err = m.managerDB.queryProhibitWordsCount()
 		if err != nil {
 			m.Error(common.ErrData.Error(), zap.Error(err))
-			c.ResponseError(errors.New("查询违禁词总数错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 	} else {
 		result, err = m.managerDB.queryProhibitWordsWithContentAndPage(searchKey, uint64(pageIndex), uint64(pageSize))
 		if err != nil {
 			m.Error(common.ErrData.Error(), zap.Error(err))
-			c.ResponseError(errors.New("搜索查询违禁词列表错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 
 		count, err = m.managerDB.queryProhibitWordsCountWithContent(searchKey)
 		if err != nil {
 			m.Error(common.ErrData.Error(), zap.Error(err))
-			c.ResponseError(errors.New("查询搜索违禁词总数错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 	}
@@ -378,23 +382,24 @@ func (m *Manager) prohibitWords(c *wkhttp.Context) {
 func (m *Manager) addProhibitWords(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondMessageForbidden(c)
 		return
 	}
 	content := c.Query("content")
 	if content == "" {
-		c.ResponseError(errors.New("违禁词不能为空"))
+		respondMessageRequestInvalid(c, "word")
 		return
 	}
 	model, err := m.managerDB.queryProhibitWordsWithContent(content)
 	if err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(errors.New("查询违禁词错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	version, err := m.ctx.GenSeq(common.ProhibitWordKey)
 	if err != nil {
-		c.ResponseError(err)
+		m.Error("生成违禁词序列号失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	if model != nil {
@@ -403,7 +408,7 @@ func (m *Manager) addProhibitWords(c *wkhttp.Context) {
 		err = m.managerDB.updateProhibitWord(model)
 		if err != nil {
 			m.Error(common.ErrData.Error(), zap.Error(err))
-			c.ResponseError(errors.New("修改违禁词错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 	} else {
@@ -414,7 +419,7 @@ func (m *Manager) addProhibitWords(c *wkhttp.Context) {
 		})
 		if err != nil {
 			m.Error(common.ErrData.Error(), zap.Error(err))
-			c.ResponseError(errors.New("新增违禁词错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 	}
@@ -423,28 +428,28 @@ func (m *Manager) addProhibitWords(c *wkhttp.Context) {
 func (m *Manager) recordpersonal(c *wkhttp.Context) {
 	err := c.CheckLoginRole()
 	if err != nil {
-		c.ResponseError(err)
+		respondMessageForbidden(c)
 		return
 	}
 	uid := c.Query("uid")
 	touid := c.Query("touid")
 	pageIndex, pageSize := c.GetPage()
 	if strings.TrimSpace(uid) == "" || strings.TrimSpace(touid) == "" {
-		c.ResponseError(errors.New("uid不能为空"))
+		respondMessageRequestInvalid(c, "uid")
 		return
 	}
 	channelID := common.GetFakeChannelIDWith(uid, touid)
 	msgs, err := m.managerDB.queryWithChannelID(channelID, uint64(pageIndex), uint64(pageSize))
 	if err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(errors.New("查询消息记录错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 
 	count, err := m.managerDB.queryRecordCount(channelID)
 	if err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(errors.New("查询消息总量错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	list := make([]*recordVO, 0)
@@ -461,13 +466,13 @@ func (m *Manager) recordpersonal(c *wkhttp.Context) {
 	msgExtrs, err := m.managerDB.queryMsgExtrWithMsgIds(msgIds)
 	if err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(errors.New("查询消息扩展错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	userList, err := m.userService.GetUsers(uids)
 	if err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(errors.New("查询发送者信息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	ids := make([]int64, 0)
@@ -564,7 +569,7 @@ func (m *Manager) recordpersonal(c *wkhttp.Context) {
 func (m *Manager) record(c *wkhttp.Context) {
 	err := c.CheckLoginRole()
 	if err != nil {
-		c.ResponseError(err)
+		respondMessageForbidden(c)
 		return
 	}
 	var channelID = c.Query("channel_id")
@@ -572,13 +577,13 @@ func (m *Manager) record(c *wkhttp.Context) {
 	msgs, err := m.managerDB.queryWithChannelID(channelID, uint64(pageIndex), uint64(pageSize))
 	if err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(errors.New("查询消息记录错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	count, err := m.managerDB.queryRecordCount(channelID)
 	if err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(errors.New("查询消息总量错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 
@@ -596,13 +601,13 @@ func (m *Manager) record(c *wkhttp.Context) {
 	msgExtrs, err := m.managerDB.queryMsgExtrWithMsgIds(msgIds)
 	if err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(errors.New("查询消息扩展错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	userList, err := m.userService.GetUsers(uids)
 	if err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(errors.New("查询发送者信息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	ids := make([]int64, 0)
@@ -702,7 +707,7 @@ func (m *Manager) record(c *wkhttp.Context) {
 func (m *Manager) sendMsgToAllUsers(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondMessageForbidden(c)
 		return
 	}
 	type SendMsgReq struct {
@@ -711,12 +716,13 @@ func (m *Manager) sendMsgToAllUsers(c *wkhttp.Context) {
 	var req SendMsgReq
 	if err := c.BindJSON(&req); err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(common.ErrData)
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	userList, err := m.userService.GetAllUsers()
 	if err != nil {
-		c.ResponseError(err)
+		m.Error("查询用户列表失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	uids := make([][]string, 0)
@@ -760,17 +766,17 @@ func (m *Manager) sendMessageBatch(uids [][]string, content string) error {
 func (m *Manager) sendMsg(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondMessageForbidden(c)
 		return
 	}
 	var req managerSendMsgReq
 	if err := c.BindJSON(&req); err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(common.ErrData)
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	if err := req.check(); err != nil {
-		c.ResponseError(err)
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	var receiverName string = ""
@@ -778,11 +784,11 @@ func (m *Manager) sendMsg(c *wkhttp.Context) {
 		user, err := m.userService.GetUser(req.ReceivedChannelID)
 		if err != nil {
 			m.Error("查询接受的者信息错误", zap.Error(err), zap.String("uid", req.ReceivedChannelID))
-			c.ResponseError(errors.New("查询接受的者信息错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if user == nil {
-			c.ResponseError(errors.New("消息接受者用户不存在"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageReceiverNotFound, nil, nil)
 			return
 		}
 		receiverName = user.Name
@@ -791,11 +797,11 @@ func (m *Manager) sendMsg(c *wkhttp.Context) {
 		group, err := m.groupService.GetGroupWithGroupNo(req.ReceivedChannelID)
 		if err != nil {
 			m.Error("查询接受群信息错误", zap.Error(err), zap.String("groupNo", req.ReceivedChannelID))
-			c.ResponseError(errors.New("查询接受群信息错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if group == nil {
-			c.ResponseError(errors.New("消息接受群不存在"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageGroupNotFound, nil, nil)
 			return
 		}
 		receiverName = group.Name
@@ -851,7 +857,7 @@ func (m *Manager) sendMsg(c *wkhttp.Context) {
 	})
 	if err != nil {
 		m.Error("发送消息错误", zap.Error(err))
-		c.ResponseError(errors.New("发送消息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
 		return
 	}
 	// 添加发送消息记录
@@ -867,7 +873,7 @@ func (m *Manager) sendMsg(c *wkhttp.Context) {
 	})
 	if err != nil {
 		m.Error("添加发送消息记录错误", zap.Error(err))
-		c.ResponseError(errors.New("添加发送消息记录错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -877,20 +883,20 @@ func (m *Manager) sendMsg(c *wkhttp.Context) {
 func (m *Manager) list(c *wkhttp.Context) {
 	err := c.CheckLoginRole()
 	if err != nil {
-		c.ResponseError(err)
+		respondMessageForbidden(c)
 		return
 	}
 	pageIndex, pageSize := c.GetPage()
 	list, err := m.managerDB.queryMsgWithPage(uint64(pageSize), uint64(pageIndex))
 	if err != nil {
 		m.Error("查询代发消息记录错误", zap.Error(err))
-		c.ResponseError(errors.New("查询代发消息记录错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	count, err := m.managerDB.queryMsgCount()
 	if err != nil {
 		m.Error("查询代发消息总数错误", zap.Error(err))
-		c.ResponseError(errors.New("查询代发消息总数错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	result := make([]*managerSendMsgResp, 0)

--- a/modules/message/api_message_get.go
+++ b/modules/message/api_message_get.go
@@ -12,6 +12,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -88,12 +90,12 @@ func (m *Message) getGroupMessage(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 
 	if !thread.IsValidGroupNo(groupNo) {
-		c.ResponseError(errors.New("invalid group_no format"))
+		respondMessageRequestInvalid(c, "group_no")
 		return
 	}
 	messageID, ok := parsePositiveMessageID(messageIDStr)
 	if !ok {
-		c.ResponseError(errors.New("invalid message_id"))
+		respondMessageRequestInvalid(c, "message_id")
 		return
 	}
 	if !m.requireGroupMember(c, groupNo, loginUID) {
@@ -110,16 +112,16 @@ func (m *Message) getThreadMessage(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 
 	if !thread.IsValidGroupNo(groupNo) {
-		c.ResponseError(errors.New("invalid group_no format"))
+		respondMessageRequestInvalid(c, "group_no")
 		return
 	}
 	if !thread.IsValidShortID(shortID) {
-		c.ResponseError(errors.New("invalid short_id format"))
+		respondMessageRequestInvalid(c, "short_id")
 		return
 	}
 	messageID, ok := parsePositiveMessageID(messageIDStr)
 	if !ok {
-		c.ResponseError(errors.New("invalid message_id"))
+		respondMessageRequestInvalid(c, "message_id")
 		return
 	}
 	if !m.requireGroupMember(c, groupNo, loginUID) {
@@ -128,7 +130,8 @@ func (m *Message) getThreadMessage(c *wkhttp.Context) {
 	t, err := m.threadDB.QueryByGroupNoAndShortID(groupNo, shortID)
 	if err != nil {
 		m.Error("查询子区失败", zap.Error(err))
-		c.ResponseError(errors.Wrap(err, "查询子区失败"))
+		m.Error("查询子区失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	// 与 IM datasource (modules/thread/1module.go:87)、ExistByGroupNoAndShortID
@@ -173,7 +176,8 @@ func (m *Message) requireGroupMember(c *wkhttp.Context, groupNo, loginUID string
 	g, err := m.groupDB.QueryWithGroupNo(groupNo)
 	if err != nil {
 		m.Error("查询群信息失败", zap.Error(err))
-		c.ResponseError(errors.Wrap(err, "查询群信息失败"))
+		m.Error("查询群信息失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return false
 	}
 	// 白名单语义：只有 GroupStatusNormal 允许通过；Disband / Disabled / 未来新增的
@@ -185,7 +189,8 @@ func (m *Message) requireGroupMember(c *wkhttp.Context, groupNo, loginUID string
 	isActive, err := m.groupDB.ExistMemberActive(loginUID, groupNo)
 	if err != nil {
 		m.Error("检查群成员失败", zap.Error(err))
-		c.ResponseError(errors.Wrap(err, "检查群成员失败"))
+		m.Error("检查群成员失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return false
 	}
 	if !isActive {
@@ -211,7 +216,8 @@ func (m *Message) respondSingleMessage(c *wkhttp.Context, channelID string, chan
 	msgModel, err := m.db.queryMessageByID(channelID, channelType, messageIDStr)
 	if err != nil {
 		m.Error("查询消息失败", zap.Error(err), zap.String("channel_id", channelID), zap.Int64("message_id", messageID))
-		c.ResponseError(errors.Wrap(err, "查询消息失败"))
+		m.Error("查询消息失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	if msgModel == nil {
@@ -231,7 +237,8 @@ func (m *Message) respondSingleMessage(c *wkhttp.Context, channelID string, chan
 
 	extra, userExtra, reactions, err := m.fetchMessageExtras(messageID, loginUID)
 	if err != nil {
-		c.ResponseError(err)
+		m.Error("查询消息扩展失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	if extra != nil && (extra.Revoke == 1 || extra.IsDeleted == 1) {
@@ -250,7 +257,8 @@ func (m *Message) respondSingleMessage(c *wkhttp.Context, channelID string, chan
 	// channel_setting.offset_message_seq 是两张不同的表 / 两套语义，必须都查。
 	if userOffset, err := m.channelOffsetDB.queryWithUIDAndChannel(loginUID, channelID, channelType); err != nil {
 		m.Error("查询用户清理偏移失败", zap.Error(err))
-		c.ResponseError(errors.Wrap(err, "查询用户清理偏移失败"))
+		m.Error("查询用户清理偏移失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	} else if userOffset != nil && msgModel.MessageSeq <= userOffset.MessageSeq {
 		c.JSON(http.StatusNotFound, gin.H{"msg": "message not found"})
@@ -260,7 +268,8 @@ func (m *Message) respondSingleMessage(c *wkhttp.Context, channelID string, chan
 	channelOffsetSeq, err := m.lookupChannelOffsetSeq(channelID, channelType, loginUID)
 	if err != nil {
 		m.Error("查询频道设置失败", zap.Error(err))
-		c.ResponseError(errors.Wrap(err, "查询频道设置失败"))
+		m.Error("查询频道设置失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 

--- a/modules/message/api_message_get.go
+++ b/modules/message/api_message_get.go
@@ -2,7 +2,6 @@ package message
 
 import (
 	"encoding/json"
-	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -14,7 +13,6 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
-	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
@@ -130,7 +128,6 @@ func (m *Message) getThreadMessage(c *wkhttp.Context) {
 	t, err := m.threadDB.QueryByGroupNoAndShortID(groupNo, shortID)
 	if err != nil {
 		m.Error("查询子区失败", zap.Error(err))
-		m.Error("查询子区失败", zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
@@ -140,7 +137,7 @@ func (m *Message) getThreadMessage(c *wkhttp.Context) {
 	// 消息，发完自动解档）。
 	// body 用 "message not found"（与其它 404 一致）避免泄露 thread 是否存在的信号。
 	if t == nil || t.Status == thread.ThreadStatusDeleted {
-		c.JSON(http.StatusNotFound, gin.H{"msg": "message not found"})
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
 		return
 	}
 
@@ -176,25 +173,23 @@ func (m *Message) requireGroupMember(c *wkhttp.Context, groupNo, loginUID string
 	g, err := m.groupDB.QueryWithGroupNo(groupNo)
 	if err != nil {
 		m.Error("查询群信息失败", zap.Error(err))
-		m.Error("查询群信息失败", zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return false
 	}
 	// 白名单语义：只有 GroupStatusNormal 允许通过；Disband / Disabled / 未来新增的
 	// 非正常状态一律 fail closed。与 ExistMemberActive 的 status=Normal 一致。
 	if g == nil || g.Status != group.GroupStatusNormal {
-		c.JSON(http.StatusNotFound, gin.H{"msg": "message not found"})
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
 		return false
 	}
 	isActive, err := m.groupDB.ExistMemberActive(loginUID, groupNo)
 	if err != nil {
 		m.Error("检查群成员失败", zap.Error(err))
-		m.Error("检查群成员失败", zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return false
 	}
 	if !isActive {
-		c.JSON(http.StatusNotFound, gin.H{"msg": "message not found"})
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
 		return false
 	}
 	return true
@@ -216,12 +211,11 @@ func (m *Message) respondSingleMessage(c *wkhttp.Context, channelID string, chan
 	msgModel, err := m.db.queryMessageByID(channelID, channelType, messageIDStr)
 	if err != nil {
 		m.Error("查询消息失败", zap.Error(err), zap.String("channel_id", channelID), zap.Int64("message_id", messageID))
-		m.Error("查询消息失败", zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	if msgModel == nil {
-		c.JSON(http.StatusNotFound, gin.H{"msg": "message not found"})
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
 		return
 	}
 
@@ -231,7 +225,7 @@ func (m *Message) respondSingleMessage(c *wkhttp.Context, channelID string, chan
 	// 拿不到字段、IsDeleted 不会被置 1，依赖"from() 后兜底 IsDeleted"的策略失效，
 	// 非白名单成员能拿到该消息的元数据。原始 payload 解析在所有大小下都正确。
 	if !visiblesAllows(msgModel.Payload, loginUID) {
-		c.JSON(http.StatusNotFound, gin.H{"msg": "message not found"})
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
 		return
 	}
 
@@ -242,11 +236,11 @@ func (m *Message) respondSingleMessage(c *wkhttp.Context, channelID string, chan
 		return
 	}
 	if extra != nil && (extra.Revoke == 1 || extra.IsDeleted == 1) {
-		c.JSON(http.StatusNotFound, gin.H{"msg": "message not found"})
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
 		return
 	}
 	if userExtra != nil && userExtra.MessageIsDeleted == 1 {
-		c.JSON(http.StatusNotFound, gin.H{"msg": "message not found"})
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
 		return
 	}
 
@@ -257,17 +251,15 @@ func (m *Message) respondSingleMessage(c *wkhttp.Context, channelID string, chan
 	// channel_setting.offset_message_seq 是两张不同的表 / 两套语义，必须都查。
 	if userOffset, err := m.channelOffsetDB.queryWithUIDAndChannel(loginUID, channelID, channelType); err != nil {
 		m.Error("查询用户清理偏移失败", zap.Error(err))
-		m.Error("查询用户清理偏移失败", zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	} else if userOffset != nil && msgModel.MessageSeq <= userOffset.MessageSeq {
-		c.JSON(http.StatusNotFound, gin.H{"msg": "message not found"})
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
 		return
 	}
 
 	channelOffsetSeq, err := m.lookupChannelOffsetSeq(channelID, channelType, loginUID)
 	if err != nil {
-		m.Error("查询频道设置失败", zap.Error(err))
 		m.Error("查询频道设置失败", zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
@@ -288,7 +280,7 @@ func (m *Message) respondSingleMessage(c *wkhttp.Context, channelID string, chan
 	// 置 1。批量同步把 IsDeleted=1 留给客户端过滤；单条直查不能依赖客户端，
 	// 否则相当于把"白名单消息"在 200 响应里整段下发给非授权用户。
 	if resp.IsDeleted == 1 {
-		c.JSON(http.StatusNotFound, gin.H{"msg": "message not found"})
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
 		return
 	}
 

--- a/modules/message/api_pinned.go
+++ b/modules/message/api_pinned.go
@@ -140,7 +140,7 @@ func (m *Message) pinnedMessage(c *wkhttp.Context) {
 		return
 	}
 	if currentCount >= int64(maxCount) && (pinnedMessage == nil || pinnedMessage.IsDeleted == 1) {
-		httperr.ResponseErrorL(c, errcode.ErrMessagePinnedLimitExceeded, nil, nil)
+		respondMessagePinnedLimitExceeded(c, maxCount)
 		return
 	}
 
@@ -435,7 +435,6 @@ func (m *Message) clearPinnedMessage(c *wkhttp.Context) {
 		}, tx)
 		if err != nil {
 			tx.Rollback()
-			m.Error("修改消息扩展置顶状态错误", zap.Error(err))
 			m.Error("修改消息扩展置顶状态错误", zap.Error(err))
 			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return

--- a/modules/message/api_pinned.go
+++ b/modules/message/api_pinned.go
@@ -12,6 +12,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"github.com/gocraft/dbr/v2"
 	"github.com/pkg/errors"
@@ -31,36 +33,36 @@ func (m *Message) pinnedMessage(c *wkhttp.Context) {
 	var req reqVO
 	if err := c.BindJSON(&req); err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(common.ErrData)
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	if req.ChannelID == "" {
-		c.ResponseError(errors.New("频道ID不能为空"))
+		respondMessageRequestInvalid(c, "channel_id")
 		return
 	}
 	if req.MessageID == "" {
-		c.ResponseError(errors.New("消息ID不能为空"))
+		respondMessageRequestInvalid(c, "message_id")
 		return
 	}
 	if req.MessageSeq <= 0 {
-		c.ResponseError(errors.New("消息seq不合法"))
+		respondMessageRequestInvalid(c, "message_seq")
 		return
 	}
 
 	fakeChannelID := req.ChannelID
 	if req.ChannelType == common.ChannelTypePerson.Uint8() {
 		if loginUID == req.ChannelID {
-			c.ResponseError(errors.New("频道ID不合法"))
+			respondMessageRequestInvalid(c, "channel_id")
 			return
 		}
 		isFriend, err := m.userService.IsFriend(loginUID, req.ChannelID)
 		if err != nil {
 			m.Error("查询好友关系错误", zap.Error(err))
-			c.ResponseError(errors.New("查询好友关系错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if !isFriend {
-			c.ResponseError(errors.New("无权操作此会话"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageConversationForbidden, nil, nil)
 			return
 		}
 		fakeChannelID = common.GetFakeChannelIDWith(loginUID, req.ChannelID)
@@ -68,21 +70,21 @@ func (m *Message) pinnedMessage(c *wkhttp.Context) {
 		groupInfo, err := m.groupService.GetGroupDetail(req.ChannelID, loginUID)
 		if err != nil {
 			m.Error("查询群组信息错误", zap.Error(err))
-			c.ResponseError(errors.New("查询群组信息错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if groupInfo == nil || groupInfo.Status != 1 {
-			c.ResponseError(errors.New("群不存在或已删除"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageGroupNotFound, nil, nil)
 			return
 		}
 		isCreatorOrManager, err := m.groupService.IsCreatorOrManager(req.ChannelID, loginUID)
 		if err != nil {
 			m.Error("查询用户在群内权限错误", zap.Error(err))
-			c.ResponseError(errors.New("查询用户在群内权限错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if !isCreatorOrManager && groupInfo.AllowMemberPinnedMessage == 0 {
-			c.ResponseError(errors.New("普通成员不允许置顶消息"))
+			httperr.ResponseErrorL(c, errcode.ErrMessagePinnedForbidden, nil, nil)
 			return
 		}
 	}
@@ -97,28 +99,28 @@ func (m *Message) pinnedMessage(c *wkhttp.Context) {
 	})
 	if err != nil {
 		m.Error("查询消息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询消息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	if syncMsg == nil || len(syncMsg.Messages) == 0 {
-		c.ResponseError(errors.New("该消息不存在或已删除"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
 		return
 	}
 	message := syncMsg.Messages[0]
 	messageExtra, err := m.messageExtraDB.queryWithMessageID(req.MessageID)
 	if err != nil {
 		m.Error("查询消息扩展信息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询消息扩展信息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	if messageExtra != nil && messageExtra.IsDeleted == 1 {
-		c.ResponseError(errors.New("该消息不存在或已删除"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
 		return
 	}
 	appConfig, err := m.commonService.GetAppConfig()
 	if err != nil {
 		m.Error("查询配置错误", zap.Error(err))
-		c.ResponseError(errors.New("查询配置错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	var maxCount = 10
@@ -128,24 +130,24 @@ func (m *Message) pinnedMessage(c *wkhttp.Context) {
 	currentCount, err := m.pinnedDB.queryCountWithChannel(fakeChannelID, req.ChannelType)
 	if err != nil {
 		m.Error("查询当前置顶消息数量错误", zap.Error(err))
-		c.ResponseError(errors.New("查询当前置顶消息数量错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	pinnedMessage, err := m.pinnedDB.queryWithMessageId(fakeChannelID, req.ChannelType, req.MessageID)
 	if err != nil {
 		m.Error("查询置顶消息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询置顶消息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	if currentCount >= int64(maxCount) && (pinnedMessage == nil || pinnedMessage.IsDeleted == 1) {
-		c.ResponseError(errors.New("置顶数量已达到上限"))
+		httperr.ResponseErrorL(c, errcode.ErrMessagePinnedLimitExceeded, nil, nil)
 		return
 	}
 
 	tx, err := m.db.session.Begin()
 	if err != nil {
 		m.Error("开启事务错误", zap.Error(err))
-		c.ResponseError(errors.New("开启事务错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	defer func() {
@@ -168,7 +170,7 @@ func (m *Message) pinnedMessage(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			m.Error("新增置顶消息错误", zap.Error(err))
-			c.ResponseError(errors.New("新增置顶消息错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 		isSendSystemMsg = true
@@ -186,7 +188,7 @@ func (m *Message) pinnedMessage(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			m.Error("取消置顶消息错误", zap.Error(err))
-			c.ResponseError(errors.New("取消置顶消息错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 	}
@@ -194,7 +196,7 @@ func (m *Message) pinnedMessage(c *wkhttp.Context) {
 	if err != nil {
 		tx.Rollback()
 		m.Error("生成消息扩展序列号失败！", zap.Error(err))
-		c.ResponseError(errors.New("生成消息扩展序列号失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	err = m.messageExtraDB.insertOrUpdatePinnedTx(&messageExtraModel{
@@ -207,12 +209,14 @@ func (m *Message) pinnedMessage(c *wkhttp.Context) {
 	}, tx)
 	if err != nil {
 		tx.Rollback()
-		c.ResponseErrorf("更新消息置顶状态失败！", err)
+		m.Error("更新消息置顶状态失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	if err := tx.Commit(); err != nil {
 		tx.Rollback()
-		c.ResponseErrorf("事务提交失败！", err)
+		m.Error("事务提交失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	err = m.ctx.SendCMD(config.MsgCMDReq{
@@ -225,7 +229,7 @@ func (m *Message) pinnedMessage(c *wkhttp.Context) {
 
 	if err != nil {
 		m.Error("发送cmd失败！", zap.Error(err))
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
 		return
 	}
 	if isSendSystemMsg {
@@ -305,27 +309,27 @@ func (m *Message) clearPinnedMessage(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		m.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	if req.ChannelID == "" {
-		c.ResponseError(errors.New("频道ID不能为空"))
+		respondMessageRequestInvalid(c, "channel_id")
 		return
 	}
 	fakeChannelID := req.ChannelID
 	if req.ChannelType == common.ChannelTypePerson.Uint8() {
 		if loginUID == req.ChannelID {
-			c.ResponseError(errors.New("频道ID不合法"))
+			respondMessageRequestInvalid(c, "channel_id")
 			return
 		}
 		isFriend, err := m.userService.IsFriend(loginUID, req.ChannelID)
 		if err != nil {
 			m.Error("查询好友关系错误", zap.Error(err))
-			c.ResponseError(errors.New("查询好友关系错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if !isFriend {
-			c.ResponseError(errors.New("无权操作此会话"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageConversationForbidden, nil, nil)
 			return
 		}
 		fakeChannelID = common.GetFakeChannelIDWith(loginUID, req.ChannelID)
@@ -334,18 +338,18 @@ func (m *Message) clearPinnedMessage(c *wkhttp.Context) {
 		isCreatorOrManager, err := m.groupService.IsCreatorOrManager(req.ChannelID, loginUID)
 		if err != nil {
 			m.Error("查询用户在群内权限错误", zap.Error(err))
-			c.ResponseError(errors.New("查询用户在群内权限错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if !isCreatorOrManager {
-			c.ResponseError(errors.New("用户无权清空置顶消息"))
+			httperr.ResponseErrorL(c, errcode.ErrMessagePinnedForbidden, nil, nil)
 			return
 		}
 	}
 	pinnedMsgs, err := m.pinnedDB.queryWithUnDeletedMessage(fakeChannelID, req.ChannelType)
 	if err != nil {
 		m.Error("查询置顶消息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询置顶消息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	messageIds := make([]string, 0)
@@ -360,13 +364,13 @@ func (m *Message) clearPinnedMessage(c *wkhttp.Context) {
 	messageUserExtras, err := m.messageUserExtraDB.queryWithMessageIDsAndUID(messageIds, loginUID)
 	if err != nil {
 		m.Error("查询用户消息扩展字段失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询用户消息扩展字段失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	channelOffsetM, err := m.channelOffsetDB.queryWithUIDAndChannel(loginUID, fakeChannelID, req.ChannelType)
 	if err != nil {
 		m.Error("查询频道偏移量失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询频道偏移量失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	updateModel := make([]*pinnedMessageModel, 0)
@@ -396,7 +400,7 @@ func (m *Message) clearPinnedMessage(c *wkhttp.Context) {
 	tx, err := m.db.session.Begin()
 	if err != nil {
 		m.Error("开启事务错误", zap.Error(err))
-		c.ResponseError(errors.New("开启事务错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	defer func() {
@@ -410,7 +414,7 @@ func (m *Message) clearPinnedMessage(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			m.Error("删除置顶消息错误", zap.Error(err))
-			c.ResponseError(errors.New("删除置顶消息错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 
@@ -418,7 +422,7 @@ func (m *Message) clearPinnedMessage(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			m.Error("生成消息扩展序列号失败！", zap.Error(err))
-			c.ResponseError(errors.New("生成消息扩展序列号失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 		err = m.messageExtraDB.insertOrUpdatePinnedTx(&messageExtraModel{
@@ -432,14 +436,16 @@ func (m *Message) clearPinnedMessage(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			m.Error("修改消息扩展置顶状态错误", zap.Error(err))
-			c.ResponseErrorf("修改消息扩展置顶状态错误", err)
+			m.Error("修改消息扩展置顶状态错误", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 	}
 
 	if err := tx.Commit(); err != nil {
 		tx.Rollback()
-		c.ResponseErrorf("事务提交失败！", err)
+		m.Error("事务提交失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	err = m.ctx.SendCMD(config.MsgCMDReq{
@@ -452,7 +458,7 @@ func (m *Message) clearPinnedMessage(c *wkhttp.Context) {
 
 	if err != nil {
 		m.Error("发送cmd失败！", zap.Error(err))
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -467,27 +473,27 @@ func (m *Message) syncPinnedMessage(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		m.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	if req.ChannelID == "" {
-		c.ResponseError(errors.New("频道ID不能为空"))
+		respondMessageRequestInvalid(c, "channel_id")
 		return
 	}
 	fakeChannelID := req.ChannelID
 	if req.ChannelType == common.ChannelTypePerson.Uint8() {
 		if loginUID == req.ChannelID {
-			c.ResponseError(errors.New("频道ID不合法"))
+			respondMessageRequestInvalid(c, "channel_id")
 			return
 		}
 		isFriend, err := m.userService.IsFriend(loginUID, req.ChannelID)
 		if err != nil {
 			m.Error("查询好友关系错误", zap.Error(err))
-			c.ResponseError(errors.New("查询好友关系错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if !isFriend {
-			c.ResponseError(errors.New("无权操作此会话"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageConversationForbidden, nil, nil)
 			return
 		}
 		fakeChannelID = common.GetFakeChannelIDWith(loginUID, req.ChannelID)
@@ -495,18 +501,18 @@ func (m *Message) syncPinnedMessage(c *wkhttp.Context) {
 		isMember, err := m.groupService.ExistMember(req.ChannelID, loginUID)
 		if err != nil {
 			m.Error("查询群成员失败", zap.Error(err))
-			c.ResponseError(errors.New("查询权限失败"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 		if !isMember {
-			c.ResponseError(errors.New("非群成员，无权访问置顶消息"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageNotGroupMember, nil, nil)
 			return
 		}
 	}
 	pinnedMsgs, err := m.pinnedDB.queryWithChannelIDAndVersion(fakeChannelID, req.ChannelType, req.Version)
 	if err != nil {
 		m.Error("查询置顶消息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询置顶消息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	messageSeqs := make([]uint32, 0)
@@ -529,7 +535,7 @@ func (m *Message) syncPinnedMessage(c *wkhttp.Context) {
 	resp, err := m.ctx.IMGetWithChannelAndSeqs(req.ChannelID, req.ChannelType, loginUID, messageSeqs)
 	if err != nil {
 		m.Error("查询频道内的消息失败！", zap.Error(err), zap.String("req", util.ToJson(req)))
-		c.ResponseError(errors.New("查询频道内的消息失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 
@@ -544,7 +550,7 @@ func (m *Message) syncPinnedMessage(c *wkhttp.Context) {
 	messageExtras, err := m.messageExtraDB.queryWithMessageIDsAndUID(messageIds, loginUID)
 	if err != nil {
 		m.Error("查询消息扩展字段失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询用户消息扩展错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	messageExtraMap := map[string]*messageExtraDetailModel{}
@@ -557,7 +563,7 @@ func (m *Message) syncPinnedMessage(c *wkhttp.Context) {
 	messageUserExtras, err := m.messageUserExtraDB.queryWithMessageIDsAndUID(messageIds, loginUID)
 	if err != nil {
 		m.Error("查询用户消息扩展字段失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询用户消息扩展字段失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	messageUserExtraMap := map[string]*messageUserExtraModel{}
@@ -570,7 +576,7 @@ func (m *Message) syncPinnedMessage(c *wkhttp.Context) {
 	messageReaction, err := m.messageReactionDB.queryWithMessageIDs(messageIds)
 	if err != nil {
 		m.Error("查询消息回应数据错误", zap.Error(err))
-		c.ResponseError(errors.New("查询消息回应数据错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	messageReactionMap := map[string][]*reactionModel{}
@@ -587,7 +593,7 @@ func (m *Message) syncPinnedMessage(c *wkhttp.Context) {
 	channelOffsetM, err := m.channelOffsetDB.queryWithUIDAndChannel(loginUID, fakeChannelID, req.ChannelType)
 	if err != nil {
 		m.Error("查询频道偏移量失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询频道偏移量失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	// 频道偏移
@@ -596,7 +602,7 @@ func (m *Message) syncPinnedMessage(c *wkhttp.Context) {
 	channelSettings, err := m.channelService.GetChannelSettings(channelIds)
 	if err != nil {
 		m.Error("查询频道设置错误", zap.Error(err), zap.String("req", util.ToJson(req)))
-		c.ResponseError(errors.New("查询频道设置错误"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 	var channelOffsetMessageSeq uint32 = 0

--- a/modules/message/api_reminders.go
+++ b/modules/message/api_reminders.go
@@ -2,7 +2,6 @@ package message
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -14,6 +13,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"go.uber.org/zap"
 )
 
@@ -21,18 +22,18 @@ import (
 func (m *Message) reminderDone(c *wkhttp.Context) {
 	var ids []int64
 	if err := c.BindJSON(&ids); err != nil {
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	if len(ids) == 0 {
-		c.ResponseError(errors.New("数据不能为空！"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	loginUID := c.GetLoginUID()
 	tx, err := m.ctx.DB().Begin()
 	if err != nil {
 		m.Error("开启事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("开启事务失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	defer func() {
@@ -45,27 +46,28 @@ func (m *Message) reminderDone(c *wkhttp.Context) {
 	if err != nil {
 		tx.Rollback()
 		m.Error("添加done失败！", zap.Error(err))
-		c.ResponseError(errors.New("添加done失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	for _, id := range ids {
 		version, err := m.nextReminderSeq()
 		if err != nil {
-			c.ResponseError(err)
+			m.Error("生成提醒项序列号失败", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 		err = m.remindersDB.updateVersionTx(version, id, tx)
 		if err != nil {
 			tx.Rollback()
 			m.Error("更新提醒项版本失败！", zap.Error(err))
-			c.ResponseError(errors.New("更新提醒项版本失败！"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
 	}
 	if err := tx.Commit(); err != nil {
 		tx.RollbackUnlessCommitted()
 		m.Error("提交事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("提交事务失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
 	err = m.ctx.SendCMD(config.MsgCMDReq{
@@ -76,7 +78,7 @@ func (m *Message) reminderDone(c *wkhttp.Context) {
 	})
 	if err != nil {
 		m.Error("发送同步提醒项cmd失败！", zap.Error(err))
-		c.ResponseError(errors.New("发送同步提醒项cmd失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -91,14 +93,14 @@ func (m *Message) reminderSync(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		m.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	loginUID := c.GetLoginUID()
 	reminders, err := m.remindersDB.sync(loginUID, req.Version, req.Limit, req.ChannelIDs)
 	if err != nil {
 		m.Error("同步提醒项失败！", zap.Error(err))
-		c.ResponseError(errors.New("同步提醒项失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 
@@ -128,7 +130,7 @@ func (m *Message) reminderSync(c *wkhttp.Context) {
 		members, err = m.groupService.GetMembersWithUIDAndGroupIds(loginUID, groupIds)
 		if err != nil {
 			m.Error("查询登录用户加入群成员信息错误", zap.Error(err))
-			c.ResponseError(errors.New("查询登录用户加入群成员信息错误"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
 	}

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -16,9 +16,9 @@
 //  5. Append standalone thread ext entries not already in the IM result.
 //  6. Sort:
 //     follow  – category_sort ASC → pinned DESC → follow_sort ASC →
-//               intra-category sort ASC → target_id ASC (Issue #41 — sidebar
-//               drag wins over category-management UI; pin overrides everything
-//               within a category; see sortFollowItems for the full rationale).
+//     intra-category sort ASC → target_id ASC (Issue #41 — sidebar
+//     drag wins over category-management UI; pin overrides everything
+//     within a category; see sortFollowItems for the full rationale).
 //     recent  – pinned DESC, timestamp DESC.
 //  7. Return SidebarSyncResp{Items, Version}.
 //
@@ -47,6 +47,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"go.uber.org/zap"
@@ -107,7 +109,7 @@ type SidebarItem struct {
 	//     conversation 级别保持空避免误锁定。
 	// 客户端 WebSocket 收到群消息时拿这个字段决定渲染到哪个 Space tab，
 	// 与服务端 FilterRawConversationsBySpace 的可见性判定同口径。
-	SpaceID     string `json:"space_id,omitempty"`
+	SpaceID string `json:"space_id,omitempty"`
 	// MySourceSpaceID 是当前用户加入该群的"来源 Space"（外部成员场景）。
 	//   - GROUP: externalGroupMap[channelID]，即 group_external_member.source_space_id；
 	//   - COMMUNITY_TOPIC: externalGroupMap[parentGroupNo]（与父群保持同口径）；
@@ -115,12 +117,12 @@ type SidebarItem struct {
 	// 与 v1 SyncUserConversationResp.MySourceSpaceID 字段口径一致
 	// （GH octo-server#153 Round-2 P1）。客户端在 source Space 下用 sidebar 时
 	// 需要这个字段才能识别"我以哪个 Space 身份加入了这个外部群"。
-	MySourceSpaceID string `json:"my_source_space_id,omitempty"`
-	Timestamp   int64  `json:"timestamp"`
-	Unread      int    `json:"unread"`
-	IsPinned    bool   `json:"is_pinned"`
-	IsFollowed  bool   `json:"is_followed"`
-	CategoryID  *string `json:"category_id,omitempty"`
+	MySourceSpaceID string  `json:"my_source_space_id,omitempty"`
+	Timestamp       int64   `json:"timestamp"`
+	Unread          int     `json:"unread"`
+	IsPinned        bool    `json:"is_pinned"`
+	IsFollowed      bool    `json:"is_followed"`
+	CategoryID      *string `json:"category_id,omitempty"`
 	// CategorySort 暴露给客户端的"类别之间排序权重"，来源是 group_category.sort
 	// （PR #21 review by lml2468 blocker #3）。改类别顺序会 bump follow_version
 	// 并改变这里返回的值，与 /category/sort 接口及 swagger 一致。
@@ -213,11 +215,11 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 	var req sidebarSyncReq
 	if err := c.BindJSON(&req); err != nil {
 		sb.Error("sidebar sync: bad JSON", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误"))
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 	if err := validateSidebarRequest(&req); err != nil {
-		c.ResponseError(err)
+		respondMessageRequestInvalid(c, "")
 		return
 	}
 
@@ -249,7 +251,7 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 	rawConversations, err := sb.ctx.IMSyncUserConversation(loginUID, req.Version, req.MsgCount, req.LastMsgSeqs, nil)
 	if err != nil {
 		sb.Error("sidebar sync: IM fetch failed", zap.Error(err))
-		c.ResponseError(errors.New("同步会话失败"))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
 
@@ -288,7 +290,7 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 		}
 		if isFollowTab {
 			sb.Error("sidebar sync: "+stage+" failed (follow tab fail-closed)", zap.Error(err))
-			c.ResponseError(errors.New("同步会话失败"))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return true
 		}
 		sb.Warn("sidebar sync: "+stage+" failed (recent tab non-fatal)", zap.Error(err))
@@ -869,12 +871,12 @@ func buildFollowItems(
 			// CategorySort + intraCategorySort，让 thread 和父群在同一分类块内排序，
 			// 而不是默认全部落到 CategorySort=0 桶（与 DM 混在 follow tab 顶部）。
 			items = append(items, &SidebarItem{
-				TargetType:        int(common.ChannelTypeCommunityTopic),
-				TargetID:          conv.ChannelID,
-				ChannelType:       conv.ChannelType,
-				ChannelID:         conv.ChannelID,
+				TargetType:  int(common.ChannelTypeCommunityTopic),
+				TargetID:    conv.ChannelID,
+				ChannelType: conv.ChannelType,
+				ChannelID:   conv.ChannelID,
 				// thread 继承父群 SpaceID（GH octo-server#153）。
-				SpaceID:           groupSpaceMap[groupNo],
+				SpaceID: groupSpaceMap[groupNo],
 				// thread 同样继承父群的 MySourceSpaceID（GH octo-server#153 Round-2 P1）。
 				// Round-3 (GH#154 Round-2 Finding 2)：父群 source_space_id="" 兜底到 defaultSpaceID。
 				MySourceSpaceID:   sidebarMySourceSpaceID(externalGroupMap, groupNo, defaultSpaceID),
@@ -1032,12 +1034,12 @@ func mergeThreadEntries(
 		}
 		// 与 buildFollowItems thread 分支一致：继承父群 CategorySort + intraCategorySort。
 		result = append(result, &SidebarItem{
-			TargetType:        int(common.ChannelTypeCommunityTopic),
-			TargetID:          ext.TargetID,
-			ChannelType:       common.ChannelTypeCommunityTopic.Uint8(),
-			ChannelID:         ext.TargetID,
+			TargetType:  int(common.ChannelTypeCommunityTopic),
+			TargetID:    ext.TargetID,
+			ChannelType: common.ChannelTypeCommunityTopic.Uint8(),
+			ChannelID:   ext.TargetID,
 			// thread 继承父群 SpaceID（GH octo-server#153）。
-			SpaceID:           groupSpaceMap[groupNo],
+			SpaceID: groupSpaceMap[groupNo],
 			// thread 同样继承父群的 MySourceSpaceID（GH octo-server#153 Round-2 P1）。
 			// Round-3 (GH#154 Round-2 Finding 2)：父群 source_space_id="" 兜底到 defaultSpaceID。
 			MySourceSpaceID:   sidebarMySourceSpaceID(externalGroupMap, groupNo, defaultSpaceID),

--- a/pkg/errcode/message.go
+++ b/pkg/errcode/message.go
@@ -1,0 +1,165 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// err.server.message.* — modules/message business error codes (api.go,
+// api_manager.go, api_pinned.go, api_conversation.go, api_message_get.go,
+// api_reminders.go, api_channel_files.go, api_sidebar.go). DefaultMessage holds
+// the en-US source (D4); zh-CN runtime translations live in
+// pkg/i18n/locales/active.zh-CN.toml. Internal=true codes never surface their
+// message on the wire — callers MUST log the underlying err with full context
+// before responding.
+var (
+	// ---- validation (400) ----------------------------------------------------
+
+	// ErrMessageRequestInvalid is the catch-all for missing / malformed request
+	// input (empty ids, bad channel-id / message-id / seq format, BindJSON
+	// failure, unsupported channel type, etc.). The offending field is surfaced
+	// via Details when the caller can identify it.
+	ErrMessageRequestInvalid = register(codes.Code{
+		ID:             "err.server.message.request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid request.",
+		SafeDetailKeys: []string{"field"},
+	})
+	ErrMessageIDSeqMismatch = register(codes.Code{
+		ID:             "err.server.message.id_seq_mismatch",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Message ID does not match the message sequence.",
+	})
+
+	// ---- permission / authorization (403) ------------------------------------
+
+	ErrMessageNotFriend = register(codes.Code{
+		ID:             "err.server.message.not_friend",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You are not friends with this user.",
+	})
+	ErrMessagePeerNotInSpace = register(codes.Code{
+		ID:             "err.server.message.peer_not_in_space",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "The other party is not in this space.",
+	})
+	ErrMessageConversationForbidden = register(codes.Code{
+		ID:             "err.server.message.conversation_forbidden",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You do not have permission to operate on this conversation.",
+	})
+	ErrMessageCannotDeleteSelfConversation = register(codes.Code{
+		ID:             "err.server.message.cannot_delete_self_conversation",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "You cannot delete the conversation with yourself.",
+	})
+	ErrMessageChannelAccessDenied = register(codes.Code{
+		ID:             "err.server.message.channel_access_denied",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You do not have permission to operate on this channel.",
+	})
+	ErrMessageNotGroupMember = register(codes.Code{
+		ID:             "err.server.message.not_group_member",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You are not a member of this group.",
+	})
+	ErrMessageDeleteForbidden = register(codes.Code{
+		ID:             "err.server.message.delete_forbidden",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You do not have permission to delete this message.",
+	})
+	ErrMessageRecallForbidden = register(codes.Code{
+		ID:             "err.server.message.recall_forbidden",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You do not have permission to recall this message.",
+	})
+	ErrMessagePinnedForbidden = register(codes.Code{
+		ID:             "err.server.message.pinned_forbidden",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You do not have permission to pin or unpin messages.",
+	})
+	ErrMessageEditOwnOnly = register(codes.Code{
+		ID:             "err.server.message.edit_own_only",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You can only edit your own messages.",
+	})
+	ErrMessageProxySendUnsupported = register(codes.Code{
+		ID:             "err.server.message.proxy_send_unsupported",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Sending messages on behalf of another user is not supported.",
+	})
+
+	// ---- not found (404) -----------------------------------------------------
+
+	ErrMessageNotFound = register(codes.Code{
+		ID:             "err.server.message.not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Message not found or already deleted.",
+	})
+	ErrMessageGroupNotFound = register(codes.Code{
+		ID:             "err.server.message.group_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "The target group does not exist or has been deleted.",
+	})
+	ErrMessageReceiverNotFound = register(codes.Code{
+		ID:             "err.server.message.receiver_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "The message recipient does not exist.",
+	})
+	ErrMessageBanwordNotFound = register(codes.Code{
+		ID:             "err.server.message.banword_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "The banned word does not exist.",
+	})
+
+	// ---- limit / time window (400) -------------------------------------------
+
+	ErrMessagePinnedLimitExceeded = register(codes.Code{
+		ID:             "err.server.message.pinned_limit_exceeded",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The pinned-message limit has been reached.",
+		SafeDetailKeys: []string{"max"},
+	})
+	ErrMessageRecallTimeExceeded = register(codes.Code{
+		ID:             "err.server.message.recall_time_exceeded",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The message is past the recall time window.",
+	})
+
+	// ---- internal (500, Internal=true) ---------------------------------------
+
+	// ErrMessageQueryFailed covers read-path failures (DB SELECT/count, cache
+	// GET, membership / permission checks, search-result decoding, sync reads).
+	ErrMessageQueryFailed = register(codes.Code{
+		ID:             "err.server.message.query_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to query message data.",
+		Internal:       true,
+	})
+	// ErrMessageStoreFailed covers mutation-path failures (DB write, transaction
+	// begin/commit, sequence generation, cache SET, offset/read/pin/recall/edit
+	// persistence).
+	ErrMessageStoreFailed = register(codes.Code{
+		ID:             "err.server.message.store_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to persist message data.",
+		Internal:       true,
+	})
+	// ErrMessageNotifyFailed covers outbound IM command / sync-command / recall
+	// dispatch failures.
+	ErrMessageNotifyFailed = register(codes.Code{
+		ID:             "err.server.message.notify_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to dispatch the message command.",
+		Internal:       true,
+	})
+	// ErrMessageSearchFailed covers failures calling / parsing the external
+	// search service.
+	ErrMessageSearchFailed = register(codes.Code{
+		ID:             "err.server.message.search_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Message search failed.",
+		Internal:       true,
+	})
+)

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -475,3 +475,72 @@ other = "保存群数据失败。"
 
 ["err.server.group.notify_failed"]
 other = "发送群通知失败。"
+
+["err.server.message.request_invalid"]
+other = "请求参数有误。"
+
+["err.server.message.id_seq_mismatch"]
+other = "消息 ID 与消息序号不匹配。"
+
+["err.server.message.not_friend"]
+other = "你与对方不是好友。"
+
+["err.server.message.peer_not_in_space"]
+other = "对方不在该空间内。"
+
+["err.server.message.conversation_forbidden"]
+other = "你没有权限操作此会话。"
+
+["err.server.message.cannot_delete_self_conversation"]
+other = "不能删除与自己的会话。"
+
+["err.server.message.channel_access_denied"]
+other = "你没有权限操作此频道。"
+
+["err.server.message.not_group_member"]
+other = "你不是该群成员。"
+
+["err.server.message.delete_forbidden"]
+other = "你没有权限删除此消息。"
+
+["err.server.message.recall_forbidden"]
+other = "你没有权限撤回此消息。"
+
+["err.server.message.pinned_forbidden"]
+other = "你没有权限置顶或取消置顶消息。"
+
+["err.server.message.edit_own_only"]
+other = "只能编辑自己发送的消息。"
+
+["err.server.message.proxy_send_unsupported"]
+other = "不支持代发消息。"
+
+["err.server.message.not_found"]
+other = "消息不存在或已删除。"
+
+["err.server.message.group_not_found"]
+other = "目标群不存在或已删除。"
+
+["err.server.message.receiver_not_found"]
+other = "消息接收者不存在。"
+
+["err.server.message.banword_not_found"]
+other = "操作的违禁词不存在。"
+
+["err.server.message.pinned_limit_exceeded"]
+other = "置顶消息数量已达上限。"
+
+["err.server.message.recall_time_exceeded"]
+other = "消息已超过可撤回时限。"
+
+["err.server.message.query_failed"]
+other = "查询消息数据失败。"
+
+["err.server.message.store_failed"]
+other = "保存消息数据失败。"
+
+["err.server.message.notify_failed"]
+other = "发送消息指令失败。"
+
+["err.server.message.search_failed"]
+other = "消息搜索失败。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -123,6 +123,75 @@ other = "The target user does not exist or has been deactivated."
 ["err.server.group.view_forbidden"]
 other = "You do not have permission to view this."
 
+["err.server.message.banword_not_found"]
+other = "The banned word does not exist."
+
+["err.server.message.cannot_delete_self_conversation"]
+other = "You cannot delete the conversation with yourself."
+
+["err.server.message.channel_access_denied"]
+other = "You do not have permission to operate on this channel."
+
+["err.server.message.conversation_forbidden"]
+other = "You do not have permission to operate on this conversation."
+
+["err.server.message.delete_forbidden"]
+other = "You do not have permission to delete this message."
+
+["err.server.message.edit_own_only"]
+other = "You can only edit your own messages."
+
+["err.server.message.group_not_found"]
+other = "The target group does not exist or has been deleted."
+
+["err.server.message.id_seq_mismatch"]
+other = "Message ID does not match the message sequence."
+
+["err.server.message.not_found"]
+other = "Message not found or already deleted."
+
+["err.server.message.not_friend"]
+other = "You are not friends with this user."
+
+["err.server.message.not_group_member"]
+other = "You are not a member of this group."
+
+["err.server.message.notify_failed"]
+other = "Failed to dispatch the message command."
+
+["err.server.message.peer_not_in_space"]
+other = "The other party is not in this space."
+
+["err.server.message.pinned_forbidden"]
+other = "You do not have permission to pin or unpin messages."
+
+["err.server.message.pinned_limit_exceeded"]
+other = "The pinned-message limit has been reached."
+
+["err.server.message.proxy_send_unsupported"]
+other = "Sending messages on behalf of another user is not supported."
+
+["err.server.message.query_failed"]
+other = "Failed to query message data."
+
+["err.server.message.recall_forbidden"]
+other = "You do not have permission to recall this message."
+
+["err.server.message.recall_time_exceeded"]
+other = "The message is past the recall time window."
+
+["err.server.message.receiver_not_found"]
+other = "The message recipient does not exist."
+
+["err.server.message.request_invalid"]
+other = "Invalid request."
+
+["err.server.message.search_failed"]
+other = "Message search failed."
+
+["err.server.message.store_failed"]
+other = "Failed to persist message data."
+
 ["err.server.thread.creator_cannot_leave"]
 other = "Thread creator cannot leave the thread."
 


### PR DESCRIPTION
## Summary

Phase 2.1 i18n migration of `modules/message` — the next hot module after `thread` (#176), `user` (#188 / #197) and `group` (#198). All **336** legacy error-response sites across 8 files migrate from the legacy `c.ResponseError(...)` / `c.ResponseErrorf(...)` / `c.ResponseErrorWithStatus(...)` envelope to the localized `httperr.ResponseErrorL` facade, reusing the established playbook.

Organized as 8 reviewable commits: code registry → respond helpers → per-file migration → tests.

| file | sites |
|---|---|
| `api.go` | 138 |
| `api_manager.go` | 60 |
| `api_pinned.go` | 56 |
| `api_conversation.go` | 44 |
| `api_message_get.go` / `api_reminders.go` / `api_channel_files.go` / `api_sidebar.go` | 38 |

## What changed

- **23 new `err.server.message.*` codes** (`pkg/errcode/message.go`) + zh-CN runtime translations + regenerated AST marker. Codes group by class: validation (400), permission (403), not-found (404), recall window / pinned limit (400), and `Internal=true` query / store / notify / search buckets (500).
- **`modules/message/api_i18n.go`** respond helpers (`respondMessageRequestInvalid` with field detail, `respondMessagePinnedLimitExceeded` with max detail, and the shared `auth.required` / `auth.token_invalid` / `auth.forbidden` guards for the proxy-send and management-console paths).
- Internal failures collapse to the `Internal=true` buckets; every such site keeps (or gains) an `m.Error(..., zap.Error(err))` log so the underlying error is never put on the wire. `ResponseErrorf("msg", err)` and `errors.Wrap(err, "msg")` sites preserve the original message as the log.
- Sentinels reused where the service layer already provides them: `authorizeMutualDelete` → `delete_forbidden` (403), `verifyRevokeMessageID` → `id_seq_mismatch` (400).

## Behavior change (frontend, please note)

Following the i18n design (D14), every migrated error response returns **HTTP wire status 400** during the compatibility window; the semantic status lives in `error.http_status` and clients should branch on `error.code`. Three `api_conversation.go` sync-failure sites that previously returned a real `500` now return a `400` envelope with `error.http_status: 500` (Internal). This is consistent with the thread/user/group migrations already merged.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./modules/message/`
- [x] `make i18n-lint` (D23 direct-error-response ratchet + unregistered-code)
- [x] `make i18n-extract-check` (AST marker recall)
- [x] `go test ./modules/message ./pkg/errcode ./pkg/i18n/...` (clean DB) — the full module's existing 642 test cases pass unchanged, since they assert the wire-400 contract that D14 preserves.
- [x] New tests: `TestMessageNoLegacyResponseError` (source guard over all 8 files) and `TestRespondMessageHelpers` (helper / sentinel / Internal-no-leak / dual-envelope / detail keys).

## Follow-ups (non-blocking)

- Service-layer sentinel errors (`errors.Is`) to replace the err-string matching used for business-vs-internal classification — the same shared follow-up tracked for thread/user/group.
