### PR TITLE
feat(searchetl): scaffold message-search ETL module + cursor table (YUJ-4530 phase 1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	firebase.google.com/go/v4 v4.13.0
 	github.com/BurntSushi/toml v1.6.0
 	github.com/DATA-DOG/go-sqlmock v1.5.0
-	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260605071834-330ed3ce7e6a
+	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260614033907-f62e626a34db
 	github.com/alibabacloud-go/darabonba-openapi v0.2.1
 	github.com/alibabacloud-go/sms-intl-20180501 v1.0.1
 	github.com/alibabacloud-go/tea v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260605071834-330ed3ce7e6a h1:nC17gAXfODuv8zu0NLj7KfceLGV0dCq94prfhgknZ4g=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260605071834-330ed3ce7e6a/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260614033907-f62e626a34db h1:FudjIbMVhMga/sUsysfzKBI7LTdz0Rgw9EWU2tEJzAo=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260614033907-f62e626a34db/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae h1:DcFpTQBYQ9Ct2d6sC7ol0/ynxc2pO1cpGUM+f4t5adg=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae/go.mod h1:rJJ84PyA/Wlmw1hO+xTzV2wsSUon6J5ktg0g8BF2PuU=
 github.com/RichardKnop/machinery/v2 v2.0.11 h1:BTfLGOmOju3W/OtlZmLX26OjYNZsU4PJo04pQReycdc=

--- a/internal/modules.go
+++ b/internal/modules.go
@@ -46,6 +46,9 @@ import (
 	_ "github.com/Mininglamp-OSS/octo-server/modules/qrcode"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/report"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/search"
+	// searchetl: 消息检索增量 ETL（读 message 分表 → Kafka → es-indexer → OpenSearch，YUJ-4530）。
+	// 阶段 1 仅注册迁移（独立游标表 octo_etl_es_cursor），不启动 scheduler、不接 Kafka。
+	_ "github.com/Mininglamp-OSS/octo-server/modules/searchetl"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/space"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/statistics"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/thread"

--- a/modules/searchetl/1module.go
+++ b/modules/searchetl/1module.go
@@ -1,0 +1,28 @@
+package searchetl
+
+import (
+	"embed"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
+)
+
+//go:embed sql
+var sqlFS embed.FS
+
+// 模块注册（YUJ-4530 阶段 1 骨架）。
+//
+// 阶段 1 只注册迁移（建独立游标表 octo_etl_es_cursor）。**不**启动 scheduler、**不**接 Kafka——
+// producer 的事务拆分 / 单副本互斥 / Kafka 投递在阶段 2/3 落地，届时再在此挂 Start/Stop 钩子。
+// 这样阶段 1 PR 可独立编译/迁移 dry-run，且不在生产引入任何运行期行为变更。
+func init() {
+	register.AddModule(func(ctx interface{}) register.Module {
+		appCtx := ctx.(*config.Context)
+		return register.Module{
+			Name:   "searchetl",
+			SQLDir: register.NewSQLFS(sqlFS),
+			// Service 暴露 ETL，便于后续 ops 端点/测试触达（阶段 1 仅 dry-run 能力）。
+			Service: NewETL(appCtx),
+		}
+	})
+}

--- a/modules/searchetl/config.go
+++ b/modules/searchetl/config.go
@@ -1,0 +1,90 @@
+package searchetl
+
+import (
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"go.uber.org/zap"
+)
+
+// searchetl 消息检索 ETL（YUJ-4530）的运行参数。沿用 opanalytics 的 env 钳制范式。
+//
+// 阶段 1（本骨架）：仅 batch / lag / tick 三参就位，模块空跑游标、不接 Kafka。
+// lag 的稳定性语义与 opanalytics 完全一致（见 envLagSeconds 注释），是防丢消息硬条件 C1。
+const (
+	// envBatch 单次 keyset 分页从 message 分片抽取的行数上限。
+	envBatch     = "OCTO_SEARCHETL_BATCH"
+	defaultBatch = 5000
+	minBatch     = 100
+	maxBatch     = 50000
+
+	// envLagSeconds 抽取稳定性滞后窗口（秒）。message.id 在 INSERT 时分配、COMMIT 时才可见，
+	// 提交顺序≠id 顺序：低 id 的事务可能晚于高 id 提交。若严格按 id>cursor 推进，会漏掉
+	// 「已被游标越过、之后才提交」的低 id 行。对策：只处理 created_at ≤ DB_NOW-lag 的稳定
+	// 前缀，游标只推进到该前缀末尾。要求 lag > 单条消息落库事务的最大时长。
+	//
+	// 🔴 硬条件 C1（STOP）：生产环境 lag 不得为 0、不得删除该过滤。设 0 仅限单实例可控测试。
+	envLagSeconds     = "OCTO_SEARCHETL_LAG_SECONDS"
+	defaultLagSeconds = 600
+	maxLagSeconds     = 86400
+
+	// envTickSeconds 增量 tick 周期（秒）。opanalytics 是每日 cron，searchetl 改分钟级 tick。
+	envTickSeconds     = "OCTO_SEARCHETL_TICK_SECONDS"
+	defaultTickSeconds = 60
+	minTickSeconds     = 5
+	maxTickSeconds     = 3600
+)
+
+// batchSize 返回 keyset 分页大小（钳制到 [min,max]）。
+func batchSize() int {
+	return clampInt(envBatch, defaultBatch, minBatch, maxBatch)
+}
+
+// lagSeconds 返回稳定性滞后窗口秒数（钳制到 [0,max]；0 仅测试用）。
+func lagSeconds() int64 {
+	v := os.Getenv(envLagSeconds)
+	if v == "" {
+		return defaultLagSeconds
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		log.Warn("invalid OCTO_SEARCHETL_LAG_SECONDS, using default",
+			zap.String("value", v), zap.Int64("default", defaultLagSeconds), zap.Error(err))
+		return defaultLagSeconds
+	}
+	if n < 0 {
+		return 0
+	}
+	if n > maxLagSeconds {
+		return maxLagSeconds
+	}
+	return n
+}
+
+// tickInterval 返回增量 tick 周期。
+func tickInterval() time.Duration {
+	return time.Duration(clampInt(envTickSeconds, defaultTickSeconds, minTickSeconds, maxTickSeconds)) * time.Second
+}
+
+// clampInt 读取整型 env 并钳制到 [min,max]；缺省/非法回退 def。
+func clampInt(env string, def, min, max int) int {
+	v := os.Getenv(env)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		log.Warn("invalid searchetl int config, using default",
+			zap.String("env", env), zap.String("value", v), zap.Int("default", def), zap.Error(err))
+		return def
+	}
+	if n < min {
+		return min
+	}
+	if n > max {
+		return max
+	}
+	return n
+}

--- a/modules/searchetl/etl.go
+++ b/modules/searchetl/etl.go
@@ -1,0 +1,83 @@
+package searchetl
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"go.uber.org/zap"
+)
+
+// ETL 是 searchetl 消息检索增量抽取器（YUJ-4530，克隆 opanalytics 游标范式）。
+//
+// 目标架构：读 message 5 分表 → 投 Kafka topic octo.message.v1 → es-indexer 消费 → OpenSearch。
+// 撤回/删除走读时查询侧 join（路线甲），producer 只跑正文一条流。
+//
+// 🚧 阶段 1（本骨架）：只做「空跑游标」——遍历分片、读稳定前缀、记录将会推进到的水位，
+// 但**不接 Kafka、不推进游标**。事务拆分（读事务→事务外投 Kafka→推进事务）+ 单副本重入
+// 互斥 + 整 chunk 原子重投在阶段 2/3 落地（plan §3.5）。稳定性闸门（C1）已在此就位。
+type ETL struct {
+	log.Log
+	ctx   *config.Context
+	db    *etlDB
+	batch int
+	lag   int64
+}
+
+// NewETL 创建 ETL。
+func NewETL(ctx *config.Context) *ETL {
+	return &ETL{
+		Log:   log.NewTLog("SearchETL"),
+		ctx:   ctx,
+		db:    newETLDB(ctx),
+		batch: batchSize(),
+		lag:   lagSeconds(),
+	}
+}
+
+// RunIncrementalDryRun 跑一轮「空跑游标」（阶段 1）：逐分片读稳定前缀、统计稳定行数与积压，
+// **不投 Kafka、不推进游标**。用于骨架自检与上线前观察源读取/稳定性闸门是否符合预期。
+//
+// 阶段 2 将以此为基替换为真实 RunIncremental：读事务取稳定前缀 → 事务外整批投 Kafka 确认 →
+// 短事务推进游标到稳定前缀末（at-least-once + ES _id 幂等 sink = sink 处 effectively-once）。
+func (e *ETL) RunIncrementalDryRun() error {
+	nowUnix, err := e.db.dbNowUnix()
+	if err != nil {
+		return err
+	}
+	cutoff := nowUnix - e.lag
+
+	var totalStable, totalBacklog int64
+	for _, table := range e.db.messageTables() {
+		if err = e.db.ensureCursor(table); err != nil {
+			return err
+		}
+		cursor, lerr := e.db.loadCursor(table)
+		if lerr != nil {
+			return lerr
+		}
+		maxID, merr := e.db.maxID(table)
+		if merr != nil {
+			return merr
+		}
+		rows, rerr := e.db.readBatch(table, cursor, e.batch)
+		if rerr != nil {
+			return rerr
+		}
+		stable := stablePrefix(rows, cutoff)
+		totalStable += int64(len(stable))
+		if maxID > cursor {
+			totalBacklog += maxID - cursor
+		}
+		e.Debug("searchetl dry-run shard scanned",
+			zap.String("table", table),
+			zap.Int64("cursor", cursor),
+			zap.Int64("max_id", maxID),
+			zap.Int("read", len(rows)),
+			zap.Int("stable", len(stable)))
+	}
+
+	e.Info("searchetl incremental dry-run done (no Kafka, no cursor advance)",
+		zap.Int64("stable_rows", totalStable),
+		zap.Int64("backlog_ids", totalBacklog),
+		zap.Int64("lag_seconds", e.lag))
+	return nil
+}

--- a/modules/searchetl/etl_db.go
+++ b/modules/searchetl/etl_db.go
@@ -1,0 +1,80 @@
+package searchetl
+
+import (
+	"fmt"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/gocraft/dbr/v2"
+)
+
+// etlDB 是 searchetl 的数据访问层（读 message 分片 + 独立游标表 octo_etl_es_cursor）。
+//
+// 阶段 1（本骨架）：只读——ensureCursor / readStablePrefix / dbNowUnix。游标推进（advanceCursor）
+// 在阶段 2 接 Kafka、确认投递成功后才调用（事务拆分见 plan §3.5）；阶段 1 空跑不推进。
+type etlDB struct {
+	ctx     *config.Context
+	session *dbr.Session
+}
+
+func newETLDB(ctx *config.Context) *etlDB {
+	return &etlDB{ctx: ctx, session: ctx.DB()}
+}
+
+// messageTables 枚举全部 message 分片表（与 opanalytics/message 模块分片集一致）。
+func (d *etlDB) messageTables() []string {
+	count := d.ctx.GetConfig().TablePartitionConfig.MessageTableCount
+	if count <= 0 {
+		return []string{"message"}
+	}
+	tables := make([]string, 0, count)
+	tables = append(tables, "message")
+	for i := 1; i < count; i++ {
+		tables = append(tables, fmt.Sprintf("message%d", i))
+	}
+	return tables
+}
+
+// ensureCursor 确保分片水位行存在（首次为 0），使后续 FOR UPDATE 总能命中行串行化。
+func (d *etlDB) ensureCursor(table string) error {
+	_, err := d.session.InsertBySql(
+		"INSERT IGNORE INTO octo_etl_es_cursor (shard_table, last_id) VALUES (?, 0)", table).Exec()
+	return err
+}
+
+// dbNowUnix 返回数据库当前时间（纪元秒），作为稳定性闸门统一时基（避免应用/DB 时钟偏差）。
+func (d *etlDB) dbNowUnix() (int64, error) {
+	var now int64
+	err := d.session.SelectBySql("SELECT UNIX_TIMESTAMP()").LoadOne(&now)
+	return now, err
+}
+
+// loadCursor 读取某分片当前水位（只读，不加锁；阶段 1 空跑用）。
+func (d *etlDB) loadCursor(table string) (int64, error) {
+	var cursor int64
+	err := d.session.SelectBySql(
+		"SELECT last_id FROM octo_etl_es_cursor WHERE shard_table=?", table).LoadOne(&cursor)
+	return cursor, err
+}
+
+// maxID 返回某分片当前最大主键 id（用于积压量 max(id)-cursor 监控；阶段 1 空跑用）。
+func (d *etlDB) maxID(table string) (int64, error) {
+	var maxID int64
+	// COALESCE 兜底空表返回 0。
+	err := d.session.SelectBySql(
+		fmt.Sprintf("SELECT COALESCE(MAX(id),0) FROM `%s`", table)).LoadOne(&maxID)
+	return maxID, err
+}
+
+// readBatch 从某分片按 keyset 读一批（id>cursor 升序 LIMIT batch）。
+//
+// 阶段 1：不开事务、不加 FOR UPDATE（仅空跑读取，不推进游标）。源 SELECT 已含 message_id /
+// payload 与稳定性闸门所需 created_unix——阶段 2 接 Kafka 时直接复用同一行结构，无需再改 SQL。
+func (d *etlDB) readBatch(table string, cursor int64, batch int) ([]*srcMessageRow, error) {
+	var rows []*srcMessageRow
+	_, err := d.session.SelectBySql(
+		fmt.Sprintf("SELECT id, message_id, from_uid, channel_id, channel_type, `timestamp`, "+
+			"UNIX_TIMESTAMP(created_at) AS created_unix, payload "+
+			"FROM `%s` WHERE id>? ORDER BY id ASC LIMIT ?", table),
+		cursor, batch).Load(&rows)
+	return rows, err
+}

--- a/modules/searchetl/etl_lock.go
+++ b/modules/searchetl/etl_lock.go
@@ -1,0 +1,94 @@
+package searchetl
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
+)
+
+// etlRunLockKey 是 searchetl 增量抽取的分布式互斥锁 key。与 opanalytics 的
+// `opanalytics:etl:run` 独立——两条 ETL 各跑各的游标，绝不共用一把锁。
+//
+// 🔴 单副本互斥（C3）：plan §3.5 把 opanalytics 的「读游标 + 推进同一 FOR UPDATE 事务」
+// 拆成三段后，FOR UPDATE 行级第二防线消失。须靠本 Redis 锁全程持有 + 续租，且续租失败必须
+// 立即 abort 在飞批次（阶段 3 落地）。阶段 1 骨架先就位锁原语。
+const etlRunLockKey = "searchetl:etl:run"
+
+// etlRunLockTTL 锁租约。执行期间定期续租以覆盖可能超过单 TTL 的长任务（如全量 backfill）；
+// 进程崩溃则 TTL 自动释放。
+const etlRunLockTTL = 30 * time.Minute
+
+// luaReleaseETLLock CAS-DEL：仅当 token 匹配时才释放（规避 lease 边界误删后继 owner 锁）。
+var luaReleaseETLLock = rd.NewScript(`
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+else
+  return 0
+end
+`)
+
+// luaRenewETLLock 仅当 token 匹配当前 owner 时续租，避免误延长后继 owner 的锁。
+var luaRenewETLLock = rd.NewScript(`
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("PEXPIRE", KEYS[1], ARGV[2])
+else
+  return 0
+end
+`)
+
+// etlLock 用 Redis SET NX EX + Lua CAS-DEL/CAS-PEXPIRE 实现的单实例 ETL 互斥锁
+// （仿 opanalytics etlLock）。
+type etlLock struct {
+	client *rd.Client
+}
+
+func newETLLock(ctx *config.Context) *etlLock {
+	client := rd.NewClient(octoredis.MustBuildOptions(ctx.GetConfig(), func(o *rd.Options) {
+		o.MaxRetries = 3
+		o.ReadTimeout = 3 * time.Second
+		o.WriteTimeout = 3 * time.Second
+		o.DialTimeout = 3 * time.Second
+	}))
+	return &etlLock{client: client}
+}
+
+// Acquire 用 SET NX EX 原子抢锁。返回 (true,nil)=抢到, (false,nil)=别人持锁, (_,err)=Redis 故障。
+func (l *etlLock) Acquire(token string) (bool, error) {
+	ok, err := l.client.SetNX(etlRunLockKey, token, etlRunLockTTL).Result()
+	if err != nil {
+		return false, fmt.Errorf("searchetl: etl lock acquire: %w", err)
+	}
+	return ok, nil
+}
+
+// Release 走 Lua CAS-DEL，只在 token 匹配时释放（token 不匹配/已过期均视为正常，不报错）。
+func (l *etlLock) Release(token string) error {
+	_, err := luaReleaseETLLock.Run(l.client, []string{etlRunLockKey}, token).Result()
+	if err != nil && !errors.Is(err, rd.Nil) {
+		return fmt.Errorf("searchetl: etl lock release: %w", err)
+	}
+	return nil
+}
+
+// Renew 在当前 token 仍持有锁时延长租约。返回 false 表示锁已过期或 owner 已变化
+// （阶段 3：续租失败 → 立即 abort 在飞批次，C3）。
+func (l *etlLock) Renew(token string) (bool, error) {
+	res, err := luaRenewETLLock.Run(l.client, []string{etlRunLockKey}, token, etlRunLockTTL.Milliseconds()).Result()
+	if err != nil && !errors.Is(err, rd.Nil) {
+		return false, fmt.Errorf("searchetl: etl lock renew: %w", err)
+	}
+	n, ok := res.(int64)
+	return ok && n == 1, nil
+}
+
+// Close 释放底层连接池。
+func (l *etlLock) Close() error {
+	if l.client == nil {
+		return nil
+	}
+	return l.client.Close()
+}

--- a/modules/searchetl/model.go
+++ b/modules/searchetl/model.go
@@ -1,0 +1,17 @@
+package searchetl
+
+// srcMessageRow 是 message 分片表读出的单条消息（searchetl 取索引正文 + 鉴权可见性 +
+// 稳定性闸门所需列）。
+//
+// 阶段 1（本骨架）：仅 ID/CreatedUnix 投入使用（空跑游标 + 稳定性闸门）。MessageID/Payload
+// 等正文字段在阶段 2 接 Kafka 时随源 SELECT 改造一并启用，契约见 octo-lib contract/searchmsg。
+type srcMessageRow struct {
+	ID          int64
+	MessageID   string
+	FromUID     string
+	ChannelID   string
+	ChannelType uint8
+	Timestamp   int64 // 发送时间（纪元秒）
+	CreatedUnix int64 // 落库时间（纪元秒, = UNIX_TIMESTAMP(created_at)），稳定性闸门用
+	Payload     []byte
+}

--- a/modules/searchetl/sql/20260614000001_searchetl_init.sql
+++ b/modules/searchetl/sql/20260614000001_searchetl_init.sql
@@ -1,0 +1,18 @@
+-- +migrate Up
+
+-- searchetl 消息检索 ETL 抽取水位（YUJ-4530 ETL→Kafka→ES indexer）。
+-- 每个 message 分片表一行，记录已投递到 Kafka 的最大主键 id 水位。
+--
+-- 与 opanalytics 的 octo_etl_message_cursor 物理隔离（两条独立 ETL，各自游标，互不影响）。
+-- 增量抽取按 PK `WHERE id>last_id ORDER BY id LIMIT batch` keyset 分页；水位只推进到
+-- 「落库已超过 lag（稳定性滞后窗口）」的稳定前缀末尾，杜绝低 id 晚提交被游标越过的并发漏扫。
+-- 撤回/删除态不走该游标（路线甲：读时回 MySQL join 过滤），本游标只跑正文一条流。
+CREATE TABLE `octo_etl_es_cursor` (
+  `shard_table` VARCHAR(64) NOT NULL          COMMENT 'message 分片表名 (message / message1 / ...)',
+  `last_id`     BIGINT      NOT NULL DEFAULT 0 COMMENT '已投递到 Kafka 的最大 message.id 水位',
+  `updated_at`  TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '行更新时间',
+  PRIMARY KEY (`shard_table`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='消息检索ETL抽取水位(searchetl)';
+
+-- +migrate Down
+DROP TABLE IF EXISTS `octo_etl_es_cursor`;

--- a/modules/searchetl/stability.go
+++ b/modules/searchetl/stability.go
@@ -1,0 +1,20 @@
+package searchetl
+
+// stablePrefix 截取一批按 id 升序读出的行中「落库已超过 lag」的无空洞稳定前缀（硬条件 C1）。
+//
+// 语义与 opanalytics runChunk 的稳定性闸门完全一致：message.id 在 INSERT 时分配、COMMIT 时
+// 才可见，提交顺序≠id 顺序。id 与 created_at 同在 insert 时刻分配、近似同序，故首个未稳定行
+// （CreatedUnix > cutoff）之后（更高 id）均视为未稳定，从该处截断即为无空洞稳定前缀。
+//
+// 游标只能推进到该前缀末尾的 id，绝不能推进到 batch 末尾——否则会越过「低 id、晚提交、尚未
+// 落库满 lag」的行造成永久漏扫（message_id 幂等也修不回，因为这些消息从未被 produce）。
+//
+// cutoff = DB_NOW - lag。返回稳定前缀（rows 的前缀切片）；队首即未稳定时返回空切片。
+func stablePrefix(rows []*srcMessageRow, cutoff int64) []*srcMessageRow {
+	for i, r := range rows {
+		if r.CreatedUnix > cutoff {
+			return rows[:i]
+		}
+	}
+	return rows
+}

--- a/modules/searchetl/stability_test.go
+++ b/modules/searchetl/stability_test.go
@@ -1,0 +1,61 @@
+package searchetl
+
+import "testing"
+
+func row(id, createdUnix int64) *srcMessageRow {
+	return &srcMessageRow{ID: id, CreatedUnix: createdUnix}
+}
+
+// TestStablePrefix_AllStable 全部行落库已超过 lag → 整批稳定。
+func TestStablePrefix_AllStable(t *testing.T) {
+	rows := []*srcMessageRow{row(1, 100), row(2, 110), row(3, 120)}
+	cutoff := int64(200) // now-lag，远大于所有 created
+	got := stablePrefix(rows, cutoff)
+	if len(got) != 3 {
+		t.Fatalf("want 3 stable, got %d", len(got))
+	}
+}
+
+// TestStablePrefix_TailUnstable 批尾若干行未满 lag → 只取稳定前缀，游标不越过未稳定行。
+func TestStablePrefix_TailUnstable(t *testing.T) {
+	rows := []*srcMessageRow{row(1, 100), row(2, 110), row(3, 250), row(4, 260)}
+	cutoff := int64(200)
+	got := stablePrefix(rows, cutoff)
+	if len(got) != 2 {
+		t.Fatalf("want 2 stable, got %d", len(got))
+	}
+	if got[len(got)-1].ID != 2 {
+		t.Fatalf("stable prefix must end at id=2, got id=%d", got[len(got)-1].ID)
+	}
+}
+
+// TestStablePrefix_HeadUnstable 队首即未稳定 → 空前缀，本轮不前进。
+func TestStablePrefix_HeadUnstable(t *testing.T) {
+	rows := []*srcMessageRow{row(1, 300), row(2, 310)}
+	cutoff := int64(200)
+	got := stablePrefix(rows, cutoff)
+	if len(got) != 0 {
+		t.Fatalf("want 0 stable (head unstable), got %d", len(got))
+	}
+}
+
+// TestStablePrefix_LowIdLateCommit C1 核心反例：低 id 行晚提交（created 更晚）混在高稳定行后。
+// 因游标按稳定前缀末尾推进，未稳定的低 id 行（id=3, created=250）会被保留，下轮重读，
+// 不会被越过漏扫。验证「首个未稳定行之后一律视为未稳定」的无空洞前缀语义。
+func TestStablePrefix_LowIdLateCommit(t *testing.T) {
+	// id 升序，但 id=3 落库晚（晚提交）→ created=250 未满 lag。
+	rows := []*srcMessageRow{row(1, 100), row(2, 110), row(3, 250), row(4, 130)}
+	cutoff := int64(200)
+	got := stablePrefix(rows, cutoff)
+	// 截断在首个未稳定行（id=3）处，即便 id=4 自身 created 已稳定也不纳入（无空洞保证）。
+	if len(got) != 2 || got[len(got)-1].ID != 2 {
+		t.Fatalf("want prefix ending at id=2 (no-hole cut at first unstable), got len=%d", len(got))
+	}
+}
+
+// TestStablePrefix_Empty 空批 → 空前缀。
+func TestStablePrefix_Empty(t *testing.T) {
+	if got := stablePrefix(nil, 100); len(got) != 0 {
+		t.Fatalf("want 0 on empty, got %d", len(got))
+	}
+}


### PR DESCRIPTION
## What

Phase 1 (part 2 of 2) of the octo-im message → ETL → Kafka → ES-indexer search pipeline. This PR scaffolds the **`searchetl` module + its isolated cursor table** in octo-server, cloning the proven `opanalytics` incremental-cursor ETL paradigm.

### Files
- **Migration** `modules/searchetl/sql/20260614000001_searchetl_init.sql` — new table `octo_etl_es_cursor` (per-shard `last_id` watermark), physically isolated from opanalytics' `octo_etl_message_cursor`. The two ETLs run independent cursors.
- **`modules/searchetl/`** — module skeleton:
  - `etl_db.go` — shard enumeration, cursor ensure/load, `max(id)` (for backlog metric), keyset batch read. Source SELECT already pulls `message_id` + `payload` + `created_unix` so phase 2 reuses the exact row shape.
  - `stability.go` (+ tests) — the **stability gate** `created_unix <= DB_NOW - lag` with no-hole prefix cut. This is the hard anti-data-loss condition **C1** and is present from day one: the cursor may only advance to the stable-prefix tail, never the batch tail, so a low-id/late-commit row is never skipped.
  - `etl.go` — `RunIncrementalDryRun`: walks every shard, reads the stable prefix, logs stable-row + backlog counts, **without advancing the cursor and without producing to Kafka**.
  - `etl_lock.go` — Redis run-lock primitive (key `searchetl:etl:run`, SET NX EX + Lua CAS-DEL/CAS-PEXPIRE), staged for the single-replica mutual exclusion (**C3**) that lands with the transaction split in later phases.
  - `config.go` — `batch` / `lag` / `tick` env knobs (clamped), lag default 600s (C1 STOP: prod lag must never be 0).
- `internal/modules.go` — blank-import registration.

### Why no behaviour change yet
No scheduler is started, no Kafka, no cursor advancement. The module **compiles against the current octo-lib pin** — the contract import + `go.mod` pin bump happen in **phase 2 after the octo-lib PR merges** (publish order / plan STOP #11: never pin to an unmerged commit).

## Verification
- `go build ./...` ✅ · `go vet ./modules/searchetl ./internal` ✅
- `go test ./modules/searchetl` ✅ — stability-gate unit tests incl. the C1 low-id/late-commit no-hole reproduction
- Migration is additive (CREATE TABLE + DROP on down); dry-run safe.
- /codex review: PASS ✅ (no blocking issues in SQL construction, stable-prefix gating, Redis lock, cursor data-loss behaviour)

## Merge order
⚠️ Independent-compiling, but logically **after** octo-lib#76. Phase 2 (Kafka wiring) will bump the pin to octo-lib#76's merge SHA and import `contract/searchmsg`.
Depends on: Mininglamp-OSS/octo-lib#76

Part of YUJ-4530 (phase 1).
