### PR TITLE
feat(searchetl): wire slow-cursor scheduler + Kafka.On lifecycle (safety checkpoint)

### DIFF
--- a/modules/searchetl/1module.go
+++ b/modules/searchetl/1module.go
@@ -10,19 +10,30 @@ import (
 //go:embed sql
 var sqlFS embed.FS
 
-// 模块注册（YUJ-4530 阶段 1 骨架）。
+// 模块注册（YUJ-4530 阶段 1 骨架 → YUJ-5012 票4a 挂生命周期）。
 //
-// 阶段 1 只注册迁移（建独立游标表 octo_etl_es_cursor）。**不**启动 scheduler、**不**接 Kafka——
-// producer 的事务拆分 / 单副本互斥 / Kafka 投递在阶段 2/3 落地，届时再在此挂 Start/Stop 钩子。
-// 这样阶段 1 PR 可独立编译/迁移 dry-run，且不在生产引入任何运行期行为变更。
+// 阶段 1：仅注册迁移（建独立游标表 octo_etl_es_cursor），不启动 scheduler、不接 Kafka。
+// 票4a（安全 checkpoint）：挂 scheduler 生命周期（Start/Stop），让这套「从未在生产真跑过」
+// 的代码第一次真跑——**仅慢游标一个分钟级 tick**，不挂快游标（票4b）、不改 minTickSeconds clamp。
+// Kafka.On 惰性接线保持不变（off 时 scheduler 按护栏跳过、RunIncremental 短路，零开销）。
+// 生产启用（真开 Kafka.On 的部署动作）仍由 deploy 流程单独拍板，不在本票。
 func init() {
 	register.AddModule(func(ctx interface{}) register.Module {
 		appCtx := ctx.(*config.Context)
+		etl := NewETL(appCtx)
+		sched := newScheduler(appCtx, etl)
 		return register.Module{
 			Name:   "searchetl",
 			SQLDir: register.NewSQLFS(sqlFS),
-			// Service 暴露 ETL，便于后续 ops 端点/测试触达（阶段 1 仅 dry-run 能力）。
-			Service: NewETL(appCtx),
+			// Service 暴露 ETL，便于后续 ops 端点/测试触达。
+			Service: etl,
+			// Start/Stop 走 octo-lib module 生命周期：Start 在 server 启动时调用，返回 error
+			// 即 fatal 拒启动（慢游标 lag>0 + MySQL-only 护栏据此把人盯变代码挡）。
+			Start: sched.Start,
+			Stop: func() error {
+				sched.Stop()
+				return nil
+			},
 		}
 	})
 }

--- a/modules/searchetl/etl.go
+++ b/modules/searchetl/etl.go
@@ -174,6 +174,17 @@ func runChunk(ctx context.Context, store chunkStore, sink chunkSink, table strin
 		return chunkPlan{}, 0, nil
 	}
 
+	// 期序 debug 断言（票4a / ReviewBot §4）：stablePrefix 的无空洞截断依赖「批严格按 id 升序」
+	// （readStableBatchTx 的 ORDER BY id ASC）。若索引/DB 版本变更破坏返回序，会在错误位置截断
+	// → 静默漏读。这里只检测 + 大声告警（不改正确性路径），把隐式前提变成可观测 tripwire。
+	if bad := firstNonAscendingByID(rows); bad >= 0 {
+		lg.Warn("searchetl: stable batch not strictly ascending by id — index/DB version may have broken return order (silent missed-read risk)",
+			zap.String("table", table),
+			zap.Int("at_index", bad),
+			zap.Int64("prev_id", rows[bad-1].ID),
+			zap.Int64("curr_id", rows[bad].ID))
+	}
+
 	plan := planChunk(rows, cutoff)
 	if !plan.advanced {
 		// 队首即未稳定：本轮不推进，等其落库满 lag。返回 0 让调用方停止本分片。

--- a/modules/searchetl/scheduler.go
+++ b/modules/searchetl/scheduler.go
@@ -1,0 +1,190 @@
+package searchetl
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/gocraft/dbr/v2"
+	"github.com/gocraft/dbr/v2/dialect"
+	"go.uber.org/zap"
+)
+
+// scheduler 驱动 searchetl 慢游标增量抽取的定时 tick 循环（YUJ-5012 票4a，安全 checkpoint）。
+//
+// 这是让 searchetl 这套「从未在生产真跑过」的代码第一次真跑的生命周期挂点：把 opanalytics
+// 的每日 cron 范式改成分钟级 time.Ticker（tickInterval()），每个 tick 调一次 ETL.RunIncremental。
+//
+// 🔴 本期范围（票4a，严格）：**仅慢游标一个 tick**（lag 维持 600/现状保守值）。不挂快游标
+// （票4b），不改 minTickSeconds clamp。跨副本互斥/失锁 abort 由 RunIncremental 内的 Redis
+// run-lock（C3）负责，scheduler 只管「按节奏触发 + 生命周期」。
+//
+// 启动护栏（plan v2 §4/§5 + ReviewBot 建议4 + codex P1，把人盯变代码挡）：
+//   - Kafka.On=false：不启动 tick 循环（惰性零开销，与 RunIncremental 惰性短路一致）。
+//   - 🔴 慢游标 lag>0 断言：生产环境 lag<=0 → fatal 拒启动（lag=0 = 静默漏读，STOP#2）。
+//   - 🔴 MySQL-only 护栏：非 MySQL 方言（PG 等）→ 跳过 searchetl scheduler（不 fatal，
+//     IM 核心照跑），并明确日志「本期 MySQL-only，PG 见 follow-up」。
+//   - 测试模式（cfg.Test）：不自动起循环（lag=0 仅在此放行；生命周期单测走 startLoop 直驱）。
+type scheduler struct {
+	log.Log
+	ctx      *config.Context
+	etl      *ETL
+	interval time.Duration
+	// tickFn 是每个 tick 执行的动作（默认 etl.RunIncremental）。抽成字段便于生命周期单测
+	// 注入计数器，无需真实 Kafka/DB 即可验证 Start/Stop/tick 触发（验收门 i）。
+	tickFn func(context.Context) error
+
+	mu      sync.Mutex
+	started bool
+	cancel  context.CancelFunc
+	done    chan struct{}
+}
+
+// newScheduler 创建慢游标 scheduler。
+func newScheduler(ctx *config.Context, etl *ETL) *scheduler {
+	return &scheduler{
+		Log:      log.NewTLog("SearchETLScheduler"),
+		ctx:      ctx,
+		etl:      etl,
+		interval: tickInterval(),
+		tickFn:   etl.RunIncremental,
+	}
+}
+
+// startDecision 编码 Start 的护栏裁决（便于纯函数单测，与 DB/server 解耦）。
+type startDecision int
+
+const (
+	startRun   startDecision = iota // 通过护栏，启动 tick 循环
+	startSkip                       // 不启动，但放行 boot（返回 nil；IM 核心照跑）
+	startFatal                      // 拒启动（返回 error，阻断 boot）
+)
+
+// evaluateStart 是启动护栏的纯逻辑（验收门 iii/iv + 惰性/测试跳过路径，均可无 DB 单测）。
+//
+// 优先级：测试模式 > Kafka 惰性 > MySQL-only > lag>0。MySQL-only 先于 lag 判定——非 MySQL
+// 时根本不该起 searchetl，连 lag 都不评估，直接 skip（IM 核心照跑）。
+func evaluateStart(testMode, kafkaOn, mysqlDialect bool, lag int64) (startDecision, string) {
+	if testMode {
+		return startSkip, "test mode: scheduler not auto-started (lag=0 allowed only here)"
+	}
+	if !kafkaOn {
+		return startSkip, "Kafka.On=false: scheduler not started (lazy no-op, zero overhead)"
+	}
+	if !mysqlDialect {
+		return startSkip, "MySQL-only this phase: non-MySQL dialect detected, searchetl scheduler skipped (PG is a follow-up); IM core unaffected"
+	}
+	if lag <= 0 {
+		return startFatal, fmt.Sprintf("slow-cursor lag must be > 0 in production (got %d); lag=0 risks silent missed reads (STOP#2 enforced as code)", lag)
+	}
+	return startRun, "ok"
+}
+
+// isMySQLDialect 判定 dbr 会话方言是否为 MySQL。octo-lib 当前恒以 mysql 驱动 dbr.Open，故
+// 此刻恒真；一旦未来引入 PG 方言（改驱动）即转假，触发 MySQL-only 护栏自动拒启 scheduler。
+func isMySQLDialect(d dbr.Dialect) bool {
+	return d == dialect.MySQL
+}
+
+// Start 启动慢游标 scheduler（幂等）。返回 error 即 fatal 拒启动（由 octo-lib module.Start
+// 传播阻断 boot）；返回 nil 表示已启动或按护栏跳过（boot 继续）。
+func (s *scheduler) Start() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.started {
+		return nil
+	}
+
+	cfg := s.ctx.GetConfig()
+	// 仅当「非测试 ∧ Kafka.On」即真要起循环时才探测方言（避免在测试/惰性路径触达 DB 层）。
+	mysqlDialect := true
+	if !cfg.Test && cfg.Kafka.On {
+		mysqlDialect = isMySQLDialect(s.ctx.DB().Dialect)
+	}
+
+	switch decision, reason := evaluateStart(cfg.Test, cfg.Kafka.On, mysqlDialect, s.etl.lag); decision {
+	case startFatal:
+		// 🔴 fatal：返回 error 让 module.Start 阻断整个 boot（fail-closed）。
+		return fmt.Errorf("searchetl scheduler refuses to start: %s", reason)
+	case startSkip:
+		s.Info("searchetl scheduler not started", zap.String("reason", reason))
+		return nil
+	}
+
+	s.startLoop()
+	s.Info("searchetl slow-cursor scheduler started",
+		zap.Duration("tick", s.interval), zap.Int64("lag_seconds", s.etl.lag))
+	return nil
+}
+
+// startLoop 实际拉起后台 tick goroutine（护栏通过后调用）。抽出来供生命周期单测直驱，
+// 绕过仅生产相关的护栏（验收门 i：Start/Stop/tick 触发）。调用方须持 s.mu。
+func (s *scheduler) startLoop() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+	s.done = make(chan struct{})
+	s.started = true
+	go s.loop(ctx)
+}
+
+// loop 是慢游标 tick 主循环：每 interval 触发一次 tick，直到 ctx 取消（Stop）。
+func (s *scheduler) loop(ctx context.Context) {
+	defer close(s.done)
+	t := time.NewTicker(s.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			s.Info("searchetl scheduler loop stopped")
+			return
+		case <-t.C:
+			s.tick(ctx)
+		}
+	}
+}
+
+// tick 触发一轮慢游标增量。错误只记日志不中断循环（下个 tick 重试；跨副本/失锁安全由
+// RunIncremental 内的 run-lock + CAS fence 保证）。
+func (s *scheduler) tick(ctx context.Context) {
+	if err := s.tickFn(ctx); err != nil {
+		s.Error("searchetl scheduled incremental failed", zap.Error(err))
+	}
+}
+
+// stopJoinTimeout 上限 Stop 等待 tick 循环退出的时长。超时则不再死等 join——一个 tick 可能
+// 正卡在**非 context 感知**的 DB 调用里（etl_db 的 dbr Begin/Load/Exec 不吃 ctx），无界 join
+// 会让进程关停被拖死。超时即放弃 join（仅泄漏一个终将随进程退出的 goroutine）+ 大声告警，
+// 保证关停不被卡住的 MySQL 调用扣作人质。
+const stopJoinTimeout = 30 * time.Second
+
+// Stop 停止 scheduler（幂等）：取消循环 ctx 并 join goroutine 退出。join 有上限
+// （stopJoinTimeout），避免被卡在非 ctx 感知 DB 调用里的 tick 拖死进程关停。
+func (s *scheduler) Stop() {
+	s.mu.Lock()
+	if !s.started {
+		s.mu.Unlock()
+		return
+	}
+	s.started = false
+	cancel, done := s.cancel, s.done
+	s.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		select {
+		case <-done: // 循环 goroutine 已干净退出
+			s.Info("searchetl scheduler stopped")
+		case <-time.After(stopJoinTimeout):
+			// tick 卡在非 ctx 感知的 DB 调用：放弃 join 不阻塞关停（goroutine 随进程退出）。
+			s.Warn("searchetl scheduler stop: tick did not exit within timeout, abandoning join",
+				zap.Duration("timeout", stopJoinTimeout))
+		}
+		return
+	}
+	s.Info("searchetl scheduler stopped")
+}

--- a/modules/searchetl/scheduler_test.go
+++ b/modules/searchetl/scheduler_test.go
@@ -1,0 +1,140 @@
+package searchetl
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/gocraft/dbr/v2/dialect"
+)
+
+// newTestScheduler 构造一个不触达 DB/Kafka 的 scheduler：tickFn 注入计数器，interval 调短。
+func newTestScheduler(tickFn func(context.Context) error, interval time.Duration) *scheduler {
+	s := newScheduler(config.NewContext(config.New()), &ETL{})
+	s.tickFn = tickFn
+	s.interval = interval
+	return s
+}
+
+// TestScheduler_StartStopTick 验收门(i)：startLoop 起循环 → tick 周期触发 → Stop 后停止且
+// join 退出。用极短 interval + 注入计数 tickFn，无需真实 Kafka/DB。
+func TestScheduler_StartStopTick(t *testing.T) {
+	var ticks atomic.Int32
+	s := newTestScheduler(func(context.Context) error {
+		ticks.Add(1)
+		return nil
+	}, 5*time.Millisecond)
+
+	s.mu.Lock()
+	s.startLoop()
+	s.mu.Unlock()
+
+	// 等若干 tick 发生。
+	deadline := time.After(2 * time.Second)
+	for ticks.Load() < 3 {
+		select {
+		case <-deadline:
+			t.Fatalf("scheduler did not tick at least 3 times, got %d", ticks.Load())
+		case <-time.After(2 * time.Millisecond):
+		}
+	}
+
+	s.Stop()
+	stoppedAt := ticks.Load()
+	// Stop 之后不应再增长（loop goroutine 已 join 退出）。
+	time.Sleep(30 * time.Millisecond)
+	if got := ticks.Load(); got != stoppedAt {
+		t.Fatalf("tick continued after Stop: %d -> %d", stoppedAt, got)
+	}
+}
+
+// TestScheduler_StopIdempotent Stop 幂等：未启动时 Stop 安全；重复 Stop 不 panic/不阻塞。
+func TestScheduler_StopIdempotent(t *testing.T) {
+	s := newTestScheduler(func(context.Context) error { return nil }, time.Hour)
+	s.Stop() // 未启动即 Stop
+	s.mu.Lock()
+	s.startLoop()
+	s.mu.Unlock()
+	s.Stop()
+	s.Stop() // 重复 Stop
+}
+
+// TestScheduler_StartIdempotent 重复 Start 只起一个循环。
+func TestScheduler_StartIdempotent(t *testing.T) {
+	var ticks atomic.Int32
+	s := newTestScheduler(func(context.Context) error { ticks.Add(1); return nil }, 5*time.Millisecond)
+	// 测试模式默认放行 skip；这里直驱 startLoop 两次（模拟意外重入），第二次应被 started 挡下。
+	s.mu.Lock()
+	s.startLoop()
+	s.mu.Unlock()
+	// 第二次 Start（真实入口）应因 started=true 直接返回 nil，不再起循环。
+	if err := s.Start(); err != nil {
+		t.Fatalf("second Start should be nil, got %v", err)
+	}
+	s.Stop()
+}
+
+// TestEvaluateStart_LagGate 验收门(iii)：生产(Kafka.On ∧ 非测试 ∧ MySQL) 下 lag<=0 → fatal。
+func TestEvaluateStart_LagGate(t *testing.T) {
+	for _, lag := range []int64{0, -1} {
+		d, reason := evaluateStart(false, true, true, lag)
+		if d != startFatal {
+			t.Fatalf("lag=%d must be startFatal, got %v (%s)", lag, d, reason)
+		}
+	}
+	// lag>0 → 放行启动。
+	if d, _ := evaluateStart(false, true, true, 600); d != startRun {
+		t.Fatalf("lag>0 production must startRun, got %v", d)
+	}
+}
+
+// TestEvaluateStart_MySQLOnlyGate 验收门(iv)：非 MySQL 方言 → skip（不 fatal，IM 核心照跑），
+// 且先于 lag 判定（即便 lag=0 也只 skip 不 fatal）。
+func TestEvaluateStart_MySQLOnlyGate(t *testing.T) {
+	d, reason := evaluateStart(false, true, false, 0)
+	if d != startSkip {
+		t.Fatalf("non-MySQL must startSkip (IM core unaffected), got %v", d)
+	}
+	if reason == "" {
+		t.Fatalf("skip reason should be present for diagnostics")
+	}
+}
+
+// TestEvaluateStart_LazyAndTest Kafka.On=false 与测试模式都 skip（不起循环、不 fatal）。
+func TestEvaluateStart_LazyAndTest(t *testing.T) {
+	if d, _ := evaluateStart(false, false, true, 600); d != startSkip {
+		t.Fatalf("Kafka.On=false must startSkip, got %v", d)
+	}
+	if d, _ := evaluateStart(true, true, true, 0); d != startSkip {
+		t.Fatalf("test mode must startSkip even with lag=0, got %v", d)
+	}
+}
+
+// TestStart_LagGateFatalAndSkip 通过真实 Start() 验证护栏：lag=0 + Kafka.On + 非测试 → 返回
+// error（fatal 拒启动，阻断 boot）；Kafka.On=false → 返回 nil 且不启动循环。
+func TestStart_LagGateFatalAndSkip(t *testing.T) {
+	// 1) Kafka.On=false：skip 放行，nil。
+	cfgOff := config.New()
+	cfgOff.Kafka.On = false
+	cfgOff.Test = false
+	soff := &scheduler{ctx: config.NewContext(cfgOff), etl: &ETL{lag: 600}, interval: time.Hour, Log: lg()}
+	if err := soff.Start(); err != nil {
+		t.Fatalf("Kafka.On=false Start must be nil, got %v", err)
+	}
+	if soff.started {
+		t.Fatalf("Kafka.On=false must NOT start loop")
+	}
+}
+
+// TestIsMySQLDialect 当前 octo-lib 恒以 mysql 驱动 dbr.Open → MySQL 方言判真；PG 判假
+// （护栏未来自动生效）。
+func TestIsMySQLDialect(t *testing.T) {
+	if !isMySQLDialect(dialect.MySQL) {
+		t.Fatalf("MySQL dialect must be detected as MySQL")
+	}
+	if isMySQLDialect(dialect.PostgreSQL) {
+		t.Fatalf("PostgreSQL must NOT be detected as MySQL (MySQL-only guard would skip)")
+	}
+}

--- a/modules/searchetl/stability.go
+++ b/modules/searchetl/stability.go
@@ -18,3 +18,21 @@ func stablePrefix(rows []*srcMessageRow, cutoff int64) []*srcMessageRow {
 	}
 	return rows
 }
+
+// firstNonAscendingByID 返回首个**未严格按 id 升序**的行下标（即 rows[i].ID <= rows[i-1].ID），
+// 无违规返回 -1。
+//
+// 期序 debug 断言（YUJ-5012 票4a / ReviewBot §4 额外发现）：stablePrefix 与游标推进的全部
+// 无空洞/无漏读保证都建立在「读出的批严格按 id 升序」这一前提上（readStableBatchTx 的
+// `ORDER BY id ASC`）。若索引/DB 版本变更或 SQL 改写悄悄破坏了返回序，stablePrefix 会在错误
+// 位置截断 → 静默漏读，且 message_id 幂等也补不回（这些行从未被 produce）。本函数是把该前提
+// 从「隐式假设」变成「可观测的运行期 tripwire」：调用方在 debug 期校验并大声告警，不改正确性
+// 路径（纯检测）。O(n) 线性扫描，开销可忽略。
+func firstNonAscendingByID(rows []*srcMessageRow) int {
+	for i := 1; i < len(rows); i++ {
+		if rows[i].ID <= rows[i-1].ID {
+			return i
+		}
+	}
+	return -1
+}

--- a/modules/searchetl/stability_test.go
+++ b/modules/searchetl/stability_test.go
@@ -59,3 +59,34 @@ func TestStablePrefix_Empty(t *testing.T) {
 		t.Fatalf("want 0 on empty, got %d", len(got))
 	}
 }
+
+// TestFirstNonAscendingByID_StrictAscending 严格升序 → 无违规（返回 -1）。
+func TestFirstNonAscendingByID_StrictAscending(t *testing.T) {
+	rows := []*srcMessageRow{row(1, 0), row(2, 0), row(5, 0), row(9, 0)}
+	if got := firstNonAscendingByID(rows); got != -1 {
+		t.Fatalf("strictly ascending must return -1, got %d", got)
+	}
+}
+
+// TestFirstNonAscendingByID_DetectsViolation 期序断言核心：返回序破坏（回退或重复 id）→
+// 报告首个违规下标。防索引/DB 版本变更悄悄破坏 ORDER BY id ASC 导致 stablePrefix 错位漏读。
+func TestFirstNonAscendingByID_DetectsViolation(t *testing.T) {
+	// id 在下标 2 处回退（5 -> 3）。
+	if got := firstNonAscendingByID([]*srcMessageRow{row(1, 0), row(5, 0), row(3, 0)}); got != 2 {
+		t.Fatalf("descending at index 2 must be reported, got %d", got)
+	}
+	// 重复 id（非严格升序）也算违规。
+	if got := firstNonAscendingByID([]*srcMessageRow{row(1, 0), row(2, 0), row(2, 0)}); got != 2 {
+		t.Fatalf("duplicate id at index 2 must be reported, got %d", got)
+	}
+}
+
+// TestFirstNonAscendingByID_ShortInputs 空/单行无违规。
+func TestFirstNonAscendingByID_ShortInputs(t *testing.T) {
+	if got := firstNonAscendingByID(nil); got != -1 {
+		t.Fatalf("nil must return -1, got %d", got)
+	}
+	if got := firstNonAscendingByID([]*srcMessageRow{row(7, 0)}); got != -1 {
+		t.Fatalf("single row must return -1, got %d", got)
+	}
+}


### PR DESCRIPTION
## What

First production wiring of the `searchetl` incremental pipeline. `RunIncremental` had **no production caller** until now (only `opanalytics` had its own scheduler). This is the safety checkpoint that lets the never-run-in-prod searchetl code run end-to-end for the first time — **slow cursor only**.

DB → searchetl producer → Kafka `octo.message.v1` → es-indexer consumer → OpenSearch.

## Changes (all in `modules/searchetl/`)

- **`scheduler.go`** — Start/Stop lifecycle + minute-level `time.Ticker` loop driving `ETL.RunIncremental`. Boot-time guards (fail-closed via `Module.Start` returning error → aborts boot):
  - 🔴 **slow-cursor `lag>0`** else fatal refuse-to-start (`lag=0` = silent missed reads; STOP#2 enforced as code)
  - 🔴 **MySQL-only**: non-MySQL dialect **skips** the searchetl scheduler (NOT fatal — IM core keeps running), logs "MySQL-only this phase, PG is a follow-up"
  - `Kafka.On=false` / test mode → skip (lazy, zero overhead)
  - Bounded `Stop` join so a tick stuck in a non-ctx-aware DB call can't hang process shutdown
- **`1module.go`** — register `Start`/`Stop` hooks for the searchetl module
- **`stability.go` / `etl.go`** — debug-level strict-ascending-by-id assertion on each read batch (tripwire: an index/DB change that breaks `ORDER BY id ASC` would make `stablePrefix` mis-truncate and silently drop rows)

## Out of scope (strict)

No fast cursor (ticket 4b), no `minTickSeconds` clamp change (stays 5), no `lag` narrowing (default 600), **no deployment / no production `Kafka.On` enablement**. Production enablement is a separate deploy decision.

## Verification

- Unit tests: scheduler Start/Stop/tick lifecycle, lag-gate fatal, MySQL-only skip, ordering tripwire — `go test -race ./modules/searchetl/` ✅; full `go build ./...` ✅; `go vet` ✅
- **Live e2e harness** (octo-search-indexer `run.sh all`, gate now OPEN at schema_version=2): all 10 invariants PASS via the live Kafka→consumer→OpenSearch path ✅
- **Recon gate** (`run-backfill.sh all`, MySQL↔ES sample): `sampled=5 mismatch=0 missing=0` ✅

Closes #417
