### PR TITLE
fix(botfather): always generate lowercase bot IDs (Fixes #302)

### DIFF
--- a/modules/botfather/command.go
+++ b/modules/botfather/command.go
@@ -979,9 +979,15 @@ func (h *commandHandler) sendCreatedPrompt(toUID string, name string, bot *robot
 
 // generateBotID 生成全局唯一的 Bot 标识符
 // 时间戳 Base62 + 4字节随机 hex，即使并发同纳秒也不会碰撞
+//
+// Lowercase the full returned ID so newly-generated bot IDs are case-insensitive-safe
+// against OpenClaw's normalizeOptionalLowercaseString routing layer. randomHex and
+// BotUsernameSuffix are already lowercase today; wrapping the whole concatenation
+// defends against future charset drift in either component.
+// See: octo-server#302, openclaw-channel-octo#33
 func generateBotID() string {
 	suffix, _ := randomHex(4)
-	return util.Ten2Hex(time.Now().UnixNano()) + suffix + BotUsernameSuffix
+	return strings.ToLower(util.Ten2Hex(time.Now().UnixNano()) + suffix + BotUsernameSuffix)
 }
 
 func (h *commandHandler) getBotDisplayName(robotID string) string {

--- a/modules/botfather/const_test.go
+++ b/modules/botfather/const_test.go
@@ -257,6 +257,25 @@ func TestGenerateBotID(t *testing.T) {
 	assert.NotEqual(t, id1, id2)
 }
 
+// TestGenerateBotID_AlwaysLowercase asserts the lowercase invariant on every
+// generated bot ID. util.Ten2Hex is Base62 (charset 0-9 + a-z + A-Z); its
+// uppercase half hits ~50% of timestamp chars, so 200 samples gives near-
+// certainty if the strings.ToLower wrapper in generateBotID() is ever removed.
+//
+// Background: octo-server#302 / openclaw-channel-octo#33 — mixed-case IDs
+// silently mismatch against OpenClaw's lowercase normalize layer.
+func TestGenerateBotID_AlwaysLowercase(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		id := generateBotID()
+		if id != strings.ToLower(id) {
+			t.Fatalf("generateBotID() returned mixed-case ID: %q (iter %d)", id, i)
+		}
+		if !strings.HasSuffix(id, BotUsernameSuffix) {
+			t.Fatalf("generateBotID() missing suffix %q: %q", BotUsernameSuffix, id)
+		}
+	}
+}
+
 func TestBotNameValidation(t *testing.T) {
 	// Pure string-length validation logic — no DB / Redis / IM dependencies.
 	// 模拟 onBotNameInput 中的验证逻辑


### PR DESCRIPTION
## Summary

`generateBotID()` previously concatenated `util.Ten2Hex` (Base62 alphabet, includes uppercase `A-Z`) with a random hex suffix, so the resulting bot ID could contain uppercase characters. OpenClaw's routing layer normalizes `accountId` to lowercase before lookups, so any uppercase letter caused mismatches that surfaced downstream as silently dropped messages, broken owner checks, and duplicated per-account caches.

Wrap the final string in `strings.ToLower` so every new bot ID is lowercase — matching the existing convention used by the routing / normalize path.

## Why

Closes #302 — root cause of the mixed-case bot ID issue tracked by the plugin side at [Mininglamp-OSS/openclaw-channel-octo#33](https://github.com/Mininglamp-OSS/openclaw-channel-octo/issues/33).

## Compat

- Existing mixed-case bots in production remain functional via the case-insensitive (`utf8mb4_general_ci`) collation already in use on the `robot` table — no data migration required.
- Companion fix on the plugin side (openclaw-channel-octo#33) extends the same case-insensitivity to all in-memory caches and on-disk paths, so legacy mixed-case bots behave identically to new lowercase ones after both ship.

## Test plan

- [x] New unit test `TestGenerateBotID_AlwaysLowercase` (200 iterations) guards against regressions
- [x] Manual: `BotFather` `/newbot` flow on local `octo-server` (this branch) produces an all-lowercase bot ID (`27yxelxj3n665b00457_bot`, `27yxtfsyyjyeb9be348_bot` observed during local validation)
- [x] 5 rounds of `codex` plan review (12 → 8 → 6 → 2 → 0 findings) covering DB collation verification, no-migration-required justification, and naming consistency with the existing `lower()` callsites in the routing path
