### PR TITLE
feat(security): CI source-guard requiring a role check on every /v1/manager route

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,36 @@ jobs:
       - name: Reject direct PERSONAL MsgSendReq literals
         run: go run ./tools/lint-personal-msgsendreq ./modules
 
+  manager-authz-lint:
+    needs: [changes]
+    if: |
+      (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
+      needs.changes.outputs.code == 'true'
+    # Mininglamp-OSS/octo-server#366 Part 1: source-guard for the admin
+    # (/v1/manager) authorization surface. Authz there is enforced per-handler
+    # by an inline c.CheckLoginRole / c.CheckLoginRoleIsSuperAdmin call (no
+    # central policy middleware yet). A new /v1/manager route that forgets the
+    # check would silently ship a privilege-escalation hole — AuthMiddleware
+    # only authenticates, it does not gate role. This guard AST-walks ./modules
+    # and fails CI if any /v1/manager route handler lacks a role check, unless
+    # the route is allowlisted (tools/lint-manager-authz/allowlist.txt) with a
+    # reason. The tool's own unit tests run first.
+    name: Manager Authz Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Test the guard
+        run: go test ./tools/lint-manager-authz/...
+
+      - name: Require a role check on every /v1/manager route
+        run: go run ./tools/lint-manager-authz ./modules
+
   i18n-extract-check:
     needs: [changes]
     if: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ Tests require MySQL + Redis + WuKongIM running (see CI or `make env-test` in dmw
 - API routes: prefix `/v1/`
 - New modules: add blank import in `internal/modules.go`
 - Auth: all routes go through `AuthMiddleware` unless explicitly excluded — document why if skipping
+- Manager authz: every `/v1/manager` **admin** route handler must call a role check (`c.CheckLoginRoleIsSuperAdmin()` or `c.CheckLoginRole()`) before doing work — `AuthMiddleware` only authenticates, it does not gate admin role. The `manager-authz-lint` CI guard (`tools/lint-manager-authz`) fails the build on any `/v1/manager` route whose handler lacks a check. Routes that live under `/v1/manager` but are NOT admin (public login, user-scoped CRUD like `/v1/manager/secrets`) go in `tools/lint-manager-authz/allowlist.txt` with a one-line reason (octo-server#366 Part 1)
 - i18n: user-facing errors use `httperr.ResponseErrorL` + a registered `pkg/errcode` code; never raw `c.ResponseError`/`c.JSON`/`AbortWithStatusJSON`. Run `make i18n-extract-check` + `make i18n-lint` after touching codes (see Architecture › Error Handling & i18n)
 - Rate limiting: mount `SharedUIDRateLimiter` (auth routes) or `StrictIPRateLimitMiddleware` (unauth) — never hand-roll a Redis counter for request-frequency limiting (see Architecture › Rate Limiting)
 - Space isolation: handlers that access user data must go through Space middleware

--- a/tools/lint-manager-authz/allowlist.txt
+++ b/tools/lint-manager-authz/allowlist.txt
@@ -1,0 +1,16 @@
+# lint-manager-authz allowlist — routes under /v1/manager that intentionally
+# do NOT carry an admin role check. Format: "<VERB> <path>  # reason".
+# Every entry MUST have a reason. See tools/lint-manager-authz/main.go and
+# https://github.com/Mininglamp-OSS/octo-server/issues/366.
+
+# Public, pre-auth: issues the admin session token. The group has no
+# AuthMiddleware by design; role cannot be checked before login.
+POST /v1/manager/login  # public login endpoint, issues admin session token
+
+# User-scoped secret CRUD that happens to live under the /v1/manager/secrets
+# path. Authz here is AuthMiddleware (authenticated user) + owner==login-UID
+# scoping inside the handler, NOT an admin-role gate. Not an admin surface.
+POST   /v1/manager/secrets              # user-scoped (owner=UID), not admin
+GET    /v1/manager/secrets              # user-scoped (owner=UID), not admin
+PUT    /v1/manager/secrets/:secret_id   # user-scoped (owner=UID), not admin
+DELETE /v1/manager/secrets/:secret_id   # user-scoped (owner=UID), not admin

--- a/tools/lint-manager-authz/main.go
+++ b/tools/lint-manager-authz/main.go
@@ -1,0 +1,583 @@
+// Command lint-manager-authz is the octo-server#366 Part 1 source-guard. It
+// AST-walks the module packages and fails the build if any route registered on
+// a `/v1/manager` route group has a handler that does not perform a role/authz
+// check.
+//
+// Why this guard exists:
+//
+//	Authorization on the manager (admin) surface is enforced per-handler by an
+//	inline `c.CheckLoginRoleIsSuperAdmin()` / `c.CheckLoginRole()` call — there
+//	is no central policy middleware yet (that is the SecurityEngineer's systemic
+//	workstream). With the check scattered across ~100 handlers, a new
+//	`/v1/manager/...` route that simply forgets the check silently ships a
+//	privilege-escalation hole: `AuthMiddleware` only authenticates the caller,
+//	it does NOT gate on admin role. This guard makes that omission a CI failure
+//	instead of a production incident — a thin, reversible safety net that holds
+//	the line until the centralized authz layer lands.
+//
+// What counts as "checked":
+//
+//	A handler is covered if its body (or a same-package helper it calls, up to a
+//	small depth) invokes one of the approved role-check primitives, OR its route
+//	group is constructed with a role-enforcing middleware (see roleMiddleware),
+//	OR the route is explicitly allowlisted in allowlist.txt with a reason.
+//
+// How to satisfy the guard for a NEW /v1/manager route:
+//
+//	Call a role check at the top of the handler before doing any work, e.g.
+//	    if err := c.CheckLoginRoleIsSuperAdmin(); err != nil { c.ResponseError(err); return }
+//	(use CheckLoginRole for the admin∪superAdmin tier). If the route is
+//	deliberately NOT an admin route (public, or user-scoped by UID like
+//	/v1/manager/secrets), add it to tools/lint-manager-authz/allowlist.txt with
+//	a one-line reason.
+//
+// Usage:
+//
+//	go run ./tools/lint-manager-authz [root...]
+//
+// Defaults to scanning ./modules. Test files (*_test.go) are skipped.
+//
+// Exit codes: 0 (clean), 1 (uncovered route(s)), 2 (walk/allowlist error).
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// managerPathPrefix is the route-group path that puts a handler in scope. It
+// matches the exact prefix and any deeper group (e.g. /v1/manager/workplace,
+// /v1/manager/dashboard, /v1/manager/secrets).
+const managerPathPrefix = "/v1/manager"
+
+// allowlistRelPath lives next to this command so `go run ./tools/...` finds it
+// regardless of the CI step's working directory.
+const allowlistRelPath = "tools/lint-manager-authz/allowlist.txt"
+
+// roleCheckNames is the set of *wkhttp.Context methods that count as a role/
+// authz gate. Keep this in sync with octo-lib's wkhttp.Context.
+var roleCheckNames = map[string]bool{
+	"CheckLoginRole":             true, // admin ∪ superAdmin
+	"CheckLoginRoleIsSuperAdmin": true, // superAdmin only
+}
+
+// roleMiddleware is the set of route-group middleware identifiers that enforce
+// a role by themselves, making a per-handler check unnecessary. Empty today —
+// the manager surface authenticates at the group (AuthMiddleware) and gates
+// role per-handler. Populated here so a future role-enforcing middleware is
+// recognized without touching the walk logic.
+var roleMiddleware = map[string]bool{}
+
+// httpVerbs is the set of route-registration method names on a route group.
+var httpVerbs = map[string]bool{
+	"GET": true, "POST": true, "PUT": true, "DELETE": true,
+	"PATCH": true, "HEAD": true, "OPTIONS": true, "Any": true, "Handle": true,
+}
+
+// maxHelperDepth bounds the transitive same-package helper search so a handler
+// that delegates its role check to a small wrapper still counts as covered,
+// without the cost (or cycles) of whole-program analysis.
+const maxHelperDepth = 2
+
+func main() {
+	roots := os.Args[1:]
+	if len(roots) == 0 {
+		roots = []string{"modules"}
+	}
+
+	allow, err := loadAllowlist(allowlistRelPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load allowlist %q: %v\n", allowlistRelPath, err)
+		os.Exit(2)
+	}
+
+	pkgs, err := collectPackages(roots)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(2)
+	}
+
+	var violations []string
+	routeCount := 0
+	for _, pkg := range pkgs {
+		v, n := pkg.collectViolations(allow)
+		violations = append(violations, v...)
+		routeCount += n
+	}
+
+	sort.Strings(violations)
+	if len(violations) > 0 {
+		for _, v := range violations {
+			fmt.Println(v)
+		}
+		fmt.Printf("\nFound %d /v1/manager route(s) with no role check.\n", len(violations))
+		fmt.Println("Add a role check at the top of the handler, e.g.:")
+		fmt.Println("    if err := c.CheckLoginRoleIsSuperAdmin(); err != nil { c.ResponseError(err); return }")
+		fmt.Println("If the route is intentionally NOT an admin route (public, or user-scoped by UID),")
+		fmt.Println("add it to " + allowlistRelPath + " with a one-line reason.")
+		fmt.Println("See https://github.com/Mininglamp-OSS/octo-server/issues/366.")
+		os.Exit(1)
+	}
+
+	fmt.Printf("OK: all %d /v1/manager route(s) are role-checked or allowlisted (%d allowlist entr(ies)).\n",
+		routeCount, len(allow))
+}
+
+// route is a single registration on a manager route group.
+type route struct {
+	file                   string
+	line                   int
+	method                 string // HTTP verb
+	path                   string // full path including the group base
+	handler                ast.Expr
+	enclosingRecvType      string // receiver type of the func that registered the route
+	groupHasRoleMiddleware bool
+}
+
+func (r route) sig() string { return r.method + " " + r.path }
+
+func (r route) handlerName() string {
+	switch h := r.handler.(type) {
+	case *ast.SelectorExpr:
+		if h.Sel != nil {
+			return h.Sel.Name
+		}
+	case *ast.Ident:
+		return h.Name
+	case *ast.FuncLit:
+		return "<func literal>"
+	}
+	return "<unknown>"
+}
+
+// pkg holds the parsed files of a single Go package directory plus the indexes
+// the analysis needs.
+type pkg struct {
+	dir   string
+	fset  *token.FileSet
+	files []*ast.File
+	// funcsByName maps a function/method name to all its declarations in the
+	// package (handlers may collide across receiver types; resolution prefers a
+	// matching receiver type, see handlerHasRoleCheck). This is package-global
+	// on purpose: a route registered in api_manager.go may point at a handler
+	// method defined in another file of the same package.
+	funcsByName map[string][]*ast.FuncDecl
+}
+
+type groupInfo struct {
+	basePath  string
+	hasRoleMW bool
+}
+
+// collectPackages walks the roots and groups .go files by directory.
+func collectPackages(roots []string) ([]*pkg, error) {
+	byDir := map[string][]string{}
+	for _, root := range roots {
+		walkErr := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				if name := info.Name(); name == "vendor" || name == "tools" || name == "testdata" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			dir := filepath.Dir(path)
+			byDir[dir] = append(byDir[dir], path)
+			return nil
+		})
+		if walkErr != nil {
+			return nil, fmt.Errorf("walk %q: %w", root, walkErr)
+		}
+	}
+
+	dirs := make([]string, 0, len(byDir))
+	for d := range byDir {
+		dirs = append(dirs, d)
+	}
+	sort.Strings(dirs)
+
+	var pkgs []*pkg
+	for _, dir := range dirs {
+		p := &pkg{
+			dir:         dir,
+			fset:        token.NewFileSet(),
+			funcsByName: map[string][]*ast.FuncDecl{},
+		}
+		for _, path := range byDir[dir] {
+			f, perr := parser.ParseFile(p.fset, path, nil, 0)
+			if perr != nil {
+				// go build / go vet is the canonical syntax gate; skip
+				// unparseable files rather than failing the lint on them.
+				continue
+			}
+			p.files = append(p.files, f)
+			for _, decl := range f.Decls {
+				if fn, ok := decl.(*ast.FuncDecl); ok {
+					p.funcsByName[fn.Name.Name] = append(p.funcsByName[fn.Name.Name], fn)
+				}
+			}
+		}
+		pkgs = append(pkgs, p)
+	}
+	return pkgs, nil
+}
+
+// localGroupVars resolves, within a single function body, the variables bound to
+// a `/v1/manager` route group. Route-group variables are function-local (every
+// Route() method reuses names like `auth`/`v`), so resolution MUST be scoped to
+// the function — a package-global index would conflate the admin group in
+// api_manager.go with an unrelated `/v1` or `/v1/space` group of the same name
+// in api.go. Subgroups derived from a manager group within the same body are
+// followed to a fixed point.
+func localGroupVars(body *ast.BlockStmt) map[string]groupInfo {
+	type pending struct {
+		name     string
+		recvExpr ast.Expr // the X in X.Group(...)
+		basePath string
+		hasMW    bool
+	}
+	var all []pending
+	ast.Inspect(body, func(n ast.Node) bool {
+		as, ok := n.(*ast.AssignStmt)
+		if !ok || len(as.Lhs) != 1 || len(as.Rhs) != 1 {
+			return true
+		}
+		lhs, ok := as.Lhs[0].(*ast.Ident)
+		if !ok {
+			return true
+		}
+		call, ok := as.Rhs[0].(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel == nil || sel.Sel.Name != "Group" || len(call.Args) == 0 {
+			return true
+		}
+		lit := stringLit(call.Args[0])
+		if lit == "" {
+			return true
+		}
+		all = append(all, pending{
+			name:     lhs.Name,
+			recvExpr: sel.X,
+			basePath: lit,
+			hasMW:    hasRoleMiddleware(call.Args[1:]),
+		})
+		return true
+	})
+
+	groups := map[string]groupInfo{}
+	for changed := true; changed; {
+		changed = false
+		for _, pd := range all {
+			if _, done := groups[pd.name]; done {
+				continue
+			}
+			var base string
+			var inheritedMW bool
+			if strings.HasPrefix(pd.basePath, managerPathPrefix) {
+				base = pd.basePath
+			} else if recv, ok := pd.recvExpr.(*ast.Ident); ok {
+				parent, ok := groups[recv.Name]
+				if !ok {
+					continue // not a manager group (or parent not yet known)
+				}
+				base = parent.basePath + pd.basePath
+				inheritedMW = parent.hasRoleMW
+			} else {
+				continue
+			}
+			groups[pd.name] = groupInfo{basePath: base, hasRoleMW: pd.hasMW || inheritedMW}
+			changed = true
+		}
+	}
+	return groups
+}
+
+// collectViolations returns the uncovered-route messages for this package and
+// the total number of manager routes inspected. A route is covered if it is
+// allowlisted, its group carries a role-enforcing middleware, or its handler
+// performs a role check.
+func (p *pkg) collectViolations(allow map[string]bool) (violations []string, routeCount int) {
+	for _, rt := range p.managerRoutes() {
+		routeCount++
+		if allow[rt.sig()] || rt.groupHasRoleMiddleware {
+			continue
+		}
+		if p.handlerHasRoleCheck(rt.handler, rt.enclosingRecvType) {
+			continue
+		}
+		violations = append(violations,
+			fmt.Sprintf("%s:%d: %s %s -> handler %s has no role check (CheckLoginRole / CheckLoginRoleIsSuperAdmin)",
+				rt.file, rt.line, rt.method, rt.path, rt.handlerName()))
+	}
+	return violations, routeCount
+}
+
+// managerRoutes returns every route registered on a `/v1/manager` group,
+// analyzing each function independently so function-local group variables do
+// not leak across Route() methods.
+func (p *pkg) managerRoutes() []route {
+	var routes []route
+	for _, f := range p.files {
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			groups := localGroupVars(fn.Body)
+			if len(groups) == 0 {
+				continue
+			}
+			recvType := recvTypeName(fn)
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel == nil || !httpVerbs[sel.Sel.Name] {
+					return true
+				}
+				recv, ok := sel.X.(*ast.Ident)
+				if !ok {
+					return true
+				}
+				gi, ok := groups[recv.Name]
+				if !ok {
+					return true
+				}
+				if len(call.Args) < 2 {
+					return true
+				}
+				sub := stringLit(call.Args[0])
+				handler := call.Args[len(call.Args)-1]
+				pos := p.fset.Position(call.Pos())
+				routes = append(routes, route{
+					file:                   filepath.ToSlash(pos.Filename),
+					line:                   pos.Line,
+					method:                 sel.Sel.Name,
+					path:                   joinRoutePath(gi.basePath, sub),
+					handler:                handler,
+					enclosingRecvType:      recvType,
+					groupHasRoleMiddleware: gi.hasRoleMW,
+				})
+				return true
+			})
+		}
+	}
+	return routes
+}
+
+// handlerHasRoleCheck reports whether the handler expression (a func literal,
+// package func ident, or recv.method selector) performs a role check, directly
+// or via a same-package helper within maxHelperDepth.
+func (p *pkg) handlerHasRoleCheck(handler ast.Expr, recvType string) bool {
+	switch h := handler.(type) {
+	case *ast.FuncLit:
+		return p.bodyHasRoleCheck(h.Body, recvType, maxHelperDepth, map[string]bool{})
+	case *ast.Ident:
+		return p.namedFuncHasRoleCheck(h.Name, recvType, maxHelperDepth, map[string]bool{})
+	case *ast.SelectorExpr:
+		if h.Sel == nil {
+			return false
+		}
+		return p.namedFuncHasRoleCheck(h.Sel.Name, recvType, maxHelperDepth, map[string]bool{})
+	}
+	return false
+}
+
+// namedFuncHasRoleCheck resolves a function/method by name (preferring a
+// receiver-type match) and checks its body.
+func (p *pkg) namedFuncHasRoleCheck(name, recvType string, depth int, visited map[string]bool) bool {
+	if visited[name] {
+		return false
+	}
+	visited[name] = true
+
+	cands := p.funcsByName[name]
+	if len(cands) == 0 {
+		// Handler defined outside this package (rare for manager routes). We
+		// cannot see its body, so we cannot confirm a check — treat as not
+		// covered so the gap surfaces (allowlist if intentional).
+		return false
+	}
+	// Prefer a candidate whose receiver type matches the registering func.
+	var chosen *ast.FuncDecl
+	for _, fn := range cands {
+		if recvTypeName(fn) == recvType {
+			chosen = fn
+			break
+		}
+	}
+	if chosen == nil {
+		chosen = cands[0]
+	}
+	if chosen.Body == nil {
+		return false
+	}
+	return p.bodyHasRoleCheck(chosen.Body, recvTypeName(chosen), depth, visited)
+}
+
+// bodyHasRoleCheck scans a function body for a role-check call. If none is found
+// directly and depth remains, it recurses into same-package functions/methods
+// the body calls (handles a handler that delegates the check to a wrapper).
+func (p *pkg) bodyHasRoleCheck(body *ast.BlockStmt, recvType string, depth int, visited map[string]bool) bool {
+	found := false
+	var helperCalls []string
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch fun := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			if fun.Sel == nil {
+				return true
+			}
+			if roleCheckNames[fun.Sel.Name] {
+				found = true
+				return false
+			}
+			// recv.helper(...) — candidate same-package method to recurse into.
+			helperCalls = append(helperCalls, fun.Sel.Name)
+		case *ast.Ident:
+			// helper(...) — candidate same-package function.
+			helperCalls = append(helperCalls, fun.Name)
+		}
+		return true
+	})
+	if found {
+		return true
+	}
+	if depth <= 0 {
+		return false
+	}
+	for _, name := range helperCalls {
+		if roleCheckNames[name] {
+			return true
+		}
+		if p.namedFuncHasRoleCheck(name, recvType, depth-1, visited) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasRoleMiddleware reports whether any of the group's middleware arguments is
+// a recognized role-enforcing middleware.
+func hasRoleMiddleware(args []ast.Expr) bool {
+	for _, a := range args {
+		if name := calleeName(a); name != "" && roleMiddleware[name] {
+			return true
+		}
+	}
+	return false
+}
+
+// calleeName returns the trailing identifier of a middleware expression, e.g.
+// `it.requireSuperAdmin()` -> "requireSuperAdmin", `RequireRole(r)` -> "RequireRole".
+func calleeName(e ast.Expr) string {
+	switch t := e.(type) {
+	case *ast.CallExpr:
+		return calleeName(t.Fun)
+	case *ast.SelectorExpr:
+		if t.Sel != nil {
+			return t.Sel.Name
+		}
+	case *ast.Ident:
+		return t.Name
+	}
+	return ""
+}
+
+// recvTypeName returns the receiver type name of a method decl ("" for a plain
+// func), unwrapping a pointer receiver.
+func recvTypeName(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return ""
+	}
+	switch t := fn.Recv.List[0].Type.(type) {
+	case *ast.StarExpr:
+		if id, ok := t.X.(*ast.Ident); ok {
+			return id.Name
+		}
+	case *ast.Ident:
+		return t.Name
+	}
+	return ""
+}
+
+// stringLit returns the unquoted value of a basic string literal, or "".
+func stringLit(e ast.Expr) string {
+	lit, ok := e.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return ""
+	}
+	return strings.Trim(lit.Value, "`\"")
+}
+
+// joinRoutePath joins a group base path and a route sub-path with exactly one
+// slash, tolerating sub-paths written with or without a leading slash.
+func joinRoutePath(base, sub string) string {
+	if sub == "" {
+		return base
+	}
+	if strings.HasSuffix(base, "/") {
+		base = strings.TrimSuffix(base, "/")
+	}
+	if !strings.HasPrefix(sub, "/") {
+		sub = "/" + sub
+	}
+	return base + sub
+}
+
+// loadAllowlist parses allowlist.txt. Each non-blank, non-comment line is a
+// route signature "<VERB> <path>"; an inline "# reason" is required by
+// convention but not enforced syntactically. Returns a set keyed by signature.
+func loadAllowlist(path string) (map[string]bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]bool{}, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	allow := map[string]bool{}
+	sc := bufio.NewScanner(f)
+	lineNo := 0
+	for sc.Scan() {
+		lineNo++
+		line := strings.TrimSpace(sc.Text())
+		if i := strings.Index(line, "#"); i >= 0 {
+			line = strings.TrimSpace(line[:i])
+		}
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("malformed allowlist line %d: %q (want '<VERB> <path>')", lineNo, line)
+		}
+		allow[fields[0]+" "+fields[1]] = true
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return allow, nil
+}

--- a/tools/lint-manager-authz/main_test.go
+++ b/tools/lint-manager-authz/main_test.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// newTestPkg builds a *pkg from one or more in-memory source files (all in the
+// same package/dir), mirroring what collectPackages does on disk. Each source
+// is given a synthetic filename so violation messages are stable.
+func newTestPkg(t *testing.T, srcs ...string) *pkg {
+	t.Helper()
+	p := &pkg{
+		dir:         "testpkg",
+		fset:        token.NewFileSet(),
+		funcsByName: map[string][]*ast.FuncDecl{},
+	}
+	for i, src := range srcs {
+		name := "src" + string(rune('0'+i)) + ".go"
+		f, err := parser.ParseFile(p.fset, name, src, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		p.files = append(p.files, f)
+		for _, decl := range f.Decls {
+			if fn, ok := decl.(*ast.FuncDecl); ok {
+				p.funcsByName[fn.Name.Name] = append(p.funcsByName[fn.Name.Name], fn)
+			}
+		}
+	}
+	return p
+}
+
+func violationsFor(t *testing.T, allow map[string]bool, srcs ...string) []string {
+	t.Helper()
+	if allow == nil {
+		allow = map[string]bool{}
+	}
+	p := newTestPkg(t, srcs...)
+	v, _ := p.collectViolations(allow)
+	sort.Strings(v)
+	return v
+}
+
+// A manager route whose handler has NO role check must be reported. This is the
+// acceptance-criterion fixture: a deliberately-introduced unchecked manager
+// route makes the guard (and therefore CI) fail.
+func TestFlagsUncheckedManagerRoute(t *testing.T) {
+	src := `package x
+type Manager struct{}
+func (m *Manager) Route(r R) {
+	auth := r.Group("/v1/manager", AuthMiddleware())
+	auth.GET("/danger", m.danger)
+}
+func (m *Manager) danger(c C) {
+	c.Response("leaked admin data")
+}
+`
+	got := violationsFor(t, nil, src)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %v", len(got), got)
+	}
+	if !strings.Contains(got[0], "GET /v1/manager/danger") || !strings.Contains(got[0], "danger") {
+		t.Fatalf("violation message not as expected: %q", got[0])
+	}
+}
+
+// A manager route whose handler calls CheckLoginRoleIsSuperAdmin must pass.
+func TestPassesSuperAdminCheckedRoute(t *testing.T) {
+	src := `package x
+type Manager struct{}
+func (m *Manager) Route(r R) {
+	auth := r.Group("/v1/manager", AuthMiddleware())
+	auth.POST("/backup/trigger", m.trigger)
+}
+func (m *Manager) trigger(c C) {
+	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
+		c.ResponseError(err)
+		return
+	}
+	c.ResponseOK()
+}
+`
+	if got := violationsFor(t, nil, src); len(got) != 0 {
+		t.Fatalf("expected 0 violations on a checked route, got: %v", got)
+	}
+}
+
+// CheckLoginRole (admin∪superAdmin tier) also counts as a check.
+func TestPassesAdminTierCheckedRoute(t *testing.T) {
+	src := `package x
+type Manager struct{}
+func (m *Manager) Route(r R) {
+	auth := r.Group("/v1/manager", AuthMiddleware())
+	auth.GET("/me", m.me)
+}
+func (m *Manager) me(c C) {
+	if err := c.CheckLoginRole(); err != nil {
+		return
+	}
+	c.Response("ok")
+}
+`
+	if got := violationsFor(t, nil, src); len(got) != 0 {
+		t.Fatalf("expected 0 violations, got: %v", got)
+	}
+}
+
+// REGRESSION: route-group variables are function-local. The user-scoped `/v1`
+// group in one method reuses the name `auth` from the admin `/v1/manager` group
+// in another method. The guard must NOT conflate them: the `/v1/users/:uid`
+// route is out of scope (no flag), while the unchecked `/v1/manager/x` admin
+// route IS flagged. (An earlier package-global index produced a flood of false
+// positives here.)
+func TestFunctionLocalGroupScoping(t *testing.T) {
+	adminSrc := `package x
+type Manager struct{}
+func (m *Manager) Route(r R) {
+	auth := r.Group("/v1/manager", AuthMiddleware())
+	auth.GET("/x", m.adminX)
+}
+func (m *Manager) adminX(c C) { c.Response("admin") }
+`
+	userSrc := `package x
+type API struct{}
+func (a *API) Route(r R) {
+	auth := a.Group("/v1", AuthMiddleware())
+	auth.GET("/users/:uid", a.getUser)
+}
+func (a *API) getUser(c C) { c.Response("self") }
+`
+	got := violationsFor(t, nil, adminSrc, userSrc)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 violation (admin /v1/manager/x only), got %d: %v", len(got), got)
+	}
+	if !strings.Contains(got[0], "/v1/manager/x") {
+		t.Fatalf("expected the admin route to be flagged, got: %q", got[0])
+	}
+	for _, v := range got {
+		if strings.Contains(v, "/v1/users") {
+			t.Fatalf("user-scoped /v1 route must NOT be flagged: %q", v)
+		}
+	}
+}
+
+// A subgroup path is NOT under /v1/manager: routes registered on it are out of
+// scope even when defined in the same function as a manager group.
+func TestIgnoresNonManagerSiblingGroup(t *testing.T) {
+	src := `package x
+type API struct{}
+func (a *API) Route(r R) {
+	base := r.Group("/v1/integrations", AuthMiddleware())
+	base.GET("/spaces", a.listSpaces)
+	manager := r.Group("/v1/manager", AuthMiddleware())
+	manager.PUT("/integrations/oidc/client", a.upsert)
+}
+func (a *API) listSpaces(c C) { c.Response("ok") }
+func (a *API) upsert(c C) {
+	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil { return }
+	c.ResponseOK()
+}
+`
+	if got := violationsFor(t, nil, src); len(got) != 0 {
+		t.Fatalf("expected 0 violations (base group out of scope, manager route checked), got: %v", got)
+	}
+}
+
+// A nested subgroup whose parent is a /v1/manager group is in scope and its
+// full path is composed from the parent base + subpath.
+func TestManagerSubgroupInScope(t *testing.T) {
+	src := `package x
+type Manager struct{}
+func (m *Manager) Route(r R) {
+	mgr := r.Group("/v1/manager", AuthMiddleware())
+	sub := mgr.Group("/reports")
+	sub.GET("/list", m.list)
+}
+func (m *Manager) list(c C) { c.Response("no check") }
+`
+	got := violationsFor(t, nil, src)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 violation on the subgroup route, got %d: %v", len(got), got)
+	}
+	if !strings.Contains(got[0], "/v1/manager/reports/list") {
+		t.Fatalf("expected composed subgroup path, got: %q", got[0])
+	}
+}
+
+// Delegated check: the handler itself does no check but calls a same-package
+// helper that does. This must count as covered (no false positive).
+func TestPassesDelegatedCheck(t *testing.T) {
+	src := `package x
+type Manager struct{}
+func (m *Manager) Route(r R) {
+	auth := r.Group("/v1/manager", AuthMiddleware())
+	auth.GET("/thing", m.thing)
+}
+func (m *Manager) thing(c C) {
+	if !m.requireAdmin(c) { return }
+	c.Response("ok")
+}
+func (m *Manager) requireAdmin(c C) bool {
+	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil { return false }
+	return true
+}
+`
+	if got := violationsFor(t, nil, src); len(got) != 0 {
+		t.Fatalf("expected 0 violations on a delegated check, got: %v", got)
+	}
+}
+
+// The allowlist suppresses an otherwise-flagged route (public/login or
+// user-scoped routes that live under /v1/manager by path but are not admin).
+func TestAllowlistSuppresses(t *testing.T) {
+	src := `package x
+type Manager struct{}
+func (m *Manager) Route(r R) {
+	user := r.Group("/v1/manager")
+	user.POST("/login", m.login)
+}
+func (m *Manager) login(c C) { c.Response("token") }
+`
+	if got := violationsFor(t, nil, src); len(got) != 1 {
+		t.Fatalf("expected 1 violation without allowlist, got: %v", got)
+	}
+	allow := map[string]bool{"POST /v1/manager/login": true}
+	if got := violationsFor(t, allow, src); len(got) != 0 {
+		t.Fatalf("expected allowlist to suppress the login route, got: %v", got)
+	}
+}
+
+// A role-enforcing group middleware covers all routes on the group without a
+// per-handler check. roleMiddleware is empty in production today; the test
+// injects one to lock in the behavior for when one is introduced.
+func TestRoleMiddlewareCoversGroup(t *testing.T) {
+	roleMiddleware["RequireSuperAdmin"] = true
+	defer delete(roleMiddleware, "RequireSuperAdmin")
+
+	src := `package x
+type Manager struct{}
+func (m *Manager) Route(r R) {
+	auth := r.Group("/v1/manager", AuthMiddleware(), RequireSuperAdmin(r))
+	auth.GET("/x", m.x)
+}
+func (m *Manager) x(c C) { c.Response("ok") }
+`
+	if got := violationsFor(t, nil, src); len(got) != 0 {
+		t.Fatalf("expected role middleware to cover the group, got: %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

octo-server#366 Part 1. Authz on the admin `/v1/manager` surface is enforced per-handler by an inline `c.CheckLoginRoleIsSuperAdmin()` / `c.CheckLoginRole()` call — there is **no central policy middleware yet** (that's the SecurityEngineer's systemic workstream). With the check scattered across ~100 handlers, a new `/v1/manager` route that forgets the check silently ships a **privilege-escalation hole**: `AuthMiddleware` only authenticates, it does not gate admin role.

This PR is a thin, reversible CI safety net (no refactor): it makes a missing role check a **build failure**.

- **`tools/lint-manager-authz`** — an AST guard that fails if any handler registered on a `/v1/manager` route group lacks a role check.
  - Route-group variables are resolved **function-locally**, so the admin group doesn't conflate with unrelated `/v1` or `/v1/space` groups that reuse names like `auth` (this was a real false-positive trap — see the regression test).
  - A handler counts as covered if it (or a same-package helper it calls) invokes `CheckLoginRole` / `CheckLoginRoleIsSuperAdmin`, or its group has a role-enforcing middleware, or it's allowlisted.
  - **Fail-closed**: a handler that can't be resolved is treated as unchecked.
- **`allowlist.txt`** — the 5 routes that live under `/v1/manager` by path but are intentionally not admin:
  - `POST /v1/manager/login` (public, issues the admin token pre-auth).
  - `/v1/manager/secrets` CRUD ×4 (user-scoped, `owner == c.GetLoginUID()`, not an admin surface).
- **CI**: new `manager-authz-lint` job (mirrors `personal-msgsendreq-lint`) — runs the guard's unit tests, then the guard over `./modules`.
- **Docs-as-interface**: convention documented in the tool's package doc, the failure message, the allowlist header, and `CLAUDE.md`.

Inventory today: **109** `/v1/manager` routes, all role-checked or allowlisted.

### How to satisfy the guard for a new `/v1/manager` route

Call a role check at the top of the handler before doing any work:

```go
if err := c.CheckLoginRoleIsSuperAdmin(); err != nil { c.ResponseError(err); return }
```

(use `CheckLoginRole` for the admin∪superAdmin tier). If the route is deliberately **not** an admin route (public, or user-scoped by UID), add it to `tools/lint-manager-authz/allowlist.txt` with a one-line reason.

## Test plan

- [x] `go test ./tools/lint-manager-authz/...` — 9 cases incl. the function-local-scoping regression, delegated check, subgroup composition, allowlist suppression, and the **unchecked-route fixture** that proves CI fails.
- [x] `go run ./tools/lint-manager-authz ./modules` → green (109 routes).
- [x] Live proof: injected an unchecked `GET /v1/manager/backup/leak` into a real module → guard exits 1; reverted → exits 0.
- [x] Confirmed the 5 allowlist entries are exactly the routes flagged with an empty allowlist (no stale/over-broad entries).
- [x] `gofmt` / `go vet` clean; `ci.yml` YAML validated.
- [ ] CTO review as security owner before merge. Consider adding `Manager Authz Lint` to required status checks.

Scope guard: this is **Part 1 only** — no central authz refactor (held for the SecurityEngineer).

Closes #366
