### PR TITLE
feat(runtime): localize bot_provision and verify-api-key error responses

### DIFF
--- a/modules/bot_provision/api_i18n_test.go
+++ b/modules/bot_provision/api_i18n_test.go
@@ -1,0 +1,223 @@
+package bot_provision_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBotProvisionNoLegacyResponseError is the source guard (CLAUDE.md): the
+// handler file must route every user-facing error through
+// httperr.ResponseErrorL / ResponseErrorLWithStatus with a registered
+// errcode.ErrBotProvision* / shared code — never a legacy raw response. The
+// lint-direct-error-response gate only counts c.AbortWithStatus*, so the
+// c.ResponseError* family is enforced here instead.
+func TestBotProvisionNoLegacyResponseError(t *testing.T) {
+	files := []string{"bot_api.go"}
+	banned := []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(", "c.Response(\"", ".AbortWithStatusJSON(", ".AbortWithStatus("}
+	for _, f := range files {
+		t.Run(f, func(t *testing.T) {
+			data, err := os.ReadFile(f)
+			require.NoErrorf(t, err, "read %s", f)
+			// Strip line comments so the doc comments referencing the old
+			// pattern names don't trip the guard.
+			var clean strings.Builder
+			for _, line := range strings.Split(string(data), "\n") {
+				if idx := strings.Index(line, "//"); idx >= 0 {
+					line = line[:idx]
+				}
+				clean.WriteString(line)
+				clean.WriteByte('\n')
+			}
+			cleaned := clean.String()
+			for _, b := range banned {
+				if strings.Contains(cleaned, b) {
+					t.Fatalf("modules/bot_provision/%s must use httperr.ResponseErrorL / ResponseErrorLWithStatus + errcode.ErrBotProvision* / shared codes instead of legacy %s", f, b)
+				}
+			}
+		})
+	}
+}
+
+// TestBotProvisionZhParity guards against the silent en-US fallback: make
+// i18n-extract only maintains the en markers, while active.zh-CN.toml is hand
+// maintained, so a missing zh entry would render English with no gate catching
+// it. Assert every bot_provision code (the 5 new ones + the two shared codes it
+// reuses) renders a Chinese string distinct from its English DefaultMessage.
+func TestBotProvisionZhParity(t *testing.T) {
+	loc := i18n.NewLocalizer(i18n.DefaultLanguage)
+	cases := []struct {
+		id     string
+		wantZh string
+		enSrc  string
+	}{
+		{"err.server.bot_provision.request_invalid", "请求参数有误。", "Invalid request."},
+		{"err.server.bot_provision.auth_failed", "认证失败。", "Authentication failed."},
+		{"err.server.bot_provision.space_forbidden", "你不是该空间的成员，无法在此创建 Bot。", "You are not a member of this space."},
+		{"err.server.bot_provision.bot_forbidden", "无权访问该 Bot。", "Not authorized for this bot."},
+		{"err.server.bot_provision.bot_not_found", "Bot 不存在。", "Bot not found."},
+		// shared codes reused by bot_provision
+		{"err.shared.auth.required", "请先登录！", ""},
+		{"err.shared.internal", "服务器内部错误。", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			got := loc.Translate(tc.id, "zh-CN", nil)
+			assert.Equalf(t, tc.wantZh, got, "zh-CN render of %s", tc.id)
+			if tc.enSrc != "" {
+				assert.NotEqualf(t, tc.enSrc, got, "%s fell back to English — missing zh entry in active.zh-CN.toml", tc.id)
+			}
+		})
+	}
+}
+
+// errEnvelope is the partial shape of an httperr.ResponseErrorL response
+// (dual-envelope: legacy {msg,status} + v2 {error.{...}}).
+type errEnvelope struct {
+	Error struct {
+		Code       string         `json:"code"`
+		Message    string         `json:"message"`
+		Details    map[string]any `json:"details"`
+		HTTPStatus int            `json:"http_status"`
+	} `json:"error"`
+	Msg    string `json:"msg"`
+	Status int    `json:"status"`
+}
+
+// probeHarness mounts a single GET /probe route with the i18n renderer wired
+// (mirroring main.go), so a probe can exercise an errcode + facade and we can
+// assert the rendered envelope without DB / auth setup.
+func probeHarness(probe func(c *wkhttp.Context)) *wkhttp.WKHttp {
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	r.GET("/probe", probe)
+	return r
+}
+
+func doProbe(t *testing.T, r *wkhttp.WKHttp) (int, errEnvelope) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/probe", nil)
+	require.NoError(t, err)
+	r.ServeHTTP(w, req)
+	var env errEnvelope
+	require.NoErrorf(t, json.Unmarshal(w.Body.Bytes(), &env), "decode envelope: %s", w.Body.String())
+	return w.Code, env
+}
+
+// TestBotProvisionErrorEnvelopes validates each code's render contract: the
+// transport (wire) status the facade choice produces, the body code ID and
+// canonical http_status, the request_invalid field detail, and that the
+// Internal shared code hides its message/details. The transport-vs-canonical
+// split is the load-bearing invariant — the daemon branches on the wire status,
+// so ResponseErrorL must pin 400 (D14) while ResponseErrorLWithStatus must emit
+// the code's real status.
+func TestBotProvisionErrorEnvelopes(t *testing.T) {
+	t.Run("request_invalid carries the field detail (ResponseErrorL → wire 400)", func(t *testing.T) {
+		status, env := doProbe(t, probeHarness(func(c *wkhttp.Context) {
+			httperr.ResponseErrorL(c, errcode.ErrBotProvisionRequestInvalid, nil, i18n.Details{"field": "display_name"})
+		}))
+		assert.Equal(t, http.StatusBadRequest, status, "transport status (D14 legacy 400)")
+		assert.Equal(t, "err.server.bot_provision.request_invalid", env.Error.Code)
+		assert.Equal(t, http.StatusBadRequest, env.Error.HTTPStatus)
+		assert.Equal(t, "display_name", env.Error.Details["field"])
+		assert.Contains(t, env.Error.Message, "请求参数有误")
+	})
+
+	t.Run("request_invalid drops empty/nil details", func(t *testing.T) {
+		_, env := doProbe(t, probeHarness(func(c *wkhttp.Context) {
+			httperr.ResponseErrorL(c, errcode.ErrBotProvisionRequestInvalid, nil, nil)
+		}))
+		assert.Equal(t, "err.server.bot_provision.request_invalid", env.Error.Code)
+		_, hasField := env.Error.Details["field"]
+		assert.False(t, hasField, "nil details must not surface an empty field key")
+	})
+
+	t.Run("auth_failed is a 401 on the wire (ResponseErrorLWithStatus)", func(t *testing.T) {
+		status, env := doProbe(t, probeHarness(func(c *wkhttp.Context) {
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrBotProvisionAuthFailed, nil, nil)
+		}))
+		assert.Equal(t, http.StatusUnauthorized, status, "transport status preserved for daemon")
+		assert.Equal(t, "err.server.bot_provision.auth_failed", env.Error.Code)
+		assert.Equal(t, http.StatusUnauthorized, env.Error.HTTPStatus)
+	})
+
+	t.Run("bot_not_found is a 404 on the wire", func(t *testing.T) {
+		status, env := doProbe(t, probeHarness(func(c *wkhttp.Context) {
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrBotProvisionBotNotFound, nil, nil)
+		}))
+		assert.Equal(t, http.StatusNotFound, status)
+		assert.Equal(t, "err.server.bot_provision.bot_not_found", env.Error.Code)
+		assert.Equal(t, http.StatusNotFound, env.Error.HTTPStatus)
+	})
+
+	t.Run("bot_forbidden is a 403 on the wire", func(t *testing.T) {
+		status, env := doProbe(t, probeHarness(func(c *wkhttp.Context) {
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrBotProvisionBotForbidden, nil, nil)
+		}))
+		assert.Equal(t, http.StatusForbidden, status)
+		assert.Equal(t, "err.server.bot_provision.bot_forbidden", env.Error.Code)
+		assert.Equal(t, http.StatusForbidden, env.Error.HTTPStatus)
+	})
+
+	t.Run("space_forbidden is a 403 on the wire", func(t *testing.T) {
+		status, env := doProbe(t, probeHarness(func(c *wkhttp.Context) {
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrBotProvisionSpaceForbidden, nil, nil)
+		}))
+		assert.Equal(t, http.StatusForbidden, status)
+		assert.Equal(t, "err.server.bot_provision.space_forbidden", env.Error.Code)
+		assert.Equal(t, http.StatusForbidden, env.Error.HTTPStatus)
+	})
+
+	t.Run("mint missing-uid guard reuses shared auth_required (401 on the wire)", func(t *testing.T) {
+		status, env := doProbe(t, probeHarness(func(c *wkhttp.Context) {
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedAuthRequired, nil, nil)
+		}))
+		assert.Equal(t, http.StatusUnauthorized, status)
+		assert.Equal(t, "err.shared.auth.required", env.Error.Code)
+		assert.Equal(t, http.StatusUnauthorized, env.Error.HTTPStatus)
+	})
+
+	t.Run("internal: ResponseErrorL pins wire 400 while http_status stays 500, message+details hidden", func(t *testing.T) {
+		status, env := doProbe(t, probeHarness(func(c *wkhttp.Context) {
+			httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, i18n.Details{"field": "leak"})
+		}))
+		assert.Equal(t, http.StatusBadRequest, status, "internal site kept its legacy wire 400 (was c.ResponseError)")
+		assert.Equal(t, "err.shared.internal", env.Error.Code)
+		assert.Equal(t, http.StatusInternalServerError, env.Error.HTTPStatus)
+		assert.NotContains(t, env.Error.Message, "leak")
+		_, hasField := env.Error.Details["field"]
+		assert.False(t, hasField, "Internal code must not surface details")
+	})
+}
+
+// TestBotToken_NoBearer_AuthFailedEndToEnd proves the real botToken handler
+// (not just an isolated probe) routes a missing-Bearer credential through
+// ResponseErrorLWithStatus(ErrBotProvisionAuthFailed): wire 401 + the
+// anti-enumeration code. This locks the facade choice at the actual call site —
+// a future flip to ResponseErrorL would drop the wire status to 400 and fail
+// here. botToken validates the api_key inline (no AuthMiddleware), and the
+// missing-Bearer branch returns before any DB access, so no seed is needed.
+func TestBotToken_NoBearer_AuthFailedEndToEnd(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	s.GetRoute().SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+
+	w := doBotToken(t, s, "bot_any", "" /* no bearer */)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code, "body: %s", w.Body.String())
+	var env errEnvelope
+	require.NoErrorf(t, json.Unmarshal(w.Body.Bytes(), &env), "decode envelope: %s", w.Body.String())
+	assert.Equal(t, "err.server.bot_provision.auth_failed", env.Error.Code)
+}

--- a/modules/bot_provision/bot_api.go
+++ b/modules/bot_provision/bot_api.go
@@ -19,13 +19,14 @@ package bot_provision
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/botfather"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	rd "github.com/go-redis/redis"
 	"go.uber.org/zap"
@@ -50,20 +51,21 @@ func (a *BotProvision) mintBot(c *wkhttp.Context) {
 	// AuthMiddleware would have set "uid"; if not present we 401.
 	uid := c.GetLoginUID()
 	if uid == "" {
-		c.ResponseErrorWithStatus(errors.New("login required"), http.StatusUnauthorized)
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedAuthRequired, nil, nil)
 		return
 	}
 	var req mintRequest
 	if err := c.BindJSON(&req); err != nil {
-		c.ResponseError(fmt.Errorf("invalid body: %w", err))
+		a.Error("mintBot: bind body", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrBotProvisionRequestInvalid, nil, nil)
 		return
 	}
 	if strings.TrimSpace(req.DisplayName) == "" {
-		c.ResponseError(errors.New("display_name required"))
+		httperr.ResponseErrorL(c, errcode.ErrBotProvisionRequestInvalid, nil, i18n.Details{"field": "display_name"})
 		return
 	}
 	if strings.TrimSpace(req.SpaceID) == "" {
-		c.ResponseError(errors.New("space_id required"))
+		httperr.ResponseErrorL(c, errcode.ErrBotProvisionRequestInvalid, nil, i18n.Details{"field": "space_id"})
 		return
 	}
 	// PR-D.1 #2: caller must actually be in the target space before
@@ -71,7 +73,8 @@ func (a *BotProvision) mintBot(c *wkhttp.Context) {
 	// was unchecked — any logged-in user could mint a bot in any space
 	// they knew the id of and then use that bot to observe groups.
 	if err := a.assertSpaceMember(uid, req.SpaceID); err != nil {
-		c.ResponseErrorWithStatus(err, http.StatusForbidden)
+		a.Error("mintBot: space membership check", zap.Error(err))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotProvisionSpaceForbidden, nil, nil)
 		return
 	}
 	botToken := req.BotToken
@@ -79,14 +82,15 @@ func (a *BotProvision) mintBot(c *wkhttp.Context) {
 		var err error
 		botToken, err = generateBfToken()
 		if err != nil {
-			c.ResponseError(fmt.Errorf("gen token: %w", err))
+			a.Error("mintBot: gen bot token", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
 			return
 		}
 	}
 	res, err := botfather.MintBotOBO(a.ctx, uid, req.SpaceID, req.DisplayName, botToken)
 	if err != nil {
 		a.Error("MintBotOBO failed", zap.Error(err))
-		c.ResponseError(fmt.Errorf("mint: %w", err))
+		httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
 		return
 	}
 	c.JSON(http.StatusOK, mintResponse{BotUID: res.BotUID})
@@ -110,17 +114,20 @@ func (a *BotProvision) mintBot(c *wkhttp.Context) {
 func (a *BotProvision) botToken(c *wkhttp.Context) {
 	auth := c.GetHeader("Authorization")
 	if !strings.HasPrefix(auth, "Bearer ") {
-		c.ResponseErrorWithStatus(errors.New("missing Bearer token"), http.StatusUnauthorized)
+		a.Warn("botToken: missing Bearer token")
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotProvisionAuthFailed, nil, nil)
 		return
 	}
 	apiKey := strings.TrimPrefix(auth, "Bearer ")
 	if apiKey == "" {
-		c.ResponseErrorWithStatus(errors.New("empty Bearer token"), http.StatusUnauthorized)
+		a.Warn("botToken: empty Bearer token")
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotProvisionAuthFailed, nil, nil)
 		return
 	}
 	callerUID, callerSpace, err := a.resolveAPIKey(apiKey)
 	if err != nil {
-		c.ResponseErrorWithStatus(errors.New("invalid api_key"), http.StatusUnauthorized)
+		a.Error("botToken: resolve api_key", zap.Error(err))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotProvisionAuthFailed, nil, nil)
 		return
 	}
 	botUID := c.Param("uid")
@@ -149,18 +156,18 @@ func (a *BotProvision) botToken(c *wkhttp.Context) {
 	).Load(&r)
 	if err != nil {
 		a.Error("query robot for token", zap.Error(err), zap.String("bot_uid", botUID))
-		c.ResponseError(errors.New("lookup failed"))
+		httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
 		return
 	}
 	if r.BotToken == "" {
-		c.ResponseErrorWithStatus(errors.New("bot not found"), http.StatusNotFound)
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotProvisionBotNotFound, nil, nil)
 		return
 	}
 	if r.CreatorUID != callerUID {
 		// Caller's api_key uid must equal the bot's creator. Anything
 		// else means a daemon for one user is asking for another user's
 		// bot — clean 403, no info leak about whether the bot exists.
-		c.ResponseErrorWithStatus(errors.New("not authorized for this bot"), http.StatusForbidden)
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotProvisionBotForbidden, nil, nil)
 		return
 	}
 	c.JSON(http.StatusOK, map[string]string{

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -4358,7 +4358,8 @@ func (u *User) authVerifyAPIKey(c *wkhttp.Context) {
 		Where("api_key=? AND space_id!='' AND status=? AND client_id=?", req.APIKey, 1, "botfather").
 		Load(&keyInfo)
 	if err != nil || keyInfo.UID == "" {
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"msg": "invalid api_key"})
+		u.Warn("authVerifyAPIKey: api_key not resolvable", zap.Error(err))
+		respondUserAPIKeyInvalid(c)
 		return
 	}
 
@@ -4387,7 +4388,8 @@ func (u *User) authVerifyAPIKey(c *wkhttp.Context) {
 		keyInfo.SpaceID, keyInfo.UID,
 	).LoadOne(&n)
 	if err != nil || n == 0 {
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"msg": "invalid api_key"})
+		u.Warn("authVerifyAPIKey: api_key owner not a member of bound space", zap.Error(err))
+		respondUserAPIKeyInvalid(c)
 		return
 	}
 

--- a/modules/user/api_i18n.go
+++ b/modules/user/api_i18n.go
@@ -26,6 +26,15 @@ func respondUserErrorWithStatus(c *wkhttp.Context, code codes.Code) {
 	httperr.ResponseErrorLWithStatus(c, code, nil, nil)
 }
 
+// respondUserAPIKeyInvalid is the daemon verify-api-key anti-enumeration 401:
+// an unknown/unresolvable key and a key whose owner is not a member of the
+// bound space both render the same envelope. Status-preserving (the daemon
+// branches on 401); the specific reason is logged at the call site, never
+// surfaced.
+func respondUserAPIKeyInvalid(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrUserAPIKeyInvalid, nil, nil)
+}
+
 // respondUserRequestInvalid covers the common "X 不能为空" / "数据格式有误"
 // shape — one code, one optional field detail. An empty field is omitted
 // so the renderer does not surface a noisy empty key to clients.

--- a/modules/user/api_i18n_test.go
+++ b/modules/user/api_i18n_test.go
@@ -296,6 +296,14 @@ func TestRespondUserHelpers(t *testing.T) {
 			wantContains:    "不支持的语言",
 		},
 		{
+			name:            "respondUserAPIKeyInvalid is a status-preserving 401 (daemon verify-api-key)",
+			probe:           func(c *wkhttp.Context) { respondUserAPIKeyInvalid(c) },
+			wantCodeID:      "err.server.user.api_key_invalid",
+			wantSemStatus:   http.StatusUnauthorized,
+			wantTransStatus: http.StatusUnauthorized,
+			wantContains:    "api_key",
+		},
+		{
 			name:            "ErrUserAccountBanned surfaces zh-CN copy",
 			probe:           func(c *wkhttp.Context) { respondUserError(c, errcode.ErrUserAccountBanned) },
 			wantCodeID:      "err.server.user.account_banned",

--- a/pkg/errcode/bot_provision.go
+++ b/pkg/errcode/bot_provision.go
@@ -1,0 +1,94 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// err.server.bot_provision.* — modules/bot_provision business error codes.
+// bot_provision is the cross-service "open an account for a daemon" surface:
+//   - POST /v1/bot/mint        — web/session caller mints a bot OBO.
+//   - GET  /v1/bot/:uid/token  — daemon (api_key Bearer) fetches a bot_token.
+//
+// Wire status: the mint validation sites historically returned the legacy
+// compatibility 400 via c.ResponseError, so they are rendered with
+// httperr.ResponseErrorL (wire 400, body error.http_status = the code's status).
+// The sites that returned a real semantic status (401/403/404 via
+// c.ResponseErrorWithStatus) are rendered with httperr.ResponseErrorLWithStatus
+// to PRESERVE that wire status, which the daemon branches on.
+//
+// Anti-enumeration (CLAUDE.md): the daemon token endpoint's credential failures
+// (missing/empty Bearer, unresolvable api_key) ALL collapse to a single
+// ErrBotProvisionAuthFailed 401 — the specific reason is logged, never returned,
+// so a caller cannot probe which factor was wrong. The mint endpoint's
+// defensive "no session uid" guard reuses the shared auth-required code.
+//
+// DefaultMessage holds the en-US source (D4); the zh-CN runtime translation
+// lives in pkg/i18n/locales/active.zh-CN.toml.
+var (
+	// ---- validation (400) ----------------------------------------------------
+
+	// ErrBotProvisionRequestInvalid is the catch-all for malformed/missing mint
+	// request input: BindJSON failure (field omitted) and the required-field
+	// guards (field = "display_name" / "space_id"). The offending field is
+	// surfaced via Details when identifiable; the raw parse error is logged.
+	ErrBotProvisionRequestInvalid = register(codes.Code{
+		ID:             "err.server.bot_provision.request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid request.",
+		SafeDetailKeys: []string{"field"},
+	})
+
+	// ---- auth (401, anti-enumeration) ----------------------------------------
+
+	// ErrBotProvisionAuthFailed is the SINGLE anti-enumeration code for the
+	// daemon token endpoint's credential failures: missing Authorization header,
+	// empty Bearer token, and unresolvable api_key ALL collapse here so an
+	// external caller cannot probe which factor was wrong. The specific reason is
+	// logged, never returned. Rendered via ResponseErrorLWithStatus to PRESERVE
+	// the real 401 (the daemon branches on it).
+	ErrBotProvisionAuthFailed = register(codes.Code{
+		ID:             "err.server.bot_provision.auth_failed",
+		HTTPStatus:     http.StatusUnauthorized,
+		DefaultMessage: "Authentication failed.",
+	})
+
+	// ---- permission (403) ----------------------------------------------------
+
+	// ErrBotProvisionSpaceForbidden covers a mint caller who is not a member of
+	// the target space (PR-D.1 #2 guard — a user may not mint a bot into a space
+	// they do not belong to). DB errors from the membership check are logged and
+	// also map here (the original handler returned a single 403 for any failure).
+	ErrBotProvisionSpaceForbidden = register(codes.Code{
+		ID:             "err.server.bot_provision.space_forbidden",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You are not a member of this space.",
+	})
+	// ErrBotProvisionBotForbidden covers the daemon token endpoint when the
+	// caller's api_key uid is not the bot's creator — a clean 403 with no leak of
+	// whether the bot exists.
+	ErrBotProvisionBotForbidden = register(codes.Code{
+		ID:             "err.server.bot_provision.bot_forbidden",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Not authorized for this bot.",
+	})
+
+	// ---- not found (404) -----------------------------------------------------
+
+	// ErrBotProvisionBotNotFound covers the daemon token endpoint when no bot row
+	// (status=1, in the caller's space) yields a token.
+	ErrBotProvisionBotNotFound = register(codes.Code{
+		ID:             "err.server.bot_provision.bot_not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Bot not found.",
+	})
+)
+
+// Shared codes reused at the call sites (no per-module alias needed — the
+// global selectors already exist):
+//   - errcode.ErrSharedAuthRequired (401) — mint's defensive missing-session-uid
+//     guard (the route sits behind AuthMiddleware, so this is belt-and-suspenders).
+//   - errcode.ErrSharedInternal (500, Internal=true) — token gen / MintBotOBO /
+//     robot lookup failures; message+details never surface, each call site logs
+//     the underlying err with zap before responding.

--- a/pkg/errcode/user.go
+++ b/pkg/errcode/user.go
@@ -56,6 +56,15 @@ var (
 		HTTPStatus:     http.StatusUnauthorized,
 		DefaultMessage: "Invalid username or password.",
 	})
+	// ErrUserAPIKeyInvalid is the anti-enumeration 401 for the daemon
+	// verify-api-key endpoint: both an unresolvable/unknown key and a key whose
+	// owner is not a member of the bound space collapse here, so a caller cannot
+	// probe which factor was wrong. The specific reason is logged, never returned.
+	ErrUserAPIKeyInvalid = register(codes.Code{
+		ID:             "err.server.user.api_key_invalid",
+		HTTPStatus:     http.StatusUnauthorized,
+		DefaultMessage: "Invalid api_key.",
+	})
 	ErrUserCodeInvalid = register(codes.Code{
 		ID:             "err.server.user.code_invalid",
 		HTTPStatus:     http.StatusBadRequest,

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -113,6 +113,9 @@ other = "Token 不能为空。"
 ["err.server.user.invalid_credentials"]
 other = "用户名或密码错误。"
 
+["err.server.user.api_key_invalid"]
+other = "api_key 无效。"
+
 ["err.server.user.code_invalid"]
 other = "验证码错误。"
 
@@ -923,6 +926,21 @@ other = "获取 IM 令牌失败。"
 
 ["err.server.app_bot.internal"]
 other = "服务器内部错误。"
+
+["err.server.bot_provision.request_invalid"]
+other = "请求参数有误。"
+
+["err.server.bot_provision.auth_failed"]
+other = "认证失败。"
+
+["err.server.bot_provision.space_forbidden"]
+other = "你不是该空间的成员，无法在此创建 Bot。"
+
+["err.server.bot_provision.bot_forbidden"]
+other = "无权访问该 Bot。"
+
+["err.server.bot_provision.bot_not_found"]
+other = "Bot 不存在。"
 
 ["err.server.bot_api.request_invalid"]
 other = "请求参数有误。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -159,6 +159,21 @@ other = "The upstream service is unavailable."
 ["err.server.bot_api.user_not_found"]
 other = "User not found."
 
+["err.server.bot_provision.auth_failed"]
+other = "Authentication failed."
+
+["err.server.bot_provision.bot_forbidden"]
+other = "Not authorized for this bot."
+
+["err.server.bot_provision.bot_not_found"]
+other = "Bot not found."
+
+["err.server.bot_provision.request_invalid"]
+other = "Invalid request."
+
+["err.server.bot_provision.space_forbidden"]
+other = "You are not a member of this space."
+
 ["err.server.botfather.already_friends"]
 other = "You are already friends."
 
@@ -812,6 +827,9 @@ other = "User already exists."
 
 ["err.server.user.already_friend"]
 other = "You are already friends."
+
+["err.server.user.api_key_invalid"]
+other = "Invalid api_key."
 
 ["err.server.user.auth_code_not_found"]
 other = "Authorization code is invalid or has expired."


### PR DESCRIPTION
## What
Migrate the runtime error surface to the registered error-code i18n framework.

- bot_provision: all 13 hardcoded error sites -> registered codes + httperr.ResponseErrorL / ResponseErrorLWithStatus, preserving each site's wire status; daemon credential failures collapse to one anti-enumeration 401; internal failures route through the shared internal code without leaking detail.
- user (verify-api-key): the two raw 401 responses -> status-preserving ErrUserAPIKeyInvalid (anti-enumeration, reason logged), clearing the lint-direct-error-response (D23) regression on user/api.go.

## Tests / gates
- New i18n tests: source guard, zh parity, envelope + wire-status contracts.
- Green: make i18n-extract-check, lint-unregistered-code, lint-direct-error-response; full bot_provision + user module tests pass.