### PR TITLE
feat(oidc): RP-Initiated Logout — backend issues end_session URL on logout

### DIFF
--- a/modules/oidc/api.go
+++ b/modules/oidc/api.go
@@ -912,12 +912,29 @@ func (o *OIDC) endSessionEndpoint() string {
 //   - 无可用 end_session 端点。
 //
 // 取出 id_token 即一次性消费(Take 内部删除)。不带 state(Aegis Discovery 未声明)。
+//
+// 顺序很关键:先解析+校验端点,再消费 id_token。原因有二:
+//   - 端点非法时不白烧 token(GETDEL 不可逆),logout 仍可重试拿到 end_session_url;
+//   - end_session 端点可能来自 discovery(非 config override,未经启动期校验),这里统一
+//     过一道 https 校验 —— 防 IdP 万一下发 http:// 把带 id_token 的 URL 降级到非 https。
 func (o *OIDC) buildEndSessionURL(ctx context.Context, uid string) string {
 	if o.cfg == nil || o.cfg.Provider.PostLogoutRedirectURI == "" || o.idTokens == nil {
 		return ""
 	}
 	endpoint := o.endSessionEndpoint()
 	if endpoint == "" {
+		return ""
+	}
+	// 校验 + 解析端点(在消费 token 之前)。validateLogoutURL 强制绝对 https
+	// (dev 可 OCTO_OIDC_LOGOUT_ALLOW_INSECURE=1),覆盖 discovery 与 override 两种来源。
+	if err := validateLogoutURL("end_session_endpoint", endpoint); err != nil {
+		o.Error("OIDC logout end_session 端点不合法,跳过 IdP 登出", zap.String("endpoint", endpoint), zap.Error(err))
+		return ""
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		// 只记端点本身,不记含 id_token 的完整 URL。
+		o.Error("OIDC logout 解析 end_session 端点失败", zap.String("endpoint", endpoint), zap.Error(err))
 		return ""
 	}
 	idToken, err := o.idTokens.Take(ctx, uid)
@@ -927,12 +944,6 @@ func (o *OIDC) buildEndSessionURL(ctx context.Context, uid string) string {
 		return ""
 	}
 	if idToken == "" {
-		return ""
-	}
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		// 只记端点本身,不记含 id_token 的完整 URL。
-		o.Error("OIDC logout 解析 end_session 端点失败", zap.String("endpoint", endpoint), zap.Error(err))
 		return ""
 	}
 	q := u.Query()

--- a/modules/oidc/api.go
+++ b/modules/oidc/api.go
@@ -160,15 +160,23 @@ func New(ctx *config.Context) *OIDC {
 	}
 	o.client = client
 	// id_token 缓存(RP-Initiated Logout)仅在功能"确实可用"时启用:既配了回跳地址
-	// (PostLogoutRedirectURI),又拿得到 end_session 端点(discovery 或 override)。
-	// 缺任一项时 buildEndSessionURL 永远返回空,此时不应把每次登录的 id_token(含 PII
-	// 的签名 JWT)加密写 Redis,也不必白占连接池。放在 client 构造之后才能判端点可用性。
-	// 密钥已在 LoadConfig 校验为 32B,构造失败仅记日志降级,不影响登录主流程。
-	if cfg.Provider.PostLogoutRedirectURI != "" && o.endSessionEndpoint() != "" {
-		if enc, eerr := NewEncryptor(cfg.Provider.RefreshTokenEncryptionKey); eerr != nil {
-			o.Error("构造 id_token Encryptor 失败,RP-Initiated Logout 禁用", zap.Error(eerr))
-		} else {
-			o.idTokens = newRedisIDTokenStore(ctx, enc)
+	// (PostLogoutRedirectURI),又拿得到*合法 https* 的 end_session 端点(discovery 或
+	// override)。端点仅"非空"不够 —— 非法/非 https 端点下 logout 也出不了 URL
+	// (buildEndSessionURL 会拒),此时建池存 PII id_token 纯属浪费。放在 client 之后才能判
+	// 端点可用性。密钥已在 LoadConfig 校验为 32B,构造失败仅记日志降级,不影响登录主流程。
+	if cfg.Provider.PostLogoutRedirectURI != "" {
+		endpoint := o.endSessionEndpoint()
+		switch {
+		case endpoint == "" || validateLogoutURL("end_session_endpoint", endpoint) != nil:
+			// 配了回跳地址却拿不到可用端点:打 Info 让运维可见"为什么 RP-logout 没生效"。
+			o.Info("RP-Initiated Logout 已禁用:end_session 端点不可用(discovery 未提供且未配 override,或非 https)",
+				zap.String("endpoint", endpoint))
+		default:
+			if enc, eerr := NewEncryptor(cfg.Provider.RefreshTokenEncryptionKey); eerr != nil {
+				o.Error("构造 id_token Encryptor 失败,RP-Initiated Logout 禁用", zap.Error(eerr))
+			} else {
+				o.idTokens = newRedisIDTokenStore(ctx, enc)
+			}
 		}
 	}
 	return o
@@ -889,6 +897,9 @@ func (o *OIDC) logout(c *wkhttp.Context) {
 	// 此时省略字段,前端降级为仅清本地。end_session_url 含 id_token,不写日志。
 	if endSessionURL := o.buildEndSessionURL(ctx, uid); endSessionURL != "" {
 		resp["end_session_url"] = endSessionURL
+		// 响应体含 id_token_hint,禁止任何缓存(OAuth/OIDC 安全 BCP、RFC 6749 §5.1)。
+		c.Header("Cache-Control", "no-store")
+		c.Header("Pragma", "no-cache")
 	}
 	c.JSON(http.StatusOK, resp)
 }

--- a/modules/oidc/api.go
+++ b/modules/oidc/api.go
@@ -135,12 +135,16 @@ func New(ctx *config.Context) *OIDC {
 	o.audit = db
 	o.revoker = db
 	o.killer = ctxKiller{ctx: ctx}
-	// id_token 缓存(RP-Initiated Logout)。密钥已在 LoadConfig 校验为 32B,
-	// 这里构造失败仅记日志并禁用 end_session 跳转,不影响登录主流程。
-	if enc, eerr := NewEncryptor(cfg.Provider.RefreshTokenEncryptionKey); eerr != nil {
-		o.Error("构造 id_token Encryptor 失败,RP-Initiated Logout 禁用", zap.Error(eerr))
-	} else {
-		o.idTokens = newRedisIDTokenStore(ctx, enc)
+	// id_token 缓存(RP-Initiated Logout)仅在配置了回跳地址、功能确实可用时才启用。
+	// 缺省未配 PostLogoutRedirectURI 的部署里 buildEndSessionURL 永远返回空,此时不应
+	// 把每次登录的 id_token(含 PII 的签名 JWT)加密写 Redis 存 7 天,也不必白占一个
+	// 连接池。密钥已在 LoadConfig 校验为 32B,构造失败仅记日志降级,不影响登录主流程。
+	if cfg.Provider.PostLogoutRedirectURI != "" {
+		if enc, eerr := NewEncryptor(cfg.Provider.RefreshTokenEncryptionKey); eerr != nil {
+			o.Error("构造 id_token Encryptor 失败,RP-Initiated Logout 禁用", zap.Error(eerr))
+		} else {
+			o.idTokens = newRedisIDTokenStore(ctx, enc)
+		}
 	}
 	o.cbGuard = NewCallbackGuard(
 		ctx.GetRedisConn(),
@@ -575,6 +579,8 @@ func (o *OIDC) callback(c *wkhttp.Context) {
 			jti, ierr := o.bind.IssueWithReason(c.Request.Context(), claims, sd, reason)
 			if ierr == nil {
 				result = "bind_pending" // 已在 callbackResultLabels 注册
+				// bind 接管时尚不知 uid,先按 jti 暂存 id_token,confirm/create 后迁移到 uid。
+				o.saveBindIDTokenHint(c.Request.Context(), jti, rawID)
 				o.writeAudit("bind:"+subHash(jti), EventBindIssued, sd, "")
 				o.redirectToBindPage(c, sd, jti)
 				return
@@ -928,6 +934,39 @@ func (o *OIDC) buildEndSessionURL(ctx context.Context, uid string) string {
 	q.Set("post_logout_redirect_uri", o.cfg.Provider.PostLogoutRedirectURI)
 	u.RawQuery = q.Encode()
 	return u.String()
+}
+
+// saveBindIDTokenHint 在自助绑定接管(callback bind_pending)时,按 bind token(jti)
+// 暂存验签过的 id_token,TTL 对齐 bind session —— bind 路径的 callback 还不知道最终
+// uid,无法直接按 uid 存。confirm/create 成功后由 promoteBindIDToken 迁移到 uid 名下。
+// 仅在 RP-Initiated Logout 启用(idTokens!=nil)时生效;best-effort,失败不阻断绑定。
+func (o *OIDC) saveBindIDTokenHint(ctx context.Context, jti, rawID string) {
+	if o.idTokens == nil || jti == "" || rawID == "" {
+		return
+	}
+	if err := o.idTokens.Save(ctx, bindIDTokenKey(jti), rawID, o.cfg.Bind.TokenTTL); err != nil {
+		o.Warn("OIDC bind 暂存 id_token 失败(不影响绑定,仅 RP-logout 降级)", zap.Error(err))
+	}
+}
+
+// promoteBindIDToken 把 bind 接管阶段按 jti 暂存的 id_token 迁移到已确定的 uid 名下,
+// 供后续 logout 当 id_token_hint。一次性消费 jti 暂存项(Take 内部删除);无值时静默
+// (非 OIDC bind 登录 / 已过期 / 功能未启用)。best-effort,失败不阻断绑定完成。
+func (o *OIDC) promoteBindIDToken(ctx context.Context, jti, uid string) {
+	if o.idTokens == nil || jti == "" || uid == "" {
+		return
+	}
+	raw, err := o.idTokens.Take(ctx, bindIDTokenKey(jti))
+	if err != nil {
+		o.Warn("OIDC bind 取暂存 id_token 失败,跳过 RP-logout 缓存", zap.Error(err))
+		return
+	}
+	if raw == "" {
+		return
+	}
+	if err := o.idTokens.Save(ctx, uid, raw, o.cfg.Provider.IDTokenTTL); err != nil {
+		o.Warn("OIDC bind 迁移 id_token 到 uid 失败", zap.Error(err))
+	}
 }
 
 func (o *OIDC) failWithAuthcode(ctx context.Context, sd *StateData, claims *IDTokenClaims, err error) {

--- a/modules/oidc/api.go
+++ b/modules/oidc/api.go
@@ -135,17 +135,6 @@ func New(ctx *config.Context) *OIDC {
 	o.audit = db
 	o.revoker = db
 	o.killer = ctxKiller{ctx: ctx}
-	// id_token 缓存(RP-Initiated Logout)仅在配置了回跳地址、功能确实可用时才启用。
-	// 缺省未配 PostLogoutRedirectURI 的部署里 buildEndSessionURL 永远返回空,此时不应
-	// 把每次登录的 id_token(含 PII 的签名 JWT)加密写 Redis 存 7 天,也不必白占一个
-	// 连接池。密钥已在 LoadConfig 校验为 32B,构造失败仅记日志降级,不影响登录主流程。
-	if cfg.Provider.PostLogoutRedirectURI != "" {
-		if enc, eerr := NewEncryptor(cfg.Provider.RefreshTokenEncryptionKey); eerr != nil {
-			o.Error("构造 id_token Encryptor 失败,RP-Initiated Logout 禁用", zap.Error(eerr))
-		} else {
-			o.idTokens = newRedisIDTokenStore(ctx, enc)
-		}
-	}
 	o.cbGuard = NewCallbackGuard(
 		ctx.GetRedisConn(),
 		callbackGuardThresholdFromEnv(),
@@ -170,6 +159,18 @@ func New(ctx *config.Context) *OIDC {
 		return o
 	}
 	o.client = client
+	// id_token 缓存(RP-Initiated Logout)仅在功能"确实可用"时启用:既配了回跳地址
+	// (PostLogoutRedirectURI),又拿得到 end_session 端点(discovery 或 override)。
+	// 缺任一项时 buildEndSessionURL 永远返回空,此时不应把每次登录的 id_token(含 PII
+	// 的签名 JWT)加密写 Redis,也不必白占连接池。放在 client 构造之后才能判端点可用性。
+	// 密钥已在 LoadConfig 校验为 32B,构造失败仅记日志降级,不影响登录主流程。
+	if cfg.Provider.PostLogoutRedirectURI != "" && o.endSessionEndpoint() != "" {
+		if enc, eerr := NewEncryptor(cfg.Provider.RefreshTokenEncryptionKey); eerr != nil {
+			o.Error("构造 id_token Encryptor 失败,RP-Initiated Logout 禁用", zap.Error(eerr))
+		} else {
+			o.idTokens = newRedisIDTokenStore(ctx, enc)
+		}
+	}
 	return o
 }
 
@@ -824,9 +825,14 @@ func (o *OIDC) Close() error {
 //
 // IdP 端 RP-Initiated Logout(/end_session)的跳转地址由后端拼好后随 200 响应返回
 // (end_session_url 字段),前端做顶层跳转。后端收口的原因:本架构 code→token 在
-// 服务端完成,前端从不持有 id_token,无法自行构造 id_token_hint;且 end_session 端点 /
-// 参数 / 回跳白名单集中在服务端更易维护。真正终止 Aegis 会话仍依赖浏览器顶层跳转
-// 携带 IdP 域 cookie,所以后端只给 URL,不代理跳转。
+// 服务端完成,前端无法自行*构造* id_token_hint(它不经手 token 交换),也不应散落
+// end_session 端点 / 参数 / 回跳白名单这些 IdP 细节 —— 由后端给出单次性 URL 最稳妥。
+// 真正终止 IdP 会话仍依赖浏览器顶层跳转携带 IdP 域 cookie,所以后端只给 URL,不代理跳转。
+//
+// 信任模型说明:end_session_url 里必然带 id_token_hint(RFC 规定的 front-channel 参数),
+// 因此该 id_token 会暴露到前端 JS、浏览器历史、Referer 及 IdP 访问日志 —— 这是
+// RP-Initiated Logout 协议固有的。可接受:它是单次性、不可重放的登出提示(octo-server
+// 自身从不把它当 bearer/assertion 复用),取出即原子作废(luaGetDel)。
 //
 // 配置缺失(未配 PostLogoutRedirectURI / 无 end_session 端点 / 无缓存的 id_token)时
 // 省略 end_session_url,前端降级为仅清本地 —— 纯增量,不影响存量行为。

--- a/modules/oidc/api.go
+++ b/modules/oidc/api.go
@@ -80,10 +80,13 @@ type OIDC struct {
 	audit      auditWriter
 	killer     sessionKiller
 	revoker    rtRevoker
-	worker     *SyncWorker
-	tickLock   *RedisTickLock
-	cbGuard    *CallbackGuard
-	bind       *BindService // 自助绑定(P0);Bind.Enabled=false 时为 nil,handler 不挂载
+	// idTokens 缓存登录时验签过的 id_token,供 logout 当 RP-Initiated Logout 的
+	// id_token_hint。nil 时 logout 不生成 end_session_url(降级为仅清本地)。
+	idTokens idTokenStore
+	worker   *SyncWorker
+	tickLock *RedisTickLock
+	cbGuard  *CallbackGuard
+	bind     *BindService // 自助绑定(P0);Bind.Enabled=false 时为 nil,handler 不挂载
 	// bindStore 单独持引用便于 Close 时关连接池。bind.store 是 BindStore 接口,
 	// 接口本身没 Close,production impl(*redisBindStore)有独立 redis.Client,
 	// 不关会泄漏。
@@ -132,6 +135,13 @@ func New(ctx *config.Context) *OIDC {
 	o.audit = db
 	o.revoker = db
 	o.killer = ctxKiller{ctx: ctx}
+	// id_token 缓存(RP-Initiated Logout)。密钥已在 LoadConfig 校验为 32B,
+	// 这里构造失败仅记日志并禁用 end_session 跳转,不影响登录主流程。
+	if enc, eerr := NewEncryptor(cfg.Provider.RefreshTokenEncryptionKey); eerr != nil {
+		o.Error("构造 id_token Encryptor 失败,RP-Initiated Logout 禁用", zap.Error(eerr))
+	} else {
+		o.idTokens = newRedisIDTokenStore(ctx, enc)
+	}
 	o.cbGuard = NewCallbackGuard(
 		ctx.GetRedisConn(),
 		callbackGuardThresholdFromEnv(),
@@ -745,6 +755,14 @@ func (o *OIDC) callback(c *wkhttp.Context) {
 	result = "ok"
 	// 成功路径清场:防止 IP 长尾累积导致历史失败 + 偶发 state 过期把用户误锁。
 	o.cbGuard.ResetLogged(clientIP)
+	// 缓存验签过的 id_token,供后续 logout 当 RP-Initiated Logout 的 id_token_hint。
+	// best-effort:存失败只告警,不影响登录(logout 时退回"仅清本地")。日志不打 token。
+	if o.idTokens != nil && sessResp.UID != "" {
+		if serr := o.idTokens.Save(c.Request.Context(), sessResp.UID, rawID, o.cfg.Provider.IDTokenTTL); serr != nil {
+			o.Warn("OIDC callback 缓存 id_token 失败(不影响登录,仅 RP-logout 降级)",
+				zap.String("trace_id", traceID), zap.Error(serr))
+		}
+	}
 	o.writeAudit(sessResp.UID, EventCallbackOK, sd, "")
 	o.redirectAfterCallback(c, sd, false)
 }
@@ -773,6 +791,15 @@ func (o *OIDC) Close() error {
 		}
 		o.bindStore = nil
 	}
+	// idTokens 独立 redis.Client(RP-Initiated Logout),New() 在 enabled 时创建。
+	// 与 bindStore 同样需在关闭路径释放,否则连接池 fd 泄漏。放在 stateStore nil
+	// 早返回之前,保证 stateStore 已被置 nil 的二次 Close 仍能关掉 idTokens。
+	if ridt, ok := o.idTokens.(*redisIDTokenStore); ok {
+		if err := ridt.Close(); err != nil {
+			o.Error("关闭 OIDC id_token store 失败", zap.Error(err))
+		}
+		o.idTokens = nil
+	}
 	if o.stateStore == nil {
 		return nil
 	}
@@ -789,8 +816,14 @@ func (o *OIDC) Close() error {
 // 理由:logout 客户端关心的是"我点了登出,本地已清空状态",对幂等性要求高于完美吊销。
 // 真正的兜底由 SyncWorker 的下次轮询补足(refresh 失败也会触发踢线)。
 //
-// IdP 端 RP-Initiated Logout(/end_session)由前端按需调用,后端不代理:
-// id_token_hint 在前端容易拿到,且跨域跳转更适合浏览器层面发起。
+// IdP 端 RP-Initiated Logout(/end_session)的跳转地址由后端拼好后随 200 响应返回
+// (end_session_url 字段),前端做顶层跳转。后端收口的原因:本架构 code→token 在
+// 服务端完成,前端从不持有 id_token,无法自行构造 id_token_hint;且 end_session 端点 /
+// 参数 / 回跳白名单集中在服务端更易维护。真正终止 Aegis 会话仍依赖浏览器顶层跳转
+// 携带 IdP 域 cookie,所以后端只给 URL,不代理跳转。
+//
+// 配置缺失(未配 PostLogoutRedirectURI / 无 end_session 端点 / 无缓存的 id_token)时
+// 省略 end_session_url,前端降级为仅清本地 —— 纯增量,不影响存量行为。
 func (o *OIDC) logout(c *wkhttp.Context) {
 	uid := c.GetLoginUID()
 	if uid == "" {
@@ -838,7 +871,63 @@ func (o *OIDC) logout(c *wkhttp.Context) {
 		IP:        util.GetClientPublicIP(c.Request),
 		UserAgent: c.Request.UserAgent(),
 	}, "")
-	c.JSON(http.StatusOK, map[string]interface{}{"status": 200})
+
+	resp := map[string]interface{}{"status": 200}
+	// 拼 IdP end_session 跳转地址(RP-Initiated Logout)。任一前置缺失时返回空串,
+	// 此时省略字段,前端降级为仅清本地。end_session_url 含 id_token,不写日志。
+	if endSessionURL := o.buildEndSessionURL(ctx, uid); endSessionURL != "" {
+		resp["end_session_url"] = endSessionURL
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+// endSessionEndpoint 解析 IdP 的 RP-Initiated Logout 端点:config override 优先,
+// 否则取 Discovery 解析值。两者皆空时返回空串(IdP 未声明且未配 override)。
+func (o *OIDC) endSessionEndpoint() string {
+	if o.cfg != nil && o.cfg.Provider.EndSessionURL != "" {
+		return o.cfg.Provider.EndSessionURL
+	}
+	if o.client != nil {
+		return o.client.EndSessionEndpoint()
+	}
+	return ""
+}
+
+// buildEndSessionURL 构造 RP-Initiated Logout 跳转地址,带 id_token_hint +
+// post_logout_redirect_uri。任一前置不满足返回空串(调用方据此省略字段、前端降级):
+//   - 未配置 PostLogoutRedirectURI(运维写死的回跳页,同时充当白名单);
+//   - idTokens 未注入 / 取不到该 uid 的 id_token(非 OIDC 登录 / 已过期 / 已消费);
+//   - 无可用 end_session 端点。
+//
+// 取出 id_token 即一次性消费(Take 内部删除)。不带 state(Aegis Discovery 未声明)。
+func (o *OIDC) buildEndSessionURL(ctx context.Context, uid string) string {
+	if o.cfg == nil || o.cfg.Provider.PostLogoutRedirectURI == "" || o.idTokens == nil {
+		return ""
+	}
+	endpoint := o.endSessionEndpoint()
+	if endpoint == "" {
+		return ""
+	}
+	idToken, err := o.idTokens.Take(ctx, uid)
+	if err != nil {
+		// 取 id_token 失败不阻断 logout(本地已踢线+吊销),仅降级跳过 IdP 跳转。
+		o.Warn("OIDC logout 取 id_token 失败,跳过 end_session 跳转", zap.Error(err))
+		return ""
+	}
+	if idToken == "" {
+		return ""
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		// 只记端点本身,不记含 id_token 的完整 URL。
+		o.Error("OIDC logout 解析 end_session 端点失败", zap.String("endpoint", endpoint), zap.Error(err))
+		return ""
+	}
+	q := u.Query()
+	q.Set("id_token_hint", idToken)
+	q.Set("post_logout_redirect_uri", o.cfg.Provider.PostLogoutRedirectURI)
+	u.RawQuery = q.Encode()
+	return u.String()
 }
 
 func (o *OIDC) failWithAuthcode(ctx context.Context, sd *StateData, claims *IDTokenClaims, err error) {

--- a/modules/oidc/api_bind.go
+++ b/modules/oidc/api_bind.go
@@ -335,6 +335,8 @@ func (o *OIDC) bindConfirm(c *wkhttp.Context) {
 		return
 	}
 	m.result = "ok"
+	// bind 完成,迁移 callback 阶段按 jti 暂存的 id_token 到 uid,供 logout 用。
+	o.promoteBindIDToken(ctx, req.Token, resp.UID)
 	// 回填原发起设备的 ThirdAuthcode key,让 A 设备的轮询能拿到 LoginRespJSON
 	// (FR-6.3 跨设备流转)。同设备时这一步与 response body 等价,前端任选其一。
 	// 写失败不致命:用户在 B 设备(当前)已经拿到了 LoginRespJSON。
@@ -483,6 +485,8 @@ func (o *OIDC) bindCreate(c *wkhttp.Context) {
 		return
 	}
 	m.result = "ok"
+	// bind 建号完成,迁移 callback 阶段按 jti 暂存的 id_token 到 uid,供 logout 用。
+	o.promoteBindIDToken(ctx, req.Token, resp.UID)
 	if resp.SD != nil && resp.SD.ClientAuthcode != "" && o.authcode != nil {
 		if e := o.authcode.SetAuthcode(ctx, resp.SD.ClientAuthcode,
 			resp.IssueResp.LoginRespJSON, thirdAuthcodeTTL); e != nil {

--- a/modules/oidc/api_bind_test.go
+++ b/modules/oidc/api_bind_test.go
@@ -715,6 +715,68 @@ func TestAPI_BindCreate_HappyPath(t *testing.T) {
 	}
 }
 
+// bind/confirm 成功后,应把 callback 阶段按 jti 暂存的 id_token 迁移到 uid 名下
+// (#215 review #2:bind 登录路径也要能拿到 end_session_url),并消费掉 jti 暂存项。
+func TestAPI_BindConfirm_PromotesIDToken(t *testing.T) {
+	o, jti, auth, loc, _, _, users, _ := newTestOIDCWithBindFull(t, defaultBindCfg(), sampleClaims(), false)
+	auth.verifyPasswordResp.matched = true
+	loc.byUsername["alice"] = "u-alice"
+	users.resp = &IssueSessionResp{UID: "u-alice", LoginRespJSON: `{"token":"t-alice"}`}
+	ids := newFakeIDTokenStore()
+	ids.tokens[bindIDTokenKey(jti)] = "raw-bind-idtoken" // 模拟 callback bind_pending 暂存
+	o.idTokens = ids
+	r := newTestBindRouter(o)
+
+	body, _ := json.Marshal(map[string]string{"token": jti, "identifier": "alice", "password": "Pwd@1"})
+	req := httptest.NewRequest("POST", "/v1/auth/oidc/aegis/bind/verify/password", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("verify status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	body2, _ := json.Marshal(map[string]string{"token": jti})
+	req2 := httptest.NewRequest("POST", "/v1/auth/oidc/aegis/bind/confirm", bytes.NewReader(body2))
+	req2.Header.Set("Content-Type", "application/json")
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("confirm status=%d body=%s", w2.Code, w2.Body.String())
+	}
+	if got := ids.get("u-alice"); got != "raw-bind-idtoken" {
+		t.Errorf("id_token not promoted to uid: got %q", got)
+	}
+	if ids.get(bindIDTokenKey(jti)) != "" {
+		t.Errorf("bind-pending id_token must be consumed after confirm")
+	}
+}
+
+// bind/create 成功后同样迁移暂存的 id_token 到新建 uid。
+func TestAPI_BindCreate_PromotesIDToken(t *testing.T) {
+	o, jti, _, _, _, _, users, _ := newTestOIDCWithBindFull(t, defaultBindCfg(), sampleClaims(), false)
+	users.resp = &IssueSessionResp{UID: "u-created", LoginRespJSON: `{"token":"t-created"}`}
+	ids := newFakeIDTokenStore()
+	ids.tokens[bindIDTokenKey(jti)] = "raw-bind-idtoken"
+	o.idTokens = ids
+	r := newTestBindRouter(o)
+
+	body, _ := json.Marshal(map[string]string{"token": jti})
+	req := httptest.NewRequest("POST", "/v1/auth/oidc/aegis/bind/create", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("create status=%d body=%s", w.Code, w.Body.String())
+	}
+	if got := ids.get("u-created"); got != "raw-bind-idtoken" {
+		t.Errorf("id_token not promoted to uid: got %q", got)
+	}
+	if ids.get(bindIDTokenKey(jti)) != "" {
+		t.Errorf("bind-pending id_token must be consumed after create")
+	}
+}
+
 // T31: token 缺失/非法 → 400
 func TestAPI_BindCreate_MissingToken(t *testing.T) {
 	o, _, _, _, _, _, _, _ := newTestOIDCWithBindFull(t, defaultBindCfg(), nil, true)

--- a/modules/oidc/config.go
+++ b/modules/oidc/config.go
@@ -72,6 +72,22 @@ type ProviderConfig struct {
 	// (DM_OIDC_RETURN_TO_HOSTS,逗号分隔)。空列表表示禁用 return_to,
 	// 防开放重定向是 P1.2 必须做的硬约束。
 	ReturnToHosts []string
+
+	// ---- RP-Initiated Logout(可选,#215)----
+
+	// PostLogoutRedirectURI logout 成功后让 IdP 回跳的地址(写死的登录页)。
+	// 空时 logout 不生成 end_session_url,前端退回"仅清本地"。安全考量:此值由
+	// 运维写死、不接受前端传入,因此无需在服务端再做 redirect 白名单 —— 单值即白名单。
+	// 上线前需在 IdP 侧注册该回跳地址。
+	PostLogoutRedirectURI string
+
+	// EndSessionURL 覆盖/兜底 IdP 的 end_session 端点。优先级高于 Discovery 解析值,
+	// 仅在 Discovery 未暴露 end_session_endpoint 时才需要配置。
+	EndSessionURL string
+
+	// IDTokenTTL callback 成功后缓存 id_token(供 logout 当 id_token_hint)的 TTL。
+	// 默认对齐 RT 生命周期(7d),覆盖用户登录后较长时间才登出的场景。
+	IDTokenTTL time.Duration
 }
 
 // LoadConfig 从环境变量加载 OIDC 配置
@@ -134,6 +150,11 @@ func loadProvider() (ProviderConfig, error) {
 		SyncConcurrency: getIntWithAlias("DM_OIDC_PROVIDER_SYNC_CONCURRENCY", "DM_OIDC_AEGIS_SYNC_CONCURRENCY", 10),
 
 		ReturnToHosts: getStringSlice("DM_OIDC_RETURN_TO_HOSTS", nil),
+
+		// RP-Initiated Logout(可选):缺省即禁用 end_session 跳转,纯增量不影响存量部署。
+		PostLogoutRedirectURI: getString("DM_OIDC_POST_LOGOUT_REDIRECT_URI", ""),
+		EndSessionURL:         getString("DM_OIDC_PROVIDER_END_SESSION_URL", ""),
+		IDTokenTTL:            getDurationWithAlias("DM_OIDC_PROVIDER_ID_TOKEN_TTL", "", 7*24*time.Hour),
 	}
 
 	// 用 slice 保证检查顺序稳定,缺多个字段时报第一项固定,排查体验更好。
@@ -159,6 +180,12 @@ func loadProvider() (ProviderConfig, error) {
 
 	if !providerIDRe.MatchString(p.ID) {
 		return p, fmt.Errorf("DM_OIDC_PROVIDER_ID %q invalid: must match %s", p.ID, providerIDRe)
+	}
+
+	// IDTokenTTL<=0 会让 Redis SET 的过期变成"永不过期"(go-redis 语义),id_token
+	// 密文将永久驻留。误配 0 / 负值时钳回默认 7d,杜绝该 footgun。
+	if p.IDTokenTTL <= 0 {
+		p.IDTokenTTL = 7 * 24 * time.Hour
 	}
 
 	keyB64 := getString("DM_OIDC_RT_ENC_KEY", "")

--- a/modules/oidc/config.go
+++ b/modules/oidc/config.go
@@ -152,9 +152,9 @@ func loadProvider() (ProviderConfig, error) {
 		ReturnToHosts: getStringSlice("DM_OIDC_RETURN_TO_HOSTS", nil),
 
 		// RP-Initiated Logout(可选):缺省即禁用 end_session 跳转,纯增量不影响存量部署。
-		PostLogoutRedirectURI: getString("DM_OIDC_POST_LOGOUT_REDIRECT_URI", ""),
-		EndSessionURL:         getString("DM_OIDC_PROVIDER_END_SESSION_URL", ""),
-		IDTokenTTL:            getDurationWithAlias("DM_OIDC_PROVIDER_ID_TOKEN_TTL", "", 7*24*time.Hour),
+		PostLogoutRedirectURI: getString("OCTO_OIDC_POST_LOGOUT_REDIRECT_URI", ""),
+		EndSessionURL:         getString("OCTO_OIDC_PROVIDER_END_SESSION_URL", ""),
+		IDTokenTTL:            getDurationWithAlias("OCTO_OIDC_PROVIDER_ID_TOKEN_TTL", "", 7*24*time.Hour),
 	}
 
 	// 用 slice 保证检查顺序稳定,缺多个字段时报第一项固定,排查体验更好。

--- a/modules/oidc/config.go
+++ b/modules/oidc/config.go
@@ -3,6 +3,7 @@ package oidc
 import (
 	"encoding/base64"
 	"fmt"
+	"net/url"
 	"os"
 	"regexp"
 	"strconv"
@@ -86,7 +87,9 @@ type ProviderConfig struct {
 	EndSessionURL string
 
 	// IDTokenTTL callback 成功后缓存 id_token(供 logout 当 id_token_hint)的 TTL。
-	// 默认对齐 RT 生命周期(7d),覆盖用户登录后较长时间才登出的场景。
+	// 默认对齐 RT 生命周期(7 天 = 168h),覆盖用户登录后较长时间才登出的场景。
+	// 注意 env 值用 time.ParseDuration 解析,只认 h/m/s —— 写 "7d" 会解析失败并静默
+	// 回落默认,要 7 天请填 "168h"。
 	IDTokenTTL time.Duration
 }
 
@@ -188,6 +191,16 @@ func loadProvider() (ProviderConfig, error) {
 		p.IDTokenTTL = 7 * 24 * time.Hour
 	}
 
+	// RP-Initiated Logout 的两个 URL 都会进浏览器顶层跳转(end_session 还携带 id_token),
+	// 启动期 fail-loud 校验为绝对 https,拦相对地址 / javascript: 等,杜绝误配把 token
+	// 发去任意域或在导航时执行脚本。与 validateBindRedirectBase 同模式。空值=功能未开,跳过。
+	if err := validateLogoutURL("OCTO_OIDC_POST_LOGOUT_REDIRECT_URI", p.PostLogoutRedirectURI); err != nil {
+		return p, err
+	}
+	if err := validateLogoutURL("OCTO_OIDC_PROVIDER_END_SESSION_URL", p.EndSessionURL); err != nil {
+		return p, err
+	}
+
 	keyB64 := getString("DM_OIDC_RT_ENC_KEY", "")
 	if keyB64 == "" {
 		return p, fmt.Errorf("required env DM_OIDC_RT_ENC_KEY is empty")
@@ -201,6 +214,33 @@ func loadProvider() (ProviderConfig, error) {
 	}
 	p.RefreshTokenEncryptionKey = key
 	return p, nil
+}
+
+// validateLogoutURL 启动期 fail-loud 校验 RP-Initiated Logout 相关 URL 为绝对 https。
+//
+// 空值视作"功能未开",直接放行(可选配置)。非空时必须是绝对地址且 https,拦
+// 相对地址 / javascript: / data: 等 —— 这两个值最终都会进浏览器顶层跳转,
+// EndSessionURL 还携带 id_token,误配会把 token 发去任意域或在导航时执行脚本。
+// 开发环境可用 OCTO_OIDC_LOGOUT_ALLOW_INSECURE=1 放宽到 http(与 bind 的同名机制对齐)。
+func validateLogoutURL(envName, raw string) error {
+	if raw == "" {
+		return nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("oidc: invalid %s %q: %w", envName, raw, err)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("oidc: %s %q must be absolute (scheme://host/path)", envName, raw)
+	}
+	if u.Scheme == "https" {
+		return nil
+	}
+	if u.Scheme == "http" && getBool("OCTO_OIDC_LOGOUT_ALLOW_INSECURE", false) {
+		return nil
+	}
+	return fmt.Errorf("oidc: %s %q must use https scheme "+
+		"(set OCTO_OIDC_LOGOUT_ALLOW_INSECURE=1 to allow http for dev)", envName, raw)
 }
 
 func getString(key, def string) string {

--- a/modules/oidc/config_test.go
+++ b/modules/oidc/config_test.go
@@ -311,8 +311,104 @@ func clearOIDCEnv(t *testing.T) {
 		"DM_OIDC_AEGIS_AUTO_LINK_BY_PHONE",
 		"DM_OIDC_AEGIS_ALLOW_NEW_USER",
 		"DM_OIDC_RT_ENC_KEY",
+		// RP-Initiated Logout(可选)
+		"OCTO_OIDC_POST_LOGOUT_REDIRECT_URI",
+		"OCTO_OIDC_PROVIDER_END_SESSION_URL",
+		"OCTO_OIDC_PROVIDER_ID_TOKEN_TTL",
+		"OCTO_OIDC_LOGOUT_ALLOW_INSECURE",
 	}
 	for _, k := range keys {
 		t.Setenv(k, "")
+	}
+}
+
+// setRequiredOIDCEnv 设齐 enabled + 必填项,供下面只想验单个可选项的用例复用。
+func setRequiredOIDCEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("DM_OIDC_ENABLED", "true")
+	t.Setenv("DM_OIDC_PROVIDER_ISSUER", "https://accounts.imocto.cn")
+	t.Setenv("DM_OIDC_PROVIDER_CLIENT_ID", "cid")
+	t.Setenv("DM_OIDC_PROVIDER_CLIENT_SECRET", "csecret")
+	t.Setenv("DM_OIDC_PROVIDER_REDIRECT_URI", "https://web.imocto.cn/cb")
+	t.Setenv("DM_OIDC_RT_ENC_KEY", base64.StdEncoding.EncodeToString(make([]byte, 32)))
+}
+
+// TTL:默认 7d=168h;合法 override 生效;"7d"(ParseDuration 不认 d)静默回落默认;
+// 0 / 负值被钳回默认 —— 杜绝 go-redis "永不过期" footgun。
+func TestLoadConfig_IDTokenTTL(t *testing.T) {
+	const def = 7 * 24 * time.Hour
+	cases := []struct {
+		name string
+		set  bool
+		val  string
+		want time.Duration
+	}{
+		{"default", false, "", def},
+		{"override 24h", true, "24h", 24 * time.Hour},
+		{"invalid 7d falls back", true, "7d", def},
+		{"zero clamped", true, "0", def},
+		{"negative clamped", true, "-5h", def},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearOIDCEnv(t)
+			setRequiredOIDCEnv(t)
+			if tc.set {
+				t.Setenv("OCTO_OIDC_PROVIDER_ID_TOKEN_TTL", tc.val)
+			}
+			cfg, err := LoadConfig()
+			if err != nil {
+				t.Fatalf("LoadConfig: %v", err)
+			}
+			if cfg.Provider.IDTokenTTL != tc.want {
+				t.Errorf("IDTokenTTL = %v, want %v", cfg.Provider.IDTokenTTL, tc.want)
+			}
+		})
+	}
+}
+
+// validateLogoutURL:空=放行(可选);绝对 https 放行;相对/javascript:/非 http(s) 拒绝;
+// http 仅在 OCTO_OIDC_LOGOUT_ALLOW_INSECURE=1 时放行。
+func TestValidateLogoutURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		raw      string
+		insecure bool
+		wantErr  bool
+	}{
+		{"empty ok", "", false, false},
+		{"https ok", "https://app.example.com/login", false, false},
+		{"relative rejected", "/login", false, true},
+		{"javascript rejected", "javascript:alert(1)", false, true},
+		{"ftp rejected", "ftp://host/x", false, true},
+		{"http rejected by default", "http://app.example.com/login", false, true},
+		{"http allowed with dev flag", "http://app.example.com/login", true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.insecure {
+				t.Setenv("OCTO_OIDC_LOGOUT_ALLOW_INSECURE", "1")
+			}
+			err := validateLogoutURL("OCTO_OIDC_POST_LOGOUT_REDIRECT_URI", tc.raw)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error for %q", tc.raw)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error for %q: %v", tc.raw, err)
+			}
+		})
+	}
+}
+
+// LoadConfig 对非法 logout URL 启动期 fail-loud(整模块拒绝加载)。
+func TestLoadConfig_RejectsInsecureLogoutURL(t *testing.T) {
+	clearOIDCEnv(t)
+	setRequiredOIDCEnv(t)
+	t.Setenv("OCTO_OIDC_POST_LOGOUT_REDIRECT_URI", "http://insecure.example.com/login")
+
+	if _, err := LoadConfig(); err == nil {
+		t.Fatal("expected LoadConfig to reject non-https post_logout_redirect_uri")
+	} else if !strings.Contains(err.Error(), "OCTO_OIDC_POST_LOGOUT_REDIRECT_URI") {
+		t.Errorf("error should name the offending env, got: %v", err)
 	}
 }

--- a/modules/oidc/logout_idtoken.go
+++ b/modules/oidc/logout_idtoken.go
@@ -107,3 +107,12 @@ func (s *redisIDTokenStore) Close() error {
 func idTokenKey(uid string) string {
 	return idTokenKeyPrefix + uid
 }
+
+// bindIDTokenKey 自助绑定接管阶段(bind_pending)的暂存键。
+//
+// bind 路径的 callback 还不知道最终 uid,无法按 uid 存;先按 bind token(jti)暂存,
+// confirm/create 拿到 uid 后再迁移(见 OIDC.promoteBindIDToken)。"bind:" 前缀与正常
+// 的 uid 键命名空间隔离 —— uid 不会以 "bind:" 开头。jti 本身已是 32B base64,无注入风险。
+func bindIDTokenKey(jti string) string {
+	return "bind:" + jti
+}

--- a/modules/oidc/logout_idtoken.go
+++ b/modules/oidc/logout_idtoken.go
@@ -1,0 +1,109 @@
+package oidc
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
+)
+
+// idTokenKeyPrefix RP-Initiated Logout 所需 id_token_hint 的 Redis key 前缀。
+// 按 uid 存一份(最近一次登录的 id_token);logout 原子取出并删除。
+const idTokenKeyPrefix = "oidc:idtoken:"
+
+// idTokenStore 存取 RP-Initiated Logout 所需的 id_token_hint。
+//
+// 生产实现把 id_token 加密后写 Redis,TTL 到期自动清理;测试注入内存 fake。
+// id_token 含 PII(email/phone/name)+ 是有效的 IdP 签名 JWT,因此必须加密落盘,
+// 与 refresh_token 在 DB 中加密存储的安全等级保持一致。
+type idTokenStore interface {
+	// Save 覆盖写 uid 当前的 id_token(空 uid / 空 token 视作 no-op,返回 nil)。
+	Save(ctx context.Context, uid, idToken string, ttl time.Duration) error
+	// Take 原子取出并删除 uid 的 id_token(一次性消费);未命中返回 ("", nil)。
+	Take(ctx context.Context, uid string) (string, error)
+}
+
+// redisIDTokenStore 生产实现。
+//
+// 与 redisStateStore 同构:持独立 *redis.Client(go-redis v6),用 Lua GETDEL 保证
+// "取出即作废"的原子性 —— 避免并发双击 logout 时同一 id_token 被取两次。
+// Read/WriteTimeout 提供命令级超时,网络分区时不阻塞 logout 路径。
+// 值为 base64(AES-256-GCM 密文),避免 id_token 在 Redis 明文落盘。
+type redisIDTokenStore struct {
+	client *rd.Client
+	enc    *Encryptor
+}
+
+func newRedisIDTokenStore(ctx *config.Context, enc *Encryptor) *redisIDTokenStore {
+	client := rd.NewClient(octoredis.MustBuildOptions(ctx.GetConfig(), func(o *rd.Options) {
+		o.MaxRetries = 3
+		o.ReadTimeout = 3 * time.Second
+		o.WriteTimeout = 3 * time.Second
+		o.DialTimeout = 3 * time.Second
+	}))
+	return &redisIDTokenStore{client: client, enc: enc}
+}
+
+// Save 接受 context.Context 满足接口契约,但 go-redis v6 的命令 API 不支持 context
+// 取消;cancellation 由 Read/WriteTimeout 替代(与 redisStateStore 一致)。
+func (s *redisIDTokenStore) Save(_ context.Context, uid, idToken string, ttl time.Duration) error {
+	if uid == "" || idToken == "" {
+		return nil
+	}
+	ct, err := s.enc.Encrypt([]byte(idToken))
+	if err != nil {
+		return fmt.Errorf("oidc: encrypt id_token: %w", err)
+	}
+	val := base64.StdEncoding.EncodeToString(ct)
+	if err := s.client.Set(idTokenKey(uid), val, ttl).Err(); err != nil {
+		return fmt.Errorf("oidc: redis set id_token: %w", err)
+	}
+	return nil
+}
+
+func (s *redisIDTokenStore) Take(_ context.Context, uid string) (string, error) {
+	if uid == "" {
+		return "", nil
+	}
+	// 复用 state_store_redis.go 的 luaGetDel:原子 GET+DEL,消除并发双取窗口。
+	res, err := luaGetDel.Run(s.client, []string{idTokenKey(uid)}).Result()
+	if err != nil {
+		if errors.Is(err, rd.Nil) {
+			return "", nil // 未命中:非 OIDC 登录 / 已过期 / 已消费
+		}
+		return "", fmt.Errorf("oidc: redis getdel id_token: %w", err)
+	}
+	raw, ok := res.(string)
+	if !ok || raw == "" {
+		return "", nil
+	}
+	ct, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		return "", fmt.Errorf("oidc: decode id_token: %w", err)
+	}
+	pt, err := s.enc.Decrypt(ct)
+	if err != nil {
+		return "", fmt.Errorf("oidc: decrypt id_token: %w", err)
+	}
+	return string(pt), nil
+}
+
+// Close 释放底层 Redis 连接池,在模块/进程优雅关闭时调用。
+func (s *redisIDTokenStore) Close() error {
+	if s == nil || s.client == nil {
+		return nil
+	}
+	if err := s.client.Close(); err != nil {
+		return fmt.Errorf("oidc: redis id_token store close: %w", err)
+	}
+	return nil
+}
+
+func idTokenKey(uid string) string {
+	return idTokenKeyPrefix + uid
+}

--- a/modules/oidc/logout_idtoken_test.go
+++ b/modules/oidc/logout_idtoken_test.go
@@ -91,6 +91,8 @@ func TestAPI_Logout_ReturnsEndSessionURL(t *testing.T) {
 	ids.tokens["u-1"] = "raw-id-token-xyz"
 	o.idTokens = ids
 	o.cfg.Provider.PostLogoutRedirectURI = "https://app.example.com/login"
+	// MockProvider 的 end_session 端点是 http(httptest),dev 放宽位允许 http。
+	t.Setenv("OCTO_OIDC_LOGOUT_ALLOW_INSECURE", "1")
 
 	w := runLogout(o, "u-1")
 	if w.Code != http.StatusOK {
@@ -129,6 +131,7 @@ func TestAPI_Logout_NoIDToken_OmitsURL(t *testing.T) {
 	o.revoker = revoker
 	o.idTokens = newFakeIDTokenStore() // 空
 	o.cfg.Provider.PostLogoutRedirectURI = "https://app.example.com/login"
+	t.Setenv("OCTO_OIDC_LOGOUT_ALLOW_INSECURE", "1") // 让流程走到 Take(端点是 http mock)
 
 	w := runLogout(o, "u-2")
 	if w.Code != http.StatusOK {
@@ -193,6 +196,7 @@ func TestAPI_Logout_TakeError_OmitsURL(t *testing.T) {
 	ids.takeErr = errors.New("redis down")
 	o.idTokens = ids
 	o.cfg.Provider.PostLogoutRedirectURI = "https://app.example.com/login"
+	t.Setenv("OCTO_OIDC_LOGOUT_ALLOW_INSECURE", "1") // 让流程走到 Take 才能触发 takeErr
 
 	w := runLogout(o, "u-e")
 	if w.Code != http.StatusOK {

--- a/modules/oidc/logout_idtoken_test.go
+++ b/modules/oidc/logout_idtoken_test.go
@@ -118,6 +118,10 @@ func TestAPI_Logout_ReturnsEndSessionURL(t *testing.T) {
 	if ids.get("u-1") != "" {
 		t.Errorf("id_token should be consumed (one-time) after logout")
 	}
+	// 含 id_token_hint 的响应必须禁缓存。
+	if got := w.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store", got)
+	}
 }
 
 // 没有存 id_token(非 OIDC 登录 / 已过期)时,logout 仍 200 + 踢线 + 吊销,

--- a/modules/oidc/logout_idtoken_test.go
+++ b/modules/oidc/logout_idtoken_test.go
@@ -3,6 +3,7 @@ package oidc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -177,6 +178,62 @@ func TestAPI_Logout_NilStore_OmitsURL(t *testing.T) {
 	}
 	if _, ok := decodeLogoutBody(t, w)["end_session_url"]; ok {
 		t.Errorf("end_session_url must be omitted when id_token store disabled")
+	}
+}
+
+// 取 id_token 出错(Redis 抖动)时,logout 仍 200 且省略 end_session_url —— 守住
+// "best-effort 降级"契约的 Take 错误分支。
+func TestAPI_Logout_TakeError_OmitsURL(t *testing.T) {
+	mp := NewMockProvider(t)
+	o := newTestOIDC(t, mp, &fakeUserLookup{}, newFakeIdentityStore())
+	o.killer = &fakeKiller{}
+	o.revoker = &fakeRevoker{}
+	ids := newFakeIDTokenStore()
+	ids.tokens["u-e"] = "tok"
+	ids.takeErr = errors.New("redis down")
+	o.idTokens = ids
+	o.cfg.Provider.PostLogoutRedirectURI = "https://app.example.com/login"
+
+	w := runLogout(o, "u-e")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (best-effort)", w.Code)
+	}
+	if _, ok := decodeLogoutBody(t, w)["end_session_url"]; ok {
+		t.Errorf("end_session_url must be omitted when Take errors")
+	}
+}
+
+// 缓存 id_token 出错(Save 失败)时,callback 仍完成登录(302)—— 守住 Save 错误分支
+// 不阻断登录的契约。
+func TestAPI_Callback_IDTokenSaveError_LoginStillSucceeds(t *testing.T) {
+	mp := NewMockProvider(t)
+	mp.PrepUser("sub-se", map[string]interface{}{
+		"email": "se@example.com", "email_verified": true, "name": "SE",
+	})
+	users := &fakeUserLookup{loginResp: &IssueSessionResp{UID: "u-se", LoginRespJSON: `{"token":"t-se"}`}}
+	store := newFakeIdentityStore()
+	_ = store.Insert(&IdentityModel{UID: "u-se", Issuer: mp.Issuer, Subject: "sub-se"})
+	o := newTestOIDC(t, mp, users, store)
+	ids := newFakeIDTokenStore()
+	ids.saveErr = errors.New("redis down")
+	o.idTokens = ids
+	r := newTestRouter(o)
+
+	req := httptest.NewRequest("GET", "/v1/auth/oidc/aegis/authorize?authcode=ac-se&return_to=/home", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	authURL, _ := url.Parse(w.Header().Get("Location"))
+	state := authURL.Query().Get("state")
+	mp.PrepCode("code-se", "sub-se", authURL.Query().Get("nonce"))
+
+	req2 := httptest.NewRequest("GET", "/v1/auth/oidc/aegis/callback?state="+state+"&code=code-se", nil)
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusFound {
+		t.Fatalf("login must still succeed despite id_token save error; status=%d body=%s", w2.Code, w2.Body.String())
+	}
+	if ids.get("u-se") != "" {
+		t.Errorf("save failed, so nothing should be stored for uid")
 	}
 }
 

--- a/modules/oidc/logout_idtoken_test.go
+++ b/modules/oidc/logout_idtoken_test.go
@@ -161,6 +161,77 @@ func TestAPI_Logout_NoRedirectConfig_OmitsURL(t *testing.T) {
 	}
 }
 
+// idTokens 未启用(nil,缺省未配 PostLogoutRedirectURI)时,logout 仍 200 且不返回
+// end_session_url —— 守住 #1 修复的降级路径。
+func TestAPI_Logout_NilStore_OmitsURL(t *testing.T) {
+	mp := NewMockProvider(t)
+	o := newTestOIDC(t, mp, &fakeUserLookup{}, newFakeIdentityStore())
+	o.killer = &fakeKiller{}
+	o.revoker = &fakeRevoker{}
+	o.idTokens = nil // 功能禁用
+	o.cfg.Provider.PostLogoutRedirectURI = "https://app.example.com/login"
+
+	w := runLogout(o, "u-x")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if _, ok := decodeLogoutBody(t, w)["end_session_url"]; ok {
+		t.Errorf("end_session_url must be omitted when id_token store disabled")
+	}
+}
+
+// 自助绑定接管(callback bind_pending)时,应按 bind token(jti)暂存 id_token,
+// 供 confirm/create 后迁移到 uid。校验暂存键 = bindIDTokenKey(redirect 的 token 参数)。
+func TestAPI_Callback_BindPending_StoresIDTokenUnderBindKey(t *testing.T) {
+	mp := NewMockProvider(t)
+	mp.PrepUser("sub-newcomer", map[string]interface{}{
+		"email": "nobody@example.com", "email_verified": true, "name": "Newcomer",
+	})
+	users := &fakeUserLookup{}
+	store := newFakeIdentityStore()
+	o := newTestOIDC(t, mp, users, store)
+	o.cfg.Provider.AllowNewUser = false
+	o.service = newService(o.cfg.Provider, store, users)
+	o.cfg.Bind = BindConfig{
+		Enabled: true, IssuerAllowlist: []string{mp.Issuer}, TokenTTL: time.Minute,
+		VerifyMax: 5, OTPSendMax: 3, ConfirmMax: 3, UIDFailPerDay: 10,
+		Methods:      []BindMethod{BindMethodPassword, BindMethodSMSOTP},
+		RedirectBase: "https://im.example.com/oidc/bind",
+	}
+	o.bind = newBindService(o.cfg.Bind, newMemoryBindStore(), &fakeBindAuth{}, &fakeBindLocator{
+		byUsername: map[string]string{}, byPhone: map[string][]string{},
+	})
+	ids := newFakeIDTokenStore()
+	o.idTokens = ids
+	r := newTestRouter(o)
+
+	req := httptest.NewRequest("GET", "/v1/auth/oidc/aegis/authorize?authcode=front-bind&return_to=/home", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	authURL, _ := url.Parse(w.Header().Get("Location"))
+	state := authURL.Query().Get("state")
+	mp.PrepCode("idp-code", "sub-newcomer", authURL.Query().Get("nonce"))
+
+	req2 := httptest.NewRequest("GET", "/v1/auth/oidc/aegis/callback?state="+state+"&code=idp-code", nil)
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusFound {
+		t.Fatalf("callback status=%d body=%s", w2.Code, w2.Body.String())
+	}
+	loc, _ := url.Parse(w2.Header().Get("Location"))
+	jti := loc.Query().Get("token")
+	if jti == "" {
+		t.Fatalf("bind redirect missing token; loc=%s", w2.Header().Get("Location"))
+	}
+	if got := ids.get(bindIDTokenKey(jti)); got == "" {
+		t.Errorf("id_token must be stashed under bind key %q during bind_pending", bindIDTokenKey(jti))
+	}
+	// 还没确定 uid,不应有 uid 键
+	if ids.get("u-newcomer") != "" {
+		t.Errorf("must not store under uid before confirm/create")
+	}
+}
+
 // callback 成功后应把验签过的 id_token 存进 idTokenStore,供后续 RP-Initiated Logout
 // 取用作 id_token_hint。存储失败不阻断登录(best-effort),此处只断言成功路径存了。
 func TestAPI_Callback_StoresIDTokenForLogout(t *testing.T) {

--- a/modules/oidc/logout_idtoken_test.go
+++ b/modules/oidc/logout_idtoken_test.go
@@ -1,0 +1,233 @@
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/gin-gonic/gin"
+)
+
+// fakeIDTokenStore 内存版 id_token_hint 存取,断言 logout 拼 URL 与一次性消费。
+type fakeIDTokenStore struct {
+	mu      sync.Mutex
+	tokens  map[string]string
+	saveErr error
+	takeErr error
+}
+
+func newFakeIDTokenStore() *fakeIDTokenStore {
+	return &fakeIDTokenStore{tokens: make(map[string]string)}
+}
+
+func (f *fakeIDTokenStore) Save(_ context.Context, uid, idToken string, _ time.Duration) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.saveErr != nil {
+		return f.saveErr
+	}
+	f.tokens[uid] = idToken
+	return nil
+}
+
+func (f *fakeIDTokenStore) Take(_ context.Context, uid string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.takeErr != nil {
+		return "", f.takeErr
+	}
+	v := f.tokens[uid]
+	delete(f.tokens, uid)
+	return v, nil
+}
+
+func (f *fakeIDTokenStore) get(uid string) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.tokens[uid]
+}
+
+// runLogout 模拟 AuthMiddleware 已校验,把 uid 注入 gin.Context 后调 logout handler。
+func runLogout(o *OIDC, uid string) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/v1/auth/oidc/aegis/logout", func(c *gin.Context) {
+		if uid != "" {
+			c.Set("uid", uid)
+		}
+		o.logout(wrapWk(c))
+	})
+	req := httptest.NewRequest("POST", "/v1/auth/oidc/aegis/logout", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func decodeLogoutBody(t *testing.T, w *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var m map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &m); err != nil {
+		t.Fatalf("decode logout body %q: %v", w.Body.String(), err)
+	}
+	return m
+}
+
+// 配置齐全(回跳地址 + end_session 端点 + 存有 id_token)时,logout 应在 200 响应里
+// 返回 end_session_url,带 id_token_hint + post_logout_redirect_uri,且 id_token 被消费。
+func TestAPI_Logout_ReturnsEndSessionURL(t *testing.T) {
+	mp := NewMockProvider(t)
+	o := newTestOIDC(t, mp, &fakeUserLookup{}, newFakeIdentityStore())
+	o.killer = &fakeKiller{}
+	o.revoker = &fakeRevoker{}
+	ids := newFakeIDTokenStore()
+	ids.tokens["u-1"] = "raw-id-token-xyz"
+	o.idTokens = ids
+	o.cfg.Provider.PostLogoutRedirectURI = "https://app.example.com/login"
+
+	w := runLogout(o, "u-1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	raw, _ := decodeLogoutBody(t, w)["end_session_url"].(string)
+	if raw == "" {
+		t.Fatalf("missing end_session_url; body=%s", w.Body.String())
+	}
+	if !strings.HasPrefix(raw, mp.Issuer+"/end_session") {
+		t.Errorf("end_session_url = %q, want prefix %q", raw, mp.Issuer+"/end_session")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse end_session_url: %v", err)
+	}
+	if got := u.Query().Get("id_token_hint"); got != "raw-id-token-xyz" {
+		t.Errorf("id_token_hint = %q, want raw-id-token-xyz", got)
+	}
+	if got := u.Query().Get("post_logout_redirect_uri"); got != "https://app.example.com/login" {
+		t.Errorf("post_logout_redirect_uri = %q", got)
+	}
+	if ids.get("u-1") != "" {
+		t.Errorf("id_token should be consumed (one-time) after logout")
+	}
+}
+
+// 没有存 id_token(非 OIDC 登录 / 已过期)时,logout 仍 200 + 踢线 + 吊销,
+// 但不返回 end_session_url —— 前端据此降级为仅清本地。
+func TestAPI_Logout_NoIDToken_OmitsURL(t *testing.T) {
+	mp := NewMockProvider(t)
+	o := newTestOIDC(t, mp, &fakeUserLookup{}, newFakeIdentityStore())
+	killer := &fakeKiller{}
+	revoker := &fakeRevoker{}
+	o.killer = killer
+	o.revoker = revoker
+	o.idTokens = newFakeIDTokenStore() // 空
+	o.cfg.Provider.PostLogoutRedirectURI = "https://app.example.com/login"
+
+	w := runLogout(o, "u-2")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if _, ok := decodeLogoutBody(t, w)["end_session_url"]; ok {
+		t.Errorf("end_session_url should be omitted when no id_token stored")
+	}
+	if got := killer.snapshot(); len(got) != 1 || got[0] != "u-2" {
+		t.Errorf("kick should still happen, got %v", got)
+	}
+}
+
+// 未配置 post_logout_redirect_uri 时,即便有 id_token 也不返回 end_session_url。
+func TestAPI_Logout_NoRedirectConfig_OmitsURL(t *testing.T) {
+	mp := NewMockProvider(t)
+	o := newTestOIDC(t, mp, &fakeUserLookup{}, newFakeIdentityStore())
+	o.killer = &fakeKiller{}
+	o.revoker = &fakeRevoker{}
+	ids := newFakeIDTokenStore()
+	ids.tokens["u-3"] = "tok"
+	o.idTokens = ids
+	// PostLogoutRedirectURI 默认空
+
+	w := runLogout(o, "u-3")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if _, ok := decodeLogoutBody(t, w)["end_session_url"]; ok {
+		t.Errorf("end_session_url should be omitted when redirect URI not configured")
+	}
+}
+
+// callback 成功后应把验签过的 id_token 存进 idTokenStore,供后续 RP-Initiated Logout
+// 取用作 id_token_hint。存储失败不阻断登录(best-effort),此处只断言成功路径存了。
+func TestAPI_Callback_StoresIDTokenForLogout(t *testing.T) {
+	mp := NewMockProvider(t)
+	mp.PrepUser("sub-LT", map[string]interface{}{
+		"email":          "lt@example.com",
+		"email_verified": true,
+		"name":           "LT",
+	})
+	users := &fakeUserLookup{
+		loginResp: &IssueSessionResp{UID: "u-lt", LoginRespJSON: `{"token":"t-lt"}`},
+	}
+	store := newFakeIdentityStore()
+	_ = store.Insert(&IdentityModel{UID: "u-lt", Issuer: mp.Issuer, Subject: "sub-LT"})
+
+	o := newTestOIDC(t, mp, users, store)
+	ids := newFakeIDTokenStore()
+	o.idTokens = ids
+	r := newTestRouter(o)
+
+	req := httptest.NewRequest("GET", "/v1/auth/oidc/aegis/authorize?authcode=ac-lt&return_to=/home", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	authURL, _ := url.Parse(w.Header().Get("Location"))
+	state := authURL.Query().Get("state")
+	mp.PrepCode("code-lt", "sub-LT", authURL.Query().Get("nonce"))
+
+	req2 := httptest.NewRequest("GET", "/v1/auth/oidc/aegis/callback?state="+state+"&code=code-lt", nil)
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, body=%s", w2.Code, w2.Body.String())
+	}
+	if ids.get("u-lt") == "" {
+		t.Errorf("expected id_token stored for uid u-lt after successful callback")
+	}
+}
+
+// buildEndSessionURL 直接单测:EndSessionURL override 生效;已带 query 的端点要保留;
+// id_token_hint / post_logout_redirect_uri 中的特殊字符要正确转义。
+func TestBuildEndSessionURL_OverrideAndEscaping(t *testing.T) {
+	ids := newFakeIDTokenStore()
+	ids.tokens["u"] = "tok with space&amp"
+	o := &OIDC{
+		Log:      log.NewTLog("OIDC-test"),
+		idTokens: ids,
+		cfg: &Config{Provider: ProviderConfig{
+			EndSessionURL:         "https://idp.example.com/end?foo=bar",
+			PostLogoutRedirectURI: "https://app.example.com/login?next=/x y",
+		}},
+	}
+	got := o.buildEndSessionURL(context.Background(), "u")
+	if got == "" {
+		t.Fatal("buildEndSessionURL returned empty")
+	}
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	q := u.Query()
+	if q.Get("foo") != "bar" {
+		t.Errorf("pre-existing query foo=bar lost: %q", got)
+	}
+	if q.Get("id_token_hint") != "tok with space&amp" {
+		t.Errorf("id_token_hint not round-tripped: %q", q.Get("id_token_hint"))
+	}
+	if q.Get("post_logout_redirect_uri") != "https://app.example.com/login?next=/x y" {
+		t.Errorf("post_logout_redirect_uri not round-tripped: %q", q.Get("post_logout_redirect_uri"))
+	}
+}

--- a/modules/oidc/mock_provider.go
+++ b/modules/oidc/mock_provider.go
@@ -165,6 +165,7 @@ func (m *MockProvider) handleDiscovery(w http.ResponseWriter, _ *http.Request) {
 		"authorization_endpoint":                m.Issuer + "/authorize",
 		"token_endpoint":                        m.Issuer + "/oauth/token",
 		"userinfo_endpoint":                     m.Issuer + "/userinfo",
+		"end_session_endpoint":                  m.Issuer + "/end_session",
 		"jwks_uri":                              m.Issuer + "/keys",
 		"response_types_supported":              []string{"code"},
 		"subject_types_supported":               []string{"public"},

--- a/modules/oidc/oidc_client.go
+++ b/modules/oidc/oidc_client.go
@@ -145,6 +145,11 @@ type Client struct {
 	verifier *oidc.IDTokenVerifier
 	oauth2   *oauth2.Config
 	http     *http.Client
+
+	// endSession 从 Discovery 文档的 end_session_endpoint 解出(RP-Initiated Logout)。
+	// go-oidc 的 Provider 只暴露 auth/token/userinfo/jwks,end_session 需要额外
+	// 从原始 metadata claims 取。Discovery 未声明时为空,logout 退回 config override 或降级。
+	endSession string
 }
 
 // NewClient 走 Discovery 拉 issuer metadata,构造 Client。
@@ -172,6 +177,14 @@ func NewClient(ctx context.Context, cfg ClientConfig) (*Client, error) {
 			return time.Now().Add(-skew)
 		},
 	})
+
+	// end_session_endpoint 不在 go-oidc 的 Provider 公开字段里,从原始 Discovery
+	// metadata 解。解析失败/字段缺失时留空 —— 不阻断 Client 构造,logout 自行降级。
+	var extra struct {
+		EndSessionEndpoint string `json:"end_session_endpoint"`
+	}
+	_ = provider.Claims(&extra)
+
 	return &Client{
 		cfg:      cfg,
 		provider: provider,
@@ -183,9 +196,14 @@ func NewClient(ctx context.Context, cfg ClientConfig) (*Client, error) {
 			Endpoint:     provider.Endpoint(),
 			Scopes:       cfg.Scopes,
 		},
-		http: hc,
+		http:       hc,
+		endSession: extra.EndSessionEndpoint,
 	}, nil
 }
+
+// EndSessionEndpoint 返回 Discovery 暴露的 RP-Initiated Logout 端点;
+// IdP 未声明时返回空字符串。
+func (c *Client) EndSessionEndpoint() string { return c.endSession }
 
 // Issuer 返回 issuer URL(便于断言/审计)。
 func (c *Client) Issuer() string { return c.cfg.Issuer }

--- a/modules/oidc/oidc_client_test.go
+++ b/modules/oidc/oidc_client_test.go
@@ -50,6 +50,16 @@ func TestClient_Discover(t *testing.T) {
 	}
 }
 
+// EndSessionEndpoint 应从 Discovery 文档的 end_session_endpoint 解出,
+// 供 logout 拼 RP-Initiated Logout URL。
+func TestClient_EndSessionEndpoint_FromDiscovery(t *testing.T) {
+	mp := NewMockProvider(t)
+	c := newTestClient(t, mp)
+	if got, want := c.EndSessionEndpoint(), mp.Issuer+"/end_session"; got != want {
+		t.Errorf("EndSessionEndpoint() = %q, want %q", got, want)
+	}
+}
+
 // Cycle 6 RED: 用 refresh_token 换新 token。
 func TestClient_Refresh(t *testing.T) {
 	mp := NewMockProvider(t)


### PR DESCRIPTION
## Summary

Implements **RP-Initiated Logout** for OIDC login: the backend now hands the
frontend a ready-to-use `end_session_url` so a logout can terminate **both** the
local Octo session **and** the IdP (Aegis) browser SSO session.

Why backend-owned: the `code → token` exchange happens server-side, so the
frontend never holds the `id_token` and cannot build the `id_token_hint` itself.
The backend caches the verified `id_token` at login and assembles the
`end_session` URL at logout. Companion frontend issue: Mininglamp-OSS/octo-web#184.

## Changes

- **`oidc_client.go`** — resolve `end_session_endpoint` from discovery
  (`provider.Claims`), expose `EndSessionEndpoint()`.
- **callback** — on success (both the direct `IssueSession` path and the
  self-service **bind** path), cache the verified `id_token` **AES-256-GCM
  encrypted** in Redis. The bind path stashes it under a bind-token (`jti`) key
  at `bind_pending` and promotes it to the `uid` key on `/bind/confirm` or
  `/bind/create` success (one-time consumed).
- **`logout`** — kick + revoke unchanged; now also returns `end_session_url`
  (`id_token_hint` + a server-configured `post_logout_redirect_uri`). The
  `id_token` is consumed atomically (Lua GETDEL).
- **config** — three new **optional** env vars (see below).

## Configuration (new, all optional)

| Env | Default | Purpose |
|-----|---------|---------|
| `OCTO_OIDC_POST_LOGOUT_REDIRECT_URI` | `""` (feature **off**) | Post-logout redirect target (a hard-coded login page). Acts as the master switch **and** the redirect allowlist — it is never taken from the request body. |
| `OCTO_OIDC_PROVIDER_END_SESSION_URL` | `""` | Override/fallback for the IdP `end_session` endpoint; only needed if discovery omits `end_session_endpoint`. |
| `OCTO_OIDC_PROVIDER_ID_TOKEN_TTL` | `168h` (7d) | TTL for the cached `id_token`; clamped to `>0` to avoid a never-expiring key. Parsed by `time.ParseDuration` (no `d` unit — use `168h`, not `7d`). |

## Backward compatibility

Purely additive and **opt-in**:

- With `OCTO_OIDC_POST_LOGOUT_REDIRECT_URI` unset (default), the `id_token`
  store is **not** constructed — no PII-bearing JWT is persisted, no extra
  Redis connection pool — and `logout` returns exactly the prior
  `{"status":200}`. Behavior is byte-for-byte unchanged.
- The only API-contract change is an **optional** additional field
  (`end_session_url`) on the logout response; JSON consumers ignore unknown
  fields.
- No SQL / migration / schema changes. No new required config. No changes
  outside `modules/oidc/`.

## Security

- `id_token` is encrypted at rest (same key derivation as the refresh token)
  and **never logged** (nor is the assembled URL that embeds it).
- `post_logout_redirect_uri` is server-side hard-coded, so it doubles as the
  allowlist (no open-redirect surface from the request body).

## Testing

- `go test ./modules/oidc -race` (unit + integration) — pass.
- `gofmt` / `go vet` clean; D23 `lint-direct-error-response` gate — no new
  direct error responses.
- New coverage: discovery `end_session_endpoint` parsing; logout URL build /
  escaping / one-time consume; degrade paths (no id_token / no redirect config /
  store disabled); callback caches id_token; bind `confirm`/`create` promote the
  stashed id_token to uid.

## Ops prerequisites (before enabling in an environment)

- [ ] Register the `post_logout_redirect_uri` on the Aegis side (IdP logout
      redirect allowlist).
- [ ] Confirm whether Aegis `end_session` requires `id_token_hint`.

Closes #215

