### PR TITLE
fix(thread): close subchannel blacklist read/write gates with ExistMemberActive (fast-follow #343)

### DIFF
--- a/modules/group/exist_member_active_test.go
+++ b/modules/group/exist_member_active_test.go
@@ -106,3 +106,52 @@ func TestExistMembersActive_ExcludesBlacklist(t *testing.T) {
 	assert.ElementsMatch(t, []string{gNormal}, active,
 		"existMembersActive 必须排除黑名单 / 已删除 / 非成员群（子区批量越权读门禁）")
 }
+
+// TestExistMemberActive 验证子区(CommunityTopic)读/写门禁所依赖的活跃成员判定：
+// status=Normal AND is_deleted=0 才放行；Blacklist / Quit / 已删除一律 fail-closed。
+// 这是 YUJ-4219 把 thread 模块 + channel_files + mutualDelete 子区分支统一切到
+// ExistMemberActive 后，所有这些门禁共享的授权原语，故在 DB 层兜底双向覆盖。
+func TestExistMemberActive(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	assert.NoError(t, testutil.CleanAllTables(ctx))
+
+	db := NewDB(ctx)
+	groupNo := "g-yuj4219-active"
+
+	// 正常成员
+	assert.NoError(t, db.InsertMember(&MemberModel{
+		GroupNo: groupNo,
+		UID:     "normal",
+		Role:    MemberRoleCommon,
+		Status:  int(common.GroupMemberStatusNormal),
+		Version: 1,
+	}))
+	// 被拉黑成员（is_deleted=0，仅 status=Blacklist）—— 越权读的核心攻击面
+	assert.NoError(t, db.InsertMember(&MemberModel{
+		GroupNo: groupNo,
+		UID:     "blacklisted",
+		Role:    MemberRoleCommon,
+		Status:  int(common.GroupMemberStatusBlacklist),
+		Version: 2,
+	}))
+
+	// normal → 放行
+	ok, err := db.ExistMemberActive("normal", groupNo)
+	assert.NoError(t, err)
+	assert.True(t, ok, "正常成员应放行")
+
+	// blacklist → 拒
+	ok, err = db.ExistMemberActive("blacklisted", groupNo)
+	assert.NoError(t, err)
+	assert.False(t, ok, "被拉黑成员(is_deleted=0,status=Blacklist)必须拒绝越权读")
+
+	// 不存在的用户 → 拒
+	ok, err = db.ExistMemberActive("ghost", groupNo)
+	assert.NoError(t, err)
+	assert.False(t, ok, "非成员应拒绝")
+
+	// 对照：旧的 permissive ExistMember 对被拉黑成员仍会放行，证明二者语义差异
+	permissive, err := db.ExistMember("blacklisted", groupNo)
+	assert.NoError(t, err)
+	assert.True(t, permissive, "ExistMember(permissive) 对被拉黑成员仍 true —— 正是必须改用 Active 的原因")
+}

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -80,8 +80,9 @@ type IService interface {
 	GetMemberTotalAndOnlineCount(groupNo string) (int, int, error)
 	// 是否存在群成员
 	ExistMember(groupNo string, uid string) (bool, error)
-	// ExistMemberActive 是否存在「活跃」群成员（is_deleted=0 AND status=Normal），
-	// 排除被拉黑成员，供绕过 IM 直查本地分表的读/发门禁使用
+	// ExistMemberActive 是否存在「活跃」群成员（is_deleted=0 AND status=Normal，
+	// 白名单语义、fail-closed），排除被拉黑成员。供绕过 IM 直查本地分表的读/发门禁，
+	// 以及子区(CommunityTopic)解析父群后的读/写门禁使用，防止被拉黑用户越权读子区内容。
 	ExistMemberActive(groupNo string, uid string) (bool, error)
 	// 成员是否在某群里存在 返回对应在群里的群编号
 	ExistMembers(groupNos []string, uid string) ([]string, error)

--- a/modules/message/1module.go
+++ b/modules/message/1module.go
@@ -146,7 +146,12 @@ func (c *threadAuthChecker) AuthorizeThreadFollow(uid, spaceID, groupNo, shortID
 		return convext.ErrThreadForbidden
 	}
 	// 1. Channel-level checks (membership + Space visibility) — shared with FollowChannel.
-	if err := c.checkChannelAccess(uid, spaceID, groupNo); err != nil {
+	//    FollowThread 关注的是子区(CommunityTopic)，授权来自「父群活跃成员」身份：
+	//    被拉黑(status=Blacklist、is_deleted=0)的父群成员不应能 follow 子区、被
+	//    OnThreadCreated fanout 物化子区 ext 行、收新子区创建通知。因此这里 require
+	//    active membership（ExistMemberActive），与 #345 把所有子区门禁切到 active
+	//    语义保持一致。GROUP 分支（AuthorizeChannelFollow）保留 permissive ExistMember。
+	if err := c.checkChannelAccess(uid, spaceID, groupNo, true); err != nil {
 		// 已是 ErrChannelForbidden 时，对 thread API 仍翻译为 ErrThreadForbidden，
 		// 让 handler 走原有 403 路径，客户端无需感知两套 sentinel。
 		if errors.Is(err, convext.ErrChannelForbidden) {
@@ -177,22 +182,39 @@ func (c *threadAuthChecker) AuthorizeThreadFollow(uid, spaceID, groupNo, shortID
 // 引入背景（PR #123 round-1 by Jerry-Xin / yujiawei P1）：FollowChannel 现在会
 // 物化 thread ext + 挂 OnThreadCreated fanout 订阅，必须先校验 caller 能"看到"
 // 这个群，否则同 Space 内私有群的子区元数据会泄露。
+//
+// 注意：FollowChannel 关注的是 GROUP 本身（写群级 auto_follow ext 行），授权语义
+// 保持 permissive ExistMember——与 server 各处 GROUP 分支一致，绝不 over-block 正常
+// 群成员。子区(CommunityTopic)分支的 active 校验只发生在 AuthorizeThreadFollow。
 func (c *threadAuthChecker) AuthorizeChannelFollow(uid, spaceID, groupNo string) error {
-	return c.checkChannelAccess(uid, spaceID, groupNo)
+	return c.checkChannelAccess(uid, spaceID, groupNo, false)
 }
 
 // checkChannelAccess 复用 FollowThread 既有逻辑的群级访问校验：
 //  1. spaceID 非空
-//  2. caller 是 group 成员
+//  2. caller 是 group 成员（requireActive=false 用 permissive ExistMember；
+//     requireActive=true 用 ExistMemberActive，额外排除被拉黑成员）
 //  3. group 在请求 Space 可见（内部群 same-space / 外部群 sourceSpaceID-match / 旧群 wildcard）
 //
+// requireActive 区分调用方语义：
+//   - GROUP 分支（AuthorizeChannelFollow / DefaultFollowedGroupGuard）传 false，
+//     保留 ExistMember 原语义，不 over-block 正常群成员。
+//   - 子区(CommunityTopic)分支（AuthorizeThreadFollow）传 true，被拉黑父群成员
+//     fail-closed 拒绝，关掉 follow 子区 / 收新子区创建通知的剩余缺口。
+//
 // 鉴权失败返回 convext.ErrChannelForbidden；基础设施错误 wrap 后上传。
-func (c *threadAuthChecker) checkChannelAccess(uid, spaceID, groupNo string) error {
+func (c *threadAuthChecker) checkChannelAccess(uid, spaceID, groupNo string, requireActive bool) error {
 	if spaceID == "" {
 		return convext.ErrChannelForbidden
 	}
-	// 1. Membership check.
-	isMember, err := c.groupSvc.ExistMember(groupNo, uid)
+	// 1. Membership check. 子区分支要求 active（排除黑名单）；GROUP 分支保留 permissive。
+	var isMember bool
+	var err error
+	if requireActive {
+		isMember, err = c.groupSvc.ExistMemberActive(groupNo, uid)
+	} else {
+		isMember, err = c.groupSvc.ExistMember(groupNo, uid)
+	}
 	if err != nil {
 		return err
 	}

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -1881,7 +1881,7 @@ func (m *Message) mutualDelete(c *wkhttp.Context) {
 			httperr.ResponseErrorL(c, errcode.ErrMessageDeleteForbidden, nil, nil)
 			return
 		}
-		isParentGroupMember, err = m.groupService.ExistMember(parentGroupNo, loginUID)
+		isParentGroupMember, err = m.groupService.ExistMemberActive(parentGroupNo, loginUID)
 		if err != nil {
 			m.Error("查询父群成员关系失败", zap.Error(err))
 			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)

--- a/modules/message/api_channel_files.go
+++ b/modules/message/api_channel_files.go
@@ -165,7 +165,10 @@ func (m *Message) channelFiles(c *wkhttp.Context) {
 	// 群聊/话题校验成员身份
 	if req.ChannelType == common.ChannelTypeGroup.Uint8() || req.ChannelType == common.ChannelTypeCommunityTopic.Uint8() {
 		groupNo := req.ChannelID
-		if req.ChannelType == common.ChannelTypeCommunityTopic.Uint8() {
+		// isTopic 为真时走子区父群门禁，需排除黑名单(ExistMemberActive)；
+		// GROUP 分支保留 ExistMember 既有语义，避免误杀正常群成员。
+		isTopic := req.ChannelType == common.ChannelTypeCommunityTopic.Uint8()
+		if isTopic {
 			parentGroupNo, _, perr := thread.ParseChannelID(req.ChannelID)
 			if perr != nil {
 				respondMessageRequestInvalid(c, "channel_id")
@@ -173,7 +176,13 @@ func (m *Message) channelFiles(c *wkhttp.Context) {
 			}
 			groupNo = parentGroupNo
 		}
-		isMember, err := m.groupService.ExistMember(groupNo, loginUID)
+		var isMember bool
+		var err error
+		if isTopic {
+			isMember, err = m.groupService.ExistMemberActive(groupNo, loginUID)
+		} else {
+			isMember, err = m.groupService.ExistMember(groupNo, loginUID)
+		}
 		if err != nil {
 			m.Error("查询群成员关系错误", zap.Error(err))
 			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)

--- a/modules/message/channel_files_blacklist_test.go
+++ b/modules/message/channel_files_blacklist_test.go
@@ -27,6 +27,10 @@ func TestChannelFiles_TopicBlacklist(t *testing.T) {
 	// 与本文件 TestChannelFiles_WithFiles 手建 message_extra 等表的写法一致。
 	_, err := ctx.DB().UpdateBySql("CREATE TABLE IF NOT EXISTS group_member (id INTEGER PRIMARY KEY AUTO_INCREMENT, group_no VARCHAR(40), uid VARCHAR(40), status INT DEFAULT 1, is_deleted INT DEFAULT 0)").Exec()
 	assert.NoError(t, err)
+	// 正常成员放行后会走到 channel_offset 查询；手建最小表让 200 放行路径可达
+	// （mockIM 返回空文件列表，无需 message_extra 等下游表）。
+	_, err = ctx.DB().UpdateBySql("CREATE TABLE IF NOT EXISTS channel_offset (id INTEGER PRIMARY KEY AUTO_INCREMENT, uid VARCHAR(40), channel_id VARCHAR(100), channel_type SMALLINT DEFAULT 0, message_seq BIGINT DEFAULT 0)").Exec()
+	assert.NoError(t, err)
 
 	// 父群 channelID：32 hex groupNo + 合法 snowflake shortID
 	parentGroupNo := strings.ReplaceAll(util.GenerUUID(), "-", "")
@@ -59,12 +63,13 @@ func TestChannelFiles_TopicBlacklist(t *testing.T) {
 	assert.NotEqual(t, http.StatusOK, w.Code, "被拉黑用户必须被门禁拦截")
 	assert.Contains(t, w.Body.String(), "not a member", "应被识别为非活跃成员")
 
-	// 升级为正常成员 → 放行（不再被成员门禁拦截）。
-	// 注：本测试只验证子区父群成员门禁，不验证下游 IM/文件解析，故只断言
-	// 「不再返回 not a member」，避免耦合下游表结构。
+	// 升级为正常成员 → 放行：mockIM 已配置返回空文件列表，正常成员应一路到
+	// http.StatusOK（Jerry-Xin 非阻塞建议：把断言从「不再返回 not a member」加强
+	// 到完整放行）。
 	_, err = ctx.DB().UpdateBySql("UPDATE group_member SET status=? WHERE group_no=? AND uid=?",
 		int(common.GroupMemberStatusNormal), parentGroupNo, uid).Exec()
 	assert.NoError(t, err)
 	w = doReq()
+	assert.Equal(t, http.StatusOK, w.Code, "正常成员应一路放行至 200")
 	assert.NotContains(t, w.Body.String(), "not a member", "正常成员不应被成员门禁 over-block")
 }

--- a/modules/message/channel_files_blacklist_test.go
+++ b/modules/message/channel_files_blacklist_test.go
@@ -1,0 +1,70 @@
+package message
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestChannelFiles_TopicBlacklist 验证 YUJ-4219：/channel/files 子区(CommunityTopic)分支
+// 解析父群后必须用 ExistMemberActive 排除黑名单。被拉黑用户(is_deleted=0,status=Blacklist)
+// 不应能拉取子区文件清单（名/URL），正常成员可正常通过门禁。
+func TestChannelFiles_TopicBlacklist(t *testing.T) {
+	// IM mock：成员通过门禁后返回空文件列表即可（本测试只验门禁，不验文件解析）。
+	mockIM := mockWuKongIMServer(t, []map[string]interface{}{})
+	defer mockIM.Close()
+
+	s, ctx := newTestServer()
+	ctx.GetConfig().WuKongIM.APIURL = mockIM.URL
+
+	// 本包的 newTestServer 不跑迁移；门禁只查 group_member 表，按需手建最小列集，
+	// 与本文件 TestChannelFiles_WithFiles 手建 message_extra 等表的写法一致。
+	_, err := ctx.DB().UpdateBySql("CREATE TABLE IF NOT EXISTS group_member (id INTEGER PRIMARY KEY AUTO_INCREMENT, group_no VARCHAR(40), uid VARCHAR(40), status INT DEFAULT 1, is_deleted INT DEFAULT 0)").Exec()
+	assert.NoError(t, err)
+
+	// 父群 channelID：32 hex groupNo + 合法 snowflake shortID
+	parentGroupNo := strings.ReplaceAll(util.GenerUUID(), "-", "")
+	shortID := "1489104291682713601"
+	topicChannelID := parentGroupNo + "____" + shortID
+
+	// uid(=登录用户) 先设为被拉黑成员（is_deleted=0, status=Blacklist）
+	_, err = ctx.DB().UpdateBySql("INSERT INTO group_member (group_no, uid, status, is_deleted) VALUES (?,?,?,0)",
+		parentGroupNo, uid, int(common.GroupMemberStatusBlacklist)).Exec()
+	assert.NoError(t, err)
+
+	msg := New(ctx)
+	msg.Route(s.GetRoute())
+
+	doReq := func() *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/v1/message/channel/files",
+			bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+				"channel_id":   topicChannelID,
+				"channel_type": int(common.ChannelTypeCommunityTopic.Uint8()),
+				"category":     "all",
+			}))))
+		req.Header.Set("token", token)
+		s.GetRoute().ServeHTTP(w, req)
+		return w
+	}
+
+	// 被拉黑 → 拒（not a member of this group）
+	w := doReq()
+	assert.NotEqual(t, http.StatusOK, w.Code, "被拉黑用户必须被门禁拦截")
+	assert.Contains(t, w.Body.String(), "not a member", "应被识别为非活跃成员")
+
+	// 升级为正常成员 → 放行（不再被成员门禁拦截）。
+	// 注：本测试只验证子区父群成员门禁，不验证下游 IM/文件解析，故只断言
+	// 「不再返回 not a member」，避免耦合下游表结构。
+	_, err = ctx.DB().UpdateBySql("UPDATE group_member SET status=? WHERE group_no=? AND uid=?",
+		int(common.GroupMemberStatusNormal), parentGroupNo, uid).Exec()
+	assert.NoError(t, err)
+	w = doReq()
+	assert.NotContains(t, w.Body.String(), "not a member", "正常成员不应被成员门禁 over-block")
+}

--- a/modules/message/thread_follow_blacklist_e2e_test.go
+++ b/modules/message/thread_follow_blacklist_e2e_test.go
@@ -1,0 +1,128 @@
+//go:build integration
+
+package message
+
+// =============================================================================
+// E2E coverage for YUJ-4229 必修 2 — checkChannelAccess channel_type 区分。
+//
+// AuthorizeThreadFollow (FollowThread, 子区/CommunityTopic 分支) require 父群
+// 「活跃成员」(ExistMemberActive)：被拉黑(status=Blacklist、is_deleted=0)的父群
+// 成员不能 follow 子区、不被 OnThreadCreated fanout 物化子区 ext、不收新子区
+// 创建通知。
+//
+// AuthorizeChannelFollow (FollowChannel, GROUP 分支) 保留 permissive
+// ExistMember 语义：被拉黑成员对 GROUP 本身的 follow 不被 over-block（与 server
+// 各处 GROUP 分支一致）。
+//
+// 复用 default_followed_group_guard_e2e_test.go 的 ensureGuardE2ETables /
+// seedGroupRow / seedGroupMember helper（同包），额外建一张最小 thread 表。
+// =============================================================================
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ensureThreadE2ETable 建一张最小 thread 表，仅含 AuthorizeThreadFollow 走的
+// QueryActiveByGroupShortIDs 读到的列。
+func ensureThreadE2ETable(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	_, err := ctx.DB().Exec("DROP TABLE IF EXISTS thread")
+	require.NoError(t, err, "drop thread")
+	_, err = ctx.DB().Exec(
+		"CREATE TABLE `thread` (" +
+			"  `id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY," +
+			"  `group_no` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `short_id` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `name` VARCHAR(100) NOT NULL DEFAULT ''," +
+			"  `creator_uid` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `status` INT NOT NULL DEFAULT 1," +
+			"  `last_message_at` TIMESTAMP NULL DEFAULT NULL," +
+			"  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+			"  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+			"  UNIQUE KEY `uk_short` (`short_id`)" +
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4")
+	require.NoError(t, err, "create thread")
+}
+
+func seedThreadE2E(t *testing.T, ctx *config.Context, groupNo, shortID string) {
+	t.Helper()
+	_, err := ctx.DB().Exec(
+		"INSERT INTO thread (group_no, short_id, name, creator_uid, status) VALUES (?, ?, 'topic', '', 1)",
+		groupNo, shortID,
+	)
+	require.NoError(t, err, "seedThreadE2E %s/%s", groupNo, shortID)
+}
+
+func setMemberStatusE2E(t *testing.T, ctx *config.Context, groupNo, uid string, status common.GroupMemberStatus) {
+	t.Helper()
+	_, err := ctx.DB().Exec(
+		"UPDATE group_member SET status=? WHERE group_no=? AND uid=?",
+		int(status), groupNo, uid,
+	)
+	require.NoError(t, err, "setMemberStatusE2E %s/%s", groupNo, uid)
+}
+
+// TestE2E_ThreadFollow_BlacklistedParentMember verifies the channel_type split:
+// FollowThread (CommunityTopic) requires active membership; FollowChannel (GROUP)
+// stays permissive.
+func TestE2E_ThreadFollow_BlacklistedParentMember(t *testing.T) {
+	ctx := newSidebarIntegCtx(t)
+	ensureGuardE2ETables(t, ctx)
+	ensureThreadE2ETable(t, ctx)
+	t.Cleanup(func() { cleanGuardE2ERows(t, ctx) })
+
+	const (
+		uid     = "e2e-fl-user"
+		spaceA  = "e2e-space-a"
+		groupNo = "e2e-fl-group"
+		shortID = "e2e-fl-topic"
+	)
+
+	seedGroupRow(t, ctx, groupNo, spaceA, 1 /* GroupStatusNormal */)
+	seedGroupMember(t, ctx, groupNo, uid, 0, "")
+	seedThreadE2E(t, ctx, groupNo, shortID)
+
+	checker := newThreadAuthChecker(ctx)
+
+	// --- 正常成员：两条 follow 都放行 ---
+	t.Run("normal member can follow both thread and channel", func(t *testing.T) {
+		require.NoError(t, checker.AuthorizeThreadFollow(uid, spaceA, groupNo, shortID),
+			"正常成员 follow 子区不应被拦")
+		require.NoError(t, checker.AuthorizeChannelFollow(uid, spaceA, groupNo),
+			"正常成员 follow GROUP 不应被拦")
+	})
+
+	// --- 被拉黑：子区分支拒，GROUP 分支保留 permissive 放行 ---
+	setMemberStatusE2E(t, ctx, groupNo, uid, common.GroupMemberStatusBlacklist)
+
+	t.Run("blacklisted member denied FollowThread (CommunityTopic branch)", func(t *testing.T) {
+		err := checker.AuthorizeThreadFollow(uid, spaceA, groupNo, shortID)
+		require.Error(t, err, "被拉黑父群成员 follow 子区必须被拒")
+		assert.True(t, errors.Is(err, convext.ErrThreadForbidden),
+			"应返回 ErrThreadForbidden，got %v", err)
+	})
+
+	t.Run("blacklisted member still allowed FollowChannel (GROUP branch permissive)", func(t *testing.T) {
+		err := checker.AuthorizeChannelFollow(uid, spaceA, groupNo)
+		assert.NoError(t, err,
+			"GROUP 分支保留 permissive ExistMember，不应 over-block 被拉黑成员的 channel follow")
+	})
+
+	// --- 被移出（is_deleted=1）：两条都拒（既有语义，纵深防御） ---
+	t.Run("removed member denied both", func(t *testing.T) {
+		_, err := ctx.DB().Exec(
+			"UPDATE group_member SET is_deleted=1 WHERE group_no=? AND uid=?", groupNo, uid)
+		require.NoError(t, err)
+		assert.Error(t, checker.AuthorizeThreadFollow(uid, spaceA, groupNo, shortID),
+			"被移出成员 follow 子区必须被拒")
+		assert.Error(t, checker.AuthorizeChannelFollow(uid, spaceA, groupNo),
+			"被移出成员 follow GROUP 也被拒")
+	})
+}

--- a/modules/thread/api.go
+++ b/modules/thread/api.go
@@ -322,8 +322,8 @@ func (t *Thread) listThreads(c *wkhttp.Context) {
 		return
 	}
 
-	// 验证是群成员
-	isMember, err := t.groupService.ExistMember(groupNo, loginUID)
+	// 验证是活跃父群成员（排除黑名单，被拉黑用户不应越权读子区内容）
+	isMember, err := t.groupService.ExistMemberActive(groupNo, loginUID)
 	if err != nil {
 		t.Error("检查群成员失败", zap.Error(err))
 		respondThreadServiceError(c, err)
@@ -402,8 +402,8 @@ func (t *Thread) getThread(c *wkhttp.Context) {
 		return
 	}
 
-	// 验证是群成员
-	isMember, err := t.groupService.ExistMember(groupNo, loginUID)
+	// 验证是活跃父群成员（排除黑名单，被拉黑用户不应越权读子区内容）
+	isMember, err := t.groupService.ExistMemberActive(groupNo, loginUID)
 	if err != nil {
 		t.Error("检查群成员失败", zap.Error(err))
 		respondThreadServiceError(c, err)
@@ -492,8 +492,8 @@ func (t *Thread) listMembers(c *wkhttp.Context) {
 		return
 	}
 
-	// 验证是群成员
-	isMember, err := t.groupService.ExistMember(groupNo, loginUID)
+	// 验证是活跃父群成员（排除黑名单，被拉黑用户不应越权读子区内容）
+	isMember, err := t.groupService.ExistMemberActive(groupNo, loginUID)
 	if err != nil {
 		t.Error("检查群成员失败", zap.Error(err))
 		respondThreadServiceError(c, err)
@@ -616,8 +616,8 @@ func (t *Thread) threadMdGet(c *wkhttp.Context) {
 		return
 	}
 
-	// 权限：必须是父群成员
-	isMember, err := t.groupService.ExistMember(groupNo, loginUID)
+	// 权限：必须是活跃父群成员（排除黑名单，threadMdGet 返回 GROUP.md 正文，防越权读）
+	isMember, err := t.groupService.ExistMemberActive(groupNo, loginUID)
 	if err != nil {
 		t.Error("check group member failed", zap.Error(err))
 		respondThreadError(c, errcode.ErrThreadStoreFailed, nil)
@@ -914,8 +914,8 @@ func (t *Thread) getThreadSimple(c *wkhttp.Context) {
 		return
 	}
 
-	// 验证是父群成员
-	isMember, err := t.groupService.ExistMember(thread.GroupNo, loginUID)
+	// 验证是活跃父群成员（排除黑名单）
+	isMember, err := t.groupService.ExistMemberActive(thread.GroupNo, loginUID)
 	if err != nil {
 		respondThreadServiceError(c, err)
 		return

--- a/modules/thread/blacklist_membership_test.go
+++ b/modules/thread/blacklist_membership_test.go
@@ -1,0 +1,106 @@
+package thread
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/stretchr/testify/assert"
+)
+
+// setupBlacklistTestData 建一个父群，含 normal 成员 + blacklist 成员（is_deleted=0），
+// 用于验证 YUJ-4219 把子区写门禁切到 ExistMemberActive 后被拉黑用户 fail-closed。
+func setupBlacklistTestData(t *testing.T) (*Service, string) {
+	t.Helper()
+	_, ctx := testutil.NewTestServer()
+	assert.NoError(t, testutil.CleanAllTables(ctx))
+
+	userDB := user.NewDB(ctx)
+	assert.NoError(t, userDB.Insert(&user.Model{UID: "normal-u", Name: "normal", ShortNo: "sn_normal"}))
+	assert.NoError(t, userDB.Insert(&user.Model{UID: "black-u", Name: "black", ShortNo: "sn_black"}))
+
+	groupNo := strings.ReplaceAll(util.GenerUUID(), "-", "")
+	groupDB := group.NewDB(ctx)
+	assert.NoError(t, groupDB.Insert(&group.Model{GroupNo: groupNo, Name: "父群", Creator: "normal-u", Status: 1, Version: 1}))
+	// 正常成员
+	assert.NoError(t, groupDB.InsertMember(&group.MemberModel{
+		GroupNo: groupNo, UID: "normal-u", Role: group.MemberRoleCreator,
+		Status: int(common.GroupMemberStatusNormal), Version: 1, Vercode: util.GenerUUID(),
+	}))
+	// 被拉黑成员：is_deleted=0，仅 status=Blacklist
+	assert.NoError(t, groupDB.InsertMember(&group.MemberModel{
+		GroupNo: groupNo, UID: "black-u", Role: group.MemberRoleCommon,
+		Status: int(common.GroupMemberStatusBlacklist), Version: 2, Vercode: util.GenerUUID(),
+	}))
+
+	return NewService(ctx).(*Service), groupNo
+}
+
+// TestCreateThread_BlacklistDenied 被拉黑用户不应能创建子区（fail-closed）。
+func TestCreateThread_BlacklistDenied(t *testing.T) {
+	svc, groupNo := setupBlacklistTestData(t)
+
+	_, err := svc.CreateThread(&CreateThreadReq{
+		GroupNo: groupNo, Name: "越权建区", CreatorUID: "black-u", CreatorName: "black",
+	})
+	assert.Error(t, err, "被拉黑用户创建子区必须被拒")
+	assert.Contains(t, err.Error(), "not a group member")
+}
+
+// TestCreateThread_NormalAllowed 正常成员可以创建子区（不被 over-block）。
+func TestCreateThread_NormalAllowed(t *testing.T) {
+	svc, groupNo := setupBlacklistTestData(t)
+
+	th, err := svc.CreateThread(&CreateThreadReq{
+		GroupNo: groupNo, Name: "正常建区", CreatorUID: "normal-u", CreatorName: "normal",
+	})
+	assert.NoError(t, err, "正常成员创建子区不应被拦")
+	assert.NotNil(t, th)
+}
+
+// TestJoinThread_BlacklistDenied 被拉黑用户不应能加入子区（fail-closed）。
+func TestJoinThread_BlacklistDenied(t *testing.T) {
+	svc, groupNo := setupBlacklistTestData(t)
+
+	// 先由正常成员建一个子区
+	th, err := svc.CreateThread(&CreateThreadReq{
+		GroupNo: groupNo, Name: "目标子区", CreatorUID: "normal-u", CreatorName: "normal",
+	})
+	assert.NoError(t, err)
+
+	err = svc.JoinThread(groupNo, th.ShortID, "black-u")
+	assert.Error(t, err, "被拉黑用户加入子区必须被拒")
+	assert.Contains(t, err.Error(), "not a group member")
+}
+
+// TestJoinThread_NormalAllowed 正常父群成员可以加入子区。
+func TestJoinThread_NormalAllowed(t *testing.T) {
+	svc, groupNo := setupBlacklistTestData(t)
+
+	th, err := svc.CreateThread(&CreateThreadReq{
+		GroupNo: groupNo, Name: "目标子区2", CreatorUID: "normal-u", CreatorName: "normal",
+	})
+	assert.NoError(t, err)
+
+	// 正常成员加入子区
+	err = svc.JoinThread(groupNo, th.ShortID, "normal-u")
+	assert.NoError(t, err, "正常成员加入子区不应被拦")
+}
+
+// TestUpdateSetting_BlacklistDenied 被拉黑用户不应能改子区 per-user 设置。
+func TestUpdateSetting_BlacklistDenied(t *testing.T) {
+	svc, groupNo := setupBlacklistTestData(t)
+
+	th, err := svc.CreateThread(&CreateThreadReq{
+		GroupNo: groupNo, Name: "设置子区", CreatorUID: "normal-u", CreatorName: "normal",
+	})
+	assert.NoError(t, err)
+
+	err = svc.UpdateSetting(groupNo, th.ShortID, "black-u", map[string]interface{}{"mute": 1})
+	assert.Error(t, err, "被拉黑用户改子区设置必须被拒")
+	assert.Contains(t, err.Error(), "not a group member")
+}

--- a/modules/thread/creator_blacklist_test.go
+++ b/modules/thread/creator_blacklist_test.go
@@ -1,0 +1,169 @@
+package thread
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupCreatorBlacklistTest 建一个父群 + 一个由 creator-u（普通成员、子区创建者）
+// 建好的子区。返回 service、ctx、groupNo、子区 shortID，供「creator 建区后被拉黑」
+// 的授权回归用：测试通过把 creator-u 的 group_member.status 改成 Blacklist 来模拟
+// 「先 Normal 后被拉黑」的状态转换。
+//
+// 验证 YUJ-4229 必修 1：canOperate / UpdateName 在给 creator/admin 特权之前先
+// require 父群 active 成员身份，被拉黑创建者 fail-closed。
+func setupCreatorBlacklistTest(t *testing.T) (*Service, *config.Context, string, string) {
+	t.Helper()
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	userDB := user.NewDB(ctx)
+	require.NoError(t, userDB.Insert(&user.Model{UID: "owner-u", Name: "owner", ShortNo: "sn_owner"}))
+	require.NoError(t, userDB.Insert(&user.Model{UID: "creator-u", Name: "creator", ShortNo: "sn_creator"}))
+
+	groupNo := strings.ReplaceAll(util.GenerUUID(), "-", "")
+	groupDB := group.NewDB(ctx)
+	require.NoError(t, groupDB.Insert(&group.Model{GroupNo: groupNo, Name: "父群", Creator: "owner-u", Status: 1, Version: 1}))
+	// 群主
+	require.NoError(t, groupDB.InsertMember(&group.MemberModel{
+		GroupNo: groupNo, UID: "owner-u", Role: group.MemberRoleCreator,
+		Status: int(common.GroupMemberStatusNormal), Version: 1, Vercode: util.GenerUUID(),
+	}))
+	// 子区创建者：建区时是 Normal 普通成员
+	require.NoError(t, groupDB.InsertMember(&group.MemberModel{
+		GroupNo: groupNo, UID: "creator-u", Role: group.MemberRoleCommon,
+		Status: int(common.GroupMemberStatusNormal), Version: 2, Vercode: util.GenerUUID(),
+	}))
+
+	svc := NewService(ctx).(*Service)
+	th, err := svc.CreateThread(&CreateThreadReq{
+		GroupNo: groupNo, Name: "我的子区", CreatorUID: "creator-u", CreatorName: "creator",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, th)
+
+	return svc, ctx, groupNo, th.ShortID
+}
+
+// blacklistMember 把 group_member.status 切到 Blacklist（is_deleted 仍=0），
+// 模拟「先是正常成员、后被拉黑」的转换。
+func blacklistMember(t *testing.T, ctx *config.Context, groupNo, uid string) {
+	t.Helper()
+	_, err := ctx.DB().UpdateBySql(
+		"UPDATE group_member SET status=? WHERE group_no=? AND uid=?",
+		int(common.GroupMemberStatusBlacklist), groupNo, uid,
+	).Exec()
+	require.NoError(t, err)
+}
+
+// TestCanOperate_CreatorBlacklisted_Denied creator 建区后被拉黑，
+// canOperate 必须拒（不能再 short-circuit 给 creator 特权）。
+func TestCanOperate_CreatorBlacklisted_Denied(t *testing.T) {
+	svc, ctx, groupNo, shortID := setupCreatorBlacklistTest(t)
+
+	// 正常 creator 仍放行（基线）。
+	ok, err := svc.canOperate(groupNo, shortID, "creator-u")
+	require.NoError(t, err)
+	assert.True(t, ok, "正常 creator 应有操作权")
+
+	// 被拉黑后必须拒。
+	blacklistMember(t, ctx, groupNo, "creator-u")
+	ok, err = svc.canOperate(groupNo, shortID, "creator-u")
+	require.NoError(t, err)
+	assert.False(t, ok, "被拉黑的 creator 不应再有操作权")
+}
+
+// TestArchiveThread_CreatorBlacklisted_Denied 被拉黑 creator 不能归档自己建的子区。
+func TestArchiveThread_CreatorBlacklisted_Denied(t *testing.T) {
+	svc, ctx, groupNo, shortID := setupCreatorBlacklistTest(t)
+
+	// 正常 creator 先验证可归档。
+	require.NoError(t, svc.ArchiveThread(groupNo, shortID, "creator-u"))
+	require.NoError(t, svc.UnarchiveThread(groupNo, shortID, "creator-u"))
+
+	blacklistMember(t, ctx, groupNo, "creator-u")
+	err := svc.ArchiveThread(groupNo, shortID, "creator-u")
+	assert.Error(t, err, "被拉黑 creator 归档必须被拒")
+	assert.Contains(t, err.Error(), "no permission")
+}
+
+// TestUnarchiveThread_CreatorBlacklisted_Denied 被拉黑 creator 不能取消归档。
+func TestUnarchiveThread_CreatorBlacklisted_Denied(t *testing.T) {
+	svc, ctx, groupNo, shortID := setupCreatorBlacklistTest(t)
+
+	require.NoError(t, svc.ArchiveThread(groupNo, shortID, "creator-u"))
+
+	blacklistMember(t, ctx, groupNo, "creator-u")
+	err := svc.UnarchiveThread(groupNo, shortID, "creator-u")
+	assert.Error(t, err, "被拉黑 creator 取消归档必须被拒")
+	assert.Contains(t, err.Error(), "no permission")
+}
+
+// TestDeleteThread_CreatorBlacklisted_Denied 被拉黑 creator 不能删除自己建的子区。
+func TestDeleteThread_CreatorBlacklisted_Denied(t *testing.T) {
+	svc, ctx, groupNo, shortID := setupCreatorBlacklistTest(t)
+
+	blacklistMember(t, ctx, groupNo, "creator-u")
+	err := svc.DeleteThread(groupNo, shortID, "creator-u")
+	assert.Error(t, err, "被拉黑 creator 删除必须被拒")
+	assert.Contains(t, err.Error(), "no permission")
+}
+
+// TestDeleteThread_CreatorNormal_Allowed 正常 creator 仍可删除（不被 over-block）。
+func TestDeleteThread_CreatorNormal_Allowed(t *testing.T) {
+	svc, _, groupNo, shortID := setupCreatorBlacklistTest(t)
+	assert.NoError(t, svc.DeleteThread(groupNo, shortID, "creator-u"),
+		"正常 creator 删除不应被拦")
+}
+
+// TestUpdateName_CreatorBlacklisted_Denied 被拉黑 creator 不能改子区名。
+func TestUpdateName_CreatorBlacklisted_Denied(t *testing.T) {
+	svc, ctx, groupNo, shortID := setupCreatorBlacklistTest(t)
+
+	// 正常 creator 先验证可改名。
+	require.NoError(t, svc.UpdateName(groupNo, shortID, "creator-u", "新名字"))
+
+	blacklistMember(t, ctx, groupNo, "creator-u")
+	err := svc.UpdateName(groupNo, shortID, "creator-u", "越权改名")
+	assert.Error(t, err, "被拉黑 creator 改名必须被拒")
+	assert.Contains(t, err.Error(), "no permission")
+}
+
+// TestCanEditThreadMd_CreatorBlacklisted_Denied 被拉黑 creator 不能 edit/delete GROUP.md。
+func TestCanEditThreadMd_CreatorBlacklisted_Denied(t *testing.T) {
+	svc, ctx, groupNo, shortID := setupCreatorBlacklistTest(t)
+
+	ok, err := svc.CanEditThreadMd(groupNo, shortID, "creator-u")
+	require.NoError(t, err)
+	assert.True(t, ok, "正常 creator 应能编辑 GROUP.md")
+
+	blacklistMember(t, ctx, groupNo, "creator-u")
+	ok, err = svc.CanEditThreadMd(groupNo, shortID, "creator-u")
+	require.NoError(t, err)
+	assert.False(t, ok, "被拉黑 creator 不应能编辑/删除 GROUP.md")
+}
+
+// TestCanOperate_GroupOwnerBlacklisted_Denied 群主自己被拉黑后也不能管理子区
+// （admin 特权同样在 active 校验之后）。
+func TestCanOperate_GroupOwnerBlacklisted_Denied(t *testing.T) {
+	svc, ctx, groupNo, shortID := setupCreatorBlacklistTest(t)
+
+	// 群主（非 creator）正常时可操作。
+	ok, err := svc.canOperate(groupNo, shortID, "owner-u")
+	require.NoError(t, err)
+	assert.True(t, ok, "正常群主应可管理子区")
+
+	blacklistMember(t, ctx, groupNo, "owner-u")
+	ok, err = svc.canOperate(groupNo, shortID, "owner-u")
+	require.NoError(t, err)
+	assert.False(t, ok, "被拉黑群主不应再能管理子区")
+}

--- a/modules/thread/read_path_blacklist_test.go
+++ b/modules/thread/read_path_blacklist_test.go
@@ -1,0 +1,121 @@
+package thread
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/server"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupReadPathBlacklistData 建一个父群（登录用户 testutil.UID 为正常成员、且是
+// 子区创建者），返回 server/ctx/groupNo/子区 shortID。读路径门禁（list/get/
+// listMembers/getThreadSimple）都查 testutil.UID 的父群 active 成员身份；测试通过
+// 把它的 group_member.status 切到 Blacklist 来验证「normal → later blacklisted」
+// 转换后读路径直接 deny（#345 复审 + ReviewBot P2-test 点名补强）。
+func setupReadPathBlacklistData(t *testing.T) (*server.Server, *config.Context, string, string) {
+	t.Helper()
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	userDB := user.NewDB(ctx)
+	require.NoError(t, userDB.Insert(&user.Model{UID: testutil.UID, Name: "登录用户", ShortNo: "sn_login"}))
+
+	groupNo := strings.ReplaceAll(util.GenerUUID(), "-", "")
+	groupDB := group.NewDB(ctx)
+	require.NoError(t, groupDB.Insert(&group.Model{GroupNo: groupNo, Name: "父群", Creator: testutil.UID, Status: 1, Version: 1}))
+	require.NoError(t, groupDB.InsertMember(&group.MemberModel{
+		GroupNo: groupNo, UID: testutil.UID, Role: group.MemberRoleCreator,
+		Status: int(common.GroupMemberStatusNormal), Version: 1, Vercode: util.GenerUUID(),
+	}))
+
+	// 由登录用户建一个子区作为读目标。
+	svc := NewService(ctx).(*Service)
+	th, err := svc.CreateThread(&CreateThreadReq{
+		GroupNo: groupNo, Name: "读目标子区", CreatorUID: testutil.UID, CreatorName: "登录用户",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, th)
+
+	return s, ctx, groupNo, th.ShortID
+}
+
+func blacklistLoginUser(t *testing.T, ctx *config.Context, groupNo string) {
+	t.Helper()
+	_, err := ctx.DB().UpdateBySql(
+		"UPDATE group_member SET status=? WHERE group_no=? AND uid=?",
+		int(common.GroupMemberStatusBlacklist), groupNo, testutil.UID,
+	).Exec()
+	require.NoError(t, err)
+}
+
+func doGet(t *testing.T, s *server.Server, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", path, nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	return w
+}
+
+// TestReadPath_ListThreads_BlacklistTransition 列表读路径：normal 放行，
+// 被拉黑后直接 deny。
+func TestReadPath_ListThreads_BlacklistTransition(t *testing.T) {
+	s, ctx, groupNo, _ := setupReadPathBlacklistData(t)
+	path := "/v1/groups/" + groupNo + "/threads"
+
+	w := doGet(t, s, path)
+	assert.Equal(t, http.StatusOK, w.Code, "正常成员应能列出子区")
+
+	blacklistLoginUser(t, ctx, groupNo)
+	w = doGet(t, s, path)
+	assert.NotEqual(t, http.StatusOK, w.Code, "被拉黑后列子区必须被拒")
+}
+
+// TestReadPath_GetThread_BlacklistTransition 详情读路径转换。
+func TestReadPath_GetThread_BlacklistTransition(t *testing.T) {
+	s, ctx, groupNo, shortID := setupReadPathBlacklistData(t)
+	path := "/v1/groups/" + groupNo + "/threads/" + shortID
+
+	w := doGet(t, s, path)
+	assert.Equal(t, http.StatusOK, w.Code, "正常成员应能读子区详情")
+
+	blacklistLoginUser(t, ctx, groupNo)
+	w = doGet(t, s, path)
+	assert.NotEqual(t, http.StatusOK, w.Code, "被拉黑后读详情必须被拒")
+}
+
+// TestReadPath_ListMembers_BlacklistTransition 成员列表读路径转换。
+func TestReadPath_ListMembers_BlacklistTransition(t *testing.T) {
+	s, ctx, groupNo, shortID := setupReadPathBlacklistData(t)
+	path := "/v1/groups/" + groupNo + "/threads/" + shortID + "/members"
+
+	w := doGet(t, s, path)
+	assert.Equal(t, http.StatusOK, w.Code, "正常成员应能列子区成员")
+
+	blacklistLoginUser(t, ctx, groupNo)
+	w = doGet(t, s, path)
+	assert.NotEqual(t, http.StatusOK, w.Code, "被拉黑后列成员必须被拒")
+}
+
+// TestReadPath_GetThreadSimple_BlacklistTransition 简化路由读路径转换。
+func TestReadPath_GetThreadSimple_BlacklistTransition(t *testing.T) {
+	s, ctx, groupNo, shortID := setupReadPathBlacklistData(t)
+	path := "/v1/threads/" + shortID
+
+	w := doGet(t, s, path)
+	assert.Equal(t, http.StatusOK, w.Code, "正常成员应能读子区(简化路由)")
+
+	blacklistLoginUser(t, ctx, groupNo)
+	w = doGet(t, s, path)
+	assert.NotEqual(t, http.StatusOK, w.Code, "被拉黑后读子区(简化路由)必须被拒")
+}

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -380,8 +380,18 @@ func (s *Service) UpdateName(groupNo, shortID, operatorUID, name string) error {
 		return errors.New("thread has been deleted")
 	}
 
+	// 子区操作权来自「父群活跃成员」身份：被拉黑/移出父群的用户即使是子区创建者也
+	// 无权改名。必须在授予 creator/admin 特权之前先校验。fail-closed。
+	isActive, err := s.groupService.ExistMemberActive(thread.GroupNo, operatorUID)
+	if err != nil {
+		return fmt.Errorf("check active membership: %w", err)
+	}
+	if !isActive {
+		return errors.New("no permission to update")
+	}
+
 	if thread.CreatorUID != operatorUID {
-		isManager, err := s.groupService.IsCreatorOrManager(groupNo, operatorUID)
+		isManager, err := s.groupService.IsCreatorOrManager(thread.GroupNo, operatorUID)
 		if err != nil {
 			return fmt.Errorf("check permission: %w", err)
 		}
@@ -678,13 +688,25 @@ func (s *Service) canOperate(groupNo, shortID, uid string) (bool, error) {
 		return false, nil
 	}
 
+	// 子区操作权来自「父群活跃成员」身份：被拉黑/移出父群的用户即使是子区创建者或
+	// 群管理员也无权操作。必须在授予 creator/admin 特权之前先校验，否则被拉黑的
+	// 创建者仍能 rename/archive/delete 自己建的子区 + edit/delete 它的 GROUP.md。
+	// fail-closed：parentGroupNo 取自 thread 记录，查询出错或非活跃成员一律拒。
+	isActive, err := s.groupService.ExistMemberActive(thread.GroupNo, uid)
+	if err != nil {
+		return false, fmt.Errorf("check active membership: %w", err)
+	}
+	if !isActive {
+		return false, nil
+	}
+
 	// 创建者可以操作
 	if thread.CreatorUID == uid {
 		return true, nil
 	}
 
 	// 群管理员可以操作
-	isManager, err := s.groupService.IsCreatorOrManager(groupNo, uid)
+	isManager, err := s.groupService.IsCreatorOrManager(thread.GroupNo, uid)
 	if err != nil {
 		return false, fmt.Errorf("check manager permission: %w", err)
 	}

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -155,8 +155,8 @@ func (s *Service) threadVersionGen() func() (int64, error) {
 
 // CreateThread 创建子区
 func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
-	// 验证是群成员
-	isMember, err := s.groupService.ExistMember(req.GroupNo, req.CreatorUID)
+	// 验证是活跃群成员（排除黑名单，被拉黑用户不应能创建子区）
+	isMember, err := s.groupService.ExistMemberActive(req.GroupNo, req.CreatorUID)
 	if err != nil {
 		return nil, fmt.Errorf("check group membership: %w", err)
 	}
@@ -841,8 +841,8 @@ func IsValidGroupNo(groupNo string) bool {
 
 // JoinThread 加入子区
 func (s *Service) JoinThread(groupNo, shortID, uid string) error {
-	// 验证是父群成员
-	isMember, err := s.groupService.ExistMember(groupNo, uid)
+	// 验证是活跃父群成员（排除黑名单，被拉黑用户不应能加入子区）
+	isMember, err := s.groupService.ExistMemberActive(groupNo, uid)
 	if err != nil {
 		return fmt.Errorf("check group membership: %w", err)
 	}
@@ -981,9 +981,9 @@ func (s *Service) IsMember(groupNo, shortID, uid string) (bool, error) {
 }
 
 // UpdateSetting 更新用户对某子区的个人设置(目前支持 mute)
-// 权限: 必须是父群成员; 无需是子区成员(与群聊 setting 行为保持一致)
+// 权限: 必须是活跃父群成员(排除黑名单); 无需是子区成员(与群聊 setting 行为保持一致)
 func (s *Service) UpdateSetting(groupNo, shortID, uid string, settings map[string]interface{}) error {
-	isGroupMember, err := s.groupService.ExistMember(groupNo, uid)
+	isGroupMember, err := s.groupService.ExistMemberActive(groupNo, uid)
 	if err != nil {
 		return fmt.Errorf("check group membership: %w", err)
 	}


### PR DESCRIPTION
## What & why

Fast-follow to #343. #343 switched the **6 message-layer** subchannel (CommunityTopic) read/send gates from blacklist-permissive `ExistMember`/`ExistMembers` to active semantics `ExistMemberActive`/`existMembersActive` (`status=Normal AND is_deleted=0`). But the **thread module** and a few **message bypasses** are pre-existing baseline code that #343 never touched, so the same class of unauthorized read was not closed: a blacklisted user (`status=Blacklist`, `is_deleted=0`) could still pass these gates and read subchannel content.

Two independent reviewers (ReviewBot + Octo-Q) both flagged this residual on #343. This PR unifies the **entire** subchannel authorization surface to active semantics. **Separate PR, not folded into #343.**

## Fixed points (by severity)

**Highest — returns content body (true unauthorized read):**
1. `modules/thread/api.go` `threadMdGet` — returns subchannel `GROUP.md` document body.
2. `modules/message/api_channel_files.go` `channelFiles` — subchannel branch (file name/URL listing via IMSearchUserMessages).

**thread module reads/enumeration:**
3. `api.go` `listThreads`
4. `api.go` `getThread`
5. `api.go` `listMembers`
6. `api.go` `getThreadSimple` (shortID fallback route)

**thread module writes (fail-closed — blacklisted user must not create/join/change settings):**
7. `service.go` `CreateThread`
8. `service.go` `JoinThread`
9. `service.go` `UpdateSetting`

**message bypass:**
10. `modules/message/api.go` `authorizeMutualDelete` subchannel branch.

## How

- All subchannel (CommunityTopic) parent-group checks: `ExistMember` → `ExistMemberActive`.
- **Only CommunityTopic branches changed.** GROUP branches keep `ExistMember`/`ExistMembers` to avoid over-blocking normal members (#343 review confirmed GROUP branch must stay).
- `group.IService` gains an `ExistMemberActive` wrapper over the existing `DB.ExistMemberActive` helper (the interface previously exposed only `ExistMember`/`ExistMembers`).
- fail-closed throughout: errors / parse failures reject.

## Self-check

`grep -rn 'ExistMember(' modules/thread/ modules/message/ | grep -v Active` — remaining hits are all out of scope: thread's own `thread.db.ExistMember` (subchannel-member, not parent-group), the GROUP branch I split out in `channel_files`, GROUP-only branches, and #343's six message points (which land via #343, not here).

## Tests

- `modules/group/exist_member_active_test.go` — DB-layer `ExistMemberActive` (blacklist deny / normal allow / non-member deny), plus a contrast assertion that permissive `ExistMember` still returns true for the blacklisted row.
- `modules/thread/blacklist_membership_test.go` — `CreateThread` / `JoinThread` / `UpdateSetting` blacklist-deny + normal-allow.
- `modules/message/channel_files_blacklist_test.go` — `/channel/files` topic branch blacklist-deny + normal pass-through.
- `go build ./...` + `go vet` + changed-package `go test` all green.

## Note (out of scope, not fixed here)

`modules/message/1module.go:195 checkChannelAccess` (FollowThread/FollowChannel auth) also resolves a parent group with permissive `ExistMember`. It was on the terminal-review P2 list but not in this task's explicit fix set, so it's left for a separate follow-up to keep this PR mechanical and aligned with the assignment.

Part of #343 follow-up.
