### PR TITLE
feat(bot_api): /v1/bot streaming + per-UID rate limiting (OCT-31, OCT-42, OCT-41)

### DIFF
--- a/modules/bot_api/api_i18n_test.go
+++ b/modules/bot_api/api_i18n_test.go
@@ -37,6 +37,7 @@ func TestBotAPINoLegacyResponseError(t *testing.T) {
 		"auth.go", "register.go", "commands.go", "events.go", "mention_pref.go",
 		"sync.go", "typing.go", "send.go", "threads.go", "file.go", "groups.go",
 		"voice_adapter.go", "obo_api.go", "resolve_targets.go", "incoming_webhook.go",
+		"stream.go",
 	}
 	banned := []string{
 		".ResponseError(",

--- a/modules/bot_api/auth.go
+++ b/modules/bot_api/auth.go
@@ -42,6 +42,18 @@ func (ba *BotAPI) authBot() wkhttp.HandlerFunc {
 	}
 }
 
+// setBotActorUID records the resolved bot identity on both the bot-specific
+// CtxKeyRobotID and the generic "uid" context key. The "uid" mirror is what
+// SharedUIDRateLimiter (and any other AuthMiddleware-shaped consumer) reads —
+// setting it at every authBot resolution point means every authBot-mounted
+// group is per-UID rate limited without each call site remembering to insert
+// botActorUID(). The limiter fails open silently when "uid" is unset (see
+// UIDRateLimitMiddleware), so this must run wherever auth succeeds. (OCT-42)
+func setBotActorUID(c *wkhttp.Context, uid string) {
+	c.Set(CtxKeyRobotID, uid)
+	c.Set("uid", uid)
+}
+
 // authUserBot authenticates a User Bot via robot table lookup.
 func (ba *BotAPI) authUserBot(c *wkhttp.Context, token string) {
 	robot, err := ba.db.queryRobotByBotToken(token)
@@ -55,7 +67,7 @@ func (ba *BotAPI) authUserBot(c *wkhttp.Context, token string) {
 		return
 	}
 
-	c.Set(CtxKeyRobotID, robot.RobotID)
+	setBotActorUID(c, robot.RobotID)
 	c.Set(CtxKeyBotKind, BotKindUser)
 	c.Set(CtxKeyRobot, robot)
 	c.Next()
@@ -67,7 +79,7 @@ func (ba *BotAPI) authUserBot(c *wkhttp.Context, token string) {
 func (ba *BotAPI) authAppBot(c *wkhttp.Context, token string) {
 	// Try in-memory Registry first (O(1))
 	if spec := ba.lookupAppBotRegistry(token); spec != nil {
-		c.Set(CtxKeyRobotID, spec.UID)
+		setBotActorUID(c, spec.UID)
 		c.Set(CtxKeyBotKind, BotKindApp)
 		c.Set(CtxKeyAppBotScope, spec.Scope)
 		if spec.Scope == "space" {
@@ -95,7 +107,7 @@ func (ba *BotAPI) authAppBot(c *wkhttp.Context, token string) {
 		return
 	}
 
-	c.Set(CtxKeyRobotID, appBot.UID)
+	setBotActorUID(c, appBot.UID)
 	c.Set(CtxKeyBotKind, BotKindApp)
 	c.Set(CtxKeyAppBotScope, appBot.Scope)
 	if appBot.Scope == "space" {

--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -66,6 +66,12 @@ type BotAPI struct {
 	// WuKongIM. nil in production → the real ba.ctx path runs.
 	streamStartOverride func(config.MessageStreamStartReq) (string, error)
 	streamEndOverride   func(config.MessageStreamEndReq) error
+	// streamOwnerStoreOverride lets unit tests inject an in-memory
+	// stream_no→robotID ownership map so the OCT-41 ownership check in
+	// streamEnd (and the binding write in streamStart) can be table-tested
+	// without a live Redis. nil in production → the Redis-backed
+	// redisStreamOwnerStore runs. See stream_owner.go.
+	streamOwnerStoreOverride streamOwnerStore
 	// oboStoreOverride lets unit tests inject an in-memory oboStore so
 	// checkOBO / REST handlers / fan-out can run without standing up MySQL.
 	// nil in production; the real path uses ba.db (which satisfies oboStore).

--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/modules/voice_adapter"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 )
 
 const (
@@ -29,13 +30,13 @@ const (
 // BotAPI is the public Bot API gateway module.
 // It handles all bot-facing endpoints (/v1/bot/*) with unified auth.
 type BotAPI struct {
-	ctx                   *config.Context
-	db                    *botAPIDB
-	userService           user.IService
-	fileService           file.IService
-	groupService          group.IService
-	userDB                *user.DB
-	threadService         thread.IService
+	ctx           *config.Context
+	db            *botAPIDB
+	userService   user.IService
+	fileService   file.IService
+	groupService  group.IService
+	userDB        *user.DB
+	threadService thread.IService
 	// robotService gives the OBO fan-out path a way to enqueue synthetic
 	// events directly into a grantee bot's /v1/bot/events queue. The
 	// webhook layer drops NoPersist=1 messages before NotifyMessagesListeners
@@ -232,8 +233,12 @@ func (ba *BotAPI) Route(r *wkhttp.WKHttp) {
 	// register endpoint (token needed but not via authBot group — handled inline)
 	r.POST("/v1/bot/register", ba.register)
 
-	// Bot API endpoints (unified auth middleware)
-	botAPI := r.Group("/v1/bot", ba.authBot())
+	// Bot API endpoints (unified auth middleware).
+	// SharedUIDRateLimiter is mounted AFTER authBot() so it reads the "uid"
+	// authBot sets (= robotID): every authenticated bot send/stream/manage call
+	// is capped per-bot, not just by the global per-IP DDoS floor. This closes
+	// the stream-amplification gap on stream/start (OCT-42).
+	botAPI := r.Group("/v1/bot", ba.authBot(), appwkhttp.SharedUIDRateLimiter(r, ba.ctx))
 	{
 		botAPI.POST("/sendMessage", ba.sendMessage)
 		botAPI.POST("/typing", ba.typing)
@@ -295,8 +300,9 @@ func (ba *BotAPI) Route(r *wkhttp.WKHttp) {
 		botAPI.GET("/obo-grant", ba.oboBotGetGrant)
 	}
 
-	// Bot File API (separate group for wildcard conflict avoidance)
-	botFileAPI := r.Group("/v1/botfile", ba.authBot())
+	// Bot File API (separate group for wildcard conflict avoidance).
+	// Same per-UID cap as the main bot group (OCT-42).
+	botFileAPI := r.Group("/v1/botfile", ba.authBot(), appwkhttp.SharedUIDRateLimiter(r, ba.ctx))
 	{
 		botFileAPI.GET("/*path", ba.botProxyFile)
 		botFileAPI.POST("/upload", ba.botUploadFile)

--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -58,6 +58,13 @@ type BotAPI struct {
 	// final MsgSendReq (including server-authoritative payload.space_id).
 	// nil in production; the real path goes through ba.ctx.SendMessageWithResult.
 	dispatchOverride func(*config.MsgSendReq) (*config.MsgSendResp, error)
+	// streamStartOverride / streamEndOverride let unit tests intercept the
+	// WuKongIM stream RPCs (IMStreamStart / IMStreamEnd) so the /v1/bot/stream/*
+	// handlers can be table-tested — including the security-critical assertion
+	// that FromUID is forced to the authenticated robotID — without a live
+	// WuKongIM. nil in production → the real ba.ctx path runs.
+	streamStartOverride func(config.MessageStreamStartReq) (string, error)
+	streamEndOverride   func(config.MessageStreamEndReq) error
 	// oboStoreOverride lets unit tests inject an in-memory oboStore so
 	// checkOBO / REST handlers / fan-out can run without standing up MySQL.
 	// nil in production; the real path uses ba.db (which satisfies oboStore).
@@ -140,6 +147,28 @@ func (ba *BotAPI) dispatchMsgSendReq(req *config.MsgSendReq) (*config.MsgSendRes
 	return ba.ctx.SendMessageWithResult(req)
 }
 
+// dispatchStreamStart opens a WuKongIM message stream via ba.ctx, OR a
+// test-injected streamStartOverride. Returns the server-assigned stream_no.
+func (ba *BotAPI) dispatchStreamStart(req config.MessageStreamStartReq) (string, error) {
+	if ba.streamStartOverride != nil {
+		return ba.streamStartOverride(req)
+	}
+	return ba.ctx.IMStreamStart(req)
+}
+
+// dispatchStreamEnd closes a WuKongIM message stream via ba.ctx, OR a
+// test-injected streamEndOverride. This is the terminal signal the octo-web
+// client waits on (streamFlag == END) to stop the live "streaming" bubble;
+// a missing END leaves the bubble stuck. The gateway (cc-channel-octo) must
+// always call /v1/bot/stream/end in a finally so END fires even on
+// error/abort/truncation.
+func (ba *BotAPI) dispatchStreamEnd(req config.MessageStreamEndReq) error {
+	if ba.streamEndOverride != nil {
+		return ba.streamEndOverride(req)
+	}
+	return ba.ctx.IMStreamEnd(req)
+}
+
 // NewBotAPI creates the Bot API gateway module.
 func NewBotAPI(ctx *config.Context) *BotAPI {
 	speechURL := os.Getenv(voice_adapter.EnvSpeechServiceURL)
@@ -208,6 +237,13 @@ func (ba *BotAPI) Route(r *wkhttp.WKHttp) {
 	{
 		botAPI.POST("/sendMessage", ba.sendMessage)
 		botAPI.POST("/typing", ba.typing)
+		// Incremental channel streaming (OCT-31). Mirrors the internal
+		// modules/robot stream protocol on the public bot API: open a
+		// stream, send incremental items via /sendMessage with the returned
+		// stream_no, then close it. Both are gated by checkSendPermission and
+		// scoped to the authenticated bot — see stream.go.
+		botAPI.POST("/stream/start", ba.streamStart)
+		botAPI.POST("/stream/end", ba.streamEnd)
 		botAPI.POST("/readReceipt", ba.readReceipt)
 		botAPI.POST("/events", ba.getEvents)
 		botAPI.POST("/events/:event_id/ack", ba.eventAck)

--- a/modules/bot_api/ratelimit_test.go
+++ b/modules/bot_api/ratelimit_test.go
@@ -53,22 +53,20 @@ func setupBotRateLimitEnv(t *testing.T) (http.Handler, func()) {
 	}
 }
 
-// TestBotAPI_PerUIDRateLimit_TripsBucket hammers an authenticated /v1/bot route
-// with one bot token until the per-UID bucket is exhausted, then asserts the
-// limiter returned the shared rate.limited response scoped to "uid".
-func TestBotAPI_PerUIDRateLimit_TripsBucket(t *testing.T) {
-	handler, cleanup := setupBotRateLimitEnv(t)
-	defer cleanup()
+// assertPerUIDBucketTrips drives one bot token against an authenticated /v1/bot
+// route until its per-UID bucket is exhausted. It asserts (a) the first call
+// passes AND carries X-RateLimit-Scope: uid — proving the limiter actually read
+// "uid" rather than silently failing open (the bug OCT-42 fixes) — and (b) a
+// later call trips with a uid-scoped 429 carrying Retry-After.
+func assertPerUIDBucketTrips(t *testing.T, handler http.Handler, token string) {
+	t.Helper()
 
 	// /v1/bot/heartbeat is the lightest authenticated route: it only needs a
 	// valid bot token and Redis, returns 200, and sits on the same authBot group
 	// as the send/stream endpoints — so it exercises the exact middleware chain.
 	const path = "/v1/bot/heartbeat"
 
-	// First call: bucket full → passes. The UID limiter still annotates the
-	// response, which proves it is actually reading "uid" (not silently failing
-	// open because uid was unset — the bug this issue fixes).
-	first := doBot(handler, botReq(t, "POST", path, rlBotToken, nil))
+	first := doBot(handler, botReq(t, "POST", path, token, nil))
 	require.Equalf(t, http.StatusOK, first.Code, "baseline heartbeat should pass; body: %s", first.Body.String())
 	require.Equalf(t, "uid", first.Header().Get("X-RateLimit-Scope"),
 		"limiter must be scoped to uid (else it failed open / not mounted)")
@@ -77,7 +75,7 @@ func TestBotAPI_PerUIDRateLimit_TripsBucket(t *testing.T) {
 	// 200 rapid in-process requests comfortably exhaust it even with refill.
 	var tripped *struct{ scope, retryAfter string }
 	for i := 0; i < 200; i++ {
-		w := doBot(handler, botReq(t, "POST", path, rlBotToken, nil))
+		w := doBot(handler, botReq(t, "POST", path, token, nil))
 		if w.Code == http.StatusTooManyRequests {
 			tripped = &struct{ scope, retryAfter string }{
 				scope:      w.Header().Get("X-RateLimit-Scope"),
@@ -90,4 +88,86 @@ func TestBotAPI_PerUIDRateLimit_TripsBucket(t *testing.T) {
 	require.NotNil(t, tripped, "per-UID bucket never tripped after 200 requests — limiter not enforcing")
 	assert.Equal(t, "uid", tripped.scope, "rate-limited response must be uid-scoped (per-bot), not ip-scoped")
 	assert.NotEmpty(t, tripped.retryAfter, "rate.limited response must carry Retry-After")
+}
+
+// TestBotAPI_PerUIDRateLimit_TripsBucket proves the User Bot (bf_) path sets
+// "uid" and is per-UID capped.
+func TestBotAPI_PerUIDRateLimit_TripsBucket(t *testing.T) {
+	handler, cleanup := setupBotRateLimitEnv(t)
+	defer cleanup()
+	assertPerUIDBucketTrips(t, handler, rlBotToken)
+}
+
+const (
+	rlAppRegBotUID = "app_ratelimit_oct42_reg_bot"
+	rlAppRegBotTok = "app_ratelimit_oct42_reg_token"
+	rlAppDBBotUID  = "app_ratelimit_oct42_db_bot"
+	rlAppDBBotTok  = "app_ratelimit_oct42_db_token"
+)
+
+// TestBotAPI_PerUIDRateLimit_AppBot_TripsBucket proves the App Bot (app_)
+// principals — not just the User Bot path — also set "uid" and are per-UID
+// capped. authBot resolves App Bots in two places (O(1) in-memory registry,
+// then DB fallback) and BOTH must call setBotActorUID; otherwise app_ tokens
+// silently fail open and re-introduce the OCT-42 amplification gap for App Bots.
+// Each path is exercised with a distinct app_ token.
+func TestBotAPI_PerUIDRateLimit_AppBot_TripsBucket(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	// Registry path: inject an adapter that resolves the registry token. Restore
+	// the prior global registry afterwards so we don't leak state into other
+	// tests in this package.
+	prevReg := GetAppBotRegistry()
+	reg := NewAppBotRegistryAdapter()
+	reg.Add(rlAppRegBotTok, &AppBotRegistrySpec{UID: rlAppRegBotUID, Scope: "platform"})
+	SetAppBotRegistry(reg)
+	t.Cleanup(func() {
+		if prevReg != nil {
+			SetAppBotRegistry(prevReg)
+			return
+		}
+		// atomic.Value cannot store an untyped nil; an empty adapter is
+		// behaviourally identical to "no registry" for FindByToken.
+		SetAppBotRegistry(NewAppBotRegistryAdapter())
+	})
+
+	// DB-fallback path: a published app_bot row whose token is NOT in the
+	// registry, so authAppBot falls through to queryAppBotByToken. The app_bot
+	// table is owned by the app_bot module, which this test binary does not
+	// import; the shared CI schema has it, but a partial local DB may not — so
+	// skip (not fail) the DB-fallback subtest if the row can't be inserted.
+	dbBotReady := true
+	if _, err := ctx.DB().InsertBySql(
+		"INSERT INTO app_bot (id, uid, display_name, scope, status, token, created_by) VALUES (?, ?, ?, 'platform', 1, ?, ?)",
+		rlAppDBBotUID, rlAppDBBotUID, "oct42 app db bot", rlAppDBBotTok, "owner_oct42").Exec(); err != nil {
+		dbBotReady = false
+		t.Logf("app_bot DB-fallback row not inserted (app_bot table likely absent in this binary's schema): %v", err)
+	}
+
+	rds := redis.NewClient(&redis.Options{
+		Addr:     ctx.GetConfig().DB.RedisAddr,
+		Password: ctx.GetConfig().DB.RedisPass,
+	})
+	resetBucket := func() {
+		if keys, err := rds.Keys("ratelimit:uid:*").Result(); err == nil && len(keys) > 0 {
+			_ = rds.Del(keys...).Err()
+		}
+	}
+	t.Cleanup(func() { resetBucket(); _ = rds.Close() })
+
+	handler := s.GetRoute()
+
+	t.Run("registry path", func(t *testing.T) {
+		resetBucket() // distinct UIDs use distinct buckets; reset keeps each subtest hermetic
+		assertPerUIDBucketTrips(t, handler, rlAppRegBotTok)
+	})
+
+	t.Run("db fallback path", func(t *testing.T) {
+		if !dbBotReady {
+			t.Skip("app_bot table unavailable in this test binary's schema; DB-fallback path covered in CI")
+		}
+		resetBucket()
+		assertPerUIDBucketTrips(t, handler, rlAppDBBotTok)
+	})
 }

--- a/modules/bot_api/ratelimit_test.go
+++ b/modules/bot_api/ratelimit_test.go
@@ -1,0 +1,93 @@
+package bot_api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/go-redis/redis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// OCT-42: the /v1/bot send surface must enforce a per-UID (per-bot) cap, not
+// just the global per-IP DDoS floor. authBot() now mirrors robotID onto the
+// "uid" context key and the group mounts SharedUIDRateLimiter after it, so a
+// single bot token hammering an authenticated route trips its own Redis bucket
+// (ratelimit:uid:{robotID}) and gets the shared rate.limited response.
+//
+// This is the regression guard for the stream-amplification gap: stream/start
+// rides the same authBot group, so this proves it is now per-bot capped.
+
+const (
+	rlBotID    = "bot_ratelimit_oct42"
+	rlBotToken = "bf_ratelimit_oct42_token"
+)
+
+func setupBotRateLimitEnv(t *testing.T) (http.Handler, func()) {
+	t.Helper()
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, status, creator_uid, bot_token) VALUES (?, 1, ?, ?)",
+		rlBotID, "owner_oct42", rlBotToken).Exec()
+	require.NoError(t, err)
+
+	// The UID bucket lives in Redis (ratelimit:uid:*) and persists across tests;
+	// CleanAllTables does NOT clear it. Reset so we start from a full bucket.
+	rds := redis.NewClient(&redis.Options{
+		Addr:     ctx.GetConfig().DB.RedisAddr,
+		Password: ctx.GetConfig().DB.RedisPass,
+	})
+	resetBucket := func() {
+		if keys, err := rds.Keys("ratelimit:uid:*").Result(); err == nil && len(keys) > 0 {
+			_ = rds.Del(keys...).Err()
+		}
+	}
+	resetBucket()
+
+	return s.GetRoute(), func() {
+		resetBucket()
+		_ = rds.Close()
+	}
+}
+
+// TestBotAPI_PerUIDRateLimit_TripsBucket hammers an authenticated /v1/bot route
+// with one bot token until the per-UID bucket is exhausted, then asserts the
+// limiter returned the shared rate.limited response scoped to "uid".
+func TestBotAPI_PerUIDRateLimit_TripsBucket(t *testing.T) {
+	handler, cleanup := setupBotRateLimitEnv(t)
+	defer cleanup()
+
+	// /v1/bot/heartbeat is the lightest authenticated route: it only needs a
+	// valid bot token and Redis, returns 200, and sits on the same authBot group
+	// as the send/stream endpoints — so it exercises the exact middleware chain.
+	const path = "/v1/bot/heartbeat"
+
+	// First call: bucket full → passes. The UID limiter still annotates the
+	// response, which proves it is actually reading "uid" (not silently failing
+	// open because uid was unset — the bug this issue fixes).
+	first := doBot(handler, botReq(t, "POST", path, rlBotToken, nil))
+	require.Equalf(t, http.StatusOK, first.Code, "baseline heartbeat should pass; body: %s", first.Body.String())
+	require.Equalf(t, "uid", first.Header().Get("X-RateLimit-Scope"),
+		"limiter must be scoped to uid (else it failed open / not mounted)")
+
+	// Hammer until the bucket trips. Default burst is 60 (DM_API_UID_RATELIMIT_BURST);
+	// 200 rapid in-process requests comfortably exhaust it even with refill.
+	var tripped *struct{ scope, retryAfter string }
+	for i := 0; i < 200; i++ {
+		w := doBot(handler, botReq(t, "POST", path, rlBotToken, nil))
+		if w.Code == http.StatusTooManyRequests {
+			tripped = &struct{ scope, retryAfter string }{
+				scope:      w.Header().Get("X-RateLimit-Scope"),
+				retryAfter: w.Header().Get("Retry-After"),
+			}
+			break
+		}
+	}
+
+	require.NotNil(t, tripped, "per-UID bucket never tripped after 200 requests — limiter not enforcing")
+	assert.Equal(t, "uid", tripped.scope, "rate-limited response must be uid-scoped (per-bot), not ip-scoped")
+	assert.NotEmpty(t, tripped.retryAfter, "rate.limited response must carry Retry-After")
+}

--- a/modules/bot_api/stream.go
+++ b/modules/bot_api/stream.go
@@ -67,6 +67,17 @@ func (ba *BotAPI) streamStart(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrBotAPISendFailed, nil, nil)
 		return
 	}
+
+	// OCT-41: record stream_no → robotID so /v1/bot/stream/end can verify the
+	// caller owns the stream before terminating it. Best-effort — the bubble is
+	// already live, so a binding-write failure must not fail the open; it only
+	// weakens the later ownership check (which then falls through to the channel
+	// gate). Log and continue.
+	if bindErr := ba.streamOwners().bind(streamNo, robotID); bindErr != nil {
+		ba.Warn("记录stream owner失败", zap.Error(bindErr),
+			zap.String("robotID", robotID), zap.String("streamNo", streamNo))
+	}
+
 	c.Response(gin.H{
 		"stream_no": streamNo,
 	})
@@ -84,6 +95,21 @@ func (ba *BotAPI) streamStart(c *wkhttp.Context) {
 //
 // Gated by the same checkSendPermission as stream/start and sendMessage so a
 // bot can only close streams in channels it may post to.
+//
+// OCT-41 — ownership binding. The channel gate alone does NOT prove the caller
+// opened this stream_no: WuKongIM resolves a stream by its stream_no alone, and
+// the channel_id/channel_type in MessageStreamEndReq are addressing/routing
+// fields, not a stream↔channel authorization check (the deployed WuKongIM, an
+// octo-im v2.2.x fork, exposes no "does stream_no belong to channel_id?" check
+// — the legacy /streammessage/* manager API that octo-lib targets is served
+// only by older v1.x images and still keys streams by stream_no). So without
+// the explicit owner check below, a co-member bot could observe a peer's live
+// stream_no (it is rendered into the channel and visible via /messages/sync)
+// and prematurely terminate the peer's bubble. We bind stream_no → robotID at
+// start (streamStart) and reject an end whose recorded owner is a different
+// bot. The binding is independent of channel_id, so it also closes the
+// channel-gate-bypass concern (claiming a channel you may post to while ending
+// a stream that lives elsewhere).
 func (ba *BotAPI) streamEnd(c *wkhttp.Context) {
 	var req config.MessageStreamEndReq
 	if err := c.BindJSON(&req); err != nil {
@@ -111,6 +137,25 @@ func (ba *BotAPI) streamEnd(c *wkhttp.Context) {
 		return
 	}
 
+	// OCT-41 ownership gate. Posture: deny on a CONFIRMED owner mismatch; fall
+	// through (allow) when no binding is found or the lookup errors. A binding
+	// is present for the entire live window of any stream opened via
+	// stream/start, so the griefing window — a co-member bot ending a peer's
+	// still-live bubble — is fully covered. Absence means the stream is stale
+	// (TTL elapsed, so it closed long ago) or was opened outside this path;
+	// failing open there preserves the terminal-END guarantee (a missing END
+	// leaves the octo-web bubble stuck "streaming") without reopening the
+	// attack, since a stale/foreign stream_no has no live bubble to grief.
+	if owner, ownErr := ba.streamOwners().owner(req.StreamNo); ownErr != nil {
+		ba.Warn("查询stream owner失败，跳过归属校验", zap.Error(ownErr),
+			zap.String("robotID", robotID), zap.String("streamNo", req.StreamNo))
+	} else if owner != "" && owner != robotID {
+		ba.Warn("拒绝结束非本bot的stream", zap.String("robotID", robotID),
+			zap.String("owner", owner), zap.String("streamNo", req.StreamNo))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStreamNotOwned, nil, nil)
+		return
+	}
+
 	req.ChannelID = ba.resolveSpaceChannelID(robotID, req.ChannelID, req.ChannelType)
 
 	if err := ba.dispatchStreamEnd(req); err != nil {
@@ -118,5 +163,13 @@ func (ba *BotAPI) streamEnd(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrBotAPISendFailed, nil, nil)
 		return
 	}
+
+	// Stream closed: drop the binding so the stream_no does not linger in the
+	// store. Best-effort — a stale binding only expires by TTL otherwise.
+	if relErr := ba.streamOwners().release(req.StreamNo); relErr != nil {
+		ba.Warn("释放stream owner失败", zap.Error(relErr),
+			zap.String("robotID", robotID), zap.String("streamNo", req.StreamNo))
+	}
+
 	c.ResponseOK()
 }

--- a/modules/bot_api/stream.go
+++ b/modules/bot_api/stream.go
@@ -1,0 +1,122 @@
+package bot_api
+
+import (
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+// streamStart handles POST /v1/bot/stream/start.
+//
+// OCT-31 — public bot-API mirror of modules/robot streamStart (api.go
+// L305-322). It opens a WuKongIM message stream so a bot can render a live,
+// token-by-token bubble in a channel. The returned stream_no is then passed
+// to /v1/bot/sendMessage for each incremental chunk (send.go already forwards
+// StreamNo to MsgSendReq), and /v1/bot/stream/end terminates the bubble.
+//
+// Security (PR review gate): unlike the internal robot path — which trusts the
+// client-supplied FromUID — this is a PUBLIC route that emits into a channel,
+// so two things are enforced here:
+//
+//  1. Channel gate: the same checkSendPermission used by sendMessage runs
+//     first, so a bot can only open a stream in a channel it may post to.
+//     hasOBOContext=false — stream start always dispatches AS the bot (we
+//     force FromUID below), never as an OBO grantor, so the friend-gate
+//     bypass must not apply.
+//  2. Sender scoping: any client-supplied FromUID is overwritten with the
+//     authenticated robotID, so the live bubble can only ever be attributed
+//     to the calling bot.
+func (ba *BotAPI) streamStart(c *wkhttp.Context) {
+	var req config.MessageStreamStartReq
+	if err := c.BindJSON(&req); err != nil {
+		respondBotAPIRequestInvalid(c, "")
+		return
+	}
+	if strings.TrimSpace(req.ChannelID) == "" {
+		respondBotAPIRequestInvalid(c, "channel_id")
+		return
+	}
+	if req.ChannelType == 0 {
+		respondBotAPIRequestInvalid(c, "channel_type")
+		return
+	}
+
+	robotID := getRobotIDFromContext(c)
+	botKind := getBotKindFromContext(c)
+
+	// Channel send-permission / membership gate — identical to sendMessage.
+	if err := ba.checkSendPermission(c, botKind, robotID, req.ChannelID, req.ChannelType, false); err != nil {
+		respondSendPermissionError(c, err)
+		return
+	}
+
+	// Scope the stream to the authenticated bot. The client cannot choose the
+	// stream's sender identity; overwrite any supplied value so the bubble is
+	// always attributed to this bot.
+	req.FromUID = robotID
+	req.ChannelID = ba.resolveSpaceChannelID(robotID, req.ChannelID, req.ChannelType)
+
+	streamNo, err := ba.dispatchStreamStart(req)
+	if err != nil {
+		ba.Error("发送stream start消息失败", zap.Error(err), zap.String("robotID", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPISendFailed, nil, nil)
+		return
+	}
+	c.Response(gin.H{
+		"stream_no": streamNo,
+	})
+}
+
+// streamEnd handles POST /v1/bot/stream/end.
+//
+// OCT-31 — public bot-API mirror of modules/robot streamEnd (api.go
+// L324-338). This emits the terminal END (streamFlag == END) that the
+// octo-web client waits on to stop the live "streaming" bubble. It is
+// REQUIRED: a missing END leaves the client bubble stuck "streaming"
+// indefinitely (the exact failure Frontend flagged on OCT-10/OCT-18). The
+// gateway (cc-channel-octo) must therefore always call this in a finally so
+// END fires even on agent error/abort/truncation.
+//
+// Gated by the same checkSendPermission as stream/start and sendMessage so a
+// bot can only close streams in channels it may post to.
+func (ba *BotAPI) streamEnd(c *wkhttp.Context) {
+	var req config.MessageStreamEndReq
+	if err := c.BindJSON(&req); err != nil {
+		respondBotAPIRequestInvalid(c, "")
+		return
+	}
+	if strings.TrimSpace(req.StreamNo) == "" {
+		respondBotAPIRequestInvalid(c, "stream_no")
+		return
+	}
+	if strings.TrimSpace(req.ChannelID) == "" {
+		respondBotAPIRequestInvalid(c, "channel_id")
+		return
+	}
+	if req.ChannelType == 0 {
+		respondBotAPIRequestInvalid(c, "channel_type")
+		return
+	}
+
+	robotID := getRobotIDFromContext(c)
+	botKind := getBotKindFromContext(c)
+
+	if err := ba.checkSendPermission(c, botKind, robotID, req.ChannelID, req.ChannelType, false); err != nil {
+		respondSendPermissionError(c, err)
+		return
+	}
+
+	req.ChannelID = ba.resolveSpaceChannelID(robotID, req.ChannelID, req.ChannelType)
+
+	if err := ba.dispatchStreamEnd(req); err != nil {
+		ba.Error("发送stream end消息失败", zap.Error(err), zap.String("robotID", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPISendFailed, nil, nil)
+		return
+	}
+	c.ResponseOK()
+}

--- a/modules/bot_api/stream_owner.go
+++ b/modules/bot_api/stream_owner.go
@@ -1,0 +1,86 @@
+package bot_api
+
+import "time"
+
+// OCT-41 — stream_no → robotID ownership binding.
+//
+// /v1/bot/stream/end is gated by checkSendPermission on the supplied
+// channel_id, but that gate only proves the caller MAY post to that channel —
+// it does NOT prove the caller opened the stream it is trying to end. WuKongIM
+// resolves a stream by its stream_no alone; the channel_id/channel_type in the
+// end request are addressing/routing fields, not an ownership or
+// stream↔channel authorization check (the deployed WuKongIM exposes no way to
+// assert "stream_no belongs to channel_id"). Without an explicit binding a
+// co-member bot could observe a peer's live stream_no (it is rendered into the
+// channel and visible via /messages/sync) and prematurely terminate the peer's
+// bubble. We therefore record which bot opened each stream at start and reject
+// an end whose recorded owner is a different bot.
+//
+// The binding is keyed solely on stream_no and is independent of channel_id,
+// so it also closes the channel-gate-bypass concern in OCT-41 item #2: an
+// attacker cannot end a stream they do not own no matter which channel they
+// claim in the request.
+
+const (
+	// streamOwnerKeyPrefix namespaces the Redis keys that hold a stream's owner.
+	streamOwnerKeyPrefix = "bot:stream:owner:"
+
+	// streamOwnerTTL bounds how long a stream_no → robotID binding lives. It
+	// must comfortably exceed the longest plausible live bubble (a slow LLM
+	// generation streamed token-by-token) so a still-streaming bubble is never
+	// orphaned — an absent binding fails open (see streamEnd) to preserve the
+	// terminal-END guarantee, so the only cost of an over-long TTL is a slightly
+	// larger Redis key set. Streams normally close within seconds; one hour is
+	// deliberately generous.
+	streamOwnerTTL = time.Hour
+)
+
+// streamOwnerStore records and verifies which bot owns a given WuKongIM stream.
+// Production uses a Redis-backed implementation; unit tests inject an in-memory
+// store via BotAPI.streamOwnerStoreOverride so the ownership gate can be
+// table-tested without a live Redis.
+type streamOwnerStore interface {
+	// bind records streamNo → robotID at stream open. It overwrites any prior
+	// binding for the same stream_no.
+	bind(streamNo, robotID string) error
+	// owner returns the bound robotID for streamNo, or "" when no binding
+	// exists (TTL elapsed, opened outside this path, or never recorded).
+	owner(streamNo string) (string, error)
+	// release removes the binding after a successful end so the stream_no does
+	// not linger in the store. Best-effort; callers ignore the error.
+	release(streamNo string) error
+}
+
+// redisStreamOwnerStore is the production streamOwnerStore backed by the shared
+// Redis connection on the BotAPI context.
+type redisStreamOwnerStore struct {
+	ba  *BotAPI
+	ttl time.Duration
+}
+
+func (s redisStreamOwnerStore) key(streamNo string) string {
+	return streamOwnerKeyPrefix + streamNo
+}
+
+func (s redisStreamOwnerStore) bind(streamNo, robotID string) error {
+	return s.ba.ctx.GetRedisConn().SetAndExpire(s.key(streamNo), robotID, s.ttl)
+}
+
+func (s redisStreamOwnerStore) owner(streamNo string) (string, error) {
+	// GetString returns ("", nil) for a missing key, which the caller treats as
+	// "no binding" → fail open.
+	return s.ba.ctx.GetRedisConn().GetString(s.key(streamNo))
+}
+
+func (s redisStreamOwnerStore) release(streamNo string) error {
+	return s.ba.ctx.GetRedisConn().Del(s.key(streamNo))
+}
+
+// streamOwners returns the active streamOwnerStore: the test override when set,
+// otherwise the Redis-backed production store.
+func (ba *BotAPI) streamOwners() streamOwnerStore {
+	if ba.streamOwnerStoreOverride != nil {
+		return ba.streamOwnerStoreOverride
+	}
+	return redisStreamOwnerStore{ba: ba, ttl: streamOwnerTTL}
+}

--- a/modules/bot_api/stream_owner_test.go
+++ b/modules/bot_api/stream_owner_test.go
@@ -1,0 +1,234 @@
+// Package bot_api · OCT-41: tests for the stream_no→robotID ownership binding
+// that guards /v1/bot/stream/end against co-member bot griefing.
+//
+// The handler ownership check runs against a streamOwnerStore. These tests
+// inject an in-memory store (memStreamOwnerStore) via streamOwnerStoreOverride
+// so the gate is exercised without a live Redis. The same in-memory store is
+// reused by the start/end happy-path tests in stream_test.go to keep ba.ctx
+// (and thus Redis) out of those pure-Go handler tests.
+package bot_api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// memStreamOwnerStore is an in-memory streamOwnerStore for handler tests.
+type memStreamOwnerStore struct {
+	mu sync.Mutex
+	m  map[string]string
+}
+
+func newMemStreamOwnerStore() *memStreamOwnerStore {
+	return &memStreamOwnerStore{m: make(map[string]string)}
+}
+
+func (s *memStreamOwnerStore) bind(streamNo, robotID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[streamNo] = robotID
+	return nil
+}
+
+func (s *memStreamOwnerStore) owner(streamNo string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.m[streamNo], nil
+}
+
+func (s *memStreamOwnerStore) release(streamNo string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, streamNo)
+	return nil
+}
+
+func (s *memStreamOwnerStore) get(streamNo string) (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.m[streamNo]
+	return v, ok
+}
+
+// TestStreamEnd_RejectsForeignOwner is the OCT-41 acceptance test: in a shared
+// channel, Bot B must NOT be able to end a stream_no opened by Bot A. Bot A
+// owns the stream (recorded at start); Bot B passes the channel gate (it is a
+// legitimate member, modelled here via the DM creator-bypass branch) yet must
+// be denied by the ownership check, and IMStreamEnd must NOT fire.
+func TestStreamEnd_RejectsForeignOwner(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		botA     = "bot_A"
+		botB     = "bot_B"
+		streamNo = "stream_owned_by_A"
+		// Both bots are addressed via a DM whose channel_id == their CreatorUID,
+		// so checkSendPermission takes the creator-bypass branch (no DB) and the
+		// only thing left to stop Bot B is the ownership gate.
+		channelB = "user_creator_B"
+	)
+
+	owners := newMemStreamOwnerStore()
+	_ = owners.bind(streamNo, botA) // Bot A opened this stream.
+
+	ec := &streamEndCapture{}
+	ba := &BotAPI{
+		Log:                      log.NewTLog("BotAPI-stream-it"),
+		streamEndOverride:        ec.hook,
+		streamOwnerStoreOverride: owners,
+	}
+
+	body, _ := json.Marshal(config.MessageStreamEndReq{
+		StreamNo:    streamNo,
+		ChannelID:   channelB,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+	})
+
+	rec := httptest.NewRecorder()
+	c := newStreamTestContext(rec, "/v1/bot/stream/end", body, botB, channelB, BotKindUser)
+	ba.streamEnd(c)
+
+	// Denials go through the ResponseErrorL facade, which pins the wire status
+	// to 400 (D14 compat) and carries the real 403 in error.http_status — the
+	// existing permission tests assert NotEqual(200) for the same reason. We
+	// also assert the distinctive ownership message so this isn't confused with
+	// a channel-gate denial.
+	assert.NotEqualf(t, http.StatusOK, rec.Code,
+		"Bot B ending Bot A's stream must be denied, got %d body=%s", rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), "stream you opened",
+		"denial must be the stream-ownership guard, not some other gate")
+	ec.mu.Lock()
+	assert.Nil(t, ec.captured, "IMStreamEnd must NOT fire when the caller is not the stream owner")
+	ec.mu.Unlock()
+
+	// The binding must survive a rejected end so the true owner can still close it.
+	got, ok := owners.get(streamNo)
+	assert.True(t, ok, "binding must not be released on a denied end")
+	assert.Equal(t, botA, got)
+}
+
+// TestStreamEnd_OwnerCanEnd: the bot that opened the stream ends it
+// successfully, IMStreamEnd fires, and the binding is released afterward.
+func TestStreamEnd_OwnerCanEnd(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		botA       = "bot_A"
+		creatorUID = "user_creator"
+		streamNo   = "stream_owned_by_A"
+	)
+
+	owners := newMemStreamOwnerStore()
+	_ = owners.bind(streamNo, botA)
+
+	ec := &streamEndCapture{}
+	ba := &BotAPI{
+		Log:                      log.NewTLog("BotAPI-stream-it"),
+		streamEndOverride:        ec.hook,
+		streamOwnerStoreOverride: owners,
+	}
+
+	body, _ := json.Marshal(config.MessageStreamEndReq{
+		StreamNo:    streamNo,
+		ChannelID:   creatorUID,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+	})
+
+	rec := httptest.NewRecorder()
+	c := newStreamTestContext(rec, "/v1/bot/stream/end", body, botA, creatorUID, BotKindUser)
+	ba.streamEnd(c)
+
+	assert.Equalf(t, http.StatusOK, rec.Code,
+		"owner ending its own stream should be 200, got %d body=%s", rec.Code, rec.Body.String())
+	ec.mu.Lock()
+	if assert.NotNil(t, ec.captured, "IMStreamEnd MUST fire for the stream owner") {
+		assert.Equal(t, streamNo, ec.captured.StreamNo)
+	}
+	ec.mu.Unlock()
+
+	_, ok := owners.get(streamNo)
+	assert.False(t, ok, "binding should be released after a successful end")
+}
+
+// TestStreamEnd_NoBindingFallsThrough: an absent binding (stale TTL, or a
+// stream opened outside this path) must NOT block the end — the terminal-END
+// guarantee outweighs the bounded griefing risk, which only exists while a
+// binding is present. IMStreamEnd must still fire.
+func TestStreamEnd_NoBindingFallsThrough(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		botX       = "bot_X"
+		creatorUID = "user_creator"
+		streamNo   = "stream_with_no_binding"
+	)
+
+	owners := newMemStreamOwnerStore() // empty: no binding for streamNo
+
+	ec := &streamEndCapture{}
+	ba := &BotAPI{
+		Log:                      log.NewTLog("BotAPI-stream-it"),
+		streamEndOverride:        ec.hook,
+		streamOwnerStoreOverride: owners,
+	}
+
+	body, _ := json.Marshal(config.MessageStreamEndReq{
+		StreamNo:    streamNo,
+		ChannelID:   creatorUID,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+	})
+
+	rec := httptest.NewRecorder()
+	c := newStreamTestContext(rec, "/v1/bot/stream/end", body, botX, creatorUID, BotKindUser)
+	ba.streamEnd(c)
+
+	assert.Equalf(t, http.StatusOK, rec.Code,
+		"absent binding must fall through to allow, got %d body=%s", rec.Code, rec.Body.String())
+	ec.mu.Lock()
+	assert.NotNil(t, ec.captured, "IMStreamEnd MUST fire when no binding exists (terminal-END guarantee)")
+	ec.mu.Unlock()
+}
+
+// TestStreamStart_BindsOwner: a successful stream/start records stream_no →
+// robotID so a later stream/end can verify ownership.
+func TestStreamStart_BindsOwner(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		botRobotID = "bot_X"
+		creatorUID = "user_creator"
+		wantStream = "stream_99"
+	)
+
+	owners := newMemStreamOwnerStore()
+	sc := &streamStartCapture{streamNo: wantStream}
+	ba := &BotAPI{
+		Log:                      log.NewTLog("BotAPI-stream-it"),
+		streamStartOverride:      sc.hook,
+		streamOwnerStoreOverride: owners,
+	}
+
+	body, _ := json.Marshal(config.MessageStreamStartReq{
+		ChannelID:   creatorUID,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+	})
+
+	rec := httptest.NewRecorder()
+	c := newStreamTestContext(rec, "/v1/bot/stream/start", body, botRobotID, creatorUID, BotKindUser)
+	ba.streamStart(c)
+
+	assert.Equalf(t, http.StatusOK, rec.Code,
+		"streamStart should respond 200, got %d body=%s", rec.Code, rec.Body.String())
+	got, ok := owners.get(wantStream)
+	assert.True(t, ok, "stream/start must record the owner binding")
+	assert.Equal(t, botRobotID, got, "binding must map stream_no → authenticated robotID")
+}

--- a/modules/bot_api/stream_test.go
+++ b/modules/bot_api/stream_test.go
@@ -1,0 +1,258 @@
+// Package bot_api · OCT-31: tests for the public /v1/bot/stream/* routes.
+//
+// Exercises the streamStart / streamEnd HTTP handlers end-to-end with the
+// IMStreamStart / IMStreamEnd RPCs intercepted via streamStartOverride /
+// streamEndOverride, so no live WuKongIM is required.
+//
+// Permission paths used to avoid DB dependencies:
+//   - allowed:  BotKindUser DM where CreatorUID == channel_id (creator-bypass
+//     branch of checkSendPermission — no IsFriend / group_member query).
+//   - denied:   BotKindApp with a GROUP channel (App bots are DM-only, so
+//     checkSendPermission rejects before any DB call).
+package bot_api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// streamStartCapture records the MessageStreamStartReq passed to the override.
+type streamStartCapture struct {
+	mu       sync.Mutex
+	captured *config.MessageStreamStartReq
+	streamNo string
+}
+
+func (s *streamStartCapture) hook(req config.MessageStreamStartReq) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	clone := req
+	s.captured = &clone
+	return s.streamNo, nil
+}
+
+// streamEndCapture records the MessageStreamEndReq passed to the override.
+type streamEndCapture struct {
+	mu       sync.Mutex
+	captured *config.MessageStreamEndReq
+}
+
+func (s *streamEndCapture) hook(req config.MessageStreamEndReq) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	clone := req
+	s.captured = &clone
+	return nil
+}
+
+func newStreamTestContext(rec *httptest.ResponseRecorder, path string, body []byte, robotID, creatorUID, botKind string) *wkhttp.Context {
+	httpReq := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httpReq
+	c := &wkhttp.Context{Context: gc}
+	c.Set(CtxKeyRobotID, robotID)
+	c.Set(CtxKeyBotKind, botKind)
+	// CreatorUID == DM peer exercises the creator-bypass branch of
+	// checkSendPermission (no DB). Harmless for the App-bot denial path.
+	c.Set(CtxKeyRobot, &robotModel{RobotID: robotID, CreatorUID: creatorUID})
+	return c
+}
+
+// TestStreamStart_ScopesFromUIDToBot is the OCT-31 security acceptance test:
+// a forged client FromUID MUST be overwritten with the authenticated robotID,
+// and the channel send-permission gate MUST run before the stream opens.
+func TestStreamStart_ScopesFromUIDToBot(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		botRobotID = "bot_X"
+		creatorUID = "user_creator" // == channel_id → creator-bypass branch
+		forgedFrom = "victim_user"  // attacker-supplied FromUID
+		wantStream = "stream_42"
+	)
+
+	sc := &streamStartCapture{streamNo: wantStream}
+	ba := &BotAPI{
+		Log:                 log.NewTLog("BotAPI-stream-it"),
+		streamStartOverride: sc.hook,
+	}
+
+	body, _ := json.Marshal(config.MessageStreamStartReq{
+		FromUID:     forgedFrom, // must be ignored by the server
+		ChannelID:   creatorUID,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+	})
+
+	rec := httptest.NewRecorder()
+	c := newStreamTestContext(rec, "/v1/bot/stream/start", body, botRobotID, creatorUID, BotKindUser)
+	ba.streamStart(c)
+
+	assert.Equalf(t, http.StatusOK, rec.Code,
+		"streamStart should respond 200, got %d body=%s", rec.Code, rec.Body.String())
+
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	if !assert.NotNil(t, sc.captured, "IMStreamStart must have been invoked") {
+		return
+	}
+	assert.Equal(t, botRobotID, sc.captured.FromUID,
+		"FromUID MUST be forced to the authenticated robotID, not the forged client value")
+	assert.NotEqual(t, forgedFrom, sc.captured.FromUID)
+	assert.Equal(t, creatorUID, sc.captured.ChannelID)
+
+	// Response body carries the server-assigned stream_no.
+	var resp struct {
+		Data struct {
+			StreamNo string `json:"stream_no"`
+		} `json:"data"`
+		StreamNo string `json:"stream_no"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	got := resp.StreamNo
+	if got == "" {
+		got = resp.Data.StreamNo
+	}
+	assert.Equal(t, wantStream, got, "response must return the stream_no from IMStreamStart")
+}
+
+// TestStreamStart_PermissionDenied: an App bot may only DM, so a GROUP stream
+// must be rejected and IMStreamStart must NOT be called.
+func TestStreamStart_PermissionDenied(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	sc := &streamStartCapture{streamNo: "should_not_be_used"}
+	ba := &BotAPI{
+		Log:                 log.NewTLog("BotAPI-stream-it"),
+		streamStartOverride: sc.hook,
+	}
+
+	body, _ := json.Marshal(config.MessageStreamStartReq{
+		ChannelID:   "group_123",
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+	})
+
+	rec := httptest.NewRecorder()
+	c := newStreamTestContext(rec, "/v1/bot/stream/start", body, "app_bot", "", BotKindApp)
+	ba.streamStart(c)
+
+	assert.NotEqual(t, http.StatusOK, rec.Code, "App bot GROUP stream must be denied")
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	assert.Nil(t, sc.captured, "IMStreamStart must NOT run when permission check fails")
+}
+
+func TestStreamStart_MissingFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cases := []struct {
+		name string
+		req  config.MessageStreamStartReq
+	}{
+		{"missing channel_id", config.MessageStreamStartReq{ChannelType: common.ChannelTypePerson.Uint8()}},
+		{"missing channel_type", config.MessageStreamStartReq{ChannelID: "user_creator"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := &streamStartCapture{streamNo: "x"}
+			ba := &BotAPI{Log: log.NewTLog("BotAPI-stream-it"), streamStartOverride: sc.hook}
+			body, _ := json.Marshal(tc.req)
+			rec := httptest.NewRecorder()
+			c := newStreamTestContext(rec, "/v1/bot/stream/start", body, "bot_X", "user_creator", BotKindUser)
+			ba.streamStart(c)
+			assert.NotEqual(t, http.StatusOK, rec.Code, "missing required field must be rejected")
+			sc.mu.Lock()
+			assert.Nil(t, sc.captured, "IMStreamStart must NOT run on a malformed request")
+			sc.mu.Unlock()
+		})
+	}
+}
+
+// TestStreamEnd_EmitsTerminalEnd is the OCT-31 terminal-END guarantee: a valid
+// stream/end call MUST reach IMStreamEnd with the supplied stream_no. A missing
+// END would leave the octo-web bubble stuck "streaming".
+func TestStreamEnd_EmitsTerminalEnd(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		botRobotID = "bot_X"
+		creatorUID = "user_creator"
+		streamNo   = "stream_42"
+	)
+
+	ec := &streamEndCapture{}
+	ba := &BotAPI{
+		Log:               log.NewTLog("BotAPI-stream-it"),
+		streamEndOverride: ec.hook,
+	}
+
+	body, _ := json.Marshal(config.MessageStreamEndReq{
+		StreamNo:    streamNo,
+		ChannelID:   creatorUID,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+	})
+
+	rec := httptest.NewRecorder()
+	c := newStreamTestContext(rec, "/v1/bot/stream/end", body, botRobotID, creatorUID, BotKindUser)
+	ba.streamEnd(c)
+
+	assert.Equalf(t, http.StatusOK, rec.Code,
+		"streamEnd should respond 200, got %d body=%s", rec.Code, rec.Body.String())
+	ec.mu.Lock()
+	defer ec.mu.Unlock()
+	if !assert.NotNil(t, ec.captured, "IMStreamEnd MUST be invoked (terminal END guarantee)") {
+		return
+	}
+	assert.Equal(t, streamNo, ec.captured.StreamNo)
+	assert.Equal(t, creatorUID, ec.captured.ChannelID)
+}
+
+func TestStreamEnd_MissingStreamNo(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	ec := &streamEndCapture{}
+	ba := &BotAPI{Log: log.NewTLog("BotAPI-stream-it"), streamEndOverride: ec.hook}
+	body, _ := json.Marshal(config.MessageStreamEndReq{
+		ChannelID:   "user_creator",
+		ChannelType: common.ChannelTypePerson.Uint8(),
+	})
+	rec := httptest.NewRecorder()
+	c := newStreamTestContext(rec, "/v1/bot/stream/end", body, "bot_X", "user_creator", BotKindUser)
+	ba.streamEnd(c)
+
+	assert.NotEqual(t, http.StatusOK, rec.Code, "missing stream_no must be rejected")
+	ec.mu.Lock()
+	assert.Nil(t, ec.captured, "IMStreamEnd must NOT run on a malformed request")
+	ec.mu.Unlock()
+}
+
+func TestStreamEnd_PermissionDenied(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	ec := &streamEndCapture{}
+	ba := &BotAPI{Log: log.NewTLog("BotAPI-stream-it"), streamEndOverride: ec.hook}
+	body, _ := json.Marshal(config.MessageStreamEndReq{
+		StreamNo:    "stream_42",
+		ChannelID:   "group_123",
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+	})
+	rec := httptest.NewRecorder()
+	c := newStreamTestContext(rec, "/v1/bot/stream/end", body, "app_bot", "", BotKindApp)
+	ba.streamEnd(c)
+
+	assert.NotEqual(t, http.StatusOK, rec.Code, "App bot GROUP stream/end must be denied")
+	ec.mu.Lock()
+	assert.Nil(t, ec.captured, "IMStreamEnd must NOT run when permission check fails")
+	ec.mu.Unlock()
+}

--- a/modules/bot_api/stream_test.go
+++ b/modules/bot_api/stream_test.go
@@ -85,8 +85,9 @@ func TestStreamStart_ScopesFromUIDToBot(t *testing.T) {
 
 	sc := &streamStartCapture{streamNo: wantStream}
 	ba := &BotAPI{
-		Log:                 log.NewTLog("BotAPI-stream-it"),
-		streamStartOverride: sc.hook,
+		Log:                      log.NewTLog("BotAPI-stream-it"),
+		streamStartOverride:      sc.hook,
+		streamOwnerStoreOverride: newMemStreamOwnerStore(),
 	}
 
 	body, _ := json.Marshal(config.MessageStreamStartReq{
@@ -193,8 +194,9 @@ func TestStreamEnd_EmitsTerminalEnd(t *testing.T) {
 
 	ec := &streamEndCapture{}
 	ba := &BotAPI{
-		Log:               log.NewTLog("BotAPI-stream-it"),
-		streamEndOverride: ec.hook,
+		Log:                      log.NewTLog("BotAPI-stream-it"),
+		streamEndOverride:        ec.hook,
+		streamOwnerStoreOverride: newMemStreamOwnerStore(),
 	}
 
 	body, _ := json.Marshal(config.MessageStreamEndReq{

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -51,6 +51,7 @@ type Group struct {
 	groupService  IService
 	fileService   file.IService
 	commonService common2.IService
+	reconciler    *ChannelReconciler
 }
 
 // New New
@@ -73,7 +74,51 @@ func New(ctx *config.Context) *Group {
 	g.ctx.AddEventListener(event.OrgOrDeptEmployeeUpdate, g.handleOrgOrDeptEmployeeUpdate)
 	g.ctx.AddEventListener(event.OrgEmployeeExit, g.handleOrgEmployeeExit)
 	source.SetGroupMemberProvider(g)
+	g.startChannelReconciler()
 	return g
+}
+
+// startChannelReconciler 启动 IM 频道孤儿找回 worker（octo-server #394）。
+//
+// 在 New 中启动而非 register.Module.Start：main.go 只调 module.Setup（间接触发本
+// 构造），并不调 module.Start，与 oidc SyncWorker 的接入点一致。测试模式
+// (cfg.Test) 下禁用——避免后台 goroutine 在测试进程里周期性打真实 WuKongIM/Redis；
+// reconcile 逻辑由单测直接构造 ChannelReconciler 验证。
+//
+// 周期/grace 可经环境变量覆盖；间隔 ≤0 视为禁用。多实例用 Redis tick lock 去重，
+// 锁不可用时降级无锁运行（重建/翻转幂等，正确性不受影响）。
+func (g *Group) startChannelReconciler() {
+	if g.ctx.GetConfig().Test {
+		return
+	}
+	interval := defaultReconcileInterval
+	if v := strings.TrimSpace(os.Getenv("DM_GROUP_CHANNEL_RECONCILE_INTERVAL_SEC")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			interval = time.Duration(n) * time.Second
+		}
+	}
+	if interval <= 0 {
+		g.Info("channel reconcile worker disabled (interval<=0)")
+		return
+	}
+	grace := defaultReconcileGraceSec
+	if v := strings.TrimSpace(os.Getenv("DM_GROUP_CHANNEL_RECONCILE_GRACE_SEC")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			grace = n
+		}
+	}
+	svc, ok := g.groupService.(*Service)
+	if !ok {
+		g.Error("channel reconcile worker not started: groupService is not *Service")
+		return
+	}
+	g.reconciler = NewChannelReconciler(svc, ReconcileConfig{
+		Interval: interval,
+		GraceSec: grace,
+	}, newRedisReconcileLock(g.ctx))
+	g.reconciler.Start(context.Background())
+	g.Info("channel reconcile worker started",
+		zap.Duration("interval", interval), zap.Int("graceSec", grace))
 }
 
 // Route 路由配置

--- a/modules/group/channel_reconcile.go
+++ b/modules/group/channel_reconcile.go
@@ -1,0 +1,268 @@
+package group
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
+	"go.uber.org/zap"
+)
+
+// octo-server #394：建群与 IM 频道创建非原子，commit 与 IM 创建之间任何失败/崩溃都会
+// 留下「可查询但无 IM 频道」的孤儿群。CreateGroup 已把待确认的群标记成
+// channel_synced=0，本 worker 周期性地把超过 grace 窗口仍为 0 的群找出来，幂等重建
+// IM 频道（IMCreateOrUpdateChannel 本身是 create-or-update，可安全重复调用）并翻转
+// channel_synced=1，实现最终一致——孤儿可被找回，而非永久残留。
+
+const (
+	// reconcileTickLockKey reconcile worker tick 级分布式互斥的 Redis key。
+	// 多实例部署时同一时刻只允许一个实例扫描，避免 N×IM 流量。锁不可用时降级为
+	// 无锁运行——因为重建/翻转都是幂等的，无锁只会多打几次 IM，不影响正确性。
+	reconcileTickLockKey = "group:channel_reconcile:tick"
+
+	defaultReconcileInterval = 120 * time.Second
+	defaultReconcileGraceSec = 120
+	defaultReconcileBatch    = 200
+)
+
+// ReconcileConfig 控制 reconcile worker 的调度参数。
+type ReconcileConfig struct {
+	Interval  time.Duration // ≤ 0 视为禁用，Start 直接返回
+	GraceSec  int           // 孤儿判定的 grace 窗口（秒）：仅处理创建超过该时长仍未同步的群
+	BatchSize int           // 单 tick 处理的孤儿上限
+	LockTTL   time.Duration // 分布式锁持有期，默认 = Interval
+}
+
+func (c *ReconcileConfig) withDefaults() {
+	if c.GraceSec <= 0 {
+		c.GraceSec = defaultReconcileGraceSec
+	}
+	if c.BatchSize <= 0 {
+		c.BatchSize = defaultReconcileBatch
+	}
+	if c.LockTTL <= 0 {
+		c.LockTTL = c.Interval
+	}
+}
+
+// reconcileTickLock tick 级分布式互斥锁的最小接口（与 oidc.tickLock 同语义：
+// Acquire 必须原子 SET NX EX，Release 必须 token-aware CAS-DEL）。nil = 不互斥。
+type reconcileTickLock interface {
+	Acquire(ctx context.Context, key, token string, ttl time.Duration) (bool, error)
+	Release(ctx context.Context, key, token string) (bool, error)
+}
+
+// luaReconcileReleaseLock CAS-DEL：仅当 value==token 时 DEL，避免 lease 边界误删他人锁。
+var luaReconcileReleaseLock = rd.NewScript(`
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+else
+  return 0
+end
+`)
+
+// redisReconcileLock 用 Redis SET NX EX + Lua CAS-DEL 实现 reconcileTickLock。
+type redisReconcileLock struct {
+	client *rd.Client
+}
+
+func newRedisReconcileLock(ctx *config.Context) *redisReconcileLock {
+	client := rd.NewClient(octoredis.MustBuildOptions(ctx.GetConfig(), func(o *rd.Options) {
+		o.MaxRetries = 3
+		o.ReadTimeout = 3 * time.Second
+		o.WriteTimeout = 3 * time.Second
+		o.DialTimeout = 3 * time.Second
+	}))
+	return &redisReconcileLock{client: client}
+}
+
+func (l *redisReconcileLock) Acquire(_ context.Context, key, token string, ttl time.Duration) (bool, error) {
+	if key == "" || token == "" || ttl <= 0 {
+		return false, fmt.Errorf("group: reconcile lock Acquire: key/token/ttl required")
+	}
+	ok, err := l.client.SetNX(key, token, ttl).Result()
+	if err != nil {
+		return false, fmt.Errorf("group: reconcile lock Acquire %q: %w", key, err)
+	}
+	return ok, nil
+}
+
+func (l *redisReconcileLock) Release(_ context.Context, key, token string) (bool, error) {
+	if key == "" || token == "" {
+		return false, fmt.Errorf("group: reconcile lock Release: key/token required")
+	}
+	res, err := luaReconcileReleaseLock.Run(l.client, []string{key}, token).Result()
+	if err != nil {
+		if errors.Is(err, rd.Nil) {
+			return false, nil
+		}
+		return false, fmt.Errorf("group: reconcile lock Release %q: %w", key, err)
+	}
+	n, ok := res.(int64)
+	if !ok {
+		return false, fmt.Errorf("group: reconcile lock Release %q: unexpected lua result type %T", key, res)
+	}
+	return n == 1, nil
+}
+
+func (l *redisReconcileLock) Close() error {
+	if l.client == nil {
+		return nil
+	}
+	return l.client.Close()
+}
+
+// ChannelReconciler 周期性找回 channel_synced=0 的孤儿群（octo-server #394）。
+type ChannelReconciler struct {
+	svc  *Service
+	cfg  ReconcileConfig
+	lock reconcileTickLock // nil = 单实例 / 测试，不做互斥
+	log.Log
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// NewChannelReconciler 构造 reconciler。lock 传 nil 时退化为「每实例独立 tick」——
+// 因重建/翻转幂等，无锁只是多打 IM，不影响正确性。
+func NewChannelReconciler(svc *Service, cfg ReconcileConfig, lock reconcileTickLock) *ChannelReconciler {
+	cfg.withDefaults()
+	return &ChannelReconciler{
+		svc:  svc,
+		cfg:  cfg,
+		lock: lock,
+		Log:  log.NewTLog("groupChannelReconcile"),
+	}
+}
+
+// Start 启动后台 ticker goroutine。Interval ≤ 0 视为禁用。
+// 幂等：重复调用会先 Stop 旧 goroutine 再启动新的。
+func (r *ChannelReconciler) Start(ctx context.Context) {
+	if r.cfg.Interval <= 0 {
+		return
+	}
+	if r.cancel != nil {
+		r.cancel()
+		r.wg.Wait()
+	}
+	rctx, cancel := context.WithCancel(ctx)
+	r.cancel = cancel
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		t := time.NewTicker(r.cfg.Interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-rctx.Done():
+				return
+			case <-t.C:
+				if err := r.RunOnce(rctx); err != nil && !errors.Is(err, context.Canceled) {
+					r.Error("channel reconcile tick failed", zap.Error(err))
+				}
+			}
+		}
+	}()
+}
+
+// Stop 通知 worker 退出并等待进行中的 tick 完成。
+func (r *ChannelReconciler) Stop() {
+	if r.cancel != nil {
+		r.cancel()
+	}
+	r.wg.Wait()
+}
+
+// RunOnce 执行一轮 reconcile：抢锁（可选）→ 扫描孤儿 → 逐个幂等重建 IM 频道 + 翻转标记。
+//
+// 多实例：抢到 tick lock 才扫描，抢不到直接返回（本 tick 由别人跑）。锁故障降级无锁运行。
+// 返回 ctx.Err() 让上层日志区分「正常停机」与「异常失败」。
+func (r *ChannelReconciler) RunOnce(ctx context.Context) error {
+	if r.lock != nil {
+		token := util.GenerUUID()
+		got, err := r.lock.Acquire(ctx, reconcileTickLockKey, token, r.cfg.LockTTL)
+		if err != nil {
+			// Redis 故障：降级到无锁路径而非阻塞。幂等保证正确性，仅多打 IM。
+			metricReconcileTickTotal.WithLabelValues("lock_err").Inc()
+			r.Warn("channel reconcile lock unavailable, running lock-free this tick", zap.Error(err))
+		} else if !got {
+			metricReconcileTickTotal.WithLabelValues("lock_held").Inc()
+			return nil
+		} else {
+			defer func() {
+				if _, rerr := r.lock.Release(ctx, reconcileTickLockKey, token); rerr != nil {
+					r.Warn("channel reconcile lock release failed", zap.Error(rerr))
+				}
+			}()
+		}
+	}
+
+	groupNos, err := r.svc.db.QueryReconcilableGroupNos(r.cfg.GraceSec, r.cfg.BatchSize)
+	if err != nil {
+		metricReconcileTickTotal.WithLabelValues("query_err").Inc()
+		return fmt.Errorf("group: query reconcilable groups: %w", err)
+	}
+	metricReconcileTickTotal.WithLabelValues("ran").Inc()
+	if len(groupNos) == 0 {
+		return nil
+	}
+	metricReconcileDetected.Add(float64(len(groupNos)))
+	r.Info("channel reconcile detected orphan groups", zap.Int("count", len(groupNos)))
+
+	for _, groupNo := range groupNos {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		r.reconcileOne(groupNo)
+	}
+	return nil
+}
+
+// reconcileOne 找回单个孤儿群：重建 IM 频道（幂等）→ 翻转 channel_synced=1。
+// 任何失败只记日志、不中断整批——下个 tick 会重试（全程幂等）。
+func (r *ChannelReconciler) reconcileOne(groupNo string) {
+	uids, err := r.svc.GetSubscribableMemberUIDs(groupNo)
+	if err != nil {
+		metricReconcileOutcomeTotal.WithLabelValues("im_fail").Inc()
+		r.Error("channel reconcile query members failed", zap.Error(err), zap.String("groupNo", groupNo))
+		return
+	}
+	if len(uids) == 0 {
+		// 没有可订阅成员（全员退出/被删）：这种群无需 IM 频道，标记同步避免反复扫描。
+		if _, ferr := r.svc.db.MarkChannelSynced(groupNo); ferr != nil {
+			metricReconcileOutcomeTotal.WithLabelValues("flag_fail").Inc()
+			r.Error("channel reconcile flag-only flip failed", zap.Error(ferr), zap.String("groupNo", groupNo))
+			return
+		}
+		metricReconcileOutcomeTotal.WithLabelValues("skipped").Inc()
+		return
+	}
+
+	if err := r.svc.imCreateChannel(&config.ChannelCreateReq{
+		ChannelID:   groupNo,
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		Subscribers: uids,
+	}); err != nil {
+		metricReconcileOutcomeTotal.WithLabelValues("im_fail").Inc()
+		r.Error("channel reconcile recreate IM channel failed", zap.Error(err), zap.String("groupNo", groupNo))
+		return
+	}
+
+	if _, err := r.svc.db.MarkChannelSynced(groupNo); err != nil {
+		metricReconcileOutcomeTotal.WithLabelValues("flag_fail").Inc()
+		r.Error("channel reconcile flip flag failed (IM channel already recreated, will retry)", zap.Error(err), zap.String("groupNo", groupNo))
+		return
+	}
+	metricReconcileOutcomeTotal.WithLabelValues("resolved").Inc()
+	r.Info("channel reconcile resolved orphan group", zap.String("groupNo", groupNo))
+}

--- a/modules/group/channel_reconcile_test.go
+++ b/modules/group/channel_reconcile_test.go
@@ -1,0 +1,195 @@
+package group
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readChannelSynced 直接读 group.channel_synced（Model 结构体不含该列，故走原始查询）。
+func readChannelSynced(t *testing.T, ctx *config.Context, groupNo string) (int, bool) {
+	t.Helper()
+	var vals []int
+	_, err := ctx.DB().Select("channel_synced").From("`group`").Where("group_no=?", groupNo).Load(&vals)
+	require.NoError(t, err)
+	if len(vals) == 0 {
+		return 0, false
+	}
+	return vals[0], true
+}
+
+// seedOrphanGroup 直接落一个「已提交但无 IM 频道」的孤儿群：channel_synced=0，
+// created_at 设为 ageAgo 之前。这正是「commit 与 IM 创建之间崩溃」或「IM 失败且补偿
+// 删除也失败」之后 DB 里残留的状态（octo-server #394）。
+func seedOrphanGroup(t *testing.T, ctx *config.Context, groupNo string, status int, ageAgo time.Duration, memberUIDs ...string) {
+	t.Helper()
+	createdAt := time.Now().Add(-ageAgo)
+	_, err := ctx.DB().InsertInto("group").
+		Columns("group_no", "name", "creator", "status", "version", "channel_synced", "created_at", "updated_at").
+		Values(groupNo, "orphan-"+groupNo, memberUIDs[0], status, 1, 0, createdAt, createdAt).Exec()
+	require.NoError(t, err)
+	for _, uid := range memberUIDs {
+		_, err := ctx.DB().InsertInto("group_member").
+			Columns("group_no", "uid", "role", "version", "status", "is_deleted").
+			Values(groupNo, uid, MemberRoleCommon, 1, int(common.GroupMemberStatusNormal), 0).Exec()
+		require.NoError(t, err)
+	}
+}
+
+// TestCreateGroup_Success_MarksChannelSynced 成功路径：IM 频道确认后 channel_synced=1。
+func TestCreateGroup_Success_MarksChannelSynced(t *testing.T) {
+	svc, userDB := setupServiceTest(t)
+	insertTestUsers(t, userDB, testutil.UID, "m1")
+
+	resp, err := svc.CreateGroup(&CreateGroupServiceReq{
+		Creator: testutil.UID,
+		Members: []string{"m1"},
+		Name:    "synced-ok",
+	})
+	require.NoError(t, err)
+
+	got, ok := readChannelSynced(t, svc.(*Service).ctx, resp.GroupNo)
+	assert.True(t, ok, "group row must exist")
+	assert.Equal(t, 1, got, "channel_synced must be flipped to 1 after IM channel confirmed")
+}
+
+// TestCreateGroup_IMFail_CompensatingDeleteRemovesGroup IM 创建失败 + 补偿删除成功：
+// 无孤儿残留（窄窗口路径）。注入失败的 imCreateChannel，避免依赖真实 WuKongIM 故障注入。
+func TestCreateGroup_IMFail_CompensatingDeleteRemovesGroup(t *testing.T) {
+	svc, userDB := setupServiceTest(t)
+	insertTestUsers(t, userDB, testutil.UID, "m1")
+
+	s := svc.(*Service)
+	s.imCreateChannel = func(*config.ChannelCreateReq) error {
+		return errors.New("simulated IM channel create failure")
+	}
+
+	resp, err := svc.CreateGroup(&CreateGroupServiceReq{
+		Creator: testutil.UID,
+		Members: []string{"m1"},
+		Name:    "im-fail",
+	})
+	require.Error(t, err, "CreateGroup must surface IM failure")
+	assert.Nil(t, resp, "resp must be nil on IM failure")
+
+	// 补偿删除成功路径：group 行已被清除，没有孤儿。
+	var count int
+	_, qerr := s.ctx.DB().Select("count(*)").From("`group`").Where("creator=? AND name=?", testutil.UID, "im-fail").Load(&count)
+	require.NoError(t, qerr)
+	assert.Equal(t, 0, count, "compensating delete should remove the group row")
+}
+
+// TestChannelReconcile_RecreatesChannelAndFlipsFlag 直接构造 reconciler 处理孤儿群：
+// 重建 IM 频道（捕获调用）+ 翻转 channel_synced=1。覆盖「crash-between-commit-and-IM」
+// 与「IM-fail + delete-fail」两种失败模式留下的残留状态。
+func TestChannelReconcile_RecreatesChannelAndFlipsFlag(t *testing.T) {
+	svc, userDB, ctx := setupServiceTestWithCtx(t)
+	insertTestUsers(t, userDB, "ou", "om1")
+
+	groupNo := "orphan-grp-1"
+	seedOrphanGroup(t, ctx, groupNo, GroupStatusNormal, 10*time.Minute, "ou", "om1")
+
+	s := svc.(*Service)
+	var gotReq *config.ChannelCreateReq
+	s.imCreateChannel = func(req *config.ChannelCreateReq) error {
+		gotReq = req
+		return nil
+	}
+
+	r := NewChannelReconciler(s, ReconcileConfig{Interval: time.Minute, GraceSec: 60, BatchSize: 50}, nil)
+	require.NoError(t, r.RunOnce(context.Background()))
+
+	require.NotNil(t, gotReq, "reconcile must recreate the IM channel")
+	assert.Equal(t, groupNo, gotReq.ChannelID)
+	assert.Equal(t, common.ChannelTypeGroup.Uint8(), gotReq.ChannelType)
+	assert.ElementsMatch(t, []string{"ou", "om1"}, gotReq.Subscribers)
+
+	got, ok := readChannelSynced(t, ctx, groupNo)
+	assert.True(t, ok)
+	assert.Equal(t, 1, got, "channel_synced must be flipped to 1 after reconcile")
+}
+
+// TestChannelReconcile_Idempotent 第二次 RunOnce 不应再处理已修复的群（幂等 + 可观测）。
+func TestChannelReconcile_Idempotent(t *testing.T) {
+	svc, userDB, ctx := setupServiceTestWithCtx(t)
+	insertTestUsers(t, userDB, "iu")
+
+	groupNo := "orphan-idem"
+	seedOrphanGroup(t, ctx, groupNo, GroupStatusNormal, 10*time.Minute, "iu")
+
+	s := svc.(*Service)
+	var calls int
+	s.imCreateChannel = func(*config.ChannelCreateReq) error { calls++; return nil }
+
+	r := NewChannelReconciler(s, ReconcileConfig{Interval: time.Minute, GraceSec: 60, BatchSize: 50}, nil)
+	require.NoError(t, r.RunOnce(context.Background()))
+	require.NoError(t, r.RunOnce(context.Background()))
+
+	assert.Equal(t, 1, calls, "second reconcile run must be a no-op (flag already synced)")
+}
+
+// TestChannelReconcile_RespectsGraceWindow grace 窗口内的新建群不被找回，避免与正在进行
+// 的建群/IM 确认竞争误删/误重建。
+func TestChannelReconcile_RespectsGraceWindow(t *testing.T) {
+	svc, userDB, ctx := setupServiceTestWithCtx(t)
+	insertTestUsers(t, userDB, "gu")
+
+	fresh := "orphan-fresh"
+	seedOrphanGroup(t, ctx, fresh, GroupStatusNormal, 1*time.Second, "gu")
+
+	s := svc.(*Service)
+	var calls int
+	s.imCreateChannel = func(*config.ChannelCreateReq) error { calls++; return nil }
+
+	r := NewChannelReconciler(s, ReconcileConfig{Interval: time.Minute, GraceSec: 120, BatchSize: 50}, nil)
+	require.NoError(t, r.RunOnce(context.Background()))
+
+	assert.Equal(t, 0, calls, "groups within the grace window must not be reconciled")
+	got, _ := readChannelSynced(t, ctx, fresh)
+	assert.Equal(t, 0, got, "fresh pending group stays channel_synced=0 until past grace")
+}
+
+// TestChannelReconcile_SkipsDisbandedGroup 已解散群的 IM 频道是被有意销毁的，不应重建。
+func TestChannelReconcile_SkipsDisbandedGroup(t *testing.T) {
+	svc, userDB, ctx := setupServiceTestWithCtx(t)
+	insertTestUsers(t, userDB, "du")
+
+	groupNo := "orphan-disband"
+	seedOrphanGroup(t, ctx, groupNo, GroupStatusDisband, 10*time.Minute, "du")
+
+	s := svc.(*Service)
+	var calls int
+	s.imCreateChannel = func(*config.ChannelCreateReq) error { calls++; return nil }
+
+	r := NewChannelReconciler(s, ReconcileConfig{Interval: time.Minute, GraceSec: 60, BatchSize: 50}, nil)
+	require.NoError(t, r.RunOnce(context.Background()))
+
+	assert.Equal(t, 0, calls, "disbanded groups must not be reconciled")
+}
+
+// TestChannelReconcile_IMFailLeavesOrphanForRetry 重建 IM 频道失败时保持 channel_synced=0，
+// 下个 tick 重试——孤儿不会被错误地标记为已修复。
+func TestChannelReconcile_IMFailLeavesOrphanForRetry(t *testing.T) {
+	svc, userDB, ctx := setupServiceTestWithCtx(t)
+	insertTestUsers(t, userDB, "fu")
+
+	groupNo := "orphan-retry"
+	seedOrphanGroup(t, ctx, groupNo, GroupStatusNormal, 10*time.Minute, "fu")
+
+	s := svc.(*Service)
+	s.imCreateChannel = func(*config.ChannelCreateReq) error { return errors.New("IM still down") }
+
+	r := NewChannelReconciler(s, ReconcileConfig{Interval: time.Minute, GraceSec: 60, BatchSize: 50}, nil)
+	require.NoError(t, r.RunOnce(context.Background()))
+
+	got, ok := readChannelSynced(t, ctx, groupNo)
+	assert.True(t, ok)
+	assert.Equal(t, 0, got, "channel_synced must stay 0 when IM recreate fails, so next tick retries")
+}

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -38,6 +38,47 @@ func (d *DB) Insert(m *Model) error {
 	return err
 }
 
+// markChannelPendingTx 在事务内把群标记为「IM 频道尚未确认」(channel_synced=0)。
+//
+// octo-server #394：CreateGroup 在 commit 后才创建 IM 频道，commit 与 IM 创建之间
+// 的任何失败/崩溃都会留下孤儿群。建群事务内先把行写成 pending，确认 IM 频道后再
+// 调 MarkChannelSynced 翻成 1，使孤儿可被 reconcile worker 检测与找回。
+//
+// channel_synced 不在 Model 结构体上（避免 AttrToUnderscore 把它带进系统群/注册建群
+// 等其它 Insert 路径，那些路径应保持 DB 默认值 1）；故这里用独立 UPDATE 显式置 0。
+func (d *DB) markChannelPendingTx(groupNo string, tx *dbr.Tx) error {
+	_, err := tx.Update("group").Set("channel_synced", 0).Where("group_no=?", groupNo).Exec()
+	return err
+}
+
+// MarkChannelSynced 确认 IM 频道已就绪后把群标记为已同步(channel_synced=1)。
+// 幂等：重复调用只是把已为 1 的行再写 1。返回受影响行数供 reconcile 竞态观测。
+func (d *DB) MarkChannelSynced(groupNo string) (int64, error) {
+	res, err := d.session.Update("group").Set("channel_synced", 1).Where("group_no=?", groupNo).Exec()
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// QueryReconcilableGroupNos 返回需要 reconcile 的孤儿群编号：channel_synced=0 且
+// 状态正常(GroupStatusNormal)、且创建时间早于 graceSeconds（避开正在进行中的建群
+// 与 IM 确认之间的正常窗口，防止误判）。limit 控制单批处理量。
+//
+// 只挑 GroupStatusNormal：已解散(GroupStatusDisband)的群其 IM 频道是被有意销毁的，
+// 不应重建。
+func (d *DB) QueryReconcilableGroupNos(graceSeconds, limit int) ([]string, error) {
+	var groupNos []string
+	_, err := d.session.Select("group_no").
+		From("`group`").
+		Where("channel_synced=0 AND status=?", GroupStatusNormal).
+		Where(fmt.Sprintf("created_at < DATE_SUB(NOW(), INTERVAL %d SECOND)", graceSeconds)).
+		OrderAsc("created_at").
+		Limit(uint64(limit)).
+		Load(&groupNos)
+	return groupNos, err
+}
+
 // 修改群类型
 func (d *DB) UpdateGroupTypeTx(groupNo string, groupType GroupType, tx *dbr.Tx) error {
 	_, err := tx.Update("group").Set("group_type", int(groupType)).Where("group_no=?", groupNo).Exec()

--- a/modules/group/metrics.go
+++ b/modules/group/metrics.go
@@ -1,0 +1,78 @@
+package group
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// 本文件登记 group 模块 octo-server #394（建群原子性 / IM 频道孤儿找回）相关的
+// Prometheus 指标。设计取舍与 modules/oidc/metrics.go 一致：
+//   - 注册到全局默认 Registry(promauto.New*)，由基础设施侧暴露 /metrics 端点。
+//   - Counter 用 *Vec 带 result/outcome 维度，便于 Grafana 切分成功/失败比例。
+//   - 不加 group_no/uid 这类高基数 label —— 会爆 Prometheus 内存。
+const groupMetricNamespace = "group"
+
+// channelCreateResultLabels 建群路径上 IM 频道创建的结果维度。
+//   - ok：IM 频道确认创建成功。
+//   - im_fail：IM 创建失败，已走补偿删除（失败时留 channel_synced=0 兜底）。
+func channelCreateResultLabels() []string { return []string{"ok", "im_fail"} }
+
+// reconcileTickResultLabels reconcile worker 每个 tick 的出口维度。
+//   - ran：本 tick 实际执行了一轮扫描。
+//   - lock_held：未抢到分布式锁，本 tick 由其它实例执行（多实例去重）。
+//   - lock_err：抢锁时 Redis 故障，已降级为无锁执行（幂等，安全）。
+//   - query_err：扫描孤儿行失败。
+func reconcileTickResultLabels() []string {
+	return []string{"ran", "lock_held", "lock_err", "query_err"}
+}
+
+// reconcileOutcomeLabels 单个孤儿群被 reconcile 处理的结果维度。
+//   - resolved：IM 频道幂等重建成功并翻转 channel_synced=1。
+//   - im_fail：重建 IM 频道失败，下个 tick 重试。
+//   - flag_fail：IM 频道已就绪但翻转标记失败，下个 tick 重试（幂等）。
+//   - skipped：处理时群已不再满足条件（已被删除/已解散/已被它实例修复）。
+func reconcileOutcomeLabels() []string {
+	return []string{"resolved", "im_fail", "flag_fail", "skipped"}
+}
+
+func init() {
+	for _, l := range channelCreateResultLabels() {
+		metricChannelCreateTotal.WithLabelValues(l).Add(0)
+	}
+	for _, l := range reconcileTickResultLabels() {
+		metricReconcileTickTotal.WithLabelValues(l).Add(0)
+	}
+	for _, l := range reconcileOutcomeLabels() {
+		metricReconcileOutcomeTotal.WithLabelValues(l).Add(0)
+	}
+}
+
+var (
+	// metricChannelCreateTotal 建群路径 IM 频道创建结果计数（result=ok|im_fail）。
+	metricChannelCreateTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: groupMetricNamespace,
+		Name:      "channel_create_total",
+		Help:      "IM channel create outcomes on the CreateGroup path (octo-server #394).",
+	}, []string{"result"})
+
+	// metricReconcileTickTotal reconcile worker tick 结果计数。
+	metricReconcileTickTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: groupMetricNamespace,
+		Name:      "channel_reconcile_tick_total",
+		Help:      "Channel-sync reconcile worker tick outcomes (octo-server #394).",
+	}, []string{"result"})
+
+	// metricReconcileDetected 每个 tick 检测到的孤儿群数量（channel_synced=0 且超过 grace）。
+	metricReconcileDetected = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: groupMetricNamespace,
+		Name:      "channel_reconcile_detected_total",
+		Help:      "Total orphan groups (channel_synced=0 past grace) detected by the reconcile worker (octo-server #394).",
+	})
+
+	// metricReconcileOutcomeTotal 单个孤儿群处理结果计数。
+	metricReconcileOutcomeTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: groupMetricNamespace,
+		Name:      "channel_reconcile_outcome_total",
+		Help:      "Per-orphan reconcile outcomes (octo-server #394).",
+	}, []string{"outcome"})
+)

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -134,17 +134,24 @@ type Service struct {
 	log.Log
 	settingDB *settingDB
 	userDB    *user.DB
+
+	// imCreateChannel 是「创建/更新 IM 频道」的注入点，生产默认指向
+	// ctx.IMCreateOrUpdateChannel。抽成字段是为了让 CreateGroup 的 IM 失败补偿
+	// 路径与 reconcile worker 的找回逻辑可在单测里注入受控失败/成功，而无需依赖
+	// 真实 WuKongIM 的故障注入（octo-server #394）。
+	imCreateChannel func(*config.ChannelCreateReq) error
 }
 
 // NewService NewService
 func NewService(ctx *config.Context) IService {
 	return &Service{
-		ctx:       ctx,
-		db:        NewDB(ctx),
-		managerDB: newManagerDB(ctx.DB()),
-		Log:       log.NewTLog("groupService"),
-		settingDB: newSettingDB(ctx),
-		userDB:    user.NewDB(ctx),
+		ctx:             ctx,
+		db:              NewDB(ctx),
+		managerDB:       newManagerDB(ctx.DB()),
+		Log:             log.NewTLog("groupService"),
+		settingDB:       newSettingDB(ctx),
+		userDB:          user.NewDB(ctx),
+		imCreateChannel: ctx.IMCreateOrUpdateChannel,
 	}
 }
 
@@ -1136,6 +1143,15 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 		return nil, errors.New("failed to insert group record")
 	}
 
+	// octo-server #394：在事务内把新群标记为「IM 频道尚未确认」(channel_synced=0)。
+	// IM 频道在 commit 之后才创建；若 IM 创建失败 + 补偿删除也失败，或在 commit 与
+	// IM 创建之间崩溃，这一标记让残留的 group 行可被 reconcile worker 检测并找回，
+	// 而不会永久成为「可查询但无 IM 频道」的孤儿。确认 IM 频道后再翻成 1。
+	if err := s.db.markChannelPendingTx(groupNo, tx); err != nil {
+		s.Error("mark channel pending failed", zap.Error(err), zap.String("groupNo", groupNo))
+		return nil, errors.New("failed to mark channel pending")
+	}
+
 	// 插入成员
 	realMemberUIDs := make([]string, 0, len(memberUsers))
 	memberVos := make([]*config.UserBaseVo, 0, len(memberUsers))
@@ -1275,24 +1291,38 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 	}
 
 	// 创建 IM 频道
-	err = s.ctx.IMCreateOrUpdateChannel(&config.ChannelCreateReq{
+	err = s.imCreateChannel(&config.ChannelCreateReq{
 		ChannelID:   groupNo,
 		ChannelType: common.ChannelTypeGroup.Uint8(),
 		Subscribers: realMemberUIDs,
 	})
 	if err != nil {
 		s.Error("create IM channel failed, performing compensating rollback", zap.Error(err), zap.String("groupNo", groupNo))
+		metricChannelCreateTotal.WithLabelValues("im_fail").Inc()
 		// Compensating delete: remove group_member and group records that were
 		// already committed. Use s.ctx.DB() (not tx) because the transaction
 		// has already been committed.
+		//
+		// octo-server #394: this delete is best-effort and narrows the orphan
+		// window. If it fails, the group row remains with channel_synced=0 and
+		// the reconcile worker will detect + recover it — the orphan is no
+		// longer permanent.
 		if _, delErr := s.ctx.DB().DeleteFrom("group_member").Where("group_no=?", groupNo).Exec(); delErr != nil {
 			s.Error("compensating delete group_member failed", zap.Error(delErr), zap.String("groupNo", groupNo))
 		}
 		if _, delErr := s.ctx.DB().DeleteFrom("group").Where("group_no=?", groupNo).Exec(); delErr != nil {
-			s.Error("compensating delete group failed", zap.Error(delErr), zap.String("groupNo", groupNo))
+			s.Error("compensating delete group failed, group left as channel_synced=0 for reconcile", zap.Error(delErr), zap.String("groupNo", groupNo))
 		}
 		return nil, errors.New("failed to create IM channel, group has been rolled back")
 	}
+
+	// octo-server #394：IM 频道确认创建成功，把群翻成已同步(channel_synced=1)，
+	// reconcile worker 不再处理它。这一步失败不阻断建群（频道已就绪，群可用），
+	// 仅记日志——reconcile worker 会在 grace 窗口后重做这次幂等翻转兜底。
+	if _, syncErr := s.db.MarkChannelSynced(groupNo); syncErr != nil {
+		s.Error("mark channel synced failed (reconcile will recover)", zap.Error(syncErr), zap.String("groupNo", groupNo))
+	}
+	metricChannelCreateTotal.WithLabelValues("ok").Inc()
 
 	// 发送群创建通知
 	s.ctx.SendGroupCreate(&config.MsgGroupCreateReq{

--- a/modules/group/sql/20260617000001_group_channel_synced.sql
+++ b/modules/group/sql/20260617000001_group_channel_synced.sql
@@ -1,0 +1,71 @@
+-- +migrate Up
+-- octo-server #394：建群与 IM 频道创建之间存在「孤儿群」窗口——CreateGroup 在
+-- tx.Commit() 之后才创建 IM 频道，若 IM 创建失败且补偿删除也失败（或在 commit 与
+-- IM 创建之间崩溃），group 行会残留而没有对应 IM 频道。channel_synced 标记把这种
+-- 孤儿变得「可检测」：仅在确认 IM 频道创建成功后才置 1，后台 reconcile worker 据此
+-- 找回并幂等重建。
+--
+-- 默认 1（已同步）：存量群以及所有不经过 CreateGroup 待确认流程的插入路径（系统群、
+-- 注册建群、AddGroup 等）天然视为已同步，零回归、不会被 reconcile 误判为孤儿。
+-- 只有 CreateGroup 显式把新行写成 0，确认 IM 频道后再翻成 1。
+--
+-- 幂等/可重入写法（INFORMATION_SCHEMA 守卫 + 存储过程，与 20260604000001、
+-- 20260605000002 同范式）：MySQL DDL 隐式提交，sql-migrate 仅在「一个迁移的所有
+-- 语句都成功」后才记账；多 pod 滚动发布或部分迁移重试时，裸 ADD COLUMN 重跑会因
+-- 列已存在报 Duplicate column name 而 CrashLoopBackOff（见 #239/#253）。守卫后可安全重入。
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_channel_synced;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __group_channel_synced()
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND COLUMN_NAME = 'channel_synced') THEN
+    ALTER TABLE `group`
+      ADD COLUMN `channel_synced` TINYINT NOT NULL DEFAULT 1 COMMENT 'IM channel sync flag: 1=backing IM channel confirmed (default, backward-compat), 0=group row committed but IM channel not yet confirmed (reconcile target, octo-server #394)';
+  END IF;
+  -- 二级索引：reconcile worker 周期性扫描 channel_synced=0 的孤儿行，避免全表扫描。
+  -- 选择性极高（正常情况下几乎没有 0 行），低基数列单列索引足够。
+  IF NOT EXISTS (SELECT 1 FROM information_schema.STATISTICS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND INDEX_NAME = 'idx_group_channel_synced') THEN
+    ALTER TABLE `group`
+      ADD INDEX `idx_group_channel_synced` (`channel_synced`);
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __group_channel_synced();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_channel_synced;
+-- +migrate StatementEnd
+
+-- +migrate Down
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_channel_synced_down;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __group_channel_synced_down()
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.STATISTICS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND INDEX_NAME = 'idx_group_channel_synced') THEN
+    ALTER TABLE `group` DROP INDEX `idx_group_channel_synced`;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND COLUMN_NAME = 'channel_synced') THEN
+    ALTER TABLE `group` DROP COLUMN `channel_synced`;
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __group_channel_synced_down();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_channel_synced_down;
+-- +migrate StatementEnd

--- a/pkg/errcode/bot_api.go
+++ b/pkg/errcode/bot_api.go
@@ -175,6 +175,15 @@ var (
 		HTTPStatus:     http.StatusForbidden,
 		DefaultMessage: "You can only edit messages you sent.",
 	})
+	// ErrBotAPIStreamNotOwned covers the OCT-41 stream-ownership guard: a bot may
+	// only end a stream it opened. /v1/bot/stream/end rejects a stream_no whose
+	// recorded owner is a different bot (a co-member bot must not terminate a
+	// peer's live bubble).
+	ErrBotAPIStreamNotOwned = register(codes.Code{
+		ID:             "err.server.bot_api.stream_not_owned",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You can only end a stream you opened.",
+	})
 	// ErrBotAPIOBONotAuthorized covers a send/typing OBO request lacking an
 	// active grant or per-channel scope (ErrOBONotAuthorized).
 	ErrBotAPIOBONotAuthorized = register(codes.Code{

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -984,6 +984,9 @@ other = "用户尚未与该机器人发起会话。"
 ["err.server.bot_api.message_edit_forbidden"]
 other = "只能编辑自己发送的消息。"
 
+["err.server.bot_api.stream_not_owned"]
+other = "只能结束自己开启的消息流。"
+
 ["err.server.bot_api.obo_not_authorized"]
 other = "无权代表该用户操作。"
 

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -147,6 +147,9 @@ other = "Failed to send the message."
 ["err.server.bot_api.store_failed"]
 other = "Failed to update data."
 
+["err.server.bot_api.stream_not_owned"]
+other = "You can only end a stream you opened."
+
 ["err.server.bot_api.thread_channel_not_accepted"]
 other = "A thread channel id is not accepted here; use the thread GROUP.md endpoint instead."
 


### PR DESCRIPTION
Integration branch for the **OCT-31** epic (public `/v1/bot` streaming). Carries the OCT-42 security fix and the OCT-41 stream-ownership binding as children that fold into this PR. Opened as **draft**: OCT-31 is blocked by OCT-37 (in_review) and final merge clears the 3-review / `enforce_admins` gate.

## Commits
- `9162560` feat(bot_api): add `/v1/bot/stream/{start,end}` for incremental channel streaming (OCT-31)
- `8699351` feat(bot_api): per-UID rate limit the `/v1/bot` send surface (OCT-42)
- `7423c5d` fix(bot_api): bind stream_no↔bot ownership on `/v1/bot/stream/end` (OCT-41)
- `70e7606` test(bot_api): cover App Bot (`app_`) per-UID rate limiting (OCT-42)

## OCT-42 — per-UID rate limiting (up for Security review)
**Gap:** `/v1/bot` and `/v1/botfile` mounted only `authBot()` — no per-bot (UID) cap, only the global per-IP DDoS floor. `stream/start` (a live WuKongIM stream + channel bubble) was the sharpest amplification primitive on this surface.

**Fix:**
- `authBot()` mirrors the resolved `robotID`/UID onto the generic `"uid"` context key in one place (`setBotActorUID`) at **all three** principal-set sites — User Bot (`auth.go` userbot), App Bot registry, App Bot DB-fallback — so `SharedUIDRateLimiter` reads `uid` instead of silently failing open.
- Mounted `SharedUIDRateLimiter` after `authBot()` on both `/v1/bot` and `/v1/botfile` (shared bucket `ratelimit:uid:{robotID}`, default 2 rps / burst 60).

**Tests** (`modules/bot_api/ratelimit_test.go`):
- `TestBotAPI_PerUIDRateLimit_TripsBucket` — User Bot (`bf_`) trips the bucket → 429 + `X-RateLimit-Scope: uid` + `Retry-After`.
- `TestBotAPI_PerUIDRateLimit_AppBot_TripsBucket` — App Bot (`app_`) via registry path (always) and DB-fallback path (runs in CI where the `app_bot` table is present; skips on partial local schemas). Proves `app_` tokens are per-UID capped too — closing the silent-fail-open trap for App Bots.

**Item #2 (dedicated `stream/start` cap):** deferred → tracked in OCT-50 (octo-lib hardcodes the `ratelimit:uid:` bucket prefix, so a second middleware shares the same bucket; a true concurrent-open ceiling needs the OCT-41 `bot:stream:owner:{stream_no}` foundation).

## Verification
- `go test ./modules/bot_api/` → PASS (full package)
- `go vet` + `go build ./modules/bot_api/` clean

Refs: OCT-31, OCT-42, OCT-41, OCT-38 (source review), OCT-50 (follow-up).