### PR TITLE
feat(i18n): migrate small utility modules to ResponseErrorL

### DIFF
--- a/modules/qrcode/api.go
+++ b/modules/qrcode/api.go
@@ -1,22 +1,23 @@
 package qrcode
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
-	"github.com/Mininglamp-OSS/octo-server/modules/group"
-	spacemod "github.com/Mininglamp-OSS/octo-server/modules/space"
-	"github.com/Mininglamp-OSS/octo-server/modules/user"
-	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
-	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	spacemod "github.com/Mininglamp-OSS/octo-server/modules/space"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"go.uber.org/zap"
 )
 
@@ -64,13 +65,13 @@ func (q *QRCode) Route(r *wkhttp.WKHttp) {
 func (q *QRCode) handleQRCodeInfo(c *wkhttp.Context) {
 	token := c.GetHeader("token")
 	if token == "" {
-		c.ResponseError(errors.New("token不能为空！"))
+		respondQRCodeTokenRequired(c)
 		return
 	}
 	raw, err := q.ctx.Cache().Get(q.ctx.GetConfig().Cache.TokenCachePrefix + token)
 	if err != nil {
 		q.Error("获取登录信息失败！", zap.Error(err))
-		c.ResponseError(errors.New("获取登录信息失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrQRCodeQueryFailed, nil, nil)
 		return
 	}
 	if strings.TrimSpace(raw) == "" {
@@ -79,7 +80,7 @@ func (q *QRCode) handleQRCodeInfo(c *wkhttp.Context) {
 	}
 	info, decodeErr := auth.Decode(raw)
 	if decodeErr != nil {
-		c.ResponseError(errors.New("登录信息格式错误！"))
+		httperr.ResponseErrorL(c, errcode.ErrQRCodeTokenInvalid, nil, nil)
 		return
 	}
 	loginUID := info.UID
@@ -88,18 +89,18 @@ func (q *QRCode) handleQRCodeInfo(c *wkhttp.Context) {
 	if strings.HasPrefix(code, "user_") { // 用户资料二维码 格式： user_xxxx
 		targetUID := code[len("user_"):]
 		if targetUID == "" {
-			c.ResponseError(errors.New("用户UID不能为空"))
+			respondQRCodeRequestInvalid(c, "uid")
 			return
 		}
 		// Validate target user exists
 		targetUser, err := q.userService.GetUser(targetUID)
 		if err != nil {
 			q.Error("查询目标用户失败", zap.String("targetUID", targetUID), zap.Error(err))
-			c.ResponseError(errors.New("查询用户信息失败"))
+			httperr.ResponseErrorL(c, errcode.ErrQRCodeQueryFailed, nil, nil)
 			return
 		}
 		if targetUser == nil {
-			c.ResponseError(errors.New("用户不存在"))
+			httperr.ResponseErrorL(c, errcode.ErrQRCodeUserNotFound, nil, nil)
 			return
 		}
 		c.Response(NewHandleResult(ForwardNative, HandlerTypeUserInfo, map[string]interface{}{
@@ -111,11 +112,12 @@ func (q *QRCode) handleQRCodeInfo(c *wkhttp.Context) {
 		qrvercode := code[len("vercode_"):]
 		userResp, err := q.userService.GetUserWithQRVercode(qrvercode)
 		if err != nil {
-			c.ResponseErrorf("通过qrvercode获取用户信息失败！", err)
+			q.Error("通过qrvercode获取用户信息失败", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrQRCodeQueryFailed, nil, nil)
 			return
 		}
 		if userResp == nil {
-			c.ResponseError(errors.New("用户不存在！"))
+			httperr.ResponseErrorL(c, errcode.ErrQRCodeUserNotFound, nil, nil)
 			return
 		}
 		c.Response(NewHandleResult(ForwardNative, HandlerTypeUserInfo, map[string]interface{}{
@@ -128,19 +130,19 @@ func (q *QRCode) handleQRCodeInfo(c *wkhttp.Context) {
 	qrcodeContent, err := q.ctx.GetRedisConn().GetString(fmt.Sprintf("%s%s", common.QRCodeCachePrefix, code))
 	if err != nil {
 		q.Error("获取二维码信息失败！", zap.Error(err))
-		c.ResponseError(errors.New("获取二维码信息失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrQRCodeQueryFailed, nil, nil)
 		return
 	}
 	if qrcodeContent == "" {
 		q.Error("二维码或已过期！", zap.String("code", code))
-		c.ResponseError(errors.New("二维码或已过期！"))
+		httperr.ResponseErrorL(c, errcode.ErrQRCodeNotFound, nil, nil)
 		return
 	}
 	var qrCodeModel common.QRCodeModel
 	err = util.ReadJsonByByte([]byte(qrcodeContent), &qrCodeModel)
 	if err != nil {
 		q.Error("解码二维码信息失败！", zap.Error(err))
-		c.ResponseError(errors.New("解码二维码信息失败！"))
+		respondQRCodeRequestInvalid(c, "code")
 		return
 	}
 	var result interface{}
@@ -150,11 +152,11 @@ func (q *QRCode) handleQRCodeInfo(c *wkhttp.Context) {
 	case common.QRCodeTypeScanLogin: // 扫描登录
 		result, err = q.handleScanLogin(loginUID, code, qrCodeModel)
 	default:
-		err = errors.New("不支持的扫码类型！")
+		err = errQRCodeUnsupportedType
 	}
 	if err != nil {
 		q.Error("处理请求失败！", zap.Error(err))
-		c.ResponseError(err)
+		respondQRCodeHandleError(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, result)
@@ -171,7 +173,7 @@ func (q *QRCode) handleScanLogin(loginUID string, uuid string, qrCodeModel commo
 	}), time.Minute*10)
 	if err != nil {
 		q.Error("生成扫码登录授权码失败", zap.Error(err))
-		return nil, errors.New("生成登录授权码失败，请稍后重试")
+		return nil, fmt.Errorf("%w: scan login auth code", errQRCodeInternalStoreFailed)
 	}
 	var pubkey string
 	if qrCodeModel.Data != nil && qrCodeModel.Data["pub_key"] != nil {
@@ -185,7 +187,7 @@ func (q *QRCode) handleScanLogin(loginUID string, uuid string, qrCodeModel commo
 	err = q.ctx.GetRedisConn().SetAndExpire(fmt.Sprintf("%s%s", common.QRCodeCachePrefix, uuid), util.ToJson(qrcodeInfo), time.Minute*5)
 	if err != nil {
 		q.Error("设置扫描登录二维码信息失败", zap.Error(err))
-		return nil, errors.New("扫码登录失败，请稍后重试")
+		return nil, fmt.Errorf("%w: scan login state", errQRCodeInternalStoreFailed)
 	}
 	user.SendQRCodeInfo(uuid, qrcodeInfo)
 	return NewHandleResult(ForwardNative, HandlerTypeLoginConfirm, map[string]interface{}{
@@ -212,21 +214,21 @@ func (q *QRCode) handleJoinGroup(loginUID string, qrCodeModel common.QRCodeModel
 
 	groupNo, ok := qrCodeModel.Data["group_no"].(string)
 	if !ok {
-		return nil, errors.New("invalid QR code data: missing or invalid group_no")
+		return nil, fmt.Errorf("%w: group_no", errQRCodeGroupDataInvalid)
 	}
 	generator, ok := qrCodeModel.Data["generator"].(string)
 	if !ok {
-		return nil, errors.New("invalid QR code data: missing or invalid generator")
+		return nil, fmt.Errorf("%w: generator", errQRCodeGroupDataInvalid)
 	}
 
 	// 查询群信息用于预览
 	groupModel, err := q.groupDB.QueryWithGroupNo(groupNo)
 	if err != nil {
 		q.Error("查询群信息失败", zap.Error(err))
-		return nil, errors.New("获取群信息失败，请稍后重试")
+		return nil, fmt.Errorf("%w: group", errQRCodeInternalQueryFailed)
 	}
 	if groupModel == nil {
-		return nil, errors.New("群不存在")
+		return nil, errQRCodeGroupNotFound
 	}
 
 	// 扫码预检仅拦截「群禁止外部成员且扫码者非 Space 成员」的场景。
@@ -238,23 +240,23 @@ func (q *QRCode) handleJoinGroup(loginUID string, qrCodeModel common.QRCodeModel
 		isMember, err := spacepkg.CheckMembership(q.ctx.DB(), groupModel.SpaceID, loginUID)
 		if err != nil {
 			q.Error("查询空间成员失败", zap.Error(err))
-			return nil, errors.New("校验空间成员失败，请稍后重试")
+			return nil, fmt.Errorf("%w: space membership", errQRCodeInternalQueryFailed)
 		}
 		if !isMember {
-			return nil, errors.New("该群仅允许本空间成员加入")
+			return nil, errQRCodeGroupSpaceForbidden
 		}
 	}
 
 	memberCount, err := q.groupDB.QueryMemberCount(groupNo)
 	if err != nil {
 		q.Error("查询群成员数失败", zap.Error(err))
-		return nil, errors.New("获取群信息失败，请稍后重试")
+		return nil, fmt.Errorf("%w: member count", errQRCodeInternalQueryFailed)
 	}
 
 	exist, err := q.groupDB.ExistMember(loginUID, groupNo)
 	if err != nil {
 		q.Error("查询群成员失败", zap.Error(err))
-		return nil, errors.New("获取群信息失败，请稍后重试")
+		return nil, fmt.Errorf("%w: membership", errQRCodeInternalQueryFailed)
 	}
 	if exist {
 		return NewHandleResult(ForwardNative, HandlerTypeGroup, map[string]interface{}{
@@ -275,7 +277,7 @@ func (q *QRCode) handleJoinGroup(loginUID string, qrCodeModel common.QRCodeModel
 	}), time.Minute*30)
 	if err != nil {
 		q.Error("生成入群授权码失败", zap.Error(err))
-		return nil, errors.New("生成入群授权码失败，请稍后重试")
+		return nil, fmt.Errorf("%w: join group auth code", errQRCodeInternalStoreFailed)
 	}
 	return NewHandleResult(ForwardNative, HandlerTypeGroup, map[string]interface{}{
 		"group_no":     groupNo,

--- a/modules/qrcode/api_i18n.go
+++ b/modules/qrcode/api_i18n.go
@@ -1,0 +1,46 @@
+package qrcode
+
+import (
+	"errors"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+var (
+	errQRCodeUnsupportedType     = errors.New("qrcode: unsupported type")
+	errQRCodeGroupDataInvalid    = errors.New("qrcode: group data invalid")
+	errQRCodeGroupNotFound       = errors.New("qrcode: group not found")
+	errQRCodeGroupSpaceForbidden = errors.New("qrcode: group space forbidden")
+	errQRCodeInternalQueryFailed = errors.New("qrcode: internal query failed")
+	errQRCodeInternalStoreFailed = errors.New("qrcode: internal store failed")
+)
+
+func respondQRCodeRequestInvalid(c *wkhttp.Context, field string) {
+	details := i18n.Details{}
+	if field != "" {
+		details["field"] = field
+	}
+	httperr.ResponseErrorL(c, errcode.ErrQRCodeRequestInvalid, nil, details)
+}
+
+func respondQRCodeTokenRequired(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errcode.ErrQRCodeTokenRequired, nil, i18n.Details{"field": "token"})
+}
+
+func respondQRCodeHandleError(c *wkhttp.Context, err error) {
+	switch {
+	case errors.Is(err, errQRCodeGroupDataInvalid), errors.Is(err, errQRCodeUnsupportedType):
+		respondQRCodeRequestInvalid(c, "code")
+	case errors.Is(err, errQRCodeGroupNotFound):
+		httperr.ResponseErrorL(c, errcode.ErrQRCodeGroupNotFound, nil, nil)
+	case errors.Is(err, errQRCodeGroupSpaceForbidden):
+		httperr.ResponseErrorL(c, errcode.ErrQRCodeGroupSpaceForbidden, nil, nil)
+	case errors.Is(err, errQRCodeInternalStoreFailed):
+		httperr.ResponseErrorL(c, errcode.ErrQRCodeStoreFailed, nil, nil)
+	default:
+		httperr.ResponseErrorL(c, errcode.ErrQRCodeQueryFailed, nil, nil)
+	}
+}

--- a/modules/qrcode/api_i18n_test.go
+++ b/modules/qrcode/api_i18n_test.go
@@ -1,0 +1,129 @@
+package qrcode
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+type qrErrEnvelope struct {
+	Error struct {
+		Code       string         `json:"code"`
+		Details    map[string]any `json:"details"`
+		HTTPStatus int            `json:"http_status"`
+	} `json:"error"`
+	Status int `json:"status"`
+}
+
+func TestQRCodeNoLegacyResponseError(t *testing.T) {
+	files := []string{"api.go"}
+	banned := []string{
+		".ResponseError(",
+		".ResponseErrorf(",
+		".ResponseErrorWithStatus(",
+		".AbortWithStatusJSON(",
+		".AbortWithStatus(",
+		".ResponseWithStatus(",
+		"c.Response(\"",
+	}
+	for _, f := range files {
+		t.Run(f, func(t *testing.T) {
+			data, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+			cleaned := stripLineComments(string(data))
+			for _, b := range banned {
+				if strings.Contains(cleaned, b) {
+					t.Fatalf("modules/qrcode/%s must use httperr.ResponseErrorL instead of legacy %s", f, b)
+				}
+			}
+			for _, line := range strings.Split(cleaned, "\n") {
+				if strings.Contains(line, "c.JSON(http.Status") && !strings.Contains(line, "c.JSON(http.StatusOK") {
+					t.Fatalf("modules/qrcode/%s must not use raw non-OK c.JSON: %s", f, strings.TrimSpace(line))
+				}
+			}
+		})
+	}
+}
+
+func TestRespondQRCodeHelpers(t *testing.T) {
+	cases := []struct {
+		name       string
+		probe      func(c *wkhttp.Context)
+		wantCode   string
+		wantHTTP   int
+		wantDetail string
+	}{
+		{
+			name:       "token_required",
+			probe:      respondQRCodeTokenRequired,
+			wantCode:   "err.server.qrcode.token_required",
+			wantHTTP:   http.StatusBadRequest,
+			wantDetail: "token",
+		},
+		{
+			name:     "group_space_forbidden",
+			probe:    func(c *wkhttp.Context) { respondQRCodeHandleError(c, errQRCodeGroupSpaceForbidden) },
+			wantCode: "err.server.qrcode.group_space_forbidden",
+			wantHTTP: http.StatusForbidden,
+		},
+		{
+			name:     "wrapped_store_failed",
+			probe:    func(c *wkhttp.Context) { respondQRCodeHandleError(c, errors.Join(errQRCodeInternalStoreFailed)) },
+			wantCode: "err.server.qrcode.store_failed",
+			wantHTTP: http.StatusInternalServerError,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := exerciseQRCodeHelper(t, tc.probe)
+			if env.Status != http.StatusBadRequest {
+				t.Fatalf("wire status = %d, want 400", env.Status)
+			}
+			if env.Error.Code != tc.wantCode {
+				t.Fatalf("code = %q, want %q", env.Error.Code, tc.wantCode)
+			}
+			if env.Error.HTTPStatus != tc.wantHTTP {
+				t.Fatalf("http_status = %d, want %d", env.Error.HTTPStatus, tc.wantHTTP)
+			}
+			if tc.wantDetail != "" && env.Error.Details["field"] != tc.wantDetail {
+				t.Fatalf("field detail = %v, want %q", env.Error.Details["field"], tc.wantDetail)
+			}
+		})
+	}
+}
+
+func exerciseQRCodeHelper(t *testing.T, probe func(c *wkhttp.Context)) qrErrEnvelope {
+	t.Helper()
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	r.GET("/probe", probe)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	r.ServeHTTP(w, req)
+	var env qrErrEnvelope
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode envelope: %v\nbody: %s", err, w.Body.String())
+	}
+	return env
+}
+
+func stripLineComments(src string) string {
+	var clean strings.Builder
+	for _, line := range strings.Split(src, "\n") {
+		if idx := strings.Index(line, "//"); idx >= 0 {
+			line = line[:idx]
+		}
+		clean.WriteString(line)
+		clean.WriteByte('\n')
+	}
+	return clean.String()
+}

--- a/modules/report/api.go
+++ b/modules/report/api.go
@@ -10,14 +10,19 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/util"
+	"go.uber.org/zap"
 )
 
 // Report 举报
 type Report struct {
 	ctx *config.Context
 	db  *db
+	log.Log
 }
 
 // New 创建一个举报对象
@@ -25,6 +30,7 @@ func New(ctx *config.Context) *Report {
 	return &Report{
 		ctx: ctx,
 		db:  newDB(ctx),
+		Log: log.NewTLog("report"),
 	}
 }
 
@@ -85,18 +91,24 @@ func (r *Report) resolveSession(c *wkhttp.Context) {
 		SessionID string `json:"session_id"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseErrorf("请求数据格式有误！", err)
+		r.Error("请求数据格式有误", zap.Error(err))
+		respondReportRequestInvalid(c, "")
 		return
 	}
 	if req.SessionID == "" {
-		c.ResponseError(errors.New("session_id不能为空"))
+		respondReportRequestInvalid(c, "session_id")
 		return
 	}
 
 	key := fmt.Sprintf("%s%s", reportSessionPrefix, req.SessionID)
 	data, err := r.ctx.GetRedisConn().GetString(key)
-	if err != nil || data == "" {
-		c.ResponseError(errors.New("会话已过期或无效"))
+	if err != nil {
+		r.Error("查询举报会话失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrReportQueryFailed, nil, nil)
+		return
+	}
+	if data == "" {
+		httperr.ResponseErrorL(c, errcode.ErrReportSessionInvalid, nil, nil)
 		return
 	}
 
@@ -108,7 +120,8 @@ func (r *Report) resolveSession(c *wkhttp.Context) {
 		Token string `json:"token"`
 	}
 	if err := json.Unmarshal([]byte(data), &session); err != nil || session.UID == "" || session.Token == "" {
-		c.ResponseError(errors.New("会话数据无效"))
+		r.Warn("举报会话数据无效", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrReportSessionInvalid, nil, nil)
 		return
 	}
 
@@ -122,11 +135,12 @@ func (r *Report) resolveSession(c *wkhttp.Context) {
 func (r *Report) report(c *wkhttp.Context) {
 	var req reportReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseErrorf("请求数据格式有误！", err)
+		r.Error("请求数据格式有误", zap.Error(err))
+		respondReportRequestInvalid(c, "")
 		return
 	}
-	if err := req.check(); err != nil {
-		c.ResponseError(err)
+	if field := req.invalidField(); field != "" {
+		respondReportRequestInvalid(c, field)
 		return
 	}
 
@@ -144,7 +158,8 @@ func (r *Report) report(c *wkhttp.Context) {
 		ChannelType: req.ChannelType,
 	})
 	if err != nil {
-		c.ResponseErrorf("添加举报数据失败！", err)
+		r.Error("添加举报数据失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrReportStoreFailed, nil, nil)
 		return
 	}
 
@@ -166,7 +181,8 @@ func (r *Report) categoies(c *wkhttp.Context) {
 
 	categoryModels, err := r.db.queryCategoryAll()
 	if err != nil {
-		c.ResponseErrorf("查询类别失败！", err)
+		r.Error("查询举报类别失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrReportQueryFailed, nil, nil)
 		return
 	}
 
@@ -241,15 +257,28 @@ type reportReq struct {
 	Remark      string   `json:"remark"`       // 举报备注
 }
 
-func (r reportReq) check() error {
+func (r reportReq) invalidField() string {
 	if r.ChannelID == "" {
-		return errors.New("频道ID不能为空！")
+		return "channel_id"
 	}
 	if r.ChannelType <= 0 {
-		return errors.New("频道类型不能为空！")
+		return "channel_type"
 	}
 	if r.CategoryNo == "" {
-		return errors.New("举报类别不能为空！")
+		return "category_no"
 	}
-	return nil
+	return ""
+}
+
+func (r reportReq) check() error {
+	switch r.invalidField() {
+	case "channel_id":
+		return errors.New("频道ID不能为空！")
+	case "channel_type":
+		return errors.New("频道类型不能为空！")
+	case "category_no":
+		return errors.New("举报类别不能为空！")
+	default:
+		return nil
+	}
 }

--- a/modules/report/api_i18n.go
+++ b/modules/report/api_i18n.go
@@ -1,0 +1,16 @@
+package report
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+func respondReportRequestInvalid(c *wkhttp.Context, field string) {
+	details := i18n.Details{}
+	if field != "" {
+		details["field"] = field
+	}
+	httperr.ResponseErrorL(c, errcode.ErrReportRequestInvalid, nil, details)
+}

--- a/modules/report/api_i18n_test.go
+++ b/modules/report/api_i18n_test.go
@@ -1,0 +1,111 @@
+package report
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+func TestReportNoLegacyResponseError(t *testing.T) {
+	files := []string{"api.go", "api_manager.go"}
+	for _, f := range files {
+		t.Run(f, func(t *testing.T) {
+			data, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+			cleaned := stripReportLineComments(string(data))
+			for _, b := range []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(", ".AbortWithStatusJSON(", ".AbortWithStatus(", ".ResponseWithStatus(", "c.Response(\""} {
+				if strings.Contains(cleaned, b) {
+					t.Fatalf("modules/report/%s must use httperr.ResponseErrorL instead of legacy %s", f, b)
+				}
+			}
+			for _, line := range strings.Split(cleaned, "\n") {
+				if strings.Contains(line, "c.JSON(http.Status") && !strings.Contains(line, "c.JSON(http.StatusOK") {
+					t.Fatalf("modules/report/%s must not use raw non-OK c.JSON: %s", f, strings.TrimSpace(line))
+				}
+			}
+		})
+	}
+}
+
+func TestRespondReportHelpers(t *testing.T) {
+	cases := []struct {
+		name     string
+		probe    func(c *wkhttp.Context)
+		wantCode string
+		wantHTTP int
+	}{
+		{
+			name:     "request_invalid",
+			probe:    func(c *wkhttp.Context) { respondReportRequestInvalid(c, "channel_id") },
+			wantCode: "err.server.report.request_invalid",
+			wantHTTP: http.StatusBadRequest,
+		},
+		{
+			name:     "session_invalid",
+			probe:    func(c *wkhttp.Context) { httperr.ResponseErrorL(c, errcode.ErrReportSessionInvalid, nil, nil) },
+			wantCode: "err.server.report.session_invalid",
+			wantHTTP: http.StatusBadRequest,
+		},
+		{
+			name:     "query_failed",
+			probe:    func(c *wkhttp.Context) { httperr.ResponseErrorL(c, errcode.ErrReportQueryFailed, nil, nil) },
+			wantCode: "err.server.report.query_failed",
+			wantHTTP: http.StatusInternalServerError,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := exerciseReportHelper(t, tc.probe)
+			if env.Error.Code != tc.wantCode {
+				t.Fatalf("code = %q, want %q", env.Error.Code, tc.wantCode)
+			}
+			if env.Error.HTTPStatus != tc.wantHTTP {
+				t.Fatalf("http_status = %d, want %d", env.Error.HTTPStatus, tc.wantHTTP)
+			}
+		})
+	}
+}
+
+type reportErrEnvelope struct {
+	Error struct {
+		Code       string `json:"code"`
+		HTTPStatus int    `json:"http_status"`
+	} `json:"error"`
+}
+
+func exerciseReportHelper(t *testing.T, probe func(c *wkhttp.Context)) reportErrEnvelope {
+	t.Helper()
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	r.GET("/probe", probe)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	r.ServeHTTP(w, req)
+	var env reportErrEnvelope
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode envelope: %v\nbody: %s", err, w.Body.String())
+	}
+	return env
+}
+
+func stripReportLineComments(src string) string {
+	var clean strings.Builder
+	for _, line := range strings.Split(src, "\n") {
+		if idx := strings.Index(line, "//"); idx >= 0 {
+			line = line[:idx]
+		}
+		clean.WriteString(line)
+		clean.WriteByte('\n')
+	}
+	return clean.String()
+}

--- a/modules/report/api_manager.go
+++ b/modules/report/api_manager.go
@@ -1,16 +1,17 @@
 package report
 
 import (
-	"errors"
 	"strings"
 
-	"github.com/Mininglamp-OSS/octo-server/modules/group"
-	wkutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
-	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	wkutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
 	"go.uber.org/zap"
 )
 
@@ -49,26 +50,26 @@ func (m *Manager) Route(l *wkhttp.WKHttp) {
 func (m *Manager) reportList(c *wkhttp.Context) {
 	err := c.CheckLoginRole()
 	if err != nil {
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrSharedForbidden, nil, nil)
 		return
 	}
 	pageIndex, pageSize := c.GetPage()
 	channelType := c.Query("channel_type")
 	if channelType == "" {
-		c.ResponseError(errors.New("查询频道类型不能为空"))
+		respondReportRequestInvalid(c, "channel_type")
 		return
 	}
 	queryChannelType := wkutil.AtoiOrDefault(channelType, 0)
 	list, err := m.managerDB.list(uint64(pageSize), uint64(pageIndex), queryChannelType)
 	if err != nil {
 		m.Error("查询举报列表错误", zap.Error(err))
-		c.ResponseError(errors.New("查询举报列表错误"))
+		httperr.ResponseErrorL(c, errcode.ErrReportQueryFailed, nil, nil)
 		return
 	}
 	count, err := m.managerDB.queryReportCount(queryChannelType)
 	if err != nil {
 		m.Error("查询举报总数量错误", zap.Error(err))
-		c.ResponseError(errors.New("查询举报总数量错误"))
+		httperr.ResponseErrorL(c, errcode.ErrReportQueryFailed, nil, nil)
 		return
 	}
 	result := make([]*managerReportResp, 0)
@@ -87,19 +88,19 @@ func (m *Manager) reportList(c *wkhttp.Context) {
 		users, err := m.userDB.QueryByUIDs(uids)
 		if err != nil {
 			m.Error("查询用户信息错误", zap.Error(err))
-			c.ResponseError(errors.New("查询用户信息错误"))
+			httperr.ResponseErrorL(c, errcode.ErrReportQueryFailed, nil, nil)
 			return
 		}
 		reprotUsers, err := m.userDB.QueryByUIDs(reportUserUIDs)
 		if err != nil {
 			m.Error("查询举报用户集合错误", zap.Error(err))
-			c.ResponseError(errors.New("查询举报用户集合错误"))
+			httperr.ResponseErrorL(c, errcode.ErrReportQueryFailed, nil, nil)
 			return
 		}
 		reprotGroups, err := m.groupDB.QueryGroupsWithGroupNos(reportGroupIDs)
 		if err != nil {
 			m.Error("查询举报群集合错误", zap.Error(err))
-			c.ResponseError(errors.New("查询举报群集合错误"))
+			httperr.ResponseErrorL(c, errcode.ErrReportQueryFailed, nil, nil)
 			return
 		}
 		for _, report := range list {

--- a/modules/search/api.go
+++ b/modules/search/api.go
@@ -1,7 +1,6 @@
 package search
 
 import (
-	"errors"
 	"fmt"
 	"html"
 	"strings"
@@ -13,6 +12,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/message"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/log"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"github.com/Mininglamp-OSS/octo-server/pkg/util"
@@ -77,7 +78,7 @@ func (s *Search) global(c *wkhttp.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		s.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondSearchRequestInvalid(c, "")
 		return
 	}
 	if req.Limit > 100 {
@@ -116,21 +117,21 @@ func (s *Search) global(c *wkhttp.Context) {
 	revokedMsgExtras, err := s.messageService.GetRevokedMessages(messageIds)
 	if err != nil {
 		s.Error("查询消息撤回消息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询消息撤回消息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrSearchMessageQueryFailed, nil, nil)
 		return
 	}
 	// 查询后台管理删除标记
 	deletedMsgExtras, err := s.messageService.GetDeletedMessages(messageIds)
 	if err != nil {
 		s.Error("查询消息删除消息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询消息删除消息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrSearchMessageQueryFailed, nil, nil)
 		return
 	}
 	// 查询登录用户的删除标记
 	deletedMsgUserExtras, err := s.messageService.GetDeletedMessagesWithUID(loginUID, messageIds)
 	if err != nil {
 		s.Error("查询消息删除消息错误", zap.Error(err))
-		c.ResponseError(errors.New("查询消息删除消息错误"))
+		httperr.ResponseErrorL(c, errcode.ErrSearchMessageQueryFailed, nil, nil)
 		return
 	}
 
@@ -138,7 +139,7 @@ func (s *Search) global(c *wkhttp.Context) {
 	channelOffsetResps, err := s.messageService.GetChannelOffsetWithUID(loginUID, channelIds)
 	if err != nil {
 		s.Error("查询用户清空channel消息标记错误", zap.Error(err))
-		c.ResponseError(errors.New("查询用户清空channel消息标记错误"))
+		httperr.ResponseErrorL(c, errcode.ErrSearchMessageQueryFailed, nil, nil)
 		return
 	}
 
@@ -201,7 +202,7 @@ func (s *Search) global(c *wkhttp.Context) {
 		joinedGroups, err = s.groupService.GetGroupsWithMemberUID(loginUID)
 		if err != nil {
 			s.Error("查询加入的群列表错误", zap.Error(err))
-			c.ResponseError(errors.New("查询加入的群列表错误"))
+			httperr.ResponseErrorL(c, errcode.ErrSearchGroupQueryFailed, nil, nil)
 			return
 		}
 		if len(joinedGroups) > 0 {
@@ -218,7 +219,7 @@ func (s *Search) global(c *wkhttp.Context) {
 		groups, err = s.groupService.GetGroupDetails(groupIds, loginUID)
 		if err != nil {
 			s.Error("查询群列表错误", zap.Error(err))
-			c.ResponseError(errors.New("查询群列表错误"))
+			httperr.ResponseErrorL(c, errcode.ErrSearchGroupQueryFailed, nil, nil)
 			return
 		}
 	}
@@ -230,7 +231,7 @@ func (s *Search) global(c *wkhttp.Context) {
 		users, err = s.userService.GetUserDetails(realUids, loginUID)
 		if err != nil {
 			s.Error("查询用户列表错误", zap.Error(err))
-			c.ResponseError(errors.New("查询用户列表错误"))
+			httperr.ResponseErrorL(c, errcode.ErrSearchUserQueryFailed, nil, nil)
 			return
 		}
 	}
@@ -317,7 +318,7 @@ func (s *Search) global(c *wkhttp.Context) {
 			friends, err := s.userService.SearchFriendsWithKeyword(loginUID, req.Keyword)
 			if err != nil {
 				s.Error("查询好友错误", zap.Error(err))
-				c.ResponseError(err)
+				httperr.ResponseErrorL(c, errcode.ErrSearchUserQueryFailed, nil, nil)
 				return
 			}
 			if len(friends) > 0 {

--- a/modules/search/api_i18n.go
+++ b/modules/search/api_i18n.go
@@ -1,0 +1,16 @@
+package search
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+func respondSearchRequestInvalid(c *wkhttp.Context, field string) {
+	details := i18n.Details{}
+	if field != "" {
+		details["field"] = field
+	}
+	httperr.ResponseErrorL(c, errcode.ErrSearchRequestInvalid, nil, details)
+}

--- a/modules/search/api_i18n_test.go
+++ b/modules/search/api_i18n_test.go
@@ -1,0 +1,100 @@
+package search
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+func TestSearchNoLegacyResponseError(t *testing.T) {
+	data, err := os.ReadFile("api.go")
+	if err != nil {
+		t.Fatalf("read api.go: %v", err)
+	}
+	cleaned := stripSearchLineComments(string(data))
+	for _, b := range []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(", ".AbortWithStatusJSON(", ".AbortWithStatus(", ".ResponseWithStatus(", "c.Response(\""} {
+		if strings.Contains(cleaned, b) {
+			t.Fatalf("modules/search/api.go must use httperr.ResponseErrorL instead of legacy %s", b)
+		}
+	}
+	for _, line := range strings.Split(cleaned, "\n") {
+		if strings.Contains(line, "c.JSON(http.Status") && !strings.Contains(line, "c.JSON(http.StatusOK") {
+			t.Fatalf("modules/search/api.go must not use raw non-OK c.JSON: %s", strings.TrimSpace(line))
+		}
+	}
+}
+
+func TestRespondSearchHelpers(t *testing.T) {
+	cases := []struct {
+		name     string
+		probe    func(c *wkhttp.Context)
+		wantCode string
+		wantHTTP int
+	}{
+		{
+			name:     "request_invalid",
+			probe:    func(c *wkhttp.Context) { respondSearchRequestInvalid(c, "keyword") },
+			wantCode: "err.server.search.request_invalid",
+			wantHTTP: http.StatusBadRequest,
+		},
+		{
+			name:     "message_query_failed",
+			probe:    func(c *wkhttp.Context) { httperr.ResponseErrorL(c, errcode.ErrSearchMessageQueryFailed, nil, nil) },
+			wantCode: "err.server.search.message_query_failed",
+			wantHTTP: http.StatusInternalServerError,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := exerciseSearchHelper(t, tc.probe)
+			if env.Error.Code != tc.wantCode {
+				t.Fatalf("code = %q, want %q", env.Error.Code, tc.wantCode)
+			}
+			if env.Error.HTTPStatus != tc.wantHTTP {
+				t.Fatalf("http_status = %d, want %d", env.Error.HTTPStatus, tc.wantHTTP)
+			}
+		})
+	}
+}
+
+type searchErrEnvelope struct {
+	Error struct {
+		Code       string `json:"code"`
+		HTTPStatus int    `json:"http_status"`
+	} `json:"error"`
+}
+
+func exerciseSearchHelper(t *testing.T, probe func(c *wkhttp.Context)) searchErrEnvelope {
+	t.Helper()
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	r.GET("/probe", probe)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	r.ServeHTTP(w, req)
+	var env searchErrEnvelope
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode envelope: %v\nbody: %s", err, w.Body.String())
+	}
+	return env
+}
+
+func stripSearchLineComments(src string) string {
+	var clean strings.Builder
+	for _, line := range strings.Split(src, "\n") {
+		if idx := strings.Index(line, "//"); idx >= 0 {
+			line = line[:idx]
+		}
+		clean.WriteString(line)
+		clean.WriteByte('\n')
+	}
+	return clean.String()
+}

--- a/modules/statistics/api.go
+++ b/modules/statistics/api.go
@@ -1,13 +1,13 @@
 package statistics
 
 import (
-	"errors"
-
-	"github.com/Mininglamp-OSS/octo-server/modules/group"
-	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"go.uber.org/zap"
 )
 
@@ -43,7 +43,7 @@ func (s *Statistics) Route(r *wkhttp.WKHttp) {
 func (s *Statistics) countNum(c *wkhttp.Context) {
 	err := c.CheckLoginRole()
 	if err != nil {
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrSharedForbidden, nil, nil)
 		return
 	}
 	date := c.Query("date")
@@ -51,35 +51,35 @@ func (s *Statistics) countNum(c *wkhttp.Context) {
 	totalUserCount, err := s.userService.GetAllUserCount()
 	if err != nil {
 		s.Error("查询用户数量错误", zap.Error(err))
-		c.ResponseError(errors.New("查询用户数量错误"))
+		httperr.ResponseErrorL(c, errcode.ErrStatisticsQueryFailed, nil, nil)
 		return
 	}
 	// 查询某天注册量
 	registerCount, err := s.userService.GetRegisterWithDate(date)
 	if err != nil {
 		s.Error("查询某天用户注册量错误", zap.Error(err))
-		c.ResponseError(errors.New("查询某天用户注册量错误"))
+		httperr.ResponseErrorL(c, errcode.ErrStatisticsQueryFailed, nil, nil)
 		return
 	}
 	// 查询总群数
 	totalGroupCount, err := s.groupService.GetAllGroupCount()
 	if err != nil {
 		s.Error("查询总群数量错误", zap.Error(err))
-		c.ResponseError(errors.New("查询总群数量错误"))
+		httperr.ResponseErrorL(c, errcode.ErrStatisticsQueryFailed, nil, nil)
 		return
 	}
 	// 查询某天的新建群数量
 	groupCreatedCount, err := s.groupService.GetCreatedCountWithDate(date)
 	if err != nil {
 		s.Error("查询某天群新建数量错误", zap.Error(err))
-		c.ResponseError(errors.New("查询某天群新建数量错误"))
+		httperr.ResponseErrorL(c, errcode.ErrStatisticsQueryFailed, nil, nil)
 		return
 	}
 	// 查询总在线数量
 	onlineCount, err := s.userService.GetOnlineCount()
 	if err != nil {
 		s.Error("查询总在线用户数量错误", zap.Error(err))
-		c.ResponseError(errors.New("查询总在线用户数量错误"))
+		httperr.ResponseErrorL(c, errcode.ErrStatisticsQueryFailed, nil, nil)
 		return
 	}
 	// 查询机器人总数
@@ -103,18 +103,19 @@ func (s *Statistics) countNum(c *wkhttp.Context) {
 func (s *Statistics) registerUserListWithDateSpace(c *wkhttp.Context) {
 	err := c.CheckLoginRole()
 	if err != nil {
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrSharedForbidden, nil, nil)
 		return
 	}
 	startDate := c.Param("start_date")
 	endDate := c.Param("end_date")
 	if startDate == "" || endDate == "" {
-		c.ResponseError(errors.New("查询日期不能为空"))
+		respondStatisticsRequestInvalid(c, "date")
 		return
 	}
 	list, err := s.userService.GetRegisterCountWithDateSpace(startDate, endDate)
 	if err != nil {
-		c.ResponseError(errors.New("查询注册用户数量错误"))
+		s.Error("查询注册用户数量错误", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrStatisticsQueryFailed, nil, nil)
 		return
 	}
 	c.Response(list)
@@ -124,18 +125,19 @@ func (s *Statistics) registerUserListWithDateSpace(c *wkhttp.Context) {
 func (s *Statistics) createGroupWithDateSpace(c *wkhttp.Context) {
 	err := c.CheckLoginRole()
 	if err != nil {
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrSharedForbidden, nil, nil)
 		return
 	}
 	startDate := c.Param("start_date")
 	endDate := c.Param("end_date")
 	if startDate == "" || endDate == "" {
-		c.ResponseError(errors.New("查询日期不能为空"))
+		respondStatisticsRequestInvalid(c, "date")
 		return
 	}
 	list, err := s.groupService.GetGroupWithDateSpace(startDate, endDate)
 	if err != nil {
-		c.ResponseError(errors.New("查询注册用户数量错误"))
+		s.Error("查询建群数量错误", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrStatisticsQueryFailed, nil, nil)
 		return
 	}
 	c.Response(list)

--- a/modules/statistics/api_i18n.go
+++ b/modules/statistics/api_i18n.go
@@ -1,0 +1,16 @@
+package statistics
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+func respondStatisticsRequestInvalid(c *wkhttp.Context, field string) {
+	details := i18n.Details{}
+	if field != "" {
+		details["field"] = field
+	}
+	httperr.ResponseErrorL(c, errcode.ErrStatisticsRequestInvalid, nil, details)
+}

--- a/modules/statistics/api_i18n_test.go
+++ b/modules/statistics/api_i18n_test.go
@@ -1,0 +1,95 @@
+package statistics
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+func TestStatisticsNoLegacyResponseError(t *testing.T) {
+	data, err := os.ReadFile("api.go")
+	if err != nil {
+		t.Fatalf("read api.go: %v", err)
+	}
+	cleaned := stripStatisticsLineComments(string(data))
+	for _, b := range []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(", ".AbortWithStatusJSON(", ".AbortWithStatus(", ".ResponseWithStatus(", "c.Response(\""} {
+		if strings.Contains(cleaned, b) {
+			t.Fatalf("modules/statistics/api.go must use httperr.ResponseErrorL instead of legacy %s", b)
+		}
+	}
+}
+
+func TestRespondStatisticsHelpers(t *testing.T) {
+	cases := []struct {
+		name     string
+		probe    func(c *wkhttp.Context)
+		wantCode string
+		wantHTTP int
+	}{
+		{
+			name:     "request_invalid",
+			probe:    func(c *wkhttp.Context) { respondStatisticsRequestInvalid(c, "date") },
+			wantCode: "err.server.statistics.request_invalid",
+			wantHTTP: http.StatusBadRequest,
+		},
+		{
+			name:     "query_failed",
+			probe:    func(c *wkhttp.Context) { httperr.ResponseErrorL(c, errcode.ErrStatisticsQueryFailed, nil, nil) },
+			wantCode: "err.server.statistics.query_failed",
+			wantHTTP: http.StatusInternalServerError,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := exerciseStatisticsHelper(t, tc.probe)
+			if env.Error.Code != tc.wantCode {
+				t.Fatalf("code = %q, want %q", env.Error.Code, tc.wantCode)
+			}
+			if env.Error.HTTPStatus != tc.wantHTTP {
+				t.Fatalf("http_status = %d, want %d", env.Error.HTTPStatus, tc.wantHTTP)
+			}
+		})
+	}
+}
+
+type statisticsErrEnvelope struct {
+	Error struct {
+		Code       string `json:"code"`
+		HTTPStatus int    `json:"http_status"`
+	} `json:"error"`
+}
+
+func exerciseStatisticsHelper(t *testing.T, probe func(c *wkhttp.Context)) statisticsErrEnvelope {
+	t.Helper()
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	r.GET("/probe", probe)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	r.ServeHTTP(w, req)
+	var env statisticsErrEnvelope
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode envelope: %v\nbody: %s", err, w.Body.String())
+	}
+	return env
+}
+
+func stripStatisticsLineComments(src string) string {
+	var clean strings.Builder
+	for _, line := range strings.Split(src, "\n") {
+		if idx := strings.Index(line, "//"); idx >= 0 {
+			line = line[:idx]
+		}
+		clean.WriteString(line)
+		clean.WriteByte('\n')
+	}
+	return clean.String()
+}

--- a/pkg/errcode/qrcode.go
+++ b/pkg/errcode/qrcode.go
@@ -1,0 +1,60 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// err.server.qrcode.* — modules/qrcode business error codes (api.go).
+var (
+	ErrQRCodeRequestInvalid = register(codes.Code{
+		ID:             "err.server.qrcode.request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid QR code request.",
+		SafeDetailKeys: []string{"field"},
+	})
+	ErrQRCodeTokenRequired = register(codes.Code{
+		ID:             "err.server.qrcode.token_required",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Token is required.",
+		SafeDetailKeys: []string{"field"},
+	})
+	ErrQRCodeTokenInvalid = register(codes.Code{
+		ID:             "err.server.qrcode.token_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Token information is invalid.",
+	})
+	ErrQRCodeNotFound = register(codes.Code{
+		ID:             "err.server.qrcode.not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "The QR code is invalid or has expired.",
+	})
+	ErrQRCodeUserNotFound = register(codes.Code{
+		ID:             "err.server.qrcode.user_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "User not found.",
+	})
+	ErrQRCodeGroupNotFound = register(codes.Code{
+		ID:             "err.server.qrcode.group_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Group not found.",
+	})
+	ErrQRCodeGroupSpaceForbidden = register(codes.Code{
+		ID:             "err.server.qrcode.group_space_forbidden",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Only members of this space can join the group.",
+	})
+	ErrQRCodeQueryFailed = register(codes.Code{
+		ID:             "err.server.qrcode.query_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to query QR code data.",
+		Internal:       true,
+	})
+	ErrQRCodeStoreFailed = register(codes.Code{
+		ID:             "err.server.qrcode.store_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to update QR code data.",
+		Internal:       true,
+	})
+)

--- a/pkg/errcode/report.go
+++ b/pkg/errcode/report.go
@@ -1,0 +1,35 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// err.server.report.* — modules/report business error codes (api.go /
+// api_manager.go).
+var (
+	ErrReportRequestInvalid = register(codes.Code{
+		ID:             "err.server.report.request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid report request.",
+		SafeDetailKeys: []string{"field"},
+	})
+	ErrReportSessionInvalid = register(codes.Code{
+		ID:             "err.server.report.session_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The report session is invalid or has expired.",
+	})
+	ErrReportQueryFailed = register(codes.Code{
+		ID:             "err.server.report.query_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to query report data.",
+		Internal:       true,
+	})
+	ErrReportStoreFailed = register(codes.Code{
+		ID:             "err.server.report.store_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to update report data.",
+		Internal:       true,
+	})
+)

--- a/pkg/errcode/search.go
+++ b/pkg/errcode/search.go
@@ -1,0 +1,35 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// err.server.search.* — modules/search business error codes (api.go).
+var (
+	ErrSearchRequestInvalid = register(codes.Code{
+		ID:             "err.server.search.request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid search request.",
+		SafeDetailKeys: []string{"field"},
+	})
+	ErrSearchMessageQueryFailed = register(codes.Code{
+		ID:             "err.server.search.message_query_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to query message search data.",
+		Internal:       true,
+	})
+	ErrSearchGroupQueryFailed = register(codes.Code{
+		ID:             "err.server.search.group_query_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to query group search data.",
+		Internal:       true,
+	})
+	ErrSearchUserQueryFailed = register(codes.Code{
+		ID:             "err.server.search.user_query_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to query user search data.",
+		Internal:       true,
+	})
+)

--- a/pkg/errcode/statistics.go
+++ b/pkg/errcode/statistics.go
@@ -1,0 +1,23 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// err.server.statistics.* — modules/statistics business error codes (api.go).
+var (
+	ErrStatisticsRequestInvalid = register(codes.Code{
+		ID:             "err.server.statistics.request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid statistics request.",
+		SafeDetailKeys: []string{"field"},
+	})
+	ErrStatisticsQueryFailed = register(codes.Code{
+		ID:             "err.server.statistics.query_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to query statistics data.",
+		Internal:       true,
+	})
+)

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -689,6 +689,49 @@ other = "查询 webhook 信息失败。"
 ["err.server.incomingwebhook.mgmt_operation_failed"]
 other = "操作失败，请稍后再试。"
 
+# ---- err.server.qrcode.* (modules/qrcode: api.go) ----
+
+["err.server.qrcode.request_invalid"]
+other = "二维码请求无效。"
+
+["err.server.qrcode.token_required"]
+other = "token 不能为空。"
+
+["err.server.qrcode.token_invalid"]
+other = "登录信息格式错误。"
+
+["err.server.qrcode.not_found"]
+other = "二维码无效或已过期。"
+
+["err.server.qrcode.user_not_found"]
+other = "用户不存在。"
+
+["err.server.qrcode.group_not_found"]
+other = "群不存在。"
+
+["err.server.qrcode.group_space_forbidden"]
+other = "该群仅允许本空间成员加入。"
+
+["err.server.qrcode.query_failed"]
+other = "查询二维码数据失败。"
+
+["err.server.qrcode.store_failed"]
+other = "更新二维码数据失败。"
+
+# ---- err.server.report.* (modules/report: api.go / api_manager.go) ----
+
+["err.server.report.request_invalid"]
+other = "举报请求无效。"
+
+["err.server.report.session_invalid"]
+other = "举报会话已过期或无效。"
+
+["err.server.report.query_failed"]
+other = "查询举报数据失败。"
+
+["err.server.report.store_failed"]
+other = "保存举报数据失败。"
+
 # ---- err.server.robot.* (modules/robot: api.go / api_manager.go / mention_pref.go) ----
 
 ["err.server.robot.request_invalid"]
@@ -818,3 +861,25 @@ other = "查询空间数据失败。"
 
 ["err.server.space.store_failed"]
 other = "更新空间数据失败。"
+
+# ---- err.server.search.* (modules/search: api.go) ----
+
+["err.server.search.request_invalid"]
+other = "搜索请求无效。"
+
+["err.server.search.message_query_failed"]
+other = "查询消息搜索数据失败。"
+
+["err.server.search.group_query_failed"]
+other = "查询群搜索数据失败。"
+
+["err.server.search.user_query_failed"]
+other = "查询用户搜索数据失败。"
+
+# ---- err.server.statistics.* (modules/statistics: api.go) ----
+
+["err.server.statistics.request_invalid"]
+other = "统计请求无效。"
+
+["err.server.statistics.query_failed"]
+other = "查询统计数据失败。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -318,6 +318,45 @@ other = "The binding session has expired or is invalid. Please start over."
 ["err.server.oidc.bind_verify_required"]
 other = "Please complete verification before confirming."
 
+["err.server.qrcode.group_not_found"]
+other = "Group not found."
+
+["err.server.qrcode.group_space_forbidden"]
+other = "Only members of this space can join the group."
+
+["err.server.qrcode.not_found"]
+other = "The QR code is invalid or has expired."
+
+["err.server.qrcode.query_failed"]
+other = "Failed to query QR code data."
+
+["err.server.qrcode.request_invalid"]
+other = "Invalid QR code request."
+
+["err.server.qrcode.store_failed"]
+other = "Failed to update QR code data."
+
+["err.server.qrcode.token_invalid"]
+other = "Token information is invalid."
+
+["err.server.qrcode.token_required"]
+other = "Token is required."
+
+["err.server.qrcode.user_not_found"]
+other = "User not found."
+
+["err.server.report.query_failed"]
+other = "Failed to query report data."
+
+["err.server.report.request_invalid"]
+other = "Invalid report request."
+
+["err.server.report.session_invalid"]
+other = "The report session is invalid or has expired."
+
+["err.server.report.store_failed"]
+other = "Failed to update report data."
+
 ["err.server.robot.auth_check_failed"]
 other = "Robot authentication check failed."
 
@@ -374,6 +413,18 @@ other = "Failed to generate the robot token."
 
 ["err.server.robot.upload_failed"]
 other = "Failed to process the file."
+
+["err.server.search.group_query_failed"]
+other = "Failed to query group search data."
+
+["err.server.search.message_query_failed"]
+other = "Failed to query message search data."
+
+["err.server.search.request_invalid"]
+other = "Invalid search request."
+
+["err.server.search.user_query_failed"]
+other = "Failed to query user search data."
 
 ["err.server.space.already_member"]
 other = "You are already a member of this space."
@@ -443,6 +494,12 @@ other = "Invalid request."
 
 ["err.server.space.store_failed"]
 other = "Failed to update space data."
+
+["err.server.statistics.query_failed"]
+other = "Failed to query statistics data."
+
+["err.server.statistics.request_invalid"]
+other = "Invalid statistics request."
 
 ["err.server.thread.creator_cannot_leave"]
 other = "Thread creator cannot leave the thread."


### PR DESCRIPTION
## Summary

Migrate four low-risk utility modules to the localized error envelope:

- `modules/qrcode`
- `modules/search`
- `modules/statistics`
- `modules/report`

## Related Issue

Closes https://github.com/Mininglamp-OSS/octo-server/issues/272

Part of #170.

## Changes

- Register 19 new `err.server.*` codes across qrcode, report, search, and statistics.
- Replace legacy `c.ResponseError` / `c.ResponseErrorf` paths with `httperr.ResponseErrorL`.
- Preserve existing success and raw redirect behavior; only user-facing error responses are migrated.
- Add per-module source guards banning legacy/raw error response shapes, including `ResponseWithStatus` and raw non-OK `c.JSON`.
- Add helper envelope tests and zh-CN translations; regenerate en-US markers.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified via targeted CLI checks

```bash
go test ./modules/qrcode ./modules/search ./modules/statistics ./modules/report ./pkg/errcode ./pkg/i18n/...
go vet ./modules/qrcode ./modules/search ./modules/statistics ./modules/report ./pkg/errcode ./pkg/i18n/...
make i18n-extract-check
make i18n-lint
git diff --check
```

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (not applicable; no user-facing docs changed)
- [x] Followed commit message conventions (Conventional Commits)
