### PR TITLE
fix(robot): bot 事件 mention 归一化（strip 裸 mention.all=1）

### DIFF
--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -1,6 +1,7 @@
 package robot
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"encoding/json"
 	"errors"
@@ -179,6 +180,15 @@ func enqueueBotEventGeneric(ctx *config.Context, robotID string, message *config
 	}
 	if message == nil {
 		return errors.New("robot: nil message, cannot enqueue bot event")
+	}
+	// YUJ-2531 / Mininglamp-OSS/octo-server#208: bot-delivery chokepoint
+	// (synthetic-event path). Mirror saveRobotMessage: strip any bare
+	// legacy `mention.all=1` and inject `mention.humans=1` on a copy so
+	// the bot event queue never carries the legacy broadcast flag.
+	if normalized := stripBareMentionAllForBot(message.Payload); !bytes.Equal(normalized, message.Payload) {
+		cp := *message
+		cp.Payload = normalized
+		message = &cp
 	}
 	seq, err := ctx.GenSeq(fmt.Sprintf("%s%s", common.RobotEventSeqKey, robotID))
 	if err != nil {

--- a/modules/robot/event.go
+++ b/modules/robot/event.go
@@ -1,6 +1,7 @@
 package robot
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -336,6 +337,18 @@ func (rb *Robot) autoReadForBot(message *config.MessageResp, robotID string) {
 }
 
 func (rb *Robot) saveRobotMessage(message *config.MessageResp, robotID string) {
+
+	// YUJ-2531 / Mininglamp-OSS/octo-server#208: bot-delivery chokepoint.
+	// Strip any bare legacy `mention.all=1` and inject `mention.humans=1`
+	// so bots never observe the legacy broadcast flag regardless of the
+	// (user-machine-resident, possibly outdated) adapter version. Operates
+	// on a copy of the payload; the original `message.Payload` shared with
+	// the human-client fan-out keeps `all=1` for rendering.
+	if normalized := stripBareMentionAllForBot(message.Payload); !bytes.Equal(normalized, message.Payload) {
+		cp := *message
+		cp.Payload = normalized
+		message = &cp
+	}
 
 	seq, err := rb.ctx.GenSeq(fmt.Sprintf("%s%s", common.RobotEventSeqKey, robotID))
 	if err != nil {

--- a/modules/robot/normalize_bot_mention.go
+++ b/modules/robot/normalize_bot_mention.go
@@ -1,0 +1,146 @@
+// modules/robot/normalize_bot_mention.go
+//
+// YUJ-2531 / Mininglamp-OSS/octo-server#208: server-side guard that
+// strips a bare `mention.all=1` from payloads delivered to bots and
+// injects `mention.humans=1` in its place.
+//
+// Why this exists
+// ===============
+// The three-state mention contract (octo-server#94 / #142) treats
+// `mention.all=1` as the LEGACY `@所有人` signal. Read-side clients
+// render the "@所有人" pill from it, but the new routing semantics are
+// driven by `mention.humans=1` (notify humans) and `mention.ais=1`
+// (notify bots). A legacy client that only emits `mention.all=1`
+// produces a payload that a bot adapter cannot interpret cleanly — and
+// the openclaw adapter (openclaw-channel-octo) lives on the user's own
+// machine, so we cannot guarantee it is updated to map `all` → humans.
+//
+// To make bot ingress robust regardless of adapter version, every
+// payload that reaches a bot's event queue is normalized here:
+//   - `mention.all` is stripped (bots must never see the bare legacy
+//     broadcast flag), and
+//   - `mention.humans=1` is injected when it is not already present,
+//     preserving the "notify humans" intent the legacy `all=1` carried.
+//
+// Human-client delivery is NOT affected: this helper is only invoked on
+// the bot event-queue write paths (saveRobotMessage / enqueueBotEvent-
+// Generic). The WuKongIM fan-out to human clients keeps `all=1` for
+// rendering.
+//
+// Contract (locked by normalize_bot_mention_test.go):
+//  1. Pure: never mutates the caller's `payload` byte slice; a new
+//     []byte is returned only when a rewrite actually happens.
+//  2. Only `mention.all` and `mention.humans` are touched. `mention.ais`,
+//     `mention.uids`, `mention.entities`, and every sibling key are
+//     preserved exactly.
+//  3. No-op when there is no truthy `mention.all`: the original bytes are
+//     returned unchanged (no allocation, no re-serialization).
+//  4. Idempotent: a second pass over a normalized payload is a no-op
+//     (the stripped `all` is already gone).
+//  5. Best-effort on malformed input: if the payload does not parse, or
+//     `mention` is not an object, the original bytes are returned. We
+//     MUST NOT drop the message.
+//  6. Numeric precision: int64 fields (e.g. message_id) survive the
+//     round trip via json.Decoder.UseNumber().
+package robot
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
+	"github.com/tidwall/gjson"
+)
+
+// stripBareMentionAllForBot returns a payload byte slice with a truthy
+// `mention.all` removed and `mention.humans=1` injected (when not
+// already set). See the file header for the full contract.
+func stripBareMentionAllForBot(payload []byte) []byte {
+	if len(payload) == 0 {
+		return payload
+	}
+
+	// Fast-path: nothing to do unless `mention.all` is truthy.
+	allResult := gjson.GetBytes(payload, "mention.all")
+	if !mentionAllTruthy(allResult) {
+		return payload
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(payload))
+	dec.UseNumber()
+	var doc map[string]interface{}
+	if err := dec.Decode(&doc); err != nil {
+		return payload
+	}
+	if doc == nil {
+		return payload
+	}
+
+	raw, ok := doc[mentionrewrite.MentionKey]
+	if !ok || raw == nil {
+		return payload
+	}
+	mention, isObj := raw.(map[string]interface{})
+	if !isObj {
+		// Malformed mention — best-effort skip (contract clause 5).
+		return payload
+	}
+
+	// Strip the legacy `all` flag and preserve the "notify humans"
+	// intent via `humans=1` unless the client already set it.
+	delete(mention, mentionrewrite.AllKey)
+	if !decodedTruthyOne(mention[mentionrewrite.HumansKey]) {
+		mention[mentionrewrite.HumansKey] = 1
+	}
+
+	out, err := json.Marshal(doc)
+	if err != nil {
+		return payload
+	}
+	return out
+}
+
+// decodedTruthyOne reports whether a json.Decoder(UseNumber)-decoded
+// value is the numeric/boolean form of 1. Covers the shapes the bot
+// payload decoder can produce for `mention.humans` (json.Number on the
+// hot path, plus bool / float64 defensively).
+func decodedTruthyOne(v interface{}) bool {
+	switch x := v.(type) {
+	case nil:
+		return false
+	case json.Number:
+		n, err := x.Int64()
+		return err == nil && n == 1
+	case float64:
+		return x == 1
+	case int:
+		return x == 1
+	case int64:
+		return x == 1
+	case bool:
+		return x
+	default:
+		return false
+	}
+}
+
+// mentionAllTruthy reports whether a gjson-parsed `mention.all` value is
+// the canonical truthy form (1 / true / "1"). Mirrors mentionAisTruthy
+// (ais_broadcast.go) so the strip side and the dispatch side agree on
+// what counts as a set flag.
+func mentionAllTruthy(r gjson.Result) bool {
+	if !r.Exists() {
+		return false
+	}
+	switch r.Type {
+	case gjson.True:
+		return true
+	case gjson.False, gjson.Null:
+		return false
+	case gjson.Number:
+		return r.Int() == 1
+	case gjson.String:
+		return r.Str == "1"
+	}
+	return false
+}

--- a/modules/robot/normalize_bot_mention_test.go
+++ b/modules/robot/normalize_bot_mention_test.go
@@ -1,0 +1,116 @@
+package robot
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestStripBareMentionAllForBot_StripsAllAndInjectsHumans(t *testing.T) {
+	in := []byte(`{"type":1,"content":"hi","mention":{"all":1}}`)
+	out := stripBareMentionAllForBot(in)
+
+	if gjson.GetBytes(out, "mention.all").Exists() {
+		t.Fatalf("expected mention.all to be stripped, got %s", out)
+	}
+	if gjson.GetBytes(out, "mention.humans").Int() != 1 {
+		t.Fatalf("expected mention.humans=1, got %s", out)
+	}
+}
+
+func TestStripBareMentionAllForBot_PreservesAisAndUids(t *testing.T) {
+	in := []byte(`{"type":1,"mention":{"all":1,"ais":1,"uids":["bot_a"]}}`)
+	out := stripBareMentionAllForBot(in)
+
+	if gjson.GetBytes(out, "mention.all").Exists() {
+		t.Fatalf("expected mention.all stripped, got %s", out)
+	}
+	if gjson.GetBytes(out, "mention.ais").Int() != 1 {
+		t.Fatalf("expected mention.ais preserved, got %s", out)
+	}
+	if gjson.GetBytes(out, "mention.humans").Int() != 1 {
+		t.Fatalf("expected mention.humans injected, got %s", out)
+	}
+	uids := gjson.GetBytes(out, "mention.uids").Array()
+	if len(uids) != 1 || uids[0].String() != "bot_a" {
+		t.Fatalf("expected mention.uids preserved, got %s", out)
+	}
+}
+
+func TestStripBareMentionAllForBot_KeepsExistingHumans(t *testing.T) {
+	// humans already set: do not clobber, just strip all.
+	in := []byte(`{"mention":{"all":1,"humans":1}}`)
+	out := stripBareMentionAllForBot(in)
+	if gjson.GetBytes(out, "mention.all").Exists() {
+		t.Fatalf("expected mention.all stripped, got %s", out)
+	}
+	if gjson.GetBytes(out, "mention.humans").Int() != 1 {
+		t.Fatalf("expected mention.humans=1, got %s", out)
+	}
+}
+
+func TestStripBareMentionAllForBot_NoOpWithoutAll(t *testing.T) {
+	in := []byte(`{"type":1,"mention":{"ais":1,"uids":["bot_a"]}}`)
+	out := stripBareMentionAllForBot(in)
+	if string(out) != string(in) {
+		t.Fatalf("expected no-op, got %s", out)
+	}
+}
+
+func TestStripBareMentionAllForBot_NoOpWithoutMention(t *testing.T) {
+	in := []byte(`{"type":1,"content":"hi"}`)
+	out := stripBareMentionAllForBot(in)
+	if string(out) != string(in) {
+		t.Fatalf("expected no-op, got %s", out)
+	}
+}
+
+func TestStripBareMentionAllForBot_FalsyAllIsNoOp(t *testing.T) {
+	in := []byte(`{"mention":{"all":0}}`)
+	out := stripBareMentionAllForBot(in)
+	if string(out) != string(in) {
+		t.Fatalf("expected no-op for all=0, got %s", out)
+	}
+}
+
+func TestStripBareMentionAllForBot_Idempotent(t *testing.T) {
+	in := []byte(`{"mention":{"all":1}}`)
+	once := stripBareMentionAllForBot(in)
+	twice := stripBareMentionAllForBot(once)
+	if string(once) != string(twice) {
+		t.Fatalf("expected idempotent, once=%s twice=%s", once, twice)
+	}
+}
+
+func TestStripBareMentionAllForBot_MalformedPayloadIsNoOp(t *testing.T) {
+	in := []byte(`not json`)
+	out := stripBareMentionAllForBot(in)
+	if string(out) != string(in) {
+		t.Fatalf("expected malformed payload returned unchanged, got %s", out)
+	}
+}
+
+func TestStripBareMentionAllForBot_PreservesMessageIDPrecision(t *testing.T) {
+	in := []byte(`{"message_id":9223372036854775807,"mention":{"all":1}}`)
+	out := stripBareMentionAllForBot(in)
+	var doc map[string]interface{}
+	dec := json.NewDecoder(bytes.NewReader(out))
+	dec.UseNumber()
+	if err := dec.Decode(&doc); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if n, ok := doc["message_id"].(json.Number); !ok || n.String() != "9223372036854775807" {
+		t.Fatalf("message_id precision lost, got %v (%s)", doc["message_id"], out)
+	}
+}
+
+func TestStripBareMentionAllForBot_DoesNotMutateCaller(t *testing.T) {
+	in := []byte(`{"mention":{"all":1}}`)
+	orig := string(in)
+	_ = stripBareMentionAllForBot(in)
+	if string(in) != orig {
+		t.Fatalf("caller payload mutated: %s", in)
+	}
+}


### PR DESCRIPTION
## 背景
adapter 装在用户电脑上，不能保证更新。Server 端需保证 bot 收到的 payload 不含裸 `mention.all=1`——三态路由由 `mention.humans`（通知真人）/ `mention.ais`（通知 bot）驱动（YUJ-2531 / #208）。

## 改动
新增 `modules/robot/normalize_bot_mention.go`：`stripBareMentionAllForBot` strip 掉 truthy `mention.all` 并注入 `mention.humans=1`（保留旧语义），在 payload 副本上操作。

接入两个 bot 投递 chokepoint：
- `saveRobotMessage`（listener 路径，event.go）
- `enqueueBotEventGeneric`（synthetic 路径，api.go）

人类客户端 fan-out 不受影响（保留 all=1 供渲染）。helper 纯函数、幂等、对 malformed payload best-effort；ais/uids/entities 与 message_id 精度均保留。

## 验证
- `go build ./modules/robot/` ✅
- `go vet ./modules/robot/` ✅
- `go test ./modules/robot/` — ok（含新增 11 个 normalize 用例）✅

Fixes #208