### PR TITLE
feat(messages_search): support empty keyword on _search and _search_all

### DIFF
--- a/modules/messages_search/dsl_test.go
+++ b/modules/messages_search/dsl_test.go
@@ -59,6 +59,30 @@ func TestBuildSearchMessagesDSL_Shape(t *testing.T) {
 	}
 }
 
+func TestBuildSearchMessagesDSL_NoKeywordSkipsMultiMatch(t *testing.T) {
+	req := SearchMessagesReq{
+		ChannelType: channelTypeGroup,
+		ChannelID:   "groupNo",
+	}
+	q := buildSearchMessagesDSL(req, "groupNo", "")
+	js, _ := json.Marshal(extractDSL(t, q.(interface {
+		Source() (any, error)
+	})))
+	body := string(js)
+	if strings.Contains(body, "multi_match") {
+		t.Errorf("search_messages DSL with empty keyword must not include multi_match:\n%s", body)
+	}
+	for _, want := range []string{
+		`"channelId":"groupNo"`,
+		`"revoked":true`,
+		`"payload.type":99`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("empty-keyword DSL missing %q in:\n%s", want, body)
+		}
+	}
+}
+
 func TestBuildSearchMediaDSL_FiltersTypes(t *testing.T) {
 	req := SearchMediaReq{ChannelType: channelTypeGroup, ChannelID: "g"}
 	q := buildSearchMediaDSL(req, "g", "")
@@ -121,6 +145,33 @@ func TestBuildSearchAllDSL_TypeFilter(t *testing.T) {
 		if !strings.Contains(body, want) && !strings.Contains(body, strings.ReplaceAll(want, ",", ", ")) {
 			t.Errorf("search_all DSL missing %q in:\n%s", want, body)
 		}
+	}
+}
+
+func TestBuildSearchAllDSL_NoKeywordKeepsTypeFilter(t *testing.T) {
+	req := SearchMessagesReq{ChannelType: channelTypeGroup, ChannelID: "g"}
+	q := buildSearchAllDSL(req, "g", "")
+	js, _ := json.Marshal(extractDSL(t, q.(interface {
+		Source() (any, error)
+	})))
+	body := string(js)
+	if strings.Contains(body, "multi_match") {
+		t.Errorf("search_all DSL with empty keyword must not include multi_match:\n%s", body)
+	}
+	if strings.Contains(body, "minimum_should_match") {
+		t.Errorf("search_all DSL with empty keyword must not include minimum_should_match:\n%s", body)
+	}
+	for _, want := range []string{
+		`"channelId":"g"`,
+		`"revoked":true`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("empty-keyword search_all DSL missing %q in:\n%s", want, body)
+		}
+	}
+	// type filter must still segment message vs file
+	if !strings.Contains(body, `"payload.type":[1,8,11]`) && !strings.Contains(body, `"payload.type":[1, 8, 11]`) {
+		t.Errorf("empty-keyword search_all DSL must still filter payload.type [1,8,11]:\n%s", body)
 	}
 }
 

--- a/modules/messages_search/search_all.go
+++ b/modules/messages_search/search_all.go
@@ -36,10 +36,10 @@ func (h *Handler) searchAll(c *wkhttp.Context) {
 	req.Keyword = strings.TrimSpace(req.Keyword)
 	loginUID := c.GetLoginUID()
 
-	if !validateKeywordRequired(c, req.Keyword) {
+	if !validateKeywordOptional(c, req.Keyword) {
 		return
 	}
-	pageSize, ok := validateBase(c, h.cfg, req.ChannelType, req.ChannelID, req.Sort, req.Cursor, req.Filters, req.PageSize, true)
+	pageSize, ok := validateBase(c, h.cfg, req.ChannelType, req.ChannelID, req.Sort, req.Cursor, req.Filters, req.PageSize, req.Keyword != "")
 	if !ok {
 		return
 	}
@@ -80,9 +80,11 @@ func (h *Handler) searchAll(c *wkhttp.Context) {
 			Index(h.cfg.OSReadAlias).
 			Routing(normID).
 			Query(dsl).
-			Highlight(buildSearchAllHighlight()).
 			Size(size).
 			TrackTotalHits(false)
+		if req.Keyword != "" {
+			svc = svc.Highlight(buildSearchAllHighlight())
+		}
 		svc = applySort(svc, req.Sort)
 		if len(searchAfter) > 0 {
 			svc = svc.SearchAfter(searchAfter...)
@@ -127,17 +129,19 @@ func buildSearchAllDSL(req SearchAllReq, normChannelID, spaceID string) elastic.
 		payloadTypeMergeForward,
 	))
 	addCommonFilters(b, req.Filters)
-	b.Should(
-		elastic.NewMultiMatchQuery(req.Keyword,
-			"payload.text.content^3",
-			"payload.mergeForward.msgs.searchText",
-		),
-		elastic.NewMultiMatchQuery(req.Keyword,
-			"payload.file.name^2",
-			"payload.file.caption",
-		),
-	)
-	b.MinimumShouldMatch("1")
+	if req.Keyword != "" {
+		b.Should(
+			elastic.NewMultiMatchQuery(req.Keyword,
+				"payload.text.content^3",
+				"payload.mergeForward.msgs.searchText",
+			),
+			elastic.NewMultiMatchQuery(req.Keyword,
+				"payload.file.name^2",
+				"payload.file.caption",
+			),
+		)
+		b.MinimumShouldMatch("1")
+	}
 	return b
 }
 

--- a/modules/messages_search/search_messages.go
+++ b/modules/messages_search/search_messages.go
@@ -41,10 +41,10 @@ func (h *Handler) searchMessages(c *wkhttp.Context) {
 	req.Keyword = strings.TrimSpace(req.Keyword)
 	loginUID := c.GetLoginUID()
 
-	if !validateKeywordRequired(c, req.Keyword) {
+	if !validateKeywordOptional(c, req.Keyword) {
 		return
 	}
-	pageSize, ok := validateBase(c, h.cfg, req.ChannelType, req.ChannelID, req.Sort, req.Cursor, req.Filters, req.PageSize, true)
+	pageSize, ok := validateBase(c, h.cfg, req.ChannelType, req.ChannelID, req.Sort, req.Cursor, req.Filters, req.PageSize, req.Keyword != "")
 	if !ok {
 		return
 	}
@@ -85,9 +85,11 @@ func (h *Handler) searchMessages(c *wkhttp.Context) {
 			Index(h.cfg.OSReadAlias).
 			Routing(normID).
 			Query(dsl).
-			Highlight(buildSearchMessagesHighlight()).
 			Size(size).
 			TrackTotalHits(false)
+		if req.Keyword != "" {
+			svc = svc.Highlight(buildSearchMessagesHighlight())
+		}
 		svc = applySort(svc, req.Sort)
 		if len(searchAfter) > 0 {
 			svc = svc.SearchAfter(searchAfter...)
@@ -126,12 +128,14 @@ func (h *Handler) searchMessages(c *wkhttp.Context) {
 // buildSearchMessagesDSL constructs the bool query for /_search.
 func buildSearchMessagesDSL(req SearchMessagesReq, normChannelID, spaceID string) elastic.Query {
 	b := elastic.NewBoolQuery()
-	b.Must(elastic.NewMultiMatchQuery(req.Keyword,
-		"payload.text.content^3",
-		"payload.image.caption", "payload.image.name",
-		"payload.file.caption", "payload.file.name",
-		"payload.mergeForward.msgs.searchText",
-	))
+	if req.Keyword != "" {
+		b.Must(elastic.NewMultiMatchQuery(req.Keyword,
+			"payload.text.content^3",
+			"payload.image.caption", "payload.image.name",
+			"payload.file.caption", "payload.file.name",
+			"payload.mergeForward.msgs.searchText",
+		))
+	}
 	applyChannelAndRevoked(b, normChannelID)
 	applySpaceIDScope(b, req.ChannelType, spaceID)
 	addCommonFilters(b, req.Filters)

--- a/modules/messages_search/swagger/api.yaml
+++ b/modules/messages_search/swagger/api.yaml
@@ -29,7 +29,7 @@ paths:
         - "messages_search"
       operationId: "message.search"
       summary: "Search text + forward messages"
-      description: "Full-text search across text/forward/image/file payload fields scoped to a single channel. Required keyword."
+      description: "Full-text search across text/forward/image/file payload fields scoped to a single channel. Keyword is optional — when empty the endpoint returns the channel's messages in time order (relevance sort then requires a non-empty keyword)."
       consumes:
         - "application/json"
       produces:
@@ -188,7 +188,7 @@ paths:
         - "messages_search"
       operationId: "message.search_all"
       summary: "Search across messages and files"
-      description: "Combined search across text/forward and files in a single channel; required keyword."
+      description: "Combined search across text/forward and files in a single channel. Keyword is optional — when empty the endpoint mixes messages and files in time order (relevance sort then requires a non-empty keyword)."
       consumes:
         - "application/json"
       produces:
@@ -348,7 +348,6 @@ definitions:
     required:
       - channel_type
       - channel_id
-      - keyword
     properties:
       channel_type:
         type: integer

--- a/modules/messages_search/validate.go
+++ b/modules/messages_search/validate.go
@@ -25,13 +25,14 @@ type SearchFilters struct {
 
 // SearchMessagesReq is the request body for POST /v1/messages/_search.
 //
-// `Keyword` is required and non-empty per A doc §2.1. `Sort` accepts
-// time_desc (default) | time_asc | relevance. `PageSize` is normalised into
-// [1, 100] with a default of 20.
+// `Keyword` is optional; when empty the DSL drops the multi_match clause and
+// the endpoint behaves as a time-ordered listing. `Sort` accepts time_desc
+// (default) | time_asc | relevance — relevance requires a non-empty keyword.
+// `PageSize` is normalised into [1, 100] with a default of 20.
 type SearchMessagesReq struct {
 	ChannelType uint8         `json:"channel_type"`
 	ChannelID   string        `json:"channel_id"`
-	Keyword     string        `json:"keyword"`
+	Keyword     string        `json:"keyword,omitempty"`
 	Filters     SearchFilters `json:"filters,omitempty"`
 	Sort        string        `json:"sort,omitempty"`
 	PageSize    int           `json:"page_size,omitempty"`
@@ -65,7 +66,7 @@ type SearchFilesReq struct {
 }
 
 // SearchAllReq is the request body for POST /v1/messages/_search_all. Same
-// shape as _search; keyword required.
+// shape as _search; keyword optional and gated identically.
 type SearchAllReq = SearchMessagesReq
 
 // SearchAroundReq is the request body for POST /v1/messages/_search_around.
@@ -161,23 +162,6 @@ func validateBase(c *wkhttp.Context, cfg SearchConfig, channelType uint8, channe
 		page = defaultPage
 	}
 	return page, true
-}
-
-// validateKeywordRequired runs the keyword length / non-empty check.
-func validateKeywordRequired(c *wkhttp.Context, keyword string) bool {
-	if keyword == "" {
-		respondValidation(c, "keyword", "required")
-		return false
-	}
-	if utf8.RuneCountInString(keyword) > maxKeywordLen {
-		respondValidationDetails(c, i18n.Details{
-			"field":      "keyword",
-			"reason":     "too long",
-			"max_length": maxKeywordLen,
-		})
-		return false
-	}
-	return true
 }
 
 // validateKeywordOptional accepts an empty keyword but still bounds length.

--- a/modules/messages_search/validate_test.go
+++ b/modules/messages_search/validate_test.go
@@ -104,3 +104,28 @@ func TestValidateBase_MalformedCursorRejected(t *testing.T) {
 		t.Fatalf("cursor rejection must render a validation envelope, got %q", rec.Body.String())
 	}
 }
+
+// sort=relevance with allowRelevance=false (the empty-keyword path) must be
+// refused — relevance has no _score to sort on when the multi_match clause is
+// dropped. The user-facing body is rendered through i18n templates so the
+// raw reason string is not asserted here (other validate tests follow the
+// same envelope-only pattern); the rejection itself is the contract.
+func TestValidateBase_RelevanceRequiresKeyword(t *testing.T) {
+	c, rec := newValidateCtx(t)
+	_, ok := validateBase(c, SearchConfig{}, channelTypeGroup, "G1", "relevance", "",
+		SearchFilters{}, 20, false)
+	if ok {
+		t.Fatalf("sort=relevance without keyword (allowRelevance=false) must be rejected")
+	}
+	if rec.Body.Len() == 0 {
+		t.Fatalf("rejection must render a VALIDATION_ERROR envelope")
+	}
+
+	// And the symmetric positive: with allowRelevance=true (keyword present)
+	// the same sort value passes — guards against regressing the gate.
+	c2, _ := newValidateCtx(t)
+	if _, ok := validateBase(c2, SearchConfig{}, channelTypeGroup, "G1", "relevance", "",
+		SearchFilters{}, 20, true); !ok {
+		t.Fatalf("sort=relevance with allowRelevance=true must be accepted")
+	}
+}


### PR DESCRIPTION
Make keyword optional on POST /v1/messages/_search and POST /v1/messages/_search_all. When keyword is empty, the DSL drops the multi_match clause (and minimum_should_match for _search_all) and the endpoint becomes a time-ordered listing scoped by channel + space + revoked + payload-type filter. sort=relevance now requires a non-empty keyword on both endpoints (validated through validateBase with allowRelevance = req.Keyword != ""). Highlight is also skipped when keyword is empty to avoid wasted OS work.

This matches the pattern already used by _search_files, so the three keyword-optional endpoints share one model. _search_media (keyword must be empty) and _search_around (no keyword field) are untouched.

- swap validateKeywordRequired -> validateKeywordOptional in search_messages.go and search_all.go; remove the now-unused helper
- gate multi_match / minimum_should_match in buildSearchMessagesDSL and buildSearchAllDSL on keyword != ""
- only attach Highlight() when keyword is non-empty in both handlers
- swagger: drop keyword from SearchMessagesReq.required (shared by both endpoints) and refresh the two endpoint descriptions
- tests: new DSL cases assert no multi_match / no minimum_should_match with empty keyword while channel + revoked + payload.type filters stay; new validate case covers the allowRelevance=false rejection plus the allowRelevance=true positive

openapi-diff vs upstream/main: breakingDifferencesFound=false (keyword moves from required to optional; old clients are 100% compatible).

## Summary

<!-- What does this PR do? -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. Fixes #123 -->

## Changes

<!-- Bullet list of concrete changes -->

-
-

## Testing

<!-- How was this tested? Include commands, screenshots, or test output. -->

- [ ] Unit tests added/updated
- [ ] Manually verified

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] PR description is in English
- [ ] Added tests for my changes
- [ ] Updated documentation
- [ ] Followed commit message conventions (Conventional Commits)
