### PR TITLE
fix(group): clean thread_setting on removal and drop latent thread-module cleanup copy

### DIFF
--- a/modules/group/api_groupexit_cascade_thread_test.go
+++ b/modules/group/api_groupexit_cascade_thread_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ensureThreadTables 为 group 模块的测试脚手架补上 thread / thread_member 表。
+// ensureThreadTables 为 group 模块的测试脚手架补上 thread / thread_member / thread_setting 表。
 // group 模块的测试不会自动运行 thread 模块的迁移，沿用 TestMain 里手工建表的同款做法。
 func ensureThreadTables(t *testing.T, f *Group) {
 	t.Helper()
@@ -40,7 +40,20 @@ func ensureThreadTables(t *testing.T, f *Group) {
 		UNIQUE KEY uk_thread_uid (thread_id, uid)
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`).Exec()
 	require.NoError(t, err)
+	_, err = f.ctx.DB().UpdateBySql(`CREATE TABLE IF NOT EXISTS thread_setting (
+		id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+		group_no VARCHAR(40) NOT NULL DEFAULT '',
+		short_id VARCHAR(32) NOT NULL DEFAULT '',
+		uid VARCHAR(40) NOT NULL DEFAULT '',
+		mute TINYINT NOT NULL DEFAULT 0,
+		version BIGINT NOT NULL DEFAULT 0,
+		created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+		UNIQUE KEY uk_thread_uid (group_no, short_id, uid)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`).Exec()
+	require.NoError(t, err)
 	// CleanAllTables 之后再 delete 一遍，保证干净
+	_, _ = f.ctx.DB().DeleteFrom("thread_setting").Exec()
 	_, _ = f.ctx.DB().DeleteFrom("thread_member").Exec()
 	_, _ = f.ctx.DB().DeleteFrom("thread").Exec()
 }

--- a/modules/group/thread_cleanup.go
+++ b/modules/group/thread_cleanup.go
@@ -40,10 +40,11 @@ func queryThreadShortIDsForCleanup(ctx *config.Context, groupNo string) ([]strin
 	return out, nil
 }
 
-// removeUserFromGroupThreadsCleanup 是被踢/退群路径上“清理某用户在某群所有子区的 thread_member
-// 记录、IM 订阅和置顶”的统一入口。原本 (*Group).removeUserFromGroupThreads 与
+// removeUserFromGroupThreadsCleanup 是被踢/退群路径上“清理某用户在某群所有子区的 thread_member、
+// thread_setting 记录、IM 订阅和置顶”的统一入口。原本 (*Group).removeUserFromGroupThreads 与
 // (*Service).removeUserFromGroupThreads 是两份逐字重复的实现且各自带 Issue #27 的同型 bug；
-// 这里合并到一处，避免下次再“修一处漏一处”。
+// 这里合并到一处，避免下次再“修一处漏一处”。thread 模块曾有一份同名导出方法，IM 退订同样
+// 被 JOIN thread_member 限定（#27 同型隐患），已随 Issue #331 移除——群/Bot 移除路径只能走这里。
 //
 // 失败只记日志、不中断（与原行为一致）。logger 由调用方传入以保留各自的 module 标签。
 func removeUserFromGroupThreadsCleanup(ctx *config.Context, logger log.Log, groupNo, uid, spaceID string) {
@@ -55,16 +56,20 @@ func removeUserFromGroupThreadsCleanup(ctx *config.Context, logger log.Log, grou
 		logger.Error("查询群子区失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("uid", uid))
 		return
 	}
-	if len(shortIDs) == 0 {
-		return
-	}
 
-	// best-effort 删除 thread_member 行：DELETE 按 uid 过滤，没有匹配行也是 0 rows affected。
-	// 即使删除失败也要继续摘 IM 订阅 —— 不能让 DB 异常导致订阅泄漏。
+	// best-effort 删除 thread_member / thread_setting 行：DELETE 按 uid 过滤，没有匹配行也是
+	// 0 rows affected。即使删除失败也要继续摘 IM 订阅 —— 不能让 DB 异常导致订阅泄漏。
+	// 两条 DELETE 不 gate 在 len(shortIDs) 上：用户可能只 mute 过子区而从未 JoinThread
+	// （Issue #331），thread_setting 必须按 group_no+uid 直删，连同已删除子区的残留行一并清掉。
 	if _, err := ctx.DB().DeleteFrom("thread_member").
 		Where("uid=? AND thread_id IN (SELECT id FROM thread WHERE group_no=?)", uid, groupNo).
 		Exec(); err != nil {
 		logger.Error("删除子区成员记录失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("uid", uid))
+	}
+	if _, err := ctx.DB().DeleteFrom("thread_setting").
+		Where("group_no=? AND uid=?", groupNo, uid).
+		Exec(); err != nil {
+		logger.Error("删除子区个人设置失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("uid", uid))
 	}
 
 	for _, shortID := range shortIDs {

--- a/modules/group/thread_cleanup_test.go
+++ b/modules/group/thread_cleanup_test.go
@@ -124,6 +124,60 @@ func TestRemoveUserFromGroupThreadsCleanup_DeletesMemberWithoutOwnRow(t *testing
 	assert.Equal(t, 1, otherCount, "cleanup 只能按 uid 删除，不能波及其他用户的 thread_member")
 }
 
+// TestRemoveUserFromGroupThreadsCleanup_CleansSettingWithoutMembership 是 Issue #331（item 2）
+// 的回归：用户只对子区设置过 mute（thread_setting 有行）但从未 JoinThread（thread_member 无行），
+// 被移出群后 setting 行必须被清掉，否则重新入群时老 mute 静默生效。同时断言按 uid / group_no
+// 隔离：其他用户的 setting、该用户在其他群的 setting 都不受影响。
+func TestRemoveUserFromGroupThreadsCleanup_CleansSettingWithoutMembership(t *testing.T) {
+	svc, _ := setupServiceTest(t)
+	s := svc.(*Service)
+	f := New(s.ctx)
+	ensureThreadTables(t, f)
+
+	const groupNo = "g_issue331_setting"
+	const targetUID = "mute_only_user"
+	_, err := f.ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("th_331", groupNo, "setting", "owner", 1, 1).Exec()
+	require.NoError(t, err)
+
+	// target 只 mute、未 join：thread_setting 有行，thread_member 无行
+	_, err = f.ctx.DB().InsertInto("thread_setting").
+		Columns("group_no", "short_id", "uid", "mute", "version").
+		Values(groupNo, "th_331", targetUID, 1, 1).Exec()
+	require.NoError(t, err)
+	// 其他用户在同子区的 setting —— 不能被波及
+	_, err = f.ctx.DB().InsertInto("thread_setting").
+		Columns("group_no", "short_id", "uid", "mute", "version").
+		Values(groupNo, "th_331", "someone_else", 1, 1).Exec()
+	require.NoError(t, err)
+	// target 在另一个群的 setting —— 不能被波及
+	_, err = f.ctx.DB().InsertInto("thread_setting").
+		Columns("group_no", "short_id", "uid", "mute", "version").
+		Values("g_other_331", "th_other_331", targetUID, 1, 1).Exec()
+	require.NoError(t, err)
+
+	s.removeUserFromGroupThreads(groupNo, targetUID, "sp_331")
+
+	var targetCount int
+	_, err = f.ctx.DB().Select("count(*)").From("thread_setting").
+		Where("group_no=? AND uid=?", groupNo, targetUID).Load(&targetCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, targetCount, "mute 而未 join 的用户被移出群后，thread_setting 必须被清理（Issue #331）")
+
+	var otherUserCount int
+	_, err = f.ctx.DB().Select("count(*)").From("thread_setting").
+		Where("group_no=? AND uid=?", groupNo, "someone_else").Load(&otherUserCount)
+	require.NoError(t, err)
+	assert.Equal(t, 1, otherUserCount, "cleanup 只能按 uid 删除，不能波及其他用户的 thread_setting")
+
+	var otherGroupCount int
+	_, err = f.ctx.DB().Select("count(*)").From("thread_setting").
+		Where("group_no=? AND uid=?", "g_other_331", targetUID).Load(&otherGroupCount)
+	require.NoError(t, err)
+	assert.Equal(t, 1, otherGroupCount, "cleanup 只能按 group_no 删除，不能波及该用户在其他群的 thread_setting")
+}
+
 // TestRemoveUserFromGroupThreadsCleanup_EmptyInputs 验证 uid/groupNo 防御守卫：
 // 空 uid 或空 groupNo 时直接 no-op，绝不下发任何 SQL/IM 调用。
 func TestRemoveUserFromGroupThreadsCleanup_EmptyInputs(t *testing.T) {
@@ -142,6 +196,10 @@ func TestRemoveUserFromGroupThreadsCleanup_EmptyInputs(t *testing.T) {
 		Columns("thread_id", "uid", "role", "version").
 		Values(threadID, "u", 0, 1).Exec()
 	require.NoError(t, err)
+	_, err = f.ctx.DB().InsertInto("thread_setting").
+		Columns("group_no", "short_id", "uid", "mute", "version").
+		Values("g_guard", "th_guard", "u", 1, 1).Exec()
+	require.NoError(t, err)
 
 	removeUserFromGroupThreadsCleanup(s.ctx, s.Log, "", "u", "sp")
 	removeUserFromGroupThreadsCleanup(s.ctx, s.Log, "g_guard", "", "sp")
@@ -151,4 +209,10 @@ func TestRemoveUserFromGroupThreadsCleanup_EmptyInputs(t *testing.T) {
 		Where("thread_id=? AND uid=?", threadID, "u").Load(&count)
 	require.NoError(t, err)
 	assert.Equal(t, 1, count, "空参数时 helper 必须立即返回、不下发 DELETE/IMRemoveSubscriber")
+
+	var settingCount int
+	_, err = f.ctx.DB().Select("count(*)").From("thread_setting").
+		Where("group_no=? AND uid=?", "g_guard", "u").Load(&settingCount)
+	require.NoError(t, err)
+	assert.Equal(t, 1, settingCount, "空参数时 helper 不得删除 thread_setting")
 }

--- a/modules/thread/db.go
+++ b/modules/thread/db.go
@@ -520,32 +520,6 @@ func (d *DB) QueryByID(id int64) (*Model, error) {
 	return model, err
 }
 
-// QueryThreadsByGroupNoAndUID 查询用户在某群下加入的所有子区
-func (d *DB) QueryThreadsByGroupNoAndUID(groupNo, uid string) ([]*Model, error) {
-	var models []*Model
-	_, err := d.session.Select("t.*").
-		From(dbr.I("thread").As("t")).
-		Join(dbr.I("thread_member").As("tm"), "t.id = tm.thread_id").
-		Where("t.group_no=? AND tm.uid=? AND t.status!=?", groupNo, uid, ThreadStatusDeleted).
-		Load(&models)
-	return models, err
-}
-
-// DeleteMembersByGroupNoAndUIDTx 事务中删除用户在某群下所有子区的成员记录
-func (d *DB) DeleteMembersByGroupNoAndUIDTx(groupNo, uid string, tx *dbr.Tx) error {
-	_, err := tx.DeleteFrom("thread_member").
-		Where("uid=? AND thread_id IN (SELECT id FROM thread WHERE group_no=?)", uid, groupNo).
-		Exec()
-	return err
-}
-
-// DeleteSettingsByGroupNoAndUIDTx 事务中删除用户在某群下所有子区的个人设置
-func (d *DB) DeleteSettingsByGroupNoAndUIDTx(groupNo, uid string, tx *dbr.Tx) error {
-	_, err := tx.DeleteFrom("thread_setting").
-		Where("group_no=? AND uid=?", groupNo, uid).Exec()
-	return err
-}
-
 // MemberModel 子区成员数据模型
 type MemberModel struct {
 	ID       int64  `json:"id"`

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -62,8 +62,6 @@ type IService interface {
 	GetMemberUIDs(groupNo, shortID string) ([]string, error)
 	// IsMember 检查是否是子区成员
 	IsMember(groupNo, shortID, uid string) (bool, error)
-	// RemoveUserFromGroupThreads 退群时移除用户在该群所有子区的成员身份和 IM 订阅
-	RemoveUserFromGroupThreads(groupNo, uid string) error
 	// GetThreadMd 获取子区 GROUP.md
 	GetThreadMd(groupNo, shortID string) (*ThreadMdResult, error)
 	// UpdateThreadMd 更新子区 GROUP.md（纯透传，不含权限检查）
@@ -1073,55 +1071,9 @@ func (s *Service) GetSettingsWithUIDs(groupNo, shortID string, uids []string) ([
 	return resp, nil
 }
 
-// RemoveUserFromGroupThreads 退群时清理用户在该群所有子区的成员身份、个人设置、IM 订阅
-// 注:即使用户未加入任何子区,也要清理 thread_setting(用户可能只设置了 mute 但未 join)
-func (s *Service) RemoveUserFromGroupThreads(groupNo, uid string) error {
-	// 查询用户在该群加入的所有子区(用于 IM 退订)
-	threads, err := s.db.QueryThreadsByGroupNoAndUID(groupNo, uid)
-	if err != nil {
-		return fmt.Errorf("query user threads in group: %w", err)
-	}
-
-	// 批量清理 thread_member + thread_setting(同一事务)
-	tx, err := s.db.session.Begin()
-	if err != nil {
-		return fmt.Errorf("begin transaction: %w", err)
-	}
-	defer func() {
-		if err != nil {
-			_ = tx.Rollback()
-		}
-	}()
-
-	err = s.db.DeleteMembersByGroupNoAndUIDTx(groupNo, uid, tx)
-	if err != nil {
-		return fmt.Errorf("delete thread members: %w", err)
-	}
-
-	err = s.db.DeleteSettingsByGroupNoAndUIDTx(groupNo, uid, tx)
-	if err != nil {
-		return fmt.Errorf("delete thread settings: %w", err)
-	}
-
-	if err = tx.Commit(); err != nil {
-		return fmt.Errorf("commit transaction: %w", err)
-	}
-
-	// 移除 IM 订阅（事务外，失败仅记日志）
-	for _, t := range threads {
-		channelID := BuildChannelID(groupNo, t.ShortID)
-		rmErr := s.ctx.IMRemoveSubscriber(&config.SubscriberRemoveReq{
-			ChannelID:   channelID,
-			ChannelType: common.ChannelTypeCommunityTopic.Uint8(),
-			Subscribers: []string{uid},
-		})
-		if rmErr != nil {
-			s.Error("移除子区IM订阅者失败", zap.Error(rmErr), zap.String("groupNo", groupNo), zap.String("shortID", t.ShortID), zap.String("uid", uid))
-		}
-	}
-
-	return nil
-}
+// 注:本模块不再提供 RemoveUserFromGroupThreads —— 旧实现的 IM 退订被 JOIN thread_member
+// 限定,接到群/Bot 移除路径会复活 Issue #27 的订阅泄漏。退群/踢人/删 Bot 的子区清理统一走
+// group 模块的 removeUserFromGroupThreadsCleanup(modules/group/thread_cleanup.go,Issue #331)。
 
 // sanitizeListStatuses 把入参里只保留 listThreads 允许列出的 status（active / archived），
 // 去重；若过滤后为空（nil、空切片、或全是非法值如 deleted/未知码），fallback 到

--- a/modules/thread/service_setting_test.go
+++ b/modules/thread/service_setting_test.go
@@ -162,60 +162,8 @@ func TestGetSettingsWithUIDs_Empty(t *testing.T) {
 	assert.Len(t, settings, 0)
 }
 
-// 用户退群时应清理其 thread_setting,避免重新入群时老 mute 静默生效
-func TestRemoveUserFromGroupThreads_CleansSettings(t *testing.T) {
-	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	svc, groupNo := setupServiceTestData(t)
-	thread, err := svc.CreateThread(&CreateThreadReq{
-		GroupNo: groupNo, Name: "s1", CreatorUID: testutil.UID, CreatorName: "用户1",
-	})
-	assert.NoError(t, err)
-
-	// user2 加入子区并设置 mute
-	assert.NoError(t, svc.JoinThread(groupNo, thread.ShortID, "user2"))
-	assert.NoError(t, svc.UpdateSetting(groupNo, thread.ShortID, "user2", map[string]interface{}{
-		"mute": float64(1),
-	}))
-
-	// 退群前确认设置存在
-	settings, err := svc.GetSettingsWithUIDs(groupNo, thread.ShortID, []string{"user2"})
-	assert.NoError(t, err)
-	assert.Len(t, settings, 1)
-
-	// 退群
-	assert.NoError(t, svc.RemoveUserFromGroupThreads(groupNo, "user2"))
-
-	// 设置应被清理
-	settings, err = svc.GetSettingsWithUIDs(groupNo, thread.ShortID, []string{"user2"})
-	assert.NoError(t, err)
-	assert.Len(t, settings, 0, "退群后 thread_setting 应被清理")
-}
-
-// 用户未加入任何子区,但设置了 mute,退群时也应清理(不应被 early return 跳过)
-func TestRemoveUserFromGroupThreads_CleansSettingsWithoutMembership(t *testing.T) {
-	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	svc, groupNo := setupServiceTestData(t)
-	thread, err := svc.CreateThread(&CreateThreadReq{
-		GroupNo: groupNo, Name: "s1", CreatorUID: testutil.UID, CreatorName: "用户1",
-	})
-	assert.NoError(t, err)
-
-	// user2 仅设置 mute,但未 JoinThread
-	assert.NoError(t, svc.UpdateSetting(groupNo, thread.ShortID, "user2", map[string]interface{}{
-		"mute": float64(1),
-	}))
-	settings, err := svc.GetSettingsWithUIDs(groupNo, thread.ShortID, []string{"user2"})
-	assert.NoError(t, err)
-	assert.Len(t, settings, 1)
-
-	// 退群
-	assert.NoError(t, svc.RemoveUserFromGroupThreads(groupNo, "user2"))
-
-	// 设置应被清理
-	settings, err = svc.GetSettingsWithUIDs(groupNo, thread.ShortID, []string{"user2"})
-	assert.NoError(t, err)
-	assert.Len(t, settings, 0)
-}
+// 退群清理 thread_setting 的回归(含 mute 而未 join 的场景)已随清理逻辑迁往
+// modules/group/thread_cleanup_test.go(removeUserFromGroupThreadsCleanup,Issue #331)。
 
 func TestGetSettingsWithUIDs_Batch(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")

--- a/modules/thread/service_test.go
+++ b/modules/thread/service_test.go
@@ -582,8 +582,6 @@ func TestUpdateMessageStats(t *testing.T) {
 	assert.Equal(t, "sender2", thread.LastMessageSenderUID)
 }
 
-// ==================== RemoveUserFromGroupThreads 测试 ====================
-
 func setupServiceTestData(t *testing.T) (*Service, string) {
 	_, ctx := testutil.NewTestServer()
 	err := testutil.CleanAllTables(ctx)
@@ -608,53 +606,6 @@ func setupServiceTestData(t *testing.T) (*Service, string) {
 
 	svc := NewService(ctx).(*Service)
 	return svc, groupNo
-}
-
-func TestRemoveUserFromGroupThreads(t *testing.T) {
-	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	svc, groupNo := setupServiceTestData(t)
-
-	// 创建两个子区
-	thread1, err := svc.CreateThread(&CreateThreadReq{GroupNo: groupNo, Name: "子区1", CreatorUID: testutil.UID, CreatorName: "用户1"})
-	assert.NoError(t, err)
-	thread2, err := svc.CreateThread(&CreateThreadReq{GroupNo: groupNo, Name: "子区2", CreatorUID: testutil.UID, CreatorName: "用户1"})
-	assert.NoError(t, err)
-
-	// user2 加入两个子区
-	err = svc.JoinThread(groupNo, thread1.ShortID, "user2")
-	assert.NoError(t, err)
-	err = svc.JoinThread(groupNo, thread2.ShortID, "user2")
-	assert.NoError(t, err)
-
-	// 确认 user2 是两个子区的成员
-	isMember1, _ := svc.IsMember(groupNo, thread1.ShortID, "user2")
-	isMember2, _ := svc.IsMember(groupNo, thread2.ShortID, "user2")
-	assert.True(t, isMember1)
-	assert.True(t, isMember2)
-
-	// 执行批量移除
-	err = svc.RemoveUserFromGroupThreads(groupNo, "user2")
-	assert.NoError(t, err)
-
-	// 验证 user2 已从所有子区移除
-	isMember1, _ = svc.IsMember(groupNo, thread1.ShortID, "user2")
-	isMember2, _ = svc.IsMember(groupNo, thread2.ShortID, "user2")
-	assert.False(t, isMember1)
-	assert.False(t, isMember2)
-
-	// 验证创建者(testutil.UID)不受影响
-	isCreator1, _ := svc.IsMember(groupNo, thread1.ShortID, testutil.UID)
-	isCreator2, _ := svc.IsMember(groupNo, thread2.ShortID, testutil.UID)
-	assert.True(t, isCreator1)
-	assert.True(t, isCreator2)
-}
-
-func TestRemoveUserFromGroupThreads_NoThreads(t *testing.T) {
-	svc, groupNo := setupServiceTestData(t)
-
-	// user2 没加入任何子区，调用应无副作用
-	err := svc.RemoveUserFromGroupThreads(groupNo, "user2")
-	assert.NoError(t, err)
 }
 
 // ==================== UpdateName 测试 ====================
@@ -740,44 +691,6 @@ func TestUpdateName_TooLong(t *testing.T) {
 	err = svc.UpdateName(groupNo, thread.ShortID, testutil.UID, longName)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "name")
-}
-
-func TestRemoveUserFromGroupThreads_OnlyAffectsTargetGroup(t *testing.T) {
-	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	svc, groupNo1 := setupServiceTestData(t)
-
-	// 创建第二个群
-	groupNo2 := strings.ReplaceAll(util.GenerUUID(), "-", "")
-	groupDB := group.NewDB(svc.ctx)
-	err := groupDB.Insert(&group.Model{GroupNo: groupNo2, Name: "群2", Creator: testutil.UID, Status: 1, Version: 1})
-	assert.NoError(t, err)
-	err = groupDB.InsertMember(&group.MemberModel{GroupNo: groupNo2, UID: testutil.UID, Role: group.MemberRoleCreator, Status: 1, Version: 1, Vercode: util.GenerUUID()})
-	assert.NoError(t, err)
-	err = groupDB.InsertMember(&group.MemberModel{GroupNo: groupNo2, UID: "user2", Role: group.MemberRoleCommon, Status: 1, Version: 1, Vercode: util.GenerUUID()})
-	assert.NoError(t, err)
-
-	// 两个群各创建一个子区，user2 都加入
-	t1, err := svc.CreateThread(&CreateThreadReq{GroupNo: groupNo1, Name: "群1子区", CreatorUID: testutil.UID, CreatorName: "用户1"})
-	assert.NoError(t, err)
-	t2, err := svc.CreateThread(&CreateThreadReq{GroupNo: groupNo2, Name: "群2子区", CreatorUID: testutil.UID, CreatorName: "用户1"})
-	assert.NoError(t, err)
-
-	err = svc.JoinThread(groupNo1, t1.ShortID, "user2")
-	assert.NoError(t, err)
-	err = svc.JoinThread(groupNo2, t2.ShortID, "user2")
-	assert.NoError(t, err)
-
-	// 只移除群1的子区成员
-	err = svc.RemoveUserFromGroupThreads(groupNo1, "user2")
-	assert.NoError(t, err)
-
-	// 群1子区已移除
-	isMember1, _ := svc.IsMember(groupNo1, t1.ShortID, "user2")
-	assert.False(t, isMember1)
-
-	// 群2子区不受影响
-	isMember2, _ := svc.IsMember(groupNo2, t2.ShortID, "user2")
-	assert.True(t, isMember2)
 }
 
 // ==================== DB 层 ThreadMd 测试 ====================


### PR DESCRIPTION
Closes #331. Follow-ups from PR #300 / Issue #27 — this PR fixes items 1 + 2. Item 3 (`OrgEmployeeExitReq.Operator` comment) lives in octo-lib and is split into a dedicated octo-lib issue (cross-referenced on #331), so closing #331 here does not lose track of it.

## Summary

Two changes, fixed together as suggested in #331:

1. **`thread_setting` is now cleaned on the group-removal path** (item 2). The consolidated `removeUserFromGroupThreadsCleanup` (`modules/group/thread_cleanup.go`) cleaned `thread_member`, IM subscriptions, pinned, and `conversation_ext` — but not `thread_setting`. A user who only muted a thread (setting row, no `thread_member` row) left an orphaned mute row after being removed from the group, which would silently re-apply if they ever rejoined.

2. **`thread.Service.RemoveUserFromGroupThreads` (2-arg) is removed** (item 1). It was dead in production (only referenced by `thread.IService` and the thread module's own tests — group/bot removal goes through the `group` module's consolidated helper), but its IM-unsubscribe loop still listed threads via `JOIN thread_member` — the exact Issue #27 pattern #300 removed everywhere else. Any future caller wiring this exported method onto a removal path would have silently reintroduced the subscription leak.

## What changed

- `modules/group/thread_cleanup.go`: `removeUserFromGroupThreadsCleanup` now also deletes `thread_setting` rows keyed by `group_no + uid` (best-effort, log-only on failure, same as the other DB cleanup). The `thread_member` / `thread_setting` DELETEs are no longer gated on the group having non-deleted threads, preserving the removed method's "clean settings even when the user never joined" semantics and sweeping residue rows for deleted threads.
- `modules/thread/`: removed `Service.RemoveUserFromGroupThreads`, its `IService` entry, and the three DB helpers only it used (`QueryThreadsByGroupNoAndUID`, `DeleteMembersByGroupNoAndUIDTx`, `DeleteSettingsByGroupNoAndUIDTx`). Left a signpost comment pointing group/bot removal at the consolidated group helper.
- Tests: new `TestRemoveUserFromGroupThreadsCleanup_CleansSettingWithoutMembership` (mute-without-join regression; asserts uid and group_no isolation), `thread_setting` guard added to `TestRemoveUserFromGroupThreadsCleanup_EmptyInputs`, `ensureThreadTables` now provisions `thread_setting`. The removed method's tests are deleted — 4 of 5 were already `t.Skip` (issue #17 backlog); the live coverage migrated to the group helper's tests.

Net −131 lines.

## Verification

Ran against a CI-equivalent stack (MySQL 8.0.46, Redis 7, WuKongIM v2.2.4-20260313, `OCTO_MASTER_KEY` set, `test` DB recreated `utf8mb4_general_ci` + `FLUSHALL` between packages), `go test -race -shuffle=on -count=1`:

```
ok  github.com/Mininglamp-OSS/octo-server/modules/group      45.6s   # incl. new #331 regressions
ok  github.com/Mininglamp-OSS/octo-server/modules/thread     14.2s
ok  github.com/Mininglamp-OSS/octo-server/modules/botfather  32.4s   # holds thread.IService
ok  github.com/Mininglamp-OSS/octo-server/modules/bot_api     8.9s   # holds thread.IService
```

All seven `TestQueryThreadShortIDsForCleanup_*` / `TestRemoveUserFromGroupThreadsCleanup_*` cases verified individually (PASS, none skipped). `go build ./...` and `go vet` clean.

Additionally ran the opt-in live-WuKongIM E2E (excluded from CI by the `wukong_e2e` build tag) against the same stack, exercising the **modified** helper end-to-end — a bot with no `thread_member` row receives thread messages before cleanup and stops receiving after, while a still-subscribed user keeps receiving:

```
go test -tags wukong_e2e -race -count=1 -run TestE2E_Issue27 -v ./modules/group/
--- PASS: TestE2E_Issue27_RemovedBotStopsReceivingThreadMessages (5.74s)
```

https://claude.ai/code/session_01XMVEVo6tBXp9eYUMWMnM3q