### PR TITLE
feat(incomingwebhook): delivery failure observability + test push + text alias (Phase 2)

### DIFF
--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -33,6 +33,8 @@ Content-Type: application/json
 ```
 
 - `content`：必填，非空；语义长度上限 4000 rune（`DM_INCOMINGWEBHOOK_MAX_CONTENT_RUNES`）。
+- `text`：`content` 的别名（Slack 等平台习惯用 `text`）。`content` 为空时回退到 `text`，
+  降低从既有集成迁移的改造成本；两者都填以 `content` 为准。
 - `username` / `avatar_url`：可选，覆盖该条消息的展示发送者名/头像（不改 webhook 本身配置）。
 
 ### 2. 富文本 / 图文混排（`msg_type` = `"richtext"`）
@@ -86,3 +88,50 @@ Content-Type: application/json
 | 体积过大 | 413 | 超 body cap 或富文本 >1MB |
 | 投递失败 | 502 | 下游发送失败 |
 | 功能停用 | 404 | 全局开关 `incomingwebhook.enabled=0` |
+
+## 管理端点（群主 / 管理员）
+
+需登录态 + 群管理员权限，路径前缀 `/v1/groups/:group_no/incoming-webhooks`。
+除创建/列出/更新/删除/重置外，Phase 2 新增两个：
+
+### 测试推送
+
+```
+POST /v1/groups/:group_no/incoming-webhooks/:webhook_id/test
+```
+
+向群里发一条固定文案的测试消息，端到端验证配置（群可达、消息能投递）。返回
+`{"status":0,"message_id":<int>}`。会记一条 `adapter=test` 的成功投递，便于在
+deliveries 里与真实流量区分。
+
+### 投递记录（排障）
+
+```
+GET /v1/groups/:group_no/incoming-webhooks/:webhook_id/deliveries?limit=50
+```
+
+倒序返回该 webhook 最近的投递记录（**成功 + 失败**），供发送方排障。`limit` 默认 50、
+上限 100。失败记录的 `reason` / `http_status` 与 push 响应一致，便于对照定位。
+
+```json
+{
+  "list": [
+    {
+      "status": 2, "reason": "blocks", "http_status": 400, "adapter": "native",
+      "ip": "203.0.113.10", "byte_size": 84, "message_id": 0, "created_at": 1749200000
+    },
+    {
+      "status": 1, "reason": "", "http_status": 200, "adapter": "native",
+      "ip": "203.0.113.10", "byte_size": 42, "message_id": 123456, "created_at": 1749199900
+    }
+  ]
+}
+```
+
+- `status`：`1`=成功，`2`=失败。
+- `reason`（失败时）：`rate_limited` / `body` / `json` / `content` / `blocks` / `msg_type` /
+  `too_large` / `delivery_failed`。
+- `adapter`：`native`（推送端点）/ `test`（测试推送）。
+
+> **反枚举不变量**：鉴权失败（未知 webhook / 错 token / 已解散群）**不记入** deliveries，
+> 只进 IP 失败预算——只有「鉴权通过后」的投递结果才落审计。

--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -100,9 +100,10 @@ Content-Type: application/json
 POST /v1/groups/:group_no/incoming-webhooks/:webhook_id/test
 ```
 
-向群里发一条固定文案的测试消息，端到端验证配置（群可达、消息能投递）。返回
-`{"status":0,"message_id":<int>}`。会记一条 `adapter=test` 的成功投递，便于在
-deliveries 里与真实流量区分。
+向群里发一条测试消息，端到端验证配置（群可达、消息能投递）。文案按出站语言本地化
+（en-US / zh-CN，由 `i18n.OutboundLanguage` 协商）。返回 `{"status":0,"message_id":<int>}`。
+会记一条 `adapter=test` 的投递（成功或失败都记，便于在 deliveries 里与真实流量区分），
+且**不**计入 `call_count` / `last_used_at`（测试不是真实流量）。
 
 ### 投递记录（排障）
 
@@ -118,11 +119,11 @@ GET /v1/groups/:group_no/incoming-webhooks/:webhook_id/deliveries?limit=50
   "list": [
     {
       "status": 2, "reason": "blocks", "http_status": 400, "adapter": "native",
-      "ip": "203.0.113.10", "byte_size": 84, "message_id": 0, "created_at": 1749200000
+      "byte_size": 84, "message_id": 0, "created_at": 1749200000
     },
     {
       "status": 1, "reason": "", "http_status": 200, "adapter": "native",
-      "ip": "203.0.113.10", "byte_size": 42, "message_id": 123456, "created_at": 1749199900
+      "byte_size": 42, "message_id": 123456, "created_at": 1749199900
     }
   ]
 }
@@ -132,6 +133,8 @@ GET /v1/groups/:group_no/incoming-webhooks/:webhook_id/deliveries?limit=50
 - `reason`（失败时）：`body` / `json` / `content` / `blocks` / `msg_type` / `too_large` /
   `delivery_failed`。
 - `adapter`：`native`（推送端点）/ `test`（测试推送）。
+- `http_status`：返回给调用方的状态码。**迁移前的历史成功行为 `0`（未知）**——不伪造成 200。
+- **不返回调用方 `ip`**：审计表仍存 ip 作排查上下文，但出于隐私不向群管理员下发（review 决定）。
 
 > **限流（429）不入审计**：`rate_limited` 是天然高频失败，逐条落库会在重试风暴时放大
 > DB 写入、反噬限流的廉价丢弃；429 + `X-RateLimit-*`/`Retry-After` 头已把信息给到调用方。

--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -129,9 +129,13 @@ GET /v1/groups/:group_no/incoming-webhooks/:webhook_id/deliveries?limit=50
 ```
 
 - `status`：`1`=成功，`2`=失败。
-- `reason`（失败时）：`rate_limited` / `body` / `json` / `content` / `blocks` / `msg_type` /
-  `too_large` / `delivery_failed`。
+- `reason`（失败时）：`body` / `json` / `content` / `blocks` / `msg_type` / `too_large` /
+  `delivery_failed`。
 - `adapter`：`native`（推送端点）/ `test`（测试推送）。
+
+> **限流（429）不入审计**：`rate_limited` 是天然高频失败，逐条落库会在重试风暴时放大
+> DB 写入、反噬限流的廉价丢弃；429 + `X-RateLimit-*`/`Retry-After` 头已把信息给到调用方。
+> 节流可从 deliveries 里成功记录的稀疏/中断间接观察。
 
 > **反枚举不变量**：鉴权失败（未知 webhook / 错 token / 已解散群）**不记入** deliveries，
 > 只进 IP 失败预算——只有「鉴权通过后」的投递结果才落审计。

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -168,6 +169,10 @@ func (w *IncomingWebhook) Route(r *wkhttp.WKHttp) {
 		mgr.PUT("/:group_no/incoming-webhooks/:webhook_id", w.requireMgmtEnabled(), w.update)
 		mgr.DELETE("/:group_no/incoming-webhooks/:webhook_id", w.requireMgmtEnabled(), w.delete)
 		mgr.POST("/:group_no/incoming-webhooks/:webhook_id/regenerate", w.requireMgmtEnabled(), w.regenerate)
+		// 排障：最近投递记录（成功+失败）。只读，与 list 一致不挂 requireMgmtEnabled。
+		mgr.GET("/:group_no/incoming-webhooks/:webhook_id/deliveries", w.deliveries)
+		// 测试推送：管理员一键发一条样例消息验证配置。写操作，挂总开关闸。
+		mgr.POST("/:group_no/incoming-webhooks/:webhook_id/test", w.requireMgmtEnabled(), w.testPush)
 	}
 
 	// 推送类：URL 内 token 鉴权，无 AuthMiddleware。四层限流，由粗到细：
@@ -663,6 +668,119 @@ func (w *IncomingWebhook) regenerate(c *wkhttp.Context) {
 }
 
 // ============================================================
+// 排障 / 测试端点（管理端，群管理员）
+// ============================================================
+
+// deliveries 返回条数控制。
+const (
+	defaultDeliveriesLimit = 50
+	maxDeliveriesLimit     = 100
+)
+
+// testPushContent 是「测试推送」固定文案。webhook 消息本就是任意文本，这里不走 i18n
+// 错误信封（那是错误响应专用）；固定一句中性文案即可，发到群里让管理员确认链路打通。
+const testPushContent = "✅ Incoming Webhook 测试消息：配置成功，链路已打通。"
+
+// deliveries 返回某 webhook 最近的投递记录（成功+失败），供发送方排障。只读、群管理员
+// 可见；绝不返回 token。失败记录的 reason/http_status 与 push 路径返回给调用方的响应
+// 一致，便于对照定位。
+func (w *IncomingWebhook) deliveries(c *wkhttp.Context) {
+	groupNo := c.Param("group_no")
+	webhookID := c.Param("webhook_id")
+	if _, ok := w.requireGroupAdmin(c, groupNo); !ok {
+		return
+	}
+	// 复用 queryManageable：webhook 必须属于该群且未软删除（跨群/不存在→404）。
+	if _, ok := w.queryManageable(c, groupNo, webhookID); !ok {
+		return
+	}
+	limit := defaultDeliveriesLimit
+	if v := c.Query("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > maxDeliveriesLimit {
+		limit = maxDeliveriesLimit
+	}
+	list, err := w.db.queryRecentAudits(webhookID, limit)
+	if err != nil {
+		w.Error("query deliveries failed", zap.String("webhook_id", webhookID), zap.Error(err))
+		mgmtQueryFailed(c)
+		return
+	}
+	resps := make([]deliveryResp, 0, len(list))
+	for _, a := range list {
+		resps = append(resps, deliveryRespFrom(a))
+	}
+	c.Response(map[string]interface{}{"list": resps})
+}
+
+func deliveryRespFrom(a *auditModel) deliveryResp {
+	return deliveryResp{
+		Status:     a.Status,
+		Reason:     a.Reason,
+		HTTPStatus: a.HTTPStatus,
+		Adapter:    a.Adapter,
+		IP:         a.IP,
+		ByteSize:   a.ByteSize,
+		MessageID:  a.MessageID,
+		CreatedAt:  time.Time(a.CreatedAt).Unix(),
+	}
+}
+
+// testPush 由群管理员触发，向群里发一条固定文案的测试消息，端到端验证 webhook 配置
+// （群可达、消息能投递）。走与正式推送相同的 buildPayload(text) → SendMessage 链路，
+// 并记一条 adapter=test 的成功投递，便于在 deliveries 里与真实流量区分。
+func (w *IncomingWebhook) testPush(c *wkhttp.Context) {
+	groupNo := c.Param("group_no")
+	webhookID := c.Param("webhook_id")
+	if _, ok := w.requireGroupAdmin(c, groupNo); !ok {
+		return
+	}
+	// 群必须仍为 Normal —— 不向已解散/禁用群发测试消息（与 create/enable 一致）。
+	g, err := w.requireActiveGroup(groupNo)
+	if err != nil {
+		w.Error("query group failed", zap.Error(err))
+		mgmtQueryFailed(c)
+		return
+	}
+	if g == nil {
+		mgmtGroupNotFound(c)
+		return
+	}
+	m, ok := w.queryManageable(c, groupNo, webhookID)
+	if !ok {
+		return
+	}
+
+	req := &pushPayloadReq{Content: testPushContent}
+	payload := buildPayload(m, req)
+	resp, err := w.ctx.SendMessageWithResult(&config.MsgSendReq{
+		Header:      config.MsgHeader{RedDot: 1},
+		ChannelID:   m.GroupNo,
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		FromUID:     m.WebhookID,
+		Payload:     []byte(util.ToJson(payload)),
+	})
+	if err != nil {
+		w.Error("send test webhook message failed",
+			zap.String("webhook_id", m.WebhookID), zap.Error(err))
+		mgmtOperationFailed(c)
+		return
+	}
+	var msgID int64
+	if resp != nil {
+		msgID = resp.MessageID
+	}
+	w.submitSuccess(m, len(testPushContent), clientIP(c.Request), msgID, adapterTest)
+	c.Response(map[string]interface{}{
+		"status":     0,
+		"message_id": msgID,
+	})
+}
+
+// ============================================================
 // 推送端点
 // ============================================================
 
@@ -745,6 +863,8 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 		allowed = true
 	}
 	if !allowed {
+		// 鉴权已通过、群为 Normal：失败计入投递审计（body 尚未读，byteSize=0）。
+		w.submitFailure(m, 0, ip, "rate_limited", http.StatusTooManyRequests)
 		pushRateLimited(c)
 		return
 	}
@@ -753,16 +873,19 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 	limit := maxBytes()
 	body, err := io.ReadAll(io.LimitReader(c.Request.Body, int64(limit)+1))
 	if err != nil {
+		w.submitFailure(m, 0, ip, "body", http.StatusBadRequest)
 		pushPayloadInvalid(c, "body")
 		return
 	}
 	if len(body) > limit {
+		w.submitFailure(m, len(body), ip, "too_large", http.StatusRequestEntityTooLarge)
 		pushPayloadTooLarge(c)
 		return
 	}
 
 	var req pushPayloadReq
 	if err := json.Unmarshal(body, &req); err != nil {
+		w.submitFailure(m, len(body), ip, "json", http.StatusBadRequest)
 		pushPayloadInvalid(c, "json")
 		return
 	}
@@ -773,13 +896,19 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 	var payload map[string]interface{}
 	switch strings.ToLower(strings.TrimSpace(req.MsgType)) {
 	case "", msgTypeText:
+		// "text" 是 content 的别名：content 为空时回退，降低从既有集成迁移的改造成本。
+		if req.Content == "" {
+			req.Content = req.Text
+		}
 		if strings.TrimSpace(req.Content) == "" {
+			w.submitFailure(m, len(body), ip, "content", http.StatusBadRequest)
 			pushPayloadInvalid(c, "content")
 			return
 		}
 		// content 语义长度上限（按 rune 计），独立于 8KB 字节 body cap：防止单条消息
 		// 正文过长污染所有客户端渲染。超限按 413 拒绝，与 body 超限同语义。
 		if utf8.RuneCountInString(req.Content) > maxContentRunes() {
+			w.submitFailure(m, len(body), ip, "too_large", http.StatusRequestEntityTooLarge)
 			pushPayloadTooLarge(c)
 			return
 		}
@@ -794,14 +923,17 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 			// 空 text 块 / 非 http(s) 图片 url / 缺图片宽高 / 未知块类型 / 超块数上限）
 			// 一律 400 invalid，reason=blocks 供调用方定位。
 			if errors.Is(err, common.ErrRichTextPayloadTooLarge) {
+				w.submitFailure(m, len(body), ip, "too_large", http.StatusRequestEntityTooLarge)
 				pushPayloadTooLarge(c)
 				return
 			}
+			w.submitFailure(m, len(body), ip, "blocks", http.StatusBadRequest)
 			pushPayloadInvalid(c, "blocks")
 			return
 		}
 		payload = p
 	default:
+		w.submitFailure(m, len(body), ip, "msg_type", http.StatusBadRequest)
 		pushPayloadInvalid(c, "msg_type")
 		return
 	}
@@ -818,6 +950,7 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 	if err != nil {
 		w.Error("send incoming webhook message failed",
 			zap.String("webhook_id", m.WebhookID), zap.Error(err))
+		w.submitFailure(m, len(body), ip, "delivery_failed", http.StatusBadGateway)
 		pushDeliveryFailed(c)
 		return
 	}
@@ -828,7 +961,7 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 		msgID = resp.MessageID
 	}
 	// 审计用同一可信 IP（clientIP），而非 gin 可伪造的 c.ClientIP()。
-	w.submitRecordSuccess(m, len(body), ip, msgID)
+	w.submitSuccess(m, len(body), ip, msgID, adapterNative)
 
 	c.Response(map[string]interface{}{
 		"status":     0,
@@ -904,53 +1037,83 @@ func resolveFromIdentity(m *incomingWebhookModel, req *pushPayloadReq) (name, av
 	return truncateUTF8(name, maxFromNameBytes), truncateUTF8(avatar, maxFromAvatarBytes)
 }
 
-// submitRecordSuccess 把审计任务投递给有界并发池：未达上限时异步执行；已达上限时
-// **丢弃**本次审计（仅 Warn）。如此审计占用的 DB 连接总数恒 ≤ auditSem 容量，不会在
-// 洪峰下与主流量抢连接池。审计为非关键路径，溢出丢弃优于回落到请求 goroutine 同步执行
-// （后者请求并发无界时会重新压垮连接池）。
-func (w *IncomingWebhook) submitRecordSuccess(m *incomingWebhookModel, byteSize int, ip string, msgID int64) {
+// submitSuccess 记录一次成功投递：审计 + 累加调用计数(bumpUsed=true)。adapter 标记
+// 来源（native 推送 / test 测试推送）。
+func (w *IncomingWebhook) submitSuccess(m *incomingWebhookModel, byteSize int, ip string, msgID int64, adapter string) {
+	w.submitDelivery(&auditModel{
+		WebhookID:  m.WebhookID,
+		GroupNo:    m.GroupNo,
+		IP:         ip,
+		ByteSize:   byteSize,
+		MessageID:  msgID,
+		Status:     auditSuccess,
+		HTTPStatus: http.StatusOK,
+		Adapter:    adapter,
+	}, true)
+}
+
+// submitFailure 记录一次【鉴权通过后】的失败投递（限流/payload 非法/体积过大/投递失败）。
+// 不累加调用计数(bumpUsed=false)——call_count 语义是「成功调用次数」。reason/httpStatus
+// 与 push 路径返回给调用方的响应保持一致，供 deliveries 端点排障。
+//
+// ⚠️ 仅在 webhook 已通过 token 鉴权且群为 Normal 之后调用：鉴权失败（未知/错 token/
+// 已解散群）绝不落本表，只进 IP 失败预算，维持 push 路径的反枚举不变量。
+func (w *IncomingWebhook) submitFailure(m *incomingWebhookModel, byteSize int, ip, reason string, httpStatus int) {
+	w.submitDelivery(&auditModel{
+		WebhookID:  m.WebhookID,
+		GroupNo:    m.GroupNo,
+		IP:         ip,
+		ByteSize:   byteSize,
+		Status:     auditFailed,
+		Reason:     reason,
+		HTTPStatus: httpStatus,
+		Adapter:    adapterNative,
+	}, false)
+}
+
+// submitDelivery 把审计任务投递给有界并发池：未达上限时异步执行；已达上限时**丢弃**
+// 本次审计（仅 Warn）。如此审计占用的 DB 连接总数恒 ≤ auditSem 容量，不会在洪峰下与
+// 主流量抢连接池。审计为非关键路径，溢出丢弃优于回落到请求 goroutine 同步执行（后者
+// 请求并发无界时会重新压垮连接池）。
+func (w *IncomingWebhook) submitDelivery(audit *auditModel, bumpUsed bool) {
 	select {
 	case w.auditSem <- struct{}{}:
 		go func() {
 			defer func() { <-w.auditSem }()
-			w.recordSuccess(m, byteSize, ip, msgID)
+			w.recordDelivery(audit, bumpUsed)
 		}()
 	default:
 		// 并发已达上限：丢弃审计，保证总 DB 并发有界、不抢占主流量连接池。
 		w.Warn("audit dropped: concurrency cap reached",
-			zap.String("webhook_id", m.WebhookID))
+			zap.String("webhook_id", audit.WebhookID))
 	}
 }
 
-// auditWriteTimeout 限定一次审计（markUsed + insertAudit 两次写）的总耗时上限。
-// recordSuccess 始终跑在独立 goroutine 上（submitRecordSuccess 满载时直接丢弃、不回落
-// 到请求 goroutine），所以这个超时**不影响 push 响应延迟**；它的作用是封顶单个 detached
+// auditWriteTimeout 限定一次审计（markUsed + insertAudit 最多两次写）的总耗时上限。
+// recordDelivery 始终跑在独立 goroutine 上（submitDelivery 满载时直接丢弃、不回落到
+// 请求 goroutine），所以这个超时**不影响 push 响应延迟**；它的作用是封顶单个 detached
 // 审计 goroutine 在 DB 饱和/故障时持有连接池连接的时长，避免慢 DB 下连接被长期占用。
 // 3s 足够正常写入，又能在故障时快速放手（审计本就是非关键路径，失败仅记日志）。
 const auditWriteTimeout = 3 * time.Second
 
-// recordSuccess 写审计 + 累加调用计数。失败仅记日志，不阻塞主流程。
-func (w *IncomingWebhook) recordSuccess(m *incomingWebhookModel, byteSize int, ip string, msgID int64) {
+// recordDelivery 写一条投递审计；bumpUsed 时额外累加调用计数（仅成功路径）。失败仅记
+// 日志，不阻塞主流程。
+func (w *IncomingWebhook) recordDelivery(audit *auditModel, bumpUsed bool) {
 	defer func() {
 		if r := recover(); r != nil {
-			w.Error("recordSuccess panic", zap.Any("recover", r))
+			w.Error("recordDelivery panic", zap.Any("recover", r))
 		}
 	}()
 	// 两次写共用一个截止时间，封顶单个审计 goroutine 在 DB 饱和/故障时持有连接的时长。
 	ctx, cancel := context.WithTimeout(context.Background(), auditWriteTimeout)
 	defer cancel()
-	if err := w.db.markUsed(ctx, m.WebhookID, time.Now()); err != nil {
-		w.Warn("markUsed failed", zap.String("webhook_id", m.WebhookID), zap.Error(err))
-	}
-	audit := &auditModel{
-		WebhookID: m.WebhookID,
-		GroupNo:   m.GroupNo,
-		IP:        ip,
-		ByteSize:  byteSize,
-		MessageID: msgID,
+	if bumpUsed {
+		if err := w.db.markUsed(ctx, audit.WebhookID, time.Now()); err != nil {
+			w.Warn("markUsed failed", zap.String("webhook_id", audit.WebhookID), zap.Error(err))
+		}
 	}
 	if err := w.db.insertAudit(ctx, audit); err != nil {
-		w.Warn("insert audit failed", zap.String("webhook_id", m.WebhookID), zap.Error(err))
+		w.Warn("insert audit failed", zap.String("webhook_id", audit.WebhookID), zap.Error(err))
 	}
 }
 

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	commonmod "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"github.com/go-redis/redis"
@@ -677,9 +678,16 @@ const (
 	maxDeliveriesLimit     = 100
 )
 
-// testPushContent 是「测试推送」固定文案。webhook 消息本就是任意文本，这里不走 i18n
-// 错误信封（那是错误响应专用）；固定一句中性文案即可，发到群里让管理员确认链路打通。
-const testPushContent = "✅ Incoming Webhook 测试消息：配置成功，链路已打通。"
+// testPushMessage 返回「测试推送」文案，按出站语言本地化。webhook 消息是普通消息体、
+// 不走 i18n 错误信封（那是错误响应专用），故采用与 outbound 邮件一致的做法：用
+// i18n.OutboundLanguage(ctx) 解析协商语言，再选对应文案。支持矩阵为 en-US / zh-CN
+// （默认 zh-CN）。
+func testPushMessage(ctx context.Context) string {
+	if i18n.OutboundLanguage(ctx) == "en-US" {
+		return "✅ Incoming Webhook test message: setup works, the delivery path is live."
+	}
+	return "✅ Incoming Webhook 测试消息：配置成功，链路已打通。"
+}
 
 // deliveries 返回某 webhook 最近的投递记录（成功+失败），供发送方排障。只读、群管理员
 // 可见；绝不返回 token。失败记录的 reason/http_status 与 push 路径返回给调用方的响应
@@ -722,7 +730,6 @@ func deliveryRespFrom(a *auditModel) deliveryResp {
 		Reason:     a.Reason,
 		HTTPStatus: a.HTTPStatus,
 		Adapter:    a.Adapter,
-		IP:         a.IP,
 		ByteSize:   a.ByteSize,
 		MessageID:  a.MessageID,
 		CreatedAt:  time.Time(a.CreatedAt).Unix(),
@@ -754,8 +761,10 @@ func (w *IncomingWebhook) testPush(c *wkhttp.Context) {
 		return
 	}
 
-	req := &pushPayloadReq{Content: testPushContent}
+	msg := testPushMessage(c.Request.Context())
+	req := &pushPayloadReq{Content: msg}
 	payload := buildPayload(m, req)
+	ip := clientIP(c.Request)
 	resp, err := w.ctx.SendMessageWithResult(&config.MsgSendReq{
 		Header:      config.MsgHeader{RedDot: 1},
 		ChannelID:   m.GroupNo,
@@ -766,6 +775,12 @@ func (w *IncomingWebhook) testPush(c *wkhttp.Context) {
 	if err != nil {
 		w.Error("send test webhook message failed",
 			zap.String("webhook_id", m.WebhookID), zap.Error(err))
+		// 记一条 adapter=test 的失败投递，让排障故事对称（成功/失败都可见）。bumpUsed=false。
+		w.submitDelivery(&auditModel{
+			WebhookID: m.WebhookID, GroupNo: m.GroupNo, IP: ip, ByteSize: len(msg),
+			Status: auditFailed, Reason: "delivery_failed",
+			HTTPStatus: http.StatusInternalServerError, Adapter: adapterTest,
+		}, false)
 		mgmtOperationFailed(c)
 		return
 	}
@@ -774,7 +789,7 @@ func (w *IncomingWebhook) testPush(c *wkhttp.Context) {
 		msgID = resp.MessageID
 	}
 	// bumpUsed=false：测试推送不计入 call_count / last_used_at（adapter=test 已可区分）。
-	w.submitSuccess(m, len(testPushContent), clientIP(c.Request), msgID, adapterTest, false)
+	w.submitSuccess(m, len(msg), ip, msgID, adapterTest, false)
 	c.Response(map[string]interface{}{
 		"status":     0,
 		"message_id": msgID,

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -773,7 +773,8 @@ func (w *IncomingWebhook) testPush(c *wkhttp.Context) {
 	if resp != nil {
 		msgID = resp.MessageID
 	}
-	w.submitSuccess(m, len(testPushContent), clientIP(c.Request), msgID, adapterTest)
+	// bumpUsed=false：测试推送不计入 call_count / last_used_at（adapter=test 已可区分）。
+	w.submitSuccess(m, len(testPushContent), clientIP(c.Request), msgID, adapterTest, false)
 	c.Response(map[string]interface{}{
 		"status":     0,
 		"message_id": msgID,
@@ -863,8 +864,11 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 		allowed = true
 	}
 	if !allowed {
-		// 鉴权已通过、群为 Normal：失败计入投递审计（body 尚未读，byteSize=0）。
-		w.submitFailure(m, 0, ip, "rate_limited", http.StatusTooManyRequests)
+		// 刻意【不】记 rate_limited 审计：429 + X-RateLimit-*/Retry-After 头已把节流信息
+		// 给到调用方；而 rate_limited 是唯一天然高频的失败类型（其余失败都在限流闸之后、
+		// 已被 per-webhook 5rps 收住），逐条落审计会在重试风暴时放大 DB 写入与 auditSem 溢出
+		// 的 Warn 日志，反噬限流「廉价丢弃」的本意。管理员可从 deliveries 里成功记录的稀疏/
+		// 中断间接看出节流（review 跟进）。
 		pushRateLimited(c)
 		return
 	}
@@ -960,8 +964,9 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 	if resp != nil {
 		msgID = resp.MessageID
 	}
-	// 审计用同一可信 IP（clientIP），而非 gin 可伪造的 c.ClientIP()。
-	w.submitSuccess(m, len(body), ip, msgID, adapterNative)
+	// 审计用同一可信 IP（clientIP），而非 gin 可伪造的 c.ClientIP()。bumpUsed=true：
+	// 真实推送成功累加 call_count / last_used_at。
+	w.submitSuccess(m, len(body), ip, msgID, adapterNative, true)
 
 	c.Response(map[string]interface{}{
 		"status":     0,
@@ -1037,9 +1042,10 @@ func resolveFromIdentity(m *incomingWebhookModel, req *pushPayloadReq) (name, av
 	return truncateUTF8(name, maxFromNameBytes), truncateUTF8(avatar, maxFromAvatarBytes)
 }
 
-// submitSuccess 记录一次成功投递：审计 + 累加调用计数(bumpUsed=true)。adapter 标记
-// 来源（native 推送 / test 测试推送）。
-func (w *IncomingWebhook) submitSuccess(m *incomingWebhookModel, byteSize int, ip string, msgID int64, adapter string) {
+// submitSuccess 记录一次成功投递。adapter 标记来源（native 推送 / test 测试推送）。
+// bumpUsed 控制是否累加 call_count / 刷新 last_used_at：native 真实推送为 true，
+// 管理端「测试推送」为 false——测试不是真实流量，不应污染管理列表展示的使用量。
+func (w *IncomingWebhook) submitSuccess(m *incomingWebhookModel, byteSize int, ip string, msgID int64, adapter string, bumpUsed bool) {
 	w.submitDelivery(&auditModel{
 		WebhookID:  m.WebhookID,
 		GroupNo:    m.GroupNo,
@@ -1049,12 +1055,15 @@ func (w *IncomingWebhook) submitSuccess(m *incomingWebhookModel, byteSize int, i
 		Status:     auditSuccess,
 		HTTPStatus: http.StatusOK,
 		Adapter:    adapter,
-	}, true)
+	}, bumpUsed)
 }
 
-// submitFailure 记录一次【鉴权通过后】的失败投递（限流/payload 非法/体积过大/投递失败）。
+// submitFailure 记录一次【鉴权通过后】的失败投递（payload 非法/体积过大/投递失败）。
 // 不累加调用计数(bumpUsed=false)——call_count 语义是「成功调用次数」。reason/httpStatus
 // 与 push 路径返回给调用方的响应保持一致，供 deliveries 端点排障。
+//
+// 刻意【不】覆盖 rate_limited（429）：它在限流闸处直接返回、不入审计——见 push 路径中
+// !allowed 分支的说明（天然高频，逐条落库会反噬限流的廉价丢弃）。
 //
 // ⚠️ 仅在 webhook 已通过 token 鉴权且群为 Normal 之后调用：鉴权失败（未知/错 token/
 // 已解散群）绝不落本表，只进 IP 失败预算，维持 push 路径的反枚举不变量。

--- a/modules/incomingwebhook/db.go
+++ b/modules/incomingwebhook/db.go
@@ -167,10 +167,24 @@ func (d *incomingWebhookDB) disableByGroupNo(groupNo string) error {
 	return err
 }
 
-// insertAudit 写一条成功推送审计。同样走 ExecContext，理由见 markUsed。
+// insertAudit 写一条投递审计（成功或失败）。新增列（status/reason/http_status/adapter）
+// 由 util.AttrToUnderscore + Record 反射自动映射，无需改动。走 ExecContext，理由见 markUsed。
 func (d *incomingWebhookDB) insertAudit(ctx context.Context, m *auditModel) error {
 	_, err := d.session.InsertInto("incoming_webhook_audit").
 		Columns(util.AttrToUnderscore(m)...).
 		Record(m).ExecContext(ctx)
 	return err
+}
+
+// queryRecentAudits 倒序取某 webhook 最近 limit 条投递记录，供管理端 deliveries 排障。
+// 命中 idx_iwa_webhook_time(webhook_id, created_at) 前缀索引：等值 webhook_id + 按
+// created_at 倒序，无需回表全扫。limit 由调用方钳制在合理上限。
+func (d *incomingWebhookDB) queryRecentAudits(webhookID string, limit int) ([]*auditModel, error) {
+	var list []*auditModel
+	_, err := d.session.Select("*").From("incoming_webhook_audit").
+		Where("webhook_id=?", webhookID).
+		OrderDir("created_at", false).
+		Limit(uint64(limit)).
+		Load(&list)
+	return list, err
 }

--- a/modules/incomingwebhook/db.go
+++ b/modules/incomingwebhook/db.go
@@ -179,11 +179,15 @@ func (d *incomingWebhookDB) insertAudit(ctx context.Context, m *auditModel) erro
 // queryRecentAudits 倒序取某 webhook 最近 limit 条投递记录，供管理端 deliveries 排障。
 // 命中 idx_iwa_webhook_time(webhook_id, created_at) 前缀索引：等值 webhook_id + 按
 // created_at 倒序，无需回表全扫。limit 由调用方钳制在合理上限。
+//
+// 二级排序 id 倒序：created_at 是秒级精度，同秒内多条投递若只按 created_at 排序顺序
+// 不确定（「最近」语义会抖动）；id 自增、单调，作 tiebreaker 给出确定的最近优先顺序。
 func (d *incomingWebhookDB) queryRecentAudits(webhookID string, limit int) ([]*auditModel, error) {
 	var list []*auditModel
 	_, err := d.session.Select("*").From("incoming_webhook_audit").
 		Where("webhook_id=?", webhookID).
 		OrderDir("created_at", false).
+		OrderDir("id", false).
 		Limit(uint64(limit)).
 		Load(&list)
 	return list, err

--- a/modules/incomingwebhook/db_test.go
+++ b/modules/incomingwebhook/db_test.go
@@ -221,7 +221,7 @@ func TestInsertAndQueryAudit(t *testing.T) {
 	}))
 	assert.NoError(t, d.insertAudit(context.Background(), &auditModel{
 		WebhookID: whID, GroupNo: groupNo, IP: "1.2.3.4",
-		Status: auditFailed, Reason: "rate_limited", HTTPStatus: 429, Adapter: adapterNative,
+		Status: auditFailed, Reason: "delivery_failed", HTTPStatus: 502, Adapter: adapterNative,
 	}))
 
 	list, err := d.queryRecentAudits(whID, 10)
@@ -238,8 +238,8 @@ func TestInsertAndQueryAudit(t *testing.T) {
 			assert.Equal(t, int64(99), a.MessageID)
 		case auditFailed:
 			failed++
-			assert.Equal(t, "rate_limited", a.Reason)
-			assert.Equal(t, 429, a.HTTPStatus)
+			assert.Equal(t, "delivery_failed", a.Reason)
+			assert.Equal(t, 502, a.HTTPStatus)
 		}
 	}
 	assert.Equal(t, 1, success, "should record one success")

--- a/modules/incomingwebhook/db_test.go
+++ b/modules/incomingwebhook/db_test.go
@@ -204,6 +204,53 @@ func TestMarkUsed_SkipsDeleted(t *testing.T) {
 	}
 }
 
+// TestInsertAndQueryAudit 验证 Phase 2 审计扩展的 DB 层：insertAudit 落库成功+失败两
+// 类记录（新增列 status/reason/http_status/adapter 由反射自动映射），queryRecentAudits
+// 按 webhook 取回并受 limit 钳制。同步路径，不依赖异步 submitDelivery，断言确定。
+func TestInsertAndQueryAudit(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+	d := newDB(ctx)
+
+	groupNo := "g_" + util.GenerUUID()[:12]
+	whID := mustInsertWebhook(t, d, groupNo)
+
+	assert.NoError(t, d.insertAudit(context.Background(), &auditModel{
+		WebhookID: whID, GroupNo: groupNo, IP: "1.2.3.4", ByteSize: 12, MessageID: 99,
+		Status: auditSuccess, HTTPStatus: 200, Adapter: adapterNative,
+	}))
+	assert.NoError(t, d.insertAudit(context.Background(), &auditModel{
+		WebhookID: whID, GroupNo: groupNo, IP: "1.2.3.4",
+		Status: auditFailed, Reason: "rate_limited", HTTPStatus: 429, Adapter: adapterNative,
+	}))
+
+	list, err := d.queryRecentAudits(whID, 10)
+	assert.NoError(t, err)
+	assert.Len(t, list, 2)
+	// created_at 同秒内顺序不保证，只校验集合内容与字段映射。
+	var success, failed int
+	for _, a := range list {
+		assert.Equal(t, adapterNative, a.Adapter)
+		switch a.Status {
+		case auditSuccess:
+			success++
+			assert.Equal(t, 200, a.HTTPStatus)
+			assert.Equal(t, int64(99), a.MessageID)
+		case auditFailed:
+			failed++
+			assert.Equal(t, "rate_limited", a.Reason)
+			assert.Equal(t, 429, a.HTTPStatus)
+		}
+	}
+	assert.Equal(t, 1, success, "should record one success")
+	assert.Equal(t, 1, failed, "should record one failure")
+
+	// limit 钳制。
+	limited, err := d.queryRecentAudits(whID, 1)
+	assert.NoError(t, err)
+	assert.Len(t, limited, 1)
+}
+
 func mustInsertWebhook(t *testing.T, d *incomingWebhookDB, groupNo string) string {
 	t.Helper()
 	return mustInsertWebhookWithMax(t, d, groupNo, 100)

--- a/modules/incomingwebhook/model.go
+++ b/modules/incomingwebhook/model.go
@@ -33,13 +33,31 @@ type incomingWebhookModel struct {
 	db.BaseModel
 }
 
-// auditModel 对应 incoming_webhook_audit 表，记录成功推送的最小审计信息。
+// 审计投递结果（auditModel.Status）。1/2 而非 0/1：避免「未设置即默认 0」被误读为
+// 一个有效结果——历史行与新成功行都应是 auditSuccess(1)，迁移默认值即 1。
+const (
+	auditSuccess = 1
+	auditFailed  = 2
+)
+
+// 投递来源/适配器（auditModel.Adapter）。Phase 3/4 扩展 github/gitlab/wecom/feishu。
+const (
+	adapterNative = "native" // 原生推送端点
+	adapterTest   = "test"   // 管理端「测试推送」
+)
+
+// auditModel 对应 incoming_webhook_audit 表，记录【鉴权通过后】的每次投递结果
+// （成功+失败）。鉴权失败（未知/错 token）不落本表，仅进 IP 失败预算，维持反枚举。
 type auditModel struct {
-	WebhookID string
-	GroupNo   string
-	IP        string
-	ByteSize  int
-	MessageID int64
+	WebhookID  string
+	GroupNo    string
+	IP         string
+	ByteSize   int
+	MessageID  int64
+	Status     int    // auditSuccess / auditFailed
+	Reason     string // 失败原因码；成功为空
+	HTTPStatus int    // 返回给调用方的 HTTP 状态码
+	Adapter    string // 来源/适配器：adapterNative / adapterTest / ...
 	db.BaseModel
 }
 
@@ -51,8 +69,11 @@ type auditModel struct {
 //     octo 原生 RichText(=14) 后走 richtext.Validate/Finalize。对外刻意不暴露内部
 //     ContentType 数字与 plain 等服务端字段——调用方只需描述「文本块 / 图片块」。
 type pushPayloadReq struct {
-	MsgType   string                 `json:"msg_type,omitempty"`
-	Content   string                 `json:"content"`
+	MsgType string `json:"msg_type,omitempty"`
+	Content string `json:"content"`
+	// Text 是 Content 的别名（Slack/部分平台用 "text"）：Content 为空时回退到 Text，
+	// 降低从既有集成迁移的改造成本。两者都填以 Content 为准。
+	Text      string                 `json:"text,omitempty"`
 	Blocks    []webhookBlock         `json:"blocks,omitempty"`
 	Username  string                 `json:"username,omitempty"`
 	AvatarURL string                 `json:"avatar_url,omitempty"`
@@ -106,4 +127,16 @@ type createResp struct {
 	webhookResp
 	Token string `json:"token"`
 	URL   string `json:"url"`
+}
+
+// deliveryResp 是 deliveries 排障端点返回的单条投递记录（成功+失败）。绝不含 token。
+type deliveryResp struct {
+	Status     int    `json:"status"`      // auditSuccess / auditFailed
+	Reason     string `json:"reason"`      // 失败原因码；成功为空
+	HTTPStatus int    `json:"http_status"` // 返回给调用方的 HTTP 状态码
+	Adapter    string `json:"adapter"`     // 来源/适配器
+	IP         string `json:"ip"`
+	ByteSize   int    `json:"byte_size"`
+	MessageID  int64  `json:"message_id"`
+	CreatedAt  int64  `json:"created_at"`
 }

--- a/modules/incomingwebhook/model.go
+++ b/modules/incomingwebhook/model.go
@@ -130,12 +130,14 @@ type createResp struct {
 }
 
 // deliveryResp 是 deliveries 排障端点返回的单条投递记录（成功+失败）。绝不含 token。
+//
+// 刻意【不】下发调用方 IP：审计表仍存 ip（限流/排查上下文），但向群管理员暴露来源 IP
+// 是隐私取舍，按 review 决定收敛——deliveries 只回投递结果元数据，不回 IP（PR #299 review）。
 type deliveryResp struct {
 	Status     int    `json:"status"`      // auditSuccess / auditFailed
 	Reason     string `json:"reason"`      // 失败原因码；成功为空
 	HTTPStatus int    `json:"http_status"` // 返回给调用方的 HTTP 状态码
 	Adapter    string `json:"adapter"`     // 来源/适配器
-	IP         string `json:"ip"`
 	ByteSize   int    `json:"byte_size"`
 	MessageID  int64  `json:"message_id"`
 	CreatedAt  int64  `json:"created_at"`

--- a/modules/incomingwebhook/observability_test.go
+++ b/modules/incomingwebhook/observability_test.go
@@ -28,7 +28,7 @@ func TestDeliveries_Endpoint(t *testing.T) {
 	require.NoError(t, err)
 	_, err = ctx.DB().InsertBySql(
 		"INSERT INTO incoming_webhook_audit(webhook_id, group_no, ip, byte_size, message_id, status, reason, http_status, adapter) VALUES(?,?,?,?,?,?,?,?,?)",
-		whID, groupNo, "1.2.3.4", 0, 0, 2, "rate_limited", 429, "native").Exec()
+		whID, groupNo, "1.2.3.4", 0, 0, 2, "delivery_failed", 502, "native").Exec()
 	require.NoError(t, err)
 
 	w := do(handler, authReq("GET", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s/deliveries", groupNo, whID), nil))
@@ -47,8 +47,8 @@ func TestDeliveries_Endpoint(t *testing.T) {
 			assert.Equal(t, float64(200), row["http_status"])
 		case 2:
 			failed++
-			assert.Equal(t, "rate_limited", row["reason"])
-			assert.Equal(t, float64(429), row["http_status"])
+			assert.Equal(t, "delivery_failed", row["reason"])
+			assert.Equal(t, float64(502), row["http_status"])
 		}
 	}
 	assert.Equal(t, 1, success)

--- a/modules/incomingwebhook/observability_test.go
+++ b/modules/incomingwebhook/observability_test.go
@@ -1,0 +1,195 @@
+package incomingwebhook_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Phase 2（失败可观测性 + 管理 UX）的 HTTP e2e 用例。需 MySQL/Redis/WuKongIM（CI）。
+// 审计写入是异步（submitDelivery → goroutine），故依赖异步落库的断言用 require.Eventually
+// 轮询，避免 flaky；不依赖异步的（直接 DB 注入 + 读端点、鉴权/404）则确定断言。
+
+// --- deliveries 端点 ---
+
+// 直接 DB 注入成功+失败各一条，GET deliveries 必须确定返回两条且字段正确、无 token。
+func TestDeliveries_Endpoint(t *testing.T) {
+	handler, ctx, groupNo := setupTestEnv(t)
+	whID, _ := createWebhookWithToken(t, handler, groupNo)
+
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO incoming_webhook_audit(webhook_id, group_no, ip, byte_size, message_id, status, reason, http_status, adapter) VALUES(?,?,?,?,?,?,?,?,?)",
+		whID, groupNo, "1.2.3.4", 12, 99, 1, "", 200, "native").Exec()
+	require.NoError(t, err)
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO incoming_webhook_audit(webhook_id, group_no, ip, byte_size, message_id, status, reason, http_status, adapter) VALUES(?,?,?,?,?,?,?,?,?)",
+		whID, groupNo, "1.2.3.4", 0, 0, 2, "rate_limited", 429, "native").Exec()
+	require.NoError(t, err)
+
+	w := do(handler, authReq("GET", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s/deliveries", groupNo, whID), nil))
+	require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.NotContains(t, w.Body.String(), "token")
+
+	list, _ := parseJSON(t, w)["list"].([]interface{})
+	require.Len(t, list, 2)
+
+	var success, failed int
+	for _, item := range list {
+		row, _ := item.(map[string]interface{})
+		switch int(row["status"].(float64)) {
+		case 1:
+			success++
+			assert.Equal(t, float64(200), row["http_status"])
+		case 2:
+			failed++
+			assert.Equal(t, "rate_limited", row["reason"])
+			assert.Equal(t, float64(429), row["http_status"])
+		}
+	}
+	assert.Equal(t, 1, success)
+	assert.Equal(t, 1, failed)
+}
+
+// limit 查询参数钳制返回条数。
+func TestDeliveries_LimitParam(t *testing.T) {
+	handler, ctx, groupNo := setupTestEnv(t)
+	whID, _ := createWebhookWithToken(t, handler, groupNo)
+	for i := 0; i < 3; i++ {
+		_, err := ctx.DB().InsertBySql(
+			"INSERT INTO incoming_webhook_audit(webhook_id, group_no, ip, status, http_status, adapter) VALUES(?,?,?,?,?,?)",
+			whID, groupNo, "1.2.3.4", 1, 200, "native").Exec()
+		require.NoError(t, err)
+	}
+	w := do(handler, authReq("GET", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s/deliveries?limit=2", groupNo, whID), nil))
+	require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	list, _ := parseJSON(t, w)["list"].([]interface{})
+	assert.Len(t, list, 2)
+}
+
+// 非群管理员不可看 deliveries。
+func TestDeliveries_RequiresAdmin(t *testing.T) {
+	handler, ctx, groupNo := setupTestEnv(t)
+	whID, _ := createWebhookWithToken(t, handler, groupNo)
+	_, err := ctx.DB().UpdateBySql("UPDATE group_member SET role=0 WHERE group_no=? AND uid=?", groupNo, testutil.UID).Exec()
+	require.NoError(t, err)
+
+	w := do(handler, authReq("GET", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s/deliveries", groupNo, whID), nil))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// 不存在 / 跨群 webhook → 404。
+func TestDeliveries_NotFound(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("GET", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/iwh_nonexistent/deliveries", groupNo), nil))
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// 端到端：推送非法 blocks → 400，且失败被异步记入审计（reason=blocks, http_status=400）。
+func TestDeliveries_RecordsPushFailure(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	// 缺图片宽高 → 400（确定）。
+	pw := pushRichText(handler, whID, token, map[string]interface{}{
+		"msg_type": "richtext",
+		"blocks":   []map[string]interface{}{{"type": "image", "url": "https://example.com/a.png"}},
+	})
+	require.Equalf(t, http.StatusBadRequest, pw.Code, "bad blocks must 400; body=%s", pw.Body.String())
+
+	// 异步审计：轮询 deliveries 直到出现一条 reason=blocks 的失败记录。
+	require.Eventually(t, func() bool {
+		w := do(handler, authReq("GET", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s/deliveries", groupNo, whID), nil))
+		if w.Code != http.StatusOK {
+			return false
+		}
+		list, _ := parseJSON(t, w)["list"].([]interface{})
+		for _, item := range list {
+			row, _ := item.(map[string]interface{})
+			if row["reason"] == "blocks" && int(row["status"].(float64)) == 2 && int(row["http_status"].(float64)) == 400 {
+				return true
+			}
+		}
+		return false
+	}, 3*time.Second, 50*time.Millisecond, "push failure must be recorded as a delivery")
+}
+
+// 鉴权失败（错 token）绝不落 deliveries（反枚举不变量）：失败仅进 IP 失败预算。
+func TestDeliveries_AuthFailureNotRecorded(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, _ := createWebhookWithToken(t, handler, groupNo)
+
+	bad := pushRichText(handler, whID, "wrong-token", map[string]interface{}{"content": "hi"})
+	require.Equal(t, http.StatusUnauthorized, bad.Code)
+
+	// 给异步留点时间，随后 deliveries 必须仍为空（鉴权失败不记审计）。
+	time.Sleep(300 * time.Millisecond)
+	w := do(handler, authReq("GET", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s/deliveries", groupNo, whID), nil))
+	require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	list, _ := parseJSON(t, w)["list"].([]interface{})
+	assert.Empty(t, list, "auth failures must not be recorded per-webhook (anti-enumeration)")
+}
+
+// --- 测试推送端点 ---
+
+// 非管理员不可触发测试推送。
+func TestTestPush_RequiresAdmin(t *testing.T) {
+	handler, ctx, groupNo := setupTestEnv(t)
+	whID, _ := createWebhookWithToken(t, handler, groupNo)
+	_, err := ctx.DB().UpdateBySql("UPDATE group_member SET role=0 WHERE group_no=? AND uid=?", groupNo, testutil.UID).Exec()
+	require.NoError(t, err)
+
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s/test", groupNo, whID), nil))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// 不存在的 webhook → 404。
+func TestTestPush_NotFound(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/iwh_nope/test", groupNo), nil))
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// 管理员触发测试推送通过鉴权/校验（下游投递在测试桩下可能 200 或 500，故只断言非
+// 403/404；成功时记一条 adapter=test 的投递）。
+func TestTestPush_PassesAuth(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, _ := createWebhookWithToken(t, handler, groupNo)
+
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s/test", groupNo, whID), nil))
+	assert.NotEqualf(t, http.StatusForbidden, w.Code, "admin must pass auth; body=%s", w.Body.String())
+	assert.NotEqualf(t, http.StatusNotFound, w.Code, "existing webhook must be found; body=%s", w.Body.String())
+
+	if w.Code == http.StatusOK {
+		require.Eventually(t, func() bool {
+			dw := do(handler, authReq("GET", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s/deliveries", groupNo, whID), nil))
+			if dw.Code != http.StatusOK {
+				return false
+			}
+			list, _ := parseJSON(t, dw)["list"].([]interface{})
+			for _, item := range list {
+				row, _ := item.(map[string]interface{})
+				if row["adapter"] == "test" {
+					return true
+				}
+			}
+			return false
+		}, 3*time.Second, 50*time.Millisecond, "successful test push must be recorded with adapter=test")
+	}
+}
+
+// --- text 别名 ---
+
+// 缺省 msg_type 下 {"text":"..."} 作为 content 别名通过校验（非 400）。
+func TestPush_TextAlias(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	w := pushRichText(handler, whID, token, map[string]interface{}{"text": "hello via alias"})
+	assert.NotEqualf(t, http.StatusBadRequest, w.Code, "text alias must satisfy content; body=%s", w.Body.String())
+	assert.NotEqualf(t, http.StatusUnauthorized, w.Code, "valid token must authorize; body=%s", w.Body.String())
+}

--- a/modules/incomingwebhook/observability_test.go
+++ b/modules/incomingwebhook/observability_test.go
@@ -34,6 +34,8 @@ func TestDeliveries_Endpoint(t *testing.T) {
 	w := do(handler, authReq("GET", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s/deliveries", groupNo, whID), nil))
 	require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
 	assert.NotContains(t, w.Body.String(), "token")
+	// 隐私取舍：deliveries 不下发调用方 IP（review 决定）。
+	assert.NotContains(t, w.Body.String(), "1.2.3.4", "deliveries must not expose caller ip")
 
 	list, _ := parseJSON(t, w)["list"].([]interface{})
 	require.Len(t, list, 2)

--- a/modules/incomingwebhook/sql/20260606000001_incomingwebhook_audit_outcome.sql
+++ b/modules/incomingwebhook/sql/20260606000001_incomingwebhook_audit_outcome.sql
@@ -1,0 +1,22 @@
+-- +migrate Up
+
+-- Phase 2 失败可观测性：审计表原本只记成功推送，发送方调试失败（限流/payload 非法/
+-- 投递失败）时是黑盒。扩展为记录「鉴权通过后」的全部投递结果（成功+失败），供管理端
+-- deliveries 端点排障。鉴权失败（未知/错 token）仍只进 IP 失败预算、不落本表，维持
+-- push 路径的反枚举不变量。
+--
+-- 目标库 MySQL 8.0：在表末尾 ADD COLUMN 走 INSTANT 算法、瞬时无锁，无需显式 pin
+-- ALGORITHM/LOCK。历史行均为成功推送：status 默认 1(成功) 即正确回填，http_status
+-- 历史值未知留 0，adapter 回填 'native'。
+ALTER TABLE `incoming_webhook_audit`
+  ADD COLUMN `status`      SMALLINT     NOT NULL DEFAULT 1        COMMENT '投递结果：1=成功,2=失败',
+  ADD COLUMN `reason`      VARCHAR(32)  NOT NULL DEFAULT ''       COMMENT '失败原因码（rate_limited/payload_invalid/too_large/delivery_failed 等）；成功为空',
+  ADD COLUMN `http_status` SMALLINT     NOT NULL DEFAULT 0        COMMENT '返回给调用方的 HTTP 状态码',
+  ADD COLUMN `adapter`     VARCHAR(16)  NOT NULL DEFAULT 'native' COMMENT '消息来源/适配器：native/test（Phase 3/4 扩展 github/gitlab/wecom/feishu）';
+
+-- +migrate Down
+ALTER TABLE `incoming_webhook_audit`
+  DROP COLUMN `status`,
+  DROP COLUMN `reason`,
+  DROP COLUMN `http_status`,
+  DROP COLUMN `adapter`;

--- a/modules/incomingwebhook/sql/20260606000001_incomingwebhook_audit_outcome.sql
+++ b/modules/incomingwebhook/sql/20260606000001_incomingwebhook_audit_outcome.sql
@@ -10,7 +10,7 @@
 -- 历史值未知留 0，adapter 回填 'native'。
 ALTER TABLE `incoming_webhook_audit`
   ADD COLUMN `status`      SMALLINT     NOT NULL DEFAULT 1        COMMENT '投递结果：1=成功,2=失败',
-  ADD COLUMN `reason`      VARCHAR(32)  NOT NULL DEFAULT ''       COMMENT '失败原因码（rate_limited/payload_invalid/too_large/delivery_failed 等）；成功为空',
+  ADD COLUMN `reason`      VARCHAR(32)  NOT NULL DEFAULT ''       COMMENT '失败原因码（body/json/content/blocks/msg_type/too_large/delivery_failed）；成功为空。限流429不入审计',
   ADD COLUMN `http_status` SMALLINT     NOT NULL DEFAULT 0        COMMENT '返回给调用方的 HTTP 状态码',
   ADD COLUMN `adapter`     VARCHAR(16)  NOT NULL DEFAULT 'native' COMMENT '消息来源/适配器：native/test（Phase 3/4 扩展 github/gitlab/wecom/feishu）';
 

--- a/modules/incomingwebhook/sql/20260606000001_incomingwebhook_audit_outcome.sql
+++ b/modules/incomingwebhook/sql/20260606000001_incomingwebhook_audit_outcome.sql
@@ -11,7 +11,7 @@
 ALTER TABLE `incoming_webhook_audit`
   ADD COLUMN `status`      SMALLINT     NOT NULL DEFAULT 1        COMMENT '投递结果：1=成功,2=失败',
   ADD COLUMN `reason`      VARCHAR(32)  NOT NULL DEFAULT ''       COMMENT '失败原因码（body/json/content/blocks/msg_type/too_large/delivery_failed）；成功为空。限流429不入审计',
-  ADD COLUMN `http_status` SMALLINT     NOT NULL DEFAULT 0        COMMENT '返回给调用方的 HTTP 状态码',
+  ADD COLUMN `http_status` SMALLINT     NOT NULL DEFAULT 0        COMMENT '返回给调用方的 HTTP 状态码；0=未知（迁移前的历史成功行，刻意不伪造成 200）',
   ADD COLUMN `adapter`     VARCHAR(16)  NOT NULL DEFAULT 'native' COMMENT '消息来源/适配器：native/test（Phase 3/4 扩展 github/gitlab/wecom/feishu）';
 
 -- +migrate Down


### PR DESCRIPTION
## Background

**Phase 2** of epic #297. Make push delivery debuggable for senders and improve onboarding UX.

> ⚠️ **Base retargeted to `main` to run the full CI pipeline.** While #298 (Phase 1) is still open, this PR's diff **temporarily includes Phase 1's commits** (this branch is stacked on Phase 1). Once #298 merges into `main`, this diff automatically shrinks to Phase-2-only. **Recommended merge order: merge #298 first, then this.** To review only Phase 2's own changes, use the [compare range](https://github.com/Mininglamp-OSS/octo-server/compare/feat/incoming-webhook-richtext...feat/incoming-webhook-observability).

## Changes

**Failure observability**
- Migration: add `status`/`reason`/`http_status`/`adapter` to `incoming_webhook_audit` (MySQL 8 INSTANT add-column; historical rows default to success, `http_status=0`=unknown).
- Record every **post-authentication** delivery outcome (success + failure: `body`/`json`/`content`/`blocks`/`msg_type`/`too_large`/`delivery_failed`), reusing the existing bounded async `auditSem`; `reason`/`http_status` mirror the push response.
- **Anti-enumeration invariant preserved**: pre-auth failures (unknown/bad token, disbanded group) are NOT recorded — they only spend the IP failure budget.
- **Rate-limit 429 is intentionally NOT audited**: it is naturally high-frequency, so per-request recording would amplify DB writes and defeat the limiter's cheap load-shedding; the info is already conveyed by the 429 + rate-limit headers.

**Management UX**
- `GET .../:webhook_id/deliveries?limit=50` — recent deliveries (success + failure), admin-only read, max 100, never returns token, `id` secondary sort for deterministic recency. Does **not** expose caller `ip` (privacy).
- `POST .../:webhook_id/test` — admin one-click test push (recorded as `adapter=test`, does **not** bump `call_count`; message localized via i18n; failures also audited).
- Native push accepts `text` as an alias for `content` (migration-friendly).

## Testing (TDD)

- Synchronous DB unit test `TestInsertAndQueryAudit`: audit insert + `queryRecentAudits` + limit (deterministic assertions).
- e2e `observability_test.go` (CI): deliveries endpoint / auth / 404, **async failure recording** (`require.Eventually`), anti-enumeration not-recorded, test-push auth / 404, text alias, ip-not-exposed.

## Review follow-ups applied

Includes a self-review `refactor` commit (drop rate_limited auditing, test push excluded from `call_count`, deliveries `id` secondary sort) and a maintainer-review `refactor` commit (drop caller-ip from deliveries, i18n the test-push message, audit failed test pushes, document `http_status=0` legacy rows).

## Checks

`go build` / `go vet` / `gofmt` / unit tests / guard / `make i18n-lint` / `make i18n-extract-check` all pass. DB/e2e run in CI.

Refs #297

https://claude.ai/code/session_011kXG9RmQcEvmEp5ZZcPA9y