### PR TITLE
test(opanalytics): harden trend edge cases

### DIFF
--- a/modules/opanalytics/api_test.go
+++ b/modules/opanalytics/api_test.go
@@ -414,6 +414,18 @@ func compositionByType(items []*messageCompositionItem) map[uint8]*messageCompos
 	return out
 }
 
+func expectedConvTypeOrder() []uint8 {
+	return []uint8{convTypeHHGroup, convTypeHAGroup, convTypeHHPrivate, convTypeHAPrivate}
+}
+
+func compositionTypes(items []*messageCompositionItem) []uint8 {
+	out := make([]uint8, 0, len(items))
+	for _, item := range items {
+		out = append(out, item.ConvType)
+	}
+	return out
+}
+
 func trendByBucket(items []*trendItem) map[string]*trendItem {
 	out := make(map[string]*trendItem, len(items))
 	for _, item := range items {
@@ -428,6 +440,45 @@ func trendConvByType(items []*trendConvTypeMsgItem) map[uint8]*trendConvTypeMsgI
 		out[item.ConvType] = item
 	}
 	return out
+}
+
+func trendConvTypes(items []*trendConvTypeMsgItem) []uint8 {
+	out := make([]uint8, 0, len(items))
+	for _, item := range items {
+		out = append(out, item.ConvType)
+	}
+	return out
+}
+
+func insertLeakedPrivateFactWithSpace(t *testing.T, ctx *config.Context, channelID string, convType uint8, humanMsg, agentMsg int64) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO octo_fact_channel_daily "+
+			"(stat_date,channel_id,channel_type,space_id,conv_type,human_msg_count,agent_msg_count,active_human_members,active_agent_members,last_msg_at) "+
+			"VALUES (?,?,?,?,?,?,?,?,?,?)",
+		statDay, channelID, channelTypePerson, "s1", convType, humanMsg, agentMsg, 1, 0, 0,
+	).Exec()
+	require.NoError(t, err)
+}
+
+func seedDimMember(t *testing.T, ctx *config.Context, uid, name string, memberType uint8) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO octo_dim_member (uid,name,member_type,is_excluded) VALUES (?,?,?,0)",
+		uid, name, memberType,
+	).Exec()
+	require.NoError(t, err)
+}
+
+func insertLeakedPrivateMemberFactWithSpace(t *testing.T, ctx *config.Context, channelID, senderUID string, convType, senderType uint8) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO octo_fact_member_channel_daily "+
+			"(stat_date,channel_id,channel_type,space_id,conv_type,content_type,sender_uid,sender_type,msg_count,last_msg_at) "+
+			"VALUES (?,?,?,?,?,?,?,?,?,?)",
+		statDay, channelID, channelTypePerson, "s1", convType, uint8(0), senderUID, senderType, 1, int64(0),
+	).Exec()
+	require.NoError(t, err)
 }
 
 func TestOpanalyticsEndpoints(t *testing.T) {
@@ -450,6 +501,7 @@ func TestOpanalyticsEndpoints(t *testing.T) {
 	assert.Equal(t, int64(12), ov.HumanMsgCount) // g1:5 + g2:2 + private:5
 	assert.Equal(t, int64(5), ov.AgentMsgCount)
 	assert.Equal(t, int64(1), ov.PrivateActiveCount)
+	assert.Equal(t, expectedConvTypeOrder(), compositionTypes(ov.MessageComposition))
 	ovComp := compositionByType(ov.MessageComposition)
 	require.Len(t, ovComp, 4, "overview composition must always return conv_type 1..4")
 	assert.Equal(t, int64(2), ovComp[convTypeHHGroup].HumanMsgCount)
@@ -479,6 +531,7 @@ func TestOpanalyticsEndpoints(t *testing.T) {
 	assert.Equal(t, int64(5), ovS1.HumanMsgCount, "私聊/g2 不计入 s1")
 	assert.Equal(t, int64(5), ovS1.AgentMsgCount)
 	assert.Equal(t, int64(0), ovS1.PrivateActiveCount, "选中 Space 时私聊数置 0(私聊无 space 归属)")
+	assert.Equal(t, expectedConvTypeOrder(), compositionTypes(ovS1.MessageComposition))
 	ovS1Comp := compositionByType(ovS1.MessageComposition)
 	require.Len(t, ovS1Comp, 4)
 	assert.Equal(t, int64(10), ovS1Comp[convTypeHAGroup].TotalMsgCount)
@@ -490,6 +543,7 @@ func TestOpanalyticsEndpoints(t *testing.T) {
 	// ---- overview 空范围：composition 仍固定 4 类且全部补 0 ----
 	var empty overviewResp
 	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/overview?start_date=2026-05-31&end_date=2026-05-31"), &empty)
+	assert.Equal(t, expectedConvTypeOrder(), compositionTypes(empty.MessageComposition))
 	emptyComp := compositionByType(empty.MessageComposition)
 	require.Len(t, emptyComp, 4)
 	for _, item := range emptyComp {
@@ -594,6 +648,7 @@ func TestOpanalyticsTrendEndpoint(t *testing.T) {
 	assert.Equal(t, int64(1), jun1.ActiveAgentMembers)
 	assert.Equal(t, int64(2), jun1.ActiveGroups)
 	assert.Equal(t, int64(1), jun1.PrivateActiveCount)
+	assert.Equal(t, expectedConvTypeOrder(), trendConvTypes(jun1.ConvTypeMsgCounts))
 	jun1Conv := trendConvByType(jun1.ConvTypeMsgCounts)
 	require.Len(t, jun1Conv, 4)
 	assert.Equal(t, int64(2), jun1Conv[convTypeHHGroup].TotalMsgCount)
@@ -632,6 +687,24 @@ func TestOpanalyticsTrendEndpoint(t *testing.T) {
 	assert.Equal(t, int64(5), weekConv[convTypeHHPrivate].TotalMsgCount)
 	assert.Zero(t, weekConv[convTypeHAPrivate].TotalMsgCount)
 
+	var partialWeekTrend trendResp
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/trend?start_date=2026-06-02&end_date=2026-06-09&granularity=week"), &partialWeekTrend)
+	assert.Equal(t, "week", partialWeekTrend.Granularity)
+	require.Len(t, partialWeekTrend.List, 2)
+	firstPartial := partialWeekTrend.List[0]
+	assert.Equal(t, "2026-06-01", firstPartial.Bucket, "bucket remains the report-timezone Monday")
+	assert.Equal(t, "2026-06-02", firstPartial.StartDate, "partial week start is clipped to the request")
+	assert.Equal(t, "2026-06-07", firstPartial.EndDate)
+	assert.Equal(t, int64(2), firstPartial.TotalMsgCount)
+	assert.Equal(t, int64(1), firstPartial.ActiveHumanMembers)
+	assert.Equal(t, int64(1), firstPartial.ActiveAgentMembers)
+	assert.Equal(t, int64(1), firstPartial.ActiveGroups)
+	secondPartial := partialWeekTrend.List[1]
+	assert.Equal(t, "2026-06-08", secondPartial.Bucket)
+	assert.Equal(t, "2026-06-08", secondPartial.StartDate)
+	assert.Equal(t, "2026-06-09", secondPartial.EndDate, "partial week end is clipped to the request")
+	assert.Zero(t, secondPartial.TotalMsgCount)
+
 	var s1Trend trendResp
 	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/trend?start_date="+statDay+"&end_date="+statDay+"&space_ids=s1"), &s1Trend)
 	require.Len(t, s1Trend.List, 1)
@@ -643,6 +716,40 @@ func TestOpanalyticsTrendEndpoint(t *testing.T) {
 	s1Conv := trendConvByType(s1Day.ConvTypeMsgCounts)
 	assert.Equal(t, int64(10), s1Conv[convTypeHAGroup].TotalMsgCount)
 	assert.Zero(t, s1Conv[convTypeHHPrivate].TotalMsgCount, "选中 Space 时私聊 conv_type 置 0")
+
+	insertLeakedPrivateFactWithSpace(t, ctx, "leaked_hh_private", convTypeHHPrivate, 7, 0)
+	insertLeakedPrivateFactWithSpace(t, ctx, "leaked_ha_private", convTypeHAPrivate, 3, 4)
+	seedDimMember(t, ctx, "u_private_only_human", "PrivateOnlyHuman", memberTypeHuman)
+	seedDimMember(t, ctx, "u_private_only_agent", "PrivateOnlyAgent", memberTypeAgent)
+	seedSpaceMember(t, ctx, "s1", "u_private_only_human")
+	seedSpaceMember(t, ctx, "s1", "u_private_only_agent")
+	insertLeakedPrivateMemberFactWithSpace(t, ctx, "leaked_hh_private", "u_private_only_human", convTypeHHPrivate, memberTypeHuman)
+	insertLeakedPrivateMemberFactWithSpace(t, ctx, "leaked_ha_private", "u_private_only_agent", convTypeHAPrivate, memberTypeAgent)
+
+	var guardedOverview overviewResp
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/overview?start_date="+statDay+"&end_date="+statDay+"&space_ids=s1"), &guardedOverview)
+	assert.Equal(t, int64(5), guardedOverview.HumanMsgCount, "service must not mix leaked private rows into space overview totals")
+	assert.Equal(t, int64(5), guardedOverview.AgentMsgCount, "service must not mix leaked private rows into space overview totals")
+	assert.Equal(t, int64(2), guardedOverview.ActiveHumanMembers, "space overview active members must exclude leaked private member facts")
+	assert.Equal(t, int64(1), guardedOverview.ActiveAgentMembers, "space overview active members must exclude leaked private member facts")
+	assert.Zero(t, guardedOverview.PrivateActiveCount)
+	guardedComp := compositionByType(guardedOverview.MessageComposition)
+	assert.Zero(t, guardedComp[convTypeHHPrivate].TotalMsgCount, "service must zero private composition under space filter")
+	assert.Zero(t, guardedComp[convTypeHAPrivate].TotalMsgCount, "service must zero private composition under space filter")
+
+	var guardedTrend trendResp
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/trend?start_date="+statDay+"&end_date="+statDay+"&space_ids=s1"), &guardedTrend)
+	require.Len(t, guardedTrend.List, 1)
+	guardedDay := guardedTrend.List[0]
+	assert.Equal(t, int64(5), guardedDay.HumanMsgCount, "service must not mix leaked private rows into space trend totals")
+	assert.Equal(t, int64(5), guardedDay.AgentMsgCount, "service must not mix leaked private rows into space trend totals")
+	assert.Equal(t, int64(10), guardedDay.TotalMsgCount)
+	assert.Equal(t, int64(2), guardedDay.ActiveHumanMembers, "space trend active members must exclude leaked private member facts")
+	assert.Equal(t, int64(1), guardedDay.ActiveAgentMembers, "space trend active members must exclude leaked private member facts")
+	assert.Zero(t, guardedDay.PrivateActiveCount, "service must zero private trend metrics under space filter")
+	guardedTrendConv := trendConvByType(guardedDay.ConvTypeMsgCounts)
+	assert.Zero(t, guardedTrendConv[convTypeHHPrivate].TotalMsgCount, "service must zero private trend conv_type under space filter")
+	assert.Zero(t, guardedTrendConv[convTypeHAPrivate].TotalMsgCount, "service must zero private trend conv_type under space filter")
 
 	rec := opaGet(t, route, "/v1/manager/dashboard/trend?start_date="+statDay+"&end_date="+statDay+"&granularity=month")
 	assert.Equal(t, "err.server.opanalytics.request_invalid", errorCode(t, rec))

--- a/modules/opanalytics/db.go
+++ b/modules/opanalytics/db.go
@@ -121,7 +121,7 @@ func (d *opanalyticsDB) overviewActiveMembers(start, end string, spaceIDs []stri
 	args = append(args, start, end)
 	if len(spaceIDs) > 0 {
 		spaceClause, spaceArgs := inClause("f.space_id", spaceIDs)
-		sql += " AND " + spaceClause
+		sql += " AND f.channel_type=2 AND " + spaceClause
 		args = append(args, spaceArgs...)
 	}
 	_, err = d.session.SelectBySql(sql, args...).Load(&res)
@@ -269,7 +269,7 @@ func (d *opanalyticsDB) queryTrendActiveMembers(start, end, granularity string, 
 	args = append(args, start, end)
 	if len(spaceIDs) > 0 {
 		spaceClause, spaceArgs := inClause("f.space_id", spaceIDs)
-		sql += " AND " + spaceClause
+		sql += " AND f.channel_type=2 AND " + spaceClause
 		args = append(args, spaceArgs...)
 	}
 	sql += " GROUP BY bucket"
@@ -290,6 +290,8 @@ func (d *opanalyticsDB) queryTrendActiveMembers(start, end, granularity string, 
 }
 
 func trendBucketSQL(col, granularity string) string {
+	// SECURITY: col is an internal constant from call sites, and granularity is normalized
+	// to the closed enum day/week before service dispatch; no raw user input reaches this SQL fragment.
 	if granularity == "week" {
 		return "DATE_FORMAT(DATE_SUB(" + col + ", INTERVAL WEEKDAY(" + col + ") DAY), '%Y-%m-%d')"
 	}

--- a/modules/opanalytics/service.go
+++ b/modules/opanalytics/service.go
@@ -56,6 +56,11 @@ func (s *service) overview(start, end string, spaceIDs []string) (*overviewResp,
 	if err != nil {
 		return nil, err
 	}
+	messageComposition := normalizeMessageComposition(composition)
+	if len(spaceIDs) > 0 {
+		humanMsg, agentMsg = stripPrivateCompositionTotals(humanMsg, agentMsg, messageComposition)
+		zeroPrivateMessageComposition(messageComposition)
+	}
 	return &overviewResp{
 		SpaceTotal:         spaceTotal,
 		GroupTotal:         groupTotal,
@@ -67,7 +72,7 @@ func (s *service) overview(start, end string, spaceIDs []string) (*overviewResp,
 		HumanMsgCount:      humanMsg,
 		AgentMsgCount:      agentMsg,
 		PrivateActiveCount: privateActive,
-		MessageComposition: normalizeMessageComposition(composition),
+		MessageComposition: messageComposition,
 	}, nil
 }
 
@@ -91,6 +96,12 @@ func (s *service) trend(start, end, granularity string, spaceIDs []string) (*tre
 	for _, b := range buckets {
 		ca := channelAgg[b.Bucket]
 		ma := memberAgg[b.Bucket]
+		convTypes := normalizeTrendConvTypes(convAgg[b.Bucket])
+		if len(spaceIDs) > 0 {
+			ca.HumanMsg, ca.AgentMsg = stripPrivateTrendTotals(ca.HumanMsg, ca.AgentMsg, convTypes)
+			ca.PrivateActive = 0
+			zeroPrivateTrendConvTypes(convTypes)
+		}
 		item := &trendItem{
 			Bucket:             b.Bucket,
 			StartDate:          b.StartDate,
@@ -102,7 +113,7 @@ func (s *service) trend(start, end, granularity string, spaceIDs []string) (*tre
 			ActiveAgentMembers: ma.ActiveAgent,
 			ActiveGroups:       ca.ActiveGroups,
 			PrivateActiveCount: ca.PrivateActive,
-			ConvTypeMsgCounts:  normalizeTrendConvTypes(convAgg[b.Bucket]),
+			ConvTypeMsgCounts:  convTypes,
 		}
 		items = append(items, item)
 	}
@@ -186,6 +197,30 @@ func normalizeMessageComposition(rows []*messageCompositionItem) []*messageCompo
 	return out
 }
 
+func stripPrivateCompositionTotals(humanMsg, agentMsg int64, rows []*messageCompositionItem) (int64, int64) {
+	var privateHuman, privateAgent int64
+	for _, row := range rows {
+		if !isPrivateConvType(row.ConvType) {
+			continue
+		}
+		privateHuman += row.HumanMsgCount
+		privateAgent += row.AgentMsgCount
+	}
+	return subtractFloor(humanMsg, privateHuman), subtractFloor(agentMsg, privateAgent)
+}
+
+func zeroPrivateMessageComposition(rows []*messageCompositionItem) {
+	for _, row := range rows {
+		if !isPrivateConvType(row.ConvType) {
+			continue
+		}
+		row.HumanMsgCount = 0
+		row.AgentMsgCount = 0
+		row.TotalMsgCount = 0
+		row.ActiveChannelCount = 0
+	}
+}
+
 func normalizeTrendConvTypes(rows map[uint8]trendConvTypeAgg) []*trendConvTypeMsgItem {
 	out := make([]*trendConvTypeMsgItem, 0, 4)
 	for _, convType := range []uint8{convTypeHHGroup, convTypeHAGroup, convTypeHHPrivate, convTypeHAPrivate} {
@@ -198,6 +233,40 @@ func normalizeTrendConvTypes(rows map[uint8]trendConvTypeAgg) []*trendConvTypeMs
 		})
 	}
 	return out
+}
+
+func stripPrivateTrendTotals(humanMsg, agentMsg int64, rows []*trendConvTypeMsgItem) (int64, int64) {
+	var privateHuman, privateAgent int64
+	for _, row := range rows {
+		if !isPrivateConvType(row.ConvType) {
+			continue
+		}
+		privateHuman += row.HumanMsgCount
+		privateAgent += row.AgentMsgCount
+	}
+	return subtractFloor(humanMsg, privateHuman), subtractFloor(agentMsg, privateAgent)
+}
+
+func zeroPrivateTrendConvTypes(rows []*trendConvTypeMsgItem) {
+	for _, row := range rows {
+		if !isPrivateConvType(row.ConvType) {
+			continue
+		}
+		row.HumanMsgCount = 0
+		row.AgentMsgCount = 0
+		row.TotalMsgCount = 0
+	}
+}
+
+func isPrivateConvType(convType uint8) bool {
+	return convType == convTypeHHPrivate || convType == convTypeHAPrivate
+}
+
+func subtractFloor(total, n int64) int64 {
+	if n >= total {
+		return 0
+	}
+	return total - n
 }
 
 type trendBucket struct {

--- a/modules/opanalytics/swagger/api.yaml
+++ b/modules/opanalytics/swagger/api.yaml
@@ -65,7 +65,8 @@ paths:
       summary: "趋势图（模块C）"
       description: >
         按 day/week 返回消息量、活跃成员、活跃群、活跃私聊和会话类型消息分布。
-        week 以报告时区周一作为 bucket；缺失日期/周补 0。选中 space 时私聊指标返回 0。
+        week 以报告时区周一作为 bucket；部分周的 bucket 仍是周一，前端展示范围请使用
+        start_date/end_date。缺失日期/周补 0。选中 space 时私聊指标返回 0。
       operationId: "m dashboard trend"
       produces:
         - "application/json"
@@ -431,15 +432,15 @@ definitions:
       bucket:
         type: string
         format: date
-        description: "bucket 起点；day=当天，week=报告时区周一"
+        description: "bucket 起点；day=当天，week=报告时区周一。部分周展示请使用 start_date/end_date"
       start_date:
         type: string
         format: date
-        description: "该 bucket 在请求范围内的起始日期"
+        description: "该 bucket 在请求范围内的起始日期；部分周会裁剪到请求 start_date"
       end_date:
         type: string
         format: date
-        description: "该 bucket 在请求范围内的结束日期"
+        description: "该 bucket 在请求范围内的结束日期；部分周会裁剪到请求 end_date"
       human_msg_count:
         type: integer
         format: int64


### PR DESCRIPTION
## Summary
- add fixed conv_type order assertions for overview composition and trend conv_type buckets
- add partial-week trend coverage for clipped start_date/end_date while preserving Monday bucket
- defensively strip private conv_type 3/4 metrics from space-filtered overview/trend results in service code
- document trusted SQL fragment inputs and clarify partial-week Swagger semantics

## Tests
- go test ./modules/opanalytics -run TestOpanalyticsTrendEndpoint -count=1
- go test ./modules/opanalytics/...
- go vet ./modules/opanalytics/...
- git diff --check

Closes #319
