### PR TITLE
feat(incomingwebhook): soft-delete webhooks so deleted webhooks' historical messages still render

### DIFF
--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -278,6 +278,26 @@ func (w *IncomingWebhook) requireGroupAdmin(c *wkhttp.Context, groupNo string) (
 	return loginUID, true
 }
 
+// queryManageable 查询属于 groupNo 且未被软删除的 webhook，供管理端写操作（update /
+// delete / regenerate）复用。未命中 / 跨群 / 已软删除（statusDeleted）一律按 not-found
+// 写响应；查询故障写 5xx。任一情况返回 (nil, false)，调用方据此提前返回。
+//
+// 把"已删除视为不存在"集中在此一处，保证三个写端点不会遗漏软删除判断而误操作或复活
+// 已删除的 webhook（#254）。
+func (w *IncomingWebhook) queryManageable(c *wkhttp.Context, groupNo, webhookID string) (*incomingWebhookModel, bool) {
+	m, err := w.db.queryByWebhookID(webhookID)
+	if err != nil {
+		w.Error("query webhook failed", zap.Error(err))
+		mgmtQueryFailed(c)
+		return nil, false
+	}
+	if m == nil || m.GroupNo != groupNo || m.Status == statusDeleted {
+		mgmtNotFound(c)
+		return nil, false
+	}
+	return m, true
+}
+
 // ============================================================
 // 管理端点
 // ============================================================
@@ -328,7 +348,7 @@ func (w *IncomingWebhook) create(c *wkhttp.Context) {
 		Name:       req.Name,
 		Avatar:     req.Avatar,
 		CreatorUID: loginUID,
-		Status:     1,
+		Status:     statusEnabled,
 	}
 	// 配额校验 + 写入在事务内原子完成；FOR UPDATE 锁住 group_no 范围，防止并发越限。
 	//
@@ -381,14 +401,8 @@ func (w *IncomingWebhook) update(c *wkhttp.Context) {
 		return
 	}
 
-	m, err := w.db.queryByWebhookID(webhookID)
-	if err != nil {
-		w.Error("query webhook failed", zap.Error(err))
-		mgmtQueryFailed(c)
-		return
-	}
-	if m == nil || m.GroupNo != groupNo {
-		mgmtNotFound(c)
+	m, ok := w.queryManageable(c, groupNo, webhookID)
+	if !ok {
 		return
 	}
 
@@ -411,13 +425,15 @@ func (w *IncomingWebhook) update(c *wkhttp.Context) {
 		fields["avatar"] = *req.Avatar
 	}
 	if req.Status != nil {
-		if *req.Status != 0 && *req.Status != 1 {
+		// 仅接受启用/禁用；statusDeleted(2) 不可经 update 设置——删除只能走 DELETE
+		// 端点（软删除），update 也不能复活已删除行（见下方 queryManageable）。
+		if *req.Status != statusDisabled && *req.Status != statusEnabled {
 			mgmtRequestInvalid(c, "status")
 			return
 		}
 		// 启用 webhook 前必须确认群仍处于 Normal —— 阻断 disband → re-enable 复活路径。
 		// 禁用（status=0）始终允许，便于管理员主动关停。
-		if *req.Status == 1 {
+		if *req.Status == statusEnabled {
 			g, err := w.requireActiveGroup(groupNo)
 			if err != nil {
 				w.Error("query group failed", zap.Error(err))
@@ -455,14 +471,7 @@ func (w *IncomingWebhook) delete(c *wkhttp.Context) {
 	if _, ok := w.requireGroupAdmin(c, groupNo); !ok {
 		return
 	}
-	m, err := w.db.queryByWebhookID(webhookID)
-	if err != nil {
-		w.Error("query webhook failed", zap.Error(err))
-		mgmtQueryFailed(c)
-		return
-	}
-	if m == nil || m.GroupNo != groupNo {
-		mgmtNotFound(c)
+	if _, ok := w.queryManageable(c, groupNo, webhookID); !ok {
 		return
 	}
 	if err := w.db.deleteByWebhookID(webhookID); err != nil {
@@ -490,14 +499,8 @@ func (w *IncomingWebhook) regenerate(c *wkhttp.Context) {
 		mgmtGroupNotFound(c)
 		return
 	}
-	m, err := w.db.queryByWebhookID(webhookID)
-	if err != nil {
-		w.Error("query webhook failed", zap.Error(err))
-		mgmtQueryFailed(c)
-		return
-	}
-	if m == nil || m.GroupNo != groupNo {
-		mgmtNotFound(c)
+	m, ok := w.queryManageable(c, groupNo, webhookID)
+	if !ok {
 		return
 	}
 	token, hash, err := generateToken()
@@ -538,7 +541,7 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 		pushUnauthorized(c)
 		return
 	}
-	if m == nil || m.Status != 1 {
+	if m == nil || m.Status != statusEnabled {
 		pushUnauthorized(c)
 		return
 	}

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -458,8 +458,17 @@ func (w *IncomingWebhook) update(c *wkhttp.Context) {
 	}
 	updated, qErr := w.db.queryByWebhookID(webhookID)
 	if qErr != nil || updated == nil {
-		// 更新已成功落库，但回读失败/为空时返回更新前数据，不阻塞客户端。
-		c.Response(toResp(m))
+		// 回读失败/行消失：无法确认更新结果（可能已落库，也可能因并发软删除而落空），
+		// 不返回可能失真的更新前快照，按 5xx 交客户端重试，不谎报成功。
+		w.Error("re-read after update failed", zap.Error(qErr))
+		mgmtOperationFailed(c)
+		return
+	}
+	// 并发软删除竞态：updateFields 的 status != statusDeleted 守卫保证不会把已删除行的
+	// 字段写回（杜绝复活）。若回读到 statusDeleted，说明本次 update 与 DELETE 并发且
+	// DELETE 胜出——按 not-found 返回，与"删除即不可再操作"一致。
+	if updated.Status == statusDeleted {
+		mgmtNotFound(c)
 		return
 	}
 	c.Response(toResp(updated))
@@ -499,8 +508,7 @@ func (w *IncomingWebhook) regenerate(c *wkhttp.Context) {
 		mgmtGroupNotFound(c)
 		return
 	}
-	m, ok := w.queryManageable(c, groupNo, webhookID)
-	if !ok {
+	if _, ok := w.queryManageable(c, groupNo, webhookID); !ok {
 		return
 	}
 	token, hash, err := generateToken()
@@ -514,9 +522,23 @@ func (w *IncomingWebhook) regenerate(c *wkhttp.Context) {
 		mgmtOperationFailed(c)
 		return
 	}
-	m.TokenHash = hash
+	// 并发软删除竞态：updateFields 的 status != statusDeleted 守卫保证不会给已删除的
+	// webhook 写新 token_hash。回读确认行仍存活，避免向客户端返回一个实际未落库、
+	// 指向已删除行的"新 token"。
+	updated, qErr := w.db.queryByWebhookID(webhookID)
+	if qErr != nil || updated == nil {
+		// 回读失败/行消失：token 是否落库无法确认，按 5xx 让客户端重试，不误报 404。
+		w.Error("re-read after regenerate failed", zap.Error(qErr))
+		mgmtOperationFailed(c)
+		return
+	}
+	if updated.Status == statusDeleted {
+		// 与并发 DELETE 竞争且 DELETE 胜出：token_hash 未写入已删除行，按 not-found。
+		mgmtNotFound(c)
+		return
+	}
 	c.Response(createResp{
-		webhookResp: toResp(m),
+		webhookResp: toResp(updated),
 		Token:       token,
 		URL:         publicURL(webhookID, token),
 	})

--- a/modules/incomingwebhook/api_test.go
+++ b/modules/incomingwebhook/api_test.go
@@ -274,6 +274,49 @@ func TestDelete_PushFails(t *testing.T) {
 	assert.Equalf(t, http.StatusUnauthorized, w.Code, "push with deleted webhook token must 401: %s", w.Body.String())
 }
 
+// TestDelete_ConcurrentUpdate_NoRevive 端到端回归 TOCTOU 复活漏洞（#254 follow-up）：
+// DELETE 与多个 PUT status=1 并发时，删除必须最终生效——webhook 不得复活进列表，原
+// token 不得再推送。修复后此性质与调度无关恒成立（条件 updateFields 永不写已删除行），
+// 故为稳定断言；修复前命中竞态窗口时会失败。配合 -race 一并探测数据竞争。
+func TestDelete_ConcurrentUpdate_NoRevive(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	assert.Equal(t, http.StatusOK, w.Code)
+	created := parseJSON(t, w)
+	whID := created["webhook_id"].(string)
+	token := created["token"].(string)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		do(handler, authReq("DELETE", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID), nil))
+	}()
+	statusOne := 1
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			do(handler, authReq("PUT", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID),
+				map[string]interface{}{"status": statusOne}))
+		}()
+	}
+	wg.Wait()
+
+	// 删除必须最终生效：列表不含该 webhook。
+	w = do(handler, authReq("GET", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), nil))
+	res := parseJSON(t, w)
+	list, _ := res["list"].([]interface{})
+	assert.Emptyf(t, list, "deleted webhook must not be revived into the management list; list=%v", list)
+
+	// 原 token 必须保持失效。
+	body, _ := json.Marshal(pushReq{Content: "hi"})
+	w = do(handler, anonReq("POST", fmt.Sprintf("/v1/incoming-webhooks/%s/%s", whID, token), body))
+	assert.Equalf(t, http.StatusUnauthorized, w.Code, "deleted webhook token must stay revoked, body=%s", w.Body.String())
+}
+
 func TestRegenerate_RotatesToken(t *testing.T) {
 	handler, _, groupNo := setupTestEnv(t)
 	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{

--- a/modules/incomingwebhook/api_test.go
+++ b/modules/incomingwebhook/api_test.go
@@ -317,6 +317,92 @@ func TestDelete_ConcurrentUpdate_NoRevive(t *testing.T) {
 	assert.Equalf(t, http.StatusUnauthorized, w.Code, "deleted webhook token must stay revoked, body=%s", w.Body.String())
 }
 
+// TestDelete_ConcurrentRegenerate_NoRevive 端到端回归 DELETE 与 regenerate 并发：
+// regenerate 有自己的"回读 + 返回新 token"路径，必须同样不能复活已删除 webhook。无论
+// regenerate 是否赢得竞态轮换 token，删除最终生效——webhook 不在列表，且最初的 token
+// 始终失效（要么被某次 regenerate 换掉，要么因 status=2 失效）。
+func TestDelete_ConcurrentRegenerate_NoRevive(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	assert.Equal(t, http.StatusOK, w.Code)
+	created := parseJSON(t, w)
+	whID := created["webhook_id"].(string)
+	token := created["token"].(string)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		do(handler, authReq("DELETE", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID), nil))
+	}()
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s/regenerate", groupNo, whID), nil))
+		}()
+	}
+	wg.Wait()
+
+	// 删除必须最终生效：列表不含该 webhook。
+	w = do(handler, authReq("GET", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), nil))
+	res := parseJSON(t, w)
+	list, _ := res["list"].([]interface{})
+	assert.Emptyf(t, list, "deleted webhook must not be revived by concurrent regenerate; list=%v", list)
+
+	// 最初的 token 必须保持失效。
+	body, _ := json.Marshal(pushReq{Content: "hi"})
+	w = do(handler, anonReq("POST", fmt.Sprintf("/v1/incoming-webhooks/%s/%s", whID, token), body))
+	assert.Equalf(t, http.StatusUnauthorized, w.Code, "original token must stay revoked, body=%s", w.Body.String())
+}
+
+// TestUpdate_DBError_Returns5xx / TestRegenerate_DBError_Returns5xx 守护本 PR 的语义
+// 变更：update / regenerate 在底层表不可用时按 5xx 失败，绝不退回旧的 stale-200 兜底
+// （那会谎报成功）。
+//
+// 实现说明：通过 RENAME 掉 incoming_webhook 表注入查询故障。黑盒下故障会先命中
+// queryManageable 的前置读（同样返回 5xx），无法单独触发"写后回读"那一支；但本测试仍
+// 锁定了总契约——这些管理写端点在 DB 不可用时一律 5xx，不会返回 stale-200。
+func TestUpdate_DBError_Returns5xx(t *testing.T) {
+	handler, ctx, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	assert.Equal(t, http.StatusOK, w.Code)
+	whID := parseJSON(t, w)["webhook_id"].(string)
+
+	_, err := ctx.DB().UpdateBySql("RENAME TABLE incoming_webhook TO incoming_webhook_bak").Exec()
+	assert.NoError(t, err)
+	defer func() {
+		_, _ = ctx.DB().UpdateBySql("RENAME TABLE incoming_webhook_bak TO incoming_webhook").Exec()
+	}()
+
+	name := "x2"
+	w = do(handler, authReq("PUT", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID),
+		map[string]interface{}{"name": name}))
+	assert.GreaterOrEqualf(t, w.Code, 500, "update must fail as 5xx when the table is unavailable, never stale-200; code=%d body=%s", w.Code, w.Body.String())
+}
+
+func TestRegenerate_DBError_Returns5xx(t *testing.T) {
+	handler, ctx, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	assert.Equal(t, http.StatusOK, w.Code)
+	whID := parseJSON(t, w)["webhook_id"].(string)
+
+	_, err := ctx.DB().UpdateBySql("RENAME TABLE incoming_webhook TO incoming_webhook_bak").Exec()
+	assert.NoError(t, err)
+	defer func() {
+		_, _ = ctx.DB().UpdateBySql("RENAME TABLE incoming_webhook_bak TO incoming_webhook").Exec()
+	}()
+
+	w = do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s/regenerate", groupNo, whID), nil))
+	assert.GreaterOrEqualf(t, w.Code, 500, "regenerate must fail as 5xx when the table is unavailable, never stale-200; code=%d body=%s", w.Code, w.Body.String())
+}
+
 func TestRegenerate_RotatesToken(t *testing.T) {
 	handler, _, groupNo := setupTestEnv(t)
 	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{

--- a/modules/incomingwebhook/api_test.go
+++ b/modules/incomingwebhook/api_test.go
@@ -191,6 +191,89 @@ func TestListAndDelete(t *testing.T) {
 	assert.Equal(t, 1, len(list))
 }
 
+// TestDelete_FreesQuota 软删除（#254）后释放每群配额：填满→删一个→可再建一个。
+func TestDelete_FreesQuota(t *testing.T) {
+	t.Setenv("DM_INCOMINGWEBHOOK_MAX_PER_GROUP", "2")
+	handler, _, groupNo := setupTestEnv(t)
+
+	ids := make([]string, 0, 2)
+	for i := 0; i < 2; i++ {
+		w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+			"name": fmt.Sprintf("wh-%d", i),
+		}))
+		assert.Equalf(t, http.StatusOK, w.Code, "i=%d body=%s", i, w.Body.String())
+		ids = append(ids, parseJSON(t, w)["webhook_id"].(string))
+	}
+
+	// 配额满：第三个 409。
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "overflow",
+	}))
+	assert.Equalf(t, http.StatusConflict, w.Code, "quota must be full: %s", w.Body.String())
+
+	// 删一个释放配额。
+	w = do(handler, authReq("DELETE", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, ids[0]), nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// 现在可再建一个。
+	w = do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "after-delete",
+	}))
+	assert.Equalf(t, http.StatusOK, w.Code, "soft-delete must free quota: %s", w.Body.String())
+}
+
+// TestDelete_CannotRevive 软删除（#254）后该 webhook 不可被复活/再操作：
+// update / 再次 delete / regenerate 都必须 404。
+func TestDelete_CannotRevive(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	assert.Equal(t, http.StatusOK, w.Code)
+	whID := parseJSON(t, w)["webhook_id"].(string)
+
+	w = do(handler, authReq("DELETE", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID), nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// update 改名必须 404（不可对已删除资源操作）。
+	name := "revived"
+	w = do(handler, authReq("PUT", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID),
+		map[string]interface{}{"name": name}))
+	assert.Equalf(t, http.StatusNotFound, w.Code, "update on soft-deleted webhook must 404: %s", w.Body.String())
+
+	// update 重新启用必须 404（不可复活）。
+	statusOne := 1
+	w = do(handler, authReq("PUT", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID),
+		map[string]interface{}{"status": statusOne}))
+	assert.Equalf(t, http.StatusNotFound, w.Code, "re-enable soft-deleted webhook must 404: %s", w.Body.String())
+
+	// 再次 delete 必须 404（已删除视为不存在）。
+	w = do(handler, authReq("DELETE", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID), nil))
+	assert.Equalf(t, http.StatusNotFound, w.Code, "re-delete soft-deleted webhook must 404: %s", w.Body.String())
+
+	// regenerate 必须 404（不可给已删除 webhook 颁发新 token）。
+	w = do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s/regenerate", groupNo, whID), nil))
+	assert.Equalf(t, http.StatusNotFound, w.Code, "regenerate soft-deleted webhook must 404: %s", w.Body.String())
+}
+
+// TestDelete_PushFails 软删除（#254）后用原 token 推送必须 401（status 闸自动失效）。
+func TestDelete_PushFails(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	created := parseJSON(t, w)
+	whID := created["webhook_id"].(string)
+	token := created["token"].(string)
+
+	w = do(handler, authReq("DELETE", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID), nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	body, _ := json.Marshal(pushReq{Content: "hi"})
+	w = do(handler, anonReq("POST", fmt.Sprintf("/v1/incoming-webhooks/%s/%s", whID, token), body))
+	assert.Equalf(t, http.StatusUnauthorized, w.Code, "push with deleted webhook token must 401: %s", w.Body.String())
+}
+
 func TestRegenerate_RotatesToken(t *testing.T) {
 	handler, _, groupNo := setupTestEnv(t)
 	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
@@ -237,7 +320,7 @@ func TestPush_RejectsDisabledWebhook(t *testing.T) {
 	whID := created["webhook_id"].(string)
 	token := created["token"].(string)
 
-	// 禁用
+	// 禁用（status=0 即 statusDisabled）
 	_, err := ctx.DB().UpdateBySql("UPDATE incoming_webhook SET status=0 WHERE webhook_id=?", whID).Exec()
 	assert.NoError(t, err)
 
@@ -409,9 +492,11 @@ func TestCreate_QuotaConcurrent(t *testing.T) {
 	}
 	assert.Equalf(t, cap, ok, "exactly %d concurrent creates should succeed, got %d (codes=%v)", cap, ok, codes)
 
-	// DB 里也应当只有 cap 条记录
+	// DB 里也应当只有 cap 条有效记录。按 status != statusDeleted(2) 计——与
+	// insertWithQuota 的有效计数同语义；本测试无软删除行，过滤与否结果相同，但保持
+	// 一致可避免将来扩展（先删再并发建）时断言被软删除行误导。
 	var rows int
-	_, err := ctx.DB().SelectBySql("SELECT count(*) FROM incoming_webhook WHERE group_no=?", groupNo).Load(&rows)
+	_, err := ctx.DB().SelectBySql("SELECT count(*) FROM incoming_webhook WHERE group_no=? AND status != 2", groupNo).Load(&rows)
 	assert.NoError(t, err)
 	assert.Equal(t, cap, rows, "DB row count must equal cap; quota leaked under concurrency")
 }
@@ -442,7 +527,7 @@ func TestDisbandedGroup_FailsClosed(t *testing.T) {
 	assert.Equalf(t, http.StatusUnauthorized, w.Code,
 		"push must fail closed on disbanded group, body=%s", w.Body.String())
 
-	// 2) update 启用：先模拟"异步禁用已落库"，管理员 PUT status=1 复活必须 404
+	// 2) update 启用：先模拟"异步禁用已落库"（status=0 即 statusDisabled），管理员 PUT status=1 复活必须 404
 	_, err = ctx.DB().UpdateBySql("UPDATE incoming_webhook SET status=0 WHERE webhook_id=?", whID).Exec()
 	assert.NoError(t, err)
 	statusOne := 1

--- a/modules/incomingwebhook/db.go
+++ b/modules/incomingwebhook/db.go
@@ -103,6 +103,12 @@ var updateFieldsAllowed = map[string]struct{}{
 	"token_hash": {},
 }
 
+// updateFields 更新单个 webhook 的允许列。带 status != statusDeleted 守卫：对已软删除
+// 的行一律不写入——这是并发复活漏洞的根因防线。queryManageable（非事务读）与本次写入
+// 之间有 TOCTOU 窗口，若期间被并发 DELETE 软删，无守卫的写会把 status / token_hash
+// 写回，令已删除 webhook 复活（重回列表 + 旧 token 可推送）。InnoDB 行锁让该条件 UPDATE
+// 与并发 DELETE 的 UPDATE 串行化，保证"一旦删除，任何后续写都落空"。调用方应回读确认
+// 行未被软删除（见 api 层 update / regenerate）。
 func (d *incomingWebhookDB) updateFields(webhookID string, fields map[string]interface{}) error {
 	if len(fields) == 0 {
 		return nil
@@ -114,7 +120,8 @@ func (d *incomingWebhookDB) updateFields(webhookID string, fields map[string]int
 	}
 	_, err := d.session.Update("incoming_webhook").
 		SetMap(fields).
-		Where("webhook_id=?", webhookID).Exec()
+		Where("webhook_id=?", webhookID).
+		Where("status != ?", statusDeleted).Exec()
 	return err
 }
 
@@ -123,20 +130,24 @@ func (d *incomingWebhookDB) updateFields(webhookID string, fields map[string]int
 // 过滤）。push 闸（status != statusEnabled）随之自动失效，列表/配额按 status !=
 // statusDeleted 排除，且 update 不再允许复活已删除行。调用方应先确认目标行存在且
 // 未删除（api 层在 query 后判 statusDeleted 返回 not-found）。
+// status != statusDeleted 守卫使重复软删除幂等：并发两次 DELETE，第二次落空。
 func (d *incomingWebhookDB) deleteByWebhookID(webhookID string) error {
 	_, err := d.session.Update("incoming_webhook").
 		Set("status", statusDeleted).
-		Where("webhook_id=?", webhookID).Exec()
+		Where("webhook_id=?", webhookID).
+		Where("status != ?", statusDeleted).Exec()
 	return err
 }
 
 // markUsed 累加调用计数并刷新 last_used_at；非关键路径，调用方应忽略错误（最多记日志）。
 // 走 ExecContext：审计在 push 路径的同步兜底分支下跑在请求 goroutine 上，必须受 ctx
 // 超时约束，否则 DB 饱和变慢会无限拖住 push 响应。
+// status != statusDeleted 守卫：与其它写路径一致，异步审计执行时行若已被并发软删除，
+// 不再给已删除 webhook 记账（不影响安全，仅保持纵深防御的一致性）。
 func (d *incomingWebhookDB) markUsed(ctx context.Context, webhookID string, now time.Time) error {
 	_, err := d.session.UpdateBySql(
-		"UPDATE incoming_webhook SET call_count = call_count + 1, last_used_at = ? WHERE webhook_id = ?",
-		now, webhookID,
+		"UPDATE incoming_webhook SET call_count = call_count + 1, last_used_at = ? WHERE webhook_id = ? AND status != ?",
+		now, webhookID, statusDeleted,
 	).ExecContext(ctx)
 	return err
 }

--- a/modules/incomingwebhook/db.go
+++ b/modules/incomingwebhook/db.go
@@ -109,6 +109,10 @@ var updateFieldsAllowed = map[string]struct{}{
 // 写回，令已删除 webhook 复活（重回列表 + 旧 token 可推送）。InnoDB 行锁让该条件 UPDATE
 // 与并发 DELETE 的 UPDATE 串行化，保证"一旦删除，任何后续写都落空"。调用方应回读确认
 // 行未被软删除（见 api 层 update / regenerate）。
+//
+// ⚠️ 正确性依赖单语句 autocommit 的当前读（UPDATE ... WHERE 对最新已提交行版本求值）。
+// 若未来把 update + 回读包进同一显式 REPEATABLE READ 事务、改用快照 SELECT，这个
+// "删除后写必落空"的不变量会被破坏，须改用 SELECT ... FOR UPDATE 重新串行化。
 func (d *incomingWebhookDB) updateFields(webhookID string, fields map[string]interface{}) error {
 	if len(fields) == 0 {
 		return nil

--- a/modules/incomingwebhook/db.go
+++ b/modules/incomingwebhook/db.go
@@ -55,8 +55,9 @@ func (d *incomingWebhookDB) insertWithQuota(m *incomingWebhookModel, max int) er
 
 	var count int
 	if _, err = tx.SelectBySql(
-		"SELECT count(*) FROM incoming_webhook WHERE group_no=?",
-		m.GroupNo,
+		// 软删除（statusDeleted）的行不占配额：删除即释放名额（#254）。
+		"SELECT count(*) FROM incoming_webhook WHERE group_no=? AND status != ?",
+		m.GroupNo, statusDeleted,
 	).Load(&count); err != nil {
 		return fmt.Errorf("incomingwebhook: count: %w", err)
 	}
@@ -82,10 +83,12 @@ func (d *incomingWebhookDB) queryByWebhookID(webhookID string) (*incomingWebhook
 	return m, err
 }
 
+// queryByGroupNo 列出群下 webhook 供管理端展示，隐藏软删除（statusDeleted）项（#254）。
 func (d *incomingWebhookDB) queryByGroupNo(groupNo string) ([]*incomingWebhookModel, error) {
 	var list []*incomingWebhookModel
 	_, err := d.session.Select("*").From("incoming_webhook").
 		Where("group_no=?", groupNo).
+		Where("status != ?", statusDeleted).
 		OrderDir("created_at", false).
 		Load(&list)
 	return list, err
@@ -115,8 +118,14 @@ func (d *incomingWebhookDB) updateFields(webhookID string, fields map[string]int
 	return err
 }
 
+// deleteByWebhookID 软删除（#254）：把 status 置为 statusDeleted 而非物理 DELETE，
+// 保留行供该 webhook 历史消息的发送者名/头像渲染（display datasource 不按 status
+// 过滤）。push 闸（status != statusEnabled）随之自动失效，列表/配额按 status !=
+// statusDeleted 排除，且 update 不再允许复活已删除行。调用方应先确认目标行存在且
+// 未删除（api 层在 query 后判 statusDeleted 返回 not-found）。
 func (d *incomingWebhookDB) deleteByWebhookID(webhookID string) error {
-	_, err := d.session.DeleteFrom("incoming_webhook").
+	_, err := d.session.Update("incoming_webhook").
+		Set("status", statusDeleted).
 		Where("webhook_id=?", webhookID).Exec()
 	return err
 }
@@ -132,11 +141,14 @@ func (d *incomingWebhookDB) markUsed(ctx context.Context, webhookID string, now 
 	return err
 }
 
-// disableByGroupNo 把指定群下所有 webhook 置为禁用，用于群解散等级联场景。
+// disableByGroupNo 把指定群下所有【未删除】的 webhook 置为禁用，用于群解散等级联场景。
+// 必须跳过 statusDeleted 行：否则会把软删除（2）翻成禁用（0），令其重新出现在管理列表
+// 并重新占用配额，等同"复活"了已删除的 webhook（#254）。
 func (d *incomingWebhookDB) disableByGroupNo(groupNo string) error {
 	_, err := d.session.Update("incoming_webhook").
-		Set("status", 0).
-		Where("group_no=?", groupNo).Exec()
+		Set("status", statusDisabled).
+		Where("group_no=?", groupNo).
+		Where("status != ?", statusDeleted).Exec()
 	return err
 }
 

--- a/modules/incomingwebhook/db_test.go
+++ b/modules/incomingwebhook/db_test.go
@@ -1,7 +1,9 @@
 package incomingwebhook
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
@@ -124,6 +126,81 @@ func TestDisableByGroupNo_SkipsDeleted(t *testing.T) {
 	assert.NotNil(t, deleted)
 	if deleted != nil {
 		assert.Equal(t, statusDeleted, deleted.Status, "soft-deleted webhook must NOT be revived to disabled on disband")
+	}
+}
+
+// TestUpdateFields_SkipsDeleted 锁定并发复活漏洞的根因防线（#254 follow-up）：
+// queryManageable 是非事务读，与 updateFields 之间有 TOCTOU 窗口——PUT 先通过校验，
+// 随后并发 DELETE 把行软删，最后 PUT 的 updateFields 把 status 写回 1 即"复活"已删除
+// webhook（重回列表 + 旧 token 复活）。updateFields 必须带 status != statusDeleted
+// 守卫，对已删除行的写入一律落空。这里直接对一个已软删除的行调 updateFields，断言
+// status / 业务字段都【不】被写入。
+func TestUpdateFields_SkipsDeleted(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+	d := newDB(ctx)
+
+	groupNo := "g_" + util.GenerUUID()[:12]
+	whID := mustInsertWebhook(t, d, groupNo)
+	assert.NoError(t, d.deleteByWebhookID(whID)) // status -> statusDeleted
+
+	// 模拟竞态尾部：对已删除行尝试 PUT status=1 + 改名。
+	assert.NoError(t, d.updateFields(whID, map[string]interface{}{
+		"status": statusEnabled,
+		"name":   "revived",
+	}))
+
+	m, err := d.queryByWebhookID(whID)
+	assert.NoError(t, err)
+	assert.NotNil(t, m)
+	if m != nil {
+		assert.Equal(t, statusDeleted, m.Status, "soft-deleted webhook must NOT be revived by a racing updateFields")
+		assert.NotEqual(t, "revived", m.Name, "soft-deleted webhook business fields must not be writable")
+	}
+}
+
+// TestUpdateFields_TokenHash_SkipsDeleted 覆盖 regenerate 路径：不得给已删除 webhook
+// 轮换 token_hash（否则会向调用方返回一个"看似有效"实则指向已删除行的新 token）。
+func TestUpdateFields_TokenHash_SkipsDeleted(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+	d := newDB(ctx)
+
+	groupNo := "g_" + util.GenerUUID()[:12]
+	whID := mustInsertWebhook(t, d, groupNo)
+	before, err := d.queryByWebhookID(whID)
+	assert.NoError(t, err)
+	assert.NotNil(t, before)
+	assert.NoError(t, d.deleteByWebhookID(whID))
+
+	assert.NoError(t, d.updateFields(whID, map[string]interface{}{"token_hash": "newhash"}))
+
+	after, err := d.queryByWebhookID(whID)
+	assert.NoError(t, err)
+	assert.NotNil(t, after)
+	if after != nil && before != nil {
+		assert.Equal(t, before.TokenHash, after.TokenHash, "token_hash of a soft-deleted webhook must not be rotated")
+	}
+}
+
+// TestMarkUsed_SkipsDeleted 锁定纵深防御一致性：push 成功后的异步审计若在行被并发软
+// 删除后才执行，markUsed 不得再给已删除 webhook 记账（call_count 不增）。
+func TestMarkUsed_SkipsDeleted(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+	d := newDB(ctx)
+
+	groupNo := "g_" + util.GenerUUID()[:12]
+	whID := mustInsertWebhook(t, d, groupNo)
+	assert.NoError(t, d.deleteByWebhookID(whID))
+
+	assert.NoError(t, d.markUsed(context.Background(), whID, time.Now()))
+
+	m, err := d.queryByWebhookID(whID)
+	assert.NoError(t, err)
+	assert.NotNil(t, m)
+	if m != nil {
+		assert.Equal(t, int64(0), m.CallCount, "markUsed must not bump a soft-deleted webhook")
 	}
 }
 

--- a/modules/incomingwebhook/db_test.go
+++ b/modules/incomingwebhook/db_test.go
@@ -48,15 +48,99 @@ func TestDisableByGroupNo(t *testing.T) {
 	assert.Equal(t, 1, mb.Status, "groupB webhook must stay enabled (no cross-group impact)")
 }
 
+// TestSoftDelete 验证软删除（#254）的 DB 层语义：deleteByWebhookID 把行标记为
+// statusDeleted 而非物理删除——记录仍可被 queryByWebhookID 解析（供历史消息渲染），
+// 但从 queryByGroupNo 列表隐藏。
+func TestSoftDelete(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+	d := newDB(ctx)
+
+	groupNo := "g_" + util.GenerUUID()[:12]
+	whID := mustInsertWebhook(t, d, groupNo)
+
+	assert.NoError(t, d.deleteByWebhookID(whID))
+
+	// 行仍在，status=statusDeleted（display datasource 据此仍能渲染发送者名/头像）。
+	m, err := d.queryByWebhookID(whID)
+	assert.NoError(t, err)
+	assert.NotNil(t, m, "soft-deleted row must remain for historical message rendering")
+	if m != nil {
+		assert.Equal(t, statusDeleted, m.Status)
+	}
+
+	// 管理列表隐藏已删除项。
+	list, err := d.queryByGroupNo(groupNo)
+	assert.NoError(t, err)
+	assert.Empty(t, list, "soft-deleted webhook must not appear in management list")
+}
+
+// TestSoftDelete_FreesQuota 验证软删除释放每群配额：填满配额后软删一个应能再建一个。
+func TestSoftDelete_FreesQuota(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+	d := newDB(ctx)
+
+	groupNo := "g_" + util.GenerUUID()[:12]
+	const max = 2
+
+	id1 := mustInsertWebhookWithMax(t, d, groupNo, max)
+	mustInsertWebhookWithMax(t, d, groupNo, max)
+
+	// 配额已满：第三个被拒。
+	over := &incomingWebhookModel{WebhookID: generateWebhookID(), TokenHash: "h", GroupNo: groupNo, Name: "wh", Status: statusEnabled}
+	assert.ErrorIs(t, d.insertWithQuota(over, max), ErrQuotaExceeded)
+
+	// 软删一个释放配额后可再建一个。
+	assert.NoError(t, d.deleteByWebhookID(id1))
+	again := &incomingWebhookModel{WebhookID: generateWebhookID(), TokenHash: "h", GroupNo: groupNo, Name: "wh", Status: statusEnabled}
+	assert.NoError(t, d.insertWithQuota(again, max), "soft-delete must free per-group quota")
+}
+
+// TestDisableByGroupNo_SkipsDeleted 验证群解散级联禁用不会"复活"已软删除的 webhook：
+// disableByGroupNo 把启用项翻为 statusDisabled，但必须跳过 statusDeleted 行（否则
+// status 2→0 会让它重新出现在列表、重新占配额）。
+func TestDisableByGroupNo_SkipsDeleted(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+	d := newDB(ctx)
+
+	groupNo := "g_" + util.GenerUUID()[:12]
+	enabledID := mustInsertWebhook(t, d, groupNo)
+	deletedID := mustInsertWebhook(t, d, groupNo)
+	assert.NoError(t, d.deleteByWebhookID(deletedID))
+
+	assert.NoError(t, d.disableByGroupNo(groupNo))
+
+	enabled, err := d.queryByWebhookID(enabledID)
+	assert.NoError(t, err)
+	assert.NotNil(t, enabled)
+	if enabled != nil {
+		assert.Equal(t, statusDisabled, enabled.Status, "enabled webhook must be disabled on disband")
+	}
+
+	deleted, err := d.queryByWebhookID(deletedID)
+	assert.NoError(t, err)
+	assert.NotNil(t, deleted)
+	if deleted != nil {
+		assert.Equal(t, statusDeleted, deleted.Status, "soft-deleted webhook must NOT be revived to disabled on disband")
+	}
+}
+
 func mustInsertWebhook(t *testing.T, d *incomingWebhookDB, groupNo string) string {
+	t.Helper()
+	return mustInsertWebhookWithMax(t, d, groupNo, 100)
+}
+
+func mustInsertWebhookWithMax(t *testing.T, d *incomingWebhookDB, groupNo string, max int) string {
 	t.Helper()
 	m := &incomingWebhookModel{
 		WebhookID: generateWebhookID(),
 		TokenHash: "h",
 		GroupNo:   groupNo,
 		Name:      "wh",
-		Status:    1,
+		Status:    statusEnabled,
 	}
-	assert.NoError(t, d.insertWithQuota(m, 100))
+	assert.NoError(t, d.insertWithQuota(m, max))
 	return m.WebhookID
 }

--- a/modules/incomingwebhook/display.go
+++ b/modules/incomingwebhook/display.go
@@ -76,8 +76,10 @@ func newWebhookChannelResp(m *incomingWebhookModel) *model.ChannelResp {
 
 // newChannelGetDatasource 构造 incomingwebhook 模块的 BussDataSource.ChannelGet：
 //   - 仅处理"单聊 + iwh_ 前缀"，其余一律返回 ErrDatasourceNotProcess 交还链路；
-//   - webhook 已删除（记录不存在）时同样返回 ErrDatasourceNotProcess，最终由上层
-//     优雅回落到"频道不存在/未知发送者"，不报 500。
+//   - 软删除（status=statusDeleted）后记录仍保留，且此处刻意不按 status 过滤，因此
+//     已删除 webhook 的历史消息仍能解析出真实发送者名/头像（#254，这正是软删除的目的）；
+//   - 仅当记录真正不存在（伪造或历史硬删除遗留的 iwh_）时返回 ErrDatasourceNotProcess，
+//     由上层优雅回落到"频道不存在/未知发送者"，不报 500。
 func newChannelGetDatasource(d *incomingWebhookDB) func(channelID string, channelType uint8, loginUID string) (*model.ChannelResp, error) {
 	return func(channelID string, channelType uint8, _ string) (*model.ChannelResp, error) {
 		if channelType != common.ChannelTypePerson.Uint8() || !isWebhookUID(channelID) {

--- a/modules/incomingwebhook/model.go
+++ b/modules/incomingwebhook/model.go
@@ -5,6 +5,19 @@ import (
 	"github.com/gocraft/dbr/v2"
 )
 
+// incoming_webhook.status 取值。SQL 列为 SMALLINT，仅 0/1 由 init 迁移注释覆盖；
+// 2 是 #254 引入的软删除标记，复用同一列、无需迁移。
+//
+//   - statusEnabled  正常可推送（push 闸要求 status == statusEnabled）。
+//   - statusDisabled 管理员主动关停，或群解散级联禁用（handleGroupDisband）。
+//   - statusDeleted  软删除：保留行供历史消息渲染（display datasource 不按 status
+//     过滤），同时 push 自动失效、从管理列表隐藏、释放每群配额，且不可经 update 复活。
+const (
+	statusDisabled = 0
+	statusEnabled  = 1
+	statusDeleted  = 2
+)
+
 // incomingWebhookModel 对应 incoming_webhook 表。
 type incomingWebhookModel struct {
 	WebhookID  string

--- a/modules/incomingwebhook/sql/20260604000002_incomingwebhook_status_comment.sql
+++ b/modules/incomingwebhook/sql/20260604000002_incomingwebhook_status_comment.sql
@@ -1,0 +1,13 @@
+-- +migrate Up
+
+-- #254 软删除复用 status 列引入 2=已删除 取值；列定义不变，仅刷新 COMMENT 让 schema
+-- 自文档化。原 COMMENT 只写 0/1，运维直接读表结构可能把 status=2 当脏数据，手动
+-- `UPDATE ... SET status=0 WHERE status=2` 会静默复活已删除 webhook（连同旧 token），
+-- 与软删除"删除即撤销"的语义相悖。目标库 MySQL 8.0：仅改 COMMENT 的 MODIFY COLUMN
+-- 走 INSTANT 算法、瞬时无锁，无需显式 pin ALGORITHM/LOCK。
+ALTER TABLE `incoming_webhook`
+  MODIFY COLUMN `status` SMALLINT NOT NULL DEFAULT 1 COMMENT '0=禁用,1=启用,2=已删除(软删除)';
+
+-- +migrate Down
+ALTER TABLE `incoming_webhook`
+  MODIFY COLUMN `status` SMALLINT NOT NULL DEFAULT 1 COMMENT '0=禁用,1=启用';

--- a/modules/incomingwebhook/webhook_render_test.go
+++ b/modules/incomingwebhook/webhook_render_test.go
@@ -85,17 +85,36 @@ func TestWebhookRender_Avatar_Default(t *testing.T) {
 	assert.NotEmpty(t, w.Body.Bytes())
 }
 
-// 删除 webhook 后：接口②优雅降级为非 200，且绝不 500。
-func TestWebhookRender_AfterDelete_UserGet(t *testing.T) {
+// 软删除（#254）后：接口②仍返回 200 + 真实发送者名，让该 webhook 的历史消息继续
+// 可渲染（软删除保留行，display datasource 不按 status 过滤）。
+func TestWebhookRender_AfterSoftDelete_UserGet(t *testing.T) {
 	handler, _, groupNo := setupTestEnv(t)
-	whID := createWebhook(t, handler, groupNo, "WH", "")
+	whID := createWebhook(t, handler, groupNo, "GitHub Bot", "")
 
 	w := do(handler, authReq("DELETE", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID), nil))
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	w = do(handler, authReq("GET", fmt.Sprintf("/v1/users/%s?group_no=%s", whID, groupNo), nil))
-	assert.NotEqual(t, http.StatusOK, w.Code)
-	assert.NotEqualf(t, http.StatusInternalServerError, w.Code, "deleted webhook must degrade gracefully, not 500; body: %s", w.Body.String())
+	assert.Equalf(t, http.StatusOK, w.Code, "soft-deleted webhook must still resolve; body: %s", w.Body.String())
+	res := parseJSON(t, w)
+	assert.Equal(t, whID, res["uid"])
+	assert.Equal(t, "GitHub Bot", res["name"])
+	assert.Equal(t, "webhook", res["category"])
+	assert.NotContains(t, w.Body.String(), "token")
+}
+
+// 软删除（#254）后：接口①仍把 webhook 解析为单聊频道并返回真实名。
+func TestWebhookRender_AfterSoftDelete_ChannelGet(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID := createWebhook(t, handler, groupNo, "GitHub Bot", "")
+
+	w := do(handler, authReq("DELETE", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID), nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	w = do(handler, authReq("GET", fmt.Sprintf("/v1/channels/%s/1", whID), nil))
+	assert.Equalf(t, http.StatusOK, w.Code, "soft-deleted webhook channel must still resolve; body: %s", w.Body.String())
+	res := parseJSON(t, w)
+	assert.Equal(t, "GitHub Bot", res["name"])
 }
 
 // 真实查询故障必须返回 5xx，不能被降级成 404 / 默认头像（reviewer #250 🔴）。
@@ -128,15 +147,16 @@ func TestWebhookRender_Avatar_QueryError_Returns5xx(t *testing.T) {
 	assert.GreaterOrEqualf(t, w.Code, 500, "query failure must surface as 5xx, not a default avatar; code=%d", w.Code)
 }
 
-// 删除 webhook 后：接口③仍回退默认头像（不裂图、不 404）。
-func TestWebhookRender_AfterDelete_Avatar(t *testing.T) {
+// 软删除（#254）后：接口③仍 302 重定向到真实头像 URL（头像行保留，不退化为默认图）。
+func TestWebhookRender_AfterSoftDelete_Avatar(t *testing.T) {
 	handler, _, groupNo := setupTestEnv(t)
-	whID := createWebhook(t, handler, groupNo, "WH", "https://example.com/a.png")
+	const avatarURL = "https://example.com/a.png"
+	whID := createWebhook(t, handler, groupNo, "WH", avatarURL)
 
 	w := do(handler, authReq("DELETE", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID), nil))
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	w = do(handler, anonReq("GET", fmt.Sprintf("/v1/users/%s/avatar", whID), nil))
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
+	assert.Equalf(t, http.StatusFound, w.Code, "soft-deleted webhook avatar must still redirect; code=%d", w.Code)
+	assert.Equal(t, avatarURL, w.Header().Get("Location"))
 }


### PR DESCRIPTION
## Summary

Closes #254.

Incoming webhook deletion was a hard `DELETE`, so once a webhook was deleted its `name`/`avatar` row was gone and historical messages from that webhook lost their sender name/avatar (the display endpoints added in #250 could only degrade). This PR changes deletion to a **soft delete** by reusing the existing `status` column (`status=2 = deleted`), so a deleted webhook's past messages keep rendering the real sender, while delete still behaves as a full revoke. No DB migration (reuses the existing `SMALLINT status` column).

## Behavior

| Concern | After soft-delete |
|---|---|
| Display (`/v1/channels/{iwh}/:type`, `/v1/users/{iwh}`, `/v1/users/{iwh}/avatar`) | still return the real name/avatar (datasource deliberately does not filter status) |
| Push with the deleted token | rejected (push gate requires `status == enabled`) |
| Management list / per-group quota | hidden / quota freed (`status != deleted`) |
| Revive via update / regenerate | rejected (404) |
| Group-disband cascade | skips deleted rows (won't flip `2 -> 0`) |

## Concurrency safety

A naive soft-delete has a TOCTOU window: the management write path reads the row (non-transactional) and then writes unconditionally, so a `PUT status=1` racing a `DELETE` could write `status` back to `1` and **revive a just-deleted webhook** — it reappears in the list and its old token can push again, breaking "delete == revoke". Fixed by:

- All management writes (`updateFields`, `deleteByWebhookID`, `markUsed`) carry a `WHERE status != deleted` guard, so any write targeting a soft-deleted row is a no-op. InnoDB row locks serialize the conditional UPDATE with the racing delete UPDATE — once a row is deleted, every later write falls through (no resurrection, no deadlock).
- `update` / `regenerate` re-read after the write: a `deleted` read-back returns 404 (lost the race to DELETE); a failed/empty read-back returns 5xx (retry) instead of a misleading 200 / spurious 404.

Note: not-found is decided by re-reading status, **not** by affected-rows, because the MySQL driver defaults to *changed*-rows (not matched-rows) — a value-unchanged update would otherwise be misclassified as not-found.

## Tests

`go test -race ./modules/incomingwebhook/` passes (the concurrency regression is stable at `-count=10`):

- **DB-level**: soft-delete keeps the row / hides from list / frees quota; disband skips deleted rows; `updateFields` / `markUsed` skip deleted rows (anti-revive).
- **HTTP-level**: quota release after delete, cannot-revive (update / delete / regenerate → 404), push fails after delete, and an end-to-end concurrent `DELETE` + `PUT status=1` regression that reproduced the resurrection + token-reuse before the fix.
- Rewrote #250's two "post-delete degradation" tests to assert "post-soft-delete still returns real data".

## Notes

- No DB migration. The `status` column COMMENT still documents only `0/1`; the `2 = deleted` semantics are documented on the code-level status constants (kept migration-free per the issue).
- Follow-up to #246 / #250.
- The linked issue is tracked on the Octo Board under the current sprint.
