### PR TITLE
fix(auth): gate daemon api_key on status=1 + client_id=botfather

### DIFF
--- a/modules/bot_provision/bot_api_test.go
+++ b/modules/bot_provision/bot_api_test.go
@@ -98,6 +98,18 @@ func insertAPIKey(t *testing.T, ctx *config.Context, uid, apiKey, spaceID string
 	require.NoError(t, err)
 }
 
+// insertAPIKeyFull inserts a user_api_key row with explicit status/client_id
+// (the 3-col insertAPIKey relies on the column DEFAULTs status=1 /
+// client_id='botfather'). Used to seed revoked keys and legacy plaintext
+// non-botfather rows the daemon botToken path must reject.
+func insertAPIKeyFull(t *testing.T, ctx *config.Context, uid, apiKey, spaceID string, status int, clientID string) {
+	t.Helper()
+	_, err := ctx.DB().InsertInto("user_api_key").
+		Columns("uid", "api_key", "space_id", "status", "client_id").
+		Values(uid, apiKey, spaceID, status, clientID).Exec()
+	require.NoError(t, err)
+}
+
 // insertBotInSpace creates a robot row (creator, bot_token, status) and a
 // space_member row putting the bot in spaceID. Mirrors botfather/db.go's
 // MintBotOBO write pattern at the SQL level so tests bypass the OBO logic.
@@ -191,6 +203,36 @@ func TestBotToken_LegacyEmptySpace_401(t *testing.T) {
 	insertBotInSpace(t, ctx, "bot_legacy", bpTestUIDA, "bf_tok_lg", bpTestSpaceA, 1)
 
 	w := doBotToken(t, s, "bot_legacy", "uk_bp_legacy_xxxxxxxxxxxxxxxxxxxxxxxx")
+	assert.Equal(t, http.StatusUnauthorized, w.Code, "body: %s", w.Body.String())
+}
+
+// 5b) user_api_key.status=0 (revoked daemon key) → 401. resolveAPIKey's
+// status=1 filter is the kill switch; without it a revoked key still mints
+// bot_token.
+func TestBotToken_RevokedKey_401(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	seedBPFixtures(t, ctx)
+	insertAPIKeyFull(t, ctx, bpTestUIDA, "uk_bp_revoked_xxxxxxxxxxxxxxxxxxxxxx", bpTestSpaceA, 0, "botfather")
+	insertBotInSpace(t, ctx, "bot_revoked", bpTestUIDA, "bf_tok_rv", bpTestSpaceA, 1)
+
+	w := doBotToken(t, s, "bot_revoked", "uk_bp_revoked_xxxxxxxxxxxxxxxxxxxxxx")
+	assert.Equal(t, http.StatusUnauthorized, w.Code, "body: %s", w.Body.String())
+}
+
+// 5c) legacy plaintext key owned by a non-botfather client → 401. The daemon
+// botToken path is native-only; integration-client keys must not mint
+// bot_token. Seeded as a PLAINTEXT row (not via the service, which stores
+// integration keys as a "hash:" digest) so the api_key=? match still hits —
+// only client_id='botfather' rejects it, proving that filter works.
+func TestBotToken_NonBotfatherClient_401(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	seedBPFixtures(t, ctx)
+	insertAPIKeyFull(t, ctx, bpTestUIDA, "uk_bp_integration_xxxxxxxxxxxxxxxxxx", bpTestSpaceA, 1, "some-integration")
+	insertBotInSpace(t, ctx, "bot_integ", bpTestUIDA, "bf_tok_ig", bpTestSpaceA, 1)
+
+	w := doBotToken(t, s, "bot_integ", "uk_bp_integration_xxxxxxxxxxxxxxxxxx")
 	assert.Equal(t, http.StatusUnauthorized, w.Code, "body: %s", w.Body.String())
 }
 

--- a/modules/bot_provision/resolve.go
+++ b/modules/bot_provision/resolve.go
@@ -64,8 +64,14 @@ func (a *BotProvision) resolveAPIKey(apiKey string) (string, string, error) {
 		SpaceID string `db:"space_id"`
 	}
 	var r row
+	// status=1 / client_id='botfather' gate the post-main schema additions:
+	// status filters out revoked keys (status=0), and client_id restricts
+	// the daemon path to native octo keys — integration-client keys
+	// (client_id != 'botfather') must not authenticate a daemon. Literals
+	// mirror user_api_key's active status + native client; the canonical
+	// botfather constants are unexported and unreachable here.
 	_, err := a.ctx.DB().Select("uid", "space_id").From("user_api_key").
-		Where("api_key=? AND space_id!=''", apiKey).Load(&r)
+		Where("api_key=? AND space_id!='' AND status=? AND client_id=?", apiKey, 1, "botfather").Load(&r)
 	if err != nil {
 		return "", "", err
 	}

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -4343,12 +4343,19 @@ func (u *User) authVerifyAPIKey(c *wkhttp.Context) {
 	}
 
 	// Step 1: lookup api_key, reject legacy space_id=''.
+	// status=1 / client_id='botfather' gate the post-main schema additions:
+	// status filters out revoked keys (status=0), and client_id restricts
+	// verify-api-key to native octo keys — integration-client keys
+	// (client_id != 'botfather') must not validate on the daemon path.
+	// Literals mirror user_api_key's active status + native client; the
+	// canonical botfather constants are unexported and the user package
+	// cannot import botfather (botfather -> user import cycle).
 	var keyInfo struct {
 		UID     string `db:"uid"`
 		SpaceID string `db:"space_id"`
 	}
 	_, err := u.db.session.Select("uid", "space_id").From("user_api_key").
-		Where("api_key=? AND space_id!=''", req.APIKey).
+		Where("api_key=? AND space_id!='' AND status=? AND client_id=?", req.APIKey, 1, "botfather").
 		Load(&keyInfo)
 	if err != nil || keyInfo.UID == "" {
 		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"msg": "invalid api_key"})

--- a/modules/user/api_verify_apikey_test.go
+++ b/modules/user/api_verify_apikey_test.go
@@ -62,6 +62,18 @@ func insertAPIKey(t *testing.T, ctx *config.Context, uid, apiKey, spaceID string
 	require.NoError(t, err)
 }
 
+// insertAPIKeyFull inserts a user_api_key row with explicit status/client_id
+// (the 3-col insertAPIKey relies on the column DEFAULTs status=1 /
+// client_id='botfather'). Used to seed revoked keys and legacy plaintext
+// non-botfather rows the daemon path must reject.
+func insertAPIKeyFull(t *testing.T, ctx *config.Context, uid, apiKey, spaceID string, status int, clientID string) {
+	t.Helper()
+	_, err := ctx.DB().InsertInto("user_api_key").
+		Columns("uid", "api_key", "space_id", "status", "client_id").
+		Values(uid, apiKey, spaceID, status, clientID).Exec()
+	require.NoError(t, err)
+}
+
 func doVerifyAPIKey(t *testing.T, s *server.Server, body interface{}) *httptest.ResponseRecorder {
 	t.Helper()
 	var reqBody *bytes.Reader
@@ -146,6 +158,38 @@ func TestAuthVerifyAPIKey_NonActiveStatus(t *testing.T) {
 	require.NoError(t, err)
 
 	w := doVerifyAPIKey(t, s, map[string]string{"api_key": "uk_nonactive_xxxxxxxxxxxxxxxxxxxxxxxx"})
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// Case 3c: user_api_key.status=0 (revoked key) → 401. Distinct from the
+// space_member.status cases above — this gates the KEY's own revocation
+// flag (added with the client-dimension migration). Without the SQL
+// `status=1` filter a revoked daemon key keeps verifying.
+func TestAuthVerifyAPIKey_RevokedKey_401(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	seedAPIKeyFixtures(t, ctx)
+	insertAPIKeyFull(t, ctx, testAPIKeyUID, "uk_revoked_xxxxxxxxxxxxxxxxxxxxxxxxxx", testAPIKeySpaceA, 0, "botfather")
+
+	w := doVerifyAPIKey(t, s, map[string]string{"api_key": "uk_revoked_xxxxxxxxxxxxxxxxxxxxxxxxxx"})
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// Case 3d: a legacy plaintext row owned by a non-botfather client → 401.
+// verify-api-key is the native daemon path and must only accept botfather
+// keys; integration-client keys belong to external apps. Seeded as a
+// PLAINTEXT row (not via the service, which stores integration keys as a
+// "hash:" digest) precisely so the api_key=? match would still hit — only
+// the client_id='botfather' filter rejects it, proving that filter works.
+func TestAuthVerifyAPIKey_NonBotfatherClient_401(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	seedAPIKeyFixtures(t, ctx)
+	insertAPIKeyFull(t, ctx, testAPIKeyUID, "uk_integration_xxxxxxxxxxxxxxxxxxxxxx", testAPIKeySpaceA, 1, "some-integration")
+
+	w := doVerifyAPIKey(t, s, map[string]string{"api_key": "uk_integration_xxxxxxxxxxxxxxxxxxxxxx"})
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }


### PR DESCRIPTION
## 问题
合入 main 后,`user_api_key` 表新增 `status`(1=active/0=revoked)与 `client_id`(默认 botfather)两列以支持吊销与第三方 integration client 维度。但 runtime 的两条 daemon 鉴权直查是在加列之前写的,只匹配 `api_key + space_id`,**未过滤 status/client_id**:

- 被吊销的 key(status=0)仍能通过 daemon 鉴权;
- 原生 daemon 路径可能接受第三方 integration client key(client_id ≠ botfather)。

属语义缺口,`go build` 抓不到。

## 改动
两条查询同步补 `status=1 AND client_id='botfather'`(绑定参数):
- `modules/user/api.go` `authVerifyAPIKey`(/v1/auth/verify-api-key,fleet/matter 调用)
- `modules/bot_provision/resolve.go` `resolveAPIKey`(daemon→bot_token)

字面量 `1`/`'botfather'` 对应列语义;botfather 包常量未导出,且 `user` 无法 import botfather(`botfather → user` 循环)。两处 SQL 旁加注释说明。

**不在范围**:`modules/integration/db.go` 的 Update 是 integration 自身管理 key 的写路径,非 daemon 鉴权读。

## 测试
两条路径各加回归用例:
- 吊销 key(status=0)→ 401
- legacy 明文非 botfather client(client_id≠botfather)→ 401(刻意 direct-insert 明文,使 `api_key` 仍能命中,**仅靠 client_id 过滤拒绝**,证明过滤生效)
- 正常 botfather key(status=1)→ 仍 200

`modules/user`、`modules/bot_provision` 全量测试通过;`go build ./...` + `go vet` 通过。