### PR TITLE
fix(ci): provision WuKongIM for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,12 +107,13 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # MySQL and Redis are required by ~10 modules' integration tests
-    # (modules/{user,oidc,thread,group,space,...}). The tests hardcode
-    # 127.0.0.1:3306 (root/demo/test) and 127.0.0.1:6379 — see
+    # MySQL, Redis, and WuKongIM are required by integration tests
+    # (modules/{user,oidc,thread,group,space,botfather,...}). The tests
+    # hardcode 127.0.0.1:3306 (root/demo/test), 127.0.0.1:6379, and
+    # octo-lib's default WuKongIM API URL http://127.0.0.1:5001 — see
     # github.com/Mininglamp-OSS/octo-lib/testutil.NewTestServer and
-    # modules/oidc/callback_guard_test.go. Ports are mapped to the host
-    # so jobs running in the runner VM can reach them via 127.0.0.1.
+    # config.New. Ports are mapped to the host so jobs running in the
+    # runner VM can reach them via 127.0.0.1.
     services:
       mysql:
         image: mysql:8.0
@@ -135,6 +136,29 @@ jobs:
           --health-interval=5s
           --health-timeout=5s
           --health-retries=20
+      wukongim:
+        # Keep this pinned. WuKongIM tags have changed manager-token and
+        # tokenAuthOn behavior across releases; this tag is the docker
+        # stack's validated baseline.
+        image: wukongim/wukongim:v2.2.4-20260313
+        env:
+          WK_MODE: debug
+          # Tests use octo-lib's default empty manager token. Disable IM
+          # token auth explicitly so /channel and /health are reachable
+          # from the runner without test-specific config files.
+          WK_TOKENAUTHON: "false"
+          WK_EXTERNAL_IP: 127.0.0.1
+          WK_EXTERNAL_WSADDR: ws://127.0.0.1:5200
+        ports:
+          - 5001:5001
+          - 5100:5100
+          - 5200:5200
+        options: >-
+          --health-cmd="wget -q -O - http://127.0.0.1:5001/health >/dev/null 2>&1 || wget -q -O - http://127.0.0.1:5001/varz >/dev/null 2>&1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=12
+          --health-start-period=40s
     env:
       # common.Setup (post 2026-05) refuses to boot without a 32-byte master
       # key; see modules/user/main_test.go for the same pattern. Use a fixed
@@ -174,6 +198,18 @@ jobs:
             sleep 2
           done
           echo "mysql did not become ready" >&2
+          exit 1
+
+      - name: Wait for WuKongIM
+        run: |
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:5001/health >/dev/null || curl -fsS http://127.0.0.1:5001/varz >/dev/null; then
+              echo "wukongim ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "wukongim did not become ready" >&2
           exit 1
 
       - name: Run tests

--- a/go.mod
+++ b/go.mod
@@ -175,5 +175,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/modules/category/api_test.go
+++ b/modules/category/api_test.go
@@ -201,7 +201,7 @@ func TestCategory_Update(t *testing.T) {
 
 	// create a category
 	wc := createCategory(t, route, spaceID, "工作")
-	assert.Equal(t, http.StatusOK, wc.Code)
+	require.Equalf(t, http.StatusOK, wc.Code, "create category response: %s", wc.Body.String())
 	cat := parseJSON(t, wc)
 	catID := cat["category_id"].(string)
 

--- a/modules/category/api_toctou_test.go
+++ b/modules/category/api_toctou_test.go
@@ -34,7 +34,22 @@ func TestMain(m *testing.M) {
 		_, _ = rand.Read(key)
 		_ = os.Setenv("OCTO_MASTER_KEY", hex.EncodeToString(key))
 	}
+	primeRegisterModulesForSharedTestDB()
 	os.Exit(m.Run())
+}
+
+func primeRegisterModulesForSharedTestDB() {
+	cfg := config.New()
+	cfg.Test = true
+	cfg.DB.MySQLAddr = "root:demo@tcp(127.0.0.1)/test?charset=utf8mb4&parseTime=true"
+	cfg.DB.Migration = false
+	ctx := config.NewContext(cfg)
+	s := server.New(ctx)
+	s.GetRoute().UseGin(ctx.Tracer().GinMiddle())
+	ctx.SetHttpRoute(s.GetRoute())
+	if err := module.Setup(ctx); err != nil {
+		panic(err)
+	}
 }
 
 // toctouDefaultDB is the isolated MySQL database this test file owns. We
@@ -86,12 +101,18 @@ func newToctouTestServer(t *testing.T) (*server.Server, *config.Context, *Catego
 
 	require.NoError(t, ctx.Cache().Set(cfg.Cache.TokenCachePrefix+testutil.Token, testutil.UID+"@test"), "seed token")
 
+	setupServer := server.New(ctx)
+	setupServer.GetRoute().UseGin(ctx.Tracer().GinMiddle())
+	ctx.SetHttpRoute(setupServer.GetRoute())
+	require.NoError(t, module.Setup(ctx), "module setup")
+
 	s := server.New(ctx)
 	s.GetRoute().UseGin(ctx.Tracer().GinMiddle())
 	ctx.SetHttpRoute(s.GetRoute())
-	require.NoError(t, module.Setup(ctx), "module setup")
+	f := New(ctx)
+	f.Route(s.GetRoute())
 
-	return s, ctx, New(ctx)
+	return s, ctx, f
 }
 
 // ensureToctouDB parses the DSN, opens a connection WITHOUT a DB name, and

--- a/modules/common/api_test.go
+++ b/modules/common/api_test.go
@@ -7,10 +7,18 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func cleanAllTablesAndReloadSettings(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, EnsureSystemSettings(ctx).Reload())
+}
 
 func TestAddVersion(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
@@ -18,8 +26,7 @@ func TestAddVersion(t *testing.T) {
 	f := New(ctx)
 	f.Route(s.GetRoute())
 	//清除数据
-	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
+	cleanAllTablesAndReloadSettings(t, ctx)
 	w := httptest.NewRecorder()
 	model := &appVersionReq{
 		AppVersion:  "1.0",
@@ -39,9 +46,8 @@ func TestGetNewVersion(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
 	f := New(ctx)
 	//清除数据
-	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
-	_, err = f.db.insertAppVersion(&appVersionModel{
+	cleanAllTablesAndReloadSettings(t, ctx)
+	_, err := f.db.insertAppVersion(&appVersionModel{
 		AppVersion:  "1.0",
 		OS:          "android",
 		DownloadURL: "http://www.githubim.com",
@@ -71,9 +77,8 @@ func TestGetAppConfig(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
 	f := New(ctx)
 	//清除数据
-	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
-	err = f.appConfigDB.insert(&appConfigModel{
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{
 		WelcomeMessage:                 "欢迎使用DMWork",
 		NewUserJoinSystemGroup:         1,
 		RegisterInviteOn:               1,
@@ -102,9 +107,8 @@ func TestGetAppConfig(t *testing.T) {
 func TestGetAppConfig_SystemBotUIDsOnVersionShortCircuit(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
 	f := New(ctx)
-	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
-	err = f.appConfigDB.insert(&appConfigModel{})
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	// 带一个极大 version 强制命中短路分支
@@ -125,9 +129,8 @@ func TestGetAppConfig_DisableUserCreateSpace_DefaultsZero(t *testing.T) {
 	t.Setenv("DM_SPACE_DISABLE_USER_CREATE", "")
 	s, ctx := testutil.NewTestServer()
 	f := New(ctx)
-	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
-	err = f.appConfigDB.insert(&appConfigModel{})
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
@@ -143,9 +146,8 @@ func TestGetAppConfig_DisableUserCreateSpace_DBOverride(t *testing.T) {
 	t.Setenv("DM_SPACE_DISABLE_USER_CREATE", "")
 	s, ctx := testutil.NewTestServer()
 	f := New(ctx)
-	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
-	err = f.appConfigDB.insert(&appConfigModel{})
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
 	assert.NoError(t, err)
 
 	settings := EnsureSystemSettings(ctx)
@@ -167,9 +169,8 @@ func TestGetAppConfig_DisableUserCreateSpace_OnVersionShortCircuit(t *testing.T)
 	t.Setenv("DM_SPACE_DISABLE_USER_CREATE", "")
 	s, ctx := testutil.NewTestServer()
 	f := New(ctx)
-	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
-	err = f.appConfigDB.insert(&appConfigModel{})
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
 	assert.NoError(t, err)
 
 	settings := EnsureSystemSettings(ctx)
@@ -188,9 +189,8 @@ func TestGetAppConfig_DisableUserCreateSpace_OnVersionShortCircuit(t *testing.T)
 func TestGetAppConfig_LocalLoginOff_DefaultsZero(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
 	f := New(ctx)
-	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
-	err = f.appConfigDB.insert(&appConfigModel{})
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
@@ -208,9 +208,8 @@ func TestGetAppConfig_LocalLoginOff_DBOverride(t *testing.T) {
 	enableFullOIDCForTest(t)
 	s, ctx := testutil.NewTestServer()
 	f := New(ctx)
-	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
-	err = f.appConfigDB.insert(&appConfigModel{})
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
 	assert.NoError(t, err)
 
 	settings := EnsureSystemSettings(ctx)
@@ -231,9 +230,8 @@ func TestGetAppConfig_LocalLoginOff_OnVersionShortCircuit(t *testing.T) {
 	enableFullOIDCForTest(t)
 	s, ctx := testutil.NewTestServer()
 	f := New(ctx)
-	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
-	err = f.appConfigDB.insert(&appConfigModel{})
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
 	assert.NoError(t, err)
 
 	settings := EnsureSystemSettings(ctx)
@@ -265,9 +263,8 @@ func TestGetAppConfig_OIDCProvidersHonoursParseBoolSpellings(t *testing.T) {
 
 			s, ctx := testutil.NewTestServer()
 			f := New(ctx)
-			err := testutil.CleanAllTables(ctx)
-			assert.NoError(t, err)
-			err = f.appConfigDB.insert(&appConfigModel{})
+			cleanAllTablesAndReloadSettings(t, ctx)
+			err := f.appConfigDB.insert(&appConfigModel{})
 			assert.NoError(t, err)
 
 			settings := EnsureSystemSettings(ctx)
@@ -300,9 +297,8 @@ func TestGetAppConfig_LocalLoginOff_SafetyOverrideWithoutSSO(t *testing.T) {
 	ctx.GetConfig().Gitee.ClientID = ""
 	ctx.GetConfig().Gitee.ClientSecret = ""
 	f := New(ctx)
-	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
-	err = f.appConfigDB.insert(&appConfigModel{})
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
 	assert.NoError(t, err)
 
 	settings := EnsureSystemSettings(ctx)
@@ -324,9 +320,8 @@ func TestGetAppConfig_OIDCURLsExplicit(t *testing.T) {
 	t.Setenv("DM_OIDC_RESET_PASSWORD_URL", "https://accounts.example.com/reset")
 	s, ctx := testutil.NewTestServer()
 	f := New(ctx)
-	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
-	err = f.appConfigDB.insert(&appConfigModel{})
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
@@ -346,9 +341,8 @@ func TestGetAppConfig_OIDCAccountURLFallsBackToIssuer(t *testing.T) {
 	t.Setenv("DM_OIDC_RESET_PASSWORD_URL", "")
 	s, ctx := testutil.NewTestServer()
 	f := New(ctx)
-	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
-	err = f.appConfigDB.insert(&appConfigModel{})
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
@@ -370,9 +364,8 @@ func TestGetAppConfig_OIDCProvidersWithCustomID(t *testing.T) {
 	t.Setenv("DM_OIDC_RESET_PASSWORD_URL", "https://accounts.google.com/signin/recovery")
 	s, ctx := testutil.NewTestServer()
 	f := New(ctx)
-	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
-	err = f.appConfigDB.insert(&appConfigModel{})
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
@@ -396,9 +389,8 @@ func TestGetAppConfig_OIDCProvidersDefaults(t *testing.T) {
 	t.Setenv("DM_OIDC_AEGIS_ISSUER", "https://accounts.imocto.cn")
 	s, ctx := testutil.NewTestServer()
 	f := New(ctx)
-	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
-	err = f.appConfigDB.insert(&appConfigModel{})
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
@@ -420,9 +412,8 @@ func TestGetAppConfig_OIDCAccountURLFallsBackToProviderIssuer(t *testing.T) {
 	t.Setenv("DM_OIDC_AEGIS_ISSUER", "")
 	s, ctx := testutil.NewTestServer()
 	f := New(ctx)
-	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
-	err = f.appConfigDB.insert(&appConfigModel{})
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
@@ -442,9 +433,8 @@ func TestGetAppConfig_OIDCProvidersInvalidIDFallsBackToDefault(t *testing.T) {
 	t.Setenv("DM_OIDC_PROVIDER_NAME", "Bad")
 	s, ctx := testutil.NewTestServer()
 	f := New(ctx)
-	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
-	err = f.appConfigDB.insert(&appConfigModel{})
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
@@ -464,9 +454,8 @@ func TestGetAppConfig_OIDCProvidersDisabledOmitted(t *testing.T) {
 	t.Setenv("DM_OIDC_ACCOUNT_URL", "https://accounts.google.com/")
 	s, ctx := testutil.NewTestServer()
 	f := New(ctx)
-	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
-	err = f.appConfigDB.insert(&appConfigModel{})
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
@@ -485,9 +474,8 @@ func TestGetAppConfig_OIDCDisabledOmitsAll(t *testing.T) {
 	t.Setenv("DM_OIDC_RESET_PASSWORD_URL", "https://accounts.example.com/reset")
 	s, ctx := testutil.NewTestServer()
 	f := New(ctx)
-	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
-	err = f.appConfigDB.insert(&appConfigModel{})
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
@@ -505,9 +493,8 @@ func TestGetAppConfig_OIDCDisabledOmitsAll(t *testing.T) {
 func TestGetAppConfig_SystemBotUIDsDownstreamed(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
 	f := New(ctx)
-	err := testutil.CleanAllTables(ctx)
-	assert.NoError(t, err)
-	err = f.appConfigDB.insert(&appConfigModel{})
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)

--- a/modules/common/key_encryption_test.go
+++ b/modules/common/key_encryption_test.go
@@ -7,9 +7,37 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func setenvForTest(t *testing.T, key, value string) {
+	t.Helper()
+	previous, ok := os.LookupEnv(key)
+	if err := os.Setenv(key, value); err != nil {
+		t.Fatalf("set %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if ok {
+			_ = os.Setenv(key, previous)
+			return
+		}
+		_ = os.Unsetenv(key)
+	})
+}
+
+func unsetenvForTest(t *testing.T, key string) {
+	t.Helper()
+	previous, ok := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if ok {
+			_ = os.Setenv(key, previous)
+		}
+	})
+}
+
 func TestEncryptKey_NoMasterKey_ReturnsError(t *testing.T) {
 	// Ensure OCTO_MASTER_KEY is not set
-	os.Unsetenv(masterKeyEnv)
+	unsetenvForTest(t, masterKeyEnv)
 
 	plaintext := "test-private-key-content"
 	result, err := encryptKey(plaintext)
@@ -21,8 +49,7 @@ func TestEncryptKey_NoMasterKey_ReturnsError(t *testing.T) {
 
 func TestEncryptKey_InvalidKeyLength_ReturnsError(t *testing.T) {
 	// Set an invalid key (not 32 bytes)
-	os.Setenv(masterKeyEnv, "short-key")
-	defer os.Unsetenv(masterKeyEnv)
+	setenvForTest(t, masterKeyEnv, "short-key")
 
 	plaintext := "test-private-key-content"
 	result, err := encryptKey(plaintext)
@@ -34,8 +61,7 @@ func TestEncryptKey_InvalidKeyLength_ReturnsError(t *testing.T) {
 
 func TestEncryptKey_ValidKey_ReturnsEncrypted(t *testing.T) {
 	// Set a valid 32-byte key
-	os.Setenv(masterKeyEnv, "12345678901234567890123456789012")
-	defer os.Unsetenv(masterKeyEnv)
+	setenvForTest(t, masterKeyEnv, "12345678901234567890123456789012")
 
 	plaintext := "test-private-key-content"
 	result, err := encryptKey(plaintext)
@@ -48,7 +74,7 @@ func TestEncryptKey_ValidKey_ReturnsEncrypted(t *testing.T) {
 
 func TestDecryptKey_LegacyPlaintext_ReturnsAsIs(t *testing.T) {
 	// Legacy plaintext without enc: prefix should be returned as-is
-	os.Unsetenv(masterKeyEnv)
+	unsetenvForTest(t, masterKeyEnv)
 
 	plaintext := "legacy-plaintext-key"
 	result, err := decryptKey(plaintext)
@@ -59,7 +85,7 @@ func TestDecryptKey_LegacyPlaintext_ReturnsAsIs(t *testing.T) {
 
 func TestDecryptKey_EncryptedWithoutMasterKey_ReturnsError(t *testing.T) {
 	// Encrypted key but no master key configured
-	os.Unsetenv(masterKeyEnv)
+	unsetenvForTest(t, masterKeyEnv)
 
 	encrypted := encryptedKeyPrefix + "some-base64-data"
 	result, err := decryptKey(encrypted)
@@ -71,8 +97,7 @@ func TestDecryptKey_EncryptedWithoutMasterKey_ReturnsError(t *testing.T) {
 
 func TestEncryptDecrypt_RoundTrip(t *testing.T) {
 	// Set a valid 32-byte key
-	os.Setenv(masterKeyEnv, "12345678901234567890123456789012")
-	defer os.Unsetenv(masterKeyEnv)
+	setenvForTest(t, masterKeyEnv, "12345678901234567890123456789012")
 
 	original := "test-private-key-content-12345"
 	encrypted, err := encryptKey(original)

--- a/modules/group/api_test.go
+++ b/modules/group/api_test.go
@@ -13,12 +13,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	_ "github.com/go-sql-driver/mysql"
 
-	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -47,6 +49,25 @@ func TestMain(m *testing.M) {
 		db.Exec("CREATE TABLE IF NOT EXISTS `robot_menu` (`id` BIGINT AUTO_INCREMENT PRIMARY KEY, `robot_id` VARCHAR(40) NOT NULL DEFAULT '', `cmd` VARCHAR(100) NOT NULL DEFAULT '', `remark` VARCHAR(100) NOT NULL DEFAULT '', `type` VARCHAR(100) NOT NULL DEFAULT '', `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci")
 	}
 	os.Exit(m.Run())
+}
+
+func ensureGroupCategorySchema(t *testing.T, ctx *config.Context) {
+	t.Helper()
+
+	_, err := ctx.DB().InsertBySql("CREATE TABLE IF NOT EXISTS `group_category` (`id` BIGINT AUTO_INCREMENT PRIMARY KEY, `category_id` VARCHAR(32) NOT NULL, `space_id` VARCHAR(40) NOT NULL, `uid` VARCHAR(40) NOT NULL, `name` VARCHAR(100) NOT NULL, `sort` INT NOT NULL DEFAULT 0, `status` TINYINT NOT NULL DEFAULT 1, `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP, `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, UNIQUE KEY `uk_category_id` (`category_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci").Exec()
+	require.NoError(t, err)
+
+	allowDuplicateColumn(t, ctx, "ALTER TABLE `group_setting` ADD COLUMN `category_id` VARCHAR(32) DEFAULT NULL")
+	allowDuplicateColumn(t, ctx, "ALTER TABLE `group_setting` ADD COLUMN `category_sort` INT NOT NULL DEFAULT 0")
+}
+
+func allowDuplicateColumn(t *testing.T, ctx *config.Context, stmt string) {
+	t.Helper()
+
+	_, err := ctx.DB().InsertBySql(stmt).Exec()
+	if err != nil && !strings.Contains(err.Error(), "Duplicate column name") {
+		require.NoError(t, err)
+	}
 }
 
 func TestGroupCreate(t *testing.T) {
@@ -83,10 +104,7 @@ func TestGroupCreate_WithCategoryID(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
 	f := New(ctx)
 
-	// 确保 group_category 表和 group_setting category 列存在（category 模块迁移可能未执行）
-	ctx.DB().InsertBySql("CREATE TABLE IF NOT EXISTS `group_category` (`id` BIGINT AUTO_INCREMENT PRIMARY KEY, `category_id` VARCHAR(32) NOT NULL, `space_id` VARCHAR(40) NOT NULL, `uid` VARCHAR(40) NOT NULL, `name` VARCHAR(100) NOT NULL, `sort` INT NOT NULL DEFAULT 0, `status` TINYINT NOT NULL DEFAULT 1, `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP, `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, UNIQUE KEY `uk_category_id` (`category_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4").Exec()
-	ctx.DB().InsertBySql("ALTER TABLE `group_setting` ADD COLUMN `category_id` VARCHAR(32) DEFAULT NULL").Exec()
-	ctx.DB().InsertBySql("ALTER TABLE `group_setting` ADD COLUMN `category_sort` INT NOT NULL DEFAULT 0").Exec()
+	ensureGroupCategorySchema(t, ctx)
 
 	spaceID := "space-create-cat-001"
 	categoryID := "cat-create-001"
@@ -170,6 +188,7 @@ func TestGroupCreate_WithCategoryID_NoSpaceID(t *testing.T) {
 
 func TestGroupCreate_WithCategoryID_NotFound(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
+	ensureGroupCategorySchema(t, ctx)
 
 	spaceID := "space-cat-notfound"
 
@@ -198,6 +217,7 @@ func TestGroupCreate_WithCategoryID_NotFound(t *testing.T) {
 
 func TestGroupCreate_WithCategoryID_NotOwned(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
+	ensureGroupCategorySchema(t, ctx)
 
 	spaceID := "space-cat-notowned"
 	categoryID := "cat-other-user"

--- a/tools/workflow-guards/ci_test.go
+++ b/tools/workflow-guards/ci_test.go
@@ -1,0 +1,103 @@
+package workflowguards
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type workflow struct {
+	Jobs map[string]job `yaml:"jobs"`
+}
+
+type job struct {
+	Services map[string]service `yaml:"services"`
+	Steps    []step             `yaml:"steps"`
+}
+
+type service struct {
+	Image   string                 `yaml:"image"`
+	Env     map[string]interface{} `yaml:"env"`
+	Ports   []string               `yaml:"ports"`
+	Options string                 `yaml:"options"`
+}
+
+type step struct {
+	Name string `yaml:"name"`
+}
+
+func TestCITestJobProvidesWuKongIM(t *testing.T) {
+	wf := readWorkflow(t, ".github/workflows/ci.yml")
+	testJob, ok := wf.Jobs["test"]
+	if !ok {
+		t.Fatal("ci.yml must define the test job")
+	}
+
+	wk, ok := testJob.Services["wukongim"]
+	if !ok {
+		t.Fatal("CI test job must provision a wukongim service for IM-channel integration tests")
+	}
+	if wk.Image != "wukongim/wukongim:v2.2.4-20260313" {
+		t.Fatalf("wukongim service image = %q, want pinned wukongim/wukongim:v2.2.4-20260313", wk.Image)
+	}
+	if !contains(wk.Ports, "5001:5001") {
+		t.Fatalf("wukongim service ports = %v, want 5001:5001 for octo-lib's default APIURL", wk.Ports)
+	}
+	if got := wk.Env["WK_TOKENAUTHON"]; got != "false" {
+		t.Fatalf("wukongim WK_TOKENAUTHON = %#v, want \"false\" so tests can use an empty manager token", got)
+	}
+	if wk.Options == "" {
+		t.Fatal("wukongim service must define a health check")
+	}
+
+	waitIdx := stepIndex(testJob.Steps, "Wait for WuKongIM")
+	runIdx := stepIndex(testJob.Steps, "Run tests")
+	if waitIdx < 0 {
+		t.Fatal("CI test job must wait for WuKongIM before running Go tests")
+	}
+	if runIdx < 0 {
+		t.Fatal("CI test job must define the Run tests step")
+	}
+	if waitIdx > runIdx {
+		t.Fatal("Wait for WuKongIM must run before Run tests")
+	}
+}
+
+func readWorkflow(t *testing.T, rel string) workflow {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(file), "../.."))
+	b, err := os.ReadFile(filepath.Join(root, rel))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wf workflow
+	if err := yaml.Unmarshal(b, &wf); err != nil {
+		t.Fatal(err)
+	}
+	return wf
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func stepIndex(steps []step, name string) int {
+	for i, step := range steps {
+		if step.Name == name {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## Summary

- add a WuKongIM service to the CI Test job so group / botfather IM-channel integration tests can reach 127.0.0.1:5001
- add a workflow guard test to keep the service, 5001 port mapping, and wait step from regressing

## Verification

- RED: go test ./tools/workflow-guards -run TestCITestJobProvidesWuKongIM -count=1 failed before the workflow fix because the test job had no wukongim service
- GREEN: go test ./tools/workflow-guards -run TestCITestJobProvidesWuKongIM -count=1
- GREEN: go test ./tools/...
- GREEN: ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'

Fixes #266