### PR TITLE
fix(group): rollback MySQL records when IM channel creation fails during CreateGroup

### DIFF
--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -1234,7 +1234,17 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 		Subscribers: realMemberUIDs,
 	})
 	if err != nil {
-		s.Error("create IM channel failed", zap.Error(err))
+		s.Error("create IM channel failed, performing compensating rollback", zap.Error(err), zap.String("groupNo", groupNo))
+		// Compensating delete: remove group_member and group records that were
+		// already committed. Use s.ctx.DB() (not tx) because the transaction
+		// has already been committed.
+		if _, delErr := s.ctx.DB().DeleteFrom("group_member").Where("group_no=?", groupNo).Exec(); delErr != nil {
+			s.Error("compensating delete group_member failed", zap.Error(delErr), zap.String("groupNo", groupNo))
+		}
+		if _, delErr := s.ctx.DB().DeleteFrom("group").Where("group_no=?", groupNo).Exec(); delErr != nil {
+			s.Error("compensating delete group failed", zap.Error(delErr), zap.String("groupNo", groupNo))
+		}
+		return nil, errors.New("failed to create IM channel, group has been rolled back")
 	}
 
 	// 发送群创建通知


### PR DESCRIPTION
## Problem

`CreateGroup` calls `IMCreateOrUpdateChannel` **after** `tx.Commit()`. If the IM channel creation fails, group and group_member records are already persisted in MySQL but no IM channel exists — producing a "ghost group" that appears in the DB/UI but cannot receive messages.

Closes #247

## Solution

Add **compensating deletes** on IM channel creation failure:

1. Delete `group_member` records for the new group
2. Delete the `group` record itself
3. Return an error to the caller so the API reports failure

If the compensating deletes themselves fail, the errors are logged but the original IM failure is still returned to the caller (best-effort cleanup).

### What is NOT rolled back (by design)

- **Bot admin setting** (`UpdateBotAdmin`) — best-effort enhancement
- **Category/group setting** (`CategoryID`) — best-effort enhancement

These are non-critical enhancements that do not affect basic group usability and will be orphaned (harmless) if the group record is deleted.

## Changes

- `modules/group/service.go`: In `CreateGroup`, replace the fire-and-forget error log on `IMCreateOrUpdateChannel` failure with compensating `DELETE FROM group_member` + `DELETE FROM group` and early return with error.