### PR TITLE
fix(group): unsubscribe removed members from all non-deleted thread channels (#27)

### DIFF
--- a/modules/botfather/command.go
+++ b/modules/botfather/command.go
@@ -660,6 +660,9 @@ func (h *commandHandler) onDeleteConfirm(fromUID string, input string) {
 			if err != nil {
 				h.Error("从IM频道移除Bot失败", zap.String("groupNo", g.GroupNo), zap.Error(err))
 			}
+			// Issue #27：父群订阅之外，还要对齐摘除该 Bot 在群内所有非删除子区的 IM 订阅，
+			// 否则被删除的 Bot 仍会通过 WuKongIM 持续收到子区消息。
+			h.groupService.RemoveUserFromGroupThreads(g.GroupNo, botID, g.SpaceID)
 		}
 	}
 

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -3039,50 +3039,11 @@ func (g *Group) groupExit(c *wkhttp.Context) {
 
 }
 
-// removeUserFromGroupThreads 移除用户在某群下所有子区的成员记录、IM 订阅和置顶
+// removeUserFromGroupThreads 移除用户在某群下所有子区的成员记录、IM 订阅和置顶。
+// 委托给包级 removeUserFromGroupThreadsCleanup（见 thread_cleanup.go，Issue #27），
+// 保留方法签名以最小化调用方改动。
 func (g *Group) removeUserFromGroupThreads(groupNo, uid, spaceID string) {
-	// 查询用户在该群加入的所有子区（shortID 用于构建 IM channelID）
-	type threadInfo struct {
-		ShortID string `db:"short_id"`
-	}
-	var threads []threadInfo
-	_, err := g.db.session.Select("thread.short_id").
-		From("thread").
-		Join("thread_member", "thread.id = thread_member.thread_id").
-		Where("thread.group_no=? AND thread_member.uid=? AND thread.status!=3", groupNo, uid).
-		Load(&threads)
-	if err != nil {
-		g.Error("查询用户子区失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("uid", uid))
-		return
-	}
-	if len(threads) == 0 {
-		return
-	}
-
-	// 删除成员记录
-	_, err = g.db.session.DeleteFrom("thread_member").
-		Where("uid=? AND thread_id IN (SELECT id FROM thread WHERE group_no=?)", uid, groupNo).
-		Exec()
-	if err != nil {
-		g.Error("删除子区成员失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("uid", uid))
-		return
-	}
-
-	// 移除 IM 订阅和置顶
-	for _, t := range threads {
-		// 子区 channelID 格式: {groupNo}____{shortID} (与 thread.BuildChannelID 一致)
-		channelID := groupNo + "____" + t.ShortID
-		if rmErr := g.ctx.IMRemoveSubscriber(&config.SubscriberRemoveReq{
-			ChannelID:   channelID,
-			ChannelType: common.ChannelTypeCommunityTopic.Uint8(),
-			Subscribers: []string{uid},
-		}); rmErr != nil {
-			g.Error("移除子区IM订阅者失败", zap.Error(rmErr), zap.String("channelID", channelID), zap.String("uid", uid))
-		}
-		// 清理用户在该子区的置顶
-		user.RemovePinnedForUserInSpace(uid, spaceID, channelID, common.ChannelTypeCommunityTopic.Uint8())
-		conversation_ext.RemoveConvExtForUserInSpace(uid, spaceID, channelID, common.ChannelTypeCommunityTopic.Uint8())
-	}
+	removeUserFromGroupThreadsCleanup(g.ctx, g.Log, groupNo, uid, spaceID)
 }
 
 // addUsersToGroupThreads 新成员入群时，将其加入该群所有子区的 IM 订阅（允许发消息）

--- a/modules/group/e2e_issue27_wukong_test.go
+++ b/modules/group/e2e_issue27_wukong_test.go
@@ -1,0 +1,96 @@
+//go:build wukong_e2e
+
+// End-to-end verification for Issue #27 against a live WuKongIM (channel_type=5,
+// 子区/CommunityTopic). Opt-in only — excluded from normal `go test` by the
+// `wukong_e2e` build tag so it never burdens CI (WuKongIM message-delivery
+// semantics are version-coupled; see PR #300 review discussion).
+//
+// Run (requires the CI-equivalent stack: MySQL+Redis+WuKongIM on default ports,
+// OCTO_MASTER_KEY set, `test` DB as utf8mb4_general_ci):
+//
+//	go test -tags wukong_e2e ./modules/group/ -run TestE2E_Issue27 -v -count=1
+//
+// What it proves, through the REAL fixed code path:
+//  1. A bot subscribed to a thread channel (as addUsersToGroupThreads does on
+//     join) actually RECEIVES messages pushed to that channel — the #27 leak.
+//  2. After removeUserFromGroupThreadsCleanup (the fix) runs for that bot —
+//     even though the bot has NO thread_member row (the exact #27 scenario the
+//     old JOIN query skipped) — the bot STOPS receiving thread messages at the
+//     WuKongIM layer, while a still-subscribed user keeps receiving.
+package group
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestE2E_Issue27_RemovedBotStopsReceivingThreadMessages(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	f := New(ctx)
+	ensureThreadTables(t, f)
+
+	const (
+		groupNo = "e2e_g27"
+		shortID = "e2eth01"
+		spaceID = "e2e_space"
+		botUID  = "e2e_bot"   // 入群但从不 JoinThread —— #27 的典型 bot
+		usrUID  = "e2e_user"  // 普通成员，对照组
+		sender  = "e2e_sender"
+	)
+	channelID := groupNo + "____" + shortID
+	ct := common.ChannelTypeCommunityTopic.Uint8() // == 5
+
+	// 入群时挂订阅（与 addUsersToGroupThreads 一致：bot 和 user 都订阅，无 thread_member）
+	require.NoError(t, ctx.IMAddSubscriber(&config.SubscriberAddReq{
+		ChannelID: channelID, ChannelType: ct, Subscribers: []string{botUID, usrUID},
+	}))
+
+	// seed 一个 active 子区，但故意不给 bot 建 thread_member 行（#27 场景）
+	_, err := ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values(shortID, groupNo, "e2e-sub", "owner", 1, 1).Exec()
+	require.NoError(t, err)
+
+	sendToThread := func(content string) {
+		require.NoError(t, ctx.SendMessage(&config.MsgSendReq{
+			Header:      config.MsgHeader{RedDot: 1},
+			FromUID:     sender,
+			ChannelID:   channelID,
+			ChannelType: ct,
+			Payload:     []byte(`{"type":1,"content":"` + content + `"}`),
+		}))
+	}
+	hasChannel := func(uid string) bool {
+		convs, serr := ctx.IMSyncUserConversation(uid, 0, 50, "", nil)
+		require.NoError(t, serr)
+		for _, c := range convs {
+			if c.ChannelID == channelID && c.ChannelType == ct {
+				return true
+			}
+		}
+		return false
+	}
+
+	// --- 1. 移除前：bot 是订阅者，应收到子区消息 ---
+	sendToThread("before-remove")
+	time.Sleep(800 * time.Millisecond)
+	require.True(t, hasChannel(botUID), "前置：未移除时 bot 应通过 WuKongIM 收到子区消息（#27 泄漏面）")
+	require.True(t, hasChannel(usrUID), "前置：普通成员应收到")
+
+	// --- 2. 跑修复后的真实 helper（bot 无 thread_member 行，旧 JOIN 查询会直接跳过）---
+	removeUserFromGroupThreadsCleanup(ctx, f.Log, groupNo, botUID, spaceID)
+
+	// --- 3. 移除后：再发一条，bot 不应再收到；user 仍订阅、继续收到 ---
+	sendToThread("after-remove")
+	time.Sleep(800 * time.Millisecond)
+	require.False(t, hasChannel(botUID),
+		"修复生效：removeUserFromGroupThreadsCleanup 后被移除的 bot 必须不再收到子区消息（Issue #27）")
+	require.True(t, hasChannel(usrUID),
+		"对照：仍在订阅的成员必须继续收到，证明摘订阅是精确按 uid 的")
+}

--- a/modules/group/event.go
+++ b/modules/group/event.go
@@ -739,10 +739,12 @@ func (g *Group) handleOrgEmployeeExit(data []byte, commit config.EventCommit) {
 		return
 	}
 	realGroups := make([]string, 0)
+	spaceIDByGroupNo := make(map[string]string, len(groups))
 	for _, groupNo := range req.GroupNos {
 		for _, group := range groups {
 			if groupNo == group.GroupNo {
 				realGroups = append(realGroups, groupNo)
+				spaceIDByGroupNo[groupNo] = group.SpaceID
 				break
 			}
 		}
@@ -805,6 +807,9 @@ func (g *Group) handleOrgEmployeeExit(data []byte, commit config.EventCommit) {
 			commit(err)
 			return
 		}
+		// Issue #27 同型：组织退出也必须摘除该用户在群内所有非删除子区的
+		// IM 订阅，与踢人/退群路径对齐（helper 为 best-effort，失败只记日志）。
+		g.removeUserFromGroupThreads(groupNo, req.Operator, spaceIDByGroupNo[groupNo])
 		// 发送群成员更新命令
 		err = g.ctx.SendCMD(config.MsgCMDReq{
 			ChannelID:   groupNo,

--- a/modules/group/event_orgexit_thread_test.go
+++ b/modules/group/event_orgexit_thread_test.go
@@ -1,0 +1,83 @@
+package group
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleOrgEmployeeExit_AlsoCleansThreads 回归 Issue #27 同型缺口：
+// 组织/部门同步退出（handleOrgEmployeeExit）原本只删 group_member + 摘父群
+// IM 订阅，从不清理子区 —— 与踢人/退群路径不对称，组织驱动的移除会持续
+// 泄漏子区订阅。修复后该 handler 对每个群调用 removeUserFromGroupThreads。
+//
+// 与 cascade 测试同款 DB-level 断言：直查 thread_member 证明子区清理被执行
+// （IM 订阅摘除本身由 thread_cleanup 的单测和共享 helper 保证）。
+func TestHandleOrgEmployeeExit_AlsoCleansThreads(t *testing.T) {
+	svc, userDB := setupServiceTest(t)
+	s := svc.(*Service)
+	f := New(s.ctx)
+	ensureThreadTables(t, f)
+
+	insertTestUsers(t, userDB, "org_owner", "org_leaver")
+
+	spaceID := "space_orgexit"
+	groupNo := "g_orgexit_thread"
+	require.NoError(t, f.db.Insert(&Model{
+		GroupNo: groupNo,
+		Name:    "orgexit-thread",
+		Creator: "org_owner",
+		SpaceID: spaceID,
+		Status:  1,
+	}))
+	require.NoError(t, f.db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: "org_owner", Role: MemberRoleCreator,
+		Status: 1, Version: 1, Vercode: fmt.Sprintf("%s@1", util.GenerUUID()),
+	}))
+	require.NoError(t, f.db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: "org_leaver", Role: MemberRoleCommon,
+		Status: 1, Version: 1, Vercode: fmt.Sprintf("%s@1", util.GenerUUID()),
+	}))
+
+	// 子区 + leaver 的 thread_member 行（DB 可见的清理证据）
+	res, err := f.ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("orgexit_thread", groupNo, "orgexit-sub", "org_owner", 1, 1).Exec()
+	require.NoError(t, err)
+	threadID, err := res.LastInsertId()
+	require.NoError(t, err)
+	_, err = f.ctx.DB().InsertInto("thread_member").
+		Columns("thread_id", "uid", "role", "version").
+		Values(threadID, "org_leaver", 0, 1).Exec()
+	require.NoError(t, err)
+
+	// 触发组织退出事件 handler
+	payload := config.OrgEmployeeExitReq{
+		Operator: "org_leaver",
+		GroupNos: []string{groupNo},
+	}
+	var commitErr error
+	committed := false
+	f.handleOrgEmployeeExit([]byte(util.ToJson(payload)), func(err error) {
+		committed = true
+		commitErr = err
+	})
+	require.True(t, committed, "handler 必须调用 commit")
+	require.NoError(t, commitErr, "组织退出事件处理不应报错")
+
+	// 核心断言：子区成员记录已被清理（修复前 handler 不会触达 thread_member）
+	var postCount int
+	_, err = f.ctx.DB().Select("count(*)").From("thread_member").
+		Where("thread_id=? AND uid=?", threadID, "org_leaver").Load(&postCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, postCount, "组织退出必须同步清理子区成员/订阅（Issue #27 同型）")
+
+	// 旁证：群成员已删除，原有语义未回归
+	existInGroup, err := f.db.ExistMember("org_leaver", groupNo)
+	require.NoError(t, err)
+	assert.False(t, existInGroup, "组织退出必须删除 group_member")
+}

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -107,6 +107,9 @@ type IService interface {
 	AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMembersServiceResp, error)
 	// RemoveGroupMembers 移除群成员
 	RemoveGroupMembers(req *RemoveGroupMembersServiceReq) (*RemoveGroupMembersServiceResp, error)
+	// RemoveUserFromGroupThreads 清理某用户在某群所有子区的 thread_member 记录、IM 订阅和置顶。
+	// 供 botfather 删除 Bot 等“父群成员已移除、需对齐摘除子区订阅”的外部路径调用（Issue #27）。
+	RemoveUserFromGroupThreads(groupNo, uid, spaceID string)
 	// UpdateGroupInfo 更新群信息
 	UpdateGroupInfo(req *UpdateGroupInfoServiceReq) error
 }
@@ -1847,48 +1850,15 @@ func beginAvatarUpdateEvent(ctx *config.Context, db *DB, groupNo string, memberU
 	return eventID, nil
 }
 
-// removeUserFromGroupThreads 移除用户在某群下所有子区的成员记录、IM 订阅和置顶（直接 SQL）
+// removeUserFromGroupThreads 移除用户在某群下所有子区的成员记录、IM 订阅和置顶。
+// 委托给包级 removeUserFromGroupThreadsCleanup（见 thread_cleanup.go，Issue #27）。
 func (s *Service) removeUserFromGroupThreads(groupNo, uid, spaceID string) {
-	type threadInfo struct {
-		ShortID string `db:"short_id"`
-	}
-	var threads []threadInfo
-	_, err := s.ctx.DB().Select("thread.short_id").
-		From("thread").
-		Join("thread_member", "thread.id = thread_member.thread_id").
-		Where("thread.group_no=? AND thread_member.uid=? AND thread.status!=3", groupNo, uid).
-		Load(&threads)
-	if err != nil {
-		s.Error("query user threads failed", zap.Error(err), zap.String("groupNo", groupNo), zap.String("uid", uid))
-		return
-	}
-	if len(threads) == 0 {
-		return
-	}
+	removeUserFromGroupThreadsCleanup(s.ctx, s.Log, groupNo, uid, spaceID)
+}
 
-	// 删除成员记录
-	_, err = s.ctx.DB().DeleteFrom("thread_member").
-		Where("uid=? AND thread_id IN (SELECT id FROM thread WHERE group_no=?)", uid, groupNo).
-		Exec()
-	if err != nil {
-		s.Error("delete thread member failed", zap.Error(err), zap.String("groupNo", groupNo), zap.String("uid", uid))
-		return
-	}
-
-	// 移除 IM 订阅和置顶
-	for _, t := range threads {
-		channelID := groupNo + "____" + t.ShortID
-		if rmErr := s.ctx.IMRemoveSubscriber(&config.SubscriberRemoveReq{
-			ChannelID:   channelID,
-			ChannelType: common.ChannelTypeCommunityTopic.Uint8(),
-			Subscribers: []string{uid},
-		}); rmErr != nil {
-			s.Error("remove thread IM subscriber failed", zap.Error(rmErr), zap.String("channelID", channelID), zap.String("uid", uid))
-		}
-		// 清理用户在该子区的置顶
-		user.RemovePinnedForUserInSpace(uid, spaceID, channelID, common.ChannelTypeCommunityTopic.Uint8())
-		conversation_ext.RemoveConvExtForUserInSpace(uid, spaceID, channelID, common.ChannelTypeCommunityTopic.Uint8())
-	}
+// RemoveUserFromGroupThreads 导出版，供其他模块（botfather）对齐摘除子区订阅，见接口注释。
+func (s *Service) RemoveUserFromGroupThreads(groupNo, uid, spaceID string) {
+	s.removeUserFromGroupThreads(groupNo, uid, spaceID)
 }
 
 // addUsersToGroupThreads 新成员入群时，将其加入该群所有子区的 IM 订阅（直接 SQL）

--- a/modules/group/thread_cleanup.go
+++ b/modules/group/thread_cleanup.go
@@ -1,0 +1,84 @@
+package group
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"go.uber.org/zap"
+)
+
+// queryThreadShortIDsForCleanup 返回某群下所有需要在“成员被踢/退群”时摘除 IM 订阅的子区
+// short_id（active + archived，排除 deleted）。
+//
+// Issue #27：旧实现把 thread JOIN thread_member 过滤，导致没主动 JoinThread 的成员（典型
+// 就是 Bot）查不到子区 → IMRemoveSubscriber 不被调用 → Bot 被踢后仍订阅子区频道并通过
+// WuKongIM WebSocket 持续收子区消息。子区频道的 IM 订阅本就是入群时按“父群成员”批量挂上
+// 的（参考 addUsersToGroupThreads，WHERE status!=3），出群必须对称地按“父群所有非删除子区”
+// 摘订阅。archived（status=2）子区可被 UnarchiveThread 重新激活，因此也必须摘除；只有
+// deleted（status=3）子区的 IM 频道已销毁，排除。
+func queryThreadShortIDsForCleanup(ctx *config.Context, groupNo string) ([]string, error) {
+	if groupNo == "" {
+		return nil, nil
+	}
+	type row struct {
+		ShortID string `db:"short_id"`
+	}
+	var rows []row
+	_, err := ctx.DB().Select("short_id").
+		From("thread").
+		Where("group_no=? AND status!=3", groupNo).
+		Load(&rows)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r.ShortID)
+	}
+	return out, nil
+}
+
+// removeUserFromGroupThreadsCleanup 是被踢/退群路径上“清理某用户在某群所有子区的 thread_member
+// 记录、IM 订阅和置顶”的统一入口。原本 (*Group).removeUserFromGroupThreads 与
+// (*Service).removeUserFromGroupThreads 是两份逐字重复的实现且各自带 Issue #27 的同型 bug；
+// 这里合并到一处，避免下次再“修一处漏一处”。
+//
+// 失败只记日志、不中断（与原行为一致）。logger 由调用方传入以保留各自的 module 标签。
+func removeUserFromGroupThreadsCleanup(ctx *config.Context, logger log.Log, groupNo, uid, spaceID string) {
+	if groupNo == "" || uid == "" {
+		return
+	}
+	shortIDs, err := queryThreadShortIDsForCleanup(ctx, groupNo)
+	if err != nil {
+		logger.Error("查询群子区失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("uid", uid))
+		return
+	}
+	if len(shortIDs) == 0 {
+		return
+	}
+
+	// best-effort 删除 thread_member 行：DELETE 按 uid 过滤，没有匹配行也是 0 rows affected。
+	// 即使删除失败也要继续摘 IM 订阅 —— 不能让 DB 异常导致订阅泄漏。
+	if _, err := ctx.DB().DeleteFrom("thread_member").
+		Where("uid=? AND thread_id IN (SELECT id FROM thread WHERE group_no=?)", uid, groupNo).
+		Exec(); err != nil {
+		logger.Error("删除子区成员记录失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("uid", uid))
+	}
+
+	for _, shortID := range shortIDs {
+		// 子区 channelID 格式: {groupNo}____{shortID} (与 thread.BuildChannelID 一致)
+		channelID := groupNo + "____" + shortID
+		if rmErr := ctx.IMRemoveSubscriber(&config.SubscriberRemoveReq{
+			ChannelID:   channelID,
+			ChannelType: common.ChannelTypeCommunityTopic.Uint8(),
+			Subscribers: []string{uid},
+		}); rmErr != nil {
+			logger.Error("移除子区IM订阅者失败", zap.Error(rmErr), zap.String("channelID", channelID), zap.String("uid", uid))
+		}
+		// 清理用户在该子区的置顶 / 会话扩展
+		user.RemovePinnedForUserInSpace(uid, spaceID, channelID, common.ChannelTypeCommunityTopic.Uint8())
+		conversation_ext.RemoveConvExtForUserInSpace(uid, spaceID, channelID, common.ChannelTypeCommunityTopic.Uint8())
+	}
+}

--- a/modules/group/thread_cleanup_test.go
+++ b/modules/group/thread_cleanup_test.go
@@ -1,0 +1,154 @@
+package group
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestQueryThreadShortIDsForCleanup_ReturnsAllNonDeletedRegardlessOfMembership
+// 是 Issue #27 的核心回归：群下有 active+archived 子区，但 uid 从未出现在 thread_member
+// 表里（Bot 入群后不会主动 JoinThread 的常见情况）。修复前 SQL 用 JOIN thread_member
+// 过滤导致返回空切片，IMRemoveSubscriber 永不被调用 → Bot 被踢后仍订阅子区频道。
+// 修复后应返回该群所有非 deleted 子区的 short_id。
+func TestQueryThreadShortIDsForCleanup_ReturnsAllNonDeletedRegardlessOfMembership(t *testing.T) {
+	svc, _ := setupServiceTest(t)
+	f := New(svc.(*Service).ctx)
+	ensureThreadTables(t, f)
+
+	const groupNo = "g_issue27_basic"
+	// active (status=1)
+	_, err := f.ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("th_active", groupNo, "active", "owner", 1, 1).Exec()
+	require.NoError(t, err)
+	// archived (status=2) —— 可被 UnarchiveThread 重激活，不能漏摘订阅
+	_, err = f.ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("th_archived", groupNo, "archived", "owner", 2, 1).Exec()
+	require.NoError(t, err)
+	// deleted (status=3) —— 必须排除（IM 频道已销毁）
+	_, err = f.ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("th_deleted", groupNo, "deleted", "owner", 3, 1).Exec()
+	require.NoError(t, err)
+	// 另一个群下的子区，不应被返回
+	_, err = f.ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("th_other_group", "g_other", "other", "owner", 1, 1).Exec()
+	require.NoError(t, err)
+
+	// 关键：不插入任何 thread_member 行 —— 模拟 Bot 入群后未 JoinThread
+	shortIDs, err := queryThreadShortIDsForCleanup(f.ctx, groupNo)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"th_active", "th_archived"}, shortIDs,
+		"必须返回所有非 deleted 子区，不能依赖 thread_member（Issue #27）")
+}
+
+// TestQueryThreadShortIDsForCleanup_EmptyGroupNo 防御：空 group_no 直接返回空。
+func TestQueryThreadShortIDsForCleanup_EmptyGroupNo(t *testing.T) {
+	svc, _ := setupServiceTest(t)
+	f := New(svc.(*Service).ctx)
+	ensureThreadTables(t, f)
+
+	shortIDs, err := queryThreadShortIDsForCleanup(f.ctx, "")
+	require.NoError(t, err)
+	assert.Empty(t, shortIDs)
+}
+
+// TestQueryThreadShortIDsForCleanup_NoThreads 群下没子区 → 空切片。
+func TestQueryThreadShortIDsForCleanup_NoThreads(t *testing.T) {
+	svc, _ := setupServiceTest(t)
+	f := New(svc.(*Service).ctx)
+	ensureThreadTables(t, f)
+
+	shortIDs, err := queryThreadShortIDsForCleanup(f.ctx, "g_nothreads")
+	require.NoError(t, err)
+	assert.Empty(t, shortIDs)
+}
+
+// TestQueryThreadShortIDsForCleanup_OnlyDeleted 群下只有已删除子区 → 空切片。
+// 保证已删除子区永不被回流为 IMRemoveSubscriber 调用对象。
+func TestQueryThreadShortIDsForCleanup_OnlyDeleted(t *testing.T) {
+	svc, _ := setupServiceTest(t)
+	f := New(svc.(*Service).ctx)
+	ensureThreadTables(t, f)
+
+	const groupNo = "g_only_deleted"
+	_, err := f.ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("th_dead", groupNo, "dead", "owner", 3, 1).Exec()
+	require.NoError(t, err)
+
+	shortIDs, err := queryThreadShortIDsForCleanup(f.ctx, groupNo)
+	require.NoError(t, err)
+	assert.Empty(t, shortIDs)
+}
+
+// TestRemoveUserFromGroupThreadsCleanup_DeletesMemberWithoutOwnRow 验证修复的端到端行为：
+// 即便目标 uid 在 thread_member 没有任何行（Bot 场景），cleanup 也要走完整个流程而不是
+// 提前 return —— 这是和旧实现最关键的差异。这里用一个“别人 join 了、target 没 join”的
+// 子区，断言 cleanup 不会因为 target 没有 thread_member 行而跳过，且 target 自己后来
+// 误留的行（如有）会被清掉，别人的行不受影响。
+func TestRemoveUserFromGroupThreadsCleanup_DeletesMemberWithoutOwnRow(t *testing.T) {
+	svc, _ := setupServiceTest(t)
+	s := svc.(*Service)
+	f := New(s.ctx)
+	ensureThreadTables(t, f)
+
+	const groupNo = "g_issue27_e2e"
+	const targetUID = "bot_no_join"
+	res, err := f.ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("th_e2e", groupNo, "e2e", "owner", 1, 1).Exec()
+	require.NoError(t, err)
+	threadID, err := res.LastInsertId()
+	require.NoError(t, err)
+
+	// 一个无关用户在子区里有 thread_member 行 —— cleanup target 时不能误删
+	_, err = f.ctx.DB().InsertInto("thread_member").
+		Columns("thread_id", "uid", "role", "version").
+		Values(threadID, "someone_else", 0, 1).Exec()
+	require.NoError(t, err)
+
+	// target 自己没有 thread_member 行：旧实现会 JOIN 出 0 行直接 return，新实现必须照常处理。
+	// IMRemoveSubscriber 在无 IM 服务的测试环境里只记日志、不影响 DELETE 路径与断言。
+	s.removeUserFromGroupThreads(groupNo, targetUID, "sp_e2e")
+
+	// 无关用户的 thread_member 行仍在
+	var otherCount int
+	_, err = f.ctx.DB().Select("count(*)").From("thread_member").
+		Where("thread_id=? AND uid=?", threadID, "someone_else").Load(&otherCount)
+	require.NoError(t, err)
+	assert.Equal(t, 1, otherCount, "cleanup 只能按 uid 删除，不能波及其他用户的 thread_member")
+}
+
+// TestRemoveUserFromGroupThreadsCleanup_EmptyInputs 验证 uid/groupNo 防御守卫：
+// 空 uid 或空 groupNo 时直接 no-op，绝不下发任何 SQL/IM 调用。
+func TestRemoveUserFromGroupThreadsCleanup_EmptyInputs(t *testing.T) {
+	svc, _ := setupServiceTest(t)
+	s := svc.(*Service)
+	f := New(s.ctx)
+	ensureThreadTables(t, f)
+
+	res, err := f.ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("th_guard", "g_guard", "guard", "owner", 1, 1).Exec()
+	require.NoError(t, err)
+	threadID, err := res.LastInsertId()
+	require.NoError(t, err)
+	_, err = f.ctx.DB().InsertInto("thread_member").
+		Columns("thread_id", "uid", "role", "version").
+		Values(threadID, "u", 0, 1).Exec()
+	require.NoError(t, err)
+
+	removeUserFromGroupThreadsCleanup(s.ctx, s.Log, "", "u", "sp")
+	removeUserFromGroupThreadsCleanup(s.ctx, s.Log, "g_guard", "", "sp")
+
+	var count int
+	_, err = f.ctx.DB().Select("count(*)").From("thread_member").
+		Where("thread_id=? AND uid=?", threadID, "u").Load(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "空参数时 helper 必须立即返回、不下发 DELETE/IMRemoveSubscriber")
+}


### PR DESCRIPTION
Refs #27.

> Linkage kept as **Refs**, not **Closes**: the code-level asymmetry is `bug-verified`, but the
> end-to-end symptom ("removed bot keeps receiving thread pushes") still carries `needs-human-verify`
> — it depends on whether WuKongIM gates pushes server-side on membership, which can't be settled from
> octo-server source. This PR is the symmetry fix + de-dupe; flip to `Closes` once the WuKongIM
> `channel/subscribers` before/after evidence lands.

## Summary

When a member (typically a bot) is removed from a group, the parent group channel was correctly
unsubscribed from WuKongIM but **thread (子区) channel subscriptions were leaked**. The removed member
therefore kept receiving every thread message over its WuKongIM WebSocket connection — and any bot
using that stream re-emitted them as DMs back to the user, looking like the bot was spying after removal.

## Root cause

`removeUserFromGroupThreads` (duplicated verbatim in `modules/group/api.go` and `modules/group/service.go`)
listed threads via:

```sql
SELECT thread.short_id
FROM thread
JOIN thread_member ON thread.id = thread_member.thread_id
WHERE thread.group_no=? AND thread_member.uid=? AND thread.status!=3
```

The `JOIN thread_member` returns zero rows for any member who never actively called `JoinThread` — the
default for bots, and for any non-bot member who never opened a specific thread. With zero rows the helper
returned early before `IMRemoveSubscriber`, so all thread channels stayed subscribed.

The mirror path is asymmetric: `addUsersToGroupThreads` subscribes a new member to **every** thread
`WHERE group_no=? AND status!=3` (active + archived), regardless of `thread_member`. The remove path must match.

## What changed

- **New `modules/group/thread_cleanup.go`** — single source of truth:
  - `queryThreadShortIDsForCleanup(ctx, groupNo)` returns all non-deleted thread short_ids. Archived
    (`status=2`) threads are included because they can be reactivated via `UnarchiveThread`; only deleted
    (`status=3`) are excluded.
  - `removeUserFromGroupThreadsCleanup(ctx, logger, groupNo, uid, spaceID)` — list threads → best-effort
    `DELETE thread_member` (no longer gates the loop on row count) → `IMRemoveSubscriber` + pinned +
    conversation_ext cleanup per thread.
- `(*Group).removeUserFromGroupThreads` and `(*Service).removeUserFromGroupThreads` now delegate to the
  shared helper, so the bug cannot regress in one copy only.
- **Aligned the BotFather bot-delete path**: exported `RemoveUserFromGroupThreads` on `group.IService`
  and call it from `modules/botfather/command.go` after the per-group parent-channel `IMRemoveSubscriber`,
  so a deleted bot is also removed from all thread channels (item 3 in the issue's suggested fix).
- Tests in `modules/group/thread_cleanup_test.go` covering: the Issue #27 reproducer (no `thread_member`
  row), archived inclusion, deleted exclusion, cross-group isolation, the no-own-row delete path, and
  empty-input guards.

Behavior change is intentional and surgical: only the thread-channel cleanup is widened to match the
addition path. Parent-channel cleanup and the cascade flows are unchanged. Note this keeps the existing
`conversation_ext.RemoveConvExtForUserInSpace` cleanup (the prior closed PR #28 had dropped it, which would
have been a regression).

## Verification

Ran against the CI-equivalent stack (MySQL 8.0 / Redis 7 / WuKongIM v2.2.4, `OCTO_MASTER_KEY` set,
`test` DB created `utf8mb4_general_ci`):

```
ok  github.com/Mininglamp-OSS/octo-server/modules/group      25.9s   # full package, incl. new #27 tests
ok  github.com/Mininglamp-OSS/octo-server/modules/botfather  17.9s   # full package, incl. delete-bot path
```

New tests, all PASS:
- `TestQueryThreadShortIDsForCleanup_ReturnsAllNonDeletedRegardlessOfMembership` — the direct #27 reproducer
- `TestQueryThreadShortIDsForCleanup_EmptyGroupNo` / `_NoThreads` / `_OnlyDeleted`
- `TestRemoveUserFromGroupThreadsCleanup_DeletesMemberWithoutOwnRow` / `_EmptyInputs`

Existing regressions intact: `TestGroupExit_CascadeBot_AlsoRemovesFromThread`,
`TestRemoveGroupMembers_CascadeRemovesInvitedBots`, `TestDeleteBotCleansUpGroupMembers`.

`go build ./...` and `go vet` clean.

## Out of scope (noted in #27)

- `modules/robot/event.go` `robotMessageListen` group-message dispatch has no group-membership check;
  affects bots polling `/v1/bot/events`, a separate route — worth a separate issue.
- The end-to-end "stale subscriber actually receives a push" question (`needs-human-verify`) needs a
  WuKongIM-attached environment to check `channel/subscribers` for `{groupNo}____{shortID}` before/after a kick.

https://claude.ai/code/session_01LLe3uvs1ZGkUkLexYm4Mo7

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLe3uvs1ZGkUkLexYm4Mo7)_