### PR TITLE
fix(group): atomic/reconciled group create — no permanent orphan rows (#394)

### DIFF
--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -51,6 +51,7 @@ type Group struct {
 	groupService  IService
 	fileService   file.IService
 	commonService common2.IService
+	reconciler    *ChannelReconciler
 }
 
 // New New
@@ -73,7 +74,51 @@ func New(ctx *config.Context) *Group {
 	g.ctx.AddEventListener(event.OrgOrDeptEmployeeUpdate, g.handleOrgOrDeptEmployeeUpdate)
 	g.ctx.AddEventListener(event.OrgEmployeeExit, g.handleOrgEmployeeExit)
 	source.SetGroupMemberProvider(g)
+	g.startChannelReconciler()
 	return g
+}
+
+// startChannelReconciler 启动 IM 频道孤儿找回 worker（octo-server #394）。
+//
+// 在 New 中启动而非 register.Module.Start：main.go 只调 module.Setup（间接触发本
+// 构造），并不调 module.Start，与 oidc SyncWorker 的接入点一致。测试模式
+// (cfg.Test) 下禁用——避免后台 goroutine 在测试进程里周期性打真实 WuKongIM/Redis；
+// reconcile 逻辑由单测直接构造 ChannelReconciler 验证。
+//
+// 周期/grace 可经环境变量覆盖；间隔 ≤0 视为禁用。多实例用 Redis tick lock 去重，
+// 锁不可用时降级无锁运行（重建/翻转幂等，正确性不受影响）。
+func (g *Group) startChannelReconciler() {
+	if g.ctx.GetConfig().Test {
+		return
+	}
+	interval := defaultReconcileInterval
+	if v := strings.TrimSpace(os.Getenv("DM_GROUP_CHANNEL_RECONCILE_INTERVAL_SEC")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			interval = time.Duration(n) * time.Second
+		}
+	}
+	if interval <= 0 {
+		g.Info("channel reconcile worker disabled (interval<=0)")
+		return
+	}
+	grace := defaultReconcileGraceSec
+	if v := strings.TrimSpace(os.Getenv("DM_GROUP_CHANNEL_RECONCILE_GRACE_SEC")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			grace = n
+		}
+	}
+	svc, ok := g.groupService.(*Service)
+	if !ok {
+		g.Error("channel reconcile worker not started: groupService is not *Service")
+		return
+	}
+	g.reconciler = NewChannelReconciler(svc, ReconcileConfig{
+		Interval: interval,
+		GraceSec: grace,
+	}, newRedisReconcileLock(g.ctx))
+	g.reconciler.Start(context.Background())
+	g.Info("channel reconcile worker started",
+		zap.Duration("interval", interval), zap.Int("graceSec", grace))
 }
 
 // Route 路由配置

--- a/modules/group/channel_reconcile.go
+++ b/modules/group/channel_reconcile.go
@@ -1,0 +1,268 @@
+package group
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
+	"go.uber.org/zap"
+)
+
+// octo-server #394：建群与 IM 频道创建非原子，commit 与 IM 创建之间任何失败/崩溃都会
+// 留下「可查询但无 IM 频道」的孤儿群。CreateGroup 已把待确认的群标记成
+// channel_synced=0，本 worker 周期性地把超过 grace 窗口仍为 0 的群找出来，幂等重建
+// IM 频道（IMCreateOrUpdateChannel 本身是 create-or-update，可安全重复调用）并翻转
+// channel_synced=1，实现最终一致——孤儿可被找回，而非永久残留。
+
+const (
+	// reconcileTickLockKey reconcile worker tick 级分布式互斥的 Redis key。
+	// 多实例部署时同一时刻只允许一个实例扫描，避免 N×IM 流量。锁不可用时降级为
+	// 无锁运行——因为重建/翻转都是幂等的，无锁只会多打几次 IM，不影响正确性。
+	reconcileTickLockKey = "group:channel_reconcile:tick"
+
+	defaultReconcileInterval = 120 * time.Second
+	defaultReconcileGraceSec = 120
+	defaultReconcileBatch    = 200
+)
+
+// ReconcileConfig 控制 reconcile worker 的调度参数。
+type ReconcileConfig struct {
+	Interval  time.Duration // ≤ 0 视为禁用，Start 直接返回
+	GraceSec  int           // 孤儿判定的 grace 窗口（秒）：仅处理创建超过该时长仍未同步的群
+	BatchSize int           // 单 tick 处理的孤儿上限
+	LockTTL   time.Duration // 分布式锁持有期，默认 = Interval
+}
+
+func (c *ReconcileConfig) withDefaults() {
+	if c.GraceSec <= 0 {
+		c.GraceSec = defaultReconcileGraceSec
+	}
+	if c.BatchSize <= 0 {
+		c.BatchSize = defaultReconcileBatch
+	}
+	if c.LockTTL <= 0 {
+		c.LockTTL = c.Interval
+	}
+}
+
+// reconcileTickLock tick 级分布式互斥锁的最小接口（与 oidc.tickLock 同语义：
+// Acquire 必须原子 SET NX EX，Release 必须 token-aware CAS-DEL）。nil = 不互斥。
+type reconcileTickLock interface {
+	Acquire(ctx context.Context, key, token string, ttl time.Duration) (bool, error)
+	Release(ctx context.Context, key, token string) (bool, error)
+}
+
+// luaReconcileReleaseLock CAS-DEL：仅当 value==token 时 DEL，避免 lease 边界误删他人锁。
+var luaReconcileReleaseLock = rd.NewScript(`
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+else
+  return 0
+end
+`)
+
+// redisReconcileLock 用 Redis SET NX EX + Lua CAS-DEL 实现 reconcileTickLock。
+type redisReconcileLock struct {
+	client *rd.Client
+}
+
+func newRedisReconcileLock(ctx *config.Context) *redisReconcileLock {
+	client := rd.NewClient(octoredis.MustBuildOptions(ctx.GetConfig(), func(o *rd.Options) {
+		o.MaxRetries = 3
+		o.ReadTimeout = 3 * time.Second
+		o.WriteTimeout = 3 * time.Second
+		o.DialTimeout = 3 * time.Second
+	}))
+	return &redisReconcileLock{client: client}
+}
+
+func (l *redisReconcileLock) Acquire(_ context.Context, key, token string, ttl time.Duration) (bool, error) {
+	if key == "" || token == "" || ttl <= 0 {
+		return false, fmt.Errorf("group: reconcile lock Acquire: key/token/ttl required")
+	}
+	ok, err := l.client.SetNX(key, token, ttl).Result()
+	if err != nil {
+		return false, fmt.Errorf("group: reconcile lock Acquire %q: %w", key, err)
+	}
+	return ok, nil
+}
+
+func (l *redisReconcileLock) Release(_ context.Context, key, token string) (bool, error) {
+	if key == "" || token == "" {
+		return false, fmt.Errorf("group: reconcile lock Release: key/token required")
+	}
+	res, err := luaReconcileReleaseLock.Run(l.client, []string{key}, token).Result()
+	if err != nil {
+		if errors.Is(err, rd.Nil) {
+			return false, nil
+		}
+		return false, fmt.Errorf("group: reconcile lock Release %q: %w", key, err)
+	}
+	n, ok := res.(int64)
+	if !ok {
+		return false, fmt.Errorf("group: reconcile lock Release %q: unexpected lua result type %T", key, res)
+	}
+	return n == 1, nil
+}
+
+func (l *redisReconcileLock) Close() error {
+	if l.client == nil {
+		return nil
+	}
+	return l.client.Close()
+}
+
+// ChannelReconciler 周期性找回 channel_synced=0 的孤儿群（octo-server #394）。
+type ChannelReconciler struct {
+	svc  *Service
+	cfg  ReconcileConfig
+	lock reconcileTickLock // nil = 单实例 / 测试，不做互斥
+	log.Log
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// NewChannelReconciler 构造 reconciler。lock 传 nil 时退化为「每实例独立 tick」——
+// 因重建/翻转幂等，无锁只是多打 IM，不影响正确性。
+func NewChannelReconciler(svc *Service, cfg ReconcileConfig, lock reconcileTickLock) *ChannelReconciler {
+	cfg.withDefaults()
+	return &ChannelReconciler{
+		svc:  svc,
+		cfg:  cfg,
+		lock: lock,
+		Log:  log.NewTLog("groupChannelReconcile"),
+	}
+}
+
+// Start 启动后台 ticker goroutine。Interval ≤ 0 视为禁用。
+// 幂等：重复调用会先 Stop 旧 goroutine 再启动新的。
+func (r *ChannelReconciler) Start(ctx context.Context) {
+	if r.cfg.Interval <= 0 {
+		return
+	}
+	if r.cancel != nil {
+		r.cancel()
+		r.wg.Wait()
+	}
+	rctx, cancel := context.WithCancel(ctx)
+	r.cancel = cancel
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		t := time.NewTicker(r.cfg.Interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-rctx.Done():
+				return
+			case <-t.C:
+				if err := r.RunOnce(rctx); err != nil && !errors.Is(err, context.Canceled) {
+					r.Error("channel reconcile tick failed", zap.Error(err))
+				}
+			}
+		}
+	}()
+}
+
+// Stop 通知 worker 退出并等待进行中的 tick 完成。
+func (r *ChannelReconciler) Stop() {
+	if r.cancel != nil {
+		r.cancel()
+	}
+	r.wg.Wait()
+}
+
+// RunOnce 执行一轮 reconcile：抢锁（可选）→ 扫描孤儿 → 逐个幂等重建 IM 频道 + 翻转标记。
+//
+// 多实例：抢到 tick lock 才扫描，抢不到直接返回（本 tick 由别人跑）。锁故障降级无锁运行。
+// 返回 ctx.Err() 让上层日志区分「正常停机」与「异常失败」。
+func (r *ChannelReconciler) RunOnce(ctx context.Context) error {
+	if r.lock != nil {
+		token := util.GenerUUID()
+		got, err := r.lock.Acquire(ctx, reconcileTickLockKey, token, r.cfg.LockTTL)
+		if err != nil {
+			// Redis 故障：降级到无锁路径而非阻塞。幂等保证正确性，仅多打 IM。
+			metricReconcileTickTotal.WithLabelValues("lock_err").Inc()
+			r.Warn("channel reconcile lock unavailable, running lock-free this tick", zap.Error(err))
+		} else if !got {
+			metricReconcileTickTotal.WithLabelValues("lock_held").Inc()
+			return nil
+		} else {
+			defer func() {
+				if _, rerr := r.lock.Release(ctx, reconcileTickLockKey, token); rerr != nil {
+					r.Warn("channel reconcile lock release failed", zap.Error(rerr))
+				}
+			}()
+		}
+	}
+
+	groupNos, err := r.svc.db.QueryReconcilableGroupNos(r.cfg.GraceSec, r.cfg.BatchSize)
+	if err != nil {
+		metricReconcileTickTotal.WithLabelValues("query_err").Inc()
+		return fmt.Errorf("group: query reconcilable groups: %w", err)
+	}
+	metricReconcileTickTotal.WithLabelValues("ran").Inc()
+	if len(groupNos) == 0 {
+		return nil
+	}
+	metricReconcileDetected.Add(float64(len(groupNos)))
+	r.Info("channel reconcile detected orphan groups", zap.Int("count", len(groupNos)))
+
+	for _, groupNo := range groupNos {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		r.reconcileOne(groupNo)
+	}
+	return nil
+}
+
+// reconcileOne 找回单个孤儿群：重建 IM 频道（幂等）→ 翻转 channel_synced=1。
+// 任何失败只记日志、不中断整批——下个 tick 会重试（全程幂等）。
+func (r *ChannelReconciler) reconcileOne(groupNo string) {
+	uids, err := r.svc.GetSubscribableMemberUIDs(groupNo)
+	if err != nil {
+		metricReconcileOutcomeTotal.WithLabelValues("im_fail").Inc()
+		r.Error("channel reconcile query members failed", zap.Error(err), zap.String("groupNo", groupNo))
+		return
+	}
+	if len(uids) == 0 {
+		// 没有可订阅成员（全员退出/被删）：这种群无需 IM 频道，标记同步避免反复扫描。
+		if _, ferr := r.svc.db.MarkChannelSynced(groupNo); ferr != nil {
+			metricReconcileOutcomeTotal.WithLabelValues("flag_fail").Inc()
+			r.Error("channel reconcile flag-only flip failed", zap.Error(ferr), zap.String("groupNo", groupNo))
+			return
+		}
+		metricReconcileOutcomeTotal.WithLabelValues("skipped").Inc()
+		return
+	}
+
+	if err := r.svc.imCreateChannel(&config.ChannelCreateReq{
+		ChannelID:   groupNo,
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		Subscribers: uids,
+	}); err != nil {
+		metricReconcileOutcomeTotal.WithLabelValues("im_fail").Inc()
+		r.Error("channel reconcile recreate IM channel failed", zap.Error(err), zap.String("groupNo", groupNo))
+		return
+	}
+
+	if _, err := r.svc.db.MarkChannelSynced(groupNo); err != nil {
+		metricReconcileOutcomeTotal.WithLabelValues("flag_fail").Inc()
+		r.Error("channel reconcile flip flag failed (IM channel already recreated, will retry)", zap.Error(err), zap.String("groupNo", groupNo))
+		return
+	}
+	metricReconcileOutcomeTotal.WithLabelValues("resolved").Inc()
+	r.Info("channel reconcile resolved orphan group", zap.String("groupNo", groupNo))
+}

--- a/modules/group/channel_reconcile_test.go
+++ b/modules/group/channel_reconcile_test.go
@@ -1,0 +1,195 @@
+package group
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readChannelSynced 直接读 group.channel_synced（Model 结构体不含该列，故走原始查询）。
+func readChannelSynced(t *testing.T, ctx *config.Context, groupNo string) (int, bool) {
+	t.Helper()
+	var vals []int
+	_, err := ctx.DB().Select("channel_synced").From("`group`").Where("group_no=?", groupNo).Load(&vals)
+	require.NoError(t, err)
+	if len(vals) == 0 {
+		return 0, false
+	}
+	return vals[0], true
+}
+
+// seedOrphanGroup 直接落一个「已提交但无 IM 频道」的孤儿群：channel_synced=0，
+// created_at 设为 ageAgo 之前。这正是「commit 与 IM 创建之间崩溃」或「IM 失败且补偿
+// 删除也失败」之后 DB 里残留的状态（octo-server #394）。
+func seedOrphanGroup(t *testing.T, ctx *config.Context, groupNo string, status int, ageAgo time.Duration, memberUIDs ...string) {
+	t.Helper()
+	createdAt := time.Now().Add(-ageAgo)
+	_, err := ctx.DB().InsertInto("group").
+		Columns("group_no", "name", "creator", "status", "version", "channel_synced", "created_at", "updated_at").
+		Values(groupNo, "orphan-"+groupNo, memberUIDs[0], status, 1, 0, createdAt, createdAt).Exec()
+	require.NoError(t, err)
+	for _, uid := range memberUIDs {
+		_, err := ctx.DB().InsertInto("group_member").
+			Columns("group_no", "uid", "role", "version", "status", "is_deleted").
+			Values(groupNo, uid, MemberRoleCommon, 1, int(common.GroupMemberStatusNormal), 0).Exec()
+		require.NoError(t, err)
+	}
+}
+
+// TestCreateGroup_Success_MarksChannelSynced 成功路径：IM 频道确认后 channel_synced=1。
+func TestCreateGroup_Success_MarksChannelSynced(t *testing.T) {
+	svc, userDB := setupServiceTest(t)
+	insertTestUsers(t, userDB, testutil.UID, "m1")
+
+	resp, err := svc.CreateGroup(&CreateGroupServiceReq{
+		Creator: testutil.UID,
+		Members: []string{"m1"},
+		Name:    "synced-ok",
+	})
+	require.NoError(t, err)
+
+	got, ok := readChannelSynced(t, svc.(*Service).ctx, resp.GroupNo)
+	assert.True(t, ok, "group row must exist")
+	assert.Equal(t, 1, got, "channel_synced must be flipped to 1 after IM channel confirmed")
+}
+
+// TestCreateGroup_IMFail_CompensatingDeleteRemovesGroup IM 创建失败 + 补偿删除成功：
+// 无孤儿残留（窄窗口路径）。注入失败的 imCreateChannel，避免依赖真实 WuKongIM 故障注入。
+func TestCreateGroup_IMFail_CompensatingDeleteRemovesGroup(t *testing.T) {
+	svc, userDB := setupServiceTest(t)
+	insertTestUsers(t, userDB, testutil.UID, "m1")
+
+	s := svc.(*Service)
+	s.imCreateChannel = func(*config.ChannelCreateReq) error {
+		return errors.New("simulated IM channel create failure")
+	}
+
+	resp, err := svc.CreateGroup(&CreateGroupServiceReq{
+		Creator: testutil.UID,
+		Members: []string{"m1"},
+		Name:    "im-fail",
+	})
+	require.Error(t, err, "CreateGroup must surface IM failure")
+	assert.Nil(t, resp, "resp must be nil on IM failure")
+
+	// 补偿删除成功路径：group 行已被清除，没有孤儿。
+	var count int
+	_, qerr := s.ctx.DB().Select("count(*)").From("`group`").Where("creator=? AND name=?", testutil.UID, "im-fail").Load(&count)
+	require.NoError(t, qerr)
+	assert.Equal(t, 0, count, "compensating delete should remove the group row")
+}
+
+// TestChannelReconcile_RecreatesChannelAndFlipsFlag 直接构造 reconciler 处理孤儿群：
+// 重建 IM 频道（捕获调用）+ 翻转 channel_synced=1。覆盖「crash-between-commit-and-IM」
+// 与「IM-fail + delete-fail」两种失败模式留下的残留状态。
+func TestChannelReconcile_RecreatesChannelAndFlipsFlag(t *testing.T) {
+	svc, userDB, ctx := setupServiceTestWithCtx(t)
+	insertTestUsers(t, userDB, "ou", "om1")
+
+	groupNo := "orphan-grp-1"
+	seedOrphanGroup(t, ctx, groupNo, GroupStatusNormal, 10*time.Minute, "ou", "om1")
+
+	s := svc.(*Service)
+	var gotReq *config.ChannelCreateReq
+	s.imCreateChannel = func(req *config.ChannelCreateReq) error {
+		gotReq = req
+		return nil
+	}
+
+	r := NewChannelReconciler(s, ReconcileConfig{Interval: time.Minute, GraceSec: 60, BatchSize: 50}, nil)
+	require.NoError(t, r.RunOnce(context.Background()))
+
+	require.NotNil(t, gotReq, "reconcile must recreate the IM channel")
+	assert.Equal(t, groupNo, gotReq.ChannelID)
+	assert.Equal(t, common.ChannelTypeGroup.Uint8(), gotReq.ChannelType)
+	assert.ElementsMatch(t, []string{"ou", "om1"}, gotReq.Subscribers)
+
+	got, ok := readChannelSynced(t, ctx, groupNo)
+	assert.True(t, ok)
+	assert.Equal(t, 1, got, "channel_synced must be flipped to 1 after reconcile")
+}
+
+// TestChannelReconcile_Idempotent 第二次 RunOnce 不应再处理已修复的群（幂等 + 可观测）。
+func TestChannelReconcile_Idempotent(t *testing.T) {
+	svc, userDB, ctx := setupServiceTestWithCtx(t)
+	insertTestUsers(t, userDB, "iu")
+
+	groupNo := "orphan-idem"
+	seedOrphanGroup(t, ctx, groupNo, GroupStatusNormal, 10*time.Minute, "iu")
+
+	s := svc.(*Service)
+	var calls int
+	s.imCreateChannel = func(*config.ChannelCreateReq) error { calls++; return nil }
+
+	r := NewChannelReconciler(s, ReconcileConfig{Interval: time.Minute, GraceSec: 60, BatchSize: 50}, nil)
+	require.NoError(t, r.RunOnce(context.Background()))
+	require.NoError(t, r.RunOnce(context.Background()))
+
+	assert.Equal(t, 1, calls, "second reconcile run must be a no-op (flag already synced)")
+}
+
+// TestChannelReconcile_RespectsGraceWindow grace 窗口内的新建群不被找回，避免与正在进行
+// 的建群/IM 确认竞争误删/误重建。
+func TestChannelReconcile_RespectsGraceWindow(t *testing.T) {
+	svc, userDB, ctx := setupServiceTestWithCtx(t)
+	insertTestUsers(t, userDB, "gu")
+
+	fresh := "orphan-fresh"
+	seedOrphanGroup(t, ctx, fresh, GroupStatusNormal, 1*time.Second, "gu")
+
+	s := svc.(*Service)
+	var calls int
+	s.imCreateChannel = func(*config.ChannelCreateReq) error { calls++; return nil }
+
+	r := NewChannelReconciler(s, ReconcileConfig{Interval: time.Minute, GraceSec: 120, BatchSize: 50}, nil)
+	require.NoError(t, r.RunOnce(context.Background()))
+
+	assert.Equal(t, 0, calls, "groups within the grace window must not be reconciled")
+	got, _ := readChannelSynced(t, ctx, fresh)
+	assert.Equal(t, 0, got, "fresh pending group stays channel_synced=0 until past grace")
+}
+
+// TestChannelReconcile_SkipsDisbandedGroup 已解散群的 IM 频道是被有意销毁的，不应重建。
+func TestChannelReconcile_SkipsDisbandedGroup(t *testing.T) {
+	svc, userDB, ctx := setupServiceTestWithCtx(t)
+	insertTestUsers(t, userDB, "du")
+
+	groupNo := "orphan-disband"
+	seedOrphanGroup(t, ctx, groupNo, GroupStatusDisband, 10*time.Minute, "du")
+
+	s := svc.(*Service)
+	var calls int
+	s.imCreateChannel = func(*config.ChannelCreateReq) error { calls++; return nil }
+
+	r := NewChannelReconciler(s, ReconcileConfig{Interval: time.Minute, GraceSec: 60, BatchSize: 50}, nil)
+	require.NoError(t, r.RunOnce(context.Background()))
+
+	assert.Equal(t, 0, calls, "disbanded groups must not be reconciled")
+}
+
+// TestChannelReconcile_IMFailLeavesOrphanForRetry 重建 IM 频道失败时保持 channel_synced=0，
+// 下个 tick 重试——孤儿不会被错误地标记为已修复。
+func TestChannelReconcile_IMFailLeavesOrphanForRetry(t *testing.T) {
+	svc, userDB, ctx := setupServiceTestWithCtx(t)
+	insertTestUsers(t, userDB, "fu")
+
+	groupNo := "orphan-retry"
+	seedOrphanGroup(t, ctx, groupNo, GroupStatusNormal, 10*time.Minute, "fu")
+
+	s := svc.(*Service)
+	s.imCreateChannel = func(*config.ChannelCreateReq) error { return errors.New("IM still down") }
+
+	r := NewChannelReconciler(s, ReconcileConfig{Interval: time.Minute, GraceSec: 60, BatchSize: 50}, nil)
+	require.NoError(t, r.RunOnce(context.Background()))
+
+	got, ok := readChannelSynced(t, ctx, groupNo)
+	assert.True(t, ok)
+	assert.Equal(t, 0, got, "channel_synced must stay 0 when IM recreate fails, so next tick retries")
+}

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -38,6 +38,47 @@ func (d *DB) Insert(m *Model) error {
 	return err
 }
 
+// markChannelPendingTx 在事务内把群标记为「IM 频道尚未确认」(channel_synced=0)。
+//
+// octo-server #394：CreateGroup 在 commit 后才创建 IM 频道，commit 与 IM 创建之间
+// 的任何失败/崩溃都会留下孤儿群。建群事务内先把行写成 pending，确认 IM 频道后再
+// 调 MarkChannelSynced 翻成 1，使孤儿可被 reconcile worker 检测与找回。
+//
+// channel_synced 不在 Model 结构体上（避免 AttrToUnderscore 把它带进系统群/注册建群
+// 等其它 Insert 路径，那些路径应保持 DB 默认值 1）；故这里用独立 UPDATE 显式置 0。
+func (d *DB) markChannelPendingTx(groupNo string, tx *dbr.Tx) error {
+	_, err := tx.Update("group").Set("channel_synced", 0).Where("group_no=?", groupNo).Exec()
+	return err
+}
+
+// MarkChannelSynced 确认 IM 频道已就绪后把群标记为已同步(channel_synced=1)。
+// 幂等：重复调用只是把已为 1 的行再写 1。返回受影响行数供 reconcile 竞态观测。
+func (d *DB) MarkChannelSynced(groupNo string) (int64, error) {
+	res, err := d.session.Update("group").Set("channel_synced", 1).Where("group_no=?", groupNo).Exec()
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// QueryReconcilableGroupNos 返回需要 reconcile 的孤儿群编号：channel_synced=0 且
+// 状态正常(GroupStatusNormal)、且创建时间早于 graceSeconds（避开正在进行中的建群
+// 与 IM 确认之间的正常窗口，防止误判）。limit 控制单批处理量。
+//
+// 只挑 GroupStatusNormal：已解散(GroupStatusDisband)的群其 IM 频道是被有意销毁的，
+// 不应重建。
+func (d *DB) QueryReconcilableGroupNos(graceSeconds, limit int) ([]string, error) {
+	var groupNos []string
+	_, err := d.session.Select("group_no").
+		From("`group`").
+		Where("channel_synced=0 AND status=?", GroupStatusNormal).
+		Where(fmt.Sprintf("created_at < DATE_SUB(NOW(), INTERVAL %d SECOND)", graceSeconds)).
+		OrderAsc("created_at").
+		Limit(uint64(limit)).
+		Load(&groupNos)
+	return groupNos, err
+}
+
 // 修改群类型
 func (d *DB) UpdateGroupTypeTx(groupNo string, groupType GroupType, tx *dbr.Tx) error {
 	_, err := tx.Update("group").Set("group_type", int(groupType)).Where("group_no=?", groupNo).Exec()

--- a/modules/group/metrics.go
+++ b/modules/group/metrics.go
@@ -1,0 +1,78 @@
+package group
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// 本文件登记 group 模块 octo-server #394（建群原子性 / IM 频道孤儿找回）相关的
+// Prometheus 指标。设计取舍与 modules/oidc/metrics.go 一致：
+//   - 注册到全局默认 Registry(promauto.New*)，由基础设施侧暴露 /metrics 端点。
+//   - Counter 用 *Vec 带 result/outcome 维度，便于 Grafana 切分成功/失败比例。
+//   - 不加 group_no/uid 这类高基数 label —— 会爆 Prometheus 内存。
+const groupMetricNamespace = "group"
+
+// channelCreateResultLabels 建群路径上 IM 频道创建的结果维度。
+//   - ok：IM 频道确认创建成功。
+//   - im_fail：IM 创建失败，已走补偿删除（失败时留 channel_synced=0 兜底）。
+func channelCreateResultLabels() []string { return []string{"ok", "im_fail"} }
+
+// reconcileTickResultLabels reconcile worker 每个 tick 的出口维度。
+//   - ran：本 tick 实际执行了一轮扫描。
+//   - lock_held：未抢到分布式锁，本 tick 由其它实例执行（多实例去重）。
+//   - lock_err：抢锁时 Redis 故障，已降级为无锁执行（幂等，安全）。
+//   - query_err：扫描孤儿行失败。
+func reconcileTickResultLabels() []string {
+	return []string{"ran", "lock_held", "lock_err", "query_err"}
+}
+
+// reconcileOutcomeLabels 单个孤儿群被 reconcile 处理的结果维度。
+//   - resolved：IM 频道幂等重建成功并翻转 channel_synced=1。
+//   - im_fail：重建 IM 频道失败，下个 tick 重试。
+//   - flag_fail：IM 频道已就绪但翻转标记失败，下个 tick 重试（幂等）。
+//   - skipped：处理时群已不再满足条件（已被删除/已解散/已被它实例修复）。
+func reconcileOutcomeLabels() []string {
+	return []string{"resolved", "im_fail", "flag_fail", "skipped"}
+}
+
+func init() {
+	for _, l := range channelCreateResultLabels() {
+		metricChannelCreateTotal.WithLabelValues(l).Add(0)
+	}
+	for _, l := range reconcileTickResultLabels() {
+		metricReconcileTickTotal.WithLabelValues(l).Add(0)
+	}
+	for _, l := range reconcileOutcomeLabels() {
+		metricReconcileOutcomeTotal.WithLabelValues(l).Add(0)
+	}
+}
+
+var (
+	// metricChannelCreateTotal 建群路径 IM 频道创建结果计数（result=ok|im_fail）。
+	metricChannelCreateTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: groupMetricNamespace,
+		Name:      "channel_create_total",
+		Help:      "IM channel create outcomes on the CreateGroup path (octo-server #394).",
+	}, []string{"result"})
+
+	// metricReconcileTickTotal reconcile worker tick 结果计数。
+	metricReconcileTickTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: groupMetricNamespace,
+		Name:      "channel_reconcile_tick_total",
+		Help:      "Channel-sync reconcile worker tick outcomes (octo-server #394).",
+	}, []string{"result"})
+
+	// metricReconcileDetected 每个 tick 检测到的孤儿群数量（channel_synced=0 且超过 grace）。
+	metricReconcileDetected = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: groupMetricNamespace,
+		Name:      "channel_reconcile_detected_total",
+		Help:      "Total orphan groups (channel_synced=0 past grace) detected by the reconcile worker (octo-server #394).",
+	})
+
+	// metricReconcileOutcomeTotal 单个孤儿群处理结果计数。
+	metricReconcileOutcomeTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: groupMetricNamespace,
+		Name:      "channel_reconcile_outcome_total",
+		Help:      "Per-orphan reconcile outcomes (octo-server #394).",
+	}, []string{"outcome"})
+)

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -134,17 +134,24 @@ type Service struct {
 	log.Log
 	settingDB *settingDB
 	userDB    *user.DB
+
+	// imCreateChannel 是「创建/更新 IM 频道」的注入点，生产默认指向
+	// ctx.IMCreateOrUpdateChannel。抽成字段是为了让 CreateGroup 的 IM 失败补偿
+	// 路径与 reconcile worker 的找回逻辑可在单测里注入受控失败/成功，而无需依赖
+	// 真实 WuKongIM 的故障注入（octo-server #394）。
+	imCreateChannel func(*config.ChannelCreateReq) error
 }
 
 // NewService NewService
 func NewService(ctx *config.Context) IService {
 	return &Service{
-		ctx:       ctx,
-		db:        NewDB(ctx),
-		managerDB: newManagerDB(ctx.DB()),
-		Log:       log.NewTLog("groupService"),
-		settingDB: newSettingDB(ctx),
-		userDB:    user.NewDB(ctx),
+		ctx:             ctx,
+		db:              NewDB(ctx),
+		managerDB:       newManagerDB(ctx.DB()),
+		Log:             log.NewTLog("groupService"),
+		settingDB:       newSettingDB(ctx),
+		userDB:          user.NewDB(ctx),
+		imCreateChannel: ctx.IMCreateOrUpdateChannel,
 	}
 }
 
@@ -1136,6 +1143,15 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 		return nil, errors.New("failed to insert group record")
 	}
 
+	// octo-server #394：在事务内把新群标记为「IM 频道尚未确认」(channel_synced=0)。
+	// IM 频道在 commit 之后才创建；若 IM 创建失败 + 补偿删除也失败，或在 commit 与
+	// IM 创建之间崩溃，这一标记让残留的 group 行可被 reconcile worker 检测并找回，
+	// 而不会永久成为「可查询但无 IM 频道」的孤儿。确认 IM 频道后再翻成 1。
+	if err := s.db.markChannelPendingTx(groupNo, tx); err != nil {
+		s.Error("mark channel pending failed", zap.Error(err), zap.String("groupNo", groupNo))
+		return nil, errors.New("failed to mark channel pending")
+	}
+
 	// 插入成员
 	realMemberUIDs := make([]string, 0, len(memberUsers))
 	memberVos := make([]*config.UserBaseVo, 0, len(memberUsers))
@@ -1275,24 +1291,38 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 	}
 
 	// 创建 IM 频道
-	err = s.ctx.IMCreateOrUpdateChannel(&config.ChannelCreateReq{
+	err = s.imCreateChannel(&config.ChannelCreateReq{
 		ChannelID:   groupNo,
 		ChannelType: common.ChannelTypeGroup.Uint8(),
 		Subscribers: realMemberUIDs,
 	})
 	if err != nil {
 		s.Error("create IM channel failed, performing compensating rollback", zap.Error(err), zap.String("groupNo", groupNo))
+		metricChannelCreateTotal.WithLabelValues("im_fail").Inc()
 		// Compensating delete: remove group_member and group records that were
 		// already committed. Use s.ctx.DB() (not tx) because the transaction
 		// has already been committed.
+		//
+		// octo-server #394: this delete is best-effort and narrows the orphan
+		// window. If it fails, the group row remains with channel_synced=0 and
+		// the reconcile worker will detect + recover it — the orphan is no
+		// longer permanent.
 		if _, delErr := s.ctx.DB().DeleteFrom("group_member").Where("group_no=?", groupNo).Exec(); delErr != nil {
 			s.Error("compensating delete group_member failed", zap.Error(delErr), zap.String("groupNo", groupNo))
 		}
 		if _, delErr := s.ctx.DB().DeleteFrom("group").Where("group_no=?", groupNo).Exec(); delErr != nil {
-			s.Error("compensating delete group failed", zap.Error(delErr), zap.String("groupNo", groupNo))
+			s.Error("compensating delete group failed, group left as channel_synced=0 for reconcile", zap.Error(delErr), zap.String("groupNo", groupNo))
 		}
 		return nil, errors.New("failed to create IM channel, group has been rolled back")
 	}
+
+	// octo-server #394：IM 频道确认创建成功，把群翻成已同步(channel_synced=1)，
+	// reconcile worker 不再处理它。这一步失败不阻断建群（频道已就绪，群可用），
+	// 仅记日志——reconcile worker 会在 grace 窗口后重做这次幂等翻转兜底。
+	if _, syncErr := s.db.MarkChannelSynced(groupNo); syncErr != nil {
+		s.Error("mark channel synced failed (reconcile will recover)", zap.Error(syncErr), zap.String("groupNo", groupNo))
+	}
+	metricChannelCreateTotal.WithLabelValues("ok").Inc()
 
 	// 发送群创建通知
 	s.ctx.SendGroupCreate(&config.MsgGroupCreateReq{

--- a/modules/group/sql/20260617000001_group_channel_synced.sql
+++ b/modules/group/sql/20260617000001_group_channel_synced.sql
@@ -1,0 +1,71 @@
+-- +migrate Up
+-- octo-server #394：建群与 IM 频道创建之间存在「孤儿群」窗口——CreateGroup 在
+-- tx.Commit() 之后才创建 IM 频道，若 IM 创建失败且补偿删除也失败（或在 commit 与
+-- IM 创建之间崩溃），group 行会残留而没有对应 IM 频道。channel_synced 标记把这种
+-- 孤儿变得「可检测」：仅在确认 IM 频道创建成功后才置 1，后台 reconcile worker 据此
+-- 找回并幂等重建。
+--
+-- 默认 1（已同步）：存量群以及所有不经过 CreateGroup 待确认流程的插入路径（系统群、
+-- 注册建群、AddGroup 等）天然视为已同步，零回归、不会被 reconcile 误判为孤儿。
+-- 只有 CreateGroup 显式把新行写成 0，确认 IM 频道后再翻成 1。
+--
+-- 幂等/可重入写法（INFORMATION_SCHEMA 守卫 + 存储过程，与 20260604000001、
+-- 20260605000002 同范式）：MySQL DDL 隐式提交，sql-migrate 仅在「一个迁移的所有
+-- 语句都成功」后才记账；多 pod 滚动发布或部分迁移重试时，裸 ADD COLUMN 重跑会因
+-- 列已存在报 Duplicate column name 而 CrashLoopBackOff（见 #239/#253）。守卫后可安全重入。
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_channel_synced;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __group_channel_synced()
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND COLUMN_NAME = 'channel_synced') THEN
+    ALTER TABLE `group`
+      ADD COLUMN `channel_synced` TINYINT NOT NULL DEFAULT 1 COMMENT 'IM channel sync flag: 1=backing IM channel confirmed (default, backward-compat), 0=group row committed but IM channel not yet confirmed (reconcile target, octo-server #394)';
+  END IF;
+  -- 二级索引：reconcile worker 周期性扫描 channel_synced=0 的孤儿行，避免全表扫描。
+  -- 选择性极高（正常情况下几乎没有 0 行），低基数列单列索引足够。
+  IF NOT EXISTS (SELECT 1 FROM information_schema.STATISTICS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND INDEX_NAME = 'idx_group_channel_synced') THEN
+    ALTER TABLE `group`
+      ADD INDEX `idx_group_channel_synced` (`channel_synced`);
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __group_channel_synced();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_channel_synced;
+-- +migrate StatementEnd
+
+-- +migrate Down
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_channel_synced_down;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __group_channel_synced_down()
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.STATISTICS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND INDEX_NAME = 'idx_group_channel_synced') THEN
+    ALTER TABLE `group` DROP INDEX `idx_group_channel_synced`;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND COLUMN_NAME = 'channel_synced') THEN
+    ALTER TABLE `group` DROP COLUMN `channel_synced`;
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __group_channel_synced_down();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_channel_synced_down;
+-- +migrate StatementEnd


### PR DESCRIPTION
## Summary

Fixes [#394](https://github.com/Mininglamp-OSS/octo-server/issues/394). `group.CreateGroup` created the IM channel **after** `tx.Commit()`; on IM-create failure it ran a best-effort, non-atomic compensating `DELETE` that only logged. A DB blip on that delete — or a crash between commit and IM-create — left an **orphan group** with no backing IM channel, permanently queryable.

- **`channel_synced` flag** (migration, `DEFAULT 1` for backward compat). `CreateGroup` writes new rows as `0` in-tx and flips to `1` only after a confirmed IM channel create. Existing rows / other insert paths keep the DB default `1`, so they're never mis-detected as orphans.
- **Compensating delete kept** (narrows the window) but orphans are now **detectable** via `channel_synced=0` instead of silently permanent.
- **Idempotent periodic reconcile worker**: finds `channel_synced=0` rows older than a grace window, re-creates the IM channel (`IMCreateOrUpdateChannel` is create-or-update → idempotent) and flips the flag. Optional Redis tick-lock dedups across instances; lock-free fallback stays correct via idempotency. Disabled under `cfg.Test`; interval/grace tunable via `DM_GROUP_CHANNEL_RECONCILE_INTERVAL_SEC` / `_GRACE_SEC`.
- **Observability**: Prometheus metrics for channel-create result, reconcile ticks, orphans detected, and per-orphan outcome.
- IM-create call injected on `Service` so failure modes are unit-testable.

## Acceptance (#394)

- ✅ A group can never remain queryable without a backing IM channel after a create failure — orphans are now reconciled (eventual consistency), not permanent.
- ✅ Reconcile is observable (metrics + structured logs) and idempotent.

## API contract

No REST/WS contract change. `channel_synced` is internal; the group-create response shape is unchanged.

## Test plan

- [x] `TestCreateGroup_Success_MarksChannelSynced` — happy path flips flag to 1
- [x] `TestCreateGroup_IMFail_CompensatingDeleteRemovesGroup` — IM-fail + delete-OK leaves no orphan
- [x] `TestChannelReconcile_RecreatesChannelAndFlipsFlag` — crash-between-commit-and-IM / delete-fail residue recovered
- [x] `TestChannelReconcile_Idempotent` — second run is a no-op
- [x] `TestChannelReconcile_RespectsGraceWindow` — in-flight creates not raced
- [x] `TestChannelReconcile_SkipsDisbandedGroup` — disbanded channels not recreated
- [x] `TestChannelReconcile_IMFailLeavesOrphanForRetry` — flag stays 0 for retry on IM failure
- [x] full `go test ./modules/group/` green; `go build ./...` green

🤖 OCT-16 (sub-task of OCT-10)