### PR TITLE
feat(space): add paginated member search endpoint for space admins

### DIFF
--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	rd "github.com/go-redis/redis"
 	"github.com/gocraft/dbr/v2"
 	"go.uber.org/zap"
@@ -94,6 +95,11 @@ func (s *Space) Route(r *wkhttp.WKHttp) {
 		auth.POST("/:space_id/email-invites", s.createMemberEmailInvite)
 		auth.GET("/:space_id/email-invites", s.listMemberEmailInvites)
 		auth.DELETE("/:space_id/email-invites/:id", s.revokeMemberEmailInvite)
+	}
+
+	search := r.Group("/v1/space", s.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, s.ctx))
+	{
+		search.GET("/:space_id/members/search", s.searchMembers)
 	}
 
 	// 邀请码预览端点（公开无认证）严格 per-IP 限流：防枚举 + 暴破（issue #1000）。

--- a/modules/space/api_i18n_test.go
+++ b/modules/space/api_i18n_test.go
@@ -26,6 +26,7 @@ func httperrL(c *wkhttp.Context, code codes.Code) {
 func TestSpaceNoLegacyResponseError(t *testing.T) {
 	files := []string{
 		"api.go",
+		"api_member_search.go",
 		"api_manager.go",
 		"api_email_invite.go",
 		"api_email_invite_public.go",

--- a/modules/space/api_member_search.go
+++ b/modules/space/api_member_search.go
@@ -1,0 +1,103 @@
+package space
+
+import (
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"go.uber.org/zap"
+)
+
+// spaceRoleAdmin is the minimum role allowed to manage space-scoped resources.
+const spaceRoleAdmin = 1
+
+// maxMemberSearchPageIndex 兜住 page_index 上限：page_size≤200 时 offset≤2e7，
+// 远超任何空间成员数，且避免 (pageIndex-1)*pageSize 在转 uint64 前整型溢出。
+const maxMemberSearchPageIndex = 100000
+
+func (s *Space) searchMembers(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+	spaceId := c.Param("space_id")
+
+	// 空间必须处于激活态。封禁(status=2)只更新 space 行、不会把 space_member 置为
+	// 非激活,因此仅靠成员行 status=1 的 gate 会让封禁/解散空间的 admin 仍能搜出成员
+	// (含掩码 email/phone),绕过封禁冻结。显式校验 space.status=1 统一挡掉封禁与解散。
+	if s.checkSpaceActive(c, spaceId) {
+		return
+	}
+
+	member, err := s.db.queryMember(spaceId, loginUID)
+	if err != nil {
+		s.Error("查询空间成员权限失败", zap.Error(err), zap.String("operator_uid", loginUID), zap.String("space_id", spaceId))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
+		return
+	}
+	if member == nil {
+		httperr.ResponseErrorL(c, errcode.ErrSpaceNotMember, nil, nil)
+		return
+	}
+	if member.Role < spaceRoleAdmin {
+		httperr.ResponseErrorL(c, errcode.ErrSpacePermissionDenied, nil, nil)
+		return
+	}
+
+	pageIndex, pageSize := clampPage(c.GetPage())
+	if pageIndex > maxMemberSearchPageIndex {
+		pageIndex = maxMemberSearchPageIndex
+	}
+	// keyword 跨列匹配 name/username/email(明文)/uid；phone 仅匹配后 4 位
+	// （见 memberSearchActiveWhere）——前端按手机号检索时只需传后 4 位。
+	keyword := strings.TrimSpace(c.Query("keyword"))
+	count, err := s.db.countSearchMembers(spaceId, keyword)
+	if err != nil {
+		s.Error("统计空间成员搜索结果失败", zap.Error(err), zap.String("operator_uid", loginUID), zap.String("space_id", spaceId))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
+		return
+	}
+	if count == 0 {
+		c.Response(map[string]interface{}{"count": int64(0), "list": []memberSearchResp{}})
+		return
+	}
+	members, err := s.db.searchMembers(spaceId, keyword, pageIndex, pageSize)
+	if err != nil {
+		s.Error("查询空间成员搜索结果失败", zap.Error(err), zap.String("operator_uid", loginUID), zap.String("space_id", spaceId))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
+		return
+	}
+
+	resps := make([]memberSearchResp, 0, len(members))
+	for _, m := range members {
+		resps = append(resps, memberSearchResp{
+			UID:       m.UID,
+			Name:      m.Name,
+			Username:  m.Username,
+			Email:     m.Email,
+			Phone:     maskPhone(m.Phone),
+			Role:      m.Role,
+			Robot:     m.Robot,
+			CreatedAt: m.CreatedAt.String(),
+		})
+	}
+
+	s.Info("空间成员搜索", zap.String("operator_uid", loginUID), zap.String("space_id", spaceId), zap.Int64("count", count))
+	c.Response(map[string]interface{}{
+		"count": count,
+		"list":  resps,
+	})
+}
+
+// maskPhone 将手机号掩码为「前 3 + **** + 后 4」（如 138****5678）。后 4 位也是
+// memberSearchActiveWhere 唯一可检索的部分，使「可检索粒度 == 可见粒度」，避免
+// admin 通过子串查询逐位探测/重建完整号码。用 rune 切片，避免多字节输入被字节
+// 索引切成无效 UTF-8。空值保持空串。
+func maskPhone(p string) string {
+	r := []rune(p)
+	if len(r) == 0 {
+		return ""
+	}
+	if len(r) < 7 {
+		return "***"
+	}
+	return string(r[:3]) + "****" + string(r[len(r)-4:])
+}

--- a/modules/space/api_member_search_test.go
+++ b/modules/space/api_member_search_test.go
@@ -1,0 +1,383 @@
+package space
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/server"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/go-redis/redis"
+	"github.com/stretchr/testify/assert"
+)
+
+type spaceMembersSearchResponse struct {
+	Count int64                           `json:"count"`
+	List  []spaceMembersSearchItemForTest `json:"list"`
+}
+
+type spaceMembersSearchItemForTest struct {
+	UID       string `json:"uid"`
+	Name      string `json:"name"`
+	Username  string `json:"username"`
+	Email     string `json:"email"`
+	Phone     string `json:"phone"`
+	Role      int    `json:"role"`
+	Robot     int    `json:"robot"`
+	CreatedAt string `json:"created_at"`
+}
+
+func resetSpaceUIDRateLimit(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	rdsClient := redis.NewClient(&redis.Options{
+		Addr:     ctx.GetConfig().DB.RedisAddr,
+		Password: ctx.GetConfig().DB.RedisPass,
+	})
+	defer rdsClient.Close()
+	keys, err := rdsClient.Keys("ratelimit:uid:*").Result()
+	if err == nil && len(keys) > 0 {
+		_ = rdsClient.Del(keys...).Err()
+	}
+}
+
+func getMembersSearch(t *testing.T, srv *server.Server, ctx *config.Context, spaceId string, q url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+	resetSpaceUIDRateLimit(t, ctx)
+	path := "/v1/space/" + spaceId + "/members/search"
+	if encoded := q.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("token", testutil.Token)
+	srv.GetRoute().ServeHTTP(w, req)
+	return w
+}
+
+func decodeMembersSearchResp(t *testing.T, w *httptest.ResponseRecorder) spaceMembersSearchResponse {
+	t.Helper()
+	var resp spaceMembersSearchResponse
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), w.Body.String())
+	return resp
+}
+
+func seedMemberSearchSpace(t *testing.T, spaceId, creator string) {
+	t.Helper()
+	assert.NoError(t, testSpaceDB.insertSpaceNoTx(&SpaceModel{
+		SpaceId: spaceId,
+		Name:    spaceId,
+		Creator: creator,
+		Status:  SpaceStatusNormal,
+	}))
+	assert.NoError(t, testSpaceDB.insertMemberNoTx(&MemberModel{
+		SpaceId: spaceId,
+		UID:     creator,
+		Role:    2,
+		Status:  1,
+	}))
+}
+
+func seedMemberSearchMember(t *testing.T, spaceId, uid string, role, status int) {
+	t.Helper()
+	assert.NoError(t, testSpaceDB.insertMemberNoTx(&MemberModel{
+		SpaceId: spaceId,
+		UID:     uid,
+		Role:    role,
+		Status:  status,
+	}))
+}
+
+func seedMemberSearchUser(t *testing.T, uid, name, username, email, phone string) {
+	t.Helper()
+	_, err := testCtx.DB().InsertBySql(
+		"INSERT INTO `user` (uid, name, username, email, phone) VALUES (?, ?, ?, ?, ?) "+
+			"ON DUPLICATE KEY UPDATE name=VALUES(name), username=VALUES(username), email=VALUES(email), phone=VALUES(phone)",
+		uid, name, username, email, phone,
+	).Exec()
+	assert.NoError(t, err)
+}
+
+func seedMemberSearchRobot(t *testing.T, uid, name string) {
+	t.Helper()
+	seedMemberSearchUser(t, uid, name, uid, "", "")
+	_, err := testCtx.DB().InsertInto("robot").Columns("robot_id", "token", "status", "creator_uid").
+		Values(uid, "token-"+uid, 1, testutil.UID).Exec()
+	assert.NoError(t, err)
+}
+
+func findMemberSearchItem(list []spaceMembersSearchItemForTest, uid string) (spaceMembersSearchItemForTest, bool) {
+	for _, it := range list {
+		if it.UID == uid {
+			return it, true
+		}
+	}
+	return spaceMembersSearchItemForTest{}, false
+}
+
+func TestMaskPhone(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"mainland mobile", "13812345678", "138****5678"},
+		{"seven chars boundary keeps first three and last four", "1234567", "123****4567"},
+		{"six chars fully masked", "123456", "***"},
+		{"short value fully masked", "12345", "***"},
+		{"empty value stays empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, maskPhone(tc.in))
+		})
+	}
+}
+
+func TestSpaceMembersSearchAuthz(t *testing.T) {
+	srv, _, err := setup(t)
+	assert.NoError(t, err)
+	ctx := testCtx
+
+	t.Run("non member gets not_member", func(t *testing.T) {
+		spaceId := "sp-search-nonmember"
+		seedMemberSearchSpace(t, spaceId, "owner-nonmember")
+
+		w := getMembersSearch(t, srv, ctx, spaceId, nil)
+		assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+		assertSpaceErrorCode(t, w, "err.server.space.not_member")
+	})
+
+	t.Run("regular member gets permission_denied", func(t *testing.T) {
+		assert.NoError(t, testutil.CleanAllTables(testCtx))
+		spaceId := "sp-search-member"
+		seedMemberSearchSpace(t, spaceId, "owner-member")
+		seedMemberSearchMember(t, spaceId, testutil.UID, 0, 1)
+
+		w := getMembersSearch(t, srv, ctx, spaceId, nil)
+		assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+		assertSpaceErrorCode(t, w, "err.server.space.permission_denied")
+	})
+}
+
+func TestSpaceMembersSearchEmptyKeywordReturnsActiveMembersAndBots(t *testing.T) {
+	srv, _, err := setup(t)
+	assert.NoError(t, err)
+	spaceId := "sp-search-all"
+	seedMemberSearchSpace(t, spaceId, "owner-all")
+	seedMemberSearchMember(t, spaceId, testutil.UID, 1, 1)
+	seedMemberSearchUser(t, "human-all", "Human All", "human_all", "human@example.com", "13812345678")
+	seedMemberSearchMember(t, spaceId, "human-all", 0, 1)
+	seedMemberSearchRobot(t, "bot-all", "Bot All")
+	seedMemberSearchMember(t, spaceId, "bot-all", 0, 1)
+	seedMemberSearchUser(t, "removed-all", "Removed All", "removed_all", "removed@example.com", "13912345678")
+	seedMemberSearchMember(t, spaceId, "removed-all", 0, 0)
+
+	w := getMembersSearch(t, srv, testCtx, spaceId, url.Values{
+		"page_index": {"1"},
+		"page_size":  {"20"},
+	})
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	resp := decodeMembersSearchResp(t, w)
+	assert.EqualValues(t, 4, resp.Count)
+	assert.Len(t, resp.List, 4)
+
+	human, ok := findMemberSearchItem(resp.List, "human-all")
+	if assert.True(t, ok) {
+		assert.Equal(t, "human@example.com", human.Email)
+		assert.Equal(t, "138****5678", human.Phone)
+		assert.Equal(t, 0, human.Robot)
+	}
+	bot, ok := findMemberSearchItem(resp.List, "bot-all")
+	if assert.True(t, ok) {
+		assert.Equal(t, 1, bot.Robot)
+	}
+	_, ok = findMemberSearchItem(resp.List, "removed-all")
+	assert.False(t, ok, "removed members must not be visible from the space-side search")
+}
+
+func TestSpaceMembersSearchEmptyContactFieldsStayEmpty(t *testing.T) {
+	srv, _, err := setup(t)
+	assert.NoError(t, err)
+	spaceId := "sp-search-empty-contact"
+	seedMemberSearchSpace(t, spaceId, testutil.UID)
+	seedMemberSearchUser(t, "empty-contact", "Empty Contact", "empty_contact", "", "")
+	seedMemberSearchMember(t, spaceId, "empty-contact", 0, 1)
+
+	w := getMembersSearch(t, srv, testCtx, spaceId, url.Values{
+		"keyword": {"empty_contact"},
+	})
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	resp := decodeMembersSearchResp(t, w)
+	if assert.Len(t, resp.List, 1) {
+		assert.Equal(t, "", resp.List[0].Email)
+		assert.Equal(t, "", resp.List[0].Phone)
+	}
+}
+
+// TestSpaceMembersSearchIncludesBotsFromOtherCreators pins the deliberate admin-view
+// behavior: unlike the member-facing listMembers (which only surfaces bots created by
+// the caller), this admin search returns ALL bots in the space regardless of creator.
+func TestSpaceMembersSearchIncludesBotsFromOtherCreators(t *testing.T) {
+	srv, _, err := setup(t)
+	assert.NoError(t, err)
+	spaceId := "sp-search-otherbot"
+	seedMemberSearchSpace(t, spaceId, testutil.UID)
+	// a bot created by someone other than the caller
+	seedMemberSearchUser(t, "bot-other", "Bot Other", "bot_other", "", "")
+	_, err = testCtx.DB().InsertInto("robot").Columns("robot_id", "token", "status", "creator_uid").
+		Values("bot-other", "token-bot-other", 1, "someone-else").Exec()
+	assert.NoError(t, err)
+	seedMemberSearchMember(t, spaceId, "bot-other", 0, 1)
+
+	w := getMembersSearch(t, srv, testCtx, spaceId, url.Values{"keyword": {"bot_other"}})
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	resp := decodeMembersSearchResp(t, w)
+	bot, ok := findMemberSearchItem(resp.List, "bot-other")
+	if assert.True(t, ok, "admin search must surface bots created by others") {
+		assert.Equal(t, 1, bot.Robot)
+	}
+}
+
+func TestSpaceMembersSearchKeywordColumnsMaskingAndEscaping(t *testing.T) {
+	srv, _, err := setup(t)
+	assert.NoError(t, err)
+	spaceId := "sp-search-columns"
+	seedMemberSearchSpace(t, spaceId, testutil.UID)
+
+	fixtures := []struct {
+		uid      string
+		name     string
+		username string
+		email    string
+		phone    string
+	}{
+		{"u-name-target", "Alice Cooper", "alice123", "alice@example.com", "13800001111"},
+		{"u-username-target", "Bob", "zzqqxx", "bob.unique@corp.io", "13900002222"},
+		{"u-phone-target", "Carol", "carol", "carol@example.com", "15512348888"},
+		{"u-uid-target", "Dave", "dave", "dave@example.com", "15600003333"},
+	}
+	for _, f := range fixtures {
+		seedMemberSearchUser(t, f.uid, f.name, f.username, f.email, f.phone)
+		seedMemberSearchMember(t, spaceId, f.uid, 0, 1)
+	}
+
+	doSearch := func(keyword string) spaceMembersSearchResponse {
+		w := getMembersSearch(t, srv, testCtx, spaceId, url.Values{"keyword": {keyword}})
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		return decodeMembersSearchResp(t, w)
+	}
+
+	cases := []struct {
+		name    string
+		keyword string
+		wantUID string
+	}{
+		{"by name", "Alice", "u-name-target"},
+		{"by username", "zzqqxx", "u-username-target"},
+		{"by email", "bob.unique", "u-username-target"},
+		{"by phone last4", "8888", "u-phone-target"},
+		{"by uid", "u-uid-target", "u-uid-target"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := doSearch(tc.keyword)
+			assert.EqualValues(t, 1, resp.Count)
+			if assert.Len(t, resp.List, 1) {
+				assert.Equal(t, tc.wantUID, resp.List[0].UID)
+			}
+		})
+	}
+
+	t.Run("email returned in cleartext, phone masked to last 4", func(t *testing.T) {
+		resp := doSearch("bob.unique")
+		if assert.Len(t, resp.List, 1) {
+			assert.Equal(t, "bob.unique@corp.io", resp.List[0].Email)
+			assert.Equal(t, "139****2222", resp.List[0].Phone)
+		}
+	})
+
+	t.Run("list and count share the same keyword filter", func(t *testing.T) {
+		resp := doSearch("example.com")
+		assert.EqualValues(t, 3, resp.Count)
+		assert.Len(t, resp.List, 3)
+	})
+
+	t.Run("like wildcard characters are escaped", func(t *testing.T) {
+		resp := doSearch("zzqqx_")
+		assert.EqualValues(t, 0, resp.Count)
+		assert.Len(t, resp.List, 0)
+	})
+}
+
+// TestSpaceMembersSearchRejectsInactiveSpace pins the lifecycle authz gate:
+// banning a space (status=2) only updates the space row and leaves space_member
+// rows at status=1, so without an explicit active-space check a former admin
+// could still search members (incl. masked email/phone) of a banned/disbanded
+// space. checkSpaceActive (strict status=1) must reject both.
+func TestSpaceMembersSearchRejectsInactiveSpace(t *testing.T) {
+	srv, _, err := setup(t)
+	assert.NoError(t, err)
+	cases := []struct {
+		name   string
+		status int
+	}{
+		{"banned", 2},
+		{"disbanded", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.NoError(t, testutil.CleanAllTables(testCtx))
+			spaceId := "sp-inactive-" + tc.name
+			assert.NoError(t, testSpaceDB.insertSpaceNoTx(&SpaceModel{
+				SpaceId: spaceId,
+				Name:    spaceId,
+				Creator: testutil.UID,
+				Status:  tc.status,
+			}))
+			// caller is a still-active owner row (role=2, status=1) — the exact
+			// state a ban leaves behind; only the space-level gate can reject it.
+			assert.NoError(t, testSpaceDB.insertMemberNoTx(&MemberModel{
+				SpaceId: spaceId,
+				UID:     testutil.UID,
+				Role:    2,
+				Status:  1,
+			}))
+			w := getMembersSearch(t, srv, testCtx, spaceId, url.Values{})
+			assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+		})
+	}
+}
+
+func TestSpaceMembersSearchPaginationClamp(t *testing.T) {
+	srv, _, err := setup(t)
+	assert.NoError(t, err)
+	spaceId := "sp-search-page"
+	seedMemberSearchSpace(t, spaceId, testutil.UID)
+	for i := 0; i < 204; i++ {
+		uid := fmt.Sprintf("page-member-%03d", i)
+		seedMemberSearchUser(t, uid, uid, uid, "", "")
+		seedMemberSearchMember(t, spaceId, uid, 0, 1)
+	}
+
+	w := getMembersSearch(t, srv, testCtx, spaceId, url.Values{
+		"page_index": {"1"},
+		"page_size":  {"999"},
+	})
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	resp := decodeMembersSearchResp(t, w)
+	assert.EqualValues(t, 205, resp.Count)
+	assert.Len(t, resp.List, 200, "page_size must be clamped to the shared 200-row cap")
+
+	w = getMembersSearch(t, srv, testCtx, spaceId, url.Values{
+		"page_index": {"2"},
+		"page_size":  {"2"},
+	})
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	resp = decodeMembersSearchResp(t, w)
+	assert.EqualValues(t, 205, resp.Count)
+	assert.Len(t, resp.List, 2)
+}

--- a/modules/space/db.go
+++ b/modules/space/db.go
@@ -161,6 +161,47 @@ func (d *DB) queryMembers(spaceId string, loginUID string, page uint64, limit ui
 	return models, err
 }
 
+func (d *DB) searchMembers(spaceId, keyword string, pageIndex, pageSize int) ([]*memberSearchModel, error) {
+	builder := d.session.Select(
+		"sm.*",
+		"IFNULL(u.name,'') as name",
+		"IFNULL(u.username,'') as username",
+		"IFNULL(u.email,'') as email",
+		"IFNULL(u.phone,'') as phone",
+		"CASE WHEN r.robot_id IS NOT NULL AND r.status=1 THEN 1 ELSE 0 END as robot",
+	).From(dbr.I("space_member").As("sm")).
+		LeftJoin(dbr.I("user").As("u"), "u.uid=sm.uid").
+		LeftJoin(dbr.I("robot").As("r"), "r.robot_id=sm.uid").
+		Where("sm.space_id=? AND sm.status=1", spaceId)
+	if keyword != "" {
+		clause, args := memberSearchActiveWhere(keyword)
+		builder = builder.Where(clause, args...)
+	}
+	var list []*memberSearchModel
+	_, err := builder.
+		OrderDir("sm.role", false).
+		OrderAsc("sm.created_at").
+		OrderAsc("sm.uid").
+		Limit(uint64(pageSize)).
+		Offset(uint64((pageIndex - 1) * pageSize)).
+		Load(&list)
+	return list, err
+}
+
+func (d *DB) countSearchMembers(spaceId, keyword string) (int64, error) {
+	builder := d.session.Select("COUNT(*)").
+		From(dbr.I("space_member").As("sm")).
+		LeftJoin(dbr.I("user").As("u"), "u.uid=sm.uid").
+		Where("sm.space_id=? AND sm.status=1", spaceId)
+	if keyword != "" {
+		clause, args := memberSearchActiveWhere(keyword)
+		builder = builder.Where(clause, args...)
+	}
+	var count int64
+	_, err := builder.Load(&count)
+	return count, err
+}
+
 // removeMemberLocked 锁内重读角色后移除成员，防并发转让产生无主空间，
 // 见 db_manager.go removeMemberLocked。
 func (d *DB) removeMemberLocked(spaceId, uid string, rejectRoleAtOrAbove int) error {

--- a/modules/space/db_manager.go
+++ b/modules/space/db_manager.go
@@ -47,6 +47,28 @@ func memberSearchWhere(keyword string) (string, []interface{}) {
 	return strings.Join(clauses, " OR "), args
 }
 
+// memberSearchActiveColumns 空间侧 members/search 端点的检索列。与管理端
+// memberSearchColumns 的区别：
+//   - email 明文匹配、明文返回（工作邮箱，无需掩码）；
+//   - phone 仅匹配后 4 位（RIGHT(u.phone,4)），使「可检索粒度 == 可见粒度」
+//     （响应仅显示 138****5678），admin 无法通过子串查询逐位探测/重建完整号码。
+//
+// 前端注意：phone 检索只匹配后 4 位，传完整号码不会命中——按手机号查找请用后 4 位。
+var memberSearchActiveColumns = []string{"u.name", "u.username", "u.email", "RIGHT(u.phone,4)", "sm.uid"}
+
+// memberSearchActiveWhere 为空间侧 members/search 组装跨列 OR LIKE 条件。
+// list / count 共用同一条件，避免搜索范围漂移导致分页错位。
+func memberSearchActiveWhere(keyword string) (string, []interface{}) {
+	like := buildLikePattern(keyword)
+	clauses := make([]string, len(memberSearchActiveColumns))
+	args := make([]interface{}, len(memberSearchActiveColumns))
+	for i, col := range memberSearchActiveColumns {
+		clauses[i] = col + " LIKE ?" + likeEscapeClause
+		args[i] = like
+	}
+	return strings.Join(clauses, " OR "), args
+}
+
 // placeholders 生成 "?, ?, ?" 形式 placeholder 字符串，n 必须大于 0。
 func placeholders(n int) string {
 	return strings.TrimRight(strings.Repeat("?,", n), ",")
@@ -262,8 +284,8 @@ var ErrSpaceBannedForUpdate = errors.New("space is banned and caller disallowed 
 // 状态守卫契约（事务内强制，关闭 handler 层 guard 与 UPDATE 之间的 TOCTOU 窗口）：
 //   - SpaceStatusDisbanded 永远拒绝（ErrSpaceDisbandedForUpdate）
 //   - SpaceStatusBanned 由 allowBanned 控制：
-//       allowBanned=true（管理端）  → 放行，允许对封禁空间执行修复性更新
-//       allowBanned=false（用户端）→ 拒绝（ErrSpaceBannedForUpdate）
+//     allowBanned=true（管理端）  → 放行，允许对封禁空间执行修复性更新
+//     allowBanned=false（用户端）→ 拒绝（ErrSpaceBannedForUpdate）
 //
 // 用户端 handler 必须传 allowBanned=false：仅在入口用 checkSpaceActive 挡 banned 不够，
 // 入口检查与事务之间存在 race 窗口（manager 并发 ban），事务侧必须再挡一次才闭环。

--- a/modules/space/model.go
+++ b/modules/space/model.go
@@ -18,16 +18,16 @@ const (
 
 // SpaceModel 空间表模型
 type SpaceModel struct {
-	SpaceId        string // 空间ID
-	Name           string // 空间名称
-	Description    string // 空间描述
-	Logo           string // 空间Logo
-	Creator        string // 创建者uid
+	SpaceId        string  // 空间ID
+	Name           string  // 空间名称
+	Description    string  // 空间描述
+	Logo           string  // 空间Logo
+	Creator        string  // 创建者uid
 	MaxUsers       int     // 最大成员数 0.不限制
 	PresetGroupIds *string // 预设群组ID列表（JSON数组）
 	JoinMode       int     // 加入模式 0=直接加入 1=需要审批
 	Status         int     // 状态 1.正常 0.已解散
-	Version        int64  // 版本号
+	Version        int64   // 版本号
 	db.BaseModel
 }
 
@@ -41,15 +41,24 @@ type MemberModel struct {
 	db.BaseModel
 }
 
+type memberSearchModel struct {
+	MemberModel
+	Name     string
+	Username string
+	Email    string
+	Phone    string
+	Robot    int
+}
+
 // InvitationModel 邀请表模型
 type InvitationModel struct {
-	SpaceId    string  // 空间ID
-	InviteCode string  // 邀请码
-	Creator    string  // 创建者uid
-	MaxUses    int     // 最大使用次数
-	UsedCount  int     // 已使用次数
+	SpaceId    string   // 空间ID
+	InviteCode string   // 邀请码
+	Creator    string   // 创建者uid
+	MaxUses    int      // 最大使用次数
+	UsedCount  int      // 已使用次数
 	ExpiresAt  *db.Time // 过期时间
-	Status     int     // 状态 1.有效 0.无效
+	Status     int      // 状态 1.有效 0.无效
 	db.BaseModel
 }
 
@@ -169,6 +178,17 @@ type spaceResp struct {
 type memberResp struct {
 	UID       string `json:"uid"`
 	Name      string `json:"name"`
+	Role      int    `json:"role"`
+	Robot     int    `json:"robot"`
+	CreatedAt string `json:"created_at"`
+}
+
+type memberSearchResp struct {
+	UID       string `json:"uid"`
+	Name      string `json:"name"`
+	Username  string `json:"username"`
+	Email     string `json:"email"`
+	Phone     string `json:"phone"`
 	Role      int    `json:"role"`
 	Robot     int    `json:"robot"`
 	CreatedAt string `json:"created_at"`

--- a/modules/space/swagger/api.yaml
+++ b/modules/space/swagger/api.yaml
@@ -14,6 +14,54 @@ schemes:
 basePath: "/v1"
 
 paths:
+  /space/{space_id}/members/search:
+    get:
+      tags:
+        - "space"
+      summary: "空间成员检索（空间 admin/owner）"
+      description: "空间 admin/owner 分页检索本空间在册成员；keyword 跨列模糊匹配 昵称/用户名/邮箱/手机号/UID。email/phone 返回掩码。含机器人。"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "path"
+          name: "space_id"
+          type: string
+          required: true
+        - in: "query"
+          name: "keyword"
+          type: string
+          required: false
+          description: "子串模糊匹配 name/username/email(明文)/uid；phone 仅匹配后 4 位(传完整号码不命中，前端按手机号检索请用后 4 位)；_/%/\\ 按字面量；为空不过滤"
+        - in: "query"
+          name: "page_index"
+          type: integer
+          required: false
+          description: "页码，<=0 归 1"
+        - in: "query"
+          name: "page_size"
+          type: integer
+          required: false
+          description: "每页条数，省略或 <=0 时为 15，上限 200"
+      responses:
+        200:
+          description: "返回"
+          schema:
+            type: object
+            properties:
+              count:
+                type: integer
+                description: "符合条件的成员总数"
+              list:
+                type: array
+                items:
+                  $ref: "#/definitions/memberSearchResp"
+        400:
+          description: "非成员 / 无权限 / 查询失败"
+          schema:
+            $ref: "#/definitions/response"
+      security:
+        - token: []
+
   /manager/spaces/{space_id}/members:
     get:
       tags:
@@ -67,6 +115,30 @@ paths:
         - token: []
 
 definitions:
+  memberSearchResp:
+    type: object
+    properties:
+      uid:
+        type: string
+      name:
+        type: string
+        description: "昵称"
+      username:
+        type: string
+      email:
+        type: string
+        description: "邮箱（明文，工作邮箱不掩码）"
+      phone:
+        type: string
+        description: "手机号，掩码为 前3+****+后4（如 138****5678）；仅后 4 位可检索"
+      role:
+        type: integer
+        description: "0.普通成员 1.管理员 2.拥有者"
+      robot:
+        type: integer
+        description: "1=机器人 0=否"
+      created_at:
+        type: string
   managerMemberResp:
     type: object
     properties:


### PR DESCRIPTION
## Summary
Adds `GET /v1/space/:space_id/members/search`, a space-scoped, paginated member search for space admins/owners.

## Motivation
The user-side member list (`/v1/space/:space_id/members`) has no keyword search, and the management endpoint (`/v1/manager/spaces/:space_id/members`) is gated on a **platform** role — so a space owner/admin who is a regular platform user cannot search the members of their own space. This endpoint fills that gap, mirroring the existing `/v1/space/:space_id/app_bot` pattern.

## Endpoint
`GET /v1/space/{space_id}/members/search?keyword=&page_index=1&page_size=20`

→ `{ "count": N, "list": [ { uid, name, username, email, phone, role, robot, created_at } ] }`

## Design
- **Authz**: space-level role gate (`role >= admin`); non-member → `ErrSpaceNotMember`, regular member → `ErrSpacePermissionDenied`.
- **Lifecycle gate**: `checkSpaceActive` (strict `space.status=1`) runs first, so banned (status=2) and disbanded (status=0) spaces are rejected — a ban only updates the space row and leaves member rows at `status=1`, so the member-row gate alone is not enough.
- **Search**: keyword (trimmed) matches `name/username/email/uid` as cleartext substrings; **phone matches ONLY its last 4 digits** (`RIGHT(u.phone,4)`). Escaped `LIKE`; `_ / % / \` literal.
- **Visibility**: only `status=1` members; **all bots in the space included** (admin view — intentional divergence from the member-facing list).
- **Privacy**: **email returned in cleartext** (work emails); **phone masked to `138****5678`**. Searchable granularity == visible granularity, so masked phone digits cannot be reconstructed via substring probing. keyword is never logged. ⚠️ **Frontend note**: search phone by its **last 4 digits** — a full number will not match.
- **Envelope & paging**: `{count, list}`; `page_size` clamped to 200, `page_index` capped, deterministic `sm.uid` tie-break, `count=0` short-circuits the list query.
- **Rate limiting**: `SharedUIDRateLimiter`. Swagger 2.0 spec added.

## Test plan
- Authz: non-member / regular-member rejected.
- Lifecycle: banned (status=2) and disbanded (status=0) spaces rejected even for an active owner row.
- Empty keyword returns active members + bots; removed members hidden.
- Keyword column matching, escaping, **email cleartext + phone last-4 mask**, **phone search by last 4**.
- Bots created by others are visible (explicit admin-view decision).
- Empty contact fields stay empty; pagination clamp to 200.
- `go build` / `go vet` / unit tests pass locally; DB-backed integration tests run in CI.

## Review feedback addressed
- **(blocking)** Reject inactive spaces via `checkSpaceActive` — closes the post-ban member/PII exposure hole.
- email cleartext + phone last-4 (search & display) — **removes the masked-PII search oracle**.
- keyword trim; deterministic `uid` tie-break; swagger `page_size` default fixed (15).
- `count=0` short-circuit; `page_index` cap (avoids offset integer overflow); `maskPhone` rune-aware.
- Test: bots from other creators are visible (made the admin-view behavior explicit).

## Known non-blocking follow-ups
- Authz tests assert HTTP status only (400, D14-pinned); they do not yet assert `error.code`.
- Pre-existing (separate PR): `queryMember` returns `(nil, nil)` on a DB error, surfacing a DB failure as "not a member" rather than 5xx — affects ~6 call-sites.
