### PR TITLE
chore(ops): one-off thread subscription leak reconciler

### DIFF
--- a/docs/thread-subscription-reconcile-runbook.md
+++ b/docs/thread-subscription-reconcile-runbook.md
@@ -1,0 +1,84 @@
+# 子区订阅泄漏存量对账运维手册
+
+一次性运维工具：清理历史上残留在 WuKongIM 里的越权子区订阅。
+
+## 背景
+
+被踢/退群（`group_member.is_deleted=1`）或被拉黑（`status=blacklist, is_deleted=0`）的成员，
+在入群时按“父群成员”批量挂上的子区频道订阅，可能从未被对称摘除：
+
+- 已被踢/退群的人：当年挂进 WuKongIM 的子区订阅没被摘，可能要等 channel 缓存失效才自愈，不保证。
+- 被拉黑的人：成员数据源不过滤 `status`，即使 WuKongIM 重载也可能永不自愈。
+
+事件驱动的修复只覆盖“未来发生的移除”，不处理 bug 期间已经泄漏的存量。本工具做一次性对账：
+扫所有群里这两类成员，把他们在该群**所有非 deleted 子区**频道上的 IM 订阅摘掉。
+
+## 工具行为
+
+- **只摘订阅，不删数据**：仅调用 WuKongIM 的 `IMRemoveSubscriber`，不删 `thread_member` /
+  `thread_setting` 行，不动置顶 / 会话扩展。订阅泄漏是“多挂了订阅”，对账只需摘掉这份越权订阅。
+- **幂等**：`IMRemoveSubscriber` 对不存在的订阅是 no-op，重复执行安全。
+- **dry-run 默认**：不带 `--apply` 时只统计“将摘除多少 (uid, 子区) 订阅对”，绝不实际调用。
+- **失败不中断**：单个子区/批次调用失败只记录进报告，继续处理其余，最后以非零退出码收尾。
+
+## 用法
+
+工具是主二进制的一个子命令（与 `api` 同级），复用同一份 `-config`：
+
+```bash
+# 1) dry-run（默认）：只统计将摘除多少订阅对，不写
+./app -config configs/tsdd.yaml reconcile-thread-subs
+
+# 2) 真正执行：加 --apply
+./app -config configs/tsdd.yaml reconcile-thread-subs --apply
+
+# 3) 大群限速执行：每次 IM 调用间隔 200ms，单次最多带 50 个 uid
+./app -config configs/tsdd.yaml reconcile-thread-subs --apply --interval 200ms --batch-size 50
+```
+
+容器内（镜像 ENTRYPOINT 为 `/home/app`，工作目录 `/home`）：
+
+```bash
+docker exec -it <octo-server-container> /home/app reconcile-thread-subs
+docker exec -it <octo-server-container> /home/app reconcile-thread-subs --apply --interval 200ms
+```
+
+### 参数
+
+| 参数 | 默认 | 说明 |
+|------|------|------|
+| `--apply` | `false` | 不带则 dry-run（只统计）；带上才真正摘订阅 |
+| `--batch-size` | `100` | 单次 `IMRemoveSubscriber` 调用最多携带的 uid 数（同一子区频道下分批） |
+| `--interval` | `0` | 每次 IM 调用之间的休眠（限速），如 `200ms`、`1s` |
+
+### 退出码
+
+- `0`：成功，无失败项。
+- `1`：扫描阶段出错（如 DB 查询失败），未进入摘除。
+- `2`：摘除阶段有失败项（已全部跑完，失败项见报告）。
+
+## 推荐执行顺序
+
+1. **先在 dry-run 模式跑一遍**，确认受影响群数 / 泄漏成员数 / 计划摘除对数在预期范围。
+2. 建议在“数据源排除 blacklist + 拉黑路径补 helper”修复合入后再 `--apply`，
+   否则跑完拉黑成员可能被其他路径重新挂回。**注意：对账幂等，重跑无害**，即便提前跑也安全。
+3. 生产 `--apply` 建议带 `--interval` 限速，避免打爆 WuKongIM IM 接口。
+
+## 报告示例
+
+```
+子区订阅泄漏对账报告 [DRY-RUN (未实际摘除任何订阅；加 --apply 才执行)]
+  受影响群数:        12
+  泄漏成员数(去重):  47
+  扫描子区数:        38
+  计划摘除订阅对:    156
+  失败项:            0
+```
+
+## 回滚与影响面
+
+- **无需回滚**：本工具只摘订阅、不删任何 DB 数据。
+- **影响面**：被摘订阅的成员是已被踢/退群/拉黑的人，他们本就不该再收该群子区消息；
+  摘订阅后他们停止从 WuKongIM 收到对应子区频道的消息，符合预期。
+- 万一误摘了正常成员的订阅（理论上不会，判定条件是 `is_deleted=1 OR status=blacklist`），
+  该成员下次正常进入子区时会按既有入群/激活路径重新挂回订阅，不造成永久损坏。

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/Mininglamp-OSS/octo-server/internal"
 	commonapi "github.com/Mininglamp-OSS/octo-server/modules/base/common"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/accesslog"
 	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
@@ -82,15 +83,60 @@ func main() {
 	log.Configure(logOpts)
 
 	var serverType string
-	if len(os.Args) > 1 {
+	subArgs := flag.Args()
+	if len(subArgs) > 0 {
+		serverType = strings.TrimSpace(subArgs[0])
+		serverType = strings.Replace(serverType, "-", "", -1)
+	} else if len(os.Args) > 1 {
 		serverType = strings.TrimSpace(os.Args[1])
 		serverType = strings.Replace(serverType, "-", "", -1)
+	}
+
+	switch serverType {
+	case "reconcilethreadsubs": // 存量子区订阅泄漏一次性对账工具（Issue YUJ-4186）
+		var rest []string
+		if len(subArgs) > 1 {
+			rest = subArgs[1:]
+		}
+		runReconcileThreadSubs(ctx, rest)
+		return
 	}
 
 	if serverType == "api" || serverType == "" || serverType == "config" { // api服务启动
 		runAPI(ctx)
 	}
 
+}
+
+// runReconcileThreadSubs 运行存量子区订阅泄漏对账工具（Issue YUJ-4186）。
+// 默认 dry-run（只统计、不摘订阅），加 --apply 才真正执行。
+//
+//	用法: app [-config configs/tsdd.yaml] reconcile-thread-subs [--apply] [--batch-size N] [--interval 200ms]
+func runReconcileThreadSubs(ctx *config.Context, args []string) {
+	fs := flag.NewFlagSet("reconcile-thread-subs", flag.ExitOnError)
+	apply := fs.Bool("apply", false, "实际摘除订阅（默认 false，即 dry-run，只统计不写）")
+	batchSize := fs.Int("batch-size", 100, "单次 IMRemoveSubscriber 调用最多携带的 uid 数（同一子区频道下分批）")
+	interval := fs.Duration("interval", 0, "每次 IMRemoveSubscriber 调用之间的休眠（限速，如 200ms）")
+	if err := fs.Parse(args); err != nil {
+		panic(err)
+	}
+
+	report, err := group.RunThreadSubscriptionReconcile(ctx, log.NewTLog("reconcileThreadSubs"), group.ReconcileOptions{
+		Apply:     *apply,
+		BatchSize: *batchSize,
+		Interval:  *interval,
+	})
+	if report != nil {
+		fmt.Print(report.String())
+	}
+	if err != nil {
+		log.Error("子区订阅对账失败", zap.Error(err))
+		os.Exit(1)
+	}
+	if report != nil && len(report.Failures) > 0 {
+		// 有失败项时以非零退出码收尾，便于运维脚本感知（失败本身不中断对账，已全部跑完）。
+		os.Exit(2)
+	}
 }
 
 func runAPI(ctx *config.Context) {

--- a/modules/group/thread_subscription_reconcile.go
+++ b/modules/group/thread_subscription_reconcile.go
@@ -1,0 +1,246 @@
+package group
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"go.uber.org/zap"
+)
+
+// 存量子区订阅泄漏一次性对账工具（Issue YUJ-4186，承接 #27/#332/YUJ-4185 根因调查）。
+//
+// 背景：#27/#332 + YUJ-4185 都是“事件驱动”修复，只在“未来发生移除”时摘子区订阅。代码库里
+// 没有任何 backfill/reconcile migration，所以 bug 期间已经泄漏的存量订阅会原地留存：
+//   - 已被踢出/退群的人(is_deleted=1)：当年入群时挂进 WuKongIM 的子区订阅从没被摘。
+//   - 被拉黑的人(status=blacklist, is_deleted=0)：GetMembers 不过滤 status，即使 WuKongIM
+//     重载也永不自愈。
+//
+// 本工具扫所有群的 group_member，找出 is_deleted=1 OR status=blacklist 的成员，对每个
+// (group_no, uid) 复用 queryThreadShortIDsForCleanup 查该群所有非 deleted 子区，逐个对子区
+// 频道 IMRemoveSubscriber 该 uid。
+//
+// 设计约束（验收要求“只摘订阅不删数据，无需回滚”）：本工具刻意只调 IMRemoveSubscriber，
+// 不删 thread_member / thread_setting 行、不动 pinned / conversation_ext —— 与被踢/退群路径上
+// 的 removeUserFromGroupThreadsCleanup（会删 DB 行）区别开。订阅泄漏是“多挂了订阅”，对账只需
+// 摘掉这份越权订阅；DB 行是否残留属于另一类问题，不在本单范围内，也避免误删带来的回滚风险。
+//
+// 幂等：IMRemoveSubscriber 对不存在的订阅是 no-op，重复执行安全。
+// dry-run：默认只统计将摘除多少 (uid, 子区) 订阅对，不实际调用；ReconcileOptions.Apply=true 才执行。
+
+// ReconcileOptions 控制对账工具的执行模式与限速。
+type ReconcileOptions struct {
+	// Apply=false（默认）为 dry-run：只扫描统计，绝不调用 IMRemoveSubscriber。
+	// Apply=true 才真正摘订阅。
+	Apply bool
+	// BatchSize 单次 IMRemoveSubscriber 调用最多携带多少个 uid（同一子区频道下分批），
+	// 用于避免单次请求 body 过大。<=0 时回退到 defaultReconcileBatchSize。
+	BatchSize int
+	// Interval 每次 IMRemoveSubscriber 调用之间的休眠，用于限速避免打爆 WuKongIM。
+	// <=0 时不休眠。
+	Interval time.Duration
+}
+
+const defaultReconcileBatchSize = 100
+
+// ReconcileFailure 记录单次摘订阅调用失败（失败只记录不中断）。
+type ReconcileFailure struct {
+	GroupNo   string
+	ChannelID string
+	UIDs      []string
+	Err       string
+}
+
+// ReconcileReport 对账执行报告。
+type ReconcileReport struct {
+	DryRun         bool
+	GroupsAffected int                // 含至少一个泄漏成员的群数
+	LeakedMembers  int                // 泄漏的 (group, uid) 去重对数
+	ThreadsScanned int                // 受影响群下非 deleted 子区总数
+	PairsPlanned   int                // 计划摘除的 (uid, 子区) 订阅对总数
+	PairsRemoved   int                // 实际摘除成功的订阅对数（dry-run 恒为 0）
+	IMCalls        int                // 实际发起的 IMRemoveSubscriber 调用次数
+	Failures       []ReconcileFailure // 失败项（不中断）
+}
+
+// String 渲染人类可读的报告。
+func (r *ReconcileReport) String() string {
+	mode := "APPLY"
+	if r.DryRun {
+		mode = "DRY-RUN (未实际摘除任何订阅；加 --apply 才执行)"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "子区订阅泄漏对账报告 [%s]\n", mode)
+	fmt.Fprintf(&b, "  受影响群数:        %d\n", r.GroupsAffected)
+	fmt.Fprintf(&b, "  泄漏成员数(去重):  %d\n", r.LeakedMembers)
+	fmt.Fprintf(&b, "  扫描子区数:        %d\n", r.ThreadsScanned)
+	fmt.Fprintf(&b, "  计划摘除订阅对:    %d\n", r.PairsPlanned)
+	if !r.DryRun {
+		fmt.Fprintf(&b, "  实际摘除订阅对:    %d\n", r.PairsRemoved)
+		fmt.Fprintf(&b, "  IM 调用次数:       %d\n", r.IMCalls)
+	}
+	fmt.Fprintf(&b, "  失败项:            %d\n", len(r.Failures))
+	for _, f := range r.Failures {
+		fmt.Fprintf(&b, "    - group=%s channel=%s uids=%d err=%s\n",
+			f.GroupNo, f.ChannelID, len(f.UIDs), f.Err)
+	}
+	return b.String()
+}
+
+// ThreadSubscriptionReconciler 是存量子区订阅泄漏的一次性对账器。
+type ThreadSubscriptionReconciler struct {
+	ctx    *config.Context
+	logger log.Log
+	// removeFn 摘除某子区频道下一批 uid 的订阅。默认包一层 ctx.IMRemoveSubscriber，
+	// 抽成字段是为了让单测无需真实 WuKongIM 也能验证“扫描 + 幂等 + dry-run 不写”逻辑。
+	removeFn func(channelID string, uids []string) error
+}
+
+// RunThreadSubscriptionReconcile 是给 main.go 子命令用的导出入口：构造对账器并执行一次，
+// 返回报告。把入口放在 group 包内是为了复用包内未导出的 queryThreadShortIDsForCleanup，
+// 不把内部清理逻辑外泄到 cmd 层。
+func RunThreadSubscriptionReconcile(ctx *config.Context, logger log.Log, opts ReconcileOptions) (*ReconcileReport, error) {
+	return NewThreadSubscriptionReconciler(ctx, logger).Run(opts)
+}
+
+// NewThreadSubscriptionReconciler 构造对账器。logger 由调用方传入以保留 module 标签。
+func NewThreadSubscriptionReconciler(ctx *config.Context, logger log.Log) *ThreadSubscriptionReconciler {
+	r := &ThreadSubscriptionReconciler{ctx: ctx, logger: logger}
+	r.removeFn = func(channelID string, uids []string) error {
+		return ctx.IMRemoveSubscriber(&config.SubscriberRemoveReq{
+			ChannelID:   channelID,
+			ChannelType: common.ChannelTypeCommunityTopic.Uint8(),
+			Subscribers: uids,
+		})
+	}
+	return r
+}
+
+// groupPlan 是单个群的对账计划：哪些 uid（泄漏成员）要在哪些子区（shortID）摘订阅。
+type groupPlan struct {
+	groupNo  string
+	uids     []string
+	shortIDs []string
+}
+
+// scanLeakedMembers 扫 group_member，返回每个群的泄漏成员（按 group_no 聚合、uid 去重）。
+// 泄漏判定：is_deleted=1 OR status=blacklist（与 Issue 描述一致）。
+func (r *ThreadSubscriptionReconciler) scanLeakedMembers() (map[string][]string, error) {
+	type leakedRow struct {
+		GroupNo string `db:"group_no"`
+		UID     string `db:"uid"`
+	}
+	var rows []leakedRow
+	_, err := r.ctx.DB().Select("group_no", "uid").
+		From("group_member").
+		Where("is_deleted=1 OR status=?", int(common.GroupMemberStatusBlacklist)).
+		OrderAsc("group_no").
+		Load(&rows)
+	if err != nil {
+		return nil, err
+	}
+	// 按 group_no 聚合 + uid 去重（同一成员可能同时 is_deleted=1 且 blacklist）。
+	byGroup := make(map[string][]string)
+	seen := make(map[string]map[string]struct{})
+	for _, row := range rows {
+		if row.GroupNo == "" || row.UID == "" {
+			continue
+		}
+		if seen[row.GroupNo] == nil {
+			seen[row.GroupNo] = make(map[string]struct{})
+		}
+		if _, dup := seen[row.GroupNo][row.UID]; dup {
+			continue
+		}
+		seen[row.GroupNo][row.UID] = struct{}{}
+		byGroup[row.GroupNo] = append(byGroup[row.GroupNo], row.UID)
+	}
+	return byGroup, nil
+}
+
+// buildPlan 把泄漏成员 + 各群非 deleted 子区组合成对账计划，并填好统计字段。
+// 查子区失败的群按失败记录、跳过（不中断整体对账）。
+func (r *ThreadSubscriptionReconciler) buildPlan(report *ReconcileReport) ([]groupPlan, error) {
+	byGroup, err := r.scanLeakedMembers()
+	if err != nil {
+		return nil, err
+	}
+	plans := make([]groupPlan, 0, len(byGroup))
+	for groupNo, uids := range byGroup {
+		report.GroupsAffected++
+		report.LeakedMembers += len(uids)
+
+		shortIDs, qerr := queryThreadShortIDsForCleanup(r.ctx, groupNo)
+		if qerr != nil {
+			r.logger.Error("对账查询群子区失败", zap.Error(qerr), zap.String("groupNo", groupNo))
+			report.Failures = append(report.Failures, ReconcileFailure{
+				GroupNo: groupNo,
+				Err:     "query threads: " + qerr.Error(),
+			})
+			continue
+		}
+		if len(shortIDs) == 0 {
+			continue
+		}
+		report.ThreadsScanned += len(shortIDs)
+		report.PairsPlanned += len(uids) * len(shortIDs)
+		plans = append(plans, groupPlan{groupNo: groupNo, uids: uids, shortIDs: shortIDs})
+	}
+	return plans, nil
+}
+
+// Run 执行对账。dry-run（Apply=false）只统计不写；Apply=true 才逐子区批量摘订阅。
+func (r *ThreadSubscriptionReconciler) Run(opts ReconcileOptions) (*ReconcileReport, error) {
+	report := &ReconcileReport{DryRun: !opts.Apply}
+
+	plans, err := r.buildPlan(report)
+	if err != nil {
+		return report, err
+	}
+	if !opts.Apply {
+		// dry-run：到此为止，绝不调用 removeFn。
+		return report, nil
+	}
+
+	batchSize := opts.BatchSize
+	if batchSize <= 0 {
+		batchSize = defaultReconcileBatchSize
+	}
+
+	for _, p := range plans {
+		for _, shortID := range p.shortIDs {
+			// 子区 channelID 格式: {groupNo}____{shortID}（与 thread.BuildChannelID 及
+			// removeUserFromGroupThreadsCleanup 一致）。
+			channelID := p.groupNo + "____" + shortID
+			for start := 0; start < len(p.uids); start += batchSize {
+				end := start + batchSize
+				if end > len(p.uids) {
+					end = len(p.uids)
+				}
+				chunk := p.uids[start:end]
+
+				if opts.Interval > 0 {
+					time.Sleep(opts.Interval)
+				}
+				report.IMCalls++
+				if rmErr := r.removeFn(channelID, chunk); rmErr != nil {
+					// 失败只记录不中断：单个子区/批次失败不应阻断其余存量对账。
+					r.logger.Error("对账摘除子区IM订阅失败",
+						zap.Error(rmErr), zap.String("channelID", channelID), zap.Int("uids", len(chunk)))
+					report.Failures = append(report.Failures, ReconcileFailure{
+						GroupNo:   p.groupNo,
+						ChannelID: channelID,
+						UIDs:      append([]string(nil), chunk...),
+						Err:       rmErr.Error(),
+					})
+					continue
+				}
+				report.PairsRemoved += len(chunk)
+			}
+		}
+	}
+	return report, nil
+}

--- a/modules/group/thread_subscription_reconcile_test.go
+++ b/modules/group/thread_subscription_reconcile_test.go
@@ -1,0 +1,211 @@
+package group
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// imCall 记录一次 removeFn 调用，供测试断言 dry-run 不写 / apply 实际摘除 / 幂等重跑。
+type imCall struct {
+	channelID string
+	uids      []string
+}
+
+// newTestReconciler 构造一个用假 removeFn 的对账器：把每次摘订阅调用录进 calls，
+// 无需真实 WuKongIM 即可验证扫描 / dry-run / apply / 幂等逻辑。
+func newTestReconciler(t *testing.T) (*ThreadSubscriptionReconciler, *[]imCall) {
+	t.Helper()
+	svc, _ := setupServiceTest(t)
+	s := svc.(*Service)
+	f := New(s.ctx)
+	ensureThreadTables(t, f)
+
+	calls := &[]imCall{}
+	r := NewThreadSubscriptionReconciler(s.ctx, s.Log)
+	r.removeFn = func(channelID string, uids []string) error {
+		*calls = append(*calls, imCall{channelID: channelID, uids: append([]string(nil), uids...)})
+		return nil
+	}
+	return r, calls
+}
+
+func insertThread(t *testing.T, r *ThreadSubscriptionReconciler, shortID, groupNo string, status int) {
+	t.Helper()
+	_, err := r.ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values(shortID, groupNo, shortID, "owner", status, 1).Exec()
+	require.NoError(t, err)
+}
+
+func insertMember(t *testing.T, r *ThreadSubscriptionReconciler, groupNo, uid string, isDeleted, status int) {
+	t.Helper()
+	_, err := r.ctx.DB().InsertInto("group_member").
+		Columns("group_no", "uid", "is_deleted", "status", "version").
+		Values(groupNo, uid, isDeleted, status, 1).Exec()
+	require.NoError(t, err)
+}
+
+// TestReconcile_ScansLeakedMembersAndThreads 覆盖核心扫描逻辑：
+// is_deleted=1 与 status=blacklist 的成员都要被识别为泄漏，正常成员被排除；
+// 计划摘除对数 = 泄漏成员数 × 该群非 deleted 子区数。
+func TestReconcile_ScansLeakedMembersAndThreads(t *testing.T) {
+	r, calls := newTestReconciler(t)
+	const groupNo = "g_scan"
+
+	// 两个非 deleted 子区（active + archived）+ 一个 deleted（必须排除）
+	insertThread(t, r, "th_active", groupNo, 1)
+	insertThread(t, r, "th_archived", groupNo, 2)
+	insertThread(t, r, "th_deleted", groupNo, 3)
+
+	// 泄漏成员：被踢(is_deleted=1) + 被拉黑(status=blacklist)
+	insertMember(t, r, groupNo, "u_kicked", 1, int(common.GroupMemberStatusNormal))
+	insertMember(t, r, groupNo, "u_black", 0, int(common.GroupMemberStatusBlacklist))
+	// 正常成员：不应被摘
+	insertMember(t, r, groupNo, "u_normal", 0, int(common.GroupMemberStatusNormal))
+
+	report, err := r.Run(ReconcileOptions{Apply: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, report.GroupsAffected)
+	assert.Equal(t, 2, report.LeakedMembers)
+	assert.Equal(t, 2, report.ThreadsScanned)
+	assert.Equal(t, 4, report.PairsPlanned, "2 泄漏成员 × 2 非 deleted 子区")
+	assert.Equal(t, 4, report.PairsRemoved)
+	assert.Empty(t, report.Failures)
+
+	// 断言只摘了泄漏成员、且只在非 deleted 子区频道
+	removed := map[string]map[string]bool{}
+	for _, c := range *calls {
+		if removed[c.channelID] == nil {
+			removed[c.channelID] = map[string]bool{}
+		}
+		for _, u := range c.uids {
+			removed[c.channelID][u] = true
+		}
+	}
+	for _, ch := range []string{groupNo + "____th_active", groupNo + "____th_archived"} {
+		assert.True(t, removed[ch]["u_kicked"], "被踢成员应在 %s 被摘", ch)
+		assert.True(t, removed[ch]["u_black"], "被拉黑成员应在 %s 被摘", ch)
+		assert.False(t, removed[ch]["u_normal"], "正常成员不应被摘")
+	}
+	assert.Nil(t, removed[groupNo+"____th_deleted"], "deleted 子区频道不应被触碰")
+}
+
+// TestReconcile_DryRunDoesNotWrite 是验收要求的核心：默认 dry-run 只统计，绝不调用 removeFn。
+func TestReconcile_DryRunDoesNotWrite(t *testing.T) {
+	r, calls := newTestReconciler(t)
+	const groupNo = "g_dryrun"
+
+	insertThread(t, r, "th1", groupNo, 1)
+	insertThread(t, r, "th2", groupNo, 1)
+	insertMember(t, r, groupNo, "u_kicked", 1, int(common.GroupMemberStatusNormal))
+	insertMember(t, r, groupNo, "u_black", 0, int(common.GroupMemberStatusBlacklist))
+
+	report, err := r.Run(ReconcileOptions{Apply: false})
+	require.NoError(t, err)
+
+	assert.True(t, report.DryRun)
+	assert.Equal(t, 4, report.PairsPlanned, "dry-run 仍要算出将摘除多少对")
+	assert.Equal(t, 0, report.PairsRemoved, "dry-run 不得实际摘除")
+	assert.Equal(t, 0, report.IMCalls)
+	assert.Empty(t, *calls, "dry-run 绝不能调用 IMRemoveSubscriber")
+}
+
+// TestReconcile_Idempotent 验证重复执行安全：连续两次 apply，第二次行为与第一次一致
+// （IMRemoveSubscriber 对不存在订阅是 no-op，故工具侧每次都照常下发、统计稳定）。
+func TestReconcile_Idempotent(t *testing.T) {
+	r, calls := newTestReconciler(t)
+	const groupNo = "g_idem"
+
+	insertThread(t, r, "th1", groupNo, 1)
+	insertMember(t, r, groupNo, "u_black", 0, int(common.GroupMemberStatusBlacklist))
+
+	r1, err := r.Run(ReconcileOptions{Apply: true})
+	require.NoError(t, err)
+	firstCalls := len(*calls)
+
+	r2, err := r.Run(ReconcileOptions{Apply: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, r1.PairsRemoved, r2.PairsRemoved, "重跑摘除对数应一致")
+	assert.Equal(t, r1.PairsPlanned, r2.PairsPlanned)
+	assert.Equal(t, firstCalls*2, len(*calls), "重跑安全：第二次照常下发，无异常")
+}
+
+// TestReconcile_DedupesMemberAcrossDeletedAndBlacklist 验证同一成员同时 is_deleted=1
+// 且 blacklist 时只算一次（OR 条件可能让聚合前重复出现）。
+func TestReconcile_DedupesMemberAcrossDeletedAndBlacklist(t *testing.T) {
+	r, _ := newTestReconciler(t)
+	const groupNo = "g_dedup"
+
+	insertThread(t, r, "th1", groupNo, 1)
+	// 一个成员既被踢又被拉黑
+	insertMember(t, r, groupNo, "u_both", 1, int(common.GroupMemberStatusBlacklist))
+
+	report, err := r.Run(ReconcileOptions{Apply: true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.LeakedMembers, "同一成员只算一次")
+	assert.Equal(t, 1, report.PairsRemoved)
+}
+
+// TestReconcile_FailureRecordedNotAborted 验证“失败只记录不中断”：某次摘除报错时，
+// 其余订阅对仍继续处理，失败被收进 report.Failures。
+func TestReconcile_FailureRecordedNotAborted(t *testing.T) {
+	r, _ := newTestReconciler(t)
+	const groupNo = "g_fail"
+
+	insertThread(t, r, "th_bad", groupNo, 1)
+	insertThread(t, r, "th_ok", groupNo, 1)
+	insertMember(t, r, groupNo, "u_black", 0, int(common.GroupMemberStatusBlacklist))
+
+	badChannel := groupNo + "____th_bad"
+	r.removeFn = func(channelID string, uids []string) error {
+		if channelID == badChannel {
+			return errors.New("boom")
+		}
+		return nil
+	}
+
+	report, err := r.Run(ReconcileOptions{Apply: true})
+	require.NoError(t, err)
+	require.Len(t, report.Failures, 1)
+	assert.Equal(t, badChannel, report.Failures[0].ChannelID)
+	assert.Equal(t, 1, report.PairsRemoved, "失败不影响其余子区继续摘除")
+}
+
+// TestReconcile_NoLeakedMembers 空结果：没有泄漏成员时报告全 0、无调用。
+func TestReconcile_NoLeakedMembers(t *testing.T) {
+	r, calls := newTestReconciler(t)
+	const groupNo = "g_clean"
+
+	insertThread(t, r, "th1", groupNo, 1)
+	insertMember(t, r, groupNo, "u_normal", 0, int(common.GroupMemberStatusNormal))
+
+	report, err := r.Run(ReconcileOptions{Apply: true})
+	require.NoError(t, err)
+	assert.Equal(t, 0, report.GroupsAffected)
+	assert.Equal(t, 0, report.PairsPlanned)
+	assert.Empty(t, *calls)
+}
+
+// TestReconcile_BatchingSplitsUIDs 验证大群分批：batch-size 小于泄漏成员数时，
+// 同一子区频道的摘除拆成多次调用，但摘除总对数不变。
+func TestReconcile_BatchingSplitsUIDs(t *testing.T) {
+	r, calls := newTestReconciler(t)
+	const groupNo = "g_batch"
+
+	insertThread(t, r, "th1", groupNo, 1)
+	insertMember(t, r, groupNo, "u1", 1, int(common.GroupMemberStatusNormal))
+	insertMember(t, r, groupNo, "u2", 1, int(common.GroupMemberStatusNormal))
+	insertMember(t, r, groupNo, "u3", 1, int(common.GroupMemberStatusNormal))
+
+	report, err := r.Run(ReconcileOptions{Apply: true, BatchSize: 2})
+	require.NoError(t, err)
+	assert.Equal(t, 3, report.PairsRemoved)
+	assert.Equal(t, 2, report.IMCalls, "3 个 uid / 批大小 2 = 2 次调用")
+	assert.Len(t, *calls, 2)
+}


### PR DESCRIPTION
## What

Adds a one-off, idempotent, dry-run-first maintenance command that removes
stale community-topic (thread) subscriptions left in the IM layer for members
who are no longer eligible.

Event-driven fixes only handle removals that happen *going forward*; they don't
reconcile subscriptions that leaked before the fix shipped. This command closes
that gap as a one-time backfill.

## Scope

- Scans `group_member` for members with `is_deleted=1` OR blacklist status.
- For each `(group_no, uid)`, reuses the existing
  `queryThreadShortIDsForCleanup` helper to enumerate all non-deleted threads
  of that group and removes the user's subscription on each thread channel.
- **Only removes IM subscriptions** — it does not delete `thread_member` /
  `thread_setting` rows or touch pins / conversation extensions. (This is
  deliberately narrower than the kick/leave cleanup path.)

## Safety

- **Dry-run by default**: without `--apply` it only counts the
  `(uid, thread)` pairs that would be removed; it never calls the IM API.
- **Idempotent**: subscriber removal is a no-op for non-existent
  subscriptions, so re-runs are safe.
- **Rate limiting**: `--batch-size` and `--interval` bound the load on the IM
  service for large groups.
- **Failures are recorded, not fatal**: a failed call is logged and collected
  into the report; the run continues and exits non-zero if any failures
  occurred.

## Usage

```bash
# dry-run (default): only report counts
./app -config configs/tsdd.yaml reconcile-thread-subs

# apply, with rate limiting
./app -config configs/tsdd.yaml reconcile-thread-subs --apply --interval 200ms --batch-size 50
```

See `docs/thread-subscription-reconcile-runbook.md` for the full runbook
(dry-run vs apply, parameters, exit codes, rollback/impact notes).

## Tests

New unit tests cover scanning, dry-run-does-not-write, idempotency, batching,
and failure-isolation. `go build ./...`, `go vet ./...`, and the group package
tests all pass.

## Rollback

No rollback needed — the tool only removes IM subscriptions and deletes no
data. Affected users are already kicked/left/blacklisted and should not be
receiving those thread messages anyway.

Part of #YUJ-4186

<!-- sprint-set-retrigger -->