### PR TITLE
feat(searchetl): enrich producer with SpaceID/Visibles/MessageSeq (contract v2, fail-closed)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	firebase.google.com/go/v4 v4.13.0
 	github.com/BurntSushi/toml v1.6.0
 	github.com/DATA-DOG/go-sqlmock v1.5.0
-	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260614033907-f62e626a34db
+	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260618083705-a57dc301cbf3
 	github.com/alibabacloud-go/darabonba-openapi v0.2.1
 	github.com/alibabacloud-go/sms-intl-20180501 v1.0.1
 	github.com/alibabacloud-go/tea v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260614033907-f62e626a34db h1:FudjIbMVhMga/sUsysfzKBI7LTdz0Rgw9EWU2tEJzAo=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260614033907-f62e626a34db/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260618083705-a57dc301cbf3 h1:bdZVEI6F7b60DVtHB3G4N8aJ4ikzAywepS5Ebyk5oH0=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260618083705-a57dc301cbf3/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae h1:DcFpTQBYQ9Ct2d6sC7ol0/ynxc2pO1cpGUM+f4t5adg=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae/go.mod h1:rJJ84PyA/Wlmw1hO+xTzV2wsSUon6J5ktg0g8BF2PuU=
 github.com/RichardKnop/machinery/v2 v2.0.11 h1:BTfLGOmOju3W/OtlZmLX26OjYNZsU4PJo04pQReycdc=

--- a/modules/searchetl/etl_db.go
+++ b/modules/searchetl/etl_db.go
@@ -78,7 +78,7 @@ func (d *etlDB) maxID(table string) (int64, error) {
 func (d *etlDB) readBatch(table string, cursor int64, batch int) ([]*srcMessageRow, error) {
 	var rows []*srcMessageRow
 	_, err := d.session.SelectBySql(
-		fmt.Sprintf("SELECT id, message_id, from_uid, channel_id, channel_type, setting, `signal`, "+
+		fmt.Sprintf("SELECT id, message_id, message_seq, from_uid, channel_id, channel_type, setting, `signal`, "+
 			"`timestamp`, UNIX_TIMESTAMP(created_at) AS created_unix, payload "+
 			"FROM `%s` WHERE id>? ORDER BY id ASC LIMIT ?", table),
 		cursor, batch).Load(&rows)
@@ -105,7 +105,7 @@ func (d *etlDB) readStableBatchTx(table string, batch int) (cursor int64, rows [
 		return 0, nil, err
 	}
 	if _, err = tx.SelectBySql(
-		fmt.Sprintf("SELECT id, message_id, from_uid, channel_id, channel_type, setting, `signal`, "+
+		fmt.Sprintf("SELECT id, message_id, message_seq, from_uid, channel_id, channel_type, setting, `signal`, "+
 			"`timestamp`, UNIX_TIMESTAMP(created_at) AS created_unix, payload "+
 			"FROM `%s` WHERE id>? ORDER BY id ASC LIMIT ?", table),
 		cursor, batch).Load(&rows); err != nil {

--- a/modules/searchetl/model.go
+++ b/modules/searchetl/model.go
@@ -9,6 +9,7 @@ package searchetl
 type srcMessageRow struct {
 	ID          int64
 	MessageID   string
+	MessageSeq  uint64 // 频道内消息序号（message.message_seq BIGINT 列，全精度）——reader「清空会话」channel_offset gate 依赖；契约 v2 字段亦为 uint64
 	FromUID     string
 	ChannelID   string
 	ChannelType uint8

--- a/modules/searchetl/payload.go
+++ b/modules/searchetl/payload.go
@@ -28,13 +28,21 @@ const (
 //
 // P1-d 规则：
 //   - Signal 加密（setting 的 Signal 位 或 signal 列为真）→ payload 非明文 JSON，
-//     直接 raw_excluded（不尝试解析，避免把密文当损坏 JSON 误判进 DLQ）。
+//     直接 raw_excluded（不尝试解析，避免把密文当损坏 JSON 误判进 DLQ）。spaceId/visibles
+//     留空走 reader fail-closed（安全：正文本就 raw_excluded，不可检索）。
 //   - 非 Signal → payload 应是明文 JSON。解析失败（本应可解析却失败）→ DLQ。
 //   - 解析成功后按 type 三态（float64/int/json.Number，复用 message.CoerceTextPayloadContent
 //     的兼容口径）取 content：
 //       · type=Text 且 content 为 string → 取该 string 作正文。
 //       · 非 Text 或 content 非 string（媒体/富文本/结构化对象）→ 本期保守 raw_excluded
 //         （阶段 4+ 可细化为序列化可检索文本，契约字段不变）。
+//
+// 🔴 v2 富化 + fail-closed 可见性（防 #1124 重演）：非加密消息额外用 octo-lib 共享的
+// searchmsg.ExtractVisibility 从 payload 抽 SpaceID/Visibles 填进契约 v2 字段。一旦可见性
+// 无法可信解析（payload 非 JSON 对象、visibles 键在却 unparseable 或 valid-but-empty）→
+// **整条落 DLQ**，绝不写空 Visibles —— 否则 reader(visibility.go) 把空 visibles 当 fail-OPEN
+// （普通成员搜出「仅指定成员可见」的群定向系统消息）。MessageSeq 从 message.message_seq 列取。
+// producer 与 backfill 共用同一 ExtractVisibility + 同一组 fail-closed 向量锁口径（验收门 ii）。
 //
 // 返回的 Message 已填 SchemaVersion / Source / 可见性字段；outcome 决定投正文 topic 还是 DLQ。
 func extractMessage(row *srcMessageRow) (searchmsg.Message, extractOutcome) {
@@ -46,11 +54,13 @@ func extractMessage(row *srcMessageRow) (searchmsg.Message, extractOutcome) {
 		FromUID:       row.FromUID,
 		MsgTimestamp:  row.Timestamp,
 		CreatedAt:     row.CreatedUnix,
+		MessageSeq:    row.MessageSeq,
 		Source:        searchmsg.SourceETLMessageTable,
 	}
 
 	if isSignalEncrypted(row) {
-		// Signal 加密 DM：payload 是密文，解不出明文是预期行为，非异常。
+		// Signal 加密 DM：payload 是密文，解不出明文是预期行为，非异常。spaceId/visibles 留空
+		// （reader fail-closed，安全）。
 		msg.RawExcluded = true
 		msg.Content = nil
 		return msg, outcomeRawExcluded
@@ -61,6 +71,15 @@ func extractMessage(row *srcMessageRow) (searchmsg.Message, extractOutcome) {
 		// 非加密消息本应是明文 JSON，解析失败/空 map 属真异常 → DLQ（游标仍推进）。
 		return msg, outcomeDLQ
 	}
+
+	// 🔴 富化可见性（fail-closed）：可见性是 access-control ACL。无法可信解析 → 整条 DLQ，
+	// 绝不写空 Visibles 让 reader fail-OPEN。space_id 非字符串类型不连累合法 visibles（V3b 隔离）。
+	spaceID, visibles, verr := searchmsg.ExtractVisibility(row.Payload)
+	if verr != nil {
+		return msg, outcomeDLQ
+	}
+	msg.SpaceID = spaceID
+	msg.Visibles = visibles
 
 	contentType, isText := payloadType(m)
 	msg.ContentType = contentType

--- a/modules/searchetl/visibility_test.go
+++ b/modules/searchetl/visibility_test.go
@@ -1,0 +1,161 @@
+package searchetl
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
+)
+
+// TestExtractMessage_SharedFailClosedVectors 跑 octo-lib 共享的 fail-closed 可见性向量集
+// （验收门 (i)+(ii)）：producer 与 octo-search-indexer backfill 跑**同一组**向量锁口径。
+//
+// 安全口径（ReviewBot YUJ-4953 钉死）：非加密群消息 visibles
+//   - 解析失败 → outcomeDLQ（绝不进 main topic）
+//   - valid-but-empty（null / [] / 全非字符串）→ 同样 outcomeDLQ
+// visibles 键缺失 = 广播消息 → outcomeOK 进 main，visibles 为空（reader 无 gate 属预期安全）。
+func TestExtractMessage_SharedFailClosedVectors(t *testing.T) {
+	for _, v := range searchmsg.FailClosedVisibilityVectors() {
+		v := v
+		t.Run(v.Name, func(t *testing.T) {
+			// 非加密 type=Text 行：直接用向量 payload（向量本身已含 type/content）。
+			row := &srcMessageRow{MessageID: "m_" + v.Name, ChannelType: common.ChannelTypeGroup.Uint8(), Payload: v.Payload}
+			msg, outcome := extractMessage(row)
+
+			if v.WantErr {
+				// 🔴 非加密、可见性不可信 → 必须落 DLQ，绝不进 main topic。
+				if outcome != outcomeDLQ {
+					t.Fatalf("%s: visibility fail-closed must route to DLQ, got outcome=%v visibles=%v", v.Name, outcome, msg.Visibles)
+				}
+				// DLQ 消息绝不能携带空 visibles 假装广播进主流（即便它最终不投 main，也防误用）。
+				if len(msg.Visibles) != 0 {
+					t.Fatalf("%s: DLQ msg must not carry visibles, got %v", v.Name, msg.Visibles)
+				}
+				return
+			}
+
+			// 放行类：必须不是 DLQ，且 visibles/spaceID 与期望一致。
+			if outcome == outcomeDLQ {
+				t.Fatalf("%s: must not DLQ, got outcome=%v", v.Name, outcome)
+			}
+			if msg.SpaceID != v.WantSpaceID {
+				t.Fatalf("%s: spaceID=%q want %q", v.Name, msg.SpaceID, v.WantSpaceID)
+			}
+			if !reflect.DeepEqual(msg.Visibles, v.WantVisibles) {
+				t.Fatalf("%s: visibles=%v want %v", v.Name, msg.Visibles, v.WantVisibles)
+			}
+		})
+	}
+}
+
+// TestExtractMessage_EmptyVisiblesGroupMsgDLQ 单独钉死验收门 (i) 的核心：
+// 非加密群消息 valid-but-empty visibles → DLQ 不进 main（ReviewBot 特别强调 population 主落点）。
+func TestExtractMessage_EmptyVisiblesGroupMsgDLQ(t *testing.T) {
+	row := &srcMessageRow{
+		MessageID:   "grp-empty-vis",
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		Payload:     []byte(`{"type":99,"content":"you were removed","visibles":[]}`),
+	}
+	_, outcome := extractMessage(row)
+	if outcome != outcomeDLQ {
+		t.Fatalf("group msg with valid-but-empty visibles MUST DLQ (else reader fail-OPEN #1124), got %v", outcome)
+	}
+}
+
+// TestExtractMessage_UnparseableVisiblesGroupMsgDLQ 非加密群消息 visibles 解析失败 → DLQ。
+func TestExtractMessage_UnparseableVisiblesGroupMsgDLQ(t *testing.T) {
+	row := &srcMessageRow{
+		MessageID:   "grp-bad-vis",
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		Payload:     []byte(`{"type":99,"content":"x","visibles":"not-an-array"}`),
+	}
+	_, outcome := extractMessage(row)
+	if outcome != outcomeDLQ {
+		t.Fatalf("group msg with unparseable visibles MUST DLQ, got %v", outcome)
+	}
+}
+
+// TestExtractMessage_ValidVisiblesEnriched 合法定向系统消息 → 进 main 且 visibles 富化进契约。
+func TestExtractMessage_ValidVisiblesEnriched(t *testing.T) {
+	row := &srcMessageRow{
+		MessageID:   "grp-ok-vis",
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		Payload:     []byte(`{"type":99,"content":"removed","visibles":["u_alice","u_bob"]}`),
+	}
+	msg, outcome := extractMessage(row)
+	if outcome == outcomeDLQ {
+		t.Fatalf("valid targeted system msg must not DLQ, got %v", outcome)
+	}
+	if !reflect.DeepEqual(msg.Visibles, []string{"u_alice", "u_bob"}) {
+		t.Fatalf("visibles must be enriched into contract, got %v", msg.Visibles)
+	}
+}
+
+// TestExtractMessage_NormalGroupChatBroadcast 普通群聊正文（无 visibles 键）→ 进 main 广播，
+// visibles 为空属预期（否则全部正常消息被灌进 DLQ）。
+func TestExtractMessage_NormalGroupChatBroadcast(t *testing.T) {
+	row := &srcMessageRow{
+		MessageID:   "grp-chat",
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		Payload:     []byte(`{"type":1,"content":"hello everyone"}`),
+	}
+	msg, outcome := extractMessage(row)
+	if outcome != outcomeOK {
+		t.Fatalf("normal group chat must be outcomeOK (broadcast), got %v", outcome)
+	}
+	if len(msg.Visibles) != 0 {
+		t.Fatalf("broadcast msg must have empty visibles, got %v", msg.Visibles)
+	}
+}
+
+// TestExtractMessage_MessageSeqEnriched messageSeq 从 message.message_seq 列取并填进契约。
+func TestExtractMessage_MessageSeqEnriched(t *testing.T) {
+	row := &srcMessageRow{
+		MessageID:   "seq-row",
+		MessageSeq:  4242,
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		Payload:     []byte(`{"type":1,"content":"x"}`),
+	}
+	msg, outcome := extractMessage(row)
+	if outcome != outcomeOK {
+		t.Fatalf("outcome=%v", outcome)
+	}
+	if msg.MessageSeq != 4242 {
+		t.Fatalf("messageSeq must be carried from row, got %d", msg.MessageSeq)
+	}
+}
+
+// TestExtractMessage_MessageSeqFullWidth message_seq 是 BIGINT/uint64：超过 uint32 上限的
+// 序号必须无损全精度透传，不得截断（高序号频道「清空会话」gate 正确性依赖此）。
+func TestExtractMessage_MessageSeqFullWidth(t *testing.T) {
+	const big = uint64(1) << 40 // 远超 math.MaxUint32
+	row := &srcMessageRow{
+		MessageID:   "seq-big",
+		MessageSeq:  big,
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		Payload:     []byte(`{"type":1,"content":"x"}`),
+	}
+	msg, _ := extractMessage(row)
+	if msg.MessageSeq != big {
+		t.Fatalf("messageSeq must be carried full-width without truncation, got %d want %d", msg.MessageSeq, big)
+	}
+}
+
+// TestExtractMessage_EncryptedSkipsVisibility 加密 DM：payload 是密文不解析，
+// spaceID/visibles 留空走 reader fail-closed，且不因密文非 JSON 而误 DLQ。
+func TestExtractMessage_EncryptedSkipsVisibility(t *testing.T) {
+	row := &srcMessageRow{
+		MessageID:   "enc",
+		Signal:      1,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Payload:     []byte("ENCRYPTED-CIPHERTEXT-NOT-JSON"),
+	}
+	msg, outcome := extractMessage(row)
+	if outcome != outcomeRawExcluded {
+		t.Fatalf("encrypted msg must be raw_excluded, got %v", outcome)
+	}
+	if msg.SpaceID != "" || len(msg.Visibles) != 0 {
+		t.Fatalf("encrypted msg must leave spaceID/visibles empty (fail-closed), got %q %v", msg.SpaceID, msg.Visibles)
+	}
+}


### PR DESCRIPTION
## What

Enrich the `searchetl` Kafka producer to fill the three v2 contract safety/correctness fields the search reader requires, and re-pin `octo-lib` to the v2 contract + shared visibility parser.

- **MessageSeq**: add `message_seq` to the message-table SELECT (both `readBatch` and `readStableBatchTx`) and carry it through `srcMessageRow` (typed `uint64` to match the BIGINT column / `uint64` contract field — no truncation on high-sequence channels) into the contract.
- **SpaceID / Visibles**: parse from the raw payload via `octo-lib`'s shared `searchmsg.ExtractVisibility` — the single source of truth now shared with the indexer's backfill, so the visibility semantic does **not** fork across repos.

## Security: fail-closed visibility (prevents reader fail-OPEN / over-exposure)

The reader treats an empty `visibles` array as **fail-OPEN** (no gate). So for **non-encrypted** messages, if visibility cannot be trusted, the whole row is routed to **DLQ** — never emitted with empty `visibles`:

- payload not exactly one JSON object (corrupt / array / scalar / `null` / trailing data) → DLQ
- `visibles` key present but unparseable OR **valid-but-empty** (`null` / `[]` / all-non-string) → DLQ
- `visibles` key absent → genuine broadcast message → pass through (`visibles=nil`, expected & safe)

DLQ rows still advance the shard cursor (no stall) and are produced to the DLQ topic (never silently dropped). Encrypted DM payloads are ciphertext: not parsed; `spaceId`/`visibles` left empty (reader fail-closed; body already `raw_excluded`).

`space_id` is type-tolerant: only taken when a JSON string, otherwise empty — without dropping a legitimate `visibles` array.

## Same vectors both sides

Producer and indexer backfill run the **identical** `searchmsg.FailClosedVisibilityVectors()` set (15 cases incl. valid-but-empty, trailing-delimiter, type-tolerant), locking one semantic across repos.

## Test

`go build ./...`, `go vet`, `go test ./modules/searchetl/...` all green. New `modules/searchetl/visibility_test.go` covers the shared vectors + targeted fail-closed/broadcast/full-width-seq cases.

## Merge order

⚠️ Depends on the `octo-lib` change (shared `ExtractVisibility`). Merge `Mininglamp-OSS/octo-lib#80` first, then this PR will re-pin to the merged commit.

Part of the Route A real-time search unblock chain.
