### PR TITLE
feat(search): harden message read path, fail-closed authz, explicit backend

### DIFF
--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/searchbackend"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
@@ -401,6 +402,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 			SystemBotUIDs:          spacepkg.SystemBotList(),
 			LocalLoginOff:          boolToFlag(cn.systemSettings.LocalLoginOff()),
 			DisableUserCreateSpace: boolToFlag(cn.systemSettings.SpaceDisableUserCreate()),
+			SearchEnabled:          searchbackend.Resolve(cn.ctx.GetConfig().ZincSearch.SearchOn).SearchEnabled(),
 		})
 		return
 	}
@@ -439,6 +441,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 		SystemBotUIDs:          spacepkg.SystemBotList(),
 		LocalLoginOff:          boolToFlag(cn.systemSettings.LocalLoginOff()),
 		DisableUserCreateSpace: boolToFlag(cn.systemSettings.SpaceDisableUserCreate()),
+		SearchEnabled:          searchbackend.Resolve(cn.ctx.GetConfig().ZincSearch.SearchOn).SearchEnabled(),
 	})
 }
 
@@ -753,6 +756,14 @@ type appConfigResp struct {
 	// 实时性。后端 POST /v1/space/create 也走同一个 getter 校验,客户端隐藏
 	// 与服务端拒绝由单一真源驱动,不存在前后端漂移。
 	DisableUserCreateSpace int `json:"disable_user_create_space"`
+
+	// SearchEnabled 告知客户端当前部署是否启用消息搜索（OCTO_SEARCH_BACKEND
+	// != disabled）。为 false 时前端应隐藏搜索入口，而不是每次调用搜索接口
+	// 再吃一个 SEARCH_DISABLED 错误（YUJ-4667 步骤 2 / YUJ-4662 §7-#10）。
+	//
+	// 与 app_config.version 解耦的原因同 LocalLoginOff / DisableUserCreateSpace：
+	// 运维切 backend 后老客户端命中 version 短路分支也必须拿到最新值。
+	SearchEnabled bool `json:"search_enabled"`
 }
 
 type oidcProviderResp struct {

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -34,6 +34,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
 	"github.com/Mininglamp-OSS/octo-server/pkg/richtext"
+	"github.com/Mininglamp-OSS/octo-server/pkg/searchbackend"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"github.com/gocraft/dbr/v2"
@@ -1322,6 +1323,17 @@ func (m *Message) typing(c *wkhttp.Context) {
 
 // 搜索消息
 func (m *Message) search(c *wkhttp.Context) {
+	// search.backend 三态收口（YUJ-4667 步骤 2）：旧 /v1/message/search 走
+	// WuKongIM→Zinc，只有显式声明 backend=zinc 时才服务。
+	//   - disabled：搜索全关，统一返回 SEARCH_DISABLED（与新 _search* 表面一致）。
+	//   - es：OpenSearch 路径为权威读路径，旧 Zinc 路径不再服务（绝不让 es
+	//     部署把流量悄悄落回 Zinc 读到陈旧索引）；客户端应改打 _search*。
+	//   - zinc：维持旧行为（迁移/回滚过渡态）。
+	backend := searchbackend.Resolve(m.ctx.GetConfig().ZincSearch.SearchOn)
+	if !backend.LegacyZinc {
+		httperr.ResponseErrorL(c, errcode.ErrMessagesSearchDisabled, nil, nil)
+		return
+	}
 	var req struct {
 		UID         string `json:"uid"` // 搜索的消息限定这某个用户内
 		ChannelID   string `json:"channel_id"`
@@ -1431,7 +1443,15 @@ func (m *Message) filterResultsBySpace(results []map[string]interface{}, spaceID
 				filtered = append(filtered, r)
 			}
 		default:
-			filtered = append(filtered, r)
+			// 安全收口（fail-CLOSED）：未知 channel_type 无法判定其 Space 归属，
+			// 一律剔除，绝不放行。此前 `default: append` 会把任何无法识别的
+			// channel_type 直接放进结果，构成跨 Space 越权暴露面（搜索 A Space
+			// 时可命中 B Space / 未加入频道的消息）。新链 modules/messages_search
+			// 已 fail-CLOSED，此处把旧 Zinc/WuKongIM 读路径对齐到同一安全语义。
+			m.Warn("搜索结果命中未知 channel_type，已按 fail-closed 剔除",
+				zap.Int("channel_type", channelType),
+				zap.String("channel_id", chID),
+				zap.String("space_id", spaceID))
 		}
 	}
 	return filtered, nil

--- a/modules/message/api_search_space_filter_test.go
+++ b/modules/message/api_search_space_filter_test.go
@@ -1,0 +1,102 @@
+package message
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/stretchr/testify/assert"
+)
+
+// N0 安全收口验证门（YUJ-4667）：旧 /v1/message/search 读路径的
+// filterResultsBySpace 此前 `default: append` 把无法识别的 channel_type 直接
+// 放行，构成跨 Space 越权暴露面。本组用例锁定 fail-CLOSED 语义：
+//   - 群聊(2)：仅命中 space 匹配的群；越权（B-only 群）剔除。
+//   - DM(1)：仅命中 payload.space_id 匹配的；越权剔除。
+//   - 未知 channel_type：一律剔除（核心安全收口，防回归）。
+
+// fakeSpaceGroupService 只实现 filterResultsBySpace 调用到的 GetGroups。
+type fakeSpaceGroupService struct {
+	group.IService
+	bySpace map[string]string // group_no -> space_id
+}
+
+func (f *fakeSpaceGroupService) GetGroups(groupNos []string) ([]*group.InfoResp, error) {
+	out := make([]*group.InfoResp, 0, len(groupNos))
+	for _, no := range groupNos {
+		out = append(out, &group.InfoResp{GroupNo: no, SpaceID: f.bySpace[no]})
+	}
+	return out, nil
+}
+
+func newSpaceFilterTestMessage(gs group.IService) *Message {
+	return &Message{
+		Log:          log.NewTLog("space-filter-test"),
+		groupService: gs,
+	}
+}
+
+func dmResultWithSpace(channelID, spaceID string) map[string]interface{} {
+	payload, _ := json.Marshal(map[string]interface{}{"space_id": spaceID})
+	return map[string]interface{}{
+		"channel_id":   channelID,
+		"channel_type": float64(1),
+		"payload":      base64.StdEncoding.EncodeToString(payload),
+	}
+}
+
+func spaceFilterChannelIDs(results []map[string]interface{}) []string {
+	out := make([]string, 0, len(results))
+	for _, r := range results {
+		id, _ := r["channel_id"].(string)
+		out = append(out, id)
+	}
+	return out
+}
+
+// 场景：A 在 Space A 搜索，结果集混有 B-only 群、A 群、跨 Space DM、未知类型。
+// fail-CLOSED 后只应保留属于 Space A 的群与 DM。
+func TestFilterResultsBySpace_FailClosed(t *testing.T) {
+	const spaceA = "spaceA"
+	gs := &fakeSpaceGroupService{bySpace: map[string]string{
+		"groupA": spaceA,
+		"groupB": "spaceB",
+	}}
+	m := newSpaceFilterTestMessage(gs)
+
+	results := []map[string]interface{}{
+		{"channel_id": "groupA", "channel_type": float64(2)}, // 同 space 群 → 保留
+		{"channel_id": "groupB", "channel_type": float64(2)}, // 越权群 → 剔除
+		dmResultWithSpace("dmA", spaceA),                     // 同 space DM → 保留
+		dmResultWithSpace("dmB", "spaceB"),                   // 越权 DM → 剔除
+		// 未知 channel_type（系统/CS/社区等本期未开类型）→ 必须剔除（核心收口）。
+		{"channel_id": "unknownChan", "channel_type": float64(99)},
+	}
+
+	filtered, err := m.filterResultsBySpace(results, spaceA)
+	assert.NoError(t, err)
+
+	ids := spaceFilterChannelIDs(filtered)
+	assert.ElementsMatch(t, []string{"groupA", "dmA"}, ids,
+		"fail-closed：仅保留同 Space 群/DM；越权频道与未知类型必须剔除")
+	assert.NotContains(t, ids, "unknownChan",
+		"未知 channel_type 必须 drop，绝不 fail-open 放行")
+	assert.NotContains(t, ids, "groupB")
+	assert.NotContains(t, ids, "dmB")
+}
+
+// 单独锁定「未知 channel_type 一律剔除」这一最高优先收口点，防止未来有人
+// 误把 default 改回 append。
+func TestFilterResultsBySpace_UnknownChannelTypeDropped(t *testing.T) {
+	m := newSpaceFilterTestMessage(&fakeSpaceGroupService{})
+	results := []map[string]interface{}{
+		{"channel_id": "x", "channel_type": float64(0)},
+		{"channel_id": "y", "channel_type": float64(3)},
+		{"channel_id": "z", "channel_type": float64(255)},
+	}
+	filtered, err := m.filterResultsBySpace(results, "anySpace")
+	assert.NoError(t, err)
+	assert.Empty(t, filtered, "所有未知 channel_type 必须被 fail-closed 剔除")
+}

--- a/modules/messages_search/api.go
+++ b/modules/messages_search/api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
+	"github.com/Mininglamp-OSS/octo-server/pkg/searchbackend"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 )
 
@@ -32,6 +33,10 @@ type Handler struct {
 
 	limiter *uidLimiter
 	cache   *senderCache
+	// mode is the resolved OCTO_SEARCH_BACKEND posture. When mode.ESServe is
+	// false the backendGate middleware refuses every _search* request with
+	// SEARCH_DISABLED — the OS path never serves under zinc/disabled.
+	mode searchbackend.Mode
 }
 
 // New constructs the Handler. ES client setup is deferred to first request so
@@ -51,6 +56,7 @@ func New(ctx *config.Context) *Handler {
 		visibility:     newMessageVisibilityProbe(msgSvc),
 		limiter:        newUIDLimiter(cfg.RateLimit.QPS, cfg.RateLimit.Burst),
 		cache:          newSenderCache(senderCacheCapacity, senderCacheTTL),
+		mode:           searchbackend.Resolve(ctx.GetConfig().ZincSearch.SearchOn),
 	}
 	if cfg.CursorHMAC == "" {
 		// The fallback key in cursor.go is a published constant, so cursors
@@ -73,6 +79,12 @@ func New(ctx *config.Context) *Handler {
 // auth/space/uid-limit chain plus the per-user search rate limiter and the
 // audit middleware (PRM-02). Individual handlers are wired in their own
 // search_*.go files via the registerHandler helper.
+//
+// The backendGate middleware runs INSIDE the chain (after auth + rate limit +
+// audit) so a disabled / zinc deployment still meters and audits the refusal
+// — an attacker cannot enumerate channels through an unmetered "search off"
+// reply (V9). When the backend is not `es` every _search* endpoint returns
+// SEARCH_DISABLED uniformly.
 func (h *Handler) Route(r *wkhttp.WKHttp) {
 	g := r.Group("/v1/messages",
 		h.ctx.AuthMiddleware(r),
@@ -80,9 +92,25 @@ func (h *Handler) Route(r *wkhttp.WKHttp) {
 		spacepkg.SpaceMiddleware(h.ctx),
 		h.searchRateLimiter(),
 		h.auditMiddleware(),
+		h.backendGate(),
 	)
 	for _, mount := range routeMounters {
 		mount(h, g)
+	}
+}
+
+// backendGate refuses every _search* request with SEARCH_DISABLED unless the
+// resolved backend is `es`. It sits after the rate-limiter + audit middleware
+// so the refusal is still counted and logged (V9: failure paths must not be a
+// free enumeration oracle).
+func (h *Handler) backendGate() wkhttp.HandlerFunc {
+	return func(c *wkhttp.Context) {
+		if !h.mode.ESServe {
+			respondSearchDisabled(c)
+			c.Abort()
+			return
+		}
+		c.Next()
 	}
 }
 

--- a/modules/messages_search/api_i18n.go
+++ b/modules/messages_search/api_i18n.go
@@ -63,6 +63,23 @@ func respondNotFound(c *wkhttp.Context, resource string) {
 	httperr.ResponseErrorL(c, errcode.ErrMessagesSearchNotFound, nil, d)
 }
 
+// respondSearchDisabled emits SEARCH_DISABLED — the deployment has
+// OCTO_SEARCH_BACKEND=disabled so no search surface serves. Used by the
+// backendGate middleware (and mirrored by the legacy surfaces) so every
+// search entry point refuses uniformly instead of 500/panic/leaking.
+func respondSearchDisabled(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errcode.ErrMessagesSearchDisabled, nil, nil)
+}
+
+// respondDepthExceeded emits DEPTH_EXCEEDED — the cumulative pagination depth
+// cap (max_result_window) was reached. Carries the cap so clients can surface
+// a meaningful "narrow your search" hint.
+func respondDepthExceeded(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errcode.ErrMessagesSearchDepthExceeded, nil, i18n.Details{
+		"max_depth": maxPaginationDepth,
+	})
+}
+
 // classifyOSError categorises an error returned by the olivere/elastic client
 // into one of our R2 buckets. Returns the responder helper to invoke.
 //

--- a/modules/messages_search/backend_gate_test.go
+++ b/modules/messages_search/backend_gate_test.go
@@ -1,0 +1,61 @@
+package messages_search
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/searchbackend"
+	"github.com/gin-gonic/gin"
+)
+
+func newBackendGateCtx(t *testing.T) (*wkhttp.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest("POST", "/v1/messages/_search", nil)
+	return &wkhttp.Context{Context: gc}, rec
+}
+
+// V6 — when the resolved mode does not serve ES (disabled or zinc), the
+// _search* surface must refuse uniformly with SEARCH_DISABLED rather than reach
+// OS, and must Abort so no downstream handler runs.
+func TestBackendGate_RefusesWhenESOff(t *testing.T) {
+	modes := []searchbackend.Mode{
+		{ESServe: false, LegacyZinc: false, Declared: searchbackend.DeclaredDisabled},
+		{ESServe: false, LegacyZinc: true, Declared: searchbackend.DeclaredZinc},
+	}
+	for _, m := range modes {
+		h := &Handler{Log: log.NewTLog("backend-gate-test"), mode: m}
+		c, rec := newBackendGateCtx(t)
+		h.backendGate()(c)
+		if !c.IsAborted() {
+			t.Fatalf("mode %+v: gate must Abort the chain", m)
+		}
+		if rec.Body.Len() == 0 {
+			t.Fatalf("mode %+v: gate must render a SEARCH_DISABLED envelope", m)
+		}
+		body := rec.Body.String()
+		if !strings.Contains(strings.ToLower(body), "disabled") &&
+			!strings.Contains(body, "未启用") &&
+			!strings.Contains(body, "not enabled") {
+			t.Fatalf("mode %+v: expected SEARCH_DISABLED envelope, got %q", m, body)
+		}
+	}
+}
+
+// V6 — under a mode that serves ES the gate is transparent.
+func TestBackendGate_PassesWhenESServes(t *testing.T) {
+	h := &Handler{Log: log.NewTLog("backend-gate-test"), mode: searchbackend.Mode{ESServe: true}}
+	c, rec := newBackendGateCtx(t)
+	h.backendGate()(c)
+	if c.IsAborted() {
+		t.Fatalf("ES-serving mode: gate must NOT abort")
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("ES-serving mode: gate must not write a body, got %q", rec.Body.String())
+	}
+}

--- a/modules/messages_search/cursor.go
+++ b/modules/messages_search/cursor.go
@@ -17,7 +17,21 @@ type cursorPayload struct {
 	TS    int64    `json:"ts"`          // OS `timestamp` field, epoch seconds
 	MsgID int64    `json:"id"`          // OS `messageId` tiebreaker
 	Score *float64 `json:"s,omitempty"` // _score, relevance sort only
+	// Depth is the cumulative number of results the caller has already been
+	// served BEFORE the page this cursor opens. The server enforces the
+	// max-pagination-depth cap against this value, not against page_size, so
+	// changing page_size between requests cannot be used to walk past the cap
+	// (YUJ-4667 step 4 / V7 depth cap). omitempty keeps pre-depth cursors
+	// (Depth==0 first page) byte-identical to the old encoding.
+	Depth int64 `json:"d,omitempty"`
 }
+
+// maxPaginationDepth caps the cumulative number of results a single
+// cursor-walk may traverse, aligned with OpenSearch's default
+// max_result_window (10000). Beyond this the from+size / search_after window
+// stops being cheap and deep paging is the wrong tool — callers narrow the
+// query instead. Enforced on the cumulative count carried in the cursor.
+const maxPaginationDepth = 10000
 
 // cursorSigLen is the HMAC tail length appended after the JSON body. 8 bytes
 // of SHA-256 is plenty for a non-monetary tamper check while keeping the
@@ -35,9 +49,18 @@ var hmacKeyFn = func(cfg SearchConfig) []byte {
 
 // encodeCursor packs (timestamp, messageId, score?) into a base64url-encoded
 // opaque cursor with an 8-byte HMAC tail. Pass score=nil for time_desc /
-// time_asc; pass a non-nil pointer for relevance sort.
+// time_asc; pass a non-nil pointer for relevance sort. Depth defaults to 0
+// (the cumulative-depth cap treats a depth-less cursor as a fresh walk); use
+// encodeCursorWithDepth to carry the running total.
 func encodeCursor(cfg SearchConfig, ts, msgID int64, score *float64) string {
-	p := cursorPayload{TS: ts, MsgID: msgID, Score: score}
+	return encodeCursorWithDepth(cfg, ts, msgID, score, 0)
+}
+
+// encodeCursorWithDepth is encodeCursor plus the cumulative result-depth the
+// next page will start from. The depth is HMAC-signed along with the rest of
+// the payload so a client cannot tamper it back to 0 to bypass the cap.
+func encodeCursorWithDepth(cfg SearchConfig, ts, msgID int64, score *float64, depth int64) string {
+	p := cursorPayload{TS: ts, MsgID: msgID, Score: score, Depth: depth}
 	body, _ := json.Marshal(p)
 	mac := hmac.New(sha256.New, hmacKeyFn(cfg))
 	mac.Write(body)
@@ -50,22 +73,29 @@ func encodeCursor(cfg SearchConfig, ts, msgID int64, score *float64) string {
 // handler can map to VALIDATION_ERROR(field=cursor). The returned score is
 // nil for legacy 2-tuple cursors (time_*) and non-nil for relevance cursors.
 func decodeCursor(cfg SearchConfig, s string) (int64, int64, *float64, error) {
+	ts, msgID, score, _, err := decodeCursorWithDepth(cfg, s)
+	return ts, msgID, score, err
+}
+
+// decodeCursorWithDepth is decodeCursor plus the cumulative depth carried in
+// the cursor (0 for legacy cursors that predate the field).
+func decodeCursorWithDepth(cfg SearchConfig, s string) (int64, int64, *float64, int64, error) {
 	if s == "" {
-		return 0, 0, nil, errors.New("cursor: empty")
+		return 0, 0, nil, 0, errors.New("cursor: empty")
 	}
 	raw, err := base64.RawURLEncoding.DecodeString(s)
 	if err != nil || len(raw) < cursorSigLen+1 {
-		return 0, 0, nil, errors.New("cursor: malformed")
+		return 0, 0, nil, 0, errors.New("cursor: malformed")
 	}
 	body, sig := raw[:len(raw)-cursorSigLen], raw[len(raw)-cursorSigLen:]
 	mac := hmac.New(sha256.New, hmacKeyFn(cfg))
 	mac.Write(body)
 	if !hmac.Equal(mac.Sum(nil)[:cursorSigLen], sig) {
-		return 0, 0, nil, errors.New("cursor: bad signature")
+		return 0, 0, nil, 0, errors.New("cursor: bad signature")
 	}
 	var p cursorPayload
 	if err := json.Unmarshal(body, &p); err != nil {
-		return 0, 0, nil, errors.New("cursor: unmarshal")
+		return 0, 0, nil, 0, errors.New("cursor: unmarshal")
 	}
-	return p.TS, p.MsgID, p.Score, nil
+	return p.TS, p.MsgID, p.Score, p.Depth, nil
 }

--- a/modules/messages_search/depth_cap_test.go
+++ b/modules/messages_search/depth_cap_test.go
@@ -1,0 +1,115 @@
+package messages_search
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/gin-gonic/gin"
+)
+
+func newDepthCtx(t *testing.T) (*wkhttp.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest("POST", "/v1/messages/_search", nil)
+	return &wkhttp.Context{Context: gc}, rec
+}
+
+func newDepthHandler() *Handler {
+	return &Handler{Log: log.NewTLog("depth-cap-test"), cfg: SearchConfig{}}
+}
+
+// V7 depth cap — a cursor whose cumulative depth has reached the cap is
+// rejected with DEPTH_EXCEEDED before any OS round-trip.
+func TestResolveCursorDepth_AtCapRejected(t *testing.T) {
+	h := newDepthHandler()
+	cur := encodeCursorWithDepth(h.cfg, 1717000000, 42, nil, maxPaginationDepth)
+	c, rec := newDepthCtx(t)
+	_, ok := h.resolveCursorDepth(c, cur, 1)
+	if ok {
+		t.Fatalf("cursor at the depth cap must be rejected")
+	}
+	if !strings.Contains(strings.ToLower(rec.Body.String()), "depth") &&
+		!strings.Contains(rec.Body.String(), "最大深度") {
+		t.Fatalf("expected DEPTH_EXCEEDED envelope, got %q", rec.Body.String())
+	}
+}
+
+func TestResolveCursorDepth_OverCapRejected(t *testing.T) {
+	h := newDepthHandler()
+	cur := encodeCursorWithDepth(h.cfg, 1717000000, 42, nil, maxPaginationDepth+500)
+	c, rec := newDepthCtx(t)
+	if _, ok := h.resolveCursorDepth(c, cur, 1); ok {
+		t.Fatalf("cursor over the depth cap must be rejected")
+	}
+	if rec.Body.Len() == 0 {
+		t.Fatalf("over-cap cursor must render an error envelope")
+	}
+}
+
+func TestResolveCursorDepth_UnderCapAllowed(t *testing.T) {
+	h := newDepthHandler()
+	c, _ := newDepthCtx(t)
+	if d, ok := h.resolveCursorDepth(c, "", 20); !ok || d != 0 {
+		t.Fatalf("empty cursor must allow with depth 0, got (%d,%v)", d, ok)
+	}
+	cur := encodeCursorWithDepth(h.cfg, 1717000000, 42, nil, 100)
+	c2, _ := newDepthCtx(t)
+	if d, ok := h.resolveCursorDepth(c2, cur, 20); !ok || d != 100 {
+		t.Fatalf("shallow cursor must allow and report depth 100, got (%d,%v)", d, ok)
+	}
+}
+
+// V7 — THE anti-bypass case (codex P2). The cap is checked against
+// priorDepth + pageSize, so a caller just under the cap cannot pick a larger
+// page_size to read past it.
+func TestDepthCap_LargerPageSizeCannotOverrun(t *testing.T) {
+	h := newDepthHandler()
+	nearCap := encodeCursorWithDepth(h.cfg, 1717000000, 42, nil, maxPaginationDepth-1)
+
+	c, rec := newDepthCtx(t)
+	if _, ok := h.resolveCursorDepth(c, nearCap, 100); ok {
+		t.Fatalf("depth=%d + page_size=100 overruns the cap and must be rejected", maxPaginationDepth-1)
+	}
+	if rec.Body.Len() == 0 {
+		t.Fatalf("overrun must render DEPTH_EXCEEDED")
+	}
+
+	c2, _ := newDepthCtx(t)
+	if _, ok := h.resolveCursorDepth(c2, nearCap, 1); !ok {
+		t.Fatalf("depth=%d + page_size=1 lands exactly at the cap and must be allowed", maxPaginationDepth-1)
+	}
+}
+
+// V7 — shrinking page_size cannot bypass the cap once the cursor's cumulative
+// depth is already at/over it.
+func TestDepthCap_SmallPageSizeCannotBypassAtCap(t *testing.T) {
+	h := newDepthHandler()
+	atCap := encodeCursorWithDepth(h.cfg, 1717000000, 42, nil, maxPaginationDepth)
+	c, rec := newDepthCtx(t)
+	if _, ok := h.resolveCursorDepth(c, atCap, 1); ok {
+		t.Fatalf("shrinking page_size must NOT bypass the cumulative depth cap")
+	}
+	if rec.Body.Len() == 0 {
+		t.Fatalf("anti-bypass path must render DEPTH_EXCEEDED")
+	}
+}
+
+// HMAC-signed depth: tampering invalidates the signature → rejected.
+func TestDepthCap_TamperedDepthRejected(t *testing.T) {
+	h := newDepthHandler()
+	cur := encodeCursorWithDepth(h.cfg, 1717000000, 42, nil, maxPaginationDepth)
+	b := []byte(cur)
+	b[len(b)/2] ^= 0x01
+	c, rec := newDepthCtx(t)
+	if _, ok := h.resolveCursorDepth(c, string(b), 20); ok {
+		t.Fatalf("tampered cursor must be rejected")
+	}
+	if rec.Body.Len() == 0 {
+		t.Fatalf("tampered cursor must render an error envelope")
+	}
+}

--- a/modules/messages_search/join_load_test.go
+++ b/modules/messages_search/join_load_test.go
@@ -1,0 +1,114 @@
+package messages_search
+
+import (
+	"context"
+	"testing"
+)
+
+// countingProbe records the largest IN() list it was handed per call and the
+// number of probe round-trips, so we can bound the MySQL join load a single
+// search request can impose (YUJ-4667 step 7 — read-path join performance
+// gate). Every signal survives (no filtering) so the page fills on round 1.
+type countingProbe struct {
+	maxINList int
+	calls     int
+}
+
+func (p *countingProbe) note(ids []string) {
+	p.calls++
+	if len(ids) > p.maxINList {
+		p.maxINList = len(ids)
+	}
+}
+
+func (p *countingProbe) RevokedSet(ids []string) (map[string]struct{}, error) {
+	p.note(ids)
+	return map[string]struct{}{}, nil
+}
+func (p *countingProbe) GloballyDeletedSet(ids []string) (map[string]struct{}, error) {
+	p.note(ids)
+	return map[string]struct{}{}, nil
+}
+func (p *countingProbe) UserDeletedSet(uid string, ids []string) (map[string]struct{}, error) {
+	p.note(ids)
+	return map[string]struct{}{}, nil
+}
+func (p *countingProbe) ChannelOffset(uid, channelID string) (uint32, error) { return 0, nil }
+
+// Step 7 — the per-request MySQL join IN() list MUST stay bounded by
+// pageSize * oversampleMultiplier (one round's oversample fetch), NOT by the
+// corpus size or the number of OS hits. This is the machine-checkable proxy
+// for "join / DB load stays within threshold at a typical page-size": the IN()
+// expansion that the plan calls out as the load risk is structurally capped.
+//
+// Threshold (measured here, pinned as the gate):
+//   - max IN() list per probe call  <= pageSize * oversampleMultiplier
+//   - total probe round-trips        <= loopBudget * 4 signals
+// At the max page_size of 100 that is <= 300 ids per IN(), <= 12 round-trips —
+// a single bounded JOIN batch per round, never an unbounded fan-out.
+func TestJoinLoad_INListBoundedByPageSize(t *testing.T) {
+	for _, pageSize := range []int{1, 20, 100} {
+		probe := &countingProbe{}
+		h := newVisibilityHandler(probe)
+
+		// OS returns a full oversample page every round (signals that the
+		// corpus is huge); all hits are visible so the page fills on round 1.
+		fetchSize := pageSize * oversampleMultiplier
+		osQuery := func(searchAfter []any, size int) ([]rawHit, error) {
+			return makeFakeHits(t, 1, fetchSize), nil
+		}
+		collected, _, _, err := h.paginateWithFilter(
+			context.Background(), "me", "C1", pageSize, nil, false,
+			wrapHitsQuery(osQuery), wrapProject(),
+		)
+		if err != nil {
+			t.Fatalf("pageSize=%d: paginate: %v", pageSize, err)
+		}
+		if len(collected) != pageSize {
+			t.Fatalf("pageSize=%d: expected full page, got %d", pageSize, len(collected))
+		}
+		// The IN() list is the unique ids of ONE oversample round, never the
+		// whole corpus.
+		wantMax := pageSize * oversampleMultiplier
+		if probe.maxINList > wantMax {
+			t.Fatalf("pageSize=%d: IN() list %d exceeds bound %d — join load not capped",
+				pageSize, probe.maxINList, wantMax)
+		}
+		t.Logf("pageSize=%d: max IN()=%d (bound %d), probe round-trips=%d",
+			pageSize, probe.maxINList, wantMax, probe.calls)
+	}
+}
+
+// Even when the page never fills (every hit filtered), the join load is still
+// bounded: at most loopBudget rounds, each with one oversample IN() list.
+func TestJoinLoad_BoundedAcrossBudgetExhaustion(t *testing.T) {
+	pageSize := 100
+	// Reuse stubProbe so we can mark everything revoked; wrap a counter by
+	// asserting the documented round bound via call counts.
+	probe := &stubProbe{revoked: map[string]bool{}}
+	for i := 1; i <= pageSize*oversampleMultiplier*loopBudget; i++ {
+		probe.revoked[itoa(i)] = true
+	}
+	h := newVisibilityHandler(probe)
+
+	roundCalls := 0
+	osQuery := func(searchAfter []any, size int) ([]rawHit, error) {
+		roundCalls++
+		start := (roundCalls-1)*(pageSize*oversampleMultiplier) + 1
+		return makeFakeHits(t, start, start+pageSize*oversampleMultiplier-1), nil
+	}
+	_, _, _, err := h.paginateWithFilter(
+		context.Background(), "me", "C1", pageSize, nil, false,
+		wrapHitsQuery(osQuery), wrapProject(),
+	)
+	if err != nil {
+		t.Fatalf("paginate: %v", err)
+	}
+	// One RevokedSet call per round; the loop must not exceed loopBudget rounds
+	// no matter how big the corpus is.
+	if probe.revokedCalls > loopBudget {
+		t.Fatalf("probe queried %d rounds, exceeds loopBudget %d — unbounded join load",
+			probe.revokedCalls, loopBudget)
+	}
+	t.Logf("budget-exhaustion: probe rounds=%d (bound %d)", probe.revokedCalls, loopBudget)
+}

--- a/modules/messages_search/no_zinc_fallthrough_test.go
+++ b/modules/messages_search/no_zinc_fallthrough_test.go
@@ -1,0 +1,57 @@
+package messages_search
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// V5 — the es read path must NEVER fall through to Zinc/WuKongIM search. We
+// enforce this structurally: no non-test source file in modules/messages_search
+// may invoke the legacy Zinc query surface (the WuKongIM /message/search
+// forward, the IMSearchUserMessages global search, or modules/search). An es
+// deployment whose OpenSearch is down surfaces UPSTREAM_UNAVAILABLE (see
+// classifyOSError + respondUpstream) instead of silently returning Zinc
+// results. Reading the ZincSearch.SearchOn config toggle to compute the
+// default backend is a declaration read (allowed), not a query fall-through.
+func TestNoZincFallthrough(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	banned := []string{
+		"IMSearchUserMessages",
+		"/message/search",
+		"modules/search",
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Clean(name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		// Strip // line comments so doc cross-references (e.g. "mirrors
+		// modules/search/api.go's predicate") don't trip the structural ban —
+		// we only care about live code invoking the legacy surface. Same
+		// comment-stripping approach as api_i18n_test.go.
+		var clean strings.Builder
+		for _, line := range strings.Split(string(data), "\n") {
+			if idx := strings.Index(line, "//"); idx >= 0 {
+				line = line[:idx]
+			}
+			clean.WriteString(line)
+			clean.WriteByte('\n')
+		}
+		cleaned := clean.String()
+		for _, b := range banned {
+			if strings.Contains(cleaned, b) {
+				t.Fatalf("%s references the legacy Zinc surface %q — the es read path "+
+					"must never fall through to Zinc (V5)", name, b)
+			}
+		}
+	}
+}

--- a/modules/messages_search/recon_metrics.go
+++ b/modules/messages_search/recon_metrics.go
@@ -1,0 +1,72 @@
+package messages_search
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// ES↔MySQL 对账 drift 只读指标（YUJ-4667 步骤 5 / YUJ-4662 §4 步骤 5）。
+//
+// 权威对账作业（doc-count vs MySQL message 行数 + 抽样比对）跑在 indexer 仓
+// （近 OS 写侧，复用阶段 6 recon 范式，产出结构化报告）。octo-server 侧**只读**
+// 暴露最近一次对账结果，供「搜不到」定位：运维在 Grafana 上看到
+// search_recon_doc_drift != 0 即知 ES 与 MySQL 失配。
+//
+// 失败阈值（机检口径，钉死在此）：
+//   - search_recon_doc_drift == 0           → 健康
+//   - search_recon_doc_drift > 0  (ES 多 doc：该删没删 / 越权可搜)  → 告警
+//   - search_recon_doc_drift < 0  (ES 少 doc：漏索引 / 搜不到)      → 告警
+//   - now - search_recon_last_run_timestamp_seconds > 2 * 对账周期 → 作业停摆告警
+//
+// 指标命名：search_recon_* 命名空间，无高基维 label（单集群够用）。
+var (
+	// reconDocDrift = ES doc-count - MySQL message 行数（带符号）。
+	reconDocDrift = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "search_recon",
+		Name:      "doc_drift",
+		Help: "Signed ES↔MySQL message-count drift from the latest reconciliation " +
+			"run (ES doc-count minus MySQL row-count). 0=healthy; >0 ES has extra " +
+			"docs (delete-miss / over-recall); <0 ES is missing docs (index-miss).",
+	})
+
+	// reconSampleMismatch = 抽样比对中字段级失配的 doc 数。
+	reconSampleMismatch = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "search_recon",
+		Name:      "sample_mismatch",
+		Help: "Number of sampled documents whose ES projection diverged from the " +
+			"MySQL source of truth in the latest reconciliation run. 0=healthy.",
+	})
+
+	// reconLastRunTimestamp = 最近一次对账完成的 unix 秒。
+	reconLastRunTimestamp = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "search_recon",
+		Name:      "last_run_timestamp_seconds",
+		Help: "Unix timestamp (seconds) when the latest reconciliation run " +
+			"completed. Staleness vs the expected cadence signals a stalled job.",
+	})
+)
+
+// ReconReport is the structured drift summary the indexer-side reconciliation
+// job pushes to octo-server's read-only ingestion point. octo-server NEVER
+// computes drift itself (that needs the OS write side); it only stores the last
+// report so the gauges above can be scraped.
+type ReconReport struct {
+	ESDocCount       int64 `json:"es_doc_count"`
+	MySQLRowCount    int64 `json:"mysql_row_count"`
+	SampleMismatch   int64 `json:"sample_mismatch"`
+	RanAtUnixSeconds int64 `json:"ran_at_unix_seconds"`
+}
+
+// DocDrift is the signed ES-minus-MySQL count.
+func (r ReconReport) DocDrift() int64 { return r.ESDocCount - r.MySQLRowCount }
+
+// PublishReconReport updates the read-only drift gauges from a reconciliation
+// report. Idempotent; safe to call on every report push. Returns the computed
+// signed drift so callers (and tests) can assert on it.
+func PublishReconReport(r ReconReport) int64 {
+	drift := r.DocDrift()
+	reconDocDrift.Set(float64(drift))
+	reconSampleMismatch.Set(float64(r.SampleMismatch))
+	reconLastRunTimestamp.Set(float64(r.RanAtUnixSeconds))
+	return drift
+}

--- a/modules/messages_search/recon_metrics_test.go
+++ b/modules/messages_search/recon_metrics_test.go
@@ -1,0 +1,29 @@
+package messages_search
+
+import "testing"
+
+// Step 5 — the read-only drift gauges reflect the latest reconciliation report.
+// octo-server only stores/exposes the report (the authoritative recon runs in
+// the indexer repo); these assertions pin the signed-drift math and the
+// machine-checkable failure thresholds (drift!=0 => unhealthy).
+func TestPublishReconReport_SignedDrift(t *testing.T) {
+	cases := []struct {
+		name   string
+		report ReconReport
+		want   int64
+	}{
+		{"healthy", ReconReport{ESDocCount: 1000, MySQLRowCount: 1000}, 0},
+		{"es_extra_delete_miss", ReconReport{ESDocCount: 1005, MySQLRowCount: 1000}, 5},
+		{"es_missing_index_miss", ReconReport{ESDocCount: 990, MySQLRowCount: 1000}, -10},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.report.DocDrift(); got != tc.want {
+				t.Fatalf("DocDrift() = %d, want %d", got, tc.want)
+			}
+			if got := PublishReconReport(tc.report); got != tc.want {
+				t.Fatalf("PublishReconReport() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/modules/messages_search/route_chain_test.go
+++ b/modules/messages_search/route_chain_test.go
@@ -1,0 +1,37 @@
+package messages_search
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+)
+
+// V9 — every _search* endpoint, including the new _search_around, must be
+// mounted through the shared routeMounters list. That list is wired in
+// Route() under the single middleware group that carries Auth + SharedUID +
+// Space + searchRateLimiter + audit + backendGate, so no endpoint can quietly
+// skip the rate-limit / audit / disabled-backend gates. We assert the count of
+// mounters here as a regression guard: a new search_*.go that forgets
+// registerRoute (and instead mounts directly) would not increment this and the
+// test would flag the drift.
+func TestRouteMountersCoverAllEndpoints(t *testing.T) {
+	// _search, _search_media, _search_files, _search_all, _search_around.
+	const wantEndpoints = 5
+	if len(routeMounters) != wantEndpoints {
+		t.Fatalf("expected %d endpoints registered via registerRoute (so all go "+
+			"through the shared rate-limit/audit/backendGate chain), got %d. "+
+			"A new endpoint that bypasses registerRoute would skip those gates (V9).",
+			wantEndpoints, len(routeMounters))
+	}
+
+	// Each mounter must actually register a path under the group (smoke check
+	// that the closures are non-nil and runnable against a real router group).
+	r := wkhttp.New()
+	g := r.Group("/v1/messages")
+	for i, mount := range routeMounters {
+		if mount == nil {
+			t.Fatalf("routeMounters[%d] is nil", i)
+		}
+		mount(&Handler{}, g)
+	}
+}

--- a/modules/messages_search/search_all.go
+++ b/modules/messages_search/search_all.go
@@ -67,6 +67,10 @@ func (h *Handler) searchAll(c *wkhttp.Context) {
 		respondValidation(c, "cursor", "malformed")
 		return
 	}
+	priorDepth, ok := h.resolveCursorDepth(c, req.Cursor, pageSize)
+	if !ok {
+		return
+	}
 
 	ctx, cancel := context.WithTimeout(c.Request.Context(), h.cfg.Timeout)
 	defer cancel()
@@ -93,8 +97,8 @@ func (h *Handler) searchAll(c *wkhttp.Context) {
 		return res.Hits.Hits, nil
 	}
 
-	filtered, hasMore, nextCursor, err := h.paginateWithFilter(
-		ctx, loginUID, req.ChannelID, pageSize, initialAfter, isRelevance, osQuery, projectDocRef(req.ChannelID),
+	filtered, hasMore, nextCursor, err := h.paginateWithFilterDepth(
+		ctx, loginUID, req.ChannelID, pageSize, priorDepth, initialAfter, isRelevance, osQuery, projectDocRef(req.ChannelID),
 	)
 	if err != nil {
 		if responder := classifyOSError(err); responder != nil {

--- a/modules/messages_search/search_around.go
+++ b/modules/messages_search/search_around.go
@@ -1,0 +1,299 @@
+package messages_search
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/olivere/elastic"
+	"go.uber.org/zap"
+)
+
+// AroundResult is the response envelope for POST /v1/messages/_search_around.
+// The window is returned in chronological (time_asc) order: `before` (older
+// than the anchor, oldest-first), then `anchor`, then `after` (newer than the
+// anchor, oldest-first). has_more_before / has_more_after tell the client
+// whether paging further in each direction would yield more visible messages.
+type AroundResult struct {
+	Before        []MessageHit `json:"before"`
+	Anchor        MessageHit   `json:"anchor"`
+	After         []MessageHit `json:"after"`
+	HasMoreBefore bool         `json:"has_more_before"`
+	HasMoreAfter  bool         `json:"has_more_after"`
+}
+
+func init() {
+	registerRoute(func(h *Handler, g *wkhttp.RouterGroup) {
+		g.POST("/_search_around", h.searchAround)
+	})
+}
+
+// searchAround is POST /v1/messages/_search_around.
+//
+// Security contract (YUJ-4662 §4 step 3 / V8-b, STOP #3): the anchor is
+// pre-validated through the SAME gates as a normal read before any context is
+// fetched —
+//
+//  1. checkChannelAccess: caller must be able to read the channel at all.
+//  2. resolveP2PSpaceScope: p2p anchor is scoped to the caller's Space, so a
+//     cross-Space anchor cannot be located (the spaceId term filter on the
+//     anchor lookup returns nothing → NOT_FOUND).
+//  3. filterVisible on the anchor doc itself: a revoked / deleted /
+//     not-in-visibles / cleared-by-offset anchor is NOT_FOUND.
+//
+// Only after the anchor passes all three do we fetch the surrounding window.
+// We never pull context around an anchor the caller could not see — that would
+// be both a disclosure (the neighbours) and a probing oracle (existence of the
+// anchor). All window hits go through the same filterVisible post-filter.
+func (h *Handler) searchAround(c *wkhttp.Context) {
+	var req SearchAroundReq
+	if err := c.BindJSON(&req); err != nil {
+		respondValidation(c, "body", "invalid JSON")
+		return
+	}
+	loginUID := c.GetLoginUID()
+
+	// Reuse the shared field validation (channel form, page_size, filters).
+	// No sort/cursor on this endpoint; relevance is not applicable.
+	pageSize, ok := validateBase(c, h.cfg, req.ChannelType, req.ChannelID, "", "", req.Filters, req.PageSize, false)
+	if !ok {
+		return
+	}
+	anchorID, perr := strconv.ParseInt(req.AnchorMessageID, 10, 64)
+	if perr != nil || anchorID <= 0 {
+		respondValidation(c, "anchor_message_id", "must be a positive integer id")
+		return
+	}
+	if !h.checkChannelAccess(c, req.ChannelType, req.ChannelID, loginUID) {
+		return
+	}
+	spaceID, ok := h.resolveP2PSpaceScope(c, req.ChannelType, loginUID)
+	if !ok {
+		return
+	}
+
+	client, err := ESClient(h.cfg)
+	if err != nil {
+		h.Error("ESClient init failed", zap.Error(err))
+		respondUpstream(c)
+		return
+	}
+
+	normID := normalizedChannelID(req.ChannelType, req.ChannelID, loginUID)
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), h.cfg.Timeout)
+	defer cancel()
+
+	// --- 1. Locate + pre-validate the anchor (single doc). ---
+	anchorHit, err := h.fetchAnchor(ctx, client, req, normID, spaceID, loginUID, anchorID)
+	if err != nil {
+		if responder := classifyOSError(err); responder != nil {
+			h.Warn("OS around anchor fetch failed", zap.Error(err))
+			responder(c)
+			return
+		}
+		h.Error("messages_search: around anchor visibility check failed", zap.Error(err))
+		respondInternal(c)
+		return
+	}
+	if anchorHit == nil {
+		// Anchor not present, cross-Space, or filtered out by visibility — all
+		// collapse to NOT_FOUND so the failure path is not an existence oracle.
+		respondNotFound(c, "channel")
+		return
+	}
+
+	anchorSort, ok := buildSearchAfterFromHit(anchorHit, false)
+	if !ok {
+		// A located anchor whose _source/sort can't yield a resume key is
+		// unusable for windowing; treat as not found rather than emit a
+		// half-window.
+		respondNotFound(c, "channel")
+		return
+	}
+
+	// --- 2. Fetch the two directions around the anchor. ---
+	// `after` (newer): time_asc, search_after = anchor sort tuple.
+	afterHits, hasMoreAfter, err := h.aroundDirection(ctx, client, req, normID, spaceID, loginUID, pageSize, anchorSort, false)
+	if err != nil {
+		h.respondAroundErr(c, err, "after")
+		return
+	}
+	// `before` (older): time_desc (reversed), search_after = anchor sort tuple
+	// in the reversed sort space. Re-reversed to chronological order below.
+	beforeDesc, hasMoreBefore, err := h.aroundDirection(ctx, client, req, normID, spaceID, loginUID, pageSize, anchorSort, true)
+	if err != nil {
+		h.respondAroundErr(c, err, "before")
+		return
+	}
+	beforeHits := reverseHits(beforeDesc)
+
+	// --- 3. Project + sender-join the whole window in one batch. ---
+	window := make([]*elastic.SearchHit, 0, len(beforeHits)+1+len(afterHits))
+	window = append(window, beforeHits...)
+	window = append(window, anchorHit)
+	window = append(window, afterHits...)
+	hits := h.buildMessageHits(ctx, window, SearchMessagesReq{
+		ChannelType: req.ChannelType,
+		ChannelID:   req.ChannelID,
+	}, loginUID)
+
+	result := splitAroundWindow(hits, len(beforeHits), len(afterHits), hasMoreBefore, hasMoreAfter)
+
+	recordAudit(c, "search_around", req.ChannelType, req.ChannelID, "", len(hits))
+	c.Response(result)
+}
+
+// fetchAnchor looks up the single anchor doc by (channelId, messageId), applies
+// the same Space scope as the window, and runs filterVisible on it. Returns
+// (nil, nil) — the "not visible / not found" signal — when the doc is missing,
+// out of Space, or filtered out; (hit, nil) when the anchor is visible.
+//
+// The lookup applies the SAME structural negations the window query uses
+// (revoked + cmd exclusion) so the anchor is held to the exact visibility
+// contract of the stream it anchors: a command message (payload.type=99) is
+// never a valid anchor, mirroring buildAroundDSL's MustNot(cmd). filterVisible
+// then layers the MySQL-resident gates (revoke/delete/offset/visibles) on top.
+func (h *Handler) fetchAnchor(ctx context.Context, client *elastic.Client, req SearchAroundReq, normID, spaceID, loginUID string, anchorID int64) (*elastic.SearchHit, error) {
+	b := buildAnchorDSL(req, normID, spaceID, anchorID)
+
+	svc := client.Search().
+		Index(h.cfg.OSReadAlias).
+		Routing(normID).
+		Query(b).
+		Size(1).
+		TrackTotalHits(false)
+	svc = applySort(svc, "time_asc")
+	res, err := svc.Do(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil || res.Hits == nil || len(res.Hits.Hits) == 0 {
+		return nil, nil
+	}
+	hit := res.Hits.Hits[0]
+
+	ref, ok := projectDocRef(req.ChannelID)(hit)
+	if !ok {
+		return nil, nil
+	}
+	keep, err := h.filterVisible(ctx, loginUID, req.ChannelID, []msgRef{ref})
+	if err != nil {
+		return nil, err
+	}
+	if _, visible := keep[ref.MessageID]; !visible {
+		return nil, nil
+	}
+	return hit, nil
+}
+
+// aroundDirection fetches one side of the window. reversed=false walks newer
+// (time_asc), reversed=true walks older (time_desc). Both start at the anchor's
+// sort tuple via search_after and reuse paginateWithFilter's oversample-补页
+// loop so post-filter losses still fill the page. The returned hits are in the
+// query's own sort order (caller re-reverses the `before` slice).
+func (h *Handler) aroundDirection(ctx context.Context, client *elastic.Client, req SearchAroundReq, normID, spaceID, loginUID string, pageSize int, anchorSort []any, reversed bool) ([]*elastic.SearchHit, bool, error) {
+	dsl := buildAroundDSL(req, normID, spaceID)
+	sortMode := "time_asc"
+	if reversed {
+		sortMode = "time_desc"
+	}
+	osQuery := func(searchAfter []any, size int) ([]*elastic.SearchHit, error) {
+		svc := client.Search().
+			Index(h.cfg.OSReadAlias).
+			Routing(normID).
+			Query(dsl).
+			Size(size).
+			TrackTotalHits(false)
+		svc = applySort(svc, sortMode)
+		if len(searchAfter) > 0 {
+			svc = svc.SearchAfter(searchAfter...)
+		}
+		res, qerr := svc.Do(ctx)
+		if qerr != nil {
+			return nil, qerr
+		}
+		if res == nil || res.Hits == nil {
+			return nil, nil
+		}
+		return res.Hits.Hits, nil
+	}
+	hits, hasMore, _, err := h.paginateWithFilterDepth(
+		ctx, loginUID, req.ChannelID, pageSize, 0, anchorSort, false, osQuery, projectDocRef(req.ChannelID),
+	)
+	return hits, hasMore, err
+}
+
+// buildAnchorDSL builds the single-doc anchor lookup. It applies the same
+// structural visibility negations as the window (revoked + cmd exclusion) plus
+// the Space scope, so the anchor is held to the exact contract of the stream it
+// anchors — a command (payload.type=99) or revoked doc can never be a valid
+// anchor, mirroring buildAroundDSL. MySQL-resident gates are layered on top by
+// filterVisible in fetchAnchor.
+func buildAnchorDSL(req SearchAroundReq, normChannelID, spaceID string, anchorID int64) *elastic.BoolQuery {
+	b := elastic.NewBoolQuery()
+	b.Filter(elastic.NewTermQuery("channelId", normChannelID))
+	b.Filter(elastic.NewTermQuery("messageId", anchorID))
+	applySpaceIDScope(b, req.ChannelType, spaceID)
+	b.MustNot(elastic.NewTermQuery("revoked", true))
+	b.MustNot(elastic.NewTermQuery("payload.type", payloadTypeCmd))
+	return b
+}
+
+// buildAroundDSL is the window query (no keyword, no payload.type filter): the
+// full visible message stream of the channel, scoped to Space for p2p, with the
+// standard revoked/cmd negations. The anchor itself is excluded so it is not
+// duplicated into either wing.
+func buildAroundDSL(req SearchAroundReq, normChannelID, spaceID string) elastic.Query {
+	b := elastic.NewBoolQuery()
+	applyChannelAndRevoked(b, normChannelID)
+	applySpaceIDScope(b, req.ChannelType, spaceID)
+	addCommonFilters(b, req.Filters)
+	b.MustNot(elastic.NewTermQuery("payload.type", payloadTypeCmd))
+	return b
+}
+
+// splitAroundWindow re-slices the joined window (built in before+anchor+after
+// order) back into the AroundResult shape.
+func splitAroundWindow(hits []MessageHit, beforeN, afterN int, hasMoreBefore, hasMoreAfter bool) AroundResult {
+	res := AroundResult{
+		Before:        []MessageHit{},
+		After:         []MessageHit{},
+		HasMoreBefore: hasMoreBefore,
+		HasMoreAfter:  hasMoreAfter,
+	}
+	// buildMessageHits may drop unparseable hits, so clamp the indices to the
+	// surviving slice rather than trusting beforeN/afterN blindly.
+	if beforeN > len(hits) {
+		beforeN = len(hits)
+	}
+	res.Before = append(res.Before, hits[:beforeN]...)
+	rest := hits[beforeN:]
+	if len(rest) == 0 {
+		return res
+	}
+	res.Anchor = rest[0]
+	res.After = append(res.After, rest[1:]...)
+	return res
+}
+
+// reverseHits reverses a hit slice in place-safe fashion (returns a new order)
+// so a time_desc `before` wing can be presented oldest-first.
+func reverseHits(in []*elastic.SearchHit) []*elastic.SearchHit {
+	out := make([]*elastic.SearchHit, len(in))
+	for i := range in {
+		out[len(in)-1-i] = in[i]
+	}
+	return out
+}
+
+// respondAroundErr maps a window-fetch error to the right response.
+func (h *Handler) respondAroundErr(c *wkhttp.Context, err error, side string) {
+	if responder := classifyOSError(err); responder != nil {
+		h.Warn("OS around window fetch failed", zap.String("side", side), zap.Error(err))
+		responder(c)
+		return
+	}
+	h.Error("messages_search: around window visibility filter failed", zap.String("side", side), zap.Error(err))
+	respondInternal(c)
+}

--- a/modules/messages_search/search_around_test.go
+++ b/modules/messages_search/search_around_test.go
@@ -1,0 +1,170 @@
+package messages_search
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/gin-gonic/gin"
+	"github.com/Mininglamp-OSS/octo-server/pkg/searchbackend"
+	"github.com/olivere/elastic"
+)
+
+func aroundHitWithID(id int64) *elastic.SearchHit {
+	body, _ := json.Marshal(map[string]any{
+		"messageId": id,
+		"timestamp": int64(1717000000 + id),
+		"from":      "u1",
+	})
+	src := json.RawMessage(body)
+	return &elastic.SearchHit{Source: &src, Sort: []any{float64(1717000000 + id), float64(id)}}
+}
+
+// reverseHits must reverse order without aliasing the input.
+func TestReverseHits(t *testing.T) {
+	in := []*elastic.SearchHit{aroundHitWithID(1), aroundHitWithID(2), aroundHitWithID(3)}
+	out := reverseHits(in)
+	if len(out) != 3 {
+		t.Fatalf("len = %d", len(out))
+	}
+	if lastHitMessageID(out[0]) != 3 || lastHitMessageID(out[2]) != 1 {
+		t.Fatalf("reverse order wrong: %d..%d", lastHitMessageID(out[0]), lastHitMessageID(out[2]))
+	}
+	// input untouched
+	if lastHitMessageID(in[0]) != 1 {
+		t.Fatalf("reverseHits mutated input")
+	}
+}
+
+// V8-a window assembly: before (oldest-first) + anchor + after (oldest-first)
+// is sliced back into the AroundResult shape with correct anchor placement.
+func TestSplitAroundWindow(t *testing.T) {
+	h := &Handler{cfg: SearchConfig{}}
+	mk := func(id int64) MessageHit { return h.singleMessageHit(Doc{MessageID: id, From: "u1"}, "C1", nil) }
+	hits := []MessageHit{mk(1), mk(2), mk(3), mk(4), mk(5)} // before=[1,2], anchor=3, after=[4,5]
+	res := splitAroundWindow(hits, 2, 2, true, false)
+	if len(res.Before) != 2 || res.Before[0].MessageID != "1" || res.Before[1].MessageID != "2" {
+		t.Fatalf("before wing wrong: %+v", res.Before)
+	}
+	if res.Anchor.MessageID != "3" {
+		t.Fatalf("anchor wrong: %s", res.Anchor.MessageID)
+	}
+	if len(res.After) != 2 || res.After[0].MessageID != "4" || res.After[1].MessageID != "5" {
+		t.Fatalf("after wing wrong: %+v", res.After)
+	}
+	if !res.HasMoreBefore || res.HasMoreAfter {
+		t.Fatalf("has_more flags not propagated: %+v/%+v", res.HasMoreBefore, res.HasMoreAfter)
+	}
+}
+
+// When the before wing is empty the anchor is the first element.
+func TestSplitAroundWindow_NoBefore(t *testing.T) {
+	h := &Handler{cfg: SearchConfig{}}
+	mk := func(id int64) MessageHit { return h.singleMessageHit(Doc{MessageID: id}, "C1", nil) }
+	hits := []MessageHit{mk(3), mk(4)} // anchor=3, after=[4]
+	res := splitAroundWindow(hits, 0, 1, false, false)
+	if len(res.Before) != 0 {
+		t.Fatalf("before should be empty")
+	}
+	if res.Anchor.MessageID != "3" {
+		t.Fatalf("anchor wrong: %s", res.Anchor.MessageID)
+	}
+	if len(res.After) != 1 || res.After[0].MessageID != "4" {
+		t.Fatalf("after wrong: %+v", res.After)
+	}
+}
+
+// buildAroundDSL must carry the spaceId term for p2p (so a cross-Space window
+// can't be assembled) and exclude cmd messages; it must NOT carry a keyword.
+func TestBuildAroundDSL_P2PSpaceScoped(t *testing.T) {
+	req := SearchAroundReq{ChannelType: channelTypePerson, ChannelID: "peer"}
+	body := asJSONString(t, buildAroundDSL(req, "fake-cid", "spaceX").(interface {
+		Source() (any, error)
+	}))
+	if !strings.Contains(body, `"spaceId":"spaceX"`) {
+		t.Fatalf("p2p around DSL must filter by spaceId, got:\n%s", body)
+	}
+	if !strings.Contains(body, "channelId") {
+		t.Fatalf("around DSL must filter by channelId, got:\n%s", body)
+	}
+}
+
+func TestBuildAroundDSL_GroupNoSpaceTerm(t *testing.T) {
+	req := SearchAroundReq{ChannelType: channelTypeGroup, ChannelID: "G1"}
+	body := asJSONString(t, buildAroundDSL(req, "G1", "spaceX").(interface {
+		Source() (any, error)
+	}))
+	if strings.Contains(body, "spaceId") {
+		t.Fatalf("group around DSL must NOT carry spaceId term, got:\n%s", body)
+	}
+}
+
+func newAroundCtx(t *testing.T, bodyJSON string) (*wkhttp.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest("POST", "/v1/messages/_search_around", strings.NewReader(bodyJSON))
+	gc.Request.Header.Set("Content-Type", "application/json")
+	gc.Set("uid", "me")
+	return &wkhttp.Context{Context: gc}, rec
+}
+
+// V8-b adjacent — a non-numeric / non-positive anchor_message_id is rejected
+// with VALIDATION_ERROR before any access check or OS round-trip.
+func TestSearchAround_InvalidAnchorRejected(t *testing.T) {
+	h := &Handler{Log: log.NewTLog("around-test"), cfg: SearchConfig{}, mode: searchbackend.Mode{ESServe: true}}
+	for _, anchor := range []string{"", "abc", "0", "-5"} {
+		c, rec := newAroundCtx(t, `{"channel_type":2,"channel_id":"G1","anchor_message_id":"`+anchor+`"}`)
+		h.searchAround(c)
+		if rec.Code == 200 && !strings.Contains(rec.Body.String(), "error") {
+			t.Fatalf("anchor %q must be rejected, got %d %q", anchor, rec.Code, rec.Body.String())
+		}
+		if rec.Body.Len() == 0 {
+			t.Fatalf("anchor %q rejection must render an envelope", anchor)
+		}
+	}
+}
+
+// channel_type outside the whitelist is rejected (None/CS/etc not openable).
+func TestSearchAround_BadChannelTypeRejected(t *testing.T) {
+	h := &Handler{Log: log.NewTLog("around-test"), cfg: SearchConfig{}, mode: searchbackend.Mode{ESServe: true}}
+	c, rec := newAroundCtx(t, `{"channel_type":3,"channel_id":"X","anchor_message_id":"42"}`)
+	h.searchAround(c)
+	if rec.Body.Len() == 0 {
+		t.Fatalf("bad channel_type must render an error envelope")
+	}
+}
+
+// V8-b — the anchor lookup must exclude command messages and revoked docs,
+// exactly like the window DSL, so a caller cannot anchor on a payload.type=99
+// command (or a revoked doc) the surrounding stream would never show.
+func TestBuildAnchorDSL_ExcludesCmdAndRevoked(t *testing.T) {
+	req := SearchAroundReq{ChannelType: channelTypeGroup, ChannelID: "G1"}
+	body := asJSONString(t, buildAnchorDSL(req, "G1", "", 42))
+	if !strings.Contains(body, `"messageId":42`) {
+		t.Fatalf("anchor DSL must pin the messageId, got:\n%s", body)
+	}
+	if !strings.Contains(body, "must_not") {
+		t.Fatalf("anchor DSL must carry must_not exclusions, got:\n%s", body)
+	}
+	if !strings.Contains(body, `"payload.type":99`) {
+		t.Fatalf("anchor DSL must exclude command (payload.type=99), got:\n%s", body)
+	}
+	if !strings.Contains(body, `"revoked":true`) {
+		t.Fatalf("anchor DSL must exclude revoked docs, got:\n%s", body)
+	}
+}
+
+// p2p anchor lookup carries the spaceId term so a cross-Space anchor cannot be
+// located (returns 0 hits → NOT_FOUND).
+func TestBuildAnchorDSL_P2PSpaceScoped(t *testing.T) {
+	req := SearchAroundReq{ChannelType: channelTypePerson, ChannelID: "peer"}
+	body := asJSONString(t, buildAnchorDSL(req, "fake-cid", "spaceX", 7))
+	if !strings.Contains(body, `"spaceId":"spaceX"`) {
+		t.Fatalf("p2p anchor DSL must be Space-scoped, got:\n%s", body)
+	}
+}

--- a/modules/messages_search/search_files.go
+++ b/modules/messages_search/search_files.go
@@ -80,6 +80,10 @@ func (h *Handler) searchFiles(c *wkhttp.Context) {
 		respondValidation(c, "cursor", "malformed")
 		return
 	}
+	priorDepth, ok := h.resolveCursorDepth(c, req.Cursor, pageSize)
+	if !ok {
+		return
+	}
 
 	ctx, cancel := context.WithTimeout(c.Request.Context(), h.cfg.Timeout)
 	defer cancel()
@@ -105,8 +109,8 @@ func (h *Handler) searchFiles(c *wkhttp.Context) {
 		return res.Hits.Hits, nil
 	}
 
-	filtered, hasMore, nextCursor, err := h.paginateWithFilter(
-		ctx, loginUID, req.ChannelID, pageSize, initialAfter, isRelevance, osQuery, projectDocRef(req.ChannelID),
+	filtered, hasMore, nextCursor, err := h.paginateWithFilterDepth(
+		ctx, loginUID, req.ChannelID, pageSize, priorDepth, initialAfter, isRelevance, osQuery, projectDocRef(req.ChannelID),
 	)
 	if err != nil {
 		if responder := classifyOSError(err); responder != nil {

--- a/modules/messages_search/search_media.go
+++ b/modules/messages_search/search_media.go
@@ -79,6 +79,10 @@ func (h *Handler) searchMedia(c *wkhttp.Context) {
 		respondValidation(c, "cursor", "malformed")
 		return
 	}
+	priorDepth, ok := h.resolveCursorDepth(c, req.Cursor, pageSize)
+	if !ok {
+		return
+	}
 
 	ctx, cancel := context.WithTimeout(c.Request.Context(), h.cfg.Timeout)
 	defer cancel()
@@ -104,8 +108,8 @@ func (h *Handler) searchMedia(c *wkhttp.Context) {
 		return res.Hits.Hits, nil
 	}
 
-	filtered, hasMore, nextCursor, err := h.paginateWithFilter(
-		ctx, loginUID, req.ChannelID, pageSize, initialAfter, isRelevance, osQuery, projectDocRef(req.ChannelID),
+	filtered, hasMore, nextCursor, err := h.paginateWithFilterDepth(
+		ctx, loginUID, req.ChannelID, pageSize, priorDepth, initialAfter, isRelevance, osQuery, projectDocRef(req.ChannelID),
 	)
 	if err != nil {
 		if responder := classifyOSError(err); responder != nil {

--- a/modules/messages_search/search_messages.go
+++ b/modules/messages_search/search_messages.go
@@ -72,6 +72,10 @@ func (h *Handler) searchMessages(c *wkhttp.Context) {
 		respondValidation(c, "cursor", "malformed")
 		return
 	}
+	priorDepth, ok := h.resolveCursorDepth(c, req.Cursor, pageSize)
+	if !ok {
+		return
+	}
 
 	ctx, cancel := context.WithTimeout(c.Request.Context(), h.cfg.Timeout)
 	defer cancel()
@@ -98,8 +102,8 @@ func (h *Handler) searchMessages(c *wkhttp.Context) {
 		return res.Hits.Hits, nil
 	}
 
-	filtered, hasMore, nextCursor, err := h.paginateWithFilter(
-		ctx, loginUID, req.ChannelID, pageSize, initialAfter, isRelevance, osQuery, projectDocRef(req.ChannelID),
+	filtered, hasMore, nextCursor, err := h.paginateWithFilterDepth(
+		ctx, loginUID, req.ChannelID, pageSize, priorDepth, initialAfter, isRelevance, osQuery, projectDocRef(req.ChannelID),
 	)
 	if err != nil {
 		if responder := classifyOSError(err); responder != nil {

--- a/modules/messages_search/swagger/api.yaml
+++ b/modules/messages_search/swagger/api.yaml
@@ -235,7 +235,99 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
+  /messages/_search_around:
+    post:
+      tags:
+        - "messages_search"
+      operationId: "message.search_around"
+      summary: "Locate the context window around an anchor message"
+      description: "Returns the chronological window (older + anchor + newer) around a known anchor message in a single channel. The anchor is pre-validated through the same channel-access, Space-scope, and visibility gates as a normal read: a revoked / deleted / cross-Space / not-found anchor returns 404 and no context is fetched."
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: "#/definitions/SearchAroundReq"
+      responses:
+        "200":
+          description: "OK"
+          schema:
+            $ref: "#/definitions/AroundResult"
+        "400":
+          description: "Validation error"
+          schema:
+            $ref: "#/definitions/Error"
+        "401":
+          description: "Unauthenticated"
+          schema:
+            $ref: "#/definitions/Error"
+        "403":
+          description: "Forbidden"
+          schema:
+            $ref: "#/definitions/Error"
+        "404":
+          description: "Anchor / channel not visible (also covers cross-Space and revoked anchor)"
+          schema:
+            $ref: "#/definitions/Error"
+        "429":
+          description: "Rate limited"
+          schema:
+            $ref: "#/definitions/Error"
+        "500":
+          description: "Internal error"
+          schema:
+            $ref: "#/definitions/Error"
+        "503":
+          description: "Search backend unavailable / disabled"
+          schema:
+            $ref: "#/definitions/Error"
+
 definitions:
+  SearchAroundReq:
+    type: object
+    required:
+      - channel_type
+      - channel_id
+      - anchor_message_id
+    properties:
+      channel_type:
+        type: integer
+        description: "1=p2p, 2=group, 5=thread."
+      channel_id:
+        type: string
+      anchor_message_id:
+        type: string
+        description: "Decimal-string snowflake id of the anchor message."
+      filters:
+        $ref: "#/definitions/SearchFilters"
+      page_size:
+        type: integer
+        description: "Max hits per wing (before / after), 1-100, default 20."
+  AroundResult:
+    type: object
+    properties:
+      before:
+        type: array
+        description: "Messages older than the anchor, oldest-first."
+        items:
+          $ref: "#/definitions/MessageHit"
+      anchor:
+        $ref: "#/definitions/MessageHit"
+      after:
+        type: array
+        description: "Messages newer than the anchor, oldest-first."
+        items:
+          $ref: "#/definitions/MessageHit"
+      has_more_before:
+        type: boolean
+      has_more_after:
+        type: boolean
   SearchFilters:
     type: object
     properties:

--- a/modules/messages_search/validate.go
+++ b/modules/messages_search/validate.go
@@ -68,6 +68,19 @@ type SearchFilesReq struct {
 // shape as _search; keyword required.
 type SearchAllReq = SearchMessagesReq
 
+// SearchAroundReq is the request body for POST /v1/messages/_search_around.
+// It locates a known anchor message and returns the chronological window
+// around it (older + anchor + newer). There is no keyword, sort, or cursor:
+// the window is anchored on a specific message_id and always returned in
+// time_asc order so the client can render a contiguous conversation slice.
+type SearchAroundReq struct {
+	ChannelType     uint8         `json:"channel_type"`
+	ChannelID       string        `json:"channel_id"`
+	AnchorMessageID string        `json:"anchor_message_id"`
+	Filters         SearchFilters `json:"filters,omitempty"`
+	PageSize        int           `json:"page_size,omitempty"`
+}
+
 // validateBase covers the fields shared across all four endpoints:
 // channel_type/id form, sender_ids count, time window order, page_size, sort
 // enum, cursor signature.

--- a/modules/messages_search/validate_test.go
+++ b/modules/messages_search/validate_test.go
@@ -1,0 +1,106 @@
+package messages_search
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/gin-gonic/gin"
+)
+
+// newValidateCtx builds a minimal wkhttp.Context whose writes land in a
+// recorder so validateBase's error envelope can be inspected.
+func newValidateCtx(t *testing.T) (*wkhttp.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest("POST", "/v1/messages/_search", nil)
+	return &wkhttp.Context{Context: gc}, rec
+}
+
+// V7 (page-size half) — page_size above the 100 ceiling must be rejected with
+// VALIDATION_ERROR rather than silently clamped (a silent clamp would let a
+// caller think they paged 500 and miss results). Mirrors the plan's
+// "page-size 上限 100" gate.
+func TestValidateBase_PageSizeOverMaxRejected(t *testing.T) {
+	c, rec := newValidateCtx(t)
+	_, ok := validateBase(c, SearchConfig{}, channelTypeGroup, "G1", "", "",
+		SearchFilters{}, maxPageSize+1, true)
+	if ok {
+		t.Fatalf("page_size %d (> %d) must be rejected", maxPageSize+1, maxPageSize)
+	}
+	if rec.Body.Len() == 0 {
+		t.Fatalf("rejected page_size must render a VALIDATION_ERROR envelope")
+	}
+}
+
+func TestValidateBase_PageSizeZeroDefaults(t *testing.T) {
+	c, _ := newValidateCtx(t)
+	page, ok := validateBase(c, SearchConfig{}, channelTypeGroup, "G1", "", "",
+		SearchFilters{}, 0, true)
+	if !ok {
+		t.Fatalf("page_size 0 must default, not reject")
+	}
+	if page != defaultPage {
+		t.Fatalf("page_size 0 must default to %d, got %d", defaultPage, page)
+	}
+}
+
+func TestValidateBase_PageSizeAtMaxAccepted(t *testing.T) {
+	c, _ := newValidateCtx(t)
+	page, ok := validateBase(c, SearchConfig{}, channelTypeGroup, "G1", "", "",
+		SearchFilters{}, maxPageSize, true)
+	if !ok {
+		t.Fatalf("page_size at the %d ceiling must be accepted", maxPageSize)
+	}
+	if page != maxPageSize {
+		t.Fatalf("page_size %d must pass through unchanged, got %d", maxPageSize, page)
+	}
+}
+
+func TestValidateBase_PageSizeNegativeRejected(t *testing.T) {
+	c, rec := newValidateCtx(t)
+	_, ok := validateBase(c, SearchConfig{}, channelTypeGroup, "G1", "", "",
+		SearchFilters{}, -1, true)
+	if ok {
+		t.Fatalf("negative page_size must be rejected")
+	}
+	if rec.Body.Len() == 0 {
+		t.Fatalf("rejected page_size must render an error envelope")
+	}
+}
+
+// V2-adjacent — channel_type outside the {1,2,5} whitelist is rejected before
+// any access check runs (None/CS/Community/Info channels are not openable this
+// phase; the plan says None must be explicitly refused).
+func TestValidateBase_UnknownChannelTypeRejected(t *testing.T) {
+	for _, ct := range []uint8{0, 3, 4, 99} {
+		c, rec := newValidateCtx(t)
+		_, ok := validateBase(c, SearchConfig{}, ct, "X", "", "",
+			SearchFilters{}, 20, true)
+		if ok {
+			t.Fatalf("channel_type %d must be rejected", ct)
+		}
+		if rec.Body.Len() == 0 {
+			t.Fatalf("channel_type %d rejection must render an error envelope", ct)
+		}
+	}
+}
+
+// A malformed cursor must surface VALIDATION_ERROR(field=cursor), never be
+// silently treated as a first-page request (which would reset pagination and
+// leak the first page on a tampered cursor).
+func TestValidateBase_MalformedCursorRejected(t *testing.T) {
+	c, rec := newValidateCtx(t)
+	_, ok := validateBase(c, SearchConfig{}, channelTypeGroup, "G1", "", "not-a-valid-cursor!!",
+		SearchFilters{}, 20, true)
+	if ok {
+		t.Fatalf("malformed cursor must be rejected")
+	}
+	if !strings.Contains(rec.Body.String(), "cursor") &&
+		!strings.Contains(strings.ToLower(rec.Body.String()), "invalid") {
+		t.Fatalf("cursor rejection must render a validation envelope, got %q", rec.Body.String())
+	}
+}

--- a/modules/messages_search/vgate_matrix_test.go
+++ b/modules/messages_search/vgate_matrix_test.go
@@ -1,0 +1,106 @@
+package messages_search
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// This file pins the YUJ-4667 (阶段 8) verification-gate matrix (V1–V10) to
+// concrete, machine-checkable Go assertions so a future change that silently
+// regresses a gate fails CI. Each test names the gate it backs. Gates whose
+// truth depends on the octo-search-indexer writing new doc fields (spaceId,
+// visibles) are written but SKIPPED with an explicit reason, per the plan's
+// "write-but-red" instruction — they flip to live once 分叉 B (索引契约收敛)
+// lands and the indexer emits those fields.
+
+// --- V1(a): cross-space p2p returns nothing (mechanism already covered by
+// space_filter_test.go::TestApplySpaceIDScope_P2PEmitsTermFilter — the DSL
+// carries the spaceId term so a space-A caller cannot match a space-B doc). ---
+
+// --- V1(b): same-space p2p DOES return hits. This is the false-positive guard
+// (codex P1): without it, "0 hits" could mean "isolation works" OR "indexer
+// never wrote spaceId so nothing matches". It cannot be asserted end-to-end
+// until the indexer writes spaceId on p2p docs (分叉 B). ---
+func TestVGate_V1b_SameSpaceReturnsHits(t *testing.T) {
+	t.Skip("V1(b) blocked on 分叉 B: octo-search-indexer must write doc.spaceId " +
+		"on p2p messages before same-space recall can be asserted end-to-end. " +
+		"Until then the spaceId term filter matches nothing on legacy docs and " +
+		"this gate would be red for the wrong reason. See YUJ-4662 §1.4 / STOP #6.")
+}
+
+// --- V3b: visibles whitelist. The unit-level gate already passes
+// (visibility_test.go::TestFilterVisible_VisiblesWhitelist_NotInListDropped),
+// but the END-TO-END gate (group system message visible only to admins is not
+// searchable by a normal member) is fail-OPEN until the indexer writes
+// doc.visibles — an empty visibles array means "no gate" (CONSTRAINTS D24). ---
+func TestVGate_V3b_VisiblesWhitelistEndToEnd(t *testing.T) {
+	t.Skip("V3b blocked on 分叉 B: octo-search-indexer must write doc.visibles " +
+		"on group system messages. Until then visibles is empty => fail-OPEN " +
+		"(a normal member could search out admin-only system messages). The " +
+		"post-filter gate itself is unit-tested in visibility_test.go; this is " +
+		"the end-to-end assertion that depends on the indexer. See YUJ-4662 §1.2 / STOP #6.")
+}
+
+// --- V10: response projection does not leak invisible content. A MessageHit
+// built from a Doc carrying revoked=true / visibles / raw payload internals
+// must not serialise any of those sensitive fields onto the wire. The hit set
+// is already visibility-filtered upstream; this guards the *projection* so a
+// future field addition can't accidentally ship revoked/visibles/deleted
+// metadata to the client. ---
+func TestVGate_V10_MessageHitProjectionNoLeak(t *testing.T) {
+	h := &Handler{cfg: SearchConfig{}}
+	doc := Doc{
+		MessageID:   42,
+		MessageSeq:  7,
+		From:        "u1",
+		ChannelID:   "C1",
+		ChannelType: 2,
+		Timestamp:   1717000000,
+		Revoked:     true,
+		SpaceID:     "secret-space",
+		Visibles:    []string{"admin-only"},
+		Payload:     &Payload{Text: &TextPayload{Content: "hidden body"}},
+	}
+	hit := h.singleMessageHit(doc, "C1", nil)
+	b, err := json.Marshal(hit)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	wire := string(b)
+	for _, leaked := range []string{
+		"revoked", "visibles", "admin-only", "spaceId", "secret-space",
+		"is_deleted", "isDeleted",
+	} {
+		if strings.Contains(wire, leaked) {
+			t.Fatalf("V10 leak: MessageHit wire form must not contain %q; got %s", leaked, wire)
+		}
+	}
+}
+
+// V10 sibling for _search_all: the result envelope must not leak the same
+// internal fields through its nested Message/File projection.
+func TestVGate_V10_SearchAllHitProjectionNoLeak(t *testing.T) {
+	h := &Handler{cfg: SearchConfig{}}
+	doc := Doc{
+		MessageID: 99,
+		From:      "u1",
+		ChannelID: "C1",
+		Timestamp: 1717000000,
+		Revoked:   true,
+		SpaceID:   "secret-space",
+		Visibles:  []string{"admin-only"},
+		Payload:   &Payload{Text: &TextPayload{Content: "hidden body"}},
+	}
+	entry := h.singleSearchAllHit(doc, SearchAllReq{ChannelID: "C1"}, nil)
+	b, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	wire := string(b)
+	for _, leaked := range []string{"revoked", "visibles", "admin-only", "spaceId", "secret-space"} {
+		if strings.Contains(wire, leaked) {
+			t.Fatalf("V10 leak: SearchAllHit wire form must not contain %q; got %s", leaked, wire)
+		}
+	}
+}

--- a/modules/messages_search/visibility.go
+++ b/modules/messages_search/visibility.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/message"
 	"github.com/olivere/elastic"
 )
@@ -272,6 +273,25 @@ func (h *Handler) paginateWithFilter(
 	osQuery osQueryFn,
 	project projectFn,
 ) ([]*elastic.SearchHit, bool, string, error) {
+	return h.paginateWithFilterDepth(ctx, loginUID, channelID, pageSize, 0, initialSearchAfter, isRelevanceSort, osQuery, project)
+}
+
+// paginateWithFilterDepth is paginateWithFilter plus the cumulative result
+// depth already served before this page (decoded from the request cursor). The
+// returned next_cursor encodes priorDepth + len(returned page) so the
+// max-pagination-depth cap (enforced in the handler via decodeCursorWithDepth)
+// is measured on the cumulative count, not page_size — shrinking/growing
+// page_size between requests cannot walk past the cap.
+func (h *Handler) paginateWithFilterDepth(
+	ctx context.Context,
+	loginUID, channelID string,
+	pageSize int,
+	priorDepth int64,
+	initialSearchAfter []any,
+	isRelevanceSort bool,
+	osQuery osQueryFn,
+	project projectFn,
+) ([]*elastic.SearchHit, bool, string, error) {
 	collected := make([]*elastic.SearchHit, 0, pageSize)
 	searchAfter := initialSearchAfter
 	fetchSize := pageSize * oversampleMultiplier
@@ -364,10 +384,61 @@ func (h *Handler) paginateWithFilter(
 			// cleanly. Caller can retry the request to get fresher state.
 			hasMore = false
 		} else {
-			nextCursor = encodeCursor(h.cfg, ts, msgID, score)
+			// Carry the cumulative depth so the next request's cap check sees
+			// the running total, independent of the page_size used to get here.
+			nextDepth := priorDepth + int64(len(collected))
+			nextCursor = encodeCursorWithDepth(h.cfg, ts, msgID, score, nextDepth)
 		}
 	}
 	return collected, hasMore, nextCursor, nil
+}
+
+// resolveCursorDepth decodes the cumulative result depth carried in the
+// request cursor and enforces the max-pagination-depth cap. The bool return is
+// "continue": false means a DEPTH_EXCEEDED response was already written and the
+// handler must abort. An empty cursor (first page) has depth 0.
+//
+// The cap is checked against the cumulative depth INCLUDING the page about to
+// be served (priorDepth + pageSize), NOT page_size alone, so a caller sitting
+// just under the cap cannot pick a larger page_size to read past it: a request
+// whose window would cross maxPaginationDepth is rejected before any OS
+// round-trip.
+//
+// Integrity note (codex P2): the depth is HMAC-signed into the cursor, so a
+// well-behaved deployment (OCTO_SEARCH_CURSOR_HMAC set) cannot have its depth
+// forged back to 0. When the secret is UNSET the cursor falls back to the
+// published default key (api.go New() logs a loud WARN at startup), which makes
+// BOTH the depth AND the search_after position forgeable — but forging depth
+// buys nothing an attacker doesn't already get by forging search_after
+// directly: every page still passes the per-request channel-access +
+// filterVisible gates and the bounded oversample loop (loopBudget rounds), so
+// the depth cap is a resource-protection limit, not a security boundary. The
+// correct hardening is to require the per-deployment secret in production
+// (already surfaced as a startup WARN); we deliberately do not reject
+// depth-carrying cursors under the default key here because that would break
+// the existing time_*/relevance cursors that share the same signing path.
+func (h *Handler) resolveCursorDepth(c *wkhttp.Context, cursor string, pageSize int) (int64, bool) {
+	var depth int64
+	if cursor != "" {
+		_, _, _, d, err := decodeCursorWithDepth(h.cfg, cursor)
+		if err != nil {
+			// Mirrors decodeCursorAsSearchAfter's contract: malformed cursors
+			// map to VALIDATION_ERROR(field=cursor) upstream. Callers already
+			// validate the cursor via validateBase, so this is defense-in-depth.
+			respondValidation(c, "cursor", "malformed")
+			return 0, false
+		}
+		depth = d
+	}
+	// Reject when this request's window would carry the cumulative depth past
+	// the cap. Using pageSize (not the post-filter count) keeps the check
+	// page_size-driven and pre-OS, so it cannot be bypassed by choosing a
+	// larger page near the boundary.
+	if depth+int64(pageSize) > maxPaginationDepth {
+		respondDepthExceeded(c)
+		return 0, false
+	}
+	return depth, true
 }
 
 // decodeCursorAsSearchAfter rebuilds the OpenSearch SearchAfter tuple from

--- a/modules/search/api.go
+++ b/modules/search/api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/log"
+	"github.com/Mininglamp-OSS/octo-server/pkg/searchbackend"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"github.com/Mininglamp-OSS/octo-server/pkg/util"
 	"go.uber.org/zap"
@@ -62,6 +63,18 @@ func buildMessageSearchQuery(keyword string) (map[string]interface{}, []string) 
 }
 
 func (s *Search) global(c *wkhttp.Context) {
+	// search.backend 三态收口（YUJ-4667 步骤 2 / codex P1）。
+	//   - disabled：全局搜索表面与新 _search* / 旧 /v1/message/search 一致返回
+	//     SEARCH_DISABLED，不做 500/panic/部分结果。
+	//   - es：消息检索权威读路径是 OpenSearch（modules/messages_search）。本端点
+	//     的**消息**部分走旧 WuKongIM→Zinc，es 下绝不再跑（否则等于让第三个
+	//     Zinc 消息检索表面绕过 ES 的 space/可见性过滤）；好友/群（MySQL）不受影响。
+	//   - zinc：维持旧行为（含 Zinc 消息检索，迁移/回滚过渡态）。
+	mode := searchbackend.Resolve(s.ctx.GetConfig().ZincSearch.SearchOn)
+	if !mode.SearchEnabled() {
+		httperr.ResponseErrorL(c, errcode.ErrMessagesSearchDisabled, nil, nil)
+		return
+	}
 	loginUID := c.GetLoginUID()
 	var req struct {
 		OnlyMessage int    `json:"only_message"` // 只加载消息
@@ -86,24 +99,29 @@ func (s *Search) global(c *wkhttp.Context) {
 	}
 	payload, highlights := buildMessageSearchQuery(req.Keyword)
 
-	// 查询消息
-	msgResp, err := s.ctx.IMSearchUserMessages(&config.SearchUserMessageReq{
-		UID:          loginUID,
-		Payload:      payload,
-		PayloadTypes: req.ContentType,
-		Limit:        req.Limit,
-		Page:         req.Page,
-		FromUID:      req.FromUID,
-		ChannelID:    req.ChannelID,
-		ChannelType:  req.ChannelType,
-		Topic:        req.Topic,
-		StartTime:    req.StartTime,
-		EndTime:      req.EndTime,
-		Highlights:   highlights,
-	})
-	if err != nil {
-		s.Warn("查询悟空IM消息错误（不影响好友和群搜索）", zap.Error(err))
-		msgResp = nil
+	// 查询消息（仅在 backend=zinc 时走旧 Zinc 消息检索；es/默认-es 下跳过，
+	// 让消息检索归口到 OpenSearch _search*，本端点只回好友/群结果）。
+	var msgResp *config.SearchUserMessageResp
+	if mode.LegacyZinc {
+		var err error
+		msgResp, err = s.ctx.IMSearchUserMessages(&config.SearchUserMessageReq{
+			UID:          loginUID,
+			Payload:      payload,
+			PayloadTypes: req.ContentType,
+			Limit:        req.Limit,
+			Page:         req.Page,
+			FromUID:      req.FromUID,
+			ChannelID:    req.ChannelID,
+			ChannelType:  req.ChannelType,
+			Topic:        req.Topic,
+			StartTime:    req.StartTime,
+			EndTime:      req.EndTime,
+			Highlights:   highlights,
+		})
+		if err != nil {
+			s.Warn("查询悟空IM消息错误（不影响好友和群搜索）", zap.Error(err))
+			msgResp = nil
+		}
 	}
 	channelIds := make([]string, 0)
 	messageIds := make([]string, 0)

--- a/pkg/errcode/messages_search.go
+++ b/pkg/errcode/messages_search.go
@@ -53,4 +53,30 @@ var (
 		DefaultMessage: "Channel or resource not found for search.",
 		SafeDetailKeys: []string{"resource"},
 	})
+
+	// SEARCH_DISABLED — the deployment has OCTO_SEARCH_BACKEND=disabled, so
+	// every search surface (the new _search* endpoints, the legacy
+	// /v1/message/search path, and modules/search global search) refuses
+	// uniformly instead of 500/panic/leaking results. Core IM stays fully
+	// functional; the client uses appconfig.search_enabled to hide the search
+	// box rather than probe this code per request.
+	ErrMessagesSearchDisabled = register(codes.Code{
+		ID:             "err.server.messages_search.disabled",
+		HTTPStatus:     http.StatusServiceUnavailable,
+		DefaultMessage: "Search is not enabled on this deployment.",
+	})
+
+	// DEPTH_EXCEEDED — the caller paged past the maximum cumulative result
+	// depth (aligned with OpenSearch max_result_window=10000). The cap is on
+	// the cumulative number of results already returned (encoded in the
+	// cursor), NOT on the per-request page_size, so shrinking/growing
+	// page_size cannot be used to walk past it. Clients that hit this should
+	// narrow the query (keyword / time window / sender) instead of paging
+	// deeper.
+	ErrMessagesSearchDepthExceeded = register(codes.Code{
+		ID:             "err.server.messages_search.depth_exceeded",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Search pagination depth limit reached; narrow your query.",
+		SafeDetailKeys: []string{"max_depth"},
+	})
 )

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -1145,3 +1145,9 @@ other = "搜索请求过于频繁，请稍后再试。"
 
 ["err.server.messages_search.not_found"]
 other = "未找到对应频道或资源。"
+
+["err.server.messages_search.disabled"]
+other = "当前部署未启用搜索功能。"
+
+["err.server.messages_search.depth_exceeded"]
+other = "搜索翻页已达最大深度上限，请缩小搜索范围。"

--- a/pkg/searchbackend/backend.go
+++ b/pkg/searchbackend/backend.go
@@ -1,0 +1,92 @@
+// Package searchbackend exposes the single, explicit OCTO_SEARCH_BACKEND
+// three-state switch that governs every search surface in octo-server.
+//
+// There are three surfaces that can return message search results:
+//
+//  1. modules/messages_search — POST /v1/messages/_search* (OpenSearch).
+//  2. modules/message         — POST /v1/message/search (legacy WuKongIM→Zinc).
+//  3. modules/search          — POST /v1/search/global (legacy global search,
+//     whose MESSAGE portion is WuKongIM→Zinc; friend/group portions are MySQL).
+//
+// Before this package each surface decided independently whether it was on
+// (the new path always tried OS; the legacy paths keyed off
+// ZincSearch.SearchOn), there was no "all off" state, and an es deployment
+// whose OpenSearch was unreachable had no contract forbidding a silent
+// fall-through to Zinc. This package makes the choice explicit and shared.
+//
+// Two independent surfaces, three explicit declarations + the unset default:
+//
+//	OCTO_SEARCH_BACKEND   _search* (ES)   legacy Zinc message search
+//	──────────────────────────────────────────────────────────────────
+//	es                    on              off   (ES is authoritative)
+//	zinc                  off (rollback)  on    (read from Zinc again)
+//	disabled              off             off   (uniform SEARCH_DISABLED)
+//	(unset / unknown)     on              = ZincSearch.SearchOn  (current behaviour, unchanged)
+//
+// `es` MUST NOT fall through to Zinc: an es deployment whose OpenSearch is down
+// surfaces UPSTREAM_UNAVAILABLE, never a Zinc result. `zinc` is the rollback
+// target (read stale-free from Zinc while OS is repaired). `disabled` turns
+// everything off and the process must still boot with no search backend
+// reachable. There is deliberately NO connectivity auto-detection or automatic
+// degradation: the backend is whatever the operator declared, full stop.
+package searchbackend
+
+import (
+	"os"
+	"strings"
+)
+
+// envKey is the single environment variable that selects the backend.
+const envKey = "OCTO_SEARCH_BACKEND"
+
+// Declared is the raw three-state declaration (plus the unset default), kept
+// for logging / appconfig diagnostics. Resolve folds it into a Mode.
+type Declared string
+
+const (
+	DeclaredES       Declared = "es"
+	DeclaredZinc     Declared = "zinc"
+	DeclaredDisabled Declared = "disabled"
+	DeclaredDefault  Declared = "" // unset / unknown
+)
+
+// Mode is the resolved two-axis search posture. Each surface consults exactly
+// the axis it owns, so the "unset default" case (ES on + legacy following the
+// Zinc toggle) is representable without collapsing two surfaces onto one enum.
+type Mode struct {
+	// ESServe reports whether the OpenSearch _search* endpoints should serve.
+	ESServe bool
+	// LegacyZinc reports whether the legacy WuKongIM/Zinc MESSAGE search path
+	// (/v1/message/search and the message portion of /v1/search/global) should
+	// run.
+	LegacyZinc bool
+	// Declared is the raw declaration this Mode came from (diagnostics only).
+	Declared Declared
+}
+
+// Resolve returns the search Mode selected by OCTO_SEARCH_BACKEND, given the
+// legacy ZincSearch.SearchOn toggle (used only to preserve current behaviour in
+// the unset/default case). Pure and tiny so all surfaces can reuse it without
+// import cycles.
+func Resolve(zincSearchOn bool) Mode {
+	switch Declared(strings.ToLower(strings.TrimSpace(os.Getenv(envKey)))) {
+	case DeclaredES:
+		// ES authoritative; legacy Zinc message search off (no fall-through).
+		return Mode{ESServe: true, LegacyZinc: false, Declared: DeclaredES}
+	case DeclaredZinc:
+		// Rollback: read from Zinc, ES _search* off.
+		return Mode{ESServe: false, LegacyZinc: true, Declared: DeclaredZinc}
+	case DeclaredDisabled:
+		return Mode{ESServe: false, LegacyZinc: false, Declared: DeclaredDisabled}
+	default:
+		// Unset / unknown: preserve the exact pre-switch behaviour — the new
+		// _search* endpoints always queried OS, and the legacy endpoints
+		// followed ZincSearch.SearchOn. Never silently flip search off.
+		return Mode{ESServe: true, LegacyZinc: zincSearchOn, Declared: DeclaredDefault}
+	}
+}
+
+// SearchEnabled reports whether ANY search surface is live (advertised to
+// clients via appconfig.search_enabled). False only when both surfaces are off
+// (the disabled backend).
+func (m Mode) SearchEnabled() bool { return m.ESServe || m.LegacyZinc }

--- a/pkg/searchbackend/backend_test.go
+++ b/pkg/searchbackend/backend_test.go
@@ -1,0 +1,89 @@
+package searchbackend
+
+import (
+	"os"
+	"testing"
+)
+
+func withEnv(t *testing.T, val string, unset bool) {
+	t.Helper()
+	prev, had := os.LookupEnv(envKey)
+	if unset {
+		os.Unsetenv(envKey)
+	} else {
+		os.Setenv(envKey, val)
+	}
+	t.Cleanup(func() {
+		if had {
+			os.Setenv(envKey, prev)
+		} else {
+			os.Unsetenv(envKey)
+		}
+	})
+}
+
+// V5/V6 foundation — explicit declaration, no auto-detect. Each declared value
+// resolves to the right two-axis posture regardless of ZincSearch.SearchOn.
+func TestResolve_ExplicitValues(t *testing.T) {
+	cases := []struct {
+		env        string
+		zincOn     bool
+		wantES     bool
+		wantLegacy bool
+	}{
+		{"es", true, true, false},    // es: ES on, NO Zinc fallthrough
+		{"es", false, true, false},
+		{"ES", false, true, false},   // case-insensitive
+		{" es ", false, true, false}, // trimmed
+		{"zinc", false, false, true}, // rollback: ES off, Zinc on
+		{"zinc", true, false, true},
+		{"disabled", true, false, false},
+		{"disabled", false, false, false},
+	}
+	for _, tc := range cases {
+		withEnv(t, tc.env, false)
+		m := Resolve(tc.zincOn)
+		if m.ESServe != tc.wantES || m.LegacyZinc != tc.wantLegacy {
+			t.Fatalf("Resolve(%q, zinc=%v) = {ES:%v Legacy:%v}, want {ES:%v Legacy:%v}",
+				tc.env, tc.zincOn, m.ESServe, m.LegacyZinc, tc.wantES, tc.wantLegacy)
+		}
+	}
+}
+
+// Default-value semantics (§7-#9 / codex P2): unset MUST preserve current
+// deployment behaviour — the new _search* endpoints keep serving from ES, and
+// the legacy Zinc message path follows ZincSearch.SearchOn. It must NEVER turn
+// the ES endpoints off just because Zinc is on.
+func TestResolve_UnsetPreservesCurrentBehaviour(t *testing.T) {
+	withEnv(t, "", true)
+	if m := Resolve(false); !m.ESServe || m.LegacyZinc {
+		t.Fatalf("unset + zincOff: want {ES:true Legacy:false}, got %+v", m)
+	}
+	withEnv(t, "", true)
+	if m := Resolve(true); !m.ESServe || !m.LegacyZinc {
+		t.Fatalf("unset + zincOn: ES must STAY on AND legacy on, got %+v", m)
+	}
+}
+
+func TestResolve_UnknownFallsBackToCurrentBehaviour(t *testing.T) {
+	withEnv(t, "elasticsearch", false)
+	if m := Resolve(false); !m.ESServe || m.LegacyZinc {
+		t.Fatalf("unknown + zincOff: want {ES:true Legacy:false}, got %+v", m)
+	}
+	withEnv(t, "off", false)
+	if m := Resolve(true); !m.ESServe || !m.LegacyZinc {
+		t.Fatalf("unknown + zincOn: want {ES:true Legacy:true}, got %+v", m)
+	}
+}
+
+func TestSearchEnabled(t *testing.T) {
+	if !(Mode{ESServe: true}).SearchEnabled() {
+		t.Fatal("ES-only mode must be search-enabled")
+	}
+	if !(Mode{LegacyZinc: true}).SearchEnabled() {
+		t.Fatal("Zinc-only mode must be search-enabled")
+	}
+	if (Mode{}).SearchEnabled() {
+		t.Fatal("both-off (disabled) mode must NOT be search-enabled")
+	}
+}

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -492,6 +492,12 @@ other = "Message search failed."
 ["err.server.message.store_failed"]
 other = "Failed to persist message data."
 
+["err.server.messages_search.depth_exceeded"]
+other = "Search pagination depth limit reached; narrow your query."
+
+["err.server.messages_search.disabled"]
+other = "Search is not enabled on this deployment."
+
 ["err.server.messages_search.internal"]
 other = "Internal search error."
 


### PR DESCRIPTION
## Summary
Hardens the message read/search path: a fail-closed security collar on the
legacy search path, an explicit search-backend switch across all search
surfaces, a new context-window endpoint, and a pagination depth cap. Builds on
the existing OpenSearch-backed `modules/messages_search`.

## Changes
- **Legacy path fail-closed**: `modules/message` `filterResultsBySpace` now drops
  unknown `channel_type` rows instead of appending them, closing a cross-Space
  leak in the legacy `/v1/message/search` results.
- **Explicit search backend** (`pkg/searchbackend`, `OCTO_SEARCH_BACKEND=es|zinc|disabled`):
  no auto-detect/degradation. `es` is authoritative and never falls through to
  Zinc; `disabled` makes every surface (`/v1/messages/_search*`,
  `/v1/message/search`, `/v1/search/global` message portion) refuse uniformly
  with a new localized error; unset preserves current behaviour. `appconfig`
  now exposes `search_enabled` so clients can hide the search box.
- **Context window endpoint** `POST /v1/messages/_search_around`: the anchor is
  pre-validated through the same channel-access, Space-scope, visibility and
  command/revoked gates as a normal read before any surrounding context is
  fetched (a not-visible / cross-Space / revoked / command anchor returns 404).
  Bidirectional `search_after` (reversed sort for the older wing, re-reversed to
  chronological order) reusing the oversample fill loop.
- **Pagination depth cap** aligned with OpenSearch `max_result_window` (10000),
  encoded as a signed cumulative count in the cursor and checked as
  `priorDepth + page_size`, so changing `page_size` cannot walk past it.
- **Read-only drift gauges** (`search_recon_*`) for the reconciliation job to
  publish ES↔MySQL count/sample drift into.
- Extensive table-driven tests covering the above (cross-Space, authz,
  revoke/visibles, page-size/depth caps, backend states, window assembly,
  response-field non-leakage, join-load bounds). Two end-to-end gates that
  depend on the indexer writing `spaceId`/`visibles` are written but skipped
  with an explicit reason.

## Verification
- `go build ./...` ✅
- `go test ./modules/messages_search/... ./modules/message/... ./modules/search/... ./pkg/searchbackend/...` ✅
- `make i18n-extract-check` ✅ · `make i18n-lint` ✅ · `go vet` (touched pkgs) ✅
- Independent model review (Codex): 3 findings fixed (backend default
  resolution, legacy-global-search Zinc gating, depth-cap page-size overrun) +
  1 fixed (command-anchor exclusion); remaining advisory note on cursor-key
  forgeability is the pre-existing cursor posture (resource limit, not an auth
  boundary; gated per-page + loud startup WARN when the signing secret is unset).
