### PR TITLE
fix(group/test): bound test DB pool to stop MySQL connection exhaustion (OCT-8)

### DIFF
--- a/modules/group/api_allow_no_mention_test.go
+++ b/modules/group/api_allow_no_mention_test.go
@@ -13,7 +13,7 @@ import (
 // (allow). This mirrors how the ALTER TABLE migration backfills existing rows,
 // so deploying this feature does not silently turn off any existing no-@ bot.
 func TestGroup_AllowNoMention_DefaultsTo1(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	assert.NoError(t, testutil.CleanAllTables(ctx))
 
 	groupNo := "g-default-nomention"
@@ -148,7 +148,7 @@ func TestGroupSettingUpdate_AllowNoMention_SilentToggleSucceeds(t *testing.T) {
 // non-manager/creator toggling the group-level switch gets 403, not 500. The
 // permission check runs before any DB/event write.
 func TestGroupSettingUpdate_AllowNoMention_NonManagerForbidden(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	wireI18nRendererForGroupTest(s)
 	f := New(ctx)
 

--- a/modules/group/api_bot_ownership_test.go
+++ b/modules/group/api_bot_ownership_test.go
@@ -41,7 +41,7 @@ func insertBotUser(t *testing.T, f *Group, uid, name, shortNo, creatorUID string
 // No external bots are owned by user-c by default; individual tests insert
 // the bots they need.
 func setupBotOwnershipGroup(t *testing.T) (*Group, http.Handler) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	// NB: module.Setup(ctx) inside NewTestServer already constructs a Group
 	// instance and registers its routes on s.GetRoute(). Calling
 	// f.Route(s.GetRoute()) again would double-register the same paths and
@@ -183,7 +183,7 @@ func TestGroupMemberAdd_BotOwnershipBlocksMixedBatch(t *testing.T) {
 // TestCheckBotOwnership_SkipsNonBots exercises the pure helper: non-bot UIDs
 // pass through untouched regardless of inviter.
 func TestCheckBotOwnership_SkipsNonBots(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	assert.NoError(t, testutil.CleanAllTables(ctx))
 
 	_, err := ctx.DB().InsertInto("user").

--- a/modules/group/api_groupmd_test.go
+++ b/modules/group/api_groupmd_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func setupGroupMdTest(t *testing.T) (*Group, *server.Server) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 	err := testutil.CleanAllTables(ctx)

--- a/modules/group/api_i18n_regression_test.go
+++ b/modules/group/api_i18n_regression_test.go
@@ -72,7 +72,7 @@ func putGroupSetting(t *testing.T, handler http.Handler, groupNo, body string) *
 // because it ignored getGroupInfo's not-found sentinel. The exit of a
 // non-existent group is a user-facing 404, not an internal error.
 func TestGroupExit_NotFoundGroup(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	wireI18nRendererForGroupTest(s)
 	_ = New(ctx)
 
@@ -95,7 +95,7 @@ func TestGroupExit_NotFoundGroup(t *testing.T) {
 // JSON-decode failure mapped to store_failed (500). An expired authorization
 // code is a normal user-facing state and must surface as auth_code_invalid.
 func TestGroupMemberInviteSure_ExpiredCode(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	wireI18nRendererForGroupTest(s)
 	_ = New(ctx)
 
@@ -129,7 +129,7 @@ func TestGroupMemberAdd_BlankMembersIsRequestInvalid(t *testing.T) {
 // RemoveGroupMembers return "none of the members are in this group" — a 404
 // business error, not the store_failed (500) it was being mapped to.
 func TestManagerMemberRemove_NotInGroupIsNotFound(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	wireI18nRendererForGroupTest(s)
 	f := New(ctx)
 
@@ -194,7 +194,7 @@ func TestGroupSettingUpdate_AllowExternalRangeIsRequestInvalid(t *testing.T) {
 // checkPermissions's "没有权限！" collapsed into store_failed (500). Updating a
 // group attribute without permission is a 403, not an internal error.
 func TestGroupSettingUpdate_NonManagerForbidden(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	wireI18nRendererForGroupTest(s)
 	f := New(ctx)
 
@@ -243,7 +243,7 @@ func TestGroupAvatarUpload_MissingFileIsRequestInvalid(t *testing.T) {
 // upload contract: after object storage and DB update succeed, the IM
 // notification is best-effort and must not make the client retry the upload.
 func TestGroupAvatarUpload_PostCommitNotifyFailureRespondsOK(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	err := testutil.CleanAllTables(ctx)
 	assert.NoError(t, err)
 

--- a/modules/group/api_invite_detail_optional_auth_test.go
+++ b/modules/group/api_invite_detail_optional_auth_test.go
@@ -36,7 +36,7 @@ import (
 // 合法 token + 同 Space 成员：detail 应该返回 joinable，让前端显示加入按钮。
 // 这是 YUJ-39 的核心正向路径——修复 PR#1174 遗留 UX 短板。
 func TestGroupInviteDetail_OptionalAuth_SameSpaceMember_Joinable(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -96,7 +96,7 @@ func TestGroupInviteDetail_OptionalAuth_SameSpaceMember_Joinable(t *testing.T) {
 // 合法 token + 同 Space 成员 + invite=1：detail 应该返回 invite_required，
 // 而不是被 external_blocked 盖住。验证可选鉴权后 invite_required 状态也能正常透出。
 func TestGroupInviteDetail_OptionalAuth_SameSpaceMember_InviteRequired(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -152,7 +152,7 @@ func TestGroupInviteDetail_OptionalAuth_SameSpaceMember_InviteRequired(t *testin
 // 合法 token + 跨 Space 访问者：detail 仍返回 external_blocked 并标记 is_external=1。
 // 回归保护：可选鉴权不得让跨 Space 用户错误获得 joinable。
 func TestGroupInviteDetail_OptionalAuth_CrossSpace_Blocked(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -222,7 +222,7 @@ func TestGroupInviteDetail_OptionalAuth_CrossSpace_Blocked(t *testing.T) {
 // 无效 / 过期 token：detail 应降级为匿名路径（external_blocked + is_external=0），
 // 不得因为脏 token 崩溃或泄漏敏感状态。
 func TestGroupInviteDetail_OptionalAuth_InvalidToken_Degrades(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)

--- a/modules/group/api_invite_h5_test.go
+++ b/modules/group/api_invite_h5_test.go
@@ -36,7 +36,7 @@ func deterministicIPSuffix(name string) int {
 }
 
 func TestGroupInviteDetail_Joinable(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -79,7 +79,7 @@ func TestGroupInviteDetail_Joinable(t *testing.T) {
 }
 
 func TestGroupInviteDetail_InviteRequired(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -116,7 +116,7 @@ func TestGroupInviteDetail_InviteRequired(t *testing.T) {
 }
 
 func TestGroupInviteDetail_Expired(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	_ = New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -132,7 +132,7 @@ func TestGroupInviteDetail_Expired(t *testing.T) {
 }
 
 func TestGroupInviteDetail_NotFound(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -168,7 +168,7 @@ func TestGroupInviteDetail_NotFound(t *testing.T) {
 }
 
 func TestGroupInviteDetail_EmptyCode(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	_ = New(ctx)
 
 	w := httptest.NewRecorder()
@@ -178,7 +178,7 @@ func TestGroupInviteDetail_EmptyCode(t *testing.T) {
 
 // 非 group 类型的二维码（如 scanLogin）应返回 expired，避免跨类型数据被透出。
 func TestGroupInviteDetail_WrongQRCodeType(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	_ = New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -206,7 +206,7 @@ func TestGroupInviteDetail_WrongQRCodeType(t *testing.T) {
 // 落地页渲染需要从 repo 根目录读取 assets/web/group_invite.html。
 // 测试时 cwd 是 modules/group/，所以临时切到 repo 根再切回。
 func TestGroupInvitePage_RendersHTMLWithAPIBase(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	_ = New(ctx)
 
 	wd, err := os.Getwd()
@@ -246,7 +246,7 @@ func TestGroupInvitePage_RendersHTMLWithAPIBase(t *testing.T) {
 
 // 已登录用户用公开 code 换取 auth_code：基础路径。
 func TestGroupInviteAuthorize_OK(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -302,7 +302,7 @@ func TestGroupInviteAuthorize_OK(t *testing.T) {
 
 // invite=1 的群（需审批）不应通过 authorize 生成 auth_code。
 func TestGroupInviteAuthorize_InviteRequired(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	wireI18nRendererForGroupTest(s)
 	f := New(ctx)
 
@@ -343,7 +343,7 @@ func TestGroupInviteAuthorize_InviteRequired(t *testing.T) {
 
 // code 已过期 / 不存在：返回错误。
 func TestGroupInviteAuthorize_Expired(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	wireI18nRendererForGroupTest(s)
 	_ = New(ctx)
 
@@ -363,7 +363,7 @@ func TestGroupInviteAuthorize_Expired(t *testing.T) {
 
 // 未登录：AuthMiddleware 直接拦截。
 func TestGroupInviteAuthorize_RequiresAuth(t *testing.T) {
-	s, _ := testutil.NewTestServer()
+	s, _ := newTestServer(t)
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/v1/group/invite/authorize?code=foo", nil)
@@ -375,7 +375,7 @@ func TestGroupInviteAuthorize_RequiresAuth(t *testing.T) {
 // 落地页 HTML 应包含「加入群聊」按钮与 authorize 端点引用，
 // 确保前端改动不会被后端模板替换误伤。
 func TestGroupInvitePage_ContainsJoinButton(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	_ = New(ctx)
 
 	wd, err := os.Getwd()
@@ -401,7 +401,7 @@ func TestGroupInvitePage_ContainsJoinButton(t *testing.T) {
 // 这两个字面量钉死：任何人再把按钮加回来都会挂 CI。
 func TestGroupInvitePage_NoDmworkScheme(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	_ = New(ctx)
 
 	wd, err := os.Getwd()
@@ -430,7 +430,7 @@ func TestGroupInvitePage_NoDmworkScheme(t *testing.T) {
 // 那是 pkg/wkhttp/ratelimit_test.go 的职责，此处避开依赖 SharedUIDRateLimiter
 // 的进程级单例 + 环境变量带来的耦合。
 func TestGroupInviteAuthorize_HasUIDRateLimit(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -478,7 +478,7 @@ func TestGroupInviteAuthorize_HasUIDRateLimit(t *testing.T) {
 // 让 H5 落地页直接给明确提示、藏掉「加入群聊」按钮，而不是等用户点了才被
 // groupScanJoin 拒绝。
 func TestGroupInviteDetail_ExternalBlocked(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -522,7 +522,7 @@ func TestGroupInviteDetail_ExternalBlocked(t *testing.T) {
 // allow_external=1（默认）或群无 SpaceID 时不应触发 external_blocked。
 // 这里确保我们没把默认路径（App 内创建的无 Space 群）误伤。
 func TestGroupInviteDetail_NoSpaceNotExternalBlocked(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -566,7 +566,7 @@ func TestGroupInviteDetail_NoSpaceNotExternalBlocked(t *testing.T) {
 // Redis auth_code（与 qrcode/api.go handleJoinGroup 的预检对齐，避免
 // scanjoin 回「已经在群内」的模糊错误 + 白占 30min TTL）。
 func TestGroupInviteAuthorize_AlreadyMember(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -619,7 +619,7 @@ func TestGroupInviteAuthorize_AlreadyMember(t *testing.T) {
 // 这固化「already_member 判定必须早于 invite 判定」的顺序约定，
 // 与 qrcode/api.go handleJoinGroup 对齐。
 func TestGroupInviteAuthorize_Invite1_AlreadyMember(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -672,7 +672,7 @@ func TestGroupInviteAuthorize_Invite1_AlreadyMember(t *testing.T) {
 // 拦截（与 TestGroupInviteAuthorize_InviteRequired 互为对照：这里显式断言
 // 当 already_member 判定 miss 时，invite 判定仍然生效，顺序重排不影响非成员路径）。
 func TestGroupInviteAuthorize_Invite1_NonMember(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	wireI18nRendererForGroupTest(s)
 	f := New(ctx)
 
@@ -716,7 +716,7 @@ func TestGroupInviteAuthorize_Invite1_NonMember(t *testing.T) {
 // 群属于某 Space 且 allow_external=0 时，authorize 应短路返回 external_blocked，
 // 不生成 auth_code。这是 H5 版本错位时的兜底路径（正常情况下 detail 已经藏掉按钮）。
 func TestGroupInviteAuthorize_ExternalBlocked(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -765,7 +765,7 @@ func TestGroupInviteAuthorize_ExternalBlocked(t *testing.T) {
 // 跨 Space 用户扫 AllowExternal=0 群邀请码：authorize 短路返回 external_blocked。
 // 这显式覆盖「登录用户不是该 Space 成员」的分支（回归 YUJ-38 修复）。
 func TestGroupInviteAuthorize_ExternalBlocked_NonSpaceMember(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -825,7 +825,7 @@ func TestGroupInviteAuthorize_ExternalBlocked_NonSpaceMember(t *testing.T) {
 // 同 Space 成员扫 AllowExternal=0 群邀请码：authorize 不再误杀为 external_blocked，
 // 应继续走正常流程并生成 auth_code（回归 YUJ-38 Critical 修复）。
 func TestGroupInviteAuthorize_SameSpaceMemberNotBlocked(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)

--- a/modules/group/api_invite_landing_space_info_test.go
+++ b/modules/group/api_invite_landing_space_info_test.go
@@ -35,7 +35,7 @@ import (
 
 // 群挂在 Space 下：detail 必须下发真实 space_id + space_name，前端才能渲染归属行。
 func TestGroupInviteDetail_IncludesSpaceID_WithSpace(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -89,7 +89,7 @@ func TestGroupInviteDetail_IncludesSpaceID_WithSpace(t *testing.T) {
 // 公共群（无 SpaceID）：space_id 必须为空串而非缺省，前端按空串隐藏归属行，
 // 且保证旧客户端 JSON.parse 看到的是稳定字段集合（向后兼容）。
 func TestGroupInviteDetail_IncludesSpaceID_PublicGroup(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -136,7 +136,7 @@ func TestGroupInviteDetail_IncludesSpaceID_PublicGroup(t *testing.T) {
 // external_blocked 状态同样需要下发 space_id + space_name，
 // 前端状态页据此渲染「你不是「XX」Space 的成员」。
 func TestGroupInviteDetail_ExternalBlocked_IncludesSpaceInfo(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -191,7 +191,7 @@ func TestGroupInviteDetail_ExternalBlocked_IncludesSpaceInfo(t *testing.T) {
 // 落地页 HTML 必须包含归属行元素 + external_blocked 额外提示锚点，
 // 保证前端代码不会被后端模板替换误伤。用 grep 测试钉字面量。
 func TestGroupInvitePage_RendersSpaceLandingElements(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	_ = New(ctx)
 
 	wd, err := os.Getwd()

--- a/modules/group/api_invite_need_space_test.go
+++ b/modules/group/api_invite_need_space_test.go
@@ -56,7 +56,7 @@ func seedDefaultSpaceForTestUID(t *testing.T, ctx *config.Context) string {
 // （allow_external=1）邀请码 → authorize 必须短路返回 need_space，不生成 auth_code。
 // 这是 GH #1319 的核心回归：Direction A 决策后，任何入群路径都必须前置检查。
 func TestGroupInviteAuthorize_NeedSpace_ExternalGroup(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -106,7 +106,7 @@ func TestGroupInviteAuthorize_NeedSpace_ExternalGroup(t *testing.T) {
 // 而不是 external_blocked。need_space 是用户侧修复路径（加 Space 后重试），
 // 比群级 external_blocked 更根本、更可操作，三端才能正确引导用户。
 func TestGroupInviteAuthorize_NeedSpace_PriorityOverExternalBlocked(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -164,7 +164,7 @@ func TestGroupInviteAuthorize_NeedSpace_PriorityOverExternalBlocked(t *testing.T
 // 有 Space 的登录用户扫外部群邀请码 → 正常流程（不被 need_space 误杀），
 // 生成 auth_code。回归保护：避免 need_space 条件误把所有用户挡在外面。
 func TestGroupInviteAuthorize_HasSpaceGoesNormalPath(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -215,7 +215,7 @@ func TestGroupInviteAuthorize_HasSpaceGoesNormalPath(t *testing.T) {
 // 未登录访问者（loginUID=""）不触发，保持公共预览体验（回归保护：
 // TestGroupInviteDetail_Joinable / TestGroupInviteDetail_ExternalBlocked 无 token）。
 func TestGroupInviteDetail_NeedSpace_OptionalAuth(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)

--- a/modules/group/api_landing_space_info_test.go
+++ b/modules/group/api_landing_space_info_test.go
@@ -33,7 +33,7 @@ import (
 
 // 群挂在 Space 下，登录者本身是该 Space 成员 → 只显示 space_name，不标外部。
 func TestGroupDetailGet_WithSpace_SameSpaceMember(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -76,7 +76,7 @@ func TestGroupDetailGet_WithSpace_SameSpaceMember(t *testing.T) {
 
 // 群挂在 Space 下但登录者不在该 Space 成员表中 → is_external=1，前端渲染外部徽标。
 func TestGroupDetailGet_WithSpace_CrossSpaceViewer(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -123,7 +123,7 @@ func TestGroupDetailGet_WithSpace_CrossSpaceViewer(t *testing.T) {
 
 // 群无 SpaceID（App 内创建的普通群） → space_name="" / is_external=0，前端完全不渲染。
 func TestGroupDetailGet_NoSpace(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -156,7 +156,7 @@ func TestGroupDetailGet_NoSpace(t *testing.T) {
 
 // 公开接口永远没有登录态，is_external 只会是 0；但 space_name 仍然要下发。
 func TestGroupInviteDetail_IncludesSpaceName_Anonymous(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -207,7 +207,7 @@ func TestGroupInviteDetail_IncludesSpaceName_Anonymous(t *testing.T) {
 
 // 群无 Space 时公开接口返回的 space_name 应为空字符串，前端不渲染 Space 信息。
 func TestGroupInviteDetail_NoSpace(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -250,7 +250,7 @@ func TestGroupInviteDetail_NoSpace(t *testing.T) {
 
 // 群挂 Space，登录的被邀请者不是该 Space 成员 → is_external=1 + space_name 下发。
 func TestGroupMemberInviteDetail_CrossSpaceViewer(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -306,7 +306,7 @@ func TestGroupMemberInviteDetail_CrossSpaceViewer(t *testing.T) {
 
 // 群无 Space 时邀请详情 space_name 为空，is_external 为 0。
 func TestGroupMemberInviteDetail_NoSpace(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)

--- a/modules/group/api_manager_test.go
+++ b/modules/group/api_manager_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestGroupList(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	m := NewManager(ctx)
 	m.Route(s.GetRoute())
 	//清除数据
@@ -35,7 +35,7 @@ func TestGroupList(t *testing.T) {
 
 func TestGroupCount(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	m := NewManager(ctx)
 	m.Route(s.GetRoute())
 	//清除数据
@@ -55,7 +55,7 @@ func TestGroupCount(t *testing.T) {
 }
 func TestDisableList(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	m := NewManager(ctx)
 	m.Route(s.GetRoute())
 	//清除数据
@@ -82,7 +82,7 @@ func TestDisableList(t *testing.T) {
 
 func TestBlackList(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	m := NewManager(ctx)
 	m.Route(s.GetRoute())
 	//清除数据

--- a/modules/group/api_realname_test.go
+++ b/modules/group/api_realname_test.go
@@ -141,7 +141,7 @@ func seedUserVerification(t *testing.T, f *Group, uid, realName string, verified
 // 和 :227 的已验证 setup 模式。漏这一行三个测试会打到 404 路径,所谓的 pass
 // 其实是 vacuous,证明不了 feature works（Jerry + lml2468 R6 独立 confirm）。
 func setupMembersGroup(t *testing.T) (*Group, http.Handler, string, string) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 	require.NoError(t, testutil.CleanAllTables(ctx))

--- a/modules/group/api_test.go
+++ b/modules/group/api_test.go
@@ -73,7 +73,7 @@ func allowDuplicateColumn(t *testing.T, ctx *config.Context, stmt string) {
 func TestGroupCreate(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 
@@ -101,7 +101,7 @@ func TestGroupCreate(t *testing.T) {
 }
 
 func TestGroupCreate_WithCategoryID(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	ensureGroupCategorySchema(t, ctx)
@@ -171,7 +171,7 @@ func TestGroupCreate_WithCategoryID(t *testing.T) {
 }
 
 func TestGroupCreate_WithCategoryID_NoSpaceID(t *testing.T) {
-	s, _ := testutil.NewTestServer()
+	s, _ := newTestServer(t)
 
 	// 传 category_id 但不传 space_id → 应报错
 	w := httptest.NewRecorder()
@@ -187,7 +187,7 @@ func TestGroupCreate_WithCategoryID_NoSpaceID(t *testing.T) {
 }
 
 func TestGroupCreate_WithCategoryID_NotFound(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	ensureGroupCategorySchema(t, ctx)
 
 	spaceID := "space-cat-notfound"
@@ -216,7 +216,7 @@ func TestGroupCreate_WithCategoryID_NotFound(t *testing.T) {
 }
 
 func TestGroupCreate_WithCategoryID_NotOwned(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	ensureGroupCategorySchema(t, ctx)
 
 	spaceID := "space-cat-notowned"
@@ -253,7 +253,7 @@ func TestGroupCreate_WithCategoryID_NotOwned(t *testing.T) {
 
 func TestGroupGet(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 
@@ -295,7 +295,7 @@ func TestGroupGet(t *testing.T) {
 
 func TestGroupMemberAdd(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 
@@ -346,7 +346,7 @@ func TestGroupMemberAdd(t *testing.T) {
 // TestGroupMemberAdd_NonMemberForbidden 回归测试 issue#1018:
 // 非群成员的任意用户不能向 Invite==0 的群添加成员
 func TestGroupMemberAdd_NonMemberForbidden(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -396,7 +396,7 @@ func TestGroupMemberAdd_NonMemberForbidden(t *testing.T) {
 // TestGroupMemberAdd_KickedMemberForbidden 回归测试 issue#1018:
 // 曾经是群成员但已被移除(is_deleted=1)的用户,不能再通过 memberAdd 添加他人
 func TestGroupMemberAdd_KickedMemberForbidden(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -449,7 +449,7 @@ func TestGroupMemberAdd_KickedMemberForbidden(t *testing.T) {
 
 func TestGroupMemberRemove(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 
@@ -490,7 +490,7 @@ func TestGroupMemberRemove(t *testing.T) {
 
 func TestSyncMembers(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 
@@ -543,7 +543,7 @@ func TestSyncMembers(t *testing.T) {
 
 func TestGroupSettingUpdate(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 
@@ -581,7 +581,7 @@ func TestGroupSettingUpdate(t *testing.T) {
 
 func TestGroupUpdate(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 
@@ -616,7 +616,7 @@ func TestGroupUpdate(t *testing.T) {
 }
 func TestList(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 
@@ -651,7 +651,7 @@ func TestList(t *testing.T) {
 // TestGroupExit 测试退出群聊
 func TestGroupExit(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 
@@ -686,7 +686,7 @@ func TestGroupExit(t *testing.T) {
 // TestGroupDisband 测试解散群组
 func TestGroupDisband(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 
@@ -720,7 +720,7 @@ func TestGroupDisband(t *testing.T) {
 // TestGroupManagerAdd 测试添加管理员
 func TestGroupManagerAdd(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 
@@ -770,7 +770,7 @@ func TestGroupManagerAdd(t *testing.T) {
 // TestGroupManagerRemove 测试移除管理员
 func TestGroupManagerRemove(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 
@@ -820,7 +820,7 @@ func TestGroupManagerRemove(t *testing.T) {
 // TestGroupTransfer 测试群主转让
 func TestGroupTransfer(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 
@@ -868,7 +868,7 @@ func TestGroupTransfer(t *testing.T) {
 // TestGroupForbidden 测试群组全员禁言
 func TestGroupForbidden(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 
@@ -911,7 +911,7 @@ func TestGroupForbidden(t *testing.T) {
 // TestGroupMembersGet 测试获取群成员列表
 func TestGroupMembersGet(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 
@@ -958,7 +958,7 @@ func TestGroupMembersGet(t *testing.T) {
 
 func TestGroupDetailGet_MemberCanAccess(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 
@@ -995,7 +995,7 @@ func TestGroupDetailGet_MemberCanAccess(t *testing.T) {
 
 func TestGroupDetailGet_NonMemberDenied(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 
@@ -1024,7 +1024,7 @@ func TestGroupDetailGet_NonMemberDenied(t *testing.T) {
 
 func TestGroupDetailGet_UnauthenticatedDenied(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 
@@ -1052,7 +1052,7 @@ func TestGroupDetailGet_UnauthenticatedDenied(t *testing.T) {
 // members with ForbiddenExpirTime == 0, not all requested UIDs (issue #482)
 func TestBlacklistRemoveUsesFilteredUIDs(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 	f.Route(s.GetRoute())
 
@@ -1145,7 +1145,7 @@ func TestBlacklistRemoveUsesFilteredUIDs(t *testing.T) {
 
 // TestGroupMemberGet_Hit 调用方是成员，目标 uid 是在群成员 → exists=true 且返回 member
 func TestGroupMemberGet_Hit(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1177,7 +1177,7 @@ func TestGroupMemberGet_Hit(t *testing.T) {
 
 // TestGroupMemberGet_Miss 调用方是成员，目标 uid 不在群 → exists=false
 func TestGroupMemberGet_Miss(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1204,7 +1204,7 @@ func TestGroupMemberGet_Miss(t *testing.T) {
 
 // TestGroupMemberGet_Deleted 目标 uid 之前在群但 is_deleted=1 → exists=false
 func TestGroupMemberGet_Deleted(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1234,7 +1234,7 @@ func TestGroupMemberGet_Deleted(t *testing.T) {
 
 // TestGroupMemberGet_Self 调用方查询自己 → exists=true 且返回自身成员信息
 func TestGroupMemberGet_Self(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	f := New(ctx)
 
 	err := testutil.CleanAllTables(ctx)
@@ -1260,7 +1260,7 @@ func TestGroupMemberGet_Self(t *testing.T) {
 
 // TestGroupMemberGet_CallerNotMember 调用方非该群成员 → 403/error
 func TestGroupMemberGet_CallerNotMember(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	wireI18nRendererForGroupTest(s)
 	f := New(ctx)
 

--- a/modules/group/avatar_version_test.go
+++ b/modules/group/avatar_version_test.go
@@ -12,7 +12,7 @@ import (
 // （后者是阻止旧的自动合成事件覆盖手动头像的关键标志）。QueryWithGroupNo
 // 读回这些字段，avatarGet 据此选择 versioned/legacy path。
 func TestGroupAvatarVersionDBRoundTrip(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	g := New(ctx)
 

--- a/modules/group/db_external_member_count_test.go
+++ b/modules/group/db_external_member_count_test.go
@@ -16,7 +16,7 @@ import (
 //
 // 场景：同一个群内 1 个人类外部成员 + 1 个 bot 外部成员 → 计数应为 1。
 func TestQueryExternalMemberCount_ExcludesBots(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	err := testutil.CleanAllTables(ctx)
 	assert.NoError(t, err)
 
@@ -57,7 +57,7 @@ func TestQueryExternalMemberCount_ExcludesBots(t *testing.T) {
 // （人类外部成员都已退群）时，计数为 0 —— 这正是 T-bot-5 E2E 复现的关键路径：
 // refreshIsExternalGroup 应据此把 is_external_group 改回 0。
 func TestQueryExternalMemberCount_OnlyBotsReturnsZero(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	err := testutil.CleanAllTables(ctx)
 	assert.NoError(t, err)
 
@@ -84,7 +84,7 @@ func TestQueryExternalMemberCount_OnlyBotsReturnsZero(t *testing.T) {
 
 // TestQueryExternalMemberCount_EmptyGroup 边界：空群（0 成员）应返回 0。
 func TestQueryExternalMemberCount_EmptyGroup(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	err := testutil.CleanAllTables(ctx)
 	assert.NoError(t, err)
 
@@ -101,7 +101,7 @@ func TestQueryExternalMemberCount_EmptyGroup(t *testing.T) {
 // TestQueryExternalMemberCount_MixedMulti 多成员混合场景：
 // 2 human external + 3 bot external + 1 human internal → 只返回 human external 数（2）。
 func TestQueryExternalMemberCount_MixedMulti(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	err := testutil.CleanAllTables(ctx)
 	assert.NoError(t, err)
 
@@ -140,7 +140,7 @@ func TestQueryExternalMemberCount_MixedMulti(t *testing.T) {
 // TestQueryExternalMemberCount_DeletedHuman 软删除的人类外部成员必须排除
 // （is_deleted=1 AND is_external=1 AND robot=0 → 不算）。
 func TestQueryExternalMemberCount_DeletedHuman(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	err := testutil.CleanAllTables(ctx)
 	assert.NoError(t, err)
 

--- a/modules/group/e2e_issue27_wukong_test.go
+++ b/modules/group/e2e_issue27_wukong_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestE2E_Issue27_RemovedBotStopsReceivingThreadMessages(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	f := New(ctx)
 	ensureThreadTables(t, f)

--- a/modules/group/exist_member_active_test.go
+++ b/modules/group/exist_member_active_test.go
@@ -14,7 +14,7 @@ import (
 // 仍返回 true（被拉黑用户可越权读子区历史/会话）。ExistMemberActive 必须额外要求
 // status=Normal，把黑名单成员挡在门外（YUJ-4212 CR 整改）。
 func TestExistMemberActive_ExcludesBlacklist(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 
 	db := NewDB(ctx)
@@ -64,7 +64,7 @@ func TestExistMemberActive_ExcludesBlacklist(t *testing.T) {
 // 仍透出子区。ExistMembersActive 必须只返回 status=Normal AND is_deleted=0 的群编号
 // （YUJ-4212 CR 整改）。
 func TestExistMembersActive_ExcludesBlacklist(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 
 	db := NewDB(ctx)
@@ -112,7 +112,7 @@ func TestExistMembersActive_ExcludesBlacklist(t *testing.T) {
 // 这是 YUJ-4219 把 thread 模块 + channel_files + mutualDelete 子区分支统一切到
 // ExistMemberActive 后，所有这些门禁共享的授权原语，故在 DB 层兜底双向覆盖。
 func TestExistMemberActive(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	assert.NoError(t, testutil.CleanAllTables(ctx))
 
 	db := NewDB(ctx)

--- a/modules/group/group_name_widen_test.go
+++ b/modules/group/group_name_widen_test.go
@@ -28,7 +28,7 @@ const groupNameWidenMigrationFile = "20260615000001_group_name_widen.sql"
 // fits. A defer restores the column to 50 so a mid-test failure can't leave the shared test
 // schema narrowed for later tests.
 func TestGroupNameWidenMigration(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	defer testutil.CleanAllTables(ctx)
 
 	require.Equal(t, 50, MaxGroupNameLen, "MaxGroupNameLen and the column width must move together")

--- a/modules/group/home_space_test.go
+++ b/modules/group/home_space_test.go
@@ -16,7 +16,7 @@ import (
 // 且一次调用内合并了 source_space_name 回填（Jerry-Xin review #1209 优化 1：
 // 只打 1 次 group 查询兜底 + 1 次 space WHERE IN 批量）。
 func TestFillSpaceRelatedFields_ExternalAndInternal(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	err := testutil.CleanAllTables(ctx)
 	assert.NoError(t, err)
 
@@ -85,7 +85,7 @@ func TestFillSpaceRelatedFields_ExternalAndInternal(t *testing.T) {
 // fillSpaceRelatedFields 不应查询群资料也不应写 group space，纯按 source 计算。
 // 这个用例保证即便 group 行意外缺失也不会 panic / 被错误填充。
 func TestFillSpaceRelatedFields_NoInternalMembers(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	err := testutil.CleanAllTables(ctx)
 	assert.NoError(t, err)
 
@@ -116,7 +116,7 @@ func TestFillSpaceRelatedFields_NoInternalMembers(t *testing.T) {
 // fillSpaceRelatedFields 不应再做 group 表查询，依然正确填充内部成员的 home_space_*。
 // 为了证明没有 fallback 到 group 表，故意传一个数据库里不存在的 groupNo。
 func TestFillSpaceRelatedFields_GroupSpaceIDPassedIn(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	err := testutil.CleanAllTables(ctx)
 	assert.NoError(t, err)
 
@@ -146,7 +146,7 @@ func TestFillSpaceRelatedFields_GroupSpaceIDPassedIn(t *testing.T) {
 // TestGetMemberExternalMarkers_HomeSpace 验证 Service 层 GetMemberExternalMarkers
 // 同时暴露 HomeSpaceID / HomeSpaceName，供消息同步热路径使用（YUJ-63 / #1208）。
 func TestGetMemberExternalMarkers_HomeSpace(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	err := testutil.CleanAllTables(ctx)
 	assert.NoError(t, err)
 

--- a/modules/group/is_manager_external_test.go
+++ b/modules/group/is_manager_external_test.go
@@ -13,7 +13,7 @@ import (
 // 的成员（例如 managerAdd 外部成员校验加入前遗留的数据），
 // QueryIsGroupManagerOrCreator 也必须返回 false，从而在角色判定层阻断 8 项敏感操作。
 func TestQueryIsGroupManagerOrCreator_ExternalMemberFailSafe(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	err := testutil.CleanAllTables(ctx)
 	assert.NoError(t, err)
 

--- a/modules/group/is_manager_status_test.go
+++ b/modules/group/is_manager_status_test.go
@@ -16,7 +16,7 @@ import (
 //
 // 配对 [[is_manager_external_test]]：两条 fail-safe 都在同一处 WHERE 上叠加。
 func TestQueryIsGroupManagerOrCreator_BlacklistedFailSafe(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	err := testutil.CleanAllTables(ctx)
 	assert.NoError(t, err)
 

--- a/modules/group/managerAdd_external_test.go
+++ b/modules/group/managerAdd_external_test.go
@@ -20,7 +20,7 @@ import (
 // 构造：creator + 1 个内部成员 + 1 个外部成员；creator 一次请求提拔两人。
 // 期望：返回 403 且拒绝写入（两人角色都保持 common）。
 func TestManagerAdd_RejectsExternalMember(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	wireI18nRendererForGroupTest(s)
 	f := New(ctx)
 
@@ -107,7 +107,7 @@ func TestManagerAdd_RejectsExternalMember(t *testing.T) {
 // 外部成员时，返回 403。防止外部成员获得 creator 角色从而取得所有敏感操作权限
 // (YUJ-231 / GH#1289)。
 func TestTransferGrouper_RejectsExternalMember(t *testing.T) {
-	s, ctx := testutil.NewTestServer()
+	s, ctx := newTestServer(t)
 	wireI18nRendererForGroupTest(s)
 	f := New(ctx)
 

--- a/modules/group/service_member_external_fields_test.go
+++ b/modules/group/service_member_external_fields_test.go
@@ -9,7 +9,7 @@ import (
 
 // TestGetMemberExternalFields_External YUJ-206 单成员版：外部成员 → home = source。
 func TestGetMemberExternalFields_External(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	assert.NoError(t, testutil.CleanAllTables(ctx))
 
 	groupSpaceID := "space-home-206"
@@ -39,7 +39,7 @@ func TestGetMemberExternalFields_External(t *testing.T) {
 
 // TestGetMemberExternalFields_Internal YUJ-206 单成员版：内部成员 → home = 群 Space。
 func TestGetMemberExternalFields_Internal(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	assert.NoError(t, testutil.CleanAllTables(ctx))
 
 	groupSpaceID := "space-home-206-int"
@@ -69,7 +69,7 @@ func TestGetMemberExternalFields_Internal(t *testing.T) {
 // TestGetMemberExternalFields_MissingOrEmpty 覆盖空入参 / 不存在成员 / 群无 Space
 // 三类边界，确保都返回全零值 + nil error，不抛异常。
 func TestGetMemberExternalFields_MissingOrEmpty(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	assert.NoError(t, testutil.CleanAllTables(ctx))
 
 	s := NewService(ctx).(*Service)

--- a/modules/group/service_test.go
+++ b/modules/group/service_test.go
@@ -13,7 +13,7 @@ import (
 
 func setupServiceTest(t *testing.T) (IService, *user.DB) {
 	t.Helper()
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	err := testutil.CleanAllTables(ctx)
 	assert.NoError(t, err)
 	userDB := user.NewDB(ctx)
@@ -24,7 +24,7 @@ func setupServiceTest(t *testing.T) (IService, *user.DB) {
 // setupServiceTestWithCtx exposes ctx so tests can seed space/space_member/group fixtures directly.
 func setupServiceTestWithCtx(t *testing.T) (IService, *user.DB, *config.Context) {
 	t.Helper()
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	err := testutil.CleanAllTables(ctx)
 	assert.NoError(t, err)
 	userDB := user.NewDB(ctx)

--- a/modules/group/subscribable_members_test.go
+++ b/modules/group/subscribable_members_test.go
@@ -15,7 +15,7 @@ import (
 // WuKongIM 重载订阅时把被拉黑用户加回订阅列表 → 拉黑不自愈。GetSubscribableMemberUIDs
 // 必须只返回 status=normal AND is_deleted=0 的成员。
 func TestGetSubscribableMemberUIDs_ExcludesBlacklist(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 
 	db := NewDB(ctx)
@@ -62,7 +62,7 @@ func TestGetSubscribableMemberUIDs_ExcludesBlacklist(t *testing.T) {
 
 // TestGetSubscribableMemberUIDs_ExcludesDeleted 防御：is_deleted=1 的成员同样排除。
 func TestGetSubscribableMemberUIDs_ExcludesDeleted(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
+	_, ctx := newTestServer(t)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 
 	db := NewDB(ctx)

--- a/modules/group/testserver_test.go
+++ b/modules/group/testserver_test.go
@@ -1,0 +1,44 @@
+package group
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/server"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+)
+
+// newTestServer wraps testutil.NewTestServer with a test-scoped connection
+// pool bound.
+//
+// testutil.NewTestServer builds a fresh *config.Context per call, and each
+// Context lazily opens its own *sql.DB pool (default 100 max / 10 idle conns)
+// that nothing ever closes. This package has 200+ tests that each call it, so
+// under `go test -race -shuffle=on` the abandoned pools accumulated idle
+// connections until the CI MySQL service hit max_connections and the suite
+// panicked with "Error 1040: Too many connections" (OCT-8).
+//
+// We bound each pool small and, crucially, give idle connections a short
+// lifetime so an abandoned pool drains to zero connections shortly after its
+// test finishes. We deliberately do NOT Close() the pool: config.NewContext
+// starts background dispatchers (EventPool/PushPool/RobotEventPool) and a
+// timing wheel that outlive the test and may still touch that Context's DB;
+// closing it out from under them panics a later test with "sql: database is
+// closed".
+func newTestServer(t *testing.T) (*server.Server, *config.Context) {
+	t.Helper()
+	s, ctx := testutil.NewTestServer()
+	bindTestDBPool(ctx)
+	return s, ctx
+}
+
+func bindTestDBPool(ctx *config.Context) {
+	conn := ctx.DB()
+	conn.SetMaxOpenConns(12)
+	conn.SetMaxIdleConns(2)
+	// Reap idle connections fast so leaked per-test pools shed their
+	// connections back to MySQL instead of pinning them until ConnMaxLifetime.
+	conn.SetConnMaxIdleTime(time.Second)
+	conn.SetConnMaxLifetime(30 * time.Second)
+}


### PR DESCRIPTION
## Summary
Permanent fix for the P1 flaky test `TestHandleGroupDisbandEvent_CleansThreadMembers` that turned `main` red on 2026-06-17 with `panic: Error 1040: Too many connections`.

**Root cause:** `modules/group` has 200+ tests that each call `testutil.NewTestServer`, which builds a fresh `*config.Context` and lazily opens its own `*sql.DB` pool (octo-lib defaults: 100 max / 10 idle conns). Nothing closes those pools. Under `go test -race -shuffle=on` the abandoned pools accumulate idle connections until the CI MySQL service exhausts `max_connections` (151) and the suite panics. It surfaced on the disband test only because `-shuffle` happened to land it after enough leaked pools.

**Fix:** Add a package-local `newTestServer(t)` chokepoint (`modules/group/testserver_test.go`) that bounds each pool (12 max / 2 idle) and reaps idle connections after 1s so abandoned pools drain back to MySQL. Migrated all 112 `testutil.NewTestServer()` call sites to it.

Pools are intentionally **not** `Close()`d: `config.NewContext` starts background dispatchers (`EventPool`/`PushPool`/`RobotEventPool`) and a timing wheel that outlive the test; closing the pool under them panics a later test with `sql: database is closed`. Capping idle conns + short idle lifetime fixes the leak without that hazard.

No production code changed — test harness only.

## Test plan
Run against the full CI service stack (`mysql:8.0` / `redis:7` / `wukongim v2.2.4-20260313`), DB recreated `utf8mb4_general_ci`:

- [x] **Before (this branch's parent):** `go test -race -shuffle=on -count=5 ./modules/group/...` → `panic: Error 1040: Too many connections` at ~26s.
- [x] **After:** same command → `ok ... 140.566s`, exit 0. `TestHandleGroupDisbandEvent_CleansThreadMembers` passes 5/5.
- [x] Peak `MySQL Max_used_connections` during the green run = **21** (limit 151), down from exhausting 151+.
- [x] `go vet ./modules/group/` clean; `go test -race -c` builds.

Paperclip: OCT-8