### PR TITLE
feat(i18n): migrate modules/workplace to ResponseErrorL

### DIFF
--- a/modules/workplace/api.go
+++ b/modules/workplace/api.go
@@ -1,15 +1,16 @@
 package workplace
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"runtime/debug"
 
-	"github.com/Mininglamp-OSS/octo-server/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/log"
 	"go.uber.org/zap"
 )
 
@@ -48,13 +49,13 @@ func (w *Workplace) deleteRecord(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	appId := c.Query("app_id")
 	if appId == "" {
-		c.ResponseError(errors.New("删除的应用ID不能为空"))
+		respondWorkplaceRequestInvalid(c, "app_id")
 		return
 	}
 	err := w.db.deleteRecord(loginUID, appId)
 	if err != nil {
 		w.Error("删除使用记录错误", zap.Error(err))
-		c.ResponseError(errors.New("删除使用记录错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -65,7 +66,7 @@ func (w *Workplace) getRecord(c *wkhttp.Context) {
 	records, err := w.db.queryRecordWithUid(loginUID)
 	if err != nil {
 		w.Error("查询使用记录错误", zap.Error(err))
-		c.ResponseError(errors.New("查询使用记录错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		return
 	}
 	list := make([]*appResp, 0)
@@ -77,7 +78,7 @@ func (w *Workplace) getRecord(c *wkhttp.Context) {
 		apps, err := w.db.queryAppWithAppIds(appIds)
 		if err != nil {
 			w.Error("查询一批应用错误", zap.Error(err))
-			c.ResponseError(errors.New("查询一批应用错误"))
+			httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 			return
 		}
 		if len(apps) > 0 {
@@ -85,7 +86,7 @@ func (w *Workplace) getRecord(c *wkhttp.Context) {
 			saveList, err := w.db.queryAppWithUid(loginUID)
 			if err != nil {
 				w.Error("查询用户已保存的应用错误", zap.Error(err))
-				c.ResponseError(errors.New("查询用户已保存的应用错误"))
+				httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 				return
 			}
 			for _, app := range apps {
@@ -111,23 +112,23 @@ func (w *Workplace) addRecord(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	appId := c.Param("app_id")
 	if appId == "" {
-		c.ResponseError(errors.New("应用ID不能为空"))
+		respondWorkplaceRequestInvalid(c, "app_id")
 		return
 	}
 	app, err := w.db.queryAppWithAppId(appId)
 	if err != nil {
 		w.Error("查询应用错误", zap.Error(err))
-		c.ResponseError(errors.New("查询应用错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		return
 	}
 	if app == nil || app.Status == 0 {
-		c.ResponseError(errors.New("该应用已删除或不可用"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceAppNotFound, nil, nil)
 		return
 	}
 	record, err := w.db.queryRecordWithUidAndAppId(loginUID, appId)
 	if err != nil {
 		w.Error("查询使用记录错误", zap.Error(err))
-		c.ResponseError(errors.New("查询使用记录错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		return
 	}
 	if record == nil {
@@ -138,7 +139,7 @@ func (w *Workplace) addRecord(c *wkhttp.Context) {
 		})
 		if err != nil {
 			w.Error("新增使用记录错误", zap.Error(err))
-			c.ResponseError(errors.New("新增使用记录错误"))
+			httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 			return
 		}
 	} else {
@@ -146,7 +147,7 @@ func (w *Workplace) addRecord(c *wkhttp.Context) {
 		err := w.db.updateRecordCount(record)
 		if err != nil {
 			w.Error("修改使用记录错误", zap.Error(err))
-			c.ResponseError(errors.New("修改使用记录错误"))
+			httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 			return
 		}
 	}
@@ -156,13 +157,13 @@ func (w *Workplace) getAppWithCategory(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	categoryNo := c.Param("category_no")
 	if categoryNo == "" {
-		c.ResponseError(errors.New("分类编号不能为空"))
+		respondWorkplaceRequestInvalid(c, "category_no")
 		return
 	}
 	apps, err := w.db.queryAppWithCategroyNo(categoryNo)
 	if err != nil {
 		w.Error("通过分类查询应用错误", zap.Error(err))
-		c.ResponseError(errors.New("通过分类查询应用错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		return
 	}
 	list := make([]*appResp, 0)
@@ -171,7 +172,7 @@ func (w *Workplace) getAppWithCategory(c *wkhttp.Context) {
 		saveList, err := w.db.queryAppWithUid(loginUID)
 		if err != nil {
 			w.Error("查询用户已保存的应用错误", zap.Error(err))
-			c.ResponseError(errors.New("查询用户已保存的应用错误"))
+			httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 			return
 		}
 		for _, app := range apps {
@@ -201,19 +202,19 @@ func (w *Workplace) reorderApp(c *wkhttp.Context) {
 	var req reqVO
 	if err := c.BindJSON(&req); err != nil {
 		w.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(common.ErrData)
+		respondWorkplaceRequestInvalid(c, "")
 		return
 	}
 	tx, err := w.ctx.DB().Begin()
 	if err != nil {
 		w.Error("开启事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("开启事务失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	defer func() {
 		if err := recover(); err != nil {
 			tx.Rollback()
-			c.ResponseError(errors.New("服务器内部错误"))
+			respondWorkplaceInternal(c)
 			fmt.Fprintf(os.Stderr, "recovered panic in goroutine: %v\n%s\n", err, debug.Stack())
 		}
 	}()
@@ -224,7 +225,7 @@ func (w *Workplace) reorderApp(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			w.Error("修改用户app顺序错误", zap.Error(err))
-			c.ResponseError(errors.New("修改用户app顺序错误"))
+			httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 			return
 		}
 		tempSortNum--
@@ -232,7 +233,7 @@ func (w *Workplace) reorderApp(c *wkhttp.Context) {
 	err = tx.Commit()
 	if err != nil {
 		w.Error("数据库事物提交失败", zap.Error(err))
-		c.ResponseError(errors.New("数据库事物提交失败"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		tx.Rollback()
 		return
 	}
@@ -244,12 +245,12 @@ func (w *Workplace) deleteApp(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	appId := c.Param("app_id")
 	if appId == "" {
-		c.ResponseError(errors.New("appId不能为空"))
+		respondWorkplaceRequestInvalid(c, "app_id")
 		return
 	}
 	err := w.db.deleteUserAppWithAppId(loginUID, appId)
 	if err != nil {
-		c.ResponseError(errors.New("删除用户app错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		w.Error("删除用户app错误", zap.Error(err))
 		return
 	}
@@ -261,23 +262,23 @@ func (w *Workplace) addApp(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	appId := c.Param("app_id")
 	if appId == "" {
-		c.ResponseError(errors.New("应用ID不能为空"))
+		respondWorkplaceRequestInvalid(c, "app_id")
 		return
 	}
 	app, err := w.db.queryAppWithAppId(appId)
 	if err != nil {
-		c.ResponseError(errors.New("查询应用错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		w.Error("查询应用错误", zap.Error(err))
 		return
 	}
 	if app == nil || len(app.AppID) == 0 || app.Status == 0 {
-		c.ResponseError(errors.New("该应用不存在或被禁用"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceAppNotFound, nil, nil)
 		w.Error("该应用不存在或被禁用", zap.Error(err))
 		return
 	}
 	userApp, err := w.db.queryUserAppWithAPPId(loginUID, appId)
 	if err != nil {
-		c.ResponseError(errors.New("查询用户某个应用错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		w.Error("查询用户某个应用错误", zap.Error(err))
 		return
 	}
@@ -287,7 +288,7 @@ func (w *Workplace) addApp(c *wkhttp.Context) {
 	}
 	maxSortNumApp, err := w.db.queryUserAppMaxSortNumWithUID(loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("查询用户最大序号app错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		w.Error("查询用户最大序号app错误", zap.Error(err))
 		return
 	}
@@ -301,7 +302,7 @@ func (w *Workplace) addApp(c *wkhttp.Context) {
 		AppID:   appId,
 	})
 	if err != nil {
-		c.ResponseError(errors.New("添加用户app错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		w.Error("添加用户app错误", zap.Error(err))
 		return
 	}
@@ -312,7 +313,7 @@ func (w *Workplace) addApp(c *wkhttp.Context) {
 func (w *Workplace) getCategory(c *wkhttp.Context) {
 	models, err := w.db.queryCategory()
 	if err != nil {
-		c.ResponseError(errors.New("查询分类错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		w.Error("查询分类错误", zap.Error(err))
 		return
 	}
@@ -333,7 +334,7 @@ func (w *Workplace) getCategory(c *wkhttp.Context) {
 func (w *Workplace) getApps(c *wkhttp.Context) {
 	models, err := w.db.queryUserApp(c.GetLoginUID())
 	if err != nil {
-		c.ResponseError(errors.New("查询用户应用错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		w.Error("查询用户应用错误", zap.Error(err))
 		return
 	}
@@ -345,7 +346,7 @@ func (w *Workplace) getApps(c *wkhttp.Context) {
 		}
 		apps, err := w.db.queryAppWithAppIds(appIds)
 		if err != nil {
-			c.ResponseError(errors.New("通过应用ID查询应用错误"))
+			httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 			w.Error("通过应用ID查询应用错误", zap.Error(err))
 			return
 		}
@@ -382,7 +383,7 @@ func (w *Workplace) getApps(c *wkhttp.Context) {
 func (w *Workplace) getBanner(c *wkhttp.Context) {
 	models, err := w.db.queryBanner()
 	if err != nil {
-		c.ResponseError(errors.New("查询横幅数据错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		w.Error("查询横幅数据错误", zap.Error(err))
 		return
 	}

--- a/modules/workplace/api_i18n.go
+++ b/modules/workplace/api_i18n.go
@@ -1,0 +1,62 @@
+package workplace
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// respond helpers for modules/workplace. Most migrated sites call
+// httperr.ResponseErrorL(c, errcode.ErrWorkplaceXxx, nil, nil) directly; the
+// helpers below exist only for the high-frequency shapes that either carry a
+// Detail field (so the SafeDetailKeys contract stays in one place) or resolve a
+// shared err.shared.* code at init.
+//
+// Internal=true codes (ErrWorkplaceQueryFailed / ErrWorkplaceStoreFailed) are
+// intentionally NOT wrapped: each call site keeps its existing
+// w.Error(..., zap.Error(err)) log so ops can debug from logs, and the wire
+// response carries no message.
+
+// respondWorkplaceRequestInvalid covers the common "X 不能为空" / "数据格式有误"
+// (common.ErrData) / BindJSON-failure shape — one code, one optional field
+// detail. An empty field is omitted so the renderer does not surface a noisy
+// empty key to clients.
+func respondWorkplaceRequestInvalid(c *wkhttp.Context, field string) {
+	details := i18n.Details{}
+	if field != "" {
+		details["field"] = field
+	}
+	httperr.ResponseErrorL(c, errcode.ErrWorkplaceRequestInvalid, nil, details)
+}
+
+// errSharedForbidden / errSharedInternal cache the shared codes so the
+// per-handler role guards and panic-recovery paths do not pay a registry lookup
+// on every miss. Looked up at package init; a missing registration panics
+// loudly rather than silently rendering an empty envelope at request time.
+var (
+	errSharedForbidden = mustLookupSharedCode("err.shared.auth.forbidden")
+	errSharedInternal  = mustLookupSharedCode("err.shared.internal")
+)
+
+func mustLookupSharedCode(id string) codes.Code {
+	c, ok := codes.Lookup(id)
+	if !ok {
+		panic("modules/workplace: shared code not registered: " + id)
+	}
+	return c
+}
+
+// respondWorkplaceForbidden renders the shared 403 envelope for the
+// CheckLoginRole / CheckLoginRoleIsSuperAdmin role guards, which previously
+// passed octo-lib's raw role error straight to c.ResponseError.
+func respondWorkplaceForbidden(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errSharedForbidden, nil, nil)
+}
+
+// respondWorkplaceInternal renders the shared 500 envelope for the deferred
+// panic-recovery paths ("服务器内部错误") where no business code applies.
+func respondWorkplaceInternal(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errSharedInternal, nil, nil)
+}

--- a/modules/workplace/api_i18n_test.go
+++ b/modules/workplace/api_i18n_test.go
@@ -1,0 +1,232 @@
+package workplace
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// httperrL is a terse test shim for the no-params/no-details ResponseErrorL
+// call shape exercised by the direct-code cases below.
+func httperrL(c *wkhttp.Context, code codes.Code) {
+	httperr.ResponseErrorL(c, code, nil, nil)
+}
+
+// TestWorkplaceNoLegacyResponseError pins the Phase 2.1 contract that the
+// migrated modules/workplace handlers do not regress to legacy octo-lib error
+// responses. Comments are stripped first so commented-out breadcrumbs do not
+// trip the guard. The m.Error(common.ErrData.Error(), ...) zap LOG calls are not
+// responses and are intentionally allowed (they match neither banned token).
+func TestWorkplaceNoLegacyResponseError(t *testing.T) {
+	files := []string{"api.go", "api_manager.go"}
+	banned := []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(", "c.Response(\""}
+	for _, f := range files {
+		t.Run(f, func(t *testing.T) {
+			data, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+			var clean strings.Builder
+			for _, line := range strings.Split(string(data), "\n") {
+				if idx := strings.Index(line, "//"); idx >= 0 {
+					line = line[:idx]
+				}
+				clean.WriteString(line)
+				clean.WriteByte('\n')
+			}
+			cleaned := clean.String()
+			for _, b := range banned {
+				if strings.Contains(cleaned, b) {
+					t.Fatalf("modules/workplace/%s must use httperr.ResponseErrorL via respondWorkplace* helpers / errcode.ErrWorkplace* instead of legacy %s", f, b)
+				}
+			}
+		})
+	}
+}
+
+// envelope is the partial shape of an httperr.ResponseErrorL response. The
+// renderer emits both the legacy {msg,status} and the v2 {error.{...}} blocks
+// unconditionally (v7.2 dual-envelope contract).
+type envelope struct {
+	Error struct {
+		Code       string         `json:"code"`
+		Message    string         `json:"message"`
+		Details    map[string]any `json:"details"`
+		HTTPStatus int            `json:"http_status"`
+	} `json:"error"`
+	Msg    string `json:"msg"`
+	Status int    `json:"status"`
+}
+
+func decodeEnvelope(t *testing.T, body []byte) envelope {
+	t.Helper()
+	var env envelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("decode envelope: %v\nbody: %s", err, body)
+	}
+	return env
+}
+
+// helperHarness mounts a single GET /probe route that invokes the supplied
+// helper with the i18n renderer wired, so tests can assert the rendered
+// envelope without paying the DB / auth setup cost.
+func helperHarness(probe func(c *wkhttp.Context)) *wkhttp.WKHttp {
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	r.GET("/probe", probe)
+	return r
+}
+
+func TestRespondWorkplaceHelpers(t *testing.T) {
+	cases := []struct {
+		name            string
+		probe           func(c *wkhttp.Context)
+		wantCodeID      string
+		wantSemStatus   int
+		wantTransStatus int    // always 400 for legacy compat (D14)
+		wantContains    string // zh-CN substring expected in error.message
+		wantNotContains string // forbid leaked English DefaultMessage when Internal=true
+		wantDetails     map[string]any
+	}{
+		{
+			name:            "respondWorkplaceRequestInvalid carries the field detail",
+			probe:           func(c *wkhttp.Context) { respondWorkplaceRequestInvalid(c, "app_id") },
+			wantCodeID:      "err.server.workplace.request_invalid",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "请求参数有误",
+			wantDetails:     map[string]any{"field": "app_id"},
+		},
+		{
+			name:            "respondWorkplaceRequestInvalid drops empty field key",
+			probe:           func(c *wkhttp.Context) { respondWorkplaceRequestInvalid(c, "") },
+			wantCodeID:      "err.server.workplace.request_invalid",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "请求参数有误",
+			wantDetails:     map[string]any{},
+		},
+		{
+			name:            "respondWorkplaceForbidden routes to shared.auth.forbidden",
+			probe:           func(c *wkhttp.Context) { respondWorkplaceForbidden(c) },
+			wantCodeID:      "err.shared.auth.forbidden",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "无权执行此操作",
+		},
+		{
+			name:            "respondWorkplaceInternal routes to shared.internal",
+			probe:           func(c *wkhttp.Context) { respondWorkplaceInternal(c) },
+			wantCodeID:      "err.shared.internal",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+		},
+		{
+			name:            "ErrWorkplaceAppNotFound surfaces 404 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrWorkplaceAppNotFound) },
+			wantCodeID:      "err.server.workplace.app_not_found",
+			wantSemStatus:   http.StatusNotFound,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "该应用不存在或不可用",
+		},
+		{
+			name:            "ErrWorkplaceCategoryNotFound surfaces 404 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrWorkplaceCategoryNotFound) },
+			wantCodeID:      "err.server.workplace.category_not_found",
+			wantSemStatus:   http.StatusNotFound,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "该分类不存在",
+		},
+		{
+			name:            "ErrWorkplaceAppNameExists surfaces 409 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrWorkplaceAppNameExists) },
+			wantCodeID:      "err.server.workplace.app_name_exists",
+			wantSemStatus:   http.StatusConflict,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "该应用名称已存在",
+		},
+		{
+			name:            "ErrWorkplaceCategoryNameExists surfaces 409 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrWorkplaceCategoryNameExists) },
+			wantCodeID:      "err.server.workplace.category_name_exists",
+			wantSemStatus:   http.StatusConflict,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "该分类名称已存在",
+		},
+		{
+			name:            "ErrWorkplaceQueryFailed (Internal=true) collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrWorkplaceQueryFailed) },
+			wantCodeID:      "err.server.workplace.query_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "query workplace data",
+		},
+		{
+			name:            "ErrWorkplaceStoreFailed (Internal=true) collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrWorkplaceStoreFailed) },
+			wantCodeID:      "err.server.workplace.store_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "update workplace data",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := helperHarness(tc.probe)
+			req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+			req.Header.Set("Accept-Language", "zh-CN")
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantTransStatus {
+				t.Fatalf("HTTP status = %d, want %d; body=%s", rec.Code, tc.wantTransStatus, rec.Body.String())
+			}
+			env := decodeEnvelope(t, rec.Body.Bytes())
+			if env.Error.Code != tc.wantCodeID {
+				t.Fatalf("error.code = %q, want %q", env.Error.Code, tc.wantCodeID)
+			}
+			if env.Error.HTTPStatus != tc.wantSemStatus {
+				t.Fatalf("error.http_status = %d, want %d", env.Error.HTTPStatus, tc.wantSemStatus)
+			}
+			if env.Status != tc.wantTransStatus {
+				t.Fatalf("legacy status = %d, want %d (D14 transport=400 compat)", env.Status, tc.wantTransStatus)
+			}
+			if env.Msg != env.Error.Message {
+				t.Fatalf("legacy msg %q != error.message %q (dual envelope must agree)", env.Msg, env.Error.Message)
+			}
+			if !strings.Contains(env.Error.Message, tc.wantContains) {
+				t.Fatalf("error.message = %q, want substring %q", env.Error.Message, tc.wantContains)
+			}
+			if tc.wantNotContains != "" && strings.Contains(env.Error.Message, tc.wantNotContains) {
+				t.Fatalf("error.message = %q must not contain %q (Internal leak)", env.Error.Message, tc.wantNotContains)
+			}
+			if tc.wantDetails != nil {
+				got := env.Error.Details
+				if got == nil {
+					got = map[string]any{}
+				}
+				if len(got) != len(tc.wantDetails) {
+					t.Fatalf("error.details = %#v, want %#v", got, tc.wantDetails)
+				}
+				for k, v := range tc.wantDetails {
+					if got[k] != v {
+						t.Fatalf("error.details[%q] = %#v, want %#v", k, got[k], v)
+					}
+				}
+			}
+		})
+	}
+}

--- a/modules/workplace/api_manager.go
+++ b/modules/workplace/api_manager.go
@@ -1,7 +1,6 @@
 package workplace
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"runtime/debug"
@@ -11,6 +10,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/log"
 	"github.com/Mininglamp-OSS/octo-server/pkg/util"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
@@ -62,7 +63,7 @@ func (m *manager) Route(r *wkhttp.WKHttp) {
 func (m *manager) reorderBanner(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondWorkplaceForbidden(c)
 		return
 	}
 	type reqVO struct {
@@ -71,19 +72,19 @@ func (m *manager) reorderBanner(c *wkhttp.Context) {
 	var req reqVO
 	if err := c.BindJSON(&req); err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(common.ErrData)
+		respondWorkplaceRequestInvalid(c, "")
 		return
 	}
 	tx, err := m.ctx.DB().Begin()
 	if err != nil {
 		m.Error("开启事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("开启事务失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	defer func() {
 		if err := recover(); err != nil {
 			tx.Rollback()
-			c.ResponseError(errors.New("服务器内部错误"))
+			respondWorkplaceInternal(c)
 			fmt.Fprintf(os.Stderr, "recovered panic in goroutine: %v\n%s\n", err, debug.Stack())
 		}
 	}()
@@ -93,7 +94,7 @@ func (m *manager) reorderBanner(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			m.Error("修改分类排序错误", zap.Error(err))
-			c.ResponseError(errors.New("修改分类排序错误"))
+			httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 			return
 		}
 		tempSortNum--
@@ -101,7 +102,7 @@ func (m *manager) reorderBanner(c *wkhttp.Context) {
 	err = tx.Commit()
 	if err != nil {
 		m.Error("数据库事物提交失败", zap.Error(err))
-		c.ResponseError(errors.New("数据库事物提交失败"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -111,12 +112,12 @@ func (m *manager) reorderBanner(c *wkhttp.Context) {
 func (m *manager) updateCategory(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondWorkplaceForbidden(c)
 		return
 	}
 	categoryNo := c.Param("category_no")
 	if categoryNo == "" {
-		c.ResponseError(errors.New("分类ID不能为空"))
+		respondWorkplaceRequestInvalid(c, "category_no")
 		return
 	}
 	type reqVO struct {
@@ -125,24 +126,24 @@ func (m *manager) updateCategory(c *wkhttp.Context) {
 	var req reqVO
 	if err := c.BindJSON(&req); err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(common.ErrData)
+		respondWorkplaceRequestInvalid(c, "")
 		return
 	}
 	category, err := m.db.queryCategoryWithNo(categoryNo)
 	if err != nil {
 		m.Error("获取分类错误", zap.Error(err))
-		c.ResponseError(errors.New("获取分类错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		return
 	}
 	if category == nil {
-		c.ResponseError(errors.New("该分类不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceCategoryNotFound, nil, nil)
 		return
 	}
 	category.Name = req.Name
 	err = m.db.updateCategory(category)
 	if err != nil {
 		m.Error("修改分类错误", zap.Error(err))
-		c.ResponseError(errors.New("修改分类错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -152,18 +153,18 @@ func (m *manager) updateCategory(c *wkhttp.Context) {
 func (m *manager) deleteCategory(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondWorkplaceForbidden(c)
 		return
 	}
 	categoryNo := c.Param("category_no")
 	if categoryNo == "" {
-		c.ResponseError(errors.New("分类ID不能为空"))
+		respondWorkplaceRequestInvalid(c, "category_no")
 		return
 	}
 	err = m.db.deleteCategory(categoryNo)
 	if err != nil {
 		m.Error("删除分类错误", zap.Error(err))
-		c.ResponseError(errors.New("删除分类错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -172,7 +173,7 @@ func (m *manager) deleteCategory(c *wkhttp.Context) {
 func (m *manager) getApps(c *wkhttp.Context) {
 	err := c.CheckLoginRole()
 	if err != nil {
-		c.ResponseError(err)
+		respondWorkplaceForbidden(c)
 		return
 	}
 	page := c.Query("page_index")
@@ -186,26 +187,26 @@ func (m *manager) getApps(c *wkhttp.Context) {
 		apps, err = m.db.queryAppWithPage(uint64(pageSize), uint64(pageIndex))
 		if err != nil {
 			m.Error("查询所有应用错误", zap.Error(err))
-			c.ResponseError(errors.New("查询所有应用错误"))
+			httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 			return
 		}
 		count, err = m.db.queryAppCount()
 		if err != nil {
 			m.Error("查询总数量错误", zap.Error(err))
-			c.ResponseError(errors.New("查询总数量错误"))
+			httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 			return
 		}
 	} else {
 		apps, err = m.db.searchApp(keyword, uint64(pageSize), uint64(pageIndex))
 		if err != nil {
 			m.Error("搜索应用错误", zap.Error(err))
-			c.ResponseError(errors.New("搜索应用错误"))
+			httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 			return
 		}
 		count, err = m.db.queryAppCountWithKeyWord(keyword)
 		if err != nil {
 			m.Error("查询总数量错误", zap.Error(err))
-			c.ResponseError(errors.New("查询总数量错误"))
+			httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 			return
 		}
 	}
@@ -236,23 +237,23 @@ func (m *manager) getApps(c *wkhttp.Context) {
 func (m *manager) deleteCategoryApp(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondWorkplaceForbidden(c)
 		return
 	}
 	categoryNo := c.Param("category_no")
 	appId := c.Param("app_id")
 	if categoryNo == "" {
-		c.ResponseError(errors.New("分类编号不能为空"))
+		respondWorkplaceRequestInvalid(c, "category_no")
 		return
 	}
 	if appId == "" {
-		c.ResponseError(errors.New("应用ID不能为空"))
+		respondWorkplaceRequestInvalid(c, "app_id")
 		return
 	}
 	err = m.db.deleteCategoryApp(appId, categoryNo)
 	if err != nil {
 		m.Error("删除分类下app错误", zap.Error(err))
-		c.ResponseError(errors.New("删除分类下app错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -261,7 +262,7 @@ func (m *manager) deleteCategoryApp(c *wkhttp.Context) {
 func (m *manager) addCategoryApp(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondWorkplaceForbidden(c)
 		return
 	}
 	categoryNo := c.Param("category_no")
@@ -271,31 +272,31 @@ func (m *manager) addCategoryApp(c *wkhttp.Context) {
 	var req reqVO
 	if err := c.BindJSON(&req); err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(common.ErrData)
+		respondWorkplaceRequestInvalid(c, "")
 		return
 	}
 	if categoryNo == "" {
-		c.ResponseError(errors.New("分类编号不能为空"))
+		respondWorkplaceRequestInvalid(c, "category_no")
 		return
 	}
 	if len(req.AppIds) == 0 {
-		c.ResponseError(errors.New("应用ID不能为空"))
+		respondWorkplaceRequestInvalid(c, "app_ids")
 		return
 	}
 	appList, err := m.wpDB.queryAppWithAppIds(req.AppIds)
 	if err != nil {
 		m.Error("查询一批应用错误", zap.Error(err))
-		c.ResponseError(errors.New("查询一批应用错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		return
 	}
 	if len(appList) != len(req.AppIds) {
-		c.ResponseError(errors.New("添加的应用不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceAppNotFound, nil, nil)
 		return
 	}
 	apps, err := m.wpDB.queryAppWithCategroyNo(categoryNo)
 	if err != nil {
 		m.Error("查询该分类下应用错误", zap.Error(err))
-		c.ResponseError(errors.New("查询该分类下应用错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		return
 	}
 	saveIds := make([]string, 0)
@@ -320,7 +321,7 @@ func (m *manager) addCategoryApp(c *wkhttp.Context) {
 	maxSortNumApp, err := m.db.queryMaxSortNumCategoryApp(categoryNo)
 	if err != nil {
 		m.Error("查询分类应用最大序号错误", zap.Error(err))
-		c.ResponseError(errors.New("查询分类应用最大序号错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		return
 	}
 	maxNum := 0
@@ -330,13 +331,13 @@ func (m *manager) addCategoryApp(c *wkhttp.Context) {
 	tx, err := m.ctx.DB().Begin()
 	if err != nil {
 		m.Error("开启事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("开启事务失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	defer func() {
 		if err := recover(); err != nil {
 			tx.Rollback()
-			c.ResponseError(errors.New("服务器内部错误"))
+			respondWorkplaceInternal(c)
 			fmt.Fprintf(os.Stderr, "recovered panic in goroutine: %v\n%s\n", err, debug.Stack())
 		}
 	}()
@@ -350,7 +351,7 @@ func (m *manager) addCategoryApp(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			m.Error("添加分类下app错误", zap.Error(err))
-			c.ResponseError(errors.New("添加分类下app错误"))
+			httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 			return
 		}
 		tempSortNum--
@@ -358,7 +359,7 @@ func (m *manager) addCategoryApp(c *wkhttp.Context) {
 	err = tx.Commit()
 	if err != nil {
 		m.Error("数据库事物提交失败", zap.Error(err))
-		c.ResponseError(errors.New("数据库事物提交失败"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -366,7 +367,7 @@ func (m *manager) addCategoryApp(c *wkhttp.Context) {
 func (m *manager) reorderCategoryApp(c *wkhttp.Context) {
 	err := c.CheckLoginRole()
 	if err != nil {
-		c.ResponseError(err)
+		respondWorkplaceForbidden(c)
 		return
 	}
 	categoryNo := c.Param("category_no")
@@ -376,27 +377,27 @@ func (m *manager) reorderCategoryApp(c *wkhttp.Context) {
 	var req reqVO
 	if err := c.BindJSON(&req); err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(common.ErrData)
+		respondWorkplaceRequestInvalid(c, "")
 		return
 	}
 	if categoryNo == "" {
-		c.ResponseError(errors.New("分类编号不能为空"))
+		respondWorkplaceRequestInvalid(c, "category_no")
 		return
 	}
 	if len(req.AppIds) == 0 {
-		c.ResponseError(errors.New("应用ID不能为空"))
+		respondWorkplaceRequestInvalid(c, "app_ids")
 		return
 	}
 	tx, err := m.ctx.DB().Begin()
 	if err != nil {
 		m.Error("开启事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("开启事务失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	defer func() {
 		if err := recover(); err != nil {
 			tx.Rollback()
-			c.ResponseError(errors.New("服务器内部错误"))
+			respondWorkplaceInternal(c)
 			fmt.Fprintf(os.Stderr, "recovered panic in goroutine: %v\n%s\n", err, debug.Stack())
 		}
 	}()
@@ -406,7 +407,7 @@ func (m *manager) reorderCategoryApp(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			m.Error("修改分类下app排序错误", zap.Error(err))
-			c.ResponseError(errors.New("修改分类下app排序错误"))
+			httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 			return
 		}
 		tempSortNum--
@@ -414,7 +415,7 @@ func (m *manager) reorderCategoryApp(c *wkhttp.Context) {
 	err = tx.Commit()
 	if err != nil {
 		m.Error("数据库事物提交失败", zap.Error(err))
-		c.ResponseError(errors.New("数据库事物提交失败"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -423,18 +424,18 @@ func (m *manager) reorderCategoryApp(c *wkhttp.Context) {
 func (m *manager) getCategoryApps(c *wkhttp.Context) {
 	err := c.CheckLoginRole()
 	if err != nil {
-		c.ResponseError(err)
+		respondWorkplaceForbidden(c)
 		return
 	}
 	categoryNo := c.Param("category_no")
 	if categoryNo == "" {
-		c.ResponseError(errors.New("分类编号不能为空"))
+		respondWorkplaceRequestInvalid(c, "category_no")
 		return
 	}
 	apps, err := m.wpDB.queryAppWithCategroyNo(categoryNo)
 	if err != nil {
 		m.Error("获取分类下的app错误", zap.Error(err))
-		c.ResponseError(errors.New("获取分类下的app错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		return
 	}
 
@@ -462,26 +463,26 @@ func (m *manager) getCategoryApps(c *wkhttp.Context) {
 func (m *manager) updateBanner(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondWorkplaceForbidden(c)
 		return
 	}
 	bannerNo := c.Param("banner_no")
 	var req bannerReq
 	if err := c.BindJSON(&req); err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(common.ErrData)
+		respondWorkplaceRequestInvalid(c, "")
 		return
 	}
 	if bannerNo == "" {
-		c.ResponseError(errors.New("横幅编号不能为空"))
+		respondWorkplaceRequestInvalid(c, "banner_no")
 		return
 	}
 	if strings.TrimSpace(req.Route) == "" {
-		c.ResponseError(errors.New("横幅跳转地址不能为空"))
+		respondWorkplaceRequestInvalid(c, "route")
 		return
 	}
 	if strings.TrimSpace(req.Cover) == "" {
-		c.ResponseError(errors.New("横幅封面不能为空"))
+		respondWorkplaceRequestInvalid(c, "cover")
 		return
 	}
 	err = m.db.updateBanner(&bannerModel{
@@ -494,7 +495,7 @@ func (m *manager) updateBanner(c *wkhttp.Context) {
 	})
 	if err != nil {
 		m.Error("修改横幅错误", zap.Error(err))
-		c.ResponseError(errors.New("修改横幅错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -503,13 +504,13 @@ func (m *manager) updateBanner(c *wkhttp.Context) {
 func (m *manager) getBanners(c *wkhttp.Context) {
 	err := c.CheckLoginRole()
 	if err != nil {
-		c.ResponseError(err)
+		respondWorkplaceForbidden(c)
 		return
 	}
 	banners, err := m.wpDB.queryBanner()
 	if err != nil {
 		m.Error("查询横幅错误", zap.Error(err))
-		c.ResponseError(errors.New("查询横幅错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		return
 	}
 	list := make([]*bannerResp, 0)
@@ -533,18 +534,18 @@ func (m *manager) getBanners(c *wkhttp.Context) {
 func (m *manager) deleteBanner(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondWorkplaceForbidden(c)
 		return
 	}
 	bannerNo := c.Param("banner_no")
 	if bannerNo == "" {
-		c.ResponseError(errors.New("横幅编号不能为空"))
+		respondWorkplaceRequestInvalid(c, "banner_no")
 		return
 	}
 	err = m.db.deleteBanner(bannerNo)
 	if err != nil {
 		m.Error("删除横幅错误", zap.Error(err))
-		c.ResponseError(errors.New("删除横幅错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -553,14 +554,14 @@ func (m *manager) deleteBanner(c *wkhttp.Context) {
 func (m *manager) getCategory(c *wkhttp.Context) {
 	err := c.CheckLoginRole()
 	if err != nil {
-		c.ResponseError(err)
+		respondWorkplaceForbidden(c)
 		return
 	}
 	list := make([]*categoryResp, 0)
 	models, err := m.db.queryCategory()
 	if err != nil {
 		m.Error("查询所有分类错误", zap.Error(err))
-		c.ResponseError(errors.New("查询所有分类错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		return
 	}
 	if len(models) > 0 {
@@ -578,21 +579,21 @@ func (m *manager) getCategory(c *wkhttp.Context) {
 func (m *manager) addBanner(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondWorkplaceForbidden(c)
 		return
 	}
 	var req bannerReq
 	if err := c.BindJSON(&req); err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(common.ErrData)
+		respondWorkplaceRequestInvalid(c, "")
 		return
 	}
 	if strings.TrimSpace(req.Route) == "" {
-		c.ResponseError(errors.New("横幅跳转地址不能为空"))
+		respondWorkplaceRequestInvalid(c, "route")
 		return
 	}
 	if strings.TrimSpace(req.Cover) == "" {
-		c.ResponseError(errors.New("横幅封面不能为空"))
+		respondWorkplaceRequestInvalid(c, "cover")
 		return
 	}
 	err = m.db.insertBanner(&bannerModel{
@@ -605,7 +606,7 @@ func (m *manager) addBanner(c *wkhttp.Context) {
 	})
 	if err != nil {
 		m.Error("新增横幅信息错误", zap.Error(err))
-		c.ResponseError(errors.New("新增横幅信息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -613,32 +614,32 @@ func (m *manager) addBanner(c *wkhttp.Context) {
 func (m *manager) updateApp(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondWorkplaceForbidden(c)
 		return
 	}
 	appId := c.Param("app_id")
 	var req updateAppReq
 	if err := c.BindJSON(&req); err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(common.ErrData)
+		respondWorkplaceRequestInvalid(c, "")
 		return
 	}
-	if err := req.checkAddAPP(); err != nil {
-		c.ResponseError(err)
+	if field := req.checkAddAPP(); field != "" {
+		respondWorkplaceRequestInvalid(c, field)
 		return
 	}
 	if strings.TrimSpace(appId) == "" {
-		c.ResponseError(errors.New("修改的应用ID不能为空"))
+		respondWorkplaceRequestInvalid(c, "app_id")
 		return
 	}
 	app, err := m.wpDB.queryAppWithAppId(appId)
 	if err != nil {
 		m.Error("查询应用信息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询应用信息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		return
 	}
 	if app == nil {
-		c.ResponseError(errors.New("该应用不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceAppNotFound, nil, nil)
 		return
 	}
 	app.AppCategory = req.AppCategory
@@ -653,7 +654,7 @@ func (m *manager) updateApp(c *wkhttp.Context) {
 	err = m.db.updateApp(app)
 	if err != nil {
 		m.Error("修改应用信息错误", zap.Error(err))
-		c.ResponseError(errors.New("修改应用信息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -662,18 +663,18 @@ func (m *manager) updateApp(c *wkhttp.Context) {
 func (m *manager) deleteApp(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondWorkplaceForbidden(c)
 		return
 	}
 	appId := c.Param("app_id")
 	if appId == "" {
-		c.ResponseError(errors.New("分类ID和应用ID均不能为空"))
+		respondWorkplaceRequestInvalid(c, "app_id")
 		return
 	}
 	app, err := m.wpDB.queryAppWithAppId(appId)
 	if err != nil {
 		m.Error("查询app信息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询app信息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		return
 	}
 	if app == nil {
@@ -683,13 +684,13 @@ func (m *manager) deleteApp(c *wkhttp.Context) {
 	tx, err := m.ctx.DB().Begin()
 	if err != nil {
 		m.Error("开启事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("开启事务失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	defer func() {
 		if err := recover(); err != nil {
 			tx.Rollback()
-			c.ResponseError(errors.New("服务器内部错误"))
+			respondWorkplaceInternal(c)
 			fmt.Fprintf(os.Stderr, "recovered panic in goroutine: %v\n%s\n", err, debug.Stack())
 		}
 	}()
@@ -697,33 +698,33 @@ func (m *manager) deleteApp(c *wkhttp.Context) {
 	if err != nil {
 		tx.Rollback()
 		m.Error("删除应用错误", zap.Error(err))
-		c.ResponseError(errors.New("删除应用错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	err = m.db.deleteCategoryAppTx(appId, tx)
 	if err != nil {
 		tx.Rollback()
 		m.Error("删除分类下应用错误", zap.Error(err))
-		c.ResponseError(errors.New("删除分类下应用错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	err = m.db.deleteUserAppTx(appId, tx)
 	if err != nil {
 		tx.Rollback()
 		m.Error("删除用户app错误", zap.Error(err))
-		c.ResponseError(errors.New("删除用户app错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	err = m.db.deleteUserRecordAppTx(appId, tx)
 	if err != nil {
 		tx.Rollback()
 		m.Error("删除用户app使用记录错误", zap.Error(err))
-		c.ResponseError(errors.New("删除用户app使用记录错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	if err = tx.Commit(); err != nil {
 		m.Error("数据库事物提交失败", zap.Error(err))
-		c.ResponseError(errors.New("数据库事物提交失败"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -732,7 +733,7 @@ func (m *manager) deleteApp(c *wkhttp.Context) {
 func (m *manager) reorderCategory(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondWorkplaceForbidden(c)
 		return
 	}
 	type reqVO struct {
@@ -741,19 +742,19 @@ func (m *manager) reorderCategory(c *wkhttp.Context) {
 	var req reqVO
 	if err := c.BindJSON(&req); err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(common.ErrData)
+		respondWorkplaceRequestInvalid(c, "")
 		return
 	}
 	tx, err := m.ctx.DB().Begin()
 	if err != nil {
 		m.Error("开启事务失败！", zap.Error(err))
-		c.ResponseError(errors.New("开启事务失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	defer func() {
 		if err := recover(); err != nil {
 			tx.Rollback()
-			c.ResponseError(errors.New("服务器内部错误"))
+			respondWorkplaceInternal(c)
 			fmt.Fprintf(os.Stderr, "recovered panic in goroutine: %v\n%s\n", err, debug.Stack())
 		}
 	}()
@@ -763,7 +764,7 @@ func (m *manager) reorderCategory(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			m.Error("修改分类排序错误", zap.Error(err))
-			c.ResponseError(errors.New("修改分类排序错误"))
+			httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 			return
 		}
 		tempSortNum--
@@ -771,7 +772,7 @@ func (m *manager) reorderCategory(c *wkhttp.Context) {
 	err = tx.Commit()
 	if err != nil {
 		m.Error("数据库事物提交失败", zap.Error(err))
-		c.ResponseError(errors.New("数据库事物提交失败"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -780,27 +781,27 @@ func (m *manager) reorderCategory(c *wkhttp.Context) {
 func (m *manager) addApp(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondWorkplaceForbidden(c)
 		return
 	}
 	var req appReq
 	if err := c.BindJSON(&req); err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(common.ErrData)
+		respondWorkplaceRequestInvalid(c, "")
 		return
 	}
-	if err := req.checkAddAPP(); err != nil {
-		c.ResponseError(err)
+	if field := req.checkAddAPP(); field != "" {
+		respondWorkplaceRequestInvalid(c, field)
 		return
 	}
 	app, err := m.db.queryAppWithAppNameAndCategoryNo(req.Name)
 	if err != nil {
 		m.Error("查询此分类下app是否存在此名称错误", zap.Error(err))
-		c.ResponseError(errors.New("查询此分类下app是否存在此名称错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		return
 	}
 	if app != nil && len(app.AppID) > 0 {
-		c.ResponseError(errors.New("此应用名已存在"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceAppNameExists, nil, nil)
 		return
 	}
 
@@ -818,7 +819,7 @@ func (m *manager) addApp(c *wkhttp.Context) {
 	})
 	if err != nil {
 		m.Error("新增应用错误", zap.Error(err))
-		c.ResponseError(errors.New("新增应用错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -827,7 +828,7 @@ func (m *manager) addApp(c *wkhttp.Context) {
 func (m *manager) addCategory(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondWorkplaceForbidden(c)
 		return
 	}
 	type reqVO struct {
@@ -836,23 +837,23 @@ func (m *manager) addCategory(c *wkhttp.Context) {
 	var req reqVO
 	if err := c.BindJSON(&req); err != nil {
 		m.Error(common.ErrData.Error(), zap.Error(err))
-		c.ResponseError(common.ErrData)
+		respondWorkplaceRequestInvalid(c, "")
 		return
 	}
 	category, err := m.db.queryCateogryWithName(req.Name)
 	if err != nil {
 		m.Error("通过分类名查询分类错误", zap.Error(err))
-		c.ResponseError(errors.New("通过分类名查询分类错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		return
 	}
 	if category != nil && len(category.CategoryNo) > 0 {
-		c.ResponseError(errors.New("该分类名称已存在"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceCategoryNameExists, nil, nil)
 		return
 	}
 	maxSortNumCategory, err := m.db.queryMaxSortNumCategory()
 	if err != nil {
 		m.Error("查询最大序号分类错误", zap.Error(err))
-		c.ResponseError(errors.New("查询最大序号分类错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceQueryFailed, nil, nil)
 		return
 	}
 	var sortNum = 1
@@ -866,23 +867,26 @@ func (m *manager) addCategory(c *wkhttp.Context) {
 	})
 	if err != nil {
 		m.Error("新增分类错误", zap.Error(err))
-		c.ResponseError(errors.New("新增分类错误"))
+		httperr.ResponseErrorL(c, errcode.ErrWorkplaceStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
 }
 
-func (req *appReq) checkAddAPP() error {
+// checkAddAPP validates the app create/update payload and returns the offending
+// JSON field name (empty when valid) so the handler can surface it via the
+// err.server.workplace.request_invalid Details contract instead of a raw string.
+func (req *appReq) checkAddAPP() string {
 	if strings.TrimSpace(req.Name) == "" {
-		return errors.New("应用名称不能为空")
+		return "name"
 	}
 	if strings.TrimSpace(req.AppRoute) == "" {
-		return errors.New("应用打开地址不能为空")
+		return "app_route"
 	}
 	if strings.TrimSpace(req.Icon) == "" {
-		return errors.New("应用logo不能为空")
+		return "icon"
 	}
-	return nil
+	return ""
 }
 
 type updateAppReq struct {

--- a/pkg/errcode/workplace.go
+++ b/pkg/errcode/workplace.go
@@ -1,0 +1,74 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// err.server.workplace.* — modules/workplace business error codes (api.go /
+// api_manager.go). DefaultMessage holds the en-US source (D4); the zh-CN runtime
+// translation lives in pkg/i18n/locales/active.zh-CN.toml. Internal=true codes
+// never surface their message on the wire — callers MUST log the underlying err
+// with full context via the module logger before responding.
+var (
+	// ---- validation (400) ----------------------------------------------------
+
+	// ErrWorkplaceRequestInvalid is the catch-all for missing/malformed request
+	// input (empty app_id / category_no / banner_no path params, empty required
+	// body fields, BindJSON failure, common.ErrData). The offending field is
+	// surfaced via Details when the caller can identify it.
+	ErrWorkplaceRequestInvalid = register(codes.Code{
+		ID:             "err.server.workplace.request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid request.",
+		SafeDetailKeys: []string{"field"},
+	})
+
+	// ---- not found (404) -----------------------------------------------------
+
+	// ErrWorkplaceAppNotFound covers an app that does not exist, has been
+	// deleted, or is disabled (add/update/record paths).
+	ErrWorkplaceAppNotFound = register(codes.Code{
+		ID:             "err.server.workplace.app_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "The app does not exist or is unavailable.",
+	})
+	ErrWorkplaceCategoryNotFound = register(codes.Code{
+		ID:             "err.server.workplace.category_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "The category does not exist.",
+	})
+
+	// ---- conflict (409) ------------------------------------------------------
+
+	ErrWorkplaceAppNameExists = register(codes.Code{
+		ID:             "err.server.workplace.app_name_exists",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "An app with this name already exists.",
+	})
+	ErrWorkplaceCategoryNameExists = register(codes.Code{
+		ID:             "err.server.workplace.category_name_exists",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "A category with this name already exists.",
+	})
+
+	// ---- internal (500, Internal=true) ---------------------------------------
+
+	// ErrWorkplaceQueryFailed covers read-path failures (DB SELECT/search/count).
+	// Log the underlying err before responding.
+	ErrWorkplaceQueryFailed = register(codes.Code{
+		ID:             "err.server.workplace.query_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to query workplace data.",
+		Internal:       true,
+	})
+	// ErrWorkplaceStoreFailed covers mutation-path failures (DB write, transaction
+	// begin/commit/rollback). Log the underlying err before responding.
+	ErrWorkplaceStoreFailed = register(codes.Code{
+		ID:             "err.server.workplace.store_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to update workplace data.",
+		Internal:       true,
+	})
+)

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -544,3 +544,24 @@ other = "发送消息指令失败。"
 
 ["err.server.message.search_failed"]
 other = "消息搜索失败。"
+
+["err.server.workplace.request_invalid"]
+other = "请求参数有误。"
+
+["err.server.workplace.app_not_found"]
+other = "该应用不存在或不可用。"
+
+["err.server.workplace.category_not_found"]
+other = "该分类不存在。"
+
+["err.server.workplace.app_name_exists"]
+other = "该应用名称已存在。"
+
+["err.server.workplace.category_name_exists"]
+other = "该分类名称已存在。"
+
+["err.server.workplace.query_failed"]
+other = "查询工作台数据失败。"
+
+["err.server.workplace.store_failed"]
+other = "保存工作台数据失败。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -497,3 +497,24 @@ other = "Failed to fetch WeChat user profile."
 
 ["err.server.user.wechat_response_invalid"]
 other = "WeChat response is malformed."
+
+["err.server.workplace.app_name_exists"]
+other = "An app with this name already exists."
+
+["err.server.workplace.app_not_found"]
+other = "The app does not exist or is unavailable."
+
+["err.server.workplace.category_name_exists"]
+other = "A category with this name already exists."
+
+["err.server.workplace.category_not_found"]
+other = "The category does not exist."
+
+["err.server.workplace.query_failed"]
+other = "Failed to query workplace data."
+
+["err.server.workplace.request_invalid"]
+other = "Invalid request."
+
+["err.server.workplace.store_failed"]
+other = "Failed to update workplace data."


### PR DESCRIPTION
## Summary

Phase 2.1 i18n migration of `modules/workplace` (131 legacy error sites),
following the established thread/user/group/message playbook. Pure SDK reuse —
no email / gRPC dependencies, no Phase 1 blockers.

## Changes

- **Register 7 `err.server.workplace.*` codes** (`pkg/errcode/workplace.go`) with
  en-US source + zh-CN runtime translations, and regenerate the extract marker:
  `request_invalid` (400, `field` detail) / `app_not_found` (404) /
  `category_not_found` (404) / `app_name_exists` (409) /
  `category_name_exists` (409) / `query_failed` (500, Internal) /
  `store_failed` (500, Internal). The two Internal codes never surface their
  message on the wire.
- **Add respond helpers** (`api_i18n.go`): `respondWorkplaceRequestInvalid`
  (field detail), `respondWorkplaceForbidden` (shared `auth.forbidden` for the
  `CheckLoginRole*` role guards) and `respondWorkplaceInternal` (shared
  `internal` for panic-recovery paths).
- **Migrate all 131 sites** in `api.go` (31) and `api_manager.go` (100) to
  `httperr.ResponseErrorL`. Role guards → shared 403, business errors map to
  semantic 404/409, DB read/write failures to Internal 500 (message masked),
  validation to 400 with a `field` detail. `appReq.checkAddAPP` now returns the
  offending JSON field name instead of a raw Chinese error string. Existing
  `zap.Error` logs preserved for Internal paths. Drop the now-unused `errors`
  import.
- **Tests** (`api_i18n_test.go`): `TestWorkplaceNoLegacyResponseError`
  source-guards both handler files against legacy response APIs;
  `TestRespondWorkplaceHelpers` asserts the rendered dual envelope (code /
  semantic status / D14 wire-400 / zh-CN copy / details) for every helper and
  code, including Internal-leak checks on `query_failed` / `store_failed`.

## Behavior change

Per the established migration (same as thread/user/group), HTTP wire status stays
fixed at 400 (D14) while `error.http_status` carries the real semantic status
(403/404/409/500). Clients should branch on `error.code` / `error.http_status`,
not the wire status.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `make i18n-extract-check`
- [x] `make i18n-lint` (D23 direct-error-response + unregistered-code)
- [x] `go test ./modules/workplace ./pkg/errcode ./pkg/i18n/...` (incl. DB integration)