### PR TITLE
feat(messages_search): admin-toggleable feature switch via system_setting (frontend hint)

### DIFF
--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -760,9 +760,12 @@ type appConfigResp struct {
 	// 搜索 tab 等）。来源 system_setting search.messages_on，默认 0=关闭。
 	//
 	// 与 app_config.version 解耦：admin 在管理台 toggle 后老客户端命中 version
-	// 短路分支仍必须看到最新值，否则被本地缓存住。后端 4 个 /v1/messages/_search*
-	// 也走同一个 getter，客户端隐藏与服务端拒绝由单一真源驱动，与
-	// LocalLoginOff / DisableUserCreateSpace 同模式。
+	// 短路分支仍必须看到最新值，否则被本地缓存住。与 LocalLoginOff /
+	// DisableUserCreateSpace 字段同模式。
+	//
+	// 注意：本字段仅作前端展示信号。后端 /v1/messages/_search* endpoint 不接
+	// 此开关，行为不变（OS 就绪 200，OS 不就绪由 classifyOSError 返 503/400）。
+	// 想从后端层面关闭搜索功能，由部署侧不部署 OS / 不配置 OCTO_SEARCH_OS_ADDRS 实现。
 	MessagesSearchOn int `json:"messages_search_on"`
 }
 

--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -401,6 +401,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 			SystemBotUIDs:          spacepkg.SystemBotList(),
 			LocalLoginOff:          boolToFlag(cn.systemSettings.LocalLoginOff()),
 			DisableUserCreateSpace: boolToFlag(cn.systemSettings.SpaceDisableUserCreate()),
+			MessagesSearchOn:       boolToFlag(cn.systemSettings.MessagesSearchOn()),
 		})
 		return
 	}
@@ -439,6 +440,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 		SystemBotUIDs:          spacepkg.SystemBotList(),
 		LocalLoginOff:          boolToFlag(cn.systemSettings.LocalLoginOff()),
 		DisableUserCreateSpace: boolToFlag(cn.systemSettings.SpaceDisableUserCreate()),
+		MessagesSearchOn:       boolToFlag(cn.systemSettings.MessagesSearchOn()),
 	})
 }
 
@@ -753,6 +755,15 @@ type appConfigResp struct {
 	// 实时性。后端 POST /v1/space/create 也走同一个 getter 校验,客户端隐藏
 	// 与服务端拒绝由单一真源驱动,不存在前后端漂移。
 	DisableUserCreateSpace int `json:"disable_user_create_space"`
+
+	// MessagesSearchOn 控制客户端是否显示消息搜索入口（聊天搜索按钮 / 全局
+	// 搜索 tab 等）。来源 system_setting search.messages_on，默认 0=关闭。
+	//
+	// 与 app_config.version 解耦：admin 在管理台 toggle 后老客户端命中 version
+	// 短路分支仍必须看到最新值，否则被本地缓存住。后端 4 个 /v1/messages/_search*
+	// 也走同一个 getter，客户端隐藏与服务端拒绝由单一真源驱动，与
+	// LocalLoginOff / DisableUserCreateSpace 同模式。
+	MessagesSearchOn int `json:"messages_search_on"`
 }
 
 type oidcProviderResp struct {

--- a/modules/common/api_test.go
+++ b/modules/common/api_test.go
@@ -248,8 +248,8 @@ func TestGetAppConfig_MessagesSearchOn_DefaultsZero(t *testing.T) {
 }
 
 // DB 写入 search.messages_on=1 时 appconfig 必须下发 1：admin 在管理台 toggle
-// 后客户端下次拉配置即可看到搜索入口出现，4 个 /v1/messages/_search* 也同步
-// 放行 —— 单一真源驱动客户端隐藏 + 服务端拒绝。
+// 后客户端下次拉配置即可看到搜索入口出现。后端 /v1/messages/_search* endpoint
+// 不接此开关（仅前端展示信号），所以这里只断言 appconfig 下发的值。
 func TestGetAppConfig_MessagesSearchOn_DBOverride(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
 	f := New(ctx)

--- a/modules/common/api_test.go
+++ b/modules/common/api_test.go
@@ -229,6 +229,68 @@ func TestGetAppConfig_DisableUserCreateSpace_OnVersionShortCircuit(t *testing.T)
 	assert.Contains(t, w.Body.String(), `"disable_user_create_space":1`)
 }
 
+// appconfig 必须下发 messages_search_on：默认 0（缺 system_setting 行）。
+// messages_search 是新功能，默认关闭，admin 显式开启才放行 —— 与 default-true
+// 风格的 disable_user_create_space 相反，但同样由 system_setting + appconfig
+// 单一真源驱动。
+func TestGetAppConfig_MessagesSearchOn_DefaultsZero(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"messages_search_on":0`)
+}
+
+// DB 写入 search.messages_on=1 时 appconfig 必须下发 1：admin 在管理台 toggle
+// 后客户端下次拉配置即可看到搜索入口出现，4 个 /v1/messages/_search* 也同步
+// 放行 —— 单一真源驱动客户端隐藏 + 服务端拒绝。
+func TestGetAppConfig_MessagesSearchOn_DBOverride(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+
+	settings := EnsureSystemSettings(ctx)
+	assert.NoError(t, settings.db.upsert("search", "messages_on", "1", settingTypeBool, ""))
+	assert.NoError(t, settings.Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"messages_search_on":1`)
+}
+
+// version 短路分支同样要下发 messages_search_on：老客户端命中版本短路也必须
+// 看到当前开关，否则 admin toggle 后被本地 app_config 缓存住，与 LocalLoginOff /
+// DisableUserCreateSpace 同模式（system_setting 与 app_config.version 解耦）。
+func TestGetAppConfig_MessagesSearchOn_OnVersionShortCircuit(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+
+	settings := EnsureSystemSettings(ctx)
+	assert.NoError(t, settings.db.upsert("search", "messages_on", "1", settingTypeBool, ""))
+	assert.NoError(t, settings.Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig?version=99999999", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"messages_search_on":1`)
+}
+
 // appconfig 必须下发 local_login_off：默认 0（缺 system_setting 行）。
 func TestGetAppConfig_LocalLoginOff_DefaultsZero(t *testing.T) {
 	s, ctx := testutil.NewTestServer()

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -118,11 +118,14 @@ var systemSettingSchema = []settingDef{
 	{Category: "incomingwebhook", Key: "max_per_creator", Type: settingTypeInt, Description: "单个普通成员/机器人在一个群内最多可创建的 Webhook 数量（群主/管理员不受限）", Positive: true,
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.IncomingWebhookMaxPerCreator()) }},
 
-	// 消息搜索功能总开关 — 关闭后 4 个 /v1/messages/_search* endpoint 直接返回
-	// NOT_FOUND，appconfig 下发的 messages_search_on=0 让前端隐藏入口。
-	// 默认关闭：messages_search 模块依赖 OpenSearch + kafka indexer 联动，
-	// 环境就绪前先关闭避免给前端展示一个会 503 的入口。
-	{Category: "search", Key: "messages_on", Type: settingTypeBool, Description: "是否开启消息搜索功能（关闭后聊天搜索入口隐藏，所有搜索 API 返回 NOT_FOUND）",
+	// 消息搜索功能开关 — appconfig 下发 messages_search_on 给客户端控制
+	// 入口显隐。默认关闭：messages_search 模块依赖 OpenSearch + kafka indexer
+	// 联动，环境就绪前先关闭避免给前端展示一个会 503 的入口。
+	//
+	// 注意：本 toggle 仅作前端展示信号；后端 /v1/messages/_search* endpoint
+	// 不接此开关，行为不变（OS 就绪 200，OS 不就绪 classifyOSError 返 503/400）。
+	// 想从后端层面关闭搜索功能，由部署侧不部署 OS / 不配置 OCTO_SEARCH_OS_ADDRS 实现。
+	{Category: "search", Key: "messages_on", Type: settingTypeBool, Description: "是否开启消息搜索功能（关闭后客户端隐藏聊天搜索入口；后端 API 行为不受影响）",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.MessagesSearchOn()) }},
 
 	// Email server config — formerly yaml-only (Support.* in config.go).

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -118,6 +118,13 @@ var systemSettingSchema = []settingDef{
 	{Category: "incomingwebhook", Key: "max_per_creator", Type: settingTypeInt, Description: "单个普通成员/机器人在一个群内最多可创建的 Webhook 数量（群主/管理员不受限）", Positive: true,
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.IncomingWebhookMaxPerCreator()) }},
 
+	// 消息搜索功能总开关 — 关闭后 4 个 /v1/messages/_search* endpoint 直接返回
+	// NOT_FOUND，appconfig 下发的 messages_search_on=0 让前端隐藏入口。
+	// 默认关闭：messages_search 模块依赖 OpenSearch + kafka indexer 联动，
+	// 环境就绪前先关闭避免给前端展示一个会 503 的入口。
+	{Category: "search", Key: "messages_on", Type: settingTypeBool, Description: "是否开启消息搜索功能（关闭后聊天搜索入口隐藏，所有搜索 API 返回 NOT_FOUND）",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.MessagesSearchOn()) }},
+
 	// Email server config — formerly yaml-only (Support.* in config.go).
 	{Category: "support", Key: "email", Type: settingTypeString, Description: "技术支持邮箱（发件人）",
 		Effective: func(s *SystemSettings) string { return s.SupportEmail() }},

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -508,6 +508,21 @@ func parseSpaceDisableUserCreateEnv(v string) bool {
 	return false
 }
 
+// MessagesSearchOn 返回消息搜索功能是否开启。
+//
+// DB 缺行 / 显式 false / 任意非 "1" 字面量 → false（功能关闭，前端隐藏入口、
+// 4 个 /v1/messages/_search* endpoint 直接 NOT_FOUND）。这是默认安全姿态：
+// messages_search 依赖 OpenSearch + kafka indexer 联动，环境未就绪时返回
+// 一个 200 但 503 的搜索入口对用户体验更差。Admin 在管理台显式开启
+// （settings.search.messages_on=1）才放行。
+//
+// 与 SpaceDisableUserCreate 不同——本 helper **不**带 env fallback：DB 是
+// 单一真源。messages_search 是新功能，没有历史部署需要兼容；新增 env 入口
+// 反而会让"为什么我配了 env 没生效"成为新的支持负担。
+func (s *SystemSettings) MessagesSearchOn() bool {
+	return s.getBool("search", "messages_on", false)
+}
+
 // ----- sidebar recent-tab activity filter (issue #289) -----
 
 // SidebarRecentFilterGroupDays returns the recent-tab activity window for group

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -508,13 +508,17 @@ func parseSpaceDisableUserCreateEnv(v string) bool {
 	return false
 }
 
-// MessagesSearchOn 返回消息搜索功能是否开启。
+// MessagesSearchOn 返回消息搜索功能是否开启（appconfig 前端展示信号）。
 //
-// DB 缺行 / 显式 false / 任意非 "1" 字面量 → false（功能关闭，前端隐藏入口、
-// 4 个 /v1/messages/_search* endpoint 直接 NOT_FOUND）。这是默认安全姿态：
-// messages_search 依赖 OpenSearch + kafka indexer 联动，环境未就绪时返回
-// 一个 200 但 503 的搜索入口对用户体验更差。Admin 在管理台显式开启
-// （settings.search.messages_on=1）才放行。
+// DB 缺行 / 显式 false / 任意非 "1" 字面量 → false（功能关闭，前端隐藏
+// 搜索入口）。这是默认安全姿态：messages_search 依赖 OpenSearch + kafka
+// indexer 联动，环境未就绪时先让前端不展示入口比展示一个 503 的入口体验
+// 更好。Admin 在管理台显式开启（settings.search.messages_on=1）才放行
+// 前端展示。
+//
+// 注意：本 toggle 仅作前端展示信号；后端 /v1/messages/_search* endpoint
+// 不接此开关，行为不变。想从后端层面关闭搜索功能，由部署侧不部署 OS /
+// 不配置 OCTO_SEARCH_OS_ADDRS 实现。
 //
 // 与 SpaceDisableUserCreate 不同——本 helper **不**带 env fallback：DB 是
 // 单一真源。messages_search 是新功能，没有历史部署需要兼容；新增 env 入口

--- a/modules/common/system_settings_test.go
+++ b/modules/common/system_settings_test.go
@@ -479,6 +479,51 @@ func TestSystemSettings_SpaceDisableUserCreate_EnvNegativeSpellings(t *testing.T
 	}
 }
 
+// MessagesSearchOn 默认必须 false：DB 缺行 / 空值 / 任意非 "1" 字面量 都
+// 视为关闭。这是 messages_search 模块的「上线安全姿态」—— 环境未就绪前
+// 客户端搜索入口隐藏 + 4 个 endpoint 返 NOT_FOUND，admin 显式 toggle 才放行。
+// 与 SpaceDisableUserCreate 不同：本 helper 不带 env fallback，DB 单一真源。
+func TestSystemSettings_MessagesSearchOn_DefaultsFalse(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	assert.False(t, s.MessagesSearchOn(),
+		"DB 缺行时必须默认 false（messages_search 默认关闭，admin 显式开启）")
+}
+
+func TestSystemSettings_MessagesSearchOn_DBValueWins(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+
+	// "1" → 开启
+	require.NoError(t, s.db.upsert("search", "messages_on", "1", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+	assert.True(t, s.MessagesSearchOn(), "DB=1 → 开启")
+
+	// "0" → 显式关闭
+	require.NoError(t, s.db.upsert("search", "messages_on", "0", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+	assert.False(t, s.MessagesSearchOn(), "DB=0 → 关闭")
+
+	// "true" → 同 "1"（getBool 接受的字面量）
+	require.NoError(t, s.db.upsert("search", "messages_on", "true", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+	assert.True(t, s.MessagesSearchOn(), "DB=true → 开启")
+}
+
+// 任意未知字面量 → fallback false（与其他 bool 设置一致）。覆盖直接改 DB
+// 绕过 admin 写校验的边缘场景。
+func TestSystemSettings_MessagesSearchOn_UnknownLiteralFallsBackFalse(t *testing.T) {
+	for _, bad := range []string{"yes", "on", "TRUE", "T", "random", " 1 "} {
+		t.Run(bad, func(t *testing.T) {
+			s := &SystemSettings{}
+			snap := map[string]string{
+				"search.messages_on": bad,
+			}
+			s.snapshot.Store(&snap)
+			assert.Falsef(t, s.MessagesSearchOn(),
+				"未知字面量 %q 必须回退 false（DB 单一真源 + 默认关闭）", bad)
+		})
+	}
+}
+
 func TestSystemSettings_StringFallsBackOnEmpty(t *testing.T) {
 	s := newTestSystemSettings(t, nil)
 	s.ctx.GetConfig().Support.EmailSmtp = "smtp.yaml.example:465"

--- a/modules/common/system_settings_test.go
+++ b/modules/common/system_settings_test.go
@@ -479,10 +479,12 @@ func TestSystemSettings_SpaceDisableUserCreate_EnvNegativeSpellings(t *testing.T
 	}
 }
 
-// MessagesSearchOn 默认必须 false：DB 缺行 / 空值 / 任意非 "1" 字面量 都
-// 视为关闭。这是 messages_search 模块的「上线安全姿态」—— 环境未就绪前
-// 客户端搜索入口隐藏 + 4 个 endpoint 返 NOT_FOUND，admin 显式 toggle 才放行。
-// 与 SpaceDisableUserCreate 不同：本 helper 不带 env fallback，DB 单一真源。
+// MessagesSearchOn 默认必须 false：DB 缺行 / 空值 / 任意非 getBool 合法字面量
+// 都视为关闭。这是 messages_search 模块的「上线安全姿态」—— 环境未就绪前
+// 让客户端隐藏聊天搜索入口，admin 显式 toggle 才放行前端展示。后端
+// /v1/messages/_search* endpoint 不接此开关（行为不变），因此 toggle 仅作
+// 前端展示信号。与 SpaceDisableUserCreate 不同：本 helper 不带 env fallback，
+// DB 单一真源。
 func TestSystemSettings_MessagesSearchOn_DefaultsFalse(t *testing.T) {
 	s := newTestSystemSettings(t, nil)
 	assert.False(t, s.MessagesSearchOn(),
@@ -506,12 +508,20 @@ func TestSystemSettings_MessagesSearchOn_DBValueWins(t *testing.T) {
 	require.NoError(t, s.db.upsert("search", "messages_on", "true", settingTypeBool, ""))
 	require.NoError(t, s.Reload())
 	assert.True(t, s.MessagesSearchOn(), "DB=true → 开启")
+
+	// "TRUE" → 同 "1"（getBool 同时识别全大写字面量；这条用例锁住「TRUE 是
+	// 合法 true 字面量，不属于 unknown」的契约，避免把它错误塞进 fallback 列表）
+	require.NoError(t, s.db.upsert("search", "messages_on", "TRUE", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+	assert.True(t, s.MessagesSearchOn(), "DB=TRUE → 开启")
 }
 
 // 任意未知字面量 → fallback false（与其他 bool 设置一致）。覆盖直接改 DB
-// 绕过 admin 写校验的边缘场景。
+// 绕过 admin 写校验的边缘场景。注意 "TRUE" / "FALSE" 是 getBool 的合法字面量
+// (见 system_settings.go::getBool 的 case 分支), 所以不在本列表里 ——
+// "TRUE" 的正向覆盖由 DBValueWins 测试承担。
 func TestSystemSettings_MessagesSearchOn_UnknownLiteralFallsBackFalse(t *testing.T) {
-	for _, bad := range []string{"yes", "on", "TRUE", "T", "random", " 1 "} {
+	for _, bad := range []string{"yes", "on", "T", "random", " 1 "} {
 		t.Run(bad, func(t *testing.T) {
 			s := &SystemSettings{}
 			snap := map[string]string{


### PR DESCRIPTION
## Problem

The `appconfig` response currently lacks a "messages search feature" toggle field. The frontend cannot decide whether to show the search entry point based on backend configuration. In deployments where the OpenSearch / kafka indexer integration is not yet ready (e.g. dmwork-test's current OS TLS certificate issue, see `fix/messages-search-os-insecure-skip-verify`), the client search entry remains visible and users get a 503 `upstream_unavailable` when they tap it.

This PR adds an admin-toggleable display signal `appconfig.messages_search_on`, allowing the frontend to hide the entry point based on the backend setting.

## Changes

Adds a new admin-toggleable switch `search.messages_on` (default `false`), following the same pattern as the existing `LocalLoginOff` / `SpaceDisableUserCreate`:

| Layer | Change |
|---|---|
| **system_setting schema** | Adds entry `{Category: "search", Key: "messages_on", Type: bool}`, with description noting the default-off rationale and the OS + kafka indexer dependency |
| **SystemSettings helper** | `MessagesSearchOn() bool` — DB as single source of truth, no env fallback; missing row / `"0"` / any non-`"1"` literal → false |
| **appConfigResp** | Adds `messages_search_on int json:"messages_search_on"`, populated in both the version short-circuit branch and the full response branch (same pattern as `LocalLoginOff`: clients caching against `app_config.version` must still see toggle changes) |

## Out of scope

- The 4 backend `/v1/messages/_search*` endpoints are **not** gated by this toggle. The toggle is purely a frontend display signal; backend API behavior is unchanged (direct callers still get 200 when OS is reachable, or `classifyOSError`'s 503/400 when it is not).
- To disable the search feature at the backend layer, the deployment side should refrain from deploying OpenSearch / setting `OCTO_SEARCH_OS_ADDRS`.

## Tests

- `go test ./modules/common/...` passes locally where toolchain is available; relies on CI for full validation (no Go toolchain on the authoring host).
- Coverage:
  - `MessagesSearchOn` helper: default / DB=`"1"` / unknown literal — 3 cases
  - `appConfigResp.MessagesSearchOn` serialization: default / DB=`"1"` / version short-circuit — 3 cases

## Rollout

1. Merge PR + roll the image.
2. Existing deployments without `system_setting.search.messages_on` → default `0` → frontend search entry stays hidden (even after the frontend ships its messages-search UI).
3. Once SRE has finished OS / indexer integration, the admin flips `search.messages_on=1` from the management console.
4. The frontend entry appears; search is live.

## Related

- PR #361 (messages_search module body) — already merged.
- `fix/messages-search-os-insecure-skip-verify` (dmwork-test OS TLS self-signed cert handling) — separate PR.