### PR TITLE
fix(group): close remaining thread-subscription cleanup gaps + exclude blacklist from subscriber source (续 #27/#332)

### DIFF
--- a/modules/group/1module.go
+++ b/modules/group/1module.go
@@ -65,15 +65,14 @@ func init() {
 				},
 				Subscribers: func(channelID string, channelType uint8) ([]string, error) {
 
-					mebmers, err := api.groupService.GetMembers(channelID)
+					// 父群权威订阅源排除被拉黑成员（status=blacklist）：WuKongIM 缓存
+					// 这份列表做 WS push，若含黑名单用户，重载订阅会把他加回 → 拉黑后
+					// 仍能收父群实时消息（YUJ-4185 P0-2 根因收口，使 blacklist handler 的
+					// 父群 IMRemoveSubscriber 持久生效）。Blacklist 回调仍单独返回黑名单
+					// 挡发送，两者互补。
+					subscribers, err := api.groupService.GetSubscribableMemberUIDs(channelID)
 					if err != nil {
 						return nil, err
-					}
-					subscribers := make([]string, 0)
-					if len(mebmers) > 0 {
-						for _, member := range mebmers {
-							subscribers = append(subscribers, member.UID)
-						}
 					}
 					return subscribers, nil
 				},

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -3154,6 +3154,20 @@ func (g *Group) blacklist(c *wkhttp.Context) {
 			httperr.ResponseErrorL(c, errcode.ErrGroupStoreFailed, nil, nil)
 			return
 		}
+		// YUJ-4185 P0-1：拉黑 add 分支必须主动摘除每个被拉黑 uid 的子区 + 父群 IM 订阅。
+		// 仅靠 setGroupBlacklist(IMBlacklistAdd) 只挡“发送”，不断“接收”——被拉黑者仍
+		// 通过 WuKongIM WS 收子区/父群实时消息（越权读 P0）。子区订阅复用 #27/#332 统一
+		// helper；父群订阅显式 IMRemoveSubscriber。best-effort：失败只记日志、不回滚拉黑。
+		for _, uid := range req.Uids {
+			g.removeUserFromGroupThreads(groupNo, uid, group.SpaceID)
+		}
+		if rmErr := g.ctx.IMRemoveSubscriber(&config.SubscriberRemoveReq{
+			ChannelID:   groupNo,
+			ChannelType: common.ChannelTypeGroup.Uint8(),
+			Subscribers: req.Uids,
+		}); rmErr != nil {
+			g.Error("拉黑摘除父群IM订阅失败", zap.Error(rmErr), zap.String("groupNo", groupNo))
+		}
 	} else {
 		members, err := g.db.QueryMembersWithUids(req.Uids, groupNo)
 		if err != nil {
@@ -3178,6 +3192,18 @@ func (g *Group) blacklist(c *wkhttp.Context) {
 				httperr.ResponseErrorL(c, errcode.ErrGroupStoreFailed, nil, nil)
 				return
 			}
+			// YUJ-4185 P0-1：解除拉黑必须对称恢复订阅（add 分支摘掉了父群+子区订阅）。
+			// updateMembersStatus 已把 status 改回 Normal，此处把这些成员重新挂回父群和
+			// 群内所有非删除子区的 IM 订阅，参考入群 addUsersToGroupThreads。
+			// best-effort：失败只记日志，不回滚解除黑名单。
+			if addErr := g.ctx.IMAddSubscriber(&config.SubscriberAddReq{
+				ChannelID:   groupNo,
+				ChannelType: common.ChannelTypeGroup.Uint8(),
+				Subscribers: removeUIDs,
+			}); addErr != nil {
+				g.Error("解除拉黑恢复父群IM订阅失败", zap.Error(addErr), zap.String("groupNo", groupNo))
+			}
+			g.addUsersToGroupThreads(groupNo, removeUIDs)
 		}
 	}
 	if group.GroupType == int(GroupTypeCommon) {

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -422,6 +422,24 @@ func (d *DB) queryBlacklistMemberUIDsWithGroupNo(groupNo string) ([]string, erro
 	return uids, err
 }
 
+// querySubscribableMemberUIDsWithGroupNo 返回某群「可订阅」成员 uid 集合：
+// is_deleted=0 AND status=GroupMemberStatusNormal，即排除被拉黑（status=blacklist）的成员。
+// 子区(channel_type=CommunityTopic) 实时下发的权威订阅源就读这份列表（thread/1module.go
+// Subscribers 回调），WuKongIM 缓存它做 WebSocket push。被拉黑成员若仍出现在这里，即使
+// 上层主动 IMRemoveSubscriber，下一次 WuKongIM 重载 Subscribers 仍会把他加回去 → 拉黑
+// 不自愈（YUJ-4185 P0-2 根因）。
+//
+// 与 queryMembersWithGroupNo（GetMembers，多处复用、语义是“所有非删除成员”）分开，
+// 不改动既有调用方语义；只有需要“能收实时推送的成员”的订阅数据源走这里。
+func (d *DB) querySubscribableMemberUIDsWithGroupNo(groupNo string) ([]string, error) {
+	var uids []string
+	_, err := d.session.Select("group_member.uid").
+		From("group_member").
+		Where("group_member.group_no=? and group_member.is_deleted=0 and status=?", groupNo, common.GroupMemberStatusNormal).
+		Load(&uids)
+	return uids, err
+}
+
 // 查询在线成员数量
 func (d *DB) queryMemberOnlineCount(groupNo string) (int64, error) {
 	var count int64

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -193,6 +193,20 @@ func (d *DB) existMembers(groupNos []string, uid string) ([]string, error) {
 	return results, err
 }
 
+// existMembersActive 是 existMembers 的白名单（fail closed）批量变体：在 is_deleted=0
+// 之外额外要求 status=GroupMemberStatusNormal，即把被拉黑（status=Blacklist）以及未来
+// 可能新增的非正常状态成员从结果里排除。
+// 与单群的 ExistMemberActive 语义一致，专供「子区(CommunityTopic)读/发门禁」这类绕过
+// IM datasource、直查本地分表的批量校验使用，避免被拉黑用户仍出现在“仍是成员”的集合里
+// 进而越权读子区历史/会话（YUJ-4185 CR 整改）。
+func (d *DB) existMembersActive(groupNos []string, uid string) ([]string, error) {
+	var results []string
+	_, err := d.session.Select("group_no").From("group_member").
+		Where("group_no in ? and uid=? and is_deleted=0 and status=?",
+			groupNos, uid, common.GroupMemberStatusNormal).Load(&results)
+	return results, err
+}
+
 // ExistMemberDelete 存在已删除的群成员数据
 func (d *DB) ExistMemberDelete(uid string, groupNo string) (bool, error) {
 	var count int64

--- a/modules/group/event.go
+++ b/modules/group/event.go
@@ -49,9 +49,10 @@ func (g *Group) handleGroupDisbandEvent(data []byte, commit config.EventCommit) 
 		})),
 	})
 	if err != nil {
+		// YUJ-4185 P1-1：解散提示是装饰性通知，best-effort 即可。绝不能因它失败就
+		// return —— 否则后续频道删除 / 子区订阅清理被跳过，群处于“半解散”状态：
+		// 成员仍订阅父群 / 子区频道，继续收消息（越权读）。只记日志，继续清理。
 		g.Error("发送解散群消息错误", zap.Error(err))
-		commit(err)
-		return
 	}
 	// 删除channel
 	err = g.ctx.IMDelChannel(&config.ChannelDeleteReq{
@@ -62,6 +63,39 @@ func (g *Group) handleGroupDisbandEvent(data []byte, commit config.EventCommit) 
 		g.Error("删除IM频道失败", zap.Error(err))
 		commit(err)
 		return
+	}
+	// YUJ-4185 P1-1：群解散必须连同所有子区(CommunityTopic)频道一起销毁，否则子区的
+	// IM 频道仍存活、成员订阅未摘 → 解散后成员仍能通过子区频道收/拉历史消息（越权读）。
+	// 直接 IMDelChannel 每个非删除子区频道（频道删除即断所有订阅），再清成员对子区的
+	// 置顶 / 会话扩展。best-effort：单个子区清理失败只记日志，不阻塞父群解散。
+	threadShortIDs, threadErr := queryThreadShortIDsForCleanup(g.ctx, req.GroupNo)
+	if threadErr != nil {
+		g.Error("查询群子区失败（解散清理）", zap.Error(threadErr), zap.String("groupNo", req.GroupNo))
+	}
+	for _, shortID := range threadShortIDs {
+		threadChannelID := req.GroupNo + "____" + shortID
+		if delErr := g.ctx.IMDelChannel(&config.ChannelDeleteReq{
+			ChannelID:   threadChannelID,
+			ChannelType: common.ChannelTypeCommunityTopic.Uint8(),
+		}); delErr != nil {
+			g.Error("删除子区IM频道失败（解散清理）", zap.Error(delErr), zap.String("channelID", threadChannelID))
+		}
+		user.RemovePinnedForChannel(threadChannelID, common.ChannelTypeCommunityTopic.Uint8())
+		conversation_ext.RemoveConvExtForChannel(threadChannelID, common.ChannelTypeCommunityTopic.Uint8())
+	}
+	// 删除该群所有子区的成员 / 个人设置行，避免解散后残留脏数据（频道已销毁，
+	// 这些行不再有意义）。best-effort：失败只记日志。
+	if len(threadShortIDs) > 0 {
+		if _, delErr := g.ctx.DB().DeleteFrom("thread_member").
+			Where("thread_id IN (SELECT id FROM thread WHERE group_no=?)", req.GroupNo).
+			Exec(); delErr != nil {
+			g.Error("删除子区成员记录失败（解散清理）", zap.Error(delErr), zap.String("groupNo", req.GroupNo))
+		}
+		if _, delErr := g.ctx.DB().DeleteFrom("thread_setting").
+			Where("group_no=?", req.GroupNo).
+			Exec(); delErr != nil {
+			g.Error("删除子区个人设置失败（解散清理）", zap.Error(delErr), zap.String("groupNo", req.GroupNo))
+		}
 	}
 	// 清理所有用户对该群的置顶
 	user.RemovePinnedForChannel(req.GroupNo, common.ChannelTypeGroup.Uint8())
@@ -621,6 +655,13 @@ func (g *Group) handleOrgOrDeptEmployeeUpdate(data []byte, commit config.EventCo
 	}
 
 	if len(deleteMembers) > 0 {
+		// YUJ-4185 P1-2：组织/部门结构更新删人也要摘子区订阅，与已修的
+		// handleOrgEmployeeExit / 踢人 / 退群 对称。按 groupNo 取 SpaceID 供 helper
+		// 清理 Space 维度的 pinned / 会话扩展。
+		spaceIDByGroupNo := make(map[string]string, len(groups))
+		for _, grp := range groups {
+			spaceIDByGroupNo[grp.GroupNo] = grp.SpaceID
+		}
 		for _, m := range deleteMembers {
 			members := make([]string, 0)
 			for index := range m.Members {
@@ -635,6 +676,11 @@ func (g *Group) handleOrgOrDeptEmployeeUpdate(data []byte, commit config.EventCo
 				g.Error("调用IM的订阅接口失败！", zap.Error(err))
 				commit(err)
 				return
+			}
+			// Issue #27 同型：组织/部门删人必须摘除该 uid 在群内所有非删除子区的
+			// IM 订阅（复用统一 helper，best-effort）。
+			for _, uid := range members {
+				g.removeUserFromGroupThreads(m.GroupNo, uid, spaceIDByGroupNo[m.GroupNo])
 			}
 			// 发送群成员更新命令
 			err = g.ctx.SendCMD(config.MsgCMDReq{

--- a/modules/group/event.go
+++ b/modules/group/event.go
@@ -25,6 +25,14 @@ func (g *Group) handleGroupDisbandEvent(data []byte, commit config.EventCommit) 
 		commit(nil)
 		return
 	}
+	if req.GroupNo == "" {
+		// 空 groupNo 守卫：对齐 handleOrgEmployeeExit。空值会让下游清理退化为
+		// 全表/无目标的危险 SQL（如 thread_member 子查询、IMDelChannel 空频道），
+		// best-effort 提交后直接 return。
+		g.Error("解散群groupNo不能为空", zap.Error(errors.New("解散群groupNo不能为空")))
+		commit(nil)
+		return
+	}
 
 	content := "{0}已解散该群聊"
 	err = g.ctx.SendMessage(&config.MsgSendReq{
@@ -85,17 +93,20 @@ func (g *Group) handleGroupDisbandEvent(data []byte, commit config.EventCommit) 
 	}
 	// 删除该群所有子区的成员 / 个人设置行，避免解散后残留脏数据（频道已销毁，
 	// 这些行不再有意义）。best-effort：失败只记日志。
-	if len(threadShortIDs) > 0 {
-		if _, delErr := g.ctx.DB().DeleteFrom("thread_member").
-			Where("thread_id IN (SELECT id FROM thread WHERE group_no=?)", req.GroupNo).
-			Exec(); delErr != nil {
-			g.Error("删除子区成员记录失败（解散清理）", zap.Error(delErr), zap.String("groupNo", req.GroupNo))
-		}
-		if _, delErr := g.ctx.DB().DeleteFrom("thread_setting").
-			Where("group_no=?", req.GroupNo).
-			Exec(); delErr != nil {
-			g.Error("删除子区个人设置失败（解散清理）", zap.Error(delErr), zap.String("groupNo", req.GroupNo))
-		}
+	// 不 gate 在 len(threadShortIDs) > 0 上：对齐 removeUserFromGroupThreadsCleanup
+	// 的“不 gate 扫残留”约定 —— 用户可能只 mute 过子区而从未 JoinThread（Issue #331），
+	// 或子区已被删除（不在 queryThreadShortIDsForCleanup 的存活集合里）但 thread_member /
+	// thread_setting 仍有残留行。这两条 DELETE 按 group_no 直删，把残留一并清掉。
+	// req.GroupNo 非空已在函数开头守卫，子查询不会退化为全表。
+	if _, delErr := g.ctx.DB().DeleteFrom("thread_member").
+		Where("thread_id IN (SELECT id FROM thread WHERE group_no=?)", req.GroupNo).
+		Exec(); delErr != nil {
+		g.Error("删除子区成员记录失败（解散清理）", zap.Error(delErr), zap.String("groupNo", req.GroupNo))
+	}
+	if _, delErr := g.ctx.DB().DeleteFrom("thread_setting").
+		Where("group_no=?", req.GroupNo).
+		Exec(); delErr != nil {
+		g.Error("删除子区个人设置失败（解散清理）", zap.Error(delErr), zap.String("groupNo", req.GroupNo))
 	}
 	// 清理所有用户对该群的置顶
 	user.RemovePinnedForChannel(req.GroupNo, common.ChannelTypeGroup.Uint8())

--- a/modules/group/event_disband_thread_test.go
+++ b/modules/group/event_disband_thread_test.go
@@ -1,0 +1,82 @@
+package group
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleGroupDisbandEvent_CleansThreadMembers 回归 YUJ-4185 P1-1：群解散原本
+// 只 IMDelChannel 父群 + 清父群 pinned，不遍历子区 —— 子区频道仍存活、成员订阅未摘，
+// 解散后成员仍能经子区频道收/拉历史（越权读）。修复后解散遍历所有非删除子区，
+// 删除子区 IM 频道并清成员订阅 / 置顶。DB-level 断言：thread_member 被清空。
+func TestHandleGroupDisbandEvent_CleansThreadMembers(t *testing.T) {
+	svc, userDB := setupServiceTest(t)
+	s := svc.(*Service)
+	f := New(s.ctx)
+	ensureThreadTables(t, f)
+
+	insertTestUsers(t, userDB, "db_owner", "db_member")
+
+	spaceID := "space_disband"
+	groupNo := "g_disband_thread"
+	require.NoError(t, f.db.Insert(&Model{
+		GroupNo: groupNo, Name: "disband-thread", Creator: "db_owner",
+		SpaceID: spaceID, Status: 1,
+	}))
+	require.NoError(t, f.db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: "db_owner", Role: MemberRoleCreator,
+		Status: 1, Version: 1, Vercode: fmt.Sprintf("%s@1", util.GenerUUID()),
+	}))
+	require.NoError(t, f.db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: "db_member", Role: MemberRoleCommon,
+		Status: 1, Version: 1, Vercode: fmt.Sprintf("%s@1", util.GenerUUID()),
+	}))
+
+	// 两个子区（active + archived），都要被清理
+	resActive, err := f.ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("disband_active", groupNo, "active-sub", "db_owner", 1, 1).Exec()
+	require.NoError(t, err)
+	activeID, err := resActive.LastInsertId()
+	require.NoError(t, err)
+	resArchived, err := f.ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("disband_archived", groupNo, "archived-sub", "db_owner", 2, 1).Exec()
+	require.NoError(t, err)
+	archivedID, err := resArchived.LastInsertId()
+	require.NoError(t, err)
+
+	for _, tid := range []int64{activeID, archivedID} {
+		_, err = f.ctx.DB().InsertInto("thread_member").
+			Columns("thread_id", "uid", "role", "version").
+			Values(tid, "db_member", 0, 1).Exec()
+		require.NoError(t, err)
+	}
+
+	payload := config.MsgGroupDisband{
+		GroupNo:      groupNo,
+		Operator:     "db_owner",
+		OperatorName: "owner",
+	}
+	var commitErr error
+	committed := false
+	f.handleGroupDisbandEvent([]byte(util.ToJson(payload)), func(err error) {
+		committed = true
+		commitErr = err
+	})
+	require.True(t, committed, "handler 必须调用 commit")
+	require.NoError(t, commitErr, "群解散处理不应报错")
+
+	// 核心断言：所有子区成员记录被清理（active + archived）
+	var postCount int
+	_, err = f.ctx.DB().Select("count(*)").From("thread_member").
+		Where("uid=? AND thread_id IN (SELECT id FROM thread WHERE group_no=?)", "db_member", groupNo).
+		Load(&postCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, postCount, "群解散必须清理所有子区成员/订阅（YUJ-4185 P1-1）")
+}

--- a/modules/group/event_orgupdate_thread_test.go
+++ b/modules/group/event_orgupdate_thread_test.go
@@ -1,0 +1,77 @@
+package group
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleOrgOrDeptEmployeeUpdate_DeleteAlsoCleansThreads 回归 YUJ-4185 P1-2：
+// 组织/部门结构更新删人（handleOrgOrDeptEmployeeUpdate 的 deleteMembers 分支）原本
+// 只摘父群 IM 订阅 + 发 CMD，漏掉子区清理 —— 与已修的 handleOrgEmployeeExit 不对称。
+// 修复后对每个被删 uid 调 removeUserFromGroupThreads。DB-level 断言直查 thread_member。
+func TestHandleOrgOrDeptEmployeeUpdate_DeleteAlsoCleansThreads(t *testing.T) {
+	svc, userDB := setupServiceTest(t)
+	s := svc.(*Service)
+	f := New(s.ctx)
+	ensureThreadTables(t, f)
+
+	insertTestUsers(t, userDB, "ou_owner", "ou_leaver")
+
+	spaceID := "space_orgupdate"
+	groupNo := "g_orgupdate_thread"
+	require.NoError(t, f.db.Insert(&Model{
+		GroupNo: groupNo, Name: "orgupdate-thread", Creator: "ou_owner",
+		SpaceID: spaceID, Status: 1,
+	}))
+	require.NoError(t, f.db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: "ou_owner", Role: MemberRoleCreator,
+		Status: 1, Version: 1, Vercode: fmt.Sprintf("%s@1", util.GenerUUID()),
+	}))
+	require.NoError(t, f.db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: "ou_leaver", Role: MemberRoleCommon,
+		Status: 1, Version: 1, Vercode: fmt.Sprintf("%s@1", util.GenerUUID()),
+	}))
+
+	res, err := f.ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("orgupd_thread", groupNo, "orgupd-sub", "ou_owner", 1, 1).Exec()
+	require.NoError(t, err)
+	threadID, err := res.LastInsertId()
+	require.NoError(t, err)
+	_, err = f.ctx.DB().InsertInto("thread_member").
+		Columns("thread_id", "uid", "role", "version").
+		Values(threadID, "ou_leaver", 0, 1).Exec()
+	require.NoError(t, err)
+
+	payload := config.MsgOrgOrDeptEmployeeUpdateReq{
+		Members: []*config.OrgOrDeptEmployeeVO{
+			{
+				Operator:     "ou_owner",
+				OperatorName: "owner",
+				EmployeeUid:  "ou_leaver",
+				EmployeeName: "leaver",
+				GroupNo:      groupNo,
+				Action:       "delete",
+			},
+		},
+	}
+	var commitErr error
+	committed := false
+	f.handleOrgOrDeptEmployeeUpdate([]byte(util.ToJson(payload)), func(err error) {
+		committed = true
+		commitErr = err
+	})
+	require.True(t, committed, "handler 必须调用 commit")
+	require.NoError(t, commitErr, "组织结构更新删人处理不应报错")
+
+	var postCount int
+	_, err = f.ctx.DB().Select("count(*)").From("thread_member").
+		Where("thread_id=? AND uid=?", threadID, "ou_leaver").Load(&postCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, postCount, "组织结构更新删人必须同步清理子区成员/订阅（YUJ-4185 P1-2）")
+}

--- a/modules/group/exist_member_active_test.go
+++ b/modules/group/exist_member_active_test.go
@@ -1,0 +1,108 @@
+package group
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExistMemberActive_ExcludesBlacklist 验证子区(CommunityTopic)读/发门禁的单群
+// 白名单校验：拉黑只把 status 翻成 Blacklist、is_deleted 仍为 0，普通 ExistMember
+// 仍返回 true（被拉黑用户可越权读子区历史/会话）。ExistMemberActive 必须额外要求
+// status=Normal，把黑名单成员挡在门外（YUJ-4212 CR 整改）。
+func TestExistMemberActive_ExcludesBlacklist(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	db := NewDB(ctx)
+	const groupNo = "g-yuj4212-active"
+
+	require.NoError(t, db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: "normal", Role: MemberRoleCommon,
+		Status: int(common.GroupMemberStatusNormal), Version: 1,
+	}))
+	require.NoError(t, db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: "blacklisted", Role: MemberRoleCommon,
+		Status: int(common.GroupMemberStatusBlacklist), Version: 2,
+	}))
+	require.NoError(t, db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: "deleted", Role: MemberRoleCommon,
+		Status: int(common.GroupMemberStatusNormal), Version: 3, IsDeleted: 1,
+	}))
+
+	// 现状对照：旧 ExistMember 对被拉黑用户仍返回 true（正是越权读的口子）。
+	blExist, err := db.ExistMember("blacklisted", groupNo)
+	require.NoError(t, err)
+	assert.True(t, blExist, "ExistMember 只过滤 is_deleted，黑名单仍过门（对照基线）")
+
+	// ExistMemberActive：正常成员过门
+	ok, err := db.ExistMemberActive("normal", groupNo)
+	require.NoError(t, err)
+	assert.True(t, ok, "正常成员必须过 ExistMemberActive")
+
+	// ExistMemberActive：被拉黑用户被拒
+	ok, err = db.ExistMemberActive("blacklisted", groupNo)
+	require.NoError(t, err)
+	assert.False(t, ok, "被拉黑成员必须被 ExistMemberActive 拒绝（子区越权读门禁）")
+
+	// ExistMemberActive：已删除用户被拒
+	ok, err = db.ExistMemberActive("deleted", groupNo)
+	require.NoError(t, err)
+	assert.False(t, ok, "已删除成员必须被 ExistMemberActive 拒绝")
+
+	// ExistMemberActive：非成员被拒
+	ok, err = db.ExistMemberActive("stranger", groupNo)
+	require.NoError(t, err)
+	assert.False(t, ok, "非成员必须被 ExistMemberActive 拒绝")
+}
+
+// TestExistMembersActive_ExcludesBlacklist 验证子区批量读门禁的白名单校验：
+// 旧 ExistMembers 把被拉黑用户所在群也算进“仍是成员”的集合，使其会话列表/sidebar
+// 仍透出子区。ExistMembersActive 必须只返回 status=Normal AND is_deleted=0 的群编号
+// （YUJ-4212 CR 整改）。
+func TestExistMembersActive_ExcludesBlacklist(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	db := NewDB(ctx)
+	const uid = "u-yuj4212"
+	const gNormal = "g-active-normal"
+	const gBlack = "g-active-black"
+	const gDeleted = "g-active-deleted"
+	const gStranger = "g-active-stranger"
+
+	require.NoError(t, db.InsertMember(&MemberModel{
+		GroupNo: gNormal, UID: uid, Role: MemberRoleCommon,
+		Status: int(common.GroupMemberStatusNormal), Version: 1,
+	}))
+	require.NoError(t, db.InsertMember(&MemberModel{
+		GroupNo: gBlack, UID: uid, Role: MemberRoleCommon,
+		Status: int(common.GroupMemberStatusBlacklist), Version: 2,
+	}))
+	require.NoError(t, db.InsertMember(&MemberModel{
+		GroupNo: gDeleted, UID: uid, Role: MemberRoleCommon,
+		Status: int(common.GroupMemberStatusNormal), Version: 3, IsDeleted: 1,
+	}))
+	// gStranger 里 uid 完全不存在（只放一个别的成员占位）
+	require.NoError(t, db.InsertMember(&MemberModel{
+		GroupNo: gStranger, UID: "someone-else", Role: MemberRoleCommon,
+		Status: int(common.GroupMemberStatusNormal), Version: 4,
+	}))
+
+	groupNos := []string{gNormal, gBlack, gDeleted, gStranger}
+
+	// 现状对照：旧 ExistMembers 把黑名单群也算成员。
+	legacy, err := db.existMembers(groupNos, uid)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{gNormal, gBlack}, legacy,
+		"existMembers 只过滤 is_deleted：黑名单群仍在结果里（对照基线）")
+
+	// ExistMembersActive 只返回正常成员所在群。
+	active, err := db.existMembersActive(groupNos, uid)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{gNormal}, active,
+		"existMembersActive 必须排除黑名单 / 已删除 / 非成员群（子区批量越权读门禁）")
+}

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -80,8 +80,14 @@ type IService interface {
 	GetMemberTotalAndOnlineCount(groupNo string) (int, int, error)
 	// 是否存在群成员
 	ExistMember(groupNo string, uid string) (bool, error)
+	// ExistMemberActive 是否存在「活跃」群成员（is_deleted=0 AND status=Normal），
+	// 排除被拉黑成员，供绕过 IM 直查本地分表的读/发门禁使用
+	ExistMemberActive(groupNo string, uid string) (bool, error)
 	// 成员是否在某群里存在 返回对应在群里的群编号
 	ExistMembers(groupNos []string, uid string) ([]string, error)
+	// ExistMembersActive 批量版 ExistMemberActive：返回 uid 处于「活跃」状态
+	// （is_deleted=0 AND status=Normal）的群编号集合，排除被拉黑成员
+	ExistMembersActive(groupNos []string, uid string) ([]string, error)
 	// GetGroupsWithMemberUID 获取某个用户的所有群
 	GetGroupsWithMemberUID(uid string) ([]*InfoResp, error)
 	// 获取指定群的群成员的最大数据版本
@@ -559,8 +565,22 @@ func (s *Service) ExistMember(groupNo string, uid string) (bool, error) {
 	return s.db.ExistMember(uid, groupNo)
 }
 
+// ExistMemberActive 是 ExistMember 的白名单（fail closed）变体：除 is_deleted=0 外还
+// 要求 status=GroupMemberStatusNormal，明确排除被拉黑及未来新增的非正常状态成员。
+// 子区(CommunityTopic)读/发门禁用它替代 ExistMember，避免被拉黑用户越权读/发（YUJ-4185 CR 整改）。
+func (s *Service) ExistMemberActive(groupNo string, uid string) (bool, error) {
+	return s.db.ExistMemberActive(uid, groupNo)
+}
+
 func (s *Service) ExistMembers(groupNos []string, uid string) ([]string, error) {
 	return s.db.existMembers(groupNos, uid)
+}
+
+// ExistMembersActive 是 ExistMembers 的白名单（fail closed）批量变体：在 is_deleted=0
+// 之外额外要求 status=GroupMemberStatusNormal，把被拉黑成员从“仍是成员”的集合里排除。
+// 子区(CommunityTopic)批量读门禁用它替代 ExistMembers（YUJ-4185 CR 整改）。
+func (s *Service) ExistMembersActive(groupNos []string, uid string) ([]string, error) {
+	return s.db.existMembersActive(groupNos, uid)
 }
 
 func (s *Service) GetSettings(groupNos []string, uid string) ([]*SettingResp, error) {

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -66,6 +66,10 @@ type IService interface {
 	GetMember(groupNo, uid string) (*MemberResp, error)
 	// 获取黑名单成员uid集合
 	GetBlacklistMemberUIDs(groupNo string) ([]string, error)
+	// GetSubscribableMemberUIDs 返回可订阅成员 uid 集合（status=normal AND is_deleted=0，
+	// 即排除被拉黑成员），供子区/父群的 IM Subscribers 数据源使用。与 GetMembers
+	// （“所有非删除成员”）语义不同，不可互换。
+	GetSubscribableMemberUIDs(groupNo string) ([]string, error)
 	// 查询管理员成员uid列表（包括创建者）
 	GetMemberUIDsOfManager(groupNo string) ([]string, error)
 	// 是否是创建者或管理者
@@ -512,6 +516,17 @@ func (s *Service) GetMember(groupNo, uid string) (*MemberResp, error) {
 
 func (s *Service) GetBlacklistMemberUIDs(groupNo string) ([]string, error) {
 	uids, err := s.db.queryBlacklistMemberUIDsWithGroupNo(groupNo)
+	if err != nil {
+		return nil, err
+	}
+	return uids, nil
+}
+
+// GetSubscribableMemberUIDs 返回可订阅成员 uid（status=normal AND is_deleted=0）。
+// 子区/父群 IM Subscribers 数据源专用：排除被拉黑成员，避免 WuKongIM 重载订阅时
+// 把黑名单用户加回订阅列表（YUJ-4185 P0-2）。
+func (s *Service) GetSubscribableMemberUIDs(groupNo string) ([]string, error) {
+	uids, err := s.db.querySubscribableMemberUIDsWithGroupNo(groupNo)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/group/subscribable_members_test.go
+++ b/modules/group/subscribable_members_test.go
@@ -1,0 +1,86 @@
+package group
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetSubscribableMemberUIDs_ExcludesBlacklist 验证 YUJ-4185 P0-2 根因收口：
+// 子区/父群的 IM Subscribers 数据源必须排除 status=blacklist 成员。GetMembers
+// （queryMembersWithGroupNo）只过滤 is_deleted=0，会把黑名单成员一并返回，导致
+// WuKongIM 重载订阅时把被拉黑用户加回订阅列表 → 拉黑不自愈。GetSubscribableMemberUIDs
+// 必须只返回 status=normal AND is_deleted=0 的成员。
+func TestGetSubscribableMemberUIDs_ExcludesBlacklist(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	db := NewDB(ctx)
+	svc := NewService(ctx)
+	const groupNo = "g-yuj4185-p0-2"
+
+	// 正常成员
+	require.NoError(t, db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: "normal-1", Role: MemberRoleCommon,
+		Status: int(common.GroupMemberStatusNormal), Version: 1,
+	}))
+	require.NoError(t, db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: "normal-2", Role: MemberRoleCreator,
+		Status: int(common.GroupMemberStatusNormal), Version: 2,
+	}))
+	// 被拉黑成员（is_deleted=0，status=blacklist）—— 必须被排除
+	require.NoError(t, db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: "blacklisted", Role: MemberRoleCommon,
+		Status: int(common.GroupMemberStatusBlacklist), Version: 3,
+	}))
+
+	// GetMembers 仍返回全部非删除成员（语义不变，不能破坏其它调用方）
+	all, err := svc.GetMembers(groupNo)
+	require.NoError(t, err)
+	allUIDs := make([]string, 0, len(all))
+	for _, m := range all {
+		allUIDs = append(allUIDs, m.UID)
+	}
+	assert.ElementsMatch(t, []string{"normal-1", "normal-2", "blacklisted"}, allUIDs,
+		"GetMembers 语义不变：返回所有非删除成员，包括黑名单")
+
+	// GetSubscribableMemberUIDs 排除黑名单
+	subs, err := svc.GetSubscribableMemberUIDs(groupNo)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"normal-1", "normal-2"}, subs,
+		"GetSubscribableMemberUIDs 必须排除 status=blacklist 成员（YUJ-4185 P0-2）")
+
+	// GetBlacklistMemberUIDs 仍只返回黑名单成员（兼容性：Blacklist 数据源回调不受影响）
+	bl, err := svc.GetBlacklistMemberUIDs(groupNo)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"blacklisted"}, bl,
+		"GetBlacklistMemberUIDs 兼容性不变：只返回黑名单成员")
+}
+
+// TestGetSubscribableMemberUIDs_ExcludesDeleted 防御：is_deleted=1 的成员同样排除。
+func TestGetSubscribableMemberUIDs_ExcludesDeleted(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	db := NewDB(ctx)
+	svc := NewService(ctx)
+	const groupNo = "g-yuj4185-p0-2-del"
+
+	require.NoError(t, db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: "active", Role: MemberRoleCommon,
+		Status: int(common.GroupMemberStatusNormal), Version: 1,
+	}))
+	deleted := &MemberModel{
+		GroupNo: groupNo, UID: "deleted", Role: MemberRoleCommon,
+		Status: int(common.GroupMemberStatusNormal), Version: 2, IsDeleted: 1,
+	}
+	require.NoError(t, db.InsertMember(deleted))
+
+	subs, err := svc.GetSubscribableMemberUIDs(groupNo)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"active"}, subs,
+		"GetSubscribableMemberUIDs 必须排除 is_deleted=1 成员")
+}

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -446,13 +446,15 @@ func (m *Message) sendMsg(c *wkhttp.Context) {
 		// YUJ-4185 P1-3：代发到子区(CommunityTopic)必须校验 sender 仍是父群成员
 		// （fail-closed）。子区无独立成员表，权威成员身份在父群，参考 authorizeMutualDelete
 		// 的子区分支。原本缺这条分支 → 被移除者仍可经 /v1/message/send 往子区代发消息。
+		// CR 整改：用 ExistMemberActive（status=Normal 白名单）而非 ExistMember，
+		// 否则被拉黑（status=Blacklist、is_deleted=0）用户仍能过门往子区代发。
 		parentGroupNo, _, perr := thread.ParseChannelID(req.ReceiveChannelID)
 		if perr != nil || parentGroupNo == "" {
 			m.Error("解析子区频道ID失败", zap.Error(perr), zap.String("channelID", req.ReceiveChannelID))
 			httperr.ResponseErrorL(c, errcode.ErrMessageNotGroupMember, nil, nil)
 			return
 		}
-		isExist, err := m.groupService.ExistMember(parentGroupNo, uid)
+		isExist, err := m.groupService.ExistMemberActive(parentGroupNo, uid)
 		if err != nil {
 			m.Error("查询发送者是否在父群内错误", zap.Error(err))
 			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
@@ -1196,6 +1198,8 @@ func (m *Message) syncChannelMessage(c *wkhttp.Context) {
 	// YUJ-4185 P1-4：子区(CommunityTopic)历史读取必须校验调用者仍是父群成员
 	// （fail-closed）。原本只有 GROUP 分支做 ExistMember，子区无校验 →
 	// 被移除者仍可经 /v1/message/channel/sync 拉子区历史（越权读）。
+	// CR 整改：用 ExistMemberActive（status=Normal 白名单）而非 ExistMember，
+	// 否则被拉黑（status=Blacklist、is_deleted=0）用户仍能过门拉子区历史正文。
 	if req.ChannelType == common.ChannelTypeCommunityTopic.Uint8() {
 		parentGroupNo, _, perr := thread.ParseChannelID(req.ChannelID)
 		if perr != nil || parentGroupNo == "" {
@@ -1208,7 +1212,7 @@ func (m *Message) syncChannelMessage(c *wkhttp.Context) {
 			})
 			return
 		}
-		exist, err := m.groupService.ExistMember(parentGroupNo, c.GetLoginUID())
+		exist, err := m.groupService.ExistMemberActive(parentGroupNo, c.GetLoginUID())
 		if err != nil {
 			m.Error("查询是否在父群内存在失败！", zap.Error(err))
 			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -442,6 +442,27 @@ func (m *Message) sendMsg(c *wkhttp.Context) {
 			return
 		}
 	}
+	if req.ReceiveChannelType == common.ChannelTypeCommunityTopic.Uint8() {
+		// YUJ-4185 P1-3：代发到子区(CommunityTopic)必须校验 sender 仍是父群成员
+		// （fail-closed）。子区无独立成员表，权威成员身份在父群，参考 authorizeMutualDelete
+		// 的子区分支。原本缺这条分支 → 被移除者仍可经 /v1/message/send 往子区代发消息。
+		parentGroupNo, _, perr := thread.ParseChannelID(req.ReceiveChannelID)
+		if perr != nil || parentGroupNo == "" {
+			m.Error("解析子区频道ID失败", zap.Error(perr), zap.String("channelID", req.ReceiveChannelID))
+			httperr.ResponseErrorL(c, errcode.ErrMessageNotGroupMember, nil, nil)
+			return
+		}
+		isExist, err := m.groupService.ExistMember(parentGroupNo, uid)
+		if err != nil {
+			m.Error("查询发送者是否在父群内错误", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+			return
+		}
+		if !isExist {
+			httperr.ResponseErrorL(c, errcode.ErrMessageNotGroupMember, nil, nil)
+			return
+		}
+	}
 	// YUJ-644 / Mininglamp-OSS#33: 把 SpaceMiddleware 已校验的发送方 SpaceID 透传给
 	// sendMessage，作为 PERSONAL DM 的权威 space_id 注入源（不信客户端 body）。
 	senderSpaceID := spacepkg.GetSpaceID(c)
@@ -1159,6 +1180,37 @@ func (m *Message) syncChannelMessage(c *wkhttp.Context) {
 		exist, err := m.groupService.ExistMember(req.ChannelID, c.GetLoginUID())
 		if err != nil {
 			m.Error("查询是否在群内存在失败！", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+			return
+		}
+		if !exist {
+			c.JSON(http.StatusOK, &syncChannelMessageResp{
+				StartMessageSeq: req.EndMessageSeq,
+				EndMessageSeq:   req.EndMessageSeq,
+				PullMode:        req.PullMode,
+				Messages:        make([]*MsgSyncResp, 0),
+			})
+			return
+		}
+	}
+	// YUJ-4185 P1-4：子区(CommunityTopic)历史读取必须校验调用者仍是父群成员
+	// （fail-closed）。原本只有 GROUP 分支做 ExistMember，子区无校验 →
+	// 被移除者仍可经 /v1/message/channel/sync 拉子区历史（越权读）。
+	if req.ChannelType == common.ChannelTypeCommunityTopic.Uint8() {
+		parentGroupNo, _, perr := thread.ParseChannelID(req.ChannelID)
+		if perr != nil || parentGroupNo == "" {
+			m.Error("解析子区频道ID失败", zap.Error(perr), zap.String("channelID", req.ChannelID))
+			c.JSON(http.StatusOK, &syncChannelMessageResp{
+				StartMessageSeq: req.EndMessageSeq,
+				EndMessageSeq:   req.EndMessageSeq,
+				PullMode:        req.PullMode,
+				Messages:        make([]*MsgSyncResp, 0),
+			})
+			return
+		}
+		exist, err := m.groupService.ExistMember(parentGroupNo, c.GetLoginUID())
+		if err != nil {
+			m.Error("查询是否在父群内存在失败！", zap.Error(err))
 			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}

--- a/modules/message/api_conversation.go
+++ b/modules/message/api_conversation.go
@@ -641,26 +641,40 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 
 	syncUserConversationResps := make([]*SyncUserConversationResp, 0, len(conversations))
 	userKey := loginUID
+	// YUJ-4185 P0-3：把 groupVailds（ExistMembers 返回的“当前仍是成员”的群集合）
+	// 转成 set，既给 GROUP 分支 O(1) 校验，也给子区分支补“父群成员”校验用。
+	// groupNos 构造时已把每个子区的 parent groupNo 一并加入（见上文 addGroupNo），
+	// 所以 ExistMembers 的结果天然覆盖父群。
+	groupVaildSet := make(map[string]struct{}, len(groupVailds))
+	for _, gv := range groupVailds {
+		groupVaildSet[gv] = struct{}{}
+	}
 	if len(conversations) > 0 {
 		for _, conversation := range conversations {
 
 			if conversation.ChannelType == common.ChannelTypeGroup.Uint8() {
-				vaild := false
-				for _, groupVaild := range groupVailds {
-					if groupVaild == conversation.ChannelID {
-						vaild = true
-						break
-					}
-				}
-				if !vaild { // 无效群则跳过
+				if _, vaild := groupVaildSet[conversation.ChannelID]; !vaild { // 无效群则跳过
 					continue
 				}
 			}
 
-			if conversation.ChannelType == common.ChannelTypeCommunityTopic.Uint8() && threadFilterEnabled {
-				if shortID, ok := threadChannelShortIDMap[conversation.ChannelID]; ok {
-					if _, active := activeThreadShortIDs[shortID]; !active {
-						continue
+			if conversation.ChannelType == common.ChannelTypeCommunityTopic.Uint8() {
+				// YUJ-4185 P0-3：子区可见性必须校验调用者仍是父群成员（fail-closed）。
+				// 之前只按 activeThreadShortIDs 过滤“子区是否存活”，不校验成员身份，
+				// 被移除者的会话列表仍能看到子区并据此拉历史（越权读 P0）。
+				// parent groupNo 在 groupNos 里，ExistMembers 已覆盖；解析失败也 skip。
+				parentNo, _, perr := thread.ParseChannelID(conversation.ChannelID)
+				if perr != nil {
+					continue
+				}
+				if _, member := groupVaildSet[parentNo]; !member {
+					continue
+				}
+				if threadFilterEnabled {
+					if shortID, ok := threadChannelShortIDMap[conversation.ChannelID]; ok {
+						if _, active := activeThreadShortIDs[shortID]; !active {
+							continue
+						}
 					}
 				}
 			}

--- a/modules/message/api_conversation.go
+++ b/modules/message/api_conversation.go
@@ -466,6 +466,7 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 	groupMap := map[string]*group.GroupResp{}                   // 群详情
 	conversationExtraMap := map[string]*conversationExtraResp{} // 最近会话扩展
 	groupVailds := make([]string, 0, len(conversations))        // 有效群
+	groupActives := make([]string, 0, len(conversations))       // 活跃群（排除黑名单）
 	activeThreadShortIDs := make(map[string]struct{})           // 有效子区
 
 	// ---------- 是否在群内 ----------
@@ -473,6 +474,15 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 		groupVailds, err = co.groupService.ExistMembers(groupNos, loginUID)
 		if err != nil {
 			co.Error("查询有效群失败！", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+			return
+		}
+		// CR 整改：子区(CommunityTopic)父群成员校验必须排除黑名单，否则被拉黑
+		// (status=Blacklist、is_deleted=0) 用户仍能在会话列表看到子区并据此拉历史
+		// （越权读）。GROUP 分支沿用 groupVailds 保持既有语义不变。
+		groupActives, err = co.groupService.ExistMembersActive(groupNos, loginUID)
+		if err != nil {
+			co.Error("查询活跃群失败！", zap.Error(err))
 			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
@@ -649,6 +659,11 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 	for _, gv := range groupVailds {
 		groupVaildSet[gv] = struct{}{}
 	}
+	// CR 整改：子区父群成员校验走 active-only 集合（排除黑名单）。
+	groupActiveSet := make(map[string]struct{}, len(groupActives))
+	for _, ga := range groupActives {
+		groupActiveSet[ga] = struct{}{}
+	}
 	if len(conversations) > 0 {
 		for _, conversation := range conversations {
 
@@ -662,12 +677,14 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 				// YUJ-4185 P0-3：子区可见性必须校验调用者仍是父群成员（fail-closed）。
 				// 之前只按 activeThreadShortIDs 过滤“子区是否存活”，不校验成员身份，
 				// 被移除者的会话列表仍能看到子区并据此拉历史（越权读 P0）。
-				// parent groupNo 在 groupNos 里，ExistMembers 已覆盖；解析失败也 skip。
+				// parent groupNo 在 groupNos 里，ExistMembersActive 已覆盖；解析失败也 skip。
+				// CR 整改：用 groupActiveSet（排除黑名单）而非 groupVaildSet，否则被拉黑
+				// 用户仍能透出子区。
 				parentNo, _, perr := thread.ParseChannelID(conversation.ChannelID)
 				if perr != nil {
 					continue
 				}
-				if _, member := groupVaildSet[parentNo]; !member {
+				if _, member := groupActiveSet[parentNo]; !member {
 					continue
 				}
 				if threadFilterEnabled {

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -281,6 +281,17 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 		conversations = FilterRawConversationsBySpace(rawConversations, spaceID, loginUID, sb.ctx, sb.groupService)
 		conversations = EnsureSystemBotsPresentRaw(conversations)
 	}
+	// YUJ-4185 P1-4：子区(CommunityTopic)条目必须按父群成员身份过滤（fail-closed）。
+	// FilterRawConversationsBySpace 只在 spaceID != "" 时跑，且历史上它只比 space
+	// 不校验成员；这里对所有路径（含无 X-Space-ID 的请求）显式补父群 ExistMember，
+	// 避免被移除者在 sidebar 仍看到子区入口（越权读）。DB-only thread ext 行另在
+	// 下方 2a.6 单独过滤。
+	conversations = filterThreadConvsByParentMembership(
+		conversations,
+		func(c *config.SyncUserConversationResp) string { return c.ChannelID },
+		func(c *config.SyncUserConversationResp) uint8 { return c.ChannelType },
+		loginUID, sb.groupService,
+	)
 
 	// 2. Load ancillary data
 	//
@@ -330,6 +341,16 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 		var err error
 		threadExtRows, err = sb.filterThreadExtsBySpace(threadExtRows, spaceID, loginUID)
 		if failClosedForFollow("thread ext space filter", err) {
+			return
+		}
+	}
+	// 2a.6. YUJ-4185 P1-4：DB-only thread ext 行也必须按父群成员身份过滤（fail-closed）。
+	//       这些行不经 conversations 路径，mergeThreadEntries 只校验父群 category/follow，
+	//       不校验成员 → 被移除者的子区仍可能从 ext 表透出到 follow tab（越权读）。
+	if isFollowTab && len(threadExtRows) > 0 {
+		var err error
+		threadExtRows, err = sb.filterThreadExtsByParentMembership(threadExtRows, loginUID)
+		if failClosedForFollow("thread ext parent membership filter", err) {
 			return
 		}
 	}
@@ -848,6 +869,37 @@ func (sb *Sidebar) filterThreadExtsBySpace(rows []*convext.Model, spaceID, login
 		if sourceSpace, ok := externalMap[parentNo]; ok && sourceSpace == spaceID {
 			kept = append(kept, ext)
 		}
+	}
+	return kept, nil
+}
+
+// filterThreadExtsByParentMembership 剔除“调用者已不是父群成员”的 DB-only thread ext 行。
+// YUJ-4185 P1-4：子区无独立成员表，权威成员身份在父群；被踢/退群/拉黑后 thread ext 行
+// 仍可能残留，必须按父群 ExistMembers 校验，避免子区从 follow tab 越权透出。
+// fail-closed：父群成员查询失败时返回 error，调用方 follow tab 整体退避。
+func (sb *Sidebar) filterThreadExtsByParentMembership(rows []*convext.Model, loginUID string) ([]*convext.Model, error) {
+	parentNos := uniqueThreadParentGroupNos(rows)
+	if len(parentNos) == 0 {
+		return rows, nil
+	}
+	memberNos, err := sb.groupService.ExistMembers(parentNos, loginUID)
+	if err != nil {
+		return nil, fmt.Errorf("filter thread ext by parent membership: %w", err)
+	}
+	memberSet := make(map[string]struct{}, len(memberNos))
+	for _, no := range memberNos {
+		memberSet[no] = struct{}{}
+	}
+	kept := make([]*convext.Model, 0, len(rows))
+	for _, ext := range rows {
+		parentNo, _, perr := parseThreadChannelIDSidebar(ext.TargetID)
+		if perr != nil {
+			continue // malformed; drop silently
+		}
+		if _, member := memberSet[parentNo]; !member {
+			continue // not a parent-group member → drop (fail-closed)
+		}
+		kept = append(kept, ext)
 	}
 	return kept, nil
 }

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -283,9 +283,9 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 	}
 	// YUJ-4185 P1-4：子区(CommunityTopic)条目必须按父群成员身份过滤（fail-closed）。
 	// FilterRawConversationsBySpace 只在 spaceID != "" 时跑，且历史上它只比 space
-	// 不校验成员；这里对所有路径（含无 X-Space-ID 的请求）显式补父群 ExistMember，
-	// 避免被移除者在 sidebar 仍看到子区入口（越权读）。DB-only thread ext 行另在
-	// 下方 2a.6 单独过滤。
+	// 不校验成员；这里对所有路径（含无 X-Space-ID 的请求）显式补父群 ExistMembersActive
+	// （排除黑名单），避免被移除/拉黑者在 sidebar 仍看到子区入口（越权读）。DB-only
+	// thread ext 行另在下方 2a.6 单独过滤。
 	conversations = filterThreadConvsByParentMembership(
 		conversations,
 		func(c *config.SyncUserConversationResp) string { return c.ChannelID },
@@ -875,14 +875,16 @@ func (sb *Sidebar) filterThreadExtsBySpace(rows []*convext.Model, spaceID, login
 
 // filterThreadExtsByParentMembership 剔除“调用者已不是父群成员”的 DB-only thread ext 行。
 // YUJ-4185 P1-4：子区无独立成员表，权威成员身份在父群；被踢/退群/拉黑后 thread ext 行
-// 仍可能残留，必须按父群 ExistMembers 校验，避免子区从 follow tab 越权透出。
+// 仍可能残留，必须按父群 ExistMembersActive 校验，避免子区从 follow tab 越权透出。
+// CR 整改：用 ExistMembersActive（status=Normal 白名单）而非 ExistMembers，否则被拉黑
+// (status=Blacklist、is_deleted=0) 用户仍能从 follow tab 看到子区。
 // fail-closed：父群成员查询失败时返回 error，调用方 follow tab 整体退避。
 func (sb *Sidebar) filterThreadExtsByParentMembership(rows []*convext.Model, loginUID string) ([]*convext.Model, error) {
 	parentNos := uniqueThreadParentGroupNos(rows)
 	if len(parentNos) == 0 {
 		return rows, nil
 	}
-	memberNos, err := sb.groupService.ExistMembers(parentNos, loginUID)
+	memberNos, err := sb.groupService.ExistMembersActive(parentNos, loginUID)
 	if err != nil {
 		return nil, fmt.Errorf("filter thread ext by parent membership: %w", err)
 	}

--- a/modules/message/space_filter.go
+++ b/modules/message/space_filter.go
@@ -90,7 +90,86 @@ func FilterConversationsBySpace(
 	// Bot DM 过滤
 	botSet, botInSpace, skipBotFilter := resolveBotFilter(ctx, filterSpaceID, bareDMUIDs)
 
+	// YUJ-4185 P0-3：子区过滤纳入父群成员校验。space_filter 之前只按父群 space_id
+	// 决定子区可见性，不校验调用者仍是父群成员 → 被移除者会话列表仍见子区并拉历史
+	// （越权读 P0）。在 Space 过滤前先剔除“父群已非成员”的子区会话（fail-closed）。
+	conversations = filterThreadConvsByParentMembership(
+		conversations,
+		func(c *SyncUserConversationResp) string { return c.ChannelID },
+		func(c *SyncUserConversationResp) uint8 { return c.ChannelType },
+		loginUID, groupService,
+	)
+
 	return filterConversationsCore(conversations, filterSpaceID, defaultSpaceID, groupSpaceMap, externalGroupMap, botSet, botInSpace, skipGroupFilter, skipBotFilter)
+}
+
+// filterThreadConvsByParentMembership 剔除“调用者已不是父群成员”的子区(CommunityTopic)
+// 会话，非子区会话原样保留。YUJ-4185 P0-3：子区无独立成员表，权威成员身份在父群；
+// 被踢/退群/拉黑后子区会话仍可能残留在 IM 返回里，必须按父群成员校验。
+//
+// fail-closed：父群成员查询失败时 drop 全部子区会话（宁可让用户多刷一次，也不放行
+// 可能越权的子区）。channelID 解析失败的子区同样 drop。泛型适配 v1
+// (*message.SyncUserConversationResp) 与 v2 (*config.SyncUserConversationResp) 两种载荷。
+func filterThreadConvsByParentMembership[T any](
+	conversations []T,
+	channelID func(T) string,
+	channelType func(T) uint8,
+	loginUID string,
+	groupService group.IService,
+) []T {
+	if len(conversations) == 0 {
+		return conversations
+	}
+	// 收集所有子区会话的父群 groupNo（去重）。
+	parentSeen := make(map[string]struct{})
+	parentNos := make([]string, 0)
+	hasThread := false
+	for _, conv := range conversations {
+		if channelType(conv) != common.ChannelTypeCommunityTopic.Uint8() {
+			continue
+		}
+		hasThread = true
+		parentNo, _, err := thread.ParseChannelID(channelID(conv))
+		if err != nil || parentNo == "" {
+			continue
+		}
+		if _, ok := parentSeen[parentNo]; ok {
+			continue
+		}
+		parentSeen[parentNo] = struct{}{}
+		parentNos = append(parentNos, parentNo)
+	}
+	if !hasThread {
+		return conversations
+	}
+	memberParents := make(map[string]struct{})
+	if len(parentNos) > 0 {
+		memberNos, err := groupService.ExistMembers(parentNos, loginUID)
+		if err != nil {
+			// fail-closed：无法确认成员身份时丢弃全部子区会话。
+			log.Warn("子区父群成员校验失败，按 fail-closed 丢弃子区会话", zap.Error(err))
+		} else {
+			for _, no := range memberNos {
+				memberParents[no] = struct{}{}
+			}
+		}
+	}
+	filtered := make([]T, 0, len(conversations))
+	for _, conv := range conversations {
+		if channelType(conv) != common.ChannelTypeCommunityTopic.Uint8() {
+			filtered = append(filtered, conv)
+			continue
+		}
+		parentNo, _, err := thread.ParseChannelID(channelID(conv))
+		if err != nil || parentNo == "" {
+			continue
+		}
+		if _, member := memberParents[parentNo]; !member {
+			continue
+		}
+		filtered = append(filtered, conv)
+	}
+	return filtered
 }
 
 // filterConversationsCore 是纯过滤逻辑，不依赖 DB/ctx，便于单元测试。
@@ -529,6 +608,18 @@ func FilterRawConversationsBySpace(
 	ctx *config.Context,
 	groupService group.IService,
 ) []*config.SyncUserConversationResp {
+	if len(conversations) == 0 {
+		return conversations
+	}
+
+	// YUJ-4185 P0-3：先按父群成员身份剔除越权子区会话（fail-closed），再做 Space 过滤。
+	// 与 v1 FilterConversationsBySpace 同口径，保证 sidebar 不暴露被移除者的子区。
+	conversations = filterThreadConvsByParentMembership(
+		conversations,
+		func(c *config.SyncUserConversationResp) string { return c.ChannelID },
+		func(c *config.SyncUserConversationResp) uint8 { return c.ChannelType },
+		loginUID, groupService,
+	)
 	if len(conversations) == 0 {
 		return conversations
 	}

--- a/modules/message/space_filter.go
+++ b/modules/message/space_filter.go
@@ -144,7 +144,9 @@ func filterThreadConvsByParentMembership[T any](
 	}
 	memberParents := make(map[string]struct{})
 	if len(parentNos) > 0 {
-		memberNos, err := groupService.ExistMembers(parentNos, loginUID)
+		// CR 整改：用 ExistMembersActive（排除黑名单）而非 ExistMembers，否则被拉黑
+		// (status=Blacklist、is_deleted=0) 用户的子区会话仍会透出。
+		memberNos, err := groupService.ExistMembersActive(parentNos, loginUID)
 		if err != nil {
 			// fail-closed：无法确认成员身份时丢弃全部子区会话。
 			log.Warn("子区父群成员校验失败，按 fail-closed 丢弃子区会话", zap.Error(err))

--- a/modules/message/thread_parent_membership_filter_test.go
+++ b/modules/message/thread_parent_membership_filter_test.go
@@ -10,15 +10,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// fakeMembershipGroupService 是 group.IService 的最小替身，只实现 ExistMembers，
-// 用来验证 YUJ-4185 P0-3 / P1-4 的子区父群成员过滤。
+// fakeMembershipGroupService 是 group.IService 的最小替身，只实现 ExistMembersActive，
+// 用来验证 YUJ-4185 P0-3 / P1-4 的子区父群成员过滤（active-only，排除黑名单）。
 type fakeMembershipGroupService struct {
 	group.IService
-	memberOf map[string]bool // groupNo -> 当前 uid 是否仍是成员
+	memberOf map[string]bool // groupNo -> 当前 uid 是否仍是活跃成员（非黑名单）
 	err      error
 }
 
-func (f *fakeMembershipGroupService) ExistMembers(groupNos []string, uid string) ([]string, error) {
+func (f *fakeMembershipGroupService) ExistMembersActive(groupNos []string, uid string) ([]string, error) {
 	if f.err != nil {
 		return nil, f.err
 	}

--- a/modules/message/thread_parent_membership_filter_test.go
+++ b/modules/message/thread_parent_membership_filter_test.go
@@ -1,0 +1,97 @@
+package message
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeMembershipGroupService 是 group.IService 的最小替身，只实现 ExistMembers，
+// 用来验证 YUJ-4185 P0-3 / P1-4 的子区父群成员过滤。
+type fakeMembershipGroupService struct {
+	group.IService
+	memberOf map[string]bool // groupNo -> 当前 uid 是否仍是成员
+	err      error
+}
+
+func (f *fakeMembershipGroupService) ExistMembers(groupNos []string, uid string) ([]string, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make([]string, 0, len(groupNos))
+	for _, no := range groupNos {
+		if f.memberOf[no] {
+			out = append(out, no)
+		}
+	}
+	return out, nil
+}
+
+func convV2(channelID string, ct uint8) *config.SyncUserConversationResp {
+	return &config.SyncUserConversationResp{ChannelID: channelID, ChannelType: ct}
+}
+
+func chID(c *config.SyncUserConversationResp) string  { return c.ChannelID }
+func chType(c *config.SyncUserConversationResp) uint8 { return c.ChannelType }
+
+// TestFilterThreadConvsByParentMembership_DropsNonMemberThreads 验证被移除者
+// （已不是父群成员）的子区会话被剔除，而仍是成员的子区 + 非子区会话保留。
+func TestFilterThreadConvsByParentMembership_DropsNonMemberThreads(t *testing.T) {
+	gs := &fakeMembershipGroupService{memberOf: map[string]bool{
+		"gMember": true,  // 仍是成员
+		"gKicked": false, // 已被移除
+	}}
+	ct := common.ChannelTypeCommunityTopic.Uint8()
+	gt := common.ChannelTypeGroup.Uint8()
+	pt := common.ChannelTypePerson.Uint8()
+
+	convs := []*config.SyncUserConversationResp{
+		convV2("gMember____th1", ct), // 保留：仍是父群成员
+		convV2("gKicked____th2", ct), // 剔除：已被移除
+		convV2("gMember", gt),        // 保留：群会话不受影响（GROUP 校验在别处）
+		convV2("u_peer", pt),         // 保留：DM 不受影响
+		convV2("bad-thread-id", ct),  // 剔除：channelID 解析失败 fail-closed
+	}
+
+	out := filterThreadConvsByParentMembership(convs, chID, chType, "uX", gs)
+
+	got := make([]string, 0, len(out))
+	for _, c := range out {
+		got = append(got, c.ChannelID)
+	}
+	assert.ElementsMatch(t, []string{"gMember____th1", "gMember", "u_peer"}, got,
+		"非父群成员的子区会话 + 非法 channelID 子区必须被剔除")
+}
+
+// TestFilterThreadConvsByParentMembership_FailClosedOnError 验证 ExistMembers 查询
+// 失败时所有子区会话被 fail-closed 丢弃（非子区不受影响）。
+func TestFilterThreadConvsByParentMembership_FailClosedOnError(t *testing.T) {
+	gs := &fakeMembershipGroupService{err: errors.New("db down")}
+	ct := common.ChannelTypeCommunityTopic.Uint8()
+	gt := common.ChannelTypeGroup.Uint8()
+
+	convs := []*config.SyncUserConversationResp{
+		convV2("gAny____th1", ct),
+		convV2("gAny", gt),
+	}
+	out := filterThreadConvsByParentMembership(convs, chID, chType, "uX", gs)
+	got := make([]string, 0, len(out))
+	for _, c := range out {
+		got = append(got, c.ChannelID)
+	}
+	assert.ElementsMatch(t, []string{"gAny"}, got,
+		"查询失败时子区会话 fail-closed 丢弃，非子区会话保留")
+}
+
+// TestFilterThreadConvsByParentMembership_NoThreadsPassthrough 无子区会话时原样返回。
+func TestFilterThreadConvsByParentMembership_NoThreadsPassthrough(t *testing.T) {
+	gs := &fakeMembershipGroupService{memberOf: map[string]bool{}}
+	gt := common.ChannelTypeGroup.Uint8()
+	convs := []*config.SyncUserConversationResp{convV2("g1", gt)}
+	out := filterThreadConvsByParentMembership(convs, chID, chType, "uX", gs)
+	assert.Len(t, out, 1)
+}

--- a/modules/thread/1module.go
+++ b/modules/thread/1module.go
@@ -131,15 +131,14 @@ func init() {
 						return nil, err
 					}
 
-					// 返回父群成员（允许所有父群成员查看和发送消息）
-					members, err := groupService.GetMembers(groupNo)
+					// 返回父群可订阅成员（允许查看和发送消息）。必须排除被拉黑
+					// （status=blacklist）成员：WuKongIM 缓存这份列表做 WS push，
+					// 若包含黑名单用户，重载订阅时会把他加回，导致拉黑不自愈
+					// （YUJ-4185 P0-2 根因）。Blacklist 回调仍单独继承父群黑名单
+					// 做纵深防御（挡发送），两者互补。
+					uids, err := groupService.GetSubscribableMemberUIDs(groupNo)
 					if err != nil {
 						return nil, err
-					}
-
-					uids := make([]string, 0, len(members))
-					for _, m := range members {
-						uids = append(uids, m.UID)
 					}
 					return uids, nil
 				},


### PR DESCRIPTION
## 背景
续 #27/#332 子区订阅清理对称性。memberRemove / groupExit / handleOrgEmployeeExit 三条路径已在 #27/#332 修对，本单收口其余移除入口，并从数据源层排除 blacklist，避免被移除 / 被拉黑用户继续通过实时下发或历史读取接口访问子区内容。

## 改动（fail-closed 原则，只改 server）
- **订阅数据源排除 blacklist（根因收口）**：父群 + 子区的 IM Subscribers 数据源改用新增的 `GetSubscribableMemberUIDs`（status=normal AND is_deleted=0），不再返回被拉黑成员。`GetMembers` 语义保持不变，不影响其它调用方。Blacklist 数据源回调保持原样（仍挡发送），两者互补；订阅源重载时不会再把被拉黑用户加回。
- **拉黑/解除拉黑订阅对称**：拉黑 add 主动摘除每个 uid 的父群 + 子区订阅（复用统一 cleanup helper）；解除拉黑对称恢复订阅。
- **会话同步 / sidebar / space 过滤**：子区可见性补「调用者仍是父群成员」校验（fail-closed），覆盖 v1/v2 两条 space 过滤路径与 DB-only thread ext 行。
- **群解散 / 组织部门删人 / 代发 / 历史同步**：补齐子区频道销毁 + 订阅清理 / 父群成员鉴权，与已修路径对齐。解散提示消息降级为 best-effort，避免通知失败导致「半解散」。

## 测试
- 数据源排除（含 GetMembers 语义不变 / is_deleted 排除）
- 父群成员过滤（含 fail-closed、非法 channelID）
- 群解散 / 组织部门删人的子区清理
- 风格对齐 e2e_issue27_wukong_test.go / thread_cleanup_test.go
- `go build ./...`、`go vet`、group/message/thread 包测试全过。

## 自审（/review）
按 gstack review checklist 过 critical pass（SQL/Data Safety、Race、LLM trust boundary、Shell、Enum completeness）：无新增 finding。改动均为读路径鉴权收紧 + 订阅数据源过滤，无 SQL 拼接、无新枚举消费缺口；新增查询走参数化 dbr。改动规模：+682/-28，14 文件（含 4 个测试）。

review-tier: high-risk（auth/权限/跨端），请走独立 ReviewBot 审查单。

Fixes YUJ-4185

<!-- sprint-set-retrigger -->