### PR TITLE
feat(auth): per-request role resolution + tighten high-impact management gates

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,11 +117,16 @@ func runAPI(ctx *config.Context) {
 	// 解析 cache value，支持 v2 JSON envelope 与 "uid@name[@role]" 旧格式（i18n D19/D21）。
 	// 同时注入 LanguageResolver，让 AuthMiddleware 把 user_language:{uid} → DB 的
 	// 真相源结果写到 UserInfo.Language 上，供 i18n.LanguageFromContext 读侧合并。
+	// 同时注入 RoleResolver：系统角色（admin/superAdmin）此前烧死在 token 里，
+	// 降权 / 删除管理员要到 token 过期才生效。这里在 Parse 时按 uid 实时解析 DB
+	// 角色（user_role:{uid} 热缓存 → DB），把降权生效窗口收敛到缓存 TTL。
 	userLangSvc := user.NewLanguageService(user.NewDB(ctx), ctx.Cache())
+	userRoleSvc := user.NewRoleService(user.NewDB(ctx), ctx.Cache())
 	route.SetTokenParser(auth.NewCacheTokenParser(
 		ctx.Cache(),
 		ctx.GetConfig().Cache.TokenCachePrefix,
 		auth.WithLanguageResolver(userLangSvc),
+		auth.WithRoleResolver(userRoleSvc),
 	))
 	// 替换web下的配置文件
 	replaceWebConfig(ctx.GetConfig())

--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -20,6 +20,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
@@ -537,10 +539,11 @@ func (cn *Common) countriesList(c *wkhttp.Context) {
 // 发版会设置客户端的下载来源（DownloadURL），属供应链敏感写操作，因此要求
 // superAdmin —— 普通 admin 定位为只读运营位，不应能改动全体用户的客户端来源。
 // 路由仍保留在 /v1/common（历史调用方依赖），仅收紧角色门槛。
+// 拒绝路径走 i18n 信封并返回通用 403（ErrSharedForbidden），不泄露"需要更高
+// 角色"的具体原因（反枚举），与 space 管理端的 requireSuperAdmin 保持一致。
 func (cn *Common) addAppVersion(c *wkhttp.Context) {
-	err := c.CheckLoginRoleIsSuperAdmin()
-	if err != nil {
-		c.ResponseError(err)
+	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
+		httperr.ResponseErrorL(c, errcode.ErrSharedForbidden, nil, nil)
 		return
 	}
 	var req appVersionReq
@@ -548,12 +551,11 @@ func (cn *Common) addAppVersion(c *wkhttp.Context) {
 		c.ResponseError(errors.New("请求数据格式有误！"))
 		return
 	}
-	err = cn.check(req)
-	if err != nil {
+	if err := cn.check(req); err != nil {
 		c.ResponseError(err)
 		return
 	}
-	_, err = cn.db.insertAppVersion(&appVersionModel{
+	_, err := cn.db.insertAppVersion(&appVersionModel{
 		AppVersion:  req.AppVersion,
 		OS:          req.OS,
 		IsForce:     req.IsForce,

--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -533,8 +533,12 @@ func (cn *Common) countriesList(c *wkhttp.Context) {
 }
 
 // 添加app版本
+//
+// 发版会设置客户端的下载来源（DownloadURL），属供应链敏感写操作，因此要求
+// superAdmin —— 普通 admin 定位为只读运营位，不应能改动全体用户的客户端来源。
+// 路由仍保留在 /v1/common（历史调用方依赖），仅收紧角色门槛。
 func (cn *Common) addAppVersion(c *wkhttp.Context) {
-	err := c.CheckLoginRole()
+	err := c.CheckLoginRoleIsSuperAdmin()
 	if err != nil {
 		c.ResponseError(err)
 		return

--- a/modules/common/api_test.go
+++ b/modules/common/api_test.go
@@ -9,10 +9,54 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestAddAppVersion_RequiresSuperAdmin pins the issue #363 gate: POST
+// /v1/common/appversion (sets the client download source — supply-chain
+// sensitive) must reject a plain admin and only let superAdmin through. The
+// denial goes through the generic forbidden envelope (anti-enumeration).
+func TestAddAppVersion_RequiresSuperAdmin(t *testing.T) {
+	// testutil.NewTestServer already registers every module's routes via
+	// module.Setup, so the appversion handler is live — don't call cn.Route
+	// (double registration panics). It also does not wire the i18n renderer, so
+	// mirror main.go here to get a populated error.code in the envelope.
+	s, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+	s.GetRoute().SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+
+	cacheCfg := ctx.GetConfig().Cache
+	body := util.ToJson(&appVersionReq{
+		AppVersion:  "9.9",
+		OS:          "android",
+		DownloadURL: "http://example.com/x.apk",
+		IsForce:     1,
+		UpdateDesc:  "x",
+	})
+
+	// plain admin → rejected by the generic forbidden envelope
+	adminTok := "common-appver-admin"
+	require.NoError(t, ctx.Cache().Set(cacheCfg.TokenCachePrefix+adminTok, "admin-uid@admin@"+string(wkhttp.Admin)))
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/common/appversion", bytes.NewReader([]byte(body)))
+	req.Header.Set("token", adminTok)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Contains(t, w.Body.String(), "err.shared.auth.forbidden", "plain admin must be rejected: %s", w.Body.String())
+
+	// superAdmin → passes the role gate (downstream insert outcome is irrelevant
+	// to this assertion; we only prove the gate let it through)
+	superTok := "common-appver-superadmin"
+	require.NoError(t, ctx.Cache().Set(cacheCfg.TokenCachePrefix+superTok, "root-uid@root@"+string(wkhttp.SuperAdmin)))
+	w2 := httptest.NewRecorder()
+	req2, _ := http.NewRequest("POST", "/v1/common/appversion", bytes.NewReader([]byte(body)))
+	req2.Header.Set("token", superTok)
+	s.GetRoute().ServeHTTP(w2, req2)
+	assert.NotContains(t, w2.Body.String(), "err.shared.auth.forbidden", "superAdmin must pass the role gate: %s", w2.Body.String())
+}
 
 func cleanAllTablesAndReloadSettings(t *testing.T, ctx *config.Context) {
 	t.Helper()

--- a/modules/space/api_manager.go
+++ b/modules/space/api_manager.go
@@ -608,6 +608,10 @@ func (m *Manager) updateSpaceProfile(c *wkhttp.Context) {
 // addMembers 管理员强制添加成员（绕过 max_users 限制）。
 // 注意：此操作绕过了 executeJoinSpace 的业务副作用（SpaceMemberJoin 事件、预设群组），
 // 属于 low-level 管理操作；常规入口请走 /v1/space/join。
+//
+// 仍保持 requireAdmin（而非 requireSuperAdmin）是有意为之：强制"添加"是可逆的
+// （随后可移除），而强制解散/封禁/移除/改角色不可逆，故只把后者收紧到 superAdmin。
+// 若日后判定强制加人也需收紧，改成 requireSuperAdmin 即可。
 func (m *Manager) addMembers(c *wkhttp.Context) {
 	if !m.requireAdmin(c) {
 		return

--- a/modules/space/api_manager.go
+++ b/modules/space/api_manager.go
@@ -156,9 +156,23 @@ func toSpaceResp(m *managerSpaceModel) *managerSpaceResp {
 	}
 }
 
-// requireAdmin 统一的 admin/superAdmin 角色检查。未通过时已写入响应，调用方应立即返回。
+// requireAdmin 统一的 admin/superAdmin 角色检查，用于只读 / 低风险管理接口。
+// 未通过时已写入响应，调用方应立即返回。
 func (m *Manager) requireAdmin(c *wkhttp.Context) bool {
 	if err := c.CheckLoginRole(); err != nil {
+		httperr.ResponseErrorL(c, errcode.ErrSharedForbidden, nil, nil)
+		return false
+	}
+	return true
+}
+
+// requireSuperAdmin 仅放行 superAdmin，用于跨空间的高危/不可逆操作（强制解散、
+// 封禁/解禁、强制移除成员、修改成员角色含转让所有权）。这些操作此前只要求
+// admin，等于让"只读运营位"对任意空间拥有上帝模式；收敛到 superAdmin。
+// 返回 ErrSharedForbidden（与 requireAdmin 同一个通用 403），不暴露"需要更高
+// 角色"的具体原因，符合反枚举约定。未通过时已写入响应，调用方应立即返回。
+func (m *Manager) requireSuperAdmin(c *wkhttp.Context) bool {
+	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
 		httperr.ResponseErrorL(c, errcode.ErrSharedForbidden, nil, nil)
 		return false
 	}
@@ -309,7 +323,7 @@ func (m *Manager) detail(c *wkhttp.Context) {
 
 // forceDisband 强制解散空间（同时移除全部成员）
 func (m *Manager) forceDisband(c *wkhttp.Context) {
-	if !m.requireAdmin(c) {
+	if !m.requireSuperAdmin(c) {
 		return
 	}
 	spaceId := c.Param("space_id")
@@ -401,7 +415,7 @@ func (m *Manager) members(c *wkhttp.Context) {
 // liftBan 封禁 / 解禁空间：status=1 恢复正常，status=2 置为封禁。
 // status=0（解散）请用 DELETE /space/:space_id。
 func (m *Manager) liftBan(c *wkhttp.Context) {
-	if !m.requireAdmin(c) {
+	if !m.requireSuperAdmin(c) {
 		return
 	}
 	spaceId := c.Param("space_id")
@@ -650,7 +664,7 @@ func (m *Manager) addMembers(c *wkhttp.Context) {
 // 禁止移除 owner——实际检查在 managerDB.removeMembersForce 的事务内用
 // SELECT ... FOR UPDATE 原子完成，避免 handler 层 check 与 update 之间的 TOCTOU。
 func (m *Manager) removeMembers(c *wkhttp.Context) {
-	if !m.requireAdmin(c) {
+	if !m.requireSuperAdmin(c) {
 		return
 	}
 	spaceId := c.Param("space_id")
@@ -714,7 +728,7 @@ func normalizeUIDs(in []string) []string {
 
 // updateMemberRole 修改成员角色；role=2 时自动把当前 owner 降级为 admin。
 func (m *Manager) updateMemberRole(c *wkhttp.Context) {
-	if !m.requireAdmin(c) {
+	if !m.requireSuperAdmin(c) {
 		return
 	}
 	spaceId := c.Param("space_id")

--- a/modules/space/api_manager_test.go
+++ b/modules/space/api_manager_test.go
@@ -19,12 +19,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// adminToken 在 token 缓存中注入一个带 admin 角色的 token，供管理接口测试使用。
+// adminToken 在 token 缓存中注入一个带 admin 角色的 token，供只读 / 低风险管理
+// 接口测试使用。高危/不可逆操作（强制解散、封禁、移除成员、改角色）已收敛到
+// superAdmin，对应测试请用 superAdminToken。
 func adminToken(t *testing.T) string {
 	t.Helper()
 	token := "space-mgr-admin-token"
 	cfg := testCtx.GetConfig()
 	err := testCtx.Cache().Set(cfg.Cache.TokenCachePrefix+token, testutil.UID+"@admin@"+string(wkhttp.Admin))
+	assert.NoError(t, err)
+	return token
+}
+
+// superAdminToken 注入一个带 superAdmin 角色的 token，供仅限超级管理员的高危
+// 管理接口测试使用。
+func superAdminToken(t *testing.T) string {
+	t.Helper()
+	token := "space-mgr-superadmin-token"
+	cfg := testCtx.GetConfig()
+	err := testCtx.Cache().Set(cfg.Cache.TokenCachePrefix+token, testutil.UID+"@superadmin@"+string(wkhttp.SuperAdmin))
 	assert.NoError(t, err)
 	return token
 }
@@ -172,7 +185,7 @@ func TestManager_SpaceDetail(t *testing.T) {
 func TestManager_ForceDisband(t *testing.T) {
 	s, _, err := setup(t)
 	assert.NoError(t, err)
-	token := adminToken(t)
+	token := superAdminToken(t)
 
 	seedSpace(t, "mgr-force", "about to die", "u-owner", 1)
 	err = testSpaceDB.insertMemberNoTx(&MemberModel{
@@ -324,7 +337,7 @@ func TestManager_Members_KeywordSearch(t *testing.T) {
 func TestManager_LiftBan(t *testing.T) {
 	s, _, err := setup(t)
 	assert.NoError(t, err)
-	token := adminToken(t)
+	token := superAdminToken(t)
 
 	seedSpace(t, "mgr-ban-target", "to be banned", "u-owner", SpaceStatusNormal)
 
@@ -426,7 +439,7 @@ func TestManager_AddMembers(t *testing.T) {
 func TestManager_RemoveMembers(t *testing.T) {
 	s, _, err := setup(t)
 	assert.NoError(t, err)
-	token := adminToken(t)
+	token := superAdminToken(t)
 
 	seedSpace(t, "mgr-rm", "remove members", "u-owner", SpaceStatusNormal)
 	for _, uid := range []string{"rm-1", "rm-2", "rm-3"} {
@@ -468,7 +481,7 @@ func TestManager_RemoveMembers(t *testing.T) {
 func TestManager_UpdateMemberRole(t *testing.T) {
 	s, _, err := setup(t)
 	assert.NoError(t, err)
-	token := adminToken(t)
+	token := superAdminToken(t)
 
 	seedSpace(t, "mgr-role", "role ops", "u-owner", SpaceStatusNormal)
 	err = testSpaceDB.insertMemberNoTx(&MemberModel{
@@ -1003,6 +1016,39 @@ func TestManager_AuthBoundary(t *testing.T) {
 	})
 }
 
+// TestManager_DestructiveOpsRequireSuperAdmin 固化 issue #363 item 2 的边界：
+// 强制解散 / 封禁 / 移除成员 / 改成员角色这些跨空间高危操作只放行 superAdmin，
+// 普通 admin（只读运营位）一律 403。superAdmin 放行路径由各操作的成功用例覆盖。
+func TestManager_DestructiveOpsRequireSuperAdmin(t *testing.T) {
+	s, _, err := setup(t)
+	assert.NoError(t, err)
+	token := adminToken(t) // 仅 admin，非 superAdmin
+
+	seedSpace(t, "mgr-su-guard", "guard", "u-owner", SpaceStatusNormal)
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{"forceDisband", "DELETE", "/v1/manager/spaces/mgr-su-guard", ""},
+		{"ban", "PUT", "/v1/manager/spaces/mgr-su-guard/status/2", ""},
+		{"removeMembers", "DELETE", "/v1/manager/spaces/mgr-su-guard/members", `{"uids":["u-owner"]}`},
+		{"updateMemberRole", "PUT", "/v1/manager/spaces/mgr-su-guard/members/u-owner/role", `{"role":1}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(tc.method, tc.path, strings.NewReader(tc.body))
+			req.Header.Set("token", token)
+			s.GetRoute().ServeHTTP(w, req)
+			// admin 被拒：通用 403，不泄露"需要更高角色"的具体原因（反枚举）。
+			assertSpaceErrorCode(t, w, "err.shared.auth.forbidden")
+		})
+	}
+}
+
 func TestManager_DisableListIncludesBanned(t *testing.T) {
 	s, _, err := setup(t)
 	assert.NoError(t, err)
@@ -1104,7 +1150,7 @@ func TestManager_LiftBanRefreshesCache(t *testing.T) {
 	// 验证 liftBan 成功后会异步调用 loadKnownSpaceIDs 刷新 pkg/space 缓存
 	s, _, err := setup(t)
 	assert.NoError(t, err)
-	token := adminToken(t)
+	token := superAdminToken(t)
 
 	seedSpace(t, "mgr-ban-cache", "cache", "u-owner-c", SpaceStatusBanned)
 
@@ -1140,7 +1186,7 @@ func TestManager_AddMembersOnDisbandedSpace(t *testing.T) {
 func TestManager_RemoveMembersOnNonExistentSpace(t *testing.T) {
 	s, _, err := setup(t)
 	assert.NoError(t, err)
-	token := adminToken(t)
+	token := superAdminToken(t)
 
 	body := util.ToJson(map[string]interface{}{"uids": []string{"any"}})
 	w := httptest.NewRecorder()
@@ -1708,7 +1754,7 @@ func TestManager_UpdateSpaceProfile_Validation(t *testing.T) {
 func TestManager_UpdateMemberRoleIdempotent(t *testing.T) {
 	s, _, err := setup(t)
 	assert.NoError(t, err)
-	token := adminToken(t)
+	token := superAdminToken(t)
 
 	seedSpace(t, "mgr-role-idem", "role idem", "u-owner", SpaceStatusNormal)
 	err = testSpaceDB.insertMemberNoTx(&MemberModel{

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/cache"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	common2 "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
@@ -330,43 +331,72 @@ func (m *Manager) deleteAdminUsers(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
-	// 撤销该管理员在所有设备端（APP/Web/PC）的登录态，而不只是 Web —— 否则一个
-	// 仍存活的非 Web token 在 RoleCacheTTL 窗口内仍可能按旧角色放行。
+	// 先失效角色热缓存，再撤销 token。DB 里该 uid 已删（权威源 role 已为空），所以
+	// 只要这里清掉 user_role:{uid} 热缓存，即便下面的 token 撤销失败、某个 token 残
+	// 留，下一请求经 RoleResolver 也会从 DB 解析出"无系统角色"而被拒。顺序反过来
+	// （先撤 token，失败就 return）会跳过 Invalidate，让旧 role 缓存存活到 TTL，
+	// 与残留 token 叠加成提权窗口——正是本 PR 要消除的（PR #364 review）。
+	m.roleService.Invalidate(user.UID)
+	// 撤销该管理员在所有设备端（APP/Web/PC）的登录态，而不只是 Web。尽力删除每个端
+	// （不在首个错误就中断），最大化吊销面；任一失败仍向调用方报错以便排查。
 	if err := m.revokeAllDeviceTokens(user.UID); err != nil {
 		m.Error("清除管理员token数据错误", zap.Error(err), zap.String("uid", user.UID))
 		respondUserError(c, errcode.ErrUserTokenCacheFailed)
 		return
 	}
-	// 立即失效角色热缓存：即便上面漏删了某个 token，下一请求经 RoleResolver 也会
-	// 从 DB（该 uid 已删，role 为空）解析出"无系统角色"，把降权窗口收敛到一次往返
-	// 而非等 RoleCacheTTL 自愈。
-	m.roleService.Invalidate(user.UID)
 	c.ResponseOK()
 }
 
-// revokeAllDeviceTokens 清除某 uid 在所有设备端（APP/Web/PC）的登录态：既删
-// token:{token} 让旧 token 立即失效，也删 UIDToken:{flag}{uid} 反查映射，避免
-// 残留。任一删除失败即返回错误，调用方据此报错（不静默吞，以免"以为已吊销实则
-// 残留"）。
-func (m *Manager) revokeAllDeviceTokens(uid string) error {
-	cacheCfg := m.ctx.GetConfig().Cache
+// deviceTokenRevokeFailure pairs a device flag with the error from trying to
+// revoke its session, so the caller can log per-device outcomes.
+type deviceTokenRevokeFailure struct {
+	flag config.DeviceFlag
+	err  error
+}
+
+// revokeDeviceTokensInCache is the cache-only, injectable core of
+// revokeAllDeviceTokens (factored out so it can be unit-tested with a fake
+// cache). It removes uid's token payload + UIDToken reverse mapping for every
+// device flag. best-effort: it does NOT abort on the first error — it attempts
+// every flag and returns one failure entry per error, so a Redis hiccup on one
+// device cannot strand the others.
+func revokeDeviceTokensInCache(c cache.Cache, uidTokenPrefix, tokenPrefix, uid string) []deviceTokenRevokeFailure {
+	var failures []deviceTokenRevokeFailure
 	for _, flag := range []config.DeviceFlag{config.APP, config.Web, config.PC} {
-		uidKey := fmt.Sprintf("%s%d%s", cacheCfg.UIDTokenCachePrefix, flag, uid)
-		token, err := m.ctx.Cache().Get(uidKey)
+		uidKey := fmt.Sprintf("%s%d%s", uidTokenPrefix, flag, uid)
+		token, err := c.Get(uidKey)
 		if err != nil {
-			return err
+			failures = append(failures, deviceTokenRevokeFailure{flag, err})
+			continue
 		}
 		if token == "" {
 			continue
 		}
-		if err := m.ctx.Cache().Delete(cacheCfg.TokenCachePrefix + token); err != nil {
-			return err
+		if err := c.Delete(tokenPrefix + token); err != nil {
+			failures = append(failures, deviceTokenRevokeFailure{flag, err})
+			continue
 		}
-		if err := m.ctx.Cache().Delete(uidKey); err != nil {
-			return err
+		if err := c.Delete(uidKey); err != nil {
+			failures = append(failures, deviceTokenRevokeFailure{flag, err})
 		}
 	}
-	return nil
+	return failures
+}
+
+// revokeAllDeviceTokens 清除某 uid 在所有设备端（APP/Web/PC）的登录态：既删
+// token:{token} 让旧 token 立即失效，也删 UIDToken:{flag}{uid} 反查映射。
+// best-effort（见 revokeDeviceTokensInCache），逐端记日志，返回首个错误供调用方报错。
+func (m *Manager) revokeAllDeviceTokens(uid string) error {
+	cacheCfg := m.ctx.GetConfig().Cache
+	failures := revokeDeviceTokensInCache(m.ctx.Cache(), cacheCfg.UIDTokenCachePrefix, cacheCfg.TokenCachePrefix, uid)
+	var firstErr error
+	for _, f := range failures {
+		m.Error("撤销设备token失败", zap.Error(f.err), zap.String("uid", uid), zap.Uint8("device_flag", f.flag.Uint8()))
+		if firstErr == nil {
+			firstErr = f.err
+		}
+	}
+	return firstErr
 }
 
 // 查询管理员列表

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -36,6 +36,7 @@ type Manager struct {
 	friendDB      *friendDB
 	onlineService IOnlineService
 	commonService common2.IService
+	roleService   *RoleService
 }
 
 // NewManager NewManager
@@ -50,6 +51,7 @@ func NewManager(ctx *config.Context) *Manager {
 		userSettingDB: NewSettingDB(ctx.DB()),
 		onlineService: NewOnlineService(ctx),
 		commonService: common2.NewService(ctx),
+		roleService:   NewRoleService(NewDB(ctx), ctx.Cache()),
 	}
 	m.createManagerAccount()
 	return m
@@ -328,21 +330,43 @@ func (m *Manager) deleteAdminUsers(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
-	oldToken, err := m.ctx.Cache().Get(fmt.Sprintf("%s%d%s", m.ctx.GetConfig().Cache.UIDTokenCachePrefix, config.Web, user.UID))
-	if err != nil {
-		m.Error("获取旧token错误", zap.Error(err))
+	// 撤销该管理员在所有设备端（APP/Web/PC）的登录态，而不只是 Web —— 否则一个
+	// 仍存活的非 Web token 在 RoleCacheTTL 窗口内仍可能按旧角色放行。
+	if err := m.revokeAllDeviceTokens(user.UID); err != nil {
+		m.Error("清除管理员token数据错误", zap.Error(err), zap.String("uid", user.UID))
 		respondUserError(c, errcode.ErrUserTokenCacheFailed)
 		return
 	}
-	if oldToken != "" {
-		err = m.ctx.Cache().Delete(m.ctx.GetConfig().Cache.TokenCachePrefix + oldToken)
+	// 立即失效角色热缓存：即便上面漏删了某个 token，下一请求经 RoleResolver 也会
+	// 从 DB（该 uid 已删，role 为空）解析出"无系统角色"，把降权窗口收敛到一次往返
+	// 而非等 RoleCacheTTL 自愈。
+	m.roleService.Invalidate(user.UID)
+	c.ResponseOK()
+}
+
+// revokeAllDeviceTokens 清除某 uid 在所有设备端（APP/Web/PC）的登录态：既删
+// token:{token} 让旧 token 立即失效，也删 UIDToken:{flag}{uid} 反查映射，避免
+// 残留。任一删除失败即返回错误，调用方据此报错（不静默吞，以免"以为已吊销实则
+// 残留"）。
+func (m *Manager) revokeAllDeviceTokens(uid string) error {
+	cacheCfg := m.ctx.GetConfig().Cache
+	for _, flag := range []config.DeviceFlag{config.APP, config.Web, config.PC} {
+		uidKey := fmt.Sprintf("%s%d%s", cacheCfg.UIDTokenCachePrefix, flag, uid)
+		token, err := m.ctx.Cache().Get(uidKey)
 		if err != nil {
-			m.Error("清除旧token数据错误", zap.Error(err))
-			respondUserError(c, errcode.ErrUserTokenCacheFailed)
-			return
+			return err
+		}
+		if token == "" {
+			continue
+		}
+		if err := m.ctx.Cache().Delete(cacheCfg.TokenCachePrefix + token); err != nil {
+			return err
+		}
+		if err := m.ctx.Cache().Delete(uidKey); err != nil {
+			return err
 		}
 	}
-	c.ResponseOK()
+	return nil
 }
 
 // 查询管理员列表

--- a/modules/user/api_manager_test.go
+++ b/modules/user/api_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -748,5 +749,30 @@ func TestManager_DeleteAdminUser_RevokesSessionsAndRoleCache(t *testing.T) {
 		uidMap, err := ctx.Cache().Get(fmt.Sprintf("%s%d%s", cacheCfg.UIDTokenCachePrefix, flag, adminUID))
 		assert.NoError(t, err)
 		assert.Empty(t, uidMap, "UIDToken mapping (flag %d) must be cleared", flag)
+	}
+}
+
+// TestRevokeDeviceTokensInCache_BestEffort pins that a Redis error on one device
+// flag does not abort revocation of the others (PR #364 review F2): the loop
+// attempts all three flags and reports a failure per error rather than bailing
+// on the first. Uses the shared fakeLangCache (implements cache.Cache).
+func TestRevokeDeviceTokensInCache_BestEffort(t *testing.T) {
+	c := newFakeLangCache()
+	const uidTokenPrefix, tokenPrefix, uid = "UIDTOKEN:", "TOKEN:", "u1"
+	for _, fl := range []config.DeviceFlag{config.APP, config.Web, config.PC} {
+		tok := fmt.Sprintf("tok-%d", fl)
+		c.store[fmt.Sprintf("%s%d%s", uidTokenPrefix, fl, uid)] = tok
+		c.store[tokenPrefix+tok] = uid + "@x@admin"
+	}
+	// Every Delete fails: a fail-fast loop would stop after flag 0; best-effort
+	// must still attempt all three.
+	c.delErr = errors.New("redis down")
+
+	failures := revokeDeviceTokensInCache(c, uidTokenPrefix, tokenPrefix, uid)
+	if len(failures) != 3 {
+		t.Fatalf("best-effort revoke must attempt all 3 device flags despite errors, got %d failures", len(failures))
+	}
+	if len(c.deletes) < 3 {
+		t.Fatalf("expected a Delete attempt per device flag, got %d", len(c.deletes))
 	}
 }

--- a/modules/user/api_manager_test.go
+++ b/modules/user/api_manager_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
@@ -684,4 +685,68 @@ func TestDeleteAdminUser(t *testing.T) {
 	s.GetRoute().ServeHTTP(w, req)
 	// assert.Equal(t, http.StatusOK, w.Code)
 	panic(w.Body)
+}
+
+// TestManager_DeleteAdminUser_RevokesSessionsAndRoleCache pins the issue #363
+// fast-follow: deleting an admin must invalidate the user_role:{uid} hot cache
+// AND revoke that admin's tokens on every device flag (not just Web), so the
+// removal takes effect on the next request instead of waiting out RoleCacheTTL.
+func TestManager_DeleteAdminUser_RevokesSessionsAndRoleCache(t *testing.T) {
+	// testutil.NewTestServer already registers every module's routes via
+	// module.Setup, so the DELETE handler is live — don't call m.Route (double
+	// registration panics). NewDB(ctx) is only for seeding rows; the request is
+	// served by the module.Setup-constructed Manager, whose roleService shares
+	// the same Redis namespace as our assertions.
+	s, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+	assert.NoError(t, testutil.CleanAllTables(ctx))
+
+	userDB := NewDB(ctx)
+	cacheCfg := ctx.GetConfig().Cache
+
+	// caller must be superAdmin (deleteAdminUsers requires it)
+	callerTok := "user-mgr-superadmin-caller"
+	assert.NoError(t, ctx.Cache().Set(cacheCfg.TokenCachePrefix+callerTok, "root-uid@root@"+string(wkhttp.SuperAdmin)))
+
+	// victim admin with live sessions on every device flag + a hot role cache
+	adminUID := "admin-victim-uid"
+	assert.NoError(t, userDB.Insert(&Model{
+		UID:      adminUID,
+		Name:     "管理员X",
+		Role:     string(wkhttp.Admin),
+		Username: "admin-victim",
+	}))
+	deviceTokens := map[config.DeviceFlag]string{
+		config.APP: "victim-tok-app",
+		config.Web: "victim-tok-web",
+		config.PC:  "victim-tok-pc",
+	}
+	for flag, tok := range deviceTokens {
+		assert.NoError(t, ctx.Cache().Set(fmt.Sprintf("%s%d%s", cacheCfg.UIDTokenCachePrefix, flag, adminUID), tok))
+		assert.NoError(t, ctx.Cache().Set(cacheCfg.TokenCachePrefix+tok, adminUID+"@管理员X@"+string(wkhttp.Admin)))
+	}
+	assert.NoError(t, ctx.Cache().Set(RoleCacheKeyPrefix+adminUID, string(wkhttp.Admin)))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/v1/manager/user/admin?uid="+adminUID, nil)
+	req.Header.Set("token", callerTok)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// role hot cache invalidated
+	roleCached, err := ctx.Cache().Get(RoleCacheKeyPrefix + adminUID)
+	assert.NoError(t, err)
+	assert.Empty(t, roleCached, "user_role hot cache must be invalidated after deletion")
+
+	// every device session revoked: both the token:{token} payload and the
+	// UIDToken:{flag}{uid} reverse mapping
+	for flag, tok := range deviceTokens {
+		payload, err := ctx.Cache().Get(cacheCfg.TokenCachePrefix + tok)
+		assert.NoError(t, err)
+		assert.Empty(t, payload, "device token payload (flag %d) must be revoked", flag)
+
+		uidMap, err := ctx.Cache().Get(fmt.Sprintf("%s%d%s", cacheCfg.UIDTokenCachePrefix, flag, adminUID))
+		assert.NoError(t, err)
+		assert.Empty(t, uidMap, "UIDToken mapping (flag %d) must be cleared", flag)
+	}
 }

--- a/modules/user/db.go
+++ b/modules/user/db.go
@@ -129,6 +129,17 @@ func (d *DB) UpdateLanguageByUID(uid, language string) error {
 	return err
 }
 
+// QueryRoleByUID returns the user's system role column only ("superAdmin" /
+// "admin" / "" for a normal user). Used by RoleService as the authoritative
+// source behind the per-request role resolver — only SELECTs the single
+// column to keep the auth hot path light, mirroring QueryLanguageByUID.
+// (uid 不存在时返回 ("", nil)，语义即"无系统角色"。)
+func (d *DB) QueryRoleByUID(uid string) (string, error) {
+	var role string
+	_, err := d.session.Select("role").From("user").Where("uid=?", uid).Load(&role)
+	return role, err
+}
+
 // QueryByVercode 通过用户vercode查询用户信息
 func (d *DB) QueryByVercode(vercode string) (*Model, error) {
 	var model *Model

--- a/modules/user/role_service.go
+++ b/modules/user/role_service.go
@@ -25,6 +25,12 @@ const RoleCacheTTL = 60 * time.Second
 // cache miss ("" → query DB) from a confirmed "no role" (negative hit → skip
 // DB), so the hot path does not hammer MySQL for every normal-user request.
 // A bare '-' is unambiguous because it is not a valid role string.
+//
+// IMPORTANT for future authors: any code path that MUTATES user.role on an
+// *existing* uid (today only addAdminUser, which writes role on a brand-new
+// uid, and deleteAdminUsers, which calls Invalidate) MUST call Invalidate(uid)
+// afterwards. Otherwise a cached negative marker (or a stale positive role)
+// suppresses the change for up to RoleCacheTTL.
 const roleNegativeMarker = "-"
 
 // roleReader is the read surface RoleService needs from the user DB layer,

--- a/modules/user/role_service.go
+++ b/modules/user/role_service.go
@@ -1,0 +1,115 @@
+package user
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/cache"
+)
+
+// RoleCacheKeyPrefix is the Redis key prefix for the `user_role:{uid}` hot
+// cache. Exported so ops scripts / role-mutation sites can invalidate the key
+// without duplicating the literal.
+const RoleCacheKeyPrefix = "user_role:"
+
+// RoleCacheTTL bounds how long a stale system role can survive after a
+// privilege change. The token used to bake the role in for its full lifetime
+// (days); resolving per request against this cache caps that staleness to the
+// TTL while keeping the auth hot path off MySQL for the common case. Kept
+// deliberately short because this gates admin / superAdmin access.
+const RoleCacheTTL = 60 * time.Second
+
+// roleNegativeMarker is the sentinel stored when the DB role is empty (a
+// normal user — the overwhelming majority). It lets Resolve distinguish a
+// cache miss ("" → query DB) from a confirmed "no role" (negative hit → skip
+// DB), so the hot path does not hammer MySQL for every normal-user request.
+// A bare '-' is unambiguous because it is not a valid role string.
+const roleNegativeMarker = "-"
+
+// roleReader is the read surface RoleService needs from the user DB layer,
+// defined consumer-side so tests can stub it without dbr. *DB satisfies it.
+type roleReader interface {
+	QueryRoleByUID(uid string) (string, error)
+}
+
+// RoleService resolves the authoritative system role for a user. It satisfies
+// pkg/auth.RoleResolver, consumed by CacheTokenParser so that a role baked
+// into a token at login no longer outlives a demotion until token expiry.
+//
+// Lookup order: Redis `user_role:{uid}` → DB `user.role` → "". DB results are
+// written back to Redis (empty stored as a negative marker) so subsequent
+// requests for normal users don't touch MySQL. The TTL alone bounds staleness;
+// callers that demote/remove an admin should additionally invalidate the hot
+// key (Invalidate) for immediate effect.
+type RoleService struct {
+	db    roleReader
+	cache cache.Cache
+	ttl   time.Duration
+}
+
+// NewRoleService constructs a RoleService with the canonical TTL. cache and db
+// must be non-nil; nil is a programmer error and panics on construction rather
+// than silently degrading at request time.
+func NewRoleService(db roleReader, c cache.Cache) *RoleService {
+	if db == nil {
+		panic("user: NewRoleService requires non-nil db reader")
+	}
+	if c == nil {
+		panic("user: NewRoleService requires non-nil cache")
+	}
+	return &RoleService{db: db, cache: c, ttl: RoleCacheTTL}
+}
+
+// ResolveRole returns the user's current system role, or "" if none.
+// Errors are surfaced to the caller; pkg/auth.CacheTokenParser keeps the token
+// snapshot on resolver error so a cache/DB outage does not fail authentication.
+func (s *RoleService) ResolveRole(ctx context.Context, uid string) (string, error) {
+	if uid == "" {
+		return "", nil
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	key := RoleCacheKeyPrefix + uid
+	cached, cacheErr := s.cache.Get(key)
+	if cacheErr == nil {
+		switch cached {
+		case "":
+			// cache miss → fall through to DB
+		case roleNegativeMarker:
+			return "", nil
+		default:
+			return cached, nil
+		}
+	}
+
+	role, dbErr := s.db.QueryRoleByUID(uid)
+	if dbErr != nil {
+		return "", fmt.Errorf("user: read role from db: %w", dbErr)
+	}
+	s.writeCache(key, role)
+	return role, nil
+}
+
+// Invalidate drops the hot-cache entry for a user so the next request re-reads
+// the role from DB. Call after any mutation of user.role (e.g. removing an
+// admin) to make the change take effect within one round-trip instead of
+// waiting out RoleCacheTTL. Best-effort: a Redis error degrades to TTL-bounded
+// staleness, not a failure.
+func (s *RoleService) Invalidate(uid string) {
+	if uid == "" {
+		return
+	}
+	_ = s.cache.Delete(RoleCacheKeyPrefix + uid)
+}
+
+func (s *RoleService) writeCache(key, role string) {
+	value := role
+	if value == "" {
+		value = roleNegativeMarker
+	}
+	// Best-effort write — a Redis outage degrades to "no cache", not a
+	// request failure.
+	_ = s.cache.SetAndExpire(key, value, s.ttl)
+}

--- a/modules/user/role_service_test.go
+++ b/modules/user/role_service_test.go
@@ -97,6 +97,29 @@ func TestRoleServiceResolveCacheMissEmptyPopulatesNegativeMarker(t *testing.T) {
 	}
 }
 
+// TestRoleServiceResolveCacheErrorFallsThroughToDB pins the security-sensitive
+// degradation branch: a Redis Get error must NOT be treated as "no role" — it
+// falls through to the authoritative DB read so a momentary cache outage can't
+// silently strip (or grant) privileges.
+func TestRoleServiceResolveCacheErrorFallsThroughToDB(t *testing.T) {
+	c := newFakeLangCache()
+	c.getErr = errors.New("redis down")
+	db := newFakeRoleDB()
+	db.role["u1"] = "superAdmin"
+	svc := NewRoleService(db, c)
+
+	got, err := svc.ResolveRole(context.Background(), "u1")
+	if err != nil {
+		t.Fatalf("ResolveRole: %v", err)
+	}
+	if got != "superAdmin" {
+		t.Fatalf("role = %q, want superAdmin (cache error must fall through to DB truth)", got)
+	}
+	if db.queryCalls != 1 {
+		t.Fatalf("expected exactly 1 DB query on cache error, got %d", db.queryCalls)
+	}
+}
+
 func TestRoleServiceResolvePropagatesDBError(t *testing.T) {
 	c := newFakeLangCache()
 	db := newFakeRoleDB()

--- a/modules/user/role_service_test.go
+++ b/modules/user/role_service_test.go
@@ -1,0 +1,158 @@
+package user
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// fakeRoleDB stubs the read surface so RoleService can be exercised without a
+// real *DB.
+type fakeRoleDB struct {
+	role       map[string]string
+	queryErr   error
+	queryCalls int
+}
+
+func newFakeRoleDB() *fakeRoleDB {
+	return &fakeRoleDB{role: map[string]string{}}
+}
+
+func (d *fakeRoleDB) QueryRoleByUID(uid string) (string, error) {
+	d.queryCalls++
+	if d.queryErr != nil {
+		return "", d.queryErr
+	}
+	return d.role[uid], nil
+}
+
+func TestRoleServiceResolveCacheHit(t *testing.T) {
+	c := newFakeLangCache()
+	c.store[RoleCacheKeyPrefix+"u1"] = "admin"
+	db := newFakeRoleDB()
+	svc := NewRoleService(db, c)
+
+	got, err := svc.ResolveRole(context.Background(), "u1")
+	if err != nil {
+		t.Fatalf("ResolveRole: %v", err)
+	}
+	if got != "admin" {
+		t.Fatalf("role = %q, want admin", got)
+	}
+	if db.queryCalls != 0 {
+		t.Fatalf("cache hit must not touch DB, queryCalls=%d", db.queryCalls)
+	}
+}
+
+func TestRoleServiceResolveNegativeCacheSkipsDB(t *testing.T) {
+	c := newFakeLangCache()
+	c.store[RoleCacheKeyPrefix+"u1"] = roleNegativeMarker
+	db := newFakeRoleDB()
+	svc := NewRoleService(db, c)
+
+	got, err := svc.ResolveRole(context.Background(), "u1")
+	if err != nil {
+		t.Fatalf("ResolveRole: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("role = %q, want \"\" (negative cache)", got)
+	}
+	if db.queryCalls != 0 {
+		t.Fatalf("negative cache hit must not touch DB, queryCalls=%d", db.queryCalls)
+	}
+}
+
+func TestRoleServiceResolveCacheMissPopulatesCache(t *testing.T) {
+	c := newFakeLangCache()
+	db := newFakeRoleDB()
+	db.role["u1"] = "superAdmin"
+	svc := NewRoleService(db, c)
+
+	got, err := svc.ResolveRole(context.Background(), "u1")
+	if err != nil {
+		t.Fatalf("ResolveRole: %v", err)
+	}
+	if got != "superAdmin" {
+		t.Fatalf("role = %q, want superAdmin", got)
+	}
+	if c.store[RoleCacheKeyPrefix+"u1"] != "superAdmin" {
+		t.Fatalf("cache not populated with DB value, got %q", c.store[RoleCacheKeyPrefix+"u1"])
+	}
+}
+
+func TestRoleServiceResolveCacheMissEmptyPopulatesNegativeMarker(t *testing.T) {
+	c := newFakeLangCache()
+	db := newFakeRoleDB() // u1 has no role → normal user
+	svc := NewRoleService(db, c)
+
+	got, err := svc.ResolveRole(context.Background(), "u1")
+	if err != nil {
+		t.Fatalf("ResolveRole: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("role = %q, want \"\"", got)
+	}
+	if c.store[RoleCacheKeyPrefix+"u1"] != roleNegativeMarker {
+		t.Fatalf("empty DB role must cache negative marker, got %q", c.store[RoleCacheKeyPrefix+"u1"])
+	}
+}
+
+func TestRoleServiceResolvePropagatesDBError(t *testing.T) {
+	c := newFakeLangCache()
+	db := newFakeRoleDB()
+	db.queryErr = errors.New("db down")
+	svc := NewRoleService(db, c)
+
+	_, err := svc.ResolveRole(context.Background(), "u1")
+	if err == nil {
+		t.Fatalf("expected DB error to propagate (parser keeps token snapshot on error)")
+	}
+}
+
+func TestRoleServiceResolveEmptyUID(t *testing.T) {
+	svc := NewRoleService(newFakeRoleDB(), newFakeLangCache())
+	got, err := svc.ResolveRole(context.Background(), "")
+	if err != nil || got != "" {
+		t.Fatalf("empty uid => (\"\", nil), got (%q, %v)", got, err)
+	}
+}
+
+func TestRoleServiceResolveContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	svc := NewRoleService(newFakeRoleDB(), newFakeLangCache())
+	if _, err := svc.ResolveRole(ctx, "u1"); err == nil {
+		t.Fatalf("cancelled context must surface an error")
+	}
+}
+
+func TestRoleServiceInvalidateDeletesHotKey(t *testing.T) {
+	c := newFakeLangCache()
+	c.store[RoleCacheKeyPrefix+"u1"] = "admin"
+	svc := NewRoleService(newFakeRoleDB(), c)
+
+	svc.Invalidate("u1")
+	if _, ok := c.store[RoleCacheKeyPrefix+"u1"]; ok {
+		t.Fatalf("Invalidate must delete the hot key")
+	}
+}
+
+func TestNewRoleServicePanicsOnNilDeps(t *testing.T) {
+	cases := []struct {
+		name string
+		fn   func()
+	}{
+		{"nil_db", func() { _ = NewRoleService(nil, newFakeLangCache()) }},
+		{"nil_cache", func() { _ = NewRoleService(newFakeRoleDB(), nil) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatalf("expected panic on %s", tc.name)
+				}
+			}()
+			tc.fn()
+		})
+	}
+}

--- a/pkg/auth/parser.go
+++ b/pkg/auth/parser.go
@@ -19,6 +19,20 @@ type LanguageResolver interface {
 	Resolve(ctx context.Context, uid string) (string, error)
 }
 
+// RoleResolver hydrates UserInfo.Role with the user's *current* system role
+// (Redis cache → DB → "") instead of the value snapshotted into the token at
+// issuance. Without it, a system role baked into the token at login keeps
+// granting admin / superAdmin access until the token expires — a demotion or
+// admin-account removal cannot be honoured promptly. Resolving per request
+// bounds that staleness to the resolver's cache TTL.
+//
+// Like LanguageResolver it is shaped at the consumer side so pkg/auth stays
+// free of DB / Redis imports; the concrete implementation lives in
+// modules/user (RoleService).
+type RoleResolver interface {
+	ResolveRole(ctx context.Context, uid string) (string, error)
+}
+
 // CacheTokenParser implements octo-lib's wkhttp.TokenParser using the shared
 // pkg/auth codec. It supersedes octo-lib's legacyTokenParser so that octo-server
 // can write v2 JSON envelopes while still decoding any legacy uid@name[@role]
@@ -34,9 +48,10 @@ type LanguageResolver interface {
 // Construct once at boot and register with WKHttp.SetTokenParser; the parser
 // is safe for concurrent use as long as the underlying cache + resolver are.
 type CacheTokenParser struct {
-	Cache    cache.Cache
-	Prefix   string
-	resolver LanguageResolver
+	Cache        cache.Cache
+	Prefix       string
+	resolver     LanguageResolver
+	roleResolver RoleResolver
 }
 
 // ParserOption configures optional CacheTokenParser behaviour.
@@ -49,6 +64,18 @@ func WithLanguageResolver(r LanguageResolver) ParserOption {
 	return func(p *CacheTokenParser) {
 		if r != nil {
 			p.resolver = r
+		}
+	}
+}
+
+// WithRoleResolver wires a RoleResolver into the parser; nil resolver is a
+// no-op so callers (and tests) can pass an interface value that may be unset
+// without an extra guard. When unset, Parse falls back to the role snapshot
+// decoded from the token — i.e. legacy behaviour.
+func WithRoleResolver(r RoleResolver) ParserOption {
+	return func(p *CacheTokenParser) {
+		if r != nil {
+			p.roleResolver = r
 		}
 	}
 }
@@ -109,10 +136,29 @@ func (p *CacheTokenParser) Parse(ctx context.Context, token string) (wkhttp.User
 			language = resolved
 		}
 	}
+	role := info.Role
+	if p.roleResolver != nil {
+		// Authoritative source for the system role:
+		//   * rerr != nil → keep the token snapshot. Authentication must not
+		//     5xx because the role cache / DB is momentarily unreachable; the
+		//     snapshot is the agreed last-resort fallback (fail-open to the
+		//     token's role, identical degradation philosophy to language).
+		//   * resolved == "" (no error) → the user holds no system role right
+		//     now (normal user, or demoted since the token was minted). Drop
+		//     the snapshot so a token minted while the user was admin stops
+		//     granting admin the moment the DB says otherwise — this is the
+		//     whole point of resolving per request rather than trusting the
+		//     baked-in role.
+		//   * resolved != "" → use the fresh authoritative role.
+		resolved, rerr := p.roleResolver.ResolveRole(ctx, info.UID)
+		if rerr == nil {
+			role = resolved
+		}
+	}
 	return wkhttp.UserInfo{
 		UID:      info.UID,
 		Name:     info.Name,
-		Role:     info.Role,
+		Role:     role,
 		Language: language,
 	}, nil
 }

--- a/pkg/auth/parser_test.go
+++ b/pkg/auth/parser_test.go
@@ -223,3 +223,98 @@ func TestNewCacheTokenParserPanicsOnNilCache(t *testing.T) {
 	}()
 	_ = NewCacheTokenParser(nil, testPrefix)
 }
+
+// stubRoleResolver exercises the RoleResolver hook without pulling modules/user
+// into pkg/auth's test deps.
+type stubRoleResolver struct {
+	role   string
+	err    error
+	gotUID string
+}
+
+func (s *stubRoleResolver) ResolveRole(_ context.Context, uid string) (string, error) {
+	s.gotUID = uid
+	return s.role, s.err
+}
+
+// TestCacheTokenParserRoleResolverOverridesSnapshot pins the core revocation
+// fix: the role returned to AuthMiddleware comes from the resolver (DB truth),
+// not the value baked into the token at issuance.
+func TestCacheTokenParserRoleResolverOverridesSnapshot(t *testing.T) {
+	t.Parallel()
+	c := newFakeCache()
+	// Token was minted while the user was superAdmin...
+	encoded, _ := Encode(TokenInfo{UID: "u1", Name: "alice", Role: "superAdmin"})
+	_ = c.Set(testPrefix+"tok1", encoded)
+
+	// ...but the DB now says plain admin (partial demotion).
+	resolver := &stubRoleResolver{role: "admin"}
+	p := NewCacheTokenParser(c, testPrefix, WithRoleResolver(resolver))
+	got, err := p.Parse(context.Background(), "tok1")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got.Role != "admin" {
+		t.Fatalf("Role = %q, want resolver value admin (token snapshot superAdmin must not win)", got.Role)
+	}
+	if resolver.gotUID != "u1" {
+		t.Fatalf("resolver got uid %q, want u1", resolver.gotUID)
+	}
+}
+
+// TestCacheTokenParserRoleResolverEmptyDropsRole covers full demotion: a token
+// minted while admin must stop granting admin the moment the DB role is empty.
+func TestCacheTokenParserRoleResolverEmptyDropsRole(t *testing.T) {
+	t.Parallel()
+	c := newFakeCache()
+	encoded, _ := Encode(TokenInfo{UID: "u1", Name: "alice", Role: "admin"})
+	_ = c.Set(testPrefix+"tok1", encoded)
+
+	resolver := &stubRoleResolver{role: ""}
+	p := NewCacheTokenParser(c, testPrefix, WithRoleResolver(resolver))
+	got, err := p.Parse(context.Background(), "tok1")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got.Role != "" {
+		t.Fatalf("Role = %q, want \"\" (resolver authoritative empty must drop the baked-in admin role)", got.Role)
+	}
+}
+
+// TestCacheTokenParserRoleResolverFailureKeepsSnapshot pins fail-open: a
+// cache/DB outage must not 5xx auth, so the token's role snapshot is preserved.
+func TestCacheTokenParserRoleResolverFailureKeepsSnapshot(t *testing.T) {
+	t.Parallel()
+	c := newFakeCache()
+	encoded, _ := Encode(TokenInfo{UID: "u1", Name: "alice", Role: "admin"})
+	_ = c.Set(testPrefix+"tok1", encoded)
+
+	resolver := &stubRoleResolver{err: errors.New("redis down")}
+	p := NewCacheTokenParser(c, testPrefix, WithRoleResolver(resolver))
+	got, err := p.Parse(context.Background(), "tok1")
+	if err != nil {
+		t.Fatalf("Parse must not surface resolver failure, got %v", err)
+	}
+	if got.Role != "admin" {
+		t.Fatalf("Role = %q, want snapshot admin (resolver failed)", got.Role)
+	}
+}
+
+func TestWithRoleResolverNilIsNoOp(t *testing.T) {
+	t.Parallel()
+	c := newFakeCache()
+	encoded, _ := Encode(TokenInfo{UID: "u1", Name: "alice", Role: "admin"})
+	_ = c.Set(testPrefix+"tok1", encoded)
+
+	p := NewCacheTokenParser(c, testPrefix, WithRoleResolver(nil))
+	if p.roleResolver != nil {
+		t.Fatal("nil role resolver option must not set the field")
+	}
+	got, err := p.Parse(context.Background(), "tok1")
+	if err != nil {
+		t.Fatalf("Parse should still succeed without a role resolver, got %v", err)
+	}
+	if got.Role != "admin" {
+		t.Fatalf("without a resolver the token snapshot role must pass through, got %q", got.Role)
+	}
+}


### PR DESCRIPTION
## Summary

Hardens system-level role handling on management endpoints. Closes #363.

1. **`POST /v1/common/appversion` → `superAdmin`.** Setting the client download source is a supply-chain-sensitive write and should not be reachable by the read-only `admin` tier. Role gate tightened from `CheckLoginRole()` to `CheckLoginRoleIsSuperAdmin()`; **route path unchanged** so existing callers are not broken.

2. **Destructive cross-space manager ops → `superAdmin`.** `forceDisband` / `liftBan` / `removeMembers` / `updateMemberRole` previously accepted any `admin`, giving the general admin role god-mode over any space. New `requireSuperAdmin` helper gates these four; read / low-risk management endpoints stay at `admin`. Returns the same generic 403 (`ErrSharedForbidden`) — no "needs higher role" leak (anti-enumeration).

3. **Per-request role resolution (revocation).** The system role was baked into the session token at login, so a demotion / admin-removal was not honored until the token expired. Added a `RoleResolver` hook on `CacheTokenParser` (mirroring the existing `LanguageResolver`) that resolves the authoritative role per request (`user_role:{uid}` Redis cache → DB → ""), overriding the token snapshot. Fail-open to the snapshot on resolver error so a cache/DB blip can't 5xx auth. Demotion now converges within the cache TTL (60s) instead of token lifetime — and because items 1 & 2 read this resolved role, those gates become revocation-aware automatically.

> Note: items 1 & 2 are intentional behavior changes — accounts holding only `admin` lose access to these specific operations.

## Changes

- `pkg/auth/parser.go` — `RoleResolver` interface, `WithRoleResolver` option, per-request role resolution in `Parse`.
- `modules/user/role_service.go` (new) — `RoleService` (Redis-cached, negative-marker for normal users).
- `modules/user/db.go` — `QueryRoleByUID` (single-column authoritative read).
- `main.go` — wire `RoleResolver` into the token parser.
- `modules/common/api.go` — `superAdmin` gate on `addAppVersion`.
- `modules/space/api_manager.go` — `requireSuperAdmin` + gate the four destructive handlers.

## Test plan

Validated against the real CI dependency stack (MySQL 8.0 / Redis 7 / WuKongIM v2.2.4-20260313):

- `go build ./...`, `go vet ./...` — pass
- Integration: `modules/space`, `modules/common`, `modules/user`, `pkg/auth` — pass
- New unit tests: parser role-resolver hook (override / empty-drops-role / fail-open / nil no-op); `RoleService` (cache hit / negative cache / DB miss backfill / DB error / invalidate / nil-dep panics)
- New regression: `TestManager_DestructiveOpsRequireSuperAdmin` asserts a plain `admin` is rejected (403) on all four destructive endpoints; the four happy-path manager tests elevated to `superAdmin`
- `make i18n-extract-check`, `make i18n-lint` — pass

https://claude.ai/code/session_01EaxNGwThDUvTqk2T5bPQvZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EaxNGwThDUvTqk2T5bPQvZ)_