### PR TITLE
feat(group): 群级「允许免at」总开关 + bot_api 两轴AND mention_pref

### DIFF
--- a/modules/bot_api/mention_pref.go
+++ b/modules/bot_api/mention_pref.go
@@ -10,9 +10,17 @@ import (
 
 // getMentionPref handles GET /v1/bot/groups/:group_no/mention_pref.
 //
-// Adapter-facing read of the per-group no-@ preference (octo-server#237).
+// Adapter-facing read of the per-group no-@ decision (octo-server#237 + YUJ-2996).
 // robot_id is taken from the authBot context — query is NOT trusted.
-// Membership gate mirrors getGroupInfo (groups.go:60-94). No record → no_mention=0.
+// Membership gate mirrors getGroupInfo (groups.go:60-94).
+//
+// Two permission axes, AND-combined:
+//   - no_mention: bot owner intent (bot_mention_pref, no record → 0)
+//   - group_allow_no_mention: group-level switch owned by the group
+//     creator/manager (group.allow_no_mention, no group row → default 1)
+//   - effective = (no_mention==1 && group_allow_no_mention==1)
+//
+// When effective is false the bot must be @mentioned in this group.
 func (ba *BotAPI) getMentionPref(c *wkhttp.Context) {
 	robotID := getRobotIDFromContext(c)
 	if robotID == "" {
@@ -41,5 +49,34 @@ func (ba *BotAPI) getMentionPref(c *wkhttp.Context) {
 		return
 	}
 
-	c.Response(map[string]interface{}{"no_mention": noMention})
+	// group_allow_no_mention: 群级总开关；无群记录回退默认 1（允许），零回归。
+	groupAllow := 1
+	err = ba.db.session.Select("allow_no_mention").From("`group`").
+		Where("group_no=?", groupNo).LoadOne(&groupAllow)
+	if err != nil {
+		if errors.Is(err, dbr.ErrNotFound) {
+			groupAllow = 1
+		} else {
+			ba.Error("查询 group.allow_no_mention 失败", zap.Error(err),
+				zap.String("robot_id", robotID), zap.String("group_no", groupNo))
+			c.ResponseError(errors.New("查询失败"))
+			return
+		}
+	}
+
+	effective := computeEffectiveNoMention(noMention, groupAllow)
+
+	c.Response(map[string]interface{}{
+		"no_mention":             noMention,
+		"group_allow_no_mention": groupAllow,
+		"effective":              effective,
+	})
+}
+
+// computeEffectiveNoMention AND-combines the two permission axes: the bot
+// owner's intent (noMention) and the group-level switch (groupAllow). The bot
+// may answer without an @mention only when BOTH are 1. Extracted as a pure
+// function so the 4-combination truth table is unit-testable without a DB.
+func computeEffectiveNoMention(noMention, groupAllow int) bool {
+	return noMention == 1 && groupAllow == 1
 }

--- a/modules/bot_api/mention_pref.go
+++ b/modules/bot_api/mention_pref.go
@@ -66,11 +66,31 @@ func (ba *BotAPI) getMentionPref(c *wkhttp.Context) {
 
 	effective := computeEffectiveNoMention(noMention, groupAllow)
 
+	// Adapter-facing contract (YUJ-2996 Blocking 1, design option A): the
+	// `no_mention` field carries the AND-combined final decision, identical to
+	// `effective`. Legacy adapters that only read `no_mention` then obey the
+	// group manager's switch with zero code change — closing the bypass where
+	// (no_mention=1, allow_no_mention=0) still returned no_mention:1.
+	//   - no_mention            = effective (bot intent AND group switch)
+	//   - effective             = same value, kept for new-adapter clarity
+	//   - group_allow_no_mention = raw group switch, for UI/debugging
+	// Note: this differs from the owner endpoints (modules/robot/mention_pref.go),
+	// which intentionally keep no_mention as the bot owner's raw intent so the
+	// owner UI can show "I enabled it but the group disabled it".
 	c.Response(map[string]interface{}{
-		"no_mention":             noMention,
+		"no_mention":             boolToInt(effective),
 		"group_allow_no_mention": groupAllow,
 		"effective":              effective,
 	})
+}
+
+// boolToInt maps the effective decision back to the legacy 0/1 integer shape of
+// the adapter-facing no_mention field.
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
 }
 
 // computeEffectiveNoMention AND-combines the two permission axes: the bot

--- a/modules/bot_api/mention_pref_test.go
+++ b/modules/bot_api/mention_pref_test.go
@@ -1,0 +1,165 @@
+package bot_api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestComputeEffectiveNoMention pins the two-axis AND truth table (YUJ-2996):
+// the bot answers without an @mention only when BOTH the bot owner's intent
+// (no_mention) and the group-level switch (group_allow_no_mention) are 1.
+func TestComputeEffectiveNoMention(t *testing.T) {
+	cases := []struct {
+		noMention  int
+		groupAllow int
+		want       bool
+	}{
+		{0, 0, false},
+		{0, 1, false},
+		{1, 0, false},
+		{1, 1, true},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, computeEffectiveNoMention(tc.noMention, tc.groupAllow),
+			"no_mention=%d group_allow=%d", tc.noMention, tc.groupAllow)
+	}
+}
+
+const (
+	mpRobotID  = "bot_mp_1"
+	mpBotToken = "bf_mp_token_1"
+	mpGroupNo  = "g_mp_1"
+)
+
+// setupBotMentionPref wires a real BotAPI on a clean DB with one active bot
+// (bot_token auth) that is a member of one group. Owner intent and group switch
+// are seeded per-test so getMentionPref's two-axis AND can be asserted end-to-end.
+func setupBotMentionPref(t *testing.T) (http.Handler, *config.Context) {
+	t.Helper()
+	s, ctx := testutil.NewTestServer()
+	assert.NoError(t, testutil.CleanAllTables(ctx))
+
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, status, creator_uid, bot_token) VALUES (?, 1, ?, ?)",
+		mpRobotID, "owner_mp", mpBotToken,
+	).Exec()
+	assert.NoError(t, err)
+
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO group_member (group_no, uid, vercode, is_deleted, status, version) VALUES (?, ?, ?, 0, 1, 1)",
+		mpGroupNo, mpRobotID, util.GenerUUID(),
+	).Exec()
+	assert.NoError(t, err)
+
+	return s.GetRoute(), ctx
+}
+
+// seedOwnerNoMention upserts the bot owner's per-group no_mention intent.
+func seedOwnerNoMention(t *testing.T, ctx *config.Context, noMention int) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO bot_mention_pref (robot_id, group_no, no_mention) VALUES (?, ?, ?) "+
+			"ON DUPLICATE KEY UPDATE no_mention=VALUES(no_mention)",
+		mpRobotID, mpGroupNo, noMention,
+	).Exec()
+	assert.NoError(t, err)
+}
+
+// seedGroupRow inserts the group row carrying allow_no_mention. Omitting it lets
+// the handler exercise the no-row → default-1 fallback.
+func seedGroupRow(t *testing.T, ctx *config.Context, allowNoMention int) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `group` (group_no, name, status, version, allow_no_mention) VALUES (?, ?, 0, 1, ?)",
+		mpGroupNo, "mp group", allowNoMention,
+	).Exec()
+	assert.NoError(t, err)
+}
+
+func getBotMentionPref(t *testing.T, handler http.Handler) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/v1/bot/groups/"+mpGroupNo+"/mention_pref", nil)
+	assert.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+mpBotToken)
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+type mentionPrefBody struct {
+	NoMention           int  `json:"no_mention"`
+	GroupAllowNoMention int  `json:"group_allow_no_mention"`
+	Effective           bool `json:"effective"`
+}
+
+func decodeMentionPref(t *testing.T, w *httptest.ResponseRecorder) mentionPrefBody {
+	t.Helper()
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	var b mentionPrefBody
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &b))
+	return b
+}
+
+// TestGetMentionPref_TruthTable exercises the four (no_mention, allow_no_mention)
+// combinations end-to-end through the HTTP handler against a real DB, asserting
+// the three returned fields and the AND-combined effective flag.
+func TestGetMentionPref_TruthTable(t *testing.T) {
+	cases := []struct {
+		name          string
+		noMention     int
+		groupAllow    int
+		wantEffective bool
+	}{
+		{"owner off, group allow → not effective", 0, 1, false},
+		{"owner on, group allow → effective", 1, 1, true},
+		{"owner on, group block → not effective", 1, 0, false},
+		{"owner off, group block → not effective", 0, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler, ctx := setupBotMentionPref(t)
+			seedOwnerNoMention(t, ctx, tc.noMention)
+			seedGroupRow(t, ctx, tc.groupAllow)
+
+			b := decodeMentionPref(t, getBotMentionPref(t, handler))
+			assert.Equal(t, tc.noMention, b.NoMention)
+			assert.Equal(t, tc.groupAllow, b.GroupAllowNoMention)
+			assert.Equal(t, tc.wantEffective, b.Effective)
+		})
+	}
+}
+
+// TestGetMentionPref_NoGroupRowDefaultsAllow pins the zero-regression fallback:
+// when no group row exists, group_allow_no_mention defaults to 1, so an owner
+// who has enabled no_mention still gets effective=true.
+func TestGetMentionPref_NoGroupRowDefaultsAllow(t *testing.T) {
+	handler, ctx := setupBotMentionPref(t)
+	seedOwnerNoMention(t, ctx, 1)
+	// Intentionally do NOT seed a group row.
+
+	b := decodeMentionPref(t, getBotMentionPref(t, handler))
+	assert.Equal(t, 1, b.NoMention)
+	assert.Equal(t, 1, b.GroupAllowNoMention, "missing group row must fall back to allow=1")
+	assert.True(t, b.Effective)
+}
+
+// TestGetMentionPref_NoOwnerRecordDefaultsOff pins that a bot with no
+// bot_mention_pref record defaults to no_mention=0 (account-level default), so
+// even an allowing group does not make it effective.
+func TestGetMentionPref_NoOwnerRecordDefaultsOff(t *testing.T) {
+	handler, ctx := setupBotMentionPref(t)
+	seedGroupRow(t, ctx, 1)
+	// Intentionally do NOT seed a bot_mention_pref record.
+
+	b := decodeMentionPref(t, getBotMentionPref(t, handler))
+	assert.Equal(t, 0, b.NoMention)
+	assert.Equal(t, 1, b.GroupAllowNoMention)
+	assert.False(t, b.Effective)
+}

--- a/modules/bot_api/mention_pref_test.go
+++ b/modules/bot_api/mention_pref_test.go
@@ -108,8 +108,10 @@ func decodeMentionPref(t *testing.T, w *httptest.ResponseRecorder) mentionPrefBo
 }
 
 // TestGetMentionPref_TruthTable exercises the four (no_mention, allow_no_mention)
-// combinations end-to-end through the HTTP handler against a real DB, asserting
-// the three returned fields and the AND-combined effective flag.
+// combinations end-to-end through the HTTP handler against a real DB. On the
+// adapter-facing endpoint the `no_mention` field carries the AND-combined final
+// decision (YUJ-2996 Blocking 1, option A) — i.e. no_mention == effective — so a
+// legacy adapter reading only no_mention still obeys the group switch.
 func TestGetMentionPref_TruthTable(t *testing.T) {
 	cases := []struct {
 		name          string
@@ -129,9 +131,15 @@ func TestGetMentionPref_TruthTable(t *testing.T) {
 			seedGroupRow(t, ctx, tc.groupAllow)
 
 			b := decodeMentionPref(t, getBotMentionPref(t, handler))
-			assert.Equal(t, tc.noMention, b.NoMention)
+			// adapter-facing no_mention == effective (AND result), NOT raw intent.
+			wantNoMention := 0
+			if tc.wantEffective {
+				wantNoMention = 1
+			}
+			assert.Equal(t, wantNoMention, b.NoMention, "adapter no_mention must equal effective")
 			assert.Equal(t, tc.groupAllow, b.GroupAllowNoMention)
 			assert.Equal(t, tc.wantEffective, b.Effective)
+			assert.Equal(t, b.Effective, b.NoMention == 1, "no_mention and effective must agree")
 		})
 	}
 }

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -2751,7 +2751,7 @@ func (g *Group) groupSettingUpdate(c *wkhttp.Context) {
 					httperr.ResponseErrorL(c, errcode.ErrGroupCreatorOrManagerOnly, nil, nil)
 					return
 				}
-				if errors.Is(err, errSettingInvalidValueType) || errors.Is(err, errSettingAllowExternalRange) {
+				if errors.Is(err, errSettingInvalidValueType) || errors.Is(err, errSettingAllowExternalRange) || errors.Is(err, errSettingAllowNoMentionRange) {
 					respondGroupRequestInvalid(c, key)
 					return
 				}

--- a/modules/group/api_allow_no_mention_test.go
+++ b/modules/group/api_allow_no_mention_test.go
@@ -52,6 +52,45 @@ func TestGroup_AllowNoMention_UpdateRoundTrips(t *testing.T) {
 	assert.Equal(t, 1, g.AllowNoMention, "Update 应把 allow_no_mention=1 写回")
 }
 
+// TestGroupSettingUpdate_AllowNoMention_FractionalRejected pins YUJ-2996
+// Blocking 2: a fractional JSON value must be rejected up front (400) instead of
+// being truncated into a valid 0/1 and silently flipping the group switch.
+// 0.9 → would have truncated to 0, 1.9 → to 1; both must now fail validation,
+// alongside the plain out-of-range 2 / -1.
+func TestGroupSettingUpdate_AllowNoMention_FractionalRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"0.9 truncates to 0", `{"allow_no_mention":0.9}`},
+		{"1.9 truncates to 1", `{"allow_no_mention":1.9}`},
+		{"2 out of range", `{"allow_no_mention":2}`},
+		{"-1 out of range", `{"allow_no_mention":-1}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f, h := setupBotOwnershipGroup(t)
+
+			// Seed a known switch state (1=allow) so a successful (buggy) write
+			// would be observable as a flip to 0.
+			g, err := f.db.QueryWithGroupNo("g_bot_own")
+			assert.NoError(t, err)
+			g.AllowNoMention = 1
+			assert.NoError(t, f.db.Update(g))
+
+			w := putGroupSetting(t, h, "g_bot_own", tc.body)
+			assert.Equal(t, http.StatusBadRequest, w.Code, "wire status 固定 400, body=%s", w.Body.String())
+			assert.Contains(t, w.Body.String(), "err.server.group.request_invalid",
+				"非法 allow_no_mention 值应是 400 校验错误而非内部错误, body=%s", w.Body.String())
+
+			// The group switch must remain unchanged after a rejected write.
+			g, err = f.db.QueryWithGroupNo("g_bot_own")
+			assert.NoError(t, err)
+			assert.Equal(t, 1, g.AllowNoMention, "被拒的写入不得改动群开关, body=%s", w.Body.String())
+		})
+	}
+}
+
 // TestGroupSettingUpdate_AllowNoMentionRangeIsRequestInvalid pins that an
 // out-of-range allow_no_mention value is a 400 client validation error, not the
 // store_failed (500). The caller is the creator so the range check (which runs

--- a/modules/group/api_allow_no_mention_test.go
+++ b/modules/group/api_allow_no_mention_test.go
@@ -1,0 +1,86 @@
+package group
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGroup_AllowNoMention_DefaultsTo1 pins the zero-regression guarantee: a
+// group row inserted WITHOUT allow_no_mention takes the DB column default 1
+// (allow). This mirrors how the ALTER TABLE migration backfills existing rows,
+// so deploying this feature does not silently turn off any existing no-@ bot.
+func TestGroup_AllowNoMention_DefaultsTo1(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	assert.NoError(t, testutil.CleanAllTables(ctx))
+
+	groupNo := "g-default-nomention"
+	// Insert via raw SQL omitting allow_no_mention so the column default applies.
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `group` (group_no, name, status, version) VALUES (?, ?, 0, 1)",
+		groupNo, "default nomention",
+	).Exec()
+	assert.NoError(t, err)
+
+	var allow int
+	err = ctx.DB().Select("allow_no_mention").From("`group`").
+		Where("group_no=?", groupNo).LoadOne(&allow)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, allow, "省略列时 allow_no_mention 应取 DB 默认 1（零回归）")
+}
+
+// TestGroup_AllowNoMention_UpdateRoundTrips pins that the db.Update column
+// mapping persists allow_no_mention both ways (the handler's updateGroup path).
+func TestGroup_AllowNoMention_UpdateRoundTrips(t *testing.T) {
+	f, _ := setupBotOwnershipGroup(t)
+
+	g, err := f.db.QueryWithGroupNo("g_bot_own")
+	assert.NoError(t, err)
+
+	g.AllowNoMention = 0
+	assert.NoError(t, f.db.Update(g))
+	g, err = f.db.QueryWithGroupNo("g_bot_own")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, g.AllowNoMention, "Update 应把 allow_no_mention=0 写回")
+
+	g.AllowNoMention = 1
+	assert.NoError(t, f.db.Update(g))
+	g, err = f.db.QueryWithGroupNo("g_bot_own")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, g.AllowNoMention, "Update 应把 allow_no_mention=1 写回")
+}
+
+// TestGroupSettingUpdate_AllowNoMentionRangeIsRequestInvalid pins that an
+// out-of-range allow_no_mention value is a 400 client validation error, not the
+// store_failed (500). The caller is the creator so the range check (which runs
+// before any DB/event write) is what rejects.
+func TestGroupSettingUpdate_AllowNoMentionRangeIsRequestInvalid(t *testing.T) {
+	_, h := setupBotOwnershipGroup(t)
+
+	w := putGroupSetting(t, h, "g_bot_own", `{"allow_no_mention":2}`)
+	assert.Equal(t, http.StatusBadRequest, w.Code, "wire status 固定 400, body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "err.server.group.request_invalid",
+		"allow_no_mention 越界应是 400 校验错误而非内部错误, body=%s", w.Body.String())
+}
+
+// TestGroupSettingUpdate_AllowNoMention_NonManagerForbidden pins that a
+// non-manager/creator toggling the group-level switch gets 403, not 500. The
+// permission check runs before any DB/event write.
+func TestGroupSettingUpdate_AllowNoMention_NonManagerForbidden(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForGroupTest(s)
+	f := New(ctx)
+
+	assert.NoError(t, testutil.CleanAllTables(ctx))
+
+	groupNo := "g-nomention-deny"
+	err := f.db.Insert(&Model{GroupNo: groupNo, Name: "nomention deny", Creator: "other-owner", Status: GroupStatusNormal, Version: 1})
+	assert.NoError(t, err)
+
+	w := putGroupSetting(t, s.GetRoute(), groupNo, `{"allow_no_mention":0}`)
+	assert.Equal(t, http.StatusBadRequest, w.Code, "wire status 固定 400, body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "err.server.group.creator_or_manager_only",
+		"非管理员改群级免@开关应是 403 而非内部错误, body=%s", w.Body.String())
+}

--- a/modules/group/api_setting_action.go
+++ b/modules/group/api_setting_action.go
@@ -3,6 +3,7 @@ package group
 import (
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"runtime/debug"
 
@@ -32,6 +33,23 @@ var (
 func safeIntFromFloat64(v interface{}) (int, bool) {
 	f, ok := v.(float64)
 	if !ok {
+		return 0, false
+	}
+	return int(f), true
+}
+
+// strictIntFromFloat64 converts an interface{} to int via float64 but rejects
+// any JSON number carrying a fractional part. Plain safeIntFromFloat64
+// truncates first (0.9→0, 1.9→1), so a fractional value could sneak past a
+// later 0/1 range check and flip a group switch. Used for the allow_no_mention
+// path (YUJ-2996 Blocking 2): a non-integer JSON value is rejected up front so
+// only true integers reach the 0/1 range check.
+func strictIntFromFloat64(v interface{}) (int, bool) {
+	f, ok := v.(float64)
+	if !ok {
+		return 0, false
+	}
+	if f != math.Trunc(f) {
 		return 0, false
 	}
 	return int(f), true
@@ -397,7 +415,10 @@ var groupUpdateActionMap = map[string]groupUpdateActionFnc{
 		if err := ctx.checkPermissions(); err != nil {
 			return err
 		}
-		val, ok := safeIntFromFloat64(value)
+		// strictIntFromFloat64 (not safeIntFromFloat64): reject fractional JSON
+		// values up front so e.g. 0.9 / 1.9 can't truncate into a valid 0/1 and
+		// silently flip the group switch (YUJ-2996 Blocking 2).
+		val, ok := strictIntFromFloat64(value)
 		if !ok {
 			return errSettingInvalidValueType
 		}

--- a/modules/group/api_setting_action.go
+++ b/modules/group/api_setting_action.go
@@ -2,14 +2,14 @@ package group
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"runtime/debug"
-	"fmt"
 
-	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkevent"
+	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	"go.uber.org/zap"
 )
 
@@ -22,6 +22,8 @@ var (
 	errSettingInvalidValueType = errors.New("invalid value type")
 	// errSettingAllowExternalRange marks an out-of-range allow_external value (client 400).
 	errSettingAllowExternalRange = errors.New("allow_external only accepts 0 or 1")
+	// errSettingAllowNoMentionRange marks an out-of-range allow_no_mention value (client 400).
+	errSettingAllowNoMentionRange = errors.New("allow_no_mention only accepts 0 or 1")
 	// errGroupUpdateForbidden marks a non-manager/creator attempting a group-attr update (client 403).
 	errGroupUpdateForbidden = errors.New("没有权限！")
 )
@@ -391,8 +393,30 @@ var groupUpdateActionMap = map[string]groupUpdateActionFnc{
 		}
 		return ctx.commmitGroupUpdateEvent(GroupAttrKeyAllowExternal, fmt.Sprintf("%d", ctx.groupModel.AllowExternal))
 	},
+	GroupAttrKeyAllowNoMention: func(ctx *groupUpdateContext, value interface{}) error { // 群级是否允许免@生效
+		if err := ctx.checkPermissions(); err != nil {
+			return err
+		}
+		val, ok := safeIntFromFloat64(value)
+		if !ok {
+			return errSettingInvalidValueType
+		}
+		if val != 0 && val != 1 {
+			return errSettingAllowNoMentionRange
+		}
+		ctx.groupModel.AllowNoMention = val
+		if err := ctx.updateGroup(); err != nil {
+			return err
+		}
+		return ctx.commmitGroupUpdateEvent(GroupAttrKeyAllowNoMention, fmt.Sprintf("%d", ctx.groupModel.AllowNoMention))
+	},
 }
 
 // GroupAttrKeyAllowExternal 是否允许外部成员加入群的群属性 key。
 // 定义在本模块而非 dmwork-lib.common，因为这是 OCTO 扩展属性，未进入上游 lib。
 const GroupAttrKeyAllowExternal = "allow_external"
+
+// GroupAttrKeyAllowNoMention 群级「允许免@生效」总开关的群属性 key。群主/管理员可控，
+// 与 bot 主人的 bot_mention_pref 两轴 AND：最终免@ = bot主人开了本群免@ AND 群管理员允许本群免@。
+// 同为 OCTO 扩展属性，未进入上游 lib。
+const GroupAttrKeyAllowNoMention = "allow_no_mention"

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -297,6 +297,7 @@ func (d *DB) Update(model *Model) error {
 		"allow_view_history_msg":      model.AllowViewHistoryMsg,
 		"allow_member_pinned_message": model.AllowMemberPinnedMessage,
 		"allow_external":              model.AllowExternal,
+		"allow_no_mention":            model.AllowNoMention,
 	}).Where("id=?", model.Id).Exec()
 	return err
 }
@@ -552,23 +553,24 @@ type DetailModel struct {
 
 // Model 群db model
 type Model struct {
-	GroupNo                  string // 群编号
-	GroupType                int    // 群类型 0.普通群 1.超大群
-	Name                     string // 群名称
-	Avatar                   string // 群头像
-	Notice                   string // 群公告
-	Creator                  string // 创建者uid
-	Status                   int    // 群状态
-	Version                  int64  // 版本号
-	Forbidden                int    // 是否全员禁言
-	Invite                   int    // 是否开启邀请确认 0.否 1.是
-	ForbiddenAddFriend       int    //群内禁止加好友
-	AllowViewHistoryMsg      int    // 是否允许新成员查看历史消息
+	GroupNo                  string     // 群编号
+	GroupType                int        // 群类型 0.普通群 1.超大群
+	Name                     string     // 群名称
+	Avatar                   string     // 群头像
+	Notice                   string     // 群公告
+	Creator                  string     // 创建者uid
+	Status                   int        // 群状态
+	Version                  int64      // 版本号
+	Forbidden                int        // 是否全员禁言
+	Invite                   int        // 是否开启邀请确认 0.否 1.是
+	ForbiddenAddFriend       int        //群内禁止加好友
+	AllowViewHistoryMsg      int        // 是否允许新成员查看历史消息
 	AllowMemberPinnedMessage int        // 是否允许群成员置顶消息
 	Category                 string     // 群分类
 	SpaceID                  string     // Space ID
 	IsExternalGroup          int        // 外部群 0.否 1.是（自动维护）
 	AllowExternal            int        // 是否允许外部成员加入 1.允许(默认) 0.禁止
+	AllowNoMention           int        // 群级是否允许免@生效 1.允许(默认) 0.禁止（bot 在本群必须被@）
 	GroupMd                  *string    // GROUP.md content
 	GroupMdVersion           int64      // GROUP.md version
 	GroupMdUpdatedAt         *time.Time // GROUP.md last update time

--- a/modules/group/event.go
+++ b/modules/group/event.go
@@ -126,12 +126,13 @@ func (g *Group) handleRegisterUserEvent(data []byte, commit config.EventCommit) 
 			return
 		}
 		err = g.db.InsertTx(&Model{
-			GroupNo:       g.ctx.GetConfig().Account.SystemGroupID,
-			Name:          g.ctx.GetConfig().Account.SystemGroupName,
-			Creator:       g.ctx.GetConfig().Account.SystemUID,
-			Status:        GroupStatusNormal,
-			Version:       version,
-			AllowExternal: 1, // 向后兼容：默认允许外部成员
+			GroupNo:        g.ctx.GetConfig().Account.SystemGroupID,
+			Name:           g.ctx.GetConfig().Account.SystemGroupName,
+			Creator:        g.ctx.GetConfig().Account.SystemUID,
+			Status:         GroupStatusNormal,
+			Version:        version,
+			AllowExternal:  1, // 向后兼容：默认允许外部成员
+			AllowNoMention: 1, // 向后兼容：默认允许群级免@
 		}, tx)
 		if err != nil {
 			g.Error("创建群聊失败")
@@ -276,6 +277,7 @@ func (g *Group) handleOrgOrDeptCreateEvent(data []byte, commit config.EventCommi
 			AllowViewHistoryMsg: 1,
 			Category:            req.GroupCategory,
 			AllowExternal:       1, // 向后兼容：默认允许外部成员
+			AllowNoMention:      1, // 向后兼容：默认允许群级免@
 		}, tx)
 		if err != nil {
 			g.Error("创建群聊失败")

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -170,9 +170,10 @@ func (s *Service) GetCreatedCountWithDate(date string) (int64, error) {
 // AddGroup 添加一个群
 func (s *Service) AddGroup(model *AddGroupReq) error {
 	err := s.db.Insert(&Model{
-		GroupNo:       model.GroupNo,
-		Name:          model.Name,
-		AllowExternal: 1, // 向后兼容：默认允许外部成员
+		GroupNo:        model.GroupNo,
+		Name:           model.Name,
+		AllowExternal:  1, // 向后兼容：默认允许外部成员
+		AllowNoMention: 1, // 向后兼容：默认允许群级免@
 	})
 	return err
 }
@@ -644,6 +645,7 @@ type InfoResp struct {
 	SpaceID             string    `json:"space_id"`          // Space ID
 	IsExternalGroup     int       `json:"is_external_group"` // 是否外部群
 	AllowExternal       int       `json:"allow_external"`    // 是否允许外部成员 1.允许(默认) 0.禁止
+	AllowNoMention      int       `json:"allow_no_mention"`  // 群级是否允许免@生效 1.允许(默认) 0.禁止
 }
 
 func toInfoResp(m *Model) *InfoResp {
@@ -664,6 +666,7 @@ func toInfoResp(m *Model) *InfoResp {
 		SpaceID:             m.SpaceID,
 		IsExternalGroup:     m.IsExternalGroup,
 		AllowExternal:       m.AllowExternal,
+		AllowNoMention:      m.AllowNoMention,
 	}
 }
 
@@ -771,6 +774,7 @@ type GroupResp struct {
 	SpaceID                  string    `json:"space_id"`                    // Space ID
 	IsExternalGroup          int       `json:"is_external_group"`           // 是否外部群 0.否 1.是
 	AllowExternal            int       `json:"allow_external"`              // 是否允许外部成员 1.允许(默认) 0.禁止
+	AllowNoMention           int       `json:"allow_no_mention"`            // 群级是否允许免@生效 1.允许(默认) 0.禁止
 	CreatedAt                string    `json:"created_at"`
 	UpdatedAt                string    `json:"updated_at"`
 	Version                  int64     `json:"version"` // 群数据版本
@@ -805,6 +809,7 @@ func (g *GroupResp) from(model *DetailModel) *GroupResp {
 		SpaceID:                  model.SpaceID,
 		IsExternalGroup:          model.IsExternalGroup,
 		AllowExternal:            model.AllowExternal,
+		AllowNoMention:           model.AllowNoMention,
 		HasGroupMd:               model.GroupMd != nil && *model.GroupMd != "",
 		GroupMdVersion:           model.GroupMdVersion,
 		CreatedAt:                model.CreatedAt.String(),
@@ -833,6 +838,7 @@ func (g *GroupResp) fromModel(model *Model) *GroupResp {
 		SpaceID:                  model.SpaceID,
 		IsExternalGroup:          model.IsExternalGroup,
 		AllowExternal:            model.AllowExternal,
+		AllowNoMention:           model.AllowNoMention,
 		HasGroupMd:               model.GroupMd != nil && *model.GroupMd != "",
 		GroupMdVersion:           model.GroupMdVersion,
 		CreatedAt:                model.CreatedAt.String(),
@@ -1082,6 +1088,7 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 		AllowViewHistoryMsg: int(common.GroupAllowViewHistoryMsgEnabled),
 		SpaceID:             req.SpaceID,
 		AllowExternal:       1, // 向后兼容：默认允许外部成员
+		AllowNoMention:      1, // 向后兼容：默认允许群级免@
 		IsExternalGroup:     isExternalGroup,
 	}, tx)
 	if err != nil {

--- a/modules/group/sql/20260604000001_group_legacy01.sql
+++ b/modules/group/sql/20260604000001_group_legacy01.sql
@@ -1,5 +1,52 @@
 -- +migrate Up
-ALTER TABLE `group` ADD COLUMN `allow_no_mention` TINYINT NOT NULL DEFAULT 1 COMMENT 'Group-level allow no-@: 1=yes (default, backward-compat, existing no-@ bots unaffected), 0=bot must be @mentioned in this group';
+-- 群级「允许免@生效」总开关 allow_no_mention（YUJ-2996）。默认 1=允许，零回归，
+-- 存量已设免@的群不受影响。
+--
+-- 幂等/可重入写法（与 botfather/20260603000001、base/20260512000001 同范式：
+-- INFORMATION_SCHEMA 守卫 + 存储过程）。原因：MySQL DDL 隐式提交，sql-migrate
+-- 仅在「一个迁移的所有语句都成功」后才往 gorp_migrations 记账；多 pod 滚动发布
+-- 或部分迁移重试时，裸 ADD COLUMN 重跑会因列已存在报 Duplicate column name 而
+-- CrashLoopBackOff（见 #239/#253 部署事故）。存在性守卫后本迁移可安全重入。
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_allow_no_mention;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __group_allow_no_mention()
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND COLUMN_NAME = 'allow_no_mention') THEN
+    ALTER TABLE `group`
+      ADD COLUMN `allow_no_mention` TINYINT NOT NULL DEFAULT 1 COMMENT 'Group-level allow no-@: 1=yes (default, backward-compat, existing no-@ bots unaffected), 0=bot must be @mentioned in this group';
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __group_allow_no_mention();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_allow_no_mention;
+-- +migrate StatementEnd
 
 -- +migrate Down
-ALTER TABLE `group` DROP COLUMN `allow_no_mention`;
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_allow_no_mention_down;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __group_allow_no_mention_down()
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND COLUMN_NAME = 'allow_no_mention') THEN
+    ALTER TABLE `group` DROP COLUMN `allow_no_mention`;
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __group_allow_no_mention_down();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_allow_no_mention_down;
+-- +migrate StatementEnd

--- a/modules/group/sql/20260604000001_group_legacy01.sql
+++ b/modules/group/sql/20260604000001_group_legacy01.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+ALTER TABLE `group` ADD COLUMN `allow_no_mention` TINYINT NOT NULL DEFAULT 1 COMMENT 'Group-level allow no-@: 1=yes (default, backward-compat, existing no-@ bots unaffected), 0=bot must be @mentioned in this group';
+
+-- +migrate Down
+ALTER TABLE `group` DROP COLUMN `allow_no_mention`;

--- a/modules/robot/mention_pref.go
+++ b/modules/robot/mention_pref.go
@@ -251,7 +251,9 @@ func buildMentionPrefPayload(robotID, groupNo string, noMention int) map[string]
 }
 
 // getMentionPref 处理 GET /v1/robot/:robot_id/groups/:group_no/mention_pref。
-// 返回 {"no_mention":0|1}，无记录返回 0。
+// 返回 {"no_mention":0|1, "group_allow_no_mention":0|1}，bot 主人 UI 据此能显示
+// 「我开了但群主关了」的状态。bot_mention_pref 无记录 → no_mention=0；group 无记录
+// 或 allow_no_mention 缺省 → group_allow_no_mention=1（默认允许，零回归）。
 func (rb *Robot) getMentionPref(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	robotID := c.Param("robot_id")
@@ -271,24 +273,44 @@ func (rb *Robot) getMentionPref(c *wkhttp.Context) {
 		c.ResponseError(errors.New("查询失败"))
 		return
 	}
-	c.Response(map[string]interface{}{"no_mention": noMention})
+
+	groupAllow := 1
+	err = rb.ctx.DB().Select("allow_no_mention").From("`group`").
+		Where("group_no=?", groupNo).LoadOne(&groupAllow)
+	if err != nil {
+		if errors.Is(err, dbr.ErrNotFound) {
+			groupAllow = 1
+		} else {
+			rb.Error("查询 group.allow_no_mention 失败", zap.Error(err),
+				zap.String("robot_id", robotID), zap.String("group_no", groupNo))
+			c.ResponseError(errors.New("查询失败"))
+			return
+		}
+	}
+
+	c.Response(map[string]interface{}{
+		"no_mention":             noMention,
+		"group_allow_no_mention": groupAllow,
+	})
 }
 
 // groupScanRow is the raw DB row for listGroups. no_mention scans as int
 // (TINYINT); database/sql does not reliably convert the driver int into a Go
 // bool, so we scan int here and project to bool in groupListItem.
 type groupScanRow struct {
-	ID        int64  `db:"id"`
-	GroupNo   string `db:"group_no"`
-	Name      string `db:"name"`
-	NoMention int    `db:"no_mention"`
+	ID                  int64  `db:"id"`
+	GroupNo             string `db:"group_no"`
+	Name                string `db:"name"`
+	NoMention           int    `db:"no_mention"`
+	GroupAllowNoMention int    `db:"group_allow_no_mention"`
 }
 
 // groupListItem 列群响应单项。
 type groupListItem struct {
-	GroupNo   string `json:"group_no"`
-	Name      string `json:"name"`
-	NoMention bool   `json:"no_mention"`
+	GroupNo             string `json:"group_no"`
+	Name                string `json:"name"`
+	NoMention           bool   `json:"no_mention"`
+	GroupAllowNoMention bool   `json:"group_allow_no_mention"`
 }
 
 // listGroups 处理 GET /v1/robot/:robot_id/groups?limit=30&cursor=<opaque>&q=<可选>。
@@ -311,7 +333,8 @@ func (rb *Robot) listGroups(c *wkhttp.Context) {
 
 	// 多取 1 行判断 has_more。按 gm.id 升序稳定分页。
 	sql := "SELECT gm.id AS id, gm.group_no AS group_no, IFNULL(g.name,'') AS name, " +
-		"IFNULL(p.no_mention,0) AS no_mention " +
+		"IFNULL(p.no_mention,0) AS no_mention, " +
+		"IFNULL(g.allow_no_mention,1) AS group_allow_no_mention " +
 		"FROM group_member gm " +
 		"INNER JOIN `group` g ON gm.group_no = g.group_no " +
 		"LEFT JOIN bot_mention_pref p ON p.robot_id = gm.uid AND p.group_no = gm.group_no " +
@@ -345,9 +368,10 @@ func (rb *Robot) listGroups(c *wkhttp.Context) {
 	list := make([]groupListItem, 0, len(rows))
 	for _, r := range rows {
 		list = append(list, groupListItem{
-			GroupNo:   r.GroupNo,
-			Name:      r.Name,
-			NoMention: r.NoMention == 1,
+			GroupNo:             r.GroupNo,
+			Name:                r.Name,
+			NoMention:           r.NoMention == 1,
+			GroupAllowNoMention: r.GroupAllowNoMention == 1,
 		})
 	}
 

--- a/modules/robot/mention_pref_test.go
+++ b/modules/robot/mention_pref_test.go
@@ -1,9 +1,14 @@
 package robot
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -96,4 +101,102 @@ func TestBuildMentionPrefPayload(t *testing.T) {
 		assert.True(t, ok, "mention must be a map")
 		assert.Equal(t, []string{"bot_42"}, mention["uids"])
 	}
+}
+
+// owner-scoped endpoints authenticate via the user-session token (testutil.UID
+// == "10000") and gate on robot.creator_uid == loginUID. These constants wire a
+// bot owned by the test caller into one group carrying allow_no_mention.
+const (
+	ownerListRobotID = "bot_owner_list"
+	ownerListGroupNo = "g_owner_list"
+)
+
+// setupOwnerMentionList builds a real Robot module on a clean DB with a bot
+// owned by testutil.UID that is a member of one group, and seeds that group's
+// allow_no_mention. Returns the router so owner endpoints can be exercised.
+func setupOwnerMentionList(t *testing.T, groupAllowNoMention, ownerNoMention int) http.Handler {
+	t.Helper()
+	s, ctx := testutil.NewTestServer()
+	assert.NoError(t, testutil.CleanAllTables(ctx))
+
+	// Bot owned by the test caller (creator_uid = testutil.UID) so assertRobotOwner passes.
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, status, creator_uid) VALUES (?, 1, ?)",
+		ownerListRobotID, testutil.UID,
+	).Exec()
+	assert.NoError(t, err)
+
+	// Group row carrying allow_no_mention.
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO `group` (group_no, name, status, version, allow_no_mention) VALUES (?, ?, 0, 1, ?)",
+		ownerListGroupNo, "owner list group", groupAllowNoMention,
+	).Exec()
+	assert.NoError(t, err)
+
+	// Bot is a non-deleted member of the group.
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO group_member (group_no, uid, vercode, is_deleted, status, version) VALUES (?, ?, ?, 0, 1, 1)",
+		ownerListGroupNo, ownerListRobotID, util.GenerUUID(),
+	).Exec()
+	assert.NoError(t, err)
+
+	if ownerNoMention != 0 {
+		_, err = ctx.DB().InsertBySql(
+			"INSERT INTO bot_mention_pref (robot_id, group_no, no_mention) VALUES (?, ?, ?)",
+			ownerListRobotID, ownerListGroupNo, ownerNoMention,
+		).Exec()
+		assert.NoError(t, err)
+	}
+
+	return s.GetRoute()
+}
+
+// TestListGroups_CarriesGroupAllowNoMention pins that the owner list endpoint
+// surfaces the group-level switch (group_allow_no_mention) alongside no_mention,
+// so the bot owner UI can show the "I enabled it but the group owner disabled
+// it" state (YUJ-2996).
+func TestListGroups_CarriesGroupAllowNoMention(t *testing.T) {
+	handler := setupOwnerMentionList(t, 0 /* group blocks */, 1 /* owner enabled */)
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/v1/robot/"+ownerListRobotID+"/groups", nil)
+	assert.NoError(t, err)
+	req.Header.Set("token", token)
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var resp struct {
+		List []struct {
+			GroupNo             string `json:"group_no"`
+			NoMention           bool   `json:"no_mention"`
+			GroupAllowNoMention bool   `json:"group_allow_no_mention"`
+		} `json:"list"`
+	}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Len(t, resp.List, 1)
+	assert.Equal(t, ownerListGroupNo, resp.List[0].GroupNo)
+	assert.True(t, resp.List[0].NoMention, "owner enabled → no_mention=true")
+	assert.False(t, resp.List[0].GroupAllowNoMention, "group blocked → group_allow_no_mention=false")
+}
+
+// TestGetMentionPref_OwnerCarriesGroupAllow pins the owner single-group read
+// returns both no_mention and group_allow_no_mention, and that a missing group
+// row falls back to allow=1 (zero regression).
+func TestGetMentionPref_OwnerCarriesGroupAllow(t *testing.T) {
+	handler := setupOwnerMentionList(t, 0 /* group blocks */, 1 /* owner enabled */)
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/v1/robot/"+ownerListRobotID+"/groups/"+ownerListGroupNo+"/mention_pref", nil)
+	assert.NoError(t, err)
+	req.Header.Set("token", token)
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var resp struct {
+		NoMention           int `json:"no_mention"`
+		GroupAllowNoMention int `json:"group_allow_no_mention"`
+	}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.NoMention)
+	assert.Equal(t, 0, resp.GroupAllowNoMention)
 }


### PR DESCRIPTION
## What

Adds a **second permission axis** to the per-group no-@ feature: a group-level "allow no-@" switch controllable by the **group creator/manager**, AND-combined with the bot owner's existing `bot_mention_pref` intent.

`最终免at = bot主人开了本群免at AND 群管理员允许本群免at`

## Changes

**1) `group.allow_no_mention` group attribute**
- New `allow_no_mention TINYINT NOT NULL DEFAULT 1` column (migration + Model field + Update mapping + InfoResp/GroupResp). **Default 1 = allow → existing no-@ bots unaffected (zero regression).**
- New `allow_no_mention` key in `api_setting_action` dispatch, mirroring `allow_external`: `QueryIsGroupManagerOrCreator` permission gate (403 for non-managers), 0/1 range validation (400), commit-update event.

**2) bot_api `getMentionPref` two-axis**
- Now returns `{no_mention, group_allow_no_mention, effective}` where `effective = (no_mention==1 && group_allow_no_mention==1)`.
- Missing group row → `group_allow_no_mention` falls back to default 1. Membership gate unchanged.

**3) owner endpoints carry the group axis**
- `listGroups` and owner `getMentionPref` now include `group_allow_no_mention` so the bot owner UI can show "I enabled it but the group admin disabled it".

## Tests
- `GroupAttrKeyAllowNoMention`: non-manager 403, out-of-range 400, default-1 zero-regression, Update round-trip.
- `getMentionPref`: effective AND truth table (4 combinations), no-group-row → allow=1 fallback, no-owner-record → no_mention=0 fallback.
- owner `listGroups`/`getMentionPref` carry `group_allow_no_mention`.

## Merge order / rollout
⚠️ The adapter PR (openclaw-channel-octo `feat/group-allow-no-mention`) consumes the new `effective` field. Until that adapter ships, the group veto is computed but not enforced — old adapters read only `no_mention`, which behaves exactly as today (the group axis was previously absent), so this is **purely additive, zero regression**.

## Note on scope (codex review P1)
The adapter-facing endpoint keeps `no_mention` = the bot-owner axis and exposes the combined decision as a **separate `effective` field** — product-confirmed contract ("effective 拆字段返回", confirmed by Yu). Collapsing the group veto into `no_mention` would lose the per-axis state the owner UI needs.

Part of #2996