### PR TITLE
fix(incomingwebhook): address #246 post-merge follow-ups

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	commonapi "github.com/Mininglamp-OSS/octo-server/modules/base/common"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/accesslog"
 	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
 	octodb "github.com/Mininglamp-OSS/octo-server/pkg/db"
 	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
@@ -93,6 +94,13 @@ func main() {
 }
 
 func runAPI(ctx *config.Context) {
+	// 在注册 recovery 之前给 gin 的 panic 输出包一层 token 脱敏 writer：octo-lib 的
+	// server.New → wkhttp.New 内部装 gin.Recovery()。release 模式下 gin 在 broken-pipe
+	// 分支会 dump 整条请求行（含 incoming-webhook 推送路由 path 里的明文 token），panic
+	// value 本身也可能带上该 path——两者都会绕过 access logger 落进 DefaultErrorWriter。
+	// gin.Recovery 在注册时即捕获 DefaultErrorWriter，故必须在 server.New 之前替换（#246）。
+	gin.DefaultErrorWriter = accesslog.NewErrorWriter(gin.DefaultErrorWriter)
+
 	// 创建server
 	s := server.New(ctx)
 	route := s.GetRoute()
@@ -139,6 +147,11 @@ func runAPI(ctx *config.Context) {
 	httpMetrics := metrics.NewHTTPMetrics(prometheus.DefaultRegisterer)
 	route.UseGin(httpMetrics.GinMiddleware())
 	metricsSrv := startMetricsScrapeServer()
+	// 用自定义 LogFormatter 替换 gin 默认 access logger：incoming-webhook 推送路由
+	// /v1/incoming-webhooks/{webhook_id}/{token} 把明文 token 写在 URL path 里，
+	// gin 默认 logger 会把整条 path 落进 access log，泄漏 token。accesslog.Formatter
+	// 与默认行格式一致，但对该 path 的 token 段做脱敏（见 #246）。logger 只构造一次复用。
+	accessLogger := gin.LoggerWithFormatter(accesslog.Formatter)
 	route.UseGin(func(c *gin.Context) {
 		ingorePaths := ingorePaths()
 		for _, ingorePath := range ingorePaths {
@@ -146,7 +159,7 @@ func runAPI(ctx *config.Context) {
 				return
 			}
 		}
-		gin.Logger()(c)
+		accessLogger(c)
 	})
 	// 全局 per-IP 作为 DDoS 底线：办公室共享出网 IP 下 IM 基础量就能到 100+ rps
 	// （每人 1-2 rps × 数十人），200 余量过小；真实 DDoS 常数千 rps+，底线设 500

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -39,6 +38,7 @@ const (
 	envRatePerWebhookBurst = "DM_INCOMINGWEBHOOK_BURST"
 	envIngressIPRPS        = "DM_INCOMINGWEBHOOK_IP_RPS"
 	envIngressIPBurst      = "DM_INCOMINGWEBHOOK_IP_BURST"
+	envMaxContentRunes     = "DM_INCOMINGWEBHOOK_MAX_CONTENT_RUNES"
 
 	defaultMaxPerGroup    = 10
 	defaultMaxBytes       = 8 * 1024
@@ -46,6 +46,10 @@ const (
 	defaultRatePerWHBurst = 10
 	defaultIngressIPRPS   = 30.0
 	defaultIngressIPBurst = 60
+	// content 的语义长度上限（rune 数）。8KB body cap 是字节传输上限，这里再加一道
+	// 业务上限：单条消息正文过长既影响客户端渲染，也无 IM 语义。默认 4000 rune
+	// 介于 Discord(~2k) 与 Slack(~40k) 之间，可经 env 调整。
+	defaultMaxContentRunes = 4000
 )
 
 // 撤回权限说明：webhook 消息的 FromUID 形如 "iwh_xxx"，永远不是群成员。
@@ -61,6 +65,29 @@ type IncomingWebhook struct {
 	db        *incomingWebhookDB
 	groupDB   *group.DB
 	rateRedis *redis.Client
+	// auditSem 给 push 成功后的异步审计(recordSuccess)限并发：每次推送有两次 DB 写，
+	// 无界 `go recordSuccess` 在 Redis 限流 fail-open + 推送洪峰下会无限堆 goroutine、
+	// 压垮 DB 连接池。用带缓冲 channel 作信号量给审计的 DB 操作总并发封顶——满了就**丢弃**
+	// 本次审计（仅 Warn），而不是回落到请求 goroutine 同步执行。审计是非关键路径（失败
+	// 本就只记日志），丢弃换来的是：审计占用的 DB 连接数恒 ≤ 桶容量，洪峰下不会和主流量
+	// 抢连接池。同步回落则会让每个请求 goroutine 各占一条连接，在限流全 fail-open、请求
+	// 并发本身无界时重新压垮连接池——正是这个信号量要避免的（yujiawei review P2）。
+	auditSem chan struct{}
+}
+
+// maxConcurrentAudit 限制异步审计 goroutine 的最大并发数（默认值，可被 env 覆盖）。
+const (
+	envAuditConcurrency     = "DM_INCOMINGWEBHOOK_AUDIT_CONCURRENCY"
+	defaultAuditConcurrency = 64
+)
+
+func auditConcurrency() int {
+	if v := os.Getenv(envAuditConcurrency); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultAuditConcurrency
 }
 
 // rateRedisOnce 让限流用的 redis client 在进程内单例化，避免每次 New() 都开新连接池
@@ -92,6 +119,7 @@ func New(ctx *config.Context) *IncomingWebhook {
 		db:        newDB(ctx),
 		groupDB:   group.NewDB(ctx),
 		rateRedis: sharedRateRedis(ctx.GetConfig()),
+		auditSem:  make(chan struct{}, auditConcurrency()),
 	}
 	// 群解散级联禁用所有 webhook
 	w.ctx.AddEventListener(event.GroupDisband, w.handleGroupDisband)
@@ -143,6 +171,15 @@ func maxBytes() int {
 		}
 	}
 	return defaultMaxBytes
+}
+
+func maxContentRunes() int {
+	if v := os.Getenv(envMaxContentRunes); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultMaxContentRunes
 }
 
 func perWebhookRPS() float64 {
@@ -231,11 +268,11 @@ func (w *IncomingWebhook) requireGroupAdmin(c *wkhttp.Context, groupNo string) (
 	ok, err := w.groupDB.QueryIsGroupManagerOrCreator(groupNo, loginUID)
 	if err != nil {
 		w.Error("query group manager failed", zap.Error(err))
-		c.ResponseError(errors.New("查询群权限失败"))
+		mgmtQueryFailed(c)
 		return "", false
 	}
 	if !ok {
-		c.ResponseErrorWithStatus(errors.New("仅群主或管理员可管理 webhook"), http.StatusForbidden)
+		mgmtForbidden(c)
 		return "", false
 	}
 	return loginUID, true
@@ -254,16 +291,12 @@ func (w *IncomingWebhook) create(c *wkhttp.Context) {
 
 	var req createReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(fmt.Errorf("无效请求: %w", err))
+		mgmtRequestInvalid(c, "body")
 		return
 	}
 	req.Name = strings.TrimSpace(req.Name)
-	if req.Name == "" {
-		c.ResponseError(errors.New("name 不能为空"))
-		return
-	}
-	if len(req.Name) > 64 {
-		c.ResponseError(errors.New("name 长度需 ≤ 64"))
+	if req.Name == "" || len(req.Name) > 64 {
+		mgmtRequestInvalid(c, "name")
 		return
 	}
 
@@ -272,18 +305,18 @@ func (w *IncomingWebhook) create(c *wkhttp.Context) {
 	g, err := w.requireActiveGroup(groupNo)
 	if err != nil {
 		w.Error("query group failed", zap.Error(err))
-		c.ResponseError(errors.New("查询群信息失败"))
+		mgmtQueryFailed(c)
 		return
 	}
 	if g == nil {
-		c.ResponseErrorWithStatus(errors.New("群不存在或已解散"), http.StatusNotFound)
+		mgmtGroupNotFound(c)
 		return
 	}
 
 	token, hash, err := generateToken()
 	if err != nil {
 		w.Error("generate token failed", zap.Error(err))
-		c.ResponseError(errors.New("创建失败"))
+		mgmtOperationFailed(c)
 		return
 	}
 
@@ -298,13 +331,20 @@ func (w *IncomingWebhook) create(c *wkhttp.Context) {
 		Status:     1,
 	}
 	// 配额校验 + 写入在事务内原子完成；FOR UPDATE 锁住 group_no 范围，防止并发越限。
-	if err := w.db.insertWithQuota(m, maxPerGroup()); err != nil {
+	//
+	// TOCTOU 说明：requireActiveGroup 的 status 检查是 insert 事务之前的非事务读，
+	// 事务内仅靠 group 行锁串行化、不重查 status。极小窗口内群被解散仍可能写入一条
+	// status=1 的行，但这**不构成安全问题**：该 webhook 永远推不出消息——push 路径的
+	// requireActiveGroup 重查才是权威闸（群非 Normal 一律 401），且 disband 级联会把
+	// status 翻 0。故此处不在事务内重读 group.status，避免给热路径加锁负担。
+	maxWH := maxPerGroup()
+	if err := w.db.insertWithQuota(m, maxWH); err != nil {
 		if errors.Is(err, ErrQuotaExceeded) {
-			c.ResponseError(fmt.Errorf("每个群最多 %d 个 webhook", maxPerGroup()))
+			mgmtQuotaExceeded(c, maxWH)
 			return
 		}
 		w.Error("insert webhook failed", zap.Error(err))
-		c.ResponseError(errors.New("创建失败"))
+		mgmtOperationFailed(c)
 		return
 	}
 
@@ -324,7 +364,7 @@ func (w *IncomingWebhook) list(c *wkhttp.Context) {
 	list, err := w.db.queryByGroupNo(groupNo)
 	if err != nil {
 		w.Error("list webhooks failed", zap.Error(err))
-		c.ResponseError(errors.New("查询失败"))
+		mgmtQueryFailed(c)
 		return
 	}
 	resps := make([]webhookResp, 0, len(list))
@@ -344,17 +384,17 @@ func (w *IncomingWebhook) update(c *wkhttp.Context) {
 	m, err := w.db.queryByWebhookID(webhookID)
 	if err != nil {
 		w.Error("query webhook failed", zap.Error(err))
-		c.ResponseError(errors.New("查询失败"))
+		mgmtQueryFailed(c)
 		return
 	}
 	if m == nil || m.GroupNo != groupNo {
-		c.ResponseErrorWithStatus(errors.New("webhook 不存在"), http.StatusNotFound)
+		mgmtNotFound(c)
 		return
 	}
 
 	var req updateReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(fmt.Errorf("无效请求: %w", err))
+		mgmtRequestInvalid(c, "body")
 		return
 	}
 
@@ -362,7 +402,7 @@ func (w *IncomingWebhook) update(c *wkhttp.Context) {
 	if req.Name != nil {
 		name := strings.TrimSpace(*req.Name)
 		if name == "" || len(name) > 64 {
-			c.ResponseError(errors.New("name 不合法"))
+			mgmtRequestInvalid(c, "name")
 			return
 		}
 		fields["name"] = name
@@ -372,7 +412,7 @@ func (w *IncomingWebhook) update(c *wkhttp.Context) {
 	}
 	if req.Status != nil {
 		if *req.Status != 0 && *req.Status != 1 {
-			c.ResponseError(errors.New("status 仅允许 0 或 1"))
+			mgmtRequestInvalid(c, "status")
 			return
 		}
 		// 启用 webhook 前必须确认群仍处于 Normal —— 阻断 disband → re-enable 复活路径。
@@ -381,11 +421,11 @@ func (w *IncomingWebhook) update(c *wkhttp.Context) {
 			g, err := w.requireActiveGroup(groupNo)
 			if err != nil {
 				w.Error("query group failed", zap.Error(err))
-				c.ResponseError(errors.New("查询群信息失败"))
+				mgmtQueryFailed(c)
 				return
 			}
 			if g == nil {
-				c.ResponseErrorWithStatus(errors.New("群不存在或已解散，无法启用 webhook"), http.StatusNotFound)
+				mgmtGroupNotFound(c)
 				return
 			}
 		}
@@ -397,7 +437,7 @@ func (w *IncomingWebhook) update(c *wkhttp.Context) {
 	}
 	if err := w.db.updateFields(webhookID, fields); err != nil {
 		w.Error("update webhook failed", zap.Error(err))
-		c.ResponseError(errors.New("更新失败"))
+		mgmtOperationFailed(c)
 		return
 	}
 	updated, qErr := w.db.queryByWebhookID(webhookID)
@@ -418,16 +458,16 @@ func (w *IncomingWebhook) delete(c *wkhttp.Context) {
 	m, err := w.db.queryByWebhookID(webhookID)
 	if err != nil {
 		w.Error("query webhook failed", zap.Error(err))
-		c.ResponseError(errors.New("查询失败"))
+		mgmtQueryFailed(c)
 		return
 	}
 	if m == nil || m.GroupNo != groupNo {
-		c.ResponseErrorWithStatus(errors.New("webhook 不存在"), http.StatusNotFound)
+		mgmtNotFound(c)
 		return
 	}
 	if err := w.db.deleteByWebhookID(webhookID); err != nil {
 		w.Error("delete webhook failed", zap.Error(err))
-		c.ResponseError(errors.New("删除失败"))
+		mgmtOperationFailed(c)
 		return
 	}
 	c.ResponseOK()
@@ -443,32 +483,32 @@ func (w *IncomingWebhook) regenerate(c *wkhttp.Context) {
 	g, err := w.requireActiveGroup(groupNo)
 	if err != nil {
 		w.Error("query group failed", zap.Error(err))
-		c.ResponseError(errors.New("查询群信息失败"))
+		mgmtQueryFailed(c)
 		return
 	}
 	if g == nil {
-		c.ResponseErrorWithStatus(errors.New("群不存在或已解散"), http.StatusNotFound)
+		mgmtGroupNotFound(c)
 		return
 	}
 	m, err := w.db.queryByWebhookID(webhookID)
 	if err != nil {
 		w.Error("query webhook failed", zap.Error(err))
-		c.ResponseError(errors.New("查询失败"))
+		mgmtQueryFailed(c)
 		return
 	}
 	if m == nil || m.GroupNo != groupNo {
-		c.ResponseErrorWithStatus(errors.New("webhook 不存在"), http.StatusNotFound)
+		mgmtNotFound(c)
 		return
 	}
 	token, hash, err := generateToken()
 	if err != nil {
 		w.Error("generate token failed", zap.Error(err))
-		c.ResponseError(errors.New("重置失败"))
+		mgmtOperationFailed(c)
 		return
 	}
 	if err := w.db.updateFields(webhookID, map[string]interface{}{"token_hash": hash}); err != nil {
 		w.Error("update token_hash failed", zap.Error(err))
-		c.ResponseError(errors.New("重置失败"))
+		mgmtOperationFailed(c)
 		return
 	}
 	m.TokenHash = hash
@@ -511,7 +551,8 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 	}
 
 	// 2.5) 群必须仍处于 Normal —— 兜底 handleGroupDisband 的异步窗口期，
-	// 也防止对已解散群继续推送消息。统一返回 401（不区分原因，防探测）。
+	// 也防止对已解散群继续推送消息。统一返回 401（响应体不区分原因——防探测的主防线；
+	// 时序非恒定，仅尽力而为，见 errcode/incomingwebhook.go 注释）。
 	g, err := w.requireActiveGroup(m.GroupNo)
 	if err != nil {
 		w.Error("query group on push failed",
@@ -556,6 +597,12 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 		pushPayloadInvalid(c, "content")
 		return
 	}
+	// content 语义长度上限（按 rune 计），独立于 8KB 字节 body cap：防止单条消息正文
+	// 过长污染所有客户端渲染。超限按 413 拒绝，与 body 超限同语义。
+	if utf8.RuneCountInString(req.Content) > maxContentRunes() {
+		pushPayloadTooLarge(c)
+		return
+	}
 
 	// 5) 构造 payload 并发送
 	payload := buildPayload(m, &req)
@@ -575,12 +622,12 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 		return
 	}
 
-	// 6) 异步审计 + markUsed（失败不影响响应）
+	// 6) 异步审计 + markUsed（失败不影响响应），并发受 auditSem 限制
 	var msgID int64
 	if resp != nil {
 		msgID = resp.MessageID
 	}
-	go w.recordSuccess(m, len(body), c.ClientIP(), msgID)
+	w.submitRecordSuccess(m, len(body), c.ClientIP(), msgID)
 
 	c.Response(map[string]interface{}{
 		"status":     0,
@@ -604,7 +651,10 @@ func truncateUTF8(s string, max int) string {
 			return s[:i]
 		}
 	}
-	return s[:max]
+	// 兜底：max 落在首个 rune 内部（max < 首 rune 宽度）时无回退边界。
+	// 当前 64/255 字节上限远大于任何 rune 宽度，这条不可达；但若未来把上限调到
+	// 个位数，返回空串也好过 s[:max] 切出半个 rune。
+	return ""
 }
 
 // buildPayload 把 webhook 请求映射到群消息 payload。
@@ -646,6 +696,31 @@ func buildPayload(m *incomingWebhookModel, req *pushPayloadReq) map[string]inter
 	}
 }
 
+// submitRecordSuccess 把审计任务投递给有界并发池：未达上限时异步执行；已达上限时
+// **丢弃**本次审计（仅 Warn）。如此审计占用的 DB 连接总数恒 ≤ auditSem 容量，不会在
+// 洪峰下与主流量抢连接池。审计为非关键路径，溢出丢弃优于回落到请求 goroutine 同步执行
+// （后者请求并发无界时会重新压垮连接池）。
+func (w *IncomingWebhook) submitRecordSuccess(m *incomingWebhookModel, byteSize int, ip string, msgID int64) {
+	select {
+	case w.auditSem <- struct{}{}:
+		go func() {
+			defer func() { <-w.auditSem }()
+			w.recordSuccess(m, byteSize, ip, msgID)
+		}()
+	default:
+		// 并发已达上限：丢弃审计，保证总 DB 并发有界、不抢占主流量连接池。
+		w.Warn("audit dropped: concurrency cap reached",
+			zap.String("webhook_id", m.WebhookID))
+	}
+}
+
+// auditWriteTimeout 限定一次审计（markUsed + insertAudit 两次写）的总耗时上限。
+// recordSuccess 始终跑在独立 goroutine 上（submitRecordSuccess 满载时直接丢弃、不回落
+// 到请求 goroutine），所以这个超时**不影响 push 响应延迟**；它的作用是封顶单个 detached
+// 审计 goroutine 在 DB 饱和/故障时持有连接池连接的时长，避免慢 DB 下连接被长期占用。
+// 3s 足够正常写入，又能在故障时快速放手（审计本就是非关键路径，失败仅记日志）。
+const auditWriteTimeout = 3 * time.Second
+
 // recordSuccess 写审计 + 累加调用计数。失败仅记日志，不阻塞主流程。
 func (w *IncomingWebhook) recordSuccess(m *incomingWebhookModel, byteSize int, ip string, msgID int64) {
 	defer func() {
@@ -653,7 +728,10 @@ func (w *IncomingWebhook) recordSuccess(m *incomingWebhookModel, byteSize int, i
 			w.Error("recordSuccess panic", zap.Any("recover", r))
 		}
 	}()
-	if err := w.db.markUsed(m.WebhookID, time.Now()); err != nil {
+	// 两次写共用一个截止时间，封顶单个审计 goroutine 在 DB 饱和/故障时持有连接的时长。
+	ctx, cancel := context.WithTimeout(context.Background(), auditWriteTimeout)
+	defer cancel()
+	if err := w.db.markUsed(ctx, m.WebhookID, time.Now()); err != nil {
 		w.Warn("markUsed failed", zap.String("webhook_id", m.WebhookID), zap.Error(err))
 	}
 	audit := &auditModel{
@@ -663,7 +741,7 @@ func (w *IncomingWebhook) recordSuccess(m *incomingWebhookModel, byteSize int, i
 		ByteSize:  byteSize,
 		MessageID: msgID,
 	}
-	if err := w.db.insertAudit(audit); err != nil {
+	if err := w.db.insertAudit(ctx, audit); err != nil {
 		w.Warn("insert audit failed", zap.String("webhook_id", m.WebhookID), zap.Error(err))
 	}
 }

--- a/modules/incomingwebhook/api_i18n.go
+++ b/modules/incomingwebhook/api_i18n.go
@@ -50,3 +50,51 @@ func pushDeliveryFailed(c *wkhttp.Context) {
 	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookPushDeliveryFailed, nil, nil)
 	c.Abort()
 }
+
+// ============================================================
+// management-path error responders
+//
+// The admin-only management endpoints (create / list / update / delete /
+// regenerate) also use ResponseErrorLWithStatus and keep their real semantic
+// HTTP status — they are a new feature with no legacy clients keyed to the
+// fixed-400 ResponseErrorL. These replace the legacy raw-string
+// c.ResponseError(errors.New(...)) pattern (#246). Handlers must return
+// immediately after calling one; no c.Abort() is needed at handler level.
+// ============================================================
+
+// mgmtForbidden returns 403 — caller is neither owner nor admin.
+func mgmtForbidden(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookForbidden, nil, nil)
+}
+
+// mgmtRequestInvalid returns 400 for malformed body / invalid field; reason ∈
+// {body, name, status} is surfaced via the safe-listed Details key.
+func mgmtRequestInvalid(c *wkhttp.Context, reason string) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookRequestInvalid, nil, i18n.Details{"reason": reason})
+}
+
+// mgmtGroupNotFound returns 404 — group missing or not Normal (disbanded).
+func mgmtGroupNotFound(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookGroupNotFound, nil, nil)
+}
+
+// mgmtNotFound returns 404 — webhook missing or cross-group.
+func mgmtNotFound(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookNotFound, nil, nil)
+}
+
+// mgmtQuotaExceeded returns 409 — per-group webhook cap reached; max carries
+// the configured limit for the message.
+func mgmtQuotaExceeded(c *wkhttp.Context, max int) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookQuotaExceeded, i18n.Params{"max": max}, nil)
+}
+
+// mgmtQueryFailed returns 500 (Internal) — a read failed; real error logged.
+func mgmtQueryFailed(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookQueryFailed, nil, nil)
+}
+
+// mgmtOperationFailed returns 500 (Internal) — a write failed; real error logged.
+func mgmtOperationFailed(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookOperationFailed, nil, nil)
+}

--- a/modules/incomingwebhook/api_test.go
+++ b/modules/incomingwebhook/api_test.go
@@ -141,14 +141,12 @@ func TestCreate_HappyPath(t *testing.T) {
 }
 
 func TestCreate_RejectsEmptyName(t *testing.T) {
-	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	handler, _, groupNo := setupTestEnv(t)
 	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{}))
 	assert.NotEqual(t, http.StatusOK, w.Code)
 }
 
 func TestCreate_NonAdminForbidden(t *testing.T) {
-	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	handler, ctx, groupNo := setupTestEnv(t)
 	// 把当前用户降级为普通成员
 	_, err := ctx.DB().UpdateBySql("UPDATE group_member SET role=0 WHERE group_no=? AND uid=?", groupNo, testutil.UID).Exec()
@@ -165,7 +163,6 @@ func TestCreate_NonAdminForbidden(t *testing.T) {
 // ============================================================
 
 func TestListAndDelete(t *testing.T) {
-	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	handler, _, groupNo := setupTestEnv(t)
 
 	// 创建 2 个
@@ -195,7 +192,6 @@ func TestListAndDelete(t *testing.T) {
 }
 
 func TestRegenerate_RotatesToken(t *testing.T) {
-	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	handler, _, groupNo := setupTestEnv(t)
 	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
 		"name": "x",
@@ -252,7 +248,6 @@ func TestPush_RejectsDisabledWebhook(t *testing.T) {
 }
 
 func TestPush_RejectsTooLargeBody(t *testing.T) {
-	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	// 用 env 把上限收紧到 1KB，让测试与运行时配置共用同一函数（maxBytes()），
 	// 避免在测试里硬编码 8KB 与生产默认值漂移。
 	t.Setenv("DM_INCOMINGWEBHOOK_MAX_BYTES", "1024")
@@ -273,7 +268,6 @@ func TestPush_RejectsTooLargeBody(t *testing.T) {
 }
 
 func TestPush_RejectsEmptyContent(t *testing.T) {
-	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	handler, _, groupNo := setupTestEnv(t)
 	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
 		"name": "x",
@@ -292,7 +286,6 @@ func TestPush_RejectsEmptyContent(t *testing.T) {
 // 把 burst 收紧到 2、rps 收紧到 0.01（10s 补 1 个），连发 3 次，第 3 次必拒。
 // 前两次允许的请求可能因 WuKongIM 投递失败返回 502；这里只断言限流分支。
 func TestPush_PerWebhookRateLimitTriggers429(t *testing.T) {
-	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	t.Setenv("DM_INCOMINGWEBHOOK_BURST", "2")
 	t.Setenv("DM_INCOMINGWEBHOOK_RPS", "0.01")
 
@@ -320,7 +313,6 @@ func TestPush_PerWebhookRateLimitTriggers429(t *testing.T) {
 // TestPush_PerWebhookRateLimitIsPerWebhook 验证一个 webhook 被打满不影响另一个 webhook
 // （限流键空间按 webhook_id 隔离）。
 func TestPush_PerWebhookRateLimitIsPerWebhook(t *testing.T) {
-	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	t.Setenv("DM_INCOMINGWEBHOOK_BURST", "1")
 	t.Setenv("DM_INCOMINGWEBHOOK_RPS", "0.01")
 
@@ -348,7 +340,6 @@ func TestPush_PerWebhookRateLimitIsPerWebhook(t *testing.T) {
 }
 
 func TestPush_RegenerateInvalidatesOldToken(t *testing.T) {
-	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	handler, _, groupNo := setupTestEnv(t)
 	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
 		"name": "x",
@@ -379,12 +370,12 @@ func TestCreate_QuotaEnforced(t *testing.T) {
 		}))
 		assert.Equalf(t, http.StatusOK, w.Code, "i=%d body=%s", i, w.Body.String())
 	}
-	// 第 3 个应当拒绝
+	// 第 3 个应当被配额拒绝：迁移到 typed code 后返回语义化 409 Conflict
+	// （ErrIncomingWebhookQuotaExceeded），不再依赖响应里的中文文案。
 	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
 		"name": "overflow",
 	}))
-	assert.NotEqual(t, http.StatusOK, w.Code)
-	assert.Contains(t, w.Body.String(), "最多")
+	assert.Equalf(t, http.StatusConflict, w.Code, "quota exceeded must be 409: %s", w.Body.String())
 }
 
 // TestCreate_QuotaConcurrent 验证 insertWithQuota 在并发下守住上限。
@@ -429,7 +420,6 @@ func TestCreate_QuotaConcurrent(t *testing.T) {
 // 状态，create / update(启用) / push 三条路径都必须拒绝，杜绝 stale 管理员
 // 在 handleGroupDisband 异步窗口或之后让 webhook 复活。
 func TestDisbandedGroup_FailsClosed(t *testing.T) {
-	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	handler, ctx, groupNo := setupTestEnv(t)
 
 	// 在群 Normal 状态下先建一个 webhook，方便后续测 update / push
@@ -477,7 +467,6 @@ func TestDisbandedGroup_FailsClosed(t *testing.T) {
 }
 
 func TestUpdate_RejectsCrossGroupAccess(t *testing.T) {
-	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	handler, ctx, groupNoA := setupTestEnv(t)
 
 	// 在群 A 创建一个 webhook

--- a/modules/incomingwebhook/db.go
+++ b/modules/incomingwebhook/db.go
@@ -1,6 +1,7 @@
 package incomingwebhook
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -121,11 +122,13 @@ func (d *incomingWebhookDB) deleteByWebhookID(webhookID string) error {
 }
 
 // markUsed 累加调用计数并刷新 last_used_at；非关键路径，调用方应忽略错误（最多记日志）。
-func (d *incomingWebhookDB) markUsed(webhookID string, now time.Time) error {
+// 走 ExecContext：审计在 push 路径的同步兜底分支下跑在请求 goroutine 上，必须受 ctx
+// 超时约束，否则 DB 饱和变慢会无限拖住 push 响应。
+func (d *incomingWebhookDB) markUsed(ctx context.Context, webhookID string, now time.Time) error {
 	_, err := d.session.UpdateBySql(
 		"UPDATE incoming_webhook SET call_count = call_count + 1, last_used_at = ? WHERE webhook_id = ?",
 		now, webhookID,
-	).Exec()
+	).ExecContext(ctx)
 	return err
 }
 
@@ -137,9 +140,10 @@ func (d *incomingWebhookDB) disableByGroupNo(groupNo string) error {
 	return err
 }
 
-func (d *incomingWebhookDB) insertAudit(m *auditModel) error {
+// insertAudit 写一条成功推送审计。同样走 ExecContext，理由见 markUsed。
+func (d *incomingWebhookDB) insertAudit(ctx context.Context, m *auditModel) error {
 	_, err := d.session.InsertInto("incoming_webhook_audit").
 		Columns(util.AttrToUnderscore(m)...).
-		Record(m).Exec()
+		Record(m).ExecContext(ctx)
 	return err
 }

--- a/modules/incomingwebhook/db_test.go
+++ b/modules/incomingwebhook/db_test.go
@@ -1,0 +1,62 @@
+package incomingwebhook
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+
+	// 迁移依赖链：与 api_test.go 一致，缺任一模块 module.Setup 会在跨模块 ALTER 失败。
+	_ "github.com/Mininglamp-OSS/octo-server/modules/base"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/common"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/group"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/robot"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/space"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/user"
+)
+
+// TestDisableByGroupNo 验证群解散级联禁用的 DB 层语义：disableByGroupNo 把指定群下
+// 所有 webhook 的 status 翻 0，且不影响其他群。这是 #246 列出的便宜回归——只验 DB
+// 层（disband fail-closed 的核心），不依赖完整 HTTP / 鉴权 harness（那部分仍 gated
+// 在 #17 上）。
+func TestDisableByGroupNo(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+	d := newDB(ctx)
+
+	groupA := "g_" + util.GenerUUID()[:12]
+	groupB := "g_" + util.GenerUUID()[:12]
+
+	// groupA：两个启用 webhook；groupB：一个启用 webhook（对照，验证不被误伤）。
+	mustInsertWebhook(t, d, groupA)
+	mustInsertWebhook(t, d, groupA)
+	bID := mustInsertWebhook(t, d, groupB)
+
+	assert.NoError(t, d.disableByGroupNo(groupA))
+
+	listA, err := d.queryByGroupNo(groupA)
+	assert.NoError(t, err)
+	assert.Len(t, listA, 2)
+	for _, m := range listA {
+		assert.Equalf(t, 0, m.Status, "groupA webhook %s must be disabled", m.WebhookID)
+	}
+
+	mb, err := d.queryByWebhookID(bID)
+	assert.NoError(t, err)
+	assert.NotNil(t, mb)
+	assert.Equal(t, 1, mb.Status, "groupB webhook must stay enabled (no cross-group impact)")
+}
+
+func mustInsertWebhook(t *testing.T, d *incomingWebhookDB, groupNo string) string {
+	t.Helper()
+	m := &incomingWebhookModel{
+		WebhookID: generateWebhookID(),
+		TokenHash: "h",
+		GroupNo:   groupNo,
+		Name:      "wh",
+		Status:    1,
+	}
+	assert.NoError(t, d.insertWithQuota(m, 100))
+	return m.WebhookID
+}

--- a/modules/incomingwebhook/sql/20260604000001_incomingwebhook_audit_created_at_index.sql
+++ b/modules/incomingwebhook/sql/20260604000001_incomingwebhook_audit_created_at_index.sql
@@ -1,0 +1,13 @@
+-- +migrate Up
+
+-- 审计表 TTL 清理（计划中的 DELETE ... WHERE created_at < ?）需要 created_at 单列
+-- 前导索引。原 idx_iwa_webhook_time(webhook_id, created_at) 的前导列是 webhook_id，
+-- TTL 删除没有 webhook_id 等值条件，命中不了该索引，会退化成全表扫。补一条 created_at
+-- 单列索引专供按时间批量清理使用。
+-- 目标库为 MySQL 8.0：ADD INDEX 默认即 INPLACE 在线建索引、不锁表，无需显式 pin。
+ALTER TABLE `incoming_webhook_audit`
+  ADD INDEX `idx_iwa_created` (`created_at`);
+
+-- +migrate Down
+ALTER TABLE `incoming_webhook_audit`
+  DROP INDEX `idx_iwa_created`;

--- a/modules/incomingwebhook/util_test.go
+++ b/modules/incomingwebhook/util_test.go
@@ -1,6 +1,7 @@
 package incomingwebhook
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -65,15 +66,15 @@ func TestBuildPayload_DropsAllExtra(t *testing.T) {
 	req := &pushPayloadReq{
 		Content: "real",
 		Extra: map[string]interface{}{
-			"visibles":   []string{"attacker_uid"}, // 关键：访问控制字段必须被丢弃
-			"mention":    map[string]interface{}{"all": true},
-			"reminder":   "fake",
-			"link":       "https://x",
-			"type":       9999,
-			"content":    "fake",
-			"from":       "fake",
-			"space_id":   "forged",
-			"anything":   "else",
+			"visibles": []string{"attacker_uid"}, // 关键：访问控制字段必须被丢弃
+			"mention":  map[string]interface{}{"all": true},
+			"reminder": "fake",
+			"link":     "https://x",
+			"type":     9999,
+			"content":  "fake",
+			"from":     "fake",
+			"space_id": "forged",
+			"anything": "else",
 		},
 	}
 	p := buildPayload(m, req)
@@ -146,6 +147,32 @@ func TestBuildPayload_TruncateRespectsUTF8(t *testing.T) {
 	gotName := from["name"].(string)
 	assert.LessOrEqualf(t, len(gotName), 64, "byte length capped; got %d", len(gotName))
 	assert.Truef(t, utf8.ValidString(gotName), "truncated name must remain valid UTF-8; got %q", gotName)
+}
+
+// TestTruncateUTF8_FallthroughReturnsEmpty 锁定 max 落在首 rune 内部时的兜底：
+// 返回空串而非切出半个 rune（破坏 UTF-8）。中文 3 字节，max=2 无回退边界。
+func TestTruncateUTF8_FallthroughReturnsEmpty(t *testing.T) {
+	got := truncateUTF8("一二三", 2) // 首 rune 宽 3 > max=2，无 rune 边界可回退
+	assert.Equal(t, "", got, "must return empty, never a half rune")
+	assert.True(t, utf8.ValidString(got))
+}
+
+// TestToResp_NeverLeaksToken 是 #246 的便宜安全回归：对外响应结构体 webhookResp
+// 永远不得包含 token / token_hash 字段。即便 model 持有 TokenHash，序列化后的
+// JSON 也不能出现该哈希或 token 关键字。
+func TestToResp_NeverLeaksToken(t *testing.T) {
+	const secretHash = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	m := &incomingWebhookModel{
+		WebhookID: "iwh_x",
+		TokenHash: secretHash,
+		GroupNo:   "g_1",
+		Name:      "WH",
+	}
+	raw, err := json.Marshal(toResp(m))
+	assert.NoError(t, err)
+	s := string(raw)
+	assert.NotContainsf(t, s, secretHash, "response must not contain token_hash: %s", s)
+	assert.NotContainsf(t, s, "token", "response must not contain any token field/key: %s", s)
 }
 
 func TestPublicURL(t *testing.T) {

--- a/pkg/accesslog/accesslog.go
+++ b/pkg/accesslog/accesslog.go
@@ -1,0 +1,121 @@
+// Package accesslog provides a gin access-log formatter that scrubs secrets
+// embedded in request URL paths before they are written to logs.
+//
+// Motivation: the incoming-webhook push route is /v1/incoming-webhooks/
+// {webhook_id}/{token} — a Discord-style URL with a PLAINTEXT bearer token in
+// the path (#246). gin's default access logger writes the full request path,
+// which would persist live tokens into access logs. Formatter mirrors gin's
+// default line format exactly but masks the token segment.
+package accesslog
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	// maskedToken replaces a plaintext token segment in logged paths.
+	maskedToken = "***"
+	// incomingWebhookPrefix is the push route whose trailing path segment is a
+	// plaintext webhook token.
+	incomingWebhookPrefix = "/v1/incoming-webhooks/"
+)
+
+// ScrubPath masks secrets embedded in a request path before it is logged.
+//
+// It targets the incoming-webhook push route
+// /v1/incoming-webhooks/{webhook_id}/{token}: the trailing {token} segment (and
+// anything after it, e.g. a stray query string) is replaced with "***". The
+// non-secret {webhook_id} is preserved so logs remain useful for correlation.
+// Any path without the prefix, or with no token segment, is returned unchanged.
+//
+// The prefix match is case-INSENSITIVE: gin logs c.Request.URL.Path verbatim
+// for every request including 404s (the access logger runs after c.Next()
+// regardless of route match), so a request to /V1/INCOMING-WEBHOOKS/... that
+// 404s on the case-sensitive router would otherwise still log the token
+// unmasked. Scrubbing is the security control here, so it must survive
+// path-casing variants. Original casing of the prefix/webhook_id is preserved
+// in the output; only the token segment is replaced.
+func ScrubPath(path string) string {
+	if len(path) < len(incomingWebhookPrefix) ||
+		!strings.EqualFold(path[:len(incomingWebhookPrefix)], incomingWebhookPrefix) {
+		return path
+	}
+	rest := path[len(incomingWebhookPrefix):]
+	// rest == "{webhook_id}/{token}[?query]". The token is everything after the
+	// first '/'. No '/' means only {webhook_id} is present — nothing to mask.
+	slash := strings.IndexByte(rest, '/')
+	if slash < 0 {
+		return path
+	}
+	return path[:len(incomingWebhookPrefix)] + rest[:slash] + "/" + maskedToken
+}
+
+// tokenInText matches a webhook push path embedded anywhere in free-form log
+// text and captures the prefix up to and including the webhook_id segment; the
+// trailing token segment is everything up to the next whitespace / quote / ? .
+// Used to scrub tokens from the gin.Recovery panic dump, which writes the full
+// request line (httputil.DumpRequest) including the token-bearing path.
+// Case-insensitive ((?i)) for the same reason as ScrubPath — a non-canonical
+// path casing must not slip a token past the mask.
+var tokenInText = regexp.MustCompile(`(?i)(/v1/incoming-webhooks/[^/\s?"']+/)[^\s?"']+`)
+
+// scrubbingErrorWriter wraps an io.Writer and masks incoming-webhook tokens in
+// everything written through it. ScrubPath only covers the access-log line;
+// this covers the OTHER sink — gin.Recovery's panic dump, which bypasses the
+// access logger entirely and would otherwise persist a plaintext token on any
+// panic while serving the push route (#246).
+type scrubbingErrorWriter struct{ w io.Writer }
+
+// NewErrorWriter wraps w so that incoming-webhook tokens are masked before they
+// reach it. Assign it to gin.DefaultErrorWriter BEFORE the recovery middleware
+// is registered (gin.Recovery captures DefaultErrorWriter at registration time).
+func NewErrorWriter(w io.Writer) io.Writer { return scrubbingErrorWriter{w: w} }
+
+// Write masks tokens in p and forwards it. INVARIANT: the regex runs on each p
+// independently with no carry-over buffer, so it assumes a token never splits
+// across two Write calls. This holds for the only current caller —
+// gin.Recovery → log.Logger.Output assembles the whole panic message (with the
+// token-bearing request line from httputil.DumpRequest embedded) into a single
+// Write. A future caller that writes in chunks (io.Copy, a chunked middleware)
+// could split a token across Writes and bypass the mask; if that becomes a
+// possibility, buffer until newline here.
+func (s scrubbingErrorWriter) Write(p []byte) (int, error) {
+	scrubbed := tokenInText.ReplaceAll(p, []byte("${1}***"))
+	if _, err := s.w.Write(scrubbed); err != nil {
+		return 0, err
+	}
+	// Report the original length: all of p was consumed (the byte-count change
+	// from masking is internal and must not look like a short write).
+	return len(p), nil
+}
+
+// Formatter is a gin.LogFormatter that reproduces gin's default access-log line
+// byte-for-byte except the request path is run through ScrubPath. Wire it via
+// gin.LoggerWithFormatter(accesslog.Formatter).
+func Formatter(param gin.LogFormatterParams) string {
+	var statusColor, methodColor, resetColor string
+	if param.IsOutputColor() {
+		statusColor = param.StatusCodeColor()
+		methodColor = param.MethodColor()
+		resetColor = param.ResetColor()
+	}
+
+	if param.Latency > time.Minute {
+		param.Latency = param.Latency.Truncate(time.Second)
+	}
+	return fmt.Sprintf("[GIN] %v |%s %3d %s| %13v | %15s |%s %-7s %s %#v\n%s",
+		param.TimeStamp.Format("2006/01/02 - 15:04:05"),
+		statusColor, param.StatusCode, resetColor,
+		param.Latency,
+		param.ClientIP,
+		methodColor, param.Method, resetColor,
+		ScrubPath(param.Path),
+		param.ErrorMessage,
+	)
+}

--- a/pkg/accesslog/accesslog_test.go
+++ b/pkg/accesslog/accesslog_test.go
@@ -1,0 +1,155 @@
+package accesslog
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestScrubPath(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "push path masks token, keeps webhook_id",
+			in:   "/v1/incoming-webhooks/iwh_abc123/deadbeefcafetoken",
+			want: "/v1/incoming-webhooks/iwh_abc123/***",
+		},
+		{
+			name: "push path with trailing query is fully masked after id",
+			in:   "/v1/incoming-webhooks/iwh_abc123/secrettoken?foo=bar",
+			want: "/v1/incoming-webhooks/iwh_abc123/***",
+		},
+		{
+			name: "uppercase prefix still masks token (case-insensitive), original case kept",
+			in:   "/V1/INCOMING-WEBHOOKS/iwh_abc123/secrettoken",
+			want: "/V1/INCOMING-WEBHOOKS/iwh_abc123/***",
+		},
+		{
+			name: "mixed-case prefix still masks token",
+			in:   "/v1/Incoming-Webhooks/iwh_abc123/secrettoken",
+			want: "/v1/Incoming-Webhooks/iwh_abc123/***",
+		},
+		{
+			name: "webhook_id only, no token segment, unchanged",
+			in:   "/v1/incoming-webhooks/iwh_abc123",
+			want: "/v1/incoming-webhooks/iwh_abc123",
+		},
+		{
+			name: "management route is not a push path, unchanged",
+			in:   "/v1/groups/g_1/incoming-webhooks",
+			want: "/v1/groups/g_1/incoming-webhooks",
+		},
+		{
+			name: "unrelated path unchanged",
+			in:   "/v1/message/send",
+			want: "/v1/message/send",
+		},
+		{
+			name: "empty path unchanged",
+			in:   "",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ScrubPath(tt.in); got != tt.want {
+				t.Fatalf("ScrubPath(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestScrubPath_NeverLeaksToken guards the security invariant: for any push
+// path, the plaintext token must not survive scrubbing.
+func TestScrubPath_NeverLeaksToken(t *testing.T) {
+	const token = "S3cr3tT0k3nMustNotLeak"
+	got := ScrubPath("/v1/incoming-webhooks/iwh_xyz/" + token)
+	if strings.Contains(got, token) {
+		t.Fatalf("scrubbed path %q still contains the token", got)
+	}
+}
+
+// TestErrorWriter_ScrubsPanicDump simulates gin.Recovery's panic dump (a full
+// HTTP request line via httputil.DumpRequest) and asserts the token is masked
+// while the rest of the text passes through unchanged.
+func TestErrorWriter_ScrubsPanicDump(t *testing.T) {
+	const token = "deadbeefTOKENmustNotLeak"
+	var buf bytes.Buffer
+	w := NewErrorWriter(&buf)
+
+	dump := "[Recovery] panic recovered:\n" +
+		"POST /v1/incoming-webhooks/iwh_abc/" + token + " HTTP/1.1\r\n" +
+		"Host: example\r\n"
+	n, err := w.Write([]byte(dump))
+	if err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	if n != len(dump) {
+		t.Fatalf("Write returned n=%d, want %d (must report full consumption)", n, len(dump))
+	}
+	got := buf.String()
+	if strings.Contains(got, token) {
+		t.Fatalf("panic dump still leaks token: %q", got)
+	}
+	if !strings.Contains(got, "/v1/incoming-webhooks/iwh_abc/***") {
+		t.Fatalf("expected masked path in dump, got: %q", got)
+	}
+	if !strings.Contains(got, "Host: example") {
+		t.Fatalf("non-token content must pass through unchanged, got: %q", got)
+	}
+}
+
+// TestErrorWriter_ScrubsUppercasePath asserts the panic-dump scrubber is also
+// case-insensitive (a non-canonical path casing must not leak the token).
+func TestErrorWriter_ScrubsUppercasePath(t *testing.T) {
+	const token = "UPPERtokenLEAK"
+	var buf bytes.Buffer
+	w := NewErrorWriter(&buf)
+	if _, err := w.Write([]byte("POST /V1/INCOMING-WEBHOOKS/iwh_x/" + token + " HTTP/1.1\r\n")); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	if strings.Contains(buf.String(), token) {
+		t.Fatalf("uppercase-path panic dump leaks token: %q", buf.String())
+	}
+}
+
+// TestErrorWriter_PassesThroughUnrelated ensures unrelated text is written
+// byte-for-byte (no accidental mutation).
+func TestErrorWriter_PassesThroughUnrelated(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewErrorWriter(&buf)
+	const text = "GET /v1/message/send HTTP/1.1\r\nplain panic stack frame\n"
+	if _, err := w.Write([]byte(text)); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	if buf.String() != text {
+		t.Fatalf("unrelated text mutated: got %q want %q", buf.String(), text)
+	}
+}
+
+// TestFormatter_ScrubsToken asserts the wired formatter masks the token in the
+// rendered access-log line.
+func TestFormatter_ScrubsToken(t *testing.T) {
+	gin.DisableConsoleColor()
+	const token = "tok_DEADBEEF"
+	line := Formatter(gin.LogFormatterParams{
+		TimeStamp:  time.Unix(0, 0).UTC(),
+		StatusCode: 200,
+		Latency:    time.Millisecond,
+		ClientIP:   "127.0.0.1",
+		Method:     "POST",
+		Path:       "/v1/incoming-webhooks/iwh_1/" + token,
+	})
+	if strings.Contains(line, token) {
+		t.Fatalf("formatted log line leaks token: %q", line)
+	}
+	if !strings.Contains(line, "/v1/incoming-webhooks/iwh_1/***") {
+		t.Fatalf("formatted log line missing masked path: %q", line)
+	}
+}

--- a/pkg/errcode/incomingwebhook.go
+++ b/pkg/errcode/incomingwebhook.go
@@ -13,8 +13,13 @@ import (
 // The push endpoint is an unauthenticated, token-in-URL surface. Every
 // authentication failure (missing/disabled webhook, bad token, disbanded
 // group) intentionally collapses to the SINGLE push_unauthorized code with a
-// uniform message, so a probe cannot tell "no such webhook" from "wrong token"
-// — see modules/incomingwebhook/api.go respondPushUnauthorized. Migrated off
+// uniform RESPONSE (same code/message/status), so a probe cannot distinguish
+// "no such webhook" from "wrong token" by the response body. Timing is only
+// best-effort, not constant: not-found returns before any hash, wrong-token
+// pays the SHA-256 compare, valid-token+dead-group pays an extra DB round-trip.
+// The 128-bit unguessable webhook_id plus per-IP rate limit make timing-based
+// enumeration impractical; the response-uniformity is the primary defense.
+// See modules/incomingwebhook/api.go pushUnauthorized. Migrated off
 // the raw c.AbortWithStatusJSON pattern to satisfy the D23 i18n lint gate
 // (PR Mininglamp-OSS/octo-server#31, yujiawei review #3).
 var (
@@ -58,6 +63,77 @@ var (
 		ID:             "err.server.incomingwebhook.push_delivery_failed",
 		HTTPStatus:     http.StatusBadGateway,
 		DefaultMessage: "Failed to deliver the webhook message.",
+		Internal:       true,
+	})
+)
+
+// err.server.incomingwebhook.mgmt_* — management-endpoint error codes
+// (create / list / update / delete / regenerate in modules/incomingwebhook/
+// api.go). These are authenticated, admin-only endpoints with no legacy
+// clients, so — like the push path — they are rendered via
+// httperr.ResponseErrorLWithStatus and keep their real semantic HTTP status
+// (403/404/409/400/500). This replaces the legacy raw-string
+// c.ResponseError(errors.New(...)) pattern (#246 follow-up).
+var (
+	// ErrIncomingWebhookForbidden (403) — caller is neither group owner nor
+	// admin; the only role allowed to manage a group's webhooks.
+	ErrIncomingWebhookForbidden = register(codes.Code{
+		ID:             "err.server.incomingwebhook.mgmt_forbidden",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Only the group owner or an admin can manage webhooks.",
+	})
+
+	// ErrIncomingWebhookRequestInvalid (400) — malformed body or invalid field
+	// (blank/over-long name, status not in {0,1}). The offending field is
+	// surfaced via Details["reason"] (body / name / status).
+	ErrIncomingWebhookRequestInvalid = register(codes.Code{
+		ID:             "err.server.incomingwebhook.mgmt_request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid request.",
+		SafeDetailKeys: []string{"reason"},
+	})
+
+	// ErrIncomingWebhookGroupNotFound (404) — group does not exist or is no
+	// longer Normal (disbanded/disabled). Blocks create / enable / regenerate
+	// from reviving webhooks on a dead group.
+	ErrIncomingWebhookGroupNotFound = register(codes.Code{
+		ID:             "err.server.incomingwebhook.mgmt_group_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "The group does not exist or has been disbanded.",
+	})
+
+	// ErrIncomingWebhookNotFound (404) — webhook does not exist or does not
+	// belong to the group in the path (cross-group guard).
+	ErrIncomingWebhookNotFound = register(codes.Code{
+		ID:             "err.server.incomingwebhook.mgmt_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "The webhook does not exist.",
+	})
+
+	// ErrIncomingWebhookQuotaExceeded (409) — the group already holds the
+	// maximum number of webhooks. Params["max"] carries the configured cap.
+	ErrIncomingWebhookQuotaExceeded = register(codes.Code{
+		ID:             "err.server.incomingwebhook.mgmt_quota_exceeded",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "Each group allows at most {{.max}} webhooks.",
+	})
+
+	// ErrIncomingWebhookQueryFailed (500, Internal) — a read (group / webhook /
+	// list / permission) failed; the underlying error is logged, not surfaced.
+	ErrIncomingWebhookQueryFailed = register(codes.Code{
+		ID:             "err.server.incomingwebhook.mgmt_query_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to query webhook information.",
+		Internal:       true,
+	})
+
+	// ErrIncomingWebhookOperationFailed (500, Internal) — a write
+	// (create / update / delete / regenerate / token generation) failed; the
+	// underlying error is logged, not surfaced.
+	ErrIncomingWebhookOperationFailed = register(codes.Code{
+		ID:             "err.server.incomingwebhook.mgmt_operation_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "The operation failed. Please try again later.",
 		Internal:       true,
 	})
 )

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -665,3 +665,26 @@ other = "请求内容过大。"
 
 ["err.server.incomingwebhook.push_delivery_failed"]
 other = "Webhook 消息投递失败。"
+
+# ---- err.server.incomingwebhook.mgmt_* (management endpoints, #246 follow-up) ----
+
+["err.server.incomingwebhook.mgmt_forbidden"]
+other = "仅群主或管理员可管理 webhook。"
+
+["err.server.incomingwebhook.mgmt_request_invalid"]
+other = "请求参数无效。"
+
+["err.server.incomingwebhook.mgmt_group_not_found"]
+other = "群不存在或已解散。"
+
+["err.server.incomingwebhook.mgmt_not_found"]
+other = "webhook 不存在。"
+
+["err.server.incomingwebhook.mgmt_quota_exceeded"]
+other = "每个群最多 {{.max}} 个 webhook。"
+
+["err.server.incomingwebhook.mgmt_query_failed"]
+other = "查询 webhook 信息失败。"
+
+["err.server.incomingwebhook.mgmt_operation_failed"]
+other = "操作失败，请稍后再试。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -168,6 +168,27 @@ other = "The target user does not exist or has been deactivated."
 ["err.server.group.view_forbidden"]
 other = "You do not have permission to view this."
 
+["err.server.incomingwebhook.mgmt_forbidden"]
+other = "Only the group owner or an admin can manage webhooks."
+
+["err.server.incomingwebhook.mgmt_group_not_found"]
+other = "The group does not exist or has been disbanded."
+
+["err.server.incomingwebhook.mgmt_not_found"]
+other = "The webhook does not exist."
+
+["err.server.incomingwebhook.mgmt_operation_failed"]
+other = "The operation failed. Please try again later."
+
+["err.server.incomingwebhook.mgmt_query_failed"]
+other = "Failed to query webhook information."
+
+["err.server.incomingwebhook.mgmt_quota_exceeded"]
+other = "Each group allows at most {{.max}} webhooks."
+
+["err.server.incomingwebhook.mgmt_request_invalid"]
+other = "Invalid request."
+
 ["err.server.incomingwebhook.push_delivery_failed"]
 other = "Failed to deliver the webhook message."
 


### PR DESCRIPTION
## Summary

Addresses the non-blocking post-merge follow-ups for the incoming-webhooks feature (#31), tracked in #246. These are hardening, error-handling-consistency, security, and test-coverage improvements — none of them is a current defect.

## Error-handling consistency

- Migrate the management endpoints (`create` / `list` / `update` / `delete` / `regenerate` + `requireGroupAdmin`) off the legacy `c.ResponseError(errors.New(...))` pattern to typed i18n codes rendered via `ResponseErrorLWithStatus`, keeping semantic HTTP status (403/404/409/400/500). Adds `mgmt_*` codes in `pkg/errcode/incomingwebhook.go` and their zh-CN translations.

## Hardening / robustness

- `truncateUTF8`: return `""` on the half-rune fall-through instead of cutting mid-rune (robust against future sub-rune caps).
- `create`: document that the push-path `requireActiveGroup` recheck is the authoritative gate, so the create-time status read needs no in-tx re-read (TOCTOU note).
- Bound the async audit (`recordSuccess`) behind a semaphore (`DM_INCOMINGWEBHOOK_AUDIT_CONCURRENCY`, default 64); on overflow the audit is **dropped** (it is non-critical — failures only log), so total audit DB concurrency stays bounded and a push flood under a Redis outage (limiters fail open) can't pressure the connection pool. `markUsed`/`insertAudit` run via `ExecContext` under a 3s deadline that caps each detached audit goroutine's DB-connection hold time.
- Add an explicit rune-based content length cap (`DM_INCOMINGWEBHOOK_MAX_CONTENT_RUNES`, default 4000) on the push path; over-cap returns 413.
- Add `INDEX(created_at)` on `incoming_webhook_audit` so the planned TTL `DELETE ... WHERE created_at < ?` does not table-scan.
- Soften the anti-probe comment to "response-uniform / best-effort timing".

## Security: token in access logs

- Scrub the plaintext webhook token from gin access logs via a custom `LogFormatter` (`pkg/accesslog`). The push route carries the token in the URL path (`/v1/incoming-webhooks/{webhook_id}/{token}`, by design for Discord compatibility) and gin's default logger would persist it. The formatter reproduces gin's default line byte-for-byte but masks the token segment, preserving the non-secret `webhook_id` for correlation.

## Tests

- DB-level `disableByGroupNo` (disband fail-closed core).
- `toResp` never leaks `token` / `token_hash`.
- `truncateUTF8` half-rune fall-through.
- `accesslog` `ScrubPath` / `Formatter` token masking (incl. a never-leaks-token invariant).
- **Unskip the 11 incoming-webhook integration tests** previously gated on the #17 test-infra debt: cross-group IDOR, non-admin 403, disband fail-closed, token rotation, per-webhook rate limit, and payload limits. The skip root cause was CI infra not being ready at #31 time, not the tests themselves — they are this module's own tests and pass under `-race -count=2`. The broader #17 cleanup of other modules' skipped tests is unaffected.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...` (changed packages) + `gofmt`
- [x] `go test -race -count=2 ./modules/incomingwebhook/` — 30 tests, all pass, no flakiness
- [x] `go test ./pkg/i18n/... ./pkg/errcode/... ./pkg/accesslog/... ./pkg/httperr/...`
- [x] Verified the quota `{{.max}}` template renders through the real i18n localizer (first templated zh-CN entry)

## Not in scope (intentionally left in #246)

- MySQL-outage 401 storm alert: an ops-side alerting rule (the push path masks DB errors as 401 for anti-probe). The code-side signal already exists — the `query webhook failed` / `query group on push failed` ERROR logs carry `webhook_id` — so this is a monitoring-config follow-up, not a code change.

Closes #246

