### PR TITLE
feat(incomingwebhook): runtime master toggle + tunable thresholds via system_setting

### DIFF
--- a/modules/common/api_manager_system_setting.go
+++ b/modules/common/api_manager_system_setting.go
@@ -221,6 +221,15 @@ func (m *Manager) updateSystemSettings(c *wkhttp.Context) {
 					return
 				}
 			}
+		case settingTypeFloat:
+			if item.Value != "" {
+				if _, err := strconv.ParseFloat(item.Value, 64); err != nil {
+					c.JSON(http.StatusBadRequest, jsonH{
+						"msg": fmt.Sprintf("%s.%s 必须是数字", item.Category, item.Key),
+					})
+					return
+				}
+			}
 		case settingTypeEncrypted:
 			if item.Value == "" || item.Value == secretMask {
 				// Empty payload or the GET mask sentinel preserves the existing

--- a/modules/common/api_manager_system_setting.go
+++ b/modules/common/api_manager_system_setting.go
@@ -3,6 +3,7 @@ package common
 import (
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 
@@ -203,7 +204,9 @@ func (m *Manager) updateSystemSettings(c *wkhttp.Context) {
 		case settingTypeInt:
 			// Empty value means "reset to default" (the getter treats an empty
 			// snapshot entry as not-configured), so only validate non-empty
-			// payloads. Bounds-check against [settingIntMin, settingIntMax] —
+			// payloads. A Positive key (rate-limit / quota knob) must be a
+			// strictly-positive int and skips the shared day-window bound;
+			// otherwise bounds-check against [settingIntMin, settingIntMax] —
 			// previously this path only ran strconv.Atoi with no range guard,
 			// letting absurd windows (or negatives) reach the DB (issue #289).
 			if item.Value != "" {
@@ -214,7 +217,14 @@ func (m *Manager) updateSystemSettings(c *wkhttp.Context) {
 					})
 					return
 				}
-				if n < settingIntMin || n > settingIntMax {
+				if def.Positive {
+					if n <= 0 {
+						c.JSON(http.StatusBadRequest, jsonH{
+							"msg": fmt.Sprintf("%s.%s 必须是正整数", item.Category, item.Key),
+						})
+						return
+					}
+				} else if n < settingIntMin || n > settingIntMax {
 					c.JSON(http.StatusBadRequest, jsonH{
 						"msg": fmt.Sprintf("%s.%s 必须在 [%d, %d] 范围内", item.Category, item.Key, settingIntMin, settingIntMax),
 					})
@@ -222,10 +232,28 @@ func (m *Manager) updateSystemSettings(c *wkhttp.Context) {
 				}
 			}
 		case settingTypeFloat:
+			// Reject non-finite (NaN / ±Inf — all of which strconv.ParseFloat
+			// happily accepts) so they can never reach a rate limiter: a NaN rps
+			// errors the Redis Lua script (fail-open) and ±Inf/≤0 short-circuit
+			// the bucket to "always allowed". A Positive key additionally rejects
+			// ≤0. Read side mirrors this (clamp → default) for direct DB edits.
 			if item.Value != "" {
-				if _, err := strconv.ParseFloat(item.Value, 64); err != nil {
+				f, err := strconv.ParseFloat(item.Value, 64)
+				if err != nil {
 					c.JSON(http.StatusBadRequest, jsonH{
 						"msg": fmt.Sprintf("%s.%s 必须是数字", item.Category, item.Key),
+					})
+					return
+				}
+				if math.IsNaN(f) || math.IsInf(f, 0) {
+					c.JSON(http.StatusBadRequest, jsonH{
+						"msg": fmt.Sprintf("%s.%s 必须是有限数字", item.Category, item.Key),
+					})
+					return
+				}
+				if def.Positive && f <= 0 {
+					c.JSON(http.StatusBadRequest, jsonH{
+						"msg": fmt.Sprintf("%s.%s 必须是正数", item.Category, item.Key),
 					})
 					return
 				}

--- a/modules/common/api_manager_system_setting_test.go
+++ b/modules/common/api_manager_system_setting_test.go
@@ -433,3 +433,68 @@ func TestManagerSystemSetting_UpdateAcceptsInRangeIntBoundaries(t *testing.T) {
 	assert.Equal(t, "3650", got["sidebar.recent_filter_thread_days"])
 	assert.Equal(t, "7", got["sidebar.recent_filter_person_days"])
 }
+
+// TestManagerSystemSetting_UpdateRejectsInvalidIncomingWebhookNumerics pins the
+// #292-review hardening: the rate-limit / quota knobs are Positive keys, so the
+// write path must reject 0 / negative / NaN / ±Inf / non-numeric — values that
+// would otherwise silently disable the per-webhook limiter or the quota.
+func TestManagerSystemSetting_UpdateRejectsInvalidIncomingWebhookNumerics(t *testing.T) {
+	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.SuperAdmin),
+	))
+
+	cases := []struct{ key, value string }{
+		{"per_webhook_rps", "0"}, {"per_webhook_rps", "-1.5"}, {"per_webhook_rps", "NaN"},
+		{"per_webhook_rps", "+Inf"}, {"per_webhook_rps", "-Inf"}, {"per_webhook_rps", "abc"},
+		{"per_webhook_burst", "0"}, {"per_webhook_burst", "-1"},
+		{"max_per_group", "0"}, {"max_per_group", "-5"},
+	}
+	for _, tc := range cases {
+		body := []byte(`{"items":[{"category":"incomingwebhook","key":"` + tc.key + `","value":"` + tc.value + `"}]}`)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/v1/manager/common/system_setting", bytes.NewReader(body))
+		req.Header.Set("token", testutil.Token)
+		s.GetRoute().ServeHTTP(w, req)
+		assert.NotEqualf(t, http.StatusOK, w.Code, "incomingwebhook.%s=%q must be rejected", tc.key, tc.value)
+	}
+}
+
+// TestManagerSystemSetting_UpdateAcceptsPositiveIncomingWebhookNumerics pins that
+// valid positive values are accepted, including a large burst — Positive keys opt
+// out of the shared [0,3650] day-window cap, so there is no artificial upper bound
+// (matching the env semantics they fall back to).
+func TestManagerSystemSetting_UpdateAcceptsPositiveIncomingWebhookNumerics(t *testing.T) {
+	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.SuperAdmin),
+	))
+
+	body := []byte(`{"items":[` +
+		`{"category":"incomingwebhook","key":"per_webhook_rps","value":"8.5"},` +
+		`{"category":"incomingwebhook","key":"per_webhook_burst","value":"100000"},` +
+		`{"category":"incomingwebhook","key":"max_per_group","value":"50"}` +
+		`]}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/manager/common/system_setting", bytes.NewReader(body))
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	db := newSystemSettingDB(ctx)
+	rows, err := db.listAll()
+	require.NoError(t, err)
+	got := map[string]string{}
+	for _, r := range rows {
+		got[schemaKey(r.Category, r.KeyName)] = r.Value
+	}
+	assert.Equal(t, "8.5", got["incomingwebhook.per_webhook_rps"])
+	assert.Equal(t, "100000", got["incomingwebhook.per_webhook_burst"], "no artificial upper bound for Positive keys")
+	assert.Equal(t, "50", got["incomingwebhook.max_per_group"])
+}

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -7,6 +7,7 @@ const (
 	settingTypeString    = "string"
 	settingTypeBool      = "bool"
 	settingTypeInt       = "int"
+	settingTypeFloat     = "float"
 	settingTypeEncrypted = "encrypted"
 )
 
@@ -93,6 +94,18 @@ var systemSettingSchema = []settingDef{
 	{Category: "sidebar", Key: "recent_filter_person_days", Type: settingTypeInt, Description: "最近会话-单聊(DM)活跃过滤窗口(天)，0=不过滤(默认)",
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.SidebarRecentFilterPersonDays()) }},
 
+	// Incoming webhook 总开关 + 核心阈值 — 与 env(DM_INCOMINGWEBHOOK_*) 等价，DB 为
+	// 单一真源。enabled 关闭后 push 返回 404、管理写操作被拒、仅保留 list 只读；
+	// 其余三项实时调阈值无需重启（SystemSettings 快照 60s 内多实例收敛）。
+	{Category: "incomingwebhook", Key: "enabled", Type: settingTypeBool, Description: "是否开启群入站 Webhook（关闭后停止推送与管理写操作）",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.IncomingWebhookEnabled()) }},
+	{Category: "incomingwebhook", Key: "per_webhook_rps", Type: settingTypeFloat, Description: "单个 Webhook 每秒推送速率上限（令牌桶 rps）",
+		Effective: func(s *SystemSettings) string { return floatToCanonical(s.IncomingWebhookPerWebhookRPS()) }},
+	{Category: "incomingwebhook", Key: "per_webhook_burst", Type: settingTypeInt, Description: "单个 Webhook 推送突发上限（令牌桶 burst）",
+		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.IncomingWebhookPerWebhookBurst()) }},
+	{Category: "incomingwebhook", Key: "max_per_group", Type: settingTypeInt, Description: "单个群最多可创建的 Webhook 数量",
+		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.IncomingWebhookMaxPerGroup()) }},
+
 	// Email server config — formerly yaml-only (Support.* in config.go).
 	{Category: "support", Key: "email", Type: settingTypeString, Description: "技术支持邮箱（发件人）",
 		Effective: func(s *SystemSettings) string { return s.SupportEmail() }},
@@ -110,6 +123,12 @@ func boolToCanonical(v bool) string {
 		return "1"
 	}
 	return "0"
+}
+
+// floatToCanonical 把 float 规范成最短十进制表示（5.0 → "5"，0.5 → "0.5"），与
+// settingTypeFloat 的 DB 存储 / POST 入参拼写保持一致，供 GET effective_value 用。
+func floatToCanonical(v float64) string {
+	return strconv.FormatFloat(v, 'g', -1, 64)
 }
 
 // schemaKey returns the canonical "category.key" string used as map key in

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -55,6 +55,16 @@ type settingDef struct {
 	// API layer is responsible for masking before serialisation; never
 	// surface this value directly.
 	Effective func(*SystemSettings) string
+	// Positive, when set on a settingTypeInt / settingTypeFloat key, requires a
+	// strictly-positive finite value on the admin write path and OPTS OUT of the
+	// shared [settingIntMin, settingIntMax] bound (which exists for the
+	// day-window int settings where 0 is a valid "disable" sentinel). Used by
+	// rate-limit / quota knobs (incomingwebhook.*) where 0 / negative / NaN / Inf
+	// would silently disable the control — the schema comment on settingIntMin
+	// anticipated this per-key override. No artificial upper bound is imposed
+	// (matches the env semantics these keys fall back to). Read-side defence is
+	// in the typed getters (clamp ≤0 / non-finite → default).
+	Positive bool
 }
 
 // systemSettingSchema enumerates every admin-tunable setting backed by the
@@ -99,11 +109,11 @@ var systemSettingSchema = []settingDef{
 	// 其余三项实时调阈值无需重启（SystemSettings 快照 60s 内多实例收敛）。
 	{Category: "incomingwebhook", Key: "enabled", Type: settingTypeBool, Description: "是否开启群入站 Webhook（关闭后停止推送与管理写操作）",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.IncomingWebhookEnabled()) }},
-	{Category: "incomingwebhook", Key: "per_webhook_rps", Type: settingTypeFloat, Description: "单个 Webhook 每秒推送速率上限（令牌桶 rps）",
+	{Category: "incomingwebhook", Key: "per_webhook_rps", Type: settingTypeFloat, Description: "单个 Webhook 每秒推送速率上限（令牌桶 rps）", Positive: true,
 		Effective: func(s *SystemSettings) string { return floatToCanonical(s.IncomingWebhookPerWebhookRPS()) }},
-	{Category: "incomingwebhook", Key: "per_webhook_burst", Type: settingTypeInt, Description: "单个 Webhook 推送突发上限（令牌桶 burst）",
+	{Category: "incomingwebhook", Key: "per_webhook_burst", Type: settingTypeInt, Description: "单个 Webhook 推送突发上限（令牌桶 burst）", Positive: true,
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.IncomingWebhookPerWebhookBurst()) }},
-	{Category: "incomingwebhook", Key: "max_per_group", Type: settingTypeInt, Description: "单个群最多可创建的 Webhook 数量",
+	{Category: "incomingwebhook", Key: "max_per_group", Type: settingTypeInt, Description: "单个群最多可创建的 Webhook 数量", Positive: true,
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.IncomingWebhookMaxPerGroup()) }},
 
 	// Email server config — formerly yaml-only (Support.* in config.go).

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -581,7 +581,14 @@ func (s *SystemSettings) IncomingWebhookEnabled() bool {
 // 让 Redis Lua 脚本报错而 fail-open——正是这个 getter 要兜住的。写侧也已拒绝
 // （settingTypeFloat + Positive，见 api_manager_system_setting.go），此处是纵深防御。
 func (s *SystemSettings) IncomingWebhookPerWebhookRPS() float64 {
+	// env fallback 同样消毒：wkhttp.ParseRPSFromEnv 用 strconv.ParseFloat，会接受
+	// NaN / +Inf（DM_INCOMINGWEBHOOK_RPS=NaN 原样透出），所以 def 本身可能非有限。
+	// 若 env 给出非有限/≤0 的 def，回退到永远合法的 code default，避免它穿过下面的
+	// clamp 继续把 NaN 喂给限流器（Jerry-Xin #292 review）。
 	def := wkhttp.ParseRPSFromEnv(envIncomingWebhookPerWebhookRPS, defaultIncomingWebhookPerWebhookRPS)
+	if math.IsNaN(def) || math.IsInf(def, 0) || def <= 0 {
+		def = defaultIncomingWebhookPerWebhookRPS
+	}
 	v := s.getFloat("incomingwebhook", "per_webhook_rps", def)
 	if math.IsNaN(v) || math.IsInf(v, 0) || v <= 0 {
 		return def

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"go.uber.org/zap"
 )
 
@@ -232,6 +233,18 @@ func (s *SystemSettings) getIntClamped(category, key string, fallback int) int {
 		return fallback
 	}
 	return v
+}
+
+func (s *SystemSettings) getFloat(category, key string, fallback float64) float64 {
+	v, ok := s.lookup(category, key)
+	if !ok {
+		return fallback
+	}
+	parsed, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return fallback
+	}
+	return parsed
 }
 
 func (s *SystemSettings) getEncrypted(category, key string, fallback string) string {
@@ -532,4 +545,75 @@ func (s *SystemSettings) SupportEmailSmtp() string {
 // this getter returns the yaml fallback.
 func (s *SystemSettings) SupportEmailPwd() string {
 	return s.getEncrypted("support", "email_pwd", s.ctx.GetConfig().Support.EmailPwd)
+}
+
+// ----- incomingwebhook settings (总开关 + 核心阈值) -----
+//
+// 这些 env 名 / 默认值是 modules/incomingwebhook 的「单一真源」：incomingwebhook 侧
+// 通过下面的 getter 读取（不再各自读 env），从而让 system_setting 的 effective_value
+// 能反映完整的 DB → env → code-default 回退链。修改 env 名或默认值时，需同步
+// systemSettingSchema 的 incomingwebhook 行；reciprocal sync 注释见
+// modules/incomingwebhook/api.go 的 New / allowPerWebhook / create。
+const (
+	envIncomingWebhookEnabled         = "DM_INCOMINGWEBHOOK_ENABLED"
+	envIncomingWebhookPerWebhookRPS   = "DM_INCOMINGWEBHOOK_RPS"
+	envIncomingWebhookPerWebhookBurst = "DM_INCOMINGWEBHOOK_BURST"
+	envIncomingWebhookMaxPerGroup     = "DM_INCOMINGWEBHOOK_MAX_PER_GROUP"
+
+	defaultIncomingWebhookEnabled         = true
+	defaultIncomingWebhookPerWebhookRPS   = 5.0
+	defaultIncomingWebhookPerWebhookBurst = 10
+	defaultIncomingWebhookMaxPerGroup     = 10
+)
+
+// IncomingWebhookEnabled 是群入站 Webhook 功能的总开关。关闭后 push 端点返回 404、
+// 管理写操作（create/update/delete/regenerate）被拒绝，仅保留 list 只读。
+// 回退链：DB → env(DM_INCOMINGWEBHOOK_ENABLED) → 默认开启(true)。
+func (s *SystemSettings) IncomingWebhookEnabled() bool {
+	return s.getBool("incomingwebhook", "enabled", incomingWebhookEnabledEnvDefault())
+}
+
+// IncomingWebhookPerWebhookRPS 单个 webhook 令牌桶速率(rps)。DB → env → 默认 5。
+func (s *SystemSettings) IncomingWebhookPerWebhookRPS() float64 {
+	return s.getFloat("incomingwebhook", "per_webhook_rps",
+		wkhttp.ParseRPSFromEnv(envIncomingWebhookPerWebhookRPS, defaultIncomingWebhookPerWebhookRPS))
+}
+
+// IncomingWebhookPerWebhookBurst 单个 webhook 令牌桶突发上限。DB → env → 默认 10。
+func (s *SystemSettings) IncomingWebhookPerWebhookBurst() int {
+	return s.getInt("incomingwebhook", "per_webhook_burst",
+		wkhttp.ParseBurstFromEnv(envIncomingWebhookPerWebhookBurst, defaultIncomingWebhookPerWebhookBurst))
+}
+
+// IncomingWebhookMaxPerGroup 单个群可创建的 webhook 数量上限。DB → env → 默认 10。
+func (s *SystemSettings) IncomingWebhookMaxPerGroup() int {
+	return s.getInt("incomingwebhook", "max_per_group", incomingWebhookMaxPerGroupEnvDefault())
+}
+
+// incomingWebhookEnabledEnvDefault 解析 DM_INCOMINGWEBHOOK_ENABLED（缺省/无法识别
+// 视为开启），作为 DB 未配置时的 fallback。比 getBool 的 DB 解析更宽松，接受
+// 1/0/true/false/yes/no/on/off（大小写不敏感、允许前后空格）。
+func incomingWebhookEnabledEnvDefault() bool {
+	v := strings.TrimSpace(os.Getenv(envIncomingWebhookEnabled))
+	if v == "" {
+		return defaultIncomingWebhookEnabled
+	}
+	switch strings.ToLower(v) {
+	case "0", "false", "no", "off":
+		return false
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return defaultIncomingWebhookEnabled
+}
+
+// incomingWebhookMaxPerGroupEnvDefault 解析 DM_INCOMINGWEBHOOK_MAX_PER_GROUP；仅
+// 接受正整数，否则回退默认值（语义与迁移前 modules/incomingwebhook.maxPerGroup 一致）。
+func incomingWebhookMaxPerGroupEnvDefault() int {
+	if v := os.Getenv(envIncomingWebhookMaxPerGroup); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultIncomingWebhookMaxPerGroup
 }

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"encoding/base64"
+	"math"
 	"os"
 	"regexp"
 	"strconv"
@@ -574,20 +575,41 @@ func (s *SystemSettings) IncomingWebhookEnabled() bool {
 }
 
 // IncomingWebhookPerWebhookRPS 单个 webhook 令牌桶速率(rps)。DB → env → 默认 5。
+//
+// 读侧防御（D-289 同型，覆盖直接改库的旁路）：rps 必须是正有限值；NaN/±Inf/≤0 一律
+// 回退到 env/默认。否则 allowPerWebhook 的 `rps<=0` 短路会把限流器静默关掉，NaN 还会
+// 让 Redis Lua 脚本报错而 fail-open——正是这个 getter 要兜住的。写侧也已拒绝
+// （settingTypeFloat + Positive，见 api_manager_system_setting.go），此处是纵深防御。
 func (s *SystemSettings) IncomingWebhookPerWebhookRPS() float64 {
-	return s.getFloat("incomingwebhook", "per_webhook_rps",
-		wkhttp.ParseRPSFromEnv(envIncomingWebhookPerWebhookRPS, defaultIncomingWebhookPerWebhookRPS))
+	def := wkhttp.ParseRPSFromEnv(envIncomingWebhookPerWebhookRPS, defaultIncomingWebhookPerWebhookRPS)
+	v := s.getFloat("incomingwebhook", "per_webhook_rps", def)
+	if math.IsNaN(v) || math.IsInf(v, 0) || v <= 0 {
+		return def
+	}
+	return v
 }
 
 // IncomingWebhookPerWebhookBurst 单个 webhook 令牌桶突发上限。DB → env → 默认 10。
+// 读侧防御：≤0 回退默认（同 RPS，避免 `burst<=0` 短路静默关掉限流器）。
 func (s *SystemSettings) IncomingWebhookPerWebhookBurst() int {
-	return s.getInt("incomingwebhook", "per_webhook_burst",
-		wkhttp.ParseBurstFromEnv(envIncomingWebhookPerWebhookBurst, defaultIncomingWebhookPerWebhookBurst))
+	def := wkhttp.ParseBurstFromEnv(envIncomingWebhookPerWebhookBurst, defaultIncomingWebhookPerWebhookBurst)
+	v := s.getInt("incomingwebhook", "per_webhook_burst", def)
+	if v <= 0 {
+		return def
+	}
+	return v
 }
 
 // IncomingWebhookMaxPerGroup 单个群可创建的 webhook 数量上限。DB → env → 默认 10。
+// 读侧防御：≤0 回退默认（max_per_group=0 会让每次 create 都 ErrQuotaExceeded，是
+// 总开关之外一种更难诊断的「暗关」）。
 func (s *SystemSettings) IncomingWebhookMaxPerGroup() int {
-	return s.getInt("incomingwebhook", "max_per_group", incomingWebhookMaxPerGroupEnvDefault())
+	def := incomingWebhookMaxPerGroupEnvDefault()
+	v := s.getInt("incomingwebhook", "max_per_group", def)
+	if v <= 0 {
+		return def
+	}
+	return v
 }
 
 // incomingWebhookEnabledEnvDefault 解析 DM_INCOMINGWEBHOOK_ENABLED（缺省/无法识别

--- a/modules/common/system_settings_test.go
+++ b/modules/common/system_settings_test.go
@@ -195,6 +195,17 @@ func TestSystemSettings_IncomingWebhook_ReadSideClamp_NoInfra(t *testing.T) {
 		assert.Equalf(t, defaultIncomingWebhookMaxPerGroup, s.IncomingWebhookMaxPerGroup(), "max_per_group=%q must clamp to default", bad)
 	}
 
+	// env-derived fallback is sanitized too: DM_INCOMINGWEBHOOK_RPS=NaN (which
+	// ParseRPSFromEnv passes through) with no DB row must NOT reach the getter as
+	// NaN — it falls back to the code default (Jerry-Xin #292 review).
+	t.Setenv(envIncomingWebhookPerWebhookRPS, "NaN")
+	emptySnap := &SystemSettings{}
+	em := map[string]string{}
+	emptySnap.snapshot.Store(&em)
+	assert.Equal(t, defaultIncomingWebhookPerWebhookRPS, emptySnap.IncomingWebhookPerWebhookRPS(),
+		"env=NaN with no DB row must fall back to the code default, not NaN")
+	t.Setenv(envIncomingWebhookPerWebhookRPS, "")
+
 	// A valid positive value is served as-is (clamp only catches the bad cases).
 	s := &SystemSettings{}
 	snap := map[string]string{

--- a/modules/common/system_settings_test.go
+++ b/modules/common/system_settings_test.go
@@ -172,6 +172,49 @@ func TestSystemSettings_IncomingWebhookRPS_EnvFallbackWhenDBUnset(t *testing.T) 
 	assert.Equal(t, 7.0, s.IncomingWebhookPerWebhookRPS(), "DB 未配置 → env 生效")
 }
 
+// TestSystemSettings_IncomingWebhook_GetterChain_NoInfra exercises the full
+// snapshot(DB) → env → code-default fallback for the incomingwebhook getters
+// WITHOUT a test server: it drives the snapshot map directly. This lets the
+// core getter logic be verified even where MySQL is unavailable; the DB-backed
+// tests above additionally cover the real Load/Reload path in CI.
+func TestSystemSettings_IncomingWebhook_GetterChain_NoInfra(t *testing.T) {
+	// 1) 空快照 + 无 env → code default。
+	t.Setenv(envIncomingWebhookEnabled, "")
+	t.Setenv(envIncomingWebhookPerWebhookRPS, "")
+	t.Setenv(envIncomingWebhookPerWebhookBurst, "")
+	t.Setenv(envIncomingWebhookMaxPerGroup, "")
+	s := &SystemSettings{}
+	empty := map[string]string{}
+	s.snapshot.Store(&empty)
+	assert.True(t, s.IncomingWebhookEnabled())
+	assert.Equal(t, defaultIncomingWebhookPerWebhookRPS, s.IncomingWebhookPerWebhookRPS())
+	assert.Equal(t, defaultIncomingWebhookPerWebhookBurst, s.IncomingWebhookPerWebhookBurst())
+	assert.Equal(t, defaultIncomingWebhookMaxPerGroup, s.IncomingWebhookMaxPerGroup())
+
+	// 2) env override（snapshot 仍空）。
+	t.Setenv(envIncomingWebhookEnabled, "off")
+	t.Setenv(envIncomingWebhookPerWebhookRPS, "7")
+	t.Setenv(envIncomingWebhookPerWebhookBurst, "3")
+	t.Setenv(envIncomingWebhookMaxPerGroup, "2")
+	assert.False(t, s.IncomingWebhookEnabled())
+	assert.Equal(t, 7.0, s.IncomingWebhookPerWebhookRPS())
+	assert.Equal(t, 3, s.IncomingWebhookPerWebhookBurst())
+	assert.Equal(t, 2, s.IncomingWebhookMaxPerGroup())
+
+	// 3) snapshot(DB) 压制 env。
+	snap := map[string]string{
+		"incomingwebhook.enabled":           "1",
+		"incomingwebhook.per_webhook_rps":   "8.5",
+		"incomingwebhook.per_webhook_burst": "25",
+		"incomingwebhook.max_per_group":     "9",
+	}
+	s.snapshot.Store(&snap)
+	assert.True(t, s.IncomingWebhookEnabled())
+	assert.Equal(t, 8.5, s.IncomingWebhookPerWebhookRPS())
+	assert.Equal(t, 25, s.IncomingWebhookPerWebhookBurst())
+	assert.Equal(t, 9, s.IncomingWebhookMaxPerGroup())
+}
+
 func TestSystemSettings_BoolOverridesYamlWhenSet(t *testing.T) {
 	s := newTestSystemSettings(t, nil)
 	s.ctx.GetConfig().Register.EmailOn = true // yaml says on

--- a/modules/common/system_settings_test.go
+++ b/modules/common/system_settings_test.go
@@ -172,6 +172,42 @@ func TestSystemSettings_IncomingWebhookRPS_EnvFallbackWhenDBUnset(t *testing.T) 
 	assert.Equal(t, 7.0, s.IncomingWebhookPerWebhookRPS(), "DB 未配置 → env 生效")
 }
 
+// TestSystemSettings_IncomingWebhook_ReadSideClamp_NoInfra pins the read-side
+// defence (#292 review): a snapshot carrying NaN / ±Inf / ≤0 — which a direct DB
+// edit could introduce even though the admin write path now rejects them — must
+// clamp back to the env/code default so the rate limiter never sees a value that
+// would silently disable it. Drives the snapshot directly, no infra.
+func TestSystemSettings_IncomingWebhook_ReadSideClamp_NoInfra(t *testing.T) {
+	t.Setenv(envIncomingWebhookPerWebhookRPS, "")   // → default 5
+	t.Setenv(envIncomingWebhookPerWebhookBurst, "") // → default 10
+	t.Setenv(envIncomingWebhookMaxPerGroup, "")     // → default 10
+
+	for _, bad := range []string{"NaN", "+Inf", "-Inf", "0", "-1", "-3.5"} {
+		s := &SystemSettings{}
+		snap := map[string]string{
+			"incomingwebhook.per_webhook_rps":   bad,
+			"incomingwebhook.per_webhook_burst": bad,
+			"incomingwebhook.max_per_group":     bad,
+		}
+		s.snapshot.Store(&snap)
+		assert.Equalf(t, defaultIncomingWebhookPerWebhookRPS, s.IncomingWebhookPerWebhookRPS(), "rps=%q must clamp to default", bad)
+		assert.Equalf(t, defaultIncomingWebhookPerWebhookBurst, s.IncomingWebhookPerWebhookBurst(), "burst=%q must clamp to default", bad)
+		assert.Equalf(t, defaultIncomingWebhookMaxPerGroup, s.IncomingWebhookMaxPerGroup(), "max_per_group=%q must clamp to default", bad)
+	}
+
+	// A valid positive value is served as-is (clamp only catches the bad cases).
+	s := &SystemSettings{}
+	snap := map[string]string{
+		"incomingwebhook.per_webhook_rps":   "8.5",
+		"incomingwebhook.per_webhook_burst": "25",
+		"incomingwebhook.max_per_group":     "3",
+	}
+	s.snapshot.Store(&snap)
+	assert.Equal(t, 8.5, s.IncomingWebhookPerWebhookRPS())
+	assert.Equal(t, 25, s.IncomingWebhookPerWebhookBurst())
+	assert.Equal(t, 3, s.IncomingWebhookMaxPerGroup())
+}
+
 // TestSystemSettings_IncomingWebhook_GetterChain_NoInfra exercises the full
 // snapshot(DB) → env → code-default fallback for the incomingwebhook getters
 // WITHOUT a test server: it drives the snapshot map directly. This lets the

--- a/modules/common/system_settings_test.go
+++ b/modules/common/system_settings_test.go
@@ -123,6 +123,55 @@ func TestSystemSettings_BoolFallsBackToYamlWhenUnset(t *testing.T) {
 	assert.False(t, s.RegisterOff(), "DB empty -> fall back to yaml false")
 }
 
+// ----- incomingwebhook settings (总开关 + 核心阈值) -----
+
+func TestSystemSettings_IncomingWebhookEnabled_DefaultsTrue(t *testing.T) {
+	t.Setenv(envIncomingWebhookEnabled, "") // 证明开关纯由 DB / 默认驱动
+	s := newTestSystemSettings(t, nil)
+	assert.True(t, s.IncomingWebhookEnabled(), "DB+env 缺失时默认开启")
+}
+
+func TestSystemSettings_IncomingWebhookEnabled_DBOverridesToFalse(t *testing.T) {
+	t.Setenv(envIncomingWebhookEnabled, "")
+	s := newTestSystemSettings(t, nil)
+	require.NoError(t, s.db.upsert("incomingwebhook", "enabled", "0", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+	assert.False(t, s.IncomingWebhookEnabled(), "DB 0 必须压制默认 true")
+}
+
+func TestSystemSettings_IncomingWebhookEnabled_EnvFallbackWhenDBUnset(t *testing.T) {
+	t.Setenv(envIncomingWebhookEnabled, "false")
+	s := newTestSystemSettings(t, nil)
+	assert.False(t, s.IncomingWebhookEnabled(), "DB 未配置 → env=false 生效")
+}
+
+func TestSystemSettings_IncomingWebhookThresholds_DefaultsAndDBOverride(t *testing.T) {
+	t.Setenv(envIncomingWebhookPerWebhookRPS, "")
+	t.Setenv(envIncomingWebhookPerWebhookBurst, "")
+	t.Setenv(envIncomingWebhookMaxPerGroup, "")
+	s := newTestSystemSettings(t, nil)
+
+	// DB+env 缺失 → code default。
+	assert.Equal(t, defaultIncomingWebhookPerWebhookRPS, s.IncomingWebhookPerWebhookRPS())
+	assert.Equal(t, defaultIncomingWebhookPerWebhookBurst, s.IncomingWebhookPerWebhookBurst())
+	assert.Equal(t, defaultIncomingWebhookMaxPerGroup, s.IncomingWebhookMaxPerGroup())
+
+	// DB 覆盖（含 float rps）。
+	require.NoError(t, s.db.upsert("incomingwebhook", "per_webhook_rps", "8.5", settingTypeFloat, ""))
+	require.NoError(t, s.db.upsert("incomingwebhook", "per_webhook_burst", "25", settingTypeInt, ""))
+	require.NoError(t, s.db.upsert("incomingwebhook", "max_per_group", "3", settingTypeInt, ""))
+	require.NoError(t, s.Reload())
+	assert.Equal(t, 8.5, s.IncomingWebhookPerWebhookRPS())
+	assert.Equal(t, 25, s.IncomingWebhookPerWebhookBurst())
+	assert.Equal(t, 3, s.IncomingWebhookMaxPerGroup())
+}
+
+func TestSystemSettings_IncomingWebhookRPS_EnvFallbackWhenDBUnset(t *testing.T) {
+	t.Setenv(envIncomingWebhookPerWebhookRPS, "7")
+	s := newTestSystemSettings(t, nil)
+	assert.Equal(t, 7.0, s.IncomingWebhookPerWebhookRPS(), "DB 未配置 → env 生效")
+}
+
 func TestSystemSettings_BoolOverridesYamlWhenSet(t *testing.T) {
 	s := newTestSystemSettings(t, nil)
 	s.ctx.GetConfig().Register.EmailOn = true // yaml says on

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
+	commonmod "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
@@ -32,20 +33,17 @@ import (
 
 // 默认配置（可被环境变量覆盖）。
 const (
-	envMaxPerGroup         = "DM_INCOMINGWEBHOOK_MAX_PER_GROUP"
-	envBodyMax             = "DM_INCOMINGWEBHOOK_MAX_BYTES"
-	envRatePerWebhookRPS   = "DM_INCOMINGWEBHOOK_RPS"
-	envRatePerWebhookBurst = "DM_INCOMINGWEBHOOK_BURST"
-	envIngressIPRPS        = "DM_INCOMINGWEBHOOK_IP_RPS"
-	envIngressIPBurst      = "DM_INCOMINGWEBHOOK_IP_BURST"
-	envIPFailRPS           = "DM_INCOMINGWEBHOOK_IP_FAIL_RPS"
-	envIPFailBurst         = "DM_INCOMINGWEBHOOK_IP_FAIL_BURST"
-	envMaxContentRunes     = "DM_INCOMINGWEBHOOK_MAX_CONTENT_RUNES"
+	envBodyMax         = "DM_INCOMINGWEBHOOK_MAX_BYTES"
+	envIngressIPRPS    = "DM_INCOMINGWEBHOOK_IP_RPS"
+	envIngressIPBurst  = "DM_INCOMINGWEBHOOK_IP_BURST"
+	envIPFailRPS       = "DM_INCOMINGWEBHOOK_IP_FAIL_RPS"
+	envIPFailBurst     = "DM_INCOMINGWEBHOOK_IP_FAIL_BURST"
+	envMaxContentRunes = "DM_INCOMINGWEBHOOK_MAX_CONTENT_RUNES"
 
-	defaultMaxPerGroup    = 10
-	defaultMaxBytes       = 8 * 1024
-	defaultRatePerWHRPS   = 5.0
-	defaultRatePerWHBurst = 10
+	defaultMaxBytes = 8 * 1024
+	// 总开关(enabled) 与 per_webhook rps/burst、max_per_group 已迁移到 system_setting
+	// （单一真源在 modules/common.SystemSettings.IncomingWebhook*），运行时可经管理台
+	// 动态调；env DM_INCOMINGWEBHOOK_{ENABLED,RPS,BURST,MAX_PER_GROUP} 仍作 fallback。
 	// per-IP 请求限流（StrictIPRateLimitMiddleware，计入全部请求）的默认值。刻意高于
 	// 旧值(30/60)、但仍低于进程级 floor(200/400)：合法共享/固定 IP 的正常推送量(受
 	// per-webhook 5rps 约束，单 IP 多 webhook 聚合一般 ≪100rps)不被误杀，同时把"单 IP
@@ -84,6 +82,11 @@ type IncomingWebhook struct {
 	// floor 是 push 端点的 Redis-independent 进程级限流地板：两个 Redis 限流器在
 	// Redis 故障时 fail-open，floor 用纯内存令牌桶兜底，保证单实例推送速率始终有界。
 	floor *localFloor
+	// settings 是进程级共享的 system_setting 快照（admin 可动态调）。本模块的总开关
+	// (enabled) 与核心阈值(per_webhook rps/burst、max_per_group) 都走它读取：DB →
+	// env(DM_INCOMINGWEBHOOK_*) → code-default。admin 在管理台改值后 Reload 立即生效，
+	// 多实例 60s 内收敛，无需重启。其余阈值(IP/失败预算/floor/body/content)仍走 env。
+	settings *commonmod.SystemSettings
 }
 
 // maxConcurrentAudit 限制异步审计 goroutine 的最大并发数（默认值，可被 env 覆盖）。
@@ -135,6 +138,7 @@ func New(ctx *config.Context) *IncomingWebhook {
 		rateRedis: sharedRateRedis(ctx.GetConfig()),
 		auditSem:  make(chan struct{}, auditConcurrency()),
 		floor:     newLocalFloor(),
+		settings:  commonmod.EnsureSystemSettings(ctx),
 	}
 	// 群解散级联禁用所有 webhook
 	w.ctx.AddEventListener(event.GroupDisband, w.handleGroupDisband)
@@ -148,11 +152,13 @@ func (w *IncomingWebhook) Route(r *wkhttp.WKHttp) {
 	// 给 create/regenerate 等敏感写操作补 per-login-user 限流。
 	mgr := r.Group("/v1/groups", w.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, w.ctx))
 	{
-		mgr.POST("/:group_no/incoming-webhooks", w.create)
+		// 总开关(system_setting incomingwebhook.enabled)关闭时，写操作一律 403 拒绝，
+		// 仅保留 list 只读——运维仍可查看/排查已存在配置。requireMgmtEnabled 不挂在 list 上。
+		mgr.POST("/:group_no/incoming-webhooks", w.requireMgmtEnabled(), w.create)
 		mgr.GET("/:group_no/incoming-webhooks", w.list)
-		mgr.PUT("/:group_no/incoming-webhooks/:webhook_id", w.update)
-		mgr.DELETE("/:group_no/incoming-webhooks/:webhook_id", w.delete)
-		mgr.POST("/:group_no/incoming-webhooks/:webhook_id/regenerate", w.regenerate)
+		mgr.PUT("/:group_no/incoming-webhooks/:webhook_id", w.requireMgmtEnabled(), w.update)
+		mgr.DELETE("/:group_no/incoming-webhooks/:webhook_id", w.requireMgmtEnabled(), w.delete)
+		mgr.POST("/:group_no/incoming-webhooks/:webhook_id/regenerate", w.requireMgmtEnabled(), w.regenerate)
 	}
 
 	// 推送类：URL 内 token 鉴权，无 AuthMiddleware。四层限流，由粗到细：
@@ -175,22 +181,40 @@ func (w *IncomingWebhook) Route(r *wkhttp.WKHttp) {
 
 	push := r.Group("/v1")
 	{
-		push.POST("/incoming-webhooks/:webhook_id/:token", w.localFloorMiddleware(), ipLimit, w.ipFailureGateMiddleware(), w.push)
+		// requirePushEnabled 在最前：总开关关闭时直接 404，最廉价地短路（甚至不进 floor）。
+		push.POST("/incoming-webhooks/:webhook_id/:token", w.requirePushEnabled(), w.localFloorMiddleware(), ipLimit, w.ipFailureGateMiddleware(), w.push)
+	}
+}
+
+// requirePushEnabled 在总开关(system_setting incomingwebhook.enabled)关闭时让 push
+// 端点返回 404。这是「功能全局停用」语义，对所有请求一致（不区分 webhook 是否存在），
+// 因此与 push 路径的反枚举不变量不冲突。
+func (w *IncomingWebhook) requirePushEnabled() wkhttp.HandlerFunc {
+	return func(c *wkhttp.Context) {
+		if !w.settings.IncomingWebhookEnabled() {
+			pushDisabled(c)
+			return
+		}
+		c.Next()
+	}
+}
+
+// requireMgmtEnabled 在总开关关闭时拒绝所有管理写操作（create/update/delete/
+// regenerate）并返回 403；list 只读不挂此闸。挂在 AuthMiddleware 之后，故仅对已认证的
+// 群管理员生效——总开关是「功能是否开放」而非鉴权，403 语义恰当。
+func (w *IncomingWebhook) requireMgmtEnabled() wkhttp.HandlerFunc {
+	return func(c *wkhttp.Context) {
+		if !w.settings.IncomingWebhookEnabled() {
+			mgmtFeatureDisabled(c)
+			return
+		}
+		c.Next()
 	}
 }
 
 // ============================================================
 // 配置读取（每次读 env，便于运行时调参）
 // ============================================================
-
-func maxPerGroup() int {
-	if v := os.Getenv(envMaxPerGroup); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			return n
-		}
-	}
-	return defaultMaxPerGroup
-}
 
 func maxBytes() int {
 	if v := os.Getenv(envBodyMax); v != "" {
@@ -208,14 +232,6 @@ func maxContentRunes() int {
 		}
 	}
 	return defaultMaxContentRunes
-}
-
-func perWebhookRPS() float64 {
-	return wkhttp.ParseRPSFromEnv(envRatePerWebhookRPS, defaultRatePerWHRPS)
-}
-
-func perWebhookBurst() int {
-	return wkhttp.ParseBurstFromEnv(envRatePerWebhookBurst, defaultRatePerWHBurst)
 }
 
 // ipFailRPS / ipFailBurst bound the per-IP AUTH-FAILURE budget (not request
@@ -397,7 +413,7 @@ func (w *IncomingWebhook) create(c *wkhttp.Context) {
 	// status=1 的行，但这**不构成安全问题**：该 webhook 永远推不出消息——push 路径的
 	// requireActiveGroup 重查才是权威闸（群非 Normal 一律 401），且 disband 级联会把
 	// status 翻 0。故此处不在事务内重读 group.status，避免给热路径加锁负担。
-	maxWH := maxPerGroup()
+	maxWH := w.settings.IncomingWebhookMaxPerGroup()
 	if err := w.db.insertWithQuota(m, maxWH); err != nil {
 		if errors.Is(err, ErrQuotaExceeded) {
 			mgmtQuotaExceeded(c, maxWH)

--- a/modules/incomingwebhook/api_i18n.go
+++ b/modules/incomingwebhook/api_i18n.go
@@ -84,8 +84,15 @@ func mgmtForbidden(c *wkhttp.Context) {
 // mgmtFeatureDisabled returns 403 when the feature is globally disabled
 // (system_setting incomingwebhook.enabled=0). Gates every management write
 // (create/update/delete/regenerate); list (read) stays open.
+//
+// Unlike the other mgmt responders (which are called from inside a handler that
+// returns immediately after), this one runs from the requireMgmtEnabled
+// MIDDLEWARE, so it MUST c.Abort() — a bare return only exits the middleware
+// closure and Gin would still invoke the downstream write handler, executing
+// the mutation after the 403 was written. Symmetric with pushDisabled.
 func mgmtFeatureDisabled(c *wkhttp.Context) {
 	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookDisabled, nil, nil)
+	c.Abort()
 }
 
 // mgmtRequestInvalid returns 400 for malformed body / invalid field; reason ∈

--- a/modules/incomingwebhook/api_i18n.go
+++ b/modules/incomingwebhook/api_i18n.go
@@ -57,6 +57,14 @@ func pushDeliveryFailed(c *wkhttp.Context) {
 	c.Abort()
 }
 
+// pushDisabled returns 404 when the feature is globally disabled
+// (system_setting incomingwebhook.enabled=0). Uniform across all pushes — a
+// global state, not a per-webhook signal, so it does not leak webhook existence.
+func pushDisabled(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookPushDisabled, nil, nil)
+	c.Abort()
+}
+
 // ============================================================
 // management-path error responders
 //
@@ -71,6 +79,13 @@ func pushDeliveryFailed(c *wkhttp.Context) {
 // mgmtForbidden returns 403 — caller is neither owner nor admin.
 func mgmtForbidden(c *wkhttp.Context) {
 	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookForbidden, nil, nil)
+}
+
+// mgmtFeatureDisabled returns 403 when the feature is globally disabled
+// (system_setting incomingwebhook.enabled=0). Gates every management write
+// (create/update/delete/regenerate); list (read) stays open.
+func mgmtFeatureDisabled(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookDisabled, nil, nil)
 }
 
 // mgmtRequestInvalid returns 400 for malformed body / invalid field; reason ∈

--- a/modules/incomingwebhook/api_i18n_test.go
+++ b/modules/incomingwebhook/api_i18n_test.go
@@ -85,7 +85,9 @@ func TestIncomingWebhookRespondHelpers(t *testing.T) {
 		{"pushPayloadInvalid", func(c *wkhttp.Context) { pushPayloadInvalid(c, "json") }, http.StatusBadRequest, "err.server.incomingwebhook.push_payload_invalid", false},
 		{"pushPayloadTooLarge", pushPayloadTooLarge, http.StatusRequestEntityTooLarge, "err.server.incomingwebhook.push_payload_too_large", false},
 		{"pushDeliveryFailed", pushDeliveryFailed, http.StatusBadGateway, "err.server.incomingwebhook.push_delivery_failed", false},
+		{"pushDisabled", pushDisabled, http.StatusNotFound, "err.server.incomingwebhook.push_disabled", false},
 		{"mgmtForbidden", mgmtForbidden, http.StatusForbidden, "err.server.incomingwebhook.mgmt_forbidden", false},
+		{"mgmtFeatureDisabled", mgmtFeatureDisabled, http.StatusForbidden, "err.server.incomingwebhook.mgmt_disabled", false},
 		{"mgmtNotFound", mgmtNotFound, http.StatusNotFound, "err.server.incomingwebhook.mgmt_not_found", false},
 		{"mgmtQuotaExceeded", func(c *wkhttp.Context) { mgmtQuotaExceeded(c, 10) }, http.StatusConflict, "err.server.incomingwebhook.mgmt_quota_exceeded", false},
 	}

--- a/modules/incomingwebhook/api_test.go
+++ b/modules/incomingwebhook/api_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-redis/redis"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	// 该模块自身需注册以触发其 SQL 迁移
 	_ "github.com/Mininglamp-OSS/octo-server/modules/incomingwebhook"
@@ -236,9 +237,15 @@ func TestFeatureToggle_DisabledStopsPushAndMgmtWrites(t *testing.T) {
 	}))
 	assert.Equalf(t, http.StatusForbidden, cw.Code, "create body: %s", cw.Body.String())
 
-	// 5) list 只读仍可用 → 200。
+	// 5) list 只读仍可用 → 200，且必须仍只有最初那 1 个 webhook —— 证明被拒的 create
+	//    没有真正落库（requireMgmtEnabled 必须 c.Abort()，否则 403 之后 create handler
+	//    仍会执行、把 "blocked" 写进去，列表会变成 2 条）。
 	lw := do(handler, authReq("GET", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), nil))
 	assert.Equalf(t, http.StatusOK, lw.Code, "list body: %s", lw.Body.String())
+	list, _ := parseJSON(t, lw)["list"].([]interface{})
+	require.Lenf(t, list, 1, "disabled create must not insert a row; list=%s", lw.Body.String())
+	first, _ := list[0].(map[string]interface{})
+	assert.Equal(t, "toggle-wh", first["name"], "the only webhook must be the original, not the blocked create")
 }
 
 // ============================================================

--- a/modules/incomingwebhook/api_test.go
+++ b/modules/incomingwebhook/api_test.go
@@ -25,7 +25,7 @@ import (
 	// 缺失任何一个都会导致 module.Setup 在跨模块 ALTER 时报错。
 	// 详见 memory: skill_service_test.md「迁移顺序陷阱」。
 	_ "github.com/Mininglamp-OSS/octo-server/modules/base"
-	_ "github.com/Mininglamp-OSS/octo-server/modules/common"
+	modulescommon "github.com/Mininglamp-OSS/octo-server/modules/common"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/group"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/robot"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/space"
@@ -191,6 +191,54 @@ func TestCreate_NonAdminForbidden(t *testing.T) {
 		"name": "x",
 	}))
 	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// TestFeatureToggle_DisabledStopsPushAndMgmtWrites 验证总开关
+// (system_setting incomingwebhook.enabled=0) 关闭后：push 返回 404、管理写操作
+// (create) 返回 403，而 list 只读仍可用。直接 DB 写 + Reload 共享快照，模拟
+// manager 写路径但避开 admin token（语义同 space.TestCreateSpace_DisabledBySystemSetting）。
+func TestFeatureToggle_DisabledStopsPushAndMgmtWrites(t *testing.T) {
+	handler, ctx, groupNo := setupTestEnv(t)
+	t.Setenv("DM_INCOMINGWEBHOOK_ENABLED", "") // 证明开关纯由 DB 驱动
+
+	// 1) 功能开启时先建一个 webhook，拿到推送 URL。
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "toggle-wh",
+	}))
+	assert.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	pushURL, _ := parseJSON(t, w)["url"].(string)
+	assert.True(t, strings.HasPrefix(pushURL, "/v1/incoming-webhooks/"), "url: %s", pushURL)
+
+	// 2) 关闭总开关：DB 写入 incomingwebhook.enabled=0 + Reload 共享快照。
+	_, err := ctx.DB().InsertInto("system_setting").
+		Pair("category", "incomingwebhook").
+		Pair("key_name", "enabled").
+		Pair("value", "0").
+		Pair("value_type", "bool").
+		Pair("description", "").
+		Exec()
+	assert.NoError(t, err)
+	settings := modulescommon.EnsureSystemSettings(ctx)
+	assert.NoError(t, settings.Reload())
+	defer func() {
+		_, _ = ctx.DB().DeleteFrom("system_setting").
+			Where("category=?", "incomingwebhook").Exec()
+		_ = settings.Reload()
+	}()
+
+	// 3) push → 404（功能全局停用，gate 在限流链最前短路）。
+	pw := do(handler, anonReq("POST", pushURL, []byte(`{"content":"hi"}`)))
+	assert.Equalf(t, http.StatusNotFound, pw.Code, "push body: %s", pw.Body.String())
+
+	// 4) 管理写操作 → 403。
+	cw := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "blocked",
+	}))
+	assert.Equalf(t, http.StatusForbidden, cw.Code, "create body: %s", cw.Body.String())
+
+	// 5) list 只读仍可用 → 200。
+	lw := do(handler, authReq("GET", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), nil))
+	assert.Equalf(t, http.StatusOK, lw.Code, "list body: %s", lw.Body.String())
 }
 
 // ============================================================

--- a/modules/incomingwebhook/ratelimit.go
+++ b/modules/incomingwebhook/ratelimit.go
@@ -138,8 +138,8 @@ func (w *IncomingWebhook) runBucketScript(script *redis.Script, key string, args
 // allowPerWebhook 按 webhook_id 维度做令牌桶判定，独立于 IP 限流。
 // Redis 故障时返回 (true, err)，由调用方决定是否记日志（fail-open）。
 func (w *IncomingWebhook) allowPerWebhook(_ context.Context, webhookID string) (bool, error) {
-	rps := perWebhookRPS()
-	burst := perWebhookBurst()
+	rps := w.settings.IncomingWebhookPerWebhookRPS()
+	burst := w.settings.IncomingWebhookPerWebhookBurst()
 	if rps <= 0 || burst <= 0 {
 		return true, nil
 	}

--- a/pkg/errcode/incomingwebhook.go
+++ b/pkg/errcode/incomingwebhook.go
@@ -65,6 +65,16 @@ var (
 		DefaultMessage: "Failed to deliver the webhook message.",
 		Internal:       true,
 	})
+
+	// ErrIncomingWebhookPushDisabled (404) — the incoming-webhook feature is
+	// globally disabled via system_setting incomingwebhook.enabled=0. Returned
+	// for every push while disabled; it is a global state (not per-webhook), so
+	// a uniform 404 does not leak whether any specific webhook exists.
+	ErrIncomingWebhookPushDisabled = register(codes.Code{
+		ID:             "err.server.incomingwebhook.push_disabled",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Not found.",
+	})
 )
 
 // err.server.incomingwebhook.mgmt_* — management-endpoint error codes
@@ -135,5 +145,15 @@ var (
 		HTTPStatus:     http.StatusInternalServerError,
 		DefaultMessage: "The operation failed. Please try again later.",
 		Internal:       true,
+	})
+
+	// ErrIncomingWebhookDisabled (403) — the incoming-webhook feature is globally
+	// disabled via system_setting incomingwebhook.enabled=0. Returned for every
+	// management write (create / update / delete / regenerate) while disabled;
+	// list (read) stays available so operators can still inspect existing config.
+	ErrIncomingWebhookDisabled = register(codes.Code{
+		ID:             "err.server.incomingwebhook.mgmt_disabled",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "The incoming webhook feature is currently disabled.",
 	})
 )

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -666,6 +666,9 @@ other = "请求内容过大。"
 ["err.server.incomingwebhook.push_delivery_failed"]
 other = "Webhook 消息投递失败。"
 
+["err.server.incomingwebhook.push_disabled"]
+other = "未找到。"
+
 # ---- err.server.incomingwebhook.mgmt_* (management endpoints, #246 follow-up) ----
 
 ["err.server.incomingwebhook.mgmt_forbidden"]
@@ -688,6 +691,9 @@ other = "查询 webhook 信息失败。"
 
 ["err.server.incomingwebhook.mgmt_operation_failed"]
 other = "操作失败，请稍后再试。"
+
+["err.server.incomingwebhook.mgmt_disabled"]
+other = "群入站 Webhook 功能当前已关闭。"
 
 # ---- err.server.qrcode.* (modules/qrcode: api.go) ----
 

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -333,6 +333,9 @@ other = "The target user does not exist or has been deactivated."
 ["err.server.group.view_forbidden"]
 other = "You do not have permission to view this."
 
+["err.server.incomingwebhook.mgmt_disabled"]
+other = "The incoming webhook feature is currently disabled."
+
 ["err.server.incomingwebhook.mgmt_forbidden"]
 other = "Only the group owner or an admin can manage webhooks."
 
@@ -356,6 +359,9 @@ other = "Invalid request."
 
 ["err.server.incomingwebhook.push_delivery_failed"]
 other = "Failed to deliver the webhook message."
+
+["err.server.incomingwebhook.push_disabled"]
+other = "Not found."
 
 ["err.server.incomingwebhook.push_payload_invalid"]
 other = "Invalid request payload."


### PR DESCRIPTION
Wires the incoming-webhook module into the admin-tunable `system_setting` layer (`modules/common.SystemSettings`) so the feature can be switched off and its core thresholds adjusted **at runtime** — `Reload` takes effect immediately on the writing instance, peers converge within the snapshot TTL, no restart needed.

This is the config/operability ask raised alongside #284 (separate from #284's caching item, which is its own PR).

## What changed

New `system_setting` category `incomingwebhook` (schema-driven — no table migration):

| key | type | meaning |
|---|---|---|
| `enabled` | bool | master switch |
| `per_webhook_rps` | float | per-webhook token-bucket rate |
| `per_webhook_burst` | int | per-webhook token-bucket burst |
| `max_per_group` | int | per-group webhook quota |

Each resolves **DB → env(`DM_INCOMINGWEBHOOK_*`) → code-default**, so existing env tuning still applies and the admin `GET /v1/manager/common/system_setting` surfaces the true effective value. The env knobs now live solely in `modules/common` as the single source of truth; `incomingwebhook` reads them through the typed getters (`IncomingWebhookEnabled/PerWebhookRPS/PerWebhookBurst/MaxPerGroup`).

### Master toggle off (operator-visible)
- **push** endpoint → **404** (uniform global state; not per-webhook, so no enumeration leak — gated first in the limiter chain, short-circuits before the floor)
- **management writes** (create/update/delete/regenerate) → **403**
- **list** (read) stays available so operators can still inspect existing config

### Supporting changes
- Adds `settingTypeFloat` + `SystemSettings.getFloat` for the rps knob (with matching manager-write validation).
- Two new errcodes `push_disabled` (404) / `mgmt_disabled` (403) with zh-CN translations; en-US markers regenerated via `make i18n-extract`.

## Verification

Run and passing in this environment (no infra needed):
- `TestSystemSettings_IncomingWebhook_GetterChain_NoInfra` — the full snapshot(DB) → env → code-default precedence incl. float rps
- `TestIncomingWebhookRespondHelpers/{pushDisabled,mgmtFeatureDisabled}` — 404/403 + correct i18n code
- `TestIncomingWebhookNoLegacyResponseError`, `pkg/i18n/...`, `go build ./...`, `golangci-lint` (0 issues), `make i18n-extract-check` + `i18n-lint`

Compiled but **not executed locally** (need MySQL/Redis, blocked by this sandbox's network policy — will run in CI):
- `TestSystemSettings_IncomingWebhook*` (DB-backed Load/Reload)
- `TestFeatureToggle_DisabledStopsPushAndMgmtWrites` (end-to-end: DB write `enabled=0` → Reload → push 404 / create 403 / list 200)

https://claude.ai/code/session_01Lq2ejFV7X16HvAmg9BDGTu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lq2ejFV7X16HvAmg9BDGTu)_