### PR TITLE
docs: add i18n / error-localization conventions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,17 +55,56 @@ Standard module structure:
 | Package | Purpose |
 |---------|---------|
 | `pkg/auth/` | Token parsing, CacheTokenParser, auth middleware |
-| `pkg/errcode/` | Error code definitions per module (group.go, message.go, user.go) |
+| `pkg/errcode/` | Error code definitions per module (group.go, message.go, user.go, oidc.go) |
+| `pkg/httperr/` | `ResponseErrorL` / `ResponseErrorLWithStatus` error facades |
+| `pkg/i18n/` | Localization SDK: codes registry, localizer, renderer, language negotiation, `locales/` |
 | `internal/` | Internal wiring, module imports |
 | `modules/base/event/` | Async event system |
 
-### Error Handling
+### Error Handling & i18n (Localization)
 
-Use `httperr.ResponseErrorL()` with typed error codes from `pkg/errcode/`:
+All user-facing error responses go through the i18n error envelope. **Never** use
+`c.ResponseError(errors.New(...))`, `c.ResponseErrorf(...)`, `c.AbortWithStatusJSON(...)`,
+or non-OK `c.JSON(...)` — these are legacy and bypass the localized envelope.
+
+**Two facades** (`pkg/httperr`) — the envelope body is identical, only the wire status differs:
+
+| Facade | Wire status | Use for |
+|---|---|---|
+| `ResponseErrorL(c, code, params, details)` | pinned **400** (D14 compat); real status in `error.http_status` | **default** — every legacy-bearing endpoint |
+| `ResponseErrorLWithStatus(c, code, params, details)` | the code's real `HTTPStatus` | **new endpoints only** with no clients depending on fixed-400 (currently just `modules/oidc` bind); diverging from D14 needs maintainer sign-off |
+
 ```go
 httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
 ```
-Do NOT use raw `c.ResponseError(errors.New(...))` — that's legacy pattern.
+
+**Error codes** — register in `pkg/errcode/<module>.go`:
+```go
+ErrXxx = register(codes.Code{
+    ID:             "err.server.<module>.<reason>", // or reuse err.shared.* (auth/rate/param/internal/not_found)
+    HTTPStatus:     http.StatusBadRequest,
+    DefaultMessage: "English source (D4).",          // zh-CN runtime translation goes in active.zh-CN.toml
+    SafeDetailKeys: []string{"field"},               // whitelist for details; all other keys are dropped
+    Internal:       false,                            // see invariant below
+})
+```
+- **5xx ⟺ `Internal=true`** (renderer hides the message + details; log the cause via `zap.Error` before responding). 4xx codes must NOT be Internal.
+- **Anti-enumeration**: auth / verify failures map to ONE generic code (e.g. a single 401), never a per-reason code — the specific reason goes to logs only.
+- **Params vs Details** (D15): `params` interpolate into the message template; `details` are structured fields surfaced to the client, filtered by `SafeDetailKeys`.
+
+**Per-module helpers** live in `modules/<module>/api_i18n.go` (`respond<Module>Xxx` for detail-carrying shapes; `mustLookupSharedCode` resolves shared codes at init, panicking loudly if unregistered).
+
+**After adding/changing any code, these must pass** (also enforced in CI):
+```bash
+make i18n-extract        # regenerate en-US markers from codes.Register call sites
+make i18n-extract-check  # 100% recall: every registered code has a marker
+make i18n-lint           # D23 guard (no new raw error responses) + unregistered-code check
+```
+Then add the zh-CN translation to `pkg/i18n/locales/active.zh-CN.toml` (one `["id"]` + `other = "..."` block per code).
+
+**Guard test**: each migrated module has a `Test<Module>NoLegacyResponseError` source guard forbidding legacy/raw responses — add any new handler files to its list. Protocol endpoints that intentionally keep raw responses (e.g. OAuth2/OIDC browser-redirect flow) are exempted and tracked in `tools/lint-direct-error-response/baseline.txt`.
+
+**Emails**: localized templates live in `modules/base/common/emailtmpl/templates/{lang}/` (per-language `subject`/`html`/`text`, go:embed). Send functions take a `lang` arg resolved via `i18n.OutboundLanguage(ctx)` — never hardcode subject/body strings.
 
 ### Rate Limiting
 
@@ -108,6 +147,7 @@ Tests require MySQL + Redis + WuKongIM running (see CI or `make env-test` in dmw
 - API routes: prefix `/v1/`
 - New modules: add blank import in `internal/modules.go`
 - Auth: all routes go through `AuthMiddleware` unless explicitly excluded — document why if skipping
+- i18n: user-facing errors use `httperr.ResponseErrorL` + a registered `pkg/errcode` code; never raw `c.ResponseError`/`c.JSON`/`AbortWithStatusJSON`. Run `make i18n-extract-check` + `make i18n-lint` after touching codes (see Architecture › Error Handling & i18n)
 - Rate limiting: mount `SharedUIDRateLimiter` (auth routes) or `StrictIPRateLimitMiddleware` (unauth) — never hand-roll a Redis counter for request-frequency limiting (see Architecture › Rate Limiting)
 - Space isolation: handlers that access user data must go through Space middleware
 - Bot API (`modules/bot_api/`): validate bot ownership before operations


### PR DESCRIPTION
Part of #170 (backend i18n).

## Summary

Docs-only. Captures the i18n / error-localization conventions in `CLAUDE.md` so future changes follow the playbook established by the migrated modules (#176/#188/#198/#203/#213/#214) and the recent OIDC (#223) and email (#224) work — instead of re-deriving it each time.

## What's documented

- **Two facades** (`pkg/httperr`): `ResponseErrorL` (fixed-400 / D14) vs `ResponseErrorLWithStatus` (real status, new endpoints only), with a comparison table.
- **Error codes** (`pkg/errcode/<module>.go`): registration shape, the **5xx ⟺ `Internal=true`** invariant, anti-enumeration (one generic code), and the Params/Details split.
- **Per-module helpers** (`modules/<module>/api_i18n.go`) and `mustLookupSharedCode`.
- **The required gate**: `make i18n-extract` / `i18n-extract-check` / `i18n-lint`, plus zh-CN translations in `active.zh-CN.toml`.
- **Source guard**: `Test<Module>NoLegacyResponseError` and the `baseline.txt` exemption for protocol endpoints.
- **Emails**: `emailtmpl` localized templates + `i18n.OutboundLanguage(ctx)`.

Also adds `pkg/httperr` / `pkg/i18n` to the Key Packages table and an i18n line to Coding Conventions.

## Test plan

- [x] Docs-only; no code changes. Every command/path/API referenced exists in the tree (verified against #223/#224).
