### PR TITLE
feat(audit): operator logging on /v1/manager admin writes (#367 Phase 1)

### DIFF
--- a/docs/operator-audit-log.md
+++ b/docs/operator-audit-log.md
@@ -1,0 +1,55 @@
+# Operator-Audit Log — admin/management writes (#367 Phase 1)
+
+Forensic "who did what" trail for the admin/management write surface. Every
+mutating request to `/v1/manager` emits **one** structured log line. This is
+**Phase 1 (logging only)** — Phase 2 (the centralized admin-action audit table,
+SecurityEngineer workstream) consumes these lines into durable storage.
+
+- Implementation: `pkg/accesslog/operator_audit.go`
+  (`OperatorAuditMiddleware`), wired as a global middleware in `main.go`.
+- Scope of writes audited: HTTP `POST` / `PUT` / `PATCH` / `DELETE` whose request
+  path is `/v1/manager` or under `/v1/manager/…` (covers `user`, `message`,
+  `group`, `workplace`, `robot`, `common`, and any future manager subgroup —
+  matching is on the raw request path, so new routes are covered automatically).
+- Read traffic (`GET`/`HEAD`) and non-manager routes are **not** audited.
+
+## Line format
+
+The line is emitted via the standard zap logger (`log.NewTLog("ManagerAudit")`),
+so it also carries the logger's own `ts` and `level`. Audit-specific fields:
+
+| field         | type   | meaning                                                              |
+| ------------- | ------ | -------------------------------------------------------------------- |
+| `audit`       | string | constant `manager_admin_action` — stable discriminator for ingest.  |
+| `operator_id` | string | acting user/agent id (`c.GetLoginUID()` / `c.Set("uid")`).           |
+| `action`      | string | HTTP method: `POST` \| `PUT` \| `PATCH` \| `DELETE`.                 |
+| `target`      | string | scrubbed request path identifying the resource acted on.             |
+| `status`      | int    | final HTTP response status code.                                     |
+| `ts`          | string | RFC3339 UTC timestamp when the line was emitted.                     |
+
+The zap message string is also `manager_admin_action`, identical to the `audit`
+field. Phase 2 can key ingest off either.
+
+### Reading `operator_id`
+
+- Non-empty `operator_id` + 2xx `status` ⇒ an authenticated admin successfully
+  performed the action.
+- **Empty** `operator_id` (paired with a 4xx `status`) ⇒ an unauthenticated or
+  auth-rejected attempt. These are intentionally audited too, as attempt
+  forensics; Phase 2 may choose to store or filter them.
+
+## Security-by-default (what is deliberately NOT logged)
+
+- **No request bodies.** The middleware never reads the body, so secrets that
+  ride in bodies cannot leak — notably `POST /v1/manager/user/resetpassword`
+  and `POST /v1/manager/user/updatepassword`.
+- **No query string.** `target` is the URL *path* only, run through
+  `ScrubPath` (the same scrubber used by the access logger), so even a path that
+  embeds a token is masked.
+- Consequence for Phase 2: the path names the target *surface* (e.g.
+  `/v1/manager/robots/:robot_id`); for actions whose target id lives in the body
+  (e.g. password reset), Phase 1 records the operator + action + endpoint but
+  not the body-side target. Capturing richer, safe target detail is Phase 2's
+  job in the audit table.
+
+GitHub: https://github.com/Mininglamp-OSS/octo-server/issues/367

--- a/main.go
+++ b/main.go
@@ -161,6 +161,11 @@ func runAPI(ctx *config.Context) {
 		}
 		accessLogger(c)
 	})
+	// Operator-audit log for admin/management writes (#367 Phase 1): one
+	// structured "who did what" line per mutating /v1/manager request. Reads the
+	// operator id set by AuthMiddleware after c.Next(); see pkg/accesslog
+	// operator_audit.go for the field schema Phase 2 consumes.
+	route.UseGin(accesslog.OperatorAuditMiddleware(log.NewTLog("ManagerAudit")))
 	// 全局 per-IP 作为 DDoS 底线：办公室共享出网 IP 下 IM 基础量就能到 100+ rps
 	// （每人 1-2 rps × 数十人），200 余量过小；真实 DDoS 常数千 rps+，底线设 500
 	// 更合理。精细限流交给 UID 层和端点级严格桶（#1090）。

--- a/pkg/accesslog/operator_audit.go
+++ b/pkg/accesslog/operator_audit.go
@@ -1,0 +1,87 @@
+package accesslog
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+// Operator-audit logging (octo-server #367 Phase 1).
+//
+// Goal: a "who did what" forensic trail for admin/management writes. Every
+// mutating request to the /v1/manager surface emits exactly one structured log
+// line carrying the acting operator's id, the action, the target, the response
+// status and a timestamp. This is logging-only — the centralized audit table
+// (Phase 2, SecurityEngineer) consumes these lines later; see the format note
+// in this file's doc comments below.
+//
+// Security-by-default: the line is built from the request method, the
+// URL *path* (scrubbed via ScrubPath, never the query string) and the operator
+// id set by AuthMiddleware. Request bodies are never read, so secrets that ride
+// in bodies (e.g. /v1/manager/user/resetpassword, .../updatepassword) cannot
+// leak into logs. The path of a manager route names the target resource and is
+// itself the action metadata Phase 2 needs.
+
+const (
+	// managerPrefix is the admin/management write surface being audited.
+	managerPrefix = "/v1/manager"
+
+	// AuditLogMessage is the stable zap message (and "audit" field value) on
+	// every admin-action line. Phase 2 keys its audit-table ingest off this
+	// exact discriminator, so it must not change without coordinating the
+	// consumer.
+	AuditLogMessage = "manager_admin_action"
+)
+
+// OperatorAuditMiddleware returns a gin middleware that emits one structured
+// audit log line per mutating (POST/PUT/PATCH/DELETE) request under
+// /v1/manager.
+//
+// Field schema of each emitted line (in addition to the logger's own ts/level):
+//
+//   - audit:       constant "manager_admin_action" (stable discriminator)
+//   - operator_id: acting user/agent id (empty string => unauthenticated or
+//     auth-rejected attempt; pair with a 4xx status to read it that way)
+//   - action:      HTTP method (POST | PUT | PATCH | DELETE)
+//   - target:      scrubbed request path identifying the resource acted on
+//   - status:      final HTTP response status code
+//   - ts:          RFC3339 UTC timestamp of when the line was emitted
+//
+// The operator id is read after c.Next() because AuthMiddleware (which runs in
+// the matched route group, i.e. during c.Next()) is what sets it via
+// c.Set("uid", ...). Logging post-handler also lets us record the real
+// response status, so rejected/forbidden attempts are captured too.
+func OperatorAuditMiddleware(lg log.Log) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !isManagerWrite(c.Request.Method, c.Request.URL.Path) {
+			c.Next()
+			return
+		}
+		c.Next()
+		lg.Info(AuditLogMessage,
+			zap.String("audit", AuditLogMessage),
+			zap.String("operator_id", c.GetString("uid")),
+			zap.String("action", c.Request.Method),
+			zap.String("target", ScrubPath(c.Request.URL.Path)),
+			zap.Int("status", c.Writer.Status()),
+			zap.String("ts", time.Now().UTC().Format(time.RFC3339)),
+		)
+	}
+}
+
+// isManagerWrite reports whether (method, path) is a mutating action on the
+// /v1/manager admin surface. Match is on the raw request path (not the matched
+// route template) so that attempts which 404 under the manager prefix are still
+// audited.
+func isManagerWrite(method, path string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+	default:
+		return false
+	}
+	return path == managerPrefix || strings.HasPrefix(path, managerPrefix+"/")
+}

--- a/pkg/accesslog/operator_audit_test.go
+++ b/pkg/accesslog/operator_audit_test.go
@@ -1,0 +1,166 @@
+package accesslog
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+// captureLog is a log.Log fake that records the fields of the most recent
+// Info call so tests can assert on the emitted audit line.
+type captureLog struct {
+	calls []capturedLine
+}
+
+type capturedLine struct {
+	msg    string
+	fields map[string]zap.Field
+}
+
+func (c *captureLog) record(msg string, fields []zap.Field) {
+	m := make(map[string]zap.Field, len(fields))
+	for _, f := range fields {
+		m[f.Key] = f
+	}
+	c.calls = append(c.calls, capturedLine{msg: msg, fields: m})
+}
+
+func (c *captureLog) Info(msg string, fields ...zap.Field)  { c.record(msg, fields) }
+func (c *captureLog) Debug(msg string, fields ...zap.Field) {}
+func (c *captureLog) Error(msg string, fields ...zap.Field) {}
+func (c *captureLog) Warn(msg string, fields ...zap.Field)  {}
+
+// newAuditRouter builds a gin router wired exactly like production: the audit
+// middleware is global, and a fake AuthMiddleware (mirroring octo-lib's
+// c.Set("uid", ...)) runs inside the matched /v1/manager route group. operator
+// is the uid the fake auth sets; pass "" to simulate an unauthenticated actor.
+func newAuditRouter(lg *captureLog, operator string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(OperatorAuditMiddleware(lg))
+
+	mgr := r.Group("/v1/manager", func(c *gin.Context) {
+		if operator != "" {
+			c.Set("uid", operator)
+		}
+		c.Next()
+	})
+	mgr.POST("/user/admin", func(c *gin.Context) { c.Status(http.StatusOK) })
+	mgr.GET("/user/list", func(c *gin.Context) { c.Status(http.StatusOK) })
+	return r
+}
+
+// Representative admin mutation: the operator id must appear on the audit line.
+func TestOperatorAuditMiddleware_LogsOperatorOnAdminWrite(t *testing.T) {
+	lg := &captureLog{}
+	r := newAuditRouter(lg, "u_admin_42")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/manager/user/admin", nil)
+	r.ServeHTTP(w, req)
+
+	if len(lg.calls) != 1 {
+		t.Fatalf("expected exactly 1 audit line, got %d", len(lg.calls))
+	}
+	line := lg.calls[0]
+	if line.msg != AuditLogMessage {
+		t.Errorf("audit message = %q, want %q", line.msg, AuditLogMessage)
+	}
+
+	op, ok := line.fields["operator_id"]
+	if !ok {
+		t.Fatal("audit line missing operator_id field")
+	}
+	if op.String != "u_admin_42" {
+		t.Errorf("operator_id = %q, want %q", op.String, "u_admin_42")
+	}
+
+	// Action, target and a timestamp must all be present for Phase 2 ingest.
+	if got := line.fields["action"].String; got != http.MethodPost {
+		t.Errorf("action = %q, want %q", got, http.MethodPost)
+	}
+	if got := line.fields["target"].String; got != "/v1/manager/user/admin" {
+		t.Errorf("target = %q, want %q", got, "/v1/manager/user/admin")
+	}
+	if _, ok := line.fields["ts"]; !ok {
+		t.Error("audit line missing ts field")
+	}
+	if got := line.fields["status"].Integer; got != int64(http.StatusOK) {
+		t.Errorf("status = %d, want %d", got, http.StatusOK)
+	}
+}
+
+// Read-only admin traffic must not be audited.
+func TestOperatorAuditMiddleware_SkipsReads(t *testing.T) {
+	lg := &captureLog{}
+	r := newAuditRouter(lg, "u_admin_42")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/manager/user/list", nil)
+	r.ServeHTTP(w, req)
+
+	if len(lg.calls) != 0 {
+		t.Fatalf("GET should not be audited, got %d lines", len(lg.calls))
+	}
+}
+
+// Non-manager writes must not be audited.
+func TestOperatorAuditMiddleware_SkipsNonManager(t *testing.T) {
+	lg := &captureLog{}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(OperatorAuditMiddleware(lg))
+	r.POST("/v1/message/send", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/message/send", nil)
+	r.ServeHTTP(w, req)
+
+	if len(lg.calls) != 0 {
+		t.Fatalf("non-manager write should not be audited, got %d lines", len(lg.calls))
+	}
+}
+
+// An unauthenticated/rejected attempt is still audited, with an empty
+// operator_id — useful forensic signal when paired with a 4xx status.
+func TestOperatorAuditMiddleware_AuditsRejectedAttemptWithEmptyOperator(t *testing.T) {
+	lg := &captureLog{}
+	r := newAuditRouter(lg, "") // no uid set => unauthenticated
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/manager/user/admin", nil)
+	r.ServeHTTP(w, req)
+
+	if len(lg.calls) != 1 {
+		t.Fatalf("expected 1 audit line for the attempt, got %d", len(lg.calls))
+	}
+	if got := lg.calls[0].fields["operator_id"].String; got != "" {
+		t.Errorf("operator_id = %q, want empty for unauthenticated attempt", got)
+	}
+}
+
+func TestIsManagerWrite(t *testing.T) {
+	tests := []struct {
+		method, path string
+		want         bool
+	}{
+		{http.MethodPost, "/v1/manager/user/admin", true},
+		{http.MethodPut, "/v1/manager/group/liftban/g1/1", true},
+		{http.MethodDelete, "/v1/manager/robots/r1", true},
+		{http.MethodPatch, "/v1/manager/anything", true},
+		{http.MethodPost, "/v1/manager/workplace/app", true},
+		{http.MethodGet, "/v1/manager/user/list", false},
+		{http.MethodHead, "/v1/manager/user/list", false},
+		{http.MethodPost, "/v1/message/send", false},
+		{http.MethodPost, "/v1/managerx/foo", false}, // prefix must be a path segment
+		{http.MethodPost, "/v1/manager", true},       // bare prefix counts
+	}
+	for _, tt := range tests {
+		if got := isManagerWrite(tt.method, tt.path); got != tt.want {
+			t.Errorf("isManagerWrite(%q, %q) = %v, want %v", tt.method, tt.path, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of #367 — a forensic "who did what" trail for admin/management writes (logging only; the centralized audit table is Phase 2, SecurityEngineer).

- New global gin middleware `accesslog.OperatorAuditMiddleware` (`pkg/accesslog/operator_audit.go`), wired in `main.go` alongside the existing access logger.
- Emits **one** structured log line per mutating (`POST`/`PUT`/`PATCH`/`DELETE`) request under `/v1/manager`, with fields: `audit`, `operator_id`, `action`, `target`, `status`, `ts`.
- One chokepoint covers every manager subgroup (user/message/group/workplace/robot/common/…) **and future routes** — matching is on the raw request path. Operator id is read after `c.Next()` (AuthMiddleware sets `c.Set("uid", …)` during the matched group), which also lets us capture auth-rejected attempts (empty `operator_id` + 4xx).

## Security-by-default

- Never reads request bodies, so password-bearing routes (`/v1/manager/user/resetpassword`, `.../updatepassword`) can't leak secrets into logs.
- `target` is the URL **path only**, run through the existing `ScrubPath`; the query string is never logged.

## Format for Phase 2

Documented in `docs/operator-audit-log.md` so the audit-table ingest can key off the stable `manager_admin_action` discriminator.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/accesslog/` — incl. a test asserting `operator_id` is present on a representative admin mutation (`POST /v1/manager/user/admin`), plus skip-reads / skip-non-manager / rejected-attempt / `isManagerWrite` table.
- [x] `gofmt` clean, `go vet ./pkg/accesslog/` clean
- [ ] CI green
- [ ] CTO security review (security owner) before merge

Closes #367 (Phase 1 scope only).