### PR TITLE
fix(incomingwebhook): address PR #330 review follow-ups (#297)

### DIFF
--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -147,13 +147,16 @@ POST /v1/incoming-webhooks/:webhook_id/:token/github
 
 **子集之外的事件/动作返回 200 + `{"skipped":"event"}`**（GitHub 侧显示投递成功、
 不标红；deliveries 里以 `status=3` 可见），缺 `X-GitHub-Event` 头则按 400
-`reason=event` 拒绝。事件里的超长字段（标题/提交信息/评论）服务端截断，GitHub 流量
-不会触发 413。
+`reason=no_event` 拒绝——配置错误与「正常但不渲染」用不同 reason 区分，deliveries 里
+只看 reason 即可分辨。事件里的超长字段（标题/提交信息/评论）服务端截断；GitHub 可控的
+链接文本（PR/issue/release 标题）里的 `]`/`[` 会被转义，防止破坏渲染出的链接。GitHub
+流量不会触发 413。
 
 **body 上限独立于 native**：GitHub 事件 JSON 由平台生成（真实 push/PR 事件普遍
 >8KiB，发送方无法修短），github 路由的请求体上限默认 **1MiB**
-（`DM_INCOMINGWEBHOOK_GITHUB_MAX_BYTES`）；native/wecom 的 body 由调用方编写，
-仍是 8KiB。该读取发生在 token 鉴权 + per-webhook 限流之后，不构成放大面。
+（`DM_INCOMINGWEBHOOK_GITHUB_MAX_BYTES`，上限钳到 25MiB 硬顶防手误巨值）；native/wecom
+的 body 由调用方编写，仍是 8KiB。该读取发生在 token 鉴权 + per-webhook 限流之后，不构成
+放大面。
 
 ### 企业微信（WeCom 群机器人格式）
 
@@ -168,7 +171,7 @@ POST /v1/incoming-webhooks/:webhook_id/:token/wecom
 | `msgtype` | 处理 |
 |-----------|------|
 | `text` / `markdown` / `markdown_v2` | → 文本消息（客户端按 markdown 渲染）；`mentioned_list`/`mentioned_mobile_list` 降级丢弃 |
-| `news` | 降级 markdown：每篇文章「标题链接 + 描述」一段；`picurl` 丢弃 |
+| `news` | 降级 markdown：每篇文章「标题链接 + 描述」一段；`picurl` 丢弃。建议单条 `news` 文章数控制在 **15–20 篇以内**，避免拼接后超过 4000 rune 的语义上限被 413 拒绝 |
 | `template_card` | 降级 markdown：主标题 + 描述 + 副标题 + 跳转链接；按钮等交互元素丢弃 |
 | `image` / `file` / `voice` 等素材类 | **400 `reason=msg_type`**：base64/media_id 素材无法转存，显式失败优于静默丢弃 |
 
@@ -196,7 +199,7 @@ curl -X POST "$BASE/v1/incoming-webhooks/$WEBHOOK_ID/$TOKEN/wecom" \
 | 已接收、刻意不投递 | 200 | `{"status":0,"message_id":0,"skipped":"ping"\|"event"}`（仅适配器路由） |
 | 鉴权失败 | 401 | 统一响应，不区分原因（反枚举） |
 | 限流 | 429 | 带 `Retry-After` |
-| 请求非法 | 400 | `details.reason` ∈ `body`/`json`/`content`/`blocks`/`msg_type`/`event` |
+| 请求非法 | 400 | `details.reason` ∈ `body`/`json`/`content`/`blocks`/`msg_type`/`no_event`（缺 `X-GitHub-Event` 头） |
 | 体积过大 | 413 | 超 body cap 或富文本 >1MB |
 | 投递失败 | 502 | 下游发送失败 |
 | 功能停用 | 404 | 全局开关 `incomingwebhook.enabled=0` |

--- a/modules/incomingwebhook/adapter.go
+++ b/modules/incomingwebhook/adapter.go
@@ -110,3 +110,16 @@ func oneLine(s string) string {
 	s = strings.ReplaceAll(s, "\r", " ")
 	return strings.TrimSpace(s)
 }
+
+// mdLinkTextEscaper 转义会破坏 markdown 链接结构的字符：放进 `[text](url)` 的文本里
+// 出现 `]` 会提前闭合链接、`[` 会引入嵌套——而 PR / issue 标题、评论、release 名乃至
+// 仓库名都来自公开仓库的外部输入，必须转义后再拼进链接文本，否则攻击者可用一个带 `]`
+// 的标题把后续 URL 暴露成可见文本甚至错位渲染（PR #330 review 跟进）。`\` 先于括号
+// 转义，避免二次转义。
+var mdLinkTextEscaper = strings.NewReplacer(`\`, `\\`, `[`, `\[`, `]`, `\]`)
+
+// mdLinkText 把外部文本钳到 max rune 后转义为安全的 markdown 链接文本。先钳后转义：
+// 钳约束的是可见长度，转义引入的反斜杠不该挤占可见字符预算。
+func mdLinkText(s string, max int) string {
+	return mdLinkTextEscaper.Replace(clipRunes(oneLine(s), max))
+}

--- a/modules/incomingwebhook/adapter_github.go
+++ b/modules/incomingwebhook/adapter_github.go
@@ -37,15 +37,24 @@ const maxRenderedCommits = 5
 const (
 	envGitHubBodyMax      = "DM_INCOMINGWEBHOOK_GITHUB_MAX_BYTES"
 	defaultGitHubMaxBytes = 1 << 20 // 1MiB
+	// GitHub 自身把单次 webhook delivery 的 payload 上限定在 25MB，超过这个值的配置
+	// 必然是手误（多打几个 0）。给 env 钳一个硬顶，避免一个被误填的巨大值把单请求的
+	// body 缓冲放大到危险量级——上限本就是防御性的，不该因配置失误反而失去防御
+	//（PR #330 review 跟进）。
+	maxGitHubMaxBytes = 25 << 20 // 25MiB
 )
 
 func githubMaxBytes() int {
+	n := defaultGitHubMaxBytes
 	if v := os.Getenv(envGitHubBodyMax); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			return n
+		if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 {
+			n = parsed
 		}
 	}
-	return defaultGitHubMaxBytes
+	if n > maxGitHubMaxBytes {
+		return maxGitHubMaxBytes
+	}
+	return n
 }
 
 type ghUser struct {
@@ -127,8 +136,11 @@ func parseGitHubPush(header http.Header, body []byte) (*pushPayloadReq, string, 
 	event := strings.TrimSpace(header.Get("X-GitHub-Event"))
 	if event == "" {
 		// 不带事件头的请求不可能来自 GitHub——按非法请求拒绝而非静默跳过，
-		// 让误把 native 流量打到 /github 后缀的调用方立刻发现配置错误。
-		return nil, "", "event"
+		// 让误把 native 流量打到 /github 后缀的调用方立刻发现配置错误。用独立的
+		// no_event 与「事件在渲染子集之外」的 200 skipped(reason=event) 区分开：
+		// 二者语义不同（前者是配置错误，后者是正常但不渲染），deliveries 里只看
+		// reason 即可分辨，不必再去比对 status/http_status（PR #330 review 跟进）。
+		return nil, "", "no_event"
 	}
 
 	var content string
@@ -227,7 +239,7 @@ func renderGitHubPullRequest(body []byte) (string, error) {
 	}
 	return ghWithRepo(fmt.Sprintf("**%s** %s pull request [#%d %s](%s)",
 		ghLogin(ev.Sender), verb, ev.PullRequest.Number,
-		clipRunes(oneLine(ev.PullRequest.Title), 200), ev.PullRequest.HTMLURL),
+		mdLinkText(ev.PullRequest.Title, 200), ev.PullRequest.HTMLURL),
 		ev.Repository), nil
 }
 
@@ -243,7 +255,7 @@ func renderGitHubIssues(body []byte) (string, error) {
 	}
 	return ghWithRepo(fmt.Sprintf("**%s** %s issue [#%d %s](%s)",
 		ghLogin(ev.Sender), ev.Action, ev.Issue.Number,
-		clipRunes(oneLine(ev.Issue.Title), 200), ev.Issue.HTMLURL),
+		mdLinkText(ev.Issue.Title, 200), ev.Issue.HTMLURL),
 		ev.Repository), nil
 }
 
@@ -257,7 +269,7 @@ func renderGitHubIssueComment(body []byte) (string, error) {
 	}
 	line := ghWithRepo(fmt.Sprintf("**%s** commented on [#%d %s](%s)",
 		ghLogin(ev.Sender), ev.Issue.Number,
-		clipRunes(oneLine(ev.Issue.Title), 200), ev.Comment.HTMLURL),
+		mdLinkText(ev.Issue.Title, 200), ev.Comment.HTMLURL),
 		ev.Repository)
 	if snippet := clipRunes(oneLine(ev.Comment.Body), 300); snippet != "" {
 		line += "\n> " + snippet
@@ -278,7 +290,7 @@ func renderGitHubRelease(body []byte) (string, error) {
 		title = ev.Release.TagName
 	}
 	return ghWithRepo(fmt.Sprintf("**%s** published release [%s](%s)",
-		ghLogin(ev.Sender), clipRunes(oneLine(title), 200), ev.Release.HTMLURL),
+		ghLogin(ev.Sender), mdLinkText(title, 200), ev.Release.HTMLURL),
 		ev.Repository), nil
 }
 

--- a/modules/incomingwebhook/adapter_github_test.go
+++ b/modules/incomingwebhook/adapter_github_test.go
@@ -3,6 +3,7 @@ package incomingwebhook
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -26,7 +27,9 @@ func TestParseGitHubPush_HeaderGate(t *testing.T) {
 		req, skip, invalid := parseGitHubPush(http.Header{}, []byte(`{}`))
 		assert.Nil(t, req)
 		assert.Empty(t, skip)
-		assert.Equal(t, "event", invalid)
+		// 缺事件头是配置错误 → 独立 no_event，与「渲染子集之外」的 200 skipped(event)
+		// 分开，deliveries 里只看 reason 即可分辨二者（PR #330 review 跟进）。
+		assert.Equal(t, "no_event", invalid)
 	})
 	t.Run("ping is skipped", func(t *testing.T) {
 		req, skip, invalid := parseGitHubPush(ghHeader("ping"), []byte(`{"zen":"Design for failure."}`))
@@ -105,9 +108,32 @@ func TestParseGitHubPush_NoCommitRefUpdateSkipped(t *testing.T) {
 }
 
 // GitHub 事件 body 是平台生成的（普遍 >8KiB 且发送方无法修短），其上限必须宽于
-// native 的调用方编写上限——钉住 review 阻断项的修复不被回退。
+// native 的调用方编写上限——钉住 review 阻断项的修复不被回退。两个 cap 的 env 都用
+// t.Setenv 清空钉到各自默认值，结果不再依赖宿主机的环境变量（PR #330 review 跟进）。
 func TestGitHubMaxBytes_ExceedsNativeCap(t *testing.T) {
+	t.Setenv(envBodyMax, "")
+	t.Setenv(envGitHubBodyMax, "")
 	assert.Greater(t, githubMaxBytes(), maxBytes())
+	assert.Equal(t, defaultGitHubMaxBytes, githubMaxBytes())
+}
+
+// env 被手误填成天文数字时，githubMaxBytes 钳到 25MiB 硬顶，不让单请求 body 缓冲被
+// 放大到危险量级；合理的自定义值（如 4MiB）仍原样生效（PR #330 review 跟进）。
+func TestGitHubMaxBytes_ClampsHugeEnv(t *testing.T) {
+	t.Run("fat-fingered huge value is clamped", func(t *testing.T) {
+		t.Setenv(envGitHubBodyMax, "999999999999")
+		assert.Equal(t, maxGitHubMaxBytes, githubMaxBytes())
+	})
+	t.Run("reasonable custom value passes through", func(t *testing.T) {
+		t.Setenv(envGitHubBodyMax, strconv.Itoa(4<<20))
+		assert.Equal(t, 4<<20, githubMaxBytes())
+	})
+	t.Run("invalid / non-positive falls back to default", func(t *testing.T) {
+		t.Setenv(envGitHubBodyMax, "-1")
+		assert.Equal(t, defaultGitHubMaxBytes, githubMaxBytes())
+		t.Setenv(envGitHubBodyMax, "garbage")
+		assert.Equal(t, defaultGitHubMaxBytes, githubMaxBytes())
+	})
 }
 
 func TestParseGitHubPush_CommitListTruncated(t *testing.T) {
@@ -203,6 +229,54 @@ func TestParseGitHubPush_Release(t *testing.T) {
 		assert.Nil(t, req)
 		assert.Equal(t, "event", skip)
 	})
+}
+
+// 公开仓库可控的链接文本（PR/issue/release 标题）里的 `]`/`[` 必须转义，否则一个
+// 形如 `evil]( ` 的标题会提前闭合 `[...]` 把后续 URL 暴露成可见文本甚至错位渲染
+//（PR #330 review 跟进）。
+func TestParseGitHubPush_LinkTextEscaped(t *testing.T) {
+	// 标题里塞入会破坏链接结构的字符；断言渲染结果里这些字符已被反斜杠转义，
+	// 且原始的 URL 边界 `](` 不会被标题内容提前引入。
+	const evil = `pwn](http://evil) [x`
+	cases := []struct {
+		name  string
+		event string
+		body  string
+		url   string
+	}{
+		{
+			"pull_request title", "pull_request",
+			fmt.Sprintf(`{"action":"opened","pull_request":{"number":1,"title":%q,"html_url":"https://safe/pr/1"},"sender":{"login":"a"}}`, evil),
+			"https://safe/pr/1",
+		},
+		{
+			"issue title", "issues",
+			fmt.Sprintf(`{"action":"opened","issue":{"number":2,"title":%q,"html_url":"https://safe/i/2"},"sender":{"login":"a"}}`, evil),
+			"https://safe/i/2",
+		},
+		{
+			"release name", "release",
+			fmt.Sprintf(`{"action":"published","release":{"tag_name":"v1","name":%q,"html_url":"https://safe/rel"},"sender":{"login":"a"}}`, evil),
+			"https://safe/rel",
+		},
+		{
+			"issue_comment issue title", "issue_comment",
+			fmt.Sprintf(`{"action":"created","issue":{"number":3,"title":%q},"comment":{"html_url":"https://safe/c","body":"hi"},"sender":{"login":"a"}}`, evil),
+			"https://safe/c",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, skip, invalid := parseGitHubPush(ghHeader(tc.event), []byte(tc.body))
+			require.NotNil(t, req, "skip=%q invalid=%q", skip, invalid)
+			assert.Contains(t, req.Content, `\]`, "closing bracket in title must be escaped")
+			assert.Contains(t, req.Content, `\[`, "opening bracket in title must be escaped")
+			// 真正的链接边界紧贴受控 URL，标题没能提前注入一个 `](`。
+			assert.Contains(t, req.Content, "]("+tc.url+")")
+			// 标题里紧跟 "pwn" 的 `]` 已被转义为 `\]`，不再是未转义的链接闭合。
+			assert.NotContains(t, req.Content, "pwn](", "title's closing bracket must be escaped, not left raw")
+		})
+	}
 }
 
 // 平台事件里的超长字段被钳制，绝不让 GitHub 流量撞 413（调用方无法修短一个事件）。

--- a/modules/incomingwebhook/api_i18n_test.go
+++ b/modules/incomingwebhook/api_i18n_test.go
@@ -126,7 +126,7 @@ func TestIncomingWebhookRespondHelpers(t *testing.T) {
 // legacy {msg,status} shape, so an e2e body never carries error.details — see the
 // note in richtext_push_test.go. No DB/Redis needed; this only exercises the renderer.
 func TestPushPayloadInvalidSurfacesReason(t *testing.T) {
-	for _, reason := range []string{"blocks", "msg_type", "content", "json", "event"} {
+	for _, reason := range []string{"blocks", "msg_type", "content", "json", "no_event"} {
 		t.Run(reason, func(t *testing.T) {
 			r := iwhHelperHarness(func(c *wkhttp.Context) { pushPayloadInvalid(c, reason) })
 			req := httptest.NewRequest(http.MethodGet, "/probe", nil)

--- a/modules/incomingwebhook/sql/20260618000001_incomingwebhook_no_event_comment.sql
+++ b/modules/incomingwebhook/sql/20260618000001_incomingwebhook_no_event_comment.sql
@@ -1,0 +1,12 @@
+-- +migrate Up
+
+-- #297 Phase 3 review 跟进：缺 X-GitHub-Event 头的 400 改用独立 reason `no_event`，
+-- 与「事件在渲染子集之外」的 200 跳过(reason=event) 区分开（前者是配置错误，后者正常
+-- 但不渲染）。仅刷新 reason 列 COMMENT 让 schema 自文档化（同 20260610000001 的做法）。
+-- 目标库 MySQL 8.0：仅改 COMMENT 的 MODIFY COLUMN 走 INSTANT 算法、瞬时无锁。
+ALTER TABLE `incoming_webhook_audit`
+  MODIFY COLUMN `reason` VARCHAR(32) NOT NULL DEFAULT '' COMMENT '失败/跳过原因码（body/json/content/blocks/msg_type/no_event/too_large/delivery_failed/event/ping）；成功为空。限流429不入审计';
+
+-- +migrate Down
+ALTER TABLE `incoming_webhook_audit`
+  MODIFY COLUMN `reason` VARCHAR(32) NOT NULL DEFAULT '' COMMENT '失败/跳过原因码（body/json/content/blocks/msg_type/too_large/delivery_failed/event/ping）；成功为空。限流429不入审计';

--- a/pkg/errcode/incomingwebhook.go
+++ b/pkg/errcode/incomingwebhook.go
@@ -43,7 +43,10 @@ var (
 	// JSON, empty content, malformed rich-text blocks, an unknown msg_type, or a
 	// platform-adapter request that cannot be translated (missing X-GitHub-Event
 	// header, unsupported WeCom msgtype). The offending stage is surfaced via
-	// Details["reason"] (body / json / content / blocks / msg_type / event).
+	// Details["reason"] (body / json / content / blocks / msg_type / no_event).
+	// Note: no_event is the missing-X-GitHub-Event 400; a GitHub event that is
+	// merely outside the rendered subset is NOT an error — it answers 200 with
+	// skipped=event (see modules/incomingwebhook/adapter_github.go).
 	ErrIncomingWebhookPushPayloadInvalid = register(codes.Code{
 		ID:             "err.server.incomingwebhook.push_payload_invalid",
 		HTTPStatus:     http.StatusBadRequest,
@@ -52,7 +55,11 @@ var (
 	})
 
 	// ErrIncomingWebhookPushPayloadTooLarge (413) — body exceeds the configured
-	// byte cap (DM_INCOMINGWEBHOOK_MAX_BYTES).
+	// per-shape byte cap: native/wecom use DM_INCOMINGWEBHOOK_MAX_BYTES (8KiB
+	// default, caller-authored bodies), GitHub events use the wider
+	// DM_INCOMINGWEBHOOK_GITHUB_MAX_BYTES (1MiB default, clamped to 25MiB; the
+	// platform-generated event JSON the sender cannot shorten). Rich-text payloads
+	// also 413 here when finalized output exceeds the richtext size limit.
 	ErrIncomingWebhookPushPayloadTooLarge = register(codes.Code{
 		ID:             "err.server.incomingwebhook.push_payload_too_large",
 		HTTPStatus:     http.StatusRequestEntityTooLarge,


### PR DESCRIPTION
## Summary

Clears the six non-blocking review follow-ups tracked on #297 Phase 3 (the `modules/incomingwebhook` platform-adapter work shipped in #330). All small, self-contained, and independently mergeable.

## Changes

- **Escape `]`/`[` in GitHub-controlled markdown link text.** New `mdLinkText` helper (`adapter.go`) escapes `\`/`[`/`]` and is applied to PR / issue / release / issue-comment titles in `adapter_github.go`. A crafted title like `pwn](http://evil)` can no longer prematurely close `[text](url)` and expose/garble the real URL. (Commit SHAs and the comment-body snippet are unaffected — SHAs are hex, the snippet renders inside a `>` blockquote, not link text.)
- **Clamp `githubMaxBytes()` to a 25MiB hard ceiling** (GitHub's own webhook payload cap), so a fat-fingered `DM_INCOMINGWEBHOOK_GITHUB_MAX_BYTES` can't blow up the per-request body buffer. Default stays 1MiB.
- **Distinct `no_event` reason** for the missing-`X-GitHub-Event` 400, separating the config-error case from the legitimate 200 `skipped(reason=event)` case (event outside the rendered subset). Deliveries can now tell them apart by `reason` alone.
- **Tests:** pin both byte-cap env vars via `t.Setenv` in `TestGitHubMaxBytes_ExceedsNativeCap` (no longer ambient-env dependent); add `TestGitHubMaxBytes_ClampsHugeEnv` and `TestParseGitHubPush_LinkTextEscaped`.
- **Docs/comments:** refresh the stale 413 comment in `pkg/errcode` to document the per-shape caps (native/wecom 8KiB vs GitHub 1MiB→25MiB); README notes the recommended WeCom `news` article count (~15–20) to stay under the 4000-rune cap; README + errcode reason list updated to `no_event`.
- **Migration:** append `20260618000001_incomingwebhook_no_event_comment.sql` — a comment-only `MODIFY COLUMN` that adds `no_event` to the `reason` column's self-documenting enumeration (same append-a-comment-migration pattern as #330's `20260610000001`).

This leaves #297 with only **Phase 4 (GitLab / Feishu adapters)** outstanding.

## Testing

Infra provisioned locally (Redis native, MySQL 8.0; WuKongIM image unreachable under the env network policy but the package's tests tolerate best-effort IM delivery):

- `go build` + `go vet` clean.
- Full `go test ./modules/incomingwebhook/ ./pkg/errcode/...` — **PASS** (incl. the new unit tests and the GitHub `no_event`/skipped/auth integration paths).
- New migration applied against a fresh `test` DB; verified `no_event` lands in the live column comment.
- `make i18n-extract-check` + `make i18n-lint` — **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018p6e3Lt7ZkeBcKF6itATsz)_