### PR TITLE
feat(messages_search): keyword optional on _search/_search_all + empty-search guard (reland #388)

### DIFF
--- a/modules/messages_search/dsl_test.go
+++ b/modules/messages_search/dsl_test.go
@@ -59,6 +59,30 @@ func TestBuildSearchMessagesDSL_Shape(t *testing.T) {
 	}
 }
 
+func TestBuildSearchMessagesDSL_NoKeywordSkipsMultiMatch(t *testing.T) {
+	req := SearchMessagesReq{
+		ChannelType: channelTypeGroup,
+		ChannelID:   "groupNo",
+	}
+	q := buildSearchMessagesDSL(req, "groupNo", "")
+	js, _ := json.Marshal(extractDSL(t, q.(interface {
+		Source() (any, error)
+	})))
+	body := string(js)
+	if strings.Contains(body, "multi_match") {
+		t.Errorf("search_messages DSL with empty keyword must not include multi_match:\n%s", body)
+	}
+	for _, want := range []string{
+		`"channelId":"groupNo"`,
+		`"revoked":true`,
+		`"payload.type":99`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("empty-keyword DSL missing %q in:\n%s", want, body)
+		}
+	}
+}
+
 func TestBuildSearchMediaDSL_FiltersTypes(t *testing.T) {
 	req := SearchMediaReq{ChannelType: channelTypeGroup, ChannelID: "g"}
 	q := buildSearchMediaDSL(req, "g", "")
@@ -121,6 +145,36 @@ func TestBuildSearchAllDSL_TypeFilter(t *testing.T) {
 		if !strings.Contains(body, want) && !strings.Contains(body, strings.ReplaceAll(want, ",", ", ")) {
 			t.Errorf("search_all DSL missing %q in:\n%s", want, body)
 		}
+	}
+}
+
+func TestBuildSearchAllDSL_NoKeywordKeepsTypeFilter(t *testing.T) {
+	req := SearchMessagesReq{ChannelType: channelTypeGroup, ChannelID: "g"}
+	q := buildSearchAllDSL(req, "g", "")
+	js, _ := json.Marshal(extractDSL(t, q.(interface {
+		Source() (any, error)
+	})))
+	body := string(js)
+	if strings.Contains(body, "multi_match") {
+		t.Errorf("search_all DSL with empty keyword must not include multi_match:\n%s", body)
+	}
+	if strings.Contains(body, "minimum_should_match") {
+		t.Errorf("search_all DSL with empty keyword must not include minimum_should_match:\n%s", body)
+	}
+	if strings.Contains(body, `"should"`) {
+		t.Errorf("search_all DSL with empty keyword must not include a should clause:\n%s", body)
+	}
+	for _, want := range []string{
+		`"channelId":"g"`,
+		`"revoked":true`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("empty-keyword search_all DSL missing %q in:\n%s", want, body)
+		}
+	}
+	// type filter must still segment message vs file
+	if !strings.Contains(body, `"payload.type":[1,8,11]`) && !strings.Contains(body, `"payload.type":[1, 8, 11]`) {
+		t.Errorf("empty-keyword search_all DSL must still filter payload.type [1,8,11]:\n%s", body)
 	}
 }
 

--- a/modules/messages_search/search_all.go
+++ b/modules/messages_search/search_all.go
@@ -36,10 +36,13 @@ func (h *Handler) searchAll(c *wkhttp.Context) {
 	req.Keyword = strings.TrimSpace(req.Keyword)
 	loginUID := c.GetLoginUID()
 
-	if !validateKeywordRequired(c, req.Keyword) {
+	if !validateKeywordOptional(c, req.Keyword) {
 		return
 	}
-	pageSize, ok := validateBase(c, h.cfg, req.ChannelType, req.ChannelID, req.Sort, req.Cursor, req.Filters, req.PageSize, true)
+	if !validateSearchNotEmpty(c, req.Keyword, req.Filters) {
+		return
+	}
+	pageSize, ok := validateBase(c, h.cfg, req.ChannelType, req.ChannelID, req.Sort, req.Cursor, req.Filters, req.PageSize, req.Keyword != "")
 	if !ok {
 		return
 	}
@@ -80,9 +83,11 @@ func (h *Handler) searchAll(c *wkhttp.Context) {
 			Index(h.cfg.OSReadAlias).
 			Routing(normID).
 			Query(dsl).
-			Highlight(buildSearchAllHighlight()).
 			Size(size).
 			TrackTotalHits(false)
+		if req.Keyword != "" {
+			svc = svc.Highlight(buildSearchAllHighlight())
+		}
 		svc = applySort(svc, req.Sort)
 		if len(searchAfter) > 0 {
 			svc = svc.SearchAfter(searchAfter...)
@@ -127,17 +132,19 @@ func buildSearchAllDSL(req SearchAllReq, normChannelID, spaceID string) elastic.
 		payloadTypeMergeForward,
 	))
 	addCommonFilters(b, req.Filters)
-	b.Should(
-		elastic.NewMultiMatchQuery(req.Keyword,
-			"payload.text.content^3",
-			"payload.mergeForward.msgs.searchText",
-		),
-		elastic.NewMultiMatchQuery(req.Keyword,
-			"payload.file.name^2",
-			"payload.file.caption",
-		),
-	)
-	b.MinimumShouldMatch("1")
+	if req.Keyword != "" {
+		b.Should(
+			elastic.NewMultiMatchQuery(req.Keyword,
+				"payload.text.content^3",
+				"payload.mergeForward.msgs.searchText",
+			),
+			elastic.NewMultiMatchQuery(req.Keyword,
+				"payload.file.name^2",
+				"payload.file.caption",
+			),
+		)
+		b.MinimumShouldMatch("1")
+	}
 	return b
 }
 

--- a/modules/messages_search/search_messages.go
+++ b/modules/messages_search/search_messages.go
@@ -41,10 +41,13 @@ func (h *Handler) searchMessages(c *wkhttp.Context) {
 	req.Keyword = strings.TrimSpace(req.Keyword)
 	loginUID := c.GetLoginUID()
 
-	if !validateKeywordRequired(c, req.Keyword) {
+	if !validateKeywordOptional(c, req.Keyword) {
 		return
 	}
-	pageSize, ok := validateBase(c, h.cfg, req.ChannelType, req.ChannelID, req.Sort, req.Cursor, req.Filters, req.PageSize, true)
+	if !validateSearchNotEmpty(c, req.Keyword, req.Filters) {
+		return
+	}
+	pageSize, ok := validateBase(c, h.cfg, req.ChannelType, req.ChannelID, req.Sort, req.Cursor, req.Filters, req.PageSize, req.Keyword != "")
 	if !ok {
 		return
 	}
@@ -85,9 +88,11 @@ func (h *Handler) searchMessages(c *wkhttp.Context) {
 			Index(h.cfg.OSReadAlias).
 			Routing(normID).
 			Query(dsl).
-			Highlight(buildSearchMessagesHighlight()).
 			Size(size).
 			TrackTotalHits(false)
+		if req.Keyword != "" {
+			svc = svc.Highlight(buildSearchMessagesHighlight())
+		}
 		svc = applySort(svc, req.Sort)
 		if len(searchAfter) > 0 {
 			svc = svc.SearchAfter(searchAfter...)
@@ -126,12 +131,14 @@ func (h *Handler) searchMessages(c *wkhttp.Context) {
 // buildSearchMessagesDSL constructs the bool query for /_search.
 func buildSearchMessagesDSL(req SearchMessagesReq, normChannelID, spaceID string) elastic.Query {
 	b := elastic.NewBoolQuery()
-	b.Must(elastic.NewMultiMatchQuery(req.Keyword,
-		"payload.text.content^3",
-		"payload.image.caption", "payload.image.name",
-		"payload.file.caption", "payload.file.name",
-		"payload.mergeForward.msgs.searchText",
-	))
+	if req.Keyword != "" {
+		b.Must(elastic.NewMultiMatchQuery(req.Keyword,
+			"payload.text.content^3",
+			"payload.image.caption", "payload.image.name",
+			"payload.file.caption", "payload.file.name",
+			"payload.mergeForward.msgs.searchText",
+		))
+	}
 	applyChannelAndRevoked(b, normChannelID)
 	applySpaceIDScope(b, req.ChannelType, spaceID)
 	addCommonFilters(b, req.Filters)

--- a/modules/messages_search/swagger/api.yaml
+++ b/modules/messages_search/swagger/api.yaml
@@ -29,7 +29,7 @@ paths:
         - "messages_search"
       operationId: "message.search"
       summary: "Search text + forward messages"
-      description: "Full-text search across text/forward/image/file payload fields scoped to a single channel. Required keyword."
+      description: "Full-text search across text/forward/image/file payload fields scoped to a single channel. Keyword is optional — when empty the endpoint returns the channel's messages in time order (relevance sort then requires a non-empty keyword). An empty keyword requires at least one filter (sender_ids/sent_at_*); keyword + filter both empty is rejected with 400."
       consumes:
         - "application/json"
       produces:
@@ -188,7 +188,7 @@ paths:
         - "messages_search"
       operationId: "message.search_all"
       summary: "Search across messages and files"
-      description: "Combined search across text/forward and files in a single channel; required keyword."
+      description: "Combined search across text/forward and files in a single channel. Keyword is optional — when empty the endpoint mixes messages and files in time order (relevance sort then requires a non-empty keyword). An empty keyword requires at least one filter (sender_ids/sent_at_*); keyword + filter both empty is rejected with 400."
       consumes:
         - "application/json"
       produces:
@@ -348,7 +348,6 @@ definitions:
     required:
       - channel_type
       - channel_id
-      - keyword
     properties:
       channel_type:
         type: integer

--- a/modules/messages_search/validate.go
+++ b/modules/messages_search/validate.go
@@ -25,13 +25,16 @@ type SearchFilters struct {
 
 // SearchMessagesReq is the request body for POST /v1/messages/_search.
 //
-// `Keyword` is required and non-empty per A doc §2.1. `Sort` accepts
-// time_desc (default) | time_asc | relevance. `PageSize` is normalised into
-// [1, 100] with a default of 20.
+// `Keyword` is optional; when empty the DSL drops the multi_match clause and
+// the endpoint behaves as a time-ordered listing. To prevent an unconditional
+// full-channel scan, an empty keyword still requires at least one effective
+// filter (see validateSearchNotEmpty). `Sort` accepts time_desc (default) |
+// time_asc | relevance — relevance requires a non-empty keyword. `PageSize` is
+// normalised into [1, 100] with a default of 20.
 type SearchMessagesReq struct {
 	ChannelType uint8         `json:"channel_type"`
 	ChannelID   string        `json:"channel_id"`
-	Keyword     string        `json:"keyword"`
+	Keyword     string        `json:"keyword,omitempty"`
 	Filters     SearchFilters `json:"filters,omitempty"`
 	Sort        string        `json:"sort,omitempty"`
 	PageSize    int           `json:"page_size,omitempty"`
@@ -65,7 +68,7 @@ type SearchFilesReq struct {
 }
 
 // SearchAllReq is the request body for POST /v1/messages/_search_all. Same
-// shape as _search; keyword required.
+// shape as _search; keyword optional and gated identically.
 type SearchAllReq = SearchMessagesReq
 
 // SearchAroundReq is the request body for POST /v1/messages/_search_around.
@@ -163,11 +166,10 @@ func validateBase(c *wkhttp.Context, cfg SearchConfig, channelType uint8, channe
 	return page, true
 }
 
-// validateKeywordRequired runs the keyword length / non-empty check.
-func validateKeywordRequired(c *wkhttp.Context, keyword string) bool {
+// validateKeywordOptional accepts an empty keyword but still bounds length.
+func validateKeywordOptional(c *wkhttp.Context, keyword string) bool {
 	if keyword == "" {
-		respondValidation(c, "keyword", "required")
-		return false
+		return true
 	}
 	if utf8.RuneCountInString(keyword) > maxKeywordLen {
 		respondValidationDetails(c, i18n.Details{
@@ -180,17 +182,42 @@ func validateKeywordRequired(c *wkhttp.Context, keyword string) bool {
 	return true
 }
 
-// validateKeywordOptional accepts an empty keyword but still bounds length.
-func validateKeywordOptional(c *wkhttp.Context, keyword string) bool {
-	if keyword == "" {
+// hasEffectiveFilters reports whether the structured filters carry at least one
+// clause that survives DSL construction. It mirrors addCommonFilters' own
+// emptiness handling so the validator and the query builder agree on what
+// "has a filter" means:
+//
+//   - sender_ids is effective only if it contains a non-empty (trimmed) id.
+//     `{"sender_ids":[""]}` is NOT effective — dsl.go::addCommonFilters drops
+//     empty strings and would otherwise emit no terms clause, degenerating into
+//     a full-channel scan. This is the documented bypass the guard must close.
+//   - sent_at_from / sent_at_to is effective if either bound is set (trimmed).
+//
+// Keeping this in lockstep with addCommonFilters is the invariant: anything
+// that would not produce an OS filter clause must not count as a filter here.
+func hasEffectiveFilters(filters SearchFilters) bool {
+	for _, s := range filters.SenderIDs {
+		if strings.TrimSpace(s) != "" {
+			return true
+		}
+	}
+	if strings.TrimSpace(filters.SentAtFrom) != "" {
 		return true
 	}
-	if utf8.RuneCountInString(keyword) > maxKeywordLen {
-		respondValidationDetails(c, i18n.Details{
-			"field":      "keyword",
-			"reason":     "too long",
-			"max_length": maxKeywordLen,
-		})
+	if strings.TrimSpace(filters.SentAtTo) != "" {
+		return true
+	}
+	return false
+}
+
+// validateSearchNotEmpty is the empty-search guard for the keyword-optional
+// endpoints (_search / _search_all). With no keyword AND no effective filter,
+// the query degenerates into an unconditional full-channel scan that can pin
+// OpenSearch; reject it with 400 instead. keyword is assumed already trimmed by
+// the caller.
+func validateSearchNotEmpty(c *wkhttp.Context, keyword string, filters SearchFilters) bool {
+	if keyword == "" && !hasEffectiveFilters(filters) {
+		respondValidation(c, "keyword", "keyword or at least one filter is required")
 		return false
 	}
 	return true

--- a/modules/messages_search/validate_test.go
+++ b/modules/messages_search/validate_test.go
@@ -104,3 +104,111 @@ func TestValidateBase_MalformedCursorRejected(t *testing.T) {
 		t.Fatalf("cursor rejection must render a validation envelope, got %q", rec.Body.String())
 	}
 }
+
+// sort=relevance with allowRelevance=false (the empty-keyword path) must be
+// refused — relevance has no _score to sort on when the multi_match clause is
+// dropped. The user-facing body is rendered through i18n templates so the
+// raw reason string is not asserted here (other validate tests follow the
+// same envelope-only pattern); the rejection itself is the contract.
+func TestValidateBase_RelevanceRequiresKeyword(t *testing.T) {
+	c, rec := newValidateCtx(t)
+	_, ok := validateBase(c, SearchConfig{}, channelTypeGroup, "G1", "relevance", "",
+		SearchFilters{}, 20, false)
+	if ok {
+		t.Fatalf("sort=relevance without keyword (allowRelevance=false) must be rejected")
+	}
+	if rec.Body.Len() == 0 {
+		t.Fatalf("rejection must render a VALIDATION_ERROR envelope")
+	}
+
+	// And the symmetric positive: with allowRelevance=true (keyword present)
+	// the same sort value passes — guards against regressing the gate.
+	c2, _ := newValidateCtx(t)
+	if _, ok := validateBase(c2, SearchConfig{}, channelTypeGroup, "G1", "relevance", "",
+		SearchFilters{}, 20, true); !ok {
+		t.Fatalf("sort=relevance with allowRelevance=true must be accepted")
+	}
+}
+
+// Empty-search guard: empty keyword AND no effective filter must be rejected
+// with a VALIDATION_ERROR — that combination degenerates into an unconditional
+// full-channel scan that can pin OpenSearch.
+func TestValidateSearchNotEmpty_EmptyKeywordEmptyFilter_Rejected(t *testing.T) {
+	c, rec := newValidateCtx(t)
+	if validateSearchNotEmpty(c, "", SearchFilters{}) {
+		t.Fatalf("empty keyword + empty filter must be rejected")
+	}
+	if rec.Body.Len() == 0 {
+		t.Fatalf("rejection must render a VALIDATION_ERROR envelope")
+	}
+}
+
+// 🔴 Bypass point: a sender_ids list of only empty strings must NOT count as a
+// filter. dsl.go::addCommonFilters trims empty ids and emits no terms clause,
+// so `{"sender_ids":[""]}` with an empty keyword still degenerates into a full
+// scan. The guard must reject it the same as a wholly empty filter.
+func TestValidateSearchNotEmpty_EmptyKeywordBlankSenderIDs_Rejected(t *testing.T) {
+	for _, senders := range [][]string{
+		{""},
+		{"", "  "},
+		{"\t", " "},
+	} {
+		c, rec := newValidateCtx(t)
+		if validateSearchNotEmpty(c, "", SearchFilters{SenderIDs: senders}) {
+			t.Fatalf("empty keyword + blank sender_ids %v must be rejected (bypass point)", senders)
+		}
+		if rec.Body.Len() == 0 {
+			t.Fatalf("rejection must render a VALIDATION_ERROR envelope for %v", senders)
+		}
+	}
+}
+
+// An empty keyword with at least one effective filter is allowed — this is the
+// keyword-optional listing path the guard must NOT block.
+func TestValidateSearchNotEmpty_EmptyKeywordEffectiveFilter_Accepted(t *testing.T) {
+	cases := []SearchFilters{
+		{SenderIDs: []string{"u1"}},
+		{SenderIDs: []string{"", "u2"}},
+		{SentAtFrom: "2026-01-01"},
+		{SentAtTo: "2026-12-31"},
+	}
+	for _, f := range cases {
+		c, _ := newValidateCtx(t)
+		if !validateSearchNotEmpty(c, "", f) {
+			t.Fatalf("empty keyword with effective filter %+v must be accepted", f)
+		}
+	}
+}
+
+// A non-empty keyword always passes the guard regardless of filters.
+func TestValidateSearchNotEmpty_KeywordPresent_Accepted(t *testing.T) {
+	c, _ := newValidateCtx(t)
+	if !validateSearchNotEmpty(c, "hello", SearchFilters{}) {
+		t.Fatalf("non-empty keyword must be accepted with no filters")
+	}
+}
+
+// hasEffectiveFilters must agree with addCommonFilters on what "has a filter"
+// means — blank-only sender_ids and untrimmed-empty time bounds are not
+// effective.
+func TestHasEffectiveFilters(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters SearchFilters
+		want    bool
+	}{
+		{"empty", SearchFilters{}, false},
+		{"blank sender", SearchFilters{SenderIDs: []string{""}}, false},
+		{"whitespace sender", SearchFilters{SenderIDs: []string{"  ", "\t"}}, false},
+		{"real sender", SearchFilters{SenderIDs: []string{"u1"}}, true},
+		{"mixed sender", SearchFilters{SenderIDs: []string{"", "u1"}}, true},
+		{"from set", SearchFilters{SentAtFrom: "2026-01-01"}, true},
+		{"to set", SearchFilters{SentAtTo: "2026-01-01"}, true},
+		{"blank from", SearchFilters{SentAtFrom: "   "}, false},
+	}
+	for _, tc := range tests {
+		if got := hasEffectiveFilters(tc.filters); got != tc.want {
+			t.Errorf("%s: hasEffectiveFilters=%v want %v", tc.name, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Relands the keyword-optional capability for `/v1/messages/_search` and `/v1/messages/_search_all` (originally proposed by @BrDing-Rookie in #388), plus the empty-search 400 guard so the two land together (no "full empty search pins OpenSearch" gap).

This is a clean reland from a fork branch based on current `main` (on top of #387 `c60bbd8`), opened by the maintainer side after the external contributor paused. Original authorship preserved via `Co-authored-by`.

## Changes

**keyword optional (from #388):**
- swap `validateKeywordRequired` → `validateKeywordOptional` in `search_messages.go` / `search_all.go`; remove the now-unused helper
- gate `multi_match` in `buildSearchMessagesDSL` on `keyword != ""`
- gate `should` + `minimum_should_match` in `buildSearchAllDSL` on `keyword != ""` (empty branch drops both, aligning with `search_files`' empty-keyword drop)
- only attach `Highlight()` when keyword is non-empty
- `sort=relevance` requires a non-empty keyword
- swagger: drop keyword from `SearchMessagesReq.required`; refresh descriptions

**empty-search guard (B2 backend):**
- new `validateSearchNotEmpty`: empty keyword AND no effective filter → 400
- new `hasEffectiveFilters` mirrors `addCommonFilters`: trims + drops empty `sender_ids` and empty time bounds, so `{"sender_ids":[""]}` does NOT count as a filter (closes the full-channel-scan bypass)
- wired into both `_search` and `_search_all` before `validateBase`

## Cross-space isolation (unchanged, verified)

`applySpaceIDScope` guard is preserved; P2P search always attaches the spaceId term. `OCTO_SEARCH_REQUIRE_SPACE_ID` defaults to `true` (config.go) with no override in deployment, so empty-keyword search remains fail-closed.

## Tests

`go test ./modules/messages_search/...` — 30/30 PASS, covering:
- empty keyword skips multi_match (`_search`) / skips should+minimum_should_match (`_search_all`) while channel/revoked/payload.type filters stay
- P2P space-scoped DSL (around/anchor) + RequireSpaceID fail-closed (+ escape hatch + whitespace-as-missing)
- relevance requires keyword
- empty kw + empty filter → 400, `{"sender_ids":[""]}` bypass → 400, empty kw + effective filter → ok

## Note on #388

Supersedes #388 (same capability, rebased on current main, with the empty-search guard added so they land atomically). Closing #388 in favor of this.

Co-authored-by: BrDing-Rookie <brding.rookie@users.noreply.github.com>
