### PR TITLE
feat(auth_jwt): shorten daemonTokenTTL from 30d to 24h

### DIFF
--- a/modules/auth_jwt/bot_api.go
+++ b/modules/auth_jwt/bot_api.go
@@ -149,8 +149,8 @@ func (a *AuthJWT) requireDaemonJWT(c *wkhttp.Context) (*Claims, error) {
 	}
 	// PR-A fix (齐乐 review #3): signature-only verification let expired
 	// tokens through. Plan AU1 requires "JWT 过期 → 401" — enforce it
-	// here, otherwise a daemon JWT past 30-day TTL could still mint a
-	// bot_token forever.
+	// here, otherwise a daemon JWT past its TTL (currently 24h) could
+	// still mint a bot_token forever.
 	//
 	// Note on clock skew: Time field below is exact wall-clock; we rely
 	// on go-jose's DefaultLeeway (1 min) to tolerate small daemon ↔ server

--- a/modules/auth_jwt/jwt.go
+++ b/modules/auth_jwt/jwt.go
@@ -43,8 +43,15 @@ const (
 	jwtIssuer    = "octo-server"
 
 	// Token lifetimes — see spec §"技术决策"
-	webTokenTTL    = 30 * time.Minute
-	daemonTokenTTL = 30 * 24 * time.Hour
+	webTokenTTL = 30 * time.Minute
+	// daemon-side EnsureJWT lazy-refreshes at 5min-remaining (see
+	// octo-daemon-cli/internal/client.go EnsureJWT). 24h TTL gives ~23h55min
+	// of safety margin against the refresh floor. Shortening the TTL further
+	// would require revisiting that floor (currently a hardcoded 5 minutes).
+	// Net effect of 24h vs prior 30d: tightens the api_key-revocation window
+	// from 30 days to 1 day. (Per comm protocol decision; will be superseded
+	// if auth session moves to api_key-direct-call path.)
+	daemonTokenTTL = 24 * time.Hour
 )
 
 // AuthJWT is the module entrypoint registered with octo-lib.
@@ -222,8 +229,9 @@ func (a *AuthJWT) IssueDaemonToken(uid, spaceID, daemonID string) (string, error
 // JWKS is unauthenticated and cacheable.
 //
 // PR-A.2 added two cross-service bot endpoints (see bot_api.go):
-//   POST /v1/bot/mint        — web session auth, mints bot OBO
-//   GET  /v1/bot/:uid/token  — daemon JWT auth, returns bot_token
+//
+//	POST /v1/bot/mint        — web session auth, mints bot OBO
+//	GET  /v1/bot/:uid/token  — daemon JWT auth, returns bot_token
 func (a *AuthJWT) Route(r *wkhttp.WKHttp) {
 	r.GET("/.well-known/jwks.json", a.serveJWKS)
 	r.POST("/v1/auth/token", a.exchangeToken)


### PR DESCRIPTION
## Summary
- \`daemonTokenTTL\` 30 * 24h → 24h
- 同步 bot_api.go 里过时的 "30-day TTL" 注释 (codex review MINOR)

## Why
通信协议决策 P1-5. daemon 端 EnsureJWT 早就在过期前自动 refresh, 缩 TTL 没有运行时影响, 但把 api_key 撤销窗口从 30 天降到 1 天 (生产合规).

## Note
- 如果 auth session 决定走 "去 daemon JWT 改 api_key 直连" 路线 (review 结论 4), 这个改动就作废. 但当前 JWT 路线下这是安全的紧化, 两种方向都不冲突.

## Test plan
- [x] \`go build ./...\` 通过

## Reviewers
@lvsijia @lijianhui