### PR TITLE
feat(appconfig): emit messages_search_on alongside search_enabled

### DIFF
--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -396,13 +396,18 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 	if err != nil && versionStr != "" {
 		cn.Warn("解析版本号失败", zap.String("version", versionStr), zap.Error(err))
 	}
+	// 消息搜索开关：search_enabled / messages_search_on 同源同值。前者保留向后兼容，
+	// 后者是收敛后的真源 key（与 octo-web ChannelSearch、octo-admin messages_search
+	// 命名一致）。两个分支共用同一计算结果，避免 Resolve 被调用多次。
+	searchEnabled := searchbackend.Resolve(cn.ctx.GetConfig().ZincSearch.SearchOn).SearchEnabled()
 	if versionI64 != 0 && int(versionI64) >= appConfigM.Version {
 		c.JSON(http.StatusOK, &appConfigResp{
 			Version:                appConfigM.Version,
 			SystemBotUIDs:          spacepkg.SystemBotList(),
 			LocalLoginOff:          boolToFlag(cn.systemSettings.LocalLoginOff()),
 			DisableUserCreateSpace: boolToFlag(cn.systemSettings.SpaceDisableUserCreate()),
-			SearchEnabled:          searchbackend.Resolve(cn.ctx.GetConfig().ZincSearch.SearchOn).SearchEnabled(),
+			SearchEnabled:          searchEnabled,
+			MessagesSearchOn:       searchEnabled,
 		})
 		return
 	}
@@ -441,7 +446,8 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 		SystemBotUIDs:          spacepkg.SystemBotList(),
 		LocalLoginOff:          boolToFlag(cn.systemSettings.LocalLoginOff()),
 		DisableUserCreateSpace: boolToFlag(cn.systemSettings.SpaceDisableUserCreate()),
-		SearchEnabled:          searchbackend.Resolve(cn.ctx.GetConfig().ZincSearch.SearchOn).SearchEnabled(),
+		SearchEnabled:          searchEnabled,
+		MessagesSearchOn:       searchEnabled,
 	})
 }
 
@@ -764,6 +770,13 @@ type appConfigResp struct {
 	// 与 app_config.version 解耦的原因同 LocalLoginOff / DisableUserCreateSpace：
 	// 运维切 backend 后老客户端命中 version 短路分支也必须拿到最新值。
 	SearchEnabled bool `json:"search_enabled"`
+
+	// MessagesSearchOn 与 SearchEnabled 同源同值，是消息搜索功能开关下发给前端
+	// 的「收敛后」key。Web 端 (octo-web ChannelSearch) 读 messages_search_on，
+	// 与 octo-admin 的 messages_search 命名保持一致；旧端仍读 search_enabled。
+	// 两字段并存：search_enabled 保留作向后兼容，messages_search_on 为新真源 key。
+	// 下发 bool，前端 parseRemoteBool(true) 即可正确开关，无需 0/1 特判。
+	MessagesSearchOn bool `json:"messages_search_on"`
 }
 
 type oidcProviderResp struct {

--- a/modules/common/api_test.go
+++ b/modules/common/api_test.go
@@ -167,6 +167,66 @@ func TestGetAppConfig_SystemBotUIDsOnVersionShortCircuit(t *testing.T) {
 	assert.Contains(t, body, `"fileHelper"`)
 }
 
+// 消息搜索开关下发：search_enabled 与 messages_search_on 必须同源同值。
+// messages_search_on 是收敛后的真源 key（octo-web ChannelSearch 读它，与
+// octo-admin messages_search 命名一致），search_enabled 保留作向后兼容。
+// OCTO_SEARCH_BACKEND=es → 两者都为 true。
+func TestGetAppConfig_MessagesSearchOn_Enabled(t *testing.T) {
+	t.Setenv("OCTO_SEARCH_BACKEND", "es")
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `"messages_search_on":true`)
+	assert.Contains(t, body, `"search_enabled":true`)
+}
+
+// OCTO_SEARCH_BACKEND=disabled → messages_search_on 与 search_enabled 均为
+// false，前端据此隐藏 ChannelSearch 入口。
+func TestGetAppConfig_MessagesSearchOn_Disabled(t *testing.T) {
+	t.Setenv("OCTO_SEARCH_BACKEND", "disabled")
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `"messages_search_on":false`)
+	assert.Contains(t, body, `"search_enabled":false`)
+}
+
+// version 短路分支同样要下发 messages_search_on：老客户端命中版本短路也必须
+// 拿到当前开关，否则被缓存住失去实时性（与 search_enabled / disable_user_create_space
+// 同样的「与 app_config.version 解耦」约束）。
+func TestGetAppConfig_MessagesSearchOn_OnVersionShortCircuit(t *testing.T) {
+	t.Setenv("OCTO_SEARCH_BACKEND", "es")
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig?version=99999999", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `"messages_search_on":true`)
+	assert.Contains(t, body, `"search_enabled":true`)
+}
+
 // appconfig 必须下发 disable_user_create_space：默认 0（缺 system_setting 行且
 // env 未设置）。客户端据此显示/隐藏「创建空间」入口；缺省必须保持开放。
 func TestGetAppConfig_DisableUserCreateSpace_DefaultsZero(t *testing.T) {


### PR DESCRIPTION
## What

`/v1/common/appconfig` now emits a new boolean field `messages_search_on` alongside the existing `search_enabled`.

## Why

The web client (octo-web ChannelSearch, #386) gates its search entry on `appconfig.messages_search_on`, but the backend only emitted `search_enabled`. The keys never matched, so the flag could never turn on and the search entry never appeared.

Per the agreed convergence, `messages_search_on` is the canonical key (matches octo-admin's `messages_search` naming). `search_enabled` is kept for backward compatibility with existing clients (iOS/Android/older web).

## How

Both fields are populated from the same resolved value — `searchbackend.Resolve(cfg.ZincSearch.SearchOn).SearchEnabled()` — in **both** response branches (normal response and the `version` short-circuit), so old and new clients stay in sync and the new field is also delivered to clients that hit the version short-circuit. The value is computed once and reused.

The field is a bool; the web client's `parseRemoteBool(true)` reads it correctly with no 0/1 special-casing.

## Tests

Added 3 tests in `modules/common/api_test.go`:
- `OCTO_SEARCH_BACKEND=es` → both `messages_search_on` and `search_enabled` are `true`.
- `OCTO_SEARCH_BACKEND=disabled` → both `false`.
- version short-circuit branch also emits `messages_search_on`.

All pass (`go test ./modules/common/ -run TestGetAppConfig`). Full `go build ./...` and `go vet ./modules/common/...` clean.

Part of #395
