### PR TITLE
feat(sidebar): make recent-tab activity filter configurable per channel type

### DIFF
--- a/modules/common/api_manager_system_setting.go
+++ b/modules/common/api_manager_system_setting.go
@@ -201,10 +201,22 @@ func (m *Manager) updateSystemSettings(c *wkhttp.Context) {
 			}
 			p.value = normalised
 		case settingTypeInt:
+			// Empty value means "reset to default" (the getter treats an empty
+			// snapshot entry as not-configured), so only validate non-empty
+			// payloads. Bounds-check against [settingIntMin, settingIntMax] —
+			// previously this path only ran strconv.Atoi with no range guard,
+			// letting absurd windows (or negatives) reach the DB (issue #289).
 			if item.Value != "" {
-				if _, err := strconv.Atoi(item.Value); err != nil {
+				n, err := strconv.Atoi(item.Value)
+				if err != nil {
 					c.JSON(http.StatusBadRequest, jsonH{
 						"msg": fmt.Sprintf("%s.%s 必须是整数", item.Category, item.Key),
+					})
+					return
+				}
+				if n < settingIntMin || n > settingIntMax {
+					c.JSON(http.StatusBadRequest, jsonH{
+						"msg": fmt.Sprintf("%s.%s 必须在 [%d, %d] 范围内", item.Category, item.Key, settingIntMin, settingIntMax),
 					})
 					return
 				}

--- a/modules/common/api_manager_system_setting_test.go
+++ b/modules/common/api_manager_system_setting_test.go
@@ -363,3 +363,73 @@ func TestManagerSystemSetting_UpdatePersistsAndReloads(t *testing.T) {
 	assert.True(t, settings.RegisterEmailOn(), "Reload should run inside the update handler")
 	assert.Equal(t, "smtp.test:587", settings.SupportEmailSmtp())
 }
+
+// --- int range validation (issue #289) -------------------------------------
+
+func TestManagerSystemSetting_UpdateRejectsOutOfRangeInt(t *testing.T) {
+	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.SuperAdmin),
+	))
+
+	for _, v := range []string{"-1", "3651", "100000"} {
+		body := []byte(`{"items":[{"category":"sidebar","key":"recent_filter_group_days","value":"` + v + `"}]}`)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/v1/manager/common/system_setting", bytes.NewReader(body))
+		req.Header.Set("token", testutil.Token)
+		s.GetRoute().ServeHTTP(w, req)
+		assert.NotEqual(t, http.StatusOK, w.Code, "越界整数 %q 必须被拒绝", v)
+	}
+}
+
+func TestManagerSystemSetting_UpdateRejectsNonInt(t *testing.T) {
+	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.SuperAdmin),
+	))
+
+	body := []byte(`{"items":[{"category":"sidebar","key":"recent_filter_group_days","value":"abc"}]}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/manager/common/system_setting", bytes.NewReader(body))
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.NotEqual(t, http.StatusOK, w.Code)
+}
+
+func TestManagerSystemSetting_UpdateAcceptsInRangeIntBoundaries(t *testing.T) {
+	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.SuperAdmin),
+	))
+
+	body := []byte(`{"items":[` +
+		`{"category":"sidebar","key":"recent_filter_group_days","value":"0"},` +
+		`{"category":"sidebar","key":"recent_filter_thread_days","value":"3650"},` +
+		`{"category":"sidebar","key":"recent_filter_person_days","value":"7"}` +
+		`]}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/manager/common/system_setting", bytes.NewReader(body))
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	db := newSystemSettingDB(ctx)
+	rows, err := db.listAll()
+	require.NoError(t, err)
+	got := map[string]string{}
+	for _, r := range rows {
+		got[schemaKey(r.Category, r.KeyName)] = r.Value
+	}
+	assert.Equal(t, "0", got["sidebar.recent_filter_group_days"])
+	assert.Equal(t, "3650", got["sidebar.recent_filter_thread_days"])
+	assert.Equal(t, "7", got["sidebar.recent_filter_person_days"])
+}

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -1,11 +1,38 @@
 package common
 
+import "strconv"
+
 // Value types accepted by system_setting.value_type.
 const (
 	settingTypeString    = "string"
 	settingTypeBool      = "bool"
 	settingTypeInt       = "int"
 	settingTypeEncrypted = "encrypted"
+)
+
+// settingIntMin / settingIntMax bound every settingTypeInt value, applied both
+// on the admin write path (api_manager_system_setting.go) and in the clamping
+// getters (getIntClamped). Today all int settings are day-window counts
+// (sidebar.recent_filter_*_days), for which [0, 3650] (0 .. ~10 years) is a
+// generous sane range; 0 is the documented "disable filter" sentinel. Adding
+// an int setting that needs a different range should move this to a per-key
+// field on settingDef — until then a single shared bound keeps the write path
+// simple and closes the pre-existing "no bounds check" gap (issue #289).
+const (
+	settingIntMin = 0
+	settingIntMax = 3650
+)
+
+// Sidebar recent-tab activity-filter defaults (issue #289). The recent tab of
+// POST /v1/sidebar/sync hides conversations whose last activity is older than
+// a per-channel-type window. These defaults reproduce the historical
+// hard-coded behaviour exactly (groups/threads = 3-day window, DMs unfiltered)
+// so the feature is zero-impact until an operator opts in. A value of 0
+// disables the window for that channel type (return all, no time limit).
+const (
+	defaultSidebarRecentFilterGroupDays  = 3
+	defaultSidebarRecentFilterThreadDays = 3
+	defaultSidebarRecentFilterPersonDays = 0
 )
 
 // settingDef is the canonical definition of a system_setting key.
@@ -55,6 +82,16 @@ var systemSettingSchema = []settingDef{
 	// 仍作 fallback,DB 行为单一真源。
 	{Category: "space", Key: "disable_user_create", Type: settingTypeBool, Description: "是否关闭普通用户创建空间入口",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.SpaceDisableUserCreate()) }},
+
+	// Sidebar recent-tab activity filter — per-channel-type window in days for
+	// POST /v1/sidebar/sync 的 recent tab。0 = 关闭该类型的时间过滤（全量返回）。
+	// 默认复刻历史硬编码行为：群/话题 3 天窗口、DM 不过滤（issue #289）。
+	{Category: "sidebar", Key: "recent_filter_group_days", Type: settingTypeInt, Description: "最近会话-群聊活跃过滤窗口(天)，0=不过滤",
+		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.SidebarRecentFilterGroupDays()) }},
+	{Category: "sidebar", Key: "recent_filter_thread_days", Type: settingTypeInt, Description: "最近会话-话题(社区话题)活跃过滤窗口(天)，0=不过滤",
+		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.SidebarRecentFilterThreadDays()) }},
+	{Category: "sidebar", Key: "recent_filter_person_days", Type: settingTypeInt, Description: "最近会话-单聊(DM)活跃过滤窗口(天)，0=不过滤(默认)",
+		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.SidebarRecentFilterPersonDays()) }},
 
 	// Email server config — formerly yaml-only (Support.* in config.go).
 	{Category: "support", Key: "email", Type: settingTypeString, Description: "技术支持邮箱（发件人）",

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -222,6 +222,18 @@ func (s *SystemSettings) getInt(category, key string, fallback int) int {
 	return parsed
 }
 
+// getIntClamped is getInt with range enforcement: a value outside
+// [settingIntMin, settingIntMax] — which the admin write path rejects, but a
+// direct DB edit could still introduce — falls back to the code default rather
+// than being served verbatim. Defence in depth for the int settings (D-289).
+func (s *SystemSettings) getIntClamped(category, key string, fallback int) int {
+	v := s.getInt(category, key, fallback)
+	if v < settingIntMin || v > settingIntMax {
+		return fallback
+	}
+	return v
+}
+
 func (s *SystemSettings) getEncrypted(category, key string, fallback string) string {
 	// Encrypted values are stored decrypted in the snapshot, so a plain
 	// lookup is sufficient. The dedicated method exists so callers — and
@@ -480,6 +492,29 @@ func parseSpaceDisableUserCreateEnv(v string) bool {
 		return true
 	}
 	return false
+}
+
+// ----- sidebar recent-tab activity filter (issue #289) -----
+
+// SidebarRecentFilterGroupDays returns the recent-tab activity window for group
+// conversations, in days. 0 disables the window (all groups returned). Defaults
+// to defaultSidebarRecentFilterGroupDays (3) — today's hard-coded behaviour.
+func (s *SystemSettings) SidebarRecentFilterGroupDays() int {
+	return s.getIntClamped("sidebar", "recent_filter_group_days", defaultSidebarRecentFilterGroupDays)
+}
+
+// SidebarRecentFilterThreadDays returns the recent-tab activity window for
+// thread (community topic) conversations, in days. 0 disables the window.
+func (s *SystemSettings) SidebarRecentFilterThreadDays() int {
+	return s.getIntClamped("sidebar", "recent_filter_thread_days", defaultSidebarRecentFilterThreadDays)
+}
+
+// SidebarRecentFilterPersonDays returns the recent-tab activity window for DM
+// conversations, in days. Defaults to 0, which keeps today's "DMs are always
+// shown regardless of age" behaviour; the per-type default makes the historical
+// hard-coded `!isDM` exemption data-driven.
+func (s *SystemSettings) SidebarRecentFilterPersonDays() int {
+	return s.getIntClamped("sidebar", "recent_filter_person_days", defaultSidebarRecentFilterPersonDays)
 }
 
 // SupportEmail returns the From address used by the SMTP sender.

--- a/modules/common/system_settings_test.go
+++ b/modules/common/system_settings_test.go
@@ -408,3 +408,53 @@ func TestSystemSettings_ConcurrentReadsAndReloads(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// ---------------------------------------------------------------------------
+// Sidebar recent-tab activity filter windows (issue #289)
+// ---------------------------------------------------------------------------
+
+// Defaults reproduce today's hard-coded behaviour: groups/threads = 3-day
+// window, DMs = unfiltered (0).
+func TestSystemSettings_SidebarRecentFilter_Defaults(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	assert.Equal(t, 3, s.SidebarRecentFilterGroupDays(), "group window default 3 天")
+	assert.Equal(t, 3, s.SidebarRecentFilterThreadDays(), "thread window default 3 天")
+	assert.Equal(t, 0, s.SidebarRecentFilterPersonDays(), "DM 默认 0 = 不过滤")
+}
+
+// A configured DB value overrides the code default, including the 0 sentinel
+// that disables the filter for that channel type.
+func TestSystemSettings_SidebarRecentFilter_DBOverrides(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	require.NoError(t, s.db.upsert("sidebar", "recent_filter_group_days", "0", settingTypeInt, ""))
+	require.NoError(t, s.db.upsert("sidebar", "recent_filter_thread_days", "7", settingTypeInt, ""))
+	require.NoError(t, s.db.upsert("sidebar", "recent_filter_person_days", "30", settingTypeInt, ""))
+	require.NoError(t, s.Reload())
+
+	assert.Equal(t, 0, s.SidebarRecentFilterGroupDays(), "DB 0 → 关闭群过滤（全量）")
+	assert.Equal(t, 7, s.SidebarRecentFilterThreadDays(), "DB 覆盖话题窗口")
+	assert.Equal(t, 30, s.SidebarRecentFilterPersonDays(), "DB 覆盖 DM 窗口")
+}
+
+// Out-of-range DB values (someone editing the table directly, bypassing the
+// admin API's range check) clamp back to the code default — defence in depth.
+func TestSystemSettings_SidebarRecentFilter_OutOfRangeClampsToDefault(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	require.NoError(t, s.db.upsert("sidebar", "recent_filter_group_days", "-5", settingTypeInt, ""))
+	require.NoError(t, s.db.upsert("sidebar", "recent_filter_thread_days", "999999", settingTypeInt, ""))
+	require.NoError(t, s.Reload())
+
+	assert.Equal(t, 3, s.SidebarRecentFilterGroupDays(), "负值越界 → 回退默认 3")
+	assert.Equal(t, 3, s.SidebarRecentFilterThreadDays(), "超上限越界 → 回退默认 3")
+}
+
+// Boundary values exactly on [settingIntMin, settingIntMax] are accepted as-is.
+func TestSystemSettings_SidebarRecentFilter_BoundaryValuesAccepted(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	require.NoError(t, s.db.upsert("sidebar", "recent_filter_group_days", "0", settingTypeInt, ""))
+	require.NoError(t, s.db.upsert("sidebar", "recent_filter_thread_days", "3650", settingTypeInt, ""))
+	require.NoError(t, s.Reload())
+
+	assert.Equal(t, 0, s.SidebarRecentFilterGroupDays(), "下界 0 接受")
+	assert.Equal(t, 3650, s.SidebarRecentFilterThreadDays(), "上界 3650 接受")
+}

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -43,6 +43,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	commonapi "github.com/Mininglamp-OSS/octo-server/modules/common"
 	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/space"
@@ -521,7 +522,8 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 			}
 		}
 	case "recent":
-		items = buildRecentItems(conversations, pinnedSet, groupSpaceMap, externalGroupMap, defaultSpaceID)
+		cutoffs := sb.loadRecentCutoffs(time.Now())
+		items = buildRecentItems(conversations, cutoffs, pinnedSet, groupSpaceMap, externalGroupMap, defaultSpaceID)
 	}
 
 	// 4. Enrich pinned flag (follow tab items also need it)
@@ -627,8 +629,58 @@ func (sb *Sidebar) loadThreadLastMsgAt(extRows []*convext.Model) (map[string]*ti
 // Filter helpers
 // ---------------------------------------------------------------------------
 
-// threeDaysAgo returns the unix timestamp 72h ago.
-func threeDaysAgo() int64 { return time.Now().Add(-72 * time.Hour).Unix() }
+// recentCutoffs holds the per-channel-type activity cutoffs (unix seconds) for
+// the recent tab. A conversation is hidden when its timestamp <= the cutoff for
+// its channel type. A cutoff of 0 means "no time filter" — that type is
+// returned in full regardless of age (issue #289).
+type recentCutoffs struct {
+	group  int64
+	thread int64
+	person int64
+}
+
+// daysCutoff converts a day-count window to a unix-second cutoff relative to
+// now. A window of 0 (or negative, defensively) yields 0 = "no filter"; the
+// caller's `cutoff == 0` check then skips filtering entirely. Unifying the
+// "disabled" case as cutoff 0 lets buildRecentItems treat every channel type
+// the same way, including the DM exemption (person window default 0).
+func daysCutoff(now time.Time, days int) int64 {
+	if days <= 0 {
+		return 0
+	}
+	return now.Add(-time.Duration(days) * 24 * time.Hour).Unix()
+}
+
+// loadRecentCutoffs resolves the per-channel-type recent-tab windows from the
+// shared system_settings snapshot (admin-tunable, ~60s reload). Defaults
+// reproduce the historical hard-coded behaviour exactly: groups/threads use a
+// 3-day window, DMs are unfiltered.
+func (sb *Sidebar) loadRecentCutoffs(now time.Time) recentCutoffs {
+	ss := commonapi.EnsureSystemSettings(sb.ctx)
+	return recentCutoffs{
+		group:  daysCutoff(now, ss.SidebarRecentFilterGroupDays()),
+		thread: daysCutoff(now, ss.SidebarRecentFilterThreadDays()),
+		person: daysCutoff(now, ss.SidebarRecentFilterPersonDays()),
+	}
+}
+
+// cutoffFor returns the activity cutoff for a given channel type. Unknown
+// channel types (anything that is not group / thread / DM) return 0 = no
+// filter; the recent tab only ever carries those three types, but defaulting
+// unknown types to "kept" avoids silently dropping a future channel type on an
+// unrelated code path.
+func (c recentCutoffs) cutoffFor(channelType uint8) int64 {
+	switch channelType {
+	case common.ChannelTypeGroup.Uint8():
+		return c.group
+	case common.ChannelTypeCommunityTopic.Uint8():
+		return c.thread
+	case common.ChannelTypePerson.Uint8():
+		return c.person
+	default:
+		return 0
+	}
+}
 
 // channelKey returns a string key for (channelID, channelType).
 func channelKey(channelID string, channelType uint8) string {
@@ -896,28 +948,31 @@ func buildFollowItems(
 
 // buildRecentItems constructs the SidebarItem list for the recent tab.
 // Rules:
-//   - DM: always included (no time window).
-//   - Group / Thread: only included if timestamp > threeDaysAgo().
+//   - Each conversation is filtered against the cutoff for its channel type
+//     (cutoffs.cutoffFor): kept iff cutoff == 0 (window disabled) OR
+//     timestamp > cutoff. With the default cutoffs (groups/threads = 3-day
+//     window, DMs = 0) this reproduces the historical behaviour where DMs are
+//     always shown and groups/threads obey a 72h window — but every type is
+//     now operator-tunable via system_settings (issue #289).
 //   - The returned slice is not yet sorted.
 //
 // Intentional non-rule (PR review Important #6): unfollowed groups
 // (group_unfollowed=1 in user_conversation_ext) are NOT filtered out here.
 // Per PM decision on issue #337 — "取消关注就是移除关注列表，放到最近 tab" —
 // an unfollowed group still belongs in the recent tab as long as it has
-// activity within the 72 h window.  The unfollow blacklist only affects
+// activity within the configured window.  The unfollow blacklist only affects
 // the follow tab.
 func buildRecentItems(
 	convs []*config.SyncUserConversationResp,
+	cutoffs recentCutoffs,
 	pinnedSet map[string]struct{},
 	groupSpaceMap map[string]string,
 	externalGroupMap map[string]string,
 	defaultSpaceID string,
 ) []*SidebarItem {
-	cutoff := threeDaysAgo()
 	items := make([]*SidebarItem, 0, len(convs))
 	for _, conv := range convs {
-		isDM := conv.ChannelType == common.ChannelTypePerson.Uint8()
-		if !isDM && conv.Timestamp <= cutoff {
+		if cutoff := cutoffs.cutoffFor(conv.ChannelType); cutoff != 0 && conv.Timestamp <= cutoff {
 			continue
 		}
 		pinned := false

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -12,7 +12,11 @@
 //  4. Apply tab-specific filtering:
 //     follow  – groups with category + not unfollowed; followed DMs; threads
 //     with ext row whose parent group is in the follow set.
-//     recent  – all DMs; groups/threads with timestamp > now-72h.
+//     recent  – per-channel-type activity window from system_settings
+//     (sidebar.recent_filter_{group,thread,person}_days); a window of 0
+//     disables filtering for that type. Defaults reproduce the historical
+//     behaviour for the types the recent tab carries (groups/threads = 3-day
+//     window, DMs unfiltered). See buildRecentItems / loadRecentCutoffs.
 //  5. Append standalone thread ext entries not already in the IM result.
 //  6. Sort:
 //     follow  – category_sort ASC → pinned DESC → follow_sort ASC →
@@ -652,9 +656,16 @@ func daysCutoff(now time.Time, days int) int64 {
 }
 
 // loadRecentCutoffs resolves the per-channel-type recent-tab windows from the
-// shared system_settings snapshot (admin-tunable, ~60s reload). Defaults
-// reproduce the historical hard-coded behaviour exactly: groups/threads use a
-// 3-day window, DMs are unfiltered.
+// shared system_settings snapshot (admin-tunable, ~60s reload). For the channel
+// types the recent tab carries, the defaults reproduce the historical
+// hard-coded behaviour: groups/threads use a 3-day window, DMs are unfiltered.
+// (Unknown types are kept unconditionally — see cutoffFor.)
+//
+// NOTE: EnsureSystemSettings returns a process-wide singleton, so this reads a
+// snapshot shared across the process. Tests that mutate sidebar.* settings must
+// Reload() after wiping the table (see the recent-filter e2e setup), else a
+// stale snapshot from a prior test (within the ~60s auto-reload TTL) can leak
+// in.
 func (sb *Sidebar) loadRecentCutoffs(now time.Time) recentCutoffs {
 	ss := commonapi.EnsureSystemSettings(sb.ctx)
 	return recentCutoffs{

--- a/modules/message/api_sidebar_recent_filter_e2e_test.go
+++ b/modules/message/api_sidebar_recent_filter_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package message
 
 // End-to-end coverage for the configurable recent-tab activity filter
@@ -10,6 +12,17 @@ package message
 // sidebar.* settings have no yaml fallback, so the singleton SystemSettings
 // instance reads the rows we POST regardless of which ctx it was first bound
 // to — the documented binding footgun does not apply here.
+//
+// Build-tagged `integration` (run with `go test -tags=integration`), matching
+// api_sidebar_integration_test.go. These tests spin up testutil.NewTestServer
+// against the shared `test` DB; running them in the default `go test ./...`
+// Test job is order-fragile (a prior test in the package can leave the schema
+// in a state where NewTestServer's module.Setup re-applies a migration whose
+// table already exists and panics, crashing the whole package binary). The
+// per-type filter logic is covered by the unit tests in api_sidebar_test.go,
+// and the system_settings DB read/write path by the common package tests, both
+// of which run in the default Test job; this file is the extra full-stack glue
+// check.
 
 import (
 	"bytes"

--- a/modules/message/api_sidebar_recent_filter_e2e_test.go
+++ b/modules/message/api_sidebar_recent_filter_e2e_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	commonapi "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -48,6 +49,11 @@ func TestE2E_RecentFilter_DefaultsReproduceLegacyBehaviour(t *testing.T) {
 	t.Setenv(masterKeyEnvE2E, "0123456789abcdef0123456789abcdef")
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
+	// Start from a known-good snapshot: the shared SystemSettings singleton may
+	// hold sidebar.* rows written by a prior test (within the ~60s auto-reload
+	// TTL). Reload after wiping the table so "no override" actually means
+	// defaults here (PR #291 review, lml2468).
+	require.NoError(t, commonapi.EnsureSystemSettings(ctx).Reload())
 
 	sb := &Sidebar{ctx: ctx}
 	now := time.Now()

--- a/modules/message/api_sidebar_recent_filter_e2e_test.go
+++ b/modules/message/api_sidebar_recent_filter_e2e_test.go
@@ -1,0 +1,114 @@
+package message
+
+// End-to-end coverage for the configurable recent-tab activity filter
+// (issue #289). Exercises the full seam that the unit tests stub out:
+//
+//	admin HTTP write  →  system_setting DB row  →  shared SystemSettings
+//	snapshot reload   →  Sidebar.loadRecentCutoffs  →  buildRecentItems filter
+//
+// All test ctxs share one physical MySQL `test` database (same DSN), and the
+// sidebar.* settings have no yaml fallback, so the singleton SystemSettings
+// instance reads the rows we POST regardless of which ctx it was first bound
+// to — the documented binding footgun does not apply here.
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const masterKeyEnvE2E = "OCTO_MASTER_KEY"
+
+// TestE2E_RecentFilter_DefaultsReproduceLegacyBehaviour verifies that with no
+// admin override, loadRecentCutoffs yields the historical windows: groups and
+// threads = 3 days, DMs unfiltered.
+func TestE2E_RecentFilter_DefaultsReproduceLegacyBehaviour(t *testing.T) {
+	t.Setenv(masterKeyEnvE2E, "0123456789abcdef0123456789abcdef")
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	sb := &Sidebar{ctx: ctx}
+	now := time.Now()
+	cutoffs := sb.loadRecentCutoffs(now)
+
+	assert.Equal(t, daysCutoff(now, 3), cutoffs.group, "群默认 3 天窗口")
+	assert.Equal(t, daysCutoff(now, 3), cutoffs.thread, "话题默认 3 天窗口")
+	assert.Equal(t, int64(0), cutoffs.person, "DM 默认 0 = 不过滤")
+
+	// And the filter behaves like today's hard-coded path.
+	convs := []*config.SyncUserConversationResp{
+		makeIMConv("g-new", common.ChannelTypeGroup.Uint8(), now.Add(-1*time.Hour).Unix()),
+		makeIMConv("g-old", common.ChannelTypeGroup.Uint8(), now.Add(-73*time.Hour).Unix()),
+		makeIMConv("dm-old", common.ChannelTypePerson.Uint8(), now.Add(-1000*time.Hour).Unix()),
+	}
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	ids := idSet(items)
+	assert.True(t, ids["g-new"])
+	assert.False(t, ids["g-old"], "默认 3 天窗口剔除超期群")
+	assert.True(t, ids["dm-old"], "DM 不受窗口影响")
+}
+
+// TestE2E_RecentFilter_AdminOverrideTakesEffect writes per-type windows through
+// the admin HTTP endpoint and asserts the running cutoffs + filter reflect them
+// without any redeploy.
+func TestE2E_RecentFilter_AdminOverrideTakesEffect(t *testing.T) {
+	t.Setenv(masterKeyEnvE2E, "0123456789abcdef0123456789abcdef")
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.SuperAdmin),
+	))
+
+	// Operator: return ALL groups (window off), keep a 3-day thread window, and
+	// start filtering DMs at 7 days.
+	body := `{"items":[` +
+		`{"category":"sidebar","key":"recent_filter_group_days","value":"0"},` +
+		`{"category":"sidebar","key":"recent_filter_thread_days","value":"3"},` +
+		`{"category":"sidebar","key":"recent_filter_person_days","value":"7"}` +
+		`]}`
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/manager/common/system_setting", bytes.NewReader([]byte(body)))
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	sb := &Sidebar{ctx: ctx}
+	now := time.Now()
+	cutoffs := sb.loadRecentCutoffs(now)
+	assert.Equal(t, int64(0), cutoffs.group, "群窗口关闭 → cutoff 0")
+	assert.Equal(t, daysCutoff(now, 3), cutoffs.thread)
+	assert.Equal(t, daysCutoff(now, 7), cutoffs.person)
+
+	convs := []*config.SyncUserConversationResp{
+		makeIMConv("g-ancient", common.ChannelTypeGroup.Uint8(), now.Add(-5000*time.Hour).Unix()),
+		makeIMConv("g1____t-old", common.ChannelTypeCommunityTopic.Uint8(), now.Add(-73*time.Hour).Unix()),
+		makeIMConv("g1____t-new", common.ChannelTypeCommunityTopic.Uint8(), now.Add(-1*time.Hour).Unix()),
+		makeIMConv("dm-6d", common.ChannelTypePerson.Uint8(), now.Add(-6*24*time.Hour).Unix()),
+		makeIMConv("dm-8d", common.ChannelTypePerson.Uint8(), now.Add(-8*24*time.Hour).Unix()),
+	}
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	ids := idSet(items)
+	assert.True(t, ids["g-ancient"], "群窗口关闭 → 远古群也返回")
+	assert.False(t, ids["g1____t-old"], "话题 3 天窗口 → 剔除超期话题")
+	assert.True(t, ids["g1____t-new"])
+	assert.True(t, ids["dm-6d"], "DM 7 天窗口内保留")
+	assert.False(t, ids["dm-8d"], "DM 超 7 天 → 剔除（数据驱动的 DM 过滤）")
+}
+
+func idSet(items []*SidebarItem) map[string]bool {
+	ids := map[string]bool{}
+	for _, it := range items {
+		ids[it.TargetID] = true
+	}
+	return ids
+}

--- a/modules/message/api_sidebar_test.go
+++ b/modules/message/api_sidebar_test.go
@@ -46,6 +46,19 @@ func now3DaysAgo() int64 { return time.Now().Add(-73 * time.Hour).Unix() }
 // nowRecent returns a unix timestamp well within the 3-day window
 func nowRecent() int64 { return time.Now().Add(-1 * time.Hour).Unix() }
 
+// legacyRecentCutoffs reproduces the historical hard-coded recent-tab filter:
+// group/thread use a 72h window, DMs are unfiltered (cutoff 0). Used by the
+// buildRecentItems unit tests so their original assertions still hold under the
+// new per-channel-type cutoff signature (issue #289).
+func legacyRecentCutoffs() recentCutoffs {
+	now := time.Now()
+	return recentCutoffs{
+		group:  daysCutoff(now, 3),
+		thread: daysCutoff(now, 3),
+		person: daysCutoff(now, 0), // 0 → no filter
+	}
+}
+
 // ---------------------------------------------------------------------------
 // validateSidebarRequest
 // ---------------------------------------------------------------------------
@@ -235,7 +248,7 @@ func TestBuildRecentItems_GroupWithinWindow_Included(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), nowRecent()),
 	}
-	items := buildRecentItems(convs, nil, nil, nil, "")
+	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, "g1", items[0].TargetID)
 }
@@ -244,7 +257,7 @@ func TestBuildRecentItems_GroupOutsideWindow_Excluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, nil, nil, nil, "")
+	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 
@@ -253,7 +266,7 @@ func TestBuildRecentItems_DMAlwaysIncluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("peer1", common.ChannelTypePerson.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, nil, nil, nil, "")
+	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, "peer1", items[0].TargetID)
 }
@@ -262,7 +275,7 @@ func TestBuildRecentItems_ThreadWithinWindow_Included(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1____th1", common.ChannelTypeCommunityTopic.Uint8(), nowRecent()),
 	}
-	items := buildRecentItems(convs, nil, nil, nil, "")
+	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, "g1____th1", items[0].TargetID)
 }
@@ -271,7 +284,7 @@ func TestBuildRecentItems_ThreadOutsideWindow_Excluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1____th1", common.ChannelTypeCommunityTopic.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, nil, nil, nil, "")
+	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 
@@ -283,7 +296,7 @@ func TestBuildRecentItems_PinnedFirst(t *testing.T) {
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), nowRecent()),
 		makeIMConv("g2", common.ChannelTypeGroup.Uint8(), nowRecent()-10),
 	}
-	items := buildRecentItems(convs, pinnedSet, nil, nil, "")
+	items := buildRecentItems(convs, legacyRecentCutoffs(), pinnedSet, nil, nil, "")
 	require.Len(t, items, 2)
 
 	// buildRecentItems sets IsPinned flag; sorting is done separately
@@ -300,6 +313,75 @@ func TestBuildRecentItems_PinnedFirst(t *testing.T) {
 	// After sort, pinned item is first
 	sortRecentItems(items)
 	assert.Equal(t, "g2", items[0].TargetID)
+}
+
+// ---------------------------------------------------------------------------
+// buildRecentItems — configurable per-channel-type windows (issue #289)
+// ---------------------------------------------------------------------------
+
+// daysCutoff: 0/negative → 0 (no filter), positive → now - days*24h.
+func TestDaysCutoff(t *testing.T) {
+	now := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	assert.Equal(t, int64(0), daysCutoff(now, 0), "0 天 = 不过滤")
+	assert.Equal(t, int64(0), daysCutoff(now, -1), "负数 = 不过滤")
+	assert.Equal(t, now.Add(-24*time.Hour).Unix(), daysCutoff(now, 1))
+	assert.Equal(t, now.Add(-72*time.Hour).Unix(), daysCutoff(now, 3))
+}
+
+// cutoff == 0 disables the window for that type: an ancient group conversation
+// is kept when group days = 0 (the "all groups, no time limit" operator ask).
+func TestBuildRecentItems_GroupCutoffZero_AllGroupsKept(t *testing.T) {
+	cutoffs := recentCutoffs{group: 0, thread: daysCutoff(time.Now(), 3), person: 0}
+	convs := []*config.SyncUserConversationResp{
+		makeIMConv("g-old", common.ChannelTypeGroup.Uint8(), now3DaysAgo()),
+		makeIMConv("g-new", common.ChannelTypeGroup.Uint8(), nowRecent()),
+	}
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	assert.Len(t, items, 2, "group 窗口关闭时，超期群也保留")
+}
+
+// Each channel type honours its own window independently: groups unfiltered
+// but threads keep a 3-day window in the same response.
+func TestBuildRecentItems_PerTypeWindowsIndependent(t *testing.T) {
+	cutoffs := recentCutoffs{group: 0, thread: daysCutoff(time.Now(), 3), person: 0}
+	convs := []*config.SyncUserConversationResp{
+		makeIMConv("g-old", common.ChannelTypeGroup.Uint8(), now3DaysAgo()),                // kept (group window off)
+		makeIMConv("g1____t-old", common.ChannelTypeCommunityTopic.Uint8(), now3DaysAgo()), // dropped (thread window on)
+		makeIMConv("g1____t-new", common.ChannelTypeCommunityTopic.Uint8(), nowRecent()),   // kept
+	}
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	ids := map[string]bool{}
+	for _, it := range items {
+		ids[it.TargetID] = true
+	}
+	assert.True(t, ids["g-old"], "群窗口关闭 → 超期群保留")
+	assert.False(t, ids["g1____t-old"], "话题窗口仍生效 → 超期话题剔除")
+	assert.True(t, ids["g1____t-new"], "窗口内话题保留")
+	assert.Len(t, items, 2)
+}
+
+// person window is data-driven: a non-zero DM window now actually filters DMs,
+// replacing the old hard-coded "DMs always shown" exemption.
+func TestBuildRecentItems_PersonWindowFiltersDMs(t *testing.T) {
+	cutoffs := recentCutoffs{group: daysCutoff(time.Now(), 3), thread: daysCutoff(time.Now(), 3), person: daysCutoff(time.Now(), 3)}
+	convs := []*config.SyncUserConversationResp{
+		makeIMConv("dm-old", common.ChannelTypePerson.Uint8(), now3DaysAgo()),
+		makeIMConv("dm-new", common.ChannelTypePerson.Uint8(), nowRecent()),
+	}
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	require.Len(t, items, 1, "person 窗口=3天时，超期 DM 被剔除")
+	assert.Equal(t, "dm-new", items[0].TargetID)
+}
+
+// person cutoff 0 (the default) keeps every DM regardless of age — today's
+// behaviour, now expressed as data rather than an `!isDM` branch.
+func TestBuildRecentItems_PersonCutoffZero_AllDMsKept(t *testing.T) {
+	cutoffs := recentCutoffs{group: daysCutoff(time.Now(), 3), thread: daysCutoff(time.Now(), 3), person: 0}
+	convs := []*config.SyncUserConversationResp{
+		makeIMConv("dm-ancient", common.ChannelTypePerson.Uint8(), time.Now().Add(-1000*time.Hour).Unix()),
+	}
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	require.Len(t, items, 1, "person 默认 0 → DM 永远保留")
 }
 
 // ---------------------------------------------------------------------------
@@ -729,7 +811,7 @@ func TestBuildFollowItems_EmptyConversations(t *testing.T) {
 }
 
 func TestBuildRecentItems_EmptyConversations(t *testing.T) {
-	items := buildRecentItems(nil, nil, nil, nil, "")
+	items := buildRecentItems(nil, legacyRecentCutoffs(), nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 

--- a/modules/message/api_sidebar_test.go
+++ b/modules/message/api_sidebar_test.go
@@ -373,6 +373,27 @@ func TestBuildRecentItems_PersonWindowFiltersDMs(t *testing.T) {
 	assert.Equal(t, "dm-new", items[0].TargetID)
 }
 
+// Unknown channel types (anything that is not group/thread/DM) are kept
+// unconditionally, even with group/thread/person windows all enabled and an
+// ancient timestamp. This locks the deliberate `cutoffFor` default = 0 (no
+// filter) — a documented divergence from the old "filter every non-DM type by
+// 72h" behaviour (PR #291 review P2). The recent tab does not meaningfully
+// carry these types today; the test guards against silently re-filtering them.
+func TestBuildRecentItems_UnknownChannelType_KeptUnconditionally(t *testing.T) {
+	const unknownChannelType uint8 = 99 // not group(2)/person(1)/communityTopic(5)
+	cutoffs := recentCutoffs{
+		group:  daysCutoff(time.Now(), 3),
+		thread: daysCutoff(time.Now(), 3),
+		person: daysCutoff(time.Now(), 3),
+	}
+	convs := []*config.SyncUserConversationResp{
+		makeIMConv("x-ancient", unknownChannelType, time.Now().Add(-10000*time.Hour).Unix()),
+	}
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	require.Len(t, items, 1, "未知频道类型不应被时间窗口过滤（cutoffFor 默认 0=不过滤）")
+	assert.Equal(t, "x-ancient", items[0].TargetID)
+}
+
 // person cutoff 0 (the default) keeps every DM regardless of age — today's
 // behaviour, now expressed as data rather than an `!isDM` branch.
 func TestBuildRecentItems_PersonCutoffZero_AllDMsKept(t *testing.T) {

--- a/modules/message/round2_findings_test.go
+++ b/modules/message/round2_findings_test.go
@@ -152,7 +152,7 @@ func TestSpaceID_Round2_Finding3_BuildRecentItems_ExternalGroupMySource(t *testi
 	groupSpaceMap := map[string]string{"g_external": "spaceB"}
 	externalGroupMap := map[string]string{"g_external": "spaceA"}
 
-	items := buildRecentItems(convs, nil, groupSpaceMap, externalGroupMap, "")
+	items := buildRecentItems(convs, recentCutoffs{}, nil, groupSpaceMap, externalGroupMap, "")
 
 	byID := map[string]*SidebarItem{}
 	for _, it := range items {

--- a/modules/message/round3_findings_test.go
+++ b/modules/message/round3_findings_test.go
@@ -192,7 +192,7 @@ func TestSpaceID_Round3_Finding2_Sidebar_EmptySourceFallback(t *testing.T) {
 	})
 
 	t.Run("buildRecentItems", func(t *testing.T) {
-		items := buildRecentItems(convs, nil, groupSpaceMap, externalGroupMap, defaultSpaceID)
+		items := buildRecentItems(convs, recentCutoffs{}, nil, groupSpaceMap, externalGroupMap, defaultSpaceID)
 		byID := map[string]*SidebarItem{}
 		for _, it := range items {
 			byID[it.TargetID] = it

--- a/modules/message/sidebar_space_id_test.go
+++ b/modules/message/sidebar_space_id_test.go
@@ -78,7 +78,7 @@ func TestSpaceID_BuildRecentItems_GroupAndThreadFilled(t *testing.T) {
 		"g1": "spaceB",
 	}
 
-	items := buildRecentItems(convs, nil, groupSpaceMap, nil, "")
+	items := buildRecentItems(convs, recentCutoffs{}, nil, groupSpaceMap, nil, "")
 
 	bySpace := map[string]string{}
 	for _, it := range items {


### PR DESCRIPTION
Closes #289.

## Background

The `recent` tab of `POST /v1/sidebar/sync` hid group/thread (community topic) conversations whose last activity was older than a **hard-coded 72h window**, while DMs were always kept. The window was neither runtime-adjustable nor differentiated by channel type. Operators asked to (a) turn the time filter on/off and (b) tune the window length, **per channel type** (e.g. "return all groups, no time limit; keep the 3-day window for threads").

## What this does

Drives the recent-tab window from the existing `system_settings` mechanism, with **per-channel-type day counts** and a `0` sentinel that disables filtering.

| setting key | default | meaning |
|---|---|---|
| `sidebar.recent_filter_group_days` | `3` | group window in days; `0` = no filter (all groups) |
| `sidebar.recent_filter_thread_days` | `3` | thread window; `0` = no filter |
| `sidebar.recent_filter_person_days` | `0` | DM window; `0` keeps today's "always shown" behaviour |

**Defaults reproduce today's exact behaviour** (groups/threads = 3 days, DMs unfiltered), so this is zero-impact until an operator opts in. Setting `recent_filter_group_days = 0` yields the requested "all groups, no time limit" case.

### Dynamic, near-real-time
Configured via the existing admin endpoint `POST /v1/manager/common/system_setting` (SuperAdmin). The handler reloads the in-memory snapshot synchronously before returning, so the writing instance sees the new value on the **next** sidebar request; other instances converge within the ~60s auto-reload TTL. No redeploy.

## Changes

**`modules/common`**
- Three int settings added to the `system_setting` schema with typed getters.
- `getIntClamped` clamps out-of-range DB values back to the default (defence in depth against direct DB edits).
- `[0, 3650]` range validation for int settings on the admin write path — closes a pre-existing gap where the int branch only ran `strconv.Atoi` with no bounds check.

**`modules/message`**
- `threeDaysAgo()` replaced by `daysCutoff` + a per-type `recentCutoffs` struct loaded from `system_settings` (`loadRecentCutoffs`). `buildRecentItems` selects the cutoff by channel type and skips filtering when `cutoff == 0`. The DM exemption is now **data-driven** (person window default `0`) rather than a hard-coded `!isDM` branch. Unknown channel types are kept (recent tab only ever carries group/thread/DM).

## Tests

- `system_settings` getter unit tests: defaults, DB override, out-of-range clamp, boundary values.
- Admin write-path validation: rejects out-of-range / non-int, accepts boundaries and persists.
- `buildRecentItems` per-type window cases: group cutoff `0` = all kept, independent per-type windows, DM window now filters, DM `0` keeps all; plus a `daysCutoff` unit test.
- A DB-backed e2e covering the full path: admin HTTP write → settings reload → handler `loadRecentCutoffs` → filter.

Verified locally against MySQL + Redis (WuKongIM not required — the IM result is stubbed via synthetic conversation slices). `go build ./...`, `go vet`, `golangci-lint` (0 issues), and the i18n lints all pass.

## Out of scope
`POST /v1/conversation/sync` has no time-window filtering (intentionally untouched); the `follow` tab applies no time filter and is unaffected.

https://claude.ai/code/session_01PeCytGvTzrdXjHmVAPVLfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeCytGvTzrdXjHmVAPVLfN)_