### PR TITLE
fix: use shared UID limiter for app bot apply

### DIFF
--- a/modules/app_bot/app_bot.go
+++ b/modules/app_bot/app_bot.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/bot_api"
 	"github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 )
@@ -138,7 +139,10 @@ func (ab *AppBot) Route(r *wkhttp.WKHttp) {
 	r.GET("/v1/app_bot/available", ab.ctx.AuthMiddleware(r), ab.discoverBots)
 
 	// User opt-in: establish friend relationship with App Bot
-	r.POST("/v1/app_bot/apply", ab.ctx.AuthMiddleware(r), ab.applyBot)
+	applyAPI := r.Group("/v1/app_bot", ab.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, ab.ctx))
+	{
+		applyAPI.POST("/apply", ab.applyBot)
+	}
 }
 
 // checkSpaceAdmin verifies the logged-in user is admin/owner of the given space.
@@ -978,28 +982,6 @@ func (ab *AppBot) applyBot(c *wkhttp.Context) {
 	// Validate robot_uid format: must match app_*_bot pattern
 	if !strings.HasPrefix(req.RobotUID, AppBotUIDPrefix) || !strings.HasSuffix(req.RobotUID, AppBotUIDSuffix) {
 		c.ResponseError(errors.New("invalid robot_uid format"))
-		return
-	}
-
-	// Rate limit: 10 apply requests per minute per user
-	rateLimitKey := fmt.Sprintf("app_bot_apply_rate:%s", loginUID)
-	count, redisErr := ab.ctx.GetRedisConn().Incr(rateLimitKey)
-	if redisErr != nil {
-		ab.Error("rate limit Redis error, denying request", zap.Error(redisErr))
-		c.ResponseError(errors.New("服务繁忙，请稍后再试"))
-		return
-	}
-	if count == 1 {
-		// First request in this window — set TTL (fixed window, not sliding).
-		// If SetExpire fails, DEL the key to prevent permanent rate-limiting.
-		if expErr := ab.ctx.GetRedisConn().SetExpire(rateLimitKey, time.Minute); expErr != nil {
-			ab.Error("rate limit SetExpire failed, deleting key to prevent permanent block",
-				zap.Error(expErr), zap.String("key", rateLimitKey))
-			ab.ctx.GetRedisConn().Del(rateLimitKey)
-		}
-	}
-	if count > 10 {
-		c.ResponseError(errors.New("请求过于频繁，请稍后再试"))
 		return
 	}
 

--- a/modules/app_bot/app_bot_rate_limit_test.go
+++ b/modules/app_bot/app_bot_rate_limit_test.go
@@ -1,0 +1,89 @@
+package app_bot
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/gocraft/dbr/v2"
+	"github.com/gocraft/dbr/v2/dialect"
+)
+
+func TestApplyBotUsesSharedUIDRateLimiter(t *testing.T) {
+	route, ctx, mock, cleanup := newApplyBotRateLimitTestRoute(t)
+	defer cleanup()
+
+	oldKey := "app_bot_apply_rate:" + testutil.UID
+	if err := ctx.GetRedisConn().Del(oldKey); err != nil {
+		t.Fatalf("delete old app_bot apply rate-limit key: %v", err)
+	}
+	if err := ctx.GetRedisConn().Del("ratelimit:uid:" + testutil.UID); err != nil {
+		t.Fatalf("delete shared uid rate-limit key: %v", err)
+	}
+	mock.ExpectQuery(`SELECT \* FROM app_bot WHERE \(uid='app_missing_bot'\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	body := bytes.NewBufferString(`{"robot_uid":"app_missing_bot"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/app_bot/apply", body)
+	req.Header.Set("token", testutil.Token)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	route.ServeHTTP(w, req)
+
+	if got := w.Header().Get("X-RateLimit-Scope"); got != "uid" {
+		t.Fatalf("X-RateLimit-Scope = %q, want uid", got)
+	}
+	if got := w.Header().Get("X-RateLimit-Limit"); got == "" {
+		t.Fatal("X-RateLimit-Limit is empty; shared UID limiter was not applied")
+	}
+	if got := w.Header().Get("X-RateLimit-Remaining"); got == "" {
+		t.Fatal("X-RateLimit-Remaining is empty; shared UID limiter was not applied")
+	}
+	if got, err := ctx.GetRedisConn().GetString(oldKey); err != nil {
+		t.Fatalf("read old app_bot apply rate-limit key: %v", err)
+	} else if got != "" {
+		t.Fatalf("old app_bot apply rate-limit key = %q, want absent", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
+	}
+}
+
+func newApplyBotRateLimitTestRoute(t *testing.T) (*wkhttp.WKHttp, *config.Context, sqlmock.Sqlmock, func()) {
+	t.Helper()
+
+	cfg := config.New()
+	cfg.Test = true
+	ctx := config.NewContext(cfg)
+	if err := ctx.Cache().Set(cfg.Cache.TokenCachePrefix+testutil.Token, testutil.UID+"@test"); err != nil {
+		t.Fatalf("seed auth token: %v", err)
+	}
+
+	rawDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	conn := &dbr.Connection{DB: rawDB, EventReceiver: &dbr.NullEventReceiver{}, Dialect: dialect.MySQL}
+
+	route := wkhttp.New()
+	ab := &AppBot{
+		ctx: ctx,
+		db: &appBotDB{
+			ctx:     ctx,
+			session: conn.NewSession(nil),
+		},
+		Log: log.NewTLog("AppBotRateLimitTest"),
+	}
+	ab.Route(route)
+
+	return route, ctx, mock, func() {
+		_ = rawDB.Close()
+	}
+}


### PR DESCRIPTION
## Summary
- mount SharedUIDRateLimiter on POST /v1/app_bot/apply after AuthMiddleware
- remove the hand-rolled app_bot_apply_rate:{uid} Redis fixed-window limiter
- add a regression test asserting X-RateLimit-* headers and absence of the old key

Fixes #229.

## Tests
- go test ./modules/app_bot -run TestApplyBotUsesSharedUIDRateLimiter -count=1
- go test ./modules/app_bot -count=1
- go test ./modules/app_bot ./pkg/wkhttp -count=1
- go vet ./modules/app_bot ./pkg/wkhttp
- git diff --check origin/main...

## Note
- go test ./... -run ^'$' still hits the existing modules/space TestMain migration ledger failure: 20191106000001_event_legacy01.sql unknown migration in database. The new app_bot test avoids testutil.NewTestServer and uses wkhttp.New + sqlmock + Redis cache to avoid that known migration issue while still exercising AuthMiddleware + SharedUIDRateLimiter.