### PR TITLE
feat(opanalytics): add trend and message composition

### DIFF
--- a/modules/opanalytics/api.go
+++ b/modules/opanalytics/api.go
@@ -55,6 +55,7 @@ func (m *Manager) Route(r *wkhttp.WKHttp) {
 	auth := r.Group("/v1/manager/dashboard", m.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, m.ctx))
 	{
 		auth.GET("/overview", m.overview)                       // 模块A 概览卡片
+		auth.GET("/trend", m.trend)                             // 模块C 趋势
 		auth.GET("/spaces", m.spaces)                           // 表一 Space 列表
 		auth.GET("/spaces/:space_id/channels", m.spaceChannels) // 表二 群组列表(仅群组)
 		auth.GET("/global/direct-chats", m.globalDirectChats)   // 全局私聊活跃列表
@@ -75,6 +76,30 @@ func (m *Manager) overview(c *wkhttp.Context) {
 	resp, err := m.service.overview(start, end, parseSpaceIDs(c))
 	if err != nil {
 		m.Error("overview query failed", zap.Error(err))
+		respQueryFailed(c)
+		return
+	}
+	c.Response(resp)
+}
+
+// trend 模块C 趋势(day/week，缺桶补 0)。
+func (m *Manager) trend(c *wkhttp.Context) {
+	if !m.requireSuperAdmin(c) {
+		return
+	}
+	start, end, ok := parseDateRange(c)
+	if !ok {
+		respRequestInvalid(c, "date_range")
+		return
+	}
+	granularity, ok := normalizeGranularity(c.Query("granularity"))
+	if !ok {
+		respRequestInvalid(c, "granularity")
+		return
+	}
+	resp, err := m.service.trend(start, end, granularity, parseSpaceIDs(c))
+	if err != nil {
+		m.Error("trend query failed", zap.Error(err))
 		respQueryFailed(c)
 		return
 	}
@@ -257,6 +282,18 @@ func normalizeActiveStatus(v string) string {
 		return v
 	default:
 		return "all"
+	}
+}
+
+// normalizeGranularity 收敛为 day/week，缺省 day。
+func normalizeGranularity(v string) (string, bool) {
+	switch v {
+	case "", "day":
+		return "day", true
+	case "week":
+		return "week", true
+	default:
+		return "", false
 	}
 }
 

--- a/modules/opanalytics/api_i18n.go
+++ b/modules/opanalytics/api_i18n.go
@@ -12,7 +12,7 @@ func respForbidden(c *wkhttp.Context) {
 	httperr.ResponseErrorL(c, errcode.ErrOpanalyticsForbidden, nil, nil)
 }
 
-// respRequestInvalid 请求参数无效(reason ∈ {date_range, space_id, sort})。
+// respRequestInvalid 请求参数无效(reason 如 date_range / granularity / space_id / sort)。
 func respRequestInvalid(c *wkhttp.Context, reason string) {
 	details := i18n.Details{}
 	if reason != "" {

--- a/modules/opanalytics/api_test.go
+++ b/modules/opanalytics/api_test.go
@@ -406,6 +406,30 @@ func countFacts(t *testing.T, ctx *config.Context) (int64, int64) {
 	return r3, r4
 }
 
+func compositionByType(items []*messageCompositionItem) map[uint8]*messageCompositionItem {
+	out := make(map[uint8]*messageCompositionItem, len(items))
+	for _, item := range items {
+		out[item.ConvType] = item
+	}
+	return out
+}
+
+func trendByBucket(items []*trendItem) map[string]*trendItem {
+	out := make(map[string]*trendItem, len(items))
+	for _, item := range items {
+		out[item.Bucket] = item
+	}
+	return out
+}
+
+func trendConvByType(items []*trendConvTypeMsgItem) map[uint8]*trendConvTypeMsgItem {
+	out := make(map[uint8]*trendConvTypeMsgItem, len(items))
+	for _, item := range items {
+		out[item.ConvType] = item
+	}
+	return out
+}
+
 func TestOpanalyticsEndpoints(t *testing.T) {
 	ctx, route, etl := opaSetup(t)
 	seedScenario(t, ctx)
@@ -426,6 +450,21 @@ func TestOpanalyticsEndpoints(t *testing.T) {
 	assert.Equal(t, int64(12), ov.HumanMsgCount) // g1:5 + g2:2 + private:5
 	assert.Equal(t, int64(5), ov.AgentMsgCount)
 	assert.Equal(t, int64(1), ov.PrivateActiveCount)
+	ovComp := compositionByType(ov.MessageComposition)
+	require.Len(t, ovComp, 4, "overview composition must always return conv_type 1..4")
+	assert.Equal(t, int64(2), ovComp[convTypeHHGroup].HumanMsgCount)
+	assert.Equal(t, int64(0), ovComp[convTypeHHGroup].AgentMsgCount)
+	assert.Equal(t, int64(2), ovComp[convTypeHHGroup].TotalMsgCount)
+	assert.Equal(t, int64(1), ovComp[convTypeHHGroup].ActiveChannelCount)
+	assert.Equal(t, int64(5), ovComp[convTypeHAGroup].HumanMsgCount)
+	assert.Equal(t, int64(5), ovComp[convTypeHAGroup].AgentMsgCount)
+	assert.Equal(t, int64(10), ovComp[convTypeHAGroup].TotalMsgCount)
+	assert.Equal(t, int64(1), ovComp[convTypeHAGroup].ActiveChannelCount)
+	assert.Equal(t, int64(5), ovComp[convTypeHHPrivate].HumanMsgCount)
+	assert.Equal(t, int64(0), ovComp[convTypeHHPrivate].AgentMsgCount)
+	assert.Equal(t, int64(5), ovComp[convTypeHHPrivate].TotalMsgCount)
+	assert.Equal(t, int64(1), ovComp[convTypeHHPrivate].ActiveChannelCount)
+	assert.Zero(t, ovComp[convTypeHAPrivate].TotalMsgCount)
 
 	// ---- overview 限定 Space=s1：总数也随筛选收敛(否则活跃比例失真) ----
 	var ovS1 overviewResp
@@ -440,6 +479,23 @@ func TestOpanalyticsEndpoints(t *testing.T) {
 	assert.Equal(t, int64(5), ovS1.HumanMsgCount, "私聊/g2 不计入 s1")
 	assert.Equal(t, int64(5), ovS1.AgentMsgCount)
 	assert.Equal(t, int64(0), ovS1.PrivateActiveCount, "选中 Space 时私聊数置 0(私聊无 space 归属)")
+	ovS1Comp := compositionByType(ovS1.MessageComposition)
+	require.Len(t, ovS1Comp, 4)
+	assert.Equal(t, int64(10), ovS1Comp[convTypeHAGroup].TotalMsgCount)
+	assert.Equal(t, int64(1), ovS1Comp[convTypeHAGroup].ActiveChannelCount)
+	assert.Zero(t, ovS1Comp[convTypeHHGroup].TotalMsgCount)
+	assert.Zero(t, ovS1Comp[convTypeHHPrivate].TotalMsgCount, "选中 Space 时私聊 composition 为 0")
+	assert.Zero(t, ovS1Comp[convTypeHAPrivate].TotalMsgCount, "选中 Space 时私聊 composition 为 0")
+
+	// ---- overview 空范围：composition 仍固定 4 类且全部补 0 ----
+	var empty overviewResp
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/overview?start_date=2026-05-31&end_date=2026-05-31"), &empty)
+	emptyComp := compositionByType(empty.MessageComposition)
+	require.Len(t, emptyComp, 4)
+	for _, item := range emptyComp {
+		assert.Zero(t, item.TotalMsgCount)
+		assert.Zero(t, item.ActiveChannelCount)
+	}
 
 	// ---- spaces (表一) ----
 	var spaces struct {
@@ -501,6 +557,98 @@ func TestOpanalyticsEndpoints(t *testing.T) {
 	// ---- 非 superAdmin → 403 ----
 	setPlainUserToken(t, ctx)
 	rec = opaGet(t, route, "/v1/manager/dashboard/overview"+rng)
+	assert.Equal(t, "err.server.opanalytics.forbidden", errorCode(t, rec))
+}
+
+func TestOpanalyticsTrendEndpoint(t *testing.T) {
+	ctx, route, etl := opaSetup(t)
+	seedScenario(t, ctx)
+	require.NoError(t, etl.RunIncremental())
+
+	nextDay := "2026-06-02"
+	nextStart, _, err := dayWindowUnix(nextDay)
+	require.NoError(t, err)
+	insertMsgs(t, ctx, "u_alice", "g1", channelTypeGroup, nextStart+3600, 1, 0)
+	insertMsgs(t, ctx, "u_agent", "g1", channelTypeGroup, nextStart+3610, 1, 0)
+	require.NoError(t, etl.RunIncremental())
+
+	var dayTrend trendResp
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/trend?start_date=2026-05-31&end_date=2026-06-02&granularity=day"), &dayTrend)
+	assert.Equal(t, "day", dayTrend.Granularity)
+	require.Len(t, dayTrend.List, 3)
+	byDay := trendByBucket(dayTrend.List)
+
+	may31 := byDay["2026-05-31"]
+	require.NotNil(t, may31)
+	assert.Equal(t, "2026-05-31", may31.StartDate)
+	assert.Equal(t, "2026-05-31", may31.EndDate)
+	assert.Zero(t, may31.TotalMsgCount, "missing days must be zero-filled")
+	assert.Zero(t, may31.ActiveHumanMembers)
+
+	jun1 := byDay[statDay]
+	require.NotNil(t, jun1)
+	assert.Equal(t, int64(12), jun1.HumanMsgCount)
+	assert.Equal(t, int64(5), jun1.AgentMsgCount)
+	assert.Equal(t, int64(17), jun1.TotalMsgCount)
+	assert.Equal(t, int64(3), jun1.ActiveHumanMembers)
+	assert.Equal(t, int64(1), jun1.ActiveAgentMembers)
+	assert.Equal(t, int64(2), jun1.ActiveGroups)
+	assert.Equal(t, int64(1), jun1.PrivateActiveCount)
+	jun1Conv := trendConvByType(jun1.ConvTypeMsgCounts)
+	require.Len(t, jun1Conv, 4)
+	assert.Equal(t, int64(2), jun1Conv[convTypeHHGroup].TotalMsgCount)
+	assert.Equal(t, int64(10), jun1Conv[convTypeHAGroup].TotalMsgCount)
+	assert.Equal(t, int64(5), jun1Conv[convTypeHHPrivate].TotalMsgCount)
+	assert.Zero(t, jun1Conv[convTypeHAPrivate].TotalMsgCount)
+
+	jun2 := byDay[nextDay]
+	require.NotNil(t, jun2)
+	assert.Equal(t, int64(1), jun2.HumanMsgCount)
+	assert.Equal(t, int64(1), jun2.AgentMsgCount)
+	assert.Equal(t, int64(2), jun2.TotalMsgCount)
+	assert.Equal(t, int64(1), jun2.ActiveHumanMembers)
+	assert.Equal(t, int64(1), jun2.ActiveAgentMembers)
+	assert.Equal(t, int64(1), jun2.ActiveGroups)
+	assert.Zero(t, jun2.PrivateActiveCount)
+
+	var weekTrend trendResp
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/trend?start_date=2026-06-01&end_date=2026-06-07&granularity=week"), &weekTrend)
+	assert.Equal(t, "week", weekTrend.Granularity)
+	require.Len(t, weekTrend.List, 1)
+	week := weekTrend.List[0]
+	assert.Equal(t, "2026-06-01", week.Bucket, "week bucket is Monday in report timezone")
+	assert.Equal(t, "2026-06-01", week.StartDate)
+	assert.Equal(t, "2026-06-07", week.EndDate)
+	assert.Equal(t, int64(13), week.HumanMsgCount)
+	assert.Equal(t, int64(6), week.AgentMsgCount)
+	assert.Equal(t, int64(19), week.TotalMsgCount)
+	assert.Equal(t, int64(3), week.ActiveHumanMembers, "week active members must be bucket-level distinct, not daily sums")
+	assert.Equal(t, int64(1), week.ActiveAgentMembers)
+	assert.Equal(t, int64(2), week.ActiveGroups, "week active groups must be bucket-level distinct, not daily sums")
+	assert.Equal(t, int64(1), week.PrivateActiveCount)
+	weekConv := trendConvByType(week.ConvTypeMsgCounts)
+	assert.Equal(t, int64(2), weekConv[convTypeHHGroup].TotalMsgCount)
+	assert.Equal(t, int64(12), weekConv[convTypeHAGroup].TotalMsgCount)
+	assert.Equal(t, int64(5), weekConv[convTypeHHPrivate].TotalMsgCount)
+	assert.Zero(t, weekConv[convTypeHAPrivate].TotalMsgCount)
+
+	var s1Trend trendResp
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/trend?start_date="+statDay+"&end_date="+statDay+"&space_ids=s1"), &s1Trend)
+	require.Len(t, s1Trend.List, 1)
+	s1Day := s1Trend.List[0]
+	assert.Equal(t, int64(5), s1Day.HumanMsgCount)
+	assert.Equal(t, int64(5), s1Day.AgentMsgCount)
+	assert.Equal(t, int64(1), s1Day.ActiveGroups)
+	assert.Zero(t, s1Day.PrivateActiveCount, "选中 Space 时私聊趋势置 0")
+	s1Conv := trendConvByType(s1Day.ConvTypeMsgCounts)
+	assert.Equal(t, int64(10), s1Conv[convTypeHAGroup].TotalMsgCount)
+	assert.Zero(t, s1Conv[convTypeHHPrivate].TotalMsgCount, "选中 Space 时私聊 conv_type 置 0")
+
+	rec := opaGet(t, route, "/v1/manager/dashboard/trend?start_date="+statDay+"&end_date="+statDay+"&granularity=month")
+	assert.Equal(t, "err.server.opanalytics.request_invalid", errorCode(t, rec))
+
+	setPlainUserToken(t, ctx)
+	rec = opaGet(t, route, "/v1/manager/dashboard/trend?start_date="+statDay+"&end_date="+statDay)
 	assert.Equal(t, "err.server.opanalytics.forbidden", errorCode(t, rec))
 }
 

--- a/modules/opanalytics/db.go
+++ b/modules/opanalytics/db.go
@@ -138,6 +138,164 @@ func (d *opanalyticsDB) privateActiveCount(start, end string) (int64, error) {
 	return n, err
 }
 
+// queryMessageComposition 返回模块B会话类型分布。固定 conv_type 补齐在 service 层完成。
+func (d *opanalyticsDB) queryMessageComposition(start, end string, spaceIDs []string) ([]*messageCompositionItem, error) {
+	var rows []*messageCompositionItem
+	stmt := d.session.Select(
+		"conv_type",
+		"IFNULL(SUM(human_msg_count),0) AS human_msg_count",
+		"IFNULL(SUM(agent_msg_count),0) AS agent_msg_count",
+		"COUNT(DISTINCT channel_id) AS active_channel_count",
+	).From("octo_fact_channel_daily").
+		Where("stat_date BETWEEN ? AND ?", start, end).
+		Where("conv_type BETWEEN 1 AND 4").
+		GroupBy("conv_type")
+	stmt = applySpaceFilter(stmt, spaceIDs)
+	_, err := stmt.Load(&rows)
+	return rows, err
+}
+
+type trendChannelAgg struct {
+	HumanMsg      int64
+	AgentMsg      int64
+	ActiveGroups  int64
+	PrivateActive int64
+}
+
+type trendMemberAgg struct {
+	ActiveHuman int64
+	ActiveAgent int64
+}
+
+type trendConvTypeAgg struct {
+	HumanMsg int64
+	AgentMsg int64
+}
+
+func (d *opanalyticsDB) queryTrendChannelAgg(start, end, granularity string, spaceIDs []string) (map[string]trendChannelAgg, map[string]map[uint8]trendConvTypeAgg, error) {
+	total, err := d.queryTrendChannelTotals(start, end, granularity, spaceIDs)
+	if err != nil {
+		return nil, nil, err
+	}
+	conv, err := d.queryTrendConvTypeMsg(start, end, granularity, spaceIDs)
+	if err != nil {
+		return nil, nil, err
+	}
+	return total, conv, nil
+}
+
+func (d *opanalyticsDB) queryTrendChannelTotals(start, end, granularity string, spaceIDs []string) (map[string]trendChannelAgg, error) {
+	bucketExpr := trendBucketSQL("stat_date", granularity)
+	sql := "SELECT " + bucketExpr + " AS bucket, " +
+		"IFNULL(SUM(human_msg_count),0) AS human_msg, " +
+		"IFNULL(SUM(agent_msg_count),0) AS agent_msg, " +
+		"COUNT(DISTINCT CASE WHEN channel_type=2 THEN channel_id END) AS active_groups, " +
+		"COUNT(DISTINCT CASE WHEN channel_type=1 THEN channel_id END) AS private_active " +
+		"FROM octo_fact_channel_daily WHERE stat_date BETWEEN ? AND ?"
+	args := []interface{}{start, end}
+	if len(spaceIDs) > 0 {
+		spaceClause, spaceArgs := inClause("space_id", spaceIDs)
+		sql += " AND " + spaceClause
+		args = append(args, spaceArgs...)
+	}
+	sql += " GROUP BY bucket"
+
+	var rows []struct {
+		Bucket        string `db:"bucket"`
+		HumanMsg      int64  `db:"human_msg"`
+		AgentMsg      int64  `db:"agent_msg"`
+		ActiveGroups  int64  `db:"active_groups"`
+		PrivateActive int64  `db:"private_active"`
+	}
+	if _, err := d.session.SelectBySql(sql, args...).Load(&rows); err != nil {
+		return nil, err
+	}
+	out := make(map[string]trendChannelAgg, len(rows))
+	for _, r := range rows {
+		out[r.Bucket] = trendChannelAgg{
+			HumanMsg: r.HumanMsg, AgentMsg: r.AgentMsg,
+			ActiveGroups: r.ActiveGroups, PrivateActive: r.PrivateActive,
+		}
+	}
+	return out, nil
+}
+
+func (d *opanalyticsDB) queryTrendConvTypeMsg(start, end, granularity string, spaceIDs []string) (map[string]map[uint8]trendConvTypeAgg, error) {
+	bucketExpr := trendBucketSQL("stat_date", granularity)
+	sql := "SELECT " + bucketExpr + " AS bucket, conv_type, " +
+		"IFNULL(SUM(human_msg_count),0) AS human_msg, " +
+		"IFNULL(SUM(agent_msg_count),0) AS agent_msg " +
+		"FROM octo_fact_channel_daily WHERE stat_date BETWEEN ? AND ? AND conv_type BETWEEN 1 AND 4"
+	args := []interface{}{start, end}
+	if len(spaceIDs) > 0 {
+		spaceClause, spaceArgs := inClause("space_id", spaceIDs)
+		sql += " AND " + spaceClause
+		args = append(args, spaceArgs...)
+	}
+	sql += " GROUP BY bucket, conv_type"
+
+	var rows []struct {
+		Bucket   string `db:"bucket"`
+		ConvType uint8  `db:"conv_type"`
+		HumanMsg int64  `db:"human_msg"`
+		AgentMsg int64  `db:"agent_msg"`
+	}
+	if _, err := d.session.SelectBySql(sql, args...).Load(&rows); err != nil {
+		return nil, err
+	}
+	out := make(map[string]map[uint8]trendConvTypeAgg, len(rows))
+	for _, r := range rows {
+		if out[r.Bucket] == nil {
+			out[r.Bucket] = map[uint8]trendConvTypeAgg{}
+		}
+		out[r.Bucket][r.ConvType] = trendConvTypeAgg{HumanMsg: r.HumanMsg, AgentMsg: r.AgentMsg}
+	}
+	return out, nil
+}
+
+func (d *opanalyticsDB) queryTrendActiveMembers(start, end, granularity string, spaceIDs []string) (map[string]trendMemberAgg, error) {
+	bucketExpr := trendBucketSQL("f.stat_date", granularity)
+	sql := "SELECT " + bucketExpr + " AS bucket, " +
+		"COUNT(DISTINCT CASE WHEN m.member_type=1 THEN f.sender_uid END) AS active_human, " +
+		"COUNT(DISTINCT CASE WHEN m.member_type=2 THEN f.sender_uid END) AS active_agent " +
+		"FROM octo_fact_member_channel_daily f JOIN octo_dim_member m ON m.uid = f.sender_uid"
+	args := []interface{}{}
+	if len(spaceIDs) > 0 {
+		smClause, smArgs := inClause("sm.space_id", spaceIDs)
+		sql += " JOIN space_member sm ON sm.uid = f.sender_uid AND sm.status=1 AND " + smClause
+		args = append(args, smArgs...)
+	}
+	sql += " WHERE f.stat_date BETWEEN ? AND ? AND m.is_excluded=0"
+	args = append(args, start, end)
+	if len(spaceIDs) > 0 {
+		spaceClause, spaceArgs := inClause("f.space_id", spaceIDs)
+		sql += " AND " + spaceClause
+		args = append(args, spaceArgs...)
+	}
+	sql += " GROUP BY bucket"
+
+	var rows []struct {
+		Bucket      string `db:"bucket"`
+		ActiveHuman int64  `db:"active_human"`
+		ActiveAgent int64  `db:"active_agent"`
+	}
+	if _, err := d.session.SelectBySql(sql, args...).Load(&rows); err != nil {
+		return nil, err
+	}
+	out := make(map[string]trendMemberAgg, len(rows))
+	for _, r := range rows {
+		out[r.Bucket] = trendMemberAgg{ActiveHuman: r.ActiveHuman, ActiveAgent: r.ActiveAgent}
+	}
+	return out, nil
+}
+
+func trendBucketSQL(col, granularity string) string {
+	if granularity == "week" {
+		return "DATE_FORMAT(DATE_SUB(" + col + ", INTERVAL WEEKDAY(" + col + ") DAY), '%Y-%m-%d')"
+	}
+	return "DATE_FORMAT(" + col + ", '%Y-%m-%d')"
+}
+
 // ===== 表一 Space 列表(在内存合并/排序/分页，spaces 数量适中) =====
 
 type spaceBaseRow struct {

--- a/modules/opanalytics/model.go
+++ b/modules/opanalytics/model.go
@@ -76,16 +76,53 @@ type srcMessageRow struct {
 
 // overviewResp 模块A 概览卡片(私聊只出活跃数，无总数/占比)。
 type overviewResp struct {
-	SpaceTotal         int64 `json:"space_total"`
-	GroupTotal         int64 `json:"group_total"`
-	HumanMemberTotal   int64 `json:"human_member_total"`
-	AgentTotal         int64 `json:"agent_total"`
-	ActiveGroups       int64 `json:"active_groups"`
-	ActiveHumanMembers int64 `json:"active_human_members"`
-	ActiveAgentMembers int64 `json:"active_agent_members"`
+	SpaceTotal         int64                     `json:"space_total"`
+	GroupTotal         int64                     `json:"group_total"`
+	HumanMemberTotal   int64                     `json:"human_member_total"`
+	AgentTotal         int64                     `json:"agent_total"`
+	ActiveGroups       int64                     `json:"active_groups"`
+	ActiveHumanMembers int64                     `json:"active_human_members"`
+	ActiveAgentMembers int64                     `json:"active_agent_members"`
+	HumanMsgCount      int64                     `json:"human_msg_count"`
+	AgentMsgCount      int64                     `json:"agent_msg_count"`
+	PrivateActiveCount int64                     `json:"private_active_count"` // 私聊活跃数(口径1：不出总数)
+	MessageComposition []*messageCompositionItem `json:"message_composition"`
+}
+
+// messageCompositionItem 模块B 会话类型分布(固定 conv_type=1..4，缺数据补 0)。
+type messageCompositionItem struct {
+	ConvType           uint8 `json:"conv_type"`
 	HumanMsgCount      int64 `json:"human_msg_count"`
 	AgentMsgCount      int64 `json:"agent_msg_count"`
-	PrivateActiveCount int64 `json:"private_active_count"` // 私聊活跃数(口径1：不出总数)
+	TotalMsgCount      int64 `json:"total_msg_count"`
+	ActiveChannelCount int64 `json:"active_channel_count"`
+}
+
+// trendResp 模块C 趋势响应。
+type trendResp struct {
+	Granularity string       `json:"granularity"`
+	List        []*trendItem `json:"list"`
+}
+
+type trendItem struct {
+	Bucket             string                  `json:"bucket"`
+	StartDate          string                  `json:"start_date"`
+	EndDate            string                  `json:"end_date"`
+	HumanMsgCount      int64                   `json:"human_msg_count"`
+	AgentMsgCount      int64                   `json:"agent_msg_count"`
+	TotalMsgCount      int64                   `json:"total_msg_count"`
+	ActiveHumanMembers int64                   `json:"active_human_members"`
+	ActiveAgentMembers int64                   `json:"active_agent_members"`
+	ActiveGroups       int64                   `json:"active_groups"`
+	PrivateActiveCount int64                   `json:"private_active_count"`
+	ConvTypeMsgCounts  []*trendConvTypeMsgItem `json:"conv_type_msg_counts"`
+}
+
+type trendConvTypeMsgItem struct {
+	ConvType      uint8 `json:"conv_type"`
+	HumanMsgCount int64 `json:"human_msg_count"`
+	AgentMsgCount int64 `json:"agent_msg_count"`
+	TotalMsgCount int64 `json:"total_msg_count"`
 }
 
 // spaceListItem 表一 Space 列表行。

--- a/modules/opanalytics/service.go
+++ b/modules/opanalytics/service.go
@@ -2,6 +2,7 @@ package opanalytics
 
 import (
 	"sort"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
@@ -51,6 +52,10 @@ func (s *service) overview(start, end string, spaceIDs []string) (*overviewResp,
 			return nil, err
 		}
 	}
+	composition, err := s.db.queryMessageComposition(start, end, spaceIDs)
+	if err != nil {
+		return nil, err
+	}
 	return &overviewResp{
 		SpaceTotal:         spaceTotal,
 		GroupTotal:         groupTotal,
@@ -62,7 +67,46 @@ func (s *service) overview(start, end string, spaceIDs []string) (*overviewResp,
 		HumanMsgCount:      humanMsg,
 		AgentMsgCount:      agentMsg,
 		PrivateActiveCount: privateActive,
+		MessageComposition: normalizeMessageComposition(composition),
 	}, nil
+}
+
+// trend 组装模块C 趋势。消息/活跃会话走 ④，活跃成员走 ③ join 当前 dim_member；
+// week 桶内活跃成员按 distinct 计算，不能把每日活跃数相加。
+func (s *service) trend(start, end, granularity string, spaceIDs []string) (*trendResp, error) {
+	buckets, err := buildTrendBuckets(start, end, granularity)
+	if err != nil {
+		return nil, err
+	}
+	channelAgg, convAgg, err := s.db.queryTrendChannelAgg(start, end, granularity, spaceIDs)
+	if err != nil {
+		return nil, err
+	}
+	memberAgg, err := s.db.queryTrendActiveMembers(start, end, granularity, spaceIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]*trendItem, 0, len(buckets))
+	for _, b := range buckets {
+		ca := channelAgg[b.Bucket]
+		ma := memberAgg[b.Bucket]
+		item := &trendItem{
+			Bucket:             b.Bucket,
+			StartDate:          b.StartDate,
+			EndDate:            b.EndDate,
+			HumanMsgCount:      ca.HumanMsg,
+			AgentMsgCount:      ca.AgentMsg,
+			TotalMsgCount:      ca.HumanMsg + ca.AgentMsg,
+			ActiveHumanMembers: ma.ActiveHuman,
+			ActiveAgentMembers: ma.ActiveAgent,
+			ActiveGroups:       ca.ActiveGroups,
+			PrivateActiveCount: ca.PrivateActive,
+			ConvTypeMsgCounts:  normalizeTrendConvTypes(convAgg[b.Bucket]),
+		}
+		items = append(items, item)
+	}
+	return &trendResp{Granularity: granularity, List: items}, nil
 }
 
 // spaceList 表一：内存合并维表/活跃聚合 → 过滤(活跃状态) → 排序 → 分页。
@@ -122,6 +166,93 @@ func (s *service) spaceList(start, end, name, activeStatus, sortBy, order string
 		end2 = len(items)
 	}
 	return items[offset:end2], total, nil
+}
+
+func normalizeMessageComposition(rows []*messageCompositionItem) []*messageCompositionItem {
+	byType := make(map[uint8]*messageCompositionItem, len(rows))
+	for _, row := range rows {
+		cp := *row
+		cp.TotalMsgCount = cp.HumanMsgCount + cp.AgentMsgCount
+		byType[cp.ConvType] = &cp
+	}
+	out := make([]*messageCompositionItem, 0, 4)
+	for _, convType := range []uint8{convTypeHHGroup, convTypeHAGroup, convTypeHHPrivate, convTypeHAPrivate} {
+		if row := byType[convType]; row != nil {
+			out = append(out, row)
+			continue
+		}
+		out = append(out, &messageCompositionItem{ConvType: convType})
+	}
+	return out
+}
+
+func normalizeTrendConvTypes(rows map[uint8]trendConvTypeAgg) []*trendConvTypeMsgItem {
+	out := make([]*trendConvTypeMsgItem, 0, 4)
+	for _, convType := range []uint8{convTypeHHGroup, convTypeHAGroup, convTypeHHPrivate, convTypeHAPrivate} {
+		row := rows[convType]
+		out = append(out, &trendConvTypeMsgItem{
+			ConvType:      convType,
+			HumanMsgCount: row.HumanMsg,
+			AgentMsgCount: row.AgentMsg,
+			TotalMsgCount: row.HumanMsg + row.AgentMsg,
+		})
+	}
+	return out
+}
+
+type trendBucket struct {
+	Bucket    string
+	StartDate string
+	EndDate   string
+}
+
+func buildTrendBuckets(start, end, granularity string) ([]trendBucket, error) {
+	loc := reportLocation()
+	const layout = "2006-01-02"
+	startDate, err := time.ParseInLocation(layout, start, loc)
+	if err != nil {
+		return nil, err
+	}
+	endDate, err := time.ParseInLocation(layout, end, loc)
+	if err != nil {
+		return nil, err
+	}
+	if granularity == "week" {
+		return buildWeekBuckets(startDate, endDate), nil
+	}
+	out := make([]trendBucket, 0, int(endDate.Sub(startDate)/(24*time.Hour))+1)
+	for d := startDate; !d.After(endDate); d = d.AddDate(0, 0, 1) {
+		day := d.Format(layout)
+		out = append(out, trendBucket{Bucket: day, StartDate: day, EndDate: day})
+	}
+	return out, nil
+}
+
+func buildWeekBuckets(start, end time.Time) []trendBucket {
+	const layout = "2006-01-02"
+	weekStart := mondayOf(start)
+	out := make([]trendBucket, 0)
+	for d := weekStart; !d.After(end); d = d.AddDate(0, 0, 7) {
+		bs := d
+		if bs.Before(start) {
+			bs = start
+		}
+		be := d.AddDate(0, 0, 6)
+		if be.After(end) {
+			be = end
+		}
+		out = append(out, trendBucket{
+			Bucket:    d.Format(layout),
+			StartDate: bs.Format(layout),
+			EndDate:   be.Format(layout),
+		})
+	}
+	return out
+}
+
+func mondayOf(d time.Time) time.Time {
+	offset := (int(d.Weekday()) + 6) % 7 // Go: Sunday=0; desired Monday=0.
+	return d.AddDate(0, 0, -offset)
 }
 
 // channelList 表二(仅群组)：SQL 侧 LEFT JOIN + 分页。

--- a/modules/opanalytics/swagger/api.yaml
+++ b/modules/opanalytics/swagger/api.yaml
@@ -58,6 +58,57 @@ paths:
       security:
         - token: []
 
+  /manager/dashboard/trend:
+    get:
+      tags:
+        - "opanalyticsManager"
+      summary: "趋势图（模块C）"
+      description: >
+        按 day/week 返回消息量、活跃成员、活跃群、活跃私聊和会话类型消息分布。
+        week 以报告时区周一作为 bucket；缺失日期/周补 0。选中 space 时私聊指标返回 0。
+      operationId: "m dashboard trend"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "query"
+          name: "start_date"
+          type: string
+          format: date
+          description: "起始统计日 YYYY-MM-DD（报告时区）。缺省=近 30 天；含两端最多 366 天"
+          required: false
+        - in: "query"
+          name: "end_date"
+          type: string
+          format: date
+          description: "结束统计日 YYYY-MM-DD（含）。缺省=今天"
+          required: false
+        - in: "query"
+          name: "space_ids"
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+          description: "可选空间筛选；多值用 space_ids=a&space_ids=b。为空=全局"
+          required: false
+        - in: "query"
+          name: "granularity"
+          type: string
+          enum: ["day", "week"]
+          default: "day"
+          description: "趋势粒度"
+          required: false
+      responses:
+        200:
+          description: "趋势数据"
+          schema:
+            $ref: "#/definitions/trendResp"
+        400:
+          description: "错误（error.http_status 含真实状态码）"
+          schema:
+            $ref: "#/definitions/dashboardError"
+      security:
+        - token: []
+
   /manager/dashboard/spaces:
     get:
       tags:
@@ -337,6 +388,104 @@ definitions:
         type: integer
         format: int64
         description: "范围内活跃私聊数（全局；选中 space 时为 0）"
+      message_composition:
+        type: array
+        description: "会话类型分布，固定返回 conv_type 1..4；选中 space 时私聊类型为 0"
+        items:
+          $ref: "#/definitions/messageCompositionItem"
+
+  messageCompositionItem:
+    type: object
+    properties:
+      conv_type:
+        type: integer
+        description: "会话类型 1.HH群 2.HA群 3.HH私聊 4.HA私聊"
+      human_msg_count:
+        type: integer
+        format: int64
+      agent_msg_count:
+        type: integer
+        format: int64
+      total_msg_count:
+        type: integer
+        format: int64
+      active_channel_count:
+        type: integer
+        format: int64
+        description: "范围内该类型活跃会话数"
+
+  trendResp:
+    type: object
+    properties:
+      granularity:
+        type: string
+        enum: ["day", "week"]
+      list:
+        type: array
+        items:
+          $ref: "#/definitions/trendItem"
+
+  trendItem:
+    type: object
+    properties:
+      bucket:
+        type: string
+        format: date
+        description: "bucket 起点；day=当天，week=报告时区周一"
+      start_date:
+        type: string
+        format: date
+        description: "该 bucket 在请求范围内的起始日期"
+      end_date:
+        type: string
+        format: date
+        description: "该 bucket 在请求范围内的结束日期"
+      human_msg_count:
+        type: integer
+        format: int64
+      agent_msg_count:
+        type: integer
+        format: int64
+      total_msg_count:
+        type: integer
+        format: int64
+      active_human_members:
+        type: integer
+        format: int64
+        description: "bucket 内活跃 human 成员去重数"
+      active_agent_members:
+        type: integer
+        format: int64
+        description: "bucket 内活跃 agent 成员去重数"
+      active_groups:
+        type: integer
+        format: int64
+        description: "bucket 内活跃群去重数"
+      private_active_count:
+        type: integer
+        format: int64
+        description: "bucket 内活跃私聊去重数；选中 space 时为 0"
+      conv_type_msg_counts:
+        type: array
+        description: "固定返回 conv_type 1..4 的消息量"
+        items:
+          $ref: "#/definitions/trendConvTypeMsgItem"
+
+  trendConvTypeMsgItem:
+    type: object
+    properties:
+      conv_type:
+        type: integer
+        description: "会话类型 1.HH群 2.HA群 3.HH私聊 4.HA私聊"
+      human_msg_count:
+        type: integer
+        format: int64
+      agent_msg_count:
+        type: integer
+        format: int64
+      total_msg_count:
+        type: integer
+        format: int64
 
   spaceListResp:
     type: object


### PR DESCRIPTION
## Summary
- add message_composition to the manager dashboard overview response with fixed conv_type 1..4 buckets
- add GET /v1/manager/dashboard/trend with day/week buckets and zero-filled gaps
- document the new trend API and response shapes in Swagger

## Issue
Closes #318

## Notes
- uses existing opanalytics dim/fact tables only; no ETL/content_type/pair changes
- keeps private chats global-only: space-filtered overview/trend returns private metrics as 0

## Tests
- go test ./modules/opanalytics/...
- go test ./modules/opanalytics -run ^$ -count=1
- go test ./modules/opanalytics -run 'TestOpanalytics(NoLegacyResponseError|RespondHelpers)$'
- go vet ./modules/opanalytics/...
- make i18n-extract-check
- make i18n-lint
- git diff --check
