### PR TITLE
feat(opanalytics): add manual ETL trigger endpoint

### DIFF
--- a/modules/opanalytics/api.go
+++ b/modules/opanalytics/api.go
@@ -1,6 +1,7 @@
 package opanalytics
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -57,6 +58,7 @@ func (m *Manager) Route(r *wkhttp.WKHttp) {
 		auth.GET("/spaces", m.spaces)                           // 表一 Space 列表
 		auth.GET("/spaces/:space_id/channels", m.spaceChannels) // 表二 群组列表(仅群组)
 		auth.GET("/global/direct-chats", m.globalDirectChats)   // 全局私聊活跃列表
+		auth.POST("/etl/run", m.runETL)                         // 手动触发增量 ETL
 	}
 }
 
@@ -157,6 +159,32 @@ func (m *Manager) globalDirectChats(c *wkhttp.Context) {
 		return
 	}
 	c.Response(map[string]interface{}{"count": total, "list": list})
+}
+
+// runETL 手动触发一轮增量 ETL。首轮可能是长时间全历史回填，因此只接受任务并异步执行。
+func (m *Manager) runETL(c *wkhttp.Context) {
+	if !m.requireSuperAdmin(c) {
+		return
+	}
+
+	accepted, err := m.scheduler.TriggerManualRun()
+	if err != nil {
+		m.Error("manual opanalytics ETL trigger failed",
+			zap.String("uid", c.GetLoginUID()),
+			zap.Error(err))
+		respETLTriggerFailed(c)
+		return
+	}
+	if !accepted {
+		respETLAlreadyRunning(c)
+		return
+	}
+
+	m.Info("manual opanalytics ETL accepted", zap.String("uid", c.GetLoginUID()))
+	c.ResponseWithStatus(http.StatusAccepted, map[string]interface{}{
+		"status": http.StatusAccepted,
+		"state":  "accepted",
+	})
 }
 
 // ===== 参数解析 =====

--- a/modules/opanalytics/api_i18n.go
+++ b/modules/opanalytics/api_i18n.go
@@ -30,3 +30,13 @@ func respNotFound(c *wkhttp.Context) {
 func respQueryFailed(c *wkhttp.Context) {
 	httperr.ResponseErrorL(c, errcode.ErrOpanalyticsQueryFailed, nil, nil)
 }
+
+// respETLAlreadyRunning 表示已有定时或手动 ETL 正在执行。
+func respETLAlreadyRunning(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errcode.ErrOpanalyticsETLAlreadyRunning, nil, nil)
+}
+
+// respETLTriggerFailed 手动触发 ETL 失败 → 500(Internal，调用方须先记 zap 日志)。
+func respETLTriggerFailed(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errcode.ErrOpanalyticsETLTriggerFailed, nil, nil)
+}

--- a/modules/opanalytics/api_i18n_test.go
+++ b/modules/opanalytics/api_i18n_test.go
@@ -78,6 +78,8 @@ func TestOpanalyticsRespondHelpers(t *testing.T) {
 		{"requestInvalid", func(c *wkhttp.Context) { respRequestInvalid(c, "date_range") }, http.StatusBadRequest, "err.server.opanalytics.request_invalid"},
 		{"notFound", respNotFound, http.StatusNotFound, "err.server.opanalytics.not_found"},
 		{"queryFailed", respQueryFailed, http.StatusInternalServerError, "err.server.opanalytics.query_failed"},
+		{"etlAlreadyRunning", respETLAlreadyRunning, http.StatusConflict, "err.server.opanalytics.etl_already_running"},
+		{"etlTriggerFailed", respETLTriggerFailed, http.StatusInternalServerError, "err.server.opanalytics.etl_trigger_failed"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/modules/opanalytics/api_test.go
+++ b/modules/opanalytics/api_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -35,6 +36,20 @@ func opaSetup(t *testing.T) (*config.Context, *wkhttp.WKHttp, *ETL) {
 	return ctx, route, NewETL(ctx)
 }
 
+func opaRouteOnlySetup(t *testing.T) (*config.Context, *wkhttp.WKHttp) {
+	t.Helper()
+	cfg := config.New()
+	cfg.Test = true
+	ctx := config.NewContext(cfg)
+	route := wkhttp.New()
+	route.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	ctx.SetHttpRoute(route)
+	setSuperAdminToken(t, ctx)
+	resetUIDRateLimit(t, ctx)
+	New(ctx).Route(route)
+	return ctx, route
+}
+
 // resetUIDRateLimit 清空 SharedUIDRateLimiter 的每-uid 令牌桶(ratelimit:uid:*)。该桶持久在
 // Redis、跨测试残留且不被 CleanAllTables 清，须在 setup 重置，否则同一 binary 内靠后的测试会 429。
 func resetUIDRateLimit(t *testing.T, ctx *config.Context) {
@@ -47,6 +62,7 @@ func resetUIDRateLimit(t *testing.T, ctx *config.Context) {
 	if keys, err := rds.Keys("ratelimit:uid:*").Result(); err == nil && len(keys) > 0 {
 		_ = rds.Del(keys...).Err()
 	}
+	_ = rds.Del(etlRunLockKey).Err()
 }
 
 func setSuperAdminToken(t *testing.T, ctx *config.Context) {
@@ -212,6 +228,15 @@ func opaGet(t *testing.T, route *wkhttp.WKHttp, path string) *httptest.ResponseR
 	return rec
 }
 
+func opaPost(t *testing.T, route *wkhttp.WKHttp, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, nil)
+	req.Header.Set("token", testutil.Token)
+	rec := httptest.NewRecorder()
+	route.ServeHTTP(rec, req)
+	return rec
+}
+
 func decodeOK(t *testing.T, rec *httptest.ResponseRecorder, out interface{}) {
 	t.Helper()
 	require.Equalf(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
@@ -228,6 +253,18 @@ func errorCode(t *testing.T, rec *httptest.ResponseRecorder) string {
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &env))
 	return env.Error.Code
+}
+
+func waitForFact4Human(t *testing.T, ctx *config.Context, channelID string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := fact4Human(t, ctx, channelID); got == want {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	assert.Equal(t, want, fact4Human(t, ctx, channelID))
 }
 
 // ---- the scenario seed ----
@@ -465,6 +502,76 @@ func TestOpanalyticsEndpoints(t *testing.T) {
 	setPlainUserToken(t, ctx)
 	rec = opaGet(t, route, "/v1/manager/dashboard/overview"+rng)
 	assert.Equal(t, "err.server.opanalytics.forbidden", errorCode(t, rec))
+}
+
+func TestOpanalyticsManualETLRunEndpoint(t *testing.T) {
+	ctx, route, _ := opaSetup(t)
+	seedScenario(t, ctx)
+
+	rec := opaPost(t, route, "/v1/manager/dashboard/etl/run")
+	require.Equalf(t, http.StatusAccepted, rec.Code, "body=%s", rec.Body.String())
+	var accepted struct {
+		Status int    `json:"status"`
+		State  string `json:"state"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &accepted))
+	assert.Equal(t, http.StatusAccepted, accepted.Status)
+	assert.Equal(t, "accepted", accepted.State)
+
+	waitForFact4Human(t, ctx, "g1", 5)
+	assert.Equal(t, 3, fact3Msg(t, ctx, "g1", "u_alice"))
+}
+
+func TestOpanalyticsManualETLRunForbiddenAndAlreadyRunning(t *testing.T) {
+	ctx, route := opaRouteOnlySetup(t)
+
+	setPlainUserToken(t, ctx)
+	rec := opaPost(t, route, "/v1/manager/dashboard/etl/run")
+	assert.Equal(t, "err.server.opanalytics.forbidden", errorCode(t, rec))
+
+	setSuperAdminToken(t, ctx)
+	lock := newETLLock(ctx)
+	defer lock.Close()
+	token := "manual-etl-test-lock"
+	acquired, err := lock.Acquire(token)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	defer func() { require.NoError(t, lock.Release(token)) }()
+
+	rec = opaPost(t, route, "/v1/manager/dashboard/etl/run")
+	assert.Equal(t, "err.server.opanalytics.etl_already_running", errorCode(t, rec))
+	acquired, err = lock.Acquire("second-token")
+	require.NoError(t, err)
+	assert.False(t, acquired, "already-running path must not drop or replace the held lock")
+}
+
+func TestETLLockRenewRequiresMatchingToken(t *testing.T) {
+	ctx, _ := opaRouteOnlySetup(t)
+	lock := newETLLock(ctx)
+	defer lock.Close()
+
+	token := "renew-token"
+	acquired, err := lock.Acquire(token)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	renewed, err := lock.Renew(token)
+	require.NoError(t, err)
+	require.True(t, renewed)
+
+	renewed, err = lock.Renew("other-token")
+	require.NoError(t, err)
+	require.False(t, renewed)
+
+	acquired, err = lock.Acquire("second-token")
+	require.NoError(t, err)
+	require.False(t, acquired, "wrong-token renew must not drop the held lock")
+
+	require.NoError(t, lock.Release(token))
+	acquired, err = lock.Acquire("second-token")
+	require.NoError(t, err)
+	require.True(t, acquired)
+	require.NoError(t, lock.Release("second-token"))
 }
 
 // TestOpanalyticsETLExclusion 验收①：系统机器人(pkg/space.SystemBots，含 notification)与

--- a/modules/opanalytics/etl_lock.go
+++ b/modules/opanalytics/etl_lock.go
@@ -17,14 +17,23 @@ import (
 // 串行化，故即便锁因 TTL 过期出现短暂并发，消息仍精确一次累加。
 const etlRunLockKey = "opanalytics:etl:run"
 
-// etlRunLockTTL 锁租约。调度每日仅触发一次，TTL 只需覆盖各实例 01:30 同时触发的窗口；
-// 即使单轮(含首次全量回填)超过 TTL，当天也不会有第二个实例再次触发(各实例每 tick 只抢一次)。
+// etlRunLockTTL 锁租约。执行期间由 scheduler/手动触发路径定期续租，用于覆盖首次全量回填
+// 这类可能超过单个 TTL 的长任务；若进程崩溃，TTL 仍会自动释放锁。
 const etlRunLockTTL = 30 * time.Minute
 
 // luaReleaseETLLock CAS-DEL:仅当 token 匹配时才释放(规避 lease 边界误删后继 owner 锁)。
 var luaReleaseETLLock = rd.NewScript(`
 if redis.call("GET", KEYS[1]) == ARGV[1] then
   return redis.call("DEL", KEYS[1])
+else
+  return 0
+end
+`)
+
+// luaRenewETLLock 仅当 token 匹配当前 owner 时续租，避免误延长后继 owner 的锁。
+var luaRenewETLLock = rd.NewScript(`
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("PEXPIRE", KEYS[1], ARGV[2])
 else
   return 0
 end
@@ -61,6 +70,16 @@ func (l *etlLock) Release(token string) error {
 		return fmt.Errorf("opanalytics: etl lock release: %w", err)
 	}
 	return nil
+}
+
+// Renew 在当前 token 仍持有锁时延长租约。返回 false 表示锁已过期或 owner 已变化。
+func (l *etlLock) Renew(token string) (bool, error) {
+	res, err := luaRenewETLLock.Run(l.client, []string{etlRunLockKey}, token, etlRunLockTTL.Milliseconds()).Result()
+	if err != nil && !errors.Is(err, rd.Nil) {
+		return false, fmt.Errorf("opanalytics: etl lock renew: %w", err)
+	}
+	n, ok := res.(int64)
+	return ok && n == 1, nil
 }
 
 // Close 释放底层连接池。

--- a/modules/opanalytics/scheduler.go
+++ b/modules/opanalytics/scheduler.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"sync"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
@@ -60,12 +61,7 @@ func (s *Scheduler) Start() error {
 
 // runOnce 单次触发：抢分布式锁，抢到才执行增量 ETL，结束释放锁。
 func (s *Scheduler) runOnce() {
-	token, err := randomToken()
-	if err != nil {
-		s.Error("opanalytics ETL: gen lock token failed", zap.Error(err))
-		return
-	}
-	acquired, err := s.lock.Acquire(token)
+	token, acquired, err := s.acquireRunLock()
 	if err != nil {
 		// Redis 故障:不强行执行(避免多实例同跑);等下一 tick。
 		s.Error("opanalytics ETL: acquire lock failed, skip this tick", zap.Error(err))
@@ -75,15 +71,76 @@ func (s *Scheduler) runOnce() {
 		s.Info("opanalytics ETL: lock held by another instance, skip")
 		return
 	}
+
+	s.runWithHeldLock(token, "scheduled", zap.String("cron", dailyCronExpr))
+}
+
+// TriggerManualRun 抢同一把 ETL 分布式锁，抢到后异步跑一轮增量 ETL。
+// 返回 (false,nil) 表示已有 cron 或手动任务在运行。
+func (s *Scheduler) TriggerManualRun() (bool, error) {
+	token, acquired, err := s.acquireRunLock()
+	if err != nil || !acquired {
+		return acquired, err
+	}
+
+	go s.runWithHeldLock(token, "manual")
+	return true, nil
+}
+
+func (s *Scheduler) acquireRunLock() (string, bool, error) {
+	token, err := randomToken()
+	if err != nil {
+		return "", false, err
+	}
+	acquired, err := s.lock.Acquire(token)
+	if err != nil {
+		return "", false, err
+	}
+	return token, acquired, nil
+}
+
+func (s *Scheduler) runWithHeldLock(token, source string, fields ...zap.Field) {
+	done := make(chan struct{})
+	go s.renewLockUntilDone(token, source, done)
 	defer func() {
+		close(done)
 		if rerr := s.lock.Release(token); rerr != nil {
 			s.Error("opanalytics ETL: release lock failed", zap.Error(rerr))
 		}
 	}()
 
-	s.Info("scheduled opanalytics ETL triggered", zap.String("cron", dailyCronExpr))
+	fields = append([]zap.Field{zap.String("source", source)}, fields...)
+	s.Info("opanalytics ETL triggered", fields...)
 	if err := s.etl.RunIncremental(); err != nil {
-		s.Error("scheduled opanalytics ETL failed", zap.Error(err))
+		s.Error("opanalytics ETL failed", append(fields, zap.Error(err))...)
+		return
+	}
+	s.Info("opanalytics ETL finished", fields...)
+}
+
+func (s *Scheduler) renewLockUntilDone(token, source string, done <-chan struct{}) {
+	interval := etlRunLockTTL / 3
+	if interval < time.Second {
+		interval = time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			renewed, err := s.lock.Renew(token)
+			if err != nil {
+				s.Error("opanalytics ETL: renew lock failed", zap.String("source", source), zap.Error(err))
+				continue
+			}
+			if !renewed {
+				s.Error("opanalytics ETL: lock ownership lost, stop renewing", zap.String("source", source))
+				return
+			}
+		}
 	}
 }
 

--- a/modules/opanalytics/swagger/api.yaml
+++ b/modules/opanalytics/swagger/api.yaml
@@ -262,6 +262,30 @@ paths:
       security:
         - token: []
 
+  /manager/dashboard/etl/run:
+    post:
+      tags:
+        - "opanalyticsManager"
+      summary: "手动触发增量 ETL"
+      description: >
+        superAdmin 手动触发一轮运营看板增量 ETL。接口只负责抢占与每日调度相同的
+        Redis 锁并异步启动 RunIncremental；首轮全历史回填可能较长，成功时立即返回 202。
+        若 cron 或上一轮手动任务仍在运行，返回 already_running 错误，不会启动第二轮。
+      operationId: "m dashboard etl run"
+      produces:
+        - "application/json"
+      responses:
+        202:
+          description: "已接受，ETL 在后台异步执行"
+          schema:
+            $ref: "#/definitions/etlRunAcceptedResp"
+        400:
+          description: "错误（error.http_status 含真实状态码：403 越权 / 409 已在运行 / 500 触发失败）"
+          schema:
+            $ref: "#/definitions/dashboardError"
+      security:
+        - token: []
+
 securityDefinitions:
   token:
     type: "apiKey"
@@ -439,6 +463,18 @@ definitions:
         format: int64
         description: "最后活跃时间戳（纪元秒）"
 
+  etlRunAcceptedResp:
+    type: object
+    properties:
+      status:
+        type: integer
+        example: 202
+        description: "HTTP 202 Accepted"
+      state:
+        type: string
+        example: "accepted"
+        description: "已接受后台执行"
+
   dashboardError:
     type: object
     description: "i18n 错误信封。传输层 HTTP 状态恒为 400（D14 兼容），真实状态在 error.http_status。"
@@ -451,10 +487,10 @@ definitions:
         properties:
           code:
             type: string
-            description: "错误码，如 err.server.opanalytics.not_found / forbidden / request_invalid / query_failed"
+            description: "错误码，如 err.server.opanalytics.not_found / forbidden / request_invalid / query_failed / etl_already_running / etl_trigger_failed"
           http_status:
             type: integer
-            description: "真实 HTTP 语义状态码（403/404/400/500）"
+            description: "真实 HTTP 语义状态码（400/403/404/409/500）"
           message:
             type: string
             description: "本地化文案（5xx 内部错误隐藏）"

--- a/pkg/errcode/opanalytics.go
+++ b/pkg/errcode/opanalytics.go
@@ -32,4 +32,15 @@ var (
 		DefaultMessage: "Failed to query analytics data.",
 		Internal:       true,
 	})
+	ErrOpanalyticsETLAlreadyRunning = register(codes.Code{
+		ID:             "err.server.opanalytics.etl_already_running",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "Analytics ETL is already running.",
+	})
+	ErrOpanalyticsETLTriggerFailed = register(codes.Code{
+		ID:             "err.server.opanalytics.etl_trigger_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to trigger analytics ETL.",
+		Internal:       true,
+	})
 )

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -1084,3 +1084,9 @@ other = "Space 不存在。"
 
 ["err.server.opanalytics.query_failed"]
 other = "查询看板数据失败。"
+
+["err.server.opanalytics.etl_already_running"]
+other = "运营看板 ETL 正在运行，请稍后再试。"
+
+["err.server.opanalytics.etl_trigger_failed"]
+other = "触发运营看板 ETL 失败。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -486,6 +486,12 @@ other = "The binding session has expired or is invalid. Please start over."
 ["err.server.oidc.bind_verify_required"]
 other = "Please complete verification before confirming."
 
+["err.server.opanalytics.etl_already_running"]
+other = "Analytics ETL is already running."
+
+["err.server.opanalytics.etl_trigger_failed"]
+other = "Failed to trigger analytics ETL."
+
 ["err.server.opanalytics.forbidden"]
 other = "Only a super admin can access the analytics dashboard."
 


### PR DESCRIPTION
## Summary

- Add `POST /v1/manager/dashboard/etl/run` for superAdmin-only manual incremental dashboard ETL runs.
- Reuse the scheduler Redis lock `opanalytics:etl:run`, return an i18n `etl_already_running` envelope when cron or another manual run holds it, and run `RunIncremental()` asynchronously after returning 202.
- Add token-checked Redis lock renewal while ETL is in flight so long first backfills do not outlive the lock lease.
- Update opanalytics Swagger 2.0 spec and i18n marker/zh-CN translations.

Closes #314.

## Testing

- `go test ./modules/opanalytics`
- `go test ./modules/opanalytics -run 'TestOpanalyticsManualETLRun|TestETLLockRenewRequiresMatchingToken'`
- `go test ./pkg/errcode ./pkg/httperr ./pkg/i18n`
- `make i18n-extract`
- `make i18n-extract-check`
- `make i18n-lint`
- `git diff --check`

## E2E

Started the current branch as a real octo-server API on `:18090`, seeded MySQL/Redis test data, and verified through HTTP:

- `POST /v1/manager/dashboard/etl/run` returned `202` with `{"state":"accepted","status":202}`.
- The manual ETL completed with `messages_scanned=4` and `recomputed_days=1` in server logs.
- `GET /v1/manager/dashboard/overview?start_date=2026-06-01&end_date=2026-06-01&space_ids=e2e_s1` returned expected aggregates: `human_msg_count=3`, `agent_msg_count=1`, `active_groups=1`.
- Non-superAdmin trigger returned `err.server.opanalytics.forbidden` with `error.http_status=403`.
- Pre-held `opanalytics:etl:run` lock returned `err.server.opanalytics.etl_already_running` with `error.http_status=409`.
