### PR TITLE
fix(message): apply group revoke permission to community topics (#222)

### DIFF
--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -2111,29 +2111,53 @@ func (m *Message) hasRevokePermission(messageM *messageModel, loginUID string) (
 			return true, nil
 		}
 	}
-	if messageM.ChannelType == common.ChannelTypeGroup.Uint8() { // 管理者或创建者可以撤回其他成员的消息
-		loginMember, err := m.groupService.GetMember(messageM.ChannelID, loginUID)
-		if err != nil {
-			return false, err
-		}
-		if loginMember == nil {
+	switch messageM.ChannelType {
+	case common.ChannelTypeGroup.Uint8(): // 管理者或创建者可以撤回其他成员的消息
+		return m.groupRoleRevokeAllowed(messageM.ChannelID, messageM.FromUID, loginUID)
+	case common.ChannelTypeCommunityTopic.Uint8():
+		// issue #222: 子区沿用群聊撤回权限，权限判断基于父群角色（与 authorizeMutualDelete
+		// 的子区逻辑对齐）；忽略子区创建人概念，不给创建人额外特权。
+		parentGroupNo, _, perr := thread.ParseChannelID(messageM.ChannelID)
+		if perr != nil {
+			// fail-closed：无法解析出父群即视为无权限（与 delete2 解析失败的处理一致）。
+			m.Warn("解析子区频道ID失败，拒绝撤回",
+				zap.Error(perr), zap.String("channelID", messageM.ChannelID))
 			return false, nil
 		}
-		fromMember, err := m.groupService.GetMember(messageM.ChannelID, messageM.FromUID)
-		if err != nil {
-			return false, err
-		}
-		if fromMember == nil {
-			// 消息发送者已不在群：管理员/创建者可撤回，普通成员不可
-			return loginMember.Role != int(common.GroupMemberRoleNormal), nil
-		}
-		if fromMember.Role == int(common.GroupMemberRoleCreater) || loginMember.Role == int(common.GroupMemberRoleNormal) {
-			return false, nil
-		}
-		if loginMember.Role == int(common.GroupMemberRoleCreater) || (loginMember.Role == int(common.GroupMemberRoleManager) && fromMember.Role == int(common.GroupMemberRoleNormal)) {
-			return true, nil
-		}
+		return m.groupRoleRevokeAllowed(parentGroupNo, messageM.FromUID, loginUID)
+	}
 
+	return false, nil
+}
+
+// groupRoleRevokeAllowed 按群聊撤回权限矩阵判定 loginUID 是否可撤回 fromUID 在
+// groupNo 群内发的消息。子区（CommunityTopic）传入解析出的父群 groupNo 即可复用同一矩阵。
+//   - 群主：可撤回任何人的消息
+//   - 管理员：仅可撤回普通成员的消息，不能撤回其他管理员或群主
+//   - 普通成员：不能撤回他人（撤回自己的消息已在上层短路）
+//
+// 注意：自己发的消息、bot-owner 等短路分支由调用方 hasRevokePermission 在进入此方法前处理。
+func (m *Message) groupRoleRevokeAllowed(groupNo, fromUID, loginUID string) (bool, error) {
+	loginMember, err := m.groupService.GetMember(groupNo, loginUID)
+	if err != nil {
+		return false, err
+	}
+	if loginMember == nil {
+		return false, nil
+	}
+	fromMember, err := m.groupService.GetMember(groupNo, fromUID)
+	if err != nil {
+		return false, err
+	}
+	if fromMember == nil {
+		// 消息发送者已不在群：管理员/创建者可撤回，普通成员不可
+		return loginMember.Role != int(common.GroupMemberRoleNormal), nil
+	}
+	if fromMember.Role == int(common.GroupMemberRoleCreater) || loginMember.Role == int(common.GroupMemberRoleNormal) {
+		return false, nil
+	}
+	if loginMember.Role == int(common.GroupMemberRoleCreater) || (loginMember.Role == int(common.GroupMemberRoleManager) && fromMember.Role == int(common.GroupMemberRoleNormal)) {
+		return true, nil
 	}
 
 	return false, nil

--- a/modules/message/revoke_topic_integration_test.go
+++ b/modules/message/revoke_topic_integration_test.go
@@ -1,0 +1,103 @@
+//go:build integration
+
+package message
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// issue #222 集成测试：用真实 groupService（真实 MySQL）验证子区
+// （CommunityTopic）撤回权限端到端链路。
+//
+// 与 revoke_topic_test.go 的单元测试互补：单元测试用的 fakeGroupService 忽略
+// groupNo（按 uid 返回），无法验证「子区用解析出的父群号查成员角色」是否正确。
+// 这里建真实的 group_member 行、调真实 group.Service.GetMember——若
+// hasRevokePermission 误用子区 channelID（含 "____shortID"）而非父群号去查，
+// GetMember 将查不到任何成员、所有用例都会拒绝，从而暴露回归。
+//
+// 与 default_followed_group_guard_e2e_test.go / api_sidebar_integration_test.go
+// 一致，本测试挂在 `integration` build tag 下、跑在独立的 conv_ext_test 库上：
+//   - CI 常规 `go test ./...`（不带 tag）不编译本文件，因此不会与 message 包内
+//     裸建表的单元测试（api_channel_files_test.go 等）在共享 test 库的 sql-migrate
+//     上冲突（参见 issue #17）。
+//   - 手动 `go test -tags=integration -run TestHasRevokePermission_CommunityTopic_Integration ./modules/message/`
+//     时才运行，针对 conv_ext_test 库，与 test 库隔离。
+//
+// robotService 注入空实现（消息发送者非 bot），聚焦父群角色矩阵这条真实 DB 链路；
+// bot-owner / channelID 解析失败等分支由 revoke_topic_test.go 单元测试覆盖。
+func TestHasRevokePermission_CommunityTopic_Integration(t *testing.T) {
+	ctx := newSidebarIntegCtx(t)
+	ensureGuardE2ETables(t, ctx) // DROP+CREATE group/group_member/group_setting，天然清空
+
+	// group.Service.GetMember 会 LEFT JOIN user 取 name；该库不一定有 user 表，
+	// 建一个最小表满足 JOIN（成员 name 由 IFNULL 兜底，无需插行）。
+	_, err := ctx.DB().Exec("CREATE TABLE IF NOT EXISTS `user` (" +
+		"`id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY," +
+		"`uid` VARCHAR(40) NOT NULL DEFAULT ''," +
+		"`name` VARCHAR(100) NOT NULL DEFAULT ''" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4")
+	require.NoError(t, err, "create minimal user table")
+
+	const (
+		groupNo    = "e2eint-grp"
+		creatorUID = "e2eint-creator"
+		managerA   = "e2eint-mgr-a"
+		managerB   = "e2eint-mgr-b"
+		normalA    = "e2eint-normal-a"
+		normalB    = "e2eint-normal-b"
+		outsider   = "e2eint-outsider"
+	)
+	// 子区频道 ID 形如 "父群No____shortID"；ParseChannelID 解析得父群 groupNo。
+	topicChannelID := groupNo + "____123456789012345"
+
+	seedMember := func(uid string, role int) {
+		_, err := ctx.DB().Exec(
+			"INSERT INTO group_member (group_no, uid, role, is_deleted, status, version, vercode) "+
+				"VALUES (?, ?, ?, 0, 1, 1, ?)",
+			groupNo, uid, role, uid+"-vc",
+		)
+		require.NoError(t, err, "seed group_member %s", uid)
+	}
+	seedMember(creatorUID, group.MemberRoleCreator)
+	seedMember(managerA, group.MemberRoleManager)
+	seedMember(managerB, group.MemberRoleManager)
+	seedMember(normalA, group.MemberRoleCommon)
+	seedMember(normalB, group.MemberRoleCommon)
+	// outsider 故意不入群
+
+	// 真实 group.Service（查真实 group_member 表）+ 空 robot 服务（发送者非 bot）。
+	m := newRevokeTestMessage(&fakeRobotService{byRobotID: map[string]string{}}, group.NewService(ctx))
+
+	tests := []struct {
+		name     string
+		fromUID  string
+		loginUID string
+		want     bool
+	}{
+		{"群主可撤回普通成员消息", normalA, creatorUID, true},
+		{"群主可撤回管理员消息", managerA, creatorUID, true},
+		{"管理员可撤回普通成员消息", normalA, managerA, true},
+		{"管理员不能撤回其他管理员消息", managerB, managerA, false},
+		{"管理员不能撤回群主消息", creatorUID, managerA, false},
+		{"普通成员不能撤回他人消息", normalB, normalA, false},
+		{"非父群成员不能撤回消息", normalA, outsider, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := &messageModel{
+				FromUID:     tt.fromUID,
+				ChannelID:   topicChannelID,
+				ChannelType: common.ChannelTypeCommunityTopic.Uint8(),
+			}
+			allow, err := m.hasRevokePermission(msg, tt.loginUID)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, allow)
+		})
+	}
+}

--- a/modules/message/revoke_topic_test.go
+++ b/modules/message/revoke_topic_test.go
@@ -1,0 +1,196 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/stretchr/testify/assert"
+)
+
+// issue #222: 子区（CommunityTopic）撤回权限单元测试。
+//
+// 验证 hasRevokePermission 对子区的处理：解析出父群后，复用群聊撤回权限矩阵
+// （基于父群角色判断），忽略子区创建人概念。撤回自己消息 / bot-owner 等短路
+// 分支在群聊用例（revoke_bot_test.go）已覆盖，这里聚焦父群角色矩阵与子区
+// 频道 ID 解析。
+//
+// fakeGroupService.GetMember 忽略 groupNo、按 uid 返回，因此父群 GroupNo 用
+// 解析自 topicChannelID 的 "PG1" 即可，无需在 members 里区分群号。
+
+const (
+	// topicChannelID 形如 "父群No____shortID"，thread.ParseChannelID 解析得父群 "PG1"。
+	topicChannelID  = "PG1____123456789012345"
+	topicCreaterUID = "topic_creater"
+	topicManagerUID = "topic_manager"
+	topicManager2ID = "topic_manager2"
+	topicNormalUID  = "topic_normal"
+	topicNormal2ID  = "topic_normal2"
+	topicOutsiderID = "topic_outsider"
+)
+
+func member(uid string, role common.GroupMemberRole) *group.MemberResp {
+	return &group.MemberResp{GroupNo: "PG1", UID: uid, Role: int(role)}
+}
+
+func TestHasRevokePermission_CommunityTopic_ParentRoleMatrix(t *testing.T) {
+	tests := []struct {
+		name     string
+		members  map[string]*group.MemberResp // key: uid（父群成员关系，nil 表示不在群）
+		fromUID  string
+		loginUID string
+		want     bool
+	}{
+		{
+			name: "群主可撤回普通成员消息",
+			members: map[string]*group.MemberResp{
+				topicCreaterUID: member(topicCreaterUID, common.GroupMemberRoleCreater),
+				topicNormalUID:  member(topicNormalUID, common.GroupMemberRoleNormal),
+			},
+			fromUID:  topicNormalUID,
+			loginUID: topicCreaterUID,
+			want:     true,
+		},
+		{
+			name: "群主可撤回管理员消息",
+			members: map[string]*group.MemberResp{
+				topicCreaterUID: member(topicCreaterUID, common.GroupMemberRoleCreater),
+				topicManagerUID: member(topicManagerUID, common.GroupMemberRoleManager),
+			},
+			fromUID:  topicManagerUID,
+			loginUID: topicCreaterUID,
+			want:     true,
+		},
+		{
+			name: "管理员可撤回普通成员消息",
+			members: map[string]*group.MemberResp{
+				topicManagerUID: member(topicManagerUID, common.GroupMemberRoleManager),
+				topicNormalUID:  member(topicNormalUID, common.GroupMemberRoleNormal),
+			},
+			fromUID:  topicNormalUID,
+			loginUID: topicManagerUID,
+			want:     true,
+		},
+		{
+			name: "管理员不能撤回其他管理员消息",
+			members: map[string]*group.MemberResp{
+				topicManagerUID: member(topicManagerUID, common.GroupMemberRoleManager),
+				topicManager2ID: member(topicManager2ID, common.GroupMemberRoleManager),
+			},
+			fromUID:  topicManager2ID,
+			loginUID: topicManagerUID,
+			want:     false,
+		},
+		{
+			name: "管理员不能撤回群主消息",
+			members: map[string]*group.MemberResp{
+				topicManagerUID: member(topicManagerUID, common.GroupMemberRoleManager),
+				topicCreaterUID: member(topicCreaterUID, common.GroupMemberRoleCreater),
+			},
+			fromUID:  topicCreaterUID,
+			loginUID: topicManagerUID,
+			want:     false,
+		},
+		{
+			name: "普通成员不能撤回他人消息",
+			members: map[string]*group.MemberResp{
+				topicNormalUID: member(topicNormalUID, common.GroupMemberRoleNormal),
+				topicNormal2ID: member(topicNormal2ID, common.GroupMemberRoleNormal),
+			},
+			fromUID:  topicNormal2ID,
+			loginUID: topicNormalUID,
+			want:     false,
+		},
+		{
+			name: "非父群成员不能撤回消息",
+			members: map[string]*group.MemberResp{
+				topicNormalUID: member(topicNormalUID, common.GroupMemberRoleNormal),
+				// topicOutsiderID 不在父群 → loginMember 为 nil
+			},
+			fromUID:  topicNormalUID,
+			loginUID: topicOutsiderID,
+			want:     false,
+		},
+		{
+			name: "发送者已退群-管理员可撤回",
+			members: map[string]*group.MemberResp{
+				topicManagerUID: member(topicManagerUID, common.GroupMemberRoleManager),
+				// fromUID 已退群 → fromMember 为 nil
+			},
+			fromUID:  topicNormalUID,
+			loginUID: topicManagerUID,
+			want:     true,
+		},
+		{
+			name: "发送者已退群-普通成员不可撤回",
+			members: map[string]*group.MemberResp{
+				topicNormalUID: member(topicNormalUID, common.GroupMemberRoleNormal),
+				// fromUID 已退群 → fromMember 为 nil
+			},
+			fromUID:  topicNormal2ID,
+			loginUID: topicNormalUID,
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// robotService 注入空实现：消息发送者非 bot，GetCreatorUID 返回空，
+			// 不会命中 bot-owner 短路，确保走父群角色矩阵。
+			rb := &fakeRobotService{byRobotID: map[string]string{}}
+			m := newRevokeTestMessage(rb, &fakeGroupService{members: tt.members})
+
+			msg := &messageModel{
+				FromUID:     tt.fromUID,
+				ChannelID:   topicChannelID,
+				ChannelType: common.ChannelTypeCommunityTopic.Uint8(),
+			}
+
+			allow, err := m.hasRevokePermission(msg, tt.loginUID)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, allow)
+		})
+	}
+}
+
+// 子区频道 ID 无法解析为父群时，fail-closed 返回 false 且不报错。
+func TestHasRevokePermission_CommunityTopic_InvalidChannelID(t *testing.T) {
+	rb := &fakeRobotService{byRobotID: map[string]string{}}
+	// 即便操作者在某群是群主，channelID 解析失败也必须拒绝。
+	gs := &fakeGroupService{members: map[string]*group.MemberResp{
+		topicCreaterUID: member(topicCreaterUID, common.GroupMemberRoleCreater),
+		topicNormalUID:  member(topicNormalUID, common.GroupMemberRoleNormal),
+	}}
+	m := newRevokeTestMessage(rb, gs)
+
+	msg := &messageModel{
+		FromUID:     topicNormalUID,
+		ChannelID:   "no-separator-here", // 缺少 "____"，ParseChannelID 报错
+		ChannelType: common.ChannelTypeCommunityTopic.Uint8(),
+	}
+
+	allow, err := m.hasRevokePermission(msg, topicCreaterUID)
+	assert.NoError(t, err, "解析失败应 fail-closed，不向上传播 error")
+	assert.False(t, allow, "子区频道ID解析失败必须拒绝撤回")
+}
+
+// 子区内 bot 创建者可撤回自己 bot 发的消息（验证 bot-owner 短路对子区同样生效）。
+func TestHasRevokePermission_CommunityTopic_BotOwner(t *testing.T) {
+	rb := &fakeRobotService{byRobotID: map[string]string{botUID: ownerUID}}
+	// 故意让操作者在父群只是普通成员，确保若 bot-owner 分支未命中必然落 false。
+	gs := &fakeGroupService{members: map[string]*group.MemberResp{
+		ownerUID: member(ownerUID, common.GroupMemberRoleNormal),
+		botUID:   member(botUID, common.GroupMemberRoleNormal),
+	}}
+	m := newRevokeTestMessage(rb, gs)
+
+	msg := &messageModel{
+		FromUID:     botUID,
+		ChannelID:   topicChannelID,
+		ChannelType: common.ChannelTypeCommunityTopic.Uint8(),
+	}
+
+	allow, err := m.hasRevokePermission(msg, ownerUID)
+	assert.NoError(t, err)
+	assert.True(t, allow, "bot 创建者应能在子区撤回自己 bot 发的消息")
+}


### PR DESCRIPTION
## Problem

Closes #222.

CommunityTopic (Thread) messages had no admin revoke logic. Group owners and managers could only revoke their own messages and messages from bots they created, because `hasRevokePermission` (`modules/message/api.go`) only handled `ChannelTypeGroup` and fell through to deny for community topics.

## Change

- Add a `ChannelTypeCommunityTopic` branch to `hasRevokePermission` that resolves the parent group via `thread.ParseChannelID` and reuses the group revoke role matrix.
- Extract the shared role matrix into `groupRoleRevokeAllowed(groupNo, fromUID, loginUID)`, used by both the `Group` and `CommunityTopic` branches. The existing `Group` behavior is unchanged (pure refactor).
- Parse failures fail closed (deny).
- The existing bot-owner short-circuit applies to topics as well.

### Resulting permission matrix (based on parent-group role)

| Operator | Can revoke |
|----------|-----------|
| Owner | anyone |
| Manager | normal members only (not other managers / owner) |
| Normal member | only their own messages |

Per product decision on the issue: topics reuse the channel (group) permission model, topic-creator gets no special privilege, and managers cannot revoke each other. This aligns with how `authorizeMutualDelete` already handles community topics.

## Tests

- `revoke_topic_test.go` — unit tests (fake group service) covering the parent-role matrix, channel-ID parse failure, and the bot-owner branch.
- `revoke_topic_integration_test.go` — integration test (`integration` build tag, isolated DB) exercising the real `group.Service.GetMember` lookup via the resolved parent group. Tagged to stay out of the default CI `test`-DB run to avoid the sql-migrate conflict tracked in #17.

## Test plan

- [x] `go test ./modules/message/` (unit, clean DB) — pass
- [x] `go test -race ./modules/message/` (no tag, mirrors CI) — pass
- [x] `go test -tags=integration -run TestHasRevokePermission_CommunityTopic_Integration ./modules/message/` — pass
- [x] `gofmt` / `go vet` (both tag sets) — clean
