### PR TITLE
feat(octo-server): RichText=14 server adapt — plain gen + push alert + search index (Phase 1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	firebase.google.com/go/v4 v4.13.0
 	github.com/BurntSushi/toml v1.6.0
 	github.com/DATA-DOG/go-sqlmock v1.5.0
-	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260527083114-263f221a1bfe
+	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260602143311-8c26a826e07b
 	github.com/alibabacloud-go/darabonba-openapi v0.2.1
 	github.com/alibabacloud-go/sms-intl-20180501 v1.0.1
 	github.com/alibabacloud-go/tea v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -65,10 +65,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260525041639-11d9edbc605b h1:k+OHyVQK60l/2eDkuWeBbmLQGQIwG/gjqB/FQ+v8DZw=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260525041639-11d9edbc605b/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260527083114-263f221a1bfe h1:hWnAdfKj+PxFmSslic2UDbIrC+cuFqXvBzW1QlBoUXw=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260527083114-263f221a1bfe/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260602143311-8c26a826e07b h1:twl6DmiVGPv8C7+XFAht9xGIZjetJ6ofW9iujZrDXQI=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260602143311-8c26a826e07b/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae h1:DcFpTQBYQ9Ct2d6sC7ol0/ynxc2pO1cpGUM+f4t5adg=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae/go.mod h1:rJJ84PyA/Wlmw1hO+xTzV2wsSUon6J5ktg0g8BF2PuU=
 github.com/RichardKnop/machinery/v2 v2.0.11 h1:BTfLGOmOju3W/OtlZmLX26OjYNZsU4PJo04pQReycdc=

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
+	"github.com/Mininglamp-OSS/octo-server/pkg/richtext"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"github.com/gocraft/dbr/v2"
@@ -463,6 +464,15 @@ func (m *Message) sendMessage(channelID string, channelType uint8, fromUID strin
 	// BEFORE persistence/dispatch. See sanitizeUserIngressPayload below
 	// for the full rationale and unit test surface.
 	sanitizeUserIngressPayload(payload, channelID, channelType, fromUID, m.Warn)
+	// 图文混排 RichText(=14)：派发出口用 content 重算权威顶层 plain，覆盖客户端
+	// 不可信的 plain（契约 §2）。这一步是下游 summary / matter / search / 复制 /
+	// 推送 全部依赖的前置——server 必须在消息落库 / 进 IM 搜索索引前把权威 plain
+	// 写进 payload 字节。非 type=14 的 payload 此 helper 为 no-op，老消息路径不变。
+	// EnsurePlain 内部对回填 plain 后的整条 payload 复检 1MB 上限，超限拒发。
+	if err := richtext.EnsurePlain(payload); err != nil {
+		m.Error("RichText payload plain 生成失败", zap.Error(err), zap.String("channelID", channelID), zap.String("fromUID", fromUID))
+		return err
+	}
 	// YUJ-202 / Mininglamp-OSS#94 / #142 — mention pass-through chokepoint.
 	// The original Plan X §5 design (docs/2026-05-mention-all-chokepoint-audit.md)
 	// rewrote legacy `mention.all=1` to also carry `mention.ais=1` so

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -445,6 +445,17 @@ func (m *Message) sendMsg(c *wkhttp.Context) {
 	// YUJ-644 / Mininglamp-OSS#33: 把 SpaceMiddleware 已校验的发送方 SpaceID 透传给
 	// sendMessage，作为 PERSONAL DM 的权威 space_id 注入源（不信客户端 body）。
 	senderSpaceID := spacepkg.GetSpaceID(c)
+	// PR#232 review (Jerry-Xin Critical#1): 主用户入口对 RichText(=14) 补 write-strict
+	// 强校验，与 robot 路径（modules/robot/api.go payloadIsVail→ValidateRichTextPayload）
+	// 对称。拒 缺/空 content、空 text 块、data: 图片 URL、缺图片宽高、未知 block type，
+	// 大小上限作用在原始完整 payload 字节。脏 payload 在派发前以 400 拒绝，不进 IM。
+	// EnsurePlain（plain 权威生成 + enrich 后真实出站 payload 的 1MB 复检）在
+	// sendMessage 内、所有 server 端 enrich 之后由 richtext.Finalize 完成。
+	if err := richtext.Validate(req.Payload); err != nil {
+		m.Error("RichText payload 校验失败", zap.Error(err), zap.String("channelID", req.ReceiveChannelID), zap.String("fromUID", uid))
+		respondMessageRequestInvalid(c, "payload")
+		return
+	}
 	err = m.sendMessage(req.ReceiveChannelID, req.ReceiveChannelType, uid, req.Payload, senderSpaceID)
 	if err != nil {
 		m.Error("发送消息失败", zap.Error(err))
@@ -464,15 +475,6 @@ func (m *Message) sendMessage(channelID string, channelType uint8, fromUID strin
 	// BEFORE persistence/dispatch. See sanitizeUserIngressPayload below
 	// for the full rationale and unit test surface.
 	sanitizeUserIngressPayload(payload, channelID, channelType, fromUID, m.Warn)
-	// 图文混排 RichText(=14)：派发出口用 content 重算权威顶层 plain，覆盖客户端
-	// 不可信的 plain（契约 §2）。这一步是下游 summary / matter / search / 复制 /
-	// 推送 全部依赖的前置——server 必须在消息落库 / 进 IM 搜索索引前把权威 plain
-	// 写进 payload 字节。非 type=14 的 payload 此 helper 为 no-op，老消息路径不变。
-	// EnsurePlain 内部对回填 plain 后的整条 payload 复检 1MB 上限，超限拒发。
-	if err := richtext.EnsurePlain(payload); err != nil {
-		m.Error("RichText payload plain 生成失败", zap.Error(err), zap.String("channelID", channelID), zap.String("fromUID", fromUID))
-		return err
-	}
 	// YUJ-202 / Mininglamp-OSS#94 / #142 — mention pass-through chokepoint.
 	// The original Plan X §5 design (docs/2026-05-mention-all-chokepoint-audit.md)
 	// rewrote legacy `mention.all=1` to also carry `mention.ais=1` so
@@ -496,6 +498,20 @@ func (m *Message) sendMessage(channelID string, channelType uint8, fromUID strin
 	// 直接覆盖客户端 payload.space_id，跨 Space 推送时收端 SpaceFilter 拿到权威值
 	// 立刻丢弃，不再依赖 channelInfo 缓存命中。
 	payload = m.enrichPayloadWithSpaceID(channelID, channelType, payload, senderSpaceID)
+	// 图文混排 RichText(=14)：派发出口用 content 重算权威顶层 plain，覆盖客户端
+	// 不可信的 plain（契约 §2）。这一步是下游 summary / matter / search / 复制 /
+	// 推送 全部依赖的前置——server 必须在消息落库 / 进 IM 搜索索引前把权威 plain
+	// 写进 payload 字节。非 type=14 的 payload 此 helper 为 no-op，老消息路径不变。
+	//
+	// ⚠️ PR#232 review (Jerry-Xin Critical#2)：Finalize 必须排在 *所有* server 端
+	// enrich（sanitize / RewriteMention / enrichPayloadWithSpaceID）之后，且其 1MB
+	// 复检作用在真实最终 payload 上——server 注入 space_id 等顶层字段会把 payload
+	// 撑大，若在 enrich 前复检会放过「enrich 后超限」的 payload。入站 write-strict
+	// 校验已在 sendMsg handler 用 richtext.Validate 完成（与 robot 路径对称）。
+	if err := richtext.Finalize(payload); err != nil {
+		m.Error("RichText payload plain 生成/复检失败", zap.Error(err), zap.String("channelID", channelID), zap.String("fromUID", fromUID))
+		return err
+	}
 	// Mininglamp-OSS/octo-server#144 + PR#145 review follow-up:
 	// second-pass mention chokepoint. When mention.ais=1 in a GROUP
 	// channel, expand mention.uids to include every bot member of the

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -484,9 +484,12 @@ func (rb *Robot) sendMessage(c *wkhttp.Context) {
 
 	// 图文混排 RichText(=14)：派发出口用 content 重算权威顶层 plain，覆盖客户端
 	// 不可信 plain（契约 §2），供下游 summary / matter / search / 复制 / 推送 复用。
-	// 非 type=14 为 no-op，老消息路径不变；内部对回填后整条 payload 复检 1MB 上限。
-	if err := richtext.EnsurePlain(payload); err != nil {
-		rb.Error("RichText payload plain 生成失败", zap.Error(err), zap.String("robotID", robotID), zap.String("channelID", messageReq.ChannelID))
+	// 非 type=14 为 no-op，老消息路径不变。入站 write-strict 校验已由上方
+	// payloadIsVail→common.ValidateRichTextPayload 完成（与 user 路径 richtext.Validate
+	// 对称）；这里只做 plain 权威生成 + 对真实最终 payload（含 enrichBotPayloadWithSpaceID
+	// 注入的顶层字段）的 1MB 复检（PR#232 Jerry-Xin Critical#2）。
+	if err := richtext.Finalize(payload); err != nil {
+		rb.Error("RichText payload plain 生成/复检失败", zap.Error(err), zap.String("robotID", robotID), zap.String("channelID", messageReq.ChannelID))
 		c.ResponseError(fmt.Errorf("无效的payload[%s]", util.ToJson(messageReq.Payload)))
 		return
 	}

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
+	"github.com/Mininglamp-OSS/octo-server/pkg/richtext"
 	pkgutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
 	"github.com/gin-gonic/gin"
 	"github.com/go-redis/redis"
@@ -481,6 +482,15 @@ func (rb *Robot) sendMessage(c *wkhttp.Context) {
 		payload = rb.enrichBotPayloadWithSpaceID(robotID, payload)
 	}
 
+	// 图文混排 RichText(=14)：派发出口用 content 重算权威顶层 plain，覆盖客户端
+	// 不可信 plain（契约 §2），供下游 summary / matter / search / 复制 / 推送 复用。
+	// 非 type=14 为 no-op，老消息路径不变；内部对回填后整条 payload 复检 1MB 上限。
+	if err := richtext.EnsurePlain(payload); err != nil {
+		rb.Error("RichText payload plain 生成失败", zap.Error(err), zap.String("robotID", robotID), zap.String("channelID", messageReq.ChannelID))
+		c.ResponseError(fmt.Errorf("无效的payload[%s]", util.ToJson(messageReq.Payload)))
+		return
+	}
+
 	// YUJ-202 / Mininglamp-OSS#94 / #142 — mention pass-through
 	// chokepoint. Same contract as the user and bot API ingresses:
 	// post-#142 the helper no longer infers `mention.ais=1` from
@@ -562,7 +572,18 @@ func (rb *Robot) payloadIsVail(payloadResult maputil.Data) bool {
 	case common.File:
 		return payloadResult.Get("url") != nil
 	case common.RichText:
-		return payloadResult.Get("content") != nil
+		// 图文混排 RichText(=14)：发送端 write-strict 校验。升级为调
+		// common.ValidateRichTextPayload，对序列化后的 payload 做大小上限、
+		// content 必填非空、每个 block 结构合法（text 非空 / image url scheme +
+		// width/height）的完整契约校验，取代旧的仅 content != nil 浅检。
+		raw, err := json.Marshal(map[string]interface{}(payloadResult))
+		if err != nil {
+			return false
+		}
+		if _, err := common.ValidateRichTextPayload(raw); err != nil {
+			return false
+		}
+		return true
 	}
 	return false
 }

--- a/modules/robot/richtext_payload_test.go
+++ b/modules/robot/richtext_payload_test.go
@@ -1,0 +1,92 @@
+// Package robot · 图文混排 RichText(=14) 发送校验单测。
+//
+// 任务背景：payloadIsVail 对 type=14 原本只检查 content != nil，伪造 / 残缺的
+// RichText payload（如空 content 数组、image 缺 url / scheme 非法 / 缺尺寸）会被放行。
+// 这里锁定升级后调 common.ValidateRichTextPayload 的 write-strict 行为。
+package robot
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/gookit/goutil/maputil"
+	"github.com/stretchr/testify/assert"
+)
+
+func richTextData(content []interface{}) maputil.Data {
+	m := maputil.Data{"type": common.RichText.Int()}
+	if content != nil {
+		m["content"] = content
+	}
+	return m
+}
+
+func TestPayloadIsVail_RichText(t *testing.T) {
+	rb := &Robot{}
+
+	cases := []struct {
+		name    string
+		payload maputil.Data
+		want    bool
+	}{
+		{
+			name: "valid_text_and_image",
+			payload: richTextData([]interface{}{
+				map[string]interface{}{"type": "text", "text": "hi"},
+				map[string]interface{}{"type": "image", "url": "https://x/y.png", "width": 10, "height": 10},
+			}),
+			want: true,
+		},
+		{
+			name:    "missing_content_rejected",
+			payload: richTextData(nil),
+			want:    false,
+		},
+		{
+			name:    "empty_content_array_rejected",
+			payload: richTextData([]interface{}{}),
+			want:    false,
+		},
+		{
+			name: "text_block_empty_rejected",
+			payload: richTextData([]interface{}{
+				map[string]interface{}{"type": "text", "text": "   "},
+			}),
+			want: false,
+		},
+		{
+			name: "image_missing_url_rejected",
+			payload: richTextData([]interface{}{
+				map[string]interface{}{"type": "image", "width": 10, "height": 10},
+			}),
+			want: false,
+		},
+		{
+			name: "image_bad_scheme_rejected",
+			payload: richTextData([]interface{}{
+				map[string]interface{}{"type": "image", "url": "data:image/png;base64,AAAA", "width": 10, "height": 10},
+			}),
+			want: false,
+		},
+		{
+			name: "image_no_size_rejected",
+			payload: richTextData([]interface{}{
+				map[string]interface{}{"type": "image", "url": "https://x/y.png"},
+			}),
+			want: false,
+		},
+		{
+			name: "unknown_block_rejected",
+			payload: richTextData([]interface{}{
+				map[string]interface{}{"type": "video", "url": "https://x/y.mp4"},
+			}),
+			want: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := rb.payloadIsVail(c.payload)
+			assert.Equal(t, c.want, got)
+		})
+	}
+}

--- a/modules/search/api.go
+++ b/modules/search/api.go
@@ -45,6 +45,21 @@ func (s *Search) Route(r *wkhttp.WKHttp) {
 	}
 }
 
+// buildMessageSearchQuery 构造给 WuKongIM usersearch 的 payload 字段匹配集合与
+// 高亮字段集合。除原有 content / name 外，补 payload.plain：图文混排 RichText(=14)
+// 的正文文字承载在 content blocks 内，server 在派发出口把权威纯文本镜像写到顶层
+// plain（含 [图片] 占位），只搜 payload.content 命不中 14 的文字，必须一并搜 plain
+// 才能让富文本消息可被搜索与高亮。
+func buildMessageSearchQuery(keyword string) (map[string]interface{}, []string) {
+	payload := map[string]interface{}{
+		"content": keyword,
+		"name":    keyword,
+		"plain":   keyword,
+	}
+	highlights := []string{"payload.content", "payload.name", "payload.plain"}
+	return payload, highlights
+}
+
 func (s *Search) global(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	var req struct {
@@ -68,11 +83,7 @@ func (s *Search) global(c *wkhttp.Context) {
 	if req.Limit > 100 {
 		req.Limit = 100
 	}
-	payload := map[string]interface{}{
-		"content": req.Keyword,
-		"name":    req.Keyword,
-	}
-	highlights := []string{"payload.content", "payload.name"}
+	payload, highlights := buildMessageSearchQuery(req.Keyword)
 
 	// 查询消息
 	msgResp, err := s.ctx.IMSearchUserMessages(&config.SearchUserMessageReq{

--- a/modules/search/richtext_search_test.go
+++ b/modules/search/richtext_search_test.go
@@ -1,0 +1,26 @@
+// Package search · 图文混排 RichText(=14) 搜索索引单测。
+//
+// 任务背景：原本只搜 payload.content / payload.name，RichText(=14) 的正文文字在
+// content blocks 内、镜像在顶层 plain，content 命不中。这里锁定搜索 payload 与
+// highlights 都补上 payload.plain。
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildMessageSearchQuery_IncludesPlain(t *testing.T) {
+	payload, highlights := buildMessageSearchQuery("北京")
+
+	// payload 匹配字段必须含 plain，且与 content/name 取同一关键字。
+	assert.Equal(t, "北京", payload["plain"])
+	assert.Equal(t, "北京", payload["content"])
+	assert.Equal(t, "北京", payload["name"])
+
+	// highlights 必须含 payload.plain，保证富文本命中后高亮回显。
+	assert.Contains(t, highlights, "payload.plain")
+	assert.Contains(t, highlights, "payload.content")
+	assert.Contains(t, highlights, "payload.name")
+}

--- a/modules/webhook/api.go
+++ b/modules/webhook/api.go
@@ -127,7 +127,7 @@ func New(ctx *config.Context) *Webhook {
 	}
 }
 func getSupportTypes() []common.ContentType {
-	return []common.ContentType{common.Text, common.Image, common.GIF, common.Voice, common.Video, common.File, common.Location, common.Card, common.MultipleForward, common.VectorSticker, common.EmojiSticker}
+	return []common.ContentType{common.Text, common.Image, common.GIF, common.Voice, common.Video, common.File, common.Location, common.Card, common.MultipleForward, common.VectorSticker, common.EmojiSticker, common.RichText}
 }
 
 // Route 路由配置

--- a/modules/webhook/common.go
+++ b/modules/webhook/common.go
@@ -188,6 +188,13 @@ func getMessageAlert(msg msgOfflineNotify, toUser *user.Resp, ctx *config.Contex
 		alert = "[emoji表情]"
 	case common.MultipleForward:
 		alert = "[聊天记录]"
+	case common.RichText:
+		// 图文混排 RichText(=14)：推送正文取 server 已生成的权威 plain（含 [图片]
+		// 占位）。GetRichTextDisplayText 优先用 payload.plain，缺失时现场遍历
+		// content 兜底，再不行回退到 GetDisplayText(=「富文本消息」)。这里走的是
+		// 「存储后展示路径」，payload 已在派发出口经 EnsurePlain 用 content 重算
+		// 覆盖端上 plain，故信任 plain 是正确且高效的。
+		alert = common.GetRichTextDisplayText(msg.Payload)
 	}
 	return alert, nil
 }

--- a/modules/webhook/richtext_alert_test.go
+++ b/modules/webhook/richtext_alert_test.go
@@ -1,0 +1,77 @@
+// Package webhook · 图文混排 RichText(=14) 推送 alert 单测。
+//
+// 任务背景：getMessageAlert 的 switch 原本无 type=14 case，14 消息推送正文为空
+// 字符串。这里锁定新增的 RichText case 用 common.GetRichTextDisplayText 从 server
+// 权威 plain 生成推送正文，并验证 14 已进入 getSupportTypes（否则 pushTo 在
+// containSupportType 处就把 14 丢弃，永远到不了 getMessageAlert）。
+package webhook
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/stretchr/testify/assert"
+)
+
+// makeRichTextOfflineMsg builds a PERSONAL msgOfflineNotify carrying a RichText
+// payload, with both PayloadMap (for the gate) and Payload bytes (the alert
+// builder reads the raw bytes via GetRichTextDisplayText).
+func makeRichTextOfflineMsg(t *testing.T, payloadJSON string) msgOfflineNotify {
+	t.Helper()
+	var m msgOfflineNotify
+	m.ChannelType = common.ChannelTypePerson.Uint8()
+	m.Payload = []byte(payloadJSON)
+	dec := json.NewDecoder(bytes.NewBufferString(payloadJSON))
+	dec.UseNumber() // 复刻 ingress 解码（type 为 json.Number），命中 alert switch 的 json.Number 分支
+	var pm map[string]interface{}
+	if err := dec.Decode(&pm); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	m.PayloadMap = pm
+	return m
+}
+
+func TestGetSupportTypes_IncludesRichText(t *testing.T) {
+	found := false
+	for _, ct := range getSupportTypes() {
+		if ct == common.RichText {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "RichText=14 必须在 getSupportTypes，否则 pushTo 丢弃 14 消息推不出")
+}
+
+func TestGetMessageAlert_RichText_UsesAuthoritativePlain(t *testing.T) {
+	ctx := config.NewContext(config.New()) // ContentDetailOn defaults true
+	toUser := &user.Resp{MsgShowDetail: 1}
+
+	msg := makeRichTextOfflineMsg(t, `{"type":14,"plain":"看这张图 [图片] 谢谢","content":[
+		{"type":"text","text":"看这张图 "},
+		{"type":"image","url":"https://x/y.png","width":10,"height":10},
+		{"type":"text","text":" 谢谢"}
+	]}`)
+
+	alert, err := getMessageAlert(msg, toUser, ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "看这张图 [图片] 谢谢", alert)
+}
+
+func TestGetMessageAlert_RichText_FallbackBuildsFromContent(t *testing.T) {
+	// plain 缺失时 GetRichTextDisplayText 现场遍历 content 生成。
+	ctx := config.NewContext(config.New())
+	toUser := &user.Resp{MsgShowDetail: 1}
+
+	msg := makeRichTextOfflineMsg(t, `{"type":14,"content":[
+		{"type":"text","text":"hi"},
+		{"type":"image","url":"https://x/y.png","width":1,"height":1}
+	]}`)
+
+	alert, err := getMessageAlert(msg, toUser, ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "hi"+common.RichTextImagePlaceholder, alert)
+}

--- a/pkg/richtext/plain.go
+++ b/pkg/richtext/plain.go
@@ -1,0 +1,63 @@
+// Package richtext owns the server-side authoritative handling of
+// RichText (ContentType=14) message payloads.
+//
+// 图文混排（Phase 1）: RichText=14 复用既有 ContentType（见 octo-lib
+// common/msg.go），正文以有序 content block 数组承载，顶层 plain 为冗余纯
+// 文本。契约规定 plain 由 server 在派发/入库出口权威生成（不信任端上送的
+// plain），供 search / 推送 / 摘要 / 复制 / 下游 LLM 复用。
+//
+// 本包把「检测 type=14 → 用 content 重算 plain → 回写 payload」这一步收敛到
+// 一个 helper，供每个 RichText 发送出口（user /v1/message/send、robot
+// /message/send）共用，保证各出口对 plain 的生成口径一致。底层重算与 1MB
+// 复检由 octo-lib common.(*RichTextPayload).FillPlainBounded 提供。
+package richtext
+
+import (
+	"encoding/json"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+)
+
+// IsRichTextPayload 判断 payload map 的 type 字段是否为 RichText(=14)。
+// 兼容 json.Number / float64 / int 几种反序列化结果（gin BindJSON 出 float64，
+// json.Decoder.UseNumber 出 json.Number）。string 类型的 "14" 不识别，避免误命中。
+func IsRichTextPayload(payload map[string]interface{}) bool {
+	switch v := payload["type"].(type) {
+	case float64:
+		return int(v) == common.RichText.Int()
+	case int:
+		return v == common.RichText.Int()
+	case json.Number:
+		i, err := v.Int64()
+		return err == nil && int(i) == common.RichText.Int()
+	}
+	return false
+}
+
+// EnsurePlain 是 RichText(=14) 派发出口的权威 plain 生成入口：
+//   - 非 type=14 的 payload 原样返回（no-op），保证老消息路径不变；
+//   - type=14 时用 content 重算顶层 plain 覆盖客户端不可信的 plain，并对回填后
+//     的整条 payload 复检 1MB 上限（FillPlainBounded），超限返回其 error。
+//
+// 就地修改传入的 payload map（写入 payload["plain"]），调用方拿到的即同一个 map。
+// 这是下游 summary / matter / search / 复制 / 推送 全部依赖的前置：server 在派发
+// 前把权威 plain 写进随消息一起落库 / 进 IM 搜索索引的 payload 字节。
+func EnsurePlain(payload map[string]interface{}) error {
+	if !IsRichTextPayload(payload) {
+		return nil
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	var p common.RichTextPayload
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return err
+	}
+	plain, err := p.FillPlainBounded()
+	if err != nil {
+		return err
+	}
+	payload["plain"] = plain
+	return nil
+}

--- a/pkg/richtext/plain.go
+++ b/pkg/richtext/plain.go
@@ -6,10 +6,24 @@
 // 文本。契约规定 plain 由 server 在派发/入库出口权威生成（不信任端上送的
 // plain），供 search / 推送 / 摘要 / 复制 / 下游 LLM 复用。
 //
-// 本包把「检测 type=14 → 用 content 重算 plain → 回写 payload」这一步收敛到
-// 一个 helper，供每个 RichText 发送出口（user /v1/message/send、robot
-// /message/send）共用，保证各出口对 plain 的生成口径一致。底层重算与 1MB
-// 复检由 octo-lib common.(*RichTextPayload).FillPlainBounded 提供。
+// 本包把 RichText(=14) 发送出口的两步收敛成共用 helper，供每个出口
+// （user /v1/message/send、robot /message/send）对称调用：
+//
+//  1. Validate —— 入站 write-strict 校验（与 robot payloadIsVail 对称）：
+//     拒 缺/空 content、空 text、data: 图片 URL、缺图片宽高、未知 block type；
+//     大小上限作用在原始「完整」payload 字节（含未知顶层字段），不是裁剪后的
+//     content+plain 子集。
+//  2. Finalize —— 所有 server 端 enrich（space_id 注入 / mention 改写 / 展开
+//     等）之后调用：用 content 重算权威顶层 plain 覆盖端上不可信 plain，并对
+//     真正出站的「完整」payload（含 server 注入的顶层字段）复检 1MB 上限。
+//
+// 设计要点（Jerry-Xin PR#232 review 两条 Critical 的修复口径）：
+//   - 大小检查必须落在真实完整 payload 上。octo-lib 的
+//     (*RichTextPayload).FillPlainBounded 只 marshal content+plain 子集，原始
+//     map 的未知/ server 顶层字段在 size check 前已被丢弃——会漏检。故本包统一
+//     marshal 整个 payload map 来判定大小。
+//   - Finalize 必须排在所有 enrich 之后：server 注入 space_id / 展开 mention.uids
+//     都会把 payload 撑大，入站只看原始字节会放过「enrich 后超限」的 payload。
 package richtext
 
 import (
@@ -34,15 +48,51 @@ func IsRichTextPayload(payload map[string]interface{}) bool {
 	return false
 }
 
-// EnsurePlain 是 RichText(=14) 派发出口的权威 plain 生成入口：
+// Validate 是 RichText(=14) 发送入口的 write-strict 校验 gate（与 robot 路径
+// 的 payloadIsVail→common.ValidateRichTextPayload 对称）：
+//   - 非 type=14 的 payload 直接通过（no-op），保证老消息路径不变；
+//   - type=14 时对「完整」payload 跑 common.ValidateRichTextPayload：拒 缺/空
+//     content、空 text 块、data:/javascript:/file: 等非 http(s) 图片 URL、缺图片
+//     宽高、未知 block type，并把 1MB 大小上限作用在原始完整 payload 字节上
+//     （含未知顶层字段）。
+//
+// ⚠️ 与「裁剪后子集校验」的关键差异（PR#232 Jerry-Xin Critical#2）：这里 marshal
+// 的是 *整个* payload map，不是 content+plain 子集。octo-lib 内部的
+// (*RichTextPayload).UnmarshalJSON 会丢弃未知顶层字段，若先 marshal 子集再判定
+// 大小，端塞的未知顶层巨字段会逃过 size check。本函数从完整 map 取字节，size
+// 检查与真实入站体一致。
+//
+// Validate 不修改 payload，只做 gate；plain 的权威生成在所有 enrich 之后由
+// Finalize 完成。
+func Validate(payload map[string]interface{}) error {
+	if !IsRichTextPayload(payload) {
+		return nil
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if _, err := common.ValidateRichTextPayload(raw); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Finalize 是 RichText(=14) 派发出口的权威收尾：必须在所有 server 端 enrich
+// （space_id 注入 / mention 改写 / mention.uids 展开等）之后调用。
 //   - 非 type=14 的 payload 原样返回（no-op），保证老消息路径不变；
-//   - type=14 时用 content 重算顶层 plain 覆盖客户端不可信的 plain，并对回填后
-//     的整条 payload 复检 1MB 上限（FillPlainBounded），超限返回其 error。
+//   - type=14 时用 content 重算顶层 plain 覆盖客户端不可信的 plain，并对真正出站
+//     的「完整」payload（含 server 注入的顶层字段，如 space_id）复检 1MB 上限，
+//     超限返回 common.ErrRichTextPayloadTooLarge。
 //
 // 就地修改传入的 payload map（写入 payload["plain"]），调用方拿到的即同一个 map。
 // 这是下游 summary / matter / search / 复制 / 推送 全部依赖的前置：server 在派发
 // 前把权威 plain 写进随消息一起落库 / 进 IM 搜索索引的 payload 字节。
-func EnsurePlain(payload map[string]interface{}) error {
+//
+// ⚠️ 大小复检落在完整 payload（PR#232 Jerry-Xin Critical#2）：先 FillPlain 重算
+// plain 写回 map，再 marshal *整个* map 判定大小，确保 server enrich 把 payload
+// 撑过 1MB 的情况会被这里拦下——而不是只看 content+plain 子集而漏检。
+func Finalize(payload map[string]interface{}) error {
 	if !IsRichTextPayload(payload) {
 		return nil
 	}
@@ -54,10 +104,29 @@ func EnsurePlain(payload map[string]interface{}) error {
 	if err := json.Unmarshal(raw, &p); err != nil {
 		return err
 	}
-	plain, err := p.FillPlainBounded()
+	// server 权威重算 plain（不复检子集大小，大小复检在下方对完整 payload 做）。
+	payload["plain"] = p.FillPlain()
+	// 对真正出站的完整 payload（含未知/ server 注入顶层字段）复检 1MB 上限。
+	out, err := json.Marshal(payload)
 	if err != nil {
 		return err
 	}
-	payload["plain"] = plain
+	if len(out) > common.RichTextMaxPayloadBytes {
+		return common.ErrRichTextPayloadTooLarge
+	}
 	return nil
+}
+
+// EnsurePlain 是旧的「校验+回填 plain」单步入口，保留以兼容仍只需要回填
+// plain 的调用方。
+//
+// Deprecated: 新出口请改用 Validate（入站 gate）+ Finalize（enrich 后收尾）的
+// 两步组合，使 1MB 复检作用在真实最终 payload 上、入站强校验与 robot 路径对称。
+// 本函数等价于 Validate 后立即 Finalize（中间无 enrich），仅用于无 enrich 的
+// 简单路径。
+func EnsurePlain(payload map[string]interface{}) error {
+	if err := Validate(payload); err != nil {
+		return err
+	}
+	return Finalize(payload)
 }

--- a/pkg/richtext/plain_test.go
+++ b/pkg/richtext/plain_test.go
@@ -94,3 +94,165 @@ func TestEnsurePlain_OversizeReturnsError(t *testing.T) {
 		t.Fatalf("expected oversize error, got nil")
 	}
 }
+
+// --- PR#232 Critical#1: user-send write-strict 校验（与 robot 路径对称）---
+
+// TestValidate_NonRichTextIsNoOp 非 type=14 的 payload 不进 RichText gate，
+// 任意 shape 都通过（老消息路径不变）。
+func TestValidate_NonRichTextIsNoOp(t *testing.T) {
+	p := payloadFromJSON(t, `{"type":1,"content":""}`)
+	if err := Validate(p); err != nil {
+		t.Fatalf("non-richtext Validate err: %v", err)
+	}
+}
+
+// TestValidate_RejectsDirtyPayloads 覆盖 Jerry-Xin Critical#1 列出的脏 payload：
+// 缺/空 content、空 text 块、data: 图片 URL、缺图片宽高、未知 block type
+// 全部必须被拒（旧 EnsurePlain 经 FillPlainBounded 会放过这些）。
+func TestValidate_RejectsDirtyPayloads(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+	}{
+		{"missing_content", `{"type":14,"plain":"x"}`},
+		{"null_content", `{"type":14,"content":null}`},
+		{"empty_content_array", `{"type":14,"content":[]}`},
+		{"empty_text_block", `{"type":14,"content":[{"type":"text","text":""}]}`},
+		{"blank_text_block", `{"type":14,"content":[{"type":"text","text":"   "}]}`},
+		{"data_uri_image", `{"type":14,"content":[{"type":"image","url":"data:image/png;base64,AAAA","width":10,"height":10}]}`},
+		{"javascript_uri_image", `{"type":14,"content":[{"type":"image","url":"javascript:alert(1)","width":10,"height":10}]}`},
+		{"image_missing_size", `{"type":14,"content":[{"type":"image","url":"https://x/y.png"}]}`},
+		{"image_zero_size", `{"type":14,"content":[{"type":"image","url":"https://x/y.png","width":0,"height":0}]}`},
+		{"image_no_url", `{"type":14,"content":[{"type":"image","width":10,"height":10}]}`},
+		{"unknown_block_type", `{"type":14,"content":[{"type":"video","text":"hi"}]}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := payloadFromJSON(t, c.payload)
+			if err := Validate(p); err == nil {
+				t.Fatalf("Validate accepted dirty payload %q, want reject", c.payload)
+			}
+		})
+	}
+}
+
+// TestValidate_AcceptsCleanPayload 合法 payload 通过，且 Validate 不改写 payload
+// （plain 的权威生成留给 enrich 之后的 Finalize）。
+func TestValidate_AcceptsCleanPayload(t *testing.T) {
+	p := payloadFromJSON(t, `{"type":14,"plain":"FORGED","content":[
+		{"type":"text","text":"hi"},
+		{"type":"image","url":"https://x/y.png","width":10,"height":10}
+	]}`)
+	if err := Validate(p); err != nil {
+		t.Fatalf("Validate rejected clean payload: %v", err)
+	}
+	// Validate 是只读 gate：不得在此处覆盖端上的 plain。
+	if p["plain"] != "FORGED" {
+		t.Fatalf("Validate mutated plain: %v", p["plain"])
+	}
+}
+
+// TestValidate_OversizeWithExtraTopLevelField 校验大小计算用的是「完整」payload
+// 字节（含未知顶层字段），而不是 content+plain 子集（Jerry-Xin Critical#2 的
+// size 计算分支）。一个未知顶层巨字段必须把 payload 顶过 1MB 并被拒。
+func TestValidate_OversizeWithExtraTopLevelField(t *testing.T) {
+	bigExtra := strings.Repeat("x", common.RichTextMaxPayloadBytes)
+	p := map[string]interface{}{
+		"type": float64(14),
+		"content": []interface{}{
+			map[string]interface{}{"type": "text", "text": "hi"},
+		},
+		// 未知顶层字段：octo-lib RichTextPayload 解析时会丢弃它，
+		// 若 size check 跑在裁剪后子集上就会漏检——这里必须算进总大小。
+		"junk": bigExtra,
+	}
+	if err := Validate(p); err == nil {
+		t.Fatalf("Validate accepted payload oversized by unknown top-level field")
+	}
+}
+
+// --- PR#232 Critical#2: 1MB 复检作用在真实最终 payload（enrich 之后）---
+
+// TestFinalize_OverwritesUntrustedPlain Finalize 用 content 重算权威 plain，
+// 覆盖端上不可信 plain（与旧 EnsurePlain 行为一致）。
+func TestFinalize_OverwritesUntrustedPlain(t *testing.T) {
+	p := payloadFromJSON(t, `{"type":14,"plain":"FORGED","content":[
+		{"type":"text","text":"hello "},
+		{"type":"image","url":"https://x/y.png","width":10,"height":10},
+		{"type":"text","text":" world"}
+	]}`)
+	if err := Finalize(p); err != nil {
+		t.Fatalf("Finalize err: %v", err)
+	}
+	want := "hello " + common.RichTextImagePlaceholder + " world"
+	if p["plain"] != want {
+		t.Fatalf("plain=%q want %q", p["plain"], want)
+	}
+}
+
+// TestFinalize_NonRichTextIsNoOp 非 type=14 payload Finalize 不改写。
+func TestFinalize_NonRichTextIsNoOp(t *testing.T) {
+	p := payloadFromJSON(t, `{"type":1,"content":"hi","plain":"client-sent"}`)
+	if err := Finalize(p); err != nil {
+		t.Fatalf("Finalize err: %v", err)
+	}
+	if p["plain"] != "client-sent" {
+		t.Fatalf("non-richtext plain mutated: %v", p["plain"])
+	}
+}
+
+// TestFinalize_OversizeAfterServerEnrich 模拟 server enrich 后超限：入站时
+// payload 在 1MB 内（能过 Validate），但 server 注入一个顶层字段把它顶过 1MB，
+// Finalize 必须对真实最终 payload 复检并拒发（Jerry-Xin Critical#2 主场景）。
+func TestFinalize_OversizeAfterServerEnrich(t *testing.T) {
+	// 入站 payload：text 接近上限但仍合法、可过 Validate。
+	big := strings.Repeat("x", common.RichTextMaxPayloadBytes-400)
+	p := map[string]interface{}{
+		"type": float64(14),
+		"content": []interface{}{
+			map[string]interface{}{"type": "text", "text": big},
+		},
+	}
+	if err := Validate(p); err != nil {
+		t.Fatalf("入站 payload 应能过 Validate，却被拒: %v", err)
+	}
+	// server enrich：注入权威 space_id（enrichPayloadWithSpaceID 等）后再注入
+	// plain 镜像，整体顶过 1MB。
+	p["space_id"] = strings.Repeat("s", 800)
+	if err := Finalize(p); err == nil {
+		t.Fatalf("Finalize 未拦下 enrich 后超限的 payload")
+	}
+}
+
+// TestFinalize_SizeCountsFullPayload 复检大小落在完整 payload 上：一个 content 合法、
+// 但带未知顶层巨字段的 payload，Finalize 必须按完整字节判定超限。
+func TestFinalize_SizeCountsFullPayload(t *testing.T) {
+	bigExtra := strings.Repeat("x", common.RichTextMaxPayloadBytes)
+	p := map[string]interface{}{
+		"type": float64(14),
+		"content": []interface{}{
+			map[string]interface{}{"type": "text", "text": "hi"},
+		},
+		"junk": bigExtra,
+	}
+	if err := Finalize(p); err == nil {
+		t.Fatalf("Finalize 未按完整 payload 字节判定超限")
+	}
+}
+
+// TestFinalize_PreservesExtraTopLevelFields Finalize 只写 plain，不得丢弃
+// payload 上的其它顶层字段（server enrich 注入的 space_id 等必须保留出站）。
+func TestFinalize_PreservesExtraTopLevelFields(t *testing.T) {
+	p := payloadFromJSON(t, `{"type":14,"space_id":"sp-1","content":[
+		{"type":"text","text":"hi"}
+	]}`)
+	if err := Finalize(p); err != nil {
+		t.Fatalf("Finalize err: %v", err)
+	}
+	if p["space_id"] != "sp-1" {
+		t.Fatalf("Finalize dropped top-level space_id: %v", p["space_id"])
+	}
+	if p["plain"] != "hi" {
+		t.Fatalf("plain=%q want %q", p["plain"], "hi")
+	}
+}

--- a/pkg/richtext/plain_test.go
+++ b/pkg/richtext/plain_test.go
@@ -1,0 +1,96 @@
+package richtext
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+)
+
+// payloadFromJSON decodes a JSON object the same way the HTTP ingress does
+// (gin BindJSON → float64 for numbers), so the test exercises the float64
+// branch of IsRichTextPayload.
+func payloadFromJSON(t *testing.T, s string) map[string]interface{} {
+	t.Helper()
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return m
+}
+
+func TestIsRichTextPayload(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload map[string]interface{}
+		want    bool
+	}{
+		{"float64_14", map[string]interface{}{"type": float64(14)}, true},
+		{"int_14", map[string]interface{}{"type": 14}, true},
+		{"json_number_14", map[string]interface{}{"type": json.Number("14")}, true},
+		{"float64_text", map[string]interface{}{"type": float64(1)}, false},
+		{"string_14_not_matched", map[string]interface{}{"type": "14"}, false},
+		{"missing_type", map[string]interface{}{}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsRichTextPayload(c.payload); got != c.want {
+				t.Fatalf("IsRichTextPayload=%v want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestEnsurePlain_NonRichTextIsNoOp(t *testing.T) {
+	p := payloadFromJSON(t, `{"type":1,"content":"hi","plain":"client-sent"}`)
+	if err := EnsurePlain(p); err != nil {
+		t.Fatalf("EnsurePlain err: %v", err)
+	}
+	// 非 type=14：plain 不应被改写（老消息路径不变）。
+	if p["plain"] != "client-sent" {
+		t.Fatalf("non-richtext plain mutated: %v", p["plain"])
+	}
+}
+
+func TestEnsurePlain_OverwritesUntrustedPlain(t *testing.T) {
+	// 端上送了伪造的 plain，server 必须用 content 重算覆盖。
+	p := payloadFromJSON(t, `{"type":14,"plain":"FORGED","content":[
+		{"type":"text","text":"hello "},
+		{"type":"image","url":"https://x/y.png","width":10,"height":10},
+		{"type":"text","text":" world"}
+	]}`)
+	if err := EnsurePlain(p); err != nil {
+		t.Fatalf("EnsurePlain err: %v", err)
+	}
+	want := "hello " + common.RichTextImagePlaceholder + " world"
+	if p["plain"] != want {
+		t.Fatalf("plain=%q want %q", p["plain"], want)
+	}
+}
+
+func TestEnsurePlain_LegacyStringContent(t *testing.T) {
+	// 老 payload content 是字符串：FillPlainBounded 经 UnmarshalJSON 兼容。
+	p := payloadFromJSON(t, `{"type":14,"content":"legacy text"}`)
+	if err := EnsurePlain(p); err != nil {
+		t.Fatalf("EnsurePlain err: %v", err)
+	}
+	if p["plain"] != "legacy text" {
+		t.Fatalf("plain=%q want %q", p["plain"], "legacy text")
+	}
+}
+
+func TestEnsurePlain_OversizeReturnsError(t *testing.T) {
+	// 构造一条单 text block，文本接近 1MB，回填 plain（镜像一份）后超 1MB。
+	big := strings.Repeat("x", common.RichTextMaxPayloadBytes-200)
+	p := map[string]interface{}{
+		"type": float64(14),
+		"content": []interface{}{
+			map[string]interface{}{"type": "text", "text": big},
+		},
+	}
+	err := EnsurePlain(p)
+	if err == nil {
+		t.Fatalf("expected oversize error, got nil")
+	}
+}


### PR DESCRIPTION
## 概述

图文混排 Phase 1：octo-server 侧对 RichText (ContentType=14) 的全链路适配。

升级 go.mod 中 octo-lib 到含 RichText schema/工具的版本（`v0.0.0-20260602143311-8c26a826e07b`，HEAD 8c26a826），并接入四处服务端 chokepoint。

## 改动

1. **plain 权威生成（入库/序列化出口）** — 新增 `pkg/richtext.EnsurePlain`：对 type=14 用 content 重算顶层 `plain` 覆盖客户端不可信 plain，内部经 `FillPlainBounded` 复检 1MB（超限拒发）；非 14 为 no-op。接入 user `/v1/message/send`（`modules/message.sendMessage`）与 robot `/message/send`（`modules/robot.sendMessage`）两个发送出口，使权威 plain 随消息一起落库/进 IM 搜索索引——这是下游 summary/matter/search/复制/推送 的前置。

2. **webhook 推送 alert** — `getMessageAlert` switch 新增 `common.RichText` case，用 `common.GetRichTextDisplayText` 生成推送正文；并把 RichText 加入 `getSupportTypes`（否则 `pushTo` 在 `containSupportType` 处就把 14 丢弃，永远到不了 alert）。

3. **搜索索引/高亮** — `modules/search` 搜索 payload 与 highlights 补 `payload.plain`，让承载在 blocks 内的 14 文字可被搜索与高亮。

4. **robot 发送校验** — `payloadIsVail` 的 RichText case 从浅检 `content != nil` 升级为 `common.ValidateRichTextPayload`（write-strict：大小上限/content 非空/block 结构合法）。

## 测试

- `pkg/richtext`：EnsurePlain（覆盖端 plain / 老字符串 content / 超限 error / no-op）+ IsRichTextPayload。
- `modules/webhook`：alert 用权威 plain、缺 plain 现场兜底、getSupportTypes 含 14。
- `modules/robot`：payloadIsVail 对合法/空 content/空数组/text 空/image 缺 url/scheme 非法/缺尺寸/未知 block 的判定。
- `modules/search`：buildMessageSearchQuery 含 payload.plain。

`go build ./...` / `go vet ./...` 全绿；新增包与改动包测试通过。`modules/message` 集成测试需本地 Redis（既有基础设施依赖，与本改动无关），改动经 EnsurePlain 单测全覆盖。

## 兼容性

向后兼容：非 type=14 路径全部 no-op，老字符串 content 经 octo-lib UnmarshalJSON 兼容。未碰客户端渲染、其他仓、无关消息类型路径。

Fixes #230