### PR TITLE
feat(i18n): migrate bot_api module to ResponseErrorL (#276)

### DIFF
--- a/modules/bot_api/api_i18n.go
+++ b/modules/bot_api/api_i18n.go
@@ -1,0 +1,144 @@
+package bot_api
+
+import (
+	"errors"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+// respond helpers for modules/bot_api. Most migrated sites call
+// httperr.ResponseErrorL / ResponseErrorLWithStatus directly; the helpers below
+// exist for the shapes that carry a Detail field (so the SafeDetailKeys
+// contract stays in one place) and for the bot-auth middleware and
+// permission-check classifier.
+//
+// Audience: every bot_api endpoint serves EXTERNAL bot adapters (bf_/app_
+// tokens) or the logged-in user (OBO management). Sites that already returned a
+// real HTTP status (401/403/404/409/413/502) keep it via ResponseErrorLWithStatus;
+// legacy c.ResponseError sites stay at wire 400 (D14).
+//
+// Internal=true codes (ErrBotAPIQueryFailed / StoreFailed / SendFailed /
+// UploadFailed / IMTokenFailed / AuthCheckFailed / OBOInternal / UpstreamFailed)
+// never surface their message on the wire — each call site keeps its existing
+// ba.Error(..., zap.Error(err)) log so ops can debug from logs.
+
+// respondBotAPIIdentityMissing renders the defensive guard for a handler that
+// found no robot_id in context — authBot is mounted on every bot route and must
+// have populated it, so an empty value is an internal assertion failure: it is
+// logged and rendered as a generic Internal 500 (never a probe-able 4xx).
+func (ba *BotAPI) respondBotAPIIdentityMissing(c *wkhttp.Context) {
+	ba.Error("robot_id missing in context after authBot")
+	httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
+}
+
+// respondBotAPIRequestInvalid covers the common BindJSON-failure / "X 不能为空" /
+// invalid-format shape — one code, one optional field detail. An empty field is
+// omitted so the renderer does not surface a noisy empty key.
+func respondBotAPIRequestInvalid(c *wkhttp.Context, field string) {
+	details := i18n.Details{}
+	if field != "" {
+		details["field"] = field
+	}
+	httperr.ResponseErrorL(c, errcode.ErrBotAPIRequestInvalid, nil, details)
+}
+
+// respondBotAPILimitExceeded surfaces the offending list field and its cap so
+// the client can render a localized hint without hard-coding the limit.
+func respondBotAPILimitExceeded(c *wkhttp.Context, field string, max int) {
+	details := i18n.Details{"max": max}
+	if field != "" {
+		details["field"] = field
+	}
+	httperr.ResponseErrorL(c, errcode.ErrBotAPILimitExceeded, nil, details)
+}
+
+// respondBotAPIContentTooLarge surfaces the content field and its byte cap.
+func respondBotAPIContentTooLarge(c *wkhttp.Context, field string, maxSize int) {
+	details := i18n.Details{"max_size": maxSize}
+	if field != "" {
+		details["field"] = field
+	}
+	httperr.ResponseErrorL(c, errcode.ErrBotAPIContentTooLarge, nil, details)
+}
+
+// respondBotAPIFileTooLarge surfaces the upload size cap (in MB) for the
+// legacy (wire-400) upload path.
+func respondBotAPIFileTooLarge(c *wkhttp.Context, maxMB int64) {
+	httperr.ResponseErrorL(c, errcode.ErrBotAPIFileTooLarge, nil, i18n.Details{"max_mb": maxMB})
+}
+
+// respondBotAPIPayloadTooLarge surfaces the upload byte cap on the voice proxy,
+// preserving the real 413 the external client branches on.
+func respondBotAPIPayloadTooLarge(c *wkhttp.Context, maxBytes int64) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIPayloadTooLarge, nil, i18n.Details{"max_bytes": maxBytes})
+}
+
+// ---- bot-auth middleware (status-preserving, anti-enumeration) --------------
+
+// respondBotAPIAuthFailed renders the single anti-enumeration 401 for the bot
+// auth middleware, preserving the real 401 wire status (external adapters branch
+// on HTTP 401, not the D14 fixed-400), then aborts the gin chain so the
+// protected handler never runs. The specific reason is logged at the call site,
+// never returned.
+func respondBotAPIAuthFailed(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIAuthFailed, nil, nil)
+	c.Abort()
+}
+
+// respondBotAPIAuthCheckFailed renders the auth-middleware infrastructure
+// failure (our DB lookup errored), preserving the real 500 so adapters retry
+// instead of treating it as a permanent 401, then aborts the chain.
+// Internal=true → the underlying cause must be logged at the call site.
+func respondBotAPIAuthCheckFailed(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIAuthCheckFailed, nil, nil)
+	c.Abort()
+}
+
+// respondBotAPIBotUnavailable renders the not-published App Bot guard,
+// preserving the real 403, then aborts the chain.
+func respondBotAPIBotUnavailable(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIBotUnavailable, nil, nil)
+	c.Abort()
+}
+
+// ---- checkSendPermission classifier -----------------------------------------
+
+// Sentinel errors returned by checkSendPermission so the call sites
+// (sendMessage / readReceipt) can map a permission failure to the right code
+// via errors.Is — instead of forwarding a raw errors.New string to the wire.
+// Infrastructure failures (DB query / missing space_id / unknown bot kind) are
+// logged inside checkSendPermission and collapsed to errBotSendPermCheckFailed.
+var (
+	errBotSendPermAppBotDMOnly   = errors.New("app bot only supports direct messages")
+	errBotSendPermNotFriend      = errors.New("bot is not a friend of this user")
+	errBotSendPermConvNotStarted = errors.New("user has not started conversation with this bot")
+	errBotSendPermNotGroupMember = errors.New("bot is not a member of this group")
+	errBotSendPermNotSpaceMember = errors.New("user is no longer a member of bot's space")
+	errBotSendPermBadThreadChan  = errors.New("invalid thread channel_id format")
+	errBotSendPermCheckFailed    = errors.New("permission check failed")
+)
+
+// respondSendPermissionError maps a checkSendPermission sentinel to the i18n
+// envelope. Business denials keep wire 400 (legacy ResponseError parity, D14);
+// the infrastructure-failure fallback is an Internal 500 (already logged).
+func respondSendPermissionError(c *wkhttp.Context, err error) {
+	switch {
+	case errors.Is(err, errBotSendPermAppBotDMOnly):
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIAppBotDMOnly, nil, nil)
+	case errors.Is(err, errBotSendPermNotFriend):
+		httperr.ResponseErrorL(c, errcode.ErrBotAPINotFriend, nil, nil)
+	case errors.Is(err, errBotSendPermConvNotStarted):
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIConversationNotStarted, nil, nil)
+	case errors.Is(err, errBotSendPermNotGroupMember):
+		httperr.ResponseErrorL(c, errcode.ErrBotAPINotGroupMember, nil, nil)
+	case errors.Is(err, errBotSendPermNotSpaceMember):
+		httperr.ResponseErrorL(c, errcode.ErrBotAPINotSpaceMember, nil, nil)
+	case errors.Is(err, errBotSendPermBadThreadChan):
+		respondBotAPIRequestInvalid(c, "channel_id")
+	default:
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
+	}
+}

--- a/modules/bot_api/api_i18n_test.go
+++ b/modules/bot_api/api_i18n_test.go
@@ -1,0 +1,433 @@
+package bot_api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// httperrL / httperrLWS are terse shims for the two ResponseErrorL call shapes
+// (D14 fixed-400 vs status-preserving) exercised by the direct-code cases.
+func httperrL(c *wkhttp.Context, code codes.Code)   { httperr.ResponseErrorL(c, code, nil, nil) }
+func httperrLWS(c *wkhttp.Context, code codes.Code) { httperr.ResponseErrorLWithStatus(c, code, nil, nil) }
+
+// TestBotAPINoLegacyResponseError pins the Phase 2.1 contract that every
+// migrated modules/bot_api handler renders through the i18n envelope and never
+// regresses to a legacy octo-lib error response or a raw non-OK gin write.
+// Comments are stripped first so commented-out breadcrumbs do not trip the
+// guard. ba.Error(...)/ba.Warn(...) zap LOG calls are not responses and are
+// intentionally allowed. Success writes (c.JSON(http.StatusOK,...), c.Response,
+// c.Redirect, c.DataFromReader) are allowed; only NON-OK c.JSON(...) is banned.
+//
+// Known exemption (tracked as a follow-up, outside D23): getEvents still emits
+// an HTTP-200 in-band error via c.Response(gin.H{"status":0,"msg":err.Error()}),
+// which is not an error *response* (wire 200) and so is not bannable here.
+func TestBotAPINoLegacyResponseError(t *testing.T) {
+	files := []string{
+		"auth.go", "register.go", "commands.go", "events.go", "mention_pref.go",
+		"sync.go", "typing.go", "send.go", "threads.go", "file.go", "groups.go",
+		"voice_adapter.go", "obo_api.go",
+	}
+	banned := []string{
+		".ResponseError(",
+		".ResponseErrorf(",
+		".ResponseErrorWithStatus(",
+		".AbortWithStatusJSON(",
+		".AbortWithStatus(",
+		"c.Response(\"",
+		// raw non-OK c.JSON — every error status must go through the envelope
+		"c.JSON(http.StatusBadRequest",
+		"c.JSON(http.StatusUnauthorized",
+		"c.JSON(http.StatusForbidden",
+		"c.JSON(http.StatusNotFound",
+		"c.JSON(http.StatusConflict",
+		"c.JSON(http.StatusInternalServerError",
+		"c.JSON(http.StatusBadGateway",
+	}
+	for _, f := range files {
+		t.Run(f, func(t *testing.T) {
+			data, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+			var clean strings.Builder
+			for _, line := range strings.Split(string(data), "\n") {
+				if idx := strings.Index(line, "//"); idx >= 0 {
+					line = line[:idx]
+				}
+				clean.WriteString(line)
+				clean.WriteByte('\n')
+			}
+			cleaned := clean.String()
+			for _, b := range banned {
+				if strings.Contains(cleaned, b) {
+					t.Fatalf("modules/bot_api/%s must render via httperr.ResponseErrorL / respondBotAPI* helpers / errcode.ErrBotAPI* instead of legacy %s", f, b)
+				}
+			}
+		})
+	}
+}
+
+// errEnvelope is the partial shape of an httperr.ResponseErrorL response. The
+// renderer emits both the legacy {msg,status} and the v2 {error.{...}} blocks
+// unconditionally (v7.2 dual-envelope contract).
+type errEnvelope struct {
+	Error struct {
+		Code       string         `json:"code"`
+		Message    string         `json:"message"`
+		Details    map[string]any `json:"details"`
+		HTTPStatus int            `json:"http_status"`
+	} `json:"error"`
+	Msg    string `json:"msg"`
+	Status int    `json:"status"`
+}
+
+// helperHarness mounts a single GET /probe route with the i18n renderer wired,
+// so tests can assert the rendered envelope without DB / auth setup.
+func helperHarness(probe func(c *wkhttp.Context)) *wkhttp.WKHttp {
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	r.GET("/probe", probe)
+	return r
+}
+
+func TestRespondBotAPIHelpers(t *testing.T) {
+	// ba carries only a logger — enough for the helpers that log (identity
+	// guard) without standing up DB / redis / IM.
+	ba := &BotAPI{Log: log.NewTLog("BotAPI-i18n-test")}
+
+	cases := []struct {
+		name            string
+		probe           func(c *wkhttp.Context)
+		wantCodeID      string
+		wantSemStatus   int
+		wantTransStatus int // 400 for D14 ResponseErrorL; real status for WithStatus
+		wantContains    string
+		wantNotContains string // forbid leaked English DefaultMessage when Internal=true
+		wantDetails     map[string]any
+	}{
+		// ---- detail-carrying validation helpers (400, D14) -------------------
+		{
+			name:            "respondBotAPIRequestInvalid carries the field detail",
+			probe:           func(c *wkhttp.Context) { respondBotAPIRequestInvalid(c, "channel_id") },
+			wantCodeID:      "err.server.bot_api.request_invalid",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "请求参数有误",
+			wantDetails:     map[string]any{"field": "channel_id"},
+		},
+		{
+			name:            "respondBotAPIRequestInvalid drops empty field key",
+			probe:           func(c *wkhttp.Context) { respondBotAPIRequestInvalid(c, "") },
+			wantCodeID:      "err.server.bot_api.request_invalid",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "请求参数有误",
+			wantDetails:     map[string]any{},
+		},
+		{
+			name:            "respondBotAPILimitExceeded surfaces field + cap",
+			probe:           func(c *wkhttp.Context) { respondBotAPILimitExceeded(c, "members", 200) },
+			wantCodeID:      "err.server.bot_api.limit_exceeded",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "请求数量超过上限",
+			wantDetails:     map[string]any{"field": "members", "max": float64(200)},
+		},
+		{
+			name:            "respondBotAPIContentTooLarge surfaces field + max_size",
+			probe:           func(c *wkhttp.Context) { respondBotAPIContentTooLarge(c, "content", 4096) },
+			wantCodeID:      "err.server.bot_api.content_too_large",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "内容大小超过限制",
+			wantDetails:     map[string]any{"field": "content", "max_size": float64(4096)},
+		},
+		{
+			name:            "respondBotAPIFileTooLarge surfaces the MB cap",
+			probe:           func(c *wkhttp.Context) { respondBotAPIFileTooLarge(c, 100) },
+			wantCodeID:      "err.server.bot_api.file_too_large",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "文件大小超过限制",
+			wantDetails:     map[string]any{"max_mb": float64(100)},
+		},
+		{
+			name:            "respondBotAPIPayloadTooLarge preserves 413 + byte cap",
+			probe:           func(c *wkhttp.Context) { respondBotAPIPayloadTooLarge(c, 1048576) },
+			wantCodeID:      "err.server.bot_api.payload_too_large",
+			wantSemStatus:   http.StatusRequestEntityTooLarge,
+			wantTransStatus: http.StatusRequestEntityTooLarge,
+			wantContains:    "上传文件大小超过限制",
+			wantDetails:     map[string]any{"max_bytes": float64(1048576)},
+		},
+		// ---- direct business codes: 400 / 403 / 404 / 409 (D14, wire 400) ----
+		{
+			name:            "ErrBotAPINotGroupMember 403 semantic, wire 400",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrBotAPINotGroupMember) },
+			wantCodeID:      "err.server.bot_api.not_group_member",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "机器人不是该群成员",
+		},
+		{
+			name:            "ErrBotAPIAppBotUnsupported 403",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrBotAPIAppBotUnsupported) },
+			wantCodeID:      "err.server.bot_api.app_bot_unsupported",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "应用机器人不支持该操作",
+		},
+		{
+			name:            "ErrBotAPIOBONotAuthorized 403",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrBotAPIOBONotAuthorized) },
+			wantCodeID:      "err.server.bot_api.obo_not_authorized",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "无权代表该用户操作",
+		},
+		{
+			name:            "ErrBotAPIMemberNotHuman 400",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrBotAPIMemberNotHuman) },
+			wantCodeID:      "err.server.bot_api.member_not_human",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "仅可通过机器人 API 添加真人成员",
+		},
+		{
+			name:            "ErrBotAPIGroupNotFound 404 semantic, wire 400",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrBotAPIGroupNotFound) },
+			wantCodeID:      "err.server.bot_api.group_not_found",
+			wantSemStatus:   http.StatusNotFound,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "群组不存在",
+		},
+		{
+			name:            "ErrBotAPIMessageNotDelivered 409 semantic, wire 400",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrBotAPIMessageNotDelivered) },
+			wantCodeID:      "err.server.bot_api.message_not_delivered",
+			wantSemStatus:   http.StatusConflict,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "消息尚未投递完成",
+		},
+		// ---- internal codes (500, Internal=true): collapse + no English leak --
+		{
+			name:            "ErrBotAPIQueryFailed collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrBotAPIQueryFailed) },
+			wantCodeID:      "err.server.bot_api.query_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "query data",
+		},
+		{
+			name:            "ErrBotAPIStoreFailed collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrBotAPIStoreFailed) },
+			wantCodeID:      "err.server.bot_api.store_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "update data",
+		},
+		{
+			name:            "ErrBotAPISendFailed collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrBotAPISendFailed) },
+			wantCodeID:      "err.server.bot_api.send_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "send the message",
+		},
+		{
+			name:            "ErrBotAPIUploadFailed collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrBotAPIUploadFailed) },
+			wantCodeID:      "err.server.bot_api.upload_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "process the file",
+		},
+		{
+			name:            "ErrBotAPIOBOInternal collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrBotAPIOBOInternal) },
+			wantCodeID:      "err.server.bot_api.obo_internal",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "OBO operation",
+		},
+		{
+			name:            "ErrBotAPIIMTokenFailed collapses to shared internal copy",
+			probe:           func(c *wkhttp.Context) { httperrL(c, errcode.ErrBotAPIIMTokenFailed) },
+			wantCodeID:      "err.server.bot_api.im_token_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "IM token",
+		},
+		// ---- status-preserving middleware helpers (real wire status) ---------
+		{
+			name:            "respondBotAPIAuthFailed preserves 401 (external adapters)",
+			probe:           respondBotAPIAuthFailed,
+			wantCodeID:      "err.server.bot_api.auth_failed",
+			wantSemStatus:   http.StatusUnauthorized,
+			wantTransStatus: http.StatusUnauthorized,
+			wantContains:    "机器人认证失败",
+		},
+		{
+			name:            "respondBotAPIBotUnavailable preserves 403",
+			probe:           respondBotAPIBotUnavailable,
+			wantCodeID:      "err.server.bot_api.bot_unavailable",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusForbidden,
+			wantContains:    "机器人不可用",
+		},
+		{
+			name:            "respondBotAPIAuthCheckFailed preserves 500 + hides internal copy",
+			probe:           respondBotAPIAuthCheckFailed,
+			wantCodeID:      "err.server.bot_api.auth_check_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusInternalServerError,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "authentication check",
+		},
+		// ---- status-preserving direct codes (OBO management + voice) ---------
+		{
+			name:            "ErrBotAPIOBOGrantNotFound preserves 404",
+			probe:           func(c *wkhttp.Context) { httperrLWS(c, errcode.ErrBotAPIOBOGrantNotFound) },
+			wantCodeID:      "err.server.bot_api.obo_grant_not_found",
+			wantSemStatus:   http.StatusNotFound,
+			wantTransStatus: http.StatusNotFound,
+			wantContains:    "OBO 授权不存在",
+		},
+		{
+			name:            "ErrBotAPIOBOGrantExists preserves 409",
+			probe:           func(c *wkhttp.Context) { httperrLWS(c, errcode.ErrBotAPIOBOGrantExists) },
+			wantCodeID:      "err.server.bot_api.obo_grant_exists",
+			wantSemStatus:   http.StatusConflict,
+			wantTransStatus: http.StatusConflict,
+			wantContains:    "OBO 授权已存在",
+		},
+		{
+			name:            "ErrBotAPISharedAuthRequired preserves 401",
+			probe:           func(c *wkhttp.Context) { httperrLWS(c, errcode.ErrBotAPISharedAuthRequired) },
+			wantCodeID:      "err.shared.auth.required",
+			wantSemStatus:   http.StatusUnauthorized,
+			wantTransStatus: http.StatusUnauthorized,
+			wantContains:    "请先登录",
+		},
+		{
+			name:            "ErrBotAPIUpstreamFailed preserves 502 + hides internal copy",
+			probe:           func(c *wkhttp.Context) { httperrLWS(c, errcode.ErrBotAPIUpstreamFailed) },
+			wantCodeID:      "err.server.bot_api.upstream_failed",
+			wantSemStatus:   http.StatusBadGateway,
+			wantTransStatus: http.StatusBadGateway,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "upstream service",
+		},
+		// ---- checkSendPermission classifier ----------------------------------
+		{
+			name:            "respondSendPermissionError maps not-friend → 403 not_friend",
+			probe:           func(c *wkhttp.Context) { respondSendPermissionError(c, errBotSendPermNotFriend) },
+			wantCodeID:      "err.server.bot_api.not_friend",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "机器人不是该用户的好友",
+		},
+		{
+			name:            "respondSendPermissionError maps conv-not-started → 403",
+			probe:           func(c *wkhttp.Context) { respondSendPermissionError(c, errBotSendPermConvNotStarted) },
+			wantCodeID:      "err.server.bot_api.conversation_not_started",
+			wantSemStatus:   http.StatusForbidden,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "用户尚未与该机器人发起会话",
+		},
+		{
+			name:            "respondSendPermissionError maps bad-thread-channel → 400 field",
+			probe:           func(c *wkhttp.Context) { respondSendPermissionError(c, errBotSendPermBadThreadChan) },
+			wantCodeID:      "err.server.bot_api.request_invalid",
+			wantSemStatus:   http.StatusBadRequest,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "请求参数有误",
+			wantDetails:     map[string]any{"field": "channel_id"},
+		},
+		{
+			name:            "respondSendPermissionError maps infra failure → 500 query_failed no leak",
+			probe:           func(c *wkhttp.Context) { respondSendPermissionError(c, errBotSendPermCheckFailed) },
+			wantCodeID:      "err.server.bot_api.query_failed",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+			wantNotContains: "query data",
+		},
+		// ---- defensive identity guard ----------------------------------------
+		{
+			name:            "respondBotAPIIdentityMissing renders generic internal 500",
+			probe:           func(c *wkhttp.Context) { ba.respondBotAPIIdentityMissing(c) },
+			wantCodeID:      "err.shared.internal",
+			wantSemStatus:   http.StatusInternalServerError,
+			wantTransStatus: http.StatusBadRequest,
+			wantContains:    "服务器内部错误",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := helperHarness(tc.probe)
+			req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+			req.Header.Set("Accept-Language", "zh-CN")
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantTransStatus {
+				t.Fatalf("HTTP status = %d, want %d; body=%s", rec.Code, tc.wantTransStatus, rec.Body.String())
+			}
+			var env errEnvelope
+			if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+				t.Fatalf("decode envelope: %v\nbody: %s", err, rec.Body.String())
+			}
+			if env.Error.Code != tc.wantCodeID {
+				t.Fatalf("error.code = %q, want %q", env.Error.Code, tc.wantCodeID)
+			}
+			if env.Error.HTTPStatus != tc.wantSemStatus {
+				t.Fatalf("error.http_status = %d, want %d", env.Error.HTTPStatus, tc.wantSemStatus)
+			}
+			if env.Status != tc.wantTransStatus {
+				t.Fatalf("legacy status = %d, want %d", env.Status, tc.wantTransStatus)
+			}
+			if env.Msg != env.Error.Message {
+				t.Fatalf("legacy msg %q != error.message %q (dual envelope must agree)", env.Msg, env.Error.Message)
+			}
+			if !strings.Contains(env.Error.Message, tc.wantContains) {
+				t.Fatalf("error.message = %q, want substring %q", env.Error.Message, tc.wantContains)
+			}
+			if tc.wantNotContains != "" && strings.Contains(env.Error.Message, tc.wantNotContains) {
+				t.Fatalf("error.message = %q must not contain %q (Internal leak)", env.Error.Message, tc.wantNotContains)
+			}
+			if tc.wantDetails != nil {
+				got := env.Error.Details
+				if got == nil {
+					got = map[string]any{}
+				}
+				if len(got) != len(tc.wantDetails) {
+					t.Fatalf("error.details = %#v, want %#v", got, tc.wantDetails)
+				}
+				for k, v := range tc.wantDetails {
+					if got[k] != v {
+						t.Fatalf("error.details[%q] = %#v, want %#v", k, got[k], v)
+					}
+				}
+			}
+		})
+	}
+}

--- a/modules/bot_api/auth.go
+++ b/modules/bot_api/auth.go
@@ -1,11 +1,9 @@
 package bot_api
 
 import (
-	"net/http"
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
-	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 )
 
@@ -17,10 +15,10 @@ const (
 
 // Context keys for bot identity.
 const (
-	CtxKeyRobotID      = "robot_id"
-	CtxKeyBotKind      = "bot_kind"
-	CtxKeyRobot        = "robot"         // *robotModel for User Bot
-	CtxKeyAppBotScope  = "app_bot_scope" // "platform" | "space"
+	CtxKeyRobotID       = "robot_id"
+	CtxKeyBotKind       = "bot_kind"
+	CtxKeyRobot         = "robot"         // *robotModel for User Bot
+	CtxKeyAppBotScope   = "app_bot_scope" // "platform" | "space"
 	CtxKeyAppBotSpaceID = "app_bot_space_id"
 )
 
@@ -30,7 +28,7 @@ func (ba *BotAPI) authBot() wkhttp.HandlerFunc {
 	return func(c *wkhttp.Context) {
 		token := extractBotToken(c)
 		if token == "" {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"msg": "缺少Authorization头或token无效"})
+			respondBotAPIAuthFailed(c)
 			return
 		}
 
@@ -49,11 +47,11 @@ func (ba *BotAPI) authUserBot(c *wkhttp.Context, token string) {
 	robot, err := ba.db.queryRobotByBotToken(token)
 	if err != nil {
 		ba.Error("查询机器人失败", zap.Error(err))
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"msg": "认证失败"})
+		respondBotAPIAuthCheckFailed(c)
 		return
 	}
 	if robot == nil {
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"msg": "无效的bot token"})
+		respondBotAPIAuthFailed(c)
 		return
 	}
 
@@ -83,17 +81,17 @@ func (ba *BotAPI) authAppBot(c *wkhttp.Context, token string) {
 	appBot, err := ba.db.queryAppBotByToken(token)
 	if err != nil {
 		ba.Error("查询App Bot失败", zap.Error(err))
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"msg": "认证失败"})
+		respondBotAPIAuthCheckFailed(c)
 		return
 	}
 	if appBot == nil {
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"msg": "无效的bot token"})
+		respondBotAPIAuthFailed(c)
 		return
 	}
 
 	// App Bot must be published (status=1) to serve API requests
 	if appBot.Status != 1 {
-		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"msg": "bot not available"})
+		respondBotAPIBotUnavailable(c)
 		return
 	}
 

--- a/modules/bot_api/commands.go
+++ b/modules/bot_api/commands.go
@@ -76,7 +76,7 @@ func (ba *BotAPI) getUserInfo(c *wkhttp.Context) {
 	userResp, err := ba.userService.GetUser(bareUID)
 	if err != nil {
 		ba.Error("query user info failed", zap.Error(err), zap.String("uid", bareUID))
-		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 	if userResp == nil {

--- a/modules/bot_api/commands.go
+++ b/modules/bot_api/commands.go
@@ -2,13 +2,14 @@ package bot_api
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 )
@@ -22,8 +23,7 @@ func (ba *BotAPI) setCommands(c *wkhttp.Context) {
 		} `json:"commands"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		ba.Error("数据格式有误", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误"))
+		respondBotAPIRequestInvalid(c, "")
 		return
 	}
 
@@ -38,14 +38,14 @@ func (ba *BotAPI) setCommands(c *wkhttp.Context) {
 	commandsJSON, err := json.Marshal(req.Commands)
 	if err != nil {
 		ba.Error("序列化命令列表失败", zap.Error(err))
-		c.ResponseError(errors.New("序列化命令列表失败"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 		return
 	}
 
 	err = ba.db.updateBotCommands(robotID, string(commandsJSON))
 	if err != nil {
 		ba.Error("保存命令列表失败", zap.Error(err))
-		c.ResponseError(errors.New("保存命令列表失败"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 		return
 	}
 
@@ -67,15 +67,20 @@ func stripSpacePrefix(uid string) string {
 func (ba *BotAPI) getUserInfo(c *wkhttp.Context) {
 	uid := strings.TrimSpace(c.Query("uid"))
 	if uid == "" {
-		c.ResponseError(errors.New("uid参数不能为空"))
+		respondBotAPIRequestInvalid(c, "uid")
 		return
 	}
 
 	bareUID := stripSpacePrefix(uid)
 
 	userResp, err := ba.userService.GetUser(bareUID)
-	if err != nil || userResp == nil {
-		c.JSON(http.StatusNotFound, gin.H{"msg": "用户不存在"})
+	if err != nil {
+		ba.Error("query user info failed", zap.Error(err), zap.String("uid", bareUID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
+		return
+	}
+	if userResp == nil {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIUserNotFound, nil, nil)
 		return
 	}
 

--- a/modules/bot_api/events.go
+++ b/modules/bot_api/events.go
@@ -1,7 +1,6 @@
 package bot_api
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -9,6 +8,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/gin-gonic/gin"
 	"github.com/go-redis/redis"
 	"go.uber.org/zap"
@@ -41,7 +42,7 @@ type messageResp struct {
 func (ba *BotAPI) getEvents(c *wkhttp.Context) {
 	var req BotEventsReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("数据格式有误"))
+		respondBotAPIRequestInvalid(c, "")
 		return
 	}
 
@@ -111,11 +112,11 @@ func (ba *BotAPI) getEventsResult(robotID string, eventID int64, limit int64) ([
 	results := make([]*eventResp, 0)
 	if len(robotEventJsons) > 0 {
 		type robotEvent struct {
-			EventID   int64                    `json:"event_id,omitempty"`
-			Message   *config.MessageResp      `json:"message,omitempty"`
-			EventType string                   `json:"event_type,omitempty"`
-			EventData map[string]interface{}   `json:"event_data,omitempty"`
-			Expire    int64                    `json:"expire,omitempty"`
+			EventID   int64                  `json:"event_id,omitempty"`
+			Message   *config.MessageResp    `json:"message,omitempty"`
+			EventType string                 `json:"event_type,omitempty"`
+			EventData map[string]interface{} `json:"event_data,omitempty"`
+			Expire    int64                  `json:"expire,omitempty"`
 		}
 
 		events := make([]*robotEvent, 0)
@@ -140,7 +141,7 @@ func (ba *BotAPI) getEventsResult(robotID string, eventID int64, limit int64) ([
 					MessageID:  ev.Message.MessageID,
 					MessageSeq: ev.Message.MessageSeq,
 					FromUID:    ev.Message.FromUID,
-					Timestamp:   ev.Message.Timestamp,
+					Timestamp:  ev.Message.Timestamp,
 				}
 				if ev.Message.ChannelType != common.ChannelTypePerson.Uint8() {
 					resp.Message.ChannelID = ev.Message.ChannelID
@@ -167,14 +168,15 @@ func (ba *BotAPI) eventAck(c *wkhttp.Context) {
 	eventIDStr := c.Param("event_id")
 	eventID, err := strconv.ParseInt(eventIDStr, 10, 64)
 	if err != nil {
-		c.ResponseError(errors.New("event_id 格式无效"))
+		respondBotAPIRequestInvalid(c, "event_id")
 		return
 	}
 
 	key := fmt.Sprintf("%s%s", robotEventPrefix, robotID)
 	err = ba.ctx.GetRedisConn().ZRemRangeByScore(key, fmt.Sprintf("%d", eventID), fmt.Sprintf("%d", eventID))
 	if err != nil {
-		c.ResponseError(err)
+		ba.Error("ack event failed", zap.Error(err), zap.String("robotID", robotID), zap.Int64("eventID", eventID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()

--- a/modules/bot_api/file.go
+++ b/modules/bot_api/file.go
@@ -16,6 +16,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/file"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	pkgutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
 	"github.com/gin-gonic/gin"
 	sts "github.com/tencentyun/qcloud-cos-sts-sdk/go"
@@ -26,7 +28,7 @@ import (
 func (ba *BotAPI) botProxyFile(c *wkhttp.Context) {
 	ph := c.Param("path")
 	if ph == "" {
-		c.ResponseError(errors.New("文件路径不能为空"))
+		respondBotAPIRequestInvalid(c, "path")
 		return
 	}
 	ph = strings.TrimPrefix(ph, "/")
@@ -34,7 +36,7 @@ func (ba *BotAPI) botProxyFile(c *wkhttp.Context) {
 
 	cleaned := filepath.Clean(ph)
 	if strings.Contains(cleaned, "..") || strings.ContainsAny(cleaned, "\x00") {
-		c.ResponseErrorWithStatus(errors.New("文件路径无效"), http.StatusBadRequest)
+		respondBotAPIRequestInvalid(c, "path")
 		return
 	}
 	ph = cleaned
@@ -47,7 +49,7 @@ func (ba *BotAPI) botProxyFile(c *wkhttp.Context) {
 	downloadURL, err := ba.fileService.DownloadURL(ph, filename)
 	if err != nil {
 		ba.Error("获取文件下载URL失败", zap.Error(err), zap.String("path", ph))
-		c.ResponseErrorWithStatus(errors.New("获取文件失败"), http.StatusNotFound)
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedNotFound, nil, nil)
 		return
 	}
 	c.Redirect(http.StatusFound, downloadURL)
@@ -60,15 +62,14 @@ func (ba *BotAPI) botUploadFile(c *wkhttp.Context) {
 
 	multipartFile, fileHeader, err := c.Request.FormFile("file")
 	if err != nil {
-		ba.Error("读取上传文件失败", zap.Error(err))
-		c.ResponseError(errors.New("读取文件失败"))
+		respondBotAPIRequestInvalid(c, "file")
 		return
 	}
 	defer multipartFile.Close()
 
 	const maxSize int64 = 100 * 1024 * 1024
 	if fileHeader.Size > maxSize {
-		c.ResponseError(fmt.Errorf("文件大小不能超过%dMB", maxSize/1024/1024))
+		respondBotAPIFileTooLarge(c, maxSize/1024/1024)
 		return
 	}
 
@@ -93,7 +94,7 @@ func (ba *BotAPI) botUploadFile(c *wkhttp.Context) {
 	})
 	if err != nil {
 		ba.Error("上传文件失败", zap.Error(err))
-		c.ResponseError(errors.New("上传文件失败"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIUploadFailed, nil, nil)
 		return
 	}
 
@@ -113,14 +114,14 @@ func (ba *BotAPI) botUploadFile(c *wkhttp.Context) {
 func (ba *BotAPI) botFileDownload(c *wkhttp.Context) {
 	ph := c.Param("path")
 	if ph == "" {
-		c.ResponseError(errors.New("文件路径不能为空"))
+		respondBotAPIRequestInvalid(c, "path")
 		return
 	}
 	ph = strings.TrimPrefix(ph, "/")
 
 	ph, err := sanitizeBotFilePath(ph)
 	if err != nil {
-		c.ResponseErrorWithStatus(errors.New("文件路径无效"), http.StatusBadRequest)
+		respondBotAPIRequestInvalid(c, "path")
 		return
 	}
 
@@ -132,7 +133,7 @@ func (ba *BotAPI) botFileDownload(c *wkhttp.Context) {
 	downloadURL, err := ba.fileService.DownloadURL(ph, filename)
 	if err != nil {
 		ba.Error("获取文件下载URL失败", zap.Error(err), zap.String("path", ph))
-		c.ResponseErrorWithStatus(errors.New("获取文件失败"), http.StatusNotFound)
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedNotFound, nil, nil)
 		return
 	}
 	c.Redirect(http.StatusFound, downloadURL)
@@ -162,21 +163,21 @@ func sanitizeBotFilePath(p string) (string, error) {
 func (ba *BotAPI) botUploadCredentials(c *wkhttp.Context) {
 	filename := c.Query("filename")
 	if strings.TrimSpace(filename) == "" {
-		c.ResponseError(errors.New("filename 不能为空"))
+		respondBotAPIRequestInvalid(c, "filename")
 		return
 	}
 	filename = filepath.Base(filename)
 
 	ext := strings.ToLower(filepath.Ext(filename))
 	if ext == "" || file.IsBlockedExtension(ext) || !file.IsAllowedExtension(ext) {
-		c.ResponseError(errors.New("不支持的文件类型"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIFileTypeUnsupported, nil, nil)
 		return
 	}
 
 	cosConfig := ba.ctx.GetConfig().COS
 	if cosConfig.SecretID == "" || cosConfig.SecretKey == "" || cosConfig.Bucket == "" {
 		ba.Error("COS 配置不完整")
-		c.ResponseError(errors.New("COS 未配置"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIUploadFailed, nil, nil)
 		return
 	}
 
@@ -199,7 +200,7 @@ func (ba *BotAPI) botUploadCredentials(c *wkhttp.Context) {
 	}
 	if appId == "" {
 		ba.Error("无法从 bucket 名称中提取 appId", zap.String("bucket", bucket))
-		c.ResponseError(errors.New("COS 配置错误：bucket 格式不正确"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIUploadFailed, nil, nil)
 		return
 	}
 
@@ -221,7 +222,7 @@ func (ba *BotAPI) botUploadCredentials(c *wkhttp.Context) {
 	res, err := client.GetCredential(opt)
 	if err != nil {
 		ba.Error("获取 STS 临时密钥失败", zap.Error(err))
-		c.ResponseError(errors.New("获取临时密钥失败"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIUploadFailed, nil, nil)
 		return
 	}
 
@@ -244,7 +245,7 @@ func (ba *BotAPI) botUploadCredentials(c *wkhttp.Context) {
 func (ba *BotAPI) botUploadPresigned(c *wkhttp.Context) {
 	filename := c.Query("filename")
 	if strings.TrimSpace(filename) == "" {
-		c.ResponseError(errors.New("filename 不能为空"))
+		respondBotAPIRequestInvalid(c, "filename")
 		return
 	}
 	filename = filepath.Base(filename)
@@ -254,24 +255,24 @@ func (ba *BotAPI) botUploadPresigned(c *wkhttp.Context) {
 	// guard the public file API enforces (see modules/file/api.go).
 	fileSizeRaw := strings.TrimSpace(c.Query("fileSize"))
 	if fileSizeRaw == "" {
-		c.ResponseError(errors.New("fileSize 参数必填，且不能超过最大限制"))
+		respondBotAPIRequestInvalid(c, "fileSize")
 		return
 	}
 	fileSize, parseErr := strconv.ParseInt(fileSizeRaw, 10, 64)
 	if parseErr != nil || fileSize <= 0 {
-		c.ResponseError(errors.New("fileSize 参数必须为正整数（字节）"))
+		respondBotAPIRequestInvalid(c, "fileSize")
 		return
 	}
 	if fileSize > file.MaxFileSize {
 		ba.Warn("预签名上传 fileSize 超出限制",
 			zap.Int64("size", fileSize), zap.Int64("max", file.MaxFileSize))
-		c.ResponseError(fmt.Errorf("文件大小不能超过%dMB", file.MaxFileSize/1024/1024))
+		respondBotAPIFileTooLarge(c, file.MaxFileSize/1024/1024)
 		return
 	}
 
 	ext := strings.ToLower(filepath.Ext(filename))
 	if ext == "" || file.IsBlockedExtension(ext) || !file.IsAllowedExtension(ext) {
-		c.ResponseError(errors.New("不支持的文件类型"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIFileTypeUnsupported, nil, nil)
 		return
 	}
 
@@ -286,7 +287,7 @@ func (ba *BotAPI) botUploadPresigned(c *wkhttp.Context) {
 	uploadURL, downloadURL, err := ba.fileService.PresignedPutURL(objectPath, contentType, contentDisposition, fileSize, expiry)
 	if err != nil {
 		ba.Error("生成预签名上传URL失败", zap.Error(err))
-		c.ResponseError(errors.New("生成上传URL失败"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIUploadFailed, nil, nil)
 		return
 	}
 

--- a/modules/bot_api/groups.go
+++ b/modules/bot_api/groups.go
@@ -1,6 +1,7 @@
 package bot_api
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"runtime/debug"
@@ -15,6 +16,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/gin-gonic/gin"
+	"github.com/gocraft/dbr/v2"
 	"go.uber.org/zap"
 )
 
@@ -86,7 +88,12 @@ func (ba *BotAPI) getGroupInfo(c *wkhttp.Context) {
 	_, err = ba.db.session.Select("group_no, name, IFNULL(notice,'') notice, IFNULL(creator,'') creator, status, created_at").
 		From("`group`").Where("group_no=?", groupNo).Load(&grp)
 	if err != nil {
-		httperr.ResponseErrorL(c, errcode.ErrBotAPIGroupNotFound, nil, nil)
+		if errors.Is(err, dbr.ErrNotFound) {
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIGroupNotFound, nil, nil)
+			return
+		}
+		ba.Error("query group info failed", zap.Error(err), zap.String("groupNo", groupNo))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 

--- a/modules/bot_api/groups.go
+++ b/modules/bot_api/groups.go
@@ -488,7 +488,12 @@ func (ba *BotAPI) botGroupUpdate(c *wkhttp.Context) {
 	}
 
 	isBotAdmin, err := ba.groupService.IsBotAdmin(groupNo, robotID)
-	if err != nil || !isBotAdmin {
+	if err != nil {
+		ba.Error("check bot admin failed", zap.Error(err), zap.String("groupNo", groupNo), zap.String("robotID", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
+		return
+	}
+	if !isBotAdmin {
 		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPINotGroupAdmin, nil, nil)
 		return
 	}
@@ -622,7 +627,12 @@ func (ba *BotAPI) botGroupMemberRemove(c *wkhttp.Context) {
 	}
 
 	isBotAdmin, err := ba.groupService.IsBotAdmin(groupNo, robotID)
-	if err != nil || !isBotAdmin {
+	if err != nil {
+		ba.Error("check bot admin failed", zap.Error(err), zap.String("groupNo", groupNo), zap.String("robotID", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
+		return
+	}
+	if !isBotAdmin {
 		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPINotGroupAdmin, nil, nil)
 		return
 	}

--- a/modules/bot_api/groups.go
+++ b/modules/bot_api/groups.go
@@ -1,7 +1,6 @@
 package bot_api
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"runtime/debug"
@@ -12,6 +11,9 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 )
@@ -23,7 +25,7 @@ const threadChannelIDSeparator = "____"
 func (ba *BotAPI) getGroups(c *wkhttp.Context) {
 	robotID := getRobotIDFromContext(c)
 	if robotID == "" {
-		c.ResponseError(errors.New("robot_id not found"))
+		ba.respondBotAPIIdentityMissing(c)
 		return
 	}
 
@@ -49,7 +51,7 @@ func (ba *BotAPI) getGroups(c *wkhttp.Context) {
 	}
 	if err != nil {
 		ba.Error("查询机器人群组失败", zap.Error(err))
-		c.ResponseError(errors.New("查询群组失败"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 
@@ -63,8 +65,13 @@ func (ba *BotAPI) getGroupInfo(c *wkhttp.Context) {
 
 	var count int
 	err := ba.db.session.SelectBySql("SELECT COUNT(*) FROM group_member WHERE group_no=? AND uid=? AND is_deleted=0", groupNo, robotID).LoadOne(&count)
-	if err != nil || count == 0 {
-		c.ResponseError(errors.New("bot is not a member of this group"))
+	if err != nil {
+		ba.Error("query group membership failed", zap.Error(err), zap.String("groupNo", groupNo), zap.String("robotID", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
+		return
+	}
+	if count == 0 {
+		httperr.ResponseErrorL(c, errcode.ErrBotAPINotGroupMember, nil, nil)
 		return
 	}
 
@@ -79,7 +86,7 @@ func (ba *BotAPI) getGroupInfo(c *wkhttp.Context) {
 	_, err = ba.db.session.Select("group_no, name, IFNULL(notice,'') notice, IFNULL(creator,'') creator, status, created_at").
 		From("`group`").Where("group_no=?", groupNo).Load(&grp)
 	if err != nil {
-		c.ResponseError(errors.New("group not found"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIGroupNotFound, nil, nil)
 		return
 	}
 
@@ -100,8 +107,13 @@ func (ba *BotAPI) getGroupMembers(c *wkhttp.Context) {
 
 	var count int
 	err := ba.db.session.SelectBySql("SELECT COUNT(*) FROM group_member WHERE group_no=? AND uid=? AND is_deleted=0", groupNo, robotID).LoadOne(&count)
-	if err != nil || count == 0 {
-		c.ResponseError(errors.New("bot is not a member of this group"))
+	if err != nil {
+		ba.Error("query group membership failed", zap.Error(err), zap.String("groupNo", groupNo), zap.String("robotID", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
+		return
+	}
+	if count == 0 {
+		httperr.ResponseErrorL(c, errcode.ErrBotAPINotGroupMember, nil, nil)
 		return
 	}
 
@@ -126,7 +138,8 @@ func (ba *BotAPI) getGroupMembers(c *wkhttp.Context) {
 		ORDER BY gm.role DESC, gm.created_at ASC
 	`, groupNo).Load(&members)
 	if err != nil {
-		c.ResponseError(err)
+		ba.Error("query group members failed", zap.Error(err), zap.String("groupNo", groupNo))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 
@@ -137,30 +150,30 @@ func (ba *BotAPI) getGroupMembers(c *wkhttp.Context) {
 func (ba *BotAPI) getGroupMd(c *wkhttp.Context) {
 	robotID := getRobotIDFromContext(c)
 	if robotID == "" {
-		c.ResponseError(errors.New("robot_id not found"))
+		ba.respondBotAPIIdentityMissing(c)
 		return
 	}
 	groupNo := c.Param("group_no")
 	if strings.Contains(groupNo, threadChannelIDSeparator) {
-		c.ResponseError(errors.New("thread channel id is not accepted here; use /v1/bot/groups/<group_no>/threads/<short_id>/md instead"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIThreadChannelNotAccepted, nil, nil)
 		return
 	}
 
 	isMember, err := ba.groupService.ExistMember(groupNo, robotID)
 	if err != nil {
 		ba.Error("check group membership failed", zap.Error(err))
-		c.ResponseError(errors.New("check group membership failed"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 	if !isMember {
-		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"msg": "bot is not a member of this group", "status": 403})
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPINotGroupMember, nil, nil)
 		return
 	}
 
 	result, err := ba.groupService.GetGroupMd(groupNo)
 	if err != nil {
 		ba.Error("query GROUP.md failed", zap.Error(err))
-		c.ResponseError(errors.New("query GROUP.md failed"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 	if result == nil {
@@ -184,34 +197,34 @@ func (ba *BotAPI) getGroupMd(c *wkhttp.Context) {
 func (ba *BotAPI) updateGroupMd(c *wkhttp.Context) {
 	robotID := getRobotIDFromContext(c)
 	if robotID == "" {
-		c.ResponseError(errors.New("robot_id not found"))
+		ba.respondBotAPIIdentityMissing(c)
 		return
 	}
 	groupNo := c.Param("group_no")
 	if strings.Contains(groupNo, threadChannelIDSeparator) {
-		c.ResponseError(errors.New("thread channel id is not accepted here; use /v1/bot/groups/<group_no>/threads/<short_id>/md instead"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIThreadChannelNotAccepted, nil, nil)
 		return
 	}
 
 	isMember, err := ba.groupService.ExistMember(groupNo, robotID)
 	if err != nil {
 		ba.Error("check group membership failed", zap.Error(err))
-		c.ResponseError(errors.New("check group membership failed"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 	if !isMember {
-		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"msg": "bot is not a member of this group", "status": 403})
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPINotGroupMember, nil, nil)
 		return
 	}
 
 	isBotAdmin, err := ba.groupService.IsBotAdmin(groupNo, robotID)
 	if err != nil {
 		ba.Error("check bot admin failed", zap.Error(err))
-		c.ResponseError(errors.New("check bot admin failed"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 	if !isBotAdmin {
-		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"msg": "bot is not a bot_admin in this group", "status": 403})
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPINotGroupAdmin, nil, nil)
 		return
 	}
 
@@ -219,20 +232,20 @@ func (ba *BotAPI) updateGroupMd(c *wkhttp.Context) {
 		Content string `json:"content"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("invalid request body"))
+		respondBotAPIRequestInvalid(c, "")
 		return
 	}
 
 	maxSize := group.GetGroupMdMaxSize()
 	if len(req.Content) > maxSize {
-		c.ResponseError(fmt.Errorf("GROUP.md content exceeds max size %d bytes", maxSize))
+		respondBotAPIContentTooLarge(c, "content", maxSize)
 		return
 	}
 
 	newVersion, err := ba.groupService.UpdateGroupMd(groupNo, req.Content, robotID)
 	if err != nil {
 		ba.Error("update GROUP.md failed", zap.Error(err))
-		c.ResponseError(errors.New("update GROUP.md failed"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 		return
 	}
 
@@ -257,7 +270,7 @@ func (ba *BotAPI) updateGroupMd(c *wkhttp.Context) {
 func (ba *BotAPI) botSpaceMembers(c *wkhttp.Context) {
 	robotID := getRobotIDFromContext(c)
 	if robotID == "" {
-		c.ResponseError(errors.New("robot_id not found"))
+		ba.respondBotAPIIdentityMissing(c)
 		return
 	}
 
@@ -297,11 +310,11 @@ func (ba *BotAPI) botSpaceMembers(c *wkhttp.Context) {
 			"SELECT COUNT(*) FROM space_member WHERE space_id=? AND uid=? AND status=1", spaceID, robotID,
 		).LoadOne(&count); spErr != nil {
 			ba.Error("query space membership failed", zap.Error(spErr))
-			c.ResponseError(errors.New("查询空间成员失败"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 			return
 		}
 		if count == 0 {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"msg": "bot is not a member of this space"})
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPINotSpaceMember, nil, nil)
 			return
 		}
 	}
@@ -323,7 +336,7 @@ func (ba *BotAPI) botSpaceMembers(c *wkhttp.Context) {
 	}
 	if err != nil {
 		ba.Error("query space members failed", zap.Error(err))
-		c.ResponseError(errors.New("failed to query space members"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 
@@ -334,13 +347,13 @@ func (ba *BotAPI) botSpaceMembers(c *wkhttp.Context) {
 func (ba *BotAPI) botGroupCreate(c *wkhttp.Context) {
 	robotID := getRobotIDFromContext(c)
 	if robotID == "" {
-		c.ResponseError(errors.New("robot_id not found"))
+		ba.respondBotAPIIdentityMissing(c)
 		return
 	}
 
 	// App Bot is DM-only — deny group operations
 	if getBotKindFromContext(c) == BotKindApp {
-		c.ResponseError(errors.New("app bot does not support group operations"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIAppBotUnsupported, nil, nil)
 		return
 	}
 
@@ -351,15 +364,15 @@ func (ba *BotAPI) botGroupCreate(c *wkhttp.Context) {
 		SpaceID string   `json:"space_id"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("invalid request body"))
+		respondBotAPIRequestInvalid(c, "")
 		return
 	}
 	if len(req.Members) == 0 {
-		c.ResponseError(errors.New("members is required"))
+		respondBotAPIRequestInvalid(c, "members")
 		return
 	}
 	if len(req.Members) > 200 {
-		c.ResponseError(errors.New("members exceeds maximum of 200"))
+		respondBotAPILimitExceeded(c, "members", 200)
 		return
 	}
 
@@ -370,7 +383,7 @@ func (ba *BotAPI) botGroupCreate(c *wkhttp.Context) {
 		).Load(&spaceIDs)
 		if spErr != nil {
 			ba.Error("query bot space failed", zap.Error(spErr))
-			c.ResponseError(errors.New("failed to determine bot space association"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 			return
 		}
 		if len(spaceIDs) > 0 {
@@ -381,7 +394,7 @@ func (ba *BotAPI) botGroupCreate(c *wkhttp.Context) {
 	memberUsers, err := ba.userDB.QueryByUIDs(req.Members)
 	if err != nil {
 		ba.Error("query member info failed", zap.Error(err))
-		c.ResponseError(errors.New("failed to query member info"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 	robotSet := make(map[string]bool)
@@ -397,7 +410,7 @@ func (ba *BotAPI) botGroupCreate(c *wkhttp.Context) {
 		}
 	}
 	if len(humanMembers) == 0 {
-		c.ResponseError(errors.New("only human members can be added through bot API"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIMemberNotHuman, nil, nil)
 		return
 	}
 
@@ -407,15 +420,15 @@ func (ba *BotAPI) botGroupCreate(c *wkhttp.Context) {
 		creatorUser, err := ba.userDB.QueryByUID(req.Creator)
 		if err != nil {
 			ba.Error("query creator info failed", zap.Error(err))
-			c.ResponseError(errors.New("failed to query creator info"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 			return
 		}
 		if creatorUser == nil {
-			c.ResponseError(errors.New("creator user does not exist"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIUserNotFound, nil, nil)
 			return
 		}
 		if creatorUser.Robot == 1 {
-			c.ResponseError(errors.New("creator cannot be a bot"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIMemberNotHuman, nil, i18n.Details{"field": "creator"})
 			return
 		}
 	}
@@ -429,7 +442,7 @@ func (ba *BotAPI) botGroupCreate(c *wkhttp.Context) {
 	})
 	if err != nil {
 		ba.Error("create group failed", zap.Error(err))
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 		return
 	}
 
@@ -450,7 +463,7 @@ func (ba *BotAPI) botGroupUpdate(c *wkhttp.Context) {
 
 	// App Bot is DM-only — deny group operations
 	if getBotKindFromContext(c) == BotKindApp {
-		c.ResponseError(errors.New("app bot does not support group operations"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIAppBotUnsupported, nil, nil)
 		return
 	}
 
@@ -459,17 +472,17 @@ func (ba *BotAPI) botGroupUpdate(c *wkhttp.Context) {
 	isMember, err := ba.groupService.ExistMember(groupNo, robotID)
 	if err != nil {
 		ba.Error("check group membership failed", zap.Error(err))
-		c.ResponseError(errors.New("查询群成员失败"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 	if !isMember {
-		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"msg": "bot is not a member of this group"})
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPINotGroupMember, nil, nil)
 		return
 	}
 
 	isBotAdmin, err := ba.groupService.IsBotAdmin(groupNo, robotID)
 	if err != nil || !isBotAdmin {
-		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"msg": "bot is not a bot_admin in this group"})
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPINotGroupAdmin, nil, nil)
 		return
 	}
 
@@ -478,11 +491,11 @@ func (ba *BotAPI) botGroupUpdate(c *wkhttp.Context) {
 		Notice *string `json:"notice"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("invalid request body"))
+		respondBotAPIRequestInvalid(c, "")
 		return
 	}
 	if req.Name == nil && req.Notice == nil {
-		c.ResponseError(errors.New("at least one of name or notice is required"))
+		respondBotAPIRequestInvalid(c, "")
 		return
 	}
 
@@ -495,7 +508,7 @@ func (ba *BotAPI) botGroupUpdate(c *wkhttp.Context) {
 	})
 	if err != nil {
 		ba.Error("update group failed", zap.Error(err))
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 		return
 	}
 
@@ -509,7 +522,7 @@ func (ba *BotAPI) botGroupMemberAdd(c *wkhttp.Context) {
 
 	// App Bot is DM-only — deny group operations
 	if getBotKindFromContext(c) == BotKindApp {
-		c.ResponseError(errors.New("app bot does not support group operations"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIAppBotUnsupported, nil, nil)
 		return
 	}
 
@@ -518,11 +531,11 @@ func (ba *BotAPI) botGroupMemberAdd(c *wkhttp.Context) {
 	isMember, err := ba.groupService.ExistMember(groupNo, robotID)
 	if err != nil {
 		ba.Error("check group membership failed", zap.Error(err))
-		c.ResponseError(errors.New("查询群成员失败"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 	if !isMember {
-		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"msg": "bot is not a member of this group"})
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPINotGroupMember, nil, nil)
 		return
 	}
 
@@ -530,19 +543,18 @@ func (ba *BotAPI) botGroupMemberAdd(c *wkhttp.Context) {
 		Members []string `json:"members"`
 	}
 	if err := c.BindJSON(&req); err != nil || len(req.Members) == 0 {
-		c.ResponseError(errors.New("members is required"))
+		respondBotAPIRequestInvalid(c, "members")
 		return
 	}
 	if len(req.Members) > 200 {
-		c.ResponseError(errors.New("members exceeds maximum of 200"))
+		respondBotAPILimitExceeded(c, "members", 200)
 		return
 	}
-
 
 	memberUsers, err := ba.userDB.QueryByUIDs(req.Members)
 	if err != nil {
 		ba.Error("query member info failed", zap.Error(err))
-		c.ResponseError(errors.New("failed to query member info"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 	var humanMembers []string
@@ -555,7 +567,7 @@ func (ba *BotAPI) botGroupMemberAdd(c *wkhttp.Context) {
 		humanMembers = append(humanMembers, u.UID)
 	}
 	if len(humanMembers) == 0 {
-		c.ResponseError(errors.New("only human members can be added through bot API"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIMemberNotHuman, nil, nil)
 		return
 	}
 
@@ -567,7 +579,7 @@ func (ba *BotAPI) botGroupMemberAdd(c *wkhttp.Context) {
 	})
 	if err != nil {
 		ba.Error("add group members failed", zap.Error(err))
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 		return
 	}
 
@@ -585,7 +597,7 @@ func (ba *BotAPI) botGroupMemberRemove(c *wkhttp.Context) {
 
 	// App Bot is DM-only — deny group operations
 	if getBotKindFromContext(c) == BotKindApp {
-		c.ResponseError(errors.New("app bot does not support group operations"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIAppBotUnsupported, nil, nil)
 		return
 	}
 
@@ -594,17 +606,17 @@ func (ba *BotAPI) botGroupMemberRemove(c *wkhttp.Context) {
 	isMember, err := ba.groupService.ExistMember(groupNo, robotID)
 	if err != nil {
 		ba.Error("check group membership failed", zap.Error(err))
-		c.ResponseError(errors.New("查询群成员失败"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 	if !isMember {
-		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"msg": "bot is not a member of this group"})
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPINotGroupMember, nil, nil)
 		return
 	}
 
 	isBotAdmin, err := ba.groupService.IsBotAdmin(groupNo, robotID)
 	if err != nil || !isBotAdmin {
-		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"msg": "bot is not a bot_admin in this group"})
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPINotGroupAdmin, nil, nil)
 		return
 	}
 
@@ -612,7 +624,7 @@ func (ba *BotAPI) botGroupMemberRemove(c *wkhttp.Context) {
 		Members []string `json:"members"`
 	}
 	if err := c.BindJSON(&req); err != nil || len(req.Members) == 0 {
-		c.ResponseError(errors.New("members is required"))
+		respondBotAPIRequestInvalid(c, "members")
 		return
 	}
 
@@ -635,7 +647,7 @@ func (ba *BotAPI) botGroupMemberRemove(c *wkhttp.Context) {
 	})
 	if err != nil {
 		ba.Error("remove group members failed", zap.Error(err))
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 		return
 	}
 
@@ -675,4 +687,3 @@ func (ba *BotAPI) sendGroupMdNotification(groupNo string, updatedBy string, vers
 		Payload:     []byte(util.ToJson(payload)),
 	})
 }
-

--- a/modules/bot_api/mention_pref.go
+++ b/modules/bot_api/mention_pref.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/gocraft/dbr/v2"
 	"go.uber.org/zap"
 )
@@ -24,7 +26,7 @@ import (
 func (ba *BotAPI) getMentionPref(c *wkhttp.Context) {
 	robotID := getRobotIDFromContext(c)
 	if robotID == "" {
-		c.ResponseError(errors.New("robot_id not found"))
+		ba.respondBotAPIIdentityMissing(c)
 		return
 	}
 	groupNo := c.Param("group_no")
@@ -34,8 +36,14 @@ func (ba *BotAPI) getMentionPref(c *wkhttp.Context) {
 		"SELECT COUNT(*) FROM group_member WHERE group_no=? AND uid=? AND is_deleted=0",
 		groupNo, robotID,
 	).LoadOne(&count)
-	if err != nil || count == 0 {
-		c.ResponseError(errors.New("bot is not a member of this group"))
+	if err != nil {
+		ba.Error("query group membership failed", zap.Error(err),
+			zap.String("robot_id", robotID), zap.String("group_no", groupNo))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
+		return
+	}
+	if count == 0 {
+		httperr.ResponseErrorL(c, errcode.ErrBotAPINotGroupMember, nil, nil)
 		return
 	}
 
@@ -45,7 +53,7 @@ func (ba *BotAPI) getMentionPref(c *wkhttp.Context) {
 	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
 		ba.Error("查询 bot_mention_pref 失败", zap.Error(err),
 			zap.String("robot_id", robotID), zap.String("group_no", groupNo))
-		c.ResponseError(errors.New("查询失败"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 
@@ -59,7 +67,7 @@ func (ba *BotAPI) getMentionPref(c *wkhttp.Context) {
 		} else {
 			ba.Error("查询 group.allow_no_mention 失败", zap.Error(err),
 				zap.String("robot_id", robotID), zap.String("group_no", groupNo))
-			c.ResponseError(errors.New("查询失败"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 			return
 		}
 	}

--- a/modules/bot_api/obo_api.go
+++ b/modules/bot_api/obo_api.go
@@ -7,16 +7,17 @@
 // NOT support cross-user persona management in v0 (RFC §2 / out-of-scope).
 //
 // Status code map (kept narrow on purpose):
-//   200 — success (single object or list)
-//   400 — bad request body / missing required fields
-//   401 — no user token (handled by upstream middleware)
-//   403 — (reserved — production currently uses 404 for cross-user attempts
-//          as a user-enumeration defense; see requireOwnedGrant comment.)
-//   404 — grant_id / scope_id not found; cross-user grant/scope access
-//          (existence-leak defense)
-//   409 — duplicate (grantor+grantee already exists / scope already exists,
-//          with no soft-deleted row to reactivate in place)
-//   500 — DB error
+//
+//	200 — success (single object or list)
+//	400 — bad request body / missing required fields
+//	401 — no user token (handled by upstream middleware)
+//	403 — (reserved — production currently uses 404 for cross-user attempts
+//	       as a user-enumeration defense; see requireOwnedGrant comment.)
+//	404 — grant_id / scope_id not found; cross-user grant/scope access
+//	       (existence-leak defense)
+//	409 — duplicate (grantor+grantee already exists / scope already exists,
+//	       with no soft-deleted row to reactivate in place)
+//	500 — DB error
 package bot_api
 
 import (
@@ -24,12 +25,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"go.uber.org/zap"
 )
 
@@ -203,20 +205,20 @@ type oboCreateScopeReq struct {
 func (ba *BotAPI) oboCreateGrant(c *wkhttp.Context) {
 	uid := c.GetLoginUID()
 	if uid == "" {
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin404("unauthorized"))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPISharedAuthRequired, nil, nil)
 		return
 	}
 	var req oboCreateGrantReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("数据格式有误"))
+		respondBotAPIRequestInvalid(c, "")
 		return
 	}
 	if strings.TrimSpace(req.GranteeBotUID) == "" {
-		c.ResponseError(errors.New("grantee_bot_uid 不能为空"))
+		respondBotAPIRequestInvalid(c, "grantee_bot_uid")
 		return
 	}
 	if req.GranteeBotUID == uid {
-		c.ResponseError(errors.New("grantee_bot_uid 不能等于自己"))
+		respondBotAPIRequestInvalid(c, "grantee_bot_uid")
 		return
 	}
 	mode := req.Mode
@@ -225,7 +227,7 @@ func (ba *BotAPI) oboCreateGrant(c *wkhttp.Context) {
 	}
 	if mode != "auto" {
 		// v0 — see RFC §2 / out-of-scope. Draft mode lands in v1.
-		c.ResponseError(errors.New("mode 仅支持 auto (v0)"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOModeUnsupported, nil, nil)
 		return
 	}
 	// PR#109 / YUJ-1471 — persona_prompt length cap. Fan-out appends
@@ -234,7 +236,7 @@ func (ba *BotAPI) oboCreateGrant(c *wkhttp.Context) {
 	// budget. 4096 bytes is generous for natural-language guidance and
 	// matches the cap UI surfaces (see web persona editor).
 	if len(req.PersonaPrompt) > oboPersonaPromptMaxBytes {
-		c.ResponseError(errors.New("persona_prompt 长度超过上限 (最多 4096 字节)"))
+		respondBotAPIContentTooLarge(c, "persona_prompt", oboPersonaPromptMaxBytes)
 		return
 	}
 
@@ -245,18 +247,18 @@ func (ba *BotAPI) oboCreateGrant(c *wkhttp.Context) {
 	creatorUID, isBot, found, err := ba.oboStoreOrDefault().queryRobotOwner(req.GranteeBotUID)
 	if err != nil {
 		ba.Error("queryRobotOwner failed", zap.Error(err), zap.String("bot", req.GranteeBotUID))
-		c.ResponseError(errors.New("内部错误"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOInternal, nil, nil)
 		return
 	}
 	if !found || !isBot {
-		c.JSON(http.StatusNotFound, gin404("grantee_bot_uid not a registered bot"))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIBotNotRegistered, nil, nil)
 		return
 	}
 	if creatorUID != uid {
 		// Owned by someone else; treat as not-found to avoid telling the
 		// caller "this bot exists but isn't yours". Same posture as
 		// requireOwnedGrant.
-		c.JSON(http.StatusNotFound, gin404("grantee_bot_uid not a registered bot"))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIBotNotRegistered, nil, nil)
 		return
 	}
 
@@ -274,14 +276,14 @@ func (ba *BotAPI) oboCreateGrant(c *wkhttp.Context) {
 	grant, _, err := ba.oboStoreOrDefault().createOrReactivateGrantAtomic(uid, req.GranteeBotUID, mode, req.PersonaPrompt)
 	if err != nil {
 		if errors.Is(err, errOBOGrantAlreadyActive) {
-			c.JSON(http.StatusConflict, gin404("grant already exists"))
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIOBOGrantExists, nil, nil)
 			return
 		}
 		ba.Error("createOrReactivateGrantAtomic failed",
 			zap.Error(err),
 			zap.String("grantor", uid),
 			zap.String("bot", req.GranteeBotUID))
-		c.ResponseError(errors.New("内部错误"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOInternal, nil, nil)
 		return
 	}
 	c.Response(grant)
@@ -292,13 +294,13 @@ func (ba *BotAPI) oboCreateGrant(c *wkhttp.Context) {
 func (ba *BotAPI) oboListGrants(c *wkhttp.Context) {
 	uid := c.GetLoginUID()
 	if uid == "" {
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin404("unauthorized"))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPISharedAuthRequired, nil, nil)
 		return
 	}
 	grants, err := ba.oboStoreOrDefault().listGrantsByGrantor(uid)
 	if err != nil {
 		ba.Error("listGrants failed", zap.Error(err))
-		c.ResponseError(errors.New("内部错误"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOInternal, nil, nil)
 		return
 	}
 	c.Response(map[string]interface{}{"items": grants})
@@ -318,7 +320,7 @@ func (ba *BotAPI) oboDeleteGrant(c *wkhttp.Context) {
 	}
 	if err := ba.oboStoreOrDefault().revokeGrant(id); err != nil {
 		ba.Error("revokeGrant failed", zap.Error(err), zap.Int64("id", id))
-		c.ResponseError(errors.New("内部错误"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOInternal, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -381,7 +383,7 @@ func (ba *BotAPI) oboUpdateGrant(c *wkhttp.Context) {
 	}
 	var req oboUpdateGrantReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("数据格式有误"))
+		respondBotAPIRequestInvalid(c, "")
 		return
 	}
 	// YUJ-1424 / W1 / YUJ-1735 — paused-vs-revoked gate. See function
@@ -392,7 +394,7 @@ func (ba *BotAPI) oboUpdateGrant(c *wkhttp.Context) {
 			zap.Int64("grant_id", id),
 			zap.String("grantor", uid),
 			zap.Int("active", grant.Active))
-		c.JSON(http.StatusNotFound, gin404("grant not found"))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIOBOGrantNotFound, nil, nil)
 		return
 	}
 	if grant.Active != 1 && req.Active == nil {
@@ -400,17 +402,17 @@ func (ba *BotAPI) oboUpdateGrant(c *wkhttp.Context) {
 			zap.Int64("grant_id", id),
 			zap.String("grantor", uid),
 			zap.Int("active", grant.Active))
-		c.JSON(http.StatusNotFound, gin404("grant not found"))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIOBOGrantNotFound, nil, nil)
 		return
 	}
 	if req.Mode != "" && req.Mode != "auto" {
-		c.ResponseError(errors.New("mode 仅支持 auto (v0)"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOModeUnsupported, nil, nil)
 		return
 	}
 	// PR#109 / YUJ-1471 — persona_prompt length cap. Same rationale as
 	// the create handler; rejected before any DB work hits the row.
 	if req.PersonaPrompt != nil && len(*req.PersonaPrompt) > oboPersonaPromptMaxBytes {
-		c.ResponseError(errors.New("persona_prompt 长度超过上限 (最多 4096 字节)"))
+		respondBotAPIContentTooLarge(c, "persona_prompt", oboPersonaPromptMaxBytes)
 		return
 	}
 	if req.Mode == "" && req.GlobalEnabled == nil && req.PersonaPrompt == nil && req.Active == nil {
@@ -435,14 +437,14 @@ func (ba *BotAPI) oboUpdateGrant(c *wkhttp.Context) {
 		}
 		if err := ba.oboStoreOrDefault().setGrantActive(id, v); err != nil {
 			ba.Error("setGrantActive failed", zap.Error(err), zap.Int64("id", id))
-			c.ResponseError(errors.New("内部错误"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOInternal, nil, nil)
 			return
 		}
 	}
 	if req.Mode != "" || req.GlobalEnabled != nil || req.PersonaPrompt != nil {
 		if err := ba.oboStoreOrDefault().updateGrant(id, req.Mode, req.GlobalEnabled, req.PersonaPrompt); err != nil {
 			ba.Error("updateGrant failed", zap.Error(err), zap.Int64("id", id))
-			c.ResponseError(errors.New("内部错误"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOInternal, nil, nil)
 			return
 		}
 	}
@@ -470,16 +472,16 @@ func (ba *BotAPI) oboUpdateGrant(c *wkhttp.Context) {
 func (ba *BotAPI) oboCreateScope(c *wkhttp.Context) {
 	uid := c.GetLoginUID()
 	if uid == "" {
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin404("unauthorized"))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPISharedAuthRequired, nil, nil)
 		return
 	}
 	var req oboCreateScopeReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("数据格式有误"))
+		respondBotAPIRequestInvalid(c, "")
 		return
 	}
 	if req.GrantID == 0 || strings.TrimSpace(req.ChannelID) == "" || req.ChannelType == 0 {
-		c.ResponseError(errors.New("grant_id / channel_id / channel_type 不能为空"))
+		respondBotAPIRequestInvalid(c, "")
 		return
 	}
 	grant, err := ba.requireOwnedGrant(c, uid, req.GrantID)
@@ -497,7 +499,7 @@ func (ba *BotAPI) oboCreateScope(c *wkhttp.Context) {
 			zap.Error(err), zap.String("grantor", uid),
 			zap.String("channel_id", req.ChannelID),
 			zap.Uint8("channel_type", req.ChannelType))
-		c.ResponseError(errors.New("内部错误"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOInternal, nil, nil)
 		return
 	}
 	if !ok {
@@ -505,7 +507,7 @@ func (ba *BotAPI) oboCreateScope(c *wkhttp.Context) {
 			zap.String("grantor", uid),
 			zap.String("channel_id", req.ChannelID),
 			zap.Uint8("channel_type", req.ChannelType))
-		c.JSON(http.StatusNotFound, gin404("channel not found"))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIOBOChannelNotFound, nil, nil)
 		return
 	}
 
@@ -516,11 +518,11 @@ func (ba *BotAPI) oboCreateScope(c *wkhttp.Context) {
 	id, err := ba.oboStoreOrDefault().insertScope(req.GrantID, req.ChannelID, req.ChannelType, enabled)
 	if err != nil {
 		if isDuplicateKeyErr(err) {
-			c.JSON(http.StatusConflict, gin404("scope already exists"))
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIOBOScopeExists, nil, nil)
 			return
 		}
 		ba.Error("insertScope failed", zap.Error(err))
-		c.ResponseError(errors.New("内部错误"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOInternal, nil, nil)
 		return
 	}
 	c.Response(map[string]interface{}{
@@ -543,7 +545,7 @@ func (ba *BotAPI) oboCreateScope(c *wkhttp.Context) {
 func (ba *BotAPI) oboDeleteScope(c *wkhttp.Context) {
 	uid := c.GetLoginUID()
 	if uid == "" {
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin404("unauthorized"))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPISharedAuthRequired, nil, nil)
 		return
 	}
 	id, ok := parseIDParam(c, "id")
@@ -553,19 +555,19 @@ func (ba *BotAPI) oboDeleteScope(c *wkhttp.Context) {
 	owner, found, err := ba.oboStoreOrDefault().findScopeOwner(id)
 	if err != nil {
 		ba.Error("scope ownership lookup failed", zap.Error(err), zap.Int64("id", id))
-		c.ResponseError(errors.New("内部错误"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOInternal, nil, nil)
 		return
 	}
 	if !found || owner != uid {
 		// Existence-leak defense: cross-user delete attempts return 404,
 		// indistinguishable from "scope id never existed". Matches the
 		// posture in requireOwnedGrant.
-		c.JSON(http.StatusNotFound, gin404("scope not found"))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIOBOScopeNotFound, nil, nil)
 		return
 	}
 	if err := ba.oboStoreOrDefault().deleteScope(id); err != nil {
 		ba.Error("deleteScope failed", zap.Error(err), zap.Int64("id", id))
-		c.ResponseError(errors.New("内部错误"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOInternal, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -585,7 +587,7 @@ func (ba *BotAPI) oboListScopes(c *wkhttp.Context) {
 	scopes, err := ba.oboStoreOrDefault().listScopesByGrant(id)
 	if err != nil {
 		ba.Error("listScopes failed", zap.Error(err))
-		c.ResponseError(errors.New("内部错误"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOInternal, nil, nil)
 		return
 	}
 	c.Response(map[string]interface{}{"items": scopes})
@@ -623,13 +625,13 @@ type oboBotGetGrantResp struct {
 // Status code map:
 //   - 200 — grant found; body is oboBotGetGrantResp.
 //   - 401 — handled by ba.authBot() upstream (this handler only runs
-//           on authenticated requests; the defensive empty-uid branch
-//           below 500s because reaching it means the middleware broke
-//           its invariant and a 401 would mask that).
+//     on authenticated requests; the defensive empty-uid branch
+//     below 500s because reaching it means the middleware broke
+//     its invariant and a 401 would mask that).
 //   - 404 — no active grant for this bot. Note: "no active grant"
-//           covers both "grant never existed" and "grant was paused
-//           or revoked"; the adapter should treat 404 as "do not
-//           apply a persona" without distinguishing the cause.
+//     covers both "grant never existed" and "grant was paused
+//     or revoked"; the adapter should treat 404 as "do not
+//     apply a persona" without distinguishing the cause.
 //   - 500 — store error.
 //
 // `persona_prompt` round-trips as an empty string when the column is
@@ -642,7 +644,7 @@ func (ba *BotAPI) oboBotGetGrant(c *wkhttp.Context) {
 		// rather than 401 so the misconfiguration is noisy upstream
 		// instead of being silently mis-attributed to an auth failure.
 		ba.Error("oboBotGetGrant: empty robot id from auth context")
-		c.ResponseError(errors.New("内部错误"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOInternal, nil, nil)
 		return
 	}
 	grant, err := ba.oboStoreOrDefault().findActiveGrantByBot(botUID)
@@ -650,11 +652,11 @@ func (ba *BotAPI) oboBotGetGrant(c *wkhttp.Context) {
 		ba.Error("findActiveGrantByBot failed",
 			zap.Error(err),
 			zap.String("bot", botUID))
-		c.ResponseError(errors.New("内部错误"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOInternal, nil, nil)
 		return
 	}
 	if grant == nil {
-		c.JSON(http.StatusNotFound, gin404("no active grant"))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIOBOGrantNotFound, nil, nil)
 		return
 	}
 	c.Response(oboBotGetGrantResp{
@@ -672,23 +674,23 @@ func (ba *BotAPI) oboBotGetGrant(c *wkhttp.Context) {
 // any failure path so callers can simply `return`.
 func (ba *BotAPI) requireOwnedGrant(c *wkhttp.Context, uid string, id int64) (*oboGrantModel, error) {
 	if uid == "" {
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin404("unauthorized"))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPISharedAuthRequired, nil, nil)
 		return nil, nil
 	}
 	grant, err := ba.oboStoreOrDefault().findGrantByID(id)
 	if err != nil {
 		ba.Error("findGrantByID failed", zap.Error(err), zap.Int64("id", id))
-		c.ResponseError(errors.New("内部错误"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOInternal, nil, nil)
 		return nil, err
 	}
 	if grant == nil {
-		c.JSON(http.StatusNotFound, gin404("grant not found"))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIOBOGrantNotFound, nil, nil)
 		return nil, nil
 	}
 	if grant.GrantorUID != uid {
 		// Treat as 404, not 403, so we don't leak grant existence to
 		// non-owners. (Same logic as classic "user enumeration" defense.)
-		c.JSON(http.StatusNotFound, gin404("grant not found"))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIOBOGrantNotFound, nil, nil)
 		return nil, nil
 	}
 	return grant, nil
@@ -793,7 +795,7 @@ func parseIDParam(c *wkhttp.Context, name string) (int64, bool) {
 	raw := c.Param(name)
 	id, err := strconv.ParseInt(raw, 10, 64)
 	if err != nil || id <= 0 {
-		c.ResponseError(errors.New(name + " 无效"))
+		respondBotAPIRequestInvalid(c, name)
 		return 0, false
 	}
 	return id, true

--- a/modules/bot_api/obo_send_test.go
+++ b/modules/bot_api/obo_send_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/gin-gonic/gin"
 )
 
@@ -169,7 +170,7 @@ func TestSendMessage_OBO_Unauthorized_Returns400Body(t *testing.T) {
 	// ResponseError → 400 with body containing the message. Asserting on
 	// the body rather than the code keeps the test independent of the
 	// project's choice of error transport.
-	if !strings.Contains(rec.Body.String(), ErrOBONotAuthorized.Error()) {
+	if !strings.Contains(rec.Body.String(), errcode.ErrBotAPIOBONotAuthorized.DefaultMessage) {
 		t.Fatalf("expected obo-not-authorized in body, got %s", rec.Body.String())
 	}
 	if dc.captured != nil {
@@ -411,7 +412,7 @@ func TestSendMessage_OBO_GrantorReplyBypass_RequiresActiveGrant(t *testing.T) {
 	c.Set(CtxKeyRobot, &robotModel{RobotID: botID, CreatorUID: stranger})
 
 	ba.sendMessage(c)
-	if !strings.Contains(rec.Body.String(), ErrOBONotAuthorized.Error()) {
+	if !strings.Contains(rec.Body.String(), errcode.ErrBotAPIOBONotAuthorized.DefaultMessage) {
 		t.Fatalf("bypass must refuse to fire without a real grant; expected obo-not-authorized, got %s", rec.Body.String())
 	}
 	if dc.captured != nil {
@@ -496,7 +497,7 @@ func TestSendMessage_OBO_GrantorReplyBypass_DoesNotApplyToThirdPartySend(t *test
 	}
 
 	ba.sendMessage(c)
-	if !strings.Contains(rec.Body.String(), ErrOBONotAuthorized.Error()) {
+	if !strings.Contains(rec.Body.String(), errcode.ErrBotAPIOBONotAuthorized.DefaultMessage) {
 		t.Fatalf("third-party OBO send with explicit-disabled scope must still be rejected; got %s", rec.Body.String())
 	}
 	if dc.captured != nil {
@@ -602,7 +603,7 @@ func TestSendMessage_RejectsReservedOBOKey(t *testing.T) {
 
 	ba.sendMessage(c)
 	// Body must carry the reject message; dispatch must NOT fire.
-	if !strings.Contains(rec.Body.String(), "__obo_") {
+	if !strings.Contains(rec.Body.String(), errcode.ErrBotAPIOBOReservedField.DefaultMessage) {
 		t.Fatalf("expected reject body to mention __obo_ prefix, got %s", rec.Body.String())
 	}
 	if dc.captured != nil {
@@ -711,7 +712,7 @@ func TestBotMessage_OBOReservedKeysKept(t *testing.T) {
 
 	// Reject must carry a body that mentions the prefix so bot authors
 	// can grep for it in their logs.
-	if !strings.Contains(rec.Body.String(), "__obo_") {
+	if !strings.Contains(rec.Body.String(), errcode.ErrBotAPIOBOReservedField.DefaultMessage) {
 		t.Fatalf("expected bot-API reject body to mention __obo_ prefix, got %s", rec.Body.String())
 	}
 	// And no dispatch (= the strip-and-pass behavior the user ingress

--- a/modules/bot_api/obo_v2_typing_test.go
+++ b/modules/bot_api/obo_v2_typing_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/gin-gonic/gin"
 )
 
@@ -190,7 +191,7 @@ func TestTyping_V2_OBOContextWithoutGrantDenied(t *testing.T) {
 	c := buildTypingCtx(rec, body)
 	ba.typing(c)
 
-	if !strings.Contains(rec.Body.String(), "obo not authorized") {
+	if !strings.Contains(rec.Body.String(), errcode.ErrBotAPIOBONotAuthorized.DefaultMessage) {
 		t.Fatalf("typing on_behalf_of a non-granting user must surface obo-not-authorized; got body=%s", rec.Body.String())
 	}
 	if len(cap.cmds) != 0 {
@@ -205,10 +206,10 @@ func TestTyping_V2_OBOContextWithoutGrantDenied(t *testing.T) {
 func TestTyping_V2_OBOContextDispatchesGroupTypingAsGrantor(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	const (
-		admin    = "user_admin"
-		bot      = "bot_clone_james"
-		groupNo  = "group_42"
-		botKind  = BotKindUser
+		admin   = "user_admin"
+		bot     = "bot_clone_james"
+		groupNo = "group_42"
+		botKind = BotKindUser
 	)
 	s := newFakeOBOStore()
 	gid, _ := s.insertGrant(admin, bot, "auto", "")

--- a/modules/bot_api/register.go
+++ b/modules/bot_api/register.go
@@ -1,13 +1,14 @@
 package bot_api
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/pkg/botutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"go.uber.org/zap"
 )
 
@@ -33,7 +34,7 @@ type BotRegisterResp struct {
 func (ba *BotAPI) register(c *wkhttp.Context) {
 	token := extractBotToken(c)
 	if token == "" {
-		c.ResponseError(errors.New("缺少Authorization头"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIAuthFailed, nil, nil)
 		return
 	}
 
@@ -49,11 +50,11 @@ func (ba *BotAPI) registerUserBot(c *wkhttp.Context, token string) {
 	robot, err := ba.db.queryRobotByBotToken(token)
 	if err != nil {
 		ba.Error("查询机器人失败", zap.Error(err))
-		c.ResponseError(errors.New("认证失败"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIAuthCheckFailed, nil, nil)
 		return
 	}
 	if robot == nil {
-		c.ResponseError(errors.New("无效的bot token"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIAuthFailed, nil, nil)
 		return
 	}
 
@@ -67,7 +68,7 @@ func (ba *BotAPI) registerUserBot(c *wkhttp.Context, token string) {
 	})
 	if tokenErr != nil || resp.Status != config.UpdateTokenStatusSuccess {
 		ba.Error("获取IM Token失败", zap.Any("error", tokenErr), zap.String("robotID", robot.RobotID), zap.Any("status", resp))
-		c.ResponseError(errors.New("获取IM Token失败"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIIMTokenFailed, nil, nil)
 		return
 	}
 	if robot.IMTokenCache != imToken {
@@ -129,17 +130,17 @@ func (ba *BotAPI) registerAppBot(c *wkhttp.Context, token string) {
 	appBot, err := ba.db.queryAppBotByToken(token)
 	if err != nil {
 		ba.Error("查询App Bot失败", zap.Error(err))
-		c.ResponseError(errors.New("认证失败"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIAuthCheckFailed, nil, nil)
 		return
 	}
 	if appBot == nil {
-		c.ResponseError(errors.New("无效的bot token"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIAuthFailed, nil, nil)
 		return
 	}
 
 	// Only published App Bots can register
 	if appBot.Status != 1 {
-		c.ResponseError(errors.New("无效的bot token"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIAuthFailed, nil, nil)
 		return
 	}
 
@@ -157,7 +158,7 @@ func (ba *BotAPI) registerAppBot(c *wkhttp.Context, token string) {
 	})
 	if tokenErr != nil || resp.Status != config.UpdateTokenStatusSuccess {
 		ba.Error("App Bot IM Token注册失败", zap.Any("error", tokenErr), zap.String("uid", appBot.UID), zap.Any("status", resp))
-		c.ResponseError(errors.New("获取IM Token失败"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIIMTokenFailed, nil, nil)
 		return
 	}
 
@@ -178,4 +179,3 @@ func (ba *BotAPI) registerAppBot(c *wkhttp.Context, token string) {
 		OwnerChannelID: appBot.CreatedBy,
 	})
 }
-

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -685,7 +685,12 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 			return
 		}
 		isFriend, fErr := ba.userService.IsFriend(robotID, req.ChannelID)
-		if fErr != nil || !isFriend {
+		if fErr != nil {
+			ba.Error("verify app bot friend failed", zap.Error(fErr), zap.String("robotID", robotID), zap.String("channelID", req.ChannelID))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
+			return
+		}
+		if !isFriend {
 			httperr.ResponseErrorL(c, errcode.ErrBotAPIConversationNotStarted, nil, nil)
 			return
 		}

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -13,6 +13,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
 	"github.com/Mininglamp-OSS/octo-server/pkg/richtext"
 	"github.com/gocraft/dbr/v2"
@@ -38,20 +40,19 @@ type BotSendMessageReq struct {
 func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 	var req BotSendMessageReq
 	if err := c.BindJSON(&req); err != nil {
-		ba.Error("数据格式有误", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误"))
+		respondBotAPIRequestInvalid(c, "")
 		return
 	}
 	if strings.TrimSpace(req.ChannelID) == "" {
-		c.ResponseError(errors.New("channel_id不能为空"))
+		respondBotAPIRequestInvalid(c, "channel_id")
 		return
 	}
 	if req.ChannelType == 0 {
-		c.ResponseError(errors.New("channel_type不能为空"))
+		respondBotAPIRequestInvalid(c, "channel_type")
 		return
 	}
 	if len(req.Payload) == 0 {
-		c.ResponseError(errors.New("payload不能为空"))
+		respondBotAPIRequestInvalid(c, "payload")
 		return
 	}
 	// PR#82 review #2 P1-2 + PR#121 R2 + PR#121 R3 — reject any
@@ -76,7 +77,7 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 	// checkSendPermission / checkOBO so the error is fast and the
 	// auth path doesn't run on poisoned input.
 	if payloadHasReservedOBOKey(req.Payload) {
-		c.ResponseError(errors.New("payload 不允许使用 OBO 保留字段（__obo_* 前缀、obo_respond_as/obo_grantor_uid/obo_fanout/obo_origin_*/obo_system_hint，或 actual_sender_uid）"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOReservedField, nil, nil)
 		return
 	}
 
@@ -94,7 +95,7 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 
 	// Permission check based on bot kind
 	if err := ba.checkSendPermission(c, botKind, robotID, req.ChannelID, req.ChannelType, hasOBOContext); err != nil {
-		c.ResponseError(err)
+		respondSendPermissionError(c, err)
 		return
 	}
 
@@ -141,7 +142,7 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 					zap.String("bot", robotID),
 					zap.String("grantor", req.OnBehalfOf),
 					zap.Error(err))
-				c.ResponseError(errors.New("OBO 检查失败"))
+				httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOInternal, nil, nil)
 				return
 			}
 			grantorReplyBypass = hasGrant
@@ -155,10 +156,12 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 						zap.String("on_behalf_of", req.OnBehalfOf),
 						zap.String("channel_id", req.ChannelID),
 						zap.Uint8("channel_type", req.ChannelType))
-					c.ResponseError(ErrOBONotAuthorized)
+					httperr.ResponseErrorL(c, errcode.ErrBotAPIOBONotAuthorized, nil, nil)
 					return
 				}
-				c.ResponseError(errors.New("OBO 检查失败"))
+				ba.Error("OBO check failed", zap.Error(err),
+					zap.String("bot", robotID), zap.String("on_behalf_of", req.OnBehalfOf))
+				httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOInternal, nil, nil)
 				return
 			}
 			fromUID = req.OnBehalfOf
@@ -251,7 +254,7 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 	result, err := ba.dispatchMsgSendReq(msgReq)
 	if err != nil {
 		ba.Error("发送消息失败", zap.Error(err))
-		c.ResponseError(errors.New("发送消息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPISendFailed, nil, nil)
 		return
 	}
 
@@ -285,29 +288,32 @@ func (ba *BotAPI) checkSendPermission(c *wkhttp.Context, botKind, robotID, chann
 	case BotKindApp:
 		// Rule 1: App Bot only supports DM
 		if channelType != common.ChannelTypePerson.Uint8() {
-			return errors.New("app bot only supports direct messages")
+			return errBotSendPermAppBotDMOnly
 		}
 		// Rule 2: Must have friend relationship (user opt-in via /v1/robot/apply)
 		isFriend, err := ba.userService.IsFriend(robotID, channelID)
 		if err != nil {
-			return errors.New("failed to verify relationship")
+			ba.Error("failed to verify relationship", zap.Error(err), zap.String("robotID", robotID))
+			return errBotSendPermCheckFailed
 		}
 		if !isFriend {
-			return errors.New("user has not started conversation with this bot")
+			return errBotSendPermConvNotStarted
 		}
 		// Rule 3: Space bot — user must still be a space member (fail-closed)
 		if scope, _ := c.Get(CtxKeyAppBotScope); scope == "space" {
 			spaceIDStr, _ := c.Get(CtxKeyAppBotSpaceID)
 			sid, _ := spaceIDStr.(string)
 			if sid == "" {
-				return errors.New("internal error: space bot missing space_id")
+				ba.Error("space bot missing space_id in context", zap.String("robotID", robotID))
+				return errBotSendPermCheckFailed
 			}
 			isMember, memberErr := ba.isSpaceMember(channelID, sid)
 			if memberErr != nil {
-				return errors.New("failed to verify space membership")
+				ba.Error("failed to verify space membership", zap.Error(memberErr), zap.String("robotID", robotID))
+				return errBotSendPermCheckFailed
 			}
 			if !isMember {
-				return errors.New("user is no longer a member of bot's space")
+				return errBotSendPermNotSpaceMember
 			}
 		}
 		return nil
@@ -327,10 +333,10 @@ func (ba *BotAPI) checkSendPermission(c *wkhttp.Context, botKind, robotID, chann
 				).LoadOne(&count)
 				if err != nil {
 					ba.Error("查询群成员失败", zap.Error(err))
-					return errors.New("查询群成员失败")
+					return errBotSendPermCheckFailed
 				}
 				if count == 0 {
-					return errors.New("bot is not a member of this group")
+					return errBotSendPermNotGroupMember
 				}
 			}
 		} else if channelType == common.ChannelTypeCommunityTopic.Uint8() {
@@ -353,7 +359,7 @@ func (ba *BotAPI) checkSendPermission(c *wkhttp.Context, botKind, robotID, chann
 			if !hasOBOContext {
 				parts := strings.SplitN(channelID, threadChannelIDSeparator, 2)
 				if len(parts) != 2 {
-					return errors.New("invalid thread channel_id format")
+					return errBotSendPermBadThreadChan
 				}
 				var count int
 				err := ba.db.session.SelectBySql(
@@ -362,10 +368,10 @@ func (ba *BotAPI) checkSendPermission(c *wkhttp.Context, botKind, robotID, chann
 				).LoadOne(&count)
 				if err != nil {
 					ba.Error("查询群成员失败", zap.Error(err))
-					return errors.New("查询群成员失败")
+					return errBotSendPermCheckFailed
 				}
 				if count == 0 {
-					return errors.New("bot is not a member of this group")
+					return errBotSendPermNotGroupMember
 				}
 			}
 		} else if channelType == common.ChannelTypePerson.Uint8() {
@@ -392,17 +398,18 @@ func (ba *BotAPI) checkSendPermission(c *wkhttp.Context, botKind, robotID, chann
 				allowed, err := ba.isFriendOrOBOBypass(robotID, channelID, channelType, hasOBOContext)
 				if err != nil {
 					ba.Error("查询好友关系失败", zap.Error(err))
-					return errors.New("查询好友关系失败")
+					return errBotSendPermCheckFailed
 				}
 				if !allowed {
-					return errors.New("bot is not a friend of this user")
+					return errBotSendPermNotFriend
 				}
 			}
 		}
 		return nil
 
 	default:
-		return errors.New("unknown bot kind")
+		ba.Error("unknown bot kind", zap.String("botKind", botKind), zap.String("robotID", robotID))
+		return errBotSendPermCheckFailed
 	}
 }
 
@@ -433,11 +440,11 @@ type BotReadReceiptReq struct {
 func (ba *BotAPI) readReceipt(c *wkhttp.Context) {
 	var req BotReadReceiptReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("数据格式有误"))
+		respondBotAPIRequestInvalid(c, "")
 		return
 	}
 	if strings.TrimSpace(req.ChannelID) == "" {
-		c.ResponseError(errors.New("channel_id不能为空"))
+		respondBotAPIRequestInvalid(c, "channel_id")
 		return
 	}
 
@@ -453,7 +460,7 @@ func (ba *BotAPI) readReceipt(c *wkhttp.Context) {
 	// apply here (hasOBOContext=false).
 	botKind := getBotKindFromContext(c)
 	if err := ba.checkSendPermission(c, botKind, robotID, req.ChannelID, channelType, false); err != nil {
-		c.ResponseError(err)
+		respondSendPermissionError(c, err)
 		return
 	}
 
@@ -465,11 +472,12 @@ func (ba *BotAPI) readReceipt(c *wkhttp.Context) {
 			"SELECT COUNT(*) FROM `group` WHERE group_no=? AND is_deleted=0", req.ChannelID,
 		).LoadOne(&groupCount)
 		if grpErr != nil {
-			c.ResponseError(errors.New("验证频道类型失败"))
+			ba.Error("verify channel type failed", zap.Error(grpErr), zap.String("channelID", req.ChannelID))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 			return
 		}
 		if groupCount > 0 {
-			c.ResponseError(errors.New("app bot can only access direct message channels"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIAppBotDMOnly, nil, nil)
 			return
 		}
 	}
@@ -489,7 +497,7 @@ func (ba *BotAPI) readReceipt(c *wkhttp.Context) {
 
 	// 2. Message-level read receipt
 	if len(req.MessageIDs) > 100 {
-		c.ResponseError(errors.New("message_ids exceeds maximum of 100"))
+		respondBotAPILimitExceeded(c, "message_ids", 100)
 		return
 	}
 	if len(req.MessageIDs) > 0 {
@@ -524,7 +532,7 @@ func (ba *BotAPI) readReceipt(c *wkhttp.Context) {
 		})
 		if err != nil {
 			ba.Error("查询消息失败", zap.Error(err))
-			c.ResponseError(errors.New("查询消息失败"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 			return
 		}
 		if syncMsg != nil && len(syncMsg.Messages) > 0 {
@@ -539,7 +547,7 @@ func (ba *BotAPI) readReceipt(c *wkhttp.Context) {
 			_, err = ba.db.session.InsertBySql(stmt, valueArgs...).Exec()
 			if err != nil {
 				ba.Error("插入已读记录失败", zap.Error(err))
-				c.ResponseError(errors.New("保存已读记录失败"))
+				httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 				return
 			}
 
@@ -592,26 +600,25 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 		ContentEdit string `json:"content_edit"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		ba.Error("数据格式有误！", zap.Error(err))
-		c.ResponseError(errors.New("数据格式有误！"))
+		respondBotAPIRequestInvalid(c, "")
 		return
 	}
 	if req.MessageID == "" {
-		c.ResponseError(errors.New("message_id 不能为空"))
+		respondBotAPIRequestInvalid(c, "message_id")
 		return
 	}
 	if req.ChannelID == "" {
-		c.ResponseError(errors.New("channel_id 不能为空"))
+		respondBotAPIRequestInvalid(c, "channel_id")
 		return
 	}
 	if strings.TrimSpace(req.ContentEdit) == "" {
-		c.ResponseError(errors.New("content_edit 不能为空"))
+		respondBotAPIRequestInvalid(c, "content_edit")
 		return
 	}
 
 	robotID := getRobotIDFromContext(c)
 	if robotID == "" {
-		c.ResponseError(errors.New("robot_id 不能为空"))
+		ba.respondBotAPIIdentityMissing(c)
 		return
 	}
 
@@ -621,11 +628,11 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 		resp, err := ba.ctx.IMGetWithChannelAndSeqs(req.ChannelID, req.ChannelType, robotID, []uint32{req.MessageSeq})
 		if err != nil {
 			ba.Error("查询消息错误", zap.Error(err))
-			c.ResponseError(errors.New("查询消息错误"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 			return
 		}
 		if resp == nil || len(resp.Messages) == 0 {
-			c.ResponseError(errors.New("消息不存在"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIMessageNotFound, nil, nil)
 			return
 		}
 		if req.MessageID != strconv.FormatInt(resp.Messages[0].MessageID, 10) {
@@ -639,8 +646,8 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 	} else {
 		msgIDInt, parseErr := strconv.ParseInt(req.MessageID, 10, 64)
 		if parseErr != nil {
-			ba.Error("message_id格式错误", zap.String("message_id", req.MessageID), zap.Error(parseErr))
-			c.ResponseError(errors.New("message_id格式错误"))
+			ba.Warn("message_id格式错误", zap.String("message_id", req.MessageID), zap.Error(parseErr))
+			respondBotAPIRequestInvalid(c, "message_id")
 			return
 		}
 		syncResp, err := ba.ctx.IMSearchMessages(&config.MsgSearchReq{
@@ -651,22 +658,22 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 		})
 		if err != nil {
 			ba.Error("查询消息错误", zap.Error(err))
-			c.ResponseError(errors.New("查询消息错误"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 			return
 		}
 		if syncResp == nil || len(syncResp.Messages) == 0 {
-			c.ResponseError(errors.New("消息不存在"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIMessageNotFound, nil, nil)
 			return
 		}
 		if syncResp.Messages[0].MessageSeq == 0 {
-			c.ResponseError(errors.New("消息尚未投递完成，请稍后重试"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIMessageNotDelivered, nil, nil)
 			return
 		}
 		msgFromUID = syncResp.Messages[0].FromUID
 		req.MessageSeq = syncResp.Messages[0].MessageSeq
 	}
 	if msgFromUID != robotID {
-		c.ResponseError(errors.New("只能编辑自己发送的消息"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIMessageEditForbidden, nil, nil)
 		return
 	}
 
@@ -674,12 +681,12 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 	botKind := getBotKindFromContext(c)
 	if botKind == BotKindApp {
 		if req.ChannelType != common.ChannelTypePerson.Uint8() {
-			c.ResponseError(errors.New("app bot can only edit direct messages"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIAppBotDMOnly, nil, nil)
 			return
 		}
 		isFriend, fErr := ba.userService.IsFriend(robotID, req.ChannelID)
 		if fErr != nil || !isFriend {
-			c.ResponseError(errors.New("user has not started conversation with this bot"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIConversationNotStarted, nil, nil)
 			return
 		}
 	}
@@ -690,8 +697,8 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 	// 落库前以错误拒绝。MD5 去重 hash 落在 normalize 后的 canonical 体上。
 	normalizedEdit, err := richtext.NormalizeContentEdit(req.ContentEdit)
 	if err != nil {
-		ba.Error("RichText content_edit 校验失败", zap.Error(err), zap.String("messageID", req.MessageID))
-		c.ResponseError(errors.New("无效的 content_edit"))
+		ba.Warn("RichText content_edit 校验失败", zap.Error(err), zap.String("messageID", req.MessageID))
+		respondBotAPIRequestInvalid(c, "content_edit")
 		return
 	}
 	req.ContentEdit = normalizedEdit
@@ -703,7 +710,7 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 	err = ba.ctx.DB().Select("count(*)").From("message_extra").Where("message_id=? and content_edit_hash=?", req.MessageID, contentMD5).LoadOne(&existCount)
 	if err != nil {
 		ba.Error("查询是否存在相同正文失败！", zap.Error(err))
-		c.ResponseError(errors.New("查询是否存在相同正文失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 	if existCount > 0 {
@@ -719,7 +726,7 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 	version, err := ba.ctx.GenSeq(fmt.Sprintf("%s:%s", common.MessageExtraSeqKey, fakeChannelID))
 	if err != nil {
 		ba.Error("生成消息扩展序列号失败！", zap.Error(err))
-		c.ResponseError(errors.New("生成消息扩展序列号失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 		return
 	}
 
@@ -729,7 +736,7 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 	).Exec()
 	if err != nil {
 		ba.Error("添加或修改编辑内容失败！", zap.Error(err))
-		c.ResponseError(errors.New("添加或修改编辑内容失败！"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 		return
 	}
 

--- a/modules/bot_api/sync.go
+++ b/modules/bot_api/sync.go
@@ -1,12 +1,13 @@
 package bot_api
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"go.uber.org/zap"
 )
 
@@ -24,15 +25,15 @@ type BotSyncMessagesReq struct {
 func (ba *BotAPI) syncMessages(c *wkhttp.Context) {
 	var req BotSyncMessagesReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("invalid request body"))
+		respondBotAPIRequestInvalid(c, "")
 		return
 	}
 	if strings.TrimSpace(req.ChannelID) == "" {
-		c.ResponseError(errors.New("channel_id不能为空"))
+		respondBotAPIRequestInvalid(c, "channel_id")
 		return
 	}
 	if req.ChannelType == 0 {
-		c.ResponseError(errors.New("channel_type不能为空"))
+		respondBotAPIRequestInvalid(c, "channel_type")
 		return
 	}
 	if req.Limit <= 0 {
@@ -49,7 +50,7 @@ func (ba *BotAPI) syncMessages(c *wkhttp.Context) {
 		// App Bot is DM-only — deny group sync entirely
 		botKind := getBotKindFromContext(c)
 		if botKind == BotKindApp {
-			c.ResponseError(errors.New("app bot only supports direct messages"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIAppBotDMOnly, nil, nil)
 			return
 		}
 		var count int
@@ -59,11 +60,11 @@ func (ba *BotAPI) syncMessages(c *wkhttp.Context) {
 		).LoadOne(&count)
 		if err != nil {
 			ba.Error("failed to query group members", zap.Error(err))
-			c.ResponseError(errors.New("failed to query group members"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 			return
 		}
 		if count == 0 {
-			c.ResponseError(errors.New("bot is not a member of this group"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPINotGroupMember, nil, nil)
 			return
 		}
 	} else if req.ChannelType == common.ChannelTypePerson.Uint8() {
@@ -73,11 +74,11 @@ func (ba *BotAPI) syncMessages(c *wkhttp.Context) {
 			isFriend, err := ba.userService.IsFriend(robotID, req.ChannelID)
 			if err != nil {
 				ba.Error("failed to verify relationship", zap.Error(err))
-				c.ResponseError(errors.New("failed to verify relationship"))
+				httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 				return
 			}
 			if !isFriend {
-				c.ResponseError(errors.New("user has not started conversation with this bot"))
+				httperr.ResponseErrorL(c, errcode.ErrBotAPIConversationNotStarted, nil, nil)
 				return
 			}
 		case BotKindUser:
@@ -100,11 +101,11 @@ func (ba *BotAPI) syncMessages(c *wkhttp.Context) {
 				allowed, err := ba.isFriendOrOBOBypass(robotID, req.ChannelID, req.ChannelType, false)
 				if err != nil {
 					ba.Error("failed to check friend relationship", zap.Error(err))
-					c.ResponseError(errors.New("failed to check friend relationship"))
+					httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 					return
 				}
 				if !allowed {
-					c.ResponseError(errors.New("bot is not a friend of this user"))
+					httperr.ResponseErrorL(c, errcode.ErrBotAPINotFriend, nil, nil)
 					return
 				}
 			}
@@ -113,12 +114,12 @@ func (ba *BotAPI) syncMessages(c *wkhttp.Context) {
 		// Thread: App Bot denied (DM-only), User Bot must be member of parent group
 		botKind := getBotKindFromContext(c)
 		if botKind == BotKindApp {
-			c.ResponseError(errors.New("app bot only supports direct messages"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIAppBotDMOnly, nil, nil)
 			return
 		}
 		parts := strings.SplitN(req.ChannelID, threadChannelIDSeparator, 2)
 		if len(parts) != 2 {
-			c.ResponseError(errors.New("invalid thread channel_id format"))
+			respondBotAPIRequestInvalid(c, "channel_id")
 			return
 		}
 		var count int
@@ -128,11 +129,11 @@ func (ba *BotAPI) syncMessages(c *wkhttp.Context) {
 		).LoadOne(&count)
 		if err != nil {
 			ba.Error("failed to query group members", zap.Error(err))
-			c.ResponseError(errors.New("failed to query group members"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 			return
 		}
 		if count == 0 {
-			c.ResponseError(errors.New("bot is not a member of this group"))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPINotGroupMember, nil, nil)
 			return
 		}
 	}
@@ -150,7 +151,7 @@ func (ba *BotAPI) syncMessages(c *wkhttp.Context) {
 	resp, err := ba.ctx.IMSyncChannelMessage(syncReq)
 	if err != nil {
 		ba.Error("同步消息失败", zap.Error(err))
-		c.ResponseError(errors.New("同步消息失败"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPISendFailed, nil, nil)
 		return
 	}
 

--- a/modules/bot_api/threads.go
+++ b/modules/bot_api/threads.go
@@ -1,8 +1,6 @@
 package bot_api
 
 import (
-	"errors"
-	"fmt"
 	"net/http"
 	"runtime/debug"
 	"strings"
@@ -13,6 +11,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 )
@@ -23,25 +23,25 @@ func (ba *BotAPI) validateBotGroupAccess(c *wkhttp.Context) (robotID, groupNo st
 
 	// App Bot is DM-only — deny all group/thread operations
 	if getBotKindFromContext(c) == BotKindApp {
-		c.ResponseError(errors.New("app bot does not support group operations"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIAppBotUnsupported, nil, nil)
 		return "", "", false
 	}
 
 	groupNo = c.Param("group_no")
 
 	if !thread.IsValidGroupNo(groupNo) {
-		c.ResponseError(errors.New("invalid group_no format"))
+		respondBotAPIRequestInvalid(c, "group_no")
 		return "", "", false
 	}
 
 	isMember, err := ba.groupService.ExistMember(groupNo, robotID)
 	if err != nil {
 		ba.Error("检查群成员失败", zap.Error(err))
-		c.ResponseError(errors.New("check group membership failed"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return "", "", false
 	}
 	if !isMember {
-		c.ResponseError(errors.New("bot is not a member of this group"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPINotGroupMember, nil, nil)
 		return "", "", false
 	}
 
@@ -57,7 +57,7 @@ func (ba *BotAPI) validateBotThreadAccess(c *wkhttp.Context) (robotID, groupNo, 
 
 	shortID = c.Param("short_id")
 	if !thread.IsValidShortID(shortID) {
-		c.ResponseError(errors.New("invalid short_id format"))
+		respondBotAPIRequestInvalid(c, "short_id")
 		return "", "", "", false
 	}
 
@@ -76,8 +76,7 @@ func (ba *BotAPI) botCreateThread(c *wkhttp.Context) {
 		SourceMessageID *int64 `json:"source_message_id"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		ba.Error("参数错误", zap.Error(err))
-		c.ResponseError(errors.New("invalid request: name is required"))
+		respondBotAPIRequestInvalid(c, "name")
 		return
 	}
 
@@ -96,7 +95,7 @@ func (ba *BotAPI) botCreateThread(c *wkhttp.Context) {
 	})
 	if err != nil {
 		ba.Error("创建子区失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("robotID", robotID))
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 		return
 	}
 	c.Response(resp)
@@ -120,7 +119,7 @@ func (ba *BotAPI) botListThreads(c *wkhttp.Context) {
 	threads, total, err := ba.threadService.GetThreads(groupNo, nil, pageIndex, pageSize)
 	if err != nil {
 		ba.Error("获取子区列表失败", zap.Error(err), zap.String("groupNo", groupNo))
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 	if !hasPageParam {
@@ -143,7 +142,7 @@ func (ba *BotAPI) botGetThread(c *wkhttp.Context) {
 	resp, err := ba.threadService.GetThread(groupNo, shortID, "")
 	if err != nil {
 		ba.Error("获取子区详情失败", zap.Error(err))
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 	c.Response(resp)
@@ -159,7 +158,7 @@ func (ba *BotAPI) botDeleteThread(c *wkhttp.Context) {
 	err := ba.threadService.DeleteThread(groupNo, shortID, robotID)
 	if err != nil {
 		ba.Error("删除子区失败", zap.Error(err))
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -175,7 +174,7 @@ func (ba *BotAPI) botListThreadMembers(c *wkhttp.Context) {
 	members, err := ba.threadService.GetMembers(groupNo, shortID)
 	if err != nil {
 		ba.Error("获取成员列表失败", zap.Error(err))
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 	c.Response(members)
@@ -191,7 +190,7 @@ func (ba *BotAPI) botJoinThread(c *wkhttp.Context) {
 	err := ba.threadService.JoinThread(groupNo, shortID, robotID)
 	if err != nil {
 		ba.Error("加入子区失败", zap.Error(err))
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -207,7 +206,7 @@ func (ba *BotAPI) botLeaveThread(c *wkhttp.Context) {
 	err := ba.threadService.LeaveThread(groupNo, shortID, robotID)
 	if err != nil {
 		ba.Error("离开子区失败", zap.Error(err))
-		c.ResponseError(err)
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -223,7 +222,7 @@ func (ba *BotAPI) botGetThreadMd(c *wkhttp.Context) {
 	result, err := ba.threadService.GetThreadMd(groupNo, shortID)
 	if err != nil {
 		ba.Error("query thread GROUP.md failed", zap.Error(err))
-		c.ResponseError(errors.New("query thread GROUP.md failed"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 	if result == nil {
@@ -253,14 +252,11 @@ func (ba *BotAPI) botUpdateThreadMd(c *wkhttp.Context) {
 	isBotAdmin, err := ba.groupService.IsBotAdmin(groupNo, robotID)
 	if err != nil {
 		ba.Error("check bot admin failed", zap.Error(err))
-		c.ResponseError(errors.New("check bot admin failed"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 	if !isBotAdmin {
-		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-			"msg":    "bot is not a bot_admin in this group",
-			"status": 403,
-		})
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPINotGroupAdmin, nil, nil)
 		return
 	}
 
@@ -268,25 +264,25 @@ func (ba *BotAPI) botUpdateThreadMd(c *wkhttp.Context) {
 		Content string `json:"content"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("invalid request body"))
+		respondBotAPIRequestInvalid(c, "")
 		return
 	}
 
 	if strings.TrimSpace(req.Content) == "" {
-		c.ResponseError(errors.New("content must not be empty"))
+		respondBotAPIRequestInvalid(c, "content")
 		return
 	}
 
 	maxSize := group.GetGroupMdMaxSize()
 	if len(req.Content) > maxSize {
-		c.ResponseError(fmt.Errorf("GROUP.md content exceeds max size %d bytes", maxSize))
+		respondBotAPIContentTooLarge(c, "content", maxSize)
 		return
 	}
 
 	newVersion, err := ba.threadService.UpdateThreadMd(groupNo, shortID, req.Content, robotID)
 	if err != nil {
 		ba.Error("update thread GROUP.md failed", zap.Error(err))
-		c.ResponseError(errors.New("update thread GROUP.md failed"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 		return
 	}
 

--- a/modules/bot_api/typing.go
+++ b/modules/bot_api/typing.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
-	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	octolibredis "github.com/Mininglamp-OSS/octo-lib/pkg/redis"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"go.uber.org/zap"
 )
 
@@ -37,15 +39,15 @@ type BotTypingReq struct {
 func (ba *BotAPI) typing(c *wkhttp.Context) {
 	var req BotTypingReq
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(errors.New("数据格式有误"))
+		respondBotAPIRequestInvalid(c, "")
 		return
 	}
 	if strings.TrimSpace(req.ChannelID) == "" {
-		c.ResponseError(errors.New("channel_id不能为空"))
+		respondBotAPIRequestInvalid(c, "channel_id")
 		return
 	}
 	if req.ChannelType == 0 {
-		c.ResponseError(errors.New("channel_type不能为空"))
+		respondBotAPIRequestInvalid(c, "channel_type")
 		return
 	}
 
@@ -71,7 +73,7 @@ func (ba *BotAPI) typing(c *wkhttp.Context) {
 	// with a user that has not opted in to that bot.
 	botKind := getBotKindFromContext(c)
 	if err := ba.checkSendPermission(c, botKind, robotID, req.ChannelID, req.ChannelType, hasOBOContext); err != nil {
-		c.ResponseError(err)
+		respondSendPermissionError(c, err)
 		return
 	}
 
@@ -95,7 +97,7 @@ func (ba *BotAPI) typing(c *wkhttp.Context) {
 					zap.String("bot", robotID),
 					zap.String("grantor", req.OnBehalfOf),
 					zap.Error(err))
-				c.ResponseError(errors.New("OBO 检查失败"))
+				httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOInternal, nil, nil)
 				return
 			}
 			grantorReplyBypass = hasGrant
@@ -108,11 +110,11 @@ func (ba *BotAPI) typing(c *wkhttp.Context) {
 						zap.String("on_behalf_of", req.OnBehalfOf),
 						zap.String("channel_id", req.ChannelID),
 						zap.Uint8("channel_type", req.ChannelType))
-					c.ResponseError(ErrOBONotAuthorized)
+					httperr.ResponseErrorL(c, errcode.ErrBotAPIOBONotAuthorized, nil, nil)
 					return
 				}
 				ba.Error("OBO typing check failed", zap.Error(err))
-				c.ResponseError(errors.New("OBO 检查失败"))
+				httperr.ResponseErrorL(c, errcode.ErrBotAPIOBOInternal, nil, nil)
 				return
 			}
 			// Typing fromUID becomes the grantor — the typing CMD
@@ -176,9 +178,9 @@ func (ba *BotAPI) typing(c *wkhttp.Context) {
 		paramChannelID = robotID
 	}
 	err := ba.dispatchTypingCMD(config.MsgCMDReq{
-		NoPersist: true,
-		CMD:       common.CMDTyping,
-		ChannelID: channelID,
+		NoPersist:   true,
+		CMD:         common.CMDTyping,
+		ChannelID:   channelID,
 		ChannelType: req.ChannelType,
 		Param: map[string]interface{}{
 			// YUJ-1465 — fromUID is the OBO grantor when on_behalf_of
@@ -193,7 +195,7 @@ func (ba *BotAPI) typing(c *wkhttp.Context) {
 	})
 	if err != nil {
 		ba.Error("发送typing失败", zap.Error(err))
-		c.ResponseError(errors.New("发送typing失败"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPISendFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()
@@ -226,7 +228,7 @@ func (ba *BotAPI) heartbeat(c *wkhttp.Context) {
 	err := ba.ctx.GetRedisConn().SetAndExpire(key, "1", time.Second*heartbeatTTL)
 	if err != nil {
 		ba.Error("设置心跳失败", zap.Error(err))
-		c.ResponseError(errors.New("设置心跳失败"))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPISendFailed, nil, nil)
 		return
 	}
 	c.ResponseOK()

--- a/modules/bot_api/voice_adapter.go
+++ b/modules/bot_api/voice_adapter.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/voice_adapter"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/gin-gonic/gin"
 	"github.com/gocraft/dbr/v2"
 	"go.uber.org/zap"
@@ -20,20 +22,14 @@ import (
 func (ba *BotAPI) resolveOwnerAndSpace(c *wkhttp.Context) (string, string, string, bool) {
 	botKind := getBotKindFromContext(c)
 	if botKind == BotKindApp {
-		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-			"status": http.StatusForbidden,
-			"msg":    "app bot does not support voice operations",
-		})
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIAppBotUnsupported, nil, nil)
 		return "", "", "", false
 	}
 
 	robot := getRobotFromContext(c)
 	if robot == nil {
 		ba.Error("invalid bot token: robot not found in context")
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-			"status": http.StatusUnauthorized,
-			"msg":    "invalid bot token",
-		})
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIAuthFailed, nil, nil)
 		return "", "", "", false
 	}
 
@@ -41,7 +37,7 @@ func (ba *BotAPI) resolveOwnerAndSpace(c *wkhttp.Context) (string, string, strin
 	ownerUID := robot.CreatorUID
 	if ownerUID == "" {
 		ba.Error("bot has no owner", zap.String("robotID", robotID))
-		c.ResponseErrorWithStatus(errors.New("bot has no owner"), http.StatusBadRequest)
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIBotNotProvisioned, nil, nil)
 		return "", "", "", false
 	}
 
@@ -49,16 +45,16 @@ func (ba *BotAPI) resolveOwnerAndSpace(c *wkhttp.Context) (string, string, strin
 	if err != nil {
 		if errors.Is(err, dbr.ErrNotFound) {
 			ba.Warn("bot is not in any active space", zap.String("robotID", robotID))
-			c.ResponseErrorWithStatus(errors.New("bot is not in any active space"), http.StatusBadRequest)
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIBotNotProvisioned, nil, nil)
 			return "", "", "", false
 		}
 		ba.Error("query space by robot failed", zap.Error(err), zap.String("robotID", robotID))
-		c.ResponseErrorWithStatus(errors.New("query space failed"), http.StatusInternalServerError)
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return "", "", "", false
 	}
 	if spaceID == "" {
 		ba.Warn("bot is not in any active space", zap.String("robotID", robotID))
-		c.ResponseErrorWithStatus(errors.New("bot is not in any active space"), http.StatusBadRequest)
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIBotNotProvisioned, nil, nil)
 		return "", "", "", false
 	}
 	if len(allSpaces) > 1 {
@@ -84,21 +80,18 @@ func (ba *BotAPI) botPutVoiceContext(c *wkhttp.Context) {
 		Context string `json:"context"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseErrorWithStatus(errors.New("invalid request body"), http.StatusBadRequest)
+		respondBotAPIRequestInvalid(c, "")
 		return
 	}
 
 	ctx := strings.TrimSpace(req.Context)
 	if ctx == "" {
-		c.ResponseErrorWithStatus(errors.New("context cannot be empty"), http.StatusBadRequest)
+		respondBotAPIRequestInvalid(c, "context")
 		return
 	}
 
 	if len([]rune(ctx)) > ba.maxVoiceContextLength {
-		c.ResponseErrorWithStatus(
-			fmt.Errorf("context exceeds max length (%d characters)", ba.maxVoiceContextLength),
-			http.StatusBadRequest,
-		)
+		respondBotAPIContentTooLarge(c, "context", ba.maxVoiceContextLength)
 		return
 	}
 
@@ -111,7 +104,7 @@ func (ba *BotAPI) botPutVoiceContext(c *wkhttp.Context) {
 	})
 	if err != nil {
 		ba.Error("put vocabulary failed", zap.Error(err), zap.String("robotID", robotID))
-		c.ResponseErrorWithStatus(errors.New("save voice context failed"), http.StatusInternalServerError)
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 		return
 	}
 
@@ -127,7 +120,7 @@ func (ba *BotAPI) botGetVoiceContext(c *wkhttp.Context) {
 	vocab, err := ba.speechClient.GetVocabulary(c.Request.Context(), ownerUID, "space", spaceID)
 	if err != nil {
 		ba.Error("get vocabulary failed", zap.Error(err), zap.String("robotID", robotID))
-		c.ResponseErrorWithStatus(errors.New("query voice context failed"), http.StatusInternalServerError)
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIQueryFailed, nil, nil)
 		return
 	}
 
@@ -148,7 +141,7 @@ func (ba *BotAPI) botDeleteVoiceContext(c *wkhttp.Context) {
 	err := ba.speechClient.DeleteVocabulary(c.Request.Context(), ownerUID, "space", spaceID)
 	if err != nil {
 		ba.Error("delete vocabulary failed", zap.Error(err), zap.String("robotID", robotID))
-		c.ResponseErrorWithStatus(errors.New("delete voice context failed"), http.StatusInternalServerError)
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 		return
 	}
 
@@ -158,10 +151,7 @@ func (ba *BotAPI) botDeleteVoiceContext(c *wkhttp.Context) {
 func (ba *BotAPI) botTranscribe(c *wkhttp.Context) {
 	botKind := getBotKindFromContext(c)
 	if botKind == BotKindApp {
-		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-			"status": http.StatusForbidden,
-			"msg":    "app bot does not support voice operations",
-		})
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIAppBotUnsupported, nil, nil)
 		return
 	}
 
@@ -170,10 +160,10 @@ func (ba *BotAPI) botTranscribe(c *wkhttp.Context) {
 	if err := c.Request.ParseMultipartForm(32 << 20); err != nil {
 		var maxErr *http.MaxBytesError
 		if errors.As(err, &maxErr) {
-			c.ResponseErrorWithStatus(errors.New("request body too large"), http.StatusRequestEntityTooLarge)
+			respondBotAPIPayloadTooLarge(c, ba.maxBodySize)
 			return
 		}
-		c.ResponseErrorWithStatus(errors.New("invalid multipart form"), http.StatusBadRequest)
+		respondBotAPIRequestInvalid(c, "")
 		return
 	}
 	defer c.Request.MultipartForm.RemoveAll()
@@ -181,10 +171,7 @@ func (ba *BotAPI) botTranscribe(c *wkhttp.Context) {
 	for _, fileHeaders := range c.Request.MultipartForm.File {
 		for _, fh := range fileHeaders {
 			if fh.Size > ba.maxFileSize {
-				c.ResponseErrorWithStatus(
-					fmt.Errorf("file %s exceeds max size %d bytes", fh.Filename, ba.maxFileSize),
-					http.StatusRequestEntityTooLarge,
-				)
+				respondBotAPIPayloadTooLarge(c, ba.maxFileSize)
 				return
 			}
 		}
@@ -197,10 +184,7 @@ func (ba *BotAPI) botTranscribe(c *wkhttp.Context) {
 	case "edit", "":
 		mode = "smart"
 	default:
-		c.ResponseErrorWithStatus(
-			fmt.Errorf("invalid mode '%s': must be 'append' or 'edit'", mode),
-			http.StatusBadRequest,
-		)
+		respondBotAPIRequestInvalid(c, "mode")
 		return
 	}
 
@@ -215,13 +199,15 @@ func (ba *BotAPI) botTranscribe(c *wkhttp.Context) {
 			modeWritten = true
 		}
 		if err := w.WriteField(key, v); err != nil {
-			c.ResponseErrorWithStatus(errors.New("failed to build request"), http.StatusInternalServerError)
+			ba.Error("build transcribe request failed", zap.Error(err))
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
 			return
 		}
 	}
 	if !modeWritten {
 		if err := w.WriteField("mode", mode); err != nil {
-			c.ResponseErrorWithStatus(errors.New("failed to build request"), http.StatusInternalServerError)
+			ba.Error("build transcribe request failed", zap.Error(err))
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
 			return
 		}
 	}
@@ -230,7 +216,7 @@ func (ba *BotAPI) botTranscribe(c *wkhttp.Context) {
 		for _, fh := range fileHeaders {
 			src, err := fh.Open()
 			if err != nil {
-				c.ResponseErrorWithStatus(errors.New("failed to read uploaded file"), http.StatusBadRequest)
+				respondBotAPIRequestInvalid(c, "file")
 				return
 			}
 
@@ -246,12 +232,14 @@ func (ba *BotAPI) botTranscribe(c *wkhttp.Context) {
 			dst, err := w.CreatePart(partHeader)
 			if err != nil {
 				src.Close()
-				c.ResponseErrorWithStatus(errors.New("failed to build request"), http.StatusInternalServerError)
+				ba.Error("build transcribe request failed", zap.Error(err))
+				httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
 				return
 			}
 			if _, err := io.Copy(dst, src); err != nil {
 				src.Close()
-				c.ResponseErrorWithStatus(errors.New("failed to build request"), http.StatusInternalServerError)
+				ba.Error("build transcribe request failed", zap.Error(err))
+				httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
 				return
 			}
 			src.Close()
@@ -262,10 +250,7 @@ func (ba *BotAPI) botTranscribe(c *wkhttp.Context) {
 	resp, err := ba.speechClient.ForwardTranscribeBody(c.Request.Context(), &buf, w.FormDataContentType())
 	if err != nil {
 		ba.Error("forward transcribe failed", zap.Error(err))
-		c.JSON(http.StatusBadGateway, gin.H{
-			"status": http.StatusBadGateway,
-			"msg":    "speech service unavailable",
-		})
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIUpstreamFailed, nil, nil)
 		return
 	}
 	defer resp.Body.Close()

--- a/modules/bot_api/voice_adapter_test.go
+++ b/modules/bot_api/voice_adapter_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/voice_adapter"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )
@@ -229,7 +230,7 @@ func TestBotPutVoiceContext_Overlength(t *testing.T) {
 	ba.botPutVoiceContext(c)
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
-	assert.Contains(t, rec.Body.String(), "max length")
+	assert.Contains(t, rec.Body.String(), errcode.ErrBotAPIContentTooLarge.DefaultMessage)
 }
 
 func TestResolveOwnerAndSpace_AppBotRejected(t *testing.T) {
@@ -248,7 +249,7 @@ func TestResolveOwnerAndSpace_AppBotRejected(t *testing.T) {
 
 	assert.False(t, ok)
 	assert.Equal(t, http.StatusForbidden, rec.Code)
-	assert.Contains(t, rec.Body.String(), "app bot does not support voice")
+	assert.Contains(t, rec.Body.String(), errcode.ErrBotAPIAppBotUnsupported.DefaultMessage)
 }
 
 func TestResolveOwnerAndSpace_NilRobot(t *testing.T) {
@@ -396,7 +397,7 @@ func TestBotTranscribe_UnknownModeRejected(t *testing.T) {
 	ba.botTranscribe(c)
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
-	assert.Contains(t, rec.Body.String(), "invalid mode")
+	assert.Contains(t, rec.Body.String(), errcode.ErrBotAPIRequestInvalid.DefaultMessage)
 }
 
 func TestBotTranscribe_MultipleFormFields(t *testing.T) {

--- a/modules/botfather/api_bot_group_test.go
+++ b/modules/botfather/api_bot_group_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/stretchr/testify/assert"
 
 	// Ensure dependent modules register SQL migrations and HTTP routes.
@@ -135,7 +136,7 @@ func TestBotGroupCreate_EmptyMembers(t *testing.T) {
 	}))
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "members is required")
+	assert.Contains(t, w.Body.String(), errcode.ErrBotAPIRequestInvalid.DefaultMessage)
 }
 
 func TestBotGroupCreate_EmptyCreator(t *testing.T) {
@@ -621,7 +622,7 @@ func TestBotSpaceMembers_RejectOtherSpace(t *testing.T) {
 	w := doRequest(handler, botReq("GET", fmt.Sprintf("/v1/bot/space/members?space_id=%s", otherSpaceID), botToken, nil))
 
 	assert.Equal(t, http.StatusForbidden, w.Code)
-	assert.Contains(t, w.Body.String(), "not a member of this space")
+	assert.Contains(t, w.Body.String(), errcode.ErrBotAPINotSpaceMember.DefaultMessage)
 }
 
 // TestBotGroupCreate_RejectCreatorOutsideSpace 验证 creator 不在 Space 时应失败
@@ -776,7 +777,7 @@ func TestBotGroupMemberAdd_RejectPureBotMembers(t *testing.T) {
 	}))
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "only human members")
+	assert.Contains(t, w.Body.String(), errcode.ErrBotAPIMemberNotHuman.DefaultMessage)
 }
 
 // TestBotGroupMemberAdd_MixedHumanAndBot 混合传入时 bot 被过滤，人正常添加

--- a/pkg/errcode/bot_api.go
+++ b/pkg/errcode/bot_api.go
@@ -1,0 +1,349 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// err.server.bot_api.* — modules/bot_api business error codes. Unlike the
+// dmwork-facing modules, every bot_api endpoint serves EXTERNAL bot adapters /
+// integrations authenticated by bf_/app_ tokens (plus the OBO grant-management
+// endpoints, which serve the logged-in user). Many sites already returned real
+// HTTP status codes that adapters branch on, so those are rendered via
+// httperr.ResponseErrorLWithStatus to PRESERVE the wire status rather than the
+// D14 fixed-400 path; the legacy c.ResponseError sites stay at wire 400.
+//
+// DefaultMessage holds the en-US source (D4); the zh-CN runtime translation
+// lives in pkg/i18n/locales/active.zh-CN.toml. Internal=true codes never
+// surface their message on the wire — callers MUST log the underlying err with
+// full context (zap.Error) before responding.
+var (
+	// ---- validation (400) ----------------------------------------------------
+
+	// ErrBotAPIRequestInvalid is the catch-all for missing/malformed request
+	// input (BindJSON failure, "X 不能为空", invalid id/format, empty payload).
+	// The offending field is surfaced via Details when identifiable.
+	ErrBotAPIRequestInvalid = register(codes.Code{
+		ID:             "err.server.bot_api.request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid request.",
+		SafeDetailKeys: []string{"field"},
+	})
+	// ErrBotAPILimitExceeded covers a list parameter exceeding its cap
+	// (members > 200, message_ids > 100). The cap is surfaced so the client can
+	// render a localized hint without hard-coding it.
+	ErrBotAPILimitExceeded = register(codes.Code{
+		ID:             "err.server.bot_api.limit_exceeded",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The request exceeds the maximum allowed items.",
+		SafeDetailKeys: []string{"field", "max"},
+	})
+	// ErrBotAPIContentTooLarge covers a content body exceeding its byte/char cap
+	// (GROUP.md content, voice vocabulary context, OBO persona_prompt). The cap
+	// is surfaced via Details; the raw content never is.
+	ErrBotAPIContentTooLarge = register(codes.Code{
+		ID:             "err.server.bot_api.content_too_large",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The content exceeds the maximum allowed size.",
+		SafeDetailKeys: []string{"field", "max_size", "max_bytes"},
+	})
+	// ErrBotAPIFileTooLarge surfaces the upload size cap (in MB) for the legacy
+	// (wire-400) upload path.
+	ErrBotAPIFileTooLarge = register(codes.Code{
+		ID:             "err.server.bot_api.file_too_large",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The file exceeds the maximum allowed size.",
+		SafeDetailKeys: []string{"max_mb"},
+	})
+	// ErrBotAPIPayloadTooLarge is the status-preserving (413) variant used by the
+	// voice transcribe proxy, whose external client branches on HTTP 413.
+	ErrBotAPIPayloadTooLarge = register(codes.Code{
+		ID:             "err.server.bot_api.payload_too_large",
+		HTTPStatus:     http.StatusRequestEntityTooLarge,
+		DefaultMessage: "The uploaded file exceeds the maximum allowed size.",
+		SafeDetailKeys: []string{"max_bytes"},
+	})
+	// ErrBotAPIFileTypeUnsupported covers an unsupported / extension-less upload.
+	ErrBotAPIFileTypeUnsupported = register(codes.Code{
+		ID:             "err.server.bot_api.file_type_unsupported",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Unsupported file type.",
+	})
+	// ErrBotAPIMemberNotHuman covers the bot-API rule that only human users may
+	// be added to a group through this API (no bot members, creator must not be a
+	// bot).
+	ErrBotAPIMemberNotHuman = register(codes.Code{
+		ID:             "err.server.bot_api.member_not_human",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Only human members can be added through the bot API.",
+		SafeDetailKeys: []string{"field"},
+	})
+	// ErrBotAPIThreadChannelNotAccepted rejects a thread channel id supplied to a
+	// group-level GROUP.md endpoint (the caller must use the thread md route).
+	ErrBotAPIThreadChannelNotAccepted = register(codes.Code{
+		ID:             "err.server.bot_api.thread_channel_not_accepted",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "A thread channel id is not accepted here; use the thread GROUP.md endpoint instead.",
+	})
+	// ErrBotAPIBotNotProvisioned covers a bot that cannot serve the request
+	// because it is not fully provisioned (no owner, or not in any active space)
+	// — a configuration gap, surfaced as a 400 to the voice client.
+	ErrBotAPIBotNotProvisioned = register(codes.Code{
+		ID:             "err.server.bot_api.bot_not_provisioned",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The bot is not fully provisioned for this operation.",
+	})
+	// ErrBotAPIOBOModeUnsupported covers an OBO grant created/updated with a mode
+	// other than the only supported value (auto, v0).
+	ErrBotAPIOBOModeUnsupported = register(codes.Code{
+		ID:             "err.server.bot_api.obo_mode_unsupported",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Unsupported OBO mode.",
+	})
+	// ErrBotAPIOBOReservedField rejects an inbound message payload that carries a
+	// server-only reserved OBO key (__obo_* / obo_* / actual_sender_uid).
+	ErrBotAPIOBOReservedField = register(codes.Code{
+		ID:             "err.server.bot_api.obo_reserved_field",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The payload uses reserved OBO fields.",
+	})
+
+	// ---- permission / authorization (403) ------------------------------------
+
+	// ErrBotAPINotGroupMember covers the bot-not-a-group-member guard.
+	ErrBotAPINotGroupMember = register(codes.Code{
+		ID:             "err.server.bot_api.not_group_member",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "The bot is not a member of this group.",
+	})
+	// ErrBotAPINotGroupAdmin covers the bot-not-a-group-admin guard.
+	ErrBotAPINotGroupAdmin = register(codes.Code{
+		ID:             "err.server.bot_api.not_group_admin",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "The bot is not an admin of this group.",
+	})
+	// ErrBotAPINotSpaceMember covers the bot/user-not-a-space-member guard.
+	ErrBotAPINotSpaceMember = register(codes.Code{
+		ID:             "err.server.bot_api.not_space_member",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Not a member of this space.",
+	})
+	// ErrBotAPIAppBotUnsupported covers operations an App Bot may not perform
+	// (group operations, voice operations) — App Bots are DM-scoped.
+	ErrBotAPIAppBotUnsupported = register(codes.Code{
+		ID:             "err.server.bot_api.app_bot_unsupported",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "This operation is not supported for app bots.",
+	})
+	// ErrBotAPIAppBotDMOnly covers the App Bot direct-message-only restriction
+	// (App Bots may only access / edit direct message channels).
+	ErrBotAPIAppBotDMOnly = register(codes.Code{
+		ID:             "err.server.bot_api.app_bot_dm_only",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "App bots can only operate on direct message channels.",
+	})
+	// ErrBotAPINotFriend covers the user-bot friend gate (the target user has not
+	// added / opted into the bot).
+	ErrBotAPINotFriend = register(codes.Code{
+		ID:             "err.server.bot_api.not_friend",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "The bot is not a friend of this user.",
+	})
+	// ErrBotAPIConversationNotStarted covers the App Bot gate where the user has
+	// not started a conversation with the bot yet.
+	ErrBotAPIConversationNotStarted = register(codes.Code{
+		ID:             "err.server.bot_api.conversation_not_started",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "The user has not started a conversation with this bot.",
+	})
+	// ErrBotAPIMessageEditForbidden covers the bot-message edit guard (a bot may
+	// only edit messages it sent).
+	ErrBotAPIMessageEditForbidden = register(codes.Code{
+		ID:             "err.server.bot_api.message_edit_forbidden",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You can only edit messages you sent.",
+	})
+	// ErrBotAPIOBONotAuthorized covers a send/typing OBO request lacking an
+	// active grant or per-channel scope (ErrOBONotAuthorized).
+	ErrBotAPIOBONotAuthorized = register(codes.Code{
+		ID:             "err.server.bot_api.obo_not_authorized",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Not authorized to act on behalf of this user.",
+	})
+	// ErrBotAPIBotUnavailable covers an App Bot that is not published (status!=1)
+	// and therefore may not serve API requests. Status-preserving (403).
+	ErrBotAPIBotUnavailable = register(codes.Code{
+		ID:             "err.server.bot_api.bot_unavailable",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "The bot is not available.",
+	})
+
+	// ---- not found (404) -----------------------------------------------------
+
+	// ErrBotAPIGroupNotFound covers a missing target group.
+	ErrBotAPIGroupNotFound = register(codes.Code{
+		ID:             "err.server.bot_api.group_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Group not found.",
+	})
+	// ErrBotAPIMessageNotFound covers a missing target message on edit.
+	ErrBotAPIMessageNotFound = register(codes.Code{
+		ID:             "err.server.bot_api.message_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Message not found.",
+	})
+	// ErrBotAPIUserNotFound covers a missing target user (group member lookup,
+	// command target).
+	ErrBotAPIUserNotFound = register(codes.Code{
+		ID:             "err.server.bot_api.user_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "User not found.",
+	})
+	// ErrBotAPIBotNotRegistered covers an OBO grantee uid that is not a
+	// registered bot (existence-leak-safe 404; ownership mismatch also maps here).
+	ErrBotAPIBotNotRegistered = register(codes.Code{
+		ID:             "err.server.bot_api.bot_not_registered",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "The grantee is not a registered bot.",
+	})
+	// ErrBotAPIOBOGrantNotFound covers a missing / inactive OBO grant.
+	ErrBotAPIOBOGrantNotFound = register(codes.Code{
+		ID:             "err.server.bot_api.obo_grant_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "OBO grant not found.",
+	})
+	// ErrBotAPIOBOScopeNotFound covers a missing OBO per-channel scope.
+	ErrBotAPIOBOScopeNotFound = register(codes.Code{
+		ID:             "err.server.bot_api.obo_scope_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "OBO scope not found.",
+	})
+	// ErrBotAPIOBOChannelNotFound covers an OBO scope referencing a channel that
+	// does not exist / the grantor cannot reach.
+	ErrBotAPIOBOChannelNotFound = register(codes.Code{
+		ID:             "err.server.bot_api.obo_channel_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Channel not found.",
+	})
+
+	// ---- conflict (409) ------------------------------------------------------
+
+	// ErrBotAPIOBOGrantExists covers an OBO grant create that collides with an
+	// already-active grant.
+	ErrBotAPIOBOGrantExists = register(codes.Code{
+		ID:             "err.server.bot_api.obo_grant_exists",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "An OBO grant already exists.",
+	})
+	// ErrBotAPIOBOScopeExists covers an OBO scope create that collides with an
+	// existing scope.
+	ErrBotAPIOBOScopeExists = register(codes.Code{
+		ID:             "err.server.bot_api.obo_scope_exists",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "An OBO scope already exists.",
+	})
+	// ErrBotAPIMessageNotDelivered covers an edit targeting a message that has not
+	// finished delivering yet (retryable).
+	ErrBotAPIMessageNotDelivered = register(codes.Code{
+		ID:             "err.server.bot_api.message_not_delivered",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "The message has not finished delivering; please retry.",
+	})
+
+	// ---- bot auth (401, anti-enumeration) ------------------------------------
+
+	// ErrBotAPIAuthFailed is the SINGLE anti-enumeration code for the bot-token
+	// auth middleware and the legacy register endpoints: missing Authorization
+	// header, invalid/unknown bot token, and unauthenticated OBO calls ALL
+	// collapse to one 401 so an external caller cannot probe which factor was
+	// wrong. The specific reason is logged, never returned. Rendered via
+	// ResponseErrorLWithStatus to PRESERVE the real 401 (adapters branch on it).
+	ErrBotAPIAuthFailed = register(codes.Code{
+		ID:             "err.server.bot_api.auth_failed",
+		HTTPStatus:     http.StatusUnauthorized,
+		DefaultMessage: "Bot authentication failed.",
+	})
+
+	// ---- upstream (502) ------------------------------------------------------
+
+	// ErrBotAPIUpstreamFailed covers a downstream speech-service failure on the
+	// voice transcribe proxy. Status-preserving (502) so the client retries.
+	ErrBotAPIUpstreamFailed = register(codes.Code{
+		ID:             "err.server.bot_api.upstream_failed",
+		HTTPStatus:     http.StatusBadGateway,
+		DefaultMessage: "The upstream service is unavailable.",
+		Internal:       true,
+	})
+
+	// ---- internal (500, Internal=true) ---------------------------------------
+
+	// ErrBotAPIQueryFailed covers read-path failures (group/space/member/message
+	// SELECTs, friend/membership verification, GROUP.md / voice-context reads,
+	// OBO grant/scope lists). Log the underlying err before responding.
+	ErrBotAPIQueryFailed = register(codes.Code{
+		ID:             "err.server.bot_api.query_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to query data.",
+		Internal:       true,
+	})
+	// ErrBotAPIStoreFailed covers mutation-path failures (DB write/update/delete,
+	// GROUP.md / voice-context writes, read-receipt inserts, message-extra
+	// writes, OBO grant/scope create/revoke). Log the underlying err first.
+	ErrBotAPIStoreFailed = register(codes.Code{
+		ID:             "err.server.bot_api.store_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to update data.",
+		Internal:       true,
+	})
+	// ErrBotAPISendFailed covers WuKongIM dispatch failures (send message /
+	// typing / heartbeat / messages-sync / CMD). Log the underlying err first.
+	ErrBotAPISendFailed = register(codes.Code{
+		ID:             "err.server.bot_api.send_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to send the message.",
+		Internal:       true,
+	})
+	// ErrBotAPIUploadFailed covers the file proxy / upload / STS-credential /
+	// presigned-URL path (read, storage write, COS misconfiguration). Log first.
+	ErrBotAPIUploadFailed = register(codes.Code{
+		ID:             "err.server.bot_api.upload_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to process the file.",
+		Internal:       true,
+	})
+	// ErrBotAPIIMTokenFailed covers IM-token issuance failures on the bot
+	// register endpoints. Log the underlying err before responding.
+	ErrBotAPIIMTokenFailed = register(codes.Code{
+		ID:             "err.server.bot_api.im_token_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to obtain an IM token.",
+		Internal:       true,
+	})
+	// ErrBotAPIAuthCheckFailed covers the bot-auth middleware's own
+	// infrastructure failures (DB lookup for robot / app bot errored) — distinct
+	// from ErrBotAPIAuthFailed (a real credential failure). Preserves the real
+	// 500 via ResponseErrorLWithStatus so adapters retry instead of treating it
+	// as a permanent 401. Log the underlying err before responding.
+	ErrBotAPIAuthCheckFailed = register(codes.Code{
+		ID:             "err.server.bot_api.auth_check_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Bot authentication check failed.",
+		Internal:       true,
+	})
+	// ErrBotAPIOBOInternal covers OBO grant/scope store failures and the OBO
+	// permission-check infrastructure failure ("OBO 检查失败"). Log first.
+	ErrBotAPIOBOInternal = register(codes.Code{
+		ID:             "err.server.bot_api.obo_internal",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "OBO operation failed.",
+		Internal:       true,
+	})
+)
+
+// Shared codes reused by bot_api (resolved at init from the codes registry).
+// The bot-auth-required defensive check on the OBO endpoints maps to the shared
+// 401; generic internal asserts map to the shared 500.
+var (
+	ErrBotAPISharedAuthRequired = shared("err.shared.auth.required")
+)

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -883,3 +883,122 @@ other = "统计请求无效。"
 
 ["err.server.statistics.query_failed"]
 other = "查询统计数据失败。"
+["err.server.bot_api.request_invalid"]
+other = "请求参数有误。"
+
+["err.server.bot_api.limit_exceeded"]
+other = "请求数量超过上限。"
+
+["err.server.bot_api.content_too_large"]
+other = "内容大小超过限制。"
+
+["err.server.bot_api.file_too_large"]
+other = "文件大小超过限制。"
+
+["err.server.bot_api.payload_too_large"]
+other = "上传文件大小超过限制。"
+
+["err.server.bot_api.file_type_unsupported"]
+other = "不支持的文件类型。"
+
+["err.server.bot_api.member_not_human"]
+other = "仅可通过机器人 API 添加真人成员。"
+
+["err.server.bot_api.thread_channel_not_accepted"]
+other = "此处不接受子区频道 ID，请使用子区 GROUP.md 接口。"
+
+["err.server.bot_api.bot_not_provisioned"]
+other = "机器人尚未完成配置，无法执行该操作。"
+
+["err.server.bot_api.obo_mode_unsupported"]
+other = "不支持的 OBO 模式。"
+
+["err.server.bot_api.obo_reserved_field"]
+other = "请求体包含 OBO 保留字段。"
+
+["err.server.bot_api.not_group_member"]
+other = "机器人不是该群成员。"
+
+["err.server.bot_api.not_group_admin"]
+other = "机器人不是该群管理员。"
+
+["err.server.bot_api.not_space_member"]
+other = "不是该空间成员。"
+
+["err.server.bot_api.app_bot_unsupported"]
+other = "应用机器人不支持该操作。"
+
+["err.server.bot_api.app_bot_dm_only"]
+other = "应用机器人仅支持私聊频道操作。"
+
+["err.server.bot_api.not_friend"]
+other = "机器人不是该用户的好友。"
+
+["err.server.bot_api.conversation_not_started"]
+other = "用户尚未与该机器人发起会话。"
+
+["err.server.bot_api.message_edit_forbidden"]
+other = "只能编辑自己发送的消息。"
+
+["err.server.bot_api.obo_not_authorized"]
+other = "无权代表该用户操作。"
+
+["err.server.bot_api.bot_unavailable"]
+other = "机器人不可用。"
+
+["err.server.bot_api.group_not_found"]
+other = "群组不存在。"
+
+["err.server.bot_api.message_not_found"]
+other = "消息不存在。"
+
+["err.server.bot_api.user_not_found"]
+other = "用户不存在。"
+
+["err.server.bot_api.bot_not_registered"]
+other = "被授权方不是已注册的机器人。"
+
+["err.server.bot_api.obo_grant_not_found"]
+other = "OBO 授权不存在。"
+
+["err.server.bot_api.obo_scope_not_found"]
+other = "OBO 授权范围不存在。"
+
+["err.server.bot_api.obo_channel_not_found"]
+other = "频道不存在。"
+
+["err.server.bot_api.obo_grant_exists"]
+other = "OBO 授权已存在。"
+
+["err.server.bot_api.obo_scope_exists"]
+other = "OBO 授权范围已存在。"
+
+["err.server.bot_api.message_not_delivered"]
+other = "消息尚未投递完成，请稍后重试。"
+
+["err.server.bot_api.auth_failed"]
+other = "机器人认证失败。"
+
+["err.server.bot_api.upstream_failed"]
+other = "上游服务不可用。"
+
+["err.server.bot_api.query_failed"]
+other = "查询数据失败。"
+
+["err.server.bot_api.store_failed"]
+other = "更新数据失败。"
+
+["err.server.bot_api.send_failed"]
+other = "消息发送失败。"
+
+["err.server.bot_api.upload_failed"]
+other = "文件处理失败。"
+
+["err.server.bot_api.im_token_failed"]
+other = "获取 IM Token 失败。"
+
+["err.server.bot_api.auth_check_failed"]
+other = "机器人认证校验失败。"
+
+["err.server.bot_api.obo_internal"]
+other = "OBO 操作失败。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -9,6 +9,126 @@
 ["err.server.bot.occupied"]
 other = "Bot is already occupied by another agent."
 
+["err.server.bot_api.app_bot_dm_only"]
+other = "App bots can only operate on direct message channels."
+
+["err.server.bot_api.app_bot_unsupported"]
+other = "This operation is not supported for app bots."
+
+["err.server.bot_api.auth_check_failed"]
+other = "Bot authentication check failed."
+
+["err.server.bot_api.auth_failed"]
+other = "Bot authentication failed."
+
+["err.server.bot_api.bot_not_provisioned"]
+other = "The bot is not fully provisioned for this operation."
+
+["err.server.bot_api.bot_not_registered"]
+other = "The grantee is not a registered bot."
+
+["err.server.bot_api.bot_unavailable"]
+other = "The bot is not available."
+
+["err.server.bot_api.content_too_large"]
+other = "The content exceeds the maximum allowed size."
+
+["err.server.bot_api.conversation_not_started"]
+other = "The user has not started a conversation with this bot."
+
+["err.server.bot_api.file_too_large"]
+other = "The file exceeds the maximum allowed size."
+
+["err.server.bot_api.file_type_unsupported"]
+other = "Unsupported file type."
+
+["err.server.bot_api.group_not_found"]
+other = "Group not found."
+
+["err.server.bot_api.im_token_failed"]
+other = "Failed to obtain an IM token."
+
+["err.server.bot_api.limit_exceeded"]
+other = "The request exceeds the maximum allowed items."
+
+["err.server.bot_api.member_not_human"]
+other = "Only human members can be added through the bot API."
+
+["err.server.bot_api.message_edit_forbidden"]
+other = "You can only edit messages you sent."
+
+["err.server.bot_api.message_not_delivered"]
+other = "The message has not finished delivering; please retry."
+
+["err.server.bot_api.message_not_found"]
+other = "Message not found."
+
+["err.server.bot_api.not_friend"]
+other = "The bot is not a friend of this user."
+
+["err.server.bot_api.not_group_admin"]
+other = "The bot is not an admin of this group."
+
+["err.server.bot_api.not_group_member"]
+other = "The bot is not a member of this group."
+
+["err.server.bot_api.not_space_member"]
+other = "Not a member of this space."
+
+["err.server.bot_api.obo_channel_not_found"]
+other = "Channel not found."
+
+["err.server.bot_api.obo_grant_exists"]
+other = "An OBO grant already exists."
+
+["err.server.bot_api.obo_grant_not_found"]
+other = "OBO grant not found."
+
+["err.server.bot_api.obo_internal"]
+other = "OBO operation failed."
+
+["err.server.bot_api.obo_mode_unsupported"]
+other = "Unsupported OBO mode."
+
+["err.server.bot_api.obo_not_authorized"]
+other = "Not authorized to act on behalf of this user."
+
+["err.server.bot_api.obo_reserved_field"]
+other = "The payload uses reserved OBO fields."
+
+["err.server.bot_api.obo_scope_exists"]
+other = "An OBO scope already exists."
+
+["err.server.bot_api.obo_scope_not_found"]
+other = "OBO scope not found."
+
+["err.server.bot_api.payload_too_large"]
+other = "The uploaded file exceeds the maximum allowed size."
+
+["err.server.bot_api.query_failed"]
+other = "Failed to query data."
+
+["err.server.bot_api.request_invalid"]
+other = "Invalid request."
+
+["err.server.bot_api.send_failed"]
+other = "Failed to send the message."
+
+["err.server.bot_api.store_failed"]
+other = "Failed to update data."
+
+["err.server.bot_api.thread_channel_not_accepted"]
+other = "A thread channel id is not accepted here; use the thread GROUP.md endpoint instead."
+
+["err.server.bot_api.upload_failed"]
+other = "Failed to process the file."
+
+["err.server.bot_api.upstream_failed"]
+other = "The upstream service is unavailable."
+
+["err.server.bot_api.user_not_found"]
+other = "User not found."
+
 ["err.server.category.default_immutable"]
 other = "The default category cannot be modified."
 

--- a/tools/lint-direct-error-response/baseline.txt
+++ b/tools/lint-direct-error-response/baseline.txt
@@ -16,11 +16,11 @@
 # envelope) are tagged "# EXEMPT: <why>" so future migrations don't try to
 # zero them; all other rows are migration debt and should ratchet to 0.
 9 modules/app_bot/app_bot.go
-6 modules/bot_api/auth.go
-9 modules/bot_api/groups.go
-5 modules/bot_api/obo_api.go
-1 modules/bot_api/threads.go
-3 modules/bot_api/voice_adapter.go
+0 modules/bot_api/auth.go  # migrated to httperr.ResponseErrorLWithStatus (#276)
+0 modules/bot_api/groups.go  # migrated to httperr.ResponseErrorL / ResponseErrorLWithStatus (#276)
+0 modules/bot_api/obo_api.go  # migrated to httperr.ResponseErrorLWithStatus (#276)
+0 modules/bot_api/threads.go  # migrated to httperr.ResponseErrorLWithStatus (#276)
+0 modules/bot_api/voice_adapter.go  # migrated to httperr.ResponseErrorLWithStatus (#276)
 3 modules/botfather/api.go
 9 modules/botfather/api_bot.go
 1 modules/botfather/api_bot_thread.go


### PR DESCRIPTION
Closes #276. Part of #170 (i18n — backend / octo-server).

Migrates `modules/bot_api` — the largest remaining Phase 2 hotspot, and the most varied in error shapes — to the i18n error envelope, reusing the merged `user`/`group`/`robot`/`space` playbook.

**Not blocked on the gRPC interceptor.** `bot_api` was listed as blocked on the Phase 1 `x-octo-lang` interceptor, but its production code makes **no gRPC client calls and never imports `pkg/i18n`** — the gRPC propagation boundary lives in `modules/webhook` (#275), not here. This is a pure HTTP error-envelope change.

## Audience → status-code policy
Every `bot_api` endpoint serves **external bot adapters** (`bf_`/`app_` tokens), plus the OBO grant-management endpoints (logged-in user). Many sites already returned real HTTP status codes that adapters branch on, so those **preserve their wire status** via `ResponseErrorLWithStatus`; the legacy `c.ResponseError` sites stay at wire 400 (D14, real status in `error.http_status`). **Zero status drift** either way.

## Scope
~247 legacy response sites across 13 files → `httperr.ResponseErrorL` + `errcode.ErrBotAPI*`:

| File | sites | File | sites |
|---|---|---|---|
| `send.go` | 36 | `register.go` | 8 |
| `groups.go` | 57 | `commands.go` | 5 |
| `obo_api.go` | 41 | `mention_pref.go` | 4 |
| `voice_adapter.go` | 23 | `events.go` | 3 (+1 follow-up) |
| `threads.go` | 20 | `auth.go` | 6 |
| `file.go` | 20 | | |
| `sync.go` | 15 | `typing.go` | 9 |

39 new `err.server.bot_api.*` codes + zh-CN translations + regenerated en-US markers.

## Key decisions (review focus)
- **Bot auth middleware** (`auth.go`, `register.go`, voice/obo guards): the genuine auth failures (missing/invalid token, bot/app not found) collapse into a **single anti-enumeration 401** (`auth_failed`); the masquerading DB-lookup failures (`查询机器人失败` / `查询App Bot失败`) route to `auth_check_failed` (real 500); the not-published App Bot keeps its `403` (`bot_unavailable`). `auth.go`/voice abort sites use `ResponseErrorLWithStatus` to **preserve 401/403**; `register.go` was already `c.ResponseError` (wire 400) so it stays 400 per D14. The specific reason is logged, never returned.
- **OBO grant/scope** (`obo_api.go`): the existence-leak-safe `c.JSON(404)` / `c.JSON(409)` and the defensive `unauthorized` 401 all **preserve their status** (`ResponseErrorLWithStatus`); the 14 logged `内部错误` sites collapse to one `obo_internal` (500). The `errOBOGrantAlreadyActive` / cross-user-404 / channel-wiretap-404 postures are unchanged.
- **`checkSendPermission` refactor**: the helper returned raw `errors.New(...)` strings mixing 4xx business denials and 5xx infra failures, forwarded straight to the wire by `sendMessage`/`readReceipt`. It now returns package sentinels classified by `respondSendPermissionError` via `errors.Is` (no string matching); infra failures are logged inside the helper and collapse to a generic `query_failed` 500.
- **voice_adapter.go**: external-proxy semantics preserved — `413` (payload too large), `502` (`upstream_failed`, speech service down), `400`/`500` all kept exactly.
- **DB / IM failures** route to `Internal=true` codes (`query_failed`/`store_failed`/`send_failed`/`upload_failed`/`im_token_failed`/`obo_internal`/`auth_check_failed`); the existing `zap.Error` log is kept at each site (and added where one was missing), since the renderer hides the message on the wire.
- **Pre-existing `err != nil || count == 0` shapes** (membership / user lookups) are split so a DB error logs + returns `query_failed` (500) instead of masquerading as a 4xx.

## Tests
- `TestBotAPINoLegacyResponseError` — source guard over the 13 migrated files (bans `.ResponseError(` / `.ResponseErrorf(` / `.ResponseErrorWithStatus(` / `.AbortWithStatus*` / raw `c.Response("` / raw non-OK `c.JSON(http.Status...)`).
- `TestRespondBotAPIHelpers` — table cases over the rendered dual envelope: field/limit/size details, 400/403/404/409 mappings, `Internal=true` copy collapse with no English leak, the `ResponseErrorLWithStatus` 401/403/404/409/413/500/502 status preservation, and the `respondSendPermissionError` classifier.
- Updated the existing `obo_send_test` / `obo_v2_typing_test` / `voice_adapter_test` body-substring assertions to the migrated `DefaultMessage`s (status assertions unchanged — proving zero drift).

## Verification
`go build ./...`, `go vet`, gofmt (new/changed files), `make i18n-extract-check`, `make i18n-lint` (baseline ratcheted to 0 for bot_api), `go test ./pkg/errcode ./pkg/i18n/...`, and `go test ./modules/bot_api/` (incl. DB integration with `OCTO_MASTER_KEY` set) all green.

## Out of scope (follow-ups, non-blocking)
- `getEvents` returns an HTTP-200 in-band error `c.Response(gin.H{"status":0,"msg":err.Error()})` (wire 200, outside D23) — still leaks `err.Error()` to adapters; should be closed separately (same shape as robot's `getEventsForPost`).
- Service-layer sentinel errors for thread/group operations instead of mapping all thread/group service errors to query/store_failed (same follow-up as thread/user/group/robot).
- `modules/botfather/*` (separate hotspot).
