### PR TITLE
fix: resolve incoming-webhook sender name in offline push

### DIFF
--- a/modules/incomingwebhook/push_name_test.go
+++ b/modules/incomingwebhook/push_name_test.go
@@ -1,0 +1,32 @@
+package incomingwebhook
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestResolveWebhookDisplayName_ForPush 验证离线推送链路能解析出 incoming webhook 虚拟
+// 发送者（iwh_xxx，user 表里没有行）的展示名。推送侧用 user.ResolveWebhookDisplayName
+// 兜底，它经 BussDataSource.ChannelGet 注册链命中本模块的 datasource（init 已注册）。
+func TestResolveWebhookDisplayName_ForPush(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+
+	groupNo := "g_" + util.GenerUUID()[:12]
+	whID := mustInsertWebhook(t, newDB(ctx), groupNo) // Name 固定为 "wh"
+
+	name, err := user.ResolveWebhookDisplayName(ctx, whID)
+	assert.NoError(t, err)
+	assert.Equal(t, "wh", name, "webhook 发送者应能解析出展示名供推送使用")
+
+	// 不存在的 iwh_（已删除/伪造）→ 各模块均 ErrDatasourceNotProcess → 干净的"无人处理"
+	// 语义：("", nil)，调用方据此保持空名、不报错（注意：非 iwh_ 的未知 uid 会被 user 模块
+	// 的 datasource 当作"用户不存在"返回真实 error，不是这里要测的 not-found 路径）。
+	name, err = user.ResolveWebhookDisplayName(ctx, "iwh_"+util.GenerUUID()[:12])
+	assert.NoError(t, err)
+	assert.Empty(t, name)
+}

--- a/modules/user/webhook_identity.go
+++ b/modules/user/webhook_identity.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/model"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
@@ -45,7 +46,15 @@ const (
 // datasource 用 register.ErrDatasourceNotProcess 表示"不处理"，用包装后的真实 error
 // 表示故障（见 incomingwebhook 的 newChannelGetDatasource），这里据此区分。
 func (u *User) resolveWebhookChannel(uid, loginUID string) (*model.ChannelResp, error) {
-	for _, m := range register.GetModules(u.ctx) {
+	return resolveWebhookChannelVia(u.ctx, uid, loginUID)
+}
+
+// resolveWebhookChannelVia 是 resolveWebhookChannel 的 ctx 版实现，供 *User 的 HTTP
+// 处理器与包级 ResolveWebhookDisplayName（推送链路无 *User 实例，只有 ctx）共用，避免
+// 复制 datasource 遍历与 (resp,nil)/(nil,nil)/(nil,err) 的错误语义。语义见
+// resolveWebhookChannel 的注释。
+func resolveWebhookChannelVia(ctx *config.Context, uid, loginUID string) (*model.ChannelResp, error) {
+	for _, m := range register.GetModules(ctx) {
 		if m.BussDataSource.ChannelGet == nil {
 			continue
 		}
@@ -61,6 +70,23 @@ func (u *User) resolveWebhookChannel(uid, loginUID string) (*model.ChannelResp, 
 		}
 	}
 	return nil, nil
+}
+
+// ResolveWebhookDisplayName 返回合成发送者（如 incoming webhook 的 iwh_xxx，user 表里
+// 没有对应行）的展示名，通过 BussDataSource.ChannelGet 注册链解析。离线推送链路用它兜底
+// 渲染发送者名，避免 webhook 消息推送出来没有发件人名字。
+//
+// 返回 ("", nil) 表示没有任何模块处理该 uid（不是 webhook，或已删除）；("", err) 仅在
+// datasource 真实故障时返回。调用方应把空名当作"无兜底"，把 err 当作可记录的非致命错误。
+func ResolveWebhookDisplayName(ctx *config.Context, uid string) (string, error) {
+	ch, err := resolveWebhookChannelVia(ctx, uid, "")
+	if err != nil {
+		return "", err
+	}
+	if ch == nil {
+		return "", nil
+	}
+	return ch.Name, nil
 }
 
 // newWebhookUserDetailResp 把 webhook 频道详情合成为最小化用户详情，供 /v1/users/:uid

--- a/modules/webhook/common.go
+++ b/modules/webhook/common.go
@@ -232,6 +232,24 @@ func fallbackSyntheticSenderName(ctx *config.Context, fromUID, name string) (res
 	return resolved, true
 }
 
+// repairEmptyCachedName 处理"缓存命中但 name 为空"的存量场景：修复前已对某合成发送者
+// （如 iwh_）缓存过空名的条目，命中后会直接返回空名、绕过 miss 分支的兜底，导致存量
+// iwh_ 发送者在旧缓存 TTL 到期前仍显示空发件人名。这里在命中时同样补一次兜底解析，并
+// 就地修复缓存的 name 字段（只改 name，不动 remark/name_in_group，也不重置 TTL），根治
+// 存量、无需等旧 TTL。解析失败或无人处理则保持空名（下次再试），不影响本次推送。
+func repairEmptyCachedName(ctx *config.Context, key, fromUID, name string) string {
+	if name != "" {
+		return name
+	}
+	resolved, cacheable := fallbackSyntheticSenderName(ctx, fromUID, name)
+	if cacheable && resolved != "" {
+		if err := ctx.GetRedisConn().Hset(key, "name", resolved); err != nil {
+			log.Warn("修复发送者名缓存失败", zap.String("key", key), zap.Error(err))
+		}
+	}
+	return resolved
+}
+
 func getAndCacheShowNameForFromUID(msgResp msgOfflineNotify, ctx *config.Context) (string, error) {
 	db := getWebhookDB(ctx)
 
@@ -248,6 +266,7 @@ func getAndCacheShowNameForFromUID(msgResp msgOfflineNotify, ctx *config.Context
 		if len(nameMap) > 0 { // 存在缓存，直接取出
 			name = nameMap["name"]
 			remark = nameMap["remark"]
+			name = repairEmptyCachedName(ctx, key, msgResp.FromUID, name)
 		} else { // 不存在缓存，从DB获取，然后再缓存
 			name, remark, _, err = db.GetThirdName(msgResp.FromUID, msgResp.ToUID, "")
 			if err != nil {
@@ -279,6 +298,7 @@ func getAndCacheShowNameForFromUID(msgResp msgOfflineNotify, ctx *config.Context
 			name = nameMap["name"]
 			remark = nameMap["remark"]
 			nameInGroup = nameMap["name_in_group"]
+			name = repairEmptyCachedName(ctx, key, msgResp.FromUID, name)
 		} else { // 不存在缓存，从DB获取，然后再缓存
 			name, remark, nameInGroup, err = db.GetThirdName(msgResp.FromUID, msgResp.ToUID, msgResp.ChannelID)
 			if err != nil {

--- a/modules/webhook/common.go
+++ b/modules/webhook/common.go
@@ -212,6 +212,26 @@ func getWebhookDB(ctx *config.Context) *DB {
 }
 
 // 获取和缓存发送者的显示名称
+// fallbackSyntheticSenderName 在 GetThirdName 取不到常用名（name 为空）时，尝试解析合成
+// 发送者的展示名。典型场景：incoming webhook 的虚拟发送者（iwh_xxx）在 user 表里没有行，
+// 直查 user 表得到空名，推送就没有发件人名字。这里复用 user 模块基于 BussDataSource 的
+// 解析器(不在推送层硬编码 iwh_ 前缀)。
+//
+// 返回 cacheable 表示结果是否可写入缓存：解析发生瞬时故障（datasource 报错）时返回原值
+// 且 cacheable=false，让下一次推送重试，避免把空名冻结到 TTL（最长 NameCacheExpire）。
+// 解析成功（含"无人处理"返回空名，如已删除 webhook）则 cacheable=true。失败不影响推送。
+func fallbackSyntheticSenderName(ctx *config.Context, fromUID, name string) (resolved string, cacheable bool) {
+	if name != "" {
+		return name, true
+	}
+	resolved, err := user.ResolveWebhookDisplayName(ctx, fromUID)
+	if err != nil {
+		log.Warn("解析合成发送者名失败", zap.String("from_uid", fromUID), zap.Error(err))
+		return name, false
+	}
+	return resolved, true
+}
+
 func getAndCacheShowNameForFromUID(msgResp msgOfflineNotify, ctx *config.Context) (string, error) {
 	db := getWebhookDB(ctx)
 
@@ -233,15 +253,19 @@ func getAndCacheShowNameForFromUID(msgResp msgOfflineNotify, ctx *config.Context
 			if err != nil {
 				return "", err
 			}
-			err = ctx.GetRedisConn().Hmset(key, "name", name, "remark", remark)
-			if err != nil {
-				log.Error("缓存名字失败！", zap.Error(err))
-				return "", err
-			}
-			err = ctx.GetRedisConn().Expire(key, ctx.GetConfig().Cache.NameCacheExpire)
-			if err != nil {
-				log.Error("设置过期时间失败！", zap.String("key", key), zap.Error(err))
-				return "", err
+			var cacheable bool
+			name, cacheable = fallbackSyntheticSenderName(ctx, msgResp.FromUID, name)
+			if cacheable {
+				err = ctx.GetRedisConn().Hmset(key, "name", name, "remark", remark)
+				if err != nil {
+					log.Error("缓存名字失败！", zap.Error(err))
+					return "", err
+				}
+				err = ctx.GetRedisConn().Expire(key, ctx.GetConfig().Cache.NameCacheExpire)
+				if err != nil {
+					log.Error("设置过期时间失败！", zap.String("key", key), zap.Error(err))
+					return "", err
+				}
 			}
 		}
 	} else {
@@ -260,15 +284,19 @@ func getAndCacheShowNameForFromUID(msgResp msgOfflineNotify, ctx *config.Context
 			if err != nil {
 				return "", err
 			}
-			err = ctx.GetRedisConn().Hmset(key, "name", name, "remark", remark, "name_in_group", nameInGroup)
-			if err != nil {
-				log.Error("缓存名字失败！", zap.Error(err))
-				return "", err
-			}
-			err = ctx.GetRedisConn().Expire(key, ctx.GetConfig().Cache.NameCacheExpire)
-			if err != nil {
-				log.Error("设置过期时间失败！", zap.String("key", key), zap.Error(err))
-				return "", err
+			var cacheable bool
+			name, cacheable = fallbackSyntheticSenderName(ctx, msgResp.FromUID, name)
+			if cacheable {
+				err = ctx.GetRedisConn().Hmset(key, "name", name, "remark", remark, "name_in_group", nameInGroup)
+				if err != nil {
+					log.Error("缓存名字失败！", zap.Error(err))
+					return "", err
+				}
+				err = ctx.GetRedisConn().Expire(key, ctx.GetConfig().Cache.NameCacheExpire)
+				if err != nil {
+					log.Error("设置过期时间失败！", zap.String("key", key), zap.Error(err))
+					return "", err
+				}
 			}
 		}
 

--- a/modules/webhook/push_sender_name_integration_test.go
+++ b/modules/webhook/push_sender_name_integration_test.go
@@ -1,0 +1,110 @@
+package webhook
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+
+	// Migration chain + incomingwebhook's BussDataSource.ChannelGet registration
+	// (its init() via register.AddModule). Without these the push path can't
+	// resolve an iwh_ sender's display name. Mirrors modules/incomingwebhook
+	// db_test.go's import set; none of them import modules/webhook (no cycle).
+	_ "github.com/Mininglamp-OSS/octo-server/modules/base"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/common"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/group"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/incomingwebhook"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/robot"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/space"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/user"
+)
+
+func TestMain(m *testing.M) {
+	// common.Setup (run by module.Setup inside NewTestServer) requires a 32-byte
+	// master key; matches modules/incomingwebhook/api_test.go.
+	if os.Getenv("OCTO_MASTER_KEY") == "" {
+		_ = os.Setenv("OCTO_MASTER_KEY", "12345678901234567890123456789012")
+	}
+	os.Exit(m.Run())
+}
+
+// insertWebhookRow seeds a minimal incoming_webhook row (all other columns have
+// NOT NULL DEFAULT ”) and returns the synthetic sender UID (iwh_...).
+func insertWebhookRow(t *testing.T, ctx *config.Context, groupNo, name string) string {
+	t.Helper()
+	whID := "iwh_" + strings.ReplaceAll(util.GenerUUID(), "-", "")
+	_, err := ctx.DB().InsertInto("incoming_webhook").
+		Columns("webhook_id", "token_hash", "group_no", "name", "status").
+		Values(whID, "h", groupNo, name, 1).Exec()
+	assert.NoError(t, err)
+	return whID
+}
+
+// TestGetAndCacheShowNameForFromUID_Webhook_GroupMiss is the end-to-end regression
+// for the original bug: an offline group push from an incoming-webhook sender
+// (iwh_, absent from the `user` table) must render the webhook's display name
+// instead of an empty sender. Exercises the cache-MISS path: DB miss → fallback
+// resolve via the datasource registry → cache the resolved name.
+func TestGetAndCacheShowNameForFromUID_Webhook_GroupMiss(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+
+	groupNo := "g_" + util.GenerUUID()[:12]
+	whID := insertWebhookRow(t, ctx, groupNo, "GH Bot")
+	toUID := "u_" + util.GenerUUID()[:12]
+
+	key := fmt.Sprintf("%s%s-%s@%s", nameCachePrefix, whID, toUID, groupNo)
+	assert.NoError(t, ctx.GetRedisConn().Del(key)) // ensure cache miss
+
+	msg := msgOfflineNotify{}
+	msg.FromUID = whID
+	msg.ToUID = toUID
+	msg.ChannelID = groupNo
+	msg.ChannelType = common.ChannelTypeGroup.Uint8()
+
+	name, err := getAndCacheShowNameForFromUID(msg, ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "GH Bot", name, "incoming webhook 发送者名应在推送里解析出来")
+
+	// resolved name must be cached so subsequent pushes hit the cache
+	cached, err := ctx.GetRedisConn().Hget(key, "name")
+	assert.NoError(t, err)
+	assert.Equal(t, "GH Bot", cached)
+}
+
+// TestGetAndCacheShowNameForFromUID_Webhook_CacheHitStaleEmptyRepaired covers the
+// cache-HIT repair path (repairEmptyCachedName): an entry cached with an empty
+// name before the fix must be re-resolved and repaired in place on hit, rather
+// than serving the stale empty name until the TTL expires.
+func TestGetAndCacheShowNameForFromUID_Webhook_CacheHitStaleEmptyRepaired(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+
+	groupNo := "g_" + util.GenerUUID()[:12]
+	whID := insertWebhookRow(t, ctx, groupNo, "GH Bot")
+	toUID := "u_" + util.GenerUUID()[:12]
+
+	key := fmt.Sprintf("%s%s-%s@%s", nameCachePrefix, whID, toUID, groupNo)
+	// Simulate a stale empty name cached by the pre-fix code.
+	assert.NoError(t, ctx.GetRedisConn().Hmset(key, "name", "", "remark", "", "name_in_group", ""))
+
+	msg := msgOfflineNotify{}
+	msg.FromUID = whID
+	msg.ToUID = toUID
+	msg.ChannelID = groupNo
+	msg.ChannelType = common.ChannelTypeGroup.Uint8()
+
+	name, err := getAndCacheShowNameForFromUID(msg, ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "GH Bot", name, "命中旧空名应触发兜底并就地修复")
+
+	cached, err := ctx.GetRedisConn().Hget(key, "name")
+	assert.NoError(t, err)
+	assert.Equal(t, "GH Bot", cached, "缓存的 name 字段应被就地修复")
+}

--- a/modules/webhook/push_sender_name_test.go
+++ b/modules/webhook/push_sender_name_test.go
@@ -1,0 +1,13 @@
+package webhook
+
+import "testing"
+
+// TestFallbackSyntheticSenderName_KeepsExistingName 验证：当 GetThirdName 已取到常用名
+// （真实用户）时，兜底逻辑直接原样返回、cacheable=true，也不触碰 datasource（因此传 nil
+// ctx 也安全）。只有名字为空（如 incoming webhook 虚拟发送者）才会走解析兜底。
+func TestFallbackSyntheticSenderName_KeepsExistingName(t *testing.T) {
+	got, cacheable := fallbackSyntheticSenderName(nil, "iwh_abc", "Alice")
+	if got != "Alice" || !cacheable {
+		t.Fatalf("fallbackSyntheticSenderName(nil, iwh_abc, Alice) = (%q, %v), want (Alice, true)", got, cacheable)
+	}
+}

--- a/modules/webhook/push_sender_name_test.go
+++ b/modules/webhook/push_sender_name_test.go
@@ -11,3 +11,12 @@ func TestFallbackSyntheticSenderName_KeepsExistingName(t *testing.T) {
 		t.Fatalf("fallbackSyntheticSenderName(nil, iwh_abc, Alice) = (%q, %v), want (Alice, true)", got, cacheable)
 	}
 }
+
+// TestRepairEmptyCachedName_KeepsExistingName 验证缓存命中且 name 非空时,修复逻辑原样
+// 返回、不触碰 datasource/Redis(因此 nil ctx 也安全)。只有命中到空名(存量 iwh_)才会
+// 走兜底解析并就地修复。
+func TestRepairEmptyCachedName_KeepsExistingName(t *testing.T) {
+	if got := repairEmptyCachedName(nil, "name:k", "iwh_abc", "Alice"); got != "Alice" {
+		t.Fatalf("repairEmptyCachedName overrode a present cached name: got %q, want %q", got, "Alice")
+	}
+}


### PR DESCRIPTION
## Problem

An offline push notification for a message sent by an **incoming-webhook virtual sender** (uid `iwh_xxx`) shows **no sender name** — the body renders as `: <message>` instead of `<WebhookName>: <message>`.

Closes #411.

## Root cause

The push pipeline resolves the sender name via `getAndCacheShowNameForFromUID` → `db.GetThirdName` (`modules/webhook/`), which only reads the **`user`** table. Incoming-webhook senders have **no `user` row** — their name lives in `incoming_webhook.name` — so the lookup returns empty. (Real users / bots have `user` rows and are unaffected.)

Same `iwh_`-is-not-a-real-user family as #250 / #255, but a **distinct, server-fixable surface**: #250 fixed `/v1/users`·`/v1/channels`·avatar; #255 is the client-rendered revoke tip; this is the **offline push** sender name.

## What changed

- **`modules/user`** — extract the `BussDataSource.ChannelGet` resolution into a ctx-based `resolveWebhookChannelVia` (`resolveWebhookChannel` now delegates, behavior unchanged) and export `ResolveWebhookDisplayName(ctx, uid)`. This reuses the **same datasource registry** that already powers `/v1/users` for `iwh_` identities; the push path has only a `ctx`, not a `*User`.
- **`modules/webhook`** — when `GetThirdName` yields an empty name, fall back to `ResolveWebhookDisplayName` and cache the resolved name in the existing `name:` hash. Triggered by an **empty name** (real users always have one) rather than hardcoding the `iwh_` prefix in the push layer. A transient datasource error returns `cacheable=false` so the empty name is **not** frozen for the TTL (next push retries); resolution failure is warn-and-continue and never drops the push.

No import cycle (`webhook`→`user` only). No new user-facing error responses (i18n envelope untouched).

## Tests

- `modules/incomingwebhook/push_name_test.go` (integration, CI): `ResolveWebhookDisplayName` resolves a webhook's name via the registry; a non-existent `iwh_` uid returns the clean `("", nil)` not-found result.
- `modules/webhook/push_sender_name_test.go` (unit): the fallback never overrides a present name and reports `cacheable=true`.
- Local: `go build ./...`, `go vet`, `gofmt`, `make i18n-lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHG3Akmfr6mwihJmLZWxoL

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHG3Akmfr6mwihJmLZWxoL)_