### PR TITLE
ci: add -shuffle=on to go test for order-dependency detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
             mysql -h 127.0.0.1 -uroot -pdemo -e "DROP DATABASE IF EXISTS test; CREATE DATABASE test CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;"
             redis-cli -h 127.0.0.1 -p 6379 FLUSHALL >/dev/null
             echo "::group::go test $pkg"
-            if ! go test -race -count=1 -timeout 5m "$pkg"; then
+            if ! go test -race -shuffle=on -count=1 -timeout 5m "$pkg"; then
               fail=1
             fi
             echo "::endgroup::"


### PR DESCRIPTION
## What

Add `-shuffle=on` flag to the `go test` invocation in CI.

## Why

`-shuffle=on` randomizes test execution order, exposing implicit ordering dependencies that cause flaky tests. This is a zero-cost quality improvement — any test that fails with shuffle enabled has a latent bug.

## Changes

Added `-shuffle=on` to `go test` command in `.github/workflows/ci.yml` (line 200):

```diff
-go test -race -count=1 -timeout 5m "$pkg"
+go test -race -shuffle=on -count=1 -timeout 5m "$pkg"
```

## Risk

None. If tests fail after this change, it reveals pre-existing hidden ordering dependencies that should be fixed.

Refs: Mininglamp-OSS workflow optimization T05