### PR TITLE
fix(group): expose allow_no_mention in channel serialization + silent toggle

### DIFF
--- a/modules/group/1module.go
+++ b/modules/group/1module.go
@@ -196,6 +196,9 @@ func newChannelRespWithGroupResp(groupResp *GroupResp) *model.ChannelResp {
 	extraMap["allow_view_history_msg"] = groupResp.AllowViewHistoryMsg
 	extraMap["group_type"] = groupResp.GroupType
 	extraMap["allow_member_pinned_message"] = groupResp.AllowMemberPinnedMessage
+	// 群级「允许免@回答」总开关：前端 channelInfo.orgData.allow_no_mention 据此回读
+	// 真实 0/1 值，否则开关永远显示「开」且关不掉（refresh 弹回）。默认 1=允许，零回归。
+	extraMap["allow_no_mention"] = groupResp.AllowNoMention
 	if groupResp.MemberCount != 0 {
 		extraMap["member_count"] = groupResp.MemberCount
 	}

--- a/modules/group/api_allow_no_mention_test.go
+++ b/modules/group/api_allow_no_mention_test.go
@@ -104,7 +104,47 @@ func TestGroupSettingUpdate_AllowNoMentionRangeIsRequestInvalid(t *testing.T) {
 		"allow_no_mention 越界应是 400 校验错误而非内部错误, body=%s", w.Body.String())
 }
 
-// TestGroupSettingUpdate_AllowNoMention_NonManagerForbidden pins that a
+// TestNewChannelResp_CarriesAllowNoMention pins YUJ-3153 Bug 2 root cause: the
+// channel serialization (channels/{uid}/{type}, which feeds the web's
+// channelInfo.orgData) must expose allow_no_mention. Before the fix the field
+// was written to the DB but omitted from extraMap, so the client read undefined,
+// defaulted to 1, and the switch was stuck "on" (refresh bounced it back).
+func TestNewChannelResp_CarriesAllowNoMention(t *testing.T) {
+	for _, want := range []int{0, 1} {
+		resp := newChannelRespWithGroupResp(&GroupResp{
+			GroupNo:        "g-extra",
+			Name:           "extra group",
+			AllowNoMention: want,
+		})
+		got, ok := resp.Extra["allow_no_mention"]
+		assert.True(t, ok, "extra 必须透出 allow_no_mention，否则前端开关关不掉")
+		assert.Equal(t, want, got, "extra.allow_no_mention 应等于群 model 的值")
+	}
+}
+
+// TestGroupSettingUpdate_AllowNoMention_SilentToggleSucceeds pins YUJ-3153 Bug
+// 3: toggling the switch as creator now goes through the silent
+// SendChannelUpdateToGroup path (like mute / allow_view_history_msg) instead of
+// commmitGroupUpdateEvent. The latter published a GroupUpdate + wkevent.Message
+// that rendered as a blank announcement and an unread red dot on every click.
+// A successful 200 + persisted value here proves the toggle no longer routes
+// through the visible-message event path (which nil-derefs ctx.Event in testutil).
+func TestGroupSettingUpdate_AllowNoMention_SilentToggleSucceeds(t *testing.T) {
+	f, h := setupBotOwnershipGroup(t)
+
+	g, err := f.db.QueryWithGroupNo("g_bot_own")
+	assert.NoError(t, err)
+	g.AllowNoMention = 1
+	assert.NoError(t, f.db.Update(g))
+
+	w := putGroupSetting(t, h, "g_bot_own", `{"allow_no_mention":0}`)
+	assert.Equal(t, http.StatusOK, w.Code, "静默开关切换应成功返回 200, body=%s", w.Body.String())
+
+	g, err = f.db.QueryWithGroupNo("g_bot_own")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, g.AllowNoMention, "切换后 allow_no_mention 应持久化为 0")
+}
+
 // non-manager/creator toggling the group-level switch gets 403, not 500. The
 // permission check runs before any DB/event write.
 func TestGroupSettingUpdate_AllowNoMention_NonManagerForbidden(t *testing.T) {

--- a/modules/group/api_setting_action.go
+++ b/modules/group/api_setting_action.go
@@ -429,7 +429,13 @@ var groupUpdateActionMap = map[string]groupUpdateActionFnc{
 		if err := ctx.updateGroup(); err != nil {
 			return err
 		}
-		return ctx.commmitGroupUpdateEvent(GroupAttrKeyAllowNoMention, fmt.Sprintf("%d", ctx.groupModel.AllowNoMention))
+		// 静默群属性开关：只发不可见的频道刷新 cmd（同 mute / AllowViewHistoryMsg /
+		// AllowMemberPinnedMessage），不走 commmitGroupUpdateEvent。后者会发布
+		// GroupUpdate + wkevent.Message，客户端当成系统消息渲染并产生未读红点，而
+		// 客户端没有 allow_no_mention 的本地化模板，结果渲染成「只有用户名、无内容」
+		// 的空白公告（YUJ-3153 Bug 3）。allow_external 仍走 commmitGroupUpdateEvent，
+		// 本单不动以避免回归。
+		return ctx.g.ctx.SendChannelUpdateToGroup(ctx.groupModel.GroupNo)
 	},
 }
 


### PR DESCRIPTION
## What

YUJ-3153 真机测出群级「允许免@回答」开关的 3 个 bug，其中 2 个根因在 server 端，本 PR 修这两个（Bug 1 在 octo-web，另开 PR）。

### Bug 2：开关关不掉（主因）
`allow_no_mention` 写进了 group model 也进了 `db.Update` 映射，但 **channel 序列化漏掉了该字段**。`channels/{uid}/{type}`（`newChannelRespWithGroupResp` 的 `extraMap`）没透出 `allow_no_mention`，前端 `channelInfo.orgData.allow_no_mention` 永远 undefined → 默认回退 1 → 开关恒显示「开」，点击写库成功但 refresh 弹回。

修：`extraMap["allow_no_mention"] = groupResp.AllowNoMention`（默认 1，零回归），对照 `allow_view_history_msg` 等已有字段。

### Bug 3：每次点击产生红点 + 空白公告消息
`allow_no_mention` dispatch 复用 `commmitGroupUpdateEvent`，发布 `event.GroupUpdate` + `wkevent.Message`，客户端当系统消息渲染产生红点，但客户端无 `allow_no_mention` 本地化模板 → 渲染成「只有用户名、无内容」的空白公告。

修：改为只调 `SendChannelUpdateToGroup`（不可见的频道刷新 cmd），对照同文件 mute / `allow_view_history_msg` / `allow_member_pinned_message` 等静默开关写法。**`allow_external` 仍走旧路径，本单不动以避免回归。**

## Tests
- 新增 `TestNewChannelResp_CarriesAllowNoMention`（纯函数，pin Bug 2）— PASS。
- 新增 `TestGroupSettingUpdate_AllowNoMention_SilentToggleSucceeds`（pin Bug 3，需 DB）。
- `go build ./...` / `go vet ./modules/group/` PASS。
- ⚠️ DB-backed 测试在本地需要 MySQL + 迁移表（`NewTestServer` migration plan），CI 环境会跑。

Part of #3153
