### PR TITLE
feat(opanalytics): complete P1 dashboard queries

### DIFF
--- a/modules/opanalytics/api.go
+++ b/modules/opanalytics/api.go
@@ -205,7 +205,7 @@ func (m *Manager) channelMembers(c *wkhttp.Context) {
 	}
 	pageIndex, pageSize := clampPage(c.GetPage())
 	resp, err := m.service.channelMemberList(
-		channelID, start, end, memberTypes, c.Query("keyword"),
+		channelID, start, end, memberTypes, memberKeywordQuery(c),
 		c.Query("sort_by"), c.Query("order"), (pageIndex-1)*pageSize, pageSize)
 	if err != nil {
 		m.Error("channel member list query failed", zap.Error(err))
@@ -398,6 +398,13 @@ func queryListValues(c *wkhttp.Context, names []string) []string {
 		}
 	}
 	return out
+}
+
+func memberKeywordQuery(c *wkhttp.Context) string {
+	if keyword := strings.TrimSpace(c.Query("member_keyword")); keyword != "" {
+		return keyword
+	}
+	return c.Query("keyword")
 }
 
 // normalizeActiveStatus 收敛为 all/active/inactive。

--- a/modules/opanalytics/api.go
+++ b/modules/opanalytics/api.go
@@ -2,6 +2,8 @@ package opanalytics
 
 import (
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -58,8 +60,9 @@ func (m *Manager) Route(r *wkhttp.WKHttp) {
 		auth.GET("/trend", m.trend)                             // 模块C 趋势
 		auth.GET("/spaces", m.spaces)                           // 表一 Space 列表
 		auth.GET("/spaces/:space_id/channels", m.spaceChannels) // 表二 群组列表(仅群组)
-		auth.GET("/global/direct-chats", m.globalDirectChats)   // 全局私聊活跃列表
-		auth.POST("/etl/run", m.runETL)                         // 手动触发增量 ETL
+		auth.GET("/channels/:channel_id/members", m.channelMembers)
+		auth.GET("/global/direct-chats", m.globalDirectChats) // 全局私聊活跃列表
+		auth.POST("/etl/run", m.runETL)                       // 手动触发增量 ETL
 	}
 }
 
@@ -153,9 +156,14 @@ func (m *Manager) spaceChannels(c *wkhttp.Context) {
 		respRequestInvalid(c, "date_range")
 		return
 	}
+	convTypes, ok := parseConvTypes(c)
+	if !ok {
+		respRequestInvalid(c, "conv_types")
+		return
+	}
 	pageIndex, pageSize := clampPage(c.GetPage())
 	list, total, err := m.service.channelList(
-		spaceID, start, end, normalizeActiveStatus(c.Query("active_status")),
+		spaceID, start, end, normalizeActiveStatus(c.Query("active_status")), convTypes, c.Query("member_keyword"),
 		c.Query("sort_by"), c.Query("order"), (pageIndex-1)*pageSize, pageSize)
 	if err != nil {
 		m.Error("channel list query failed", zap.Error(err))
@@ -163,6 +171,48 @@ func (m *Manager) spaceChannels(c *wkhttp.Context) {
 		return
 	}
 	c.Response(map[string]interface{}{"count": total, "list": list})
+}
+
+// channelMembers 表三子表A：会话内成员消息统计汇总。
+func (m *Manager) channelMembers(c *wkhttp.Context) {
+	if !m.requireSuperAdmin(c) {
+		return
+	}
+	channelID := c.Param("channel_id")
+	if channelID == "" {
+		respRequestInvalid(c, "channel_id")
+		return
+	}
+	exists, err := m.service.groupChannelExists(channelID)
+	if err != nil {
+		m.Error("channel exists check failed", zap.Error(err))
+		respQueryFailed(c)
+		return
+	}
+	if !exists {
+		respNotFound(c)
+		return
+	}
+	start, end, ok := parseDateRange(c)
+	if !ok {
+		respRequestInvalid(c, "date_range")
+		return
+	}
+	memberTypes, ok := parseMemberTypes(c)
+	if !ok {
+		respRequestInvalid(c, "member_types")
+		return
+	}
+	pageIndex, pageSize := clampPage(c.GetPage())
+	resp, err := m.service.channelMemberList(
+		channelID, start, end, memberTypes, c.Query("keyword"),
+		c.Query("sort_by"), c.Query("order"), (pageIndex-1)*pageSize, pageSize)
+	if err != nil {
+		m.Error("channel member list query failed", zap.Error(err))
+		respQueryFailed(c)
+		return
+	}
+	c.Response(resp)
 }
 
 // globalDirectChats 全局私聊活跃列表(无活跃状态筛选；私聊恒活跃集)。
@@ -177,7 +227,7 @@ func (m *Manager) globalDirectChats(c *wkhttp.Context) {
 	}
 	pageIndex, pageSize := clampPage(c.GetPage())
 	list, total, err := m.service.directChatList(
-		start, end, c.Query("sort_by"), c.Query("order"), (pageIndex-1)*pageSize, pageSize)
+		start, end, c.Query("member_keyword"), c.Query("sort_by"), c.Query("order"), (pageIndex-1)*pageSize, pageSize)
 	if err != nil {
 		m.Error("direct chat list query failed", zap.Error(err))
 		respQueryFailed(c)
@@ -271,6 +321,81 @@ func parseSpaceIDs(c *wkhttp.Context) []string {
 		}
 		seen[id] = struct{}{}
 		out = append(out, id)
+	}
+	return out
+}
+
+func parseConvTypes(c *wkhttp.Context) ([]uint8, bool) {
+	return parseUint8QueryList(c, []string{"conv_types", "conv_types[]"}, map[uint8]struct{}{
+		convTypeHHGroup:   {},
+		convTypeHAGroup:   {},
+		convTypeHHPrivate: {},
+		convTypeHAPrivate: {},
+	})
+}
+
+func parseMemberTypes(c *wkhttp.Context) ([]uint8, bool) {
+	values := queryListValues(c, []string{"member_types", "member_types[]"})
+	if len(values) == 0 {
+		return nil, true
+	}
+	seen := map[uint8]struct{}{}
+	out := make([]uint8, 0, len(values))
+	for _, v := range values {
+		var t uint8
+		switch strings.ToLower(v) {
+		case "1", "human":
+			t = memberTypeHuman
+		case "2", "agent":
+			t = memberTypeAgent
+		default:
+			return nil, false
+		}
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	return out, true
+}
+
+func parseUint8QueryList(c *wkhttp.Context, names []string, allowed map[uint8]struct{}) ([]uint8, bool) {
+	values := queryListValues(c, names)
+	if len(values) == 0 {
+		return nil, true
+	}
+	seen := map[uint8]struct{}{}
+	out := make([]uint8, 0, len(values))
+	for _, v := range values {
+		n, err := strconv.ParseUint(v, 10, 8)
+		if err != nil {
+			return nil, false
+		}
+		u := uint8(n)
+		if _, ok := allowed[u]; !ok {
+			return nil, false
+		}
+		if _, ok := seen[u]; ok {
+			continue
+		}
+		seen[u] = struct{}{}
+		out = append(out, u)
+	}
+	return out, true
+}
+
+func queryListValues(c *wkhttp.Context, names []string) []string {
+	out := make([]string, 0)
+	for _, name := range names {
+		for _, raw := range c.QueryArray(name) {
+			for _, part := range strings.Split(raw, ",") {
+				part = strings.TrimSpace(part)
+				if part != "" {
+					out = append(out, part)
+				}
+			}
+		}
 	}
 	return out
 }

--- a/modules/opanalytics/api_test.go
+++ b/modules/opanalytics/api_test.go
@@ -689,8 +689,6 @@ func TestOpanalyticsChannelMembersEndpoint(t *testing.T) {
 		MemberUID     string  `json:"member_uid"`
 		Name          string  `json:"name"`
 		Email         string  `json:"email"`
-		Phone         string  `json:"phone"`
-		Zone          string  `json:"zone"`
 		MemberType    uint8   `json:"member_type"`
 		TotalMsgCount int64   `json:"total_msg_count"`
 		Percentage    float64 `json:"percentage"`
@@ -714,6 +712,15 @@ func TestOpanalyticsChannelMembersEndpoint(t *testing.T) {
 	assert.Equal(t, int64(5), resp.List[0].TotalMsgCount)
 	assert.InEpsilon(t, 0.5, resp.List[0].Percentage, 0.0001)
 
+	rawRec := opaGet(t, route, "/v1/manager/dashboard/channels/g1/members?start_date="+statDay+"&end_date="+statDay)
+	var raw struct {
+		List []map[string]interface{} `json:"list"`
+	}
+	decodeOK(t, rawRec, &raw)
+	require.NotEmpty(t, raw.List)
+	assert.NotContains(t, raw.List[0], "phone")
+	assert.NotContains(t, raw.List[0], "zone")
+
 	byUID := make(map[string]memberItem, len(resp.List))
 	for _, item := range resp.List {
 		byUID[item.MemberUID] = item
@@ -735,6 +742,11 @@ func TestOpanalyticsChannelMembersEndpoint(t *testing.T) {
 	assert.Equal(t, int64(1), alice.Count)
 	require.Len(t, alice.List, 1)
 	assert.Equal(t, "u_alice", alice.List[0].MemberUID)
+
+	aliceByMemberKeyword := getMembers("&member_keyword=alice%40example.com")
+	assert.Equal(t, int64(1), aliceByMemberKeyword.Count)
+	require.Len(t, aliceByMemberKeyword.List, 1)
+	assert.Equal(t, "u_alice", aliceByMemberKeyword.List[0].MemberUID)
 
 	asc := getMembers("&sort_by=percentage&order=asc")
 	require.Len(t, asc.List, 3)

--- a/modules/opanalytics/api_test.go
+++ b/modules/opanalytics/api_test.go
@@ -767,6 +767,58 @@ func TestOpanalyticsChannelMembersEndpoint(t *testing.T) {
 	assert.Equal(t, "err.server.opanalytics.forbidden", errorCode(t, rec))
 }
 
+func TestOpanalyticsChannelMembersKeepEventTimeMessagesForDisabledSender(t *testing.T) {
+	ctx, route, etl := opaSetup(t)
+	seedScenario(t, ctx)
+	require.NoError(t, etl.RunIncremental())
+
+	_, err := ctx.DB().Exec("UPDATE `user` SET status=0 WHERE uid='u_bob'")
+	require.NoError(t, err)
+	require.NoError(t, etl.RunIncremental())
+
+	rng := "?start_date=" + statDay + "&end_date=" + statDay
+	var channels struct {
+		List []channelListItem `json:"list"`
+	}
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/spaces/s1/channels"+rng), &channels)
+	var g1 channelListItem
+	for _, item := range channels.List {
+		if item.ChannelID == "g1" {
+			g1 = item
+			break
+		}
+	}
+	require.Equal(t, "g1", g1.ChannelID)
+	assert.Equal(t, int64(10), g1.HumanMsgCount+g1.AgentMsgCount)
+
+	var members struct {
+		Count         int64 `json:"count"`
+		TotalMsgCount int64 `json:"total_msg_count"`
+		List          []struct {
+			MemberUID     string  `json:"member_uid"`
+			TotalMsgCount int64   `json:"total_msg_count"`
+			Percentage    float64 `json:"percentage"`
+		} `json:"list"`
+	}
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/channels/g1/members"+rng), &members)
+	assert.Equal(t, int64(3), members.Count)
+	assert.Equal(t, int64(10), members.TotalMsgCount)
+
+	byUID := make(map[string]struct {
+		TotalMsgCount int64
+		Percentage    float64
+	}, len(members.List))
+	for _, item := range members.List {
+		byUID[item.MemberUID] = struct {
+			TotalMsgCount int64
+			Percentage    float64
+		}{TotalMsgCount: item.TotalMsgCount, Percentage: item.Percentage}
+	}
+	require.Contains(t, byUID, "u_bob")
+	assert.Equal(t, int64(2), byUID["u_bob"].TotalMsgCount)
+	assert.InEpsilon(t, 0.2, byUID["u_bob"].Percentage, 0.0001)
+}
+
 func TestOpanalyticsTrendEndpoint(t *testing.T) {
 	ctx, route, etl := opaSetup(t)
 	seedScenario(t, ctx)

--- a/modules/opanalytics/api_test.go
+++ b/modules/opanalytics/api_test.go
@@ -817,6 +817,27 @@ func TestOpanalyticsChannelMembersKeepEventTimeMessagesForDisabledSender(t *test
 	require.Contains(t, byUID, "u_bob")
 	assert.Equal(t, int64(2), byUID["u_bob"].TotalMsgCount)
 	assert.InEpsilon(t, 0.2, byUID["u_bob"].Percentage, 0.0001)
+
+	_, err = ctx.DB().Exec("DELETE FROM `user` WHERE uid='u_alice'")
+	require.NoError(t, err)
+	require.NoError(t, etl.RunIncremental())
+
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/channels/g1/members"+rng), &members)
+	assert.Equal(t, int64(3), members.Count)
+	assert.Equal(t, int64(10), members.TotalMsgCount)
+	byUID = make(map[string]struct {
+		TotalMsgCount int64
+		Percentage    float64
+	}, len(members.List))
+	for _, item := range members.List {
+		byUID[item.MemberUID] = struct {
+			TotalMsgCount int64
+			Percentage    float64
+		}{TotalMsgCount: item.TotalMsgCount, Percentage: item.Percentage}
+	}
+	require.Contains(t, byUID, "u_alice")
+	assert.Equal(t, int64(3), byUID["u_alice"].TotalMsgCount)
+	assert.InEpsilon(t, 0.3, byUID["u_alice"].Percentage, 0.0001)
 }
 
 func TestOpanalyticsTrendEndpoint(t *testing.T) {

--- a/modules/opanalytics/api_test.go
+++ b/modules/opanalytics/api_test.go
@@ -309,6 +309,19 @@ func seedScenario(t *testing.T, ctx *config.Context) string {
 	return fc
 }
 
+func seedS1HumanGroup(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	seedUser(t, ctx, "u_dave", "Dave", "dave@example.com", 0)
+	seedSpaceMember(t, ctx, "s1", "u_dave")
+	seedGroup(t, ctx, "g3", "Human Group", "s1")
+	seedGroupMember(t, ctx, "g3", "u_alice", 0)
+	seedGroupMember(t, ctx, "g3", "u_dave", 0)
+
+	start, _, err := dayWindowUnix(statDay)
+	require.NoError(t, err)
+	insertMsgs(t, ctx, "u_dave", "g3", channelTypeGroup, start+5400, 1, 0)
+}
+
 // ---- tests ----
 
 func TestOpanalyticsETLAndDB(t *testing.T) {
@@ -611,6 +624,127 @@ func TestOpanalyticsEndpoints(t *testing.T) {
 	// ---- 非 superAdmin → 403 ----
 	setPlainUserToken(t, ctx)
 	rec = opaGet(t, route, "/v1/manager/dashboard/overview"+rng)
+	assert.Equal(t, "err.server.opanalytics.forbidden", errorCode(t, rec))
+}
+
+func TestOpanalyticsChannelListP1Filters(t *testing.T) {
+	ctx, route, etl := opaSetup(t)
+	seedScenario(t, ctx)
+	seedS1HumanGroup(t, ctx)
+	require.NoError(t, etl.RunIncremental())
+
+	rng := "?start_date=" + statDay + "&end_date=" + statDay
+	channelsOf := func(query string) []channelListItem {
+		var resp struct {
+			Count int64             `json:"count"`
+			List  []channelListItem `json:"list"`
+		}
+		decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/spaces/s1/channels"+rng+query), &resp)
+		require.Equal(t, int64(len(resp.List)), resp.Count)
+		return resp.List
+	}
+
+	all := channelsOf("")
+	require.Len(t, all, 2)
+
+	hhOnly := channelsOf("&conv_types=1")
+	require.Len(t, hhOnly, 1)
+	assert.Equal(t, "g3", hhOnly[0].ChannelID)
+	assert.Equal(t, convTypeHHGroup, hhOnly[0].ConvType)
+
+	haOnly := channelsOf("&conv_types[]=2")
+	require.Len(t, haOnly, 1)
+	assert.Equal(t, "g1", haOnly[0].ChannelID)
+	assert.Equal(t, convTypeHAGroup, haOnly[0].ConvType)
+
+	agentMember := channelsOf("&member_keyword=AgentX")
+	require.Len(t, agentMember, 1)
+	assert.Equal(t, "g1", agentMember[0].ChannelID)
+
+	daveEmail := channelsOf("&member_keyword=dave%40example.com")
+	require.Len(t, daveEmail, 1)
+	assert.Equal(t, "g3", daveEmail[0].ChannelID)
+
+	rec := opaGet(t, route, "/v1/manager/dashboard/spaces/s1/channels"+rng+"&conv_types=bad")
+	assert.Equal(t, "err.server.opanalytics.request_invalid", errorCode(t, rec))
+
+	var direct struct {
+		Count int64            `json:"count"`
+		List  []directChatItem `json:"list"`
+	}
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/global/direct-chats"+rng+"&member_keyword=alice%40example.com"), &direct)
+	assert.Equal(t, int64(1), direct.Count)
+	require.Len(t, direct.List, 1)
+	decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/global/direct-chats"+rng+"&member_keyword=AgentX"), &direct)
+	assert.Zero(t, direct.Count, "direct chat member_keyword only matches its two participants")
+	assert.Empty(t, direct.List)
+}
+
+func TestOpanalyticsChannelMembersEndpoint(t *testing.T) {
+	ctx, route, etl := opaSetup(t)
+	seedScenario(t, ctx)
+	require.NoError(t, etl.RunIncremental())
+
+	type memberItem struct {
+		MemberUID     string  `json:"member_uid"`
+		Name          string  `json:"name"`
+		Email         string  `json:"email"`
+		Phone         string  `json:"phone"`
+		Zone          string  `json:"zone"`
+		MemberType    uint8   `json:"member_type"`
+		TotalMsgCount int64   `json:"total_msg_count"`
+		Percentage    float64 `json:"percentage"`
+	}
+	type membersResp struct {
+		Count         int64        `json:"count"`
+		TotalMsgCount int64        `json:"total_msg_count"`
+		List          []memberItem `json:"list"`
+	}
+	getMembers := func(query string) membersResp {
+		var resp membersResp
+		decodeOK(t, opaGet(t, route, "/v1/manager/dashboard/channels/g1/members?start_date="+statDay+"&end_date="+statDay+query), &resp)
+		return resp
+	}
+
+	resp := getMembers("")
+	assert.Equal(t, int64(3), resp.Count)
+	assert.Equal(t, int64(10), resp.TotalMsgCount)
+	require.Len(t, resp.List, 3)
+	assert.Equal(t, "u_agent", resp.List[0].MemberUID, "default sort is total_msg_count desc")
+	assert.Equal(t, int64(5), resp.List[0].TotalMsgCount)
+	assert.InEpsilon(t, 0.5, resp.List[0].Percentage, 0.0001)
+
+	byUID := make(map[string]memberItem, len(resp.List))
+	for _, item := range resp.List {
+		byUID[item.MemberUID] = item
+	}
+	assert.Equal(t, int64(3), byUID["u_alice"].TotalMsgCount)
+	assert.Equal(t, "alice@example.com", byUID["u_alice"].Email)
+	assert.InEpsilon(t, 0.3, byUID["u_alice"].Percentage, 0.0001)
+	assert.Equal(t, int64(2), byUID["u_bob"].TotalMsgCount)
+	assert.InEpsilon(t, 0.2, byUID["u_bob"].Percentage, 0.0001)
+
+	humans := getMembers("&member_types=human")
+	assert.Equal(t, int64(2), humans.Count)
+	require.Len(t, humans.List, 2)
+	for _, item := range humans.List {
+		assert.Equal(t, memberTypeHuman, item.MemberType)
+	}
+
+	alice := getMembers("&keyword=alice%40example.com")
+	assert.Equal(t, int64(1), alice.Count)
+	require.Len(t, alice.List, 1)
+	assert.Equal(t, "u_alice", alice.List[0].MemberUID)
+
+	asc := getMembers("&sort_by=percentage&order=asc")
+	require.Len(t, asc.List, 3)
+	assert.Equal(t, "u_bob", asc.List[0].MemberUID)
+
+	rec := opaGet(t, route, "/v1/manager/dashboard/channels/nope/members?start_date="+statDay+"&end_date="+statDay)
+	assert.Equal(t, "err.server.opanalytics.not_found", errorCode(t, rec))
+
+	setPlainUserToken(t, ctx)
+	rec = opaGet(t, route, "/v1/manager/dashboard/channels/g1/members?start_date="+statDay+"&end_date="+statDay)
 	assert.Equal(t, "err.server.opanalytics.forbidden", errorCode(t, rec))
 }
 

--- a/modules/opanalytics/api_test.go
+++ b/modules/opanalytics/api_test.go
@@ -718,6 +718,7 @@ func TestOpanalyticsChannelMembersEndpoint(t *testing.T) {
 	}
 	decodeOK(t, rawRec, &raw)
 	require.NotEmpty(t, raw.List)
+	// NotContains on a map asserts the wire response key is absent, not only zero-valued.
 	assert.NotContains(t, raw.List[0], "phone")
 	assert.NotContains(t, raw.List[0], "zone")
 
@@ -751,6 +752,12 @@ func TestOpanalyticsChannelMembersEndpoint(t *testing.T) {
 	asc := getMembers("&sort_by=percentage&order=asc")
 	require.Len(t, asc.List, 3)
 	assert.Equal(t, "u_bob", asc.List[0].MemberUID)
+
+	page2 := getMembers("&page_size=2&page_index=2")
+	assert.Equal(t, int64(3), page2.Count)
+	assert.Equal(t, int64(10), page2.TotalMsgCount)
+	require.Len(t, page2.List, 1)
+	assert.Equal(t, "u_bob", page2.List[0].MemberUID)
 
 	rec := opaGet(t, route, "/v1/manager/dashboard/channels/nope/members?start_date="+statDay+"&end_date="+statDay)
 	assert.Equal(t, "err.server.opanalytics.not_found", errorCode(t, rec))

--- a/modules/opanalytics/db.go
+++ b/modules/opanalytics/db.go
@@ -517,7 +517,8 @@ func (d *opanalyticsDB) groupChannelExists(channelID string) (bool, error) {
 
 var channelMemberSortColumns = map[string]string{
 	"total_msg_count": "total_msg_count",
-	"percentage":      "total_msg_count",
+	// percentage sorts by the same expression because the denominator is fixed for a channel/date range.
+	"percentage": "total_msg_count",
 }
 
 func (d *opanalyticsDB) queryChannelMemberList(channelID, start, end string, memberTypes []uint8, keyword, sortBy, order string, offset, limit int) ([]*channelMemberListItem, int64, int64, error) {
@@ -561,9 +562,9 @@ func (d *opanalyticsDB) queryChannelMemberList(channelID, start, end string, mem
 		return []*channelMemberListItem{}, 0, totalMsg, nil
 	}
 
-	sel := "SELECT f.sender_uid AS member_uid, m.name, m.email, m.phone, m.zone, m.member_type, " +
+	sel := "SELECT f.sender_uid AS member_uid, m.name, m.email, m.member_type, " +
 		"SUM(f.msg_count) AS total_msg_count " + base +
-		fmt.Sprintf(" GROUP BY f.sender_uid, m.name, m.email, m.phone, m.zone, m.member_type ORDER BY %s %s, f.sender_uid ASC LIMIT ? OFFSET ?", sortExpr, dir)
+		fmt.Sprintf(" GROUP BY f.sender_uid, m.name, m.email, m.member_type ORDER BY %s %s, f.sender_uid ASC LIMIT ? OFFSET ?", sortExpr, dir)
 	listArgs := append(append([]interface{}{}, args...), limit, offset)
 
 	var rows []*channelMemberListItem

--- a/modules/opanalytics/db.go
+++ b/modules/opanalytics/db.go
@@ -415,7 +415,7 @@ var channelSortColumns = map[string]string{
 }
 
 // queryChannelList 表二群组列表(仅 channel_type=2)。activeStatus ∈ {all,active,inactive}。
-func (d *opanalyticsDB) queryChannelList(spaceID, start, end, activeStatus, sortBy, order string, offset, limit int) ([]*channelListItem, int64, error) {
+func (d *opanalyticsDB) queryChannelList(spaceID, start, end, activeStatus string, convTypes []uint8, memberKeyword, sortBy, order string, offset, limit int) ([]*channelListItem, int64, error) {
 	sortExpr, ok := channelSortColumns[sortBy]
 	if !ok {
 		sortExpr = "c.last_active_at"
@@ -434,11 +434,13 @@ func (d *opanalyticsDB) queryChannelList(spaceID, start, end, activeStatus, sort
 		"FROM octo_fact_channel_daily WHERE stat_date BETWEEN ? AND ? AND space_id=? AND channel_type=2 " +
 		"GROUP BY channel_id) f ON f.channel_id=c.channel_id " +
 		"WHERE c.space_id=? AND c.channel_type=2" + activeCond
+	args := []interface{}{start, end, spaceID, spaceID}
+	base = applyUint8FilterSQL(base, &args, "c.conv_type", convTypes)
+	base = applyChannelMemberKeywordSQL(base, &args, memberKeyword)
 
 	// 计数
 	var total int64
-	cntArgs := []interface{}{start, end, spaceID, spaceID}
-	_, err := d.session.SelectBySql("SELECT COUNT(*) "+base, cntArgs...).Load(&total)
+	_, err := d.session.SelectBySql("SELECT COUNT(*) "+base, args...).Load(&total)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -450,7 +452,7 @@ func (d *opanalyticsDB) queryChannelList(spaceID, start, end, activeStatus, sort
 		"c.status, c.last_active_at, IFNULL(f.hm,0) AS human_msg, IFNULL(f.am,0) AS agent_msg, " +
 		"(f.channel_id IS NOT NULL) AS is_active " + base +
 		fmt.Sprintf(" ORDER BY %s %s, c.channel_id ASC LIMIT ? OFFSET ?", sortExpr, dir)
-	listArgs := []interface{}{start, end, spaceID, spaceID, limit, offset}
+	listArgs := append(append([]interface{}{}, args...), limit, offset)
 
 	var rows []struct {
 		ChannelID        string `db:"channel_id"`
@@ -480,12 +482,95 @@ func (d *opanalyticsDB) queryChannelList(spaceID, start, end, activeStatus, sort
 	return out, total, nil
 }
 
+func applyChannelMemberKeywordSQL(base string, args *[]interface{}, keyword string) string {
+	keyword = strings.TrimSpace(keyword)
+	if keyword == "" {
+		return base
+	}
+	like := "%" + escapeLike(keyword) + "%"
+	*args = append(*args, like, like)
+	return base + " AND EXISTS (" +
+		"SELECT 1 FROM group_member gm JOIN octo_dim_member m ON m.uid=gm.uid " +
+		"WHERE gm.group_no=c.channel_id AND gm.status=1 AND gm.is_deleted=0 AND m.is_excluded=0 " +
+		"AND (m.name LIKE ? ESCAPE '!' OR m.email LIKE ? ESCAPE '!'))"
+}
+
 // spaceExists 仅在 Space 存在**且 status=1** 时返回 true：与 /spaces 列表口径一致，
 // 软删除的 Space 视为不存在(表二返回 404，而非 200+数据)。
 func (d *opanalyticsDB) spaceExists(spaceID string) (bool, error) {
 	var n int64
 	_, err := d.session.Select("count(*)").From("space").Where("space_id=? AND status=1", spaceID).Load(&n)
 	return n > 0, err
+}
+
+// groupChannelExists 表三仅开放正常群组；私聊仍走 global/direct-chats。
+func (d *opanalyticsDB) groupChannelExists(channelID string) (bool, error) {
+	var n int64
+	_, err := d.session.SelectBySql(
+		"SELECT COUNT(*) FROM octo_dim_channel c "+
+			"JOIN `group` g ON g.group_no=c.channel_id AND g.status=1 "+
+			"WHERE c.channel_id=? AND c.channel_type=2",
+		channelID,
+	).Load(&n)
+	return n > 0, err
+}
+
+var channelMemberSortColumns = map[string]string{
+	"total_msg_count": "total_msg_count",
+	"percentage":      "total_msg_count",
+}
+
+func (d *opanalyticsDB) queryChannelMemberList(channelID, start, end string, memberTypes []uint8, keyword, sortBy, order string, offset, limit int) ([]*channelMemberListItem, int64, int64, error) {
+	sortExpr, ok := channelMemberSortColumns[sortBy]
+	if !ok {
+		sortExpr = "total_msg_count"
+	}
+	dir := "DESC"
+	if strings.EqualFold(order, "asc") {
+		dir = "ASC"
+	}
+
+	var totalMsg int64
+	_, err := d.session.SelectBySql(
+		"SELECT IFNULL(SUM(f.msg_count),0) FROM octo_fact_member_channel_daily f "+
+			"JOIN octo_dim_member m ON m.uid=f.sender_uid "+
+			"WHERE f.channel_id=? AND f.channel_type=2 AND f.stat_date BETWEEN ? AND ? AND m.is_excluded=0",
+		channelID, start, end,
+	).Load(&totalMsg)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+
+	base := "FROM octo_fact_member_channel_daily f JOIN octo_dim_member m ON m.uid=f.sender_uid " +
+		"WHERE f.channel_id=? AND f.channel_type=2 AND f.stat_date BETWEEN ? AND ? AND m.is_excluded=0"
+	args := []interface{}{channelID, start, end}
+	base = applyUint8FilterSQL(base, &args, "m.member_type", memberTypes)
+	keyword = strings.TrimSpace(keyword)
+	if keyword != "" {
+		like := "%" + escapeLike(keyword) + "%"
+		base += " AND (m.name LIKE ? ESCAPE '!' OR m.email LIKE ? ESCAPE '!')"
+		args = append(args, like, like)
+	}
+
+	var total int64
+	cntSQL := "SELECT COUNT(*) FROM (SELECT f.sender_uid " + base + " GROUP BY f.sender_uid) x"
+	if _, err = d.session.SelectBySql(cntSQL, args...).Load(&total); err != nil {
+		return nil, 0, 0, err
+	}
+	if total == 0 {
+		return []*channelMemberListItem{}, 0, totalMsg, nil
+	}
+
+	sel := "SELECT f.sender_uid AS member_uid, m.name, m.email, m.phone, m.zone, m.member_type, " +
+		"SUM(f.msg_count) AS total_msg_count " + base +
+		fmt.Sprintf(" GROUP BY f.sender_uid, m.name, m.email, m.phone, m.zone, m.member_type ORDER BY %s %s, f.sender_uid ASC LIMIT ? OFFSET ?", sortExpr, dir)
+	listArgs := append(append([]interface{}{}, args...), limit, offset)
+
+	var rows []*channelMemberListItem
+	if _, err = d.session.SelectBySql(sel, listArgs...).Load(&rows); err != nil {
+		return nil, 0, 0, err
+	}
+	return rows, total, totalMsg, nil
 }
 
 // ===== 全局私聊活跃列表(SQL 侧聚合 + 分页) =====
@@ -495,7 +580,7 @@ var directSortColumns = map[string]string{
 	"last_active": "last_active",
 }
 
-func (d *opanalyticsDB) queryDirectChatList(start, end, sortBy, order string, offset, limit int) ([]*directChatItem, int64, error) {
+func (d *opanalyticsDB) queryDirectChatList(start, end, memberKeyword, sortBy, order string, offset, limit int) ([]*directChatItem, int64, error) {
 	sortExpr, ok := directSortColumns[sortBy]
 	if !ok {
 		sortExpr = "last_active"
@@ -505,11 +590,13 @@ func (d *opanalyticsDB) queryDirectChatList(start, end, sortBy, order string, of
 		dir = "ASC"
 	}
 
+	base := "FROM octo_fact_channel_daily f JOIN octo_dim_channel c ON c.channel_id=f.channel_id " +
+		"WHERE f.channel_type=1 AND f.stat_date BETWEEN ? AND ?"
+	args := []interface{}{start, end}
+	base = applyDirectMemberKeywordSQL(base, &args, memberKeyword)
+
 	var total int64
-	_, err := d.session.Select("COUNT(DISTINCT channel_id)").
-		From("octo_fact_channel_daily").
-		Where("channel_type=1 AND stat_date BETWEEN ? AND ?", start, end).
-		Load(&total)
+	_, err := d.session.SelectBySql("SELECT COUNT(DISTINCT f.channel_id) "+base, args...).Load(&total)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -519,10 +606,10 @@ func (d *opanalyticsDB) queryDirectChatList(start, end, sortBy, order string, of
 
 	sel := "SELECT f.channel_id AS channel_id, c.member_a_uid AS member_a_uid, c.member_b_uid AS member_b_uid, " +
 		"c.conv_type AS conv_type, SUM(f.human_msg_count + f.agent_msg_count) AS msg_count, MAX(f.last_msg_at) AS last_active " +
-		"FROM octo_fact_channel_daily f JOIN octo_dim_channel c ON c.channel_id=f.channel_id " +
-		"WHERE f.channel_type=1 AND f.stat_date BETWEEN ? AND ? " +
+		base + " " +
 		"GROUP BY f.channel_id, c.member_a_uid, c.member_b_uid, c.conv_type " +
 		fmt.Sprintf("ORDER BY %s %s, f.channel_id ASC LIMIT ? OFFSET ?", sortExpr, dir)
+	listArgs := append(append([]interface{}{}, args...), limit, offset)
 
 	var rows []struct {
 		ChannelID  string `db:"channel_id"`
@@ -532,7 +619,7 @@ func (d *opanalyticsDB) queryDirectChatList(start, end, sortBy, order string, of
 		MsgCount   int64  `db:"msg_count"`
 		LastActive int64  `db:"last_active"`
 	}
-	if _, err = d.session.SelectBySql(sel, start, end, limit, offset).Load(&rows); err != nil {
+	if _, err = d.session.SelectBySql(sel, listArgs...).Load(&rows); err != nil {
 		return nil, 0, err
 	}
 
@@ -544,6 +631,19 @@ func (d *opanalyticsDB) queryDirectChatList(start, end, sortBy, order string, of
 		})
 	}
 	return out, total, nil
+}
+
+func applyDirectMemberKeywordSQL(base string, args *[]interface{}, keyword string) string {
+	keyword = strings.TrimSpace(keyword)
+	if keyword == "" {
+		return base
+	}
+	like := "%" + escapeLike(keyword) + "%"
+	*args = append(*args, like, like)
+	return base + " AND EXISTS (" +
+		"SELECT 1 FROM octo_dim_member m " +
+		"WHERE m.uid IN (c.member_a_uid, c.member_b_uid) AND m.is_excluded=0 " +
+		"AND (m.name LIKE ? ESCAPE '!' OR m.email LIKE ? ESCAPE '!'))"
 }
 
 // queryMemberNames 批量取 uid→展示名(用于私聊"A & B"展示)。
@@ -589,6 +689,17 @@ func inClause(col string, vals []string) (string, []interface{}) {
 		args[i] = v
 	}
 	return col + " IN (" + ph + ")", args
+}
+
+func applyUint8FilterSQL(base string, args *[]interface{}, col string, vals []uint8) string {
+	if len(vals) == 0 {
+		return base
+	}
+	ph := strings.TrimSuffix(strings.Repeat("?,", len(vals)), ",")
+	for _, v := range vals {
+		*args = append(*args, v)
+	}
+	return base + " AND " + col + " IN (" + ph + ")"
 }
 
 func applySpaceFilter(stmt *dbr.SelectStmt, spaceIDs []string) *dbr.SelectStmt {

--- a/modules/opanalytics/db.go
+++ b/modules/opanalytics/db.go
@@ -534,22 +534,21 @@ func (d *opanalyticsDB) queryChannelMemberList(channelID, start, end string, mem
 	var totalMsg int64
 	_, err := d.session.SelectBySql(
 		"SELECT IFNULL(SUM(f.msg_count),0) FROM octo_fact_member_channel_daily f "+
-			"JOIN octo_dim_member m ON m.uid=f.sender_uid "+
-			"WHERE f.channel_id=? AND f.channel_type=2 AND f.stat_date BETWEEN ? AND ? AND m.is_excluded=0",
+			"WHERE f.channel_id=? AND f.channel_type=2 AND f.stat_date BETWEEN ? AND ?",
 		channelID, start, end,
 	).Load(&totalMsg)
 	if err != nil {
 		return nil, 0, 0, err
 	}
 
-	base := "FROM octo_fact_member_channel_daily f JOIN octo_dim_member m ON m.uid=f.sender_uid " +
-		"WHERE f.channel_id=? AND f.channel_type=2 AND f.stat_date BETWEEN ? AND ? AND m.is_excluded=0"
+	base := "FROM octo_fact_member_channel_daily f LEFT JOIN octo_dim_member m ON m.uid=f.sender_uid " +
+		"WHERE f.channel_id=? AND f.channel_type=2 AND f.stat_date BETWEEN ? AND ?"
 	args := []interface{}{channelID, start, end}
-	base = applyUint8FilterSQL(base, &args, "m.member_type", memberTypes)
+	base = applyUint8FilterSQL(base, &args, "COALESCE(m.member_type, f.sender_type)", memberTypes)
 	keyword = strings.TrimSpace(keyword)
 	if keyword != "" {
 		like := "%" + escapeLike(keyword) + "%"
-		base += " AND (m.name LIKE ? ESCAPE '!' OR m.email LIKE ? ESCAPE '!')"
+		base += " AND (COALESCE(m.name,'') LIKE ? ESCAPE '!' OR COALESCE(m.email,'') LIKE ? ESCAPE '!')"
 		args = append(args, like, like)
 	}
 
@@ -562,9 +561,10 @@ func (d *opanalyticsDB) queryChannelMemberList(channelID, start, end string, mem
 		return []*channelMemberListItem{}, 0, totalMsg, nil
 	}
 
-	sel := "SELECT f.sender_uid AS member_uid, m.name, m.email, m.member_type, " +
+	sel := "SELECT f.sender_uid AS member_uid, COALESCE(m.name,'') AS name, COALESCE(m.email,'') AS email, " +
+		"COALESCE(m.member_type, f.sender_type) AS member_type, " +
 		"SUM(f.msg_count) AS total_msg_count " + base +
-		fmt.Sprintf(" GROUP BY f.sender_uid, m.name, m.email, m.member_type ORDER BY %s %s, f.sender_uid ASC LIMIT ? OFFSET ?", sortExpr, dir)
+		fmt.Sprintf(" GROUP BY f.sender_uid, COALESCE(m.name,''), COALESCE(m.email,''), COALESCE(m.member_type, f.sender_type) ORDER BY %s %s, f.sender_uid ASC LIMIT ? OFFSET ?", sortExpr, dir)
 	listArgs := append(append([]interface{}{}, args...), limit, offset)
 
 	var rows []*channelMemberListItem

--- a/modules/opanalytics/model.go
+++ b/modules/opanalytics/model.go
@@ -153,6 +153,24 @@ type channelListItem struct {
 	IsActive         bool   `json:"is_active"`
 }
 
+// channelMemberListResp 表三子表A：会话内成员消息统计汇总。
+type channelMemberListResp struct {
+	Count         int64                    `json:"count"`
+	TotalMsgCount int64                    `json:"total_msg_count"`
+	List          []*channelMemberListItem `json:"list"`
+}
+
+type channelMemberListItem struct {
+	MemberUID     string  `json:"member_uid"`
+	Name          string  `json:"name"`
+	Email         string  `json:"email"`
+	Phone         string  `json:"phone"`
+	Zone          string  `json:"zone"`
+	MemberType    uint8   `json:"member_type"`
+	TotalMsgCount int64   `json:"total_msg_count"`
+	Percentage    float64 `json:"percentage"`
+}
+
 // directChatItem 全局私聊活跃列表行(口径2：私聊走独立全局列表)。
 type directChatItem struct {
 	ChannelID   string `json:"channel_id"`

--- a/modules/opanalytics/model.go
+++ b/modules/opanalytics/model.go
@@ -161,13 +161,11 @@ type channelMemberListResp struct {
 }
 
 type channelMemberListItem struct {
-	MemberUID     string  `json:"member_uid"`
-	Name          string  `json:"name"`
-	Email         string  `json:"email"`
-	Phone         string  `json:"phone"`
-	Zone          string  `json:"zone"`
-	MemberType    uint8   `json:"member_type"`
-	TotalMsgCount int64   `json:"total_msg_count"`
+	MemberUID     string  `db:"member_uid" json:"member_uid"`
+	Name          string  `db:"name" json:"name"`
+	Email         string  `db:"email" json:"email"`
+	MemberType    uint8   `db:"member_type" json:"member_type"`
+	TotalMsgCount int64   `db:"total_msg_count" json:"total_msg_count"`
 	Percentage    float64 `json:"percentage"`
 }
 

--- a/modules/opanalytics/service.go
+++ b/modules/opanalytics/service.go
@@ -325,8 +325,8 @@ func mondayOf(d time.Time) time.Time {
 }
 
 // channelList 表二(仅群组)：SQL 侧 LEFT JOIN + 分页。
-func (s *service) channelList(spaceID, start, end, activeStatus, sortBy, order string, offset, limit int) ([]*channelListItem, int64, error) {
-	return s.db.queryChannelList(spaceID, start, end, activeStatus, sortBy, order, offset, limit)
+func (s *service) channelList(spaceID, start, end, activeStatus string, convTypes []uint8, memberKeyword, sortBy, order string, offset, limit int) ([]*channelListItem, int64, error) {
+	return s.db.queryChannelList(spaceID, start, end, activeStatus, convTypes, memberKeyword, sortBy, order, offset, limit)
 }
 
 // spaceExists 判断 Space 是否存在(用于表二 404)。
@@ -334,9 +334,28 @@ func (s *service) spaceExists(spaceID string) (bool, error) {
 	return s.db.spaceExists(spaceID)
 }
 
+// groupChannelExists 判断表三会话是否存在且仍是正常群组。
+func (s *service) groupChannelExists(channelID string) (bool, error) {
+	return s.db.groupChannelExists(channelID)
+}
+
+// channelMemberList 表三子表A：会话内成员消息统计汇总。
+func (s *service) channelMemberList(channelID, start, end string, memberTypes []uint8, keyword, sortBy, order string, offset, limit int) (*channelMemberListResp, error) {
+	items, total, totalMsg, err := s.db.queryChannelMemberList(channelID, start, end, memberTypes, keyword, sortBy, order, offset, limit)
+	if err != nil {
+		return nil, err
+	}
+	if totalMsg > 0 {
+		for _, item := range items {
+			item.Percentage = float64(item.TotalMsgCount) / float64(totalMsg)
+		}
+	}
+	return &channelMemberListResp{Count: total, TotalMsgCount: totalMsg, List: items}, nil
+}
+
 // directChatList 全局私聊活跃列表 + 解析双方展示名。
-func (s *service) directChatList(start, end, sortBy, order string, offset, limit int) ([]*directChatItem, int64, error) {
-	items, total, err := s.db.queryDirectChatList(start, end, sortBy, order, offset, limit)
+func (s *service) directChatList(start, end, memberKeyword, sortBy, order string, offset, limit int) ([]*directChatItem, int64, error) {
+	items, total, err := s.db.queryDirectChatList(start, end, memberKeyword, sortBy, order, offset, limit)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/modules/opanalytics/swagger/api.yaml
+++ b/modules/opanalytics/swagger/api.yaml
@@ -276,7 +276,8 @@ paths:
       description: >
         指定正常群组的成员消息统计汇总视图。列表只包含所选时间范围内发过消息的成员；
         percentage = 该成员 total_msg_count / 本会话 total_msg_count，取值范围 0..1。
-        成员类型按当前 octo_dim_member 口径；成员搜索仅匹配 name/email，手机号搜索属于 P2。
+        消息量沿用 event-time 口径，保留禁用/注销用户历史消息；成员类型优先按当前 octo_dim_member，缺失时回退事实表 sender_type。
+        成员搜索仅匹配当前维表 name/email，手机号搜索属于 P2。
         响应不返回 phone/zone，避免在运营分析接口新增手机号/区号暴露面。
       operationId: "m dashboard channel members"
       produces:

--- a/modules/opanalytics/swagger/api.yaml
+++ b/modules/opanalytics/swagger/api.yaml
@@ -277,6 +277,7 @@ paths:
         指定正常群组的成员消息统计汇总视图。列表只包含所选时间范围内发过消息的成员；
         percentage = 该成员 total_msg_count / 本会话 total_msg_count，取值范围 0..1。
         成员类型按当前 octo_dim_member 口径；成员搜索仅匹配 name/email，手机号搜索属于 P2。
+        响应不返回 phone/zone，避免在运营分析接口新增手机号/区号暴露面。
       operationId: "m dashboard channel members"
       produces:
         - "application/json"
@@ -308,9 +309,14 @@ paths:
           description: "成员类型筛选；支持 human/agent 或 1/2，多值用 member_types=human&member_types=agent"
           required: false
         - in: "query"
-          name: "keyword"
+          name: "member_keyword"
           type: string
           description: "成员名称/邮箱模糊匹配（% _ 作字面量处理）；P1 不含手机号搜索"
+          required: false
+        - in: "query"
+          name: "keyword"
+          type: string
+          description: "兼容别名；新调用请使用 member_keyword"
           required: false
         - in: "query"
           name: "sort_by"
@@ -687,7 +693,7 @@ definitions:
       total_msg_count:
         type: integer
         format: int64
-        description: "该会话所选时间范围内总消息数（不受 member_types/keyword 筛选影响）"
+        description: "该会话所选时间范围内总消息数（不受 member_types/member_keyword 筛选影响）"
       list:
         type: array
         items:
@@ -701,11 +707,6 @@ definitions:
       name:
         type: string
       email:
-        type: string
-      phone:
-        type: string
-        description: "仅返回展示字段；P1 查询不按手机号筛选"
-      zone:
         type: string
       member_type:
         type: integer

--- a/modules/opanalytics/swagger/api.yaml
+++ b/modules/opanalytics/swagger/api.yaml
@@ -223,7 +223,7 @@ paths:
             type: integer
             enum: [1, 2, 3, 4]
           collectionFormat: multi
-          description: "会话类型筛选；多值用 conv_types=1&conv_types=2，也兼容 conv_types[]=1。表二仅展示群组，3/4 会返回空集合"
+          description: "会话类型筛选；多值用 conv_types=1&conv_types=2，也兼容 conv_types[]=1 和 conv_types=1,2。表二仅展示群组，3/4 会返回空集合"
           required: false
         - in: "query"
           name: "member_keyword"
@@ -306,7 +306,7 @@ paths:
             type: string
             enum: ["human", "agent", "1", "2"]
           collectionFormat: multi
-          description: "成员类型筛选；支持 human/agent 或 1/2，多值用 member_types=human&member_types=agent"
+          description: "成员类型筛选；支持 human/agent 或 1/2，多值用 member_types=human&member_types=agent，也兼容 member_types=human,agent"
           required: false
         - in: "query"
           name: "member_keyword"

--- a/modules/opanalytics/swagger/api.yaml
+++ b/modules/opanalytics/swagger/api.yaml
@@ -217,6 +217,20 @@ paths:
           description: "活跃状态筛选"
           required: false
         - in: "query"
+          name: "conv_types"
+          type: array
+          items:
+            type: integer
+            enum: [1, 2, 3, 4]
+          collectionFormat: multi
+          description: "会话类型筛选；多值用 conv_types=1&conv_types=2，也兼容 conv_types[]=1。表二仅展示群组，3/4 会返回空集合"
+          required: false
+        - in: "query"
+          name: "member_keyword"
+          type: string
+          description: "成员名称/邮箱模糊匹配（% _ 作字面量处理）；P1 不含手机号搜索"
+          required: false
+        - in: "query"
           name: "sort_by"
           type: string
           enum: ["last_active", "human_msg_count", "agent_msg_count", "total_msg", "member_count"]
@@ -254,6 +268,88 @@ paths:
       security:
         - token: []
 
+  /manager/dashboard/channels/{channel_id}/members:
+    get:
+      tags:
+        - "opanalyticsManager"
+      summary: "会话成员消息统计（表三子表A汇总）"
+      description: >
+        指定正常群组的成员消息统计汇总视图。列表只包含所选时间范围内发过消息的成员；
+        percentage = 该成员 total_msg_count / 本会话 total_msg_count，取值范围 0..1。
+        成员类型按当前 octo_dim_member 口径；成员搜索仅匹配 name/email，手机号搜索属于 P2。
+      operationId: "m dashboard channel members"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "path"
+          name: "channel_id"
+          type: string
+          description: "群组 channel_id（group_no）；私聊不支持此接口"
+          required: true
+        - in: "query"
+          name: "start_date"
+          type: string
+          format: date
+          description: "起始统计日 YYYY-MM-DD。缺省=近 30 天"
+          required: false
+        - in: "query"
+          name: "end_date"
+          type: string
+          format: date
+          description: "结束统计日 YYYY-MM-DD（含）"
+          required: false
+        - in: "query"
+          name: "member_types"
+          type: array
+          items:
+            type: string
+            enum: ["human", "agent", "1", "2"]
+          collectionFormat: multi
+          description: "成员类型筛选；支持 human/agent 或 1/2，多值用 member_types=human&member_types=agent"
+          required: false
+        - in: "query"
+          name: "keyword"
+          type: string
+          description: "成员名称/邮箱模糊匹配（% _ 作字面量处理）；P1 不含手机号搜索"
+          required: false
+        - in: "query"
+          name: "sort_by"
+          type: string
+          enum: ["total_msg_count", "percentage"]
+          default: "total_msg_count"
+          description: "排序字段（白名单）；percentage 与 total_msg_count 分母相同，排序等价"
+          required: false
+        - in: "query"
+          name: "order"
+          type: string
+          enum: ["asc", "desc"]
+          default: "desc"
+          description: "排序方向"
+          required: false
+        - in: "query"
+          name: "page_index"
+          type: integer
+          default: 1
+          description: "页码（从 1 起，上限 1000000）"
+          required: false
+        - in: "query"
+          name: "page_size"
+          type: integer
+          default: 20
+          description: "每页条数（上限 200）"
+          required: false
+      responses:
+        200:
+          description: "成员消息统计"
+          schema:
+            $ref: "#/definitions/channelMemberListResp"
+        400:
+          description: "错误（error.http_status：404 会话不存在/不是正常群组 / 403 越权 / 400 参数无效 / 500）"
+          schema:
+            $ref: "#/definitions/dashboardError"
+      security:
+        - token: []
+
   /manager/dashboard/global/direct-chats:
     get:
       tags:
@@ -275,6 +371,11 @@ paths:
           type: string
           format: date
           description: "结束统计日 YYYY-MM-DD（含）"
+          required: false
+        - in: "query"
+          name: "member_keyword"
+          type: string
+          description: "私聊双方成员名称/邮箱模糊匹配（% _ 作字面量处理）；P1 不含手机号搜索"
           required: false
         - in: "query"
           name: "sort_by"
@@ -575,6 +676,48 @@ definitions:
       is_active:
         type: boolean
         description: "范围内是否活跃"
+
+  channelMemberListResp:
+    type: object
+    properties:
+      count:
+        type: integer
+        format: int64
+        description: "筛选后的成员统计行数"
+      total_msg_count:
+        type: integer
+        format: int64
+        description: "该会话所选时间范围内总消息数（不受 member_types/keyword 筛选影响）"
+      list:
+        type: array
+        items:
+          $ref: "#/definitions/channelMemberListItem"
+
+  channelMemberListItem:
+    type: object
+    properties:
+      member_uid:
+        type: string
+      name:
+        type: string
+      email:
+        type: string
+      phone:
+        type: string
+        description: "仅返回展示字段；P1 查询不按手机号筛选"
+      zone:
+        type: string
+      member_type:
+        type: integer
+        description: "1=human 2=agent"
+      total_msg_count:
+        type: integer
+        format: int64
+        description: "成员在该会话、该时间范围内发送的消息数"
+      percentage:
+        type: number
+        format: double
+        description: "成员消息占比，0..1"
 
   directChatListResp:
     type: object


### PR DESCRIPTION
Closes #328
Refs #320
Supersedes #327

## Summary
- add Table 2 `conv_types` and `member_keyword` filters for space channel lists
- add `GET /v1/manager/dashboard/channels/{channel_id}/members` for Table 3 subtable A summary
- add member type/name/email filtering, total message count, percentage, sorting, pagination, and Swagger contract
- add member name/email filtering to global direct chats for frontend parity

## Scope Notes
- P1B message/content type classification remains separate; call analytics are not included
- interaction analysis, pair/bitmap facts, CSV export, and phone search remain out of scope
- Table 2 still lists groups only; private chats remain under `/global/direct-chats`

## Verification
- RED: `go test ./modules/opanalytics -run 'TestOpanalytics(ChannelListP1Filters|ChannelMembersEndpoint)$' -count=1` failed after rebuilding the local test DB because `/channels/g1/members` was missing
- `go test ./modules/opanalytics/... -count=1`
- `go vet ./modules/opanalytics/...`
- `go test ./modules/opanalytics -run 'TestOpanalytics(NoLegacyResponseError|RespondHelpers)$' -count=1`
- `git diff --check`

## Operational Notes
- Local MySQL `test` database was rebuilt before the RED run because it still contained the known stale `20191106000001_event_legacy01.sql` migration record.
- No new migration is required; the new endpoint reads existing opanalytics fact/dim tables.
