### PR TITLE
feat(botfather): UserAPIKeyService + Bot occupancy (bind/unbind) for Octo-link

### DIFF
--- a/modules/botfather/api.go
+++ b/modules/botfather/api.go
@@ -46,6 +46,7 @@ type BotFather struct {
 	appService       app.IService
 	fileService      file.IService
 	groupService     group.IService
+	apiKeyService    UserAPIKeyService
 	userDB           *user.DB
 	threadService    thread.IService
 	robotEventPrefix string
@@ -64,6 +65,7 @@ func New(ctx *config.Context) *BotFather {
 		appService:       app.NewService(ctx),
 		fileService:      file.NewService(ctx),
 		groupService:     group.NewService(ctx),
+		apiKeyService:    NewUserAPIKeyService(ctx),
 		userDB:           user.NewDB(ctx),
 		threadService:    thread.NewService(ctx),
 		robotEventPrefix: "robotEvent:",

--- a/modules/botfather/api_user.go
+++ b/modules/botfather/api_user.go
@@ -8,6 +8,9 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
@@ -15,6 +18,17 @@ import (
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 )
+
+// botBoundAtFormat 与 octo-lib db.Time 的序列化格式一致，保证 bound_at 在列表/
+// 占用响应里与其它时间字段同构。
+const botBoundAtFormat = "2006-01-02 15:04:05"
+
+// maxAgentRefLen 限制 agent_ref 长度，与 robot.bound_agent_ref 列宽（128）一致。
+const maxAgentRefLen = 128
+
+// bindMaxAttempts 限定 bind 在「CAS 与复查之间被并发 unbind 释放」竞态下的重试次数，
+// 防止极端 bind/unbind 抖动时无限循环。正常路径一次成功。
+const bindMaxAttempts = 3
 
 // ========== User API Key 认证中间件 ==========
 
@@ -26,13 +40,17 @@ func (bf *BotFather) authUserAPIKey() wkhttp.HandlerFunc {
 			return
 		}
 
-		keyModel, err := bf.db.queryUserAPIKeyByKey(token)
+		keyModel, err := bf.apiKeyService.AuthByKey(token)
 		if err != nil {
 			bf.Error("查询User API Key失败", zap.Error(err))
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"msg": "认证失败"})
 			return
 		}
 		if keyModel == nil {
+			// key 不存在或非 active（AuthByKey 已按 status=1 过滤）→ 统一 401。
+			// 注意：当前 PR 尚无生产路径把 key 置为 revoked（status=0）；status=1
+			// 过滤是为 PR2 的 DELETE /v1/integrations/oidc/binding 撤销能力预留的
+			// 前瞻防御，届时撤销的 key 会在此被拒为 401。
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"msg": "无效的API Key"})
 			return
 		}
@@ -65,14 +83,14 @@ func getAPIKeySpaceID(c *wkhttp.Context) string {
 	return ""
 }
 
-// isBotInSpace checks whether a bot belongs to the given Space.
+// isBotInSpace checks whether a bot belongs to the given (active) Space.
+//
+// Delegates to bf.db.isBotInSpace, which additionally joins space.status=1 so a
+// bot whose space_member row is still active but whose Space is disabled does
+// NOT pass. Kept as a thin wrapper so the existing handler call sites
+// (update/delete/getToken/bind/unbind) need no churn.
 func (bf *BotFather) isBotInSpace(botID, spaceID string) (bool, error) {
-	var count int
-	_, err := bf.db.session.SelectBySql(
-		"SELECT COUNT(*) FROM space_member WHERE space_id=? AND uid=? AND status=1",
-		spaceID, botID,
-	).Load(&count)
-	return count > 0, err
+	return bf.db.isBotInSpace(botID, spaceID)
 }
 
 // setupUserAPIRoutes 注册 User API Key 认证的路由
@@ -84,6 +102,8 @@ func (bf *BotFather) setupUserAPIRoutes(r *wkhttp.WKHttp) {
 		userAPI.PUT("/bots/:bot_id", bf.updateUserBot)
 		userAPI.DELETE("/bots/:bot_id", bf.deleteUserBot)
 		userAPI.GET("/bots/:bot_id/token", bf.getUserBotToken)
+		userAPI.POST("/bots/:bot_id/bind", bf.bindUserBot)
+		userAPI.DELETE("/bots/:bot_id/bind", bf.unbindUserBot)
 	}
 }
 
@@ -279,12 +299,18 @@ func (bf *BotFather) listUserBots(c *wkhttp.Context) {
 		if userResp != nil {
 			name = userResp.Name
 		}
+		var boundAt *string
+		if bot.BoundAt.Valid {
+			s := bot.BoundAt.Time.Format(botBoundAtFormat)
+			boundAt = &s
+		}
 		list = append(list, &UserBotResp{
 			RobotID:       bot.RobotID,
 			Username:      bot.Username,
 			Name:          name,
 			Description:   bot.Description,
-			BotToken:      bot.BotToken,
+			BoundAgentRef: bot.BoundAgentRef,
+			BoundAt:       boundAt,
 			AgentPlatform: bot.AgentPlatform,
 			AgentVersion:  bot.AgentVersion,
 			PluginVersion: bot.PluginVersion,
@@ -490,5 +516,193 @@ func (bf *BotFather) getUserBotToken(c *wkhttp.Context) {
 	c.Response(gin.H{
 		"robot_id":  bot.RobotID,
 		"bot_token": bot.BotToken,
+	})
+}
+
+// ========== Bot 占用 / 绑定 ==========
+
+// bindUserBot POST /v1/user/bots/:bot_id/bind
+//
+// 占用一个自有 Bot。creator 级权限 + 行级 CAS 互斥：多个 Agent 并发抢同一空闲
+// Bot 时 Octo 侧只放行一个；重复传同一 agent_ref 幂等成功；已被他人占用返回
+// 409 并在 error.details.occupied_by 透传当前占用方。
+func (bf *BotFather) bindUserBot(c *wkhttp.Context) {
+	uid := getAPIKeyUID(c)
+	spaceID := getAPIKeySpaceID(c)
+	botID := c.Param("bot_id")
+
+	var req BindBotReq
+	if err := c.BindJSON(&req); err != nil {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedParamInvalid, nil, i18n.Details{"field": "agent_ref"})
+		return
+	}
+	agentRef := strings.TrimSpace(req.AgentRef)
+	if agentRef == "" || len(agentRef) > maxAgentRefLen {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedParamInvalid, nil, i18n.Details{"field": "agent_ref"})
+		return
+	}
+
+	// 1) 存在性 + creator 校验：他人创建的 Bot 不可见（按 PM creator 级边界）。
+	bot, err := bf.db.queryRobotByRobotIDAndCreator(botID, uid)
+	if err != nil {
+		bf.Error("查询Bot失败", zap.Error(err))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+	if bot == nil {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedNotFound, nil, nil)
+		return
+	}
+
+	// 2) Space 隔离：key 绑定到 Space 时校验 Bot 属于该 Space。
+	if spaceID != "" {
+		inSpace, sErr := bf.isBotInSpace(botID, spaceID)
+		if sErr != nil {
+			bf.Error("校验Bot Space归属失败", zap.Error(sErr))
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+			return
+		}
+		if !inSpace {
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedForbidden, nil, nil)
+			return
+		}
+	}
+
+	// 3) 行级 CAS 占用。带有界重试，原因见下方各分支注释。
+	for attempt := 0; attempt < bindMaxAttempts; attempt++ {
+		affected, err := bf.db.bindRobotCAS(botID, uid, agentRef)
+		if err != nil {
+			bf.Error("占用Bot失败", zap.Error(err))
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+			return
+		}
+
+		// affected==1：CAS 命中，本次占用确定成功（写入即真相，无需复查——复查会被
+		// 并发 unbind 污染成「已释放」的陈旧视图）。直接按 agentRef 回包；bound_at
+		// best-effort 回读。
+		if affected == 1 {
+			boundAt := ""
+			if cur, rErr := bf.db.queryRobotByRobotIDAndCreator(botID, uid); rErr == nil && cur != nil && cur.BoundAt.Valid {
+				boundAt = cur.BoundAt.Time.Format(botBoundAtFormat)
+			}
+			c.Response(&BindBotResp{RobotID: botID, BoundAgentRef: agentRef, BoundAt: boundAt})
+			return
+		}
+
+		// affected==0：不一定是冲突——MySQL 按「实际改动行数」计，幂等 re-bind（占用方
+		// 未变、同秒 NOW() 也不变）同样返回 0。复查 bound_agent_ref 区分：
+		current, err := bf.db.queryRobotByRobotIDAndCreator(botID, uid)
+		if err != nil {
+			bf.Error("回读占用状态失败", zap.Error(err))
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+			return
+		}
+		switch {
+		case current == nil:
+			// 1)~3) 之间 Bot 被并发删除 → 404（而非 500）。
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedNotFound, nil, nil)
+			return
+		case current.BoundAgentRef == agentRef:
+			// 已是自己持有（幂等成功）。
+			boundAt := ""
+			if current.BoundAt.Valid {
+				boundAt = current.BoundAt.Time.Format(botBoundAtFormat)
+			}
+			c.Response(&BindBotResp{RobotID: botID, BoundAgentRef: current.BoundAgentRef, BoundAt: boundAt})
+			return
+		case current.BoundAgentRef == "":
+			// CAS 时被他人持有（故 affected=0），复查时又被并发 unbind 释放成空闲。
+			// 这是可恢复的竞态：重试 CAS 抢占，而非把空占用方塞进 409。
+			continue
+		default:
+			// 被其他 agent_ref 占用。
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrBotOccupied, nil, i18n.Details{"occupied_by": current.BoundAgentRef})
+			return
+		}
+	}
+
+	// 重试用尽仍未抢到（极端高频 bind/unbind 抖动）：按冲突返回，让调用方退避重试。
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrBotOccupied, nil, nil)
+}
+
+// unbindUserBot DELETE /v1/user/bots/:bot_id/bind
+//
+// 释放占用。creator 级权限 + **agent_ref 归属校验**：只有当前占用方本人（或 Bot
+// 已空闲）才能释放，否则 409。这与 bind 对称，共同保证「一个 Bot 同时只被一个
+// Agent 占用」——否则同一用户的另一 Agent 能用共享 uk_ 把别人的占用清掉再自占。
+// 对占用方幂等（已空闲再次调用仍成功）。
+func (bf *BotFather) unbindUserBot(c *wkhttp.Context) {
+	uid := getAPIKeyUID(c)
+	spaceID := getAPIKeySpaceID(c)
+	botID := c.Param("bot_id")
+
+	var req BindBotReq
+	if err := c.BindJSON(&req); err != nil {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedParamInvalid, nil, i18n.Details{"field": "agent_ref"})
+		return
+	}
+	agentRef := strings.TrimSpace(req.AgentRef)
+	if agentRef == "" || len(agentRef) > maxAgentRefLen {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedParamInvalid, nil, i18n.Details{"field": "agent_ref"})
+		return
+	}
+
+	bot, err := bf.db.queryRobotByRobotIDAndCreator(botID, uid)
+	if err != nil {
+		bf.Error("查询Bot失败", zap.Error(err))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+	if bot == nil {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedNotFound, nil, nil)
+		return
+	}
+
+	if spaceID != "" {
+		inSpace, sErr := bf.isBotInSpace(botID, spaceID)
+		if sErr != nil {
+			bf.Error("校验Bot Space归属失败", zap.Error(sErr))
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+			return
+		}
+		if !inSpace {
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedForbidden, nil, nil)
+			return
+		}
+	}
+
+	affected, err := bf.db.unbindRobotCAS(botID, uid, agentRef)
+	if err != nil {
+		bf.Error("释放Bot占用失败", zap.Error(err))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+	// affected=0 不一定是冲突：Bot 已空闲（幂等）时 bound_agent_ref 未变也返回 0。
+	// 复查 bound_agent_ref 区分「已空闲（幂等成功）」「被他人占用（409）」「被删（404）」。
+	if affected == 0 {
+		current, reErr := bf.db.queryRobotByRobotIDAndCreator(botID, uid)
+		if reErr != nil {
+			bf.Error("回读占用状态失败", zap.Error(reErr))
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+			return
+		}
+		switch {
+		case current == nil:
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedNotFound, nil, nil)
+			return
+		case current.BoundAgentRef != "" && current.BoundAgentRef != agentRef:
+			// 被其他 Agent 占用：不允许越权释放。
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrBotOccupied, nil, i18n.Details{"occupied_by": current.BoundAgentRef})
+			return
+		}
+		// 否则 Bot 已空闲 → 幂等成功，落到下方统一响应。
+	}
+
+	// bound_at 显式置 null：释放后无占用时间，与 docs §6 的响应形状及 bind 路径
+	// 的 bound_at 字段对齐，避免严格按文档编码的客户端读到 undefined。
+	c.Response(gin.H{
+		"robot_id":        botID,
+		"bound_agent_ref": "",
+		"bound_at":        nil,
 	})
 }

--- a/modules/botfather/api_user_bind_test.go
+++ b/modules/botfather/api_user_bind_test.go
@@ -1,0 +1,347 @@
+package botfather
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUserAPITestServer wraps testutil.NewTestServer and wires the i18n
+// ErrorRenderer onto the route, mirroring main.go. Without it, httperr.
+// ResponseErrorLWithStatus → c.RenderError falls back to the legacy {msg,status}
+// envelope with no error.code, and the bind/occupied assertions can't see the
+// stable code.
+func newUserAPITestServer(t *testing.T) (http.Handler, *config.Context) {
+	t.Helper()
+	s, ctx := testutil.NewTestServer()
+	s.GetRoute().SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	return s.GetRoute(), ctx
+}
+
+// mintUserAPIKey creates a no-space `uk_` for uid so the User API routes
+// authenticate as that user (space isolation branch skipped).
+func mintUserAPIKey(t *testing.T, ctx *config.Context, uid string) string {
+	key, err := NewUserAPIKeyService(ctx).GetOrCreate(uid, "", clientIDBotFather)
+	require.NoError(t, err)
+	return key
+}
+
+// mintUserAPIKeyInSpace creates a space-bound `uk_`; the middleware then sets
+// api_key_space_id, so handlers exercise the Space isolation branch.
+func mintUserAPIKeyInSpace(t *testing.T, ctx *config.Context, uid, spaceID string) string {
+	key, err := NewUserAPIKeyService(ctx).GetOrCreate(uid, spaceID, clientIDBotFather)
+	require.NoError(t, err)
+	return key
+}
+
+// addBotToSpace registers the bot as an active member of an active Space. It
+// also ensures the `space` row exists with status=1 — isBotInSpace joins
+// space.status=1, so membership alone is not enough.
+func addBotToSpace(t *testing.T, ctx *config.Context, spaceID, botID string) {
+	_, err := ctx.DB().InsertBySql(
+		"INSERT IGNORE INTO space (space_id, name, status) VALUES (?, ?, 1)",
+		spaceID, spaceID,
+	).Exec()
+	require.NoError(t, err)
+	_, err = ctx.DB().InsertBySql(
+		"INSERT IGNORE INTO space_member (space_id, uid, role, status, created_at, updated_at) VALUES (?, ?, 0, 1, NOW(), NOW())",
+		spaceID, botID,
+	).Exec()
+	require.NoError(t, err)
+}
+
+func userAPIRequest(t *testing.T, method, path, token string, body interface{}) *http.Request {
+	t.Helper()
+	var r io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		r = bytes.NewReader(b)
+	}
+	req := httptest.NewRequest(method, path, r)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+// errEnvelope mirrors the httperr i18n envelope shape we assert on.
+type errEnvelope struct {
+	Error struct {
+		Code       string         `json:"code"`
+		HTTPStatus int            `json:"http_status"`
+		Details    map[string]any `json:"details"`
+	} `json:"error"`
+}
+
+func TestListUserBots_NoTokenLeak_WithOccupancy(t *testing.T) {
+	route, ctx := newUserAPITestServer(t)
+	db := newBotfatherDB(ctx)
+
+	uid := "u_" + util.GenerUUID()[:8]
+	insertTestUser(t, ctx, uid, "owner")
+	token := mintUserAPIKey(t, ctx, uid)
+
+	freeBot := "free_" + util.GenerUUID()[:8]
+	busyBot := "busy_" + util.GenerUUID()[:8]
+	insertTestBot(t, ctx, freeBot, uid)
+	insertTestBot(t, ctx, busyBot, uid)
+
+	// Occupy busyBot through the CAS path.
+	affected, err := db.bindRobotCAS(busyBot, uid, "octopush:agent_1")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), affected)
+
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, userAPIRequest(t, http.MethodGet, "/v1/user/bots", token, nil))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// Decode into raw maps so we can prove bot_token is present (contract kept)
+	// but empty (no bf_ leaked).
+	var raw []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
+	require.Len(t, raw, 2)
+
+	byID := map[string]map[string]any{}
+	for _, item := range raw {
+		tok, hasToken := item["bot_token"]
+		assert.True(t, hasToken, "bot_token field must be retained for backward compat: %v", item)
+		assert.Equal(t, "", tok, "listUserBots must not leak a real bf_ token: %v", item)
+		byID[item["robot_id"].(string)] = item
+	}
+
+	assert.Equal(t, "", byID[freeBot]["bound_agent_ref"], "free bot must report empty bound_agent_ref")
+	assert.Equal(t, "octopush:agent_1", byID[busyBot]["bound_agent_ref"])
+}
+
+func TestBindUserBot_Lifecycle(t *testing.T) {
+	route, ctx := newUserAPITestServer(t)
+
+	uid := "u_" + util.GenerUUID()[:8]
+	insertTestUser(t, ctx, uid, "owner")
+	token := mintUserAPIKey(t, ctx, uid)
+
+	botID := "bot_" + util.GenerUUID()[:8]
+	insertTestBot(t, ctx, botID, uid)
+	path := fmt.Sprintf("/v1/user/bots/%s/bind", botID)
+
+	// 1) First bind succeeds.
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, userAPIRequest(t, http.MethodPost, path, token, BindBotReq{AgentRef: "octopush:agent_A"}))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var resp BindBotResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, botID, resp.RobotID)
+	assert.Equal(t, "octopush:agent_A", resp.BoundAgentRef)
+	assert.NotEmpty(t, resp.BoundAt)
+
+	// 2) Re-bind with the SAME agent_ref is idempotent (200).
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, userAPIRequest(t, http.MethodPost, path, token, BindBotReq{AgentRef: "octopush:agent_A"}))
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// 3) Bind with a DIFFERENT agent_ref is rejected 409 + occupied_by.
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, userAPIRequest(t, http.MethodPost, path, token, BindBotReq{AgentRef: "octopush:agent_B"}))
+	require.Equal(t, http.StatusConflict, w.Code, w.Body.String())
+	var env errEnvelope
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, "err.server.bot.occupied", env.Error.Code)
+	assert.Equal(t, http.StatusConflict, env.Error.HTTPStatus)
+	assert.Equal(t, "octopush:agent_A", env.Error.Details["occupied_by"])
+
+	// 4) Unbind by the owning agent releases the occupation (idempotent).
+	// Response carries the documented shape: bound_agent_ref="" and
+	// bound_at=null (docs §6).
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, userAPIRequest(t, http.MethodDelete, path, token, BindBotReq{AgentRef: "octopush:agent_A"}))
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var unbindBody map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &unbindBody))
+	assert.Equal(t, "", unbindBody["bound_agent_ref"])
+	if v, ok := unbindBody["bound_at"]; !ok || v != nil {
+		t.Fatalf("unbind response bound_at = %v (present=%v), want explicit null", v, ok)
+	}
+
+	// 5) After release a new agent can occupy it.
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, userAPIRequest(t, http.MethodPost, path, token, BindBotReq{AgentRef: "octopush:agent_B"}))
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+// Unbind must prove agent ownership: a different agent_ref (sharing the same
+// user's uk_) cannot release another agent's binding — otherwise the
+// single-holder mutual-exclusion contract is bypassable via unbind-then-bind.
+func TestUnbindUserBot_OwnershipEnforced(t *testing.T) {
+	route, ctx := newUserAPITestServer(t)
+
+	uid := "u_" + util.GenerUUID()[:8]
+	insertTestUser(t, ctx, uid, "owner")
+	token := mintUserAPIKey(t, ctx, uid)
+	botID := "bot_" + util.GenerUUID()[:8]
+	insertTestBot(t, ctx, botID, uid)
+	path := fmt.Sprintf("/v1/user/bots/%s/bind", botID)
+
+	// Agent A occupies the bot.
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, userAPIRequest(t, http.MethodPost, path, token, BindBotReq{AgentRef: "octopush:agent_A"}))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// Missing agent_ref on unbind → 400 (cannot release without identifying self).
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, userAPIRequest(t, http.MethodDelete, path, token, BindBotReq{AgentRef: "  "}))
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+
+	// Agent B (same user's uk_, different agent_ref) cannot release A's binding.
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, userAPIRequest(t, http.MethodDelete, path, token, BindBotReq{AgentRef: "octopush:agent_B"}))
+	require.Equal(t, http.StatusConflict, w.Code, w.Body.String())
+	var env errEnvelope
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, "err.server.bot.occupied", env.Error.Code)
+	assert.Equal(t, "octopush:agent_A", env.Error.Details["occupied_by"])
+
+	// Bot is still occupied by A — B cannot bind it either.
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, userAPIRequest(t, http.MethodPost, path, token, BindBotReq{AgentRef: "octopush:agent_B"}))
+	require.Equal(t, http.StatusConflict, w.Code, w.Body.String())
+
+	// Owner A releases successfully.
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, userAPIRequest(t, http.MethodDelete, path, token, BindBotReq{AgentRef: "octopush:agent_A"}))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// Idempotent: A releasing an already-free bot still succeeds.
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, userAPIRequest(t, http.MethodDelete, path, token, BindBotReq{AgentRef: "octopush:agent_A"}))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// Now that it's free, B can occupy it.
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, userAPIRequest(t, http.MethodPost, path, token, BindBotReq{AgentRef: "octopush:agent_B"}))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+func TestBindUserBot_MissingAgentRef(t *testing.T) {
+	route, ctx := newUserAPITestServer(t)
+
+	uid := "u_" + util.GenerUUID()[:8]
+	insertTestUser(t, ctx, uid, "owner")
+	token := mintUserAPIKey(t, ctx, uid)
+	botID := "bot_" + util.GenerUUID()[:8]
+	insertTestBot(t, ctx, botID, uid)
+
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, userAPIRequest(t, http.MethodPost, fmt.Sprintf("/v1/user/bots/%s/bind", botID), token, BindBotReq{AgentRef: "   "}))
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	var env errEnvelope
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, "err.shared.param.invalid", env.Error.Code)
+}
+
+func TestBindUserBot_NonCreatorNotFound(t *testing.T) {
+	route, ctx := newUserAPITestServer(t)
+
+	owner := "u_" + util.GenerUUID()[:8]
+	other := "u_" + util.GenerUUID()[:8]
+	insertTestUser(t, ctx, owner, "owner")
+	insertTestUser(t, ctx, other, "other")
+	otherToken := mintUserAPIKey(t, ctx, other)
+
+	botID := "bot_" + util.GenerUUID()[:8]
+	insertTestBot(t, ctx, botID, owner) // owned by `owner`
+
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, userAPIRequest(t, http.MethodPost, fmt.Sprintf("/v1/user/bots/%s/bind", botID), otherToken, BindBotReq{AgentRef: "octopush:x"}))
+	require.Equal(t, http.StatusNotFound, w.Code, w.Body.String())
+	var env errEnvelope
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, "err.shared.not_found", env.Error.Code)
+}
+
+// Space isolation: a space-bound uk_ may bind a bot that belongs to that
+// space, but a same-creator bot OUTSIDE the space is rejected 403 — exercising
+// the spaceID != "" branch that the no-space tests skip.
+func TestBindUserBot_SpaceIsolation(t *testing.T) {
+	route, ctx := newUserAPITestServer(t)
+
+	uid := "u_" + util.GenerUUID()[:8]
+	spaceID := "s_" + util.GenerUUID()[:8]
+	insertTestUser(t, ctx, uid, "owner")
+	token := mintUserAPIKeyInSpace(t, ctx, uid, spaceID)
+
+	botIn := "in_" + util.GenerUUID()[:8]
+	botOut := "out_" + util.GenerUUID()[:8]
+	insertTestBot(t, ctx, botIn, uid)
+	insertTestBot(t, ctx, botOut, uid)
+	addBotToSpace(t, ctx, spaceID, botIn) // only botIn joins the space
+
+	// In-space bot: bind succeeds.
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, userAPIRequest(t, http.MethodPost, fmt.Sprintf("/v1/user/bots/%s/bind", botIn), token, BindBotReq{AgentRef: "octopush:a"}))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// Out-of-space bot (same creator): bind rejected 403.
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, userAPIRequest(t, http.MethodPost, fmt.Sprintf("/v1/user/bots/%s/bind", botOut), token, BindBotReq{AgentRef: "octopush:a"}))
+	require.Equal(t, http.StatusForbidden, w.Code, w.Body.String())
+	var env errEnvelope
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, "err.shared.auth.forbidden", env.Error.Code)
+
+	// Out-of-space bot: unbind also rejected 403.
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, userAPIRequest(t, http.MethodDelete, fmt.Sprintf("/v1/user/bots/%s/bind", botOut), token, BindBotReq{AgentRef: "octopush:a"}))
+	require.Equal(t, http.StatusForbidden, w.Code, w.Body.String())
+}
+
+// Concurrent binds on the same free bot: exactly one wins, the rest get 409.
+func TestBindUserBot_ConcurrentMutualExclusion(t *testing.T) {
+	route, ctx := newUserAPITestServer(t)
+
+	uid := "u_" + util.GenerUUID()[:8]
+	insertTestUser(t, ctx, uid, "owner")
+	token := mintUserAPIKey(t, ctx, uid)
+	botID := "bot_" + util.GenerUUID()[:8]
+	insertTestBot(t, ctx, botID, uid)
+	path := fmt.Sprintf("/v1/user/bots/%s/bind", botID)
+
+	const n = 8
+	var success, conflict int32
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			w := httptest.NewRecorder()
+			route.ServeHTTP(w, userAPIRequest(t, http.MethodPost, path, token, BindBotReq{AgentRef: fmt.Sprintf("octopush:agent_%d", i)}))
+			switch w.Code {
+			case http.StatusOK:
+				atomic.AddInt32(&success, 1)
+			case http.StatusConflict:
+				atomic.AddInt32(&conflict, 1)
+			default:
+				t.Errorf("unexpected status %d: %s", w.Code, w.Body.String())
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), success, "exactly one concurrent bind must win")
+	assert.Equal(t, int32(n-1), conflict, "all other concurrent binds must get 409")
+}

--- a/modules/botfather/command.go
+++ b/modules/botfather/command.go
@@ -20,24 +20,26 @@ import (
 
 // commandHandler 处理BotFather命令
 type commandHandler struct {
-	ctx          *config.Context
-	db           *botfatherDB
-	sm           *stateMachine
-	userService  user.IService
-	groupService group.IService
-	appService   app.IService
+	ctx           *config.Context
+	db            *botfatherDB
+	sm            *stateMachine
+	userService   user.IService
+	groupService  group.IService
+	appService    app.IService
+	apiKeyService UserAPIKeyService
 	log.Log
 }
 
 func newCommandHandler(ctx *config.Context) *commandHandler {
 	return &commandHandler{
-		ctx:          ctx,
-		db:           newBotfatherDB(ctx),
-		sm:           newStateMachine(ctx),
-		userService:  user.NewService(ctx),
-		groupService: group.NewService(ctx),
-		appService:   app.NewService(ctx),
-		Log:          log.NewTLog("BotFather"),
+		ctx:           ctx,
+		db:            newBotfatherDB(ctx),
+		sm:            newStateMachine(ctx),
+		userService:   user.NewService(ctx),
+		groupService:  group.NewService(ctx),
+		appService:    app.NewService(ctx),
+		apiKeyService: NewUserAPIKeyService(ctx),
+		Log:           log.NewTLog("BotFather"),
 	}
 }
 
@@ -411,56 +413,14 @@ func (h *commandHandler) handleQuickstart(fromUID string) {
 	// 获取当前 Space ID，绑定到 API Key
 	spaceID := h.resolveSpaceID(fromUID)
 
-	// 获取或创建 User API Key（每个 Space 独立一把 Key）
-	var apiKey string
-	if spaceID != "" {
-		// 优先查当前 Space 是否已有 Key
-		existing, err := h.db.queryUserAPIKeyByUIDAndSpaceID(realUID, spaceID)
-		if err != nil {
-			h.Error("查询User API Key失败", zap.Error(err))
-			h.reply(fromUID, "操作失败，请稍后重试。")
-			return
-		}
-		if existing != nil {
-			apiKey = existing.APIKey
-		} else {
-			apiKey, err = generateUserAPIKey()
-			if err != nil {
-				h.Error("生成User API Key失败", zap.Error(err))
-				h.reply(fromUID, "操作失败，请稍后重试。")
-				return
-			}
-			err = h.db.insertUserAPIKey(realUID, apiKey, spaceID)
-			if err != nil {
-				h.Error("保存User API Key失败", zap.Error(err))
-				h.reply(fromUID, "操作失败，请稍后重试。")
-				return
-			}
-		}
-	} else {
-		// 无 Space 场景：回退到按 UID 查询（兼容旧数据）
-		existing, err := h.db.queryUserAPIKeyByUID(realUID)
-		if err != nil {
-			h.Error("查询User API Key失败", zap.Error(err))
-			h.reply(fromUID, "操作失败，请稍后重试。")
-			return
-		}
-		if existing != nil {
-			apiKey = existing.APIKey
-		} else {
-			apiKey, err = generateUserAPIKey()
-			if err != nil {
-				h.Error("生成User API Key失败", zap.Error(err))
-				h.reply(fromUID, "操作失败，请稍后重试。")
-				return
-			}
-			err = h.db.insertUserAPIKey(realUID, apiKey, "")
-			if err != nil {
-				h.Error("保存User API Key失败", zap.Error(err))
-				h.reply(fromUID, "操作失败，请稍后重试。")
-				return
-			}
-		}
+	// 获取或创建 User API Key（每个 (uid, space, client) 独立一把 Key）。
+	// botfather 自身的 client 维度恒为 clientIDBotFather；spaceID="" 的无 Space
+	// 场景由 GetOrCreate 内部按 space_id='' 自然处理（兼容旧数据）。
+	apiKey, err := h.apiKeyService.GetOrCreate(realUID, spaceID, clientIDBotFather)
+	if err != nil {
+		h.Error("获取User API Key失败", zap.Error(err))
+		h.reply(fromUID, "操作失败，请稍后重试。")
+		return
 	}
 
 	cfg := h.ctx.GetConfig()

--- a/modules/botfather/db.go
+++ b/modules/botfather/db.go
@@ -37,6 +37,11 @@ type robotModel struct {
 	AgentPlatform string // AI Agent 平台名称（如 OpenClaw）
 	AgentVersion  string // Agent 平台版本号
 	PluginVersion string // Octo 插件版本号
+	// BoundAgentRef 占用方不透明标签（如 octopush:agent_xxx）；空=空闲。
+	BoundAgentRef string
+	// BoundAt 占用时间；timestamp NULL，未占用时无效。用 NullTime 承接 NULL，
+	// 否则 Select("*") 把 NULL bound_at 扫进 string 会报错，殃及所有 robot 查询。
+	BoundAt dbr.NullTime
 	db.BaseModel
 }
 
@@ -181,34 +186,36 @@ func (d *botfatherDB) queryAllActiveRobots() ([]*robotModel, error) {
 
 // ========== User API Key ==========
 
-// queryUserAPIKeyByKey 通过API Key查询
-func (d *botfatherDB) queryUserAPIKeyByKey(apiKey string) (*userAPIKeyModel, error) {
+// queryActiveUserAPIKeyByKey 通过明文 API Key 查询 active（status=1）记录（鉴权链路）。
+// 当前 PR 无生产路径把 key 置为 revoked（status=0）；status=1 过滤是为 PR2 的撤销
+// 能力预留的前瞻防御，届时被撤销的 key 在此即时失效。存量行经迁移 DEFAULT 1 回填，
+// 行为不变。
+func (d *botfatherDB) queryActiveUserAPIKeyByKey(apiKey string) (*userAPIKeyModel, error) {
 	if apiKey == "" {
 		return nil, nil
 	}
 	var m *userAPIKeyModel
-	_, err := d.session.Select("*").From("user_api_key").Where("api_key=?", apiKey).Load(&m)
+	_, err := d.session.Select("*").From("user_api_key").
+		Where("api_key=? AND status=?", apiKey, userAPIKeyStatusActive).Load(&m)
 	return m, err
 }
 
-// queryUserAPIKeyByUID 查询用户的无 Space 绑定的 API Key（legacy 回退）
-func (d *botfatherDB) queryUserAPIKeyByUID(uid string) (*userAPIKeyModel, error) {
+// queryActiveUserAPIKey 按 (uid, space_id, client_id) 三元组查询未撤销的 key。
+// spaceID="" 对应无 Space 绑定的 legacy 行（client_id 由迁移 DEFAULT 回填）。
+func (d *botfatherDB) queryActiveUserAPIKey(uid, spaceID, clientID string) (*userAPIKeyModel, error) {
 	var m *userAPIKeyModel
-	_, err := d.session.Select("*").From("user_api_key").Where("uid=? AND space_id=''", uid).Load(&m)
+	_, err := d.session.Select("*").From("user_api_key").
+		Where("uid=? AND space_id=? AND client_id=? AND status=?", uid, spaceID, clientID, userAPIKeyStatusActive).
+		Load(&m)
 	return m, err
 }
 
-// insertUserAPIKey 插入用户API Key（含绑定的Space ID）
-func (d *botfatherDB) insertUserAPIKey(uid, apiKey, spaceID string) error {
-	_, err := d.session.InsertInto("user_api_key").Columns("uid", "api_key", "space_id").Values(uid, apiKey, spaceID).Exec()
+// insertUserAPIKey 插入用户API Key（含绑定的 Space ID 与 client_id 维度）。
+func (d *botfatherDB) insertUserAPIKey(uid, apiKey, spaceID, clientID string) error {
+	_, err := d.session.InsertInto("user_api_key").
+		Columns("uid", "api_key", "space_id", "client_id").
+		Values(uid, apiKey, spaceID, clientID).Exec()
 	return err
-}
-
-// queryUserAPIKeyByUIDAndSpaceID 查询用户在指定Space下的API Key
-func (d *botfatherDB) queryUserAPIKeyByUIDAndSpaceID(uid, spaceID string) (*userAPIKeyModel, error) {
-	var m *userAPIKeyModel
-	_, err := d.session.Select("*").From("user_api_key").Where("uid=? AND space_id=?", uid, spaceID).Load(&m)
-	return m, err
 }
 
 // querySpaceNameByID 查询Space名称
@@ -263,4 +270,46 @@ func (d *botfatherDB) querySpaceIDByRobotID(robotID string) (string, error) {
 		robotID,
 	).LoadOne(&spaceID)
 	return spaceID, err
+}
+
+// ========== Bot 占用 / 绑定 ==========
+
+// bindRobotCAS 行级 CAS 占用 Bot：仅当 Bot 空闲（bound_agent_ref='')或已被
+// 同一 agentRef 占用（幂等）时才写入。返回受影响行数：1=占用成功，0=未命中
+// （不存在 / 非本 creator / 已被他人占用），由调用方复查区分。
+//
+// 互斥完全由这条 UPDATE 的 WHERE 在 DB 层保证，无需额外锁——多个 Agent 并发抢
+// 同一空闲 Bot 时只有一条能把 bound_agent_ref 从 '' 改走，其余 affected=0。
+func (d *botfatherDB) bindRobotCAS(robotID, creatorUID, agentRef string) (int64, error) {
+	res, err := d.session.UpdateBySql(
+		"UPDATE robot SET bound_agent_ref=?, bound_at=NOW() "+
+			"WHERE robot_id=? AND creator_uid=? AND status=1 "+
+			"AND (bound_agent_ref='' OR bound_agent_ref=?)",
+		agentRef, robotID, creatorUID, agentRef,
+	).Exec()
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// unbindRobotCAS 行级 CAS 释放占用：仅当 Bot 已空闲（幂等）或当前占用方正是
+// agentRef 时才清空。返回受影响行数；affected=0 时由调用方复查区分「已空闲（幂等
+// 成功）」「被他人占用（拒绝）」「不存在 / 非本 creator」。
+//
+// 归属校验是互斥不变量的关键一环：uk_ 按 (uid, space, client) 维度，同一用户同一
+// client 的所有 Agent 共享一把 key，若释放不校验 agent_ref，Agent B 就能用同一把
+// key 把 Agent A 的占用清掉再自占——绕过 bind 的抢占互斥。故释放与占用对称地用
+// agent_ref 做 CAS。
+func (d *botfatherDB) unbindRobotCAS(robotID, creatorUID, agentRef string) (int64, error) {
+	res, err := d.session.UpdateBySql(
+		"UPDATE robot SET bound_agent_ref='', bound_at=NULL "+
+			"WHERE robot_id=? AND creator_uid=? AND status=1 "+
+			"AND (bound_agent_ref='' OR bound_agent_ref=?)",
+		robotID, creatorUID, agentRef,
+	).Exec()
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
 }

--- a/modules/botfather/model.go
+++ b/modules/botfather/model.go
@@ -110,6 +110,8 @@ type userAPIKeyModel struct {
 	UID       string `json:"uid"`
 	APIKey    string `json:"api_key"`
 	SpaceID   string `json:"space_id"`
+	ClientID  string `json:"client_id"`
+	Status    int    `json:"status"`
 	CreatedAt string `json:"created_at"`
 }
 
@@ -137,15 +139,38 @@ type UpdateBotReq struct {
 	Description *string `json:"description"`
 }
 
-// UserBotResp 用户Bot列表项
+// UserBotResp 用户Bot列表项。
+//
+// 安全：列表不批量回填 `bf_` 凭证。为不破坏既有响应契约，保留 bot_token 字段
+// 但**恒为空串**——老客户端读字段不会拿到 undefined，但拿不到真实 token；需要
+// 某个 Bot 的 token 时单独调 GET /v1/user/bots/:bot_id/token。
 type UserBotResp struct {
-	RobotID       string `json:"robot_id"`
-	Username      string `json:"username"`
-	Name          string `json:"name"`
-	Description   string `json:"description"`
-	BotToken      string `json:"bot_token"`
-	CreatedAt     string `json:"created_at"`
-	AgentPlatform string `json:"agent_platform,omitempty"`
+	RobotID     string `json:"robot_id"`
+	Username    string `json:"username"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	// BotToken 出于安全在列表里恒为空串（不批量泄露 `bf_`）；取 token 走单端点。
+	BotToken    string `json:"bot_token"`
+	CreatedAt   string `json:"created_at"`
+	// BoundAgentRef 占用方不透明标签（如 octopush:agent_xxx）；空=空闲。
+	BoundAgentRef string `json:"bound_agent_ref"`
+	// BoundAt 占用时间（timeFormart）；未占用时为 null（*string，与 doc 的
+	// string|null 及 unbind 的显式 null 对齐——不用 omitempty 省略字段）。
+	BoundAt       *string `json:"bound_at"`
+	AgentPlatform string  `json:"agent_platform,omitempty"`
 	AgentVersion  string `json:"agent_version,omitempty"`
 	PluginVersion string `json:"plugin_version,omitempty"`
+}
+
+// BindBotReq 占用（绑定）Bot 请求。
+type BindBotReq struct {
+	// AgentRef 占用方不透明标签（如 octopush:agent_xxx）。Octo 不解析其语义。
+	AgentRef string `json:"agent_ref"`
+}
+
+// BindBotResp 占用（绑定）Bot 响应。
+type BindBotResp struct {
+	RobotID       string `json:"robot_id"`
+	BoundAgentRef string `json:"bound_agent_ref"`
+	BoundAt       string `json:"bound_at"`
 }

--- a/modules/botfather/service_userapikey.go
+++ b/modules/botfather/service_userapikey.go
@@ -1,0 +1,126 @@
+package botfather
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+)
+
+// clientIDBotFather labels `uk_` keys minted by botfather's own /quickstart
+// flow. The integration (Octo-link) module passes other client_id labels
+// (e.g. the external application id) into the same service, so every `uk_` is
+// organised along the (uid, space_id, client_id) dimension.
+const clientIDBotFather = "botfather"
+
+// user_api_key.status values.
+const (
+	userAPIKeyStatusRevoked = 0
+	userAPIKeyStatusActive  = 1
+)
+
+// UserAPIKey is the resolved, active `uk_` record exposed to callers. It
+// deliberately omits storage-only columns (hash/cipher placeholders, audit
+// fields) so consumers only see what they need.
+type UserAPIKey struct {
+	ID       int64
+	UID      string
+	SpaceID  string
+	ClientID string
+	APIKey   string
+}
+
+// UserAPIKeyService owns the get-or-create and authenticate semantics for
+// `uk_` user API keys. botfather (/quickstart) and the integration module
+// (OIDC exchange) share one implementation so both stay consistent on the
+// (uid, space_id, client_id) dimension and the plaintext-echo idempotency
+// contract.
+type UserAPIKeyService interface {
+	// GetOrCreate returns the active plaintext `uk_` for (uid, spaceID,
+	// clientID), creating one when none exists. Repeated calls return the
+	// same key (idempotent plaintext echo). A blank clientID defaults to
+	// the botfather client.
+	GetOrCreate(uid, spaceID, clientID string) (string, error)
+	// AuthByKey resolves an active key by its plaintext value. It returns
+	// (nil, nil) when the key is unknown or revoked.
+	AuthByKey(plaintext string) (*UserAPIKey, error)
+}
+
+type userAPIKeyService struct {
+	db *botfatherDB
+	log.Log
+}
+
+// NewUserAPIKeyService builds a UserAPIKeyService. botfather uses it for
+// /quickstart; the integration module uses it to mint `uk_` for external
+// clients.
+func NewUserAPIKeyService(ctx *config.Context) UserAPIKeyService {
+	return &userAPIKeyService{
+		db:  newBotfatherDB(ctx),
+		Log: log.NewTLog("UserAPIKeyService"),
+	}
+}
+
+func (s *userAPIKeyService) GetOrCreate(uid, spaceID, clientID string) (string, error) {
+	if strings.TrimSpace(clientID) == "" {
+		clientID = clientIDBotFather
+	}
+
+	existing, err := s.db.queryActiveUserAPIKey(uid, spaceID, clientID)
+	if err != nil {
+		return "", fmt.Errorf("query user api key: %w", err)
+	}
+	if existing != nil {
+		return existing.APIKey, nil
+	}
+
+	apiKey, err := generateUserAPIKey()
+	if err != nil {
+		return "", fmt.Errorf("generate user api key: %w", err)
+	}
+
+	if err := s.db.insertUserAPIKey(uid, apiKey, spaceID, clientID); err != nil {
+		// Only a duplicate-key collision (a concurrent caller inserted the
+		// same uk_uid_space_client triple first) is safe to recover by
+		// echoing the winning row — that preserves the idempotency
+		// contract. Any other insert failure (connection lost, unrelated
+		// constraint) must surface, not be masked by a stale re-read.
+		if isDuplicateKeyErr(err) {
+			again, reErr := s.db.queryActiveUserAPIKey(uid, spaceID, clientID)
+			if reErr == nil && again != nil {
+				return again.APIKey, nil
+			}
+		}
+		return "", fmt.Errorf("insert user api key: %w", err)
+	}
+	return apiKey, nil
+}
+
+// isDuplicateKeyErr reports whether err is a MySQL duplicate-key violation
+// (error 1062). Matched by substring to avoid coupling this package to a
+// specific driver error type; the message is stable across go-sql-driver and
+// dbr-wrapped errors.
+func isDuplicateKeyErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "Duplicate entry") || strings.Contains(err.Error(), "1062")
+}
+
+func (s *userAPIKeyService) AuthByKey(plaintext string) (*UserAPIKey, error) {
+	m, err := s.db.queryActiveUserAPIKeyByKey(plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("query user api key by key: %w", err)
+	}
+	if m == nil {
+		return nil, nil
+	}
+	return &UserAPIKey{
+		ID:       m.ID,
+		UID:      m.UID,
+		SpaceID:  m.SpaceID,
+		ClientID: m.ClientID,
+		APIKey:   m.APIKey,
+	}, nil
+}

--- a/modules/botfather/service_userapikey_test.go
+++ b/modules/botfather/service_userapikey_test.go
@@ -1,0 +1,171 @@
+package botfather
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/Mininglamp-OSS/octo-server/modules/space"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/user"
+)
+
+func setupAPIKeyServiceTest(t *testing.T) (*config.Context, UserAPIKeyService) {
+	_, ctx := testutil.NewTestServer()
+	return ctx, NewUserAPIKeyService(ctx)
+}
+
+// countUserAPIKeys returns how many rows exist for (uid, space, client),
+// regardless of status — used to prove GetOrCreate does not duplicate.
+func countUserAPIKeys(t *testing.T, ctx *config.Context, uid, spaceID, clientID string) int {
+	var n int
+	err := ctx.DB().SelectBySql(
+		"SELECT COUNT(*) FROM user_api_key WHERE uid=? AND space_id=? AND client_id=?",
+		uid, spaceID, clientID,
+	).LoadOne(&n)
+	require.NoError(t, err)
+	return n
+}
+
+func TestUserAPIKeyService_GetOrCreate_Idempotent(t *testing.T) {
+	ctx, svc := setupAPIKeyServiceTest(t)
+	uid := "u_" + util.GenerUUID()[:8]
+	spaceID := "s_" + util.GenerUUID()[:8]
+
+	first, err := svc.GetOrCreate(uid, spaceID, clientIDBotFather)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(first, UserAPIKeyPrefix), "key should carry uk_ prefix, got %q", first)
+
+	second, err := svc.GetOrCreate(uid, spaceID, clientIDBotFather)
+	require.NoError(t, err)
+	assert.Equal(t, first, second, "repeated GetOrCreate must echo the same plaintext key")
+	assert.Equal(t, 1, countUserAPIKeys(t, ctx, uid, spaceID, clientIDBotFather), "must not create a duplicate row")
+}
+
+func TestUserAPIKeyService_GetOrCreate_DistinctPerClient(t *testing.T) {
+	_, svc := setupAPIKeyServiceTest(t)
+	uid := "u_" + util.GenerUUID()[:8]
+	spaceID := "s_" + util.GenerUUID()[:8]
+
+	bf, err := svc.GetOrCreate(uid, spaceID, clientIDBotFather)
+	require.NoError(t, err)
+	octopush, err := svc.GetOrCreate(uid, spaceID, "octopush")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, bf, octopush, "different client_id under same uid+space must get distinct keys")
+}
+
+// GetOrCreate with a blank clientID must default to the botfather client, so
+// it shares the same key the /quickstart flow produces.
+func TestUserAPIKeyService_GetOrCreate_BlankClientDefaultsBotFather(t *testing.T) {
+	_, svc := setupAPIKeyServiceTest(t)
+	uid := "u_" + util.GenerUUID()[:8]
+	spaceID := "s_" + util.GenerUUID()[:8]
+
+	blank, err := svc.GetOrCreate(uid, spaceID, "")
+	require.NoError(t, err)
+	explicit, err := svc.GetOrCreate(uid, spaceID, clientIDBotFather)
+	require.NoError(t, err)
+	assert.Equal(t, blank, explicit)
+}
+
+// Empty spaceID maps to the legacy no-space row and is still idempotent.
+func TestUserAPIKeyService_GetOrCreate_EmptySpace(t *testing.T) {
+	ctx, svc := setupAPIKeyServiceTest(t)
+	uid := "u_" + util.GenerUUID()[:8]
+
+	first, err := svc.GetOrCreate(uid, "", clientIDBotFather)
+	require.NoError(t, err)
+	second, err := svc.GetOrCreate(uid, "", clientIDBotFather)
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+	assert.Equal(t, 1, countUserAPIKeys(t, ctx, uid, "", clientIDBotFather))
+}
+
+// Concurrent GetOrCreate on the same (uid, space, client): the unique key
+// forces all-but-one INSERT to collide, and the duplicate-key fallback must
+// re-read the winning row — so every caller returns the SAME plaintext key and
+// exactly one row exists. This exercises the H2 fallback path deterministically.
+func TestUserAPIKeyService_GetOrCreate_ConcurrentNoDuplicate(t *testing.T) {
+	ctx, svc := setupAPIKeyServiceTest(t)
+	uid := "u_" + util.GenerUUID()[:8]
+	spaceID := "s_" + util.GenerUUID()[:8]
+
+	const n = 8
+	keys := make([]string, n)
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			keys[i], errs[i] = svc.GetOrCreate(uid, spaceID, "octopush")
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i := 0; i < n; i++ {
+		require.NoError(t, errs[i], "concurrent GetOrCreate #%d", i)
+		assert.Equal(t, keys[0], keys[i], "all concurrent callers must converge on one key")
+	}
+	assert.Equal(t, 1, countUserAPIKeys(t, ctx, uid, spaceID, "octopush"), "concurrent create must not duplicate rows")
+}
+
+func TestIsDuplicateKeyErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"duplicate entry message", errors.New("Error 1062: Duplicate entry 'u1-s1-octopush' for key 'uk_uid_space_client'"), true},
+		{"bare 1062", errors.New("mysql: 1062 duplicate"), true},
+		{"unrelated error", errors.New("connection refused"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isDuplicateKeyErr(tc.err))
+		})
+	}
+}
+
+func TestUserAPIKeyService_AuthByKey(t *testing.T) {
+	ctx, svc := setupAPIKeyServiceTest(t)
+	uid := "u_" + util.GenerUUID()[:8]
+	spaceID := "s_" + util.GenerUUID()[:8]
+
+	key, err := svc.GetOrCreate(uid, spaceID, "octopush")
+	require.NoError(t, err)
+
+	got, err := svc.AuthByKey(key)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, uid, got.UID)
+	assert.Equal(t, spaceID, got.SpaceID)
+	assert.Equal(t, "octopush", got.ClientID)
+	assert.Equal(t, key, got.APIKey)
+
+	// Unknown key resolves to (nil, nil).
+	unknown, err := svc.AuthByKey("uk_does_not_exist")
+	require.NoError(t, err)
+	assert.Nil(t, unknown)
+
+	// Revoked key (status=0) must fail auth.
+	_, err = ctx.DB().UpdateBySql(
+		"UPDATE user_api_key SET status=? WHERE api_key=?", userAPIKeyStatusRevoked, key,
+	).Exec()
+	require.NoError(t, err)
+
+	revoked, err := svc.AuthByKey(key)
+	require.NoError(t, err)
+	assert.Nil(t, revoked, "revoked key must not authenticate")
+}

--- a/modules/botfather/sql/20260603000001_botfather_legacy01.sql
+++ b/modules/botfather/sql/20260603000001_botfather_legacy01.sql
@@ -1,0 +1,37 @@
+-- +migrate Up
+-- 扩展 user_api_key 支持 integration client 维度、撤销状态与使用审计。
+-- client_id 默认 'botfather'：存量行自动回填，botfather 现有不带 client_id 的
+-- insert/query 经 DEFAULT 兜底无感不回归。
+-- api_key_hash / api_key_cipher 本期预留留空（后续 hash 化加固用）。
+ALTER TABLE `user_api_key`
+  ADD COLUMN `client_id` varchar(100) NOT NULL DEFAULT 'botfather' COMMENT '外部应用ID；botfather 自身为 botfather' AFTER `space_id`,
+  ADD COLUMN `status` tinyint(4) NOT NULL DEFAULT 1 COMMENT '1=active 0=revoked' AFTER `client_id`,
+  ADD COLUMN `api_key_hash` varchar(64) NOT NULL DEFAULT '' COMMENT '预留：uk_ 明文 SHA-256 hex（鉴权查询用）',
+  ADD COLUMN `api_key_cipher` varchar(255) NOT NULL DEFAULT '' COMMENT '预留：uk_ 明文密文（回显用）',
+  ADD COLUMN `last_used_at` timestamp NULL DEFAULT NULL COMMENT '最近使用时间',
+  ADD COLUMN `last_used_ip` varchar(64) NOT NULL DEFAULT '' COMMENT '最近使用IP',
+  ADD COLUMN `last_used_user_agent` varchar(255) NOT NULL DEFAULT '' COMMENT '最近调用方UA',
+  ADD COLUMN `revoked_at` timestamp NULL DEFAULT NULL COMMENT '撤销时间';
+
+-- 唯一键 (uid, space_id) -> (uid, space_id, client_id)。存量 client_id 均为
+-- 'botfather'，改键安全；否则同一 uid+space 下为不同 client 插第二把 key 会撞旧约束。
+ALTER TABLE `user_api_key` DROP INDEX `uk_uid_space`;
+ALTER TABLE `user_api_key` ADD UNIQUE KEY `uk_uid_space_client` (`uid`, `space_id`, `client_id`);
+
+-- +migrate Down
+ALTER TABLE `user_api_key` DROP INDEX `uk_uid_space_client`;
+-- 回滚到 (uid, space_id) 唯一键前，先清掉本特性引入的非 botfather client 行：
+-- 一旦特性被使用过，同一 uid+space 下可能存在多个 client 的 key，直接重建旧唯一键
+-- 会因重复 (uid, space_id) 撞键失败。删除这些行后 botfather 自有行在 (uid, space_id)
+-- 上仍唯一（旧唯一键时代即如此），重建安全。回滚即移除本特性，删其数据符合语义。
+DELETE FROM `user_api_key` WHERE `client_id` <> 'botfather';
+ALTER TABLE `user_api_key` ADD UNIQUE KEY `uk_uid_space` (`uid`, `space_id`);
+ALTER TABLE `user_api_key`
+  DROP COLUMN `revoked_at`,
+  DROP COLUMN `last_used_user_agent`,
+  DROP COLUMN `last_used_ip`,
+  DROP COLUMN `last_used_at`,
+  DROP COLUMN `api_key_cipher`,
+  DROP COLUMN `api_key_hash`,
+  DROP COLUMN `status`,
+  DROP COLUMN `client_id`;

--- a/modules/botfather/sql/20260603000002_botfather_legacy01.sql
+++ b/modules/botfather/sql/20260603000002_botfather_legacy01.sql
@@ -1,0 +1,12 @@
+-- +migrate Up
+-- robot 占用/绑定字段（PM Octo-link：一个 Bot 同时只被一个 Agent 占用）。
+-- bound_agent_ref 为不透明标签（如 octopush:agent_xxx），空=空闲；占用互斥由
+-- bind 接口的行级 CAS 保证，无需额外索引。
+ALTER TABLE `robot`
+  ADD COLUMN `bound_agent_ref` varchar(128) NOT NULL DEFAULT '' COMMENT '占用方不透明标签（如 octopush:agent_xxx）；空=空闲',
+  ADD COLUMN `bound_at` timestamp NULL DEFAULT NULL COMMENT '占用时间；释放时清空';
+
+-- +migrate Down
+ALTER TABLE `robot`
+  DROP COLUMN `bound_at`,
+  DROP COLUMN `bound_agent_ref`;

--- a/pkg/errcode/integration.go
+++ b/pkg/errcode/integration.go
@@ -1,0 +1,60 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// Integration / Octo-link 错误码。
+//
+// integration 接口对外固定英文输出（路由层强制 en-US，外部 API 不做多语言），
+// 这里登记的 zh-CN 译文仅为 i18n 体系完整性兜底，正常不会被 integration 路由使用。
+var (
+	// ErrIntegrationDisabled —— exchange 能力被全局开关禁用（选项 A）。
+	ErrIntegrationDisabled = register(codes.Code{
+		ID:              "err.server.integration.disabled",
+		HTTPStatus:      http.StatusForbidden,
+		DefaultMessage:  "OIDC integration exchange is disabled.",
+		DefaultMessages: map[string]string{"zh-CN": "OIDC 集成换取能力已禁用。"},
+	})
+
+	// ErrIntegrationUserNotLinked —— (issuer, sub) 未绑定 Octo 用户。
+	ErrIntegrationUserNotLinked = register(codes.Code{
+		ID:              "err.server.integration.user_not_linked",
+		HTTPStatus:      http.StatusForbidden,
+		DefaultMessage:  "User is not linked to an Octo account.",
+		DefaultMessages: map[string]string{"zh-CN": "用户尚未关联 Octo 账号。"},
+	})
+
+	// ErrBotOccupied —— Bot 已被其他 Agent 占用；occupied_by 透传当前占用方。
+	ErrBotOccupied = register(codes.Code{
+		ID:              "err.server.bot.occupied",
+		HTTPStatus:      http.StatusConflict,
+		DefaultMessage:  "Bot is already occupied by another agent.",
+		DefaultMessages: map[string]string{"zh-CN": "该 Bot 已被其他 Agent 占用。"},
+		SafeDetailKeys:  []string{"occupied_by"},
+	})
+)
+
+// 复用 pkg/i18n/codes 已注册的 err.shared.* 码：integration / Octo-link 与 Bot
+// 占用端点的非业务错误（参数、未找到、无权限、内部错误）走这些通用码。在此以
+// 强类型 var 暴露，调用点与上面的 err.server.* 对称，避免裸字符串引用 ID。
+// 这些码由 codes 包 init 注册（shared.go），Go 保证被导入包的 init 先于本包 var
+// 初始化执行，故 shared() 查找一定命中。
+var (
+	ErrSharedParamInvalid = shared("err.shared.param.invalid")
+	ErrSharedForbidden    = shared("err.shared.auth.forbidden")
+	ErrSharedNotFound     = shared("err.shared.not_found")
+	ErrSharedInternal     = shared("err.shared.internal")
+)
+
+// shared 解析一个**已注册**的 err.shared.* 码。未知 ID 直接 panic——在包初始化
+// 期暴露拼写错误，而非延迟到请求时静默降级。
+func shared(id string) codes.Code {
+	c, ok := codes.Lookup(id)
+	if !ok {
+		panic("errcode: unknown shared code " + id)
+	}
+	return c
+}

--- a/pkg/errcode/integration_test.go
+++ b/pkg/errcode/integration_test.go
@@ -1,0 +1,52 @@
+package errcode
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+func TestIntegrationCodesRegistered(t *testing.T) {
+	for _, tc := range []struct {
+		code   codes.Code
+		id     string
+		status int
+	}{
+		{ErrIntegrationDisabled, "err.server.integration.disabled", http.StatusForbidden},
+		{ErrIntegrationUserNotLinked, "err.server.integration.user_not_linked", http.StatusForbidden},
+		{ErrBotOccupied, "err.server.bot.occupied", http.StatusConflict},
+	} {
+		t.Run(tc.id, func(t *testing.T) {
+			if tc.code.ID != tc.id {
+				t.Fatalf("var ID = %q, want %q", tc.code.ID, tc.id)
+			}
+			got, ok := codes.Lookup(tc.id)
+			if !ok {
+				t.Fatalf("%s not registered", tc.id)
+			}
+			if got.HTTPStatus != tc.status {
+				t.Fatalf("%s HTTPStatus = %d, want %d", tc.id, got.HTTPStatus, tc.status)
+			}
+			if got.DefaultMessage == "" {
+				t.Fatalf("%s missing en DefaultMessage", tc.id)
+			}
+		})
+	}
+}
+
+func TestBotOccupiedWhitelistsOccupiedBy(t *testing.T) {
+	got, ok := codes.Lookup("err.server.bot.occupied")
+	if !ok {
+		t.Fatal("err.server.bot.occupied not registered")
+	}
+	found := false
+	for _, k := range got.SafeDetailKeys {
+		if k == "occupied_by" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("err.server.bot.occupied must whitelist occupied_by, got %v", got.SafeDetailKeys)
+	}
+}

--- a/pkg/httperr/respond.go
+++ b/pkg/httperr/respond.go
@@ -28,10 +28,12 @@ func ResponseErrorL(c *wkhttp.Context, code codes.Code, params i18n.Params, deta
 // compatibility 400 (D14).
 //
 // Use this ONLY for endpoints that have NO legacy clients depending on the
-// fixed-400 behavior. The sole current consumer is the OIDC self-service bind
-// flow (modules/oidc/api_bind.go), a recent feature that has always returned
-// semantic status codes (400/401/409/410/422/429/503); pinning those to 400
-// would be a regression and break the bind wizard's status-based branching.
+// fixed-400 behavior. Current consumers:
+//   - the OIDC self-service bind flow (modules/oidc/api_bind.go) — always
+//     returned semantic codes (400/401/409/410/422/429/503);
+//   - the Octo-link Bot bind/unbind endpoints (modules/botfather/api_user.go,
+//     POST/DELETE /v1/user/bots/:bot_id/bind) — new endpoints that must return
+//     real REST status (404/409/…) so external Agents branch on the wire code.
 //
 // The body envelope is byte-for-byte identical to ResponseErrorL; only the
 // transport status differs — here it equals the code's canonical HTTPStatus, so

--- a/pkg/httperr/respond_test.go
+++ b/pkg/httperr/respond_test.go
@@ -87,6 +87,7 @@ func TestResponseErrorLUnknownCodeFallsBackToInternal(t *testing.T) {
 	}
 }
 
+
 // TestResponseErrorLWithStatusKeepsSemanticStatus verifies the WithStatus facade
 // emits the code's canonical HTTPStatus on the wire (not the legacy 400), while
 // keeping the body envelope identical to ResponseErrorL.
@@ -151,5 +152,37 @@ func TestResponseErrorLWithStatusInternalStays5xx(t *testing.T) {
 		if _, leaked := details["raw_err"]; leaked {
 			t.Fatal("internal code leaked unsafe detail")
 		}
+	}
+}
+
+// TestResponseErrorLWithStatusUsesRealStatus pins the facade on an integration
+// (Octo-link) code: the wire + error.http_status must both be the real 403.
+func TestResponseErrorLWithStatusUsesRealStatus(t *testing.T) {
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.SourceLanguage)))
+	r.GET("/x", func(c *wkhttp.Context) {
+		ResponseErrorLWithStatus(c, errcode.ErrIntegrationUserNotLinked, nil, nil)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("HTTP status = %d, want 403", rec.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got := body["status"]; got != float64(http.StatusForbidden) {
+		t.Fatalf("status = %v, want 403", got)
+	}
+	errObj := body["error"].(map[string]any)
+	if got := errObj["code"]; got != errcode.ErrIntegrationUserNotLinked.ID {
+		t.Fatalf("error.code = %q", got)
+	}
+	if got := errObj["http_status"]; got != float64(http.StatusForbidden) {
+		t.Fatalf("error.http_status = %v, want 403", got)
 	}
 }

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -6,6 +6,9 @@
 #
 # CI rejects PRs that change codes.Register input without re-running extract.
 
+["err.server.bot.occupied"]
+other = "Bot is already occupied by another agent."
+
 ["err.server.category.default_immutable"]
 other = "The default category cannot be modified."
 
@@ -203,6 +206,12 @@ other = "Too many requests. Please retry later."
 
 ["err.server.incomingwebhook.push_unauthorized"]
 other = "Unauthorized."
+
+["err.server.integration.disabled"]
+other = "OIDC integration exchange is disabled."
+
+["err.server.integration.user_not_linked"]
+other = "User is not linked to an Octo account."
 
 ["err.server.message.banword_not_found"]
 other = "The banned word does not exist."


### PR DESCRIPTION
Closes #240 — backend foundation sub-task of #236.

## Summary

Backend foundation (PR1 of the Octo-link / OIDC exchange effort) that makes the
existing BotFather `uk_` User API Key reusable across clients and adds Bot
occupancy so an external Agent can claim a Bot with guaranteed single-holder
mutual exclusion. The OIDC exchange module itself (`/v1/integrations/oidc/*`)
lands in a follow-up PR.

## What's included

- **errcode / httperr**
  - Register `err.server.integration.{disabled,user_not_linked}` and
    `err.server.bot.occupied` (with `occupied_by` whitelisted in `SafeDetailKeys`).
  - Add `ResponseErrorLWithStatus`: same i18n envelope as `ResponseErrorL` but
    emits the real HTTP status (401/403/404/409/…) instead of the legacy fixed
    400, for external-facing endpoints.

- **Migrations**
  - `user_api_key`: add `client_id` / `status` / usage-audit columns and reserved
    `api_key_hash` / `api_key_cipher` placeholders (kept empty this version);
    switch the unique key from `(uid, space_id)` to `(uid, space_id, client_id)`.
    Existing rows are backfilled to `client_id = 'botfather'` via the column
    DEFAULT, so the current `/quickstart` flow keeps hitting its own keys.
  - `robot`: add `bound_agent_ref` / `bound_at` for single-occupant Bot binding.

- **UserAPIKeyService** (exported)
  - `GetOrCreate(uid, spaceID, clientID)` + `AuthByKey(plaintext)`, shared by
    BotFather `/quickstart` (`client_id="botfather"`) and the upcoming
    integration module. Auth filters `status=1`; `GetOrCreate` is idempotent and
    recovers from concurrent unique-key collisions.

- **`GET /v1/user/bots`**: stop returning `bot_token` (fixes a `bf_` leak in the
  list response — fetch a single token via `GET /v1/user/bots/:bot_id/token`);
  expose occupancy (`bound_agent_ref`, and `bound_at` as `string|null`).

- **`POST` / `DELETE /v1/user/bots/:bot_id/bind`**: creator-level auth + row-level
  CAS mutual exclusion.
  - **Bind**: concurrent Agents racing for one free Bot resolve to exactly one
    winner; same-`agent_ref` re-bind is idempotent; another holder yields
    `409 err.server.bot.occupied` carrying `occupied_by`; bind/unbind races use a
    bounded retry.
  - **Unbind**: requires the caller's `agent_ref` and is holder-scoped — only the
    current holder (or an already-free Bot) can release; a different agent yields
    `409 ... occupied_by`; idempotent for the holder. This keeps the single-holder
    invariant unbypassable via unbind-then-bind.

> Integrator note: `DELETE /v1/user/bots/:bot_id/bind` now takes a JSON body
> `{ "agent_ref": "..." }`. Since all of a user's Agents share one `uk_`, the
> `agent_ref` is what proves which Agent owns the binding.

## Migrations verified

- Clean from-zero `Up` across the full migration chain.
- `Up → Down → Up` reversibility on an isolated copy. The Down path first deletes
  non-`botfather` rows before restoring the `(uid, space_id)` unique key, so
  rollback succeeds even after multi-client rows exist (verified with diverged
  data).
- Legacy-row backfill (`client_id='botfather'`, `status=1`).

## Test plan

- `go test ./modules/botfather/ ./pkg/errcode/ ./pkg/httperr/ ./pkg/i18n/...`
  green.
- `-race` on the concurrent-bind mutual-exclusion test (8 goroutines → 1 success,
  7 × 409).
- Unbind ownership regression: agent A binds, agent B (same `uk_`, different
  `agent_ref`) is rejected `409`, agent A unbinds idempotently.
- `go build ./...`, `go vet`, and the i18n extractor check all pass.

## Out of scope (follow-up PR2 — #241)

`modules/integration` (`/spaces`, `/exchange`, `/binding`), the
`integration_client` table + global exchange switch, `has_available_bot`
aggregation, IP/sub rate limiting, and the fixed-`en-US` integration routing.
