### PR TITLE
feat(incomingwebhook): rich text / image-text blocks on push (Phase 1)

### DIFF
--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -15,6 +15,11 @@ Content-Type: application/json
 
 由 `msg_type` 选择，**缺省即纯文本**，与历史行为完全一致：
 
+> **兼容性提醒**：`msg_type` 现在严格校验——只接受省略 / `"text"` / `"richtext"`，其它非空值
+> （如 `"markdown"`）返回 400 `reason=msg_type`。历史上未知 JSON 字段会被忽略，因此若有旧
+> 客户端误带了别的 `msg_type` 值，升级后需要去掉它（带合法 `content` 也会被拒）。`msg_type`
+> 大小写不敏感（内部做了 lower+trim），但块 `type` 大小写敏感、须为精确小写（`text`/`image`）。
+
 ### 1. 纯文本（`msg_type` 省略或 `"text"`）
 
 `content` 必填，客户端按 markdown 渲染。

--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -58,8 +58,11 @@ Content-Type: application/json
 约束：
 
 - `blocks` 必填且非空；块数量上限默认 50（`DM_INCOMINGWEBHOOK_MAX_BLOCKS`）。
-- 整条消息序列化后 ≤ 1MB（图片仅 URL 引用，不内嵌）。
-- 请求体仍受 8KB body cap 约束（`DM_INCOMINGWEBHOOK_MAX_BYTES`）。
+- **实际生效的上限是 8KB body cap**（`DM_INCOMINGWEBHOOK_MAX_BYTES`）：请求体在解析前即被
+  截断，超出按 413 拒绝。由于图片仅 URL 引用（不内嵌 base64），8KB 足以承载数十个文本/
+  图片块；多图文消息请用 URL 引用，不要内联大体积内容。
+- 服务端另有 1MB 的 RichText 硬上限（octo-lib 契约）兜底，但在默认 8KB body cap 下不会
+  先触达——它是上调 body cap 后才会成为约束的二级护栏。
 
 ## 通用字段与安全
 

--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -1,0 +1,80 @@
+# Incoming Webhook 推送契约
+
+外部服务通过带 token 的 URL 向指定群推送消息。管理端点（创建/列出/更新/删除/重置）
+由群主或管理员调用，详见 `api.go`。本文聚焦**推送端点**的请求契约。
+
+```
+POST /v1/incoming-webhooks/:webhook_id/:token
+Content-Type: application/json
+```
+
+鉴权走 URL 内的 token（SHA-256 存储、常量时间比对），无需登录态。所有鉴权失败统一
+返回 401（反枚举），并受多层限流约束。
+
+## 消息形态
+
+由 `msg_type` 选择，**缺省即纯文本**，与历史行为完全一致：
+
+### 1. 纯文本（`msg_type` 省略或 `"text"`）
+
+`content` 必填，客户端按 markdown 渲染。
+
+```json
+{
+  "content": "Build **#123** passed ✅  https://ci.example.com/123",
+  "username": "CI Bot",
+  "avatar_url": "https://example.com/ci.png"
+}
+```
+
+- `content`：必填，非空；语义长度上限 4000 rune（`DM_INCOMINGWEBHOOK_MAX_CONTENT_RUNES`）。
+- `username` / `avatar_url`：可选，覆盖该条消息的展示发送者名/头像（不改 webhook 本身配置）。
+
+### 2. 富文本 / 图文混排（`msg_type` = `"richtext"`）
+
+`blocks` 承载**有序**的图文块，数组顺序即图文穿插顺序。服务端翻译为内部 RichText 消息，
+客户端复用既有富文本渲染链路。
+
+```json
+{
+  "msg_type": "richtext",
+  "blocks": [
+    { "type": "text",  "text": "Build #123 passed ✅" },
+    { "type": "image", "url": "https://example.com/chart.png", "width": 800, "height": 400 },
+    { "type": "text",  "text": "耗时 42s" }
+  ],
+  "username": "CI Bot",
+  "avatar_url": "https://example.com/ci.png"
+}
+```
+
+块类型：
+
+| `type`  | 必填字段 | 约束 |
+|---------|----------|------|
+| `text`  | `text`   | 非空（纯文本，不渲染 markdown） |
+| `image` | `url`、`width`、`height` | `url` 仅接受 `http`/`https`（禁 `data:`/`base64`）；`width`/`height` 必须 > 0（供端上占位排版，避免抖动） |
+
+约束：
+
+- `blocks` 必填且非空；块数量上限默认 50（`DM_INCOMINGWEBHOOK_MAX_BLOCKS`）。
+- 整条消息序列化后 ≤ 1MB（图片仅 URL 引用，不内嵌）。
+- 请求体仍受 8KB body cap 约束（`DM_INCOMINGWEBHOOK_MAX_BYTES`）。
+
+## 通用字段与安全
+
+- `username` / `avatar_url`：两种形态通用，服务端裁剪到字节上限（名 64B / 头像 255B）。
+- 其它任意字段（含 `extra`、`space_id`）一律**丢弃**：消息归属的 Space 由服务端从群派生，
+  不接受调用方覆盖，防止伪造到其它 Space。
+
+## 响应
+
+| 场景 | HTTP | 说明 |
+|------|------|------|
+| 成功 | 200 | `{"status":0,"message_id":<int>}` |
+| 鉴权失败 | 401 | 统一响应，不区分原因（反枚举） |
+| 限流 | 429 | 带 `Retry-After` |
+| 请求非法 | 400 | `details.reason` ∈ `body`/`json`/`content`/`blocks`/`msg_type` |
+| 体积过大 | 413 | 超 body cap 或富文本 >1MB |
+| 投递失败 | 502 | 下游发送失败 |
+| 功能停用 | 404 | 全局开关 `incomingwebhook.enabled=0` |

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -766,19 +766,43 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 		pushPayloadInvalid(c, "json")
 		return
 	}
-	if strings.TrimSpace(req.Content) == "" {
-		pushPayloadInvalid(c, "content")
-		return
-	}
-	// content 语义长度上限（按 rune 计），独立于 8KB 字节 body cap：防止单条消息正文
-	// 过长污染所有客户端渲染。超限按 413 拒绝，与 body 超限同语义。
-	if utf8.RuneCountInString(req.Content) > maxContentRunes() {
-		pushPayloadTooLarge(c)
+
+	// 5) 按 msg_type 构造 payload。缺省/"text" 走历史纯文本路径（content 必填，客户端
+	//    按 markdown 渲染），完全向后兼容；"richtext" 走图文混排：blocks 翻译为 octo
+	//    原生 RichText(=14) 并由 richtext.Validate/Finalize 权威校验。
+	var payload map[string]interface{}
+	switch strings.ToLower(strings.TrimSpace(req.MsgType)) {
+	case "", msgTypeText:
+		if strings.TrimSpace(req.Content) == "" {
+			pushPayloadInvalid(c, "content")
+			return
+		}
+		// content 语义长度上限（按 rune 计），独立于 8KB 字节 body cap：防止单条消息
+		// 正文过长污染所有客户端渲染。超限按 413 拒绝，与 body 超限同语义。
+		if utf8.RuneCountInString(req.Content) > maxContentRunes() {
+			pushPayloadTooLarge(c)
+			return
+		}
+		payload = buildPayload(m, &req)
+	case msgTypeRichText:
+		p, err := buildRichTextPayload(m, &req)
+		if err != nil {
+			// 仅 >1MB 映射 413（与 body/content 超限同语义）；其余结构性非法（空 content /
+			// 空 text 块 / 非 http(s) 图片 url / 缺图片宽高 / 未知块类型 / 超块数上限）
+			// 一律 400 invalid，reason=blocks 供调用方定位。
+			if errors.Is(err, common.ErrRichTextPayloadTooLarge) {
+				pushPayloadTooLarge(c)
+				return
+			}
+			pushPayloadInvalid(c, "blocks")
+			return
+		}
+		payload = p
+	default:
+		pushPayloadInvalid(c, "msg_type")
 		return
 	}
 
-	// 5) 构造 payload 并发送
-	payload := buildPayload(m, &req)
 	resp, err := w.ctx.SendMessageWithResult(&config.MsgSendReq{
 		// RedDot=1 让 webhook 消息触发未读红点和推送，与 botfather/robot 一致。
 		Header:      config.MsgHeader{RedDot: 1},
@@ -845,21 +869,12 @@ func truncateUTF8(s string, max int) string {
 //   - req.Username / req.AvatarURL 服务端裁剪到 create 侧同样的字节上限。push 路径
 //     原本只受 8KB body cap 约束，调用方可塞 KB 级字符串污染所有客户端 from.* 渲染。
 func buildPayload(m *incomingWebhookModel, req *pushPayloadReq) map[string]interface{} {
-	name := req.Username
-	if name == "" {
-		name = m.Name
-	}
-	avatar := req.AvatarURL
-	if avatar == "" {
-		avatar = m.Avatar
-	}
-	name = truncateUTF8(name, maxFromNameBytes)
-	avatar = truncateUTF8(avatar, maxFromAvatarBytes)
+	name, avatar := resolveFromIdentity(m, req)
 	return map[string]interface{}{
 		"type":    int(common.Text),
 		"content": req.Content,
 		"from": map[string]interface{}{
-			"kind":       "webhook",
+			"kind":       extraKindValue,
 			"webhook_id": m.WebhookID,
 			"name":       name,
 			"avatar":     avatar,
@@ -868,6 +883,22 @@ func buildPayload(m *incomingWebhookModel, req *pushPayloadReq) map[string]inter
 		// 防止 webhook 消息被伪造到其他 Space。
 		"space_id": m.SpaceID,
 	}
+}
+
+// resolveFromIdentity 解析 webhook 消息的展示发送者名/头像：调用方在 push 请求里
+// 覆盖（Username/AvatarURL）优先，否则回落到 webhook 自身配置；两者都裁剪到与
+// create 侧一致的字节上限，防止 push 路径成为绕过列长度约束的旁路。文本与富文本
+// 两条路径共用此函数，保证 from.* 渲染口径一致。
+func resolveFromIdentity(m *incomingWebhookModel, req *pushPayloadReq) (name, avatar string) {
+	name = req.Username
+	if name == "" {
+		name = m.Name
+	}
+	avatar = req.AvatarURL
+	if avatar == "" {
+		avatar = m.Avatar
+	}
+	return truncateUTF8(name, maxFromNameBytes), truncateUTF8(avatar, maxFromAvatarBytes)
 }
 
 // submitRecordSuccess 把审计任务投递给有界并发池：未达上限时异步执行；已达上限时

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -785,6 +785,9 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 		}
 		payload = buildPayload(m, &req)
 	case msgTypeRichText:
+		// 注意：richtext 路径【不】套用纯文本的 maxContentRunes(4000) 语义上限——富文本
+		// 由块结构 + 1MB 序列化上限约束，默认 8KB body cap 下不可能逾越。这是与文本路径的
+		// 有意不对称（若运维上调 body cap，富文本仍受 1MB 兜底，不会无界）。
 		p, err := buildRichTextPayload(m, &req)
 		if err != nil {
 			// 仅 >1MB 映射 413（与 body/content 超限同语义）；其余结构性非法（空 content /

--- a/modules/incomingwebhook/api_i18n.go
+++ b/modules/incomingwebhook/api_i18n.go
@@ -36,7 +36,8 @@ func pushRateLimited(c *wkhttp.Context) {
 }
 
 // pushPayloadInvalid returns 400 for unreadable body / malformed JSON / empty
-// content; reason ∈ {body, json, content} is surfaced via the safe-listed
+// content / malformed rich-text blocks / unknown msg_type; reason ∈
+// {body, json, content, blocks, msg_type} is surfaced via the safe-listed
 // Details key so callers can tell what to fix.
 func pushPayloadInvalid(c *wkhttp.Context, reason string) {
 	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookPushPayloadInvalid, nil, i18n.Details{"reason": reason})

--- a/modules/incomingwebhook/api_i18n_test.go
+++ b/modules/incomingwebhook/api_i18n_test.go
@@ -117,3 +117,27 @@ func TestIncomingWebhookRespondHelpers(t *testing.T) {
 		})
 	}
 }
+
+// TestPushPayloadInvalidSurfacesReason locks the external contract that
+// pushPayloadInvalid surfaces details.reason in the i18n error envelope. This is
+// asserted HERE (with the i18n ErrorRenderer wired, as in production via main.go)
+// rather than in the full e2e harness: testutil.NewTestServer renders only the
+// legacy {msg,status} shape, so an e2e body never carries error.details — see the
+// note in richtext_push_test.go. No DB/Redis needed; this only exercises the renderer.
+func TestPushPayloadInvalidSurfacesReason(t *testing.T) {
+	for _, reason := range []string{"blocks", "msg_type", "content", "json"} {
+		t.Run(reason, func(t *testing.T) {
+			r := iwhHelperHarness(func(c *wkhttp.Context) { pushPayloadInvalid(c, reason) })
+			req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), reason) {
+				t.Fatalf("body must surface details.reason=%q; body=%s", reason, rec.Body.String())
+			}
+		})
+	}
+}

--- a/modules/incomingwebhook/model.go
+++ b/modules/incomingwebhook/model.go
@@ -64,6 +64,9 @@ type pushPayloadReq struct {
 // 不让调用方感知内部 ContentType 编号或 plain/size 等服务端派生字段。
 //   - type=="text"  ：Text 必填且非空。
 //   - type=="image" ：URL（仅 http/https）+ Width/Height（>0）必填，供端上占位排版。
+//
+// ⚠️ 新增块类型时务必与 pkg/richtext（及其底层 common.RichTextBlock 支持的类型）保持
+// 同步：buildRichTextPayload 按白名单逐类翻译，未在此显式支持的块类型会被 Validate 拒绝。
 type webhookBlock struct {
 	Type   string `json:"type"`
 	Text   string `json:"text,omitempty"`

--- a/modules/incomingwebhook/model.go
+++ b/modules/incomingwebhook/model.go
@@ -44,11 +44,32 @@ type auditModel struct {
 }
 
 // pushPayloadReq 推送端点的请求体。
+//
+// 兼容两种消息形态，由 MsgType 选择（缺省/"text" 走纯文本，与历史行为一致）：
+//   - 纯文本：Content 必填，客户端按 markdown 渲染（历史契约不变）。
+//   - 富文本/图文混排（MsgType=="richtext"）：Blocks 承载有序图文块，服务端翻译为
+//     octo 原生 RichText(=14) 后走 richtext.Validate/Finalize。对外刻意不暴露内部
+//     ContentType 数字与 plain 等服务端字段——调用方只需描述「文本块 / 图片块」。
 type pushPayloadReq struct {
+	MsgType   string                 `json:"msg_type,omitempty"`
 	Content   string                 `json:"content"`
+	Blocks    []webhookBlock         `json:"blocks,omitempty"`
 	Username  string                 `json:"username,omitempty"`
 	AvatarURL string                 `json:"avatar_url,omitempty"`
 	Extra     map[string]interface{} `json:"extra,omitempty"`
+}
+
+// webhookBlock 是富文本消息的单个有序块（对外契约）。字段刻意与 octo-lib
+// common.RichTextBlock 对齐但独立声明：对外只暴露 text/image 两类块所需的字段，
+// 不让调用方感知内部 ContentType 编号或 plain/size 等服务端派生字段。
+//   - type=="text"  ：Text 必填且非空。
+//   - type=="image" ：URL（仅 http/https）+ Width/Height（>0）必填，供端上占位排版。
+type webhookBlock struct {
+	Type   string `json:"type"`
+	Text   string `json:"text,omitempty"`
+	URL    string `json:"url,omitempty"`
+	Width  int    `json:"width,omitempty"`
+	Height int    `json:"height,omitempty"`
 }
 
 // createReq 管理端创建 webhook 的请求体。

--- a/modules/incomingwebhook/richtext.go
+++ b/modules/incomingwebhook/richtext.go
@@ -1,0 +1,104 @@
+package incomingwebhook
+
+import (
+	"errors"
+	"os"
+	"strconv"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/richtext"
+)
+
+// 推送消息形态（pushPayloadReq.MsgType 取值）。缺省与 "text" 等价，保持历史纯文本
+// 契约不变；"richtext" 走图文混排 blocks 路径。
+const (
+	msgTypeText     = "text"
+	msgTypeRichText = "richtext"
+)
+
+// 富文本 block 数量上限。8KB 的 body cap 已是天然约束，这里再加一道显式上限，避免
+// 调用方用海量空块构造病态 payload（每块都要进 Validate 遍历）。可经 env 调整。
+const (
+	envMaxBlocks     = "DM_INCOMINGWEBHOOK_MAX_BLOCKS"
+	defaultMaxBlocks = 50
+)
+
+// errTooManyBlocks blocks 数量超过 maxBlocks 上限。映射为 400 invalid（reason=blocks），
+// 而非 413：413 语义是「字节/体积过大」，块数超限是结构性非法，归 invalid 更准确。
+var errTooManyBlocks = errors.New("incomingwebhook: too many richtext blocks")
+
+func maxBlocks() int {
+	if v := os.Getenv(envMaxBlocks); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultMaxBlocks
+}
+
+// buildRichTextPayload 把对外的 webhookBlock 数组翻译为 octo 原生 RichText(=14)
+// 消息 payload，并在发送前做权威校验/收尾：
+//
+//   - 逐块按白名单复制字段（text 块只取 text；image 块只取 url/width/height），
+//     绝不透传调用方的其它任意字段——与 buildPayload 丢弃 req.Extra 的安全基线一致；
+//   - from.kind=webhook + 服务端派生的 space_id 注入方式与纯文本路径完全相同，
+//     保证客户端识别 webhook 发送者、且消息不可被伪造到其它 Space；
+//   - richtext.Validate 跑 write-strict 校验（缺/空 content、空 text 块、非 http(s)
+//     图片 URL、缺图片宽高、未知 block 类型、>1MB 等一律拒绝），是块合法性的权威闸；
+//   - richtext.Finalize 在注入完所有服务端字段后用 content 重算权威顶层 plain（供
+//     搜索/推送/摘要/复制复用），并对真正出站的完整 payload 复检 1MB 上限。
+//
+// 校验失败返回错误，由 push 路径映射：common.ErrRichTextPayloadTooLarge → 413，
+// 其余（含 errTooManyBlocks 与 Validate 的各类结构错误）→ 400 invalid(reason=blocks)。
+func buildRichTextPayload(m *incomingWebhookModel, req *pushPayloadReq) (map[string]interface{}, error) {
+	if len(req.Blocks) > maxBlocks() {
+		return nil, errTooManyBlocks
+	}
+	// 空 blocks 不在此处单独报错：构造空 content 交由 richtext.Validate 统一拦
+	// （common.ErrRichTextEmptyContent），保持「块合法性单一权威 = Validate」。
+	content := make([]map[string]interface{}, 0, len(req.Blocks))
+	for _, b := range req.Blocks {
+		switch b.Type {
+		case common.RichTextBlockText:
+			content = append(content, map[string]interface{}{
+				"type": common.RichTextBlockText,
+				"text": b.Text,
+			})
+		case common.RichTextBlockImage:
+			content = append(content, map[string]interface{}{
+				"type":   common.RichTextBlockImage,
+				"url":    b.URL,
+				"width":  b.Width,
+				"height": b.Height,
+			})
+		default:
+			// 未知块类型：原样带上 type 交给 Validate 拒绝（ErrRichTextUnknownBlock），
+			// 不在此处复制任何其它字段，避免未知块夹带任意字段。
+			content = append(content, map[string]interface{}{"type": b.Type})
+		}
+	}
+
+	name, avatar := resolveFromIdentity(m, req)
+	payload := map[string]interface{}{
+		"type":    int(common.RichText),
+		"content": content,
+		"from": map[string]interface{}{
+			"kind":       extraKindValue,
+			"webhook_id": m.WebhookID,
+			"name":       name,
+			"avatar":     avatar,
+		},
+		// space_id 由服务端从 group 派生，不接受调用方覆盖（与 buildPayload 一致）。
+		"space_id": m.SpaceID,
+	}
+
+	// Validate（入站 write-strict）→ Finalize（注入后重算 plain + 完整 payload 复检
+	// 1MB）。push 路径无后续 enrich，两步紧邻即可。
+	if err := richtext.Validate(payload); err != nil {
+		return nil, err
+	}
+	if err := richtext.Finalize(payload); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}

--- a/modules/incomingwebhook/richtext_push_test.go
+++ b/modules/incomingwebhook/richtext_push_test.go
@@ -64,6 +64,7 @@ func TestPush_RichText_RejectsEmptyBlocks(t *testing.T) {
 		"blocks":   []map[string]interface{}{},
 	})
 	assert.Equalf(t, http.StatusBadRequest, w.Code, "empty blocks must 400; body=%s", w.Body.String())
+	assert.Containsf(t, w.Body.String(), "blocks", "details.reason should be blocks; body=%s", w.Body.String())
 }
 
 // 图片块缺 width/height → 400。
@@ -78,6 +79,7 @@ func TestPush_RichText_RejectsBadImage(t *testing.T) {
 		},
 	})
 	assert.Equalf(t, http.StatusBadRequest, w.Code, "image without size must 400; body=%s", w.Body.String())
+	assert.Containsf(t, w.Body.String(), "blocks", "details.reason should be blocks; body=%s", w.Body.String())
 }
 
 // 非法 msg_type → 400（reason=msg_type）。
@@ -90,6 +92,7 @@ func TestPush_RejectsUnknownMsgType(t *testing.T) {
 		"content":  "hi",
 	})
 	assert.Equalf(t, http.StatusBadRequest, w.Code, "unknown msg_type must 400; body=%s", w.Body.String())
+	assert.Containsf(t, w.Body.String(), "msg_type", "details.reason should be msg_type; body=%s", w.Body.String())
 }
 
 // 向后兼容：显式 msg_type="text" 与缺省一致，纯文本仍走老路径通过校验。

--- a/modules/incomingwebhook/richtext_push_test.go
+++ b/modules/incomingwebhook/richtext_push_test.go
@@ -15,6 +15,10 @@ import (
 // （需 MySQL/Redis/WuKongIM，CI 执行）。成功路径断言「通过校验」而非强求 200：测试
 // 桩下游 SendMessage 可能返回 200 或 502，关键是请求没被 4xx（鉴权/校验）挡下——与
 // 既有 TestPush_* 的鲁棒断言口径一致。
+//
+// 这里只断言 HTTP 状态码、不断言 details.reason：testutil.NewTestServer 未挂 i18n
+// ErrorRenderer，错误体只是 legacy 的 {msg,status}（不含 error.details）。reason 契约
+// 改在 api_i18n_test.go 的 i18n 渲染器 harness 里锁（生产经 main.go 挂了该 renderer）。
 
 // createWebhookWithToken 创建一个 webhook 并返回 (webhook_id, token)。
 func createWebhookWithToken(t *testing.T, handler http.Handler, groupNo string) (string, string) {
@@ -64,7 +68,6 @@ func TestPush_RichText_RejectsEmptyBlocks(t *testing.T) {
 		"blocks":   []map[string]interface{}{},
 	})
 	assert.Equalf(t, http.StatusBadRequest, w.Code, "empty blocks must 400; body=%s", w.Body.String())
-	assert.Containsf(t, w.Body.String(), "blocks", "details.reason should be blocks; body=%s", w.Body.String())
 }
 
 // 图片块缺 width/height → 400。
@@ -79,7 +82,6 @@ func TestPush_RichText_RejectsBadImage(t *testing.T) {
 		},
 	})
 	assert.Equalf(t, http.StatusBadRequest, w.Code, "image without size must 400; body=%s", w.Body.String())
-	assert.Containsf(t, w.Body.String(), "blocks", "details.reason should be blocks; body=%s", w.Body.String())
 }
 
 // 非法 msg_type → 400（reason=msg_type）。
@@ -92,7 +94,6 @@ func TestPush_RejectsUnknownMsgType(t *testing.T) {
 		"content":  "hi",
 	})
 	assert.Equalf(t, http.StatusBadRequest, w.Code, "unknown msg_type must 400; body=%s", w.Body.String())
-	assert.Containsf(t, w.Body.String(), "msg_type", "details.reason should be msg_type; body=%s", w.Body.String())
 }
 
 // 向后兼容：显式 msg_type="text" 与缺省一致，纯文本仍走老路径通过校验。

--- a/modules/incomingwebhook/richtext_push_test.go
+++ b/modules/incomingwebhook/richtext_push_test.go
@@ -1,0 +1,106 @@
+package incomingwebhook_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Phase 1（图文混排）push 端到端用例。与现有 push 测试同风格走 testutil.NewTestServer
+// （需 MySQL/Redis/WuKongIM，CI 执行）。成功路径断言「通过校验」而非强求 200：测试
+// 桩下游 SendMessage 可能返回 200 或 502，关键是请求没被 4xx（鉴权/校验）挡下——与
+// 既有 TestPush_* 的鲁棒断言口径一致。
+
+// createWebhookWithToken 创建一个 webhook 并返回 (webhook_id, token)。
+func createWebhookWithToken(t *testing.T, handler http.Handler, groupNo string) (string, string) {
+	t.Helper()
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "richtext-wh",
+	}))
+	require.Equalf(t, http.StatusOK, w.Code, "create body: %s", w.Body.String())
+	created := parseJSON(t, w)
+	return created["webhook_id"].(string), created["token"].(string)
+}
+
+func pushRichText(handler http.Handler, whID, token string, body map[string]interface{}) *httptest.ResponseRecorder {
+	raw, _ := json.Marshal(body)
+	return do(handler, anonReq("POST", fmt.Sprintf("/v1/incoming-webhooks/%s/%s", whID, token), raw))
+}
+
+// 成功：text + image 图文混排通过校验（非 4xx）。
+func TestPush_RichText_Success(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	body := map[string]interface{}{
+		"msg_type": "richtext",
+		"blocks": []map[string]interface{}{
+			{"type": "text", "text": "Build #123 passed ✅"},
+			{"type": "image", "url": "https://example.com/chart.png", "width": 800, "height": 400},
+		},
+	}
+	w := pushRichText(handler, whID, token, body)
+	assert.NotEqualf(t, http.StatusBadRequest, w.Code, "valid richtext must pass validation; body=%s", w.Body.String())
+	assert.NotEqualf(t, http.StatusRequestEntityTooLarge, w.Code, "valid richtext must not be 413; body=%s", w.Body.String())
+	assert.NotEqualf(t, http.StatusUnauthorized, w.Code, "valid token must authorize; body=%s", w.Body.String())
+	// 下游投递成功时返回 200 + message_id；测试桩可能 502，故仅在 200 时校验 message_id。
+	if w.Code == http.StatusOK {
+		assert.Contains(t, w.Body.String(), "message_id")
+	}
+}
+
+// 空 blocks → 400（reason=blocks）。
+func TestPush_RichText_RejectsEmptyBlocks(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	w := pushRichText(handler, whID, token, map[string]interface{}{
+		"msg_type": "richtext",
+		"blocks":   []map[string]interface{}{},
+	})
+	assert.Equalf(t, http.StatusBadRequest, w.Code, "empty blocks must 400; body=%s", w.Body.String())
+}
+
+// 图片块缺 width/height → 400。
+func TestPush_RichText_RejectsBadImage(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	w := pushRichText(handler, whID, token, map[string]interface{}{
+		"msg_type": "richtext",
+		"blocks": []map[string]interface{}{
+			{"type": "image", "url": "https://example.com/a.png"},
+		},
+	})
+	assert.Equalf(t, http.StatusBadRequest, w.Code, "image without size must 400; body=%s", w.Body.String())
+}
+
+// 非法 msg_type → 400（reason=msg_type）。
+func TestPush_RejectsUnknownMsgType(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	w := pushRichText(handler, whID, token, map[string]interface{}{
+		"msg_type": "card",
+		"content":  "hi",
+	})
+	assert.Equalf(t, http.StatusBadRequest, w.Code, "unknown msg_type must 400; body=%s", w.Body.String())
+}
+
+// 向后兼容：显式 msg_type="text" 与缺省一致，纯文本仍走老路径通过校验。
+func TestPush_TextMsgTypeBackCompat(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	w := pushRichText(handler, whID, token, map[string]interface{}{
+		"msg_type": "text",
+		"content":  "hello **world**",
+	})
+	assert.NotEqualf(t, http.StatusBadRequest, w.Code, "text msg_type must pass; body=%s", w.Body.String())
+	assert.NotEqualf(t, http.StatusUnauthorized, w.Code, "valid token must authorize; body=%s", w.Body.String())
+}

--- a/modules/incomingwebhook/richtext_test.go
+++ b/modules/incomingwebhook/richtext_test.go
@@ -1,0 +1,187 @@
+package incomingwebhook
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 这些是 Phase 1（图文混排）的纯单测：buildRichTextPayload 是无 DB 依赖的纯翻译/
+// 校验函数，可本地直接 go test，不需要 MySQL/Redis/WuKongIM。push 端到端行为另由
+// richtext_push_test.go 的集成用例覆盖（CI）。
+
+func textBlock(s string) webhookBlock { return webhookBlock{Type: "text", Text: s} }
+func imageBlock(u string, w, h int) webhookBlock {
+	return webhookBlock{Type: "image", URL: u, Width: w, Height: h}
+}
+
+func sampleWebhook() *incomingWebhookModel {
+	return &incomingWebhookModel{
+		WebhookID: "iwh_abc123",
+		Name:      "CI Bot",
+		Avatar:    "https://example.com/ci.png",
+		GroupNo:   "g_123",
+		SpaceID:   "space_42",
+		TokenHash: "SECRET_SHOULD_NOT_LEAK",
+	}
+}
+
+// 纯文本块：翻译为 RichText(=14)，注入 from.kind=webhook + 服务端 space_id，
+// plain 由 server 权威生成（== 文本内容）。
+func TestBuildRichTextPayload_TextOnly(t *testing.T) {
+	m := sampleWebhook()
+	req := &pushPayloadReq{MsgType: msgTypeRichText, Blocks: []webhookBlock{textBlock("Build #123 passed")}}
+
+	payload, err := buildRichTextPayload(m, req)
+	require.NoError(t, err)
+
+	assert.Equal(t, int(common.RichText), payload["type"])
+	assert.Equal(t, m.SpaceID, payload["space_id"])
+	assert.Equal(t, "Build #123 passed", payload["plain"], "server 应权威重算 plain")
+
+	from, _ := payload["from"].(map[string]interface{})
+	require.NotNil(t, from)
+	assert.Equal(t, extraKindValue, from["kind"])
+	assert.Equal(t, m.WebhookID, from["webhook_id"])
+	assert.Equal(t, "CI Bot", from["name"])
+
+	content, _ := payload["content"].([]map[string]interface{})
+	require.Len(t, content, 1)
+	assert.Equal(t, common.RichTextBlockText, content[0]["type"])
+	assert.Equal(t, "Build #123 passed", content[0]["text"])
+}
+
+// 图片块：保留 url/width/height，plain 注入 [图片] 占位符。
+func TestBuildRichTextPayload_Image(t *testing.T) {
+	m := sampleWebhook()
+	req := &pushPayloadReq{MsgType: msgTypeRichText, Blocks: []webhookBlock{
+		imageBlock("https://example.com/chart.png", 800, 400),
+	}}
+
+	payload, err := buildRichTextPayload(m, req)
+	require.NoError(t, err)
+
+	content, _ := payload["content"].([]map[string]interface{})
+	require.Len(t, content, 1)
+	assert.Equal(t, common.RichTextBlockImage, content[0]["type"])
+	assert.Equal(t, "https://example.com/chart.png", content[0]["url"])
+	assert.Equal(t, 800, content[0]["width"])
+	assert.Equal(t, 400, content[0]["height"])
+	assert.Equal(t, common.RichTextImagePlaceholder, payload["plain"])
+}
+
+// 图文混排：数组顺序即穿插顺序，plain 拼接保序（文本 + [图片] + 文本）。
+func TestBuildRichTextPayload_MixedOrderPreserved(t *testing.T) {
+	m := sampleWebhook()
+	req := &pushPayloadReq{MsgType: msgTypeRichText, Blocks: []webhookBlock{
+		textBlock("before "),
+		imageBlock("https://example.com/a.png", 10, 10),
+		textBlock(" after"),
+	}}
+
+	payload, err := buildRichTextPayload(m, req)
+	require.NoError(t, err)
+
+	content, _ := payload["content"].([]map[string]interface{})
+	require.Len(t, content, 3)
+	assert.Equal(t, common.RichTextBlockText, content[0]["type"])
+	assert.Equal(t, common.RichTextBlockImage, content[1]["type"])
+	assert.Equal(t, common.RichTextBlockText, content[2]["type"])
+	assert.Equal(t, "before "+common.RichTextImagePlaceholder+" after", payload["plain"])
+}
+
+// 调用方覆盖 username/avatar_url 优先于 webhook 自身配置。
+func TestBuildRichTextPayload_FromOverride(t *testing.T) {
+	m := sampleWebhook()
+	req := &pushPayloadReq{
+		MsgType:   msgTypeRichText,
+		Blocks:    []webhookBlock{textBlock("hi")},
+		Username:  "Override Name",
+		AvatarURL: "https://example.com/override.png",
+	}
+	payload, err := buildRichTextPayload(m, req)
+	require.NoError(t, err)
+	from, _ := payload["from"].(map[string]interface{})
+	assert.Equal(t, "Override Name", from["name"])
+	assert.Equal(t, "https://example.com/override.png", from["avatar"])
+}
+
+// 调用方写 space_id 不能覆盖服务端派生值（防伪造到其它 Space）。本路径压根不读
+// 调用方 space_id：webhookBlock 无该字段，且 from/space_id 全由服务端注入。
+func TestBuildRichTextPayload_SpaceIDNotForgeable(t *testing.T) {
+	m := sampleWebhook()
+	req := &pushPayloadReq{MsgType: msgTypeRichText, Blocks: []webhookBlock{textBlock("hi")}}
+	payload, err := buildRichTextPayload(m, req)
+	require.NoError(t, err)
+	assert.Equal(t, "space_42", payload["space_id"])
+}
+
+// 不泄漏 token_hash。
+func TestBuildRichTextPayload_NoTokenLeak(t *testing.T) {
+	m := sampleWebhook()
+	req := &pushPayloadReq{MsgType: msgTypeRichText, Blocks: []webhookBlock{textBlock("hi")}}
+	payload, err := buildRichTextPayload(m, req)
+	require.NoError(t, err)
+	assert.NotContains(t, util.ToJson(payload), "SECRET_SHOULD_NOT_LEAK")
+}
+
+// ---- 拒绝路径（write-strict，权威闸 = richtext.Validate） ----
+
+func TestBuildRichTextPayload_Rejects(t *testing.T) {
+	m := sampleWebhook()
+	cases := []struct {
+		name   string
+		blocks []webhookBlock
+	}{
+		{"empty blocks", nil},
+		{"empty text block", []webhookBlock{textBlock("   ")}},
+		{"unknown block type", []webhookBlock{{Type: "video", URL: "https://x/y"}}},
+		{"image missing url", []webhookBlock{{Type: "image", Width: 10, Height: 10}}},
+		{"image non-http scheme", []webhookBlock{imageBlock("data:image/png;base64,AAAA", 10, 10)}},
+		{"image missing size", []webhookBlock{{Type: "image", URL: "https://example.com/a.png"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildRichTextPayload(m, &pushPayloadReq{MsgType: msgTypeRichText, Blocks: tc.blocks})
+			assert.Error(t, err, "应拒绝非法 blocks: %s", tc.name)
+		})
+	}
+}
+
+// 块数超过上限 → errTooManyBlocks（映射 400 invalid，而非 413）。
+func TestBuildRichTextPayload_TooManyBlocks(t *testing.T) {
+	t.Setenv(envMaxBlocks, "2")
+	m := sampleWebhook()
+	blocks := []webhookBlock{textBlock("a"), textBlock("b"), textBlock("c")}
+	_, err := buildRichTextPayload(m, &pushPayloadReq{MsgType: msgTypeRichText, Blocks: blocks})
+	assert.ErrorIs(t, err, errTooManyBlocks)
+}
+
+// 未知块只带 type、不夹带任意字段：未知块被 Validate 拒绝，确认不会因夹带字段而误放行。
+func TestBuildRichTextPayload_UnknownBlockDropsExtraFields(t *testing.T) {
+	m := sampleWebhook()
+	// type=text 合法块 + 一个未知块（携带看似合法的 url/width/height）：整体必须被拒。
+	blocks := []webhookBlock{textBlock("ok"), {Type: "image_v2", URL: "https://x/y", Width: 1, Height: 1}}
+	_, err := buildRichTextPayload(m, &pushPayloadReq{MsgType: msgTypeRichText, Blocks: blocks})
+	assert.Error(t, err)
+}
+
+// resolveFromIdentity：覆盖优先、回落 webhook 配置、超长裁剪到字节上限。
+func TestResolveFromIdentity(t *testing.T) {
+	m := &incomingWebhookModel{Name: "WH", Avatar: "https://a/x.png"}
+
+	name, avatar := resolveFromIdentity(m, &pushPayloadReq{})
+	assert.Equal(t, "WH", name)
+	assert.Equal(t, "https://a/x.png", avatar)
+
+	name, _ = resolveFromIdentity(m, &pushPayloadReq{Username: "Override"})
+	assert.Equal(t, "Override", name)
+
+	longName := strings.Repeat("x", maxFromNameBytes+10)
+	name, _ = resolveFromIdentity(m, &pushPayloadReq{Username: longName})
+	assert.LessOrEqual(t, len(name), maxFromNameBytes)
+}

--- a/pkg/errcode/incomingwebhook.go
+++ b/pkg/errcode/incomingwebhook.go
@@ -40,8 +40,9 @@ var (
 	})
 
 	// ErrIncomingWebhookPushPayloadInvalid (400) — unreadable body, malformed
-	// JSON, or empty content. The offending stage is surfaced via
-	// Details["reason"] (body / json / content).
+	// JSON, empty content, malformed rich-text blocks, or an unknown msg_type.
+	// The offending stage is surfaced via Details["reason"]
+	// (body / json / content / blocks / msg_type).
 	ErrIncomingWebhookPushPayloadInvalid = register(codes.Code{
 		ID:             "err.server.incomingwebhook.push_payload_invalid",
 		HTTPStatus:     http.StatusBadRequest,


### PR DESCRIPTION
## Background

**Phase 1** of epic #297. Today the incoming-webhook push endpoint always sends `Text(1)`, so it can only carry plain text / markdown — no mixed image-and-text messages. This PR adds rich-text / image-text support without breaking backward compatibility.

## Changes

- Add an optional `msg_type` + `blocks` to `pushPayloadReq`:
  - omitted or `"text"` → the existing plain-text path, **zero behavior change**.
  - `"richtext"` → `blocks` carries ordered image/text blocks (`{type:text}` / `{type:image,url,width,height}`).
- New `buildRichTextPayload`: whitelist-translates `blocks` into the native `RichText(=14)` payload, reusing `pkg/richtext` `Validate`/`Finalize` (rejects missing/empty content, empty text, non-http(s) image URL, missing image size, unknown block, >1MB; server authoritatively generates `plain`).
- Error mapping: >1MB → 413; other structural errors → 400 `reason=blocks`; unknown `msg_type` → 400 `reason=msg_type`.

## Design notes

- **High-level external contract**: callers only describe text/image blocks; the internal ContentType number and server-derived fields (`plain`/`size`) are not exposed.
- **Security baseline preserved**: `from.kind=webhook` and `space_id` are server-injected; all other caller fields (incl. `extra`) are dropped, preventing cross-Space forgery — identical to the text path.
- **Client coordination**: rich-text messages are standard `type=14`, so the existing RichText rendering path is reused with no new client work.

## Testing (TDD)

- Unit tests `richtext_test.go` (no infra, green locally): translation/validation, order preservation, from override, space_id non-forgeable, no token leak, every rejection path, block-count cap.
- e2e `richtext_push_test.go` (CI): richtext success / empty blocks / bad image / unknown msg_type / text backward-compat.
- README push-contract doc.

## Checks

`go build` / `go vet` / `gofmt` / unit tests / the `TestIncomingWebhookNoLegacyResponseError` guard / `make i18n-lint` / `make i18n-extract-check` all pass. DB/e2e tests depend on MySQL+Redis+WuKongIM and run in CI.

Refs #297

https://claude.ai/code/session_011kXG9RmQcEvmEp5ZZcPA9y