### PR TITLE
ci: add Docker lint workflow (hadolint + shellcheck)

### DIFF
--- a/.github/workflows/docker-lint.yml
+++ b/.github/workflows/docker-lint.yml
@@ -1,0 +1,21 @@
+name: Docker Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Dockerfile*'
+      - 'docker/**'
+      - '.hadolint.yaml'
+      - '.github/workflows/docker-lint.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Dockerfile*'
+      - 'docker/**'
+      - '.hadolint.yaml'
+      - '.github/workflows/docker-lint.yml'
+
+jobs:
+  docker-lint:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-docker-lint.yml@main

--- a/.github/workflows/docker-lint.yml
+++ b/.github/workflows/docker-lint.yml
@@ -19,3 +19,4 @@ on:
 jobs:
   docker-lint:
     uses: Mininglamp-OSS/.github/.github/workflows/reusable-docker-lint.yml@main
+    # Ref: Mininglamp-OSS workflow optimization T11

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,5 @@
+# DL3008: Pin versions in apt-get install.
+# Pinning Debian package versions is fragile (versions rotate with point releases)
+# and breaks reproducibility more than it helps in practice.
+ignored:
+  - DL3008

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,13 @@ ENV GO111MODULE on
 
 WORKDIR /go/cache
 
-ADD go.mod .
-ADD go.sum .
+COPY go.mod .
+COPY go.sum .
 RUN go mod download
 
 WORKDIR /go/release
 
-ADD . .
+COPY . .
 
 RUN GIT_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo unknown) && \
     GIT_COMMIT_DATE=$(git log --date=iso8601-strict -1 --pretty=%ct 2>/dev/null || echo 0) && \
@@ -32,7 +32,7 @@ RUN GIT_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo unknown) && \
       -installsuffix cgo -o app ./main.go
 
 
-FROM alpine AS prod
+FROM alpine:3.21 AS prod
 COPY --from=build /etc/passwd /etc/passwd
 COPY --from=build /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 RUN mkdir -p /usr/share/zoneinfo/Asia && \

--- a/Dockerfile.ghcr
+++ b/Dockerfile.ghcr
@@ -14,4 +14,4 @@ RUN apt-get update && \
 COPY assets ./assets
 COPY configs ./configs
 COPY --chmod=0755 linux_${TARGETARCH} main
-CMD /app/main
+CMD ["/app/main"]


### PR DESCRIPTION
## What

Add `docker-lint.yml` caller workflow that invokes the organization's
`reusable-docker-lint.yml` to lint Dockerfiles (hadolint) and shell
scripts in `docker/` (shellcheck).

## How it works

- **hadolint**: auto-discovers `Dockerfile*` at repo root. Skips gracefully
  if none found.
- **shellcheck**: scans `./docker/` for `.sh` files. Skips gracefully if
  directory doesn't exist or has no scripts.
- Only triggers on changes to Docker-related files (path filter).

## Dependency

Requires Mininglamp-OSS/.github#61 to be merged first (the reusable
workflow definition).

Ref: Mininglamp-OSS workflow optimization T11.
