### PR TITLE
feat(robot): mention_pref 写后推 mention_pref_updated 事件

### DIFF
--- a/modules/robot/mention_pref.go
+++ b/modules/robot/mention_pref.go
@@ -7,6 +7,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/gocraft/dbr/v2"
 	"go.uber.org/zap"
@@ -149,6 +152,9 @@ func (rb *Robot) setMentionPref(c *wkhttp.Context) {
 		c.ResponseError(errors.New("更新失败"))
 		return
 	}
+	// 写库成功后即时通知对应 bot 失效缓存（best-effort，失败不阻塞主流程；
+	// adapter 仍有 TTL 兜底）。octo-server#242 / YUJ-2884。
+	rb.sendMentionPrefNotification(robotID, groupNo, loginUID, req.NoMention)
 	c.ResponseOK()
 }
 
@@ -171,7 +177,59 @@ func (rb *Robot) deleteMentionPref(c *wkhttp.Context) {
 		c.ResponseError(errors.New("删除失败"))
 		return
 	}
+	// 删除回退账号级默认即 no_mention=0；同样推事件让 adapter 即时失效缓存
+	// （best-effort，失败不阻塞）。octo-server#242 / YUJ-2884。
+	rb.sendMentionPrefNotification(robotID, groupNo, loginUID, 0)
 	c.ResponseOK()
+}
+
+// sendMentionPrefNotification 在 owner 改群级免@偏好后，给对应 bot 推一条
+// mention_pref_updated 事件，让 adapter 即时失效 (bot, group) 缓存，消除偏好
+// 改动到生效之间的 TTL 延迟（octo-server#242 / YUJ-2884）。
+//
+// 结构对齐 group 模块 sendGroupMdNotification（owner 网页 → group 频道）：
+//   - 走 group 频道，channel_id=groupNo —— adapter 用 extractParentGroupNo
+//     (channel_id) 解析群号，与 GROUP.md 事件同一接收路径；
+//   - mention.uids 只放当前 robotID（不广播），群里的其它 bot 不会被惊动，
+//     而 robot 模块的事件分发按 mention.uids 把消息精确投递到该 bot 的事件队列；
+//   - event 载荷带 group_no + no_mention，adapter 据此精准失效缓存。
+//
+// best-effort：投递失败仅记日志，不影响写接口返回 200（adapter 有 TTL 兜底）。
+func (rb *Robot) sendMentionPrefNotification(robotID, groupNo, updatedBy string, noMention int) {
+	payload := buildMentionPrefPayload(robotID, groupNo, noMention)
+
+	err := rb.ctx.SendMessage(&config.MsgSendReq{
+		Header: config.MsgHeader{
+			RedDot: 0,
+		},
+		ChannelID:   groupNo,
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		FromUID:     updatedBy,
+		Payload:     []byte(util.ToJson(payload)),
+	})
+	if err != nil {
+		rb.Error("send mention_pref notification failed", zap.Error(err),
+			zap.String("robot_id", robotID), zap.String("group_no", groupNo))
+	}
+}
+
+// buildMentionPrefPayload 构造 mention_pref_updated 事件的消息载荷。提取为纯函数
+// 便于单测断言事件结构（type / group_no / no_mention / mention.uids）。
+func buildMentionPrefPayload(robotID, groupNo string, noMention int) map[string]interface{} {
+	return map[string]interface{}{
+		"type":    common.Text,
+		"content": "mention_pref updated",
+		"event": map[string]interface{}{
+			"type":       "mention_pref_updated",
+			"group_no":   groupNo,
+			"no_mention": noMention,
+		},
+		// 只 @ 目标 bot —— 不广播给群里其它 bot。robot 事件分发按 mention.uids
+		// 精确投递到该 bot 的事件队列。
+		"mention": map[string]interface{}{
+			"uids": []string{robotID},
+		},
+	}
 }
 
 // getMentionPref 处理 GET /v1/robot/:robot_id/groups/:group_no/mention_pref。

--- a/modules/robot/mention_pref.go
+++ b/modules/robot/mention_pref.go
@@ -152,9 +152,16 @@ func (rb *Robot) setMentionPref(c *wkhttp.Context) {
 		c.ResponseError(errors.New("更新失败"))
 		return
 	}
-	// 写库成功后即时通知对应 bot 失效缓存（best-effort，失败不阻塞主流程；
+	// 写库成功后即时通知对应 bot 失效缓存（best-effort，异步不阻塞主流程；
 	// adapter 仍有 TTL 兜底）。octo-server#242 / YUJ-2884。
-	rb.sendMentionPrefNotification(robotID, groupNo, loginUID, req.NoMention)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				rb.Error("sendMentionPrefNotification panic", zap.Any("recover", r))
+			}
+		}()
+		rb.sendMentionPrefNotification(robotID, groupNo, req.NoMention)
+	}()
 	c.ResponseOK()
 }
 
@@ -178,8 +185,15 @@ func (rb *Robot) deleteMentionPref(c *wkhttp.Context) {
 		return
 	}
 	// 删除回退账号级默认即 no_mention=0；同样推事件让 adapter 即时失效缓存
-	// （best-effort，失败不阻塞）。octo-server#242 / YUJ-2884。
-	rb.sendMentionPrefNotification(robotID, groupNo, loginUID, 0)
+	// （best-effort，异步不阻塞）。octo-server#242 / YUJ-2884。
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				rb.Error("sendMentionPrefNotification panic", zap.Any("recover", r))
+			}
+		}()
+		rb.sendMentionPrefNotification(robotID, groupNo, 0)
+	}()
 	c.ResponseOK()
 }
 
@@ -195,7 +209,11 @@ func (rb *Robot) deleteMentionPref(c *wkhttp.Context) {
 //   - event 载荷带 group_no + no_mention，adapter 据此精准失效缓存。
 //
 // best-effort：投递失败仅记日志，不影响写接口返回 200（adapter 有 TTL 兜底）。
-func (rb *Robot) sendMentionPrefNotification(robotID, groupNo, updatedBy string, noMention int) {
+//
+// FromUID 用 robotID 而非 owner —— bot 必是群成员，WuKongIM 不会因发送方非
+// 群成员而拒发；owner 可能已退群，用 owner 会让事件静默失败退化成 TTL
+// （对齐 bot_api/botfather 样板）。
+func (rb *Robot) sendMentionPrefNotification(robotID, groupNo string, noMention int) {
 	payload := buildMentionPrefPayload(robotID, groupNo, noMention)
 
 	err := rb.ctx.SendMessage(&config.MsgSendReq{
@@ -204,7 +222,7 @@ func (rb *Robot) sendMentionPrefNotification(robotID, groupNo, updatedBy string,
 		},
 		ChannelID:   groupNo,
 		ChannelType: common.ChannelTypeGroup.Uint8(),
-		FromUID:     updatedBy,
+		FromUID:     robotID,
 		Payload:     []byte(util.ToJson(payload)),
 	})
 	if err != nil {

--- a/modules/robot/mention_pref_test.go
+++ b/modules/robot/mention_pref_test.go
@@ -3,6 +3,7 @@ package robot
 import (
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -68,4 +69,31 @@ func TestGroupsCursorRoundTrip(t *testing.T) {
 	assert.Equal(t, int64(0), decodeGroupsCursor("!!!not-base64!!!"))
 	// Valid base64 of a non-numeric string also falls back to 0.
 	assert.Equal(t, int64(0), decodeGroupsCursor("YWJj")) // base64("abc")
+}
+
+// TestBuildMentionPrefPayload verifies the mention_pref_updated event payload
+// the owner write/delete endpoints push to the adapter (octo-server#242). The
+// adapter keys cache invalidation off event.type + event.group_no + the
+// message channel, and the bot only receives it via mention.uids — so those
+// fields are the contract under test.
+func TestBuildMentionPrefPayload(t *testing.T) {
+	for _, noMention := range []int{0, 1} {
+		p := buildMentionPrefPayload("bot_42", "g_100", noMention)
+
+		// Top-level type is Text so it rides the same group-message path as
+		// GROUP.md events.
+		assert.Equal(t, common.Text, p["type"])
+
+		event, ok := p["event"].(map[string]interface{})
+		assert.True(t, ok, "event must be a map")
+		assert.Equal(t, "mention_pref_updated", event["type"])
+		assert.Equal(t, "g_100", event["group_no"])
+		assert.Equal(t, noMention, event["no_mention"])
+
+		// Targeted (non-broadcast): only the affected bot is mentioned, so the
+		// robot dispatcher routes the event to that bot's queue alone.
+		mention, ok := p["mention"].(map[string]interface{})
+		assert.True(t, ok, "mention must be a map")
+		assert.Equal(t, []string{"bot_42"}, mention["uids"])
+	}
 }


### PR DESCRIPTION
## 背景
owner 在网页改 bot 的群级免@偏好后，adapter 端缓存 `(bot, group) → no_mention` 需等一个 TTL 窗口才失效，导致改动生效有延迟。

## 改动
在两个 owner 写端点写库成功后，给对应 bot 追加推一条 `mention_pref_updated` 事件，让 adapter 即时失效缓存：
- `PUT /v1/robot/:robot_id/groups/:group_no/mention_pref`
- `DELETE /v1/robot/:robot_id/groups/:group_no/mention_pref`

事件载荷 `event {type:'mention_pref_updated', group_no, no_mention:0|1}`。

## 实现要点
- **照搬现有 group_md_updated 发送路径**：复用 group 频道（group message + `event` 载荷），不新造事件通道。adapter 用 `extractParentGroupNo(channel_id)` 解析群号，与 GROUP.md 同一接收路径。
- **不广播**：`mention.uids` 只放当前 `robot_id`，robot 模块事件分发按 `mention.uids` 精确投递到该 bot 队列，群里其它 bot 不受影响。
- **发送异步 + panic recovery**：两端点的事件发送均包进 `go func(){ defer recover() ... }()`，在 `ResponseOK()` 之后不阻塞主流程（底层 `http.DefaultClient` 无超时，WuKongIM 卡住不再拖垮 owner 的 PUT/DELETE；panic 也不会把已成功的写库变成 500）。结构对齐 `group/api.go`、`bot_api/groups.go`、`botfather/api_bot.go` 三处样板。
- **FromUID=robotID**：发送方用 bot（必是群成员）而非 owner（可能已退群，WuKongIM 可能拒非成员发送 → 事件静默失败退化成 TTL），对齐 bot_api/botfather 样板。
- **best-effort**：投递失败仅记日志，不阻塞写接口主流程（返回 200），adapter 仍有 TTL 兜底。
- DELETE 回退账号级默认即 `no_mention=0`，按 0 推事件。

## 测试
- `buildMentionPrefPayload` 提取为纯函数，新增单测断言事件结构（type / group_no / no_mention / mention.uids）。
- `go build ./modules/robot/...`、`go vet ./modules/robot/...`、`go test ./modules/robot/ -run TestBuildMentionPrefPayload` 全绿。

## 关联 / 跨仓部署顺序
跨仓 adapter 侧 `openclaw-channel-octo#61` 已 squash-merge 进 `main`（`f6fdffab`，2026-06-03 12:52Z），`mention_pref_updated` handler 已在 adapter 默认分支。跨仓部署顺序约束已解除，本 PR 现在可安全 merge——adapter 已能消费该事件，不会再漏进 LLM。

Fixes #242
