### PR TITLE
feat(searchetl): ordered commit + cross-replica run-lock (C3)

### DIFF
--- a/modules/searchetl/chunk_test.go
+++ b/modules/searchetl/chunk_test.go
@@ -20,10 +20,10 @@ func textRow(id int64, mid, content string, createdUnix int64) *srcMessageRow {
 // 游标 maxID 取稳定前缀末（含 raw_excluded/dlq 行的 id，必须计入水位）。
 func TestPlanChunk_StablePrefixAndRouting(t *testing.T) {
 	rows := []*srcMessageRow{
-		textRow(1, "a", "hi", 100),                                              // OK → main
+		textRow(1, "a", "hi", 100), // OK → main
 		{ID: 2, MessageID: "b", Signal: 1, CreatedUnix: 110, Payload: []byte("x")}, // signal → main(raw_excluded)
 		{ID: 3, MessageID: "c", CreatedUnix: 120, Payload: []byte("{bad")},         // bad json → dlq
-		textRow(4, "d", "late", 250),                                            // 未稳定 → 截断
+		textRow(4, "d", "late", 250),                                               // 未稳定 → 截断
 	}
 	plan := planChunk(rows, 200)
 	if plan.stableCount != 3 {
@@ -229,4 +229,77 @@ func TestRunChunk_SignalNotInDLQ(t *testing.T) {
 		t.Fatalf("cursor must advance past signal msg, got %d", store.advancedTo)
 	}
 	_ = common.Text
+}
+
+// TestRunChunk_LockLostAfterProduceNoAdvance 🔴 C3：投递成功后、推进游标前锁丢失（lockCtx 取消）
+// → 不推进游标（advanceCursor 零调用），返回 ctx 错误。已投消息靠 message_id 幂等 + ES _id
+// upsert 下轮重投覆盖；绝不在失锁后推进游标（失锁不双算）。
+func TestRunChunk_LockLostAfterProduceNoAdvance(t *testing.T) {
+	store := &fakeStore{cursor: 0, rows: []*srcMessageRow{textRow(1, "a", "x", 100)}}
+	// sink 在投递成功后取消 ctx，模拟「投递与推进之间续租失败」。
+	ctx, cancel := context.WithCancel(context.Background())
+	sink := &cancelSink{cancel: cancel}
+	_, n, err := runChunk(ctx, store, sink, "message", 200, 5000, lg())
+	if err == nil {
+		t.Fatalf("expected ctx error after lock loss")
+	}
+	if n != 0 {
+		t.Fatalf("lock-lost chunk must report 0 progress, got %d", n)
+	}
+	if store.advanceCalls != 0 {
+		t.Fatalf("advanceCursor must NOT be called after lock loss, got %d", store.advanceCalls)
+	}
+	if store.cursor != 0 {
+		t.Fatalf("cursor must stay at 0 (re-produce next tick), got %d", store.cursor)
+	}
+	if sink.mainCalls != 1 {
+		t.Fatalf("produce should have happened once before loss, got %d", sink.mainCalls)
+	}
+}
+
+// cancelSink 在 produceBatch 成功后取消传入的 ctx，模拟投递与游标推进之间的失锁。
+type cancelSink struct {
+	cancel    context.CancelFunc
+	mainCalls int
+}
+
+func (s *cancelSink) produceBatch(ctx context.Context, msgs []searchmsg.Message) error {
+	s.mainCalls++
+	s.cancel() // 投递成功后立即失锁
+	return nil
+}
+
+func (s *cancelSink) produceDLQ(ctx context.Context, msgs []searchmsg.Message) error {
+	return nil
+}
+
+// TestRunChunk_CASMissNoAdvance 🔴 C3 fence：投递成功后游标已被另一持锁副本推进（CAS 失配，
+// advanceCursor 返回 false）→ 本轮不计已投、不报错，下轮从新水位续跑。这是失锁竞态的安全收口：
+// 即便本 owner 失锁后仍跑到 advanceCursor，游标行 CAS（WHERE last_id=expected）也挡住越权推进。
+func TestRunChunk_CASMissNoAdvance(t *testing.T) {
+	store := &casMissStore{cursor: 0, rows: []*srcMessageRow{textRow(1, "a", "x", 100)}}
+	sink := &fakeSink{}
+	_, n, err := runChunk(context.Background(), store, sink, "message", 200, 5000, lg())
+	if err != nil {
+		t.Fatalf("CAS miss must not error, got %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("CAS-miss chunk must report 0 progress, got %d", n)
+	}
+	if sink.mainCalls != 1 {
+		t.Fatalf("produce should have happened once, got %d", sink.mainCalls)
+	}
+}
+
+// casMissStore 的 advanceCursor 恒返回 (false,nil)，模拟「游标已被另一持锁副本推进」。
+type casMissStore struct {
+	cursor int64
+	rows   []*srcMessageRow
+}
+
+func (s *casMissStore) readStableBatchTx(table string, batch int) (int64, []*srcMessageRow, error) {
+	return s.cursor, s.rows, nil
+}
+func (s *casMissStore) advanceCursor(table string, expected, newID int64) (bool, error) {
+	return false, nil // CAS 失配：另一副本已推进游标
 }

--- a/modules/searchetl/etl.go
+++ b/modules/searchetl/etl.go
@@ -3,6 +3,7 @@ package searchetl
 import (
 	"context"
 	"sync/atomic"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
@@ -29,43 +30,57 @@ type chunkSink interface {
 // 目标架构：读 message 5 分表 → 投 Kafka topic octo.message.v1 → es-indexer 消费 → OpenSearch。
 // 撤回/删除走读时查询侧 join（路线甲），producer 只跑正文一条流。
 //
-// 阶段 2（本次）：接 Kafka producer + 事务拆分（C2）+ payload 抽取（P1-d）。RunIncremental
-// 走「短读事务取批 → 事务外整批投 Kafka 确认 → 短事务推进游标到稳定前缀末」，并带**进程内**
-// 重入护栏（running CAS）挡住同进程并发重复投递。跨副本互斥（C3：Redis 锁全程持有 + 续租失败
-// abort）与 scheduler 接入留阶段 3——本阶段不自动启 tick，Kafka.On=off 时连 producer 都不
-// 构造（保持阶段 1 惰性，部署测试环境零运行期变更）。
+// 阶段 2：接 Kafka producer + 事务拆分（C2）+ payload 抽取（P1-d）。
+// 阶段 3（本次）：顺序提交（游标只单调推进到已确认成功投递的稳定连续前缀末）+ 跨副本互斥
+// （C3）——RunIncremental 整轮在 Redis run-lock 保护下执行（横跨「读批 → 投 Kafka → 推游标」），
+// 续租失败尽早 abort 在飞批次。**正确性的最终保证不是 Redis 锁本身，而是「先投递后推进」的
+// 顺序 + 游标行 CAS（advanceCursor 的 WHERE last_id=expected，由 FOR UPDATE 串行化）作 fence
+// + ES _id 幂等 upsert**：即便失锁竞态，CAS 也挡住越权推进，重复投递由幂等 sink 去重，绝无
+// 空洞/丢失/双算（详见 runChunk 注释）。Redis 锁是降低重复、保证「正常情况下单副本跑」的
+// 第一道防线；CAS fence 是底线。进程内 running CAS 挡同进程重入。Kafka.On=off 时连 producer/
+// lock 都不构造（保持惰性）。
 type ETL struct {
 	log.Log
 	ctx   *config.Context
 	db    *etlDB
 	batch int
 	lag   int64
-	// running 是**进程内**重入护栏（CAS 0→1）：拆事务后单 chunk 内不再有跨读-投-推进的
-	// FOR UPDATE 第二防线，若同进程并发跑两轮 RunIncremental，会在同批 readStableBatchTx 后
-	// 各自向 Kafka 重复投递（ES _id upsert 去重故不丢/不脏，但浪费且无谓放大）。本护栏挡住
-	// 同进程并发；**跨进程/多副本**互斥仍由阶段 3 的 Redis 锁（全程持有 + 续租失败 abort）负责。
+	// running 是**进程内**重入护栏（CAS 0→1）：挡同进程并发跑两轮 RunIncremental。
+	// **跨进程/多副本**互斥由 C3 的 Redis run-lock（runLockedTick：全程持有 + 续租失败 abort）负责。
 	running atomic.Bool
+	// newLock 构造 Redis run-lock（C3）。默认 productionNewLock；测试可替换为假锁验证锁语义。
+	newLock func(*config.Context) runLock
+	// renewInterval 续租周期（默认 lockRenewInterval()）。测试可调短以快速触发续租路径。
+	renewInterval time.Duration
 }
 
 // NewETL 创建 ETL。
 func NewETL(ctx *config.Context) *ETL {
 	return &ETL{
-		Log:   log.NewTLog("SearchETL"),
-		ctx:   ctx,
-		db:    newETLDB(ctx),
-		batch: batchSize(),
-		lag:   lagSeconds(),
+		Log:           log.NewTLog("SearchETL"),
+		ctx:           ctx,
+		db:            newETLDB(ctx),
+		batch:         batchSize(),
+		lag:           lagSeconds(),
+		newLock:       productionNewLock,
+		renewInterval: lockRenewInterval(),
 	}
 }
 
-// RunIncremental 跑一轮真实增量抽取（阶段 2）：逐分片以事务拆分（C2）投递正文到 Kafka。
+// productionNewLock 用真实 Redis 构造 run-lock（*etlLock 实现 runLock 接口）。
+func productionNewLock(ctx *config.Context) runLock {
+	return newETLLock(ctx)
+}
+
+// RunIncremental 跑一轮真实增量抽取（阶段 2/3）：在 Redis run-lock 保护下，逐分片以事务拆分
+// 投递正文到 Kafka，游标顺序提交到已确认成功投递的稳定连续前缀末。
 //
-// 前置：仅当 Kafka.On 时才有意义——off 时直接返回（不连 Kafka、不推进游标，保持惰性）。
-// 单实例互斥（C3）由调用方（阶段 3 的 scheduler，持 Redis 锁 + 续租）保证；本方法本身不抢锁，
-// 当前仅供测试/未来 scheduler 调用，未挂自动 tick。
+// 前置：仅当 Kafka.On 时才有意义——off 时直接返回（不连 Kafka/Redis、不推进游标，保持惰性）。
 //
-// 每分片循环 runChunk 直到触达未稳定尾部（稳定前缀 < batch）。任一 chunk 投递失败即整轮
-// 返回 error、该分片游标不推进，下轮整批重投（message_id 幂等 + ES _id upsert 去重，C2）。
+// 互斥两道防线：
+//   - 进程内 running CAS：挡同进程并发重入。
+//   - 🔴 C3 Redis run-lock（runLockedTick）：挡跨副本并发——锁横跨整 tick 持有，续租失败立即
+//     abort 在飞批次（lockCtx 取消 → 投递/推进游标都停），失锁不双算。抢不到锁直接跳过本轮。
 func (e *ETL) RunIncremental(ctx context.Context) error {
 	cfg := e.ctx.GetConfig()
 	if !cfg.Kafka.On {
@@ -74,13 +89,29 @@ func (e *ETL) RunIncremental(ctx context.Context) error {
 	}
 
 	// 进程内重入护栏：已有一轮在跑则直接跳过本轮（不报错，等下个 tick）。
-	// 跨副本互斥由阶段 3 Redis 锁补上；这里挡住同进程并发重复投递。
 	if !e.running.CompareAndSwap(false, true) {
 		e.Info("searchetl: another incremental run in progress (same process), skip")
 		return nil
 	}
 	defer e.running.Store(false)
 
+	// 🔴 C3：整轮在 Redis run-lock 保护下执行。lockCtx 在续租失败时被取消，runTick 内尊重取消。
+	lock := e.newLock(e.ctx)
+	if closer, ok := lock.(interface{ Close() error }); ok {
+		defer func() {
+			if cerr := closer.Close(); cerr != nil {
+				e.Error("searchetl: close run-lock failed", zap.Error(cerr))
+			}
+		}()
+	}
+	return runLockedTick(ctx, lock, e.renewInterval, e.Log, e.runTick)
+}
+
+// runTick 是「持有 run-lock 的一轮」实际工作：构造 producer，逐分片 runChunk 投递 + 顺序推进游标。
+// ctx 即 lockCtx——续租失败被取消后，每个 chunk 前的 ctx.Err() 检查令在飞循环立即 abort，
+// 绝不在失锁后继续投递或推进游标（C3 验证门：失锁路径不双算）。
+func (e *ETL) runTick(ctx context.Context) error {
+	cfg := e.ctx.GetConfig()
 	prod := newProducer(cfg)
 	defer func() {
 		if cerr := prod.Close(); cerr != nil {
@@ -100,6 +131,12 @@ func (e *ETL) RunIncremental(ctx context.Context) error {
 			return err
 		}
 		for {
+			// 🔴 C3：每个 chunk 前检查锁是否仍持有（lockCtx 未取消）。失锁立即停，不再投递/推进。
+			if cerr := ctx.Err(); cerr != nil {
+				e.Warn("searchetl: lock lost / ctx cancelled, abort in-flight tick",
+					zap.String("table", table), zap.Error(cerr))
+				return cerr
+			}
 			plan, n, cerr := runChunk(ctx, e.db, prod, table, cutoff, e.batch, e.Log)
 			if cerr != nil {
 				return cerr
@@ -151,14 +188,34 @@ func runChunk(ctx context.Context, store chunkStore, sink chunkSink, table strin
 		return plan, 0, err
 	}
 
-	// 全部投递确认成功 → 短事务推进游标到稳定前缀末（绝不到 batch 末，C1）。
+	// 🔴 C3 安全性的真正保证不是下面的 ctx 检查，而是「先投递后推进」的顺序 + 游标行 CAS
+	// （advanceCursor 的 WHERE last_id=expected，由 readStableBatchTx 的 FOR UPDATE 串行化）
+	// 充当 fencing token，外加 ES _id 幂等 upsert。推演任意交错：
+	//   - 本 owner 总是在「投递全部 [cursor+1, maxID] 成功」之后才尝试推进，故游标永不领先于
+	//     已投递消息——绝无空洞/丢失。
+	//   - 若本 owner 已失锁、另一副本 B 抢到并先推进了游标：本 owner 的 CAS（last_id=cursor）
+	//     失配 → 不推进（落入下方 !advanced 分支）。
+	//   - 若本 owner 先推进、B 后读：B 的 FOR UPDATE 读到新水位、从新位置续投。
+	//   - 两副本重叠投递的重复条由 ES _id upsert 去重（at-least-once 本就允许重复）。
+	// 因此「失锁推进」在本设计下无害：CAS 是 fence，Redis 锁失效不会造成双算/空洞。
+	//
+	// 下面的 ctx.Err() 仅是**尽力而为的早退优化**：失锁后尽早停手、少做无谓的重复推进，
+	// 但即便它漏判（检查通过后才失锁），CAS + 顺序 + 幂等仍保证正确性。
+	if cerr := ctx.Err(); cerr != nil {
+		lg.Warn("searchetl: lock lost after produce, skip cursor advance (re-produce next tick)",
+			zap.String("table", table), zap.Int64("to", plan.maxID), zap.Error(cerr))
+		return plan, 0, cerr
+	}
+
+	// 投递确认成功 → 短事务以游标行 CAS 推进到稳定前缀末（绝不到 batch 末，C1）。
 	advanced, err := store.advanceCursor(table, cursor, plan.maxID)
 	if err != nil {
 		return plan, 0, err
 	}
 	if !advanced {
-		// 游标已被他者改动（理论上 C3 锁保证不会发生）：本轮不计已投，下轮乐观重试。
-		lg.Warn("searchetl: cursor moved by another writer, skip advance",
+		// CAS 失配：游标已被另一持锁副本推进（失锁竞态的安全收口）。本轮不计已投，
+		// 已投消息靠 message_id 幂等 + ES _id upsert 覆盖，下轮从新水位续跑——无空洞。
+		lg.Warn("searchetl: cursor moved by another writer (CAS miss), skip advance",
 			zap.String("table", table), zap.Int64("expected", cursor), zap.Int64("new", plan.maxID))
 		return plan, 0, nil
 	}

--- a/modules/searchetl/etl_run_lock.go
+++ b/modules/searchetl/etl_run_lock.go
@@ -1,0 +1,117 @@
+package searchetl
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"go.uber.org/zap"
+)
+
+// runLock 抽象 searchetl 的 Redis 分布式互斥锁（由 *etlLock 实现）。抽成接口便于单测注入
+// 假锁，验证 C3 三条硬语义：锁横跨整 tick 持有、续租失败立即 abort 在飞批次、失锁不双算。
+type runLock interface {
+	// Acquire 抢锁：(true,nil)=抢到, (false,nil)=别人持锁, (_,err)=Redis 故障。
+	Acquire(token string) (bool, error)
+	// Renew 续租：true=仍持有并已续期, false=锁已过期或 owner 变更（须 abort）。
+	Renew(token string) (bool, error)
+	// Release 释放（CAS-DEL，仅 token 匹配时）。
+	Release(token string) error
+}
+
+// lockRenewInterval 续租周期：TTL/3，留足余量让单次 Redis 抖动不致误判失锁。
+func lockRenewInterval() time.Duration {
+	iv := etlRunLockTTL / 3
+	if iv < time.Second {
+		iv = time.Second
+	}
+	return iv
+}
+
+// randomToken 生成锁持有者 token（每轮新生成，供 CAS-DEL/CAS-PEXPIRE 校验 owner）。
+func randomToken() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// runLockedTick 在持有 Redis run-lock 的前提下跑一轮 run（C3 跨副本互斥编排核心）。
+//
+// 语义（plan §3.5 / 硬条件 C3）：
+//   - 抢锁：抢不到（别的副本在跑）→ 直接跳过本轮返回 nil，不报错（验证门：两副本只一个跑 tick）。
+//   - 锁横跨整 tick：后台续租 goroutine 在 run 执行期间周期续租，覆盖「读批 → 投 Kafka →
+//     推游标」整个窗口。
+//   - 🔴 续租失败立即 abort：Renew 返回 error 或 false（锁过期/被抢）→ 取消 lockCtx，令在飞
+//     批次 abort——run 内的 Kafka 投递与游标推进都尊重 lockCtx 取消，绝不在失锁后继续推进游标
+//     或投递（验证门：锁失效路径不双算）。
+//   - 释放：tick 结束 CAS-DEL 释放（token 不匹配则不误删后继 owner 的锁）。
+//
+// interval 为续租周期（生产用 lockRenewInterval()，测试可传短值）。run 收到的 ctx 即 lockCtx，
+// 失锁时被取消。
+func runLockedTick(ctx context.Context, lock runLock, interval time.Duration, lg log.Log, run func(context.Context) error) error {
+	token, err := randomToken()
+	if err != nil {
+		return err
+	}
+	acquired, err := lock.Acquire(token)
+	if err != nil {
+		// Redis 故障：不强行裸跑（避免多副本同跑），等下个 tick。
+		lg.Error("searchetl: acquire run-lock failed, skip tick", zap.Error(err))
+		return err
+	}
+	if !acquired {
+		lg.Info("searchetl: run-lock held by another replica, skip tick")
+		return nil
+	}
+
+	lockCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// renewDone 在续租 goroutine 退出后关闭，供下方 join——必须先停 + 等续租 goroutine 真正退出，
+	// 再 Release，避免「Release 后迟到的 Renew 误判 owner 丢失」与 goroutine 泄漏（续租比 tick 长寿）。
+	done := make(chan struct{})
+	renewDone := make(chan struct{})
+	go func() {
+		defer close(renewDone)
+		renewUntilDone(lock, token, interval, cancel, done, lg)
+	}()
+
+	defer func() {
+		close(done) // 通知续租 goroutine 停止
+		<-renewDone // join：等其真正退出，确保此后不再有 Renew 调用，再释放
+		if rerr := lock.Release(token); rerr != nil {
+			lg.Error("searchetl: release run-lock failed", zap.Error(rerr))
+		}
+	}()
+
+	return run(lockCtx)
+}
+
+// renewUntilDone 周期续租，直到 done 关闭（tick 正常结束）或续租失败。
+// 🔴 续租失败（err 或 owner 丢失）→ cancel(lockCtx) 触发在飞批次 abort，并停止续租。
+func renewUntilDone(lock runLock, token string, interval time.Duration, cancel context.CancelFunc, done <-chan struct{}, lg log.Log) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-done:
+			return
+		case <-t.C:
+			ok, err := lock.Renew(token)
+			if err != nil {
+				lg.Error("searchetl: renew run-lock failed, abort in-flight tick", zap.Error(err))
+				cancel()
+				return
+			}
+			if !ok {
+				lg.Error("searchetl: run-lock ownership lost, abort in-flight tick")
+				cancel()
+				return
+			}
+		}
+	}
+}

--- a/modules/searchetl/etl_run_lock_test.go
+++ b/modules/searchetl/etl_run_lock_test.go
@@ -1,0 +1,266 @@
+package searchetl
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeLock 是 runLock 的可控假实现，用于验证 C3 锁编排语义（无需真实 Redis）。
+type fakeLock struct {
+	acquireOK  bool  // Acquire 是否抢到
+	acquireErr error // Acquire 是否 Redis 故障
+
+	renewErr   error // Renew 是否报错
+	renewFalse bool  // Renew 是否返回 false（owner 丢失）
+	renewAfter int   // 前 N 次 Renew 正常，第 N+1 次起按 renewErr/renewFalse 失败
+
+	acquireCalls atomic.Int32
+	renewCalls   atomic.Int32
+	releaseCalls atomic.Int32
+	released     atomic.Bool
+}
+
+func (f *fakeLock) Acquire(token string) (bool, error) {
+	f.acquireCalls.Add(1)
+	if f.acquireErr != nil {
+		return false, f.acquireErr
+	}
+	return f.acquireOK, nil
+}
+
+func (f *fakeLock) Renew(token string) (bool, error) {
+	n := int(f.renewCalls.Add(1))
+	if n <= f.renewAfter {
+		return true, nil // 前 renewAfter 次正常续租
+	}
+	if f.renewErr != nil {
+		return false, f.renewErr
+	}
+	if f.renewFalse {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (f *fakeLock) Release(token string) error {
+	f.releaseCalls.Add(1)
+	f.released.Store(true)
+	return nil
+}
+
+// TestRunLockedTick_AcquireFailsSkips 抢不到锁（别副本在跑）→ 跳过本轮返回 nil，run 不执行。
+func TestRunLockedTick_AcquireFailsSkips(t *testing.T) {
+	lock := &fakeLock{acquireOK: false}
+	ran := false
+	err := runLockedTick(context.Background(), lock, time.Hour, lg(), func(ctx context.Context) error {
+		ran = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("acquire-miss must return nil, got %v", err)
+	}
+	if ran {
+		t.Fatalf("run must NOT execute when lock not acquired (no duplicate work)")
+	}
+	if lock.releaseCalls.Load() != 0 {
+		t.Fatalf("must not release a lock we never acquired")
+	}
+}
+
+// TestRunLockedTick_RedisErrorSkips Redis 故障 → 不裸跑（避免多副本同跑），返回 err，run 不执行。
+func TestRunLockedTick_RedisErrorSkips(t *testing.T) {
+	lock := &fakeLock{acquireErr: errors.New("redis down")}
+	ran := false
+	err := runLockedTick(context.Background(), lock, time.Hour, lg(), func(ctx context.Context) error {
+		ran = true
+		return nil
+	})
+	if err == nil {
+		t.Fatalf("redis error should propagate")
+	}
+	if ran {
+		t.Fatalf("run must NOT execute on redis error")
+	}
+}
+
+// TestRunLockedTick_HappyPathReleases 抢到锁 → run 执行 → 结束释放锁。
+func TestRunLockedTick_HappyPathReleases(t *testing.T) {
+	lock := &fakeLock{acquireOK: true}
+	err := runLockedTick(context.Background(), lock, time.Hour, lg(), func(ctx context.Context) error {
+		if ctx.Err() != nil {
+			t.Fatalf("ctx must be live during run")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("happy path err: %v", err)
+	}
+	if !lock.released.Load() {
+		t.Fatalf("lock must be released after tick")
+	}
+}
+
+// TestRunLockedTick_NoRenewAfterRelease 续租 goroutine 必须在 Release 之前 join 退出：
+// Release 后绝不再有 Renew 调用（否则迟到 Renew 误判 owner 丢失 + goroutine 泄漏）。
+// 用短续租周期让续租活跃，orderLock 记录 Release 后是否仍发生 Renew。
+func TestRunLockedTick_NoRenewAfterRelease(t *testing.T) {
+	lock := &orderLock{}
+	err := runLockedTick(context.Background(), lock, time.Millisecond, lg(), func(ctx context.Context) error {
+		time.Sleep(20 * time.Millisecond) // 让续租至少跑几次
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !lock.released.Load() {
+		t.Fatalf("must release")
+	}
+	if lock.renewAfterRelease.Load() {
+		t.Fatalf("Renew was called after Release — renew goroutine not joined before release")
+	}
+}
+
+// orderLock 记录 Release 之后是否仍有 Renew 被调用（验证 join 正确性）。
+type orderLock struct {
+	released          atomic.Bool
+	renewAfterRelease atomic.Bool
+}
+
+func (o *orderLock) Acquire(token string) (bool, error) { return true, nil }
+func (o *orderLock) Renew(token string) (bool, error) {
+	if o.released.Load() {
+		o.renewAfterRelease.Store(true)
+	}
+	return true, nil
+}
+func (o *orderLock) Release(token string) error {
+	o.released.Store(true)
+	return nil
+}
+
+// TestRunLockedTick_RenewFailureAbortsInFlight 🔴 C3 核心：续租失败 → lockCtx 取消 →
+// 在飞 run 立即收到取消并 abort（不继续推进）。验证「锁失效路径不双算」。
+func TestRunLockedTick_RenewFailureAbortsInFlight(t *testing.T) {
+	// renewAfter=0 + renewErr：第一次续租即失败 → 触发 cancel。
+	lock := &fakeLock{acquireOK: true, renewErr: errors.New("renew failed")}
+
+	aborted := make(chan struct{})
+	var advancedAfterLoss atomic.Bool
+	err := runLockedTick(context.Background(), lock, 10*time.Millisecond, lg(), func(ctx context.Context) error {
+		// 模拟在飞批次：持续工作直到 lockCtx 被取消。
+		select {
+		case <-ctx.Done():
+			close(aborted)
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
+			// 若 5s 内没被取消，说明续租失败没触发 abort → C3 失败。
+			advancedAfterLoss.Store(true)
+			return nil
+		}
+	})
+	select {
+	case <-aborted:
+		// 正确：在飞批次被 abort。
+	case <-time.After(2 * time.Second):
+		t.Fatalf("in-flight run was not aborted after renew failure (C3 violated)")
+	}
+	if advancedAfterLoss.Load() {
+		t.Fatalf("run continued after lock loss — double-count risk (C3 violated)")
+	}
+	if err == nil {
+		t.Fatalf("aborted run should return ctx error")
+	}
+}
+
+// TestRunLockedTick_RenewOwnerLostAborts 续租返回 false（owner 被抢）同样 abort 在飞批次。
+func TestRunLockedTick_RenewOwnerLostAborts(t *testing.T) {
+	lock := &fakeLock{acquireOK: true, renewFalse: true}
+	aborted := make(chan struct{})
+	_ = runLockedTick(context.Background(), lock, 10*time.Millisecond, lg(), func(ctx context.Context) error {
+		select {
+		case <-ctx.Done():
+			close(aborted)
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
+			return nil
+		}
+	})
+	select {
+	case <-aborted:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("owner-lost renew must abort in-flight run (C3)")
+	}
+}
+
+// TestRunLockedTick_TwoReplicasOnlyOneRuns 两副本并发抢同一把锁，只有一个跑 run，另一个跳过。
+// 消除调度敏感：持锁副本进入 run 后阻塞，直到两副本都已调用过 Acquire（acquireCalls==2），
+// 确保「第二副本在第一副本仍持锁时竞争」，而非第一副本跑完释放后第二副本才抢（那会假阳性双跑）。
+func TestRunLockedTick_TwoReplicasOnlyOneRuns(t *testing.T) {
+	shared := &sharedLock{}
+	var runCount atomic.Int32
+	release := make(chan struct{})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = runLockedTick(context.Background(), shared, time.Hour, lg(), func(ctx context.Context) error {
+				runCount.Add(1)
+				// 持锁直到两副本都已尝试 Acquire（含抢不到的那个），保证竞争发生在持锁期间。
+				for shared.acquireCalls.Load() < 2 {
+					time.Sleep(time.Millisecond)
+				}
+				<-release
+				return nil
+			})
+		}()
+	}
+	// 两副本都 Acquire 过后放行。轮询等待，避免依赖 sleep 时长。
+	for shared.acquireCalls.Load() < 2 {
+		time.Sleep(time.Millisecond)
+	}
+	close(release)
+	wg.Wait()
+
+	if runCount.Load() != 1 {
+		t.Fatalf("exactly one replica must run the tick, got %d", runCount.Load())
+	}
+}
+
+// sharedLock 模拟 Redis SET NX 单 owner 语义（多 goroutine 抢同一把锁）。
+type sharedLock struct {
+	mu           sync.Mutex
+	owner        string
+	acquireCalls atomic.Int32
+}
+
+func (s *sharedLock) Acquire(token string) (bool, error) {
+	s.acquireCalls.Add(1)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.owner != "" {
+		return false, nil
+	}
+	s.owner = token
+	return true, nil
+}
+
+func (s *sharedLock) Renew(token string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.owner == token, nil
+}
+
+func (s *sharedLock) Release(token string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.owner == token {
+		s.owner = ""
+	}
+	return nil
+}

--- a/modules/searchetl/etl_test.go
+++ b/modules/searchetl/etl_test.go
@@ -44,3 +44,20 @@ func TestRunIncremental_ReentrancyGuard(t *testing.T) {
 		t.Fatalf("reentrant run must short-circuit to nil, got err=%v", err)
 	}
 }
+
+// TestRunIncremental_LockAcquireMissSkipsBeforeDB 🔴 C3：Kafka.On=true 时，run-lock 抢不到
+// （别副本在跑）→ RunIncremental 立即跳过返回 nil，**不读 DB、不投 Kafka**。证明锁横跨整 tick：
+// 抢锁发生在任何 DB/Kafka 工作之前（若锁未先行，runTick 会调 dbNowUnix 在无 DB 时报错/超时）。
+func TestRunIncremental_LockAcquireMissSkipsBeforeDB(t *testing.T) {
+	cfg := config.New()
+	cfg.Kafka.On = true
+	cfg.Kafka.Brokers = []string{"127.0.0.1:0"}
+	ctx := config.NewContext(cfg)
+	etl := NewETL(ctx)
+	// 注入抢不到的假锁（模拟另一副本持锁）。
+	etl.newLock = func(*config.Context) runLock { return &fakeLock{acquireOK: false} }
+
+	if err := etl.RunIncremental(context.Background()); err != nil {
+		t.Fatalf("lock-miss must short-circuit to nil (no DB access), got err=%v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Stage 3 of the message-search ETL → Kafka → ES indexer pipeline: make the producer tick safe under multiple replicas, completing the reliability story started by the Stage 2 transaction split. Builds on `main` (includes Stage 2 #368).

Feature flag unchanged: `Kafka.On` defaults **off** — no producer/lock constructed, no runtime change until explicitly enabled.

## What's in this PR

**Ordered commit** — the cursor only advances to the end of the confirmed contiguous stable prefix. A mid-batch produce failure leaves the cursor unmoved (whole-chunk re-produce, no holes); produce always precedes advance, so the cursor never leads un-produced messages.

**Cross-replica mutex (C3)** — the whole `RunIncremental` tick now runs under the existing Redis run-lock (`searchetl:etl:run`, SET NX EX + Lua CAS), held across read-batch → produce → advance-cursor, renewed in a background goroutine:
- **Abort on lock loss**: renew failure / ownership loss cancels the lock context; the in-flight tick stops — no further produce, no advance.
- **Acquire-miss / Redis error** skips the tick instead of running unlocked, so two replicas never both run.
- **Renew goroutine is joined before release** (no late `Renew` after `Release`, no goroutine leak).

**The real safety invariant** (documented in `runChunk`): correctness does not rest on the Redis lock alone. It rests on *produce-before-advance ordering* + the *cursor-row CAS* (`advanceCursor`'s `WHERE last_id=expected`, serialized by `FOR UPDATE`) acting as a fencing token + ES `_id` idempotent upsert. Even under a lock-loss race, a stale owner's CAS misses and cannot advance; overlapping produces are deduped by the idempotent sink. No interleaving yields loss, a cursor hole, or double-count. The `ctx.Err()` check before advance is a best-effort early-exit, not the guarantee.

The in-process reentrancy guard (Stage 2) is retained as the first line of defence.

## Tests (verification gates)

Lock orchestration extracted behind a `runLock` interface so C3 is unit-tested without a live Redis:
- Cursor only advances to the confirmed contiguous prefix; partial failure → no advance (no holes)
- Lock loss (renew fail / owner lost) → in-flight tick aborts, cursor not advanced
- CAS miss (cursor moved by another replica) → no advance, no error (fence backstop)
- Two replicas contend while the first holds the lock → exactly one runs
- Acquire-miss / Redis error → skip tick, don't run unlocked
- No `Renew` after `Release` (renew goroutine joined)

`go build ./...`, `go vet`, and `go test -race ./modules/searchetl/...` all green; timing-sensitive tests stable across 20× `-race` runs. Independent model review: PASS (after addressing join ordering and hardening the lock-loss / CAS-fence coverage).

## Notes

Next stage (Stage 4): standalone `es-indexer` binary (consumer C4 + bulk + mapping). The write path will be organised so the bulk writer is reusable by the Stage 6 backfill job.
