### PR TITLE
fix(space): add display-name fallback for blank user.name (#344)

### DIFF
--- a/modules/space/api_test.go
+++ b/modules/space/api_test.go
@@ -60,6 +60,10 @@ func TestMain(m *testing.M) {
 		// username/phone 对齐生产 user 表（modules/user/sql/20191106000003），管理端成员搜索按这两列做 LIKE 匹配。
 		"DROP TABLE IF EXISTS `user`",
 		"CREATE TABLE `user` (id BIGINT AUTO_INCREMENT PRIMARY KEY, uid VARCHAR(40) NOT NULL DEFAULT '', name VARCHAR(100) DEFAULT '', username VARCHAR(40) DEFAULT '', email VARCHAR(200) DEFAULT '', phone VARCHAR(20) DEFAULT '', avatar VARCHAR(200) DEFAULT '', robot SMALLINT DEFAULT 0, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, UNIQUE KEY idx_uid(uid)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+		// user_verification 表：member 列表/搜索的 display-name 兜底链 LEFT JOIN 它取 real_name
+		// （issue #344）。生产 DDL 见 modules/user/sql/20260505000003_user_legacy01.sql；
+		// 这里只建测试所需的 user_id/real_name 两列，IF NOT EXISTS 复用同库即可。
+		"CREATE TABLE IF NOT EXISTS user_verification (user_id VARCHAR(40) NOT NULL, real_name VARCHAR(128) NOT NULL DEFAULT '', source VARCHAR(40) DEFAULT '', source_sub VARCHAR(128) DEFAULT '', verified_at TIMESTAMP NULL, PRIMARY KEY (user_id)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
 	}
 	for _, ddl := range depDDLs {
 		if _, err := db.Exec(ddl); err != nil {

--- a/modules/space/api_test.go
+++ b/modules/space/api_test.go
@@ -61,9 +61,24 @@ func TestMain(m *testing.M) {
 		"DROP TABLE IF EXISTS `user`",
 		"CREATE TABLE `user` (id BIGINT AUTO_INCREMENT PRIMARY KEY, uid VARCHAR(40) NOT NULL DEFAULT '', name VARCHAR(100) DEFAULT '', username VARCHAR(40) DEFAULT '', email VARCHAR(200) DEFAULT '', phone VARCHAR(20) DEFAULT '', avatar VARCHAR(200) DEFAULT '', robot SMALLINT DEFAULT 0, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, UNIQUE KEY idx_uid(uid)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
 		// user_verification 表：member 列表/搜索的 display-name 兜底链 LEFT JOIN 它取 real_name
-		// （issue #344）。生产 DDL 见 modules/user/sql/20260505000003_user_legacy01.sql；
-		// 这里只建测试所需的 user_id/real_name 两列，IF NOT EXISTS 复用同库即可。
-		"CREATE TABLE IF NOT EXISTS user_verification (user_id VARCHAR(40) NOT NULL, real_name VARCHAR(128) NOT NULL DEFAULT '', source VARCHAR(40) DEFAULT '', source_sub VARCHAR(128) DEFAULT '', verified_at TIMESTAMP NULL, PRIMARY KEY (user_id)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+		// 使用与生产迁移一致的完整 DDL（20260505000003_user_legacy01.sql），
+		// 先 DROP 再 CREATE 避免截断版 IF NOT EXISTS 在共享 test DB 上被跳过，
+		// 导致后续测试包缺列。
+		"DROP TABLE IF EXISTS user_verification",
+		`CREATE TABLE user_verification (
+			user_id     VARCHAR(40)  NOT NULL COMMENT 'OCTO 用户 UID',
+			real_name   VARCHAR(128) NOT NULL COMMENT '实名',
+			source      VARCHAR(32)  NOT NULL COMMENT '实名来源: cas/wecom/feishu',
+			source_sub  VARCHAR(128) NOT NULL COMMENT '来源侧 sub',
+			emp_id      VARCHAR(64)  DEFAULT NULL COMMENT '工号',
+			dept        VARCHAR(255) DEFAULT NULL COMMENT '部门',
+			email       VARCHAR(255) DEFAULT NULL COMMENT '邮箱',
+			mobile      VARCHAR(32)  DEFAULT NULL COMMENT '手机号',
+			verified_at DATETIME     NOT NULL COMMENT '实名完成时间（UTC）',
+			updated_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			PRIMARY KEY (user_id),
+			KEY idx_user_verification_source (source, source_sub)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci`,
 	}
 	for _, ddl := range depDDLs {
 		if _, err := db.Exec(ddl); err != nil {

--- a/modules/space/db.go
+++ b/modules/space/db.go
@@ -146,10 +146,16 @@ func (d *DB) queryMemberIncludeRemoved(spaceId string, uid string) (*MemberModel
 func (d *DB) queryMembers(spaceId string, loginUID string, page uint64, limit uint64) ([]*MemberDetailModel, error) {
 	var models []*MemberDetailModel
 	_, err := d.session.SelectBySql(`
-		SELECT sm.*, IFNULL(u.name,'') as name,
+		SELECT sm.*,
+			CASE
+				WHEN u.name IS NOT NULL AND u.name <> '' THEN u.name
+				WHEN uv.real_name IS NOT NULL AND uv.real_name <> '' THEN uv.real_name
+				ELSE CONCAT('User-', LEFT(sm.uid, 6))
+			END AS name,
 			CASE WHEN r.robot_id IS NOT NULL AND r.status=1 THEN 1 ELSE 0 END as robot
 		FROM space_member sm
 		LEFT JOIN user u ON u.uid=sm.uid
+		LEFT JOIN user_verification uv ON uv.user_id=sm.uid
 		LEFT JOIN robot r ON r.robot_id=sm.uid
 		WHERE sm.space_id=? AND sm.status=1 AND (
 			r.robot_id IS NULL
@@ -164,13 +170,18 @@ func (d *DB) queryMembers(spaceId string, loginUID string, page uint64, limit ui
 func (d *DB) searchMembers(spaceId, keyword string, pageIndex, pageSize int) ([]*memberSearchModel, error) {
 	builder := d.session.Select(
 		"sm.*",
-		"IFNULL(u.name,'') as name",
+		`CASE
+			WHEN u.name IS NOT NULL AND u.name <> '' THEN u.name
+			WHEN uv.real_name IS NOT NULL AND uv.real_name <> '' THEN uv.real_name
+			ELSE CONCAT('User-', LEFT(sm.uid, 6))
+		END AS name`,
 		"IFNULL(u.username,'') as username",
 		"IFNULL(u.email,'') as email",
 		"IFNULL(u.phone,'') as phone",
 		"CASE WHEN r.robot_id IS NOT NULL AND r.status=1 THEN 1 ELSE 0 END as robot",
 	).From(dbr.I("space_member").As("sm")).
 		LeftJoin(dbr.I("user").As("u"), "u.uid=sm.uid").
+		LeftJoin(dbr.I("user_verification").As("uv"), "uv.user_id=sm.uid").
 		LeftJoin(dbr.I("robot").As("r"), "r.robot_id=sm.uid").
 		Where("sm.space_id=? AND sm.status=1", spaceId)
 	if keyword != "" {

--- a/modules/space/db.go
+++ b/modules/space/db.go
@@ -203,6 +203,7 @@ func (d *DB) countSearchMembers(spaceId, keyword string) (int64, error) {
 	builder := d.session.Select("COUNT(*)").
 		From(dbr.I("space_member").As("sm")).
 		LeftJoin(dbr.I("user").As("u"), "u.uid=sm.uid").
+		LeftJoin(dbr.I("user_verification").As("uv"), "uv.user_id=sm.uid").
 		Where("sm.space_id=? AND sm.status=1", spaceId)
 	if keyword != "" {
 		clause, args := memberSearchActiveWhere(keyword)

--- a/modules/space/db_manager.go
+++ b/modules/space/db_manager.go
@@ -54,7 +54,7 @@ func memberSearchWhere(keyword string) (string, []interface{}) {
 //     （响应仅显示 138****5678），admin 无法通过子串查询逐位探测/重建完整号码。
 //
 // 前端注意：phone 检索只匹配后 4 位，传完整号码不会命中——按手机号查找请用后 4 位。
-var memberSearchActiveColumns = []string{"u.name", "u.username", "u.email", "RIGHT(u.phone,4)", "sm.uid", "uv.real_name"}
+var memberSearchActiveColumns = []string{"u.name", "u.username", "u.email", "RIGHT(u.phone,4)", "sm.uid"}
 
 // memberSearchActiveWhere 为空间侧 members/search 组装跨列 OR LIKE 条件。
 // list / count 共用同一条件，避免搜索范围漂移导致分页错位。

--- a/modules/space/db_manager.go
+++ b/modules/space/db_manager.go
@@ -54,28 +54,31 @@ func memberSearchWhere(keyword string) (string, []interface{}) {
 //     （响应仅显示 138****5678），admin 无法通过子串查询逐位探测/重建完整号码。
 //
 // 前端注意：phone 检索只匹配后 4 位，传完整号码不会命中——按手机号查找请用后 4 位。
-//
-// real_name 单独处理：仅在 user.name 为空时才加入 OR 条件（见 memberSearchActiveWhere），
-// 保证「可检索 == 可见」，消除 PII 探测 oracle。
-var memberSearchActiveColumns = []string{"u.name", "u.username", "u.email", "RIGHT(u.phone,4)", "sm.uid"}
+// memberSearchActiveColumns 空间侧 members/search 非 name 维度的检索列。
+// name 维度单独用 CASE 表达式（见 memberSearchActiveWhere），保证可检索 == 可见。
+var memberSearchActiveColumns = []string{"u.username", "u.email", "RIGHT(u.phone,4)", "sm.uid"}
 
 // memberSearchActiveWhere 为空间侧 members/search 组装跨列 OR LIKE 条件。
 // list / count 共用同一条件，避免搜索范围漂移导致分页错位。
 //
-// real_name 特殊处理：
-//   只在 u.name 为空（NULL 或 ''）时才 OR uv.real_name LIKE ?，
-//   确保「可检索 == 可见」——real_name 兜底展示的场景下才允许按 real_name 检索，
-//   避免对 user.name 非空用户产生 PII 探测 oracle。
+// name 维度用与展示 CASE 完全一致的表达式搜索，保证「可检索 == 可见」：
+//   - user.name 非空 → 只能按 user.name 匹配，real_name 不可探测
+//   - user.name 为空 → 按 real_name 匹配（与展示一致，无 PII oracle）
+//   - 两者均空      → 按 User-<uid[:6]> 占位符匹配
 func memberSearchActiveWhere(keyword string) (string, []interface{}) {
 	like := buildLikePattern(keyword)
+	// 非 name 列的普通 LIKE 条件
 	clauses := make([]string, len(memberSearchActiveColumns))
 	args := make([]interface{}, len(memberSearchActiveColumns))
 	for i, col := range memberSearchActiveColumns {
 		clauses[i] = col + " LIKE ?" + likeEscapeClause
 		args[i] = like
 	}
-	// 仅当 u.name 为空时才允许按 real_name 检索，保证可检索 == 可见，防 PII oracle。
-	clauses = append(clauses, "((u.name IS NULL OR u.name = '') AND uv.real_name LIKE ?"+likeEscapeClause+")")
+	// name 维度：CASE 表达式与 SELECT 展示逻辑字节完全一致，保证可检索 == 可见
+	nameCASE := "(CASE WHEN u.name IS NOT NULL AND u.name <> '' THEN u.name" +
+		" WHEN uv.real_name IS NOT NULL AND uv.real_name <> '' THEN uv.real_name" +
+		" ELSE CONCAT('User-', LEFT(sm.uid, 6)) END)"
+	clauses = append(clauses, nameCASE+" LIKE ?"+likeEscapeClause)
 	args = append(args, like)
 	return strings.Join(clauses, " OR "), args
 }

--- a/modules/space/db_manager.go
+++ b/modules/space/db_manager.go
@@ -32,7 +32,7 @@ func buildLikePattern(keyword string) string {
 // email/username 对 SSO / 邮箱登录用户尤为关键：这类用户 username 可能为空，
 // 只能靠 email 定位（与 user 模块 queryUserListWithPageAndKeyword 的取向一致）。
 // u.* 来自 LEFT JOIN 的 user 表，sm.uid 来自 space_member 自身。
-var memberSearchColumns = []string{"u.name", "u.username", "u.email", "u.phone", "sm.uid"}
+var memberSearchColumns = []string{"u.name", "u.username", "u.email", "u.phone", "sm.uid", "uv.real_name"}
 
 // memberSearchWhere 按 keyword 组装跨列 OR LIKE 条件及其占位参数。
 // list / count 两处共用，避免搜索范围漂移导致"列表与总数样本不一致"的分页错位。
@@ -54,7 +54,7 @@ func memberSearchWhere(keyword string) (string, []interface{}) {
 //     （响应仅显示 138****5678），admin 无法通过子串查询逐位探测/重建完整号码。
 //
 // 前端注意：phone 检索只匹配后 4 位，传完整号码不会命中——按手机号查找请用后 4 位。
-var memberSearchActiveColumns = []string{"u.name", "u.username", "u.email", "RIGHT(u.phone,4)", "sm.uid"}
+var memberSearchActiveColumns = []string{"u.name", "u.username", "u.email", "RIGHT(u.phone,4)", "sm.uid", "uv.real_name"}
 
 // memberSearchActiveWhere 为空间侧 members/search 组装跨列 OR LIKE 条件。
 // list / count 共用同一条件，避免搜索范围漂移导致分页错位。

--- a/modules/space/db_manager.go
+++ b/modules/space/db_manager.go
@@ -32,7 +32,7 @@ func buildLikePattern(keyword string) string {
 // email/username 对 SSO / 邮箱登录用户尤为关键：这类用户 username 可能为空，
 // 只能靠 email 定位（与 user 模块 queryUserListWithPageAndKeyword 的取向一致）。
 // u.* 来自 LEFT JOIN 的 user 表，sm.uid 来自 space_member 自身。
-var memberSearchColumns = []string{"u.name", "u.username", "u.email", "u.phone", "sm.uid", "uv.real_name"}
+var memberSearchColumns = []string{"u.name", "u.username", "u.email", "u.phone", "sm.uid"}
 
 // memberSearchWhere 按 keyword 组装跨列 OR LIKE 条件及其占位参数。
 // list / count 两处共用，避免搜索范围漂移导致"列表与总数样本不一致"的分页错位。

--- a/modules/space/db_manager.go
+++ b/modules/space/db_manager.go
@@ -47,17 +47,25 @@ func memberSearchWhere(keyword string) (string, []interface{}) {
 	return strings.Join(clauses, " OR "), args
 }
 
-// memberSearchActiveColumns 空间侧 members/search 端点的检索列。与管理端
-// memberSearchColumns 的区别：
+// memberSearchActiveColumns 空间侧 members/search 端点的基础检索列（不含 real_name）。
+// 与管理端 memberSearchColumns 的区别：
 //   - email 明文匹配、明文返回（工作邮箱，无需掩码）；
 //   - phone 仅匹配后 4 位（RIGHT(u.phone,4)），使「可检索粒度 == 可见粒度」
 //     （响应仅显示 138****5678），admin 无法通过子串查询逐位探测/重建完整号码。
 //
 // 前端注意：phone 检索只匹配后 4 位，传完整号码不会命中——按手机号查找请用后 4 位。
+//
+// real_name 单独处理：仅在 user.name 为空时才加入 OR 条件（见 memberSearchActiveWhere），
+// 保证「可检索 == 可见」，消除 PII 探测 oracle。
 var memberSearchActiveColumns = []string{"u.name", "u.username", "u.email", "RIGHT(u.phone,4)", "sm.uid"}
 
 // memberSearchActiveWhere 为空间侧 members/search 组装跨列 OR LIKE 条件。
 // list / count 共用同一条件，避免搜索范围漂移导致分页错位。
+//
+// real_name 特殊处理：
+//   只在 u.name 为空（NULL 或 ''）时才 OR uv.real_name LIKE ?，
+//   确保「可检索 == 可见」——real_name 兜底展示的场景下才允许按 real_name 检索，
+//   避免对 user.name 非空用户产生 PII 探测 oracle。
 func memberSearchActiveWhere(keyword string) (string, []interface{}) {
 	like := buildLikePattern(keyword)
 	clauses := make([]string, len(memberSearchActiveColumns))
@@ -66,6 +74,9 @@ func memberSearchActiveWhere(keyword string) (string, []interface{}) {
 		clauses[i] = col + " LIKE ?" + likeEscapeClause
 		args[i] = like
 	}
+	// 仅当 u.name 为空时才允许按 real_name 检索，保证可检索 == 可见，防 PII oracle。
+	clauses = append(clauses, "((u.name IS NULL OR u.name = '') AND uv.real_name LIKE ?"+likeEscapeClause+")")
+	args = append(args, like)
 	return strings.Join(clauses, " OR "), args
 }
 

--- a/modules/space/db_test.go
+++ b/modules/space/db_test.go
@@ -1,0 +1,116 @@
+package space
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedUserVerification 往 user_verification 写一条实名记录（issue #344 display-name 兜底链）。
+func seedUserVerification(t *testing.T, uid, realName string) {
+	t.Helper()
+	_, err := testCtx.DB().InsertBySql(
+		"INSERT INTO user_verification (user_id, real_name, source, source_sub) VALUES (?, ?, 'aegis', ?) "+
+			"ON DUPLICATE KEY UPDATE real_name=VALUES(real_name)",
+		uid, realName, "sub-"+uid,
+	).Exec()
+	require.NoError(t, err)
+}
+
+// findMemberDetail 在 queryMembers 结果里按 uid 找成员。
+func findMemberDetail(list []*MemberDetailModel, uid string) (*MemberDetailModel, bool) {
+	for _, m := range list {
+		if m.UID == uid {
+			return m, true
+		}
+	}
+	return nil, false
+}
+
+// TestQueryMembersDisplayNameFallback 验证 member 列表的 display-name 兜底链（issue #344）：
+//
+//	user.name → user_verification.real_name（已实名用户）→ "User-" + left(uid,6) 占位符
+//
+// 修复前空间成员若 user.name 为空（OIDC IdP 未下发 name claim）会返回空 name 字段。
+func TestQueryMembersDisplayNameFallback(t *testing.T) {
+	_, _, err := setup(t)
+	require.NoError(t, err)
+
+	spaceId := "sp-name-fallback"
+	owner := "owner-name-fallback"
+	seedMemberSearchSpace(t, spaceId, owner)
+
+	const (
+		namedUID       = "uid-named-001"
+		verifiedUID    = "uid-verified-002"
+		placeholderUID = "uidplaceholder003"
+	)
+
+	// 1. user.name 非空 → 直接用 user.name
+	seedMemberSearchUser(t, namedUID, "Alice", "alice", "", "")
+	seedMemberSearchMember(t, spaceId, namedUID, 0, 1)
+
+	// 2. user.name 空但 user_verification.real_name 有值 → 用 real_name
+	seedMemberSearchUser(t, verifiedUID, "", "bob", "", "")
+	seedUserVerification(t, verifiedUID, "Bob Real")
+	seedMemberSearchMember(t, spaceId, verifiedUID, 0, 1)
+
+	// 3. user.name 空且无实名记录 → "User-" + left(uid,6) 占位符
+	seedMemberSearchUser(t, placeholderUID, "", "carol", "", "")
+	seedMemberSearchMember(t, spaceId, placeholderUID, 0, 1)
+
+	members, err := testSpaceDB.queryMembers(spaceId, owner, 1, 50)
+	require.NoError(t, err)
+
+	named, ok := findMemberDetail(members, namedUID)
+	require.True(t, ok, "named member should be present")
+	assert.Equal(t, "Alice", named.Name)
+
+	verified, ok := findMemberDetail(members, verifiedUID)
+	require.True(t, ok, "verified member should be present")
+	assert.Equal(t, "Bob Real", verified.Name)
+
+	placeholder, ok := findMemberDetail(members, placeholderUID)
+	require.True(t, ok, "placeholder member should be present")
+	assert.Equal(t, "User-"+placeholderUID[:6], placeholder.Name)
+	assert.NotEmpty(t, placeholder.Name, "name must never be empty (issue #344)")
+}
+
+// TestSearchMembersDisplayNameFallback 验证成员搜索（空 keyword 返回全部）走同一条兜底链。
+func TestSearchMembersDisplayNameFallback(t *testing.T) {
+	_, _, err := setup(t)
+	require.NoError(t, err)
+
+	spaceId := "sp-search-name-fallback"
+	owner := "owner-search-fallback"
+	seedMemberSearchSpace(t, spaceId, owner)
+
+	const (
+		namedUID       = "uid-s-named-001"
+		verifiedUID    = "uid-s-verified-002"
+		placeholderUID = "uidsplaceholder03"
+	)
+
+	seedMemberSearchUser(t, namedUID, "Alice", "s-alice", "", "")
+	seedMemberSearchMember(t, spaceId, namedUID, 0, 1)
+
+	seedMemberSearchUser(t, verifiedUID, "", "s-bob", "", "")
+	seedUserVerification(t, verifiedUID, "Bob Real")
+	seedMemberSearchMember(t, spaceId, verifiedUID, 0, 1)
+
+	seedMemberSearchUser(t, placeholderUID, "", "s-carol", "", "")
+	seedMemberSearchMember(t, spaceId, placeholderUID, 0, 1)
+
+	list, err := testSpaceDB.searchMembers(spaceId, "", 1, 50)
+	require.NoError(t, err)
+
+	byUID := map[string]string{}
+	for _, m := range list {
+		byUID[m.UID] = m.Name
+	}
+
+	assert.Equal(t, "Alice", byUID[namedUID])
+	assert.Equal(t, "Bob Real", byUID[verifiedUID])
+	assert.Equal(t, "User-"+placeholderUID[:6], byUID[placeholderUID])
+}

--- a/modules/space/db_test.go
+++ b/modules/space/db_test.go
@@ -114,3 +114,51 @@ func TestSearchMembersDisplayNameFallback(t *testing.T) {
 	assert.Equal(t, "Bob Real", byUID[verifiedUID])
 	assert.Equal(t, "User-"+placeholderUID[:6], byUID[placeholderUID])
 }
+
+// TestSearchMembersKeywordByRealName 验证 real_name 仅在 user.name 为空时参与 keyword 检索（防 PII oracle）。
+func TestSearchMembersKeywordByRealName(t *testing.T) {
+	_, _, err := setup(t)
+	require.NoError(t, err)
+
+	spaceId := "sp-keyword-realname"
+	owner := "owner-keyword-realname"
+	seedMemberSearchSpace(t, spaceId, owner)
+
+	// 用户 A：user.name 非空，有 real_name → keyword=real_name 不应命中（PII oracle 防护）
+	namedUID := "uid-kw-named-001"
+	seedMemberSearchUser(t, namedUID, "DisplayName", "kw-alice", "", "")
+	seedUserVerification(t, namedUID, "Alice Real")
+	seedMemberSearchMember(t, spaceId, namedUID, 0, 1)
+
+	// 用户 B：user.name 为空，有 real_name → keyword=real_name 应命中（可检索==可见）
+	verifiedUID := "uid-kw-verified-002"
+	seedMemberSearchUser(t, verifiedUID, "", "kw-bob", "", "")
+	seedUserVerification(t, verifiedUID, "Bob Real")
+	seedMemberSearchMember(t, spaceId, verifiedUID, 0, 1)
+
+	// 场景 1：按 "Alice Real"（用户 A 的 real_name）搜索 → 不命中（user.name 非空，防 oracle）
+	list, err := testSpaceDB.searchMembers(spaceId, "Alice Real", 1, 50)
+	require.NoError(t, err)
+	uids := make([]string, 0, len(list))
+	for _, m := range list {
+		uids = append(uids, m.UID)
+	}
+	assert.NotContains(t, uids, namedUID, "user.name 非空时 real_name 不应参与 keyword 搜索")
+
+	count, err := testSpaceDB.countSearchMembers(spaceId, "Alice Real")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count, "count 应与 list 一致")
+
+	// 场景 2：按 "Bob Real"（用户 B 的 real_name）搜索 → 命中（user.name 为空，可检索==可见）
+	list2, err := testSpaceDB.searchMembers(spaceId, "Bob Real", 1, 50)
+	require.NoError(t, err)
+	uids2 := make([]string, 0, len(list2))
+	for _, m := range list2 {
+		uids2 = append(uids2, m.UID)
+	}
+	assert.Contains(t, uids2, verifiedUID, "user.name 为空时 real_name 应参与 keyword 搜索")
+
+	count2, err := testSpaceDB.countSearchMembers(spaceId, "Bob Real")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count2, "count 应与 list 一致")
+}

--- a/modules/space/db_test.go
+++ b/modules/space/db_test.go
@@ -11,7 +11,7 @@ import (
 func seedUserVerification(t *testing.T, uid, realName string) {
 	t.Helper()
 	_, err := testCtx.DB().InsertBySql(
-		"INSERT INTO user_verification (user_id, real_name, source, source_sub) VALUES (?, ?, 'aegis', ?) "+
+		"INSERT INTO user_verification (user_id, real_name, source, source_sub, verified_at) VALUES (?, ?, 'aegis', ?, NOW()) "+
 			"ON DUPLICATE KEY UPDATE real_name=VALUES(real_name)",
 		uid, realName, "sub-"+uid,
 	).Exec()


### PR DESCRIPTION
## Summary

Fixes #344

When a user registers via OIDC and the IdP issues no `name` claim, `user.name` stays permanently empty. This PR adds a three-level fallback chain at query time in the member list and member search paths:

`user.name` → `user_verification.real_name` (verified users) → `User-{uid[:6]}` (placeholder)

## Changes

- `modules/space/db.go`: Add `LEFT JOIN user_verification` and replace `IFNULL(u.name,'')` with a `CASE` fallback in both `queryMembers` and `searchMembers`; extend keyword search (`memberSearchActiveColumns`) to also match `uv.real_name`; keep `memberSearchColumns` (admin path) unchanged to avoid regression
- `modules/space/db_test.go`: New test file covering all three fallback branches and keyword-search via `real_name`
- `modules/space/api_test.go`: Add full-schema `user_verification` DDL (DROP + CREATE with all production columns) to test harness

## Testing

`go build ./...` ✅  `go vet ./...` ✅

Unit tests cover:
- Member with non-empty `user.name` → returns `user.name`
- Member with empty `user.name` but `user_verification.real_name` present → returns `real_name`
- Member with both empty → returns `User-{uid[:6]}` placeholder
- Keyword search matching via `real_name`