### PR TITLE
fix(space): prevent ownerless space via member role update

### DIFF
--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -869,26 +869,16 @@ func (s *Space) updateMemberRole(c *wkhttp.Context) {
 		return
 	}
 
-	// 如果要转让owner，使用事务保证原子性
+	// 转让 owner：复用带 SELECT ... FOR UPDATE 行锁的原语（与管理端一致）。
+	// 不在 handler 层内联事务——目标行不加锁的话，pre-check 通过后目标被并发
+	// 移除，提升 UPDATE 影响 0 行而降级仍执行，会产生无主空间（PR #339 review）。
 	if req.Role == 2 {
-		tx, txErr := s.ctx.DB().Begin()
-		if txErr != nil {
-			httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
-			return
-		}
-		defer tx.RollbackUnlessCommitted()
-
-		// 先提升目标为owner
-		if err = s.db.updateMemberRoleTx(tx, spaceId, targetUID, 2); err != nil {
-			httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
-			return
-		}
-		// 再把当前owner降为admin
-		if err = s.db.updateMemberRoleTx(tx, spaceId, loginUID, 1); err != nil {
-			httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
-			return
-		}
-		if err = tx.Commit(); err != nil {
+		if err = s.db.transferOwnerAdmin(spaceId, targetUID); err != nil {
+			if errors.Is(err, ErrTransferTargetMissing) {
+				httperr.ResponseErrorL(c, errcode.ErrSpaceMemberNotFound, nil, nil)
+				return
+			}
+			s.Error("转让空间所有权失败", zap.Error(err), zap.String("spaceId", spaceId), zap.String("targetUID", targetUID))
 			httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 			return
 		}

--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -753,21 +753,14 @@ func (s *Space) removeMembers(c *wkhttp.Context) {
 	}
 
 	for _, uid := range req.UIDs {
-		target, err := s.db.queryMember(spaceId, uid)
-		if err != nil {
-			httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
-			return
-		}
-		if target == nil {
-			continue
-		}
-		if target.Role == 2 {
-			continue // 不能移除owner
-		}
-		if member.Role <= target.Role {
-			continue // 不能移除同级或更高角色
-		}
-		if err = s.db.removeMember(spaceId, uid); err != nil {
+		// 角色校验在锁内完成（removeMemberLocked 事务内重读 role）：
+		// owner 与同级及更高角色静默跳过，与既有语义一致；锁内重读
+		// 防止 pre-check 后目标被并发转让升为 owner 仍被移除（PR #339 review）。
+		if err = s.db.removeMemberLocked(spaceId, uid, member.Role); err != nil {
+			if errors.Is(err, ErrCannotRemoveOwner) || errors.Is(err, ErrRemoveHierarchy) {
+				continue
+			}
+			s.Error("移除空间成员失败", zap.Error(err), zap.String("spaceId", spaceId), zap.String("uid", uid))
 			httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 			return
 		}
@@ -802,8 +795,14 @@ func (s *Space) leaveSpace(c *wkhttp.Context) {
 		return
 	}
 
-	err = s.db.removeMember(spaceId, loginUID)
+	// 锁内重读角色：pre-check 与移除之间可能被并发转让升为 owner（PR #339 review）
+	err = s.db.removeMemberLocked(spaceId, loginUID, 2)
 	if err != nil {
+		if errors.Is(err, ErrCannotRemoveOwner) {
+			httperr.ResponseErrorL(c, errcode.ErrSpaceOwnerConstraint, nil, nil)
+			return
+		}
+		s.Error("退出空间失败", zap.Error(err), zap.String("spaceId", spaceId), zap.String("uid", loginUID))
 		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
@@ -885,6 +884,7 @@ func (s *Space) updateMemberRole(c *wkhttp.Context) {
 	} else {
 		err = s.db.updateMemberRole(spaceId, targetUID, req.Role)
 		if err != nil {
+			s.Error("修改成员角色失败", zap.Error(err), zap.String("spaceId", spaceId), zap.String("targetUID", targetUID), zap.Int("role", req.Role))
 			httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 			return
 		}

--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -882,6 +882,8 @@ func (s *Space) updateMemberRole(c *wkhttp.Context) {
 			return
 		}
 	} else {
+		// 残余竞态（pre-check 后目标被并发转让升为 owner）由 updateMemberRole
+		// 的 role<>2 SQL 守卫兜底（PR #339 review F1）
 		err = s.db.updateMemberRole(spaceId, targetUID, req.Role)
 		if err != nil {
 			s.Error("修改成员角色失败", zap.Error(err), zap.String("spaceId", spaceId), zap.String("targetUID", targetUID), zap.Int("role", req.Role))

--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -855,6 +855,20 @@ func (s *Space) updateMemberRole(c *wkhttp.Context) {
 		return
 	}
 
+	// 防无主空间：owner 不能被直接降级（本接口仅 owner 可调，即禁止自降级）。
+	// 转让所有权必须通过把其他成员设为 role=2 触发下方的原子对调，
+	// 与管理端 updateMemberRole 的约束一致（见 api_manager.go）。
+	if target.Role == 2 && req.Role != 2 {
+		httperr.ResponseErrorL(c, errcode.ErrSpaceOwnerConstraint, nil, nil)
+		return
+	}
+	// 幂等：目标已是该角色时直接成功。该分支同时挡住「转让给自己」——
+	// 否则下方事务会把唯一 owner 先升后降（同一行），产生无主空间。
+	if target.Role == req.Role {
+		c.ResponseOK()
+		return
+	}
+
 	// 如果要转让owner，使用事务保证原子性
 	if req.Role == 2 {
 		tx, txErr := s.ctx.DB().Begin()

--- a/modules/space/api_manager.go
+++ b/modules/space/api_manager.go
@@ -747,6 +747,12 @@ func (m *Manager) updateMemberRole(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrSpaceOwnerConstraint, nil, nil)
 		return
 	}
+	// 幂等：目标已是该角色直接成功，与用户侧守卫对称（PR #339 P2），
+	// 同时避免「转让给现任 owner」空转一次降级/提升事务。
+	if target.Role == req.Role {
+		c.ResponseOK()
+		return
+	}
 	if req.Role == 2 {
 		if err = m.managerDB.transferOwnerAdmin(spaceId, targetUID); err != nil {
 			if errors.Is(err, ErrTransferTargetMissing) {

--- a/modules/space/api_manager_test.go
+++ b/modules/space/api_manager_test.go
@@ -390,7 +390,7 @@ func TestManager_AddMembers(t *testing.T) {
 	assert.Equal(t, 3, count) // owner + 2 new
 
 	t.Run("reactivate removed member", func(t *testing.T) {
-		err := testSpaceDB.removeMember("mgr-addmem", "new-u-1")
+		err := testSpaceDB.removeMemberLocked("mgr-addmem", "new-u-1", 2)
 		assert.NoError(t, err)
 
 		body2 := util.ToJson(map[string]interface{}{"uids": []string{"new-u-1"}})
@@ -1704,4 +1704,40 @@ func TestManager_UpdateSpaceProfile_Validation(t *testing.T) {
 		s.GetRoute().ServeHTTP(w, req)
 		assert.NotEqual(t, http.StatusOK, w.Code)
 	})
+}
+
+// TestManager_UpdateMemberRoleIdempotent 目标已是该角色时幂等成功（PR #339 P2：
+// 与用户侧守卫对称），不触发空转的转让事务。
+func TestManager_UpdateMemberRoleIdempotent(t *testing.T) {
+	s, _, err := setup(t)
+	assert.NoError(t, err)
+	token := adminToken(t)
+
+	seedSpace(t, "mgr-role-idem", "role idem", "u-owner", SpaceStatusNormal)
+	err = testSpaceDB.insertMemberNoTx(&MemberModel{
+		SpaceId: "mgr-role-idem", UID: "m-target", Role: 1, Status: 1,
+	})
+	assert.NoError(t, err)
+
+	// 同角色更新：幂等 OK
+	body := util.ToJson(map[string]interface{}{"role": 1})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/v1/manager/spaces/mgr-role-idem/members/m-target/role", bytes.NewReader([]byte(body)))
+	req.Header.Set("token", token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	mem, err := testSpaceDB.queryMember("mgr-role-idem", "m-target")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, mem.Role)
+
+	// 「转让给现任 owner」：幂等 OK，owner 角色不变
+	body = util.ToJson(map[string]interface{}{"role": 2})
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("PUT", "/v1/manager/spaces/mgr-role-idem/members/u-owner/role", bytes.NewReader([]byte(body)))
+	req.Header.Set("token", token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	owner, err := testSpaceDB.queryMember("mgr-role-idem", "u-owner")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, owner.Role)
 }

--- a/modules/space/api_manager_test.go
+++ b/modules/space/api_manager_test.go
@@ -492,8 +492,7 @@ func TestManager_UpdateMemberRole(t *testing.T) {
 	t.Run("reject demoting owner directly", func(t *testing.T) {
 		// 此前已通过子测试 "promote to admin" 把 m-target 提到 admin
 		// 先把 m-target 提成 owner 来构造"降级 owner"场景
-		err := testSpaceDB.updateMemberRole("mgr-role", "m-target", 2)
-		assert.NoError(t, err)
+		setMemberRoleRaw(t, "mgr-role", "m-target", 2)
 
 		body := util.ToJson(map[string]interface{}{"role": 0})
 		w := httptest.NewRecorder()
@@ -508,10 +507,8 @@ func TestManager_UpdateMemberRole(t *testing.T) {
 		assert.Equal(t, 2, mem.Role, "owner role must not be dropped")
 
 		// 恢复：把 owner 转回 u-owner 以免影响后续子测试
-		err = testSpaceDB.updateMemberRole("mgr-role", "m-target", 1)
-		assert.NoError(t, err)
-		err = testSpaceDB.updateMemberRole("mgr-role", "u-owner", 2)
-		assert.NoError(t, err)
+		setMemberRoleRaw(t, "mgr-role", "m-target", 1)
+		setMemberRoleRaw(t, "mgr-role", "u-owner", 2)
 	})
 
 	t.Run("transfer ownership demotes previous owner", func(t *testing.T) {

--- a/modules/space/api_member_role_test.go
+++ b/modules/space/api_member_role_test.go
@@ -1,0 +1,177 @@
+package space
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+// memberRoleFixture 建一个空间：testutil.UID 为 ownerRole 角色的登录成员，
+// 另插入一个 m-target 成员（targetRole），返回 spaceId。
+func memberRoleFixture(t *testing.T, f *Space, spaceId string, ownerRole, targetRole int) {
+	t.Helper()
+	err := f.db.insertSpaceNoTx(&SpaceModel{
+		SpaceId: spaceId,
+		Name:    "角色管理测试",
+		Creator: testutil.UID,
+		Status:  1,
+	})
+	assert.NoError(t, err)
+	err = f.db.insertMemberNoTx(&MemberModel{
+		SpaceId: spaceId,
+		UID:     testutil.UID,
+		Role:    ownerRole,
+		Status:  1,
+	})
+	assert.NoError(t, err)
+	err = f.db.insertMemberNoTx(&MemberModel{
+		SpaceId: spaceId,
+		UID:     "m-target",
+		Role:    targetRole,
+		Status:  1,
+	})
+	assert.NoError(t, err)
+}
+
+func putMemberRole(t *testing.T, spaceId, targetUID string, role int) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("PUT", "/v1/space/"+spaceId+"/members/"+targetUID+"/role",
+		bytes.NewReader([]byte(util.ToJson(map[string]interface{}{"role": role}))))
+	assert.NoError(t, err)
+	req.Header.Set("token", testutil.Token)
+	testSrv.GetRoute().ServeHTTP(w, req)
+	return w
+}
+
+// TestUpdateMemberRoleByOwner owner 提升成员为管理员、再降回成员。
+func TestUpdateMemberRoleByOwner(t *testing.T) {
+	_, f, err := setup(t)
+	assert.NoError(t, err)
+	spaceId := "role-owner-ok"
+	memberRoleFixture(t, f, spaceId, 2, 0)
+
+	w := putMemberRole(t, spaceId, "m-target", 1)
+	assert.Equal(t, http.StatusOK, w.Code)
+	mem, err := f.db.queryMember(spaceId, "m-target")
+	assert.NoError(t, err)
+	assert.NotNil(t, mem)
+	assert.Equal(t, 1, mem.Role)
+
+	w = putMemberRole(t, spaceId, "m-target", 0)
+	assert.Equal(t, http.StatusOK, w.Code)
+	mem, err = f.db.queryMember(spaceId, "m-target")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, mem.Role)
+}
+
+// TestUpdateMemberRoleTransferOwner owner 把 role=2 给其他成员触发原子转让：
+// 目标变 owner，原 owner 降为管理员。
+func TestUpdateMemberRoleTransferOwner(t *testing.T) {
+	_, f, err := setup(t)
+	assert.NoError(t, err)
+	spaceId := "role-transfer"
+	memberRoleFixture(t, f, spaceId, 2, 1)
+
+	w := putMemberRole(t, spaceId, "m-target", 2)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	target, err := f.db.queryMember(spaceId, "m-target")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, target.Role)
+	prevOwner, err := f.db.queryMember(spaceId, testutil.UID)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, prevOwner.Role)
+}
+
+// TestUpdateMemberRoleNoPermission 管理员（role=1）无权修改角色，仅 owner 可以。
+func TestUpdateMemberRoleNoPermission(t *testing.T) {
+	_, f, err := setup(t)
+	assert.NoError(t, err)
+	spaceId := "role-no-perm"
+	memberRoleFixture(t, f, spaceId, 1, 0)
+
+	w := putMemberRole(t, spaceId, "m-target", 1)
+	assert.NotEqual(t, http.StatusOK, w.Code)
+	assertSpaceErrorCode(t, w, "err.server.space.permission_denied")
+	mem, err := f.db.queryMember(spaceId, "m-target")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, mem.Role)
+}
+
+// TestUpdateMemberRoleOwnerCannotSelfDemote 防无主空间：owner 不能把自己降级，
+// 必须通过把其他成员设为 role=2 转让（回归 GH：用户侧缺管理端的 owner-constraint 守卫）。
+func TestUpdateMemberRoleOwnerCannotSelfDemote(t *testing.T) {
+	_, f, err := setup(t)
+	assert.NoError(t, err)
+	spaceId := "role-self-demote"
+	memberRoleFixture(t, f, spaceId, 2, 0)
+
+	for _, role := range []int{0, 1} {
+		w := putMemberRole(t, spaceId, testutil.UID, role)
+		assert.NotEqual(t, http.StatusOK, w.Code)
+		assertSpaceErrorCode(t, w, "err.server.space.owner_constraint")
+	}
+	owner, err := f.db.queryMember(spaceId, testutil.UID)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, owner.Role)
+}
+
+// TestUpdateMemberRoleSelfTransferNoop 防无主空间：owner「转让给自己」幂等成功，
+// 不得走转让事务把唯一 owner 先升后降为管理员（回归同上）。
+func TestUpdateMemberRoleSelfTransferNoop(t *testing.T) {
+	_, f, err := setup(t)
+	assert.NoError(t, err)
+	spaceId := "role-self-transfer"
+	memberRoleFixture(t, f, spaceId, 2, 0)
+
+	w := putMemberRole(t, spaceId, testutil.UID, 2)
+	assert.Equal(t, http.StatusOK, w.Code)
+	owner, err := f.db.queryMember(spaceId, testutil.UID)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, owner.Role)
+}
+
+// TestUpdateMemberRoleIdempotent 目标已是该角色时幂等成功，不报错。
+func TestUpdateMemberRoleIdempotent(t *testing.T) {
+	_, f, err := setup(t)
+	assert.NoError(t, err)
+	spaceId := "role-idempotent"
+	memberRoleFixture(t, f, spaceId, 2, 1)
+
+	w := putMemberRole(t, spaceId, "m-target", 1)
+	assert.Equal(t, http.StatusOK, w.Code)
+	mem, err := f.db.queryMember(spaceId, "m-target")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, mem.Role)
+}
+
+// TestUpdateMemberRoleTargetNotFound 目标非空间成员时返回 member_not_found。
+func TestUpdateMemberRoleTargetNotFound(t *testing.T) {
+	_, f, err := setup(t)
+	assert.NoError(t, err)
+	spaceId := "role-no-target"
+	err = f.db.insertSpaceNoTx(&SpaceModel{
+		SpaceId: spaceId,
+		Name:    "角色管理测试",
+		Creator: testutil.UID,
+		Status:  1,
+	})
+	assert.NoError(t, err)
+	err = f.db.insertMemberNoTx(&MemberModel{
+		SpaceId: spaceId,
+		UID:     testutil.UID,
+		Role:    2,
+		Status:  1,
+	})
+	assert.NoError(t, err)
+
+	w := putMemberRole(t, spaceId, "ghost-user", 1)
+	assert.NotEqual(t, http.StatusOK, w.Code)
+	assertSpaceErrorCode(t, w, "err.server.space.member_not_found")
+}

--- a/modules/space/api_member_role_test.go
+++ b/modules/space/api_member_role_test.go
@@ -151,6 +151,30 @@ func TestUpdateMemberRoleIdempotent(t *testing.T) {
 	assert.Equal(t, 1, mem.Role)
 }
 
+// TestTransferOwnerAdminTargetRemoved 防无主空间（并发路径回归，PR #339 review）：
+// 转让原语在事务内用 FOR UPDATE 确认目标 status=1；目标已被移除时必须整体
+// 回滚返回 ErrTransferTargetMissing，owner 不得被降级。
+// 模拟的是「handler pre-check 通过后、事务提交前目标被并发移除」的最终态。
+func TestTransferOwnerAdminTargetRemoved(t *testing.T) {
+	_, f, err := setup(t)
+	assert.NoError(t, err)
+	spaceId := "role-transfer-race"
+	memberRoleFixture(t, f, spaceId, 2, 1)
+
+	// 目标被移除（status=0），等价于 pre-check 与事务之间被并发踢出
+	err = f.db.removeMember(spaceId, "m-target")
+	assert.NoError(t, err)
+
+	err = f.db.transferOwnerAdmin(spaceId, "m-target")
+	assert.ErrorIs(t, err, ErrTransferTargetMissing)
+
+	// owner 必须保持 role=2，不能出现「目标没升、自己已降」的无主状态
+	owner, err := f.db.queryMember(spaceId, testutil.UID)
+	assert.NoError(t, err)
+	assert.NotNil(t, owner)
+	assert.Equal(t, 2, owner.Role)
+}
+
 // TestUpdateMemberRoleTargetNotFound 目标非空间成员时返回 member_not_found。
 func TestUpdateMemberRoleTargetNotFound(t *testing.T) {
 	_, f, err := setup(t)

--- a/modules/space/api_member_role_test.go
+++ b/modules/space/api_member_role_test.go
@@ -162,7 +162,7 @@ func TestTransferOwnerAdminTargetRemoved(t *testing.T) {
 	memberRoleFixture(t, f, spaceId, 2, 1)
 
 	// 目标被移除（status=0），等价于 pre-check 与事务之间被并发踢出
-	err = f.db.removeMember(spaceId, "m-target")
+	err = f.db.removeMemberLocked(spaceId, "m-target", 2)
 	assert.NoError(t, err)
 
 	err = f.db.transferOwnerAdmin(spaceId, "m-target")
@@ -173,6 +173,103 @@ func TestTransferOwnerAdminTargetRemoved(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, owner)
 	assert.Equal(t, 2, owner.Role)
+}
+
+// TestRemoveMemberLockedGuards 移除原语的锁内角色守卫（PR #339 review）：
+// owner 拒绝（ErrCannotRemoveOwner）、同级及更高拒绝（ErrRemoveHierarchy）、
+// 更低角色移除成功、目标不存在幂等返回 nil。
+// 模拟「pre-check 读到低角色后目标被并发提升」的最终态——锁内重读必须兜住。
+func TestRemoveMemberLockedGuards(t *testing.T) {
+	_, f, err := setup(t)
+	assert.NoError(t, err)
+	spaceId := "remove-locked"
+	memberRoleFixture(t, f, spaceId, 2, 1) // testutil.UID=owner, m-target=admin
+
+	// owner 不可移除，无论调用方上限是多少
+	err = f.db.removeMemberLocked(spaceId, testutil.UID, 2)
+	assert.ErrorIs(t, err, ErrCannotRemoveOwner)
+	owner, _ := f.db.queryMember(spaceId, testutil.UID)
+	assert.Equal(t, 2, owner.Role)
+
+	// 操作者 admin(1) 移除 admin(1)：同级拒绝
+	err = f.db.removeMemberLocked(spaceId, "m-target", 1)
+	assert.ErrorIs(t, err, ErrRemoveHierarchy)
+	target, _ := f.db.queryMember(spaceId, "m-target")
+	assert.NotNil(t, target)
+
+	// 操作者 owner(2) 移除 admin(1)：成功
+	err = f.db.removeMemberLocked(spaceId, "m-target", 2)
+	assert.NoError(t, err)
+	target, _ = f.db.queryMember(spaceId, "m-target")
+	assert.Nil(t, target)
+
+	// 目标已不存在：幂等 nil
+	err = f.db.removeMemberLocked(spaceId, "m-target", 2)
+	assert.NoError(t, err)
+}
+
+// TestLeaveSpace 退出空间：普通成员/管理员可退出；owner 必须先转让。
+func TestLeaveSpace(t *testing.T) {
+	_, f, err := setup(t)
+	assert.NoError(t, err)
+	spaceId := "leave-ok"
+	memberRoleFixture(t, f, spaceId, 1, 2) // testutil.UID=admin，m-target=owner 保证空间有主
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/space/"+spaceId+"/leave", nil)
+	req.Header.Set("token", testutil.Token)
+	testSrv.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	mem, err := f.db.queryMember(spaceId, testutil.UID)
+	assert.NoError(t, err)
+	assert.Nil(t, mem)
+}
+
+// TestLeaveSpaceOwnerRejected owner 退出被 owner_constraint 拒绝。
+func TestLeaveSpaceOwnerRejected(t *testing.T) {
+	_, f, err := setup(t)
+	assert.NoError(t, err)
+	spaceId := "leave-owner"
+	memberRoleFixture(t, f, spaceId, 2, 0)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/space/"+spaceId+"/leave", nil)
+	req.Header.Set("token", testutil.Token)
+	testSrv.GetRoute().ServeHTTP(w, req)
+	assert.NotEqual(t, http.StatusOK, w.Code)
+	assertSpaceErrorCode(t, w, "err.server.space.owner_constraint")
+	owner, _ := f.db.queryMember(spaceId, testutil.UID)
+	assert.Equal(t, 2, owner.Role)
+}
+
+// TestRemoveMembersSkipsOwnerAndPeers 管理员批量移除：owner 与同级管理员
+// 静默跳过（既有语义），更低角色移除成功。
+func TestRemoveMembersSkipsOwnerAndPeers(t *testing.T) {
+	_, f, err := setup(t)
+	assert.NoError(t, err)
+	spaceId := "remove-batch"
+	memberRoleFixture(t, f, spaceId, 1, 2) // testutil.UID=admin 操作者，m-target=owner
+	err = f.db.insertMemberNoTx(&MemberModel{SpaceId: spaceId, UID: "m-peer", Role: 1, Status: 1})
+	assert.NoError(t, err)
+	err = f.db.insertMemberNoTx(&MemberModel{SpaceId: spaceId, UID: "m-low", Role: 0, Status: 1})
+	assert.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/space/"+spaceId+"/members/remove",
+		bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+			"uids": []string{"m-target", "m-peer", "m-low"},
+		}))))
+	req.Header.Set("token", testutil.Token)
+	testSrv.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	ownerMem, _ := f.db.queryMember(spaceId, "m-target")
+	assert.NotNil(t, ownerMem, "owner must be skipped")
+	assert.Equal(t, 2, ownerMem.Role)
+	peer, _ := f.db.queryMember(spaceId, "m-peer")
+	assert.NotNil(t, peer, "peer admin must be skipped")
+	low, _ := f.db.queryMember(spaceId, "m-low")
+	assert.Nil(t, low, "lower role must be removed")
 }
 
 // TestUpdateMemberRoleTargetNotFound 目标非空间成员时返回 member_not_found。

--- a/modules/space/api_member_role_test.go
+++ b/modules/space/api_member_role_test.go
@@ -272,6 +272,36 @@ func TestRemoveMembersSkipsOwnerAndPeers(t *testing.T) {
 	assert.Nil(t, low, "lower role must be removed")
 }
 
+// setMemberRoleRaw 测试 fixture 专用：绕过生产侧 updateMemberRole 的
+// role<>2 守卫直接改角色，用于构造（含非法的）任意角色状态。
+func setMemberRoleRaw(t *testing.T, spaceId, uid string, role int) {
+	t.Helper()
+	_, err := testSpaceDB.session.Update("space_member").
+		Set("role", role).
+		Where("space_id=? and uid=?", spaceId, uid).Exec()
+	assert.NoError(t, err)
+}
+
+// TestUpdateMemberRoleDBGuardSkipsOwner 守卫回归（PR #339 review F1）：
+// updateMemberRole 的 WHERE 带 role<>2。模拟「pre-check 读到 role<2 后，
+// 目标被并发转让升为 owner」的最终态——降级 UPDATE 必须空转，owner 不被降级。
+func TestUpdateMemberRoleDBGuardSkipsOwner(t *testing.T) {
+	_, f, err := setup(t)
+	assert.NoError(t, err)
+	spaceId := "role-db-guard"
+	memberRoleFixture(t, f, spaceId, 2, 0)
+
+	// 并发转让的最终态：m-target 已是 owner（raw 直写，绕过守卫构造场景）
+	setMemberRoleRaw(t, spaceId, "m-target", 2)
+
+	// 此刻才落地的降级 UPDATE（pre-check 早已通过）必须被 SQL 守卫挡住
+	err = f.db.updateMemberRole(spaceId, "m-target", 1)
+	assert.NoError(t, err)
+	mem, err := f.db.queryMember(spaceId, "m-target")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, mem.Role, "owner must not be demoted by the bare update path")
+}
+
 // TestUpdateMemberRoleTargetNotFound 目标非空间成员时返回 member_not_found。
 func TestUpdateMemberRoleTargetNotFound(t *testing.T) {
 	_, f, err := setup(t)

--- a/modules/space/db.go
+++ b/modules/space/db.go
@@ -175,10 +175,17 @@ func (d *DB) reactivateMember(spaceId string, uid string, role int) error {
 	return err
 }
 
+// updateMemberRole 更新成员角色，仅用于非 owner 角色（0/1）的变更。
+//
+// WHERE 带 role <> 2 守卫（PR #339 review F1）：调用方的 pre-check 都在事务外，
+// 目标可能在 check 后被并发转让升为 owner，裸 UPDATE 会把新 owner 降级产生
+// 无主空间。命中守卫时影响 0 行、静默幂等——显式的 owner 降级已被各调用方
+// pre-check 拒绝，竞态命中时保持 owner 角色就是正确结果。
+// 设 role=2 必须走 transferOwnerAdminLocked，禁止经本函数产生第二个 owner。
 func (d *DB) updateMemberRole(spaceId string, uid string, role int) error {
 	_, err := d.session.Update("space_member").Set("role", role).
 		Set("updated_at", time.Now()).
-		Where("space_id=? and uid=? and status=1", spaceId, uid).Exec()
+		Where("space_id=? and uid=? and status=1 and role <> 2", spaceId, uid).Exec()
 	return err
 }
 

--- a/modules/space/db.go
+++ b/modules/space/db.go
@@ -161,11 +161,10 @@ func (d *DB) queryMembers(spaceId string, loginUID string, page uint64, limit ui
 	return models, err
 }
 
-func (d *DB) removeMember(spaceId string, uid string) error {
-	_, err := d.session.Update("space_member").Set("status", 0).
-		Set("updated_at", time.Now()).
-		Where("space_id=? and uid=?", spaceId, uid).Exec()
-	return err
+// removeMemberLocked 锁内重读角色后移除成员，防并发转让产生无主空间，
+// 见 db_manager.go removeMemberLocked。
+func (d *DB) removeMemberLocked(spaceId, uid string, rejectRoleAtOrAbove int) error {
+	return removeMemberLocked(d.session, spaceId, uid, rejectRoleAtOrAbove)
 }
 
 func (d *DB) reactivateMember(spaceId string, uid string, role int) error {

--- a/modules/space/db.go
+++ b/modules/space/db.go
@@ -183,11 +183,10 @@ func (d *DB) updateMemberRole(spaceId string, uid string, role int) error {
 	return err
 }
 
-func (d *DB) updateMemberRoleTx(tx *dbr.Tx, spaceId string, uid string, role int) error {
-	_, err := tx.Update("space_member").Set("role", role).
-		Set("updated_at", time.Now()).
-		Where("space_id=? and uid=? and status=1", spaceId, uid).Exec()
-	return err
+// transferOwnerAdmin 用户侧转让所有权，复用管理端的行锁原语，
+// 防止目标被并发移除后仍把当前 owner 降级产生无主空间。
+func (d *DB) transferOwnerAdmin(spaceId, newOwnerUID string) error {
+	return transferOwnerAdminLocked(d.session, spaceId, newOwnerUID)
 }
 
 // queryCoMemberUIDs 查询与指定用户同在至少一个空间的所有用户UID

--- a/modules/space/db_manager.go
+++ b/modules/space/db_manager.go
@@ -459,6 +459,49 @@ func transferOwnerAdminLocked(sess *dbr.Session, spaceId, newOwnerUID string) er
 	return tx.Commit()
 }
 
+// ErrRemoveHierarchy 操作者未严格高于目标角色，不能移除目标成员
+var ErrRemoveHierarchy = errors.New("operator does not outrank removal target")
+
+// removeMemberLocked 在单事务内锁定目标行并重读角色后移除成员。
+//
+// 目标 role 必须在锁内重读：pre-check 读到非 owner 后，目标可能被并发转让
+// 升为 owner，裸 UPDATE 仍会把它移除，产生无主空间——与 transferOwnerAdminLocked
+// 防御的是同源的对称竞态（PR #339 review）。
+//   - 目标行不存在 / 已移除 → 幂等返回 nil（pre-check 与事务之间被并发移除）；
+//   - 目标 role == 2 → ErrCannotRemoveOwner；
+//   - 目标 role >= rejectRoleAtOrAbove → ErrRemoveHierarchy
+//     （removeMembers 传操作者角色，实现「仅可移除更低角色」；自助退出传 2，仅拦 owner）。
+func removeMemberLocked(sess *dbr.Session, spaceId, uid string, rejectRoleAtOrAbove int) error {
+	tx, err := sess.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	var roles []int
+	if _, err = tx.SelectBySql(
+		"SELECT role FROM space_member WHERE space_id=? AND uid=? AND status=1 FOR UPDATE",
+		spaceId, uid,
+	).Load(&roles); err != nil {
+		return err
+	}
+	if len(roles) == 0 {
+		return nil
+	}
+	if roles[0] == 2 {
+		return ErrCannotRemoveOwner
+	}
+	if roles[0] >= rejectRoleAtOrAbove {
+		return ErrRemoveHierarchy
+	}
+	if _, err = tx.Update("space_member").
+		Set("status", 0).Set("updated_at", time.Now()).
+		Where("space_id=? AND uid=?", spaceId, uid).Exec(); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 // queryInvitesAdmin 分页查询空间所有邀请码（含已禁用）
 func (d *managerDB) queryInvitesAdmin(spaceId string, pageSize, pageIndex uint64) ([]*InvitationModel, error) {
 	var list []*InvitationModel

--- a/modules/space/db_manager.go
+++ b/modules/space/db_manager.go
@@ -413,13 +413,20 @@ func (d *managerDB) removeMembersForce(spaceId string, uids []string) error {
 // ErrTransferTargetMissing 目标成员不存在或已被移除，不能成为新 owner
 var ErrTransferTargetMissing = errors.New("transfer target not found or already removed")
 
-// transferOwnerAdmin 将 newOwner 置为 owner(2)，将当前所有 owner 降为 admin(1)。
+// transferOwnerAdmin 管理端转让所有权，见 transferOwnerAdminLocked。
+func (d *managerDB) transferOwnerAdmin(spaceId, newOwnerUID string) error {
+	return transferOwnerAdminLocked(d.session, spaceId, newOwnerUID)
+}
+
+// transferOwnerAdminLocked 将 newOwner 置为 owner(2)，将当前所有 owner 降为 admin(1)。
+// 管理端与用户侧转让共用此原语（PR #339 review：用户侧内联事务缺行锁，
+// 目标被并发移除后 UPDATE 影响 0 行仍降级 owner，产生无主空间）。
 //
 // 事务开始时先用 SELECT ... FOR UPDATE 锁定目标行并确认其 status=1，
 // 避免「先降老 owner → 目标被并发 remove → 后续 UPDATE 影响 0 行」导致空间无主。
 // 若目标不存在 / 已被移除，整个事务回滚并返回 ErrTransferTargetMissing。
-func (d *managerDB) transferOwnerAdmin(spaceId, newOwnerUID string) error {
-	tx, err := d.session.Begin()
+func transferOwnerAdminLocked(sess *dbr.Session, spaceId, newOwnerUID string) error {
+	tx, err := sess.Begin()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Background

While investigating "Space owners cannot manage member roles", we confirmed that the user-side API `PUT /v1/space/:space_id/members/:uid/role` has existed all along and that the owner permission check is correct. The immediate reason owners could not change roles was in the octo-admin frontend: the member panel hardcoded role management as visible only in the super-admin console. That frontend patch is tracked separately in Mininglamp-OSS/octo-admin#89.

During the backend investigation, however, we found a high-risk bug in this API. This PR fixes the backend issue.

Closes #341

## Problem: Missing Ownerless-Space Guard

The manager-side endpoint with the same purpose (`api_manager.go` `updateMemberRole`) has an owner-constraint guard (`target.Role == 2 && req.Role != 2` -> reject), but the user-side endpoint did not. Two paths could permanently leave a space without an owner:

1. **Owner self-demotion**: the owner calls the API on themselves with `role=0/1` -> the direct UPDATE succeeds -> the space has no member with `role=2`.
2. **Owner self-transfer** (more subtle): the owner calls the API on themselves with `role=2` -> the transfer transaction first promotes themselves to 2 (same row, no-op), then demotes the "current owner" (still themselves) to 1 -> the space becomes ownerless.

After a space becomes ownerless, all owner-only operations such as role management, dissolution, and transfer become permanently unavailable unless a system administrator repairs the space from the manager side. This endpoint previously had no test coverage.

## Changes

- `modules/space/api.go`: add two guards after target validation:
  - `target.Role == 2 && req.Role != 2` -> `err.server.space.owner_constraint`. Owners cannot be directly demoted, matching manager-side semantics; ownership transfer must happen by setting another member to `role=2`, which triggers the atomic role swap.
  - `target.Role == req.Role` -> return OK idempotently. This also prevents the "self-transfer" path from entering the transfer transaction.
- `modules/space/api_member_role_test.go` (new): add 7 cases covering owner promote/demote of a member, atomic ownership transfer with both roles asserted, role=1 admin forbidden, owner self-demotion rejected, self-transfer idempotently does not demote the owner, same-role idempotency, and missing target member.

## Tests

```bash
go test ./modules/space/   # Passed in full, including the 7 new cases, run against MariaDB + Redis
```

https://claude.ai/code/session_01U7aZb8p6xxfuXfrzF9pMXK

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7aZb8p6xxfuXfrzF9pMXK)_
