### PR TITLE
feat(manager): refine superAdmin/admin read gates + add /v1/manager/me capability map

### DIFF
--- a/modules/common/api_manager_system_setting.go
+++ b/modules/common/api_manager_system_setting.go
@@ -68,11 +68,11 @@ type systemSettingGetResp struct {
 
 // listSystemSettings handles GET /v1/manager/common/system_setting.
 //
-// Read access uses CheckLoginRole — any authenticated admin can view the
-// effective config (encrypted columns are masked). Writes require
-// SuperAdmin (see updateSystemSettings).
+// Read access requires SuperAdmin — the system configuration surface is
+// SuperAdmin-only for both read and write (encrypted columns are masked
+// regardless). Writes also require SuperAdmin (see updateSystemSettings).
 func (m *Manager) listSystemSettings(c *wkhttp.Context) {
-	if err := c.CheckLoginRole(); err != nil {
+	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
 		c.ResponseError(err)
 		return
 	}

--- a/modules/common/api_manager_system_setting_test.go
+++ b/modules/common/api_manager_system_setting_test.go
@@ -165,6 +165,29 @@ func TestManagerSystemSetting_UpdateRequiresSuperAdmin(t *testing.T) {
 	assert.NotEqual(t, http.StatusOK, w.Code, "non-superAdmin must not be able to write")
 }
 
+// TestManagerSystemSetting_ListRequiresSuperAdmin pins the read-side gate: the
+// system configuration surface is SuperAdmin-only for read as well as write, so
+// a plain admin token (which passes CheckLoginRole but not
+// CheckLoginRoleIsSuperAdmin) must be rejected on GET.
+func TestManagerSystemSetting_ListRequiresSuperAdmin(t *testing.T) {
+	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	// admin (not superAdmin) — previously allowed to read, now rejected.
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.Admin),
+	))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/manager/common/system_setting", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.NotEqual(t, http.StatusOK, w.Code, "admin must not be able to read system settings (superAdmin only)")
+}
+
 func TestManagerSystemSetting_UpdateRejectsUnknownKey(t *testing.T) {
 	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
 	s, ctx := testutil.NewTestServer()

--- a/modules/opanalytics/api.go
+++ b/modules/opanalytics/api.go
@@ -272,8 +272,10 @@ func (m *Manager) requireSuperAdmin(c *wkhttp.Context) bool {
 	return true
 }
 
-// requireAdmin 放行 admin∪superAdmin，用于看板只读端点。看板是 admin 已有的跨
-// space 读面（用户/群/空间列表）的聚合视图，放给 admin 一致；手动触发类写操作
+// requireAdmin 放行 admin∪superAdmin，用于看板只读端点。看板读面不比 admin 已有的
+// 访问更敏感：含私聊元数据的 globalDirectChats 也只是"谁跟谁聊过、几条、何时"，而 admin
+// 经 message 模块的 recordpersonal/record 早已能读任意 (uid,touid) 的私聊正文，元数据
+// 严格更弱；用户/群/空间列表同样早是 admin 读面。故放给 admin 一致；手动触发类写操作
 // （runETL）仍走 requireSuperAdmin。
 func (m *Manager) requireAdmin(c *wkhttp.Context) bool {
 	if err := c.CheckLoginRole(); err != nil {

--- a/modules/opanalytics/api.go
+++ b/modules/opanalytics/api.go
@@ -68,7 +68,7 @@ func (m *Manager) Route(r *wkhttp.WKHttp) {
 
 // overview 模块A 概览(私聊只出活跃数)。
 func (m *Manager) overview(c *wkhttp.Context) {
-	if !m.requireSuperAdmin(c) {
+	if !m.requireAdmin(c) {
 		return
 	}
 	start, end, ok := parseDateRange(c)
@@ -87,7 +87,7 @@ func (m *Manager) overview(c *wkhttp.Context) {
 
 // trend 模块C 趋势(day/week，缺桶补 0)。
 func (m *Manager) trend(c *wkhttp.Context) {
-	if !m.requireSuperAdmin(c) {
+	if !m.requireAdmin(c) {
 		return
 	}
 	start, end, ok := parseDateRange(c)
@@ -111,7 +111,7 @@ func (m *Manager) trend(c *wkhttp.Context) {
 
 // spaces 表一 Space 列表。
 func (m *Manager) spaces(c *wkhttp.Context) {
-	if !m.requireSuperAdmin(c) {
+	if !m.requireAdmin(c) {
 		return
 	}
 	start, end, ok := parseDateRange(c)
@@ -133,7 +133,7 @@ func (m *Manager) spaces(c *wkhttp.Context) {
 
 // spaceChannels 表二 群组列表(仅群组，私聊不进表二)。
 func (m *Manager) spaceChannels(c *wkhttp.Context) {
-	if !m.requireSuperAdmin(c) {
+	if !m.requireAdmin(c) {
 		return
 	}
 	spaceID := c.Param("space_id")
@@ -175,7 +175,7 @@ func (m *Manager) spaceChannels(c *wkhttp.Context) {
 
 // channelMembers 表三子表A：会话内成员消息统计汇总。
 func (m *Manager) channelMembers(c *wkhttp.Context) {
-	if !m.requireSuperAdmin(c) {
+	if !m.requireAdmin(c) {
 		return
 	}
 	channelID := c.Param("channel_id")
@@ -217,7 +217,7 @@ func (m *Manager) channelMembers(c *wkhttp.Context) {
 
 // globalDirectChats 全局私聊活跃列表(无活跃状态筛选；私聊恒活跃集)。
 func (m *Manager) globalDirectChats(c *wkhttp.Context) {
-	if !m.requireSuperAdmin(c) {
+	if !m.requireAdmin(c) {
 		return
 	}
 	start, end, ok := parseDateRange(c)
@@ -266,6 +266,17 @@ func (m *Manager) runETL(c *wkhttp.Context) {
 
 func (m *Manager) requireSuperAdmin(c *wkhttp.Context) bool {
 	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
+		respForbidden(c)
+		return false
+	}
+	return true
+}
+
+// requireAdmin 放行 admin∪superAdmin，用于看板只读端点。看板是 admin 已有的跨
+// space 读面（用户/群/空间列表）的聚合视图，放给 admin 一致；手动触发类写操作
+// （runETL）仍走 requireSuperAdmin。
+func (m *Manager) requireAdmin(c *wkhttp.Context) bool {
+	if err := c.CheckLoginRole(); err != nil {
 		respForbidden(c)
 		return false
 	}

--- a/modules/opanalytics/api_test.go
+++ b/modules/opanalytics/api_test.go
@@ -78,6 +78,13 @@ func setPlainUserToken(t *testing.T, ctx *config.Context) {
 		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token, testutil.UID+"@test"))
 }
 
+func setAdminToken(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.Admin)))
+}
+
 func shardTables(ctx *config.Context) []string {
 	count := ctx.GetConfig().TablePartitionConfig.MessageTableCount
 	if count <= 0 {
@@ -1024,6 +1031,26 @@ func TestOpanalyticsManualETLRunForbiddenAndAlreadyRunning(t *testing.T) {
 	acquired, err = lock.Acquire("second-token")
 	require.NoError(t, err)
 	assert.False(t, acquired, "already-running path must not drop or replace the held lock")
+}
+
+// TestOpanalyticsDashboardReadAdminTriggerSuperAdmin pins the split role policy:
+// the read-only dashboard endpoints accept admin∪superAdmin, while the manual
+// ETL trigger stays superAdmin-only.
+func TestOpanalyticsDashboardReadAdminTriggerSuperAdmin(t *testing.T) {
+	ctx, route := opaRouteOnlySetup(t)
+	rng := "?start_date=2026-06-01&end_date=2026-06-02"
+
+	setAdminToken(t, ctx)
+	// admin passes the read gate (it must NOT be rejected for role; the query
+	// itself may then succeed or fail on data, neither of which is forbidden).
+	rec := opaGet(t, route, "/v1/manager/dashboard/overview"+rng)
+	assert.NotEqual(t, "err.server.opanalytics.forbidden", errorCode(t, rec),
+		"admin must pass the dashboard read gate")
+
+	// admin must NOT trigger the ETL — that stays superAdmin-only.
+	rec = opaPost(t, route, "/v1/manager/dashboard/etl/run")
+	assert.Equal(t, "err.server.opanalytics.forbidden", errorCode(t, rec),
+		"manual ETL trigger must stay superAdmin-only")
 }
 
 func TestETLLockRenewRequiresMatchingToken(t *testing.T) {

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -116,21 +116,33 @@ func (m *Manager) me(c *wkhttp.Context) {
 // 已通过 CheckLoginRole（admin∪superAdmin），故 admin 档位项恒 true；superAdmin
 // 专属项取 isSuper。键名是与前端的稳定约定。
 //
+// 读/写分档：凡是某个领域里读端点 admin 可达、但写/销毁端点要 superAdmin 的，都拆成
+// `<域>.read`（恒 true）与 `<域>.write`（isSuper），避免前端拿单一粗标志去渲染会被后端
+// 403 的写按钮（confused-deputy UI）。当前已按各端点真实 gate 拆分：
+//   - users.read   = list/friends/blacklist/disableUsers/devices/online（CheckLoginRole）
+//   - users.write  = resetUserPassword/addUser/liftBanUser/updatePwd（CheckLoginRoleIsSuperAdmin）
+//   - users.manage_admin = get/add/delete 管理员账号（CheckLoginRoleIsSuperAdmin）
+//   - groups.read  = list/disablelist/members/blacklist（CheckLoginRole）
+//   - groups.write = leftbangroup/forbidden/removeMember（CheckLoginRoleIsSuperAdmin）
+//
 // TODO(#366 Part 2): 目前这张表按各端点当前档位手工维护；集中式 authz 策略表落地
 // 后，应改为由同一份 route→role 真源派生，彻底消除前后端漂移。
 func managerCapabilities(isSuper bool) map[string]bool {
 	return map[string]bool{
 		// superAdmin 专属
-		"system_setting":    isSuper, // 系统配置：读写均超管
-		"backup":            isSuper, // 备份管理：读写均超管
-		"appversion.write":  isSuper, // 版本发布 / 下载源设置
-		"dashboard.trigger": isSuper, // 手动触发 ETL
-		"space.destructive": isSuper, // 强制解散/封禁/强制移除/改成员角色
+		"system_setting":     isSuper, // 系统配置：读写均超管
+		"backup":             isSuper, // 备份管理：读写均超管
+		"appversion.write":   isSuper, // 版本发布 / 下载源设置
+		"dashboard.trigger":  isSuper, // 手动触发 ETL
+		"space.destructive":  isSuper, // 强制解散/封禁/强制移除/改成员角色
+		"users.write":        isSuper, // 重置密码 / 新增用户 / 解封 / 改密
+		"users.manage_admin": isSuper, // 管理员账号 增/查/删
+		"groups.write":       isSuper, // 解散封禁群 / 强制移除成员
 		// admin ∪ superAdmin（此处恒 true，列出供前端统一读取）
 		"appversion.read": true, // 版本列表
 		"dashboard.read":  true, // 运营看板查看
-		"users":           true, // 用户管理
-		"groups":          true, // 群组管理
+		"users.read":      true, // 用户列表 / 好友 / 黑名单 / 禁用 / 设备 / 在线
+		"groups.read":     true, // 群组列表 / 禁用群 / 群成员 / 群黑名单
 		"space.read":      true, // 空间查看 / 列表
 	}
 }

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -116,14 +116,19 @@ func (m *Manager) me(c *wkhttp.Context) {
 // 已通过 CheckLoginRole（admin∪superAdmin），故 admin 档位项恒 true；superAdmin
 // 专属项取 isSuper。键名是与前端的稳定约定。
 //
-// 读/写分档：凡是某个领域里读端点 admin 可达、但写/销毁端点要 superAdmin 的，都拆成
-// `<域>.read`（恒 true）与 `<域>.write`（isSuper），避免前端拿单一粗标志去渲染会被后端
-// 403 的写按钮（confused-deputy UI）。当前已按各端点真实 gate 拆分：
+// 读/写分档：每个能力键按该组操作的真实 gate 取值——admin 可达的读/写恒 true，
+// superAdmin 专属的写/销毁取 isSuper——既避免前端拿单一粗标志去渲染会被后端 403 的
+// 写按钮（confused-deputy UI），也避免反过来把 admin 实际能做的操作藏掉。注意有的域
+// 是三档（读=admin、写=admin、销毁=superAdmin，如 space），不要漏掉 admin 写这一档。
+// 当前已按各端点真实 gate 拆分：
 //   - users.read   = list/friends/blacklist/disableUsers/devices/online（CheckLoginRole）
 //   - users.write  = resetUserPassword/addUser/liftBanUser/updatePwd（CheckLoginRoleIsSuperAdmin）
 //   - users.manage_admin = get/add/delete 管理员账号（CheckLoginRoleIsSuperAdmin）
 //   - groups.read  = list/disablelist/members/blacklist（CheckLoginRole）
 //   - groups.write = leftbangroup/forbidden/removeMember（CheckLoginRoleIsSuperAdmin）
+//   - space.read        = 空间/成员/邀请/入群申请 列表查询（requireAdmin）
+//   - space.write       = 建空间/改资料/加成员/邀请增改禁用/通过拒绝入群申请（requireAdmin，故恒 true）
+//   - space.destructive = 强制解散/封禁/强制移除/改成员角色（requireSuperAdmin）
 //
 // TODO(#366 Part 2): 目前这张表按各端点当前档位手工维护；集中式 authz 策略表落地
 // 后，应改为由同一份 route→role 真源派生，彻底消除前后端漂移。
@@ -144,6 +149,7 @@ func managerCapabilities(isSuper bool) map[string]bool {
 		"users.read":      true, // 用户列表 / 好友 / 黑名单 / 禁用 / 设备 / 在线
 		"groups.read":     true, // 群组列表 / 禁用群 / 群成员 / 群黑名单
 		"space.read":      true, // 空间查看 / 列表
+		"space.write":     true, // 建空间 / 改资料 / 加成员 / 邀请增改禁用 / 通过拒绝入群申请（requireAdmin）
 	}
 }
 

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -66,6 +66,7 @@ func (m *Manager) Route(r *wkhttp.WKHttp) {
 	}
 	auth := r.Group("/v1/manager", m.ctx.AuthMiddleware(r))
 	{
+		auth.GET("/me", m.me)                                 // 当前登录管理员的身份 + 能力图谱（前端据此渲染权限）
 		auth.POST("/user/admin", m.addAdminUser)              // 添加一个管理员
 		auth.GET("/user/admin", m.getAdminUsers)              // 查询管理员用户
 		auth.DELETE("/user/admin", m.deleteAdminUsers)        // 删除管理员用户
@@ -79,6 +80,58 @@ func (m *Manager) Route(r *wkhttp.WKHttp) {
 		auth.PUT("/user/liftban/:uid/:status", m.liftBanUser) // 解禁或封禁用户
 		auth.POST("/user/updatepassword", m.updatePwd)        // 修改用户密码
 		auth.GET("/user/devices", m.devices)                  // 查看某用户设备列表
+	}
+}
+
+// managerMeResp 是管理台「我是谁 + 我能做什么」响应。capabilities 是一张后端拥有
+// 的 feature→是否放行 布尔图，供前端渲染菜单/按钮（隐藏或禁用），从而不必靠撞
+// 403 反推权限。
+//
+// 反枚举：这张图只回答「当前用户能做什么」，不暴露「某端点需要什么角色」。它由
+// 本次请求解析出的权威角色（pkg/auth RoleResolver，吊销感知）计算。
+type managerMeResp struct {
+	UID          string          `json:"uid"`
+	Name         string          `json:"name"`
+	Role         string          `json:"role"`
+	Capabilities map[string]bool `json:"capabilities"`
+}
+
+// me 返回当前登录管理员的身份与能力图谱。管理台任一已登录管理员（admin∪
+// superAdmin）可读自己的能力；普通用户没有管理台访问，被 CheckLoginRole 挡下。
+func (m *Manager) me(c *wkhttp.Context) {
+	if err := c.CheckLoginRole(); err != nil {
+		respondManagerForbidden(c)
+		return
+	}
+	role := c.GetLoginRole()
+	c.Response(&managerMeResp{
+		UID:          c.GetLoginUID(),
+		Name:         c.GetLoginName(),
+		Role:         role,
+		Capabilities: managerCapabilities(role == string(wkhttp.SuperAdmin)),
+	})
+}
+
+// managerCapabilities 把当前各管理端点的角色档位映射为 feature→是否放行。调用方
+// 已通过 CheckLoginRole（admin∪superAdmin），故 admin 档位项恒 true；superAdmin
+// 专属项取 isSuper。键名是与前端的稳定约定。
+//
+// TODO(#366 Part 2): 目前这张表按各端点当前档位手工维护；集中式 authz 策略表落地
+// 后，应改为由同一份 route→role 真源派生，彻底消除前后端漂移。
+func managerCapabilities(isSuper bool) map[string]bool {
+	return map[string]bool{
+		// superAdmin 专属
+		"system_setting":    isSuper, // 系统配置：读写均超管
+		"backup":            isSuper, // 备份管理：读写均超管
+		"appversion.write":  isSuper, // 版本发布 / 下载源设置
+		"dashboard.trigger": isSuper, // 手动触发 ETL
+		"space.destructive": isSuper, // 强制解散/封禁/强制移除/改成员角色
+		// admin ∪ superAdmin（此处恒 true，列出供前端统一读取）
+		"appversion.read": true, // 版本列表
+		"dashboard.read":  true, // 运营看板查看
+		"users":           true, // 用户管理
+		"groups":          true, // 群组管理
+		"space.read":      true, // 空间查看 / 列表
 	}
 }
 

--- a/modules/user/api_manager_me_test.go
+++ b/modules/user/api_manager_me_test.go
@@ -25,7 +25,7 @@ func TestManagerCapabilities(t *testing.T) {
 		"users.write", "users.manage_admin", "groups.write",
 	}
 	adminTier := []string{
-		"appversion.read", "dashboard.read", "users.read", "groups.read", "space.read",
+		"appversion.read", "dashboard.read", "users.read", "groups.read", "space.read", "space.write",
 	}
 
 	for _, k := range superOnly {
@@ -88,7 +88,13 @@ func TestManagerMe_RejectsPlainUser(t *testing.T) {
 
 	loginAsRole(t, ctx, "") // no system role
 	w := getManagerMe(s.GetRoute())
-	assert.NotEqual(t, http.StatusOK, w.Code, "plain user must not access /v1/manager/me")
+	// Assert the specific forbidden outcome, not merely "not 200": respondManagerForbidden
+	// renders err.shared.auth.forbidden, pinned to wire 400 (D14) with the shared
+	// permission message. This rejects a 500/panic, 404 (route regression) or 401
+	// masquerading as a passing auth test.
+	assert.Equal(t, http.StatusBadRequest, w.Code, "forbidden is pinned to wire 400 (D14)")
+	assert.Contains(t, w.Body.String(), "permission",
+		"plain user must be rejected for the role reason (forbidden), not some other failure")
 }
 
 // TestManagerMe_AdminGetsReadCapsNotWrite verifies an admin is admitted and the
@@ -108,9 +114,11 @@ func TestManagerMe_AdminGetsReadCapsNotWrite(t *testing.T) {
 	assert.Equal(t, string(wkhttp.Admin), resp.Role)
 	assert.True(t, resp.Capabilities["users.read"], "admin should have users.read")
 	assert.True(t, resp.Capabilities["groups.read"], "admin should have groups.read")
+	assert.True(t, resp.Capabilities["space.write"], "admin should have space.write (admin-allowed space writes)")
 	assert.False(t, resp.Capabilities["users.write"], "admin must NOT have users.write")
 	assert.False(t, resp.Capabilities["users.manage_admin"], "admin must NOT have users.manage_admin")
 	assert.False(t, resp.Capabilities["groups.write"], "admin must NOT have groups.write")
+	assert.False(t, resp.Capabilities["space.destructive"], "admin must NOT have space.destructive")
 	assert.False(t, resp.Capabilities["system_setting"], "admin must NOT have system_setting")
 }
 

--- a/modules/user/api_manager_me_test.go
+++ b/modules/user/api_manager_me_test.go
@@ -1,0 +1,37 @@
+package user
+
+import "testing"
+
+// TestManagerCapabilities pins the /v1/manager/me capability map: superAdmin-only
+// features must be false for a plain admin, while admin∪superAdmin features are
+// true for both. Pure function — no server / DB needed.
+func TestManagerCapabilities(t *testing.T) {
+	super := managerCapabilities(true)
+	admin := managerCapabilities(false)
+
+	superOnly := []string{
+		"system_setting", "backup", "appversion.write", "dashboard.trigger", "space.destructive",
+	}
+	adminTier := []string{
+		"appversion.read", "dashboard.read", "users", "groups", "space.read",
+	}
+
+	for _, k := range superOnly {
+		if !super[k] {
+			t.Errorf("superAdmin must have capability %q", k)
+		}
+		if admin[k] {
+			t.Errorf("admin must NOT have superAdmin-only capability %q", k)
+		}
+	}
+	for _, k := range adminTier {
+		if !super[k] || !admin[k] {
+			t.Errorf("admin-tier capability %q must be true for both admin and superAdmin", k)
+		}
+	}
+
+	// Guard against a key being silently dropped/renamed out of the contract.
+	if got, want := len(super), len(superOnly)+len(adminTier); got != want {
+		t.Errorf("capability map has %d keys, want %d (update this test if the contract changed)", got, want)
+	}
+}

--- a/modules/user/api_manager_me_test.go
+++ b/modules/user/api_manager_me_test.go
@@ -1,6 +1,17 @@
 package user
 
-import "testing"
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 // TestManagerCapabilities pins the /v1/manager/me capability map: superAdmin-only
 // features must be false for a plain admin, while admin∪superAdmin features are
@@ -11,9 +22,10 @@ func TestManagerCapabilities(t *testing.T) {
 
 	superOnly := []string{
 		"system_setting", "backup", "appversion.write", "dashboard.trigger", "space.destructive",
+		"users.write", "users.manage_admin", "groups.write",
 	}
 	adminTier := []string{
-		"appversion.read", "dashboard.read", "users", "groups", "space.read",
+		"appversion.read", "dashboard.read", "users.read", "groups.read", "space.read",
 	}
 
 	for _, k := range superOnly {
@@ -34,4 +46,90 @@ func TestManagerCapabilities(t *testing.T) {
 	if got, want := len(super), len(superOnly)+len(adminTier); got != want {
 		t.Errorf("capability map has %d keys, want %d (update this test if the contract changed)", got, want)
 	}
+}
+
+// meResponse mirrors managerMeResp for decoding the HTTP body.
+type meResponse struct {
+	UID          string          `json:"uid"`
+	Name         string          `json:"name"`
+	Role         string          `json:"role"`
+	Capabilities map[string]bool `json:"capabilities"`
+}
+
+func getManagerMe(h http.Handler) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/manager/me", nil)
+	req.Header.Set("token", testutil.Token)
+	h.ServeHTTP(w, req)
+	return w
+}
+
+// loginAsRole logs testutil.UID in with the given system role via the token
+// cache (uid@name[@role]). The test server does not wire a RoleResolver (only
+// main.go does), so the token's baked role is authoritative here — matching the
+// setPlainUserToken / setAdminToken helpers in the opanalytics tests. role == ""
+// omits the role segment → no system role → CheckLoginRole rejects.
+func loginAsRole(t *testing.T, ctx *config.Context, role string) {
+	t.Helper()
+	val := testutil.UID + "@test"
+	if role != "" {
+		val += "@" + role
+	}
+	require.NoError(t, ctx.Cache().Set(ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token, val))
+}
+
+// TestManagerMe_RejectsPlainUser pins the gate at the HTTP layer: a logged-in but
+// non-manager user (passes auth, fails CheckLoginRole) must NOT reach /v1/manager/me.
+// Complements the pure-function TestManagerCapabilities, which cannot catch a
+// regression in the handler's role check.
+func TestManagerMe_RejectsPlainUser(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	loginAsRole(t, ctx, "") // no system role
+	w := getManagerMe(s.GetRoute())
+	assert.NotEqual(t, http.StatusOK, w.Code, "plain user must not access /v1/manager/me")
+}
+
+// TestManagerMe_AdminGetsReadCapsNotWrite verifies an admin is admitted and the
+// echoed capability map reflects the read/write split: read tiers true, the
+// superAdmin-only write tiers false — so the console won't render write buttons
+// that the backend would 403.
+func TestManagerMe_AdminGetsReadCapsNotWrite(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	loginAsRole(t, ctx, string(wkhttp.Admin))
+	w := getManagerMe(s.GetRoute())
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp meResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, string(wkhttp.Admin), resp.Role)
+	assert.True(t, resp.Capabilities["users.read"], "admin should have users.read")
+	assert.True(t, resp.Capabilities["groups.read"], "admin should have groups.read")
+	assert.False(t, resp.Capabilities["users.write"], "admin must NOT have users.write")
+	assert.False(t, resp.Capabilities["users.manage_admin"], "admin must NOT have users.manage_admin")
+	assert.False(t, resp.Capabilities["groups.write"], "admin must NOT have groups.write")
+	assert.False(t, resp.Capabilities["system_setting"], "admin must NOT have system_setting")
+}
+
+// TestManagerMe_SuperAdminGetsWriteCaps verifies a superAdmin is admitted and the
+// write/destructive tiers come back true.
+func TestManagerMe_SuperAdminGetsWriteCaps(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	loginAsRole(t, ctx, string(wkhttp.SuperAdmin))
+	w := getManagerMe(s.GetRoute())
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp meResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, string(wkhttp.SuperAdmin), resp.Role)
+	assert.True(t, resp.Capabilities["users.write"], "superAdmin should have users.write")
+	assert.True(t, resp.Capabilities["users.manage_admin"], "superAdmin should have users.manage_admin")
+	assert.True(t, resp.Capabilities["groups.write"], "superAdmin should have groups.write")
+	assert.True(t, resp.Capabilities["system_setting"], "superAdmin should have system_setting")
+	assert.True(t, resp.Capabilities["users.read"], "superAdmin should have users.read")
 }


### PR DESCRIPTION
## What

Refines the management-console authorization model along the read/write boundary and gives the frontend a single source of truth for what the current operator may do.

### 1. `common` — reading system settings requires superAdmin (`f0431ca`)
System-setting reads expose secrets (masked) and effective config; tightened from admin to **superAdmin**, matching the existing write/update gate. No change to the masked-secret behaviour.

### 2. `opanalytics` — dashboard reads allow admin, ETL trigger stays superAdmin (`fd1e09f`)
The 6 read-only dashboard endpoints (overview / trend / spaces / space-channels / channel-members / global direct-chats) now accept **admin** — they are read-only analytics. The single state-changing endpoint, `POST /v1/manager/dashboard/etl/run`, **remains superAdmin**. This splits "look at the dashboard" (admin) from "kick off an ETL run" (superAdmin).

### 3. `user` — new `GET /v1/manager/me` identity + capability map (`7858a25`)
Returns `{uid, name, role, capabilities}` so the console can render/hide controls from one call instead of probing endpoints. The capability map is a pure function of role; auth/role resolution is unchanged, and it surfaces no per-reason detail (anti-enumeration preserved).

## Why
The previous gating treated read and write uniformly per module. These changes make the boundary consistent: secret-bearing reads and state-changing actions require superAdmin, while pure analytics reads are available to admin. `/me` removes the frontend's need to infer capabilities by trial.

## Testing
Full integration suites for all three touched modules pass against **MySQL 8 + Redis** (WuKongIM not required — IM-token calls are logged-only and non-fatal):

| Module | Result |
|---|---|
| `modules/user` | ok, 0 failures |
| `modules/common` | ok, 0 failures |
| `modules/opanalytics` | ok, 0 failures |

Includes new regression tests: `TestManagerSystemSetting*` (read requires superAdmin), `TestOpanalyticsDashboardReadAdminTriggerSuperAdmin` (read=admin, trigger=superAdmin), and `TestManagerCapabilities` (pure capability-map coverage).

> Note for local reproduction: use MySQL 8 (a `robot_legacy01` migration uses MySQL-8-only functional-index syntax) and create the test DB with `utf8mb4_general_ci` (the MySQL-8 default `utf8mb4_0900_ai_ci` triggers collation-mix errors in opanalytics joins). CI already uses these.

## Follow-up (not in this PR)
Frontend references `PUT /v1/manager/download/versions/{id}` which has no backend handler — tracked separately, pending a decision on whether to add the endpoint or drop the frontend call.

https://claude.ai/code/session_01G8ocbvm4BTcTUfyehwYB12

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8ocbvm4BTcTUfyehwYB12)_