### PR TITLE
fix(space): display-name fallback for blank member names in member list (#344)

### DIFF
--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	commonmod "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/displayname"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
@@ -620,15 +621,37 @@ func (s *Space) listMembers(c *wkhttp.Context) {
 		return
 	}
 
+	// 展示名兜底（issue #344）：user.name 允许为空（RegisterUserMustCompleteInfoOn==1
+	// 时的注册/SSO 建号路径），列表不能渲染空名。实名记录批量查（零 N+1），
+	// 查询失败仅 log 不阻断 —— 实名是增强信息，语义同 group fillRealnameFields。
+	uids := make([]string, 0, len(members))
+	for _, m := range members {
+		uids = append(uids, m.UID)
+	}
+	verifications, vErr := s.db.queryVerificationsByUIDs(uids)
+	if vErr != nil {
+		s.Warn("查询空间成员实名认证记录失败", zap.Error(vErr), zap.String("space_id", spaceId))
+		verifications = map[string]*memberVerificationModel{}
+	}
+
 	resps := make([]memberResp, 0, len(members))
 	for _, m := range members {
-		resps = append(resps, memberResp{
+		resp := memberResp{
 			UID:       m.UID,
 			Name:      m.Name,
 			Role:      m.Role,
 			Robot:     m.Robot,
 			CreatedAt: m.CreatedAt.String(),
-		})
+		}
+		if v, ok := verifications[m.UID]; ok {
+			resp.RealnameVerified = true
+			resp.RealName = v.RealName
+			if !v.VerifiedAt.IsZero() {
+				resp.RealnameVerifiedAt = v.VerifiedAt.Unix()
+			}
+		}
+		resp.Name = displayname.Resolve(m.Name, resp.RealName, m.UID)
+		resps = append(resps, resp)
 	}
 	c.Response(resps)
 }

--- a/modules/space/api_members_displayname_test.go
+++ b/modules/space/api_members_displayname_test.go
@@ -1,0 +1,241 @@
+package space
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// issue #344 · 空间成员列表展示名兜底 + 实名字段契约
+//
+// 根因：user.name 在 RegisterUserMustCompleteInfoOn==1 时允许为空（本地注册与
+// OIDC 建号同走 createUserWithRespAndTx 的空名分支），queryMembers 直接渲染
+// user.name，空名成员在 GET /v1/space/:space_id/members 显示为空字符串。
+//
+// 修复契约（对齐 modules/group YUJ-413 的既有口径）：
+//  1. memberResp 下发 realname_verified / real_name / realname_verified_at
+//     三字段，JSON tag 与 group memberDetailResp 逐字一致；
+//  2. name 按 displayname.Resolve 兜底：name → real_name（仅已实名）→ 占位名；
+//  3. 实名记录批量查询（零 N+1），失败仅 log 不阻断成员列表。
+//
+// 断言分两层（同 group/api_realname_test.go）：
+//  1. 源码级 grep 锁定 —— 任何环境都能跑；
+//  2. 真 HTTP 端到端 —— 需要 testutil 的 MySQL/Redis/WuKongIM 栈。
+// =============================================================================
+
+// --- 源码级锁定（无 DB 依赖） ---
+
+// TestMemberResp_HasRealnameFields_Contract 锁住 memberResp 必须带实名三字段，
+// JSON tag 与 modules/group memberDetailResp（YUJ-413）完全对齐。
+func TestMemberResp_HasRealnameFields_Contract(t *testing.T) {
+	src, err := os.ReadFile("model.go")
+	require.NoError(t, err)
+	body := string(src)
+
+	startIdx := strings.Index(body, "type memberResp struct {")
+	require.NotEqual(t, -1, startIdx, "memberResp struct 不见了？")
+	endIdx := strings.Index(body[startIdx:], "\n}")
+	require.NotEqual(t, -1, endIdx)
+	block := body[startIdx : startIdx+endIdx]
+
+	assert.Regexp(t,
+		regexp.MustCompile("RealnameVerified\\s+bool\\s+`json:\"realname_verified\"`"),
+		block, "memberResp 缺 realname_verified（tag 必须与 group memberDetailResp 对齐）")
+	assert.Regexp(t,
+		regexp.MustCompile("RealName\\s+string\\s+`json:\"real_name,omitempty\"`"),
+		block, "memberResp 缺 real_name（tag 必须与 group memberDetailResp 对齐）")
+	assert.Regexp(t,
+		regexp.MustCompile("RealnameVerifiedAt\\s+int64\\s+`json:\"realname_verified_at,omitempty\"`"),
+		block, "memberResp 缺 realname_verified_at（tag 必须与 group memberDetailResp 对齐）")
+}
+
+// TestListMembers_UsesDisplayNameFallback_Contract 锁住 listMembers 必须：
+//   - 经 displayname.Resolve 兜底 name（issue #344 的展示层修复点）；
+//   - 走批量 queryVerificationsByUIDs 取实名记录（零 N+1）；
+//   - 不允许出现单查 QueryByUID（N+1 回归）。
+func TestListMembers_UsesDisplayNameFallback_Contract(t *testing.T) {
+	src, err := os.ReadFile("api.go")
+	require.NoError(t, err)
+	body := string(src)
+
+	startIdx := strings.Index(body, "func (s *Space) listMembers(")
+	require.NotEqual(t, -1, startIdx, "listMembers handler 不见了？")
+	endIdx := strings.Index(body[startIdx:], "\nfunc ")
+	require.NotEqual(t, -1, endIdx)
+	block := body[startIdx : startIdx+endIdx]
+
+	assert.Contains(t, block, "displayname.Resolve(",
+		"listMembers 必须经 displayname.Resolve 兜底空 name（issue #344）")
+	assert.Contains(t, block, "queryVerificationsByUIDs(",
+		"listMembers 必须批量查实名记录（零 N+1，对齐 group fillRealnameFields）")
+	assert.NotContains(t, block, "QueryByUID(",
+		"listMembers 不允许逐成员单查实名记录（N+1 回归）")
+}
+
+// --- 真 HTTP 端到端（需要 MySQL） ---
+
+// seedSpaceMemberUser 往裁剪版 user 表插一行（TestMain 建表，列见 api_test.go）。
+func seedSpaceMemberUser(t *testing.T, uid, name string) {
+	t.Helper()
+	_, err := testCtx.DB().InsertBySql(
+		"INSERT INTO `user` (uid, name) VALUES (?, ?)", uid, name,
+	).Exec()
+	require.NoError(t, err)
+}
+
+// seedSpaceUserVerification 往 user_verification 表写一条已实名记录
+// （schema 对齐 modules/user/sql/20260505000003_user_legacy01.sql）。
+func seedSpaceUserVerification(t *testing.T, uid, realName string, verifiedAt time.Time) {
+	t.Helper()
+	_, err := testCtx.DB().InsertBySql(
+		"INSERT INTO user_verification (user_id, real_name, source, source_sub, verified_at) "+
+			"VALUES (?, ?, 'aegis', ?, ?)",
+		uid, realName, "sub-"+uid, verifiedAt,
+	).Exec()
+	require.NoError(t, err)
+}
+
+// setupDisplayNameSpace 建一个空间：登录用户 + 三类目标成员
+//   - m-named-0001：user.name 正常
+//   - m-verified-0002：user.name 为空 + user_verification.real_name="张三"
+//   - m-blank-0003：user.name 为空且未实名
+func setupDisplayNameSpace(t *testing.T) (f *Space, spaceId string) {
+	_, f, err := setup(t)
+	require.NoError(t, err)
+
+	spaceId = "sp-displayname-344"
+	require.NoError(t, f.db.insertSpaceNoTx(&SpaceModel{
+		SpaceId: spaceId,
+		Name:    "展示名兜底测试",
+		Creator: testutil.UID,
+		Status:  1,
+	}))
+
+	seedSpaceMemberUser(t, testutil.UID, "operator")
+	seedSpaceMemberUser(t, "m-named-0001", "正常用户")
+	seedSpaceMemberUser(t, "m-verified-0002", "")
+	seedSpaceMemberUser(t, "m-blank-0003", "")
+	seedSpaceUserVerification(t, "m-verified-0002", "张三",
+		time.Date(2026, 5, 11, 10, 0, 0, 0, time.UTC))
+
+	for i, uid := range []string{testutil.UID, "m-named-0001", "m-verified-0002", "m-blank-0003"} {
+		role := 0
+		if i == 0 {
+			role = 2
+		}
+		require.NoError(t, f.db.insertMemberNoTx(&MemberModel{
+			SpaceId: spaceId,
+			UID:     uid,
+			Role:    role,
+			Status:  1,
+		}))
+	}
+	return f, spaceId
+}
+
+func getMembers(t *testing.T, spaceId string) []map[string]interface{} {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/v1/space/"+spaceId+"/members?limit=100", nil)
+	require.NoError(t, err)
+	req.Header.Set("token", testutil.Token)
+	testSrv.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var members []map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &members))
+	return members
+}
+
+// TestListMembers_DisplayNameFallback：GET /v1/space/:space_id/members
+// 任何成员的 name 都不允许为空（issue #344 的用户可见症状）：
+//   - name 正常成员原样返回，realname_verified=false；
+//   - 空名已实名成员回退 real_name，且带实名三字段；
+//   - 空名未实名成员回退占位名（"用户"+uid 后 4 位）。
+func TestListMembers_DisplayNameFallback(t *testing.T) {
+	_, spaceId := setupDisplayNameSpace(t)
+	members := getMembers(t, spaceId)
+	require.Len(t, members, 4, "成员数不对")
+
+	byUID := map[string]map[string]interface{}{}
+	for _, m := range members {
+		uid, _ := m["uid"].(string)
+		byUID[uid] = m
+		name, _ := m["name"].(string)
+		assert.NotEqual(t, "", strings.TrimSpace(name),
+			"uid=%s 的 name 不允许为空（issue #344）", uid)
+	}
+
+	named := byUID["m-named-0001"]
+	require.NotNil(t, named)
+	assert.Equal(t, "正常用户", named["name"])
+	assert.Equal(t, false, named["realname_verified"])
+	if v, ok := named["real_name"]; ok {
+		assert.Equal(t, "", v, "未实名成员不应下发 real_name")
+	}
+
+	verified := byUID["m-verified-0002"]
+	require.NotNil(t, verified)
+	assert.Equal(t, "张三", verified["name"], "空名已实名成员的 name 必须回退 real_name")
+	assert.Equal(t, true, verified["realname_verified"])
+	assert.Equal(t, "张三", verified["real_name"])
+	ts, ok := verified["realname_verified_at"].(float64)
+	require.True(t, ok, "已实名成员必须带 realname_verified_at; body=%v", verified)
+	assert.Greater(t, ts, float64(0))
+
+	blank := byUID["m-blank-0003"]
+	require.NotNil(t, blank)
+	assert.Equal(t, "用户0003", blank["name"],
+		"空名未实名成员的 name 必须回退占位名（用户+uid 后 4 位）")
+	assert.Equal(t, false, blank["realname_verified"])
+}
+
+// TestListMembers_NormalNameUnchanged：实名记录存在但 user.name 非空时，
+// name 保持用户自取名 —— real_name 只兜底，不覆盖。
+func TestListMembers_NormalNameUnchanged(t *testing.T) {
+	_, f, err := setup(t)
+	require.NoError(t, err)
+
+	spaceId := "sp-displayname-keep"
+	require.NoError(t, f.db.insertSpaceNoTx(&SpaceModel{
+		SpaceId: spaceId,
+		Name:    "自取名优先测试",
+		Creator: testutil.UID,
+		Status:  1,
+	}))
+	seedSpaceMemberUser(t, testutil.UID, "operator")
+	seedSpaceMemberUser(t, "m-both-0009", "网名小王")
+	seedSpaceUserVerification(t, "m-both-0009", "王五",
+		time.Date(2026, 5, 11, 10, 0, 0, 0, time.UTC))
+	for i, uid := range []string{testutil.UID, "m-both-0009"} {
+		role := 0
+		if i == 0 {
+			role = 2
+		}
+		require.NoError(t, f.db.insertMemberNoTx(&MemberModel{
+			SpaceId: spaceId, UID: uid, Role: role, Status: 1,
+		}))
+	}
+
+	members := getMembers(t, spaceId)
+	var both map[string]interface{}
+	for _, m := range members {
+		if m["uid"] == "m-both-0009" {
+			both = m
+		}
+	}
+	require.NotNil(t, both)
+	assert.Equal(t, "网名小王", both["name"], "name 非空时不允许被 real_name 覆盖")
+	assert.Equal(t, true, both["realname_verified"])
+	assert.Equal(t, "王五", both["real_name"])
+}

--- a/modules/space/api_test.go
+++ b/modules/space/api_test.go
@@ -60,6 +60,11 @@ func TestMain(m *testing.M) {
 		// username/phone 对齐生产 user 表（modules/user/sql/20191106000003），管理端成员搜索按这两列做 LIKE 匹配。
 		"DROP TABLE IF EXISTS `user`",
 		"CREATE TABLE `user` (id BIGINT AUTO_INCREMENT PRIMARY KEY, uid VARCHAR(40) NOT NULL DEFAULT '', name VARCHAR(100) DEFAULT '', username VARCHAR(40) DEFAULT '', email VARCHAR(200) DEFAULT '', phone VARCHAR(20) DEFAULT '', avatar VARCHAR(200) DEFAULT '', robot SMALLINT DEFAULT 0, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, UNIQUE KEY idx_uid(uid)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+		// user_verification 属 user 模块迁移（20260505000003_user_legacy01.sql），
+		// 但 user 包反向依赖 space，本测试二进制不含 user 模块，迁移不会建表；
+		// 成员列表展示名兜底（issue #344）批量查此表，这里按生产 schema 重建。
+		"DROP TABLE IF EXISTS user_verification",
+		"CREATE TABLE user_verification (user_id VARCHAR(40) NOT NULL, real_name VARCHAR(128) NOT NULL, source VARCHAR(32) NOT NULL, source_sub VARCHAR(128) NOT NULL, emp_id VARCHAR(64) DEFAULT NULL, dept VARCHAR(255) DEFAULT NULL, email VARCHAR(255) DEFAULT NULL, mobile VARCHAR(32) DEFAULT NULL, verified_at DATETIME NOT NULL, updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, PRIMARY KEY (user_id), KEY idx_user_verification_source (source, source_sub)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
 	}
 	for _, ddl := range depDDLs {
 		if _, err := db.Exec(ddl); err != nil {

--- a/modules/space/db.go
+++ b/modules/space/db.go
@@ -161,6 +161,48 @@ func (d *DB) queryMembers(spaceId string, loginUID string, page uint64, limit ui
 	return models, err
 }
 
+// memberVerificationModel 成员列表展示名兜底所需的最小实名视图（issue #344），
+// 对应 user_verification 表（modules/user/sql/20260505000003）。
+type memberVerificationModel struct {
+	UserID     string    `db:"user_id"`
+	RealName   string    `db:"real_name"`
+	VerifiedAt time.Time `db:"verified_at"`
+}
+
+// memberVerificationBatchSize 限制单次 `WHERE user_id IN (?)` 的参数数量，
+// 取值与 modules/user/db_verification.go verificationBatchSize 一致（成员列表
+// 单页上限 10000，分批避免超大 IN list 对 packet/planner 不友好）。
+const memberVerificationBatchSize = 1000
+
+// queryVerificationsByUIDs 批量查 user_verification，返回 uid → 实名记录；
+// 无记录的 uid 不在 map 中（调用方视为未实名）。
+//
+// 不能复用 modules/user.QueryVerificationsByUIDs —— user 包反向依赖 space
+// （service.go 等 4 处 import），这里直查表。不在 queryMembers SQL 里 JOIN
+// 的原因：user_verification 是 utf8mb4_general_ci，而存量库的 legacy 表可能
+// 还是 utf8mb4_0900_ai_ci（issue #150 的混排雷区），参数化 IN 查询不触发
+// 跨表 collation 比较；同时与 group fillRealnameFields 的批量回填同模式。
+func (d *DB) queryVerificationsByUIDs(uids []string) (map[string]*memberVerificationModel, error) {
+	out := make(map[string]*memberVerificationModel, len(uids))
+	for start := 0; start < len(uids); start += memberVerificationBatchSize {
+		end := start + memberVerificationBatchSize
+		if end > len(uids) {
+			end = len(uids)
+		}
+		var models []*memberVerificationModel
+		_, err := d.session.Select("user_id", "real_name", "verified_at").
+			From("user_verification").
+			Where("user_id IN ?", uids[start:end]).Load(&models)
+		if err != nil {
+			return nil, err
+		}
+		for _, m := range models {
+			out[m.UserID] = m
+		}
+	}
+	return out, nil
+}
+
 // removeMemberLocked 锁内重读角色后移除成员，防并发转让产生无主空间，
 // 见 db_manager.go removeMemberLocked。
 func (d *DB) removeMemberLocked(spaceId, uid string, rejectRoleAtOrAbove int) error {

--- a/modules/space/model.go
+++ b/modules/space/model.go
@@ -167,11 +167,17 @@ type spaceResp struct {
 }
 
 type memberResp struct {
-	UID       string `json:"uid"`
-	Name      string `json:"name"`
-	Role      int    `json:"role"`
-	Robot     int    `json:"robot"`
-	CreatedAt string `json:"created_at"`
+	UID   string `json:"uid"`
+	Name  string `json:"name"`
+	Role  int    `json:"role"`
+	Robot int    `json:"robot"`
+	// OCTO 实名认证三字段（issue #344），JSON tag 与 modules/group
+	// memberDetailResp（YUJ-413）逐字对齐 —— Android/iOS 已按这套契约解析。
+	// 未实名：realname_verified=false，其余 omitempty 省略。
+	RealnameVerified   bool   `json:"realname_verified"`
+	RealName           string `json:"real_name,omitempty"`
+	RealnameVerifiedAt int64  `json:"realname_verified_at,omitempty"`
+	CreatedAt          string `json:"created_at"`
 }
 
 type inviteResp struct {

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/file"
 	"github.com/Mininglamp-OSS/octo-server/modules/source"
 	"github.com/Mininglamp-OSS/octo-server/pkg/avatarrender"
+	"github.com/Mininglamp-OSS/octo-server/pkg/displayname"
 	"github.com/Mininglamp-OSS/octo-server/pkg/avatarversion"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
@@ -585,7 +586,22 @@ func (u *User) UserAvatar(c *wkhttp.Context) {
 				c.Header("Cache-Control", "public, max-age=300, must-revalidate")
 			}
 
-			text := avatarrender.IndividualText(userInfo.Name)
+			// 展示名与成员列表的兜底链保持一致（issue #344 / pkg/displayname）：
+			// 空名用户列表已显示 real_name/占位名，头像若仍按裸 user.name 走 uid
+			// ASCII 兜底图，同一用户两个 UI 面会不一致。仅空名才多查一次实名记录
+			// （PK 单查），正常用户热路径零额外开销；查询失败仅 log 按未实名继续
+			// —— 占位名仍保证可渲染。
+			avatarName := userInfo.Name
+			if strings.TrimSpace(avatarName) == "" {
+				realName := ""
+				if vr, vErr := u.verificationDB.QueryByUID(uid); vErr != nil {
+					u.Warn("查询实名认证记录失败（头像展示名兜底）", zap.Error(vErr), zap.String("uid", uid))
+				} else if vr != nil {
+					realName = vr.RealName
+				}
+				avatarName = displayname.Resolve(userInfo.Name, realName, uid)
+			}
+			text := avatarrender.IndividualText(avatarName)
 			nameMode := avatarrender.Renderable(text)
 			// ETag 覆盖决定内容的因子：渲染模式版本 + uid(决定颜色) + 展示文字。
 			etag := avatarETag("ascii-v1", uid)

--- a/modules/user/avatar_displayname_test.go
+++ b/modules/user/avatar_displayname_test.go
@@ -1,0 +1,113 @@
+package user
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/avatarrender"
+	"github.com/Mininglamp-OSS/octo-server/pkg/displayname"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// issue #344 · 默认头像与成员列表展示名兜底的一致性
+//
+// 成员列表对空 user.name 兜底为 real_name / 占位名后，默认头像若仍用裸
+// userInfo.Name 渲染（空名 → Renderable=false → uid ASCII 兜底图），同一个
+// 用户会出现「列表名是张三、头像却是 uid 字符图」的两面不一致。
+//
+// 契约：UserAvatar 的昵称渲染分支必须经同一条 displayname.Resolve 链取展示名。
+// 断言走 ETag —— name-v3 模式的 ETag 含展示文字因子，能精确证明头像内容
+// 来源于兜底名，而无需解码 PNG。
+// =============================================================================
+
+// avatarGetRaw 直接打 GET /v1/users/:uid/avatar，返回 recorder。
+func avatarGetRaw(t *testing.T, handler http.Handler, uid string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/v1/users/"+uid+"/avatar", nil)
+	require.NoError(t, err)
+	req.Header.Set("token", testutil.Token)
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+func seedAvatarUserVerification(t *testing.T, u *User, uid, realName string) {
+	t.Helper()
+	_, err := u.ctx.DB().InsertBySql(
+		"INSERT INTO user_verification (user_id, real_name, source, source_sub, verified_at) "+
+			"VALUES (?, ?, 'aegis', ?, ?)",
+		uid, realName, "sub-"+uid, time.Date(2026, 5, 11, 10, 0, 0, 0, time.UTC),
+	).Exec()
+	require.NoError(t, err)
+}
+
+// TestUserAvatar_BlankNameVerified_RendersRealName：空名已实名用户的默认头像
+// 必须按 real_name 渲染（ETag = name-v3 + real_name 后两字），与成员列表
+// 显示的兜底名一致，而不是回退 uid ASCII 兜底图。
+func TestUserAvatar_BlankNameVerified_RendersRealName(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	u := New(ctx) // 路由已由 NewTestServer 挂载（user 模块 init 注册），重复 Route 会 panic
+
+	const uid = "av_blank_verified_01"
+	require.NoError(t, u.db.Insert(&Model{
+		UID: uid, Name: "", Username: "av_bv_01", ShortNo: "av_bv_sn01", Status: 1,
+	}))
+	seedAvatarUserVerification(t, u, uid, "张三")
+
+	w := avatarGetRaw(t, s.GetRoute(), uid)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
+
+	wantText := avatarrender.IndividualText("张三")
+	assert.Equal(t, avatarETag("name-v3", uid, wantText), w.Header().Get("ETag"),
+		"空名已实名用户的头像必须按 real_name 渲染（与列表兜底名一致）")
+}
+
+// TestUserAvatar_BlankNameUnverified_RendersPlaceholder：空名未实名用户的
+// 默认头像必须按占位名渲染（与列表显示的「用户+uid 后 4 位」一致），
+// 不再走 ascii-v1 的 uid 字符兜底图。
+func TestUserAvatar_BlankNameUnverified_RendersPlaceholder(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	u := New(ctx) // 路由已由 NewTestServer 挂载（user 模块 init 注册），重复 Route 会 panic
+
+	const uid = "av_blank_plain_0007"
+	require.NoError(t, u.db.Insert(&Model{
+		UID: uid, Name: "", Username: "av_bp_07", ShortNo: "av_bp_sn07", Status: 1,
+	}))
+
+	w := avatarGetRaw(t, s.GetRoute(), uid)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
+
+	wantText := avatarrender.IndividualText(displayname.Resolve("", "", uid))
+	assert.Equal(t, avatarETag("name-v3", uid, wantText), w.Header().Get("ETag"),
+		"空名未实名用户的头像必须按占位名渲染（与列表兜底名一致）")
+}
+
+// TestUserAvatar_NormalName_NotOverriddenByRealName：name 非空时头像保持按
+// 用户自取名渲染 —— real_name 只兜底，不覆盖（与列表语义一致）。
+func TestUserAvatar_NormalName_NotOverriddenByRealName(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	u := New(ctx) // 路由已由 NewTestServer 挂载（user 模块 init 注册），重复 Route 会 panic
+
+	const uid = "av_named_keep_0008"
+	require.NoError(t, u.db.Insert(&Model{
+		UID: uid, Name: "网名小王", Username: "av_nk_08", ShortNo: "av_nk_sn08", Status: 1,
+	}))
+	seedAvatarUserVerification(t, u, uid, "王五")
+
+	w := avatarGetRaw(t, s.GetRoute(), uid)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	wantText := avatarrender.IndividualText("网名小王")
+	assert.Equal(t, avatarETag("name-v3", uid, wantText), w.Header().Get("ETag"),
+		"name 非空时头像不允许被 real_name 覆盖")
+}

--- a/pkg/displayname/displayname.go
+++ b/pkg/displayname/displayname.go
@@ -1,0 +1,43 @@
+// Package displayname 统一解析用户对外展示名（issue #344）。
+//
+// 背景：user.name 在 RegisterUserMustCompleteInfoOn==1 时允许为空（本地注册与
+// OIDC 建号同走 createUserWithRespAndTx 的空名分支，见 modules/user/api.go），
+// 列表类端点直接渲染 user.name 会出现空名。所有"他人视图"的读路径用同一条
+// 解析链兜底：
+//
+//	name（用户自取名）→ real_name（仅已实名用户）→ "用户"+uid 后 4 位（占位名）
+//
+// 适用边界：
+//   - 只用于响应组装，不回写 user.name —— 写时不变量是独立决策（issue #344 Phase 2）；
+//   - 自我视图（/v1/user/current）不适用 —— name 为空是客户端"完善资料"流程的信号；
+//   - 把 real_name 下发/展示给同空间、同群成员沿用 modules/group YUJ-413 的既有口径。
+//
+// 占位名固定中文（产品主用户群）：响应数据层目前没有按请求语言渲染的先例
+// （pkg/i18n 只覆盖错误信息与邮件模板），引入会把语言协商拉进所有列表热路径。
+package displayname
+
+import "strings"
+
+const (
+	placeholderPrefix    = "用户"
+	placeholderSuffixLen = 4
+)
+
+// Resolve 返回用户的对外展示名，保证非空。
+//
+// name 非空时原样返回（不做 trim 改写）；空白串视为空。realName 仅在已实名
+// 用户处非空，未实名调用方应传 ""。占位名后缀取 uid 末 4 位（uid 为 ASCII
+// 短编码，按字节切安全），uid 不足 4 位时整个 uid 作为后缀。
+func Resolve(name, realName, uid string) string {
+	if strings.TrimSpace(name) != "" {
+		return name
+	}
+	if rn := strings.TrimSpace(realName); rn != "" {
+		return rn
+	}
+	suffix := uid
+	if len(uid) > placeholderSuffixLen {
+		suffix = uid[len(uid)-placeholderSuffixLen:]
+	}
+	return placeholderPrefix + suffix
+}

--- a/pkg/displayname/displayname_test.go
+++ b/pkg/displayname/displayname_test.go
@@ -1,0 +1,81 @@
+package displayname
+
+import "testing"
+
+// TestResolve 锁定展示名解析链（issue #344）：
+//
+//	name（用户自取名）→ real_name（仅已实名）→ "用户"+uid 后 4 位（占位名）
+func TestResolve(t *testing.T) {
+	tests := []struct {
+		name     string
+		userName string
+		realName string
+		uid      string
+		want     string
+	}{
+		{
+			name:     "name 非空时原样返回，real_name 不参与",
+			userName: "张小明",
+			realName: "张三",
+			uid:      "uid-1234",
+			want:     "张小明",
+		},
+		{
+			name:     "name 非空时不做 trim 改写",
+			userName: " 张小明 ",
+			realName: "",
+			uid:      "uid-1234",
+			want:     " 张小明 ",
+		},
+		{
+			name:     "name 为空回退 real_name",
+			userName: "",
+			realName: "张三",
+			uid:      "uid-1234",
+			want:     "张三",
+		},
+		{
+			name:     "name 纯空白视为空，回退 real_name",
+			userName: "   ",
+			realName: "张三",
+			uid:      "uid-1234",
+			want:     "张三",
+		},
+		{
+			name:     "name 与 real_name 均为空时生成占位名（uid 后 4 位）",
+			userName: "",
+			realName: "",
+			uid:      "1234567890abcdef",
+			want:     "用户cdef",
+		},
+		{
+			name:     "real_name 纯空白同样视为空",
+			userName: "",
+			realName: " \t",
+			uid:      "1234567890abcdef",
+			want:     "用户cdef",
+		},
+		{
+			name:     "uid 不足 4 位时整个 uid 作为后缀",
+			userName: "",
+			realName: "",
+			uid:      "ab",
+			want:     "用户ab",
+		},
+		{
+			name:     "全部为空时仅返回占位前缀",
+			userName: "",
+			realName: "",
+			uid:      "",
+			want:     "用户",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Resolve(tt.userName, tt.realName, tt.uid); got != tt.want {
+				t.Errorf("Resolve(%q, %q, %q) = %q, want %q",
+					tt.userName, tt.realName, tt.uid, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 背景（issue #344 · Phase 1）

`GET /v1/space/{space_id}/members` 对 `user.name` 为空的成员渲染空字符串。空名来源是 `createUserWithRespAndTx` 的 `RegisterUserMustCompleteInfoOn==1` 分支（本地注册与 OIDC 建号同走此路径，见 issue 下 triage 修正）。受影响人群分两类：已实名（`user_verification.real_name` 存在）与未实名（全空）。

## 修法（读时兜底，对齐 modules/group YUJ-413 既有口径）

统一展示名解析链，新增 `pkg/displayname`（纯函数、无模块依赖）：

```
name（用户自取名）→ real_name（仅已实名）→ "用户" + uid 后 4 位（占位名）
```

**Commit 1 — `modules/space` 成员列表：**

- 批量查 `user_verification`（零 N+1，分批 IN，批大小对齐 user 模块 `verificationBatchSize`），响应组装时对 `name` 套解析链；查询失败仅 log 不阻断（语义同 group `fillRealnameFields`）
- **`memberResp` 新增实名三字段** `realname_verified` / `real_name` / `realname_verified_at`，JSON tag 与 group `memberDetailResp`（YUJ-413）逐字对齐 —— 隐私口径沿用既有先例（群成员列表已下发同字段），不引入新暴露面
- **不用 SQL JOIN 而走独立参数化查询**：`user_verification` 是 `utf8mb4_general_ci`，存量库 legacy 表可能仍是 `utf8mb4_0900_ai_ci`（#150 的混排雷区），参数化 IN 不触发跨表 collation 比较

**Commit 2 — `modules/user` 默认头像一致性（review 中提出）：**

`UserAvatar` 昵称渲染分支原先用裸 `userInfo.Name`：空名用户 `Renderable=false` 回退 uid ASCII 兜底图，与列表显示的兜底名两面不一致（列表"张三"、头像 uid 字符图）。改为同一条 `displayname.Resolve` 链取展示名：

- 仅 `name` 为空时多查一次实名记录（PK 单查），正常用户热路径零额外开销；查询失败仅 log 按未实名继续
- `name-v3` ETag 本就含展示文字因子，兜底名变化（如事后实名）缓存自动 revalidate，无需版本升级

### 刻意不做（边界）

- 不回写 `user.name` —— 写时不变量 + 存量 backfill 是 issue #344 Phase 2 的产品决策
- 不动自我视图（`/v1/user/current`）—— 空名是客户端"完善资料"流程的信号
- 不用 `username` / `short_no` 兜底（隐私门控、可为空、非人读，issue 已论证）
- 不动 OIDC 重复登录的非空同步守卫（#1307 有意行为）；webhook `iwh_` 头像路径不变（#255 另案）

### 后续（不阻塞本 PR）

其余读 `user.name` 的列表端点（`search/api.go`、`bot_api/groups.go`、入空间申请人名、group 成员列表 `name` 字段、`GET /v1/users/{uid}` 他人视图）将以同一 helper 分批扫尾，保持本 PR size 可审。

## 测试（TDD：先红后绿）

- `pkg/displayname` 单测：8 个 case 锁定解析链（含空白串、uid 短于 4 位等边界）
- 源码级契约锁定（无 DB 依赖，照搬 `group/api_realname_test.go` 模式）：`memberResp` 三字段 tag 逐字断言；`listMembers` 必须调 `displayname.Resolve` + 批量 `queryVerificationsByUIDs`、禁止单查 N+1
- 真 HTTP e2e（MySQL/Redis/WuKongIM 真栈）：
  - 成员列表：三类成员（正常名 / 空名已实名 / 空名未实名）断言 `name` 分别为自取名、`real_name`、占位名，且全员 name 非空；另有"自取名优先，real_name 不覆盖"用例
  - 默认头像：空名已实名 → ETag=`name-v3`+real_name 文字；空名未实名 → ETag=`name-v3`+占位名文字；正常名不被 real_name 覆盖（ETag 含文字因子，可精确证明渲染来源而无需解码 PNG）
- space TestMain 依赖表补 `user_verification` DDL（user 包反向依赖 space，迁移不会在本包测试二进制里建表）

本地验证（CI 同款流程，fresh DB + `-race -shuffle=on`）：
- `go test -race -shuffle=on ./modules/space/ ./modules/user/ ./pkg/displayname/ ./pkg/avatarrender/` ✅
- `go build ./...` / `go vet` ✅
- `make i18n-extract-check` / `make i18n-lint` ✅
- `golangci-lint run`（改动包）：0 issues ✅

Part of #344（issue 留开放：Phase 2 写时不变量与扫尾批次仍在该 issue 跟踪）

https://claude.ai/code/session_01FGroLGwNY9zoC5A25FXFem