### PR TITLE
chore(octospec): adopt OKF v0.1 frontmatter + index/log

### DIFF
--- a/.claude/commands/octospec-finish.md
+++ b/.claude/commands/octospec-finish.md
@@ -7,7 +7,10 @@ You are running the octospec **Finish** phase for task `$ARGUMENTS`.
 
 1. Run the final verification gate one more time (lint / type-check / tests).
 2. Write `.octospec/journal/shared/$ARGUMENTS.md` — a short, team-visible record:
-   what was done, any structural learning, any gotcha worth remembering.
+   what was done, any structural learning, any gotcha worth remembering. Start
+   the file with OKF frontmatter (`type: Journal`, plus `title`/`description`/
+   `tags`/`timestamp`) so it stays a valid OKF unit and passes `octospec-lint`.
+   Also add a dated entry to `.octospec/log.md` (create it if missing).
 3. If a learning is worth promoting into a reusable rule, drop a candidate in
    `.octospec/learnings/pending/$ARGUMENTS.md`. Promotion into `rules/` is a
    separate, reviewed PR — do not auto-edit `rules/`.

--- a/.claude/commands/octospec-plan.md
+++ b/.claude/commands/octospec-plan.md
@@ -11,7 +11,9 @@ Task: $ARGUMENTS
 2. Read `.octospec/tasks/_brief.template.md` for the required shape.
 3. Inspect the relevant existing code to ground the brief in reality (you may
    draft the brief from the code; the human will confirm it).
-4. Write `.octospec/tasks/<slug>/brief.md` filling every section:
+4. Write `.octospec/tasks/<slug>/brief.md` filling every section (including the
+   OKF frontmatter from the template — set `type: Task`, `title`, `description`,
+   `tags`, `timestamp`):
    - **Goal** — what behavior changes and why.
    - **Load-bearing list** — existing behaviors/contracts this touches. Use the
      same tags as `.octospec/rules/_index.yaml` `inject_when.touches` where they

--- a/.claude/skills/octospec-workflow/SKILL.md
+++ b/.claude/skills/octospec-workflow/SKILL.md
@@ -61,6 +61,8 @@ manually; as a skill you perform the same steps.
 ### 4. Finish
 - Run the final gate once more.
 - Write `.octospec/journal/shared/<slug>.md` (what was done + any learning).
+  Start it with OKF frontmatter (`type: Journal` + title/description/tags/
+  timestamp) and add a dated entry to `.octospec/log.md`.
 - If a learning is worth reusing, stage it in `.octospec/learnings/pending/`
   (promotion into `rules/` is a separate reviewed PR — do not auto-edit rules).
 - Open a PR. Fill the PR template's **Linked Spec** (→ the brief) and the

--- a/.octospec/index.md
+++ b/.octospec/index.md
@@ -1,0 +1,18 @@
+# octo-server rules index
+
+Human-readable catalog of this repo's `.octospec/rules/`. Each rule is an
+[OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+`Rule` unit with octospec extension fields for on-demand injection. Repo rules
+inherit and may override the global constitution
+(`inherits: octo-spec@1.1.0` in `manifest.yaml`).
+
+## Rules
+
+- [Space isolation & access control](rules/space-isolation.md) — queries and access checks must enforce space isolation; no cross-space leakage. *(load-bearing, priority 92)*
+- [Error handling & i18n](rules/error-handling.md) — user-facing errors must use the localized error envelope. *(load-bearing, priority 85)*
+- [Rate limiting](rules/rate-limit.md) — per-UID/per-route rate limiting for service endpoints. *(load-bearing, priority 80)*
+- [Testing conventions](rules/testing.md) — test setup must bound the DB connection pool and clean up. *(priority 70)*
+- [Commit & PR style](rules/commit-style.md) — repo commit/PR conventions inheriting the global commit rule. *(priority 60)*
+
+For machine-precise injection metadata see each rule's frontmatter, or
+`rules/_index.yaml` for the consolidated index.

--- a/.octospec/journal/shared/member-list-name-fallback.md
+++ b/.octospec/journal/shared/member-list-name-fallback.md
@@ -1,3 +1,13 @@
+---
+type: Journal
+title: "Journal: member-list-name-fallback (octo-server #344)"
+description: Record of the member-list empty-name fallback fix and the rules it honored.
+tags: ["space", "member-list", "name-fallback"]
+timestamp: 2026-06-19T00:00:00Z
+# --- octospec extension fields ---
+task: member-list-name-fallback
+source: self
+---
 # Journal: member-list-name-fallback (octo-server #344)
 
 ## What was done

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -1,0 +1,22 @@
+# Change log
+
+Change history for this repo's `.octospec/`, following the
+[OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+change-log convention (§7). Newest first.
+
+## 2026-06-19
+
+- **Update** — Adopted OKF v0.1 compatible frontmatter across all repo rules
+  (`commit-style`, `error-handling`, `rate-limit`, `space-isolation`,
+  `testing`): added `type`, `title`, `description`, `tags`, `timestamp`. The
+  octospec orchestration fields are retained as OKF extension fields.
+- **Update** — Bumped global inheritance pin to `octo-spec@1.1.0`.
+- **Creation** — Added `.octospec/index.md` (human-readable rule catalog) and
+  this `.octospec/log.md` change log.
+
+## 2026-06-18
+
+- **Creation** — octospec pilot scaffolding: rules `error-handling`,
+  `rate-limit`, `space-isolation`, `testing`, `commit-style`; manifest, task
+  templates, slash commands (PR #418).
+- **Creation** — Dogfood task `member-list-name-fallback` (#344 → PR #420).

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -20,3 +20,8 @@ change-log convention (§7). Newest first.
   `rate-limit`, `space-isolation`, `testing`, `commit-style`; manifest, task
   templates, slash commands (PR #418).
 - **Creation** — Dogfood task `member-list-name-fallback` (#344 → PR #420).
+
+## 2026-06-19 (tooling)
+
+- **Update** — Synced OKF-aware slash commands, workflow skill, and task brief
+  template from octo-spec 1.1.0 so generated briefs/journals stay conformant.

--- a/.octospec/manifest.yaml
+++ b/.octospec/manifest.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 
 # Which global ("constitution") version this repo inherits.
 # Pin an exact semver; upgrade = bump this + re-run octospec-sync.
-inherits: octo-spec@1.0.0
+inherits: octo-spec@1.1.0
 
 # Repo tier is always "repo" here (the global layer lives in octo-spec).
 tier: repo

--- a/.octospec/rules/commit-style.md
+++ b/.octospec/rules/commit-style.md
@@ -1,4 +1,10 @@
 ---
+type: Rule
+title: Commit & PR style (repo)
+description: Repo-specific commit and PR conventions inheriting the global commit rule.
+tags: ["commit", "git"]
+timestamp: 2026-06-19T00:00:00Z
+# --- octospec extension fields (OKF-permitted; consumers must preserve) ---
 id: commit-style
 tier: repo
 priority: 60
@@ -6,7 +12,7 @@ load_bearing: false
 inject_when:
   paths: ["**"]
   touches: ["commit", "git"]
-source: octo-spec@1.0.0
+source: octo-spec@1.1.0
 supersedes: []
 ---
 

--- a/.octospec/rules/error-handling.md
+++ b/.octospec/rules/error-handling.md
@@ -1,4 +1,10 @@
 ---
+type: Rule
+title: Error handling & i18n
+description: User-facing errors must use the localized error envelope.
+tags: ["error-response", "i18n", "wire-contract"]
+timestamp: 2026-06-19T00:00:00Z
+# --- octospec extension fields (OKF-permitted; consumers must preserve) ---
 id: error-handling
 tier: repo
 priority: 85

--- a/.octospec/rules/rate-limit.md
+++ b/.octospec/rules/rate-limit.md
@@ -1,4 +1,10 @@
 ---
+type: Rule
+title: Rate limiting
+description: Per-UID/per-route rate limiting requirements for service endpoints.
+tags: ["rate-limit", "throttle"]
+timestamp: 2026-06-19T00:00:00Z
+# --- octospec extension fields (OKF-permitted; consumers must preserve) ---
 id: rate-limit
 tier: repo
 priority: 80

--- a/.octospec/rules/space-isolation.md
+++ b/.octospec/rules/space-isolation.md
@@ -1,4 +1,10 @@
 ---
+type: Rule
+title: Space isolation & access control
+description: Queries and access checks must enforce space isolation; no cross-space leakage.
+tags: ["space", "isolation", "auth", "bot-api", "thread", "acl"]
+timestamp: 2026-06-19T00:00:00Z
+# --- octospec extension fields (OKF-permitted; consumers must preserve) ---
 id: space-isolation
 tier: repo
 priority: 92

--- a/.octospec/rules/testing.md
+++ b/.octospec/rules/testing.md
@@ -1,4 +1,10 @@
 ---
+type: Rule
+title: Testing conventions
+description: Test setup must bound the DB connection pool and clean up; coverage expectations.
+tags: ["test", "testing"]
+timestamp: 2026-06-19T00:00:00Z
+# --- octospec extension fields (OKF-permitted; consumers must preserve) ---
 id: testing
 tier: repo
 priority: 70

--- a/.octospec/tasks/_brief.template.md
+++ b/.octospec/tasks/_brief.template.md
@@ -1,3 +1,15 @@
+---
+type: Task
+title: "Task: <slug>"
+description: <one-line summary of the task>
+tags: []
+timestamp: <ISO8601>
+# --- octospec extension fields ---
+slug: <slug>
+upstream: <issue ref, e.g. repo#123>
+source: self
+---
+
 # Task: <slug>
 
 > One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for

--- a/.octospec/tasks/member-list-name-fallback/brief.md
+++ b/.octospec/tasks/member-list-name-fallback/brief.md
@@ -1,3 +1,14 @@
+---
+type: Task
+title: "Task: member-list-name-fallback"
+description: Add a display-name fallback so the space member list never renders a blank name.
+tags: ["space", "member-list", "name-fallback"]
+timestamp: 2026-06-19T00:00:00Z
+# --- octospec extension fields ---
+slug: member-list-name-fallback
+upstream: "octo-server#344"
+source: self
+---
 # Task: member-list-name-fallback
 
 > One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for


### PR DESCRIPTION
## What

Align this repo's `.octospec/` with the **OKF v0.1** format adopted in octo-spec 1.1.0 (companion PR octo-spec#1). The `.octospec/` directory becomes a valid OKF knowledge bundle while keeping octospec's injection/gating fields as OKF extension fields.

Decision: Yu, 2026-06-18. Sequenced after #418 (pilot) + #420 (dogfood) merged to main.

## Changes (docs/spec only — no Go code)

- `rules/*.md` — add OKF fields `type`/`title`/`description`/`tags`/`timestamp`; retain `id`/`tier`/`priority`/`load_bearing`/`inject_when`/`source`/`supersedes` as OKF extension fields.
- `journal/shared/*.md` + `tasks/*/brief.md` — add OKF `Journal`/`Task` frontmatter.
- `manifest.yaml` — bump `inherits: octo-spec@1.0.0` → `@1.1.0`.
- Add `.octospec/index.md` (OKF index) + `.octospec/log.md` (OKF change log).

## Verification

octo-spec's `octospec-lint.sh` passes against `.octospec/` (7 knowledge files conform: frontmatter present + non-empty `type`). No `.go` files touched, so this should not be subject to the flaky group-test DB pool path.

## Depends on

octo-spec#1 (defines the 1.1.0 format this pins to). Safe to merge independently since fields are additive, but the `inherits` pin assumes octo-spec 1.1.0 is tagged.