### PR TITLE
feat(i18n): propagate language over gRPC

### DIFF
--- a/modules/webhook/api.go
+++ b/modules/webhook/api.go
@@ -2,7 +2,6 @@ package webhook
 
 import (
 	"bytes"
-	"runtime/debug"
 	"compress/gzip"
 	"context"
 	"encoding/json"
@@ -11,12 +10,10 @@ import (
 	"io"
 	"net"
 	"os"
+	"runtime/debug"
 	"strconv"
 	"strings"
 
-	"github.com/Mininglamp-OSS/octo-server/modules/group"
-	"github.com/Mininglamp-OSS/octo-server/modules/user"
-	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
@@ -24,6 +21,10 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhook"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -161,15 +162,19 @@ func grpcAuthInterceptor(expectedToken string) grpc.UnaryServerInterceptor {
 
 func (w *Webhook) Start() error {
 	var opts []grpc.ServerOption
+	unaryInterceptors := []grpc.UnaryServerInterceptor{
+		i18n.UnaryServerLanguageInterceptor(),
+	}
 
 	// 配置 gRPC 认证拦截器（通过环境变量 TS_GRPC_AUTH_TOKEN 启用）
 	grpcAuthToken := os.Getenv("TS_GRPC_AUTH_TOKEN")
 	if grpcAuthToken != "" {
-		opts = append(opts, grpc.UnaryInterceptor(grpcAuthInterceptor(grpcAuthToken)))
+		unaryInterceptors = append(unaryInterceptors, grpcAuthInterceptor(grpcAuthToken))
 		w.Info("gRPC server auth enabled")
 	} else {
 		w.Warn("gRPC server auth not configured, set TS_GRPC_AUTH_TOKEN to enable authentication")
 	}
+	opts = append(opts, grpc.ChainUnaryInterceptor(unaryInterceptors...))
 
 	w.grpcServer = grpc.NewServer(opts...)
 

--- a/pkg/i18n/ctx.go
+++ b/pkg/i18n/ctx.go
@@ -93,6 +93,8 @@ func languageSourcePriority(source LanguageSource) int {
 	switch source {
 	case LanguageSourceTrustedHeader:
 		return 60
+	case LanguageSourceGRPCMetadata:
+		return 60
 	case LanguageSourceQuery:
 		return 50
 	case LanguageSourceCookie:

--- a/pkg/i18n/grpc_propagation.go
+++ b/pkg/i18n/grpc_propagation.go
@@ -1,0 +1,69 @@
+package i18n
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	// MetadataOctoLang is the gRPC metadata key used for language propagation.
+	MetadataOctoLang = "x-octo-lang"
+)
+
+// UnaryClientLanguageInterceptor propagates the negotiated language through gRPC metadata.
+func UnaryClientLanguageInterceptor() grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		ctx = InjectGRPCMetadata(ctx)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+// UnaryServerLanguageInterceptor reads propagated language metadata into context.
+func UnaryServerLanguageInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if lang, ok := languageFromIncomingMetadata(ctx); ok {
+			ctx = WithLanguage(ctx, LanguageDecision{
+				Language: lang,
+				Source:   LanguageSourceGRPCMetadata,
+			})
+		}
+		return handler(ctx, req)
+	}
+}
+
+// InjectGRPCMetadata propagates the negotiated language into outgoing gRPC metadata.
+func InjectGRPCMetadata(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	decision, ok := LanguageFromContext(ctx)
+	if !ok || decision.Language == "" {
+		return ctx
+	}
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if ok {
+		md = md.Copy()
+	} else {
+		md = metadata.MD{}
+	}
+	md.Set(MetadataOctoLang, decision.Language)
+	return metadata.NewOutgoingContext(ctx, md)
+}
+
+func languageFromIncomingMetadata(ctx context.Context) (string, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return "", false
+	}
+	for _, raw := range md.Get(MetadataOctoLang) {
+		if lang, ok := MatchSupportedLanguage(raw); ok {
+			return lang, true
+		}
+	}
+	return "", false
+}

--- a/pkg/i18n/grpc_propagation_test.go
+++ b/pkg/i18n/grpc_propagation_test.go
@@ -1,0 +1,94 @@
+package i18n
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestUnaryClientLanguageInterceptorInjectsMetadata(t *testing.T) {
+	ctx := WithLanguage(context.Background(), LanguageDecision{
+		Language: "zh-CN",
+		Source:   LanguageSourceCookie,
+	})
+
+	err := UnaryClientLanguageInterceptor()(ctx, "/test.Service/Method", nil, nil, nil,
+		func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			md, ok := metadata.FromOutgoingContext(ctx)
+			if !ok {
+				t.Fatal("outgoing metadata missing")
+			}
+			if got := md.Get(MetadataOctoLang); len(got) != 1 || got[0] != "zh-CN" {
+				t.Fatalf("%s metadata = %v, want [zh-CN]", MetadataOctoLang, got)
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("interceptor returned error: %v", err)
+	}
+}
+
+func TestUnaryClientLanguageInterceptorOverwritesExistingMetadata(t *testing.T) {
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(MetadataOctoLang, "en-US"))
+	ctx = WithLanguage(ctx, LanguageDecision{
+		Language: "zh-CN",
+		Source:   LanguageSourceCookie,
+	})
+
+	err := UnaryClientLanguageInterceptor()(ctx, "/test.Service/Method", nil, nil, nil,
+		func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			md, ok := metadata.FromOutgoingContext(ctx)
+			if !ok {
+				t.Fatal("outgoing metadata missing")
+			}
+			if got := md.Get(MetadataOctoLang); len(got) != 1 || got[0] != "zh-CN" {
+				t.Fatalf("%s metadata = %v, want [zh-CN]", MetadataOctoLang, got)
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("interceptor returned error: %v", err)
+	}
+}
+
+func TestUnaryServerLanguageInterceptorWritesLanguageContext(t *testing.T) {
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(MetadataOctoLang, "zh"))
+
+	resp, err := UnaryServerLanguageInterceptor()(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"},
+		func(ctx context.Context, req interface{}) (interface{}, error) {
+			decision, ok := LanguageFromContext(ctx)
+			if !ok {
+				t.Fatal("language decision missing from context")
+			}
+			if decision.Language != "zh-CN" {
+				t.Fatalf("Language = %q, want zh-CN", decision.Language)
+			}
+			if decision.Source != LanguageSourceGRPCMetadata {
+				t.Fatalf("Source = %q, want %q", decision.Source, LanguageSourceGRPCMetadata)
+			}
+			return "ok", nil
+		})
+	if err != nil {
+		t.Fatalf("interceptor returned error: %v", err)
+	}
+	if resp != "ok" {
+		t.Fatalf("resp = %v, want ok", resp)
+	}
+}
+
+func TestUnaryServerLanguageInterceptorIgnoresUnsupportedMetadata(t *testing.T) {
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(MetadataOctoLang, "not-a-language"))
+
+	_, err := UnaryServerLanguageInterceptor()(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"},
+		func(ctx context.Context, req interface{}) (interface{}, error) {
+			if decision, ok := LanguageFromContext(ctx); ok {
+				t.Fatalf("LanguageFromContext = %#v, want none", decision)
+			}
+			return nil, nil
+		})
+	if err != nil {
+		t.Fatalf("interceptor returned error: %v", err)
+	}
+}

--- a/pkg/i18n/lang.go
+++ b/pkg/i18n/lang.go
@@ -23,6 +23,7 @@ type LanguageSource string
 
 const (
 	LanguageSourceTrustedHeader LanguageSource = "trusted_header"
+	LanguageSourceGRPCMetadata  LanguageSource = "grpc_metadata"
 	LanguageSourceQuery         LanguageSource = "query"
 	LanguageSourceCookie        LanguageSource = "cookie"
 	LanguageSourceUser          LanguageSource = "user"


### PR DESCRIPTION
## Summary

Add gRPC unary language propagation for backend i18n.

## Related Issue

Closes https://github.com/Mininglamp-OSS/octo-server/issues/274

Part of #170.

## Changes

- Add `pkg/i18n` gRPC unary client/server interceptors.
- Use `x-octo-lang` metadata for gRPC language propagation.
- Client interceptor injects the language from `LanguageFromContext`.
- Server interceptor reads metadata, applies `MatchSupportedLanguage`, and stores the decision with `WithLanguage`.
- Wire `modules/webhook/api.go` with `grpc.ChainUnaryInterceptor` so language propagation and existing gRPC auth run together.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified via targeted CLI checks

```bash
go test ./pkg/i18n ./modules/webhook
go vet ./pkg/i18n ./modules/webhook
git diff --check origin/main...HEAD
```

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (not applicable; no user-facing docs changed)
- [x] Followed commit message conventions (Conventional Commits)
