### PR TITLE
fix: invalidate offline-push name cache on group/thread rename

### DIFF
--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
 	spacemod "github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/pushcache"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"github.com/gocraft/dbr/v2"
 	"go.uber.org/zap"
@@ -1806,6 +1807,12 @@ func (s *Service) UpdateGroupInfo(req *UpdateGroupInfoServiceReq) error {
 
 	// 发布群更新事件（name 和 notice 分开发送）
 	if req.Name != nil {
+		// 群名变更后失效离线推送标题缓存（modules/webhook 侧按群名缓存推送标题），否则手机
+		// 推送标题会沿用旧名直到 TTL 过期（最长 Cache.NameCacheExpire）。best-effort：缓存
+		// 已落库的改名是事实，失效失败仅告警，TTL 仍是兜底。必须在事务提交后执行。
+		if err := pushcache.InvalidateGroupName(s.ctx.GetRedisConn(), req.GroupNo); err != nil {
+			s.Warn("失效群名推送缓存失败", zap.String("group_no", req.GroupNo), zap.Error(err))
+		}
 		s.ctx.SendGroupUpdate(&config.MsgGroupUpdateReq{
 			GroupNo:      req.GroupNo,
 			Operator:     req.OperatorUID,

--- a/modules/group/service_pushcache_test.go
+++ b/modules/group/service_pushcache_test.go
@@ -1,0 +1,65 @@
+package group
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/pushcache"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestUpdateGroupInfo_InvalidatesPushNameCache 验证群改名后，离线推送标题缓存
+// (pushcache.GroupNameKey) 被主动失效，避免手机推送在 TTL 到期前一直沿用旧群名。
+func TestUpdateGroupInfo_InvalidatesPushNameCache(t *testing.T) {
+	svc, _, ctx := setupServiceTestWithCtx(t)
+
+	groupNo := strings.ReplaceAll(util.GenerUUID(), "-", "")
+	err := NewDB(ctx).Insert(&Model{GroupNo: groupNo, Name: "旧群名", Creator: testutil.UID, Status: 1, Version: 1})
+	assert.NoError(t, err)
+
+	// 预置一条旧群名缓存，模拟此前推送已写入缓存的状态。
+	key := pushcache.GroupNameKey(groupNo)
+	assert.NoError(t, ctx.GetRedisConn().Set(key, "旧群名"))
+
+	newName := "新群名"
+	err = svc.UpdateGroupInfo(&UpdateGroupInfoServiceReq{
+		GroupNo:      groupNo,
+		OperatorUID:  testutil.UID,
+		OperatorName: "操作者",
+		Name:         &newName,
+	})
+	assert.NoError(t, err)
+
+	// 改名后缓存应被删除，下一次推送会回源拿到新群名。
+	cached, err := ctx.GetRedisConn().GetString(key)
+	assert.NoError(t, err)
+	assert.Empty(t, cached, "群改名后应失效推送群名缓存")
+}
+
+// TestUpdateGroupInfo_NoticeOnlyKeepsPushNameCache 验证只改公告(不改名)时不会动群名缓存，
+// 避免无谓的回源。
+func TestUpdateGroupInfo_NoticeOnlyKeepsPushNameCache(t *testing.T) {
+	svc, _, ctx := setupServiceTestWithCtx(t)
+
+	groupNo := strings.ReplaceAll(util.GenerUUID(), "-", "")
+	err := NewDB(ctx).Insert(&Model{GroupNo: groupNo, Name: "群名", Creator: testutil.UID, Status: 1, Version: 1})
+	assert.NoError(t, err)
+
+	key := pushcache.GroupNameKey(groupNo)
+	assert.NoError(t, ctx.GetRedisConn().Set(key, "群名"))
+
+	notice := "新公告"
+	err = svc.UpdateGroupInfo(&UpdateGroupInfoServiceReq{
+		GroupNo:      groupNo,
+		OperatorUID:  testutil.UID,
+		OperatorName: "操作者",
+		Notice:       &notice,
+	})
+	assert.NoError(t, err)
+
+	cached, err := ctx.GetRedisConn().GetString(key)
+	assert.NoError(t, err)
+	assert.Equal(t, "群名", cached, "仅改公告不应失效群名缓存")
+}

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/pushcache"
 	"go.uber.org/zap"
 )
 
@@ -408,6 +409,13 @@ func (s *Service) UpdateName(groupNo, shortID, operatorUID, name string) error {
 			return errors.New("thread has been deleted")
 		}
 		return fmt.Errorf("update thread name: %w", err)
+	}
+
+	// 子区改名后失效离线推送标题缓存（推送标题含子区名），否则手机推送会沿用旧子区名直到
+	// TTL 过期。best-effort：失败仅告警，TTL 兜底。
+	channelID := BuildChannelID(groupNo, shortID)
+	if err := pushcache.InvalidateThreadName(s.ctx.GetRedisConn(), channelID); err != nil {
+		s.Warn("失效子区名推送缓存失败", zap.String("channel_id", channelID), zap.Error(err))
 	}
 	return nil
 }

--- a/modules/webhook/common.go
+++ b/modules/webhook/common.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/pushcache"
 	"github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"go.uber.org/zap"
 )
@@ -36,9 +37,7 @@ const EventOnlineStatus = "user.onlinestatus"
 const EventMsgNotify = "msg.notify"
 
 const (
-	nameCachePrefix        string = "name:"
-	groupNameCachePrefix   string = "groupName:"
-	threadTitleCachePrefix string = "threadTitle:"
+	nameCachePrefix string = "name:"
 )
 
 type PayloadInfo struct {
@@ -106,7 +105,7 @@ func ParsePushInfo(msgResp msgOfflineNotify, ctx *config.Context, toUser *user.R
 	if msgResp.ChannelType == common.ChannelTypePerson.Uint8() {
 		payloadInfo.Title = fromName
 	} else if msgResp.ChannelType == common.ChannelTypeCommunityTopic.Uint8() {
-		threadTitle, err := getAndCacheThreadTitle(msgResp, ctx)
+		threadTitle, err := getThreadPushTitle(msgResp, ctx)
 		if err != nil {
 			log.Error("获取子区推送标题失败", zap.Error(err), zap.String("channel_id", msgResp.ChannelID))
 			return nil, err
@@ -122,7 +121,7 @@ func ParsePushInfo(msgResp msgOfflineNotify, ctx *config.Context, toUser *user.R
 		content = formatGroupPushBody(ctx, threadGroupNo, msgResp.FromUID, fromName, content)
 	} else {
 		var groupName string
-		groupName, err = getAndCacheGroupName(msgResp, ctx)
+		groupName, err = getCachedGroupName(msgResp.ChannelID, ctx)
 		if err != nil {
 			log.Error("获取群名失败！", zap.Error(err), zap.String("group_no", msgResp.ChannelID))
 			return nil, err
@@ -283,29 +282,30 @@ func getAndCacheShowNameForFromUID(msgResp msgOfflineNotify, ctx *config.Context
 	return name, nil
 }
 
-// 获取和缓存群名
-func getAndCacheGroupName(msgResp msgOfflineNotify, ctx *config.Context) (string, error) {
-	db := getWebhookDB(ctx)
-
-	key := fmt.Sprintf("%s%s", groupNameCachePrefix, msgResp.ChannelID)
+// getCachedGroupName 读取群名（用作推送标题），命中缓存直接返回，否则回源 DB 并写入
+// 带 TTL 的缓存。缓存 key 由 pushcache 统一定义，群改名时由 modules/group 主动失效，
+// 避免推送标题在 TTL 到期前一直沿用旧名。
+func getCachedGroupName(groupNo string, ctx *config.Context) (string, error) {
+	key := pushcache.GroupNameKey(groupNo)
 	groupName, err := ctx.GetRedisConn().GetString(key)
 	if err != nil {
 		return "", err
 	}
-	if groupName == "" {
-		groupName, err = db.GetGroupName(msgResp.ChannelID)
-		if err != nil {
-			return "", err
-		}
-		err = ctx.GetRedisConn().Set(key, groupName)
-		if err != nil {
-			return "", err
-		}
-		err = ctx.GetRedisConn().Expire(key, ctx.GetConfig().Cache.NameCacheExpire)
-		if err != nil {
-			log.Error("设置群名过期时间失败！", zap.String("key", key), zap.Error(err))
-			return "", err
-		}
+	if groupName != "" {
+		return groupName, nil
+	}
+
+	groupName, err = getWebhookDB(ctx).GetGroupName(groupNo)
+	if err != nil {
+		return "", err
+	}
+	if err = ctx.GetRedisConn().Set(key, groupName); err != nil {
+		return "", err
+	}
+	// Expire 失败不影响本次取名：群名已成功取到（并已写入缓存，只是少了 TTL）。失败仅告警、
+	// 继续返回，避免一次瞬时 Redis 错误把整条推送打挂（群推送和子区推送共用本函数）。
+	if err = ctx.GetRedisConn().Expire(key, ctx.GetConfig().Cache.NameCacheExpire); err != nil {
+		log.Warn("设置群名过期时间失败", zap.String("key", key), zap.Error(err))
 	}
 	return groupName, nil
 }
@@ -331,44 +331,53 @@ func BuildThreadTitle(channelID, threadName, groupName string) string {
 	return channelID
 }
 
-// getAndCacheThreadTitle 获取子区推送标题，格式：#子区名,群名
-func getAndCacheThreadTitle(msgResp msgOfflineNotify, ctx *config.Context) (string, error) {
-	key := fmt.Sprintf("%s%s", threadTitleCachePrefix, msgResp.ChannelID)
-	title, err := ctx.GetRedisConn().GetString(key)
-	if err != nil {
-		return "", err
-	}
-	if title != "" {
-		return title, nil
-	}
-
+// getThreadPushTitle 组装子区推送标题，格式：#子区名,群名。
+//
+// 子区名和群名分别独立缓存（见 getCachedThreadName / getCachedGroupName），标题在读取时
+// 现场拼接，而不是把拼好的整串冻结进缓存。这样群改名时只需失效 groupName: 单个 key，群推送
+// 标题和该群下所有子区推送标题就会一起刷新，无需遍历子区、也不依赖 Redis KEYS 扫描。
+func getThreadPushTitle(msgResp msgOfflineNotify, ctx *config.Context) (string, error) {
 	groupNo, shortID, ok := parseThreadChannelID(msgResp.ChannelID)
 	if !ok {
 		return msgResp.ChannelID, nil
 	}
 
-	db := getWebhookDB(ctx)
-
-	threadName, err := db.GetThreadName(groupNo, shortID)
+	threadName, err := getCachedThreadName(msgResp.ChannelID, groupNo, shortID, ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to get thread name: %w", err)
+		return "", err
 	}
-
-	groupName, err := db.GetGroupName(groupNo)
+	groupName, err := getCachedGroupName(groupNo, ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get group name: %w", err)
 	}
 
-	title = BuildThreadTitle(msgResp.ChannelID, threadName, groupName)
+	return BuildThreadTitle(msgResp.ChannelID, threadName, groupName), nil
+}
 
-	if err = ctx.GetRedisConn().Set(key, title); err != nil {
+// getCachedThreadName 读取子区名，命中缓存直接返回，否则回源 DB 并写入带 TTL 的缓存。
+// 缓存 key 由 pushcache 统一定义，子区改名时由 modules/thread 主动失效。
+func getCachedThreadName(channelID, groupNo, shortID string, ctx *config.Context) (string, error) {
+	key := pushcache.ThreadNameKey(channelID)
+	threadName, err := ctx.GetRedisConn().GetString(key)
+	if err != nil {
+		return "", err
+	}
+	if threadName != "" {
+		return threadName, nil
+	}
+
+	threadName, err = getWebhookDB(ctx).GetThreadName(groupNo, shortID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get thread name: %w", err)
+	}
+	if err = ctx.GetRedisConn().Set(key, threadName); err != nil {
 		return "", err
 	}
 	if err = ctx.GetRedisConn().Expire(key, ctx.GetConfig().Cache.NameCacheExpire); err != nil {
-		log.Warn("设置子区标题过期时间失败", zap.String("key", key), zap.Error(err))
+		log.Warn("设置子区名过期时间失败", zap.String("key", key), zap.Error(err))
 	}
 
-	return title, nil
+	return threadName, nil
 }
 
 func getUserBadge(uid string, ctx *config.Context) (int, error) {

--- a/modules/webhook/thread_push_test.go
+++ b/modules/webhook/thread_push_test.go
@@ -1,7 +1,6 @@
 package webhook
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -112,10 +111,4 @@ func TestParseThreadChannelID(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestThreadTitleCacheKey(t *testing.T) {
-	channelID := "groupNo____shortID"
-	key := fmt.Sprintf("%s%s", threadTitleCachePrefix, channelID)
-	assert.Equal(t, "threadTitle:groupNo____shortID", key)
 }

--- a/pkg/pushcache/pushcache.go
+++ b/pkg/pushcache/pushcache.go
@@ -1,0 +1,55 @@
+// Package pushcache centralizes the Redis cache-key scheme for offline push
+// notification titles (group name / thread name) and the invalidation helpers
+// that keep those caches fresh when the underlying name changes.
+//
+// The offline-push pipeline (modules/webhook) reads these display names through
+// a TTL cache to avoid a database hit on every offline message. Because the
+// modules/webhook package imports modules/group, the group/thread packages
+// cannot import webhook to bust the cache on rename without creating an import
+// cycle. This package is the neutral, lower-level home that both the producer
+// (webhook, which builds the keys) and the writers (group/thread, which
+// invalidate on rename) can depend on, so the key format lives in exactly one
+// place.
+package pushcache
+
+import "github.com/Mininglamp-OSS/octo-lib/pkg/redis"
+
+const (
+	// groupNamePrefix keys the cached display name of a group, keyed by its
+	// group number: groupName:<groupNo>.
+	groupNamePrefix = "groupName:"
+	// threadNamePrefix keys the cached display name of a thread (sub-area),
+	// keyed by its channel ID (<groupNo>____<shortID>): threadName:<channelID>.
+	//
+	// Only the thread's own name is cached here; the group-name portion of a
+	// thread push title is composed at read time from GroupNameKey, so renaming
+	// a group only needs to invalidate that single group key for both the group
+	// push title and every thread push title under it to refresh.
+	threadNamePrefix = "threadName:"
+)
+
+// GroupNameKey returns the cache key holding a group's display name.
+func GroupNameKey(groupNo string) string {
+	return groupNamePrefix + groupNo
+}
+
+// ThreadNameKey returns the cache key holding a thread's display name, keyed by
+// the thread channel ID (<groupNo>____<shortID>).
+func ThreadNameKey(channelID string) string {
+	return threadNamePrefix + channelID
+}
+
+// InvalidateGroupName drops the cached group display name so the next offline
+// push re-reads it from the database. Call it after a group rename. It is
+// best-effort: callers should log but not fail their operation on error — the
+// cache TTL is the backstop.
+func InvalidateGroupName(rc *redis.Conn, groupNo string) error {
+	return rc.Del(GroupNameKey(groupNo))
+}
+
+// InvalidateThreadName drops the cached thread display name. channelID is the
+// thread channel ID (<groupNo>____<shortID>). See InvalidateGroupName for the
+// best-effort contract.
+func InvalidateThreadName(rc *redis.Conn, channelID string) error {
+	return rc.Del(ThreadNameKey(channelID))
+}

--- a/pkg/pushcache/pushcache_test.go
+++ b/pkg/pushcache/pushcache_test.go
@@ -1,0 +1,15 @@
+package pushcache
+
+import "testing"
+
+func TestGroupNameKey(t *testing.T) {
+	if got := GroupNameKey("g123"); got != "groupName:g123" {
+		t.Fatalf("GroupNameKey = %q, want %q", got, "groupName:g123")
+	}
+}
+
+func TestThreadNameKey(t *testing.T) {
+	if got := ThreadNameKey("g123____s456"); got != "threadName:g123____s456" {
+		t.Fatalf("ThreadNameKey = %q, want %q", got, "threadName:g123____s456")
+	}
+}


### PR DESCRIPTION
## Problem

Offline push notification titles read the group name (and thread title) through a Redis cache (`Cache.NameCacheExpire`, default **7 days**), but the cache was **never invalidated on rename**. Mobile push banners kept showing the old auto-generated name (e.g. member names joined with `、`) for up to 7 days, while web/app clients already showed the renamed group.

Closes #397.

## Root cause

- `modules/webhook/common.go` caches the push title under `groupName:<groupNo>` / `threadTitle:<channelID>` with a TTL.
- The only invalidation was TTL expiry — group rename (`group.UpdateGroupInfo`) and thread rename (`thread.UpdateName`) updated the DB and notified clients but never dropped the push cache.

## What changed

- **`pkg/pushcache`** — new neutral package owning the push-title cache key scheme plus thin best-effort invalidation helpers. `modules/webhook` imports `modules/group`, so `group`/`thread` cannot import `webhook` to bust the cache (import cycle); this lower-level package is the shared home, keeping the key format in one place.
- **`modules/webhook`** — compose the thread push title from an **independently cached** thread name + group name at read time, instead of caching the frozen composed string. A group rename then only needs to drop the single `groupName:` key for both the group push title **and every thread push title under it** to refresh — no per-thread enumeration, no Redis `KEYS` scan.
- **Invalidation** — bust `groupName:` on group rename and `threadName:` on thread rename, **after the DB write commits** (busting before commit could let a concurrent push re-cache the stale value).
- **Resilience** — a failed Redis `Expire` on the group-name cache is now warn-and-continue (matching the thread-name cache) instead of failing the push.

### Notification contract

The push wire output (`Title`/`Content`/`Badge`/`ChannelID`) is **unchanged** for the same DB state — the title is still composed by the same `BuildThreadTitle` over the same DB-sourced names. Only the caching layout behind those values changed.

### Scope notes

- Disband intentionally does **not** invalidate: a disbanded group gets no further pushes and its name doesn't change, so the entry just TTLs out (no observable benefit → omitted to avoid dead code).
- Old `threadTitle:` keys orphan out via TTL (≤7 days), never read again.

## Testing

- `go build ./...`, `go vet`, `gofmt`, `make i18n-lint` — all green.
- Unit tests (key scheme, `BuildThreadTitle`, `parseThreadChannelID`) pass locally.
- New `modules/group/service_pushcache_test.go` covers "rename invalidates the cache" and "notice-only change keeps it" — these need MySQL/Redis and run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHG3Akmfr6mwihJmLZWxoL

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHG3Akmfr6mwihJmLZWxoL)_