### PR TITLE
fix(conversation_ext): exclude blacklisted members from thread-ext materialization (fanout + FollowChannel)

### DIFF
--- a/modules/conversation_ext/service.go
+++ b/modules/conversation_ext/service.go
@@ -101,6 +101,23 @@ type DefaultFollowedGroupGuard interface {
 	FilterDefaultFollowed(uid, spaceID string, candidateGroupNos []string) ([]string, error)
 }
 
+// ActiveMemberFilter 把一批 uid 过滤为「仍是 groupNo 活跃成员」（is_deleted=0 AND
+// status=Normal，排除被拉黑成员）的子集。窄接口、依赖倒置，由 message/1module.go
+// 注入实现（group.IService），避免 conversation_ext 直接 import group 形成循环依赖。
+//
+// 引入背景（issue #351 / PR #345 mandatory follow-up）：AuthorizeChannelFollow
+// 对 GROUP follow 有意保持 permissive ExistMember，但 FollowChannel 不是纯群操作——
+// 它写 auto_follow_threads=1 并物化既有子区 ext 行；OnThreadCreated fanout 也只
+// re-check ext flag（auto_follow_threads=1 AND group_unfollowed=0），不查群成员
+// 状态。被拉黑的父群成员因此持续收到既有/新建子区的 ext 行与创建通知（元数据层
+// 泄漏；内容读已被 ExistMemberActive 门禁拦住）。本接口用于在这两条子区物化写
+// 路径上按 active membership 过滤：GROUP 行本身的语义不变。
+type ActiveMemberFilter interface {
+	// FilterActiveMemberUIDs 返回 uids 中当前是 groupNo 活跃成员的子集。
+	// 实现不要求保序，也不要求去重输入。
+	FilterActiveMemberUIDs(groupNo string, uids []string) ([]string, error)
+}
+
 // ThreadEnumerator 是 FollowChannel 级联物化子区时使用的窄接口。
 // 与 ThreadAuthChecker 一样采用依赖倒置，避免 conversation_ext 直接 import thread。
 // 由 message/1module.go 启动时通过 SetThreadEnumerator 注入；nil 时跳过物化
@@ -158,6 +175,11 @@ type Service struct {
 	// DefaultFollowedGroups 直接返回空——fail-closed 比放过更安全。
 	defaultFollowedGuard  DefaultFollowedGroupGuard
 	defaultFollowedGuardM sync.RWMutex
+	// activeMemberFilter 是子区 ext 物化写路径（FollowChannel Phase 2/3 +
+	// OnThreadCreated fanout）的活跃成员过滤钩子（issue #351）。由 message/1module.go
+	// 启动时注入；nil 时跳过过滤（仅供单测 / 迁移期使用，与 threadAuth 同约定）。
+	activeMemberFilter  ActiveMemberFilter
+	activeMemberFilterM sync.RWMutex
 	log.Log
 }
 
@@ -235,6 +257,24 @@ func (s *Service) getDefaultFollowedGroupGuard() DefaultFollowedGroupGuard {
 	g := s.defaultFollowedGuard
 	s.defaultFollowedGuardM.RUnlock()
 	return g
+}
+
+// SetActiveMemberFilter injects the active-membership filter used by the two
+// thread-ext materialization write paths (FollowChannel Phase 2/3 and the
+// OnThreadCreated fanout) — issue #351.  Safe for concurrent use; intended to
+// be called once at startup from message/1module.go after the group module
+// has initialised.
+func (s *Service) SetActiveMemberFilter(f ActiveMemberFilter) {
+	s.activeMemberFilterM.Lock()
+	s.activeMemberFilter = f
+	s.activeMemberFilterM.Unlock()
+}
+
+func (s *Service) getActiveMemberFilter() ActiveMemberFilter {
+	s.activeMemberFilterM.RLock()
+	f := s.activeMemberFilter
+	s.activeMemberFilterM.RUnlock()
+	return f
 }
 
 // AuthorizeAndMaterializeDefaultFollowedGroups is the pre-flight step the
@@ -399,6 +439,25 @@ func (s *Service) FollowChannel(uid, spaceID, groupNo string) error {
 		return nil
 	}); err != nil {
 		return err
+	}
+
+	// issue #351（PR #345 mandatory follow-up）：子区 ext 物化只面向「活跃父群成员」。
+	// GROUP follow 本身保持 permissive（Phase 1 已写群行，与 AuthorizeChannelFollow
+	// 的 GROUP 语义一致），但被拉黑成员不得借 FollowChannel 重新物化既有子区 ext 行
+	// （元数据泄漏——removeUserFromGroupThreadsCleanup 在拉黑时已删过一轮）。
+	// auto_follow_threads=1 保留：OnThreadCreated fanout 侧同样按 active 过滤，flag
+	// 残留期间无泄漏；解除拉黑后新子区 fanout 自动恢复，无需用户重新操作。
+	// nil filter 仅用于单测 / 迁移期（与 threadAuth / channelAuth 同约定）。
+	if filter := s.getActiveMemberFilter(); filter != nil {
+		activeUIDs, err := filter.FilterActiveMemberUIDs(groupNo, []string{uid})
+		if err != nil {
+			// Phase 1 已 commit（群行语义不受影响）；过滤失败 fail-closed 跳过物化，
+			// 错误向上返回让调用方记录。缺失的子区行由下次 FollowChannel / fanout 补齐。
+			return fmt.Errorf("FollowChannel filter active member: %w", err)
+		}
+		if len(activeUIDs) == 0 {
+			return nil
+		}
 	}
 
 	enum := s.getThreadEnumerator()
@@ -624,6 +683,22 @@ func (s *Service) OnThreadCreated(groupNo, shortID string) error {
 		return nil
 	}
 
+	// 1.5 issue #351（PR #345 mandatory follow-up）：按「活跃父群成员」过滤 fanout
+	//     目标。auto_follow_threads=1 只代表用户曾关注 channel，不代表当前仍可见——
+	//     被拉黑（status=Blacklist）成员的群行 flag 仍在，但不应再收到新子区的 ext
+	//     行 / 创建通知（元数据层泄漏；内容读已被 ExistMemberActive 门禁兜住）。
+	//     与初始 SELECT 一样在 tx 外执行（快照语义，不延长锁窗口）；解除拉黑后
+	//     从下一条新子区起自动恢复 fanout。nil filter 仅用于单测 / 迁移期。
+	if filter := s.getActiveMemberFilter(); filter != nil {
+		targets, err = filterFanoutTargetsByActiveMembership(filter, groupNo, targets)
+		if err != nil {
+			return fmt.Errorf("OnThreadCreated filter active members: %w", err)
+		}
+		if len(targets) == 0 {
+			return nil
+		}
+	}
+
 	threadChannelID := groupNo + threadSeparator + shortID
 
 	// 2. 按 batch 切分，每 batch 一个 tx：
@@ -721,6 +796,37 @@ func isRetriableMySQLLockErr(err error) bool {
 type onThreadCreatedTarget = struct {
 	UID     string `db:"uid"`
 	SpaceID string `db:"space_id"`
+}
+
+// filterFanoutTargetsByActiveMembership 把 OnThreadCreated 的 fanout 目标过滤为
+// 「仍是 groupNo 活跃成员」的子集（issue #351）。同一 uid 可能带多个 space_id 行，
+// 先按 uid 去重再批量查询，过滤结果保持 targets 原有顺序（ORDER BY uid, space_id
+// 的锁序约定不被破坏）。
+func filterFanoutTargetsByActiveMembership(filter ActiveMemberFilter, groupNo string, targets []onThreadCreatedTarget) ([]onThreadCreatedTarget, error) {
+	uids := make([]string, 0, len(targets))
+	seen := make(map[string]struct{}, len(targets))
+	for _, t := range targets {
+		if _, ok := seen[t.UID]; ok {
+			continue
+		}
+		seen[t.UID] = struct{}{}
+		uids = append(uids, t.UID)
+	}
+	activeUIDs, err := filter.FilterActiveMemberUIDs(groupNo, uids)
+	if err != nil {
+		return nil, err
+	}
+	activeSet := make(map[string]struct{}, len(activeUIDs))
+	for _, u := range activeUIDs {
+		activeSet[u] = struct{}{}
+	}
+	filtered := make([]onThreadCreatedTarget, 0, len(targets))
+	for _, t := range targets {
+		if _, ok := activeSet[t.UID]; ok {
+			filtered = append(filtered, t)
+		}
+	}
+	return filtered, nil
 }
 
 // bulkBumpFollowVersionTx 批量给一批已排序的 (uid, space_id) +1 follow_version。

--- a/modules/message/1module.go
+++ b/modules/message/1module.go
@@ -80,6 +80,11 @@ func init() {
 			// 子区前必须校验 caller 是群成员 + 群在 Space 可见。复用同一个 struct
 			// 实现，共享 checkChannelAccess 逻辑。
 			svc.SetChannelAuthChecker(checker)
+			// 注入 ActiveMemberFilter（issue #351）：子区 ext 物化写路径（FollowChannel
+			// Phase 2/3 + OnThreadCreated fanout）按「活跃父群成员」过滤，被拉黑成员
+			// 不再收到既有/新建子区的 ext 行。GROUP 行语义不变（AuthorizeChannelFollow
+			// 保持 permissive）。复用同一个 threadAuthChecker，共享 group.IService 实例。
+			svc.SetActiveMemberFilter(checker)
 			// 注入 DefaultFollowedGroupGuard：/v1/follow/sort 的 target_type=2
 			// 候选必须先经过 (成员 + Space 可见性 + 非 Disband + category_id) 完整
 			// 校验链才能被物化为 ext 行。没有这一步，恶意客户端可借 sort 接口给
@@ -188,6 +193,47 @@ func (c *threadAuthChecker) AuthorizeThreadFollow(uid, spaceID, groupNo, shortID
 // 群成员。子区(CommunityTopic)分支的 active 校验只发生在 AuthorizeThreadFollow。
 func (c *threadAuthChecker) AuthorizeChannelFollow(uid, spaceID, groupNo string) error {
 	return c.checkChannelAccess(uid, spaceID, groupNo, false)
+}
+
+// FilterActiveMemberUIDs implements convext.ActiveMemberFilter (issue #351).
+//
+// 返回 uids 中当前是 groupNo「活跃成员」（is_deleted=0 AND status=Normal，排除
+// 被拉黑成员）的子集，供 conversation_ext 的子区 ext 物化写路径（FollowChannel
+// Phase 2/3 + OnThreadCreated fanout）过滤目标。
+//
+//   - 单 uid（FollowChannel 路径）：直查 ExistMemberActive，避免拉全群成员列表；
+//   - 多 uid（fanout 路径）：一次 GetSubscribableMemberUIDs（status=Normal AND
+//     is_deleted=0，与 #343 的 IM 订阅数据源同语义）后在内存里取交集——fanout
+//     单批最多 1000 目标，逐个 ExistMemberActive 会放大 N 倍查询。
+func (c *threadAuthChecker) FilterActiveMemberUIDs(groupNo string, uids []string) ([]string, error) {
+	switch len(uids) {
+	case 0:
+		return nil, nil
+	case 1:
+		active, err := c.groupSvc.ExistMemberActive(groupNo, uids[0])
+		if err != nil {
+			return nil, err
+		}
+		if !active {
+			return nil, nil
+		}
+		return []string{uids[0]}, nil
+	}
+	activeUIDs, err := c.groupSvc.GetSubscribableMemberUIDs(groupNo)
+	if err != nil {
+		return nil, err
+	}
+	activeSet := make(map[string]struct{}, len(activeUIDs))
+	for _, u := range activeUIDs {
+		activeSet[u] = struct{}{}
+	}
+	out := make([]string, 0, len(uids))
+	for _, u := range uids {
+		if _, ok := activeSet[u]; ok {
+			out = append(out, u)
+		}
+	}
+	return out, nil
 }
 
 // checkChannelAccess 复用 FollowThread 既有逻辑的群级访问校验：

--- a/modules/message/thread_ext_blacklist_filter_test.go
+++ b/modules/message/thread_ext_blacklist_filter_test.go
@@ -9,15 +9,21 @@ package message
 // is_deleted=0）的父群成员两条路径都不应再收到子区 ext 行（元数据/通知层泄漏；
 // 内容读已被 ExistMemberActive 门禁兜住）。
 //
-// 测试基建约定（PR #356 round-1 CI 红的教训）：本包非 integration-tag 测试一律
-// 不跑 sql-migrate（包内既有 testutil.NewTestServer 用例全部 t.Skip，而
-// channel_files_blacklist_test.go 等用例手建最小表——若本文件经 module.Setup 跑
-// 迁移，shuffle 把手建表用例排在前面时 sql-migrate 会撞 Error 1050 Table already
-// exists）。因此这里照搬 integration e2e helper 的做法：手建最小表 + 裸 INSERT
-// 种子 + 显式装配 service（wiring 与 1module.go 注入逻辑逐行对齐）。
+// 测试基建约定（PR #356 round-1 CI 红 + round-2 review 的教训）：
+//  1. 不跑 sql-migrate——本包非 integration-tag 测试一律不经 module.Setup（包内
+//     既有 testutil.NewTestServer 用例全部 t.Skip，channel_files_blacklist_test.go
+//     等用例手建最小表；混跑迁移会在 -shuffle 下撞 Error 1050 Table already exists）。
+//  2. 不碰共享 test 库——本文件要 DROP+CREATE 核心表（user_conversation_ext /
+//     group_member / …），而 go test ./... 默认跨包并行、modules/group、modules/
+//     thread 等包用 testutil.NewTestServer 连同一个 test 库，跨包并行时破坏性 DDL
+//     会撞别包的查询（round-2 review blocking）。因此先在 MySQL 实例上建独立库
+//     再连入，所有 DDL/数据只落在隔离库里。
+// 写法照搬 integration e2e helper：手建最小表 + 裸 INSERT 种子 + 显式装配
+// service（wiring 与 1module.go 注入逻辑逐行对齐）。
 // =============================================================================
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -31,22 +37,41 @@ import (
 
 const extBlSpaceID = "s_ext_bl"
 
-// extBlNewCtx 构造指向测试 MySQL 的 *config.Context（config.New 默认 DSN 即
-// root:demo@…/test，与 CI service 一致），显式 Migration=false——不经 module.Setup。
+// extBlDBName 是本文件专用的隔离库名：与共享 test 库（testutil.NewTestServer /
+// 其它包的迁移与查询）完全隔离，跨包并行的 go test ./... 下破坏性 DDL 不会外溢。
+const extBlDBName = "octo_msg_blacklist_test"
+
+// extBlNewCtx 构造指向隔离库的 *config.Context：先用 config.New 默认 DSN（与 CI
+// MySQL service 同源的 root:demo@…/test）建隔离库，再把 DSN 的库名换成隔离库连入。
+// 显式 Migration=false——不经 module.Setup。可用 MSG_BLACKLIST_TEST_MYSQL_ADDR
+// 覆盖隔离库 DSN（与 newSidebarIntegCtx 的 env 覆盖风格一致）。
 func extBlNewCtx(t *testing.T) *config.Context {
 	t.Helper()
+	bootCfg := config.New()
+	bootCfg.Test = true
+	bootCfg.DB.Migration = false
+	boot := config.NewContext(bootCfg)
+	_, err := boot.DB().Exec(
+		"CREATE DATABASE IF NOT EXISTS " + extBlDBName +
+			" CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci")
+	require.NoError(t, err, "create isolated db")
+
+	addr := os.Getenv("MSG_BLACKLIST_TEST_MYSQL_ADDR")
+	if addr == "" {
+		addr = "root:demo@tcp(127.0.0.1:3306)/" + extBlDBName + "?charset=utf8mb4&parseTime=true"
+	}
 	cfg := config.New()
 	cfg.Test = true
 	cfg.DB.Migration = false
+	cfg.DB.MySQLAddr = addr
 	return config.NewContext(cfg)
 }
 
-// extBlEnsureTables 手建本测试用到的最小表（DDL 与 modules/group、
+// extBlEnsureTables 在隔离库里手建本测试用到的最小表（DDL 与 modules/group、
 // modules/conversation_ext、modules/thread 的迁移文件中本测试触达的列对齐；
 // 写法照搬 default_followed_group_guard_e2e_test.go / thread_follow_blacklist_
-// e2e_test.go 的同名 helper）。DROP + CREATE 而非 IF NOT EXISTS：其它用例
-// （如 channel_files_blacklist_test.go）可能先以更窄的列集建过 group_member，
-// 必须重建保证本测试的列都在；表只装每用例自种数据，破坏性 DDL 安全。
+// e2e_test.go 的同名 helper）。DROP + CREATE 保证每个用例拿到本文件期望的
+// schema；隔离库只被本包顺序执行的测试使用，破坏性 DDL 安全。
 func extBlEnsureTables(t *testing.T, ctx *config.Context) {
 	t.Helper()
 	for _, tbl := range []string{"user_conversation_ext", "user_follow_version", "thread", "group_member", "`group`"} {

--- a/modules/message/thread_ext_blacklist_filter_test.go
+++ b/modules/message/thread_ext_blacklist_filter_test.go
@@ -1,0 +1,154 @@
+package message
+
+// =============================================================================
+// Issue #351（PR #345 mandatory follow-up）— 子区 ext 物化按活跃成员过滤。
+//
+// AuthorizeChannelFollow 对 GROUP follow 保持 permissive ExistMember，但
+// FollowChannel 会物化既有子区 ext 行、OnThreadCreated fanout 会给所有
+// auto_follow_threads=1 的群行物化新子区 ext 行。被拉黑（status=Blacklist、
+// is_deleted=0）的父群成员两条路径都不应再收到子区 ext 行（元数据/通知层泄漏；
+// 内容读已被 ExistMemberActive 门禁兜住）。
+//
+// 非 integration tag：CI 的 go test 直接跑（MySQL/Redis service 已就绪），
+// 避免 #353 指出的「integration-tagged 测试 CI 永不编译」缺口在本修复上重演。
+// =============================================================================
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const extBlSpaceID = "s_ext_bl"
+
+// setupThreadExtBlacklistData 建一个父群（space_id 为空 → legacy wildcard 可见），
+// 两个正常成员 normalUID / victimUID，返回 ctx 与已装配好的 conversation_ext 单例。
+// 装配（ThreadAuthChecker / ChannelAuthChecker / ThreadEnumerator / ActiveMemberFilter）
+// 由 testutil.NewTestServer → module.Setup 跑本包 1module.go 的注入逻辑完成，
+// 与生产 boot 同一条 wiring 路径。
+func setupThreadExtBlacklistData(t *testing.T) (*config.Context, *convext.Service, string, string, string) {
+	t.Helper()
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	svc := convext.GetGlobalConvExtService()
+	require.NotNil(t, svc, "conversation_ext 单例应已由 module.Setup 初始化并完成注入")
+
+	groupNo := strings.ReplaceAll(util.GenerUUID(), "-", "")
+	normalUID := "u_ext_normal_" + util.GenerUUID()[:8]
+	victimUID := "u_ext_victim_" + util.GenerUUID()[:8]
+
+	groupDB := group.NewDB(ctx)
+	require.NoError(t, groupDB.Insert(&group.Model{
+		GroupNo: groupNo, Name: "父群", Creator: normalUID, Status: 1, Version: 1,
+	}))
+	for _, u := range []string{normalUID, victimUID} {
+		require.NoError(t, groupDB.InsertMember(&group.MemberModel{
+			GroupNo: groupNo, UID: u,
+			Status: int(common.GroupMemberStatusNormal), Version: 1, Vercode: util.GenerUUID(),
+		}))
+	}
+	return ctx, svc, groupNo, normalUID, victimUID
+}
+
+func blacklistMemberExtBl(t *testing.T, ctx *config.Context, groupNo, uid string) {
+	t.Helper()
+	_, err := ctx.DB().UpdateBySql(
+		"UPDATE group_member SET status=? WHERE group_no=? AND uid=?",
+		int(common.GroupMemberStatusBlacklist), groupNo, uid,
+	).Exec()
+	require.NoError(t, err)
+}
+
+// hasThreadExtRow 查 user_conversation_ext 是否存在 (uid, space, target_type=5, channelID) 行。
+func hasThreadExtRow(t *testing.T, ctx *config.Context, uid, channelID string) bool {
+	t.Helper()
+	var count int64
+	_, err := ctx.DB().Select("count(*)").From("user_conversation_ext").
+		Where("uid=? AND space_id=? AND target_type=5 AND target_id=?", uid, extBlSpaceID, channelID).
+		Load(&count)
+	require.NoError(t, err)
+	return count > 0
+}
+
+// seedActiveThread 在 thread 表插入一个 active 子区，返回 channelID。
+func seedActiveThread(t *testing.T, ctx *config.Context, groupNo, shortID string) string {
+	t.Helper()
+	require.NoError(t, thread.NewDB(ctx).Insert(&thread.Model{
+		ShortID: shortID, GroupNo: groupNo, Name: "topic", CreatorUID: "creator",
+		Status: thread.ThreadStatusActive,
+	}))
+	return groupNo + "____" + shortID
+}
+
+// TestOnThreadCreated_BlacklistedMemberExcludedFromFanout 验证：两个成员都开启了
+// auto_follow_threads（正常时 FollowChannel），其中一个随后被拉黑——新建子区的
+// fanout 只给活跃成员物化 ext 行；解除拉黑后 fanout 自动恢复。
+func TestOnThreadCreated_BlacklistedMemberExcludedFromFanout(t *testing.T) {
+	ctx, svc, groupNo, normalUID, victimUID := setupThreadExtBlacklistData(t)
+
+	// 两人在正常状态下关注 channel（写 auto_follow_threads=1 群行）。
+	require.NoError(t, svc.FollowChannel(normalUID, extBlSpaceID, groupNo))
+	require.NoError(t, svc.FollowChannel(victimUID, extBlSpaceID, groupNo))
+
+	// victim 被拉黑后新建子区。
+	blacklistMemberExtBl(t, ctx, groupNo, victimUID)
+	sid1 := "1489104291682713601"
+	require.NoError(t, svc.OnThreadCreated(groupNo, sid1))
+
+	assert.True(t, hasThreadExtRow(t, ctx, normalUID, groupNo+"____"+sid1),
+		"正常成员应收到新子区 ext 行")
+	assert.False(t, hasThreadExtRow(t, ctx, victimUID, groupNo+"____"+sid1),
+		"被拉黑成员不应收到新子区 ext 行（issue #351 元数据泄漏）")
+
+	// 解除拉黑 → 下一条新子区恢复 fanout（auto_follow_threads=1 保留的语义）。
+	_, err := ctx.DB().UpdateBySql(
+		"UPDATE group_member SET status=? WHERE group_no=? AND uid=?",
+		int(common.GroupMemberStatusNormal), groupNo, victimUID,
+	).Exec()
+	require.NoError(t, err)
+	sid2 := "1489104291682713602"
+	require.NoError(t, svc.OnThreadCreated(groupNo, sid2))
+	assert.True(t, hasThreadExtRow(t, ctx, victimUID, groupNo+"____"+sid2),
+		"解除拉黑后 fanout 应自动恢复")
+}
+
+// TestFollowChannel_BlacklistedMemberSkipsExistingThreadMaterialization 验证：
+// 被拉黑成员调用 FollowChannel（GROUP 门禁 permissive，调用本身放行）时，
+// 既有子区的 ext 物化被跳过；正常成员则正常物化。
+func TestFollowChannel_BlacklistedMemberSkipsExistingThreadMaterialization(t *testing.T) {
+	ctx, svc, groupNo, normalUID, victimUID := setupThreadExtBlacklistData(t)
+
+	existingChannelID := seedActiveThread(t, ctx, groupNo, "1489104291682713603")
+
+	blacklistMemberExtBl(t, ctx, groupNo, victimUID)
+
+	// 被拉黑成员 FollowChannel：GROUP 行写入放行（permissive 语义不变），但
+	// 不得物化既有子区 ext 行。
+	require.NoError(t, svc.FollowChannel(victimUID, extBlSpaceID, groupNo),
+		"GROUP follow 对被拉黑成员保持 permissive，调用不应报错")
+	assert.False(t, hasThreadExtRow(t, ctx, victimUID, existingChannelID),
+		"被拉黑成员不应通过 FollowChannel 重新物化既有子区 ext 行（issue #351）")
+
+	var groupRowCount int64
+	_, err := ctx.DB().Select("count(*)").From("user_conversation_ext").
+		Where("uid=? AND space_id=? AND target_type=2 AND target_id=?",
+			victimUID, extBlSpaceID, groupNo).
+		Load(&groupRowCount)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), groupRowCount, "GROUP 级 ext 行本身应照常写入（permissive 语义不变）")
+
+	// 对照组：正常成员 FollowChannel 正常物化既有子区。
+	require.NoError(t, svc.FollowChannel(normalUID, extBlSpaceID, groupNo))
+	assert.True(t, hasThreadExtRow(t, ctx, normalUID, existingChannelID),
+		"正常成员 FollowChannel 应物化既有子区 ext 行")
+}

--- a/modules/message/thread_ext_blacklist_filter_test.go
+++ b/modules/message/thread_ext_blacklist_filter_test.go
@@ -9,8 +9,12 @@ package message
 // is_deleted=0）的父群成员两条路径都不应再收到子区 ext 行（元数据/通知层泄漏；
 // 内容读已被 ExistMemberActive 门禁兜住）。
 //
-// 非 integration tag：CI 的 go test 直接跑（MySQL/Redis service 已就绪），
-// 避免 #353 指出的「integration-tagged 测试 CI 永不编译」缺口在本修复上重演。
+// 测试基建约定（PR #356 round-1 CI 红的教训）：本包非 integration-tag 测试一律
+// 不跑 sql-migrate（包内既有 testutil.NewTestServer 用例全部 t.Skip，而
+// channel_files_blacklist_test.go 等用例手建最小表——若本文件经 module.Setup 跑
+// 迁移，shuffle 把手建表用例排在前面时 sql-migrate 会撞 Error 1050 Table already
+// exists）。因此这里照搬 integration e2e helper 的做法：手建最小表 + 裸 INSERT
+// 种子 + 显式装配 service（wiring 与 1module.go 注入逻辑逐行对齐）。
 // =============================================================================
 
 import (
@@ -20,52 +24,156 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
-	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
-	"github.com/Mininglamp-OSS/octo-server/modules/group"
-	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 const extBlSpaceID = "s_ext_bl"
 
-// setupThreadExtBlacklistData 建一个父群（space_id 为空 → legacy wildcard 可见），
-// 两个正常成员 normalUID / victimUID，返回 ctx 与已装配好的 conversation_ext 单例。
-// 装配（ThreadAuthChecker / ChannelAuthChecker / ThreadEnumerator / ActiveMemberFilter）
-// 由 testutil.NewTestServer → module.Setup 跑本包 1module.go 的注入逻辑完成，
-// 与生产 boot 同一条 wiring 路径。
+// extBlNewCtx 构造指向测试 MySQL 的 *config.Context（config.New 默认 DSN 即
+// root:demo@…/test，与 CI service 一致），显式 Migration=false——不经 module.Setup。
+func extBlNewCtx(t *testing.T) *config.Context {
+	t.Helper()
+	cfg := config.New()
+	cfg.Test = true
+	cfg.DB.Migration = false
+	return config.NewContext(cfg)
+}
+
+// extBlEnsureTables 手建本测试用到的最小表（DDL 与 modules/group、
+// modules/conversation_ext、modules/thread 的迁移文件中本测试触达的列对齐；
+// 写法照搬 default_followed_group_guard_e2e_test.go / thread_follow_blacklist_
+// e2e_test.go 的同名 helper）。DROP + CREATE 而非 IF NOT EXISTS：其它用例
+// （如 channel_files_blacklist_test.go）可能先以更窄的列集建过 group_member，
+// 必须重建保证本测试的列都在；表只装每用例自种数据，破坏性 DDL 安全。
+func extBlEnsureTables(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	for _, tbl := range []string{"user_conversation_ext", "user_follow_version", "thread", "group_member", "`group`"} {
+		_, err := ctx.DB().Exec("DROP TABLE IF EXISTS " + tbl)
+		require.NoError(t, err, "drop %s", tbl)
+	}
+	stmts := []string{
+		// modules/group/sql/20191106000002 起的 group 表（仅本测试触达的列，
+		// 与 default_followed_group_guard_e2e_test.go ensureGuardE2ETables 一致）。
+		"CREATE TABLE `group` (" +
+			"  `id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY," +
+			"  `group_no` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `name` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `creator` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `status` SMALLINT NOT NULL DEFAULT 0," +
+			"  `version` BIGINT NOT NULL DEFAULT 0," +
+			"  `group_type` SMALLINT NOT NULL DEFAULT 0," +
+			"  `space_id` VARCHAR(40) DEFAULT ''," +
+			"  `is_external_group` SMALLINT NOT NULL DEFAULT 0," +
+			"  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+			"  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+			"  UNIQUE KEY `group_groupNo` (`group_no`)" +
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+		"CREATE TABLE `group_member` (" +
+			"  `id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY," +
+			"  `group_no` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `uid` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `role` SMALLINT NOT NULL DEFAULT 0," +
+			"  `version` BIGINT NOT NULL DEFAULT 0," +
+			"  `is_deleted` SMALLINT NOT NULL DEFAULT 0," +
+			"  `status` SMALLINT NOT NULL DEFAULT 1," +
+			"  `vercode` VARCHAR(100) NOT NULL DEFAULT ''," +
+			"  `robot` SMALLINT NOT NULL DEFAULT 0," +
+			"  `is_external` SMALLINT NOT NULL DEFAULT 0," +
+			"  `source_space_id` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+			"  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+			"  UNIQUE KEY `group_no_uid` (`group_no`, `uid`)" +
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+		// modules/thread 迁移中的 thread 表（最小列集，与 thread_follow_blacklist_
+		// e2e_test.go ensureThreadE2ETable 一致）。
+		"CREATE TABLE `thread` (" +
+			"  `id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY," +
+			"  `group_no` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `short_id` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `name` VARCHAR(100) NOT NULL DEFAULT ''," +
+			"  `creator_uid` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `status` INT NOT NULL DEFAULT 1," +
+			"  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+			"  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+			"  UNIQUE KEY `uk_short` (`short_id`)" +
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+		// modules/conversation_ext/sql/20260513000001 + 20260514000001(dm_category_id
+		// VARCHAR) + 20260514000002(去 version 列) + 20260522000001(auto_follow_threads
+		// + idx_channel_auto_follow) 的合成结果。
+		"CREATE TABLE `user_conversation_ext` (" +
+			"  `id` BIGINT AUTO_INCREMENT PRIMARY KEY," +
+			"  `uid` VARCHAR(40) NOT NULL," +
+			"  `space_id` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `target_type` TINYINT NOT NULL," +
+			"  `target_id` VARCHAR(100) NOT NULL," +
+			"  `followed_dm` TINYINT NOT NULL DEFAULT 0," +
+			"  `dm_category_id` VARCHAR(32) NULL," +
+			"  `group_unfollowed` TINYINT NOT NULL DEFAULT 0," +
+			"  `follow_sort` INT NOT NULL DEFAULT 0," +
+			"  `auto_follow_threads` TINYINT(1) NOT NULL DEFAULT 0," +
+			"  `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP," +
+			"  `updated_at` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP," +
+			"  UNIQUE KEY `uk` (`uid`, `space_id`, `target_type`, `target_id`)," +
+			"  KEY `idx_channel_auto_follow` (`target_type`, `target_id`, `auto_follow_threads`)" +
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+		// modules/conversation_ext/sql/20260513000002。
+		"CREATE TABLE `user_follow_version` (" +
+			"  `uid` VARCHAR(40) NOT NULL," +
+			"  `space_id` VARCHAR(40) NOT NULL DEFAULT ''," +
+			"  `version` BIGINT NOT NULL DEFAULT 0," +
+			"  `updated_at` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP," +
+			"  PRIMARY KEY (`uid`, `space_id`)" +
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+	}
+	for _, s := range stmts {
+		_, err := ctx.DB().Exec(s)
+		require.NoError(t, err, "extBlEnsureTables: %s", s[:40])
+	}
+}
+
+// setupThreadExtBlacklistData 建一个父群（space_id 为空 → legacy wildcard 可见）+
+// 两个正常成员 normalUID / victimUID，并按 1module.go 的注入逻辑显式装配
+// conversation_ext.Service（ThreadAuthChecker / ChannelAuthChecker /
+// ThreadEnumerator / ActiveMemberFilter 同源 wiring）。
 func setupThreadExtBlacklistData(t *testing.T) (*config.Context, *convext.Service, string, string, string) {
 	t.Helper()
-	_, ctx := testutil.NewTestServer()
-	require.NoError(t, testutil.CleanAllTables(ctx))
+	ctx := extBlNewCtx(t)
+	extBlEnsureTables(t, ctx)
 
-	svc := convext.GetGlobalConvExtService()
-	require.NotNil(t, svc, "conversation_ext 单例应已由 module.Setup 初始化并完成注入")
+	svc := convext.NewService(ctx)
+	checker := newThreadAuthChecker(ctx)
+	svc.SetThreadAuthChecker(checker)
+	svc.SetChannelAuthChecker(checker)
+	svc.SetThreadEnumerator(newThreadEnumerator(ctx))
+	svc.SetActiveMemberFilter(checker)
 
 	groupNo := strings.ReplaceAll(util.GenerUUID(), "-", "")
 	normalUID := "u_ext_normal_" + util.GenerUUID()[:8]
 	victimUID := "u_ext_victim_" + util.GenerUUID()[:8]
 
-	groupDB := group.NewDB(ctx)
-	require.NoError(t, groupDB.Insert(&group.Model{
-		GroupNo: groupNo, Name: "父群", Creator: normalUID, Status: 1, Version: 1,
-	}))
+	_, err := ctx.DB().Exec(
+		"INSERT INTO `group` (group_no, name, creator, status, version, space_id) VALUES (?, '父群', ?, 1, 1, '')",
+		groupNo, normalUID,
+	)
+	require.NoError(t, err, "seed group")
 	for _, u := range []string{normalUID, victimUID} {
-		require.NoError(t, groupDB.InsertMember(&group.MemberModel{
-			GroupNo: groupNo, UID: u,
-			Status: int(common.GroupMemberStatusNormal), Version: 1, Vercode: util.GenerUUID(),
-		}))
+		_, err = ctx.DB().Exec(
+			"INSERT INTO group_member (group_no, uid, vercode, is_deleted, status, version) VALUES (?, ?, ?, 0, ?, 1)",
+			groupNo, u, util.GenerUUID(), int(common.GroupMemberStatusNormal),
+		)
+		require.NoError(t, err, "seed member %s", u)
 	}
 	return ctx, svc, groupNo, normalUID, victimUID
 }
 
-func blacklistMemberExtBl(t *testing.T, ctx *config.Context, groupNo, uid string) {
+func extBlSetMemberStatus(t *testing.T, ctx *config.Context, groupNo, uid string, status common.GroupMemberStatus) {
 	t.Helper()
-	_, err := ctx.DB().UpdateBySql(
+	_, err := ctx.DB().Exec(
 		"UPDATE group_member SET status=? WHERE group_no=? AND uid=?",
-		int(common.GroupMemberStatusBlacklist), groupNo, uid,
-	).Exec()
+		int(status), groupNo, uid,
+	)
 	require.NoError(t, err)
 }
 
@@ -80,13 +188,14 @@ func hasThreadExtRow(t *testing.T, ctx *config.Context, uid, channelID string) b
 	return count > 0
 }
 
-// seedActiveThread 在 thread 表插入一个 active 子区，返回 channelID。
+// seedActiveThread 在 thread 表插入一个 active(status=1) 子区，返回 channelID。
 func seedActiveThread(t *testing.T, ctx *config.Context, groupNo, shortID string) string {
 	t.Helper()
-	require.NoError(t, thread.NewDB(ctx).Insert(&thread.Model{
-		ShortID: shortID, GroupNo: groupNo, Name: "topic", CreatorUID: "creator",
-		Status: thread.ThreadStatusActive,
-	}))
+	_, err := ctx.DB().Exec(
+		"INSERT INTO thread (group_no, short_id, name, creator_uid, status) VALUES (?, ?, 'topic', 'creator', 1)",
+		groupNo, shortID,
+	)
+	require.NoError(t, err, "seed thread %s/%s", groupNo, shortID)
 	return groupNo + "____" + shortID
 }
 
@@ -101,7 +210,7 @@ func TestOnThreadCreated_BlacklistedMemberExcludedFromFanout(t *testing.T) {
 	require.NoError(t, svc.FollowChannel(victimUID, extBlSpaceID, groupNo))
 
 	// victim 被拉黑后新建子区。
-	blacklistMemberExtBl(t, ctx, groupNo, victimUID)
+	extBlSetMemberStatus(t, ctx, groupNo, victimUID, common.GroupMemberStatusBlacklist)
 	sid1 := "1489104291682713601"
 	require.NoError(t, svc.OnThreadCreated(groupNo, sid1))
 
@@ -111,11 +220,7 @@ func TestOnThreadCreated_BlacklistedMemberExcludedFromFanout(t *testing.T) {
 		"被拉黑成员不应收到新子区 ext 行（issue #351 元数据泄漏）")
 
 	// 解除拉黑 → 下一条新子区恢复 fanout（auto_follow_threads=1 保留的语义）。
-	_, err := ctx.DB().UpdateBySql(
-		"UPDATE group_member SET status=? WHERE group_no=? AND uid=?",
-		int(common.GroupMemberStatusNormal), groupNo, victimUID,
-	).Exec()
-	require.NoError(t, err)
+	extBlSetMemberStatus(t, ctx, groupNo, victimUID, common.GroupMemberStatusNormal)
 	sid2 := "1489104291682713602"
 	require.NoError(t, svc.OnThreadCreated(groupNo, sid2))
 	assert.True(t, hasThreadExtRow(t, ctx, victimUID, groupNo+"____"+sid2),
@@ -130,7 +235,7 @@ func TestFollowChannel_BlacklistedMemberSkipsExistingThreadMaterialization(t *te
 
 	existingChannelID := seedActiveThread(t, ctx, groupNo, "1489104291682713603")
 
-	blacklistMemberExtBl(t, ctx, groupNo, victimUID)
+	extBlSetMemberStatus(t, ctx, groupNo, victimUID, common.GroupMemberStatusBlacklist)
 
 	// 被拉黑成员 FollowChannel：GROUP 行写入放行（permissive 语义不变），但
 	// 不得物化既有子区 ext 行。


### PR DESCRIPTION
## 背景

PR #345 终审 APPROVE 附带的 mandatory P1 follow-up #1（GH #351）。

`AuthorizeChannelFollow` 对 GROUP follow 有意保持 permissive `ExistMember`，但 `FollowChannel` 不是纯群操作：它写 `auto_follow_threads=1` 并批量物化既有子区 ext 行；`OnThreadCreated` fanout 选取所有 `auto_follow_threads=1` 行后只 re-check ext flag，不查群成员状态。净效果：被拉黑的父群成员（曾关注过 channel）持续收到既有/新建子区的 ext 行与创建通知——元数据/通知层泄漏（内容读已被 #345 的 `ExistMemberActive` 门禁兜死）。

## 修法（issue 两个选项中的 A：物化写路径按 active 过滤）

- `conversation_ext.Service` 新增 `ActiveMemberFilter` 注入点（与 `ThreadAuthChecker` 同款依赖倒置，避免 import group 成环；nil = 跳过，仅单测/迁移期），由 `message/1module.go` 在既有 `threadAuthChecker` 上实现并注入
- **OnThreadCreated fanout**：初始 SELECT 后、进 batch tx 前按「活跃父群成员」过滤目标。tx 外执行（快照语义不变，不延长锁窗口）；多 uid 走一次 `GetSubscribableMemberUIDs`（与 #343 IM 订阅数据源同语义：`status=Normal AND is_deleted=0`）内存取交集，不放大查询
- **FollowChannel**：Phase 2/3 既有子区物化前单点 `ExistMemberActive` 探测，非活跃成员跳过物化。Phase 1 群行写入保持 permissive GROUP 语义不变；`auto_follow_threads=1` 保留——解除拉黑后新子区 fanout 自动恢复，flag 残留期间两条物化路径都有过滤，无泄漏

## 测试（按 issue 要求补：blacklist 成员不应收到已存在/新建子区 ext 行）

- 被拉黑成员（已有 auto_follow 群 ext 行）：新建子区 fanout 不再给其物化 ext 行；正常成员不受影响；解除拉黑后 fanout 自动恢复
- 被拉黑成员调用 FollowChannel：GROUP 行照常写入（permissive 语义回归保护），既有子区 ext 行不物化；正常成员正常物化
- 测试**不带** `//go:build integration` tag（吃 CI 已就绪的 MySQL service），避免 #353 指出的「integration-tagged 测试 CI 永不编译」缺口在本修复上重演

## 与 PR #355（GH #354 Bot 跟人走）的关系

互补、无文件交集：#355 改 `modules/group/*`（拉黑级联到 owner 的 bot、成员移除级联）；本 PR 改 `modules/conversation_ext` + `modules/message`（sidebar ext 物化层过滤）。两者可独立合并，无依赖顺序要求。

## 审查状态

- 改动规模：+306 行（含 ~160 行测试），3 文件
- 编译/vet：`go build ./...`、`go vet`（含 `-tags integration`）通过
- 测试：`modules/conversation_ext`、`modules/message`、`modules/thread` 全包 `-race -shuffle=on` 通过（CI 同款 MySQL/Redis/WuKongIM 栈）
- 自审 critical pass（SQL 参数化、锁序不变量、nil-checker fail-open 范围、并发注入 RWMutex）：无新增 finding

Fixes #351
<!-- sprint-set-retrigger -->