### PR TITLE
fix(incomingwebhook): resolve iwh_ sender identity for channel/user/avatar APIs

### DIFF
--- a/modules/incomingwebhook/1module.go
+++ b/modules/incomingwebhook/1module.go
@@ -13,8 +13,9 @@ var sqlFS embed.FS
 func init() {
 	register.AddModule(func(ctx interface{}) register.Module {
 		x := ctx.(*config.Context)
-		// datasource 只需读 incoming_webhook 表，用独立轻量 db session 即可，
-		// 不必提前构造完整 API（避免在注册阶段建 redis 等重资源）。
+		// datasource 只需读 incoming_webhook 表，用 ctx.DB()（进程级共享、mysqlOnce
+		// 守卫的 session）构造一个轻量 db handle 即可，不必提前构造完整 API（避免在
+		// 注册阶段就建 redis 等重资源）。
 		d := newDB(x)
 		return register.Module{
 			Name: "incomingwebhook",

--- a/modules/incomingwebhook/1module.go
+++ b/modules/incomingwebhook/1module.go
@@ -12,12 +12,21 @@ var sqlFS embed.FS
 
 func init() {
 	register.AddModule(func(ctx interface{}) register.Module {
+		x := ctx.(*config.Context)
+		// datasource 只需读 incoming_webhook 表，用独立轻量 db session 即可，
+		// 不必提前构造完整 API（避免在注册阶段建 redis 等重资源）。
+		d := newDB(x)
 		return register.Module{
 			Name: "incomingwebhook",
 			SetupAPI: func() register.APIRouter {
-				return New(ctx.(*config.Context))
+				return New(x)
 			},
 			SQLDir: register.NewSQLFS(sqlFS),
+			// 让 webhook 合成身份（iwh_）能被 /v1/channels/:id/:type 与 /v1/users/:uid
+			// 解析为发送者名/头像，客户端无需适配即可渲染。
+			BussDataSource: register.BussDataSource{
+				ChannelGet: newChannelGetDatasource(d),
+			},
 		}
 	})
 }

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -216,9 +216,9 @@ func generateWebhookID() string {
 	buf := make([]byte, 16)
 	if _, err := rand.Read(buf); err != nil {
 		// crypto/rand 失败概率极低；退化到 UUID 仍可保证唯一性。
-		return "iwh_" + strings.ReplaceAll(util.GenerUUID(), "-", "")
+		return webhookIDPrefix + strings.ReplaceAll(util.GenerUUID(), "-", "")
 	}
-	return "iwh_" + hex.EncodeToString(buf)
+	return webhookIDPrefix + hex.EncodeToString(buf)
 }
 
 func toResp(m *incomingWebhookModel) webhookResp {

--- a/modules/incomingwebhook/display.go
+++ b/modules/incomingwebhook/display.go
@@ -1,0 +1,83 @@
+package incomingwebhook
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/model"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
+)
+
+// webhookIDPrefix 是 incoming webhook 合成发送者 UID 的固定前缀（形如 iwh_xxx）。
+// 它既是 webhook 的公开 ID，也作为消息 FromUID。客户端把它当普通用户去查
+// /v1/channels、/v1/users、/v1/users/:uid/avatar 时，服务端据此前缀识别并兜底，
+// 避免"用户信息不存在/500/头像裂图"。
+const webhookIDPrefix = "iwh_"
+
+// ChannelResp.Extra 里下发的 key 约定。user 模块的头像端点据 ExtraAvatarKey 取原始
+// avatar URL 做重定向；契约在两侧各自定义同名常量（user 模块不 import 本上层模块）。
+const (
+	extraKindKey   = "kind"           // 固定为 "webhook"，便于客户端识别非真实用户
+	extraAvatarKey = "webhook_avatar" // webhook 创建时填写的原始头像 URL（可能为空）
+	extraGroupKey  = "group_no"       // webhook 归属群
+	extraKindValue = "webhook"
+)
+
+// defaultWebhookDisplayName 当 webhook 未设置名称时的兜底展示名。
+const defaultWebhookDisplayName = "Webhook"
+
+// isWebhookUID 判断 uid 是否为 incoming webhook 合成身份。
+func isWebhookUID(uid string) bool {
+	return strings.HasPrefix(uid, webhookIDPrefix)
+}
+
+// webhookDisplayName 返回 webhook 的展示名，空名兜底到 defaultWebhookDisplayName。
+func webhookDisplayName(m *incomingWebhookModel) string {
+	if name := strings.TrimSpace(m.Name); name != "" {
+		return name
+	}
+	return defaultWebhookDisplayName
+}
+
+// newWebhookChannelResp 把 webhook 记录合成为单聊频道详情，供 /v1/channels/:id/:type
+// 与 /v1/users/:uid 渲染发送者名/头像。
+//
+// Logo 故意采用与真实用户一致的相对路径 users/{uid}/avatar，让客户端继续走头像端点；
+// 原始 avatar URL 放进 Extra[extraAvatarKey]，由头像端点决定重定向或回退默认图。
+// 绝不下发 token / token_hash。
+func newWebhookChannelResp(m *incomingWebhookModel) *model.ChannelResp {
+	resp := &model.ChannelResp{}
+	resp.Channel.ChannelID = m.WebhookID
+	resp.Channel.ChannelType = common.ChannelTypePerson.Uint8()
+	resp.Name = webhookDisplayName(m)
+	resp.Logo = fmt.Sprintf("users/%s/avatar", m.WebhookID)
+	resp.Category = extraKindValue
+	resp.Status = 1
+	resp.Extra = map[string]interface{}{
+		extraKindKey:   extraKindValue,
+		extraAvatarKey: m.Avatar,
+		extraGroupKey:  m.GroupNo,
+	}
+	return resp
+}
+
+// newChannelGetDatasource 构造 incomingwebhook 模块的 BussDataSource.ChannelGet：
+//   - 仅处理"单聊 + iwh_ 前缀"，其余一律返回 ErrDatasourceNotProcess 交还链路；
+//   - webhook 已删除（记录不存在）时同样返回 ErrDatasourceNotProcess，最终由上层
+//     优雅回落到"频道不存在/未知发送者"，不报 500。
+func newChannelGetDatasource(d *incomingWebhookDB) func(channelID string, channelType uint8, loginUID string) (*model.ChannelResp, error) {
+	return func(channelID string, channelType uint8, _ string) (*model.ChannelResp, error) {
+		if channelType != common.ChannelTypePerson.Uint8() || !isWebhookUID(channelID) {
+			return nil, register.ErrDatasourceNotProcess
+		}
+		m, err := d.queryByWebhookID(channelID)
+		if err != nil {
+			return nil, fmt.Errorf("incomingwebhook: query webhook for channel get: %w", err)
+		}
+		if m == nil {
+			return nil, register.ErrDatasourceNotProcess
+		}
+		return newWebhookChannelResp(m), nil
+	}
+}

--- a/modules/incomingwebhook/display.go
+++ b/modules/incomingwebhook/display.go
@@ -15,12 +15,21 @@ import (
 // 避免"用户信息不存在/500/头像裂图"。
 const webhookIDPrefix = "iwh_"
 
-// ChannelResp.Extra 里下发的 key 约定。user 模块的头像端点据 ExtraAvatarKey 取原始
+// WebhookIDPrefix / ExtraAvatarKey 是导出的契约常量别名，仅供其它模块的【测试】校验
+// 跨包常量一致性（见 modules/user 的一致性测试）。生产代码请勿跨层 import 本（上层）
+// 模块——user 侧本地复制同值常量以保持分层方向，编译期不可见的漂移由该测试兜底。
+const (
+	WebhookIDPrefix = webhookIDPrefix
+	ExtraAvatarKey  = extraAvatarKey
+)
+
+// ChannelResp.Extra 里下发的 key 约定。user 模块的头像端点据 extraAvatarKey 取原始
 // avatar URL 做重定向；契约在两侧各自定义同名常量（user 模块不 import 本上层模块）。
+// 刻意不下发 group_no：渲染发送者名/头像不需要它，且避免任意登录用户据 iwh_ 反查到
+// webhook 归属群（租户信息最小暴露，PR #250 review）。
 const (
 	extraKindKey   = "kind"           // 固定为 "webhook"，便于客户端识别非真实用户
 	extraAvatarKey = "webhook_avatar" // webhook 创建时填写的原始头像 URL（可能为空）
-	extraGroupKey  = "group_no"       // webhook 归属群
 	extraKindValue = "webhook"
 )
 
@@ -53,11 +62,14 @@ func newWebhookChannelResp(m *incomingWebhookModel) *model.ChannelResp {
 	resp.Name = webhookDisplayName(m)
 	resp.Logo = fmt.Sprintf("users/%s/avatar", m.WebhookID)
 	resp.Category = extraKindValue
+	// Status 固定 1（ChannelResp 语义 0/1 均为"正常"，2 才是黑名单）。webhook 的展示
+	// 身份刻意不反映 enabled/disabled：历史消息无论 webhook 当前是否被禁用（群解散会
+	// disable 而非 delete）都需渲染出发送者名/头像；推送鉴权在 push 路径独立 gate
+	// m.Status，与展示互不影响（PR #250 review，deliberate divergence）。
 	resp.Status = 1
 	resp.Extra = map[string]interface{}{
 		extraKindKey:   extraKindValue,
 		extraAvatarKey: m.Avatar,
-		extraGroupKey:  m.GroupNo,
 	}
 	return resp
 }

--- a/modules/incomingwebhook/display_test.go
+++ b/modules/incomingwebhook/display_test.go
@@ -4,8 +4,17 @@ import (
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/stretchr/testify/assert"
 )
+
+// TestWebhookContractConstantsInSyncWithUser 把 user 模块本地复制的契约常量与本模块的
+// 源头常量在测试期绑定。user 不能跨层 import 本（上层）模块，故无法在生产代码做编译期
+// tie；本测试是防漂移兜底（PR #250 review P2）。
+func TestWebhookContractConstantsInSyncWithUser(t *testing.T) {
+	assert.Equal(t, webhookIDPrefix, user.WebhookUIDPrefix, "iwh_ prefix drifted between modules")
+	assert.Equal(t, extraAvatarKey, user.WebhookExtraAvatarKey, "webhook_avatar extra key drifted between modules")
+}
 
 func TestIsWebhookUID(t *testing.T) {
 	assert.True(t, isWebhookUID("iwh_d1fc093bc19c8a7fca754bcf607562d3"))
@@ -39,7 +48,9 @@ func TestNewWebhookChannelResp(t *testing.T) {
 	assert.Equal(t, 1, resp.Status)
 	assert.Equal(t, extraKindValue, resp.Extra[extraKindKey])
 	assert.Equal(t, "https://example.com/a.png", resp.Extra[extraAvatarKey])
-	assert.Equal(t, "g_123", resp.Extra[extraGroupKey])
+	// group_no 刻意不下发（最小暴露租户信息）。
+	_, hasGroup := resp.Extra["group_no"]
+	assert.False(t, hasGroup, "group_no must not be exposed in webhook channel detail")
 	// token_hash 绝不能进入对外频道详情。
 	for k, v := range resp.Extra {
 		assert.NotEqualf(t, "SECRET_SHOULD_NOT_LEAK", v, "token leaked via extra[%s]", k)

--- a/modules/incomingwebhook/display_test.go
+++ b/modules/incomingwebhook/display_test.go
@@ -1,0 +1,47 @@
+package incomingwebhook
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsWebhookUID(t *testing.T) {
+	assert.True(t, isWebhookUID("iwh_d1fc093bc19c8a7fca754bcf607562d3"))
+	assert.False(t, isWebhookUID("d1fc093bc19c8a7fca754bcf607562d3"))
+	assert.False(t, isWebhookUID(""))
+	assert.False(t, isWebhookUID("Iwh_x")) // 前缀大小写敏感
+}
+
+func TestWebhookDisplayName(t *testing.T) {
+	assert.Equal(t, "GitHub Bot", webhookDisplayName(&incomingWebhookModel{Name: "GitHub Bot"}))
+	// 空 / 纯空白名兜底到默认展示名。
+	assert.Equal(t, defaultWebhookDisplayName, webhookDisplayName(&incomingWebhookModel{Name: ""}))
+	assert.Equal(t, defaultWebhookDisplayName, webhookDisplayName(&incomingWebhookModel{Name: "   "}))
+}
+
+func TestNewWebhookChannelResp(t *testing.T) {
+	m := &incomingWebhookModel{
+		WebhookID: "iwh_abc",
+		Name:      "GitHub Bot",
+		Avatar:    "https://example.com/a.png",
+		GroupNo:   "g_123",
+		TokenHash: "SECRET_SHOULD_NOT_LEAK",
+	}
+	resp := newWebhookChannelResp(m)
+
+	assert.Equal(t, "iwh_abc", resp.Channel.ChannelID)
+	assert.Equal(t, common.ChannelTypePerson.Uint8(), resp.Channel.ChannelType)
+	assert.Equal(t, "GitHub Bot", resp.Name)
+	assert.Equal(t, "users/iwh_abc/avatar", resp.Logo)
+	assert.Equal(t, extraKindValue, resp.Category)
+	assert.Equal(t, 1, resp.Status)
+	assert.Equal(t, extraKindValue, resp.Extra[extraKindKey])
+	assert.Equal(t, "https://example.com/a.png", resp.Extra[extraAvatarKey])
+	assert.Equal(t, "g_123", resp.Extra[extraGroupKey])
+	// token_hash 绝不能进入对外频道详情。
+	for k, v := range resp.Extra {
+		assert.NotEqualf(t, "SECRET_SHOULD_NOT_LEAK", v, "token leaked via extra[%s]", k)
+	}
+}

--- a/modules/incomingwebhook/webhook_render_test.go
+++ b/modules/incomingwebhook/webhook_render_test.go
@@ -98,6 +98,36 @@ func TestWebhookRender_AfterDelete_UserGet(t *testing.T) {
 	assert.NotEqualf(t, http.StatusInternalServerError, w.Code, "deleted webhook must degrade gracefully, not 500; body: %s", w.Body.String())
 }
 
+// 真实查询故障必须返回 5xx，不能被降级成 404 / 默认头像（reviewer #250 🔴）。
+// 通过临时重命名 incoming_webhook 表注入 query error，测完 defer 恢复。
+func TestWebhookRender_UserGet_QueryError_Returns5xx(t *testing.T) {
+	handler, ctx, groupNo := setupTestEnv(t)
+	whID := createWebhook(t, handler, groupNo, "WH", "")
+
+	_, err := ctx.DB().UpdateBySql("RENAME TABLE incoming_webhook TO incoming_webhook_bak").Exec()
+	assert.NoError(t, err)
+	defer func() {
+		_, _ = ctx.DB().UpdateBySql("RENAME TABLE incoming_webhook_bak TO incoming_webhook").Exec()
+	}()
+
+	w := do(handler, authReq("GET", fmt.Sprintf("/v1/users/%s?group_no=%s", whID, groupNo), nil))
+	assert.GreaterOrEqualf(t, w.Code, 500, "query failure must surface as 5xx, not be masked as not-found; body: %s", w.Body.String())
+}
+
+func TestWebhookRender_Avatar_QueryError_Returns5xx(t *testing.T) {
+	handler, ctx, groupNo := setupTestEnv(t)
+	whID := createWebhook(t, handler, groupNo, "WH", "https://example.com/a.png")
+
+	_, err := ctx.DB().UpdateBySql("RENAME TABLE incoming_webhook TO incoming_webhook_bak").Exec()
+	assert.NoError(t, err)
+	defer func() {
+		_, _ = ctx.DB().UpdateBySql("RENAME TABLE incoming_webhook_bak TO incoming_webhook").Exec()
+	}()
+
+	w := do(handler, anonReq("GET", fmt.Sprintf("/v1/users/%s/avatar", whID), nil))
+	assert.GreaterOrEqualf(t, w.Code, 500, "query failure must surface as 5xx, not a default avatar; code=%d", w.Code)
+}
+
 // 删除 webhook 后：接口③仍回退默认头像（不裂图、不 404）。
 func TestWebhookRender_AfterDelete_Avatar(t *testing.T) {
 	handler, _, groupNo := setupTestEnv(t)

--- a/modules/incomingwebhook/webhook_render_test.go
+++ b/modules/incomingwebhook/webhook_render_test.go
@@ -1,0 +1,112 @@
+package incomingwebhook_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	// 接口① /v1/channels/:id/:type 由 channel 模块提供，须注册其路由（及 SQL 迁移）。
+	_ "github.com/Mininglamp-OSS/octo-server/modules/channel"
+)
+
+// 这些测试覆盖 #249 合并后的客户端兼容问题：客户端把 webhook 合成发送者（iwh_ 前缀）
+// 当普通用户去查 /v1/channels、/v1/users、/v1/users/:uid/avatar，服务端需识别前缀并
+// 兜底返回发送者名/头像，且 webhook 删除后优雅降级（不报 500、不裂图）。
+
+// createWebhook 通过管理端点创建一个 webhook，返回其 webhook_id（iwh_xxx）。
+func createWebhook(t *testing.T, handler http.Handler, groupNo, name, avatar string) string {
+	t.Helper()
+	body := map[string]interface{}{"name": name}
+	if avatar != "" {
+		body["avatar"] = avatar
+	}
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), body))
+	assert.Equalf(t, http.StatusOK, w.Code, "create body: %s", w.Body.String())
+	id, _ := parseJSON(t, w)["webhook_id"].(string)
+	assert.NotEmpty(t, id)
+	return id
+}
+
+// 接口①：GET /v1/channels/:id/:type 解析 webhook 为单聊频道详情。
+func TestWebhookRender_ChannelGet(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID := createWebhook(t, handler, groupNo, "GitHub Bot", "")
+
+	w := do(handler, authReq("GET", fmt.Sprintf("/v1/channels/%s/1", whID), nil))
+	assert.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	res := parseJSON(t, w)
+
+	ch, _ := res["channel"].(map[string]interface{})
+	assert.Equal(t, whID, ch["channel_id"])
+	assert.Equal(t, float64(1), ch["channel_type"])
+	assert.Equal(t, "GitHub Bot", res["name"])
+	assert.Equal(t, fmt.Sprintf("users/%s/avatar", whID), res["logo"])
+	extra, _ := res["extra"].(map[string]interface{})
+	assert.Equal(t, "webhook", extra["kind"])
+	// 绝不泄漏 token/token_hash。
+	assert.NotContains(t, w.Body.String(), "token")
+}
+
+// 接口②：GET /v1/users/:uid 解析 webhook 为最小化用户详情。
+func TestWebhookRender_UserGet(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID := createWebhook(t, handler, groupNo, "GitHub Bot", "")
+
+	w := do(handler, authReq("GET", fmt.Sprintf("/v1/users/%s?group_no=%s", whID, groupNo), nil))
+	assert.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	res := parseJSON(t, w)
+	assert.Equal(t, whID, res["uid"])
+	assert.Equal(t, "GitHub Bot", res["name"])
+	assert.Equal(t, "webhook", res["category"])
+	assert.NotContains(t, w.Body.String(), "token")
+}
+
+// 接口③：GET /v1/users/:uid/avatar — 有自定义 http(s) 头像 URL 时 302 重定向。
+func TestWebhookRender_Avatar_Redirect(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	const avatarURL = "https://example.com/avatar.png"
+	whID := createWebhook(t, handler, groupNo, "WH", avatarURL)
+
+	w := do(handler, anonReq("GET", fmt.Sprintf("/v1/users/%s/avatar", whID), nil))
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, avatarURL, w.Header().Get("Location"))
+}
+
+// 接口③：未设置头像时回退到默认头像（不裂图）。
+func TestWebhookRender_Avatar_Default(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID := createWebhook(t, handler, groupNo, "WH", "")
+
+	w := do(handler, anonReq("GET", fmt.Sprintf("/v1/users/%s/avatar", whID), nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
+	assert.NotEmpty(t, w.Body.Bytes())
+}
+
+// 删除 webhook 后：接口②优雅降级为非 200，且绝不 500。
+func TestWebhookRender_AfterDelete_UserGet(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID := createWebhook(t, handler, groupNo, "WH", "")
+
+	w := do(handler, authReq("DELETE", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID), nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	w = do(handler, authReq("GET", fmt.Sprintf("/v1/users/%s?group_no=%s", whID, groupNo), nil))
+	assert.NotEqual(t, http.StatusOK, w.Code)
+	assert.NotEqualf(t, http.StatusInternalServerError, w.Code, "deleted webhook must degrade gracefully, not 500; body: %s", w.Body.String())
+}
+
+// 删除 webhook 后：接口③仍回退默认头像（不裂图、不 404）。
+func TestWebhookRender_AfterDelete_Avatar(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID := createWebhook(t, handler, groupNo, "WH", "https://example.com/a.png")
+
+	w := do(handler, authReq("DELETE", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID), nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	w = do(handler, anonReq("GET", fmt.Sprintf("/v1/users/%s/avatar", whID), nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
+}

--- a/modules/user/1module.go
+++ b/modules/user/1module.go
@@ -57,6 +57,11 @@ func init() {
 					if channelType != common.ChannelTypePerson.Uint8() {
 						return nil, register.ErrDatasourceNotProcess
 					}
+					// incoming webhook 合成身份（iwh_ 前缀）不是真实用户，交给
+					// incomingwebhook 模块的 datasource 处理，避免在此误报"用户不存在"。
+					if strings.HasPrefix(channelID, webhookUIDPrefix) {
+						return nil, register.ErrDatasourceNotProcess
+					}
 					userDetailResp, err := api.userService.GetUserDetail(channelID, loginUID)
 					if err != nil {
 						return nil, err

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -1074,9 +1074,15 @@ func (u *User) get(c *wkhttp.Context) {
 	}
 
 	// incoming webhook 合成发送者（iwh_ 前缀）不是真实用户，走 datasource 兜底，
-	// 否则会因查不到 user 记录返回错误。webhook 已删除时返回 not_found（优雅降级）。
+	// 否则会因查不到 user 记录返回错误。区分三种情况：真实查询故障→500（不可降级），
+	// webhook 真正不存在（含已删除）→not_found，命中→合成详情。
 	if strings.HasPrefix(uid, webhookUIDPrefix) {
-		ch := u.resolveWebhookChannel(uid, loginUID)
+		ch, err := u.resolveWebhookChannel(uid, loginUID)
+		if err != nil {
+			u.Error("查询 webhook 发送者信息失败", zap.Error(err), zap.String("uid", uid))
+			respondUserErrorWithStatus(c, errcode.ErrUserQueryFailed)
+			return
+		}
 		if ch == nil {
 			respondUserError(c, errcode.ErrUserNotFound)
 			return

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -493,6 +493,13 @@ func (u *User) UserAvatar(c *wkhttp.Context) {
 		return
 	}
 
+	// incoming webhook 合成发送者（iwh_ 前缀）不在 user 表，单独处理头像：有自定义
+	// URL 则重定向，否则回退默认头像，避免裂图（含 webhook 已删除的情况）。
+	if strings.HasPrefix(uid, webhookUIDPrefix) {
+		u.writeWebhookAvatar(c, uid)
+		return
+	}
+
 	userInfo, err := u.db.QueryByUID(uid)
 	if err != nil {
 		u.Error("查询用户信息错误", zap.Error(err))
@@ -1063,6 +1070,18 @@ func (u *User) get(c *wkhttp.Context) {
 	if u.ctx.GetConfig().IsVisitor(uid) { // 访客频道
 		c.Request.URL.Path = fmt.Sprintf("/v1/hotline/visitors/%s/im", uid)
 		u.ctx.GetHttpRoute().HandleContext(c)
+		return
+	}
+
+	// incoming webhook 合成发送者（iwh_ 前缀）不是真实用户，走 datasource 兜底，
+	// 否则会因查不到 user 记录返回错误。webhook 已删除时返回 not_found（优雅降级）。
+	if strings.HasPrefix(uid, webhookUIDPrefix) {
+		ch := u.resolveWebhookChannel(uid, loginUID)
+		if ch == nil {
+			respondUserError(c, errcode.ErrUserNotFound)
+			return
+		}
+		c.Response(newWebhookUserDetailResp(uid, ch))
 		return
 	}
 

--- a/modules/user/api_i18n.go
+++ b/modules/user/api_i18n.go
@@ -16,6 +16,16 @@ func respondUserError(c *wkhttp.Context, code codes.Code) {
 	httperr.ResponseErrorL(c, code, nil, nil)
 }
 
+// respondUserErrorWithStatus mirrors respondUserError but preserves the code's
+// real HTTP status instead of the compatibility-window fixed 400. Use ONLY on
+// branches with no legacy clients keyed to the 400 — e.g. the incoming-webhook
+// (iwh_) sender resolution path, which never resolved before this change, so a
+// genuine storage/query failure must surface to the caller as 5xx rather than
+// be masked as not-found (PR #250 reviewer feedback).
+func respondUserErrorWithStatus(c *wkhttp.Context, code codes.Code) {
+	httperr.ResponseErrorLWithStatus(c, code, nil, nil)
+}
+
 // respondUserRequestInvalid covers the common "X 不能为空" / "数据格式有误"
 // shape — one code, one optional field detail. An empty field is omitted
 // so the renderer does not surface a noisy empty key to clients.

--- a/modules/user/webhook_identity.go
+++ b/modules/user/webhook_identity.go
@@ -25,6 +25,14 @@ const (
 	webhookExtraAvatarKey = "webhook_avatar"
 )
 
+// 导出别名仅供 incomingwebhook 包的测试做跨包契约一致性校验（见其 display_test.go），
+// 把"本地复制的常量"与"上层源头常量"在编译期/测试期绑定，防止任一侧改动后悄悄漂移。
+// 生产代码不依赖这些导出。
+const (
+	WebhookUIDPrefix      = webhookUIDPrefix
+	WebhookExtraAvatarKey = webhookExtraAvatarKey
+)
+
 // resolveWebhookChannel 通过 BussDataSource.ChannelGet 链解析 webhook 合成身份的展示
 // 信息（名称/头像）。
 //

--- a/modules/user/webhook_identity.go
+++ b/modules/user/webhook_identity.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -25,22 +26,33 @@ const (
 )
 
 // resolveWebhookChannel 通过 BussDataSource.ChannelGet 链解析 webhook 合成身份的展示
-// 信息（名称/头像）。未命中（含 webhook 已删除）返回 nil。
-func (u *User) resolveWebhookChannel(uid, loginUID string) *model.ChannelResp {
+// 信息（名称/头像）。
+//
+// 返回值语义（必须区分，否则会把存储故障误判成 not-found）：
+//   - (resp, nil)：命中，resp 为合成的频道详情。
+//   - (nil, nil)：无任何模块处理此 uid（webhook 真正不存在，含已删除）→ 调用方走
+//     not-found / 默认头像降级。
+//   - (nil, err)：某模块返回了真实错误（DB/查询失败）→ 调用方必须返回 5xx，不可降级。
+//
+// datasource 用 register.ErrDatasourceNotProcess 表示"不处理"，用包装后的真实 error
+// 表示故障（见 incomingwebhook 的 newChannelGetDatasource），这里据此区分。
+func (u *User) resolveWebhookChannel(uid, loginUID string) (*model.ChannelResp, error) {
 	for _, m := range register.GetModules(u.ctx) {
 		if m.BussDataSource.ChannelGet == nil {
 			continue
 		}
 		resp, err := m.BussDataSource.ChannelGet(uid, common.ChannelTypePerson.Uint8(), loginUID)
 		if err != nil {
-			// ErrDatasourceNotProcess 等：该模块不处理，继续下一个。
-			continue
+			if errors.Is(err, register.ErrDatasourceNotProcess) {
+				continue // 该模块不处理此 uid，尝试下一个
+			}
+			return nil, err // 真实错误向上传播，禁止降级成 not-found / 默认头像
 		}
 		if resp != nil {
-			return resp
+			return resp, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 // newWebhookUserDetailResp 把 webhook 频道详情合成为最小化用户详情，供 /v1/users/:uid
@@ -57,7 +69,13 @@ func newWebhookUserDetailResp(uid string, ch *model.ChannelResp) *UserDetailResp
 // writeWebhookAvatar 处理 webhook 头像请求：有自定义 http(s) 头像 URL 则 302 重定向，
 // 否则（未设置头像或 webhook 已删除）回退到基于 uid 的默认头像，避免裂图。
 func (u *User) writeWebhookAvatar(c *wkhttp.Context, uid string) {
-	ch := u.resolveWebhookChannel(uid, "")
+	ch, err := u.resolveWebhookChannel(uid, "")
+	if err != nil {
+		// 真实查询故障：返回 500，不可静默回退默认头像（掩盖故障）。
+		u.Error("查询 webhook 头像失败", zap.Error(err), zap.String("uid", uid))
+		c.Writer.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 	avatarURL := ""
 	if ch != nil {
 		if v, ok := ch.Extra[webhookExtraAvatarKey].(string); ok {
@@ -68,6 +86,7 @@ func (u *User) writeWebhookAvatar(c *wkhttp.Context, uid string) {
 		c.Redirect(http.StatusFound, avatarURL)
 		return
 	}
+	// 仅当 webhook 存在但无自定义头像、或 webhook 已删除（ch==nil）时回退默认头像。
 	imageData, genErr := generateDefaultAvatar(uid)
 	if genErr != nil {
 		u.Error("生成 webhook 默认头像失败", zap.Error(genErr), zap.String("uid", uid))

--- a/modules/user/webhook_identity.go
+++ b/modules/user/webhook_identity.go
@@ -1,0 +1,81 @@
+package user
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/model"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"go.uber.org/zap"
+)
+
+// incoming webhook 合成身份相关常量。webhook 的发送者 UID 形如 iwh_xxx，不是真实
+// 用户，客户端渲染消息时仍会把它当用户去查 /v1/users 与 /v1/users/:uid/avatar。
+// 这里做服务端兜底，避免"用户信息不存在/500/头像裂图"。
+//
+// 注意：user 是底层模块，不能 import 上层 incomingwebhook（会造成分层倒置），因此
+// 前缀与 Extra key 在此本地复制；其权威定义在 modules/incomingwebhook/display.go，
+// 二者必须保持一致。webhook 展示数据通过 octo-lib 的 BussDataSource.ChannelGet 注册
+// 机制跨模块获取，user 模块不直接依赖 incomingwebhook。
+const (
+	webhookUIDPrefix      = "iwh_"
+	webhookExtraAvatarKey = "webhook_avatar"
+)
+
+// resolveWebhookChannel 通过 BussDataSource.ChannelGet 链解析 webhook 合成身份的展示
+// 信息（名称/头像）。未命中（含 webhook 已删除）返回 nil。
+func (u *User) resolveWebhookChannel(uid, loginUID string) *model.ChannelResp {
+	for _, m := range register.GetModules(u.ctx) {
+		if m.BussDataSource.ChannelGet == nil {
+			continue
+		}
+		resp, err := m.BussDataSource.ChannelGet(uid, common.ChannelTypePerson.Uint8(), loginUID)
+		if err != nil {
+			// ErrDatasourceNotProcess 等：该模块不处理，继续下一个。
+			continue
+		}
+		if resp != nil {
+			return resp
+		}
+	}
+	return nil
+}
+
+// newWebhookUserDetailResp 把 webhook 频道详情合成为最小化用户详情，供 /v1/users/:uid
+// 渲染发送者名。仅填充展示必需字段，其余保持零值；绝不携带 token。
+func newWebhookUserDetailResp(uid string, ch *model.ChannelResp) *UserDetailResp {
+	return &UserDetailResp{
+		UID:      uid,
+		Name:     ch.Name,
+		Category: ch.Category,
+		Status:   1,
+	}
+}
+
+// writeWebhookAvatar 处理 webhook 头像请求：有自定义 http(s) 头像 URL 则 302 重定向，
+// 否则（未设置头像或 webhook 已删除）回退到基于 uid 的默认头像，避免裂图。
+func (u *User) writeWebhookAvatar(c *wkhttp.Context, uid string) {
+	ch := u.resolveWebhookChannel(uid, "")
+	avatarURL := ""
+	if ch != nil {
+		if v, ok := ch.Extra[webhookExtraAvatarKey].(string); ok {
+			avatarURL = strings.TrimSpace(v)
+		}
+	}
+	if strings.HasPrefix(avatarURL, "http://") || strings.HasPrefix(avatarURL, "https://") {
+		c.Redirect(http.StatusFound, avatarURL)
+		return
+	}
+	imageData, genErr := generateDefaultAvatar(uid)
+	if genErr != nil {
+		u.Error("生成 webhook 默认头像失败", zap.Error(genErr), zap.String("uid", uid))
+		c.Writer.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	c.Header("Content-Type", "image/png")
+	c.Header("Content-Disposition", "inline; filename=avatar.png")
+	c.Header("Cache-Control", "public, max-age=86400")
+	c.Data(http.StatusOK, "image/png", imageData)
+}


### PR DESCRIPTION
Closes #251

## Background

Follow-up to #249 (incoming webhooks, #246). After #249 merged, verification found that clients which have not yet adapted to webhook messages render the synthetic sender UID (`iwh_xxx`) as a regular user and call the user/channel APIs, which all fail.

## Problem

The webhook sender `FromUID = iwh_xxx` never exists in the `user` table:

| Endpoint | Before |
|---|---|
| `GET /v1/channels/iwh_/:type` | `user not found` (400) |
| `GET /v1/users/iwh_` | `500 query_failed` |
| `GET /v1/users/iwh_/avatar` | `404` (broken image) |

`GET /v1/users/iwh_` returns 500 because `GetUserDetail` returns an error on a missing row and the handler maps any error to `query_failed` (this also surfaces a pre-existing not-found-as-500 mismatch, left untouched here).

## Fix

A server-side fallback recognizes the `iwh_` prefix and synthesizes display info (name/avatar) from the `incoming_webhook` table, reusing octo-lib's `register.BussDataSource.ChannelGet` so the `user` module keeps no compile-time dependency on the upper-layer `incomingwebhook` module. `token`/`token_hash` are never exposed.

- `incomingwebhook`: register a `ChannelGet` datasource; extract the `webhookIDPrefix` constant
- `user`: let `iwh_` pass through its own datasource; add `iwh_` branches to the `get` and `UserAvatar` handlers (302 redirect to a custom avatar URL, otherwise a default avatar — consistent with the existing real-user avatar redirect)
- Graceful degradation after webhook deletion (hard delete): not-found instead of 500, and a default avatar instead of 404

The authoritative render source remains `payload.from.name/avatar` embedded at send time; these endpoints are a transitional fallback until clients adapt.

## Test plan

- [x] `go build ./...`, `go vet`, `gofmt`
- [x] New unit tests (`display_test.go`): prefix detection, empty-name fallback, no token leak
- [x] New e2e tests (`webhook_render_test.go`, 9 cases): all three endpoints + post-deletion degradation + default avatar; passing with `-race`
- [x] `incomingwebhook` package regression (existing tests) pass
