### PR TITLE
fix(message): RichText=14 plain consistency on edit paths (Phase 1)

### DIFF
--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
+	"github.com/Mininglamp-OSS/octo-server/pkg/richtext"
 	"github.com/gocraft/dbr/v2"
 	"go.uber.org/zap"
 )
@@ -683,11 +684,23 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 		}
 	}
 
+	// 图文混排 RichText(=14)：编辑写入口对 content_edit 做与 send 路径对称的
+	// write-strict 校验 + 权威 plain 重算（契约 §2，plain 服务端重算不信客户端）。
+	// 编辑语义为整体替换 content blocks；非 14 / 非 JSON 体为 no-op。脏/超限 payload
+	// 落库前以错误拒绝。MD5 去重 hash 落在 normalize 后的 canonical 体上。
+	normalizedEdit, err := richtext.NormalizeContentEdit(req.ContentEdit)
+	if err != nil {
+		ba.Error("RichText content_edit 校验失败", zap.Error(err), zap.String("messageID", req.MessageID))
+		c.ResponseError(errors.New("无效的 content_edit"))
+		return
+	}
+	req.ContentEdit = normalizedEdit
+
 	contentEdit := dbr.NewNullString(req.ContentEdit).String
 	contentMD5 := util.MD5(contentEdit)
 
 	var existCount int
-	err := ba.ctx.DB().Select("count(*)").From("message_extra").Where("message_id=? and content_edit_hash=?", req.MessageID, contentMD5).LoadOne(&existCount)
+	err = ba.ctx.DB().Select("count(*)").From("message_extra").Where("message_id=? and content_edit_hash=?", req.MessageID, contentMD5).LoadOne(&existCount)
 	if err != nil {
 		ba.Error("查询是否存在相同正文失败！", zap.Error(err))
 		c.ResponseError(errors.New("查询是否存在相同正文失败！"))

--- a/modules/botfather/api.go
+++ b/modules/botfather/api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/botutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/richtext"
 	pkgutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
 	"github.com/gin-gonic/gin"
 	"github.com/go-redis/redis"
@@ -1519,12 +1520,24 @@ func (bf *BotFather) botMessageEdit(c *wkhttp.Context) {
 		return
 	}
 
+	// 图文混排 RichText(=14)：编辑写入口对 content_edit 做与 send 路径对称的
+	// write-strict 校验 + 权威 plain 重算（契约 §2，plain 服务端重算不信客户端）。
+	// 编辑语义为整体替换 content blocks；非 14 / 非 JSON 体为 no-op。脏/超限 payload
+	// 落库前以错误拒绝。MD5 去重 hash 落在 normalize 后的 canonical 体上。
+	normalizedEdit, err := richtext.NormalizeContentEdit(req.ContentEdit)
+	if err != nil {
+		bf.Error("RichText content_edit 校验失败", zap.Error(err), zap.String("messageID", req.MessageID))
+		c.ResponseError(errors.New("无效的 content_edit"))
+		return
+	}
+	req.ContentEdit = normalizedEdit
+
 	// 检查是否存在相同编辑内容
 	contentEdit := dbr.NewNullString(req.ContentEdit).String
 	contentMD5 := util.MD5(contentEdit)
 
 	var existCount int
-	err := bf.ctx.DB().Select("count(*)").From("message_extra").Where("message_id=? and content_edit_hash=?", req.MessageID, contentMD5).LoadOne(&existCount)
+	err = bf.ctx.DB().Select("count(*)").From("message_extra").Where("message_id=? and content_edit_hash=?", req.MessageID, contentMD5).LoadOne(&existCount)
 	if err != nil {
 		bf.Error("查询是否存在相同正文失败！", zap.Error(err))
 		c.ResponseError(errors.New("查询是否存在相同正文失败！"))

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -743,6 +743,19 @@ func (m *Message) messageEdit(c *wkhttp.Context) {
 		return
 	}
 
+	// 图文混排 RichText(=14)：编辑写入口对 content_edit 做与 send 路径对称的
+	// write-strict 校验 + 权威 plain 重算（契约 §2，plain 服务端重算不信客户端）。
+	// 编辑语义为整体替换 content blocks；canonical JSON 落库后即下游 summary /
+	// search / 复制 的权威来源。非 14 / 非 JSON 体为 no-op，老编辑路径不变。脏/超限
+	// payload 在落库前以 400 拒绝。MD5 去重 hash 落在 normalize 后的 canonical 体上。
+	normalizedEdit, err := richtext.NormalizeContentEdit(req.ContentEdit)
+	if err != nil {
+		m.Error("RichText content_edit 校验失败", zap.Error(err), zap.String("channelID", req.ChannelID), zap.String("messageID", req.MessageID))
+		respondMessageRequestInvalid(c, "content_edit")
+		return
+	}
+	req.ContentEdit = normalizedEdit
+
 	contentEdit := dbr.NewNullString(req.ContentEdit).String
 	contentMD5 := util.MD5(contentEdit)
 
@@ -2265,6 +2278,12 @@ func (m *Message) cancelMentionReminderIfNeed(message *messageModel) {
 }
 
 // 撤回消息
+//
+// 图文混排 RichText(=14) 说明：revoke 路径无需 14 特判 / 不补 plain。撤回只在
+// message_extra 上置 Revoke=1 + Revoker + Version（见下方 updateTx / insertTx 分支），
+// 从不读写消息 Payload 或 content_edit，因此既不会破坏既有 plain，也没有需要重算的
+// content。权威 plain 的生成只发生在写入/编辑 content 的入口（send / robot send /
+// 四个 message edit 入口），撤回不属于其中之一。
 func (m *Message) revoke(c *wkhttp.Context) {
 	loginUID := c.MustGet("uid").(string)
 	messageID := c.Query("message_id")

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -1728,6 +1728,18 @@ func (rb *Robot) botMessageEdit(c *wkhttp.Context) {
 		return
 	}
 
+	// 图文混排 RichText(=14)：编辑写入口对 content_edit 做与 send 路径对称的
+	// write-strict 校验 + 权威 plain 重算（契约 §2，plain 服务端重算不信客户端）。
+	// 编辑语义为整体替换 content blocks；非 14 / 非 JSON 体为 no-op。脏/超限 payload
+	// 落库前以错误拒绝。MD5 去重 hash 落在 normalize 后的 canonical 体上。
+	normalizedEdit, err := richtext.NormalizeContentEdit(req.ContentEdit)
+	if err != nil {
+		rb.Error("RichText content_edit 校验失败", zap.Error(err), zap.String("messageID", req.MessageID))
+		c.ResponseError(errors.New("无效的 content_edit"))
+		return
+	}
+	req.ContentEdit = normalizedEdit
+
 	// 检查是否存在相同编辑内容
 	contentEdit := dbr.NewNullString(req.ContentEdit).String
 	contentMD5 := util.MD5(contentEdit)

--- a/pkg/richtext/plain.go
+++ b/pkg/richtext/plain.go
@@ -130,3 +130,40 @@ func EnsurePlain(payload map[string]interface{}) error {
 	}
 	return Finalize(payload)
 }
+
+// NormalizeContentEdit 是所有「消息编辑」写入口共用的 RichText(=14) 收敛 gate，
+// 供 user /v1/message/edit、robot /v1/robot/.../message/edit、bot_api & botfather
+// /v1/bot/message/edit 四个入口对称调用。
+//
+// content_edit 以 JSON 字符串承载「完整」替换 payload（与 send payload 同构），
+// 落库后的字节即下游 summary / search / 复制 的权威来源（见 modules/message
+// api_manager.go 与 api.go 把 content_edit 重新解析回 payload map）。编辑语义：
+// 客户端整体替换 content blocks，顶层 plain 由 server 权威重算、不信客户端上送的
+// plain —— 与 send 路径的 Validate + Finalize 对称。
+//
+//   - type=14：跑与 send 同一套 write-strict 校验（拒 缺/空 content、空 text 块、
+//     非 http(s) 图片 URL、缺图片宽高、未知 block type、超 1MB 等脏/超限 payload），
+//     并用 content 重算权威顶层 plain，返回 canonical JSON 供落库。
+//   - 其它情况（非 14 payload，或 content_edit 不是 JSON 对象）：原样返回入参，
+//     保证老编辑路径行为不变。
+//
+// 编辑路径没有 server 端 enrich，故单步 EnsurePlain（Validate 后紧接无 enrich 的
+// Finalize）正是 send 路径「Validate + enrich 后 Finalize」的对称等价物。
+func NormalizeContentEdit(contentEdit string) (string, error) {
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(contentEdit), &payload); err != nil {
+		// 非 JSON 对象（老的/非图文混排编辑体）：保持原样，不改老行为。
+		return contentEdit, nil
+	}
+	if !IsRichTextPayload(payload) {
+		return contentEdit, nil
+	}
+	if err := EnsurePlain(payload); err != nil {
+		return "", err
+	}
+	out, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/pkg/richtext/plain_test.go
+++ b/pkg/richtext/plain_test.go
@@ -256,3 +256,93 @@ func TestFinalize_PreservesExtraTopLevelFields(t *testing.T) {
 		t.Fatalf("plain=%q want %q", p["plain"], "hi")
 	}
 }
+
+// ---- NormalizeContentEdit：四个消息编辑写入口共用的 content_edit 收敛 gate ----
+
+// TestNormalizeContentEdit_OverwritesUntrustedPlain 编辑 14 体时，server 必须用
+// content 重算权威 plain 覆盖端上送的伪造 plain，并返回 canonical JSON。
+func TestNormalizeContentEdit_OverwritesUntrustedPlain(t *testing.T) {
+	in := `{"type":14,"plain":"FORGED","content":[
+		{"type":"text","text":"hello "},
+		{"type":"image","url":"https://x/y.png","width":10,"height":10},
+		{"type":"text","text":" world"}
+	]}`
+	out, err := NormalizeContentEdit(in)
+	if err != nil {
+		t.Fatalf("NormalizeContentEdit err: %v", err)
+	}
+	got := payloadFromJSON(t, out)
+	want := "hello " + common.RichTextImagePlaceholder + " world"
+	if got["plain"] != want {
+		t.Fatalf("plain=%q want %q", got["plain"], want)
+	}
+}
+
+// TestNormalizeContentEdit_RejectsDirtyPayload 脏 14 content_edit 必须被拒，
+// 不允许写脏 content / 丢 plain 进库（与 send 路径 Validate 对称）。
+func TestNormalizeContentEdit_RejectsDirtyPayload(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"empty_content_array", `{"type":14,"content":[]}`},
+		{"empty_text_block", `{"type":14,"content":[{"type":"text","text":""}]}`},
+		{"data_uri_image", `{"type":14,"content":[{"type":"image","url":"data:image/png;base64,AAAA","width":10,"height":10}]}`},
+		{"image_missing_size", `{"type":14,"content":[{"type":"image","url":"https://x/y.png"}]}`},
+		{"unknown_block_type", `{"type":14,"content":[{"type":"video","text":"hi"}]}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := NormalizeContentEdit(c.in); err == nil {
+				t.Fatalf("NormalizeContentEdit accepted dirty payload %s", c.in)
+			}
+		})
+	}
+}
+
+// TestNormalizeContentEdit_NonRichTextUnchanged 非 14 编辑体原样返回，老编辑路径
+// 行为不变（不解析、不改 plain、不重排字段）。
+func TestNormalizeContentEdit_NonRichTextUnchanged(t *testing.T) {
+	cases := []string{
+		`{"type":1,"content":"hi","plain":"client-sent"}`,
+		`{"type":1,"content":""}`,
+	}
+	for _, in := range cases {
+		out, err := NormalizeContentEdit(in)
+		if err != nil {
+			t.Fatalf("NormalizeContentEdit err: %v", err)
+		}
+		if out != in {
+			t.Fatalf("non-14 content_edit mutated: in=%q out=%q", in, out)
+		}
+	}
+}
+
+// TestNormalizeContentEdit_NonJSONUnchanged content_edit 不是 JSON 对象（老的/
+// 自由文本编辑体）时原样返回，不报错、不改老行为。
+func TestNormalizeContentEdit_NonJSONUnchanged(t *testing.T) {
+	cases := []string{
+		"",
+		"just plain text",
+		`["a","b"]`,
+		`"a string"`,
+	}
+	for _, in := range cases {
+		out, err := NormalizeContentEdit(in)
+		if err != nil {
+			t.Fatalf("NormalizeContentEdit(%q) err: %v", in, err)
+		}
+		if out != in {
+			t.Fatalf("non-JSON content_edit mutated: in=%q out=%q", in, out)
+		}
+	}
+}
+
+// TestNormalizeContentEdit_OversizeRejected 编辑后超 1MB 的 14 体必须被拒。
+func TestNormalizeContentEdit_OversizeRejected(t *testing.T) {
+	big := strings.Repeat("x", common.RichTextMaxPayloadBytes-200)
+	in := `{"type":14,"content":[{"type":"text","text":"` + big + `"}]}`
+	if _, err := NormalizeContentEdit(in); err == nil {
+		t.Fatalf("NormalizeContentEdit accepted oversize 14 content_edit")
+	}
+}


### PR DESCRIPTION
## 背景

RichText=14 send 路径已 merge（#232：`pkg/richtext` 的 `EnsurePlain` + `common.ValidateRichTextPayload`），但**编辑/撤回路径对 14 无特判**：

- `messageEdit`（`modules/message/api.go`）直接把 `content_edit` 存库 + MD5，不解析、不为 14 重算权威 plain
- 同样的裸写还存在于另外三个编辑入口：`robot.botMessageEdit`、`bot_api.botMessageEdit`、`botfather.botMessageEdit`

后果：编辑图文混排消息会存脏 content / 丢 plain → 下游 summary / search / 复制又丢字（与 #232 同类，换了入口）。

## 改动

新增共用 gate `richtext.NormalizeContentEdit(contentEdit string) (string, error)`：

- **type=14**：跑与 send 路径同一套 write-strict 校验（`common.ValidateRichTextPayload`：拒 缺/空 content、空 text 块、非 http(s) 图片 URL、缺图片宽高、未知 block type、超 1MB），并用 content 重算权威顶层 plain，返回 canonical JSON。
- **非 14 / 非 JSON 体**：原样返回，老编辑路径行为不变。
- **编辑语义**：客户端整体替换 content blocks，plain **服务端重算不信客户端**（契约 §2）。编辑路径无 server enrich，故单步 `EnsurePlain`（Validate + 无 enrich 的 Finalize）正是 send 路径 `Validate + enrich 后 Finalize` 的对称等价物。

## 跨入口对称性（关键）

`grep` 所有写 `content_edit` 的入口，确认四个编辑写入口全部对称接入同一 gate，MD5 去重 hash 落在 normalize 后的 canonical 体上：

| 入口 | 文件 |
|---|---|
| user `/v1/message/edit` | `modules/message/api.go` |
| robot `/message/edit` | `modules/robot/api.go` |
| bot_api `/v1/bot/message/edit` | `modules/bot_api/send.go` |
| botfather `/v1/bot/message/edit` | `modules/botfather/api.go` |

## revoke 路径

无需 14 特判：`revoke` 只在 `message_extra` 上置 `Revoke=1 + Revoker + Version`，从不读写消息 Payload / `content_edit`，既不破坏既有 plain，也无需重算 content。已在 `revoke` 函数上方注释说明原因。

## 测试

`pkg/richtext/plain_test.go` 新增 `NormalizeContentEdit` 回归：
- 编辑 14 后用 content 重算 plain、覆盖伪造 plain（canonical JSON 输出）
- 脏 content_edit（空 content / 空 text / data: 图片 / 缺尺寸 / 未知 block）被拒
- 超 1MB 被拒
- 非 14 / 非 JSON 编辑体原样透传，老行为不变

## 验证

- `go build ./...` ✅
- `go vet ./...` ✅
- `gofmt -l`（改动文件）无输出 ✅
- `go test ./pkg/richtext/... ./modules/robot/... ./modules/bot_api/...` ✅
- message / botfather 测试包的失败均为 sandbox 无 MySQL 的预存基础设施失败（`dial tcp 127.0.0.1:3306: connection refused`），与本改动无关

## 禁改清单遵守

未改其他仓、未回退 #232 已落地的 send/robot/search/webhook 逻辑、未扩范围。

## 审查状态

- 改动规模：+186 / -2，6 文件
- /review（自审）：PASS ✅ — 四入口对称、非 14 透传、plain 服务端权威重算
- /codex review：PASS ✅ — "No actionable correctness issues were found in the diff. The new RichText edit normalization is applied consistently across the edited write paths and preserves legacy non-RichText behavior."

Fixes #233
