### PR TITLE
feat(incomingwebhook): open webhook management to group members and bots

### DIFF
--- a/modules/bot_api/api_i18n_test.go
+++ b/modules/bot_api/api_i18n_test.go
@@ -36,7 +36,7 @@ func TestBotAPINoLegacyResponseError(t *testing.T) {
 	files := []string{
 		"auth.go", "register.go", "commands.go", "events.go", "mention_pref.go",
 		"sync.go", "typing.go", "send.go", "threads.go", "file.go", "groups.go",
-		"voice_adapter.go", "obo_api.go", "resolve_targets.go",
+		"voice_adapter.go", "obo_api.go", "resolve_targets.go", "incoming_webhook.go",
 	}
 	banned := []string{
 		".ResponseError(",

--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -270,6 +270,10 @@ func (ba *BotAPI) Route(r *wkhttp.WKHttp) {
 	// User-token endpoints under /v1/obo. Implementation in obo_api.go;
 	// the call is split out so this Route function doesn't grow further.
 	ba.registerOBORoutes(r)
+
+	// 群入站 Webhook 管理（bot token 面），与用户路由共用 incomingwebhook 实例与
+	// 权限矩阵（管理员 bot 同权人类管理员）。实现在 incoming_webhook.go。
+	ba.registerIncomingWebhookRoutes(r)
 }
 
 // ==================== Helper Functions ====================

--- a/modules/bot_api/incoming_webhook.go
+++ b/modules/bot_api/incoming_webhook.go
@@ -1,0 +1,44 @@
+package bot_api
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/incomingwebhook"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
+)
+
+// registerIncomingWebhookRoutes 把群入站 Webhook 的管理端点（create/list/update/
+// delete/regenerate/deliveries/test）挂到 bot token 鉴权面：
+//
+//	/v1/bot/groups/:group_no/incoming-webhooks[...]
+//
+// 处理器与用户路由（/v1/groups/:group_no/incoming-webhooks）共用同一套实现
+// （incomingwebhook.NewManagementFacade，一套 Service、两个门）。权限矩阵一致：
+// bot 是群管理员（group_member.role）则与人类管理员同权；普通成员 bot 只能创建并
+// 管理自己（robot_id 即 creator_uid）创建的 webhook。bot 面写操作对 push 缓存的
+// 失效以 TTL 兜底（见 NewManagementFacade 的契约注释）。
+//
+// 中间件链：authBot（bf_/app_ token → robot_id）→ botActorUID（把 robot_id 写入
+// 共享处理器读取的 "uid" 键）→ SharedUIDRateLimiter（须在 uid 写入之后，否则读不到
+// uid 静默 fail-open；bot 与登录用户共用 per-uid 桶语义，robot_id 即桶 key）。
+func (ba *BotAPI) registerIncomingWebhookRoutes(r *wkhttp.WKHttp) {
+	iwh := incomingwebhook.NewManagementFacade(ba.ctx)
+	g := r.Group("/v1/bot/groups/:group_no/incoming-webhooks",
+		ba.authBot(), ba.botActorUID(), appwkhttp.SharedUIDRateLimiter(r, ba.ctx))
+	iwh.MountManagementRoutes(g)
+}
+
+// botActorUID 把 authBot 解析出的 robot_id 适配到 "uid" 上下文键（incomingwebhook
+// 共享处理器的操作者身份来源，与用户路由的 AuthMiddleware 同键）。robot_id 缺失说明
+// 中间件链装配有误，按内部断言失败处理（500），并 Abort 阻断后续 handler。
+func (ba *BotAPI) botActorUID() wkhttp.HandlerFunc {
+	return func(c *wkhttp.Context) {
+		robotID := getRobotIDFromContext(c)
+		if robotID == "" {
+			ba.respondBotAPIIdentityMissing(c)
+			c.Abort()
+			return
+		}
+		c.Set("uid", robotID)
+		c.Next()
+	}
+}

--- a/modules/bot_api/incoming_webhook_test.go
+++ b/modules/bot_api/incoming_webhook_test.go
@@ -141,10 +141,10 @@ func TestBotWebhook_MemberCreateAndManageOwn(t *testing.T) {
 	require.NotEmpty(t, created["token"])
 	whID := created["webhook_id"].(string)
 
-	// 自定义名称 → 200；自定义头像 → 400（仅管理员可设头像）。
+	// 自定义名称 → 200，强制带 "Webhook-" 前缀；自定义头像 → 400（仅管理员可设头像）。
 	w = doBot(handler, botReq(t, "POST", botWebhookBase(), iwhBotToken, map[string]interface{}{"name": "ci-bot-wh"}))
 	require.Equalf(t, http.StatusOK, w.Code, "named create body: %s", w.Body.String())
-	assert.Equal(t, "ci-bot-wh", decodeBody(t, w)["name"])
+	assert.Equal(t, "Webhook-ci-bot-wh", decodeBody(t, w)["name"])
 	w = doBot(handler, botReq(t, "POST", botWebhookBase(), iwhBotToken, map[string]interface{}{"avatar": "https://x/a.png"}))
 	assert.Equalf(t, http.StatusBadRequest, w.Code, "avatar create body: %s", w.Body.String())
 

--- a/modules/bot_api/incoming_webhook_test.go
+++ b/modules/bot_api/incoming_webhook_test.go
@@ -1,0 +1,211 @@
+package bot_api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/go-redis/redis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	// 触发 incomingwebhook 模块注册（SQL 迁移 + 共享实例），bot 路由挂在其上。
+	_ "github.com/Mininglamp-OSS/octo-server/modules/incomingwebhook"
+)
+
+// TestMain 准备 common.Setup 所需的 master key（必须 32 字节）：incomingwebhook 的
+// 模块依赖把 modules/common 带进了本包的测试模块集。CI 经 ci.yml 全局环境变量注入；
+// 本地直接 go test 也能跑通（与 incomingwebhook 包的 TestMain 同模式）。
+func TestMain(m *testing.M) {
+	if os.Getenv("OCTO_MASTER_KEY") == "" {
+		os.Setenv("OCTO_MASTER_KEY", "12345678901234567890123456789012")
+	}
+	os.Exit(m.Run())
+}
+
+// Bot 管理群入站 Webhook（/v1/bot/groups/:group_no/incoming-webhooks）：
+//   - 群成员 bot 可创建（名称缺省自动命名；头像仅管理员可设）并管理自己创建的；
+//   - 非成员 bot 403；成员 bot 不可动他人创建的（403）；
+//   - 担任群管理员（group_member.role=manager）的 bot 与人类管理员同权：
+//     可设头像、可管理任意 webhook。
+
+const (
+	iwhBotID         = "bot_iwh_member"
+	iwhBotToken      = "bf_iwh_member_token"
+	iwhBot2ID        = "bot_iwh_other"
+	iwhBot2Token     = "bf_iwh_other_token"
+	iwhAdminBotID    = "bot_iwh_admin"
+	iwhAdminBotToken = "bf_iwh_admin_token"
+	iwhOutBotID      = "bot_iwh_outsider"
+	iwhOutBotToken   = "bf_iwh_outsider_token"
+	iwhGroupNo       = "g_iwh_bot_1"
+)
+
+func setupBotWebhookEnv(t *testing.T) (http.Handler, *config.Context) {
+	t.Helper()
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	for _, b := range []struct{ id, token string }{
+		{iwhBotID, iwhBotToken},
+		{iwhBot2ID, iwhBot2Token},
+		{iwhAdminBotID, iwhAdminBotToken},
+		{iwhOutBotID, iwhOutBotToken},
+	} {
+		_, err := ctx.DB().InsertBySql(
+			"INSERT INTO robot (robot_id, status, creator_uid, bot_token) VALUES (?, 1, ?, ?)",
+			b.id, "owner_iwh", b.token).Exec()
+		require.NoError(t, err)
+	}
+
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `group` (group_no, name, status, version) VALUES (?, ?, 1, 1)",
+		iwhGroupNo, "iwh bot group").Exec()
+	require.NoError(t, err)
+
+	// 成员 bot ×2（role=0）、管理员 bot（role=2）；outsider 不入群。
+	for _, m := range []struct {
+		uid  string
+		role int
+	}{{iwhBotID, 0}, {iwhBot2ID, 0}, {iwhAdminBotID, 2}} {
+		_, err = ctx.DB().InsertBySql(
+			"INSERT INTO group_member (group_no, uid, role, vercode, is_deleted, status, version) VALUES (?, ?, ?, ?, 0, 1, 1)",
+			iwhGroupNo, m.uid, m.role, util.GenerUUID()).Exec()
+		require.NoError(t, err)
+	}
+
+	// bot 管理路由挂了 SharedUIDRateLimiter（按 uid=robot_id 的 Redis 桶，跨测试持久），
+	// 清桶保证从满额开始。
+	rds := redis.NewClient(&redis.Options{
+		Addr:     ctx.GetConfig().DB.RedisAddr,
+		Password: ctx.GetConfig().DB.RedisPass,
+	})
+	defer rds.Close()
+	if keys, err := rds.Keys("ratelimit:uid:*").Result(); err == nil && len(keys) > 0 {
+		_ = rds.Del(keys...).Err()
+	}
+
+	return s.GetRoute(), ctx
+}
+
+func botReq(t *testing.T, method, path, botToken string, body interface{}) *http.Request {
+	t.Helper()
+	var rd *bytes.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		require.NoError(t, err)
+		rd = bytes.NewReader(raw)
+	} else {
+		rd = bytes.NewReader(nil)
+	}
+	req, err := http.NewRequest(method, path, rd)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+botToken)
+	return req
+}
+
+func doBot(handler http.Handler, req *http.Request) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+func botWebhookBase() string {
+	return fmt.Sprintf("/v1/bot/groups/%s/incoming-webhooks", iwhGroupNo)
+}
+
+func decodeBody(t *testing.T, w *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var m map[string]interface{}
+	require.NoErrorf(t, json.Unmarshal(w.Body.Bytes(), &m), "body: %s", w.Body.String())
+	return m
+}
+
+// 成员 bot：创建（缺省自动命名 + creator=bot）→ 改自身状态 → 删除，全链路可用。
+func TestBotWebhook_MemberCreateAndManageOwn(t *testing.T) {
+	handler, _ := setupBotWebhookEnv(t)
+
+	w := doBot(handler, botReq(t, "POST", botWebhookBase(), iwhBotToken, map[string]interface{}{}))
+	require.Equalf(t, http.StatusOK, w.Code, "bot create body: %s", w.Body.String())
+	created := decodeBody(t, w)
+	assert.Equal(t, iwhBotID, created["creator_uid"])
+	assert.Regexp(t, `^Webhook-[0-9a-f]{6}$`, created["name"])
+	require.NotEmpty(t, created["token"])
+	whID := created["webhook_id"].(string)
+
+	// 自定义名称 → 200；自定义头像 → 400（仅管理员可设头像）。
+	w = doBot(handler, botReq(t, "POST", botWebhookBase(), iwhBotToken, map[string]interface{}{"name": "ci-bot-wh"}))
+	require.Equalf(t, http.StatusOK, w.Code, "named create body: %s", w.Body.String())
+	assert.Equal(t, "ci-bot-wh", decodeBody(t, w)["name"])
+	w = doBot(handler, botReq(t, "POST", botWebhookBase(), iwhBotToken, map[string]interface{}{"avatar": "https://x/a.png"}))
+	assert.Equalf(t, http.StatusBadRequest, w.Code, "avatar create body: %s", w.Body.String())
+
+	// 改自身状态 OK。
+	w = doBot(handler, botReq(t, "PUT", botWebhookBase()+"/"+whID, iwhBotToken, map[string]interface{}{"status": 0}))
+	assert.Equalf(t, http.StatusOK, w.Code, "self disable body: %s", w.Body.String())
+
+	// list 可见。
+	w = doBot(handler, botReq(t, "GET", botWebhookBase(), iwhBotToken, nil))
+	require.Equalf(t, http.StatusOK, w.Code, "list body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), whID)
+
+	// 删除自己创建的 OK。
+	w = doBot(handler, botReq(t, "DELETE", botWebhookBase()+"/"+whID, iwhBotToken, nil))
+	assert.Equalf(t, http.StatusOK, w.Code, "self delete body: %s", w.Body.String())
+}
+
+// 成员 bot 不可动他人创建的（403）；非成员 bot 一切操作 403。
+func TestBotWebhook_OwnershipAndMembershipGates(t *testing.T) {
+	handler, _ := setupBotWebhookEnv(t)
+
+	w := doBot(handler, botReq(t, "POST", botWebhookBase(), iwhBotToken, map[string]interface{}{}))
+	require.Equalf(t, http.StatusOK, w.Code, "bot create body: %s", w.Body.String())
+	whID := decodeBody(t, w)["webhook_id"].(string)
+
+	// 另一个成员 bot 动它 → 403。
+	w = doBot(handler, botReq(t, "PUT", botWebhookBase()+"/"+whID, iwhBot2Token, map[string]interface{}{"status": 0}))
+	assert.Equalf(t, http.StatusForbidden, w.Code, "other bot update body: %s", w.Body.String())
+	w = doBot(handler, botReq(t, "DELETE", botWebhookBase()+"/"+whID, iwhBot2Token, nil))
+	assert.Equalf(t, http.StatusForbidden, w.Code, "other bot delete body: %s", w.Body.String())
+
+	// 非成员 bot：创建 / 列表 都 403。
+	w = doBot(handler, botReq(t, "POST", botWebhookBase(), iwhOutBotToken, map[string]interface{}{}))
+	assert.Equalf(t, http.StatusForbidden, w.Code, "outsider create body: %s", w.Body.String())
+	w = doBot(handler, botReq(t, "GET", botWebhookBase(), iwhOutBotToken, nil))
+	assert.Equalf(t, http.StatusForbidden, w.Code, "outsider list body: %s", w.Body.String())
+}
+
+// 管理员 bot 与人类管理员同权：可设头像、管理任意成员 bot 的 webhook。
+func TestBotWebhook_AdminBotManagesAny(t *testing.T) {
+	handler, _ := setupBotWebhookEnv(t)
+
+	// 成员 bot 先建一个。
+	w := doBot(handler, botReq(t, "POST", botWebhookBase(), iwhBotToken, map[string]interface{}{}))
+	require.Equalf(t, http.StatusOK, w.Code, "member bot create body: %s", w.Body.String())
+	memberWhID := decodeBody(t, w)["webhook_id"].(string)
+
+	// 管理员 bot 自定义名称+头像创建 → 200（管理员可设头像）。
+	w = doBot(handler, botReq(t, "POST", botWebhookBase(), iwhAdminBotToken,
+		map[string]interface{}{"name": "admin-bot-wh", "avatar": "https://example.com/a.png"}))
+	require.Equalf(t, http.StatusOK, w.Code, "admin bot create body: %s", w.Body.String())
+	created := decodeBody(t, w)
+	assert.Equal(t, "admin-bot-wh", created["name"])
+	assert.Equal(t, "https://example.com/a.png", created["avatar"])
+
+	// 管理员 bot 改名成员 bot 的 webhook → 200。
+	w = doBot(handler, botReq(t, "PUT", botWebhookBase()+"/"+memberWhID, iwhAdminBotToken, map[string]interface{}{"name": "renamed-by-admin-bot"}))
+	require.Equalf(t, http.StatusOK, w.Code, "admin bot rename body: %s", w.Body.String())
+	assert.Equal(t, "renamed-by-admin-bot", decodeBody(t, w)["name"])
+
+	// 管理员 bot 删除成员 bot 的 webhook → 200。
+	w = doBot(handler, botReq(t, "DELETE", botWebhookBase()+"/"+memberWhID, iwhAdminBotToken, nil))
+	assert.Equalf(t, http.StatusOK, w.Code, "admin bot delete body: %s", w.Body.String())
+}

--- a/modules/bot_api/incoming_webhook_test.go
+++ b/modules/bot_api/incoming_webhook_test.go
@@ -183,6 +183,44 @@ func TestBotWebhook_OwnershipAndMembershipGates(t *testing.T) {
 	assert.Equalf(t, http.StatusForbidden, w.Code, "outsider list body: %s", w.Body.String())
 }
 
+// App Bot（app_ token，authBot 的另一条鉴权分支）在本管理面的现实行为：鉴权可过，
+// 但一律 403（PR #340 review，Jerry-Xin 建议钉住 app_ 分支）。
+//
+// 原因：权限判定只认 group_member 行，而 App Bot 当前【无法入群】——createBot 不写
+// space_member（见 modules/app_bot/app_bot.go addFriend 处的注释），space 群加成员
+// 对 bot 强制校验 space 成员资格（modules/group/api.go ErrGroupBotNotInSpace），
+// 所以 App Bot 永远没有 group_member 行。本管理面实际仅 User Bot 可用；若未来放开
+// App Bot 入群，resolveActor 按 uid 判定、不特判 token 类型，权限矩阵自动成立。
+//
+// 经 in-memory Registry 热路径鉴权（authAppBot 的首选分支，生产由 app_bot 模块在
+// 启动时灌注）：bot_api 测试包不能 blank-import app_bot（会成 prod→test 导入环），
+// 故不走 app_bot 表的 DB fallback 分支。
+func TestBotWebhook_AppBotAlwaysForbidden(t *testing.T) {
+	handler, _ := setupBotWebhookEnv(t)
+
+	const (
+		appBotUID   = "app_iwh_bot_uid"
+		appBotToken = "app_iwh_token"
+	)
+	adapter := NewAppBotRegistryAdapter()
+	adapter.Add(appBotToken, &AppBotRegistrySpec{UID: appBotUID, Scope: "platform"})
+	prev := GetAppBotRegistry()
+	SetAppBotRegistry(adapter)
+	t.Cleanup(func() {
+		if prev != nil {
+			SetAppBotRegistry(prev)
+		} else {
+			SetAppBotRegistry(NewAppBotRegistryAdapter()) // atomic.Value 不可存 nil，置空注册表即可
+		}
+	})
+
+	// 鉴权通过（非 401），但非群成员 → 创建/列表一律 403。
+	w := doBot(handler, botReq(t, "POST", botWebhookBase(), appBotToken, map[string]interface{}{}))
+	assert.Equalf(t, http.StatusForbidden, w.Code, "app bot create body: %s", w.Body.String())
+	w = doBot(handler, botReq(t, "GET", botWebhookBase(), appBotToken, nil))
+	assert.Equalf(t, http.StatusForbidden, w.Code, "app bot list body: %s", w.Body.String())
+}
+
 // 管理员 bot 与人类管理员同权：可设头像、管理任意成员 bot 的 webhook。
 func TestBotWebhook_AdminBotManagesAny(t *testing.T) {
 	handler, _ := setupBotWebhookEnv(t)

--- a/modules/common/api_manager_system_setting_test.go
+++ b/modules/common/api_manager_system_setting_test.go
@@ -452,6 +452,7 @@ func TestManagerSystemSetting_UpdateRejectsInvalidIncomingWebhookNumerics(t *tes
 		{"per_webhook_rps", "+Inf"}, {"per_webhook_rps", "-Inf"}, {"per_webhook_rps", "abc"},
 		{"per_webhook_burst", "0"}, {"per_webhook_burst", "-1"},
 		{"max_per_group", "0"}, {"max_per_group", "-5"},
+		{"max_per_creator", "0"}, {"max_per_creator", "-3"},
 	}
 	for _, tc := range cases {
 		body := []byte(`{"items":[{"category":"incomingwebhook","key":"` + tc.key + `","value":"` + tc.value + `"}]}`)

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -115,6 +115,8 @@ var systemSettingSchema = []settingDef{
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.IncomingWebhookPerWebhookBurst()) }},
 	{Category: "incomingwebhook", Key: "max_per_group", Type: settingTypeInt, Description: "单个群最多可创建的 Webhook 数量", Positive: true,
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.IncomingWebhookMaxPerGroup()) }},
+	{Category: "incomingwebhook", Key: "max_per_creator", Type: settingTypeInt, Description: "单个普通成员/机器人在一个群内最多可创建的 Webhook 数量（群主/管理员不受限）", Positive: true,
+		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.IncomingWebhookMaxPerCreator()) }},
 
 	// Email server config — formerly yaml-only (Support.* in config.go).
 	{Category: "support", Key: "email", Type: settingTypeString, Description: "技术支持邮箱（发件人）",

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -560,11 +560,13 @@ const (
 	envIncomingWebhookPerWebhookRPS   = "DM_INCOMINGWEBHOOK_RPS"
 	envIncomingWebhookPerWebhookBurst = "DM_INCOMINGWEBHOOK_BURST"
 	envIncomingWebhookMaxPerGroup     = "DM_INCOMINGWEBHOOK_MAX_PER_GROUP"
+	envIncomingWebhookMaxPerCreator   = "DM_INCOMINGWEBHOOK_MAX_PER_CREATOR"
 
 	defaultIncomingWebhookEnabled         = true
 	defaultIncomingWebhookPerWebhookRPS   = 5.0
 	defaultIncomingWebhookPerWebhookBurst = 10
 	defaultIncomingWebhookMaxPerGroup     = 10
+	defaultIncomingWebhookMaxPerCreator   = 5
 )
 
 // IncomingWebhookEnabled 是群入站 Webhook 功能的总开关。关闭后 push 端点返回 404、
@@ -645,4 +647,27 @@ func incomingWebhookMaxPerGroupEnvDefault() int {
 		}
 	}
 	return defaultIncomingWebhookMaxPerGroup
+}
+
+// IncomingWebhookMaxPerCreator 单个普通成员/bot 在一个群内可创建的 webhook 数量
+// 上限（群主/管理员豁免，仅受群级 max_per_group 约束）。DB → env → 默认 5。
+// 读侧防御：≤0 回退默认（同 max_per_group，避免误配成"任何成员都建不了"的暗关）。
+func (s *SystemSettings) IncomingWebhookMaxPerCreator() int {
+	def := incomingWebhookMaxPerCreatorEnvDefault()
+	v := s.getInt("incomingwebhook", "max_per_creator", def)
+	if v <= 0 {
+		return def
+	}
+	return v
+}
+
+// incomingWebhookMaxPerCreatorEnvDefault 解析 DM_INCOMINGWEBHOOK_MAX_PER_CREATOR；
+// 仅接受正整数，否则回退默认值。
+func incomingWebhookMaxPerCreatorEnvDefault() int {
+	if v := os.Getenv(envIncomingWebhookMaxPerCreator); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultIncomingWebhookMaxPerCreator
 }

--- a/modules/common/system_settings_test.go
+++ b/modules/common/system_settings_test.go
@@ -149,21 +149,31 @@ func TestSystemSettings_IncomingWebhookThresholds_DefaultsAndDBOverride(t *testi
 	t.Setenv(envIncomingWebhookPerWebhookRPS, "")
 	t.Setenv(envIncomingWebhookPerWebhookBurst, "")
 	t.Setenv(envIncomingWebhookMaxPerGroup, "")
+	t.Setenv(envIncomingWebhookMaxPerCreator, "")
 	s := newTestSystemSettings(t, nil)
 
 	// DB+env 缺失 → code default。
 	assert.Equal(t, defaultIncomingWebhookPerWebhookRPS, s.IncomingWebhookPerWebhookRPS())
 	assert.Equal(t, defaultIncomingWebhookPerWebhookBurst, s.IncomingWebhookPerWebhookBurst())
 	assert.Equal(t, defaultIncomingWebhookMaxPerGroup, s.IncomingWebhookMaxPerGroup())
+	assert.Equal(t, defaultIncomingWebhookMaxPerCreator, s.IncomingWebhookMaxPerCreator())
 
 	// DB 覆盖（含 float rps）。
 	require.NoError(t, s.db.upsert("incomingwebhook", "per_webhook_rps", "8.5", settingTypeFloat, ""))
 	require.NoError(t, s.db.upsert("incomingwebhook", "per_webhook_burst", "25", settingTypeInt, ""))
 	require.NoError(t, s.db.upsert("incomingwebhook", "max_per_group", "3", settingTypeInt, ""))
+	require.NoError(t, s.db.upsert("incomingwebhook", "max_per_creator", "2", settingTypeInt, ""))
 	require.NoError(t, s.Reload())
 	assert.Equal(t, 8.5, s.IncomingWebhookPerWebhookRPS())
 	assert.Equal(t, 25, s.IncomingWebhookPerWebhookBurst())
 	assert.Equal(t, 3, s.IncomingWebhookMaxPerGroup())
+	assert.Equal(t, 2, s.IncomingWebhookMaxPerCreator())
+}
+
+func TestSystemSettings_IncomingWebhookMaxPerCreator_EnvFallbackWhenDBUnset(t *testing.T) {
+	t.Setenv(envIncomingWebhookMaxPerCreator, "7")
+	s := newTestSystemSettings(t, nil)
+	assert.Equal(t, 7, s.IncomingWebhookMaxPerCreator(), "DB 未配置 → env 生效")
 }
 
 func TestSystemSettings_IncomingWebhookRPS_EnvFallbackWhenDBUnset(t *testing.T) {
@@ -181,6 +191,7 @@ func TestSystemSettings_IncomingWebhook_ReadSideClamp_NoInfra(t *testing.T) {
 	t.Setenv(envIncomingWebhookPerWebhookRPS, "")   // → default 5
 	t.Setenv(envIncomingWebhookPerWebhookBurst, "") // → default 10
 	t.Setenv(envIncomingWebhookMaxPerGroup, "")     // → default 10
+	t.Setenv(envIncomingWebhookMaxPerCreator, "")   // → default 5
 
 	for _, bad := range []string{"NaN", "+Inf", "-Inf", "0", "-1", "-3.5"} {
 		s := &SystemSettings{}
@@ -188,11 +199,13 @@ func TestSystemSettings_IncomingWebhook_ReadSideClamp_NoInfra(t *testing.T) {
 			"incomingwebhook.per_webhook_rps":   bad,
 			"incomingwebhook.per_webhook_burst": bad,
 			"incomingwebhook.max_per_group":     bad,
+			"incomingwebhook.max_per_creator":   bad,
 		}
 		s.snapshot.Store(&snap)
 		assert.Equalf(t, defaultIncomingWebhookPerWebhookRPS, s.IncomingWebhookPerWebhookRPS(), "rps=%q must clamp to default", bad)
 		assert.Equalf(t, defaultIncomingWebhookPerWebhookBurst, s.IncomingWebhookPerWebhookBurst(), "burst=%q must clamp to default", bad)
 		assert.Equalf(t, defaultIncomingWebhookMaxPerGroup, s.IncomingWebhookMaxPerGroup(), "max_per_group=%q must clamp to default", bad)
+		assert.Equalf(t, defaultIncomingWebhookMaxPerCreator, s.IncomingWebhookMaxPerCreator(), "max_per_creator=%q must clamp to default", bad)
 	}
 
 	// env-derived fallback is sanitized too: DM_INCOMINGWEBHOOK_RPS=NaN (which

--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -1,7 +1,41 @@
 # Incoming Webhook 推送契约
 
-外部服务通过带 token 的 URL 向指定群推送消息。管理端点（创建/列出/更新/删除/重置）
-由群主或管理员调用，详见 `api.go`。本文聚焦**推送端点**的请求契约。
+外部服务通过带 token 的 URL 向指定群推送消息。本文先给出**管理端点的权限模型**
+（#member-perms），随后聚焦**推送端点**的请求契约；管理端点实现详见 `api.go`。
+
+## 管理端点权限模型
+
+管理端点有两个挂载面，处理器与权限矩阵完全一致（一套 Service、两个门）：
+
+```
+/v1/groups/:group_no/incoming-webhooks[...]       # 用户登录态（AuthMiddleware）
+/v1/bot/groups/:group_no/incoming-webhooks[...]   # bot token（authBot，robot_id 即操作者）
+```
+
+| 操作 | 群主/管理员（含管理员 bot） | 普通成员 / 成员 bot（内部、正常状态） |
+|------|------|------|
+| create | ✅（可自定义名称+头像） | ✅ 名称可自定义（缺省自动命名 `Webhook-xxxxxx`）；头像不可设置（400） |
+| update | ✅ 任意 webhook | ✅ 仅自己创建的；可改名称/状态，头像不可改（400） |
+| delete / regenerate / test | ✅ 任意 webhook | ✅ 仅自己创建的（其余 403） |
+| list | ✅ | ✅ 只读全量可见（不回显 token/推送 URL） |
+| deliveries | ✅ 任意 webhook | ✅ 仅自己创建的（其余 403） |
+
+- 管理员判定走 `group_member.role`（`QueryIsGroupManagerOrCreator`），对人和 bot
+  一视同仁——**bot 被设为群管理员即与人类管理员同权**。外部成员（is_external=1）
+  与非正常状态成员一律 403。
+- 配额双层：群级 `max_per_group`（默认 10）对所有人生效；普通成员/bot 另受
+  per-creator 配额（system_setting `incomingwebhook.max_per_creator`，默认 5，env
+  `DM_INCOMINGWEBHOOK_MAX_PER_CREATOR`）约束，管理员豁免。超限 409。
+- **创建者退群即失效**：push 路径校验创建者仍是群内（内部、正常）成员，不满足则
+  统一 401 并把该 webhook 懒级联禁用（status→0）；启用/regenerate/测试推送对
+  创建者已退群的 webhook 返回 409（`mgmt_creator_left`），只能删除重建。创建者
+  重新入群后可由创建者/管理员重新启用。
+- 撤回不对称（已知契约）：webhook 消息的 FromUID 是 `iwh_*`，仅群主/管理员可撤回
+  （见 api.go 顶部注释）；普通成员创建者撤不了自己 webhook 发出的消息，止血手段是
+  立即禁用该 webhook。
+- 头像：成员/bot 创建的 webhook 无自定义头像，头像端点（`/v1/users/iwh_*/avatar`）
+  按 `crc32(webhook_id)` 确定性回退到 bot 默认头像 13 色 palette（与 bot 视觉口径
+  一致）；管理员可为任意 webhook 设置自定义头像 URL（302 重定向）。
 
 ```
 POST /v1/incoming-webhooks/:webhook_id/:token            # native（本文主体）

--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -79,7 +79,11 @@ Content-Type: application/json
 - `content`：必填，非空；语义长度上限 4000 rune（`DM_INCOMINGWEBHOOK_MAX_CONTENT_RUNES`）。
 - `text`：`content` 的别名（Slack 等平台习惯用 `text`）。`content` 为空时回退到 `text`，
   降低从既有集成迁移的改造成本；两者都填以 `content` 为准。
-- `username` / `avatar_url`：可选，覆盖该条消息的展示发送者名/头像（不改 webhook 本身配置）。
+- `username` / `avatar_url`：可选，覆盖该条消息的展示发送者名/头像（不改 webhook 本身
+  配置）。**仅当 webhook 创建者当前是群主/管理员时生效**；成员/bot 创建的 webhook 这
+  两个字段被静默忽略（推送仍成功），展示固定为存量名称（必带 `Webhook-` 前缀）+ 默认
+  头像——否则管理面的防冒充限制会被 push 路径整体绕过。判权结果随创建者现任角色，
+  变更生效延迟 ≤ 一个缓存 TTL（默认 3s）。
 
 ### 2. 富文本 / 图文混排（`msg_type` = `"richtext"`）
 

--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -22,7 +22,13 @@
 
 - 管理员判定走 `group_member.role`（`QueryIsGroupManagerOrCreator`），对人和 bot
   一视同仁——**bot 被设为群管理员即与人类管理员同权**。外部成员（is_external=1）
-  与非正常状态成员一律 403。
+  与非正常状态成员一律 403。能力来自 `group_member` 行，不来自 token 类型或
+  scope——App Bot（`app_` token）能过 authBot 鉴权，但当前无法入群（不在
+  space_member，space 群加成员校验会拒绝），因此本管理面实际仅 **User Bot**
+  （`bf_`）可用，App Bot 恒 403；若未来放开 App Bot 入群，权限矩阵自动成立。
+- 隐私提示：list 响应包含每个 webhook 的 `creator_uid`（供客户端判断"是否我创建的"
+  并展示归属），即任意群成员可见全群 webhook 的创建者身份——群成员名册本就互相可见，
+  属有意设计；token / 推送 URL 绝不出现在 list 中。对隐私敏感的部署请知悉此暴露面。
 - 配额双层：群级 `max_per_group`（默认 10）对所有人生效；普通成员/bot 另受
   per-creator 配额（system_setting `incomingwebhook.max_per_creator`，默认 5，env
   `DM_INCOMINGWEBHOOK_MAX_PER_CREATOR`）约束，管理员豁免。超限 409。

--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -14,8 +14,8 @@
 
 | 操作 | 群主/管理员（含管理员 bot） | 普通成员 / 成员 bot（内部、正常状态） |
 |------|------|------|
-| create | ✅（可自定义名称+头像） | ✅ 名称可自定义（缺省自动命名 `Webhook-xxxxxx`）；头像不可设置（400） |
-| update | ✅ 任意 webhook | ✅ 仅自己创建的；可改名称/状态，头像不可改（400） |
+| create | ✅（可自定义名称+头像） | ✅ 名称可自定义但强制带 `Webhook-` 前缀（缺省自动命名 `Webhook-xxxxxx`）；头像不可设置（400） |
+| update | ✅ 任意 webhook | ✅ 仅自己创建的；可改名称（强制 `Webhook-` 前缀）/状态，头像不可改（400） |
 | delete / regenerate / test | ✅ 任意 webhook | ✅ 仅自己创建的（其余 403） |
 | list | ✅ | ✅ 只读全量可见（不回显 token/推送 URL） |
 | deliveries | ✅ 任意 webhook | ✅ 仅自己创建的（其余 403） |

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -95,6 +95,11 @@ type IncomingWebhook struct {
 	// 契约见 cache.go。只缓存存在/Normal 的正向结果，不做负缓存。
 	webhookCache *ttlCache[*incomingWebhookModel]
 	groupCache   *ttlCache[*group.Model]
+	// memberCache 缓存「创建者仍是群内（内部、正常）成员」的正向结果，key 为
+	// groupNo+"|"+uid。push 路径的创建者在群闸（cachedCreatorIsMember）用它把
+	// 每次推送的 group_member 点读压到 0；只缓存 true（退群后最多 stale 一个 TTL，
+	// 之后懒级联禁用把 webhook 翻为 disabled，彻底关闸）。
+	memberCache *ttlCache[bool]
 }
 
 // maxConcurrentAudit 限制异步审计 goroutine 的最大并发数（默认值，可被 env 覆盖）。
@@ -136,10 +141,35 @@ func sharedRateRedis(cfg *config.Config) *redis.Client {
 	return rateRedisClient
 }
 
-// New 构造路由模块。
+// New 构造路由模块（完整实例：注册 push/管理路由 + GroupDisband 事件监听）。
 func New(ctx *config.Context) *IncomingWebhook {
+	w := newIncomingWebhook(ctx)
+	// 群解散级联禁用所有 webhook。只在模块主实例上注册——bot 管理面
+	// （NewManagementFacade）不重复订阅，避免一次 disband 触发两份级联写。
+	w.ctx.AddEventListener(event.GroupDisband, w.handleGroupDisband)
+	return w
+}
+
+// NewManagementFacade 构造 bot_api 挂载管理端点（MountManagementRoutes）用的轻量
+// 实例：与 New 同构（同一套 handler / DB / 审计池），但不注册事件监听（disband
+// 级联由模块主实例负责），也不会被挂 push 路由。
+//
+// ⚠️ 缓存一致性契约：facade 与模块主实例【各持一份】push 热路径缓存。bot 面的管理
+// 写操作（update/delete/regenerate）即时失效的是 facade 自己的缓存，主实例的 push
+// 缓存最多 stale 一个 TTL（默认 3s）——与既有「跨实例无主动失效、TTL 兜底」的
+// staleness 契约（cache.go）同级，等同把 bot 面视作一个对等实例；需要更快收敛就
+// 调小 DM_INCOMINGWEBHOOK_CACHE_TTL_MS。
+//
+// 刻意【不】按 ctx 记忆化共享单实例：octo-lib 的模块注册器以首个 ctx 调用各模块的
+// 创建闭包，按-ctx 记忆化会把测试进程里的多个 test server 折叠成单实例，串掉
+// per-server 的 env 派生配置（内存限流地板、缓存 TTL 等）。
+func NewManagementFacade(ctx *config.Context) *IncomingWebhook {
+	return newIncomingWebhook(ctx)
+}
+
+func newIncomingWebhook(ctx *config.Context) *IncomingWebhook {
 	cacheTTL, cacheMax := cacheTTL(), cacheMax()
-	w := &IncomingWebhook{
+	return &IncomingWebhook{
 		ctx:          ctx,
 		Log:          log.NewTLog("IncomingWebhook"),
 		db:           newDB(ctx),
@@ -150,31 +180,20 @@ func New(ctx *config.Context) *IncomingWebhook {
 		settings:     commonmod.EnsureSystemSettings(ctx),
 		webhookCache: newTTLCache[*incomingWebhookModel](cacheTTL, cacheMax),
 		groupCache:   newTTLCache[*group.Model](cacheTTL, cacheMax),
+		memberCache:  newTTLCache[bool](cacheTTL, cacheMax),
 	}
-	// 群解散级联禁用所有 webhook
-	w.ctx.AddEventListener(event.GroupDisband, w.handleGroupDisband)
-	return w
 }
 
 // Route 注册路由。
 func (w *IncomingWebhook) Route(r *wkhttp.WKHttp) {
-	// 管理类：登录用户 + 群管理员校验。认证路由默认挂 SharedUIDRateLimiter（须在
-	// AuthMiddleware 之后，否则读不到 uid 会静默 fail-open），与全局 IP floor 叠加，
-	// 给 create/regenerate 等敏感写操作补 per-login-user 限流。
-	mgr := r.Group("/v1/groups", w.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, w.ctx))
-	{
-		// 总开关(system_setting incomingwebhook.enabled)关闭时，写操作一律 403 拒绝，
-		// 仅保留 list 只读——运维仍可查看/排查已存在配置。requireMgmtEnabled 不挂在 list 上。
-		mgr.POST("/:group_no/incoming-webhooks", w.requireMgmtEnabled(), w.create)
-		mgr.GET("/:group_no/incoming-webhooks", w.list)
-		mgr.PUT("/:group_no/incoming-webhooks/:webhook_id", w.requireMgmtEnabled(), w.update)
-		mgr.DELETE("/:group_no/incoming-webhooks/:webhook_id", w.requireMgmtEnabled(), w.delete)
-		mgr.POST("/:group_no/incoming-webhooks/:webhook_id/regenerate", w.requireMgmtEnabled(), w.regenerate)
-		// 排障：最近投递记录（成功+失败）。只读，与 list 一致不挂 requireMgmtEnabled。
-		mgr.GET("/:group_no/incoming-webhooks/:webhook_id/deliveries", w.deliveries)
-		// 测试推送：管理员一键发一条样例消息验证配置。写操作，挂总开关闸。
-		mgr.POST("/:group_no/incoming-webhooks/:webhook_id/test", w.requireMgmtEnabled(), w.testPush)
-	}
+	// 管理类：登录用户 + 群成员/角色校验（resolveActor）。认证路由默认挂
+	// SharedUIDRateLimiter（须在 AuthMiddleware 之后，否则读不到 uid 会静默
+	// fail-open），与全局 IP floor 叠加，给 create/regenerate 等敏感写操作补
+	// per-login-user 限流。bot 侧的同一组端点由 bot_api 模块经
+	// MountManagementRoutes 挂到 /v1/bot/groups/:group_no/incoming-webhooks。
+	mgr := r.Group("/v1/groups/:group_no/incoming-webhooks",
+		w.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, w.ctx))
+	w.MountManagementRoutes(mgr)
 
 	// 推送类：URL 内 token 鉴权，无 AuthMiddleware。四层限流，由粗到细：
 	//  1) localFloorMiddleware —— 纯内存、不依赖 Redis 的进程级地板，先挡洪峰；Redis
@@ -208,6 +227,27 @@ func (w *IncomingWebhook) Route(r *wkhttp.WKHttp) {
 		push.POST("/incoming-webhooks/:webhook_id/:token/github", chain(w.pushGitHub)...)
 		push.POST("/incoming-webhooks/:webhook_id/:token/wecom", chain(w.pushWeCom)...)
 	}
+}
+
+// MountManagementRoutes 把管理端点（create/list/update/delete/regenerate/
+// deliveries/test）注册到 g 上。g 的路径必须已携带 :group_no（形如
+// /v1/groups/:group_no/incoming-webhooks），且调用方负责挂好鉴权中间件并保证
+// 处理器可从 c.MustGet("uid") 取到操作者身份：
+//   - 用户侧（本模块 Route）：AuthMiddleware 写入登录 uid；
+//   - bot 侧（bot_api 模块）：authBot 后由适配中间件把 robot_id 写入 "uid"。
+// 权限矩阵由 resolveActor + 各 handler 的所有权判断统一实施，与挂载面无关。
+func (w *IncomingWebhook) MountManagementRoutes(g *wkhttp.RouterGroup) {
+	// 总开关(system_setting incomingwebhook.enabled)关闭时，写操作一律 403 拒绝，
+	// 仅保留 list 只读——运维仍可查看/排查已存在配置。requireMgmtEnabled 不挂在 list 上。
+	g.POST("", w.requireMgmtEnabled(), w.create)
+	g.GET("", w.list)
+	g.PUT("/:webhook_id", w.requireMgmtEnabled(), w.update)
+	g.DELETE("/:webhook_id", w.requireMgmtEnabled(), w.delete)
+	g.POST("/:webhook_id/regenerate", w.requireMgmtEnabled(), w.regenerate)
+	// 排障：最近投递记录（成功+失败）。只读，与 list 一致不挂 requireMgmtEnabled。
+	g.GET("/:webhook_id/deliveries", w.deliveries)
+	// 测试推送：创建者/管理员一键发一条样例消息验证配置。写操作，挂总开关闸。
+	g.POST("/:webhook_id/test", w.requireMgmtEnabled(), w.testPush)
 }
 
 // requirePushEnabled 在总开关(system_setting incomingwebhook.enabled)关闭时让 push
@@ -299,6 +339,17 @@ func generateWebhookID() string {
 		return webhookIDPrefix + strings.ReplaceAll(util.GenerUUID(), "-", "")
 	}
 	return webhookIDPrefix + hex.EncodeToString(buf)
+}
+
+// autoWebhookName 在创建时未提供名称的情况下生成服务端默认名：
+// "Webhook-" + webhook_id 随机段前 6 位 hex。确定性、可与 webhook_id 对账，
+// 不引入第二个随机源。
+func autoWebhookName(webhookID string) string {
+	suffix := strings.TrimPrefix(webhookID, webhookIDPrefix)
+	if len(suffix) > 6 {
+		suffix = suffix[:6]
+	}
+	return "Webhook-" + suffix
 }
 
 func toResp(m *incomingWebhookModel) webhookResp {
@@ -397,21 +448,93 @@ func (w *IncomingWebhook) cachedRequireActiveGroup(groupNo string) (*group.Model
 	return g, nil
 }
 
-// requireGroupAdmin 校验登录用户是否为群主或管理员，是则返回 (loginUID, true)；
-// 否则已写入 4xx 响应。
-func (w *IncomingWebhook) requireGroupAdmin(c *wkhttp.Context, groupNo string) (string, bool) {
-	loginUID := c.MustGet("uid").(string)
-	ok, err := w.groupDB.QueryIsGroupManagerOrCreator(groupNo, loginUID)
+// cachedCreatorIsMember 带缓存判断创建者是否仍是群的内部正常成员，push 热路径专用。
+// 只缓存 true（与 groupCache 同理：负结果不粘住，退群后最多 stale 一个 TTL）。
+// 退群没有跨模块事件可订阅（group.memberremove 事件常量无发布方），所以这里是
+// 该规则的权威闸：闸不过 → push 401 + 懒级联禁用（见 handlePush）。
+func (w *IncomingWebhook) cachedCreatorIsMember(groupNo, uid string) (bool, error) {
+	key := groupNo + "|" + uid
+	if ok, hit := w.memberCache.get(key); hit {
+		return ok, nil
+	}
+	gen := w.memberCache.loadGen()
+	ok, err := w.db.isActiveInternalMember(groupNo, uid)
+	if err != nil {
+		return false, err
+	}
+	if ok {
+		w.memberCache.setIfGen(key, true, gen)
+	}
+	return ok, nil
+}
+
+// mgmtActor 是管理端点的操作者身份：用户登录态或 bot token 鉴权后的统一抽象。
+//   - isAdmin：群主或管理员（QueryIsGroupManagerOrCreator，人/bot 同一查询）——
+//     可管理群内任意 webhook、可自定义展示身份、不受 per-creator 配额限制；
+//   - 非 admin 的内部正常成员（含成员 bot）：可创建（展示身份服务端固定）、
+//     只能管理自己创建的（creator_uid == uid）。
+type mgmtActor struct {
+	uid     string
+	isAdmin bool
+}
+
+// resolveActor 解析并校验操作者：必须是群的【内部、正常状态】成员（管理员判定
+// 自带该 fail-safe 过滤）。失败时已写入 4xx/5xx 响应并返回 ok=false。
+// uid 来源于 "uid" 上下文键：用户路由由 AuthMiddleware 写入；bot 路由由 bot_api
+// 的适配中间件把 robot_id 写入同名键，两个挂载面共用本判定。
+func (w *IncomingWebhook) resolveActor(c *wkhttp.Context, groupNo string) (mgmtActor, bool) {
+	uid := c.MustGet("uid").(string)
+	isAdmin, err := w.groupDB.QueryIsGroupManagerOrCreator(groupNo, uid)
 	if err != nil {
 		w.Error("query group manager failed", zap.Error(err))
 		mgmtQueryFailed(c)
-		return "", false
+		return mgmtActor{}, false
+	}
+	if isAdmin {
+		return mgmtActor{uid: uid, isAdmin: true}, true
+	}
+	isMember, err := w.db.isActiveInternalMember(groupNo, uid)
+	if err != nil {
+		w.Error("query group member failed", zap.Error(err))
+		mgmtQueryFailed(c)
+		return mgmtActor{}, false
+	}
+	if !isMember {
+		mgmtForbidden(c)
+		return mgmtActor{}, false
+	}
+	return mgmtActor{uid: uid}, true
+}
+
+// requireOwnership 校验 actor 对 m 的管理权：管理员放行任意，普通成员/bot 仅放行
+// 自己创建的；否则写 403。返回 false 时调用方应立即返回。
+//
+// 刻意用 403 而非 404：list 对全员只读可见，webhook 的存在性在群内不是秘密，
+// "看得到但不能动"用 Forbidden 语义更诚实（跨群/不存在仍由 queryManageable 404）。
+func (w *IncomingWebhook) requireOwnership(c *wkhttp.Context, actor mgmtActor, m *incomingWebhookModel) bool {
+	if actor.isAdmin || m.CreatorUID == actor.uid {
+		return true
+	}
+	mgmtForbidden(c)
+	return false
+}
+
+// requireCreatorInGroup 校验 webhook 创建者仍是群的内部正常成员。enable /
+// regenerate / testPush 这些"让 webhook 可推送/保持可推送"的操作都必须过这一关：
+// 创建者退群后 webhook 永久失效（push 路径懒级联禁用兜底），只能删除重建。
+// 失败时已写入响应（409 或 5xx）。
+func (w *IncomingWebhook) requireCreatorInGroup(c *wkhttp.Context, m *incomingWebhookModel) bool {
+	ok, err := w.db.isActiveInternalMember(m.GroupNo, m.CreatorUID)
+	if err != nil {
+		w.Error("query creator membership failed", zap.Error(err))
+		mgmtQueryFailed(c)
+		return false
 	}
 	if !ok {
-		mgmtForbidden(c)
-		return "", false
+		mgmtCreatorLeft(c)
+		return false
 	}
-	return loginUID, true
+	return true
 }
 
 // queryManageable 查询属于 groupNo 且未被软删除的 webhook，供管理端写操作（update /
@@ -440,7 +563,7 @@ func (w *IncomingWebhook) queryManageable(c *wkhttp.Context, groupNo, webhookID 
 
 func (w *IncomingWebhook) create(c *wkhttp.Context) {
 	groupNo := c.Param("group_no")
-	loginUID, ok := w.requireGroupAdmin(c, groupNo)
+	actor, ok := w.resolveActor(c, groupNo)
 	if !ok {
 		return
 	}
@@ -451,8 +574,14 @@ func (w *IncomingWebhook) create(c *wkhttp.Context) {
 		return
 	}
 	req.Name = strings.TrimSpace(req.Name)
-	if req.Name == "" || len(req.Name) > 64 {
+	if len(req.Name) > 64 {
 		mgmtRequestInvalid(c, "name")
+		return
+	}
+	// 头像仅管理员可设置：普通成员/bot 的 webhook 走头像端点的确定性默认头像
+	// （bot 13 色 palette），不接受自定义，防止任意成员借头像伪装他人。
+	if !actor.isAdmin && req.Avatar != "" {
+		mgmtRequestInvalid(c, "avatar")
 		return
 	}
 
@@ -476,14 +605,20 @@ func (w *IncomingWebhook) create(c *wkhttp.Context) {
 		return
 	}
 
+	webhookID := generateWebhookID()
+	if req.Name == "" {
+		// 名称缺省时服务端自动命名（Webhook-xxxxxx，后缀取自 webhook_id，可追溯）。
+		req.Name = autoWebhookName(webhookID)
+	}
+
 	m := &incomingWebhookModel{
-		WebhookID:  generateWebhookID(),
+		WebhookID:  webhookID,
 		TokenHash:  hash,
 		GroupNo:    groupNo,
 		SpaceID:    g.SpaceID,
 		Name:       req.Name,
 		Avatar:     req.Avatar,
-		CreatorUID: loginUID,
+		CreatorUID: actor.uid,
 		Status:     statusEnabled,
 	}
 	// 配额校验 + 写入在事务内原子完成；FOR UPDATE 锁住 group_no 范围，防止并发越限。
@@ -493,10 +628,21 @@ func (w *IncomingWebhook) create(c *wkhttp.Context) {
 	// status=1 的行，但这**不构成安全问题**：该 webhook 永远推不出消息——push 路径的
 	// requireActiveGroup 重查才是权威闸（群非 Normal 一律 401），且 disband 级联会把
 	// status 翻 0。故此处不在事务内重读 group.status，避免给热路径加锁负担。
+	//
+	// 配额双层：群级 max_per_group 对所有人生效；per-creator 仅约束普通成员/bot
+	// （管理员能删任意 webhook，对其限个人额度无安全意义）。
 	maxWH := w.settings.IncomingWebhookMaxPerGroup()
-	if err := w.db.insertWithQuota(m, maxWH); err != nil {
+	maxPerCreator := 0
+	if !actor.isAdmin {
+		maxPerCreator = w.settings.IncomingWebhookMaxPerCreator()
+	}
+	if err := w.db.insertWithQuota(m, maxWH, maxPerCreator); err != nil {
 		if errors.Is(err, ErrQuotaExceeded) {
 			mgmtQuotaExceeded(c, maxWH)
+			return
+		}
+		if errors.Is(err, ErrCreatorQuotaExceeded) {
+			mgmtCreatorQuotaExceeded(c, maxPerCreator)
 			return
 		}
 		w.Error("insert webhook failed", zap.Error(err))
@@ -513,9 +659,11 @@ func (w *IncomingWebhook) create(c *wkhttp.Context) {
 	c.Response(resp)
 }
 
+// list 对任意（内部、正常）群成员只读开放：响应不含 token / token_hash / 推送 URL，
+// 看得到不等于推得了；成员据 creator_uid 识别哪些是自己创建的。
 func (w *IncomingWebhook) list(c *wkhttp.Context) {
 	groupNo := c.Param("group_no")
-	if _, ok := w.requireGroupAdmin(c, groupNo); !ok {
+	if _, ok := w.resolveActor(c, groupNo); !ok {
 		return
 	}
 	list, err := w.db.queryByGroupNo(groupNo)
@@ -534,12 +682,16 @@ func (w *IncomingWebhook) list(c *wkhttp.Context) {
 func (w *IncomingWebhook) update(c *wkhttp.Context) {
 	groupNo := c.Param("group_no")
 	webhookID := c.Param("webhook_id")
-	if _, ok := w.requireGroupAdmin(c, groupNo); !ok {
+	actor, ok := w.resolveActor(c, groupNo)
+	if !ok {
 		return
 	}
 
 	m, ok := w.queryManageable(c, groupNo, webhookID)
 	if !ok {
+		return
+	}
+	if !w.requireOwnership(c, actor, m) {
 		return
 	}
 
@@ -559,6 +711,12 @@ func (w *IncomingWebhook) update(c *wkhttp.Context) {
 		fields["name"] = name
 	}
 	if req.Avatar != nil {
+		// 头像仅管理员可改（与 create 一致）：成员/bot 的 webhook 固定走头像端点的
+		// 确定性默认头像。
+		if !actor.isAdmin {
+			mgmtRequestInvalid(c, "avatar")
+			return
+		}
 		fields["avatar"] = *req.Avatar
 	}
 	if req.Status != nil {
@@ -568,8 +726,9 @@ func (w *IncomingWebhook) update(c *wkhttp.Context) {
 			mgmtRequestInvalid(c, "status")
 			return
 		}
-		// 启用 webhook 前必须确认群仍处于 Normal —— 阻断 disband → re-enable 复活路径。
-		// 禁用（status=0）始终允许，便于管理员主动关停。
+		// 启用 webhook 前必须确认群仍处于 Normal —— 阻断 disband → re-enable 复活路径；
+		// 且创建者必须仍在群内 —— 阻断"创建者退群后被第三方复活"的旁路（push 的懒级联
+		// 禁用 + 此闸构成 belt & suspenders）。禁用（status=0）始终允许，便于主动关停。
 		if *req.Status == statusEnabled {
 			g, err := w.requireActiveGroup(groupNo)
 			if err != nil {
@@ -579,6 +738,9 @@ func (w *IncomingWebhook) update(c *wkhttp.Context) {
 			}
 			if g == nil {
 				mgmtGroupNotFound(c)
+				return
+			}
+			if !w.requireCreatorInGroup(c, m) {
 				return
 			}
 		}
@@ -617,10 +779,16 @@ func (w *IncomingWebhook) update(c *wkhttp.Context) {
 func (w *IncomingWebhook) delete(c *wkhttp.Context) {
 	groupNo := c.Param("group_no")
 	webhookID := c.Param("webhook_id")
-	if _, ok := w.requireGroupAdmin(c, groupNo); !ok {
+	actor, ok := w.resolveActor(c, groupNo)
+	if !ok {
 		return
 	}
-	if _, ok := w.queryManageable(c, groupNo, webhookID); !ok {
+	m, ok := w.queryManageable(c, groupNo, webhookID)
+	if !ok {
+		return
+	}
+	// 删除不挂 requireCreatorInGroup：创建者退群后管理员必须仍能清理（#member-perms）。
+	if !w.requireOwnership(c, actor, m) {
 		return
 	}
 	if err := w.db.deleteByWebhookID(webhookID); err != nil {
@@ -636,7 +804,8 @@ func (w *IncomingWebhook) delete(c *wkhttp.Context) {
 func (w *IncomingWebhook) regenerate(c *wkhttp.Context) {
 	groupNo := c.Param("group_no")
 	webhookID := c.Param("webhook_id")
-	if _, ok := w.requireGroupAdmin(c, groupNo); !ok {
+	actor, ok := w.resolveActor(c, groupNo)
+	if !ok {
 		return
 	}
 	// 与 create / update(启用) 保持一致：群非 Normal 不允许颁发新 token。
@@ -650,7 +819,16 @@ func (w *IncomingWebhook) regenerate(c *wkhttp.Context) {
 		mgmtGroupNotFound(c)
 		return
 	}
-	if _, ok := w.queryManageable(c, groupNo, webhookID); !ok {
+	m, ok := w.queryManageable(c, groupNo, webhookID)
+	if !ok {
+		return
+	}
+	if !w.requireOwnership(c, actor, m) {
+		return
+	}
+	// 创建者已退群的 webhook 不再颁发新 token（它无论如何推不出消息，新 token 只会
+	// 造成"为什么一直 401"的排障困惑）。
+	if !w.requireCreatorInGroup(c, m) {
 		return
 	}
 	token, hash, err := generateToken()
@@ -711,17 +889,23 @@ func testPushMessage(ctx context.Context) string {
 	return "✅ Incoming Webhook 测试消息：配置成功，链路已打通。"
 }
 
-// deliveries 返回某 webhook 最近的投递记录（成功+失败），供发送方排障。只读、群管理员
-// 可见；绝不返回 token。失败记录的 reason/http_status 与 push 路径返回给调用方的响应
-// 一致，便于对照定位。
+// deliveries 返回某 webhook 最近的投递记录（成功+失败），供发送方排障。只读、
+// 【创建者或群管理员】可见——投递元数据（失败原因/字节数/时间）只与排障相关，
+// 其他成员没有查看他人 webhook 投递明细的业务需要；绝不返回 token。失败记录的
+// reason/http_status 与 push 路径返回给调用方的响应一致，便于对照定位。
 func (w *IncomingWebhook) deliveries(c *wkhttp.Context) {
 	groupNo := c.Param("group_no")
 	webhookID := c.Param("webhook_id")
-	if _, ok := w.requireGroupAdmin(c, groupNo); !ok {
+	actor, ok := w.resolveActor(c, groupNo)
+	if !ok {
 		return
 	}
 	// 复用 queryManageable：webhook 必须属于该群且未软删除（跨群/不存在→404）。
-	if _, ok := w.queryManageable(c, groupNo, webhookID); !ok {
+	m, ok := w.queryManageable(c, groupNo, webhookID)
+	if !ok {
+		return
+	}
+	if !w.requireOwnership(c, actor, m) {
 		return
 	}
 	limit := defaultDeliveriesLimit
@@ -758,13 +942,15 @@ func deliveryRespFrom(a *auditModel) deliveryResp {
 	}
 }
 
-// testPush 由群管理员触发，向群里发一条固定文案的测试消息，端到端验证 webhook 配置
-// （群可达、消息能投递）。走与正式推送相同的 buildPayload(text) → SendMessage 链路，
-// 并记一条 adapter=test 的成功投递，便于在 deliveries 里与真实流量区分。
+// testPush 由创建者或群管理员触发，向群里发一条固定文案的测试消息，端到端验证
+// webhook 配置（群可达、消息能投递）。走与正式推送相同的 buildPayload(text) →
+// SendMessage 链路，并记一条 adapter=test 的成功投递，便于在 deliveries 里与真实
+// 流量区分。
 func (w *IncomingWebhook) testPush(c *wkhttp.Context) {
 	groupNo := c.Param("group_no")
 	webhookID := c.Param("webhook_id")
-	if _, ok := w.requireGroupAdmin(c, groupNo); !ok {
+	actor, ok := w.resolveActor(c, groupNo)
+	if !ok {
 		return
 	}
 	// 群必须仍为 Normal —— 不向已解散/禁用群发测试消息（与 create/enable 一致）。
@@ -780,6 +966,13 @@ func (w *IncomingWebhook) testPush(c *wkhttp.Context) {
 	}
 	m, ok := w.queryManageable(c, groupNo, webhookID)
 	if !ok {
+		return
+	}
+	if !w.requireOwnership(c, actor, m) {
+		return
+	}
+	// 与 push 路径的创建者在群闸同口径：创建者已退群的 webhook 连测试消息也不发。
+	if !w.requireCreatorInGroup(c, m) {
 		return
 	}
 
@@ -896,6 +1089,30 @@ func (w *IncomingWebhook) handlePush(c *wkhttp.Context, ad pushAdapter) {
 		return
 	}
 	if g == nil {
+		pushUnauthorized(c)
+		return
+	}
+
+	// 2.6) 创建者必须仍是群的内部正常成员（#member-perms）：成员/bot 可自助创建
+	// webhook 后，"退群即失效"是该权限模型的安全底线（离开的人不能继续向群里发声）。
+	// 退群没有可订阅的跨模块事件，这里即权威闸；闸不过时【懒级联禁用】该 webhook
+	// （status→disabled，幂等、不触碰软删除行），让管理列表如实反映失效状态，后续
+	// push 在 status 闸即被拒。响应仍是统一 401（持有效 token 的调用方，与群闸同
+	// 口径，不计 IP 失败预算、不入审计）。
+	ok, err := w.cachedCreatorIsMember(m.GroupNo, m.CreatorUID)
+	if err != nil {
+		// 服务端故障：拒绝但不禁用（fail closed on push, no destructive write）。
+		w.Error("query creator membership on push failed",
+			zap.String("webhook_id", m.WebhookID), zap.Error(err))
+		pushUnauthorized(c)
+		return
+	}
+	if !ok {
+		if dErr := w.db.disableEnabledByWebhookID(m.WebhookID); dErr != nil {
+			w.Warn("lazy-disable webhook on creator-left failed",
+				zap.String("webhook_id", m.WebhookID), zap.Error(dErr))
+		}
+		w.webhookCache.invalidate(m.WebhookID)
 		pushUnauthorized(c)
 		return
 	}

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -96,9 +96,10 @@ type IncomingWebhook struct {
 	webhookCache *ttlCache[*incomingWebhookModel]
 	groupCache   *ttlCache[*group.Model]
 	// memberCache 缓存「创建者仍是群内（内部、正常）成员」的正向结果，key 为
-	// groupNo+"|"+uid。push 路径的创建者在群闸（cachedCreatorIsMember）用它把
-	// 每次推送的 group_member 点读压到 0；只缓存 true（退群后最多 stale 一个 TTL，
-	// 之后懒级联禁用把 webhook 翻为 disabled，彻底关闸）。
+	// groupNo+"|"+uid，条目值为「创建者当前是否群管理员」（供 push 覆盖判权）。
+	// push 路径的创建者在群闸（cachedCreatorMembership）用它把每次推送的
+	// group_member 点读压到 0；【负结果绝不缓存】（安全不变量，退群后最多 stale
+	// 一个 TTL，之后懒级联禁用把 webhook 翻为 disabled，彻底关闸）。
 	memberCache *ttlCache[bool]
 }
 
@@ -154,11 +155,12 @@ func New(ctx *config.Context) *IncomingWebhook {
 // 实例：与 New 同构（同一套 handler / DB / 审计池），但不注册事件监听（disband
 // 级联由模块主实例负责），也不会被挂 push 路由。
 //
-// ⚠️ 缓存一致性契约：facade 与模块主实例【各持一份】push 热路径缓存。bot 面的管理
-// 写操作（update/delete/regenerate）即时失效的是 facade 自己的缓存，主实例的 push
-// 缓存最多 stale 一个 TTL（默认 3s）——与既有「跨实例无主动失效、TTL 兜底」的
-// staleness 契约（cache.go）同级，等同把 bot 面视作一个对等实例；需要更快收敛就
-// 调小 DM_INCOMINGWEBHOOK_CACHE_TTL_MS。
+// ⚠️ 缓存一致性契约：facade 不挂 push 路由，它持有的几份热路径缓存实际从不被读取
+// （仅因复用同一构造器而存在，开销可忽略）。要点只有一个：bot 面的管理写操作
+// （update/delete/regenerate）无法失效【主实例】的 push 缓存，主实例最多 stale 一个
+// TTL（默认 3s）——与既有「跨实例无主动失效、TTL 兜底」的 staleness 契约（cache.go）
+// 同级，等同把 bot 面视作一个对等实例；需要更快收敛就调小
+// DM_INCOMINGWEBHOOK_CACHE_TTL_MS。
 //
 // 刻意【不】按 ctx 记忆化共享单实例：octo-lib 的模块注册器以首个 ctx 调用各模块的
 // 创建闭包，按-ctx 记忆化会把测试进程里的多个 test server 折叠成单实例，串掉
@@ -463,24 +465,31 @@ func (w *IncomingWebhook) cachedRequireActiveGroup(groupNo string) (*group.Model
 	return g, nil
 }
 
-// cachedCreatorIsMember 带缓存判断创建者是否仍是群的内部正常成员，push 热路径专用。
-// 只缓存 true（与 groupCache 同理：负结果不粘住，退群后最多 stale 一个 TTL）。
+// cachedCreatorMembership 带缓存判断创建者是否仍是群的内部正常成员、以及当前是否
+// 群管理员，push 热路径专用。缓存【只存在于 member=true 时】（条目命中即 member=true，
+// 条目值为 isAdmin）——负结果绝不缓存（false-never-cached 是创建者退群闸的安全不变量，
+// 由 TestCreatorMembershipCache_NeverCachesNegative 钉住），退群后最多 stale 一个 TTL。
 // 退群没有跨模块事件可订阅（group.memberremove 事件常量无发布方），所以这里是
 // 该规则的权威闸：闸不过 → push 401 + 懒级联禁用（见 handlePush）。
-func (w *IncomingWebhook) cachedCreatorIsMember(groupNo, uid string) (bool, error) {
+//
+// isAdmin 供 push 的展示身份覆盖判权（resolveFromIdentity）：创建者【当前】是管理员
+// 才允许 username/avatar_url 覆盖。采用"当前角色"而非创建时快照——免迁移列，且管理员
+// 被降级后其 webhook 的覆盖能力随之收回（权限跟随现任角色，语义更严）；角色变更的
+// 生效延迟同样 ≤ 一个 TTL。
+func (w *IncomingWebhook) cachedCreatorMembership(groupNo, uid string) (member, admin bool, err error) {
 	key := groupNo + "|" + uid
-	if ok, hit := w.memberCache.get(key); hit {
-		return ok, nil
+	if isAdmin, hit := w.memberCache.get(key); hit {
+		return true, isAdmin, nil
 	}
 	gen := w.memberCache.loadGen()
-	ok, err := w.db.isActiveInternalMember(groupNo, uid)
+	member, admin, err = w.db.queryMemberRole(groupNo, uid)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
-	if ok {
-		w.memberCache.setIfGen(key, true, gen)
+	if member {
+		w.memberCache.setIfGen(key, admin, gen)
 	}
-	return ok, nil
+	return member, admin, nil
 }
 
 // mgmtActor 是管理端点的操作者身份：用户登录态或 bot token 鉴权后的统一抽象。
@@ -499,16 +508,10 @@ type mgmtActor struct {
 // 的适配中间件把 robot_id 写入同名键，两个挂载面共用本判定。
 func (w *IncomingWebhook) resolveActor(c *wkhttp.Context, groupNo string) (mgmtActor, bool) {
 	uid := c.MustGet("uid").(string)
-	isAdmin, err := w.groupDB.QueryIsGroupManagerOrCreator(groupNo, uid)
-	if err != nil {
-		w.Error("query group manager failed", zap.Error(err))
-		mgmtQueryFailed(c)
-		return mgmtActor{}, false
-	}
-	if isAdmin {
-		return mgmtActor{uid: uid, isAdmin: true}, true
-	}
-	isMember, err := w.db.isActiveInternalMember(groupNo, uid)
+	// 单查询同时拿成员资格 + 管理员身份（queryMemberRole 与
+	// group.QueryIsGroupManagerOrCreator 同一组 fail-safe 过滤），省掉非管理员
+	// 路径的二连击（PR #340 review，Octo-Q F1）。
+	isMember, isAdmin, err := w.db.queryMemberRole(groupNo, uid)
 	if err != nil {
 		w.Error("query group member failed", zap.Error(err))
 		mgmtQueryFailed(c)
@@ -518,7 +521,7 @@ func (w *IncomingWebhook) resolveActor(c *wkhttp.Context, groupNo string) (mgmtA
 		mgmtForbidden(c)
 		return mgmtActor{}, false
 	}
-	return mgmtActor{uid: uid}, true
+	return mgmtActor{uid: uid, isAdmin: isAdmin}, true
 }
 
 // requireOwnership 校验 actor 对 m 的管理权：管理员放行任意，普通成员/bot 仅放行
@@ -539,7 +542,7 @@ func (w *IncomingWebhook) requireOwnership(c *wkhttp.Context, actor mgmtActor, m
 // 创建者退群后 webhook 永久失效（push 路径懒级联禁用兜底），只能删除重建。
 // 失败时已写入响应（409 或 5xx）。
 func (w *IncomingWebhook) requireCreatorInGroup(c *wkhttp.Context, m *incomingWebhookModel) bool {
-	ok, err := w.db.isActiveInternalMember(m.GroupNo, m.CreatorUID)
+	ok, _, err := w.db.queryMemberRole(m.GroupNo, m.CreatorUID)
 	if err != nil {
 		w.Error("query creator membership failed", zap.Error(err))
 		mgmtQueryFailed(c)
@@ -590,9 +593,13 @@ func (w *IncomingWebhook) create(c *wkhttp.Context) {
 	}
 	req.Name = strings.TrimSpace(req.Name)
 	// 成员/bot 自定义名称强制带 "Webhook-" 前缀（先补前缀再做长度校验，上限对
-	// 最终落库值生效）；管理员命名不受限。
+	// 最终落库值生效）；管理员命名不受限。恰好等于裸前缀（无有效内容）视同未填，
+	// 走下方的自动命名（PR #340 review，yujiawei P2#9）。
 	if !actor.isAdmin && req.Name != "" {
 		req.Name = prefixedWebhookName(req.Name)
+		if req.Name == memberWebhookNamePrefix {
+			req.Name = ""
+		}
 	}
 	if len(req.Name) > 64 {
 		mgmtRequestInvalid(c, "name")
@@ -728,9 +735,15 @@ func (w *IncomingWebhook) update(c *wkhttp.Context) {
 			mgmtRequestInvalid(c, "name")
 			return
 		}
-		// 与 create 同口径：成员/bot 改名强制带前缀（幂等），长度校验对最终值生效。
+		// 与 create 同口径：成员/bot 改名强制带前缀（幂等），长度校验对最终值生效；
+		// 裸前缀（无有效内容）按空名拒绝——update 没有自动命名回退（既有名字是已
+		// 确立的身份，静默换成自动名会让调用方意外）。
 		if !actor.isAdmin {
 			name = prefixedWebhookName(name)
+			if name == memberWebhookNamePrefix {
+				mgmtRequestInvalid(c, "name")
+				return
+			}
 		}
 		if len(name) > 64 {
 			mgmtRequestInvalid(c, "name")
@@ -1006,7 +1019,8 @@ func (w *IncomingWebhook) testPush(c *wkhttp.Context) {
 
 	msg := testPushMessage(c.Request.Context())
 	req := &pushPayloadReq{Content: msg}
-	payload := buildPayload(m, req)
+	// 测试推送的请求体不含覆盖字段，覆盖判权传 false 即可（展示固定为 webhook 配置）。
+	payload := buildPayload(m, req, false)
 	ip := clientIP(c.Request)
 	resp, err := w.ctx.SendMessageWithResult(&config.MsgSendReq{
 		Header:      config.MsgHeader{RedDot: 1},
@@ -1121,30 +1135,6 @@ func (w *IncomingWebhook) handlePush(c *wkhttp.Context, ad pushAdapter) {
 		return
 	}
 
-	// 2.6) 创建者必须仍是群的内部正常成员（#member-perms）：成员/bot 可自助创建
-	// webhook 后，"退群即失效"是该权限模型的安全底线（离开的人不能继续向群里发声）。
-	// 退群没有可订阅的跨模块事件，这里即权威闸；闸不过时【懒级联禁用】该 webhook
-	// （status→disabled，幂等、不触碰软删除行），让管理列表如实反映失效状态，后续
-	// push 在 status 闸即被拒。响应仍是统一 401（持有效 token 的调用方，与群闸同
-	// 口径，不计 IP 失败预算、不入审计）。
-	ok, err := w.cachedCreatorIsMember(m.GroupNo, m.CreatorUID)
-	if err != nil {
-		// 服务端故障：拒绝但不禁用（fail closed on push, no destructive write）。
-		w.Error("query creator membership on push failed",
-			zap.String("webhook_id", m.WebhookID), zap.Error(err))
-		pushUnauthorized(c)
-		return
-	}
-	if !ok {
-		if dErr := w.db.disableEnabledByWebhookID(m.WebhookID); dErr != nil {
-			w.Warn("lazy-disable webhook on creator-left failed",
-				zap.String("webhook_id", m.WebhookID), zap.Error(dErr))
-		}
-		w.webhookCache.invalidate(m.WebhookID)
-		pushUnauthorized(c)
-		return
-	}
-
 	// 3) per-webhook 限流；Redis 故障时显式 fail-open，避免 Redis 抖动导致全量推送被拒。
 	allowed, err := w.allowPerWebhook(c.Request.Context(), webhookID)
 	if err != nil {
@@ -1158,6 +1148,39 @@ func (w *IncomingWebhook) handlePush(c *wkhttp.Context, ad pushAdapter) {
 		// 的 Warn 日志，反噬限流「廉价丢弃」的本意。管理员可从 deliveries 里成功记录的稀疏/
 		// 中断间接看出节流（review 跟进）。
 		pushRateLimited(c)
+		return
+	}
+
+	// 3.5) 创建者必须仍是群的内部正常成员（#member-perms）：成员/bot 可自助创建
+	// webhook 后，"退群即失效"是该权限模型的安全底线（离开的人不能继续向群里发声）。
+	// 退群没有可订阅的跨模块事件，这里即权威闸；闸不过时【懒级联禁用】该 webhook
+	// （status→disabled，幂等、不触碰软删除行），让管理列表如实反映失效状态，后续
+	// push 在 status 闸即被拒。响应仍是统一 401（持有效 token 的调用方，与群闸同
+	// 口径，不计 IP 失败预算、不入审计）。
+	//
+	// 刻意放在 per-webhook 限流【之后】：缓存只存正向结果，创建者已退群的 webhook 每次
+	// push 都会回源 group_member 点读 + 对等实例上重复幂等 disable 写，挂在 5rps 限流闸
+	// 之后让这部分 DB 负载继承限流上限（PR #340 review，yujiawei P2#2；闸在 token 鉴权
+	// 之后，语义安全）。
+	//
+	// creatorIsAdmin 顺带取自同一查询：决定 push 请求的 username/avatar_url 展示覆盖
+	// 是否生效（见 resolveFromIdentity——创建者当前是管理员才允许覆盖，堵住成员经
+	// push 路径绕过管理面前缀/头像限制的冒充旁路，PR #340 review，yujiawei P1）。
+	creatorIsMember, creatorIsAdmin, err := w.cachedCreatorMembership(m.GroupNo, m.CreatorUID)
+	if err != nil {
+		// 服务端故障：拒绝但不禁用（fail closed on push, no destructive write）。
+		w.Error("query creator membership on push failed",
+			zap.String("webhook_id", m.WebhookID), zap.Error(err))
+		pushUnauthorized(c)
+		return
+	}
+	if !creatorIsMember {
+		if dErr := w.db.disableEnabledByWebhookID(m.WebhookID); dErr != nil {
+			w.Warn("lazy-disable webhook on creator-left failed",
+				zap.String("webhook_id", m.WebhookID), zap.Error(dErr))
+		}
+		w.webhookCache.invalidate(m.WebhookID)
+		pushUnauthorized(c)
 		return
 	}
 
@@ -1216,12 +1239,12 @@ func (w *IncomingWebhook) handlePush(c *wkhttp.Context, ad pushAdapter) {
 			pushPayloadTooLarge(c)
 			return
 		}
-		payload = buildPayload(m, req)
+		payload = buildPayload(m, req, creatorIsAdmin)
 	case msgTypeRichText:
 		// 注意：richtext 路径【不】套用纯文本的 maxContentRunes(4000) 语义上限——富文本
 		// 由块结构 + 1MB 序列化上限约束，默认 8KB body cap 下不可能逾越。这是与文本路径的
 		// 有意不对称（若运维上调 body cap，富文本仍受 1MB 兜底，不会无界）。
-		p, err := buildRichTextPayload(m, req)
+		p, err := buildRichTextPayload(m, req, creatorIsAdmin)
 		if err != nil {
 			// 仅 >1MB 映射 413（与 body/content 超限同语义）；其余结构性非法（空 content /
 			// 空 text 块 / 非 http(s) 图片 url / 缺图片宽高 / 未知块类型 / 超块数上限）
@@ -1306,8 +1329,8 @@ func truncateUTF8(s string, max int) string {
 //     显式列入允许字段（且明确该字段无访问控制语义），不要再走透传。
 //   - req.Username / req.AvatarURL 服务端裁剪到 create 侧同样的字节上限。push 路径
 //     原本只受 8KB body cap 约束，调用方可塞 KB 级字符串污染所有客户端 from.* 渲染。
-func buildPayload(m *incomingWebhookModel, req *pushPayloadReq) map[string]interface{} {
-	name, avatar := resolveFromIdentity(m, req)
+func buildPayload(m *incomingWebhookModel, req *pushPayloadReq, allowOverride bool) map[string]interface{} {
+	name, avatar := resolveFromIdentity(m, req, allowOverride)
 	return map[string]interface{}{
 		"type":    int(common.Text),
 		"content": req.Content,
@@ -1323,16 +1346,28 @@ func buildPayload(m *incomingWebhookModel, req *pushPayloadReq) map[string]inter
 	}
 }
 
-// resolveFromIdentity 解析 webhook 消息的展示发送者名/头像：调用方在 push 请求里
-// 覆盖（Username/AvatarURL）优先，否则回落到 webhook 自身配置；两者都裁剪到与
-// create 侧一致的字节上限，防止 push 路径成为绕过列长度约束的旁路。文本与富文本
-// 两条路径共用此函数，保证 from.* 渲染口径一致。
-func resolveFromIdentity(m *incomingWebhookModel, req *pushPayloadReq) (name, avatar string) {
-	name = req.Username
+// resolveFromIdentity 解析 webhook 消息的展示发送者名/头像。
+//
+// allowOverride 是 push 请求 Username/AvatarURL 覆盖的判权结果（创建者【当前】是
+// 群管理员，取自 cachedCreatorMembership）：
+//   - true（管理员创建/持有）：覆盖优先，否则回落到 webhook 自身配置——历史的
+//     Slack/GitHub 兼容行为，管理员可信；
+//   - false（成员/bot 的 webhook）：覆盖一律【忽略】，固定用存量 Name/Avatar。
+//     没有这道闸，管理面的 Webhook- 前缀与头像锁就会被 push 路径整体绕过——成员拿着
+//     自己 webhook 的 token 即可以"HR 公告"+任意头像发声（PR #340 review，yujiawei
+//     P1：don't ship a half-control）。存量 Name 必然已带前缀（create/update 强制），
+//     无需在此重复加工。
+//
+// 两者都裁剪到与 create 侧一致的字节上限，防止 push 路径成为绕过列长度约束的旁路。
+// 文本与富文本两条路径共用此函数，保证 from.* 渲染口径一致。
+func resolveFromIdentity(m *incomingWebhookModel, req *pushPayloadReq, allowOverride bool) (name, avatar string) {
+	if allowOverride {
+		name = req.Username
+		avatar = req.AvatarURL
+	}
 	if name == "" {
 		name = m.Name
 	}
-	avatar = req.AvatarURL
 	if avatar == "" {
 		avatar = m.Avatar
 	}

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -341,15 +341,30 @@ func generateWebhookID() string {
 	return webhookIDPrefix + hex.EncodeToString(buf)
 }
 
+// memberWebhookNamePrefix 是非管理员（成员/bot）所设 webhook 展示名的强制前缀：
+// 成员可以自定义名称，但名称必须以 "Webhook-" 开头（缺省自动命名本就是该形态），
+// 防止成员把 webhook 命名成"HR 公告"或他人姓名冒充真实发送者（PR #340 review，
+// yujiawei P2）。管理员命名不受限（历史行为，管理员本就可信）。
+const memberWebhookNamePrefix = "Webhook-"
+
+// prefixedWebhookName 给非管理员提交的名称补强制前缀；已带前缀则原样返回（幂等，
+// 避免成员保存自己 webhook 时被二次加前缀）。
+func prefixedWebhookName(name string) string {
+	if strings.HasPrefix(name, memberWebhookNamePrefix) {
+		return name
+	}
+	return memberWebhookNamePrefix + name
+}
+
 // autoWebhookName 在创建时未提供名称的情况下生成服务端默认名：
-// "Webhook-" + webhook_id 随机段前 6 位 hex。确定性、可与 webhook_id 对账，
+// 前缀 + webhook_id 随机段前 6 位 hex。确定性、可与 webhook_id 对账，
 // 不引入第二个随机源。
 func autoWebhookName(webhookID string) string {
 	suffix := strings.TrimPrefix(webhookID, webhookIDPrefix)
 	if len(suffix) > 6 {
 		suffix = suffix[:6]
 	}
-	return "Webhook-" + suffix
+	return memberWebhookNamePrefix + suffix
 }
 
 func toResp(m *incomingWebhookModel) webhookResp {
@@ -574,6 +589,11 @@ func (w *IncomingWebhook) create(c *wkhttp.Context) {
 		return
 	}
 	req.Name = strings.TrimSpace(req.Name)
+	// 成员/bot 自定义名称强制带 "Webhook-" 前缀（先补前缀再做长度校验，上限对
+	// 最终落库值生效）；管理员命名不受限。
+	if !actor.isAdmin && req.Name != "" {
+		req.Name = prefixedWebhookName(req.Name)
+	}
 	if len(req.Name) > 64 {
 		mgmtRequestInvalid(c, "name")
 		return
@@ -704,7 +724,15 @@ func (w *IncomingWebhook) update(c *wkhttp.Context) {
 	fields := map[string]interface{}{}
 	if req.Name != nil {
 		name := strings.TrimSpace(*req.Name)
-		if name == "" || len(name) > 64 {
+		if name == "" {
+			mgmtRequestInvalid(c, "name")
+			return
+		}
+		// 与 create 同口径：成员/bot 改名强制带前缀（幂等），长度校验对最终值生效。
+		if !actor.isAdmin {
+			name = prefixedWebhookName(name)
+		}
+		if len(name) > 64 {
 			mgmtRequestInvalid(c, "name")
 			return
 		}

--- a/modules/incomingwebhook/api_i18n.go
+++ b/modules/incomingwebhook/api_i18n.go
@@ -119,6 +119,18 @@ func mgmtQuotaExceeded(c *wkhttp.Context, max int) {
 	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookQuotaExceeded, i18n.Params{"max": max}, nil)
 }
 
+// mgmtCreatorQuotaExceeded returns 409 — the calling member/bot reached its
+// per-creator cap (admins are exempt); max carries the configured limit.
+func mgmtCreatorQuotaExceeded(c *wkhttp.Context, max int) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookCreatorQuotaExceeded, i18n.Params{"max": max}, nil)
+}
+
+// mgmtCreatorLeft returns 409 — the webhook's creator is no longer in the
+// group; enable / regenerate / test push are refused (delete stays available).
+func mgmtCreatorLeft(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookCreatorLeft, nil, nil)
+}
+
 // mgmtQueryFailed returns 500 (Internal) — a read failed; real error logged.
 func mgmtQueryFailed(c *wkhttp.Context) {
 	httperr.ResponseErrorLWithStatus(c, errcode.ErrIncomingWebhookQueryFailed, nil, nil)

--- a/modules/incomingwebhook/api_member_test.go
+++ b/modules/incomingwebhook/api_member_test.go
@@ -108,6 +108,27 @@ func TestMemberCreate_AutoNameWhenOmitted(t *testing.T) {
 		map[string]interface{}{"name": "Webhook-already"}, memberAToken))
 	require.Equalf(t, http.StatusOK, w.Code, "prefixed create body: %s", w.Body.String())
 	assert.Equal(t, "Webhook-already", parseJSON(t, w)["name"])
+
+	// 恰好等于裸前缀（无有效内容）视同未填 → 自动命名。
+	w = do(handler, userReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo),
+		map[string]interface{}{"name": "Webhook-"}, memberAToken))
+	require.Equalf(t, http.StatusOK, w.Code, "bare-prefix create body: %s", w.Body.String())
+	assert.Regexp(t, autoNameRe, parseJSON(t, w)["name"])
+}
+
+// 成员的 webhook push 时 username/avatar_url 覆盖被忽略（创建者非管理员 →
+// resolveFromIdentity 判权关闭），推送本身仍成功——管理面的前缀/头像限制不可被
+// push 路径绕过（PR #340 review，yujiawei P1）。展示字段的口径由 in-package 的
+// TestResolveFromIdentity 钉住，这里钉 E2E 不拒绝（覆盖被静默忽略而非 4xx）。
+func TestPush_MemberWebhookOverrideSilentlyIgnored(t *testing.T) {
+	handler, _, groupNo := setupMemberEnv(t)
+	created := memberCreate(t, handler, groupNo)
+	pushURL := fmt.Sprintf("/v1/incoming-webhooks/%s/%s", created["webhook_id"], created["token"])
+
+	pw := do(handler, anonReq("POST", pushURL,
+		[]byte(`{"content":"hi","username":"HR 公告","avatar_url":"https://evil.example.com/ceo.png"}`)))
+	assert.NotEqualf(t, http.StatusUnauthorized, pw.Code, "push body: %s", pw.Body.String())
+	assert.NotEqualf(t, http.StatusBadRequest, pw.Code, "push body: %s", pw.Body.String())
 }
 
 // 普通成员自定义头像 → 400（头像仅管理员可设置）。

--- a/modules/incomingwebhook/api_member_test.go
+++ b/modules/incomingwebhook/api_member_test.go
@@ -97,11 +97,17 @@ func TestMemberCreate_AutoNameWhenOmitted(t *testing.T) {
 	whID, _ := created["webhook_id"].(string)
 	assert.Contains(t, whID, name[len("Webhook-"):])
 
-	// 自定义名称 → 200 且名称生效。
+	// 自定义名称 → 200，落库时强制带 "Webhook-" 前缀（防冒充真实成员/部门）。
 	w := do(handler, userReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo),
 		map[string]interface{}{"name": "my ci bot"}, memberAToken))
 	require.Equalf(t, http.StatusOK, w.Code, "named create body: %s", w.Body.String())
-	assert.Equal(t, "my ci bot", parseJSON(t, w)["name"])
+	assert.Equal(t, "Webhook-my ci bot", parseJSON(t, w)["name"])
+
+	// 已带前缀的名称不被二次加前缀（幂等）。
+	w = do(handler, userReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo),
+		map[string]interface{}{"name": "Webhook-already"}, memberAToken))
+	require.Equalf(t, http.StatusOK, w.Code, "prefixed create body: %s", w.Body.String())
+	assert.Equal(t, "Webhook-already", parseJSON(t, w)["name"])
 }
 
 // 普通成员自定义头像 → 400（头像仅管理员可设置）。
@@ -209,7 +215,7 @@ func TestMemberUpdate_NameAllowedAvatarRejected(t *testing.T) {
 
 	w := do(handler, userReq("PUT", base, map[string]interface{}{"name": "deploy-bot"}, memberAToken))
 	require.Equalf(t, http.StatusOK, w.Code, "rename body: %s", w.Body.String())
-	assert.Equal(t, "deploy-bot", parseJSON(t, w)["name"])
+	assert.Equal(t, "Webhook-deploy-bot", parseJSON(t, w)["name"])
 
 	w = do(handler, userReq("PUT", base, map[string]interface{}{"avatar": "https://x/y.png"}, memberAToken))
 	assert.Equalf(t, http.StatusBadRequest, w.Code, "avatar body: %s", w.Body.String())

--- a/modules/incomingwebhook/api_member_test.go
+++ b/modules/incomingwebhook/api_member_test.go
@@ -1,0 +1,294 @@
+package incomingwebhook_test
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 成员权限模型测试（#member-perms）：
+//   - 任意（内部、正常状态）群成员可创建 webhook：名称可自定义（缺省自动命名
+//     Webhook-xxxxxx），头像仅管理员可设置/修改；
+//   - update/delete/regenerate/deliveries/test：创建者或群管理员；其他成员 403；
+//   - list：任意成员只读可见（token 永不回显）；
+//   - 普通成员受 per-creator 配额约束（管理员豁免，仅受群级配额）；
+//   - 创建者退群：webhook 不可被启用/换 token/测试推送（409），push 懒级联禁用。
+
+const (
+	memberAUID   = "iwh_member_a"
+	memberAToken = "iwh_member_a_token"
+	memberBUID   = "iwh_member_b"
+	memberBToken = "iwh_member_b_token"
+)
+
+var autoNameRe = regexp.MustCompile(`^Webhook-[0-9a-f]{6}$`)
+
+// seedLoginUser 给指定 uid 造一个可过 AuthMiddleware 的登录 token（与
+// testutil.NewTestServer 给 testutil.UID 灌 token 的方式一致）。
+func seedLoginUser(t *testing.T, ctx *config.Context, uid, token string) {
+	t.Helper()
+	err := ctx.Cache().Set(ctx.GetConfig().Cache.TokenCachePrefix+token, uid+"@test")
+	require.NoError(t, err)
+}
+
+// seedGroupMember 把 uid 以指定角色插入群成员表（内部成员、正常状态）。
+func seedGroupMember(t *testing.T, ctx *config.Context, groupNo, uid string, role int) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO group_member(group_no, uid, role, status, is_deleted, version) VALUES(?, ?, ?, 1, 0, 1)",
+		groupNo, uid, role).Exec()
+	require.NoError(t, err)
+}
+
+// removeGroupMember 软删群成员（退群/被移出的 DB 形态）。
+func removeGroupMember(t *testing.T, ctx *config.Context, groupNo, uid string) {
+	t.Helper()
+	_, err := ctx.DB().UpdateBySql(
+		"UPDATE group_member SET is_deleted=1 WHERE group_no=? AND uid=?", groupNo, uid).Exec()
+	require.NoError(t, err)
+}
+
+// userReq 与 authReq 相同，但允许指定登录 token（第二/第三用户）。
+func userReq(method, path string, body interface{}, token string) *http.Request {
+	req := authReq(method, path, body)
+	req.Header.Set("token", token)
+	return req
+}
+
+// setupMemberEnv 在 setupTestEnv 基础上再造两个普通成员 A/B（各自带登录态）。
+func setupMemberEnv(t *testing.T) (http.Handler, *config.Context, string) {
+	handler, ctx, groupNo := setupTestEnv(t)
+	seedLoginUser(t, ctx, memberAUID, memberAToken)
+	seedLoginUser(t, ctx, memberBUID, memberBToken)
+	seedGroupMember(t, ctx, groupNo, memberAUID, 0)
+	seedGroupMember(t, ctx, groupNo, memberBUID, 0)
+	return handler, ctx, groupNo
+}
+
+// memberCreate 以成员 A 创建一个 webhook，返回解析后的响应体。
+func memberCreate(t *testing.T, handler http.Handler, groupNo string) map[string]interface{} {
+	t.Helper()
+	w := do(handler, userReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo),
+		map[string]interface{}{}, memberAToken))
+	require.Equalf(t, http.StatusOK, w.Code, "member create body: %s", w.Body.String())
+	return parseJSON(t, w)
+}
+
+// ============================================================
+// 创建
+// ============================================================
+
+// 普通成员可创建：名称缺省时自动命名 Webhook-xxxxxx、creator 记为本人；
+// 自定义名称同样允许。
+func TestMemberCreate_AutoNameWhenOmitted(t *testing.T) {
+	handler, _, groupNo := setupMemberEnv(t)
+	created := memberCreate(t, handler, groupNo)
+
+	name, _ := created["name"].(string)
+	assert.Regexp(t, autoNameRe, name)
+	assert.Equal(t, memberAUID, created["creator_uid"])
+	assert.NotEmpty(t, created["token"])
+	// 自动名的后缀必须来自 webhook_id（可追溯、确定性）。
+	whID, _ := created["webhook_id"].(string)
+	assert.Contains(t, whID, name[len("Webhook-"):])
+
+	// 自定义名称 → 200 且名称生效。
+	w := do(handler, userReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo),
+		map[string]interface{}{"name": "my ci bot"}, memberAToken))
+	require.Equalf(t, http.StatusOK, w.Code, "named create body: %s", w.Body.String())
+	assert.Equal(t, "my ci bot", parseJSON(t, w)["name"])
+}
+
+// 普通成员自定义头像 → 400（头像仅管理员可设置）。
+func TestMemberCreate_RejectsCustomAvatar(t *testing.T) {
+	handler, _, groupNo := setupMemberEnv(t)
+	w := do(handler, userReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo),
+		map[string]interface{}{"avatar": "https://example.com/x.png"}, memberAToken))
+	assert.Equalf(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+}
+
+// 非群成员 → 403。
+func TestMemberCreate_NonMemberForbidden(t *testing.T) {
+	handler, ctx, groupNo := setupMemberEnv(t)
+	removeGroupMember(t, ctx, groupNo, memberAUID)
+	w := do(handler, userReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo),
+		map[string]interface{}{}, memberAToken))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// 外部成员（is_external=1）→ 403（与管理员判定的 fail-safe 口径一致）。
+func TestMemberCreate_ExternalMemberForbidden(t *testing.T) {
+	handler, ctx, groupNo := setupMemberEnv(t)
+	_, err := ctx.DB().UpdateBySql(
+		"UPDATE group_member SET is_external=1 WHERE group_no=? AND uid=?", groupNo, memberAUID).Exec()
+	require.NoError(t, err)
+	w := do(handler, userReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo),
+		map[string]interface{}{}, memberAToken))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// 普通成员 per-creator 配额：达到上限 → 409；管理员不受 per-creator 配额限制。
+func TestMemberCreate_PerCreatorQuota(t *testing.T) {
+	t.Setenv("DM_INCOMINGWEBHOOK_MAX_PER_CREATOR", "2")
+	handler, _, groupNo := setupMemberEnv(t)
+
+	for i := 0; i < 2; i++ {
+		memberCreate(t, handler, groupNo)
+	}
+	w := do(handler, userReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo),
+		map[string]interface{}{}, memberAToken))
+	assert.Equalf(t, http.StatusConflict, w.Code, "3rd member create body: %s", w.Body.String())
+
+	// 另一个成员 B 配额独立。
+	w = do(handler, userReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo),
+		map[string]interface{}{}, memberBToken))
+	assert.Equalf(t, http.StatusOK, w.Code, "member B create body: %s", w.Body.String())
+
+	// 管理员（testutil.UID 是群主）超过 per-creator 上限仍可建（只受群级配额）。
+	for i := 0; i < 3; i++ {
+		w = do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo),
+			map[string]interface{}{"name": fmt.Sprintf("admin-wh-%d", i)}))
+		assert.Equalf(t, http.StatusOK, w.Code, "admin create #%d body: %s", i, w.Body.String())
+	}
+}
+
+// ============================================================
+// 管理（所有权）
+// ============================================================
+
+// 成员只能动自己创建的：B 对 A 的 webhook update/delete/regenerate/deliveries/test
+// 一律 403；list 对 B 仍可见（只读、不回显 token）。
+func TestMemberManage_OwnOnly(t *testing.T) {
+	handler, _, groupNo := setupMemberEnv(t)
+	created := memberCreate(t, handler, groupNo)
+	whID := created["webhook_id"].(string)
+	base := fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID)
+
+	cases := []struct {
+		method, path string
+		body         interface{}
+	}{
+		{"PUT", base, map[string]interface{}{"status": 0}},
+		{"DELETE", base, nil},
+		{"POST", base + "/regenerate", nil},
+		{"GET", base + "/deliveries", nil},
+		{"POST", base + "/test", nil},
+	}
+	for _, tc := range cases {
+		w := do(handler, userReq(tc.method, tc.path, tc.body, memberBToken))
+		assert.Equalf(t, http.StatusForbidden, w.Code, "%s %s body: %s", tc.method, tc.path, w.Body.String())
+	}
+
+	// B list 可见 A 的 webhook，且响应不含 token。
+	lw := do(handler, userReq("GET", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), nil, memberBToken))
+	require.Equalf(t, http.StatusOK, lw.Code, "list body: %s", lw.Body.String())
+	assert.Contains(t, lw.Body.String(), whID)
+	assert.NotContains(t, lw.Body.String(), created["token"].(string))
+
+	// A 自己可以禁用/启用、换 token、看 deliveries。
+	w := do(handler, userReq("PUT", base, map[string]interface{}{"status": 0}, memberAToken))
+	assert.Equalf(t, http.StatusOK, w.Code, "self disable body: %s", w.Body.String())
+	w = do(handler, userReq("PUT", base, map[string]interface{}{"status": 1}, memberAToken))
+	assert.Equalf(t, http.StatusOK, w.Code, "self enable body: %s", w.Body.String())
+	w = do(handler, userReq("POST", base+"/regenerate", nil, memberAToken))
+	assert.Equalf(t, http.StatusOK, w.Code, "self regenerate body: %s", w.Body.String())
+	w = do(handler, userReq("GET", base+"/deliveries", nil, memberAToken))
+	assert.Equalf(t, http.StatusOK, w.Code, "self deliveries body: %s", w.Body.String())
+}
+
+// 创建者可改自己 webhook 的名称；头像仅管理员可改 → 成员 400。
+func TestMemberUpdate_NameAllowedAvatarRejected(t *testing.T) {
+	handler, _, groupNo := setupMemberEnv(t)
+	whID := memberCreate(t, handler, groupNo)["webhook_id"].(string)
+	base := fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID)
+
+	w := do(handler, userReq("PUT", base, map[string]interface{}{"name": "deploy-bot"}, memberAToken))
+	require.Equalf(t, http.StatusOK, w.Code, "rename body: %s", w.Body.String())
+	assert.Equal(t, "deploy-bot", parseJSON(t, w)["name"])
+
+	w = do(handler, userReq("PUT", base, map[string]interface{}{"avatar": "https://x/y.png"}, memberAToken))
+	assert.Equalf(t, http.StatusBadRequest, w.Code, "avatar body: %s", w.Body.String())
+
+	// 管理员可改任意 webhook 的头像。
+	w = do(handler, authReq("PUT", base, map[string]interface{}{"avatar": "https://x/admin.png"}))
+	assert.Equalf(t, http.StatusOK, w.Code, "admin avatar body: %s", w.Body.String())
+}
+
+// 群主/管理员可管理任意成员创建的 webhook（改名、删除）。
+func TestAdmin_ManagesMemberWebhook(t *testing.T) {
+	handler, _, groupNo := setupMemberEnv(t)
+	whID := memberCreate(t, handler, groupNo)["webhook_id"].(string)
+	base := fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID)
+
+	w := do(handler, authReq("PUT", base, map[string]interface{}{"name": "ops-renamed"}))
+	require.Equalf(t, http.StatusOK, w.Code, "admin rename body: %s", w.Body.String())
+	assert.Equal(t, "ops-renamed", parseJSON(t, w)["name"])
+
+	w = do(handler, authReq("DELETE", base, nil))
+	assert.Equalf(t, http.StatusOK, w.Code, "admin delete body: %s", w.Body.String())
+}
+
+// ============================================================
+// 创建者退群
+// ============================================================
+
+// 创建者退群后：启用 / regenerate / 测试推送被 409 拒绝（删除、禁用仍可）。
+func TestCreatorLeft_BlocksEnableRegenerateTest(t *testing.T) {
+	handler, ctx, groupNo := setupMemberEnv(t)
+	whID := memberCreate(t, handler, groupNo)["webhook_id"].(string)
+	base := fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID)
+
+	// 管理员先禁用，再移除创建者。
+	w := do(handler, authReq("PUT", base, map[string]interface{}{"status": 0}))
+	require.Equalf(t, http.StatusOK, w.Code, "disable body: %s", w.Body.String())
+	removeGroupMember(t, ctx, groupNo, memberAUID)
+
+	w = do(handler, authReq("PUT", base, map[string]interface{}{"status": 1}))
+	assert.Equalf(t, http.StatusConflict, w.Code, "enable body: %s", w.Body.String())
+	w = do(handler, authReq("POST", base+"/regenerate", nil))
+	assert.Equalf(t, http.StatusConflict, w.Code, "regenerate body: %s", w.Body.String())
+	w = do(handler, authReq("POST", base+"/test", nil))
+	assert.Equalf(t, http.StatusConflict, w.Code, "test body: %s", w.Body.String())
+
+	// 管理员仍可删除（清理路径不被堵死）。
+	w = do(handler, authReq("DELETE", base, nil))
+	assert.Equalf(t, http.StatusOK, w.Code, "delete body: %s", w.Body.String())
+}
+
+// 创建者退群后 push 一律 401，且 webhook 被懒级联禁用（status→0）；创建者重新入群
+// 并由管理员重新启用后恢复可推送。
+func TestPush_CreatorLeft_LazyDisable(t *testing.T) {
+	handler, ctx, groupNo := setupMemberEnv(t)
+	created := memberCreate(t, handler, groupNo)
+	whID := created["webhook_id"].(string)
+	token := created["token"].(string)
+	pushURL := fmt.Sprintf("/v1/incoming-webhooks/%s/%s", whID, token)
+
+	removeGroupMember(t, ctx, groupNo, memberAUID)
+
+	pw := do(handler, anonReq("POST", pushURL, []byte(`{"content":"hi"}`)))
+	assert.Equalf(t, http.StatusUnauthorized, pw.Code, "push body: %s", pw.Body.String())
+
+	// 懒级联禁用：行状态翻为禁用（0）。
+	var status int
+	_, err := ctx.DB().SelectBySql(
+		"SELECT status FROM incoming_webhook WHERE webhook_id=?", whID).Load(&status)
+	require.NoError(t, err)
+	assert.Equal(t, 0, status, "creator-left push must lazily disable the webhook")
+
+	// 重新入群 + 管理员重新启用 → 推送恢复（非 401）。
+	_, err = ctx.DB().UpdateBySql(
+		"UPDATE group_member SET is_deleted=0 WHERE group_no=? AND uid=?", groupNo, memberAUID).Exec()
+	require.NoError(t, err)
+	w := do(handler, authReq("PUT",
+		fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID),
+		map[string]interface{}{"status": 1}))
+	require.Equalf(t, http.StatusOK, w.Code, "re-enable body: %s", w.Body.String())
+	pw = do(handler, anonReq("POST", pushURL, []byte(`{"content":"hi again"}`)))
+	assert.NotEqualf(t, http.StatusUnauthorized, pw.Code, "push after re-enable body: %s", pw.Body.String())
+}

--- a/modules/incomingwebhook/api_test.go
+++ b/modules/incomingwebhook/api_test.go
@@ -177,16 +177,25 @@ func TestCreate_HappyPath(t *testing.T) {
 	assert.Greater(t, int64(createdAt), int64(0), "created_at must be populated, not zero/epoch")
 }
 
-func TestCreate_RejectsEmptyName(t *testing.T) {
+// 名称缺省时服务端自动命名（Webhook-xxxxxx，后缀取自 webhook_id），不再 400
+// （#member-perms：成员/bot 创建路径需要一个无参可用的缺省，管理员同享该缺省）。
+func TestCreate_EmptyNameAutoGenerates(t *testing.T) {
 	handler, _, groupNo := setupTestEnv(t)
 	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{}))
-	assert.NotEqual(t, http.StatusOK, w.Code)
+	assert.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	res := parseJSON(t, w)
+	name, _ := res["name"].(string)
+	assert.Regexp(t, `^Webhook-[0-9a-f]{6}$`, name)
+	whID, _ := res["webhook_id"].(string)
+	assert.Contains(t, whID, strings.TrimPrefix(name, "Webhook-"))
 }
 
-func TestCreate_NonAdminForbidden(t *testing.T) {
+// 非群成员不可创建。注意：普通成员现在【可以】创建（自动命名 + display_locked），
+// 见 api_member_test.go 的成员权限矩阵；这里只钉"完全不在群内 → 403"。
+func TestCreate_NonMemberForbidden(t *testing.T) {
 	handler, ctx, groupNo := setupTestEnv(t)
-	// 把当前用户降级为普通成员
-	_, err := ctx.DB().UpdateBySql("UPDATE group_member SET role=0 WHERE group_no=? AND uid=?", groupNo, testutil.UID).Exec()
+	// 把当前用户移出群（软删成员行）
+	_, err := ctx.DB().UpdateBySql("UPDATE group_member SET is_deleted=1 WHERE group_no=? AND uid=?", groupNo, testutil.UID).Exec()
 	assert.NoError(t, err)
 
 	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{

--- a/modules/incomingwebhook/cache.go
+++ b/modules/incomingwebhook/cache.go
@@ -28,8 +28,17 @@ import (
 //       * 需要即时生效就把 TTL 调小或设 0。
 //     若日后要求 admin 禁用也即时，最小改动是订阅 event.GroupUpdate 并 invalidate 群条目
 //     （与 handleGroupDisband 对称）。TestPush_GroupAdminDisable_TTLBounded 钉住当前语义。
+//   - **创建者退群 / 管理员降级（memberCache）同属 TTL 兜底**：创建者在群闸与 push
+//     覆盖判权（cachedCreatorMembership）只缓存正向结果（false 绝不缓存——安全不变量，
+//     由 TestCreatorMembershipCache_NeverCachesNegative 钉住），退群/降级后旧的
+//     member/admin 快照最多再活一个 TTL，随后懒级联禁用 / 覆盖权限收回即生效。
+//     退群没有可订阅的跨模块事件，TTL 是唯一收敛机制。
 //   - TTL 默认很短（3s）以把这些窗口压到秒级。把 TTL 设为 0
 //     （DM_INCOMINGWEBHOOK_CACHE_TTL_MS=0）可彻底关闭缓存，退化为每次直查 DB 的旧行为。
+//
+// ⚠️ 因此 DM_INCOMINGWEBHOOK_CACHE_TTL_MS 是【安全参数】而不只是性能旋钮：调大它会
+// 同步拉长上述全部鉴权类 staleness 窗口（刚退群成员的 webhook 继续可推、旧 token
+// 残存、对等实例放行已解散群）。运维上调前须明确接受这一取舍。
 const (
 	envCacheTTLMs = "DM_INCOMINGWEBHOOK_CACHE_TTL_MS"
 	envCacheMax   = "DM_INCOMINGWEBHOOK_CACHE_MAX"

--- a/modules/incomingwebhook/db.go
+++ b/modules/incomingwebhook/db.go
@@ -6,14 +6,19 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/db"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/gocraft/dbr/v2"
 )
 
-// ErrQuotaExceeded 创建时配额已满，由 insertWithQuota 在事务内原子判定。
+// ErrQuotaExceeded 创建时群级配额已满，由 insertWithQuota 在事务内原子判定。
 var ErrQuotaExceeded = errors.New("incomingwebhook: per-group quota exceeded")
+
+// ErrCreatorQuotaExceeded 创建者个人配额已满（仅普通成员/bot 受限，管理员豁免），
+// 同样由 insertWithQuota 在事务内原子判定。
+var ErrCreatorQuotaExceeded = errors.New("incomingwebhook: per-creator quota exceeded")
 
 type incomingWebhookDB struct {
 	session *dbr.Session
@@ -38,7 +43,10 @@ func newDB(ctx *config.Context) *incomingWebhookDB {
 // count 检查、各自 INSERT 抢 insert-intention lock 互等 → InnoDB 死锁(1213)，且无
 // 重试，合法并发创建会以不透明的"创建失败"500 收场。锁父群这一必然存在的单行可彻底
 // 串行化而不触发 gap-lock 死锁（PR #31 yujiawei / Jerry-Xin review）。
-func (d *incomingWebhookDB) insertWithQuota(m *incomingWebhookModel, max int) error {
+// maxPerCreator <= 0 表示不启用个人配额（管理员创建路径）；> 0 时在同一事务内对
+// creator_uid 维度再做一次计数校验，超限返回 ErrCreatorQuotaExceeded。个人配额与
+// 群级配额共享同一把父群行锁，无需额外加锁。
+func (d *incomingWebhookDB) insertWithQuota(m *incomingWebhookModel, max, maxPerCreator int) error {
 	tx, err := d.session.Begin()
 	if err != nil {
 		return fmt.Errorf("incomingwebhook: begin tx: %w", err)
@@ -63,6 +71,19 @@ func (d *incomingWebhookDB) insertWithQuota(m *incomingWebhookModel, max int) er
 	}
 	if count >= max {
 		return ErrQuotaExceeded
+	}
+
+	if maxPerCreator > 0 {
+		var creatorCount int
+		if _, err = tx.SelectBySql(
+			"SELECT count(*) FROM incoming_webhook WHERE group_no=? AND creator_uid=? AND status != ?",
+			m.GroupNo, m.CreatorUID, statusDeleted,
+		).Load(&creatorCount); err != nil {
+			return fmt.Errorf("incomingwebhook: creator count: %w", err)
+		}
+		if creatorCount >= maxPerCreator {
+			return ErrCreatorQuotaExceeded
+		}
 	}
 
 	m.CreatedAt = db.Time(time.Now())
@@ -140,6 +161,34 @@ func (d *incomingWebhookDB) deleteByWebhookID(webhookID string) error {
 		Set("status", statusDeleted).
 		Where("webhook_id=?", webhookID).
 		Where("status != ?", statusDeleted).Exec()
+	return err
+}
+
+// isActiveInternalMember 判断 uid 是否为 groupNo 的【内部、正常状态、未删除】成员。
+// 与 group.QueryIsGroupManagerOrCreator 的 fail-safe 口径一致（is_external=0 +
+// status=Normal + is_deleted=0），用于：
+//   - 管理路径的成员资格闸（resolveActor）；
+//   - push 路径的"创建者仍在群内"权威闸（cachedCreatorIsMember 的回源查询）。
+//
+// 直接点读 group_member 表而非经 group 模块 DB：该表已是 bot_api 等模块的既有
+// 跨模块读取面，且这里只需一个 count，避免给 group.DB 增加仅本模块使用的接口。
+func (d *incomingWebhookDB) isActiveInternalMember(groupNo, uid string) (bool, error) {
+	var count int64
+	_, err := d.session.Select("count(*)").From("group_member").
+		Where("group_no=? AND uid=? AND is_deleted=0 AND is_external=0 AND status=?",
+			groupNo, uid, int(common.GroupMemberStatusNormal)).Load(&count)
+	return count > 0, err
+}
+
+// disableEnabledByWebhookID 把【仍处于启用态】的单个 webhook 置为禁用，用于 push
+// 路径发现创建者已退群时的懒级联禁用。status=statusEnabled 守卫保证：
+//   - 幂等（并发懒禁用只有一次生效）；
+//   - 绝不触碰软删除行（不会把 deleted 翻成 disabled 而复活到管理列表）。
+func (d *incomingWebhookDB) disableEnabledByWebhookID(webhookID string) error {
+	_, err := d.session.Update("incoming_webhook").
+		Set("status", statusDisabled).
+		Where("webhook_id=?", webhookID).
+		Where("status = ?", statusEnabled).Exec()
 	return err
 }
 

--- a/modules/incomingwebhook/db.go
+++ b/modules/incomingwebhook/db.go
@@ -76,6 +76,9 @@ func (d *incomingWebhookDB) insertWithQuota(m *incomingWebhookModel, max, maxPer
 	if maxPerCreator > 0 {
 		var creatorCount int
 		if _, err = tx.SelectBySql(
+			// 与群级配额同口径：只排除软删除（statusDeleted）。【禁用】的 webhook 刻意
+			// 仍占个人配额——否则成员可用 disable→create→disable→create 循环无限囤积
+			// 可随时启用的 webhook，配额就形同虚设。释放名额只能走删除。
 			"SELECT count(*) FROM incoming_webhook WHERE group_no=? AND creator_uid=? AND status != ?",
 			m.GroupNo, m.CreatorUID, statusDeleted,
 		).Load(&creatorCount); err != nil {

--- a/modules/incomingwebhook/db.go
+++ b/modules/incomingwebhook/db.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/db"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/gocraft/dbr/v2"
 )
 
@@ -78,7 +79,11 @@ func (d *incomingWebhookDB) insertWithQuota(m *incomingWebhookModel, max, maxPer
 		if _, err = tx.SelectBySql(
 			// 与群级配额同口径：只排除软删除（statusDeleted）。【禁用】的 webhook 刻意
 			// 仍占个人配额——否则成员可用 disable→create→disable→create 循环无限囤积
-			// 可随时启用的 webhook，配额就形同虚设。释放名额只能走删除。
+			// 可随时启用的 webhook，配额就形同虚设。释放名额只能走删除。这也意味着：
+			//   - 创建者退群被懒级联禁用的 webhook 仍占其个人配额，本人重新入群后可
+			//     自行删除释放；
+			//   - 配额是【创建闸】而非持续约束：调低 max_per_creator 不会回收已超额
+			//     成员的存量，只是不允许再建。
 			"SELECT count(*) FROM incoming_webhook WHERE group_no=? AND creator_uid=? AND status != ?",
 			m.GroupNo, m.CreatorUID, statusDeleted,
 		).Load(&creatorCount); err != nil {
@@ -167,20 +172,29 @@ func (d *incomingWebhookDB) deleteByWebhookID(webhookID string) error {
 	return err
 }
 
-// isActiveInternalMember 判断 uid 是否为 groupNo 的【内部、正常状态、未删除】成员。
-// 与 group.QueryIsGroupManagerOrCreator 的 fail-safe 口径一致（is_external=0 +
-// status=Normal + is_deleted=0），用于：
-//   - 管理路径的成员资格闸（resolveActor）；
-//   - push 路径的"创建者仍在群内"权威闸（cachedCreatorIsMember 的回源查询）。
+// queryMemberRole 一次点读返回 uid 在 groupNo 的成员资格与管理员身份：
+//   - isMember：是【内部、正常状态、未删除】成员（与 group.QueryIsGroupManagerOrCreator
+//     的 fail-safe 口径一致：is_deleted=0 + is_external=0 + status=Normal）；
+//   - isAdmin：在 isMember 基础上 role ∈ {creator, manager}。
+//
+// 单查询同时服务三处（一次往返拿全两个事实，省掉管理路径的二连击）：
+//   - 管理路径的 actor 解析（resolveActor：成员资格 + 管理员判定）；
+//   - 管理路径的"创建者仍在群内"闸（requireCreatorInGroup）；
+//   - push 路径的创建者在群闸 + 覆盖权限（cachedCreatorMembership 的回源查询，
+//     isAdmin 决定 push 的 username/avatar_url 覆盖是否生效）。
 //
 // 直接点读 group_member 表而非经 group 模块 DB：该表已是 bot_api 等模块的既有
-// 跨模块读取面，且这里只需一个 count，避免给 group.DB 增加仅本模块使用的接口。
-func (d *incomingWebhookDB) isActiveInternalMember(groupNo, uid string) (bool, error) {
-	var count int64
-	_, err := d.session.Select("count(*)").From("group_member").
+// 跨模块读取面，且这里只需一行，避免给 group.DB 增加仅本模块使用的接口。
+func (d *incomingWebhookDB) queryMemberRole(groupNo, uid string) (isMember, isAdmin bool, err error) {
+	var roles []int
+	_, err = d.session.Select("role").From("group_member").
 		Where("group_no=? AND uid=? AND is_deleted=0 AND is_external=0 AND status=?",
-			groupNo, uid, int(common.GroupMemberStatusNormal)).Load(&count)
-	return count > 0, err
+			groupNo, uid, int(common.GroupMemberStatusNormal)).
+		Limit(1).Load(&roles)
+	if err != nil || len(roles) == 0 {
+		return false, false, err
+	}
+	return true, roles[0] == group.MemberRoleCreator || roles[0] == group.MemberRoleManager, nil
 }
 
 // disableEnabledByWebhookID 把【仍处于启用态】的单个 webhook 置为禁用，用于 push

--- a/modules/incomingwebhook/db_test.go
+++ b/modules/incomingwebhook/db_test.go
@@ -91,12 +91,12 @@ func TestSoftDelete_FreesQuota(t *testing.T) {
 
 	// 配额已满：第三个被拒。
 	over := &incomingWebhookModel{WebhookID: generateWebhookID(), TokenHash: "h", GroupNo: groupNo, Name: "wh", Status: statusEnabled}
-	assert.ErrorIs(t, d.insertWithQuota(over, max), ErrQuotaExceeded)
+	assert.ErrorIs(t, d.insertWithQuota(over, max, 0), ErrQuotaExceeded)
 
 	// 软删一个释放配额后可再建一个。
 	assert.NoError(t, d.deleteByWebhookID(id1))
 	again := &incomingWebhookModel{WebhookID: generateWebhookID(), TokenHash: "h", GroupNo: groupNo, Name: "wh", Status: statusEnabled}
-	assert.NoError(t, d.insertWithQuota(again, max), "soft-delete must free per-group quota")
+	assert.NoError(t, d.insertWithQuota(again, max, 0), "soft-delete must free per-group quota")
 }
 
 // TestDisableByGroupNo_SkipsDeleted 验证群解散级联禁用不会"复活"已软删除的 webhook：
@@ -265,6 +265,6 @@ func mustInsertWebhookWithMax(t *testing.T, d *incomingWebhookDB, groupNo string
 		Name:      "wh",
 		Status:    statusEnabled,
 	}
-	assert.NoError(t, d.insertWithQuota(m, max))
+	assert.NoError(t, d.insertWithQuota(m, max, 0))
 	return m.WebhookID
 }

--- a/modules/incomingwebhook/membership_cache_test.go
+++ b/modules/incomingwebhook/membership_cache_test.go
@@ -1,0 +1,56 @@
+package incomingwebhook
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 创建者在群闸的安全不变量：cachedCreatorMembership【绝不缓存负结果】。一旦 false
+// 被缓存，刚退群的创建者会被"粘"在拒绝态之外的反面——更糟的是若实现反转，退群成员
+// 可能被粘在放行态。这里钉住：非成员查询后缓存无条目（下次仍回源 DB），成员查询后
+// 缓存有条目且值为 isAdmin（PR #340 review，yujiawei P2#3）。
+func TestCreatorMembershipCache_NeverCachesNegative(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+	w := New(ctx)
+
+	groupNo := "g_" + util.GenerUUID()[:12]
+	const uid = "cm_cache_uid"
+	key := groupNo + "|" + uid
+
+	// 非成员：返回 false，且不得写入缓存。
+	member, admin, err := w.cachedCreatorMembership(groupNo, uid)
+	require.NoError(t, err)
+	assert.False(t, member)
+	assert.False(t, admin)
+	_, hit := w.memberCache.get(key)
+	assert.False(t, hit, "negative membership must never be cached")
+
+	// 普通成员：返回 (true, false) 并缓存，条目值=isAdmin=false。
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO group_member(group_no, uid, role, status, is_deleted, version) VALUES(?, ?, 0, 1, 0, 1)",
+		groupNo, uid).Exec()
+	require.NoError(t, err)
+	member, admin, err = w.cachedCreatorMembership(groupNo, uid)
+	require.NoError(t, err)
+	assert.True(t, member)
+	assert.False(t, admin)
+	isAdmin, hit := w.memberCache.get(key)
+	assert.True(t, hit, "positive membership must be cached")
+	assert.False(t, isAdmin)
+
+	// 管理员成员：条目值=isAdmin=true（push 覆盖判权依赖该值）。
+	const adminUID = "cm_cache_admin"
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO group_member(group_no, uid, role, status, is_deleted, version) VALUES(?, ?, 2, 1, 0, 1)",
+		groupNo, adminUID).Exec()
+	require.NoError(t, err)
+	member, admin, err = w.cachedCreatorMembership(groupNo, adminUID)
+	require.NoError(t, err)
+	assert.True(t, member)
+	assert.True(t, admin)
+}

--- a/modules/incomingwebhook/model.go
+++ b/modules/incomingwebhook/model.go
@@ -116,6 +116,7 @@ type updateReq struct {
 }
 
 // webhookResp 对外暴露的 webhook 元信息（不含 token / token_hash）。
+// creator_uid 与登录 uid 对比可判断"是否我创建的"（成员仅可管理自己创建的）。
 type webhookResp struct {
 	WebhookID  string `json:"webhook_id"`
 	GroupNo    string `json:"group_no"`

--- a/modules/incomingwebhook/observability_test.go
+++ b/modules/incomingwebhook/observability_test.go
@@ -73,15 +73,16 @@ func TestDeliveries_LimitParam(t *testing.T) {
 	assert.Len(t, list, 2)
 }
 
-// 非群管理员不可看 deliveries。
-func TestDeliveries_RequiresAdmin(t *testing.T) {
+// deliveries 是创建者或管理员可见：创建者被降级为普通成员后仍可见（创建者权限），
+// 非创建者普通成员的 403 见 api_member_test.go TestMemberManage_OwnOnly。
+func TestDeliveries_DemotedCreatorStillAllowed(t *testing.T) {
 	handler, ctx, groupNo := setupTestEnv(t)
 	whID, _ := createWebhookWithToken(t, handler, groupNo)
 	_, err := ctx.DB().UpdateBySql("UPDATE group_member SET role=0 WHERE group_no=? AND uid=?", groupNo, testutil.UID).Exec()
 	require.NoError(t, err)
 
 	w := do(handler, authReq("GET", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s/deliveries", groupNo, whID), nil))
-	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
 }
 
 // 不存在 / 跨群 webhook → 404。
@@ -138,15 +139,17 @@ func TestDeliveries_AuthFailureNotRecorded(t *testing.T) {
 
 // --- 测试推送端点 ---
 
-// 非管理员不可触发测试推送。
-func TestTestPush_RequiresAdmin(t *testing.T) {
+// 测试推送是创建者或管理员可用：创建者被降级为普通成员后仍可用（创建者权限，
+// 下游投递在测试桩下可能 200/500，只断言不是 403）。非创建者普通成员的 403 见
+// api_member_test.go TestMemberManage_OwnOnly。
+func TestTestPush_DemotedCreatorStillAllowed(t *testing.T) {
 	handler, ctx, groupNo := setupTestEnv(t)
 	whID, _ := createWebhookWithToken(t, handler, groupNo)
 	_, err := ctx.DB().UpdateBySql("UPDATE group_member SET role=0 WHERE group_no=? AND uid=?", groupNo, testutil.UID).Exec()
 	require.NoError(t, err)
 
 	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s/test", groupNo, whID), nil))
-	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.NotEqualf(t, http.StatusForbidden, w.Code, "body: %s", w.Body.String())
 }
 
 // 不存在的 webhook → 404。

--- a/modules/incomingwebhook/richtext.go
+++ b/modules/incomingwebhook/richtext.go
@@ -50,7 +50,7 @@ func maxBlocks() int {
 //
 // 校验失败返回错误，由 push 路径映射：common.ErrRichTextPayloadTooLarge → 413，
 // 其余（含 errTooManyBlocks 与 Validate 的各类结构错误）→ 400 invalid(reason=blocks)。
-func buildRichTextPayload(m *incomingWebhookModel, req *pushPayloadReq) (map[string]interface{}, error) {
+func buildRichTextPayload(m *incomingWebhookModel, req *pushPayloadReq, allowOverride bool) (map[string]interface{}, error) {
 	if len(req.Blocks) > maxBlocks() {
 		return nil, errTooManyBlocks
 	}
@@ -78,7 +78,7 @@ func buildRichTextPayload(m *incomingWebhookModel, req *pushPayloadReq) (map[str
 		}
 	}
 
-	name, avatar := resolveFromIdentity(m, req)
+	name, avatar := resolveFromIdentity(m, req, allowOverride)
 	payload := map[string]interface{}{
 		"type":    int(common.RichText),
 		"content": content,

--- a/modules/incomingwebhook/richtext_test.go
+++ b/modules/incomingwebhook/richtext_test.go
@@ -36,7 +36,7 @@ func TestBuildRichTextPayload_TextOnly(t *testing.T) {
 	m := sampleWebhook()
 	req := &pushPayloadReq{MsgType: msgTypeRichText, Blocks: []webhookBlock{textBlock("Build #123 passed")}}
 
-	payload, err := buildRichTextPayload(m, req)
+	payload, err := buildRichTextPayload(m, req, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, int(common.RichText), payload["type"])
@@ -62,7 +62,7 @@ func TestBuildRichTextPayload_Image(t *testing.T) {
 		imageBlock("https://example.com/chart.png", 800, 400),
 	}}
 
-	payload, err := buildRichTextPayload(m, req)
+	payload, err := buildRichTextPayload(m, req, true)
 	require.NoError(t, err)
 
 	content, _ := payload["content"].([]map[string]interface{})
@@ -83,7 +83,7 @@ func TestBuildRichTextPayload_MixedOrderPreserved(t *testing.T) {
 		textBlock(" after"),
 	}}
 
-	payload, err := buildRichTextPayload(m, req)
+	payload, err := buildRichTextPayload(m, req, true)
 	require.NoError(t, err)
 
 	content, _ := payload["content"].([]map[string]interface{})
@@ -103,7 +103,7 @@ func TestBuildRichTextPayload_FromOverride(t *testing.T) {
 		Username:  "Override Name",
 		AvatarURL: "https://example.com/override.png",
 	}
-	payload, err := buildRichTextPayload(m, req)
+	payload, err := buildRichTextPayload(m, req, true)
 	require.NoError(t, err)
 	from, _ := payload["from"].(map[string]interface{})
 	assert.Equal(t, "Override Name", from["name"])
@@ -115,7 +115,7 @@ func TestBuildRichTextPayload_FromOverride(t *testing.T) {
 func TestBuildRichTextPayload_SpaceIDNotForgeable(t *testing.T) {
 	m := sampleWebhook()
 	req := &pushPayloadReq{MsgType: msgTypeRichText, Blocks: []webhookBlock{textBlock("hi")}}
-	payload, err := buildRichTextPayload(m, req)
+	payload, err := buildRichTextPayload(m, req, true)
 	require.NoError(t, err)
 	assert.Equal(t, "space_42", payload["space_id"])
 }
@@ -124,7 +124,7 @@ func TestBuildRichTextPayload_SpaceIDNotForgeable(t *testing.T) {
 func TestBuildRichTextPayload_NoTokenLeak(t *testing.T) {
 	m := sampleWebhook()
 	req := &pushPayloadReq{MsgType: msgTypeRichText, Blocks: []webhookBlock{textBlock("hi")}}
-	payload, err := buildRichTextPayload(m, req)
+	payload, err := buildRichTextPayload(m, req, true)
 	require.NoError(t, err)
 	assert.NotContains(t, util.ToJson(payload), "SECRET_SHOULD_NOT_LEAK")
 }
@@ -146,7 +146,7 @@ func TestBuildRichTextPayload_Rejects(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := buildRichTextPayload(m, &pushPayloadReq{MsgType: msgTypeRichText, Blocks: tc.blocks})
+			_, err := buildRichTextPayload(m, &pushPayloadReq{MsgType: msgTypeRichText, Blocks: tc.blocks}, true)
 			assert.Error(t, err, "应拒绝非法 blocks: %s", tc.name)
 		})
 	}
@@ -157,7 +157,7 @@ func TestBuildRichTextPayload_TooManyBlocks(t *testing.T) {
 	t.Setenv(envMaxBlocks, "2")
 	m := sampleWebhook()
 	blocks := []webhookBlock{textBlock("a"), textBlock("b"), textBlock("c")}
-	_, err := buildRichTextPayload(m, &pushPayloadReq{MsgType: msgTypeRichText, Blocks: blocks})
+	_, err := buildRichTextPayload(m, &pushPayloadReq{MsgType: msgTypeRichText, Blocks: blocks}, true)
 	assert.ErrorIs(t, err, errTooManyBlocks)
 }
 
@@ -166,22 +166,31 @@ func TestBuildRichTextPayload_UnknownBlockDropsExtraFields(t *testing.T) {
 	m := sampleWebhook()
 	// type=text 合法块 + 一个未知块（携带看似合法的 url/width/height）：整体必须被拒。
 	blocks := []webhookBlock{textBlock("ok"), {Type: "image_v2", URL: "https://x/y", Width: 1, Height: 1}}
-	_, err := buildRichTextPayload(m, &pushPayloadReq{MsgType: msgTypeRichText, Blocks: blocks})
+	_, err := buildRichTextPayload(m, &pushPayloadReq{MsgType: msgTypeRichText, Blocks: blocks}, true)
 	assert.Error(t, err)
 }
 
-// resolveFromIdentity：覆盖优先、回落 webhook 配置、超长裁剪到字节上限。
+// resolveFromIdentity：管理员（allowOverride=true）覆盖优先、回落 webhook 配置、
+// 超长裁剪到字节上限；成员/bot（allowOverride=false）覆盖一律忽略——否则管理面的
+// Webhook- 前缀与头像锁会被 push 路径整体绕过（PR #340 review，yujiawei P1）。
 func TestResolveFromIdentity(t *testing.T) {
 	m := &incomingWebhookModel{Name: "WH", Avatar: "https://a/x.png"}
 
-	name, avatar := resolveFromIdentity(m, &pushPayloadReq{})
+	name, avatar := resolveFromIdentity(m, &pushPayloadReq{}, true)
 	assert.Equal(t, "WH", name)
 	assert.Equal(t, "https://a/x.png", avatar)
 
-	name, _ = resolveFromIdentity(m, &pushPayloadReq{Username: "Override"})
+	name, _ = resolveFromIdentity(m, &pushPayloadReq{Username: "Override"}, true)
 	assert.Equal(t, "Override", name)
 
 	longName := strings.Repeat("x", maxFromNameBytes+10)
-	name, _ = resolveFromIdentity(m, &pushPayloadReq{Username: longName})
+	name, _ = resolveFromIdentity(m, &pushPayloadReq{Username: longName}, true)
 	assert.LessOrEqual(t, len(name), maxFromNameBytes)
+
+	// 成员/bot 的 webhook：覆盖被忽略，展示固定为存量（已带前缀的）配置。
+	spoof := &pushPayloadReq{Username: "HR 公告", AvatarURL: "https://evil/ceo.png"}
+	lockedM := &incomingWebhookModel{Name: "Webhook-abc123", Avatar: ""}
+	name, avatar = resolveFromIdentity(lockedM, spoof, false)
+	assert.Equal(t, "Webhook-abc123", name)
+	assert.Equal(t, "", avatar)
 }

--- a/modules/incomingwebhook/util_test.go
+++ b/modules/incomingwebhook/util_test.go
@@ -35,7 +35,7 @@ func TestBuildPayload_DefaultsToWebhookNameAvatar(t *testing.T) {
 		Avatar:    "https://avatar/x.png",
 	}
 	req := &pushPayloadReq{Content: "hi"}
-	p := buildPayload(m, req)
+	p := buildPayload(m, req, true)
 
 	assert.Equal(t, int(common.Text), p["type"])
 	assert.Equal(t, "hi", p["content"])
@@ -52,7 +52,7 @@ func TestBuildPayload_OverrideUsernameAndAvatar(t *testing.T) {
 		Content:  "hi",
 		Username: "GitHub Bot", AvatarURL: "https://gh/a.png",
 	}
-	from := buildPayload(m, req)["from"].(map[string]interface{})
+	from := buildPayload(m, req, true)["from"].(map[string]interface{})
 	assert.Equal(t, "GitHub Bot", from["name"])
 	assert.Equal(t, "https://gh/a.png", from["avatar"])
 }
@@ -77,7 +77,7 @@ func TestBuildPayload_DropsAllExtra(t *testing.T) {
 			"anything": "else",
 		},
 	}
-	p := buildPayload(m, req)
+	p := buildPayload(m, req, true)
 	// 核心字段保持服务端值
 	assert.Equal(t, int(common.Text), p["type"])
 	assert.Equal(t, "real", p["content"])
@@ -101,14 +101,14 @@ func TestBuildPayload_SpaceIDFromModelNotExtra(t *testing.T) {
 			"space_id": "forged_space",
 		},
 	}
-	p := buildPayload(m, req)
+	p := buildPayload(m, req, true)
 	assert.Equal(t, "real_space", p["space_id"], "space_id must come from model, not Extra")
 }
 
 func TestBuildPayload_SpaceIDSetEvenWhenExtraOmitsIt(t *testing.T) {
 	m := &incomingWebhookModel{WebhookID: "iwh_x", Name: "WH", SpaceID: "real_space"}
 	req := &pushPayloadReq{Content: "hi"}
-	p := buildPayload(m, req)
+	p := buildPayload(m, req, true)
 	assert.Equal(t, "real_space", p["space_id"])
 }
 
@@ -125,7 +125,7 @@ func TestBuildPayload_TruncatesLongUsernameAvatar(t *testing.T) {
 		Username:  longName,
 		AvatarURL: longAvatar,
 	}
-	p := buildPayload(m, req)
+	p := buildPayload(m, req, true)
 	from := p["from"].(map[string]interface{})
 	gotName := from["name"].(string)
 	gotAvatar := from["avatar"].(string)
@@ -142,7 +142,7 @@ func TestBuildPayload_TruncateRespectsUTF8(t *testing.T) {
 		Content:  "hi",
 		Username: strings.Repeat("一", 100), // 100 × 3 = 300 字节
 	}
-	p := buildPayload(m, req)
+	p := buildPayload(m, req, true)
 	from := p["from"].(map[string]interface{})
 	gotName := from["name"].(string)
 	assert.LessOrEqualf(t, len(gotName), 64, "byte length capped; got %d", len(gotName))

--- a/modules/user/webhook_avatar_palette_test.go
+++ b/modules/user/webhook_avatar_palette_test.go
@@ -1,0 +1,26 @@
+package user
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// webhook 合成发送者（iwh_）无自定义头像时，兜底必须复用 bot 默认头像逻辑：
+// crc32(uid) 确定性选取 13 色内置 PNG（与 Robot==1 用户一致），而非通用生成式
+// 默认头像——webhook 与 bot 同属"非真实用户"，视觉口径保持一致。
+func TestWebhookAvatarFallback_UsesBotDefaultPalette(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	ctx.GetConfig().Avatar.Default = ""
+	ctx.GetConfig().Avatar.DefaultBaseURL = ""
+
+	const uid = "iwh_palette_test_0001"
+	resp := getAvatarForTest(t, s.GetRoute(), uid)
+	want, err := readBotDefaultAvatar(uid)
+	require.NoError(t, err)
+	assert.Equal(t, want, resp.Body.Bytes(),
+		"webhook avatar fallback must serve the deterministic bot-palette PNG")
+}

--- a/modules/user/webhook_identity.go
+++ b/modules/user/webhook_identity.go
@@ -95,9 +95,12 @@ func (u *User) writeWebhookAvatar(c *wkhttp.Context, uid string) {
 		return
 	}
 	// 仅当 webhook 存在但无自定义头像、或 webhook 已删除（ch==nil）时回退默认头像。
-	imageData, genErr := generateDefaultAvatar(uid)
+	// 复用 bot 默认头像逻辑（crc32(uid) 确定性选 13 色内置 PNG）：webhook 与 bot 同属
+	// "非真实用户"发送者，视觉口径保持一致；成员/bot 自助创建的 webhook 不可自定义
+	// 头像（#member-perms），即默认全部落在这条 palette 路径上。
+	imageData, genErr := readBotDefaultAvatar(uid)
 	if genErr != nil {
-		u.Error("生成 webhook 默认头像失败", zap.Error(genErr), zap.String("uid", uid))
+		u.Error("读取 webhook 默认头像失败", zap.Error(genErr), zap.String("uid", uid))
 		c.Writer.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/pkg/errcode/incomingwebhook.go
+++ b/pkg/errcode/incomingwebhook.go
@@ -146,11 +146,14 @@ var (
 	// an (internal, active) member of the group, so operations that would make
 	// or keep it pushable (enable / regenerate / test push) are refused. The
 	// webhook can still be deleted; pushes are lazily disabled by the push
-	// path's creator-membership gate.
+	// path's creator-membership gate. Recovery: the creator rejoins the group,
+	// after which the creator or an admin can re-enable it — the message must
+	// state that path and offer deletion only as the cleanup option (PR #340
+	// review, Jerry-Xin: do not tell users delete-and-recreate is the only way).
 	ErrIncomingWebhookCreatorLeft = register(codes.Code{
 		ID:             "err.server.incomingwebhook.mgmt_creator_left",
 		HTTPStatus:     http.StatusConflict,
-		DefaultMessage: "The webhook's creator has left the group; it can no longer be enabled. Delete it and create a new one.",
+		DefaultMessage: "The webhook's creator has left the group, so it cannot be enabled. It can be re-enabled after the creator rejoins, or deleted and recreated by someone in the group.",
 	})
 
 	// ErrIncomingWebhookQueryFailed (500, Internal) — a read (group / webhook /

--- a/pkg/errcode/incomingwebhook.go
+++ b/pkg/errcode/incomingwebhook.go
@@ -87,12 +87,15 @@ var (
 // (403/404/409/400/500). This replaces the legacy raw-string
 // c.ResponseError(errors.New(...)) pattern (#246 follow-up).
 var (
-	// ErrIncomingWebhookForbidden (403) — caller is neither group owner nor
-	// admin; the only role allowed to manage a group's webhooks.
+	// ErrIncomingWebhookForbidden (403) — caller lacks permission: not an
+	// (internal, active) member of the group, or a plain member/bot touching a
+	// webhook created by someone else. Owners/admins manage any webhook;
+	// members and bots manage only their own. One generic code for every
+	// permission failure — the precise reason is not surfaced.
 	ErrIncomingWebhookForbidden = register(codes.Code{
 		ID:             "err.server.incomingwebhook.mgmt_forbidden",
 		HTTPStatus:     http.StatusForbidden,
-		DefaultMessage: "Only the group owner or an admin can manage webhooks.",
+		DefaultMessage: "You do not have permission to manage this webhook.",
 	})
 
 	// ErrIncomingWebhookRequestInvalid (400) — malformed body or invalid field
@@ -128,6 +131,26 @@ var (
 		ID:             "err.server.incomingwebhook.mgmt_quota_exceeded",
 		HTTPStatus:     http.StatusConflict,
 		DefaultMessage: "Each group allows at most {{.max}} webhooks.",
+	})
+
+	// ErrIncomingWebhookCreatorQuotaExceeded (409) — the calling member/bot has
+	// reached its per-creator cap in this group (owners/admins are exempt and
+	// only bounded by the group cap). Params["max"] carries the configured cap.
+	ErrIncomingWebhookCreatorQuotaExceeded = register(codes.Code{
+		ID:             "err.server.incomingwebhook.mgmt_creator_quota_exceeded",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "You can create at most {{.max}} webhooks in this group.",
+	})
+
+	// ErrIncomingWebhookCreatorLeft (409) — the webhook's creator is no longer
+	// an (internal, active) member of the group, so operations that would make
+	// or keep it pushable (enable / regenerate / test push) are refused. The
+	// webhook can still be deleted; pushes are lazily disabled by the push
+	// path's creator-membership gate.
+	ErrIncomingWebhookCreatorLeft = register(codes.Code{
+		ID:             "err.server.incomingwebhook.mgmt_creator_left",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "The webhook's creator has left the group; it can no longer be enabled. Delete it and create a new one.",
 	})
 
 	// ErrIncomingWebhookQueryFailed (500, Internal) — a read (group / webhook /

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -690,7 +690,7 @@ other = "每个群最多 {{.max}} 个 webhook。"
 other = "你在该群最多可创建 {{.max}} 个 webhook。"
 
 ["err.server.incomingwebhook.mgmt_creator_left"]
-other = "该 webhook 的创建者已退出群聊，无法再启用；请删除后重新创建。"
+other = "该 webhook 的创建者已退出群聊，暂时无法启用；待创建者重新入群后可再启用，或删除后由群内成员重新创建。"
 
 ["err.server.incomingwebhook.mgmt_query_failed"]
 other = "查询 webhook 信息失败。"

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -672,7 +672,7 @@ other = "未找到。"
 # ---- err.server.incomingwebhook.mgmt_* (management endpoints, #246 follow-up) ----
 
 ["err.server.incomingwebhook.mgmt_forbidden"]
-other = "仅群主或管理员可管理 webhook。"
+other = "你没有权限管理此 webhook。"
 
 ["err.server.incomingwebhook.mgmt_request_invalid"]
 other = "请求参数无效。"
@@ -685,6 +685,12 @@ other = "webhook 不存在。"
 
 ["err.server.incomingwebhook.mgmt_quota_exceeded"]
 other = "每个群最多 {{.max}} 个 webhook。"
+
+["err.server.incomingwebhook.mgmt_creator_quota_exceeded"]
+other = "你在该群最多可创建 {{.max}} 个 webhook。"
+
+["err.server.incomingwebhook.mgmt_creator_left"]
+other = "该 webhook 的创建者已退出群聊，无法再启用；请删除后重新创建。"
 
 ["err.server.incomingwebhook.mgmt_query_failed"]
 other = "查询 webhook 信息失败。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -334,7 +334,7 @@ other = "The target user does not exist or has been deactivated."
 other = "You do not have permission to view this."
 
 ["err.server.incomingwebhook.mgmt_creator_left"]
-other = "The webhook's creator has left the group; it can no longer be enabled. Delete it and create a new one."
+other = "The webhook's creator has left the group, so it cannot be enabled. It can be re-enabled after the creator rejoins, or deleted and recreated by someone in the group."
 
 ["err.server.incomingwebhook.mgmt_creator_quota_exceeded"]
 other = "You can create at most {{.max}} webhooks in this group."

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -333,11 +333,17 @@ other = "The target user does not exist or has been deactivated."
 ["err.server.group.view_forbidden"]
 other = "You do not have permission to view this."
 
+["err.server.incomingwebhook.mgmt_creator_left"]
+other = "The webhook's creator has left the group; it can no longer be enabled. Delete it and create a new one."
+
+["err.server.incomingwebhook.mgmt_creator_quota_exceeded"]
+other = "You can create at most {{.max}} webhooks in this group."
+
 ["err.server.incomingwebhook.mgmt_disabled"]
 other = "The incoming webhook feature is currently disabled."
 
 ["err.server.incomingwebhook.mgmt_forbidden"]
-other = "Only the group owner or an admin can manage webhooks."
+other = "You do not have permission to manage this webhook."
 
 ["err.server.incomingwebhook.mgmt_group_not_found"]
 other = "The group does not exist or has been disbanded."


### PR DESCRIPTION
Closes #348

# 背景

此前 incoming webhook 的全部管理端点（create/list/update/delete/regenerate/deliveries/test）都要求群主或管理员。本 PR 把管理面放开给普通群成员与 bot，并为 bot 挂载同一组端点（一套 Service、两个门），权限按所有权划分。

# 权限矩阵

| 操作 | 群主/管理员（含管理员 bot） | 普通成员 / 成员 bot（内部、正常状态） |
|------|------|------|
| create | ✅（可自定义名称+头像） | ✅ 名称可自定义（缺省自动命名 `Webhook-xxxxxx`）；头像不可设置（400） |
| update | ✅ 任意 | ✅ 仅自己创建的；可改名称/状态，头像不可改 |
| delete / regenerate / test | ✅ 任意 | ✅ 仅自己创建的（其余 403） |
| list | ✅ | ✅ 只读全量可见（不回显 token/推送 URL） |
| deliveries | ✅ 任意 | ✅ 仅自己创建的 |

- 管理员判定走 `group_member.role`（`QueryIsGroupManagerOrCreator`），人与 bot 同一查询——**bot 被设为群管理员即与人类管理员同权**；外部成员（is_external=1）一律 403（沿用 fail-safe 口径）。
- 非创建者写操作返回 403（list 对成员可见，存在性不是秘密）；跨群/不存在仍 404。

# 主要变更

- **Bot 路由**：`/v1/bot/groups/:group_no/incoming-webhooks[...]`，链路 `authBot → robot_id→uid 适配 → SharedUIDRateLimiter`，经 `incomingwebhook.NewManagementFacade + MountManagementRoutes` 复用全部 handler。跨挂载面的 push 缓存失效以 TTL 兜底（与既有跨实例 staleness 契约同级，见 `NewManagementFacade` 注释）。
- **个人配额**：新增 system_setting `incomingwebhook.max_per_creator`（默认 5，env `DM_INCOMINGWEBHOOK_MAX_PER_CREATOR`），与群级配额同事务原子校验；管理员豁免（仅受群级 `max_per_group` 约束）。防止单个成员刷满群配额（成员间 DoS）并封顶单人可开的免登录推送通道总量。
- **创建者退群即失效**：push 路径新增「创建者仍是群内内部正常成员」闸（进程内正向缓存，TTL 同 webhook/group 缓存）；闸不过 → 统一 401 + **懒级联禁用**（status→0，幂等，不触碰软删除行）。enable/regenerate/test 对创建者已退群的 webhook 返回 409（新错误码 `mgmt_creator_left`）；删除保持可用以便清理。重新入群后可重新启用。该规则对存量（管理员创建的）webhook 同样生效——**若线上存在创建者已退群的存量 webhook，部署后将停止推送并被禁用**，属预期行为变更。
- **展示身份**：名称缺省时服务端自动命名 `Webhook-xxxxxx`（后缀取自 webhook_id，可对账）；头像仅管理员可设置/修改，成员/bot 的 webhook 走头像端点确定性回退到 **bot 默认头像 13 色 palette**（`crc32(uid) % 13`，与 bot 视觉口径一致，原为通用生成式默认头像）。无 schema 变更。
- **i18n**：`mgmt_forbidden` 文案泛化；新增 `mgmt_creator_quota_exceeded`、`mgmt_creator_left` + zh-CN 翻译；markers 已重新生成，`i18n-extract-check` / `i18n-lint` 通过。

# 既有契约的有意变更

1. 普通成员 create 由 403 → 200（`TestCreate_NonAdminForbidden` 改为 `TestCreate_NonMemberForbidden`）。
2. 管理员空名称 create 由 400 → 自动命名 200（`TestCreate_EmptyNameAutoGenerates`）。
3. 被降级为普通成员的创建者保留对自己 webhook 的 deliveries/test 权限（原两条 RequiresAdmin 测试更名并翻转断言）。
4. 撤回不对称维持现状并写入 README：成员创建者撤不了 webhook 消息（FromUID 为 `iwh_*`），止血手段是禁用 webhook。

# 测试

- 新增 `modules/incomingwebhook/api_member_test.go`（成员权限矩阵、个人配额、外部成员/非成员 403、创建者退群 409 + push 懒禁用 + 重入群恢复）、`modules/bot_api/incoming_webhook_test.go`（成员 bot CRUD/所有权/非成员闸、管理员 bot 同权）、`modules/user/webhook_avatar_palette_test.go`（头像 palette 回退）。
- 本地（MySQL 8 + Redis + WuKongIM 桩）全量通过：`modules/incomingwebhook`、`modules/bot_api`、`modules/user`、`modules/common`、`modules/group`、`pkg/i18n/...`、`pkg/errcode`；`go vet ./...`、`golangci-lint`（受影响包）0 issue。

https://claude.ai/code/session_01KsU3psi5paYwK7BbmMcb2w

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsU3psi5paYwK7BbmMcb2w)_
