### PR TITLE
feat(incomingwebhook): layered push rate limiting (local floor + per-IP failure budget)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -166,7 +166,7 @@ require (
 	golang.org/x/arch v0.3.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect
-	golang.org/x/time v0.3.0 // indirect
+	golang.org/x/time v0.3.0
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/appengine/v2 v2.0.2 // indirect

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -73,6 +73,9 @@ type IncomingWebhook struct {
 	// 抢连接池。同步回落则会让每个请求 goroutine 各占一条连接，在限流全 fail-open、请求
 	// 并发本身无界时重新压垮连接池——正是这个信号量要避免的（yujiawei review P2）。
 	auditSem chan struct{}
+	// floor 是 push 端点的 Redis-independent 进程级限流地板：两个 Redis 限流器在
+	// Redis 故障时 fail-open，floor 用纯内存令牌桶兜底，保证单实例推送速率始终有界。
+	floor *localFloor
 }
 
 // maxConcurrentAudit 限制异步审计 goroutine 的最大并发数（默认值，可被 env 覆盖）。
@@ -103,6 +106,9 @@ func sharedRateRedis(cfg *config.Config) *redis.Client {
 		// （AWS ElastiCache / Azure Cache 等托管 TLS Redis）TLSConfig 不被遗漏。
 		// 否则限流 client 连不上 TLS-only Redis，per-IP / per-webhook 两个限流器
 		// 都会 fail-open，未认证 push 端点的反扫描/防洪泛保护被静默关闭。
+		// PoolSize 显式设 10：令牌桶 Lua 脚本是短事务，与 main.go / user / group /
+		// space / integration 等其它限流 client 的全局约定保持一致。Redis 故障/连接池
+		// 打满导致 fail-open 的兜底由进程内 localFloor 负责，不在此处放大连接池。
 		rateRedisClient = redis.NewClient(octoredis.MustBuildOptions(cfg, func(o *redis.Options) {
 			o.MaxRetries = 1
 			o.PoolSize = 10
@@ -120,6 +126,7 @@ func New(ctx *config.Context) *IncomingWebhook {
 		groupDB:   group.NewDB(ctx),
 		rateRedis: sharedRateRedis(ctx.GetConfig()),
 		auditSem:  make(chan struct{}, auditConcurrency()),
+		floor:     newLocalFloor(),
 	}
 	// 群解散级联禁用所有 webhook
 	w.ctx.AddEventListener(event.GroupDisband, w.handleGroupDisband)
@@ -145,9 +152,12 @@ func (w *IncomingWebhook) Route(r *wkhttp.WKHttp) {
 	ipBurst := wkhttp.ParseBurstFromEnv(envIngressIPBurst, defaultIngressIPBurst)
 	ipLimit := r.StrictIPRateLimitMiddleware(context.Background(), w.rateRedis, "incoming_webhook", ipRPS, ipBurst)
 
+	// 中间件顺序：localFloorMiddleware（纯内存、最廉价、不依赖 Redis）在前，先于
+	// Redis IP 限流挡住洪峰；ipLimit（Redis）次之。这样 Redis 故障/连接池打满时，
+	// 进程级地板仍能限速，避免对 DB + WuKongIM 的洪泛放大。
 	push := r.Group("/v1")
 	{
-		push.POST("/incoming-webhooks/:webhook_id/:token", ipLimit, w.push)
+		push.POST("/incoming-webhooks/:webhook_id/:token", w.localFloorMiddleware(), ipLimit, w.push)
 	}
 }
 

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -36,6 +36,8 @@ const (
 	envBodyMax             = "DM_INCOMINGWEBHOOK_MAX_BYTES"
 	envRatePerWebhookRPS   = "DM_INCOMINGWEBHOOK_RPS"
 	envRatePerWebhookBurst = "DM_INCOMINGWEBHOOK_BURST"
+	envIngressIPRPS        = "DM_INCOMINGWEBHOOK_IP_RPS"
+	envIngressIPBurst      = "DM_INCOMINGWEBHOOK_IP_BURST"
 	envIPFailRPS           = "DM_INCOMINGWEBHOOK_IP_FAIL_RPS"
 	envIPFailBurst         = "DM_INCOMINGWEBHOOK_IP_FAIL_BURST"
 	envMaxContentRunes     = "DM_INCOMINGWEBHOOK_MAX_CONTENT_RUNES"
@@ -44,6 +46,12 @@ const (
 	defaultMaxBytes       = 8 * 1024
 	defaultRatePerWHRPS   = 5.0
 	defaultRatePerWHBurst = 10
+	// per-IP 请求限流（StrictIPRateLimitMiddleware，计入全部请求）的默认值。刻意高于
+	// 旧值(30/60)、但仍低于进程级 floor(200/400)：合法共享/固定 IP 的正常推送量(受
+	// per-webhook 5rps 约束，单 IP 多 webhook 聚合一般 ≪100rps)不被误杀，同时把"单 IP
+	// 持多有效 token"的洪流封在 floor 之下，避免一个 IP 吃满全局 floor 挤占其它租户。
+	defaultIngressIPRPS   = 100.0
+	defaultIngressIPBurst = 200
 	defaultIPFailRPS      = 30.0
 	defaultIPFailBurst    = 60
 	// content 的语义长度上限（rune 数）。8KB body cap 是字节传输上限，这里再加一道
@@ -147,18 +155,23 @@ func (w *IncomingWebhook) Route(r *wkhttp.WKHttp) {
 		mgr.POST("/:group_no/incoming-webhooks/:webhook_id/regenerate", w.regenerate)
 	}
 
-	// 推送类：URL 内 token 鉴权，无 AuthMiddleware。
-	//
-	// 中间件顺序：
+	// 推送类：URL 内 token 鉴权，无 AuthMiddleware。四层限流，由粗到细：
 	//  1) localFloorMiddleware —— 纯内存、不依赖 Redis 的进程级地板，先挡洪峰；Redis
 	//     故障时仍限速，避免对 DB + WuKongIM 的洪泛放大。
-	//  2) ipFailureGateMiddleware —— 按 IP 的"鉴权失败预算"闸：只读 peek，拦掉已把失败
-	//     预算烧光的扫 token IP（在进 handler/打 DB 之前）。注意：合法推送(有效 Key)不
-	//     消耗该预算（只有鉴权失败才在 handler 内 penalize），故服务端固定/共享 IP 不会
-	//     被流量误杀；合法流量整形由 handler 内 allowPerWebhook(按 webhook_id) 负责。
+	//  2) ipLimit (StrictIPRateLimitMiddleware) —— 按 IP 对【全部】请求限流(默认 100rps，
+	//     低于 floor)，给"单 IP 持多有效 token"的洪流封一个硬天花板，防止一个 IP 吃满
+	//     全局 floor 挤占其它租户。阈值高于旧值，合法共享/固定 IP 的正常量不被误杀。
+	//  3) ipFailureGateMiddleware —— 按 IP 的"鉴权失败预算"闸(默认 60)：只读 peek，把扫
+	//     token 的 IP 在烧光失败预算后【在打 DB 之前】快速切断。合法推送(有效 Key)不消耗
+	//     该预算，故比第 2 层更早、更精准地反扫描，且不误伤合法流量。
+	//  4) allowPerWebhook(handler 内，按 webhook_id) —— 单个 webhook 的合法流量整形(5rps)。
+	ipRPS := wkhttp.ParseRPSFromEnv(envIngressIPRPS, defaultIngressIPRPS)
+	ipBurst := wkhttp.ParseBurstFromEnv(envIngressIPBurst, defaultIngressIPBurst)
+	ipLimit := r.StrictIPRateLimitMiddleware(context.Background(), w.rateRedis, "incoming_webhook", ipRPS, ipBurst)
+
 	push := r.Group("/v1")
 	{
-		push.POST("/incoming-webhooks/:webhook_id/:token", w.localFloorMiddleware(), w.ipFailureGateMiddleware(), w.push)
+		push.POST("/incoming-webhooks/:webhook_id/:token", w.localFloorMiddleware(), ipLimit, w.ipFailureGateMiddleware(), w.push)
 	}
 }
 

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -617,15 +617,17 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 		pushUnauthorized(c)
 		return
 	}
-	if m == nil {
-		// 未知 webhook——明确的扫描信号，计入 IP 失败预算。
+	if m == nil || m.Status == statusDeleted {
+		// 未知或【已软删除】的 webhook——没有合法调用方会往不存在/已删除的 URL 推送，
+		// 是明确的扫描/滥用信号，计入 IP 失败预算（否则一个泄露的已删 URL 可无限刷、
+		// 每次一次 DB 读却永不触发失败门）。
 		w.failAuth(c, ip)
 		return
 	}
 	if m.Status != statusEnabled {
-		// webhook 存在但被禁用/软删——可能是持有有效 token 的合法调用方在其 webhook 刚被
-		// 管理员禁用后继续推送，无法在 token 校验前区分，故【不】计入 IP 失败预算，避免误封
-		// 共享 IP（响应仍是同一 401，保持反枚举）。
+		// webhook 存在但被【禁用】（statusDisabled）——可能是持有有效 token 的合法调用方
+		// 在其 webhook 刚被管理员禁用后继续推送，无法在 token 校验前区分，故对禁用态保留
+		// 宽限：【不】计入 IP 失败预算，避免误封共享 IP（响应仍是同一 401，保持反枚举）。
 		pushUnauthorized(c)
 		return
 	}

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -36,16 +36,16 @@ const (
 	envBodyMax             = "DM_INCOMINGWEBHOOK_MAX_BYTES"
 	envRatePerWebhookRPS   = "DM_INCOMINGWEBHOOK_RPS"
 	envRatePerWebhookBurst = "DM_INCOMINGWEBHOOK_BURST"
-	envIngressIPRPS        = "DM_INCOMINGWEBHOOK_IP_RPS"
-	envIngressIPBurst      = "DM_INCOMINGWEBHOOK_IP_BURST"
+	envIPFailRPS           = "DM_INCOMINGWEBHOOK_IP_FAIL_RPS"
+	envIPFailBurst         = "DM_INCOMINGWEBHOOK_IP_FAIL_BURST"
 	envMaxContentRunes     = "DM_INCOMINGWEBHOOK_MAX_CONTENT_RUNES"
 
 	defaultMaxPerGroup    = 10
 	defaultMaxBytes       = 8 * 1024
 	defaultRatePerWHRPS   = 5.0
 	defaultRatePerWHBurst = 10
-	defaultIngressIPRPS   = 30.0
-	defaultIngressIPBurst = 60
+	defaultIPFailRPS      = 30.0
+	defaultIPFailBurst    = 60
 	// content 的语义长度上限（rune 数）。8KB body cap 是字节传输上限，这里再加一道
 	// 业务上限：单条消息正文过长既影响客户端渲染，也无 IM 语义。默认 4000 rune
 	// 介于 Discord(~2k) 与 Slack(~40k) 之间，可经 env 调整。
@@ -147,17 +147,18 @@ func (w *IncomingWebhook) Route(r *wkhttp.WKHttp) {
 		mgr.POST("/:group_no/incoming-webhooks/:webhook_id/regenerate", w.regenerate)
 	}
 
-	// 推送类：URL 内 token 鉴权，无 AuthMiddleware；外加 IP 限流防扫 token。
-	ipRPS := wkhttp.ParseRPSFromEnv(envIngressIPRPS, defaultIngressIPRPS)
-	ipBurst := wkhttp.ParseBurstFromEnv(envIngressIPBurst, defaultIngressIPBurst)
-	ipLimit := r.StrictIPRateLimitMiddleware(context.Background(), w.rateRedis, "incoming_webhook", ipRPS, ipBurst)
-
-	// 中间件顺序：localFloorMiddleware（纯内存、最廉价、不依赖 Redis）在前，先于
-	// Redis IP 限流挡住洪峰；ipLimit（Redis）次之。这样 Redis 故障/连接池打满时，
-	// 进程级地板仍能限速，避免对 DB + WuKongIM 的洪泛放大。
+	// 推送类：URL 内 token 鉴权，无 AuthMiddleware。
+	//
+	// 中间件顺序：
+	//  1) localFloorMiddleware —— 纯内存、不依赖 Redis 的进程级地板，先挡洪峰；Redis
+	//     故障时仍限速，避免对 DB + WuKongIM 的洪泛放大。
+	//  2) ipFailureGateMiddleware —— 按 IP 的"鉴权失败预算"闸：只读 peek，拦掉已把失败
+	//     预算烧光的扫 token IP（在进 handler/打 DB 之前）。注意：合法推送(有效 Key)不
+	//     消耗该预算（只有鉴权失败才在 handler 内 penalize），故服务端固定/共享 IP 不会
+	//     被流量误杀；合法流量整形由 handler 内 allowPerWebhook(按 webhook_id) 负责。
 	push := r.Group("/v1")
 	{
-		push.POST("/incoming-webhooks/:webhook_id/:token", w.localFloorMiddleware(), ipLimit, w.push)
+		push.POST("/incoming-webhooks/:webhook_id/:token", w.localFloorMiddleware(), w.ipFailureGateMiddleware(), w.push)
 	}
 }
 
@@ -198,6 +199,18 @@ func perWebhookRPS() float64 {
 
 func perWebhookBurst() int {
 	return wkhttp.ParseBurstFromEnv(envRatePerWebhookBurst, defaultRatePerWHBurst)
+}
+
+// ipFailRPS / ipFailBurst bound the per-IP AUTH-FAILURE budget (not request
+// volume): how fast / how many failed-auth attempts an IP may make before the
+// push gate starts rejecting it. Tunable via DM_INCOMINGWEBHOOK_IP_FAIL_RPS /
+// _BURST.
+func ipFailRPS() float64 {
+	return wkhttp.ParseRPSFromEnv(envIPFailRPS, defaultIPFailRPS)
+}
+
+func ipFailBurst() int {
+	return wkhttp.ParseBurstFromEnv(envIPFailBurst, defaultIPFailBurst)
 }
 
 // ============================================================
@@ -558,22 +571,48 @@ func (w *IncomingWebhook) regenerate(c *wkhttp.Context) {
 // 推送端点
 // ============================================================
 
+// failAuth records a per-IP auth failure (a token-scan signal) then returns the
+// uniform 401. Used only on genuine auth-failure branches — unknown/disabled
+// webhook, bad token, malformed request — never on server-side (DB) errors or
+// post-authentication state failures (valid token, group not Normal), so those
+// never penalize the caller's IP.
+func (w *IncomingWebhook) failAuth(c *wkhttp.Context, ip string) {
+	w.penalizeIPFailure(ip)
+	pushUnauthorized(c)
+}
+
 func (w *IncomingWebhook) push(c *wkhttp.Context) {
+	// 仅用于"鉴权失败才计入"的 per-IP 失败预算（见 failAuth / ipFailureGateMiddleware）。
+	// 用 clientIP（信任代理追加的 X-Real-Ip / 最右 XFF），而非 gin c.ClientIP()——后者在
+	// wkhttp 的 trust-all-proxies 默认下取最左 XFF（客户端可伪造），会让扫描者每次伪造
+	// 新 IP 从而绕过失败预算。
+	ip := clientIP(c.Request)
+
 	webhookID := c.Param("webhook_id")
 	token := c.Param("token")
 	if webhookID == "" || token == "" {
-		pushUnauthorized(c)
+		// 缺参/畸形请求——算作扫描信号，计入 IP 失败预算。
+		w.failAuth(c, ip)
 		return
 	}
 
 	// 1) 查 webhook（queryByWebhookID 已把 ErrNotFound 吸收为 nil/nil）
 	m, err := w.db.queryByWebhookID(webhookID)
 	if err != nil {
+		// 服务端故障，不是调用方扫描——绝不计入 IP 失败预算（否则 DB 抖动会误封 IP）。
 		w.Error("query webhook failed", zap.Error(err))
 		pushUnauthorized(c)
 		return
 	}
-	if m == nil || m.Status != statusEnabled {
+	if m == nil {
+		// 未知 webhook——明确的扫描信号，计入 IP 失败预算。
+		w.failAuth(c, ip)
+		return
+	}
+	if m.Status != statusEnabled {
+		// webhook 存在但被禁用/软删——可能是持有有效 token 的合法调用方在其 webhook 刚被
+		// 管理员禁用后继续推送，无法在 token 校验前区分，故【不】计入 IP 失败预算，避免误封
+		// 共享 IP（响应仍是同一 401，保持反枚举）。
 		pushUnauthorized(c)
 		return
 	}
@@ -581,7 +620,8 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 	// 2) 常量时间比对 token
 	expected := hashToken(token)
 	if subtle.ConstantTimeCompare([]byte(expected), []byte(m.TokenHash)) != 1 {
-		pushUnauthorized(c)
+		// token 不匹配——鉴权失败信号，计入 IP 失败预算。
+		w.failAuth(c, ip)
 		return
 	}
 
@@ -603,7 +643,7 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 	// 3) per-webhook 限流；Redis 故障时显式 fail-open，避免 Redis 抖动导致全量推送被拒。
 	allowed, err := w.allowPerWebhook(c.Request.Context(), webhookID)
 	if err != nil {
-		w.Warn("per-webhook rate limit redis failed, fail-open", zap.Error(err))
+		w.warnDegraded("per-webhook rate limit redis failed, fail-open", err)
 		allowed = true
 	}
 	if !allowed {
@@ -662,7 +702,8 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 	if resp != nil {
 		msgID = resp.MessageID
 	}
-	w.submitRecordSuccess(m, len(body), c.ClientIP(), msgID)
+	// 审计用同一可信 IP（clientIP），而非 gin 可伪造的 c.ClientIP()。
+	w.submitRecordSuccess(m, len(body), ip, msgID)
 
 	c.Response(map[string]interface{}{
 		"status":     0,

--- a/modules/incomingwebhook/api_i18n.go
+++ b/modules/incomingwebhook/api_i18n.go
@@ -23,8 +23,14 @@ func pushUnauthorized(c *wkhttp.Context) {
 	c.Abort()
 }
 
-// pushRateLimited returns 429 when the per-webhook token bucket rejects.
+// pushRateLimited returns 429 when a push limiter (local floor, per-IP failure
+// gate, or per-webhook bucket) rejects. It sets a conservative Retry-After so
+// machine senders back off instead of hot-looping; the limiters refill within
+// ~1s at their configured rates, so a fixed 1s hint is a safe lower bound. (The
+// per-IP request limiter, StrictIPRateLimitMiddleware, sets its own precise
+// Retry-After / X-RateLimit headers and never reaches here.)
 func pushRateLimited(c *wkhttp.Context) {
+	c.Header("Retry-After", "1")
 	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookPushRateLimited, nil, nil)
 	c.Abort()
 }

--- a/modules/incomingwebhook/api_i18n_test.go
+++ b/modules/incomingwebhook/api_i18n_test.go
@@ -1,0 +1,117 @@
+package incomingwebhook
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+// TestIncomingWebhookNoLegacyResponseError pins that the module's HTTP surface
+// renders every error through the i18n envelope (httperr.ResponseErrorL* +
+// errcode.ErrIncomingWebhook*) and never regresses to legacy octo-lib raw
+// responses. Comments are stripped first so commented-out breadcrumbs (e.g. the
+// #246 note in api_i18n.go) don't trip the guard. Add any new handler/limiter
+// file to the list below.
+func TestIncomingWebhookNoLegacyResponseError(t *testing.T) {
+	files := []string{"api.go", "api_i18n.go", "ratelimit.go", "localfloor.go"}
+	banned := []string{
+		".ResponseError(",
+		".ResponseErrorf(",
+		".ResponseErrorWithStatus(",
+		".AbortWithStatusJSON(",
+		".AbortWithStatus(",
+		"c.Response(\"",
+	}
+	for _, f := range files {
+		t.Run(f, func(t *testing.T) {
+			data, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+			var clean strings.Builder
+			for _, line := range strings.Split(string(data), "\n") {
+				if idx := strings.Index(line, "//"); idx >= 0 {
+					line = line[:idx]
+				}
+				clean.WriteString(line)
+				clean.WriteByte('\n')
+			}
+			cleaned := clean.String()
+			for _, b := range banned {
+				if strings.Contains(cleaned, b) {
+					t.Fatalf("modules/incomingwebhook/%s must render errors via httperr.ResponseErrorL* / errcode.ErrIncomingWebhook*, not legacy %s", f, b)
+				}
+			}
+		})
+	}
+}
+
+// iwhEnvelope is the partial shape of an httperr.ResponseErrorL* response.
+type iwhEnvelope struct {
+	Error struct {
+		Code       string `json:"code"`
+		HTTPStatus int    `json:"http_status"`
+	} `json:"error"`
+	Status int `json:"status"`
+}
+
+func iwhHelperHarness(probe func(c *wkhttp.Context)) *wkhttp.WKHttp {
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	r.GET("/probe", probe)
+	return r
+}
+
+// TestIncomingWebhookRespondHelpers asserts each push/management responder
+// renders the expected i18n code at its real wire status, and that the
+// rate-limit 429 carries the Retry-After back-off hint. No DB/Redis needed — it
+// only exercises the renderer.
+func TestIncomingWebhookRespondHelpers(t *testing.T) {
+	cases := []struct {
+		name           string
+		probe          func(c *wkhttp.Context)
+		wantStatus     int
+		wantCodeID     string
+		wantRetryAfter bool
+	}{
+		{"pushUnauthorized", pushUnauthorized, http.StatusUnauthorized, "err.server.incomingwebhook.push_unauthorized", false},
+		{"pushRateLimited", pushRateLimited, http.StatusTooManyRequests, "err.server.incomingwebhook.push_rate_limited", true},
+		{"pushPayloadInvalid", func(c *wkhttp.Context) { pushPayloadInvalid(c, "json") }, http.StatusBadRequest, "err.server.incomingwebhook.push_payload_invalid", false},
+		{"pushPayloadTooLarge", pushPayloadTooLarge, http.StatusRequestEntityTooLarge, "err.server.incomingwebhook.push_payload_too_large", false},
+		{"pushDeliveryFailed", pushDeliveryFailed, http.StatusBadGateway, "err.server.incomingwebhook.push_delivery_failed", false},
+		{"mgmtForbidden", mgmtForbidden, http.StatusForbidden, "err.server.incomingwebhook.mgmt_forbidden", false},
+		{"mgmtNotFound", mgmtNotFound, http.StatusNotFound, "err.server.incomingwebhook.mgmt_not_found", false},
+		{"mgmtQuotaExceeded", func(c *wkhttp.Context) { mgmtQuotaExceeded(c, 10) }, http.StatusConflict, "err.server.incomingwebhook.mgmt_quota_exceeded", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := iwhHelperHarness(tc.probe)
+			req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			var env iwhEnvelope
+			if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+				t.Fatalf("decode envelope: %v; body=%s", err, rec.Body.String())
+			}
+			if env.Error.Code != tc.wantCodeID {
+				t.Fatalf("error.code = %q, want %q", env.Error.Code, tc.wantCodeID)
+			}
+			if env.Error.HTTPStatus != tc.wantStatus {
+				t.Fatalf("error.http_status = %d, want %d", env.Error.HTTPStatus, tc.wantStatus)
+			}
+			if tc.wantRetryAfter && rec.Header().Get("Retry-After") != "1" {
+				t.Fatalf("Retry-After = %q, want \"1\"", rec.Header().Get("Retry-After"))
+			}
+		})
+	}
+}

--- a/modules/incomingwebhook/api_test.go
+++ b/modules/incomingwebhook/api_test.go
@@ -309,6 +309,74 @@ func TestDelete_PushFails(t *testing.T) {
 	assert.Equalf(t, http.StatusUnauthorized, w.Code, "push with deleted webhook token must 401: %s", w.Body.String())
 }
 
+// TestPush_SoftDeletedWebhookSpendsIPBudget locks the P2 refinement: pushing to
+// a soft-deleted webhook_id is a scan/abuse signal (no legit caller pushes to a
+// deleted URL), so it spends the IP failure budget and gets gated — closing the
+// "leaked deleted URL hammered forever, never gated" gap.
+func TestPush_SoftDeletedWebhookSpendsIPBudget(t *testing.T) {
+	t.Setenv("DM_INCOMINGWEBHOOK_IP_FAIL_RPS", "0.01")
+	t.Setenv("DM_INCOMINGWEBHOOK_IP_FAIL_BURST", "2")
+
+	handler, ctx, groupNo := setupTestEnv(t)
+	const ip = "203.0.113.77"
+	resetIPFailBucket(t, ctx, ip)
+	resetStrictIPBucket(t, ctx, ip)
+
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	created := parseJSON(t, w)
+	whID := created["webhook_id"].(string)
+	token := created["token"].(string)
+	w = do(handler, authReq("DELETE", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID), nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	body, _ := json.Marshal(pushReq{Content: "hi"})
+	url := fmt.Sprintf("/v1/incoming-webhooks/%s/%s", whID, token)
+	// Two pushes to the deleted webhook spend the budget (401 each).
+	for i := 0; i < 2; i++ {
+		w = do(handler, anonReqIP("POST", url, body, ip))
+		assert.Equalf(t, http.StatusUnauthorized, w.Code, "attempt %d should be 401; body=%s", i, w.Body.String())
+	}
+	// Budget exhausted → the gate now rejects with 429.
+	w = do(handler, anonReqIP("POST", url, body, ip))
+	assert.Equalf(t, http.StatusTooManyRequests, w.Code,
+		"a hammered soft-deleted webhook must spend the IP budget and get gated; body=%s", w.Body.String())
+}
+
+// TestPush_DisabledWebhookKeepsIPGrace is the other half of the asymmetry: a
+// merely DISABLED webhook (a legit caller may still hold a valid token in the
+// window right after an admin disables it) does NOT spend the budget, so it is
+// never gated — only ever a uniform 401.
+func TestPush_DisabledWebhookKeepsIPGrace(t *testing.T) {
+	t.Setenv("DM_INCOMINGWEBHOOK_IP_FAIL_RPS", "0.01")
+	t.Setenv("DM_INCOMINGWEBHOOK_IP_FAIL_BURST", "2")
+
+	handler, ctx, groupNo := setupTestEnv(t)
+	const ip = "203.0.113.88"
+	resetIPFailBucket(t, ctx, ip)
+	resetStrictIPBucket(t, ctx, ip)
+
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	created := parseJSON(t, w)
+	whID := created["webhook_id"].(string)
+	token := created["token"].(string)
+	// Disable (status=0), not delete.
+	_, err := ctx.DB().UpdateBySql("UPDATE incoming_webhook SET status=0 WHERE webhook_id=?", whID).Exec()
+	assert.NoError(t, err)
+
+	body, _ := json.Marshal(pushReq{Content: "hi"})
+	url := fmt.Sprintf("/v1/incoming-webhooks/%s/%s", whID, token)
+	// Even past the failure burst of 2, a disabled webhook never gates — always 401.
+	for i := 0; i < 4; i++ {
+		w = do(handler, anonReqIP("POST", url, body, ip))
+		assert.Equalf(t, http.StatusUnauthorized, w.Code,
+			"disabled webhook must keep its grace (never 429); attempt %d body=%s", i, w.Body.String())
+	}
+}
+
 // TestDelete_ConcurrentUpdate_NoRevive 端到端回归 TOCTOU 复活漏洞（#254 follow-up）：
 // DELETE 与多个 PUT status=1 并发时，删除必须最终生效——webhook 不得复活进列表，原
 // token 不得再推送。修复后此性质与调度无关恒成立（条件 updateFields 永不写已删除行），

--- a/modules/incomingwebhook/api_test.go
+++ b/modules/incomingwebhook/api_test.go
@@ -106,6 +106,29 @@ func anonReq(method, path string, body []byte) *http.Request {
 	return req
 }
 
+// anonReqIP is anonReq with a fixed client IP, so tests can exercise the per-IP
+// auth-failure budget. Sets X-Real-Ip (the trusted, top-priority source that
+// clientIP() reads), matching how a real edge proxy attributes the caller.
+func anonReqIP(method, path string, body []byte, ip string) *http.Request {
+	req := anonReq(method, path, body)
+	req.RemoteAddr = ip + ":12345"
+	req.Header.Set("X-Real-Ip", ip)
+	return req
+}
+
+// resetIPFailBucket clears the per-IP auth-failure token bucket so a test starts
+// from a full budget; the bucket persists in Redis across runs (TTL) and is not
+// cleared by CleanAllTables (mirrors resetUIDRateLimit).
+func resetIPFailBucket(t *testing.T, ctx *config.Context, ip string) {
+	t.Helper()
+	rdsClient := redis.NewClient(&redis.Options{
+		Addr:     ctx.GetConfig().DB.RedisAddr,
+		Password: ctx.GetConfig().DB.RedisPass,
+	})
+	defer rdsClient.Close()
+	_ = rdsClient.Del("ratelimit:incoming_webhook_ipfail:" + ip).Err()
+}
+
 func do(handler http.Handler, req *http.Request) *httptest.ResponseRecorder {
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
@@ -582,6 +605,104 @@ func TestPush_LocalFloorRateLimits_RedisIndependent(t *testing.T) {
 	// burst) still having capacity. Proves the floor is an independent ceiling.
 	w = do(handler, anonReq("POST", url, body))
 	assert.Equalf(t, http.StatusTooManyRequests, w.Code, "local floor must 429 after its burst; body=%s", w.Body.String())
+}
+
+// TestPush_ValidPushesNotIPLimited is the core of "only failures count toward
+// IP": with a tiny IP failure budget but a generous per-webhook limit, a stream
+// of VALID pushes from one fixed IP is never IP-throttled, because valid pushes
+// don't spend the IP budget. This is the fixed/shared server-IP case.
+func TestPush_ValidPushesNotIPLimited(t *testing.T) {
+	t.Setenv("DM_INCOMINGWEBHOOK_IP_FAIL_RPS", "0.01")
+	t.Setenv("DM_INCOMINGWEBHOOK_IP_FAIL_BURST", "1")
+	// generous per-webhook bucket so the per-Key limiter doesn't 429 either
+	t.Setenv("DM_INCOMINGWEBHOOK_RPS", "1000")
+	t.Setenv("DM_INCOMINGWEBHOOK_BURST", "1000")
+
+	handler, ctx, groupNo := setupTestEnv(t)
+	const ip = "203.0.113.7"
+	resetIPFailBucket(t, ctx, ip)
+
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	created := parseJSON(t, w)
+	whID := created["webhook_id"].(string)
+	token := created["token"].(string)
+	body, _ := json.Marshal(pushReq{Content: "hi"})
+	url := fmt.Sprintf("/v1/incoming-webhooks/%s/%s", whID, token)
+
+	// Many valid pushes from one IP, far past the IP burst of 1 — none IP-limited.
+	for i := 0; i < 5; i++ {
+		w = do(handler, anonReqIP("POST", url, body, ip))
+		assert.NotEqualf(t, http.StatusTooManyRequests, w.Code,
+			"valid push %d from a fixed IP must not be IP-limited; body=%s", i, w.Body.String())
+	}
+}
+
+// TestPush_FailedAuthGetsIPLimited verifies the failure path DOES throttle by
+// IP: with a failure budget of 2, the first two bad-token attempts return 401
+// (each spends a token), and once the budget is spent the gate rejects further
+// attempts with 429 before the handler/DB even run.
+func TestPush_FailedAuthGetsIPLimited(t *testing.T) {
+	t.Setenv("DM_INCOMINGWEBHOOK_IP_FAIL_RPS", "0.01") // ~never refills within the test
+	t.Setenv("DM_INCOMINGWEBHOOK_IP_FAIL_BURST", "2")
+
+	handler, ctx, groupNo := setupTestEnv(t)
+	const ip = "203.0.113.9"
+	resetIPFailBucket(t, ctx, ip)
+
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	whID := parseJSON(t, w)["webhook_id"].(string)
+	body, _ := json.Marshal(pushReq{Content: "hi"})
+	badURL := fmt.Sprintf("/v1/incoming-webhooks/%s/wrong-token", whID)
+
+	// First two bad-token attempts spend the budget and return 401.
+	for i := 0; i < 2; i++ {
+		w = do(handler, anonReqIP("POST", badURL, body, ip))
+		assert.Equalf(t, http.StatusUnauthorized, w.Code, "attempt %d should be 401; body=%s", i, w.Body.String())
+	}
+	// Budget exhausted: the gate now rejects with 429 before the handler runs.
+	w = do(handler, anonReqIP("POST", badURL, body, ip))
+	assert.Equalf(t, http.StatusTooManyRequests, w.Code,
+		"after burning the IP failure budget, further attempts must be 429; body=%s", w.Body.String())
+}
+
+// TestPush_IPBudgetNotSpoofableViaXFF pins the trusted-IP contract: a scanner
+// varying the LEFTMOST X-Forwarded-For entry every request cannot evade the
+// failure budget, because clientIP() keys off the RIGHTMOST (trusted-proxy-
+// appended) entry — not gin's spoofable c.ClientIP().
+func TestPush_IPBudgetNotSpoofableViaXFF(t *testing.T) {
+	t.Setenv("DM_INCOMINGWEBHOOK_IP_FAIL_RPS", "0.01")
+	t.Setenv("DM_INCOMINGWEBHOOK_IP_FAIL_BURST", "2")
+
+	handler, ctx, groupNo := setupTestEnv(t)
+	const realIP = "198.51.100.20"
+	resetIPFailBucket(t, ctx, realIP)
+
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	whID := parseJSON(t, w)["webhook_id"].(string)
+	body, _ := json.Marshal(pushReq{Content: "hi"})
+	badURL := fmt.Sprintf("/v1/incoming-webhooks/%s/wrong-token", whID)
+
+	// The trusted proxy appends realIP last; the attacker forges a different
+	// leftmost hop on every request. No X-Real-Ip, so clientIP() reads the
+	// rightmost XFF entry.
+	mk := func(spoof string) *http.Request {
+		req := anonReq("POST", badURL, body)
+		req.Header.Set("X-Forwarded-For", spoof+", "+realIP)
+		return req
+	}
+	assert.Equal(t, http.StatusUnauthorized, do(handler, mk("10.0.0.1")).Code)
+	assert.Equal(t, http.StatusUnauthorized, do(handler, mk("10.0.0.2")).Code)
+	// Despite a fresh spoofed leftmost IP each time, the budget (keyed on realIP)
+	// is exhausted → 429. A spoofable leftmost-XFF read would never reach this.
+	w = do(handler, mk("10.0.0.3"))
+	assert.Equalf(t, http.StatusTooManyRequests, w.Code,
+		"varying the leftmost XFF must not grant fresh budget; body=%s", w.Body.String())
 }
 
 func TestPush_RegenerateInvalidatesOldToken(t *testing.T) {

--- a/modules/incomingwebhook/api_test.go
+++ b/modules/incomingwebhook/api_test.go
@@ -121,12 +121,24 @@ func anonReqIP(method, path string, body []byte, ip string) *http.Request {
 // cleared by CleanAllTables (mirrors resetUIDRateLimit).
 func resetIPFailBucket(t *testing.T, ctx *config.Context, ip string) {
 	t.Helper()
+	delRedisKey(t, ctx, "ratelimit:incoming_webhook_ipfail:"+ip)
+}
+
+// resetStrictIPBucket clears the per-IP request limiter bucket
+// (StrictIPRateLimitMiddleware, tag "incoming_webhook") for the same reason.
+func resetStrictIPBucket(t *testing.T, ctx *config.Context, ip string) {
+	t.Helper()
+	delRedisKey(t, ctx, "ratelimit:strict:incoming_webhook:"+ip)
+}
+
+func delRedisKey(t *testing.T, ctx *config.Context, key string) {
+	t.Helper()
 	rdsClient := redis.NewClient(&redis.Options{
 		Addr:     ctx.GetConfig().DB.RedisAddr,
 		Password: ctx.GetConfig().DB.RedisPass,
 	})
 	defer rdsClient.Close()
-	_ = rdsClient.Del("ratelimit:incoming_webhook_ipfail:" + ip).Err()
+	_ = rdsClient.Del(key).Err()
 }
 
 func do(handler http.Handler, req *http.Request) *httptest.ResponseRecorder {
@@ -621,6 +633,7 @@ func TestPush_ValidPushesNotIPLimited(t *testing.T) {
 	handler, ctx, groupNo := setupTestEnv(t)
 	const ip = "203.0.113.7"
 	resetIPFailBucket(t, ctx, ip)
+	resetStrictIPBucket(t, ctx, ip)
 
 	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
 		"name": "x",
@@ -631,12 +644,53 @@ func TestPush_ValidPushesNotIPLimited(t *testing.T) {
 	body, _ := json.Marshal(pushReq{Content: "hi"})
 	url := fmt.Sprintf("/v1/incoming-webhooks/%s/%s", whID, token)
 
-	// Many valid pushes from one IP, far past the IP burst of 1 — none IP-limited.
+	// Many valid pushes from one IP, far past the failure burst of 1 — none
+	// failure-gated (the per-IP REQUEST limiter stays at its generous default).
 	for i := 0; i < 5; i++ {
 		w = do(handler, anonReqIP("POST", url, body, ip))
 		assert.NotEqualf(t, http.StatusTooManyRequests, w.Code,
-			"valid push %d from a fixed IP must not be IP-limited; body=%s", i, w.Body.String())
+			"valid push %d from a fixed IP must not be failure-limited; body=%s", i, w.Body.String())
 	}
+}
+
+// TestPush_ValidPushesCappedByPerIPRequestLimit locks the layer the reviewers
+// asked to keep: the per-IP REQUEST limiter (StrictIPRateLimitMiddleware) bounds
+// ALL requests from one IP — including valid pushes — so a single IP holding many
+// valid tokens cannot drive the full process floor. Only the per-IP request
+// budget is tightened here; every other layer stays generous, so a 429 can only
+// come from that limiter.
+func TestPush_ValidPushesCappedByPerIPRequestLimit(t *testing.T) {
+	t.Setenv("DM_INCOMINGWEBHOOK_IP_RPS", "0.01")
+	t.Setenv("DM_INCOMINGWEBHOOK_IP_BURST", "2")
+	t.Setenv("DM_INCOMINGWEBHOOK_RPS", "1000")
+	t.Setenv("DM_INCOMINGWEBHOOK_BURST", "1000")
+	t.Setenv("DM_INCOMINGWEBHOOK_LOCAL_BURST", "1000")
+	t.Setenv("DM_INCOMINGWEBHOOK_IP_FAIL_BURST", "1000")
+
+	handler, ctx, groupNo := setupTestEnv(t)
+	const ip = "203.0.113.50"
+	resetStrictIPBucket(t, ctx, ip)
+
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	created := parseJSON(t, w)
+	whID := created["webhook_id"].(string)
+	token := created["token"].(string)
+	body, _ := json.Marshal(pushReq{Content: "hi"})
+	url := fmt.Sprintf("/v1/incoming-webhooks/%s/%s", whID, token)
+
+	// First two valid pushes consume the per-IP request burst (not 429).
+	for i := 0; i < 2; i++ {
+		w = do(handler, anonReqIP("POST", url, body, ip))
+		assert.NotEqualf(t, http.StatusTooManyRequests, w.Code,
+			"valid push %d should pass the per-IP request burst; body=%s", i, w.Body.String())
+	}
+	// Third valid push exceeds the per-IP request budget → 429, even though the
+	// token is valid (the multi-valid-token-from-one-IP cap).
+	w = do(handler, anonReqIP("POST", url, body, ip))
+	assert.Equalf(t, http.StatusTooManyRequests, w.Code,
+		"per-IP request limiter must cap valid pushes from one IP; body=%s", w.Body.String())
 }
 
 // TestPush_FailedAuthGetsIPLimited verifies the failure path DOES throttle by

--- a/modules/incomingwebhook/api_test.go
+++ b/modules/incomingwebhook/api_test.go
@@ -551,6 +551,39 @@ func TestPush_PerWebhookRateLimitIsPerWebhook(t *testing.T) {
 		"wh2 must not be limited by wh1's bucket; got %d body=%s", w.Code, w.Body.String())
 }
 
+// TestPush_LocalFloorRateLimits_RedisIndependent verifies the process-local
+// push floor caps the public endpoint on its own. The Redis-backed per-webhook
+// and per-IP limiters are left at their generous defaults (5/10 and 30/60), so
+// they would NOT reject these few calls — the 429 therefore comes from the
+// in-memory floor, which is exactly the protection that survives a Redis outage
+// (where both Redis limiters fail open). Floor burst is tightened to 2 via env.
+func TestPush_LocalFloorRateLimits_RedisIndependent(t *testing.T) {
+	t.Setenv("DM_INCOMINGWEBHOOK_LOCAL_BURST", "2")
+	t.Setenv("DM_INCOMINGWEBHOOK_LOCAL_RPS", "0.01") // ~never refills within the test
+
+	handler, _, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "x",
+	}))
+	created := parseJSON(t, w)
+	whID := created["webhook_id"].(string)
+	token := created["token"].(string)
+
+	body, _ := json.Marshal(pushReq{Content: "hi"})
+	url := fmt.Sprintf("/v1/incoming-webhooks/%s/%s", whID, token)
+
+	// First two consume the floor burst (not rate-limited; result may be 200/502
+	// depending on WuKongIM, the point is only that they pass the floor).
+	for i := 0; i < 2; i++ {
+		w = do(handler, anonReq("POST", url, body))
+		assert.NotEqualf(t, http.StatusTooManyRequests, w.Code, "i=%d body=%s", i, w.Body.String())
+	}
+	// Third exceeds the floor → 429, despite the Redis per-webhook limiter (10
+	// burst) still having capacity. Proves the floor is an independent ceiling.
+	w = do(handler, anonReq("POST", url, body))
+	assert.Equalf(t, http.StatusTooManyRequests, w.Code, "local floor must 429 after its burst; body=%s", w.Body.String())
+}
+
 func TestPush_RegenerateInvalidatesOldToken(t *testing.T) {
 	handler, _, groupNo := setupTestEnv(t)
 	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{

--- a/modules/incomingwebhook/localfloor.go
+++ b/modules/incomingwebhook/localfloor.go
@@ -35,9 +35,10 @@ const (
 	defaultLocalFloorBurst = 400
 )
 
-// localFloor is a process-global in-memory token bucket, built once from env at
-// construction. New() builds a fresh floor per process (and per test server),
-// so the env is read at the same point as the module's other startup config.
+// localFloor is a per-instance in-memory token bucket, built once from env at
+// construction. New() builds a fresh floor per IncomingWebhook (one per process
+// in production, one per test server), so the env is read at the same point as
+// the module's other startup config.
 type localFloor struct {
 	lim *rate.Limiter // nil = disabled
 }

--- a/modules/incomingwebhook/localfloor.go
+++ b/modules/incomingwebhook/localfloor.go
@@ -1,0 +1,80 @@
+package incomingwebhook
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"golang.org/x/time/rate"
+)
+
+// Redis-independent, process-local rate ceiling for the public push endpoint.
+//
+// `POST /v1/incoming-webhooks/:webhook_id/:token` is the only unauthenticated,
+// publicly reachable route in this module. Its per-IP and per-webhook limiters
+// are both Redis-backed and fail-open: when Redis is unavailable (or its
+// connection pool is saturated) they silently stop limiting, leaving the
+// endpoint — which still performs 2 DB reads + 1 WuKongIM send per call — open
+// to flood amplification. webhook_id (128-bit) and token (256-bit) make
+// enumeration infeasible regardless, so the real exposure is a flood, not token
+// theft. This in-memory token bucket sits in FRONT of the Redis limiters as an
+// always-on floor, so a single instance keeps a bounded push rate even with
+// Redis down, and a flood is shed before it ever touches Redis.
+//
+// Defaults are deliberately generous (200 rps / 400 burst per instance): under
+// healthy Redis the per-IP (30 rps) and per-webhook (5 rps) limiters are far
+// lower and bite first, so the floor only engages as a backstop. Tunable via
+// DM_INCOMINGWEBHOOK_LOCAL_RPS / _BURST, read once at construction (no hot
+// reload, matching octo-lib's limiter middlewares). Fail-safe: the shared env
+// parsers coerce 0 / negative / unparseable values to the generous default, so
+// the floor CANNOT be silently switched off via env — loosen it with a high
+// rps/burst instead.
+const (
+	envLocalFloorRPS   = "DM_INCOMINGWEBHOOK_LOCAL_RPS"
+	envLocalFloorBurst = "DM_INCOMINGWEBHOOK_LOCAL_BURST"
+
+	defaultLocalFloorRPS   = 200.0
+	defaultLocalFloorBurst = 400
+)
+
+// localFloor is a process-global in-memory token bucket, built once from env at
+// construction. New() builds a fresh floor per process (and per test server),
+// so the env is read at the same point as the module's other startup config.
+type localFloor struct {
+	lim *rate.Limiter // nil = disabled
+}
+
+func newLocalFloor() *localFloor {
+	rps := wkhttp.ParseRPSFromEnv(envLocalFloorRPS, defaultLocalFloorRPS)
+	burst := wkhttp.ParseBurstFromEnv(envLocalFloorBurst, defaultLocalFloorBurst)
+	// Defensive: env "0"/invalid already coerces to a positive default, so this
+	// only fires if a default *constant* is ever set <=0. Without it,
+	// rate.NewLimiter(0, ...) would build a deny-all bucket and the floor would
+	// reject every push — far worse than being off. Treat <=0 as disabled.
+	if rps <= 0 || burst <= 0 {
+		return &localFloor{}
+	}
+	return &localFloor{lim: rate.NewLimiter(rate.Limit(rps), burst)}
+}
+
+// allow reports whether a push may proceed. f.lim is immutable after
+// construction and rate.Limiter.Allow() is internally synchronized, so allow()
+// needs no extra locking; a nil limiter (disabled) always allows.
+func (f *localFloor) allow() bool {
+	if f.lim == nil {
+		return true
+	}
+	return f.lim.Allow()
+}
+
+// localFloorMiddleware enforces the Redis-independent per-instance push ceiling
+// ahead of the Redis-backed IP limiter, so a flood is shed in-memory without
+// even reaching Redis. On rejection it returns the same i18n 429 as the
+// per-webhook limiter (pushRateLimited aborts the chain); on pass it calls
+// c.Next() to continue to the next handler, mirroring StrictIPRateLimitMiddleware.
+func (w *IncomingWebhook) localFloorMiddleware() wkhttp.HandlerFunc {
+	return func(c *wkhttp.Context) {
+		if !w.floor.allow() {
+			pushRateLimited(c)
+			return
+		}
+		c.Next()
+	}
+}

--- a/modules/incomingwebhook/localfloor.go
+++ b/modules/incomingwebhook/localfloor.go
@@ -19,8 +19,9 @@ import (
 // Redis down, and a flood is shed before it ever touches Redis.
 //
 // Defaults are deliberately generous (200 rps / 400 burst per instance): under
-// healthy Redis the per-IP (30 rps) and per-webhook (5 rps) limiters are far
-// lower and bite first, so the floor only engages as a backstop. Tunable via
+// healthy Redis the per-IP request limiter (100 rps) and per-webhook limiter
+// (5 rps) are lower and bite first, so the floor only engages as a backstop.
+// Tunable via
 // DM_INCOMINGWEBHOOK_LOCAL_RPS / _BURST, read once at construction (no hot
 // reload, matching octo-lib's limiter middlewares). Fail-safe: the shared env
 // parsers coerce 0 / negative / unparseable values to the generous default, so

--- a/modules/incomingwebhook/localfloor_test.go
+++ b/modules/incomingwebhook/localfloor_test.go
@@ -1,0 +1,66 @@
+package incomingwebhook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Unit tests for the Redis-independent local push floor. These need no DB /
+// Redis / WuKongIM — they exercise the in-memory token bucket directly, so they
+// run in plain `go test` and document the limiter contract.
+
+// TestLocalFloor_AllowsBurstThenBlocks: with a tiny refill rate, exactly `burst`
+// calls pass before the bucket empties and further calls are rejected.
+func TestLocalFloor_AllowsBurstThenBlocks(t *testing.T) {
+	t.Setenv(envLocalFloorBurst, "2")
+	t.Setenv(envLocalFloorRPS, "0.001") // ~never refills within the test
+
+	f := newLocalFloor()
+	assert.True(t, f.allow(), "1st call within burst must pass")
+	assert.True(t, f.allow(), "2nd call within burst must pass")
+	assert.False(t, f.allow(), "3rd call must be rejected once burst is spent")
+	assert.False(t, f.allow(), "still rejected while the bucket is empty")
+}
+
+// TestLocalFloor_ZeroEnvDoesNotDisable documents the fail-safe: the shared env
+// parsers coerce 0 / negative / unparseable values to the generous default, so
+// setting the env to "0" does NOT disable the floor — it stays enabled at the
+// default ceiling (a default-sized burst passes, one past it is still blocked).
+func TestLocalFloor_ZeroEnvDoesNotDisable(t *testing.T) {
+	t.Setenv(envLocalFloorRPS, "0")
+	t.Setenv(envLocalFloorBurst, "0")
+
+	f := newLocalFloor()
+	for i := 0; i < defaultLocalFloorBurst; i++ {
+		assert.Truef(t, f.allow(), "coerced-to-default floor must allow up to default burst (i=%d)", i)
+	}
+	assert.False(t, f.allow(), "one past the default burst is still rejected — env 0 did not disable the floor")
+}
+
+// TestLocalFloor_ConfiguredAtConstruction: env is read once when the floor is
+// built, so two floors constructed under different env get independent limits.
+func TestLocalFloor_ConfiguredAtConstruction(t *testing.T) {
+	t.Setenv(envLocalFloorBurst, "1")
+	t.Setenv(envLocalFloorRPS, "0.001")
+	tight := newLocalFloor()
+	assert.True(t, tight.allow(), "tight floor: first call gets the lone token")
+	assert.False(t, tight.allow(), "tight floor: second call is rejected")
+
+	t.Setenv(envLocalFloorBurst, "100")
+	loose := newLocalFloor()
+	for i := 0; i < 100; i++ {
+		assert.Truef(t, loose.allow(), "loose floor built later must allow its own burst (i=%d)", i)
+	}
+}
+
+// TestLocalFloor_DefaultIsBackstop: with no env override the default bucket is
+// large enough that ordinary traffic never trips it (it only acts as a Redis-
+// outage backstop). A burst of default size all passes.
+func TestLocalFloor_DefaultIsBackstop(t *testing.T) {
+	f := newLocalFloor()
+	for i := 0; i < defaultLocalFloorBurst; i++ {
+		assert.Truef(t, f.allow(), "default burst must all pass (i=%d)", i)
+	}
+	assert.False(t, f.allow(), "one past the default burst is rejected")
+}

--- a/modules/incomingwebhook/localfloor_test.go
+++ b/modules/incomingwebhook/localfloor_test.go
@@ -10,6 +10,20 @@ import (
 // Redis / WuKongIM — they exercise the in-memory token bucket directly, so they
 // run in plain `go test` and document the limiter contract.
 
+// countAllowed fires n calls and returns how many were allowed. Used by the
+// default-config tests, where the 200 rps default refill makes an exact "burst
+// then exactly one reject" assertion timing-sensitive on slow CI; a range check
+// (full burst passes, but not 2× burst) is refill-robust instead.
+func countAllowed(f *localFloor, n int) int {
+	allowed := 0
+	for i := 0; i < n; i++ {
+		if f.allow() {
+			allowed++
+		}
+	}
+	return allowed
+}
+
 // TestLocalFloor_AllowsBurstThenBlocks: with a tiny refill rate, exactly `burst`
 // calls pass before the bucket empties and further calls are rejected.
 func TestLocalFloor_AllowsBurstThenBlocks(t *testing.T) {
@@ -32,10 +46,9 @@ func TestLocalFloor_ZeroEnvDoesNotDisable(t *testing.T) {
 	t.Setenv(envLocalFloorBurst, "0")
 
 	f := newLocalFloor()
-	for i := 0; i < defaultLocalFloorBurst; i++ {
-		assert.Truef(t, f.allow(), "coerced-to-default floor must allow up to default burst (i=%d)", i)
-	}
-	assert.False(t, f.allow(), "one past the default burst is still rejected — env 0 did not disable the floor")
+	allowed := countAllowed(f, 2*defaultLocalFloorBurst)
+	assert.GreaterOrEqual(t, allowed, defaultLocalFloorBurst, "coerced-to-default burst must all pass")
+	assert.Less(t, allowed, 2*defaultLocalFloorBurst, "env 0 did not disable the floor; it stays bounded at the default")
 }
 
 // TestLocalFloor_ConfiguredAtConstruction: env is read once when the floor is
@@ -59,8 +72,7 @@ func TestLocalFloor_ConfiguredAtConstruction(t *testing.T) {
 // outage backstop). A burst of default size all passes.
 func TestLocalFloor_DefaultIsBackstop(t *testing.T) {
 	f := newLocalFloor()
-	for i := 0; i < defaultLocalFloorBurst; i++ {
-		assert.Truef(t, f.allow(), "default burst must all pass (i=%d)", i)
-	}
-	assert.False(t, f.allow(), "one past the default burst is rejected")
+	allowed := countAllowed(f, 2*defaultLocalFloorBurst)
+	assert.GreaterOrEqual(t, allowed, defaultLocalFloorBurst, "the full default burst must pass")
+	assert.Less(t, allowed, 2*defaultLocalFloorBurst, "default floor is bounded; not everything passes")
 }

--- a/modules/incomingwebhook/ratelimit.go
+++ b/modules/incomingwebhook/ratelimit.go
@@ -2,6 +2,7 @@ package incomingwebhook
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"strings"
@@ -123,6 +124,11 @@ func (w *IncomingWebhook) runBucketScript(script *redis.Script, key string, args
 	}
 	arr, ok := res.([]interface{})
 	if !ok || len(arr) < 1 {
+		// Unexpected return shape from the Lua script — fail open, but log it
+		// (throttled): on security-sensitive limiter code a silently-swallowed
+		// malformed reply would hide a real bug behind "always allowed".
+		w.warnDegraded("rate limit script returned unexpected shape, fail-open",
+			fmt.Errorf("result type %T", res))
 		return true, nil
 	}
 	allowed, _ := arr[0].(int64)

--- a/modules/incomingwebhook/ratelimit.go
+++ b/modules/incomingwebhook/ratelimit.go
@@ -206,8 +206,10 @@ func (w *IncomingWebhook) penalizeIPFailure(ip string) {
 
 // ipFailureGateMiddleware rejects (429) requests from an IP that has burned its
 // auth-failure budget, before the handler runs — so a token-scanning IP stops
-// hitting the DB and the shared local floor. Read-only peek; fail-open on Redis
-// error. On pass it calls c.Next() (mirrors StrictIPRateLimitMiddleware).
+// reaching the DB and the per-webhook limiter once cut off. Sits after the floor
+// and per-IP request limiter (which it cannot un-consume), but with a lower,
+// failure-specific budget it cuts a scanner faster and without charging valid
+// traffic. Read-only peek; fail-open on Redis error. On pass it calls c.Next().
 func (w *IncomingWebhook) ipFailureGateMiddleware() wkhttp.HandlerFunc {
 	return func(c *wkhttp.Context) {
 		ok, err := w.ipFailureBudgetOK(clientIP(c.Request))

--- a/modules/incomingwebhook/ratelimit.go
+++ b/modules/incomingwebhook/ratelimit.go
@@ -2,9 +2,15 @@ package incomingwebhook
 
 import (
 	"context"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/go-redis/redis"
+	"go.uber.org/zap"
 )
 
 // tokenBucketScript 与 octo-lib pkg/wkhttp/ratelimit.go 中的脚本同形，单独维护一份是为了
@@ -51,6 +57,78 @@ end
 return {allowed, math.floor(filled), retry_after}
 `
 
+// ipFailureBucketScript is a per-IP "auth-failure budget" token bucket whose
+// tokens are spent by the CALLER, not on every request. The push gate PEEKS
+// (spend=0) to reject an IP that has already burned its budget; each genuine
+// auth failure SPENDS (spend=1) one token. Valid pushes never spend, so a
+// fixed/shared server IP is not throttled by request volume — only sustained
+// scanning (repeated auth failures) from an IP exhausts the budget and gets
+// gated. It deliberately shares the same refill math as tokenBucketScript but
+// stays a separate script: tokenBucketScript always consumes, this one's spend
+// is caller-controlled, and folding both into one parametrized script would add
+// peek/spend branching to the per-webhook limiter for no benefit.
+const ipFailureBucketScript = `
+local key = KEYS[1]
+local rate = tonumber(ARGV[1])
+local burst = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
+local spend = tonumber(ARGV[4])
+
+if rate <= 0 or burst <= 0 then return {1} end
+
+local state = redis.call("HMGET", key, "tokens", "ts")
+local existed = state[1] ~= false
+local tokens = tonumber(state[1])
+local ts = tonumber(state[2])
+if tokens == nil then tokens = burst end
+if ts == nil then ts = now end
+
+local delta = math.max(0, now - ts)
+tokens = math.min(burst, tokens + delta * rate)
+
+local allowed = 0
+if tokens >= 1 then allowed = 1 end
+
+local ttl = math.max(1, math.ceil((burst / rate) * 2))
+if spend == 1 then
+    -- an auth failure: deduct a token and (re)arm the key TTL.
+    if tokens >= 1 then tokens = tokens - 1 end
+    redis.call("HMSET", key, "tokens", tokens, "ts", now)
+    redis.call("EXPIRE", key, ttl)
+elseif existed then
+    -- read-only peek on an existing (draining/throttled) key: refresh its TTL so
+    -- an actively-probing scanner cannot wait the key out and reset to a full
+    -- budget. The token/ts state is left untouched, so refill stays correct
+    -- (computed from the last spend's ts); legit IPs never created a key, so
+    -- this stays write-free for them.
+    redis.call("EXPIRE", key, ttl)
+end
+
+return {allowed}
+`
+
+// Compile the Lua scripts once (caches the SHA1) instead of per request.
+var (
+	perWebhookScript = redis.NewScript(tokenBucketScript)
+	ipFailureScript  = redis.NewScript(ipFailureBucketScript)
+)
+
+// runBucketScript runs a token-bucket Lua script and returns whether the call is
+// allowed (return value [0] == 1). A Redis failure yields (true, err) so every
+// caller fails open.
+func (w *IncomingWebhook) runBucketScript(script *redis.Script, key string, args ...interface{}) (bool, error) {
+	res, err := script.Run(w.rateRedis, []string{key}, args...).Result()
+	if err != nil {
+		return true, err
+	}
+	arr, ok := res.([]interface{})
+	if !ok || len(arr) < 1 {
+		return true, nil
+	}
+	allowed, _ := arr[0].(int64)
+	return allowed == 1, nil
+}
+
 // allowPerWebhook 按 webhook_id 维度做令牌桶判定，独立于 IP 限流。
 // Redis 故障时返回 (true, err)，由调用方决定是否记日志（fail-open）。
 func (w *IncomingWebhook) allowPerWebhook(_ context.Context, webhookID string) (bool, error) {
@@ -60,16 +138,109 @@ func (w *IncomingWebhook) allowPerWebhook(_ context.Context, webhookID string) (
 		return true, nil
 	}
 	now := float64(time.Now().UnixNano()) / float64(time.Second)
-	script := redis.NewScript(tokenBucketScript)
-	res, err := script.Run(w.rateRedis, []string{"ratelimit:incoming_webhook:" + webhookID},
-		rps, burst, now).Result()
-	if err != nil {
-		return true, err
+	return w.runBucketScript(perWebhookScript, "ratelimit:incoming_webhook:"+webhookID, rps, burst, now)
+}
+
+// unknownIPKey buckets requests whose client IP could not be resolved, so they
+// share one auth-failure budget (fail-closed) rather than being silently exempt.
+const unknownIPKey = "__unknown_ip__"
+
+func ipFailureKey(ip string) string {
+	if ip == "" {
+		ip = unknownIPKey
 	}
-	arr, ok := res.([]interface{})
-	if !ok || len(arr) != 3 {
+	return "ratelimit:incoming_webhook_ipfail:" + ip
+}
+
+// clientIP resolves the caller IP the same way octo-lib's limiters do: X-Real-Ip,
+// then the RIGHTMOST X-Forwarded-For entry (the value a trusted reverse proxy /
+// CLB appends — clients can prepend fake hops but not control the rightmost),
+// then RemoteAddr. Using gin's c.ClientIP() here would be WRONG: wkhttp builds
+// gin with the default trust-all-proxies config, so c.ClientIP() returns the
+// leftmost (client-controlled, spoofable) XFF entry, letting a scanner forge a
+// new IP per request and evade the failure budget entirely.
+//
+// ⚠️ Trust assumption (same as octo-lib): the edge proxy must overwrite
+// X-Real-Ip / append the real client to X-Forwarded-For.
+func clientIP(r *http.Request) string {
+	if ip := strings.TrimSpace(r.Header.Get("X-Real-Ip")); ip != "" {
+		return ip
+	}
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		parts := strings.Split(xff, ",")
+		if ip := strings.TrimSpace(parts[len(parts)-1]); ip != "" {
+			return ip
+		}
+	}
+	if ip, _, err := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr)); err == nil {
+		return ip
+	}
+	return ""
+}
+
+// ipFailureBudgetOK peeks (no spend) whether the IP still has auth-failure
+// budget. A disabled budget always passes; an empty IP shares the unknown bucket.
+func (w *IncomingWebhook) ipFailureBudgetOK(ip string) (bool, error) {
+	rps, burst := ipFailRPS(), ipFailBurst()
+	if rps <= 0 || burst <= 0 {
 		return true, nil
 	}
-	allowed, _ := arr[0].(int64)
-	return allowed == 1, nil
+	now := float64(time.Now().UnixNano()) / float64(time.Second)
+	return w.runBucketScript(ipFailureScript, ipFailureKey(ip), rps, burst, now, 0)
+}
+
+// penalizeIPFailure spends one token from the IP's auth-failure budget. Called
+// only on genuine auth-failure signals (unknown webhook / bad token / malformed
+// request), never on valid pushes or server-side (DB) errors. Best-effort: a
+// Redis failure is logged (throttled) and ignored (fail-open).
+func (w *IncomingWebhook) penalizeIPFailure(ip string) {
+	rps, burst := ipFailRPS(), ipFailBurst()
+	if rps <= 0 || burst <= 0 {
+		return
+	}
+	now := float64(time.Now().UnixNano()) / float64(time.Second)
+	if _, err := w.runBucketScript(ipFailureScript, ipFailureKey(ip), rps, burst, now, 1); err != nil {
+		w.warnDegraded("penalize ip failure budget redis failed, ignoring", err)
+	}
+}
+
+// ipFailureGateMiddleware rejects (429) requests from an IP that has burned its
+// auth-failure budget, before the handler runs — so a token-scanning IP stops
+// hitting the DB and the shared local floor. Read-only peek; fail-open on Redis
+// error. On pass it calls c.Next() (mirrors StrictIPRateLimitMiddleware).
+func (w *IncomingWebhook) ipFailureGateMiddleware() wkhttp.HandlerFunc {
+	return func(c *wkhttp.Context) {
+		ok, err := w.ipFailureBudgetOK(clientIP(c.Request))
+		if err != nil {
+			w.warnDegraded("ip failure budget peek redis failed, fail-open", err)
+			ok = true
+		}
+		if !ok {
+			pushRateLimited(c)
+			return
+		}
+		c.Next()
+	}
+}
+
+// degradeWarnInterval throttles fail-open warnings from the Redis-backed
+// limiters so a sustained Redis outage on the push hot path logs at most once
+// per interval instead of once per request (mirrors octo-lib keyedLimiter's
+// logDegrade).
+const degradeWarnInterval = 30 * time.Second
+
+var (
+	degradeWarnMu   sync.Mutex
+	degradeWarnLast time.Time
+)
+
+func (w *IncomingWebhook) warnDegraded(msg string, err error) {
+	degradeWarnMu.Lock()
+	if !degradeWarnLast.IsZero() && time.Since(degradeWarnLast) < degradeWarnInterval {
+		degradeWarnMu.Unlock()
+		return
+	}
+	degradeWarnLast = time.Now()
+	degradeWarnMu.Unlock()
+	w.Warn(msg, zap.Error(err))
 }


### PR DESCRIPTION
Hardens the **public, unauthenticated** push endpoint (`POST /v1/incoming-webhooks/:webhook_id/:token`). Addresses item 1 of #284.

## What changed — four-layer defense (coarse → fine)

```
localFloor (200/400, in-memory) → ipLimit (per-IP all requests, 100/200) → ipFailureGate (per-IP failures, 30/60) → allowPerWebhook (per-webhook, 5/10)
```

1. **Local floor** (`golang.org/x/time/rate`, in-memory, per-instance): always-on, Redis-independent backstop. Before this PR a Redis outage left the endpoint with **no** flood ceiling in front of 2 DB reads + 1 WuKongIM send per call (both Redis limiters fail open). Built once from env at construction.
2. **Per-IP request limiter** (`StrictIPRateLimitMiddleware`): caps **all** requests from one IP, bounding the "single IP holding many valid tokens" case below the floor.
3. **Per-IP auth-failure budget** (new): tokens are spent **only on genuine auth failures** (unknown / soft-deleted webhook, bad token, malformed) — never on valid pushes or DB errors. A read-only gate rejects an IP that burned its budget before the handler/DB run. This is why fixed/shared server IPs are not throttled by valid volume.
4. **Per-webhook** limiter: unchanged per-token shaping.

Trusted client IP via `clientIP()` (X-Real-Ip / **rightmost** X-Forwarded-For, matching octo-lib `getClientIP`) — not gin `c.ClientIP()`, which would read the spoofable leftmost XFF. `TestPush_IPBudgetNotSpoofableViaXFF` pins this.

## ⚠️ Operator-visible behavior changes (release-note worthy)

- **Per-IP request limiter default raised `30/60` → `100/200` rps/burst.** Higher cap so legitimate fixed/shared-egress integrations (NAT, CI servers pushing to many webhooks) aren't false-throttled, while still capping a single IP below the 200 rps floor. Env names **unchanged**: `DM_INCOMINGWEBHOOK_IP_RPS` / `DM_INCOMINGWEBHOOK_IP_BURST` — existing tuning still applies.
- **New env for the failure budget:** `DM_INCOMINGWEBHOOK_IP_FAIL_RPS` / `_BURST` (default 30/60). This is a *failure* budget, not a request volume cap — do **not** copy an old `IP_RPS` value into it.
- **New env for the floor:** `DM_INCOMINGWEBHOOK_LOCAL_RPS` / `_BURST` (default 200/400). Fail-safe: 0/invalid coerces to the default (can't be disabled via env).
- The floor is **per-instance**, so the Redis-independent ceiling is N×200 rps cluster-wide; no cluster-wide cap survives a full Redis outage (the per-IP/per-webhook Redis limiters do, when Redis is up).

## Review polish (commit `14274f0`)

- Soft-deleted `webhook_id` now **spends** the failure budget (scan/abuse signal); the grace stays only for the just-*disabled* case (valid token may still be in flight). — yujiawei P2-1
- `Retry-After: 1` on the module's 429s so machine senders back off (the per-IP request limiter already sets precise headers). — multiple reviewers
- `runBucketScript` logs (throttled) on an unexpected Lua return shape instead of silently failing open. — Jerry-Xin

## Tests
`TestLocalFloor_*` (unit, no infra) + push route tests: floor backstop, fixed-IP valid-push exemption, per-IP request cap, failure budget, XFF-spoof resistance, soft-deleted-spends / disabled-grace.

## Out of scope / follow-up
Generalizing the failure-budget limiter into octo-lib; per-site degrade-warn keys; tightening the failure-budget default; the audit-table TTL cleanup (separate #284 item, deferred).

https://claude.ai/code/session_01QANZGMWfyu7WnEdgjyGNJe