### PR TITLE
feat(i18n): migrate OIDC bind flow to ResponseErrorL (Part of #170)

### DIFF
--- a/modules/oidc/api.go
+++ b/modules/oidc/api.go
@@ -317,22 +317,28 @@ func (o *OIDC) authorize(c *wkhttp.Context) {
 	}
 	cleanReturnTo, err := ValidateReturnTo(c.Query("return_to"), o.cfg.Provider.ReturnToHosts)
 	if err != nil {
-		c.AbortWithStatusJSON(http.StatusBadRequest, errMsg(err.Error()))
+		// 不回显 err.Error():ValidateReturnTo 的消息可能 echo 客户端传入的
+		// return_to,避免把请求原文反射进响应(纵深防御)。
+		c.AbortWithStatusJSON(http.StatusBadRequest, errMsg("invalid return_to"))
 		return
 	}
 	state, err := NewRandomString(32)
 	if err != nil {
-		c.AbortWithStatusJSON(http.StatusInternalServerError, errMsg(err.Error()))
+		// 5xx 不向浏览器暴露内部错误细节,具体原因仅记日志。
+		o.Error("OIDC authorize: generate state failed", zap.Error(err))
+		c.AbortWithStatusJSON(http.StatusInternalServerError, errMsg("internal error"))
 		return
 	}
 	nonce, err := NewRandomString(32)
 	if err != nil {
-		c.AbortWithStatusJSON(http.StatusInternalServerError, errMsg(err.Error()))
+		o.Error("OIDC authorize: generate nonce failed", zap.Error(err))
+		c.AbortWithStatusJSON(http.StatusInternalServerError, errMsg("internal error"))
 		return
 	}
 	verifier, challenge, err := NewPKCEPair()
 	if err != nil {
-		c.AbortWithStatusJSON(http.StatusInternalServerError, errMsg(err.Error()))
+		o.Error("OIDC authorize: generate PKCE pair failed", zap.Error(err))
+		c.AbortWithStatusJSON(http.StatusInternalServerError, errMsg("internal error"))
 		return
 	}
 	deviceFlag := defaultDeviceFlag
@@ -358,7 +364,8 @@ func (o *OIDC) authorize(c *wkhttp.Context) {
 	}
 	authURL, err := o.client.AuthCodeURL(state, nonce, challenge)
 	if err != nil {
-		c.AbortWithStatusJSON(http.StatusInternalServerError, errMsg(err.Error()))
+		o.Error("OIDC authorize: build auth code URL failed", zap.Error(err))
+		c.AbortWithStatusJSON(http.StatusInternalServerError, errMsg("internal error"))
 		return
 	}
 	// EventAuthorize 不携带 uid(此时尚未拿到 IdP claims),仅用于审计统计:

--- a/modules/oidc/api_bind.go
+++ b/modules/oidc/api_bind.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"go.uber.org/zap"
 )
 
@@ -62,7 +63,7 @@ func (o *OIDC) guardBindReady(c *wkhttp.Context, m *bindMetricRecord) bool {
 		return false
 	}
 	m.result = "not_ready"
-	c.AbortWithStatusJSON(http.StatusServiceUnavailable, errMsg("bind service not ready"))
+	respondBindError(c, errcode.ErrOIDCBindServiceUnavailable)
 	return true
 }
 
@@ -118,7 +119,7 @@ func (o *OIDC) bindInfo(c *wkhttp.Context) {
 	token := c.Query("token")
 	if !authcodeRe.MatchString(token) {
 		m.result = "bad_request"
-		c.AbortWithStatusJSON(http.StatusBadRequest, errMsg("token invalid"))
+		respondBindError(c, errcode.ErrOIDCBindRequestInvalid)
 		return
 	}
 	info, err := o.bind.Info(c.Request.Context(), token)
@@ -153,12 +154,12 @@ func (o *OIDC) bindVerifyPassword(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		m.result = "bad_request"
-		c.AbortWithStatusJSON(http.StatusBadRequest, errMsg("invalid request body"))
+		respondBindError(c, errcode.ErrOIDCBindRequestInvalid)
 		return
 	}
 	if !authcodeRe.MatchString(req.Token) || req.Identifier == "" || req.Password == "" {
 		m.result = "bad_request"
-		c.AbortWithStatusJSON(http.StatusBadRequest, errMsg("token/identifier/password required"))
+		respondBindError(c, errcode.ErrOIDCBindRequestInvalid)
 		return
 	}
 	err := o.bind.VerifyPassword(c.Request.Context(), req.Token, req.Identifier, req.Password)
@@ -194,7 +195,7 @@ func (o *OIDC) bindOTPSend(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil || !authcodeRe.MatchString(req.Token) {
 		m.result = "bad_request"
-		c.AbortWithStatusJSON(http.StatusBadRequest, errMsg("token required"))
+		respondBindError(c, errcode.ErrOIDCBindRequestInvalid)
 		return
 	}
 	err := o.bind.SendSMS(c.Request.Context(), req.Token)
@@ -228,12 +229,12 @@ func (o *OIDC) bindOTPCheck(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		m.result = "bad_request"
-		c.AbortWithStatusJSON(http.StatusBadRequest, errMsg("invalid request body"))
+		respondBindError(c, errcode.ErrOIDCBindRequestInvalid)
 		return
 	}
 	if !authcodeRe.MatchString(req.Token) || req.Code == "" {
 		m.result = "bad_request"
-		c.AbortWithStatusJSON(http.StatusBadRequest, errMsg("token/code required"))
+		respondBindError(c, errcode.ErrOIDCBindRequestInvalid)
 		return
 	}
 	err := o.bind.VerifySMS(c.Request.Context(), req.Token, req.Code)
@@ -254,12 +255,12 @@ func (o *OIDC) bindOTPCheck(c *wkhttp.Context) {
 // 单独抽出来是因为多个 handler 共用同一组语义(token 不存在 → 410)。
 func (o *OIDC) handleBindLookupErr(c *wkhttp.Context, path, token string, err error) {
 	if errors.Is(err, ErrBindNotFound) {
-		c.AbortWithStatusJSON(http.StatusGone, errMsg("token expired or not found"))
+		respondBindError(c, errcode.ErrOIDCBindTokenInvalid)
 		return
 	}
 	o.Warn("OIDC bind lookup error",
 		zap.String("path", path), zap.String("token_hash", subHash(token)), zap.Error(err))
-	c.AbortWithStatusJSON(http.StatusInternalServerError, errMsg("internal error"))
+	respondBindError(c, codeSharedInternal)
 }
 
 // handleBindVerifyErr verify(密码 / 短信)路径上的统一错误码翻译。
@@ -267,33 +268,33 @@ func (o *OIDC) handleBindLookupErr(c *wkhttp.Context, path, token string, err er
 func (o *OIDC) handleBindVerifyErr(c *wkhttp.Context, path, token string, err error) {
 	switch {
 	case errors.Is(err, ErrBindNotFound):
-		c.AbortWithStatusJSON(http.StatusGone, errMsg("token expired or not found"))
+		respondBindError(c, errcode.ErrOIDCBindTokenInvalid)
 	case errors.Is(err, ErrBindRateLimited):
-		c.AbortWithStatusJSON(http.StatusTooManyRequests, errMsg("too many attempts, try later"))
+		respondBindError(c, codeSharedRateLimited)
 	case errors.Is(err, ErrBindStatusConflict):
 		// status 不可推:多半是重复 verify,客户端应当跳过直接走 confirm。
-		c.AbortWithStatusJSON(http.StatusConflict, errMsg("already verified"))
+		respondBindError(c, errcode.ErrOIDCBindAlreadyVerified)
 	case errors.Is(err, ErrBindConflictNeedManual):
 		// 多 dmwork 账号对应同 phone:自助流程无法判定,提示走 Admin 兜底。
-		c.AbortWithStatusJSON(http.StatusConflict, errMsg("multiple accounts matched; contact support"))
+		respondBindError(c, errcode.ErrOIDCBindConflictNeedManual)
 	case errors.Is(err, ErrBindNoPhone):
 		// claims 无 phone 但客户端硬调 /verify/otp/check —— 业务前提不满足。
 		// metric (bindResultFromErr) 已归到 bad_request,HTTP 同步 400 保持一致。
-		c.AbortWithStatusJSON(http.StatusBadRequest, errMsg("sms not available for this account"))
+		respondBindError(c, errcode.ErrOIDCBindSMSUnavailable)
 	case errors.Is(err, ErrBindMethodDisabled):
 		// 运维通过 OCTO_OIDC_BIND_METHODS 关了该方法 —— 客户端不应再 retry。
-		c.AbortWithStatusJSON(http.StatusBadRequest, errMsg("verification method disabled"))
+		respondBindError(c, errcode.ErrOIDCBindMethodDisabled)
 	case errors.Is(err, ErrBindAuthRejected):
 		// 业务拒绝(密码错 / OTP 错 / phone 不命中):统一 401 防账号枚举。
 		// 具体 reason 走 zap,客户端只看到通用文案。
 		o.Info("OIDC bind verify rejected",
 			zap.String("path", path), zap.String("token_hash", subHash(token)), zap.Error(err))
-		c.AbortWithStatusJSON(http.StatusUnauthorized, errMsg("invalid credentials"))
+		respondBindError(c, errcode.ErrOIDCBindInvalidCredentials)
 	default:
 		// 未分类 → 500。bindResultFromErr 同步落 internal_error,告警阈值对齐。
 		o.Error("OIDC bind verify internal error",
 			zap.String("path", path), zap.String("token_hash", subHash(token)), zap.Error(err))
-		c.AbortWithStatusJSON(http.StatusInternalServerError, errMsg("internal error"))
+		respondBindError(c, codeSharedInternal)
 	}
 }
 
@@ -324,7 +325,7 @@ func (o *OIDC) bindConfirm(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil || !authcodeRe.MatchString(req.Token) {
 		m.result = "bad_request"
-		c.AbortWithStatusJSON(http.StatusBadRequest, errMsg("token required"))
+		respondBindError(c, errcode.ErrOIDCBindRequestInvalid)
 		return
 	}
 	ctx := c.Request.Context()
@@ -368,26 +369,25 @@ func (o *OIDC) handleBindConfirmErr(c *wkhttp.Context, token string, err error) 
 	switch {
 	case errors.Is(err, ErrBindNotFound):
 		o.writeAudit("bind:"+tokenHash, EventBindConfirmFail, stateFromCtx(c), "token expired or not found")
-		c.AbortWithStatusJSON(http.StatusGone, errMsg("token expired or not found"))
+		respondBindError(c, errcode.ErrOIDCBindTokenInvalid)
 	case errors.Is(err, ErrBindRateLimited):
 		o.writeAudit("bind:"+tokenHash, EventBindConfirmFail, stateFromCtx(c), "rate limited")
-		c.AbortWithStatusJSON(http.StatusTooManyRequests, errMsg("too many confirm attempts"))
+		respondBindError(c, codeSharedRateLimited)
 	case errors.Is(err, ErrBindStatusConflict):
 		// 状态不是 verified —— 用户跳过了二次验证,或并发 confirm 撞上(AC-6)。
 		o.writeAudit("bind:"+tokenHash, EventBindConfirmFail, stateFromCtx(c), "status conflict")
-		c.AbortWithStatusJSON(http.StatusUnauthorized, errMsg("verify before confirm"))
+		respondBindError(c, errcode.ErrOIDCBindVerifyRequired)
 	case errors.Is(err, ErrBindAlreadyBound):
 		// 重试 confirm 命中已写 identity 的常见路径(IssueSession 失败后 retry);
 		// 文案引导用户回 OIDC 入口而不是放弃。
 		o.writeAudit("bind:"+tokenHash, EventBindConfirmFail, stateFromCtx(c), "already bound")
-		c.AbortWithStatusJSON(http.StatusConflict,
-			errMsg("identity already bound; sign in again via OIDC to continue"))
+		respondBindError(c, errcode.ErrOIDCBindAlreadyBound)
 	case errors.Is(err, ErrBindAuthRejected):
 		// TOCTOU 复核失败:verify→confirm 之间账号被停用/进入冷静期。
 		// 401 + 通用文案与 verify 路径反枚举一致(不暴露"账号被运维停用"差异);
 		// audit reason 写明区分让 SOC 在 oidc_audit_log 里能区分本因。
 		o.writeAudit("bind:"+tokenHash, EventBindConfirmFail, stateFromCtx(c), "candidate uid not bindable")
-		c.AbortWithStatusJSON(http.StatusUnauthorized, errMsg("invalid credentials"))
+		respondBindError(c, errcode.ErrOIDCBindInvalidCredentials)
 	default:
 		o.Error("OIDC bind confirm failed (internal)",
 			zap.String("token_hash", tokenHash), zap.Error(err))
@@ -395,7 +395,7 @@ func (o *OIDC) handleBindConfirmErr(c *wkhttp.Context, token string, err error) 
 		// 未来误把第三方 wrap 进来意外注入大字符串/凭据片段。256 字符上限和
 		// 其他 callback 失败审计一致(api.go:38)。
 		o.writeAudit("bind:"+tokenHash, EventBindConfirmFail, stateFromCtx(c), auditReason(err.Error()))
-		c.AbortWithStatusJSON(http.StatusInternalServerError, errMsg("internal error"))
+		respondBindError(c, codeSharedInternal)
 	}
 }
 
@@ -474,7 +474,7 @@ func (o *OIDC) bindCreate(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil || !authcodeRe.MatchString(req.Token) {
 		m.result = "bad_request"
-		c.AbortWithStatusJSON(http.StatusBadRequest, errMsg("token required"))
+		respondBindError(c, errcode.ErrOIDCBindRequestInvalid)
 		return
 	}
 	ctx := c.Request.Context()
@@ -509,34 +509,32 @@ func (o *OIDC) handleBindCreateErr(c *wkhttp.Context, token string, err error) {
 	switch {
 	case errors.Is(err, ErrBindNotFound):
 		o.writeAudit("bind:"+tokenHash, EventBindCreateFail, stateFromCtx(c), "token expired or not found")
-		c.AbortWithStatusJSON(http.StatusGone, errMsg("token expired or not found"))
+		respondBindError(c, errcode.ErrOIDCBindTokenInvalid)
 	case errors.Is(err, ErrBindRateLimited):
 		o.writeAudit("bind:"+tokenHash, EventBindCreateFail, stateFromCtx(c), "rate limited")
-		c.AbortWithStatusJSON(http.StatusTooManyRequests, errMsg("too many create attempts"))
+		respondBindError(c, codeSharedRateLimited)
 	case errors.Is(err, ErrBindStatusConflict):
 		o.writeAudit("bind:"+tokenHash, EventBindCreateFail, stateFromCtx(c), "status conflict")
-		c.AbortWithStatusJSON(http.StatusConflict, errMsg("token status conflict"))
+		respondBindError(c, errcode.ErrOIDCBindStatusConflict)
 	case errors.Is(err, ErrBindAlreadyBound):
 		// Identity 行已存在(并发 /bind/create 同 (issuer,sub) 触发了竞态)。
 		// 赢家已签发会话;此处只引导客户端重发起 OIDC 登录以拾取赢家会话。
 		// Ghost user 清理(输家创建的 dmwork user)不在本 PR 范围,见 plan §4/§15。
 		o.writeAudit("bind:"+tokenHash, EventBindCreateFail, stateFromCtx(c), "already bound")
-		c.AbortWithStatusJSON(http.StatusConflict,
-			errMsg("identity already bound; sign in via OIDC to continue"))
+		respondBindError(c, errcode.ErrOIDCBindAlreadyBound)
 	case errors.Is(err, ErrBindCreateClaimsIncomplete):
 		o.writeAudit("bind:"+tokenHash, EventBindCreateFail, stateFromCtx(c), "claims incomplete")
-		c.AbortWithStatusJSON(http.StatusUnprocessableEntity, errMsg("claims missing required fields"))
+		respondBindError(c, errcode.ErrOIDCBindClaimsIncomplete)
 	case errors.Is(err, ErrBindCreateConflictNeedManual):
 		// manual-conflict token:claims 命中多条 dmwork 账号,/bind/create
 		// 不允许重复建号,引导走 Admin 人工合并兜底(与 verify 多匹配同语义)。
 		o.writeAudit("bind:"+tokenHash, EventBindCreateFail, stateFromCtx(c), "conflict need manual")
-		c.AbortWithStatusJSON(http.StatusConflict,
-			errMsg("account conflict needs manual resolution"))
+		respondBindError(c, errcode.ErrOIDCBindConflictNeedManual)
 	default:
 		o.Error("OIDC bind create failed (internal)",
 			zap.String("token_hash", tokenHash), zap.Error(err))
 		o.writeAudit("bind:"+tokenHash, EventBindCreateFail, stateFromCtx(c), auditReason(err.Error()))
-		c.AbortWithStatusJSON(http.StatusInternalServerError, errMsg("internal error"))
+		respondBindError(c, codeSharedInternal)
 	}
 }
 
@@ -602,18 +600,18 @@ func (l dbBindLocator) UIDsByPhone(zone, phone string) ([]string, error) {
 func (o *OIDC) handleBindOTPSendErr(c *wkhttp.Context, token string, err error) {
 	switch {
 	case errors.Is(err, ErrBindNotFound):
-		c.AbortWithStatusJSON(http.StatusGone, errMsg("token expired or not found"))
+		respondBindError(c, errcode.ErrOIDCBindTokenInvalid)
 	case errors.Is(err, ErrBindRateLimited):
-		c.AbortWithStatusJSON(http.StatusTooManyRequests, errMsg("too many otp sends, try later"))
+		respondBindError(c, codeSharedRateLimited)
 	case errors.Is(err, ErrBindNoPhone):
 		// 业务前提不满足:前端应改走密码手段,不要 retry SMS。
-		c.AbortWithStatusJSON(http.StatusBadRequest, errMsg("sms not available for this account"))
+		respondBindError(c, errcode.ErrOIDCBindSMSUnavailable)
 	case errors.Is(err, ErrBindMethodDisabled):
-		c.AbortWithStatusJSON(http.StatusBadRequest, errMsg("verification method disabled"))
+		respondBindError(c, errcode.ErrOIDCBindMethodDisabled)
 	default:
 		// SMSService 内部 / 网络异常:5xx 报给客户端,运维 dashboard 可见。
 		o.Error("OIDC bind otp send failed (internal)",
 			zap.String("token_hash", subHash(token)), zap.Error(err))
-		c.AbortWithStatusJSON(http.StatusInternalServerError, errMsg("sms send failed"))
+		respondBindError(c, codeSharedInternal)
 	}
 }

--- a/modules/oidc/api_bind_i18n_test.go
+++ b/modules/oidc/api_bind_i18n_test.go
@@ -1,0 +1,178 @@
+package oidc
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+// TestOIDCBindNoLegacyResponseError is a source guard: api_bind.go must route
+// every error through httperr.ResponseErrorLWithStatus (via respondBindError),
+// never raw c.AbortWithStatusJSON / c.AbortWithStatus / non-OK c.JSON.
+//
+// api.go is intentionally NOT guarded: its OAuth2/OIDC protocol endpoints
+// (authorize/callback/logout) keep raw responses by design (browser redirect
+// flow, not the dmwork front-end) — see the EXEMPT note in
+// tools/lint-direct-error-response/baseline.txt.
+func TestOIDCBindNoLegacyResponseError(t *testing.T) {
+	data, err := os.ReadFile("api_bind.go")
+	if err != nil {
+		t.Fatalf("read api_bind.go: %v", err)
+	}
+	var clean strings.Builder
+	for _, line := range strings.Split(string(data), "\n") {
+		if idx := strings.Index(line, "//"); idx >= 0 {
+			line = line[:idx]
+		}
+		clean.WriteString(line)
+		clean.WriteByte('\n')
+	}
+	cleaned := clean.String()
+
+	for _, b := range []string{
+		".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(",
+		"c.AbortWithStatusJSON", "c.AbortWithStatus(", "errMsg(",
+	} {
+		if strings.Contains(cleaned, b) {
+			t.Fatalf("modules/oidc/api_bind.go must use respondBindError / httperr.ResponseErrorLWithStatus instead of legacy %s", b)
+		}
+	}
+	// Raw non-OK c.JSON(http.Status…) bypasses the envelope just as completely;
+	// the bind success responses (c.JSON(http.StatusOK, …)) are allowed.
+	for _, line := range strings.Split(cleaned, "\n") {
+		if strings.Contains(line, "c.JSON(http.Status") && !strings.Contains(line, "c.JSON(http.StatusOK") {
+			t.Fatalf("modules/oidc/api_bind.go must not emit raw non-OK c.JSON: %s", strings.TrimSpace(line))
+		}
+	}
+}
+
+// newBindRouterWithRenderer builds a wkhttp router with the real i18n renderer
+// injected and an optional language pinned into the request context, so the
+// bind handlers render the full dual envelope (the gin.New()-based
+// newTestBindRouter falls back to defaultErrorRenderer and cannot exercise
+// error.code / translation).
+func newBindRouterWithRenderer(o *OIDC, lang string) *wkhttp.WKHttp {
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.SourceLanguage)))
+	g := r.Group("/v1/auth/oidc/aegis", func(c *wkhttp.Context) {
+		if lang != "" {
+			c.Request = c.Request.WithContext(i18n.WithLanguage(c.Request.Context(), i18n.LanguageDecision{
+				Language: lang,
+				Source:   i18n.LanguageSourceAccept,
+			}))
+		}
+		c.Next()
+	})
+	g.GET("/bind/info", o.bindInfo)
+	g.POST("/bind/verify/password", o.bindVerifyPassword)
+	return r
+}
+
+// decodeBindError unmarshals the response and returns (wireStatus, error-object).
+func decodeBindError(t *testing.T, w *httptest.ResponseRecorder) (int, map[string]any) {
+	t.Helper()
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body %q: %v", w.Body.String(), err)
+	}
+	errObj, ok := body["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("response missing error{} envelope: %s", w.Body.String())
+	}
+	// Dual envelope: legacy msg/status must also be present.
+	if _, ok := body["msg"]; !ok {
+		t.Fatalf("response missing legacy msg field: %s", w.Body.String())
+	}
+	if _, ok := body["status"]; !ok {
+		t.Fatalf("response missing legacy status field: %s", w.Body.String())
+	}
+	return w.Code, errObj
+}
+
+// TestBindError_TokenInvalidKeepsRealStatus verifies an unknown bind token yields
+// the real 410 wire status (not the legacy 400) plus the localized envelope.
+func TestBindError_TokenInvalidKeepsRealStatus(t *testing.T) {
+	o, _, _, _, _ := newTestOIDCWithBind(t, defaultBindCfg(), nil, true)
+	r := newBindRouterWithRenderer(o, "")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/v1/auth/oidc/aegis/bind/info?token=fake-jti", nil))
+
+	code, errObj := decodeBindError(t, w)
+	if code != http.StatusGone {
+		t.Fatalf("wire status = %d, want 410", code)
+	}
+	if errObj["code"] != errcode.ErrOIDCBindTokenInvalid.ID {
+		t.Fatalf("error.code = %v, want %s", errObj["code"], errcode.ErrOIDCBindTokenInvalid.ID)
+	}
+	if errObj["http_status"] != float64(http.StatusGone) {
+		t.Fatalf("error.http_status = %v, want 410", errObj["http_status"])
+	}
+}
+
+// TestBindError_RequestInvalid verifies a malformed token yields 400 +
+// bind_request_invalid.
+func TestBindError_RequestInvalid(t *testing.T) {
+	o, _, _, _, _ := newTestOIDCWithBind(t, defaultBindCfg(), nil, true)
+	r := newBindRouterWithRenderer(o, "")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/v1/auth/oidc/aegis/bind/info?token=a.b", nil))
+
+	code, errObj := decodeBindError(t, w)
+	if code != http.StatusBadRequest {
+		t.Fatalf("wire status = %d, want 400", code)
+	}
+	if errObj["code"] != errcode.ErrOIDCBindRequestInvalid.ID {
+		t.Fatalf("error.code = %v, want %s", errObj["code"], errcode.ErrOIDCBindRequestInvalid.ID)
+	}
+}
+
+// TestBindError_AntiEnumeration verifies a rejected password (unknown username)
+// returns the single generic 401 invalid_credentials code — never a more
+// specific reason that could be used to probe account existence.
+func TestBindError_AntiEnumeration(t *testing.T) {
+	o, jti, auth, _, _ := newTestOIDCWithBind(t, defaultBindCfg(), sampleClaims(), false)
+	auth.verifyPasswordResp.matched = false // unknown user / wrong password
+	r := newBindRouterWithRenderer(o, "")
+
+	body, _ := json.Marshal(map[string]string{
+		"token": jti, "identifier": "ghost", "password": "Whatever@123",
+	})
+	req := httptest.NewRequest("POST", "/v1/auth/oidc/aegis/bind/verify/password", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	code, errObj := decodeBindError(t, w)
+	if code != http.StatusUnauthorized {
+		t.Fatalf("wire status = %d, want 401", code)
+	}
+	if errObj["code"] != errcode.ErrOIDCBindInvalidCredentials.ID {
+		t.Fatalf("error.code = %v, want %s (anti-enumeration)", errObj["code"], errcode.ErrOIDCBindInvalidCredentials.ID)
+	}
+}
+
+// TestBindError_ZhCNTranslation verifies the localized message follows the
+// request language.
+func TestBindError_ZhCNTranslation(t *testing.T) {
+	o, _, _, _, _ := newTestOIDCWithBind(t, defaultBindCfg(), nil, true)
+	r := newBindRouterWithRenderer(o, "zh-CN")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/v1/auth/oidc/aegis/bind/info?token=fake-jti", nil))
+
+	_, errObj := decodeBindError(t, w)
+	msg, _ := errObj["message"].(string)
+	if !strings.Contains(msg, "过期") {
+		t.Fatalf("zh-CN message = %q, want Chinese translation", msg)
+	}
+}

--- a/modules/oidc/api_i18n.go
+++ b/modules/oidc/api_i18n.go
@@ -21,9 +21,8 @@ import (
 // registration panics loudly here rather than silently degrading to an empty
 // envelope at request time.
 var (
-	codeSharedRateLimited  = mustLookupSharedCode("err.shared.rate.limited")
-	codeSharedInternal     = mustLookupSharedCode("err.shared.internal")
-	codeSharedAuthRequired = mustLookupSharedCode("err.shared.auth.required")
+	codeSharedRateLimited = mustLookupSharedCode("err.shared.rate.limited")
+	codeSharedInternal    = mustLookupSharedCode("err.shared.internal")
 )
 
 func mustLookupSharedCode(id string) codes.Code {

--- a/modules/oidc/api_i18n.go
+++ b/modules/oidc/api_i18n.go
@@ -1,0 +1,43 @@
+package oidc
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// respond helpers for the OIDC self-service bind flow (api_bind.go).
+//
+// Every bind error renders through respondBindError, which uses
+// httperr.ResponseErrorLWithStatus — the bind endpoints keep their real HTTP
+// status (400/401/409/410/422/429/503) instead of the legacy compatibility 400,
+// because they are a recent feature with no clients depending on fixed-400.
+//
+// The OAuth2/OIDC protocol endpoints in api.go (authorize/callback/logout) are
+// intentionally NOT migrated: they are consumed by the browser redirect flow,
+// not the dmwork front-end, and keep their raw errMsg responses.
+
+// shared codes reused by the bind flow, resolved once at init. A missing
+// registration panics loudly here rather than silently degrading to an empty
+// envelope at request time.
+var (
+	codeSharedRateLimited  = mustLookupSharedCode("err.shared.rate.limited")
+	codeSharedInternal     = mustLookupSharedCode("err.shared.internal")
+	codeSharedAuthRequired = mustLookupSharedCode("err.shared.auth.required")
+)
+
+func mustLookupSharedCode(id string) codes.Code {
+	c, ok := codes.Lookup(id)
+	if !ok {
+		panic("modules/oidc: shared code not registered: " + id)
+	}
+	return c
+}
+
+// respondBindError renders a localized bind error while keeping the code's real
+// HTTP transport status, then aborts the gin chain — matching the prior
+// c.AbortWithStatusJSON(errMsg(...)) semantics so callers can return immediately.
+func respondBindError(c *wkhttp.Context, code codes.Code) {
+	httperr.ResponseErrorLWithStatus(c, code, nil, nil)
+	c.Abort()
+}

--- a/pkg/errcode/oidc.go
+++ b/pkg/errcode/oidc.go
@@ -1,0 +1,141 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// err.server.oidc.* — modules/oidc self-service bind error codes
+// (api_bind.go). DefaultMessage holds the en-US source (D4); the zh-CN runtime
+// translation lives in pkg/i18n/locales/active.zh-CN.toml.
+//
+// These codes are rendered via httperr.ResponseErrorLWithStatus (NOT the
+// fixed-400 ResponseErrorL): the bind endpoints are a recent feature with no
+// legacy clients, and have always returned semantic status codes
+// (400/401/409/410/422/429/503). The wire status therefore equals HTTPStatus.
+//
+// Anti-enumeration: ErrBindAuthRejected (wrong password / bad OTP / phone not
+// matched) and the verify→confirm TOCTOU rejection all map to the single
+// ErrOIDCBindInvalidCredentials (401) with a generic message — the specific
+// reason is logged via zap only, never surfaced, so the response cannot be used
+// to probe "account exists vs password wrong".
+//
+// Only the 503 code is 5xx and therefore Internal=true (its message is a generic
+// placeholder; clients identify the transient condition from error.http_status).
+// Genuine internal failures (the default branch of each handle*Err) reuse
+// err.shared.internal rather than a bespoke oidc code.
+var (
+	// ---- transient infrastructure (503) -------------------------------------
+
+	// ErrOIDCBindServiceUnavailable is returned when the bind sub-service failed
+	// to initialise (Discovery failed → o.bind is nil) but the routes are still
+	// mounted. Transient: ops can recover by fixing Discovery / restarting.
+	ErrOIDCBindServiceUnavailable = register(codes.Code{
+		ID:             "err.server.oidc.bind_service_unavailable",
+		HTTPStatus:     http.StatusServiceUnavailable,
+		DefaultMessage: "The account binding service is temporarily unavailable. Please try again later.",
+		Internal:       true,
+	})
+
+	// ---- validation (400) ---------------------------------------------------
+
+	// ErrOIDCBindRequestInvalid is the catch-all for malformed bind input:
+	// BindJSON failure, missing/blank token, bad authcode format, or missing
+	// identifier/password/code fields.
+	ErrOIDCBindRequestInvalid = register(codes.Code{
+		ID:             "err.server.oidc.bind_request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid request.",
+	})
+	// ErrOIDCBindSMSUnavailable maps ErrBindNoPhone: the SSO claims carry no
+	// verified phone, so SMS verification cannot proceed — the client should
+	// switch to the password method rather than retry.
+	ErrOIDCBindSMSUnavailable = register(codes.Code{
+		ID:             "err.server.oidc.bind_sms_unavailable",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "SMS verification is not available for this account.",
+	})
+	// ErrOIDCBindMethodDisabled maps ErrBindMethodDisabled: the verification
+	// method was turned off via OCTO_OIDC_BIND_METHODS — the client should not
+	// retry it.
+	ErrOIDCBindMethodDisabled = register(codes.Code{
+		ID:             "err.server.oidc.bind_method_disabled",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "This verification method is currently disabled.",
+	})
+
+	// ---- auth / anti-enumeration (401) --------------------------------------
+
+	// ErrOIDCBindInvalidCredentials maps ErrBindAuthRejected (wrong password /
+	// bad OTP / phone not matched) and the confirm-stage TOCTOU rejection. A
+	// single generic 401 across all causes prevents account enumeration.
+	ErrOIDCBindInvalidCredentials = register(codes.Code{
+		ID:             "err.server.oidc.bind_invalid_credentials",
+		HTTPStatus:     http.StatusUnauthorized,
+		DefaultMessage: "Verification failed. Please check your details and try again.",
+	})
+	// ErrOIDCBindVerifyRequired maps ErrBindStatusConflict on the confirm path:
+	// the session is not yet verified (user skipped the second factor or a
+	// concurrent confirm raced).
+	ErrOIDCBindVerifyRequired = register(codes.Code{
+		ID:             "err.server.oidc.bind_verify_required",
+		HTTPStatus:     http.StatusUnauthorized,
+		DefaultMessage: "Please complete verification before confirming.",
+	})
+
+	// ---- conflict (409) -----------------------------------------------------
+
+	// ErrOIDCBindAlreadyVerified maps ErrBindStatusConflict on the verify path:
+	// the session is already verified; the client should skip ahead to confirm.
+	ErrOIDCBindAlreadyVerified = register(codes.Code{
+		ID:             "err.server.oidc.bind_already_verified",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "This binding session has already been verified.",
+	})
+	// ErrOIDCBindStatusConflict maps ErrBindStatusConflict on the create path:
+	// the session state does not allow account creation.
+	ErrOIDCBindStatusConflict = register(codes.Code{
+		ID:             "err.server.oidc.bind_status_conflict",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "The binding session is in a conflicting state.",
+	})
+	// ErrOIDCBindAlreadyBound maps ErrBindAlreadyBound: the identity row already
+	// exists (a retry after a successful bind, or a create race). The client is
+	// guided back to the OIDC sign-in entry point.
+	ErrOIDCBindAlreadyBound = register(codes.Code{
+		ID:             "err.server.oidc.bind_already_bound",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "This identity is already bound. Please sign in via OIDC to continue.",
+	})
+	// ErrOIDCBindConflictNeedManual maps ErrBindConflictNeedManual /
+	// ErrBindCreateConflictNeedManual: the claims match multiple accounts, which
+	// the self-service flow cannot resolve — route to admin/manual handling.
+	ErrOIDCBindConflictNeedManual = register(codes.Code{
+		ID:             "err.server.oidc.bind_conflict_need_manual",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "Multiple accounts match; manual resolution is required. Please contact support.",
+	})
+
+	// ---- gone (410) ---------------------------------------------------------
+
+	// ErrOIDCBindTokenInvalid maps ErrBindNotFound: the single-use 5-minute
+	// bind_token has expired or was already consumed. The client must restart
+	// the OIDC flow.
+	ErrOIDCBindTokenInvalid = register(codes.Code{
+		ID:             "err.server.oidc.bind_token_invalid",
+		HTTPStatus:     http.StatusGone,
+		DefaultMessage: "The binding session has expired or is invalid. Please start over.",
+	})
+
+	// ---- unprocessable (422) ------------------------------------------------
+
+	// ErrOIDCBindClaimsIncomplete maps ErrBindCreateClaimsIncomplete: the SSO
+	// claims carry neither a verified email nor a verified phone, so /bind/create
+	// cannot provision an account.
+	ErrOIDCBindClaimsIncomplete = register(codes.Code{
+		ID:             "err.server.oidc.bind_claims_incomplete",
+		HTTPStatus:     http.StatusUnprocessableEntity,
+		DefaultMessage: "The identity provider did not supply the account details required to create an account.",
+	})
+)

--- a/pkg/errcode/oidc.go
+++ b/pkg/errcode/oidc.go
@@ -31,6 +31,12 @@ var (
 	// ErrOIDCBindServiceUnavailable is returned when the bind sub-service failed
 	// to initialise (Discovery failed → o.bind is nil) but the routes are still
 	// mounted. Transient: ops can recover by fixing Discovery / restarting.
+	//
+	// NOTE: Internal=true (5xx hygiene) means the renderer emits the shared
+	// internal-error copy, not this DefaultMessage — the specific text and its
+	// zh-CN translation are intentionally unreachable on the wire. They are kept
+	// to satisfy Register and to document intent; clients distinguish the
+	// transient 503 via error.http_status, not the message.
 	ErrOIDCBindServiceUnavailable = register(codes.Code{
 		ID:             "err.server.oidc.bind_service_unavailable",
 		HTTPStatus:     http.StatusServiceUnavailable,

--- a/pkg/errcode/oidc_test.go
+++ b/pkg/errcode/oidc_test.go
@@ -1,0 +1,66 @@
+package errcode
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// TestOIDCCodesRegistered asserts every err.server.oidc.* code this package
+// declares is actually registered (a typo'd ID would otherwise only surface as a
+// runtime fallback to err.shared.internal).
+func TestOIDCCodesRegistered(t *testing.T) {
+	want := []codes.Code{
+		ErrOIDCBindServiceUnavailable,
+		ErrOIDCBindRequestInvalid,
+		ErrOIDCBindSMSUnavailable,
+		ErrOIDCBindMethodDisabled,
+		ErrOIDCBindInvalidCredentials,
+		ErrOIDCBindVerifyRequired,
+		ErrOIDCBindAlreadyVerified,
+		ErrOIDCBindStatusConflict,
+		ErrOIDCBindAlreadyBound,
+		ErrOIDCBindConflictNeedManual,
+		ErrOIDCBindTokenInvalid,
+		ErrOIDCBindClaimsIncomplete,
+	}
+	for _, c := range want {
+		if _, ok := codes.Lookup(c.ID); !ok {
+			t.Errorf("code %q not registered", c.ID)
+		}
+	}
+}
+
+// TestOIDCCodesInternalFlag mirrors the shared-code invariant for err.server.oidc.*:
+// only 5xx codes may be Internal=true, and every 5xx code MUST be — otherwise the
+// renderer would leak a raw message on a server error (D11/D13).
+func TestOIDCCodesInternalFlag(t *testing.T) {
+	for _, c := range codes.All() {
+		if !strings.HasPrefix(c.ID, "err.server.oidc.") {
+			continue
+		}
+		is5xx := c.HTTPStatus >= 500 && c.HTTPStatus < 600
+		if is5xx && !c.Internal {
+			t.Errorf("%s: HTTPStatus=%d but Internal=false; 5xx must be Internal=true", c.ID, c.HTTPStatus)
+		}
+		if !is5xx && c.Internal {
+			t.Errorf("%s: HTTPStatus=%d but Internal=true; only 5xx may be Internal", c.ID, c.HTTPStatus)
+		}
+	}
+}
+
+// TestOIDCInvalidCredentialsGeneric guards the anti-enumeration contract: the
+// 401 bind code must not hint at which factor failed.
+func TestOIDCInvalidCredentialsGeneric(t *testing.T) {
+	if ErrOIDCBindInvalidCredentials.HTTPStatus != http.StatusUnauthorized {
+		t.Fatalf("invalid_credentials status = %d, want 401", ErrOIDCBindInvalidCredentials.HTTPStatus)
+	}
+	msg := strings.ToLower(ErrOIDCBindInvalidCredentials.DefaultMessage)
+	for _, leak := range []string{"password", "account not found", "user not found", "phone", "otp"} {
+		if strings.Contains(msg, leak) {
+			t.Errorf("invalid_credentials message leaks enumeration hint %q: %q", leak, ErrOIDCBindInvalidCredentials.DefaultMessage)
+		}
+	}
+}

--- a/pkg/httperr/respond.go
+++ b/pkg/httperr/respond.go
@@ -13,13 +13,40 @@ import (
 // ResponseErrorL is the business-facing localized error facade.
 //
 // It validates the code, separates Params from Details, preserves the legacy
-// HTTP/body status=400 compatibility path, and delegates translation/envelope
-// rendering to the injected wkhttp.ErrorRenderer.
+// HTTP/body status=400 compatibility path (D14), and delegates
+// translation/envelope rendering to the injected wkhttp.ErrorRenderer.
 //
 // ResponseErrorL writes the response but does not abort the gin chain. Handlers
 // must return immediately after calling it, or call c.Abort() when used inside
 // middleware.
 func ResponseErrorL(c *wkhttp.Context, code codes.Code, params i18n.Params, details i18n.Details) {
+	respondL(c, code, params, details, false)
+}
+
+// ResponseErrorLWithStatus is the localized error facade for endpoints that
+// intentionally keep their real HTTP transport status instead of the legacy
+// compatibility 400 (D14).
+//
+// Use this ONLY for endpoints that have NO legacy clients depending on the
+// fixed-400 behavior. The sole current consumer is the OIDC self-service bind
+// flow (modules/oidc/api_bind.go), a recent feature that has always returned
+// semantic status codes (400/401/409/410/422/429/503); pinning those to 400
+// would be a regression and break the bind wizard's status-based branching.
+//
+// The body envelope is byte-for-byte identical to ResponseErrorL; only the
+// transport status differs — here it equals the code's canonical HTTPStatus, so
+// the wire status and error.http_status agree. For every other (legacy-bearing)
+// endpoint use ResponseErrorL, which keeps wire=400 during the compatibility
+// window; the fleet-wide switch to real status codes happens once in Phase 4.
+func ResponseErrorLWithStatus(c *wkhttp.Context, code codes.Code, params i18n.Params, details i18n.Details) {
+	respondL(c, code, params, details, true)
+}
+
+// respondL is the shared implementation behind ResponseErrorL /
+// ResponseErrorLWithStatus. useSemanticStatus selects the wire transport
+// status: false → legacy compatibility 400 (D14); true → the code's canonical
+// HTTPStatus. The body envelope is identical in both cases.
+func respondL(c *wkhttp.Context, code codes.Code, params i18n.Params, details i18n.Details, useSemanticStatus bool) {
 	if c == nil {
 		return
 	}
@@ -30,10 +57,15 @@ func ResponseErrorL(c *wkhttp.Context, code codes.Code, params i18n.Params, deta
 		registered, _ = codes.Lookup("err.shared.internal")
 	}
 
+	transportStatus := http.StatusBadRequest
+	if useSemanticStatus {
+		transportStatus = registered.HTTPStatus
+	}
+
 	c.RenderError(wkhttp.ErrorSpec{
 		Code:            registered.ID,
 		DefaultMessage:  registered.DefaultMessage,
-		TransportStatus: http.StatusBadRequest,
+		TransportStatus: transportStatus,
 		SemanticStatus:  registered.HTTPStatus,
 		Params:          params,
 		Details:         details.FilterBy(registered),

--- a/pkg/httperr/respond_test.go
+++ b/pkg/httperr/respond_test.go
@@ -86,3 +86,70 @@ func TestResponseErrorLUnknownCodeFallsBackToInternal(t *testing.T) {
 		t.Fatalf("error.http_status = %v, want 500", got)
 	}
 }
+
+// TestResponseErrorLWithStatusKeepsSemanticStatus verifies the WithStatus facade
+// emits the code's canonical HTTPStatus on the wire (not the legacy 400), while
+// keeping the body envelope identical to ResponseErrorL.
+func TestResponseErrorLWithStatusKeepsSemanticStatus(t *testing.T) {
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.SourceLanguage)))
+	r.GET("/x", func(c *wkhttp.Context) {
+		ResponseErrorLWithStatus(c, errcode.ErrThreadDeleted, nil, nil)
+	})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+
+	if rec.Code != http.StatusGone {
+		t.Fatalf("wire status = %d, want 410", rec.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	// Both legacy (status) and v2 (error.http_status) agree on the real status.
+	if got := body["status"]; got != float64(http.StatusGone) {
+		t.Fatalf("body status = %v, want 410", got)
+	}
+	errObj := body["error"].(map[string]any)
+	if got := errObj["code"]; got != errcode.ErrThreadDeleted.ID {
+		t.Fatalf("error.code = %q", got)
+	}
+	if got := errObj["http_status"]; got != float64(http.StatusGone) {
+		t.Fatalf("error.http_status = %v, want 410", got)
+	}
+}
+
+// TestResponseErrorLWithStatusInternalStays5xx verifies a 5xx Internal code keeps
+// its real status on the wire AND still hides the underlying message/details.
+func TestResponseErrorLWithStatusInternalStays5xx(t *testing.T) {
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.SourceLanguage)))
+	r.GET("/x", func(c *wkhttp.Context) {
+		ResponseErrorLWithStatus(c, errcode.ErrThreadStoreFailed, nil, i18n.Details{"raw_err": "secret"})
+	})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("wire status = %d, want 500", rec.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	errObj := body["error"].(map[string]any)
+	if got := errObj["http_status"]; got != float64(http.StatusInternalServerError) {
+		t.Fatalf("error.http_status = %v, want 500", got)
+	}
+	// Internal=true must not surface the raw default message or unsafe details.
+	if msg, _ := errObj["message"].(string); msg == errcode.ErrThreadStoreFailed.DefaultMessage {
+		t.Fatalf("internal code leaked its default message: %q", msg)
+	}
+	if details, ok := errObj["details"].(map[string]any); ok {
+		if _, leaked := details["raw_err"]; leaked {
+			t.Fatal("internal code leaked unsafe detail")
+		}
+	}
+}

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -610,3 +610,41 @@ other = "查询分类数据失败。"
 
 ["err.server.category.store_failed"]
 other = "保存分类数据失败。"
+
+# ---- modules/oidc：自助绑定流程（api_bind.go），保留真实 HTTP 状态码 ----
+
+["err.server.oidc.bind_service_unavailable"]
+other = "账号绑定服务暂时不可用，请稍后再试。"
+
+["err.server.oidc.bind_request_invalid"]
+other = "请求无效。"
+
+["err.server.oidc.bind_sms_unavailable"]
+other = "该账号无法使用短信验证。"
+
+["err.server.oidc.bind_method_disabled"]
+other = "该验证方式当前已停用。"
+
+["err.server.oidc.bind_invalid_credentials"]
+other = "验证失败，请核对信息后重试。"
+
+["err.server.oidc.bind_verify_required"]
+other = "请先完成验证再确认绑定。"
+
+["err.server.oidc.bind_already_verified"]
+other = "该绑定会话已完成验证。"
+
+["err.server.oidc.bind_status_conflict"]
+other = "绑定会话状态冲突。"
+
+["err.server.oidc.bind_already_bound"]
+other = "该身份已绑定，请通过 OIDC 登录以继续。"
+
+["err.server.oidc.bind_conflict_need_manual"]
+other = "匹配到多个账号，需人工处理，请联系支持人员。"
+
+["err.server.oidc.bind_token_invalid"]
+other = "绑定会话已过期或无效，请重新发起。"
+
+["err.server.oidc.bind_claims_incomplete"]
+other = "身份提供方未返回创建账号所需的账号信息。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -237,6 +237,42 @@ other = "Message search failed."
 ["err.server.message.store_failed"]
 other = "Failed to persist message data."
 
+["err.server.oidc.bind_already_bound"]
+other = "This identity is already bound. Please sign in via OIDC to continue."
+
+["err.server.oidc.bind_already_verified"]
+other = "This binding session has already been verified."
+
+["err.server.oidc.bind_claims_incomplete"]
+other = "The identity provider did not supply the account details required to create an account."
+
+["err.server.oidc.bind_conflict_need_manual"]
+other = "Multiple accounts match; manual resolution is required. Please contact support."
+
+["err.server.oidc.bind_invalid_credentials"]
+other = "Verification failed. Please check your details and try again."
+
+["err.server.oidc.bind_method_disabled"]
+other = "This verification method is currently disabled."
+
+["err.server.oidc.bind_request_invalid"]
+other = "Invalid request."
+
+["err.server.oidc.bind_service_unavailable"]
+other = "The account binding service is temporarily unavailable. Please try again later."
+
+["err.server.oidc.bind_sms_unavailable"]
+other = "SMS verification is not available for this account."
+
+["err.server.oidc.bind_status_conflict"]
+other = "The binding session is in a conflicting state."
+
+["err.server.oidc.bind_token_invalid"]
+other = "The binding session has expired or is invalid. Please start over."
+
+["err.server.oidc.bind_verify_required"]
+other = "Please complete verification before confirming."
+
 ["err.server.thread.creator_cannot_leave"]
 other = "Thread creator cannot leave the thread."
 

--- a/tools/lint-direct-error-response/baseline.txt
+++ b/tools/lint-direct-error-response/baseline.txt
@@ -26,8 +26,8 @@
 1 modules/botfather/api_bot_thread.go
 9 modules/botfather/api_user.go
 2 modules/notify/api.go
-14 modules/oidc/api.go
-37 modules/oidc/api_bind.go
+14 modules/oidc/api.go  # EXEMPT: OAuth2/OIDC protocol endpoints (authorize/callback/logout) — browser-facing redirect flow, not the dmwork front-end; raw errMsg() kept by design (#220). The err.Error() leaks were closed in #220.
+0 modules/oidc/api_bind.go  # migrated to httperr.ResponseErrorLWithStatus (#220)
 6 modules/robot/api.go
 8 modules/user/api.go
 4 modules/webhook/github.go  # EXEMPT: GitHub webhook signature errors — external GH never reads the localized envelope


### PR DESCRIPTION
## Summary

Migrates the OIDC self-service **bind** flow (`modules/oidc/api_bind.go`) to the i18n error envelope and closes the raw-error leaks in the `authorize` protocol endpoint. Part of the i18n backend rollout (#170).

OIDC was outside the Phase 2 hotspot batch because it never used the `c.ResponseError` envelope — it emitted raw `c.AbortWithStatusJSON(errMsg(...))` with a private `{"msg": ...}` shape and **semantic HTTP status codes** (400/401/409/410/422/429/503).

Closes #220.

## Design decision — `ResponseErrorLWithStatus` (keeps real HTTP status)

The bind endpoints are a recent feature with **no legacy clients depending on the fixed-400 compatibility behavior** (D14). Pinning their 410/429/409/422/503 responses to 400 would be a regression (degraded semantics, broken status-based branching, extra churn at the Phase 4 switch).

This PR adds a second facade in `pkg/httperr`:

- `ResponseErrorL` (unchanged): wire status pinned to **400**, real status in `error.http_status` (D14) — used by all legacy-bearing modules.
- `ResponseErrorLWithStatus` (**new**): wire status = the code's canonical `HTTPStatus`. Body envelope is byte-for-byte identical; only the transport status differs. The renderer already reads `spec.TransportStatus`, so there is **zero renderer change**.

This is the only consumer for now; it effectively brings the bind endpoints to their Phase 4 end state early. Flagged for maintainer review as it diverges from the current D14 fleet-wide consistency.

## What changed

1. `feat(i18n)`: `ResponseErrorLWithStatus` facade (+ shared `respondL`).
2. `feat(i18n)`: 12 `err.server.oidc.*` codes + zh-CN translations (reuses shared `rate.limited`/`internal`/`auth.required`).
3. `feat(i18n)`: migrate all 43 raw sites in `api_bind.go` via `respondBindError`.
4. `fix(oidc)`: stop leaking `err.Error()` in `authorize` (5 sites → generic message + `zap.Error`).
5. `test(i18n)`: source guard + i18n contract coverage.

## Preserved contracts

- **Anti-enumeration**: `ErrBindAuthRejected` and the confirm-stage TOCTOU rejection all map to a single generic `bind_invalid_credentials` (401); the specific reason is logged via `zap` only. Test-locked.
- **Audit + metrics**: every `writeAudit` / `bindResultFromErr` side effect is kept; only the final response call changed.
- **5xx never leaks**: 503/500 codes are `Internal=true`; clients identify the transient 503 via `error.http_status`.

## Breaking-change assessment

**HTTP status codes: zero drift.** Per-status-bucket counts are identical before/after (`400×12 / 401×3 / 409×6 / 410×5 / 422×1 / 429×4 / 500×5 / 503×1`), and the existing 30 status-code assertions in `api_bind_test.go` all pass post-migration. Success responses (`c.JSON(200)`) are untouched. `callback`/`logout` are untouched.

**Bind response body (incremental):** `{"msg": "..."}` → `{"msg": "<i18n>", "status": <real>, "error": {code, message, http_status, details}}`. New `status`/`error` fields are additive (JSON-compatible); the `msg` value changes (short phrase → full localized sentence). Adds `Content-Language` + `Vary` headers (already in CORS ExposeHeaders).

**⚠️ Front-end action item:** the only possible breakage is a client that does an **exact string match on the error `msg`** to branch error handling. The correct approach is to read the HTTP status (unchanged) or `error.code` (new). Please confirm the bind wizard does not string-match `msg`.

## Test plan

- [x] `go build ./...`, `go vet`, `gofmt` (changed files clean)
- [x] `make i18n-extract-check` (recall 100%), `make i18n-lint`
- [x] `go test ./modules/oidc -race` (full suite, fresh test DB), `pkg/httperr` / `pkg/errcode` / `pkg/i18n`
- [ ] Front-end confirms bind wizard reads HTTP status / `error.code` (not `msg` string match)
