### PR TITLE
feat(i18n): localize BotFather command menu via per-request rendering (#335)

### DIFF
--- a/modules/botfather/api.go
+++ b/modules/botfather/api.go
@@ -1,7 +1,7 @@
 package botfather
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -13,11 +13,13 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/app"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
+	"github.com/Mininglamp-OSS/octo-server/modules/botfather/cmdmenu"
 	"github.com/Mininglamp-OSS/octo-server/modules/file"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/botutil"
+	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
 )
@@ -289,36 +291,20 @@ func (bf *BotFather) initBotFatherUser() {
 }
 
 // registerBotFatherCommands 注册BotFather自身的命令列表
+//
+// 库里这份 blob 只承载一种语言：部署默认语言（OCTO_DEFAULT_LANGUAGE）。它是
+// 所有拿不到请求上下文的读取面（管理端 robot 详情、批量用户详情填充）的兜底；
+// 面向用户的菜单端点会按请求协商语言用 cmdmenu 重新渲染（#335）。每次启动
+// 无条件覆写，所以部署默认语言变更后存量数据自愈，无需迁移。
 func (bf *BotFather) registerBotFatherCommands() {
-	commands := []map[string]string{
-		{"command": CmdInstall, "description": "安装/更新 Octo 插件"},
-		{"command": CmdQuickstart, "description": "AI Agent 快速入门"},
-		{"command": CmdNewBot, "description": "创建新机器人"},
-		{"command": CmdMyBots, "description": "查看我的机器人"},
-		{"command": CmdConnect, "description": "获取连接 prompt"},
-		{"command": CmdDisconnect, "description": "断开 Agent 连接"},
-		{"command": CmdSetName, "description": "修改机器人名称"},
-		{"command": CmdSetDescription, "description": "修改机器人描述"},
-		{"command": CmdDeleteBot, "description": "删除机器人"},
-		{"command": CmdToken, "description": "查看 Token"},
-		{"command": CmdRevoke, "description": "重置 Token"},
-		{"command": CmdApprove, "description": "通过好友申请"},
-		{"command": CmdReject, "description": "拒绝好友申请"},
-		{"command": CmdPending, "description": "查看待审批好友申请"},
-		{"command": CmdHelp, "description": "显示帮助"},
-		{"command": CmdCancel, "description": "取消当前操作"},
-	}
-	commandsJSON, err := json.Marshal(commands)
-	if err != nil {
-		bf.Error("序列化BotFather命令列表失败", zap.Error(err))
-		return
-	}
-	err = bf.db.updateBotCommands(BotFatherUID, string(commandsJSON))
+	// background ctx 没有协商语言，OutboundLanguage 即返回部署默认语言。
+	lang := octoi18n.OutboundLanguage(context.Background())
+	err := bf.db.updateBotCommands(BotFatherUID, cmdmenu.JSON(lang))
 	if err != nil {
 		bf.Error("注册BotFather命令列表失败", zap.Error(err))
 		return
 	}
-	bf.Info("BotFather命令列表注册成功")
+	bf.Info("BotFather命令列表注册成功", zap.String("lang", lang))
 }
 
 // ensureBotFatherFriends 批量为缺少BotFather好友关系的用户添加

--- a/modules/botfather/api_cmdmenu_e2e_test.go
+++ b/modules/botfather/api_cmdmenu_e2e_test.go
@@ -1,0 +1,144 @@
+package botfather
+
+// End-to-end coverage for #335: BotFather's command menu is server-owned copy,
+// stored once in the deployment default language (registerBotFatherCommands)
+// and re-rendered per request on the menu-bearing read endpoints. These tests
+// live in the botfather package — not in channel/user — because this is the
+// only package that may import every involved module: user cannot blank-import
+// botfather's migrations (botfather → user would cycle), yet GetUserDetail's
+// robot-details query needs botfather-owned columns (agent_platform, ...).
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/server"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/botfather/cmdmenu"
+	"github.com/Mininglamp-OSS/octo-server/modules/channel"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/stretchr/testify/assert"
+)
+
+// setupCmdMenuE2E builds the full server and normalizes the BotFather rows the
+// module bootstrap created during module.Setup: user.robot=1 (set by the
+// deployment seed in production, not by initBotFatherUser) and a deterministic
+// zh-CN blob in robot.bot_commands (the bootstrap renders whatever
+// OCTO_DEFAULT_LANGUAGE was at setup time). Also creates the login user.
+func setupCmdMenuE2E(t *testing.T) (*server.Server, *config.Context) {
+	t.Helper()
+	s, ctx := testutil.NewTestServer()
+
+	svc := user.NewService(ctx)
+	assert.NoError(t, svc.AddUser(&user.AddUserReq{UID: testutil.UID, Name: "Login User"}))
+	_, err := ctx.DB().UpdateBySql("UPDATE user SET robot=1 WHERE uid=?", BotFatherUID).Exec()
+	assert.NoError(t, err)
+	_, err = ctx.DB().UpdateBySql("UPDATE robot SET bot_commands=? WHERE robot_id=?",
+		cmdmenu.JSON("zh-CN"), BotFatherUID).Exec()
+	assert.NoError(t, err)
+
+	return s, ctx
+}
+
+// channelExtraBotCommands extracts extra.bot_commands from a ChannelResp body.
+func channelExtraBotCommands(t *testing.T, body []byte) string {
+	t.Helper()
+	var resp struct {
+		Extra map[string]interface{} `json:"extra"`
+	}
+	assert.NoError(t, json.Unmarshal(body, &resp), "body=%s", body)
+	v, _ := resp.Extra["bot_commands"].(string)
+	return v
+}
+
+// TestChannelGet_BotFatherMenuFollowsDeploymentDefault pins the #335 floor on
+// the fully wired route set: with no negotiated request language (testutil's
+// router mounts no EarlyMiddleware, mirroring a context-less caller) the
+// override renders OCTO_DEFAULT_LANGUAGE — so an en-US deployment no longer
+// serves the stored zh-CN blob.
+func TestChannelGet_BotFatherMenuFollowsDeploymentDefault(t *testing.T) {
+	s, ctx := setupCmdMenuE2E(t)
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+
+	t.Setenv(octoi18n.EnvDefaultLanguage, "en-US")
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/v1/channels/"+BotFatherUID+"/1", nil)
+	assert.NoError(t, err)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Equal(t, cmdmenu.JSON("en-US"), channelExtraBotCommands(t, w.Body.Bytes()),
+		"en-US deployment must see the English menu even though the stored blob is zh-CN")
+}
+
+// TestChannelGet_BotFatherMenuFollowsRequestLanguage mounts the production
+// EarlyMiddleware on a fresh router (testutil's route set omits it) and pins
+// the per-request property #335's per-language-storage option was assumed to
+// require: two users of ONE deployment each see the menu in their own
+// negotiated language, with no schema change.
+func TestChannelGet_BotFatherMenuFollowsRequestLanguage(t *testing.T) {
+	_, ctx := setupCmdMenuE2E(t)
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+
+	r := wkhttp.New()
+	r.UseGin(octoi18n.EarlyMiddleware(octoi18n.MiddlewareOptions{DefaultLanguage: octoi18n.DefaultLanguage}))
+	channel.New(ctx).Route(r)
+
+	cases := []struct {
+		acceptLanguage string
+		want           string
+	}{
+		{"en-US", cmdmenu.JSON("en-US")},
+		{"zh-CN", cmdmenu.JSON("zh-CN")},
+		{"", cmdmenu.JSON(octoi18n.DefaultLanguage)},
+	}
+	for _, tc := range cases {
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/v1/channels/"+BotFatherUID+"/1", nil)
+		assert.NoError(t, err)
+		req.Header.Set("token", testutil.Token)
+		if tc.acceptLanguage != "" {
+			req.Header.Set("Accept-Language", tc.acceptLanguage)
+		}
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code, "Accept-Language=%q body=%s", tc.acceptLanguage, w.Body.String())
+		assert.Equal(t, tc.want, channelExtraBotCommands(t, w.Body.Bytes()), "Accept-Language=%q", tc.acceptLanguage)
+	}
+}
+
+// TestUserGet_BotFatherMenuLocalized pins the #335 override on
+// GET /v1/users/botfather: the response carries bot_commands rendered in the
+// resolved language, not the stored zh-CN blob.
+func TestUserGet_BotFatherMenuLocalized(t *testing.T) {
+	s, ctx := setupCmdMenuE2E(t)
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+
+	fetch := func() string {
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/v1/users/"+BotFatherUID, nil)
+		assert.NoError(t, err)
+		req.Header.Set("token", testutil.Token)
+		s.GetRoute().ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		var resp struct {
+			BotCommands string `json:"bot_commands"`
+		}
+		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		return resp.BotCommands
+	}
+
+	t.Setenv(octoi18n.EnvDefaultLanguage, "en-US")
+	assert.Equal(t, cmdmenu.JSON("en-US"), fetch(),
+		"en-US deployment must see the English menu even though the stored blob is zh-CN")
+
+	t.Setenv(octoi18n.EnvDefaultLanguage, "zh-CN")
+	assert.Equal(t, cmdmenu.JSON("zh-CN"), fetch())
+}

--- a/modules/botfather/api_cmdmenu_e2e_test.go
+++ b/modules/botfather/api_cmdmenu_e2e_test.go
@@ -22,8 +22,26 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/channel"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/go-redis/redis"
 	"github.com/stretchr/testify/assert"
 )
+
+// resetUIDRateLimit clears the per-uid token-bucket keys (ratelimit:uid:{uid})
+// so HTTP calls on SharedUIDRateLimiter-mounted routes (friend/sync) start
+// from a full bucket. The bucket persists in Redis and is NOT cleared by
+// CleanAllTables — pattern mirrors modules/category's resetUIDRateLimit.
+func resetUIDRateLimit(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	rdsClient := redis.NewClient(&redis.Options{
+		Addr:     ctx.GetConfig().DB.RedisAddr,
+		Password: ctx.GetConfig().DB.RedisPass,
+	})
+	defer rdsClient.Close()
+	keys, err := rdsClient.Keys("ratelimit:uid:*").Result()
+	if err == nil && len(keys) > 0 {
+		_ = rdsClient.Del(keys...).Err()
+	}
+}
 
 // setupCmdMenuE2E builds the full server and normalizes the BotFather rows the
 // module bootstrap created during module.Setup: user.robot=1 (set by the
@@ -141,4 +159,93 @@ func TestUserGet_BotFatherMenuLocalized(t *testing.T) {
 
 	t.Setenv(octoi18n.EnvDefaultLanguage, "zh-CN")
 	assert.Equal(t, cmdmenu.JSON("zh-CN"), fetch())
+}
+
+// TestUserGet_BotFatherMenuFollowsRequestLanguage pins the per-request
+// negotiation branch on GET /v1/users/botfather (the env-floor test above
+// cannot catch a handler reading the wrong context key).
+func TestUserGet_BotFatherMenuFollowsRequestLanguage(t *testing.T) {
+	_, ctx := setupCmdMenuE2E(t)
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+
+	r := wkhttp.New()
+	r.UseGin(octoi18n.EarlyMiddleware(octoi18n.MiddlewareOptions{DefaultLanguage: octoi18n.DefaultLanguage}))
+	user.New(ctx).Route(r)
+
+	for _, tc := range []struct {
+		acceptLanguage string
+		want           string
+	}{
+		{"en-US", cmdmenu.JSON("en-US")},
+		{"zh-CN", cmdmenu.JSON("zh-CN")},
+	} {
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/v1/users/"+BotFatherUID, nil)
+		assert.NoError(t, err)
+		req.Header.Set("token", testutil.Token)
+		req.Header.Set("Accept-Language", tc.acceptLanguage)
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code, "Accept-Language=%q body=%s", tc.acceptLanguage, w.Body.String())
+		var resp struct {
+			BotCommands string `json:"bot_commands"`
+		}
+		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, tc.want, resp.BotCommands, "Accept-Language=%q", tc.acceptLanguage)
+	}
+}
+
+// TestFriendSync_BotFatherMenuFollowsRequestLanguage covers the batch
+// GetUserDetails surface (friend sync / friend search / search / conversation
+// enrichment): BotFather is everyone's friend, and friendResp embeds
+// UserDetailResp, so the stored blob used to leak through unlocalized here
+// even though the call sites carry a request context (#338 review P1).
+func TestFriendSync_BotFatherMenuFollowsRequestLanguage(t *testing.T) {
+	_, ctx := setupCmdMenuE2E(t)
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+	resetUIDRateLimit(t, ctx)
+
+	// friendSync's legacy branch (no api_version/space_id) lists the caller's
+	// default-space members as pseudo-friends — the smallest seed that routes
+	// BotFather through the batch GetUserDetails fill.
+	for _, uid := range []string{testutil.UID, BotFatherUID} {
+		_, err := ctx.DB().InsertBySql(
+			"INSERT INTO space_member(space_id, uid, status) VALUES ('s_cmdmenu', ?, 1)", uid,
+		).Exec()
+		assert.NoError(t, err)
+	}
+
+	r := wkhttp.New()
+	r.UseGin(octoi18n.EarlyMiddleware(octoi18n.MiddlewareOptions{DefaultLanguage: octoi18n.DefaultLanguage}))
+	user.NewFriend(ctx).Route(r)
+
+	for _, tc := range []struct {
+		acceptLanguage string
+		want           string
+	}{
+		{"en-US", cmdmenu.JSON("en-US")},
+		{"zh-CN", cmdmenu.JSON("zh-CN")},
+	} {
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/v1/friend/sync", nil)
+		assert.NoError(t, err)
+		req.Header.Set("token", testutil.Token)
+		req.Header.Set("Accept-Language", tc.acceptLanguage)
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code, "Accept-Language=%q body=%s", tc.acceptLanguage, w.Body.String())
+		var resps []struct {
+			UID         string `json:"uid"`
+			BotCommands string `json:"bot_commands"`
+		}
+		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resps), "body=%s", w.Body.String())
+		found := false
+		for _, item := range resps {
+			if item.UID == BotFatherUID {
+				found = true
+				assert.Equal(t, tc.want, item.BotCommands, "Accept-Language=%q", tc.acceptLanguage)
+			}
+		}
+		assert.True(t, found, "friend sync must include BotFather; body=%s", w.Body.String())
+	}
 }

--- a/modules/botfather/api_cmdmenu_register_test.go
+++ b/modules/botfather/api_cmdmenu_register_test.go
@@ -1,0 +1,36 @@
+package botfather
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/modules/botfather/cmdmenu"
+	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRegisterBotFatherCommands_WritesDeploymentDefault pins the #335 floor:
+// the startup write renders the menu in OCTO_DEFAULT_LANGUAGE, and because it
+// overwrites unconditionally on every boot, an existing deployment's stored
+// blob self-heals after the default changes — no migration involved.
+func TestRegisterBotFatherCommands_WritesDeploymentDefault(t *testing.T) {
+	_, bf := setupTestBotFather(t)
+	createTestRobot(t, bf, BotFatherUID, "", 1)
+
+	readBlob := func() string {
+		var blob string
+		err := bf.db.session.Select("IFNULL(bot_commands,'')").From("robot").
+			Where("robot_id=?", BotFatherUID).LoadOne(&blob)
+		assert.NoError(t, err)
+		return blob
+	}
+
+	t.Setenv(octoi18n.EnvDefaultLanguage, "en-US")
+	bf.registerBotFatherCommands()
+	assert.Equal(t, cmdmenu.JSON("en-US"), readBlob(),
+		"startup write must render the deployment default language")
+
+	t.Setenv(octoi18n.EnvDefaultLanguage, "zh-CN")
+	bf.registerBotFatherCommands()
+	assert.Equal(t, cmdmenu.JSON("zh-CN"), readBlob(),
+		"unconditional overwrite must self-heal the stored blob on re-boot")
+}

--- a/modules/botfather/cmdmenu/cmdmenu.go
+++ b/modules/botfather/cmdmenu/cmdmenu.go
@@ -1,0 +1,122 @@
+// Package cmdmenu owns BotFather's own command menu — the /newbot, /help, ...
+// entries written to robot.bot_commands and rendered by clients as the chat
+// command picker (#335).
+//
+// The menu is server-owned copy (unlike user bots' commands, which are creator
+// content set via POST /v1/bot/setCommands and are never localized), so its
+// descriptions render through the shared msgtmpl catalog. The stored blob can
+// only carry ONE language, therefore localization happens in two layers:
+//
+//   - startup (botfather.registerBotFatherCommands) writes the blob in the
+//     deployment default language — the floor served by every path without a
+//     request context (admin robot detail, batch user-detail enrichment);
+//   - the menu-bearing read endpoints (channel info extra.bot_commands,
+//     /v1/robot/commands, /v1/users/:uid) override the blob per request via
+//     JSON(i18n.OutboundLanguage(ctx)), for the BotFather UID only.
+//
+// This package is deliberately a LEAF (msgtmpl + pkg/i18n only): botfather
+// imports user, so the read-side modules (user, channel, robot) can only share
+// this catalog through a package that imports neither.
+package cmdmenu
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+
+	"github.com/Mininglamp-OSS/octo-server/modules/base/common/msgtmpl"
+	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+// BotFatherUID is the BotFather system bot's UID. The canonical constant lives
+// here (not in the botfather package, which aliases it) so the read-side
+// override call sites can match it without an import cycle.
+const BotFatherUID = "botfather"
+
+// Command is one menu entry in the robot.bot_commands storage/wire shape.
+type Command struct {
+	Command     string `json:"command"`
+	Description string `json:"description"`
+}
+
+// templatesFS holds the per-language menu-description templates.
+// Layout: templates/{lang}/menu.tmpl, one {{define "menu_*"}} block per entry.
+//
+//go:embed templates
+var templatesFS embed.FS
+
+// catalog enforces the msgtmpl completeness matrix at init: a supported
+// language missing any menu key fails startup loudly.
+var catalog = msgtmpl.MustNew(templatesFS, "templates")
+
+// entries is the menu in display order; key names the {{define}} block.
+var entries = []struct{ command, key string }{
+	{"/install", "menu_install"},
+	{"/quickstart", "menu_quickstart"},
+	{"/newbot", "menu_newbot"},
+	{"/mybots", "menu_mybots"},
+	{"/connect", "menu_connect"},
+	{"/disconnect", "menu_disconnect"},
+	{"/setname", "menu_setname"},
+	{"/setdescription", "menu_setdescription"},
+	{"/deletebot", "menu_deletebot"},
+	{"/token", "menu_token"},
+	{"/revoke", "menu_revoke"},
+	{"/approve", "menu_approve"},
+	{"/reject", "menu_reject"},
+	{"/pending", "menu_pending"},
+	{"/help", "menu_help"},
+	{"/cancel", "menu_cancel"},
+}
+
+// The menu is static (no template params), so every language is pre-rendered
+// once at init; a render/marshal failure here is an asset defect and must fail
+// loud at startup, never surface as a half-built menu at request time.
+var (
+	commandsByLang = map[string][]Command{}
+	jsonByLang     = map[string]string{}
+)
+
+func init() {
+	for _, lang := range octoi18n.SupportedLanguages() {
+		menu := make([]Command, 0, len(entries))
+		for _, e := range entries {
+			desc, err := catalog.Render(e.key, lang, nil)
+			if err != nil {
+				panic(fmt.Sprintf("cmdmenu: render %s (%s): %v", e.key, lang, err))
+			}
+			menu = append(menu, Command{Command: e.command, Description: desc})
+		}
+		raw, err := json.Marshal(menu)
+		if err != nil {
+			panic(fmt.Sprintf("cmdmenu: marshal menu (%s): %v", lang, err))
+		}
+		commandsByLang[lang] = menu
+		jsonByLang[lang] = string(raw)
+	}
+}
+
+// normalize maps lang onto the supported matrix, falling back to the source
+// language for an unsupported/empty tag — the same contract as msgtmpl.Render.
+func normalize(lang string) string {
+	if norm, ok := octoi18n.MatchSupportedLanguage(lang); ok {
+		if _, present := jsonByLang[norm]; present {
+			return norm
+		}
+	}
+	return octoi18n.SourceLanguage
+}
+
+// Commands returns the menu with descriptions rendered in lang.
+func Commands(lang string) []Command {
+	src := commandsByLang[normalize(lang)]
+	out := make([]Command, len(src))
+	copy(out, src)
+	return out
+}
+
+// JSON returns the menu serialized in the robot.bot_commands storage/wire
+// shape, rendered in lang.
+func JSON(lang string) string {
+	return jsonByLang[normalize(lang)]
+}

--- a/modules/botfather/cmdmenu/cmdmenu.go
+++ b/modules/botfather/cmdmenu/cmdmenu.go
@@ -8,11 +8,13 @@
 // only carry ONE language, therefore localization happens in two layers:
 //
 //   - startup (botfather.registerBotFatherCommands) writes the blob in the
-//     deployment default language — the floor served by every path without a
-//     request context (admin robot detail, batch user-detail enrichment);
-//   - the menu-bearing read endpoints (channel info extra.bot_commands,
-//     /v1/robot/commands, /v1/users/:uid) override the blob per request via
-//     JSON(i18n.OutboundLanguage(ctx)), for the BotFather UID only.
+//     deployment default language — the floor served by paths that genuinely
+//     have no request context (admin robot detail, future context-less reads);
+//   - every request-bearing read of the blob overrides it per request via
+//     JSON(i18n.OutboundLanguage(ctx)), for the BotFather UID only: channel
+//     info extra.bot_commands, /v1/robot/commands, /v1/users/:uid, and the
+//     batch user-detail fill (user.Service.GetUserDetails) behind friend
+//     sync / friend search / search / conversation enrichment.
 //
 // This package is deliberately a LEAF (msgtmpl + pkg/i18n only): botfather
 // imports user, so the read-side modules (user, channel, robot) can only share

--- a/modules/botfather/cmdmenu/cmdmenu_test.go
+++ b/modules/botfather/cmdmenu/cmdmenu_test.go
@@ -1,0 +1,114 @@
+package cmdmenu
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+// TestMenuCompleteness asserts the template tree and the entries table cannot
+// drift: every entry key resolves in every supported language (non-empty), and
+// the tree defines no orphan keys the menu never uses.
+func TestMenuCompleteness(t *testing.T) {
+	wantKeys := map[string]struct{}{}
+	for _, e := range entries {
+		if _, dup := wantKeys[e.key]; dup {
+			t.Fatalf("duplicate entry key %q", e.key)
+		}
+		wantKeys[e.key] = struct{}{}
+	}
+
+	gotNames := catalog.Names()
+	if len(gotNames) != len(wantKeys) {
+		t.Errorf("template tree defines %d keys, entries table has %d", len(gotNames), len(wantKeys))
+	}
+	for _, name := range gotNames {
+		if _, ok := wantKeys[name]; !ok {
+			t.Errorf("orphan template key %q: defined in templates but absent from entries", name)
+		}
+	}
+
+	for _, lang := range octoi18n.SupportedLanguages() {
+		for _, e := range entries {
+			desc, err := catalog.Render(e.key, lang, nil)
+			if err != nil {
+				t.Errorf("render %s (%s): %v", e.key, lang, err)
+				continue
+			}
+			if desc == "" {
+				t.Errorf("render %s (%s): empty description", e.key, lang)
+			}
+		}
+	}
+}
+
+// TestZhCNWordingUnchanged pins the #335 acceptance criterion: the zh-CN menu
+// must be byte-identical (entries and order included) to what
+// registerBotFatherCommands hardcoded before the migration.
+func TestZhCNWordingUnchanged(t *testing.T) {
+	want := []Command{
+		{"/install", "安装/更新 Octo 插件"},
+		{"/quickstart", "AI Agent 快速入门"},
+		{"/newbot", "创建新机器人"},
+		{"/mybots", "查看我的机器人"},
+		{"/connect", "获取连接 prompt"},
+		{"/disconnect", "断开 Agent 连接"},
+		{"/setname", "修改机器人名称"},
+		{"/setdescription", "修改机器人描述"},
+		{"/deletebot", "删除机器人"},
+		{"/token", "查看 Token"},
+		{"/revoke", "重置 Token"},
+		{"/approve", "通过好友申请"},
+		{"/reject", "拒绝好友申请"},
+		{"/pending", "查看待审批好友申请"},
+		{"/help", "显示帮助"},
+		{"/cancel", "取消当前操作"},
+	}
+	if got := Commands("zh-CN"); !reflect.DeepEqual(got, want) {
+		t.Errorf("zh-CN menu drifted from the pre-migration wording:\ngot  %+v\nwant %+v", got, want)
+	}
+}
+
+// TestJSONWireShape asserts JSON() keeps the exact storage/wire shape clients
+// already parse: an array of {command, description} objects in menu order.
+func TestJSONWireShape(t *testing.T) {
+	for _, lang := range octoi18n.SupportedLanguages() {
+		var got []Command
+		if err := json.Unmarshal([]byte(JSON(lang)), &got); err != nil {
+			t.Fatalf("JSON(%s) is not valid JSON: %v", lang, err)
+		}
+		if !reflect.DeepEqual(got, Commands(lang)) {
+			t.Errorf("JSON(%s) does not round-trip to Commands(%s)", lang, lang)
+		}
+	}
+}
+
+// TestLanguageFallback asserts unsupported/empty tags fall back to the source
+// language and region-less tags match their supported variant, mirroring the
+// msgtmpl normalization contract.
+func TestLanguageFallback(t *testing.T) {
+	src := JSON(octoi18n.SourceLanguage)
+	for _, lang := range []string{"", "fr-FR", "not-a-lang"} {
+		if got := JSON(lang); got != src {
+			t.Errorf("JSON(%q) should fall back to source language", lang)
+		}
+	}
+	if got := JSON("zh"); got != JSON("zh-CN") {
+		t.Errorf("JSON(\"zh\") should match the zh-CN variant")
+	}
+	if got := JSON("en"); got != JSON("en-US") {
+		t.Errorf("JSON(\"en\") should match the en-US variant")
+	}
+}
+
+// TestCommandsReturnsCopy guards the package-level cache against caller
+// mutation — the pre-rendered slices back every request.
+func TestCommandsReturnsCopy(t *testing.T) {
+	first := Commands("zh-CN")
+	first[0].Description = "mutated"
+	if second := Commands("zh-CN"); second[0].Description == "mutated" {
+		t.Error("Commands must return a copy, not the cached slice")
+	}
+}

--- a/modules/botfather/cmdmenu/cmdmenu_test.go
+++ b/modules/botfather/cmdmenu/cmdmenu_test.go
@@ -85,6 +85,33 @@ func TestJSONWireShape(t *testing.T) {
 	}
 }
 
+// TestJSONStoredByteShapeUnchanged pins JSON("zh-CN") byte-for-byte against
+// the pre-migration json.Marshal([]map[string]string{...}) output that clients
+// parse and the startup write persists — a struct-tag or marshaling change
+// that drifts the stored bytes must fail here even if the decoded values
+// still match.
+func TestJSONStoredByteShapeUnchanged(t *testing.T) {
+	want := `[{"command":"/install","description":"安装/更新 Octo 插件"},` +
+		`{"command":"/quickstart","description":"AI Agent 快速入门"},` +
+		`{"command":"/newbot","description":"创建新机器人"},` +
+		`{"command":"/mybots","description":"查看我的机器人"},` +
+		`{"command":"/connect","description":"获取连接 prompt"},` +
+		`{"command":"/disconnect","description":"断开 Agent 连接"},` +
+		`{"command":"/setname","description":"修改机器人名称"},` +
+		`{"command":"/setdescription","description":"修改机器人描述"},` +
+		`{"command":"/deletebot","description":"删除机器人"},` +
+		`{"command":"/token","description":"查看 Token"},` +
+		`{"command":"/revoke","description":"重置 Token"},` +
+		`{"command":"/approve","description":"通过好友申请"},` +
+		`{"command":"/reject","description":"拒绝好友申请"},` +
+		`{"command":"/pending","description":"查看待审批好友申请"},` +
+		`{"command":"/help","description":"显示帮助"},` +
+		`{"command":"/cancel","description":"取消当前操作"}]`
+	if got := JSON("zh-CN"); got != want {
+		t.Errorf("JSON(\"zh-CN\") stored byte shape drifted:\ngot  %s\nwant %s", got, want)
+	}
+}
+
 // TestLanguageFallback asserts unsupported/empty tags fall back to the source
 // language and region-less tags match their supported variant, mirroring the
 // msgtmpl normalization contract.

--- a/modules/botfather/cmdmenu/templates/en-US/menu.tmpl
+++ b/modules/botfather/cmdmenu/templates/en-US/menu.tmpl
@@ -1,0 +1,31 @@
+{{define "menu_install"}}Install / update the Octo plugin{{end}}
+
+{{define "menu_quickstart"}}AI Agent quickstart{{end}}
+
+{{define "menu_newbot"}}Create a new bot{{end}}
+
+{{define "menu_mybots"}}View my bots{{end}}
+
+{{define "menu_connect"}}Get the connection prompt{{end}}
+
+{{define "menu_disconnect"}}Disconnect an Agent{{end}}
+
+{{define "menu_setname"}}Change a bot's name{{end}}
+
+{{define "menu_setdescription"}}Change a bot's description{{end}}
+
+{{define "menu_deletebot"}}Delete a bot{{end}}
+
+{{define "menu_token"}}View a token{{end}}
+
+{{define "menu_revoke"}}Reset a token{{end}}
+
+{{define "menu_approve"}}Approve a friend request{{end}}
+
+{{define "menu_reject"}}Reject a friend request{{end}}
+
+{{define "menu_pending"}}View pending friend requests{{end}}
+
+{{define "menu_help"}}Show help{{end}}
+
+{{define "menu_cancel"}}Cancel the current operation{{end}}

--- a/modules/botfather/cmdmenu/templates/zh-CN/menu.tmpl
+++ b/modules/botfather/cmdmenu/templates/zh-CN/menu.tmpl
@@ -1,0 +1,31 @@
+{{define "menu_install"}}安装/更新 Octo 插件{{end}}
+
+{{define "menu_quickstart"}}AI Agent 快速入门{{end}}
+
+{{define "menu_newbot"}}创建新机器人{{end}}
+
+{{define "menu_mybots"}}查看我的机器人{{end}}
+
+{{define "menu_connect"}}获取连接 prompt{{end}}
+
+{{define "menu_disconnect"}}断开 Agent 连接{{end}}
+
+{{define "menu_setname"}}修改机器人名称{{end}}
+
+{{define "menu_setdescription"}}修改机器人描述{{end}}
+
+{{define "menu_deletebot"}}删除机器人{{end}}
+
+{{define "menu_token"}}查看 Token{{end}}
+
+{{define "menu_revoke"}}重置 Token{{end}}
+
+{{define "menu_approve"}}通过好友申请{{end}}
+
+{{define "menu_reject"}}拒绝好友申请{{end}}
+
+{{define "menu_pending"}}查看待审批好友申请{{end}}
+
+{{define "menu_help"}}显示帮助{{end}}
+
+{{define "menu_cancel"}}取消当前操作{{end}}

--- a/modules/botfather/const.go
+++ b/modules/botfather/const.go
@@ -1,8 +1,12 @@
 package botfather
 
+import "github.com/Mininglamp-OSS/octo-server/modules/botfather/cmdmenu"
+
 const (
-	// BotFatherUID BotFather的用户UID
-	BotFatherUID = "botfather"
+	// BotFatherUID BotFather的用户UID。真相源在 cmdmenu 叶子包（#335）——
+	// 读路径模块（user/channel/robot）需要匹配该 UID 却不能 import 本包
+	//（botfather → user 会成环），这里保留别名供包内调用点使用。
+	BotFatherUID = cmdmenu.BotFatherUID
 	// BotFatherName BotFather的显示名称
 	BotFatherName = "BotFather"
 	// System UIDs excluded from bot-related batch operations

--- a/modules/botfather/const_test.go
+++ b/modules/botfather/const_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/modules/botfather/cmdmenu"
 	"github.com/Mininglamp-OSS/octo-server/pkg/botutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -318,6 +319,24 @@ func TestAllCommandsStartWithSlash(t *testing.T) {
 		assert.True(t, strings.HasPrefix(cmd, "/"), "command %q should start with /", cmd)
 		assert.Greater(t, len(cmd), 1, "command should not be just /")
 	}
+}
+
+// TestCmdMenuMatchesCommandConstants pins the cmdmenu leaf package (which
+// cannot import this package and so carries its own command literals) to the
+// Cmd* constants: same commands, same pre-migration menu order (#335).
+func TestCmdMenuMatchesCommandConstants(t *testing.T) {
+	want := []string{
+		CmdInstall, CmdQuickstart, CmdNewBot, CmdMyBots,
+		CmdConnect, CmdDisconnect, CmdSetName, CmdSetDescription,
+		CmdDeleteBot, CmdToken, CmdRevoke, CmdApprove,
+		CmdReject, CmdPending, CmdHelp, CmdCancel,
+	}
+	menu := cmdmenu.Commands("zh-CN")
+	got := make([]string, 0, len(menu))
+	for _, entry := range menu {
+		got = append(got, entry.Command)
+	}
+	assert.Equal(t, want, got)
 }
 
 func TestStateTTL_Reasonable(t *testing.T) {

--- a/modules/channel/api.go
+++ b/modules/channel/api.go
@@ -11,8 +11,10 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/botfather/cmdmenu"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"github.com/Mininglamp-OSS/octo-server/pkg/util"
 	"go.uber.org/zap"
@@ -212,6 +214,14 @@ func (ch *Channel) channelGet(c *wkhttp.Context) {
 		}
 		if channelSettingM.MsgAutoDelete > 0 {
 			channelResp.Extra["msg_auto_delete"] = channelSettingM.MsgAutoDelete
+		}
+	}
+
+	// BotFather 的命令菜单是服务端自有文案：库里只存部署默认语言的兜底，这里按
+	// 请求协商语言重渲染（#335）。其余 bot 的 commands 是创建者内容，原样透传。
+	if channelType == common.ChannelTypePerson.Uint8() && channelID == cmdmenu.BotFatherUID && channelResp.Extra != nil {
+		if _, ok := channelResp.Extra["bot_commands"]; ok {
+			channelResp.Extra["bot_commands"] = cmdmenu.JSON(octoi18n.OutboundLanguage(c.Request.Context()))
 		}
 	}
 

--- a/modules/message/api_conversation.go
+++ b/modules/message/api_conversation.go
@@ -519,7 +519,7 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 	// ---------- 用户设置 ----------
 	users := make([]*user.UserDetailResp, 0)
 	if len(uids) > 0 {
-		users, err = co.userService.GetUserDetails(uids, c.GetLoginUID())
+		users, err = co.userService.GetUserDetails(c.Request.Context(), uids, c.GetLoginUID())
 		if err != nil {
 			co.Error("查询用户信息失败！", zap.Error(err))
 			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -968,13 +968,6 @@ func (rb *Robot) getCommands(c *wkhttp.Context) {
 		return
 	}
 
-	// BotFather 自身的菜单是服务端自有文案，按请求协商语言渲染（#335）；库存
-	// blob 只是部署默认语言兜底。其余 bot 的 commands 是创建者内容，照旧读库。
-	if robotID == cmdmenu.BotFatherUID {
-		c.Response(cmdmenu.Commands(octoi18n.OutboundLanguage(c.Request.Context())))
-		return
-	}
-
 	botCommands, err := rb.db.queryBotCommandsByRobotID(robotID)
 	if err != nil {
 		rb.Error("查询机器人命令失败", zap.Error(err))
@@ -984,6 +977,15 @@ func (rb *Robot) getCommands(c *wkhttp.Context) {
 
 	if strings.TrimSpace(botCommands) == "" {
 		c.Response([]interface{}{})
+		return
+	}
+
+	// BotFather 自身的菜单是服务端自有文案，按请求协商语言渲染（#335）；库存
+	// blob 只是部署默认语言兜底。放在存在性/启用（status=1）/空值门控之后，
+	// 三个读取面的覆盖条件保持一致（仅库存非空时覆盖）。其余 bot 的 commands
+	// 是创建者内容，照旧原样返回。
+	if robotID == cmdmenu.BotFatherUID {
+		c.Response(cmdmenu.Commands(octoi18n.OutboundLanguage(c.Request.Context())))
 		return
 	}
 

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -27,11 +27,13 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/app"
+	"github.com/Mininglamp-OSS/octo-server/modules/botfather/cmdmenu"
 	"github.com/Mininglamp-OSS/octo-server/modules/file"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
 	"github.com/Mininglamp-OSS/octo-server/pkg/richtext"
 	pkgutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
@@ -963,6 +965,13 @@ func (rb *Robot) getCommands(c *wkhttp.Context) {
 	robotID := c.Query("robot_id")
 	if strings.TrimSpace(robotID) == "" {
 		respondRobotRequestInvalid(c, "robot_id")
+		return
+	}
+
+	// BotFather 自身的菜单是服务端自有文案，按请求协商语言渲染（#335）；库存
+	// blob 只是部署默认语言兜底。其余 bot 的 commands 是创建者内容，照旧读库。
+	if robotID == cmdmenu.BotFatherUID {
+		c.Response(cmdmenu.Commands(octoi18n.OutboundLanguage(c.Request.Context())))
 		return
 	}
 

--- a/modules/robot/api_commands_cmdmenu_test.go
+++ b/modules/robot/api_commands_cmdmenu_test.go
@@ -1,0 +1,68 @@
+package robot
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/botfather/cmdmenu"
+	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGetCommands_CmdMenuLocalization pins the #335 split on
+// GET /v1/robot/commands: BotFather's menu is server-owned copy rendered in
+// the request's negotiated language, while a user bot's commands are creator
+// content served from the DB untouched whatever language the caller asks for.
+func TestGetCommands_CmdMenuLocalization(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+
+	creatorContent := `[{"command":"/deploy","description":"部署到生产"}]`
+	for _, row := range []struct{ id, commands string }{
+		{cmdmenu.BotFatherUID, cmdmenu.JSON("zh-CN")},
+		{"user_bot", creatorContent},
+	} {
+		_, err := ctx.DB().InsertBySql(
+			"INSERT INTO robot (app_id, robot_id, username, token, version, status, creator_uid, description, bot_token, im_token_cache, bot_commands) VALUES ('app', ?, ?, 't', 1, 1, '', '', '', '', ?)",
+			row.id, row.id, row.commands,
+		).Exec()
+		assert.NoError(t, err)
+	}
+
+	r := wkhttp.New()
+	r.UseGin(octoi18n.EarlyMiddleware(octoi18n.MiddlewareOptions{DefaultLanguage: octoi18n.DefaultLanguage}))
+	New(ctx).Route(r)
+
+	cases := []struct {
+		name           string
+		robotID        string
+		acceptLanguage string
+		want           []cmdmenu.Command
+	}{
+		{"botfather en-US → English menu", cmdmenu.BotFatherUID, "en-US", cmdmenu.Commands("en-US")},
+		{"botfather zh-CN → Chinese menu", cmdmenu.BotFatherUID, "zh-CN", cmdmenu.Commands("zh-CN")},
+		{"botfather no header → deployment default", cmdmenu.BotFatherUID, "", cmdmenu.Commands(octoi18n.DefaultLanguage)},
+		{"user bot stays creator content under en-US", "user_bot", "en-US", []cmdmenu.Command{{Command: "/deploy", Description: "部署到生产"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := http.NewRequest("GET", "/v1/robot/commands?robot_id="+tc.robotID, nil)
+			assert.NoError(t, err)
+			req.Header.Set("token", token)
+			if tc.acceptLanguage != "" {
+				req.Header.Set("Accept-Language", tc.acceptLanguage)
+			}
+			r.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+			var got []cmdmenu.Command
+			assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &got), "body=%s", w.Body.String())
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/modules/search/api.go
+++ b/modules/search/api.go
@@ -228,7 +228,7 @@ func (s *Search) global(c *wkhttp.Context) {
 	}
 	if len(uids) > 0 {
 		realUids := util.RemoveRepeatedElement(uids)
-		users, err = s.userService.GetUserDetails(realUids, loginUID)
+		users, err = s.userService.GetUserDetails(c.Request.Context(), realUids, loginUID)
 		if err != nil {
 			s.Error("查询用户列表错误", zap.Error(err))
 			httperr.ResponseErrorL(c, errcode.ErrSearchUserQueryFailed, nil, nil)

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -39,9 +39,11 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/base/app"
 	commonapi "github.com/Mininglamp-OSS/octo-server/modules/base/common"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
+	"github.com/Mininglamp-OSS/octo-server/modules/botfather/cmdmenu"
 	common2 "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -1116,6 +1118,11 @@ func (u *User) get(c *wkhttp.Context) {
 	if userDetailResp == nil {
 		respondUserError(c, errcode.ErrUserNotFound)
 		return
+	}
+	// BotFather 的命令菜单是服务端自有文案，按请求协商语言重渲染（#335）；
+	// 库存值只是部署默认语言兜底。其余 bot 的 commands 是创建者内容，不覆盖。
+	if uid == cmdmenu.BotFatherUID && userDetailResp.BotCommands != "" {
+		userDetailResp.BotCommands = cmdmenu.JSON(octoi18n.OutboundLanguage(c.Request.Context()))
 	}
 	isShowShortNo := false
 	vercode := ""

--- a/modules/user/api_friend.go
+++ b/modules/user/api_friend.go
@@ -1049,7 +1049,7 @@ func (f *Friend) friendSync(c *wkhttp.Context) {
 				filteredUIDs = append(filteredUIDs, m)
 			}
 		}
-		userDetails, err := f.userService.GetUserDetails(filteredUIDs, c.GetLoginUID())
+		userDetails, err := f.userService.GetUserDetails(c.Request.Context(), filteredUIDs, c.GetLoginUID())
 		if err != nil {
 			f.Error("获取用户详情失败！", zap.Error(err))
 			respondUserError(c, errcode.ErrUserQueryFailed)
@@ -1082,7 +1082,7 @@ func (f *Friend) friendSync(c *wkhttp.Context) {
 			friendUIDs = append(friendUIDs, f.ToUID)
 		}
 	}
-	userDetails, err := f.userService.GetUserDetails(friendUIDs, c.GetLoginUID())
+	userDetails, err := f.userService.GetUserDetails(c.Request.Context(), friendUIDs, c.GetLoginUID())
 	if err != nil {
 		f.Error("获取用户详情失败！", zap.Error(err))
 		respondUserError(c, errcode.ErrUserQueryFailed)
@@ -1131,7 +1131,7 @@ func (f *Friend) friendSearch(c *wkhttp.Context) {
 				filteredUIDs = append(filteredUIDs, m)
 			}
 		}
-		userDetails, err := f.userService.GetUserDetails(filteredUIDs, c.GetLoginUID())
+		userDetails, err := f.userService.GetUserDetails(c.Request.Context(), filteredUIDs, c.GetLoginUID())
 		if err != nil {
 			f.Error("获取用户详情失败！", zap.Error(err))
 			respondUserError(c, errcode.ErrUserQueryFailed)

--- a/modules/user/service.go
+++ b/modules/user/service.go
@@ -8,8 +8,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-server/modules/botfather/cmdmenu"
 	"github.com/Mininglamp-OSS/octo-server/modules/source"
 	"github.com/Mininglamp-OSS/octo-server/modules/space"
+	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
@@ -25,8 +27,9 @@ type IService interface {
 	GetUser(uid string) (*Resp, error)
 	// 获取用户详情（包括与loginUID的关系等等）
 	GetUserDetail(uid string, loginUID string) (*UserDetailResp, error)
-	// 批量获取用户详情
-	GetUserDetails(uids []string, loginUID string) ([]*UserDetailResp, error)
+	// 批量获取用户详情。ctx 用于按请求协商语言渲染 BotFather 命令菜单（#335），
+	// 无请求上下文的调用方传 context.Background() 即回退部署默认语言。
+	GetUserDetails(ctx context.Context, uids []string, loginUID string) ([]*UserDetailResp, error)
 	// 通过用户名获取用户
 	GetUserWithUsername(username string) (*Resp, error)
 	// 通过用户名获取用户uid集合
@@ -563,7 +566,7 @@ func (s *Service) GetUserDetail(uid string, loginUID string) (*UserDetailResp, e
 	return resp, nil
 }
 
-func (s *Service) GetUserDetails(uids []string, loginUID string) ([]*UserDetailResp, error) {
+func (s *Service) GetUserDetails(ctx context.Context, uids []string, loginUID string) ([]*UserDetailResp, error) {
 
 	userDetails, err := s.db.QueryDetailByUIDs(uids, loginUID)
 	if err != nil {
@@ -794,6 +797,12 @@ func (s *Service) GetUserDetails(uids []string, loginUID string) ([]*UserDetailR
 					if d, ok := botMap[resp.UID]; ok {
 						if d.BotCommands != "" {
 							resp.BotCommands = d.BotCommands
+							// BotFather 的命令菜单是服务端自有文案，按请求协商语言重渲染
+							//（#335）；库存值只是部署默认语言兜底，门控与单查路径一致
+							//（仅库存非空时覆盖）。其余 bot 的 commands 是创建者内容，不覆盖。
+							if resp.UID == cmdmenu.BotFatherUID {
+								resp.BotCommands = cmdmenu.JSON(octoi18n.OutboundLanguage(ctx))
+							}
 						}
 						resp.BotDescription = d.Description
 						resp.BotCreatorUID = d.CreatorUID


### PR DESCRIPTION
Closes #335

## Problem

`registerBotFatherCommands` wrote BotFather's command menu (`robot.bot_commands`) as a single hardcoded zh-CN JSON blob at startup, so an `OCTO_DEFAULT_LANGUAGE=en-US` deployment (and every en-US user) saw a fully Chinese command menu — the defect class #304 fixed for DM bodies, deferred in PR #316 because the stored blob can only carry one language.

## Approach: option 1 + per-request read-time rendering

The menu reaches clients through **authenticated HTTP reads** (`GET /v1/channels/botfather/1` → `extra.bot_commands`), where language negotiation is fully available — so per-user localization needs **no schema change and no client coordination** (see [analysis on the issue](https://github.com/Mininglamp-OSS/octo-server/issues/335#issuecomment-4669621187)):

- **New leaf package `modules/botfather/cmdmenu`** owns the 16 menu entries, descriptions rendered through the shared `msgtmpl` catalog (`templates/{zh-CN,en-US}`, zh-CN wording unchanged). Leaf because `botfather` imports `user`, so the read-side modules can only share the catalog through a package that imports neither. All languages are pre-rendered at init; a missing key in any supported language fails startup loudly (msgtmpl completeness matrix).
- **Startup write** (`registerBotFatherCommands`) now renders the deployment default language (`OCTO_DEFAULT_LANGUAGE`) — the floor for read paths without a request context (admin robot detail, batch enrichment). The write is unconditional on every boot, so existing deployments' zh-CN blobs **self-heal on upgrade; no migration**.
- **Per-request override for the `botfather` UID only**, via `i18n.OutboundLanguage(c.Request.Context())`, on the three menu-bearing endpoints:
  - `GET /v1/channels/botfather/1` → `extra.bot_commands` (channel module)
  - `GET /v1/robot/commands?robot_id=botfather` (robot module)
  - `GET /v1/users/botfather` (user module)
- **User bots' commands are creator content** (`POST /v1/bot/setCommands`) — never templated, never overridden.

## Acceptance criteria (#335)

- [x] Command descriptions live in a msgtmpl namespace (`modules/botfather/cmdmenu/templates/{lang}/`), zh-CN wording unchanged (pinned byte-for-byte by `TestZhCNWordingUnchanged`)
- [x] `registerBotFatherCommands` renders the resolved deployment default language at startup (`TestRegisterBotFatherCommands_WritesDeploymentDefault`)
- [x] Completeness test covers the new keys in every supported language (`TestMenuCompleteness` + msgtmpl matrix at init; `TestCmdMenuMatchesCommandConstants` guards drift against the `Cmd*` constants)
- [x] `make i18n-extract-check` + `make i18n-lint` green
- [x] Beyond option 1: mixed-language deployments are correct per user (`TestChannelGet_BotFatherMenuFollowsRequestLanguage`)

## Verification

E2E against the CI service stack (MySQL 8.0 + Redis + WuKongIM v2.2.4-20260313), `-race`, per-package DB reset:

- New e2e tests: Accept-Language negotiation (en-US / zh-CN / unset) on the channel endpoint via production `EarlyMiddleware`; deployment-default floor on channel + user-detail endpoints; startup-write self-heal; creator-content passthrough on `/v1/robot/commands`
- Full suites green: `modules/botfather` (31.7s), `cmdmenu`, `channel`, `robot`, `user` (60.5s)
- `go vet`, `golangci-lint` (0 issues), `make i18n-extract-check`, `make i18n-lint` all green

Note: the botfather user row's `robot=1` flag is set by deployment seed data, not by `initBotFatherUser` — without it the channel/user paths don't deliver `bot_commands` at all (pre-existing behavior, unchanged here; the e2e setup mirrors the seed with an explicit UPDATE).

https://claude.ai/code/session_019nGSMBbhaivbpQADEdoPhc

---
_Generated by [Claude Code](https://claude.ai/code/session_019nGSMBbhaivbpQADEdoPhc)_