### PR TITLE
feat(i18n): migrate space module to ResponseErrorL (#269)

### DIFF
--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -180,7 +180,11 @@ type createSpaceResult struct {
 // createSpace 创建空间（用户侧入口）
 func (s *Space) createSpace(c *wkhttp.Context) {
 	if s.isUserCreateDisabled() {
-		httperr.ResponseErrorL(c, errcode.ErrSpaceCreationDisabled, nil, nil)
+		// Preserve the prior real 403: createSpace originally returned
+		// ResponseErrorWithStatus(403). These clients branch on HTTP 403, so use
+		// WithStatus rather than the D14 fixed-400 path (same call as #268's
+		// mention_pref owner guards).
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSpaceCreationDisabled, nil, nil)
 		return
 	}
 	loginUID := c.GetLoginUID()

--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -20,6 +20,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	commonmod "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	rd "github.com/go-redis/redis"
@@ -49,11 +51,11 @@ func New(ctx *config.Context) *Space {
 func (s *Space) checkSpaceActive(c *wkhttp.Context, spaceId string) bool {
 	active, err := s.db.isSpaceActive(spaceId)
 	if err != nil {
-		c.ResponseError(errors.New("查询空间状态失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return true
 	}
 	if !active {
-		c.ResponseError(errors.New("空间不存在或已解散"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotFound, nil, nil)
 		return true
 	}
 	return false
@@ -178,21 +180,21 @@ type createSpaceResult struct {
 // createSpace 创建空间（用户侧入口）
 func (s *Space) createSpace(c *wkhttp.Context) {
 	if s.isUserCreateDisabled() {
-		c.ResponseErrorWithStatus(errors.New("管理员已关闭空间创建功能"), http.StatusForbidden)
+		httperr.ResponseErrorL(c, errcode.ErrSpaceCreationDisabled, nil, nil)
 		return
 	}
 	loginUID := c.GetLoginUID()
 	var req createSpaceReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求参数错误"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	if req.Name == "" {
-		c.ResponseError(errors.New("空间名称不能为空"))
+		respondSpaceRequestInvalid(c, "name")
 		return
 	}
 	if req.JoinMode < JoinModeDirect || req.JoinMode > JoinModeApproval {
-		c.ResponseError(errors.New("无效的加入模式，仅支持 0(直接加入) 或 1(需要审批)"))
+		respondSpaceRequestInvalid(c, "join_mode")
 		return
 	}
 
@@ -205,7 +207,7 @@ func (s *Space) createSpace(c *wkhttp.Context) {
 	})
 	if err != nil {
 		s.Error("创建空间失败", zap.Error(err), zap.String("loginUID", loginUID))
-		c.ResponseError(errors.New("创建空间失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 
@@ -311,22 +313,22 @@ func (s *Space) getSpace(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	spaceId := c.Param("space_id")
 	if spaceId == "" {
-		c.ResponseError(errors.New("空间ID不能为空"))
+		respondSpaceRequestInvalid(c, "space_id")
 		return
 	}
 
 	detail, err := s.db.querySpaceDetail(spaceId, loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("查询空间失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if detail == nil {
-		c.ResponseError(errors.New("空间不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotFound, nil, nil)
 		return
 	}
 
 	if detail.Role < 0 {
-		c.ResponseError(errors.New("你不是该空间成员"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotMember, nil, nil)
 		return
 	}
 
@@ -366,21 +368,21 @@ func (s *Space) updateSpace(c *wkhttp.Context) {
 
 	member, err := s.db.queryMember(spaceId, loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("查询成员信息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if member == nil || member.Role < 1 {
-		c.ResponseError(errors.New("无权限修改空间信息"))
+		httperr.ResponseErrorL(c, errcode.ErrSpacePermissionDenied, nil, nil)
 		return
 	}
 
 	var req updateSpaceReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求参数错误"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	if req.Name == nil && req.Description == nil && req.Logo == nil && req.JoinMode == nil && req.PresetGroupIds == nil {
-		c.ResponseError(errors.New("至少需要提供 name / description / logo / join_mode / preset_group_ids 之一"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 
@@ -389,11 +391,11 @@ func (s *Space) updateSpace(c *wkhttp.Context) {
 	if req.Name != nil {
 		trimmed := strings.TrimSpace(*req.Name)
 		if trimmed == "" {
-			c.ResponseError(errors.New("空间名称不能为空"))
+			respondSpaceRequestInvalid(c, "name")
 			return
 		}
 		if utf8.RuneCountInString(trimmed) > managerSpaceNameMaxChars {
-			c.ResponseError(fmt.Errorf("空间名称不能超过 %d 个字符", managerSpaceNameMaxChars))
+			respondSpaceFieldTooLong(c, "name", managerSpaceNameMaxChars)
 			return
 		}
 		req.Name = &trimmed
@@ -401,22 +403,22 @@ func (s *Space) updateSpace(c *wkhttp.Context) {
 	if req.Description != nil {
 		trimmed := strings.TrimSpace(*req.Description)
 		if utf8.RuneCountInString(trimmed) > managerSpaceDescriptionMaxChars {
-			c.ResponseError(fmt.Errorf("空间描述不能超过 %d 个字符", managerSpaceDescriptionMaxChars))
+			respondSpaceFieldTooLong(c, "description", managerSpaceDescriptionMaxChars)
 			return
 		}
 		req.Description = &trimmed
 	}
 	if req.Logo != nil && utf8.RuneCountInString(*req.Logo) > managerSpaceLogoMaxChars {
-		c.ResponseError(fmt.Errorf("Logo 不能超过 %d 个字符", managerSpaceLogoMaxChars))
+		respondSpaceFieldTooLong(c, "logo", managerSpaceLogoMaxChars)
 		return
 	}
 	if req.JoinMode != nil && (*req.JoinMode < JoinModeDirect || *req.JoinMode > JoinModeApproval) {
-		c.ResponseError(errors.New("无效的加入模式，仅支持 0(直接加入) 或 1(需要审批)"))
+		respondSpaceRequestInvalid(c, "join_mode")
 		return
 	}
 	if req.PresetGroupIds != nil {
 		if err := validatePresetGroupIds(*req.PresetGroupIds); err != nil {
-			c.ResponseError(err)
+			respondSpaceRequestInvalid(c, "preset_group_ids")
 			return
 		}
 	}
@@ -428,19 +430,19 @@ func (s *Space) updateSpace(c *wkhttp.Context) {
 	if err != nil {
 		// 复用管理端 sentinel，并发解散 / 封禁与 active 检查之间的 race 由事务侧裁决。
 		if errors.Is(err, ErrSpaceNotFound) {
-			c.ResponseError(errors.New("空间不存在"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceNotFound, nil, nil)
 			return
 		}
 		if errors.Is(err, ErrSpaceDisbandedForUpdate) {
-			c.ResponseError(errors.New("空间已解散，无法修改空间信息"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceImmutable, nil, nil)
 			return
 		}
 		if errors.Is(err, ErrSpaceBannedForUpdate) {
-			c.ResponseError(errors.New("空间已封禁，无法修改空间信息"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceImmutable, nil, nil)
 			return
 		}
 		s.Error("用户修改空间信息失败", zap.Error(err), zap.String("spaceId", spaceId), zap.String("operator", loginUID))
-		c.ResponseError(errors.New("更新空间信息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 
@@ -532,17 +534,17 @@ func (s *Space) disbandSpace(c *wkhttp.Context) {
 
 	member, err := s.db.queryMember(spaceId, loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("查询成员信息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if member == nil || member.Role != 2 {
-		c.ResponseError(errors.New("只有拥有者才能解散空间"))
+		httperr.ResponseErrorL(c, errcode.ErrSpacePermissionDenied, nil, nil)
 		return
 	}
 
 	err = s.db.disbandSpace(spaceId)
 	if err != nil {
-		c.ResponseError(errors.New("解散空间失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -555,7 +557,7 @@ func (s *Space) mySpaces(c *wkhttp.Context) {
 	spaces, err := s.db.queryMySpaces(loginUID)
 	if err != nil {
 		s.Error("查询空间列表失败", zap.Error(err), zap.String("loginUID", loginUID))
-		c.ResponseError(errors.New("查询空间列表失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 
@@ -586,11 +588,11 @@ func (s *Space) listMembers(c *wkhttp.Context) {
 
 	member, err := s.db.queryMember(spaceId, loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("查询成员信息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if member == nil {
-		c.ResponseError(errors.New("你不是该空间成员"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotMember, nil, nil)
 		return
 	}
 
@@ -610,7 +612,7 @@ func (s *Space) listMembers(c *wkhttp.Context) {
 
 	members, err := s.db.queryMembers(spaceId, loginUID, page, limit)
 	if err != nil {
-		c.ResponseError(errors.New("查询成员列表失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 
@@ -638,38 +640,38 @@ func (s *Space) addMembers(c *wkhttp.Context) {
 
 	member, err := s.db.queryMember(spaceId, loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("查询成员信息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if member == nil || member.Role < 1 {
-		c.ResponseError(errors.New("无权限添加成员"))
+		httperr.ResponseErrorL(c, errcode.ErrSpacePermissionDenied, nil, nil)
 		return
 	}
 
 	var req addMemberReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求参数错误"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	if len(req.UIDs) == 0 {
-		c.ResponseError(errors.New("成员列表不能为空"))
+		respondSpaceRequestInvalid(c, "members")
 		return
 	}
 
 	// 检查空间人数上限
 	spaceInfo, err := s.db.querySpaceByID(spaceId)
 	if err != nil || spaceInfo == nil {
-		c.ResponseError(errors.New("空间不存在或已解散"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotFound, nil, nil)
 		return
 	}
 	if spaceInfo.MaxUsers > 0 {
 		memberCount, countErr := s.db.countActiveMembers(spaceId)
 		if countErr != nil {
-			c.ResponseError(errors.New("查询空间成员数失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 			return
 		}
 		if memberCount+len(req.UIDs) > spaceInfo.MaxUsers {
-			c.ResponseError(errors.New("空间成员数已达上限"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceFull, nil, nil)
 			return
 		}
 	}
@@ -678,13 +680,13 @@ func (s *Space) addMembers(c *wkhttp.Context) {
 	for _, uid := range req.UIDs {
 		existing, err := s.db.queryMemberIncludeRemoved(spaceId, uid)
 		if err != nil {
-			c.ResponseError(errors.New("查询成员信息失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 			return
 		}
 		if existing != nil {
 			if existing.Status == 0 {
 				if err = s.db.reactivateMember(spaceId, uid, 0); err != nil {
-					c.ResponseError(errors.New("重新激活成员失败"))
+					httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 					return
 				}
 				newMembers = append(newMembers, uid)
@@ -697,7 +699,7 @@ func (s *Space) addMembers(c *wkhttp.Context) {
 			Role:    0,
 			Status:  1,
 		}); err != nil {
-			c.ResponseError(errors.New("添加成员失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 			return
 		}
 		newMembers = append(newMembers, uid)
@@ -732,24 +734,24 @@ func (s *Space) removeMembers(c *wkhttp.Context) {
 
 	member, err := s.db.queryMember(spaceId, loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("查询成员信息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if member == nil || member.Role < 1 {
-		c.ResponseError(errors.New("无权限移除成员"))
+		httperr.ResponseErrorL(c, errcode.ErrSpacePermissionDenied, nil, nil)
 		return
 	}
 
 	var req removeMemberReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求参数错误"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 
 	for _, uid := range req.UIDs {
 		target, err := s.db.queryMember(spaceId, uid)
 		if err != nil {
-			c.ResponseError(errors.New("查询目标成员失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 			return
 		}
 		if target == nil {
@@ -762,7 +764,7 @@ func (s *Space) removeMembers(c *wkhttp.Context) {
 			continue // 不能移除同级或更高角色
 		}
 		if err = s.db.removeMember(spaceId, uid); err != nil {
-			c.ResponseError(errors.New("移除成员失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 			return
 		}
 	}
@@ -784,21 +786,21 @@ func (s *Space) leaveSpace(c *wkhttp.Context) {
 
 	member, err := s.db.queryMember(spaceId, loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("查询成员信息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if member == nil {
-		c.ResponseError(errors.New("你不是该空间成员"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotMember, nil, nil)
 		return
 	}
 	if member.Role == 2 {
-		c.ResponseError(errors.New("拥有者不能退出空间，请先转让拥有权"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceOwnerConstraint, nil, nil)
 		return
 	}
 
 	err = s.db.removeMember(spaceId, loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("退出空间失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	// 失效通知成员缓存
@@ -820,32 +822,32 @@ func (s *Space) updateMemberRole(c *wkhttp.Context) {
 
 	member, err := s.db.queryMember(spaceId, loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("查询成员信息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if member == nil || member.Role != 2 {
-		c.ResponseError(errors.New("只有拥有者才能修改成员角色"))
+		httperr.ResponseErrorL(c, errcode.ErrSpacePermissionDenied, nil, nil)
 		return
 	}
 
 	var req updateMemberRoleReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求参数错误"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	if req.Role < 0 || req.Role > 2 {
-		c.ResponseError(errors.New("无效的角色值"))
+		respondSpaceRequestInvalid(c, "role")
 		return
 	}
 
 	// 验证目标成员存在且活跃
 	target, err := s.db.queryMember(spaceId, targetUID)
 	if err != nil {
-		c.ResponseError(errors.New("查询目标成员失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if target == nil {
-		c.ResponseError(errors.New("目标成员不存在或已被移除"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceMemberNotFound, nil, nil)
 		return
 	}
 
@@ -853,29 +855,29 @@ func (s *Space) updateMemberRole(c *wkhttp.Context) {
 	if req.Role == 2 {
 		tx, txErr := s.ctx.DB().Begin()
 		if txErr != nil {
-			c.ResponseError(errors.New("开启事务失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 			return
 		}
 		defer tx.RollbackUnlessCommitted()
 
 		// 先提升目标为owner
 		if err = s.db.updateMemberRoleTx(tx, spaceId, targetUID, 2); err != nil {
-			c.ResponseError(errors.New("提升目标角色失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 			return
 		}
 		// 再把当前owner降为admin
 		if err = s.db.updateMemberRoleTx(tx, spaceId, loginUID, 1); err != nil {
-			c.ResponseError(errors.New("降级当前拥有者失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 			return
 		}
 		if err = tx.Commit(); err != nil {
-			c.ResponseError(errors.New("提交事务失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 			return
 		}
 	} else {
 		err = s.db.updateMemberRole(spaceId, targetUID, req.Role)
 		if err != nil {
-			c.ResponseError(errors.New("修改角色失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 			return
 		}
 	}
@@ -893,11 +895,11 @@ func (s *Space) createInvite(c *wkhttp.Context) {
 
 	member, err := s.db.queryMember(spaceId, loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("查询成员信息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if member == nil || member.Role < 1 {
-		c.ResponseError(errors.New("无权限创建邀请链接"))
+		httperr.ResponseErrorL(c, errcode.ErrSpacePermissionDenied, nil, nil)
 		return
 	}
 
@@ -910,7 +912,7 @@ func (s *Space) createInvite(c *wkhttp.Context) {
 	inviteCode, err := s.insertInvitationWithRetry(inviteModel)
 	if err != nil {
 		s.Error("创建邀请链接失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("创建邀请链接失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 
@@ -925,29 +927,29 @@ func (s *Space) joinSpace(c *wkhttp.Context) {
 
 	var req joinSpaceReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求参数错误"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	if req.InviteCode == "" {
-		c.ResponseError(errors.New("邀请码不能为空"))
+		respondSpaceRequestInvalid(c, "invite_code")
 		return
 	}
 
 	invitation, err := s.db.queryInvitationByCode(req.InviteCode)
 	if err != nil {
-		c.ResponseError(errors.New("查询邀请信息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if invitation == nil {
 		// queryInvitationByCode 已在 SQL 层过滤 status!=1 与已过期，命中即有效。
-		c.ResponseError(errors.New("邀请码无效或已过期"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceInviteCodeInvalid, nil, nil)
 		return
 	}
 
 	// 检查空间是否存在
 	space, err := s.db.querySpaceByID(invitation.SpaceId)
 	if err != nil || space == nil {
-		c.ResponseError(errors.New("空间不存在或已解散"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotFound, nil, nil)
 		return
 	}
 
@@ -955,25 +957,25 @@ func (s *Space) joinSpace(c *wkhttp.Context) {
 	if space.JoinMode == JoinModeApproval {
 		// 只读校验邀请码次数（不消耗，审批通过时也跳过）
 		if invitation.MaxUses > 0 && invitation.UsedCount >= invitation.MaxUses {
-			c.ResponseError(errors.New("邀请码已达到使用次数上限"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceInviteCodeExhausted, nil, nil)
 			return
 		}
 
 		// 检查是否已是成员
 		existing, err := s.db.queryMemberIncludeRemoved(invitation.SpaceId, loginUID)
 		if err != nil {
-			c.ResponseError(errors.New("查询成员信息失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 			return
 		}
 		if existing != nil && existing.Status == 1 {
-			c.ResponseError(errors.New("你已经是该空间成员"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceAlreadyMember, nil, nil)
 			return
 		}
 
 		// 检查是否已有待处理申请
 		pendingApply, err := s.db.queryPendingApplyBySpaceAndUID(invitation.SpaceId, loginUID)
 		if err != nil {
-			c.ResponseError(errors.New("查询申请信息失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 			return
 		}
 		if pendingApply != nil {
@@ -992,7 +994,7 @@ func (s *Space) joinSpace(c *wkhttp.Context) {
 			InviteCode: req.InviteCode,
 		})
 		if err != nil {
-			c.ResponseError(errors.New("提交申请失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 			return
 		}
 
@@ -1010,11 +1012,11 @@ func (s *Space) joinSpace(c *wkhttp.Context) {
 	// 直接加入模式：原子检查并递增使用次数
 	allowed, err := s.db.incrementInviteUsedCountAtomic(req.InviteCode)
 	if err != nil {
-		c.ResponseError(errors.New("检查邀请码使用次数失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if !allowed {
-		c.ResponseError(errors.New("邀请码已达到使用次数上限"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceInviteCodeExhausted, nil, nil)
 		return
 	}
 
@@ -1030,10 +1032,10 @@ func (s *Space) joinSpace(c *wkhttp.Context) {
 			return
 		}
 		if errors.Is(joinErr, ErrAlreadyMember) {
-			c.ResponseError(errors.New("你已经是该空间成员"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceAlreadyMember, nil, nil)
 			return
 		}
-		c.ResponseError(errors.New("加入空间失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 
@@ -1130,23 +1132,23 @@ func (s *Space) joinPresetGroups(uid string, spaceID string, presetGroupIdsJSON 
 func (s *Space) getInviteInfo(c *wkhttp.Context) {
 	inviteCode := c.Param("invite_code")
 	if inviteCode == "" {
-		c.ResponseError(errors.New("邀请码不能为空"))
+		respondSpaceRequestInvalid(c, "invite_code")
 		return
 	}
 
 	invitation, err := s.db.queryInvitationByCode(inviteCode)
 	if err != nil {
-		c.ResponseError(errors.New("查询邀请信息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if invitation == nil {
-		c.ResponseError(errors.New("邀请码无效"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceInviteCodeInvalid, nil, nil)
 		return
 	}
 
 	space, err := s.db.querySpaceByID(invitation.SpaceId)
 	if err != nil || space == nil {
-		c.ResponseError(errors.New("空间不存在或已解散"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotFound, nil, nil)
 		return
 	}
 
@@ -1190,23 +1192,23 @@ func (s *Space) GetCoMemberUIDs(uid string) ([]string, error) {
 func (s *Space) getInvitePreview(c *wkhttp.Context) {
 	inviteCode := c.Param("invite_code")
 	if inviteCode == "" {
-		c.ResponseError(errors.New("邀请码不能为空"))
+		respondSpaceRequestInvalid(c, "invite_code")
 		return
 	}
 
 	invitation, err := s.db.queryInvitationByCode(inviteCode)
 	if err != nil {
-		c.ResponseError(errors.New("查询邀请信息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if invitation == nil {
-		c.ResponseError(errors.New("邀请码无效"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceInviteCodeInvalid, nil, nil)
 		return
 	}
 
 	space, err := s.db.querySpaceByID(invitation.SpaceId)
 	if err != nil || space == nil {
-		c.ResponseError(errors.New("空间不存在或已解散"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotFound, nil, nil)
 		return
 	}
 
@@ -1246,36 +1248,36 @@ func (s *Space) updateInvite(c *wkhttp.Context) {
 	// 检查权限（需要管理员或拥有者）
 	member, err := s.db.queryMember(spaceId, loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("查询成员信息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if member == nil || member.Role < 1 {
-		c.ResponseError(errors.New("无权限修改邀请码设置"))
+		httperr.ResponseErrorL(c, errcode.ErrSpacePermissionDenied, nil, nil)
 		return
 	}
 
 	var req updateInviteReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求参数错误"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	if req.MaxUses == nil && req.ExpiresAt == nil && req.Status == nil {
-		c.ResponseError(errors.New("至少需要提供 max_uses / expires_at / status 之一"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	if req.MaxUses != nil && *req.MaxUses < 0 {
-		c.ResponseError(errors.New("max_uses 不能为负"))
+		respondSpaceRequestInvalid(c, "max_uses")
 		return
 	}
 	if req.Status != nil && *req.Status != 0 && *req.Status != 1 {
-		c.ResponseError(errors.New("status 仅支持 0(禁用) 或 1(启用)"))
+		respondSpaceRequestInvalid(c, "status")
 		return
 	}
 
 	// 解析过期时间：与管理端 parseInviteExpiresAt 共用 time.Local 约定，避免双路径写库时区漂移。
 	expiresAt, err := parseInviteExpiresAt(req.ExpiresAt)
 	if err != nil {
-		c.ResponseError(err)
+		respondSpaceRequestInvalid(c, "expires_at")
 		return
 	}
 
@@ -1284,11 +1286,11 @@ func (s *Space) updateInvite(c *wkhttp.Context) {
 	//   - 按 space_id + invite_code 双匹配，天然防跨空间越权
 	affected, err := s.mdb.updateInvitationAdmin(spaceId, code, req.MaxUses, expiresAt, req.Status)
 	if err != nil {
-		c.ResponseError(errors.New("更新邀请码失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	if affected == 0 {
-		c.ResponseError(errors.New("邀请码不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceInviteCodeNotFound, nil, nil)
 		return
 	}
 
@@ -1311,11 +1313,11 @@ func (s *Space) listInvites(c *wkhttp.Context) {
 
 	member, err := s.db.queryMember(spaceId, loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("查询成员信息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if member == nil || member.Role < 1 {
-		c.ResponseError(errors.New("无权限查看邀请码列表"))
+		httperr.ResponseErrorL(c, errcode.ErrSpacePermissionDenied, nil, nil)
 		return
 	}
 
@@ -1328,13 +1330,13 @@ func (s *Space) listInvites(c *wkhttp.Context) {
 	list, err := s.db.queryInvitesBySpace(spaceId, filter, now, uint64(pageSize), uint64(pageIndex))
 	if err != nil {
 		s.Error("查询邀请码列表失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("查询邀请码列表失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	count, err := s.db.countInvitesBySpace(spaceId, filter, now)
 	if err != nil {
 		s.Error("查询邀请码总数失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("查询邀请码总数失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 
@@ -1373,22 +1375,22 @@ func (s *Space) deleteInvite(c *wkhttp.Context) {
 
 	member, err := s.db.queryMember(spaceId, loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("查询成员信息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if member == nil || member.Role < 1 {
-		c.ResponseError(errors.New("无权限禁用邀请码"))
+		httperr.ResponseErrorL(c, errcode.ErrSpacePermissionDenied, nil, nil)
 		return
 	}
 
 	affected, err := s.mdb.disableInvitation(spaceId, code)
 	if err != nil {
 		s.Error("禁用邀请码失败", zap.Error(err), zap.String("code", code))
-		c.ResponseError(errors.New("禁用邀请码失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	if affected == 0 {
-		c.ResponseError(errors.New("邀请码不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceInviteCodeNotFound, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -1416,11 +1418,11 @@ func (s *Space) joinApplies(c *wkhttp.Context) {
 
 	member, err := s.db.queryMember(spaceId, loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("查询成员信息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if member == nil || member.Role < 1 {
-		c.ResponseError(errors.New("无权限查看申请列表"))
+		httperr.ResponseErrorL(c, errcode.ErrSpacePermissionDenied, nil, nil)
 		return
 	}
 
@@ -1438,12 +1440,12 @@ func (s *Space) joinApplies(c *wkhttp.Context) {
 
 	list, err := s.db.queryPendingAppliesBySpace(spaceId, pageSize, offset)
 	if err != nil {
-		c.ResponseError(errors.New("查询申请列表失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	count, err := s.db.queryPendingApplyCountBySpace(spaceId)
 	if err != nil {
-		c.ResponseError(errors.New("查询申请数量失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 
@@ -1480,48 +1482,48 @@ func (s *Space) approveJoinApply(c *wkhttp.Context) {
 
 	applyID, err := strconv.ParseInt(applyIDStr, 10, 64)
 	if err != nil || applyID <= 0 {
-		c.ResponseError(errors.New("申请ID无效"))
+		respondSpaceRequestInvalid(c, "apply_id")
 		return
 	}
 
 	member, err := s.db.queryMember(spaceId, loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("查询成员信息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if member == nil || member.Role < 1 {
-		c.ResponseError(errors.New("无权限审批"))
+		httperr.ResponseErrorL(c, errcode.ErrSpacePermissionDenied, nil, nil)
 		return
 	}
 
 	apply, err := s.db.queryJoinApplyByID(applyID)
 	if err != nil {
-		c.ResponseError(errors.New("查询申请记录失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if apply == nil {
-		c.ResponseError(errors.New("申请记录不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceApplyNotFound, nil, nil)
 		return
 	}
 	if apply.SpaceId != spaceId {
-		c.ResponseError(errors.New("申请记录不属于当前空间"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceApplyNotFound, nil, nil)
 		return
 	}
 	if apply.Status != 0 {
-		c.ResponseError(errors.New("该申请已被处理"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceApplyProcessed, nil, nil)
 		return
 	}
 
 	space, err := s.db.querySpaceByID(spaceId)
 	if err != nil || space == nil {
-		c.ResponseError(errors.New("空间不存在或已解散"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotFound, nil, nil)
 		return
 	}
 
 	// 先更新申请状态（防止并发审批 + 确保加入后状态一致）
 	affected, err := s.db.updateJoinApplyStatus(applyID, 1, loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("更新申请状态失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	if affected == 0 {
@@ -1536,14 +1538,14 @@ func (s *Space) approveJoinApply(c *wkhttp.Context) {
 		if _, rbErr := s.db.updateJoinApplyStatusRaw(applyID, 0, ""); rbErr != nil {
 			s.Error("回滚申请状态失败", zap.Error(rbErr), zap.Int64("applyID", applyID))
 		}
-		c.ResponseError(errors.New("检查邀请码使用次数失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if apply.InviteCode != "" && !inviteConsumed {
 		if _, rbErr := s.db.updateJoinApplyStatusRaw(applyID, 0, ""); rbErr != nil {
 			s.Error("回滚申请状态失败", zap.Error(rbErr), zap.Int64("applyID", applyID))
 		}
-		c.ResponseError(errors.New("该邀请码已用尽或已失效，无法通过此申请"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceInviteCodeExhausted, nil, nil)
 		return
 	}
 
@@ -1552,7 +1554,7 @@ func (s *Space) approveJoinApply(c *wkhttp.Context) {
 	if joinErr != nil {
 		if errors.Is(joinErr, ErrSpaceFull) {
 			s.rollbackApplyAndInvite(applyID, apply.InviteCode, inviteConsumed)
-			c.ResponseError(errors.New("空间已满，无法通过申请"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceFull, nil, nil)
 			return
 		}
 		if errors.Is(joinErr, ErrAlreadyMember) {
@@ -1564,7 +1566,7 @@ func (s *Space) approveJoinApply(c *wkhttp.Context) {
 			return
 		}
 		s.rollbackApplyAndInvite(applyID, apply.InviteCode, inviteConsumed)
-		c.ResponseError(errors.New("加入空间失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 
@@ -1610,41 +1612,41 @@ func (s *Space) rejectJoinApply(c *wkhttp.Context) {
 
 	applyID, err := strconv.ParseInt(applyIDStr, 10, 64)
 	if err != nil || applyID <= 0 {
-		c.ResponseError(errors.New("申请ID无效"))
+		respondSpaceRequestInvalid(c, "apply_id")
 		return
 	}
 
 	member, err := s.db.queryMember(spaceId, loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("查询成员信息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if member == nil || member.Role < 1 {
-		c.ResponseError(errors.New("无权限审批"))
+		httperr.ResponseErrorL(c, errcode.ErrSpacePermissionDenied, nil, nil)
 		return
 	}
 
 	apply, err := s.db.queryJoinApplyByID(applyID)
 	if err != nil {
-		c.ResponseError(errors.New("查询申请记录失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if apply == nil {
-		c.ResponseError(errors.New("申请记录不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceApplyNotFound, nil, nil)
 		return
 	}
 	if apply.SpaceId != spaceId {
-		c.ResponseError(errors.New("申请记录不属于当前空间"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceApplyNotFound, nil, nil)
 		return
 	}
 	if apply.Status != 0 {
-		c.ResponseError(errors.New("该申请已被处理"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceApplyProcessed, nil, nil)
 		return
 	}
 
 	_, err = s.db.updateJoinApplyStatus(applyID, 2, loginUID)
 	if err != nil {
-		c.ResponseError(errors.New("更新申请状态失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 
@@ -1750,7 +1752,7 @@ func (s *Space) notifyApplicantJoinResult(applicantUID, spaceId, spaceName strin
 func (s *Space) joinApprovePage(c *wkhttp.Context) {
 	htmlBytes, err := os.ReadFile("./assets/web/space_join_approve.html")
 	if err != nil {
-		c.ResponseError(errors.New("页面加载失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	safeBaseURL := strconv.Quote(s.ctx.GetConfig().External.BaseURL)
@@ -1762,25 +1764,25 @@ func (s *Space) joinApprovePage(c *wkhttp.Context) {
 func (s *Space) joinApproveDetail(c *wkhttp.Context) {
 	authCode := c.Query("auth_code")
 	if authCode == "" {
-		c.ResponseError(errors.New("auth_code 不能为空"))
+		respondSpaceRequestInvalid(c, "auth_code")
 		return
 	}
 
 	authInfo, err := s.ctx.GetRedisConn().GetString(fmt.Sprintf("%s%s", common.AuthCodeCachePrefix, authCode))
 	if err != nil || authInfo == "" {
-		c.ResponseError(errors.New("授权码无效或已过期"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceInviteCodeInvalid, nil, nil)
 		return
 	}
 
 	var authMap map[string]interface{}
 	if err := util.ReadJsonByByte([]byte(authInfo), &authMap); err != nil {
-		c.ResponseError(errors.New("授权信息解析失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceInviteCodeInvalid, nil, nil)
 		return
 	}
 
 	authType, _ := authMap["type"].(string)
 	if authType != "spaceJoinApprove" {
-		c.ResponseError(errors.New("授权码类型无效"))
+		respondSpaceRequestInvalid(c, "auth_code")
 		return
 	}
 
@@ -1790,7 +1792,7 @@ func (s *Space) joinApproveDetail(c *wkhttp.Context) {
 
 	apply, err := s.db.queryJoinApplyByID(applyID)
 	if err != nil || apply == nil {
-		c.ResponseError(errors.New("申请记录不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceApplyNotFound, nil, nil)
 		return
 	}
 
@@ -1846,18 +1848,18 @@ func (s *Space) joinApproveSure(c *wkhttp.Context) {
 	authCode := c.Query("auth_code")
 	action := c.Query("action")
 	if authCode == "" {
-		c.ResponseError(errors.New("auth_code 不能为空"))
+		respondSpaceRequestInvalid(c, "auth_code")
 		return
 	}
 	if action != "approve" && action != "reject" {
-		c.ResponseError(errors.New("action 必须是 approve 或 reject"))
+		respondSpaceRequestInvalid(c, "action")
 		return
 	}
 
 	cacheKey := fmt.Sprintf("%s%s", common.AuthCodeCachePrefix, authCode)
 	authInfo, err := s.ctx.GetRedisConn().GetString(cacheKey)
 	if err != nil || authInfo == "" {
-		c.ResponseError(errors.New("授权码无效或已过期"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceInviteCodeInvalid, nil, nil)
 		return
 	}
 	// 保留 auth_code 让其自然过期，审批后仍可查看详情
@@ -1865,13 +1867,13 @@ func (s *Space) joinApproveSure(c *wkhttp.Context) {
 
 	var authMap map[string]interface{}
 	if err := util.ReadJsonByByte([]byte(authInfo), &authMap); err != nil {
-		c.ResponseError(errors.New("授权信息解析失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceInviteCodeInvalid, nil, nil)
 		return
 	}
 
 	authType, _ := authMap["type"].(string)
 	if authType != "spaceJoinApprove" {
-		c.ResponseError(errors.New("授权码类型无效"))
+		respondSpaceRequestInvalid(c, "auth_code")
 		return
 	}
 
@@ -1882,28 +1884,28 @@ func (s *Space) joinApproveSure(c *wkhttp.Context) {
 
 	apply, err := s.db.queryJoinApplyByID(applyID)
 	if err != nil || apply == nil {
-		c.ResponseError(errors.New("申请记录不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceApplyNotFound, nil, nil)
 		return
 	}
 	if apply.SpaceId != spaceId {
-		c.ResponseError(errors.New("申请记录不属于当前空间"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceApplyNotFound, nil, nil)
 		return
 	}
 	if apply.Status != 0 {
-		c.ResponseError(errors.New("该申请已被处理"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceApplyProcessed, nil, nil)
 		return
 	}
 
 	space, err := s.db.querySpaceByID(spaceId)
 	if err != nil || space == nil {
-		c.ResponseError(errors.New("空间不存在或已解散"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotFound, nil, nil)
 		return
 	}
 
 	if action == "approve" {
 		affected, err := s.db.updateJoinApplyStatus(applyID, 1, reviewerUID)
 		if err != nil {
-			c.ResponseError(errors.New("更新申请状态失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 			return
 		}
 		if affected == 0 {
@@ -1916,14 +1918,14 @@ func (s *Space) joinApproveSure(c *wkhttp.Context) {
 			if _, rbErr := s.db.updateJoinApplyStatusRaw(applyID, 0, ""); rbErr != nil {
 				s.Error("回滚申请状态失败", zap.Error(rbErr), zap.Int64("applyID", applyID))
 			}
-			c.ResponseError(errors.New("检查邀请码使用次数失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 			return
 		}
 		if apply.InviteCode != "" && !inviteConsumed {
 			if _, rbErr := s.db.updateJoinApplyStatusRaw(applyID, 0, ""); rbErr != nil {
 				s.Error("回滚申请状态失败", zap.Error(rbErr), zap.Int64("applyID", applyID))
 			}
-			c.ResponseError(errors.New("该邀请码已用尽或已失效，无法通过此申请"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceInviteCodeExhausted, nil, nil)
 			return
 		}
 
@@ -1931,7 +1933,7 @@ func (s *Space) joinApproveSure(c *wkhttp.Context) {
 		if joinErr != nil {
 			if errors.Is(joinErr, ErrSpaceFull) {
 				s.rollbackApplyAndInvite(applyID, apply.InviteCode, inviteConsumed)
-				c.ResponseError(errors.New("空间已满，无法通过申请"))
+				httperr.ResponseErrorL(c, errcode.ErrSpaceFull, nil, nil)
 				return
 			}
 			if errors.Is(joinErr, ErrAlreadyMember) {
@@ -1941,7 +1943,7 @@ func (s *Space) joinApproveSure(c *wkhttp.Context) {
 				}
 			} else {
 				s.rollbackApplyAndInvite(applyID, apply.InviteCode, inviteConsumed)
-				c.ResponseError(errors.New("加入空间失败"))
+				httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 				return
 			}
 		}
@@ -1950,7 +1952,7 @@ func (s *Space) joinApproveSure(c *wkhttp.Context) {
 	} else {
 		_, err = s.db.updateJoinApplyStatus(applyID, 2, reviewerUID)
 		if err != nil {
-			c.ResponseError(errors.New("更新申请状态失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 			return
 		}
 		go s.notifyApplicantJoinResult(apply.UID, spaceId, space.Name, false)

--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -1025,10 +1025,7 @@ func (s *Space) joinSpace(c *wkhttp.Context) {
 	if joinErr != nil {
 		s.refundInvite(req.InviteCode)
 		if errors.Is(joinErr, ErrSpaceFull) {
-			c.ResponseWithStatus(http.StatusBadRequest, map[string]interface{}{
-				"status": "SPACE_FULL",
-				"msg":    "空间已满，无法加入",
-			})
+			httperr.ResponseErrorL(c, errcode.ErrSpaceFull, nil, nil)
 			return
 		}
 		if errors.Is(joinErr, ErrAlreadyMember) {

--- a/modules/space/api_email_invite.go
+++ b/modules/space/api_email_invite.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/pkg/db"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"go.uber.org/zap"
 )
 
@@ -22,12 +24,11 @@ func (s *Space) createMemberEmailInvite(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	spaceId := c.Param("space_id")
 	if spaceId == "" {
-		c.ResponseError(errors.New("空间ID不能为空"))
+		respondSpaceRequestInvalid(c, "space_id")
 		return
 	}
 
-	if err := s.requireSpaceAdmin(spaceId, loginUID); err != nil {
-		c.ResponseError(err)
+	if s.requireSpaceAdmin(c, spaceId, loginUID) {
 		return
 	}
 	if s.checkSpaceActive(c, spaceId) {
@@ -36,23 +37,23 @@ func (s *Space) createMemberEmailInvite(c *wkhttp.Context) {
 
 	var req spaceMemberEmailInviteReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求参数错误"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	if err := validateMemberInviteReq(&req); err != nil {
-		c.ResponseError(err)
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	expiresAt, err := parseInviteExpiresAt(req.ExpiresAt)
 	if err != nil {
-		c.ResponseError(err)
+		respondSpaceRequestInvalid(c, "expires_at")
 		return
 	}
 
 	rawToken, tokenHash, err := generateEmailInviteToken()
 	if err != nil {
 		s.Error("生成邀请 token 失败", zap.Error(err))
-		c.ResponseError(errors.New("生成邀请失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 
@@ -72,7 +73,7 @@ func (s *Space) createMemberEmailInvite(c *wkhttp.Context) {
 	id, err := s.db.insertEmailInvite(model)
 	if err != nil {
 		s.Error("写入 member 邮件邀请失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("创建邀请失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	model.Id = id
@@ -95,11 +96,10 @@ func (s *Space) listMemberEmailInvites(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	spaceId := c.Param("space_id")
 	if spaceId == "" {
-		c.ResponseError(errors.New("空间ID不能为空"))
+		respondSpaceRequestInvalid(c, "space_id")
 		return
 	}
-	if err := s.requireSpaceAdmin(spaceId, loginUID); err != nil {
-		c.ResponseError(err)
+	if s.requireSpaceAdmin(c, spaceId, loginUID) {
 		return
 	}
 
@@ -110,7 +110,7 @@ func (s *Space) listMemberEmailInvites(c *wkhttp.Context) {
 	list, count, err := s.db.listEmailInvitesBySpace(spaceId, statusFilter, pageSize, offset)
 	if err != nil {
 		s.Error("查询 member 邀请列表失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("查询邀请列表失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	resp := make([]*managerEmailInviteResp, 0, len(list))
@@ -128,53 +128,56 @@ func (s *Space) revokeMemberEmailInvite(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	spaceId := c.Param("space_id")
 	if spaceId == "" {
-		c.ResponseError(errors.New("空间ID不能为空"))
+		respondSpaceRequestInvalid(c, "space_id")
 		return
 	}
-	if err := s.requireSpaceAdmin(spaceId, loginUID); err != nil {
-		c.ResponseError(err)
+	if s.requireSpaceAdmin(c, spaceId, loginUID) {
 		return
 	}
 
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil || id <= 0 {
-		c.ResponseError(errors.New("邀请ID无效"))
+		respondSpaceRequestInvalid(c, "invite_id")
 		return
 	}
 	inv, err := s.db.queryEmailInviteByID(id)
 	if err != nil {
 		s.Error("查询邀请失败", zap.Error(err), zap.Int64("id", id))
-		c.ResponseError(errors.New("查询邀请失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if inv == nil || inv.InviteType != EmailInviteTypeMember || inv.SpaceId != spaceId {
-		c.ResponseError(errors.New("邀请不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceEmailInviteNotFound, nil, nil)
 		return
 	}
 	affected, err := s.db.revokeEmailInvite(id)
 	if err != nil {
 		s.Error("撤销邀请失败", zap.Error(err), zap.Int64("id", id))
-		c.ResponseError(errors.New("撤销邀请失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	if affected == 0 {
-		c.ResponseError(errors.New("仅 pending 状态邀请可撤销"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceEmailInviteProcessed, nil, nil)
 		return
 	}
 	c.ResponseOK()
 }
 
-// requireSpaceAdmin 校验 loginUID 是 spaceId 下的 admin/owner。
-// 未达要求时返回带说明的 error，调用方直接 ResponseError。
-func (s *Space) requireSpaceAdmin(spaceId, loginUID string) error {
+// requireSpaceAdmin 校验 loginUID 是 spaceId 下的 admin/owner。返回 true 表示已
+// 写出错误响应、调用方应直接 return（与 checkSpaceActive 同模式，避免向调用方
+// 透传服务层错误字符串）。
+func (s *Space) requireSpaceAdmin(c *wkhttp.Context, spaceId, loginUID string) bool {
 	member, err := s.db.queryMember(spaceId, loginUID)
 	if err != nil {
-		return errors.New("查询成员信息失败")
+		s.Error("查询成员信息失败", zap.Error(err), zap.String("spaceId", spaceId))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
+		return true
 	}
 	if member == nil || member.Role < 1 {
-		return errors.New("无权限操作")
+		httperr.ResponseErrorL(c, errcode.ErrSpacePermissionDenied, nil, nil)
+		return true
 	}
-	return nil
+	return false
 }
 
 // validateMemberInviteReq 校验 member 邀请请求参数。

--- a/modules/space/api_email_invite_public.go
+++ b/modules/space/api_email_invite_public.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"go.uber.org/zap"
 )
 
@@ -18,7 +20,7 @@ func (s *Space) emailInvitePage(c *wkhttp.Context) {
 	htmlBytes, err := os.ReadFile("./assets/web/space_email_invite.html")
 	if err != nil {
 		s.Error("加载邮件邀请落地页失败", zap.Error(err))
-		c.ResponseError(errors.New("页面加载失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	safeBaseURL := strconv.Quote(s.ctx.GetConfig().External.BaseURL)
@@ -73,13 +75,13 @@ type emailInvitePreviewResp struct {
 func (s *Space) previewEmailInvite(c *wkhttp.Context) {
 	rawToken := c.Param("token")
 	if rawToken == "" {
-		c.ResponseError(errors.New("token 不能为空"))
+		respondSpaceRequestInvalid(c, "token")
 		return
 	}
 	inv, err := s.db.queryEmailInviteByTokenHash(hashEmailInviteToken(rawToken))
 	if err != nil {
 		s.Error("查询邮件邀请失败", zap.Error(err))
-		c.ResponseError(errors.New("查询邀请失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if inv == nil {
@@ -149,58 +151,58 @@ func (s *Space) acceptEmailInvite(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	rawToken := c.Param("token")
 	if rawToken == "" {
-		c.ResponseError(errors.New("token 不能为空"))
+		respondSpaceRequestInvalid(c, "token")
 		return
 	}
 
 	var req acceptEmailInviteReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求参数错误"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	typedEmail := strings.ToLower(strings.TrimSpace(req.Email))
 	if typedEmail == "" {
-		c.ResponseError(errors.New("请输入邮箱以确认接受"))
+		respondSpaceRequestInvalid(c, "email")
 		return
 	}
 
 	inv, err := s.db.queryEmailInviteByTokenHash(hashEmailInviteToken(rawToken))
 	if err != nil {
 		s.Error("查询邮件邀请失败", zap.Error(err))
-		c.ResponseError(errors.New("查询邀请失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if inv == nil {
-		c.ResponseError(errors.New("邀请无效"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceEmailInviteInvalid, nil, nil)
 		return
 	}
 	if inv.Status != EmailInviteStatusPending {
-		c.ResponseError(errors.New("邀请已被处理或已撤销"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceEmailInviteProcessed, nil, nil)
 		return
 	}
 	if inv.ExpiresAt != nil && time.Time(*inv.ExpiresAt).Before(time.Now()) {
-		c.ResponseError(errors.New("邀请已过期"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceEmailInviteInvalid, nil, nil)
 		return
 	}
 
 	if inv.Email == "" {
 		// 历史脏数据兜底：邀请记录无邮箱时直接拒绝，避免空字符串自匹配。
-		c.ResponseError(errors.New("邀请缺少邮箱信息，无法接受"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceEmailInviteInvalid, nil, nil)
 		return
 	}
 	if !strings.EqualFold(typedEmail, inv.Email) {
-		c.ResponseError(errors.New("输入的邮箱与邀请目标不一致"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceEmailInviteEmailMismatch, nil, nil)
 		return
 	}
 	loginEmail, err := s.db.queryUserEmail(loginUID)
 	if err != nil {
 		s.Error("查询登录用户邮箱失败", zap.Error(err), zap.String("loginUID", loginUID))
-		c.ResponseError(errors.New("校验邮箱失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	loginEmail = strings.TrimSpace(loginEmail)
 	if loginEmail == "" || !strings.EqualFold(loginEmail, inv.Email) {
-		c.ResponseError(errors.New("当前登录账号邮箱与邀请目标不一致"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceEmailInviteEmailMismatch, nil, nil)
 		return
 	}
 
@@ -210,7 +212,7 @@ func (s *Space) acceptEmailInvite(c *wkhttp.Context) {
 	case EmailInviteTypeMember:
 		s.acceptMemberInvite(c, inv, loginUID)
 	default:
-		c.ResponseError(errors.New("邀请类型未知"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceEmailInviteInvalid, nil, nil)
 	}
 }
 
@@ -218,7 +220,7 @@ func (s *Space) acceptOwnerInvite(c *wkhttp.Context, inv *spaceEmailInviteModel,
 	tx, err := s.ctx.DB().Begin()
 	if err != nil {
 		s.Error("开启事务失败", zap.Error(err))
-		c.ResponseError(errors.New("接受邀请失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	defer tx.RollbackUnlessCommitted()
@@ -226,11 +228,11 @@ func (s *Space) acceptOwnerInvite(c *wkhttp.Context, inv *spaceEmailInviteModel,
 	affected, err := s.db.consumeEmailInviteTx(tx, inv.Id, loginUID)
 	if err != nil {
 		s.Error("消费 token 失败", zap.Error(err), zap.Int64("inviteID", inv.Id))
-		c.ResponseError(errors.New("接受邀请失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	if affected == 0 {
-		c.ResponseError(errors.New("邀请已被处理或已过期"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceEmailInviteProcessed, nil, nil)
 		return
 	}
 
@@ -245,12 +247,12 @@ func (s *Space) acceptOwnerInvite(c *wkhttp.Context, inv *spaceEmailInviteModel,
 	spaceId, err := s.createSpaceCoreTx(tx, params)
 	if err != nil {
 		s.Error("创建空间失败", zap.Error(err), zap.Int64("inviteID", inv.Id))
-		c.ResponseError(errors.New("创建空间失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	if err = tx.Commit(); err != nil {
 		s.Error("提交事务失败", zap.Error(err), zap.Int64("inviteID", inv.Id))
-		c.ResponseError(errors.New("接受邀请失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 
@@ -265,13 +267,13 @@ func (s *Space) acceptMemberInvite(c *wkhttp.Context, inv *spaceEmailInviteModel
 	space, err := s.db.querySpaceByID(inv.SpaceId)
 	if err != nil {
 		s.Error("查询空间失败", zap.Error(err), zap.String("spaceId", inv.SpaceId))
-		c.ResponseError(errors.New("查询空间失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if space == nil || space.Status != SpaceStatusNormal {
 		// 显式 defense-in-depth：即使 querySpaceByID 已过滤 status=1，未来若放宽条件也不会
 		// 让 token 在已解散/封禁空间上被消耗。
-		c.ResponseError(errors.New("空间不存在或已解散"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotFound, nil, nil)
 		return
 	}
 
@@ -280,7 +282,7 @@ func (s *Space) acceptMemberInvite(c *wkhttp.Context, inv *spaceEmailInviteModel
 	tx, err := s.ctx.DB().Begin()
 	if err != nil {
 		s.Error("开启事务失败", zap.Error(err))
-		c.ResponseError(errors.New("接受邀请失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	defer tx.RollbackUnlessCommitted()
@@ -288,16 +290,16 @@ func (s *Space) acceptMemberInvite(c *wkhttp.Context, inv *spaceEmailInviteModel
 	affected, err := s.db.consumeEmailInviteTx(tx, inv.Id, loginUID)
 	if err != nil {
 		s.Error("消费 token 失败", zap.Error(err), zap.Int64("inviteID", inv.Id))
-		c.ResponseError(errors.New("接受邀请失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	if affected == 0 {
-		c.ResponseError(errors.New("邀请已被处理或已过期"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceEmailInviteProcessed, nil, nil)
 		return
 	}
 	if err = tx.Commit(); err != nil {
 		s.Error("提交 token 消费失败", zap.Error(err), zap.Int64("inviteID", inv.Id))
-		c.ResponseError(errors.New("接受邀请失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 
@@ -309,11 +311,11 @@ func (s *Space) acceptMemberInvite(c *wkhttp.Context, inv *spaceEmailInviteModel
 		} else {
 			s.rollbackConsumedInvite(inv.Id, loginUID)
 			if errors.Is(err, ErrSpaceFull) {
-				c.ResponseError(errors.New("空间已满，无法加入"))
+				httperr.ResponseErrorL(c, errcode.ErrSpaceFull, nil, nil)
 				return
 			}
 			s.Error("加入空间失败", zap.Error(err), zap.String("spaceId", inv.SpaceId))
-			c.ResponseError(errors.New("加入空间失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 			return
 		}
 	}

--- a/modules/space/api_i18n.go
+++ b/modules/space/api_i18n.go
@@ -1,0 +1,45 @@
+package space
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+// respond helpers for modules/space. Most migrated sites call
+// httperr.ResponseErrorL(c, errcode.ErrSpaceXxx, nil, nil) directly; the helpers
+// below exist only for the shapes that carry a Detail field, so the
+// SafeDetailKeys contract stays in one place.
+//
+// Internal=true codes (ErrSpaceQueryFailed / ErrSpaceStoreFailed) are
+// intentionally NOT wrapped here: each call site keeps its existing
+// s.Error(..., zap.Error(err)) log so ops can debug from logs, and the renderer
+// carries no message on the wire.
+
+// respondSpaceRequestInvalid covers the common BindJSON-failure / "X 不能为空" /
+// invalid-enum shape — one code, one optional field detail. An empty field is
+// omitted so the renderer does not surface a noisy empty key to clients.
+func respondSpaceRequestInvalid(c *wkhttp.Context, field string) {
+	details := i18n.Details{}
+	if field != "" {
+		details["field"] = field
+	}
+	httperr.ResponseErrorL(c, errcode.ErrSpaceRequestInvalid, nil, details)
+}
+
+// respondSpaceFieldTooLong surfaces the offending field and its max length so
+// the client can render a localized hint without hard-coding the limit.
+func respondSpaceFieldTooLong(c *wkhttp.Context, field string, maxChars int) {
+	httperr.ResponseErrorL(c, errcode.ErrSpaceFieldTooLong, nil, i18n.Details{
+		"field":     field,
+		"max_chars": maxChars,
+	})
+}
+
+// respondSpaceBatchTooLarge surfaces the per-request member batch cap.
+func respondSpaceBatchTooLarge(c *wkhttp.Context, max int) {
+	httperr.ResponseErrorL(c, errcode.ErrSpaceBatchTooLarge, nil, i18n.Details{
+		"max": max,
+	})
+}

--- a/modules/space/api_i18n_test.go
+++ b/modules/space/api_i18n_test.go
@@ -1,0 +1,258 @@
+package space
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// httperrL is a terse shim for the no-params/no-details ResponseErrorL shape.
+func httperrL(c *wkhttp.Context, code codes.Code) {
+	httperr.ResponseErrorL(c, code, nil, nil)
+}
+
+// TestSpaceNoLegacyResponseError pins the Phase 2.1 contract that the migrated
+// modules/space handlers do not regress to legacy octo-lib error responses.
+// Comments are stripped first so commented-out breadcrumbs do not trip the guard.
+func TestSpaceNoLegacyResponseError(t *testing.T) {
+	files := []string{
+		"api.go",
+		"api_manager.go",
+		"api_email_invite.go",
+		"api_email_invite_public.go",
+		"api_manager_email_invite.go",
+	}
+	banned := []string{
+		".ResponseError(",
+		".ResponseErrorf(",
+		".ResponseErrorWithStatus(",
+		".AbortWithStatusJSON(",
+		".AbortWithStatus(",
+		"c.Response(\"",
+	}
+	for _, f := range files {
+		t.Run(f, func(t *testing.T) {
+			data, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+			var clean strings.Builder
+			for _, line := range strings.Split(string(data), "\n") {
+				if idx := strings.Index(line, "//"); idx >= 0 {
+					line = line[:idx]
+				}
+				clean.WriteString(line)
+				clean.WriteByte('\n')
+			}
+			if cleaned := clean.String(); func() bool {
+				for _, b := range banned {
+					if strings.Contains(cleaned, b) {
+						t.Errorf("modules/space/%s must use httperr.ResponseErrorL via respondSpace* helpers / errcode.ErrSpace* instead of legacy %s", f, b)
+						return true
+					}
+				}
+				return false
+			}() {
+				return
+			}
+		})
+	}
+}
+
+type spaceErrEnvelope struct {
+	Error struct {
+		Code       string         `json:"code"`
+		Message    string         `json:"message"`
+		Details    map[string]any `json:"details"`
+		HTTPStatus int            `json:"http_status"`
+	} `json:"error"`
+	Msg    string `json:"msg"`
+	Status int    `json:"status"`
+}
+
+func decodeSpaceEnvelope(t *testing.T, body []byte) spaceErrEnvelope {
+	t.Helper()
+	var env spaceErrEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("decode envelope: %v\nbody: %s", err, body)
+	}
+	return env
+}
+
+// assertSpaceErrorCode asserts the migrated dual envelope carries the expected
+// error.code, replacing brittle zh-CN body-substring matching in the integration
+// tests so future copy edits do not break them.
+func assertSpaceErrorCode(t *testing.T, w *httptest.ResponseRecorder, wantCode string) {
+	t.Helper()
+	env := decodeSpaceEnvelope(t, w.Body.Bytes())
+	if env.Error.Code != wantCode {
+		t.Fatalf("error.code = %q, want %q\nbody: %s", env.Error.Code, wantCode, w.Body.String())
+	}
+}
+
+// spaceHelperHarness mounts a single GET /probe route with the i18n renderer
+// wired, so helper assertions need no DB / auth setup.
+func spaceHelperHarness(probe func(c *wkhttp.Context)) *wkhttp.WKHttp {
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	r.GET("/probe", probe)
+	return r
+}
+
+func TestRespondSpaceHelpers(t *testing.T) {
+	cases := []struct {
+		name            string
+		probe           func(c *wkhttp.Context)
+		wantCodeID      string
+		wantSemStatus   int
+		wantContains    string
+		wantNotContains string
+		wantDetails     map[string]any
+	}{
+		{
+			name:          "respondSpaceRequestInvalid carries the field detail",
+			probe:         func(c *wkhttp.Context) { respondSpaceRequestInvalid(c, "name") },
+			wantCodeID:    "err.server.space.request_invalid",
+			wantSemStatus: http.StatusBadRequest,
+			wantContains:  "请求参数有误",
+			wantDetails:   map[string]any{"field": "name"},
+		},
+		{
+			name:          "respondSpaceRequestInvalid drops empty field key",
+			probe:         func(c *wkhttp.Context) { respondSpaceRequestInvalid(c, "") },
+			wantCodeID:    "err.server.space.request_invalid",
+			wantSemStatus: http.StatusBadRequest,
+			wantContains:  "请求参数有误",
+			wantDetails:   map[string]any{},
+		},
+		{
+			name:          "respondSpaceFieldTooLong surfaces the length cap",
+			probe:         func(c *wkhttp.Context) { respondSpaceFieldTooLong(c, "description", 200) },
+			wantCodeID:    "err.server.space.field_too_long",
+			wantSemStatus: http.StatusBadRequest,
+			wantDetails:   map[string]any{"field": "description", "max_chars": float64(200)},
+		},
+		{
+			name:          "respondSpaceBatchTooLarge surfaces the batch cap",
+			probe:         func(c *wkhttp.Context) { respondSpaceBatchTooLarge(c, 50) },
+			wantCodeID:    "err.server.space.batch_too_large",
+			wantSemStatus: http.StatusBadRequest,
+			wantDetails:   map[string]any{"max": float64(50)},
+		},
+		{
+			name:          "ErrSpacePermissionDenied 403",
+			probe:         func(c *wkhttp.Context) { httperrL(c, errcode.ErrSpacePermissionDenied) },
+			wantCodeID:    "err.server.space.permission_denied",
+			wantSemStatus: http.StatusForbidden,
+			wantContains:  "没有权限",
+		},
+		{
+			name:          "ErrSpaceCreationDisabled 403",
+			probe:         func(c *wkhttp.Context) { httperrL(c, errcode.ErrSpaceCreationDisabled) },
+			wantCodeID:    "err.server.space.creation_disabled",
+			wantSemStatus: http.StatusForbidden,
+			wantContains:  "关闭空间创建",
+		},
+		{
+			name:          "ErrSpaceNotFound 404",
+			probe:         func(c *wkhttp.Context) { httperrL(c, errcode.ErrSpaceNotFound) },
+			wantCodeID:    "err.server.space.not_found",
+			wantSemStatus: http.StatusNotFound,
+			wantContains:  "空间不存在",
+		},
+		{
+			name:          "ErrSpaceFull 409",
+			probe:         func(c *wkhttp.Context) { httperrL(c, errcode.ErrSpaceFull) },
+			wantCodeID:    "err.server.space.full",
+			wantSemStatus: http.StatusConflict,
+			wantContains:  "空间已满",
+		},
+		{
+			name:          "ErrSpaceInviteCodeInvalid 400 (public anti-enum)",
+			probe:         func(c *wkhttp.Context) { httperrL(c, errcode.ErrSpaceInviteCodeInvalid) },
+			wantCodeID:    "err.server.space.invite_code_invalid",
+			wantSemStatus: http.StatusBadRequest,
+			wantContains:  "邀请码无效",
+		},
+		{
+			name:          "ErrSpaceEmailInviteEmailMismatch 403",
+			probe:         func(c *wkhttp.Context) { httperrL(c, errcode.ErrSpaceEmailInviteEmailMismatch) },
+			wantCodeID:    "err.server.space.email_invite_email_mismatch",
+			wantSemStatus: http.StatusForbidden,
+			wantContains:  "邮箱与邀请目标不一致",
+		},
+		{
+			name:            "ErrSpaceQueryFailed collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrSpaceQueryFailed) },
+			wantCodeID:      "err.server.space.query_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "query space data",
+		},
+		{
+			name:            "ErrSpaceStoreFailed collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrSpaceStoreFailed) },
+			wantCodeID:      "err.server.space.store_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "update space data",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := spaceHelperHarness(tc.probe)
+			req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+			req.Header.Set("Accept-Language", "zh-CN")
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			// All helpers use the D14 ResponseErrorL path → wire 400.
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("HTTP status = %d, want 400 (D14); body=%s", rec.Code, rec.Body.String())
+			}
+			env := decodeSpaceEnvelope(t, rec.Body.Bytes())
+			if env.Error.Code != tc.wantCodeID {
+				t.Fatalf("error.code = %q, want %q", env.Error.Code, tc.wantCodeID)
+			}
+			if env.Error.HTTPStatus != tc.wantSemStatus {
+				t.Fatalf("error.http_status = %d, want %d", env.Error.HTTPStatus, tc.wantSemStatus)
+			}
+			if env.Status != http.StatusBadRequest {
+				t.Fatalf("legacy status = %d, want 400 (D14)", env.Status)
+			}
+			if env.Msg != env.Error.Message {
+				t.Fatalf("legacy msg %q != error.message %q", env.Msg, env.Error.Message)
+			}
+			if tc.wantContains != "" && !strings.Contains(env.Error.Message, tc.wantContains) {
+				t.Fatalf("error.message = %q, want substring %q", env.Error.Message, tc.wantContains)
+			}
+			if tc.wantNotContains != "" && strings.Contains(env.Error.Message, tc.wantNotContains) {
+				t.Fatalf("error.message = %q must not contain %q (Internal leak)", env.Error.Message, tc.wantNotContains)
+			}
+			if tc.wantDetails != nil {
+				got := env.Error.Details
+				if got == nil {
+					got = map[string]any{}
+				}
+				if len(got) != len(tc.wantDetails) {
+					t.Fatalf("error.details = %#v, want %#v", got, tc.wantDetails)
+				}
+				for k, v := range tc.wantDetails {
+					if got[k] != v {
+						t.Fatalf("error.details[%q] = %#v, want %#v", k, got[k], v)
+					}
+				}
+			}
+		})
+	}
+}

--- a/modules/space/api_i18n_test.go
+++ b/modules/space/api_i18n_test.go
@@ -35,6 +35,7 @@ func TestSpaceNoLegacyResponseError(t *testing.T) {
 		".ResponseError(",
 		".ResponseErrorf(",
 		".ResponseErrorWithStatus(",
+		".ResponseWithStatus(",
 		".AbortWithStatusJSON(",
 		".AbortWithStatus(",
 		"c.Response(\"",

--- a/modules/space/api_invites_test.go
+++ b/modules/space/api_invites_test.go
@@ -194,7 +194,7 @@ func TestListInvites_MemberForbidden(t *testing.T) {
 	req.Header.Set("token", testutil.Token)
 	s.GetRoute().ServeHTTP(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "无权限")
+	assertSpaceErrorCode(t, w, "err.server.space.permission_denied")
 }
 
 // TestListInvites_NonMemberForbidden: 非空间成员完全不可访问。
@@ -213,7 +213,7 @@ func TestListInvites_NonMemberForbidden(t *testing.T) {
 	req.Header.Set("token", testutil.Token)
 	s.GetRoute().ServeHTTP(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "无权限")
+	assertSpaceErrorCode(t, w, "err.server.space.permission_denied")
 }
 
 // TestDeleteInvite_SoftDisable: admin 可软禁用邀请码。
@@ -256,7 +256,7 @@ func TestDeleteInvite_MemberForbidden(t *testing.T) {
 	req.Header.Set("token", testutil.Token)
 	s.GetRoute().ServeHTTP(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "无权限")
+	assertSpaceErrorCode(t, w, "err.server.space.permission_denied")
 }
 
 // TestDeleteInvite_CodeNotFound: 删除不存在的邀请码返回错误。
@@ -342,7 +342,7 @@ func TestUpdateInvite_StatusPayload_MemberForbidden(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	s.GetRoute().ServeHTTP(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "无权限")
+	assertSpaceErrorCode(t, w, "err.server.space.permission_denied")
 
 	// 底层未变
 	var status int

--- a/modules/space/api_manager.go
+++ b/modules/space/api_manager.go
@@ -7,10 +7,10 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/Mininglamp-OSS/octo-server/pkg/db"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/db"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"go.uber.org/zap"
@@ -84,10 +84,10 @@ func (m *Manager) Route(r *wkhttp.WKHttp) {
 		auth.GET("/spaces/disabled", m.disableList) // 已解散 / 已封禁空间列表
 
 		// 空间单体
-		auth.GET("/spaces/:space_id", m.detail)                      // 空间详情
-		auth.PUT("/spaces/:space_id", m.updateSpaceProfile)          // 修改基础信息（名称/加入方式/成员上限等）
-		auth.DELETE("/spaces/:space_id", m.forceDisband)             // 强制解散
-		auth.PUT("/spaces/:space_id/status/:status", m.liftBan)      // 封禁(2) / 解禁(1)
+		auth.GET("/spaces/:space_id", m.detail)                 // 空间详情
+		auth.PUT("/spaces/:space_id", m.updateSpaceProfile)     // 修改基础信息（名称/加入方式/成员上限等）
+		auth.DELETE("/spaces/:space_id", m.forceDisband)        // 强制解散
+		auth.PUT("/spaces/:space_id/status/:status", m.liftBan) // 封禁(2) / 解禁(1)
 
 		// 成员
 		auth.GET("/spaces/:space_id/members", m.members)                    // 成员列表

--- a/modules/space/api_manager.go
+++ b/modules/space/api_manager.go
@@ -2,7 +2,6 @@ package space
 
 import (
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -12,6 +11,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"go.uber.org/zap"
 )
 
@@ -158,7 +159,7 @@ func toSpaceResp(m *managerSpaceModel) *managerSpaceResp {
 // requireAdmin 统一的 admin/superAdmin 角色检查。未通过时已写入响应，调用方应立即返回。
 func (m *Manager) requireAdmin(c *wkhttp.Context) bool {
 	if err := c.CheckLoginRole(); err != nil {
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrSharedForbidden, nil, nil)
 		return false
 	}
 	return true
@@ -175,13 +176,13 @@ func (m *Manager) listByStatuses(c *wkhttp.Context, statuses []int) {
 	list, err := m.managerDB.querySpaces(keyword, statuses, uint64(pageSize), uint64(pageIndex))
 	if err != nil {
 		m.Error("查询空间列表失败", zap.Error(err))
-		c.ResponseError(errors.New("查询空间列表失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	count, err := m.managerDB.countSpaces(keyword, statuses)
 	if err != nil {
 		m.Error("查询空间总数失败", zap.Error(err))
-		c.ResponseError(errors.New("查询空间总数失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 
@@ -219,33 +220,33 @@ func (m *Manager) create(c *wkhttp.Context) {
 	}
 	var req managerCreateSpaceReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求参数错误"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	if req.CreatorUID == "" {
-		c.ResponseError(errors.New("creator_uid 不能为空"))
+		respondSpaceRequestInvalid(c, "creator_uid")
 		return
 	}
 	if req.Name == "" {
-		c.ResponseError(errors.New("空间名称不能为空"))
+		respondSpaceRequestInvalid(c, "name")
 		return
 	}
 	if req.JoinMode < JoinModeDirect || req.JoinMode > JoinModeApproval {
-		c.ResponseError(errors.New("无效的加入模式，仅支持 0(直接加入) 或 1(需要审批)"))
+		respondSpaceRequestInvalid(c, "join_mode")
 		return
 	}
 	if req.MaxUsers < 0 {
-		c.ResponseError(errors.New("max_users 不能为负"))
+		respondSpaceRequestInvalid(c, "max_users")
 		return
 	}
 	exists, err := m.managerDB.isUserExists(req.CreatorUID)
 	if err != nil {
 		m.Error("校验用户失败", zap.Error(err), zap.String("creator_uid", req.CreatorUID))
-		c.ResponseError(errors.New("校验用户失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if !exists {
-		c.ResponseError(errors.New("目标用户不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceMemberNotFound, nil, nil)
 		return
 	}
 	result, err := m.space.createSpaceCore(createSpaceParams{
@@ -259,7 +260,7 @@ func (m *Manager) create(c *wkhttp.Context) {
 	})
 	if err != nil {
 		m.Error("管理端代建空间失败", zap.Error(err), zap.String("creator_uid", req.CreatorUID), zap.String("operator", c.GetLoginUID()))
-		c.ResponseError(errors.New("创建空间失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	m.Info("管理员代建空间",
@@ -290,17 +291,17 @@ func (m *Manager) detail(c *wkhttp.Context) {
 	}
 	spaceId := c.Param("space_id")
 	if spaceId == "" {
-		c.ResponseError(errors.New("空间ID不能为空"))
+		respondSpaceRequestInvalid(c, "space_id")
 		return
 	}
 	sp, err := m.managerDB.querySpaceIncludeDisbanded(spaceId)
 	if err != nil {
 		m.Error("查询空间详情失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("查询空间详情失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if sp == nil {
-		c.ResponseError(errors.New("空间不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotFound, nil, nil)
 		return
 	}
 	c.Response(toSpaceResp(sp))
@@ -313,17 +314,17 @@ func (m *Manager) forceDisband(c *wkhttp.Context) {
 	}
 	spaceId := c.Param("space_id")
 	if spaceId == "" {
-		c.ResponseError(errors.New("空间ID不能为空"))
+		respondSpaceRequestInvalid(c, "space_id")
 		return
 	}
 	sp, err := m.managerDB.querySpaceIncludeDisbanded(spaceId)
 	if err != nil {
 		m.Error("查询空间失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("查询空间失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if sp == nil {
-		c.ResponseError(errors.New("空间不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotFound, nil, nil)
 		return
 	}
 	if sp.Status == 0 {
@@ -332,7 +333,7 @@ func (m *Manager) forceDisband(c *wkhttp.Context) {
 	}
 	if err = m.managerDB.forceDisbandSpace(spaceId); err != nil {
 		m.Error("强制解散空间失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("强制解散空间失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	m.Info("管理员强制解散空间", zap.String("spaceId", spaceId), zap.String("operator", c.GetLoginUID()))
@@ -348,17 +349,17 @@ func (m *Manager) members(c *wkhttp.Context) {
 	}
 	spaceId := c.Param("space_id")
 	if spaceId == "" {
-		c.ResponseError(errors.New("空间ID不能为空"))
+		respondSpaceRequestInvalid(c, "space_id")
 		return
 	}
 	sp, err := m.managerDB.querySpaceIncludeDisbanded(spaceId)
 	if err != nil {
 		m.Error("查询空间失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("查询空间失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if sp == nil {
-		c.ResponseError(errors.New("空间不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotFound, nil, nil)
 		return
 	}
 
@@ -368,13 +369,13 @@ func (m *Manager) members(c *wkhttp.Context) {
 	list, err := m.managerDB.queryMembersAdmin(spaceId, keyword, uint64(pageSize), uint64(pageIndex))
 	if err != nil {
 		m.Error("查询空间成员失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("查询空间成员失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	count, err := m.managerDB.countMembersAdmin(spaceId, keyword)
 	if err != nil {
 		m.Error("查询空间成员总数失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("查询空间成员总数失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 
@@ -406,26 +407,26 @@ func (m *Manager) liftBan(c *wkhttp.Context) {
 	spaceId := c.Param("space_id")
 	statusStr := c.Param("status")
 	if spaceId == "" {
-		c.ResponseError(errors.New("空间ID不能为空"))
+		respondSpaceRequestInvalid(c, "space_id")
 		return
 	}
 	status, err := strconv.Atoi(statusStr)
 	if err != nil || (status != SpaceStatusNormal && status != SpaceStatusBanned) {
-		c.ResponseError(errors.New("无效的状态值，仅支持 1(正常) 或 2(封禁)"))
+		respondSpaceRequestInvalid(c, "status")
 		return
 	}
 	sp, err := m.managerDB.querySpaceIncludeDisbanded(spaceId)
 	if err != nil {
 		m.Error("查询空间失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("查询空间失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if sp == nil {
-		c.ResponseError(errors.New("空间不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotFound, nil, nil)
 		return
 	}
 	if sp.Status == SpaceStatusDisbanded {
-		c.ResponseError(errors.New("空间已解散，无法更新状态"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceImmutable, nil, nil)
 		return
 	}
 	if sp.Status == status {
@@ -434,7 +435,7 @@ func (m *Manager) liftBan(c *wkhttp.Context) {
 	}
 	if err = m.managerDB.updateSpaceStatus(spaceId, status); err != nil {
 		m.Error("更新空间状态失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("更新空间状态失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	m.Info("管理员修改空间状态", zap.String("spaceId", spaceId), zap.String("operator", c.GetLoginUID()), zap.Int("from", sp.Status), zap.Int("to", status))
@@ -467,17 +468,17 @@ func (m *Manager) updateSpaceProfile(c *wkhttp.Context) {
 	}
 	spaceId := c.Param("space_id")
 	if spaceId == "" {
-		c.ResponseError(errors.New("空间ID不能为空"))
+		respondSpaceRequestInvalid(c, "space_id")
 		return
 	}
 
 	var req managerUpdateSpaceProfileReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求参数错误"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	if req.Name == nil && req.Description == nil && req.Logo == nil && req.JoinMode == nil && req.MaxUsers == nil {
-		c.ResponseError(errors.New("至少需要提供 name / description / logo / join_mode / max_users 之一"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 
@@ -486,11 +487,11 @@ func (m *Manager) updateSpaceProfile(c *wkhttp.Context) {
 	if req.Name != nil {
 		trimmed := strings.TrimSpace(*req.Name)
 		if trimmed == "" {
-			c.ResponseError(errors.New("空间名称不能为空"))
+			respondSpaceRequestInvalid(c, "name")
 			return
 		}
 		if utf8.RuneCountInString(trimmed) > managerSpaceNameMaxChars {
-			c.ResponseError(fmt.Errorf("空间名称不能超过 %d 个字符", managerSpaceNameMaxChars))
+			respondSpaceFieldTooLong(c, "name", managerSpaceNameMaxChars)
 			return
 		}
 		req.Name = &trimmed
@@ -498,36 +499,36 @@ func (m *Manager) updateSpaceProfile(c *wkhttp.Context) {
 	if req.Description != nil {
 		trimmed := strings.TrimSpace(*req.Description)
 		if utf8.RuneCountInString(trimmed) > managerSpaceDescriptionMaxChars {
-			c.ResponseError(fmt.Errorf("空间描述不能超过 %d 个字符", managerSpaceDescriptionMaxChars))
+			respondSpaceFieldTooLong(c, "description", managerSpaceDescriptionMaxChars)
 			return
 		}
 		req.Description = &trimmed
 	}
 	if req.Logo != nil && utf8.RuneCountInString(*req.Logo) > managerSpaceLogoMaxChars {
-		c.ResponseError(fmt.Errorf("Logo 不能超过 %d 个字符", managerSpaceLogoMaxChars))
+		respondSpaceFieldTooLong(c, "logo", managerSpaceLogoMaxChars)
 		return
 	}
 	if req.JoinMode != nil && (*req.JoinMode < JoinModeDirect || *req.JoinMode > JoinModeApproval) {
-		c.ResponseError(errors.New("无效的加入模式，仅支持 0(直接加入) 或 1(需要审批)"))
+		respondSpaceRequestInvalid(c, "join_mode")
 		return
 	}
 	if req.MaxUsers != nil && *req.MaxUsers < 0 {
-		c.ResponseError(errors.New("max_users 不能为负"))
+		respondSpaceRequestInvalid(c, "max_users")
 		return
 	}
 
 	sp, err := m.managerDB.querySpaceIncludeDisbanded(spaceId)
 	if err != nil {
 		m.Error("查询空间失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("查询空间失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if sp == nil {
-		c.ResponseError(errors.New("空间不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotFound, nil, nil)
 		return
 	}
 	if sp.Status == SpaceStatusDisbanded {
-		c.ResponseError(errors.New("空间已解散，无法修改空间信息"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceImmutable, nil, nil)
 		return
 	}
 
@@ -538,11 +539,11 @@ func (m *Manager) updateSpaceProfile(c *wkhttp.Context) {
 		active, err := m.db.countActiveMembers(spaceId)
 		if err != nil {
 			m.Error("查询空间成员数失败", zap.Error(err), zap.String("spaceId", spaceId))
-			c.ResponseError(errors.New("查询空间成员数失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 			return
 		}
 		if *req.MaxUsers < active {
-			c.ResponseError(fmt.Errorf("max_users (%d) 不能低于当前活跃成员数 (%d)", *req.MaxUsers, active))
+			respondSpaceRequestInvalid(c, "max_users")
 			return
 		}
 	}
@@ -555,15 +556,15 @@ func (m *Manager) updateSpaceProfile(c *wkhttp.Context) {
 		// 不能依赖 RowsAffected 区分：MySQL 默认返回变更行数而非匹配行数，
 		// 字段值与现值完全相同的幂等请求会被误判为"行不存在"。
 		if errors.Is(err, ErrSpaceNotFound) {
-			c.ResponseError(errors.New("空间不存在"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceNotFound, nil, nil)
 			return
 		}
 		if errors.Is(err, ErrSpaceDisbandedForUpdate) {
-			c.ResponseError(errors.New("空间已解散，无法修改空间信息"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceImmutable, nil, nil)
 			return
 		}
 		m.Error("更新空间信息失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("更新空间信息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	// 审计日志：from 值取自事务内锁定时的快照（before），避免并发更新窗口下 tx 外读到 stale 旧值。
@@ -599,40 +600,40 @@ func (m *Manager) addMembers(c *wkhttp.Context) {
 	}
 	spaceId := c.Param("space_id")
 	if spaceId == "" {
-		c.ResponseError(errors.New("空间ID不能为空"))
+		respondSpaceRequestInvalid(c, "space_id")
 		return
 	}
 	sp, err := m.managerDB.querySpaceIncludeDisbanded(spaceId)
 	if err != nil {
 		m.Error("查询空间失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("查询空间失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if sp == nil {
-		c.ResponseError(errors.New("空间不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotFound, nil, nil)
 		return
 	}
 	if sp.Status == SpaceStatusDisbanded {
-		c.ResponseError(errors.New("空间已解散，无法添加成员"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceImmutable, nil, nil)
 		return
 	}
 	var req addMemberReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求参数错误"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	uids := normalizeUIDs(req.UIDs)
 	if len(uids) == 0 {
-		c.ResponseError(errors.New("成员列表不能为空"))
+		respondSpaceRequestInvalid(c, "members")
 		return
 	}
 	if len(uids) > managerMaxBatchUIDs {
-		c.ResponseError(fmt.Errorf("单次最多处理 %d 个成员", managerMaxBatchUIDs))
+		respondSpaceBatchTooLarge(c, managerMaxBatchUIDs)
 		return
 	}
 	if err := m.managerDB.upsertMembers(spaceId, uids); err != nil {
 		m.Error("添加成员失败", zap.Error(err), zap.String("spaceId", spaceId), zap.Strings("uids", uids))
-		c.ResponseError(errors.New("添加成员失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	m.Info("管理员添加空间成员", zap.String("spaceId", spaceId), zap.String("operator", c.GetLoginUID()), zap.Strings("uids", uids))
@@ -654,40 +655,40 @@ func (m *Manager) removeMembers(c *wkhttp.Context) {
 	}
 	spaceId := c.Param("space_id")
 	if spaceId == "" {
-		c.ResponseError(errors.New("空间ID不能为空"))
+		respondSpaceRequestInvalid(c, "space_id")
 		return
 	}
 	sp, err := m.managerDB.querySpaceIncludeDisbanded(spaceId)
 	if err != nil {
 		m.Error("查询空间失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("查询空间失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if sp == nil {
-		c.ResponseError(errors.New("空间不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotFound, nil, nil)
 		return
 	}
 	var req removeMemberReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求参数错误"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	uids := normalizeUIDs(req.UIDs)
 	if len(uids) == 0 {
-		c.ResponseError(errors.New("成员列表不能为空"))
+		respondSpaceRequestInvalid(c, "members")
 		return
 	}
 	if len(uids) > managerMaxBatchUIDs {
-		c.ResponseError(fmt.Errorf("单次最多处理 %d 个成员", managerMaxBatchUIDs))
+		respondSpaceBatchTooLarge(c, managerMaxBatchUIDs)
 		return
 	}
 	if err := m.managerDB.removeMembersForce(spaceId, uids); err != nil {
 		if errors.Is(err, ErrCannotRemoveOwner) {
-			c.ResponseError(errors.New("无法移除拥有者，请先通过修改角色转让所有权"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceOwnerConstraint, nil, nil)
 			return
 		}
 		m.Error("移除成员失败", zap.Error(err), zap.String("spaceId", spaceId), zap.Strings("uids", uids))
-		c.ResponseError(errors.New("移除成员失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	m.Info("管理员移除空间成员", zap.String("spaceId", spaceId), zap.String("operator", c.GetLoginUID()), zap.Strings("uids", uids))
@@ -719,47 +720,47 @@ func (m *Manager) updateMemberRole(c *wkhttp.Context) {
 	spaceId := c.Param("space_id")
 	targetUID := c.Param("uid")
 	if spaceId == "" || targetUID == "" {
-		c.ResponseError(errors.New("空间ID或成员UID不能为空"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	var req updateMemberRoleReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求参数错误"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	if req.Role < 0 || req.Role > 2 {
-		c.ResponseError(errors.New("无效的角色值"))
+		respondSpaceRequestInvalid(c, "role")
 		return
 	}
 	target, err := m.db.queryMember(spaceId, targetUID)
 	if err != nil {
 		m.Error("查询目标成员失败", zap.Error(err), zap.String("spaceId", spaceId), zap.String("uid", targetUID))
-		c.ResponseError(errors.New("查询目标成员失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if target == nil {
-		c.ResponseError(errors.New("目标成员不存在或已被移除"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceMemberNotFound, nil, nil)
 		return
 	}
 	// 禁止把 owner 直接降级（否则空间无主）；必须通过设置其他成员为 role=2 触发 transferOwnerAdmin 来转移。
 	if target.Role == 2 && req.Role != 2 {
-		c.ResponseError(errors.New("无法直接降级拥有者，请将其他成员设为拥有者以转让所有权"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceOwnerConstraint, nil, nil)
 		return
 	}
 	if req.Role == 2 {
 		if err = m.managerDB.transferOwnerAdmin(spaceId, targetUID); err != nil {
 			if errors.Is(err, ErrTransferTargetMissing) {
-				c.ResponseError(errors.New("目标成员已被移除，无法转让所有权"))
+				httperr.ResponseErrorL(c, errcode.ErrSpaceMemberNotFound, nil, nil)
 				return
 			}
 			m.Error("转让拥有权失败", zap.Error(err), zap.String("spaceId", spaceId), zap.String("uid", targetUID))
-			c.ResponseError(errors.New("转让拥有权失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 			return
 		}
 	} else {
 		if err = m.db.updateMemberRole(spaceId, targetUID, req.Role); err != nil {
 			m.Error("修改角色失败", zap.Error(err), zap.String("spaceId", spaceId), zap.String("uid", targetUID))
-			c.ResponseError(errors.New("修改角色失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 			return
 		}
 	}
@@ -786,20 +787,20 @@ func (m *Manager) listInvites(c *wkhttp.Context) {
 	}
 	spaceId := c.Param("space_id")
 	if spaceId == "" {
-		c.ResponseError(errors.New("空间ID不能为空"))
+		respondSpaceRequestInvalid(c, "space_id")
 		return
 	}
 	pageIndex, pageSize := clampPage(c.GetPage())
 	list, err := m.managerDB.queryInvitesAdmin(spaceId, uint64(pageSize), uint64(pageIndex))
 	if err != nil {
 		m.Error("查询邀请码失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("查询邀请码失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	count, err := m.managerDB.countInvitesAdmin(spaceId)
 	if err != nil {
 		m.Error("查询邀请码总数失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("查询邀请码总数失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	resp := make([]*managerInviteResp, 0, len(list))
@@ -845,35 +846,35 @@ func (m *Manager) createInvite(c *wkhttp.Context) {
 	}
 	spaceId := c.Param("space_id")
 	if spaceId == "" {
-		c.ResponseError(errors.New("空间ID不能为空"))
+		respondSpaceRequestInvalid(c, "space_id")
 		return
 	}
 	sp, err := m.managerDB.querySpaceIncludeDisbanded(spaceId)
 	if err != nil {
 		m.Error("查询空间失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("查询空间失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if sp == nil {
-		c.ResponseError(errors.New("空间不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotFound, nil, nil)
 		return
 	}
 	// 正向校验：仅正常状态空间可创建邀请码（封禁空间即使创建了，加入时也会被 querySpaceByID 拒）。
 	if sp.Status != SpaceStatusNormal {
-		c.ResponseError(errors.New("仅正常状态的空间可创建邀请码"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceImmutable, nil, nil)
 		return
 	}
 
 	var req managerCreateInviteReq
 	if c.Request.ContentLength > 0 {
 		if err := c.BindJSON(&req); err != nil {
-			c.ResponseError(errors.New("请求参数错误"))
+			respondSpaceRequestInvalid(c, "")
 			return
 		}
 	}
 	expiresAt, err := parseInviteExpiresAt(req.ExpiresAt)
 	if err != nil {
-		c.ResponseError(err)
+		respondSpaceRequestInvalid(c, "expires_at")
 		return
 	}
 
@@ -888,7 +889,7 @@ func (m *Manager) createInvite(c *wkhttp.Context) {
 	defMaxUses, defExpiresAt := inviteDefaults(time.Now())
 	if req.MaxUses != nil {
 		if *req.MaxUses < 0 {
-			c.ResponseError(errors.New("max_uses 不能为负"))
+			respondSpaceRequestInvalid(c, "max_uses")
 			return
 		}
 		model.MaxUses = *req.MaxUses
@@ -906,7 +907,7 @@ func (m *Manager) createInvite(c *wkhttp.Context) {
 	code, err := m.space.insertInvitationWithRetry(model)
 	if err != nil {
 		m.Error("管理端创建邀请码失败", zap.Error(err), zap.String("spaceId", spaceId), zap.String("operator", operator))
-		c.ResponseError(errors.New("创建邀请码失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 
@@ -941,41 +942,41 @@ func (m *Manager) updateInvite(c *wkhttp.Context) {
 	spaceId := c.Param("space_id")
 	code := c.Param("code")
 	if spaceId == "" || code == "" {
-		c.ResponseError(errors.New("空间ID或邀请码不能为空"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 
 	var req managerUpdateInviteReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求参数错误"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	if req.MaxUses == nil && req.ExpiresAt == nil && req.Status == nil {
-		c.ResponseError(errors.New("至少需要提供 max_uses / expires_at / status 之一"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	if req.MaxUses != nil && *req.MaxUses < 0 {
-		c.ResponseError(errors.New("max_uses 不能为负"))
+		respondSpaceRequestInvalid(c, "max_uses")
 		return
 	}
 	if req.Status != nil && *req.Status != 0 && *req.Status != 1 {
-		c.ResponseError(errors.New("status 仅支持 0(禁用) 或 1(启用)"))
+		respondSpaceRequestInvalid(c, "status")
 		return
 	}
 	expiresAt, err := parseInviteExpiresAt(req.ExpiresAt)
 	if err != nil {
-		c.ResponseError(err)
+		respondSpaceRequestInvalid(c, "expires_at")
 		return
 	}
 
 	affected, err := m.managerDB.updateInvitationAdmin(spaceId, code, req.MaxUses, expiresAt, req.Status)
 	if err != nil {
 		m.Error("修改邀请码失败", zap.Error(err), zap.String("spaceId", spaceId), zap.String("code", code))
-		c.ResponseError(errors.New("修改邀请码失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	if affected == 0 {
-		c.ResponseError(errors.New("邀请码不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceInviteCodeNotFound, nil, nil)
 		return
 	}
 
@@ -1013,17 +1014,17 @@ func (m *Manager) disableInvite(c *wkhttp.Context) {
 	spaceId := c.Param("space_id")
 	code := c.Param("code")
 	if spaceId == "" || code == "" {
-		c.ResponseError(errors.New("空间ID或邀请码不能为空"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	affected, err := m.managerDB.disableInvitation(spaceId, code)
 	if err != nil {
 		m.Error("禁用邀请码失败", zap.Error(err), zap.String("code", code))
-		c.ResponseError(errors.New("禁用邀请码失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	if affected == 0 {
-		c.ResponseError(errors.New("邀请码不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceInviteCodeNotFound, nil, nil)
 		return
 	}
 	m.Info("管理员禁用邀请码", zap.String("spaceId", spaceId), zap.String("code", code), zap.String("operator", c.GetLoginUID()))
@@ -1050,7 +1051,7 @@ func (m *Manager) listJoinApplies(c *wkhttp.Context) {
 	}
 	spaceId := c.Param("space_id")
 	if spaceId == "" {
-		c.ResponseError(errors.New("空间ID不能为空"))
+		respondSpaceRequestInvalid(c, "space_id")
 		return
 	}
 	status := -1
@@ -1064,13 +1065,13 @@ func (m *Manager) listJoinApplies(c *wkhttp.Context) {
 	list, err := m.managerDB.queryJoinAppliesAdmin(spaceId, status, uint64(pageSize), uint64(pageIndex))
 	if err != nil {
 		m.Error("查询申请列表失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("查询申请列表失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	count, err := m.managerDB.countJoinAppliesAdmin(spaceId, status)
 	if err != nil {
 		m.Error("查询申请总数失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("查询申请总数失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	resp := make([]*managerJoinApplyResp, 0, len(list))
@@ -1108,41 +1109,41 @@ func (m *Manager) approveJoinApply(c *wkhttp.Context) {
 
 	applyID, err := strconv.ParseInt(applyIDStr, 10, 64)
 	if err != nil || applyID <= 0 {
-		c.ResponseError(errors.New("申请ID无效"))
+		respondSpaceRequestInvalid(c, "apply_id")
 		return
 	}
 	apply, err := m.db.queryJoinApplyByID(applyID)
 	if err != nil {
 		m.Error("查询申请记录失败", zap.Error(err), zap.Int64("applyID", applyID))
-		c.ResponseError(errors.New("查询申请记录失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if apply == nil {
-		c.ResponseError(errors.New("申请记录不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceApplyNotFound, nil, nil)
 		return
 	}
 	if apply.SpaceId != spaceId {
-		c.ResponseError(errors.New("申请记录不属于当前空间"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceApplyNotFound, nil, nil)
 		return
 	}
 	if apply.Status != 0 {
-		c.ResponseError(errors.New("该申请已被处理"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceApplyProcessed, nil, nil)
 		return
 	}
 	sp, err := m.db.querySpaceByID(spaceId)
 	if err != nil {
 		m.Error("查询空间失败", zap.Error(err), zap.String("spaceId", spaceId))
-		c.ResponseError(errors.New("查询空间失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if sp == nil {
-		c.ResponseError(errors.New("空间不存在或已解散"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotFound, nil, nil)
 		return
 	}
 	affected, err := m.db.updateJoinApplyStatus(applyID, 1, reviewerUID)
 	if err != nil {
 		m.Error("更新申请状态失败", zap.Error(err), zap.Int64("applyID", applyID))
-		c.ResponseError(errors.New("更新申请状态失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	if affected == 0 {
@@ -1157,14 +1158,14 @@ func (m *Manager) approveJoinApply(c *wkhttp.Context) {
 		if _, rbErr := m.db.updateJoinApplyStatusRaw(applyID, 0, ""); rbErr != nil {
 			m.Error("回滚申请状态失败", zap.Error(rbErr), zap.Int64("applyID", applyID))
 		}
-		c.ResponseError(errors.New("检查邀请码使用次数失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if apply.InviteCode != "" && !inviteConsumed {
 		if _, rbErr := m.db.updateJoinApplyStatusRaw(applyID, 0, ""); rbErr != nil {
 			m.Error("回滚申请状态失败", zap.Error(rbErr), zap.Int64("applyID", applyID))
 		}
-		c.ResponseError(errors.New("该邀请码已用尽或已失效，无法通过此申请"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceInviteCodeExhausted, nil, nil)
 		return
 	}
 
@@ -1179,11 +1180,11 @@ func (m *Manager) approveJoinApply(c *wkhttp.Context) {
 		}
 		m.space.rollbackApplyAndInvite(applyID, apply.InviteCode, inviteConsumed)
 		if errors.Is(joinErr, ErrSpaceFull) {
-			c.ResponseError(errors.New("空间已满，无法通过申请"))
+			httperr.ResponseErrorL(c, errcode.ErrSpaceFull, nil, nil)
 			return
 		}
 		m.Error("加入空间失败", zap.Error(joinErr), zap.Int64("applyID", applyID))
-		c.ResponseError(errors.New("加入空间失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	go m.space.notifyApplicantJoinResult(apply.UID, spaceId, sp.Name, true)
@@ -1202,30 +1203,30 @@ func (m *Manager) rejectJoinApply(c *wkhttp.Context) {
 
 	applyID, err := strconv.ParseInt(applyIDStr, 10, 64)
 	if err != nil || applyID <= 0 {
-		c.ResponseError(errors.New("申请ID无效"))
+		respondSpaceRequestInvalid(c, "apply_id")
 		return
 	}
 	apply, err := m.db.queryJoinApplyByID(applyID)
 	if err != nil {
 		m.Error("查询申请记录失败", zap.Error(err), zap.Int64("applyID", applyID))
-		c.ResponseError(errors.New("查询申请记录失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if apply == nil {
-		c.ResponseError(errors.New("申请记录不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceApplyNotFound, nil, nil)
 		return
 	}
 	if apply.SpaceId != spaceId {
-		c.ResponseError(errors.New("申请记录不属于当前空间"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceApplyNotFound, nil, nil)
 		return
 	}
 	if apply.Status != 0 {
-		c.ResponseError(errors.New("该申请已被处理"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceApplyProcessed, nil, nil)
 		return
 	}
 	if _, err = m.db.updateJoinApplyStatus(applyID, 2, reviewerUID); err != nil {
 		m.Error("更新申请状态失败", zap.Error(err), zap.Int64("applyID", applyID))
-		c.ResponseError(errors.New("更新申请状态失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	sp, spErr := m.db.querySpaceByID(spaceId)

--- a/modules/space/api_manager_email_invite.go
+++ b/modules/space/api_manager_email_invite.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/pkg/db"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"go.uber.org/zap"
 )
 
@@ -49,23 +51,23 @@ func (m *Manager) createSpaceOwnerEmailInvite(c *wkhttp.Context) {
 	}
 	var req managerCreateOwnerEmailInviteReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("请求参数错误"))
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	if err := validateOwnerInviteReq(&req); err != nil {
-		c.ResponseError(err)
+		respondSpaceRequestInvalid(c, "")
 		return
 	}
 	expiresAt, err := parseInviteExpiresAt(req.ExpiresAt)
 	if err != nil {
-		c.ResponseError(err)
+		respondSpaceRequestInvalid(c, "expires_at")
 		return
 	}
 
 	rawToken, tokenHash, err := generateEmailInviteToken()
 	if err != nil {
 		m.Error("生成邀请 token 失败", zap.Error(err))
-		c.ResponseError(errors.New("生成邀请失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 
@@ -88,7 +90,7 @@ func (m *Manager) createSpaceOwnerEmailInvite(c *wkhttp.Context) {
 	id, err := m.db.insertEmailInvite(model)
 	if err != nil {
 		m.Error("写入 owner 邮件邀请失败", zap.Error(err))
-		c.ResponseError(errors.New("创建邀请失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	model.Id = id
@@ -115,7 +117,7 @@ func (m *Manager) listSpaceOwnerEmailInvites(c *wkhttp.Context) {
 	)
 	if err != nil {
 		m.Error("查询 owner 邀请列表失败", zap.Error(err))
-		c.ResponseError(errors.New("查询邀请列表失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	resp := make([]*managerEmailInviteResp, 0, len(list))
@@ -136,31 +138,31 @@ func (m *Manager) revokeSpaceOwnerEmailInvite(c *wkhttp.Context) {
 	idStr := c.Param("id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil || id <= 0 {
-		c.ResponseError(errors.New("邀请ID无效"))
+		respondSpaceRequestInvalid(c, "invite_id")
 		return
 	}
 	inv, err := m.db.queryEmailInviteByID(id)
 	if err != nil {
 		m.Error("查询邀请失败", zap.Error(err), zap.Int64("id", id))
-		c.ResponseError(errors.New("查询邀请失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return
 	}
 	if inv == nil || inv.InviteType != EmailInviteTypeOwner {
-		c.ResponseError(errors.New("邀请不存在"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceEmailInviteNotFound, nil, nil)
 		return
 	}
 	if inv.CreatedBy != c.GetLoginUID() {
-		c.ResponseError(errors.New("无权操作该邀请"))
+		httperr.ResponseErrorL(c, errcode.ErrSpacePermissionDenied, nil, nil)
 		return
 	}
 	affected, err := m.db.revokeEmailInvite(id)
 	if err != nil {
 		m.Error("撤销邀请失败", zap.Error(err), zap.Int64("id", id))
-		c.ResponseError(errors.New("撤销邀请失败"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
 	if affected == 0 {
-		c.ResponseError(errors.New("仅 pending 状态邀请可撤销"))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceEmailInviteProcessed, nil, nil)
 		return
 	}
 	c.ResponseOK()

--- a/modules/space/api_manager_test.go
+++ b/modules/space/api_manager_test.go
@@ -458,7 +458,7 @@ func TestManager_RemoveMembers(t *testing.T) {
 		req.Header.Set("token", token)
 		s.GetRoute().ServeHTTP(w, req)
 		assert.NotEqual(t, http.StatusOK, w.Code)
-		assert.Contains(t, w.Body.String(), "拥有者")
+		assertSpaceErrorCode(t, w, "err.server.space.owner_constraint")
 		owner, err := testSpaceDB.queryMember("mgr-rm", "u-owner")
 		assert.NoError(t, err)
 		assert.NotNil(t, owner, "owner must remain active")
@@ -501,7 +501,7 @@ func TestManager_UpdateMemberRole(t *testing.T) {
 		req.Header.Set("token", token)
 		s.GetRoute().ServeHTTP(w, req)
 		assert.NotEqual(t, http.StatusOK, w.Code)
-		assert.Contains(t, w.Body.String(), "拥有者")
+		assertSpaceErrorCode(t, w, "err.server.space.owner_constraint")
 
 		mem, err := testSpaceDB.queryMember("mgr-role", "m-target")
 		assert.NoError(t, err)
@@ -1002,7 +1002,7 @@ func TestManager_AuthBoundary(t *testing.T) {
 		req.Header.Set("token", testutil.Token)
 		s.GetRoute().ServeHTTP(w, req)
 		assert.NotEqual(t, http.StatusOK, w.Code)
-		assert.Contains(t, w.Body.String(), "角色")
+		assertSpaceErrorCode(t, w, "err.shared.auth.forbidden")
 	})
 }
 
@@ -1274,32 +1274,32 @@ func TestManager_CreateSpace_ValidationErrors(t *testing.T) {
 	cases := []struct {
 		name string
 		body map[string]interface{}
-		msg  string
+		code string
 	}{
 		{
 			"missing creator_uid",
 			map[string]interface{}{"name": "n"},
-			"creator_uid",
+			"err.server.space.request_invalid",
 		},
 		{
 			"missing name",
 			map[string]interface{}{"creator_uid": "u-ok"},
-			"名称",
+			"err.server.space.request_invalid",
 		},
 		{
 			"invalid join_mode",
 			map[string]interface{}{"creator_uid": "u-ok", "name": "n", "join_mode": 9},
-			"加入模式",
+			"err.server.space.request_invalid",
 		},
 		{
 			"negative max_users",
 			map[string]interface{}{"creator_uid": "u-ok", "name": "n", "max_users": -1},
-			"max_users",
+			"err.server.space.request_invalid",
 		},
 		{
 			"creator not exists",
 			map[string]interface{}{"creator_uid": "ghost", "name": "n"},
-			"用户不存在",
+			"err.server.space.member_not_found",
 		},
 	}
 	for _, tc := range cases {
@@ -1310,7 +1310,7 @@ func TestManager_CreateSpace_ValidationErrors(t *testing.T) {
 			req.Header.Set("token", token)
 			s.GetRoute().ServeHTTP(w, req)
 			assert.NotEqual(t, http.StatusOK, w.Code)
-			assert.Contains(t, w.Body.String(), tc.msg)
+			assertSpaceErrorCode(t, w, tc.code)
 		})
 	}
 }
@@ -1673,7 +1673,7 @@ func TestManager_UpdateSpaceProfile_Validation(t *testing.T) {
 		}
 		w := doPUT(util.ToJson(map[string]interface{}{"max_users": 2}))
 		assert.NotEqual(t, http.StatusOK, w.Code)
-		assert.Contains(t, w.Body.String(), "成员")
+		assertSpaceErrorCode(t, w, "err.server.space.request_invalid")
 	})
 
 	t.Run("reject when space does not exist", func(t *testing.T) {

--- a/modules/space/api_test.go
+++ b/modules/space/api_test.go
@@ -1593,7 +1593,7 @@ func TestCreateSpace_DisabledBySystemSetting(t *testing.T) {
 	req.Header.Set("token", testutil.Token)
 	s.GetRoute().ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusBadRequest, w.Code, "DB 开关 ON 时应返回 403, body=%s", w.Body.String())
+	assert.Equal(t, http.StatusForbidden, w.Code, "DB 开关 ON 时应返回 403, body=%s", w.Body.String())
 	assert.Contains(t, w.Body.String(), "已关闭")
 
 	var count int
@@ -1617,7 +1617,7 @@ func TestCreateSpace_DisabledByEnv(t *testing.T) {
 	req.Header.Set("token", testutil.Token)
 	s.GetRoute().ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusBadRequest, w.Code, "应返回 403")
+	assert.Equal(t, http.StatusForbidden, w.Code, "应返回 403")
 	assert.Contains(t, w.Body.String(), "已关闭")
 
 	// 不应有新空间入库：按 name 反查
@@ -1962,8 +1962,8 @@ func TestE2E_DisableUserCreateSpace_FullChain(t *testing.T) {
 	writeSetting("1")
 	assert.Contains(t, getAppconfig(), `"disable_user_create_space":1`,
 		"manager 写入后 appconfig 必须立刻下发 1")
-	assert.Equal(t, http.StatusBadRequest, createSpace("e2e-off"),
-		"开关 ON 时 createSpace 必须被拒绝（D14 wire 400 + error.http_status 403）")
+	assert.Equal(t, http.StatusForbidden, createSpace("e2e-off"),
+		"开关 ON 时 createSpace 必须 403")
 
 	// --- Step 2: 重新打开 ---
 	writeSetting("0")

--- a/modules/space/api_test.go
+++ b/modules/space/api_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/server"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	modulescommon "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -68,7 +69,7 @@ func TestMain(m *testing.M) {
 	db.Close()
 
 	// 创建共享测试服务器（只初始化一次，避免路由重复注册）
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newRenderedTestServer()
 	testSrv = s
 	testCtx = ctx
 	testSpaceDB = NewDB(ctx)
@@ -77,6 +78,17 @@ func TestMain(m *testing.M) {
 }
 
 func strPtr(s string) *string { return &s }
+
+// newRenderedTestServer wraps testutil.NewTestServer and injects the i18n
+// ErrorRenderer (mirrors main.go at boot) so the migrated handlers respond via
+// the dual envelope with a populated error.code. Without it the route falls back
+// to the legacy {msg,status} carrying the English DefaultMessage.
+// testutil.NewTestServer (octo-lib) is intentionally not touched.
+func newRenderedTestServer() (*server.Server, *config.Context) {
+	srv, ctx := testutil.NewTestServer()
+	srv.GetRoute().SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	return srv, ctx
+}
 
 // setup 返回共享的测试服务器和 Space 实例，并清理表数据
 func setup(t *testing.T) (*server.Server, *Space, error) {
@@ -88,7 +100,7 @@ func setup(t *testing.T) (*server.Server, *Space, error) {
 
 func TestGetInvitePreview(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newRenderedTestServer()
 	f := New(ctx)
 
 	// 清空旧数据
@@ -145,7 +157,7 @@ func TestGetInvitePreview(t *testing.T) {
 
 func TestGetInvitePreviewWithBots(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newRenderedTestServer()
 	f := New(ctx)
 
 	// 清空旧数据
@@ -231,7 +243,7 @@ func TestGetInvitePreviewInvalidCode(t *testing.T) {
 }
 
 func TestUpdateInvite(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newRenderedTestServer()
 	f := New(ctx)
 
 	// 清空旧数据
@@ -294,7 +306,7 @@ func TestUpdateInvite(t *testing.T) {
 }
 
 func TestUpdateInviteNoPermission(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newRenderedTestServer()
 	f := New(ctx)
 
 	// 清空旧数据
@@ -341,11 +353,11 @@ func TestUpdateInviteNoPermission(t *testing.T) {
 	s.GetRoute().ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "无权限")
+	assertSpaceErrorCode(t, w, "err.server.space.permission_denied")
 }
 
 func TestUpdateInviteInvalidCode(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newRenderedTestServer()
 	f := New(ctx)
 
 	// 清空旧数据
@@ -382,11 +394,11 @@ func TestUpdateInviteInvalidCode(t *testing.T) {
 	s.GetRoute().ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "邀请码不存在")
+	assertSpaceErrorCode(t, w, "err.server.space.invite_code_not_found")
 }
 
 func TestJoinSpaceFullReturnsSpaceFullError(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newRenderedTestServer()
 	f := New(ctx)
 
 	// 清空旧数据
@@ -441,7 +453,7 @@ func TestJoinSpaceFullReturnsSpaceFullError(t *testing.T) {
 }
 
 func TestJoinSpaceSuccessWithCapacity(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newRenderedTestServer()
 	f := New(ctx)
 
 	// 清空旧数据
@@ -499,7 +511,7 @@ func TestJoinSpaceSuccessWithCapacity(t *testing.T) {
 }
 
 func TestJoinSpaceUnlimitedCapacity(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newRenderedTestServer()
 	f := New(ctx)
 
 	// 清空旧数据
@@ -555,7 +567,7 @@ func TestJoinSpaceUnlimitedCapacity(t *testing.T) {
 
 func TestJoinSpaceWithPresetGroup(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newRenderedTestServer()
 	f := New(ctx)
 
 	// 清空旧数据
@@ -620,7 +632,7 @@ func TestJoinSpaceWithPresetGroup(t *testing.T) {
 }
 
 func TestJoinSpaceWithNoPresetGroup(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newRenderedTestServer()
 	f := New(ctx)
 
 	// 清空旧数据
@@ -677,7 +689,7 @@ func TestJoinSpaceWithNoPresetGroup(t *testing.T) {
 }
 
 func TestJoinSpacePresetGroupIdempotent(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newRenderedTestServer()
 	f := New(ctx)
 
 	// 清空旧数据
@@ -748,7 +760,7 @@ func TestJoinSpacePresetGroupIdempotent(t *testing.T) {
 }
 
 func TestJoinSpacePresetGroupDisbanded(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newRenderedTestServer()
 	f := New(ctx)
 
 	// 清空旧数据
@@ -1004,7 +1016,7 @@ func TestJoinApplies_NoPermission(t *testing.T) {
 	s.GetRoute().ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "无权限")
+	assertSpaceErrorCode(t, w, "err.server.space.permission_denied")
 }
 
 func TestApproveJoinApply_Success(t *testing.T) {
@@ -1353,7 +1365,7 @@ func TestRejectJoinApply_CrossSpaceBlocked(t *testing.T) {
 	s.GetRoute().ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code, "跨空间拒绝应被阻止")
-	assert.Contains(t, w.Body.String(), "不属于当前空间")
+	assertSpaceErrorCode(t, w, "err.server.space.apply_not_found")
 
 	// 验证申请状态未被修改
 	apply, err := f.db.queryJoinApplyByID(applyID)
@@ -1583,7 +1595,7 @@ func TestCreateSpace_DisabledBySystemSetting(t *testing.T) {
 	req.Header.Set("token", testutil.Token)
 	s.GetRoute().ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusForbidden, w.Code, "DB 开关 ON 时应返回 403, body=%s", w.Body.String())
+	assert.Equal(t, http.StatusBadRequest, w.Code, "DB 开关 ON 时应返回 403, body=%s", w.Body.String())
 	assert.Contains(t, w.Body.String(), "已关闭")
 
 	var count int
@@ -1607,7 +1619,7 @@ func TestCreateSpace_DisabledByEnv(t *testing.T) {
 	req.Header.Set("token", testutil.Token)
 	s.GetRoute().ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusForbidden, w.Code, "应返回 403")
+	assert.Equal(t, http.StatusBadRequest, w.Code, "应返回 403")
 	assert.Contains(t, w.Body.String(), "已关闭")
 
 	// 不应有新空间入库：按 name 反查
@@ -1731,7 +1743,7 @@ func TestApproveJoinApply_InviteExhaustedBlocksApproval(t *testing.T) {
 	s.GetRoute().ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "已用尽")
+	assertSpaceErrorCode(t, w, "err.server.space.invite_code_exhausted")
 
 	// 申请状态应回滚为 0，保留 owner 后续处理余地
 	updated, err := f.db.queryJoinApplyByID(applyID)
@@ -1775,7 +1787,7 @@ func TestApproveJoinApply_InviteDisabledBlocksApproval(t *testing.T) {
 	s.GetRoute().ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "已失效")
+	assertSpaceErrorCode(t, w, "err.server.space.invite_code_exhausted")
 
 	updated, err := f.db.queryJoinApplyByID(applyID)
 	assert.NoError(t, err)
@@ -1952,8 +1964,8 @@ func TestE2E_DisableUserCreateSpace_FullChain(t *testing.T) {
 	writeSetting("1")
 	assert.Contains(t, getAppconfig(), `"disable_user_create_space":1`,
 		"manager 写入后 appconfig 必须立刻下发 1")
-	assert.Equal(t, http.StatusForbidden, createSpace("e2e-off"),
-		"开关 ON 时 createSpace 必须 403")
+	assert.Equal(t, http.StatusBadRequest, createSpace("e2e-off"),
+		"开关 ON 时 createSpace 必须被拒绝（D14 wire 400 + error.http_status 403）")
 
 	// --- Step 2: 重新打开 ---
 	writeSetting("0")

--- a/modules/space/api_test.go
+++ b/modules/space/api_test.go
@@ -447,9 +447,7 @@ func TestJoinSpaceFullReturnsSpaceFullError(t *testing.T) {
 	s.GetRoute().ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	body := w.Body.String()
-	assert.Contains(t, body, `"status":"SPACE_FULL"`)
-	assert.Contains(t, body, "空间已满")
+	assertSpaceErrorCode(t, w, "err.server.space.full")
 }
 
 func TestJoinSpaceSuccessWithCapacity(t *testing.T) {

--- a/modules/space/api_update_space_test.go
+++ b/modules/space/api_update_space_test.go
@@ -320,7 +320,7 @@ func TestUserUpdateSpace_Auth(t *testing.T) {
 
 		w := putSpace(t, spaceId, body, testutil.Token)
 		assert.NotEqual(t, http.StatusOK, w.Code)
-		assert.Contains(t, w.Body.String(), "无权限")
+		assertSpaceErrorCode(t, w, "err.server.space.permission_denied")
 	})
 
 	t.Run("role=0 plain member is rejected", func(t *testing.T) {
@@ -342,7 +342,7 @@ func TestUserUpdateSpace_Auth(t *testing.T) {
 
 		w := putSpace(t, spaceId, body, testutil.Token)
 		assert.NotEqual(t, http.StatusOK, w.Code)
-		assert.Contains(t, w.Body.String(), "无权限")
+		assertSpaceErrorCode(t, w, "err.server.space.permission_denied")
 	})
 
 	t.Run("role=1 admin is accepted", func(t *testing.T) {

--- a/pkg/errcode/space.go
+++ b/pkg/errcode/space.go
@@ -151,6 +151,39 @@ var (
 		DefaultMessage: "Transfer ownership before performing this operation.",
 	})
 
+	// ---- email invite (member/owner email-invite accept & manage flows) ------
+
+	// ErrSpaceEmailInviteNotFound covers a missing email invite on the admin
+	// revoke path.
+	ErrSpaceEmailInviteNotFound = register(codes.Code{
+		ID:             "err.server.space.email_invite_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Email invite not found.",
+	})
+	// ErrSpaceEmailInviteInvalid covers an invite that cannot be accepted because
+	// it is invalid / expired / missing required data / of an unknown type. The
+	// accept endpoint is authenticated (the caller already proved identity and
+	// must match the invited email), so this stays a plain 400.
+	ErrSpaceEmailInviteInvalid = register(codes.Code{
+		ID:             "err.server.space.email_invite_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The invite is invalid or has expired.",
+	})
+	// ErrSpaceEmailInviteProcessed covers accepting/revoking an invite that has
+	// already been consumed, revoked, or is no longer pending.
+	ErrSpaceEmailInviteProcessed = register(codes.Code{
+		ID:             "err.server.space.email_invite_processed",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "This invite has already been processed.",
+	})
+	// ErrSpaceEmailInviteEmailMismatch covers the typed-email / login-account
+	// email not matching the invite target (defense-in-depth identity check).
+	ErrSpaceEmailInviteEmailMismatch = register(codes.Code{
+		ID:             "err.server.space.email_invite_email_mismatch",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "The email does not match the invite.",
+	})
+
 	// ---- internal (500, Internal=true) ---------------------------------------
 
 	// ErrSpaceQueryFailed covers read-path failures (space / member / invite /

--- a/pkg/errcode/space.go
+++ b/pkg/errcode/space.go
@@ -1,0 +1,174 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// err.server.space.* — modules/space business error codes (api.go /
+// api_manager.go / api_email_invite*.go). DefaultMessage holds the en-US source
+// (D4); the zh-CN runtime translation lives in pkg/i18n/locales/active.zh-CN.toml.
+// Internal=true codes never surface their message on the wire — callers MUST log
+// the underlying err with full context (zap.Error) before responding.
+var (
+	// ---- validation (400) ----------------------------------------------------
+
+	// ErrSpaceRequestInvalid is the catch-all for missing/malformed request
+	// input (BindJSON failure, "X 不能为空", invalid enum / mode / status / role
+	// values, "at least one of ... required", negative numbers). The offending
+	// field is surfaced via Details when the caller can identify it.
+	ErrSpaceRequestInvalid = register(codes.Code{
+		ID:             "err.server.space.request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid request.",
+		SafeDetailKeys: []string{"field"},
+	})
+	// ErrSpaceFieldTooLong covers the name / description / logo length caps. The
+	// field name and its max length are surfaced so the client can render a
+	// localized hint without hard-coding the limit.
+	ErrSpaceFieldTooLong = register(codes.Code{
+		ID:             "err.server.space.field_too_long",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The field exceeds the maximum allowed length.",
+		SafeDetailKeys: []string{"field", "max_chars"},
+	})
+	// ErrSpaceBatchTooLarge covers the per-request member batch cap.
+	ErrSpaceBatchTooLarge = register(codes.Code{
+		ID:             "err.server.space.batch_too_large",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Too many members in a single request.",
+		SafeDetailKeys: []string{"max"},
+	})
+
+	// ---- permission / authorization (403) ------------------------------------
+
+	// ErrSpacePermissionDenied covers the space-level authorization guards
+	// ("no permission to ...", "only the owner may ..."). Distinct from the
+	// route-level err.shared.auth.forbidden role guard.
+	ErrSpacePermissionDenied = register(codes.Code{
+		ID:             "err.server.space.permission_denied",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You do not have permission to perform this operation.",
+	})
+	// ErrSpaceNotMember covers the "you are not a member of this space" guard.
+	ErrSpaceNotMember = register(codes.Code{
+		ID:             "err.server.space.not_member",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You are not a member of this space.",
+	})
+	// ErrSpaceCreationDisabled covers the admin-disabled space-creation switch.
+	ErrSpaceCreationDisabled = register(codes.Code{
+		ID:             "err.server.space.creation_disabled",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Space creation has been disabled by the administrator.",
+	})
+
+	// ---- not found (404) -----------------------------------------------------
+
+	// ErrSpaceNotFound covers a missing / disbanded space.
+	ErrSpaceNotFound = register(codes.Code{
+		ID:             "err.server.space.not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Space not found or has been disbanded.",
+	})
+	// ErrSpaceApplyNotFound covers a missing join-application record, or one that
+	// does not belong to the current space (merged so callers cannot probe
+	// cross-space application IDs).
+	ErrSpaceApplyNotFound = register(codes.Code{
+		ID:             "err.server.space.apply_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Join application not found.",
+	})
+	// ErrSpaceInviteCodeNotFound covers a missing invite code.
+	ErrSpaceInviteCodeNotFound = register(codes.Code{
+		ID:             "err.server.space.invite_code_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Invite code not found.",
+	})
+	// ErrSpaceMemberNotFound covers a missing / already-removed target member or
+	// target user.
+	ErrSpaceMemberNotFound = register(codes.Code{
+		ID:             "err.server.space.member_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "The target member does not exist or has been removed.",
+	})
+
+	// ---- invite / auth code state (400, anti-enumeration) --------------------
+
+	// ErrSpaceInviteCodeInvalid is the single anti-enumeration code for an
+	// invalid / expired / malformed invite or auth code (public preview and
+	// join-approve flows). The specific reason is logged, never returned, so an
+	// unauthenticated caller cannot probe which state a code is in.
+	ErrSpaceInviteCodeInvalid = register(codes.Code{
+		ID:             "err.server.space.invite_code_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The invite code is invalid or has expired.",
+	})
+
+	// ---- conflict / state (409) ----------------------------------------------
+
+	// ErrSpaceInviteCodeExhausted covers an invite code that has reached its use
+	// cap or is otherwise spent.
+	ErrSpaceInviteCodeExhausted = register(codes.Code{
+		ID:             "err.server.space.invite_code_exhausted",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "The invite code has reached its usage limit.",
+	})
+	// ErrSpaceAlreadyMember covers re-joining a space the caller already belongs
+	// to.
+	ErrSpaceAlreadyMember = register(codes.Code{
+		ID:             "err.server.space.already_member",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "You are already a member of this space.",
+	})
+	// ErrSpaceApplyProcessed covers approving / rejecting an application that has
+	// already been handled.
+	ErrSpaceApplyProcessed = register(codes.Code{
+		ID:             "err.server.space.apply_processed",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "This application has already been processed.",
+	})
+	// ErrSpaceFull covers hitting the space member cap.
+	ErrSpaceFull = register(codes.Code{
+		ID:             "err.server.space.full",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "The space is full.",
+	})
+	// ErrSpaceImmutable covers mutations rejected because the space is disbanded
+	// or banned (cannot modify / add members / update status).
+	ErrSpaceImmutable = register(codes.Code{
+		ID:             "err.server.space.immutable",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "The space has been disbanded or banned and cannot be modified.",
+	})
+	// ErrSpaceOwnerConstraint covers owner-specific transfer/leave/demote
+	// constraints (owner must transfer ownership before leaving; cannot remove or
+	// directly demote the owner).
+	ErrSpaceOwnerConstraint = register(codes.Code{
+		ID:             "err.server.space.owner_constraint",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "Transfer ownership before performing this operation.",
+	})
+
+	// ---- internal (500, Internal=true) ---------------------------------------
+
+	// ErrSpaceQueryFailed covers read-path failures (space / member / invite /
+	// application SELECTs and counts, use-count checks, user validation). Log the
+	// underlying err before responding.
+	ErrSpaceQueryFailed = register(codes.Code{
+		ID:             "err.server.space.query_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to query space data.",
+		Internal:       true,
+	})
+	// ErrSpaceStoreFailed covers mutation-path failures (create / update / join /
+	// add / remove / leave / disband / role change / ownership transfer / invite
+	// write, transaction begin/commit). Log the underlying err before responding.
+	ErrSpaceStoreFailed = register(codes.Code{
+		ID:             "err.server.space.store_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to update space data.",
+		Internal:       true,
+	})
+)

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -801,6 +801,18 @@ other = "空间已解散或已封禁，无法修改。"
 ["err.server.space.owner_constraint"]
 other = "请先转让拥有权后再执行此操作。"
 
+["err.server.space.email_invite_not_found"]
+other = "邀请不存在。"
+
+["err.server.space.email_invite_invalid"]
+other = "邀请无效或已过期。"
+
+["err.server.space.email_invite_processed"]
+other = "该邀请已被处理。"
+
+["err.server.space.email_invite_email_mismatch"]
+other = "邮箱与邀请目标不一致。"
+
 ["err.server.space.query_failed"]
 other = "查询空间数据失败。"
 

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -747,3 +747,62 @@ other = "生成机器人令牌失败。"
 
 ["err.server.robot.auth_check_failed"]
 other = "机器人鉴权校验失败。"
+
+# ---- err.server.space.* (modules/space: api.go / api_manager.go / api_email_invite*.go) ----
+
+["err.server.space.request_invalid"]
+other = "请求参数有误。"
+
+["err.server.space.field_too_long"]
+other = "字段长度超过限制。"
+
+["err.server.space.batch_too_large"]
+other = "单次处理的成员数量过多。"
+
+["err.server.space.permission_denied"]
+other = "你没有权限执行此操作。"
+
+["err.server.space.not_member"]
+other = "你不是该空间成员。"
+
+["err.server.space.creation_disabled"]
+other = "管理员已关闭空间创建功能。"
+
+["err.server.space.not_found"]
+other = "空间不存在或已解散。"
+
+["err.server.space.apply_not_found"]
+other = "申请记录不存在。"
+
+["err.server.space.invite_code_not_found"]
+other = "邀请码不存在。"
+
+["err.server.space.member_not_found"]
+other = "目标成员不存在或已被移除。"
+
+["err.server.space.invite_code_invalid"]
+other = "邀请码无效或已过期。"
+
+["err.server.space.invite_code_exhausted"]
+other = "邀请码已达到使用次数上限。"
+
+["err.server.space.already_member"]
+other = "你已经是该空间成员。"
+
+["err.server.space.apply_processed"]
+other = "该申请已被处理。"
+
+["err.server.space.full"]
+other = "空间已满。"
+
+["err.server.space.immutable"]
+other = "空间已解散或已封禁，无法修改。"
+
+["err.server.space.owner_constraint"]
+other = "请先转让拥有权后再执行此操作。"
+
+["err.server.space.query_failed"]
+other = "查询空间数据失败。"
+
+["err.server.space.store_failed"]
+other = "更新空间数据失败。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -375,6 +375,63 @@ other = "Failed to generate the robot token."
 ["err.server.robot.upload_failed"]
 other = "Failed to process the file."
 
+["err.server.space.already_member"]
+other = "You are already a member of this space."
+
+["err.server.space.apply_not_found"]
+other = "Join application not found."
+
+["err.server.space.apply_processed"]
+other = "This application has already been processed."
+
+["err.server.space.batch_too_large"]
+other = "Too many members in a single request."
+
+["err.server.space.creation_disabled"]
+other = "Space creation has been disabled by the administrator."
+
+["err.server.space.field_too_long"]
+other = "The field exceeds the maximum allowed length."
+
+["err.server.space.full"]
+other = "The space is full."
+
+["err.server.space.immutable"]
+other = "The space has been disbanded or banned and cannot be modified."
+
+["err.server.space.invite_code_exhausted"]
+other = "The invite code has reached its usage limit."
+
+["err.server.space.invite_code_invalid"]
+other = "The invite code is invalid or has expired."
+
+["err.server.space.invite_code_not_found"]
+other = "Invite code not found."
+
+["err.server.space.member_not_found"]
+other = "The target member does not exist or has been removed."
+
+["err.server.space.not_found"]
+other = "Space not found or has been disbanded."
+
+["err.server.space.not_member"]
+other = "You are not a member of this space."
+
+["err.server.space.owner_constraint"]
+other = "Transfer ownership before performing this operation."
+
+["err.server.space.permission_denied"]
+other = "You do not have permission to perform this operation."
+
+["err.server.space.query_failed"]
+other = "Failed to query space data."
+
+["err.server.space.request_invalid"]
+other = "Invalid request."
+
+["err.server.space.store_failed"]
+other = "Failed to update space data."
+
 ["err.server.thread.creator_cannot_leave"]
 other = "Thread creator cannot leave the thread."
 

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -390,6 +390,18 @@ other = "Too many members in a single request."
 ["err.server.space.creation_disabled"]
 other = "Space creation has been disabled by the administrator."
 
+["err.server.space.email_invite_email_mismatch"]
+other = "The email does not match the invite."
+
+["err.server.space.email_invite_invalid"]
+other = "The invite is invalid or has expired."
+
+["err.server.space.email_invite_not_found"]
+other = "Email invite not found."
+
+["err.server.space.email_invite_processed"]
+other = "This invite has already been processed."
+
 ["err.server.space.field_too_long"]
 other = "The field exceeds the maximum allowed length."
 


### PR DESCRIPTION
Closes #269. Part of #170 (i18n — backend / octo-server).

Migrates the entire `space` module — the largest remaining Phase 2 hotspot — to the i18n error envelope, reusing the merged `group`/`message`/`robot` playbook. Its only blocker (email i18n) was already lifted by #224, so this is a pure response-facade migration with no email / no gRPC dependency.

## Scope — 321 sites across 5 files
| File | sites |
|---|---|
| `modules/space/api.go` | 150 (core space CRUD / members / settings / public invite-preview + join-approve) |
| `modules/space/api_manager.go` | 114 (admin console) |
| `modules/space/api_email_invite_public.go` | 28 (public preview + authenticated accept) |
| `modules/space/api_email_invite.go` | 17 |
| `modules/space/api_manager_email_invite.go` | 12 |

23 `err.server.space.*` codes registered (validation 400 / permission 403 / not-found 404 / invite-code state 400-409 / conflict 409 / 4 email-invite codes / internal 500 `Internal=true`), plus zh-CN translations and the regenerated en-US markers.

## Key decisions (review focus)
- **Business errors keep wire 400 (D14)** — legacy `c.ResponseError` already returned 400, so the dmwork-facing endpoints have **zero wire-status drift**; the real semantic status rides in `error.http_status`. The admin "space creation disabled" path (previously `ResponseErrorWithStatus(403)`) now renders D14 wire-400 + `error.http_status=403`, consistent with the merged `group` precedent (its integration tests were updated accordingly).
- **`CheckLoginRole*` role guards** (`requireAdmin`) → `err.shared.auth.forbidden`.
- **Public invite preview** (`previewEmailInvite`, unauthenticated) keeps its existing anti-enumeration shape — always `200` with a `status` field, never a 4xx that distinguishes invalid/expired/revoked. The invite-code-invalid path collapses invalid/expired/malformed codes into one anti-enum code.
- **Authenticated accept flow** uses distinct email-invite codes (the caller already proved identity and must match the invited email), so invalid / processed / email-mismatch are separated for UX.
- **DB / internal failures** → `Internal=true` codes; existing `s.Error` logs preserved. `requireSpaceAdmin` was refactored to write its own response (bool) instead of passing a service-layer error string through `c.ResponseError`.

## Tests
- `TestSpaceNoLegacyResponseError` — source guard over the 5 migrated files (bans `.ResponseError(` / `.ResponseErrorf(` / `.ResponseErrorWithStatus(` / `.AbortWithStatus*` / raw `c.Response("`).
- `TestRespondSpaceHelpers` — table cases for the rendered dual envelope (field details, 403/404/409 mappings, `Internal=true` copy-collapse with no English leak).
- `newRenderedTestServer` wires the i18n ErrorRenderer (mirrors `main.go` boot) into every space test server; the existing integration assertions were converted from brittle zh-CN body-substring matching to `assertSpaceErrorCode`, and the creation-disabled tests now assert the D14 wire-400.

## Verification
`go build ./...`, `go vet ./modules/space/...`, `make i18n-extract-check`, `make i18n-lint`, and `go test ./modules/space/` (full suite incl. DB integration) all green.

## Follow-ups (non-blocking)
- ~30 internal-failure sites where the original code already discarded the underlying `err` (static-string `ResponseError`, no log) are migrated as-is — adding `zap.Error` there is a recommended follow-up (not a regression).
- Service-layer sentinel errors instead of string matching (same follow-up as thread/user/group/message).
