### PR TITLE
fix(onboarding): npm daemon install + drop OCTO_MATTER_URL from start

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -135,10 +135,10 @@ curl -X POST http://localhost:8090/v1/user/register \
 
 ### Connect an AI Agent
 
-Install the daemon CLI:
+Install the daemon (requires Node.js ≥ 18):
 
 ```bash
-go install github.com/Mininglamp-OSS/octo-daemon-cli@latest
+npm install -g @mininglamp-oss/octo-daemon
 ```
 
 In OCTO Web, open the **Runtimes** page from the left sidebar, click the

--- a/modules/botfather/api_runtime_onboarding.go
+++ b/modules/botfather/api_runtime_onboarding.go
@@ -154,7 +154,7 @@ func (bf *BotFather) runtimeOnboarding(c *wkhttp.Context) {
 		FleetURL:  fleetURL,
 		MatterURL: matterURL,
 		Commands: onboardingCmds{
-			Install: "go install github.com/Mininglamp-OSS/octo-daemon-cli@latest",
+			Install: "npm install -g @mininglamp-oss/octo-daemon",
 			Start:   startBlock,
 		},
 		EnvVars: map[string]string{

--- a/modules/botfather/api_runtime_onboarding.go
+++ b/modules/botfather/api_runtime_onboarding.go
@@ -135,16 +135,18 @@ func (bf *BotFather) runtimeOnboarding(c *wkhttp.Context) {
 		return
 	}
 
-	// commands.start 是 standalone 可复制可跑的 multi-line block: 含 3 个
-	// OCTO_*_URL export 让 daemon 各 service 调用走 env (fleet / server /
-	// matter 各走各), 末尾 octo-daemon start 行的 --api-url 用 serverURL —
-	// 跟旧 BotFather /daemon 命令一致 (cfg.APIURL 在 daemon 内只是 env 缺
-	// 失时的 fallback, env 全设了 cfg.APIURL 不会被读). caller 直接复制
-	// commands.start 就跑得起来, 不用再去 env_vars 字段二次拼接 (env_vars
-	// 单独保留供想 set 到 shell rc 而非 inline 的场景).
+	// commands.start 是 standalone 可复制可跑的 multi-line block: 2 个
+	// OCTO_*_URL export 让 daemon 各 service 调用走 env (fleet 走 runtime/bot
+	// 端点, server 走 auth/bot_token 端点), 末尾 octo-daemon start 行的
+	// --api-url 用 serverURL — 跟旧 BotFather /daemon 命令一致 (cfg.APIURL 在
+	// daemon 内只是 env 缺失时的 fallback, env 全设了 cfg.APIURL 不会被读).
+	// 不下发 OCTO_MATTER_URL: daemon 二进制不读该 env (它不直接调 matter),
+	// 且 matter 当前未上线. caller 直接复制 commands.start 就跑得起来, 不用
+	// 再去 env_vars 字段二次拼接 (env_vars 单独保留供想 set 到 shell rc 而非
+	// inline 的场景).
 	startBlock := fmt.Sprintf(
-		"export OCTO_SERVER_URL=%s\nexport OCTO_FLEET_URL=%s\nexport OCTO_MATTER_URL=%s\nocto-daemon start --api-key %s --api-url %s",
-		serverURL, fleetURL, matterURL, apiKey, serverURL,
+		"export OCTO_SERVER_URL=%s\nexport OCTO_FLEET_URL=%s\nocto-daemon start --api-key %s --api-url %s",
+		serverURL, fleetURL, apiKey, serverURL,
 	)
 
 	resp := runtimeOnboardingResp{
@@ -160,7 +162,6 @@ func (bf *BotFather) runtimeOnboarding(c *wkhttp.Context) {
 		EnvVars: map[string]string{
 			"OCTO_SERVER_URL": serverURL,
 			"OCTO_FLEET_URL":  fleetURL,
-			"OCTO_MATTER_URL": matterURL,
 		},
 	}
 	c.JSON(http.StatusOK, resp)


### PR DESCRIPTION
## What

Align the runtime-onboarding endpoint with the npm-distributed daemon and the
current daemon 0.0.3 launch contract.

- **Install command**: `go install github.com/Mininglamp-OSS/octo-daemon-cli@latest`
  → `npm install -g @mininglamp-oss/octo-daemon` (the published package; `engines: node >= 18`).
- **Start block / env_vars**: drop `OCTO_MATTER_URL`. The daemon 0.0.3 binary does
  not read that env (it never calls matter directly — verified against the binary),
  and matter is not deployed this iteration. The start command now exports only
  `OCTO_SERVER_URL` + `OCTO_FLEET_URL`; `OCTO_MATTER_URL` is also removed from `env_vars`.
- **QUICKSTART.md** "Connect an AI Agent" section updated to the npm command so the
  in-repo docs match the served command.

## Kept on purpose

The top-level `matter_url` response field is **retained** for forward-compat — it is
no longer part of the start command or env_vars, but removing it from the response
shape would be a contract change for clients that read it. No consumer depends on it
today; keeping it is the lower-risk choice.

## Verification

Built and run locally: onboarding returns the npm install command + a two-export
start block (no `OCTO_MATTER_URL`); daemon registers and 4 runtimes report online.
No auth / space-gating behavior changed.