### PR TITLE
feat(user): add POST /v1/users/batch with whitelist projection

### DIFF
--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -207,7 +207,8 @@ func (u *User) Route(r *wkhttp.WKHttp) {
 	auth := r.Group("/v1", u.ctx.AuthMiddleware(r))
 	{
 
-		auth.GET("/users/:uid", u.get) // 根据uid查询用户信息
+		auth.GET("/users/:uid", u.get)             // 根据uid查询用户信息
+		auth.POST("/users/batch", u.batchGetUsers) // 批量获取用户（仅 uid/name/avatar 白名单投影）
 		// 获取用户的会话信息
 		// auth.GET("/users/:uid/conversation", u.userConversationInfoGet)
 

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/avatarversion"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	rd "github.com/go-redis/redis"
 	"github.com/gocraft/dbr/v2"
 	"github.com/opentracing/opentracing-go"
@@ -208,7 +209,11 @@ func (u *User) Route(r *wkhttp.WKHttp) {
 	{
 
 		auth.GET("/users/:uid", u.get)             // 根据uid查询用户信息
-		auth.POST("/users/batch", u.batchGetUsers) // 批量获取用户（仅 uid/name/avatar 白名单投影）
+		// batch is an amplification endpoint (one request fans out to up to 200
+		// lookups), so guard call frequency with a per-route per-uid limiter on
+		// top of the request-size cap. AuthMiddleware (group) runs first, so the
+		// uid is in context before SharedUIDRateLimiter reads it.
+		auth.POST("/users/batch", appwkhttp.SharedUIDRateLimiter(r, u.ctx), u.batchGetUsers) // 批量获取用户（仅 uid/name/avatar 白名单投影）
 		// 获取用户的会话信息
 		// auth.GET("/users/:uid/conversation", u.userConversationInfoGet)
 

--- a/modules/user/api_batch.go
+++ b/modules/user/api_batch.go
@@ -1,0 +1,68 @@
+package user
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"go.uber.org/zap"
+)
+
+// maxBatchUserUIDs caps a single POST /v1/users/batch request. Requests above
+// this size are rejected as an invalid parameter rather than silently
+// truncated, so callers always know they exceeded the limit.
+const maxBatchUserUIDs = 200
+
+// batchUserReq is the request body for POST /v1/users/batch.
+type batchUserReq struct {
+	UIDs []string `json:"uids"`
+}
+
+// batchUserItem is the whitelist projection returned by POST /v1/users/batch.
+// Only uid / name / avatar are exposed. The service-layer Resp also carries
+// sensitive fields (Phone / Email) which MUST NOT leak through this endpoint,
+// so we copy the three public fields by hand instead of serializing Resp.
+type batchUserItem struct {
+	UID    string `json:"uid"`
+	Name   string `json:"name"`
+	Avatar string `json:"avatar"`
+}
+
+// batchGetUsers batch-fetches users by uid and returns only the public
+// projection (uid / name / avatar). It reuses Service.GetUsers; that method's
+// IN-query returns only matched rows, so unknown uids are silently skipped and
+// a partial result is not treated as an error. An empty uids list yields an
+// empty array (GetUsers short-circuits to nil,nil on an empty slice).
+func (u *User) batchGetUsers(c *wkhttp.Context) {
+	var req batchUserReq
+	if err := c.BindJSON(&req); err != nil {
+		respondUserRequestInvalid(c, "uids")
+		return
+	}
+	if len(req.UIDs) > maxBatchUserUIDs {
+		respondUserRequestInvalid(c, "uids")
+		return
+	}
+
+	resps, err := u.userService.GetUsers(req.UIDs)
+	if err != nil {
+		u.Error("批量获取用户失败！", zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
+		return
+	}
+
+	items := make([]*batchUserItem, 0, len(resps))
+	for _, resp := range resps {
+		// Whitelist projection: copy ONLY uid / name / avatar. Phone / Email on
+		// Resp are intentionally dropped. Resp has no avatar-URL field of its
+		// own (IsUploadAvatar is an internal flag), so avatar is rendered as the
+		// stable per-uid avatar URL, matching the `avatar` shape other user
+		// endpoints emit.
+		items = append(items, &batchUserItem{
+			UID:    resp.UID,
+			Name:   resp.Name,
+			Avatar: u.ctx.GetConfig().GetAvatarPath(resp.UID),
+		})
+	}
+	c.JSON(http.StatusOK, items)
+}

--- a/modules/user/api_batch_test.go
+++ b/modules/user/api_batch_test.go
@@ -1,0 +1,65 @@
+package user
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+// TestBatchUserItemWhitelist locks the privacy contract of POST /v1/users/batch:
+// the response DTO exposes exactly uid / name / avatar and never the sensitive
+// Phone / Email fields that the service-layer Resp carries.
+func TestBatchUserItemWhitelist(t *testing.T) {
+	rt := reflect.TypeOf(batchUserItem{})
+	tags := map[string]bool{}
+	for i := 0; i < rt.NumField(); i++ {
+		tags[rt.Field(i).Tag.Get("json")] = true
+	}
+	if rt.NumField() != 3 {
+		t.Fatalf("batchUserItem must expose exactly 3 fields, got %d", rt.NumField())
+	}
+	for _, want := range []string{"uid", "name", "avatar"} {
+		if !tags[want] {
+			t.Fatalf("batchUserItem missing %q json field", want)
+		}
+	}
+	for _, banned := range []string{"phone", "email", "Phone", "Email"} {
+		if tags[banned] {
+			t.Fatalf("batchUserItem must not expose %q", banned)
+		}
+	}
+}
+
+// TestBatchGetUsersRejectsOversizedBatch exercises the >200 uid guard. The cap
+// check runs before any service / DB access, so a zero-value *User is enough to
+// drive this path without a test server.
+func TestBatchGetUsersRejectsOversizedBatch(t *testing.T) {
+	u := &User{}
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	r.POST("/v1/users/batch", u.batchGetUsers)
+
+	uids := make([]string, maxBatchUserUIDs+1)
+	for i := range uids {
+		uids[i] = "u"
+	}
+	body, err := json.Marshal(batchUserReq{UIDs: uids})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/users/batch", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	env := decodeEnvelope(t, w.Body.Bytes())
+	if env.Error.Code != "err.server.user.request_invalid" {
+		t.Fatalf("want err.server.user.request_invalid, got %q (body=%s)", env.Error.Code, w.Body.String())
+	}
+}

--- a/modules/user/api_i18n_test.go
+++ b/modules/user/api_i18n_test.go
@@ -82,6 +82,7 @@ func TestMigratedUserFilesNoLegacyResponseError(t *testing.T) {
 		"api_friend.go", "api_online.go", "api_setting.go", "api_maillist.go",
 		"api_device.go", "api_destroy.go", "api_pinned.go", "api_gitee.go",
 		"api_github.go", "api_emaillogin.go", "api_usernamelogin.go",
+		"api_batch.go",
 	}
 	for _, f := range files {
 		t.Run(f, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a new `POST /v1/users/batch` endpoint to batch-fetch users by uid, returning only a whitelist projection (`uid`, `name`, `avatar`). This supports clients that need to resolve many collaborators at once (e.g. document collaborator lists / presence) without N round-trips, while keeping sensitive fields off the wire.

## What it does

- New route `POST /v1/users/batch` mounted in the existing authenticated `/v1` group (under `AuthMiddleware`).
- Request body: `{ "uids": ["...", "..."] }`, capped at 200 uids per call.
- Reuses the existing `(*Service).GetUsers` service method — no change to it or any existing handler.
- Returns a dedicated whitelist DTO with exactly three fields: `uid`, `name`, `avatar`. The full user record (which carries `phone`/`email`) is never serialized — only those three fields are hand-mapped, so sensitive fields cannot reach the response.
- `avatar` is the per-uid avatar path, consistent with how the existing user endpoints emit it.

## Behavior

- Empty `uids` → empty array.
- Unknown uids → silently skipped (the underlying `IN` query returns only matched rows); partial results are not an error.
- Over the 200 cap or malformed body → `400` invalid-request error.
- DB/service failure → `500` (internal), logged.

## Scope / safety

- Only adds a new file (`modules/user/api_batch.go`), one route-registration line, and tests. No existing endpoint, the `GetUsers` service, or the user response struct is modified.
- New tests assert the response contains only `uid`/`name`/`avatar` (no `phone`/`email`) and that the 200 cap is enforced.

## Testing

- `go build ./...` — pass
- `go vet ./modules/user/...` — pass
- New unit tests (`api_batch_test.go`) — pass
- `make i18n-lint` — pass (no new error responses, no unregistered codes)
