### PR TITLE
fix(messages_search): add OCTO_SEARCH_OS_INSECURE_SKIP_VERIFY for sel…

### DIFF
--- a/modules/messages_search/api.go
+++ b/modules/messages_search/api.go
@@ -61,6 +61,11 @@ func New(ctx *config.Context) *Handler {
 			"built-in default cursor signing key. Set a per-deployment " +
 			"secret in production.")
 	}
+	if cfg.OSInsecureSkipVerify {
+		h.Warn("OCTO_SEARCH_OS_INSECURE_SKIP_VERIFY=true; OpenSearch TLS " +
+			"certificate verification is DISABLED. Use only in dev/test " +
+			"environments with self-signed certificates.")
+	}
 	return h
 }
 

--- a/modules/messages_search/config.go
+++ b/modules/messages_search/config.go
@@ -22,9 +22,17 @@ type SearchConfig struct {
 	// http:// addresses. Off by default: credentials over cleartext HTTP are
 	// rejected at client build time unless this is explicitly set.
 	OSInsecureHTTP bool
-	Timeout        time.Duration
-	RateLimit      RateLimitCfg
-	CursorHMAC     string
+	// OSInsecureSkipVerify disables TLS certificate verification when talking
+	// to the OpenSearch read cluster. Required for dev / test environments
+	// that use self-signed or internal-CA-signed certificates that the
+	// pod's system trust store does not include. MUST stay false in
+	// production deployments where the OS cluster has properly trusted
+	// certificates. Off by default; opt in via
+	// OCTO_SEARCH_OS_INSECURE_SKIP_VERIFY=true.
+	OSInsecureSkipVerify bool
+	Timeout              time.Duration
+	RateLimit            RateLimitCfg
+	CursorHMAC           string
 	// UserAvatarBaseURL, when non-empty, is prepended to the relative
 	// `users/{uid}/avatar` template so the response carries an absolute
 	// URL (spec v4.2 §2.1 / R8). When empty we keep the relative path and
@@ -54,12 +62,13 @@ type RateLimitCfg struct {
 // loadConfig builds a SearchConfig from process environment variables.
 func loadConfig() SearchConfig {
 	return SearchConfig{
-		OSAddrs:        splitCSV(os.Getenv("OCTO_SEARCH_OS_ADDRS"), []string{"http://localhost:9200"}),
-		OSUsername:     os.Getenv("OCTO_SEARCH_OS_USERNAME"),
-		OSPassword:     os.Getenv("OCTO_SEARCH_OS_PASSWORD"),
-		OSReadAlias:    defaultStr(os.Getenv("OCTO_SEARCH_OS_READ_ALIAS"), "wukongim-messages-read"),
-		OSInsecureHTTP: os.Getenv("OCTO_SEARCH_OS_INSECURE_HTTP") == "true",
-		Timeout:        parseDuration(os.Getenv("OCTO_SEARCH_TIMEOUT"), 5*time.Second),
+		OSAddrs:              splitCSV(os.Getenv("OCTO_SEARCH_OS_ADDRS"), []string{"http://localhost:9200"}),
+		OSUsername:           os.Getenv("OCTO_SEARCH_OS_USERNAME"),
+		OSPassword:           os.Getenv("OCTO_SEARCH_OS_PASSWORD"),
+		OSReadAlias:          defaultStr(os.Getenv("OCTO_SEARCH_OS_READ_ALIAS"), "wukongim-messages-read"),
+		OSInsecureHTTP:       os.Getenv("OCTO_SEARCH_OS_INSECURE_HTTP") == "true",
+		OSInsecureSkipVerify: os.Getenv("OCTO_SEARCH_OS_INSECURE_SKIP_VERIFY") == "true",
+		Timeout:              parseDuration(os.Getenv("OCTO_SEARCH_TIMEOUT"), 5*time.Second),
 		RateLimit: RateLimitCfg{
 			QPS:   parseFloat(os.Getenv("OCTO_SEARCH_RPS"), 5.0),
 			Burst: parseInt(os.Getenv("OCTO_SEARCH_BURST"), 20),

--- a/modules/messages_search/config_test.go
+++ b/modules/messages_search/config_test.go
@@ -1,0 +1,49 @@
+package messages_search
+
+import (
+	"os"
+	"testing"
+)
+
+// The OCTO_SEARCH_OS_INSECURE_SKIP_VERIFY env follows the same strict literal
+// "true" match as OCTO_SEARCH_OS_INSECURE_HTTP — anything else (1, yes, TRUE,
+// True, "") leaves verification ON. Lock that contract in so a future
+// "helpful" refactor to strconv.ParseBool doesn't widen the door silently.
+func TestLoadConfig_OSInsecureSkipVerify(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+		set  bool
+		want bool
+	}{
+		{name: "unset defaults to false", set: false, want: false},
+		{name: "empty string is false", val: "", set: true, want: false},
+		{name: "literal true is true", val: "true", set: true, want: true},
+		{name: "uppercase TRUE is false", val: "TRUE", set: true, want: false},
+		{name: "mixed-case True is false", val: "True", set: true, want: false},
+		{name: "numeric 1 is false", val: "1", set: true, want: false},
+		{name: "yes is false", val: "yes", set: true, want: false},
+		{name: "false is false", val: "false", set: true, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv("OCTO_SEARCH_OS_INSECURE_SKIP_VERIFY", tc.val)
+			} else {
+				// Defensively clear any host-leaked value; restore on cleanup.
+				prev, had := os.LookupEnv("OCTO_SEARCH_OS_INSECURE_SKIP_VERIFY")
+				_ = os.Unsetenv("OCTO_SEARCH_OS_INSECURE_SKIP_VERIFY")
+				t.Cleanup(func() {
+					if had {
+						_ = os.Setenv("OCTO_SEARCH_OS_INSECURE_SKIP_VERIFY", prev)
+					}
+				})
+			}
+			cfg := loadConfig()
+			if cfg.OSInsecureSkipVerify != tc.want {
+				t.Fatalf("OSInsecureSkipVerify = %v, want %v (env=%q set=%v)",
+					cfg.OSInsecureSkipVerify, tc.want, tc.val, tc.set)
+			}
+		})
+	}
+}

--- a/modules/messages_search/es_client.go
+++ b/modules/messages_search/es_client.go
@@ -2,8 +2,10 @@ package messages_search
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"net"
+	"net/http"
 	"net/url"
 	"sync"
 	"time"
@@ -101,6 +103,22 @@ func buildESClient(cfg SearchConfig) (*elastic.Client, error) {
 		elastic.SetSniff(false),
 		elastic.SetHealthcheck(true),
 		elastic.SetHealthcheckTimeout(3 * time.Second),
+	}
+	if cfg.OSInsecureSkipVerify {
+		// Self-signed / internal-CA OS clusters in dev / test environments
+		// where the pod's system trust store has no chain to verify against.
+		// Disable cert verification on the HTTP client olivere uses for both
+		// the startup healthcheck and subsequent requests. MUST NOT be set
+		// in production deployments — see config.go::OSInsecureSkipVerify.
+		hc := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			},
+		}
+		if cfg.Timeout > 0 {
+			hc.Timeout = cfg.Timeout
+		}
+		opts = append(opts, elastic.SetHttpClient(hc))
 	}
 	if cfg.OSUsername != "" {
 		opts = append(opts, elastic.SetBasicAuth(cfg.OSUsername, cfg.OSPassword))


### PR DESCRIPTION
…f-signed OS clusters

`buildESClient` had no TLS-skip switch, so olivere/elastic's startup healthcheck (HEAD /) failed with x509 "certificate signed by unknown authority" against any OpenSearch cluster whose CA isn't in the pod's system trust store. All three nodes failed → "no Elasticsearch node available" → ESClient returned err → caller mapped to 503 upstream_unavailable. dmwork-test reproduces this on every POST /v1/messages/_search call.

Add a new env `OCTO_SEARCH_OS_INSECURE_SKIP_VERIFY` (default false, strict-literal "true" to enable, matching the existing `OCTO_SEARCH_OS_INSECURE_HTTP` parsing). When true, inject a custom `http.Client` with `tls.Config{InsecureSkipVerify: true}` into the olivere client via `elastic.SetHttpClient`. A loud WARN log fires at module init so the deviation cannot stay enabled silently.

Orthogonal to the existing `OCTO_SEARCH_OS_INSECURE_HTTP`:
- INSECURE_HTTP gates basic-auth credentials over cleartext http://
- INSECURE_SKIP_VERIFY gates TLS certificate verification

Long-term fix is to install the internal CA in the pod or have the cluster issue properly trusted certificates; this env is the short-term unblock for dev / test environments.

## Summary

<!-- What does this PR do? -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. Fixes #123 -->

## Changes

<!-- Bullet list of concrete changes -->

-
-

## Testing

<!-- How was this tested? Include commands, screenshots, or test output. -->

- [ ] Unit tests added/updated
- [ ] Manually verified

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] PR description is in English
- [ ] Added tests for my changes
- [ ] Updated documentation
- [ ] Followed commit message conventions (Conventional Commits)
