### PR TITLE
fix(oidc): invalidate current token on logout

### DIFF
--- a/modules/oidc/api.go
+++ b/modules/oidc/api.go
@@ -19,6 +19,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
 	mysql "github.com/go-sql-driver/mysql"
 	"go.uber.org/zap"
 )
@@ -72,6 +74,17 @@ type rtRevoker interface {
 type currentTokenInvalidator interface {
 	InvalidateCurrentToken(ctx context.Context, uid, token string) error
 }
+
+type compareDeleter interface {
+	DeleteIfValue(key, want string) (bool, error)
+}
+
+var luaCompareDel = rd.NewScript(`
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+end
+return 0
+`)
 
 // OIDC OIDC 登录模块。
 //
@@ -150,6 +163,7 @@ func New(ctx *config.Context) *OIDC {
 		cache:          ctx.Cache(),
 		tokenPrefix:    ctx.GetConfig().Cache.TokenCachePrefix,
 		uidTokenPrefix: ctx.GetConfig().Cache.UIDTokenCachePrefix,
+		indexDel:       newRedisCompareDeleter(ctx),
 	}
 	o.cbGuard = NewCallbackGuard(
 		ctx.GetRedisConn(),
@@ -838,6 +852,14 @@ func (o *OIDC) Close() error {
 		}
 		o.idTokens = nil
 	}
+	if cti, ok := o.tokenKill.(cacheCurrentTokenInvalidator); ok {
+		if rcd, ok := cti.indexDel.(*redisCompareDeleter); ok {
+			if err := rcd.Close(); err != nil {
+				o.Error("关闭 OIDC token invalidator Redis client 失败", zap.Error(err))
+			}
+		}
+		o.tokenKill = nil
+	}
 	if o.stateStore == nil {
 		return nil
 	}
@@ -1332,6 +1354,7 @@ type cacheCurrentTokenInvalidator struct {
 	cache          cache.Cache
 	tokenPrefix    string
 	uidTokenPrefix string
+	indexDel       compareDeleter
 }
 
 func (i cacheCurrentTokenInvalidator) InvalidateCurrentToken(_ context.Context, uid, token string) error {
@@ -1347,17 +1370,62 @@ func (i cacheCurrentTokenInvalidator) InvalidateCurrentToken(_ context.Context, 
 	// 复用刚 logout 的 token 字符串。
 	for _, flag := range []config.DeviceFlag{config.APP, config.Web, config.PC} {
 		key := fmt.Sprintf("%s%d%s", i.uidTokenPrefix, flag, uid)
-		oldToken, err := i.cache.Get(key)
-		if err != nil {
+		if err := i.deleteIndexIfCurrentToken(key, token); err != nil {
 			return err
-		}
-		if strings.TrimSpace(oldToken) == token {
-			if err := i.cache.Delete(key); err != nil {
-				return err
-			}
 		}
 	}
 	return nil
+}
+
+func (i cacheCurrentTokenInvalidator) deleteIndexIfCurrentToken(key, token string) error {
+	if i.indexDel != nil {
+		_, err := i.indexDel.DeleteIfValue(key, token)
+		return err
+	}
+	oldToken, err := i.cache.Get(key)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(oldToken) == token {
+		return i.cache.Delete(key)
+	}
+	return nil
+}
+
+type redisCompareDeleter struct {
+	client *rd.Client
+}
+
+func newRedisCompareDeleter(ctx *config.Context) *redisCompareDeleter {
+	client := rd.NewClient(octoredis.MustBuildOptions(ctx.GetConfig(), func(o *rd.Options) {
+		o.MaxRetries = 3
+		o.ReadTimeout = 3 * time.Second
+		o.WriteTimeout = 3 * time.Second
+		o.DialTimeout = 3 * time.Second
+	}))
+	return &redisCompareDeleter{client: client}
+}
+
+func (d *redisCompareDeleter) DeleteIfValue(key, want string) (bool, error) {
+	if d == nil || d.client == nil || key == "" {
+		return false, nil
+	}
+	res, err := luaCompareDel.Run(d.client, []string{key}, want).Result()
+	if err != nil {
+		return false, err
+	}
+	n, ok := res.(int64)
+	if !ok {
+		return false, fmt.Errorf("oidc: compare-del unexpected lua result type %T", res)
+	}
+	return n > 0, nil
+}
+
+func (d *redisCompareDeleter) Close() error {
+	if d == nil || d.client == nil {
+		return nil
+	}
+	return d.client.Close()
 }
 
 func maskEmail(email string) string {

--- a/modules/oidc/api.go
+++ b/modules/oidc/api.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/cache"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
@@ -63,6 +64,15 @@ type rtRevoker interface {
 	RevokeRefreshByUID(uid string) (int64, error)
 }
 
+// currentTokenInvalidator 作废当前 HTTP 会话 token。
+//
+// logout 的业务语义是"当前设备退出":WuKongIM 的 device_quit 只影响 IM 长连接,
+// HTTP API 仍由 token:<token> Redis key 决定。因此需要显式删除当前请求携带的
+// HTTP token；不能按 uid 粗暴删除所有 token,否则会把其他设备一并踢下线。
+type currentTokenInvalidator interface {
+	InvalidateCurrentToken(ctx context.Context, uid, token string) error
+}
+
 // OIDC OIDC 登录模块。
 //
 // 字段全部包内可见:测试在 New 后可替换 stateStore / authcode 为内存实现。
@@ -80,6 +90,7 @@ type OIDC struct {
 	audit      auditWriter
 	killer     sessionKiller
 	revoker    rtRevoker
+	tokenKill  currentTokenInvalidator
 	// idTokens 缓存登录时验签过的 id_token,供 logout 当 RP-Initiated Logout 的
 	// id_token_hint。nil 时 logout 不生成 end_session_url(降级为仅清本地)。
 	idTokens idTokenStore
@@ -135,6 +146,11 @@ func New(ctx *config.Context) *OIDC {
 	o.audit = db
 	o.revoker = db
 	o.killer = ctxKiller{ctx: ctx}
+	o.tokenKill = cacheCurrentTokenInvalidator{
+		cache:          ctx.Cache(),
+		tokenPrefix:    ctx.GetConfig().Cache.TokenCachePrefix,
+		uidTokenPrefix: ctx.GetConfig().Cache.UIDTokenCachePrefix,
+	}
 	o.cbGuard = NewCallbackGuard(
 		ctx.GetRedisConn(),
 		callbackGuardThresholdFromEnv(),
@@ -864,10 +880,19 @@ func (o *OIDC) logout(c *wkhttp.Context) {
 	// 但指标要区分"成功 / 踢线失败 / 吊销失败",方便定位 IM 或 DB 链路问题。
 	kickFailed := false
 	revokeFailed := false
+	tokenFailed := false
 	if o.killer != nil {
 		if err := o.killer.Kick(ctx, uid); err != nil {
 			kickFailed = true
 			o.Error("OIDC logout 踢线失败",
+				zap.String("trace_id", traceID),
+				zap.Error(err), zap.String("uid", uid))
+		}
+	}
+	if o.tokenKill != nil {
+		if err := o.tokenKill.InvalidateCurrentToken(ctx, uid, c.GetHeader("token")); err != nil {
+			tokenFailed = true
+			o.Error("OIDC logout 作废当前 HTTP token 失败",
 				zap.String("trace_id", traceID),
 				zap.Error(err), zap.String("uid", uid))
 		}
@@ -880,17 +905,20 @@ func (o *OIDC) logout(c *wkhttp.Context) {
 				zap.Error(err), zap.String("uid", uid))
 		}
 	}
-	// 两个失败标签独立计数 —— 同一次 logout 可能 kick 和 revoke 都失败,
-	// 早期 switch/case 写法会把 revoke_fail 吃掉。Counter sum 仍可能 > 总请求数,
-	// 但每个失败维度的趋势准确,运维查"哪条链路在抖"时不会漏报。
+	// 失败标签独立计数 —— 同一次 logout 可能同时出现 token/kick/revoke 多个失败。
+	// Counter sum 仍可能 > 总请求数,但每个失败维度的趋势准确,运维查"哪条链路在抖"
+	// 时不会漏报。
 	switch {
-	case kickFailed && revokeFailed:
-		metricLogoutTotal.WithLabelValues("kick_fail").Inc()
-		metricLogoutTotal.WithLabelValues("revoke_fail").Inc()
-	case kickFailed:
-		metricLogoutTotal.WithLabelValues("kick_fail").Inc()
-	case revokeFailed:
-		metricLogoutTotal.WithLabelValues("revoke_fail").Inc()
+	case kickFailed || revokeFailed || tokenFailed:
+		if kickFailed {
+			metricLogoutTotal.WithLabelValues("kick_fail").Inc()
+		}
+		if tokenFailed {
+			metricLogoutTotal.WithLabelValues("token_fail").Inc()
+		}
+		if revokeFailed {
+			metricLogoutTotal.WithLabelValues("revoke_fail").Inc()
+		}
 	default:
 		metricLogoutTotal.WithLabelValues("ok").Inc()
 	}
@@ -1298,6 +1326,38 @@ type ctxKiller struct{ ctx *config.Context }
 
 func (k ctxKiller) Kick(_ context.Context, uid string) error {
 	return k.ctx.QuitUserDevice(uid, -1)
+}
+
+type cacheCurrentTokenInvalidator struct {
+	cache          cache.Cache
+	tokenPrefix    string
+	uidTokenPrefix string
+}
+
+func (i cacheCurrentTokenInvalidator) InvalidateCurrentToken(_ context.Context, uid, token string) error {
+	token = strings.TrimSpace(token)
+	if i.cache == nil || token == "" {
+		return nil
+	}
+	if err := i.cache.Delete(i.tokenPrefix + token); err != nil {
+		return err
+	}
+	// uidtoken:<flag><uid> 是登录签发时维护的反向索引。它不是枚举所有历史 token
+	// 的可靠来源,但如果它正好指向当前 token,同步删除能避免下一次同 flag 登录
+	// 复用刚 logout 的 token 字符串。
+	for _, flag := range []config.DeviceFlag{config.APP, config.Web, config.PC} {
+		key := fmt.Sprintf("%s%d%s", i.uidTokenPrefix, flag, uid)
+		oldToken, err := i.cache.Get(key)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(oldToken) == token {
+			if err := i.cache.Delete(key); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func maskEmail(email string) string {

--- a/modules/oidc/api_test.go
+++ b/modules/oidc/api_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/gin-gonic/gin"
@@ -629,6 +630,64 @@ func TestAPI_Logout_KicksAndRevokesAndAudits(t *testing.T) {
 	}
 	if !foundLogout {
 		t.Errorf("expected EventLogout in audit, got %v", events)
+	}
+}
+
+// logout 只作废当前请求携带的 HTTP token,不影响同 uid 的其他 token。
+func TestAPI_Logout_InvalidatesCurrentHTTPTokenOnly(t *testing.T) {
+	mp := NewMockProvider(t)
+	o := newTestOIDC(t, mp, &fakeUserLookup{}, newFakeIdentityStore())
+	c := common.NewMemoryCache()
+	const (
+		uid          = "u-logout-current"
+		currentToken = "tok-current"
+		otherToken   = "tok-other"
+	)
+	if err := c.Set("token:"+currentToken, "u-logout-current@test"); err != nil {
+		t.Fatalf("seed current token: %v", err)
+	}
+	if err := c.Set("token:"+otherToken, "u-logout-current@test"); err != nil {
+		t.Fatalf("seed other token: %v", err)
+	}
+	if err := c.Set("uidtoken:0"+uid, currentToken); err != nil {
+		t.Fatalf("seed current uidtoken: %v", err)
+	}
+	if err := c.Set("uidtoken:1"+uid, otherToken); err != nil {
+		t.Fatalf("seed other uidtoken: %v", err)
+	}
+	o.tokenKill = cacheCurrentTokenInvalidator{
+		cache:          c,
+		tokenPrefix:    "token:",
+		uidTokenPrefix: "uidtoken:",
+	}
+	o.killer = &fakeKiller{}
+	o.revoker = &fakeRevoker{}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/v1/auth/oidc/aegis/logout", func(gc *gin.Context) {
+		gc.Set("uid", uid)
+		o.logout(wrapWk(gc))
+	})
+	req := httptest.NewRequest("POST", "/v1/auth/oidc/aegis/logout", nil)
+	req.Header.Set("token", currentToken)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if got, _ := c.Get("token:" + currentToken); got != "" {
+		t.Fatalf("current token still cached: %q", got)
+	}
+	if got, _ := c.Get("uidtoken:0" + uid); got != "" {
+		t.Fatalf("current uidtoken index still cached: %q", got)
+	}
+	if got, _ := c.Get("token:" + otherToken); got == "" {
+		t.Fatalf("other token should remain cached")
+	}
+	if got, _ := c.Get("uidtoken:1" + uid); got != otherToken {
+		t.Fatalf("other uidtoken index = %q, want %q", got, otherToken)
 	}
 }
 

--- a/modules/oidc/api_test.go
+++ b/modules/oidc/api_test.go
@@ -691,6 +691,57 @@ func TestAPI_Logout_InvalidatesCurrentHTTPTokenOnly(t *testing.T) {
 	}
 }
 
+type raceyCompareDeleter struct {
+	cache    *common.MemoryCache
+	newToken string
+}
+
+func (d raceyCompareDeleter) DeleteIfValue(key, want string) (bool, error) {
+	if err := d.cache.Set(key, d.newToken); err != nil {
+		return false, err
+	}
+	got, err := d.cache.Get(key)
+	if err != nil {
+		return false, err
+	}
+	if got == want {
+		return true, d.cache.Delete(key)
+	}
+	return false, nil
+}
+
+func TestCurrentTokenInvalidator_DoesNotDeleteConcurrentUIDTokenUpdate(t *testing.T) {
+	c := common.NewMemoryCache()
+	const (
+		uid          = "u-race-index"
+		currentToken = "tok-current"
+		newToken     = "tok-new-login"
+	)
+	if err := c.Set("token:"+currentToken, "u-race-index@test"); err != nil {
+		t.Fatalf("seed current token: %v", err)
+	}
+	if err := c.Set("uidtoken:1"+uid, currentToken); err != nil {
+		t.Fatalf("seed uidtoken: %v", err)
+	}
+	invalidator := cacheCurrentTokenInvalidator{
+		cache:          c,
+		tokenPrefix:    "token:",
+		uidTokenPrefix: "uidtoken:",
+		indexDel:       raceyCompareDeleter{cache: c, newToken: newToken},
+	}
+
+	if err := invalidator.InvalidateCurrentToken(context.Background(), uid, currentToken); err != nil {
+		t.Fatalf("InvalidateCurrentToken: %v", err)
+	}
+
+	if got, _ := c.Get("token:" + currentToken); got != "" {
+		t.Fatalf("current token still cached: %q", got)
+	}
+	if got, _ := c.Get("uidtoken:1" + uid); got != newToken {
+		t.Fatalf("concurrent uidtoken update was deleted: got %q, want %q", got, newToken)
+	}
+}
+
 // 未登录 logout:无 uid → 401,不调踢线/吊销/审计。
 func TestAPI_Logout_NoAuth_Rejected(t *testing.T) {
 	mp := NewMockProvider(t)

--- a/modules/oidc/metrics.go
+++ b/modules/oidc/metrics.go
@@ -44,10 +44,12 @@ func callbackResultLabels() []string {
 	}
 }
 
-func stateConsumeResultLabels() []string  { return []string{"ok", "miss"} }
-func logoutResultLabels() []string        { return []string{"ok", "kick_fail", "revoke_fail"} }
-func syncTickResultLabels() []string      { return []string{"ran", "lock_held", "lock_err"} }
-func syncProcessedResultLabels() []string { return []string{"ok", "invalid_grant", "transient", "panic"} }
+func stateConsumeResultLabels() []string { return []string{"ok", "miss"} }
+func logoutResultLabels() []string       { return []string{"ok", "kick_fail", "token_fail", "revoke_fail"} }
+func syncTickResultLabels() []string     { return []string{"ran", "lock_held", "lock_err"} }
+func syncProcessedResultLabels() []string {
+	return []string{"ok", "invalid_grant", "transient", "panic"}
+}
 func syncVerificationSyncedResultLabels() []string {
 	// YUJ-405:SyncWorker rotate 后 /userinfo → upsert 的结果维度。
 	// YUJ-409 Round 2:新增 sub_mismatch(ownership 校验失败)和 fetch_nil
@@ -137,7 +139,7 @@ var (
 	metricLogoutTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metricNamespace,
 		Name:      "logout_total",
-		Help:      "POST /logout outcomes (ok|kick_fail|revoke_fail).",
+		Help:      "POST /logout outcomes (ok|kick_fail|token_fail|revoke_fail).",
 	}, []string{"result"})
 
 	metricSyncTickTotal = promauto.NewCounterVec(prometheus.CounterOpts{

--- a/modules/oidc/metrics_test.go
+++ b/modules/oidc/metrics_test.go
@@ -39,7 +39,7 @@ func TestMetrics_StateConsumeTotal_Labels(t *testing.T) {
 }
 
 func TestMetrics_LogoutTotal_Labels(t *testing.T) {
-	for _, result := range []string{"ok", "kick_fail", "revoke_fail"} {
+	for _, result := range []string{"ok", "kick_fail", "token_fail", "revoke_fail"} {
 		_, err := metricLogoutTotal.GetMetricWithLabelValues(result)
 		assert.NoError(t, err)
 	}

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -2027,7 +2027,11 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserIMCallFailed)
 		return
 	}
-	if strings.TrimSpace(token) == "" {
+	// 复用 uidtoken 反查到的旧 token 前,必须确认 token:<oldToken> 仍存在,
+	// 否则与并发 logout 删除 token 形成 TOCTOU 竞态,会复活已登出的会话。
+	// 这里只标记是否复用,真正写缓存时用 SET XX 校验(见下方 UpdateIMToken 之前)。
+	reuseExistingToken := strings.TrimSpace(token) != ""
+	if !reuseExistingToken {
 		token = util.GenerUUID()
 	}
 
@@ -2085,6 +2089,44 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 			}
 		}
 	}
+	// 在调用 IM 之前确定最终 token 并写入缓存。
+	// 复用旧 token 时用 SET XX(SetIfExists):仅当 token:<oldToken> 仍存在才刷新;
+	// 若已被并发 logout 删除,则回退到新 UUID,避免复活已登出的 token。
+	tokenPayload, err := auth.Encode(auth.TokenInfo{
+		UID:      userModel.UID,
+		Name:     userModel.Name,
+		Language: userModel.Language,
+	})
+	if err != nil {
+		u.Error("编码token缓存失败！", zap.Error(err))
+		respondUserError(c, errcode.ErrUserStoreFailed)
+		return
+	}
+	if reuseExistingToken {
+		refreshed, err := u.refreshExistingLoginToken(
+			u.ctx.GetConfig().Cache.TokenCachePrefix+token,
+			tokenPayload,
+			u.ctx.GetConfig().Cache.TokenExpire,
+		)
+		if err != nil {
+			u.Error("刷新旧token缓存失败！", zap.Error(err))
+			respondUserError(c, errcode.ErrUserStoreFailed)
+			return
+		}
+		if !refreshed {
+			token = util.GenerUUID()
+			reuseExistingToken = false
+		}
+	}
+	if !reuseExistingToken {
+		err = u.ctx.Cache().SetAndExpire(u.ctx.GetConfig().Cache.TokenCachePrefix+token, tokenPayload, u.ctx.GetConfig().Cache.TokenExpire)
+		if err != nil {
+			u.Error("设置token缓存失败！", zap.Error(err))
+			respondUserError(c, errcode.ErrUserStoreFailed)
+			return
+		}
+	}
+
 	imResp, err := u.ctx.UpdateIMToken(config.UpdateIMTokenReq{
 		UID:         scaner,
 		Token:       token,
@@ -2101,22 +2143,6 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 		return
 	}
 
-	// 将token设置到缓存
-	tokenPayload, err := auth.Encode(auth.TokenInfo{
-		UID:      userModel.UID,
-		Name:     userModel.Name,
-		Language: userModel.Language,
-	})
-	if err != nil {
-		u.Error("编码token缓存失败！", zap.Error(err))
-		return
-	}
-	err = u.ctx.Cache().SetAndExpire(u.ctx.GetConfig().Cache.TokenCachePrefix+token, tokenPayload, u.ctx.GetConfig().Cache.TokenExpire)
-	if err != nil {
-		u.Error("设置token缓存失败！", zap.Error(err))
-		respondUserError(c, errcode.ErrUserStoreFailed)
-		return
-	}
 	err = u.ctx.GetRedisConn().Del(authCodeKey)
 	if err != nil {
 		u.Error("删除授权码失败！", zap.Error(err))

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -70,17 +70,17 @@ var qrcodeChanLock sync.RWMutex
 
 // User 用户相关API
 type User struct {
-	db            *DB
-	friendDB      *friendDB
-	deviceDB      *deviceDB
-	smsServie     commonapi.ISMSService
-	fileService   file.IService
-	settingDB     *SettingDB
-	onlineDB      *onlineDB
-	userService   IService
-	onlineService *OnlineService
-	giteeDB       *giteeDB
-	githubDB      *githubDB
+	db             *DB
+	friendDB       *friendDB
+	deviceDB       *deviceDB
+	smsServie      commonapi.ISMSService
+	fileService    file.IService
+	settingDB      *SettingDB
+	onlineDB       *onlineDB
+	userService    IService
+	onlineService  *OnlineService
+	giteeDB        *giteeDB
+	githubDB       *githubDB
 	pinnedDB       *PinnedDB
 	pinned         *Pinned
 	spaceSettingDB *SpaceSettingDB
@@ -105,6 +105,22 @@ type User struct {
 	loginGuard               *LoginGuard
 	verificationDB           *verificationDB
 	languageService          *LanguageService
+	existingTokenSetter      existingTokenSetter
+}
+
+type existingTokenSetter interface {
+	SetIfExists(key string, value string, expire time.Duration) (bool, error)
+}
+
+type redisExistingTokenSetter struct {
+	client *rd.Client
+}
+
+func (s redisExistingTokenSetter) SetIfExists(key string, value string, expire time.Duration) (bool, error) {
+	if s.client == nil {
+		return false, nil
+	}
+	return s.client.SetXX(key, value, expire).Result()
 }
 
 // New New
@@ -139,6 +155,11 @@ func New(ctx *config.Context) *User {
 		pinnedDB:                 NewPinnedDB(ctx),
 		spaceSettingDB:           NewSpaceSettingDB(ctx.DB()),
 		verificationDB:           newVerificationDB(ctx),
+		existingTokenSetter: redisExistingTokenSetter{
+			client: rd.NewClient(octoredis.MustBuildOptions(ctx.GetConfig(), func(o *rd.Options) {
+				o.PoolSize = 10
+			})),
+		},
 	}
 	// LanguageService 与 main.go 注入到 CacheTokenParser 的实例独立构造，但共享
 	// 底层 *DB session / Redis 连接，因此读写同一份 user.language 列与
@@ -1476,6 +1497,7 @@ func (u *User) execLogin(userInfo *Model, flag config.DeviceFlag, device *device
 		tokenSpan.Finish()
 		return nil, errors.New("获取旧token错误")
 	}
+	reuseExistingToken := false
 	if flag == config.APP {
 		if oldToken != "" {
 			err = u.ctx.Cache().Delete(u.ctx.GetConfig().Cache.TokenCachePrefix + oldToken)
@@ -1488,6 +1510,7 @@ func (u *User) execLogin(userInfo *Model, flag config.DeviceFlag, device *device
 	} else { // PC暂时不执行删除操作，因为PC可以同时登陆
 		if strings.TrimSpace(oldToken) != "" { // 如果是web或pc类设备 因为支持多登所以这里依然使用老token
 			token = oldToken
+			reuseExistingToken = true
 		}
 	}
 
@@ -1502,11 +1525,30 @@ func (u *User) execLogin(userInfo *Model, flag config.DeviceFlag, device *device
 		tokenSpan.Finish()
 		return nil, errors.New("设置token缓存失败！")
 	}
-	err = u.ctx.Cache().SetAndExpire(u.ctx.GetConfig().Cache.TokenCachePrefix+token, tokenPayload, u.ctx.GetConfig().Cache.TokenExpire)
-	if err != nil {
-		u.Error("设置token缓存失败！", zap.Error(err))
-		tokenSpan.Finish()
-		return nil, errors.New("设置token缓存失败！")
+	if reuseExistingToken {
+		var refreshed bool
+		refreshed, err = u.refreshExistingLoginToken(
+			u.ctx.GetConfig().Cache.TokenCachePrefix+token,
+			tokenPayload,
+			u.ctx.GetConfig().Cache.TokenExpire,
+		)
+		if err != nil {
+			u.Error("刷新旧token缓存失败！", zap.Error(err))
+			tokenSpan.Finish()
+			return nil, errors.New("设置token缓存失败！")
+		}
+		if !refreshed {
+			token = util.GenerUUID()
+			reuseExistingToken = false
+		}
+	}
+	if !reuseExistingToken {
+		err = u.ctx.Cache().SetAndExpire(u.ctx.GetConfig().Cache.TokenCachePrefix+token, tokenPayload, u.ctx.GetConfig().Cache.TokenExpire)
+		if err != nil {
+			u.Error("设置token缓存失败！", zap.Error(err))
+			tokenSpan.Finish()
+			return nil, errors.New("设置token缓存失败！")
+		}
 	}
 	err = u.ctx.Cache().SetAndExpire(fmt.Sprintf("%s%d%s", u.ctx.GetConfig().Cache.UIDTokenCachePrefix, flag, userInfo.UID), token, u.ctx.GetConfig().Cache.TokenExpire)
 	if err != nil {
@@ -1540,6 +1582,13 @@ func (u *User) execLogin(userInfo *Model, flag config.DeviceFlag, device *device
 	resp := newLoginUserDetailResp(userInfo, token, u.ctx)
 	u.applyRealnameToLoginResp(resp, userInfo.UID)
 	return resp, nil
+}
+
+func (u *User) refreshExistingLoginToken(key string, payload string, expire time.Duration) (bool, error) {
+	if u.existingTokenSetter == nil {
+		return false, nil
+	}
+	return u.existingTokenSetter.SetIfExists(key, payload, expire)
 }
 
 // sendWelcomeMsg 发送欢迎语

--- a/modules/user/api_authcode_token_redis_test.go
+++ b/modules/user/api_authcode_token_redis_test.go
@@ -1,0 +1,54 @@
+package user
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// PR #225 R3 Blocking (yujiawei) 的真实 Redis 集成回归。
+//
+// resurrection 漏洞的本质是对 token:<oldToken> 的 Redis 写:扫码登录(loginWithAuthCode)
+// 复用 uidtoken 反查到的旧 token 时,必须用 SET XX(仅当 key 仍存在才写),否则会把并发
+// OIDC logout 刚删掉的 token 复活。这里用生产路径的 redisExistingTokenSetter(真实
+// go-redis SET XX)直接验证两条不变量;loginWithAuthCode 确实在调 IM 之前走这个 setter,
+// 由源码锁 TestLoginWithAuthCode_ReusedTokenGuardedBySetXX 保证。
+//
+// 只依赖 Redis(CI 必备),不碰 WuKongIM —— 完整 HTTP e2e 因 CI 的 IM 不接受给未注册 uid
+// 发 token(UpdateIMToken 返回 im_call_failed)而不可移植,故下沉到 race 真正发生的
+// Redis 层。配套 fake 实现的纯单测见 TestRefreshExistingLoginToken_DoesNotRecreateDeletedToken。
+func TestRedisExistingTokenSetter_SetXX_RealRedis(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	setter := redisExistingTokenSetter{
+		client: rd.NewClient(octoredis.MustBuildOptions(ctx.GetConfig())),
+	}
+	prefix := ctx.GetConfig().Cache.TokenCachePrefix
+
+	t.Run("key不存在_不创建_模拟logout已删除", func(t *testing.T) {
+		key := prefix + "pr225-missing-" + util.GenerUUID()
+		require.NoError(t, ctx.GetRedisConn().Del(key)) // 前置:token:<old> 已被 logout 删除
+		ok, err := setter.SetIfExists(key, "payload", time.Minute)
+		require.NoError(t, err)
+		assert.False(t, ok, "SET XX 对不存在的 key 必须返回 false,不能复活已登出 token")
+		got, err := ctx.Cache().Get(key)
+		require.NoError(t, err)
+		assert.Empty(t, got, "已登出的 token key 不得被重新创建")
+	})
+
+	t.Run("key存在_刷新payload_保证Web多端复用", func(t *testing.T) {
+		key := prefix + "pr225-exists-" + util.GenerUUID()
+		require.NoError(t, ctx.Cache().SetAndExpire(key, "old-payload", time.Minute))
+		ok, err := setter.SetIfExists(key, "new-payload", time.Minute)
+		require.NoError(t, err)
+		assert.True(t, ok, "SET XX 对存在的 key 必须返回 true(正常 Web 多端复用)")
+		got, err := ctx.Cache().Get(key)
+		require.NoError(t, err)
+		assert.Equal(t, "new-payload", got, "SET XX 必须刷新已存在 key 的 payload")
+	})
+}

--- a/modules/user/api_authcode_token_test.go
+++ b/modules/user/api_authcode_token_test.go
@@ -1,0 +1,46 @@
+package user
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// PR #225 R3 Blocking (yujiawei) — 扫码登录(loginWithAuthCode)复用 uidtoken 反查到的
+// 旧 token 时,必须先确认 token:<oldToken> 仍存在(SET XX),否则与并发 OIDC logout
+// 删除 token 形成 TOCTOU,会把刚 logout 的 HTTP token 复活,绕过登出。
+//
+// 该 handler 依赖 IM/DB/Redis,CI 单测环境不便端到端跑,这里用源码契约锁(无依赖,
+// 一定跑)锁住关键不变量,防止守卫被回归掉。配套的 SET XX 行为单测见
+// TestRefreshExistingLoginToken_DoesNotRecreateDeletedToken。
+func TestLoginWithAuthCode_ReusedTokenGuardedBySetXX(t *testing.T) {
+	src, err := os.ReadFile("api.go")
+	require.NoError(t, err)
+	body := string(src)
+
+	fnSig := "func (u *User) loginWithAuthCode("
+	fnStart := strings.Index(body, fnSig)
+	require.NotEqual(t, -1, fnStart, "loginWithAuthCode handler 必须存在")
+	fnEnd := strings.Index(body[fnStart+len(fnSig):], "\nfunc ")
+	require.NotEqual(t, -1, fnEnd)
+	fnBody := body[fnStart : fnStart+len(fnSig)+fnEnd]
+
+	// 1. 复用旧 token 必须走 SET XX 守卫(refreshExistingLoginToken),
+	//    不能再无条件 SetAndExpire 复活 token key。
+	assert.Contains(t, fnBody, "u.refreshExistingLoginToken(",
+		"loginWithAuthCode 复用旧 token 必须经 refreshExistingLoginToken(SET XX)校验,避免复活已登出 token")
+
+	// 2. 必须保留 reuseExistingToken 标记,SetAndExpire 只能在 !reuseExistingToken 分支兜底。
+	assert.Contains(t, fnBody, "if !reuseExistingToken {",
+		"loginWithAuthCode 只能在 !reuseExistingToken 分支无条件写 token 缓存")
+
+	// 3. token 缓存的最终决策必须在调用 IM 之前完成,否则 IM 会拿到回退前的旧 token。
+	guardIdx := strings.Index(fnBody, "u.refreshExistingLoginToken(")
+	imIdx := strings.Index(fnBody, "u.ctx.UpdateIMToken(")
+	require.NotEqual(t, -1, imIdx, "loginWithAuthCode 必须调用 UpdateIMToken")
+	assert.Less(t, guardIdx, imIdx,
+		"token 复用/回退决策必须在 UpdateIMToken 之前,确保 IM 使用最终 token")
+}

--- a/modules/user/api_login_token_test.go
+++ b/modules/user/api_login_token_test.go
@@ -1,0 +1,40 @@
+package user
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeExistingTokenSetter struct {
+	cache *common.MemoryCache
+}
+
+func (f fakeExistingTokenSetter) SetIfExists(key string, value string, expire time.Duration) (bool, error) {
+	got, err := f.cache.Get(key)
+	if err != nil {
+		return false, err
+	}
+	if got == "" {
+		return false, nil
+	}
+	return true, f.cache.SetAndExpire(key, value, expire)
+}
+
+// Web/PC 登录复用 uidtoken 里的旧 token 时,必须使用 "SET XX" 语义刷新 token。
+// 如果 OIDC logout 已经先删除 token:<oldToken>,登录路径不能把同一个 token key
+// 重新创建出来,否则刚 logout 的 HTTP token 会被并发登录复活。
+func TestRefreshExistingLoginToken_DoesNotRecreateDeletedToken(t *testing.T) {
+	c := common.NewMemoryCache()
+	u := &User{existingTokenSetter: fakeExistingTokenSetter{cache: c}}
+
+	ok, err := u.refreshExistingLoginToken("token:logged-out", "payload", time.Minute)
+	require.NoError(t, err)
+	require.False(t, ok, "missing token key must not be recreated")
+
+	got, err := c.Get("token:logged-out")
+	require.NoError(t, err)
+	require.Empty(t, got)
+}


### PR DESCRIPTION
## Summary
- invalidate the current HTTP API token during OIDC logout
- remove matching uidtoken reverse index only when it atomically still points to the current token
- prevent Web/PC login from recreating a token that logout has already deleted
- add logout token_fail metrics label and regression coverage

Closes #227

## Tests
- go test ./modules/user -run TestRefreshExistingLoginToken_DoesNotRecreateDeletedToken
- go test ./modules/oidc -run 'TestAPI_Logout|TestCurrentTokenInvalidator|TestMetrics_LogoutTotal_Labels'
- git diff --check

## Notes
- This intentionally invalidates only the current request token, not every token for the UID.