### PR TITLE
fix(group): bots always follow their owner — no exit/kick role exceptions, blacklist cascades to owner's bots

### DIFF
--- a/modules/bot_api/group_member_remove_guard_test.go
+++ b/modules/bot_api/group_member_remove_guard_test.go
@@ -1,0 +1,141 @@
+package bot_api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// PR#355 review 守卫：bot_admin 与人类管理员同权，POST
+// /v1/bot/groups/:group_no/members/remove 不得移除群主/管理员。#354 把
+// service 层 RemoveGroupMembers 的 manager 豁免下沉移除后，目标角色校验由
+// 调用方负责——Web API memberRemove 有 creator/manager 守卫，这里验证 Bot
+// API 路径的对等守卫：
+//   - 目标含 manager → 403 cannot_remove_privileged，且整个请求拒绝（混合
+//     列表里的普通成员也不能被"顺带"移除）；
+//   - 目标含 creator → 403 cannot_remove_privileged；
+//   - 目标全为普通成员 → 正常移除（守卫不误伤）。
+
+const (
+	rmGuardGroupNo  = "g_rm_guard_1"
+	rmGuardBotID    = "bot_rm_guard"
+	rmGuardBotToken = "bf_rm_guard_token"
+	rmGuardCreator  = "u_rm_creator"
+	rmGuardManager  = "u_rm_manager"
+	rmGuardCommon   = "u_rm_common"
+)
+
+func setupRemoveGuardEnv(t *testing.T) http.Handler {
+	t.Helper()
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, status, creator_uid, bot_token) VALUES (?, 1, ?, ?)",
+		rmGuardBotID, rmGuardCreator, rmGuardBotToken).Exec()
+	require.NoError(t, err)
+
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO `group` (group_no, name, status, version) VALUES (?, ?, 1, 1)",
+		rmGuardGroupNo, "remove guard group").Exec()
+	require.NoError(t, err)
+
+	// creator(role=1) / manager(role=2) / 普通成员(role=0) / bot 管理员(bot_admin=1)
+	for _, m := range []struct {
+		uid              string
+		role, robot, adm int
+	}{
+		{rmGuardCreator, 1, 0, 0},
+		{rmGuardManager, 2, 0, 0},
+		{rmGuardCommon, 0, 0, 0},
+		{rmGuardBotID, 0, 1, 1},
+	} {
+		_, err = ctx.DB().InsertBySql(
+			"INSERT INTO group_member (group_no, uid, role, robot, bot_admin, vercode, is_deleted, status, version) VALUES (?, ?, ?, ?, ?, ?, 0, 1, 1)",
+			rmGuardGroupNo, m.uid, m.role, m.robot, m.adm, util.GenerUUID()).Exec()
+		require.NoError(t, err)
+	}
+
+	return s.GetRoute()
+}
+
+func rmGuardIsActiveMember(t *testing.T, handler http.Handler, uid string) bool {
+	t.Helper()
+	w := doBot(handler, botReq(t, "GET", "/v1/bot/groups/"+rmGuardGroupNo+"/members", rmGuardBotToken, nil))
+	require.Equalf(t, http.StatusOK, w.Code, "list members body: %s", w.Body.String())
+	// GET /members 返回成员数组；uid 可能出现在响应的其他字段里，所以逐项
+	// 比对而不是对响应体做字符串包含判断。
+	var members []struct {
+		UID string `json:"uid"`
+	}
+	require.NoErrorf(t, json.Unmarshal(w.Body.Bytes(), &members), "list members body: %s", w.Body.String())
+	for _, m := range members {
+		if m.UID == uid {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBotGroupMemberRemove_ManagerTargetForbidden(t *testing.T) {
+	handler := setupRemoveGuardEnv(t)
+
+	w := doBot(handler, botReq(t, "POST", "/v1/bot/groups/"+rmGuardGroupNo+"/members/remove", rmGuardBotToken,
+		map[string]interface{}{"members": []string{rmGuardManager}}))
+	assert.Equalf(t, http.StatusForbidden, w.Code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "cannot be removed through the bot API")
+	assert.True(t, rmGuardIsActiveMember(t, handler, rmGuardManager), "manager must remain a member")
+}
+
+func TestBotGroupMemberRemove_CreatorTargetForbidden(t *testing.T) {
+	handler := setupRemoveGuardEnv(t)
+
+	w := doBot(handler, botReq(t, "POST", "/v1/bot/groups/"+rmGuardGroupNo+"/members/remove", rmGuardBotToken,
+		map[string]interface{}{"members": []string{rmGuardCreator}}))
+	assert.Equalf(t, http.StatusForbidden, w.Code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "cannot be removed through the bot API")
+	assert.True(t, rmGuardIsActiveMember(t, handler, rmGuardCreator), "creator must remain a member")
+}
+
+func TestBotGroupMemberRemove_MixedListRejectedAtomically(t *testing.T) {
+	handler := setupRemoveGuardEnv(t)
+
+	// 混合列表（普通成员 + 管理员）→ 整个请求 403，普通成员也不能被顺带移除。
+	w := doBot(handler, botReq(t, "POST", "/v1/bot/groups/"+rmGuardGroupNo+"/members/remove", rmGuardBotToken,
+		map[string]interface{}{"members": []string{rmGuardCommon, rmGuardManager}}))
+	assert.Equalf(t, http.StatusForbidden, w.Code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "cannot be removed through the bot API")
+	assert.True(t, rmGuardIsActiveMember(t, handler, rmGuardManager), "manager must remain a member")
+	assert.True(t, rmGuardIsActiveMember(t, handler, rmGuardCommon), "common member must not be removed when the request is rejected")
+}
+
+func TestBotGroupMemberRemove_ManagerTargetCaseVariantForbidden(t *testing.T) {
+	handler := setupRemoveGuardEnv(t)
+
+	// MySQL utf8mb4_*_ci collation 下 uid 匹配大小写不敏感：大小写变体在
+	// service 层仍会命中真实 manager 行，所以守卫必须按 DB 解析行的角色
+	// 拦截，而不是在 Go 里做大小写敏感的字符串比对（codex review P1 回归）。
+	w := doBot(handler, botReq(t, "POST", "/v1/bot/groups/"+rmGuardGroupNo+"/members/remove", rmGuardBotToken,
+		map[string]interface{}{"members": []string{strings.ToUpper(rmGuardManager)}}))
+	assert.Equalf(t, http.StatusForbidden, w.Code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "cannot be removed through the bot API")
+	assert.True(t, rmGuardIsActiveMember(t, handler, rmGuardManager), "manager must remain a member")
+}
+
+func TestBotGroupMemberRemove_CommonTargetStillWorks(t *testing.T) {
+	handler := setupRemoveGuardEnv(t)
+
+	w := doBot(handler, botReq(t, "POST", "/v1/bot/groups/"+rmGuardGroupNo+"/members/remove", rmGuardBotToken,
+		map[string]interface{}{"members": []string{rmGuardCommon}}))
+	require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := decodeBody(t, w)
+	assert.Equal(t, true, resp["ok"])
+	assert.Equal(t, float64(1), resp["removed"])
+	assert.False(t, rmGuardIsActiveMember(t, handler, rmGuardCommon), "common member should be removed")
+}

--- a/modules/bot_api/groups.go
+++ b/modules/bot_api/groups.go
@@ -656,6 +656,35 @@ func (ba *BotAPI) botGroupMemberRemove(c *wkhttp.Context) {
 		return
 	}
 
+	// PR#355 review: bot_admin 与人类管理员同权，不能踢群主/管理员——对齐
+	// Web API memberRemove 的角色守卫（manager 不可移除 manager/creator）。
+	// #354 把 service 层 RemoveGroupMembers 的 manager 豁免去掉后，目标角色
+	// 校验完全由调用方负责；不在这里拦截的话，bot_admin=1 的 bot 可以越权
+	// 踢任意管理员并级联带走其 bot。
+	//
+	// 角色校验必须基于 DB 解析后的目标行：WHERE 条件与 service 层
+	// QueryMembersWithUids 完全一致，由 MySQL collation 决定 uid 匹配
+	// （utf8mb4_*_ci 大小写不敏感）。如果改在 Go 里做大小写敏感的字符串
+	// 比对，请求方用 uid 的大小写变体即可绕过守卫、却仍命中 service 层的
+	// 真实 manager 行。
+	var targetRows []struct {
+		UID  string `db:"uid"`
+		Role int    `db:"role"`
+	}
+	_, err = ba.db.session.Select("uid", "role").From("group_member").
+		Where("uid in ? and group_no=? and is_deleted=0", filteredMembers, groupNo).Load(&targetRows)
+	if err != nil {
+		ba.Error("query target members failed", zap.Error(err), zap.String("groupNo", groupNo))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
+		return
+	}
+	for _, row := range targetRows {
+		if row.Role != group.MemberRoleCommon {
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPICannotRemovePrivileged, nil, i18n.Details{"uid": row.UID})
+			return
+		}
+	}
+
 	removeResp, err := ba.groupService.RemoveGroupMembers(&group.RemoveGroupMembersServiceReq{
 		GroupNo:      groupNo,
 		Members:      filteredMembers,

--- a/modules/botfather/api_bot_group_test.go
+++ b/modules/botfather/api_bot_group_test.go
@@ -351,9 +351,14 @@ func TestBotGroupMemberRemove_CannotRemoveCreator(t *testing.T) {
 		"members": []string{testutil.UID},
 	}))
 
-	assert.Equal(t, http.StatusOK, w.Code)
-	result := jsonResult(t, w)
-	assert.Equal(t, float64(0), result["removed"])
+	// PR#355 review (Jerry-Xin): the bot member-remove role guard now rejects
+	// the request outright instead of silently skipping the creator. This
+	// mirrors the Web API memberRemove rule (a manager cannot kick the
+	// creator/managers) — see modules/bot_api/groups.go and the matching
+	// err.server.bot_api.cannot_remove_privileged 403 in
+	// modules/bot_api/group_member_remove_guard_test.go.
+	assert.Equalf(t, http.StatusForbidden, w.Code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "cannot be removed through the bot API")
 }
 
 func TestBotGroupMemberRemove_NotBotAdmin(t *testing.T) {

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -2833,8 +2833,9 @@ func (g *Group) groupExit(c *wkhttp.Context) {
 	**/
 	var newGrouper *MemberModel // 新群主
 	if loginMember.Role == MemberRoleCreator {
-		// 查询第二老成员
-		newGrouper, err = g.db.QuerySecondOldestMember(groupNo)
+		// 查询第二老成员。#354：排除退群群主名下的 bot——它们会在下方被级联带走，
+		// 不能被选为新群主（否则新群主在同一事务内即被删除）。
+		newGrouper, err = g.db.QuerySecondOldestMemberExcludingBotsOf(groupNo, loginUID)
 		if err != nil {
 			g.Error("查询第二元老成员失败！", zap.Error(err))
 			httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
@@ -2896,21 +2897,19 @@ func (g *Group) groupExit(c *wkhttp.Context) {
 	}
 
 	// D-2 · 级联带走 inviter 拉入的 bot（YUJ-49 / Mininglamp-OSS/octo-server#1186）。
-	// Edge case: 群主退群时此逻辑不触发（角色转让由上方 newGrouper 兜底；
-	//            若确要销群应走 DismissGroup）——保持 bot 跟随新群主留在群中。
+	// #354 产品决策：bot 永远跟随其主人，无角色例外——群主退群（角色已由上方
+	// newGrouper 完成转让）同样级联带走自己名下的 bot，和普通成员一致。
 	var cascadedBotUsers []*user.Model
-	if loginMember.Role != MemberRoleCreator {
-		cascadedUIDs, cerr := cascadeRemoveBotsInvitedByUIDTx(g.db, g.ctx, groupNo, loginUID, tx)
-		if cerr != nil {
-			tx.Rollback()
-			g.Error("级联移除 bot 成员失败", zap.Error(cerr))
-			httperr.ResponseErrorL(c, errcode.ErrGroupStoreFailed, nil, nil)
-			return
-		}
-		for _, botUID := range cascadedUIDs {
-			botUser, _ := g.userDB.QueryByUID(botUID)
-			cascadedBotUsers = append(cascadedBotUsers, botUser)
-		}
+	cascadedUIDs, cerr := cascadeRemoveBotsInvitedByUIDTx(g.db, g.ctx, groupNo, loginUID, tx)
+	if cerr != nil {
+		tx.Rollback()
+		g.Error("级联移除 bot 成员失败", zap.Error(cerr))
+		httperr.ResponseErrorL(c, errcode.ErrGroupStoreFailed, nil, nil)
+		return
+	}
+	for _, botUID := range cascadedUIDs {
+		botUser, _ := g.userDB.QueryByUID(botUID)
+		cascadedBotUsers = append(cascadedBotUsers, botUser)
 	}
 
 	// 若退群者是外部成员且当前群是外部群，检查是否需要恢复普通群
@@ -3128,6 +3127,16 @@ func (g *Group) blacklist(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrGroupManagerOnly, nil, nil)
 		return
 	}
+	// #354 · Bot 跟人走：拉黑/解除拉黑级联到目标用户名下在群的 bot
+	// （robot.creator_uid 命中）。旧行为只动用户本人，其 bot 仍 status=Normal，
+	// 被拉黑用户可经自己的 bot 旁路读群/子区内容，绕过 ExistMemberActive
+	// 加固线（#343/#345）。解除拉黑走同一扩展，对称恢复。
+	targetUIDs, err := expandBlacklistTargetsWithOwnedBots(g.db, groupNo, req.Uids)
+	if err != nil {
+		g.Error("查询拉黑级联 bot 失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
+		return
+	}
 	status := 0
 	if action == "add" {
 		status = int(common.GroupMemberStatusBlacklist)
@@ -3141,14 +3150,14 @@ func (g *Group) blacklist(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrGroupStoreFailed, nil, nil)
 		return
 	}
-	err = g.db.updateMembersStatus(version, groupNo, status, req.Uids)
+	err = g.db.updateMembersStatus(version, groupNo, status, targetUIDs)
 	if err != nil {
 		g.Error("添加或移除群成员黑名单错误", zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrGroupStoreFailed, nil, nil)
 		return
 	}
 	if status == int(common.GroupMemberStatusBlacklist) {
-		err = g.setGroupBlacklist(groupNo, req.Uids, status == int(common.GroupMemberStatusBlacklist))
+		err = g.setGroupBlacklist(groupNo, targetUIDs, status == int(common.GroupMemberStatusBlacklist))
 		if err != nil {
 			g.Error("添加IM黑名单错误", zap.Error(err))
 			httperr.ResponseErrorL(c, errcode.ErrGroupStoreFailed, nil, nil)
@@ -3158,18 +3167,19 @@ func (g *Group) blacklist(c *wkhttp.Context) {
 		// 仅靠 setGroupBlacklist(IMBlacklistAdd) 只挡“发送”，不断“接收”——被拉黑者仍
 		// 通过 WuKongIM WS 收子区/父群实时消息（越权读 P0）。子区订阅复用 #27/#332 统一
 		// helper；父群订阅显式 IMRemoveSubscriber。best-effort：失败只记日志、不回滚拉黑。
-		for _, uid := range req.Uids {
+		// #354：级联拉黑的 bot 同样摘除订阅（targetUIDs 已含 bot）。
+		for _, uid := range targetUIDs {
 			g.removeUserFromGroupThreads(groupNo, uid, group.SpaceID)
 		}
 		if rmErr := g.ctx.IMRemoveSubscriber(&config.SubscriberRemoveReq{
 			ChannelID:   groupNo,
 			ChannelType: common.ChannelTypeGroup.Uint8(),
-			Subscribers: req.Uids,
+			Subscribers: targetUIDs,
 		}); rmErr != nil {
 			g.Error("拉黑摘除父群IM订阅失败", zap.Error(rmErr), zap.String("groupNo", groupNo))
 		}
 	} else {
-		members, err := g.db.QueryMembersWithUids(req.Uids, groupNo)
+		members, err := g.db.QueryMembersWithUids(targetUIDs, groupNo)
 		if err != nil {
 			g.Error("查询移除黑名单成员错误", zap.Error(err))
 			httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
@@ -3222,7 +3232,7 @@ func (g *Group) blacklist(c *wkhttp.Context) {
 			return
 		}
 	} else {
-		for _, uid := range req.Uids {
+		for _, uid := range targetUIDs {
 			// 发送群成员更新命令
 			err = g.ctx.SendCMD(config.MsgCMDReq{
 				ChannelID:   groupNo,

--- a/modules/group/api_groupexit_cascade_thread_test.go
+++ b/modules/group/api_groupexit_cascade_thread_test.go
@@ -77,7 +77,7 @@ func TestGroupExit_CascadeBot_AlsoRemovesFromThread(t *testing.T) {
 	f := New(s.ctx)
 	ensureThreadTables(t, f)
 
-	// --- 1. 用户：群主 owner、退群者 leaver（非群主，cascade 前置条件）、bot 本体 ---
+	// --- 1. 用户：群主 owner、退群者 leaver（普通成员场景；#354 起群主退群同样 cascade）、bot 本体 ---
 	insertTestUsers(t, userDB, "owner", "leaver")
 	botUID := "yuj52_bot_by_leaver"
 	require.NoError(t, userDB.Insert(&user.Model{UID: botUID, Name: "bot-by-leaver", ShortNo: "sn_" + botUID, Robot: 1}))

--- a/modules/group/blacklist_bot_cascade_test.go
+++ b/modules/group/blacklist_bot_cascade_test.go
@@ -1,0 +1,217 @@
+package group
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- #354 Gap 2 · 拉黑级联 bot ---
+//
+// blacklist HTTP handler 在本测试环境里会被 IMBlacklistAdd 的前置检查挡住（无 IM 服务），
+// 与 bot_cascade_test.go 中 QuitGroup_* 用例同因。此处按 handler 的真实序列在 DB 层组装：
+// expandBlacklistTargetsWithOwnedBots → updateMembersStatus，再用 ExistMemberActive
+// 验证门禁语义（#343/#345 加固线的同一查询）。
+
+// TestQueryBotUIDsOwnedByUIDs_BasicMatch 验证拉黑级联 SQL 的命中口径：
+// 只挑出「属于目标用户、robot.status=1、仍在群内」的 bot；孤儿/禁用/他人 bot 不命中。
+func TestQueryBotUIDsOwnedByUIDs_BasicMatch(t *testing.T) {
+	svc, userDB := setupServiceTest(t)
+	insertTestUsers(t, userDB, testutil.UID, "m1", "m2")
+
+	resp, err := svc.CreateGroup(&CreateGroupServiceReq{
+		Creator: testutil.UID,
+		Members: []string{"m1", "m2"},
+		Name:    "blacklist-cascade-query",
+	})
+	require.NoError(t, err)
+	groupNo := resp.GroupNo
+
+	s := svc.(*Service)
+	seedBotMember(t, s, groupNo, "bot_m1_x", "bm1x", "m1")
+	seedBotMember(t, s, groupNo, "bot_m1_y", "bm1y", "m1")
+	seedBotMember(t, s, groupNo, "bot_m2", "bm2", "m2")
+	seedBotMember(t, s, groupNo, "bot_orphan", "borphan", "")
+	// 禁用 bot：robot.status=0，不视为任何人的 bot
+	seedBotMember(t, s, groupNo, "bot_disabled", "bdis", "m1")
+	_, err = s.ctx.DB().UpdateBySql("UPDATE robot SET status=0 WHERE robot_id=?", "bot_disabled").Exec()
+	require.NoError(t, err)
+
+	uids, err := s.db.QueryBotUIDsOwnedByUIDs(groupNo, []string{"m1"})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"bot_m1_x", "bot_m1_y"}, uids)
+
+	// 多 owner 批量
+	uids, err = s.db.QueryBotUIDsOwnedByUIDs(groupNo, []string{"m1", "m2"})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"bot_m1_x", "bot_m1_y", "bot_m2"}, uids)
+
+	// 无 bot 的 owner / 空参数 → 空结果，不报错
+	uids, err = s.db.QueryBotUIDsOwnedByUIDs(groupNo, []string{"nobody"})
+	require.NoError(t, err)
+	assert.Empty(t, uids)
+	uids, err = s.db.QueryBotUIDsOwnedByUIDs("", []string{"m1"})
+	require.NoError(t, err)
+	assert.Nil(t, uids)
+	uids, err = s.db.QueryBotUIDsOwnedByUIDs(groupNo, nil)
+	require.NoError(t, err)
+	assert.Nil(t, uids)
+}
+
+// TestExpandBlacklistTargetsWithOwnedBots 验证目标扩展：用户本人 + 名下 bot，按原序去重；
+// 无 bot 时原样返回。
+func TestExpandBlacklistTargetsWithOwnedBots(t *testing.T) {
+	svc, userDB := setupServiceTest(t)
+	insertTestUsers(t, userDB, testutil.UID, "m1", "m2")
+
+	resp, err := svc.CreateGroup(&CreateGroupServiceReq{
+		Creator: testutil.UID,
+		Members: []string{"m1", "m2"},
+		Name:    "blacklist-cascade-expand",
+	})
+	require.NoError(t, err)
+	groupNo := resp.GroupNo
+
+	s := svc.(*Service)
+	seedBotMember(t, s, groupNo, "bot_m1", "bm1", "m1")
+
+	// m1 带 1 个 bot → 扩展为 [m1, bot_m1]
+	out, err := expandBlacklistTargetsWithOwnedBots(s.db, groupNo, []string{"m1"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"m1", "bot_m1"}, out)
+
+	// bot 已显式在目标列表里 → 去重，不重复出现
+	out, err = expandBlacklistTargetsWithOwnedBots(s.db, groupNo, []string{"m1", "bot_m1"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"m1", "bot_m1"}, out)
+
+	// 无 bot 的用户 → 原样返回
+	out, err = expandBlacklistTargetsWithOwnedBots(s.db, groupNo, []string{"m2"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"m2"}, out)
+}
+
+// TestBlacklistCascade_BotBlockedByExistMemberActive 核心安全断言（#354 Gap 2）：
+// 拉黑用户后其 bot 必须过不了 ExistMemberActive（子区读写门禁直接拒绝），
+// 解除拉黑后对称恢复。模拟 blacklist handler 的 add / remove 两分支序列。
+func TestBlacklistCascade_BotBlockedByExistMemberActive(t *testing.T) {
+	svc, userDB := setupServiceTest(t)
+	insertTestUsers(t, userDB, testutil.UID, "m1", "m2")
+
+	resp, err := svc.CreateGroup(&CreateGroupServiceReq{
+		Creator: testutil.UID,
+		Members: []string{"m1", "m2"},
+		Name:    "blacklist-cascade-gate",
+	})
+	require.NoError(t, err)
+	groupNo := resp.GroupNo
+
+	s := svc.(*Service)
+	seedBotMember(t, s, groupNo, "bot_m1", "bm1", "m1")
+	seedBotMember(t, s, groupNo, "bot_m2", "bm2", "m2") // 旁观者，不应被波及
+
+	// --- add 分支：targets = m1 + 其 bot，status → Blacklist ---
+	targets, err := expandBlacklistTargetsWithOwnedBots(s.db, groupNo, []string{"m1"})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"m1", "bot_m1"}, targets)
+
+	version, err := s.ctx.GenSeq(common.GroupMemberSeqKey)
+	require.NoError(t, err)
+	require.NoError(t, s.db.updateMembersStatus(version, groupNo, int(common.GroupMemberStatusBlacklist), targets))
+
+	// 被拉黑用户和其 bot 都过不了 ExistMemberActive（旧行为：bot 仍 Normal → 旁路读口子）
+	for _, uid := range []string{"m1", "bot_m1"} {
+		ok, err := s.db.ExistMemberActive(uid, groupNo)
+		require.NoError(t, err)
+		assert.False(t, ok, "%s 拉黑后必须被 ExistMemberActive 拒绝（#354）", uid)
+	}
+	// 仍是成员（is_deleted=0），拉黑可逆
+	for _, uid := range []string{"m1", "bot_m1"} {
+		ok, err := s.db.ExistMember(uid, groupNo)
+		require.NoError(t, err)
+		assert.True(t, ok, "%s 拉黑只翻 status，不删成员", uid)
+	}
+	// 他人和他人的 bot 不受波及
+	for _, uid := range []string{"m2", "bot_m2"} {
+		ok, err := s.db.ExistMemberActive(uid, groupNo)
+		require.NoError(t, err)
+		assert.True(t, ok, "%s 与本次拉黑无关，不应被误伤", uid)
+	}
+
+	// --- remove 分支：同一扩展对称恢复，status → Normal ---
+	targets, err = expandBlacklistTargetsWithOwnedBots(s.db, groupNo, []string{"m1"})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"m1", "bot_m1"}, targets,
+		"解除拉黑时扩展必须仍命中 Blacklist 状态的 bot（查询不过滤 status）")
+
+	version, err = s.ctx.GenSeq(common.GroupMemberSeqKey)
+	require.NoError(t, err)
+	require.NoError(t, s.db.updateMembersStatus(version, groupNo, int(common.GroupMemberStatusNormal), targets))
+
+	for _, uid := range []string{"m1", "bot_m1"} {
+		ok, err := s.db.ExistMemberActive(uid, groupNo)
+		require.NoError(t, err)
+		assert.True(t, ok, "%s 解除拉黑后必须恢复 ExistMemberActive（对称恢复）", uid)
+	}
+}
+
+// TestRemoveGroupMembers_ManagerKickCascadesBots 验证 #354 Gap 1b：manager 不再豁免，
+// 被踢的管理员连同其拉入的 bot 一并带走；creator 仍不可被踢（保底豁免回归）。
+func TestRemoveGroupMembers_ManagerKickCascadesBots(t *testing.T) {
+	svc, userDB := setupServiceTest(t)
+	insertTestUsers(t, userDB, testutil.UID, "mgr", "m2")
+
+	resp, err := svc.CreateGroup(&CreateGroupServiceReq{
+		Creator: testutil.UID,
+		Members: []string{"mgr", "m2"},
+		Name:    "kick-manager-cascade",
+	})
+	require.NoError(t, err)
+	groupNo := resp.GroupNo
+
+	s := svc.(*Service)
+	// mgr 升为管理员
+	version, err := s.ctx.GenSeq(common.GroupMemberSeqKey)
+	require.NoError(t, err)
+	require.NoError(t, s.db.UpdateMembersToManager(groupNo, []string{"mgr"}, version))
+	mgrMember, err := s.db.QueryMemberWithUID("mgr", groupNo)
+	require.NoError(t, err)
+	require.Equal(t, MemberRoleManager, mgrMember.Role)
+
+	seedBotMember(t, s, groupNo, "bot_mgr", "bmgr", "mgr")
+	seedBotMember(t, s, groupNo, "bot_m2", "bm2", "m2") // 不应被波及
+
+	removeResp, err := svc.RemoveGroupMembers(&RemoveGroupMembersServiceReq{
+		GroupNo:      groupNo,
+		Members:      []string{"mgr"},
+		OperatorUID:  testutil.UID,
+		OperatorName: "creator",
+	})
+	require.NoError(t, err)
+
+	// manager 本人 + 其 bot 一并移除（#354：manager 例外已去掉）
+	assert.Equal(t, 2, removeResp.Removed)
+	assert.ElementsMatch(t, []string{"mgr", "bot_mgr"}, removeResp.RemovedUIDs)
+
+	for _, uid := range []string{"mgr", "bot_mgr"} {
+		exist, err := s.db.ExistMember(uid, groupNo)
+		require.NoError(t, err)
+		assert.False(t, exist, "%s 应已随踢人级联离群（#354）", uid)
+	}
+	exist, err := s.db.ExistMember("bot_m2", groupNo)
+	require.NoError(t, err)
+	assert.True(t, exist, "他人 bot 不应被误伤")
+
+	// creator 仍不可被踢（豁免保底回归）
+	removeResp, err = svc.RemoveGroupMembers(&RemoveGroupMembersServiceReq{
+		GroupNo:      groupNo,
+		Members:      []string{testutil.UID},
+		OperatorUID:  testutil.UID,
+		OperatorName: "creator",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, removeResp.Removed, "creator 永远不可被踢")
+}

--- a/modules/group/bot_cascade.go
+++ b/modules/group/bot_cascade.go
@@ -51,6 +51,41 @@ func cascadeRemoveBotsInvitedByUIDTx(
 	return removed, nil
 }
 
+// expandBlacklistTargetsWithOwnedBots 把拉黑/解除拉黑的目标 uid 列表扩展为
+// 「用户本人 + 其名下在群 bot」，按原序去重后返回。
+//
+// #354 产品决策：bot 永远跟随其主人。拉黑用户时若不连带其 bot（旧行为：bot 仍
+// status=Normal），被拉黑用户可经自己的 bot 旁路读群/子区内容，绕过
+// ExistMemberActive 加固线（#343/#345）。解除拉黑走同一扩展，保证对称恢复。
+//
+// 查询失败返回 error，由调用方决定中断（拉黑是权限敏感操作，fail closed）。
+func expandBlacklistTargetsWithOwnedBots(db *DB, groupNo string, uids []string) ([]string, error) {
+	botUIDs, err := db.QueryBotUIDsOwnedByUIDs(groupNo, uids)
+	if err != nil {
+		return nil, fmt.Errorf("query bots owned by blacklist targets: %w", err)
+	}
+	if len(botUIDs) == 0 {
+		return uids, nil
+	}
+	seen := make(map[string]struct{}, len(uids)+len(botUIDs))
+	out := make([]string, 0, len(uids)+len(botUIDs))
+	for _, uid := range uids {
+		if _, ok := seen[uid]; ok {
+			continue
+		}
+		seen[uid] = struct{}{}
+		out = append(out, uid)
+	}
+	for _, uid := range botUIDs {
+		if _, ok := seen[uid]; ok {
+			continue
+		}
+		seen[uid] = struct{}{}
+		out = append(out, uid)
+	}
+	return out, nil
+}
+
 // sendBotCascadeRemovedTip 发送 D-2 级联移除 bot 的系统消息。
 //
 // 场景：inviter 离群 / 被踢时，其邀请的 bot 被同事务级联移除。为避免「bot 神秘消失」

--- a/modules/group/bot_cascade_test.go
+++ b/modules/group/bot_cascade_test.go
@@ -328,42 +328,94 @@ func TestQuitGroup_CreatorOwnsNoBot_NoOp(t *testing.T) {
 	assert.True(t, exist, "他人 bot 无关，不应被误伤")
 }
 
-// TestQuitGroup_CreatorRoleSkipsCascade 验证 edge case：若退群的人是群主，
-// groupExit 上层会跳过 cascade（见 api.go 的 if loginMember.Role != MemberRoleCreator 守卫）。
-// 本测试直接不调 cascade，只断言 bot 不被带走，体现守卫语义。
-func TestQuitGroup_CreatorRoleSkipsCascade(t *testing.T) {
+// TestQuitGroup_CreatorCascadesBots 验证 #354 产品决策：bot 永远跟随其主人，无角色例外。
+// 群主退群时（角色先转让给 newGrouper），其名下 bot 同样被级联带走；
+// 新群主人选必须排除退群群主名下的 bot（否则新群主在同一事务内即被级联删除）。
+// 本测试按 groupExit 的新事务序列组装：选主（排除 leaver 的 bot）→ 转让 → 删 leaver → cascade。
+func TestQuitGroup_CreatorCascadesBots(t *testing.T) {
 	svc, userDB := setupServiceTest(t)
 	insertTestUsers(t, userDB, testutil.UID, "m1")
 
 	resp, err := svc.CreateGroup(&CreateGroupServiceReq{
 		Creator: testutil.UID,
 		Members: []string{"m1"},
-		Name:    "quit-cascade-creator-skip",
+		Name:    "quit-cascade-creator",
 	})
 	assert.NoError(t, err)
 	groupNo := resp.GroupNo
 
 	s := svc.(*Service)
-	// 群主自己拉的 bot
+	// 群主自己拉的 bot；把 bot 的 created_at 提前，使其成为「第二元老」，
+	// 验证选主 SQL 确实排除 leaver 名下 bot 而选中人类成员 m1。
 	seedBotMember(t, s, groupNo, "bot_by_creator", "creator-bot", testutil.UID)
+	_, err = s.ctx.DB().UpdateBySql(
+		"UPDATE group_member SET created_at = DATE_SUB(NOW(), INTERVAL 1 DAY) WHERE group_no=? AND uid=?",
+		groupNo, "bot_by_creator",
+	).Exec()
+	assert.NoError(t, err)
 
-	// 模拟 groupExit 里的守卫：role==creator 时跳过 cascade，这里 role 确实是 creator
 	member, err := s.db.QueryMemberWithUID(testutil.UID, groupNo)
 	assert.NoError(t, err)
 	assert.Equal(t, MemberRoleCreator, member.Role)
 
+	// 选主：必须跳过 leaver 名下的 bot，选中 m1
+	newGrouper, err := s.db.QuerySecondOldestMemberExcludingBotsOf(groupNo, testutil.UID)
+	assert.NoError(t, err)
+	assert.NotNil(t, newGrouper)
+	assert.Equal(t, "m1", newGrouper.UID, "新群主不能是退群群主名下的 bot")
+
 	tx, err := s.ctx.DB().Begin()
 	assert.NoError(t, err)
-	leaverVersion, _ := s.ctx.GenSeq(common.GroupMemberSeqKey)
-	assert.NoError(t, s.db.DeleteMemberTx(groupNo, testutil.UID, leaverVersion, tx))
-	// 守卫条件触发 → 不调 cascade
-	if member.Role != MemberRoleCreator {
-		_, _ = cascadeRemoveBotsInvitedByUIDTx(s.db, s.ctx, groupNo, testutil.UID, tx)
-	}
+	version, _ := s.ctx.GenSeq(common.GroupMemberSeqKey)
+	assert.NoError(t, s.db.UpdateMemberRoleTx(groupNo, newGrouper.UID, MemberRoleCreator, version, tx))
+	assert.NoError(t, s.db.DeleteMemberTx(groupNo, testutil.UID, version, tx))
+	// #354：cascade 无角色例外，群主退群同样触发
+	cascaded, err := cascadeRemoveBotsInvitedByUIDTx(s.db, s.ctx, groupNo, testutil.UID, tx)
+	assert.NoError(t, err)
 	assert.NoError(t, tx.Commit())
 
-	// bot 应留下（留给继任群主）
+	assert.ElementsMatch(t, []string{"bot_by_creator"}, cascaded, "群主的 bot 必须随群主离群（#354）")
+
 	exist, err := s.db.ExistMember("bot_by_creator", groupNo)
 	assert.NoError(t, err)
-	assert.True(t, exist, "creator 退群不触发 cascade（由 DismissGroup 兜底）")
+	assert.False(t, exist, "creator 退群其 bot 必须被级联带走，无角色例外（#354）")
+
+	// 新群主 m1 仍在群且为 creator
+	m1Member, err := s.db.QueryMemberWithUID("m1", groupNo)
+	assert.NoError(t, err)
+	assert.NotNil(t, m1Member)
+	assert.Equal(t, MemberRoleCreator, m1Member.Role)
+	assert.Equal(t, 0, m1Member.IsDeleted)
+}
+
+// TestQuerySecondOldestMemberExcludingBotsOf_OnlyBotsLeft 群里除群主外只剩群主自己的 bot 时，
+// 选主返回 nil（群随之清空），不能把即将级联离群的 bot 提为新群主。
+func TestQuerySecondOldestMemberExcludingBotsOf_OnlyBotsLeft(t *testing.T) {
+	svc, userDB := setupServiceTest(t)
+	insertTestUsers(t, userDB, testutil.UID, "m1")
+
+	resp, err := svc.CreateGroup(&CreateGroupServiceReq{
+		Creator: testutil.UID,
+		Members: []string{"m1"},
+		Name:    "quit-cascade-only-bots",
+	})
+	assert.NoError(t, err)
+	groupNo := resp.GroupNo
+
+	s := svc.(*Service)
+	// m1 离群，群里只剩群主 + 群主自己的 bot
+	version, _ := s.ctx.GenSeq(common.GroupMemberSeqKey)
+	assert.NoError(t, s.db.DeleteMember(groupNo, "m1", version))
+	seedBotMember(t, s, groupNo, "bot_only", "only-bot", testutil.UID)
+
+	newGrouper, err := s.db.QuerySecondOldestMemberExcludingBotsOf(groupNo, testutil.UID)
+	assert.NoError(t, err)
+	assert.Nil(t, newGrouper, "群里只剩 leaver 自己的 bot 时不应选出新群主")
+
+	// 他人的 bot 不受排除影响（保持旧选主语义）
+	seedBotMember(t, s, groupNo, "bot_other", "other-bot", "someone_else")
+	newGrouper, err = s.db.QuerySecondOldestMemberExcludingBotsOf(groupNo, testutil.UID)
+	assert.NoError(t, err)
+	assert.NotNil(t, newGrouper)
+	assert.Equal(t, "bot_other", newGrouper.UID, "他人的 bot 不在排除范围内（与旧 QuerySecondOldestMember 语义一致）")
 }

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -80,13 +80,6 @@ func (d *DB) deleteMembersWithGroupNOTx(groupNo string, tx *dbr.Tx) error {
 	return err
 }
 
-// QuerySecondOldestMember 查询群里第二长老
-func (d *DB) QuerySecondOldestMember(groupNo string) (*MemberModel, error) {
-	var memberModel *MemberModel
-	_, err := d.session.Select("*").From("group_member").Where("group_no=? and role<>? and is_deleted=0", groupNo, MemberRoleCreator).OrderDir("created_at", true).Load(&memberModel)
-	return memberModel, err
-}
-
 // 通过vercode查询某个群成员
 func (d *DB) queryMemberWithVercode(vercode string) (*MemberModel, error) {
 	var memberModel *MemberModel
@@ -766,6 +759,48 @@ func (d *DB) QueryBotsInvitedByUIDTx(groupNo string, inviterUID string, tx *dbr.
 		groupNo, inviterUID,
 	).Load(&uids)
 	return uids, err
+}
+
+// QueryBotUIDsOwnedByUIDs 查询群内由 ownerUIDs 中任一用户名下（robot.creator_uid）
+// 的未删除 bot 成员 UID 列表。与 QueryBotsInvitedByUIDTx 同口径：只命中
+// group_member.robot=1 AND is_deleted=0 且 robot.status=1 的 bot；孤儿（无 robot 行）
+// 或禁用（status=0）bot 不视为任何人的 bot，不被级联。
+//
+// 非事务、无行锁版本，供拉黑/解除拉黑级联（#354）这类不开事务的路径使用：
+// 被拉黑用户的 bot 若不连带拉黑，用户可经 bot 旁路读群/子区内容，
+// 绕过 ExistMemberActive 加固线（#343/#345）。
+// 故意不过滤 group_member.status：解除拉黑时需要把已是 Blacklist 状态的 bot 一并恢复。
+func (d *DB) QueryBotUIDsOwnedByUIDs(groupNo string, ownerUIDs []string) ([]string, error) {
+	if groupNo == "" || len(ownerUIDs) == 0 {
+		return nil, nil
+	}
+	var uids []string
+	_, err := d.session.SelectBySql(
+		"SELECT gm.uid FROM group_member gm "+
+			"INNER JOIN robot r ON r.robot_id = gm.uid AND r.status = 1 "+
+			"WHERE gm.group_no = ? AND gm.robot = 1 AND gm.is_deleted = 0 "+
+			"AND r.creator_uid IN ?",
+		groupNo, ownerUIDs,
+	).Load(&uids)
+	return uids, err
+}
+
+// QuerySecondOldestMemberExcludingBotsOf 选出第二元老成员（群主退群时的新群主人选），
+// 在 QuerySecondOldestMember 的基础上额外排除 leaverUID 名下（robot.creator_uid）的
+// 活跃 bot：#354 起群主退群也会级联带走自己的 bot，这些 bot 在同一事务内即将离群，
+// 不能被选为新群主（否则会出现「新群主刚上任就被级联删除」的孤儿群）。
+// 其他人的 bot 不受影响，保持与旧选主逻辑一致。
+func (d *DB) QuerySecondOldestMemberExcludingBotsOf(groupNo string, leaverUID string) (*MemberModel, error) {
+	var memberModel *MemberModel
+	_, err := d.session.SelectBySql(
+		"SELECT gm.* FROM group_member gm "+
+			"LEFT JOIN robot r ON r.robot_id = gm.uid AND r.status = 1 AND r.creator_uid = ? "+
+			"WHERE gm.group_no = ? AND gm.role <> ? AND gm.is_deleted = 0 "+
+			"AND r.robot_id IS NULL "+
+			"ORDER BY gm.created_at ASC LIMIT 1",
+		leaverUID, groupNo, MemberRoleCreator,
+	).Load(&memberModel)
+	return memberModel, err
 }
 
 // QueryExternalMemberCountTx 事务内查询群内「人类」外部成员数量（FOR UPDATE 行锁防并发）。

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -1564,10 +1564,13 @@ func (s *Service) RemoveGroupMembers(req *RemoveGroupMembersServiceReq) (*Remove
 		return nil, errors.New("none of the members are in this group")
 	}
 
-	// 过滤：跳过群主、管理员、已删除的成员
+	// 过滤：跳过群主、已删除的成员。
+	// #354 产品决策：bot 永远跟随其主人，无角色例外——manager 不再豁免，
+	// 被踢的管理员连同其拉入的 bot 一并带走（API 层 memberRemove 已限制
+	// 只有群主能踢管理员；creator 仍不可被踢）。
 	var removableMembers []*MemberModel
 	for _, m := range targetMembers {
-		if m.IsDeleted == 1 || m.Role == MemberRoleCreator || m.Role == MemberRoleManager {
+		if m.IsDeleted == 1 || m.Role == MemberRoleCreator {
 			continue
 		}
 		removableMembers = append(removableMembers, m)
@@ -1619,8 +1622,8 @@ func (s *Service) RemoveGroupMembers(req *RemoveGroupMembersServiceReq) (*Remove
 		removedVos = append(removedVos, &config.UserBaseVo{UID: m.UID, Name: name})
 
 		// D-2 · 级联带走该成员拉入的 bot（#1186 / YUJ-49）。
-		// 只对非群主 / 非管理员成员触发；上层 filter 已排除 creator/manager，这里保底再判一次。
-		if m.Role == MemberRoleCreator || m.Role == MemberRoleManager {
+		// #354：manager 被踢时 bot 一并带走，仅 creator 保底豁免（上层 filter 已排除）。
+		if m.Role == MemberRoleCreator {
 			continue
 		}
 		cascadedUIDs, cerr := cascadeRemoveBotsInvitedByUIDTx(s.db, s.ctx, req.GroupNo, m.UID, tx)

--- a/pkg/errcode/bot_api.go
+++ b/pkg/errcode/bot_api.go
@@ -123,6 +123,17 @@ var (
 		HTTPStatus:     http.StatusForbidden,
 		DefaultMessage: "The bot is not an admin of this group.",
 	})
+	// ErrBotAPICannotRemovePrivileged covers the bot-API member-remove role
+	// guard: a bot admin is manager-level at most, so it may not remove the
+	// group owner or a manager (mirrors the Web API memberRemove rule where a
+	// manager cannot kick managers/creator). The first offending uid is
+	// surfaced via Details so the adapter can pinpoint the rejected target.
+	ErrBotAPICannotRemovePrivileged = register(codes.Code{
+		ID:             "err.server.bot_api.cannot_remove_privileged",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "The group owner and managers cannot be removed through the bot API.",
+		SafeDetailKeys: []string{"uid"},
+	})
 	// ErrBotAPINotSpaceMember covers the bot/user-not-a-space-member guard.
 	ErrBotAPINotSpaceMember = register(codes.Code{
 		ID:             "err.server.bot_api.not_space_member",

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -934,6 +934,9 @@ other = "机器人不是该群成员。"
 ["err.server.bot_api.not_group_admin"]
 other = "机器人不是该群管理员。"
 
+["err.server.bot_api.cannot_remove_privileged"]
+other = "群主和管理员不能通过机器人 API 移除。"
+
 ["err.server.bot_api.not_space_member"]
 other = "不是该空间成员。"
 

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -30,6 +30,9 @@ other = "The grantee is not a registered bot."
 ["err.server.bot_api.bot_unavailable"]
 other = "The bot is not available."
 
+["err.server.bot_api.cannot_remove_privileged"]
+other = "The group owner and managers cannot be removed through the bot API."
+
 ["err.server.bot_api.content_too_large"]
 other = "The content exceeds the maximum allowed size."
 


### PR DESCRIPTION
Fixes #354

Product decision: **a user's bots always follow the user — no role exceptions.** When a user leaves, is kicked, or is blacklisted, every bot they created and invited into the group must follow them. This closes the two gaps left after the D-2 cascade (#1186 / #1189).

## Gap 1 — creator/manager exceptions on the exit/kick cascade

- **`groupExit`**: removed the `loginMember.Role != MemberRoleCreator` guard. A group owner who exits (after ownership transfer to the second-oldest member) now cascades exactly like a normal member: bot members removed in the same transaction, plus the existing thread_member / IM subscription / pinned / conv_ext cleanup and the system tip.
  - New-owner selection now uses `QuerySecondOldestMemberExcludingBotsOf`, which excludes the leaving owner's own bots — otherwise a bot could be promoted to creator and cascade-deleted in the same transaction, leaving the group ownerless. Other users' bots keep the old selection semantics.
- **`RemoveGroupMembers`**: dropped the manager exception from the removable filter and from the per-member cascade guard. A kicked manager leaves together with their bots. Creator keeps the belt-and-suspenders exemption (cannot be kicked; API-level `memberRemove` already restricts manager removal to the owner).

## Gap 2 — blacklist had no cascade at all

Previously `blacklist add` only flipped the target user's member status + IM blacklist. Their bots stayed `status=Normal`, so a blacklisted user could keep reading group/subchannel content **through their own bot**, bypassing the entire `ExistMemberActive` hardening line (#343 / #345).

- On blacklist add/remove, the target list is expanded with the users' in-group bots (`robot.creator_uid` match, same fail-closed ownership semantics as the D-2 cascade: orphan/disabled bots are not anyone's bot).
- The bots then go through the same pipeline as the user: member status flip, IM blacklist add/remove, parent-group + subchannel subscription teardown (YUJ-4185 line), and symmetric restore on un-blacklist.
- The ownership query intentionally does not filter `group_member.status`, so un-blacklist finds the bots that are currently in `Blacklist` state and restores them.

## Tests

- `TestQuitGroup_CreatorCascadesBots` — owner exits → ownership transferred to a human (bot excluded from selection), owner's bot cascade-removed.
- `TestQuerySecondOldestMemberExcludingBotsOf_OnlyBotsLeft` — no new owner when only the leaver's bots remain; other users' bots unaffected.
- `TestRemoveGroupMembers_ManagerKickCascadesBots` — kicked manager + their bot both removed; creator still unkickable.
- `TestQueryBotUIDsOwnedByUIDs_BasicMatch` / `TestExpandBlacklistTargetsWithOwnedBots` — cascade target expansion semantics (ownership scoping, orphan/disabled exclusion, dedupe).
- `TestBlacklistCascade_BotBlockedByExistMemberActive` — blacklisted user's bot fails `ExistMemberActive` (subchannel read/write gate denies); un-blacklist symmetrically restores; bystanders untouched.
- Existing D-2 cascade suites (`bot_cascade_test.go`, `api_groupexit_cascade_thread_test.go`) pass unchanged except the obsolete creator-skip case, which now asserts the new product decision.

Full `modules/group`, `modules/bot_api`, `modules/thread`, `modules/message`, `modules/user`, `modules/robot`, `modules/webhook` suites pass locally.
<!-- sprint-set-retrigger -->