### PR TITLE
feat: add OIDC integration exchange

### DIFF
--- a/internal/modules.go
+++ b/internal/modules.go
@@ -23,10 +23,13 @@ package modules
 import (
 	_ "github.com/Mininglamp-OSS/octo-server/modules/backup"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/base"
+
 	// `robot` before `botfather`: botfather migrations ALTER the robot table
 	// (历史顺序，非 load-bearing —— 真正排序由 SQL 文件时间戳决定)。
 	_ "github.com/Mininglamp-OSS/octo-server/modules/robot"
+
 	_ "github.com/Mininglamp-OSS/octo-server/modules/botfather"
+
 	_ "github.com/Mininglamp-OSS/octo-server/modules/category"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/channel"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/common"
@@ -34,6 +37,7 @@ import (
 	_ "github.com/Mininglamp-OSS/octo-server/modules/file"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/group"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/incomingwebhook"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/integration"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/message"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/notify"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/oidc"
@@ -49,7 +53,9 @@ import (
 	// also imports bot_api at the Go package level, so register bot_api
 	// before app_bot（历史顺序，非 load-bearing —— Go init() 顺序由依赖图决定）.
 	_ "github.com/Mininglamp-OSS/octo-server/modules/bot_api"
+
 	_ "github.com/Mininglamp-OSS/octo-server/modules/app_bot"
+
 	_ "github.com/Mininglamp-OSS/octo-server/modules/voice_adapter"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/webhook"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/workplace"

--- a/modules/botfather/api_user.go
+++ b/modules/botfather/api_user.go
@@ -6,15 +6,16 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
-	"github.com/Mininglamp-OSS/octo-lib/common"
-	"github.com/Mininglamp-OSS/octo-lib/config"
-	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
-	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 )
@@ -48,15 +49,29 @@ func (bf *BotFather) authUserAPIKey() wkhttp.HandlerFunc {
 		}
 		if keyModel == nil {
 			// key 不存在或非 active（AuthByKey 已按 status=1 过滤）→ 统一 401。
-			// 注意：当前 PR 尚无生产路径把 key 置为 revoked（status=0）；status=1
-			// 过滤是为 PR2 的 DELETE /v1/integrations/oidc/binding 撤销能力预留的
-			// 前瞻防御，届时撤销的 key 会在此被拒为 401。
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"msg": "无效的API Key"})
 			return
 		}
+		if keyModel.ClientID != clientIDBotFather {
+			enabled, err := bf.db.isIntegrationClientEnabled(keyModel.ClientID)
+			if err != nil {
+				bf.Error("查询 integration client 状态失败", zap.String("client_id", keyModel.ClientID), zap.Error(err))
+				httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+				c.Abort()
+				return
+			}
+			if !enabled {
+				httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedTokenInvalid, nil, nil)
+				c.Abort()
+				return
+			}
+		}
 
+		c.Set("uid", keyModel.UID)
 		c.Set("api_key_uid", keyModel.UID)
 		c.Set("api_key_space_id", keyModel.SpaceID)
+		c.Set("api_key_id", keyModel.ID)
+		c.Set("api_key_client_id", keyModel.ClientID)
 		c.Next()
 	}
 }
@@ -95,7 +110,7 @@ func (bf *BotFather) isBotInSpace(botID, spaceID string) (bool, error) {
 
 // setupUserAPIRoutes 注册 User API Key 认证的路由
 func (bf *BotFather) setupUserAPIRoutes(r *wkhttp.WKHttp) {
-	userAPI := r.Group("/v1/user", bf.authUserAPIKey())
+	userAPI := r.Group("/v1/user", bf.authUserAPIKey(), appwkhttp.SharedUIDRateLimiter(r, bf.ctx))
 	{
 		userAPI.POST("/bots", bf.createUserBot)
 		userAPI.GET("/bots", bf.listUserBots)
@@ -288,16 +303,32 @@ func (bf *BotFather) listUserBots(c *wkhttp.Context) {
 		return
 	}
 
+	usernames := make([]string, 0, len(bots))
+	seenUsername := make(map[string]struct{}, len(bots))
+	for _, bot := range bots {
+		if bot.Username == "" {
+			continue
+		}
+		if _, ok := seenUsername[bot.Username]; ok {
+			continue
+		}
+		seenUsername[bot.Username] = struct{}{}
+		usernames = append(usernames, bot.Username)
+	}
+	nameByUsername, err := bf.db.queryUserNamesByUsernames(usernames)
+	if err != nil {
+		bf.Warn("批量查询Bot用户名失败，使用username兜底", zap.Error(err))
+		nameByUsername = map[string]string{}
+	}
+
 	list := make([]*UserBotResp, 0, len(bots))
 	for _, bot := range bots {
 		if bot.Status != 1 {
 			continue
 		}
-		// Get display name from user table
 		name := bot.Username
-		userResp, _ := bf.userService.GetUserWithUsername(bot.Username)
-		if userResp != nil {
-			name = userResp.Name
+		if displayName := nameByUsername[bot.Username]; displayName != "" {
+			name = displayName
 		}
 		var boundAt *string
 		if bot.BoundAt.Valid {
@@ -581,9 +612,10 @@ func (bf *BotFather) bindUserBot(c *wkhttp.Context) {
 		// 并发 unbind 污染成「已释放」的陈旧视图）。直接按 agentRef 回包；bound_at
 		// best-effort 回读。
 		if affected == 1 {
-			boundAt := ""
+			var boundAt *string
 			if cur, rErr := bf.db.queryRobotByRobotIDAndCreator(botID, uid); rErr == nil && cur != nil && cur.BoundAt.Valid {
-				boundAt = cur.BoundAt.Time.Format(botBoundAtFormat)
+				s := cur.BoundAt.Time.Format(botBoundAtFormat)
+				boundAt = &s
 			}
 			c.Response(&BindBotResp{RobotID: botID, BoundAgentRef: agentRef, BoundAt: boundAt})
 			return
@@ -604,9 +636,10 @@ func (bf *BotFather) bindUserBot(c *wkhttp.Context) {
 			return
 		case current.BoundAgentRef == agentRef:
 			// 已是自己持有（幂等成功）。
-			boundAt := ""
+			var boundAt *string
 			if current.BoundAt.Valid {
-				boundAt = current.BoundAt.Time.Format(botBoundAtFormat)
+				s := current.BoundAt.Time.Format(botBoundAtFormat)
+				boundAt = &s
 			}
 			c.Response(&BindBotResp{RobotID: botID, BoundAgentRef: current.BoundAgentRef, BoundAt: boundAt})
 			return

--- a/modules/botfather/api_user_bind_test.go
+++ b/modules/botfather/api_user_bind_test.go
@@ -145,7 +145,8 @@ func TestBindUserBot_Lifecycle(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Equal(t, botID, resp.RobotID)
 	assert.Equal(t, "octopush:agent_A", resp.BoundAgentRef)
-	assert.NotEmpty(t, resp.BoundAt)
+	require.NotNil(t, resp.BoundAt)
+	assert.NotEmpty(t, *resp.BoundAt)
 
 	// 2) Re-bind with the SAME agent_ref is idempotent (200).
 	w = httptest.NewRecorder()

--- a/modules/botfather/db.go
+++ b/modules/botfather/db.go
@@ -1,6 +1,8 @@
 package botfather
 
 import (
+	"strings"
+
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/db"
 	"github.com/gocraft/dbr/v2"
@@ -19,19 +21,19 @@ func newBotfatherDB(ctx *config.Context) *botfatherDB {
 }
 
 type robotModel struct {
-	AppID        string
-	RobotID      string
-	Username     string
-	InlineOn     int
-	Placeholder  string
-	Token        string
-	Version      int64
-	Status       int
-	CreatorUID   string
-	Description  string
-	BotToken     string
-	IMTokenCache string
-	BotCommands  string
+	AppID         string
+	RobotID       string
+	Username      string
+	InlineOn      int
+	Placeholder   string
+	Token         string
+	Version       int64
+	Status        int
+	CreatorUID    string
+	Description   string
+	BotToken      string
+	IMTokenCache  string
+	BotCommands   string
 	AutoApprove   int    // 0=需要审批 1=自动通过
 	AccessMode    int    // 0=需要审批 1=自动通过 2=禁止申请
 	AgentPlatform string // AI Agent 平台名称（如 OpenClaw）
@@ -77,6 +79,29 @@ func (d *botfatherDB) queryRobotsByCreatorUIDAndSpaceID(creatorUID, spaceID stri
 		spaceID, creatorUID,
 	).Load(&list)
 	return list, err
+}
+
+func (d *botfatherDB) queryUserNamesByUsernames(usernames []string) (map[string]string, error) {
+	out := make(map[string]string)
+	if len(usernames) == 0 {
+		return out, nil
+	}
+	var rows []struct {
+		Username string
+		Name     string
+	}
+	_, err := d.session.Select("username", "name").From("user").
+		Where("username IN ? AND status=1", usernames).
+		Load(&rows)
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		if row.Username != "" && row.Name != "" {
+			out[row.Username] = row.Name
+		}
+	}
+	return out, nil
 }
 
 // insertRobotTx 插入机器人（事务）
@@ -186,16 +211,22 @@ func (d *botfatherDB) queryAllActiveRobots() ([]*robotModel, error) {
 
 // ========== User API Key ==========
 
-// queryActiveUserAPIKeyByKey 通过明文 API Key 查询 active（status=1）记录（鉴权链路）。
-// 当前 PR 无生产路径把 key 置为 revoked（status=0）；status=1 过滤是为 PR2 的撤销
-// 能力预留的前瞻防御，届时被撤销的 key 在此即时失效。存量行经迁移 DEFAULT 1 回填，
-// 行为不变。
+// queryActiveUserAPIKeyByKey 通过明文 API Key 的 verifier hash 查询 active
+// （status=1）记录（鉴权链路）。
 func (d *botfatherDB) queryActiveUserAPIKeyByKey(apiKey string) (*userAPIKeyModel, error) {
 	if apiKey == "" {
 		return nil, nil
 	}
+	apiKeyHash, err := hashUserAPIKey(apiKey)
 	var m *userAPIKeyModel
-	_, err := d.session.Select("*").From("user_api_key").
+	if err == nil {
+		_, err = d.session.Select("*").From("user_api_key").
+			Where("api_key_hash=? AND status=?", apiKeyHash, userAPIKeyStatusActive).Load(&m)
+		if err != nil || m != nil {
+			return m, err
+		}
+	}
+	_, err = d.session.Select("*").From("user_api_key").
 		Where("api_key=? AND status=?", apiKey, userAPIKeyStatusActive).Load(&m)
 	return m, err
 }
@@ -210,12 +241,139 @@ func (d *botfatherDB) queryActiveUserAPIKey(uid, spaceID, clientID string) (*use
 	return m, err
 }
 
+func (d *botfatherDB) queryActiveUserAPIKeyTx(tx *dbr.Tx, uid, spaceID, clientID string) (*userAPIKeyModel, error) {
+	var m *userAPIKeyModel
+	_, err := tx.Select("*").From("user_api_key").
+		Where("uid=? AND space_id=? AND client_id=? AND status=?", uid, spaceID, clientID, userAPIKeyStatusActive).
+		Load(&m)
+	return m, err
+}
+
 // insertUserAPIKey 插入用户API Key（含绑定的 Space ID 与 client_id 维度）。
-func (d *botfatherDB) insertUserAPIKey(uid, apiKey, spaceID, clientID string) error {
+func (d *botfatherDB) insertUserAPIKey(uid, apiKey, apiKeyHash, apiKeyCipher, spaceID, clientID string) error {
 	_, err := d.session.InsertInto("user_api_key").
-		Columns("uid", "api_key", "space_id", "client_id").
-		Values(uid, apiKey, spaceID, clientID).Exec()
+		Columns("uid", "api_key", "api_key_hash", "api_key_cipher", "space_id", "client_id").
+		Values(uid, apiKey, apiKeyHash, apiKeyCipher, spaceID, clientID).Exec()
 	return err
+}
+
+func (d *botfatherDB) insertUserAPIKeyTx(tx *dbr.Tx, uid, apiKey, apiKeyHash, apiKeyCipher, spaceID, clientID string) error {
+	_, err := tx.InsertInto("user_api_key").
+		Columns("uid", "api_key", "api_key_hash", "api_key_cipher", "space_id", "client_id").
+		Values(uid, apiKey, apiKeyHash, apiKeyCipher, spaceID, clientID).Exec()
+	return err
+}
+
+// rotateRevokedUserAPIKey reactivates an existing revoked row occupying the
+// (uid, space_id, client_id) unique slot, replacing its stored key material.
+func (d *botfatherDB) rotateRevokedUserAPIKey(uid, spaceID, clientID, apiKey, apiKeyHash, apiKeyCipher string) (int64, error) {
+	res, err := d.session.Update("user_api_key").
+		Set("api_key", apiKey).
+		Set("api_key_hash", apiKeyHash).
+		Set("api_key_cipher", apiKeyCipher).
+		Set("status", userAPIKeyStatusActive).
+		Set("revoked_at", nil).
+		Where("uid=? AND space_id=? AND client_id=? AND status=?", uid, spaceID, clientID, userAPIKeyStatusRevoked).
+		Exec()
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+func (d *botfatherDB) rotateRevokedUserAPIKeyTx(tx *dbr.Tx, uid, spaceID, clientID, apiKey, apiKeyHash, apiKeyCipher string) (int64, error) {
+	res, err := tx.Update("user_api_key").
+		Set("api_key", apiKey).
+		Set("api_key_hash", apiKeyHash).
+		Set("api_key_cipher", apiKeyCipher).
+		Set("status", userAPIKeyStatusActive).
+		Set("revoked_at", nil).
+		Where("uid=? AND space_id=? AND client_id=? AND status=?", uid, spaceID, clientID, userAPIKeyStatusRevoked).
+		Exec()
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+func (d *botfatherDB) secureLegacyUserAPIKey(id int64, legacyAPIKey, apiKey, apiKeyHash, apiKeyCipher string) error {
+	_, err := d.session.Update("user_api_key").
+		Set("api_key", apiKey).
+		Set("api_key_hash", apiKeyHash).
+		Set("api_key_cipher", apiKeyCipher).
+		Where("id=? AND api_key=?", id, legacyAPIKey).
+		Exec()
+	return err
+}
+
+func (d *botfatherDB) secureLegacyUserAPIKeyTx(tx *dbr.Tx, id int64, legacyAPIKey, apiKey, apiKeyHash, apiKeyCipher string) error {
+	_, err := tx.Update("user_api_key").
+		Set("api_key", apiKey).
+		Set("api_key_hash", apiKeyHash).
+		Set("api_key_cipher", apiKeyCipher).
+		Where("id=? AND api_key=?", id, legacyAPIKey).
+		Exec()
+	return err
+}
+
+func (d *botfatherDB) isIntegrationClientEnabled(clientID string) (bool, error) {
+	if clientID == "" || clientID == clientIDBotFather {
+		return true, nil
+	}
+	var status int
+	err := d.session.Select("status").From("integration_client").
+		Where("client_id=?", clientID).
+		LoadOne(&status)
+	if err == nil {
+		return status == 1, nil
+	}
+	if err == dbr.ErrNotFound {
+		return false, nil
+	}
+	if isMissingTableErr(err) {
+		// Auth keeps pre-migration botfather keys usable if this table is not
+		// installed yet. Issuance for integration clients intentionally does not
+		// mirror this fallback: lockIntegrationClientEnabledTx fails closed.
+		return true, nil
+	}
+	return false, err
+}
+
+func (d *botfatherDB) lockIntegrationClientEnabledTx(tx *dbr.Tx, clientID string) (bool, error) {
+	if clientID == "" || clientID == clientIDBotFather {
+		return true, nil
+	}
+	var status int
+	err := tx.SelectBySql("SELECT status FROM integration_client WHERE client_id=? FOR UPDATE", clientID).LoadOne(&status)
+	if err == nil {
+		return status == 1, nil
+	}
+	if err == dbr.ErrNotFound {
+		return false, nil
+	}
+	return false, err
+}
+
+func (d *botfatherDB) isActiveUser(uid string) (bool, error) {
+	if uid == "" {
+		return false, nil
+	}
+	var n int
+	err := d.session.Select("COUNT(*)").From("user").
+		Where("uid=? AND status<>0 AND is_destroy=0", uid).
+		LoadOne(&n)
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+func isMissingTableErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Error 1146") || strings.Contains(msg, "doesn't exist")
 }
 
 // querySpaceNameByID 查询Space名称
@@ -274,12 +432,12 @@ func (d *botfatherDB) querySpaceIDByRobotID(robotID string) (string, error) {
 
 // ========== Bot 占用 / 绑定 ==========
 
-// bindRobotCAS 行级 CAS 占用 Bot：仅当 Bot 空闲（bound_agent_ref='')或已被
+// bindRobotCAS 行级 CAS 占用 Bot：仅当 Bot 空闲（bound_agent_ref empty）或已被
 // 同一 agentRef 占用（幂等）时才写入。返回受影响行数：1=占用成功，0=未命中
 // （不存在 / 非本 creator / 已被他人占用），由调用方复查区分。
 //
 // 互斥完全由这条 UPDATE 的 WHERE 在 DB 层保证，无需额外锁——多个 Agent 并发抢
-// 同一空闲 Bot 时只有一条能把 bound_agent_ref 从 '' 改走，其余 affected=0。
+// 同一空闲 Bot 时只有一条能把 bound_agent_ref 从 empty 改走，其余 affected=0。
 func (d *botfatherDB) bindRobotCAS(robotID, creatorUID, agentRef string) (int64, error) {
 	res, err := d.session.UpdateBySql(
 		"UPDATE robot SET bound_agent_ref=?, bound_at=NOW() "+

--- a/modules/botfather/model.go
+++ b/modules/botfather/model.go
@@ -87,15 +87,15 @@ type RobotApplySureReq struct {
 
 // RobotApplyResp 申请记录响应
 type RobotApplyResp struct {
-	ID           int64  `json:"id"`
-	UID          string `json:"uid"`
-	RobotUID     string `json:"robot_uid"`
-	RobotName    string `json:"robot_name"`
+	ID            int64  `json:"id"`
+	UID           string `json:"uid"`
+	RobotUID      string `json:"robot_uid"`
+	RobotName     string `json:"robot_name"`
 	ApplicantName string `json:"applicant_name"`
-	OwnerUID     string `json:"owner_uid"`
-	Remark       string `json:"remark"`
-	Status       int    `json:"status"`
-	CreatedAt    string `json:"created_at"`
+	OwnerUID      string `json:"owner_uid"`
+	Remark        string `json:"remark"`
+	Status        int    `json:"status"`
+	CreatedAt     string `json:"created_at"`
 }
 
 // RobotApplyListResp 申请列表响应
@@ -106,13 +106,15 @@ type RobotApplyListResp struct {
 
 // userAPIKeyModel 用户API Key模型
 type userAPIKeyModel struct {
-	ID        int64  `json:"id"`
-	UID       string `json:"uid"`
-	APIKey    string `json:"api_key"`
-	SpaceID   string `json:"space_id"`
-	ClientID  string `json:"client_id"`
-	Status    int    `json:"status"`
-	CreatedAt string `json:"created_at"`
+	ID           int64  `json:"id"`
+	UID          string `json:"uid"`
+	APIKey       string `json:"api_key"`
+	APIKeyHash   string `json:"api_key_hash"`
+	APIKeyCipher string `json:"api_key_cipher"`
+	SpaceID      string `json:"space_id"`
+	ClientID     string `json:"client_id"`
+	Status       int    `json:"status"`
+	CreatedAt    string `json:"created_at"`
 }
 
 // CreateBotReq 通过API Key创建Bot请求
@@ -150,16 +152,16 @@ type UserBotResp struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	// BotToken 出于安全在列表里恒为空串（不批量泄露 `bf_`）；取 token 走单端点。
-	BotToken    string `json:"bot_token"`
-	CreatedAt   string `json:"created_at"`
+	BotToken  string `json:"bot_token"`
+	CreatedAt string `json:"created_at"`
 	// BoundAgentRef 占用方不透明标签（如 octopush:agent_xxx）；空=空闲。
 	BoundAgentRef string `json:"bound_agent_ref"`
 	// BoundAt 占用时间（timeFormart）；未占用时为 null（*string，与 doc 的
 	// string|null 及 unbind 的显式 null 对齐——不用 omitempty 省略字段）。
 	BoundAt       *string `json:"bound_at"`
 	AgentPlatform string  `json:"agent_platform,omitempty"`
-	AgentVersion  string `json:"agent_version,omitempty"`
-	PluginVersion string `json:"plugin_version,omitempty"`
+	AgentVersion  string  `json:"agent_version,omitempty"`
+	PluginVersion string  `json:"plugin_version,omitempty"`
 }
 
 // BindBotReq 占用（绑定）Bot 请求。
@@ -170,7 +172,7 @@ type BindBotReq struct {
 
 // BindBotResp 占用（绑定）Bot 响应。
 type BindBotResp struct {
-	RobotID       string `json:"robot_id"`
-	BoundAgentRef string `json:"bound_agent_ref"`
-	BoundAt       string `json:"bound_at"`
+	RobotID       string  `json:"robot_id"`
+	BoundAgentRef string  `json:"bound_agent_ref"`
+	BoundAt       *string `json:"bound_at"`
 }

--- a/modules/botfather/service_userapikey.go
+++ b/modules/botfather/service_userapikey.go
@@ -1,11 +1,14 @@
 package botfather
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/gocraft/dbr/v2"
+	"go.uber.org/zap"
 )
 
 // clientIDBotFather labels `uk_` keys minted by botfather's own /quickstart
@@ -13,6 +16,10 @@ import (
 // (e.g. the external application id) into the same service, so every `uk_` is
 // organised along the (uid, space_id, client_id) dimension.
 const clientIDBotFather = "botfather"
+
+// ErrIntegrationClientDisabled is returned when an integration-scoped key
+// issuance attempts to run while the external client is missing or disabled.
+var ErrIntegrationClientDisabled = errors.New("botfather: integration client disabled")
 
 // user_api_key.status values.
 const (
@@ -42,6 +49,11 @@ type UserAPIKeyService interface {
 	// same key (idempotent plaintext echo). A blank clientID defaults to
 	// the botfather client.
 	GetOrCreate(uid, spaceID, clientID string) (string, error)
+	// GetOrCreateForEnabledIntegrationClient is the integration-safe issuance
+	// path. It serializes with manager disable by locking the integration_client
+	// row and re-checking enabled state in the same transaction that creates or
+	// rotates the `uk_` row.
+	GetOrCreateForEnabledIntegrationClient(uid, spaceID, clientID string) (string, error)
 	// AuthByKey resolves an active key by its plaintext value. It returns
 	// (nil, nil) when the key is unknown or revoked.
 	AuthByKey(plaintext string) (*UserAPIKey, error)
@@ -72,15 +84,23 @@ func (s *userAPIKeyService) GetOrCreate(uid, spaceID, clientID string) (string, 
 		return "", fmt.Errorf("query user api key: %w", err)
 	}
 	if existing != nil {
-		return existing.APIKey, nil
+		plaintext, err := s.plaintextForStoredKey(existing)
+		if err != nil {
+			return "", fmt.Errorf("load existing user api key: %w", err)
+		}
+		return plaintext, nil
 	}
 
 	apiKey, err := generateUserAPIKey()
 	if err != nil {
 		return "", fmt.Errorf("generate user api key: %w", err)
 	}
+	storedAPIKey, apiKeyHash, apiKeyCipher, err := buildUserAPIKeyStorageForClient(apiKey, clientID)
+	if err != nil {
+		return "", fmt.Errorf("secure user api key: %w", err)
+	}
 
-	if err := s.db.insertUserAPIKey(uid, apiKey, spaceID, clientID); err != nil {
+	if err := s.db.insertUserAPIKey(uid, storedAPIKey, apiKeyHash, apiKeyCipher, spaceID, clientID); err != nil {
 		// Only a duplicate-key collision (a concurrent caller inserted the
 		// same uk_uid_space_client triple first) is safe to recover by
 		// echoing the winning row — that preserves the idempotency
@@ -89,12 +109,195 @@ func (s *userAPIKeyService) GetOrCreate(uid, spaceID, clientID string) (string, 
 		if isDuplicateKeyErr(err) {
 			again, reErr := s.db.queryActiveUserAPIKey(uid, spaceID, clientID)
 			if reErr == nil && again != nil {
-				return again.APIKey, nil
+				plaintext, plainErr := s.plaintextForStoredKey(again)
+				if plainErr != nil {
+					return "", fmt.Errorf("load concurrent user api key: %w", plainErr)
+				}
+				return plaintext, nil
+			}
+			affected, rotateErr := s.db.rotateRevokedUserAPIKey(uid, spaceID, clientID, storedAPIKey, apiKeyHash, apiKeyCipher)
+			if rotateErr == nil && affected == 1 {
+				return apiKey, nil
+			}
+			if rotateErr != nil {
+				return "", fmt.Errorf("rotate revoked user api key: %w", rotateErr)
+			}
+			if affected == 0 {
+				again, reErr := s.db.queryActiveUserAPIKey(uid, spaceID, clientID)
+				if reErr != nil {
+					return "", fmt.Errorf("query user api key after rotate collision: %w", reErr)
+				}
+				if again != nil {
+					plaintext, plainErr := s.plaintextForStoredKey(again)
+					if plainErr != nil {
+						return "", fmt.Errorf("load rotated user api key: %w", plainErr)
+					}
+					return plaintext, nil
+				}
 			}
 		}
 		return "", fmt.Errorf("insert user api key: %w", err)
 	}
 	return apiKey, nil
+}
+
+func (s *userAPIKeyService) GetOrCreateForEnabledIntegrationClient(uid, spaceID, clientID string) (string, error) {
+	clientID = strings.TrimSpace(clientID)
+	if clientID == "" || clientID == clientIDBotFather {
+		return s.GetOrCreate(uid, spaceID, clientID)
+	}
+
+	tx, err := s.db.session.Begin()
+	if err != nil {
+		return "", fmt.Errorf("begin user api key issuance: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	enabled, err := s.db.lockIntegrationClientEnabledTx(tx, clientID)
+	if err != nil {
+		return "", fmt.Errorf("lock integration client: %w", err)
+	}
+	if !enabled {
+		return "", ErrIntegrationClientDisabled
+	}
+	if err := ValidateUserAPIKeySecret(); err != nil {
+		return "", fmt.Errorf("validate integration user api key secret: %w", err)
+	}
+
+	existing, err := s.db.queryActiveUserAPIKeyTx(tx, uid, spaceID, clientID)
+	if err != nil {
+		return "", fmt.Errorf("query user api key: %w", err)
+	}
+	if existing != nil {
+		plaintext, err := s.plaintextForStoredKeyTx(tx, existing)
+		if err != nil {
+			return "", fmt.Errorf("load existing user api key: %w", err)
+		}
+		if err := tx.Commit(); err != nil {
+			return "", fmt.Errorf("commit existing user api key issuance: %w", err)
+		}
+		committed = true
+		return plaintext, nil
+	}
+
+	apiKey, err := generateUserAPIKey()
+	if err != nil {
+		return "", fmt.Errorf("generate user api key: %w", err)
+	}
+	storedAPIKey, apiKeyHash, apiKeyCipher, err := buildUserAPIKeyStorageForClient(apiKey, clientID)
+	if err != nil {
+		return "", fmt.Errorf("secure user api key: %w", err)
+	}
+
+	if err := s.db.insertUserAPIKeyTx(tx, uid, storedAPIKey, apiKeyHash, apiKeyCipher, spaceID, clientID); err != nil {
+		if isDuplicateKeyErr(err) {
+			again, reErr := s.db.queryActiveUserAPIKeyTx(tx, uid, spaceID, clientID)
+			if reErr == nil && again != nil {
+				plaintext, plainErr := s.plaintextForStoredKeyTx(tx, again)
+				if plainErr != nil {
+					return "", fmt.Errorf("load concurrent user api key: %w", plainErr)
+				}
+				if err := tx.Commit(); err != nil {
+					return "", fmt.Errorf("commit concurrent user api key issuance: %w", err)
+				}
+				committed = true
+				return plaintext, nil
+			}
+			affected, rotateErr := s.db.rotateRevokedUserAPIKeyTx(tx, uid, spaceID, clientID, storedAPIKey, apiKeyHash, apiKeyCipher)
+			if rotateErr == nil && affected == 1 {
+				if err := tx.Commit(); err != nil {
+					return "", fmt.Errorf("commit rotated user api key issuance: %w", err)
+				}
+				committed = true
+				return apiKey, nil
+			}
+			if rotateErr != nil {
+				return "", fmt.Errorf("rotate revoked user api key: %w", rotateErr)
+			}
+			if affected == 0 {
+				again, reErr := s.db.queryActiveUserAPIKeyTx(tx, uid, spaceID, clientID)
+				if reErr != nil {
+					return "", fmt.Errorf("query user api key after rotate collision: %w", reErr)
+				}
+				if again != nil {
+					plaintext, plainErr := s.plaintextForStoredKeyTx(tx, again)
+					if plainErr != nil {
+						return "", fmt.Errorf("load rotated user api key: %w", plainErr)
+					}
+					if err := tx.Commit(); err != nil {
+						return "", fmt.Errorf("commit rotated collision user api key issuance: %w", err)
+					}
+					committed = true
+					return plaintext, nil
+				}
+			}
+		}
+		return "", fmt.Errorf("insert user api key: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return "", fmt.Errorf("commit user api key issuance: %w", err)
+	}
+	committed = true
+	return apiKey, nil
+}
+
+func buildUserAPIKeyStorageForClient(plaintext, clientID string) (stored, hash, cipherText string, err error) {
+	if strings.TrimSpace(plaintext) == "" {
+		return "", "", "", errors.New("empty user api key")
+	}
+	if clientID == "" || clientID == clientIDBotFather {
+		return plaintext, "", "", nil
+	}
+	return buildUserAPIKeyStorage(plaintext)
+}
+
+func (s *userAPIKeyService) plaintextForStoredKey(m *userAPIKeyModel) (string, error) {
+	if m == nil {
+		return "", nil
+	}
+	if m.APIKeyCipher != "" {
+		return decryptUserAPIKey(m.APIKeyCipher)
+	}
+	if strings.HasPrefix(m.APIKey, UserAPIKeyPrefix) {
+		if m.ClientID != "" && m.ClientID != clientIDBotFather {
+			storedAPIKey, apiKeyHash, apiKeyCipher, err := buildUserAPIKeyStorage(m.APIKey)
+			if err != nil {
+				return "", err
+			}
+			if err := s.db.secureLegacyUserAPIKey(m.ID, m.APIKey, storedAPIKey, apiKeyHash, apiKeyCipher); err != nil {
+				s.Warn("legacy user api key secure upgrade failed; continuing with matched key", zap.Int64("keyID", m.ID), zap.Error(err))
+			}
+		}
+		return m.APIKey, nil
+	}
+	return "", fmt.Errorf("user api key id=%d has no decryptable cipher", m.ID)
+}
+
+func (s *userAPIKeyService) plaintextForStoredKeyTx(tx *dbr.Tx, m *userAPIKeyModel) (string, error) {
+	if m == nil {
+		return "", nil
+	}
+	if m.APIKeyCipher != "" {
+		return decryptUserAPIKey(m.APIKeyCipher)
+	}
+	if strings.HasPrefix(m.APIKey, UserAPIKeyPrefix) {
+		if m.ClientID != "" && m.ClientID != clientIDBotFather {
+			storedAPIKey, apiKeyHash, apiKeyCipher, err := buildUserAPIKeyStorage(m.APIKey)
+			if err != nil {
+				return "", err
+			}
+			if err := s.db.secureLegacyUserAPIKeyTx(tx, m.ID, m.APIKey, storedAPIKey, apiKeyHash, apiKeyCipher); err != nil {
+				s.Warn("legacy user api key secure upgrade failed in transaction; continuing with matched key", zap.Int64("keyID", m.ID), zap.Error(err))
+			}
+		}
+		return m.APIKey, nil
+	}
+	return "", fmt.Errorf("user api key id=%d has no decryptable cipher", m.ID)
 }
 
 // isDuplicateKeyErr reports whether err is a MySQL duplicate-key violation
@@ -116,11 +319,34 @@ func (s *userAPIKeyService) AuthByKey(plaintext string) (*UserAPIKey, error) {
 	if m == nil {
 		return nil, nil
 	}
+	enabled, err := s.db.isIntegrationClientEnabled(m.ClientID)
+	if err != nil {
+		return nil, fmt.Errorf("query integration client status: %w", err)
+	}
+	if !enabled {
+		return nil, nil
+	}
+	activeUser, err := s.db.isActiveUser(m.UID)
+	if err != nil {
+		return nil, fmt.Errorf("query user status: %w", err)
+	}
+	if !activeUser {
+		return nil, nil
+	}
+	if m.ClientID != "" && m.ClientID != clientIDBotFather && m.APIKeyCipher == "" && strings.HasPrefix(m.APIKey, UserAPIKeyPrefix) {
+		storedAPIKey, apiKeyHash, apiKeyCipher, err := buildUserAPIKeyStorage(m.APIKey)
+		if err != nil {
+			return nil, fmt.Errorf("secure legacy user api key: %w", err)
+		}
+		if err := s.db.secureLegacyUserAPIKey(m.ID, m.APIKey, storedAPIKey, apiKeyHash, apiKeyCipher); err != nil {
+			s.Warn("legacy user api key secure upgrade failed during auth; continuing with matched key", zap.Int64("keyID", m.ID), zap.Error(err))
+		}
+	}
 	return &UserAPIKey{
 		ID:       m.ID,
 		UID:      m.UID,
 		SpaceID:  m.SpaceID,
 		ClientID: m.ClientID,
-		APIKey:   m.APIKey,
+		APIKey:   plaintext,
 	}, nil
 }

--- a/modules/botfather/service_userapikey_crypto.go
+++ b/modules/botfather/service_userapikey_crypto.go
@@ -1,0 +1,136 @@
+package botfather
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+const (
+	userAPIKeyCipherPrefix  = "enc:v1:"
+	userAPIKeyStoragePrefix = "hash:"
+	userAPIKeySecretEnv     = "OCTO_USER_API_KEY_SECRET"
+	userAPIKeyHashDomain    = "dmwork-user-api-key-verifier-v2"
+	userAPIKeyCipherDomain  = "dmwork-user-api-key-cipher-v1"
+)
+
+func hashUserAPIKey(plaintext string) (string, error) {
+	if strings.TrimSpace(plaintext) == "" {
+		return "", errors.New("empty user api key")
+	}
+	secret, err := userAPIKeySecret()
+	if err != nil {
+		return "", err
+	}
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(userAPIKeyHashDomain))
+	mac.Write([]byte{0})
+	mac.Write([]byte(plaintext))
+	return hex.EncodeToString(mac.Sum(nil)), nil
+}
+
+func storedUserAPIKeyValue(hash string) string {
+	if hash == "" {
+		return ""
+	}
+	return userAPIKeyStoragePrefix + hash
+}
+
+func buildUserAPIKeyStorage(plaintext string) (stored, hash, cipherText string, err error) {
+	if strings.TrimSpace(plaintext) == "" {
+		return "", "", "", errors.New("empty user api key")
+	}
+	hash, err = hashUserAPIKey(plaintext)
+	if err != nil {
+		return "", "", "", err
+	}
+	cipherText, err = encryptUserAPIKey(plaintext)
+	if err != nil {
+		return "", "", "", err
+	}
+	return storedUserAPIKeyValue(hash), hash, cipherText, nil
+}
+
+func encryptUserAPIKey(plaintext string) (string, error) {
+	aead, err := newUserAPIKeyAEAD()
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", fmt.Errorf("user api key nonce: %w", err)
+	}
+	ciphertext := aead.Seal(nonce, nonce, []byte(plaintext), nil)
+	return userAPIKeyCipherPrefix + base64.StdEncoding.EncodeToString(ciphertext), nil
+}
+
+func decryptUserAPIKey(cipherText string) (string, error) {
+	if cipherText == "" {
+		return "", errors.New("empty user api key cipher")
+	}
+	if !strings.HasPrefix(cipherText, userAPIKeyCipherPrefix) {
+		return "", errors.New("unknown user api key cipher prefix")
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(cipherText, userAPIKeyCipherPrefix))
+	if err != nil {
+		return "", fmt.Errorf("decode user api key cipher: %w", err)
+	}
+	aead, err := newUserAPIKeyAEAD()
+	if err != nil {
+		return "", err
+	}
+	ns := aead.NonceSize()
+	if len(raw) < ns+aead.Overhead() {
+		return "", errors.New("user api key cipher too short")
+	}
+	plaintext, err := aead.Open(nil, raw[:ns], raw[ns:], nil)
+	if err != nil {
+		return "", fmt.Errorf("decrypt user api key: %w", err)
+	}
+	return string(plaintext), nil
+}
+
+func newUserAPIKeyAEAD() (cipher.AEAD, error) {
+	secret, err := userAPIKeySecret()
+	if err != nil {
+		return nil, err
+	}
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(userAPIKeyCipherDomain))
+	key := mac.Sum(nil)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("user api key aes: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("user api key gcm: %w", err)
+	}
+	return aead, nil
+}
+
+func userAPIKeySecret() ([]byte, error) {
+	secret := []byte(os.Getenv(userAPIKeySecretEnv))
+	if len(secret) != 32 {
+		return nil, fmt.Errorf("%s must be exactly 32 bytes", userAPIKeySecretEnv)
+	}
+	return secret, nil
+}
+
+// ValidateUserAPIKeySecret is used by integration enable/issuance paths. The
+// BotFather legacy client deliberately does not require this secret so existing
+// /quickstart deployments keep working until uk_ storage hardening is enabled
+// for that client in a dedicated rollout.
+func ValidateUserAPIKeySecret() error {
+	_, err := userAPIKeySecret()
+	return err
+}

--- a/modules/botfather/service_userapikey_test.go
+++ b/modules/botfather/service_userapikey_test.go
@@ -2,6 +2,7 @@ package botfather
 
 import (
 	"errors"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -17,6 +18,8 @@ import (
 )
 
 func setupAPIKeyServiceTest(t *testing.T) (*config.Context, UserAPIKeyService) {
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	t.Setenv("OCTO_USER_API_KEY_SECRET", "fedcba9876543210fedcba9876543210")
 	_, ctx := testutil.NewTestServer()
 	return ctx, NewUserAPIKeyService(ctx)
 }
@@ -33,6 +36,13 @@ func countUserAPIKeys(t *testing.T, ctx *config.Context, uid, spaceID, clientID 
 	return n
 }
 
+func userAPIKeyHashForTest(t *testing.T, s string) string {
+	t.Helper()
+	hash, err := hashUserAPIKey(s)
+	require.NoError(t, err)
+	return hash
+}
+
 func TestUserAPIKeyService_GetOrCreate_Idempotent(t *testing.T) {
 	ctx, svc := setupAPIKeyServiceTest(t)
 	uid := "u_" + util.GenerUUID()[:8]
@@ -46,6 +56,70 @@ func TestUserAPIKeyService_GetOrCreate_Idempotent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, first, second, "repeated GetOrCreate must echo the same plaintext key")
 	assert.Equal(t, 1, countUserAPIKeys(t, ctx, uid, spaceID, clientIDBotFather), "must not create a duplicate row")
+}
+
+func TestUserAPIKeyService_GetOrCreate_StoresVerifierHashAndCipherOnly(t *testing.T) {
+	ctx, svc := setupAPIKeyServiceTest(t)
+	uid := "u_" + util.GenerUUID()[:8]
+	spaceID := "s_" + util.GenerUUID()[:8]
+	insertTestUser(t, ctx, uid, "api-key-owner")
+
+	key, err := svc.GetOrCreate(uid, spaceID, "octopush")
+	require.NoError(t, err)
+
+	var row struct {
+		APIKey       string
+		APIKeyHash   string
+		APIKeyCipher string
+	}
+	err = ctx.DB().Select("api_key", "api_key_hash", "api_key_cipher").
+		From("user_api_key").
+		Where("uid=? AND space_id=? AND client_id=?", uid, spaceID, "octopush").
+		LoadOne(&row)
+	require.NoError(t, err)
+	assert.NotEqual(t, key, row.APIKey, "api_key column must not store the bearer credential")
+	assert.Equal(t, userAPIKeyHashForTest(t, key), row.APIKeyHash)
+	assert.NotEmpty(t, row.APIKeyCipher)
+	assert.NotContains(t, row.APIKeyCipher, key)
+
+	auth, err := svc.AuthByKey(key)
+	require.NoError(t, err)
+	require.NotNil(t, auth)
+	assert.Equal(t, uid, auth.UID)
+}
+
+func TestUserAPIKeyService_GetOrCreate_UsesUserAPIKeySecretNotOctoMasterKey(t *testing.T) {
+	ctx, svc := setupAPIKeyServiceTest(t)
+	uid := "u_" + util.GenerUUID()[:8]
+	spaceID := "s_" + util.GenerUUID()[:8]
+	insertTestUser(t, ctx, uid, "api-key-owner")
+	t.Setenv("OCTO_MASTER_KEY", "")
+
+	key, err := svc.GetOrCreate(uid, spaceID, "octopush")
+	require.NoError(t, err)
+
+	auth, err := svc.AuthByKey(key)
+	require.NoError(t, err)
+	require.NotNil(t, auth)
+	assert.Equal(t, uid, auth.UID)
+	assert.Equal(t, "octopush", auth.ClientID)
+}
+
+func TestUserAPIKeyService_GetOrCreate_BotFatherDoesNotRequireUserAPIKeySecret(t *testing.T) {
+	ctx, svc := setupAPIKeyServiceTest(t)
+	uid := "u_" + util.GenerUUID()[:8]
+	spaceID := "s_" + util.GenerUUID()[:8]
+	insertTestUser(t, ctx, uid, "botfather-owner")
+	t.Setenv("OCTO_USER_API_KEY_SECRET", "")
+
+	key, err := svc.GetOrCreate(uid, spaceID, clientIDBotFather)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(key, UserAPIKeyPrefix))
+
+	auth, err := svc.AuthByKey(key)
+	require.NoError(t, err)
+	require.NotNil(t, auth)
+	assert.Equal(t, clientIDBotFather, auth.ClientID)
 }
 
 func TestUserAPIKeyService_GetOrCreate_DistinctPerClient(t *testing.T) {
@@ -120,6 +194,85 @@ func TestUserAPIKeyService_GetOrCreate_ConcurrentNoDuplicate(t *testing.T) {
 	assert.Equal(t, 1, countUserAPIKeys(t, ctx, uid, spaceID, "octopush"), "concurrent create must not duplicate rows")
 }
 
+func TestUserAPIKeyService_GetOrCreate_RotatesRevokedRow(t *testing.T) {
+	ctx, svc := setupAPIKeyServiceTest(t)
+	uid := "u_" + util.GenerUUID()[:8]
+	spaceID := "s_" + util.GenerUUID()[:8]
+	clientID := "octopush"
+	insertTestUser(t, ctx, uid, "api-key-owner")
+
+	oldKey, err := svc.GetOrCreate(uid, spaceID, clientID)
+	require.NoError(t, err)
+	_, err = ctx.DB().UpdateBySql(
+		"UPDATE user_api_key SET status=?, revoked_at=NOW() WHERE api_key_hash=?",
+		userAPIKeyStatusRevoked, userAPIKeyHashForTest(t, oldKey),
+	).Exec()
+	require.NoError(t, err)
+
+	newKey, err := svc.GetOrCreate(uid, spaceID, clientID)
+	require.NoError(t, err)
+	assert.NotEqual(t, oldKey, newKey, "reactivating a revoked row must rotate the plaintext key")
+	assert.Equal(t, 1, countUserAPIKeys(t, ctx, uid, spaceID, clientID), "revoked-row recovery must not insert a duplicate")
+
+	oldAuth, err := svc.AuthByKey(oldKey)
+	require.NoError(t, err)
+	assert.Nil(t, oldAuth, "old revoked key must stay invalid after rotation")
+
+	newAuth, err := svc.AuthByKey(newKey)
+	require.NoError(t, err)
+	require.NotNil(t, newAuth)
+	assert.Equal(t, uid, newAuth.UID)
+	assert.Equal(t, spaceID, newAuth.SpaceID)
+	assert.Equal(t, clientID, newAuth.ClientID)
+
+	var activeCleared int
+	err = ctx.DB().SelectBySql(
+		"SELECT COUNT(*) FROM user_api_key WHERE uid=? AND space_id=? AND client_id=? AND status=? AND revoked_at IS NULL",
+		uid, spaceID, clientID,
+		userAPIKeyStatusActive,
+	).LoadOne(&activeCleared)
+	require.NoError(t, err)
+	assert.Equal(t, 1, activeCleared, "rotated active row must clear revoked_at")
+}
+
+func TestUserAPIKeyService_GetOrCreate_ConcurrentRevokedRowIsIdempotent(t *testing.T) {
+	ctx, svc := setupAPIKeyServiceTest(t)
+	uid := "u_" + util.GenerUUID()[:8]
+	spaceID := "s_" + util.GenerUUID()[:8]
+	clientID := "octopush"
+
+	oldKey, err := svc.GetOrCreate(uid, spaceID, clientID)
+	require.NoError(t, err)
+	_, err = ctx.DB().UpdateBySql(
+		"UPDATE user_api_key SET status=?, revoked_at=NOW() WHERE api_key_hash=?",
+		userAPIKeyStatusRevoked, userAPIKeyHashForTest(t, oldKey),
+	).Exec()
+	require.NoError(t, err)
+
+	const n = 16
+	keys := make([]string, n)
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			keys[i], errs[i] = svc.GetOrCreate(uid, spaceID, clientID)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i := 0; i < n; i++ {
+		require.NoError(t, errs[i], "concurrent revoked-row GetOrCreate #%d", i)
+		assert.Equal(t, keys[0], keys[i], "all callers must echo the reactivated key")
+	}
+	assert.NotEqual(t, oldKey, keys[0], "revoked row recovery must rotate the old plaintext key")
+	assert.Equal(t, 1, countUserAPIKeys(t, ctx, uid, spaceID, clientID), "revoked-row recovery must keep one logical row")
+}
+
 func TestIsDuplicateKeyErr(t *testing.T) {
 	cases := []struct {
 		name string
@@ -142,6 +295,7 @@ func TestUserAPIKeyService_AuthByKey(t *testing.T) {
 	ctx, svc := setupAPIKeyServiceTest(t)
 	uid := "u_" + util.GenerUUID()[:8]
 	spaceID := "s_" + util.GenerUUID()[:8]
+	insertTestUser(t, ctx, uid, "api-key-owner")
 
 	key, err := svc.GetOrCreate(uid, spaceID, "octopush")
 	require.NoError(t, err)
@@ -161,11 +315,94 @@ func TestUserAPIKeyService_AuthByKey(t *testing.T) {
 
 	// Revoked key (status=0) must fail auth.
 	_, err = ctx.DB().UpdateBySql(
-		"UPDATE user_api_key SET status=? WHERE api_key=?", userAPIKeyStatusRevoked, key,
+		"UPDATE user_api_key SET status=? WHERE api_key_hash=?", userAPIKeyStatusRevoked, userAPIKeyHashForTest(t, key),
 	).Exec()
 	require.NoError(t, err)
 
 	revoked, err := svc.AuthByKey(key)
 	require.NoError(t, err)
 	assert.Nil(t, revoked, "revoked key must not authenticate")
+}
+
+func TestUserAPIKeyService_AuthByKeyLegacyUpgradeFailureIsBestEffort(t *testing.T) {
+	ctx, svc := setupAPIKeyServiceTest(t)
+	uid := "u_" + util.GenerUUID()[:8]
+	blockerUID := "u_" + util.GenerUUID()[:8]
+	spaceID := "s_" + util.GenerUUID()[:8]
+	insertTestUser(t, ctx, uid, "legacy-owner")
+	insertTestUser(t, ctx, blockerUID, "hash-blocker")
+
+	legacyKey := UserAPIKeyPrefix + "legacy_" + util.GenerUUID()[:8]
+	storedAPIKey := storedUserAPIKeyValue(userAPIKeyHashForTest(t, legacyKey))
+	_, err := ctx.DB().InsertInto("user_api_key").
+		Columns("uid", "api_key", "api_key_hash", "api_key_cipher", "space_id", "client_id", "status").
+		Values(uid, legacyKey, "", "", spaceID, "octopush", userAPIKeyStatusActive).
+		Exec()
+	require.NoError(t, err)
+	_, err = ctx.DB().InsertInto("user_api_key").
+		Columns("uid", "api_key", "api_key_hash", "api_key_cipher", "space_id", "client_id", "status").
+		Values(blockerUID, storedAPIKey, "", "", "s_"+util.GenerUUID()[:8], clientIDBotFather, userAPIKeyStatusActive).
+		Exec()
+	require.NoError(t, err)
+
+	got, err := svc.AuthByKey(legacyKey)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, uid, got.UID)
+	assert.Equal(t, "octopush", got.ClientID)
+	assert.Equal(t, legacyKey, got.APIKey)
+}
+
+func TestUserAPIKeyService_AuthByKeyLegacyPlaintextDoesNotNeedOctoMasterKey(t *testing.T) {
+	ctx, svc := setupAPIKeyServiceTest(t)
+	uid := "u_" + util.GenerUUID()[:8]
+	spaceID := "s_" + util.GenerUUID()[:8]
+	insertTestUser(t, ctx, uid, "legacy-owner")
+	t.Setenv("OCTO_MASTER_KEY", "")
+	t.Setenv("OCTO_USER_API_KEY_SECRET", "")
+
+	legacyKey := UserAPIKeyPrefix + "legacy_" + util.GenerUUID()[:8]
+	_, err := ctx.DB().InsertInto("user_api_key").
+		Columns("uid", "api_key", "api_key_hash", "api_key_cipher", "space_id", "client_id", "status").
+		Values(uid, legacyKey, "", "", spaceID, clientIDBotFather, userAPIKeyStatusActive).
+		Exec()
+	require.NoError(t, err)
+
+	got, err := svc.AuthByKey(legacyKey)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, uid, got.UID)
+	assert.Equal(t, legacyKey, got.APIKey)
+}
+
+func TestUserAPIKeyService_AuthByKeyRejectsInactiveUser(t *testing.T) {
+	ctx, svc := setupAPIKeyServiceTest(t)
+	uid := "u_" + util.GenerUUID()[:8]
+	spaceID := "s_" + util.GenerUUID()[:8]
+	insertTestUser(t, ctx, uid, "api-key-owner")
+
+	key, err := svc.GetOrCreate(uid, spaceID, clientIDBotFather)
+	require.NoError(t, err)
+
+	_, err = ctx.DB().Update("user").Set("status", 0).Where("uid=?", uid).Exec()
+	require.NoError(t, err)
+
+	got, err := svc.AuthByKey(key)
+	require.NoError(t, err)
+	assert.Nil(t, got, "active uk_ rows must not authenticate inactive users")
+}
+
+func TestDecryptUserAPIKeyRejectsUnknownCipherPrefix(t *testing.T) {
+	got, err := decryptUserAPIKey("plain-legacy-value")
+	require.Error(t, err)
+	assert.Empty(t, got)
+}
+
+func TestUserAPIKeyClientDimensionDownDoesNotHardDeleteIntegrationKeys(t *testing.T) {
+	raw, err := os.ReadFile("sql/20260603000001_botfather_legacy01.sql")
+	require.NoError(t, err)
+	sql := string(raw)
+
+	assert.NotContains(t, sql, "DELETE FROM `user_api_key` WHERE `client_id` <> 'botfather'")
+	assert.Contains(t, sql, "SIGNAL SQLSTATE", "rollback must abort loudly instead of silently deleting integration keys")
 }

--- a/modules/botfather/sql/20260603000001_botfather_legacy01.sql
+++ b/modules/botfather/sql/20260603000001_botfather_legacy01.sql
@@ -99,21 +99,23 @@ DROP PROCEDURE IF EXISTS __botfather_user_api_key_clientdim_down;
 -- +migrate StatementBegin
 CREATE PROCEDURE __botfather_user_api_key_clientdim_down()
 BEGIN
+  -- 回滚到 (uid, space_id) 唯一键前必须确认没有 integration client 数据。
+  -- 一旦特性被使用过，同一 uid+space 下可能存在多个 client 的 key，直接重建旧
+  -- 唯一键会因重复 (uid, space_id) 撞键失败；静默 DELETE 又会不可恢复地删除
+  -- 已签发的 integration uk_。因此这里 loud abort，由人工 runbook 决定迁移或
+  -- 撤销这些 key 后再回滚。
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key'
+         AND COLUMN_NAME = 'client_id')
+     AND EXISTS (SELECT 1 FROM `user_api_key` WHERE `client_id` <> 'botfather') THEN
+    SIGNAL SQLSTATE '45000'
+      SET MESSAGE_TEXT = 'rollback blocked: non-botfather user_api_key rows exist';
+  END IF;
+
   IF EXISTS (SELECT 1 FROM information_schema.STATISTICS
        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key'
          AND INDEX_NAME = 'uk_uid_space_client') THEN
     ALTER TABLE `user_api_key` DROP INDEX `uk_uid_space_client`;
-  END IF;
-
-  -- 回滚到 (uid, space_id) 唯一键前，先清掉本特性引入的非 botfather client 行：
-  -- 一旦特性被使用过，同一 uid+space 下可能存在多个 client 的 key，直接重建旧
-  -- 唯一键会因重复 (uid, space_id) 撞键失败。删除这些行后 botfather 自有行在
-  -- (uid, space_id) 上仍唯一（旧唯一键时代即如此），重建安全。回滚即移除本特性，
-  -- 删其数据符合语义。client_id 列仍在时才执行（列已不在说明已回滚过）。
-  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
-       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key'
-         AND COLUMN_NAME = 'client_id') THEN
-    DELETE FROM `user_api_key` WHERE `client_id` <> 'botfather';
   END IF;
 
   IF NOT EXISTS (SELECT 1 FROM information_schema.STATISTICS

--- a/modules/botfather/sql/20260604000003_user_api_key_hash.sql
+++ b/modules/botfather/sql/20260604000003_user_api_key_hash.sql
@@ -1,0 +1,68 @@
+-- +migrate Up
+-- Add keyed verifier hashes for integration uk_ lookup and index the hash used
+-- by AuthByKey. Integration writes store only a non-bearer marker in api_key
+-- plus encrypted api_key_cipher for idempotent echo. Legacy plaintext
+-- integration rows are converted on first successful touch because the verifier
+-- is keyed by OCTO_USER_API_KEY_SECRET and cannot be safely backfilled in SQL.
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __botfather_user_api_key_hash;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __botfather_user_api_key_hash()
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key' AND COLUMN_NAME = 'api_key_hash') THEN
+    ALTER TABLE `user_api_key`
+      ADD COLUMN `api_key_hash` varchar(64) NOT NULL DEFAULT '' COMMENT 'HMAC-SHA256 verifier for integration uk_ auth lookup';
+  ELSE
+    ALTER TABLE `user_api_key`
+      MODIFY COLUMN `api_key_hash` varchar(64) NOT NULL DEFAULT '' COMMENT 'HMAC-SHA256 verifier for integration uk_ auth lookup';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key' AND COLUMN_NAME = 'api_key_cipher') THEN
+    ALTER TABLE `user_api_key`
+      ADD COLUMN `api_key_cipher` varchar(255) NOT NULL DEFAULT '' COMMENT 'AES-GCM encrypted integration uk_ plaintext for idempotent echo';
+  ELSE
+    ALTER TABLE `user_api_key`
+      MODIFY COLUMN `api_key_cipher` varchar(255) NOT NULL DEFAULT '' COMMENT 'AES-GCM encrypted integration uk_ plaintext for idempotent echo';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.STATISTICS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key'
+         AND INDEX_NAME = 'idx_api_key_hash') THEN
+    ALTER TABLE `user_api_key`
+      ADD INDEX `idx_api_key_hash` (`api_key_hash`);
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __botfather_user_api_key_hash();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __botfather_user_api_key_hash;
+-- +migrate StatementEnd
+
+-- +migrate Down
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __botfather_user_api_key_hash_down;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __botfather_user_api_key_hash_down()
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.STATISTICS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_api_key'
+         AND INDEX_NAME = 'idx_api_key_hash') THEN
+    ALTER TABLE `user_api_key` DROP INDEX `idx_api_key_hash`;
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __botfather_user_api_key_hash_down();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __botfather_user_api_key_hash_down;
+-- +migrate StatementEnd

--- a/modules/integration/1module.go
+++ b/modules/integration/1module.go
@@ -1,0 +1,23 @@
+package integration
+
+import (
+	"embed"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
+)
+
+//go:embed sql
+var sqlFS embed.FS
+
+func init() {
+	register.AddModule(func(ctx interface{}) register.Module {
+		return register.Module{
+			Name: "integration",
+			SetupAPI: func() register.APIRouter {
+				return New(ctx.(*config.Context))
+			},
+			SQLDir: register.NewSQLFS(sqlFS),
+		}
+	})
+}

--- a/modules/integration/api.go
+++ b/modules/integration/api.go
@@ -1,0 +1,399 @@
+package integration
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/botfather"
+	"github.com/Mininglamp-OSS/octo-server/modules/oidc"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	pkgspace "github.com/Mininglamp-OSS/octo-server/pkg/space"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
+	"github.com/gin-gonic/gin"
+	rd "github.com/go-redis/redis"
+	"go.uber.org/zap"
+)
+
+const (
+	defaultIntegrationIPRateLimitRPS   = 2.0
+	defaultIntegrationIPRateLimitBurst = 60
+	integrationRateLimitPoolSize       = 10
+)
+
+var (
+	integrationRateRedisOnce   sync.Once
+	integrationRateRedisClient *rd.Client
+)
+
+type Integration struct {
+	ctx           *config.Context
+	db            *integrationDB
+	oidcDB        *oidc.DB
+	oidcClient    *oidc.Client
+	apiKeyService botfather.UserAPIKeyService
+	rateRedis     *rd.Client
+	log.Log
+}
+
+func New(ctx *config.Context) *Integration {
+	it := &Integration{
+		ctx:           ctx,
+		db:            newIntegrationDB(ctx),
+		oidcDB:        oidc.NewDB(ctx),
+		apiKeyService: botfather.NewUserAPIKeyService(ctx),
+		rateRedis:     sharedIntegrationRateRedis(ctx.GetConfig()),
+		Log:           log.NewTLog("Integration"),
+	}
+	cfg, err := oidc.LoadConfig()
+	if err != nil {
+		it.Error("加载 OIDC integration 配置失败", zap.Error(err))
+		return it
+	}
+	if !cfg.Enabled {
+		return it
+	}
+	client, err := oidc.NewClient(context.Background(), oidc.ClientConfig{
+		Issuer:       cfg.Provider.Issuer,
+		ClientID:     cfg.Provider.ClientID,
+		ClientSecret: cfg.Provider.ClientSecret,
+		RedirectURI:  cfg.Provider.RedirectURI,
+		Scopes:       cfg.Provider.Scopes,
+		ClockSkew:    cfg.Provider.ClockSkew,
+		HTTPTimeout:  cfg.Provider.HTTPTimeout,
+	})
+	if err != nil {
+		it.Error("初始化 OIDC integration client 失败", zap.Error(err))
+		return it
+	}
+	it.oidcClient = client
+	return it
+}
+
+func sharedIntegrationRateRedis(cfg *config.Config) *rd.Client {
+	integrationRateRedisOnce.Do(func() {
+		integrationRateRedisClient = rd.NewClient(octoredis.MustBuildOptions(cfg, func(o *rd.Options) {
+			o.MaxRetries = 1
+			o.PoolSize = integrationRateLimitPoolSize
+		}))
+	})
+	return integrationRateRedisClient
+}
+
+func (it *Integration) Route(r *wkhttp.WKHttp) {
+	ipLimit := r.StrictIPRateLimitMiddleware(
+		context.Background(),
+		it.rateRedis,
+		"integration_oidc",
+		wkhttp.ParseRPSFromEnv("DM_INTEGRATION_IP_RATELIMIT_RPS", defaultIntegrationIPRateLimitRPS),
+		wkhttp.ParseBurstFromEnv("DM_INTEGRATION_IP_RATELIMIT_BURST", defaultIntegrationIPRateLimitBurst),
+	)
+	uidLimit := appwkhttp.SharedUIDRateLimiter(r, it.ctx)
+	base := r.Group("/v1/integrations/oidc", it.forceEnglish(), ipLimit)
+	base.GET("/spaces", it.oidcAuth(), uidLimit, it.listSpaces)
+	base.POST("/exchange", it.oidcAuth(), uidLimit, it.exchange)
+	base.DELETE("/binding", it.userAPIKeyAuth(), uidLimit, it.deleteBinding)
+
+	manager := r.Group("/v1/manager", it.ctx.AuthMiddleware(r), uidLimit)
+	manager.PUT("/integrations/oidc/client", it.upsertManagerClient)
+}
+
+func (it *Integration) forceEnglish() wkhttp.HandlerFunc {
+	return func(c *wkhttp.Context) {
+		c.Request = c.Request.WithContext(i18n.WithLanguage(c.Request.Context(), i18n.LanguageDecision{
+			Language: i18n.SourceLanguage,
+			Source:   i18n.LanguageSourceTrustedHeader,
+		}))
+		c.Next()
+	}
+}
+
+func (it *Integration) oidcAuth() wkhttp.HandlerFunc {
+	return func(c *wkhttp.Context) {
+		if it.oidcClient == nil {
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+			c.Abort()
+			return
+		}
+		raw := extractBearer(c)
+		if raw == "" {
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedTokenMissing, nil, nil)
+			c.Abort()
+			return
+		}
+		claims, err := it.oidcClient.VerifyIDToken(c.Request.Context(), raw)
+		if err != nil {
+			it.Warn("OIDC integration token verify failed", zap.Error(err))
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedTokenInvalid, nil, nil)
+			c.Abort()
+			return
+		}
+		if strings.TrimSpace(claims.Subject) == "" {
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedTokenInvalid, nil, nil)
+			c.Abort()
+			return
+		}
+		enabled, err := it.db.isClientEnabled(defaultClientID)
+		if err != nil {
+			it.Error("查询 integration client 失败", zap.Error(err))
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+			c.Abort()
+			return
+		}
+		if !enabled {
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrIntegrationDisabled, nil, nil)
+			c.Abort()
+			return
+		}
+		if err := botfather.ValidateUserAPIKeySecret(); err != nil {
+			it.Error("integration request blocked by invalid user api key secret", zap.Error(err))
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+			c.Abort()
+			return
+		}
+
+		identity, err := it.oidcDB.QueryIdentityByIssuerSubject(claims.Issuer, claims.Subject)
+		if err != nil {
+			it.Error("查询 OIDC identity 失败", zap.Error(err))
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+			c.Abort()
+			return
+		}
+		if identity == nil || identity.UID == "" {
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrIntegrationUserNotLinked, nil, nil)
+			c.Abort()
+			return
+		}
+		activeUser, err := it.db.isActiveUser(identity.UID)
+		if err != nil {
+			it.Error("查询 integration 本地用户状态失败", zap.Error(err))
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+			c.Abort()
+			return
+		}
+		if !activeUser {
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrIntegrationUserNotLinked, nil, nil)
+			c.Abort()
+			return
+		}
+
+		c.Set("uid", identity.UID)
+		c.Set("integration_principal", &oidcPrincipal{
+			UID:     identity.UID,
+			Subject: claims.Subject,
+			Issuer:  claims.Issuer,
+		})
+		c.Next()
+	}
+}
+
+func (it *Integration) userAPIKeyAuth() wkhttp.HandlerFunc {
+	return func(c *wkhttp.Context) {
+		token := extractBearer(c)
+		if token == "" || !strings.HasPrefix(token, botfather.UserAPIKeyPrefix) {
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedTokenInvalid, nil, nil)
+			c.Abort()
+			return
+		}
+		key, err := it.apiKeyService.AuthByKey(token)
+		if err != nil {
+			it.Error("integration binding 查询 uk_ 失败", zap.Error(err))
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+			c.Abort()
+			return
+		}
+		if key == nil {
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedTokenInvalid, nil, nil)
+			c.Abort()
+			return
+		}
+		if key.ClientID != defaultClientID {
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedTokenInvalid, nil, nil)
+			c.Abort()
+			return
+		}
+		c.Set("uid", key.UID)
+		c.Set("integration_api_key", key)
+		c.Next()
+	}
+}
+
+func (it *Integration) upsertManagerClient(c *wkhttp.Context) {
+	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedForbidden, nil, nil)
+		return
+	}
+
+	var req managerIntegrationClientReq
+	if err := c.BindJSON(&req); err != nil {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedParamInvalid, nil, i18n.Details{"field": "body"})
+		return
+	}
+	if req.Status == nil || (*req.Status != 0 && *req.Status != 1) {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedParamInvalid, nil, i18n.Details{"field": "status"})
+		return
+	}
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		name = defaultClientName
+	}
+	if len(name) > 100 {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedParamInvalid, nil, i18n.Details{"field": "name"})
+		return
+	}
+	if *req.Status == 1 {
+		if err := botfather.ValidateUserAPIKeySecret(); err != nil {
+			it.Error("integration client enable blocked by invalid user api key secret", zap.Error(err))
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+			return
+		}
+	}
+	if err := it.db.upsertClient(defaultClientID, name, *req.Status); err != nil {
+		it.Error("写入 integration client 失败", zap.Error(err))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+	c.Response(managerIntegrationClientResp{
+		ClientID: defaultClientID,
+		Name:     name,
+		Status:   *req.Status,
+		Enabled:  *req.Status == 1,
+	})
+}
+
+func (it *Integration) listSpaces(c *wkhttp.Context) {
+	principal, ok := getPrincipal(c)
+	if !ok {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+	spaces, err := it.db.querySpaces(principal.UID)
+	if err != nil {
+		it.Error("查询 integration spaces 失败", zap.Error(err))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+	c.Response(spacesResp{
+		UID:      principal.UID,
+		ClientID: defaultClientID,
+		Spaces:   spaces,
+	})
+}
+
+func (it *Integration) exchange(c *wkhttp.Context) {
+	principal, ok := getPrincipal(c)
+	if !ok {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+
+	var req exchangeReq
+	if err := c.BindJSON(&req); err != nil {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedParamInvalid, nil, i18n.Details{"field": "body"})
+		return
+	}
+	req.SpaceID = strings.TrimSpace(req.SpaceID)
+	if req.SpaceID == "" {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedParamInvalid, nil, i18n.Details{"field": "space_id"})
+		return
+	}
+
+	spaceName, err := it.db.queryActiveSpaceName(req.SpaceID)
+	if err != nil {
+		it.Error("查询 exchange Space 失败", zap.Error(err))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+	if spaceName == "" {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedNotFound, nil, nil)
+		return
+	}
+
+	member, err := pkgspace.CheckMembership(it.ctx.DB(), req.SpaceID, principal.UID)
+	if err != nil {
+		it.Error("校验 exchange Space 成员失败", zap.Error(err))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+	if !member {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedForbidden, nil, nil)
+		return
+	}
+
+	apiKey, err := it.apiKeyService.GetOrCreateForEnabledIntegrationClient(principal.UID, req.SpaceID, defaultClientID)
+	if err != nil {
+		if errors.Is(err, botfather.ErrIntegrationClientDisabled) {
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrIntegrationDisabled, nil, nil)
+			return
+		}
+		it.Error("签发 integration uk_ 失败", zap.Error(err))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+
+	resp := exchangeResp{
+		UID:       principal.UID,
+		SpaceID:   req.SpaceID,
+		SpaceName: spaceName,
+		ClientID:  defaultClientID,
+		APIKey:    apiKey,
+	}
+	if req.IncludeBots {
+		bots, err := it.db.queryBots(principal.UID, req.SpaceID)
+		if err != nil {
+			it.Error("查询 integration bots 失败", zap.Error(err))
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+			return
+		}
+		resp.Bots = bots
+	}
+	c.Response(resp)
+}
+
+func (it *Integration) deleteBinding(c *wkhttp.Context) {
+	key, ok := getUserAPIKey(c)
+	if !ok {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+	if err := it.db.revokeUserAPIKey(key.ID); err != nil {
+		it.Error("撤销 integration uk_ 失败", zap.Int64("keyID", key.ID), zap.Error(err))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+	c.Response(gin.H{"revoked": true})
+}
+
+func extractBearer(c *wkhttp.Context) string {
+	auth := strings.TrimSpace(c.GetHeader("Authorization"))
+	parts := strings.Fields(auth)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return ""
+	}
+	return parts[1]
+}
+
+func getPrincipal(c *wkhttp.Context) (*oidcPrincipal, bool) {
+	v, ok := c.Get("integration_principal")
+	if !ok {
+		return nil, false
+	}
+	p, ok := v.(*oidcPrincipal)
+	return p, ok && p != nil
+}
+
+func getUserAPIKey(c *wkhttp.Context) (*botfather.UserAPIKey, bool) {
+	v, ok := c.Get("integration_api_key")
+	if !ok {
+		return nil, false
+	}
+	key, ok := v.(*botfather.UserAPIKey)
+	return key, ok && key != nil
+}

--- a/modules/integration/api_test.go
+++ b/modules/integration/api_test.go
@@ -1,0 +1,834 @@
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	libwkhttp "github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/botfather"
+	"github.com/Mininglamp-OSS/octo-server/modules/oidc"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupIntegrationAPITest(t *testing.T) (http.Handler, *config.Context, *oidc.MockProvider) {
+	t.Helper()
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	t.Setenv("OCTO_USER_API_KEY_SECRET", "fedcba9876543210fedcba9876543210")
+
+	mp := oidc.NewMockProvider(t)
+	rtKey := base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
+	t.Setenv("DM_OIDC_ENABLED", "true")
+	t.Setenv("DM_OIDC_PROVIDER_ISSUER", mp.Issuer)
+	t.Setenv("DM_OIDC_PROVIDER_CLIENT_ID", mp.ClientID)
+	t.Setenv("DM_OIDC_PROVIDER_CLIENT_SECRET", "test-secret")
+	t.Setenv("DM_OIDC_PROVIDER_REDIRECT_URI", "https://octo.example/callback")
+	t.Setenv("DM_OIDC_RT_ENC_KEY", rtKey)
+	t.Setenv("DM_INTEGRATION_IP_RATELIMIT_RPS", "1000")
+	t.Setenv("DM_INTEGRATION_IP_RATELIMIT_BURST", "10000")
+
+	s, ctx := testutil.NewTestServer()
+	s.GetRoute().SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.SourceLanguage)))
+	seedIntegrationClient(t, ctx, defaultClientID, 1)
+	return s.GetRoute(), ctx, mp
+}
+
+func seedIntegrationClient(t *testing.T, ctx *config.Context, clientID string, status int) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO integration_client (client_id, name, status) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE status=VALUES(status), name=VALUES(name)",
+		clientID, clientID, status,
+	).Exec()
+	require.NoError(t, err)
+}
+
+func seedIntegrationUser(t *testing.T, ctx *config.Context, issuer, subject string) string {
+	t.Helper()
+	uid := "u_" + util.GenerUUID()[:8]
+	insertIntegrationBareUser(t, ctx, uid)
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO user_oidc_identity (uid, issuer, subject, email, email_verified) VALUES (?, ?, ?, ?, 1)",
+		uid, issuer, subject, uid+"@example.com",
+	).Exec()
+	require.NoError(t, err)
+	return uid
+}
+
+func insertIntegrationBareUser(t *testing.T, ctx *config.Context, uid string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO user (uid, name, username, short_no, status) VALUES (?, ?, ?, ?, 1)",
+		uid, "User "+uid, uid, "sn_"+uid,
+	).Exec()
+	require.NoError(t, err)
+}
+
+func seedSpaceMembership(t *testing.T, ctx *config.Context, uid, spaceID, name string, role int, joinedAt string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO space (space_id, name, status, created_at, updated_at) VALUES (?, ?, 1, ?, ?)",
+		spaceID, name, joinedAt, joinedAt,
+	).Exec()
+	require.NoError(t, err)
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO space_member (space_id, uid, role, status, created_at, updated_at) VALUES (?, ?, ?, 1, ?, ?)",
+		spaceID, uid, role, joinedAt, joinedAt,
+	).Exec()
+	require.NoError(t, err)
+}
+
+func seedOwnBot(t *testing.T, ctx *config.Context, uid, spaceID, robotID, boundAgentRef string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO user (uid, name, username, short_no, robot, status) VALUES (?, ?, ?, ?, 1, 1)",
+		robotID, "Bot "+robotID, robotID, "sn_"+robotID,
+	).Exec()
+	require.NoError(t, err)
+	boundAtExpr := "NULL"
+	args := []interface{}{robotID, robotID, uid, "bf_" + robotID, boundAgentRef}
+	if boundAgentRef != "" {
+		boundAtExpr = "NOW()"
+	}
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, username, creator_uid, bot_token, status, bound_agent_ref, bound_at) VALUES (?, ?, ?, ?, 1, ?, "+boundAtExpr+")",
+		args...,
+	).Exec()
+	require.NoError(t, err)
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO space_member (space_id, uid, role, status, created_at, updated_at) VALUES (?, ?, 0, 1, NOW(), NOW())",
+		spaceID, robotID,
+	).Exec()
+	require.NoError(t, err)
+}
+
+func mintIntegrationIDToken(t *testing.T, mp *oidc.MockProvider, subject string) string {
+	t.Helper()
+	mp.PrepUser(subject, map[string]interface{}{"email": subject + "@example.com", "email_verified": true})
+	code := "code_" + util.GenerUUID()
+	mp.PrepCode(code, subject, "nonce")
+	client, err := oidc.NewClient(context.Background(), oidc.ClientConfig{
+		Issuer:       mp.Issuer,
+		ClientID:     mp.ClientID,
+		ClientSecret: "test-secret",
+		RedirectURI:  "https://octo.example/callback",
+		Scopes:       []string{"openid", "profile", "email"},
+		ClockSkew:    time.Minute,
+		HTTPTimeout:  5 * time.Second,
+	})
+	require.NoError(t, err)
+	tok, err := client.Exchange(context.Background(), code, "verifier")
+	require.NoError(t, err)
+	raw, ok := tok.Extra("id_token").(string)
+	require.True(t, ok)
+	require.NotEmpty(t, raw)
+	return raw
+}
+
+func integrationRequest(t *testing.T, method, path, token string, body interface{}) *http.Request {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		require.NoError(t, json.NewEncoder(&buf).Encode(body))
+	}
+	req := httptest.NewRequest(method, path, &buf)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+type integrationErrEnvelope struct {
+	Error struct {
+		Code       string `json:"code"`
+		Message    string `json:"message"`
+		HTTPStatus int    `json:"http_status"`
+	} `json:"error"`
+}
+
+func TestOIDCSpacesAndExchangeFlow(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	subject := "sub-flow"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	spaceA := "sp_" + util.GenerUUID()[:8]
+	spaceB := "sp_" + util.GenerUUID()[:8]
+	seedSpaceMembership(t, ctx, uid, spaceA, "Research", 2, "2026-01-01 10:00:00")
+	seedSpaceMembership(t, ctx, uid, spaceB, "Sandbox", 0, "2026-01-02 10:00:00")
+	seedOwnBot(t, ctx, uid, spaceA, "bot_"+util.GenerUUID()[:8], "")
+	seedOwnBot(t, ctx, uid, spaceB, "busy_"+util.GenerUUID()[:8], "octopush:agent_busy")
+	idToken := mintIntegrationIDToken(t, mp, subject)
+
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodGet, "/v1/integrations/oidc/spaces", idToken, nil))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var spacesResp struct {
+		UID      string `json:"uid"`
+		ClientID string `json:"client_id"`
+		Spaces   []struct {
+			SpaceID         string `json:"space_id"`
+			Name            string `json:"name"`
+			Role            int    `json:"role"`
+			MemberCount     int    `json:"member_count"`
+			IsDefault       bool   `json:"is_default"`
+			HasAvailableBot bool   `json:"has_available_bot"`
+		} `json:"spaces"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &spacesResp))
+	assert.Equal(t, uid, spacesResp.UID)
+	assert.Equal(t, defaultClientID, spacesResp.ClientID)
+	require.Len(t, spacesResp.Spaces, 2)
+	bySpace := map[string]bool{}
+	for _, sp := range spacesResp.Spaces {
+		bySpace[sp.SpaceID] = sp.HasAvailableBot
+		if sp.SpaceID == spaceA {
+			assert.True(t, sp.IsDefault)
+		}
+	}
+	assert.True(t, bySpace[spaceA])
+	assert.False(t, bySpace[spaceB])
+
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/exchange", idToken, map[string]interface{}{
+		"space_id":     spaceA,
+		"include_bots": true,
+	}))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var exchangeResp struct {
+		UID       string `json:"uid"`
+		SpaceID   string `json:"space_id"`
+		ClientID  string `json:"client_id"`
+		APIKey    string `json:"api_key"`
+		SpaceName string `json:"space_name"`
+		Bots      []struct {
+			RobotID  string `json:"robot_id"`
+			BotToken string `json:"bot_token"`
+		} `json:"bots"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &exchangeResp))
+	assert.Equal(t, uid, exchangeResp.UID)
+	assert.Equal(t, spaceA, exchangeResp.SpaceID)
+	assert.Equal(t, defaultClientID, exchangeResp.ClientID)
+	assert.Equal(t, "Research", exchangeResp.SpaceName)
+	assert.Contains(t, exchangeResp.APIKey, botfather.UserAPIKeyPrefix)
+	require.Len(t, exchangeResp.Bots, 1)
+	assert.Empty(t, exchangeResp.Bots[0].BotToken)
+}
+
+func TestOIDCSpacesWithoutMembershipReturnsEmptyArray(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	subject := "sub-no-spaces"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	idToken := mintIntegrationIDToken(t, mp, subject)
+
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodGet, "/v1/integrations/oidc/spaces", idToken, nil))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var spacesResp struct {
+		UID    string          `json:"uid"`
+		Spaces json.RawMessage `json:"spaces"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &spacesResp))
+	assert.Equal(t, uid, spacesResp.UID)
+	assert.JSONEq(t, `[]`, string(spacesResp.Spaces))
+}
+
+func TestOIDCSpacesAcceptsCaseInsensitiveBearerScheme(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	subject := "sub-lower-bearer"
+	seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	idToken := mintIntegrationIDToken(t, mp, subject)
+
+	req := integrationRequest(t, http.MethodGet, "/v1/integrations/oidc/spaces", "", nil)
+	req.Header.Set("Authorization", "bearer "+idToken)
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+func TestOIDCExchangeRejectsInactiveLinkedUser(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		status    int
+		isDestroy int
+	}{
+		{name: "disabled", status: 0, isDestroy: 0},
+		{name: "destroyed", status: 1, isDestroy: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			route, ctx, mp := setupIntegrationAPITest(t)
+			subject := "sub-inactive-" + tc.name
+			uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+			spaceID := "sp_" + util.GenerUUID()[:8]
+			seedSpaceMembership(t, ctx, uid, spaceID, "Inactive", 2, "2026-01-01 10:00:00")
+			_, err := ctx.DB().Update("user").
+				Set("status", tc.status).
+				Set("is_destroy", tc.isDestroy).
+				Where("uid=?", uid).
+				Exec()
+			require.NoError(t, err)
+			idToken := mintIntegrationIDToken(t, mp, subject)
+
+			w := httptest.NewRecorder()
+			route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/exchange", idToken, map[string]interface{}{
+				"space_id": spaceID,
+			}))
+
+			require.Equal(t, http.StatusForbidden, w.Code, w.Body.String())
+			var env integrationErrEnvelope
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+			assert.Equal(t, "err.server.integration.user_not_linked", env.Error.Code)
+
+			var active int
+			err = ctx.DB().SelectBySql(
+				"SELECT COUNT(*) FROM user_api_key WHERE uid=? AND space_id=? AND client_id=? AND status=1",
+				uid, spaceID, defaultClientID,
+			).LoadOne(&active)
+			require.NoError(t, err)
+			assert.Equal(t, 0, active)
+		})
+	}
+}
+
+func TestNewConfigBranches(t *testing.T) {
+	_, ctx, _ := setupIntegrationAPITest(t)
+
+	t.Setenv("DM_OIDC_ENABLED", "false")
+	disabled := New(ctx)
+	assert.Nil(t, disabled.oidcClient)
+
+	t.Setenv("DM_OIDC_ENABLED", "true")
+	t.Setenv("DM_OIDC_RT_ENC_KEY", "not-base64")
+	badConfig := New(ctx)
+	assert.Nil(t, badConfig.oidcClient)
+
+	rtKey := base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
+	t.Setenv("DM_OIDC_RT_ENC_KEY", rtKey)
+	t.Setenv("DM_OIDC_PROVIDER_ISSUER", "://bad")
+	badDiscovery := New(ctx)
+	assert.Nil(t, badDiscovery.oidcClient)
+}
+
+func TestIntegrationDBMissingClientAndBlankSpace(t *testing.T) {
+	_, ctx, _ := setupIntegrationAPITest(t)
+	db := newIntegrationDB(ctx)
+
+	enabled, err := db.isClientEnabled("missing-client")
+	require.NoError(t, err)
+	assert.False(t, enabled)
+
+	name, err := db.queryActiveSpaceName("")
+	require.NoError(t, err)
+	assert.Empty(t, name)
+
+	available, err := db.queryAvailableBotSpaces("", nil)
+	require.NoError(t, err)
+	assert.Empty(t, available)
+}
+
+func TestManagerIntegrationClientUpsertRequiresSuperAdmin(t *testing.T) {
+	route, ctx, _ := setupIntegrationAPITest(t)
+	_, err := ctx.DB().DeleteFrom("integration_client").Where("client_id=?", defaultClientID).Exec()
+	require.NoError(t, err)
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(libwkhttp.Admin),
+	))
+
+	w := httptest.NewRecorder()
+	req := integrationRequest(t, http.MethodPut, "/v1/manager/integrations/oidc/client", "", map[string]interface{}{
+		"name":   "Octopush",
+		"status": 1,
+	})
+	req.Header.Set("token", testutil.Token)
+	route.ServeHTTP(w, req)
+	require.Equal(t, http.StatusForbidden, w.Code, "non-superAdmin must not create integration clients")
+
+	enabled, err := newIntegrationDB(ctx).isClientEnabled(defaultClientID)
+	require.NoError(t, err)
+	assert.False(t, enabled)
+}
+
+func TestManagerIntegrationClientUpsertAndDisableRevokesKeys(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(libwkhttp.SuperAdmin),
+	))
+
+	_, err := ctx.DB().DeleteFrom("integration_client").Where("client_id=?", defaultClientID).Exec()
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	req := integrationRequest(t, http.MethodPut, "/v1/manager/integrations/oidc/client", "", map[string]interface{}{
+		"name":   "Octopush",
+		"status": 1,
+	})
+	req.Header.Set("token", testutil.Token)
+	route.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var clientResp struct {
+		ClientID string `json:"client_id"`
+		Name     string `json:"name"`
+		Status   int    `json:"status"`
+		Enabled  bool   `json:"enabled"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &clientResp))
+	assert.Equal(t, defaultClientID, clientResp.ClientID)
+	assert.Equal(t, "Octopush", clientResp.Name)
+	assert.Equal(t, 1, clientResp.Status)
+	assert.True(t, clientResp.Enabled)
+
+	subject := "sub-manager-disable"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	spaceID := "sp_" + util.GenerUUID()[:8]
+	seedSpaceMembership(t, ctx, uid, spaceID, "Managed", 2, "2026-01-01 10:00:00")
+	idToken := mintIntegrationIDToken(t, mp, subject)
+
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/exchange", idToken, map[string]interface{}{
+		"space_id": spaceID,
+	}))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var exchangeResp struct {
+		APIKey string `json:"api_key"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &exchangeResp))
+	require.NotEmpty(t, exchangeResp.APIKey)
+
+	w = httptest.NewRecorder()
+	req = integrationRequest(t, http.MethodPut, "/v1/manager/integrations/oidc/client", "", map[string]interface{}{
+		"name":   "Octopush",
+		"status": 0,
+	})
+	req.Header.Set("token", testutil.Token)
+	route.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &clientResp))
+	assert.Equal(t, 0, clientResp.Status)
+	assert.False(t, clientResp.Enabled)
+
+	auth, err := botfather.NewUserAPIKeyService(ctx).AuthByKey(exchangeResp.APIKey)
+	require.NoError(t, err)
+	assert.Nil(t, auth, "disabling the integration client must immediately revoke active octopush uk_ keys")
+}
+
+func TestManagerIntegrationClientEnableRequiresUserAPIKeySecret(t *testing.T) {
+	route, ctx, _ := setupIntegrationAPITest(t)
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(libwkhttp.SuperAdmin),
+	))
+	_, err := ctx.DB().DeleteFrom("integration_client").Where("client_id=?", defaultClientID).Exec()
+	require.NoError(t, err)
+	t.Setenv("OCTO_USER_API_KEY_SECRET", "")
+
+	w := httptest.NewRecorder()
+	req := integrationRequest(t, http.MethodPut, "/v1/manager/integrations/oidc/client", "", map[string]interface{}{
+		"name":   "Octopush",
+		"status": 1,
+	})
+	req.Header.Set("token", testutil.Token)
+	route.ServeHTTP(w, req)
+	require.Equal(t, http.StatusInternalServerError, w.Code, w.Body.String())
+
+	enabled, err := newIntegrationDB(ctx).isClientEnabled(defaultClientID)
+	require.NoError(t, err)
+	assert.False(t, enabled)
+}
+
+func TestOIDCExchangeIssuanceSerializesWithClientDisable(t *testing.T) {
+	_, ctx, _ := setupIntegrationAPITest(t)
+	uid := "u_" + util.GenerUUID()[:8]
+	spaceID := "sp_" + util.GenerUUID()[:8]
+	insertIntegrationBareUser(t, ctx, uid)
+	svc := botfather.NewUserAPIKeyService(ctx)
+
+	tx, err := ctx.DB().Begin()
+	require.NoError(t, err)
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	_, err = tx.Update("integration_client").
+		Set("status", 0).
+		Where("client_id=?", defaultClientID).
+		Exec()
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() {
+		key, issueErr := svc.GetOrCreateForEnabledIntegrationClient(uid, spaceID, defaultClientID)
+		if issueErr == nil && key != "" {
+			done <- fmt.Errorf("issued key while disable transaction held client lock: %s", key)
+			return
+		}
+		done <- issueErr
+	}()
+
+	select {
+	case issueErr := <-done:
+		require.Failf(t, "issuance completed before disable committed", "err=%v", issueErr)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	_, err = tx.Update("user_api_key").
+		Set("status", 0).
+		Set("revoked_at", time.Now()).
+		Where("client_id=? AND status=1", defaultClientID).
+		Exec()
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	committed = true
+
+	err = <-done
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, botfather.ErrIntegrationClientDisabled), "got %v", err)
+
+	var active int
+	err = ctx.DB().SelectBySql(
+		"SELECT COUNT(*) FROM user_api_key WHERE uid=? AND space_id=? AND client_id=? AND status=1",
+		uid, spaceID, defaultClientID,
+	).LoadOne(&active)
+	require.NoError(t, err)
+	assert.Equal(t, 0, active, "disable/exchange race must not leave an active key")
+
+	seedIntegrationClient(t, ctx, defaultClientID, 1)
+	err = ctx.DB().SelectBySql(
+		"SELECT COUNT(*) FROM user_api_key WHERE uid=? AND space_id=? AND client_id=? AND status=1",
+		uid, spaceID, defaultClientID,
+	).LoadOne(&active)
+	require.NoError(t, err)
+	assert.Equal(t, 0, active, "re-enabling the client must not resurrect a race-issued key")
+}
+
+func TestManagerIntegrationClientValidationAndDefaultName(t *testing.T) {
+	route, ctx, _ := setupIntegrationAPITest(t)
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(libwkhttp.SuperAdmin),
+	))
+
+	req := httptest.NewRequest(http.MethodPut, "/v1/manager/integrations/oidc/client", bytes.NewBufferString("{"))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("token", testutil.Token)
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+
+	req = integrationRequest(t, http.MethodPut, "/v1/manager/integrations/oidc/client", "", map[string]interface{}{})
+	req.Header.Set("token", testutil.Token)
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+
+	req = integrationRequest(t, http.MethodPut, "/v1/manager/integrations/oidc/client", "", map[string]interface{}{
+		"status": 2,
+	})
+	req.Header.Set("token", testutil.Token)
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+
+	req = integrationRequest(t, http.MethodPut, "/v1/manager/integrations/oidc/client", "", map[string]interface{}{
+		"status": 1,
+	})
+	req.Header.Set("token", testutil.Token)
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var resp struct {
+		ClientID string `json:"client_id"`
+		Name     string `json:"name"`
+		Status   int    `json:"status"`
+		Enabled  bool   `json:"enabled"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, defaultClientID, resp.ClientID)
+	assert.Equal(t, defaultClientName, resp.Name)
+	assert.Equal(t, 1, resp.Status)
+	assert.True(t, resp.Enabled)
+
+	req = integrationRequest(t, http.MethodPut, "/v1/manager/integrations/oidc/client", "", map[string]interface{}{
+		"name":   strings.Repeat("x", 101),
+		"status": 1,
+	})
+	req.Header.Set("token", testutil.Token)
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+}
+
+func TestOIDCBindingRevokesUserAPIKey(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	subject := "sub-revoke"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	spaceID := "sp_" + util.GenerUUID()[:8]
+	seedSpaceMembership(t, ctx, uid, spaceID, "Research", 2, "2026-01-01 10:00:00")
+	idToken := mintIntegrationIDToken(t, mp, subject)
+
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/exchange", idToken, map[string]interface{}{
+		"space_id": spaceID,
+	}))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var exchangeResp struct {
+		APIKey string `json:"api_key"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &exchangeResp))
+	require.NotEmpty(t, exchangeResp.APIKey)
+
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodDelete, "/v1/integrations/oidc/binding", exchangeResp.APIKey, nil))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.JSONEq(t, `{"revoked":true}`, w.Body.String())
+
+	auth, err := botfather.NewUserAPIKeyService(ctx).AuthByKey(exchangeResp.APIKey)
+	require.NoError(t, err)
+	assert.Nil(t, auth)
+
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodGet, "/v1/user/bots", exchangeResp.APIKey, nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestUserAPIKeyRoutesRejectActiveKeyWhenIntegrationClientDisabled(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	subject := "sub-disabled-auth"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	spaceID := "sp_" + util.GenerUUID()[:8]
+	seedSpaceMembership(t, ctx, uid, spaceID, "Research", 2, "2026-01-01 10:00:00")
+	idToken := mintIntegrationIDToken(t, mp, subject)
+
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/exchange", idToken, map[string]interface{}{
+		"space_id": spaceID,
+	}))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var exchangeResp struct {
+		APIKey string `json:"api_key"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &exchangeResp))
+	require.NotEmpty(t, exchangeResp.APIKey)
+
+	seedIntegrationClient(t, ctx, defaultClientID, 0)
+	_, err := ctx.DB().Update("user_api_key").
+		Set("status", 1).
+		Set("revoked_at", nil).
+		Where("client_id=? AND api_key_hash <> ''", defaultClientID).
+		Exec()
+	require.NoError(t, err)
+
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodDelete, "/v1/integrations/oidc/binding", exchangeResp.APIKey, nil))
+	require.Equal(t, http.StatusUnauthorized, w.Code, w.Body.String())
+	var env integrationErrEnvelope
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, "err.shared.auth.token_invalid", env.Error.Code)
+
+	auth, err := botfather.NewUserAPIKeyService(ctx).AuthByKey(exchangeResp.APIKey)
+	require.NoError(t, err)
+	assert.Nil(t, auth, "disabled integration client must make even active uk_ rows unusable")
+
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodGet, "/v1/user/bots", exchangeResp.APIKey, nil))
+	require.Equal(t, http.StatusUnauthorized, w.Code, w.Body.String())
+}
+
+func TestOIDCAuthErrors(t *testing.T) {
+	route, _, _ := setupIntegrationAPITest(t)
+
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodGet, "/v1/integrations/oidc/spaces", "", nil))
+	require.Equal(t, http.StatusUnauthorized, w.Code, w.Body.String())
+	var env integrationErrEnvelope
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, "err.shared.auth.token_missing", env.Error.Code)
+
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodGet, "/v1/integrations/oidc/spaces", "not-a-jwt", nil))
+	require.Equal(t, http.StatusUnauthorized, w.Code, w.Body.String())
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, "err.shared.auth.token_invalid", env.Error.Code)
+}
+
+func TestOIDCAuthRejectsBlankSubject(t *testing.T) {
+	route, _, mp := setupIntegrationAPITest(t)
+	idToken := mintIntegrationIDToken(t, mp, "")
+
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodGet, "/v1/integrations/oidc/spaces", idToken, nil))
+	require.Equal(t, http.StatusUnauthorized, w.Code, w.Body.String())
+	var env integrationErrEnvelope
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, "err.shared.auth.token_invalid", env.Error.Code)
+}
+
+func TestOIDCExchangeValidationErrors(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	subject := "sub-exchange-errors"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	idToken := mintIntegrationIDToken(t, mp, subject)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/integrations/oidc/exchange", strings.NewReader("{"))
+	req.Header.Set("Authorization", "Bearer "+idToken)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	var env integrationErrEnvelope
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, "err.shared.param.invalid", env.Error.Code)
+
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/exchange", idToken, map[string]interface{}{}))
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, "err.shared.param.invalid", env.Error.Code)
+
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/exchange", idToken, map[string]interface{}{
+		"space_id": "sp_missing",
+	}))
+	require.Equal(t, http.StatusNotFound, w.Code, w.Body.String())
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, "err.shared.not_found", env.Error.Code)
+
+	spaceID := "sp_" + util.GenerUUID()[:8]
+	otherUID := "u_" + util.GenerUUID()[:8]
+	insertIntegrationBareUser(t, ctx, otherUID)
+	seedSpaceMembership(t, ctx, otherUID, spaceID, "Private", 0, "2026-01-01 10:00:00")
+
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/exchange", idToken, map[string]interface{}{
+		"space_id": spaceID,
+	}))
+	require.Equal(t, http.StatusForbidden, w.Code, w.Body.String())
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, "err.shared.auth.forbidden", env.Error.Code)
+	assert.NotEmpty(t, uid)
+}
+
+func TestOIDCBindingRejectsInvalidUserAPIKey(t *testing.T) {
+	route, ctx, _ := setupIntegrationAPITest(t)
+
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodDelete, "/v1/integrations/oidc/binding", "", nil))
+	require.Equal(t, http.StatusUnauthorized, w.Code, w.Body.String())
+	var env integrationErrEnvelope
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, "err.shared.auth.token_invalid", env.Error.Code)
+
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodDelete, "/v1/integrations/oidc/binding", botfather.UserAPIKeyPrefix+"missing", nil))
+	require.Equal(t, http.StatusUnauthorized, w.Code, w.Body.String())
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, "err.shared.auth.token_invalid", env.Error.Code)
+
+	botfatherUID := "u_" + util.GenerUUID()[:8]
+	insertIntegrationBareUser(t, ctx, botfatherUID)
+	botfatherKey, err := botfather.NewUserAPIKeyService(ctx).GetOrCreate(botfatherUID, "", "")
+	require.NoError(t, err)
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodDelete, "/v1/integrations/oidc/binding", botfatherKey, nil))
+	require.Equal(t, http.StatusUnauthorized, w.Code, w.Body.String())
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, "err.shared.auth.token_invalid", env.Error.Code)
+	auth, err := botfather.NewUserAPIKeyService(ctx).AuthByKey(botfatherKey)
+	require.NoError(t, err)
+	require.NotNil(t, auth, "binding endpoint must not revoke botfather-scoped uk_ keys")
+}
+
+func TestIntegrationHandlersDefensiveWithoutAuthContext(t *testing.T) {
+	route := libwkhttp.New()
+	route.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.SourceLanguage)))
+	it := &Integration{}
+	group := route.Group("")
+	route.GET("/oidc", it.forceEnglish(), it.oidcAuth(), func(c *libwkhttp.Context) {
+		c.ResponseOK()
+	})
+	route.GET("/spaces", it.forceEnglish(), it.listSpaces)
+	route.POST("/exchange", it.forceEnglish(), it.exchange)
+	group.DELETE("/binding", it.forceEnglish(), it.deleteBinding)
+
+	for _, tc := range []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/oidc"},
+		{http.MethodGet, "/spaces"},
+		{http.MethodPost, "/exchange"},
+		{http.MethodDelete, "/binding"},
+	} {
+		w := httptest.NewRecorder()
+		route.ServeHTTP(w, integrationRequest(t, tc.method, tc.path, "token", nil))
+		require.Equal(t, http.StatusInternalServerError, w.Code, w.Body.String())
+		var env integrationErrEnvelope
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+		assert.Equal(t, "err.shared.internal", env.Error.Code)
+	}
+}
+
+func TestOIDCUserNotLinkedFixedEnglishError(t *testing.T) {
+	route, _, mp := setupIntegrationAPITest(t)
+	idToken := mintIntegrationIDToken(t, mp, "sub-missing")
+
+	req := integrationRequest(t, http.MethodGet, "/v1/integrations/oidc/spaces", idToken, nil)
+	req.Header.Set("Accept-Language", "zh-CN")
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusForbidden, w.Code, w.Body.String())
+	var env integrationErrEnvelope
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, "err.server.integration.user_not_linked", env.Error.Code)
+	assert.Equal(t, http.StatusForbidden, env.Error.HTTPStatus)
+	assert.Equal(t, "User is not linked to an Octo account.", env.Error.Message)
+}
+
+func TestOIDCDisabledClientRevokesIssuedKeys(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	subject := "sub-disabled"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	spaceID := "sp_" + util.GenerUUID()[:8]
+	seedSpaceMembership(t, ctx, uid, spaceID, "Research", 2, "2026-01-01 10:00:00")
+	idToken := mintIntegrationIDToken(t, mp, subject)
+
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/exchange", idToken, map[string]interface{}{
+		"space_id": spaceID,
+	}))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var exchangeResp struct {
+		APIKey string `json:"api_key"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &exchangeResp))
+
+	seedIntegrationClient(t, ctx, defaultClientID, 0)
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodGet, "/v1/integrations/oidc/spaces", idToken, nil))
+	require.Equal(t, http.StatusForbidden, w.Code, w.Body.String())
+	var env integrationErrEnvelope
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, "err.server.integration.disabled", env.Error.Code)
+
+	auth, err := botfather.NewUserAPIKeyService(ctx).AuthByKey(exchangeResp.APIKey)
+	require.NoError(t, err)
+	assert.Nil(t, auth, fmt.Sprintf("disabled %s must revoke issued uk_", defaultClientID))
+}

--- a/modules/integration/db.go
+++ b/modules/integration/db.go
@@ -1,0 +1,207 @@
+package integration
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/gocraft/dbr/v2"
+)
+
+type integrationDB struct {
+	session *dbr.Session
+}
+
+func newIntegrationDB(ctx *config.Context) *integrationDB {
+	return &integrationDB{session: ctx.DB()}
+}
+
+func (d *integrationDB) isClientEnabled(clientID string) (bool, error) {
+	var status int
+	err := d.session.Select("status").From("integration_client").
+		Where("client_id=?", clientID).LoadOne(&status)
+	if errors.Is(err, dbr.ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("integration: query client %q: %w", clientID, err)
+	}
+	return status == 1, nil
+}
+
+func (d *integrationDB) isActiveUser(uid string) (bool, error) {
+	if uid == "" {
+		return false, nil
+	}
+	var n int
+	err := d.session.Select("COUNT(*)").From("user").
+		Where("uid=? AND status<>0 AND is_destroy=0", uid).
+		LoadOne(&n)
+	if err != nil {
+		return false, fmt.Errorf("integration: query active user uid=%q: %w", uid, err)
+	}
+	return n > 0, nil
+}
+
+func (d *integrationDB) revokeUserAPIKey(id int64) error {
+	_, err := d.session.Update("user_api_key").
+		Set("status", 0).
+		Set("revoked_at", dbr.Expr("NOW()")).
+		Where("id=? AND status=1", id).
+		Exec()
+	if err != nil {
+		return fmt.Errorf("integration: revoke user api key id=%d: %w", id, err)
+	}
+	return nil
+}
+
+func (d *integrationDB) upsertClient(clientID, name string, status int) error {
+	tx, err := d.session.Begin()
+	if err != nil {
+		return fmt.Errorf("integration: begin upsert client %q: %w", clientID, err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	_, err = tx.InsertBySql(
+		"INSERT INTO integration_client (client_id, name, status) VALUES (?, ?, ?) "+
+			"ON DUPLICATE KEY UPDATE name=VALUES(name), status=VALUES(status)",
+		clientID, name, status,
+	).Exec()
+	if err != nil {
+		return fmt.Errorf("integration: upsert client %q: %w", clientID, err)
+	}
+	if status == 0 {
+		_, err = tx.Update("user_api_key").
+			Set("status", 0).
+			Set("revoked_at", dbr.Expr("NOW()")).
+			Where("client_id=? AND status=1", clientID).
+			Exec()
+		if err != nil {
+			return fmt.Errorf("integration: revoke active keys for disabled client %q: %w", clientID, err)
+		}
+	}
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("integration: commit upsert client %q: %w", clientID, err)
+	}
+	committed = true
+	return nil
+}
+
+func (d *integrationDB) queryActiveSpaceName(spaceID string) (string, error) {
+	if spaceID == "" {
+		return "", nil
+	}
+	var name string
+	err := d.session.Select("name").From("space").
+		Where("space_id=? AND status=1", spaceID).LoadOne(&name)
+	if errors.Is(err, dbr.ErrNotFound) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("integration: query space name %q: %w", spaceID, err)
+	}
+	return name, nil
+}
+
+func (d *integrationDB) querySpaces(uid string) ([]spaceResp, error) {
+	spaces := make([]spaceResp, 0)
+	_, err := d.session.SelectBySql(`
+		SELECT s.space_id,
+		       s.name,
+		       s.logo,
+		       sm.role,
+		       (SELECT COUNT(*) FROM space_member smc
+		         WHERE smc.space_id=s.space_id AND smc.status=1) AS member_count
+		FROM space_member sm
+		INNER JOIN space s ON s.space_id=sm.space_id AND s.status=1
+		WHERE sm.uid=? AND sm.status=1
+		ORDER BY sm.created_at ASC, s.space_id ASC`,
+		uid,
+	).Load(&spaces)
+	if err != nil {
+		return nil, fmt.Errorf("integration: query spaces for uid=%q: %w", uid, err)
+	}
+	if len(spaces) == 0 {
+		return spaces, nil
+	}
+	spaces[0].IsDefault = true
+
+	spaceIDs := make([]string, 0, len(spaces))
+	for _, sp := range spaces {
+		spaceIDs = append(spaceIDs, sp.SpaceID)
+	}
+	available, err := d.queryAvailableBotSpaces(uid, spaceIDs)
+	if err != nil {
+		return nil, err
+	}
+	for i := range spaces {
+		spaces[i].HasAvailableBot = available[spaces[i].SpaceID]
+	}
+	return spaces, nil
+}
+
+func (d *integrationDB) queryAvailableBotSpaces(uid string, spaceIDs []string) (map[string]bool, error) {
+	out := make(map[string]bool)
+	if uid == "" || len(spaceIDs) == 0 {
+		return out, nil
+	}
+	var ids []string
+	_, err := d.session.SelectBySql(`
+		SELECT sm.space_id
+		FROM robot r
+		INNER JOIN space_member sm ON sm.uid=r.robot_id AND sm.status=1
+		WHERE r.creator_uid=? AND r.status=1 AND r.bound_agent_ref='' AND sm.space_id IN ?
+		GROUP BY sm.space_id`,
+		uid, spaceIDs,
+	).Load(&ids)
+	if err != nil {
+		return nil, fmt.Errorf("integration: query available bot spaces uid=%q: %w", uid, err)
+	}
+	for _, id := range ids {
+		out[id] = true
+	}
+	return out, nil
+}
+
+func (d *integrationDB) queryBots(uid, spaceID string) ([]exchangeBotResp, error) {
+	var rows []struct {
+		RobotID     string
+		Username    string
+		Name        string
+		Description string
+		CreatedAt   time.Time
+	}
+	_, err := d.session.SelectBySql(`
+		SELECT r.robot_id,
+		       r.username,
+		       COALESCE(NULLIF(u.name, ''), r.username, r.robot_id) AS name,
+		       r.description,
+		       r.created_at
+		FROM robot r
+		INNER JOIN space_member sm ON sm.uid=r.robot_id AND sm.space_id=? AND sm.status=1
+		LEFT JOIN user u ON u.uid=r.robot_id AND u.status=1
+		WHERE r.creator_uid=? AND r.status=1
+		ORDER BY r.created_at DESC, r.robot_id ASC`,
+		spaceID, uid,
+	).Load(&rows)
+	if err != nil {
+		return nil, fmt.Errorf("integration: query bots uid=%q space=%q: %w", uid, spaceID, err)
+	}
+	bots := make([]exchangeBotResp, 0, len(rows))
+	for _, row := range rows {
+		bots = append(bots, exchangeBotResp{
+			RobotID:     row.RobotID,
+			Username:    row.Username,
+			Name:        row.Name,
+			Description: row.Description,
+			CreatedAt:   row.CreatedAt.Format(time.RFC3339),
+		})
+	}
+	return bots, nil
+}

--- a/modules/integration/e2e_test.go
+++ b/modules/integration/e2e_test.go
@@ -1,0 +1,135 @@
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-server/modules/botfather"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOIDCIntegrationE2E_CreateBindTokenUnbindRevoke(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	srv := httptest.NewServer(route)
+	defer srv.Close()
+
+	subject := "sub-e2e"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	spaceID := "sp_" + util.GenerUUID()[:8]
+	seedSpaceMembership(t, ctx, uid, spaceID, "E2E Space", 2, "2026-01-01 10:00:00")
+	idToken := mintIntegrationIDToken(t, mp, subject)
+
+	status, _, body := doE2EJSON(t, srv, http.MethodGet, "/v1/integrations/oidc/spaces", idToken, nil)
+	require.Equal(t, http.StatusOK, status, string(body))
+	var spacesResp struct {
+		UID    string `json:"uid"`
+		Spaces []struct {
+			SpaceID         string `json:"space_id"`
+			HasAvailableBot bool   `json:"has_available_bot"`
+		} `json:"spaces"`
+	}
+	require.NoError(t, json.Unmarshal(body, &spacesResp))
+	assert.Equal(t, uid, spacesResp.UID)
+	require.Len(t, spacesResp.Spaces, 1)
+	assert.Equal(t, spaceID, spacesResp.Spaces[0].SpaceID)
+	assert.False(t, spacesResp.Spaces[0].HasAvailableBot)
+
+	status, _, body = doE2EJSON(t, srv, http.MethodPost, "/v1/integrations/oidc/exchange", idToken, map[string]interface{}{
+		"space_id":     spaceID,
+		"include_bots": true,
+	})
+	require.Equal(t, http.StatusOK, status, string(body))
+	var exchangeResp struct {
+		UID     string `json:"uid"`
+		SpaceID string `json:"space_id"`
+		APIKey  string `json:"api_key"`
+		Bots    []struct {
+			RobotID string `json:"robot_id"`
+		} `json:"bots"`
+	}
+	require.NoError(t, json.Unmarshal(body, &exchangeResp))
+	assert.Equal(t, uid, exchangeResp.UID)
+	assert.Equal(t, spaceID, exchangeResp.SpaceID)
+	require.Contains(t, exchangeResp.APIKey, botfather.UserAPIKeyPrefix)
+	assert.Empty(t, exchangeResp.Bots)
+
+	description := "created by integration e2e"
+	status, _, body = doE2EJSON(t, srv, http.MethodPost, "/v1/user/bots", exchangeResp.APIKey, botfather.CreateBotReq{
+		Name:        "Octopush E2E Bot",
+		Description: &description,
+	})
+	require.Equal(t, http.StatusOK, status, string(body))
+	var createResp botfather.CreateBotResp
+	require.NoError(t, json.Unmarshal(body, &createResp))
+	require.NotEmpty(t, createResp.RobotID)
+	assert.Equal(t, "Octopush E2E Bot", createResp.Name)
+	assert.Equal(t, description, createResp.Description)
+	require.Contains(t, createResp.BotToken, botfather.BotTokenPrefix)
+
+	agentRef := "octopush:agent_e2e"
+	status, _, body = doE2EJSON(t, srv, http.MethodPost, fmt.Sprintf("/v1/user/bots/%s/bind", createResp.RobotID), exchangeResp.APIKey, botfather.BindBotReq{
+		AgentRef: agentRef,
+	})
+	require.Equal(t, http.StatusOK, status, string(body))
+	var bindResp botfather.BindBotResp
+	require.NoError(t, json.Unmarshal(body, &bindResp))
+	assert.Equal(t, createResp.RobotID, bindResp.RobotID)
+	assert.Equal(t, agentRef, bindResp.BoundAgentRef)
+	require.NotNil(t, bindResp.BoundAt)
+	assert.NotEmpty(t, *bindResp.BoundAt)
+
+	status, _, body = doE2EJSON(t, srv, http.MethodGet, fmt.Sprintf("/v1/user/bots/%s/token", createResp.RobotID), exchangeResp.APIKey, nil)
+	require.Equal(t, http.StatusOK, status, string(body))
+	var tokenResp struct {
+		RobotID  string `json:"robot_id"`
+		BotToken string `json:"bot_token"`
+	}
+	require.NoError(t, json.Unmarshal(body, &tokenResp))
+	assert.Equal(t, createResp.RobotID, tokenResp.RobotID)
+	assert.Equal(t, createResp.BotToken, tokenResp.BotToken)
+
+	status, _, body = doE2EJSON(t, srv, http.MethodDelete, fmt.Sprintf("/v1/user/bots/%s/bind", createResp.RobotID), exchangeResp.APIKey, botfather.BindBotReq{
+		AgentRef: agentRef,
+	})
+	require.Equal(t, http.StatusOK, status, string(body))
+	var unbindResp map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &unbindResp))
+	assert.Equal(t, createResp.RobotID, unbindResp["robot_id"])
+	assert.Equal(t, "", unbindResp["bound_agent_ref"])
+	assert.Contains(t, unbindResp, "bound_at")
+	assert.Nil(t, unbindResp["bound_at"])
+
+	status, _, body = doE2EJSON(t, srv, http.MethodDelete, "/v1/integrations/oidc/binding", exchangeResp.APIKey, nil)
+	require.Equal(t, http.StatusOK, status, string(body))
+	assert.JSONEq(t, `{"revoked":true}`, string(body))
+
+	status, _, body = doE2EJSON(t, srv, http.MethodGet, fmt.Sprintf("/v1/user/bots/%s/token", createResp.RobotID), exchangeResp.APIKey, nil)
+	assert.Equal(t, http.StatusUnauthorized, status, string(body))
+}
+
+func doE2EJSON(t *testing.T, srv *httptest.Server, method, path, bearer string, body interface{}) (int, http.Header, []byte) {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		require.NoError(t, json.NewEncoder(&buf).Encode(body))
+	}
+	req, err := http.NewRequest(method, srv.URL+path, &buf)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, resp.Header, respBody
+}

--- a/modules/integration/model.go
+++ b/modules/integration/model.go
@@ -1,0 +1,62 @@
+package integration
+
+const (
+	defaultClientID   = "octopush"
+	defaultClientName = "Octopush"
+)
+
+type oidcPrincipal struct {
+	UID     string
+	Subject string
+	Issuer  string
+}
+
+type spaceResp struct {
+	SpaceID         string `json:"space_id"`
+	Name            string `json:"name"`
+	Logo            string `json:"logo"`
+	Role            int    `json:"role"`
+	MemberCount     int    `json:"member_count"`
+	IsDefault       bool   `json:"is_default"`
+	HasAvailableBot bool   `json:"has_available_bot"`
+}
+
+type spacesResp struct {
+	UID      string      `json:"uid"`
+	ClientID string      `json:"client_id"`
+	Spaces   []spaceResp `json:"spaces"`
+}
+
+type exchangeReq struct {
+	SpaceID     string `json:"space_id"`
+	IncludeBots bool   `json:"include_bots"`
+}
+
+type exchangeBotResp struct {
+	RobotID     string `json:"robot_id"`
+	Username    string `json:"username"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	CreatedAt   string `json:"created_at"`
+}
+
+type exchangeResp struct {
+	UID       string            `json:"uid"`
+	SpaceID   string            `json:"space_id"`
+	SpaceName string            `json:"space_name"`
+	ClientID  string            `json:"client_id"`
+	APIKey    string            `json:"api_key"`
+	Bots      []exchangeBotResp `json:"bots,omitempty"`
+}
+
+type managerIntegrationClientReq struct {
+	Name   string `json:"name"`
+	Status *int   `json:"status"`
+}
+
+type managerIntegrationClientResp struct {
+	ClientID string `json:"client_id"`
+	Name     string `json:"name"`
+	Status   int    `json:"status"`
+	Enabled  bool   `json:"enabled"`
+}

--- a/modules/integration/sql/20260604000002_integration_client.sql
+++ b/modules/integration/sql/20260604000002_integration_client.sql
@@ -1,0 +1,18 @@
+-- +migrate Up
+-- OIDC integration clients. PR2 option A treats this as a registration table
+-- plus global exchange switch; client_secret_hash is reserved for the future
+-- actor-authenticated option B.
+CREATE TABLE IF NOT EXISTS `integration_client` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `client_id` varchar(100) NOT NULL DEFAULT '' COMMENT '外部应用 ID / 审计标签',
+  `name` varchar(100) NOT NULL DEFAULT '' COMMENT '展示名称',
+  `client_secret_hash` varchar(128) NULL DEFAULT NULL COMMENT '预留：client credentials secret hash',
+  `status` tinyint NOT NULL DEFAULT 0 COMMENT '1=enabled 0=disabled',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_integration_client_id` (`client_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='OIDC integration client registry';
+
+-- +migrate Down
+DROP TABLE IF EXISTS `integration_client`;

--- a/modules/integration/testinit_test.go
+++ b/modules/integration/testinit_test.go
@@ -1,0 +1,8 @@
+package integration
+
+import (
+	_ "github.com/Mininglamp-OSS/octo-server/modules/base"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/robot"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/space"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/user"
+)

--- a/pkg/errcode/integration.go
+++ b/pkg/errcode/integration.go
@@ -43,6 +43,9 @@ var (
 // 这些码由 codes 包 init 注册（shared.go），Go 保证被导入包的 init 先于本包 var
 // 初始化执行，故 shared() 查找一定命中。
 var (
+	ErrSharedTokenMissing = shared("err.shared.auth.token_missing")
+	ErrSharedTokenInvalid = shared("err.shared.auth.token_invalid")
+	ErrSharedRateLimited  = shared("err.shared.rate.limited")
 	ErrSharedParamInvalid = shared("err.shared.param.invalid")
 	ErrSharedForbidden    = shared("err.shared.auth.forbidden")
 	ErrSharedNotFound     = shared("err.shared.not_found")


### PR DESCRIPTION
Closes #241

## Summary
- add OIDC integration module for Octopush discovery, exchange, and binding revoke flows
- add `integration_client` migration plus superAdmin-managed enable/disable endpoint for the fixed `octopush` client
- share BotFather user API key service for `uk_` issuance, including revoked-row rotation and concurrent get-or-create recovery
- harden integration `uk_` storage: auth looks up `api_key_hash`, new/rotated integration keys store AES-GCM `api_key_cipher`, and `api_key` no longer stores new integration bearer plaintext
- keep BotFather `/quickstart` legacy `uk_` path independent from integration key storage so existing deployments do not acquire a new global auth dependency
- make disabled integration clients render active `octopush uk_` rows unusable, including simulated disable/exchange races
- use existing octo-lib rate-limit middleware only: integration keeps strict IP limiting and `uk_` routes use shared UID limiting; removed the duplicate local token bucket
- keep fixed English integration error envelope and bot listing carry-over fixes

## API / Ops Notes
- `octopush` is disabled by default; enable it with `PUT /v1/manager/integrations/oidc/client` as `superAdmin` using `{"status":1}`
- enabling or using the `octopush` integration requires `OCTO_USER_API_KEY_SECRET` to be configured as exactly 32 bytes; this key is scoped to integration `uk_` HMAC/AES-GCM storage and does not reuse `OCTO_MASTER_KEY`
- disabling `octopush` immediately revokes active `octopush` `uk_` keys in the manager transaction; auth also rejects active rows while the client is disabled
- first version authenticates `/v1/integrations/oidc/spaces` and `/exchange` with the user's OIDC `id_token`; extra client/actor credentials are not added in this PR, so deployments that expose these endpoints should keep network-level protection such as mTLS or allowlist where required

## Compatibility / Impact
- `/v1/user/bots` no longer returns real `bot_token`; callers should use `GET /v1/user/bots/:bot_id/token` when they need the token
- `/v1/user/*` requests authenticated with `uk_` now pass through the existing shared UID rate limiter and can return `429` with `Retry-After`
- `BindBotResp.bound_at` is now nullable (`string|null`)
- legacy BotFather plaintext `uk_` rows still authenticate without `OCTO_USER_API_KEY_SECRET`; legacy integration plaintext rows are converted to encrypted cipher/marker form on successful touch when the integration secret is configured
- rolling back the user-api-key client-dimension migration now aborts loudly if non-`botfather` rows exist, instead of silently deleting integration-issued keys

## Verification
- `GIN_MODE=release OCTO_MASTER_KEY=0123456789abcdef0123456789abcdef OCTO_USER_API_KEY_SECRET=fedcba9876543210fedcba9876543210 go test ./modules/integration -cover -count=1` => 80.5%
- `GIN_MODE=release OCTO_MASTER_KEY=0123456789abcdef0123456789abcdef OCTO_USER_API_KEY_SECRET=fedcba9876543210fedcba9876543210 go test -race ./modules/integration -count=1`
- `GIN_MODE=release OCTO_MASTER_KEY=0123456789abcdef0123456789abcdef OCTO_USER_API_KEY_SECRET=fedcba9876543210fedcba9876543210 go test ./modules/botfather -run '^(TestUserAPIKeyService_GetOrCreate_|TestUserAPIKeyService_AuthByKey|TestDecryptUserAPIKeyRejectsUnknownCipherPrefix|TestUserAPIKeyClientDimensionDownDoesNotHardDeleteIntegrationKeys)$' -count=1`
- `GIN_MODE=release OCTO_MASTER_KEY=0123456789abcdef0123456789abcdef OCTO_USER_API_KEY_SECRET=fedcba9876543210fedcba9876543210 go test -race ./modules/botfather -run '^(TestUserAPIKeyService_GetOrCreate_|TestUserAPIKeyService_AuthByKey|TestDecryptUserAPIKeyRejectsUnknownCipherPrefix|TestUserAPIKeyClientDimensionDownDoesNotHardDeleteIntegrationKeys)$' -count=1`
- `go test ./pkg/wkhttp ./pkg/errcode ./internal -count=1`
- `go run ./tools/lint-direct-error-response`
- `git diff --check`

## Known CI Note
- The previous CI `Test` failure was in BotFather/Group create tests that depend on IM channel creation; the integration package passed. After rebasing onto latest `origin/main`, the same local BotFather create targets still fail when IM channel creation returns `failed to create IM channel, group has been rolled back`, which is outside this PR's integration/key-auth changes.
