### PR TITLE
fix(botfather): make #239 migrations idempotent to stop CrashLoopBackOff

### DIFF
--- a/modules/botfather/sql/20260603000001_botfather_legacy01.sql
+++ b/modules/botfather/sql/20260603000001_botfather_legacy01.sql
@@ -3,35 +3,113 @@
 -- client_id 默认 'botfather'：存量行自动回填，botfather 现有不带 client_id 的
 -- insert/query 经 DEFAULT 兜底无感不回归。
 -- api_key_hash / api_key_cipher 本期预留留空（后续 hash 化加固用）。
-ALTER TABLE `user_api_key`
-  ADD COLUMN `client_id` varchar(100) NOT NULL DEFAULT 'botfather' COMMENT '外部应用ID；botfather 自身为 botfather' AFTER `space_id`,
-  ADD COLUMN `status` tinyint(4) NOT NULL DEFAULT 1 COMMENT '1=active 0=revoked' AFTER `client_id`,
-  ADD COLUMN `api_key_hash` varchar(64) NOT NULL DEFAULT '' COMMENT '预留：uk_ 明文 SHA-256 hex（鉴权查询用）',
-  ADD COLUMN `api_key_cipher` varchar(255) NOT NULL DEFAULT '' COMMENT '预留：uk_ 明文密文（回显用）',
-  ADD COLUMN `last_used_at` timestamp NULL DEFAULT NULL COMMENT '最近使用时间',
-  ADD COLUMN `last_used_ip` varchar(64) NOT NULL DEFAULT '' COMMENT '最近使用IP',
-  ADD COLUMN `last_used_user_agent` varchar(255) NOT NULL DEFAULT '' COMMENT '最近调用方UA',
-  ADD COLUMN `revoked_at` timestamp NULL DEFAULT NULL COMMENT '撤销时间';
+--
+-- 幂等/可重入写法（与 base/20260512000001_base_oss_compat_repair.sql 同范式：
+-- INFORMATION_SCHEMA 守卫 + 存储过程）。原因：MySQL 的 DDL 隐式提交，而
+-- sql-migrate 仅在「一个迁移的所有语句都成功」后才往 gorp_migrations 记账
+-- （rubenv/sql-migrate@v1.5.2 applyMigrations：失败即 Rollback，但已提交的
+-- DDL 回不掉）。一旦首条 ADD COLUMN 成功、后续 DROP INDEX / ADD UNIQUE 任一
+-- 失败，就残留「列已加但迁移未记账」的中间态——pod 重启再次执行首条 ADD COLUMN
+-- 即报 Duplicate column name 'client_id'，陷入 CrashLoopBackOff（见 #239 部署
+-- 事故）。逐项存在性守卫后本迁移可安全重入，并能自动修复已处于该中间态的环境。
 
--- 唯一键 (uid, space_id) -> (uid, space_id, client_id)。存量 client_id 均为
--- 'botfather'，改键安全；否则同一 uid+space 下为不同 client 插第二把 key 会撞旧约束。
-ALTER TABLE `user_api_key` DROP INDEX `uk_uid_space`;
-ALTER TABLE `user_api_key` ADD UNIQUE KEY `uk_uid_space_client` (`uid`, `space_id`, `client_id`);
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __botfather_user_api_key_clientdim;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __botfather_user_api_key_clientdim()
+BEGIN
+  -- 列：仅当 client_id 不存在时整体添加。首条 ADD COLUMN 是单条原子 ALTER，
+  -- 要么 8 列全在、要么全不在，故以 client_id 为存在性哨兵即可覆盖整组。
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key'
+         AND COLUMN_NAME = 'client_id') THEN
+    ALTER TABLE `user_api_key`
+      ADD COLUMN `client_id` varchar(100) NOT NULL DEFAULT 'botfather' COMMENT '外部应用ID；botfather 自身为 botfather' AFTER `space_id`,
+      ADD COLUMN `status` tinyint(4) NOT NULL DEFAULT 1 COMMENT '1=active 0=revoked' AFTER `client_id`,
+      ADD COLUMN `api_key_hash` varchar(64) NOT NULL DEFAULT '' COMMENT '预留：uk_ 明文 SHA-256 hex（鉴权查询用）',
+      ADD COLUMN `api_key_cipher` varchar(255) NOT NULL DEFAULT '' COMMENT '预留：uk_ 明文密文（回显用）',
+      ADD COLUMN `last_used_at` timestamp NULL DEFAULT NULL COMMENT '最近使用时间',
+      ADD COLUMN `last_used_ip` varchar(64) NOT NULL DEFAULT '' COMMENT '最近使用IP',
+      ADD COLUMN `last_used_user_agent` varchar(255) NOT NULL DEFAULT '' COMMENT '最近调用方UA',
+      ADD COLUMN `revoked_at` timestamp NULL DEFAULT NULL COMMENT '撤销时间';
+  END IF;
+
+  -- 唯一键 (uid, space_id) -> (uid, space_id, client_id)。存量 client_id 均为
+  -- 'botfather'，旧键 (uid, space_id) 唯一即蕴含新三元组唯一，改键安全。两步均
+  -- 加存在性守卫，重入不报 1091（DROP 不存在的索引）/ 1061（重复建索引）。
+  IF EXISTS (SELECT 1 FROM information_schema.STATISTICS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key'
+         AND INDEX_NAME = 'uk_uid_space') THEN
+    ALTER TABLE `user_api_key` DROP INDEX `uk_uid_space`;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.STATISTICS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key'
+         AND INDEX_NAME = 'uk_uid_space_client') THEN
+    ALTER TABLE `user_api_key`
+      ADD UNIQUE KEY `uk_uid_space_client` (`uid`, `space_id`, `client_id`);
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __botfather_user_api_key_clientdim();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __botfather_user_api_key_clientdim;
+-- +migrate StatementEnd
 
 -- +migrate Down
-ALTER TABLE `user_api_key` DROP INDEX `uk_uid_space_client`;
--- 回滚到 (uid, space_id) 唯一键前，先清掉本特性引入的非 botfather client 行：
--- 一旦特性被使用过，同一 uid+space 下可能存在多个 client 的 key，直接重建旧唯一键
--- 会因重复 (uid, space_id) 撞键失败。删除这些行后 botfather 自有行在 (uid, space_id)
--- 上仍唯一（旧唯一键时代即如此），重建安全。回滚即移除本特性，删其数据符合语义。
-DELETE FROM `user_api_key` WHERE `client_id` <> 'botfather';
-ALTER TABLE `user_api_key` ADD UNIQUE KEY `uk_uid_space` (`uid`, `space_id`);
-ALTER TABLE `user_api_key`
-  DROP COLUMN `revoked_at`,
-  DROP COLUMN `last_used_user_agent`,
-  DROP COLUMN `last_used_ip`,
-  DROP COLUMN `last_used_at`,
-  DROP COLUMN `api_key_cipher`,
-  DROP COLUMN `api_key_hash`,
-  DROP COLUMN `status`,
-  DROP COLUMN `client_id`;
+-- 同样做存在性守卫，使回滚可重入。
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __botfather_user_api_key_clientdim_down;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __botfather_user_api_key_clientdim_down()
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.STATISTICS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key'
+         AND INDEX_NAME = 'uk_uid_space_client') THEN
+    ALTER TABLE `user_api_key` DROP INDEX `uk_uid_space_client`;
+  END IF;
+
+  -- 回滚到 (uid, space_id) 唯一键前，先清掉本特性引入的非 botfather client 行：
+  -- 一旦特性被使用过，同一 uid+space 下可能存在多个 client 的 key，直接重建旧
+  -- 唯一键会因重复 (uid, space_id) 撞键失败。删除这些行后 botfather 自有行在
+  -- (uid, space_id) 上仍唯一（旧唯一键时代即如此），重建安全。回滚即移除本特性，
+  -- 删其数据符合语义。client_id 列仍在时才执行（列已不在说明已回滚过）。
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key'
+         AND COLUMN_NAME = 'client_id') THEN
+    DELETE FROM `user_api_key` WHERE `client_id` <> 'botfather';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.STATISTICS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key'
+         AND INDEX_NAME = 'uk_uid_space') THEN
+    ALTER TABLE `user_api_key` ADD UNIQUE KEY `uk_uid_space` (`uid`, `space_id`);
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key'
+         AND COLUMN_NAME = 'client_id') THEN
+    ALTER TABLE `user_api_key`
+      DROP COLUMN `revoked_at`,
+      DROP COLUMN `last_used_user_agent`,
+      DROP COLUMN `last_used_ip`,
+      DROP COLUMN `last_used_at`,
+      DROP COLUMN `api_key_cipher`,
+      DROP COLUMN `api_key_hash`,
+      DROP COLUMN `status`,
+      DROP COLUMN `client_id`;
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __botfather_user_api_key_clientdim_down();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __botfather_user_api_key_clientdim_down;
+-- +migrate StatementEnd

--- a/modules/botfather/sql/20260603000001_botfather_legacy01.sql
+++ b/modules/botfather/sql/20260603000001_botfather_legacy01.sql
@@ -20,19 +20,49 @@ DROP PROCEDURE IF EXISTS __botfather_user_api_key_clientdim;
 -- +migrate StatementBegin
 CREATE PROCEDURE __botfather_user_api_key_clientdim()
 BEGIN
-  -- 列：仅当 client_id 不存在时整体添加。首条 ADD COLUMN 是单条原子 ALTER，
-  -- 要么 8 列全在、要么全不在，故以 client_id 为存在性哨兵即可覆盖整组。
+  -- 列：逐列独立守卫。原始 ADD COLUMN 是单条原子 ALTER（全 8 列或全无），故本
+  -- 特性自身的半应用态用任一哨兵都够；但逐列检查能额外修复「client_id 在、某
+  -- 个同伴列缺失」的任意 schema 漂移（如手工补列或异常中断遗留），不依赖整组同
+  -- 进退的假设。各列按原始列序追加：client_id AFTER space_id、status AFTER
+  -- client_id（前序列此时必已存在），其余 6 列无 AFTER 顺序追加，与原迁移一致。
   IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
-       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key'
-         AND COLUMN_NAME = 'client_id') THEN
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key' AND COLUMN_NAME = 'client_id') THEN
     ALTER TABLE `user_api_key`
-      ADD COLUMN `client_id` varchar(100) NOT NULL DEFAULT 'botfather' COMMENT '外部应用ID；botfather 自身为 botfather' AFTER `space_id`,
-      ADD COLUMN `status` tinyint(4) NOT NULL DEFAULT 1 COMMENT '1=active 0=revoked' AFTER `client_id`,
-      ADD COLUMN `api_key_hash` varchar(64) NOT NULL DEFAULT '' COMMENT '预留：uk_ 明文 SHA-256 hex（鉴权查询用）',
-      ADD COLUMN `api_key_cipher` varchar(255) NOT NULL DEFAULT '' COMMENT '预留：uk_ 明文密文（回显用）',
-      ADD COLUMN `last_used_at` timestamp NULL DEFAULT NULL COMMENT '最近使用时间',
-      ADD COLUMN `last_used_ip` varchar(64) NOT NULL DEFAULT '' COMMENT '最近使用IP',
-      ADD COLUMN `last_used_user_agent` varchar(255) NOT NULL DEFAULT '' COMMENT '最近调用方UA',
+      ADD COLUMN `client_id` varchar(100) NOT NULL DEFAULT 'botfather' COMMENT '外部应用ID；botfather 自身为 botfather' AFTER `space_id`;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key' AND COLUMN_NAME = 'status') THEN
+    ALTER TABLE `user_api_key`
+      ADD COLUMN `status` tinyint(4) NOT NULL DEFAULT 1 COMMENT '1=active 0=revoked' AFTER `client_id`;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key' AND COLUMN_NAME = 'api_key_hash') THEN
+    ALTER TABLE `user_api_key`
+      ADD COLUMN `api_key_hash` varchar(64) NOT NULL DEFAULT '' COMMENT '预留：uk_ 明文 SHA-256 hex（鉴权查询用）';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key' AND COLUMN_NAME = 'api_key_cipher') THEN
+    ALTER TABLE `user_api_key`
+      ADD COLUMN `api_key_cipher` varchar(255) NOT NULL DEFAULT '' COMMENT '预留：uk_ 明文密文（回显用）';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key' AND COLUMN_NAME = 'last_used_at') THEN
+    ALTER TABLE `user_api_key`
+      ADD COLUMN `last_used_at` timestamp NULL DEFAULT NULL COMMENT '最近使用时间';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key' AND COLUMN_NAME = 'last_used_ip') THEN
+    ALTER TABLE `user_api_key`
+      ADD COLUMN `last_used_ip` varchar(64) NOT NULL DEFAULT '' COMMENT '最近使用IP';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key' AND COLUMN_NAME = 'last_used_user_agent') THEN
+    ALTER TABLE `user_api_key`
+      ADD COLUMN `last_used_user_agent` varchar(255) NOT NULL DEFAULT '' COMMENT '最近调用方UA';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key' AND COLUMN_NAME = 'revoked_at') THEN
+    ALTER TABLE `user_api_key`
       ADD COLUMN `revoked_at` timestamp NULL DEFAULT NULL COMMENT '撤销时间';
   END IF;
 

--- a/modules/botfather/sql/20260603000002_botfather_legacy01.sql
+++ b/modules/botfather/sql/20260603000002_botfather_legacy01.sql
@@ -2,11 +2,52 @@
 -- robot 占用/绑定字段（PM Octo-link：一个 Bot 同时只被一个 Agent 占用）。
 -- bound_agent_ref 为不透明标签（如 octopush:agent_xxx），空=空闲；占用互斥由
 -- bind 接口的行级 CAS 保证，无需额外索引。
-ALTER TABLE `robot`
-  ADD COLUMN `bound_agent_ref` varchar(128) NOT NULL DEFAULT '' COMMENT '占用方不透明标签（如 octopush:agent_xxx）；空=空闲',
-  ADD COLUMN `bound_at` timestamp NULL DEFAULT NULL COMMENT '占用时间；释放时清空';
+--
+-- 与 20260603000001 同样采用存在性守卫的可重入写法：避免任一 pod 部分应用/
+-- 滚动发布并发执行后，重启再跑 ADD COLUMN 报 Duplicate column name 而 CrashLoop。
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __botfather_robot_occupancy;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __botfather_robot_occupancy()
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'robot'
+         AND COLUMN_NAME = 'bound_agent_ref') THEN
+    ALTER TABLE `robot`
+      ADD COLUMN `bound_agent_ref` varchar(128) NOT NULL DEFAULT '' COMMENT '占用方不透明标签（如 octopush:agent_xxx）；空=空闲',
+      ADD COLUMN `bound_at` timestamp NULL DEFAULT NULL COMMENT '占用时间；释放时清空';
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __botfather_robot_occupancy();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __botfather_robot_occupancy;
+-- +migrate StatementEnd
 
 -- +migrate Down
-ALTER TABLE `robot`
-  DROP COLUMN `bound_at`,
-  DROP COLUMN `bound_agent_ref`;
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __botfather_robot_occupancy_down;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __botfather_robot_occupancy_down()
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'robot'
+         AND COLUMN_NAME = 'bound_agent_ref') THEN
+    ALTER TABLE `robot`
+      DROP COLUMN `bound_at`,
+      DROP COLUMN `bound_agent_ref`;
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __botfather_robot_occupancy_down();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __botfather_robot_occupancy_down;
+-- +migrate StatementEnd


### PR DESCRIPTION
Fixes #252.

## 问题

PR #239 的 `user_api_key` / `robot` 迁移不可崩溃安全。MySQL 的 `ALTER TABLE` 隐式提交,而 sql-migrate 仅在「一个迁移的所有语句都成功」后才往 `gorp_migrations` 记账(失败即 `Rollback()`,但已提交的 DDL 回不掉)。

于是一旦 `20260603000001` 的首条 `ADD COLUMN client_id` 提交、后续 `DROP INDEX uk_uid_space` / `ADD UNIQUE uk_uid_space_client` 任一失败(存量数据 / schema 漂移 / 滚动发布并发副本),表就停在半应用态且迁移未记账。Pod 每次重启都重跑首条 `ADD COLUMN` 并以 `Duplicate column name 'client_id'` 崩溃 → im-test 永久 CrashLoopBackOff。

## 改动

把两个 6/3 迁移改写成幂等可重入,沿用仓库已有范式(`modules/base/sql/20260512000001_base_oss_compat_repair.sql`:`INFORMATION_SCHEMA` 守卫 + 存储过程),每个列/索引操作各自做存在性判断:

- `20260603000001`：列整体以 `client_id` 为哨兵守卫;`DROP INDEX uk_uid_space` 加 `IF EXISTS`;`ADD UNIQUE uk_uid_space_client` 加 `IF NOT EXISTS`;Down 路径同样守卫。
- `20260603000002`：`robot.bound_agent_ref` / `bound_at` 加列守卫,Up/Down 均可重入。

既阻断未来的失败,又能**自愈**已经卡死的环境(下次发布跳过已存在的列、补完索引切换、记账成功)。全新安装与 Up/Down 可逆性不变。

> 注:这是就地修改已合并的迁移文件(同一迁移 ID),是有意为之 —— 崩溃 Pod 永远跑不过 `...0001`,新加修复迁移它够不着,所以必须改这一条本身。已成功记账的环境 schema 已是终态、不会重跑;只有卡 pending 的环境会重跑新的幂等体,正是要救的对象。

## 验证

光 build/解析不足以覆盖 MySQL DDL 隐式提交语义(SQLite 复现不了),故用真实 **MariaDB 10.11** + 真实生产路径(`migrate.Exec` + `go-sql-driver/mysql`,与 `pkg/db/mysql.go` 同一调用链)跑了 4 个场景:

| 场景 | 结果 |
|---|---|
| 半应用态跑**旧** SQL(崩溃 Pod 每次重启的行为) | ❌ `Error 1060: Duplicate column name 'client_id'`(精确复现线上报错) |
| 同一半应用态跑**新** SQL | ✅ 自愈:`uk_uid_space` 已删、`uk_uid_space_client` 已建、已记账 |
| 干净的 6/3 前表跑新 SQL | ✅ 列齐、索引切换正确、存量行回填 `client_id='botfather'` |
| 强制重跑新 SQL | ✅ 无报错(可重入) |
| robot `0002` 跑两遍 | ✅ 两遍成功,列齐 |

- ✅ `go build ./modules/botfather/...`
- ✅ 两个迁移文件经 `sql-migrate.ParseMigration` 解析正常(各 4 条语句,存储过程体作为单条不被内部分号切断)
- ⚠️ botfather 模块自身的集成测试需 Redis + WuKongIM,本次未在 CI 外环境运行

https://claude.ai/code/session_01Fh91f6Cad2nUozwofSHKfF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fh91f6Cad2nUozwofSHKfF)_