### PR TITLE
feat(avatar): version avatar object keys for CDN-safe cache busting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	firebase.google.com/go/v4 v4.13.0
 	github.com/BurntSushi/toml v1.6.0
 	github.com/DATA-DOG/go-sqlmock v1.5.0
-	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260602143311-8c26a826e07b
+	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260605071834-330ed3ce7e6a
 	github.com/alibabacloud-go/darabonba-openapi v0.2.1
 	github.com/alibabacloud-go/sms-intl-20180501 v1.0.1
 	github.com/alibabacloud-go/tea v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260602143311-8c26a826e07b h1:twl6DmiVGPv8C7+XFAht9xGIZjetJ6ofW9iujZrDXQI=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260602143311-8c26a826e07b/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260605071834-330ed3ce7e6a h1:nC17gAXfODuv8zu0NLj7KfceLGV0dCq94prfhgknZ4g=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260605071834-330ed3ce7e6a/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae h1:DcFpTQBYQ9Ct2d6sC7ol0/ynxc2pO1cpGUM+f4t5adg=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae/go.mod h1:rJJ84PyA/Wlmw1hO+xTzV2wsSUon6J5ktg0g8BF2PuU=
 github.com/RichardKnop/machinery/v2 v2.0.11 h1:BTfLGOmOju3W/OtlZmLX26OjYNZsU4PJo04pQReycdc=

--- a/modules/base/event/avatar_db_test.go
+++ b/modules/base/event/avatar_db_test.go
@@ -1,21 +1,23 @@
 package event
 
 import (
+	"database/sql"
+	"fmt"
 	"testing"
+	"time"
 
-	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/stretchr/testify/require"
+
+	_ "github.com/go-sql-driver/mysql"
 )
 
 // TestUpdateGeneratedGroupAvatarProtectsManualUpload 验证自动群头像合成的并发保护契约：
 // updateGeneratedGroupAvatar 带 WHERE is_upload_avatar=0，只在群头像仍为自动管理时写入
 // 合成结果；一旦群主手动上传（is_upload_avatar=1），后到的旧合成事件必须被挡掉、不得覆盖
 // 手动头像。这是本次改动最关键的正确性保证。
-//
-// event 包测试二进制不 link group module 的 migration，这里手动建最小 group 表（真实表的
-// 列子集，覆盖 queryGroupAvatarState / updateGeneratedGroupAvatar 用到的全部列）。
 func TestUpdateGeneratedGroupAvatarProtectsManualUpload(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	ctx := newIsolatedAvatarEventTestContext(t)
 	db := NewDB(ctx.DB())
 
 	_, err := ctx.DB().UpdateBySql("CREATE TABLE IF NOT EXISTS `group` (" +
@@ -67,4 +69,27 @@ func TestUpdateGeneratedGroupAvatarProtectsManualUpload(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, manualPath, got.Avatar)
 	require.Equal(t, manualVersion, got.AvatarVersion)
+}
+
+// Keep this test's hand-built `group` table out of the shared test schema so it
+// cannot poison package-level migrations in later go test invocations.
+func newIsolatedAvatarEventTestContext(t *testing.T) *config.Context {
+	t.Helper()
+
+	adminDB, err := sql.Open("mysql", "root:demo@tcp(127.0.0.1)/?charset=utf8mb4&parseTime=true")
+	require.NoError(t, err)
+
+	dbName := fmt.Sprintf("test_event_avatar_%d", time.Now().UnixNano())
+	_, err = adminDB.Exec("CREATE DATABASE `" + dbName + "` CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = adminDB.Exec("DROP DATABASE IF EXISTS `" + dbName + "`")
+		_ = adminDB.Close()
+	})
+
+	cfg := config.New()
+	cfg.Test = true
+	cfg.DB.Migration = false
+	cfg.DB.MySQLAddr = fmt.Sprintf("root:demo@tcp(127.0.0.1)/%s?charset=utf8mb4&parseTime=true", dbName)
+	return config.NewContext(cfg)
 }

--- a/modules/base/event/avatar_db_test.go
+++ b/modules/base/event/avatar_db_test.go
@@ -1,0 +1,70 @@
+package event
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateGeneratedGroupAvatarProtectsManualUpload 验证自动群头像合成的并发保护契约：
+// updateGeneratedGroupAvatar 带 WHERE is_upload_avatar=0，只在群头像仍为自动管理时写入
+// 合成结果；一旦群主手动上传（is_upload_avatar=1），后到的旧合成事件必须被挡掉、不得覆盖
+// 手动头像。这是本次改动最关键的正确性保证。
+//
+// event 包测试二进制不 link group module 的 migration，这里手动建最小 group 表（真实表的
+// 列子集，覆盖 queryGroupAvatarState / updateGeneratedGroupAvatar 用到的全部列）。
+func TestUpdateGeneratedGroupAvatarProtectsManualUpload(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	db := NewDB(ctx.DB())
+
+	_, err := ctx.DB().UpdateBySql("CREATE TABLE IF NOT EXISTS `group` (" +
+		"`group_no` varchar(40) NOT NULL," +
+		"`avatar` varchar(255) NOT NULL DEFAULT ''," +
+		"`avatar_version` bigint NOT NULL DEFAULT 0," +
+		"`is_upload_avatar` smallint NOT NULL DEFAULT 0," +
+		"PRIMARY KEY (`group_no`)" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4").Exec()
+	require.NoError(t, err)
+	_, err = ctx.DB().DeleteBySql("DELETE FROM `group`").Exec()
+	require.NoError(t, err)
+
+	const groupNo = "G_auto_avatar_1"
+	_, err = ctx.DB().InsertBySql("INSERT INTO `group` (`group_no`, `is_upload_avatar`) VALUES (?, 0)", groupNo).Exec()
+	require.NoError(t, err)
+
+	// 自动管理状态：合成事件可写入版本化头像。
+	state, err := db.queryGroupAvatarState(groupNo)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	require.Equal(t, 0, state.IsUploadAvatar)
+
+	const autoVersion int64 = 1733300000000000010
+	const autoPath = "group/1/G_auto_avatar_1/1733300000000000010.png"
+	updated, err := db.updateGeneratedGroupAvatar(groupNo, autoPath, autoVersion)
+	require.NoError(t, err)
+	require.True(t, updated, "auto-managed avatar should be composable")
+
+	// 群主手动上传后置 is_upload_avatar=1，并写入手动头像版本。
+	const manualPath = "group/1/G_auto_avatar_1/1733300000000000020.png"
+	const manualVersion int64 = 1733300000000000020
+	_, err = ctx.DB().UpdateBySql(
+		"UPDATE `group` SET `is_upload_avatar`=1, `avatar`=?, `avatar_version`=? WHERE `group_no`=?",
+		manualPath, manualVersion, groupNo).Exec()
+	require.NoError(t, err)
+
+	// 旧的合成事件再次尝试写入：必须被 WHERE is_upload_avatar=0 挡掉。
+	stale, err := db.updateGeneratedGroupAvatar(groupNo, "group/1/G_auto_avatar_1/1733300000000000030.png", 1733300000000000030)
+	require.NoError(t, err)
+	require.False(t, stale, "manual avatar must not be overwritten by a stale compose event")
+
+	// 校验手动头像保持不变。
+	var got struct {
+		Avatar        string `db:"avatar"`
+		AvatarVersion int64  `db:"avatar_version"`
+	}
+	_, err = ctx.DB().Select("avatar", "avatar_version").From("`group`").Where("group_no=?", groupNo).Load(&got)
+	require.NoError(t, err)
+	require.Equal(t, manualPath, got.Avatar)
+	require.Equal(t, manualVersion, got.AvatarVersion)
+}

--- a/modules/base/event/avatar_test.go
+++ b/modules/base/event/avatar_test.go
@@ -1,0 +1,31 @@
+package event
+
+import "testing"
+
+func TestShouldComposeGroupAvatar(t *testing.T) {
+	tests := []struct {
+		name           string
+		isUploadAvatar int
+		want           bool
+	}{
+		{
+			name:           "manual group avatar should not be overwritten",
+			isUploadAvatar: 1,
+			want:           false,
+		},
+		{
+			name:           "auto-managed group avatar can be recomposed",
+			isUploadAvatar: 0,
+			want:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldComposeGroupAvatar(tt.isUploadAvatar)
+			if got != tt.want {
+				t.Fatalf("shouldComposeGroupAvatar(%d) = %v, want %v", tt.isUploadAvatar, got, tt.want)
+			}
+		})
+	}
+}

--- a/modules/base/event/db.go
+++ b/modules/base/event/db.go
@@ -50,6 +50,31 @@ func (d *DB) QueryAllWait(limit uint64) ([]*Model, error) {
 	return models, err
 }
 
+type groupAvatarState struct {
+	IsUploadAvatar int
+}
+
+func (d *DB) queryGroupAvatarState(groupNo string) (*groupAvatarState, error) {
+	var state *groupAvatarState
+	_, err := d.session.Select("is_upload_avatar").From("`group`").Where("group_no=?", groupNo).Load(&state)
+	return state, err
+}
+
+func (d *DB) updateGeneratedGroupAvatar(groupNo string, avatar string, avatarVersion int64) (bool, error) {
+	result, err := d.session.Update("group").SetMap(map[string]interface{}{
+		"avatar":         avatar,
+		"avatar_version": avatarVersion,
+	}).Where("group_no=? and is_upload_avatar=0", groupNo).Exec()
+	if err != nil {
+		return false, err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
+}
+
 // ---------- model ----------
 
 // Model 数据库对象

--- a/modules/base/event/handler.go
+++ b/modules/base/event/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/pool"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-server/pkg/avatarversion"
 	"go.uber.org/zap"
 )
 
@@ -188,7 +189,7 @@ func (e *Event) handleGroupAvatarUpdateEvent(model *Model) {
 				}
 				downloadURLs = append(downloadURLs, fmt.Sprintf("%s/users/%s/avatar?v=%d", e.ctx.GetConfig().External.APIBaseURL, member, time.Now().UnixNano()))
 			}
-			avatarVersion := time.Now().UnixNano()
+			avatarVersion := avatarversion.New()
 			uploadPath := e.ctx.GetConfig().GetGroupAvatarFilePath(req.GroupNo, avatarVersion)
 			_, err = e.fileService.DownloadAndMakeCompose(uploadPath, downloadURLs)
 			if err != nil {

--- a/modules/base/event/handler.go
+++ b/modules/base/event/handler.go
@@ -171,6 +171,15 @@ func (e *Event) handleGroupAvatarUpdateEvent(model *Model) {
 				e.Error("解析JSON失败！", zap.Error(err), zap.String("data", model.Data))
 				return
 			}
+			state, err := e.db.queryGroupAvatarState(req.GroupNo)
+			if err != nil {
+				e.Error("查询群头像状态失败！", zap.String("groupNo", req.GroupNo), zap.Error(err))
+				return
+			}
+			if state == nil || !shouldComposeGroupAvatar(state.IsUploadAvatar) {
+				e.updateEventStatus(nil, model.VersionLock, model.Id)
+				return
+			}
 			// 组合群头像
 			downloadURLs := make([]string, 0)
 			for _, member := range req.Members {
@@ -179,10 +188,20 @@ func (e *Event) handleGroupAvatarUpdateEvent(model *Model) {
 				}
 				downloadURLs = append(downloadURLs, fmt.Sprintf("%s/users/%s/avatar?v=%d", e.ctx.GetConfig().External.APIBaseURL, member, time.Now().UnixNano()))
 			}
-			uploadPath := e.ctx.GetConfig().GetGroupAvatarFilePath(req.GroupNo)
+			avatarVersion := time.Now().UnixNano()
+			uploadPath := e.ctx.GetConfig().GetGroupAvatarFilePath(req.GroupNo, avatarVersion)
 			_, err = e.fileService.DownloadAndMakeCompose(uploadPath, downloadURLs)
 			if err != nil {
 				e.Error("组合群头像失败！", zap.String("groupNo", req.GroupNo), zap.Any("members", req.Members), zap.Error(err))
+				return
+			}
+			updated, err := e.db.updateGeneratedGroupAvatar(req.GroupNo, uploadPath, avatarVersion)
+			if err != nil {
+				e.Error("更新合成群头像版本失败！", zap.String("groupNo", req.GroupNo), zap.String("avatar", uploadPath), zap.Error(err))
+				return
+			}
+			if !updated {
+				e.updateEventStatus(nil, model.VersionLock, model.Id)
 				return
 			}
 			// 发送群头像更新命令
@@ -201,6 +220,10 @@ func (e *Event) handleGroupAvatarUpdateEvent(model *Model) {
 			e.updateEventStatus(err, model.VersionLock, model.Id)
 		},
 	}
+}
+
+func shouldComposeGroupAvatar(isUploadAvatar int) bool {
+	return isUploadAvatar != 1
 }
 
 // 群成员扫码加入

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -483,7 +483,9 @@ func (g *Group) avatarUpload(c *wkhttp.Context) {
 	})
 	if err != nil {
 		g.Error("发送群头像更新命令失败！", zap.String("groupNo", groupNo), zap.Error(err))
-		httperr.ResponseErrorL(c, errcode.ErrGroupNotifyFailed, nil, nil)
+		// The avatar object and DB version are already committed; the IM
+		// notification is best-effort so clients do not retry a successful upload.
+		c.ResponseOK()
 		return
 	}
 	c.ResponseOK()

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -29,6 +29,7 @@ import (
 	spacemod "github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
+	"github.com/Mininglamp-OSS/octo-server/pkg/avatarversion"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
@@ -454,7 +455,7 @@ func (g *Group) avatarUpload(c *wkhttp.Context) {
 		return
 	}
 
-	avatarVersion := time.Now().UnixNano()
+	avatarVersion := avatarversion.New()
 	groupAvatarPath := g.ctx.GetConfig().GetGroupAvatarFilePath(groupNo, avatarVersion)
 	_, err = g.fileService.UploadFile(groupAvatarPath, "image/png", "", func(w io.Writer) error {
 		_, err := io.Copy(w, file)

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -388,7 +388,17 @@ func (g *Group) avatarGet(c *wkhttp.Context) {
 		c.Writer.Write(avatarBytes)
 		return
 	}
-	path := g.ctx.GetConfig().GetGroupAvatarFilePath(groupNo)
+	var avatarVersion int64
+	groupInfo, err := g.db.QueryWithGroupNo(groupNo)
+	if err != nil {
+		g.Error("查询群资料错误", zap.String("group_no", groupNo), zap.Error(err))
+		c.Writer.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if groupInfo != nil {
+		avatarVersion = groupInfo.AvatarVersion
+	}
+	path := g.ctx.GetConfig().GetGroupAvatarFilePath(groupNo, avatarVersion)
 	downloadUrl, err := g.fileService.DownloadURL(path, "")
 	if err != nil {
 		g.Error("获取下载路径失败！", zap.Error(err))
@@ -444,7 +454,8 @@ func (g *Group) avatarUpload(c *wkhttp.Context) {
 		return
 	}
 
-	groupAvatarPath := g.ctx.GetConfig().GetGroupAvatarFilePath(groupNo)
+	avatarVersion := time.Now().UnixNano()
+	groupAvatarPath := g.ctx.GetConfig().GetGroupAvatarFilePath(groupNo, avatarVersion)
 	_, err = g.fileService.UploadFile(groupAvatarPath, "image/png", "", func(w io.Writer) error {
 		_, err := io.Copy(w, file)
 		return err
@@ -454,7 +465,7 @@ func (g *Group) avatarUpload(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrGroupStoreFailed, nil, nil)
 		return
 	}
-	err = g.db.updateAvatar(groupAvatarPath, groupNo)
+	err = g.db.updateAvatar(groupAvatarPath, avatarVersion, groupNo)
 	if err != nil {
 		g.Error("头像修改失败！", zap.String("group_no", groupNo), zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrGroupStoreFailed, nil, nil)

--- a/modules/group/api_i18n_regression_test.go
+++ b/modules/group/api_i18n_regression_test.go
@@ -2,10 +2,14 @@ package group
 
 import (
 	"bytes"
+	"context"
+	"errors"
+	"io"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
@@ -13,6 +17,43 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/stretchr/testify/assert"
 )
+
+type mockAvatarUploadFileService struct {
+	uploadedPath string
+}
+
+func (m *mockAvatarUploadFileService) UploadFile(filePath string, contentType string, contentDisposition string, copyFileWriter func(io.Writer) error) (map[string]interface{}, error) {
+	m.uploadedPath = filePath
+	var buf bytes.Buffer
+	if err := copyFileWriter(&buf); err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{"path": filePath}, nil
+}
+
+func (m *mockAvatarUploadFileService) DownloadURL(path string, filename string) (string, error) {
+	return "", errors.New("unused")
+}
+
+func (m *mockAvatarUploadFileService) GetFile(path string) (io.ReadCloser, string, error) {
+	return nil, "", errors.New("unused")
+}
+
+func (m *mockAvatarUploadFileService) DownloadAndMakeCompose(uploadPath string, downloadURLs []string) (map[string]interface{}, error) {
+	return nil, errors.New("unused")
+}
+
+func (m *mockAvatarUploadFileService) DownloadImage(url string, ctx context.Context) (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(nil)), nil
+}
+
+func (m *mockAvatarUploadFileService) PresignedPutURL(objectPath string, contentType string, contentDisposition string, fileSize int64, expires time.Duration) (string, string, error) {
+	return "", "", errors.New("unused")
+}
+
+func (m *mockAvatarUploadFileService) PresignedGetURL(objectPath string, filename string, disposition string, expires time.Duration) (string, error) {
+	return "", errors.New("unused")
+}
 
 // putGroupSetting issues a PUT /setting with the given JSON body using the test
 // caller's token.
@@ -196,4 +237,65 @@ func TestGroupAvatarUpload_MissingFileIsRequestInvalid(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code, "wire status 固定 400, body=%s", w.Body.String())
 	assert.Contains(t, w.Body.String(), "err.server.group.request_invalid",
 		"缺少上传文件应是 400 校验错误而非内部错误, body=%s", w.Body.String())
+}
+
+// TestGroupAvatarUpload_PostCommitNotifyFailureRespondsOK pins the committed
+// upload contract: after object storage and DB update succeed, the IM
+// notification is best-effort and must not make the client retry the upload.
+func TestGroupAvatarUpload_PostCommitNotifyFailureRespondsOK(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	err := testutil.CleanAllTables(ctx)
+	assert.NoError(t, err)
+
+	im := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "send failed", http.StatusInternalServerError)
+	}))
+	defer im.Close()
+	ctx.GetConfig().WuKongIM.APIURL = im.URL
+
+	f := New(ctx)
+	mockFS := &mockAvatarUploadFileService{}
+	f.fileService = mockFS
+
+	err = f.userDB.Insert(&user.Model{UID: testutil.UID, Name: "user-c", ShortNo: "uc_avatar"})
+	assert.NoError(t, err)
+	err = f.db.Insert(&Model{
+		GroupNo: "g-avatar-notify",
+		Name:    "avatar notify",
+		Creator: testutil.UID,
+		Status:  GroupStatusNormal,
+		Version: 1,
+	})
+	assert.NoError(t, err)
+	err = f.db.InsertMember(&MemberModel{
+		GroupNo: "g-avatar-notify",
+		UID:     testutil.UID,
+		Role:    MemberRoleCreator,
+		Status:  1,
+		Version: 1,
+		Vercode: "avatar-notify@1",
+	})
+	assert.NoError(t, err)
+
+	r := wkhttp.New()
+	r.POST("/v1/groups/:group_no/avatar", ctx.AuthMiddleware(r), f.avatarUpload)
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile("file", "avatar.png")
+	assert.NoError(t, err)
+	_, err = fw.Write([]byte("png"))
+	assert.NoError(t, err)
+	assert.NoError(t, mw.Close())
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("POST", "/v1/groups/g-avatar-notify/avatar", &buf)
+	assert.NoError(t, err)
+	req.Header.Set("token", testutil.Token)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "post-commit notify failure should not fail committed upload, body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), `"status":200`)
+	assert.NotEmpty(t, mockFS.uploadedPath)
 }

--- a/modules/group/avatar_path_test.go
+++ b/modules/group/avatar_path_test.go
@@ -1,0 +1,47 @@
+package group
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+)
+
+func TestGroupAvatarFilePathUsesVersionAwareOctoLibHelper(t *testing.T) {
+	cfg := config.New()
+	cfg.Avatar.Partition = 100
+
+	tests := []struct {
+		name    string
+		groupNo string
+		version int64
+		want    string
+	}{
+		{
+			name:    "legacy path when version is zero",
+			groupNo: "G_avatar_cache",
+			version: 0,
+			want:    "group/1/G_avatar_cache.png",
+		},
+		{
+			name:    "legacy path when version is negative",
+			groupNo: "G_avatar_cache",
+			version: -1,
+			want:    "group/1/G_avatar_cache.png",
+		},
+		{
+			name:    "versioned path when version is positive",
+			groupNo: "G_avatar_cache",
+			version: 1700000000000000001,
+			want:    "group/1/G_avatar_cache/1700000000000000001.png",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cfg.GetGroupAvatarFilePath(tt.groupNo, tt.version)
+			if got != tt.want {
+				t.Fatalf("GetGroupAvatarFilePath(%q, %d) = %q, want %q", tt.groupNo, tt.version, got, tt.want)
+			}
+		})
+	}
+}

--- a/modules/group/avatar_version_test.go
+++ b/modules/group/avatar_version_test.go
@@ -1,0 +1,45 @@
+package group
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGroupAvatarVersionDBRoundTrip 覆盖群主手动上传头像的落库路径：
+// updateAvatar 必须写入版本化对象 path、版本号，并把 is_upload_avatar 置 1
+// （后者是阻止旧的自动合成事件覆盖手动头像的关键标志）。QueryWithGroupNo
+// 读回这些字段，avatarGet 据此选择 versioned/legacy path。
+func TestGroupAvatarVersionDBRoundTrip(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	g := New(ctx)
+
+	const groupNo = "avatar_ver_group_1"
+	require.NoError(t, g.db.Insert(&Model{
+		GroupNo: groupNo,
+		Name:    "avatar group",
+		Creator: "creator_uid_1",
+		Status:  1,
+	}))
+
+	// 上传前：自动合成允许（is_upload_avatar=0），版本为 0。
+	before, err := g.db.QueryWithGroupNo(groupNo)
+	require.NoError(t, err)
+	require.NotNil(t, before)
+	require.Equal(t, 0, before.IsUploadAvatar)
+	require.Equal(t, int64(0), before.AvatarVersion)
+
+	// 群主手动上传：写版本化 path + 版本号 + is_upload_avatar=1。
+	const version int64 = 1733300000000000002
+	avatarPath := ctx.GetConfig().GetGroupAvatarFilePath(groupNo, version)
+	require.NoError(t, g.db.updateAvatar(avatarPath, version, groupNo))
+
+	after, err := g.db.QueryWithGroupNo(groupNo)
+	require.NoError(t, err)
+	require.NotNil(t, after)
+	require.Equal(t, 1, after.IsUploadAvatar)
+	require.Equal(t, version, after.AvatarVersion)
+	require.Equal(t, avatarPath, after.Avatar)
+}

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -302,9 +302,10 @@ func (d *DB) Update(model *Model) error {
 	return err
 }
 
-func (d *DB) updateAvatar(avatar string, groupNo string) error {
+func (d *DB) updateAvatar(avatar string, avatarVersion int64, groupNo string) error {
 	_, err := d.session.Update("group").SetMap(map[string]interface{}{
 		"avatar":           avatar,
+		"avatar_version":   avatarVersion,
 		"is_upload_avatar": 1,
 	}).Where("group_no=?", groupNo).Exec()
 	return err
@@ -557,6 +558,8 @@ type Model struct {
 	GroupType                int        // 群类型 0.普通群 1.超大群
 	Name                     string     // 群名称
 	Avatar                   string     // 群头像
+	AvatarVersion            int64      // 群头像对象版本，0 表示旧版稳定路径
+	IsUploadAvatar           int        // 群头像是否已经被用户上传
 	Notice                   string     // 群公告
 	Creator                  string     // 创建者uid
 	Status                   int        // 群状态

--- a/modules/group/sql/20260605000002_group_avatar_version.sql
+++ b/modules/group/sql/20260605000002_group_avatar_version.sql
@@ -44,4 +44,3 @@ CALL __group_avatar_version_down();
 -- +migrate StatementBegin
 DROP PROCEDURE IF EXISTS __group_avatar_version_down;
 -- +migrate StatementEnd
-

--- a/modules/group/sql/20260605000002_group_avatar_version.sql
+++ b/modules/group/sql/20260605000002_group_avatar_version.sql
@@ -1,0 +1,47 @@
+-- +migrate Up
+-- 群头像对象版本。0 表示沿用旧版稳定对象 key，正数写入对象 path 用于 CDN-safe cache busting。
+-- 使用 INFORMATION_SCHEMA 守卫保证迁移在部分执行后重试时仍可重入。
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_avatar_version;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __group_avatar_version()
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND COLUMN_NAME = 'avatar_version') THEN
+    ALTER TABLE `group`
+      ADD COLUMN `avatar_version` BIGINT NOT NULL DEFAULT 0 COMMENT '群头像对象版本，0 表示旧版稳定路径';
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __group_avatar_version();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_avatar_version;
+-- +migrate StatementEnd
+
+-- +migrate Down
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_avatar_version_down;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __group_avatar_version_down()
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND COLUMN_NAME = 'avatar_version') THEN
+    ALTER TABLE `group` DROP COLUMN `avatar_version`;
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __group_avatar_version_down();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_avatar_version_down;
+-- +migrate StatementEnd
+

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -514,8 +514,7 @@ func (u *User) UserAvatar(c *wkhttp.Context) {
 	ph := ""
 	downloadUrl := ""
 	if userInfo.IsUploadAvatar == 1 {
-		avatarID := crc32.ChecksumIEEE([]byte(uid)) % uint32(u.ctx.GetConfig().Avatar.Partition)
-		ph = fmt.Sprintf("/avatar/%d/%s.png", avatarID, uid)
+		ph = userAvatarFilePath(uid, u.ctx.GetConfig().Avatar.Partition, userInfo.AvatarVersion)
 	} else {
 		// 配置使用本地默认头像
 		if u.ctx.GetConfig().Avatar.Default != "" && strings.TrimSpace(u.ctx.GetConfig().Avatar.DefaultBaseURL) == "" {
@@ -635,8 +634,9 @@ func (u *User) uploadAvatar(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserFileOperationFailed)
 		return
 	}
-	avatarID := crc32.ChecksumIEEE([]byte(targetUID)) % uint32(u.ctx.GetConfig().Avatar.Partition)
-	_, err = u.fileService.UploadFile(fmt.Sprintf("avatar/%d/%s.png", avatarID, targetUID), "image/png", "", func(w io.Writer) error {
+	avatarVersion := time.Now().UnixNano()
+	avatarPath := userAvatarFilePath(targetUID, u.ctx.GetConfig().Avatar.Partition, avatarVersion)
+	_, err = u.fileService.UploadFile(avatarPath, "image/png", "", func(w io.Writer) error {
 		_, err := io.Copy(w, file)
 		return err
 	})
@@ -644,6 +644,13 @@ func (u *User) uploadAvatar(c *wkhttp.Context) {
 	if err != nil {
 		u.Error("上传文件失败！", zap.Error(err))
 		respondUserError(c, errcode.ErrUserFileOperationFailed)
+		return
+	}
+	// 更改用户上传头像状态和服务端版本；CMD 在 DB 成功后再发送，避免客户端收到通知后仍读到旧 path。
+	err = u.db.UpdateAvatarUploadStatus(targetUID, avatarVersion)
+	if err != nil {
+		u.Error("修改用户头像版本错误！", zap.Error(err))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
 	friends, err := u.friendDB.QueryFriends(targetUID)
@@ -668,13 +675,6 @@ func (u *User) uploadAvatar(c *wkhttp.Context) {
 			u.Error("发送个人头像更新命令失败！")
 			return
 		}
-	}
-	//更改用户上传头像状态
-	err = u.db.UpdateUsersWithField("is_upload_avatar", "1", targetUID)
-	if err != nil {
-		u.Error("修改用户是否修改头像错误！", zap.Error(err))
-		respondUserError(c, errcode.ErrUserStoreFailed)
-		return
 	}
 	c.ResponseOK()
 }
@@ -1324,8 +1324,8 @@ func (u *User) wxLogin(c *wkhttp.Context) {
 			imgReader, _ := u.fileService.DownloadImage(headimgurl, timeoutCtx)
 			cancel()
 			if imgReader != nil {
-				avatarID := crc32.ChecksumIEEE([]byte(uid)) % uint32(u.ctx.GetConfig().Avatar.Partition)
-				_, err = u.fileService.UploadFile(fmt.Sprintf("avatar/%d/%s.png", avatarID, uid), "image/png", "", func(w io.Writer) error {
+				avatarVersion := time.Now().UnixNano()
+				_, err = u.fileService.UploadFile(userAvatarFilePath(uid, u.ctx.GetConfig().Avatar.Partition, avatarVersion), "image/png", "", func(w io.Writer) error {
 					_, err := io.Copy(w, imgReader)
 					return err
 				})
@@ -1335,6 +1335,7 @@ func (u *User) wxLogin(c *wkhttp.Context) {
 					// c.ResponseError(errors.New("上传文件失败！"))
 					// return
 					model.IsUploadAvatar = 1
+					model.AvatarVersion = avatarVersion
 				}
 			}
 		}
@@ -3409,6 +3410,7 @@ func (u *User) createUserWithRespAndTx(registerSpanCtx context.Context, createUs
 	userModel.VoiceOn = 1
 	userModel.ShockOn = 1
 	userModel.IsUploadAvatar = createUser.IsUploadAvatar
+	userModel.AvatarVersion = createUser.AvatarVersion
 	userModel.WXOpenid = createUser.WXOpenid
 	userModel.WXUnionid = createUser.WXUnionid
 	userModel.GiteeUID = createUser.GiteeUID
@@ -3535,6 +3537,7 @@ type createUserModel struct {
 	Username       string
 	Flag           int
 	IsUploadAvatar int
+	AvatarVersion  int64
 	Device         *deviceReq
 }
 

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/model"
 	"github.com/Mininglamp-OSS/octo-server/modules/file"
 	"github.com/Mininglamp-OSS/octo-server/modules/source"
+	"github.com/Mininglamp-OSS/octo-server/pkg/avatarversion"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	rd "github.com/go-redis/redis"
@@ -634,7 +635,7 @@ func (u *User) uploadAvatar(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserFileOperationFailed)
 		return
 	}
-	avatarVersion := time.Now().UnixNano()
+	avatarVersion := avatarversion.New()
 	avatarPath := userAvatarFilePath(targetUID, u.ctx.GetConfig().Avatar.Partition, avatarVersion)
 	_, err = u.fileService.UploadFile(avatarPath, "image/png", "", func(w io.Writer) error {
 		_, err := io.Copy(w, file)
@@ -655,7 +656,8 @@ func (u *User) uploadAvatar(c *wkhttp.Context) {
 	}
 	friends, err := u.friendDB.QueryFriends(targetUID)
 	if err != nil {
-		u.Error("查询用户好友失败")
+		u.Error("查询用户好友失败", zap.String("uid", targetUID), zap.Error(err))
+		c.ResponseOK()
 		return
 	}
 	if len(friends) > 0 {
@@ -672,7 +674,8 @@ func (u *User) uploadAvatar(c *wkhttp.Context) {
 			},
 		})
 		if err != nil {
-			u.Error("发送个人头像更新命令失败！")
+			u.Error("发送个人头像更新命令失败！", zap.String("uid", targetUID), zap.Error(err))
+			c.ResponseOK()
 			return
 		}
 	}
@@ -1324,7 +1327,7 @@ func (u *User) wxLogin(c *wkhttp.Context) {
 			imgReader, _ := u.fileService.DownloadImage(headimgurl, timeoutCtx)
 			cancel()
 			if imgReader != nil {
-				avatarVersion := time.Now().UnixNano()
+				avatarVersion := avatarversion.New()
 				_, err = u.fileService.UploadFile(userAvatarFilePath(uid, u.ctx.GetConfig().Avatar.Partition, avatarVersion), "image/png", "", func(w io.Writer) error {
 					_, err := io.Copy(w, imgReader)
 					return err

--- a/modules/user/api_gitee.go
+++ b/modules/user/api_gitee.go
@@ -3,7 +3,6 @@ package user
 import (
 	"context"
 	"fmt"
-	"hash/crc32"
 	"io"
 	"net/http"
 	"net/url"
@@ -185,14 +184,15 @@ func (u *User) giteeOAuth(c *wkhttp.Context) {
 			imgReader, _ := u.fileService.DownloadImage(userInfo.AvatarURL, timeoutCtx)
 			cancel()
 			if imgReader != nil {
-				avatarID := crc32.ChecksumIEEE([]byte(uid)) % uint32(u.ctx.GetConfig().Avatar.Partition)
-				_, err = u.fileService.UploadFile(fmt.Sprintf("avatar/%d/%s.png", avatarID, uid), "image/png", "", func(w io.Writer) error {
+				avatarVersion := time.Now().UnixNano()
+				_, err = u.fileService.UploadFile(userAvatarFilePath(uid, u.ctx.GetConfig().Avatar.Partition, avatarVersion), "image/png", "", func(w io.Writer) error {
 					_, err := io.Copy(w, imgReader)
 					return err
 				})
 				defer imgReader.Close()
 				if err == nil {
 					model.IsUploadAvatar = 1
+					model.AvatarVersion = avatarVersion
 				}
 			}
 		}

--- a/modules/user/api_gitee.go
+++ b/modules/user/api_gitee.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	common "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/avatarversion"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/gin-gonic/gin"
 	"github.com/opentracing/opentracing-go"
@@ -184,7 +185,7 @@ func (u *User) giteeOAuth(c *wkhttp.Context) {
 			imgReader, _ := u.fileService.DownloadImage(userInfo.AvatarURL, timeoutCtx)
 			cancel()
 			if imgReader != nil {
-				avatarVersion := time.Now().UnixNano()
+				avatarVersion := avatarversion.New()
 				_, err = u.fileService.UploadFile(userAvatarFilePath(uid, u.ctx.GetConfig().Avatar.Partition, avatarVersion), "image/png", "", func(w io.Writer) error {
 					_, err := io.Copy(w, imgReader)
 					return err

--- a/modules/user/api_github.go
+++ b/modules/user/api_github.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	common "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/avatarversion"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -119,7 +120,7 @@ func (u *User) githubOAuth(c *wkhttp.Context) {
 			imgReader, _ := u.fileService.DownloadImage(userInfo.AvatarURL, timeoutCtx)
 			cancel()
 			if imgReader != nil {
-				avatarVersion := time.Now().UnixNano()
+				avatarVersion := avatarversion.New()
 				_, err = u.fileService.UploadFile(userAvatarFilePath(uid, u.ctx.GetConfig().Avatar.Partition, avatarVersion), "image/png", "", func(w io.Writer) error {
 					_, err := io.Copy(w, imgReader)
 					return err

--- a/modules/user/api_github.go
+++ b/modules/user/api_github.go
@@ -3,7 +3,6 @@ package user
 import (
 	"context"
 	"fmt"
-	"hash/crc32"
 	"io"
 	"net/http"
 	"net/url"
@@ -120,14 +119,15 @@ func (u *User) githubOAuth(c *wkhttp.Context) {
 			imgReader, _ := u.fileService.DownloadImage(userInfo.AvatarURL, timeoutCtx)
 			cancel()
 			if imgReader != nil {
-				avatarID := crc32.ChecksumIEEE([]byte(uid)) % uint32(u.ctx.GetConfig().Avatar.Partition)
-				_, err = u.fileService.UploadFile(fmt.Sprintf("avatar/%d/%s.png", avatarID, uid), "image/png", "", func(w io.Writer) error {
+				avatarVersion := time.Now().UnixNano()
+				_, err = u.fileService.UploadFile(userAvatarFilePath(uid, u.ctx.GetConfig().Avatar.Partition, avatarVersion), "image/png", "", func(w io.Writer) error {
 					_, err := io.Copy(w, imgReader)
 					return err
 				})
 				defer imgReader.Close()
 				if err == nil {
 					model.IsUploadAvatar = 1
+					model.AvatarVersion = avatarVersion
 				}
 			}
 		}

--- a/modules/user/api_i18n_test.go
+++ b/modules/user/api_i18n_test.go
@@ -107,6 +107,38 @@ func TestMigratedUserFilesNoLegacyResponseError(t *testing.T) {
 	}
 }
 
+func TestUploadAvatarPostCommitNotificationFailuresRespondOK(t *testing.T) {
+	data, err := os.ReadFile("api.go")
+	if err != nil {
+		t.Fatalf("read api.go: %v", err)
+	}
+	source := string(data)
+	start := strings.Index(source, "func (u *User) uploadAvatar")
+	if start < 0 {
+		t.Fatalf("locate uploadAvatar in api.go")
+	}
+	end := strings.Index(source[start:], "\n// 获取用户的IM连接地址")
+	if end < 0 {
+		t.Fatalf("locate end of uploadAvatar in api.go")
+	}
+	body := source[start : start+end]
+
+	for _, marker := range []string{"查询用户好友失败", "发送个人头像更新命令失败"} {
+		idx := strings.Index(body, marker)
+		if idx < 0 {
+			t.Fatalf("uploadAvatar missing post-commit notification branch %q", marker)
+		}
+		after := body[idx:]
+		returnIdx := strings.Index(after, "return")
+		if returnIdx < 0 {
+			t.Fatalf("uploadAvatar branch %q has no return", marker)
+		}
+		if !strings.Contains(after[:returnIdx], "c.ResponseOK()") {
+			t.Fatalf("uploadAvatar branch %q must respond OK after avatar DB update has committed", marker)
+		}
+	}
+}
+
 // helperHarness mounts a single GET /probe route that invokes the supplied
 // helper. Tests exercise the helper directly without paying the DB / auth
 // setup cost — the contract we care about is what the wkhttp envelope

--- a/modules/user/avatar_path.go
+++ b/modules/user/avatar_path.go
@@ -1,0 +1,14 @@
+package user
+
+import (
+	"fmt"
+	"hash/crc32"
+)
+
+func userAvatarFilePath(uid string, partition int, version int64) string {
+	avatarID := crc32.ChecksumIEEE([]byte(uid)) % uint32(partition)
+	if version > 0 {
+		return fmt.Sprintf("avatar/%d/%s/%d.png", avatarID, uid, version)
+	}
+	return fmt.Sprintf("avatar/%d/%s.png", avatarID, uid)
+}

--- a/modules/user/avatar_path_test.go
+++ b/modules/user/avatar_path_test.go
@@ -1,0 +1,44 @@
+package user
+
+import "testing"
+
+func TestUserAvatarFilePath(t *testing.T) {
+	tests := []struct {
+		name      string
+		uid       string
+		partition int
+		version   int64
+		want      string
+	}{
+		{
+			name:      "legacy path when version is zero",
+			uid:       "u_avatar_cache",
+			partition: 100,
+			version:   0,
+			want:      "avatar/44/u_avatar_cache.png",
+		},
+		{
+			name:      "legacy path when version is negative",
+			uid:       "u_avatar_cache",
+			partition: 100,
+			version:   -1,
+			want:      "avatar/44/u_avatar_cache.png",
+		},
+		{
+			name:      "versioned path when version is positive",
+			uid:       "u_avatar_cache",
+			partition: 100,
+			version:   1700000000000000001,
+			want:      "avatar/44/u_avatar_cache/1700000000000000001.png",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := userAvatarFilePath(tt.uid, tt.partition, tt.version)
+			if got != tt.want {
+				t.Fatalf("userAvatarFilePath(%q, %d, %d) = %q, want %q", tt.uid, tt.partition, tt.version, got, tt.want)
+			}
+		})
+	}
+}

--- a/modules/user/avatar_version_test.go
+++ b/modules/user/avatar_version_test.go
@@ -1,0 +1,57 @@
+package user
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUserAvatarVersionDBRoundTrip 覆盖 uploadAvatar 的落库路径：
+// UpdateAvatarUploadStatus 必须把 is_upload_avatar 翻成 1 并写入服务端版本号，
+// QueryByUID 能读回该版本，进而选出版本化对象 path。
+// 端到端的 TestUploadAvatar 因 issue #17 被 t.Skip，这里补 DB 层集成覆盖。
+func TestUserAvatarVersionDBRoundTrip(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	u := New(ctx)
+
+	const uid = "avatar_ver_uid_1"
+	require.NoError(t, u.db.Insert(&Model{
+		UID:      uid,
+		Name:     "avatar tester",
+		Username: "avatar_ver_user_1",
+		ShortNo:  "avatar_ver_sn_1",
+		Status:   1,
+	}))
+
+	partition := ctx.GetConfig().Avatar.Partition
+
+	// 上传前：旧用户落回 legacy 稳定 path（不含版本段）。
+	before, err := u.db.QueryByUID(uid)
+	require.NoError(t, err)
+	require.NotNil(t, before)
+	require.Equal(t, 0, before.IsUploadAvatar)
+	require.Equal(t, int64(0), before.AvatarVersion)
+	legacyPath := userAvatarFilePath(uid, partition, before.AvatarVersion)
+	require.True(t, strings.HasSuffix(legacyPath, fmt.Sprintf("/%s.png", uid)),
+		"version=0 must fall back to legacy path, got %q", legacyPath)
+
+	// 上传：标记已上传并写入版本。
+	const version int64 = 1733300000000000001
+	require.NoError(t, u.db.UpdateAvatarUploadStatus(uid, version))
+
+	after, err := u.db.QueryByUID(uid)
+	require.NoError(t, err)
+	require.NotNil(t, after)
+	require.Equal(t, 1, after.IsUploadAvatar)
+	require.Equal(t, version, after.AvatarVersion)
+
+	// 上传后：读回的版本选出版本化 path（含 /{version}.png）。
+	versionedPath := userAvatarFilePath(uid, partition, after.AvatarVersion)
+	require.True(t, strings.HasSuffix(versionedPath, fmt.Sprintf("/%d.png", version)),
+		"version>0 must select versioned path, got %q", versionedPath)
+	require.NotEqual(t, legacyPath, versionedPath)
+}

--- a/modules/user/db.go
+++ b/modules/user/db.go
@@ -207,6 +207,17 @@ func (d *DB) UpdateUsersWithField(field string, value string, uid string) error 
 	return err
 }
 
+// UpdateAvatarUploadStatus marks a user avatar as uploaded and stores the
+// server-side object-key version used to avoid CDN query-string cache-key
+// dependencies.
+func (d *DB) UpdateAvatarUploadStatus(uid string, avatarVersion int64) error {
+	_, err := d.session.Update("user").SetMap(map[string]interface{}{
+		"is_upload_avatar": 1,
+		"avatar_version":   avatarVersion,
+	}).Where("uid=?", uid).Exec()
+	return err
+}
+
 // UpdateUsersWithFieldTx 修改用户基本资料（事务版本）
 func (d *DB) UpdateUsersWithFieldTx(field string, value string, uid string, tx *dbr.Tx) error {
 	if !allowedUpdateFields[field] {
@@ -489,23 +500,24 @@ type Model struct {
 	ShockOn           int    //震动0.否1.是
 	OfflineProtection int    // 离线保护
 	Version           int64
-	Status            int    // 状态 0.禁用 1.启用
-	Vercode           string //验证码
-	QRVercode         string // 二维码验证码
-	IsUploadAvatar    int    // 是否上传过头像0:未上传1:已上传
-	Role              string // 角色 admin/superAdmin
-	Robot             int    // 机器人0.否1.是
-	MuteOfApp         int    // app是否禁音（当pc登录的时候app可以设置禁音，当pc登录后有效）
-	IsDestroy         int           // 注销状态 0.正常 1.注销申请中（冷静期） 2.已注销
-	DestroyApplyAt    dbr.NullTime  // 注销申请时间
-	DestroyExpireAt   dbr.NullTime  // 注销到期执行时间
-	WXOpenid          string // 微信openid
-	WXUnionid         string // 微信unionid
-	GiteeUID          string // gitee uid
-	GithubUID         string // github uid
-	Web3PublicKey     string // web3公钥
-	MsgExpireSecond   int64  // 消息过期时长
-	Language          string // 用户语言偏好（BCP 47，空表示沿用 OCTO_DEFAULT_LANGUAGE）
+	Status            int          // 状态 0.禁用 1.启用
+	Vercode           string       //验证码
+	QRVercode         string       // 二维码验证码
+	IsUploadAvatar    int          // 是否上传过头像0:未上传1:已上传
+	AvatarVersion     int64        // 头像对象版本，0 表示旧版稳定路径
+	Role              string       // 角色 admin/superAdmin
+	Robot             int          // 机器人0.否1.是
+	MuteOfApp         int          // app是否禁音（当pc登录的时候app可以设置禁音，当pc登录后有效）
+	IsDestroy         int          // 注销状态 0.正常 1.注销申请中（冷静期） 2.已注销
+	DestroyApplyAt    dbr.NullTime // 注销申请时间
+	DestroyExpireAt   dbr.NullTime // 注销到期执行时间
+	WXOpenid          string       // 微信openid
+	WXUnionid         string       // 微信unionid
+	GiteeUID          string       // gitee uid
+	GithubUID         string       // github uid
+	Web3PublicKey     string       // web3公钥
+	MsgExpireSecond   int64        // 消息过期时长
+	Language          string       // 用户语言偏好（BCP 47，空表示沿用 OCTO_DEFAULT_LANGUAGE）
 	db.BaseModel
 }
 

--- a/modules/user/sql/20260605000001_user_avatar_version.sql
+++ b/modules/user/sql/20260605000001_user_avatar_version.sql
@@ -44,4 +44,3 @@ CALL __user_avatar_version_down();
 -- +migrate StatementBegin
 DROP PROCEDURE IF EXISTS __user_avatar_version_down;
 -- +migrate StatementEnd
-

--- a/modules/user/sql/20260605000001_user_avatar_version.sql
+++ b/modules/user/sql/20260605000001_user_avatar_version.sql
@@ -1,0 +1,47 @@
+-- +migrate Up
+-- 用户头像对象版本。0 表示沿用旧版稳定对象 key，正数写入对象 path 用于 CDN-safe cache busting。
+-- 使用 INFORMATION_SCHEMA 守卫保证迁移在部分执行后重试时仍可重入。
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __user_avatar_version;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __user_avatar_version()
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user'
+         AND COLUMN_NAME = 'avatar_version') THEN
+    ALTER TABLE `user`
+      ADD COLUMN `avatar_version` BIGINT NOT NULL DEFAULT 0 COMMENT '用户头像对象版本，0 表示旧版稳定路径';
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __user_avatar_version();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __user_avatar_version;
+-- +migrate StatementEnd
+
+-- +migrate Down
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __user_avatar_version_down;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __user_avatar_version_down()
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user'
+         AND COLUMN_NAME = 'avatar_version') THEN
+    ALTER TABLE `user` DROP COLUMN `avatar_version`;
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __user_avatar_version_down();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __user_avatar_version_down;
+-- +migrate StatementEnd
+

--- a/pkg/avatarversion/avatarversion.go
+++ b/pkg/avatarversion/avatarversion.go
@@ -1,0 +1,41 @@
+package avatarversion
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	randomBits = 20
+	randomMask = (1 << randomBits) - 1
+)
+
+var lastVersion atomic.Int64
+
+// New returns a positive object-key version for avatar uploads.
+//
+// The high bits preserve coarse time ordering, while the low random bits make
+// same-millisecond cross-node collisions unlikely. The process-local CAS keeps
+// versions unique and monotonic even if the clock stalls or crypto/rand fails.
+func New() int64 {
+	version := time.Now().UnixMilli()<<randomBits | randomSuffix()
+	for {
+		last := lastVersion.Load()
+		if version <= last {
+			version = last + 1
+		}
+		if lastVersion.CompareAndSwap(last, version) {
+			return version
+		}
+	}
+}
+
+func randomSuffix() int64 {
+	var buf [8]byte
+	if _, err := rand.Read(buf[:]); err == nil {
+		return int64(binary.BigEndian.Uint64(buf[:]) & randomMask)
+	}
+	return time.Now().UnixNano() & randomMask
+}

--- a/pkg/avatarversion/avatarversion_test.go
+++ b/pkg/avatarversion/avatarversion_test.go
@@ -1,0 +1,36 @@
+package avatarversion
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestNewReturnsUniquePositiveVersionsUnderConcurrency(t *testing.T) {
+	const goroutines = 32
+	const perGoroutine = 2000
+
+	versions := make(chan int64, goroutines*perGoroutine)
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				versions <- New()
+			}
+		}()
+	}
+	wg.Wait()
+	close(versions)
+
+	seen := make(map[int64]struct{}, goroutines*perGoroutine)
+	for version := range versions {
+		if version <= 0 {
+			t.Fatalf("New() returned non-positive version %d", version)
+		}
+		if _, ok := seen[version]; ok {
+			t.Fatalf("New() returned duplicate version %d", version)
+		}
+		seen[version] = struct{}{}
+	}
+}


### PR DESCRIPTION
Closes #281

## Problem

After an avatar upload, clients can keep seeing the old image in deployments where the CDN cache key does not include query strings. Uploads overwrite a stable object key (`avatar/{id}/{uid}.png`, `group/{id}/{group_no}.png`), and the `?v=` redirect parameter is the only cache-buster — a no-op when the CDN ignores query strings.

## Change

Persist a server-side avatar version and move the storage object key itself, so the cache key changes on every upload.

- New `avatar_version` column on `user` and `group` (idempotent migrations). `0` keeps the legacy stable path so existing rows work with no backfill; a positive version reads/writes `avatar/{id}/{uid}/{version}.png` (and the group equivalent).
- Upload path: manual user upload and OAuth avatar imports (wx / gitee / github) generate a `UnixNano` version, upload to the versioned key, and persist the version. The DB write now happens before the IM CMD so a client is never notified ahead of the new path being readable.
- Download path: handlers select versioned vs legacy path from the stored version.
- Group auto-composition writes a versioned object too, and the compose DB update is guarded by `is_upload_avatar = 0` so a stale compose event can no longer overwrite an avatar the owner uploaded manually.
- Fix: the new compose DB update passed a back-quoted table name to `dbr.Update`, which dbr quotes again into an invalid identifier — every auto-compose write would have failed with SQL error 1064. It now passes the bare table name (matching the existing `updateAvatar`).

Version helpers use the variadic avatar-path API from `octo-lib`.

## Test Plan

- [x] `go build ./...` and `go vet` on changed packages
- [x] Unit: path selection (legacy when version <= 0, versioned when > 0) for user and group
- [x] Integration (real MySQL): user/group avatar-version DB round-trip — upload flips `is_upload_avatar`, persists the version, and read-back selects the versioned path
- [x] Integration (real MySQL): a stale group-compose event cannot overwrite a manually uploaded avatar (`is_upload_avatar = 0` guard)
- [x] i18n response-guard tests on `group`/`user` still pass
- [ ] Manual verification against a CDN that ignores query strings — the object-store upload and IM CMD legs are not covered by the local integration environment

## Notes

- Community avatar/cover handlers mentioned in #281 were not found in this tree; if they live elsewhere they likely need the same treatment.
