### PR TITLE
feat(bot_api): resolve channel target (group/thread) by name

### DIFF
--- a/modules/bot_api/api_i18n_test.go
+++ b/modules/bot_api/api_i18n_test.go
@@ -36,7 +36,7 @@ func TestBotAPINoLegacyResponseError(t *testing.T) {
 	files := []string{
 		"auth.go", "register.go", "commands.go", "events.go", "mention_pref.go",
 		"sync.go", "typing.go", "send.go", "threads.go", "file.go", "groups.go",
-		"voice_adapter.go", "obo_api.go",
+		"voice_adapter.go", "obo_api.go", "resolve_targets.go",
 	}
 	banned := []string{
 		".ResponseError(",

--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -214,6 +214,7 @@ func (ba *BotAPI) Route(r *wkhttp.WKHttp) {
 		botAPI.POST("/heartbeat", ba.heartbeat)
 		botAPI.POST("/messages/sync", ba.syncMessages)
 		botAPI.GET("/groups", ba.getGroups)
+		botAPI.GET("/resolve/targets", ba.botResolveTargets)
 		botAPI.GET("/groups/:group_no", ba.getGroupInfo)
 		botAPI.GET("/groups/:group_no/members", ba.getGroupMembers)
 		botAPI.GET("/groups/:group_no/mention_pref", ba.getMentionPref) // 群级免@偏好读（octo-server#237）

--- a/modules/bot_api/resolve_targets.go
+++ b/modules/bot_api/resolve_targets.go
@@ -1,0 +1,198 @@
+package bot_api
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"go.uber.org/zap"
+)
+
+// resolve/targets limit semantics — intentionally distinct from botSpaceMembers
+// (default 50 / max 200). This endpoint defaults to 20 and caps at 50.
+const (
+	resolveTargetsDefaultLimit = 20
+	resolveTargetsMaxLimit     = 50
+)
+
+// resolveTargetKinds enumerates the accepted `kind` filter values.
+const (
+	resolveKindAll    = "all"
+	resolveKindGroup  = "group"
+	resolveKindThread = "thread"
+)
+
+// resolveTargetCandidate is one match returned by botResolveTargets. Groups and
+// threads share this shape and are distinguished by `kind`; absent fields are
+// omitted (a group has no short_id / parent_name). Channel type is 2 for a
+// group and 5 for a thread (community topic).
+type resolveTargetCandidate struct {
+	Kind        string `json:"kind"`
+	ChannelID   string `json:"channel_id"`
+	ChannelType uint8  `json:"channel_type"`
+	Name        string `json:"name"`
+	GroupNo     string `json:"group_no"`
+	ShortID     string `json:"short_id,omitempty"`
+	ParentName  string `json:"parent_name,omitempty"`
+}
+
+// botResolveTargets handles GET /v1/bot/resolve/targets.
+//
+// It searches the calling bot's visible groups and threads by name and returns
+// a unified candidate array so the adapter can disambiguate a named target
+// ("forward to 'XXX'") instead of guessing. Visibility is defined purely by
+// membership (group_member.uid=robotID AND is_deleted=0) — there is no space_id
+// filter, so a bot pulled into a cross-space external group can still resolve
+// that group and its threads. App Bots have no group_member rows, so (like the
+// read-only getGroups precedent) they naturally resolve to an empty set rather
+// than being rejected.
+func (ba *BotAPI) botResolveTargets(c *wkhttp.Context) {
+	robotID := getRobotIDFromContext(c)
+	if robotID == "" {
+		ba.respondBotAPIIdentityMissing(c)
+		return
+	}
+
+	name := strings.TrimSpace(c.Query("name"))
+	if name == "" {
+		respondBotAPIRequestInvalid(c, "name")
+		return
+	}
+
+	kind := strings.TrimSpace(c.Query("kind"))
+	if kind == "" {
+		kind = resolveKindAll
+	}
+	if kind != resolveKindAll && kind != resolveKindGroup && kind != resolveKindThread {
+		respondBotAPIRequestInvalid(c, "kind")
+		return
+	}
+
+	// Explicit parse + clamp. Unlike botSpaceMembers (fmt.Sscanf), we validate
+	// with strconv.Atoi and degrade leniently: a missing / unparseable / <=0
+	// value keeps the default rather than erroring.
+	limit := resolveTargetsDefaultLimit
+	if s := strings.TrimSpace(c.Query("limit")); s != "" {
+		if v, err := strconv.Atoi(s); err == nil && v > 0 {
+			limit = v
+		}
+	}
+	if limit > resolveTargetsMaxLimit {
+		limit = resolveTargetsMaxLimit
+	}
+
+	// Escape LIKE wildcards in user input (same escaping as botSpaceMembers).
+	escaped := strings.ReplaceAll(name, "\\", "\\\\")
+	escaped = strings.ReplaceAll(escaped, "%", "\\%")
+	escaped = strings.ReplaceAll(escaped, "_", "\\_")
+	pattern := "%" + escaped + "%"
+
+	candidates := make([]resolveTargetCandidate, 0)
+	truncated := false
+
+	if kind == resolveKindAll || kind == resolveKindGroup {
+		type groupRow struct {
+			GroupNo string `db:"group_no"`
+			Name    string `db:"name"`
+		}
+		var rows []groupRow
+		// Only the bot's own groups (group_member.uid=robotID AND is_deleted=0);
+		// naturally includes cross-space external groups, no space filter.
+		// LIMIT limit+1 probes for truncation. ORDER BY (g.name = ?) DESC puts an
+		// exact (un-wildcarded) name match first, then a stable group_no order.
+		_, err := ba.ctx.DB().SelectBySql(
+			"SELECT g.group_no, g.name FROM group_member gm INNER JOIN `group` g ON gm.group_no = g.group_no "+
+				"WHERE gm.uid = ? AND gm.is_deleted = 0 AND g.name LIKE ? "+
+				"ORDER BY (g.name = ?) DESC, g.group_no ASC LIMIT ?",
+			robotID, pattern, name, limit+1,
+		).Load(&rows)
+		if err != nil {
+			ba.Error("resolve targets: query groups failed", zap.Error(err), zap.String("robotID", robotID))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
+			return
+		}
+		if len(rows) > limit {
+			truncated = true
+			rows = rows[:limit]
+		}
+		for _, r := range rows {
+			candidates = append(candidates, resolveTargetCandidate{
+				Kind:        resolveKindGroup,
+				ChannelID:   r.GroupNo,
+				ChannelType: common.ChannelTypeGroup.Uint8(),
+				Name:        r.Name,
+				GroupNo:     r.GroupNo,
+			})
+		}
+	}
+
+	if kind == resolveKindAll || kind == resolveKindThread {
+		type threadRow struct {
+			GroupNo    string `db:"group_no"`
+			ShortID    string `db:"short_id"`
+			Name       string `db:"name"`
+			ParentName string `db:"parent_name"`
+		}
+		var rows []threadRow
+		// Only threads under groups the bot belongs to. status IN (1,2) keeps
+		// active + archived and excludes deleted(3), matching the system
+		// GetThreads / sanitizeListStatuses contract. LIMIT limit+1 probes for
+		// truncation; exact name match first, then a stable ordering.
+		//
+		// COLLATE utf8mb4_general_ci is pinned here because thread.* is
+		// utf8mb4_general_ci while `group`/group_member.* are utf8mb4_0900_ai_ci.
+		// Two distinct reasons, do not conflate them:
+		//   1. REQUIRED — the JOIN ON column-to-column equalities
+		//      (gm.group_no = t.group_no, g.group_no = t.group_no) compare two
+		//      columns of differing collation with no literal to coerce them, so
+		//      MySQL 8.0 raises Error 1267 (Illegal mix of collations). COLLATE
+		//      on these is the actual fix.
+		//   2. DEFENSIVE — the ORDER BY exact-match check (t.name = ?) and the
+		//      t.name LIKE ? filter compare a column against a parameter/literal,
+		//      whose collation is coercible, so they normally do NOT raise 1267.
+		//      COLLATE there only pins the sort/compare semantics to one explicit
+		//      collation so ranking stays consistent.
+		// general_ci is chosen as the common collation; only the thread query
+		// needs this — the group query above touches no general_ci columns and is
+		// left untouched.
+		_, err := ba.ctx.DB().SelectBySql(
+			"SELECT t.group_no, t.short_id, t.name, g.name AS parent_name FROM thread t "+
+				"INNER JOIN group_member gm ON gm.group_no = t.group_no COLLATE utf8mb4_general_ci AND gm.uid = ? AND gm.is_deleted = 0 "+
+				"INNER JOIN `group` g ON g.group_no = t.group_no COLLATE utf8mb4_general_ci "+
+				"WHERE t.status IN (1, 2) AND t.name LIKE ? "+
+				"ORDER BY (t.name = ? COLLATE utf8mb4_general_ci) DESC, t.status ASC, t.group_no ASC, t.short_id ASC LIMIT ?",
+			robotID, pattern, name, limit+1,
+		).Load(&rows)
+		if err != nil {
+			ba.Error("resolve targets: query threads failed", zap.Error(err), zap.String("robotID", robotID))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
+			return
+		}
+		if len(rows) > limit {
+			truncated = true
+			rows = rows[:limit]
+		}
+		for _, r := range rows {
+			candidates = append(candidates, resolveTargetCandidate{
+				Kind:        resolveKindThread,
+				ChannelID:   thread.BuildChannelID(r.GroupNo, r.ShortID),
+				ChannelType: common.ChannelTypeCommunityTopic.Uint8(),
+				Name:        r.Name,
+				GroupNo:     r.GroupNo,
+				ShortID:     r.ShortID,
+				ParentName:  r.ParentName,
+			})
+		}
+	}
+
+	c.JSON(http.StatusOK, map[string]interface{}{
+		"candidates": candidates,
+		"total":      len(candidates),
+		"truncated":  truncated,
+	})
+}

--- a/modules/bot_api/resolve_targets_test.go
+++ b/modules/bot_api/resolve_targets_test.go
@@ -1,0 +1,358 @@
+package bot_api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+// resolve/targets test fixtures. One User Bot (bot_token auth) that is a member
+// of a few groups; non-member groups/threads must never surface. Seeding helpers
+// build the membership-scoped visibility the handler relies on.
+const (
+	rtRobotID  = "bot_rt_1"
+	rtBotToken = "bf_rt_token_1"
+)
+
+func setupBotResolveTargets(t *testing.T) (http.Handler, *config.Context) {
+	t.Helper()
+	s, ctx := testutil.NewTestServer()
+	assert.NoError(t, testutil.CleanAllTables(ctx))
+
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, status, creator_uid, bot_token) VALUES (?, 1, ?, ?)",
+		rtRobotID, "owner_rt", rtBotToken,
+	).Exec()
+	assert.NoError(t, err)
+
+	return s.GetRoute(), ctx
+}
+
+// seedGroup inserts a group row in the given space.
+func seedGroup(t *testing.T, ctx *config.Context, groupNo, name, spaceID string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `group` (group_no, name, status, version, space_id) VALUES (?, ?, 1, 1, ?)",
+		groupNo, name, spaceID,
+	).Exec()
+	assert.NoError(t, err)
+}
+
+// seedMember adds uid to a group (active membership).
+func seedMember(t *testing.T, ctx *config.Context, groupNo, uid string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO group_member (group_no, uid, vercode, is_deleted, status, version) VALUES (?, ?, ?, 0, 1, 1)",
+		groupNo, uid, util.GenerUUID(),
+	).Exec()
+	assert.NoError(t, err)
+}
+
+// seedThread inserts a thread row under a group with a given status.
+func seedThread(t *testing.T, ctx *config.Context, groupNo, shortID, name string, status int) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO thread (short_id, group_no, name, creator_uid, status, version) VALUES (?, ?, ?, ?, ?, 1)",
+		shortID, groupNo, name, "owner_rt", status,
+	).Exec()
+	assert.NoError(t, err)
+}
+
+type resolveTargetsResp struct {
+	Candidates []resolveTargetCandidate `json:"candidates"`
+	Total      int                      `json:"total"`
+	Truncated  bool                     `json:"truncated"`
+}
+
+func callResolveTargets(t *testing.T, handler http.Handler, token, query string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/v1/bot/resolve/targets?"+query, nil)
+	assert.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+func decodeResolveTargets(t *testing.T, w *httptest.ResponseRecorder) resolveTargetsResp {
+	t.Helper()
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	var b resolveTargetsResp
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &b))
+	return b
+}
+
+// TestResolveTargets_GroupAndThreadSameName verifies a same-named group and
+// thread both come back as distinct candidates (kind disambiguates them).
+func TestResolveTargets_GroupAndThreadSameName(t *testing.T) {
+	handler, ctx := setupBotResolveTargets(t)
+
+	seedGroup(t, ctx, "g_rt_a", "研发", "space_1")
+	seedMember(t, ctx, "g_rt_a", rtRobotID)
+	seedThread(t, ctx, "g_rt_a", "tp_a1", "研发", 1)
+
+	b := decodeResolveTargets(t, callResolveTargets(t, handler, rtBotToken, "name=研发"))
+	assert.Equal(t, 2, b.Total)
+	assert.False(t, b.Truncated)
+
+	var group, thread *resolveTargetCandidate
+	for i := range b.Candidates {
+		switch b.Candidates[i].Kind {
+		case resolveKindGroup:
+			group = &b.Candidates[i]
+		case resolveKindThread:
+			thread = &b.Candidates[i]
+		}
+	}
+	if assert.NotNil(t, group) {
+		assert.Equal(t, "g_rt_a", group.ChannelID)
+		assert.Equal(t, common.ChannelTypeGroup.Uint8(), group.ChannelType)
+		assert.Equal(t, "g_rt_a", group.GroupNo)
+	}
+	if assert.NotNil(t, thread) {
+		assert.Equal(t, "g_rt_a____tp_a1", thread.ChannelID)
+		assert.Equal(t, common.ChannelTypeCommunityTopic.Uint8(), thread.ChannelType)
+		assert.Equal(t, "g_rt_a", thread.GroupNo)
+		assert.Equal(t, "tp_a1", thread.ShortID)
+		assert.Equal(t, "研发", thread.ParentName)
+	}
+}
+
+// TestResolveTargets_MultipleSameNameThreadsAcrossGroups verifies same-named
+// threads under different parent groups all return.
+func TestResolveTargets_MultipleSameNameThreadsAcrossGroups(t *testing.T) {
+	handler, ctx := setupBotResolveTargets(t)
+
+	seedGroup(t, ctx, "g_rt_b1", "大群一", "space_1")
+	seedMember(t, ctx, "g_rt_b1", rtRobotID)
+	seedThread(t, ctx, "g_rt_b1", "tp_b1", "周报", 1)
+
+	seedGroup(t, ctx, "g_rt_b2", "大群二", "space_1")
+	seedMember(t, ctx, "g_rt_b2", rtRobotID)
+	seedThread(t, ctx, "g_rt_b2", "tp_b2", "周报", 1)
+
+	b := decodeResolveTargets(t, callResolveTargets(t, handler, rtBotToken, "name=周报&kind=thread"))
+	assert.Equal(t, 2, b.Total)
+	parents := map[string]string{}
+	for _, cand := range b.Candidates {
+		assert.Equal(t, resolveKindThread, cand.Kind)
+		parents[cand.GroupNo] = cand.ParentName
+	}
+	assert.Equal(t, "大群一", parents["g_rt_b1"])
+	assert.Equal(t, "大群二", parents["g_rt_b2"])
+}
+
+// TestResolveTargets_NonMemberNotVisible verifies groups/threads the bot is not
+// a member of never surface.
+func TestResolveTargets_NonMemberNotVisible(t *testing.T) {
+	handler, ctx := setupBotResolveTargets(t)
+
+	// Bot is a member here.
+	seedGroup(t, ctx, "g_rt_mine", "项目组", "space_1")
+	seedMember(t, ctx, "g_rt_mine", rtRobotID)
+	seedThread(t, ctx, "g_rt_mine", "tp_mine", "项目组", 1)
+
+	// Bot is NOT a member here (some other group with the same name).
+	seedGroup(t, ctx, "g_rt_other", "项目组", "space_1")
+	seedThread(t, ctx, "g_rt_other", "tp_other", "项目组", 1)
+
+	b := decodeResolveTargets(t, callResolveTargets(t, handler, rtBotToken, "name=项目组"))
+	for _, cand := range b.Candidates {
+		assert.Equal(t, "g_rt_mine", cand.GroupNo, "only the member group/thread must surface")
+	}
+	assert.Equal(t, 2, b.Total) // one group + one thread, both from g_rt_mine
+}
+
+// TestResolveTargets_CrossSpaceExternalGroup verifies that a group in a different
+// space, that the bot was pulled into as a member, is still resolvable (v2: no
+// space filter).
+func TestResolveTargets_CrossSpaceExternalGroup(t *testing.T) {
+	handler, ctx := setupBotResolveTargets(t)
+
+	// External group lives in space_2; bot is still a member.
+	seedGroup(t, ctx, "g_rt_ext", "外部协作", "space_2")
+	seedMember(t, ctx, "g_rt_ext", rtRobotID)
+	seedThread(t, ctx, "g_rt_ext", "tp_ext", "外部协作", 1)
+
+	b := decodeResolveTargets(t, callResolveTargets(t, handler, rtBotToken, "name=外部协作"))
+	assert.Equal(t, 2, b.Total)
+	for _, cand := range b.Candidates {
+		assert.Equal(t, "g_rt_ext", cand.GroupNo)
+	}
+}
+
+// TestResolveTargets_KindFilter verifies kind=group and kind=thread filters.
+func TestResolveTargets_KindFilter(t *testing.T) {
+	handler, ctx := setupBotResolveTargets(t)
+
+	seedGroup(t, ctx, "g_rt_k", "客服", "space_1")
+	seedMember(t, ctx, "g_rt_k", rtRobotID)
+	seedThread(t, ctx, "g_rt_k", "tp_k", "客服", 1)
+
+	gOnly := decodeResolveTargets(t, callResolveTargets(t, handler, rtBotToken, "name=客服&kind=group"))
+	assert.Equal(t, 1, gOnly.Total)
+	assert.Equal(t, resolveKindGroup, gOnly.Candidates[0].Kind)
+
+	tOnly := decodeResolveTargets(t, callResolveTargets(t, handler, rtBotToken, "name=客服&kind=thread"))
+	assert.Equal(t, 1, tOnly.Total)
+	assert.Equal(t, resolveKindThread, tOnly.Candidates[0].Kind)
+}
+
+// TestResolveTargets_InvalidKind rejects an unknown kind value.
+func TestResolveTargets_InvalidKind(t *testing.T) {
+	handler, _ := setupBotResolveTargets(t)
+	w := callResolveTargets(t, handler, rtBotToken, "name=x&kind=bogus")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestResolveTargets_ExactMatchFirst verifies an exact name match sorts ahead of
+// a partial (wildcard) match.
+func TestResolveTargets_ExactMatchFirst(t *testing.T) {
+	handler, ctx := setupBotResolveTargets(t)
+
+	seedGroup(t, ctx, "g_rt_e1", "产研中心", "space_1")
+	seedMember(t, ctx, "g_rt_e1", rtRobotID)
+	seedGroup(t, ctx, "g_rt_e2", "产研", "space_1")
+	seedMember(t, ctx, "g_rt_e2", rtRobotID)
+
+	b := decodeResolveTargets(t, callResolveTargets(t, handler, rtBotToken, "name=产研&kind=group"))
+	assert.Equal(t, 2, b.Total)
+	assert.Equal(t, "产研", b.Candidates[0].Name, "exact match must sort first")
+}
+
+// TestResolveTargets_LimitClampAndTruncated verifies limit>50 clamps to 50, and
+// that filling the group limit still returns the thread and sets truncated.
+func TestResolveTargets_LimitClampAndTruncated(t *testing.T) {
+	handler, ctx := setupBotResolveTargets(t)
+
+	// 3 groups + 3 threads matching "区", limit=2 → each class returns 2,
+	// both classes truncated.
+	for i, gn := range []string{"g_rt_l1", "g_rt_l2", "g_rt_l3"} {
+		seedGroup(t, ctx, gn, "区"+string(rune('A'+i)), "space_1")
+		seedMember(t, ctx, gn, rtRobotID)
+		seedThread(t, ctx, gn, "tp_l"+string(rune('1'+i)), "区"+string(rune('X'+i)), 1)
+	}
+
+	b := decodeResolveTargets(t, callResolveTargets(t, handler, rtBotToken, "name=区&limit=2"))
+	groupCount, threadCount := 0, 0
+	for _, cand := range b.Candidates {
+		if cand.Kind == resolveKindGroup {
+			groupCount++
+		} else {
+			threadCount++
+		}
+	}
+	assert.Equal(t, 2, groupCount, "group class clamped to limit")
+	assert.Equal(t, 2, threadCount, "thread class clamped to limit, not squeezed out by groups")
+	assert.True(t, b.Truncated)
+	assert.Equal(t, 4, b.Total)
+}
+
+// TestResolveTargets_GroupFullStillReturnsThread is the BLOCKER#4 guard: a full
+// group class must not squeeze out the (only) matching thread.
+func TestResolveTargets_GroupFullStillReturnsThread(t *testing.T) {
+	handler, ctx := setupBotResolveTargets(t)
+
+	// 2 matching groups, limit=1 → group class fills and truncates; the single
+	// matching thread must still come back.
+	seedGroup(t, ctx, "g_rt_f1", "同名", "space_1")
+	seedMember(t, ctx, "g_rt_f1", rtRobotID)
+	seedGroup(t, ctx, "g_rt_f2", "同名", "space_1")
+	seedMember(t, ctx, "g_rt_f2", rtRobotID)
+	seedThread(t, ctx, "g_rt_f1", "tp_f1", "同名", 1)
+
+	b := decodeResolveTargets(t, callResolveTargets(t, handler, rtBotToken, "name=同名&limit=1"))
+	groupCount, threadCount := 0, 0
+	for _, cand := range b.Candidates {
+		if cand.Kind == resolveKindGroup {
+			groupCount++
+		} else {
+			threadCount++
+		}
+	}
+	assert.Equal(t, 1, groupCount)
+	assert.Equal(t, 1, threadCount, "thread must not be squeezed out by a full group class")
+	assert.True(t, b.Truncated)
+}
+
+// TestResolveTargets_WildcardEscaped verifies % and _ in the name are treated as
+// literals, not LIKE wildcards.
+func TestResolveTargets_WildcardEscaped(t *testing.T) {
+	handler, ctx := setupBotResolveTargets(t)
+
+	seedGroup(t, ctx, "g_rt_w1", "50%达成", "space_1")
+	seedMember(t, ctx, "g_rt_w1", rtRobotID)
+	// A group that would match if % were a wildcard but must NOT match literally.
+	seedGroup(t, ctx, "g_rt_w2", "50abc达成", "space_1")
+	seedMember(t, ctx, "g_rt_w2", rtRobotID)
+
+	b := decodeResolveTargets(t, callResolveTargets(t, handler, rtBotToken, "name=50%25&kind=group"))
+	assert.Equal(t, 1, b.Total, "%% must be matched literally, not as a wildcard")
+	assert.Equal(t, "50%达成", b.Candidates[0].Name)
+}
+
+// TestResolveTargets_EmptyName returns 400 for a blank name.
+func TestResolveTargets_EmptyName(t *testing.T) {
+	handler, _ := setupBotResolveTargets(t)
+	w := callResolveTargets(t, handler, rtBotToken, "name=%20%20")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestResolveTargets_ArchivedThreadVisibleDeletedHidden verifies status IN (1,2)
+// — archived (2) is searchable, deleted (3) is not.
+func TestResolveTargets_ArchivedThreadVisibleDeletedHidden(t *testing.T) {
+	handler, ctx := setupBotResolveTargets(t)
+
+	seedGroup(t, ctx, "g_rt_s", "归档群", "space_1")
+	seedMember(t, ctx, "g_rt_s", rtRobotID)
+	seedThread(t, ctx, "g_rt_s", "tp_active", "状态区", 1)
+	seedThread(t, ctx, "g_rt_s", "tp_archived", "状态区", 2)
+	seedThread(t, ctx, "g_rt_s", "tp_deleted", "状态区", 3)
+
+	b := decodeResolveTargets(t, callResolveTargets(t, handler, rtBotToken, "name=状态区&kind=thread"))
+	shortIDs := map[string]bool{}
+	for _, cand := range b.Candidates {
+		shortIDs[cand.ShortID] = true
+	}
+	assert.True(t, shortIDs["tp_active"], "active thread must be visible")
+	assert.True(t, shortIDs["tp_archived"], "archived thread must be visible")
+	assert.False(t, shortIDs["tp_deleted"], "deleted thread must be hidden")
+	assert.Equal(t, 2, b.Total)
+}
+
+// TestResolveTargets_AppBotReturnsEmpty verifies an App Bot (no group_member
+// rows) resolves to an empty candidate set rather than being rejected.
+func TestResolveTargets_AppBotReturnsEmpty(t *testing.T) {
+	handler, ctx := setupBotResolveTargets(t)
+
+	const appToken = "app_rt_token_1"
+	// Register the App Bot in the in-memory registry so authBot resolves it via
+	// the O(1) path without needing the app_bot table in the test schema.
+	reg := NewAppBotRegistryAdapter()
+	reg.Add(appToken, &AppBotRegistrySpec{UID: "appbot_rt_uid", Scope: "platform"})
+	prev := GetAppBotRegistry()
+	SetAppBotRegistry(reg)
+	t.Cleanup(func() {
+		if prev != nil {
+			SetAppBotRegistry(prev)
+		} else {
+			SetAppBotRegistry(NewAppBotRegistryAdapter())
+		}
+	})
+
+	// Seed a group with a matching name but no app-bot membership.
+	seedGroup(t, ctx, "g_rt_app", "应用群", "space_1")
+	seedThread(t, ctx, "g_rt_app", "tp_app", "应用群", 1)
+
+	b := decodeResolveTargets(t, callResolveTargets(t, handler, appToken, "name=应用群"))
+	assert.Equal(t, 0, b.Total)
+	assert.Empty(t, b.Candidates)
+	assert.False(t, b.Truncated)
+}


### PR DESCRIPTION
## Summary

Adds `GET /v1/bot/resolve/targets`, a bot-token endpoint that searches the calling bot's visible groups and threads by name and returns a unified candidate array. This lets the adapter disambiguate a named forward target ("forward to 'XXX'") — where XXX may be a group or a thread — instead of guessing.

Closes #333.

## Behavior

- Visibility is defined purely by membership (`group_member.uid = robotID AND is_deleted = 0`). No `space_id` filter, so a bot pulled into a cross-space external group can still resolve that group and its threads.
- Same-named group and thread both come back as distinct candidates, disambiguated by `kind` (`group` / `thread`). Multiple same-named candidates are returned faithfully; the endpoint never guesses.
- `kind` filter accepts `all` (default) / `group` / `thread`.
- `status IN (1, 2)` keeps active + archived threads and excludes deleted, matching the system `GetThreads` / `sanitizeListStatuses` contract.
- `LIMIT limit+1` probes for truncation; default limit 20, capped at 50. Exact (un-wildcarded) name match is ordered first, followed by a stable ordering.
- LIKE wildcards in user input are escaped.
- App Bots (no `group_member` rows) naturally resolve to an empty set rather than being rejected, following the read-only `getGroups` precedent.

## Response shape

```json
{
  "candidates": [
    { "kind": "group",  "channel_id": "<group_no>", "channel_type": 2, "name": "...", "group_no": "..." },
    { "kind": "thread", "channel_id": "<group_no>____<short_id>", "channel_type": 5, "name": "...", "group_no": "...", "short_id": "...", "parent_name": "..." }
  ],
  "total": 2,
  "truncated": false
}
```

## Notes

- The thread query joins `thread` (`utf8mb4_general_ci`) with `group` / `group_member` (`utf8mb4_0900_ai_ci`). The cross-collation column-to-column join equalities are pinned with an explicit `COLLATE` to avoid MySQL 8.0 `Error 1267 (Illegal mix of collations)`. The group query touches no mixed-collation columns and is left untouched.

## Testing

- New integration tests in `modules/bot_api/resolve_targets_test.go` (13 subtests, run against a real MySQL 8.0): same-name group+thread, multiple same-name threads across groups, non-member not visible, cross-space external group, kind filter, invalid kind, exact-match-first ordering, limit clamp + truncation, group-full-still-returns-thread, wildcard escaping, empty name, archived-visible/deleted-hidden, app-bot-empty. All pass.
- `make i18n-extract-check` and `make i18n-lint` pass.
