### PR TITLE
[DO NOT MERGE] OCT-7 CI gate validation: deliberately-red build

### DIFF
--- a/oct7_ci_validation_DO_NOT_MERGE.go
+++ b/oct7_ci_validation_DO_NOT_MERGE.go
@@ -1,0 +1,4 @@
+package main
+
+// OCT-7 CI gate validation: intentional syntax error, DO NOT MERGE.
+func oct7Broken( {


### PR DESCRIPTION
Validation PR for OCT-7. Intentionally breaks the Go build so the required **Build** check fails and merge is blocked. Will be closed after verification. Not for merge.