### PR TITLE
feat(authz): CI guard requiring a role check on every /v1/manager route (#366)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,31 @@ jobs:
       - name: Reject direct PERSONAL MsgSendReq literals
         run: go run ./tools/lint-personal-msgsendreq ./modules
 
+  manager-authz-lint:
+    needs: [changes]
+    if: |
+      (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
+      needs.changes.outputs.code == 'true'
+    # Mininglamp-OSS/octo-server#366 Part 1: authorization safety net. The lint
+    # AST-walks modules/ and asserts every handler mounted under /v1/manager
+    # performs a role check (in-handler CheckLoginRole* / require* wrapper, or a
+    # declarative authz middleware). A new ungated management endpoint fails CI
+    # instead of shipping as a silent privilege escalation (the #364 class of
+    # bug). Intentional exceptions are allowlisted with a reason in
+    # tools/lint-manager-authz/allowlist.txt; a stale allowlist entry also fails.
+    name: Manager Authz Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Require a role check on every /v1/manager route
+        run: go run ./tools/lint-manager-authz
+
   i18n-extract-check:
     needs: [changes]
     if: |

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,20 @@ env-test:
 #                   - lint-unregistered-code: no inline codes.Code{} literals
 #                     passed to httperr.ResponseErrorL (registry bypass)
 
-.PHONY: i18n-extract i18n-extract-check i18n-merge i18n-lint
+# authz-lint   : #366 Part 1 — assert every handler mounted under /v1/manager
+#                 performs a role check (in-handler CheckLoginRole* / require*
+#                 wrapper, or a declarative authz middleware). Intentional
+#                 exceptions live in tools/lint-manager-authz/allowlist.txt with
+#                 a reason; the lint fails on an ungated route OR a stale
+#                 allowlist entry. Mirrors the i18n-lint guard pattern.
+
+.PHONY: i18n-extract i18n-extract-check i18n-merge i18n-lint authz-lint
 
 i18n-extract:
 	go run ./pkg/i18n/cmd/octo-i18n-extract
+
+authz-lint:
+	go run ./tools/lint-manager-authz
 
 i18n-lint:
 	go run ./tools/lint-direct-error-response

--- a/docs/2026-06-authz-centralized-layer-rfc.md
+++ b/docs/2026-06-authz-centralized-layer-rfc.md
@@ -1,0 +1,265 @@
+# RFC: Centralized Authorization Layer for Management Routes
+
+**Issue**: [#366](https://github.com/Mininglamp-OSS/octo-server/issues/366) Part 2 · follow-up to [#363](https://github.com/Mininglamp-OSS/octo-server/issues/363) audit / [#364](https://github.com/Mininglamp-OSS/octo-server/pull/364) fix
+**Status**: **Draft RFC — design proposal for maintainer review. Not yet implemented.**
+**Date**: 2026-06-14
+**Scope**: design only. Part 1 (the CI guard, `tools/lint-manager-authz`) has already landed; this document proposes Part 2 and how it dovetails with Part 1. No business code is changed by this RFC.
+**Decision target**: agree on the *shape* of the declarative authz layer (middleware-first vs. policy-table), the migration strategy, and the eventual runtime guard — before any module is migrated.
+
+---
+
+## TL;DR
+
+1. Today every `/v1/manager` handler hand-rolls its own role check in the handler body (`c.CheckLoginRole()` / `c.CheckLoginRoleIsSuperAdmin()`, or a per-module `requireAdmin` / `requireSuperAdmin` wrapper). Part 1 added a CI guard that *catches a missing check*; it does not *remove the boilerplate* or let a reviewer see the whole privilege surface in one place. That is Part 2.
+2. **Proposal: a declarative role middleware** in `pkg/auth` — `RequireAdmin()` / `RequireSuperAdmin()` (thin wrappers over `RequireRole(min)`) — mounted **at route registration**, next to the path, *after* `AuthMiddleware`. The requirement moves from inside the handler body to the route declaration: `auth.POST("/x", authz.RequireSuperAdmin(), m.handler)`.
+3. It is **non-breaking**: same role semantics, same single generic `ErrSharedForbidden` 403 (anti-enumeration preserved), and it reads the **per-request resolved role** wired in #364, so it stays revocation-aware for free.
+4. **It already fits Part 1.** The guard's branch (b) recognizes `RequireRole` / `RequireAdmin` / `RequireSuperAdmin` by name from day one — a migrated route stays "gated" with **zero guard churn**, and the allowlist (`/v1/manager/secrets/*`, `/v1/manager/login`) is unaffected.
+5. **Migration is incremental, module-by-module.** Start with uniform-tier modules (`backup`, `opanalytics` — all `superAdmin`), then mixed-tier ones. Each migration deletes the per-module `require*` + `respond*Forbidden` boilerplate and keeps the existing "plain `admin` is rejected" regression tests green.
+6. **End state: a runtime guard supersedes the AST heuristic.** Once gates are middleware, a test can enumerate the registered router and assert every `/v1/manager` route's middleware chain contains an authz middleware — strictly stronger than the AST guard (no handler-resolution heuristics). The Part-1 AST guard stays as belt-and-braces until migration completes.
+
+---
+
+## 1. Background & current state
+
+The #363 audit found the systemic root cause: *"鉴权裸数值散落各 handler，新增端点靠开发者自觉，漏了即权限放大，无机制兜底"*. #364 fixed the specific gaps by hand (raised four destructive cross-space ops + `appversion` to `superAdmin`) and, importantly, added **per-request role resolution** so a demotion converges within a cache TTL instead of token lifetime:
+
+- `pkg/auth/parser.go` — `RoleResolver` interface + `WithRoleResolver`; `Parse` overrides the token's baked-in role with the authoritative `user_role:{uid}` value (Redis → DB → `""`), fail-open to the snapshot on resolver error.
+- `modules/user/role_service.go` — the concrete `RoleService`.
+- `main.go` — wires `auth.WithRoleResolver(userRoleSvc)` into the token parser.
+
+Part 1 (this issue) added `tools/lint-manager-authz`: an AST guard asserting every handler under `/v1/manager` performs a role check, with an allowlist for the two intentional exceptions.
+
+**Inventory the guard reports today: 108 manager routes across 13 modules, 2 allowlisted.** The four gate idioms in use:
+
+| Idiom | Tier | Example |
+|---|---|---|
+| `c.CheckLoginRole()` | admin ∪ superAdmin | `modules/message/api_manager.go` |
+| `c.CheckLoginRoleIsSuperAdmin()` | superAdmin only | `modules/backup/api_manager.go` |
+| `m.requireAdmin(c)` (wrapper) | admin ∪ superAdmin | `modules/space/api_manager.go:161` |
+| `m.requireSuperAdmin(c)` (wrapper) | superAdmin only | `modules/space/api_manager.go:174`, `modules/opanalytics/api.go:267` |
+
+All four ultimately call the same two `wkhttp.Context` methods and respond with the same `errcode.ErrSharedForbidden`. The wrappers are **duplicated per module** (`space`, `opanalytics`, … each define their own), and every handler repeats the same 3–4 line preamble:
+
+```go
+func (m *Manager) handler(c *wkhttp.Context) {
+    if err := c.CheckLoginRoleIsSuperAdmin(); err != nil { // ← boilerplate
+        respondManagerForbidden(c)                          // ← boilerplate
+        return                                              // ← boilerplate
+    }
+    // ... actual work ...
+}
+```
+
+### Problems this leaves
+
+- **Boilerplate**: ~108 copies of the same preamble; 5+ duplicated `require*` / `respond*Forbidden` helpers.
+- **No single audit surface**: to answer "which manager routes are superAdmin-only?" you must open every handler body. The requirement is not visible at the route table.
+- **Wrong-tier is invisible**: Part 1 catches a *missing* gate but cannot catch `CheckLoginRole` used where `superAdmin` was intended — that judgment is buried in the body.
+
+---
+
+## 2. Goals / non-goals
+
+**Goals**
+- Move the role requirement to the **route registration site**, declaratively.
+- One shared implementation; delete the per-module wrappers.
+- Preserve exact behavior: same tiers, same single generic 403, revocation-aware via the #364 resolver.
+- Make the privilege surface **auditable in one place** (the route tables, and eventually a runtime enumeration test).
+- Stay inside octo-server (no octo-lib release): the middleware builds on `wkhttp.Context` methods that already exist.
+
+**Non-goals (explicitly out of scope here)**
+- Changing any route path or role tier (that was #364's job; this is a pure refactor of *where the check lives*).
+- A general RBAC/permission system, scopes, or per-resource ACLs.
+- Migrating non-manager privileged surfaces (e.g. the one `/v1/common` write #363 mentioned) — can adopt the same middleware later; the guard's prefix list is already extensible.
+- Retiring the Part-1 AST guard (kept until the runtime guard fully covers migration).
+
+---
+
+## 3. Proposed design
+
+### 3.1 The middleware (primary mechanism)
+
+A new file `pkg/auth/authz.go` exposing role-enforcing middleware that returns `wkhttp.HandlerFunc`:
+
+```go
+package auth
+
+import (
+    "github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+    "github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+    "github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+)
+
+// RequireAdmin gates a route to the admin ∪ superAdmin tier. Mount AFTER
+// AuthMiddleware (it reads the per-request resolved role off the context).
+// On failure it writes the same generic ErrSharedForbidden 403 the in-handler
+// checks use — no "needs higher role" leak (anti-enumeration) — and aborts the
+// chain so the handler never runs.
+func RequireAdmin() wkhttp.HandlerFunc {
+    return func(c *wkhttp.Context) {
+        if err := c.CheckLoginRole(); err != nil {
+            httperr.ResponseErrorL(c, errcode.ErrSharedForbidden, nil, nil)
+            c.Abort()
+            return
+        }
+        c.Next()
+    }
+}
+
+// RequireSuperAdmin gates a route to superAdmin only (cross-space destructive /
+// supply-chain-sensitive writes). Same response + abort contract as above.
+func RequireSuperAdmin() wkhttp.HandlerFunc {
+    return func(c *wkhttp.Context) {
+        if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
+            httperr.ResponseErrorL(c, errcode.ErrSharedForbidden, nil, nil)
+            c.Abort()
+            return
+        }
+        c.Next()
+    }
+}
+```
+
+> A single `RequireRole(min Role)` core with the two as thin wrappers is equivalent; the two-function form is proposed because the codebase only has two tiers and explicit names read better at the call site. The Part-1 guard recognizes all three names.
+
+Because the check delegates to `c.CheckLoginRole*`, which read the role that `CacheTokenParser.Parse` already resolved per request (#364), the middleware is **revocation-aware with no extra wiring**.
+
+### 3.2 Mounting at registration
+
+**Per-route** (the default, because most manager groups mix tiers — reads at `admin`, writes at `superAdmin`):
+
+```go
+auth := r.Group("/v1/manager", m.ctx.AuthMiddleware(r))
+{
+    auth.GET("/spaces", authz.RequireAdmin(), m.list)                  // read → admin
+    auth.DELETE("/spaces/:space_id", authz.RequireSuperAdmin(), m.forceDisband) // destructive → superAdmin
+}
+```
+
+**Group-level** where every route shares one floor (e.g. `backup` and `opanalytics` are uniformly `superAdmin`):
+
+```go
+auth := r.Group("/v1/manager",
+    m.ctx.AuthMiddleware(r),
+    authz.RequireSuperAdmin(), // every route below requires superAdmin
+)
+```
+
+The handler bodies lose their preamble entirely:
+
+```go
+func (m *Manager) forceDisband(c *wkhttp.Context) {
+    // role already enforced by RequireSuperAdmin() middleware
+    spaceID := c.Param("space_id")
+    // ... work ...
+}
+```
+
+### 3.3 Ordering constraint (must document + assert)
+
+The middleware reads the **resolved role off the request context**, which only exists after `AuthMiddleware` has run. It **must** be mounted *after* `AuthMiddleware` — exactly the same constraint `SharedUIDRateLimiter` already documents (CLAUDE.md › Rate Limiting). Mounted before, the role is empty and the middleware fails *closed* (always 403) — safe, but a broken route. Mitigations:
+
+- Convention + doc comment on the middleware (as above).
+- Optional: a tiny boot-time/registration assertion (or extend the Part-1 guard) that an authz middleware never appears earlier in a group's chain than `AuthMiddleware`.
+
+### 3.4 Why middleware-first (and what about a policy table?)
+
+A **policy table** (a central `map[routeKey]Role` validated at startup) was floated in the issue. Trade-offs:
+
+| | Middleware at registration | Central policy table |
+|---|---|---|
+| Requirement lives next to the route | ✅ yes | ❌ in a separate file, can drift from the route |
+| Greppable / diff-reviewable per route | ✅ | partial |
+| Single-screen audit of all tiers | partial (read route tables) | ✅ one file |
+| Integrates with existing gin/wkhttp chain | ✅ native | needs a lookup shim middleware anyway |
+| Recognized by Part-1 guard today | ✅ (branch b) | needs new guard logic |
+
+**Recommendation: middleware-first.** It is the smallest, most idiomatic change, keeps the requirement co-located with the route, and is already wired into the Part-1 guard. A policy table can be added *later* as a pure read-model: a single `authz_routes.md` / generated table for the one-screen audit, derived from the middleware annotations — without becoming the enforcement mechanism. Enforcement should stay in the request chain.
+
+---
+
+## 4. The runtime guard (Part-2 end state)
+
+Once gates are middleware, the privilege surface becomes **introspectable at registration time** — we no longer need the AST heuristic to peek inside handler bodies. Proposed test (lives in `main` / an integration package that builds the real router):
+
+```go
+// Build the production router, enumerate registered routes, and assert every
+// /v1/manager route's middleware chain contains a recognized authz middleware
+// (or is on the documented allowlist). Strictly stronger than the AST guard:
+// it sees the actual mounted chain, not a static approximation.
+func TestEveryManagerRouteIsRoleGated(t *testing.T) {
+    routes := buildRouter().Routes() // gin exposes RoutesInfo with handler names
+    for _, rt := range routes {
+        if !strings.HasPrefix(rt.Path, "/v1/manager") || allowlisted(rt) {
+            continue
+        }
+        require.True(t, chainHasAuthz(rt), "ungated manager route: %s %s", rt.Method, rt.Path)
+    }
+}
+```
+
+> Feasibility note: gin's `RoutesInfo` reports the *final* handler name, not the full middleware chain, so `chainHasAuthz` needs either (a) a thin registration wrapper that records each route's middleware names as routes are added, or (b) tagging the authz middleware so its presence is detectable. Either is a small, well-contained addition. This is the one genuinely new piece of infrastructure Part 2 introduces and should be prototyped early.
+
+**Coexistence with Part 1.** Keep the AST guard running throughout migration (it covers the not-yet-migrated in-handler checks). When 100% of manager routes use the middleware and the runtime guard is green, the AST guard can either be retired or kept as cheap belt-and-braces (it costs nothing on CI).
+
+---
+
+## 5. Migration plan (incremental, non-breaking)
+
+Per module, in one PR each (small, reviewable, behavior-preserving):
+
+1. Replace each handler's in-body `CheckLoginRole*` / `require*` preamble with the matching route/group middleware at registration.
+2. Delete the now-unused per-module `requireAdmin` / `requireSuperAdmin` wrapper and `respond*Forbidden` helper.
+3. Keep the **existing regression tests** (e.g. `TestManager_DestructiveOpsRequireSuperAdmin` from #364, which asserts a plain `admin` gets 403) — they should pass unchanged, since the tier and the 403 are identical. This is the proof the refactor is non-breaking.
+4. No change to the Part-1 allowlist; the two genuine exceptions stay out of the middleware.
+
+**Suggested order** (lowest risk first):
+
+1. **Uniform-tier modules** → group-level middleware, biggest boilerplate win, simplest diff: `backup` (all superAdmin), `opanalytics` (all superAdmin, also drops its local `requireSuperAdmin`).
+2. **Mostly-uniform**: `robot` (one admin read + rest superAdmin), `report` (single admin route).
+3. **Mixed-tier** → per-route middleware: `space` (the biggest, with the #364 destructive ops), `message`, `common`, `workplace`, `group`, `user`, `integration`.
+
+Worked example — `backup` before/after:
+
+```go
+// before: 8 handlers each open with
+//     if err := c.CheckLoginRoleIsSuperAdmin(); err != nil { ...; return }
+auth := r.Group("/v1/manager", m.ctx.AuthMiddleware(r))
+auth.PUT("/backup/config", m.updateConfig) // + 7 more
+
+// after: one group-level gate, 8 handlers lose their preamble
+auth := r.Group("/v1/manager", m.ctx.AuthMiddleware(r), authz.RequireSuperAdmin())
+auth.PUT("/backup/config", m.updateConfig) // body no longer re-checks
+```
+
+---
+
+## 6. Risks & edge cases
+
+- **Forgotten `c.Abort()`** in the middleware → handler runs despite the 403 write. The reference impl aborts; a unit test must assert the handler is not reached on denial.
+- **Mis-ordering vs. `AuthMiddleware`** → fail-closed 403 (safe but broken). Covered by doc + the optional ordering assertion (§3.3).
+- **The two allowlisted exceptions must NOT get the middleware.** `/v1/manager/secrets/*` is user-scoped (owner = caller, not admin) and `/v1/manager/login` is pre-auth. They stay middleware-free and remain on the Part-1 allowlist.
+- **Wrong-tier review**: the migration makes the tier explicit at the route (`RequireSuperAdmin()` next to the path), which is the audit win — but the migration PRs must preserve each route's *current* tier exactly (cross-check against #364), not "tidy" them. Any tier change is a separate, signed-off decision.
+- **octo-lib boundary**: the middleware lives in octo-server `pkg/auth`; it only calls existing `wkhttp.Context` methods, so **no octo-lib release is required**.
+- **Anti-enumeration**: keep the single generic `ErrSharedForbidden`. Do not introduce a "needs superAdmin" variant — that leaks the tier of a route to an `admin` caller.
+
+---
+
+## 7. Acceptance / rollout checklist
+
+- [ ] `pkg/auth/authz.go` with `RequireAdmin` / `RequireSuperAdmin` (+ optional `RequireRole`) and unit tests (allow / deny / abort / fail-open-on-resolver-degradation parity with #364).
+- [ ] Ordering assertion (or guard extension) for authz-after-auth.
+- [ ] Runtime guard `TestEveryManagerRouteIsRoleGated` + the registration-tagging shim it needs.
+- [ ] Module migrations (one PR each), each keeping its `admin`-rejected regression green and deleting local `require*` / `respond*Forbidden`.
+- [ ] Part-1 AST guard stays green throughout (branch b already recognizes the names); allowlist unchanged.
+- [ ] (Optional) generated one-screen tier audit (`docs/authz_routes.md`).
+
+---
+
+## 8. Open questions for maintainer sign-off
+
+1. **Middleware-first vs. policy-table-first** — this RFC recommends middleware-first with an optional derived audit table. Agree?
+2. **`RequireRole(min)` core vs. two named functions** — two named functions proposed for readability; OK, or prefer the single parameterized form?
+3. **Runtime-guard mechanism** — registration-tagging shim (records middleware names per route) vs. tagging the authz middleware. Preference?
+4. **Retire vs. keep the Part-1 AST guard** after migration completes.
+5. Should the same middleware be adopted for the non-manager privileged write(s) (#363's `/v1/common` note) in the same effort, or tracked separately?

--- a/docs/2026-06-authz-centralized-layer-rfc.md
+++ b/docs/2026-06-authz-centralized-layer-rfc.md
@@ -1,7 +1,7 @@
 # RFC: Centralized Authorization Layer for Management Routes
 
 **Issue**: [#366](https://github.com/Mininglamp-OSS/octo-server/issues/366) Part 2 · follow-up to [#363](https://github.com/Mininglamp-OSS/octo-server/issues/363) audit / [#364](https://github.com/Mininglamp-OSS/octo-server/pull/364) fix
-**Status**: **Draft RFC — design proposal for maintainer review. Not yet implemented.**
+**Status**: **RFC — design decisions resolved 2026-06-14 (see §8). Not yet implemented; implementation pending go-ahead.**
 **Date**: 2026-06-14
 **Scope**: design only. Part 1 (the CI guard, `tools/lint-manager-authz`) has already landed; this document proposes Part 2 and how it dovetails with Part 1. No business code is changed by this RFC.
 **Decision target**: agree on the *shape* of the declarative authz layer (middleware-first vs. policy-table), the migration strategy, and the eventual runtime guard — before any module is migrated.
@@ -256,10 +256,19 @@ auth.PUT("/backup/config", m.updateConfig) // body no longer re-checks
 
 ---
 
-## 8. Open questions for maintainer sign-off
+## 8. Resolved decisions (2026-06-14)
 
-1. **Middleware-first vs. policy-table-first** — this RFC recommends middleware-first with an optional derived audit table. Agree?
-2. **`RequireRole(min)` core vs. two named functions** — two named functions proposed for readability; OK, or prefer the single parameterized form?
-3. **Runtime-guard mechanism** — registration-tagging shim (records middleware names per route) vs. tagging the authz middleware. Preference?
-4. **Retire vs. keep the Part-1 AST guard** after migration completes.
-5. Should the same middleware be adopted for the non-manager privileged write(s) (#363's `/v1/common` note) in the same effort, or tracked separately?
+Settled with the maintainer; the RFC above reflects these choices.
+
+1. **Enforcement mechanism → middleware at route registration.** `RequireAdmin()` / `RequireSuperAdmin()` mounted after `AuthMiddleware`, requirement co-located with the route, already recognized by the Part-1 guard. A one-screen audit table, if wanted, is a *derived read-only* view added later — not the enforcement mechanism. (Policy-table-as-enforcement was rejected: drifts from the real routes, needs new guard logic.)
+2. **Scope of the first effort → `/v1/manager` only.** The ~108 manager routes migrate now; the non-manager privileged write(s) (#363's `/v1/common appversion`, etc.) are tracked as a separate follow-up so each PR keeps a small blast radius. The Part-1 guard's prefix list stays `/v1/manager` for now.
+3. **API shape → two named middlewares** `RequireAdmin()` / `RequireSuperAdmin()` (a `RequireRole(min)` core is an internal impl detail; names read best at the call site and match the guard's recognized set).
+4. **Runtime-guard mechanism → registration-time recording.** A thin wrapper records each route's middleware names as routes are added, and the test asserts every `/v1/manager` route's recorded chain contains an authz middleware. (More general than tagging the middleware value.)
+5. **Part-1 AST guard → kept as belt-and-braces** after migration completes (costs ~nothing on CI); revisit only if it ever becomes redundant noise.
+
+### Next implementation slice (pending go-ahead)
+
+1. `pkg/auth/authz.go` — `RequireAdmin()` / `RequireSuperAdmin()` + unit tests (allow / deny / abort / resolver-degradation parity).
+2. First module migration as the pattern-setter: **`backup`** (uniformly `superAdmin`) → group-level `authz.RequireSuperAdmin()`, drop the 8 in-handler preambles, keep its regression green.
+3. The registration-recording shim + `TestEveryManagerRouteIsRoleGated`, landed once the first module proves the shape.
+

--- a/tools/lint-manager-authz/allowlist.txt
+++ b/tools/lint-manager-authz/allowlist.txt
@@ -1,0 +1,26 @@
+# Manager-route authz allowlist (lint-manager-authz, #366 Part 1).
+#
+# Routes under /v1/manager that are INTENTIONALLY not role-gated. Every entry
+# MUST carry a "# reason". Format per line:
+#
+#     <METHOD> <path>  # why this route is exempt
+#
+# METHOD may be "*" (any verb); path may end in "/*" to match a whole subtree.
+# This list is strict: an entry that no longer matches any ungated manager
+# route fails the lint as STALE, so the exceptions cannot rot. Adding a real
+# role gate to one of these routes means deleting its line here.
+#
+# Everything NOT listed here must perform a role check (c.CheckLoginRole /
+# c.CheckLoginRoleIsSuperAdmin, a require* wrapper, or an authz middleware).
+
+# User-scoped secrets CRUD: owner = the current login user (c.GetLoginUID()),
+# not an admin. These live under /v1/manager purely for path grouping; gating
+# them on admin/superAdmin would be wrong (a normal user manages their own
+# secrets). See modules/usersecret/api.go.
+* /v1/manager/secrets/*  # user-scoped CRUD, owner = current login user (not admin)
+
+# Manager login endpoint itself: mounted on the pre-auth group (no
+# AuthMiddleware), so there is no session to role-check yet. It verifies the
+# account's role against the DB record after password check. See
+# modules/user/api_manager.go (m.login).
+POST /v1/manager/login  # pre-auth login entry; role verified from DB post-auth

--- a/tools/lint-manager-authz/main.go
+++ b/tools/lint-manager-authz/main.go
@@ -1,0 +1,765 @@
+// Command lint-manager-authz is the #366 Part-1 authorization safety net. It
+// asserts that every HTTP handler mounted under a privileged route prefix
+// (`/v1/manager`) performs a role check, so a forgotten gate on a new
+// management endpoint fails CI instead of shipping as a silent privilege
+// escalation (the #364 class of bug).
+//
+// # What counts as "gated"
+//
+// A mounted manager route is considered gated if EITHER:
+//
+//	(a) its handler body contains a call to one of the in-handler role gates
+//	    — c.CheckLoginRole(), c.CheckLoginRoleIsSuperAdmin(), or a recognized
+//	    per-module wrapper (requireAdmin / requireSuperAdmin); OR
+//	(b) the route (or its group) carries a recognized declarative authz
+//	    middleware (RequireRole / RequireAdmin / RequireSuperAdmin).
+//
+// Branch (b) is wired from day one even though no such middleware exists yet:
+// it is the forward-compatibility hook for #366 Part 2 (the centralized authz
+// layer). When Part 2 lands and a module moves its check from the handler body
+// into a route middleware, this guard keeps passing with no change — the
+// allowlist only shrinks. NOTE: AuthMiddleware is authentication (identity),
+// NOT authorization (role); it is deliberately NOT in the authz-middleware set,
+// because "you are logged in" is exactly the guarantee #366 says is not enough.
+//
+// # Allowlist (intentional exceptions)
+//
+// Some routes under /v1/manager are legitimately not role-gated — e.g. the
+// user-scoped secrets CRUD (owner = the current login user, not an admin) and
+// the manager login endpoint itself (it runs before auth and verifies the role
+// from the DB record). These are enumerated in allowlist.txt with a reason.
+// The allowlist is stricter than a tolerate-count baseline: an entry that no
+// longer matches any ungated route is reported as STALE and fails the lint, so
+// the exception list cannot rot as routes gain gates or get deleted.
+//
+// # Resolution is fail-closed
+//
+// If the lint cannot resolve a route's handler to its function declaration (so
+// it cannot prove a gate is present), the route is treated as ungated. A new
+// handler shape the resolver does not understand therefore fails loudly rather
+// than slipping through unverified.
+//
+// Usage:
+//
+//	go run ./tools/lint-manager-authz [root...]
+//
+// Defaults to scanning ./modules. Test files (*_test.go) are skipped.
+//
+// Exit codes: 0 (clean), 1 (violations: ungated/unresolved route or stale
+// allowlist entry), 2 (walk/parse/baseline error).
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// allowlistRelPath lives next to this command so `go run ./tools/...` finds it
+// regardless of the working directory the CI step uses.
+const allowlistRelPath = "tools/lint-manager-authz/allowlist.txt"
+
+// managerPrefixes are the privileged route prefixes the guard enforces. A route
+// group whose path begins with one of these is in scope. Kept as a small list
+// so coverage can grow (e.g. another privileged surface) without code changes.
+var managerPrefixes = []string{"/v1/manager"}
+
+// gateSelectorNames are the method/function names that, when called inside a
+// handler body, count as an in-handler role check (branch a). The require*
+// wrappers (modules/space, modules/opanalytics) themselves delegate to
+// CheckLoginRole* — recognizing them by name avoids a full call-graph walk,
+// matching the name-based heuristic the sibling lints already use.
+var gateSelectorNames = map[string]bool{
+	"CheckLoginRole":             true,
+	"CheckLoginRoleIsSuperAdmin": true,
+	"requireAdmin":               true,
+	"requireSuperAdmin":          true,
+}
+
+// authzMiddlewareNames are the declarative role-enforcing middlewares that
+// satisfy the gate when present on a route/group (branch b). This is the #366
+// Part-2 hook: the names are reserved now so the central layer drops in without
+// touching this guard. AuthMiddleware is intentionally absent (it is authn).
+var authzMiddlewareNames = map[string]bool{
+	"RequireRole":       true,
+	"RequireAdmin":      true,
+	"RequireSuperAdmin": true,
+}
+
+// routeVerbs are the *wkhttp.WKHttp / RouterGroup registration methods whose
+// last argument is the handler.
+var routeVerbs = map[string]bool{
+	"GET": true, "POST": true, "PUT": true, "DELETE": true,
+	"PATCH": true, "HEAD": true, "OPTIONS": true, "Any": true,
+}
+
+func main() {
+	roots := os.Args[1:]
+	if len(roots) == 0 {
+		roots = []string{"modules"}
+	}
+
+	allow, err := loadAllowlist(allowlistRelPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load allowlist %q: %v\n", allowlistRelPath, err)
+		os.Exit(2)
+	}
+
+	routes, err := collectManagerRoutes(roots)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(2)
+	}
+
+	ungated, staleIdx := analyze(routes, allow)
+
+	var violations []string
+	for _, rt := range ungated {
+		violations = append(violations, rt.violation())
+	}
+	var stale []string
+	for _, i := range staleIdx {
+		stale = append(stale, fmt.Sprintf("%s (%s:%d) — matches no ungated manager route; remove it",
+			allow[i].raw, allowlistRelPath, allow[i].lineNo))
+	}
+
+	sort.Strings(violations)
+	sort.Strings(stale)
+
+	if len(violations) == 0 && len(stale) == 0 {
+		fmt.Printf("OK: %d manager route(s) scanned, all gated or allowlisted (%d allowlist entr(y/ies)).\n",
+			len(routes), len(allow))
+		return
+	}
+
+	for _, v := range violations {
+		fmt.Println("UNGATED " + v)
+	}
+	for _, s := range stale {
+		fmt.Println("STALE   " + s)
+	}
+	fmt.Println()
+	if len(violations) > 0 {
+		fmt.Printf("Found %d manager route(s) with no role check (#366).\n", len(violations))
+		fmt.Println("Add an in-handler gate (c.CheckLoginRole / c.CheckLoginRoleIsSuperAdmin, or a")
+		fmt.Println("require* wrapper), or a declarative authz middleware. If the route is")
+		fmt.Println("intentionally not role-gated (user-scoped / pre-auth), allowlist it with a")
+		fmt.Println("reason in " + allowlistRelPath + ".")
+	}
+	if len(stale) > 0 {
+		fmt.Printf("Found %d stale allowlist entr(y/ies) in %s.\n", len(stale), allowlistRelPath)
+	}
+	os.Exit(1)
+}
+
+// analyze applies the policy: every ungated route must be covered by an
+// allowlist entry, and every allowlist entry must cover at least one ungated
+// route. It returns the ungated-and-unallowlisted routes (violations) and the
+// indexes of allowlist entries that matched nothing (stale).
+func analyze(routes []route, allow []allowEntry) (violations []route, staleIdx []int) {
+	used := make([]bool, len(allow))
+	for _, rt := range routes {
+		if rt.gated {
+			continue
+		}
+		if idx := matchAllowlist(allow, rt); idx >= 0 {
+			used[idx] = true
+			continue
+		}
+		violations = append(violations, rt)
+	}
+	for i := range allow {
+		if !used[i] {
+			staleIdx = append(staleIdx, i)
+		}
+	}
+	return violations, staleIdx
+}
+
+// route is one mounted handler under a manager prefix.
+type route struct {
+	method  string // HTTP verb, or "ANY"
+	path    string // full path, e.g. /v1/manager/user/admin
+	gated   bool
+	reason  string // why ungated, when !gated (diagnostic only)
+	file    string
+	line    int
+	handler string // package.Type.method, for grep-ability
+}
+
+func (rt route) violation() string {
+	return fmt.Sprintf("%s %s  [handler %s] (%s:%d)%s",
+		rt.method, rt.path, rt.handler, rt.file, rt.line, reasonSuffix(rt.reason))
+}
+
+func reasonSuffix(reason string) string {
+	if reason == "" {
+		return ""
+	}
+	return " — " + reason
+}
+
+// collectManagerRoutes parses every package under the roots and returns all
+// routes mounted on a manager-prefixed group.
+func collectManagerRoutes(roots []string) ([]route, error) {
+	// Group .go files by directory (one Go package per dir) so a handler can be
+	// resolved even when it is declared in a different file than its route
+	// registration (e.g. modules/integration registers in api.go).
+	pkgFiles := map[string][]string{}
+	for _, root := range roots {
+		walkErr := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				if name := info.Name(); name == "vendor" || name == "testdata" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			dir := filepath.Dir(path)
+			pkgFiles[dir] = append(pkgFiles[dir], path)
+			return nil
+		})
+		if walkErr != nil {
+			return nil, fmt.Errorf("walk %q: %w", root, walkErr)
+		}
+	}
+
+	var routes []route
+	for _, files := range pkgFiles {
+		pkg, err := parsePackage(files)
+		if err != nil {
+			return nil, err
+		}
+		routes = append(routes, pkg.routes()...)
+	}
+	return routes, nil
+}
+
+// pkgScope holds the parsed files of one package plus the indexes needed to
+// resolve a handler reference to its declaration.
+type pkgScope struct {
+	fset    *token.FileSet
+	files   []*ast.File
+	paths   []string                            // parallel to files
+	methods map[string]map[string]*ast.FuncDecl // recvType -> name -> decl
+	funcs   map[string]*ast.FuncDecl            // top-level func name -> decl
+}
+
+func parsePackage(files []string) (*pkgScope, error) {
+	p := &pkgScope{
+		fset:    token.NewFileSet(),
+		methods: map[string]map[string]*ast.FuncDecl{},
+		funcs:   map[string]*ast.FuncDecl{},
+	}
+	for _, path := range files {
+		f, err := parser.ParseFile(p.fset, path, nil, 0)
+		if err != nil {
+			// go build / go vet is the canonical syntax gate; skip unparseable
+			// files rather than failing the lint on them.
+			continue
+		}
+		p.files = append(p.files, f)
+		p.paths = append(p.paths, path)
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			if recv := receiverType(fn); recv != "" {
+				if p.methods[recv] == nil {
+					p.methods[recv] = map[string]*ast.FuncDecl{}
+				}
+				p.methods[recv][fn.Name.Name] = fn
+			} else {
+				p.funcs[fn.Name.Name] = fn
+			}
+		}
+	}
+	return p, nil
+}
+
+// routes scans the package for manager-group route registrations.
+func (p *pkgScope) routes() []route {
+	var out []route
+	for i, f := range p.files {
+		path := filepath.ToSlash(p.paths[i])
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			recvVar, recvType := receiverVarType(fn)
+			groups := managerGroupsIn(fn)
+			if len(groups) == 0 {
+				continue
+			}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				recv, ok := sel.X.(*ast.Ident)
+				if !ok {
+					return true
+				}
+				g, ok := groups[recv.Name]
+				if !ok || !routeVerbs[sel.Sel.Name] {
+					return true
+				}
+				rt := p.buildRoute(g, sel.Sel.Name, call, path, recvVar, recvType)
+				if rt != nil {
+					out = append(out, *rt)
+				}
+				return true
+			})
+		}
+	}
+	return out
+}
+
+// groupInfo describes a local variable bound to a router group.
+type groupInfo struct {
+	prefix      string   // full path prefix, e.g. /v1/manager/dashboard
+	mws         []string // middleware selector names on the group (Group(...) + Use(...))
+	managerRoot bool
+}
+
+// managerGroupsIn finds local variables in fn bound to a manager-prefixed group
+// (directly or via a sub-group of one), returning var name -> groupInfo.
+func managerGroupsIn(fn *ast.FuncDecl) map[string]groupInfo {
+	groups := map[string]groupInfo{}
+	// Two passes resolve sub-groups declared before their parent in source
+	// order (rare, but cheap to be order-independent).
+	for pass := 0; pass < 2; pass++ {
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			as, ok := n.(*ast.AssignStmt)
+			if !ok || len(as.Lhs) != 1 || len(as.Rhs) != 1 {
+				return true
+			}
+			lhs, ok := as.Lhs[0].(*ast.Ident)
+			if !ok {
+				return true
+			}
+			call, ok := as.Rhs[0].(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Group" || len(call.Args) == 0 {
+				return true
+			}
+			sub := stringLit(call.Args[0])
+			if sub == "" && !isStringLit(call.Args[0]) {
+				return true
+			}
+			mws := middlewareNames(call.Args[1:])
+			// Parent: either the router (any ident) or an already-known group.
+			if base, ok := sel.X.(*ast.Ident); ok {
+				if parent, known := groups[base.Name]; known {
+					gi := groupInfo{
+						prefix:      joinPath(parent.prefix, sub),
+						mws:         append(append([]string{}, parent.mws...), mws...),
+						managerRoot: parent.managerRoot,
+					}
+					groups[lhs.Name] = gi
+					return true
+				}
+			}
+			if hasManagerPrefix(sub) {
+				groups[lhs.Name] = groupInfo{prefix: sub, mws: mws, managerRoot: true}
+			}
+			return true
+		})
+		// Fold in .Use(mw...) calls that add middleware to a known group.
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Use" {
+				return true
+			}
+			id, ok := sel.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if gi, known := groups[id.Name]; known {
+				gi.mws = append(gi.mws, middlewareNames(call.Args)...)
+				groups[id.Name] = gi
+			}
+			return true
+		})
+	}
+	// Keep only manager-rooted groups.
+	for name, gi := range groups {
+		if !gi.managerRoot {
+			delete(groups, name)
+		}
+	}
+	return groups
+}
+
+// buildRoute assembles a route from a `group.VERB(path, mws..., handler)` call.
+func (p *pkgScope) buildRoute(g groupInfo, verb string, call *ast.CallExpr, file, recvVar, recvType string) *route {
+	if len(call.Args) == 0 {
+		return nil
+	}
+	sub := stringLit(call.Args[0])
+	if !isStringLit(call.Args[0]) {
+		return nil // dynamic path — cannot reason about it
+	}
+	full := joinPath(g.prefix, sub)
+	method := verb
+	if verb == "Any" {
+		method = "ANY"
+	}
+	rt := &route{
+		method: method,
+		path:   full,
+		file:   file,
+		line:   p.fset.Position(call.Pos()).Line,
+	}
+
+	// Per-route middlewares are the args between the path and the handler.
+	var routeMWs []string
+	if len(call.Args) > 2 {
+		routeMWs = middlewareNames(call.Args[1 : len(call.Args)-1])
+	}
+	if hasAuthzMiddleware(g.mws) || hasAuthzMiddleware(routeMWs) {
+		rt.gated = true
+		rt.handler = "(authz middleware)"
+		return rt
+	}
+
+	// Otherwise inspect the handler body for an in-handler gate.
+	handler := call.Args[len(call.Args)-1]
+	decl, name, ok := p.resolveHandler(handler, recvVar, recvType)
+	rt.handler = name
+	if !ok {
+		rt.gated = false
+		rt.reason = "handler could not be resolved (fail-closed); add a gate or allowlist"
+		return rt
+	}
+	if p.handlerGated(decl) {
+		rt.gated = true
+		return rt
+	}
+	rt.gated = false
+	rt.reason = "no role check in handler (incl. delegated helpers)"
+	return rt
+}
+
+// resolveHandler maps a handler argument to its FuncDecl. Handles method values
+// (recv.Method), bare function names, and inline function literals. Returns the
+// decl, a human-readable name, and whether resolution succeeded. A FuncLit is
+// reported via a synthetic decl wrapper so the caller can scan it.
+func (p *pkgScope) resolveHandler(expr ast.Expr, recvVar, recvType string) (*ast.FuncDecl, string, bool) {
+	switch e := expr.(type) {
+	case *ast.FuncLit:
+		return &ast.FuncDecl{Body: e.Body}, "(inline func)", true
+	case *ast.Ident:
+		if fn, ok := p.funcs[e.Name]; ok {
+			return fn, e.Name, true
+		}
+		return nil, e.Name, false
+	case *ast.SelectorExpr:
+		x, ok := e.X.(*ast.Ident)
+		if !ok {
+			return nil, exprName(e), false
+		}
+		name := e.Sel.Name
+		// Same-receiver method value (the common case): recv type is known.
+		if x.Name == recvVar && recvType != "" {
+			if m, ok := p.methods[recvType]; ok {
+				if fn, ok := m[name]; ok {
+					return fn, recvType + "." + name, true
+				}
+			}
+		}
+		// Fallback: unique method with this name anywhere in the package.
+		var found *ast.FuncDecl
+		var foundType string
+		dup := false
+		for t, m := range p.methods {
+			if fn, ok := m[name]; ok {
+				if found != nil {
+					dup = true
+				}
+				found, foundType = fn, t
+			}
+		}
+		if found != nil && !dup {
+			return found, foundType + "." + name, true
+		}
+		return nil, x.Name + "." + name, false
+	default:
+		return nil, exprName(expr), false
+	}
+}
+
+// maxGateDepth bounds how far the body scan follows same-package delegation
+// when looking for a role gate. Handlers that fan a check out through one or
+// two private helpers (e.g. modules/space list -> listByStatuses ->
+// requireAdmin) are common; a cycle- and depth-guarded walk keeps the guard
+// honest without a full type-checked call graph.
+const maxGateDepth = 6
+
+// handlerGated reports whether the handler enforces a role check, either
+// directly or through a same-receiver / same-package helper it delegates to.
+func (p *pkgScope) handlerGated(fn *ast.FuncDecl) bool {
+	return p.bodyGated(fn, 0, map[string]bool{})
+}
+
+func (p *pkgScope) bodyGated(fn *ast.FuncDecl, depth int, visited map[string]bool) bool {
+	if fn == nil || fn.Body == nil || depth > maxGateDepth {
+		return false
+	}
+	recvVar, recvType := receiverVarType(fn)
+	found := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch f := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			if gateSelectorNames[f.Sel.Name] {
+				found = true
+				return false
+			}
+			// Same-receiver method delegation: recurse into the callee body.
+			if x, ok := f.X.(*ast.Ident); ok && x.Name == recvVar && recvType != "" {
+				if p.recurseGate(recvType+"."+f.Sel.Name, p.methodDecl(recvType, f.Sel.Name), depth, visited) {
+					found = true
+					return false
+				}
+			}
+		case *ast.Ident:
+			if gateSelectorNames[f.Name] {
+				found = true
+				return false
+			}
+			// Same-package free-function delegation.
+			if p.recurseGate("."+f.Name, p.funcs[f.Name], depth, visited) {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// recurseGate descends into a resolved callee once (cycle-guarded by key).
+func (p *pkgScope) recurseGate(key string, callee *ast.FuncDecl, depth int, visited map[string]bool) bool {
+	if callee == nil || visited[key] {
+		return false
+	}
+	visited[key] = true
+	return p.bodyGated(callee, depth+1, visited)
+}
+
+func (p *pkgScope) methodDecl(recvType, name string) *ast.FuncDecl {
+	if m, ok := p.methods[recvType]; ok {
+		return m[name]
+	}
+	return nil
+}
+
+// middlewareNames returns the trailing selector/ident name of each arg that is
+// a call expression (the typical `mw()` middleware-factory form).
+func middlewareNames(args []ast.Expr) []string {
+	var names []string
+	for _, a := range args {
+		if call, ok := a.(*ast.CallExpr); ok {
+			switch f := call.Fun.(type) {
+			case *ast.SelectorExpr:
+				names = append(names, f.Sel.Name)
+			case *ast.Ident:
+				names = append(names, f.Name)
+			}
+		}
+	}
+	return names
+}
+
+func hasAuthzMiddleware(names []string) bool {
+	for _, n := range names {
+		if authzMiddlewareNames[n] {
+			return true
+		}
+	}
+	return false
+}
+
+// --- small AST helpers -----------------------------------------------------
+
+func receiverType(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return ""
+	}
+	return typeName(fn.Recv.List[0].Type)
+}
+
+func receiverVarType(fn *ast.FuncDecl) (string, string) {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return "", ""
+	}
+	field := fn.Recv.List[0]
+	t := typeName(field.Type)
+	if len(field.Names) == 0 {
+		return "", t
+	}
+	return field.Names[0].Name, t
+}
+
+// typeName returns the bare type name for `T` or `*T`.
+func typeName(e ast.Expr) string {
+	switch t := e.(type) {
+	case *ast.StarExpr:
+		return typeName(t.X)
+	case *ast.Ident:
+		return t.Name
+	}
+	return ""
+}
+
+func isStringLit(e ast.Expr) bool {
+	bl, ok := e.(*ast.BasicLit)
+	return ok && bl.Kind == token.STRING
+}
+
+func stringLit(e ast.Expr) string {
+	bl, ok := e.(*ast.BasicLit)
+	if !ok || bl.Kind != token.STRING {
+		return ""
+	}
+	return strings.Trim(bl.Value, "`\"")
+}
+
+func exprName(e ast.Expr) string {
+	switch t := e.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.SelectorExpr:
+		return exprName(t.X) + "." + t.Sel.Name
+	}
+	return "<expr>"
+}
+
+func hasManagerPrefix(p string) bool {
+	for _, pre := range managerPrefixes {
+		if p == pre || strings.HasPrefix(p, pre+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// joinPath joins a group prefix with a route sub-path, normalizing slashes the
+// way the router does (a missing leading slash on the sub-path is inserted).
+func joinPath(prefix, sub string) string {
+	prefix = strings.TrimRight(prefix, "/")
+	if sub == "" {
+		return prefix
+	}
+	if !strings.HasPrefix(sub, "/") {
+		sub = "/" + sub
+	}
+	return prefix + sub
+}
+
+// --- allowlist -------------------------------------------------------------
+
+type allowEntry struct {
+	method string // "*" or an HTTP verb / "ANY"
+	path   string // exact, or a "/*"-suffixed prefix
+	raw    string
+	lineNo int
+}
+
+// matchAllowlist returns the index of the first entry matching rt, or -1.
+func matchAllowlist(allow []allowEntry, rt route) int {
+	for i, e := range allow {
+		if e.method != "*" && !strings.EqualFold(e.method, rt.method) {
+			continue
+		}
+		if strings.HasSuffix(e.path, "/*") {
+			base := strings.TrimSuffix(e.path, "/*")
+			if rt.path == base || strings.HasPrefix(rt.path, base+"/") {
+				return i
+			}
+			continue
+		}
+		if e.path == rt.path {
+			return i
+		}
+	}
+	return -1
+}
+
+// loadAllowlist parses allowlist.txt. Format per line: "<METHOD> <path>"
+// followed by a required "# reason". Blank lines and full-line comments are
+// ignored. METHOD may be "*" (any verb); path may end in "/*" (prefix match).
+func loadAllowlist(path string) ([]allowEntry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var entries []allowEntry
+	sc := bufio.NewScanner(f)
+	lineNo := 0
+	for sc.Scan() {
+		lineNo++
+		raw := strings.TrimSpace(sc.Text())
+		if raw == "" || strings.HasPrefix(raw, "#") {
+			continue
+		}
+		body := raw
+		if i := strings.Index(body, "#"); i >= 0 {
+			// A reason comment is mandatory: an exception with no documented
+			// justification is exactly what this guard exists to prevent.
+			if strings.TrimSpace(body[i+1:]) == "" {
+				return nil, fmt.Errorf("allowlist line %d: empty reason after '#': %q", lineNo, raw)
+			}
+			body = strings.TrimSpace(body[:i])
+		} else {
+			return nil, fmt.Errorf("allowlist line %d: missing '# reason': %q", lineNo, raw)
+		}
+		fields := strings.Fields(body)
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("allowlist line %d: want '<METHOD> <path>  # reason', got %q", lineNo, raw)
+		}
+		entries = append(entries, allowEntry{
+			method: fields[0],
+			path:   fields[1],
+			raw:    raw,
+			lineNo: lineNo,
+		})
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}

--- a/tools/lint-manager-authz/main_test.go
+++ b/tools/lint-manager-authz/main_test.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, name, src string) {
+	t.Helper()
+	full := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// routesByKey indexes collected routes by "METHOD path" for assertions.
+func routesByKey(rs []route) map[string]route {
+	m := map[string]route{}
+	for _, r := range rs {
+		m[r.method+" "+r.path] = r
+	}
+	return m
+}
+
+// TestCollectRoutes_Gating exercises every gate-recognition path the guard
+// supports: direct CheckLoginRole*, require* wrappers, one-hop delegation, a
+// declarative authz middleware on the group, sub-group prefixing, an ungated
+// handler, and prefix scoping (a non-manager group is ignored).
+func TestCollectRoutes_Gating(t *testing.T) {
+	dir := t.TempDir()
+
+	// Direct in-handler gates + a require* wrapper + delegation, all in one
+	// package (so cross-method resolution within a package is covered).
+	writeFile(t, dir, "modules/direct/api.go", `package direct
+type Manager struct{}
+func (m *Manager) Route(r *R) {
+	auth := r.Group("/v1/manager", m.authMW())
+	auth.GET("/a", m.gatedAdmin)
+	auth.POST("/b", m.gatedSuper)
+	auth.GET("/c", m.viaWrapper)
+	auth.GET("/d", m.viaDelegate)
+	auth.DELETE("/e", m.ungated)
+}
+func (m *Manager) gatedAdmin(c *C) { _ = c.CheckLoginRole() }
+func (m *Manager) gatedSuper(c *C) { _ = c.CheckLoginRoleIsSuperAdmin() }
+func (m *Manager) viaWrapper(c *C) { if !m.requireAdmin(c) { return } }
+func (m *Manager) viaDelegate(c *C) { m.impl(c) }
+func (m *Manager) impl(c *C) { if !m.requireSuperAdmin(c) { return }; _ = c }
+func (m *Manager) ungated(c *C) { _ = c.Query("x") }
+`)
+
+	// Sub-group prefix (/v1/manager/dashboard) + authz middleware (branch b),
+	// whose handler body has NO in-handler gate yet is still gated.
+	writeFile(t, dir, "modules/sub/api.go", `package sub
+type Mgr struct{}
+func (m *Mgr) Route(r *R) {
+	g := r.Group("/v1/manager/dashboard", m.authMW(), m.RequireSuperAdmin())
+	g.GET("/overview", m.overview)
+}
+func (m *Mgr) overview(c *C) { _ = c.Query("x") } // no in-body gate; middleware gates it
+`)
+
+	// A non-manager group must be ignored entirely.
+	writeFile(t, dir, "modules/other/api.go", `package other
+type API struct{}
+func (a *API) Route(r *R) {
+	g := r.Group("/v1/foo", a.authMW())
+	g.GET("/bar", a.bar)
+}
+func (a *API) bar(c *C) { _ = c.Query("x") }
+`)
+
+	routes, err := collectManagerRoutes([]string{filepath.Join(dir, "modules")})
+	if err != nil {
+		t.Fatalf("collectManagerRoutes: %v", err)
+	}
+	by := routesByKey(routes)
+
+	want := map[string]bool{ // key -> expected gated
+		"GET /v1/manager/a":                  true,  // CheckLoginRole
+		"POST /v1/manager/b":                 true,  // CheckLoginRoleIsSuperAdmin
+		"GET /v1/manager/c":                  true,  // requireAdmin wrapper
+		"GET /v1/manager/d":                  true,  // delegated to impl -> requireSuperAdmin
+		"DELETE /v1/manager/e":               false, // genuinely ungated
+		"GET /v1/manager/dashboard/overview": true,  // authz middleware (branch b)
+	}
+	for key, wantGated := range want {
+		rt, ok := by[key]
+		if !ok {
+			t.Fatalf("route %q not collected; got %v", key, keys(by))
+		}
+		if rt.gated != wantGated {
+			t.Errorf("route %q gated=%v, want %v (reason=%q handler=%q)", key, rt.gated, wantGated, rt.reason, rt.handler)
+		}
+	}
+	if _, ok := by["GET /v1/foo/bar"]; ok {
+		t.Errorf("non-manager route /v1/foo/bar must not be collected")
+	}
+	if len(routes) != len(want) {
+		t.Errorf("collected %d routes, want %d: %v", len(routes), len(want), keys(by))
+	}
+}
+
+func keys(m map[string]route) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestAnalyze covers the violation / stale-allowlist decision, including the
+// two acceptance criteria: a new ungated route fails, and an allowlist entry
+// that covers nothing is reported stale.
+func TestAnalyze(t *testing.T) {
+	routes := []route{
+		{method: "GET", path: "/v1/manager/a", gated: true},
+		{method: "DELETE", path: "/v1/manager/e", gated: false},      // ungated, not allowlisted
+		{method: "POST", path: "/v1/manager/login", gated: false},    // ungated, exact-allowlisted
+		{method: "GET", path: "/v1/manager/secrets", gated: false},   // ungated, wildcard-allowlisted
+		{method: "PUT", path: "/v1/manager/secrets/x", gated: false}, // ungated, wildcard-allowlisted
+	}
+	allow := []allowEntry{
+		{method: "POST", path: "/v1/manager/login"},
+		{method: "*", path: "/v1/manager/secrets/*"},
+		{method: "GET", path: "/v1/manager/gone"}, // matches nothing -> stale
+	}
+
+	violations, staleIdx := analyze(routes, allow)
+
+	if len(violations) != 1 || violations[0].path != "/v1/manager/e" {
+		t.Fatalf("violations=%v, want exactly the ungated /v1/manager/e", violations)
+	}
+	if len(staleIdx) != 1 || allow[staleIdx[0]].path != "/v1/manager/gone" {
+		t.Fatalf("staleIdx=%v, want exactly the unused /v1/manager/gone entry", staleIdx)
+	}
+}
+
+func TestMatchAllowlist(t *testing.T) {
+	allow := []allowEntry{
+		{method: "POST", path: "/v1/manager/login"},
+		{method: "*", path: "/v1/manager/secrets/*"},
+	}
+	cases := []struct {
+		method, path string
+		wantIdx      int
+	}{
+		{"POST", "/v1/manager/login", 0},
+		{"GET", "/v1/manager/login", -1},         // method mismatch
+		{"GET", "/v1/manager/secrets", 1},        // wildcard base (no trailing segment)
+		{"DELETE", "/v1/manager/secrets/abc", 1}, // wildcard subtree, any method
+		{"GET", "/v1/manager/secretsX", -1},      // must not match sibling prefix
+		{"GET", "/v1/manager/other", -1},
+	}
+	for _, tc := range cases {
+		got := matchAllowlist(allow, route{method: tc.method, path: tc.path})
+		if got != tc.wantIdx {
+			t.Errorf("matchAllowlist(%s %s)=%d, want %d", tc.method, tc.path, got, tc.wantIdx)
+		}
+	}
+}
+
+func TestLoadAllowlist(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "allowlist.txt")
+	writeFile(t, dir, "allowlist.txt", `# header comment
+
+POST /v1/manager/login  # pre-auth entry
+* /v1/manager/secrets/*  # user-scoped
+`)
+	entries, err := loadAllowlist(path)
+	if err != nil {
+		t.Fatalf("loadAllowlist: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("entries=%d, want 2 (comment + blank ignored)", len(entries))
+	}
+	if entries[0].method != "POST" || entries[0].path != "/v1/manager/login" {
+		t.Errorf("entry0=%+v", entries[0])
+	}
+	if entries[1].method != "*" || entries[1].path != "/v1/manager/secrets/*" {
+		t.Errorf("entry1=%+v", entries[1])
+	}
+}
+
+func TestLoadAllowlist_Errors(t *testing.T) {
+	cases := map[string]string{
+		"missing reason":  "POST /v1/manager/login\n",
+		"empty reason":    "POST /v1/manager/login  #   \n",
+		"too few fields":  "/v1/manager/login  # reason\n",
+		"too many fields": "POST /v1/manager/login extra  # reason\n",
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "allowlist.txt")
+			writeFile(t, dir, "allowlist.txt", body)
+			if _, err := loadAllowlist(path); err == nil {
+				t.Fatalf("expected error for %q, got nil", body)
+			}
+		})
+	}
+}
+
+// TestResolutionFailClosed: a handler the resolver cannot map to a declaration
+// (here, a method on an unknown/imported value) must be reported ungated so it
+// cannot slip through unverified.
+func TestResolutionFailClosed(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "modules/x/api.go", `package x
+type API struct{ ext otherpkg.Handlers }
+func (a *API) Route(r *R) {
+	g := r.Group("/v1/manager", a.authMW())
+	g.GET("/y", a.ext.Foreign) // a.ext is not a known same-package receiver
+}
+`)
+	routes, err := collectManagerRoutes([]string{filepath.Join(dir, "modules")})
+	if err != nil {
+		t.Fatalf("collectManagerRoutes: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("routes=%d, want 1", len(routes))
+	}
+	if routes[0].gated {
+		t.Errorf("unresolved handler must be treated as ungated (fail-closed), got gated=true")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #366. Authorization on management endpoints is enforced as bare role checks scattered across handler bodies, with no central policy and no safety net — a new `/v1/manager` endpoint that forgets its `CheckLoginRole` / `CheckLoginRoleIsSuperAdmin` call is a silent privilege escalation that nothing catches (the #364 class of bug, fixed there by hand). This PR delivers both parts the issue tracks:

- **Part 1 (implemented): a CI guard** that turns "did the dev remember the gate?" into a mechanical gate.
- **Part 2 (design proposal): an RFC** for the centralized authz layer, with the §8 design decisions resolved.

## Part 1 — `tools/lint-manager-authz` (CI guard)

An AST guard (mirroring `lint-direct-error-response` / `lint-personal-msgsendreq`) asserting **every handler mounted under `/v1/manager` performs a role check**. A route is "gated" if either:

- **(a)** its handler body — or a same-package helper it delegates to (bounded, cycle-guarded) — calls `CheckLoginRole`, `CheckLoginRoleIsSuperAdmin`, or a `require*` wrapper; **or**
- **(b)** the route/group carries a recognized declarative authz middleware (`RequireRole` / `RequireAdmin` / `RequireSuperAdmin`).

Branch (b) is the forward-compat hook for Part 2: moving a check from handler body into a route middleware keeps the guard green with no change. `AuthMiddleware` is deliberately **not** treated as a gate — it is authentication, not authorization.

Design notes:
- **Fail-closed**: a route whose handler can't be resolved is treated as ungated, so an unfamiliar shape fails loudly rather than slipping through unverified.
- **Strict allowlist**: intentional exceptions live in `allowlist.txt` with a mandatory reason; an entry that matches no ungated route is reported **STALE** and fails the lint, so the exception list can't rot. Seeded with the two real exceptions: the user-scoped `/v1/manager/secrets/*` CRUD (owner = caller, not admin) and the pre-auth `/v1/manager/login` entry.
- During development the guard surfaced a real delegation pattern (`space` `list`/`disableList` → `listByStatuses` → `requireAdmin`); the body scan was upgraded to bounded transitive resolution to avoid that false positive.

Wiring: `make authz-lint` target + a dedicated **Manager Authz Lint** CI job.

## Part 2 — `docs/2026-06-authz-centralized-layer-rfc.md` (design proposal)

RFC proposing the centralized authz layer: a declarative role middleware (`RequireAdmin()` / `RequireSuperAdmin()` in `pkg/auth`) mounted at route registration after `AuthMiddleware`, moving the requirement out of the handler body. Non-breaking (same tiers, same generic `ErrSharedForbidden` 403, revocation-aware via the #364 resolver), already recognized by the Part-1 guard, with an incremental module-by-module migration plan and an eventual registration-time runtime guard.

**Resolved §8 decisions:** middleware-at-registration enforcement (not a policy table); `/v1/manager`-only first scope; two named middlewares; registration-time runtime guard; keep the Part-1 AST guard as belt-and-braces.

> The Part-2 *implementation* (the middleware + per-module migration) is beyond #366's acceptance (Part 2 = design proposal) and will land as separate follow-up PR(s) per the RFC.

## Test plan

- `go run ./tools/lint-manager-authz` (and `make authz-lint`): green — **108 manager routes scanned, all gated or allowlisted, 2 allowlist entries**.
- Adversarial check: a throwaway ungated `/v1/manager` route makes the guard exit 1 with a precise `file:line` + handler message; removing it returns to green.
- `go test ./tools/lint-manager-authz/`: covers each gate path (direct / `require*` wrapper / one-hop delegation / authz middleware / sub-group prefix / genuinely ungated / fail-closed), allowlist parsing (incl. mandatory-reason errors), and the violation-and-stale decision.
- `gofmt`, `go vet` clean; `tools/workflow-guards` test unaffected by the new CI job.

## Acceptance criteria (#366)

- [x] Part 1: CI guard exists and passes on the branch; a new ungated `/v1/manager` route fails CI; intentional exceptions are allowlisted with a reason.
- [x] Part 2: design proposal for the central authz layer (decisions resolved in §8).

https://claude.ai/code/session_01G8ocbvm4BTcTUfyehwYB12

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8ocbvm4BTcTUfyehwYB12)_