### PR TITLE
feat: return thread status in /sidebar/sync for thread items (#310)

### DIFF
--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -138,6 +138,11 @@ type SidebarItem struct {
 	intraCategorySort int
 	FollowSort        int    `json:"follow_sort,omitempty"`
 	ParentChannelID   string `json:"parent_channel_id,omitempty"` // thread only
+	// Status 仅对 thread 条目（target_type=5）有意义：1=active 2=archived
+	// 3=deleted，语义与 modules/thread/const.go 的 ThreadStatus* 枚举一致
+	// （GH octo-server#310）。客户端据此同步过滤已归档子区，无需等待 channelInfo。
+	// omitempty 让 DM / 群条目不带该字段，保持线上协议向后兼容。
+	Status int `json:"status,omitempty"`
 }
 
 // sidebarSyncResp is the JSON response for POST /v1/sidebar/sync.
@@ -462,11 +467,19 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 		// Append standalone thread ext entries not present in IM result.
 		// Pass categorySetting + unfollowedGroups so parent-follow filter applies
 		// to DB-only thread entries as well (PR review Round-3 Blocking #4).
-		lastMsgAtMap, err := sb.loadThreadLastMsgAt(threadExtRows)
+		lastMsgAtMap, threadStatusMap, err := sb.loadThreadLastMsgAt(threadExtRows)
 		if failClosedForFollow("thread last_message_at query", err) {
 			return
 		}
 		items = mergeThreadEntries(items, threadExtRows, lastMsgAtMap, categorySetting, unfollowedGroups, groupSpaceMap, externalGroupMap, defaultSpaceID)
+
+		// GH octo-server#310：把 thread 生命周期状态回填到 thread 条目。statusMap
+		// 来自 loadThreadLastMsgAt（复用 QueryActiveByGroupShortIDs 已 SELECT 的
+		// status，零额外查询），键为 "{groupNo}____{shortID}"，与 thread 条目的
+		// TargetID 同口径。同时覆盖 buildFollowItems（IM-present）与 mergeThreadEntries
+		// （DB-only）两条路径；mergeThreadEntries 已把不在 statusMap 中的 thread
+		// （deleted/missing）skip，所以幸存的 thread 条目必有 status。
+		backfillThreadStatus(items, threadStatusMap)
 
 		// Issue #151 symptom #2 — materialize ext rows for default-followed
 		// groups (categorized but never touched).  Without this, OnThreadCreated
@@ -528,6 +541,15 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 	case "recent":
 		cutoffs := loadRecentCutoffs(sb.ctx, time.Now())
 		items = buildRecentItems(conversations, cutoffs, pinnedSet, groupSpaceMap, externalGroupMap, defaultSpaceID)
+		// GH octo-server#310：recent tab 也要带 thread 生命周期状态。一次性批量
+		// 查询所有 thread 条目的 status（无 N+1），再 backfill。
+		// FAIL-OPEN：查询失败只记 warn 并把 Status 留空（omitempty -> 字段缺省），
+		// 与 recent tab 既有的降级行为一致，绝不 fail-closed。
+		if statusMap, qerr := sb.loadThreadStatuses(items); qerr != nil {
+			sb.Warn("sidebar sync: thread status query failed (recent tab non-fatal, status omitted)", zap.Error(qerr))
+		} else {
+			backfillThreadStatus(items, statusMap)
+		}
 	}
 
 	// 4. Enrich pinned flag (follow tab items also need it)
@@ -602,31 +624,91 @@ func (sb *Sidebar) loadPinnedSet(uid, spaceID string) (map[string]struct{}, erro
 // 在 follow tab 路径下吞掉错误并返回空 map 会让 mergeThreadEntries 把所有 DB-only
 // thread 当 "不活跃" skip，客户端 follow tab 残缺但仍带 follow_version，看上去 fresh —
 // 客户端长期缓存错误结果。所以接口契约改为：错误必须显式上报。
-func (sb *Sidebar) loadThreadLastMsgAt(extRows []*convext.Model) (map[string]*time.Time, error) {
+//
+// GH octo-server#310：QueryActiveByGroupShortIDs 同时 SELECT 了 status，这里把它
+// 一并 surface 出来（statusMap，键同为 "{groupNo}____{shortID}"），让 follow tab
+// 在 backfill 阶段把 thread 生命周期状态回填到 SidebarItem.Status，零额外查询。
+func (sb *Sidebar) loadThreadLastMsgAt(extRows []*convext.Model) (lastMsgAt map[string]*time.Time, statusMap map[string]int, err error) {
 	result := make(map[string]*time.Time, len(extRows))
+	statuses := make(map[string]int, len(extRows))
 	if len(extRows) == 0 {
-		return result, nil
+		return result, statuses, nil
 	}
 	refs := make([]thread.ShortRef, 0, len(extRows))
 	for _, m := range extRows {
-		gno, sid, err := parseThreadChannelIDSidebar(m.TargetID)
+		gno, sid, perr := parseThreadChannelIDSidebar(m.TargetID)
+		if perr != nil {
+			continue
+		}
+		refs = append(refs, thread.ShortRef{GroupNo: gno, ShortID: sid})
+	}
+	if len(refs) == 0 {
+		return result, statuses, nil
+	}
+	threadMap, qerr := sb.threadDB.QueryActiveByGroupShortIDs(refs)
+	if qerr != nil {
+		return nil, nil, fmt.Errorf("sidebar load thread last_message_at: %w", qerr)
+	}
+	// QueryActiveByGroupShortIDs 已经按 "{groupNo}____{shortID}" 做键，直接转写。
+	for key, lite := range threadMap {
+		result[key] = lite.LastMessageAt
+		statuses[key] = lite.Status
+	}
+	return result, statuses, nil
+}
+
+// loadThreadStatuses 批量查询给定 sidebar items 里 thread 条目（target_type=5）
+// 的生命周期 status，返回 map["{groupNo}____{shortID}"]status。供 recent tab 使用：
+// 那里没有现成的 thread DB 结果可复用，必须单独发一次 batched 查询（无 N+1）。
+//
+// 复用 thread.QueryActiveByGroupShortIDs：它已按 (group_no, short_id) 过滤、只返回
+// status != deleted 的行，且只 SELECT 最小列集。不修改它的过滤语义（鉴权路径依赖
+// 它过滤掉 deleted），仅消费它本就返回的 status。
+//
+// 无 thread 条目时返回空 map、不发查询。
+func (sb *Sidebar) loadThreadStatuses(items []*SidebarItem) (map[string]int, error) {
+	refs := make([]thread.ShortRef, 0)
+	for _, it := range items {
+		if it.TargetType != int(common.ChannelTypeCommunityTopic) {
+			continue
+		}
+		gno, sid, err := parseThreadChannelIDSidebar(it.TargetID)
 		if err != nil {
 			continue
 		}
 		refs = append(refs, thread.ShortRef{GroupNo: gno, ShortID: sid})
 	}
 	if len(refs) == 0 {
-		return result, nil
+		return map[string]int{}, nil
 	}
 	threadMap, err := sb.threadDB.QueryActiveByGroupShortIDs(refs)
 	if err != nil {
-		return nil, fmt.Errorf("sidebar load thread last_message_at: %w", err)
+		return nil, fmt.Errorf("sidebar load thread statuses: %w", err)
 	}
-	// QueryActiveByGroupShortIDs 已经按 "{groupNo}____{shortID}" 做键，直接转写。
+	statuses := make(map[string]int, len(threadMap))
 	for key, lite := range threadMap {
-		result[key] = lite.LastMessageAt
+		statuses[key] = lite.Status
 	}
-	return result, nil
+	return statuses, nil
+}
+
+// backfillThreadStatus 把 statusMap 里的 thread 生命周期 status 回填到 thread 条目
+// （target_type=5）的 SidebarItem.Status 上（GH octo-server#310）。statusMap 的键是
+// "{groupNo}____{shortID}"，与 thread 条目的 TargetID 一致。非 thread 条目跳过；
+// statusMap 中没有的 thread 条目保持 Status=0（omitempty -> 字段缺省），由调用方
+// 的 fail-open / fail-closed 语义决定这种情况是否会出现。
+func backfillThreadStatus(items []*SidebarItem, statusMap map[string]int) {
+	if len(statusMap) == 0 {
+		return
+	}
+	for _, it := range items {
+		if it.TargetType != int(common.ChannelTypeCommunityTopic) {
+			continue
+		}
+		if st, ok := statusMap[it.TargetID]; ok {
+			it.Status = st
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/message/api_sidebar_status_test.go
+++ b/modules/message/api_sidebar_status_test.go
@@ -1,0 +1,283 @@
+//go:build integration
+
+package message
+
+// =============================================================================
+// Sidebar thread-status surfacing — DB-backed tests (GH octo-server#310)
+//
+// /sidebar/sync must stamp each thread item (target_type=5) with the thread
+// lifecycle status (1=active / 2=archived / 3=deleted) so the client can filter
+// archived threads synchronously. These tests seed real thread rows and drive
+// the same helpers Sidebar.Sync uses:
+//   - loadThreadLastMsgAt  (follow tab: last_message_at + status, one query)
+//   - loadThreadStatuses   (recent tab: status only, one batched query)
+//   - backfillThreadStatus (stamp Status onto thread items)
+//
+// Build-tagged `integration` (run with `go test -tags=integration`), matching
+// api_sidebar_integration_test.go / api_sidebar_recent_filter_e2e_test.go:
+// these spin up testutil.NewTestServer against the shared `test` DB, which is
+// order-fragile under the default `go test ./...` job (a prior test in the
+// package can leave the schema in a state where NewTestServer's module.Setup
+// re-applies a migration whose table already exists and panics). The pure
+// backfill / JSON-shape logic is covered by api_sidebar_test.go in the default
+// job; this file is the extra DB-backed glue check.
+// =============================================================================
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedThread inserts a thread row with the given group/short/status.
+func seedThread(t *testing.T, ctx *config.Context, groupNo, shortID string, status int, lastMsgAt *time.Time) {
+	t.Helper()
+	tdb := thread.NewDB(ctx)
+	require.NoError(t, tdb.Insert(&thread.Model{
+		ShortID:       shortID,
+		GroupNo:       groupNo,
+		Name:          "thr-" + shortID,
+		CreatorUID:    "creator",
+		Status:        status,
+		Version:       1,
+		LastMessageAt: lastMsgAt,
+	}), "seed thread %s____%s status=%d", groupNo, shortID, status)
+}
+
+func threadChannelID(groupNo, shortID string) string { return groupNo + "____" + shortID }
+
+// loadThreadLastMsgAt must surface the thread status alongside last_message_at,
+// keyed by "{groupNo}____{shortID}", and must omit deleted threads (the
+// underlying QueryActiveByGroupShortIDs filters status=deleted).
+func TestLoadThreadLastMsgAt_SurfacesStatus(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+
+	const g = "g310a"
+	at := time.Now().Add(-time.Hour).Truncate(time.Second)
+	seedThread(t, ctx, g, "act", thread.ThreadStatusActive, &at)
+	seedThread(t, ctx, g, "arc", thread.ThreadStatusArchived, &at)
+	seedThread(t, ctx, g, "del", thread.ThreadStatusDeleted, &at)
+
+	sb := NewSidebar(ctx)
+	extRows := []*convext.Model{
+		{TargetID: threadChannelID(g, "act")},
+		{TargetID: threadChannelID(g, "arc")},
+		{TargetID: threadChannelID(g, "del")},
+	}
+	lastMsgAt, statusMap, err := sb.loadThreadLastMsgAt(extRows)
+	require.NoError(t, err)
+
+	assert.Equal(t, thread.ThreadStatusActive, statusMap[threadChannelID(g, "act")])
+	assert.Equal(t, thread.ThreadStatusArchived, statusMap[threadChannelID(g, "arc")])
+	_, delPresent := statusMap[threadChannelID(g, "del")]
+	assert.False(t, delPresent, "deleted thread must be filtered out (not in status map)")
+
+	// last_message_at map keeps the same keys (alive markers for mergeThreadEntries).
+	_, actAlive := lastMsgAt[threadChannelID(g, "act")]
+	_, arcAlive := lastMsgAt[threadChannelID(g, "arc")]
+	assert.True(t, actAlive)
+	assert.True(t, arcAlive)
+	_, delAlive := lastMsgAt[threadChannelID(g, "del")]
+	assert.False(t, delAlive, "deleted thread must not be an alive marker")
+}
+
+// loadThreadStatuses (recent-tab path) must batch-query status for thread items
+// only, key by the composite "{groupNo}____{shortID}", and drop deleted threads.
+// short_id is globally UNIQUE in the thread schema (uk_short_id), so a literal
+// same-short_id-across-two-groups collision can't be persisted; the composite
+// key still guarantees each thread item is matched to its own group's row (the
+// same-short_id backfill collision is covered purely in
+// TestBackfillThreadStatus_NoCrossGroupMismatch).
+func TestLoadThreadStatuses_BatchedNoCrossGroup(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+
+	const gA, gB = "g310bA", "g310bB"
+	at := time.Now().Add(-time.Hour)
+	seedThread(t, ctx, gA, "bA-act", thread.ThreadStatusActive, &at)
+	seedThread(t, ctx, gB, "bB-arc", thread.ThreadStatusArchived, &at)
+	seedThread(t, ctx, gA, "bA-gone", thread.ThreadStatusDeleted, &at)
+
+	sb := NewSidebar(ctx)
+	items := []*SidebarItem{
+		{TargetType: int(common.ChannelTypePerson), TargetID: "peer1"},
+		{TargetType: int(common.ChannelTypeGroup), TargetID: gA},
+		{TargetType: int(common.ChannelTypeCommunityTopic), TargetID: threadChannelID(gA, "bA-act")},
+		{TargetType: int(common.ChannelTypeCommunityTopic), TargetID: threadChannelID(gB, "bB-arc")},
+		{TargetType: int(common.ChannelTypeCommunityTopic), TargetID: threadChannelID(gA, "bA-gone")},
+	}
+	statusMap, err := sb.loadThreadStatuses(items)
+	require.NoError(t, err)
+
+	assert.Equal(t, thread.ThreadStatusActive, statusMap[threadChannelID(gA, "bA-act")],
+		"gA active thread matched to its own (group, short) row")
+	assert.Equal(t, thread.ThreadStatusArchived, statusMap[threadChannelID(gB, "bB-arc")],
+		"gB archived thread matched to its own (group, short) row")
+	_, gonePresent := statusMap[threadChannelID(gA, "bA-gone")]
+	assert.False(t, gonePresent, "deleted thread must not appear in status map")
+}
+
+// loadThreadStatuses with no thread items must not query and returns an empty map.
+func TestLoadThreadStatuses_NoThreadItems(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+
+	sb := NewSidebar(ctx)
+	items := []*SidebarItem{
+		{TargetType: int(common.ChannelTypePerson), TargetID: "peer1"},
+		{TargetType: int(common.ChannelTypeGroup), TargetID: "g1"},
+	}
+	statusMap, err := sb.loadThreadStatuses(items)
+	require.NoError(t, err)
+	assert.Empty(t, statusMap)
+}
+
+// Follow tab end-to-end: both the IM-present thread (buildFollowItems) and the
+// DB-only thread (mergeThreadEntries) must carry the correct Status after the
+// backfill loop; a deleted thread on the DB-only path is excluded by
+// mergeThreadEntries (it is absent from the active-thread/last_message_at map),
+// so it never reaches the backfill loop.
+func TestSidebar_FollowTab_BackfillsStatus(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+
+	const g = "g310c"
+	at := time.Now().Add(-time.Hour)
+	seedThread(t, ctx, g, "imact", thread.ThreadStatusActive, &at)   // IM-present, active
+	seedThread(t, ctx, g, "dbarc", thread.ThreadStatusArchived, &at) // DB-only, archived
+	seedThread(t, ctx, g, "dbdel", thread.ThreadStatusDeleted, &at)  // DB-only, deleted → excluded
+
+	imActID := threadChannelID(g, "imact")
+	dbArcID := threadChannelID(g, "dbarc")
+	dbDelID := threadChannelID(g, "dbdel")
+
+	catID := "cat-310c"
+	categorySetting := map[string]*GroupCategorySetting{
+		g: {GroupNo: g, CategoryID: &catID, CategorySort: 1, CategoryGroupSort: 1},
+	}
+	threadExtRows := []*convext.Model{
+		{TargetID: imActID},
+		{TargetID: dbArcID},
+		{TargetID: dbDelID},
+	}
+	threadExtMap := map[string]*convext.Model{}
+	for _, m := range threadExtRows {
+		threadExtMap[m.TargetID] = m
+	}
+
+	// IM returns only the active thread; archived + deleted are DB-only.
+	stubConvs := []*config.SyncUserConversationResp{
+		{ChannelID: imActID, ChannelType: common.ChannelTypeCommunityTopic.Uint8(), Timestamp: 100},
+	}
+
+	sb := NewSidebar(ctx)
+	items := buildFollowItems(stubConvs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil, "")
+
+	lastMsgAt, statusMap, err := sb.loadThreadLastMsgAt(threadExtRows)
+	require.NoError(t, err)
+	items = mergeThreadEntries(items, threadExtRows, lastMsgAt, categorySetting, nil, nil, nil, "")
+	backfillThreadStatus(items, statusMap)
+
+	byID := map[string]*SidebarItem{}
+	for _, it := range items {
+		byID[it.TargetID] = it
+	}
+	require.Contains(t, byID, imActID, "IM-present active thread must be present")
+	require.Contains(t, byID, dbArcID, "DB-only archived thread must be merged in")
+	assert.NotContains(t, byID, dbDelID,
+		"deleted thread (DB-only) must be excluded (mergeThreadEntries skips non-alive)")
+
+	assert.Equal(t, thread.ThreadStatusActive, byID[imActID].Status,
+		"IM-present path (buildFollowItems) thread must be stamped active")
+	assert.Equal(t, thread.ThreadStatusArchived, byID[dbArcID].Status,
+		"DB-only path (mergeThreadEntries) thread must be stamped archived")
+}
+
+// Recent tab end-to-end: thread items must be stamped with status from the
+// single batched query; deleted threads carry no status (and the recent tab,
+// unlike the conversation sync, does not itself drop them — that's the client's
+// job using this very field).
+func TestSidebar_RecentTab_BackfillsStatus(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+
+	const g = "g310d"
+	at := time.Now().Add(-time.Hour)
+	seedThread(t, ctx, g, "ract", thread.ThreadStatusActive, &at)
+	seedThread(t, ctx, g, "rarc", thread.ThreadStatusArchived, &at)
+
+	actID := threadChannelID(g, "ract")
+	arcID := threadChannelID(g, "rarc")
+
+	// person window 0 keeps DMs; group/thread within window.
+	cutoffs := recentCutoffs{group: 0, thread: 0, person: 0}
+	stubConvs := []*config.SyncUserConversationResp{
+		{ChannelID: "peer1", ChannelType: common.ChannelTypePerson.Uint8(), Timestamp: 100},
+		{ChannelID: actID, ChannelType: common.ChannelTypeCommunityTopic.Uint8(), Timestamp: 200},
+		{ChannelID: arcID, ChannelType: common.ChannelTypeCommunityTopic.Uint8(), Timestamp: 300},
+	}
+
+	sb := NewSidebar(ctx)
+	items := buildRecentItems(stubConvs, cutoffs, nil, nil, nil, "")
+	statusMap, err := sb.loadThreadStatuses(items)
+	require.NoError(t, err)
+	backfillThreadStatus(items, statusMap)
+
+	byID := map[string]*SidebarItem{}
+	for _, it := range items {
+		byID[it.TargetID] = it
+	}
+	assert.Equal(t, thread.ThreadStatusActive, byID[actID].Status)
+	assert.Equal(t, thread.ThreadStatusArchived, byID[arcID].Status)
+	assert.Equal(t, 0, byID["peer1"].Status, "DM must keep Status=0 (omitempty)")
+}
+
+// Recent tab fail-open: when the thread status query errors, the handler logs a
+// warning and leaves Status unset — it must NOT fail the request. We reproduce
+// the handler's recent branch against a context whose schema lacks the thread
+// table, so QueryActiveByGroupShortIDs errors, and assert items survive with
+// Status=0.
+func TestSidebar_RecentTab_FailOpenOnStatusError(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+
+	// Create an empty schema with NO thread table, then point a Sidebar at it.
+	const emptyDB = "sidebar_failopen_310"
+	_, err := ctx.DB().Exec("DROP DATABASE IF EXISTS " + emptyDB)
+	require.NoError(t, err)
+	_, err = ctx.DB().Exec("CREATE DATABASE " + emptyDB + " CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci")
+	require.NoError(t, err)
+	defer ctx.DB().Exec("DROP DATABASE IF EXISTS " + emptyDB)
+
+	failCfg := config.New()
+	failCfg.Test = true
+	failCfg.DB.MySQLAddr = "root:demo@tcp(127.0.0.1:3306)/" + emptyDB + "?charset=utf8mb4&parseTime=true"
+	failCfg.DB.Migration = false
+	failCtx := config.NewContext(failCfg)
+	sb := NewSidebar(failCtx)
+
+	cutoffs := recentCutoffs{group: 0, thread: 0, person: 0}
+	stubConvs := []*config.SyncUserConversationResp{
+		{ChannelID: "g310e____thr", ChannelType: common.ChannelTypeCommunityTopic.Uint8(), Timestamp: 100},
+	}
+	items := buildRecentItems(stubConvs, cutoffs, nil, nil, nil, "")
+
+	// Mirror the handler's recent branch: query may fail → fail open.
+	statusMap, qerr := sb.loadThreadStatuses(items)
+	require.Error(t, qerr, "missing thread table must surface a query error")
+	if qerr == nil {
+		backfillThreadStatus(items, statusMap)
+	}
+
+	require.Len(t, items, 1, "fail-open: item list must still be returned")
+	assert.Equal(t, 0, items[0].Status,
+		"fail-open: thread status must be left unset (omitempty → absent on the wire)")
+}

--- a/modules/message/api_sidebar_test.go
+++ b/modules/message/api_sidebar_test.go
@@ -15,6 +15,7 @@ package message
 // =============================================================================
 
 import (
+	"encoding/json"
 	"sort"
 	"strings"
 	"testing"
@@ -23,6 +24,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1106,3 +1108,123 @@ func TestParseThreadChannelIDSidebar_Invalid(t *testing.T) {
 
 func strPtr(s string) *string        { return &s }
 func timePtr(t time.Time) *time.Time { return &t }
+
+// ---------------------------------------------------------------------------
+// SidebarItem.Status — thread-only lifecycle status (GH octo-server#310)
+// ---------------------------------------------------------------------------
+
+// Non-thread items (DM / group) must serialize WITHOUT a "status" key so the
+// wire format stays backward compatible (Status=0 + omitempty → absent).
+func TestSidebarItem_JSON_NonThreadOmitsStatus(t *testing.T) {
+	cases := []struct {
+		name string
+		item *SidebarItem
+	}{
+		{
+			name: "DM",
+			item: &SidebarItem{TargetType: int(common.ChannelTypePerson), TargetID: "peer1"},
+		},
+		{
+			name: "group",
+			item: &SidebarItem{TargetType: int(common.ChannelTypeGroup), TargetID: "g1"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.item)
+			require.NoError(t, err)
+			assert.NotContains(t, string(b), "\"status\"",
+				"non-thread item must not carry a status key (omitempty)")
+		})
+	}
+}
+
+// Thread items must include the status field with the thread lifecycle value.
+func TestSidebarItem_JSON_ThreadIncludesStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		want   string
+	}{
+		{name: "active", status: thread.ThreadStatusActive, want: "\"status\":1"},
+		{name: "archived", status: thread.ThreadStatusArchived, want: "\"status\":2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			item := &SidebarItem{
+				TargetType: int(common.ChannelTypeCommunityTopic),
+				TargetID:   "g1____th1",
+				Status:     tc.status,
+			}
+			b, err := json.Marshal(item)
+			require.NoError(t, err)
+			assert.Contains(t, string(b), tc.want)
+		})
+	}
+}
+
+// Status semantics must match the thread package enum exactly (GH octo-server#310).
+func TestSidebarItem_StatusEnumMatchesThreadConst(t *testing.T) {
+	assert.Equal(t, 1, thread.ThreadStatusActive)
+	assert.Equal(t, 2, thread.ThreadStatusArchived)
+	assert.Equal(t, 3, thread.ThreadStatusDeleted)
+}
+
+// ---------------------------------------------------------------------------
+// backfillThreadStatus — pure backfill of thread lifecycle status
+// ---------------------------------------------------------------------------
+
+// backfillThreadStatus must set Status on thread items keyed by TargetID, leave
+// non-thread items untouched, and skip thread items absent from the status map.
+func TestBackfillThreadStatus(t *testing.T) {
+	items := []*SidebarItem{
+		{TargetType: int(common.ChannelTypePerson), TargetID: "peer1"},
+		{TargetType: int(common.ChannelTypeGroup), TargetID: "g1"},
+		{TargetType: int(common.ChannelTypeCommunityTopic), TargetID: "g1____active"},
+		{TargetType: int(common.ChannelTypeCommunityTopic), TargetID: "g1____archived"},
+		{TargetType: int(common.ChannelTypeCommunityTopic), TargetID: "g1____unknown"},
+	}
+	statusMap := map[string]int{
+		"g1____active":   thread.ThreadStatusActive,
+		"g1____archived": thread.ThreadStatusArchived,
+	}
+	backfillThreadStatus(items, statusMap)
+
+	got := map[string]int{}
+	for _, it := range items {
+		got[it.TargetID] = it.Status
+	}
+	assert.Equal(t, 0, got["peer1"], "DM must keep Status=0")
+	assert.Equal(t, 0, got["g1"], "group must keep Status=0")
+	assert.Equal(t, thread.ThreadStatusActive, got["g1____active"])
+	assert.Equal(t, thread.ThreadStatusArchived, got["g1____archived"])
+	assert.Equal(t, 0, got["g1____unknown"],
+		"thread absent from status map must keep Status=0 (omitempty)")
+}
+
+// A nil / empty status map must be a no-op (fail-open: recent tab leaves Status unset).
+func TestBackfillThreadStatus_EmptyMapNoOp(t *testing.T) {
+	items := []*SidebarItem{
+		{TargetType: int(common.ChannelTypeCommunityTopic), TargetID: "g1____th1"},
+	}
+	backfillThreadStatus(items, nil)
+	assert.Equal(t, 0, items[0].Status)
+	backfillThreadStatus(items, map[string]int{})
+	assert.Equal(t, 0, items[0].Status)
+}
+
+// Same short_id under two different parent groups must not cross-contaminate:
+// the composite "{groupNo}____{shortID}" key keeps them distinct.
+func TestBackfillThreadStatus_NoCrossGroupMismatch(t *testing.T) {
+	items := []*SidebarItem{
+		{TargetType: int(common.ChannelTypeCommunityTopic), TargetID: "gA____dup"},
+		{TargetType: int(common.ChannelTypeCommunityTopic), TargetID: "gB____dup"},
+	}
+	statusMap := map[string]int{
+		"gA____dup": thread.ThreadStatusActive,
+		"gB____dup": thread.ThreadStatusArchived,
+	}
+	backfillThreadStatus(items, statusMap)
+	assert.Equal(t, thread.ThreadStatusActive, items[0].Status, "gA____dup must be active")
+	assert.Equal(t, thread.ThreadStatusArchived, items[1].Status, "gB____dup must be archived")
+}

--- a/modules/message/swagger/sidebar.yaml
+++ b/modules/message/swagger/sidebar.yaml
@@ -142,6 +142,9 @@ definitions:
       parent_channel_id:
         type: string
         description: "父群频道 ID（仅子区条目返回）"
+      status:
+        type: integer
+        description: "子区生命周期状态，仅子区条目（target_type=5）返回，取值 1=active（活跃）/ 2=archived（已归档）。DM / 群条目不带该字段。子区条目若缺省该字段，表示状态未知，客户端应回退到 channelInfo（涵盖最近会话 tab 的 fail-open 情况，以及可能仍出现在最近会话 tab 中的已删除子区——已删除子区不会被标记，因此不会返回 status=3）。客户端据此同步过滤已归档子区，无需等待 channelInfo（GH octo-server#310）。"
   response:
     type: "object"
     properties:


### PR DESCRIPTION
Closes #310.

## What
`/sidebar/sync` now returns the thread lifecycle status on thread items (`target_type = 5`), so the client can filter archived threads synchronously from the sidebar payload without waiting for `channelInfo` to load.

## Changes
- `SidebarItem` gains `status int \`json:"status,omitempty"\`` — thread-only: `1=active`, `2=archived` (matching `modules/thread` enum). `omitempty` keeps DM/group items wire-compatible; absent on a thread item means "unknown — client should fall back to channelInfo".
- **Follow tab — zero new query**: surfaces the `status` that `QueryActiveByGroupShortIDs` already SELECTs (`ThreadLite.Status`); a single backfill pass after `mergeThreadEntries` stamps both IM-present (`buildFollowItems`) and DB-only (`mergeThreadEntries`) thread items. Existing fail-closed contract preserved.
- **Recent tab — one batched query** (no N+1), **fail-open**: on error the field is simply omitted and a warning is logged; the sidebar still returns 200.
- No change to `QueryActiveByGroupShortIDs` filtering semantics (still excludes deleted; auth paths unaffected). No DB migration.
- Swagger updated to document the field (values 1/2; absent = unknown).

## Tests
- JSON shape: non-thread items omit `status`; thread items emit `1`/`2`.
- Follow tab: active + archived threads stamped correctly on both IM-present and DB-only paths; deleted excluded.
- Recent tab: status backfill + a fail-open case asserting 200 with status omitted.
- Composite-key safety (no cross-group same-short_id mismatch).

## Verification
- `go build ./...`, `go vet`, `gofmt` clean; targeted unit tests green.
- End-to-end against a running instance: `/sidebar/sync` follow tab returned 31 thread items, `status` matched the DB `thread.status` 31/31 (27 archived → 2, 4 active → 1); non-thread DM items carried no `status` key.