### PR TITLE
fix(integration): correct team-group created_at + two #381 follow-ups

### DIFF
--- a/modules/group/group_name_widen_test.go
+++ b/modules/group/group_name_widen_test.go
@@ -1,15 +1,21 @@
 package group
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	migrate "github.com/rubenv/sql-migrate"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// groupNameWidenMigrationFile is the migration whose Up DDL this test exercises. Kept as a
+// named constant so the test fails loudly (file-not-found) if the migration is ever renamed.
+const groupNameWidenMigrationFile = "20260615000001_group_name_widen.sql"
 
 // TestGroupNameWidenMigration genuinely exercises the VARCHAR(40)->(50) in-place widen
 // against PRE-EXISTING data, rather than just asserting a 40-rune string fits a 50-wide
@@ -38,10 +44,28 @@ func TestGroupNameWidenMigration(t *testing.T) {
 	}
 	modifyNameWidth := func(width int) {
 		// DDL column length can't be a bound placeholder; width is a controlled int constant.
+		// Used only as test scaffolding (shrink to the pre-widen world / restore on cleanup) —
+		// the widen under test runs the migration file's OWN Up DDL via applyMigrationUp below.
 		_, err := ctx.DB().UpdateBySql(
 			fmt.Sprintf("ALTER TABLE `group` MODIFY `name` VARCHAR(%d) NOT NULL DEFAULT ''", width),
 		).Exec()
 		require.NoError(t, err)
+	}
+	// applyMigrationUp parses the real migration file from the embedded sql FS and executes its
+	// Up statements verbatim — the same source rubenv/sql-migrate runs in production. This is
+	// what keeps the test honest: if 20260615000001_group_name_widen.sql ever drifts (different
+	// width, added clause, etc.), the assertions below run against the changed DDL instead of a
+	// stale hand-inlined copy.
+	applyMigrationUp := func(filename string) {
+		data, err := sqlFS.ReadFile("sql/" + filename)
+		require.NoError(t, err, "read migration %s from embedded sql FS", filename)
+		m, err := migrate.ParseMigration(filename, bytes.NewReader(data))
+		require.NoError(t, err, "parse migration %s", filename)
+		require.NotEmpty(t, m.Up, "migration %s has no Up statements", filename)
+		for _, stmt := range m.Up {
+			_, err := ctx.DB().UpdateBySql(stmt).Exec()
+			require.NoError(t, err, "exec Up stmt of %s: %s", filename, stmt)
+		}
 	}
 
 	// Migration applied → column is already VARCHAR(50).
@@ -56,8 +80,8 @@ func TestGroupNameWidenMigration(t *testing.T) {
 	_, err := ctx.DB().InsertBySql("INSERT INTO `group` (group_no, name) VALUES (?, ?)", legacyNo, name40).Exec()
 	require.NoError(t, err)
 
-	// Run the widen (the migration's Up DDL) over the existing data.
-	modifyNameWidth(MaxGroupNameLen)
+	// Run the widen by executing the migration file's OWN Up DDL (not a hand-inlined copy).
+	applyMigrationUp(groupNameWidenMigrationFile)
 	require.Equal(t, MaxGroupNameLen, colLen(), "widen must take effect")
 
 	// Existing 40-rune data survives the in-place widen untouched.

--- a/modules/integration/api_groups.go
+++ b/modules/integration/api_groups.go
@@ -23,9 +23,13 @@ const (
 	maxTeamGroupMembers = 50
 	// idempotencyKeyHeader 客户端可选幂等 header（Stripe 式，缺省不保证幂等）。
 	idempotencyKeyHeader = "Idempotency-Key"
-	// idempotencyPendingTTL in-flight 占位 TTL；进程在「建群成功」与「写终值」之间崩溃
-	// 时最多保留这么久（之后过期，同 key 重试可能再建一个群——已知边界，可接受）。
-	idempotencyPendingTTL = 60 * time.Second
+	// idempotencyPendingTTL in-flight 占位锁的存活时间，需覆盖一次建群请求从占坑到写终值的最坏
+	// 处理时长。但 IMCreateOrUpdateChannel 走无客户端超时的 HTTP（IM 退化时服务端 goroutine 可长时间
+	// 阻塞），建群延迟没有硬上界，故不存在「绝对安全」的固定值。这里取一个工程上足以覆盖现实退化的
+	// 值，把「慢建群致 pending 锁提前过期 → 并发同 key 重试重复建群」的窗口收窄到极小。代价是进程在
+	// 「建群成功、未写终值」之间崩溃后，同 key 重试在该 TTL 内拿 409 in-flight 而非回放（宁可让客户端
+	// 稍后重试也不重复建群）。要彻底消除需给 IM 调用加超时或持锁续租——见 #381。
+	idempotencyPendingTTL = 5 * time.Minute
 	// idempotencyDoneTTL 终值（可回放）记录 TTL。
 	idempotencyDoneTTL = 24 * time.Hour
 )

--- a/modules/integration/api_groups.go
+++ b/modules/integration/api_groups.go
@@ -260,6 +260,16 @@ func (it *Integration) teamGroupExists(groupNo, spaceID, uid string) (bool, erro
 	if !found || status != group.GroupStatusNormal || creator != uid {
 		return false, nil
 	}
+	// 防御性对称（与 createGroup 的 owner 必须是人类一致）：建群时已校验 creator 是真人，正常情况
+	// 下 creator==uid 即意味着 uid 是人类；这里再复核 uid 当前仍是人类账号，让两个端点的人类约束
+	// 对称，兜住「账号被改成 robot 标记」这类极罕见的事后变更（非人类账号一律 exists=false）。
+	human, err := it.db.isHumanUser(uid)
+	if err != nil {
+		return false, err
+	}
+	if !human {
+		return false, nil
+	}
 	active, err := it.groupService.ExistMemberActive(groupNo, uid)
 	if err != nil {
 		return false, err

--- a/modules/integration/api_groups_test.go
+++ b/modules/integration/api_groups_test.go
@@ -80,8 +80,13 @@ func TestIntegrationCreateTeamGroupSuccess(t *testing.T) {
 	assert.Equal(t, uid, resp.OwnerUserID)
 	assert.Equal(t, "团队群", resp.Name)
 	assert.ElementsMatch(t, []string{botA, botB}, resp.MemberRobotIDs)
-	_, err := time.Parse(time.RFC3339, resp.CreatedAt)
+	createdAt, err := time.Parse(time.RFC3339, resp.CreatedAt)
 	assert.NoError(t, err, "created_at must be RFC3339, got %q", resp.CreatedAt)
+	// 0001-01-01T00:00:00Z (Go zero time) is itself valid RFC3339, so the parse check alone
+	// would pass on the regression. Require a real, recent timestamp instead.
+	assert.False(t, createdAt.IsZero(), "created_at must not be the zero time, got %q", resp.CreatedAt)
+	assert.WithinDuration(t, time.Now(), createdAt, 5*time.Minute,
+		"created_at must be close to now, got %q", resp.CreatedAt)
 
 	// 落库断言：owner=creator role，bot role=common + robot=1，无 bot_admin。
 	members := queryTeamGroupMembers(t, ctx, resp.GroupID)
@@ -361,6 +366,49 @@ func TestIntegrationTeamGroupExists(t *testing.T) {
 		Where("group_no=?", groupNo).Exec()
 	require.NoError(t, err)
 	assert.False(t, checkExists(groupNo).Exists)
+}
+
+// TestIntegrationTeamGroupExistsRejectsRobotCreator is the existence-side mirror of
+// TestIntegrationCreateTeamGroupRejectsRobotOwner: createGroup refuses a robot owner up front,
+// so groupExists must apply the same human guard to keep the two endpoints symmetric. We
+// create a group as a human, then flip the OIDC-linked account to a robot (AuthByKey still
+// authenticates — it ignores the robot flag) and assert the group no longer "exists".
+func TestIntegrationTeamGroupExistsRejectsRobotCreator(t *testing.T) {
+	route, ctx, mp := setupIntegrationAPITest(t)
+	subject := "sub-exists-robot"
+	uid := seedIntegrationUser(t, ctx, mp.Issuer, subject)
+	spaceID := "sp_" + util.GenerUUID()[:8]
+	seedSpaceMembership(t, ctx, uid, spaceID, "Team", 1, "2026-01-01 10:00:00")
+	bot := "bot_" + util.GenerUUID()[:8]
+	seedOwnBot(t, ctx, uid, spaceID, bot, "")
+	apiKey := exchangeTeamGroupKey(t, route, mp, subject, spaceID)
+
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, integrationRequest(t, http.MethodPost, "/v1/integrations/oidc/groups", apiKey, map[string]interface{}{
+		"name":             "团队群",
+		"member_robot_ids": []string{bot},
+	}))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var created createGroupResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+
+	checkExists := func() bool {
+		ww := httptest.NewRecorder()
+		route.ServeHTTP(ww, integrationRequest(t, http.MethodGet, "/v1/integrations/oidc/groups/"+created.GroupID, apiKey, nil))
+		require.Equal(t, http.StatusOK, ww.Code, ww.Body.String())
+		var r groupExistsResp
+		require.NoError(t, json.Unmarshal(ww.Body.Bytes(), &r))
+		return r.Exists
+	}
+
+	// Human creator + active member → exists:true.
+	assert.True(t, checkExists())
+
+	// Flip the creator's account to a robot. The key still authenticates (AuthByKey ignores the
+	// robot flag), but the human guard in teamGroupExists must now report exists:false.
+	_, err := ctx.DB().Update("user").Set("robot", 1).Where("uid=?", uid).Exec()
+	require.NoError(t, err)
+	assert.False(t, checkExists(), "a robot creator must not confirm the group (symmetric with create)")
 }
 
 // TestIntegrationTeamGroupExistsIsSpaceScoped verifies the existence check stays inside the

--- a/modules/integration/db.go
+++ b/modules/integration/db.go
@@ -175,13 +175,26 @@ func (d *integrationDB) queryAvailableBotSpaces(uid string, spaceIDs []string) (
 // 格式（非 RFC3339），故这里直读原始列，由调用方 .UTC().Format(time.RFC3339) 输出。按 space_id
 // 一并限定，与同模块 queryGroupStatus 的 Space 隔离口径一致（防御性，避免跨 Space 直读）。
 func (d *integrationDB) queryGroupCreatedAt(groupNo, spaceID string) (time.Time, error) {
-	var createdAt time.Time
+	// Must scan into a struct field (mirroring queryGroupStatus), NOT a bare time.Time:
+	// time.Time is itself a struct and implements no sql.Scanner, so dbr's reflection treats
+	// LoadOne(&t) as "find a column named created_at inside time.Time", finds none, scans into
+	// a throwaway dummy dest, and yields the zero value with a nil error. dbr only binds the
+	// column when it can match it to a named field of a wrapper struct.
+	var row struct {
+		CreatedAt time.Time `db:"created_at"`
+	}
 	err := d.session.Select("created_at").From("`group`").
-		Where("group_no=? AND space_id=?", groupNo, spaceID).LoadOne(&createdAt)
+		Where("group_no=? AND space_id=?", groupNo, spaceID).LoadOne(&row)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("integration: query group created_at %q: %w", groupNo, err)
 	}
-	return createdAt, nil
+	if row.CreatedAt.IsZero() {
+		// Defense-in-depth: a zero timestamp is never a real group creation time. Signal a read
+		// failure so the caller's server-time fallback fires instead of leaking the Go zero time
+		// (0001-01-01T00:00:00Z) into the response contract.
+		return time.Time{}, fmt.Errorf("integration: query group created_at %q: scanned zero time", groupNo)
+	}
+	return row.CreatedAt, nil
 }
 
 // queryGroupStatus returns the group's status and creator, scoped to the given space, and


### PR DESCRIPTION
## Summary

Addresses 4 of the items tracked in #381 (the non-blocking follow-ups from the #377 review). Scoped deliberately to the cheap, low-risk, integration/group-local ones; the remaining items are left for separate work (see below).

### 1. `created_at` correctness bug (the only correctness defect in #381)
`POST /v1/integrations/oidc/groups` returned `"created_at":"0001-01-01T00:00:00Z"` on **every** successful create.

`queryGroupCreatedAt` scanned `group.created_at` into a **bare `time.Time`**. dbr's reflection treats that as "find a `created_at` field inside `time.Time`", finds none, scans into a throwaway dest, and yields the **zero value with a nil error** — so the `time.Now()` fallback (guarded by `err != nil`) never fired and the zero time was returned as the success value. (Scanning into `db.Time` directly would hit the same path — it is also a struct with no `sql.Scanner`; the column only binds when matched to a *named struct field*, which is how the rest of the codebase reads it.)

Fix: scan into a struct field (mirroring `queryGroupStatus`) and treat a zero result as a read failure so the existing server-time fallback engages. The test previously only asserted `time.Parse(RFC3339)` did not error — and the zero time is itself valid RFC3339, so it slipped through; it now requires a non-zero timestamp close to now.

### 2. Existence check — symmetric human guard
`teamGroupExists` now applies the same `isHumanUser` guard `createGroup` already enforces, so the two endpoints stay symmetric (a creator later flipped to a robot no longer confirms the group). Defense-in-depth; not exploitable today (the check is already creator-scoped). Added a mirror test.

### 3. Migration test no longer inlines DDL
The name-widen test hand-inlined `ALTER TABLE ... MODIFY ... VARCHAR(50)` to stand in for the migration, which could drift from `sql/20260615000001_group_name_widen.sql`. It now parses and runs the migration file's own Up statements (via `rubenv/sql-migrate`, the same source production runs), so the assertions exercise — and break against — the real DDL.

### 4. Idempotency pending TTL (60s → 5m)
The in-flight pending lock expired after 60s, but `CreateGroup` calls `IMCreateOrUpdateChannel` over an HTTP client with **no timeout**, so a degraded WuKongIM can block the create well past 60s. The lock would then expire mid-flight and a concurrent same-key retry could acquire a fresh lock and run a parallel create → duplicate group. There is no provably-safe fixed TTL (create latency is unbounded without an IM-call timeout), so this widens the TTL to 5m — enough to cover realistic degradation and shrink the duplicate window to near zero. Trade-off: a same-key retry sees `409 in-flight` for longer after a between-commit-and-finalize crash, which is preferred over duplicate creates. Fully closing it needs an IM-call timeout or lock renewal — tracked in #381.

## Test plan
Run against MySQL + Redis + WuKongIM (all green locally and in CI):
- `go test ./modules/group/ -run TestGroupNameWidenMigration`
- `go test ./modules/integration/` (full package, no regression), incl. `TestIntegrationCreateTeamGroupSuccess`, `TestIntegrationCreateTeamGroupIdempotency`, and the new `TestIntegrationTeamGroupExistsRejectsRobotCreator`
- `gofmt` / `go vet` clean

No error codes or response envelopes changed, so no i18n regeneration needed.

## Not in this PR (remaining #381 items)
- **Compensating-delete non-atomicity (orphan group)** — the one cross-cutting data-consistency item; pre-existing shared-layer behavior (Web/Bot too), warrants its own issue + async reconcile.
- **Payload fingerprint serialization / no DB uniqueness fallback / zero-width whitespace in group name** — low priority; the uniqueness backstop in particular would change product semantics (same-name groups are legal), so documenting "send an Idempotency-Key for concurrent retries" is preferred over a DB constraint.

Closes #384

Refs #381 (umbrella issue; remaining items tracked there)