### PR TITLE
feat: generic feature gate + gate incoming webhooks for rollout

### DIFF
--- a/internal/modules.go
+++ b/internal/modules.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/Mininglamp-OSS/octo-server/modules/channel"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/common"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/featuregate"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/file"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/group"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/incomingwebhook"

--- a/modules/featuregate/1module.go
+++ b/modules/featuregate/1module.go
@@ -1,0 +1,23 @@
+package featuregate
+
+import (
+	"embed"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
+)
+
+//go:embed sql
+var sqlFS embed.FS
+
+func init() {
+	register.AddModule(func(ctx interface{}) register.Module {
+		return register.Module{
+			Name: "featuregate",
+			SetupAPI: func() register.APIRouter {
+				return NewManager(ctx.(*config.Context))
+			},
+			SQLDir: register.NewSQLFS(sqlFS),
+		}
+	})
+}

--- a/modules/featuregate/api_i18n.go
+++ b/modules/featuregate/api_i18n.go
@@ -1,0 +1,33 @@
+package featuregate
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+// 管理端 i18n 错误 responder。端点 superadmin-only、无 legacy client，统一用
+// ResponseErrorLWithStatus 保留真实语义状态（400/404/500）。superadmin 权限失败
+// 不走这里，直接 c.ResponseError(c.CheckLoginRoleIsSuperAdmin()) 复用内置错误。
+
+// gateRequestInvalid 返回 400；reason ∈ {key,body,mode,percent,description,
+// scope_type,scope_id} 经安全 Details 透出。
+func gateRequestInvalid(c *wkhttp.Context, reason string) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrFeatureGateRequestInvalid, nil, i18n.Details{"reason": reason})
+}
+
+// gateNotFound 返回 404 —— 删除的白名单条目不存在。
+func gateNotFound(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrFeatureGateNotFound, nil, nil)
+}
+
+// gateQueryFailed 返回 500（Internal）—— 读失败，真实错误仅日志。
+func gateQueryFailed(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrFeatureGateQueryFailed, nil, nil)
+}
+
+// gateOperationFailed 返回 500（Internal）—— 写失败，真实错误仅日志。
+func gateOperationFailed(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrFeatureGateOperationFailed, nil, nil)
+}

--- a/modules/featuregate/api_manager.go
+++ b/modules/featuregate/api_manager.go
@@ -1,0 +1,152 @@
+package featuregate
+
+import (
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	fg "github.com/Mininglamp-OSS/octo-server/pkg/featuregate"
+	"go.uber.org/zap"
+)
+
+const (
+	maxKeyLen         = 64
+	maxScopeIDLen     = 64
+	maxDescriptionLen = 255
+)
+
+// list 列出所有规则及其白名单条目。
+func (m *Manager) list(c *wkhttp.Context) {
+	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
+		c.ResponseError(err)
+		return
+	}
+	rules, err := m.db.listRules()
+	if err != nil {
+		m.Error("list feature gates failed", zap.Error(err))
+		gateQueryFailed(c)
+		return
+	}
+	gates := make([]gateResp, 0, len(rules))
+	for _, ru := range rules {
+		scopes, err := m.db.queryScopes(ru.FeatureKey)
+		if err != nil {
+			m.Error("list feature gate scopes failed", zap.String("key", ru.FeatureKey), zap.Error(err))
+			gateQueryFailed(c)
+			return
+		}
+		gates = append(gates, toGateResp(ru, scopes))
+	}
+	c.Response(map[string]interface{}{"gates": gates})
+}
+
+// update 创建/覆盖一条规则。先全量校验，再 upsert，最后失效缓存。
+func (m *Manager) update(c *wkhttp.Context) {
+	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
+		c.ResponseError(err)
+		return
+	}
+	key := strings.TrimSpace(c.Param("key"))
+	if key == "" || len(key) > maxKeyLen {
+		gateRequestInvalid(c, "key")
+		return
+	}
+	var req updateGateReq
+	if err := c.BindJSON(&req); err != nil {
+		gateRequestInvalid(c, "body")
+		return
+	}
+	mode := strings.TrimSpace(req.Mode)
+	if !validMode(mode) {
+		gateRequestInvalid(c, "mode")
+		return
+	}
+	if req.Percent < 0 || req.Percent > 100 {
+		gateRequestInvalid(c, "percent")
+		return
+	}
+	if len(req.Description) > maxDescriptionLen {
+		gateRequestInvalid(c, "description")
+		return
+	}
+	if err := m.db.upsertRule(key, mode, req.Percent, req.Description); err != nil {
+		m.Error("upsert feature gate failed", zap.String("key", key), zap.Error(err))
+		gateOperationFailed(c)
+		return
+	}
+	m.svc.Invalidate(key)
+	c.ResponseOK()
+}
+
+// addScope 幂等加入一条白名单条目。
+func (m *Manager) addScope(c *wkhttp.Context) {
+	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
+		c.ResponseError(err)
+		return
+	}
+	key := strings.TrimSpace(c.Param("key"))
+	if key == "" || len(key) > maxKeyLen {
+		gateRequestInvalid(c, "key")
+		return
+	}
+	var req scopeReq
+	if err := c.BindJSON(&req); err != nil {
+		gateRequestInvalid(c, "body")
+		return
+	}
+	scopeType := strings.TrimSpace(req.ScopeType)
+	if scopeType == "" {
+		scopeType = fg.ScopeTypeGroup // 缺省 group
+	}
+	if !validScopeType(scopeType) {
+		gateRequestInvalid(c, "scope_type")
+		return
+	}
+	scopeID := strings.TrimSpace(req.ScopeID)
+	if scopeID == "" || len(scopeID) > maxScopeIDLen {
+		gateRequestInvalid(c, "scope_id")
+		return
+	}
+	if err := m.db.addScope(key, scopeType, scopeID); err != nil {
+		m.Error("add feature gate scope failed",
+			zap.String("key", key), zap.String("scope_id", scopeID), zap.Error(err))
+		gateOperationFailed(c)
+		return
+	}
+	m.svc.Invalidate(key)
+	c.ResponseOK()
+}
+
+// delScope 删除一条白名单条目；条目不存在返回 404。scope_type 走 query，缺省 group。
+func (m *Manager) delScope(c *wkhttp.Context) {
+	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
+		c.ResponseError(err)
+		return
+	}
+	key := strings.TrimSpace(c.Param("key"))
+	scopeID := strings.TrimSpace(c.Param("scope_id"))
+	if key == "" || len(key) > maxKeyLen || scopeID == "" {
+		gateRequestInvalid(c, "scope_id")
+		return
+	}
+	scopeType := strings.TrimSpace(c.Query("scope_type"))
+	if scopeType == "" {
+		scopeType = fg.ScopeTypeGroup
+	}
+	if !validScopeType(scopeType) {
+		gateRequestInvalid(c, "scope_type")
+		return
+	}
+	n, err := m.db.deleteScope(key, scopeType, scopeID)
+	if err != nil {
+		m.Error("delete feature gate scope failed",
+			zap.String("key", key), zap.String("scope_id", scopeID), zap.Error(err))
+		gateOperationFailed(c)
+		return
+	}
+	if n == 0 {
+		gateNotFound(c)
+		return
+	}
+	m.svc.Invalidate(key)
+	c.ResponseOK()
+}

--- a/modules/featuregate/api_manager_test.go
+++ b/modules/featuregate/api_manager_test.go
@@ -1,0 +1,155 @@
+package featuregate
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/go-redis/redis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupManager(t *testing.T) (http.Handler, *config.Context) {
+	t.Helper()
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	resetUIDRateLimit(t, ctx)
+	return s.GetRoute(), ctx
+}
+
+// asSuperAdmin 把默认 testutil.Token 提升为 superAdmin 角色。
+func asSuperAdmin(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.SuperAdmin),
+	))
+}
+
+// resetUIDRateLimit 清 per-uid 令牌桶（SharedUIDRateLimiter 的桶不随 CleanAllTables 清）。
+func resetUIDRateLimit(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	cli := redis.NewClient(&redis.Options{
+		Addr:     ctx.GetConfig().DB.RedisAddr,
+		Password: ctx.GetConfig().DB.RedisPass,
+	})
+	defer cli.Close()
+	if keys, err := cli.Keys("ratelimit:uid:*").Result(); err == nil && len(keys) > 0 {
+		_ = cli.Del(keys...).Err()
+	}
+}
+
+func mgrReq(method, path string, body interface{}) *http.Request {
+	var r *bytes.Reader
+	if body != nil {
+		r = bytes.NewReader([]byte(util.ToJson(body)))
+	} else {
+		r = bytes.NewReader(nil)
+	}
+	req, _ := http.NewRequest(method, path, r)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("token", testutil.Token)
+	return req
+}
+
+func mgrDo(h http.Handler, req *http.Request) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w
+}
+
+func TestManager_RequiresSuperAdmin(t *testing.T) {
+	handler, _ := setupManager(t) // 不提升为 superadmin
+	key := uniqueKey("ft_")
+	w := mgrDo(handler, mgrReq("PUT", "/v1/manager/featuregate/gates/"+key,
+		map[string]interface{}{"mode": "on"}))
+	assert.Equalf(t, http.StatusBadRequest, w.Code,
+		"非 superadmin 应被拒（c.ResponseError → 400），body: %s", w.Body.String())
+}
+
+func TestManager_UpdateAndList(t *testing.T) {
+	handler, ctx := setupManager(t)
+	asSuperAdmin(t, ctx)
+	key := uniqueKey("ft_")
+
+	w := mgrDo(handler, mgrReq("PUT", "/v1/manager/featuregate/gates/"+key,
+		map[string]interface{}{"mode": "whitelist", "percent": 0, "description": "试点"}))
+	require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	w = mgrDo(handler, mgrReq("GET", "/v1/manager/featuregate/gates", nil))
+	require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	body := w.Body.String()
+	assert.Contains(t, body, key)
+	assert.Contains(t, body, `"whitelist"`)
+}
+
+func TestManager_UpdateInvalid(t *testing.T) {
+	handler, ctx := setupManager(t)
+	asSuperAdmin(t, ctx)
+	key := uniqueKey("ft_")
+
+	for _, tc := range []struct {
+		name string
+		body map[string]interface{}
+	}{
+		{"非法 mode", map[string]interface{}{"mode": "bogus"}},
+		{"percent 越界", map[string]interface{}{"mode": "percent", "percent": 101}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := mgrDo(handler, mgrReq("PUT", "/v1/manager/featuregate/gates/"+key, tc.body))
+			assert.Equalf(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+		})
+	}
+}
+
+func TestManager_UpdateRejectsLongKey(t *testing.T) {
+	handler, ctx := setupManager(t)
+	asSuperAdmin(t, ctx)
+	longKey := strings.Repeat("k", maxKeyLen+1) // 超出 feature_key VARCHAR(64)
+	w := mgrDo(handler, mgrReq("PUT", "/v1/manager/featuregate/gates/"+longKey,
+		map[string]interface{}{"mode": "on"}))
+	assert.Equalf(t, http.StatusBadRequest, w.Code, "超长 key 应 400, body: %s", w.Body.String())
+}
+
+func TestManager_ScopeAddDelete(t *testing.T) {
+	handler, ctx := setupManager(t)
+	asSuperAdmin(t, ctx)
+	key := uniqueKey("ft_")
+
+	require.Equal(t, http.StatusOK, mgrDo(handler, mgrReq("PUT",
+		"/v1/manager/featuregate/gates/"+key,
+		map[string]interface{}{"mode": "whitelist"})).Code)
+
+	// 加白名单（含幂等重复）
+	for i := 0; i < 2; i++ {
+		w := mgrDo(handler, mgrReq("POST", "/v1/manager/featuregate/gates/"+key+"/scopes",
+			map[string]interface{}{"scope_type": "group", "scope_id": "g_pilot"}))
+		require.Equalf(t, http.StatusOK, w.Code, "第 %d 次 add 应幂等成功，body: %s", i+1, w.Body.String())
+	}
+
+	// 列表应包含该白名单
+	w := mgrDo(handler, mgrReq("GET", "/v1/manager/featuregate/gates", nil))
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "g_pilot")
+
+	// 删除
+	delPath := fmt.Sprintf("/v1/manager/featuregate/gates/%s/scopes/%s?scope_type=group", key, "g_pilot")
+	require.Equal(t, http.StatusOK, mgrDo(handler, mgrReq("DELETE", delPath, nil)).Code)
+
+	// 再删 → 404
+	w = mgrDo(handler, mgrReq("DELETE", delPath, nil))
+	assert.Equalf(t, http.StatusNotFound, w.Code, "删除不存在的条目应 404，body: %s", w.Body.String())
+
+	// 列表不再包含
+	w = mgrDo(handler, mgrReq("GET", "/v1/manager/featuregate/gates", nil))
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.NotContains(t, w.Body.String(), "g_pilot")
+}

--- a/modules/featuregate/db.go
+++ b/modules/featuregate/db.go
@@ -1,0 +1,90 @@
+package featuregate
+
+import (
+	"fmt"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/gocraft/dbr/v2"
+)
+
+// gateDB 是 feature_gate / feature_gate_scope 两张表的持久化层。DB 是规则的
+// 单一真源；Service 在其上叠加 Redis 读缓存。
+type gateDB struct {
+	session *dbr.Session
+}
+
+func newDB(ctx *config.Context) *gateDB {
+	return &gateDB{session: ctx.DB()}
+}
+
+// queryRule 按 feature_key 取规则；不存在返回 (nil, nil)（Load 到 **struct，
+// 无结果时指针保持 nil），调用方按 m == nil 判定未注册。
+func (d *gateDB) queryRule(key string) (*gateModel, error) {
+	var m *gateModel
+	_, err := d.session.Select("*").From("feature_gate").
+		Where("feature_key=?", key).Load(&m)
+	return m, err
+}
+
+// queryScopes 取某 key 的全部白名单条目。
+func (d *gateDB) queryScopes(key string) ([]*scopeModel, error) {
+	var list []*scopeModel
+	_, err := d.session.Select("*").From("feature_gate_scope").
+		Where("feature_key=?", key).
+		OrderDir("scope_id", true).Load(&list)
+	return list, err
+}
+
+// listRules 列出所有规则，供管理端列表。
+func (d *gateDB) listRules() ([]*gateModel, error) {
+	var list []*gateModel
+	_, err := d.session.Select("*").From("feature_gate").
+		OrderDir("feature_key", true).Load(&list)
+	return list, err
+}
+
+// upsertRule 按 feature_key 写入/覆盖规则。靠唯一键 uk_feature_gate_key 幂等：
+// 不存在则创建（注册新功能 gate），存在则覆盖 mode/percent/description。
+func (d *gateDB) upsertRule(key, mode string, percent int, description string) error {
+	_, err := d.session.InsertBySql(
+		"INSERT INTO feature_gate (feature_key, mode, percent, description) "+
+			"VALUES (?, ?, ?, ?) "+
+			"ON DUPLICATE KEY UPDATE mode=VALUES(mode), percent=VALUES(percent), "+
+			"description=VALUES(description)",
+		key, mode, percent, description,
+	).Exec()
+	if err != nil {
+		return fmt.Errorf("featuregate: upsert rule %q: %w", key, err)
+	}
+	return nil
+}
+
+// addScope 幂等地加入一条白名单条目；重复 (key,type,id) 命中唯一键走 no-op
+// 更新，对调用方表现为成功。
+func (d *gateDB) addScope(key, scopeType, scopeID string) error {
+	_, err := d.session.InsertBySql(
+		"INSERT INTO feature_gate_scope (feature_key, scope_type, scope_id) "+
+			"VALUES (?, ?, ?) "+
+			"ON DUPLICATE KEY UPDATE feature_key=feature_key",
+		key, scopeType, scopeID,
+	).Exec()
+	if err != nil {
+		return fmt.Errorf("featuregate: add scope %q/%s/%s: %w", key, scopeType, scopeID, err)
+	}
+	return nil
+}
+
+// deleteScope 删除一条白名单条目，返回受影响行数（0 表示该条目不存在，调用方
+// 据此回 404）。
+func (d *gateDB) deleteScope(key, scopeType, scopeID string) (int64, error) {
+	res, err := d.session.DeleteFrom("feature_gate_scope").
+		Where("feature_key=? AND scope_type=? AND scope_id=?", key, scopeType, scopeID).Exec()
+	if err != nil {
+		return 0, fmt.Errorf("featuregate: delete scope %q/%s/%s: %w", key, scopeType, scopeID, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("featuregate: delete scope rows affected: %w", err)
+	}
+	return n, nil
+}

--- a/modules/featuregate/manager.go
+++ b/modules/featuregate/manager.go
@@ -1,0 +1,94 @@
+package featuregate
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	fg "github.com/Mininglamp-OSS/octo-server/pkg/featuregate"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
+)
+
+// Manager 是 featuregate 的 superadmin 管理端点。读规则/白名单走 db，写后调
+// svc.Invalidate 让缓存秒级失效。
+type Manager struct {
+	ctx *config.Context
+	log.Log
+	db  *gateDB
+	svc *Service
+}
+
+// NewManager 构造管理端。svc 仅用于写后失效缓存，与运行时评估共享同一 Redis/DB。
+func NewManager(ctx *config.Context) *Manager {
+	return &Manager{
+		ctx: ctx,
+		Log: log.NewTLog("featureGateManager"),
+		db:  newDB(ctx),
+		svc: NewService(ctx),
+	}
+}
+
+// Route 注册管理路由。AuthMiddleware 之后挂 SharedUIDRateLimiter（须在其后才能
+// 读到 uid），每个 handler 内再做 superadmin 校验。
+func (m *Manager) Route(r *wkhttp.WKHttp) {
+	g := r.Group("/v1/manager/featuregate", m.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, m.ctx))
+	{
+		g.GET("/gates", m.list)                              // 列出所有规则（含白名单）
+		g.PUT("/gates/:key", m.update)                       // 改 mode/percent/description
+		g.POST("/gates/:key/scopes", m.addScope)             // 加白名单条目
+		g.DELETE("/gates/:key/scopes/:scope_id", m.delScope) // 删白名单条目
+	}
+}
+
+// ---- 请求/响应模型 ----
+
+type updateGateReq struct {
+	Mode        string `json:"mode"`
+	Percent     int    `json:"percent"`
+	Description string `json:"description"`
+}
+
+type scopeReq struct {
+	ScopeType string `json:"scope_type"`
+	ScopeID   string `json:"scope_id"`
+}
+
+type scopeResp struct {
+	ScopeType string `json:"scope_type"`
+	ScopeID   string `json:"scope_id"`
+}
+
+type gateResp struct {
+	FeatureKey  string      `json:"feature_key"`
+	Mode        string      `json:"mode"`
+	Percent     int         `json:"percent"`
+	Description string      `json:"description"`
+	Scopes      []scopeResp `json:"scopes"`
+}
+
+func toGateResp(g *gateModel, scopes []*scopeModel) gateResp {
+	sr := make([]scopeResp, 0, len(scopes))
+	for _, s := range scopes {
+		sr = append(sr, scopeResp{ScopeType: s.ScopeType, ScopeID: s.ScopeID})
+	}
+	return gateResp{
+		FeatureKey:  g.FeatureKey,
+		Mode:        g.Mode,
+		Percent:     g.Percent,
+		Description: g.Description,
+		Scopes:      sr,
+	}
+}
+
+// ---- 字段校验 ----
+
+func validMode(mode string) bool {
+	switch fg.Mode(mode) {
+	case fg.ModeOff, fg.ModeOn, fg.ModeWhitelist, fg.ModePercent:
+		return true
+	}
+	return false
+}
+
+func validScopeType(st string) bool {
+	return st == fg.ScopeTypeGroup || st == fg.ScopeTypeSpace
+}

--- a/modules/featuregate/model.go
+++ b/modules/featuregate/model.go
@@ -1,0 +1,22 @@
+package featuregate
+
+import "github.com/Mininglamp-OSS/octo-lib/pkg/db"
+
+// gateModel 对应 feature_gate 表（每个功能 key 一行规则）。
+// 嵌入 BaseModel 提供 id/created_at/updated_at；util.AttrToUnderscore 会跳过
+// 嵌入的 struct，故 INSERT 仅写顶层标量列，时间戳交给 DB 默认值。
+type gateModel struct {
+	FeatureKey  string
+	Mode        string
+	Percent     int
+	Description string
+	db.BaseModel
+}
+
+// scopeModel 对应 feature_gate_scope 表（白名单条目，逐条加删）。
+type scopeModel struct {
+	FeatureKey string
+	ScopeType  string
+	ScopeID    string
+	db.BaseModel
+}

--- a/modules/featuregate/service.go
+++ b/modules/featuregate/service.go
@@ -1,0 +1,238 @@
+package featuregate
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	octoredis "github.com/Mininglamp-OSS/octo-lib/pkg/redis"
+	fg "github.com/Mininglamp-OSS/octo-server/pkg/featuregate"
+	"go.uber.org/zap"
+)
+
+// 缓存键前缀与兜底 TTL。Redis 是规则的读缓存（DB 才是真源）；管理端写后主动
+// DEL 失效以达成秒级全实例一致，TTL 仅作 DEL 漏掉时的最终一致兜底。
+const (
+	ruleKeyPrefix  = "ft:rule:"
+	scopeKeyPrefix = "ft:scope:"
+	cacheTTL       = 60 * time.Second
+	// nilSentinel 缓存「DB 也没有此规则」，防止未注册 key 每次穿透到 DB。
+	nilSentinel = "__nil__"
+)
+
+// Dims 是评估维度，pkg/featuregate.Dims 的别名 —— 调用方（incomingwebhook 等）
+// 只 import 本模块即可构造维度，无需再引入纯逻辑包。
+type Dims = fg.Dims
+
+// Service 是 featuregate 的带 IO 编排层：在 pkg/featuregate 纯逻辑之上叠加
+// DB 真源 + Redis 读缓存 + env kill switch + 按端固定的 fail 兜底。
+//
+// fail 策略不可按规则配置：create 一律 fail-closed、push 一律 fail-open（见
+// AllowCreate / AllowPush）。这是刻意的安全不对称（create 误拒 < 数据裸奔；
+// push 误推 < 中断存量推送），不暴露为运维旋钮以免被配反。
+//
+// 由调用方（如 incomingwebhook）直接 NewService(ctx) 构造，不经 module 注册，
+// 与 group.NewDB(ctx) 同模式，保持依赖图单向无环。
+type Service struct {
+	db    *gateDB
+	redis *octoredis.Conn
+	log.Log
+}
+
+// NewService 构造 Service，自取 DB 与 Redis。
+func NewService(ctx *config.Context) *Service {
+	return &Service{
+		db:    newDB(ctx),
+		redis: ctx.GetRedisConn(),
+		Log:   log.NewTLog("FeatureGate"),
+	}
+}
+
+// cachedRule 是规则在 Redis 中的序列化形态（不含 key —— key 已在 Redis key 里）。
+type cachedRule struct {
+	Mode    string `json:"mode"`
+	Percent int    `json:"percent"`
+}
+
+// AllowCreate 是写时闸门（fail-closed）：env kill / 存储故障 / 无规则 一律拒绝，
+// 否则交给纯函数评估。用于 create 类操作 —— 配置拿不到时拒绝新功能，胜过裸奔。
+func (s *Service) AllowCreate(ctx context.Context, key string, dims fg.Dims) bool {
+	if killSwitchOn(key) {
+		return false
+	}
+	rule, err := s.loadRule(ctx, key)
+	if err != nil {
+		s.Warn("featuregate load rule failed; create fail-closed",
+			zap.String("key", key), zap.Error(err))
+		return false
+	}
+	if rule == nil {
+		return false // 未注册规则 → fail-closed
+	}
+	var scopes []fg.Scope
+	if rule.Mode == fg.ModeWhitelist {
+		scopes, err = s.loadScopes(ctx, key)
+		if err != nil {
+			s.Warn("featuregate load scopes failed; create fail-closed",
+				zap.String("key", key), zap.Error(err))
+			return false
+		}
+	}
+	return fg.Evaluate(*rule, scopes, dims).Allow
+}
+
+// AllowPush 是推送总开关（fail-open）：仅在 env kill 或规则被显式置为 off 时
+// 拒绝；存储故障 / 无规则 / 其余 mode 一律放行。push 是群广播热路径，绝不能因
+// 灰度框架故障中断存量推送，也不做维度灰度（按群灰度对群广播无意义）。
+func (s *Service) AllowPush(ctx context.Context, key string) bool {
+	if killSwitchOn(key) {
+		return false
+	}
+	rule, err := s.loadRule(ctx, key)
+	if err != nil {
+		s.Warn("featuregate load rule failed; push fail-open",
+			zap.String("key", key), zap.Error(err))
+		return true
+	}
+	if rule == nil {
+		return true // 未注册规则 → fail-open
+	}
+	// off 是管理员主动关停（确定性），与「故障 fail-open」区分开。
+	return rule.Mode != fg.ModeOff
+}
+
+// Invalidate 失效某 key 的规则与白名单缓存。管理端写操作提交后调用，使变更秒级
+// 在所有实例生效（Redis 共享，DEL 后各实例下次读 miss 回填新值）。
+func (s *Service) Invalidate(key string) {
+	if err := s.redis.Del(ruleKeyPrefix + key); err != nil {
+		s.Warn("featuregate invalidate rule cache failed",
+			zap.String("key", key), zap.Error(err))
+	}
+	if err := s.redis.Del(scopeKeyPrefix + key); err != nil {
+		s.Warn("featuregate invalidate scope cache failed",
+			zap.String("key", key), zap.Error(err))
+	}
+}
+
+// loadRule 读规则：Redis 命中即用；miss / 缓存损坏都走 fetchRuleAndCache（查 DB
+// 并回填，损坏值被新值覆盖，避免 TTL 内反复穿透——push 热路径每请求读规则，放大
+// 明显）；Redis 真实故障则绕过缓存直查 DB（不回填）。
+func (s *Service) loadRule(_ context.Context, key string) (*fg.Rule, error) {
+	cached, err := s.redis.GetString(ruleKeyPrefix + key)
+	if err != nil {
+		return s.queryRuleFromDB(key) // Redis 故障：绕过缓存，DB 失败时由调用方走 fail 语义
+	}
+	switch cached {
+	case "":
+		return s.fetchRuleAndCache(key)
+	case nilSentinel:
+		return nil, nil
+	default:
+		var cr cachedRule
+		if err := json.Unmarshal([]byte(cached), &cr); err != nil {
+			s.Warn("featuregate rule cache corrupt; refetch from DB",
+				zap.String("key", key), zap.Error(err))
+			return s.fetchRuleAndCache(key) // 回填覆盖损坏值
+		}
+		return &fg.Rule{Key: key, Mode: fg.Mode(cr.Mode), Percent: cr.Percent}, nil
+	}
+}
+
+// fetchRuleAndCache 查 DB 并回填缓存（无规则回填 nilSentinel 防穿透）。
+func (s *Service) fetchRuleAndCache(key string) (*fg.Rule, error) {
+	rule, err := s.queryRuleFromDB(key)
+	if err != nil {
+		return nil, err
+	}
+	if rule == nil {
+		s.cacheSet(ruleKeyPrefix+key, nilSentinel)
+		return nil, nil
+	}
+	s.cacheSet(ruleKeyPrefix+key, mustJSON(cachedRule{
+		Mode: string(rule.Mode), Percent: rule.Percent,
+	}))
+	return rule, nil
+}
+
+// loadScopes 读白名单条目：语义同 loadRule。空列表序列化为 "[]"（非空串），与
+// miss（空串）天然区分，不会反复回查；miss / 缓存损坏都走 fetchScopesAndCache。
+func (s *Service) loadScopes(_ context.Context, key string) ([]fg.Scope, error) {
+	cached, err := s.redis.GetString(scopeKeyPrefix + key)
+	if err != nil {
+		return s.queryScopesFromDB(key)
+	}
+	if cached == "" {
+		return s.fetchScopesAndCache(key)
+	}
+	var scopes []fg.Scope
+	if err := json.Unmarshal([]byte(cached), &scopes); err != nil {
+		s.Warn("featuregate scope cache corrupt; refetch from DB",
+			zap.String("key", key), zap.Error(err))
+		return s.fetchScopesAndCache(key) // 回填覆盖损坏值
+	}
+	return scopes, nil
+}
+
+// fetchScopesAndCache 查 DB 并回填白名单缓存。
+func (s *Service) fetchScopesAndCache(key string) ([]fg.Scope, error) {
+	scopes, err := s.queryScopesFromDB(key)
+	if err != nil {
+		return nil, err
+	}
+	s.cacheSet(scopeKeyPrefix+key, mustJSON(scopes))
+	return scopes, nil
+}
+
+func (s *Service) queryRuleFromDB(key string) (*fg.Rule, error) {
+	m, err := s.db.queryRule(key)
+	if err != nil {
+		return nil, err
+	}
+	if m == nil {
+		return nil, nil
+	}
+	return &fg.Rule{Key: key, Mode: fg.Mode(m.Mode), Percent: m.Percent}, nil
+}
+
+func (s *Service) queryScopesFromDB(key string) ([]fg.Scope, error) {
+	rows, err := s.db.queryScopes(key)
+	if err != nil {
+		return nil, err
+	}
+	scopes := make([]fg.Scope, 0, len(rows))
+	for _, r := range rows {
+		scopes = append(scopes, fg.Scope{Type: r.ScopeType, ID: r.ScopeID})
+	}
+	return scopes, nil
+}
+
+// cacheSet 写缓存，失败仅 Warn（不阻断主流程，TTL/下次 miss 自愈）。空串跳过，
+// 避免把「未配置」状态写成可被误判为 miss 的值。
+func (s *Service) cacheSet(k, v string) {
+	if v == "" {
+		return
+	}
+	if err := s.redis.SetAndExpire(k, v, cacheTTL); err != nil {
+		s.Warn("featuregate cache set failed", zap.String("key", k), zap.Error(err))
+	}
+}
+
+// killSwitchOn 读 env 终极开关 DM_FT_<KEY>_KILL。不查任何存储，DB/Redis 全挂
+// 时仍可一键停。KEY 为 feature_key 的大写形态（incoming_webhook_push →
+// DM_FT_INCOMING_WEBHOOK_PUSH_KILL）。
+func killSwitchOn(key string) bool {
+	env := "DM_FT_" + strings.ToUpper(strings.ReplaceAll(key, "-", "_")) + "_KILL"
+	return os.Getenv(env) == "1"
+}
+
+func mustJSON(v interface{}) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "" // 极罕见；返回空串使下次仍 miss 重试，而非缓存坏值
+	}
+	return string(b)
+}

--- a/modules/featuregate/service_test.go
+++ b/modules/featuregate/service_test.go
@@ -1,0 +1,101 @@
+package featuregate
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	fg "github.com/Mininglamp-OSS/octo-server/pkg/featuregate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	// 触发基础设施迁移；featuregate 自身的迁移由本包 init() 注册触发。
+	_ "github.com/Mininglamp-OSS/octo-server/modules/base"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/common"
+)
+
+// TestMain 为 common.Setup 注入 32 字节 master key（本地直接 go test 也能跑）。
+func TestMain(m *testing.M) {
+	if os.Getenv("OCTO_MASTER_KEY") == "" {
+		os.Setenv("OCTO_MASTER_KEY", "12345678901234567890123456789012")
+	}
+	os.Exit(m.Run())
+}
+
+// uniqueKey 生成只含 [a-z0-9_] 的 feature key（去掉 UUID 的连字符），既避免测试
+// 间 Redis 缓存串扰，又能直接映射成合法的 env kill 变量名。
+func uniqueKey(prefix string) string {
+	return prefix + strings.ReplaceAll(util.GenerUUID(), "-", "")[:12]
+}
+
+func newTestSvc(t *testing.T) (*Service, *gateDB, string) {
+	t.Helper()
+	_, ctx := testutil.NewTestServer()
+	svc := NewService(ctx)
+	db := newDB(ctx)
+	key := uniqueKey("test_gate_")
+	t.Cleanup(func() { svc.Invalidate(key) })
+	return svc, db, key
+}
+
+func TestService_NoRule_FailSemantics(t *testing.T) {
+	svc, _, key := newTestSvc(t)
+	ctx := context.Background()
+	assert.False(t, svc.AllowCreate(ctx, key, fg.Dims{GroupNo: "g1"}), "无规则 → create fail-closed")
+	assert.True(t, svc.AllowPush(ctx, key), "无规则 → push fail-open")
+}
+
+func TestService_ModeOn(t *testing.T) {
+	svc, db, key := newTestSvc(t)
+	require.NoError(t, db.upsertRule(key, string(fg.ModeOn), 0, ""))
+	ctx := context.Background()
+	assert.True(t, svc.AllowCreate(ctx, key, fg.Dims{GroupNo: "g1"}))
+	assert.True(t, svc.AllowPush(ctx, key))
+}
+
+func TestService_ModeOff(t *testing.T) {
+	svc, db, key := newTestSvc(t)
+	require.NoError(t, db.upsertRule(key, string(fg.ModeOff), 0, ""))
+	ctx := context.Background()
+	assert.False(t, svc.AllowCreate(ctx, key, fg.Dims{GroupNo: "g1"}), "off → create 拒")
+	assert.False(t, svc.AllowPush(ctx, key), "off → push 确定性关停")
+}
+
+func TestService_Whitelist(t *testing.T) {
+	svc, db, key := newTestSvc(t)
+	require.NoError(t, db.upsertRule(key, string(fg.ModeWhitelist), 0, ""))
+	require.NoError(t, db.addScope(key, fg.ScopeTypeGroup, "g_allow"))
+	svc.Invalidate(key) // 确保读到刚写入的规则与白名单
+	ctx := context.Background()
+	assert.True(t, svc.AllowCreate(ctx, key, fg.Dims{GroupNo: "g_allow"}), "白名单命中放行")
+	assert.False(t, svc.AllowCreate(ctx, key, fg.Dims{GroupNo: "g_other"}), "白名单未命中拒绝")
+}
+
+func TestService_EnvKillSwitch(t *testing.T) {
+	svc, db, key := newTestSvc(t)
+	require.NoError(t, db.upsertRule(key, string(fg.ModeOn), 0, ""))
+	t.Setenv("DM_FT_"+strings.ToUpper(key)+"_KILL", "1")
+	ctx := context.Background()
+	assert.False(t, svc.AllowPush(ctx, key), "kill → push 拒")
+	assert.False(t, svc.AllowCreate(ctx, key, fg.Dims{GroupNo: "g1"}), "kill → create 拒")
+}
+
+// TestService_CacheInvalidation 验证 Redis 读缓存生效，且 Invalidate 后能秒级读到
+// 新值：写入 on 并读取（缓存）→ 直接改 DB 为 off 但不失效 → 仍读旧值 on →
+// Invalidate 后读到新值 off。
+func TestService_CacheInvalidation(t *testing.T) {
+	svc, db, key := newTestSvc(t)
+	ctx := context.Background()
+
+	require.NoError(t, db.upsertRule(key, string(fg.ModeOn), 0, ""))
+	assert.True(t, svc.AllowCreate(ctx, key, fg.Dims{GroupNo: "g1"}), "首次读到 on 并缓存")
+
+	require.NoError(t, db.upsertRule(key, string(fg.ModeOff), 0, ""))
+	assert.True(t, svc.AllowCreate(ctx, key, fg.Dims{GroupNo: "g1"}), "未失效缓存应仍读旧值 on")
+
+	svc.Invalidate(key)
+	assert.False(t, svc.AllowCreate(ctx, key, fg.Dims{GroupNo: "g1"}), "失效后读到新值 off")
+}

--- a/modules/featuregate/sql/20260605000001_featuregate_init.sql
+++ b/modules/featuregate/sql/20260605000001_featuregate_init.sql
@@ -1,0 +1,28 @@
+-- +migrate Up
+
+-- 通用功能灰度规则表：每个功能 key 一行
+CREATE TABLE `feature_gate` (
+  `id`          BIGINT       AUTO_INCREMENT PRIMARY KEY,
+  `feature_key` VARCHAR(64)  NOT NULL DEFAULT ''       COMMENT '功能键，如 incoming_webhook_create / incoming_webhook_push',
+  `mode`        VARCHAR(16)  NOT NULL DEFAULT 'off'    COMMENT 'off/on/whitelist/percent',
+  `percent`     SMALLINT     NOT NULL DEFAULT 0        COMMENT 'percent 模式阈值 [0,100]，<percent 命中',
+  `description` VARCHAR(255) NOT NULL DEFAULT ''       COMMENT '说明',
+  `created_at`  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at`  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY `uk_feature_gate_key` (`feature_key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='通用功能灰度规则';
+
+-- 灰度白名单条目表：逐条加删，scope_type 兼容 group/space，当前代码仅 group 生效
+CREATE TABLE `feature_gate_scope` (
+  `id`          BIGINT       AUTO_INCREMENT PRIMARY KEY,
+  `feature_key` VARCHAR(64)  NOT NULL DEFAULT ''      COMMENT '关联 feature_gate.feature_key',
+  `scope_type`  VARCHAR(16)  NOT NULL DEFAULT 'group' COMMENT 'group/space；当前仅 group 生效',
+  `scope_id`    VARCHAR(64)  NOT NULL DEFAULT ''      COMMENT '群编号 group_no 或 space_id',
+  `created_at`  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY `uk_fgs_key_type_id` (`feature_key`, `scope_type`, `scope_id`),
+  INDEX `idx_fgs_key` (`feature_key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='通用功能灰度白名单条目';
+
+-- +migrate Down
+DROP TABLE IF EXISTS `feature_gate_scope`;
+DROP TABLE IF EXISTS `feature_gate`;

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
+	"github.com/Mininglamp-OSS/octo-server/modules/featuregate"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
@@ -65,6 +66,8 @@ type IncomingWebhook struct {
 	db        *incomingWebhookDB
 	groupDB   *group.DB
 	rateRedis *redis.Client
+	// ftSvc 灰度闸门：create 写时门禁（fail-closed）、push 总开关（fail-open）。
+	ftSvc *featuregate.Service
 	// auditSem 给 push 成功后的异步审计(recordSuccess)限并发：每次推送有两次 DB 写，
 	// 无界 `go recordSuccess` 在 Redis 限流 fail-open + 推送洪峰下会无限堆 goroutine、
 	// 压垮 DB 连接池。用带缓冲 channel 作信号量给审计的 DB 操作总并发封顶——满了就**丢弃**
@@ -119,6 +122,7 @@ func New(ctx *config.Context) *IncomingWebhook {
 		db:        newDB(ctx),
 		groupDB:   group.NewDB(ctx),
 		rateRedis: sharedRateRedis(ctx.GetConfig()),
+		ftSvc:     featuregate.NewService(ctx),
 		auditSem:  make(chan struct{}, auditConcurrency()),
 	}
 	// 群解散级联禁用所有 webhook
@@ -310,6 +314,14 @@ func (w *IncomingWebhook) create(c *wkhttp.Context) {
 	}
 	if g == nil {
 		mgmtGroupNotFound(c)
+		return
+	}
+
+	// 灰度写时门禁（fail-closed）：未注册规则 / 存储故障 / kill 一律拒绝创建。维度
+	// 齐全（group_no + space_id + 登录 uid）后评估，按群白名单 / 百分比放量。
+	if !w.ftSvc.AllowCreate(c.Request.Context(), "incoming_webhook_create",
+		featuregate.Dims{SpaceID: g.SpaceID, GroupNo: groupNo, UID: loginUID}) {
+		createGateDenied(c)
 		return
 	}
 
@@ -524,6 +536,16 @@ func (w *IncomingWebhook) regenerate(c *wkhttp.Context) {
 // ============================================================
 
 func (w *IncomingWebhook) push(c *wkhttp.Context) {
+	// 推送总开关（放最前）：关停期所有请求统一 503，连 webhook 都不查 —— 既不泄露
+	// token 正确性（push 防探测主防线是"失败一律 401 不区分"，若关停在 token 校验
+	// 之后返 503 会让"token 对+关停"可被区分），也省去无谓 DB 访问。env kill /
+	// mode=off 时拒绝；存储故障 / 无规则一律 fail-open 继续推，绝不因灰度框架故障
+	// 中断存量推送。
+	if !w.ftSvc.AllowPush(c.Request.Context(), "incoming_webhook_push") {
+		pushDisabled(c)
+		return
+	}
+
 	webhookID := c.Param("webhook_id")
 	token := c.Param("token")
 	if webhookID == "" || token == "" {

--- a/modules/incomingwebhook/api_gate_test.go
+++ b/modules/incomingwebhook/api_gate_test.go
@@ -1,0 +1,141 @@
+package incomingwebhook_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/go-redis/redis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================
+// featuregate 灰度闸门集成测试（webhook-feature-flag-rollout）
+//
+// 固定 feature_key 的规则缓存（ft:rule:* / ft:scope:*）在 Redis 中持久，且
+// CleanAllTables 不清 Redis —— 所有改规则的 helper 都必须随手清缓存，否则上个
+// 测试的规则会泄漏到下一个。
+// ============================================================
+
+const createPathTmpl = "/v1/groups/%s/incoming-webhooks"
+
+func resetFeatureGateCache(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	cli := redis.NewClient(&redis.Options{
+		Addr:     ctx.GetConfig().DB.RedisAddr,
+		Password: ctx.GetConfig().DB.RedisPass,
+	})
+	defer cli.Close()
+	var all []string
+	for _, pat := range []string{"ft:rule:*", "ft:scope:*"} {
+		if ks, err := cli.Keys(pat).Result(); err == nil {
+			all = append(all, ks...)
+		}
+	}
+	if len(all) > 0 {
+		_ = cli.Del(all...).Err()
+	}
+}
+
+func setFeatureGate(t *testing.T, ctx *config.Context, key, mode string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO feature_gate(feature_key, mode, percent) VALUES(?, ?, 0) "+
+			"ON DUPLICATE KEY UPDATE mode=VALUES(mode)", key, mode).Exec()
+	assert.NoError(t, err)
+	resetFeatureGateCache(t, ctx)
+}
+
+func clearFeatureGate(t *testing.T, ctx *config.Context, key string) {
+	t.Helper()
+	_, err := ctx.DB().DeleteFrom("feature_gate").Where("feature_key=?", key).Exec()
+	assert.NoError(t, err)
+	resetFeatureGateCache(t, ctx)
+}
+
+func addFeatureScope(t *testing.T, ctx *config.Context, key, scopeID string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO feature_gate_scope(feature_key, scope_type, scope_id) VALUES(?, 'group', ?) "+
+			"ON DUPLICATE KEY UPDATE feature_key=feature_key", key, scopeID).Exec()
+	assert.NoError(t, err)
+	resetFeatureGateCache(t, ctx)
+}
+
+func createWebhook(t *testing.T, handler http.Handler, groupNo string) (webhookID, token string) {
+	t.Helper()
+	w := do(handler, authReq("POST", fmt.Sprintf(createPathTmpl, groupNo),
+		map[string]interface{}{"name": "gate-test"}))
+	require.Equalf(t, http.StatusOK, w.Code, "建 webhook 失败 body: %s", w.Body.String())
+	res := parseJSON(t, w)
+	return res["webhook_id"].(string), res["token"].(string)
+}
+
+func pushURL(webhookID, token string) string {
+	return fmt.Sprintf("/v1/incoming-webhooks/%s/%s", webhookID, token)
+}
+
+// ---- create 闸门 ----
+
+func TestGate_CreateDenied_NoRule(t *testing.T) {
+	handler, ctx, groupNo := setupTestEnv(t)
+	clearFeatureGate(t, ctx, "incoming_webhook_create") // 删默认 on → 无规则 fail-closed
+	w := do(handler, authReq("POST", fmt.Sprintf(createPathTmpl, groupNo),
+		map[string]interface{}{"name": "x"}))
+	assert.Equalf(t, http.StatusForbidden, w.Code, "无规则应 fail-closed 403, body: %s", w.Body.String())
+}
+
+func TestGate_CreateDenied_ModeOff(t *testing.T) {
+	handler, ctx, groupNo := setupTestEnv(t)
+	setFeatureGate(t, ctx, "incoming_webhook_create", "off")
+	w := do(handler, authReq("POST", fmt.Sprintf(createPathTmpl, groupNo),
+		map[string]interface{}{"name": "x"}))
+	assert.Equalf(t, http.StatusForbidden, w.Code, "off 应 403, body: %s", w.Body.String())
+}
+
+func TestGate_CreateWhitelist_Hit(t *testing.T) {
+	handler, ctx, groupNo := setupTestEnv(t)
+	setFeatureGate(t, ctx, "incoming_webhook_create", "whitelist")
+	addFeatureScope(t, ctx, "incoming_webhook_create", groupNo) // 命中本群
+	w := do(handler, authReq("POST", fmt.Sprintf(createPathTmpl, groupNo),
+		map[string]interface{}{"name": "x"}))
+	assert.Equalf(t, http.StatusOK, w.Code, "白名单命中应 200, body: %s", w.Body.String())
+}
+
+func TestGate_CreateWhitelist_Miss(t *testing.T) {
+	handler, ctx, groupNo := setupTestEnv(t)
+	setFeatureGate(t, ctx, "incoming_webhook_create", "whitelist") // 不加本群 scope
+	w := do(handler, authReq("POST", fmt.Sprintf(createPathTmpl, groupNo),
+		map[string]interface{}{"name": "x"}))
+	assert.Equalf(t, http.StatusForbidden, w.Code, "白名单未命中应 403, body: %s", w.Body.String())
+}
+
+// ---- push 闸门 ----
+
+func TestGate_PushDisabled(t *testing.T) {
+	handler, ctx, groupNo := setupTestEnv(t)
+	wid, token := createWebhook(t, handler, groupNo) // create=on 默认放行
+	setFeatureGate(t, ctx, "incoming_webhook_push", "off")
+	w := do(handler, anonReq("POST", pushURL(wid, token), []byte(`{"content":"hi"}`)))
+	assert.Equalf(t, http.StatusServiceUnavailable, w.Code, "push off 应 503, body: %s", w.Body.String())
+	assert.NotEmpty(t, w.Header().Get("Retry-After"), "503 应带 Retry-After")
+}
+
+func TestGate_PushKillSwitch(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	wid, token := createWebhook(t, handler, groupNo)
+	t.Setenv("DM_FT_INCOMING_WEBHOOK_PUSH_KILL", "1")
+	w := do(handler, anonReq("POST", pushURL(wid, token), []byte(`{"content":"hi"}`)))
+	assert.Equalf(t, http.StatusServiceUnavailable, w.Code, "push kill 应 503, body: %s", w.Body.String())
+}
+
+// TestGate_PushDisabled_NoTokenLeak 验证关停期防探测：连不存在的 webhook/token
+// 也返回统一 503（gate 在 handler 最前、查 DB 之前），不泄露 token 正确性。
+func TestGate_PushDisabled_NoTokenLeak(t *testing.T) {
+	handler, ctx, _ := setupTestEnv(t)
+	setFeatureGate(t, ctx, "incoming_webhook_push", "off")
+	w := do(handler, anonReq("POST", pushURL("iwh_nonexistent", "badtoken"), []byte(`{"content":"hi"}`)))
+	assert.Equalf(t, http.StatusServiceUnavailable, w.Code, "关停期任意请求统一 503, body: %s", w.Body.String())
+}

--- a/modules/incomingwebhook/api_i18n.go
+++ b/modules/incomingwebhook/api_i18n.go
@@ -98,3 +98,24 @@ func mgmtQueryFailed(c *wkhttp.Context) {
 func mgmtOperationFailed(c *wkhttp.Context) {
 	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookOperationFailed, nil, nil)
 }
+
+// ============================================================
+// feature-gate 灰度闸门 responder（webhook-feature-flag-rollout）
+// ============================================================
+
+// createGateDenied returns 403 — 灰度未对该群开放新建 webhook。管理路径，handler
+// 调用后 return 即可，无需 Abort。
+func createGateDenied(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookCreateGateDenied, nil, nil)
+}
+
+// pushRetryAfterSeconds 是关停 503 给推送方的重试间隔提示（秒）。
+const pushRetryAfterSeconds = "60"
+
+// pushDisabled returns 503 + Retry-After — 推送总开关关停。push 路径，需 Abort 以
+// 阻止后续 handler。Retry-After 让 CI/告警等正规推送方自动重试。
+func pushDisabled(c *wkhttp.Context) {
+	c.Header("Retry-After", pushRetryAfterSeconds)
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookPushDisabled, nil, nil)
+	c.Abort()
+}

--- a/modules/incomingwebhook/api_test.go
+++ b/modules/incomingwebhook/api_test.go
@@ -69,6 +69,13 @@ func setupTestEnv(t *testing.T) (http.Handler, *config.Context, string) {
 	// 429。每次 setup 清桶，保证每个测试从满桶开始（参考 category 测试同名 helper）。
 	resetUIDRateLimit(t, ctx)
 
+	// 接入 featuregate 后，create 无规则会 fail-closed、push 无规则 fail-open。
+	// 绝大多数测试聚焦各自被测逻辑，这里默认放行两扇闸门；gate 专项测试
+	// （api_gate_test.go）再各自覆盖规则。两个 helper 内部都会清 ft:* 缓存，
+	// 避免固定 feature_key 的缓存跨测试串扰（CleanAllTables 不清 Redis）。
+	setFeatureGate(t, ctx, "incoming_webhook_create", "on")
+	setFeatureGate(t, ctx, "incoming_webhook_push", "on")
+
 	return s.GetRoute(), ctx, groupNo
 }
 

--- a/modules/incomingwebhook/sql/20260605000002_incomingwebhook_seed_gate.sql
+++ b/modules/incomingwebhook/sql/20260605000002_incomingwebhook_seed_gate.sql
@@ -1,0 +1,17 @@
+-- +migrate Up
+
+-- 既有群入站 Webhook 功能（#31）已上线可用。接入 featuregate 后，create 对「无
+-- 规则」是 fail-closed —— 若不 seed，已有部署升级后原本可用的创建请求会全部变
+-- 403（升级即回归）。这里为两个 key seed 默认 mode=on，保持升级前行为；灰度 / 回滚
+-- 由运维后续改规则（whitelist/percent/off）opt-in。
+--
+-- 幂等：若运维在升级前已手动建规则，ON DUPLICATE 走 no-op，不覆盖其设置。
+-- 依赖：feature_gate 表由 featuregate 模块的 20260605000001 迁移先建（按文件时间戳
+-- 全局排序，本文件 20260605000002 在其后）。
+INSERT INTO feature_gate (feature_key, mode, description)
+VALUES ('incoming_webhook_create', 'on', 'seeded on upgrade: keep existing create enabled'),
+       ('incoming_webhook_push', 'on', 'seeded on upgrade: keep existing push enabled')
+ON DUPLICATE KEY UPDATE feature_key = feature_key;
+
+-- +migrate Down
+DELETE FROM feature_gate WHERE feature_key IN ('incoming_webhook_create', 'incoming_webhook_push');

--- a/pkg/errcode/featuregate.go
+++ b/pkg/errcode/featuregate.go
@@ -1,0 +1,45 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// err.server.featuregate.* — modules/featuregate 管理端点错误码（list / update /
+// addScope / delScope）。superadmin-only、无 legacy client，统一经
+// httperr.ResponseErrorLWithStatus 渲染并保留真实 HTTP status。zh-CN 翻译在
+// pkg/i18n/locales/active.zh-CN.toml。
+var (
+	// ErrFeatureGateRequestInvalid (400) — 请求体或字段非法（mode/percent/
+	// fail_mode/scope_type/scope_id）；具体字段经 Details["reason"] 透出。
+	ErrFeatureGateRequestInvalid = register(codes.Code{
+		ID:             "err.server.featuregate.request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid request.",
+		SafeDetailKeys: []string{"reason"},
+	})
+
+	// ErrFeatureGateNotFound (404) — 要删除的白名单条目不存在。
+	ErrFeatureGateNotFound = register(codes.Code{
+		ID:             "err.server.featuregate.not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "The feature gate scope does not exist.",
+	})
+
+	// ErrFeatureGateQueryFailed (500, Internal) — 读规则/白名单失败；真实错误仅日志。
+	ErrFeatureGateQueryFailed = register(codes.Code{
+		ID:             "err.server.featuregate.query_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to query feature gate.",
+		Internal:       true,
+	})
+
+	// ErrFeatureGateOperationFailed (500, Internal) — 写规则/白名单失败；真实错误仅日志。
+	ErrFeatureGateOperationFailed = register(codes.Code{
+		ID:             "err.server.featuregate.operation_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "The operation failed. Please try again later.",
+		Internal:       true,
+	})
+)

--- a/pkg/errcode/incomingwebhook.go
+++ b/pkg/errcode/incomingwebhook.go
@@ -137,3 +137,23 @@ var (
 		Internal:       true,
 	})
 )
+
+// err.server.incomingwebhook.{create_gate_denied,push_disabled} — featuregate
+// 灰度闸门（webhook-feature-flag-rollout）。create_gate_denied 是管理路径写时
+// 门禁（403）；push_disabled 是推送总开关关停（503，由 handler 最前统一返回，
+// 不泄露 token 正确性，正规推送方可凭 Retry-After 重试）。
+var (
+	// ErrIncomingWebhookCreateGateDenied (403) — 灰度未对该群开放新建 webhook。
+	ErrIncomingWebhookCreateGateDenied = register(codes.Code{
+		ID:             "err.server.incomingwebhook.create_gate_denied",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "This feature is not enabled for your group yet.",
+	})
+
+	// ErrIncomingWebhookPushDisabled (503) — 推送功能被灰度/运维关停。
+	ErrIncomingWebhookPushDisabled = register(codes.Code{
+		ID:             "err.server.incomingwebhook.push_disabled",
+		HTTPStatus:     http.StatusServiceUnavailable,
+		DefaultMessage: "The service is temporarily unavailable. Please retry later.",
+	})
+)

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -1,0 +1,118 @@
+// Package featuregate 提供通用的功能灰度评估纯逻辑：给定一条规则、一组白名单
+// 条目和一个评估维度，判定某次调用是否放行。
+//
+// 本包刻意保持「零 IO、零 module 依赖」：不读 env、不查 DB/Redis、不判 kill
+// switch（kill switch 由调用方在评估前短路处理）。所有外部状态（规则、白名单）
+// 由调用方加载后以参数传入，使 Evaluate 可被表驱动单测完整覆盖。
+//
+// 持久化、Redis 缓存、env kill、fail-open/closed 兜底等带 IO 的编排逻辑放在
+// modules/featuregate 的 Service 中，Service 在准备好 Rule/Scope 后调用本包。
+package featuregate
+
+import "hash/crc32"
+
+// Mode 是某个功能 key 的放量模式。
+type Mode string
+
+const (
+	// ModeOff 全部拒绝。
+	ModeOff Mode = "off"
+	// ModeOn 全部放行。
+	ModeOn Mode = "on"
+	// ModeWhitelist 仅白名单命中放行。
+	ModeWhitelist Mode = "whitelist"
+	// ModePercent 按 hash 稳定分桶的百分比放量。
+	ModePercent Mode = "percent"
+)
+
+// 白名单条目维度类型。当前 Evaluate 只消费 group；space 字段先落库、暂不参与
+// 命中判定（扩面阶段再启用），见 Evaluate 的 whitelist 分支。
+const (
+	ScopeTypeGroup = "group"
+	ScopeTypeSpace = "space"
+)
+
+// 决策原因，用于可观测与测试断言。
+const (
+	ReasonOff           = "off"
+	ReasonOn            = "on"
+	ReasonWhitelistHit  = "whitelist_hit"
+	ReasonWhitelistMiss = "whitelist_miss"
+	ReasonPercentIn     = "percent_in"
+	ReasonPercentOut    = "percent_out"
+	ReasonUnknownMode   = "unknown_mode"
+)
+
+// Rule 是某个功能 key 的规则快照（纯数据）。
+type Rule struct {
+	Key     string
+	Mode    Mode
+	Percent int // [0,100]，仅 ModePercent 使用
+}
+
+// Scope 是一条白名单条目。
+type Scope struct {
+	Type string // ScopeTypeGroup / ScopeTypeSpace
+	ID   string // group_no 或 space_id
+}
+
+// Dims 是一次评估的维度取值。
+type Dims struct {
+	SpaceID string
+	GroupNo string
+	UID     string
+}
+
+// Decision 是评估结果。Reason 取上面的 Reason* 常量之一。
+type Decision struct {
+	Allow  bool
+	Reason string
+}
+
+// Evaluate 是纯函数：按 rule.Mode 判定是否放行。不读 env、不判 kill switch。
+// 未知 mode 一律保守拒绝（fail-safe），避免规则写坏时意外放量。
+func Evaluate(rule Rule, scopes []Scope, dims Dims) Decision {
+	switch rule.Mode {
+	case ModeOff:
+		return Decision{Allow: false, Reason: ReasonOff}
+	case ModeOn:
+		return Decision{Allow: true, Reason: ReasonOn}
+	case ModeWhitelist:
+		// 当前仅按 group 维度命中；空 GroupNo 不应匹配到任何条目。
+		if dims.GroupNo != "" {
+			for _, s := range scopes {
+				if s.Type == ScopeTypeGroup && s.ID == dims.GroupNo {
+					return Decision{Allow: true, Reason: ReasonWhitelistHit}
+				}
+			}
+		}
+		return Decision{Allow: false, Reason: ReasonWhitelistMiss}
+	case ModePercent:
+		if percentIn(rule, dims) {
+			return Decision{Allow: true, Reason: ReasonPercentIn}
+		}
+		return Decision{Allow: false, Reason: ReasonPercentOut}
+	default:
+		return Decision{Allow: false, Reason: ReasonUnknownMode}
+	}
+}
+
+// percentIn 判定 percent 模式是否命中。0（及负数）全拒、>=100 全放，中间值按
+// 稳定分桶比较；空 GroupNo 落到桶 0，仍受 percent 约束。
+func percentIn(rule Rule, dims Dims) bool {
+	if rule.Percent <= 0 {
+		return false
+	}
+	if rule.Percent >= 100 {
+		return true
+	}
+	return Bucket(rule.Key, dims.GroupNo) < rule.Percent
+}
+
+// Bucket 把 (key, dimID) 稳定映射到 [0,100)。同一对入参结果恒定，保证放量曲线
+// 单调（percent 调高只会纳入更多桶，已命中的不会掉出）；按 key 加盐，使不同功能
+// 的分桶相互独立、不会同涨同落。
+func Bucket(key, dimID string) int {
+	h := crc32.ChecksumIEEE([]byte(key + ":" + dimID))
+	return int(h % 100)
+}

--- a/pkg/featuregate/featuregate_test.go
+++ b/pkg/featuregate/featuregate_test.go
@@ -1,0 +1,151 @@
+package featuregate
+
+import "testing"
+
+func TestEvaluate(t *testing.T) {
+	const key = "incoming_webhook_create"
+	groupScopes := []Scope{
+		{Type: ScopeTypeGroup, ID: "g_allow"},
+		{Type: ScopeTypeSpace, ID: "sp_allow"}, // space 条目当前应被忽略
+	}
+
+	tests := []struct {
+		name       string
+		rule       Rule
+		scopes     []Scope
+		dims       Dims
+		wantAllow  bool
+		wantReason string
+	}{
+		{
+			name:       "off 全拒",
+			rule:       Rule{Key: key, Mode: ModeOff},
+			dims:       Dims{GroupNo: "g_allow"},
+			wantAllow:  false,
+			wantReason: ReasonOff,
+		},
+		{
+			name:       "on 全放",
+			rule:       Rule{Key: key, Mode: ModeOn},
+			dims:       Dims{GroupNo: "whatever"},
+			wantAllow:  true,
+			wantReason: ReasonOn,
+		},
+		{
+			name:       "whitelist group 命中",
+			rule:       Rule{Key: key, Mode: ModeWhitelist},
+			scopes:     groupScopes,
+			dims:       Dims{GroupNo: "g_allow"},
+			wantAllow:  true,
+			wantReason: ReasonWhitelistHit,
+		},
+		{
+			name:       "whitelist group 未命中",
+			rule:       Rule{Key: key, Mode: ModeWhitelist},
+			scopes:     groupScopes,
+			dims:       Dims{GroupNo: "g_other"},
+			wantAllow:  false,
+			wantReason: ReasonWhitelistMiss,
+		},
+		{
+			name:       "whitelist 仅认 group：space 命中不放行",
+			rule:       Rule{Key: key, Mode: ModeWhitelist},
+			scopes:     groupScopes,
+			dims:       Dims{SpaceID: "sp_allow", GroupNo: "g_other"},
+			wantAllow:  false,
+			wantReason: ReasonWhitelistMiss,
+		},
+		{
+			name:       "whitelist 空 GroupNo 不匹配任何条目",
+			rule:       Rule{Key: key, Mode: ModeWhitelist},
+			scopes:     groupScopes,
+			dims:       Dims{GroupNo: ""},
+			wantAllow:  false,
+			wantReason: ReasonWhitelistMiss,
+		},
+		{
+			name:       "percent=0 全拒",
+			rule:       Rule{Key: key, Mode: ModePercent, Percent: 0},
+			dims:       Dims{GroupNo: "g_allow"},
+			wantAllow:  false,
+			wantReason: ReasonPercentOut,
+		},
+		{
+			name:       "percent=100 全放",
+			rule:       Rule{Key: key, Mode: ModePercent, Percent: 100},
+			dims:       Dims{GroupNo: "g_allow"},
+			wantAllow:  true,
+			wantReason: ReasonPercentIn,
+		},
+		{
+			name:       "未知 mode 保守拒绝",
+			rule:       Rule{Key: key, Mode: Mode("bogus")},
+			dims:       Dims{GroupNo: "g_allow"},
+			wantAllow:  false,
+			wantReason: ReasonUnknownMode,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Evaluate(tt.rule, tt.scopes, tt.dims)
+			if got.Allow != tt.wantAllow || got.Reason != tt.wantReason {
+				t.Fatalf("Evaluate() = {Allow:%v Reason:%q}, want {Allow:%v Reason:%q}",
+					got.Allow, got.Reason, tt.wantAllow, tt.wantReason)
+			}
+		})
+	}
+}
+
+// TestEvaluatePercentBoundary 用实际分桶值验证 percent 边界：阈值恰等于桶值时
+// 不命中（Bucket < percent 为严格小于），阈值比桶值大 1 时命中。无需 hardcode
+// 具体桶值，保证测试不随 hash 实现细节脆裂。
+func TestEvaluatePercentBoundary(t *testing.T) {
+	const key = "incoming_webhook_create"
+	const group = "g_boundary"
+	b := Bucket(key, group)
+
+	if b > 0 {
+		atThreshold := Evaluate(Rule{Key: key, Mode: ModePercent, Percent: b}, nil, Dims{GroupNo: group})
+		if atThreshold.Allow {
+			t.Fatalf("percent=bucket(%d) 应不命中（严格小于），却放行了", b)
+		}
+	}
+	if b < 100 {
+		aboveThreshold := Evaluate(Rule{Key: key, Mode: ModePercent, Percent: b + 1}, nil, Dims{GroupNo: group})
+		if !aboveThreshold.Allow {
+			t.Fatalf("percent=bucket+1(%d) 应命中，却被拒绝", b+1)
+		}
+	}
+}
+
+// TestBucketStable 验证分桶稳定（同入参恒定）且落在 [0,100)。
+func TestBucketStable(t *testing.T) {
+	cases := []struct{ key, id string }{
+		{"incoming_webhook_create", "g_1"},
+		{"incoming_webhook_create", "g_2"},
+		{"another_feature", "g_1"},
+		{"k", ""},
+	}
+	for _, c := range cases {
+		first := Bucket(c.key, c.id)
+		if first < 0 || first >= 100 {
+			t.Fatalf("Bucket(%q,%q)=%d 超出 [0,100)", c.key, c.id, first)
+		}
+		for i := 0; i < 5; i++ {
+			if again := Bucket(c.key, c.id); again != first {
+				t.Fatalf("Bucket(%q,%q) 不稳定：%d != %d", c.key, c.id, again, first)
+			}
+		}
+	}
+
+	// 不同 key 对同一 id 应相互独立（加盐生效）：用一个已知会分到不同桶的样本，
+	// 避免「所有 key 同桶」这种退化实现悄悄通过。
+	if Bucket("incoming_webhook_create", "g_1") == Bucket("incoming_webhook_create_x", "g_1") {
+		// 极小概率自然相等，不直接失败，仅提示；改用第二组样本兜底。
+		if Bucket("feature_a", "same") == Bucket("feature_b", "same") &&
+			Bucket("feature_c", "same") == Bucket("feature_d", "same") {
+			t.Fatalf("不同 key 的分桶高度疑似未加盐（多组样本均相等）")
+		}
+	}
+}

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -666,6 +666,14 @@ other = "请求内容过大。"
 ["err.server.incomingwebhook.push_delivery_failed"]
 other = "Webhook 消息投递失败。"
 
+# ---- 灰度闸门 (feature gate, webhook-feature-flag-rollout) ----
+
+["err.server.incomingwebhook.push_disabled"]
+other = "服务暂不可用，请稍后重试。"
+
+["err.server.incomingwebhook.create_gate_denied"]
+other = "灰度未对该群开放此功能。"
+
 # ---- err.server.incomingwebhook.mgmt_* (management endpoints, #246 follow-up) ----
 
 ["err.server.incomingwebhook.mgmt_forbidden"]

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -688,3 +688,17 @@ other = "查询 webhook 信息失败。"
 
 ["err.server.incomingwebhook.mgmt_operation_failed"]
 other = "操作失败，请稍后再试。"
+
+# ---- err.server.featuregate.* (modules/featuregate 管理端点) ----
+
+["err.server.featuregate.request_invalid"]
+other = "请求参数无效。"
+
+["err.server.featuregate.not_found"]
+other = "灰度白名单条目不存在。"
+
+["err.server.featuregate.query_failed"]
+other = "查询灰度配置失败。"
+
+["err.server.featuregate.operation_failed"]
+other = "操作失败，请稍后再试。"


### PR DESCRIPTION
## Summary

Adds a reusable **feature-gate framework** and uses it to put group **incoming webhooks** behind gradual-rollout / instant-rollback controls.

Incoming webhooks (#31) broadcast pushed messages to every group member regardless of client version, so the feature can't be rolled out per client version — only at write time (who may create) plus a push-side total kill for rollback. This PR adds that control surface, generic enough for future features to reuse.

## Commit 1 — generic feature gate (`pkg/featuregate` + `modules/featuregate`)

- Pure `Evaluate` (off / on / whitelist / percent) with crc32 stable bucketing; zero IO, table-driven tests.
- DB-truth `Service` with a Redis read-cache (DEL-on-write invalidation → second-level multi-instance consistency), env kill switch `DM_FT_<KEY>_KILL`, and asymmetric helpers `AllowCreate` (fail-closed) / `AllowPush` (fail-open). The fail policy is **fixed per side, not a per-rule knob**, so it can't be misconfigured into data exposure (create) or push interruption (push).
- Two tables (`feature_gate` rule + `feature_gate_scope` whitelist) via migration; superadmin endpoints under `/v1/manager/featuregate`.

## Commit 2 — gate incoming webhooks

- `create`: fail-closed gate (group whitelist / percent) evaluated after the group checks, where space_id / group_no / uid are all available.
- `push`: fail-open total switch placed as the **very first statement** in the handler — on shutdown every request gets a uniform `503 + Retry-After` without touching the DB and without leaking token validity (preserves the existing push anti-probe invariant: every failure collapses to one response).
- **Seed migration** sets `incoming_webhook_create/push = on` so existing deployments keep working after upgrade (create is fail-closed on a missing rule; without the seed an upgrade would turn every create into 403). Idempotent — `ON DUPLICATE` no-op, never overwrites an operator-set rule.

## Rollout / rollback path

- **Dark launch**: dormant until rules exist (or seeded `on` to preserve current behavior).
- **Dogfooding**: `create` → `whitelist` + add group scopes.
- **Ramp**: `create` → `percent`, raise gradually (5 → 20 → 50).
- **Full**: `create` → `on`.
- **Rollback**: `create` / `push` → `off` (second-level, all instances); last resort `DM_FT_INCOMING_WEBHOOK_PUSH_KILL=1` (independent of DB/Redis).

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test -race ./pkg/featuregate/...` — Evaluate / bucketing boundaries
- [x] `go test -race ./modules/featuregate/...` — cache hit/invalidation, kill switch, fail semantics, superadmin perms, scope add/remove, long-key rejection
- [x] `go test -race ./modules/incomingwebhook/...` — every gate state incl. anti-probe assertion; existing create/push suites still green
