### PR TITLE
feat(integration): team group create + existence endpoints for uk_ keys

### DIFF
--- a/modules/group/const.go
+++ b/modules/group/const.go
@@ -10,6 +10,11 @@ const (
 	GroupStatusDisband = 2
 )
 
+// MaxGroupNameLen 群名最大长度（按 rune 计）。Web / Bot / Integration 建群与改名共用，
+// 超长一律静默截断到此长度（API 层可前置 reject 给出明确错误）。配套的 `group`.`name`
+// 列宽由迁移加宽到 VARCHAR(50)，两者必须一致，否则 MySQL 严格模式下会报 Data too long。
+const MaxGroupNameLen = 50
+
 // 群成员角色
 const (
 	// MemberRoleCommon 普通成员

--- a/modules/group/group_name_widen_test.go
+++ b/modules/group/group_name_widen_test.go
@@ -1,0 +1,77 @@
+package group
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGroupNameWidenMigration genuinely exercises the VARCHAR(40)->(50) in-place widen
+// against PRE-EXISTING data, rather than just asserting a 40-rune string fits a 50-wide
+// column.
+//
+// The harness migrates the column to VARCHAR(50) up front, so to reproduce the pre-widen
+// state we shrink it back to VARCHAR(40), write a 40-rune row as legacy data, then run the
+// migration's Up DDL (the widen) and assert: the legacy row survives byte-for-byte with no
+// truncation, the column is now 50, and a new 50-rune name (the MaxGroupNameLen ceiling)
+// fits. A defer restores the column to 50 so a mid-test failure can't leave the shared test
+// schema narrowed for later tests.
+func TestGroupNameWidenMigration(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+
+	require.Equal(t, 50, MaxGroupNameLen, "MaxGroupNameLen and the column width must move together")
+
+	colLen := func() int {
+		var n int
+		err := ctx.DB().SelectBySql(
+			"SELECT CHARACTER_MAXIMUM_LENGTH FROM information_schema.columns " +
+				"WHERE table_schema=DATABASE() AND table_name='group' AND column_name='name'",
+		).LoadOne(&n)
+		require.NoError(t, err)
+		return n
+	}
+	modifyNameWidth := func(width int) {
+		// DDL column length can't be a bound placeholder; width is a controlled int constant.
+		_, err := ctx.DB().UpdateBySql(
+			fmt.Sprintf("ALTER TABLE `group` MODIFY `name` VARCHAR(%d) NOT NULL DEFAULT ''", width),
+		).Exec()
+		require.NoError(t, err)
+	}
+
+	// Migration applied → column is already VARCHAR(50).
+	require.Equal(t, MaxGroupNameLen, colLen(), "group.name must be widened to VARCHAR(50) by the migration")
+	defer modifyNameWidth(MaxGroupNameLen) // never leave the shared schema narrowed
+
+	// Reproduce the pre-widen world: a VARCHAR(40) column holding a 40-rune name.
+	modifyNameWidth(40)
+	require.Equal(t, 40, colLen())
+	name40 := strings.Repeat("名", 40)
+	legacyNo := "g40_" + util.GenerUUID()[:8]
+	_, err := ctx.DB().InsertBySql("INSERT INTO `group` (group_no, name) VALUES (?, ?)", legacyNo, name40).Exec()
+	require.NoError(t, err)
+
+	// Run the widen (the migration's Up DDL) over the existing data.
+	modifyNameWidth(MaxGroupNameLen)
+	require.Equal(t, MaxGroupNameLen, colLen(), "widen must take effect")
+
+	// Existing 40-rune data survives the in-place widen untouched.
+	var got string
+	require.NoError(t, ctx.DB().SelectBySql("SELECT name FROM `group` WHERE group_no=?", legacyNo).LoadOne(&got))
+	assert.Equal(t, name40, got, "pre-existing name must survive the widen with no truncation")
+	assert.Equal(t, 40, len([]rune(got)))
+
+	// A new 50-rune name (the new ceiling) now fits and round-trips in full.
+	name50 := strings.Repeat("字", 50)
+	newNo := "g50_" + util.GenerUUID()[:8]
+	_, err = ctx.DB().InsertBySql("INSERT INTO `group` (group_no, name) VALUES (?, ?)", newNo, name50).Exec()
+	require.NoError(t, err, "a 50-rune name must fit the widened column")
+	require.NoError(t, ctx.DB().SelectBySql("SELECT name FROM `group` WHERE group_no=?", newNo).LoadOne(&got))
+	assert.Equal(t, name50, got)
+	assert.Equal(t, 50, len([]rune(got)))
+}

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -1081,8 +1081,8 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 		groupName = strings.Join(names, "、")
 	}
 	nameRunes := []rune(groupName)
-	if len(nameRunes) > 20 {
-		groupName = string(nameRunes[:20])
+	if len(nameRunes) > MaxGroupNameLen {
+		groupName = string(nameRunes[:MaxGroupNameLen])
 	}
 
 	// 生成群编号和版本号
@@ -1776,8 +1776,8 @@ func (s *Service) UpdateGroupInfo(req *UpdateGroupInfoServiceReq) error {
 	// 更新字段
 	if req.Name != nil {
 		nameRunes := []rune(*req.Name)
-		if len(nameRunes) > 20 {
-			*req.Name = string(nameRunes[:20])
+		if len(nameRunes) > MaxGroupNameLen {
+			*req.Name = string(nameRunes[:MaxGroupNameLen])
 		}
 		groupModel.Name = *req.Name
 	}

--- a/modules/group/sql/20260615000001_group_name_widen.sql
+++ b/modules/group/sql/20260615000001_group_name_widen.sql
@@ -5,5 +5,8 @@
 ALTER TABLE `group` MODIFY `name` VARCHAR(50) NOT NULL DEFAULT '';
 
 -- +migrate Down
--- 回滚收回到 VARCHAR(40)。若已写入 >40 字符群名，回滚会截断——回滚前需确认无超 40 字符数据。
+-- 回滚收回到 VARCHAR(40)。先显式把 >40 字符群名截到 40，再收窄列宽：MySQL 严格模式（STRICT_*）
+-- 下 ALTER 收窄遇到超长数据会直接报 Data too long 而非静默截断，导致回滚失败/卡住；先 UPDATE
+-- 预截断可避免。注意这是有损回滚（>40 字符的群名会丢尾部）——保留宽列才是无损选择。
+UPDATE `group` SET `name` = LEFT(`name`, 40) WHERE CHAR_LENGTH(`name`) > 40;
 ALTER TABLE `group` MODIFY `name` VARCHAR(40) NOT NULL DEFAULT '';

--- a/modules/group/sql/20260615000001_group_name_widen.sql
+++ b/modules/group/sql/20260615000001_group_name_widen.sql
@@ -1,0 +1,9 @@
+-- +migrate Up
+-- 群名上限 20→50（应用层 MaxGroupNameLen）配套列加宽。VARCHAR(40)→(50) 两侧均
+-- < 256 字节（utf8mb4 最坏 4 字节/字符，50×4=200B），长度前缀仍 1 字节 → MySQL 8.0
+-- 走 INPLACE/LOCK=NONE 在线变更，不重建表、不截断存量数据。按项目约定不 pin ALGORITHM/LOCK。
+ALTER TABLE `group` MODIFY `name` VARCHAR(50) NOT NULL DEFAULT '';
+
+-- +migrate Down
+-- 回滚收回到 VARCHAR(40)。若已写入 >40 字符群名，回滚会截断——回滚前需确认无超 40 字符数据。
+ALTER TABLE `group` MODIFY `name` VARCHAR(40) NOT NULL DEFAULT '';

--- a/modules/integration/1module.go
+++ b/modules/integration/1module.go
@@ -10,6 +10,9 @@ import (
 //go:embed sql
 var sqlFS embed.FS
 
+//go:embed swagger/api.yaml
+var swaggerContent string
+
 func init() {
 	register.AddModule(func(ctx interface{}) register.Module {
 		return register.Module{
@@ -17,7 +20,8 @@ func init() {
 			SetupAPI: func() register.APIRouter {
 				return New(ctx.(*config.Context))
 			},
-			SQLDir: register.NewSQLFS(sqlFS),
+			SQLDir:  register.NewSQLFS(sqlFS),
+			Swagger: swaggerContent,
 		}
 	})
 }

--- a/modules/integration/api.go
+++ b/modules/integration/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/botfather"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/oidc"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
@@ -39,6 +40,7 @@ type Integration struct {
 	oidcDB        *oidc.DB
 	oidcClient    *oidc.Client
 	apiKeyService botfather.UserAPIKeyService
+	groupService  group.IService
 	rateRedis     *rd.Client
 	log.Log
 }
@@ -49,6 +51,7 @@ func New(ctx *config.Context) *Integration {
 		db:            newIntegrationDB(ctx),
 		oidcDB:        oidc.NewDB(ctx),
 		apiKeyService: botfather.NewUserAPIKeyService(ctx),
+		groupService:  group.NewService(ctx),
 		rateRedis:     sharedIntegrationRateRedis(ctx.GetConfig()),
 		Log:           log.NewTLog("Integration"),
 	}
@@ -100,6 +103,8 @@ func (it *Integration) Route(r *wkhttp.WKHttp) {
 	base.GET("/spaces", it.oidcAuth(), uidLimit, it.listSpaces)
 	base.POST("/exchange", it.oidcAuth(), uidLimit, it.exchange)
 	base.DELETE("/binding", it.userAPIKeyAuth(), uidLimit, it.deleteBinding)
+	base.POST("/groups", it.userAPIKeyAuth(), uidLimit, it.createGroup)
+	base.GET("/groups/:group_no", it.userAPIKeyAuth(), uidLimit, it.groupExists)
 
 	manager := r.Group("/v1/manager", it.ctx.AuthMiddleware(r), uidLimit)
 	manager.PUT("/integrations/oidc/client", it.upsertManagerClient)

--- a/modules/integration/api_groups.go
+++ b/modules/integration/api_groups.go
@@ -1,0 +1,328 @@
+package integration
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	pkgspace "github.com/Mininglamp-OSS/octo-server/pkg/space"
+	"go.uber.org/zap"
+)
+
+const (
+	// maxTeamGroupMembers 单次建团队群可指定的 bot 数量上限（防滥用）。
+	maxTeamGroupMembers = 50
+	// idempotencyKeyHeader 客户端可选幂等 header（Stripe 式，缺省不保证幂等）。
+	idempotencyKeyHeader = "Idempotency-Key"
+	// idempotencyPendingTTL in-flight 占位 TTL；进程在「建群成功」与「写终值」之间崩溃
+	// 时最多保留这么久（之后过期，同 key 重试可能再建一个群——已知边界，可接受）。
+	idempotencyPendingTTL = 60 * time.Second
+	// idempotencyDoneTTL 终值（可回放）记录 TTL。
+	idempotencyDoneTTL = 24 * time.Hour
+)
+
+const (
+	idemStatePending = "pending"
+	idemStateDone    = "done"
+)
+
+// idemRecord 是幂等 Redis 值的载荷。pending 仅占坑（带请求指纹）；done 携带完整响应用于回放。
+type idemRecord struct {
+	State string           `json:"state"`
+	SHA   string           `json:"sha"`
+	Resp  *createGroupResp `json:"resp,omitempty"`
+}
+
+// createGroup handles POST /v1/integrations/oidc/groups —— 用 uk_ key 建团队群
+// （owner=当前用户，成员=指定的团队 bot；不设 bot_admin）。
+func (it *Integration) createGroup(c *wkhttp.Context) {
+	key, ok := getUserAPIKey(c)
+	if !ok {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+
+	var req createGroupReq
+	if err := c.BindJSON(&req); err != nil {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedParamInvalid, nil, i18n.Details{"field": "body"})
+		return
+	}
+
+	// 1. name：trim 后非空，rune 数 <= group.MaxGroupNameLen。service 层是静默截断，
+	//    这里前置 reject 超长，给出明确 400（否则会被悄悄截短）。
+	name := strings.TrimSpace(req.Name)
+	if name == "" || len([]rune(name)) > group.MaxGroupNameLen {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedParamInvalid, nil, i18n.Details{"field": "name"})
+		return
+	}
+
+	// 2. member_robot_ids：非空、去重、数量上限。
+	robotIDs := normalizeRobotIDs(req.MemberRobotIDs)
+	if len(robotIDs) == 0 || len(robotIDs) > maxTeamGroupMembers {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedParamInvalid, nil, i18n.Details{"field": "member_robot_ids"})
+		return
+	}
+
+	// 3. owner 在 Space：前置以拿到 403；否则 CreateGroup 内部的同名校验只会冒泡成 500。
+	member, err := pkgspace.CheckMembership(it.ctx.DB(), key.SpaceID, key.UID)
+	if err != nil {
+		it.Error("integration createGroup check membership failed", zap.Error(err), zap.String("uid", key.UID))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+	if !member {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedForbidden, nil, nil)
+		return
+	}
+
+	// 4. owner 必须是人类成员：bot 不走 OIDC exchange、拿不到 uk_ key，且 AuthByKey 只校验
+	//    账号活性不看 robot 标记，故这里显式防御，保证群主/创建者恒为真人，绝不把 bot 当 owner。
+	human, err := it.db.isHumanUser(key.UID)
+	if err != nil {
+		it.Error("integration createGroup check human owner failed", zap.Error(err), zap.String("uid", key.UID))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+	if !human {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedForbidden, nil, nil)
+		return
+	}
+
+	// 5. bot 集合校验：member_robot_ids ⊆ 当前用户在该 Space「可真正入群」的 bot 集合
+	//    （owned + 在 Space active + 有可用 user 行，口径与 CreateGroup 的插入源一致）。
+	//    任一不在集合 → 统一 404（防 ID 枚举，不区分不存在/不归属/不在 Space/不可用）；
+	//    且在建群前就拦掉，避免建出群后才发现某 bot 入不了群（孤儿群 + 500）。
+	usable, err := it.db.queryOwnedActiveBotIDs(key.UID, key.SpaceID)
+	if err != nil {
+		it.Error("integration createGroup query bots failed", zap.Error(err), zap.String("uid", key.UID))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+	for _, id := range robotIDs {
+		if !usable[id] {
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedNotFound, nil, nil)
+			return
+		}
+	}
+
+	// 幂等（可选）：仅当客户端带 Idempotency-Key 才启用。
+	idemKey := strings.TrimSpace(c.GetHeader(idempotencyKeyHeader))
+	payloadSHA := teamGroupPayloadSHA(name, robotIDs)
+	var redisKey string
+	reserved := false
+	if idemKey != "" {
+		redisKey = teamGroupIdemRedisKey(key.ClientID, key.UID, key.SpaceID, idemKey)
+		handled, holding := it.idemBegin(c, redisKey, payloadSHA)
+		if handled {
+			return // 响应已写出（回放 200 / 冲突 400 / in-flight 429）
+		}
+		reserved = holding
+	}
+
+	resp, err := it.doCreateTeamGroup(key.UID, key.SpaceID, name, robotIDs)
+	if err != nil {
+		if reserved {
+			it.rateRedis.Del(redisKey) // 放行同 key 重试
+		}
+		it.Error("integration createGroup failed", zap.Error(err),
+			zap.String("uid", key.UID), zap.String("space", key.SpaceID))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+
+	if reserved {
+		it.idemFinalize(redisKey, payloadSHA, resp)
+	}
+	c.Response(resp)
+}
+
+// doCreateTeamGroup 调底层建群并组装响应。
+func (it *Integration) doCreateTeamGroup(uid, spaceID, name string, robotIDs []string) (*createGroupResp, error) {
+	createResp, err := it.groupService.CreateGroup(&group.CreateGroupServiceReq{
+		Creator: uid,
+		Members: robotIDs,
+		Name:    name,
+		SpaceID: spaceID,
+		BotUID:  "", // 不指定 bot_admin
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// 响应只回真正入群的 bot（与 group_member 实况一致），绝不 echo 一个实际没进群的成员。
+	// pre-validation（queryOwnedActiveBotIDs）已保证常态下请求的 bot 全部入群；这里读回实况
+	// 仅为兜住「校验与建群之间 bot 被注销」这类极窄 TOCTOU 竞态——此时如实少回，而非建出
+	// 一个名不副实的群或回 500。
+	members, err := it.groupService.GetMembers(createResp.GroupNo)
+	if err != nil {
+		return nil, fmt.Errorf("verify group members: %w", err)
+	}
+	joined := make(map[string]bool, len(members))
+	for _, m := range members {
+		joined[m.UID] = true
+	}
+	actualBots := make([]string, 0, len(robotIDs))
+	for _, id := range robotIDs {
+		if joined[id] {
+			actualBots = append(actualBots, id)
+		}
+	}
+
+	createdAt, err := it.db.queryGroupCreatedAt(createResp.GroupNo)
+	if err != nil {
+		return nil, err
+	}
+
+	return &createGroupResp{
+		GroupID:        createResp.GroupNo,
+		SpaceID:        spaceID,
+		OwnerUserID:    uid,
+		MemberRobotIDs: actualBots,
+		Name:           createResp.Name,
+		CreatedAt:      createdAt.Format(time.RFC3339),
+	}, nil
+}
+
+// groupExists handles GET /v1/integrations/oidc/groups/:group_no —— 用户态存在性检测（恒 200）。
+func (it *Integration) groupExists(c *wkhttp.Context) {
+	key, ok := getUserAPIKey(c)
+	if !ok {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+	groupNo := strings.TrimSpace(c.Param("group_no"))
+	if groupNo == "" {
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedParamInvalid, nil, i18n.Details{"field": "group_no"})
+		return
+	}
+
+	exists, err := it.teamGroupExists(groupNo, key.SpaceID, key.UID)
+	if err != nil {
+		it.Error("integration groupExists check failed", zap.Error(err), zap.String("group_no", groupNo))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+	c.Response(groupExistsResp{GroupID: groupNo, Exists: exists})
+}
+
+// teamGroupExists 判定 owner 当前是否还能访问该群：群属于 key 绑定的 Space、状态 normal，且
+// owner 仍是活跃成员（未被移出 / 拉黑）。按 spaceID 限定，避免一把绑定 Space A 的 uk_ key 借
+// 用户在 Space B 的成员身份探测 Space B 的群（与建群同源的 Space 隔离）。真 DB 错误向上冒泡
+// （→ 500），仅「不在本 Space / 不存在 / 非成员」返回 exists=false。
+func (it *Integration) teamGroupExists(groupNo, spaceID, uid string) (bool, error) {
+	status, found, err := it.db.queryGroupStatus(groupNo, spaceID)
+	if err != nil {
+		return false, err
+	}
+	if !found || status != group.GroupStatusNormal {
+		return false, nil
+	}
+	active, err := it.groupService.ExistMemberActive(groupNo, uid)
+	if err != nil {
+		return false, err
+	}
+	return active, nil
+}
+
+// idemBegin 尝试占坑。返回 (handled, reserved)：
+//   - handled=true  → 响应已写出（回放 / 冲突 / in-flight），调用方应直接 return。
+//   - handled=false → 调用方继续建群；reserved 表示是否持有 pending 锁（需 finalize/release）。
+//
+// Redis 故障一律 fail-open（handled=false, reserved=false）：退化为不保证幂等而非阻断建群，
+// 与 integration 其余链路（限流 fail-open）一致。
+func (it *Integration) idemBegin(c *wkhttp.Context, redisKey, payloadSHA string) (handled, reserved bool) {
+	pending, _ := json.Marshal(idemRecord{State: idemStatePending, SHA: payloadSHA})
+	set, err := it.rateRedis.SetNX(redisKey, pending, idempotencyPendingTTL).Result()
+	if err != nil {
+		it.Warn("integration idempotency SETNX failed, proceeding without idempotency", zap.Error(err))
+		return false, false
+	}
+	if set {
+		return false, true // 首次，持锁
+	}
+
+	cur, err := it.rateRedis.Get(redisKey).Result()
+	if err != nil {
+		it.Warn("integration idempotency GET failed, proceeding", zap.Error(err))
+		return false, false
+	}
+	var existing idemRecord
+	if err := json.Unmarshal([]byte(cur), &existing); err != nil {
+		it.Warn("integration idempotency record corrupt, proceeding", zap.Error(err))
+		return false, false
+	}
+	switch existing.State {
+	case idemStatePending:
+		// in-flight：同 key 仍在处理 → 409 + Retry-After（可重试，区别于终态冲突）。
+		c.Header("Retry-After", "2")
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrIntegrationIdempotencyInFlight, nil, nil)
+		return true, false
+	case idemStateDone:
+		if existing.SHA == payloadSHA && existing.Resp != nil {
+			c.Response(existing.Resp) // 回放
+			return true, false
+		}
+		// 同 key 不同 payload → 409 终态冲突（不可重试）。
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrIntegrationIdempotencyConflict, nil, nil)
+		return true, false
+	default:
+		return false, false
+	}
+}
+
+// idemFinalize 用终值（含完整响应）覆写 pending 占位，TTL 24h；失败仅告警（不影响已成功的建群）。
+func (it *Integration) idemFinalize(redisKey, payloadSHA string, resp *createGroupResp) {
+	done, err := json.Marshal(idemRecord{State: idemStateDone, SHA: payloadSHA, Resp: resp})
+	if err != nil {
+		it.Warn("integration idempotency marshal done record failed", zap.Error(err))
+		return
+	}
+	if err := it.rateRedis.Set(redisKey, done, idempotencyDoneTTL).Err(); err != nil {
+		it.Warn("integration idempotency finalize failed", zap.Error(err))
+	}
+}
+
+// normalizeRobotIDs trim、去空、按出现顺序去重。
+func normalizeRobotIDs(ids []string) []string {
+	seen := make(map[string]bool, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	return out
+}
+
+// teamGroupPayloadSHA 计算请求指纹（与成员顺序无关）：name + 排序后的 robotIDs。
+func teamGroupPayloadSHA(name string, robotIDs []string) string {
+	sorted := make([]string, len(robotIDs))
+	copy(sorted, robotIDs)
+	sort.Strings(sorted)
+	h := sha256.New()
+	h.Write([]byte(name))
+	h.Write([]byte{0})
+	for _, id := range sorted {
+		h.Write([]byte(id))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// teamGroupIdemRedisKey namespaces the idempotency record by client/uid/space so a
+// key is only ever replayed for the same integration client that created it.
+func teamGroupIdemRedisKey(clientID, uid, spaceID, idemKey string) string {
+	return fmt.Sprintf("octo:idem:%s:groupcreate:%s:%s:%s", clientID, uid, spaceID, idemKey)
+}

--- a/modules/integration/api_groups.go
+++ b/modules/integration/api_groups.go
@@ -141,11 +141,11 @@ func (it *Integration) createGroup(c *wkhttp.Context) {
 
 	resp, err := it.doCreateTeamGroup(key.UID, key.SpaceID, name, robotIDs)
 	if err != nil {
-		// 仅「建群提交前」失败会走到这里（doCreateTeamGroup 在 CreateGroup 提交后不再返回错误），
-		// 群未落库，可安全释放 pending 让同 key 重试；提交后的组装失败不会到这、也就不会重复建群。
-		if reserved {
-			it.rateRedis.Del(redisKey)
-		}
+		// CreateGroup 返回 error **不保证**群未落库：它会在 tx.Commit() 之后调
+		// IMCreateOrUpdateChannel，失败时做 best-effort 补偿删除（补偿删除自身失败则群行残留）
+		// 再返回 error。因此这里**不**释放 pending 幂等 key —— 释放会让同 key 重试再建一个群
+		// （重复 / 孤立群）。让 pending 随 TTL 自然过期后才允许重试，把重复窗口收敛到与进程崩溃
+		// 窗口同级（已知可接受边界）。同 key 在此期间重试 → idemLookup 命中 pending → 409 in-flight。
 		it.Error("integration createGroup failed", zap.Error(err),
 			zap.String("uid", key.UID), zap.String("space", key.SpaceID))
 		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
@@ -160,9 +160,14 @@ func (it *Integration) createGroup(c *wkhttp.Context) {
 
 // doCreateTeamGroup 调底层建群并组装响应。
 //
-// 关键不变量：CreateGroup 一旦返回成功，群就已提交落库；此后**绝不**再返回 error。否则调用方
-// 会把「提交后的组装失败」当成建群失败去 Del 幂等 pending key，导致同 key 重试再建一个群。
-// 因此 CreateGroup 之后的两次读（成员实况 / created_at）都做成 best-effort 降级。
+// 注意 group.CreateGroup 的真实契约（review #377：Jerry-Xin/yujiawei/lml2468 P1）：返回 nil err
+// 表示群已提交；但返回**非 nil err 并不保证群未创建**——它在 tx.Commit() 之后还会调
+// IMCreateOrUpdateChannel，失败时做 best-effort 补偿删除（补偿删除失败则群行残留）再返回 error。
+// 所以本函数：
+//   - CreateGroup 返回 error 直接上抛，调用方据此**不会**释放幂等 key（不能把它当「提交前、可安全
+//     重试」），见 createGroup 的错误分支；
+//   - CreateGroup 成功后的成员实况 / created_at 两次读做 best-effort 降级，绝不因这些读失败而把一个
+//     已落库的群当成失败。
 func (it *Integration) doCreateTeamGroup(uid, spaceID, name string, robotIDs []string) (*createGroupResp, error) {
 	createResp, err := it.groupService.CreateGroup(&group.CreateGroupServiceReq{
 		Creator: uid,
@@ -172,7 +177,7 @@ func (it *Integration) doCreateTeamGroup(uid, spaceID, name string, robotIDs []s
 		BotUID:  "", // 不指定 bot_admin
 	})
 	if err != nil {
-		return nil, err // 提交前失败（已回滚），可安全释放幂等 key 重试
+		return nil, err // 注意：不保证群未落库（见上）；调用方不得据此释放幂等 key
 	}
 
 	// 响应只回真正入群的 bot（与 group_member 实况一致），绝不 echo 一个实际没进群的成员。
@@ -196,13 +201,14 @@ func (it *Integration) doCreateTeamGroup(uid, spaceID, name string, robotIDs []s
 		actualBots = filtered
 	}
 
-	// created_at 取 DB 真实建群时间；读失败 → 退回服务端当前时刻（best-effort）。
-	createdAt := time.Now()
-	if t, cErr := it.db.queryGroupCreatedAt(createResp.GroupNo); cErr != nil {
+	// created_at 取 DB 真实建群时间；读失败 → 退回服务端当前时刻（best-effort）。两个分支都归一到
+	// UTC 再格式化，避免 fallback 与 DB 值在时区/RFC3339 偏移上漂移。
+	createdAt := time.Now().UTC()
+	if t, cErr := it.db.queryGroupCreatedAt(createResp.GroupNo, spaceID); cErr != nil {
 		it.Warn("integration createGroup read created_at failed; using server time",
 			zap.Error(cErr), zap.String("groupNo", createResp.GroupNo))
 	} else {
-		createdAt = t
+		createdAt = t.UTC()
 	}
 
 	return &createGroupResp{

--- a/modules/integration/api_groups.go
+++ b/modules/integration/api_groups.go
@@ -72,6 +72,20 @@ func (it *Integration) createGroup(c *wkhttp.Context) {
 		return
 	}
 
+	// 幂等（可选，Stripe 式）：仅当客户端带 Idempotency-Key 才启用。关键顺序——先按 body 指纹
+	// 查幂等记录（回放/冲突/in-flight），放在下面 membership / human / bot 这些「可变」校验之前：
+	// 首次成功后即便调用者成员身份或 bot 状态变了，同 key + 同 body 的重试仍能回放原结果，
+	// 而不是撞 403/404（满足回放契约）。
+	idemKey := strings.TrimSpace(c.GetHeader(idempotencyKeyHeader))
+	var redisKey, payloadSHA string
+	if idemKey != "" {
+		payloadSHA = teamGroupPayloadSHA(name, robotIDs)
+		redisKey = teamGroupIdemRedisKey(key.ClientID, key.UID, key.SpaceID, idemKey)
+		if it.idemLookup(c, redisKey, payloadSHA) {
+			return // 已写出：回放 200 / 冲突 409 / in-flight 409
+		}
+	}
+
 	// 3. owner 在 Space：前置以拿到 403；否则 CreateGroup 内部的同名校验只会冒泡成 500。
 	member, err := pkgspace.CheckMembership(it.ctx.DB(), key.SpaceID, key.UID)
 	if err != nil {
@@ -114,24 +128,23 @@ func (it *Integration) createGroup(c *wkhttp.Context) {
 		}
 	}
 
-	// 幂等（可选）：仅当客户端带 Idempotency-Key 才启用。
-	idemKey := strings.TrimSpace(c.GetHeader(idempotencyKeyHeader))
-	payloadSHA := teamGroupPayloadSHA(name, robotIDs)
-	var redisKey string
+	// 首次请求才占坑（reserve）：上面 idemLookup 已排除回放/冲突/in-flight；这里 SETNX 兜住
+	// 并发首次请求的竞争。
 	reserved := false
 	if idemKey != "" {
-		redisKey = teamGroupIdemRedisKey(key.ClientID, key.UID, key.SpaceID, idemKey)
-		handled, holding := it.idemBegin(c, redisKey, payloadSHA)
+		handled, holding := it.idemReserve(c, redisKey, payloadSHA)
 		if handled {
-			return // 响应已写出（回放 200 / 冲突 400 / in-flight 429）
+			return // 与并发首次请求竞争失败 → 已写出回放/冲突/in-flight
 		}
 		reserved = holding
 	}
 
 	resp, err := it.doCreateTeamGroup(key.UID, key.SpaceID, name, robotIDs)
 	if err != nil {
+		// 仅「建群提交前」失败会走到这里（doCreateTeamGroup 在 CreateGroup 提交后不再返回错误），
+		// 群未落库，可安全释放 pending 让同 key 重试；提交后的组装失败不会到这、也就不会重复建群。
 		if reserved {
-			it.rateRedis.Del(redisKey) // 放行同 key 重试
+			it.rateRedis.Del(redisKey)
 		}
 		it.Error("integration createGroup failed", zap.Error(err),
 			zap.String("uid", key.UID), zap.String("space", key.SpaceID))
@@ -146,6 +159,10 @@ func (it *Integration) createGroup(c *wkhttp.Context) {
 }
 
 // doCreateTeamGroup 调底层建群并组装响应。
+//
+// 关键不变量：CreateGroup 一旦返回成功，群就已提交落库；此后**绝不**再返回 error。否则调用方
+// 会把「提交后的组装失败」当成建群失败去 Del 幂等 pending key，导致同 key 重试再建一个群。
+// 因此 CreateGroup 之后的两次读（成员实况 / created_at）都做成 best-effort 降级。
 func (it *Integration) doCreateTeamGroup(uid, spaceID, name string, robotIDs []string) (*createGroupResp, error) {
 	createResp, err := it.groupService.CreateGroup(&group.CreateGroupServiceReq{
 		Creator: uid,
@@ -155,31 +172,37 @@ func (it *Integration) doCreateTeamGroup(uid, spaceID, name string, robotIDs []s
 		BotUID:  "", // 不指定 bot_admin
 	})
 	if err != nil {
-		return nil, err
+		return nil, err // 提交前失败（已回滚），可安全释放幂等 key 重试
 	}
 
 	// 响应只回真正入群的 bot（与 group_member 实况一致），绝不 echo 一个实际没进群的成员。
-	// pre-validation（queryOwnedActiveBotIDs）已保证常态下请求的 bot 全部入群；这里读回实况
-	// 仅为兜住「校验与建群之间 bot 被注销」这类极窄 TOCTOU 竞态——此时如实少回，而非建出
-	// 一个名不副实的群或回 500。
-	members, err := it.groupService.GetMembers(createResp.GroupNo)
-	if err != nil {
-		return nil, fmt.Errorf("verify group members: %w", err)
-	}
-	joined := make(map[string]bool, len(members))
-	for _, m := range members {
-		joined[m.UID] = true
-	}
-	actualBots := make([]string, 0, len(robotIDs))
-	for _, id := range robotIDs {
-		if joined[id] {
-			actualBots = append(actualBots, id)
+	// pre-validation（queryOwnedActiveBotIDs）已保证常态下请求的 bot 全部入群；读回实况兜住
+	// 「校验与建群之间 bot 被注销」这类极窄 TOCTOU 竞态。读失败 → 退回请求集合（best-effort）。
+	actualBots := robotIDs
+	if members, mErr := it.groupService.GetMembers(createResp.GroupNo); mErr != nil {
+		it.Warn("integration createGroup verify members failed; echoing requested",
+			zap.Error(mErr), zap.String("groupNo", createResp.GroupNo))
+	} else {
+		joined := make(map[string]bool, len(members))
+		for _, m := range members {
+			joined[m.UID] = true
 		}
+		filtered := make([]string, 0, len(robotIDs))
+		for _, id := range robotIDs {
+			if joined[id] {
+				filtered = append(filtered, id)
+			}
+		}
+		actualBots = filtered
 	}
 
-	createdAt, err := it.db.queryGroupCreatedAt(createResp.GroupNo)
-	if err != nil {
-		return nil, err
+	// created_at 取 DB 真实建群时间；读失败 → 退回服务端当前时刻（best-effort）。
+	createdAt := time.Now()
+	if t, cErr := it.db.queryGroupCreatedAt(createResp.GroupNo); cErr != nil {
+		it.Warn("integration createGroup read created_at failed; using server time",
+			zap.Error(cErr), zap.String("groupNo", createResp.GroupNo))
+	} else {
+		createdAt = t
 	}
 
 	return &createGroupResp{
@@ -214,16 +237,21 @@ func (it *Integration) groupExists(c *wkhttp.Context) {
 	c.Response(groupExistsResp{GroupID: groupNo, Exists: exists})
 }
 
-// teamGroupExists 判定 owner 当前是否还能访问该群：群属于 key 绑定的 Space、状态 normal，且
-// owner 仍是活跃成员（未被移出 / 拉黑）。按 spaceID 限定，避免一把绑定 Space A 的 uk_ key 借
-// 用户在 Space B 的成员身份探测 Space B 的群（与建群同源的 Space 隔离）。真 DB 错误向上冒泡
-// （→ 500），仅「不在本 Space / 不存在 / 非成员」返回 exists=false。
+// teamGroupExists 判定 owner 当前是否还能访问该群。语义是「创建者态」而非「成员态」：群属于
+// key 绑定的 Space、状态 normal、**调用者就是群主（group.creator==uid）**，且其仍是活跃成员
+// （未被移出 / 拉黑）。
+//
+//   - 按 spaceID 限定：避免一把绑定 Space A 的 uk_ key 探测 Space B 的群。
+//   - 要求 creator==uid：避免「调用者只是同 Space 某群的普通成员」也被判 true——存在性检测的
+//     契约是「我创建的群是否还在」，不是「我是不是某群成员」。
+//
+// 真 DB 错误向上冒泡（→ 500）；「不在本 Space / 不存在 / 非创建者 / 非活跃成员」均 exists=false。
 func (it *Integration) teamGroupExists(groupNo, spaceID, uid string) (bool, error) {
-	status, found, err := it.db.queryGroupStatus(groupNo, spaceID)
+	status, creator, found, err := it.db.queryGroupStatus(groupNo, spaceID)
 	if err != nil {
 		return false, err
 	}
-	if !found || status != group.GroupStatusNormal {
+	if !found || status != group.GroupStatusNormal || creator != uid {
 		return false, nil
 	}
 	active, err := it.groupService.ExistMemberActive(groupNo, uid)
@@ -233,13 +261,24 @@ func (it *Integration) teamGroupExists(groupNo, spaceID, uid string) (bool, erro
 	return active, nil
 }
 
-// idemBegin 尝试占坑。返回 (handled, reserved)：
-//   - handled=true  → 响应已写出（回放 / 冲突 / in-flight），调用方应直接 return。
-//   - handled=false → 调用方继续建群；reserved 表示是否持有 pending 锁（需 finalize/release）。
+// idemLookup 只读地查已存在的幂等记录并处理回放/冲突/in-flight，不占坑。返回 handled=true 表示
+// 已写出响应（调用方直接 return）。无记录或 Redis 故障 → handled=false（fail-open，继续建群）。
+// 放在 mutable 校验之前调用，保证首次成功后即便状态变化，同 key+同 body 仍能回放。
+func (it *Integration) idemLookup(c *wkhttp.Context, redisKey, payloadSHA string) (handled bool) {
+	cur, err := it.rateRedis.Get(redisKey).Result()
+	if err != nil {
+		// redis.Nil（无记录）或瞬时错误 → 继续走首次流程。
+		return false
+	}
+	return it.idemHandleRecord(c, cur, payloadSHA)
+}
+
+// idemReserve 原子占坑（SETNX pending，带 TTL）。返回：
+//   - handled=true  → 与并发首次请求竞争失败，已按现存记录写出回放/冲突/in-flight，调用方 return。
+//   - reserved=true → 成功持有 pending 锁（需 finalize 或失败时 release）。
 //
-// Redis 故障一律 fail-open（handled=false, reserved=false）：退化为不保证幂等而非阻断建群，
-// 与 integration 其余链路（限流 fail-open）一致。
-func (it *Integration) idemBegin(c *wkhttp.Context, redisKey, payloadSHA string) (handled, reserved bool) {
+// Redis 故障一律 fail-open（handled=false, reserved=false）：退化为不保证幂等而非阻断建群。
+func (it *Integration) idemReserve(c *wkhttp.Context, redisKey, payloadSHA string) (handled, reserved bool) {
 	pending, _ := json.Marshal(idemRecord{State: idemStatePending, SHA: payloadSHA})
 	set, err := it.rateRedis.SetNX(redisKey, pending, idempotencyPendingTTL).Result()
 	if err != nil {
@@ -249,33 +288,38 @@ func (it *Integration) idemBegin(c *wkhttp.Context, redisKey, payloadSHA string)
 	if set {
 		return false, true // 首次，持锁
 	}
-
+	// 竞争失败：lookup 与此处之间有人占坑/完成。重读并按现存记录处理。
 	cur, err := it.rateRedis.Get(redisKey).Result()
 	if err != nil {
 		it.Warn("integration idempotency GET failed, proceeding", zap.Error(err))
 		return false, false
 	}
+	return it.idemHandleRecord(c, cur, payloadSHA), false
+}
+
+// idemHandleRecord 解析一条现存记录并写出对应响应。返回是否写出（true → 调用方 return）。
+func (it *Integration) idemHandleRecord(c *wkhttp.Context, cur, payloadSHA string) bool {
 	var existing idemRecord
 	if err := json.Unmarshal([]byte(cur), &existing); err != nil {
 		it.Warn("integration idempotency record corrupt, proceeding", zap.Error(err))
-		return false, false
+		return false
 	}
 	switch existing.State {
 	case idemStatePending:
 		// in-flight：同 key 仍在处理 → 409 + Retry-After（可重试，区别于终态冲突）。
 		c.Header("Retry-After", "2")
 		httperr.ResponseErrorLWithStatus(c, errcode.ErrIntegrationIdempotencyInFlight, nil, nil)
-		return true, false
+		return true
 	case idemStateDone:
 		if existing.SHA == payloadSHA && existing.Resp != nil {
 			c.Response(existing.Resp) // 回放
-			return true, false
+			return true
 		}
 		// 同 key 不同 payload → 409 终态冲突（不可重试）。
 		httperr.ResponseErrorLWithStatus(c, errcode.ErrIntegrationIdempotencyConflict, nil, nil)
-		return true, false
+		return true
 	default:
-		return false, false
+		return false
 	}
 }
 
@@ -321,8 +365,11 @@ func teamGroupPayloadSHA(name string, robotIDs []string) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-// teamGroupIdemRedisKey namespaces the idempotency record by client/uid/space so a
-// key is only ever replayed for the same integration client that created it.
+// teamGroupIdemRedisKey namespaces the idempotency record by client/uid/space so a key is
+// only ever replayed for the same integration client that created it. The client-supplied
+// Idempotency-Key is hashed (not concatenated raw) so the Redis key has a fixed, bounded
+// size regardless of how long a header the caller sends.
 func teamGroupIdemRedisKey(clientID, uid, spaceID, idemKey string) string {
-	return fmt.Sprintf("octo:idem:%s:groupcreate:%s:%s:%s", clientID, uid, spaceID, idemKey)
+	sum := sha256.Sum256([]byte(idemKey))
+	return fmt.Sprintf("octo:idem:%s:groupcreate:%s:%s:%s", clientID, uid, spaceID, hex.EncodeToString(sum[:]))
 }

--- a/modules/integration/api_groups_test.go
+++ b/modules/integration/api_groups_test.go
@@ -403,6 +403,75 @@ func TestIntegrationTeamGroupExistsIsSpaceScoped(t *testing.T) {
 	assert.True(t, exists(keyB), "the space-B key must see its own group")
 }
 
+// TestIntegrationTeamGroupEndpointsRejectUnauthenticated pins that both endpoints sit behind
+// userAPIKeyAuth — a missing, malformed, or unknown token is rejected with 401 before any
+// handler logic runs. Guards against a future refactor accidentally dropping the auth.
+func TestIntegrationTeamGroupEndpointsRejectUnauthenticated(t *testing.T) {
+	route, _, _ := setupIntegrationAPITest(t)
+	endpoints := []struct {
+		method, path string
+		body         interface{}
+	}{
+		{http.MethodPost, "/v1/integrations/oidc/groups", map[string]interface{}{"name": "x", "member_robot_ids": []string{"b"}}},
+		{http.MethodGet, "/v1/integrations/oidc/groups/grp_x", nil},
+	}
+	for _, ep := range endpoints {
+		for _, token := range []string{"", "garbage-no-prefix", "uk_does_not_exist"} {
+			w := httptest.NewRecorder()
+			route.ServeHTTP(w, integrationRequest(t, ep.method, ep.path, token, ep.body))
+			require.Equal(t, http.StatusUnauthorized, w.Code, "%s %s token=%q: %s", ep.method, ep.path, token, w.Body.String())
+			assert.Equal(t, "err.shared.auth.token_invalid", decodeErrCode(t, w))
+		}
+	}
+}
+
+// TestIntegrationTeamGroupExistsIsOwnerScoped verifies the existence check is owner-scoped, not
+// merely member-scoped: a same-space active member who is NOT the group creator gets
+// exists:false, while the creator gets exists:true.
+func TestIntegrationTeamGroupExistsIsOwnerScoped(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	subjA := "sub-owner-a"
+	uidA := seedIntegrationUser(t, ctx, mp.Issuer, subjA)
+	space := "sp_" + util.GenerUUID()[:8]
+	seedSpaceMembership(t, ctx, uidA, space, "Team", 1, "2026-01-01 10:00:00")
+	bot := "bot_" + util.GenerUUID()[:8]
+	seedOwnBot(t, ctx, uidA, space, bot, "")
+	keyA := exchangeTeamGroupKey(t, route, mp, subjA, space)
+
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/groups", keyA, map[string]interface{}{
+		"name":             "团队群",
+		"member_robot_ids": []string{bot},
+	}))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var created createGroupResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	groupNo := created.GroupID
+
+	// User B: active member of the same space AND an active member of A's group, but not creator.
+	subjB := "sub-member-b"
+	uidB := seedIntegrationUser(t, ctx, mp.Issuer, subjB)
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO space_member (space_id, uid, role, status, created_at, updated_at) VALUES (?, ?, 0, 1, NOW(), NOW())",
+		space, uidB,
+	).Exec()
+	require.NoError(t, err)
+	_, err = ctx.DB().InsertBySql("INSERT INTO `group_member` (group_no, uid) VALUES (?, ?)", groupNo, uidB).Exec()
+	require.NoError(t, err)
+	keyB := exchangeTeamGroupKey(t, route, mp, subjB, space)
+
+	exists := func(apiKey string) bool {
+		ww := httptest.NewRecorder()
+		route.ServeHTTP(ww, integrationRequest(t, http.MethodGet, "/v1/integrations/oidc/groups/"+groupNo, apiKey, nil))
+		require.Equal(t, http.StatusOK, ww.Code, ww.Body.String())
+		var r groupExistsResp
+		require.NoError(t, json.Unmarshal(ww.Body.Bytes(), &r))
+		return r.Exists
+	}
+	assert.False(t, exists(keyB), "a non-creator active member must not see the group as existing")
+	assert.True(t, exists(keyA), "the creator must see their own group")
+}
+
 // decodeErrCode extracts error.code from the shared i18n error envelope.
 func decodeErrCode(t *testing.T, w *httptest.ResponseRecorder) string {
 	t.Helper()

--- a/modules/integration/api_groups_test.go
+++ b/modules/integration/api_groups_test.go
@@ -1,0 +1,412 @@
+package integration
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-server/modules/botfather"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/oidc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// exchangeTeamGroupKey runs the OIDC exchange to mint a uk_ key for (subject, spaceID).
+func exchangeTeamGroupKey(t *testing.T, route http.Handler, mp *oidc.MockProvider, subject, spaceID string) string {
+	t.Helper()
+	idToken := mintIntegrationIDToken(t, mp, subject)
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/exchange", idToken, map[string]interface{}{
+		"space_id": spaceID,
+	}))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var resp struct {
+		APIKey string `json:"api_key"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp.APIKey)
+	return resp.APIKey
+}
+
+type teamGroupMemberRow struct {
+	UID      string `db:"uid"`
+	Role     int    `db:"role"`
+	Robot    int    `db:"robot"`
+	BotAdmin int    `db:"bot_admin"`
+}
+
+func queryTeamGroupMembers(t *testing.T, ctx *config.Context, groupNo string) []teamGroupMemberRow {
+	t.Helper()
+	var rows []teamGroupMemberRow
+	_, err := ctx.DB().SelectBySql(
+		"SELECT uid, role, robot, bot_admin FROM group_member WHERE group_no=? AND is_deleted=0 ORDER BY role DESC, uid ASC",
+		groupNo,
+	).Load(&rows)
+	require.NoError(t, err)
+	return rows
+}
+
+func TestIntegrationCreateTeamGroupSuccess(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	subject := "sub-create-ok"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	spaceID := "sp_" + util.GenerUUID()[:8]
+	seedSpaceMembership(t, ctx, uid, spaceID, "Team", 1, "2026-01-01 10:00:00")
+	botA := "bot_" + util.GenerUUID()[:8]
+	botB := "bot_" + util.GenerUUID()[:8]
+	seedOwnBot(t, ctx, uid, spaceID, botA, "")
+	seedOwnBot(t, ctx, uid, spaceID, botB, "")
+	apiKey := exchangeTeamGroupKey(t, route, mp, subject, spaceID)
+
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/groups", apiKey, map[string]interface{}{
+		"name":             "团队群",
+		"member_robot_ids": []string{botA, botB},
+	}))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var resp createGroupResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.GroupID)
+	assert.Equal(t, spaceID, resp.SpaceID)
+	assert.Equal(t, uid, resp.OwnerUserID)
+	assert.Equal(t, "团队群", resp.Name)
+	assert.ElementsMatch(t, []string{botA, botB}, resp.MemberRobotIDs)
+	_, err := time.Parse(time.RFC3339, resp.CreatedAt)
+	assert.NoError(t, err, "created_at must be RFC3339, got %q", resp.CreatedAt)
+
+	// 落库断言：owner=creator role，bot role=common + robot=1，无 bot_admin。
+	members := queryTeamGroupMembers(t, ctx, resp.GroupID)
+	byUID := make(map[string]teamGroupMemberRow, len(members))
+	for _, m := range members {
+		byUID[m.UID] = m
+		assert.Equal(t, 0, m.BotAdmin, "no member should be bot_admin, uid=%s", m.UID)
+	}
+	require.Contains(t, byUID, uid)
+	assert.Equal(t, group.MemberRoleCreator, byUID[uid].Role)
+	for _, b := range []string{botA, botB} {
+		require.Contains(t, byUID, b, "bot %s must be a real group member", b)
+		assert.Equal(t, group.MemberRoleCommon, byUID[b].Role)
+		assert.Equal(t, 1, byUID[b].Robot, "bot %s must have robot=1", b)
+	}
+}
+
+func TestIntegrationCreateTeamGroupNameBoundary(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	subject := "sub-name-bound"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	spaceID := "sp_" + util.GenerUUID()[:8]
+	seedSpaceMembership(t, ctx, uid, spaceID, "Team", 1, "2026-01-01 10:00:00")
+	bot := "bot_" + util.GenerUUID()[:8]
+	seedOwnBot(t, ctx, uid, spaceID, bot, "")
+	apiKey := exchangeTeamGroupKey(t, route, mp, subject, spaceID)
+
+	// 50 runes → OK.
+	name50 := strings.Repeat("名", 50)
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/groups", apiKey, map[string]interface{}{
+		"name":             name50,
+		"member_robot_ids": []string{bot},
+	}))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var resp createGroupResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, name50, resp.Name)
+
+	// 51 runes → 400 param invalid (field name).
+	name51 := strings.Repeat("名", 51)
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/groups", apiKey, map[string]interface{}{
+		"name":             name51,
+		"member_robot_ids": []string{bot},
+	}))
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	assert.Equal(t, "err.shared.param.invalid", decodeErrCode(t, w))
+}
+
+func TestIntegrationCreateTeamGroupEmptyAndDedupMembers(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	subject := "sub-members"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	spaceID := "sp_" + util.GenerUUID()[:8]
+	seedSpaceMembership(t, ctx, uid, spaceID, "Team", 1, "2026-01-01 10:00:00")
+	bot := "bot_" + util.GenerUUID()[:8]
+	seedOwnBot(t, ctx, uid, spaceID, bot, "")
+	apiKey := exchangeTeamGroupKey(t, route, mp, subject, spaceID)
+
+	// empty → 400.
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/groups", apiKey, map[string]interface{}{
+		"name":             "团队群",
+		"member_robot_ids": []string{},
+	}))
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	assert.Equal(t, "err.shared.param.invalid", decodeErrCode(t, w))
+
+	// duplicates collapse to one member.
+	w = httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/groups", apiKey, map[string]interface{}{
+		"name":             "团队群",
+		"member_robot_ids": []string{bot, bot, " " + bot + " "},
+	}))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var resp createGroupResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, []string{bot}, resp.MemberRobotIDs)
+}
+
+func TestIntegrationCreateTeamGroupBotNotOwnedReturns404(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	subject := "sub-bot-404"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	spaceID := "sp_" + util.GenerUUID()[:8]
+	seedSpaceMembership(t, ctx, uid, spaceID, "Team", 1, "2026-01-01 10:00:00")
+	ownBot := "bot_" + util.GenerUUID()[:8]
+	seedOwnBot(t, ctx, uid, spaceID, ownBot, "")
+
+	// A bot owned by a different user, in a different space → not in caller's set.
+	otherUID := seedIntegrationUser(t, ctx, mp.Issuer, "sub-other")
+	otherSpace := "sp_" + util.GenerUUID()[:8]
+	seedSpaceMembership(t, ctx, otherUID, otherSpace, "Other", 1, "2026-01-01 10:00:00")
+	foreignBot := "bot_" + util.GenerUUID()[:8]
+	seedOwnBot(t, ctx, otherUID, otherSpace, foreignBot, "")
+
+	apiKey := exchangeTeamGroupKey(t, route, mp, subject, spaceID)
+
+	for _, badBot := range []string{foreignBot, "bot_does_not_exist"} {
+		w := httptest.NewRecorder()
+		route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/groups", apiKey, map[string]interface{}{
+			"name":             "团队群",
+			"member_robot_ids": []string{ownBot, badBot},
+		}))
+		require.Equal(t, http.StatusNotFound, w.Code, "bad bot %q: %s", badBot, w.Body.String())
+		assert.Equal(t, "err.shared.not_found", decodeErrCode(t, w))
+	}
+}
+
+func TestIntegrationCreateTeamGroupOwnerNotSpaceMemberReturns403(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	subject := "sub-403"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	spaceID := "sp_" + util.GenerUUID()[:8]
+	// Owner is a member at exchange time (so the key issues), then removed before create.
+	seedSpaceMembership(t, ctx, uid, spaceID, "Team", 1, "2026-01-01 10:00:00")
+	bot := "bot_" + util.GenerUUID()[:8]
+	seedOwnBot(t, ctx, uid, spaceID, bot, "")
+	apiKey := exchangeTeamGroupKey(t, route, mp, subject, spaceID)
+
+	_, err := ctx.DB().Update("space_member").Set("status", 0).
+		Where("space_id=? AND uid=?", spaceID, uid).Exec()
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/groups", apiKey, map[string]interface{}{
+		"name":             "团队群",
+		"member_robot_ids": []string{bot},
+	}))
+	require.Equal(t, http.StatusForbidden, w.Code, w.Body.String())
+	assert.Equal(t, "err.shared.auth.forbidden", decodeErrCode(t, w))
+}
+
+func TestIntegrationCreateTeamGroupRejectsRobotOwner(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	subject := "sub-robot-owner"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	// Flip the OIDC-linked account to a robot. AuthByKey only checks account activity (not
+	// the robot flag), so the key still authenticates — the owner-must-be-human guard in
+	// createGroup is what must reject it.
+	_, err := ctx.DB().Update("user").Set("robot", 1).Where("uid=?", uid).Exec()
+	require.NoError(t, err)
+	spaceID := "sp_" + util.GenerUUID()[:8]
+	seedSpaceMembership(t, ctx, uid, spaceID, "Team", 1, "2026-01-01 10:00:00")
+	bot := "bot_" + util.GenerUUID()[:8]
+	seedOwnBot(t, ctx, uid, spaceID, bot, "")
+	apiKey := exchangeTeamGroupKey(t, route, mp, subject, spaceID)
+
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/groups", apiKey, map[string]interface{}{
+		"name":             "团队群",
+		"member_robot_ids": []string{bot},
+	}))
+	require.Equal(t, http.StatusForbidden, w.Code, w.Body.String())
+	assert.Equal(t, "err.shared.auth.forbidden", decodeErrCode(t, w))
+}
+
+func TestIntegrationCreateTeamGroupRejectsForeignClientKey(t *testing.T) {
+	route, ctx, _ := setupIntegrationAPITest(t)
+	// A key scoped to a different client (here botfather) must be rejected by the
+	// middleware — the uk_ endpoints only accept the registered integration client.
+	botfatherUID := "u_" + util.GenerUUID()[:8]
+	insertIntegrationBareUser(t, ctx, botfatherUID)
+	botfatherKey, err := botfather.NewUserAPIKeyService(ctx).GetOrCreate(botfatherUID, "", "")
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/groups", botfatherKey, map[string]interface{}{
+		"name":             "团队群",
+		"member_robot_ids": []string{"bot_x"},
+	}))
+	require.Equal(t, http.StatusUnauthorized, w.Code, w.Body.String())
+	assert.Equal(t, "err.shared.auth.token_invalid", decodeErrCode(t, w))
+}
+
+func TestIntegrationCreateTeamGroupIdempotency(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	subject := "sub-idem"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	spaceID := "sp_" + util.GenerUUID()[:8]
+	seedSpaceMembership(t, ctx, uid, spaceID, "Team", 1, "2026-01-01 10:00:00")
+	bot := "bot_" + util.GenerUUID()[:8]
+	seedOwnBot(t, ctx, uid, spaceID, bot, "")
+	apiKey := exchangeTeamGroupKey(t, route, mp, subject, spaceID)
+
+	doCreate := func(idemKey, name string) *httptest.ResponseRecorder {
+		req := integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/groups", apiKey, map[string]interface{}{
+			"name":             name,
+			"member_robot_ids": []string{bot},
+		})
+		if idemKey != "" {
+			req.Header.Set(idempotencyKeyHeader, idemKey)
+		}
+		w := httptest.NewRecorder()
+		route.ServeHTTP(w, req)
+		return w
+	}
+
+	// Same key + same payload → replay same group_id.
+	idemKey := "idem-" + util.GenerUUID()[:8]
+	w1 := doCreate(idemKey, "团队群")
+	require.Equal(t, http.StatusOK, w1.Code, w1.Body.String())
+	var r1 createGroupResp
+	require.NoError(t, json.Unmarshal(w1.Body.Bytes(), &r1))
+
+	w2 := doCreate(idemKey, "团队群")
+	require.Equal(t, http.StatusOK, w2.Code, w2.Body.String())
+	var r2 createGroupResp
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &r2))
+	assert.Equal(t, r1.GroupID, r2.GroupID, "same idempotency key + payload must replay the same group")
+
+	// Same key + different payload → 409 terminal conflict (not retryable).
+	w3 := doCreate(idemKey, "另一个名字")
+	require.Equal(t, http.StatusConflict, w3.Code, w3.Body.String())
+	assert.Equal(t, "err.server.integration.idempotency_conflict", decodeErrCode(t, w3))
+
+	// In-flight (pending sentinel present) → 409 with Retry-After (retryable).
+	inflightKey := "idem-inflight-" + util.GenerUUID()[:8]
+	pending, _ := json.Marshal(idemRecord{State: idemStatePending, SHA: "stale"})
+	rkey := teamGroupIdemRedisKey(defaultClientID, uid, spaceID, inflightKey)
+	require.NoError(t, sharedIntegrationRateRedis(ctx.GetConfig()).Set(rkey, pending, time.Minute).Err())
+	w4 := doCreate(inflightKey, "团队群")
+	require.Equal(t, http.StatusConflict, w4.Code, w4.Body.String())
+	assert.Equal(t, "err.server.integration.idempotency_in_flight", decodeErrCode(t, w4))
+	assert.NotEmpty(t, w4.Header().Get("Retry-After"))
+}
+
+func TestIntegrationTeamGroupExists(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	subject := "sub-exists"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	spaceID := "sp_" + util.GenerUUID()[:8]
+	seedSpaceMembership(t, ctx, uid, spaceID, "Team", 1, "2026-01-01 10:00:00")
+	bot := "bot_" + util.GenerUUID()[:8]
+	seedOwnBot(t, ctx, uid, spaceID, bot, "")
+	apiKey := exchangeTeamGroupKey(t, route, mp, subject, spaceID)
+
+	// Create a group to probe.
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/groups", apiKey, map[string]interface{}{
+		"name":             "团队群",
+		"member_robot_ids": []string{bot},
+	}))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var created createGroupResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	groupNo := created.GroupID
+
+	checkExists := func(gno string) groupExistsResp {
+		ww := httptest.NewRecorder()
+		route.ServeHTTP(ww, integrationRequest(t, http.MethodGet, "/v1/integrations/oidc/groups/"+gno, apiKey, nil))
+		require.Equal(t, http.StatusOK, ww.Code, ww.Body.String())
+		var r groupExistsResp
+		require.NoError(t, json.Unmarshal(ww.Body.Bytes(), &r))
+		assert.Equal(t, gno, r.GroupID)
+		return r
+	}
+
+	// normal + owner active member → exists:true.
+	assert.True(t, checkExists(groupNo).Exists)
+
+	// unknown group → exists:false (no 404).
+	assert.False(t, checkExists("grp_does_not_exist").Exists)
+
+	// owner blacklisted (member status != normal) → exists:false.
+	_, err := ctx.DB().Update("group_member").Set("status", 2).
+		Where("group_no=? AND uid=?", groupNo, uid).Exec()
+	require.NoError(t, err)
+	assert.False(t, checkExists(groupNo).Exists)
+
+	// restore membership to normal (status=1), then disband the group → exists:false.
+	_, err = ctx.DB().Update("group_member").Set("status", 1).
+		Where("group_no=? AND uid=?", groupNo, uid).Exec()
+	require.NoError(t, err)
+	_, err = ctx.DB().Update("group").Set("status", group.GroupStatusDisband).
+		Where("group_no=?", groupNo).Exec()
+	require.NoError(t, err)
+	assert.False(t, checkExists(groupNo).Exists)
+}
+
+// TestIntegrationTeamGroupExistsIsSpaceScoped verifies the existence check stays inside the
+// uk_ key's space binding: a key bound to space A must not confirm a group that lives in
+// space B, even though the same user is an active member of that space-B group.
+func TestIntegrationTeamGroupExistsIsSpaceScoped(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	subject := "sub-space-scope"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	spaceA := "sp_" + util.GenerUUID()[:8]
+	spaceB := "sp_" + util.GenerUUID()[:8]
+	seedSpaceMembership(t, ctx, uid, spaceA, "TeamA", 1, "2026-01-01 10:00:00")
+	seedSpaceMembership(t, ctx, uid, spaceB, "TeamB", 1, "2026-01-02 10:00:00")
+	botB := "bot_" + util.GenerUUID()[:8]
+	seedOwnBot(t, ctx, uid, spaceB, botB, "")
+
+	// Create a group in space B with the space-B key.
+	keyB := exchangeTeamGroupKey(t, route, mp, subject, spaceB)
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/groups", keyB, map[string]interface{}{
+		"name":             "团队群B",
+		"member_robot_ids": []string{botB},
+	}))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var created createGroupResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	groupB := created.GroupID
+
+	exists := func(apiKey string) bool {
+		ww := httptest.NewRecorder()
+		route.ServeHTTP(ww, integrationRequest(t, http.MethodGet, "/v1/integrations/oidc/groups/"+groupB, apiKey, nil))
+		require.Equal(t, http.StatusOK, ww.Code, ww.Body.String())
+		var r groupExistsResp
+		require.NoError(t, json.Unmarshal(ww.Body.Bytes(), &r))
+		return r.Exists
+	}
+
+	// Space-A key must NOT see the space-B group, despite the user being an active member.
+	keyA := exchangeTeamGroupKey(t, route, mp, subject, spaceA)
+	assert.False(t, exists(keyA), "a space-A key must not confirm a space-B group")
+	// Space-B key (correct binding) sees it.
+	assert.True(t, exists(keyB), "the space-B key must see its own group")
+}
+
+// decodeErrCode extracts error.code from the shared i18n error envelope.
+func decodeErrCode(t *testing.T, w *httptest.ResponseRecorder) string {
+	t.Helper()
+	var env integrationErrEnvelope
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env), "body: %s", w.Body.String())
+	return env.Error.Code
+}

--- a/modules/integration/api_groups_test.go
+++ b/modules/integration/api_groups_test.go
@@ -10,9 +10,11 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	libwkhttp "github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/botfather"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/oidc"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -470,6 +472,105 @@ func TestIntegrationTeamGroupExistsIsOwnerScoped(t *testing.T) {
 	}
 	assert.False(t, exists(keyB), "a non-creator active member must not see the group as existing")
 	assert.True(t, exists(keyA), "the creator must see their own group")
+}
+
+// TestIntegrationCreateTeamGroupKeepsIdempotencyKeyOnCreateFailure pins the P1 fix: because
+// group.CreateGroup can return an error *after* it has committed (its post-commit IM-channel
+// create fails and the compensating delete is best-effort), the handler must NOT release the
+// pending idempotency key on a CreateGroup error — otherwise a same-key retry could create a
+// second group. Here we force the IM call to fail and assert the pending key survives and a
+// same-key retry is told it's in-flight (409) rather than creating again.
+func TestIntegrationCreateTeamGroupKeepsIdempotencyKeyOnCreateFailure(t *testing.T) {
+	_, ctx, mp := setupIntegrationAPITest(t)
+	subject := "sub-im-fail"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	space := "sp_" + util.GenerUUID()[:8]
+	seedSpaceMembership(t, ctx, uid, space, "Team", 1, "2026-01-01 10:00:00")
+	bot := "bot_" + util.GenerUUID()[:8]
+	seedOwnBot(t, ctx, uid, space, bot, "")
+
+	// The shared test route's handler is cached (register.GetModules uses sync.Once) and may be
+	// bound to an earlier test's ctx, so mutating this ctx's config wouldn't reach it. Build a
+	// FRESH integration handler bound to THIS ctx, whose WuKongIM URL points at a dead port, so
+	// CreateGroup's post-commit IMCreateOrUpdateChannel deterministically fails — exercising the
+	// "CreateGroup can error after commit" path the P1 fix is about.
+	ctx.GetConfig().WuKongIM.APIURL = "http://127.0.0.1:1"
+	route := libwkhttp.New()
+	route.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.SourceLanguage)))
+	New(ctx).Route(route)
+	apiKey := exchangeTeamGroupKey(t, route, mp, subject, space)
+
+	idemKey := "idem-imfail-" + util.GenerUUID()[:8]
+	doReq := func() *httptest.ResponseRecorder {
+		req := integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/groups", apiKey, map[string]interface{}{
+			"name":             "团队群",
+			"member_robot_ids": []string{bot},
+		})
+		req.Header.Set(idempotencyKeyHeader, idemKey)
+		w := httptest.NewRecorder()
+		route.ServeHTTP(w, req)
+		return w
+	}
+
+	// First attempt fails at the (post-commit) IM channel step -> 500.
+	w1 := doReq()
+	require.Equal(t, http.StatusInternalServerError, w1.Code, w1.Body.String())
+	assert.Equal(t, "err.shared.internal", decodeErrCode(t, w1))
+
+	// The pending idempotency key must still be present (not released).
+	rkey := teamGroupIdemRedisKey(defaultClientID, uid, space, idemKey)
+	val, err := sharedIntegrationRateRedis(ctx.GetConfig()).Get(rkey).Result()
+	require.NoError(t, err, "pending idempotency key must survive a CreateGroup failure (not released)")
+	assert.Contains(t, val, idemStatePending)
+
+	// Same-key retry -> in-flight 409, not a second create attempt.
+	w2 := doReq()
+	require.Equal(t, http.StatusConflict, w2.Code, w2.Body.String())
+	assert.Equal(t, "err.server.integration.idempotency_in_flight", decodeErrCode(t, w2))
+}
+
+// TestIntegrationCreateTeamGroupReplaysAfterStateChange exercises the replay ordering: a stored
+// "done" record must replay even after the caller's mutable eligibility changed. We create with
+// an Idempotency-Key, then remove the owner from the space and disable the bot (which would make
+// a fresh request 403/404), and assert the same key + body still replays the original 200.
+func TestIntegrationCreateTeamGroupReplaysAfterStateChange(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	subject := "sub-replay-change"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	space := "sp_" + util.GenerUUID()[:8]
+	seedSpaceMembership(t, ctx, uid, space, "Team", 1, "2026-01-01 10:00:00")
+	bot := "bot_" + util.GenerUUID()[:8]
+	seedOwnBot(t, ctx, uid, space, bot, "")
+	apiKey := exchangeTeamGroupKey(t, route, mp, subject, space)
+
+	idemKey := "idem-replay-" + util.GenerUUID()[:8]
+	body := map[string]interface{}{"name": "团队群", "member_robot_ids": []string{bot}}
+	doReq := func() *httptest.ResponseRecorder {
+		req := integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/groups", apiKey, body)
+		req.Header.Set(idempotencyKeyHeader, idemKey)
+		w := httptest.NewRecorder()
+		route.ServeHTTP(w, req)
+		return w
+	}
+
+	w1 := doReq()
+	require.Equal(t, http.StatusOK, w1.Code, w1.Body.String())
+	var r1 createGroupResp
+	require.NoError(t, json.Unmarshal(w1.Body.Bytes(), &r1))
+
+	// Mutate state so the mutable checks would now fail: owner removed from space (-> 403),
+	// bot disabled (-> 404).
+	_, err := ctx.DB().Update("space_member").Set("status", 0).Where("space_id=? AND uid=?", space, uid).Exec()
+	require.NoError(t, err)
+	_, err = ctx.DB().Update("robot").Set("status", 0).Where("robot_id=?", bot).Exec()
+	require.NoError(t, err)
+
+	// Same key + same body must still replay the original 200 (lookup runs before mutable checks).
+	w2 := doReq()
+	require.Equal(t, http.StatusOK, w2.Code, w2.Body.String())
+	var r2 createGroupResp
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &r2))
+	assert.Equal(t, r1.GroupID, r2.GroupID, "same key+body must replay the original group even after state changed")
 }
 
 // decodeErrCode extracts error.code from the shared i18n error envelope.

--- a/modules/integration/db.go
+++ b/modules/integration/db.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/gocraft/dbr/v2"
 )
 
@@ -162,6 +163,84 @@ func (d *integrationDB) queryAvailableBotSpaces(uid string, spaceIDs []string) (
 	).Load(&ids)
 	if err != nil {
 		return nil, fmt.Errorf("integration: query available bot spaces uid=%q: %w", uid, err)
+	}
+	for _, id := range ids {
+		out[id] = true
+	}
+	return out, nil
+}
+
+// queryGroupCreatedAt 读取群的真实建群时间（time.Time）。CreateGroupServiceResp 不含
+// created_at，且 group.IService.GetGroupWithGroupNo 的 InfoResp.CreatedAt 是 time.Time.String()
+// 格式（非 RFC3339），故这里直读原始列，由调用方 .Format(time.RFC3339) 对齐 exchange 风格。
+func (d *integrationDB) queryGroupCreatedAt(groupNo string) (time.Time, error) {
+	var createdAt time.Time
+	err := d.session.Select("created_at").From("`group`").
+		Where("group_no=?", groupNo).LoadOne(&createdAt)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("integration: query group created_at %q: %w", groupNo, err)
+	}
+	return createdAt, nil
+}
+
+// queryGroupStatus returns the group's status, scoped to the given space, and explicitly
+// distinguishes "group not in this space / not found" (found=false, err=nil) from a DB
+// failure (err!=nil). Scoping by space_id keeps the existence check inside the uk_ key's
+// space binding — a key for space A must not confirm groups that live in space B.
+func (d *integrationDB) queryGroupStatus(groupNo, spaceID string) (status int, found bool, err error) {
+	e := d.session.Select("status").From("`group`").
+		Where("group_no=? AND space_id=?", groupNo, spaceID).LoadOne(&status)
+	if errors.Is(e, dbr.ErrNotFound) {
+		return 0, false, nil
+	}
+	if e != nil {
+		return 0, false, fmt.Errorf("integration: query group status %q: %w", groupNo, e)
+	}
+	return status, true, nil
+}
+
+// queryOwnedActiveBotIDs returns the robot_ids that group.CreateGroup will actually
+// insert as members for this owner+space: owned (creator_uid) and active (robot.status=1),
+// active in the space (space_member.status=1), AND backed by a usable user row — it exists
+// and is not finalized-destroyed (is_destroy<>IsDestroyDone). This mirrors CreateGroup's
+// insertion source (QueryByUIDs on the user table + the IsDestroyDone skip), so validating
+// member_robot_ids against this set up front turns an unusable bot into a 404 *before* any
+// group is created, instead of a created-then-500 that leaks an orphaned group.
+// isHumanUser reports whether uid is a human account (user row exists with robot=0). Bots
+// never obtain a uk_ key (they don't go through OIDC exchange) and AuthByKey only checks
+// account activity, not the robot flag — so this is the guard that keeps a team group's
+// owner/creator always a human member.
+func (d *integrationDB) isHumanUser(uid string) (bool, error) {
+	if uid == "" {
+		return false, nil
+	}
+	var robot int
+	err := d.session.Select("robot").From("user").Where("uid=?", uid).LoadOne(&robot)
+	if errors.Is(err, dbr.ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("integration: query user robot flag uid=%q: %w", uid, err)
+	}
+	return robot == 0, nil
+}
+
+func (d *integrationDB) queryOwnedActiveBotIDs(uid, spaceID string) (map[string]bool, error) {
+	out := make(map[string]bool)
+	if uid == "" || spaceID == "" {
+		return out, nil
+	}
+	var ids []string
+	_, err := d.session.SelectBySql(`
+		SELECT r.robot_id
+		FROM robot r
+		INNER JOIN space_member sm ON sm.uid=r.robot_id AND sm.space_id=? AND sm.status=1
+		INNER JOIN `+"`user`"+` u ON u.uid=r.robot_id AND u.is_destroy<>?
+		WHERE r.creator_uid=? AND r.status=1`,
+		spaceID, user.IsDestroyDone, uid,
+	).Load(&ids)
+	if err != nil {
+		return nil, fmt.Errorf("integration: query owned active bots uid=%q space=%q: %w", uid, spaceID, err)
 	}
 	for _, id := range ids {
 		out[id] = true

--- a/modules/integration/db.go
+++ b/modules/integration/db.go
@@ -183,29 +183,28 @@ func (d *integrationDB) queryGroupCreatedAt(groupNo string) (time.Time, error) {
 	return createdAt, nil
 }
 
-// queryGroupStatus returns the group's status, scoped to the given space, and explicitly
-// distinguishes "group not in this space / not found" (found=false, err=nil) from a DB
-// failure (err!=nil). Scoping by space_id keeps the existence check inside the uk_ key's
-// space binding — a key for space A must not confirm groups that live in space B.
-func (d *integrationDB) queryGroupStatus(groupNo, spaceID string) (status int, found bool, err error) {
-	e := d.session.Select("status").From("`group`").
-		Where("group_no=? AND space_id=?", groupNo, spaceID).LoadOne(&status)
+// queryGroupStatus returns the group's status and creator, scoped to the given space, and
+// explicitly distinguishes "group not in this space / not found" (found=false, err=nil) from
+// a DB failure (err!=nil). Scoping by space_id keeps the existence check inside the uk_ key's
+// space binding — a key for space A must not confirm groups that live in space B. The creator
+// is returned so the existence check can be owner-scoped (creator==uid), not merely
+// member-scoped.
+func (d *integrationDB) queryGroupStatus(groupNo, spaceID string) (status int, creator string, found bool, err error) {
+	var row struct {
+		Status  int    `db:"status"`
+		Creator string `db:"creator"`
+	}
+	e := d.session.Select("status", "creator").From("`group`").
+		Where("group_no=? AND space_id=?", groupNo, spaceID).LoadOne(&row)
 	if errors.Is(e, dbr.ErrNotFound) {
-		return 0, false, nil
+		return 0, "", false, nil
 	}
 	if e != nil {
-		return 0, false, fmt.Errorf("integration: query group status %q: %w", groupNo, e)
+		return 0, "", false, fmt.Errorf("integration: query group status %q: %w", groupNo, e)
 	}
-	return status, true, nil
+	return row.Status, row.Creator, true, nil
 }
 
-// queryOwnedActiveBotIDs returns the robot_ids that group.CreateGroup will actually
-// insert as members for this owner+space: owned (creator_uid) and active (robot.status=1),
-// active in the space (space_member.status=1), AND backed by a usable user row — it exists
-// and is not finalized-destroyed (is_destroy<>IsDestroyDone). This mirrors CreateGroup's
-// insertion source (QueryByUIDs on the user table + the IsDestroyDone skip), so validating
-// member_robot_ids against this set up front turns an unusable bot into a 404 *before* any
-// group is created, instead of a created-then-500 that leaks an orphaned group.
 // isHumanUser reports whether uid is a human account (user row exists with robot=0). Bots
 // never obtain a uk_ key (they don't go through OIDC exchange) and AuthByKey only checks
 // account activity, not the robot flag — so this is the guard that keeps a team group's
@@ -225,6 +224,18 @@ func (d *integrationDB) isHumanUser(uid string) (bool, error) {
 	return robot == 0, nil
 }
 
+// queryOwnedActiveBotIDs returns the robot_ids that group.CreateGroup will actually insert as
+// members for this owner+space: owned (creator_uid) and active (robot.status=1), active in the
+// space (space_member.status=1), AND backed by a usable user row — it exists and is not
+// finalized-destroyed (is_destroy<>IsDestroyDone). This mirrors CreateGroup's insertion source
+// (QueryByUIDs on the user table + the IsDestroyDone skip), so validating member_robot_ids
+// against this set up front turns an unusable bot into a 404 *before* any group is created,
+// instead of a created-then-500 that leaks an orphaned group.
+//
+// Intentionally does NOT filter on robot.bound_agent_ref (unlike the sibling
+// queryAvailableBotSpaces, which lists only unoccupied bots for the exchange picker):
+// agent-occupation and team-group membership are orthogonal — a user may put their own bot in
+// a team group regardless of whether it is currently bound to an agent.
 func (d *integrationDB) queryOwnedActiveBotIDs(uid, spaceID string) (map[string]bool, error) {
 	out := make(map[string]bool)
 	if uid == "" || spaceID == "" {

--- a/modules/integration/db.go
+++ b/modules/integration/db.go
@@ -172,11 +172,12 @@ func (d *integrationDB) queryAvailableBotSpaces(uid string, spaceIDs []string) (
 
 // queryGroupCreatedAt 读取群的真实建群时间（time.Time）。CreateGroupServiceResp 不含
 // created_at，且 group.IService.GetGroupWithGroupNo 的 InfoResp.CreatedAt 是 time.Time.String()
-// 格式（非 RFC3339），故这里直读原始列，由调用方 .Format(time.RFC3339) 对齐 exchange 风格。
-func (d *integrationDB) queryGroupCreatedAt(groupNo string) (time.Time, error) {
+// 格式（非 RFC3339），故这里直读原始列，由调用方 .UTC().Format(time.RFC3339) 输出。按 space_id
+// 一并限定，与同模块 queryGroupStatus 的 Space 隔离口径一致（防御性，避免跨 Space 直读）。
+func (d *integrationDB) queryGroupCreatedAt(groupNo, spaceID string) (time.Time, error) {
 	var createdAt time.Time
 	err := d.session.Select("created_at").From("`group`").
-		Where("group_no=?", groupNo).LoadOne(&createdAt)
+		Where("group_no=? AND space_id=?", groupNo, spaceID).LoadOne(&createdAt)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("integration: query group created_at %q: %w", groupNo, err)
 	}
@@ -224,13 +225,20 @@ func (d *integrationDB) isHumanUser(uid string) (bool, error) {
 	return robot == 0, nil
 }
 
-// queryOwnedActiveBotIDs returns the robot_ids that group.CreateGroup will actually insert as
-// members for this owner+space: owned (creator_uid) and active (robot.status=1), active in the
-// space (space_member.status=1), AND backed by a usable user row — it exists and is not
-// finalized-destroyed (is_destroy<>IsDestroyDone). This mirrors CreateGroup's insertion source
-// (QueryByUIDs on the user table + the IsDestroyDone skip), so validating member_robot_ids
-// against this set up front turns an unusable bot into a 404 *before* any group is created,
-// instead of a created-then-500 that leaks an orphaned group.
+// queryOwnedActiveBotIDs returns the eligible team-bot set for this owner+space: owned
+// (creator_uid) and active (robot.status=1), active in the space (space_member.status=1), AND
+// backed by a usable user row — it exists and is not finalized-destroyed
+// (is_destroy<>IsDestroyDone). Validating member_robot_ids against this set up front turns an
+// unusable bot into a 404 *before* any group is created, instead of a created-then-500 that
+// leaks an orphaned group.
+//
+// This is a SUPERSET-tightening of CreateGroup's own insertion filter, not a byte-for-byte
+// mirror: CreateGroup inserts from userDB.QueryByUIDs (existence) + an IsDestroyDone skip, and
+// does NOT itself re-check robot.status=1 / space_member.status=1. The overlapping, load-bearing
+// predicate is "user row exists and is not finalized-destroyed"; the extra robot/space-active
+// joins here only further restrict the set, so a bot that passes this query is always insertable
+// by CreateGroup. (The remaining gap is a destroy racing in between validation and insert — a
+// narrow TOCTOU the response's actual-members read-back already tolerates.)
 //
 // Intentionally does NOT filter on robot.bound_agent_ref (unlike the sibling
 // queryAvailableBotSpaces, which lists only unoccupied bots for the exchange picker):

--- a/modules/integration/e2e_test.go
+++ b/modules/integration/e2e_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
@@ -132,4 +133,129 @@ func doE2EJSON(t *testing.T, srv *httptest.Server, method, path, bearer string, 
 	respBody, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	return resp.StatusCode, resp.Header, respBody
+}
+
+// doE2EJSONH is doE2EJSON with extra request headers (e.g. Idempotency-Key).
+func doE2EJSONH(t *testing.T, srv *httptest.Server, method, path, bearer string, headers map[string]string, body interface{}) (int, http.Header, []byte) {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		require.NoError(t, json.NewEncoder(&buf).Encode(body))
+	}
+	req, err := http.NewRequest(method, srv.URL+path, &buf)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, resp.Header, respBody
+}
+
+// TestOIDCIntegrationE2E_TeamGroup drives the full team-group flow over a real HTTP server:
+// exchange -> create team group -> existence -> boundary/edge cases -> idempotency -> key
+// revocation. Complements the handler-level unit tests with an end-to-end key lifecycle.
+func TestOIDCIntegrationE2E_TeamGroup(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	srv := httptest.NewServer(route)
+	defer srv.Close()
+
+	subject := "sub-e2e-group"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	spaceID := "sp_" + util.GenerUUID()[:8]
+	seedSpaceMembership(t, ctx, uid, spaceID, "E2E Group Space", 2, "2026-01-01 10:00:00")
+	botA := "bot_" + util.GenerUUID()[:8]
+	botB := "bot_" + util.GenerUUID()[:8]
+	seedOwnBot(t, ctx, uid, spaceID, botA, "")
+	seedOwnBot(t, ctx, uid, spaceID, botB, "")
+	idToken := mintIntegrationIDToken(t, mp, subject)
+
+	// exchange -> uk_
+	status, _, body := doE2EJSON(t, srv, http.MethodPost, "/v1/integrations/oidc/exchange", idToken, map[string]interface{}{"space_id": spaceID})
+	require.Equal(t, http.StatusOK, status, string(body))
+	var ex struct {
+		APIKey string `json:"api_key"`
+	}
+	require.NoError(t, json.Unmarshal(body, &ex))
+	require.NotEmpty(t, ex.APIKey)
+
+	createBody := map[string]interface{}{"name": "团队群 E2E", "member_robot_ids": []string{botA, botB}}
+
+	// create team group
+	status, _, body = doE2EJSON(t, srv, http.MethodPost, "/v1/integrations/oidc/groups", ex.APIKey, createBody)
+	require.Equal(t, http.StatusOK, status, string(body))
+	var created createGroupResp
+	require.NoError(t, json.Unmarshal(body, &created))
+	require.NotEmpty(t, created.GroupID)
+	assert.Equal(t, spaceID, created.SpaceID)
+	assert.Equal(t, uid, created.OwnerUserID)
+	assert.ElementsMatch(t, []string{botA, botB}, created.MemberRobotIDs)
+
+	// existence: creator sees it
+	status, _, body = doE2EJSON(t, srv, http.MethodGet, "/v1/integrations/oidc/groups/"+created.GroupID, ex.APIKey, nil)
+	require.Equal(t, http.StatusOK, status, string(body))
+	var exists groupExistsResp
+	require.NoError(t, json.Unmarshal(body, &exists))
+	assert.True(t, exists.Exists)
+
+	// existence: unknown group -> exists:false, still HTTP 200
+	status, _, body = doE2EJSON(t, srv, http.MethodGet, "/v1/integrations/oidc/groups/grp_nope", ex.APIKey, nil)
+	require.Equal(t, http.StatusOK, status, string(body))
+	require.NoError(t, json.Unmarshal(body, &exists))
+	assert.False(t, exists.Exists)
+
+	// existence: blank group_no -> 400
+	status, _, _ = doE2EJSON(t, srv, http.MethodGet, "/v1/integrations/oidc/groups/%20", ex.APIKey, nil)
+	assert.Equal(t, http.StatusBadRequest, status)
+
+	// boundary: name too long (51 runes) -> 400
+	status, _, _ = doE2EJSON(t, srv, http.MethodPost, "/v1/integrations/oidc/groups", ex.APIKey, map[string]interface{}{
+		"name": strings.Repeat("名", 51), "member_robot_ids": []string{botA},
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+
+	// boundary: empty members -> 400
+	status, _, _ = doE2EJSON(t, srv, http.MethodPost, "/v1/integrations/oidc/groups", ex.APIKey, map[string]interface{}{
+		"name": "x", "member_robot_ids": []string{},
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+
+	// boundary: foreign/unknown bot -> unified 404
+	status, _, _ = doE2EJSON(t, srv, http.MethodPost, "/v1/integrations/oidc/groups", ex.APIKey, map[string]interface{}{
+		"name": "x", "member_robot_ids": []string{"bot_unknown"},
+	})
+	assert.Equal(t, http.StatusNotFound, status)
+
+	// idempotency over real HTTP: same key + body replays the same group
+	idem := map[string]string{idempotencyKeyHeader: "e2e-idem-" + util.GenerUUID()[:8]}
+	status, _, body = doE2EJSONH(t, srv, http.MethodPost, "/v1/integrations/oidc/groups", ex.APIKey, idem, createBody)
+	require.Equal(t, http.StatusOK, status, string(body))
+	var r1 createGroupResp
+	require.NoError(t, json.Unmarshal(body, &r1))
+	status, _, body = doE2EJSONH(t, srv, http.MethodPost, "/v1/integrations/oidc/groups", ex.APIKey, idem, createBody)
+	require.Equal(t, http.StatusOK, status, string(body))
+	var r2 createGroupResp
+	require.NoError(t, json.Unmarshal(body, &r2))
+	assert.Equal(t, r1.GroupID, r2.GroupID, "same key+body replays the same group")
+
+	// idempotency: same key + different body -> 409 conflict
+	status, _, _ = doE2EJSONH(t, srv, http.MethodPost, "/v1/integrations/oidc/groups", ex.APIKey, idem, map[string]interface{}{
+		"name": "另一个名字", "member_robot_ids": []string{botA},
+	})
+	assert.Equal(t, http.StatusConflict, status)
+
+	// key lifecycle edge: revoke the uk_, then both endpoints reject it with 401
+	status, _, _ = doE2EJSON(t, srv, http.MethodDelete, "/v1/integrations/oidc/binding", ex.APIKey, nil)
+	require.Equal(t, http.StatusOK, status)
+	status, _, _ = doE2EJSON(t, srv, http.MethodPost, "/v1/integrations/oidc/groups", ex.APIKey, createBody)
+	assert.Equal(t, http.StatusUnauthorized, status, "revoked uk_ must be rejected by create")
+	status, _, _ = doE2EJSON(t, srv, http.MethodGet, "/v1/integrations/oidc/groups/"+created.GroupID, ex.APIKey, nil)
+	assert.Equal(t, http.StatusUnauthorized, status, "revoked uk_ must be rejected by existence check")
 }

--- a/modules/integration/model.go
+++ b/modules/integration/model.go
@@ -49,6 +49,29 @@ type exchangeResp struct {
 	Bots      []exchangeBotResp `json:"bots,omitempty"`
 }
 
+// createGroupReq —— 用 uk_ key 建团队群的请求体。owner / space / client 全部来自服务端
+// 解析的 key 上下文，body 仅这两个字段且不携带任何信任边界。
+type createGroupReq struct {
+	Name           string   `json:"name"`
+	MemberRobotIDs []string `json:"member_robot_ids"`
+}
+
+// createGroupResp —— 建群响应（时间 RFC3339，对齐 exchange 风格）。
+type createGroupResp struct {
+	GroupID        string   `json:"group_id"`
+	SpaceID        string   `json:"space_id"`
+	OwnerUserID    string   `json:"owner_user_id"`
+	MemberRobotIDs []string `json:"member_robot_ids"`
+	Name           string   `json:"name"`
+	CreatedAt      string   `json:"created_at"`
+}
+
+// groupExistsResp —— 用户态存在性检测响应（恒 200，不存在时 exists=false 而非 404）。
+type groupExistsResp struct {
+	GroupID string `json:"group_id"`
+	Exists  bool   `json:"exists"`
+}
+
 type managerIntegrationClientReq struct {
 	Name   string `json:"name"`
 	Status *int   `json:"status"`

--- a/modules/integration/swagger/api.yaml
+++ b/modules/integration/swagger/api.yaml
@@ -1,0 +1,221 @@
+openapi: 3.0.3
+info:
+  title: Octo Integration API
+  version: 1.0.0
+  description: >-
+    Integration endpoints for partner platforms. All routes authenticate with a
+    user-scoped API key (`uk_` prefix) issued via
+    `POST /v1/integrations/oidc/exchange`. The owner, space and client are all
+    resolved server-side from the key context; the request body carries no trust
+    boundary. Errors use the shared i18n envelope (`{ "error": { "code", ... } }`).
+
+servers:
+  - url: https://api.botgate.cn/v1
+    description: Production
+
+tags:
+  - name: integration
+    description: 集成方团队群能力
+
+security:
+  - UserAPIKey: []
+
+paths:
+  /integrations/oidc/groups:
+    post:
+      tags: [integration]
+      summary: 创建团队群
+      description: >-
+        Create a team group whose members are the calling user (owner) plus the
+        specified team bots. The bots must belong to the caller and be active in
+        the caller's space. No bot is promoted to bot admin. Pass an optional
+        `Idempotency-Key` header to make retries safe (Stripe-style).
+      operationId: createTeamGroup
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateGroupRequest'
+      responses:
+        '200':
+          description: 群创建成功（或幂等回放）
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateGroupResponse'
+        '400':
+          description: 参数非法 / 群名超长 / 成员为空
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '401':
+          description: 鉴权失败（缺失/无效 uk_ key，或 client 无权调用）
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '403':
+          description: owner 非该 Space 成员
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '404':
+          description: member_robot_ids 中存在不存在/不归属/不在该 Space 的 bot（统一 not found）
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '409':
+          description: >-
+            Idempotency-Key 冲突。两种情形均返回 409，用 error.code 区分：
+            err.server.integration.idempotency_in_flight（同 key 仍在处理中，可重试，
+            见 Retry-After）与 err.server.integration.idempotency_conflict（同 key 复用于
+            不同请求体，不可重试）。
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: in-flight 情形下建议的重试等待秒数
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '429':
+          description: 触发限流（IP/UID 层）
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '500':
+          description: 内部错误
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  /integrations/oidc/groups/{group_no}:
+    get:
+      tags: [integration]
+      summary: 团队群存在性检测
+      description: >-
+        User-scoped existence check: returns `exists=true` only when the group is
+        in normal status and the owner is still an active member (not removed or
+        blacklisted). Always returns HTTP 200; a missing/inaccessible group is
+        reported as `exists=false` rather than 404.
+      operationId: teamGroupExists
+      parameters:
+        - in: path
+          name: group_no
+          required: true
+          description: 群编号
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 存在性检测结果（恒 200）
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupExistsResponse'
+        '401':
+          description: 鉴权失败
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '500':
+          description: 内部错误
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+components:
+  securitySchemes:
+    UserAPIKey:
+      type: http
+      scheme: bearer
+      description: Bearer user API key, e.g. `Authorization: Bearer uk_xxx`.
+
+  parameters:
+    IdempotencyKey:
+      in: header
+      name: Idempotency-Key
+      required: false
+      description: >-
+        Optional idempotency token. Replaying the same key with the same body
+        returns the original result; reusing it with a different body is
+        rejected; an in-flight retry is told to back off.
+      schema:
+        type: string
+
+  schemas:
+    CreateGroupRequest:
+      type: object
+      required: [name, member_robot_ids]
+      properties:
+        name:
+          type: string
+          description: 群名称，trim 后非空，长度 ≤ 50（按 Unicode rune 计）
+          maxLength: 50
+          example: 团队群名称
+        member_robot_ids:
+          type: array
+          description: 团队 bot 的 robot_id 列表，非空、自动去重，数量 ≤ 50
+          minItems: 1
+          maxItems: 50
+          items:
+            type: string
+          example: [bot_a, bot_b, bot_c]
+
+    CreateGroupResponse:
+      type: object
+      properties:
+        group_id:
+          type: string
+          description: 群编号
+        space_id:
+          type: string
+        owner_user_id:
+          type: string
+        member_robot_ids:
+          type: array
+          items:
+            type: string
+        name:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+          description: 建群时间，RFC3339
+          example: '2026-06-15T10:00:00+08:00'
+
+    GroupExistsResponse:
+      type: object
+      properties:
+        group_id:
+          type: string
+        exists:
+          type: boolean
+
+    ErrorEnvelope:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+              description: 稳定错误码，如 err.shared.param.invalid
+            message:
+              type: string
+            http_status:
+              type: integer
+            details:
+              type: object
+              additionalProperties: true

--- a/modules/integration/swagger/api.yaml
+++ b/modules/integration/swagger/api.yaml
@@ -122,6 +122,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GroupExistsResponse'
+        '400':
+          description: group_no 为空 / 仅空白
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
         '401':
           description: 鉴权失败
           content:

--- a/pkg/errcode/integration.go
+++ b/pkg/errcode/integration.go
@@ -35,6 +35,23 @@ var (
 		DefaultMessages: map[string]string{"zh-CN": "该 Bot 已被其他 Agent 占用。"},
 		SafeDetailKeys:  []string{"occupied_by"},
 	})
+
+	// ErrIntegrationIdempotencyInFlight —— 同一 Idempotency-Key 的建群请求仍在处理中（可重试，
+	// 响应带 Retry-After）。与冲突区分开：这是「稍后重试」，不是「键被误用」。
+	ErrIntegrationIdempotencyInFlight = register(codes.Code{
+		ID:              "err.server.integration.idempotency_in_flight",
+		HTTPStatus:      http.StatusConflict,
+		DefaultMessage:  "A request with this idempotency key is still in progress; please retry.",
+		DefaultMessages: map[string]string{"zh-CN": "相同 Idempotency-Key 的请求仍在处理中，请稍后重试。"},
+	})
+
+	// ErrIntegrationIdempotencyConflict —— 同一 Idempotency-Key 复用于不同的请求体（终态冲突，不可重试）。
+	ErrIntegrationIdempotencyConflict = register(codes.Code{
+		ID:              "err.server.integration.idempotency_conflict",
+		HTTPStatus:      http.StatusConflict,
+		DefaultMessage:  "This idempotency key was already used with a different request.",
+		DefaultMessages: map[string]string{"zh-CN": "该 Idempotency-Key 已用于不同的请求。"},
+	})
 )
 
 // 复用 pkg/i18n/codes 已注册的 err.shared.* 码：integration / Octo-link 与 Bot

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -414,6 +414,12 @@ other = "Unauthorized."
 ["err.server.integration.disabled"]
 other = "OIDC integration exchange is disabled."
 
+["err.server.integration.idempotency_conflict"]
+other = "This idempotency key was already used with a different request."
+
+["err.server.integration.idempotency_in_flight"]
+other = "A request with this idempotency key is still in progress; please retry."
+
 ["err.server.integration.user_not_linked"]
 other = "User is not linked to an Octo account."
 


### PR DESCRIPTION
Closes #378
Related: #236

## Background

Let integration partners use the `uk_` User API Key (issued via OIDC exchange; the client is whatever the key is scoped to) to:
1. **Create a team group** — members are the calling user (human owner) + the specified team bots.
2. **Check whether a team group exists** (user-scoped existence check).

Implemented in `modules/integration` (alongside exchange under `/v1/integrations/oidc`). The capability is generic to any integration client — not coupled to a specific partner.

## Changes

### 1. `feat(group)`: widen group name limit 20 → 50
- The two `> 20` rune truncation sites in `CreateGroup` / `UpdateGroupInfo` now share a `MaxGroupNameLen = 50` constant (one global ceiling for Web / Bot / Integration create + rename).
- Migration widens `group`.`name` from `VARCHAR(40)` to `(50)` (online in-place ALTER; both widths < 256 bytes, no table rebuild).
- The migration test genuinely exercises the **pre-existing data** path: shrink back to `VARCHAR(40)`, write a 40-rune legacy row, run the widen over it, then assert the row survives with no truncation and a 50-rune name now fits.

### 2. `feat(integration)`: two `uk_` endpoints

**`POST /v1/integrations/oidc/groups`** — create a team group
- owner / space / client are all resolved server-side from the key context; the **body is untrusted** (only `name` + `member_robot_ids`).
- The owner must be an **active member** of the key's space (`CheckMembership`: `space_member.status=1 AND space.status=1`) and a **human** (`robot=0`); account-level activity is enforced upstream by `AuthByKey`.
- `member_robot_ids` are validated against the **same source `CreateGroup` inserts from** (owned + active in the space + backed by a usable user row), so an ineligible bot is a unified `404` **before** any group is created (prevents bot-id enumeration and avoids a created-then-500 orphan).
- No bot is promoted to `bot_admin`; the response echoes only the bots that **actually joined**; `created_at` is RFC3339.
- Optional **Idempotency-Key** (Redis, 24h, namespaced by client/uid/space): replay returns the original result; in-flight → `409 idempotency_in_flight` (with `Retry-After`, retryable); same key with a different body → `409 idempotency_conflict` (terminal). The lookup runs ahead of the mutable eligibility checks so a stored result still replays after state changes.

**`GET /v1/integrations/oidc/groups/:group_no`** — existence check
- **Scoped to the key's space and the creator** (`group_no=? AND space_id=?`, plus `group.creator == uid`) so a space-A key can't probe a space-B group, and a same-space non-creator member can't confirm it either.
- `exists:true` only when the group is normal, the caller is the creator, and still an active member; otherwise `exists:false`. **Always HTTP 200** (missing / inaccessible / out-of-space / non-creator all map to `false`, never 404). Only a real DB error surfaces as 500.

### Error codes / i18n
- Reuses shared codes (param 400 / forbidden 403 / not_found 404 / internal 500); adds two integration-scoped `409` idempotency codes (inline zh-CN, matching the existing `ErrBotOccupied`), and regenerates the i18n markers.
- **OpenAPI 3.0** spec (`modules/integration/swagger/api.yaml`), embedded and served via the module registration.

## Testing

Integration tests cover: successful create (asserts owner=creator role, bots `role=common`+`robot=1`, no bot_admin), group-name 50/51 boundary, empty/duplicate members, ineligible bot → 404, owner not a space member → 403, **owner is a robot → 403**, foreign-client key → 401, **unauthenticated → 401**, **idempotency (replay / 409 conflict / 409 in-flight)**, the existence states incl. **cross-space** and **non-creator member** → false, and the migration over pre-existing data.

Locally green: `go build ./...` · `go test ./modules/integration/...` (full, incl. pre-existing tests) · `go test ./modules/group/...` (fresh DB) · `gofmt` · `golangci-lint` (0 issues) · `make i18n-extract-check` · `make i18n-lint`.

> Note: the `group` and `integration` test binaries register different module subsets, so running both against the *same* test DB makes the second report `unknown migration in database` (a cross-binary migration-set conflict, unrelated to this change). Each package passes against a fresh test DB.

## Commits
- `feat(group): widen group name limit from 20 to 50 chars`
- `feat(integration): add team group create + existence endpoints for uk_ keys`
- `fix(integration): address PR review on team group endpoints`

https://claude.ai/code/session_014Q3jVZ7z74LVJeyFDqUQr4