### PR TITLE
ci: add timeout-minutes to all CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
   changes:
     name: Detect changed paths
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
@@ -87,6 +88,7 @@ jobs:
       needs.changes.outputs.code == 'true'
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -104,6 +106,7 @@ jobs:
       needs.changes.outputs.code == 'true'
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # MySQL and Redis are required by ~10 modules' integration tests
     # (modules/{user,oidc,thread,group,space,...}). The tests hardcode
     # 127.0.0.1:3306 (root/demo/test) and 127.0.0.1:6379 — see
@@ -211,6 +214,7 @@ jobs:
       needs.changes.outputs.code == 'true'
     name: Vet
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -228,6 +232,7 @@ jobs:
       needs.changes.outputs.code == 'true'
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -254,6 +259,7 @@ jobs:
     # semantics are uniformly applied.
     name: Personal MsgSendReq Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -278,6 +284,7 @@ jobs:
     # what extraction would emit.
     name: i18n Extract Check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -302,6 +309,7 @@ jobs:
     #             runtime downgrade to err.shared.internal).
     name: i18n Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 


### PR DESCRIPTION
## What

Add `timeout-minutes` to every CI job that is missing one.

**Timeout values:**
- `changes` (path detection): **5 min**
- `build` / `vet` / `lint` / custom lint jobs: **15 min**
- `test` / `build-and-test` / `npm-test`: **30 min**

## Why

Without explicit timeouts, a stuck test or build will run until GitHub's
6-hour default kills it — wasting runner capacity and delaying feedback.

Ref: Mininglamp-OSS workflow optimization T04.
