### PR TITLE
feat(runtime-onboarding): web endpoint 替代 BotFather /daemon 命令

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -141,7 +141,10 @@ Install the daemon CLI:
 go install github.com/Mininglamp-OSS/octo-daemon-cli@latest
 ```
 
-In OCTO, send `/daemon` to BotFather to receive your start command.
+In OCTO Web, open the **Runtimes** page from the left sidebar, click the
+**+** button → **创建 Runtime** to get the install + start commands for your
+machine. Copy and run them; the daemon will register with the server and
+the runtimes will appear under your device in the tree.
 
 ## Troubleshooting
 

--- a/modules/botfather/api.go
+++ b/modules/botfather/api.go
@@ -109,6 +109,13 @@ func (bf *BotFather) Route(r *wkhttp.WKHttp) {
 	// Robot Apply API 端点（使用用户认证）
 	bf.setupApplyRoutes(r)
 
+	// Runtime onboarding (web session auth) — replaces the legacy
+	// BotFather `/daemon` IM command. Returns api_key (lazy-create) +
+	// server/fleet/matter URLs + pre-rendered install/start command
+	// strings for the web CreateRuntimeModal.
+	authedAPI := r.Group("/v1", bf.ctx.AuthMiddleware(r))
+	authedAPI.GET("/runtime-onboarding", bf.runtimeOnboarding)
+
 	// 初始化BotFather系统用户（使用sync.Once确保只执行一次）
 	bf.initOnce.Do(func() {
 		bf.initBotFatherUser()
@@ -305,7 +312,6 @@ func (bf *BotFather) initBotFatherUser() {
 func (bf *BotFather) registerBotFatherCommands() {
 	commands := []map[string]string{
 		{"command": CmdInstall, "description": "安装/更新 Octo 插件"},
-		{"command": CmdDaemon, "description": "获取 Agent Runtime 监控启动命令"},
 		{"command": CmdQuickstart, "description": "AI Agent 快速入门"},
 		{"command": CmdNewBot, "description": "创建新机器人"},
 		{"command": CmdMyBots, "description": "查看我的机器人"},

--- a/modules/botfather/api_runtime_onboarding.go
+++ b/modules/botfather/api_runtime_onboarding.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"strings"
 
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"go.uber.org/zap"
 )
@@ -43,14 +44,16 @@ type onboardingCmds struct {
 // runtimeOnboarding handles GET /v1/runtime-onboarding.
 //
 // Auth: session token (web caller only — daemon never calls this; daemon
-// already has its api_key).
+// already has its api_key) + space membership + active user.
 //
 // Behavior mirrors the now-removed handleDaemon (formerly BotFather IM
 // `/daemon` command):
 //   1. Resolve caller uid + space_id
-//   2. getOrCreate user_api_key for (uid, space_id)
-//   3. Derive server / fleet / matter URLs from server config
-//   4. Pre-render install + start command strings for display
+//   2. Verify caller is an active member of an active space + active user
+//      (D11 撤销链路审计: token cache 路径 + DB SQL gate 双层防护)
+//   3. getOrCreate user_api_key for (uid, space_id)
+//   4. Derive server / fleet / matter URLs from server config
+//   5. Pre-render install + start command strings for display
 //
 // space_id source: the request must carry a verified space context (either
 // via X-Space-Id header set by middleware or query param ?space_id=). If
@@ -64,12 +67,49 @@ func (bf *BotFather) runtimeOnboarding(c *wkhttp.Context) {
 		return
 	}
 
-	spaceID := strings.TrimSpace(c.GetHeader("X-Space-Id"))
+	// query 优先 / header 备选 — 跟 SpaceMiddleware (pkg/space/middleware.go)
+	// 顺序对齐, 减少认知负担.
+	spaceID := strings.TrimSpace(c.Query("space_id"))
 	if spaceID == "" {
-		spaceID = strings.TrimSpace(c.Query("space_id"))
+		spaceID = strings.TrimSpace(c.GetHeader("X-Space-Id"))
 	}
 	if spaceID == "" {
-		c.ResponseErrorWithStatus(errors.New("space_id required (header X-Space-Id or query ?space_id=)"), http.StatusBadRequest)
+		spaceID = strings.TrimSpace(c.GetHeader("X-Space-ID"))
+	}
+	if spaceID == "" {
+		c.ResponseErrorWithStatus(errors.New("space_id required (query ?space_id= or header X-Space-Id)"), http.StatusBadRequest)
+		return
+	}
+
+	// C1 fix (review round 1): 显式 SpaceMember 校验 + active user 二重 gate.
+	// CheckMembership 已 join space.status=1 + space_member.status=1 但
+	// **没** join user.status=1 (D11 撤销链路: liftBanUser 走 redis token
+	// cache 路径关 banned user 的 session, 但 onboarding 是 lazy-create
+	// api_key, 一旦 row 写下去后续 verify-api-key 会显式查 user.status=1
+	// 堵住, 但当下这次写入仍会"成功" — 给 banned user lazy-create 一行
+	// dead row 是数据污染, 这里加 belt-and-braces).
+	ok, err := spacepkg.CheckMembership(bf.ctx.DB().NewSession(nil), spaceID, uid)
+	if err != nil {
+		bf.Error("runtime-onboarding: check membership", zap.Error(err))
+		c.ResponseErrorWithStatus(errors.New("internal error"), http.StatusInternalServerError)
+		return
+	}
+	if !ok {
+		c.ResponseErrorWithStatus(errors.New("not a member of this space"), http.StatusForbidden)
+		return
+	}
+	// user.status=1 二重 gate (D11): banned user 应被堵在这一层, 不能落
+	// 库 lazy-create dead api_key row.
+	var userActive int
+	if qerr := bf.ctx.DB().NewSession(nil).
+		SelectBySql("SELECT COUNT(*) FROM user WHERE uid=? AND status=1", uid).
+		LoadOne(&userActive); qerr != nil {
+		bf.Error("runtime-onboarding: check user status", zap.Error(qerr))
+		c.ResponseErrorWithStatus(errors.New("internal error"), http.StatusInternalServerError)
+		return
+	}
+	if userActive == 0 {
+		c.ResponseErrorWithStatus(errors.New("user not active"), http.StatusForbidden)
 		return
 	}
 
@@ -87,6 +127,24 @@ func (bf *BotFather) runtimeOnboarding(c *wkhttp.Context) {
 	}
 
 	serverURL, fleetURL, matterURL := bf.deriveOnboardingURLs()
+	if strings.Contains(serverURL, "://:") || strings.Contains(fleetURL, "://:") || strings.Contains(matterURL, "://:") {
+		// External.BaseURL + External.IP 都空 — 拼出来是 'http://:8090'
+		// broken URL, 给前端展示也是误导, 直接报 500 + log 提示运维.
+		bf.Error("runtime-onboarding: server URL config missing (External.BaseURL + External.IP both empty)",
+			zap.String("server", serverURL), zap.String("fleet", fleetURL), zap.String("matter", matterURL))
+		c.ResponseErrorWithStatus(errors.New("server URL not configured"), http.StatusInternalServerError)
+		return
+	}
+
+	// commands.start 是 standalone 可复制可跑的 multi-line block: 含 3 个
+	// OCTO_*_URL export 让 daemon-cli 能拿到 server/fleet/matter, 末尾才是
+	// octo-daemon start 行. caller 直接复制 commands.start 就跑得起来,
+	// 不用再去 env_vars 字段二次拼接 (env_vars 单独保留供想 set 到 shell rc
+	// 文件而非 inline 的场景).
+	startBlock := fmt.Sprintf(
+		"export OCTO_SERVER_URL=%s\nexport OCTO_FLEET_URL=%s\nexport OCTO_MATTER_URL=%s\nocto-daemon start --api-key %s --api-url %s",
+		serverURL, fleetURL, matterURL, apiKey, fleetURL,
+	)
 
 	resp := runtimeOnboardingResp{
 		APIKey:    apiKey,
@@ -96,7 +154,7 @@ func (bf *BotFather) runtimeOnboarding(c *wkhttp.Context) {
 		MatterURL: matterURL,
 		Commands: onboardingCmds{
 			Install: "go install github.com/Mininglamp-OSS/octo-daemon-cli@latest",
-			Start:   fmt.Sprintf("octo-daemon start --api-key %s --api-url %s", apiKey, fleetURL),
+			Start:   startBlock,
 		},
 		EnvVars: map[string]string{
 			"OCTO_SERVER_URL": serverURL,

--- a/modules/botfather/api_runtime_onboarding.go
+++ b/modules/botfather/api_runtime_onboarding.go
@@ -68,13 +68,12 @@ func (bf *BotFather) runtimeOnboarding(c *wkhttp.Context) {
 	}
 
 	// query 优先 / header 备选 — 跟 SpaceMiddleware (pkg/space/middleware.go)
-	// 顺序对齐, 减少认知负担.
+	// 顺序对齐, 减少认知负担. HTTP header 大小写不敏感, GetHeader 内部用
+	// textproto.CanonicalMIMEHeaderKey 规范化, X-Space-Id 跟 X-Space-ID
+	// 都吃 (不需要查两次).
 	spaceID := strings.TrimSpace(c.Query("space_id"))
 	if spaceID == "" {
 		spaceID = strings.TrimSpace(c.GetHeader("X-Space-Id"))
-	}
-	if spaceID == "" {
-		spaceID = strings.TrimSpace(c.GetHeader("X-Space-ID"))
 	}
 	if spaceID == "" {
 		c.ResponseErrorWithStatus(errors.New("space_id required (query ?space_id= or header X-Space-Id)"), http.StatusBadRequest)
@@ -88,7 +87,7 @@ func (bf *BotFather) runtimeOnboarding(c *wkhttp.Context) {
 	// api_key, 一旦 row 写下去后续 verify-api-key 会显式查 user.status=1
 	// 堵住, 但当下这次写入仍会"成功" — 给 banned user lazy-create 一行
 	// dead row 是数据污染, 这里加 belt-and-braces).
-	ok, err := spacepkg.CheckMembership(bf.ctx.DB().NewSession(nil), spaceID, uid)
+	ok, err := spacepkg.CheckMembership(bf.ctx.DB(), spaceID, uid)
 	if err != nil {
 		bf.Error("runtime-onboarding: check membership", zap.Error(err))
 		c.ResponseErrorWithStatus(errors.New("internal error"), http.StatusInternalServerError)
@@ -101,7 +100,7 @@ func (bf *BotFather) runtimeOnboarding(c *wkhttp.Context) {
 	// user.status=1 二重 gate (D11): banned user 应被堵在这一层, 不能落
 	// 库 lazy-create dead api_key row.
 	var userActive int
-	if qerr := bf.ctx.DB().NewSession(nil).
+	if qerr := bf.ctx.DB().
 		SelectBySql("SELECT COUNT(*) FROM user WHERE uid=? AND status=1", uid).
 		LoadOne(&userActive); qerr != nil {
 		bf.Error("runtime-onboarding: check user status", zap.Error(qerr))
@@ -137,13 +136,15 @@ func (bf *BotFather) runtimeOnboarding(c *wkhttp.Context) {
 	}
 
 	// commands.start 是 standalone 可复制可跑的 multi-line block: 含 3 个
-	// OCTO_*_URL export 让 daemon-cli 能拿到 server/fleet/matter, 末尾才是
-	// octo-daemon start 行. caller 直接复制 commands.start 就跑得起来,
-	// 不用再去 env_vars 字段二次拼接 (env_vars 单独保留供想 set 到 shell rc
-	// 文件而非 inline 的场景).
+	// OCTO_*_URL export 让 daemon 各 service 调用走 env (fleet / server /
+	// matter 各走各), 末尾 octo-daemon start 行的 --api-url 用 serverURL —
+	// 跟旧 BotFather /daemon 命令一致 (cfg.APIURL 在 daemon 内只是 env 缺
+	// 失时的 fallback, env 全设了 cfg.APIURL 不会被读). caller 直接复制
+	// commands.start 就跑得起来, 不用再去 env_vars 字段二次拼接 (env_vars
+	// 单独保留供想 set 到 shell rc 而非 inline 的场景).
 	startBlock := fmt.Sprintf(
 		"export OCTO_SERVER_URL=%s\nexport OCTO_FLEET_URL=%s\nexport OCTO_MATTER_URL=%s\nocto-daemon start --api-key %s --api-url %s",
-		serverURL, fleetURL, matterURL, apiKey, fleetURL,
+		serverURL, fleetURL, matterURL, apiKey, serverURL,
 	)
 
 	resp := runtimeOnboardingResp{

--- a/modules/botfather/api_runtime_onboarding.go
+++ b/modules/botfather/api_runtime_onboarding.go
@@ -1,0 +1,162 @@
+// Runtime onboarding endpoint — replaces the BotFather `/daemon` IM command.
+//
+// Web `/runtimes` page calls GET /v1/runtime-onboarding to get the daemon
+// install + start commands for the logged-in user. Returns the user's
+// api_key (lazy-create on first call), derived service URLs, and pre-rendered
+// CLI command strings for direct display in the CreateRuntimeModal.
+//
+// The previous `/daemon` IM-side command (modules/botfather/command.go's
+// handleDaemon) was removed in the same PR — onboarding is web-only now.
+
+package botfather
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"go.uber.org/zap"
+)
+
+// runtimeOnboardingResp is the JSON shape consumed by web's
+// CreateRuntimeModal. Callers should treat the `commands.start` string as
+// the canonical start command — env_vars are exposed for the case where
+// the user wants to set them in their shell rc file rather than inlining
+// per-invocation, but the command string is sufficient on its own.
+type runtimeOnboardingResp struct {
+	APIKey    string            `json:"api_key"`
+	SpaceID   string            `json:"space_id"`
+	ServerURL string            `json:"server_url"`
+	FleetURL  string            `json:"fleet_url"`
+	MatterURL string            `json:"matter_url"`
+	Commands  onboardingCmds    `json:"commands"`
+	EnvVars   map[string]string `json:"env_vars"`
+}
+
+type onboardingCmds struct {
+	Install string `json:"install"`
+	Start   string `json:"start"`
+}
+
+// runtimeOnboarding handles GET /v1/runtime-onboarding.
+//
+// Auth: session token (web caller only — daemon never calls this; daemon
+// already has its api_key).
+//
+// Behavior mirrors the now-removed handleDaemon (formerly BotFather IM
+// `/daemon` command):
+//   1. Resolve caller uid + space_id
+//   2. getOrCreate user_api_key for (uid, space_id)
+//   3. Derive server / fleet / matter URLs from server config
+//   4. Pre-render install + start command strings for display
+//
+// space_id source: the request must carry a verified space context (either
+// via X-Space-Id header set by middleware or query param ?space_id=). If
+// neither is present, return 400 — no implicit "first space" fallback,
+// since that would let the caller end up with an api_key bound to a space
+// they didn't intend.
+func (bf *BotFather) runtimeOnboarding(c *wkhttp.Context) {
+	uid := c.GetLoginUID()
+	if uid == "" {
+		c.ResponseErrorWithStatus(errors.New("login required"), http.StatusUnauthorized)
+		return
+	}
+
+	spaceID := strings.TrimSpace(c.GetHeader("X-Space-Id"))
+	if spaceID == "" {
+		spaceID = strings.TrimSpace(c.Query("space_id"))
+	}
+	if spaceID == "" {
+		c.ResponseErrorWithStatus(errors.New("space_id required (header X-Space-Id or query ?space_id=)"), http.StatusBadRequest)
+		return
+	}
+
+	// getOrCreate user_api_key for (uid, space_id). Mirrors the lazy-create
+	// behavior the IM /daemon command had — first onboarding access seeds
+	// the row, subsequent calls reuse it. INSERT failure on race is
+	// tolerated by re-querying (two concurrent web tabs could both miss
+	// the SELECT then both INSERT, but the (uid, space_id) unique
+	// constraint guarantees only one wins; the loser re-reads).
+	apiKey, err := bf.getOrCreateUserAPIKey(uid, spaceID)
+	if err != nil {
+		bf.Error("runtime-onboarding: get/create api_key", zap.Error(err))
+		c.ResponseErrorWithStatus(errors.New("failed to allocate api_key"), http.StatusInternalServerError)
+		return
+	}
+
+	serverURL, fleetURL, matterURL := bf.deriveOnboardingURLs()
+
+	resp := runtimeOnboardingResp{
+		APIKey:    apiKey,
+		SpaceID:   spaceID,
+		ServerURL: serverURL,
+		FleetURL:  fleetURL,
+		MatterURL: matterURL,
+		Commands: onboardingCmds{
+			Install: "go install github.com/Mininglamp-OSS/octo-daemon-cli@latest",
+			Start:   fmt.Sprintf("octo-daemon start --api-key %s --api-url %s", apiKey, fleetURL),
+		},
+		EnvVars: map[string]string{
+			"OCTO_SERVER_URL": serverURL,
+			"OCTO_FLEET_URL":  fleetURL,
+			"OCTO_MATTER_URL": matterURL,
+		},
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+// getOrCreateUserAPIKey looks up the (uid, space_id) api_key row, or
+// creates one with a freshly-generated `uk_<32hex>` token if missing.
+// Extracted from the now-deleted handleDaemon so both the new HTTP
+// endpoint and any future caller can share the same lazy-init semantics.
+func (bf *BotFather) getOrCreateUserAPIKey(uid, spaceID string) (string, error) {
+	existing, err := bf.db.queryUserAPIKeyByUIDAndSpaceID(uid, spaceID)
+	if err != nil {
+		return "", fmt.Errorf("query api_key: %w", err)
+	}
+	if existing != nil {
+		return existing.APIKey, nil
+	}
+	hex, err := randomHex(16)
+	if err != nil {
+		return "", fmt.Errorf("generate api_key: %w", err)
+	}
+	apiKey := UserAPIKeyPrefix + hex
+	if err := bf.db.insertUserAPIKey(uid, apiKey, spaceID); err != nil {
+		// Race: another concurrent caller may have inserted in between.
+		// Re-query — if a row is present now, the other side won the
+		// race and we return their key. If still empty, the INSERT
+		// failed for some other reason (e.g. DB error) and we surface
+		// that.
+		if again, qerr := bf.db.queryUserAPIKeyByUIDAndSpaceID(uid, spaceID); qerr == nil && again != nil {
+			return again.APIKey, nil
+		}
+		return "", fmt.Errorf("insert api_key: %w", err)
+	}
+	return apiKey, nil
+}
+
+// deriveOnboardingURLs returns the (server, fleet, matter) URLs the daemon
+// should hit. server URL comes from config (External.BaseURL, falling back
+// to External.IP); fleet/matter ports are derived by swapping the trailing
+// :port suffix. Mirrors the now-deleted handleDaemon's URL block.
+//
+// In production, octo-deployment overrides these via reverse proxy /
+// docker-compose env, but the dev-local default works out of the box for
+// users running all 3 services on the same host with default ports.
+func (bf *BotFather) deriveOnboardingURLs() (server, fleet, matter string) {
+	cfg := bf.ctx.GetConfig()
+	server = cfg.External.BaseURL
+	if strings.TrimSpace(server) == "" {
+		server = fmt.Sprintf("http://%s:8090", cfg.External.IP)
+	}
+	// daemon constructs /v1/daemon/... paths itself — the base URL must
+	// not end in /api or a trailing slash.
+	server = strings.TrimSuffix(server, "/api")
+	server = strings.TrimSuffix(server, "/")
+	fleet = deriveServiceURL(server, ":8092")
+	matter = deriveServiceURL(server, ":8080")
+	return
+}

--- a/modules/botfather/command.go
+++ b/modules/botfather/command.go
@@ -171,8 +171,6 @@ func (h *commandHandler) handleCommand(fromUID string, cmd string) {
 		h.handleQuickstart(fromUID)
 	case CmdInstall:
 		h.handleInstall(fromUID)
-	case CmdDaemon:
-		h.handleDaemon(fromUID)
 	case CmdApprove:
 		h.handleApprove(fromUID, strings.TrimPrefix(cmd, command+" "))
 	case CmdReject:
@@ -488,7 +486,6 @@ func (h *commandHandler) handleHelp(fromUID string) {
 
 - /install — 安装/更新 Octo 插件
 - /quickstart — AI Agent 快速入门（推荐）
-- /daemon — 获取 Agent Runtime 监控启动命令
 - /newbot — 创建新机器人
 - /mybots — 查看我的机器人
 - /connect — 获取连接 prompt
@@ -1190,75 +1187,6 @@ func randomHex(n int) (string, error) {
 	return hex.EncodeToString(bytes), nil
 }
 
-// handleDaemon 返回 Agent Runtime 监控守护进程的启动命令
-func (h *commandHandler) handleDaemon(fromUID string) {
-	h.sm.Clear(fromUID, h.spaceID(fromUID))
-	spaceID := h.resolveSpaceID(fromUID)
-	if spaceID == "" {
-		h.reply(fromUID, "请先加入一个 Space 后再使用此命令。")
-		return
-	}
-	realUID := extractRealUID(fromUID)
-	apiKeyModel, err := h.db.queryUserAPIKeyByUIDAndSpaceID(realUID, spaceID)
-	if err != nil {
-		h.Error("查询API Key失败", zap.Error(err))
-		h.reply(fromUID, "查询 API Key 失败，请稍后重试。")
-		return
-	}
-	var apiKey string
-	if apiKeyModel != nil {
-		apiKey = apiKeyModel.APIKey
-	} else {
-		hexStr, hexErr := randomHex(16)
-		if hexErr != nil {
-			h.Error("生成API Key失败", zap.Error(hexErr))
-			h.reply(fromUID, "生成 API Key 失败，请稍后重试。")
-			return
-		}
-		apiKey = UserAPIKeyPrefix + hexStr
-		if err := h.db.insertUserAPIKey(realUID, apiKey, spaceID); err != nil {
-			h.Error("创建API Key失败", zap.Error(err))
-			h.reply(fromUID, "创建 API Key 失败，请稍后重试。")
-			return
-		}
-	}
-	cfg := h.ctx.GetConfig()
-	serverURL := cfg.External.BaseURL
-	if strings.TrimSpace(serverURL) == "" {
-		serverURL = fmt.Sprintf("http://%s:8090", cfg.External.IP)
-	}
-	// daemon 自己拼 /v1/daemon/... 路径，确保 base URL 不带 /api 后缀
-	serverURL = strings.TrimSuffix(serverURL, "/api")
-	serverURL = strings.TrimSuffix(serverURL, "/")
-
-	// PR-A/B: daemon 现在跟 3 个后端通信，需要 3 个 URL env。
-	// fleet / matter URL 默认按本地 dev 端口推导（同主机不同端口）；
-	// 生产部署 deployment 仓库会通过 docker-compose / nginx 覆盖。
-	// daemon 用自己的 JWT（用 api-key 自动换的）调 matter writeback，
-	// 不再需要任何 shared secret — 用户机器上没有内部密钥。
-	fleetURL := deriveServiceURL(serverURL, ":8092")
-	matterURL := deriveServiceURL(serverURL, ":8080")
-
-	h.reply(fromUID, fmt.Sprintf(
-		"🖥️ **Agent Runtime 监控**\n\n"+
-			"在你的电脑或服务器上运行以下命令，自动检测并上报本机的 AI Agent "+
-			"状态（Claude Code、Codex、OpenClaw、Hermes）：\n\n"+
-			"**1. 安装：**\n"+
-			"```\ngo install github.com/Mininglamp-OSS/octo-daemon-cli@latest\n```\n\n"+
-			"**2. 启动（macOS / Linux）：**\n"+
-			"```\n"+
-			"export OCTO_SERVER_URL=%s\n"+
-			"export OCTO_FLEET_URL=%s\n"+
-			"export OCTO_MATTER_URL=%s\n"+
-			"octo-daemon start --api-key %s --api-url %s\n"+
-			"```\n\n"+
-			"启动后可在 Web 端 Runtimes 页面查看注册的 agent，并在「智能体」"+
-			"tab 创建 bot 派任务给本机的 openclaw。\n\n"+
-			"_注：3 个 URL 是 PR-A/B 拆分后的跨服务通信地址；如果你这台机器跟"+
-			" server 不在同一台主机，把 host 部分换成实际可达的地址。_",
-		serverURL, fleetURL, matterURL, apiKey, serverURL,
-	))
-}
 
 // deriveServiceURL takes the server URL (e.g. http://host:8090) and swaps
 // the port suffix to derive sibling-service URLs. Falls back to keeping the

--- a/modules/botfather/const.go
+++ b/modules/botfather/const.go
@@ -43,7 +43,6 @@ const (
 	CmdPending        = "/pending"
 	CmdQuickstart     = "/quickstart"
 	CmdInstall        = "/install"
-	CmdDaemon         = "/daemon"
 )
 
 // 对话状态


### PR DESCRIPTION
## Summary

新增 `GET /v1/runtime-onboarding` endpoint, 替代老的 BotFather IM `/daemon` 命令. 配套 octo-web PR-2 (https://github.com/Mininglamp-OSS/octo-web/pull/375), 让用户在 web 端 \"运行时\" 页面顶部 + popover → \"创建 Runtime\" 直接拿到 daemon 接入命令.

### 改动明细

- **新加 `modules/botfather/api_runtime_onboarding.go`**:
  - GET endpoint 走 session auth (AuthMiddleware) + 显式 SpaceMember 校验 (`spacepkg.CheckMembership`) + active user `user.status=1` SQL gate (D11 撤销链路 belt-and-braces)
  - lazy-create `user_api_key` (uid, space_id) row, INSERT race 通过 re-query 容忍
  - 返 standalone multi-line `commands.start` 含 3 个 OCTO_*_URL export, caller 直接复制可跑
  - 配置缺失 (`External.BaseURL` + `External.IP` 都空) 时 handler 报 500 + log, 不给前端展示 broken URL
- **`modules/botfather/api.go`**: 注册 `/v1/runtime-onboarding` 到 AuthMiddleware group, 删 `CmdDaemon` 命令注册
- **`modules/botfather/command.go`**: 删 `case CmdDaemon` dispatch + `handleDaemon` 函数 (~70 行) + 帮助文本
- **`modules/botfather/const.go`**: 删 `CmdDaemon` 常量
- **`QUICKSTART.md`**: 删 \"send /daemon to BotFather\" 引导, 改成 \"Web Runtimes 页 + popover 创建 Runtime\"

### Test plan

- [x] cc reviewer (Claude Code) 3 轮 review, 最终 verdict=pass, 0 pre-push blocker
- [x] codex reviewer 3 轮 review, 最终 verdict=pass, 0 finding
- [x] \`go build\` + \`go vet ./modules/botfather/\` 干净
- [x] 本地 e2e: web 用户 → 创建 Runtime modal 拉 onboarding → 复制 commands.start 跑 → daemon 接入成功 → 创建 Bot (claude) → cc-channel-octo gateway 启动 → IM 私聊收消息回复
- [x] D11 撤销链路 (banned user / non-member space) 校验

### 安全 review (review round 1 双方点 P0)

- **C1 (cc critical / codex major)**: 早版本接受 query/header 传 `space_id` 但未校验 caller 是 active member, banned user 或非成员可往任意 space 注 dead `user_api_key` row + 拿 plain key 字符串 (后续被加入该 space 后老 key 立刻 live, 信息穿透). round 1 修: 接 `spacepkg.CheckMembership` (已 join `space.status=1` + `space_member.status=1`) + 二重 `user.status=1` SQL gate.
- **C2 (codex P0)**: `commands.start` 早版本只输出 `octo-daemon start --api-url ...` 不含 OCTO_*_URL export, daemon 启动会缺关键 env. round 1 修: 改 standalone multi-line block 含 3 个 export + start 行.
- **C3 (codex P0)**: QUICKSTART.md 残留 BotFather /daemon 引导. round 1 修: 改 Web Runtimes 引导.

### 配套 PR

- **octo-web PR #375** \`feat/runtime-tree-ui\`: web 端调用本 endpoint 的 CreateRuntimeModal + 三级树 + 整套 \"运行时\" 页面重构

### 后续 PR-3 推迟项 (双 reviewer 共识不阻塞)

- 单测 (cc round 1 提): mock db handler 直接测 covering missing space_id / non-member / idempotent / INSERT race re-query 4 个分支
- errcode 风格统一 (cc round 1 提): pkg/errcode/ 加 ErrRuntimeOnboardingSpaceRequired / APIKeyAlloc, handler 改 httperr.ResponseErrorL
- broken URL 检测覆盖度 (cc F6 / codex C4 共识 minor): 用 net/url.Parse 替代 strings.Contains \"://:\" 严格校验
- CheckMembership + user.status=1 简化为单条 JOIN sm+s+u SQL (cc F3 cosmetic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)