### PR TITLE
feat(incomingwebhook): make local push floor IP-aware to avoid cross-IP starvation

### DIFF
--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -157,7 +157,10 @@ func (w *IncomingWebhook) Route(r *wkhttp.WKHttp) {
 
 	// 推送类：URL 内 token 鉴权，无 AuthMiddleware。四层限流，由粗到细：
 	//  1) localFloorMiddleware —— 纯内存、不依赖 Redis 的进程级地板，先挡洪峰；Redis
-	//     故障时仍限速，避免对 DB + WuKongIM 的洪泛放大。
+	//     故障时仍限速，避免对 DB + WuKongIM 的洪泛放大。内含两段（均不依赖 Redis）：
+	//     先按 IP 的内存令牌桶(默认 50rps)，再按全局进程桶(默认 200rps)。per-IP 段在前，
+	//     使单个滥用 IP 至多吃掉它那份地板配额，避免一个 IP 抽干全局桶、误杀其它 IP 的
+	//     合法推送(#287)；全局段仍封顶 Redis 故障下的分布式洪流(多 IP)，是地板的本意。
 	//  2) ipLimit (StrictIPRateLimitMiddleware) —— 按 IP 对【全部】请求限流(默认 100rps，
 	//     低于 floor)，给"单 IP 持多有效 token"的洪流封一个硬天花板，防止一个 IP 吃满
 	//     全局 floor 挤占其它租户。阈值高于旧值，合法共享/固定 IP 的正常量不被误杀。

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -158,7 +158,8 @@ func (w *IncomingWebhook) Route(r *wkhttp.WKHttp) {
 	// 推送类：URL 内 token 鉴权，无 AuthMiddleware。四层限流，由粗到细：
 	//  1) localFloorMiddleware —— 纯内存、不依赖 Redis 的进程级地板，先挡洪峰；Redis
 	//     故障时仍限速，避免对 DB + WuKongIM 的洪泛放大。内含两段（均不依赖 Redis）：
-	//     先按 IP 的内存令牌桶(默认 50rps)，再按全局进程桶(默认 200rps)。per-IP 段在前，
+	//     先按 IP 的内存令牌桶(默认 100rps，与下方 Redis per-IP 限流持平)，再按全局进程桶
+	//     (默认 200rps)。per-IP 段在前，
 	//     使单个滥用 IP 至多吃掉它那份地板配额，避免一个 IP 抽干全局桶、误杀其它 IP 的
 	//     合法推送(#287)；全局段仍封顶 Redis 故障下的分布式洪流(多 IP)，是地板的本意。
 	//  2) ipLimit (StrictIPRateLimitMiddleware) —— 按 IP 对【全部】请求限流(默认 100rps，

--- a/modules/incomingwebhook/localfloor.go
+++ b/modules/incomingwebhook/localfloor.go
@@ -1,6 +1,8 @@
 package incomingwebhook
 
 import (
+	"sync"
+
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"golang.org/x/time/rate"
 )
@@ -18,62 +20,176 @@ import (
 // always-on floor, so a single instance keeps a bounded push rate even with
 // Redis down, and a flood is shed before it ever touches Redis.
 //
-// Defaults are deliberately generous (200 rps / 400 burst per instance): under
-// healthy Redis the per-IP request limiter (100 rps) and per-webhook limiter
-// (5 rps) are lower and bite first, so the floor only engages as a backstop.
-// Tunable via
-// DM_INCOMINGWEBHOOK_LOCAL_RPS / _BURST, read once at construction (no hot
-// reload, matching octo-lib's limiter middlewares). Fail-safe: the shared env
-// parsers coerce 0 / negative / unparseable values to the generous default, so
-// the floor CANNOT be silently switched off via env — loosen it with a high
-// rps/burst instead.
+// The floor has TWO Redis-independent layers, checked per request in order:
+//
+//  1. a per-IP in-memory token bucket (perIPFloor, ~50 rps / 100 burst), and
+//  2. a global per-instance token bucket (200 rps / 400 burst).
+//
+// The per-IP layer is checked FIRST so a single abusive IP can consume at most
+// its per-IP share of the global floor: without it, the global bucket is a
+// single shared resource that one IP (bounded only by the ~500 rps/IP DDoS
+// limiter in main.go) can drain, causing collateral 429s for valid pushes from
+// other IPs (issue #287). The global layer still bounds a DISTRIBUTED flood
+// (many IPs) under a Redis outage, which is the instance cap's whole point —
+// a pure per-IP floor would lose that.
+//
+// Defaults are deliberately generous: under healthy Redis the per-IP request
+// limiter (100 rps) and per-webhook limiter (5 rps) are lower and bite first,
+// so the floor only engages as a backstop. Tunable via
+// DM_INCOMINGWEBHOOK_LOCAL_RPS / _BURST (global) and
+// DM_INCOMINGWEBHOOK_LOCAL_PERIP_RPS / _BURST / _MAX_IPS (per-IP), read once at
+// construction (no hot reload, matching octo-lib's limiter middlewares).
+// Fail-safe: the shared env parsers coerce 0 / negative / unparseable values to
+// the generous default, so neither layer can be silently switched off via env —
+// loosen it with a high rps/burst instead.
 const (
 	envLocalFloorRPS   = "DM_INCOMINGWEBHOOK_LOCAL_RPS"
 	envLocalFloorBurst = "DM_INCOMINGWEBHOOK_LOCAL_BURST"
 
+	envLocalFloorPerIPRPS   = "DM_INCOMINGWEBHOOK_LOCAL_PERIP_RPS"
+	envLocalFloorPerIPBurst = "DM_INCOMINGWEBHOOK_LOCAL_PERIP_BURST"
+	envLocalFloorMaxIPs     = "DM_INCOMINGWEBHOOK_LOCAL_MAX_IPS"
+
 	defaultLocalFloorRPS   = 200.0
 	defaultLocalFloorBurst = 400
+
+	// Per-IP sub-limit: a single IP gets at most ~50 rps / 100 burst of the
+	// global floor, so one IP cannot starve others. Lower than the global cap so
+	// several distinct IPs can coexist under the global ceiling.
+	defaultLocalFloorPerIPRPS   = 50.0
+	defaultLocalFloorPerIPBurst = 100
+	// Hard cap on the number of distinct per-IP buckets kept in memory, so a
+	// Redis-down DISTRIBUTED flood (many source IPs) cannot grow the map without
+	// bound. At the cap the oldest generation of buckets is dropped wholesale
+	// (see perIPFloor); evicted IPs simply start from a full bucket again, which
+	// is harmless because the global floor still bounds total throughput.
+	defaultLocalFloorMaxIPs = 100000
 )
 
-// localFloor is a per-instance in-memory token bucket, built once from env at
-// construction. New() builds a fresh floor per IncomingWebhook (one per process
-// in production, one per test server), so the env is read at the same point as
-// the module's other startup config.
+// localFloor is the per-instance Redis-independent push ceiling, built once from
+// env at construction. New() builds a fresh floor per IncomingWebhook (one per
+// process in production, one per test server), so the env is read at the same
+// point as the module's other startup config.
 type localFloor struct {
-	lim *rate.Limiter // nil = disabled
+	lim   *rate.Limiter // global instance cap; nil = disabled
+	perIP *perIPFloor   // per-IP sub-limit; nil = disabled
 }
 
 func newLocalFloor() *localFloor {
+	f := &localFloor{}
+
 	rps := wkhttp.ParseRPSFromEnv(envLocalFloorRPS, defaultLocalFloorRPS)
 	burst := wkhttp.ParseBurstFromEnv(envLocalFloorBurst, defaultLocalFloorBurst)
 	// Defensive: env "0"/invalid already coerces to a positive default, so this
 	// only fires if a default *constant* is ever set <=0. Without it,
 	// rate.NewLimiter(0, ...) would build a deny-all bucket and the floor would
 	// reject every push — far worse than being off. Treat <=0 as disabled.
-	if rps <= 0 || burst <= 0 {
-		return &localFloor{}
+	if rps > 0 && burst > 0 {
+		f.lim = rate.NewLimiter(rate.Limit(rps), burst)
 	}
-	return &localFloor{lim: rate.NewLimiter(rate.Limit(rps), burst)}
+
+	perIPRPS := wkhttp.ParseRPSFromEnv(envLocalFloorPerIPRPS, defaultLocalFloorPerIPRPS)
+	perIPBurst := wkhttp.ParseBurstFromEnv(envLocalFloorPerIPBurst, defaultLocalFloorPerIPBurst)
+	maxIPs := wkhttp.ParseBurstFromEnv(envLocalFloorMaxIPs, defaultLocalFloorMaxIPs)
+	if perIPRPS > 0 && perIPBurst > 0 && maxIPs > 0 {
+		f.perIP = newPerIPFloor(rate.Limit(perIPRPS), perIPBurst, maxIPs)
+	}
+
+	return f
 }
 
-// allow reports whether a push may proceed. f.lim is immutable after
-// construction and rate.Limiter.Allow() is internally synchronized, so allow()
-// needs no extra locking; a nil limiter (disabled) always allows.
-func (f *localFloor) allow() bool {
+// allow reports whether a push from ip may proceed. The per-IP sub-limit is
+// checked FIRST (so a gated IP never even spends a global token, preventing
+// single-IP starvation of the shared global bucket), then the global instance
+// cap. Both limiters are internally synchronized / lock their own state, so
+// allow() needs no extra locking; a nil layer is disabled and always allows.
+func (f *localFloor) allow(ip string) bool {
+	if f.perIP != nil && !f.perIP.allow(ip) {
+		return false
+	}
 	if f.lim == nil {
 		return true
 	}
 	return f.lim.Allow()
 }
 
+// perIPUnknownKey buckets requests whose client IP could not be resolved into
+// one shared per-IP bucket, so an unresolved-IP flood is throttled together
+// rather than each getting its own fresh bucket (which would defeat the cap).
+const perIPUnknownKey = "__unknown_ip__"
+
+// perIPFloor is a Redis-independent, memory-bounded set of per-IP token
+// buckets. Memory is capped WITHOUT a background goroutine using a
+// two-generation map: lookups hit `cur` first, then promote from `prev`; when
+// `cur` fills to maxEntries the generations rotate (prev := cur, cur := empty),
+// dropping the coldest buckets wholesale. This bounds live buckets to
+// ~2*maxEntries and keeps actively-pushing IPs alive across rotations, at the
+// cost of being an approximate-LRU rather than exact — acceptable here because
+// the per-IP layer only needs to stop single-IP starvation, while the global
+// floor remains the throughput bound under a distributed flood.
+type perIPFloor struct {
+	mu         sync.Mutex
+	rps        rate.Limit
+	burst      int
+	maxEntries int
+	cur        map[string]*rate.Limiter
+	prev       map[string]*rate.Limiter
+}
+
+func newPerIPFloor(rps rate.Limit, burst, maxEntries int) *perIPFloor {
+	return &perIPFloor{
+		rps:        rps,
+		burst:      burst,
+		maxEntries: maxEntries,
+		cur:        make(map[string]*rate.Limiter),
+	}
+}
+
+// limiterFor returns the (lazily created) bucket for ip, promoting it into the
+// current generation so active IPs survive rotation.
+func (p *perIPFloor) limiterFor(ip string) *rate.Limiter {
+	if ip == "" {
+		ip = perIPUnknownKey
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if lim, ok := p.cur[ip]; ok {
+		return lim
+	}
+	if lim, ok := p.prev[ip]; ok {
+		// Promote the survivor into the current generation so a steadily-pushing
+		// IP is never evicted out from under itself.
+		p.cur[ip] = lim
+		delete(p.prev, ip)
+		return lim
+	}
+	// New IP: rotate generations first if the current one is full, dropping the
+	// previous (coldest) generation wholesale to keep memory bounded.
+	if len(p.cur) >= p.maxEntries {
+		p.prev = p.cur
+		p.cur = make(map[string]*rate.Limiter, p.maxEntries)
+	}
+	lim := rate.NewLimiter(p.rps, p.burst)
+	p.cur[ip] = lim
+	return lim
+}
+
+func (p *perIPFloor) allow(ip string) bool {
+	return p.limiterFor(ip).Allow()
+}
+
 // localFloorMiddleware enforces the Redis-independent per-instance push ceiling
-// ahead of the Redis-backed IP limiter, so a flood is shed in-memory without
-// even reaching Redis. On rejection it returns the same i18n 429 as the
-// per-webhook limiter (pushRateLimited aborts the chain); on pass it calls
-// c.Next() to continue to the next handler, mirroring StrictIPRateLimitMiddleware.
+// (per-IP sub-limit + global cap) ahead of the Redis-backed IP limiter, so a
+// flood is shed in-memory without even reaching Redis. It keys the per-IP layer
+// on the same trusted clientIP() the Redis failure budget uses (X-Real-Ip /
+// rightmost XFF), NOT gin's spoofable c.ClientIP(), so a scanner cannot forge a
+// new IP per request to dodge its per-IP share. On rejection it returns the same
+// i18n 429 as the per-webhook limiter (pushRateLimited aborts the chain); on
+// pass it calls c.Next() to continue, mirroring StrictIPRateLimitMiddleware.
 func (w *IncomingWebhook) localFloorMiddleware() wkhttp.HandlerFunc {
 	return func(c *wkhttp.Context) {
-		if !w.floor.allow() {
+		if !w.floor.allow(clientIP(c.Request)) {
 			pushRateLimited(c)
 			return
 		}

--- a/modules/incomingwebhook/localfloor.go
+++ b/modules/incomingwebhook/localfloor.go
@@ -22,7 +22,7 @@ import (
 //
 // The floor has TWO Redis-independent layers, checked per request in order:
 //
-//  1. a per-IP in-memory token bucket (perIPFloor, ~50 rps / 100 burst), and
+//  1. a per-IP in-memory token bucket (perIPFloor, 100 rps / 200 burst), and
 //  2. a global per-instance token bucket (200 rps / 400 burst).
 //
 // The per-IP layer is checked FIRST so a single abusive IP can consume at most
@@ -33,9 +33,15 @@ import (
 // (many IPs) under a Redis outage, which is the instance cap's whole point —
 // a pure per-IP floor would lose that.
 //
-// Defaults are deliberately generous: under healthy Redis the per-IP request
-// limiter (100 rps) and per-webhook limiter (5 rps) are lower and bite first,
-// so the floor only engages as a backstop. Tunable via
+// Defaults are deliberately generous so the floor stays a Redis-outage backstop
+// rather than the binding cap under healthy Redis: the global layer (200 rps) is
+// above the Redis per-IP limiter (100 rps), and the per-IP layer is set EQUAL to
+// that Redis per-IP limiter (100 rps / 200 burst) — not below it — so it does not
+// narrow a legitimate high-volume IP's allowance while Redis is healthy (the
+// Redis limiter and this floor bite at the same per-IP threshold), yet it is half
+// the global floor so a single IP can still take at most ~half and never starve
+// others. The per-webhook limiter (5 rps) is lower still and shapes legit traffic
+// first. Tunable via
 // DM_INCOMINGWEBHOOK_LOCAL_RPS / _BURST (global) and
 // DM_INCOMINGWEBHOOK_LOCAL_PERIP_RPS / _BURST / _MAX_IPS (per-IP), read once at
 // construction (no hot reload, matching octo-lib's limiter middlewares).
@@ -53,11 +59,15 @@ const (
 	defaultLocalFloorRPS   = 200.0
 	defaultLocalFloorBurst = 400
 
-	// Per-IP sub-limit: a single IP gets at most ~50 rps / 100 burst of the
-	// global floor, so one IP cannot starve others. Lower than the global cap so
-	// several distinct IPs can coexist under the global ceiling.
-	defaultLocalFloorPerIPRPS   = 50.0
-	defaultLocalFloorPerIPBurst = 100
+	// Per-IP sub-limit: a single IP gets at most 100 rps / 200 burst of the
+	// global floor, so one IP cannot starve others. Set EQUAL to the Redis per-IP
+	// StrictIPRateLimitMiddleware (defaultIngressIPRPS/Burst, 100/200) so under
+	// healthy Redis this always-on floor does not throttle a legit high-volume IP
+	// any tighter than the Redis limiter already would; it is still half the
+	// global cap, so several distinct IPs coexist under the global ceiling and no
+	// single IP drains it. Keep these two in lockstep if either is retuned.
+	defaultLocalFloorPerIPRPS   = 100.0
+	defaultLocalFloorPerIPBurst = 200
 	// Hard cap on the number of distinct per-IP buckets kept in memory, so a
 	// Redis-down DISTRIBUTED flood (many source IPs) cannot grow the map without
 	// bound. At the cap the oldest generation of buckets is dropped wholesale
@@ -121,12 +131,15 @@ const perIPUnknownKey = "__unknown_ip__"
 // perIPFloor is a Redis-independent, memory-bounded set of per-IP token
 // buckets. Memory is capped WITHOUT a background goroutine using a
 // two-generation map: lookups hit `cur` first, then promote from `prev`; when
-// `cur` fills to maxEntries the generations rotate (prev := cur, cur := empty),
-// dropping the coldest buckets wholesale. This bounds live buckets to
-// ~2*maxEntries and keeps actively-pushing IPs alive across rotations, at the
-// cost of being an approximate-LRU rather than exact — acceptable here because
-// the per-IP layer only needs to stop single-IP starvation, while the global
-// floor remains the throughput bound under a distributed flood.
+// `cur` fills to maxEntries — on BOTH the new-IP and the promotion paths — the
+// generations rotate (prev := cur, cur := empty), dropping the coldest buckets
+// wholesale. Enforcing the cap on promotion too is what keeps the bound real: a
+// cycling attacker who re-touches every `prev` entry cannot otherwise inflate
+// `cur` past the cap each round. This bounds live buckets to ~2*maxEntries; an
+// actively-pushing IP survives at least one rotation (promoted out of `prev`)
+// but is not a permanent survivor — acceptable because the per-IP layer only
+// needs to stop single-IP starvation, while the global floor remains the
+// throughput bound under a distributed flood.
 type perIPFloor struct {
 	mu         sync.Mutex
 	rps        rate.Limit
@@ -159,7 +172,19 @@ func (p *perIPFloor) limiterFor(ip string) *rate.Limiter {
 	}
 	if lim, ok := p.prev[ip]; ok {
 		// Promote the survivor into the current generation so a steadily-pushing
-		// IP is never evicted out from under itself.
+		// IP survives AT LEAST one rotation. The cap MUST be enforced here too:
+		// without it, an attacker who keeps prev warm could promote every prev
+		// entry back into cur each cycle (cur→2N, then rotate prev:=cur→2N, …),
+		// growing the live set without bound and defeating the memory cap. So if
+		// cur is already full, rotate first — dropping the rest of the cold prev
+		// generation wholesale — before promoting into a fresh cur. A promoted
+		// survivor can therefore itself be dropped on the NEXT rotation; that is
+		// acceptable: the global floor still bounds throughput, the per-IP layer
+		// only needs to stop single-IP starvation, not be an exact LRU.
+		if len(p.cur) >= p.maxEntries {
+			p.prev = p.cur
+			p.cur = make(map[string]*rate.Limiter, p.maxEntries)
+		}
 		p.cur[ip] = lim
 		delete(p.prev, ip)
 		return lim

--- a/modules/incomingwebhook/localfloor.go
+++ b/modules/incomingwebhook/localfloor.go
@@ -181,23 +181,31 @@ func (p *perIPFloor) limiterFor(ip string) *rate.Limiter {
 		// survivor can therefore itself be dropped on the NEXT rotation; that is
 		// acceptable: the global floor still bounds throughput, the per-IP layer
 		// only needs to stop single-IP starvation, not be an exact LRU.
-		if len(p.cur) >= p.maxEntries {
-			p.prev = p.cur
-			p.cur = make(map[string]*rate.Limiter, p.maxEntries)
-		}
+		p.rotateIfFullLocked()
 		p.cur[ip] = lim
 		delete(p.prev, ip)
 		return lim
 	}
 	// New IP: rotate generations first if the current one is full, dropping the
 	// previous (coldest) generation wholesale to keep memory bounded.
-	if len(p.cur) >= p.maxEntries {
-		p.prev = p.cur
-		p.cur = make(map[string]*rate.Limiter, p.maxEntries)
-	}
+	p.rotateIfFullLocked()
 	lim := rate.NewLimiter(p.rps, p.burst)
 	p.cur[ip] = lim
 	return lim
+}
+
+// rotateIfFullLocked rotates the generations (prev := cur, cur := empty) when cur
+// has reached the cap, dropping the coldest generation wholesale. Caller must
+// hold p.mu. The fresh cur is allocated WITHOUT a size hint so it grows lazily,
+// matching newPerIPFloor's initial map: a `make(map, maxEntries)` here would do a
+// multi-MB pre-allocation inside the hot-path mutex on every rotation — and
+// rotations are triggered precisely by the distinct-IP flood the floor exists to
+// shed, so an attacker could force back-to-back large allocations under the lock.
+func (p *perIPFloor) rotateIfFullLocked() {
+	if len(p.cur) >= p.maxEntries {
+		p.prev = p.cur
+		p.cur = make(map[string]*rate.Limiter)
+	}
 }
 
 func (p *perIPFloor) allow(ip string) bool {

--- a/modules/incomingwebhook/localfloor_test.go
+++ b/modules/incomingwebhook/localfloor_test.go
@@ -31,6 +31,26 @@ func countAllowedGlobal(f *localFloor, n int) int {
 	return allowed
 }
 
+// TestPerIPFloorDefaultsMatchIngress pins the contract that the per-IP floor
+// defaults mirror the Redis per-IP StrictIPRateLimitMiddleware defaults
+// (defaultIngressIPRPS / defaultIngressIPBurst). The two sets of constants live
+// in different files (localfloor.go vs api.go) on purpose, so this guards
+// against silent drift on a future retune: if the per-IP floor were tuned BELOW
+// the Redis limiter it would silently become the binding per-IP cap under
+// healthy Redis (the yujiawei P2 from PR #288); if tuned ABOVE the global floor
+// it would stop bounding single-IP starvation. Keeping them equal preserves both
+// properties — change both together if either moves.
+func TestPerIPFloorDefaultsMatchIngress(t *testing.T) {
+	assert.Equal(t, defaultIngressIPRPS, defaultLocalFloorPerIPRPS,
+		"per-IP floor rps must match the Redis per-IP limiter so the floor stays a backstop, not a tighter cap")
+	assert.Equal(t, defaultIngressIPBurst, defaultLocalFloorPerIPBurst,
+		"per-IP floor burst must match the Redis per-IP limiter burst")
+	// And the per-IP floor must stay strictly below the global floor, else a
+	// single IP could drain the whole global bucket and starve others.
+	assert.Less(t, defaultLocalFloorPerIPRPS, defaultLocalFloorRPS,
+		"per-IP floor rps must be below the global floor so one IP cannot starve others")
+}
+
 // TestLocalFloor_AllowsBurstThenBlocks: with a tiny refill rate, exactly `burst`
 // calls pass before the GLOBAL bucket empties and further calls are rejected.
 // Distinct IPs keep the per-IP sub-limit out of the way.

--- a/modules/incomingwebhook/localfloor_test.go
+++ b/modules/incomingwebhook/localfloor_test.go
@@ -152,10 +152,52 @@ func TestPerIPFloor_MemoryBounded(t *testing.T) {
 	assert.LessOrEqual(t, live, 2*maxEntries, "live per-IP buckets must stay bounded by ~2*maxEntries")
 }
 
-// TestPerIPFloor_PromotionKeepsActiveIPAlive: an IP that keeps pushing across a
-// generation rotation is promoted rather than evicted, so its bucket (and thus
-// its accumulated rate-limit state) survives — otherwise a steady IP would get a
-// fresh full burst on every rotation and the per-IP cap would be meaningless.
+// TestPerIPFloor_CyclingDoesNotGrowBeyondBound is the #288-review regression: a
+// cycling attacker who keeps `prev` warm (re-touches every prev entry to promote
+// it back into `cur`) and then refills `cur` with fresh IPs must NOT be able to
+// grow the live set past ~2*maxEntries. Before the promotion path enforced the
+// cap, each cycle grew live by ~maxEntries without bound. This drives that exact
+// pattern and asserts the bound holds.
+func TestPerIPFloor_CyclingDoesNotGrowBeyondBound(t *testing.T) {
+	const N = 4
+	p := newPerIPFloor(rate.Limit(1000), 1000, N)
+
+	// Seed cur=N, prev=N by churning 2N distinct new IPs.
+	for i := 0; i < 2*N; i++ {
+		p.allow(uniqueIP(i))
+	}
+
+	for cycle := 0; cycle < 10; cycle++ {
+		// Snapshot and re-touch every prev entry, promoting them back into cur.
+		p.mu.Lock()
+		prevKeys := make([]string, 0, len(p.prev))
+		for k := range p.prev {
+			prevKeys = append(prevKeys, k)
+		}
+		p.mu.Unlock()
+		for _, k := range prevKeys {
+			p.allow(k)
+		}
+		// Refill cur with fresh IPs to force the next rotation.
+		for i := 0; i < N; i++ {
+			p.allow(fmt.Sprintf("fresh-%d-%d", cycle, i))
+		}
+
+		p.mu.Lock()
+		live := len(p.cur) + len(p.prev)
+		p.mu.Unlock()
+		assert.LessOrEqualf(t, live, 2*N,
+			"live buckets must stay bounded even under cycling promotion (cycle=%d)", cycle)
+	}
+}
+
+// TestPerIPFloor_PromotionKeepsActiveIPAlive: an IP that keeps pushing is
+// promoted out of `prev` rather than evicted, so it survives AT LEAST the next
+// rotation and keeps its accumulated rate-limit state — otherwise a steady IP
+// would get a fresh full burst on every rotation and the per-IP cap would be
+// meaningless. (The guarantee is "survives one rotation", not "forever": cap
+// enforcement on promotion can still drop a survivor on a LATER rotation — see
+// TestPerIPFloor_CyclingDoesNotGrowBeyondBound for why that trade-off exists.)
 func TestPerIPFloor_PromotionKeepsActiveIPAlive(t *testing.T) {
 	const maxEntries = 4
 	// burst 1, ~no refill: the active IP gets exactly one token for its lifetime.

--- a/modules/incomingwebhook/localfloor_test.go
+++ b/modules/incomingwebhook/localfloor_test.go
@@ -1,23 +1,30 @@
 package incomingwebhook
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/time/rate"
 )
 
 // Unit tests for the Redis-independent local push floor. These need no DB /
-// Redis / WuKongIM — they exercise the in-memory token bucket directly, so they
+// Redis / WuKongIM — they exercise the in-memory token buckets directly, so they
 // run in plain `go test` and document the limiter contract.
 
-// countAllowed fires n calls and returns how many were allowed. Used by the
-// default-config tests, where the 200 rps default refill makes an exact "burst
-// then exactly one reject" assertion timing-sensitive on slow CI; a range check
-// (full burst passes, but not 2× burst) is refill-robust instead.
-func countAllowed(f *localFloor, n int) int {
+// uniqueIP returns a distinct IP per index so the per-IP sub-limit never bites,
+// isolating the GLOBAL floor under test in the global-cap assertions below.
+func uniqueIP(i int) string { return fmt.Sprintf("10.%d.%d.%d", i/65536, (i/256)%256, i%256) }
+
+// countAllowedGlobal fires n calls — each from a DISTINCT IP so only the global
+// floor can reject — and returns how many were allowed. Used by the default-
+// config tests, where the 200 rps default refill makes an exact "burst then
+// exactly one reject" assertion timing-sensitive on slow CI; a range check (full
+// burst passes, but not 2× burst) is refill-robust instead.
+func countAllowedGlobal(f *localFloor, n int) int {
 	allowed := 0
 	for i := 0; i < n; i++ {
-		if f.allow() {
+		if f.allow(uniqueIP(i)) {
 			allowed++
 		}
 	}
@@ -25,16 +32,17 @@ func countAllowed(f *localFloor, n int) int {
 }
 
 // TestLocalFloor_AllowsBurstThenBlocks: with a tiny refill rate, exactly `burst`
-// calls pass before the bucket empties and further calls are rejected.
+// calls pass before the GLOBAL bucket empties and further calls are rejected.
+// Distinct IPs keep the per-IP sub-limit out of the way.
 func TestLocalFloor_AllowsBurstThenBlocks(t *testing.T) {
 	t.Setenv(envLocalFloorBurst, "2")
 	t.Setenv(envLocalFloorRPS, "0.001") // ~never refills within the test
 
 	f := newLocalFloor()
-	assert.True(t, f.allow(), "1st call within burst must pass")
-	assert.True(t, f.allow(), "2nd call within burst must pass")
-	assert.False(t, f.allow(), "3rd call must be rejected once burst is spent")
-	assert.False(t, f.allow(), "still rejected while the bucket is empty")
+	assert.True(t, f.allow("1.1.1.1"), "1st call within burst must pass")
+	assert.True(t, f.allow("1.1.1.2"), "2nd call within burst must pass")
+	assert.False(t, f.allow("1.1.1.3"), "3rd call must be rejected once burst is spent")
+	assert.False(t, f.allow("1.1.1.4"), "still rejected while the bucket is empty")
 }
 
 // TestLocalFloor_ZeroEnvDoesNotDisable documents the fail-safe: the shared env
@@ -46,7 +54,7 @@ func TestLocalFloor_ZeroEnvDoesNotDisable(t *testing.T) {
 	t.Setenv(envLocalFloorBurst, "0")
 
 	f := newLocalFloor()
-	allowed := countAllowed(f, 2*defaultLocalFloorBurst)
+	allowed := countAllowedGlobal(f, 2*defaultLocalFloorBurst)
 	assert.GreaterOrEqual(t, allowed, defaultLocalFloorBurst, "coerced-to-default burst must all pass")
 	assert.Less(t, allowed, 2*defaultLocalFloorBurst, "env 0 did not disable the floor; it stays bounded at the default")
 }
@@ -57,22 +65,126 @@ func TestLocalFloor_ConfiguredAtConstruction(t *testing.T) {
 	t.Setenv(envLocalFloorBurst, "1")
 	t.Setenv(envLocalFloorRPS, "0.001")
 	tight := newLocalFloor()
-	assert.True(t, tight.allow(), "tight floor: first call gets the lone token")
-	assert.False(t, tight.allow(), "tight floor: second call is rejected")
+	assert.True(t, tight.allow("1.1.1.1"), "tight floor: first call gets the lone token")
+	assert.False(t, tight.allow("1.1.1.2"), "tight floor: second call is rejected")
 
 	t.Setenv(envLocalFloorBurst, "100")
 	loose := newLocalFloor()
 	for i := 0; i < 100; i++ {
-		assert.Truef(t, loose.allow(), "loose floor built later must allow its own burst (i=%d)", i)
+		assert.Truef(t, loose.allow(uniqueIP(i)), "loose floor built later must allow its own burst (i=%d)", i)
 	}
 }
 
-// TestLocalFloor_DefaultIsBackstop: with no env override the default bucket is
-// large enough that ordinary traffic never trips it (it only acts as a Redis-
-// outage backstop). A burst of default size all passes.
+// TestLocalFloor_DefaultIsBackstop: with no env override the default GLOBAL
+// bucket is large enough that ordinary traffic never trips it (it only acts as a
+// Redis-outage backstop). A burst of default size from distinct IPs all passes.
 func TestLocalFloor_DefaultIsBackstop(t *testing.T) {
 	f := newLocalFloor()
-	allowed := countAllowed(f, 2*defaultLocalFloorBurst)
+	allowed := countAllowedGlobal(f, 2*defaultLocalFloorBurst)
 	assert.GreaterOrEqual(t, allowed, defaultLocalFloorBurst, "the full default burst must pass")
 	assert.Less(t, allowed, 2*defaultLocalFloorBurst, "default floor is bounded; not everything passes")
+}
+
+// TestLocalFloor_SingleIPCannotStarveOthers is the #287 regression: a single IP
+// flooding the endpoint may consume at most its per-IP share of the global
+// floor, so it CANNOT drain the global bucket and cause collateral 429s for a
+// valid push from a different IP. Per-IP budget is set tiny (burst 2, ~no
+// refill) while the global budget is large, so the attacker is gated by the
+// per-IP layer long before the global bucket is exhausted.
+func TestLocalFloor_SingleIPCannotStarveOthers(t *testing.T) {
+	t.Setenv(envLocalFloorRPS, "0.001")
+	t.Setenv(envLocalFloorBurst, "100")
+	t.Setenv(envLocalFloorPerIPRPS, "0.001")
+	t.Setenv(envLocalFloorPerIPBurst, "2")
+
+	f := newLocalFloor()
+
+	const attacker = "203.0.113.7"
+	attackerAllowed := 0
+	for i := 0; i < 1000; i++ {
+		if f.allow(attacker) {
+			attackerAllowed++
+		}
+	}
+	// The attacker is capped at its per-IP burst, NOT at the global burst.
+	assert.LessOrEqual(t, attackerAllowed, 2, "attacker must be gated by its per-IP share, not the global floor")
+
+	// A different IP's valid push still passes — the global floor was not drained.
+	assert.True(t, f.allow("198.51.100.9"), "a valid push from another IP must not be starved by the attacker")
+}
+
+// TestLocalFloor_GlobalCapHoldsUnderDistributedFlood: the per-IP layer must not
+// remove the global per-instance cap. Many distinct IPs each staying within
+// their per-IP budget still collectively cannot exceed the global ceiling — the
+// Redis-outage DB/WuKongIM protection the floor exists for.
+func TestLocalFloor_GlobalCapHoldsUnderDistributedFlood(t *testing.T) {
+	t.Setenv(envLocalFloorRPS, "0.001")
+	t.Setenv(envLocalFloorBurst, "50")
+	// Generous per-IP budget so each IP individually passes; the global cap is
+	// the only thing that can reject here.
+	t.Setenv(envLocalFloorPerIPRPS, "0.001")
+	t.Setenv(envLocalFloorPerIPBurst, "10")
+
+	f := newLocalFloor()
+	allowed := 0
+	for i := 0; i < 500; i++ {
+		if f.allow(uniqueIP(i)) {
+			allowed++
+		}
+	}
+	assert.Equal(t, 50, allowed, "distributed flood is still bounded by the global per-instance cap")
+}
+
+// TestPerIPFloor_MemoryBounded verifies the two-generation map keeps live
+// buckets bounded under a flood of distinct IPs (no background goroutine), so a
+// Redis-down distributed attack cannot grow the map without bound.
+func TestPerIPFloor_MemoryBounded(t *testing.T) {
+	const maxEntries = 4
+	p := newPerIPFloor(rate.Limit(1000), 1000, maxEntries)
+
+	for i := 0; i < 100; i++ {
+		p.allow(uniqueIP(i))
+	}
+
+	p.mu.Lock()
+	live := len(p.cur) + len(p.prev)
+	p.mu.Unlock()
+	assert.LessOrEqual(t, live, 2*maxEntries, "live per-IP buckets must stay bounded by ~2*maxEntries")
+}
+
+// TestPerIPFloor_PromotionKeepsActiveIPAlive: an IP that keeps pushing across a
+// generation rotation is promoted rather than evicted, so its bucket (and thus
+// its accumulated rate-limit state) survives — otherwise a steady IP would get a
+// fresh full burst on every rotation and the per-IP cap would be meaningless.
+func TestPerIPFloor_PromotionKeepsActiveIPAlive(t *testing.T) {
+	const maxEntries = 4
+	// burst 1, ~no refill: the active IP gets exactly one token for its lifetime.
+	p := newPerIPFloor(rate.Limit(0.001), 1, maxEntries)
+
+	const active = "203.0.113.1"
+	assert.True(t, p.allow(active), "active IP spends its single token")
+
+	// Drive enough distinct IPs to force several rotations; touch `active` each
+	// round so it keeps getting promoted into the current generation.
+	for round := 0; round < 5; round++ {
+		for i := 0; i < maxEntries; i++ {
+			p.allow(fmt.Sprintf("round%d-%d", round, i))
+		}
+		assert.Falsef(t, p.allow(active), "active IP must stay throttled across rotation (round=%d)", round)
+	}
+}
+
+// TestPerIPFloor_UnknownIPShareOneBucket: requests with an unresolved IP ("")
+// share a single bucket rather than each getting a fresh one, so an
+// unresolved-IP flood is throttled together instead of bypassing the per-IP cap.
+func TestPerIPFloor_UnknownIPShareOneBucket(t *testing.T) {
+	p := newPerIPFloor(rate.Limit(0.001), 2, 100)
+	assert.True(t, p.allow(""), "1st unknown-IP call gets a token")
+	assert.True(t, p.allow(""), "2nd unknown-IP call gets the last token")
+	assert.False(t, p.allow(""), "3rd unknown-IP call is throttled — all share one bucket")
+
+	p.mu.Lock()
+	_, ok := p.cur[perIPUnknownKey]
+	p.mu.Unlock()
+	assert.True(t, ok, "unresolved IPs must collapse onto the shared unknown-IP key")
 }


### PR DESCRIPTION
Closes #287.

## Problem

The Redis-independent local floor (`localFloorMiddleware`, 200 rps / 400 burst per instance) was a **single global in-memory bucket** mounted **first** in the push chain, ahead of the Redis-backed gates:

```
localFloor (global) → ipLimit (Redis) → ipFailureGate (Redis) → push
```

Because the floor runs before the Redis gates, a request the gates *will* reject still consumes a global floor token first. So a single abusive IP (bounded only by the global ~500 rps/IP DDoS limiter in `main.go`) could drain the 200 rps floor and cause **collateral 429s for valid pushes from other IPs**, while Redis is healthy — a small cross-IP DoS-amplification surface.

## Fix

Keep the **global** in-memory floor (instance cap, for the Redis-outage DB/WuKongIM protection) **and** add a **per-IP** in-memory sub-limit in **front** of it, both Redis-independent:

- **Per-IP token bucket** (default 50 rps / 100 burst), keyed on the same trusted `clientIP()` (X-Real-Ip / rightmost XFF) the Redis failure budget uses — a scanner cannot forge a new IP per request to dodge its share.
- **Checked first**, so a gated IP never even spends a global token → a single IP can consume at most its per-IP share of the global floor and cannot starve other IPs.
- The **global cap still bounds a distributed (many-IP) flood** under a Redis outage — the floor's whole point. A pure per-IP floor would lose that.
- **Memory-bounded** via a two-generation map (no background goroutine): lookups promote `prev → cur`, and the coldest generation is dropped wholesale once `cur` fills to `MAX_IPS`. Live buckets stay ≤ ~2×`MAX_IPS`; actively-pushing IPs survive rotation.

New env knobs (`DM_INCOMINGWEBHOOK_LOCAL_PERIP_RPS` / `_BURST` / `_MAX_IPS`); 0/invalid coerces to the generous default so the layer cannot be silently disabled.

## Acceptance criteria (each covered by a regression test)

- ✅ A single IP over its budget cannot exhaust the local floor for another IP's valid push — `TestLocalFloor_SingleIPCannotStarveOthers`
- ✅ The global per-instance cap still holds under a Redis outage — `TestLocalFloor_GlobalCapHoldsUnderDistributedFlood`
- ✅ Memory for per-IP buckets is bounded — `TestPerIPFloor_MemoryBounded` (plus active-IP promotion and shared unknown-IP bucket tests)

## Scope

Only `modules/incomingwebhook/` — it is the **only** module with a global in-memory floor in front of fail-open Redis gates (the `golang.org/x/time/rate` import is unique to it). Other limiters are Redis-backed and per-key (per-IP / per-UID / per-resource), so they don't share this single-global-bucket starvation surface. Abstracting this into octo-lib is explicitly out of scope per the issue.

## Verification

`go build` · `go vet` · `golangci-lint run` (0 issues) · `go test -run 'TestLocalFloor|TestPerIPFloor'` (9 pass) · `-race` clean. No errcode/i18n changes.

https://claude.ai/code/session_01Y6iv9PTcSoaR8qZNNRTE4t

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6iv9PTcSoaR8qZNNRTE4t)_