### PR TITLE
test(messages_search): drift-guard + empty-keyword accept-path DSL assertions

### DIFF
--- a/modules/messages_search/accept_path_dsl_test.go
+++ b/modules/messages_search/accept_path_dsl_test.go
@@ -1,0 +1,139 @@
+package messages_search
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// The existing empty-keyword DSL tests prove the *rejection* path (multi_match
+// omitted, blank sender_ids dropped). These tests prove the *acceptance* path:
+// when an empty-keyword request carries a real filter, the DSL actually emits
+// the corresponding OpenSearch clause. Without these, a regression that dropped
+// the filter clause would still pass the existing suite (no multi_match, guard
+// happy) while silently turning every listing into a full-channel scan.
+
+// emptyKeywordDSLBody builds the _search DSL for an empty-keyword request and
+// returns its JSON body for clause assertions.
+func emptyKeywordDSLBody(t *testing.T, req SearchMessagesReq, normChannelID, spaceID string) string {
+	t.Helper()
+	if req.Keyword != "" {
+		t.Fatalf("test bug: req.Keyword must be empty to exercise the listing path")
+	}
+	q := buildSearchMessagesDSL(req, normChannelID, spaceID)
+	js, err := json.Marshal(extractDSL(t, q.(interface {
+		Source() (any, error)
+	})))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := string(js)
+	if strings.Contains(body, "multi_match") {
+		t.Fatalf("empty-keyword DSL must not include multi_match:\n%s", body)
+	}
+	return body
+}
+
+// TestEmptyKeyword_RealSenderIDsEmitsTermsClause — empty keyword + a real
+// sender id must produce a `terms` clause on `from`, proving the listing path
+// reaches OpenSearch with a bounding filter (not a full scan).
+func TestEmptyKeyword_RealSenderIDsEmitsTermsClause(t *testing.T) {
+	req := SearchMessagesReq{
+		ChannelType: channelTypeGroup,
+		ChannelID:   "G1",
+		Filters:     SearchFilters{SenderIDs: []string{"", "u-real"}}, // blank dropped, u-real kept
+	}
+	body := emptyKeywordDSLBody(t, req, "G1", "")
+	if !strings.Contains(body, `"terms"`) || !strings.Contains(body, `"from"`) {
+		t.Fatalf("empty-keyword + sender_ids must emit a terms clause on `from`:\n%s", body)
+	}
+	if !strings.Contains(body, `"u-real"`) {
+		t.Fatalf("terms clause must carry the real sender id:\n%s", body)
+	}
+	if strings.Contains(body, `""`) && strings.Contains(body, `"from":["",`) {
+		t.Fatalf("blank sender id must be dropped, not emitted as a term:\n%s", body)
+	}
+}
+
+// TestEmptyKeyword_SentAtEmitsRangeClause — empty keyword + a time window must
+// produce a `range` clause on `timestamp` with the parsed bounds.
+func TestEmptyKeyword_SentAtEmitsRangeClause(t *testing.T) {
+	req := SearchMessagesReq{
+		ChannelType: channelTypeGroup,
+		ChannelID:   "G1",
+		Filters:     SearchFilters{SentAtFrom: "2026-01-01", SentAtTo: "2026-12-31"},
+	}
+	body := emptyKeywordDSLBody(t, req, "G1", "")
+	if !strings.Contains(body, `"range"`) || !strings.Contains(body, `"timestamp"`) {
+		t.Fatalf("empty-keyword + sent_at must emit a range clause on `timestamp`:\n%s", body)
+	}
+	// olivere/elastic serialises Gte/Lte as from/to + include_lower/include_upper.
+	if !strings.Contains(body, `"from":1767196800`) || !strings.Contains(body, `"to":1798732799`) {
+		t.Fatalf("range clause must carry both lower (from) and upper (to) bounds:\n%s", body)
+	}
+}
+
+// TestEmptyKeyword_P2PSpaceIDEmitsTermFilter — empty keyword + p2p with a
+// resolved spaceId must still emit the spaceId term filter (the cross-Space
+// isolation clause), proving the listing path stays fail-closed per Space.
+func TestEmptyKeyword_P2PSpaceIDEmitsTermFilter(t *testing.T) {
+	req := SearchMessagesReq{
+		ChannelType: channelTypePerson,
+		ChannelID:   "peer",
+		// p2p empty-keyword listing is gated by the guard on having a filter;
+		// here spaceId itself plus a sender id keep it a legitimate request.
+		Filters: SearchFilters{SenderIDs: []string{"u-real"}},
+	}
+	body := emptyKeywordDSLBody(t, req, "fake-cid", "spaceX")
+	if !strings.Contains(body, `"spaceId":"spaceX"`) {
+		t.Fatalf("empty-keyword p2p DSL must keep the spaceId term filter:\n%s", body)
+	}
+}
+
+// TestEmptyKeyword_AllFiltersEmitAllClauses — the combined listing request
+// (sender + time window + p2p space) must emit every clause at once, the full
+// shape the web channel-search UI sends when filtering without a keyword.
+func TestEmptyKeyword_AllFiltersEmitAllClauses(t *testing.T) {
+	req := SearchMessagesReq{
+		ChannelType: channelTypePerson,
+		ChannelID:   "peer",
+		Filters: SearchFilters{
+			SenderIDs:  []string{"u-real"},
+			SentAtFrom: "2026-01-01",
+			SentAtTo:   "2026-12-31",
+		},
+	}
+	body := emptyKeywordDSLBody(t, req, "fake-cid", "spaceX")
+	for _, want := range []string{
+		`"terms"`, `"from"`, `"u-real"`,
+		`"range"`, `"timestamp"`, `"from":1767196800`, `"to":1798732799`,
+		`"spaceId":"spaceX"`,
+		`"channelId":"fake-cid"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("combined empty-keyword listing DSL missing %q in:\n%s", want, body)
+		}
+	}
+}
+
+// TestBuildSearchAllDSL_EmptyKeywordRealSenderEmitsTerms — same acceptance
+// proof for _search_all (the second keyword-optional endpoint), so both
+// listing endpoints have a live-path assertion, not just _search.
+func TestBuildSearchAllDSL_EmptyKeywordRealSenderEmitsTerms(t *testing.T) {
+	req := SearchAllReq{
+		ChannelType: channelTypeGroup,
+		ChannelID:   "G1",
+		Filters:     SearchFilters{SenderIDs: []string{"u-real"}},
+	}
+	q := buildSearchAllDSL(req, "G1", "")
+	js, _ := json.Marshal(extractDSL(t, q.(interface {
+		Source() (any, error)
+	})))
+	body := string(js)
+	if strings.Contains(body, "multi_match") {
+		t.Fatalf("empty-keyword _search_all must not include multi_match:\n%s", body)
+	}
+	if !strings.Contains(body, `"terms"`) || !strings.Contains(body, `"u-real"`) {
+		t.Fatalf("empty-keyword _search_all + sender_ids must emit a terms clause:\n%s", body)
+	}
+}

--- a/modules/messages_search/filter_drift_test.go
+++ b/modules/messages_search/filter_drift_test.go
@@ -1,0 +1,84 @@
+package messages_search
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/olivere/elastic"
+)
+
+// effectiveFilterSamples maps each exported SearchFilters field to a request
+// in which ONLY that field is set to a representative, effective value.
+//
+// This registry is the anti-drift hinge between the validator guard
+// (validate.go::hasEffectiveFilters) and the DSL builder
+// (dsl.go::addCommonFilters). Both hardcode the same field set independently,
+// so adding a new shared filter (e.g. message_types) to one without the other
+// silently breaks the "empty keyword + new filter" listing path:
+//   - wired into addCommonFilters but NOT hasEffectiveFilters → a legitimate
+//     empty-keyword search carrying only the new filter is wrongly rejected 400.
+//   - wired into hasEffectiveFilters but NOT addCommonFilters → the guard lets
+//     the request through but the DSL emits no clause, degenerating into the
+//     full-channel scan the guard exists to prevent.
+//
+// TestSearchFilters_NoUnregisteredFields below uses reflection to force a new
+// struct field to appear here; the per-sample assertions then fail until BOTH
+// the guard and the builder agree on it. Keeping this registry complete is the
+// invariant that lets the two functions stay hardcoded yet provably in sync.
+var effectiveFilterSamples = map[string]SearchFilters{
+	"SenderIDs":  {SenderIDs: []string{"u1"}},
+	"SentAtFrom": {SentAtFrom: "2026-01-01"},
+	"SentAtTo":   {SentAtTo: "2026-12-31"},
+}
+
+// TestSearchFilters_NoUnregisteredFields fails when a new exported field is
+// added to SearchFilters without registering an effective sample above. The
+// failure message points the author at the three places a shared filter must
+// be wired so the guard and the builder cannot drift apart.
+func TestSearchFilters_NoUnregisteredFields(t *testing.T) {
+	ft := reflect.TypeOf(SearchFilters{})
+	for i := 0; i < ft.NumField(); i++ {
+		name := ft.Field(i).Name
+		if _, ok := effectiveFilterSamples[name]; !ok {
+			t.Fatalf("SearchFilters.%s has no effectiveFilterSamples entry.\n"+
+				"A new shared filter must be wired in THREE places that must stay in lockstep:\n"+
+				"  1) validate.go::hasEffectiveFilters — so empty-keyword + this filter passes the guard\n"+
+				"  2) dsl.go::addCommonFilters — so it emits an OpenSearch clause (no full-channel scan)\n"+
+				"  3) effectiveFilterSamples (this test) — a sample proving 1 and 2 agree", name)
+		}
+	}
+}
+
+// TestEffectiveFilterSamples_GuardAndBuilderAgree is the actual drift assertion.
+// For every registered field, the validator guard must count it as effective
+// AND the DSL builder must emit a filter clause for it. If either side forgets
+// the field, exactly one of these fails — making the inconsistency a red test
+// rather than a production 400 or a silent full-channel scan.
+func TestEffectiveFilterSamples_GuardAndBuilderAgree(t *testing.T) {
+	for field, sample := range effectiveFilterSamples {
+		// Guard side: hasEffectiveFilters must recognise the lone filter.
+		if !hasEffectiveFilters(sample) {
+			t.Errorf("hasEffectiveFilters(%s sample)=false; validator would reject a legitimate "+
+				"empty-keyword + %s search (guard out of sync with addCommonFilters)", field, field)
+		}
+
+		// Builder side: addCommonFilters must emit at least one OS clause.
+		b := elastic.NewBoolQuery()
+		addCommonFilters(b, sample)
+		src, err := b.Source()
+		if err != nil {
+			t.Fatalf("%s: bool Source(): %v", field, err)
+		}
+		js, err := json.Marshal(src)
+		if err != nil {
+			t.Fatalf("%s: marshal: %v", field, err)
+		}
+		if !strings.Contains(string(js), `"filter"`) {
+			t.Errorf("addCommonFilters(%s sample) emitted no filter clause; an empty-keyword search "+
+				"carrying only this filter would degenerate into a full-channel scan even though the "+
+				"guard let it through:\n%s", field, js)
+		}
+	}
+}


### PR DESCRIPTION
## What

Two non-blocking test-only follow-ups from the #395 review (empty-keyword search + empty-search guard).

### 1. Anti-drift guard: `hasEffectiveFilters` ↔ `addCommonFilters`

`validate.go::hasEffectiveFilters` (the empty-search guard) and `dsl.go::addCommonFilters` (the query builder) independently hardcode the same `SearchFilters` field set. Adding a new shared filter (e.g. `message_types`) to one without the other silently breaks the "empty keyword + new filter" listing path:
- wired into the builder but not the guard → a legitimate empty-keyword search carrying only the new filter is wrongly rejected `400`.
- wired into the guard but not the builder → the request passes but the DSL emits no clause, degenerating into the full-channel scan the guard exists to prevent.

`filter_drift_test.go` adds a reflection test that forces every exported `SearchFilters` field to register an effective sample, plus a per-sample assertion that the guard counts it AND the builder emits an OpenSearch clause for it. A new field with no sample fails immediately with a message pointing at the three places to wire it. Verified load-bearing: temporarily adding a `MessageTypes` field made the test fail as designed.

### 2. Accept-path DSL assertions

The existing empty-keyword tests only prove the reject path (no `multi_match`, blank `sender_ids` dropped). `accept_path_dsl_test.go` proves the listing path is alive: empty keyword + real `sender_ids` / `sent_at` window / p2p `spaceId` actually emit the corresponding `terms` / `range` / `spaceId` clauses on both `_search` and `_search_all`. A regression that dropped a filter clause would have passed the old suite while silently turning every listing into a full-channel scan.

## Test

- `go test ./modules/messages_search/...` → PASS
- `go build ./...`, `go vet ./modules/messages_search/...` → clean
- `gofmt` clean

Test-only; no production code touched.

Part of #395
