### PR TITLE
feat(incomingwebhook): GitHub / WeCom platform adapters on push (Phase 3)

### DIFF
--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -4,12 +4,16 @@
 由群主或管理员调用，详见 `api.go`。本文聚焦**推送端点**的请求契约。
 
 ```
-POST /v1/incoming-webhooks/:webhook_id/:token
+POST /v1/incoming-webhooks/:webhook_id/:token            # native（本文主体）
+POST /v1/incoming-webhooks/:webhook_id/:token/github     # GitHub 事件适配器
+POST /v1/incoming-webhooks/:webhook_id/:token/wecom      # 企业微信群机器人格式适配器
 Content-Type: application/json
 ```
 
 鉴权走 URL 内的 token（SHA-256 存储、常量时间比对），无需登录态。所有鉴权失败统一
-返回 401（反枚举），并受多层限流约束。
+返回 401（反枚举），并受多层限流约束。三种形态共享同一条鉴权/限流/群校验链，适配器
+只是 body 解析不同（见下文「平台适配器」）。create/regenerate 响应的 `urls` 字段
+按形态给出全部三个路径。
 
 ## 消息形态
 
@@ -71,6 +75,64 @@ Content-Type: application/json
 - 服务端另有 1MB 的 RichText 硬上限（octo-lib 契约）兜底，但在默认 8KB body cap 下不会
   先触达——它是上调 body cap 后才会成为约束的二级护栏。
 
+## 平台适配器（#297 Phase 3）
+
+适配器把第三方平台的原生格式翻译成上面的 native 消息，鉴权/限流/审计与 native 完全
+一致。适配器消息不支持 `username`/`avatar_url` 覆盖（展示身份固定为 webhook 配置）。
+
+### GitHub
+
+```
+POST /v1/incoming-webhooks/:webhook_id/:token/github
+```
+
+在 GitHub 仓库 **Settings → Webhooks** 把 Payload URL 配成上述地址、Content type 选
+`application/json` 即可。鉴权靠 URL 内 128-bit token（不强制 HMAC；`X-Hub-Signature-256`
+校验留作后续可选项）。
+
+按 `X-GitHub-Event` 渲染为 markdown，当前渲染子集：
+
+| 事件 | 渲染的动作 | 说明 |
+|------|-----------|------|
+| `ping` | — | 返回 200 不发消息（GitHub 创建 webhook 时的连通性测试） |
+| `push` | — | 分支/标签 push、删除、force-push；最多列 5 条提交 |
+| `pull_request` | `opened` / `closed`(含 merged) / `reopened` / `ready_for_review` | `synchronize` 等刷屏动作跳过 |
+| `issues` | `opened` / `closed` / `reopened` | |
+| `issue_comment` | `created` | 评论摘要压成单行、截断 300 rune |
+| `release` | `published` | |
+
+**子集之外的事件/动作返回 200 + `{"skipped":"event"}`**（GitHub 侧显示投递成功、
+不标红；deliveries 里以 `status=3` 可见），缺 `X-GitHub-Event` 头则按 400
+`reason=event` 拒绝。事件里的超长字段（标题/提交信息/评论）服务端截断，GitHub 流量
+不会触发 413。
+
+### 企业微信（WeCom 群机器人格式）
+
+```
+POST /v1/incoming-webhooks/:webhook_id/:token/wecom
+```
+
+接受企业微信「群机器人」的出站消息格式——已配置向企微机器人推送的工具只需**换 URL**
+即可迁移，消息体零改动。成功响应附带 `errcode=0`/`errmsg=ok`（多数企微 SDK 以此判定
+成功）。
+
+| `msgtype` | 处理 |
+|-----------|------|
+| `text` / `markdown` / `markdown_v2` | → 文本消息（客户端按 markdown 渲染）；`mentioned_list`/`mentioned_mobile_list` 降级丢弃 |
+| `news` | 降级 markdown：每篇文章「标题链接 + 描述」一段；`picurl` 丢弃 |
+| `template_card` | 降级 markdown：主标题 + 描述 + 副标题 + 跳转链接；按钮等交互元素丢弃 |
+| `image` / `file` / `voice` 等素材类 | **400 `reason=msg_type`**：base64/media_id 素材无法转存，显式失败优于静默丢弃 |
+
+> 高保真卡片渲染不可行，降级策略经 #297 确认。`content` 超过语义上限（4000 rune）按
+> 既有 413 拒绝——与 GitHub 适配器不同，企微格式的消息体由调用方自行编写，可以修短。
+
+```bash
+# 迁移示例：把企微机器人 URL 换成 octo 即可
+curl -X POST "$BASE/v1/incoming-webhooks/$WEBHOOK_ID/$TOKEN/wecom" \
+  -H 'Content-Type: application/json' \
+  -d '{"msgtype":"markdown","markdown":{"content":"**Build #123** passed"}}'
+```
+
 ## 通用字段与安全
 
 - `username` / `avatar_url`：两种形态通用，服务端裁剪到字节上限（名 64B / 头像 255B）。
@@ -81,10 +143,11 @@ Content-Type: application/json
 
 | 场景 | HTTP | 说明 |
 |------|------|------|
-| 成功 | 200 | `{"status":0,"message_id":<int>}` |
+| 成功 | 200 | `{"status":0,"message_id":<int>}`（wecom 路由额外带 `errcode`/`errmsg`） |
+| 已接收、刻意不投递 | 200 | `{"status":0,"message_id":0,"skipped":"ping"\|"event"}`（仅适配器路由） |
 | 鉴权失败 | 401 | 统一响应，不区分原因（反枚举） |
 | 限流 | 429 | 带 `Retry-After` |
-| 请求非法 | 400 | `details.reason` ∈ `body`/`json`/`content`/`blocks`/`msg_type` |
+| 请求非法 | 400 | `details.reason` ∈ `body`/`json`/`content`/`blocks`/`msg_type`/`event` |
 | 体积过大 | 413 | 超 body cap 或富文本 >1MB |
 | 投递失败 | 502 | 下游发送失败 |
 | 功能停用 | 404 | 全局开关 `incomingwebhook.enabled=0` |
@@ -92,6 +155,11 @@ Content-Type: application/json
 ## 管理端点（群主 / 管理员）
 
 需登录态 + 群管理员权限，路径前缀 `/v1/groups/:group_no/incoming-webhooks`。
+
+创建 / 重置（regenerate）响应除历史的 `url`（native 路径）外，还带 `urls` 对象，
+按推送形态给出全部路径（`native` / `github` / `wecom`，不含 host，由前端拼接）。
+token 仅在这两处出现一次，list 不回显 token、也不回推送 URL。
+
 除创建/列出/更新/删除/重置外，Phase 2 新增两个：
 
 ### 测试推送
@@ -129,10 +197,11 @@ GET /v1/groups/:group_no/incoming-webhooks/:webhook_id/deliveries?limit=50
 }
 ```
 
-- `status`：`1`=成功，`2`=失败。
-- `reason`（失败时）：`body` / `json` / `content` / `blocks` / `msg_type` / `too_large` /
-  `delivery_failed`。
-- `adapter`：`native`（推送端点）/ `test`（测试推送）。
+- `status`：`1`=成功，`2`=失败，`3`=跳过（已接收、刻意不投递：GitHub `ping` / 渲染
+  子集之外的事件，响应 200 但没有消息进群）。
+- `reason`（失败/跳过时）：`body` / `json` / `content` / `blocks` / `msg_type` /
+  `too_large` / `delivery_failed` / `event` / `ping`。
+- `adapter`：`native`（推送端点）/ `test`（测试推送）/ `github` / `wecom`（平台适配器）。
 - `http_status`：返回给调用方的状态码。**迁移前的历史成功行为 `0`（未知）**——不伪造成 200。
 - **不返回调用方 `ip`**：审计表仍存 ip 作排查上下文，但出于隐私不向群管理员下发（review 决定）。
 

--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -106,6 +106,11 @@ POST /v1/incoming-webhooks/:webhook_id/:token/github
 `reason=event` 拒绝。事件里的超长字段（标题/提交信息/评论）服务端截断，GitHub 流量
 不会触发 413。
 
+**body 上限独立于 native**：GitHub 事件 JSON 由平台生成（真实 push/PR 事件普遍
+>8KiB，发送方无法修短），github 路由的请求体上限默认 **1MiB**
+（`DM_INCOMINGWEBHOOK_GITHUB_MAX_BYTES`）；native/wecom 的 body 由调用方编写，
+仍是 8KiB。该读取发生在 token 鉴权 + per-webhook 限流之后，不构成放大面。
+
 ### 企业微信（WeCom 群机器人格式）
 
 ```

--- a/modules/incomingwebhook/adapter.go
+++ b/modules/incomingwebhook/adapter.go
@@ -1,0 +1,106 @@
+package incomingwebhook
+
+// 推送形态适配层（#297 Phase 3）。
+//
+// 三种推送形态共享同一条鉴权 / 限流 / 群校验 / 投递 / 审计流水线（api.go handlePush），
+// 彼此只差「如何把请求 body 翻译成 native 推送请求」这一步：
+//
+//   - native（历史契约）   POST /v1/incoming-webhooks/:webhook_id/:token
+//   - GitHub 事件          POST .../:token/github   （adapter_github.go）
+//   - 企业微信群机器人格式  POST .../:token/wecom    （adapter_wecom.go）
+//
+// 适配器不是新的攻击面：URL token 鉴权、四层限流、群 Normal 校验、payload 白名单
+// 构造（buildPayload / buildRichTextPayload 注入 from.kind=webhook 与服务端 space_id）
+// 全部复用，适配器只产出 pushPayloadReq（content / blocks），不直接触达消息 payload。
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// pushAdapter 描述一种推送形态。
+type pushAdapter struct {
+	// name 写入审计 adapter 列（adapterNative / adapterGitHub / adapterWeCom）。
+	name string
+	// parse 把平台原始 body 翻译成 native 推送请求。三个返回值恰有一个生效：
+	//   - req     非 nil：照常走 msg_type 构造 / 投递；
+	//   - skip    非空：请求合法但刻意不投递（GitHub ping / 渲染子集之外的事件），
+	//     返回 200 并以 auditSkipped 落审计，供管理端 deliveries 观察链路；
+	//   - invalid 非空：解析失败原因码，映射 400 invalid(reason=...) 并落审计。
+	parse func(header http.Header, body []byte) (req *pushPayloadReq, skip string, invalid string)
+	// successExtra 合并进成功 / skip 响应体的平台兼容字段（如企业微信的 errcode /
+	// errmsg），让按平台 SDK 校验响应的既有工具不改代码即可迁移。key 与 native 的
+	// status / message_id 不重叠，纯追加。
+	successExtra map[string]interface{}
+}
+
+var (
+	nativeAdapter = pushAdapter{name: adapterNative, parse: parseNativePush}
+	githubAdapter = pushAdapter{name: adapterGitHub, parse: parseGitHubPush}
+	wecomAdapter  = pushAdapter{
+		name:  adapterWeCom,
+		parse: parseWeComPush,
+		// 企业微信调用方普遍校验 errcode==0，附带平台习惯字段降低迁移摩擦。
+		successExtra: map[string]interface{}{"errcode": 0, "errmsg": "ok"},
+	}
+)
+
+// parseNativePush 是 native 形态的 parse：body 即 pushPayloadReq JSON 本身。
+func parseNativePush(_ http.Header, body []byte) (*pushPayloadReq, string, string) {
+	var req pushPayloadReq
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, "", "json"
+	}
+	return &req, "", ""
+}
+
+// successBody 构造推送成功（或 skip）的 200 响应体；skipped 非空时附带说明字段，
+// 让调用方能区分「已投递」与「已接收但刻意不投递」。
+func successBody(ad pushAdapter, msgID int64, skipped string) map[string]interface{} {
+	body := map[string]interface{}{
+		"status":     0,
+		"message_id": msgID,
+	}
+	if skipped != "" {
+		body["skipped"] = skipped
+	}
+	for k, v := range ad.successExtra {
+		body[k] = v
+	}
+	return body
+}
+
+// ============================================================
+// 渲染文本工具（GitHub / WeCom 适配器共用）
+// ============================================================
+
+// clipRunes 按 rune 数截断并以省略号收尾。平台事件里的标题 / 提交信息 / 评论长度
+// 不受我们控制，渲染前必须钳制——adapter 产出的 content 一旦超过 maxContentRunes
+// 会被 push 路径按 413 拒绝，而平台调用方没有任何手段「修短」一个 GitHub 事件。
+func clipRunes(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max-1]) + "…"
+}
+
+// firstLine 取首行（提交信息惯例：首行即摘要）。
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i]
+	}
+	return strings.TrimSpace(s)
+}
+
+// oneLine 把多行文本压成单行，避免标题 / 评论里的换行破坏 markdown 链接结构。
+func oneLine(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return strings.TrimSpace(s)
+}

--- a/modules/incomingwebhook/adapter.go
+++ b/modules/incomingwebhook/adapter.go
@@ -33,14 +33,20 @@ type pushAdapter struct {
 	// errmsg），让按平台 SDK 校验响应的既有工具不改代码即可迁移。key 与 native 的
 	// status / message_id 不重叠，纯追加。
 	successExtra map[string]interface{}
+	// bodyLimit 该形态的请求体字节上限。native / wecom 的 body 由调用方编写，沿用
+	// 8KiB 的 maxBytes()——上限本就是约束调用方的；github 的 body 是平台生成的事件
+	// JSON，真实 push / PR 事件普遍 >8KiB 且发送方无法修短，必须用更宽的专属上限
+	//（githubMaxBytes，见 adapter_github.go；PR #330 review 阻断项）。
+	bodyLimit func() int
 }
 
 var (
-	nativeAdapter = pushAdapter{name: adapterNative, parse: parseNativePush}
-	githubAdapter = pushAdapter{name: adapterGitHub, parse: parseGitHubPush}
+	nativeAdapter = pushAdapter{name: adapterNative, parse: parseNativePush, bodyLimit: maxBytes}
+	githubAdapter = pushAdapter{name: adapterGitHub, parse: parseGitHubPush, bodyLimit: githubMaxBytes}
 	wecomAdapter  = pushAdapter{
-		name:  adapterWeCom,
-		parse: parseWeComPush,
+		name:      adapterWeCom,
+		parse:     parseWeComPush,
+		bodyLimit: maxBytes,
 		// 企业微信调用方普遍校验 errcode==0，附带平台习惯字段降低迁移摩擦。
 		successExtra: map[string]interface{}{"errcode": 0, "errmsg": "ok"},
 	}

--- a/modules/incomingwebhook/adapter_github.go
+++ b/modules/incomingwebhook/adapter_github.go
@@ -1,0 +1,291 @@
+package incomingwebhook
+
+// GitHub 事件适配器（#297 Phase 3）。
+//
+// 路由：POST /v1/incoming-webhooks/:webhook_id/:token/github
+// 在 GitHub 仓库 Settings → Webhooks 把 Payload URL 配成上述地址、Content type 选
+// application/json 即可，无需任何中间转换层。
+//
+// 鉴权沿用 URL 内的 128-bit token（与 native 一致；经 #297 确认不强制 HMAC——
+// X-Hub-Signature-256 校验留作后续可选项，参考 modules/webhook/hmac.go）。
+//
+// 渲染策略：按 X-GitHub-Event 把常用事件翻译成 markdown 文本（走 native 纯文本路径，
+// 客户端按 markdown 渲染）。刻意只渲染「人关心的」动作子集——例如 pull_request 的
+// synchronize（PR 分支每次 push 都触发）若也进群会刷屏。子集之外的事件 / 动作返回
+// 200 并以 auditSkipped 落审计：GitHub 侧显示绿色投递成功（不会把 webhook 标红），
+// 管理端 deliveries 里 reason=event 可见，两边都不糊弄。
+//
+// 所有 gh* 结构体只声明渲染需要的字段（白名单解析），其余 payload 字段一律忽略。
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// 渲染的提交列表上限：push 事件单次最多带 20 个 commit（GitHub 截断），全列会刷屏。
+const maxRenderedCommits = 5
+
+type ghUser struct {
+	Login string `json:"login"`
+}
+
+type ghRepo struct {
+	FullName string `json:"full_name"`
+	HTMLURL  string `json:"html_url"`
+}
+
+type ghCommit struct {
+	ID      string `json:"id"`
+	Message string `json:"message"`
+	URL     string `json:"url"`
+}
+
+type ghPushEvent struct {
+	Ref        string     `json:"ref"`
+	Created    bool       `json:"created"`
+	Deleted    bool       `json:"deleted"`
+	Forced     bool       `json:"forced"`
+	Commits    []ghCommit `json:"commits"`
+	Repository ghRepo     `json:"repository"`
+	Sender     ghUser     `json:"sender"`
+}
+
+type ghPullRequestEvent struct {
+	Action      string `json:"action"`
+	PullRequest struct {
+		Number  int    `json:"number"`
+		Title   string `json:"title"`
+		HTMLURL string `json:"html_url"`
+		Merged  bool   `json:"merged"`
+	} `json:"pull_request"`
+	Repository ghRepo `json:"repository"`
+	Sender     ghUser `json:"sender"`
+}
+
+type ghIssuesEvent struct {
+	Action string `json:"action"`
+	Issue  struct {
+		Number  int    `json:"number"`
+		Title   string `json:"title"`
+		HTMLURL string `json:"html_url"`
+	} `json:"issue"`
+	Repository ghRepo `json:"repository"`
+	Sender     ghUser `json:"sender"`
+}
+
+type ghIssueCommentEvent struct {
+	Action string `json:"action"`
+	Issue  struct {
+		Number  int    `json:"number"`
+		Title   string `json:"title"`
+		HTMLURL string `json:"html_url"`
+	} `json:"issue"`
+	Comment struct {
+		HTMLURL string `json:"html_url"`
+		Body    string `json:"body"`
+	} `json:"comment"`
+	Repository ghRepo `json:"repository"`
+	Sender     ghUser `json:"sender"`
+}
+
+type ghReleaseEvent struct {
+	Action  string `json:"action"`
+	Release struct {
+		TagName string `json:"tag_name"`
+		Name    string `json:"name"`
+		HTMLURL string `json:"html_url"`
+	} `json:"release"`
+	Repository ghRepo `json:"repository"`
+	Sender     ghUser `json:"sender"`
+}
+
+// parseGitHubPush 把 GitHub webhook 事件翻译成 native 推送请求（pushAdapter.parse）。
+func parseGitHubPush(header http.Header, body []byte) (*pushPayloadReq, string, string) {
+	event := strings.TrimSpace(header.Get("X-GitHub-Event"))
+	if event == "" {
+		// 不带事件头的请求不可能来自 GitHub——按非法请求拒绝而非静默跳过，
+		// 让误把 native 流量打到 /github 后缀的调用方立刻发现配置错误。
+		return nil, "", "event"
+	}
+
+	var content string
+	var err error
+	switch event {
+	case "ping":
+		// GitHub 创建 webhook 时的连通性测试：200 即可，不发消息。
+		return nil, "ping", ""
+	case "push":
+		content, err = renderGitHubPush(body)
+	case "pull_request":
+		content, err = renderGitHubPullRequest(body)
+	case "issues":
+		content, err = renderGitHubIssues(body)
+	case "issue_comment":
+		content, err = renderGitHubIssueComment(body)
+	case "release":
+		content, err = renderGitHubRelease(body)
+	default:
+		// 渲染子集之外的事件类型：通常只是 GitHub 侧订阅范围大于我们渲染的子集，
+		// 调用方无需修复 → 200 + skipped（见文件头注释）。
+		return nil, "event", ""
+	}
+	if err != nil {
+		return nil, "", "json"
+	}
+	if content == "" {
+		// 事件类型支持、但动作不在渲染子集内（synchronize / labeled / ...）：同上 skip。
+		return nil, "event", ""
+	}
+	// 事件体里的标题 / 提交信息长度不受我们控制：钳到语义上限内，绝不让平台流量 413。
+	return &pushPayloadReq{Content: clipRunes(content, maxContentRunes())}, "", ""
+}
+
+func renderGitHubPush(body []byte) (string, error) {
+	var ev ghPushEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return "", err
+	}
+	who := ghLogin(ev.Sender)
+	ref := ghShortRef(ev.Ref)
+	switch {
+	case strings.HasPrefix(ev.Ref, "refs/tags/"):
+		if ev.Deleted {
+			return ghWithRepo(fmt.Sprintf("**%s** deleted tag `%s`", who, ref), ev.Repository), nil
+		}
+		return ghWithRepo(fmt.Sprintf("**%s** pushed tag `%s`", who, ref), ev.Repository), nil
+	case ev.Deleted:
+		return ghWithRepo(fmt.Sprintf("**%s** deleted branch `%s`", who, ref), ev.Repository), nil
+	case ev.Created && len(ev.Commits) == 0:
+		return ghWithRepo(fmt.Sprintf("**%s** created branch `%s`", who, ref), ev.Repository), nil
+	}
+
+	verb := "pushed"
+	if ev.Forced {
+		verb = "force-pushed"
+	}
+	var b strings.Builder
+	b.WriteString(ghWithRepo(
+		fmt.Sprintf("**%s** %s %d commit(s) to `%s`", who, verb, len(ev.Commits), ref),
+		ev.Repository))
+	for i, cm := range ev.Commits {
+		if i == maxRenderedCommits {
+			fmt.Fprintf(&b, "\n- …and %d more", len(ev.Commits)-maxRenderedCommits)
+			break
+		}
+		fmt.Fprintf(&b, "\n- [`%s`](%s) %s", ghShortSHA(cm.ID), cm.URL, clipRunes(firstLine(cm.Message), 120))
+	}
+	return b.String(), nil
+}
+
+func renderGitHubPullRequest(body []byte) (string, error) {
+	var ev ghPullRequestEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return "", err
+	}
+	var verb string
+	switch ev.Action {
+	case "opened", "reopened":
+		verb = ev.Action
+	case "ready_for_review":
+		verb = "marked ready for review:"
+	case "closed":
+		verb = "closed"
+		if ev.PullRequest.Merged {
+			verb = "merged"
+		}
+	default:
+		// synchronize / labeled / review_requested / ... 刷屏动作不渲染 → skip。
+		return "", nil
+	}
+	return ghWithRepo(fmt.Sprintf("**%s** %s pull request [#%d %s](%s)",
+		ghLogin(ev.Sender), verb, ev.PullRequest.Number,
+		clipRunes(oneLine(ev.PullRequest.Title), 200), ev.PullRequest.HTMLURL),
+		ev.Repository), nil
+}
+
+func renderGitHubIssues(body []byte) (string, error) {
+	var ev ghIssuesEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return "", err
+	}
+	switch ev.Action {
+	case "opened", "closed", "reopened":
+	default:
+		return "", nil
+	}
+	return ghWithRepo(fmt.Sprintf("**%s** %s issue [#%d %s](%s)",
+		ghLogin(ev.Sender), ev.Action, ev.Issue.Number,
+		clipRunes(oneLine(ev.Issue.Title), 200), ev.Issue.HTMLURL),
+		ev.Repository), nil
+}
+
+func renderGitHubIssueComment(body []byte) (string, error) {
+	var ev ghIssueCommentEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return "", err
+	}
+	if ev.Action != "created" {
+		return "", nil
+	}
+	line := ghWithRepo(fmt.Sprintf("**%s** commented on [#%d %s](%s)",
+		ghLogin(ev.Sender), ev.Issue.Number,
+		clipRunes(oneLine(ev.Issue.Title), 200), ev.Comment.HTMLURL),
+		ev.Repository)
+	if snippet := clipRunes(oneLine(ev.Comment.Body), 300); snippet != "" {
+		line += "\n> " + snippet
+	}
+	return line, nil
+}
+
+func renderGitHubRelease(body []byte) (string, error) {
+	var ev ghReleaseEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return "", err
+	}
+	if ev.Action != "published" {
+		return "", nil
+	}
+	title := ev.Release.Name
+	if strings.TrimSpace(title) == "" {
+		title = ev.Release.TagName
+	}
+	return ghWithRepo(fmt.Sprintf("**%s** published release [%s](%s)",
+		ghLogin(ev.Sender), clipRunes(oneLine(title), 200), ev.Release.HTMLURL),
+		ev.Repository), nil
+}
+
+// ghLogin 兜底空 sender（GitHub 偶发不带 sender，如某些 App 触发的事件）。
+func ghLogin(u ghUser) string {
+	if u.Login == "" {
+		return "someone"
+	}
+	return u.Login
+}
+
+// ghWithRepo 给消息行追加 " · [repo](url)" 尾注；repo 信息缺失时原样返回。
+func ghWithRepo(line string, r ghRepo) string {
+	if r.FullName == "" {
+		return line
+	}
+	if r.HTMLURL == "" {
+		return line + " · " + r.FullName
+	}
+	return fmt.Sprintf("%s · [%s](%s)", line, r.FullName, r.HTMLURL)
+}
+
+// ghShortRef 把 refs/heads/main → main、refs/tags/v1.0 → v1.0。
+func ghShortRef(ref string) string {
+	ref = strings.TrimPrefix(ref, "refs/heads/")
+	ref = strings.TrimPrefix(ref, "refs/tags/")
+	return ref
+}
+
+// ghShortSHA 取提交短哈希（7 位，GitHub 惯例）。
+func ghShortSHA(sha string) string {
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
+}

--- a/modules/incomingwebhook/adapter_github.go
+++ b/modules/incomingwebhook/adapter_github.go
@@ -21,11 +21,32 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 )
 
 // 渲染的提交列表上限：push 事件单次最多带 20 个 commit（GitHub 截断），全列会刷屏。
 const maxRenderedCommits = 5
+
+// GitHub 事件 body 的字节上限。native 的 8KiB cap 约束的是调用方自己编写的 body，
+// 而 GitHub 事件 JSON 由平台生成：真实 push / pull_request 事件（携带完整 repository
+// 对象、提交列表）普遍在几十 KiB 量级，发送方无法修短，套用 8KiB 会把合法流量 413
+// （PR #330 review 阻断项）。默认 1MiB：远高于现实事件（99% < 100KiB），仍是硬界——
+// 且 body 读取发生在 token 鉴权 + per-webhook 5rps 限流之后，不构成放大面。
+const (
+	envGitHubBodyMax      = "DM_INCOMINGWEBHOOK_GITHUB_MAX_BYTES"
+	defaultGitHubMaxBytes = 1 << 20 // 1MiB
+)
+
+func githubMaxBytes() int {
+	if v := os.Getenv(envGitHubBodyMax); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultGitHubMaxBytes
+}
 
 type ghUser struct {
 	Login string `json:"login"`
@@ -159,6 +180,11 @@ func renderGitHubPush(body []byte) (string, error) {
 		return ghWithRepo(fmt.Sprintf("**%s** deleted branch `%s`", who, ref), ev.Repository), nil
 	case ev.Created && len(ev.Commits) == 0:
 		return ghWithRepo(fmt.Sprintf("**%s** created branch `%s`", who, ref), ev.Repository), nil
+	case len(ev.Commits) == 0:
+		// 非 create/delete 且无提交的退化 ref 更新（如 force-push 回相同内容）：渲染
+		// "pushed 0 commit(s)" 只会制造噪音——返回空走 skip 路径（review 跟进，两位
+		// reviewer 同时指出）。
+		return "", nil
 	}
 
 	verb := "pushed"

--- a/modules/incomingwebhook/adapter_github_test.go
+++ b/modules/incomingwebhook/adapter_github_test.go
@@ -83,7 +83,7 @@ func TestParseGitHubPush_PushVariants(t *testing.T) {
 			"**bob** created branch `dev`"},
 		{"force push", `{"ref":"refs/heads/main","forced":true,"commits":[{"id":"abc","message":"m","url":"u"}],"sender":{"login":"bob"}}`,
 			"force-pushed 1 commit(s)"},
-		{"missing sender falls back", `{"ref":"refs/heads/main","commits":[],"sender":{}}`,
+		{"missing sender falls back", `{"ref":"refs/heads/main","commits":[{"id":"abc","message":"m","url":"u"}],"sender":{}}`,
 			"**someone** pushed"},
 	}
 	for _, tc := range cases {
@@ -93,6 +93,21 @@ func TestParseGitHubPush_PushVariants(t *testing.T) {
 			assert.Contains(t, req.Content, tc.want)
 		})
 	}
+}
+
+// 非 create/delete 且无提交的退化 ref 更新不渲染 "pushed 0 commit(s)"，走 skip。
+func TestParseGitHubPush_NoCommitRefUpdateSkipped(t *testing.T) {
+	body := `{"ref":"refs/heads/main","commits":[],"sender":{"login":"bob"}}`
+	req, skip, invalid := parseGitHubPush(ghHeader("push"), []byte(body))
+	assert.Nil(t, req)
+	assert.Equal(t, "event", skip)
+	assert.Empty(t, invalid)
+}
+
+// GitHub 事件 body 是平台生成的（普遍 >8KiB 且发送方无法修短），其上限必须宽于
+// native 的调用方编写上限——钉住 review 阻断项的修复不被回退。
+func TestGitHubMaxBytes_ExceedsNativeCap(t *testing.T) {
+	assert.Greater(t, githubMaxBytes(), maxBytes())
 }
 
 func TestParseGitHubPush_CommitListTruncated(t *testing.T) {

--- a/modules/incomingwebhook/adapter_github_test.go
+++ b/modules/incomingwebhook/adapter_github_test.go
@@ -1,0 +1,200 @@
+package incomingwebhook
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// GitHub 适配器纯翻译单测（无 DB/Redis/IM 依赖）。fixture 取自 GitHub webhook 文档的
+// 字段子集——gh* 结构体本就是白名单解析，多余字段与缺省字段都不影响结果。
+
+func ghHeader(event string) http.Header {
+	h := http.Header{}
+	if event != "" {
+		h.Set("X-GitHub-Event", event)
+	}
+	return h
+}
+
+func TestParseGitHubPush_HeaderGate(t *testing.T) {
+	t.Run("missing event header is invalid", func(t *testing.T) {
+		req, skip, invalid := parseGitHubPush(http.Header{}, []byte(`{}`))
+		assert.Nil(t, req)
+		assert.Empty(t, skip)
+		assert.Equal(t, "event", invalid)
+	})
+	t.Run("ping is skipped", func(t *testing.T) {
+		req, skip, invalid := parseGitHubPush(ghHeader("ping"), []byte(`{"zen":"Design for failure."}`))
+		assert.Nil(t, req)
+		assert.Equal(t, "ping", skip)
+		assert.Empty(t, invalid)
+	})
+	t.Run("unsupported event is skipped", func(t *testing.T) {
+		req, skip, invalid := parseGitHubPush(ghHeader("watch"), []byte(`{"action":"started"}`))
+		assert.Nil(t, req)
+		assert.Equal(t, "event", skip)
+		assert.Empty(t, invalid)
+	})
+	t.Run("malformed body is invalid json", func(t *testing.T) {
+		req, skip, invalid := parseGitHubPush(ghHeader("push"), []byte(`{not json`))
+		assert.Nil(t, req)
+		assert.Empty(t, skip)
+		assert.Equal(t, "json", invalid)
+	})
+}
+
+func TestParseGitHubPush_PushEvent(t *testing.T) {
+	body := []byte(`{
+		"ref": "refs/heads/main",
+		"commits": [
+			{"id": "aaaabbbbccccdddd", "message": "feat: first\n\nbody", "url": "https://github.com/o/r/commit/aaaabbbb"},
+			{"id": "1111222233334444", "message": "fix: second", "url": "https://github.com/o/r/commit/11112222"}
+		],
+		"repository": {"full_name": "octo/repo", "html_url": "https://github.com/octo/repo"},
+		"sender": {"login": "alice"}
+	}`)
+	req, skip, invalid := parseGitHubPush(ghHeader("push"), body)
+	require.NotNil(t, req, "skip=%q invalid=%q", skip, invalid)
+	assert.Contains(t, req.Content, "**alice** pushed 2 commit(s) to `main`")
+	assert.Contains(t, req.Content, "[octo/repo](https://github.com/octo/repo)")
+	assert.Contains(t, req.Content, "[`aaaabbb`](https://github.com/o/r/commit/aaaabbbb) feat: first")
+	assert.NotContains(t, req.Content, "body", "only the first line of a commit message is rendered")
+	assert.Empty(t, req.MsgType, "adapters emit the plain-text path")
+}
+
+func TestParseGitHubPush_PushVariants(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"tag push", `{"ref":"refs/tags/v1.2.0","sender":{"login":"bob"},"repository":{"full_name":"o/r"}}`,
+			"**bob** pushed tag `v1.2.0`"},
+		{"tag delete", `{"ref":"refs/tags/v1.2.0","deleted":true,"sender":{"login":"bob"}}`,
+			"**bob** deleted tag `v1.2.0`"},
+		{"branch delete", `{"ref":"refs/heads/dev","deleted":true,"sender":{"login":"bob"}}`,
+			"**bob** deleted branch `dev`"},
+		{"branch create without commits", `{"ref":"refs/heads/dev","created":true,"commits":[],"sender":{"login":"bob"}}`,
+			"**bob** created branch `dev`"},
+		{"force push", `{"ref":"refs/heads/main","forced":true,"commits":[{"id":"abc","message":"m","url":"u"}],"sender":{"login":"bob"}}`,
+			"force-pushed 1 commit(s)"},
+		{"missing sender falls back", `{"ref":"refs/heads/main","commits":[],"sender":{}}`,
+			"**someone** pushed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, skip, invalid := parseGitHubPush(ghHeader("push"), []byte(tc.body))
+			require.NotNil(t, req, "skip=%q invalid=%q", skip, invalid)
+			assert.Contains(t, req.Content, tc.want)
+		})
+	}
+}
+
+func TestParseGitHubPush_CommitListTruncated(t *testing.T) {
+	commits := make([]string, 0, 8)
+	for i := 0; i < 8; i++ {
+		commits = append(commits, fmt.Sprintf(`{"id":"sha%07d","message":"c%d","url":"u%d"}`, i, i, i))
+	}
+	body := fmt.Sprintf(`{"ref":"refs/heads/main","commits":[%s],"sender":{"login":"a"}}`, strings.Join(commits, ","))
+	req, _, _ := parseGitHubPush(ghHeader("push"), []byte(body))
+	require.NotNil(t, req)
+	assert.Contains(t, req.Content, "pushed 8 commit(s)")
+	assert.Contains(t, req.Content, "…and 3 more", "only %d commits are listed", maxRenderedCommits)
+	assert.NotContains(t, req.Content, "c7", "commits beyond the cap are not rendered")
+}
+
+func TestParseGitHubPush_PullRequest(t *testing.T) {
+	tpl := `{
+		"action": "%s",
+		"pull_request": {"number": 12, "title": "Add feature", "html_url": "https://github.com/o/r/pull/12", "merged": %t},
+		"repository": {"full_name": "o/r", "html_url": "https://github.com/o/r"},
+		"sender": {"login": "carol"}
+	}`
+	t.Run("opened", func(t *testing.T) {
+		req, _, _ := parseGitHubPush(ghHeader("pull_request"), []byte(fmt.Sprintf(tpl, "opened", false)))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**carol** opened pull request [#12 Add feature](https://github.com/o/r/pull/12)")
+	})
+	t.Run("closed merged renders as merged", func(t *testing.T) {
+		req, _, _ := parseGitHubPush(ghHeader("pull_request"), []byte(fmt.Sprintf(tpl, "closed", true)))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "merged pull request")
+	})
+	t.Run("closed unmerged stays closed", func(t *testing.T) {
+		req, _, _ := parseGitHubPush(ghHeader("pull_request"), []byte(fmt.Sprintf(tpl, "closed", false)))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "closed pull request")
+	})
+	t.Run("synchronize is skipped", func(t *testing.T) {
+		req, skip, invalid := parseGitHubPush(ghHeader("pull_request"), []byte(fmt.Sprintf(tpl, "synchronize", false)))
+		assert.Nil(t, req)
+		assert.Equal(t, "event", skip)
+		assert.Empty(t, invalid)
+	})
+}
+
+func TestParseGitHubPush_IssuesAndComments(t *testing.T) {
+	t.Run("issue opened", func(t *testing.T) {
+		body := `{"action":"opened","issue":{"number":3,"title":"Bug","html_url":"https://github.com/o/r/issues/3"},"sender":{"login":"dan"}}`
+		req, _, _ := parseGitHubPush(ghHeader("issues"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**dan** opened issue [#3 Bug](https://github.com/o/r/issues/3)")
+	})
+	t.Run("issue labeled is skipped", func(t *testing.T) {
+		body := `{"action":"labeled","issue":{"number":3,"title":"Bug"},"sender":{"login":"dan"}}`
+		req, skip, _ := parseGitHubPush(ghHeader("issues"), []byte(body))
+		assert.Nil(t, req)
+		assert.Equal(t, "event", skip)
+	})
+	t.Run("comment created quotes a flattened snippet", func(t *testing.T) {
+		body := `{"action":"created",
+			"issue":{"number":3,"title":"Bug"},
+			"comment":{"html_url":"https://github.com/o/r/issues/3#c1","body":"line one\nline two"},
+			"sender":{"login":"eve"}}`
+		req, _, _ := parseGitHubPush(ghHeader("issue_comment"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**eve** commented on [#3 Bug](https://github.com/o/r/issues/3#c1)")
+		assert.Contains(t, req.Content, "> line one line two", "comment body is flattened to one line")
+	})
+	t.Run("comment edited is skipped", func(t *testing.T) {
+		body := `{"action":"edited","issue":{"number":3},"comment":{"body":"x"},"sender":{"login":"eve"}}`
+		req, skip, _ := parseGitHubPush(ghHeader("issue_comment"), []byte(body))
+		assert.Nil(t, req)
+		assert.Equal(t, "event", skip)
+	})
+}
+
+func TestParseGitHubPush_Release(t *testing.T) {
+	t.Run("published", func(t *testing.T) {
+		body := `{"action":"published","release":{"tag_name":"v2.0.0","name":"Big Release","html_url":"https://github.com/o/r/releases/v2.0.0"},"sender":{"login":"fred"}}`
+		req, _, _ := parseGitHubPush(ghHeader("release"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**fred** published release [Big Release](https://github.com/o/r/releases/v2.0.0)")
+	})
+	t.Run("name falls back to tag", func(t *testing.T) {
+		body := `{"action":"published","release":{"tag_name":"v2.0.0","html_url":"u"},"sender":{"login":"fred"}}`
+		req, _, _ := parseGitHubPush(ghHeader("release"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "[v2.0.0](u)")
+	})
+	t.Run("created is skipped", func(t *testing.T) {
+		body := `{"action":"created","release":{"tag_name":"v2.0.0"},"sender":{"login":"fred"}}`
+		req, skip, _ := parseGitHubPush(ghHeader("release"), []byte(body))
+		assert.Nil(t, req)
+		assert.Equal(t, "event", skip)
+	})
+}
+
+// 平台事件里的超长字段被钳制，绝不让 GitHub 流量撞 413（调用方无法修短一个事件）。
+func TestParseGitHubPush_ContentClipped(t *testing.T) {
+	long := strings.Repeat("标", maxContentRunes()+500)
+	body := fmt.Sprintf(`{"action":"opened","issue":{"number":1,"title":%q,"html_url":"u"},"sender":{"login":"g"}}`, long)
+	req, _, _ := parseGitHubPush(ghHeader("issues"), []byte(body))
+	require.NotNil(t, req)
+	assert.LessOrEqual(t, len([]rune(req.Content)), maxContentRunes())
+}

--- a/modules/incomingwebhook/adapter_push_test.go
+++ b/modules/incomingwebhook/adapter_push_test.go
@@ -1,0 +1,145 @@
+package incomingwebhook_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Phase 3（平台适配器）push 端到端用例。与现有 push 测试同风格走 testutil.NewTestServer
+// （需 MySQL/Redis/WuKongIM，CI 执行）。成功路径只断言「通过鉴权/校验」（非 4xx）——
+// 测试桩下游 SendMessage 可能 200 或 502，口径与 richtext_push_test.go 一致。
+
+// pushAdapterRaw 向适配器后缀路由发原始 body（可带平台事件头）。
+func pushAdapterRaw(handler http.Handler, whID, token, suffix string, body []byte, header map[string]string) *httptest.ResponseRecorder {
+	r := anonReq("POST", fmt.Sprintf("/v1/incoming-webhooks/%s/%s/%s", whID, token, suffix), body)
+	for k, v := range header {
+		r.Header.Set(k, v)
+	}
+	return do(handler, r)
+}
+
+// create/regenerate 响应携带各推送形态的 URL（#297 顺延的 onboarding 项）。
+func TestCreate_ReturnsAdapterURLs(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "adapter-wh",
+	}))
+	require.Equalf(t, http.StatusOK, w.Code, "create body: %s", w.Body.String())
+	created := parseJSON(t, w)
+
+	urls, ok := created["urls"].(map[string]interface{})
+	require.True(t, ok, "create response must carry urls; body=%s", w.Body.String())
+	native, _ := urls["native"].(string)
+	assert.Equal(t, created["url"], native, "urls.native must equal the legacy url field")
+	assert.Equal(t, native+"/github", urls["github"])
+	assert.Equal(t, native+"/wecom", urls["wecom"])
+}
+
+// GitHub ping：200 + skipped，不投递消息，且异步记一条 status=3(skipped) 的投递。
+func TestPush_GitHubPing_SkippedAndAudited(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	w := pushAdapterRaw(handler, whID, token, "github",
+		[]byte(`{"zen":"Keep it logically awesome.","hook_id":1}`),
+		map[string]string{"X-GitHub-Event": "ping"})
+	require.Equalf(t, http.StatusOK, w.Code, "ping must 200; body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), `"skipped"`, "ping response must mark the delivery as skipped")
+
+	require.Eventually(t, func() bool {
+		dw := do(handler, authReq("GET", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s/deliveries", groupNo, whID), nil))
+		if dw.Code != http.StatusOK {
+			return false
+		}
+		list, _ := parseJSON(t, dw)["list"].([]interface{})
+		for _, item := range list {
+			row, _ := item.(map[string]interface{})
+			if row["adapter"] == "github" && int(row["status"].(float64)) == 3 && row["reason"] == "ping" {
+				return true
+			}
+		}
+		return false
+	}, 3*time.Second, 50*time.Millisecond, "ping must be recorded as a skipped delivery")
+}
+
+// GitHub push 事件通过鉴权/翻译（非 4xx）。
+func TestPush_GitHubPushEvent_Delivers(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	body := []byte(`{
+		"ref": "refs/heads/main",
+		"commits": [{"id": "aaaabbbbcccc", "message": "feat: hello", "url": "https://github.com/o/r/commit/aaaabbbb"}],
+		"repository": {"full_name": "o/r", "html_url": "https://github.com/o/r"},
+		"sender": {"login": "alice"}
+	}`)
+	w := pushAdapterRaw(handler, whID, token, "github", body, map[string]string{"X-GitHub-Event": "push"})
+	assert.NotEqualf(t, http.StatusBadRequest, w.Code, "valid push event must translate; body=%s", w.Body.String())
+	assert.NotEqualf(t, http.StatusUnauthorized, w.Code, "valid token must authorize; body=%s", w.Body.String())
+	if w.Code == http.StatusOK {
+		assert.Contains(t, w.Body.String(), "message_id")
+	}
+}
+
+// 渲染子集之外的事件：200 + skipped（GitHub 侧不标红，群内不刷屏）。
+func TestPush_GitHubUnsupportedEvent_Skipped(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	w := pushAdapterRaw(handler, whID, token, "github",
+		[]byte(`{"action":"started"}`), map[string]string{"X-GitHub-Event": "watch"})
+	require.Equalf(t, http.StatusOK, w.Code, "unsupported event must 200; body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), `"skipped"`)
+}
+
+// 缺事件头 → 400 invalid（误配置要立刻可见，而非静默跳过）。
+func TestPush_GitHubMissingEventHeader_Invalid(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	w := pushAdapterRaw(handler, whID, token, "github", []byte(`{}`), nil)
+	assert.Equalf(t, http.StatusBadRequest, w.Code, "missing X-GitHub-Event must 400; body=%s", w.Body.String())
+}
+
+// 适配器路由沿用同一鉴权：错 token 统一 401（反枚举口径不变）。
+func TestPush_AdapterRoute_AuthEnforced(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, _ := createWebhookWithToken(t, handler, groupNo)
+
+	for _, suffix := range []string{"github", "wecom"} {
+		w := pushAdapterRaw(handler, whID, "wrong-token", suffix,
+			[]byte(`{"msgtype":"text","text":{"content":"hi"}}`),
+			map[string]string{"X-GitHub-Event": "push"})
+		assert.Equalf(t, http.StatusUnauthorized, w.Code, "%s: bad token must 401; body=%s", suffix, w.Body.String())
+	}
+}
+
+// 企微 text 格式通过鉴权/翻译；成功响应附带 errcode=0（平台 SDK 兼容）。
+func TestPush_WeComText_Delivers(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	w := pushAdapterRaw(handler, whID, token, "wecom",
+		[]byte(`{"msgtype":"text","text":{"content":"hello from wecom"}}`), nil)
+	assert.NotEqualf(t, http.StatusBadRequest, w.Code, "valid wecom text must translate; body=%s", w.Body.String())
+	assert.NotEqualf(t, http.StatusUnauthorized, w.Code, "valid token must authorize; body=%s", w.Body.String())
+	if w.Code == http.StatusOK {
+		assert.Contains(t, w.Body.String(), `"errcode":0`)
+	}
+}
+
+// 企微素材类消息（base64 图片）→ 400 invalid（显式失败优于静默丢弃）。
+func TestPush_WeComImage_Rejected(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	w := pushAdapterRaw(handler, whID, token, "wecom",
+		[]byte(`{"msgtype":"image","image":{"base64":"...","md5":"..."}}`), nil)
+	assert.Equalf(t, http.StatusBadRequest, w.Code, "wecom image must 400; body=%s", w.Body.String())
+}

--- a/modules/incomingwebhook/adapter_push_test.go
+++ b/modules/incomingwebhook/adapter_push_test.go
@@ -1,9 +1,11 @@
 package incomingwebhook_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -118,6 +120,42 @@ func TestPush_AdapterRoute_AuthEnforced(t *testing.T) {
 			map[string]string{"X-GitHub-Event": "push"})
 		assert.Equalf(t, http.StatusUnauthorized, w.Code, "%s: bad token must 401; body=%s", suffix, w.Body.String())
 	}
+}
+
+// 真实 GitHub 事件 JSON 普遍超过 native 的 8KiB body cap 且发送方无法修短——github
+// 路由使用独立宽上限，>8KiB 的合法 push 事件必须被接受并渲染（PR #330 review 阻断项）；
+// 同一 payload 打 native 路由仍须 413，宽上限只属于平台事件形态。
+func TestPush_GitHubLargePayload_Not413(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	// 20 个提交 × ~1KiB 提交信息 ≈ >20KiB body，模拟真实大 push 事件。
+	longMsg := strings.Repeat("x", 1024)
+	commits := make([]map[string]interface{}, 0, 20)
+	for i := 0; i < 20; i++ {
+		commits = append(commits, map[string]interface{}{
+			"id":      fmt.Sprintf("sha%037d", i),
+			"message": fmt.Sprintf("c%d: %s", i, longMsg),
+			"url":     fmt.Sprintf("https://github.com/o/r/commit/%d", i),
+		})
+	}
+	body, err := json.Marshal(map[string]interface{}{
+		"ref":        "refs/heads/main",
+		"commits":    commits,
+		"repository": map[string]interface{}{"full_name": "o/r", "html_url": "https://github.com/o/r"},
+		"sender":     map[string]interface{}{"login": "alice"},
+	})
+	require.NoError(t, err)
+	require.Greater(t, len(body), 8*1024, "fixture must exceed the native body cap")
+
+	w := pushAdapterRaw(handler, whID, token, "github", body, map[string]string{"X-GitHub-Event": "push"})
+	assert.NotEqualf(t, http.StatusRequestEntityTooLarge, w.Code, "github events beyond 8KiB must not 413; body=%s", w.Body.String())
+	assert.NotEqualf(t, http.StatusBadRequest, w.Code, "valid event must render; body=%s", w.Body.String())
+	assert.NotEqualf(t, http.StatusUnauthorized, w.Code, "valid token must authorize; body=%s", w.Body.String())
+
+	// 对照组：native 路由对同一 payload 仍按 8KiB cap 413。
+	wn := do(handler, anonReq("POST", fmt.Sprintf("/v1/incoming-webhooks/%s/%s", whID, token), body))
+	assert.Equalf(t, http.StatusRequestEntityTooLarge, wn.Code, "native route keeps the caller-authored cap; body=%s", wn.Body.String())
 }
 
 // 企微 text 格式通过鉴权/翻译；成功响应附带 errcode=0（平台 SDK 兼容）。

--- a/modules/incomingwebhook/adapter_test.go
+++ b/modules/incomingwebhook/adapter_test.go
@@ -1,0 +1,62 @@
+package incomingwebhook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 适配层公共件的纯单测（无 DB/Redis/IM 依赖）：native parse、成功响应体、文本工具。
+
+func TestParseNativePush(t *testing.T) {
+	t.Run("valid json", func(t *testing.T) {
+		req, skip, invalid := parseNativePush(nil, []byte(`{"content":"hi","msg_type":"text"}`))
+		require.NotNil(t, req)
+		assert.Empty(t, skip)
+		assert.Empty(t, invalid)
+		assert.Equal(t, "hi", req.Content)
+		assert.Equal(t, "text", req.MsgType)
+	})
+	t.Run("malformed json", func(t *testing.T) {
+		req, skip, invalid := parseNativePush(nil, []byte(`{not json`))
+		assert.Nil(t, req)
+		assert.Empty(t, skip)
+		assert.Equal(t, "json", invalid)
+	})
+}
+
+func TestSuccessBody(t *testing.T) {
+	t.Run("native delivered", func(t *testing.T) {
+		body := successBody(nativeAdapter, 42, "")
+		assert.Equal(t, 0, body["status"])
+		assert.Equal(t, int64(42), body["message_id"])
+		assert.NotContains(t, body, "skipped")
+		assert.NotContains(t, body, "errcode")
+	})
+	t.Run("skip carries reason", func(t *testing.T) {
+		body := successBody(githubAdapter, 0, "ping")
+		assert.Equal(t, "ping", body["skipped"])
+		assert.Equal(t, int64(0), body["message_id"])
+	})
+	t.Run("wecom carries platform compat fields", func(t *testing.T) {
+		body := successBody(wecomAdapter, 7, "")
+		assert.Equal(t, 0, body["errcode"])
+		assert.Equal(t, "ok", body["errmsg"])
+		assert.Equal(t, int64(7), body["message_id"])
+	})
+}
+
+func TestClipRunes(t *testing.T) {
+	assert.Equal(t, "abc", clipRunes("abc", 5), "short string passes through")
+	assert.Equal(t, "ab…", clipRunes("abcdef", 3), "clip ends with ellipsis")
+	assert.Equal(t, "", clipRunes("abc", 0), "non-positive max yields empty")
+	// 多字节字符按 rune 截断，不会切出半个字符。
+	assert.Equal(t, "中文…", clipRunes("中文字符串", 3))
+}
+
+func TestFirstLineAndOneLine(t *testing.T) {
+	assert.Equal(t, "fix: bug", firstLine("fix: bug\n\nlong body"))
+	assert.Equal(t, "no newline", firstLine("no newline"))
+	assert.Equal(t, "a b c", oneLine("a\r\nb\nc"))
+}

--- a/modules/incomingwebhook/adapter_wecom.go
+++ b/modules/incomingwebhook/adapter_wecom.go
@@ -1,0 +1,141 @@
+package incomingwebhook
+
+// 企业微信群机器人格式适配器（#297 Phase 4 的 WeCom 部分，与 Phase 3 合并实施）。
+//
+// 路由：POST /v1/incoming-webhooks/:webhook_id/:token/wecom
+// 接受企业微信「群机器人」的出站消息格式：已配置向企微机器人推送的工具（CI、告警、
+// 监控脚本），只需把 webhook URL 换成上述地址即可迁移，消息体零改动。
+//
+// 形态映射（高保真卡片渲染不可行，经 #297 确认接受降级并在 README 写明）：
+//
+//   - text / markdown / markdown_v2 → native 纯文本路径（客户端按 markdown 渲染）。
+//     text 的 mentioned_list / mentioned_mobile_list 降级丢弃——与 native 把 @all
+//     降级为字面量的策略一致，webhook 消息不携带 mention 语义（绕过通知策略）。
+//   - news → 降级 markdown：每篇文章「标题链接 + 描述」一段。
+//   - template_card → 降级 markdown：主标题 + 描述 + 跳转链接。
+//   - image / file / voice 等依赖平台素材（base64 / media_id）的类型 → 400
+//     invalid(reason=msg_type)：素材无法转存为 URL 引用，静默丢弃会让调用方误以为
+//     已送达，显式失败 + deliveries 可见才是诚实的迁移体验。
+//
+// 成功响应在 native 字段基础上附带 errcode=0 / errmsg=ok（见 adapter.go
+// wecomAdapter.successExtra）：多数企微 SDK 以 errcode==0 判定成功。
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type wecomTextContent struct {
+	Content string `json:"content"`
+}
+
+type wecomArticle struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
+}
+
+type wecomTemplateCard struct {
+	MainTitle struct {
+		Title string `json:"title"`
+		Desc  string `json:"desc"`
+	} `json:"main_title"`
+	SubTitleText string `json:"sub_title_text"`
+	CardAction   struct {
+		URL string `json:"url"`
+	} `json:"card_action"`
+}
+
+// wecomMsg 只声明翻译需要的字段（白名单解析），其余 payload 字段一律忽略。
+type wecomMsg struct {
+	MsgType    string            `json:"msgtype"`
+	Text       *wecomTextContent `json:"text"`
+	Markdown   *wecomTextContent `json:"markdown"`
+	MarkdownV2 *wecomTextContent `json:"markdown_v2"`
+	News       *struct {
+		Articles []wecomArticle `json:"articles"`
+	} `json:"news"`
+	TemplateCard *wecomTemplateCard `json:"template_card"`
+}
+
+// parseWeComPush 把企业微信群机器人消息翻译成 native 推送请求（pushAdapter.parse）。
+// 与 GitHub 适配器不同，内容长度不钳制：消息体由调用方自行编写（而非平台生成的事件），
+// 超过语义上限按既有 413 拒绝，调用方有能力也应当修短。
+func parseWeComPush(_ http.Header, body []byte) (*pushPayloadReq, string, string) {
+	var msg wecomMsg
+	if err := json.Unmarshal(body, &msg); err != nil {
+		return nil, "", "json"
+	}
+	var content string
+	switch msg.MsgType {
+	case "text":
+		if msg.Text != nil {
+			content = msg.Text.Content
+		}
+	case "markdown":
+		if msg.Markdown != nil {
+			content = msg.Markdown.Content
+		}
+	case "markdown_v2":
+		if msg.MarkdownV2 != nil {
+			content = msg.MarkdownV2.Content
+		}
+	case "news":
+		if msg.News != nil {
+			content = renderWeComNews(msg.News.Articles)
+		}
+	case "template_card":
+		if msg.TemplateCard != nil {
+			content = renderWeComTemplateCard(msg.TemplateCard)
+		}
+	default:
+		// 空 msgtype 与 image / file / voice 等素材类：显式拒绝（理由见文件头注释）。
+		return nil, "", "msg_type"
+	}
+	if strings.TrimSpace(content) == "" {
+		return nil, "", "content"
+	}
+	return &pushPayloadReq{Content: content}, "", ""
+}
+
+// renderWeComNews 把图文消息降级为 markdown：每篇「[标题](url) + 换行 + 描述」一段。
+// picurl 丢弃（封面图无法以图文混排语义复现，标题链接已承载跳转）。
+func renderWeComNews(articles []wecomArticle) string {
+	parts := make([]string, 0, len(articles))
+	for _, a := range articles {
+		title := oneLine(a.Title)
+		if title == "" {
+			continue
+		}
+		line := "**" + title + "**"
+		if u := strings.TrimSpace(a.URL); u != "" {
+			line = fmt.Sprintf("[%s](%s)", line, u)
+		}
+		if desc := strings.TrimSpace(a.Description); desc != "" {
+			line += "\n" + desc
+		}
+		parts = append(parts, line)
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// renderWeComTemplateCard 把模板卡片降级为 markdown：主标题（粗体）+ 描述 +
+// 副标题 + 跳转链接，逐行拼接；按钮 / 多列等交互元素不可复现，丢弃。
+func renderWeComTemplateCard(card *wecomTemplateCard) string {
+	lines := make([]string, 0, 4)
+	if t := oneLine(card.MainTitle.Title); t != "" {
+		lines = append(lines, "**"+t+"**")
+	}
+	if d := strings.TrimSpace(card.MainTitle.Desc); d != "" {
+		lines = append(lines, d)
+	}
+	if s := strings.TrimSpace(card.SubTitleText); s != "" {
+		lines = append(lines, s)
+	}
+	if u := strings.TrimSpace(card.CardAction.URL); u != "" {
+		lines = append(lines, u)
+	}
+	return strings.Join(lines, "\n")
+}

--- a/modules/incomingwebhook/adapter_wecom_test.go
+++ b/modules/incomingwebhook/adapter_wecom_test.go
@@ -1,0 +1,88 @@
+package incomingwebhook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 企业微信适配器纯翻译单测（无 DB/Redis/IM 依赖）。fixture 即企微群机器人文档的
+// 出站消息格式——迁移调用方发什么，这里就收什么。
+
+func TestParseWeComPush_TextAndMarkdown(t *testing.T) {
+	t.Run("text", func(t *testing.T) {
+		body := `{"msgtype":"text","text":{"content":"hello","mentioned_list":["@all"]}}`
+		req, skip, invalid := parseWeComPush(nil, []byte(body))
+		require.NotNil(t, req, "skip=%q invalid=%q", skip, invalid)
+		assert.Equal(t, "hello", req.Content)
+		assert.Empty(t, req.MsgType, "adapters emit the plain-text path")
+	})
+	t.Run("markdown", func(t *testing.T) {
+		body := `{"msgtype":"markdown","markdown":{"content":"**bold** msg"}}`
+		req, _, _ := parseWeComPush(nil, []byte(body))
+		require.NotNil(t, req)
+		assert.Equal(t, "**bold** msg", req.Content)
+	})
+	t.Run("markdown_v2", func(t *testing.T) {
+		body := `{"msgtype":"markdown_v2","markdown_v2":{"content":"# title"}}`
+		req, _, _ := parseWeComPush(nil, []byte(body))
+		require.NotNil(t, req)
+		assert.Equal(t, "# title", req.Content)
+	})
+}
+
+func TestParseWeComPush_News(t *testing.T) {
+	body := `{"msgtype":"news","news":{"articles":[
+		{"title":"Release v1", "description":"changelog", "url":"https://example.com/v1", "picurl":"https://example.com/p.png"},
+		{"title":"", "description":"skipped: empty title"},
+		{"title":"No link article"}
+	]}}`
+	req, _, _ := parseWeComPush(nil, []byte(body))
+	require.NotNil(t, req)
+	assert.Contains(t, req.Content, "[**Release v1**](https://example.com/v1)")
+	assert.Contains(t, req.Content, "changelog")
+	assert.Contains(t, req.Content, "**No link article**")
+	assert.NotContains(t, req.Content, "empty title", "articles without a title are dropped")
+	assert.NotContains(t, req.Content, "picurl", "cover images are dropped")
+}
+
+func TestParseWeComPush_TemplateCard(t *testing.T) {
+	body := `{"msgtype":"template_card","template_card":{
+		"card_type":"text_notice",
+		"main_title":{"title":"Deploy done","desc":"prod cluster"},
+		"sub_title_text":"all pods healthy",
+		"card_action":{"type":1,"url":"https://example.com/deploy/1"}
+	}}`
+	req, _, _ := parseWeComPush(nil, []byte(body))
+	require.NotNil(t, req)
+	assert.Contains(t, req.Content, "**Deploy done**")
+	assert.Contains(t, req.Content, "prod cluster")
+	assert.Contains(t, req.Content, "all pods healthy")
+	assert.Contains(t, req.Content, "https://example.com/deploy/1")
+}
+
+func TestParseWeComPush_Rejections(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string // expected invalid reason
+	}{
+		{"malformed json", `{not json`, "json"},
+		{"image relies on platform media", `{"msgtype":"image","image":{"base64":"...","md5":"..."}}`, "msg_type"},
+		{"file relies on platform media", `{"msgtype":"file","file":{"media_id":"x"}}`, "msg_type"},
+		{"missing msgtype", `{"text":{"content":"hi"}}`, "msg_type"},
+		{"text without payload", `{"msgtype":"text"}`, "content"},
+		{"text with blank content", `{"msgtype":"text","text":{"content":"  "}}`, "content"},
+		{"news with no usable article", `{"msgtype":"news","news":{"articles":[{"description":"no title"}]}}`, "content"},
+		{"template_card with nothing to render", `{"msgtype":"template_card","template_card":{}}`, "content"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, skip, invalid := parseWeComPush(nil, []byte(tc.body))
+			assert.Nil(t, req)
+			assert.Empty(t, skip, "wecom adapter never skips: the sender controls the body")
+			assert.Equal(t, tc.want, invalid)
+		})
+	}
+}

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -197,7 +197,16 @@ func (w *IncomingWebhook) Route(r *wkhttp.WKHttp) {
 	push := r.Group("/v1")
 	{
 		// requirePushEnabled 在最前：总开关关闭时直接 404，最廉价地短路（甚至不进 floor）。
-		push.POST("/incoming-webhooks/:webhook_id/:token", w.requirePushEnabled(), w.localFloorMiddleware(), ipLimit, w.ipFailureGateMiddleware(), w.push)
+		// 三种推送形态（native / github / wecom）共享同一条中间件链与同一组限流桶：
+		// 适配器只是 body 解析方式不同，不是新的攻击面，不单独开配额（见 adapter.go）。
+		chain := func(h wkhttp.HandlerFunc) []wkhttp.HandlerFunc {
+			return []wkhttp.HandlerFunc{w.requirePushEnabled(), w.localFloorMiddleware(), ipLimit, w.ipFailureGateMiddleware(), h}
+		}
+		push.POST("/incoming-webhooks/:webhook_id/:token", chain(w.push)...)
+		// 平台适配器（#297 Phase 3）：GitHub 事件 / 企业微信群机器人格式。鉴权、限流、
+		// 群校验与 native 完全一致，仅 body 解析不同（adapter_github.go / adapter_wecom.go）。
+		push.POST("/incoming-webhooks/:webhook_id/:token/github", chain(w.pushGitHub)...)
+		push.POST("/incoming-webhooks/:webhook_id/:token/wecom", chain(w.pushWeCom)...)
 	}
 }
 
@@ -312,6 +321,17 @@ func toResp(m *incomingWebhookModel) webhookResp {
 // publicURL 构造对外推送 URL（不含 host，由前端拼接基础域名）。
 func publicURL(webhookID, token string) string {
 	return fmt.Sprintf("/v1/incoming-webhooks/%s/%s", webhookID, token)
+}
+
+// publicURLs 构造各推送形态的对外路径（#297 顺延的 onboarding 项）：native 即历史
+// 契约的 url 字段，github / wecom 为平台适配器后缀。与 publicURL 一样不含 host。
+func publicURLs(webhookID, token string) map[string]string {
+	base := publicURL(webhookID, token)
+	return map[string]string{
+		"native": base,
+		"github": base + "/github",
+		"wecom":  base + "/wecom",
+	}
 }
 
 // ============================================================
@@ -488,6 +508,7 @@ func (w *IncomingWebhook) create(c *wkhttp.Context) {
 		webhookResp: toResp(m),
 		Token:       token,
 		URL:         publicURL(m.WebhookID, token),
+		URLs:        publicURLs(m.WebhookID, token),
 	}
 	c.Response(resp)
 }
@@ -665,6 +686,7 @@ func (w *IncomingWebhook) regenerate(c *wkhttp.Context) {
 		webhookResp: toResp(updated),
 		Token:       token,
 		URL:         publicURL(webhookID, token),
+		URLs:        publicURLs(webhookID, token),
 	})
 }
 
@@ -810,7 +832,13 @@ func (w *IncomingWebhook) failAuth(c *wkhttp.Context, ip string) {
 	pushUnauthorized(c)
 }
 
-func (w *IncomingWebhook) push(c *wkhttp.Context) {
+// push / pushGitHub / pushWeCom 是三种推送形态的路由入口，全部走 handlePush 流水线，
+// 只差 body 解析（pushAdapter.parse，见 adapter.go）。
+func (w *IncomingWebhook) push(c *wkhttp.Context)       { w.handlePush(c, nativeAdapter) }
+func (w *IncomingWebhook) pushGitHub(c *wkhttp.Context) { w.handlePush(c, githubAdapter) }
+func (w *IncomingWebhook) pushWeCom(c *wkhttp.Context)  { w.handlePush(c, wecomAdapter) }
+
+func (w *IncomingWebhook) handlePush(c *wkhttp.Context, ad pushAdapter) {
 	// 仅用于"鉴权失败才计入"的 per-IP 失败预算（见 failAuth / ipFailureGateMiddleware）。
 	// 用 clientIP（信任代理追加的 X-Real-Ip / 最右 XFF），而非 gin c.ClientIP()——后者在
 	// wkhttp 的 trust-all-proxies 默认下取最左 XFF（客户端可伪造），会让扫描者每次伪造
@@ -892,24 +920,33 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 	limit := maxBytes()
 	body, err := io.ReadAll(io.LimitReader(c.Request.Body, int64(limit)+1))
 	if err != nil {
-		w.submitFailure(m, 0, ip, "body", http.StatusBadRequest)
+		w.submitFailure(m, 0, ip, ad.name, "body", http.StatusBadRequest)
 		pushPayloadInvalid(c, "body")
 		return
 	}
 	if len(body) > limit {
-		w.submitFailure(m, len(body), ip, "too_large", http.StatusRequestEntityTooLarge)
+		w.submitFailure(m, len(body), ip, ad.name, "too_large", http.StatusRequestEntityTooLarge)
 		pushPayloadTooLarge(c)
 		return
 	}
 
-	var req pushPayloadReq
-	if err := json.Unmarshal(body, &req); err != nil {
-		w.submitFailure(m, len(body), ip, "json", http.StatusBadRequest)
-		pushPayloadInvalid(c, "json")
+	// 5) 适配器解析：native 直接反序列化 pushPayloadReq；github/wecom 把平台格式翻译
+	//    成等价请求（见 adapter.go），之后三种形态共用同一条构造/投递/审计路径。
+	req, skipReason, invalidReason := ad.parse(c.Request.Header, body)
+	if invalidReason != "" {
+		w.submitFailure(m, len(body), ip, ad.name, invalidReason, http.StatusBadRequest)
+		pushPayloadInvalid(c, invalidReason)
+		return
+	}
+	if skipReason != "" {
+		// 已接收、刻意不投递（GitHub ping / 渲染子集之外的事件）：返回 200 让平台侧
+		// 显示投递成功，落 auditSkipped 让群管理员在 deliveries 里确认链路连通。
+		w.submitSkipped(m, len(body), ip, ad.name, skipReason)
+		c.Response(successBody(ad, 0, skipReason))
 		return
 	}
 
-	// 5) 按 msg_type 构造 payload。缺省/"text" 走历史纯文本路径（content 必填，客户端
+	// 6) 按 msg_type 构造 payload。缺省/"text" 走历史纯文本路径（content 必填，客户端
 	//    按 markdown 渲染），完全向后兼容；"richtext" 走图文混排：blocks 翻译为 octo
 	//    原生 RichText(=14) 并由 richtext.Validate/Finalize 权威校验。
 	var payload map[string]interface{}
@@ -920,39 +957,39 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 			req.Content = req.Text
 		}
 		if strings.TrimSpace(req.Content) == "" {
-			w.submitFailure(m, len(body), ip, "content", http.StatusBadRequest)
+			w.submitFailure(m, len(body), ip, ad.name, "content", http.StatusBadRequest)
 			pushPayloadInvalid(c, "content")
 			return
 		}
 		// content 语义长度上限（按 rune 计），独立于 8KB 字节 body cap：防止单条消息
 		// 正文过长污染所有客户端渲染。超限按 413 拒绝，与 body 超限同语义。
 		if utf8.RuneCountInString(req.Content) > maxContentRunes() {
-			w.submitFailure(m, len(body), ip, "too_large", http.StatusRequestEntityTooLarge)
+			w.submitFailure(m, len(body), ip, ad.name, "too_large", http.StatusRequestEntityTooLarge)
 			pushPayloadTooLarge(c)
 			return
 		}
-		payload = buildPayload(m, &req)
+		payload = buildPayload(m, req)
 	case msgTypeRichText:
 		// 注意：richtext 路径【不】套用纯文本的 maxContentRunes(4000) 语义上限——富文本
 		// 由块结构 + 1MB 序列化上限约束，默认 8KB body cap 下不可能逾越。这是与文本路径的
 		// 有意不对称（若运维上调 body cap，富文本仍受 1MB 兜底，不会无界）。
-		p, err := buildRichTextPayload(m, &req)
+		p, err := buildRichTextPayload(m, req)
 		if err != nil {
 			// 仅 >1MB 映射 413（与 body/content 超限同语义）；其余结构性非法（空 content /
 			// 空 text 块 / 非 http(s) 图片 url / 缺图片宽高 / 未知块类型 / 超块数上限）
 			// 一律 400 invalid，reason=blocks 供调用方定位。
 			if errors.Is(err, common.ErrRichTextPayloadTooLarge) {
-				w.submitFailure(m, len(body), ip, "too_large", http.StatusRequestEntityTooLarge)
+				w.submitFailure(m, len(body), ip, ad.name, "too_large", http.StatusRequestEntityTooLarge)
 				pushPayloadTooLarge(c)
 				return
 			}
-			w.submitFailure(m, len(body), ip, "blocks", http.StatusBadRequest)
+			w.submitFailure(m, len(body), ip, ad.name, "blocks", http.StatusBadRequest)
 			pushPayloadInvalid(c, "blocks")
 			return
 		}
 		payload = p
 	default:
-		w.submitFailure(m, len(body), ip, "msg_type", http.StatusBadRequest)
+		w.submitFailure(m, len(body), ip, ad.name, "msg_type", http.StatusBadRequest)
 		pushPayloadInvalid(c, "msg_type")
 		return
 	}
@@ -969,24 +1006,21 @@ func (w *IncomingWebhook) push(c *wkhttp.Context) {
 	if err != nil {
 		w.Error("send incoming webhook message failed",
 			zap.String("webhook_id", m.WebhookID), zap.Error(err))
-		w.submitFailure(m, len(body), ip, "delivery_failed", http.StatusBadGateway)
+		w.submitFailure(m, len(body), ip, ad.name, "delivery_failed", http.StatusBadGateway)
 		pushDeliveryFailed(c)
 		return
 	}
 
-	// 6) 异步审计 + markUsed（失败不影响响应），并发受 auditSem 限制
+	// 7) 异步审计 + markUsed（失败不影响响应），并发受 auditSem 限制
 	var msgID int64
 	if resp != nil {
 		msgID = resp.MessageID
 	}
 	// 审计用同一可信 IP（clientIP），而非 gin 可伪造的 c.ClientIP()。bumpUsed=true：
 	// 真实推送成功累加 call_count / last_used_at。
-	w.submitSuccess(m, len(body), ip, msgID, adapterNative, true)
+	w.submitSuccess(m, len(body), ip, msgID, ad.name, true)
 
-	c.Response(map[string]interface{}{
-		"status":     0,
-		"message_id": msgID,
-	})
+	c.Response(successBody(ad, msgID, ""))
 }
 
 // 与 create/update 路径的 webhook 名称/头像列长度约束一致，避免 push 路径成为绕过。
@@ -1075,14 +1109,14 @@ func (w *IncomingWebhook) submitSuccess(m *incomingWebhookModel, byteSize int, i
 
 // submitFailure 记录一次【鉴权通过后】的失败投递（payload 非法/体积过大/投递失败）。
 // 不累加调用计数(bumpUsed=false)——call_count 语义是「成功调用次数」。reason/httpStatus
-// 与 push 路径返回给调用方的响应保持一致，供 deliveries 端点排障。
+// 与 push 路径返回给调用方的响应保持一致，供 deliveries 端点排障；adapter 标记推送形态。
 //
 // 刻意【不】覆盖 rate_limited（429）：它在限流闸处直接返回、不入审计——见 push 路径中
 // !allowed 分支的说明（天然高频，逐条落库会反噬限流的廉价丢弃）。
 //
 // ⚠️ 仅在 webhook 已通过 token 鉴权且群为 Normal 之后调用：鉴权失败（未知/错 token/
 // 已解散群）绝不落本表，只进 IP 失败预算，维持 push 路径的反枚举不变量。
-func (w *IncomingWebhook) submitFailure(m *incomingWebhookModel, byteSize int, ip, reason string, httpStatus int) {
+func (w *IncomingWebhook) submitFailure(m *incomingWebhookModel, byteSize int, ip, adapter, reason string, httpStatus int) {
 	w.submitDelivery(&auditModel{
 		WebhookID:  m.WebhookID,
 		GroupNo:    m.GroupNo,
@@ -1091,7 +1125,24 @@ func (w *IncomingWebhook) submitFailure(m *incomingWebhookModel, byteSize int, i
 		Status:     auditFailed,
 		Reason:     reason,
 		HTTPStatus: httpStatus,
-		Adapter:    adapterNative,
+		Adapter:    adapter,
+	}, false)
+}
+
+// submitSkipped 记录一次「已接收、刻意不投递」的结果（GitHub ping / 渲染子集之外的
+// 事件类型）。响应是 200，但没有消息进群——单列 auditSkipped 状态而非伪装成成功或
+// 失败（语义见 model.go auditSkipped）。bumpUsed=false：call_count 语义是「成功投递
+// 次数」。鉴权前置约束与 submitFailure 相同（反枚举不变量）。
+func (w *IncomingWebhook) submitSkipped(m *incomingWebhookModel, byteSize int, ip, adapter, reason string) {
+	w.submitDelivery(&auditModel{
+		WebhookID:  m.WebhookID,
+		GroupNo:    m.GroupNo,
+		IP:         ip,
+		ByteSize:   byteSize,
+		Status:     auditSkipped,
+		Reason:     reason,
+		HTTPStatus: http.StatusOK,
+		Adapter:    adapter,
 	}, false)
 }
 

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -916,8 +916,11 @@ func (w *IncomingWebhook) handlePush(c *wkhttp.Context, ad pushAdapter) {
 		return
 	}
 
-	// 4) 读 body 并按统一上限拒绝过大请求。LimitReader 多读 1 字节用于判超。
-	limit := maxBytes()
+	// 4) 读 body 并按【该形态】的上限拒绝过大请求。LimitReader 多读 1 字节用于判超。
+	// native / wecom 是调用方编写的 body（8KiB 足够且应当约束）；github 是平台生成的
+	// 事件 JSON，普遍超过 8KiB 且发送方无法修短，用更宽的专属上限（见 pushAdapter.
+	// bodyLimit）。此处已通过 token 鉴权 + per-webhook 限流，宽上限不构成放大面。
+	limit := ad.bodyLimit()
 	body, err := io.ReadAll(io.LimitReader(c.Request.Body, int64(limit)+1))
 	if err != nil {
 		w.submitFailure(m, 0, ip, ad.name, "body", http.StatusBadRequest)

--- a/modules/incomingwebhook/api_i18n.go
+++ b/modules/incomingwebhook/api_i18n.go
@@ -36,9 +36,10 @@ func pushRateLimited(c *wkhttp.Context) {
 }
 
 // pushPayloadInvalid returns 400 for unreadable body / malformed JSON / empty
-// content / malformed rich-text blocks / unknown msg_type; reason ∈
-// {body, json, content, blocks, msg_type} is surfaced via the safe-listed
-// Details key so callers can tell what to fix.
+// content / malformed rich-text blocks / unknown msg_type / untranslatable
+// platform-adapter request; reason ∈ {body, json, content, blocks, msg_type,
+// event} is surfaced via the safe-listed Details key so callers can tell what
+// to fix.
 func pushPayloadInvalid(c *wkhttp.Context, reason string) {
 	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookPushPayloadInvalid, nil, i18n.Details{"reason": reason})
 	c.Abort()

--- a/modules/incomingwebhook/api_i18n_test.go
+++ b/modules/incomingwebhook/api_i18n_test.go
@@ -19,7 +19,8 @@ import (
 // #246 note in api_i18n.go) don't trip the guard. Add any new handler/limiter
 // file to the list below.
 func TestIncomingWebhookNoLegacyResponseError(t *testing.T) {
-	files := []string{"api.go", "api_i18n.go", "ratelimit.go", "localfloor.go", "cache.go"}
+	files := []string{"api.go", "api_i18n.go", "ratelimit.go", "localfloor.go", "cache.go",
+		"adapter.go", "adapter_github.go", "adapter_wecom.go"}
 	banned := []string{
 		".ResponseError(",
 		".ResponseErrorf(",

--- a/modules/incomingwebhook/api_i18n_test.go
+++ b/modules/incomingwebhook/api_i18n_test.go
@@ -126,7 +126,7 @@ func TestIncomingWebhookRespondHelpers(t *testing.T) {
 // legacy {msg,status} shape, so an e2e body never carries error.details — see the
 // note in richtext_push_test.go. No DB/Redis needed; this only exercises the renderer.
 func TestPushPayloadInvalidSurfacesReason(t *testing.T) {
-	for _, reason := range []string{"blocks", "msg_type", "content", "json"} {
+	for _, reason := range []string{"blocks", "msg_type", "content", "json", "event"} {
 		t.Run(reason, func(t *testing.T) {
 			r := iwhHelperHarness(func(c *wkhttp.Context) { pushPayloadInvalid(c, reason) })
 			req := httptest.NewRequest(http.MethodGet, "/probe", nil)

--- a/modules/incomingwebhook/model.go
+++ b/modules/incomingwebhook/model.go
@@ -38,12 +38,18 @@ type incomingWebhookModel struct {
 const (
 	auditSuccess = 1
 	auditFailed  = 2
+	// auditSkipped 「已接收、刻意不投递」：GitHub ping / 渲染子集之外的事件等，响应
+	// 200（平台侧显示投递成功）但没有消息进群。单列一种状态而非伪装成成功（message_id=0
+	// 的"成功"会误导排障）或失败（调用方无需修复任何东西）。
+	auditSkipped = 3
 )
 
-// 投递来源/适配器（auditModel.Adapter）。Phase 3/4 扩展 github/gitlab/wecom/feishu。
+// 投递来源/适配器（auditModel.Adapter）。后续扩展 gitlab/feishu。
 const (
 	adapterNative = "native" // 原生推送端点
 	adapterTest   = "test"   // 管理端「测试推送」
+	adapterGitHub = "github" // GitHub 事件适配器（#297 Phase 3）
+	adapterWeCom  = "wecom"  // 企业微信群机器人格式适配器（#297 Phase 3）
 )
 
 // auditModel 对应 incoming_webhook_audit 表，记录【鉴权通过后】的每次投递结果
@@ -54,10 +60,10 @@ type auditModel struct {
 	IP         string
 	ByteSize   int
 	MessageID  int64
-	Status     int    // auditSuccess / auditFailed
-	Reason     string // 失败原因码；成功为空
+	Status     int    // auditSuccess / auditFailed / auditSkipped
+	Reason     string // 失败/跳过原因码；成功为空
 	HTTPStatus int    // 返回给调用方的 HTTP 状态码
-	Adapter    string // 来源/适配器：adapterNative / adapterTest / ...
+	Adapter    string // 来源/适配器：adapterNative / adapterTest / adapterGitHub / adapterWeCom
 	db.BaseModel
 }
 
@@ -127,6 +133,10 @@ type createResp struct {
 	webhookResp
 	Token string `json:"token"`
 	URL   string `json:"url"`
+	// URLs 各推送形态的路径（native / github / wecom），与 URL 一样不含 host、由前端
+	// 拼接基础域名。token 仅在 create/regenerate 时可见，故完整推送路径也只在这两处
+	// 下发（list 不回显 token，自然也不回推送 URL）。
+	URLs map[string]string `json:"urls"`
 }
 
 // deliveryResp 是 deliveries 排障端点返回的单条投递记录（成功+失败）。绝不含 token。
@@ -134,8 +144,8 @@ type createResp struct {
 // 刻意【不】下发调用方 IP：审计表仍存 ip（限流/排查上下文），但向群管理员暴露来源 IP
 // 是隐私取舍，按 review 决定收敛——deliveries 只回投递结果元数据，不回 IP（PR #299 review）。
 type deliveryResp struct {
-	Status     int    `json:"status"`      // auditSuccess / auditFailed
-	Reason     string `json:"reason"`      // 失败原因码；成功为空
+	Status     int    `json:"status"`      // auditSuccess / auditFailed / auditSkipped
+	Reason     string `json:"reason"`      // 失败/跳过原因码；成功为空
 	HTTPStatus int    `json:"http_status"` // 返回给调用方的 HTTP 状态码
 	Adapter    string `json:"adapter"`     // 来源/适配器
 	ByteSize   int    `json:"byte_size"`

--- a/modules/incomingwebhook/sql/20260610000001_incomingwebhook_adapter_comment.sql
+++ b/modules/incomingwebhook/sql/20260610000001_incomingwebhook_adapter_comment.sql
@@ -1,0 +1,20 @@
+-- +migrate Up
+
+-- #297 Phase 3 平台适配器（github/wecom）引入：
+--   - adapter 新增取值 github / wecom；
+--   - status 新增取值 3=跳过（已接收、刻意不投递：GitHub ping / 渲染子集之外的事件，
+--     响应 200 但没有消息进群）；
+--   - reason 新增取值 event（不支持/不渲染的平台事件）、ping（GitHub 连通性测试）。
+-- 复用既有列、无结构变更，仅刷新 COMMENT 让 schema 自文档化（同 20260604000002 的
+-- 做法）。目标库 MySQL 8.0：仅改 COMMENT 的 MODIFY COLUMN 走 INSTANT 算法、瞬时无锁，
+-- 无需显式 pin ALGORITHM/LOCK。
+ALTER TABLE `incoming_webhook_audit`
+  MODIFY COLUMN `status`  SMALLINT    NOT NULL DEFAULT 1        COMMENT '投递结果：1=成功,2=失败,3=跳过(已接收、刻意不投递：ping/未渲染事件)',
+  MODIFY COLUMN `reason`  VARCHAR(32) NOT NULL DEFAULT ''       COMMENT '失败/跳过原因码（body/json/content/blocks/msg_type/too_large/delivery_failed/event/ping）；成功为空。限流429不入审计',
+  MODIFY COLUMN `adapter` VARCHAR(16) NOT NULL DEFAULT 'native' COMMENT '消息来源/适配器：native/test/github/wecom（后续扩展 gitlab/feishu）';
+
+-- +migrate Down
+ALTER TABLE `incoming_webhook_audit`
+  MODIFY COLUMN `status`  SMALLINT    NOT NULL DEFAULT 1        COMMENT '投递结果：1=成功,2=失败',
+  MODIFY COLUMN `reason`  VARCHAR(32) NOT NULL DEFAULT ''       COMMENT '失败原因码（body/json/content/blocks/msg_type/too_large/delivery_failed）；成功为空。限流429不入审计',
+  MODIFY COLUMN `adapter` VARCHAR(16) NOT NULL DEFAULT 'native' COMMENT '消息来源/适配器：native/test（Phase 3/4 扩展 github/gitlab/wecom/feishu）';

--- a/pkg/errcode/incomingwebhook.go
+++ b/pkg/errcode/incomingwebhook.go
@@ -40,9 +40,10 @@ var (
 	})
 
 	// ErrIncomingWebhookPushPayloadInvalid (400) — unreadable body, malformed
-	// JSON, empty content, malformed rich-text blocks, or an unknown msg_type.
-	// The offending stage is surfaced via Details["reason"]
-	// (body / json / content / blocks / msg_type).
+	// JSON, empty content, malformed rich-text blocks, an unknown msg_type, or a
+	// platform-adapter request that cannot be translated (missing X-GitHub-Event
+	// header, unsupported WeCom msgtype). The offending stage is surfaced via
+	// Details["reason"] (body / json / content / blocks / msg_type / event).
 	ErrIncomingWebhookPushPayloadInvalid = register(codes.Code{
 		ID:             "err.server.incomingwebhook.push_payload_invalid",
 		HTTPStatus:     http.StatusBadRequest,


### PR DESCRIPTION
## Background

**Phase 3** of epic #297 (scope adjusted per maintainer: GitHub + WeCom instead of GitHub + GitLab, in a single PR). Today every caller must hand-convert third-party events into our `content` format. This PR adds out-of-the-box platform adapters plus the onboarding item deferred from Phase 2.

## Changes

**Adapter pipeline**
- The push handler is refactored into `handlePush(c, pushAdapter)`: all three shapes (native / github / wecom) share the same auth / 4-layer rate-limit / group-check / audit pipeline and differ **only** in body parsing (`adapter.go`). Adapters emit a `pushPayloadReq`, never touch the message payload directly — `from.kind=webhook` + server-derived `space_id` injection is unchanged.
- New routes `POST .../:webhook_id/:token/github` and `.../wecom` reuse the exact middleware chain (same limiter instances/buckets — adapters are not a new attack surface).

**GitHub adapter** (`adapter_github.go`)
- Renders by `X-GitHub-Event` into markdown: `push` (branch/tag/delete/force-push, ≤5 commits listed), `pull_request` (opened/closed→merged/reopened/ready_for_review), `issues`, `issue_comment` (created), `release` (published).
- `ping` and out-of-subset events/actions answer **200 + `skipped`** and are audited with the new **status=3 (skipped)** — GitHub shows green deliveries (no false red), the group is not spammed (e.g. `pull_request.synchronize`), and admins still see the traffic in `deliveries`. A missing `X-GitHub-Event` header is a hard 400 `reason=event` (misconfiguration must be visible).
- Platform-generated fields (titles / commit messages / comment bodies) are clipped server-side so GitHub traffic can never hit the 413 content cap — the sender has no way to "shorten" an event.
- Auth stays the 128-bit URL token per the epic decision (no mandatory HMAC; `X-Hub-Signature-256` left as a future option).

**WeCom adapter** (`adapter_wecom.go`)
- Accepts the WeCom group-bot **outbound** format: tools already pushing to a WeCom bot migrate by changing only the URL. `text` / `markdown` / `markdown_v2` pass through; `news` and `template_card` degrade to markdown (documented, per the epic's degrade decision); media-based types (`image`/`file`/`voice`) are rejected with 400 `reason=msg_type` — an explicit failure beats silently dropping a message the sender believes was delivered.
- Success responses additionally carry `errcode=0` / `errmsg=ok` (most WeCom SDKs key off `errcode`).

**Onboarding (deferred Phase 2 item)**
- `create` / `regenerate` responses now include `urls` (`native` / `github` / `wecom`); legacy `url` field unchanged. README documents all shapes with curl examples.

**Audit**
- `adapter` column gains `github` / `wecom`; failure records now carry the real adapter; new `auditSkipped(3)` status. Migration is **comment-only** (INSTANT, no structural change). 429-not-audited and the pre-auth anti-enumeration invariant are untouched.

## Testing (TDD)

- Unit (no infra): GitHub renderers per event/action incl. skip/invalid gates, clipping, commit-list truncation; WeCom all msgtypes incl. every rejection path; adapter plumbing (native parse, success body, helpers).
- e2e (`adapter_push_test.go`): ping → 200+skipped **and** async audit row asserted via deliveries (`adapter=github, status=3, reason=ping`); push/wecom-text deliver; bad token → uniform 401 on adapter routes; missing event header → 400; wecom image → 400; create carries `urls`.
- Guard: `adapter*.go` added to `TestIncomingWebhookNoLegacyResponseError`.

## Checks

`go build` / `go vet` / `gofmt` / `make i18n-extract-check` / `make i18n-lint` pass (no new error codes — `push_payload_invalid` reused with new `reason=event`). Full module suite ran **locally against real MySQL 8 + Redis with a WuKongIM stub** (CI-identical DB recreate + FLUSHALL, `go test -race -shuffle=on`): ok in 33.7s, including the success-path assertions (`message_id`, `errcode:0`) that the CI stub sometimes degrades to 502 on.

Refs #297

> Sprint: tracked on the Octo Board under **Sprint W24** (intentionally `Refs`, not `Closes` — the epic stays open for the GitLab / Feishu phases).

https://claude.ai/code/session_01W4UKE63aRUDm1i2JGN6xSf