### PR TITLE
feat(i18n): migrate robot module to ResponseErrorL (#267)

### DIFF
--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -30,6 +30,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/file"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
 	"github.com/Mininglamp-OSS/octo-server/pkg/richtext"
 	pkgutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
@@ -302,14 +304,14 @@ func (rb *Robot) streamStart(c *wkhttp.Context) {
 	var req config.MessageStreamStartReq
 	if err := c.BindJSON(&req); err != nil {
 		rb.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondRobotRequestInvalid(c, "")
 		return
 	}
 
 	streamNo, err := rb.ctx.IMStreamStart(req)
 	if err != nil {
 		rb.Error("发送stream start消息失败！", zap.Error(err))
-		c.ResponseError(errors.New("发送stream start消息失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotSendFailed, nil, nil)
 		return
 	}
 	c.Response(gin.H{
@@ -321,13 +323,13 @@ func (rb *Robot) streamEnd(c *wkhttp.Context) {
 	var req config.MessageStreamEndReq
 	if err := c.BindJSON(&req); err != nil {
 		rb.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondRobotRequestInvalid(c, "")
 		return
 	}
 	err := rb.ctx.IMStreamEnd(req)
 	if err != nil {
 		rb.Error("发送stream end消息失败！", zap.Error(err))
-		c.ResponseError(errors.New("发送stream end消息失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotSendFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -342,35 +344,25 @@ func (rb *Robot) authRobot() wkhttp.HandlerFunc {
 		robot, err := rb.db.queryVaildRobotWithRobtID(robotID)
 		if err != nil {
 			rb.Error("查询robot失败！", zap.Error(err))
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-				"msg": "查询robot失败！",
-			})
+			respondRobotAuthCheckFailed(c)
 			return
 		}
 		if robot == nil {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-				"msg": "机器人不存在！",
-			})
+			respondRobotAuthFailed(c)
 			return
 		}
 		appM, err := rb.appService.GetApp(robot.AppID)
 		if err != nil {
 			rb.Error("查询app失败！", zap.Error(err), zap.String("appID", robot.AppID))
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-				"msg": "查询app失败！",
-			})
+			respondRobotAuthCheckFailed(c)
 			return
 		}
 		if appM == nil {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-				"msg": "app不存在！",
-			})
+			respondRobotAuthFailed(c)
 			return
 		}
 		if !hmac.Equal([]byte(appM.AppKey), []byte(appKey)) {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-				"msg": "appKey不正确！",
-			})
+			respondRobotAuthFailed(c)
 			return
 		}
 		c.Next()
@@ -381,30 +373,30 @@ func (rb *Robot) typing(c *wkhttp.Context) {
 	var req *TypingReq
 	if err := c.BindJSON(&req); err != nil {
 		rb.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondRobotRequestInvalid(c, "")
 		return
 	}
 	if strings.TrimSpace(req.ChannelID) == "" {
-		c.ResponseError(errors.New("channel_id不能为空！"))
+		respondRobotRequestInvalid(c, "channel_id")
 		return
 	}
 	if req.ChannelType == 0 {
-		c.ResponseError(errors.New("channel_type不能为空！"))
+		respondRobotRequestInvalid(c, "channel_type")
 		return
 	}
 	fromUID := c.Param("robot_id")
 	if fromUID == "" {
-		c.ResponseError(errors.New("from_uid不能为空！"))
+		respondRobotRequestInvalid(c, "from_uid")
 		return
 	}
 	if !rb.allowSendToChannel(fromUID, req.ChannelID, req.ChannelType) {
-		c.ResponseError(errors.New("不允许发送消息到此频道！"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotChannelSendForbidden, nil, nil)
 		return
 	}
 	err := rb.ctx.SendTyping(req.ChannelID, req.ChannelType, fromUID)
 	if err != nil {
 		rb.Error("发送typing消息失败！", zap.Error(err))
-		c.ResponseError(errors.New("发送typing消息失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotSendFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -414,29 +406,29 @@ func (rb *Robot) sendMessage(c *wkhttp.Context) {
 	var messageReq *MessageReq
 	if err := c.BindJSON(&messageReq); err != nil {
 		rb.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondRobotRequestInvalid(c, "")
 		return
 	}
 	if strings.TrimSpace(messageReq.ChannelID) == "" {
-		c.ResponseError(errors.New("channel_id不能为空！"))
+		respondRobotRequestInvalid(c, "channel_id")
 		return
 	}
 	if messageReq.ChannelType == 0 {
-		c.ResponseError(errors.New("channel_type不能为空！"))
+		respondRobotRequestInvalid(c, "channel_type")
 		return
 	}
 	if len(messageReq.Payload) == 0 {
-		c.ResponseError(errors.New("payload不能为空！"))
+		respondRobotContentInvalid(c, "payload")
 		return
 	}
 
 	robotID := c.Param("robot_id")
 	if robotID == "" {
-		c.ResponseError(errors.New("robot_id不能为空！"))
+		respondRobotRequestInvalid(c, "robot_id")
 		return
 	}
 	if !rb.allowSendToChannel(robotID, messageReq.ChannelID, messageReq.ChannelType) {
-		c.ResponseError(errors.New("不允许发送消息到此频道！"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotChannelSendForbidden, nil, nil)
 		return
 	}
 
@@ -457,27 +449,27 @@ func (rb *Robot) sendMessage(c *wkhttp.Context) {
 	payloadResult := maputil.Data(messageReq.Payload)
 	contentTypeValue := payloadResult.Int("type")
 	if contentTypeValue == 0 {
-		c.ResponseError(errors.New("payload.type不能为空！"))
+		respondRobotContentInvalid(c, "payload.type")
 		return
 	}
 	contentType := common.ContentType(contentTypeValue)
 	if !rb.supportContentType(contentType) {
-		c.ResponseError(fmt.Errorf("不支持的type[%d]", contentType))
+		respondRobotContentTypeUnsupported(c, int(contentType))
 		return
 	}
 
 	if !rb.payloadIsVail(payloadResult) {
-		c.ResponseError(fmt.Errorf("无效的payload[%s]", util.ToJson(messageReq.Payload)))
+		respondRobotContentInvalid(c, "payload")
 		return
 	}
 	userResp, err := rb.userService.GetUserWithUsername(robotID)
 	if err != nil {
 		rb.Error("查询机器人的用户信息失败！", zap.Error(err))
-		c.ResponseError(fmt.Errorf("获取机器人[%s]信息失败！", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 		return
 	}
 	if userResp == nil {
-		c.ResponseError(fmt.Errorf("机器人[%s]不存在！", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrRobotNotFound, nil, nil)
 		return
 	}
 	// YUJ-644 / Mininglamp-OSS#33: PERSONAL DM 派发前服务端权威 space_id 注入。
@@ -495,7 +487,7 @@ func (rb *Robot) sendMessage(c *wkhttp.Context) {
 	// 注入的顶层字段）的 1MB 复检（PR#232 Jerry-Xin Critical#2）。
 	if err := richtext.Finalize(payload); err != nil {
 		rb.Error("RichText payload plain 生成/复检失败", zap.Error(err), zap.String("robotID", robotID), zap.String("channelID", messageReq.ChannelID))
-		c.ResponseError(fmt.Errorf("无效的payload[%s]", util.ToJson(messageReq.Payload)))
+		respondRobotContentInvalid(c, "payload")
 		return
 	}
 
@@ -546,7 +538,7 @@ func (rb *Robot) sendMessage(c *wkhttp.Context) {
 	})
 	if err != nil {
 		rb.Error("发送robot消息失败！", zap.Error(err))
-		c.ResponseError(errors.New("发送消息失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotSendFailed, nil, nil)
 		return
 	}
 	c.Response(result)
@@ -619,11 +611,11 @@ func (rb *Robot) answerInlineQuery(c *wkhttp.Context) {
 	var result *InlineQueryResult
 	if err := c.BindJSON(&result); err != nil {
 		rb.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondRobotRequestInvalid(c, "")
 		return
 	}
 	if err := result.Check(); err != nil {
-		c.ResponseError(err)
+		respondRobotRequestInvalid(c, "")
 		return
 	}
 	rb.inlineQueryEventResultChanMapLock.Lock()
@@ -648,25 +640,26 @@ func (rb *Robot) inlineQuery(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		rb.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondRobotRequestInvalid(c, "")
 		return
 	}
 	if len(req.Username) == 0 {
-		c.ResponseError(errors.New("username不能为空！"))
+		respondRobotRequestInvalid(c, "username")
 		return
 	}
 	robotM, err := rb.db.queryWithUsername(req.Username)
 	if err != nil {
-		c.ResponseErrorf("查询机器人失败！", err)
+		rb.Error("查询机器人失败", zap.Error(err), zap.String("username", req.Username))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 		return
 	}
 	if robotM == nil {
-		c.ResponseError(errors.New("机器人不存在！"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotNotFound, nil, nil)
 		return
 	}
 	if strings.TrimSpace(robotM.AppID) == "" {
 		rb.Error("机器人没有app_id", zap.String("username", req.Username))
-		c.ResponseError(errors.New("机器人没有app_id！"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotNotFound, nil, nil)
 		return
 	}
 	robotID := robotM.RobotID
@@ -692,7 +685,7 @@ func (rb *Robot) inlineQuery(c *wkhttp.Context) {
 	case result := <-resultChan:
 		c.JSON(http.StatusOK, result)
 	case <-time.After(time.Second * 20):
-		c.AbortWithStatus(http.StatusRequestTimeout)
+		respondRobotInlineQueryTimeout(c)
 	}
 
 	rb.inlineQueryEventResultChanMapLock.Lock()
@@ -831,7 +824,7 @@ func (rb *Robot) getEventsForPost(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		rb.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondRobotRequestInvalid(c, "")
 		return
 	}
 	results, err := rb.getEventsResult(robotID, req.EventID, req.Limit)
@@ -883,13 +876,14 @@ func (rb *Robot) eventAck(c *wkhttp.Context) {
 	eventID, err := strconv.ParseInt(c.Param("event_id"), 10, 64)
 	if err != nil {
 		rb.Error("解析event_id参数失败", zap.Error(err), zap.String("value", c.Param("event_id")))
-		c.ResponseError(errors.New("event_id格式错误"))
+		respondRobotRequestInvalid(c, "event_id")
 		return
 	}
 
 	err = rb.removeEvent(robotID, eventID)
 	if err != nil {
-		c.ResponseError(err)
+		rb.Error("移除机器人事件失败", zap.Error(err), zap.Int64("event_id", eventID))
+		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -963,14 +957,14 @@ func (rb *Robot) insertSystemRobot() error {
 func (rb *Robot) getCommands(c *wkhttp.Context) {
 	robotID := c.Query("robot_id")
 	if strings.TrimSpace(robotID) == "" {
-		c.ResponseError(errors.New("robot_id不能为空"))
+		respondRobotRequestInvalid(c, "robot_id")
 		return
 	}
 
 	botCommands, err := rb.db.queryBotCommandsByRobotID(robotID)
 	if err != nil {
 		rb.Error("查询机器人命令失败", zap.Error(err))
-		c.ResponseError(errors.New("查询机器人命令失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 		return
 	}
 
@@ -982,7 +976,7 @@ func (rb *Robot) getCommands(c *wkhttp.Context) {
 	var commands []interface{}
 	if err := json.Unmarshal([]byte(botCommands), &commands); err != nil {
 		rb.Error("解析机器人命令失败", zap.Error(err), zap.String("botCommands", botCommands))
-		c.ResponseError(errors.New("机器人命令数据损坏"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 		return
 	}
 	c.Response(commands)
@@ -997,7 +991,7 @@ func (rb *Robot) sync(c *wkhttp.Context) {
 	}
 	var reqs []*req
 	if err := c.BindJSON(&reqs); err != nil {
-		c.ResponseError(errors.New("请求数据格式有误！"))
+		respondRobotRequestInvalid(c, "")
 		return
 	}
 
@@ -1018,14 +1012,14 @@ func (rb *Robot) sync(c *wkhttp.Context) {
 	if len(robotIDs) > 0 {
 		robotList, err = rb.db.queryWithIDs(robotIDs)
 		if err != nil {
-			c.ResponseError(errors.New("批量查询机器人数据错误"))
+			httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 			rb.Error("批量查询机器人数据错误", zap.Error(err))
 			return
 		}
 	} else if len(usernames) > 0 {
 		robotList, err = rb.db.queryWithUsernames(usernames)
 		if err != nil {
-			c.ResponseError(errors.New("批量通过username查询机器人数据错误"))
+			httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 			rb.Error("批量通过username查询机器人数据错误", zap.Error(err))
 			return
 		}
@@ -1046,7 +1040,7 @@ func (rb *Robot) sync(c *wkhttp.Context) {
 	}
 	menus, err := rb.db.queryMenusWithRobotIDs(respRobotIDs)
 	if err != nil {
-		c.ResponseError(errors.New("批量查询机器人菜单数据错误"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 		rb.Error("批量查询机器人菜单数据错误", zap.Error(err))
 		return
 	}
@@ -1177,7 +1171,7 @@ func (rb *Robot) setDescription(c *wkhttp.Context) {
 		Description string `json:"description"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("参数错误"))
+		respondRobotRequestInvalid(c, "")
 		return
 	}
 
@@ -1185,17 +1179,18 @@ func (rb *Robot) setDescription(c *wkhttp.Context) {
 	var creatorUID string
 	err := rb.ctx.DB().Select("IFNULL(creator_uid,'')").From("robot").Where("robot_id=? AND status=1", robotID).LoadOne(&creatorUID)
 	if err != nil || creatorUID == "" {
-		c.ResponseError(errors.New("机器人不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotNotFound, nil, nil)
 		return
 	}
 	if creatorUID != loginUID {
-		c.ResponseError(errors.New("只有创建者可以修改"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotCreatorOnly, nil, nil)
 		return
 	}
 
 	_, err = rb.ctx.DB().Update("robot").Set("description", req.Description).Where("robot_id=?", robotID).Exec()
 	if err != nil {
-		c.ResponseError(errors.New("更新失败"))
+		rb.Error("更新 robot description 失败", zap.Error(err), zap.String("robot_id", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -1210,7 +1205,7 @@ func (rb *Robot) setAutoApprove(c *wkhttp.Context) {
 		AutoApprove int `json:"auto_approve"` // 0:需审批 1:自动通过
 	}
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("参数错误"))
+		respondRobotRequestInvalid(c, "")
 		return
 	}
 
@@ -1218,17 +1213,18 @@ func (rb *Robot) setAutoApprove(c *wkhttp.Context) {
 	var creatorUID string
 	err := rb.ctx.DB().Select("IFNULL(creator_uid,'')").From("robot").Where("robot_id=? AND status=1", robotID).LoadOne(&creatorUID)
 	if err != nil || creatorUID == "" {
-		c.ResponseError(errors.New("机器人不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotNotFound, nil, nil)
 		return
 	}
 	if creatorUID != loginUID {
-		c.ResponseError(errors.New("只有创建者可以修改"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotCreatorOnly, nil, nil)
 		return
 	}
 
 	_, err = rb.ctx.DB().Update("robot").Set("auto_approve", req.AutoApprove).Where("robot_id=?", robotID).Exec()
 	if err != nil {
-		c.ResponseError(errors.New("更新失败"))
+		rb.Error("更新 robot auto_approve 失败", zap.Error(err), zap.String("robot_id", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -1239,7 +1235,7 @@ func (rb *Robot) spaceBots(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	spaceID := c.Query("space_id")
 	if spaceID == "" {
-		c.ResponseError(errors.New("space_id 不能为空"))
+		respondRobotRequestInvalid(c, "space_id")
 		return
 	}
 
@@ -1267,7 +1263,7 @@ func (rb *Robot) spaceBots(c *wkhttp.Context) {
 	`, spaceID).Load(&bots)
 	if err != nil {
 		rb.Error("查询 Space Bot 列表失败", zap.Error(err))
-		c.ResponseError(errors.New("查询失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 		return
 	}
 
@@ -1387,7 +1383,7 @@ func (rb *Robot) myBots(c *wkhttp.Context) {
 	_, err := rb.ctx.DB().SelectBySql(query, args...).Load(&bots)
 	if err != nil {
 		rb.Error("查询我的 Bot 列表失败", zap.Error(err))
-		c.ResponseError(errors.New("查询失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 		return
 	}
 
@@ -1433,7 +1429,7 @@ func (rb *Robot) myBots(c *wkhttp.Context) {
 func (rb *Robot) proxyFile(c *wkhttp.Context) {
 	ph := c.Param("path")
 	if ph == "" {
-		c.ResponseError(errors.New("文件路径不能为空"))
+		respondRobotRequestInvalid(c, "path")
 		return
 	}
 	// 去掉前导 /
@@ -1442,7 +1438,7 @@ func (rb *Robot) proxyFile(c *wkhttp.Context) {
 	// Sanitize path to prevent directory traversal
 	cleaned := filepath.Clean(ph)
 	if strings.Contains(cleaned, "..") || strings.ContainsAny(cleaned, "\x00") {
-		c.ResponseErrorWithStatus(errors.New("文件路径无效"), http.StatusBadRequest)
+		respondRobotRequestInvalid(c, "path")
 		return
 	}
 	ph = cleaned
@@ -1455,7 +1451,7 @@ func (rb *Robot) proxyFile(c *wkhttp.Context) {
 	downloadURL, err := rb.fileService.DownloadURL(ph, filename)
 	if err != nil {
 		rb.Error("获取文件下载URL失败", zap.Error(err), zap.String("path", ph))
-		c.ResponseError(errors.New("获取文件失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotUploadFailed, nil, nil)
 		return
 	}
 	c.Redirect(http.StatusFound, downloadURL)
@@ -1469,7 +1465,7 @@ func (rb *Robot) botUploadFile(c *wkhttp.Context) {
 	multipartFile, fileHeader, err := c.Request.FormFile("file")
 	if err != nil {
 		rb.Error("读取上传文件失败", zap.Error(err))
-		c.ResponseError(errors.New("读取文件失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotUploadFailed, nil, nil)
 		return
 	}
 	defer multipartFile.Close()
@@ -1477,14 +1473,14 @@ func (rb *Robot) botUploadFile(c *wkhttp.Context) {
 	// 文件大小限制 100MB
 	const maxSize int64 = 100 * 1024 * 1024
 	if fileHeader.Size > maxSize {
-		c.ResponseError(fmt.Errorf("文件大小不能超过%dMB", maxSize/1024/1024))
+		respondRobotFileTooLarge(c, maxSize/1024/1024)
 		return
 	}
 
 	fileName := fileHeader.Filename
 	ext := strings.ToLower(filepath.Ext(fileName))
 	if ext == "" {
-		c.ResponseError(errors.New("文件必须包含扩展名"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotFileTypeUnsupported, nil, nil)
 		return
 	}
 
@@ -1509,7 +1505,7 @@ func (rb *Robot) botUploadFile(c *wkhttp.Context) {
 	})
 	if err != nil {
 		rb.Error("上传文件失败", zap.Error(err))
-		c.ResponseError(errors.New("上传文件失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotUploadFailed, nil, nil)
 		return
 	}
 
@@ -1529,21 +1525,21 @@ func (rb *Robot) botUploadFile(c *wkhttp.Context) {
 func (rb *Robot) botUploadCredentials(c *wkhttp.Context) {
 	filename := c.Query("filename")
 	if strings.TrimSpace(filename) == "" {
-		c.ResponseError(errors.New("filename 不能为空"))
+		respondRobotRequestInvalid(c, "filename")
 		return
 	}
 	filename = filepath.Base(filename)
 
 	ext := strings.ToLower(filepath.Ext(filename))
 	if ext == "" || file.IsBlockedExtension(ext) || !file.IsAllowedExtension(ext) {
-		c.ResponseError(errors.New("不支持的文件类型"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotFileTypeUnsupported, nil, nil)
 		return
 	}
 
 	cosConfig := rb.ctx.GetConfig().COS
 	if cosConfig.SecretID == "" || cosConfig.SecretKey == "" || cosConfig.Bucket == "" {
 		rb.Error("COS 配置不完整")
-		c.ResponseError(errors.New("COS 未配置"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotUploadFailed, nil, nil)
 		return
 	}
 
@@ -1567,7 +1563,7 @@ func (rb *Robot) botUploadCredentials(c *wkhttp.Context) {
 	}
 	if appId == "" {
 		rb.Error("无法从 bucket 名称中提取 appId", zap.String("bucket", bucket))
-		c.ResponseError(errors.New("COS 配置错误：bucket 格式不正确"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotUploadFailed, nil, nil)
 		return
 	}
 
@@ -1589,7 +1585,7 @@ func (rb *Robot) botUploadCredentials(c *wkhttp.Context) {
 	res, err := client.GetCredential(opt)
 	if err != nil {
 		rb.Error("获取 STS 临时密钥失败", zap.Error(err))
-		c.ResponseError(errors.New("获取临时密钥失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotUploadFailed, nil, nil)
 		return
 	}
 
@@ -1612,7 +1608,7 @@ func (rb *Robot) botUploadCredentials(c *wkhttp.Context) {
 func (rb *Robot) botUploadPresigned(c *wkhttp.Context) {
 	filename := c.Query("filename")
 	if strings.TrimSpace(filename) == "" {
-		c.ResponseError(errors.New("filename 不能为空"))
+		respondRobotRequestInvalid(c, "filename")
 		return
 	}
 	filename = filepath.Base(filename)
@@ -1622,24 +1618,24 @@ func (rb *Robot) botUploadPresigned(c *wkhttp.Context) {
 	// guard the public file API enforces (see modules/file/api.go).
 	fileSizeRaw := strings.TrimSpace(c.Query("fileSize"))
 	if fileSizeRaw == "" {
-		c.ResponseError(errors.New("fileSize 参数必填，且不能超过最大限制"))
+		respondRobotRequestInvalid(c, "fileSize")
 		return
 	}
 	fileSize, parseErr := strconv.ParseInt(fileSizeRaw, 10, 64)
 	if parseErr != nil || fileSize <= 0 {
-		c.ResponseError(errors.New("fileSize 参数必须为正整数（字节）"))
+		respondRobotRequestInvalid(c, "fileSize")
 		return
 	}
 	if fileSize > file.MaxFileSize {
 		rb.Warn("预签名上传 fileSize 超出限制",
 			zap.Int64("size", fileSize), zap.Int64("max", file.MaxFileSize))
-		c.ResponseError(fmt.Errorf("文件大小不能超过%dMB", file.MaxFileSize/1024/1024))
+		respondRobotFileTooLarge(c, file.MaxFileSize/1024/1024)
 		return
 	}
 
 	ext := strings.ToLower(filepath.Ext(filename))
 	if ext == "" || file.IsBlockedExtension(ext) || !file.IsAllowedExtension(ext) {
-		c.ResponseError(errors.New("不支持的文件类型"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotFileTypeUnsupported, nil, nil)
 		return
 	}
 
@@ -1655,7 +1651,7 @@ func (rb *Robot) botUploadPresigned(c *wkhttp.Context) {
 	uploadURL, downloadURL, err := rb.fileService.PresignedPutURL(objectPath, contentType, contentDisposition, fileSize, expiry)
 	if err != nil {
 		rb.Error("生成预签名上传URL失败", zap.Error(err))
-		c.ResponseError(errors.New("生成上传URL失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotUploadFailed, nil, nil)
 		return
 	}
 
@@ -1690,29 +1686,29 @@ func (rb *Robot) botMessageEdit(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		rb.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondRobotRequestInvalid(c, "")
 		return
 	}
 	if req.MessageID == "" {
-		c.ResponseError(errors.New("message_id 不能为空"))
+		respondRobotRequestInvalid(c, "message_id")
 		return
 	}
 	if req.MessageSeq == 0 {
-		c.ResponseError(errors.New("message_seq 不能为空"))
+		respondRobotRequestInvalid(c, "message_seq")
 		return
 	}
 	if req.ChannelID == "" {
-		c.ResponseError(errors.New("channel_id 不能为空"))
+		respondRobotRequestInvalid(c, "channel_id")
 		return
 	}
 	if strings.TrimSpace(req.ContentEdit) == "" {
-		c.ResponseError(errors.New("content_edit 不能为空"))
+		respondRobotContentInvalid(c, "content_edit")
 		return
 	}
 
 	robotID := c.Param("robot_id")
 	if robotID == "" {
-		c.ResponseError(errors.New("robot_id 不能为空"))
+		respondRobotRequestInvalid(c, "robot_id")
 		return
 	}
 
@@ -1721,15 +1717,15 @@ func (rb *Robot) botMessageEdit(c *wkhttp.Context) {
 	resp, err := rb.ctx.IMGetWithChannelAndSeqs(req.ChannelID, req.ChannelType, robotID, messageSeqs)
 	if err != nil {
 		rb.Error("查询消息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询消息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 		return
 	}
 	if resp == nil || len(resp.Messages) == 0 {
-		c.ResponseError(errors.New("消息不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotMessageNotFound, nil, nil)
 		return
 	}
 	if resp.Messages[0].FromUID != robotID {
-		c.ResponseError(errors.New("只能编辑自己发送的消息"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotMessageEditForbidden, nil, nil)
 		return
 	}
 
@@ -1740,7 +1736,7 @@ func (rb *Robot) botMessageEdit(c *wkhttp.Context) {
 	normalizedEdit, err := richtext.NormalizeContentEdit(req.ContentEdit)
 	if err != nil {
 		rb.Error("RichText content_edit 校验失败", zap.Error(err), zap.String("messageID", req.MessageID))
-		c.ResponseError(errors.New("无效的 content_edit"))
+		respondRobotContentInvalid(c, "content_edit")
 		return
 	}
 	req.ContentEdit = normalizedEdit
@@ -1753,7 +1749,7 @@ func (rb *Robot) botMessageEdit(c *wkhttp.Context) {
 	err = rb.ctx.DB().Select("count(*)").From("message_extra").Where("message_id=? and content_edit_hash=?", req.MessageID, contentMD5).LoadOne(&existCount)
 	if err != nil {
 		rb.Error("查询是否存在相同正文失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询是否存在相同正文失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 		return
 	}
 	if existCount > 0 {
@@ -1772,7 +1768,7 @@ func (rb *Robot) botMessageEdit(c *wkhttp.Context) {
 	version, err := rb.ctx.GenSeq(fmt.Sprintf("%s:%s", common.MessageExtraSeqKey, fakeChannelID))
 	if err != nil {
 		rb.Error("生成消息扩展序列号失败！", zap.Error(err))
-		c.ResponseError(errors.New("生成消息扩展序列号失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
 		return
 	}
 
@@ -1783,7 +1779,7 @@ func (rb *Robot) botMessageEdit(c *wkhttp.Context) {
 	).Exec()
 	if err != nil {
 		rb.Error("添加或修改编辑内容失败！", zap.Error(err))
-		c.ResponseError(errors.New("添加或修改编辑内容失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
 		return
 	}
 
@@ -1797,7 +1793,7 @@ func (rb *Robot) botMessageEdit(c *wkhttp.Context) {
 	})
 	if err != nil {
 		rb.Error("发送 CMD 同步失败！", zap.Error(err))
-		c.ResponseError(errors.New("发送同步命令失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotSendFailed, nil, nil)
 		return
 	}
 

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -348,6 +348,9 @@ func (rb *Robot) authRobot() wkhttp.HandlerFunc {
 			return
 		}
 		if robot == nil {
+			// Anti-enumeration: the wire collapses to one 401, but log the
+			// specific reason so operators retain visibility.
+			rb.Warn("robot 鉴权失败：机器人不存在", zap.String("robot_id", robotID))
 			respondRobotAuthFailed(c)
 			return
 		}
@@ -358,10 +361,12 @@ func (rb *Robot) authRobot() wkhttp.HandlerFunc {
 			return
 		}
 		if appM == nil {
+			rb.Warn("robot 鉴权失败：app 不存在", zap.String("robot_id", robotID), zap.String("appID", robot.AppID))
 			respondRobotAuthFailed(c)
 			return
 		}
 		if !hmac.Equal([]byte(appM.AppKey), []byte(appKey)) {
+			rb.Warn("robot 鉴权失败：appKey 不匹配", zap.String("robot_id", robotID), zap.String("appID", robot.AppID))
 			respondRobotAuthFailed(c)
 			return
 		}
@@ -1178,7 +1183,14 @@ func (rb *Robot) setDescription(c *wkhttp.Context) {
 	// 验证操作者是 Bot 创建者
 	var creatorUID string
 	err := rb.ctx.DB().Select("IFNULL(creator_uid,'')").From("robot").Where("robot_id=? AND status=1", robotID).LoadOne(&creatorUID)
-	if err != nil || creatorUID == "" {
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		// A real DB/scan error must not masquerade as 404 — log + 500 (mirrors
+		// assertRobotOwner in mention_pref.go).
+		rb.Error("查询 robot creator 失败", zap.Error(err), zap.String("robot_id", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
+		return
+	}
+	if creatorUID == "" {
 		httperr.ResponseErrorL(c, errcode.ErrRobotNotFound, nil, nil)
 		return
 	}
@@ -1212,7 +1224,14 @@ func (rb *Robot) setAutoApprove(c *wkhttp.Context) {
 	// 验证操作者是 Bot 创建者
 	var creatorUID string
 	err := rb.ctx.DB().Select("IFNULL(creator_uid,'')").From("robot").Where("robot_id=? AND status=1", robotID).LoadOne(&creatorUID)
-	if err != nil || creatorUID == "" {
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		// A real DB/scan error must not masquerade as 404 — log + 500 (mirrors
+		// assertRobotOwner in mention_pref.go).
+		rb.Error("查询 robot creator 失败", zap.Error(err), zap.String("robot_id", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
+		return
+	}
+	if creatorUID == "" {
 		httperr.ResponseErrorL(c, errcode.ErrRobotNotFound, nil, nil)
 		return
 	}
@@ -1464,8 +1483,11 @@ func (rb *Robot) botUploadFile(c *wkhttp.Context) {
 
 	multipartFile, fileHeader, err := c.Request.FormFile("file")
 	if err != nil {
-		rb.Error("读取上传文件失败", zap.Error(err))
-		httperr.ResponseErrorL(c, errcode.ErrRobotUploadFailed, nil, nil)
+		// A missing / malformed multipart "file" part is a client error, not an
+		// upload-backend failure — surface it as request-invalid (400) with a
+		// field detail rather than the Internal=true upload code.
+		rb.Warn("读取上传文件失败", zap.Error(err))
+		respondRobotRequestInvalid(c, "file")
 		return
 	}
 	defer multipartFile.Close()

--- a/modules/robot/api_i18n.go
+++ b/modules/robot/api_i18n.go
@@ -1,0 +1,86 @@
+package robot
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+// respond helpers for modules/robot. Most migrated sites call
+// httperr.ResponseErrorL(c, errcode.ErrRobotXxx, nil, nil) directly; the helpers
+// below exist only for the shapes that carry a Detail field (so the
+// SafeDetailKeys contract stays in one place) and for the robot-webhook auth
+// middleware, which must preserve its real wire status.
+//
+// Internal=true codes (ErrRobotQueryFailed / ErrRobotStoreFailed /
+// ErrRobotSendFailed / ErrRobotUploadFailed / ErrRobotTokenGenFailed /
+// ErrRobotAuthCheckFailed) are intentionally NOT wrapped here: each call site
+// keeps its existing rb.Error(..., zap.Error(err)) log so ops can debug from
+// logs, and the renderer carries no message on the wire.
+
+// respondRobotRequestInvalid covers the common BindJSON-failure / "X 不能为空"
+// shape — one code, one optional field detail. An empty field is omitted so the
+// renderer does not surface a noisy empty key to clients.
+func respondRobotRequestInvalid(c *wkhttp.Context, field string) {
+	details := i18n.Details{}
+	if field != "" {
+		details["field"] = field
+	}
+	httperr.ResponseErrorL(c, errcode.ErrRobotRequestInvalid, nil, details)
+}
+
+// respondRobotContentInvalid covers an invalid message payload / content_edit.
+// The offending field name is surfaced; the raw payload never is.
+func respondRobotContentInvalid(c *wkhttp.Context, field string) {
+	details := i18n.Details{}
+	if field != "" {
+		details["field"] = field
+	}
+	httperr.ResponseErrorL(c, errcode.ErrRobotContentInvalid, nil, details)
+}
+
+// respondRobotContentTypeUnsupported surfaces the rejected message content type.
+func respondRobotContentTypeUnsupported(c *wkhttp.Context, contentType int) {
+	httperr.ResponseErrorL(c, errcode.ErrRobotContentTypeUnsupported, nil, i18n.Details{
+		"type": contentType,
+	})
+}
+
+// respondRobotFileTooLarge surfaces the upload size cap (in MB) so the client can
+// render a localized hint without hard-coding the limit.
+func respondRobotFileTooLarge(c *wkhttp.Context, maxMB int64) {
+	httperr.ResponseErrorL(c, errcode.ErrRobotFileTooLarge, nil, i18n.Details{
+		"max_mb": maxMB,
+	})
+}
+
+// respondRobotAuthFailed renders the single anti-enumeration 401 for the robot
+// webhook auth middleware, preserving the real 401 wire status (external bot
+// adapters branch on HTTP 401, not the D14 fixed-400), then aborts the gin chain
+// so the protected handler never runs.
+func respondRobotAuthFailed(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrRobotAuthFailed, nil, nil)
+	c.Abort()
+}
+
+// respondRobotAuthCheckFailed renders the auth-middleware infrastructure failure
+// (our DB lookup errored), preserving the real 500 so adapters retry, then aborts
+// the chain. Internal=true → the underlying cause must be logged at the call site.
+func respondRobotAuthCheckFailed(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrRobotAuthCheckFailed, nil, nil)
+	c.Abort()
+}
+
+// respondRobotInlineQueryTimeout renders the inline-query long-poll timeout,
+// preserving the real 408 so the front-end's retry logic still sees a timeout.
+func respondRobotInlineQueryTimeout(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrRobotInlineQueryTimeout, nil, nil)
+}
+
+// respondManagerForbidden maps the CheckLoginRole* role-guard failures in
+// api_manager.go to the shared 403 forbidden code (the octo-lib guard returns a
+// raw zh-CN error that must not reach the wire).
+func respondManagerForbidden(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errcode.ErrSharedForbidden, nil, nil)
+}

--- a/modules/robot/api_i18n_test.go
+++ b/modules/robot/api_i18n_test.go
@@ -1,0 +1,341 @@
+package robot
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// httperrL is a terse test shim for the no-params/no-details ResponseErrorL
+// call shape exercised by the direct-code cases below.
+func httperrL(c *wkhttp.Context, code codes.Code) {
+	httperr.ResponseErrorL(c, code, nil, nil)
+}
+
+// TestRobotNoLegacyResponseError pins the Phase 2.1 contract that the migrated
+// modules/robot handlers do not regress to legacy octo-lib error responses.
+// Comments are stripped first so commented-out breadcrumbs do not trip the
+// guard. The rb.Error(...)/m.Error(...) zap LOG calls are not responses and are
+// intentionally allowed (they match none of the banned tokens). AbortWithStatus*
+// is banned too: the robot-webhook auth middleware now renders via the i18n
+// envelope (respondRobotAuth* helpers) and the inline-query timeout via
+// respondRobotInlineQueryTimeout, so no raw gin abort should remain.
+func TestRobotNoLegacyResponseError(t *testing.T) {
+	files := []string{"api.go", "api_manager.go", "mention_pref.go"}
+	banned := []string{
+		".ResponseError(",
+		".ResponseErrorf(",
+		".ResponseErrorWithStatus(",
+		".AbortWithStatusJSON(",
+		".AbortWithStatus(",
+		"c.Response(\"",
+	}
+	for _, f := range files {
+		t.Run(f, func(t *testing.T) {
+			data, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+			var clean strings.Builder
+			for _, line := range strings.Split(string(data), "\n") {
+				if idx := strings.Index(line, "//"); idx >= 0 {
+					line = line[:idx]
+				}
+				clean.WriteString(line)
+				clean.WriteByte('\n')
+			}
+			cleaned := clean.String()
+			for _, b := range banned {
+				if strings.Contains(cleaned, b) {
+					t.Fatalf("modules/robot/%s must use httperr.ResponseErrorL via respondRobot* helpers / errcode.ErrRobot* instead of legacy %s", f, b)
+				}
+			}
+		})
+	}
+}
+
+// errEnvelope is the partial shape of an httperr.ResponseErrorL response. The
+// renderer emits both the legacy {msg,status} and the v2 {error.{...}} blocks
+// unconditionally (v7.2 dual-envelope contract).
+type errEnvelope struct {
+	Error struct {
+		Code       string         `json:"code"`
+		Message    string         `json:"message"`
+		Details    map[string]any `json:"details"`
+		HTTPStatus int            `json:"http_status"`
+	} `json:"error"`
+	Msg    string `json:"msg"`
+	Status int    `json:"status"`
+}
+
+func decodeRobotEnvelope(t *testing.T, body []byte) errEnvelope {
+	t.Helper()
+	var env errEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("decode envelope: %v\nbody: %s", err, body)
+	}
+	return env
+}
+
+// helperHarness mounts a single GET /probe route that invokes the supplied
+// helper with the i18n renderer wired, so tests can assert the rendered envelope
+// without paying the DB / auth setup cost.
+func helperHarness(probe func(c *wkhttp.Context)) *wkhttp.WKHttp {
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	r.GET("/probe", probe)
+	return r
+}
+
+func TestRespondRobotHelpers(t *testing.T) {
+	cases := []struct {
+		name            string
+		probe           func(c *wkhttp.Context)
+		wantCodeID      string
+		wantSemStatus   int
+		wantTransStatus int    // 400 for D14 ResponseErrorL; real status for ResponseErrorLWithStatus
+		wantContains    string // zh-CN substring expected in error.message
+		wantNotContains string // forbid leaked English DefaultMessage when Internal=true
+		wantDetails     map[string]any
+	}{
+		// ---- validation helpers (400, D14) -----------------------------------
+		{
+			name:            "respondRobotRequestInvalid carries the field detail",
+			probe:           func(c *wkhttp.Context) { respondRobotRequestInvalid(c, "channel_id") },
+			wantCodeID:      "err.server.robot.request_invalid",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "请求参数有误",
+			wantDetails:     map[string]any{"field": "channel_id"},
+		},
+		{
+			name:            "respondRobotRequestInvalid drops empty field key",
+			probe:           func(c *wkhttp.Context) { respondRobotRequestInvalid(c, "") },
+			wantCodeID:      "err.server.robot.request_invalid",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "请求参数有误",
+			wantDetails:     map[string]any{},
+		},
+		{
+			name:            "respondRobotContentInvalid carries the field detail",
+			probe:           func(c *wkhttp.Context) { respondRobotContentInvalid(c, "payload") },
+			wantCodeID:      "err.server.robot.content_invalid",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "消息内容无效",
+			wantDetails:     map[string]any{"field": "payload"},
+		},
+		{
+			name:            "respondRobotContentTypeUnsupported surfaces the rejected type",
+			probe:           func(c *wkhttp.Context) { respondRobotContentTypeUnsupported(c, 99) },
+			wantCodeID:      "err.server.robot.content_type_unsupported",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "不支持的消息类型",
+			wantDetails:     map[string]any{"type": float64(99)},
+		},
+		{
+			name:            "respondRobotFileTooLarge surfaces the size cap",
+			probe:           func(c *wkhttp.Context) { respondRobotFileTooLarge(c, 100) },
+			wantCodeID:      "err.server.robot.file_too_large",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "文件大小超过限制",
+			wantDetails:     map[string]any{"max_mb": float64(100)},
+		},
+		// ---- direct codes: 400 / 403 / 404 (D14) -----------------------------
+		{
+			name:            "ErrRobotFileTypeUnsupported surfaces 400 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrRobotFileTypeUnsupported) },
+			wantCodeID:      "err.server.robot.file_type_unsupported",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "不支持的文件类型",
+		},
+		{
+			name:            "ErrRobotNoFieldsToUpdate surfaces 400 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrRobotNoFieldsToUpdate) },
+			wantCodeID:      "err.server.robot.no_fields_to_update",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "没有需要更新的字段",
+		},
+		{
+			name:            "ErrRobotCreatorOnly surfaces 403 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrRobotCreatorOnly) },
+			wantCodeID:      "err.server.robot.creator_only",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "仅机器人创建者",
+		},
+		{
+			name:            "ErrRobotMessageEditForbidden surfaces 403 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrRobotMessageEditForbidden) },
+			wantCodeID:      "err.server.robot.message_edit_forbidden",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "只能编辑自己发送的消息",
+		},
+		{
+			name:            "ErrRobotChannelSendForbidden surfaces 403 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrRobotChannelSendForbidden) },
+			wantCodeID:      "err.server.robot.channel_send_forbidden",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "不允许向该频道发送消息",
+		},
+		{
+			name:            "respondManagerForbidden collapses to shared 403",
+			probe:           respondManagerForbidden,
+			wantCodeID:      "err.shared.auth.forbidden",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "无权执行此操作",
+		},
+		{
+			name:            "ErrRobotNotFound surfaces 404 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrRobotNotFound) },
+			wantCodeID:      "err.server.robot.not_found",
+			wantSemStatus:   http.StatusNotFound,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "机器人不存在",
+		},
+		{
+			name:            "ErrRobotMessageNotFound surfaces 404 zh-CN copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrRobotMessageNotFound) },
+			wantCodeID:      "err.server.robot.message_not_found",
+			wantSemStatus:   http.StatusNotFound,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "消息不存在",
+		},
+		// ---- internal codes (500, Internal=true) collapse + no English leak ---
+		{
+			name:            "ErrRobotQueryFailed collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrRobotQueryFailed) },
+			wantCodeID:      "err.server.robot.query_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "query robot data",
+		},
+		{
+			name:            "ErrRobotStoreFailed collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrRobotStoreFailed) },
+			wantCodeID:      "err.server.robot.store_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "update robot data",
+		},
+		{
+			name:            "ErrRobotSendFailed collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrRobotSendFailed) },
+			wantCodeID:      "err.server.robot.send_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "send the message",
+		},
+		{
+			name:            "ErrRobotUploadFailed collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrRobotUploadFailed) },
+			wantCodeID:      "err.server.robot.upload_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "process the file",
+		},
+		{
+			name:            "ErrRobotTokenGenFailed collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrRobotTokenGenFailed) },
+			wantCodeID:      "err.server.robot.token_gen_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "robot token",
+		},
+		// ---- ResponseErrorLWithStatus: real wire status preserved -------------
+		{
+			name:            "respondRobotAuthFailed preserves 401 (external adapters)",
+			probe:           respondRobotAuthFailed,
+			wantCodeID:      "err.server.robot.auth_failed",
+			wantSemStatus:   http.StatusUnauthorized,
+			wantTransStatus: http.StatusUnauthorized,
+			wantContains:    "机器人鉴权失败",
+		},
+		{
+			name:            "respondRobotAuthCheckFailed preserves 500 + hides internal copy",
+			probe:           respondRobotAuthCheckFailed,
+			wantCodeID:      "err.server.robot.auth_check_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusInternalServerError,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "authentication check",
+		},
+		{
+			name:            "respondRobotInlineQueryTimeout preserves 408",
+			probe:           respondRobotInlineQueryTimeout,
+			wantCodeID:      "err.server.robot.inline_query_timeout",
+			wantSemStatus:   http.StatusRequestTimeout,
+			wantTransStatus: http.StatusRequestTimeout,
+			wantContains:    "行内查询超时",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := helperHarness(tc.probe)
+			req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+			req.Header.Set("Accept-Language", "zh-CN")
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantTransStatus {
+				t.Fatalf("HTTP status = %d, want %d; body=%s", rec.Code, tc.wantTransStatus, rec.Body.String())
+			}
+			env := decodeRobotEnvelope(t, rec.Body.Bytes())
+			if env.Error.Code != tc.wantCodeID {
+				t.Fatalf("error.code = %q, want %q", env.Error.Code, tc.wantCodeID)
+			}
+			if env.Error.HTTPStatus != tc.wantSemStatus {
+				t.Fatalf("error.http_status = %d, want %d", env.Error.HTTPStatus, tc.wantSemStatus)
+			}
+			if env.Status != tc.wantTransStatus {
+				t.Fatalf("legacy status = %d, want %d", env.Status, tc.wantTransStatus)
+			}
+			if env.Msg != env.Error.Message {
+				t.Fatalf("legacy msg %q != error.message %q (dual envelope must agree)", env.Msg, env.Error.Message)
+			}
+			if !strings.Contains(env.Error.Message, tc.wantContains) {
+				t.Fatalf("error.message = %q, want substring %q", env.Error.Message, tc.wantContains)
+			}
+			if tc.wantNotContains != "" && strings.Contains(env.Error.Message, tc.wantNotContains) {
+				t.Fatalf("error.message = %q must not contain %q (Internal leak)", env.Error.Message, tc.wantNotContains)
+			}
+			if tc.wantDetails != nil {
+				got := env.Error.Details
+				if got == nil {
+					got = map[string]any{}
+				}
+				if len(got) != len(tc.wantDetails) {
+					t.Fatalf("error.details = %#v, want %#v", got, tc.wantDetails)
+				}
+				for k, v := range tc.wantDetails {
+					if got[k] != v {
+						t.Fatalf("error.details[%q] = %#v, want %#v", k, got[k], v)
+					}
+				}
+			}
+		})
+	}
+}

--- a/modules/robot/api_manager.go
+++ b/modules/robot/api_manager.go
@@ -5,15 +5,16 @@ import (
 	"os"
 	"runtime/debug"
 	"encoding/hex"
-	"errors"
 	"fmt"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
-	pkgutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	pkgutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
 	"go.uber.org/zap"
 )
 
@@ -51,17 +52,18 @@ func (m *Manager) Route(r *wkhttp.WKHttp) {
 func (m *Manager) list(c *wkhttp.Context) {
 	err := c.CheckLoginRole()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 	robotID := c.Query("robot_id")
 	if robotID == "" {
-		c.ResponseError(errors.New("机器人ID不能为空"))
+		respondRobotRequestInvalid(c, "robot_id")
 		return
 	}
 	list, err := m.db.queryMenusWithRobotID(robotID)
 	if err != nil {
-		c.ResponseError(errors.New("查询机器人菜单错误"))
+		m.Error("查询机器人菜单失败", zap.Error(err), zap.String("robot_id", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 		return
 	}
 	resps := make([]*robotMenu, 0)
@@ -87,28 +89,29 @@ func (m *Manager) list(c *wkhttp.Context) {
 func (m *Manager) delete(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 	robot_id := c.Param("robot_id")
 	id := pkgutil.ParseInt64OrDefault(c.Param("id"), 0)
 	if robot_id == "" {
-		c.ResponseError(errors.New("机器人ID不能为空"))
+		respondRobotRequestInvalid(c, "robot_id")
 		return
 	}
 	robot, err := m.db.queryRobotWithRobtID(robot_id)
 	if err != nil {
-		c.ResponseError(errors.New("查询操作的机器人错误"))
+		m.Error("查询操作的机器人失败", zap.Error(err), zap.String("robot_id", robot_id))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 		return
 	}
 	if robot == nil {
-		c.ResponseError(errors.New("操作的机器人不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotNotFound, nil, nil)
 		return
 	}
 	tx, err := m.db.session.Begin()
 	if err != nil {
 		m.Error("数据库事物开启失败", zap.Error(err))
-		c.ResponseError(errors.New("数据库事物开启失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
 		return
 	}
 	defer func() {
@@ -121,12 +124,13 @@ func (m *Manager) delete(c *wkhttp.Context) {
 	if err != nil {
 		tx.Rollback()
 		m.Error("删除机器人菜单失败", zap.Error(err))
-		c.ResponseError(errors.New("删除机器人菜单失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
 		return
 	}
 	genSeqVal, err := m.ctx.GenSeq(common.RobotSeqKey)
 	if err != nil {
-		c.ResponseError(err)
+		m.Error("生成机器人版本号失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
 		return
 	}
 	robot.Version = genSeqVal
@@ -134,14 +138,14 @@ func (m *Manager) delete(c *wkhttp.Context) {
 	if err != nil {
 		tx.Rollback()
 		m.Error("修改机器人版本号错误", zap.Error(err))
-		c.ResponseError(errors.New("修改机器人版本号错误"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
 		return
 	}
 	err = tx.Commit()
 	if err != nil {
 		tx.RollbackUnlessCommitted()
 		m.Error("数据库事物提交失败", zap.Error(err))
-		c.ResponseError(errors.New("数据库事物提交失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -151,29 +155,31 @@ func (m *Manager) delete(c *wkhttp.Context) {
 func (m *Manager) updateRobotStatus(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 	robot_id := c.Param("robot_id")
 	status := pkgutil.ParseInt64OrDefault(c.Param("status"), 0)
 
 	if robot_id == "" {
-		c.ResponseError(errors.New("机器人ID不能为空"))
+		respondRobotRequestInvalid(c, "robot_id")
 		return
 	}
 	robot, err := m.db.queryRobotWithRobtID(robot_id)
 	if err != nil {
-		c.ResponseError(errors.New("查询操作的机器人错误"))
+		m.Error("查询操作的机器人失败", zap.Error(err), zap.String("robot_id", robot_id))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 		return
 	}
 	if robot == nil {
-		c.ResponseError(errors.New("操作的机器人不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotNotFound, nil, nil)
 		return
 	}
 	robot.Status = int(status)
 	err = m.db.updateRobot(robot)
 	if err != nil {
-		c.ResponseError(errors.New("修改机器人状态信息错误"))
+		m.Error("修改机器人状态信息失败", zap.Error(err), zap.String("robot_id", robot_id))
+		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -195,7 +201,7 @@ type robotMenu struct {
 func (m *Manager) robotList(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 	pageIndex := pkgutil.AtoiOrDefault(c.Query("page_index"), 1)
@@ -210,13 +216,13 @@ func (m *Manager) robotList(c *wkhttp.Context) {
 	list, err := m.db.queryRobotListPaged(pageIndex, pageSize)
 	if err != nil {
 		m.Error("查询机器人列表失败", zap.Error(err))
-		c.ResponseError(errors.New("查询机器人列表失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 		return
 	}
 	count, err := m.db.queryRobotTotalCount()
 	if err != nil {
 		m.Error("查询机器人总数失败", zap.Error(err))
-		c.ResponseError(errors.New("查询机器人总数失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 		return
 	}
 
@@ -242,22 +248,22 @@ func (m *Manager) robotList(c *wkhttp.Context) {
 func (m *Manager) robotDetail(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 	robotID := c.Param("robot_id")
 	if robotID == "" {
-		c.ResponseError(errors.New("机器人ID不能为空"))
+		respondRobotRequestInvalid(c, "robot_id")
 		return
 	}
 	r, err := m.db.queryRobotWithRobtID(robotID)
 	if err != nil {
 		m.Error("查询机器人详情失败", zap.Error(err))
-		c.ResponseError(errors.New("查询机器人详情失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 		return
 	}
 	if r == nil {
-		c.ResponseError(errors.New("机器人不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotNotFound, nil, nil)
 		return
 	}
 	c.Response(&robotDetailResp{
@@ -277,18 +283,18 @@ func (m *Manager) robotDetail(c *wkhttp.Context) {
 func (m *Manager) robotUpdate(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 	robotID := c.Param("robot_id")
 	if robotID == "" {
-		c.ResponseError(errors.New("机器人ID不能为空"))
+		respondRobotRequestInvalid(c, "robot_id")
 		return
 	}
 
 	var req robotUpdateReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("数据格式有误"))
+		respondRobotRequestInvalid(c, "")
 		return
 	}
 
@@ -301,14 +307,14 @@ func (m *Manager) robotUpdate(c *wkhttp.Context) {
 	}
 
 	if len(fields) == 0 {
-		c.ResponseError(errors.New("没有需要更新的字段"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotNoFieldsToUpdate, nil, nil)
 		return
 	}
 
 	err = m.db.updateRobotInfo(robotID, fields)
 	if err != nil {
 		m.Error("更新机器人信息失败", zap.Error(err))
-		c.ResponseError(errors.New("更新机器人信息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -318,26 +324,26 @@ func (m *Manager) robotUpdate(c *wkhttp.Context) {
 func (m *Manager) robotDelete(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 	robotID := c.Param("robot_id")
 	if robotID == "" {
-		c.ResponseError(errors.New("机器人ID不能为空"))
+		respondRobotRequestInvalid(c, "robot_id")
 		return
 	}
 
 	// 先清理 IM 连接和缓存，再做软删除
 	if err := m.cleanupBotConnection(robotID); err != nil {
 		m.Error("清理机器人连接失败", zap.Error(err))
-		c.ResponseError(errors.New("清理机器人连接失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
 		return
 	}
 
 	err = m.db.deleteRobotSoft(robotID)
 	if err != nil {
 		m.Error("删除机器人失败", zap.Error(err))
-		c.ResponseError(errors.New("删除机器人失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -375,25 +381,25 @@ func (m *Manager) cleanupBotConnection(robotID string) error {
 func (m *Manager) robotRevokeToken(c *wkhttp.Context) {
 	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
-		c.ResponseError(err)
+		respondManagerForbidden(c)
 		return
 	}
 	robotID := c.Param("robot_id")
 	if robotID == "" {
-		c.ResponseError(errors.New("机器人ID不能为空"))
+		respondRobotRequestInvalid(c, "robot_id")
 		return
 	}
 
 	newToken, err := m.generateUniqueBotToken()
 	if err != nil {
 		m.Error("生成Token失败", zap.Error(err))
-		c.ResponseError(errors.New("生成Token失败，请重试"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotTokenGenFailed, nil, nil)
 		return
 	}
 	err = m.db.updateRobotBotToken(robotID, newToken)
 	if err != nil {
 		m.Error("重置Token失败", zap.Error(err))
-		c.ResponseError(errors.New("重置Token失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
 		return
 	}
 

--- a/modules/robot/api_manager.go
+++ b/modules/robot/api_manager.go
@@ -2,10 +2,10 @@ package robot
 
 import (
 	"crypto/rand"
-	"os"
-	"runtime/debug"
 	"encoding/hex"
 	"fmt"
+	"os"
+	"runtime/debug"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -41,9 +41,9 @@ func (m *Manager) Route(r *wkhttp.WKHttp) {
 		auth.PUT("/robot/status/:robot_id/:status", m.updateRobotStatus) // 修改机器人状态
 
 		auth.GET("/robots", m.robotList)                                // 机器人列表（分页）
-		auth.GET("/robots/:robot_id", m.robotDetail)                   // 机器人详情
-		auth.PUT("/robots/:robot_id", m.robotUpdate)                   // 编辑机器人
-		auth.DELETE("/robots/:robot_id", m.robotDelete)                // 删除机器人
+		auth.GET("/robots/:robot_id", m.robotDetail)                    // 机器人详情
+		auth.PUT("/robots/:robot_id", m.robotUpdate)                    // 编辑机器人
+		auth.DELETE("/robots/:robot_id", m.robotDelete)                 // 删除机器人
 		auth.POST("/robots/:robot_id/revoke_token", m.robotRevokeToken) // 重置Token
 	}
 }

--- a/modules/robot/mention_pref.go
+++ b/modules/robot/mention_pref.go
@@ -107,10 +107,14 @@ func (rb *Robot) assertRobotOwner(c *wkhttp.Context, robotID, loginUID string) b
 	// ErrNotFound → creatorUID 仍为 ""，decideOwnership 归类为 404。
 	switch decideOwnership(creatorUID, loginUID) {
 	case ownershipNotFound:
-		httperr.ResponseErrorL(c, errcode.ErrRobotNotFound, nil, nil)
+		// Preserve the prior real 404 (these owner endpoints are dmwork-facing
+		// and predate this PR returning ResponseErrorWithStatus(404)); D14
+		// fixed-400 would drift the wire status for existing clients.
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrRobotNotFound, nil, nil)
 		return true
 	case ownershipForbidden:
-		httperr.ResponseErrorL(c, errcode.ErrRobotCreatorOnly, nil, nil)
+		// Preserve the prior real 403 (was ResponseErrorWithStatus(403)).
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrRobotCreatorOnly, nil, nil)
 		return true
 	default:
 		return false

--- a/modules/robot/mention_pref.go
+++ b/modules/robot/mention_pref.go
@@ -11,6 +11,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/gocraft/dbr/v2"
 	"go.uber.org/zap"
 )
@@ -99,16 +101,16 @@ func (rb *Robot) assertRobotOwner(c *wkhttp.Context, robotID, loginUID string) b
 	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
 		// 真实 DB/扫描错误不能伪装成 404，否则会掩盖故障。
 		rb.Error("查询 robot creator 失败", zap.Error(err), zap.String("robot_id", robotID))
-		c.ResponseError(errors.New("查询失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 		return true
 	}
 	// ErrNotFound → creatorUID 仍为 ""，decideOwnership 归类为 404。
 	switch decideOwnership(creatorUID, loginUID) {
 	case ownershipNotFound:
-		c.ResponseErrorWithStatus(errors.New("机器人不存在"), http.StatusNotFound)
+		httperr.ResponseErrorL(c, errcode.ErrRobotNotFound, nil, nil)
 		return true
 	case ownershipForbidden:
-		c.ResponseErrorWithStatus(errors.New("只有创建者可以操作"), http.StatusForbidden)
+		httperr.ResponseErrorL(c, errcode.ErrRobotCreatorOnly, nil, nil)
 		return true
 	default:
 		return false
@@ -126,11 +128,11 @@ func (rb *Robot) setMentionPref(c *wkhttp.Context) {
 		NoMention int `json:"no_mention"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("参数错误"))
+		respondRobotRequestInvalid(c, "")
 		return
 	}
 	if req.NoMention != 0 && req.NoMention != 1 {
-		c.ResponseError(errors.New("no_mention 只能为 0 或 1"))
+		respondRobotRequestInvalid(c, "no_mention")
 		return
 	}
 
@@ -149,7 +151,7 @@ func (rb *Robot) setMentionPref(c *wkhttp.Context) {
 	if err != nil {
 		rb.Error("写入 bot_mention_pref 失败", zap.Error(err),
 			zap.String("robot_id", robotID), zap.String("group_no", groupNo))
-		c.ResponseError(errors.New("更新失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
 		return
 	}
 	// 写库成功后即时通知对应 bot 失效缓存（best-effort，异步不阻塞主流程；
@@ -181,7 +183,7 @@ func (rb *Robot) deleteMentionPref(c *wkhttp.Context) {
 	if err != nil {
 		rb.Error("删除 bot_mention_pref 失败", zap.Error(err),
 			zap.String("robot_id", robotID), zap.String("group_no", groupNo))
-		c.ResponseError(errors.New("删除失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
 		return
 	}
 	// 删除回退账号级默认即 no_mention=0；同样推事件让 adapter 即时失效缓存
@@ -270,7 +272,7 @@ func (rb *Robot) getMentionPref(c *wkhttp.Context) {
 		// dbr 在无记录时返回 ErrNotFound；其它错误才算真失败。
 		rb.Error("查询 bot_mention_pref 失败", zap.Error(err),
 			zap.String("robot_id", robotID), zap.String("group_no", groupNo))
-		c.ResponseError(errors.New("查询失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 		return
 	}
 
@@ -283,7 +285,7 @@ func (rb *Robot) getMentionPref(c *wkhttp.Context) {
 		} else {
 			rb.Error("查询 group.allow_no_mention 失败", zap.Error(err),
 				zap.String("robot_id", robotID), zap.String("group_no", groupNo))
-			c.ResponseError(errors.New("查询失败"))
+			httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 			return
 		}
 	}
@@ -351,7 +353,7 @@ func (rb *Robot) listGroups(c *wkhttp.Context) {
 	_, err := rb.ctx.DB().SelectBySql(sql, args...).Load(&rows)
 	if err != nil {
 		rb.Error("列群查询失败", zap.Error(err), zap.String("robot_id", robotID))
-		c.ResponseError(errors.New("查询群组失败"))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 		return
 	}
 

--- a/pkg/errcode/robot.go
+++ b/pkg/errcode/robot.go
@@ -1,0 +1,190 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// err.server.robot.* — modules/robot business error codes (api.go /
+// api_manager.go / mention_pref.go). DefaultMessage holds the en-US source
+// (D4); the zh-CN runtime translation lives in pkg/i18n/locales/active.zh-CN.toml.
+// Internal=true codes never surface their message on the wire — callers MUST log
+// the underlying err with full context (zap.Error) before responding.
+var (
+	// ---- validation (400) ----------------------------------------------------
+
+	// ErrRobotRequestInvalid is the catch-all for missing/malformed request
+	// input (BindJSON failure, "X 不能为空", invalid params). The offending
+	// field is surfaced via Details when the caller can identify it.
+	ErrRobotRequestInvalid = register(codes.Code{
+		ID:             "err.server.robot.request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid request.",
+		SafeDetailKeys: []string{"field"},
+	})
+	// ErrRobotContentInvalid covers an invalid message payload / content_edit
+	// (empty payload, missing payload.type, payload that fails the content-type
+	// contract, or content_edit that fails RichText normalization). The raw
+	// payload is intentionally NOT surfaced (it can be large / sensitive); only
+	// the offending field name is exposed.
+	ErrRobotContentInvalid = register(codes.Code{
+		ID:             "err.server.robot.content_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid message content.",
+		SafeDetailKeys: []string{"field"},
+	})
+	// ErrRobotContentTypeUnsupported covers an unsupported message content type.
+	ErrRobotContentTypeUnsupported = register(codes.Code{
+		ID:             "err.server.robot.content_type_unsupported",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Unsupported message type.",
+		SafeDetailKeys: []string{"type"},
+	})
+	// ErrRobotFileTypeUnsupported covers an unsupported / extension-less upload.
+	ErrRobotFileTypeUnsupported = register(codes.Code{
+		ID:             "err.server.robot.file_type_unsupported",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Unsupported file type.",
+	})
+	// ErrRobotFileTooLarge surfaces the upload size cap so the client can render
+	// a localized hint without hard-coding the limit.
+	ErrRobotFileTooLarge = register(codes.Code{
+		ID:             "err.server.robot.file_too_large",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The file exceeds the maximum allowed size.",
+		SafeDetailKeys: []string{"max_mb"},
+	})
+	// ErrRobotNoFieldsToUpdate covers an update request with no mutable fields.
+	ErrRobotNoFieldsToUpdate = register(codes.Code{
+		ID:             "err.server.robot.no_fields_to_update",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "No fields to update.",
+	})
+
+	// ---- permission / authorization (403) ------------------------------------
+
+	// ErrRobotCreatorOnly covers the creator-ownership guards on the owner-facing
+	// endpoints (set description / auto-approve / mention preference) — all the
+	// same "only the bot creator may operate" condition.
+	ErrRobotCreatorOnly = register(codes.Code{
+		ID:             "err.server.robot.creator_only",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Only the bot creator can perform this operation.",
+	})
+	// ErrRobotMessageEditForbidden covers the bot-message edit guard (a bot may
+	// only edit messages it sent).
+	ErrRobotMessageEditForbidden = register(codes.Code{
+		ID:             "err.server.robot.message_edit_forbidden",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You can only edit messages you sent.",
+	})
+	// ErrRobotChannelSendForbidden covers the channel-membership send guard.
+	ErrRobotChannelSendForbidden = register(codes.Code{
+		ID:             "err.server.robot.channel_send_forbidden",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Sending messages to this channel is not allowed.",
+	})
+
+	// ---- not found (404) -----------------------------------------------------
+
+	// ErrRobotNotFound covers a missing / disabled / not-fully-provisioned robot
+	// (no creator_uid, no app_id). No enumeration: the specific reason goes to
+	// the log, the client sees one generic "not found".
+	ErrRobotNotFound = register(codes.Code{
+		ID:             "err.server.robot.not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Robot not found.",
+	})
+	// ErrRobotMessageNotFound covers a missing target message on edit.
+	ErrRobotMessageNotFound = register(codes.Code{
+		ID:             "err.server.robot.message_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Message not found.",
+	})
+
+	// ---- robot-webhook auth (401, anti-enumeration) --------------------------
+
+	// ErrRobotAuthFailed is the SINGLE anti-enumeration code for the robot
+	// webhook auth middleware (authRobot): robot not found, app not found, and
+	// app_key mismatch ALL collapse to one 401 so an external caller cannot probe
+	// which factor was wrong. The specific reason is logged, never returned.
+	//
+	// This middleware serves external bot adapters (app_key auth), not the dmwork
+	// front-end, so it is rendered via ResponseErrorLWithStatus to PRESERVE the
+	// real 401 wire status rather than the D14 compatibility 400 — adapters branch
+	// on HTTP 401. (Divergence from D14 flagged for maintainer sign-off.)
+	ErrRobotAuthFailed = register(codes.Code{
+		ID:             "err.server.robot.auth_failed",
+		HTTPStatus:     http.StatusUnauthorized,
+		DefaultMessage: "Robot authentication failed.",
+	})
+
+	// ---- inline-query long-poll timeout (408) --------------------------------
+
+	// ErrRobotInlineQueryTimeout covers the inline-query long-poll giving up after
+	// the adapter fails to answer in time. Rendered via ResponseErrorLWithStatus
+	// to preserve the 408 so the front-end's retry logic still sees a timeout.
+	ErrRobotInlineQueryTimeout = register(codes.Code{
+		ID:             "err.server.robot.inline_query_timeout",
+		HTTPStatus:     http.StatusRequestTimeout,
+		DefaultMessage: "The inline query timed out.",
+	})
+
+	// ---- internal (500, Internal=true) ---------------------------------------
+
+	// ErrRobotQueryFailed covers read-path failures (robot / menu / command /
+	// message-extra SELECTs, corrupt stored command JSON). Log the underlying err
+	// before responding.
+	ErrRobotQueryFailed = register(codes.Code{
+		ID:             "err.server.robot.query_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to query robot data.",
+		Internal:       true,
+	})
+	// ErrRobotStoreFailed covers mutation-path failures (DB write/update/delete,
+	// transaction begin/commit/rollback, sequence generation, IM connection
+	// cleanup). Log the underlying err before responding.
+	ErrRobotStoreFailed = register(codes.Code{
+		ID:             "err.server.robot.store_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to update robot data.",
+		Internal:       true,
+	})
+	// ErrRobotSendFailed covers WuKongIM dispatch failures (send message / typing
+	// / stream start-end / CMD sync). Log the underlying err before responding.
+	ErrRobotSendFailed = register(codes.Code{
+		ID:             "err.server.robot.send_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to send the message.",
+		Internal:       true,
+	})
+	// ErrRobotUploadFailed covers the file proxy / upload / STS-credential /
+	// presigned-URL path (read, storage write, COS misconfiguration). Log the
+	// underlying err before responding.
+	ErrRobotUploadFailed = register(codes.Code{
+		ID:             "err.server.robot.upload_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to process the file.",
+		Internal:       true,
+	})
+	// ErrRobotTokenGenFailed covers bot-token (re)generation failures. Log the
+	// underlying err before responding.
+	ErrRobotTokenGenFailed = register(codes.Code{
+		ID:             "err.server.robot.token_gen_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to generate the robot token.",
+		Internal:       true,
+	})
+	// ErrRobotAuthCheckFailed covers the robot webhook auth middleware's own
+	// infrastructure failures (DB query for robot / app errored) — distinct from
+	// ErrRobotAuthFailed (a real credential failure). Preserves the real 500 via
+	// ResponseErrorLWithStatus so adapters retry instead of treating it as a
+	// permanent 401. Log the underlying err before responding.
+	ErrRobotAuthCheckFailed = register(codes.Code{
+		ID:             "err.server.robot.auth_check_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Robot authentication check failed.",
+		Internal:       true,
+	})
+)

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -688,3 +688,62 @@ other = "查询 webhook 信息失败。"
 
 ["err.server.incomingwebhook.mgmt_operation_failed"]
 other = "操作失败，请稍后再试。"
+
+# ---- err.server.robot.* (modules/robot: api.go / api_manager.go / mention_pref.go) ----
+
+["err.server.robot.request_invalid"]
+other = "请求参数有误。"
+
+["err.server.robot.content_invalid"]
+other = "消息内容无效。"
+
+["err.server.robot.content_type_unsupported"]
+other = "不支持的消息类型。"
+
+["err.server.robot.file_type_unsupported"]
+other = "不支持的文件类型。"
+
+["err.server.robot.file_too_large"]
+other = "文件大小超过限制。"
+
+["err.server.robot.no_fields_to_update"]
+other = "没有需要更新的字段。"
+
+["err.server.robot.creator_only"]
+other = "仅机器人创建者可执行此操作。"
+
+["err.server.robot.message_edit_forbidden"]
+other = "只能编辑自己发送的消息。"
+
+["err.server.robot.channel_send_forbidden"]
+other = "不允许向该频道发送消息。"
+
+["err.server.robot.not_found"]
+other = "机器人不存在。"
+
+["err.server.robot.message_not_found"]
+other = "消息不存在。"
+
+["err.server.robot.auth_failed"]
+other = "机器人鉴权失败。"
+
+["err.server.robot.inline_query_timeout"]
+other = "行内查询超时，请重试。"
+
+["err.server.robot.query_failed"]
+other = "查询机器人数据失败。"
+
+["err.server.robot.store_failed"]
+other = "更新机器人数据失败。"
+
+["err.server.robot.send_failed"]
+other = "消息发送失败。"
+
+["err.server.robot.upload_failed"]
+other = "文件处理失败。"
+
+["err.server.robot.token_gen_failed"]
+other = "生成机器人令牌失败。"
+
+["err.server.robot.auth_check_failed"]
+other = "机器人鉴权校验失败。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -318,6 +318,63 @@ other = "The binding session has expired or is invalid. Please start over."
 ["err.server.oidc.bind_verify_required"]
 other = "Please complete verification before confirming."
 
+["err.server.robot.auth_check_failed"]
+other = "Robot authentication check failed."
+
+["err.server.robot.auth_failed"]
+other = "Robot authentication failed."
+
+["err.server.robot.channel_send_forbidden"]
+other = "Sending messages to this channel is not allowed."
+
+["err.server.robot.content_invalid"]
+other = "Invalid message content."
+
+["err.server.robot.content_type_unsupported"]
+other = "Unsupported message type."
+
+["err.server.robot.creator_only"]
+other = "Only the bot creator can perform this operation."
+
+["err.server.robot.file_too_large"]
+other = "The file exceeds the maximum allowed size."
+
+["err.server.robot.file_type_unsupported"]
+other = "Unsupported file type."
+
+["err.server.robot.inline_query_timeout"]
+other = "The inline query timed out."
+
+["err.server.robot.message_edit_forbidden"]
+other = "You can only edit messages you sent."
+
+["err.server.robot.message_not_found"]
+other = "Message not found."
+
+["err.server.robot.no_fields_to_update"]
+other = "No fields to update."
+
+["err.server.robot.not_found"]
+other = "Robot not found."
+
+["err.server.robot.query_failed"]
+other = "Failed to query robot data."
+
+["err.server.robot.request_invalid"]
+other = "Invalid request."
+
+["err.server.robot.send_failed"]
+other = "Failed to send the message."
+
+["err.server.robot.store_failed"]
+other = "Failed to update robot data."
+
+["err.server.robot.token_gen_failed"]
+other = "Failed to generate the robot token."
+
+["err.server.robot.upload_failed"]
+other = "Failed to process the file."
+
 ["err.server.thread.creator_cannot_leave"]
 other = "Thread creator cannot leave the thread."
 

--- a/tools/lint-direct-error-response/baseline.txt
+++ b/tools/lint-direct-error-response/baseline.txt
@@ -28,7 +28,7 @@
 2 modules/notify/api.go
 14 modules/oidc/api.go  # EXEMPT: OAuth2/OIDC protocol endpoints (authorize/callback/logout) — browser-facing redirect flow, not the dmwork front-end; raw errMsg() kept by design (#220). The err.Error() leaks were closed in #220.
 0 modules/oidc/api_bind.go  # migrated to httperr.ResponseErrorLWithStatus (#220)
-6 modules/robot/api.go
+0 modules/robot/api.go  # migrated to httperr.ResponseErrorL / ResponseErrorLWithStatus (#267)
 8 modules/user/api.go
 4 modules/webhook/github.go  # EXEMPT: GitHub webhook signature errors — external GH never reads the localized envelope
 4 pkg/space/middleware.go


### PR DESCRIPTION
Closes #267. Part of #170 (i18n — backend / octo-server).

Migrates `modules/robot` — the last zero-dependency Phase 2 hotspot — to the i18n error envelope, reusing the merged `user`/`group`/`category` playbook (no email / no gRPC dependency).

## Scope
~133 legacy response sites across 3 files → `httperr.ResponseErrorL` + `errcode.ErrRobot*`:

| File | sites |
|---|---|
| `modules/robot/api.go` | 88 (82 `ResponseError(f)` + 5 webhook-auth aborts + 1 inline-query timeout) |
| `modules/robot/api_manager.go` | 37 |
| `modules/robot/mention_pref.go` | 10 |

19 new `err.server.robot.*` codes registered (validation 400 / permission 403 / not-found 404 / webhook-auth 401 / inline-query timeout 408 / internal 500 `Internal=true`), zh-CN translations, and the regenerated en-US extractor markers.

## Key decisions (review focus)
- **Business errors keep wire 400 (D14).** Legacy `c.ResponseError` already returned 400, so the migration is **zero status drift** for the dmwork-facing endpoints; the real semantic status rides in `error.http_status`.
- **`CheckLoginRole*` role guards** (api_manager.go, 8 sites) collapse to `err.shared.auth.forbidden`.
- **DB / IM failures** route to `Internal=true` codes; the existing `zap.Error` log is kept at each site (and added to the 5 sites that previously lacked one), since the renderer hides the message on the wire.
- **`authRobot` webhook middleware** serves **external bot adapters** (app_key auth), not the dmwork front-end. Its 5 raw `401` aborts collapse into one anti-enumeration `auth_failed` (the specific reason is logged, never returned), and its 2 masquerading DB-lookup failures route to `auth_check_failed` (real `500`). The inline-query long-poll **preserves its `408`**. These three use `ResponseErrorLWithStatus` to **preserve the real wire status** (adapters branch on HTTP 401), i.e. a **deliberate divergence from the D14 fixed-400 path — flagged for maintainer sign-off**.

## Tests
- `TestRobotNoLegacyResponseError` — source guard over the 3 migrated files (bans `.ResponseError(` / `.ResponseErrorf(` / `.ResponseErrorWithStatus(` / `.AbortWithStatus*` / raw `c.Response("`).
- `TestRespondRobotHelpers` — 21 table cases asserting the rendered dual envelope: field details, 403/404 mappings, `Internal=true` copy collapse with no English leak, and the `ResponseErrorLWithStatus` 401/500/408 status preservation.

## Verification
`go build ./...`, `go vet`, gofmt (new files), `make i18n-extract-check`, `make i18n-lint`, `go test ./pkg/errcode ./pkg/i18n/...`, and `go test ./modules/robot/` (incl. DB integration after a test-DB reset) all green. Existing integration tests are unaffected — only error responses changed; success paths are untouched.

## Out of scope (follow-ups, non-blocking)
- `getEventsForPost/Get` return `c.Response(gin.H{"status":0,"msg":err.Error()})` (HTTP 200 in-band errors, outside D23) — still leak `err.Error()` to external adapters; should be closed separately.
- `setDescription` / `setAutoApprove` merge a DB error with not-found into one 404 (pre-existing logic kept; could be split like `assertRobotOwner`).
- Service-layer sentinel errors instead of string matching (same follow-up as thread/user/group).
