### PR TITLE
feat(robot/bot_api): bot 群级免@偏好——建表 + owner 写/读/列群 + adapter 读端点

### DIFF
--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -216,6 +216,7 @@ func (ba *BotAPI) Route(r *wkhttp.WKHttp) {
 		botAPI.GET("/groups", ba.getGroups)
 		botAPI.GET("/groups/:group_no", ba.getGroupInfo)
 		botAPI.GET("/groups/:group_no/members", ba.getGroupMembers)
+		botAPI.GET("/groups/:group_no/mention_pref", ba.getMentionPref) // 群级免@偏好读（octo-server#237）
 		botAPI.GET("/groups/:group_no/md", ba.getGroupMd)
 		botAPI.PUT("/groups/:group_no/md", ba.updateGroupMd)
 		botAPI.GET("/space/members", ba.botSpaceMembers)

--- a/modules/bot_api/mention_pref.go
+++ b/modules/bot_api/mention_pref.go
@@ -1,0 +1,45 @@
+package bot_api
+
+import (
+	"errors"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/gocraft/dbr/v2"
+	"go.uber.org/zap"
+)
+
+// getMentionPref handles GET /v1/bot/groups/:group_no/mention_pref.
+//
+// Adapter-facing read of the per-group no-@ preference (octo-server#237).
+// robot_id is taken from the authBot context — query is NOT trusted.
+// Membership gate mirrors getGroupInfo (groups.go:60-94). No record → no_mention=0.
+func (ba *BotAPI) getMentionPref(c *wkhttp.Context) {
+	robotID := getRobotIDFromContext(c)
+	if robotID == "" {
+		c.ResponseError(errors.New("robot_id not found"))
+		return
+	}
+	groupNo := c.Param("group_no")
+
+	var count int
+	err := ba.db.session.SelectBySql(
+		"SELECT COUNT(*) FROM group_member WHERE group_no=? AND uid=? AND is_deleted=0",
+		groupNo, robotID,
+	).LoadOne(&count)
+	if err != nil || count == 0 {
+		c.ResponseError(errors.New("bot is not a member of this group"))
+		return
+	}
+
+	var noMention int
+	err = ba.db.session.Select("no_mention").From("bot_mention_pref").
+		Where("robot_id=? AND group_no=?", robotID, groupNo).LoadOne(&noMention)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		ba.Error("查询 bot_mention_pref 失败", zap.Error(err),
+			zap.String("robot_id", robotID), zap.String("group_no", groupNo))
+		c.ResponseError(errors.New("查询失败"))
+		return
+	}
+
+	c.Response(map[string]interface{}{"no_mention": noMention})
+}

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -267,6 +267,11 @@ func (rb *Robot) Route(r *wkhttp.WKHttp) {
 		auth.PUT("/robot/:robot_id/auto_approve", rb.setAutoApprove) // 设置是否自动通过好友申请
 		auth.GET("/robot/space_bots", rb.spaceBots)                  // Bot 广场 — Space 内所有 Bot
 		auth.GET("/robot/my_bots", rb.myBots)                        // 我的 Bot — 已添加好友的 Bot
+		// bot 群级免@偏好（octo-server#237）：owner 写/读/列群
+		auth.GET("/robot/:robot_id/groups", rb.listGroups)                                  // 列出 bot 所在群 + no_mention
+		auth.PUT("/robot/:robot_id/groups/:group_no/mention_pref", rb.setMentionPref)       // UPSERT 群级免@偏好
+		auth.DELETE("/robot/:robot_id/groups/:group_no/mention_pref", rb.deleteMentionPref) // 删除回退默认（幂等）
+		auth.GET("/robot/:robot_id/groups/:group_no/mention_pref", rb.getMentionPref)       // 读群级免@偏好
 	}
 
 	robotAuth := r.Group("/v1/robots/:robot_id/:app_key", rb.authRobot()) // :robot_id即user的username

--- a/modules/robot/mention_pref.go
+++ b/modules/robot/mention_pref.go
@@ -1,0 +1,283 @@
+package robot
+
+import (
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/gocraft/dbr/v2"
+	"go.uber.org/zap"
+)
+
+// bot_mention_pref —— bot 群级免@偏好（octo-server#237 / YUJ-2836）。
+//
+// 稀疏覆盖表：维度 (robot_id, group_no) → no_mention，只存「偏离账号级默认」的项。
+// 无记录时调用方回退账号级 requireMention（零回归）。
+//
+// owner 端点（user-session + creator 校验）在本文件实现；adapter 读端点
+// （botToken + membership）在 modules/bot_api/mention_pref.go。
+
+const (
+	groupsListDefaultLimit = 30
+	groupsListMaxLimit     = 100
+)
+
+// ownershipResult is the pure outcome of the creator-ownership check, so the
+// decision (404 not-found vs 403 forbidden vs OK) is unit-testable without a DB.
+type ownershipResult int
+
+const (
+	ownershipOK        ownershipResult = iota // login user is the creator
+	ownershipNotFound                         // robot missing / no creator_uid → 404
+	ownershipForbidden                        // creator != loginUID → 403
+)
+
+// decideOwnership maps (creatorUID, loginUID) to an ownershipResult. Mirrors
+// the setAutoApprove guard (api.go:1199-1230): empty creator → not found,
+// mismatch → forbidden.
+func decideOwnership(creatorUID, loginUID string) ownershipResult {
+	if creatorUID == "" {
+		return ownershipNotFound
+	}
+	if creatorUID != loginUID {
+		return ownershipForbidden
+	}
+	return ownershipOK
+}
+
+// clampGroupsLimit parses/normalizes the ?limit= query value: blank/invalid →
+// default 30, capped at 100, floored at 1.
+func clampGroupsLimit(raw string) int {
+	limit := groupsListDefaultLimit
+	if v := strings.TrimSpace(raw); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > groupsListMaxLimit {
+		limit = groupsListMaxLimit
+	}
+	return limit
+}
+
+// decodeGroupsCursor decodes an opaque base64 cursor to a last-seen group_member.id.
+// Blank/garbage cursor → 0 (first page), keeping the cursor opaque to clients.
+func decodeGroupsCursor(raw string) int64 {
+	cur := strings.TrimSpace(raw)
+	if cur == "" {
+		return 0
+	}
+	dec, err := base64.StdEncoding.DecodeString(cur)
+	if err != nil {
+		return 0
+	}
+	n, err := strconv.ParseInt(string(dec), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// encodeGroupsCursor encodes a group_member.id into an opaque base64 cursor.
+func encodeGroupsCursor(id int64) string {
+	return base64.StdEncoding.EncodeToString([]byte(strconv.FormatInt(id, 10)))
+}
+
+// assertRobotOwner 校验登录用户为 robot 创建者。守卫语义照搬 setAutoApprove
+// (api.go:1199-1230)，但区分 404（robot 不存在）/ 403（非 owner）/ 500（DB 故障）。
+// 返回 true 表示已写出错误响应、调用方应直接 return。
+func (rb *Robot) assertRobotOwner(c *wkhttp.Context, robotID, loginUID string) bool {
+	var creatorUID string
+	err := rb.ctx.DB().Select("IFNULL(creator_uid,'')").
+		From("robot").Where("robot_id=? AND status=1", robotID).LoadOne(&creatorUID)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		// 真实 DB/扫描错误不能伪装成 404，否则会掩盖故障。
+		rb.Error("查询 robot creator 失败", zap.Error(err), zap.String("robot_id", robotID))
+		c.ResponseError(errors.New("查询失败"))
+		return true
+	}
+	// ErrNotFound → creatorUID 仍为 ""，decideOwnership 归类为 404。
+	switch decideOwnership(creatorUID, loginUID) {
+	case ownershipNotFound:
+		c.ResponseErrorWithStatus(errors.New("机器人不存在"), http.StatusNotFound)
+		return true
+	case ownershipForbidden:
+		c.ResponseErrorWithStatus(errors.New("只有创建者可以操作"), http.StatusForbidden)
+		return true
+	default:
+		return false
+	}
+}
+
+// setMentionPref 处理 PUT /v1/robot/:robot_id/groups/:group_no/mention_pref。
+// body {"no_mention":0|1}，UPSERT 到 bot_mention_pref。
+func (rb *Robot) setMentionPref(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+	robotID := c.Param("robot_id")
+	groupNo := c.Param("group_no")
+
+	var req struct {
+		NoMention int `json:"no_mention"`
+	}
+	if err := c.BindJSON(&req); err != nil {
+		c.ResponseError(errors.New("参数错误"))
+		return
+	}
+	if req.NoMention != 0 && req.NoMention != 1 {
+		c.ResponseError(errors.New("no_mention 只能为 0 或 1"))
+		return
+	}
+
+	if rb.assertRobotOwner(c, robotID, loginUID) {
+		return
+	}
+
+	// dbr 的 InsertStmt 不暴露 Suffix，用 InsertBySql + ON DUPLICATE KEY UPDATE 完成 upsert。
+	// updated_at 走列默认 ON UPDATE CURRENT_TIMESTAMP 自动更新。
+	_, err := rb.ctx.DB().InsertBySql(
+		"INSERT INTO bot_mention_pref (robot_id, group_no, no_mention, updated_by) "+
+			"VALUES (?, ?, ?, ?) "+
+			"ON DUPLICATE KEY UPDATE no_mention=VALUES(no_mention), updated_by=VALUES(updated_by)",
+		robotID, groupNo, req.NoMention, loginUID,
+	).Exec()
+	if err != nil {
+		rb.Error("写入 bot_mention_pref 失败", zap.Error(err),
+			zap.String("robot_id", robotID), zap.String("group_no", groupNo))
+		c.ResponseError(errors.New("更新失败"))
+		return
+	}
+	c.ResponseOK()
+}
+
+// deleteMentionPref 处理 DELETE /v1/robot/:robot_id/groups/:group_no/mention_pref。
+// 删除记录回退账号级默认。幂等：删不存在记录也返回 200。
+func (rb *Robot) deleteMentionPref(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+	robotID := c.Param("robot_id")
+	groupNo := c.Param("group_no")
+
+	if rb.assertRobotOwner(c, robotID, loginUID) {
+		return
+	}
+
+	_, err := rb.ctx.DB().DeleteFrom("bot_mention_pref").
+		Where("robot_id=? AND group_no=?", robotID, groupNo).Exec()
+	if err != nil {
+		rb.Error("删除 bot_mention_pref 失败", zap.Error(err),
+			zap.String("robot_id", robotID), zap.String("group_no", groupNo))
+		c.ResponseError(errors.New("删除失败"))
+		return
+	}
+	c.ResponseOK()
+}
+
+// getMentionPref 处理 GET /v1/robot/:robot_id/groups/:group_no/mention_pref。
+// 返回 {"no_mention":0|1}，无记录返回 0。
+func (rb *Robot) getMentionPref(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+	robotID := c.Param("robot_id")
+	groupNo := c.Param("group_no")
+
+	if rb.assertRobotOwner(c, robotID, loginUID) {
+		return
+	}
+
+	var noMention int
+	err := rb.ctx.DB().Select("no_mention").From("bot_mention_pref").
+		Where("robot_id=? AND group_no=?", robotID, groupNo).LoadOne(&noMention)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		// dbr 在无记录时返回 ErrNotFound；其它错误才算真失败。
+		rb.Error("查询 bot_mention_pref 失败", zap.Error(err),
+			zap.String("robot_id", robotID), zap.String("group_no", groupNo))
+		c.ResponseError(errors.New("查询失败"))
+		return
+	}
+	c.Response(map[string]interface{}{"no_mention": noMention})
+}
+
+// groupScanRow is the raw DB row for listGroups. no_mention scans as int
+// (TINYINT); database/sql does not reliably convert the driver int into a Go
+// bool, so we scan int here and project to bool in groupListItem.
+type groupScanRow struct {
+	ID        int64  `db:"id"`
+	GroupNo   string `db:"group_no"`
+	Name      string `db:"name"`
+	NoMention int    `db:"no_mention"`
+}
+
+// groupListItem 列群响应单项。
+type groupListItem struct {
+	GroupNo   string `json:"group_no"`
+	Name      string `json:"name"`
+	NoMention bool   `json:"no_mention"`
+}
+
+// listGroups 处理 GET /v1/robot/:robot_id/groups?limit=30&cursor=<opaque>&q=<可选>。
+// group_member gm JOIN group g WHERE gm.uid=robot_id AND gm.is_deleted=0，
+// LEFT JOIN bot_mention_pref 得 no_mention。cursor 为不透明 base64(last_id)。
+func (rb *Robot) listGroups(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+	robotID := c.Param("robot_id")
+
+	if rb.assertRobotOwner(c, robotID, loginUID) {
+		return
+	}
+
+	limit := clampGroupsLimit(c.Query("limit"))
+
+	// cursor: 不透明 base64 编码的 last group_member.id；解码失败视为首页。
+	lastID := decodeGroupsCursor(c.Query("cursor"))
+
+	q := strings.TrimSpace(c.Query("q"))
+
+	// 多取 1 行判断 has_more。按 gm.id 升序稳定分页。
+	sql := "SELECT gm.id AS id, gm.group_no AS group_no, IFNULL(g.name,'') AS name, " +
+		"IFNULL(p.no_mention,0) AS no_mention " +
+		"FROM group_member gm " +
+		"INNER JOIN `group` g ON gm.group_no = g.group_no " +
+		"LEFT JOIN bot_mention_pref p ON p.robot_id = gm.uid AND p.group_no = gm.group_no " +
+		"WHERE gm.uid = ? AND gm.is_deleted = 0 AND gm.id > ?"
+	args := []interface{}{robotID, lastID}
+	if q != "" {
+		sql += " AND g.name LIKE ?"
+		args = append(args, "%"+q+"%")
+	}
+	sql += " ORDER BY gm.id ASC LIMIT ?"
+	args = append(args, limit+1)
+
+	var rows []groupScanRow
+	_, err := rb.ctx.DB().SelectBySql(sql, args...).Load(&rows)
+	if err != nil {
+		rb.Error("列群查询失败", zap.Error(err), zap.String("robot_id", robotID))
+		c.ResponseError(errors.New("查询群组失败"))
+		return
+	}
+
+	hasMore := len(rows) > limit
+	if hasMore {
+		rows = rows[:limit]
+	}
+
+	var nextCursor interface{} // null 当无下一页
+	if hasMore && len(rows) > 0 {
+		nextCursor = encodeGroupsCursor(rows[len(rows)-1].ID)
+	}
+
+	list := make([]groupListItem, 0, len(rows))
+	for _, r := range rows {
+		list = append(list, groupListItem{
+			GroupNo:   r.GroupNo,
+			Name:      r.Name,
+			NoMention: r.NoMention == 1,
+		})
+	}
+
+	c.JSON(http.StatusOK, map[string]interface{}{
+		"list":        list,
+		"next_cursor": nextCursor,
+		"has_more":    hasMore,
+	})
+}

--- a/modules/robot/mention_pref_test.go
+++ b/modules/robot/mention_pref_test.go
@@ -1,0 +1,71 @@
+package robot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDecideOwnership covers the creator-ownership decision used by the
+// owner-scoped mention_pref endpoints (octo-server#237). The ownership reject
+// paths (404 not-found, 403 forbidden) are the acceptance-required coverage.
+func TestDecideOwnership(t *testing.T) {
+	cases := []struct {
+		name       string
+		creatorUID string
+		loginUID   string
+		want       ownershipResult
+	}{
+		{"creator matches → OK", "owner_1", "owner_1", ownershipOK},
+		{"robot missing (empty creator) → 404", "", "owner_1", ownershipNotFound},
+		{"empty creator + empty login → 404", "", "", ownershipNotFound},
+		{"different user → 403", "owner_1", "intruder_2", ownershipForbidden},
+		{"creator set, login empty → 403", "owner_1", "", ownershipForbidden},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, decideOwnership(tc.creatorUID, tc.loginUID))
+		})
+	}
+}
+
+// TestClampGroupsLimit verifies default (30), upper cap (100), and floor handling.
+func TestClampGroupsLimit(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want int
+	}{
+		{"", groupsListDefaultLimit},
+		{"abc", groupsListDefaultLimit},
+		{"0", groupsListDefaultLimit},
+		{"-5", groupsListDefaultLimit},
+		{"15", 15},
+		{"30", 30},
+		{"100", 100},
+		{"101", groupsListMaxLimit},
+		{"99999", groupsListMaxLimit},
+		{"  20  ", 20},
+	}
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			assert.Equal(t, tc.want, clampGroupsLimit(tc.raw))
+		})
+	}
+}
+
+// TestGroupsCursorRoundTrip verifies the opaque cursor encodes/decodes and that
+// blank/garbage decodes to 0 (first page) — keeping the cursor opaque to clients.
+func TestGroupsCursorRoundTrip(t *testing.T) {
+	for _, id := range []int64{1, 42, 1_000_000, 9_223_372_036_854_775_807} {
+		enc := encodeGroupsCursor(id)
+		assert.NotEqual(t, "", enc)
+		assert.Equal(t, id, decodeGroupsCursor(enc))
+	}
+
+	// Blank and non-base64 / non-numeric inputs fall back to 0 (first page).
+	assert.Equal(t, int64(0), decodeGroupsCursor(""))
+	assert.Equal(t, int64(0), decodeGroupsCursor("   "))
+	assert.Equal(t, int64(0), decodeGroupsCursor("!!!not-base64!!!"))
+	// Valid base64 of a non-numeric string also falls back to 0.
+	assert.Equal(t, int64(0), decodeGroupsCursor("YWJj")) // base64("abc")
+}

--- a/modules/robot/sql/20260603000001_bot_mention_pref.sql
+++ b/modules/robot/sql/20260603000001_bot_mention_pref.sql
@@ -1,0 +1,17 @@
+-- +migrate Up
+-- bot_mention_pref: 群级免@偏好稀疏表。维度 (robot_id, group_no) → no_mention。
+-- 只存「偏离账号级默认」的覆盖项；无记录时调用方回退账号级 requireMention（零回归）。
+CREATE TABLE IF NOT EXISTS `bot_mention_pref` (
+  `id`         BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `robot_id`   VARCHAR(40)     NOT NULL DEFAULT '' COMMENT 'Bot UID',
+  `group_no`   VARCHAR(40)     NOT NULL DEFAULT '' COMMENT '群唯一编号',
+  `no_mention` TINYINT         NOT NULL DEFAULT 0  COMMENT '0=遵循账号级默认 1=本群免@回答',
+  `created_at` TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `updated_by` VARCHAR(40)     NOT NULL DEFAULT '' COMMENT '最后修改人 UID',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_robot_group` (`robot_id`, `group_no`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='Bot 群级免@偏好（稀疏覆盖表）';
+
+-- +migrate Down
+DROP TABLE IF EXISTS `bot_mention_pref`;


### PR DESCRIPTION
## 概述

实现 bot 群级免@偏好（维度 `(robot_id, group_no) → no_mention`）的后端：一张稀疏覆盖表 + 三组端点。无记录时回退账号级 `requireMention`（零回归）。

Fixes #237

## 改动

### 1. 建表（robot 模块 sql/ embed）
`modules/robot/sql/20260603000001_bot_mention_pref.sql`：`bot_mention_pref(robot_id, group_no, no_mention, created_at, updated_at, updated_by)`，唯一键 `(robot_id, group_no)`，`-- +migrate Up/Down` 可正常 up/down。稀疏表，只存偏离默认项。

### 2. owner 写/读（robot 模块，user-session 鉴权）
挂 `api.go` 的 `auth` 组：
- `PUT /v1/robot/:robot_id/groups/:group_no/mention_pref` body `{no_mention:0|1}` → UPSERT（`INSERT ... ON DUPLICATE KEY UPDATE`）
- `DELETE .../mention_pref` → 删记录回退默认，**幂等**（删不存在返回 200）
- `GET .../mention_pref` → `{no_mention:0|1}`，无记录返回 0

ownership 守卫照搬 `setAutoApprove`：`creator_uid != loginUID` → 403，robot 不存在 → 404，真实 DB 错误 → 500（不伪装成 404）。

### 3. owner 列群（robot 模块，本功能新增）
`GET /v1/robot/:robot_id/groups?limit=30&cursor=&q=`：`group_member gm JOIN group g WHERE gm.uid=robot_id AND gm.is_deleted=0`，LEFT JOIN `bot_mention_pref` 得 `no_mention`。响应 `{list:[{group_no,name,no_mention}],next_cursor,has_more}`。limit 默认 30 上限 100，cursor 不透明 base64(group_member.id)，分页到底 `next_cursor=null`。守卫同上。

### 4. adapter 读（bot_api 模块，botToken 鉴权）
挂 `bot_api.go` 的 `botAPI` 组：`GET /v1/bot/groups/:group_no/mention_pref`。`robot_id` 从 authBot ctx（`getRobotIDFromContext`）取，**禁信任 query**。membership 门照搬 `getGroupInfo`。无记录 `no_mention=0`。

## 验收对照
- ✅ 迁移 up/down OK
- ✅ 三组端点鉴权正确（写/列群 = user-session + creator 校验；读 = botToken + membership）
- ✅ DELETE 幂等
- ✅ cursor 分页到底 `next_cursor=null`
- ✅ 单测覆盖 ownership 拒绝路径（404/403）+ limit 钳制 + cursor 往返/垃圾输入

## 审查状态
- 改动规模：约 +400 行, 6 文件
- `go build ./...` ✅ | `go vet` ✅ | `go test ./modules/robot ./modules/bot_api` ✅
- codex review: PASS ✅（Medium「DB 错误被伪装成 404」已修；High「owner 端点不校验 membership」按 issue 设计为 ownership-only 守卫，不在范围内；Low「no_mention=0 = 回退默认」为设计契约）

## 跨仓
前端 octo-web#235 / adapter openclaw-channel-octo#56 依赖本仓接口，本 PR 为关键路径，需先合。

<!-- re-trigger check-sprint W23 1780474078 -->