### PR TITLE
feat(i18n): migrate modules/category to ResponseErrorL

### DIFF
--- a/modules/category/api.go
+++ b/modules/category/api.go
@@ -10,6 +10,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
 	spacemod "github.com/Mininglamp-OSS/octo-server/modules/space"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"github.com/gocraft/dbr/v2"
@@ -58,36 +60,36 @@ func (c *Category) create(ctx *wkhttp.Context) {
 	isMember, err := spacepkg.CheckMembership(c.db.session, spaceID, loginUID)
 	if err != nil {
 		c.Error("检查空间成员失败", zap.Error(err))
-		ctx.ResponseError(errors.New("检查空间成员失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryQueryFailed, nil, nil)
 		return
 	}
 	if !isMember {
-		ctx.ResponseError(errors.New("你不是该空间成员"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategorySpaceMemberRequired, nil, nil)
 		return
 	}
 
 	var req createCategoryReq
 	if err := ctx.BindJSON(&req); err != nil {
-		ctx.ResponseError(errors.New("请求参数错误"))
+		respondCategoryRequestInvalid(ctx, "")
 		return
 	}
 	if req.Name == "" {
-		ctx.ResponseError(errors.New("类别名称不能为空"))
+		respondCategoryRequestInvalid(ctx, "name")
 		return
 	}
 	if len([]rune(req.Name)) > 100 {
-		ctx.ResponseError(errors.New("类别名称不能超过100个字符"))
+		respondCategoryNameTooLong(ctx, 100)
 		return
 	}
 
 	count, err := c.db.countCategoriesByUIDAndSpaceID(loginUID, spaceID)
 	if err != nil {
 		c.Error("查询类别数量失败", zap.Error(err))
-		ctx.ResponseError(errors.New("查询类别数量失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryQueryFailed, nil, nil)
 		return
 	}
 	if count >= 20 {
-		ctx.ResponseError(errors.New("每个空间最多创建20个分类"))
+		respondCategoryLimitExceeded(ctx, 20)
 		return
 	}
 
@@ -95,7 +97,7 @@ func (c *Category) create(ctx *wkhttp.Context) {
 	nextSort, err := c.db.maxSortByUIDAndSpaceID(loginUID, spaceID)
 	if err != nil {
 		c.Error("查询排序值失败", zap.Error(err))
-		ctx.ResponseError(errors.New("创建类别失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryQueryFailed, nil, nil)
 		return
 	}
 	nextSort++
@@ -109,7 +111,7 @@ func (c *Category) create(ctx *wkhttp.Context) {
 	})
 	if err != nil {
 		c.Error("创建类别失败", zap.Error(err))
-		ctx.ResponseError(errors.New("创建类别失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 		return
 	}
 
@@ -130,11 +132,11 @@ func (c *Category) list(ctx *wkhttp.Context) {
 	isMember, err := spacepkg.CheckMembership(c.db.session, spaceID, loginUID)
 	if err != nil {
 		c.Error("检查空间成员失败", zap.Error(err))
-		ctx.ResponseError(errors.New("检查空间成员失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryQueryFailed, nil, nil)
 		return
 	}
 	if !isMember {
-		ctx.ResponseError(errors.New("你不是该空间成员"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategorySpaceMemberRequired, nil, nil)
 		return
 	}
 
@@ -148,14 +150,14 @@ func (c *Category) list(ctx *wkhttp.Context) {
 	categories, err := c.db.queryCategoriesByUIDAndSpaceID(loginUID, spaceID)
 	if err != nil {
 		c.Error("查询类别失败", zap.Error(err))
-		ctx.ResponseError(errors.New("查询类别失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryQueryFailed, nil, nil)
 		return
 	}
 
 	groups, err := c.db.queryUserGroupsInSpace(loginUID, spaceID)
 	if err != nil {
 		c.Error("查询群组失败", zap.Error(err))
-		ctx.ResponseError(errors.New("查询群组失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryQueryFailed, nil, nil)
 		return
 	}
 
@@ -180,14 +182,14 @@ func (c *Category) list(ctx *wkhttp.Context) {
 		defaultCat, err := c.db.queryDefaultCategory(loginUID, spaceID)
 		if err != nil {
 			c.Error("查询默认类别失败", zap.Error(err))
-			ctx.ResponseError(errors.New("查询类别失败"))
+			httperr.ResponseErrorL(ctx, errcode.ErrCategoryQueryFailed, nil, nil)
 			return
 		}
 		if defaultCat == nil {
 			maxSort, err := c.db.maxSortByUIDAndSpaceID(loginUID, spaceID)
 			if err != nil {
 				c.Error("查询排序值失败", zap.Error(err))
-				ctx.ResponseError(errors.New("查询类别失败"))
+				httperr.ResponseErrorL(ctx, errcode.ErrCategoryQueryFailed, nil, nil)
 				return
 			}
 			newDefault := &CategoryModel{
@@ -200,14 +202,14 @@ func (c *Category) list(ctx *wkhttp.Context) {
 			}
 			if err = c.db.insertDefaultCategory(newDefault); err != nil {
 				c.Error("创建默认类别失败", zap.Error(err))
-				ctx.ResponseError(errors.New("创建默认类别失败"))
+				httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 				return
 			}
 			// INSERT IGNORE 后重查，确保拿到实际行（防并发竞态）
 			categories, err = c.db.queryCategoriesByUIDAndSpaceID(loginUID, spaceID)
 			if err != nil {
 				c.Error("查询类别失败", zap.Error(err))
-				ctx.ResponseError(errors.New("查询类别失败"))
+				httperr.ResponseErrorL(ctx, errcode.ErrCategoryQueryFailed, nil, nil)
 				return
 			}
 		}
@@ -266,40 +268,40 @@ func (c *Category) update(ctx *wkhttp.Context) {
 	cat, err := c.db.queryCategoryByID(categoryID)
 	if err != nil {
 		c.Error("查询类别失败", zap.Error(err))
-		ctx.ResponseError(errors.New("查询类别失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryQueryFailed, nil, nil)
 		return
 	}
 	if cat == nil {
-		ctx.ResponseError(errors.New("分类不存在"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryNotFound, nil, nil)
 		return
 	}
 	if cat.UID != loginUID {
-		ctx.ResponseError(errors.New("无权限修改此分类"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryPermissionDenied, nil, nil)
 		return
 	}
 	if cat.isDefault() {
-		ctx.ResponseError(errors.New("默认分类不可修改"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryDefaultImmutable, nil, nil)
 		return
 	}
 
 	var req updateCategoryReq
 	if err := ctx.BindJSON(&req); err != nil {
-		ctx.ResponseError(errors.New("请求参数错误"))
+		respondCategoryRequestInvalid(ctx, "")
 		return
 	}
 	if req.Name == "" {
-		ctx.ResponseError(errors.New("类别名称不能为空"))
+		respondCategoryRequestInvalid(ctx, "name")
 		return
 	}
 	if len([]rune(req.Name)) > 100 {
-		ctx.ResponseError(errors.New("类别名称不能超过100个字符"))
+		respondCategoryNameTooLong(ctx, 100)
 		return
 	}
 
 	err = c.db.updateCategoryName(categoryID, req.Name)
 	if err != nil {
 		c.Error("更新类别失败", zap.Error(err))
-		ctx.ResponseError(errors.New("更新类别失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 		return
 	}
 
@@ -314,26 +316,26 @@ func (c *Category) delete(ctx *wkhttp.Context) {
 	cat, err := c.db.queryCategoryByID(categoryID)
 	if err != nil {
 		c.Error("查询类别失败", zap.Error(err))
-		ctx.ResponseError(errors.New("查询类别失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryQueryFailed, nil, nil)
 		return
 	}
 	if cat == nil {
-		ctx.ResponseError(errors.New("分类不存在"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryNotFound, nil, nil)
 		return
 	}
 	if cat.UID != loginUID {
-		ctx.ResponseError(errors.New("无权限删除此分类"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryPermissionDenied, nil, nil)
 		return
 	}
 	if cat.isDefault() {
-		ctx.ResponseError(errors.New("默认分类不可删除"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryDefaultUndeletable, nil, nil)
 		return
 	}
 
 	tx, err := c.ctx.DB().Begin()
 	if err != nil {
 		c.Error("开启事务失败", zap.Error(err))
-		ctx.ResponseError(errors.New("删除类别失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 		return
 	}
 	defer tx.RollbackUnlessCommitted()
@@ -346,7 +348,7 @@ func (c *Category) delete(ctx *wkhttp.Context) {
 		Where("category_id=? AND uid=?", categoryID, loginUID).
 		Exec(); err != nil {
 		c.Error("删除类别失败", zap.Error(err))
-		ctx.ResponseError(errors.New("删除类别失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 		return
 	}
 
@@ -361,7 +363,7 @@ func (c *Category) delete(ctx *wkhttp.Context) {
 		categoryID, loginUID,
 	).Load(&groupNos); err != nil {
 		c.Error("查询分组下群列表失败", zap.Error(err))
-		ctx.ResponseError(errors.New("删除类别失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 		return
 	}
 
@@ -376,7 +378,7 @@ func (c *Category) delete(ctx *wkhttp.Context) {
 		Where("category_id=? and uid=?", categoryID, loginUID).
 		Exec(); err != nil {
 		c.Error("清理群设置失败", zap.Error(err))
-		ctx.ResponseError(errors.New("删除类别失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 		return
 	}
 
@@ -384,7 +386,7 @@ func (c *Category) delete(ctx *wkhttp.Context) {
 	// 与 UpdateSort 同序拿 (version → ext) 锁（PR #21 Round-3 blocker #2）。
 	if _, err := convext.BumpFollowVersionTx(tx, loginUID, cat.SpaceID); err != nil {
 		c.Error("更新 follow_version 失败", zap.Error(err))
-		ctx.ResponseError(errors.New("删除类别失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 		return
 	}
 
@@ -393,18 +395,18 @@ func (c *Category) delete(ctx *wkhttp.Context) {
 	//    - DM：DELETE dm_category_id=cat 的 ext 行
 	if err := convext.UnfollowGroupsTx(tx, loginUID, cat.SpaceID, groupNos); err != nil {
 		c.Error("取消关注分组下群失败", zap.Error(err))
-		ctx.ResponseError(errors.New("删除类别失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 		return
 	}
 	if err := convext.UnfollowDMsByCategoryTx(tx, loginUID, cat.SpaceID, categoryID); err != nil {
 		c.Error("取消关注分组下私聊失败", zap.Error(err))
-		ctx.ResponseError(errors.New("删除类别失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 		return
 	}
 
 	if err = tx.Commit(); err != nil {
 		c.Error("提交事务失败", zap.Error(err))
-		ctx.ResponseError(errors.New("删除类别失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 		return
 	}
 
@@ -419,33 +421,33 @@ func (c *Category) sort(ctx *wkhttp.Context) {
 	isMember, err := spacepkg.CheckMembership(c.db.session, spaceID, loginUID)
 	if err != nil {
 		c.Error("检查空间成员失败", zap.Error(err))
-		ctx.ResponseError(errors.New("检查空间成员失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryQueryFailed, nil, nil)
 		return
 	}
 	if !isMember {
-		ctx.ResponseError(errors.New("你不是该空间成员"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategorySpaceMemberRequired, nil, nil)
 		return
 	}
 
 	var req sortCategoriesReq
 	if err := ctx.BindJSON(&req); err != nil {
-		ctx.ResponseError(errors.New("请求参数错误"))
+		respondCategoryRequestInvalid(ctx, "")
 		return
 	}
 	if len(req.CategoryIDs) == 0 {
-		ctx.ResponseError(errors.New("分类列表不能为空"))
+		respondCategoryRequestInvalid(ctx, "category_ids")
 		return
 	}
 
 	categories, err := c.db.queryCategoriesByUIDAndSpaceID(loginUID, spaceID)
 	if err != nil {
 		c.Error("查询类别失败", zap.Error(err))
-		ctx.ResponseError(errors.New("查询类别失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryQueryFailed, nil, nil)
 		return
 	}
 
 	if len(req.CategoryIDs) != len(categories) {
-		ctx.ResponseError(errors.New("分类列表数量不匹配"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategorySortListMismatch, nil, nil)
 		return
 	}
 
@@ -456,12 +458,12 @@ func (c *Category) sort(ctx *wkhttp.Context) {
 	seen := make(map[string]bool, len(req.CategoryIDs))
 	for _, id := range req.CategoryIDs {
 		if seen[id] {
-			ctx.ResponseError(errors.New("分类列表存在重复"))
+			httperr.ResponseErrorL(ctx, errcode.ErrCategorySortListDuplicate, nil, nil)
 			return
 		}
 		seen[id] = true
 		if !catMap[id] {
-			ctx.ResponseError(errors.New("分类不存在或无权限"))
+			httperr.ResponseErrorL(ctx, errcode.ErrCategoryNotFound, nil, nil)
 			return
 		}
 	}
@@ -469,7 +471,7 @@ func (c *Category) sort(ctx *wkhttp.Context) {
 	tx, err := c.ctx.DB().Begin()
 	if err != nil {
 		c.Error("开启事务失败", zap.Error(err))
-		ctx.ResponseError(errors.New("更新排序失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 		return
 	}
 	defer tx.RollbackUnlessCommitted()
@@ -481,7 +483,7 @@ func (c *Category) sort(ctx *wkhttp.Context) {
 			Exec()
 		if err != nil {
 			c.Error("更新排序失败", zap.Error(err), zap.String("categoryID", catID))
-			ctx.ResponseError(errors.New("更新排序失败"))
+			httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 			return
 		}
 	}
@@ -490,13 +492,13 @@ func (c *Category) sort(ctx *wkhttp.Context) {
 	// （sortFollowItems 首主键就是 CategorySort），客户端必须重建 follow 列表。
 	if _, err := convext.BumpFollowVersionTx(tx, loginUID, spaceID); err != nil {
 		c.Error("更新 follow_version 失败", zap.Error(err))
-		ctx.ResponseError(errors.New("更新排序失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 		return
 	}
 
 	if err = tx.Commit(); err != nil {
 		c.Error("提交事务失败", zap.Error(err))
-		ctx.ResponseError(errors.New("更新排序失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 		return
 	}
 
@@ -510,7 +512,7 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 
 	var req moveGroupToCategoryReq
 	if err := ctx.BindJSON(&req); err != nil {
-		ctx.ResponseError(errors.New("请求参数错误"))
+		respondCategoryRequestInvalid(ctx, "")
 		return
 	}
 
@@ -532,11 +534,11 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 		LoadOne(&member)
 	if err != nil {
 		if errors.Is(err, dbr.ErrNotFound) {
-			ctx.ResponseError(errors.New("你不是该群成员"))
+			httperr.ResponseErrorL(ctx, errcode.ErrCategoryGroupMemberRequired, nil, nil)
 			return
 		}
 		c.Error("查询群成员失败", zap.Error(err))
-		ctx.ResponseError(errors.New("查询群成员失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryQueryFailed, nil, nil)
 		return
 	}
 
@@ -547,11 +549,11 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 		Load(&groupSpaceID)
 	if err != nil {
 		c.Error("查询群信息失败", zap.Error(err))
-		ctx.ResponseError(errors.New("查询群信息失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryQueryFailed, nil, nil)
 		return
 	}
 	if groupSpaceID == "" {
-		ctx.ResponseError(errors.New("该群组不属于任何空间"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryGroupSpaceMissing, nil, nil)
 		return
 	}
 
@@ -578,7 +580,7 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 		} else if defaultSpaceID, derr := spacemod.GetUserDefaultSpaceIDE(c.ctx, loginUID); derr != nil {
 			// fail-closed：DB 查询失败时不要静默落到群 Space（会复现 #191），直接报错。
 			c.Error("查询用户默认空间失败", zap.Error(derr))
-			ctx.ResponseError(errors.New("查询用户默认空间失败"))
+			httperr.ResponseErrorL(ctx, errcode.ErrCategoryQueryFailed, nil, nil)
 			return
 		} else if defaultSpaceID != "" {
 			effectiveSpaceID = defaultSpaceID
@@ -591,7 +593,7 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 	setting, err := c.db.queryGroupSettingForCategory(groupNo, loginUID)
 	if err != nil {
 		c.Error("查询群设置失败", zap.Error(err))
-		ctx.ResponseError(errors.New("查询群设置失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryQueryFailed, nil, nil)
 		return
 	}
 
@@ -601,7 +603,7 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 	tx, err := c.ctx.DB().Begin()
 	if err != nil {
 		c.Error("开启事务失败", zap.Error(err))
-		ctx.ResponseError(errors.New("更新群设置失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 		return
 	}
 	defer tx.RollbackUnlessCommitted()
@@ -630,25 +632,25 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 		).LoadOne(&locked)
 		if err != nil {
 			if errors.Is(err, dbr.ErrNotFound) {
-				ctx.ResponseError(errors.New("分类不存在"))
+				httperr.ResponseErrorL(ctx, errcode.ErrCategoryNotFound, nil, nil)
 				return
 			}
 			c.Error("查询类别失败", zap.Error(err))
-			ctx.ResponseError(errors.New("查询类别失败"))
+			httperr.ResponseErrorL(ctx, errcode.ErrCategoryQueryFailed, nil, nil)
 			return
 		}
 		if locked.Status != 1 {
 			// status=2（已删除）等价于"分类不存在"——与旧路径
 			// queryCategoryByID(status=1 过滤) 后 nil 检查保持文案一致。
-			ctx.ResponseError(errors.New("分类不存在"))
+			httperr.ResponseErrorL(ctx, errcode.ErrCategoryNotFound, nil, nil)
 			return
 		}
 		if locked.UID != loginUID {
-			ctx.ResponseError(errors.New("无权限使用此分类"))
+			httperr.ResponseErrorL(ctx, errcode.ErrCategoryPermissionDenied, nil, nil)
 			return
 		}
 		if effectiveSpaceID != locked.SpaceID {
-			ctx.ResponseError(errors.New("群组和分类不在同一空间"))
+			httperr.ResponseErrorL(ctx, errcode.ErrCategorySpaceMismatch, nil, nil)
 			return
 		}
 		categoryIDPtr = &req.CategoryID
@@ -658,7 +660,7 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 		version, err := c.ctx.GenSeq(common.GroupSettingSeqKey)
 		if err != nil {
 			c.Error("生成版本号失败", zap.Error(err))
-			ctx.ResponseError(errors.New("生成版本号失败"))
+			httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 			return
 		}
 		if _, err := tx.InsertBySql(
@@ -666,7 +668,7 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 			groupNo, loginUID, categoryIDPtr, 0, version,
 		).Exec(); err != nil {
 			c.Error("创建群设置失败", zap.Error(err))
-			ctx.ResponseError(errors.New("创建群设置失败"))
+			httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 			return
 		}
 	} else {
@@ -675,7 +677,7 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 			Set("category_sort", 0).
 			Where("id=?", setting.Id).Exec(); err != nil {
 			c.Error("更新群设置失败", zap.Error(err))
-			ctx.ResponseError(errors.New("更新群设置失败"))
+			httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 			return
 		}
 	}
@@ -688,7 +690,7 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 	// version (issue #151 review #4 by an9xyz).
 	if _, err := convext.BumpFollowVersionTx(tx, loginUID, effectiveSpaceID); err != nil {
 		c.Error("更新 follow_version 失败", zap.Error(err))
-		ctx.ResponseError(errors.New("更新群设置失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 		return
 	}
 
@@ -712,20 +714,20 @@ func (c *Category) moveGroupToCategory(ctx *wkhttp.Context) {
 	if categoryIDPtr == nil {
 		if err := convext.ClearAutoFollowThreadsTx(tx, loginUID, effectiveSpaceID, []string{groupNo}); err != nil {
 			c.Error("清理 auto_follow_threads 失败", zap.Error(err))
-			ctx.ResponseError(errors.New("更新群设置失败"))
+			httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 			return
 		}
 	} else {
 		if err := convext.RestoreAutoFollowThreadsTx(tx, loginUID, effectiveSpaceID, []string{groupNo}); err != nil {
 			c.Error("恢复 auto_follow_threads 失败", zap.Error(err))
-			ctx.ResponseError(errors.New("更新群设置失败"))
+			httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 			return
 		}
 	}
 
 	if err := tx.Commit(); err != nil {
 		c.Error("提交事务失败", zap.Error(err))
-		ctx.ResponseError(errors.New("更新群设置失败"))
+		httperr.ResponseErrorL(ctx, errcode.ErrCategoryStoreFailed, nil, nil)
 		return
 	}
 

--- a/modules/category/api_i18n.go
+++ b/modules/category/api_i18n.go
@@ -1,0 +1,46 @@
+package category
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+// respond helpers for modules/category. Most migrated sites call
+// httperr.ResponseErrorL(c, errcode.ErrCategoryXxx, nil, nil) directly; the
+// helpers below exist only for the shapes that carry a Detail field, so the
+// SafeDetailKeys contract stays in one place.
+//
+// Internal=true codes (ErrCategoryQueryFailed / ErrCategoryStoreFailed) are
+// intentionally NOT wrapped: each call site keeps its existing
+// c.Error(..., zap.Error(err)) log so ops can debug from logs, and the wire
+// response carries no message.
+
+// respondCategoryRequestInvalid covers the common BindJSON-failure / "X 不能为空"
+// shape — one code, one optional field detail. An empty field is omitted so the
+// renderer does not surface a noisy empty key to clients.
+func respondCategoryRequestInvalid(ctx *wkhttp.Context, field string) {
+	details := i18n.Details{}
+	if field != "" {
+		details["field"] = field
+	}
+	httperr.ResponseErrorL(ctx, errcode.ErrCategoryRequestInvalid, nil, details)
+}
+
+// respondCategoryNameTooLong surfaces the name length cap so the client can
+// render a localized hint without hard-coding the limit.
+func respondCategoryNameTooLong(ctx *wkhttp.Context, maxLen int) {
+	httperr.ResponseErrorL(ctx, errcode.ErrCategoryNameTooLong, nil, i18n.Details{
+		"field":      "name",
+		"max_length": maxLen,
+	})
+}
+
+// respondCategoryLimitExceeded surfaces the per-space category cap so the client
+// can render a localized hint without hard-coding the limit.
+func respondCategoryLimitExceeded(ctx *wkhttp.Context, max int) {
+	httperr.ResponseErrorL(ctx, errcode.ErrCategoryLimitExceeded, nil, i18n.Details{
+		"max": max,
+	})
+}

--- a/modules/category/api_i18n_test.go
+++ b/modules/category/api_i18n_test.go
@@ -1,0 +1,302 @@
+package category
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/server"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// httperrL is a terse test shim for the no-params/no-details ResponseErrorL
+// call shape exercised by the direct-code cases below.
+func httperrL(c *wkhttp.Context, code codes.Code) {
+	httperr.ResponseErrorL(c, code, nil, nil)
+}
+
+// TestCategoryNoLegacyResponseError pins the Phase 2.1 contract that the
+// migrated modules/category handlers do not regress to legacy octo-lib error
+// responses. Comments are stripped first so commented-out breadcrumbs do not
+// trip the guard. The c.Error(...) zap LOG calls are not responses and are
+// intentionally allowed (they match neither banned token).
+func TestCategoryNoLegacyResponseError(t *testing.T) {
+	files := []string{"api.go"}
+	banned := []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(", "c.Response(\""}
+	for _, f := range files {
+		t.Run(f, func(t *testing.T) {
+			data, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+			var clean strings.Builder
+			for _, line := range strings.Split(string(data), "\n") {
+				if idx := strings.Index(line, "//"); idx >= 0 {
+					line = line[:idx]
+				}
+				clean.WriteString(line)
+				clean.WriteByte('\n')
+			}
+			cleaned := clean.String()
+			for _, b := range banned {
+				if strings.Contains(cleaned, b) {
+					t.Fatalf("modules/category/%s must use httperr.ResponseErrorL via respondCategory* helpers / errcode.ErrCategory* instead of legacy %s", f, b)
+				}
+			}
+		})
+	}
+}
+
+// newCategoryTestServer wraps testutil.NewTestServer and injects the i18n
+// ErrorRenderer onto the route, mirroring what main.go does at boot. Post-
+// Phase-2.1, modules/category handlers respond via httperr.ResponseErrorL →
+// c.RenderError; without a renderer wired the route falls back to the legacy
+// {msg,status} envelope carrying the English source DefaultMessage instead of
+// the localized zh-CN copy production clients receive. testutil.NewTestServer
+// lives in octo-lib and is intentionally not touched from this PR, so the
+// integration tests funnel construction through this single helper.
+func newCategoryTestServer() (*server.Server, *config.Context) {
+	s, ctx := testutil.NewTestServer()
+	s.GetRoute().SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	return s, ctx
+}
+
+// errEnvelope is the partial shape of an httperr.ResponseErrorL response. The
+// renderer emits both the legacy {msg,status} and the v2 {error.{...}} blocks
+// unconditionally (v7.2 dual-envelope contract).
+type errEnvelope struct {
+	Error struct {
+		Code       string         `json:"code"`
+		Message    string         `json:"message"`
+		Details    map[string]any `json:"details"`
+		HTTPStatus int            `json:"http_status"`
+	} `json:"error"`
+	Msg    string `json:"msg"`
+	Status int    `json:"status"`
+}
+
+func decodeErrEnvelope(t *testing.T, body []byte) errEnvelope {
+	t.Helper()
+	var env errEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("decode envelope: %v\nbody: %s", err, body)
+	}
+	return env
+}
+
+// assertCategoryErrorCode asserts the migrated error envelope carries the
+// expected error.code. Used by the integration tests in api_test.go in place of
+// brittle zh-CN substring matching, so future copy edits do not break them.
+func assertCategoryErrorCode(t *testing.T, w *httptest.ResponseRecorder, wantCode string) {
+	t.Helper()
+	env := decodeErrEnvelope(t, w.Body.Bytes())
+	if env.Error.Code != wantCode {
+		t.Fatalf("error.code = %q, want %q\nbody: %s", env.Error.Code, wantCode, w.Body.String())
+	}
+}
+
+// helperHarness mounts a single GET /probe route that invokes the supplied
+// helper with the i18n renderer wired, so tests can assert the rendered
+// envelope without paying the DB / auth setup cost.
+func helperHarness(probe func(c *wkhttp.Context)) *wkhttp.WKHttp {
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	r.GET("/probe", probe)
+	return r
+}
+
+func TestRespondCategoryHelpers(t *testing.T) {
+	cases := []struct {
+		name            string
+		probe           func(c *wkhttp.Context)
+		wantCodeID      string
+		wantSemStatus   int
+		wantTransStatus int    // always 400 for legacy compat (D14)
+		wantContains    string // zh-CN substring expected in error.message
+		wantNotContains string // forbid leaked English DefaultMessage when Internal=true
+		wantDetails     map[string]any
+	}{
+		{
+			name:            "respondCategoryRequestInvalid carries the field detail",
+			probe:           func(c *wkhttp.Context) { respondCategoryRequestInvalid(c, "name") },
+			wantCodeID:      "err.server.category.request_invalid",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "请求参数有误",
+			wantDetails:     map[string]any{"field": "name"},
+		},
+		{
+			name:            "respondCategoryRequestInvalid drops empty field key",
+			probe:           func(c *wkhttp.Context) { respondCategoryRequestInvalid(c, "") },
+			wantCodeID:      "err.server.category.request_invalid",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "请求参数有误",
+			wantDetails:     map[string]any{},
+		},
+		{
+			name:            "respondCategoryNameTooLong surfaces the length cap",
+			probe:           func(c *wkhttp.Context) { respondCategoryNameTooLong(c, 100) },
+			wantCodeID:      "err.server.category.name_too_long",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "100",
+			wantDetails:     map[string]any{"field": "name", "max_length": float64(100)},
+		},
+		{
+			name:            "respondCategoryLimitExceeded surfaces the per-space cap",
+			probe:           func(c *wkhttp.Context) { respondCategoryLimitExceeded(c, 20) },
+			wantCodeID:      "err.server.category.limit_exceeded",
+			wantSemStatus:   http.StatusConflict,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "20",
+			wantDetails:     map[string]any{"max": float64(20)},
+		},
+		{
+			name:            "ErrCategorySpaceMemberRequired surfaces 403 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrCategorySpaceMemberRequired) },
+			wantCodeID:      "err.server.category.space_member_required",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "你不是该空间成员",
+		},
+		{
+			name:            "ErrCategoryGroupMemberRequired surfaces 403 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrCategoryGroupMemberRequired) },
+			wantCodeID:      "err.server.category.group_member_required",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "你不是该群成员",
+		},
+		{
+			name:            "ErrCategoryPermissionDenied surfaces 403 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrCategoryPermissionDenied) },
+			wantCodeID:      "err.server.category.permission_denied",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "无权操作此分类",
+		},
+		{
+			name:            "ErrCategoryDefaultImmutable surfaces 403 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrCategoryDefaultImmutable) },
+			wantCodeID:      "err.server.category.default_immutable",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "默认分类不可修改",
+		},
+		{
+			name:            "ErrCategoryDefaultUndeletable surfaces 403 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrCategoryDefaultUndeletable) },
+			wantCodeID:      "err.server.category.default_undeletable",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "默认分类不可删除",
+		},
+		{
+			name:            "ErrCategoryNotFound surfaces 404 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrCategoryNotFound) },
+			wantCodeID:      "err.server.category.not_found",
+			wantSemStatus:   http.StatusNotFound,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "分类不存在",
+		},
+		{
+			name:            "ErrCategorySpaceMismatch surfaces 400 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrCategorySpaceMismatch) },
+			wantCodeID:      "err.server.category.space_mismatch",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "不在同一空间",
+		},
+		{
+			name:            "ErrCategorySortListMismatch surfaces 400 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrCategorySortListMismatch) },
+			wantCodeID:      "err.server.category.sort_list_mismatch",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "数量不匹配",
+		},
+		{
+			name:            "ErrCategoryGroupSpaceMissing surfaces 400 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrCategoryGroupSpaceMissing) },
+			wantCodeID:      "err.server.category.group_space_missing",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "不属于任何空间",
+		},
+		{
+			name:            "ErrCategoryQueryFailed (Internal=true) collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrCategoryQueryFailed) },
+			wantCodeID:      "err.server.category.query_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "query category data",
+		},
+		{
+			name:            "ErrCategoryStoreFailed (Internal=true) collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrCategoryStoreFailed) },
+			wantCodeID:      "err.server.category.store_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "update category data",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := helperHarness(tc.probe)
+			req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+			req.Header.Set("Accept-Language", "zh-CN")
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantTransStatus {
+				t.Fatalf("HTTP status = %d, want %d; body=%s", rec.Code, tc.wantTransStatus, rec.Body.String())
+			}
+			env := decodeErrEnvelope(t, rec.Body.Bytes())
+			if env.Error.Code != tc.wantCodeID {
+				t.Fatalf("error.code = %q, want %q", env.Error.Code, tc.wantCodeID)
+			}
+			if env.Error.HTTPStatus != tc.wantSemStatus {
+				t.Fatalf("error.http_status = %d, want %d", env.Error.HTTPStatus, tc.wantSemStatus)
+			}
+			if env.Status != tc.wantTransStatus {
+				t.Fatalf("legacy status = %d, want %d (D14 transport=400 compat)", env.Status, tc.wantTransStatus)
+			}
+			if env.Msg != env.Error.Message {
+				t.Fatalf("legacy msg %q != error.message %q (dual envelope must agree)", env.Msg, env.Error.Message)
+			}
+			if !strings.Contains(env.Error.Message, tc.wantContains) {
+				t.Fatalf("error.message = %q, want substring %q", env.Error.Message, tc.wantContains)
+			}
+			if tc.wantNotContains != "" && strings.Contains(env.Error.Message, tc.wantNotContains) {
+				t.Fatalf("error.message = %q must not contain %q (Internal leak)", env.Error.Message, tc.wantNotContains)
+			}
+			if tc.wantDetails != nil {
+				got := env.Error.Details
+				if got == nil {
+					got = map[string]any{}
+				}
+				if len(got) != len(tc.wantDetails) {
+					t.Fatalf("error.details = %#v, want %#v", got, tc.wantDetails)
+				}
+				for k, v := range tc.wantDetails {
+					if got[k] != v {
+						t.Fatalf("error.details[%q] = %#v, want %#v", k, got[k], v)
+					}
+				}
+			}
+		})
+	}
+}

--- a/modules/category/api_test.go
+++ b/modules/category/api_test.go
@@ -1741,6 +1741,39 @@ func TestCategory_SortCountMismatch(t *testing.T) {
 	assertCategoryErrorCode(t, ws, "err.server.category.sort_list_mismatch")
 }
 
+// TestCategory_SortDuplicateIDs covers the repeated-ID branch in sort: a
+// same-length category_ids list that contains a duplicate must be rejected as
+// sort_list_duplicate (not sort_list_mismatch). The duplicate guard runs before
+// the catMap membership check, so the repeat is caught even though every ID is a
+// real category. (PR #214 reviewer-requested endpoint coverage.)
+func TestCategory_SortDuplicateIDs(t *testing.T) {
+	s, ctx := newCategoryTestServer()
+	f := New(ctx)
+
+	err := testutil.CleanAllTables(ctx)
+	assert.NoError(t, err)
+	resetUIDRateLimit(t, ctx)
+
+	spaceID := "space-sortdup-001"
+	seedSpaceAndMember(t, f, spaceID, 0)
+	route := s.GetRoute()
+
+	// create 2 categories so the list length matches but contains a repeat
+	wc1 := createCategory(t, route, spaceID, "A")
+	require.Equal(t, http.StatusOK, wc1.Code)
+	cat1 := parseJSON(t, wc1)
+	wc2 := createCategory(t, route, spaceID, "B")
+	require.Equal(t, http.StatusOK, wc2.Code)
+
+	catID1 := cat1["category_id"].(string)
+	// same length (2) as the user's categories, but catID1 is repeated
+	ws := doRequest(t, route, "PUT", "/v1/spaces/"+spaceID+"/categories/sort", map[string]interface{}{
+		"category_ids": []string{catID1, catID1},
+	})
+	assert.Equal(t, http.StatusBadRequest, ws.Code)
+	assertCategoryErrorCode(t, ws, "err.server.category.sort_list_duplicate")
+}
+
 func TestCategory_MoveGroupNoSpace(t *testing.T) {
 	s, ctx := newCategoryTestServer()
 	f := New(ctx)

--- a/modules/category/api_test.go
+++ b/modules/category/api_test.go
@@ -115,7 +115,7 @@ func createCategory(t *testing.T, route *wkhttp.WKHttp, spaceID, name string) *h
 
 func TestCategory_Create(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -135,7 +135,7 @@ func TestCategory_Create(t *testing.T) {
 }
 
 func TestCategory_List(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -189,7 +189,7 @@ func TestCategory_List(t *testing.T) {
 }
 
 func TestCategory_Update(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -216,7 +216,7 @@ func TestCategory_Update(t *testing.T) {
 }
 
 func TestCategory_Delete(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -273,7 +273,7 @@ func TestCategory_Delete(t *testing.T) {
 // 群（含 thread 级联）与 DM —— 前端提示「分组下的所有会话将取消关注」对应
 // 的服务端行为。
 func TestCategory_DeleteUnfollowsContents(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -358,7 +358,7 @@ func TestCategory_DeleteUnfollowsContents(t *testing.T) {
 
 func TestCategory_Sort(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -406,7 +406,7 @@ func TestCategory_Sort(t *testing.T) {
 }
 
 func TestCategory_MoveGroupToCategory(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -471,7 +471,7 @@ func TestCategory_MoveGroupToCategory(t *testing.T) {
 // After fix the move-out branch in api.go calls ClearAutoFollowThreadsTx
 // in the same tx, restoring the read/write contract.
 func TestCategory_MoveGroupOutOfCategory_ClearsAutoFollowThreads(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -553,7 +553,7 @@ func TestCategory_MoveGroupOutOfCategory_ClearsAutoFollowThreads(t *testing.T) {
 // future change might over-eagerly clear in every move and break the
 // "default-followed across category-to-category move" contract.
 func TestCategory_MoveGroupBetweenCategories_PreservesAutoFollowThreads(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -607,7 +607,7 @@ func TestCategory_MoveGroupBetweenCategories_PreservesAutoFollowThreads(t *testi
 // selectEligibleForFanoutTx still excludes the user (=0) — phantom missing
 // fan-out.
 func TestCategory_MoveGroupBackIntoCategory_RestoresAutoFollowThreads(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -670,7 +670,7 @@ func TestCategory_MoveGroupBackIntoCategory_RestoresAutoFollowThreads(t *testing
 // auto_follow_threads=1 anyway, and the move-in handler must not
 // short-circuit any subsequent paths or write inappropriate rows.
 func TestCategory_MoveFirstTimeIntoCategory_NoOpRestore(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -712,7 +712,7 @@ func TestCategory_MoveFirstTimeIntoCategory_NoOpRestore(t *testing.T) {
 // ---------- Validation / Error Tests ----------
 
 func TestCategory_CreateLimit(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -731,11 +731,11 @@ func TestCategory_CreateLimit(t *testing.T) {
 	// 21st should fail
 	w := createCategory(t, route, spaceID, "Cat-20")
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "最多创建20个分类")
+	assertCategoryErrorCode(t, w, "err.server.category.limit_exceeded")
 }
 
 func TestCategory_CreateEmptyName(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	_ = New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -747,11 +747,11 @@ func TestCategory_CreateEmptyName(t *testing.T) {
 
 	w := createCategory(t, s.GetRoute(), spaceID, "")
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "类别名称不能为空")
+	assertCategoryErrorCode(t, w, "err.server.category.request_invalid")
 }
 
 func TestCategory_UpdateNotOwner(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -775,11 +775,11 @@ func TestCategory_UpdateNotOwner(t *testing.T) {
 	// try to update it
 	w := doRequest(t, s.GetRoute(), "PUT", "/v1/spaces/"+spaceID+"/categories/"+otherCatID, map[string]string{"name": "我要改"})
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "无权限修改此分类")
+	assertCategoryErrorCode(t, w, "err.server.category.permission_denied")
 }
 
 func TestCategory_DeleteNotOwner(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -803,11 +803,11 @@ func TestCategory_DeleteNotOwner(t *testing.T) {
 	// try to delete it
 	w := doRequest(t, s.GetRoute(), "DELETE", "/v1/spaces/"+spaceID+"/categories/"+otherCatID, nil)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "无权限删除此分类")
+	assertCategoryErrorCode(t, w, "err.server.category.permission_denied")
 }
 
 func TestCategory_MoveGroupNotMember(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -834,11 +834,11 @@ func TestCategory_MoveGroupNotMember(t *testing.T) {
 		"category_id": catID,
 	})
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "你不是该群成员")
+	assertCategoryErrorCode(t, w, "err.server.category.group_member_required")
 }
 
 func TestCategory_NonSpaceMember(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	_ = New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -856,16 +856,16 @@ func TestCategory_NonSpaceMember(t *testing.T) {
 	// try to create a category
 	w := createCategory(t, route, spaceID, "工作")
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "你不是该空间成员")
+	assertCategoryErrorCode(t, w, "err.server.category.space_member_required")
 
 	// try to list categories
 	wl := doRequest(t, route, "GET", "/v1/spaces/"+spaceID+"/categories", nil)
 	assert.Equal(t, http.StatusBadRequest, wl.Code)
-	assert.Contains(t, wl.Body.String(), "你不是该空间成员")
+	assertCategoryErrorCode(t, wl, "err.server.category.space_member_required")
 }
 
 func TestCategory_UpdateNotFound(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -877,11 +877,11 @@ func TestCategory_UpdateNotFound(t *testing.T) {
 	// try to update a non-existent category
 	w := doRequest(t, s.GetRoute(), "PUT", "/v1/spaces/"+spaceID+"/categories/nonexistent-cat", map[string]string{"name": "不存在"})
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "分类不存在")
+	assertCategoryErrorCode(t, w, "err.server.category.not_found")
 }
 
 func TestCategory_DeleteNotFound(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -893,11 +893,11 @@ func TestCategory_DeleteNotFound(t *testing.T) {
 	// try to delete a non-existent category
 	w := doRequest(t, s.GetRoute(), "DELETE", "/v1/spaces/"+spaceID+"/categories/nonexistent-cat", nil)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "分类不存在")
+	assertCategoryErrorCode(t, w, "err.server.category.not_found")
 }
 
 func TestCategory_UpdateEmptyName(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -916,11 +916,11 @@ func TestCategory_UpdateEmptyName(t *testing.T) {
 	// try to update with empty name
 	wu := doRequest(t, route, "PUT", "/v1/spaces/"+spaceID+"/categories/"+catID, map[string]string{"name": ""})
 	assert.Equal(t, http.StatusBadRequest, wu.Code)
-	assert.Contains(t, wu.Body.String(), "类别名称不能为空")
+	assertCategoryErrorCode(t, wu, "err.server.category.request_invalid")
 }
 
 func TestCategory_SortEmptyList(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -934,11 +934,11 @@ func TestCategory_SortEmptyList(t *testing.T) {
 		"category_ids": []string{},
 	})
 	assert.Equal(t, http.StatusBadRequest, ws.Code)
-	assert.Contains(t, ws.Body.String(), "分类列表不能为空")
+	assertCategoryErrorCode(t, ws, "err.server.category.request_invalid")
 }
 
 func TestCategory_SortUnknownCategory(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -957,11 +957,11 @@ func TestCategory_SortUnknownCategory(t *testing.T) {
 		"category_ids": []string{"fake-id-001"},
 	})
 	assert.Equal(t, http.StatusBadRequest, ws.Code)
-	assert.Contains(t, ws.Body.String(), "分类不存在或无权限")
+	assertCategoryErrorCode(t, ws, "err.server.category.not_found")
 }
 
 func TestCategory_SortNonSpaceMember(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	_ = New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -978,11 +978,11 @@ func TestCategory_SortNonSpaceMember(t *testing.T) {
 		"category_ids": []string{"some-id"},
 	})
 	assert.Equal(t, http.StatusBadRequest, ws.Code)
-	assert.Contains(t, ws.Body.String(), "你不是该空间成员")
+	assertCategoryErrorCode(t, ws, "err.server.category.space_member_required")
 }
 
 func TestCategory_MoveGroupCategoryNotFound(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -999,11 +999,11 @@ func TestCategory_MoveGroupCategoryNotFound(t *testing.T) {
 		"category_id": "nonexistent-cat-id",
 	})
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "分类不存在")
+	assertCategoryErrorCode(t, w, "err.server.category.not_found")
 }
 
 func TestCategory_MoveGroupCategoryNotOwner(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1032,11 +1032,11 @@ func TestCategory_MoveGroupCategoryNotOwner(t *testing.T) {
 		"category_id": otherCatID,
 	})
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "无权限使用此分类")
+	assertCategoryErrorCode(t, w, "err.server.category.permission_denied")
 }
 
 func TestCategory_MoveGroupCrossSpace(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1064,7 +1064,7 @@ func TestCategory_MoveGroupCrossSpace(t *testing.T) {
 		"category_id": catID,
 	})
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "群组和分类不在同一空间")
+	assertCategoryErrorCode(t, w, "err.server.category.space_mismatch")
 }
 
 // TestCategory_MoveExternalGroupToCurrentSpaceCategory is the regression test
@@ -1078,7 +1078,7 @@ func TestCategory_MoveGroupCrossSpace(t *testing.T) {
 // (not the group's owning Space) so the group surfaces in the follow tab the
 // sidebar queries for the user's current Space.
 func TestCategory_MoveExternalGroupToCurrentSpaceCategory(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1143,7 +1143,7 @@ func TestCategory_MoveExternalGroupToCurrentSpaceCategory(t *testing.T) {
 // same — otherwise these groups stay un-categorizable and follow_version /
 // auto_follow_threads writes land in the group's owning Space.
 func TestCategory_MoveExternalGroupEmptySourceSpaceFallsBackToDefaultSpace(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1202,7 +1202,7 @@ func TestCategory_MoveExternalGroupEmptySourceSpaceFallsBackToDefaultSpace(t *te
 // sidebar materialized the ext row — not the group's owning Space. Without the
 // effectiveSpaceID fix this clear would miss the row entirely.
 func TestCategory_MoveExternalGroupOutClearsAutoFollowThreadsInSourceSpace(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1262,7 +1262,7 @@ func TestCategory_MoveExternalGroupOutClearsAutoFollowThreadsInSourceSpace(t *te
 
 func TestCategory_ListEmpty(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1283,7 +1283,7 @@ func TestCategory_ListEmpty(t *testing.T) {
 // ---------- Default Category (is_default=1) Tests ----------
 
 func TestCategory_ListAutoCreatesDefault(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1323,7 +1323,7 @@ func TestCategory_ListAutoCreatesDefault(t *testing.T) {
 }
 
 func TestCategory_ListDefaultIdempotent(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1349,7 +1349,7 @@ func TestCategory_ListDefaultIdempotent(t *testing.T) {
 }
 
 func TestCategory_ListWithCategoriesAndDefault(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1397,7 +1397,7 @@ func TestCategory_ListWithCategoriesAndDefault(t *testing.T) {
 }
 
 func TestCategory_DeleteDefaultRejected(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1417,11 +1417,11 @@ func TestCategory_DeleteDefaultRejected(t *testing.T) {
 	// try to delete — should be rejected
 	wd := doRequest(t, route, "DELETE", "/v1/spaces/"+spaceID+"/categories/"+defaultCatID, nil)
 	assert.Equal(t, http.StatusBadRequest, wd.Code)
-	assert.Contains(t, wd.Body.String(), "默认分类不可删除")
+	assertCategoryErrorCode(t, wd, "err.server.category.default_undeletable")
 }
 
 func TestCategory_UpdateDefaultRejected(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1441,12 +1441,12 @@ func TestCategory_UpdateDefaultRejected(t *testing.T) {
 	// try to update — should be rejected
 	wu := doRequest(t, route, "PUT", "/v1/spaces/"+spaceID+"/categories/"+defaultCatID, map[string]string{"name": "改名"})
 	assert.Equal(t, http.StatusBadRequest, wu.Code)
-	assert.Contains(t, wu.Body.String(), "默认分类不可修改")
+	assertCategoryErrorCode(t, wu, "err.server.category.default_immutable")
 }
 
 func TestCategory_SortWithDefault(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1500,7 +1500,7 @@ func TestCategory_SortWithDefault(t *testing.T) {
 }
 
 func TestCategory_DefaultNameFromEnv(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1524,7 +1524,7 @@ func TestCategory_DefaultNameFromEnv(t *testing.T) {
 
 func TestCategory_DefaultNotCountedInLimit(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1552,7 +1552,7 @@ func TestCategory_DefaultNotCountedInLimit(t *testing.T) {
 
 func TestCategory_ListNoGroupsNoDefault(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1576,7 +1576,7 @@ func TestCategory_ListNoGroupsNoDefault(t *testing.T) {
 
 func TestCategory_MoveGroupToDefaultCategory(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1714,7 +1714,7 @@ func TestCategory_UniqueIndexPreventsDefaultDuplicate(t *testing.T) {
 }
 
 func TestCategory_SortCountMismatch(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1738,11 +1738,11 @@ func TestCategory_SortCountMismatch(t *testing.T) {
 		"category_ids": []string{cat1["category_id"].(string)},
 	})
 	assert.Equal(t, http.StatusBadRequest, ws.Code)
-	assert.Contains(t, ws.Body.String(), "分类列表数量不匹配")
+	assertCategoryErrorCode(t, ws, "err.server.category.sort_list_mismatch")
 }
 
 func TestCategory_MoveGroupNoSpace(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newCategoryTestServer()
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1764,5 +1764,5 @@ func TestCategory_MoveGroupNoSpace(t *testing.T) {
 		"category_id": "some-fake-cat",
 	})
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "该群组不属于任何空间")
+	assertCategoryErrorCode(t, w, "err.server.category.group_space_missing")
 }

--- a/pkg/errcode/category.go
+++ b/pkg/errcode/category.go
@@ -1,0 +1,121 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// err.server.category.* — modules/category business error codes (api.go).
+// DefaultMessage holds the en-US source (D4); the zh-CN runtime translation
+// lives in pkg/i18n/locales/active.zh-CN.toml. Internal=true codes never surface
+// their message on the wire — callers MUST log the underlying err with full
+// context via the module logger before responding.
+var (
+	// ---- validation (400) ----------------------------------------------------
+
+	// ErrCategoryRequestInvalid is the catch-all for missing/malformed request
+	// input (BindJSON failure, empty category name, empty sort list). The
+	// offending field is surfaced via Details when the caller can identify it.
+	ErrCategoryRequestInvalid = register(codes.Code{
+		ID:             "err.server.category.request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid request.",
+		SafeDetailKeys: []string{"field"},
+	})
+	ErrCategoryNameTooLong = register(codes.Code{
+		ID:             "err.server.category.name_too_long",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The category name cannot exceed 100 characters.",
+		SafeDetailKeys: []string{"field", "max_length"},
+	})
+	ErrCategorySortListMismatch = register(codes.Code{
+		ID:             "err.server.category.sort_list_mismatch",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The category list does not match the existing categories.",
+	})
+	ErrCategorySortListDuplicate = register(codes.Code{
+		ID:             "err.server.category.sort_list_duplicate",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The category list contains duplicates.",
+	})
+	ErrCategoryGroupSpaceMissing = register(codes.Code{
+		ID:             "err.server.category.group_space_missing",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The group does not belong to any space.",
+	})
+	ErrCategorySpaceMismatch = register(codes.Code{
+		ID:             "err.server.category.space_mismatch",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The group and the category are not in the same space.",
+	})
+
+	// ---- permission / authorization (403) ------------------------------------
+
+	ErrCategorySpaceMemberRequired = register(codes.Code{
+		ID:             "err.server.category.space_member_required",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You are not a member of this space.",
+	})
+	ErrCategoryGroupMemberRequired = register(codes.Code{
+		ID:             "err.server.category.group_member_required",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You are not a member of this group.",
+	})
+	// ErrCategoryPermissionDenied covers the ownership guards on update / delete /
+	// move (cat.UID != loginUID) — all the same "not your category" condition.
+	ErrCategoryPermissionDenied = register(codes.Code{
+		ID:             "err.server.category.permission_denied",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You do not have permission to operate on this category.",
+	})
+	ErrCategoryDefaultImmutable = register(codes.Code{
+		ID:             "err.server.category.default_immutable",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "The default category cannot be modified.",
+	})
+	ErrCategoryDefaultUndeletable = register(codes.Code{
+		ID:             "err.server.category.default_undeletable",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "The default category cannot be deleted.",
+	})
+
+	// ---- not found (404) -----------------------------------------------------
+
+	// ErrCategoryNotFound covers both a missing category and the deliberate
+	// "not found or no permission" merge in the sort handler (no enumeration).
+	ErrCategoryNotFound = register(codes.Code{
+		ID:             "err.server.category.not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Category not found.",
+	})
+
+	// ---- conflict (409) ------------------------------------------------------
+
+	ErrCategoryLimitExceeded = register(codes.Code{
+		ID:             "err.server.category.limit_exceeded",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "You can create at most 20 categories per space.",
+		SafeDetailKeys: []string{"max"},
+	})
+
+	// ---- internal (500, Internal=true) ---------------------------------------
+
+	// ErrCategoryQueryFailed covers read-path failures (membership check, DB
+	// SELECT/count). Log the underlying err before responding.
+	ErrCategoryQueryFailed = register(codes.Code{
+		ID:             "err.server.category.query_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to query category data.",
+		Internal:       true,
+	})
+	// ErrCategoryStoreFailed covers mutation-path failures (DB write, transaction
+	// begin/commit/rollback, sequence generation, follow-version bump). Log the
+	// underlying err before responding.
+	ErrCategoryStoreFailed = register(codes.Code{
+		ID:             "err.server.category.store_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to update category data.",
+		Internal:       true,
+	})
+)

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -565,3 +565,48 @@ other = "查询工作台数据失败。"
 
 ["err.server.workplace.store_failed"]
 other = "保存工作台数据失败。"
+
+["err.server.category.request_invalid"]
+other = "请求参数有误。"
+
+["err.server.category.name_too_long"]
+other = "类别名称不能超过100个字符。"
+
+["err.server.category.sort_list_mismatch"]
+other = "分类列表数量不匹配。"
+
+["err.server.category.sort_list_duplicate"]
+other = "分类列表存在重复。"
+
+["err.server.category.group_space_missing"]
+other = "该群组不属于任何空间。"
+
+["err.server.category.space_mismatch"]
+other = "群组和分类不在同一空间。"
+
+["err.server.category.space_member_required"]
+other = "你不是该空间成员。"
+
+["err.server.category.group_member_required"]
+other = "你不是该群成员。"
+
+["err.server.category.permission_denied"]
+other = "无权操作此分类。"
+
+["err.server.category.default_immutable"]
+other = "默认分类不可修改。"
+
+["err.server.category.default_undeletable"]
+other = "默认分类不可删除。"
+
+["err.server.category.not_found"]
+other = "分类不存在。"
+
+["err.server.category.limit_exceeded"]
+other = "每个空间最多创建20个分类。"
+
+["err.server.category.query_failed"]
+other = "查询分类数据失败。"
+
+["err.server.category.store_failed"]
+other = "保存分类数据失败。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -6,6 +6,51 @@
 #
 # CI rejects PRs that change codes.Register input without re-running extract.
 
+["err.server.category.default_immutable"]
+other = "The default category cannot be modified."
+
+["err.server.category.default_undeletable"]
+other = "The default category cannot be deleted."
+
+["err.server.category.group_member_required"]
+other = "You are not a member of this group."
+
+["err.server.category.group_space_missing"]
+other = "The group does not belong to any space."
+
+["err.server.category.limit_exceeded"]
+other = "You can create at most 20 categories per space."
+
+["err.server.category.name_too_long"]
+other = "The category name cannot exceed 100 characters."
+
+["err.server.category.not_found"]
+other = "Category not found."
+
+["err.server.category.permission_denied"]
+other = "You do not have permission to operate on this category."
+
+["err.server.category.query_failed"]
+other = "Failed to query category data."
+
+["err.server.category.request_invalid"]
+other = "Invalid request."
+
+["err.server.category.sort_list_duplicate"]
+other = "The category list contains duplicates."
+
+["err.server.category.sort_list_mismatch"]
+other = "The category list does not match the existing categories."
+
+["err.server.category.space_member_required"]
+other = "You are not a member of this space."
+
+["err.server.category.space_mismatch"]
+other = "The group and the category are not in the same space."
+
+["err.server.category.store_failed"]
+other = "Failed to update category data."
+
 ["err.server.group.already_member"]
 other = "You are already a member of this group."
 


### PR DESCRIPTION
## Summary

Phase 2.1 i18n migration of `modules/category` (69 legacy error sites),
following the established thread/user/group/message playbook. Pure SDK reuse —
no email / gRPC dependencies, no Phase 1 blockers.

## Changes

- **Register 15 `err.server.category.*` codes** (`pkg/errcode/category.go`) with
  en-US source + zh-CN runtime translations, and regenerate the extract marker:
  validation (`request_invalid` / `name_too_long` / `sort_list_mismatch` /
  `sort_list_duplicate` / `group_space_missing` / `space_mismatch`),
  permission (`space_member_required` / `group_member_required` /
  `permission_denied` / `default_immutable` / `default_undeletable`),
  `not_found` (404), `limit_exceeded` (409), and `query_failed` / `store_failed`
  (500, Internal — message masked on the wire).
- **Add respond helpers** (`api_i18n.go`): `respondCategoryRequestInvalid`
  (field detail), `respondCategoryNameTooLong` (`max_length` detail) and
  `respondCategoryLimitExceeded` (`max` detail) keep the `SafeDetailKeys`
  contract in one place; all other sites call `httperr.ResponseErrorL` with the
  errcode directly.
- **Migrate all 69 sites** in `api.go` across
  create/list/update/delete/sort/moveGroupToCategory. Membership and ownership
  guards map to semantic 403, missing categories to 404, the per-space cap to
  409, validation to 400 with a `field` detail, DB read/write failures to
  Internal 500. The `errors.Is` / `common.GroupSettingSeqKey` imports stay;
  existing `c.Error` logs preserved for Internal paths.
- **Tests**: `TestCategoryNoLegacyResponseError` source-guards `api.go`;
  `TestRespondCategoryHelpers` asserts the rendered dual envelope for every
  helper and code, including Internal-leak checks. The i18n `ErrorRenderer` is
  now wired into the existing integration tests (`testutil.NewTestServer` does
  not wire it), and the error-path assertions are converted from brittle zh-CN
  substrings to `error.code` via `assertCategoryErrorCode` so future copy edits
  do not break them.

## Behavior change

Per the established migration (same as thread/user/group), HTTP wire status stays
fixed at 400 (D14) while `error.http_status` carries the real semantic status
(403/404/409/500). Clients should branch on `error.code` / `error.http_status`,
not the wire status.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `make i18n-extract-check`
- [x] `make i18n-lint` (D23 direct-error-response + unregistered-code)
- [x] `go test ./modules/category ./pkg/errcode ./pkg/i18n/...` (incl. DB integration)