### PR TITLE
feat(opanalytics): IM operations analytics dashboard (P0)

### DIFF
--- a/internal/modules.go
+++ b/internal/modules.go
@@ -41,6 +41,7 @@ import (
 	_ "github.com/Mininglamp-OSS/octo-server/modules/message"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/notify"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/oidc"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/opanalytics"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/openapi"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/qrcode"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/report"

--- a/modules/opanalytics/1module.go
+++ b/modules/opanalytics/1module.go
@@ -10,6 +10,9 @@ import (
 //go:embed sql
 var sqlFS embed.FS
 
+//go:embed swagger/api.yaml
+var swaggerContent string
+
 func init() {
 	register.AddModule(func(ctx interface{}) register.Module {
 		return register.Module{
@@ -17,7 +20,8 @@ func init() {
 			SetupAPI: func() register.APIRouter {
 				return New(ctx.(*config.Context))
 			},
-			SQLDir: register.NewSQLFS(sqlFS),
+			SQLDir:  register.NewSQLFS(sqlFS),
+			Swagger: swaggerContent,
 		}
 	})
 }

--- a/modules/opanalytics/1module.go
+++ b/modules/opanalytics/1module.go
@@ -1,0 +1,23 @@
+package opanalytics
+
+import (
+	"embed"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
+)
+
+//go:embed sql
+var sqlFS embed.FS
+
+func init() {
+	register.AddModule(func(ctx interface{}) register.Module {
+		return register.Module{
+			Name: "opanalytics",
+			SetupAPI: func() register.APIRouter {
+				return New(ctx.(*config.Context))
+			},
+			SQLDir: register.NewSQLFS(sqlFS),
+		}
+	})
+}

--- a/modules/opanalytics/api.go
+++ b/modules/opanalytics/api.go
@@ -13,7 +13,11 @@ import (
 // maxPageSize 管理端分页上限，防止超大页把全表拉出。
 const maxPageSize = 200
 
-// maxRangeDays 时间范围上限(约 1 年)。
+// maxPageIndex 页码上限：防止超大 page_index 让 (pageIndex-1)*pageSize 溢出成负 offset，
+// 进而在内存分页(spaceList)切片越界 panic / 在 SQL 路径传负 OFFSET。封顶后越界页返回空列表。
+const maxPageIndex = 1_000_000
+
+// maxRangeDays 时间范围上限(含两端约 1 年)。
 const maxRangeDays = 366
 
 // Manager 运营分析看板(管理端 superAdmin 跨 space 只读)。
@@ -193,7 +197,8 @@ func parseDateRange(c *wkhttp.Context) (string, string, bool) {
 	if start.After(end) {
 		return "", "", false
 	}
-	if end.Sub(start) > maxRangeDays*24*time.Hour {
+	// BETWEEN 闭区间：跨度 N 天 = N+1 个自然日。用 >= 使含两端的自然日数封顶为 maxRangeDays。
+	if end.Sub(start) >= maxRangeDays*24*time.Hour {
 		return "", "", false
 	}
 	return start.Format(layout), end.Format(layout), true
@@ -227,10 +232,14 @@ func normalizeActiveStatus(v string) string {
 	}
 }
 
-// clampPage 规范化页码/页大小并执行上限保护(入参直接适配 c.GetPage())。
+// clampPage 规范化页码/页大小并执行上下限保护(入参直接适配 c.GetPage())。
+// 同时封顶 pageIndex，避免 (pageIndex-1)*pageSize 溢出成负 offset 导致切片 panic / 负 OFFSET。
 func clampPage(pageIndex, pageSize int64) (int, int) {
 	if pageIndex <= 0 {
 		pageIndex = 1
+	}
+	if pageIndex > maxPageIndex {
+		pageIndex = maxPageIndex
 	}
 	if pageSize <= 0 {
 		pageSize = 20

--- a/modules/opanalytics/api.go
+++ b/modules/opanalytics/api.go
@@ -32,7 +32,7 @@ func New(ctx *config.Context) *Manager {
 		Log:       log.NewTLog("OpanalyticsManager"),
 		service:   newService(ctx),
 		etl:       etl,
-		scheduler: NewScheduler(etl),
+		scheduler: NewScheduler(ctx, etl),
 	}
 	if !ctx.GetConfig().Test {
 		if err := m.scheduler.Start(); err != nil {

--- a/modules/opanalytics/api.go
+++ b/modules/opanalytics/api.go
@@ -1,0 +1,239 @@
+package opanalytics
+
+import (
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"go.uber.org/zap"
+)
+
+// maxPageSize 管理端分页上限，防止超大页把全表拉出。
+const maxPageSize = 200
+
+// maxRangeDays 时间范围上限(约 1 年)。
+const maxRangeDays = 366
+
+// Manager 运营分析看板(管理端 superAdmin 跨 space 只读)。
+type Manager struct {
+	ctx *config.Context
+	log.Log
+	service   *service
+	etl       *ETL
+	scheduler *Scheduler
+}
+
+// New 创建看板 Manager。生产环境(非测试)自启动每日 ETL 调度器。
+func New(ctx *config.Context) *Manager {
+	etl := NewETL(ctx)
+	m := &Manager{
+		ctx:       ctx,
+		Log:       log.NewTLog("OpanalyticsManager"),
+		service:   newService(ctx),
+		etl:       etl,
+		scheduler: NewScheduler(etl),
+	}
+	if !ctx.GetConfig().Test {
+		if err := m.scheduler.Start(); err != nil {
+			m.Error("failed to start opanalytics scheduler", zap.Error(err))
+		}
+	}
+	return m
+}
+
+// Route 配置路由。统一前缀 /v1/manager/dashboard；逐 handler 校验 superAdmin。
+func (m *Manager) Route(r *wkhttp.WKHttp) {
+	auth := r.Group("/v1/manager/dashboard", m.ctx.AuthMiddleware(r))
+	{
+		auth.GET("/overview", m.overview)                       // 模块A 概览卡片
+		auth.GET("/spaces", m.spaces)                           // 表一 Space 列表
+		auth.GET("/spaces/:space_id/channels", m.spaceChannels) // 表二 群组列表(仅群组)
+		auth.GET("/global/direct-chats", m.globalDirectChats)   // 全局私聊活跃列表
+	}
+}
+
+// overview 模块A 概览(私聊只出活跃数)。
+func (m *Manager) overview(c *wkhttp.Context) {
+	if !m.requireSuperAdmin(c) {
+		return
+	}
+	start, end, ok := parseDateRange(c)
+	if !ok {
+		respRequestInvalid(c, "date_range")
+		return
+	}
+	resp, err := m.service.overview(start, end, parseSpaceIDs(c))
+	if err != nil {
+		m.Error("overview query failed", zap.Error(err))
+		respQueryFailed(c)
+		return
+	}
+	c.Response(resp)
+}
+
+// spaces 表一 Space 列表。
+func (m *Manager) spaces(c *wkhttp.Context) {
+	if !m.requireSuperAdmin(c) {
+		return
+	}
+	start, end, ok := parseDateRange(c)
+	if !ok {
+		respRequestInvalid(c, "date_range")
+		return
+	}
+	pageIndex, pageSize := clampPage(c.GetPage())
+	list, total, err := m.service.spaceList(
+		start, end, c.Query("name"), normalizeActiveStatus(c.Query("active_status")),
+		c.Query("sort_by"), c.Query("order"), (pageIndex-1)*pageSize, pageSize)
+	if err != nil {
+		m.Error("space list query failed", zap.Error(err))
+		respQueryFailed(c)
+		return
+	}
+	c.Response(map[string]interface{}{"count": total, "list": list})
+}
+
+// spaceChannels 表二 群组列表(仅群组，私聊不进表二)。
+func (m *Manager) spaceChannels(c *wkhttp.Context) {
+	if !m.requireSuperAdmin(c) {
+		return
+	}
+	spaceID := c.Param("space_id")
+	if spaceID == "" {
+		respRequestInvalid(c, "space_id")
+		return
+	}
+	exists, err := m.service.spaceExists(spaceID)
+	if err != nil {
+		m.Error("space exists check failed", zap.Error(err))
+		respQueryFailed(c)
+		return
+	}
+	if !exists {
+		respNotFound(c)
+		return
+	}
+	start, end, ok := parseDateRange(c)
+	if !ok {
+		respRequestInvalid(c, "date_range")
+		return
+	}
+	pageIndex, pageSize := clampPage(c.GetPage())
+	list, total, err := m.service.channelList(
+		spaceID, start, end, normalizeActiveStatus(c.Query("active_status")),
+		c.Query("sort_by"), c.Query("order"), (pageIndex-1)*pageSize, pageSize)
+	if err != nil {
+		m.Error("channel list query failed", zap.Error(err))
+		respQueryFailed(c)
+		return
+	}
+	c.Response(map[string]interface{}{"count": total, "list": list})
+}
+
+// globalDirectChats 全局私聊活跃列表(无活跃状态筛选；私聊恒活跃集)。
+func (m *Manager) globalDirectChats(c *wkhttp.Context) {
+	if !m.requireSuperAdmin(c) {
+		return
+	}
+	start, end, ok := parseDateRange(c)
+	if !ok {
+		respRequestInvalid(c, "date_range")
+		return
+	}
+	pageIndex, pageSize := clampPage(c.GetPage())
+	list, total, err := m.service.directChatList(
+		start, end, c.Query("sort_by"), c.Query("order"), (pageIndex-1)*pageSize, pageSize)
+	if err != nil {
+		m.Error("direct chat list query failed", zap.Error(err))
+		respQueryFailed(c)
+		return
+	}
+	c.Response(map[string]interface{}{"count": total, "list": list})
+}
+
+// ===== 参数解析 =====
+
+func (m *Manager) requireSuperAdmin(c *wkhttp.Context) bool {
+	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
+		respForbidden(c)
+		return false
+	}
+	return true
+}
+
+// parseDateRange 解析 start_date/end_date(报告时区 YYYY-MM-DD)，默认近 30 天，上限 1 年。
+func parseDateRange(c *wkhttp.Context) (string, string, bool) {
+	loc := reportLocation()
+	const layout = "2006-01-02"
+
+	var end time.Time
+	var err error
+	if v := c.Query("end_date"); v != "" {
+		if end, err = time.ParseInLocation(layout, v, loc); err != nil {
+			return "", "", false
+		}
+	} else {
+		now := time.Now().In(loc)
+		end = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
+	}
+
+	var start time.Time
+	if v := c.Query("start_date"); v != "" {
+		if start, err = time.ParseInLocation(layout, v, loc); err != nil {
+			return "", "", false
+		}
+	} else {
+		start = end.AddDate(0, 0, -29)
+	}
+
+	if start.After(end) {
+		return "", "", false
+	}
+	if end.Sub(start) > maxRangeDays*24*time.Hour {
+		return "", "", false
+	}
+	return start.Format(layout), end.Format(layout), true
+}
+
+// parseSpaceIDs 读取 space_ids / space_ids[](去空去重)。
+func parseSpaceIDs(c *wkhttp.Context) []string {
+	raw := append(c.QueryArray("space_ids"), c.QueryArray("space_ids[]")...)
+	seen := make(map[string]struct{}, len(raw))
+	out := make([]string, 0, len(raw))
+	for _, id := range raw {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}
+
+// normalizeActiveStatus 收敛为 all/active/inactive。
+func normalizeActiveStatus(v string) string {
+	switch v {
+	case "active", "inactive":
+		return v
+	default:
+		return "all"
+	}
+}
+
+// clampPage 规范化页码/页大小并执行上限保护(入参直接适配 c.GetPage())。
+func clampPage(pageIndex, pageSize int64) (int, int) {
+	if pageIndex <= 0 {
+		pageIndex = 1
+	}
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	if pageSize > maxPageSize {
+		pageSize = maxPageSize
+	}
+	return int(pageIndex), int(pageSize)
+}

--- a/modules/opanalytics/api.go
+++ b/modules/opanalytics/api.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"go.uber.org/zap"
 )
 
@@ -43,8 +44,10 @@ func New(ctx *config.Context) *Manager {
 }
 
 // Route 配置路由。统一前缀 /v1/manager/dashboard；逐 handler 校验 superAdmin。
+// SharedUIDRateLimiter 挂在 AuthMiddleware 之后(须先解析出 uid)：这些是跨 Space 聚合的重查询，
+// 防管理端误刷/脚本轮询/token 泄漏把 DB 打满(每登录用户共享桶，见 pkg/wkhttp/ratelimit_helper.go)。
 func (m *Manager) Route(r *wkhttp.WKHttp) {
-	auth := r.Group("/v1/manager/dashboard", m.ctx.AuthMiddleware(r))
+	auth := r.Group("/v1/manager/dashboard", m.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, m.ctx))
 	{
 		auth.GET("/overview", m.overview)                       // 模块A 概览卡片
 		auth.GET("/spaces", m.spaces)                           // 表一 Space 列表

--- a/modules/opanalytics/api_i18n.go
+++ b/modules/opanalytics/api_i18n.go
@@ -1,0 +1,32 @@
+package opanalytics
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+// respForbidden 非超级管理员访问看板 → 403。
+func respForbidden(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errcode.ErrOpanalyticsForbidden, nil, nil)
+}
+
+// respRequestInvalid 请求参数无效(reason ∈ {date_range, space_id, sort})。
+func respRequestInvalid(c *wkhttp.Context, reason string) {
+	details := i18n.Details{}
+	if reason != "" {
+		details["reason"] = reason
+	}
+	httperr.ResponseErrorL(c, errcode.ErrOpanalyticsRequestInvalid, nil, details)
+}
+
+// respNotFound Space 不存在 → 404。
+func respNotFound(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errcode.ErrOpanalyticsNotFound, nil, nil)
+}
+
+// respQueryFailed 查询失败 → 500(Internal，渲染层隐藏细节，调用方须先记 zap 日志)。
+func respQueryFailed(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errcode.ErrOpanalyticsQueryFailed, nil, nil)
+}

--- a/modules/opanalytics/api_i18n_test.go
+++ b/modules/opanalytics/api_i18n_test.go
@@ -1,0 +1,105 @@
+package opanalytics
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+// TestOpanalyticsNoLegacyResponseError pins that the module's HTTP surface renders
+// every error through the i18n envelope (httperr.ResponseErrorL + errcode.ErrOpanalytics*)
+// and never regresses to legacy octo-lib raw responses. Comments are stripped first so
+// commented-out breadcrumbs don't trip the guard. Add any new handler/query file below.
+func TestOpanalyticsNoLegacyResponseError(t *testing.T) {
+	files := []string{"api.go", "api_i18n.go", "service.go", "db.go", "etl.go", "etl_db.go", "scheduler.go"}
+	banned := []string{
+		".ResponseError(",
+		".ResponseErrorf(",
+		".ResponseErrorWithStatus(",
+		".AbortWithStatusJSON(",
+		".AbortWithStatus(",
+		"c.Response(\"",
+	}
+	for _, f := range files {
+		t.Run(f, func(t *testing.T) {
+			data, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+			var clean strings.Builder
+			for _, line := range strings.Split(string(data), "\n") {
+				if idx := strings.Index(line, "//"); idx >= 0 {
+					line = line[:idx]
+				}
+				clean.WriteString(line)
+				clean.WriteByte('\n')
+			}
+			cleaned := clean.String()
+			for _, b := range banned {
+				if strings.Contains(cleaned, b) {
+					t.Fatalf("modules/opanalytics/%s must render errors via httperr.ResponseErrorL / errcode.ErrOpanalytics*, not legacy %s", f, b)
+				}
+			}
+		})
+	}
+}
+
+type opaEnvelope struct {
+	Error struct {
+		Code       string `json:"code"`
+		HTTPStatus int    `json:"http_status"`
+	} `json:"error"`
+	Status int `json:"status"`
+}
+
+func opaHelperHarness(probe func(c *wkhttp.Context)) *wkhttp.WKHttp {
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	r.GET("/probe", probe)
+	return r
+}
+
+// TestOpanalyticsRespondHelpers asserts each responder emits the expected i18n code
+// at the legacy transport-400 (ResponseErrorL) with the real status in error.http_status.
+func TestOpanalyticsRespondHelpers(t *testing.T) {
+	cases := []struct {
+		name           string
+		probe          func(c *wkhttp.Context)
+		wantHTTPStatus int
+		wantCodeID     string
+	}{
+		{"forbidden", respForbidden, http.StatusForbidden, "err.server.opanalytics.forbidden"},
+		{"requestInvalid", func(c *wkhttp.Context) { respRequestInvalid(c, "date_range") }, http.StatusBadRequest, "err.server.opanalytics.request_invalid"},
+		{"notFound", respNotFound, http.StatusNotFound, "err.server.opanalytics.not_found"},
+		{"queryFailed", respQueryFailed, http.StatusInternalServerError, "err.server.opanalytics.query_failed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := opaHelperHarness(tc.probe)
+			req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			// ResponseErrorL pins transport status = 400 (D14 compat).
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("transport status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+			}
+			var env opaEnvelope
+			if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+				t.Fatalf("decode envelope: %v; body=%s", err, rec.Body.String())
+			}
+			if env.Error.Code != tc.wantCodeID {
+				t.Fatalf("error.code = %q, want %q", env.Error.Code, tc.wantCodeID)
+			}
+			if env.Error.HTTPStatus != tc.wantHTTPStatus {
+				t.Fatalf("error.http_status = %d, want %d", env.Error.HTTPStatus, tc.wantHTTPStatus)
+			}
+		})
+	}
+}

--- a/modules/opanalytics/api_test.go
+++ b/modules/opanalytics/api_test.go
@@ -96,6 +96,7 @@ func cleanOpaAndShards(t *testing.T, ctx *config.Context) {
 	tables := append([]string{
 		"octo_dim_member", "octo_dim_channel",
 		"octo_fact_member_channel_daily", "octo_fact_channel_daily",
+		"octo_etl_message_cursor", "octo_etl_dirty_day",
 	}, shardTables(ctx)...)
 	for _, tbl := range tables {
 		_, err := ctx.DB().Exec(fmt.Sprintf("DELETE FROM `%s`", tbl))
@@ -110,6 +111,15 @@ func seedUser(t *testing.T, ctx *config.Context, uid, name, email string, robot 
 	_, err := ctx.DB().InsertBySql(
 		"INSERT INTO `user` (uid,name,email,short_no,robot,status,category) VALUES (?,?,?,?,?,1,'')",
 		uid, name, email, uid, robot).Exec()
+	require.NoError(t, err)
+}
+
+// seedUserCat 同 seedUser 但可指定 category(用于 category='system' 测试账号排除)。
+func seedUserCat(t *testing.T, ctx *config.Context, uid, name string, robot int, category string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `user` (uid,name,email,short_no,robot,status,category) VALUES (?,?,'',?,?,1,?)",
+		uid, name, uid, robot, category).Exec()
 	require.NoError(t, err)
 }
 
@@ -235,7 +245,7 @@ func seedScenario(t *testing.T, ctx *config.Context) string {
 func TestOpanalyticsETLAndDB(t *testing.T) {
 	ctx, _, etl := opaSetup(t)
 	fc := seedScenario(t, ctx)
-	require.NoError(t, etl.RunDay(statDay))
+	require.NoError(t, etl.RunIncremental())
 
 	// ③ alice 在 g1 含撤回 = 3
 	var aliceMsg int
@@ -300,10 +310,10 @@ func TestOpanalyticsETLIdempotent(t *testing.T) {
 	ctx, _, etl := opaSetup(t)
 	seedScenario(t, ctx)
 
-	require.NoError(t, etl.RunDay(statDay))
+	require.NoError(t, etl.RunIncremental())
 	rows1, fact1 := countFacts(t, ctx)
 
-	require.NoError(t, etl.RunDay(statDay)) // 重跑
+	require.NoError(t, etl.RunIncremental()) // 重跑(游标保证精确一次)
 	rows2, fact2 := countFacts(t, ctx)
 
 	assert.Equal(t, rows1, rows2, "重跑后 ③ 行数应一致")
@@ -330,7 +340,7 @@ func countFacts(t *testing.T, ctx *config.Context) (int64, int64) {
 func TestOpanalyticsEndpoints(t *testing.T) {
 	ctx, route, etl := opaSetup(t)
 	seedScenario(t, ctx)
-	require.NoError(t, etl.RunDay(statDay))
+	require.NoError(t, etl.RunIncremental())
 
 	rng := "?start_date=" + statDay + "&end_date=" + statDay
 
@@ -403,4 +413,133 @@ func TestOpanalyticsEndpoints(t *testing.T) {
 	setPlainUserToken(t, ctx)
 	rec = opaGet(t, route, "/v1/manager/dashboard/overview"+rng)
 	assert.Equal(t, "err.server.opanalytics.forbidden", errorCode(t, rec))
+}
+
+// TestOpanalyticsETLExclusion 验收①：系统机器人(pkg/space.SystemBots，含 notification)与
+// category=system 测试账号，不进总人数/消息/活跃/私聊等核心指标；注入它们后各项与基线一致。
+func TestOpanalyticsETLExclusion(t *testing.T) {
+	ctx, route, etl := opaSetup(t)
+	fc := seedScenario(t, ctx)
+
+	// 注入排除账号：botfather(系统bot，agent) + u_test(category=system，human)。
+	seedUserCat(t, ctx, "botfather", "BotFather", 1, "")
+	seedUserCat(t, ctx, "u_test", "Tester", 0, "system")
+	seedGroupMember(t, ctx, "g1", "botfather", 1) // 系统bot 是群成员，但不应计入成员数
+
+	start, _, err := dayWindowUnix(statDay)
+	require.NoError(t, err)
+	base := start + 7200
+
+	insertMsgs(t, ctx, "botfather", "g1", channelTypeGroup, base, 4, 0) // agent 系统bot → 不计
+	insertMsgs(t, ctx, "u_test", "g1", channelTypeGroup, base+10, 3, 0) // 测试账号 → 不计
+	// 私聊 alice & botfather：一方系统bot → 整条会话丢弃
+	fcBot := common.GetFakeChannelIDWith("u_alice", "botfather")
+	insertMsgs(t, ctx, "u_alice", fcBot, channelTypePerson, base, 2, 0)
+	insertMsgs(t, ctx, "botfather", fcBot, channelTypePerson, base+5, 2, 0)
+
+	require.NoError(t, etl.RunIncremental())
+
+	// ③ 不含被排除账号
+	var excludedRows int64
+	_, err = ctx.DB().Select("count(*)").From("octo_fact_member_channel_daily").
+		Where("sender_uid IN ('botfather','u_test')").Load(&excludedRows)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), excludedRows, "系统/测试账号不得进入 ③")
+
+	// alice@botfather 私聊整条丢弃(③ 无行 + dim 无行)
+	var botDMRows, botDMDim int64
+	_, err = ctx.DB().Select("count(*)").From("octo_fact_member_channel_daily").
+		Where("channel_id=?", fcBot).Load(&botDMRows)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), botDMRows, "含系统bot的私聊不得进入 ③")
+	_, err = ctx.DB().Select("count(*)").From("octo_dim_channel").Where("channel_id=?", fcBot).Load(&botDMDim)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), botDMDim, "含系统bot的私聊不得进入会话维表")
+
+	// ④ g1 各项与基线一致(botfather 的 4 条 + u_test 的 3 条均被排除)
+	var g1 struct {
+		HumanMsg    int `db:"human_msg_count"`
+		AgentMsg    int `db:"agent_msg_count"`
+		ActiveHuman int `db:"active_human_members"`
+		ActiveAgent int `db:"active_agent_members"`
+	}
+	_, err = ctx.DB().Select("human_msg_count", "agent_msg_count", "active_human_members", "active_agent_members").
+		From("octo_fact_channel_daily").Where("channel_id='g1' AND stat_date=?", statDay).Load(&g1)
+	require.NoError(t, err)
+	assert.Equal(t, 5, g1.HumanMsg, "u_test 的群消息不得计入")
+	assert.Equal(t, 5, g1.AgentMsg, "botfather 的群消息不得计入")
+	assert.Equal(t, 2, g1.ActiveHuman)
+	assert.Equal(t, 1, g1.ActiveAgent)
+
+	// dim_channel g1 成员数剔除系统bot
+	var dimG1 struct {
+		MemberCount int `db:"member_count"`
+		Agent       int `db:"agent_member_count"`
+	}
+	_, err = ctx.DB().Select("member_count", "agent_member_count").
+		From("octo_dim_channel").Where("channel_id='g1'").Load(&dimG1)
+	require.NoError(t, err)
+	assert.Equal(t, 3, dimG1.MemberCount, "botfather 不计入群成员数")
+	assert.Equal(t, 1, dimG1.Agent, "botfather 不计入 agent 成员数")
+
+	// overview / 私聊：与基线一致
+	rng := "?start_date=" + statDay + "&end_date=" + statDay
+	var ov overviewResp
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/overview"+rng), &ov)
+	assert.Equal(t, int64(3), ov.HumanMemberTotal, "u_test 不计入总人数")
+	assert.Equal(t, int64(1), ov.AgentTotal, "botfather 不计入 agent 总数")
+	assert.Equal(t, int64(12), ov.HumanMsgCount)
+	assert.Equal(t, int64(5), ov.AgentMsgCount)
+	assert.Equal(t, int64(1), ov.PrivateActiveCount, "含系统bot的私聊不计入活跃私聊数")
+
+	var direct struct {
+		Count int64            `json:"count"`
+		List  []directChatItem `json:"list"`
+	}
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/global/direct-chats"+rng), &direct)
+	assert.Equal(t, int64(1), direct.Count)
+	require.Len(t, direct.List, 1)
+	assert.Equal(t, fc, direct.List[0].ChannelID, "仅 alice&bob 私聊在列")
+}
+
+// TestOpanalyticsETLIncremental 验收③：水位增量——二次运行只累加新增消息(精确一次，不重复计)。
+func TestOpanalyticsETLIncremental(t *testing.T) {
+	ctx, _, etl := opaSetup(t)
+	seedScenario(t, ctx)
+	require.NoError(t, etl.RunIncremental())
+
+	assert.Equal(t, 3, fact3Msg(t, ctx, "g1", "u_alice"), "首轮 alice=3")
+	assert.Equal(t, 5, fact4Human(t, ctx, "g1"), "首轮 g1 human=5")
+
+	// 新增 alice 在 g1 的 2 条(新 id)，增量再跑
+	start, _, err := dayWindowUnix(statDay)
+	require.NoError(t, err)
+	insertMsgs(t, ctx, "u_alice", "g1", channelTypeGroup, start+9000, 2, 0)
+	require.NoError(t, etl.RunIncremental())
+
+	assert.Equal(t, 5, fact3Msg(t, ctx, "g1", "u_alice"), "增量后 alice=5(3+2，非6)")
+	assert.Equal(t, 7, fact4Human(t, ctx, "g1"), "增量后 g1 human=7")
+
+	// 三跑无新消息 → 不变(游标空操作)
+	require.NoError(t, etl.RunIncremental())
+	assert.Equal(t, 5, fact3Msg(t, ctx, "g1", "u_alice"), "无新消息时不变")
+	assert.Equal(t, 7, fact4Human(t, ctx, "g1"))
+}
+
+func fact3Msg(t *testing.T, ctx *config.Context, channelID, senderUID string) int {
+	t.Helper()
+	var n int
+	_, err := ctx.DB().Select("IFNULL(msg_count,0)").From("octo_fact_member_channel_daily").
+		Where("channel_id=? AND sender_uid=? AND stat_date=?", channelID, senderUID, statDay).Load(&n)
+	require.NoError(t, err)
+	return n
+}
+
+func fact4Human(t *testing.T, ctx *config.Context, channelID string) int {
+	t.Helper()
+	var n int
+	_, err := ctx.DB().Select("IFNULL(human_msg_count,0)").From("octo_fact_channel_daily").
+		Where("channel_id=? AND stat_date=?", channelID, statDay).Load(&n)
+	require.NoError(t, err)
+	return n
 }

--- a/modules/opanalytics/api_test.go
+++ b/modules/opanalytics/api_test.go
@@ -394,6 +394,7 @@ func TestOpanalyticsEndpoints(t *testing.T) {
 	assert.Equal(t, int64(1), ovS1.ActiveAgentMembers)
 	assert.Equal(t, int64(5), ovS1.HumanMsgCount, "私聊/g2 不计入 s1")
 	assert.Equal(t, int64(5), ovS1.AgentMsgCount)
+	assert.Equal(t, int64(0), ovS1.PrivateActiveCount, "选中 Space 时私聊数置 0(私聊无 space 归属)")
 
 	// ---- spaces (表一) ----
 	var spaces struct {
@@ -636,25 +637,29 @@ func TestOpanalyticsDimFullRefresh(t *testing.T) {
 	seedScenario(t, ctx)
 	require.NoError(t, etl.RunIncremental())
 
-	humanTotal := func() int64 {
+	getOverview := func() overviewResp {
 		var ov overviewResp
 		decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/overview?start_date="+statDay+"&end_date="+statDay), &ov)
-		return ov.HumanMemberTotal
+		return ov
 	}
-	require.Equal(t, int64(3), humanTotal(), "初始 human 总数=alice,bob,carol")
+	ov := getOverview()
+	require.Equal(t, int64(3), ov.HumanMemberTotal, "初始 human 总数=alice,bob,carol")
+	require.Equal(t, int64(3), ov.ActiveHumanMembers, "初始活跃 human=alice,bob,carol")
 
-	// 禁用 carol：全量刷新后从总数剔除，但其 g2 历史消息(event-time)仍在。
+	// 禁用 carol：全量刷新后从总数与活跃中剔除(活跃成员只算当前在册)，但其 g2 历史消息量(event-time)仍在。
 	_, err := ctx.DB().Exec("UPDATE `user` SET status=0 WHERE uid='u_carol'")
 	require.NoError(t, err)
 	require.NoError(t, etl.RunIncremental())
-	assert.Equal(t, int64(2), humanTotal(), "禁用 carol 后 human 总数=2")
-	assert.Equal(t, 2, fact4Human(t, ctx, "g2"), "carol 历史消息按 event-time 保留")
+	ov = getOverview()
+	assert.Equal(t, int64(2), ov.HumanMemberTotal, "禁用 carol 后 human 总数=2")
+	assert.Equal(t, int64(2), ov.ActiveHumanMembers, "禁用 carol 后活跃 human=2(活跃⊆在册，率≤100%)")
+	assert.Equal(t, 2, fact4Human(t, ctx, "g2"), "carol 历史消息量按 event-time 保留")
 
 	// 硬删除 alice：全量替换不残留陈旧 dim 行，总数再降。
 	_, err = ctx.DB().Exec("DELETE FROM `user` WHERE uid='u_alice'")
 	require.NoError(t, err)
 	require.NoError(t, etl.RunIncremental())
-	assert.Equal(t, int64(1), humanTotal(), "硬删除 alice 后 human 总数=1(仅 bob)")
+	assert.Equal(t, int64(1), getOverview().HumanMemberTotal, "硬删除 alice 后 human 总数=1(仅 bob)")
 }
 
 // TestOpanalyticsMemberTotalsConsistency 验证概览(Space 路径)与表一的"成员总数"口径一致：

--- a/modules/opanalytics/api_test.go
+++ b/modules/opanalytics/api_test.go
@@ -807,3 +807,31 @@ func TestOpanalyticsGroupMemberDeleted(t *testing.T) {
 	assert.Equal(t, 0, dim.Agent, "已退群 agent 不计入")
 	assert.Equal(t, convTypeHHGroup, dim.ConvType, "已退群 agent 不得把群误判为 HA")
 }
+
+// TestOpanalyticsHugePageIndexNoPanic 验收 P2#1：超大 page_index 不得让分页 offset 溢出成负数
+// 进而内存切片越界 panic，应干净返回空列表(封顶 pageIndex)。
+func TestOpanalyticsHugePageIndexNoPanic(t *testing.T) {
+	ctx, route, etl := opaSetup(t)
+	seedScenario(t, ctx)
+	require.NoError(t, etl.RunIncremental())
+
+	rec := opaGet(t, route, "/v1/manager/dashboard/spaces?start_date="+statDay+"&end_date="+statDay+"&page_index=9000000000000000000")
+	require.Equal(t, http.StatusOK, rec.Code, "超大 page_index 必须干净返回而非 panic→500, body=%s", rec.Body.String())
+	var resp struct {
+		Count int64           `json:"count"`
+		List  []spaceListItem `json:"list"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Empty(t, resp.List, "越界页返回空列表")
+}
+
+// TestOpanalyticsDateRangeCap 验收 P2#5：含两端的自然日数封顶 366(BETWEEN 闭区间)。
+func TestOpanalyticsDateRangeCap(t *testing.T) {
+	_, route, _ := opaSetup(t)
+	// 含两端 366 天(跨度 365 天，2025 非闰年)→ 允许
+	ok := opaGet(t, route, "/v1/manager/dashboard/overview?start_date=2025-01-01&end_date=2026-01-01")
+	assert.Equal(t, http.StatusOK, ok.Code, "366 个自然日应允许, body=%s", ok.Body.String())
+	// 含两端 367 天(跨度 366 天)→ 拒绝
+	bad := opaGet(t, route, "/v1/manager/dashboard/overview?start_date=2025-01-01&end_date=2026-01-02")
+	assert.Equal(t, "err.server.opanalytics.request_invalid", errorCode(t, bad), "367 个自然日应拒绝")
+}

--- a/modules/opanalytics/api_test.go
+++ b/modules/opanalytics/api_test.go
@@ -167,6 +167,14 @@ func seedGroupMember(t *testing.T, ctx *config.Context, groupNo, uid string, rob
 	require.NoError(t, err)
 }
 
+// seedGroupMemberDeleted 插入一个已退群/被移除(is_deleted=1，status 仍为 1)的群成员。
+func seedGroupMemberDeleted(t *testing.T, ctx *config.Context, groupNo, uid string, robot int) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `group_member` (group_no,uid,robot,status,is_deleted) VALUES (?,?,?,1,1)", groupNo, uid, robot).Exec()
+	require.NoError(t, err)
+}
+
 var msgSeq int64
 
 // insertMsgs 落 count 条消息。created_at 设为 NOW()-1天，远早于默认 lag(600s)，使其落在
@@ -773,4 +781,29 @@ func TestOpanalyticsSpaceNameLikeEscape(t *testing.T) {
 	assert.Equal(t, int64(1), resp.Count, "name=a_b 只应精确匹配 'a_b'，不应把 _ 当通配匹配到 'axb'")
 	require.Len(t, resp.List, 1)
 	assert.Equal(t, "s_underscore", resp.List[0].SpaceID)
+}
+
+// TestOpanalyticsGroupMemberDeleted 验收 P0：group_member 有 status 与 is_deleted 两个独立字段，
+// 已退群/被移除(is_deleted=1)的成员不得计入 dim_channel 成员数，也不得把群误判为 HA。
+func TestOpanalyticsGroupMemberDeleted(t *testing.T) {
+	ctx, _, etl := opaSetup(t)
+	seedScenario(t, ctx)
+	// g2(carol，HH 群)加一个已退群的 agent 成员：不得计入、不得使群变 HA。
+	seedUser(t, ctx, "u_leftbot", "LeftBot", "", 1)
+	seedGroupMemberDeleted(t, ctx, "g2", "u_leftbot", 1)
+	require.NoError(t, etl.RunIncremental())
+
+	var dim struct {
+		MemberCount int   `db:"member_count"`
+		Human       int   `db:"human_member_count"`
+		Agent       int   `db:"agent_member_count"`
+		ConvType    uint8 `db:"conv_type"`
+	}
+	_, err := ctx.DB().Select("member_count", "human_member_count", "agent_member_count", "conv_type").
+		From("octo_dim_channel").Where("channel_id='g2'").Load(&dim)
+	require.NoError(t, err)
+	assert.Equal(t, 1, dim.MemberCount, "已退群成员不计入 member_count")
+	assert.Equal(t, 1, dim.Human, "仅 carol")
+	assert.Equal(t, 0, dim.Agent, "已退群 agent 不计入")
+	assert.Equal(t, convTypeHHGroup, dim.ConvType, "已退群 agent 不得把群误判为 HA")
 }

--- a/modules/opanalytics/api_test.go
+++ b/modules/opanalytics/api_test.go
@@ -435,6 +435,12 @@ func TestOpanalyticsEndpoints(t *testing.T) {
 	rec := opaGet(t, route, "/v1/manager/dashboard/spaces/nope/channels"+rng)
 	assert.Equal(t, "err.server.opanalytics.not_found", errorCode(t, rec))
 
+	// 软删除(status=0)的 space 视为不存在 → 404(与 /spaces 列表口径一致)
+	_, err := ctx.DB().Exec("INSERT INTO space (space_id,name,status) VALUES ('s_dead','Dead Space',0)")
+	require.NoError(t, err)
+	rec = opaGet(t, route, "/v1/manager/dashboard/spaces/s_dead/channels"+rng)
+	assert.Equal(t, "err.server.opanalytics.not_found", errorCode(t, rec), "软删除 space 应 404")
+
 	// ---- global direct chats ----
 	var direct struct {
 		Count int64            `json:"count"`
@@ -691,4 +697,80 @@ func TestOpanalyticsMemberTotalsConsistency(t *testing.T) {
 	assert.Equal(t, int64(2), s1.HumanMemberTotal, "表一：孤儿 space_member 不计入")
 	assert.Equal(t, ov.HumanMemberTotal, s1.HumanMemberTotal, "概览与表一 human 口径一致")
 	assert.Equal(t, ov.AgentTotal, s1.AgentTotal, "概览与表一 agent 口径一致")
+}
+
+// TestOpanalyticsActiveRatioOnConversion 验收 P1：成员 human↔agent 转换后，活跃成员按**当前**
+// 类型计，active_human ≤ human_total(率≤100%)。修复前活跃按 ③ 冻结的 sender_type 拆会撑爆比率。
+func TestOpanalyticsActiveRatioOnConversion(t *testing.T) {
+	ctx, route, etl := opaSetup(t)
+	seedScenario(t, ctx)
+	require.NoError(t, etl.RunIncremental())
+
+	overview := func() overviewResp {
+		var o overviewResp
+		decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/overview?start_date="+statDay+"&end_date="+statDay), &o)
+		return o
+	}
+	o := overview()
+	require.Equal(t, int64(3), o.HumanMemberTotal)
+	require.Equal(t, int64(3), o.ActiveHumanMembers)
+
+	// bob 以 human 发言后被转成 agent(robot 0→1)。
+	_, err := ctx.DB().Exec("UPDATE `user` SET robot=1 WHERE uid='u_bob'")
+	require.NoError(t, err)
+	require.NoError(t, etl.RunIncremental())
+
+	o = overview()
+	assert.Equal(t, int64(2), o.HumanMemberTotal, "human 总数=alice,carol")
+	assert.Equal(t, int64(2), o.AgentTotal, "agent 总数=u_agent,bob")
+	assert.Equal(t, int64(2), o.ActiveHumanMembers, "活跃 human 按当前类型=alice,carol(不含已转 agent 的 bob)")
+	assert.Equal(t, int64(2), o.ActiveAgentMembers, "活跃 agent=u_agent,bob")
+	assert.LessOrEqual(t, o.ActiveHumanMembers, o.HumanMemberTotal, "active_human ≤ human_total")
+	assert.LessOrEqual(t, o.ActiveAgentMembers, o.AgentTotal, "active_agent ≤ agent_total")
+}
+
+// TestOpanalyticsStaleGroupHidden 验收 P2：已解散(status=0)/硬删除的群不再出现在表二
+// (读侧 INNER JOIN 活的 group 表 status=1，dim_channel 只 upsert 不删的陈旧行被挡掉)。
+func TestOpanalyticsStaleGroupHidden(t *testing.T) {
+	ctx, route, etl := opaSetup(t)
+	seedScenario(t, ctx)
+	require.NoError(t, etl.RunIncremental())
+
+	channelsOf := func(spaceID string) int64 {
+		var resp struct {
+			Count int64 `json:"count"`
+		}
+		decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/spaces/"+spaceID+"/channels?start_date="+statDay+"&end_date="+statDay), &resp)
+		return resp.Count
+	}
+	require.Equal(t, int64(1), channelsOf("s1"), "初始 s1 有 g1")
+
+	// 解散 g1(group.status=0)：表二不再展示。
+	_, err := ctx.DB().Exec("UPDATE `group` SET status=0 WHERE group_no='g1'")
+	require.NoError(t, err)
+	require.NoError(t, etl.RunIncremental())
+	assert.Equal(t, int64(0), channelsOf("s1"), "解散群不再出现在表二")
+
+	// 硬删除 g1：仍不展示(dim_channel 残留行被 group JOIN 挡掉)。
+	_, err = ctx.DB().Exec("DELETE FROM `group` WHERE group_no='g1'")
+	require.NoError(t, err)
+	require.NoError(t, etl.RunIncremental())
+	assert.Equal(t, int64(0), channelsOf("s1"), "硬删除群不再出现在表二")
+}
+
+// TestOpanalyticsSpaceNameLikeEscape 验收 P2：表一 name 过滤把 % _ 当字面量(转义)而非通配符。
+func TestOpanalyticsSpaceNameLikeEscape(t *testing.T) {
+	ctx, route, etl := opaSetup(t)
+	seedSpace(t, ctx, "s_underscore", "a_b")
+	seedSpace(t, ctx, "s_literal", "axb")
+	require.NoError(t, etl.RunIncremental())
+
+	var resp struct {
+		Count int64           `json:"count"`
+		List  []spaceListItem `json:"list"`
+	}
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/spaces?start_date="+statDay+"&end_date="+statDay+"&name=a_b"), &resp)
+	assert.Equal(t, int64(1), resp.Count, "name=a_b 只应精确匹配 'a_b'，不应把 _ 当通配匹配到 'axb'")
+	require.Len(t, resp.List, 1)
+	assert.Equal(t, "s_underscore", resp.List[0].SpaceID)
 }

--- a/modules/opanalytics/api_test.go
+++ b/modules/opanalytics/api_test.go
@@ -1,0 +1,406 @@
+package opanalytics
+
+import (
+	"encoding/json"
+	"fmt"
+	"hash/crc32"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const statDay = "2026-06-01"
+
+// ---- harness ----
+
+func opaSetup(t *testing.T) (*config.Context, *wkhttp.WKHttp, *ETL) {
+	t.Helper()
+	s, ctx := testutil.NewTestServer()
+	route := s.GetRoute()
+	route.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	setSuperAdminToken(t, ctx)
+	createMessageShards(t, ctx)
+	cleanOpaAndShards(t, ctx)
+	return ctx, route, NewETL(ctx)
+}
+
+func setSuperAdminToken(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.SuperAdmin)))
+}
+
+func setPlainUserToken(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token, testutil.UID+"@test"))
+}
+
+func shardTables(ctx *config.Context) []string {
+	count := ctx.GetConfig().TablePartitionConfig.MessageTableCount
+	if count <= 0 {
+		return []string{"message"}
+	}
+	tables := []string{"message"}
+	for i := 1; i < count; i++ {
+		tables = append(tables, fmt.Sprintf("message%d", i))
+	}
+	return tables
+}
+
+func shardFor(ctx *config.Context, channelID string) string {
+	count := ctx.GetConfig().TablePartitionConfig.MessageTableCount
+	if count <= 0 {
+		return "message"
+	}
+	idx := crc32.ChecksumIEEE([]byte(channelID)) % uint32(count)
+	if idx == 0 {
+		return "message"
+	}
+	return fmt.Sprintf("message%d", idx)
+}
+
+// createMessageShards creates the message/message1..N shard tables (WuKongIM owns
+// these in prod; no in-repo migration creates them).
+func createMessageShards(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	for _, tbl := range shardTables(ctx) {
+		_, err := ctx.DB().Exec(fmt.Sprintf("CREATE TABLE IF NOT EXISTS `%s` ("+
+			"id BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT,"+
+			"message_id VARCHAR(20) NOT NULL DEFAULT '',"+
+			"from_uid VARCHAR(40) NOT NULL DEFAULT '',"+
+			"channel_id VARCHAR(100) NOT NULL DEFAULT '',"+
+			"channel_type SMALLINT NOT NULL DEFAULT 0,"+
+			"`timestamp` BIGINT NOT NULL DEFAULT 0,"+
+			"`signal` INT NOT NULL DEFAULT 0,"+
+			"payload BLOB,"+
+			"is_deleted INT NOT NULL DEFAULT 0,"+
+			"created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"+
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", tbl))
+		require.NoError(t, err)
+	}
+}
+
+func cleanOpaAndShards(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	tables := append([]string{
+		"octo_dim_member", "octo_dim_channel",
+		"octo_fact_member_channel_daily", "octo_fact_channel_daily",
+	}, shardTables(ctx)...)
+	for _, tbl := range tables {
+		_, err := ctx.DB().Exec(fmt.Sprintf("DELETE FROM `%s`", tbl))
+		require.NoError(t, err)
+	}
+}
+
+// ---- seed helpers ----
+
+func seedUser(t *testing.T, ctx *config.Context, uid, name, email string, robot int) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `user` (uid,name,email,short_no,robot,status,category) VALUES (?,?,?,?,?,1,'')",
+		uid, name, email, uid, robot).Exec()
+	require.NoError(t, err)
+}
+
+func seedSpace(t *testing.T, ctx *config.Context, spaceID, name string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO space (space_id,name,status) VALUES (?,?,1)", spaceID, name).Exec()
+	require.NoError(t, err)
+}
+
+func seedSpaceMember(t *testing.T, ctx *config.Context, spaceID, uid string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO space_member (space_id,uid,status) VALUES (?,?,1)", spaceID, uid).Exec()
+	require.NoError(t, err)
+}
+
+func seedGroup(t *testing.T, ctx *config.Context, groupNo, name, spaceID string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `group` (group_no,name,space_id,status) VALUES (?,?,?,1)", groupNo, name, spaceID).Exec()
+	require.NoError(t, err)
+}
+
+func seedGroupMember(t *testing.T, ctx *config.Context, groupNo, uid string, robot int) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `group_member` (group_no,uid,robot,status) VALUES (?,?,?,1)", groupNo, uid, robot).Exec()
+	require.NoError(t, err)
+}
+
+var msgSeq int64
+
+func insertMsgs(t *testing.T, ctx *config.Context, fromUID, channelID string, channelType uint8, ts int64, count, deleted int) {
+	t.Helper()
+	tbl := shardFor(ctx, channelID)
+	for i := 0; i < count; i++ {
+		msgSeq++
+		isDel := 0
+		if i < deleted {
+			isDel = 1
+		}
+		_, err := ctx.DB().InsertBySql(
+			fmt.Sprintf("INSERT INTO `%s` (message_id,from_uid,channel_id,channel_type,`timestamp`,`signal`,is_deleted) VALUES (?,?,?,?,?,0,?)", tbl),
+			fmt.Sprintf("m%d", msgSeq), fromUID, channelID, channelType, ts+int64(i), isDel).Exec()
+		require.NoError(t, err)
+	}
+}
+
+// ---- HTTP helpers ----
+
+func opaGet(t *testing.T, route *wkhttp.WKHttp, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("token", testutil.Token)
+	rec := httptest.NewRecorder()
+	route.ServeHTTP(rec, req)
+	return rec
+}
+
+func decodeOK(t *testing.T, rec *httptest.ResponseRecorder, out interface{}) {
+	t.Helper()
+	require.Equalf(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), out))
+}
+
+func errorCode(t *testing.T, rec *httptest.ResponseRecorder) string {
+	t.Helper()
+	var env struct {
+		Error struct {
+			Code       string `json:"code"`
+			HTTPStatus int    `json:"http_status"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &env))
+	return env.Error.Code
+}
+
+// ---- the scenario seed ----
+
+// seedScenario builds: 2 spaces, 4 members(3 human + 1 agent), 2 groups, 1 private chat,
+// and a day of messages. Returns the private fakeChannelID.
+func seedScenario(t *testing.T, ctx *config.Context) string {
+	seedSpace(t, ctx, "s1", "Alpha Space")
+	seedSpace(t, ctx, "s2", "Beta Space")
+
+	seedUser(t, ctx, "u_alice", "Alice", "alice@example.com", 0)
+	seedUser(t, ctx, "u_bob", "Bob", "bob@example.com", 0)
+	seedUser(t, ctx, "u_carol", "Carol", "carol@example.com", 0)
+	seedUser(t, ctx, "u_agent", "AgentX", "", 1)
+
+	seedSpaceMember(t, ctx, "s1", "u_alice")
+	seedSpaceMember(t, ctx, "s1", "u_bob")
+	seedSpaceMember(t, ctx, "s1", "u_agent")
+	seedSpaceMember(t, ctx, "s2", "u_carol")
+
+	seedGroup(t, ctx, "g1", "Product Group", "s1")
+	seedGroup(t, ctx, "g2", "Beta Group", "s2")
+	seedGroupMember(t, ctx, "g1", "u_alice", 0)
+	seedGroupMember(t, ctx, "g1", "u_bob", 0)
+	seedGroupMember(t, ctx, "g1", "u_agent", 1)
+	seedGroupMember(t, ctx, "g2", "u_carol", 0)
+
+	start, _, err := dayWindowUnix(statDay)
+	require.NoError(t, err)
+	base := start + 3600 // 当日 01:00，远离边界
+
+	// g1：alice 3(含1撤回)、bob 2、agent 5
+	insertMsgs(t, ctx, "u_alice", "g1", channelTypeGroup, base, 3, 1)
+	insertMsgs(t, ctx, "u_bob", "g1", channelTypeGroup, base+10, 2, 0)
+	insertMsgs(t, ctx, "u_agent", "g1", channelTypeGroup, base+20, 5, 0)
+	// g2：carol 2
+	insertMsgs(t, ctx, "u_carol", "g2", channelTypeGroup, base, 2, 0)
+	// 私聊 alice & bob
+	fc := common.GetFakeChannelIDWith("u_alice", "u_bob")
+	insertMsgs(t, ctx, "u_alice", fc, channelTypePerson, base, 4, 0)
+	insertMsgs(t, ctx, "u_bob", fc, channelTypePerson, base+5, 1, 0)
+	return fc
+}
+
+// ---- tests ----
+
+func TestOpanalyticsETLAndDB(t *testing.T) {
+	ctx, _, etl := opaSetup(t)
+	fc := seedScenario(t, ctx)
+	require.NoError(t, etl.RunDay(statDay))
+
+	// ③ alice 在 g1 含撤回 = 3
+	var aliceMsg int
+	_, err := ctx.DB().Select("msg_count").From("octo_fact_member_channel_daily").
+		Where("channel_id='g1' AND sender_uid='u_alice' AND stat_date=?", statDay).Load(&aliceMsg)
+	require.NoError(t, err)
+	assert.Equal(t, 3, aliceMsg, "撤回消息必须计入")
+
+	// ④ g1
+	var g1 struct {
+		HumanMsg    int    `db:"human_msg_count"`
+		AgentMsg    int    `db:"agent_msg_count"`
+		ActiveHuman int    `db:"active_human_members"`
+		ActiveAgent int    `db:"active_agent_members"`
+		ConvType    uint8  `db:"conv_type"`
+		SpaceID     string `db:"space_id"`
+	}
+	_, err = ctx.DB().Select("human_msg_count", "agent_msg_count", "active_human_members", "active_agent_members", "conv_type", "space_id").
+		From("octo_fact_channel_daily").Where("channel_id='g1' AND stat_date=?", statDay).Load(&g1)
+	require.NoError(t, err)
+	assert.Equal(t, 5, g1.HumanMsg)
+	assert.Equal(t, 5, g1.AgentMsg)
+	assert.Equal(t, 2, g1.ActiveHuman)
+	assert.Equal(t, 1, g1.ActiveAgent)
+	assert.Equal(t, convTypeHAGroup, g1.ConvType)
+	assert.Equal(t, "s1", g1.SpaceID)
+
+	// dim_channel g1 成员数
+	var dimG1 struct {
+		MemberCount int   `db:"member_count"`
+		Human       int   `db:"human_member_count"`
+		Agent       int   `db:"agent_member_count"`
+		LastActive  int64 `db:"last_active_at"`
+	}
+	_, err = ctx.DB().Select("member_count", "human_member_count", "agent_member_count", "last_active_at").
+		From("octo_dim_channel").Where("channel_id='g1'").Load(&dimG1)
+	require.NoError(t, err)
+	assert.Equal(t, 3, dimG1.MemberCount)
+	assert.Equal(t, 2, dimG1.Human)
+	assert.Equal(t, 1, dimG1.Agent)
+	assert.Greater(t, dimG1.LastActive, int64(0))
+
+	// dim_channel 私聊：space_id='' 且 member_a/b 规范化
+	var dimFC struct {
+		ChannelType uint8  `db:"channel_type"`
+		SpaceID     string `db:"space_id"`
+		ConvType    uint8  `db:"conv_type"`
+		MemberA     string `db:"member_a_uid"`
+		MemberB     string `db:"member_b_uid"`
+	}
+	_, err = ctx.DB().Select("channel_type", "space_id", "conv_type", "member_a_uid", "member_b_uid").
+		From("octo_dim_channel").Where("channel_id=?", fc).Load(&dimFC)
+	require.NoError(t, err)
+	assert.Equal(t, channelTypePerson, dimFC.ChannelType)
+	assert.Equal(t, "", dimFC.SpaceID, "私聊不进空间维度")
+	assert.Equal(t, convTypeHHPrivate, dimFC.ConvType)
+	assert.Equal(t, "u_alice", dimFC.MemberA)
+	assert.Equal(t, "u_bob", dimFC.MemberB)
+}
+
+func TestOpanalyticsETLIdempotent(t *testing.T) {
+	ctx, _, etl := opaSetup(t)
+	seedScenario(t, ctx)
+
+	require.NoError(t, etl.RunDay(statDay))
+	rows1, fact1 := countFacts(t, ctx)
+
+	require.NoError(t, etl.RunDay(statDay)) // 重跑
+	rows2, fact2 := countFacts(t, ctx)
+
+	assert.Equal(t, rows1, rows2, "重跑后 ③ 行数应一致")
+	assert.Equal(t, fact1, fact2, "重跑后 ④ 行数应一致")
+
+	// 关键聚合值不变
+	var g1Human int
+	_, err := ctx.DB().Select("human_msg_count").From("octo_fact_channel_daily").
+		Where("channel_id='g1' AND stat_date=?", statDay).Load(&g1Human)
+	require.NoError(t, err)
+	assert.Equal(t, 5, g1Human)
+}
+
+func countFacts(t *testing.T, ctx *config.Context) (int64, int64) {
+	t.Helper()
+	var r3, r4 int64
+	_, err := ctx.DB().Select("count(*)").From("octo_fact_member_channel_daily").Load(&r3)
+	require.NoError(t, err)
+	_, err = ctx.DB().Select("count(*)").From("octo_fact_channel_daily").Load(&r4)
+	require.NoError(t, err)
+	return r3, r4
+}
+
+func TestOpanalyticsEndpoints(t *testing.T) {
+	ctx, route, etl := opaSetup(t)
+	seedScenario(t, ctx)
+	require.NoError(t, etl.RunDay(statDay))
+
+	rng := "?start_date=" + statDay + "&end_date=" + statDay
+
+	// ---- overview ----
+	var ov overviewResp
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/overview"+rng), &ov)
+	assert.Equal(t, int64(2), ov.SpaceTotal)
+	assert.Equal(t, int64(2), ov.GroupTotal)
+	assert.Equal(t, int64(3), ov.HumanMemberTotal)
+	assert.Equal(t, int64(1), ov.AgentTotal)
+	assert.Equal(t, int64(2), ov.ActiveGroups)
+	assert.Equal(t, int64(3), ov.ActiveHumanMembers)
+	assert.Equal(t, int64(1), ov.ActiveAgentMembers)
+	assert.Equal(t, int64(12), ov.HumanMsgCount) // g1:5 + g2:2 + private:5
+	assert.Equal(t, int64(5), ov.AgentMsgCount)
+	assert.Equal(t, int64(1), ov.PrivateActiveCount)
+
+	// ---- spaces (表一) ----
+	var spaces struct {
+		Count int64           `json:"count"`
+		List  []spaceListItem `json:"list"`
+	}
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/spaces"+rng), &spaces)
+	assert.Equal(t, int64(2), spaces.Count)
+	var s1 *spaceListItem
+	for i := range spaces.List {
+		if spaces.List[i].SpaceID == "s1" {
+			s1 = &spaces.List[i]
+		}
+	}
+	require.NotNil(t, s1)
+	assert.Equal(t, int64(1), s1.GroupTotal)
+	assert.Equal(t, int64(2), s1.HumanMemberTotal)
+	assert.Equal(t, int64(1), s1.AgentTotal)
+	assert.Equal(t, int64(5), s1.HumanMsgCount)
+	assert.Equal(t, int64(5), s1.AgentMsgCount)
+	assert.True(t, s1.IsActive)
+
+	// ---- channels (表二，仅群组) ----
+	var channels struct {
+		Count int64             `json:"count"`
+		List  []channelListItem `json:"list"`
+	}
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/spaces/s1/channels"+rng), &channels)
+	assert.Equal(t, int64(1), channels.Count)
+	require.Len(t, channels.List, 1)
+	assert.Equal(t, "g1", channels.List[0].ChannelID)
+	assert.Equal(t, convTypeHAGroup, channels.List[0].ConvType)
+	assert.Equal(t, 3, channels.List[0].MemberCount)
+	assert.Equal(t, int64(5), channels.List[0].HumanMsgCount)
+	assert.Equal(t, int64(5), channels.List[0].AgentMsgCount)
+
+	// 未知 space → 404 (ResponseErrorL：transport 400 + error.code not_found)
+	rec := opaGet(t, route, "/v1/manager/dashboard/spaces/nope/channels"+rng)
+	assert.Equal(t, "err.server.opanalytics.not_found", errorCode(t, rec))
+
+	// ---- global direct chats ----
+	var direct struct {
+		Count int64            `json:"count"`
+		List  []directChatItem `json:"list"`
+	}
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/global/direct-chats"+rng), &direct)
+	assert.Equal(t, int64(1), direct.Count)
+	require.Len(t, direct.List, 1)
+	assert.Equal(t, int64(5), direct.List[0].MsgCount)
+	assert.Equal(t, "Alice", direct.List[0].MemberAName)
+	assert.Equal(t, "Bob", direct.List[0].MemberBName)
+
+	// ---- 非 superAdmin → 403 ----
+	setPlainUserToken(t, ctx)
+	rec = opaGet(t, route, "/v1/manager/dashboard/overview"+rng)
+	assert.Equal(t, "err.server.opanalytics.forbidden", errorCode(t, rec))
+}

--- a/modules/opanalytics/api_test.go
+++ b/modules/opanalytics/api_test.go
@@ -656,3 +656,34 @@ func TestOpanalyticsDimFullRefresh(t *testing.T) {
 	require.NoError(t, etl.RunIncremental())
 	assert.Equal(t, int64(1), humanTotal(), "硬删除 alice 后 human 总数=1(仅 bob)")
 }
+
+// TestOpanalyticsMemberTotalsConsistency 验证概览(Space 路径)与表一的"成员总数"口径一致：
+// 孤儿 space_member(user 表无对应行)在两个接口都不计入(INNER JOIN，而非 LEFT JOIN 误当 human)。
+func TestOpanalyticsMemberTotalsConsistency(t *testing.T) {
+	ctx, route, etl := opaSetup(t)
+	seedScenario(t, ctx)
+	seedSpaceMember(t, ctx, "s1", "u_orphan") // user 表不存在的孤儿成员
+	require.NoError(t, etl.RunIncremental())
+
+	rng := "?start_date=" + statDay + "&end_date=" + statDay
+
+	var ov overviewResp
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/overview"+rng+"&space_ids=s1"), &ov)
+
+	var spaces struct {
+		List []spaceListItem `json:"list"`
+	}
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/spaces"+rng), &spaces)
+	var s1 *spaceListItem
+	for i := range spaces.List {
+		if spaces.List[i].SpaceID == "s1" {
+			s1 = &spaces.List[i]
+		}
+	}
+	require.NotNil(t, s1)
+
+	assert.Equal(t, int64(2), ov.HumanMemberTotal, "概览：孤儿 space_member 不计入")
+	assert.Equal(t, int64(2), s1.HumanMemberTotal, "表一：孤儿 space_member 不计入")
+	assert.Equal(t, ov.HumanMemberTotal, s1.HumanMemberTotal, "概览与表一 human 口径一致")
+	assert.Equal(t, ov.AgentTotal, s1.AgentTotal, "概览与表一 agent 口径一致")
+}

--- a/modules/opanalytics/api_test.go
+++ b/modules/opanalytics/api_test.go
@@ -153,7 +153,15 @@ func seedGroupMember(t *testing.T, ctx *config.Context, groupNo, uid string, rob
 
 var msgSeq int64
 
+// insertMsgs 落 count 条消息。created_at 设为 NOW()-1天，远早于默认 lag(600s)，使其落在
+// 稳定前缀内被 ETL 处理(与机器时钟无关)；message.timestamp(发送时间,用于日切分桶)仍取 ts。
 func insertMsgs(t *testing.T, ctx *config.Context, fromUID, channelID string, channelType uint8, ts int64, count, deleted int) {
+	t.Helper()
+	insertMsgsCreated(t, ctx, fromUID, channelID, channelType, ts, count, deleted, "DATE_SUB(NOW(), INTERVAL 1 DAY)")
+}
+
+// insertMsgsCreated 同 insertMsgs，但显式指定 created_at 的 SQL 表达式(测稳定性闸门用)。
+func insertMsgsCreated(t *testing.T, ctx *config.Context, fromUID, channelID string, channelType uint8, ts int64, count, deleted int, createdAtExpr string) {
 	t.Helper()
 	tbl := shardFor(ctx, channelID)
 	for i := 0; i < count; i++ {
@@ -163,7 +171,7 @@ func insertMsgs(t *testing.T, ctx *config.Context, fromUID, channelID string, ch
 			isDel = 1
 		}
 		_, err := ctx.DB().InsertBySql(
-			fmt.Sprintf("INSERT INTO `%s` (message_id,from_uid,channel_id,channel_type,`timestamp`,`signal`,is_deleted) VALUES (?,?,?,?,?,0,?)", tbl),
+			fmt.Sprintf("INSERT INTO `%s` (message_id,from_uid,channel_id,channel_type,`timestamp`,`signal`,is_deleted,created_at) VALUES (?,?,?,?,?,0,?,%s)", tbl, createdAtExpr),
 			fmt.Sprintf("m%d", msgSeq), fromUID, channelID, channelType, ts+int64(i), isDel).Exec()
 		require.NoError(t, err)
 	}
@@ -542,4 +550,52 @@ func fact4Human(t *testing.T, ctx *config.Context, channelID string) int {
 		Where("channel_id=? AND stat_date=?", channelID, statDay).Load(&n)
 	require.NoError(t, err)
 	return n
+}
+
+// TestOpanalyticsETLWatermarkLag 验收#1：稳定性闸门。created_at 在 lag 窗口内(未稳定)的消息
+// 本轮不处理、游标不越过；待其落库满 lag(此处用 UPDATE 模拟时间流逝)后下一轮被精确补齐，不漏不重。
+func TestOpanalyticsETLWatermarkLag(t *testing.T) {
+	ctx, _, etl := opaSetup(t)
+	seedScenario(t, ctx)
+	require.NoError(t, etl.RunIncremental())
+	require.Equal(t, 3, fact3Msg(t, ctx, "g1", "u_alice"), "稳定消息首轮入账")
+
+	// 新增 2 条"刚落库"(created_at=NOW())的未稳定消息：默认 lag=600s 内，本轮应被跳过。
+	start, _, err := dayWindowUnix(statDay)
+	require.NoError(t, err)
+	insertMsgsCreated(t, ctx, "u_alice", "g1", channelTypeGroup, start+9000, 2, 0, "NOW()")
+	require.NoError(t, etl.RunIncremental())
+	assert.Equal(t, 3, fact3Msg(t, ctx, "g1", "u_alice"), "未稳定(lag内)消息本轮必须不入账")
+
+	// 关键反例：游标不得越过未稳定行。把它们 created_at 拨老(模拟过了 lag)后，下一轮必须补上。
+	g1tbl := shardFor(ctx, "g1")
+	_, err = ctx.DB().Exec(fmt.Sprintf(
+		"UPDATE `%s` SET created_at=DATE_SUB(NOW(), INTERVAL 1 DAY) WHERE channel_id='g1' AND from_uid='u_alice' AND created_at >= DATE_SUB(NOW(), INTERVAL 60 SECOND)", g1tbl))
+	require.NoError(t, err)
+	require.NoError(t, etl.RunIncremental())
+	assert.Equal(t, 5, fact3Msg(t, ctx, "g1", "u_alice"), "稳定后必须精确补齐(3+2=5，不漏不重)")
+}
+
+// TestOpanalyticsETLRebuild 验收#2：口径回溯逃生门。把某成员事后改成 system 排除账号后，
+// 普通增量不回溯历史；Rebuild() 用当前维表全量重算，旧统计被清除。
+func TestOpanalyticsETLRebuild(t *testing.T) {
+	ctx, _, etl := opaSetup(t)
+	seedScenario(t, ctx)
+	require.NoError(t, etl.RunIncremental())
+	require.Equal(t, 2, fact3Msg(t, ctx, "g1", "u_bob"), "bob 初始入账 2")
+	require.Equal(t, 5, fact4Human(t, ctx, "g1"), "g1 human 初始 5")
+
+	// 事后把 bob 标记为 system 排除账号(口径漂移)。
+	_, err := ctx.DB().Exec("UPDATE `user` SET category='system' WHERE uid='u_bob'")
+	require.NoError(t, err)
+
+	// 普通增量不回溯：bob 旧统计仍在(event-time 语义)。
+	require.NoError(t, etl.RunIncremental())
+	assert.Equal(t, 2, fact3Msg(t, ctx, "g1", "u_bob"), "增量不回溯历史口径")
+	assert.Equal(t, 5, fact4Human(t, ctx, "g1"))
+
+	// Rebuild 用当前维表全量重算：bob 被排除，其历史统计清除。
+	require.NoError(t, etl.Rebuild())
+	assert.Equal(t, 0, fact3Msg(t, ctx, "g1", "u_bob"), "Rebuild 后被排除成员的历史行清除")
+	assert.Equal(t, 3, fact4Human(t, ctx, "g1"), "Rebuild 后 g1 human=3(alice 3，bob 被排除)")
 }

--- a/modules/opanalytics/api_test.go
+++ b/modules/opanalytics/api_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/go-redis/redis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +31,22 @@ func opaSetup(t *testing.T) (*config.Context, *wkhttp.WKHttp, *ETL) {
 	setSuperAdminToken(t, ctx)
 	createMessageShards(t, ctx)
 	cleanOpaAndShards(t, ctx)
+	resetUIDRateLimit(t, ctx)
 	return ctx, route, NewETL(ctx)
+}
+
+// resetUIDRateLimit 清空 SharedUIDRateLimiter 的每-uid 令牌桶(ratelimit:uid:*)。该桶持久在
+// Redis、跨测试残留且不被 CleanAllTables 清，须在 setup 重置，否则同一 binary 内靠后的测试会 429。
+func resetUIDRateLimit(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	rds := redis.NewClient(&redis.Options{
+		Addr:     ctx.GetConfig().DB.RedisAddr,
+		Password: ctx.GetConfig().DB.RedisPass,
+	})
+	defer rds.Close()
+	if keys, err := rds.Keys("ratelimit:uid:*").Result(); err == nil && len(keys) > 0 {
+		_ = rds.Del(keys...).Err()
+	}
 }
 
 func setSuperAdminToken(t *testing.T, ctx *config.Context) {
@@ -366,6 +382,19 @@ func TestOpanalyticsEndpoints(t *testing.T) {
 	assert.Equal(t, int64(5), ov.AgentMsgCount)
 	assert.Equal(t, int64(1), ov.PrivateActiveCount)
 
+	// ---- overview 限定 Space=s1：总数也随筛选收敛(否则活跃比例失真) ----
+	var ovS1 overviewResp
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/overview"+rng+"&space_ids=s1"), &ovS1)
+	assert.Equal(t, int64(1), ovS1.SpaceTotal, "选中 s1 → 空间总数=1")
+	assert.Equal(t, int64(1), ovS1.GroupTotal, "s1 仅 g1")
+	assert.Equal(t, int64(2), ovS1.HumanMemberTotal, "s1 在册 human=alice,bob")
+	assert.Equal(t, int64(1), ovS1.AgentTotal, "s1 在册 agent=u_agent")
+	assert.Equal(t, int64(1), ovS1.ActiveGroups)
+	assert.Equal(t, int64(2), ovS1.ActiveHumanMembers)
+	assert.Equal(t, int64(1), ovS1.ActiveAgentMembers)
+	assert.Equal(t, int64(5), ovS1.HumanMsgCount, "私聊/g2 不计入 s1")
+	assert.Equal(t, int64(5), ovS1.AgentMsgCount)
+
 	// ---- spaces (表一) ----
 	var spaces struct {
 		Count int64           `json:"count"`
@@ -598,4 +627,32 @@ func TestOpanalyticsETLRebuild(t *testing.T) {
 	require.NoError(t, etl.Rebuild())
 	assert.Equal(t, 0, fact3Msg(t, ctx, "g1", "u_bob"), "Rebuild 后被排除成员的历史行清除")
 	assert.Equal(t, 3, fact4Human(t, ctx, "g1"), "Rebuild 后 g1 human=3(alice 3，bob 被排除)")
+}
+
+// TestOpanalyticsDimFullRefresh 验收#2(维表全量刷新)：禁用(status≠1)用户从成员总数剔除、
+// 硬删除用户不残留；而其历史消息按 event-time 仍保留。
+func TestOpanalyticsDimFullRefresh(t *testing.T) {
+	ctx, route, etl := opaSetup(t)
+	seedScenario(t, ctx)
+	require.NoError(t, etl.RunIncremental())
+
+	humanTotal := func() int64 {
+		var ov overviewResp
+		decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/overview?start_date="+statDay+"&end_date="+statDay), &ov)
+		return ov.HumanMemberTotal
+	}
+	require.Equal(t, int64(3), humanTotal(), "初始 human 总数=alice,bob,carol")
+
+	// 禁用 carol：全量刷新后从总数剔除，但其 g2 历史消息(event-time)仍在。
+	_, err := ctx.DB().Exec("UPDATE `user` SET status=0 WHERE uid='u_carol'")
+	require.NoError(t, err)
+	require.NoError(t, etl.RunIncremental())
+	assert.Equal(t, int64(2), humanTotal(), "禁用 carol 后 human 总数=2")
+	assert.Equal(t, 2, fact4Human(t, ctx, "g2"), "carol 历史消息按 event-time 保留")
+
+	// 硬删除 alice：全量替换不残留陈旧 dim 行，总数再降。
+	_, err = ctx.DB().Exec("DELETE FROM `user` WHERE uid='u_alice'")
+	require.NoError(t, err)
+	require.NoError(t, etl.RunIncremental())
+	assert.Equal(t, int64(1), humanTotal(), "硬删除 alice 后 human 总数=1(仅 bob)")
 }

--- a/modules/opanalytics/config.go
+++ b/modules/opanalytics/config.go
@@ -2,6 +2,7 @@ package opanalytics
 
 import (
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -13,8 +14,16 @@ import (
 // 做成 config 不硬编码；天粒度，不上小时桶。message.timestamp 是绝对纪元秒，
 // 报告时区只在 ETL 日切分桶 / handler 解析 start_date~end_date 时应用。
 const (
-	envReportTimezone     = "DM_OPANALYTICS_TIMEZONE"
+	envReportTimezone     = "OCTO_OPANALYTICS_TIMEZONE"
 	defaultReportTimezone = "Asia/Shanghai"
+
+	// envETLBatch 单次 keyset 分页从 message 分片抽取的行数上限。增量抽取按
+	// `WHERE id>cursor ORDER BY id LIMIT batch` 流式读取，batch 同时界定单 chunk
+	// 的内存与持锁时长；过大增加事务/锁压力，过小增加往返。
+	envETLBatch     = "OCTO_OPANALYTICS_ETL_BATCH"
+	defaultETLBatch = 5000
+	minETLBatch     = 100
+	maxETLBatch     = 50000
 )
 
 var (
@@ -22,7 +31,7 @@ var (
 	_reportOnce sync.Once
 )
 
-// reportLocation 返回部署级报告时区。读取 DM_OPANALYTICS_TIMEZONE(IANA 名)，
+// reportLocation 返回部署级报告时区。读取 OCTO_OPANALYTICS_TIMEZONE(IANA 名)，
 // 缺省东八；解析失败时告警并回退东八，永不 panic。
 func reportLocation() *time.Location {
 	_reportOnce.Do(func() {
@@ -32,7 +41,7 @@ func reportLocation() *time.Location {
 		}
 		loc, err := time.LoadLocation(name)
 		if err != nil {
-			log.Warn("invalid DM_OPANALYTICS_TIMEZONE, falling back to default",
+			log.Warn("invalid OCTO_OPANALYTICS_TIMEZONE, falling back to default",
 				zap.String("value", name), zap.String("fallback", defaultReportTimezone), zap.Error(err))
 			loc, err = time.LoadLocation(defaultReportTimezone)
 			if err != nil {
@@ -42,4 +51,27 @@ func reportLocation() *time.Location {
 		_reportLoc = loc
 	})
 	return _reportLoc
+}
+
+// etlBatchSize 返回增量抽取的分页大小(读 OCTO_OPANALYTICS_ETL_BATCH，钳制到 [min,max])。
+func etlBatchSize() int {
+	v := os.Getenv(envETLBatch)
+	if v == "" {
+		return defaultETLBatch
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < minETLBatch {
+		if err != nil {
+			log.Warn("invalid OCTO_OPANALYTICS_ETL_BATCH, using default",
+				zap.String("value", v), zap.Int("default", defaultETLBatch), zap.Error(err))
+		}
+		if n < minETLBatch {
+			return minETLBatch
+		}
+		return defaultETLBatch
+	}
+	if n > maxETLBatch {
+		return maxETLBatch
+	}
+	return n
 }

--- a/modules/opanalytics/config.go
+++ b/modules/opanalytics/config.go
@@ -1,0 +1,45 @@
+package opanalytics
+
+import (
+	"os"
+	"sync"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"go.uber.org/zap"
+)
+
+// 报告时区为**部署级**配置(国内/海外分开部署、独立库)：国内默认东八，海外配当地。
+// 做成 config 不硬编码；天粒度，不上小时桶。message.timestamp 是绝对纪元秒，
+// 报告时区只在 ETL 日切分桶 / handler 解析 start_date~end_date 时应用。
+const (
+	envReportTimezone     = "DM_OPANALYTICS_TIMEZONE"
+	defaultReportTimezone = "Asia/Shanghai"
+)
+
+var (
+	_reportLoc  *time.Location
+	_reportOnce sync.Once
+)
+
+// reportLocation 返回部署级报告时区。读取 DM_OPANALYTICS_TIMEZONE(IANA 名)，
+// 缺省东八；解析失败时告警并回退东八，永不 panic。
+func reportLocation() *time.Location {
+	_reportOnce.Do(func() {
+		name := os.Getenv(envReportTimezone)
+		if name == "" {
+			name = defaultReportTimezone
+		}
+		loc, err := time.LoadLocation(name)
+		if err != nil {
+			log.Warn("invalid DM_OPANALYTICS_TIMEZONE, falling back to default",
+				zap.String("value", name), zap.String("fallback", defaultReportTimezone), zap.Error(err))
+			loc, err = time.LoadLocation(defaultReportTimezone)
+			if err != nil {
+				loc = time.FixedZone("CST", 8*3600)
+			}
+		}
+		_reportLoc = loc
+	})
+	return _reportLoc
+}

--- a/modules/opanalytics/config.go
+++ b/modules/opanalytics/config.go
@@ -24,6 +24,16 @@ const (
 	defaultETLBatch = 5000
 	minETLBatch     = 100
 	maxETLBatch     = 50000
+
+	// envETLLagSeconds 抽取稳定性滞后窗口(秒)。message.id 在 INSERT 时分配、COMMIT 时
+	// 才可见，而提交顺序≠id 顺序：低 id 的事务可能晚于高 id 提交。若严格按 id>cursor 推进，
+	// 会漏掉"已被游标越过、之后才提交"的低 id 行。对策：只处理 created_at ≤ DB_NOW-lag 的
+	// 已稳定前缀(id 与 created_at 同在 insert 时刻分配、近似同序，故稳定行构成无空洞前缀)，
+	// 游标只推进到该前缀末尾。要求 lag > 单条消息落库事务的最大时长(消息热路径写入近乎即时
+	// 提交，默认 10min 远超之)。设 0 关闭(仅测试/单实例可控场景)。
+	envETLLagSeconds     = "OCTO_OPANALYTICS_ETL_LAG_SECONDS"
+	defaultETLLagSeconds = 600
+	maxETLLagSeconds     = 86400
 )
 
 var (
@@ -72,6 +82,28 @@ func etlBatchSize() int {
 	}
 	if n > maxETLBatch {
 		return maxETLBatch
+	}
+	return n
+}
+
+// etlLagSeconds 返回抽取稳定性滞后窗口秒数(读 OCTO_OPANALYTICS_ETL_LAG_SECONDS，
+// 钳制到 [0,max])。解析失败回退默认值。
+func etlLagSeconds() int64 {
+	v := os.Getenv(envETLLagSeconds)
+	if v == "" {
+		return defaultETLLagSeconds
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		log.Warn("invalid OCTO_OPANALYTICS_ETL_LAG_SECONDS, using default",
+			zap.String("value", v), zap.Int64("default", defaultETLLagSeconds), zap.Error(err))
+		return defaultETLLagSeconds
+	}
+	if n < 0 {
+		return 0
+	}
+	if n > maxETLLagSeconds {
+		return maxETLLagSeconds
 	}
 	return n
 }

--- a/modules/opanalytics/db.go
+++ b/modules/opanalytics/db.go
@@ -1,0 +1,369 @@
+package opanalytics
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/gocraft/dbr/v2"
+)
+
+// opanalyticsDB 看板读侧数据访问层(只查预聚合表 + space/group/dim 维表)。
+type opanalyticsDB struct {
+	ctx     *config.Context
+	session *dbr.Session
+}
+
+func newOpanalyticsDB(ctx *config.Context) *opanalyticsDB {
+	return &opanalyticsDB{ctx: ctx, session: ctx.DB()}
+}
+
+// ===== 概览(模块A) =====
+
+func (d *opanalyticsDB) countSpacesTotal() (int64, error) {
+	var n int64
+	_, err := d.session.Select("count(*)").From("space").Where("status=1").Load(&n)
+	return n, err
+}
+
+func (d *opanalyticsDB) countGroupsTotal() (int64, error) {
+	var n int64
+	_, err := d.session.Select("count(*)").From("`group`").Where("status=1").Load(&n)
+	return n, err
+}
+
+// countMembersByType 全局 human/agent 成员总数(源 dim_member；P0 不按 is_excluded 过滤)。
+func (d *opanalyticsDB) countMembersByType() (human int64, agent int64, err error) {
+	var rows []struct {
+		MemberType uint8 `db:"member_type"`
+		Cnt        int64 `db:"cnt"`
+	}
+	_, err = d.session.SelectBySql(
+		"SELECT member_type, COUNT(*) AS cnt FROM octo_dim_member GROUP BY member_type",
+	).Load(&rows)
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, r := range rows {
+		if r.MemberType == memberTypeAgent {
+			agent = r.Cnt
+		} else {
+			human = r.Cnt
+		}
+	}
+	return human, agent, nil
+}
+
+// overviewMsgAndGroups 范围内人/agent 消息量与活跃群数(可选 space 过滤)。
+func (d *opanalyticsDB) overviewMsgAndGroups(start, end string, spaceIDs []string) (humanMsg, agentMsg, activeGroups int64, err error) {
+	var res struct {
+		HumanMsg     int64 `db:"human_msg"`
+		AgentMsg     int64 `db:"agent_msg"`
+		ActiveGroups int64 `db:"active_groups"`
+	}
+	stmt := d.session.Select(
+		"IFNULL(SUM(human_msg_count),0) AS human_msg",
+		"IFNULL(SUM(agent_msg_count),0) AS agent_msg",
+		"COUNT(DISTINCT CASE WHEN channel_type=2 THEN channel_id END) AS active_groups",
+	).From("octo_fact_channel_daily").Where("stat_date BETWEEN ? AND ?", start, end)
+	stmt = applySpaceFilter(stmt, spaceIDs)
+	_, err = stmt.Load(&res)
+	return res.HumanMsg, res.AgentMsg, res.ActiveGroups, err
+}
+
+// overviewActiveMembers 范围内活跃 human/agent 成员去重数(可选 space 过滤)。
+func (d *opanalyticsDB) overviewActiveMembers(start, end string, spaceIDs []string) (human, agent int64, err error) {
+	var res struct {
+		ActiveHuman int64 `db:"active_human"`
+		ActiveAgent int64 `db:"active_agent"`
+	}
+	stmt := d.session.Select(
+		"COUNT(DISTINCT CASE WHEN sender_type=1 THEN sender_uid END) AS active_human",
+		"COUNT(DISTINCT CASE WHEN sender_type=2 THEN sender_uid END) AS active_agent",
+	).From("octo_fact_member_channel_daily").Where("stat_date BETWEEN ? AND ?", start, end)
+	stmt = applySpaceFilter(stmt, spaceIDs)
+	_, err = stmt.Load(&res)
+	return res.ActiveHuman, res.ActiveAgent, err
+}
+
+// privateActiveCount 范围内活跃私聊数(口径1：只出活跃数；全局，永不按 space 过滤)。
+func (d *opanalyticsDB) privateActiveCount(start, end string) (int64, error) {
+	var n int64
+	_, err := d.session.Select("COUNT(DISTINCT channel_id)").
+		From("octo_fact_channel_daily").
+		Where("channel_type=1 AND stat_date BETWEEN ? AND ?", start, end).
+		Load(&n)
+	return n, err
+}
+
+// ===== 表一 Space 列表(在内存合并/排序/分页，spaces 数量适中) =====
+
+type spaceBaseRow struct {
+	SpaceID string `db:"space_id"`
+	Name    string `db:"name"`
+}
+
+func (d *opanalyticsDB) querySpaceBase(nameLike string) ([]*spaceBaseRow, error) {
+	var rows []*spaceBaseRow
+	stmt := d.session.Select("space_id", "name").From("space").Where("status=1")
+	if nameLike != "" {
+		stmt = stmt.Where("name LIKE ?", "%"+nameLike+"%")
+	}
+	_, err := stmt.Load(&rows)
+	return rows, err
+}
+
+func (d *opanalyticsDB) queryGroupCountBySpace() (map[string]int64, error) {
+	var rows []struct {
+		SpaceID string `db:"space_id"`
+		Cnt     int64  `db:"cnt"`
+	}
+	_, err := d.session.SelectBySql(
+		"SELECT space_id, COUNT(*) AS cnt FROM `group` WHERE status=1 GROUP BY space_id",
+	).Load(&rows)
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]int64, len(rows))
+	for _, r := range rows {
+		m[r.SpaceID] = r.Cnt
+	}
+	return m, nil
+}
+
+type spaceMemberTotals struct {
+	Human int64
+	Agent int64
+}
+
+func (d *opanalyticsDB) queryMemberTotalsBySpace() (map[string]spaceMemberTotals, error) {
+	var rows []struct {
+		SpaceID string `db:"space_id"`
+		Agent   int64  `db:"agent"`
+		Total   int64  `db:"total"`
+	}
+	_, err := d.session.SelectBySql(
+		"SELECT sm.space_id AS space_id, " +
+			"SUM(CASE WHEN m.member_type=2 THEN 1 ELSE 0 END) AS agent, COUNT(*) AS total " +
+			"FROM space_member sm LEFT JOIN octo_dim_member m ON m.uid = sm.uid " +
+			"WHERE sm.status=1 GROUP BY sm.space_id",
+	).Load(&rows)
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]spaceMemberTotals, len(rows))
+	for _, r := range rows {
+		m[r.SpaceID] = spaceMemberTotals{Human: r.Total - r.Agent, Agent: r.Agent}
+	}
+	return m, nil
+}
+
+type spaceActiveAgg struct {
+	HumanMsg   int64
+	AgentMsg   int64
+	LastActive int64
+}
+
+func (d *opanalyticsDB) queryActiveAggBySpace(start, end string) (map[string]spaceActiveAgg, error) {
+	var rows []struct {
+		SpaceID    string `db:"space_id"`
+		HumanMsg   int64  `db:"human_msg"`
+		AgentMsg   int64  `db:"agent_msg"`
+		LastActive int64  `db:"last_active"`
+	}
+	_, err := d.session.Select(
+		"space_id",
+		"IFNULL(SUM(human_msg_count),0) AS human_msg",
+		"IFNULL(SUM(agent_msg_count),0) AS agent_msg",
+		"IFNULL(MAX(last_msg_at),0) AS last_active",
+	).From("octo_fact_channel_daily").
+		Where("stat_date BETWEEN ? AND ? AND channel_type=2 AND space_id<>''", start, end).
+		GroupBy("space_id").Load(&rows)
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]spaceActiveAgg, len(rows))
+	for _, r := range rows {
+		m[r.SpaceID] = spaceActiveAgg{HumanMsg: r.HumanMsg, AgentMsg: r.AgentMsg, LastActive: r.LastActive}
+	}
+	return m, nil
+}
+
+// ===== 表二 群组列表(SQL 侧 LEFT JOIN + 分页) =====
+
+// channelSortColumns 排序白名单(防注入)。
+var channelSortColumns = map[string]string{
+	"human_msg_count": "human_msg",
+	"agent_msg_count": "agent_msg",
+	"total_msg":       "(human_msg+agent_msg)",
+	"member_count":    "c.member_count",
+	"last_active":     "c.last_active_at",
+}
+
+// queryChannelList 表二群组列表(仅 channel_type=2)。activeStatus ∈ {all,active,inactive}。
+func (d *opanalyticsDB) queryChannelList(spaceID, start, end, activeStatus, sortBy, order string, offset, limit int) ([]*channelListItem, int64, error) {
+	sortExpr, ok := channelSortColumns[sortBy]
+	if !ok {
+		sortExpr = "c.last_active_at"
+	}
+	dir := "DESC"
+	if strings.EqualFold(order, "asc") {
+		dir = "ASC"
+	}
+	activeCond := channelActiveCond(activeStatus)
+
+	base := "FROM octo_dim_channel c " +
+		"LEFT JOIN (SELECT channel_id, SUM(human_msg_count) AS hm, SUM(agent_msg_count) AS am " +
+		"FROM octo_fact_channel_daily WHERE stat_date BETWEEN ? AND ? AND space_id=? AND channel_type=2 " +
+		"GROUP BY channel_id) f ON f.channel_id=c.channel_id " +
+		"WHERE c.space_id=? AND c.channel_type=2" + activeCond
+
+	// 计数
+	var total int64
+	cntArgs := []interface{}{start, end, spaceID, spaceID}
+	_, err := d.session.SelectBySql("SELECT COUNT(*) "+base, cntArgs...).Load(&total)
+	if err != nil {
+		return nil, 0, err
+	}
+	if total == 0 {
+		return []*channelListItem{}, 0, nil
+	}
+
+	sel := "SELECT c.channel_id, c.name, c.conv_type, c.member_count, c.human_member_count, c.agent_member_count, " +
+		"c.status, c.last_active_at, IFNULL(f.hm,0) AS human_msg, IFNULL(f.am,0) AS agent_msg, " +
+		"(f.channel_id IS NOT NULL) AS is_active " + base +
+		fmt.Sprintf(" ORDER BY %s %s, c.channel_id ASC LIMIT ? OFFSET ?", sortExpr, dir)
+	listArgs := []interface{}{start, end, spaceID, spaceID, limit, offset}
+
+	var rows []struct {
+		ChannelID        string `db:"channel_id"`
+		Name             string `db:"name"`
+		ConvType         uint8  `db:"conv_type"`
+		MemberCount      int    `db:"member_count"`
+		HumanMemberCount int    `db:"human_member_count"`
+		AgentMemberCount int    `db:"agent_member_count"`
+		Status           uint8  `db:"status"`
+		LastActiveAt     int64  `db:"last_active_at"`
+		HumanMsg         int64  `db:"human_msg"`
+		AgentMsg         int64  `db:"agent_msg"`
+		IsActive         bool   `db:"is_active"`
+	}
+	if _, err = d.session.SelectBySql(sel, listArgs...).Load(&rows); err != nil {
+		return nil, 0, err
+	}
+	out := make([]*channelListItem, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, &channelListItem{
+			ChannelID: r.ChannelID, Name: r.Name, ConvType: r.ConvType,
+			MemberCount: r.MemberCount, HumanMemberCount: r.HumanMemberCount, AgentMemberCount: r.AgentMemberCount,
+			HumanMsgCount: r.HumanMsg, AgentMsgCount: r.AgentMsg,
+			LastActiveAt: r.LastActiveAt, Status: r.Status, IsActive: r.IsActive,
+		})
+	}
+	return out, total, nil
+}
+
+func (d *opanalyticsDB) spaceExists(spaceID string) (bool, error) {
+	var n int64
+	_, err := d.session.Select("count(*)").From("space").Where("space_id=?", spaceID).Load(&n)
+	return n > 0, err
+}
+
+// ===== 全局私聊活跃列表(SQL 侧聚合 + 分页) =====
+
+var directSortColumns = map[string]string{
+	"msg_count":   "msg_count",
+	"last_active": "last_active",
+}
+
+func (d *opanalyticsDB) queryDirectChatList(start, end, sortBy, order string, offset, limit int) ([]*directChatItem, int64, error) {
+	sortExpr, ok := directSortColumns[sortBy]
+	if !ok {
+		sortExpr = "last_active"
+	}
+	dir := "DESC"
+	if strings.EqualFold(order, "asc") {
+		dir = "ASC"
+	}
+
+	var total int64
+	_, err := d.session.Select("COUNT(DISTINCT channel_id)").
+		From("octo_fact_channel_daily").
+		Where("channel_type=1 AND stat_date BETWEEN ? AND ?", start, end).
+		Load(&total)
+	if err != nil {
+		return nil, 0, err
+	}
+	if total == 0 {
+		return []*directChatItem{}, 0, nil
+	}
+
+	sel := "SELECT f.channel_id AS channel_id, c.member_a_uid AS member_a_uid, c.member_b_uid AS member_b_uid, " +
+		"c.conv_type AS conv_type, SUM(f.human_msg_count + f.agent_msg_count) AS msg_count, MAX(f.last_msg_at) AS last_active " +
+		"FROM octo_fact_channel_daily f JOIN octo_dim_channel c ON c.channel_id=f.channel_id " +
+		"WHERE f.channel_type=1 AND f.stat_date BETWEEN ? AND ? " +
+		"GROUP BY f.channel_id, c.member_a_uid, c.member_b_uid, c.conv_type " +
+		fmt.Sprintf("ORDER BY %s %s, f.channel_id ASC LIMIT ? OFFSET ?", sortExpr, dir)
+
+	var rows []struct {
+		ChannelID  string `db:"channel_id"`
+		MemberAUID string `db:"member_a_uid"`
+		MemberBUID string `db:"member_b_uid"`
+		ConvType   uint8  `db:"conv_type"`
+		MsgCount   int64  `db:"msg_count"`
+		LastActive int64  `db:"last_active"`
+	}
+	if _, err = d.session.SelectBySql(sel, start, end, limit, offset).Load(&rows); err != nil {
+		return nil, 0, err
+	}
+
+	out := make([]*directChatItem, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, &directChatItem{
+			ChannelID: r.ChannelID, MemberAUID: r.MemberAUID, MemberBUID: r.MemberBUID,
+			ConvType: r.ConvType, MsgCount: r.MsgCount, LastActive: r.LastActive,
+		})
+	}
+	return out, total, nil
+}
+
+// queryMemberNames 批量取 uid→展示名(用于私聊"A & B"展示)。
+func (d *opanalyticsDB) queryMemberNames(uids []string) (map[string]string, error) {
+	if len(uids) == 0 {
+		return map[string]string{}, nil
+	}
+	var rows []struct {
+		UID  string `db:"uid"`
+		Name string `db:"name"`
+	}
+	_, err := d.session.Select("uid", "name").From("octo_dim_member").Where("uid IN ?", uids).Load(&rows)
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]string, len(rows))
+	for _, r := range rows {
+		m[r.UID] = r.Name
+	}
+	return m, nil
+}
+
+// ===== 内部辅助 =====
+
+func applySpaceFilter(stmt *dbr.SelectStmt, spaceIDs []string) *dbr.SelectStmt {
+	if len(spaceIDs) > 0 {
+		stmt = stmt.Where("space_id IN ?", spaceIDs)
+	}
+	return stmt
+}
+
+// channelActiveCond 返回拼接到 WHERE 的活跃过滤片段。
+func channelActiveCond(activeStatus string) string {
+	switch activeStatus {
+	case "active":
+		return " AND f.channel_id IS NOT NULL"
+	case "inactive":
+		return " AND f.channel_id IS NULL"
+	default:
+		return ""
+	}
+}

--- a/modules/opanalytics/db.go
+++ b/modules/opanalytics/db.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"github.com/gocraft/dbr/v2"
 )
 
@@ -32,14 +33,14 @@ func (d *opanalyticsDB) countGroupsTotal() (int64, error) {
 	return n, err
 }
 
-// countMembersByType 全局 human/agent 成员总数(源 dim_member；P0 不按 is_excluded 过滤)。
+// countMembersByType 全局 human/agent 成员总数(源 dim_member；剔除系统/测试账号 is_excluded=1)。
 func (d *opanalyticsDB) countMembersByType() (human int64, agent int64, err error) {
 	var rows []struct {
 		MemberType uint8 `db:"member_type"`
 		Cnt        int64 `db:"cnt"`
 	}
 	_, err = d.session.SelectBySql(
-		"SELECT member_type, COUNT(*) AS cnt FROM octo_dim_member GROUP BY member_type",
+		"SELECT member_type, COUNT(*) AS cnt FROM octo_dim_member WHERE is_excluded=0 GROUP BY member_type",
 	).Load(&rows)
 	if err != nil {
 		return 0, 0, err
@@ -142,11 +143,13 @@ func (d *opanalyticsDB) queryMemberTotalsBySpace() (map[string]spaceMemberTotals
 		Agent   int64  `db:"agent"`
 		Total   int64  `db:"total"`
 	}
+	botClause, botArgs := systemBotExclusion("sm.uid")
 	_, err := d.session.SelectBySql(
-		"SELECT sm.space_id AS space_id, " +
-			"SUM(CASE WHEN m.member_type=2 THEN 1 ELSE 0 END) AS agent, COUNT(*) AS total " +
-			"FROM space_member sm LEFT JOIN octo_dim_member m ON m.uid = sm.uid " +
-			"WHERE sm.status=1 GROUP BY sm.space_id",
+		"SELECT sm.space_id AS space_id, "+
+			"SUM(CASE WHEN m.member_type=2 THEN 1 ELSE 0 END) AS agent, COUNT(*) AS total "+
+			"FROM space_member sm LEFT JOIN octo_dim_member m ON m.uid = sm.uid "+
+			"WHERE sm.status=1 AND COALESCE(m.is_excluded,0)=0"+botClause+" GROUP BY sm.space_id",
+		botArgs...,
 	).Load(&rows)
 	if err != nil {
 		return nil, err
@@ -348,6 +351,19 @@ func (d *opanalyticsDB) queryMemberNames(uids []string) (map[string]string, erro
 }
 
 // ===== 内部辅助 =====
+
+// systemBotExclusion 返回 "AND <col> NOT IN (?,?...)" 片段与对应参数，按单一真源
+// pkg/space.SystemBots(botfather/u_10000/fileHelper/notification) 在成员计数处结构性
+// 剔除系统账号 —— 兜底"系统bot是 space/group 成员但无 user/dim 行致 COALESCE 漏算"的场景。
+func systemBotExclusion(col string) (string, []interface{}) {
+	bots := spacepkg.SystemBotList()
+	ph := strings.TrimSuffix(strings.Repeat("?,", len(bots)), ",")
+	args := make([]interface{}, len(bots))
+	for i, b := range bots {
+		args[i] = b
+	}
+	return " AND " + col + " NOT IN (" + ph + ")", args
+}
 
 func applySpaceFilter(stmt *dbr.SelectStmt, spaceIDs []string) *dbr.SelectStmt {
 	if len(spaceIDs) > 0 {

--- a/modules/opanalytics/db.go
+++ b/modules/opanalytics/db.go
@@ -94,22 +94,34 @@ func (d *opanalyticsDB) overviewMsgAndGroups(start, end string, spaceIDs []strin
 }
 
 // overviewActiveMembers 范围内活跃 human/agent 成员去重数(可选 space 过滤)。
-// JOIN dim_member 且 is_excluded=0：活跃成员只算**当前在册**的人(剔除事后被禁用/删除/系统账号)，
-// 使"活跃成员 ⊆ 总成员"、活跃率 ≤100%。消息量(volume)仍按 event-time 保留，二者口径有意不同。
+//
+// 与总成数**同口径**，保证 active ⊆ total、率 ≤100%：
+//   - 按**当前** dim_member.member_type 拆 human/agent(不用 ③ 里冻结的 sender_type，否则成员
+//     由 human 转 agent 后会同时撑大 active_human 与 agent_total 而对不齐)。
+//   - is_excluded=0 剔除系统/测试/禁用账号。
+//   - 选中 Space 时再 JOIN space_member(status=1) 约束为该 Space 的**当前在册**成员
+//     (否则"在群里发过言后退出空间"的人会计活跃却不计总数)。
+//   - 消息量(volume)仍按 event-time 保留，与成员口径有意不同。
 func (d *opanalyticsDB) overviewActiveMembers(start, end string, spaceIDs []string) (human, agent int64, err error) {
 	var res struct {
 		ActiveHuman int64 `db:"active_human"`
 		ActiveAgent int64 `db:"active_agent"`
 	}
 	sql := "SELECT " +
-		"COUNT(DISTINCT CASE WHEN f.sender_type=1 THEN f.sender_uid END) AS active_human, " +
-		"COUNT(DISTINCT CASE WHEN f.sender_type=2 THEN f.sender_uid END) AS active_agent " +
-		"FROM octo_fact_member_channel_daily f JOIN octo_dim_member m ON m.uid = f.sender_uid " +
-		"WHERE f.stat_date BETWEEN ? AND ? AND m.is_excluded=0"
-	args := []interface{}{start, end}
+		"COUNT(DISTINCT CASE WHEN m.member_type=1 THEN f.sender_uid END) AS active_human, " +
+		"COUNT(DISTINCT CASE WHEN m.member_type=2 THEN f.sender_uid END) AS active_agent " +
+		"FROM octo_fact_member_channel_daily f JOIN octo_dim_member m ON m.uid = f.sender_uid"
+	var args []interface{}
 	if len(spaceIDs) > 0 {
-		clause, spaceArgs := inClause("f.space_id", spaceIDs)
-		sql += " AND " + clause
+		smClause, smArgs := inClause("sm.space_id", spaceIDs)
+		sql += " JOIN space_member sm ON sm.uid = f.sender_uid AND sm.status=1 AND " + smClause
+		args = append(args, smArgs...)
+	}
+	sql += " WHERE f.stat_date BETWEEN ? AND ? AND m.is_excluded=0"
+	args = append(args, start, end)
+	if len(spaceIDs) > 0 {
+		spaceClause, spaceArgs := inClause("f.space_id", spaceIDs)
+		sql += " AND " + spaceClause
 		args = append(args, spaceArgs...)
 	}
 	_, err = d.session.SelectBySql(sql, args...).Load(&res)
@@ -137,10 +149,16 @@ func (d *opanalyticsDB) querySpaceBase(nameLike string) ([]*spaceBaseRow, error)
 	var rows []*spaceBaseRow
 	stmt := d.session.Select("space_id", "name").From("space").Where("status=1")
 	if nameLike != "" {
-		stmt = stmt.Where("name LIKE ?", "%"+nameLike+"%")
+		// 转义 LIKE 通配符，'!' 作转义符：用户输入里的 % _ 当字面量匹配，不当通配(也避免病态全表扫)。
+		stmt = stmt.Where("name LIKE ? ESCAPE '!'", "%"+escapeLike(nameLike)+"%")
 	}
 	_, err := stmt.Load(&rows)
 	return rows, err
+}
+
+// escapeLike 转义 LIKE 模式中的通配符/转义符，配合 `ESCAPE '!'` 使用。
+func escapeLike(s string) string {
+	return strings.NewReplacer("!", "!!", "%", "!%", "_", "!_").Replace(s)
 }
 
 func (d *opanalyticsDB) queryGroupCountBySpace() (map[string]int64, error) {
@@ -248,7 +266,10 @@ func (d *opanalyticsDB) queryChannelList(spaceID, start, end, activeStatus, sort
 	}
 	activeCond := channelActiveCond(activeStatus)
 
+	// INNER JOIN 活的 group 表(status=1)：硬删除的群(无 group 行)与已解散群(status≠1)不再展示。
+	// dim_channel 只 upsert 不删旧群行，故权威存在性/状态以 group 表为准。
 	base := "FROM octo_dim_channel c " +
+		"JOIN `group` g ON g.group_no = c.channel_id AND g.status=1 " +
 		"LEFT JOIN (SELECT channel_id, SUM(human_msg_count) AS hm, SUM(agent_msg_count) AS am " +
 		"FROM octo_fact_channel_daily WHERE stat_date BETWEEN ? AND ? AND space_id=? AND channel_type=2 " +
 		"GROUP BY channel_id) f ON f.channel_id=c.channel_id " +
@@ -299,9 +320,11 @@ func (d *opanalyticsDB) queryChannelList(spaceID, start, end, activeStatus, sort
 	return out, total, nil
 }
 
+// spaceExists 仅在 Space 存在**且 status=1** 时返回 true：与 /spaces 列表口径一致，
+// 软删除的 Space 视为不存在(表二返回 404，而非 200+数据)。
 func (d *opanalyticsDB) spaceExists(spaceID string) (bool, error) {
 	var n int64
-	_, err := d.session.Select("count(*)").From("space").Where("space_id=?", spaceID).Load(&n)
+	_, err := d.session.Select("count(*)").From("space").Where("space_id=? AND status=1", spaceID).Load(&n)
 	return n > 0, err
 }
 

--- a/modules/opanalytics/db.go
+++ b/modules/opanalytics/db.go
@@ -94,17 +94,25 @@ func (d *opanalyticsDB) overviewMsgAndGroups(start, end string, spaceIDs []strin
 }
 
 // overviewActiveMembers 范围内活跃 human/agent 成员去重数(可选 space 过滤)。
+// JOIN dim_member 且 is_excluded=0：活跃成员只算**当前在册**的人(剔除事后被禁用/删除/系统账号)，
+// 使"活跃成员 ⊆ 总成员"、活跃率 ≤100%。消息量(volume)仍按 event-time 保留，二者口径有意不同。
 func (d *opanalyticsDB) overviewActiveMembers(start, end string, spaceIDs []string) (human, agent int64, err error) {
 	var res struct {
 		ActiveHuman int64 `db:"active_human"`
 		ActiveAgent int64 `db:"active_agent"`
 	}
-	stmt := d.session.Select(
-		"COUNT(DISTINCT CASE WHEN sender_type=1 THEN sender_uid END) AS active_human",
-		"COUNT(DISTINCT CASE WHEN sender_type=2 THEN sender_uid END) AS active_agent",
-	).From("octo_fact_member_channel_daily").Where("stat_date BETWEEN ? AND ?", start, end)
-	stmt = applySpaceFilter(stmt, spaceIDs)
-	_, err = stmt.Load(&res)
+	sql := "SELECT " +
+		"COUNT(DISTINCT CASE WHEN f.sender_type=1 THEN f.sender_uid END) AS active_human, " +
+		"COUNT(DISTINCT CASE WHEN f.sender_type=2 THEN f.sender_uid END) AS active_agent " +
+		"FROM octo_fact_member_channel_daily f JOIN octo_dim_member m ON m.uid = f.sender_uid " +
+		"WHERE f.stat_date BETWEEN ? AND ? AND m.is_excluded=0"
+	args := []interface{}{start, end}
+	if len(spaceIDs) > 0 {
+		clause, spaceArgs := inClause("f.space_id", spaceIDs)
+		sql += " AND " + clause
+		args = append(args, spaceArgs...)
+	}
+	_, err = d.session.SelectBySql(sql, args...).Load(&res)
 	return res.ActiveHuman, res.ActiveAgent, err
 }
 

--- a/modules/opanalytics/db.go
+++ b/modules/opanalytics/db.go
@@ -21,27 +21,48 @@ func newOpanalyticsDB(ctx *config.Context) *opanalyticsDB {
 
 // ===== 概览(模块A) =====
 
-func (d *opanalyticsDB) countSpacesTotal() (int64, error) {
+// countSpacesTotal 空间总数；给定 spaceIDs 时只数其中存在(status=1)者，使概览总数随筛选收敛。
+func (d *opanalyticsDB) countSpacesTotal(spaceIDs []string) (int64, error) {
 	var n int64
-	_, err := d.session.Select("count(*)").From("space").Where("status=1").Load(&n)
+	stmt := d.session.Select("count(*)").From("space").Where("status=1")
+	stmt = applySpaceFilter(stmt, spaceIDs)
+	_, err := stmt.Load(&n)
 	return n, err
 }
 
-func (d *opanalyticsDB) countGroupsTotal() (int64, error) {
+// countGroupsTotal 群组总数；给定 spaceIDs 时只数其中的群。
+func (d *opanalyticsDB) countGroupsTotal(spaceIDs []string) (int64, error) {
 	var n int64
-	_, err := d.session.Select("count(*)").From("`group`").Where("status=1").Load(&n)
+	stmt := d.session.Select("count(*)").From("`group`").Where("status=1")
+	stmt = applySpaceFilter(stmt, spaceIDs)
+	_, err := stmt.Load(&n)
 	return n, err
 }
 
-// countMembersByType 全局 human/agent 成员总数(源 dim_member；剔除系统/测试账号 is_excluded=1)。
-func (d *opanalyticsDB) countMembersByType() (human int64, agent int64, err error) {
+// countMembersByType human/agent 成员总数。spaceIDs 为空=全局(源 dim_member)；非空=选中
+// 空间在册成员去重(space_member ⋈ dim_member)，使总数随空间筛选收敛、活跃比例不失真。
+// 两路都剔除 is_excluded(系统/测试/禁用)与 SystemBots。
+func (d *opanalyticsDB) countMembersByType(spaceIDs []string) (human int64, agent int64, err error) {
 	var rows []struct {
 		MemberType uint8 `db:"member_type"`
 		Cnt        int64 `db:"cnt"`
 	}
-	_, err = d.session.SelectBySql(
-		"SELECT member_type, COUNT(*) AS cnt FROM octo_dim_member WHERE is_excluded=0 GROUP BY member_type",
-	).Load(&rows)
+	if len(spaceIDs) == 0 {
+		_, err = d.session.SelectBySql(
+			"SELECT member_type, COUNT(*) AS cnt FROM octo_dim_member WHERE is_excluded=0 GROUP BY member_type",
+		).Load(&rows)
+	} else {
+		botClause, botArgs := systemBotExclusion("sm.uid")
+		spaceClause, spaceArgs := inClause("sm.space_id", spaceIDs)
+		args := append(botArgs, spaceArgs...)
+		_, err = d.session.SelectBySql(
+			"SELECT m.member_type AS member_type, COUNT(DISTINCT sm.uid) AS cnt "+
+				"FROM space_member sm JOIN octo_dim_member m ON m.uid = sm.uid "+
+				"WHERE sm.status=1 AND m.is_excluded=0"+botClause+" AND "+spaceClause+
+				" GROUP BY m.member_type",
+			args...,
+		).Load(&rows)
+	}
 	if err != nil {
 		return 0, 0, err
 	}
@@ -363,6 +384,16 @@ func systemBotExclusion(col string) (string, []interface{}) {
 		args[i] = b
 	}
 	return " AND " + col + " NOT IN (" + ph + ")", args
+}
+
+// inClause 构造 "<col> IN (?,?...)" 片段与参数(用于 SelectBySql 裸 SQL；调用方需保证非空)。
+func inClause(col string, vals []string) (string, []interface{}) {
+	ph := strings.TrimSuffix(strings.Repeat("?,", len(vals)), ",")
+	args := make([]interface{}, len(vals))
+	for i, v := range vals {
+		args[i] = v
+	}
+	return col + " IN (" + ph + ")", args
 }
 
 func applySpaceFilter(stmt *dbr.SelectStmt, spaceIDs []string) *dbr.SelectStmt {

--- a/modules/opanalytics/db.go
+++ b/modules/opanalytics/db.go
@@ -158,6 +158,10 @@ type spaceMemberTotals struct {
 	Agent int64
 }
 
+// queryMemberTotalsBySpace 表一每个 Space 的在册 human/agent 成员数。
+// 用 INNER JOIN dim_member(而非 LEFT JOIN+COALESCE)：孤儿 space_member(user 已删、dim 无行)
+// 不计入，与概览 Space 路径 countMembersByType 口径完全一致(同一"成员总数"两接口不打架)。
+// 一个 uid 在一个 space 至多一行，故 COUNT(*) 即去重数。
 func (d *opanalyticsDB) queryMemberTotalsBySpace() (map[string]spaceMemberTotals, error) {
 	var rows []struct {
 		SpaceID string `db:"space_id"`
@@ -168,8 +172,8 @@ func (d *opanalyticsDB) queryMemberTotalsBySpace() (map[string]spaceMemberTotals
 	_, err := d.session.SelectBySql(
 		"SELECT sm.space_id AS space_id, "+
 			"SUM(CASE WHEN m.member_type=2 THEN 1 ELSE 0 END) AS agent, COUNT(*) AS total "+
-			"FROM space_member sm LEFT JOIN octo_dim_member m ON m.uid = sm.uid "+
-			"WHERE sm.status=1 AND COALESCE(m.is_excluded,0)=0"+botClause+" GROUP BY sm.space_id",
+			"FROM space_member sm JOIN octo_dim_member m ON m.uid = sm.uid "+
+			"WHERE sm.status=1 AND m.is_excluded=0"+botClause+" GROUP BY sm.space_id",
 		botArgs...,
 	).Load(&rows)
 	if err != nil {

--- a/modules/opanalytics/etl.go
+++ b/modules/opanalytics/etl.go
@@ -1,12 +1,12 @@
 package opanalytics
 
 import (
-	"sort"
 	"strings"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"go.uber.org/zap"
 )
 
@@ -27,219 +27,80 @@ const (
 	privateMemberSize       = 2
 )
 
-// excludedSeedUIDs 固化的系统/测试账号排除种子(口径3：测试账号·系统机器人不算)。
-var excludedSeedUIDs = map[string]struct{}{
-	"u_10000":    {},
-	"botfather":  {},
-	"fileHelper": {},
-}
-
-// ETL 看板每日预聚合任务(T+1，幂等)。
+// ETL 看板预聚合任务(增量水位，幂等)。
+//
+// 抽取模型(对应验收意见③)：不再按 timestamp 全表扫 message 分片(无该索引)，
+// 改为按主键 id keyset 分页流式增量读取，每条消息精确一次累加进 ③；首次运行
+// 从 id=0 自动全量回填，之后每次只读新增。
 type ETL struct {
 	log.Log
-	ctx *config.Context
-	db  *etlDB
+	ctx   *config.Context
+	db    *etlDB
+	batch int
 }
 
 // NewETL 创建 ETL。
 func NewETL(ctx *config.Context) *ETL {
 	return &ETL{
-		Log: log.NewTLog("OpanalyticsETL"),
-		ctx: ctx,
-		db:  newETLDB(ctx),
+		Log:   log.NewTLog("OpanalyticsETL"),
+		ctx:   ctx,
+		db:    newETLDB(ctx),
+		batch: etlBatchSize(),
 	}
 }
 
-// RunYesterday 跑前一报告时区自然日(供调度器调用)。
-func (e *ETL) RunYesterday() error {
-	yesterday := time.Now().In(reportLocation()).AddDate(0, 0, -1)
-	return e.RunDay(yesterday.Format("2006-01-02"))
-}
-
-// RunBackfill 按报告时区日期回填 [fromDate, toDate](含两端，YYYY-MM-DD)，逐日幂等。
-func (e *ETL) RunBackfill(fromDate, toDate string) error {
-	from, err := time.ParseInLocation("2006-01-02", fromDate, reportLocation())
-	if err != nil {
-		return err
-	}
-	to, err := time.ParseInLocation("2006-01-02", toDate, reportLocation())
-	if err != nil {
-		return err
-	}
-	for d := from; !d.After(to); d = d.AddDate(0, 0, 1) {
-		if err := e.RunDay(d.Format("2006-01-02")); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// chanAgg 单会话当日聚合(用于活跃时间与私聊首条时间)。
-type chanAgg struct {
-	channelType uint8
-	dayMaxTs    int64
-	dayMinTs    int64
-}
-
-// senderAgg 单(会话,成员)当日聚合。
-type senderAgg struct {
-	msgCount  int
-	lastMsgAt int64
-}
-
-// channelMeta 会话的归属/分类(ETL 当日打标)。
-type channelMeta struct {
-	spaceID     string
-	convType    uint8
-	channelType uint8
-	skip        bool // 不可解析的私聊(uid 含 @ 等) → 跳过其事实行
-}
-
-// RunDay 处理某报告时区自然日(YYYY-MM-DD)：刷新维表 → 抽取消息 → ③ → 上卷 ④ → 幂等写。
-func (e *ETL) RunDay(date string) error {
-	start, end, err := dayWindowUnix(date)
+// RunIncremental 增量跑一轮：刷新维表 → 逐分片按水位流式抽取并累加 ③ → 标脏日 → 由 ③ 重算 ④。
+//
+// 幂等：游标保证已处理消息不重复计入(精确一次)；重复调用在无新消息时为空操作。
+// 崩溃安全：③ 累加与游标推进同事务提交；④ 经持久化脏日队列由本轮或下轮重算，最终一致。
+func (e *ETL) RunIncremental() error {
+	// 1. 全量刷新成员维表，得到 uid→member_type 与排除集(系统/测试账号)。
+	memberType, excluded, err := e.refreshDimMembers()
 	if err != nil {
 		return err
 	}
 
-	// 1. 刷新成员维表，得到 uid→member_type 内存映射。
-	memberType, err := e.refreshDimMembers()
-	if err != nil {
-		return err
-	}
-
-	// 2. 刷新群会话维表，得到 group_no→{space_id,conv_type}。
+	// 2. 全量刷新群会话维表，得到 group_no→{space_id,conv_type}。
 	groupMeta, err := e.refreshDimChannelGroups()
 	if err != nil {
 		return err
 	}
 
-	// 3. 跨分片抽取当日消息并内存聚合。
-	senders := map[string]*senderAgg{} // key = channelID + "\x00" + senderUID
-	channels := map[string]*chanAgg{}  // key = channelID
+	// 3. 逐分片增量抽取并累加 ③(每 chunk 一个事务，FOR UPDATE 串行化多实例)。
+	excludedUID := func(uid string) bool { return spacepkg.IsSystemBot(uid) || excluded[uid] }
+	var totalRows int64
 	for _, table := range e.db.messageTables() {
-		rows, qerr := e.db.queryDayMessages(table, start, end)
-		if qerr != nil {
-			return qerr
+		if err = e.db.ensureCursor(table); err != nil {
+			return err
 		}
-		for _, m := range rows {
-			ca := channels[m.ChannelID]
-			if ca == nil {
-				ca = &chanAgg{channelType: m.ChannelType, dayMinTs: m.Timestamp, dayMaxTs: m.Timestamp}
-				channels[m.ChannelID] = ca
+		for {
+			n, cerr := e.db.runChunk(table, e.batch, func(rows []*srcMessageRow) *chunkResult {
+				return aggregateChunk(rows, memberType, excludedUID, groupMeta)
+			})
+			if cerr != nil {
+				return cerr
 			}
-			if m.Timestamp > ca.dayMaxTs {
-				ca.dayMaxTs = m.Timestamp
-			}
-			if m.Timestamp < ca.dayMinTs {
-				ca.dayMinTs = m.Timestamp
-			}
-			key := m.ChannelID + "\x00" + m.FromUID
-			sa := senders[key]
-			if sa == nil {
-				sa = &senderAgg{}
-				senders[key] = sa
-			}
-			sa.msgCount++
-			if m.Timestamp > sa.lastMsgAt {
-				sa.lastMsgAt = m.Timestamp
+			totalRows += n
+			if int(n) < e.batch {
+				break
 			}
 		}
 	}
 
-	// 4. 发现并 upsert 私聊会话；合成全量会话归属表。
-	meta := map[string]*channelMeta{}
-	privateRows := make([][]interface{}, 0)
-	for channelID, ca := range channels {
-		if ca.channelType == channelTypeGroup {
-			if gm, ok := groupMeta[channelID]; ok {
-				meta[channelID] = &channelMeta{spaceID: gm.spaceID, convType: gm.convType, channelType: channelTypeGroup}
-			} else {
-				// 已从 group 表消失的孤儿群：仍计消息，但不归 space、类型未知。
-				meta[channelID] = &channelMeta{spaceID: "", convType: 0, channelType: channelTypeGroup}
-			}
-			continue
-		}
-		// 私聊(person)
-		a, b, ok := normalizePrivatePair(channelID)
-		if !ok {
-			e.Warn("skip unparseable private channel (uid may contain '@')", zap.String("channel_id", channelID))
-			meta[channelID] = &channelMeta{channelType: channelTypePerson, skip: true}
-			continue
-		}
-		conv := privateConvType(memberType[a], memberType[b])
-		meta[channelID] = &channelMeta{spaceID: "", convType: conv, channelType: channelTypePerson}
-		human, agent := 0, 0
-		if memberType[a] == memberTypeAgent {
-			agent++
-		} else {
-			human++
-		}
-		if memberType[b] == memberTypeAgent {
-			agent++
-		} else {
-			human++
-		}
-		privateRows = append(privateRows, []interface{}{
-			channelID, channelTypePerson, "", conv, "", a, b, privateMemberSize, human, agent, dimStatusNormal, ca.dayMinTs,
-		})
-	}
-	if err = e.db.upsertDimChannelPrivate(privateRows); err != nil {
+	// 4. 由 ③ 重算所有脏日的 ④，成功后出队(对③最终一致；下轮自愈残留脏日)。
+	days, err := e.db.loadDirtyDays()
+	if err != nil {
 		return err
 	}
-
-	// 5. 组装 ③(成员×会话×日)。
-	fact3 := make([]*factMemberChannelDailyModel, 0, len(senders))
-	for key, sa := range senders {
-		sep := strings.IndexByte(key, '\x00')
-		channelID, senderUID := key[:sep], key[sep+1:]
-		cm := meta[channelID]
-		if cm == nil || cm.skip {
-			continue
+	for _, day := range days {
+		if err = e.db.recomputeChannelDay(day); err != nil {
+			return err
 		}
-		st := memberType[senderUID]
-		if st == 0 {
-			st = memberTypeHuman
-		}
-		fact3 = append(fact3, &factMemberChannelDailyModel{
-			StatDate:    date,
-			ChannelID:   channelID,
-			ChannelType: cm.channelType,
-			SpaceID:     cm.spaceID,
-			ConvType:    cm.convType,
-			ContentType: 0,
-			SenderUID:   senderUID,
-			SenderType:  st,
-			MsgCount:    sa.msgCount,
-			LastMsgAt:   sa.lastMsgAt,
-		})
 	}
 
-	// 6. 上卷 ④(会话×日)。
-	fact4 := rollupChannelDaily(date, fact3, meta)
-
-	// 7. 幂等写两张事实表。
-	if err = e.db.replaceFactDay(date, fact3, fact4); err != nil {
-		return err
-	}
-
-	// 8. 单调更新会话最后活跃时间。
-	activityRows := make([][]interface{}, 0, len(channels))
-	for channelID, ca := range channels {
-		if cm := meta[channelID]; cm != nil && cm.skip {
-			continue
-		}
-		activityRows = append(activityRows, []interface{}{channelID, ca.channelType, ca.dayMaxTs})
-	}
-	if err = e.db.updateChannelActivity(activityRows); err != nil {
-		return err
-	}
-
-	e.Info("opanalytics ETL day done",
-		zap.String("date", date),
-		zap.Int("channels", len(channels)),
-		zap.Int("fact_member_rows", len(fact3)),
-		zap.Int("fact_channel_rows", len(fact4)))
+	e.Info("opanalytics ETL incremental done",
+		zap.Int64("messages_scanned", totalRows),
+		zap.Int("recomputed_days", len(days)))
 	return nil
 }
 
@@ -249,13 +110,183 @@ type groupMetaInfo struct {
 	convType uint8
 }
 
-// refreshDimMembers 全量刷新成员维表，返回 uid→member_type 映射。
-func (e *ETL) refreshDimMembers() (map[string]uint8, error) {
+// chunkResult 单个抽取 chunk 聚合后的待写数据(纯数据，由 etlDB 在事务内落库)。
+type chunkResult struct {
+	fact3        []*factMemberChannelDailyModel // ③ 增量(msg_count=本 chunk 计数，累加 upsert)
+	privateRows  [][]interface{}                // dim_channel 私聊 upsert 行
+	activityRows [][]interface{}                // dim_channel 活跃时间 upsert 行 [channel_id,channel_type,last_active_at]
+	dirtyDays    []string                       // 本 chunk 触达的 stat_date(去重)
+}
+
+// chanDayAgg 单(日,会话)聚合(活跃时间与私聊首条时间)。
+type chanDayAgg struct {
+	day         string
+	channelID   string
+	channelType uint8
+	dayMaxTs    int64
+	dayMinTs    int64
+}
+
+// senderDayAgg 单(日,会话,成员)聚合。
+type senderDayAgg struct {
+	day       string
+	channelID string
+	senderUID string
+	msgCount  int
+	lastMsgAt int64
+}
+
+// channelMeta 会话的归属/分类(ETL 当日打标)。
+type channelMeta struct {
+	spaceID     string
+	convType    uint8
+	channelType uint8
+	skip        bool // 不可解析的私聊(uid 含 @)或任一方为系统/测试账号 → 丢弃其事实行
+}
+
+// aggregateChunk 把一个 chunk 的消息按(日,会话,成员)聚合成待写数据(纯函数)。
+//
+// 排除口径(验收①)：excludedUID 命中的 sender(系统机器人/测试账号)其消息直接跳过，
+// 自然不进 ③/④/活跃数/活跃时间；私聊任一方被排除则整条会话丢弃。
+func aggregateChunk(rows []*srcMessageRow, memberType map[string]uint8, excludedUID func(string) bool, groupMeta map[string]groupMetaInfo) *chunkResult {
+	loc := reportLocation()
+	dayOf := func(ts int64) string { return time.Unix(ts, 0).In(loc).Format("2006-01-02") }
+
+	channels := map[string]*chanDayAgg{}  // key = day\x00channelID
+	senders := map[string]*senderDayAgg{} // key = day\x00channelID\x00senderUID
+	for _, m := range rows {
+		if excludedUID(m.FromUID) {
+			continue
+		}
+		day := dayOf(m.Timestamp)
+		ck := day + "\x00" + m.ChannelID
+		ca := channels[ck]
+		if ca == nil {
+			ca = &chanDayAgg{day: day, channelID: m.ChannelID, channelType: m.ChannelType, dayMinTs: m.Timestamp, dayMaxTs: m.Timestamp}
+			channels[ck] = ca
+		}
+		if m.Timestamp > ca.dayMaxTs {
+			ca.dayMaxTs = m.Timestamp
+		}
+		if m.Timestamp < ca.dayMinTs {
+			ca.dayMinTs = m.Timestamp
+		}
+		sk := ck + "\x00" + m.FromUID
+		sa := senders[sk]
+		if sa == nil {
+			sa = &senderDayAgg{day: day, channelID: m.ChannelID, senderUID: m.FromUID}
+			senders[sk] = sa
+		}
+		sa.msgCount++
+		if m.Timestamp > sa.lastMsgAt {
+			sa.lastMsgAt = m.Timestamp
+		}
+	}
+
+	// 会话归属/分类按 channelID 解析一次(缓存)。
+	metaCache := map[string]*channelMeta{}
+	getMeta := func(channelID string, channelType uint8) *channelMeta {
+		if cm, ok := metaCache[channelID]; ok {
+			return cm
+		}
+		cm := resolveChannelMeta(channelID, channelType, memberType, excludedUID, groupMeta)
+		metaCache[channelID] = cm
+		return cm
+	}
+
+	res := &chunkResult{}
+	dirtySet := map[string]struct{}{}
+
+	for _, ca := range channels {
+		cm := getMeta(ca.channelID, ca.channelType)
+		if cm.skip {
+			continue
+		}
+		dirtySet[ca.day] = struct{}{}
+		res.activityRows = append(res.activityRows, []interface{}{ca.channelID, ca.channelType, ca.dayMaxTs})
+		if cm.channelType == channelTypePerson {
+			a, b, _ := normalizePrivatePair(ca.channelID) // skip=false 保证可解析
+			human, agent := 0, 0
+			if memberType[a] == memberTypeAgent {
+				agent++
+			} else {
+				human++
+			}
+			if memberType[b] == memberTypeAgent {
+				agent++
+			} else {
+				human++
+			}
+			res.privateRows = append(res.privateRows, []interface{}{
+				ca.channelID, channelTypePerson, "", cm.convType, "", a, b, privateMemberSize, human, agent, dimStatusNormal, ca.dayMinTs,
+			})
+		}
+	}
+
+	for _, sa := range senders {
+		cm := getMeta(sa.channelID, channelTypeFromChannels(channels, sa.day, sa.channelID))
+		if cm == nil || cm.skip {
+			continue
+		}
+		st := memberType[sa.senderUID]
+		if st == 0 {
+			st = memberTypeHuman
+		}
+		res.fact3 = append(res.fact3, &factMemberChannelDailyModel{
+			StatDate:    sa.day,
+			ChannelID:   sa.channelID,
+			ChannelType: cm.channelType,
+			SpaceID:     cm.spaceID,
+			ConvType:    cm.convType,
+			ContentType: 0,
+			SenderUID:   sa.senderUID,
+			SenderType:  st,
+			MsgCount:    sa.msgCount,
+			LastMsgAt:   sa.lastMsgAt,
+		})
+	}
+
+	res.dirtyDays = make([]string, 0, len(dirtySet))
+	for d := range dirtySet {
+		res.dirtyDays = append(res.dirtyDays, d)
+	}
+	return res
+}
+
+// channelTypeFromChannels 取(日,会话)聚合里记录的 channel_type(供 sender 行解析 meta)。
+func channelTypeFromChannels(channels map[string]*chanDayAgg, day, channelID string) uint8 {
+	if ca := channels[day+"\x00"+channelID]; ca != nil {
+		return ca.channelType
+	}
+	return 0
+}
+
+// resolveChannelMeta 解析会话归属/分类(群查 group 维表；私聊反解 fakeChannelID)。
+func resolveChannelMeta(channelID string, channelType uint8, memberType map[string]uint8, excludedUID func(string) bool, groupMeta map[string]groupMetaInfo) *channelMeta {
+	if channelType == channelTypeGroup {
+		if gm, ok := groupMeta[channelID]; ok {
+			return &channelMeta{spaceID: gm.spaceID, convType: gm.convType, channelType: channelTypeGroup}
+		}
+		// 已从 group 表消失的孤儿群：仍计消息，但不归 space、类型未知。
+		return &channelMeta{spaceID: "", convType: 0, channelType: channelTypeGroup}
+	}
+	// 私聊(person)
+	a, b, ok := normalizePrivatePair(channelID)
+	if !ok || excludedUID(a) || excludedUID(b) {
+		// 不可解析，或任一方系统/测试账号 → 丢弃。
+		return &channelMeta{channelType: channelTypePerson, skip: true}
+	}
+	return &channelMeta{spaceID: "", convType: privateConvType(memberType[a], memberType[b]), channelType: channelTypePerson}
+}
+
+// refreshDimMembers 全量刷新成员维表，返回 uid→member_type 映射与排除集(is_excluded=1 的 uid)。
+func (e *ETL) refreshDimMembers() (map[string]uint8, map[string]bool, error) {
 	users, err := e.db.queryUsersForDim()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	memberType := make(map[string]uint8, len(users))
+	excluded := make(map[string]bool)
 	rows := make([][]interface{}, 0, len(users))
 	for _, u := range users {
 		mt := memberTypeHuman
@@ -263,16 +294,17 @@ func (e *ETL) refreshDimMembers() (map[string]uint8, error) {
 			mt = memberTypeAgent
 		}
 		memberType[u.UID] = mt
-		excluded := 0
+		ex := 0
 		if isExcludedMember(u.UID, u.Category) {
-			excluded = 1
+			ex = 1
+			excluded[u.UID] = true
 		}
-		rows = append(rows, []interface{}{u.UID, u.Name, u.Email, u.Phone, u.Zone, mt, excluded})
+		rows = append(rows, []interface{}{u.UID, u.Name, u.Email, u.Phone, u.Zone, mt, ex})
 	}
 	if err = e.db.upsertDimMembers(rows); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return memberType, nil
+	return memberType, excluded, nil
 }
 
 // refreshDimChannelGroups 全量刷新群会话维表，返回 group_no→{space_id,conv_type}。
@@ -314,81 +346,12 @@ func (e *ETL) refreshDimChannelGroups() (map[string]groupMetaInfo, error) {
 	return meta, nil
 }
 
-// rollupChannelDaily 由 ③ 上卷出 ④(会话×日)。
-func rollupChannelDaily(date string, fact3 []*factMemberChannelDailyModel, meta map[string]*channelMeta) []*factChannelDailyModel {
-	type acc struct {
-		humanMsg, agentMsg       int
-		lastMsgAt                int64
-		activeHuman, activeAgent map[string]struct{}
-	}
-	byChannel := map[string]*acc{}
-	for _, f := range fact3 {
-		a := byChannel[f.ChannelID]
-		if a == nil {
-			a = &acc{activeHuman: map[string]struct{}{}, activeAgent: map[string]struct{}{}}
-			byChannel[f.ChannelID] = a
-		}
-		if f.SenderType == memberTypeAgent {
-			a.agentMsg += f.MsgCount
-			a.activeAgent[f.SenderUID] = struct{}{}
-		} else {
-			a.humanMsg += f.MsgCount
-			a.activeHuman[f.SenderUID] = struct{}{}
-		}
-		if f.LastMsgAt > a.lastMsgAt {
-			a.lastMsgAt = f.LastMsgAt
-		}
-	}
-
-	// 稳定输出顺序(便于幂等校验/测试)。
-	channelIDs := make([]string, 0, len(byChannel))
-	for id := range byChannel {
-		channelIDs = append(channelIDs, id)
-	}
-	sort.Strings(channelIDs)
-
-	out := make([]*factChannelDailyModel, 0, len(byChannel))
-	for _, id := range channelIDs {
-		a := byChannel[id]
-		cm := meta[id]
-		var spaceID string
-		var convType, channelType uint8
-		if cm != nil {
-			spaceID, convType, channelType = cm.spaceID, cm.convType, cm.channelType
-		}
-		out = append(out, &factChannelDailyModel{
-			StatDate:           date,
-			ChannelID:          id,
-			ChannelType:        channelType,
-			SpaceID:            spaceID,
-			ConvType:           convType,
-			HumanMsgCount:      a.humanMsg,
-			AgentMsgCount:      a.agentMsg,
-			ActiveHumanMembers: len(a.activeHuman),
-			ActiveAgentMembers: len(a.activeAgent),
-			LastMsgAt:          a.lastMsgAt,
-		})
-	}
-	return out
-}
-
 // ===== 纯函数(便于单测) =====
 
-// dayWindowUnix 返回报告时区某自然日的纪元秒窗口 [start, end)。
-func dayWindowUnix(date string) (int64, int64, error) {
-	t, err := time.ParseInLocation("2006-01-02", date, reportLocation())
-	if err != nil {
-		return 0, 0, err
-	}
-	return t.Unix(), t.AddDate(0, 0, 1).Unix(), nil
-}
-
-// isExcludedMember 判定是否系统/测试账号(种子名单 ∪ category=='system')。
+// isExcludedMember 判定是否系统/测试账号。单一真源 pkg/space.SystemBots
+// (botfather/u_10000/fileHelper/notification) ∪ user.category=='system'。
 func isExcludedMember(uid, category string) bool {
-	if _, ok := excludedSeedUIDs[uid]; ok {
-		return true
-	}
-	return category == "system"
+	return spacepkg.IsSystemBot(uid) || category == "system"
 }
 
 // normalizePrivatePair 反解 fakeChannelID 双方并按字典序规范化(成员对去重一致)。
@@ -419,4 +382,13 @@ func privateConvType(aType, bType uint8) uint8 {
 		return convTypeHAPrivate
 	}
 	return convTypeHHPrivate
+}
+
+// dayWindowUnix 返回报告时区某自然日的纪元秒窗口 [start, end)(供测试与日期解析复用)。
+func dayWindowUnix(date string) (int64, int64, error) {
+	t, err := time.ParseInLocation("2006-01-02", date, reportLocation())
+	if err != nil {
+		return 0, 0, err
+	}
+	return t.Unix(), t.AddDate(0, 0, 1).Unix(), nil
 }

--- a/modules/opanalytics/etl.go
+++ b/modules/opanalytics/etl.go
@@ -1,0 +1,422 @@
+package opanalytics
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"go.uber.org/zap"
+)
+
+const (
+	memberTypeHuman uint8 = 1
+	memberTypeAgent uint8 = 2
+
+	convTypeHHGroup   uint8 = 1
+	convTypeHAGroup   uint8 = 2
+	convTypeHHPrivate uint8 = 3
+	convTypeHAPrivate uint8 = 4
+
+	channelTypePerson uint8 = 1 // = octo-lib common.ChannelTypePerson
+	channelTypeGroup  uint8 = 2 // = octo-lib common.ChannelTypeGroup
+
+	dimStatusNormal   uint8 = 1
+	dimStatusDisband  uint8 = 2
+	privateMemberSize       = 2
+)
+
+// excludedSeedUIDs 固化的系统/测试账号排除种子(口径3：测试账号·系统机器人不算)。
+var excludedSeedUIDs = map[string]struct{}{
+	"u_10000":    {},
+	"botfather":  {},
+	"fileHelper": {},
+}
+
+// ETL 看板每日预聚合任务(T+1，幂等)。
+type ETL struct {
+	log.Log
+	ctx *config.Context
+	db  *etlDB
+}
+
+// NewETL 创建 ETL。
+func NewETL(ctx *config.Context) *ETL {
+	return &ETL{
+		Log: log.NewTLog("OpanalyticsETL"),
+		ctx: ctx,
+		db:  newETLDB(ctx),
+	}
+}
+
+// RunYesterday 跑前一报告时区自然日(供调度器调用)。
+func (e *ETL) RunYesterday() error {
+	yesterday := time.Now().In(reportLocation()).AddDate(0, 0, -1)
+	return e.RunDay(yesterday.Format("2006-01-02"))
+}
+
+// RunBackfill 按报告时区日期回填 [fromDate, toDate](含两端，YYYY-MM-DD)，逐日幂等。
+func (e *ETL) RunBackfill(fromDate, toDate string) error {
+	from, err := time.ParseInLocation("2006-01-02", fromDate, reportLocation())
+	if err != nil {
+		return err
+	}
+	to, err := time.ParseInLocation("2006-01-02", toDate, reportLocation())
+	if err != nil {
+		return err
+	}
+	for d := from; !d.After(to); d = d.AddDate(0, 0, 1) {
+		if err := e.RunDay(d.Format("2006-01-02")); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// chanAgg 单会话当日聚合(用于活跃时间与私聊首条时间)。
+type chanAgg struct {
+	channelType uint8
+	dayMaxTs    int64
+	dayMinTs    int64
+}
+
+// senderAgg 单(会话,成员)当日聚合。
+type senderAgg struct {
+	msgCount  int
+	lastMsgAt int64
+}
+
+// channelMeta 会话的归属/分类(ETL 当日打标)。
+type channelMeta struct {
+	spaceID     string
+	convType    uint8
+	channelType uint8
+	skip        bool // 不可解析的私聊(uid 含 @ 等) → 跳过其事实行
+}
+
+// RunDay 处理某报告时区自然日(YYYY-MM-DD)：刷新维表 → 抽取消息 → ③ → 上卷 ④ → 幂等写。
+func (e *ETL) RunDay(date string) error {
+	start, end, err := dayWindowUnix(date)
+	if err != nil {
+		return err
+	}
+
+	// 1. 刷新成员维表，得到 uid→member_type 内存映射。
+	memberType, err := e.refreshDimMembers()
+	if err != nil {
+		return err
+	}
+
+	// 2. 刷新群会话维表，得到 group_no→{space_id,conv_type}。
+	groupMeta, err := e.refreshDimChannelGroups()
+	if err != nil {
+		return err
+	}
+
+	// 3. 跨分片抽取当日消息并内存聚合。
+	senders := map[string]*senderAgg{} // key = channelID + "\x00" + senderUID
+	channels := map[string]*chanAgg{}  // key = channelID
+	for _, table := range e.db.messageTables() {
+		rows, qerr := e.db.queryDayMessages(table, start, end)
+		if qerr != nil {
+			return qerr
+		}
+		for _, m := range rows {
+			ca := channels[m.ChannelID]
+			if ca == nil {
+				ca = &chanAgg{channelType: m.ChannelType, dayMinTs: m.Timestamp, dayMaxTs: m.Timestamp}
+				channels[m.ChannelID] = ca
+			}
+			if m.Timestamp > ca.dayMaxTs {
+				ca.dayMaxTs = m.Timestamp
+			}
+			if m.Timestamp < ca.dayMinTs {
+				ca.dayMinTs = m.Timestamp
+			}
+			key := m.ChannelID + "\x00" + m.FromUID
+			sa := senders[key]
+			if sa == nil {
+				sa = &senderAgg{}
+				senders[key] = sa
+			}
+			sa.msgCount++
+			if m.Timestamp > sa.lastMsgAt {
+				sa.lastMsgAt = m.Timestamp
+			}
+		}
+	}
+
+	// 4. 发现并 upsert 私聊会话；合成全量会话归属表。
+	meta := map[string]*channelMeta{}
+	privateRows := make([][]interface{}, 0)
+	for channelID, ca := range channels {
+		if ca.channelType == channelTypeGroup {
+			if gm, ok := groupMeta[channelID]; ok {
+				meta[channelID] = &channelMeta{spaceID: gm.spaceID, convType: gm.convType, channelType: channelTypeGroup}
+			} else {
+				// 已从 group 表消失的孤儿群：仍计消息，但不归 space、类型未知。
+				meta[channelID] = &channelMeta{spaceID: "", convType: 0, channelType: channelTypeGroup}
+			}
+			continue
+		}
+		// 私聊(person)
+		a, b, ok := normalizePrivatePair(channelID)
+		if !ok {
+			e.Warn("skip unparseable private channel (uid may contain '@')", zap.String("channel_id", channelID))
+			meta[channelID] = &channelMeta{channelType: channelTypePerson, skip: true}
+			continue
+		}
+		conv := privateConvType(memberType[a], memberType[b])
+		meta[channelID] = &channelMeta{spaceID: "", convType: conv, channelType: channelTypePerson}
+		human, agent := 0, 0
+		if memberType[a] == memberTypeAgent {
+			agent++
+		} else {
+			human++
+		}
+		if memberType[b] == memberTypeAgent {
+			agent++
+		} else {
+			human++
+		}
+		privateRows = append(privateRows, []interface{}{
+			channelID, channelTypePerson, "", conv, "", a, b, privateMemberSize, human, agent, dimStatusNormal, ca.dayMinTs,
+		})
+	}
+	if err = e.db.upsertDimChannelPrivate(privateRows); err != nil {
+		return err
+	}
+
+	// 5. 组装 ③(成员×会话×日)。
+	fact3 := make([]*factMemberChannelDailyModel, 0, len(senders))
+	for key, sa := range senders {
+		sep := strings.IndexByte(key, '\x00')
+		channelID, senderUID := key[:sep], key[sep+1:]
+		cm := meta[channelID]
+		if cm == nil || cm.skip {
+			continue
+		}
+		st := memberType[senderUID]
+		if st == 0 {
+			st = memberTypeHuman
+		}
+		fact3 = append(fact3, &factMemberChannelDailyModel{
+			StatDate:    date,
+			ChannelID:   channelID,
+			ChannelType: cm.channelType,
+			SpaceID:     cm.spaceID,
+			ConvType:    cm.convType,
+			ContentType: 0,
+			SenderUID:   senderUID,
+			SenderType:  st,
+			MsgCount:    sa.msgCount,
+			LastMsgAt:   sa.lastMsgAt,
+		})
+	}
+
+	// 6. 上卷 ④(会话×日)。
+	fact4 := rollupChannelDaily(date, fact3, meta)
+
+	// 7. 幂等写两张事实表。
+	if err = e.db.replaceFactDay(date, fact3, fact4); err != nil {
+		return err
+	}
+
+	// 8. 单调更新会话最后活跃时间。
+	activityRows := make([][]interface{}, 0, len(channels))
+	for channelID, ca := range channels {
+		if cm := meta[channelID]; cm != nil && cm.skip {
+			continue
+		}
+		activityRows = append(activityRows, []interface{}{channelID, ca.channelType, ca.dayMaxTs})
+	}
+	if err = e.db.updateChannelActivity(activityRows); err != nil {
+		return err
+	}
+
+	e.Info("opanalytics ETL day done",
+		zap.String("date", date),
+		zap.Int("channels", len(channels)),
+		zap.Int("fact_member_rows", len(fact3)),
+		zap.Int("fact_channel_rows", len(fact4)))
+	return nil
+}
+
+// groupMetaInfo 群的归属与类型。
+type groupMetaInfo struct {
+	spaceID  string
+	convType uint8
+}
+
+// refreshDimMembers 全量刷新成员维表，返回 uid→member_type 映射。
+func (e *ETL) refreshDimMembers() (map[string]uint8, error) {
+	users, err := e.db.queryUsersForDim()
+	if err != nil {
+		return nil, err
+	}
+	memberType := make(map[string]uint8, len(users))
+	rows := make([][]interface{}, 0, len(users))
+	for _, u := range users {
+		mt := memberTypeHuman
+		if u.Robot == 1 {
+			mt = memberTypeAgent
+		}
+		memberType[u.UID] = mt
+		excluded := 0
+		if isExcludedMember(u.UID, u.Category) {
+			excluded = 1
+		}
+		rows = append(rows, []interface{}{u.UID, u.Name, u.Email, u.Phone, u.Zone, mt, excluded})
+	}
+	if err = e.db.upsertDimMembers(rows); err != nil {
+		return nil, err
+	}
+	return memberType, nil
+}
+
+// refreshDimChannelGroups 全量刷新群会话维表，返回 group_no→{space_id,conv_type}。
+func (e *ETL) refreshDimChannelGroups() (map[string]groupMetaInfo, error) {
+	groups, err := e.db.queryGroupsForDim()
+	if err != nil {
+		return nil, err
+	}
+	counts, err := e.db.queryGroupMemberCounts()
+	if err != nil {
+		return nil, err
+	}
+	countByGroup := make(map[string]*groupMemberCountRow, len(counts))
+	for _, c := range counts {
+		countByGroup[c.GroupNo] = c
+	}
+
+	meta := make(map[string]groupMetaInfo, len(groups))
+	rows := make([][]interface{}, 0, len(groups))
+	for _, g := range groups {
+		agent, total := 0, 0
+		if c := countByGroup[g.GroupNo]; c != nil {
+			agent, total = c.AgentCnt, c.TotalCnt
+		}
+		human := total - agent
+		conv := groupConvType(agent)
+		status := dimStatusNormal
+		if g.Status != 1 {
+			status = dimStatusDisband
+		}
+		meta[g.GroupNo] = groupMetaInfo{spaceID: g.SpaceID, convType: conv}
+		rows = append(rows, []interface{}{
+			g.GroupNo, channelTypeGroup, g.SpaceID, conv, g.Name, total, human, agent, status, g.CreatedAtSec,
+		})
+	}
+	if err = e.db.upsertDimChannelGroups(rows); err != nil {
+		return nil, err
+	}
+	return meta, nil
+}
+
+// rollupChannelDaily 由 ③ 上卷出 ④(会话×日)。
+func rollupChannelDaily(date string, fact3 []*factMemberChannelDailyModel, meta map[string]*channelMeta) []*factChannelDailyModel {
+	type acc struct {
+		humanMsg, agentMsg       int
+		lastMsgAt                int64
+		activeHuman, activeAgent map[string]struct{}
+	}
+	byChannel := map[string]*acc{}
+	for _, f := range fact3 {
+		a := byChannel[f.ChannelID]
+		if a == nil {
+			a = &acc{activeHuman: map[string]struct{}{}, activeAgent: map[string]struct{}{}}
+			byChannel[f.ChannelID] = a
+		}
+		if f.SenderType == memberTypeAgent {
+			a.agentMsg += f.MsgCount
+			a.activeAgent[f.SenderUID] = struct{}{}
+		} else {
+			a.humanMsg += f.MsgCount
+			a.activeHuman[f.SenderUID] = struct{}{}
+		}
+		if f.LastMsgAt > a.lastMsgAt {
+			a.lastMsgAt = f.LastMsgAt
+		}
+	}
+
+	// 稳定输出顺序(便于幂等校验/测试)。
+	channelIDs := make([]string, 0, len(byChannel))
+	for id := range byChannel {
+		channelIDs = append(channelIDs, id)
+	}
+	sort.Strings(channelIDs)
+
+	out := make([]*factChannelDailyModel, 0, len(byChannel))
+	for _, id := range channelIDs {
+		a := byChannel[id]
+		cm := meta[id]
+		var spaceID string
+		var convType, channelType uint8
+		if cm != nil {
+			spaceID, convType, channelType = cm.spaceID, cm.convType, cm.channelType
+		}
+		out = append(out, &factChannelDailyModel{
+			StatDate:           date,
+			ChannelID:          id,
+			ChannelType:        channelType,
+			SpaceID:            spaceID,
+			ConvType:           convType,
+			HumanMsgCount:      a.humanMsg,
+			AgentMsgCount:      a.agentMsg,
+			ActiveHumanMembers: len(a.activeHuman),
+			ActiveAgentMembers: len(a.activeAgent),
+			LastMsgAt:          a.lastMsgAt,
+		})
+	}
+	return out
+}
+
+// ===== 纯函数(便于单测) =====
+
+// dayWindowUnix 返回报告时区某自然日的纪元秒窗口 [start, end)。
+func dayWindowUnix(date string) (int64, int64, error) {
+	t, err := time.ParseInLocation("2006-01-02", date, reportLocation())
+	if err != nil {
+		return 0, 0, err
+	}
+	return t.Unix(), t.AddDate(0, 0, 1).Unix(), nil
+}
+
+// isExcludedMember 判定是否系统/测试账号(种子名单 ∪ category=='system')。
+func isExcludedMember(uid, category string) bool {
+	if _, ok := excludedSeedUIDs[uid]; ok {
+		return true
+	}
+	return category == "system"
+}
+
+// normalizePrivatePair 反解 fakeChannelID 双方并按字典序规范化(成员对去重一致)。
+// 任一段为空或不是两段(uid 含 @)→ ok=false。
+func normalizePrivatePair(channelID string) (string, string, bool) {
+	parts := strings.Split(channelID, "@")
+	if len(parts) != privateMemberSize || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	a, b := parts[0], parts[1]
+	if a > b {
+		a, b = b, a
+	}
+	return a, b, true
+}
+
+// groupConvType 群会话类型：含 agent → HA群，否则 HH群。
+func groupConvType(agentCount int) uint8 {
+	if agentCount > 0 {
+		return convTypeHAGroup
+	}
+	return convTypeHHGroup
+}
+
+// privateConvType 私聊会话类型：任一为 agent → HA私聊，否则 HH私聊。
+func privateConvType(aType, bType uint8) uint8 {
+	if aType == memberTypeAgent || bType == memberTypeAgent {
+		return convTypeHAPrivate
+	}
+	return convTypeHHPrivate
+}

--- a/modules/opanalytics/etl.go
+++ b/modules/opanalytics/etl.go
@@ -307,14 +307,20 @@ func resolveChannelMeta(channelID string, channelType uint8, memberType map[stri
 	return &channelMeta{spaceID: "", convType: privateConvType(memberType[a], memberType[b]), channelType: channelTypePerson}
 }
 
-// refreshDimMembers 全量刷新成员维表，返回 uid→member_type 映射与排除集(is_excluded=1 的 uid)。
+// refreshDimMembers 全量替换成员维表，返回 uid→member_type 映射与**消息路径**排除集。
+//
+// 两类排除语义分离：
+//   - dim_member.is_excluded(用于成员总数)= 系统/测试账号 ∪ 禁用/注销(status≠1)。
+//     总数反映"当前在册成员"，故禁用用户应剔除。
+//   - 返回的 excludedForMessages(用于消息计数)= 仅系统/测试账号，**不含** status。
+//     消息计数是 event-time 语义：用户活跃期发的消息照算，事后禁用不回溯。
 func (e *ETL) refreshDimMembers() (map[string]uint8, map[string]bool, error) {
 	users, err := e.db.queryUsersForDim()
 	if err != nil {
 		return nil, nil, err
 	}
 	memberType := make(map[string]uint8, len(users))
-	excluded := make(map[string]bool)
+	excludedForMessages := make(map[string]bool)
 	rows := make([][]interface{}, 0, len(users))
 	for _, u := range users {
 		mt := memberTypeHuman
@@ -322,17 +328,20 @@ func (e *ETL) refreshDimMembers() (map[string]uint8, map[string]bool, error) {
 			mt = memberTypeAgent
 		}
 		memberType[u.UID] = mt
+		noise := isExcludedMember(u.UID, u.Category)
+		if noise {
+			excludedForMessages[u.UID] = true
+		}
 		ex := 0
-		if isExcludedMember(u.UID, u.Category) {
+		if noise || u.Status != 1 {
 			ex = 1
-			excluded[u.UID] = true
 		}
 		rows = append(rows, []interface{}{u.UID, u.Name, u.Email, u.Phone, u.Zone, mt, ex})
 	}
-	if err = e.db.upsertDimMembers(rows); err != nil {
+	if err = e.db.replaceDimMembers(rows); err != nil {
 		return nil, nil, err
 	}
-	return memberType, excluded, nil
+	return memberType, excludedForMessages, nil
 }
 
 // refreshDimChannelGroups 全量刷新群会话维表，返回 group_no→{space_id,conv_type}。

--- a/modules/opanalytics/etl.go
+++ b/modules/opanalytics/etl.go
@@ -124,6 +124,10 @@ func (e *ETL) RunIncremental() error {
 //
 // 运维亦可等价地手工执行：TRUNCATE octo_fact_member_channel_daily / octo_fact_channel_daily /
 // octo_etl_message_cursor / octo_etl_dirty_day，下一次定时 RunIncremental 会自动全量回填。
+//
+// 注意：本方法**不持** scheduler 的 Redis ETL 锁。当前未接任何入口(仅供运维/测试直接调用)，
+// 故安全。将来若挂到 ops 端点，必须先获取同一把锁(并暂停 cron)，否则与定时跑并发会在清空游标
+// 与增量重算之间互相踩踏。
 func (e *ETL) Rebuild() error {
 	if err := e.db.truncateForRebuild(); err != nil {
 		return err

--- a/modules/opanalytics/etl.go
+++ b/modules/opanalytics/etl.go
@@ -29,14 +29,20 @@ const (
 
 // ETL 看板预聚合任务(增量水位，幂等)。
 //
-// 抽取模型(对应验收意见③)：不再按 timestamp 全表扫 message 分片(无该索引)，
-// 改为按主键 id keyset 分页流式增量读取，每条消息精确一次累加进 ③；首次运行
-// 从 id=0 自动全量回填，之后每次只读新增。
+// 抽取模型：不再按 timestamp 全表扫 message 分片(无该索引)，改为按主键 id keyset 分页
+// 流式增量读取，每条消息精确一次累加进 ③；首次运行从 id=0 自动全量回填，之后每次只读新增。
+// 稳定性闸门(created_at ≤ DB_NOW-lag)杜绝"低 id 晚提交被游标越过"的并发漏扫(见 etlLagSeconds)。
+//
+// 口径语义(事件处理时口径 / event-time semantics)：③/④ 是按消息处理当时的维表(成员类型、
+// 排除名单、群成员构成)累加的不可变事实。事后变更维表(如 user.category 改 system、系统 bot
+// 名单扩展、robot 更正、群成员增减)只影响**之后**处理的新消息，不回溯已写入的历史行。如需让
+// 维表变更追溯既往，调用 Rebuild() 安全重建(清事实+水位，下轮用当前维表全量重算)。
 type ETL struct {
 	log.Log
 	ctx   *config.Context
 	db    *etlDB
 	batch int
+	lag   int64
 }
 
 // NewETL 创建 ETL。
@@ -46,6 +52,7 @@ func NewETL(ctx *config.Context) *ETL {
 		ctx:   ctx,
 		db:    newETLDB(ctx),
 		batch: etlBatchSize(),
+		lag:   etlLagSeconds(),
 	}
 }
 
@@ -67,6 +74,11 @@ func (e *ETL) RunIncremental() error {
 	}
 
 	// 3. 逐分片增量抽取并累加 ③(每 chunk 一个事务，FOR UPDATE 串行化多实例)。
+	//    nowUnix 取自 DB，配合 lag 构成稳定性闸门，统一时基避免应用/DB 时钟偏差。
+	nowUnix, err := e.db.dbNowUnix()
+	if err != nil {
+		return err
+	}
 	excludedUID := func(uid string) bool { return spacepkg.IsSystemBot(uid) || excluded[uid] }
 	var totalRows int64
 	for _, table := range e.db.messageTables() {
@@ -74,7 +86,7 @@ func (e *ETL) RunIncremental() error {
 			return err
 		}
 		for {
-			n, cerr := e.db.runChunk(table, e.batch, func(rows []*srcMessageRow) *chunkResult {
+			n, cerr := e.db.runChunk(table, e.batch, nowUnix, e.lag, func(rows []*srcMessageRow) *chunkResult {
 				return aggregateChunk(rows, memberType, excludedUID, groupMeta)
 			})
 			if cerr != nil {
@@ -102,6 +114,22 @@ func (e *ETL) RunIncremental() error {
 		zap.Int64("messages_scanned", totalRows),
 		zap.Int("recomputed_days", len(days)))
 	return nil
+}
+
+// Rebuild 安全重建：清空事实表(③/④)、抽取水位与脏日队列，再用**当前**维表从 id=0 全量重算。
+//
+// 用途——口径回溯(event-time 语义的逃生门)：当成员类型/排除名单/群成员构成等维度发生历史性
+// 修正，需要让既往统计也按新口径重算时，运行此入口。注意这是一次性重读全部 message 历史的重操作，
+// 应在低峰由运维显式触发(非定时路径)。
+//
+// 运维亦可等价地手工执行：TRUNCATE octo_fact_member_channel_daily / octo_fact_channel_daily /
+// octo_etl_message_cursor / octo_etl_dirty_day，下一次定时 RunIncremental 会自动全量回填。
+func (e *ETL) Rebuild() error {
+	if err := e.db.truncateForRebuild(); err != nil {
+		return err
+	}
+	e.Info("opanalytics ETL rebuild: facts/cursor cleared, full recompute starting")
+	return e.RunIncremental()
 }
 
 // groupMetaInfo 群的归属与类型。

--- a/modules/opanalytics/etl_db.go
+++ b/modules/opanalytics/etl_db.go
@@ -255,8 +255,10 @@ func (d *etlDB) queryGroupsForDim() ([]*groupDimRow, error) {
 	return rows, err
 }
 
-// queryGroupMemberCounts 按群统计在册(status=1)成员数及其中的 agent 数，剔除系统/测试账号。
+// queryGroupMemberCounts 按群统计在册成员数及其中的 agent 数，剔除系统/测试账号。
 // 成员类型优先取 dim_member.member_type，回退 group_member.robot。
+// 在册口径与 group 模块标准查询一致：group_member 有 status(黑名单/正常) 与 is_deleted(是否退群/被移除)
+// **两个独立**字段，必须同时 `status=1 AND is_deleted=0`(只查 status 会把已退群成员算进成员数/误判 HA)。
 // 排除口径：dim_member.is_excluded=1，再按单一真源结构性兜底剔除 SystemBots(防 dim 缺行)。
 func (d *etlDB) queryGroupMemberCounts() ([]*groupMemberCountRow, error) {
 	var rows []*groupMemberCountRow
@@ -266,7 +268,7 @@ func (d *etlDB) queryGroupMemberCounts() ([]*groupMemberCountRow, error) {
 			"SUM(CASE WHEN COALESCE(m.member_type, IF(gm.robot=1,2,1))=2 THEN 1 ELSE 0 END) AS agent_cnt, "+
 			"COUNT(*) AS total_cnt "+
 			"FROM `group_member` gm LEFT JOIN octo_dim_member m ON m.uid = gm.uid "+
-			"WHERE gm.status=1 AND COALESCE(m.is_excluded,0)=0"+botClause+" GROUP BY gm.group_no",
+			"WHERE gm.status=1 AND gm.is_deleted=0 AND COALESCE(m.is_excluded,0)=0"+botClause+" GROUP BY gm.group_no",
 		botArgs...,
 	).Load(&rows)
 	return rows, err

--- a/modules/opanalytics/etl_db.go
+++ b/modules/opanalytics/etl_db.go
@@ -1,0 +1,207 @@
+package opanalytics
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/gocraft/dbr/v2"
+)
+
+// upsertChunkRows 单条 upsert 语句最多带的行数，避免超大 SQL / 占位符过多。
+const upsertChunkRows = 500
+
+// etlDB 看板 ETL 的数据访问层(读源分片 + 维表 upsert + 事实表幂等替换)。
+type etlDB struct {
+	ctx     *config.Context
+	session *dbr.Session
+}
+
+func newETLDB(ctx *config.Context) *etlDB {
+	return &etlDB{ctx: ctx, session: ctx.DB()}
+}
+
+// messageTables 枚举全部消息分片表(与 modules/message/db.go getTable 的分片集一致)。
+func (d *etlDB) messageTables() []string {
+	count := d.ctx.GetConfig().TablePartitionConfig.MessageTableCount
+	if count <= 0 {
+		return []string{"message"}
+	}
+	tables := make([]string, 0, count)
+	tables = append(tables, "message")
+	for i := 1; i < count; i++ {
+		tables = append(tables, fmt.Sprintf("message%d", i))
+	}
+	return tables
+}
+
+// queryDayMessages 抽取某分片表中 [start,end) 纪元秒窗口内的消息(全量：不过滤 is_deleted/类型)。
+func (d *etlDB) queryDayMessages(table string, start, end int64) ([]*srcMessageRow, error) {
+	var rows []*srcMessageRow
+	_, err := d.session.
+		Select("from_uid", "channel_id", "channel_type", "timestamp", "`signal`").
+		From(table).
+		Where("timestamp >= ? AND timestamp < ?", start, end).
+		Load(&rows)
+	return rows, err
+}
+
+// queryUsersForDim 读 user 表(在册)用于刷新成员维表；robot=1 即 agent。
+func (d *etlDB) queryUsersForDim() ([]*userDimRow, error) {
+	var rows []*userDimRow
+	_, err := d.session.
+		Select("uid", "name", "email", "phone", "zone", "robot", "category").
+		From("`user`").
+		Where("status=1").
+		Load(&rows)
+	return rows, err
+}
+
+// queryGroupsForDim 读 group 表用于刷新会话维表(群)。
+func (d *etlDB) queryGroupsForDim() ([]*groupDimRow, error) {
+	var rows []*groupDimRow
+	_, err := d.session.
+		Select("group_no", "name", "space_id", "status", "IFNULL(UNIX_TIMESTAMP(created_at),0) AS created_at_sec").
+		From("`group`").
+		Load(&rows)
+	return rows, err
+}
+
+// queryGroupMemberCounts 按群统计在册(status=1)成员数及其中的 agent 数。
+// 成员类型优先取 dim_member.member_type，回退 group_member.robot。
+func (d *etlDB) queryGroupMemberCounts() ([]*groupMemberCountRow, error) {
+	var rows []*groupMemberCountRow
+	_, err := d.session.SelectBySql(
+		"SELECT gm.group_no AS group_no, " +
+			"SUM(CASE WHEN COALESCE(m.member_type, IF(gm.robot=1,2,1))=2 THEN 1 ELSE 0 END) AS agent_cnt, " +
+			"COUNT(*) AS total_cnt " +
+			"FROM `group_member` gm LEFT JOIN octo_dim_member m ON m.uid = gm.uid " +
+			"WHERE gm.status=1 GROUP BY gm.group_no",
+	).Load(&rows)
+	return rows, err
+}
+
+// upsertDimMembers 批量 upsert 成员维表(维表全刷可用 ODKU；禁令只针对会消失 key 的事实表)。
+func (d *etlDB) upsertDimMembers(rows [][]interface{}) error {
+	const cols = "(`uid`,`name`,`email`,`phone`,`zone`,`member_type`,`is_excluded`)"
+	const suffix = " ON DUPLICATE KEY UPDATE " +
+		"`name`=VALUES(`name`),`email`=VALUES(`email`),`phone`=VALUES(`phone`)," +
+		"`zone`=VALUES(`zone`),`member_type`=VALUES(`member_type`),`is_excluded`=VALUES(`is_excluded`)"
+	return d.execValuesUpsert("octo_dim_member", cols, 7, suffix, rows)
+}
+
+// upsertDimChannelGroups 批量 upsert 群会话维表。不触碰 last_active_at(由消息活跃单调更新)。
+// first_msg_at 取 LEAST 保持单调；群的 created_at 稳定，LEAST 等价。
+func (d *etlDB) upsertDimChannelGroups(rows [][]interface{}) error {
+	const cols = "(`channel_id`,`channel_type`,`space_id`,`conv_type`,`name`," +
+		"`member_count`,`human_member_count`,`agent_member_count`,`status`,`first_msg_at`)"
+	const suffix = " ON DUPLICATE KEY UPDATE " +
+		"`channel_type`=VALUES(`channel_type`),`space_id`=VALUES(`space_id`),`conv_type`=VALUES(`conv_type`)," +
+		"`name`=VALUES(`name`),`member_count`=VALUES(`member_count`)," +
+		"`human_member_count`=VALUES(`human_member_count`),`agent_member_count`=VALUES(`agent_member_count`)," +
+		"`status`=VALUES(`status`),`first_msg_at`=LEAST(`first_msg_at`,VALUES(`first_msg_at`))"
+	return d.execValuesUpsert("octo_dim_channel", cols, 10, suffix, rows)
+}
+
+// upsertDimChannelPrivate 批量 upsert 私聊会话维表(space_id=” 不进空间维度)。
+func (d *etlDB) upsertDimChannelPrivate(rows [][]interface{}) error {
+	const cols = "(`channel_id`,`channel_type`,`space_id`,`conv_type`,`name`," +
+		"`member_a_uid`,`member_b_uid`,`member_count`,`human_member_count`,`agent_member_count`,`status`,`first_msg_at`)"
+	const suffix = " ON DUPLICATE KEY UPDATE " +
+		"`conv_type`=VALUES(`conv_type`),`member_a_uid`=VALUES(`member_a_uid`),`member_b_uid`=VALUES(`member_b_uid`)," +
+		"`human_member_count`=VALUES(`human_member_count`),`agent_member_count`=VALUES(`agent_member_count`)," +
+		"`first_msg_at`=LEAST(`first_msg_at`,VALUES(`first_msg_at`))"
+	return d.execValuesUpsert("octo_dim_channel", cols, 12, suffix, rows)
+}
+
+// updateChannelActivity 单调更新会话最后活跃时间(GREATEST)；对消息里出现但维表缺失的
+// 孤儿会话顺带插入最小行(channel_type 来自消息)。每行: [channel_id, channel_type, last_active_at]。
+func (d *etlDB) updateChannelActivity(rows [][]interface{}) error {
+	const cols = "(`channel_id`,`channel_type`,`last_active_at`)"
+	const suffix = " ON DUPLICATE KEY UPDATE `last_active_at`=GREATEST(`last_active_at`,VALUES(`last_active_at`))"
+	return d.execValuesUpsert("octo_dim_channel", cols, 3, suffix, rows)
+}
+
+// replaceFactDay 幂等替换某统计日的两张事实表：单事务内 DELETE WHERE stat_date=X + 批量 INSERT。
+// 禁用 ODKU(事实表重算后消失的 key 会留脏行)。
+func (d *etlDB) replaceFactDay(statDate string, fact3 []*factMemberChannelDailyModel, fact4 []*factChannelDailyModel) error {
+	tx, err := d.session.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	if _, err = tx.DeleteFrom("octo_fact_member_channel_daily").Where("stat_date=?", statDate).Exec(); err != nil {
+		return err
+	}
+	if _, err = tx.DeleteFrom("octo_fact_channel_daily").Where("stat_date=?", statDate).Exec(); err != nil {
+		return err
+	}
+
+	cols3 := util.AttrToUnderscore(&factMemberChannelDailyModel{})
+	for i := 0; i < len(fact3); i += upsertChunkRows {
+		end := i + upsertChunkRows
+		if end > len(fact3) {
+			end = len(fact3)
+		}
+		ins := tx.InsertInto("octo_fact_member_channel_daily").Columns(cols3...)
+		for _, r := range fact3[i:end] {
+			ins.Record(r)
+		}
+		if _, err = ins.Exec(); err != nil {
+			return err
+		}
+	}
+
+	cols4 := util.AttrToUnderscore(&factChannelDailyModel{})
+	for i := 0; i < len(fact4); i += upsertChunkRows {
+		end := i + upsertChunkRows
+		if end > len(fact4) {
+			end = len(fact4)
+		}
+		ins := tx.InsertInto("octo_fact_channel_daily").Columns(cols4...)
+		for _, r := range fact4[i:end] {
+			ins.Record(r)
+		}
+		if _, err = ins.Exec(); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+// execValuesUpsert 构造并分块执行 `INSERT INTO t cols VALUES (...),(...) <suffix>`。
+func (d *etlDB) execValuesUpsert(table, cols string, colCount int, suffix string, rows [][]interface{}) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	placeholder := "(" + strings.TrimSuffix(strings.Repeat("?,", colCount), ",") + ")"
+	for i := 0; i < len(rows); i += upsertChunkRows {
+		end := i + upsertChunkRows
+		if end > len(rows) {
+			end = len(rows)
+		}
+		chunk := rows[i:end]
+		var sb strings.Builder
+		sb.WriteString("INSERT INTO ")
+		sb.WriteString(table)
+		sb.WriteString(" ")
+		sb.WriteString(cols)
+		sb.WriteString(" VALUES ")
+		args := make([]interface{}, 0, len(chunk)*colCount)
+		for j, row := range chunk {
+			if j > 0 {
+				sb.WriteString(",")
+			}
+			sb.WriteString(placeholder)
+			args = append(args, row...)
+		}
+		sb.WriteString(suffix)
+		if _, err := d.session.InsertBySql(sb.String(), args...).Exec(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/modules/opanalytics/etl_db.go
+++ b/modules/opanalytics/etl_db.go
@@ -50,12 +50,23 @@ func (d *etlDB) ensureCursor(table string) error {
 	return err
 }
 
+// dbNowUnix 返回数据库当前时间(纪元秒)，作为稳定性闸门的统一时基(避免应用/DB 时钟偏差)。
+func (d *etlDB) dbNowUnix() (int64, error) {
+	var now int64
+	err := d.session.SelectBySql("SELECT UNIX_TIMESTAMP()").LoadOne(&now)
+	return now, err
+}
+
 // runChunk 处理某分片的一个抽取 chunk：单事务内 SELECT 水位 FOR UPDATE → keyset 读 batch 行
-// → aggregate(纯函数) → 累加 ③ / 维表 / 脏日 → 推进水位。返回本 chunk 读到的行数。
+// → 按稳定性闸门(created_at ≤ nowUnix-lagSeconds)截取无空洞稳定前缀 → aggregate(纯函数)
+// → 累加 ③ / 维表 / 脏日 → 推进水位到稳定前缀末尾。返回本 chunk 实际处理(已稳定)的行数。
 //
-// FOR UPDATE 锁住该分片水位行，串行化多实例(配合 Redis 锁双保险)；游标与 ③ 累加同事务
-// 提交，保证每条消息精确一次(失败回滚则下次重读，不重复计入)。
-func (d *etlDB) runChunk(table string, batch int, aggregate func([]*srcMessageRow) *chunkResult) (int64, error) {
+// 正确性：① FOR UPDATE 锁住该分片水位行，串行化多实例(配合 Redis 锁双保险)；② 游标与 ③
+// 累加同事务提交，保证每条消息精确一次(失败回滚则下次重读，不重复计入)；③ 稳定性闸门只推进
+// 到"落库已超过 lag、不可能再有更低 id 未提交"的前缀，杜绝"低 id 晚提交被游标越过"的漏扫。
+//
+// 返回行数 < batch 即视为本分片本轮处理完毕(要么读尽，要么触达未稳定尾部)，由调用方停止循环。
+func (d *etlDB) runChunk(table string, batch int, nowUnix, lagSeconds int64, aggregate func([]*srcMessageRow) *chunkResult) (int64, error) {
 	tx, err := d.session.Begin()
 	if err != nil {
 		return 0, err
@@ -70,7 +81,8 @@ func (d *etlDB) runChunk(table string, batch int, aggregate func([]*srcMessageRo
 
 	var rows []*srcMessageRow
 	if _, err = tx.SelectBySql(
-		fmt.Sprintf("SELECT id, from_uid, channel_id, channel_type, `timestamp` FROM `%s` WHERE id>? ORDER BY id ASC LIMIT ?", table),
+		fmt.Sprintf("SELECT id, from_uid, channel_id, channel_type, `timestamp`, UNIX_TIMESTAMP(created_at) AS created_unix "+
+			"FROM `%s` WHERE id>? ORDER BY id ASC LIMIT ?", table),
 		cursor, batch).Load(&rows); err != nil {
 		return 0, err
 	}
@@ -78,12 +90,27 @@ func (d *etlDB) runChunk(table string, batch int, aggregate func([]*srcMessageRo
 		return 0, tx.Commit()
 	}
 
-	res := aggregate(rows)
+	// 截取稳定前缀：created_at ≤ nowUnix-lag。id 与 created_at 近似同序，故首个未稳定行
+	// 之后(更高 id)均未稳定，截断即为无空洞前缀。
+	cutoff := nowUnix - lagSeconds
+	stable := rows
+	for i, r := range rows {
+		if r.CreatedUnix > cutoff {
+			stable = rows[:i]
+			break
+		}
+	}
+	if len(stable) == 0 {
+		// 队首即未稳定：本轮不前进，等其落库满 lag。返回 0 让调用方停止本分片。
+		return 0, tx.Commit()
+	}
+
+	res := aggregate(stable)
 	if err = d.writeChunk(tx, res); err != nil {
 		return 0, err
 	}
 
-	maxID := rows[len(rows)-1].ID
+	maxID := stable[len(stable)-1].ID
 	if _, err = tx.UpdateBySql(
 		"UPDATE octo_etl_message_cursor SET last_id=? WHERE shard_table=?", maxID, table).Exec(); err != nil {
 		return 0, err
@@ -91,7 +118,8 @@ func (d *etlDB) runChunk(table string, batch int, aggregate func([]*srcMessageRo
 	if err = tx.Commit(); err != nil {
 		return 0, err
 	}
-	return int64(len(rows)), nil
+	// 触达未稳定尾部(stable<rows)时返回 stable 长度(必 < batch)，使调用方停止本分片本轮。
+	return int64(len(stable)), nil
 }
 
 // writeChunk 在事务内落库一个 chunk 的聚合结果：③ 累加 + 私聊维表 + 活跃时间 + 脏日入队。
@@ -185,6 +213,22 @@ func (d *etlDB) recomputeChannelDay(day string) error {
 		return err
 	}
 	return tx.Commit()
+}
+
+// truncateForRebuild 清空事实表、抽取水位与脏日队列，使下一轮 RunIncremental 从 id=0 起
+// 用**当前**维表全量重算(口径漂移的安全重建入口)。维表由 refresh 阶段全量覆盖，无需清。
+func (d *etlDB) truncateForRebuild() error {
+	for _, tbl := range []string{
+		"octo_fact_member_channel_daily",
+		"octo_fact_channel_daily",
+		"octo_etl_message_cursor",
+		"octo_etl_dirty_day",
+	} {
+		if _, err := d.session.DeleteBySql("DELETE FROM " + tbl).Exec(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // ===== 维表来源读取 =====

--- a/modules/opanalytics/etl_db.go
+++ b/modules/opanalytics/etl_db.go
@@ -5,14 +5,19 @@ import (
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
-	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/gocraft/dbr/v2"
 )
 
 // upsertChunkRows 单条 upsert 语句最多带的行数，避免超大 SQL / 占位符过多。
 const upsertChunkRows = 500
 
-// etlDB 看板 ETL 的数据访问层(读源分片 + 维表 upsert + 事实表幂等替换)。
+// sqlRunner 是 INSERT 语句的执行入口，*dbr.Session 与 *dbr.Tx 均满足，
+// 使维表全刷(autocommit)与 chunk 累加(事务内)复用同一批 upsert 构造逻辑。
+type sqlRunner interface {
+	InsertBySql(query string, value ...interface{}) *dbr.InsertStmt
+}
+
+// etlDB 看板 ETL 的数据访问层(读源分片 + 维表 upsert + 事实表累加 + ④ 重算)。
 type etlDB struct {
 	ctx     *config.Context
 	session *dbr.Session
@@ -36,16 +41,153 @@ func (d *etlDB) messageTables() []string {
 	return tables
 }
 
-// queryDayMessages 抽取某分片表中 [start,end) 纪元秒窗口内的消息(全量：不过滤 is_deleted/类型)。
-func (d *etlDB) queryDayMessages(table string, start, end int64) ([]*srcMessageRow, error) {
-	var rows []*srcMessageRow
-	_, err := d.session.
-		Select("from_uid", "channel_id", "channel_type", "timestamp", "`signal`").
-		From(table).
-		Where("timestamp >= ? AND timestamp < ?", start, end).
-		Load(&rows)
-	return rows, err
+// ===== 增量抽取：水位游标 + keyset 流式 chunk =====
+
+// ensureCursor 确保分片水位行存在(首次为 0)，使 chunk 内 FOR UPDATE 总能命中行串行化。
+func (d *etlDB) ensureCursor(table string) error {
+	_, err := d.session.InsertBySql(
+		"INSERT IGNORE INTO octo_etl_message_cursor (shard_table, last_id) VALUES (?, 0)", table).Exec()
+	return err
 }
+
+// runChunk 处理某分片的一个抽取 chunk：单事务内 SELECT 水位 FOR UPDATE → keyset 读 batch 行
+// → aggregate(纯函数) → 累加 ③ / 维表 / 脏日 → 推进水位。返回本 chunk 读到的行数。
+//
+// FOR UPDATE 锁住该分片水位行，串行化多实例(配合 Redis 锁双保险)；游标与 ③ 累加同事务
+// 提交，保证每条消息精确一次(失败回滚则下次重读，不重复计入)。
+func (d *etlDB) runChunk(table string, batch int, aggregate func([]*srcMessageRow) *chunkResult) (int64, error) {
+	tx, err := d.session.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	var cursor int64
+	if err = tx.SelectBySql(
+		"SELECT last_id FROM octo_etl_message_cursor WHERE shard_table=? FOR UPDATE", table).LoadOne(&cursor); err != nil {
+		return 0, err
+	}
+
+	var rows []*srcMessageRow
+	if _, err = tx.SelectBySql(
+		fmt.Sprintf("SELECT id, from_uid, channel_id, channel_type, `timestamp` FROM `%s` WHERE id>? ORDER BY id ASC LIMIT ?", table),
+		cursor, batch).Load(&rows); err != nil {
+		return 0, err
+	}
+	if len(rows) == 0 {
+		return 0, tx.Commit()
+	}
+
+	res := aggregate(rows)
+	if err = d.writeChunk(tx, res); err != nil {
+		return 0, err
+	}
+
+	maxID := rows[len(rows)-1].ID
+	if _, err = tx.UpdateBySql(
+		"UPDATE octo_etl_message_cursor SET last_id=? WHERE shard_table=?", maxID, table).Exec(); err != nil {
+		return 0, err
+	}
+	if err = tx.Commit(); err != nil {
+		return 0, err
+	}
+	return int64(len(rows)), nil
+}
+
+// writeChunk 在事务内落库一个 chunk 的聚合结果：③ 累加 + 私聊维表 + 活跃时间 + 脏日入队。
+func (d *etlDB) writeChunk(tx *dbr.Tx, res *chunkResult) error {
+	if err := d.accumulateFact3(tx, res.fact3); err != nil {
+		return err
+	}
+	if err := d.upsertDimChannelPrivate(tx, res.privateRows); err != nil {
+		return err
+	}
+	if err := d.updateChannelActivity(tx, res.activityRows); err != nil {
+		return err
+	}
+	return d.markDirtyDays(tx, res.dirtyDays)
+}
+
+// accumulateFact3 累加 upsert ③(msg_count += 本 chunk 增量；last_msg_at 单调增)。
+func (d *etlDB) accumulateFact3(tx *dbr.Tx, fact3 []*factMemberChannelDailyModel) error {
+	if len(fact3) == 0 {
+		return nil
+	}
+	const cols = "(`stat_date`,`channel_id`,`channel_type`,`space_id`,`conv_type`,`content_type`," +
+		"`sender_uid`,`sender_type`,`msg_count`,`last_msg_at`)"
+	const suffix = " ON DUPLICATE KEY UPDATE " +
+		"`channel_type`=VALUES(`channel_type`),`space_id`=VALUES(`space_id`),`conv_type`=VALUES(`conv_type`)," +
+		"`sender_type`=VALUES(`sender_type`)," +
+		"`msg_count`=`msg_count`+VALUES(`msg_count`)," +
+		"`last_msg_at`=GREATEST(`last_msg_at`,VALUES(`last_msg_at`))"
+	rows := make([][]interface{}, 0, len(fact3))
+	for _, f := range fact3 {
+		rows = append(rows, []interface{}{
+			f.StatDate, f.ChannelID, f.ChannelType, f.SpaceID, f.ConvType, f.ContentType,
+			f.SenderUID, f.SenderType, f.MsgCount, f.LastMsgAt,
+		})
+	}
+	return execValuesUpsert(tx, "octo_fact_member_channel_daily", cols, 10, suffix, rows)
+}
+
+// markDirtyDays 把本 chunk 触达的统计日入队(待全部 chunk 后由 ③ 重算 ④)。
+func (d *etlDB) markDirtyDays(tx *dbr.Tx, days []string) error {
+	if len(days) == 0 {
+		return nil
+	}
+	var sb strings.Builder
+	sb.WriteString("INSERT IGNORE INTO octo_etl_dirty_day (stat_date) VALUES ")
+	args := make([]interface{}, 0, len(days))
+	for i, day := range days {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString("(?)")
+		args = append(args, day)
+	}
+	_, err := tx.InsertBySql(sb.String(), args...).Exec()
+	return err
+}
+
+// loadDirtyDays 取出全部待重算日(DATE_FORMAT 规避驱动 DATE↔string 解析差异)。
+func (d *etlDB) loadDirtyDays() ([]string, error) {
+	var days []string
+	_, err := d.session.SelectBySql(
+		"SELECT DATE_FORMAT(stat_date,'%Y-%m-%d') FROM octo_etl_dirty_day ORDER BY stat_date").Load(&days)
+	return days, err
+}
+
+// recomputeChannelDay 由 ③ 重算某统计日的 ④，并出队该脏日(单事务，对③最终一致)。
+func (d *etlDB) recomputeChannelDay(day string) error {
+	tx, err := d.session.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	if _, err = tx.DeleteBySql("DELETE FROM octo_fact_channel_daily WHERE stat_date=?", day).Exec(); err != nil {
+		return err
+	}
+	if _, err = tx.InsertBySql(
+		"INSERT INTO octo_fact_channel_daily "+
+			"(stat_date,channel_id,channel_type,space_id,conv_type,human_msg_count,agent_msg_count,"+
+			"active_human_members,active_agent_members,last_msg_at) "+
+			"SELECT stat_date, channel_id, MAX(channel_type), MAX(space_id), MAX(conv_type), "+
+			"SUM(CASE WHEN sender_type=1 THEN msg_count ELSE 0 END), "+
+			"SUM(CASE WHEN sender_type=2 THEN msg_count ELSE 0 END), "+
+			"COUNT(DISTINCT CASE WHEN sender_type=1 THEN sender_uid END), "+
+			"COUNT(DISTINCT CASE WHEN sender_type=2 THEN sender_uid END), "+
+			"MAX(last_msg_at) "+
+			"FROM octo_fact_member_channel_daily WHERE stat_date=? GROUP BY stat_date, channel_id", day).Exec(); err != nil {
+		return err
+	}
+	if _, err = tx.DeleteBySql("DELETE FROM octo_etl_dirty_day WHERE stat_date=?", day).Exec(); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// ===== 维表来源读取 =====
 
 // queryUsersForDim 读 user 表(在册)用于刷新成员维表；robot=1 即 agent。
 func (d *etlDB) queryUsersForDim() ([]*userDimRow, error) {
@@ -68,19 +210,24 @@ func (d *etlDB) queryGroupsForDim() ([]*groupDimRow, error) {
 	return rows, err
 }
 
-// queryGroupMemberCounts 按群统计在册(status=1)成员数及其中的 agent 数。
+// queryGroupMemberCounts 按群统计在册(status=1)成员数及其中的 agent 数，剔除系统/测试账号。
 // 成员类型优先取 dim_member.member_type，回退 group_member.robot。
+// 排除口径：dim_member.is_excluded=1，再按单一真源结构性兜底剔除 SystemBots(防 dim 缺行)。
 func (d *etlDB) queryGroupMemberCounts() ([]*groupMemberCountRow, error) {
 	var rows []*groupMemberCountRow
+	botClause, botArgs := systemBotExclusion("gm.uid")
 	_, err := d.session.SelectBySql(
-		"SELECT gm.group_no AS group_no, " +
-			"SUM(CASE WHEN COALESCE(m.member_type, IF(gm.robot=1,2,1))=2 THEN 1 ELSE 0 END) AS agent_cnt, " +
-			"COUNT(*) AS total_cnt " +
-			"FROM `group_member` gm LEFT JOIN octo_dim_member m ON m.uid = gm.uid " +
-			"WHERE gm.status=1 GROUP BY gm.group_no",
+		"SELECT gm.group_no AS group_no, "+
+			"SUM(CASE WHEN COALESCE(m.member_type, IF(gm.robot=1,2,1))=2 THEN 1 ELSE 0 END) AS agent_cnt, "+
+			"COUNT(*) AS total_cnt "+
+			"FROM `group_member` gm LEFT JOIN octo_dim_member m ON m.uid = gm.uid "+
+			"WHERE gm.status=1 AND COALESCE(m.is_excluded,0)=0"+botClause+" GROUP BY gm.group_no",
+		botArgs...,
 	).Load(&rows)
 	return rows, err
 }
+
+// ===== 维表 upsert =====
 
 // upsertDimMembers 批量 upsert 成员维表(维表全刷可用 ODKU；禁令只针对会消失 key 的事实表)。
 func (d *etlDB) upsertDimMembers(rows [][]interface{}) error {
@@ -88,7 +235,7 @@ func (d *etlDB) upsertDimMembers(rows [][]interface{}) error {
 	const suffix = " ON DUPLICATE KEY UPDATE " +
 		"`name`=VALUES(`name`),`email`=VALUES(`email`),`phone`=VALUES(`phone`)," +
 		"`zone`=VALUES(`zone`),`member_type`=VALUES(`member_type`),`is_excluded`=VALUES(`is_excluded`)"
-	return d.execValuesUpsert("octo_dim_member", cols, 7, suffix, rows)
+	return execValuesUpsert(d.session, "octo_dim_member", cols, 7, suffix, rows)
 }
 
 // upsertDimChannelGroups 批量 upsert 群会话维表。不触碰 last_active_at(由消息活跃单调更新)。
@@ -101,79 +248,30 @@ func (d *etlDB) upsertDimChannelGroups(rows [][]interface{}) error {
 		"`name`=VALUES(`name`),`member_count`=VALUES(`member_count`)," +
 		"`human_member_count`=VALUES(`human_member_count`),`agent_member_count`=VALUES(`agent_member_count`)," +
 		"`status`=VALUES(`status`),`first_msg_at`=LEAST(`first_msg_at`,VALUES(`first_msg_at`))"
-	return d.execValuesUpsert("octo_dim_channel", cols, 10, suffix, rows)
+	return execValuesUpsert(d.session, "octo_dim_channel", cols, 10, suffix, rows)
 }
 
-// upsertDimChannelPrivate 批量 upsert 私聊会话维表(space_id=” 不进空间维度)。
-func (d *etlDB) upsertDimChannelPrivate(rows [][]interface{}) error {
+// upsertDimChannelPrivate 批量 upsert 私聊会话维表(space_id=” 不进空间维度)；chunk 内事务执行。
+func (d *etlDB) upsertDimChannelPrivate(runner sqlRunner, rows [][]interface{}) error {
 	const cols = "(`channel_id`,`channel_type`,`space_id`,`conv_type`,`name`," +
 		"`member_a_uid`,`member_b_uid`,`member_count`,`human_member_count`,`agent_member_count`,`status`,`first_msg_at`)"
 	const suffix = " ON DUPLICATE KEY UPDATE " +
 		"`conv_type`=VALUES(`conv_type`),`member_a_uid`=VALUES(`member_a_uid`),`member_b_uid`=VALUES(`member_b_uid`)," +
 		"`human_member_count`=VALUES(`human_member_count`),`agent_member_count`=VALUES(`agent_member_count`)," +
 		"`first_msg_at`=LEAST(`first_msg_at`,VALUES(`first_msg_at`))"
-	return d.execValuesUpsert("octo_dim_channel", cols, 12, suffix, rows)
+	return execValuesUpsert(runner, "octo_dim_channel", cols, 12, suffix, rows)
 }
 
 // updateChannelActivity 单调更新会话最后活跃时间(GREATEST)；对消息里出现但维表缺失的
 // 孤儿会话顺带插入最小行(channel_type 来自消息)。每行: [channel_id, channel_type, last_active_at]。
-func (d *etlDB) updateChannelActivity(rows [][]interface{}) error {
+func (d *etlDB) updateChannelActivity(runner sqlRunner, rows [][]interface{}) error {
 	const cols = "(`channel_id`,`channel_type`,`last_active_at`)"
 	const suffix = " ON DUPLICATE KEY UPDATE `last_active_at`=GREATEST(`last_active_at`,VALUES(`last_active_at`))"
-	return d.execValuesUpsert("octo_dim_channel", cols, 3, suffix, rows)
-}
-
-// replaceFactDay 幂等替换某统计日的两张事实表：单事务内 DELETE WHERE stat_date=X + 批量 INSERT。
-// 禁用 ODKU(事实表重算后消失的 key 会留脏行)。
-func (d *etlDB) replaceFactDay(statDate string, fact3 []*factMemberChannelDailyModel, fact4 []*factChannelDailyModel) error {
-	tx, err := d.session.Begin()
-	if err != nil {
-		return err
-	}
-	defer tx.RollbackUnlessCommitted()
-
-	if _, err = tx.DeleteFrom("octo_fact_member_channel_daily").Where("stat_date=?", statDate).Exec(); err != nil {
-		return err
-	}
-	if _, err = tx.DeleteFrom("octo_fact_channel_daily").Where("stat_date=?", statDate).Exec(); err != nil {
-		return err
-	}
-
-	cols3 := util.AttrToUnderscore(&factMemberChannelDailyModel{})
-	for i := 0; i < len(fact3); i += upsertChunkRows {
-		end := i + upsertChunkRows
-		if end > len(fact3) {
-			end = len(fact3)
-		}
-		ins := tx.InsertInto("octo_fact_member_channel_daily").Columns(cols3...)
-		for _, r := range fact3[i:end] {
-			ins.Record(r)
-		}
-		if _, err = ins.Exec(); err != nil {
-			return err
-		}
-	}
-
-	cols4 := util.AttrToUnderscore(&factChannelDailyModel{})
-	for i := 0; i < len(fact4); i += upsertChunkRows {
-		end := i + upsertChunkRows
-		if end > len(fact4) {
-			end = len(fact4)
-		}
-		ins := tx.InsertInto("octo_fact_channel_daily").Columns(cols4...)
-		for _, r := range fact4[i:end] {
-			ins.Record(r)
-		}
-		if _, err = ins.Exec(); err != nil {
-			return err
-		}
-	}
-
-	return tx.Commit()
+	return execValuesUpsert(runner, "octo_dim_channel", cols, 3, suffix, rows)
 }
 
 // execValuesUpsert 构造并分块执行 `INSERT INTO t cols VALUES (...),(...) <suffix>`。
-func (d *etlDB) execValuesUpsert(table, cols string, colCount int, suffix string, rows [][]interface{}) error {
+func execValuesUpsert(runner sqlRunner, table, cols string, colCount int, suffix string, rows [][]interface{}) error {
 	if len(rows) == 0 {
 		return nil
 	}
@@ -199,7 +297,7 @@ func (d *etlDB) execValuesUpsert(table, cols string, colCount int, suffix string
 			args = append(args, row...)
 		}
 		sb.WriteString(suffix)
-		if _, err := d.session.InsertBySql(sb.String(), args...).Exec(); err != nil {
+		if _, err := runner.InsertBySql(sb.String(), args...).Exec(); err != nil {
 			return err
 		}
 	}

--- a/modules/opanalytics/etl_db.go
+++ b/modules/opanalytics/etl_db.go
@@ -186,6 +186,11 @@ func (d *etlDB) loadDirtyDays() ([]string, error) {
 }
 
 // recomputeChannelDay 由 ③ 重算某统计日的 ④，并出队该脏日(单事务，对③最终一致)。
+//
+// 按 (stat_date, channel_id) GROUP BY，故每个(会话,日)恰好一行，④ 的 PK
+// (space_id,stat_date,channel_id) 不会因 space_id 漂移产生重复行。channel_type/space_id/conv_type
+// 取 MAX 是单值聚合——accumulateFact3 的 ON DUPLICATE KEY UPDATE 已把同一(会话,日)所有 ③ 行的
+// 这三个维度收敛到最新值，故 MAX = 该唯一值(非 DB 约束保证，改动写入侧收敛逻辑时需一并审此处)。
 func (d *etlDB) recomputeChannelDay(day string) error {
 	tx, err := d.session.Begin()
 	if err != nil {

--- a/modules/opanalytics/etl_db.go
+++ b/modules/opanalytics/etl_db.go
@@ -233,13 +233,14 @@ func (d *etlDB) truncateForRebuild() error {
 
 // ===== 维表来源读取 =====
 
-// queryUsersForDim 读 user 表(在册)用于刷新成员维表；robot=1 即 agent。
+// queryUsersForDim 读 user 表**全部**行(不按 status 过滤)用于全量刷新成员维表；robot=1 即 agent。
+// 取全量是为了让禁用/注销用户(status≠1)也能进维表并被打上 is_excluded，从而从总人数剔除，
+// 而非只查 status=1 导致旧行残留无法自愈。
 func (d *etlDB) queryUsersForDim() ([]*userDimRow, error) {
 	var rows []*userDimRow
 	_, err := d.session.
-		Select("uid", "name", "email", "phone", "zone", "robot", "category").
+		Select("uid", "name", "email", "phone", "zone", "robot", "category", "status").
 		From("`user`").
-		Where("status=1").
 		Load(&rows)
 	return rows, err
 }
@@ -273,13 +274,23 @@ func (d *etlDB) queryGroupMemberCounts() ([]*groupMemberCountRow, error) {
 
 // ===== 维表 upsert =====
 
-// upsertDimMembers 批量 upsert 成员维表(维表全刷可用 ODKU；禁令只针对会消失 key 的事实表)。
-func (d *etlDB) upsertDimMembers(rows [][]interface{}) error {
+// replaceDimMembers 在单事务内**全量替换**成员维表(DELETE 全表 + 批量 INSERT 当前 user 全集)。
+// 全量替换而非 upsert：硬删除的 user 行不会残留为陈旧 dim 行(禁用/注销则由 is_excluded 标记)，
+// 总人数因此能自愈。DELETE+INSERT 同事务，MVCC 下并发读者看到的是替换前或后的完整快照，无半态。
+func (d *etlDB) replaceDimMembers(rows [][]interface{}) error {
+	tx, err := d.session.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.RollbackUnlessCommitted()
+	if _, err = tx.DeleteBySql("DELETE FROM octo_dim_member").Exec(); err != nil {
+		return err
+	}
 	const cols = "(`uid`,`name`,`email`,`phone`,`zone`,`member_type`,`is_excluded`)"
-	const suffix = " ON DUPLICATE KEY UPDATE " +
-		"`name`=VALUES(`name`),`email`=VALUES(`email`),`phone`=VALUES(`phone`)," +
-		"`zone`=VALUES(`zone`),`member_type`=VALUES(`member_type`),`is_excluded`=VALUES(`is_excluded`)"
-	return execValuesUpsert(d.session, "octo_dim_member", cols, 7, suffix, rows)
+	if err = execValuesUpsert(tx, "octo_dim_member", cols, 7, "", rows); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // upsertDimChannelGroups 批量 upsert 群会话维表。不触碰 last_active_at(由消息活跃单调更新)。

--- a/modules/opanalytics/etl_lock.go
+++ b/modules/opanalytics/etl_lock.go
@@ -1,0 +1,72 @@
+package opanalytics
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
+)
+
+// etlRunLockKey 每日 ETL 的分布式互斥锁 key。多副本部署时同一时刻只允许一个实例
+// 真正执行 RunIncremental，避免 N 实例同跑同一轮造成的重复压力/锁竞争(验收④)。
+//
+// 注:correctness 还有第二道保险——runChunk 内对水位行 `SELECT ... FOR UPDATE`
+// 串行化，故即便锁因 TTL 过期出现短暂并发，消息仍精确一次累加。
+const etlRunLockKey = "opanalytics:etl:run"
+
+// etlRunLockTTL 锁租约。调度每日仅触发一次，TTL 只需覆盖各实例 01:30 同时触发的窗口；
+// 即使单轮(含首次全量回填)超过 TTL，当天也不会有第二个实例再次触发(各实例每 tick 只抢一次)。
+const etlRunLockTTL = 30 * time.Minute
+
+// luaReleaseETLLock CAS-DEL:仅当 token 匹配时才释放(规避 lease 边界误删后继 owner 锁)。
+var luaReleaseETLLock = rd.NewScript(`
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+else
+  return 0
+end
+`)
+
+// etlLock 用 Redis SET NX EX + Lua CAS-DEL 实现的单实例 ETL 互斥锁(仿 modules/oidc 的 RedisTickLock)。
+type etlLock struct {
+	client *rd.Client
+}
+
+func newETLLock(ctx *config.Context) *etlLock {
+	client := rd.NewClient(octoredis.MustBuildOptions(ctx.GetConfig(), func(o *rd.Options) {
+		o.MaxRetries = 3
+		o.ReadTimeout = 3 * time.Second
+		o.WriteTimeout = 3 * time.Second
+		o.DialTimeout = 3 * time.Second
+	}))
+	return &etlLock{client: client}
+}
+
+// Acquire 用 SET NX EX 原子抢锁。返回 (true,nil)=抢到, (false,nil)=别人持锁, (_,err)=Redis 故障。
+func (l *etlLock) Acquire(token string) (bool, error) {
+	ok, err := l.client.SetNX(etlRunLockKey, token, etlRunLockTTL).Result()
+	if err != nil {
+		return false, fmt.Errorf("opanalytics: etl lock acquire: %w", err)
+	}
+	return ok, nil
+}
+
+// Release 走 Lua CAS-DEL，只在 token 匹配时释放(token 不匹配/已过期均视为正常，不报错)。
+func (l *etlLock) Release(token string) error {
+	_, err := luaReleaseETLLock.Run(l.client, []string{etlRunLockKey}, token).Result()
+	if err != nil && !errors.Is(err, rd.Nil) {
+		return fmt.Errorf("opanalytics: etl lock release: %w", err)
+	}
+	return nil
+}
+
+// Close 释放底层连接池。
+func (l *etlLock) Close() error {
+	if l.client == nil {
+		return nil
+	}
+	return l.client.Close()
+}

--- a/modules/opanalytics/etl_test.go
+++ b/modules/opanalytics/etl_test.go
@@ -1,0 +1,147 @@
+package opanalytics
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDayWindowUnix(t *testing.T) {
+	loc := reportLocation()
+	exp, err := time.ParseInLocation("2006-01-02", "2026-06-01", loc)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	start, end, err := dayWindowUnix("2026-06-01")
+	if err != nil {
+		t.Fatalf("dayWindowUnix: %v", err)
+	}
+	if start != exp.Unix() {
+		t.Fatalf("start = %d, want %d", start, exp.Unix())
+	}
+	if end != exp.AddDate(0, 0, 1).Unix() {
+		t.Fatalf("end = %d, want %d", end, exp.AddDate(0, 0, 1).Unix())
+	}
+	if end-start != 24*3600 {
+		t.Fatalf("window = %d sec, want 86400", end-start)
+	}
+
+	// 边界：当日 23:30 落在 [start,end)，次日 00:00 不落在本窗口。
+	lastMoment := exp.Add(23*time.Hour + 30*time.Minute).Unix()
+	if !(lastMoment >= start && lastMoment < end) {
+		t.Fatalf("23:30 ts %d not within [%d,%d)", lastMoment, start, end)
+	}
+	nextMidnight := exp.AddDate(0, 0, 1).Unix()
+	if nextMidnight < end {
+		t.Fatalf("next midnight %d should be >= end %d", nextMidnight, end)
+	}
+}
+
+func TestNormalizePrivatePair(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantA    string
+		wantB    string
+		wantOK   bool
+		scenario string
+	}{
+		{"u_b@u_a", "u_a", "u_b", true, "hash-order normalized to lexical"},
+		{"u_a@u_b", "u_a", "u_b", true, "already lexical"},
+		{"u_a@u_a", "u_a", "u_a", true, "same (degenerate but parseable)"},
+		{"x@y@z", "", "", false, "uid contains @ -> 3 parts"},
+		{"u_a@", "", "", false, "empty second"},
+		{"@u_b", "", "", false, "empty first"},
+		{"noat", "", "", false, "no @"},
+	}
+	for _, c := range cases {
+		a, b, ok := normalizePrivatePair(c.in)
+		if ok != c.wantOK || a != c.wantA || b != c.wantB {
+			t.Fatalf("%s: normalizePrivatePair(%q) = (%q,%q,%v), want (%q,%q,%v)",
+				c.scenario, c.in, a, b, ok, c.wantA, c.wantB, c.wantOK)
+		}
+	}
+}
+
+func TestIsExcludedMember(t *testing.T) {
+	cases := []struct {
+		uid      string
+		category string
+		want     bool
+	}{
+		{"u_10000", "", true},
+		{"botfather", "", true},
+		{"fileHelper", "", true},
+		{"someone", "system", true},
+		{"someone", "normal", false},
+		{"alice", "", false},
+	}
+	for _, c := range cases {
+		if got := isExcludedMember(c.uid, c.category); got != c.want {
+			t.Fatalf("isExcludedMember(%q,%q) = %v, want %v", c.uid, c.category, got, c.want)
+		}
+	}
+}
+
+func TestConvType(t *testing.T) {
+	if groupConvType(0) != convTypeHHGroup {
+		t.Fatalf("group no-agent should be HH群")
+	}
+	if groupConvType(2) != convTypeHAGroup {
+		t.Fatalf("group with agent should be HA群")
+	}
+	if privateConvType(memberTypeHuman, memberTypeHuman) != convTypeHHPrivate {
+		t.Fatalf("human-human should be HH私聊")
+	}
+	if privateConvType(memberTypeHuman, memberTypeAgent) != convTypeHAPrivate {
+		t.Fatalf("human-agent should be HA私聊")
+	}
+	if privateConvType(memberTypeAgent, memberTypeHuman) != convTypeHAPrivate {
+		t.Fatalf("agent-human should be HA私聊")
+	}
+}
+
+func TestRollupChannelDaily(t *testing.T) {
+	const date = "2026-06-01"
+	meta := map[string]*channelMeta{
+		"g1":      {spaceID: "s1", convType: convTypeHAGroup, channelType: channelTypeGroup},
+		"u_a@u_b": {spaceID: "", convType: convTypeHHPrivate, channelType: channelTypePerson},
+	}
+	fact3 := []*factMemberChannelDailyModel{
+		{StatDate: date, ChannelID: "g1", SenderUID: "alice", SenderType: memberTypeHuman, MsgCount: 3, LastMsgAt: 100},
+		{StatDate: date, ChannelID: "g1", SenderUID: "bob", SenderType: memberTypeHuman, MsgCount: 2, LastMsgAt: 200},
+		{StatDate: date, ChannelID: "g1", SenderUID: "agentX", SenderType: memberTypeAgent, MsgCount: 5, LastMsgAt: 150},
+		{StatDate: date, ChannelID: "u_a@u_b", SenderUID: "u_a", SenderType: memberTypeHuman, MsgCount: 4, LastMsgAt: 90},
+	}
+	out := rollupChannelDaily(date, fact3, meta)
+	byID := map[string]*factChannelDailyModel{}
+	for _, r := range out {
+		byID[r.ChannelID] = r
+	}
+
+	g1 := byID["g1"]
+	if g1 == nil {
+		t.Fatal("missing g1 rollup")
+	}
+	if g1.HumanMsgCount != 5 || g1.AgentMsgCount != 5 {
+		t.Fatalf("g1 msg: human=%d agent=%d, want 5/5", g1.HumanMsgCount, g1.AgentMsgCount)
+	}
+	if g1.ActiveHumanMembers != 2 || g1.ActiveAgentMembers != 1 {
+		t.Fatalf("g1 active: human=%d agent=%d, want 2/1", g1.ActiveHumanMembers, g1.ActiveAgentMembers)
+	}
+	if g1.LastMsgAt != 200 {
+		t.Fatalf("g1 last_msg_at = %d, want 200", g1.LastMsgAt)
+	}
+	if g1.SpaceID != "s1" || g1.ConvType != convTypeHAGroup || g1.ChannelType != channelTypeGroup {
+		t.Fatalf("g1 meta wrong: space=%q conv=%d type=%d", g1.SpaceID, g1.ConvType, g1.ChannelType)
+	}
+
+	dm := byID["u_a@u_b"]
+	if dm == nil {
+		t.Fatal("missing private rollup")
+	}
+	if dm.HumanMsgCount != 4 || dm.AgentMsgCount != 0 || dm.ActiveHumanMembers != 1 {
+		t.Fatalf("private rollup wrong: %+v", dm)
+	}
+	if dm.SpaceID != "" || dm.ChannelType != channelTypePerson {
+		t.Fatalf("private meta wrong: space=%q type=%d", dm.SpaceID, dm.ChannelType)
+	}
+}

--- a/modules/opanalytics/etl_test.go
+++ b/modules/opanalytics/etl_test.go
@@ -67,9 +67,10 @@ func TestIsExcludedMember(t *testing.T) {
 		category string
 		want     bool
 	}{
-		{"u_10000", "", true},
-		{"botfather", "", true},
-		{"fileHelper", "", true},
+		{"u_10000", "", true},      // pkg/space.SystemBots
+		{"botfather", "", true},    // pkg/space.SystemBots
+		{"fileHelper", "", true},   // pkg/space.SystemBots
+		{"notification", "", true}, // pkg/space.SystemBots(此前硬编码名单漏掉)
 		{"someone", "system", true},
 		{"someone", "normal", false},
 		{"alice", "", false},
@@ -99,49 +100,65 @@ func TestConvType(t *testing.T) {
 	}
 }
 
-func TestRollupChannelDaily(t *testing.T) {
-	const date = "2026-06-01"
-	meta := map[string]*channelMeta{
-		"g1":      {spaceID: "s1", convType: convTypeHAGroup, channelType: channelTypeGroup},
-		"u_a@u_b": {spaceID: "", convType: convTypeHHPrivate, channelType: channelTypePerson},
+// TestAggregateChunk 校验 chunk 聚合的纯逻辑：排除系统/测试账号、私聊任一方被排除则丢弃、
+// 群消息按 human/agent 归类、脏日去重。
+func TestAggregateChunk(t *testing.T) {
+	const ts = int64(1_780_000_000) // 落在某报告日内
+	day := time.Unix(ts, 0).In(reportLocation()).Format("2006-01-02")
+
+	memberType := map[string]uint8{
+		"alice": memberTypeHuman, "bob": memberTypeHuman, "agentX": memberTypeAgent,
+		"botfather": memberTypeAgent, "u_test": memberTypeHuman,
 	}
-	fact3 := []*factMemberChannelDailyModel{
-		{StatDate: date, ChannelID: "g1", SenderUID: "alice", SenderType: memberTypeHuman, MsgCount: 3, LastMsgAt: 100},
-		{StatDate: date, ChannelID: "g1", SenderUID: "bob", SenderType: memberTypeHuman, MsgCount: 2, LastMsgAt: 200},
-		{StatDate: date, ChannelID: "g1", SenderUID: "agentX", SenderType: memberTypeAgent, MsgCount: 5, LastMsgAt: 150},
-		{StatDate: date, ChannelID: "u_a@u_b", SenderUID: "u_a", SenderType: memberTypeHuman, MsgCount: 4, LastMsgAt: 90},
+	excluded := map[string]bool{"u_test": true} // category=system
+	excludedUID := func(uid string) bool {
+		// 复刻 RunIncremental 里的谓词：系统 bot ∪ excluded 集
+		return uid == "botfather" || uid == "u_10000" || uid == "fileHelper" || uid == "notification" || excluded[uid]
 	}
-	out := rollupChannelDaily(date, fact3, meta)
-	byID := map[string]*factChannelDailyModel{}
-	for _, r := range out {
-		byID[r.ChannelID] = r
+	groupMeta := map[string]groupMetaInfo{
+		"g1": {spaceID: "s1", convType: convTypeHAGroup},
 	}
 
-	g1 := byID["g1"]
-	if g1 == nil {
-		t.Fatal("missing g1 rollup")
-	}
-	if g1.HumanMsgCount != 5 || g1.AgentMsgCount != 5 {
-		t.Fatalf("g1 msg: human=%d agent=%d, want 5/5", g1.HumanMsgCount, g1.AgentMsgCount)
-	}
-	if g1.ActiveHumanMembers != 2 || g1.ActiveAgentMembers != 1 {
-		t.Fatalf("g1 active: human=%d agent=%d, want 2/1", g1.ActiveHumanMembers, g1.ActiveAgentMembers)
-	}
-	if g1.LastMsgAt != 200 {
-		t.Fatalf("g1 last_msg_at = %d, want 200", g1.LastMsgAt)
-	}
-	if g1.SpaceID != "s1" || g1.ConvType != convTypeHAGroup || g1.ChannelType != channelTypeGroup {
-		t.Fatalf("g1 meta wrong: space=%q conv=%d type=%d", g1.SpaceID, g1.ConvType, g1.ChannelType)
+	rows := []*srcMessageRow{
+		{ID: 1, FromUID: "alice", ChannelID: "g1", ChannelType: channelTypeGroup, Timestamp: ts},
+		{ID: 2, FromUID: "bob", ChannelID: "g1", ChannelType: channelTypeGroup, Timestamp: ts + 1},
+		{ID: 3, FromUID: "agentX", ChannelID: "g1", ChannelType: channelTypeGroup, Timestamp: ts + 2},
+		{ID: 4, FromUID: "botfather", ChannelID: "g1", ChannelType: channelTypeGroup, Timestamp: ts + 3},       // 系统bot→剔除
+		{ID: 5, FromUID: "u_test", ChannelID: "g1", ChannelType: channelTypeGroup, Timestamp: ts + 4},          // 测试账号→剔除
+		{ID: 6, FromUID: "alice", ChannelID: "alice@bob", ChannelType: channelTypePerson, Timestamp: ts},       // HH私聊
+		{ID: 7, FromUID: "alice", ChannelID: "alice@botfather", ChannelType: channelTypePerson, Timestamp: ts}, // 一方系统bot→整条丢弃
 	}
 
-	dm := byID["u_a@u_b"]
-	if dm == nil {
-		t.Fatal("missing private rollup")
+	res := aggregateChunk(rows, memberType, excludedUID, groupMeta)
+
+	// ③：g1 仅 alice/bob/agentX，私聊仅 alice@bob 的 alice
+	got := map[string]int{}
+	for _, f := range res.fact3 {
+		got[f.ChannelID+"/"+f.SenderUID] = f.MsgCount
 	}
-	if dm.HumanMsgCount != 4 || dm.AgentMsgCount != 0 || dm.ActiveHumanMembers != 1 {
-		t.Fatalf("private rollup wrong: %+v", dm)
+	want := map[string]int{"g1/alice": 1, "g1/bob": 1, "g1/agentX": 1, "alice@bob/alice": 1}
+	if len(got) != len(want) {
+		t.Fatalf("fact3 keys = %v, want %v", got, want)
 	}
-	if dm.SpaceID != "" || dm.ChannelType != channelTypePerson {
-		t.Fatalf("private meta wrong: space=%q type=%d", dm.SpaceID, dm.ChannelType)
+	for k, v := range want {
+		if got[k] != v {
+			t.Fatalf("fact3[%s] = %d, want %d (full=%v)", k, got[k], v, got)
+		}
+	}
+	if _, ok := got["g1/botfather"]; ok {
+		t.Fatal("system bot must be excluded from fact3")
+	}
+	if _, ok := got["g1/u_test"]; ok {
+		t.Fatal("category=system account must be excluded from fact3")
+	}
+	for _, f := range res.fact3 {
+		if f.ChannelID == "alice@botfather" {
+			t.Fatal("private chat with system bot must be dropped entirely")
+		}
+	}
+
+	// 脏日去重：只有一个 day
+	if len(res.dirtyDays) != 1 || res.dirtyDays[0] != day {
+		t.Fatalf("dirtyDays = %v, want [%s]", res.dirtyDays, day)
 	}
 }

--- a/modules/opanalytics/main_test.go
+++ b/modules/opanalytics/main_test.go
@@ -1,0 +1,19 @@
+package opanalytics
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"testing"
+)
+
+// TestMain 确保集成测试启动前 OCTO_MASTER_KEY 已就位。testutil.NewTestServer
+// 触发 common.Setup，后者要求该 env 才能加密 IM 私钥。已存在不覆盖(允许 CI 注入固定密钥)。
+func TestMain(m *testing.M) {
+	if os.Getenv("OCTO_MASTER_KEY") == "" {
+		key := make([]byte, 16)
+		_, _ = rand.Read(key)
+		os.Setenv("OCTO_MASTER_KEY", hex.EncodeToString(key))
+	}
+	os.Exit(m.Run())
+}

--- a/modules/opanalytics/model.go
+++ b/modules/opanalytics/model.go
@@ -60,12 +60,13 @@ type groupMemberCountRow struct {
 }
 
 // srcMessageRow 分片 message 表读出的单条消息(ETL 只取聚合所需列)。
+// ID 是分片表自增主键，用作增量抽取的 keyset 水位(message 表无 timestamp 索引)。
 type srcMessageRow struct {
+	ID          int64
 	FromUID     string
 	ChannelID   string
 	ChannelType uint8
 	Timestamp   int64 // 发送时间(纪元秒)
-	Signal      int   // 0=明文 1=端到端加密(payload 不可解析)
 }
 
 // ===== 读侧(接口)结果 / 响应 VO =====

--- a/modules/opanalytics/model.go
+++ b/modules/opanalytics/model.go
@@ -1,0 +1,125 @@
+package opanalytics
+
+// ===== ETL 持久化模型 (扁平结构，字段↔列名一一对应，不嵌入 BaseModel) =====
+
+// factMemberChannelDailyModel 对应 octo_fact_member_channel_daily 的一行(③)。
+type factMemberChannelDailyModel struct {
+	StatDate    string // YYYY-MM-DD (报告时区自然日)
+	ChannelID   string
+	ChannelType uint8
+	SpaceID     string
+	ConvType    uint8
+	ContentType uint8
+	SenderUID   string
+	SenderType  uint8
+	MsgCount    int
+	LastMsgAt   int64
+}
+
+// factChannelDailyModel 对应 octo_fact_channel_daily 的一行(④)。
+type factChannelDailyModel struct {
+	StatDate           string
+	ChannelID          string
+	ChannelType        uint8
+	SpaceID            string
+	ConvType           uint8
+	HumanMsgCount      int
+	AgentMsgCount      int
+	ActiveHumanMembers int
+	ActiveAgentMembers int
+	LastMsgAt          int64
+}
+
+// ===== ETL 源读取/中间模型 =====
+
+// userDimRow 从 user 表读出的成员维表来源行。
+type userDimRow struct {
+	UID      string
+	Name     string
+	Email    string
+	Phone    string
+	Zone     string
+	Robot    int    // 0=human 1=agent
+	Category string // 'system' 等，用于排除判定
+}
+
+// groupDimRow 从 group 表读出的会话维表来源行。
+type groupDimRow struct {
+	GroupNo      string
+	Name         string
+	SpaceID      string
+	Status       int   // group.status: 0=异常 1=正常
+	CreatedAtSec int64 // UNIX_TIMESTAMP(group.created_at)
+}
+
+// groupMemberCountRow group_member(status=1) 按群聚合的人/agent 计数。
+type groupMemberCountRow struct {
+	GroupNo  string
+	AgentCnt int
+	TotalCnt int
+}
+
+// srcMessageRow 分片 message 表读出的单条消息(ETL 只取聚合所需列)。
+type srcMessageRow struct {
+	FromUID     string
+	ChannelID   string
+	ChannelType uint8
+	Timestamp   int64 // 发送时间(纪元秒)
+	Signal      int   // 0=明文 1=端到端加密(payload 不可解析)
+}
+
+// ===== 读侧(接口)结果 / 响应 VO =====
+
+// overviewResp 模块A 概览卡片(私聊只出活跃数，无总数/占比)。
+type overviewResp struct {
+	SpaceTotal         int64 `json:"space_total"`
+	GroupTotal         int64 `json:"group_total"`
+	HumanMemberTotal   int64 `json:"human_member_total"`
+	AgentTotal         int64 `json:"agent_total"`
+	ActiveGroups       int64 `json:"active_groups"`
+	ActiveHumanMembers int64 `json:"active_human_members"`
+	ActiveAgentMembers int64 `json:"active_agent_members"`
+	HumanMsgCount      int64 `json:"human_msg_count"`
+	AgentMsgCount      int64 `json:"agent_msg_count"`
+	PrivateActiveCount int64 `json:"private_active_count"` // 私聊活跃数(口径1：不出总数)
+}
+
+// spaceListItem 表一 Space 列表行。
+type spaceListItem struct {
+	SpaceID          string `json:"space_id"`
+	Name             string `json:"name"`
+	GroupTotal       int64  `json:"group_total"`
+	HumanMemberTotal int64  `json:"human_member_total"`
+	AgentTotal       int64  `json:"agent_total"`
+	HumanMsgCount    int64  `json:"human_msg_count"`
+	AgentMsgCount    int64  `json:"agent_msg_count"`
+	LastActive       int64  `json:"last_active"` // 最后活跃时间戳(纪元秒)，0=范围内无消息
+	IsActive         bool   `json:"is_active"`
+}
+
+// channelListItem 表二 群组列表行(仅群组，私聊不进表二)。
+type channelListItem struct {
+	ChannelID        string `json:"channel_id"`
+	Name             string `json:"name"`
+	ConvType         uint8  `json:"conv_type"`
+	MemberCount      int    `json:"member_count"`
+	HumanMemberCount int    `json:"human_member_count"`
+	AgentMemberCount int    `json:"agent_member_count"`
+	HumanMsgCount    int64  `json:"human_msg_count"`
+	AgentMsgCount    int64  `json:"agent_msg_count"`
+	LastActiveAt     int64  `json:"last_active_at"`
+	Status           uint8  `json:"status"`
+	IsActive         bool   `json:"is_active"`
+}
+
+// directChatItem 全局私聊活跃列表行(口径2：私聊走独立全局列表)。
+type directChatItem struct {
+	ChannelID   string `json:"channel_id"`
+	MemberAUID  string `json:"member_a_uid"`
+	MemberAName string `json:"member_a_name"`
+	MemberBUID  string `json:"member_b_uid"`
+	MemberBName string `json:"member_b_name"`
+	ConvType    uint8  `json:"conv_type"`
+	MsgCount    int64  `json:"msg_count"`
+	LastActive  int64  `json:"last_active"`
+}

--- a/modules/opanalytics/model.go
+++ b/modules/opanalytics/model.go
@@ -41,6 +41,7 @@ type userDimRow struct {
 	Zone     string
 	Robot    int    // 0=human 1=agent
 	Category string // 'system' 等，用于排除判定
+	Status   int    // user.status: 1=正常 其它=禁用/注销(从成员总数剔除)
 }
 
 // groupDimRow 从 group 表读出的会话维表来源行。

--- a/modules/opanalytics/model.go
+++ b/modules/opanalytics/model.go
@@ -61,12 +61,14 @@ type groupMemberCountRow struct {
 
 // srcMessageRow 分片 message 表读出的单条消息(ETL 只取聚合所需列)。
 // ID 是分片表自增主键，用作增量抽取的 keyset 水位(message 表无 timestamp 索引)。
+// CreatedUnix 是落库时间(纪元秒)，用于稳定性滞后闸门(见 etlLagSeconds)。
 type srcMessageRow struct {
 	ID          int64
 	FromUID     string
 	ChannelID   string
 	ChannelType uint8
 	Timestamp   int64 // 发送时间(纪元秒)
+	CreatedUnix int64 // 落库时间(纪元秒, = UNIX_TIMESTAMP(created_at))
 }
 
 // ===== 读侧(接口)结果 / 响应 VO =====

--- a/modules/opanalytics/scheduler.go
+++ b/modules/opanalytics/scheduler.go
@@ -1,21 +1,26 @@
 package opanalytics
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"sync"
 
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/robfig/cron/v3"
 	"go.uber.org/zap"
 )
 
-// dailyCronExpr 每日 01:30(部署机本地时钟)跑 T+1。日切到**报告时区**在 job 内
+// dailyCronExpr 每日 01:30(部署机本地时钟)触发增量 ETL。日切到**报告时区**在聚合内
 // 用 message.timestamp 纪元秒重算，与 cron 时钟无关，故跨时区部署无需改此表达式。
 const dailyCronExpr = "30 1 * * *"
 
-// Scheduler 看板预聚合 ETL 的每日定时调度器(仿 modules/backup/scheduler.go)。
+// Scheduler 看板增量 ETL 的每日定时调度器(仿 modules/backup/scheduler.go)。
+// 多副本部署时由 Redis 锁保证同一时刻只有一个实例真正执行(验收④)。
 type Scheduler struct {
 	log.Log
 	etl     *ETL
+	lock    *etlLock
 	cron    *cron.Cron
 	entryID cron.EntryID
 	mu      sync.Mutex
@@ -23,10 +28,11 @@ type Scheduler struct {
 }
 
 // NewScheduler 创建调度器。
-func NewScheduler(etl *ETL) *Scheduler {
+func NewScheduler(ctx *config.Context, etl *ETL) *Scheduler {
 	return &Scheduler{
 		Log:  log.NewTLog("OpanalyticsScheduler"),
 		etl:  etl,
+		lock: newETLLock(ctx),
 		cron: cron.New(),
 	}
 }
@@ -40,12 +46,7 @@ func (s *Scheduler) Start() error {
 		return nil
 	}
 
-	entryID, err := s.cron.AddFunc(dailyCronExpr, func() {
-		s.Info("scheduled opanalytics ETL triggered", zap.String("cron", dailyCronExpr))
-		if err := s.etl.RunYesterday(); err != nil {
-			s.Error("scheduled opanalytics ETL failed", zap.Error(err))
-		}
-	})
+	entryID, err := s.cron.AddFunc(dailyCronExpr, s.runOnce)
 	if err != nil {
 		return err
 	}
@@ -57,7 +58,36 @@ func (s *Scheduler) Start() error {
 	return nil
 }
 
-// Stop 停止调度器。
+// runOnce 单次触发：抢分布式锁，抢到才执行增量 ETL，结束释放锁。
+func (s *Scheduler) runOnce() {
+	token, err := randomToken()
+	if err != nil {
+		s.Error("opanalytics ETL: gen lock token failed", zap.Error(err))
+		return
+	}
+	acquired, err := s.lock.Acquire(token)
+	if err != nil {
+		// Redis 故障:不强行执行(避免多实例同跑);等下一 tick。
+		s.Error("opanalytics ETL: acquire lock failed, skip this tick", zap.Error(err))
+		return
+	}
+	if !acquired {
+		s.Info("opanalytics ETL: lock held by another instance, skip")
+		return
+	}
+	defer func() {
+		if rerr := s.lock.Release(token); rerr != nil {
+			s.Error("opanalytics ETL: release lock failed", zap.Error(rerr))
+		}
+	}()
+
+	s.Info("scheduled opanalytics ETL triggered", zap.String("cron", dailyCronExpr))
+	if err := s.etl.RunIncremental(); err != nil {
+		s.Error("scheduled opanalytics ETL failed", zap.Error(err))
+	}
+}
+
+// Stop 停止调度器并释放锁连接。
 func (s *Scheduler) Stop() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -66,5 +96,17 @@ func (s *Scheduler) Stop() {
 	}
 	s.cron.Stop()
 	s.started = false
+	if err := s.lock.Close(); err != nil {
+		s.Error("opanalytics scheduler: close lock failed", zap.Error(err))
+	}
 	s.Info("opanalytics scheduler stopped")
+}
+
+// randomToken 生成锁持有者 token(每次抢锁新生成，供 CAS-DEL 释放校验)。
+func randomToken() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
 }

--- a/modules/opanalytics/scheduler.go
+++ b/modules/opanalytics/scheduler.go
@@ -1,0 +1,70 @@
+package opanalytics
+
+import (
+	"sync"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/robfig/cron/v3"
+	"go.uber.org/zap"
+)
+
+// dailyCronExpr 每日 01:30(部署机本地时钟)跑 T+1。日切到**报告时区**在 job 内
+// 用 message.timestamp 纪元秒重算，与 cron 时钟无关，故跨时区部署无需改此表达式。
+const dailyCronExpr = "30 1 * * *"
+
+// Scheduler 看板预聚合 ETL 的每日定时调度器(仿 modules/backup/scheduler.go)。
+type Scheduler struct {
+	log.Log
+	etl     *ETL
+	cron    *cron.Cron
+	entryID cron.EntryID
+	mu      sync.Mutex
+	started bool
+}
+
+// NewScheduler 创建调度器。
+func NewScheduler(etl *ETL) *Scheduler {
+	return &Scheduler{
+		Log:  log.NewTLog("OpanalyticsScheduler"),
+		etl:  etl,
+		cron: cron.New(),
+	}
+}
+
+// Start 启动调度器(幂等)。出错只返回 error，由调用方记日志，不 panic。
+func (s *Scheduler) Start() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.started {
+		return nil
+	}
+
+	entryID, err := s.cron.AddFunc(dailyCronExpr, func() {
+		s.Info("scheduled opanalytics ETL triggered", zap.String("cron", dailyCronExpr))
+		if err := s.etl.RunYesterday(); err != nil {
+			s.Error("scheduled opanalytics ETL failed", zap.Error(err))
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	s.entryID = entryID
+	s.cron.Start()
+	s.started = true
+	s.Info("opanalytics scheduler started", zap.String("cron", dailyCronExpr))
+	return nil
+}
+
+// Stop 停止调度器。
+func (s *Scheduler) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.started {
+		return
+	}
+	s.cron.Stop()
+	s.started = false
+	s.Info("opanalytics scheduler stopped")
+}

--- a/modules/opanalytics/service.go
+++ b/modules/opanalytics/service.go
@@ -1,0 +1,187 @@
+package opanalytics
+
+import (
+	"sort"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+)
+
+// service 看板读侧业务编排。
+type service struct {
+	log.Log
+	db *opanalyticsDB
+}
+
+func newService(ctx *config.Context) *service {
+	return &service{
+		Log: log.NewTLog("OpanalyticsService"),
+		db:  newOpanalyticsDB(ctx),
+	}
+}
+
+// overview 组装模块A 概览卡片。总数=全局系统全量(不随时间/space 变)；活跃/消息量随范围与可选 space。
+func (s *service) overview(start, end string, spaceIDs []string) (*overviewResp, error) {
+	spaceTotal, err := s.db.countSpacesTotal()
+	if err != nil {
+		return nil, err
+	}
+	groupTotal, err := s.db.countGroupsTotal()
+	if err != nil {
+		return nil, err
+	}
+	humanTotal, agentTotal, err := s.db.countMembersByType()
+	if err != nil {
+		return nil, err
+	}
+	humanMsg, agentMsg, activeGroups, err := s.db.overviewMsgAndGroups(start, end, spaceIDs)
+	if err != nil {
+		return nil, err
+	}
+	activeHuman, activeAgent, err := s.db.overviewActiveMembers(start, end, spaceIDs)
+	if err != nil {
+		return nil, err
+	}
+	privateActive, err := s.db.privateActiveCount(start, end)
+	if err != nil {
+		return nil, err
+	}
+	return &overviewResp{
+		SpaceTotal:         spaceTotal,
+		GroupTotal:         groupTotal,
+		HumanMemberTotal:   humanTotal,
+		AgentTotal:         agentTotal,
+		ActiveGroups:       activeGroups,
+		ActiveHumanMembers: activeHuman,
+		ActiveAgentMembers: activeAgent,
+		HumanMsgCount:      humanMsg,
+		AgentMsgCount:      agentMsg,
+		PrivateActiveCount: privateActive,
+	}, nil
+}
+
+// spaceList 表一：内存合并维表/活跃聚合 → 过滤(活跃状态) → 排序 → 分页。
+func (s *service) spaceList(start, end, name, activeStatus, sortBy, order string, offset, limit int) ([]*spaceListItem, int64, error) {
+	bases, err := s.db.querySpaceBase(name)
+	if err != nil {
+		return nil, 0, err
+	}
+	groupCnt, err := s.db.queryGroupCountBySpace()
+	if err != nil {
+		return nil, 0, err
+	}
+	memberTotals, err := s.db.queryMemberTotalsBySpace()
+	if err != nil {
+		return nil, 0, err
+	}
+	activeAgg, err := s.db.queryActiveAggBySpace(start, end)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	items := make([]*spaceListItem, 0, len(bases))
+	for _, b := range bases {
+		agg, isActive := activeAgg[b.SpaceID]
+		switch activeStatus {
+		case "active":
+			if !isActive {
+				continue
+			}
+		case "inactive":
+			if isActive {
+				continue
+			}
+		}
+		mt := memberTotals[b.SpaceID]
+		items = append(items, &spaceListItem{
+			SpaceID:          b.SpaceID,
+			Name:             b.Name,
+			GroupTotal:       groupCnt[b.SpaceID],
+			HumanMemberTotal: mt.Human,
+			AgentTotal:       mt.Agent,
+			HumanMsgCount:    agg.HumanMsg,
+			AgentMsgCount:    agg.AgentMsg,
+			LastActive:       agg.LastActive,
+			IsActive:         isActive,
+		})
+	}
+
+	sortSpaceItems(items, sortBy, order)
+
+	total := int64(len(items))
+	if offset >= len(items) {
+		return []*spaceListItem{}, total, nil
+	}
+	end2 := offset + limit
+	if end2 > len(items) {
+		end2 = len(items)
+	}
+	return items[offset:end2], total, nil
+}
+
+// channelList 表二(仅群组)：SQL 侧 LEFT JOIN + 分页。
+func (s *service) channelList(spaceID, start, end, activeStatus, sortBy, order string, offset, limit int) ([]*channelListItem, int64, error) {
+	return s.db.queryChannelList(spaceID, start, end, activeStatus, sortBy, order, offset, limit)
+}
+
+// spaceExists 判断 Space 是否存在(用于表二 404)。
+func (s *service) spaceExists(spaceID string) (bool, error) {
+	return s.db.spaceExists(spaceID)
+}
+
+// directChatList 全局私聊活跃列表 + 解析双方展示名。
+func (s *service) directChatList(start, end, sortBy, order string, offset, limit int) ([]*directChatItem, int64, error) {
+	items, total, err := s.db.queryDirectChatList(start, end, sortBy, order, offset, limit)
+	if err != nil {
+		return nil, 0, err
+	}
+	uidSet := make(map[string]struct{}, len(items)*2)
+	for _, it := range items {
+		uidSet[it.MemberAUID] = struct{}{}
+		uidSet[it.MemberBUID] = struct{}{}
+	}
+	uids := make([]string, 0, len(uidSet))
+	for u := range uidSet {
+		uids = append(uids, u)
+	}
+	names, err := s.db.queryMemberNames(uids)
+	if err != nil {
+		return nil, 0, err
+	}
+	for _, it := range items {
+		it.MemberAName = names[it.MemberAUID]
+		it.MemberBName = names[it.MemberBUID]
+	}
+	return items, total, nil
+}
+
+// spaceSortValue 取某列排序值(int64)。
+func sortSpaceItems(items []*spaceListItem, sortBy, order string) {
+	val := func(it *spaceListItem) int64 {
+		switch sortBy {
+		case "human_msg_count":
+			return it.HumanMsgCount
+		case "agent_msg_count":
+			return it.AgentMsgCount
+		case "total_msg":
+			return it.HumanMsgCount + it.AgentMsgCount
+		case "group_total":
+			return it.GroupTotal
+		case "human_member_total":
+			return it.HumanMemberTotal
+		default: // last_active
+			return it.LastActive
+		}
+	}
+	asc := order == "asc"
+	sort.SliceStable(items, func(i, j int) bool {
+		vi, vj := val(items[i]), val(items[j])
+		if vi == vj {
+			return items[i].SpaceID < items[j].SpaceID // 稳定次序
+		}
+		if asc {
+			return vi < vj
+		}
+		return vi > vj
+	})
+}

--- a/modules/opanalytics/service.go
+++ b/modules/opanalytics/service.go
@@ -22,6 +22,7 @@ func newService(ctx *config.Context) *service {
 
 // overview 组装模块A 概览卡片。总数与活跃/消息量均随时间范围与可选 space 筛选收敛：选中某 Space
 // 时，总数(space/group/member)也限定到该 Space，前端用"总数+活跃数"算比例才不会失真。
+// 活跃成员只算当前在册者(见 overviewActiveMembers)，私聊数在 space 筛选下置 0(私聊无 space 归属)。
 func (s *service) overview(start, end string, spaceIDs []string) (*overviewResp, error) {
 	spaceTotal, err := s.db.countSpacesTotal(spaceIDs)
 	if err != nil {
@@ -43,9 +44,12 @@ func (s *service) overview(start, end string, spaceIDs []string) (*overviewResp,
 	if err != nil {
 		return nil, err
 	}
-	privateActive, err := s.db.privateActiveCount(start, end)
-	if err != nil {
-		return nil, err
+	// 私聊无 space 归属：选中某 Space 时置 0(否则会把"全公司私聊数"混进按空间收敛的卡片，误导)。
+	var privateActive int64
+	if len(spaceIDs) == 0 {
+		if privateActive, err = s.db.privateActiveCount(start, end); err != nil {
+			return nil, err
+		}
 	}
 	return &overviewResp{
 		SpaceTotal:         spaceTotal,

--- a/modules/opanalytics/service.go
+++ b/modules/opanalytics/service.go
@@ -20,17 +20,18 @@ func newService(ctx *config.Context) *service {
 	}
 }
 
-// overview 组装模块A 概览卡片。总数=全局系统全量(不随时间/space 变)；活跃/消息量随范围与可选 space。
+// overview 组装模块A 概览卡片。总数与活跃/消息量均随时间范围与可选 space 筛选收敛：选中某 Space
+// 时，总数(space/group/member)也限定到该 Space，前端用"总数+活跃数"算比例才不会失真。
 func (s *service) overview(start, end string, spaceIDs []string) (*overviewResp, error) {
-	spaceTotal, err := s.db.countSpacesTotal()
+	spaceTotal, err := s.db.countSpacesTotal(spaceIDs)
 	if err != nil {
 		return nil, err
 	}
-	groupTotal, err := s.db.countGroupsTotal()
+	groupTotal, err := s.db.countGroupsTotal(spaceIDs)
 	if err != nil {
 		return nil, err
 	}
-	humanTotal, agentTotal, err := s.db.countMembersByType()
+	humanTotal, agentTotal, err := s.db.countMembersByType(spaceIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/opanalytics/sql/20260608000001_opanalytics_init.sql
+++ b/modules/opanalytics/sql/20260608000001_opanalytics_init.sql
@@ -1,0 +1,84 @@
+-- +migrate Up
+
+-- ① 成员维表：每日全量刷新，union user(⊎ robot)。human/agent 都有 user 行，robot=1 即 agent。
+CREATE TABLE `octo_dim_member` (
+  `uid`         VARCHAR(40)  NOT NULL          COMMENT '成员uid (= user.uid / robot.robot_id)',
+  `name`        VARCHAR(100) NOT NULL DEFAULT '' COMMENT '展示名 (user.name)',
+  `email`       VARCHAR(100) NOT NULL DEFAULT '' COMMENT '邮箱 (user.email; agent通常为空)',
+  `phone`       VARCHAR(20)  NOT NULL DEFAULT '' COMMENT '手机号 (user.phone)',
+  `zone`        VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '手机区号 (user.zone)',
+  `member_type` TINYINT      NOT NULL DEFAULT 1  COMMENT '1=human 2=agent (源 user.robot)',
+  `is_excluded` TINYINT      NOT NULL DEFAULT 0  COMMENT '1=测试/系统账号统计排除 (u_10000/botfather/fileHelper + 规则)',
+  `created_at`  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '行创建时间',
+  `updated_at`  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '行更新时间',
+  PRIMARY KEY (`uid`),
+  KEY `idx_type` (`member_type`),
+  KEY `idx_name` (`name`),
+  KEY `idx_email` (`email`),
+  KEY `idx_phone` (`zone`,`phone`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='看板成员维表';
+
+-- ② 会话维表：群从 group 派生，私聊从消息流(fakeChannelID)派生；private space_id='' 不进空间维度。
+CREATE TABLE `octo_dim_channel` (
+  `channel_id`         VARCHAR(100) NOT NULL          COMMENT '群=group_no; 私聊=fakeChannelID(uidX@uidY)',
+  `channel_type`       TINYINT      NOT NULL          COMMENT '1=私聊 2=群 (octo-lib common.ChannelType)',
+  `space_id`           VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '群=group.space_id; 私聊="" (不进空间维度)',
+  `conv_type`          TINYINT      NOT NULL DEFAULT 0  COMMENT '1=HH群 2=HA群 3=HH私聊 4=HA私聊 (ETL当日成员组成打标)',
+  `name`               VARCHAR(255) NOT NULL DEFAULT '' COMMENT '群名(group.name); 私聊空(展示层拼"A & B")',
+  `member_a_uid`       VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '私聊成员A (ETL按uid字典序规范化)',
+  `member_b_uid`       VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '私聊成员B',
+  `member_count`       INT          NOT NULL DEFAULT 0  COMMENT '当前在册总成员数(含外部, 群; group_member.status=1)',
+  `human_member_count` INT          NOT NULL DEFAULT 0  COMMENT '当前在册human成员数',
+  `agent_member_count` INT          NOT NULL DEFAULT 0  COMMENT '当前在册agent成员数',
+  `status`             TINYINT      NOT NULL DEFAULT 1  COMMENT '1=正常 2=群解散 (源 group.status: 1->1, 0->2)',
+  `first_msg_at`       BIGINT       NOT NULL DEFAULT 0  COMMENT '群=group.created_at(纪元秒); 私聊=首条消息时间(单调减LEAST)',
+  `last_active_at`     BIGINT       NOT NULL DEFAULT 0  COMMENT '最后一条有效消息时间戳(单调增GREATEST)',
+  `created_at`         TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '行创建时间',
+  `updated_at`         TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '行更新时间',
+  PRIMARY KEY (`channel_id`),
+  KEY `idx_space` (`space_id`,`channel_type`),
+  KEY `idx_conv` (`conv_type`),
+  KEY `idx_last_active` (`last_active_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='看板会话维表';
+
+-- ③ 事实表-成员×会话×日 (最细粒度，也是 ④ 的 ETL 中间产物)。
+CREATE TABLE `octo_fact_member_channel_daily` (
+  `stat_date`    DATE         NOT NULL          COMMENT '统计日(报告时区自然日)',
+  `channel_id`   VARCHAR(100) NOT NULL          COMMENT '会话ID',
+  `channel_type` TINYINT      NOT NULL          COMMENT '1=私聊 2=群',
+  `space_id`     VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '冗余 (群=group.space_id; 私聊="")',
+  `conv_type`    TINYINT      NOT NULL DEFAULT 0  COMMENT '冗余 (ETL当日成员组成打标)',
+  `content_type` TINYINT      NOT NULL DEFAULT 0  COMMENT '保留列: P0恒0; 未来类型排除/构成扩展用',
+  `sender_uid`   VARCHAR(40)  NOT NULL          COMMENT '发送者uid (message.from_uid)',
+  `sender_type`  TINYINT      NOT NULL DEFAULT 1  COMMENT '1=human 2=agent (join dim_member)',
+  `msg_count`    INT          NOT NULL DEFAULT 0  COMMENT '当日该成员在该会话的消息数(含撤回; 全量含系统/通话)',
+  `last_msg_at`  BIGINT       NOT NULL DEFAULT 0  COMMENT '当日该成员最后一条消息时间戳',
+  `created_at`   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '行创建时间',
+  PRIMARY KEY (`channel_id`,`stat_date`,`sender_uid`),
+  KEY `idx_space_sender_date` (`space_id`,`sender_uid`,`stat_date`),
+  KEY `idx_sender_date` (`sender_uid`,`stat_date`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='看板事实表-成员×会话×日';
+
+-- ④ 事实表-会话×日 (由 ③ 上卷物化)。
+CREATE TABLE `octo_fact_channel_daily` (
+  `stat_date`            DATE         NOT NULL          COMMENT '统计日(报告时区自然日)',
+  `channel_id`           VARCHAR(100) NOT NULL          COMMENT '会话ID',
+  `channel_type`         TINYINT      NOT NULL          COMMENT '1=私聊 2=群',
+  `space_id`             VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '冗余 (私聊="")',
+  `conv_type`            TINYINT      NOT NULL DEFAULT 0  COMMENT '冗余',
+  `human_msg_count`      INT          NOT NULL DEFAULT 0  COMMENT '当日human消息总数',
+  `agent_msg_count`      INT          NOT NULL DEFAULT 0  COMMENT '当日agent消息总数',
+  `active_human_members` INT          NOT NULL DEFAULT 0  COMMENT '当日活跃human成员数(去重)',
+  `active_agent_members` INT          NOT NULL DEFAULT 0  COMMENT '当日活跃agent成员数(去重)',
+  `last_msg_at`          BIGINT       NOT NULL DEFAULT 0  COMMENT '当日最后一条消息时间戳',
+  `created_at`           TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '行创建时间',
+  PRIMARY KEY (`space_id`,`stat_date`,`channel_id`),
+  KEY `idx_conv_date` (`conv_type`,`stat_date`),
+  KEY `idx_type_date` (`channel_type`,`stat_date`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='看板事实表-会话×日(上卷)';
+
+-- +migrate Down
+DROP TABLE IF EXISTS `octo_fact_channel_daily`;
+DROP TABLE IF EXISTS `octo_fact_member_channel_daily`;
+DROP TABLE IF EXISTS `octo_dim_channel`;
+DROP TABLE IF EXISTS `octo_dim_member`;

--- a/modules/opanalytics/sql/20260608000001_opanalytics_init.sql
+++ b/modules/opanalytics/sql/20260608000001_opanalytics_init.sql
@@ -8,11 +8,12 @@ CREATE TABLE `octo_dim_member` (
   `phone`       VARCHAR(20)  NOT NULL DEFAULT '' COMMENT '手机号 (user.phone)',
   `zone`        VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '手机区号 (user.zone)',
   `member_type` TINYINT      NOT NULL DEFAULT 1  COMMENT '1=human 2=agent (源 user.robot)',
-  `is_excluded` TINYINT      NOT NULL DEFAULT 0  COMMENT '1=测试/系统账号统计排除 (u_10000/botfather/fileHelper + 规则)',
+  `is_excluded` TINYINT      NOT NULL DEFAULT 0  COMMENT '1=测试/系统账号统计排除 (单一真源 pkg/space.SystemBots: botfather/u_10000/fileHelper/notification ∪ user.category=system)',
   `created_at`  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '行创建时间',
   `updated_at`  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '行更新时间',
   PRIMARY KEY (`uid`),
   KEY `idx_type` (`member_type`),
+  KEY `idx_excluded` (`is_excluded`),
   KEY `idx_name` (`name`),
   KEY `idx_email` (`email`),
   KEY `idx_phone` (`zone`,`phone`)
@@ -27,7 +28,7 @@ CREATE TABLE `octo_dim_channel` (
   `name`               VARCHAR(255) NOT NULL DEFAULT '' COMMENT '群名(group.name); 私聊空(展示层拼"A & B")',
   `member_a_uid`       VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '私聊成员A (ETL按uid字典序规范化)',
   `member_b_uid`       VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '私聊成员B',
-  `member_count`       INT          NOT NULL DEFAULT 0  COMMENT '当前在册总成员数(含外部, 群; group_member.status=1)',
+  `member_count`       INT          NOT NULL DEFAULT 0  COMMENT '当前在册总成员数(剔除is_excluded, 群; group_member.status=1)',
   `human_member_count` INT          NOT NULL DEFAULT 0  COMMENT '当前在册human成员数',
   `agent_member_count` INT          NOT NULL DEFAULT 0  COMMENT '当前在册agent成员数',
   `status`             TINYINT      NOT NULL DEFAULT 1  COMMENT '1=正常 2=群解散 (源 group.status: 1->1, 0->2)',
@@ -41,7 +42,8 @@ CREATE TABLE `octo_dim_channel` (
   KEY `idx_last_active` (`last_active_at`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='看板会话维表';
 
--- ③ 事实表-成员×会话×日 (最细粒度，也是 ④ 的 ETL 中间产物)。
+-- ③ 事实表-成员×会话×日 (最细粒度，也是 ④ 的来源)。
+-- 增量水位 ETL：按 (channel_id,stat_date,sender_uid) 累加 upsert(游标保证每条消息精确一次)，从不按日 DELETE。
 CREATE TABLE `octo_fact_member_channel_daily` (
   `stat_date`    DATE         NOT NULL          COMMENT '统计日(报告时区自然日)',
   `channel_id`   VARCHAR(100) NOT NULL          COMMENT '会话ID',
@@ -49,17 +51,18 @@ CREATE TABLE `octo_fact_member_channel_daily` (
   `space_id`     VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '冗余 (群=group.space_id; 私聊="")',
   `conv_type`    TINYINT      NOT NULL DEFAULT 0  COMMENT '冗余 (ETL当日成员组成打标)',
   `content_type` TINYINT      NOT NULL DEFAULT 0  COMMENT '保留列: P0恒0; 未来类型排除/构成扩展用',
-  `sender_uid`   VARCHAR(40)  NOT NULL          COMMENT '发送者uid (message.from_uid)',
+  `sender_uid`   VARCHAR(40)  NOT NULL          COMMENT '发送者uid (message.from_uid; 已剔除系统/测试账号)',
   `sender_type`  TINYINT      NOT NULL DEFAULT 1  COMMENT '1=human 2=agent (join dim_member)',
-  `msg_count`    INT          NOT NULL DEFAULT 0  COMMENT '当日该成员在该会话的消息数(含撤回; 全量含系统/通话)',
+  `msg_count`    INT          NOT NULL DEFAULT 0  COMMENT '当日该成员在该会话的消息数(含撤回; 全量含通话)',
   `last_msg_at`  BIGINT       NOT NULL DEFAULT 0  COMMENT '当日该成员最后一条消息时间戳',
   `created_at`   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '行创建时间',
   PRIMARY KEY (`channel_id`,`stat_date`,`sender_uid`),
-  KEY `idx_space_sender_date` (`space_id`,`sender_uid`,`stat_date`),
+  KEY `idx_date_channel` (`stat_date`,`channel_id`,`sender_type`,`sender_uid`),
+  KEY `idx_space_date` (`space_id`,`stat_date`,`sender_type`,`sender_uid`),
   KEY `idx_sender_date` (`sender_uid`,`stat_date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='看板事实表-成员×会话×日';
 
--- ④ 事实表-会话×日 (由 ③ 上卷物化)。
+-- ④ 事实表-会话×日 (每脏日由 ③ INSERT...SELECT 物化；DELETE WHERE stat_date=? 走 idx_date_type)。
 CREATE TABLE `octo_fact_channel_daily` (
   `stat_date`            DATE         NOT NULL          COMMENT '统计日(报告时区自然日)',
   `channel_id`           VARCHAR(100) NOT NULL          COMMENT '会话ID',
@@ -73,11 +76,32 @@ CREATE TABLE `octo_fact_channel_daily` (
   `last_msg_at`          BIGINT       NOT NULL DEFAULT 0  COMMENT '当日最后一条消息时间戳',
   `created_at`           TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '行创建时间',
   PRIMARY KEY (`space_id`,`stat_date`,`channel_id`),
+  KEY `idx_date_type` (`stat_date`,`channel_type`),
   KEY `idx_conv_date` (`conv_type`,`stat_date`),
   KEY `idx_type_date` (`channel_type`,`stat_date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='看板事实表-会话×日(上卷)';
 
+-- ⑤ ETL 消息抽取水位：每个 message 分片表一行，记录已处理的最大主键 id。
+-- 增量抽取按 PK `WHERE id>last_id ORDER BY id LIMIT batch` keyset 分页，避免对无 timestamp 索引的
+-- message 分片做全表扫；chunk 内 `SELECT ... FOR UPDATE` 串行化多实例，保证消息精确一次累加。
+CREATE TABLE `octo_etl_message_cursor` (
+  `shard_table` VARCHAR(64) NOT NULL          COMMENT 'message 分片表名 (message / message1 / ...)',
+  `last_id`     BIGINT      NOT NULL DEFAULT 0 COMMENT '已处理的最大 message.id 水位',
+  `updated_at`  TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '行更新时间',
+  PRIMARY KEY (`shard_table`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='看板ETL消息抽取水位';
+
+-- ⑥ ETL 待重算日队列：③ 累加后将受影响 stat_date 标脏，全部 chunk 处理完再由 ③ 重算 ④。
+-- 持久化而非内存：保证"③已提交但④未重算"的崩溃窗口可由下次运行自愈(④对③最终一致)。
+CREATE TABLE `octo_etl_dirty_day` (
+  `stat_date`  DATE      NOT NULL          COMMENT '待由 ③ 重算 ④ 的统计日',
+  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '行更新时间',
+  PRIMARY KEY (`stat_date`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='看板ETL待重算日队列';
+
 -- +migrate Down
+DROP TABLE IF EXISTS `octo_etl_dirty_day`;
+DROP TABLE IF EXISTS `octo_etl_message_cursor`;
 DROP TABLE IF EXISTS `octo_fact_channel_daily`;
 DROP TABLE IF EXISTS `octo_fact_member_channel_daily`;
 DROP TABLE IF EXISTS `octo_dim_channel`;

--- a/modules/opanalytics/sql/20260608000001_opanalytics_init.sql
+++ b/modules/opanalytics/sql/20260608000001_opanalytics_init.sql
@@ -84,6 +84,7 @@ CREATE TABLE `octo_fact_channel_daily` (
 -- ⑤ ETL 消息抽取水位：每个 message 分片表一行，记录已处理的最大主键 id。
 -- 增量抽取按 PK `WHERE id>last_id ORDER BY id LIMIT batch` keyset 分页，避免对无 timestamp 索引的
 -- message 分片做全表扫；chunk 内 `SELECT ... FOR UPDATE` 串行化多实例，保证消息精确一次累加。
+-- 水位只推进到"落库已超过 lag(稳定性滞后窗口)"的前缀，杜绝低 id 晚提交被游标越过的并发漏扫。
 CREATE TABLE `octo_etl_message_cursor` (
   `shard_table` VARCHAR(64) NOT NULL          COMMENT 'message 分片表名 (message / message1 / ...)',
   `last_id`     BIGINT      NOT NULL DEFAULT 0 COMMENT '已处理的最大 message.id 水位',

--- a/modules/opanalytics/swagger/api.yaml
+++ b/modules/opanalytics/swagger/api.yaml
@@ -1,0 +1,460 @@
+swagger: "2.0"
+info:
+  description: "Octo API"
+  version: "1.0.0"
+  title: "Octo API"
+host: "api.botgate.cn"
+tags:
+  - name: "opanalyticsManager"
+    description: "运营分析看板（后台管理，仅 superAdmin）"
+schemes:
+  - "https"
+basePath: "/v1"
+
+paths:
+  /manager/dashboard/overview:
+    get:
+      tags:
+        - "opanalyticsManager"
+      summary: "概览卡片（模块A）"
+      description: >
+        运营看板概览。总数(space/group/member)与活跃/消息量随时间范围与可选 space 筛选收敛；
+        活跃成员只算当前在册者(active ⊆ total，率≤100%)；
+        private_active_count 为全局活跃私聊数，选中 space 时返回 0（私聊无 space 归属）。
+        消息量按 event-time 统计（含撤回，全量含通话），与成员"当前在册"口径有意不同。
+      operationId: "m dashboard overview"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "query"
+          name: "start_date"
+          type: string
+          format: date
+          description: "起始统计日 YYYY-MM-DD（报告时区）。缺省=近 30 天；含两端最多 366 天"
+          required: false
+        - in: "query"
+          name: "end_date"
+          type: string
+          format: date
+          description: "结束统计日 YYYY-MM-DD（含）。缺省=今天"
+          required: false
+        - in: "query"
+          name: "space_ids"
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+          description: "可选空间筛选；多值用 space_ids=a&space_ids=b。为空=全局"
+          required: false
+      responses:
+        200:
+          description: "概览数据"
+          schema:
+            $ref: "#/definitions/overviewResp"
+        400:
+          description: "错误（error.http_status 含真实状态码：403 越权 / 400 参数无效 / 500 查询失败）"
+          schema:
+            $ref: "#/definitions/dashboardError"
+      security:
+        - token: []
+
+  /manager/dashboard/spaces:
+    get:
+      tags:
+        - "opanalyticsManager"
+      summary: "空间列表（表一）"
+      description: "按空间汇总：群数、在册人数、消息量、最后活跃、是否活跃。支持名称筛选/活跃状态/排序/分页。"
+      operationId: "m dashboard spaces"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "query"
+          name: "start_date"
+          type: string
+          format: date
+          description: "起始统计日 YYYY-MM-DD。缺省=近 30 天"
+          required: false
+        - in: "query"
+          name: "end_date"
+          type: string
+          format: date
+          description: "结束统计日 YYYY-MM-DD（含）"
+          required: false
+        - in: "query"
+          name: "name"
+          type: string
+          description: "空间名称模糊匹配（% _ 作字面量处理）"
+          required: false
+        - in: "query"
+          name: "active_status"
+          type: string
+          enum: ["all", "active", "inactive"]
+          default: "all"
+          description: "活跃状态筛选"
+          required: false
+        - in: "query"
+          name: "sort_by"
+          type: string
+          enum: ["last_active", "human_msg_count", "agent_msg_count", "total_msg", "group_total", "human_member_total"]
+          default: "last_active"
+          description: "排序字段（白名单）"
+          required: false
+        - in: "query"
+          name: "order"
+          type: string
+          enum: ["asc", "desc"]
+          default: "desc"
+          description: "排序方向"
+          required: false
+        - in: "query"
+          name: "page_index"
+          type: integer
+          default: 1
+          description: "页码（从 1 起，上限 1000000）"
+          required: false
+        - in: "query"
+          name: "page_size"
+          type: integer
+          default: 20
+          description: "每页条数（上限 200）"
+          required: false
+      responses:
+        200:
+          description: "空间列表"
+          schema:
+            $ref: "#/definitions/spaceListResp"
+        400:
+          description: "错误（error.http_status 含真实状态码）"
+          schema:
+            $ref: "#/definitions/dashboardError"
+      security:
+        - token: []
+
+  /manager/dashboard/spaces/{space_id}/channels:
+    get:
+      tags:
+        - "opanalyticsManager"
+      summary: "群组列表（表二，仅群组）"
+      description: "某空间下的群组明细（仅 channel_type=2；私聊不进此表）。已解散/已删除群不展示。空间不存在或已停用返回 not_found。"
+      operationId: "m dashboard space channels"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "path"
+          name: "space_id"
+          type: string
+          description: "空间 ID"
+          required: true
+        - in: "query"
+          name: "start_date"
+          type: string
+          format: date
+          description: "起始统计日 YYYY-MM-DD。缺省=近 30 天"
+          required: false
+        - in: "query"
+          name: "end_date"
+          type: string
+          format: date
+          description: "结束统计日 YYYY-MM-DD（含）"
+          required: false
+        - in: "query"
+          name: "active_status"
+          type: string
+          enum: ["all", "active", "inactive"]
+          default: "all"
+          description: "活跃状态筛选"
+          required: false
+        - in: "query"
+          name: "sort_by"
+          type: string
+          enum: ["last_active", "human_msg_count", "agent_msg_count", "total_msg", "member_count"]
+          default: "last_active"
+          description: "排序字段（白名单）"
+          required: false
+        - in: "query"
+          name: "order"
+          type: string
+          enum: ["asc", "desc"]
+          default: "desc"
+          description: "排序方向"
+          required: false
+        - in: "query"
+          name: "page_index"
+          type: integer
+          default: 1
+          description: "页码（从 1 起，上限 1000000）"
+          required: false
+        - in: "query"
+          name: "page_size"
+          type: integer
+          default: 20
+          description: "每页条数（上限 200）"
+          required: false
+      responses:
+        200:
+          description: "群组列表"
+          schema:
+            $ref: "#/definitions/channelListResp"
+        400:
+          description: "错误（error.http_status：404 空间不存在 / 403 越权 / 400 参数无效 / 500）"
+          schema:
+            $ref: "#/definitions/dashboardError"
+      security:
+        - token: []
+
+  /manager/dashboard/global/direct-chats:
+    get:
+      tags:
+        - "opanalyticsManager"
+      summary: "全局私聊活跃列表"
+      description: "跨空间的活跃 1:1 私聊（无活跃状态筛选）。展示双方 uid/名称、消息量、最后活跃。"
+      operationId: "m dashboard direct chats"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "query"
+          name: "start_date"
+          type: string
+          format: date
+          description: "起始统计日 YYYY-MM-DD。缺省=近 30 天"
+          required: false
+        - in: "query"
+          name: "end_date"
+          type: string
+          format: date
+          description: "结束统计日 YYYY-MM-DD（含）"
+          required: false
+        - in: "query"
+          name: "sort_by"
+          type: string
+          enum: ["last_active", "msg_count"]
+          default: "last_active"
+          description: "排序字段（白名单）"
+          required: false
+        - in: "query"
+          name: "order"
+          type: string
+          enum: ["asc", "desc"]
+          default: "desc"
+          description: "排序方向"
+          required: false
+        - in: "query"
+          name: "page_index"
+          type: integer
+          default: 1
+          description: "页码（从 1 起，上限 1000000）"
+          required: false
+        - in: "query"
+          name: "page_size"
+          type: integer
+          default: 20
+          description: "每页条数（上限 200）"
+          required: false
+      responses:
+        200:
+          description: "私聊列表"
+          schema:
+            $ref: "#/definitions/directChatListResp"
+        400:
+          description: "错误（error.http_status 含真实状态码）"
+          schema:
+            $ref: "#/definitions/dashboardError"
+      security:
+        - token: []
+
+securityDefinitions:
+  token:
+    type: "apiKey"
+    in: "header"
+    name: "token"
+    description: "用户 token（看板接口要求 superAdmin 角色）"
+
+definitions:
+  overviewResp:
+    type: object
+    properties:
+      space_total:
+        type: integer
+        format: int64
+        description: "空间总数（随 space 筛选收敛）"
+      group_total:
+        type: integer
+        format: int64
+        description: "群组总数"
+      human_member_total:
+        type: integer
+        format: int64
+        description: "human 成员总数（当前在册，剔除系统/测试/禁用）"
+      agent_total:
+        type: integer
+        format: int64
+        description: "agent 成员总数"
+      active_groups:
+        type: integer
+        format: int64
+        description: "范围内活跃群数"
+      active_human_members:
+        type: integer
+        format: int64
+        description: "范围内活跃 human 成员去重数（当前在册口径，⊆ human_member_total）"
+      active_agent_members:
+        type: integer
+        format: int64
+        description: "范围内活跃 agent 成员去重数（⊆ agent_total）"
+      human_msg_count:
+        type: integer
+        format: int64
+        description: "范围内 human 消息量（event-time，含撤回/通话）"
+      agent_msg_count:
+        type: integer
+        format: int64
+        description: "范围内 agent 消息量"
+      private_active_count:
+        type: integer
+        format: int64
+        description: "范围内活跃私聊数（全局；选中 space 时为 0）"
+
+  spaceListResp:
+    type: object
+    properties:
+      count:
+        type: integer
+        format: int64
+        description: "总条数"
+      list:
+        type: array
+        items:
+          $ref: "#/definitions/spaceListItem"
+
+  spaceListItem:
+    type: object
+    properties:
+      space_id:
+        type: string
+      name:
+        type: string
+      group_total:
+        type: integer
+        format: int64
+      human_member_total:
+        type: integer
+        format: int64
+      agent_total:
+        type: integer
+        format: int64
+      human_msg_count:
+        type: integer
+        format: int64
+      agent_msg_count:
+        type: integer
+        format: int64
+      last_active:
+        type: integer
+        format: int64
+        description: "最后活跃时间戳（纪元秒）；0=范围内无消息"
+      is_active:
+        type: boolean
+        description: "范围内是否有群活跃"
+
+  channelListResp:
+    type: object
+    properties:
+      count:
+        type: integer
+        format: int64
+      list:
+        type: array
+        items:
+          $ref: "#/definitions/channelListItem"
+
+  channelListItem:
+    type: object
+    properties:
+      channel_id:
+        type: string
+        description: "群编号 group_no"
+      name:
+        type: string
+      conv_type:
+        type: integer
+        description: "会话类型 1.HH群 2.HA群 3.HH私聊 4.HA私聊"
+      member_count:
+        type: integer
+        description: "在册成员数（剔除系统/测试，且已退群 is_deleted=1 不计）"
+      human_member_count:
+        type: integer
+      agent_member_count:
+        type: integer
+      human_msg_count:
+        type: integer
+        format: int64
+      agent_msg_count:
+        type: integer
+        format: int64
+      last_active_at:
+        type: integer
+        format: int64
+        description: "最后活跃时间戳（纪元秒）"
+      status:
+        type: integer
+        description: "群状态 1.正常 2.解散"
+      is_active:
+        type: boolean
+        description: "范围内是否活跃"
+
+  directChatListResp:
+    type: object
+    properties:
+      count:
+        type: integer
+        format: int64
+      list:
+        type: array
+        items:
+          $ref: "#/definitions/directChatItem"
+
+  directChatItem:
+    type: object
+    properties:
+      channel_id:
+        type: string
+        description: "私聊 fakeChannelID"
+      member_a_uid:
+        type: string
+      member_a_name:
+        type: string
+      member_b_uid:
+        type: string
+      member_b_name:
+        type: string
+      conv_type:
+        type: integer
+        description: "会话类型 3.HH私聊 4.HA私聊"
+      msg_count:
+        type: integer
+        format: int64
+        description: "范围内消息量"
+      last_active:
+        type: integer
+        format: int64
+        description: "最后活跃时间戳（纪元秒）"
+
+  dashboardError:
+    type: object
+    description: "i18n 错误信封。传输层 HTTP 状态恒为 400（D14 兼容），真实状态在 error.http_status。"
+    properties:
+      status:
+        type: integer
+        description: "传输层状态（恒 400）"
+      error:
+        type: object
+        properties:
+          code:
+            type: string
+            description: "错误码，如 err.server.opanalytics.not_found / forbidden / request_invalid / query_failed"
+          http_status:
+            type: integer
+            description: "真实 HTTP 语义状态码（403/404/400/500）"
+          message:
+            type: string
+            description: "本地化文案（5xx 内部错误隐藏）"

--- a/modules/opanalytics/test_deps_setup_test.go
+++ b/modules/opanalytics/test_deps_setup_test.go
@@ -1,0 +1,14 @@
+package opanalytics
+
+// test_deps_setup_test.go blank-imports the modules whose migrations create the
+// source tables the ETL/读侧 query (user, group/group_member, space/space_member,
+// robot). Without these, module.Setup (invoked by testutil.NewTestServer) would not
+// register their SQLDir migrations and the test schema would be missing those tables.
+// The `message`/`message1..N` shard tables are NOT created by any migration (WuKongIM
+// owns them in prod); the integration test creates them itself (see api_test.go).
+import (
+	_ "github.com/Mininglamp-OSS/octo-server/modules/group"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/robot"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/space"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/user"
+)

--- a/pkg/errcode/opanalytics.go
+++ b/pkg/errcode/opanalytics.go
@@ -1,0 +1,35 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// err.server.opanalytics.* — modules/opanalytics 运营分析看板(管理端 superAdmin
+// 跨 space 只读)的业务错误码。DefaultMessage 是 en-US 源；zh-CN 运行时翻译在
+// pkg/i18n/locales/active.zh-CN.toml。5xx ⟺ Internal=true(渲染层隐藏 message/details)。
+var (
+	ErrOpanalyticsForbidden = register(codes.Code{
+		ID:             "err.server.opanalytics.forbidden",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Only a super admin can access the analytics dashboard.",
+	})
+	ErrOpanalyticsRequestInvalid = register(codes.Code{
+		ID:             "err.server.opanalytics.request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid analytics request.",
+		SafeDetailKeys: []string{"reason"},
+	})
+	ErrOpanalyticsNotFound = register(codes.Code{
+		ID:             "err.server.opanalytics.not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "The space does not exist.",
+	})
+	ErrOpanalyticsQueryFailed = register(codes.Code{
+		ID:             "err.server.opanalytics.query_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to query analytics data.",
+		Internal:       true,
+	})
+)

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -1070,3 +1070,17 @@ other = "该名称匹配到多个密钥，请进一步指明。"
 
 ["err.server.usersecret.resolve_failed"]
 other = "密钥解析失败。"
+
+# ---- modules/opanalytics：运营分析看板（管理端 superAdmin 只读） ----
+
+["err.server.opanalytics.forbidden"]
+other = "仅超级管理员可访问运营看板。"
+
+["err.server.opanalytics.request_invalid"]
+other = "请求参数无效。"
+
+["err.server.opanalytics.not_found"]
+other = "Space 不存在。"
+
+["err.server.opanalytics.query_failed"]
+other = "查询看板数据失败。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -486,6 +486,18 @@ other = "The binding session has expired or is invalid. Please start over."
 ["err.server.oidc.bind_verify_required"]
 other = "Please complete verification before confirming."
 
+["err.server.opanalytics.forbidden"]
+other = "Only a super admin can access the analytics dashboard."
+
+["err.server.opanalytics.not_found"]
+other = "The space does not exist."
+
+["err.server.opanalytics.query_failed"]
+other = "Failed to query analytics data."
+
+["err.server.opanalytics.request_invalid"]
+other = "Invalid analytics request."
+
 ["err.server.qrcode.group_not_found"]
 other = "Group not found."
 


### PR DESCRIPTION
## What

New `modules/opanalytics` — a superAdmin-only, cross-Space read dashboard for IM operations, plus the daily ETL that pre-aggregates message activity into dimension/fact tables.

Endpoints (prefix `/v1/manager/dashboard`, all behind `AuthMiddleware` + per-handler superAdmin + `SharedUIDRateLimiter`):
- `GET /overview` — module A summary cards
- `GET /spaces` — table 1: Space list (name filter / active filter / sort / paginate)
- `GET /spaces/:space_id/channels` — table 2: group list (groups only)
- `GET /global/direct-chats` — global private-chat activity list

## Data model

- Dimensions: `octo_dim_member`, `octo_dim_channel`
- Facts: `octo_fact_member_channel_daily` (③, member×channel×day), `octo_fact_channel_daily` (④, channel×day rollup)
- ETL bookkeeping: `octo_etl_message_cursor`, `octo_etl_dirty_day`

## Key design decisions

**Incremental extraction (no DDL on the hot `message` shards).** The `message` shards have only `PRIMARY KEY(id)` + `UNIQUE(message_id)` — no timestamp index. ETL tails each shard by PK keyset (`WHERE id>cursor ORDER BY id LIMIT batch`), accumulates into ③ exactly-once (cursor advance + upsert in one tx, `SELECT ... FOR UPDATE` on the cursor row serializes replicas), then rematerializes ④ per dirty day via `INSERT...SELECT`. First run backfills from id=0.

**Miss-free under concurrent writes (stability lag).** Because `id` is assigned at INSERT but rows become visible at COMMIT (commit order ≠ id order), a strict watermark could skip a low id that commits late. ETL only processes the gapless *stable prefix* (`created_at <= DB_NOW - lag`, default 600s, `OCTO_OPANALYTICS_ETL_LAG_SECONDS`); the cursor never advances past an unstable tail.

**Noise exclusion, single source of truth.** System/test accounts come from `pkg/space.SystemBots` ∪ `user.category='system'`. Excluded senders are dropped from ③/④/active counts; a private chat with either party excluded is dropped entirely.

**Event-time vs current-roster semantics.** Message volume is event-time (a since-disabled user's historical messages still count). Member *totals* and *active member* counts reflect the current roster (`dim_member` is fully refreshed each run — disabled users are `is_excluded`, deleted users leave no stale row), so active ⊆ total and the active ratio ≤ 100%. `Rebuild()` (or TRUNCATE the facts + cursor) re-runs with the current dimensions to apply retroactive corrections.

**Space filter coherence.** Overview totals (space/group/member) and active/message counts all scope to the selected Space(s); `private_active_count` returns 0 under a Space filter (private chats have no Space). Per-space member totals are consistent between overview and table 1 (both INNER JOIN dim).

**Concurrency / abuse controls.** Daily run guarded by a Redis `SET NX EX` + Lua CAS-DEL distributed lock; management routes carry `SharedUIDRateLimiter`.

i18n: errors go through `httperr.ResponseErrorL` + `pkg/errcode/opanalytics` codes; zh-CN translations added; D23 guard test included.

## Testing

`go test ./modules/opanalytics/...` — 16 cases (ETL exactness/idempotency/lag/rebuild/exclusion, dim full-refresh, overview/space-filter consistency, endpoints, i18n guard) green against MySQL 8 + Redis. `go build ./...`, `go vet`, `golangci-lint` (0 issues), `make i18n-extract-check`, `make i18n-lint` all pass.

## Migration

Adds `modules/opanalytics/sql/20260608000001_opanalytics_init.sql` (dims + facts + ETL bookkeeping). No schema change to the existing `message` shards. WuKongIM owns the `message` tables; ETL reads them only.

https://claude.ai/code/session_01EwvMdJ6itj2WLB7pYJwxtx

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwvMdJ6itj2WLB7pYJwxtx)_