### PR TITLE
feat(incomingwebhook): add GitLab + Feishu platform adapters (#297 Phase 4)

### DIFF
--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -48,6 +48,8 @@ POST /v1/incoming-webhooks/:webhook_id/:token            # native（本文主体
 POST /v1/incoming-webhooks/:webhook_id/:token/github     # GitHub 事件适配器
 POST /v1/incoming-webhooks/:webhook_id/:token/wecom      # 企业微信群机器人格式适配器
 POST /v1/incoming-webhooks/:webhook_id/:token/multica    # Multica 出站 webhook 适配器
+POST /v1/incoming-webhooks/:webhook_id/:token/gitlab     # GitLab 事件适配器
+POST /v1/incoming-webhooks/:webhook_id/:token/feishu     # 飞书自定义机器人格式适配器
 Content-Type: application/json
 ```
 
@@ -120,10 +122,11 @@ Content-Type: application/json
 - 服务端另有 1MB 的 RichText 硬上限（octo-lib 契约）兜底，但在默认 8KB body cap 下不会
   先触达——它是上调 body cap 后才会成为约束的二级护栏。
 
-## 平台适配器（#297 Phase 3）
+## 平台适配器（#297 Phase 3 / 4）
 
 适配器把第三方平台的原生格式翻译成上面的 native 消息，鉴权/限流/审计与 native 完全
 一致。适配器消息不支持 `username`/`avatar_url` 覆盖（展示身份固定为 webhook 配置）。
+GitHub / 企业微信为 Phase 3，GitLab / 飞书为 Phase 4。
 
 ### GitHub
 
@@ -224,6 +227,58 @@ curl -X POST "$BASE/v1/incoming-webhooks/$WEBHOOK_ID/$TOKEN/multica" \
        "previous_status":"todo"}'
 ```
 
+### GitLab（#297 Phase 4）
+
+```
+POST /v1/incoming-webhooks/:webhook_id/:token/gitlab
+```
+
+在 GitLab 项目 **Settings → Webhooks** 把 URL 配成上述地址。**鉴权除 URL 内的 token 外，
+还须把该 webhook 的「Secret token」字段也设为同一个 token**——GitLab 以 `X-Gitlab-Token`
+头回传，服务端在 URL token 校验通过后再常量时间比对一次；不一致返回 401（落审计
+`reason=token`，便于在 deliveries 里定位配置错误）。
+
+按 `X-Gitlab-Event` 渲染为 markdown，当前渲染子集：
+
+| 事件 | 渲染的动作 | 说明 |
+|------|-----------|------|
+| `Push Hook` | — | 分支 push、建/删分支；最多列 5 条提交 |
+| `Tag Push Hook` | — | 建/删标签 |
+| `Merge Request Hook` | `open` / `merge` / `close` / `reopen` | `update`/`approved` 等刷屏动作跳过 |
+| `Issue Hook` | `open` / `close` / `reopen` | `update` 跳过 |
+| `Note Hook` | 评论（MR / Issue / Commit） | 评论摘要压成单行、截断 300 rune |
+| `Pipeline Hook` | `success` / `failed` / `canceled` | `running`/`pending` 等非终态跳过 |
+
+子集之外的事件/动作返回 200 + `{"skipped":"event"}`（GitLab 侧投递成功、不标红），缺
+`X-Gitlab-Event` 头按 400 `reason=no_event` 拒绝（与 github 同口径，可在 deliveries 里
+与「不在渲染子集」的 200 skip 分开看）。**body 上限独立于 native**：事件 JSON 由平台
+生成，默认 **1MiB**（`DM_INCOMINGWEBHOOK_GITLAB_MAX_BYTES`）。
+
+### 飞书（自定义机器人格式，#297 Phase 4）
+
+```
+POST /v1/incoming-webhooks/:webhook_id/:token/feishu
+```
+
+接受飞书「自定义机器人」的出站消息格式——已配置向飞书机器人推送的工具只需**换 URL**
+即可迁移。成功响应附带 `code=0`/`msg=success`（多数飞书 SDK 以此判定成功）。
+
+> **鉴权说明**：飞书自定义机器人原生的 `timestamp`/`sign`（基于 secret 的防重放 HMAC）
+> 字段被**忽略**，鉴权一律走 URL 内的 token（与 native/wecom 一致，经 #297 确认）。这意味着
+> URL token 是**唯一凭证**——不像 GitLab 还有 `X-Gitlab-Token` 二道闸，URL 泄漏即失防护，
+> 请按密码强度妥善保管、必要时用 regenerate 轮换。
+
+| `msg_type` | 处理 |
+|-----------|------|
+| `text` | → 文本消息（客户端按 markdown 渲染） |
+| `post`（富文本） | 降级 markdown：标题加粗，每行 `text`/`a`(链接)/`at`(@) 内联拼接；`img` 丢弃（image_key 无法转存） |
+| `interactive`（卡片） | 降级 markdown：标题 + `div`/`markdown` 元素文本逐行拼接；按钮/图片等交互元素丢弃 |
+| `image` / `share_chat` 等素材类 | **400 `reason=msg_type`**：素材无法转存，显式失败优于静默丢弃 |
+
+> 高保真卡片渲染不可行，降级策略经 #297 确认（与 WeCom 同一契约）。`post` 刻意走文本
+> 路径而非 RichText：富文本 `text` 块不渲染 markdown，链接会失去可点击性，文本路径反而
+> 更保真，且飞书图文用 image_key 无法转为 RichText 的 URL 图片块。
+
 ## 通用字段与安全
 
 - `username` / `avatar_url`：两种形态通用，服务端裁剪到字节上限（名 64B / 头像 255B）。
@@ -236,7 +291,7 @@ curl -X POST "$BASE/v1/incoming-webhooks/$WEBHOOK_ID/$TOKEN/multica" \
 |------|------|------|
 | 成功 | 200 | `{"status":0,"message_id":<int>}`（wecom 路由额外带 `errcode`/`errmsg`） |
 | 已接收、刻意不投递 | 200 | `{"status":0,"message_id":0,"skipped":"ping"\|"event"}`（仅适配器路由） |
-| 鉴权失败 | 401 | 统一响应，不区分原因（反枚举） |
+| 鉴权失败 | 401 | 统一响应，不区分原因（反枚举）；含 GitLab `X-Gitlab-Token` 与 URL token 不匹配（落审计 `reason=token`） |
 | 限流 | 429 | 带 `Retry-After` |
 | 请求非法 | 400 | `details.reason` ∈ `body`/`json`/`content`/`blocks`/`msg_type`/`no_event`（缺 `X-GitHub-Event` 头） |
 | 体积过大 | 413 | 超 body cap 或富文本 >1MB |
@@ -248,8 +303,8 @@ curl -X POST "$BASE/v1/incoming-webhooks/$WEBHOOK_ID/$TOKEN/multica" \
 需登录态 + 群管理员权限，路径前缀 `/v1/groups/:group_no/incoming-webhooks`。
 
 创建 / 重置（regenerate）响应除历史的 `url`（native 路径）外，还带 `urls` 对象，
-按推送形态给出全部路径（`native` / `github` / `wecom` / `multica`，不含 host，由前端拼接）。
-token 仅在这两处出现一次，list 不回显 token、也不回推送 URL。
+按推送形态给出全部路径（`native` / `github` / `wecom` / `multica` / `gitlab` / `feishu`，
+不含 host，由前端拼接）。token 仅在这两处出现一次，list 不回显 token、也不回推送 URL。
 
 除创建/列出/更新/删除/重置外，Phase 2 新增两个：
 

--- a/modules/incomingwebhook/adapter.go
+++ b/modules/incomingwebhook/adapter.go
@@ -32,14 +32,19 @@ type pushAdapter struct {
 	//   - invalid 非空：解析失败原因码，映射 400 invalid(reason=...) 并落审计。
 	parse func(header http.Header, body []byte) (req *pushPayloadReq, skip string, invalid string)
 	// successExtra 合并进成功 / skip 响应体的平台兼容字段（如企业微信的 errcode /
-	// errmsg），让按平台 SDK 校验响应的既有工具不改代码即可迁移。key 与 native 的
-	// status / message_id 不重叠，纯追加。
+	// errmsg、飞书的 code / msg），让按平台 SDK 校验响应的既有工具不改代码即可迁移。
+	// key 与 native 的 status / message_id 不重叠，纯追加。
 	successExtra map[string]interface{}
-	// bodyLimit 该形态的请求体字节上限。native / wecom 的 body 由调用方编写，沿用
-	// 8KiB 的 maxBytes()——上限本就是约束调用方的；github 的 body 是平台生成的事件
-	// JSON，真实 push / PR 事件普遍 >8KiB 且发送方无法修短，必须用更宽的专属上限
-	//（githubMaxBytes，见 adapter_github.go；PR #330 review 阻断项）。
+	// bodyLimit 该形态的请求体字节上限。native / wecom / feishu 的 body 由调用方编写，
+	// 沿用 8KiB 的 maxBytes()——上限本就是约束调用方的；github / gitlab 的 body 是平台
+	// 生成的事件 JSON，真实事件普遍 >8KiB 且发送方无法修短，必须用更宽的专属上限
+	//（githubMaxBytes / gitlabMaxBytes）。
 	bodyLimit func() int
+	// verifyToken（可选）在 URL token 已校验通过后，对平台在 header 里回传的 token 再做
+	// 一次常量时间比对（目前仅 GitLab 的 X-Gitlab-Token）。返回 false → 401。能走到这里
+	// 说明 URL token 已验证、调用方已持有 webhook 真正密钥，故不匹配是配置错误而非枚举
+	// 探测（见 handlePush）。nil 表示该形态无需 header token 二次校验。
+	verifyToken func(header http.Header, urlToken string) bool
 }
 
 var (
@@ -56,6 +61,20 @@ var (
 	// 的固定 JSON envelope）。multica envelope 比 GitHub 事件紧凑（不嵌入
 	// repository 对象），8 KiB 足够，沿用 native 的 bodyLimit。
 	multicaAdapter = pushAdapter{name: adapterMultica, parse: parseMulticaPush, bodyLimit: maxBytes}
+	gitlabAdapter  = pushAdapter{
+		name:      adapterGitLab,
+		parse:     parseGitLabPush,
+		bodyLimit: gitlabMaxBytes,
+		// GitLab 额外要求把项目 Secret token 设为 URL token，经 X-Gitlab-Token 回传。
+		verifyToken: verifyGitLabToken,
+	}
+	feishuAdapter = pushAdapter{
+		name:      adapterFeishu,
+		parse:     parseFeishuPush,
+		bodyLimit: maxBytes,
+		// 飞书调用方普遍校验 code==0，附带平台习惯字段降低迁移摩擦。
+		successExtra: map[string]interface{}{"code": 0, "msg": "success"},
+	}
 )
 
 // parseNativePush 是 native 形态的 parse：body 即 pushPayloadReq JSON 本身。
@@ -107,6 +126,14 @@ func firstLine(s string) string {
 		s = s[:i]
 	}
 	return strings.TrimSpace(s)
+}
+
+// isHTTPURL 判断字符串是否是 http(s) URL（大小写不敏感）。用于把外部提供的链接
+// 目标限制到安全 scheme——非 http(s)（如 `javascript:` / `data:`）的「链接」会被降级
+// 为纯文本，杜绝 scheme 注入（#423 review）。
+func isHTTPURL(s string) bool {
+	l := strings.ToLower(strings.TrimSpace(s))
+	return strings.HasPrefix(l, "http://") || strings.HasPrefix(l, "https://")
 }
 
 // oneLine 把多行文本压成单行，避免标题 / 评论里的换行破坏 markdown 链接结构。

--- a/modules/incomingwebhook/adapter_feishu.go
+++ b/modules/incomingwebhook/adapter_feishu.go
@@ -1,0 +1,196 @@
+package incomingwebhook
+
+// 飞书自定义机器人格式适配器（#297 Phase 4）。
+//
+// 路由：POST /v1/incoming-webhooks/:webhook_id/:token/feishu
+// 接受飞书「自定义机器人」的出站消息格式：已配置向飞书机器人推送的工具，只需把
+// webhook URL 换成上述地址即可迁移，消息体零改动。
+//
+// 形态映射（高保真卡片渲染不可行，经 #297 确认接受降级并在 README 写明，与 WeCom
+// 适配器同一契约）：
+//
+//   - text        → native 纯文本路径（客户端按 markdown 渲染）。
+//   - post（富文本）→ 降级 markdown：标题加粗，每行的 text/a/at 标签内联拼接（a 渲染为
+//     markdown 链接，at 渲染为 @用户名）；img 标签丢弃——飞书图文用 image_key 引用平台
+//     素材，无法转存为 URL（与 WeCom 图片同理）。走文本路径而非 RichText：text 块不渲染
+//     markdown，链接会失去可点击性，文本路径反而更保真（#297 确认）。
+//   - interactive（卡片）→ 降级 markdown：标题 + div/markdown 元素文本逐行拼接；按钮 /
+//     图片 / 分隔等交互或素材元素丢弃。
+//   - image / share_chat 等依赖平台素材的类型 → 400 invalid(reason=msg_type)：素材无法
+//     转存，静默丢弃会让调用方误以为已送达，显式失败 + deliveries 可见才诚实。
+//
+// 成功响应在 native 字段基础上附带 code=0 / msg=success（见 adapter.go
+// feishuAdapter.successExtra）：多数飞书 SDK 以 code==0 判定成功。
+//
+// 飞书带 secret 时消息体里会有 timestamp / sign 字段——白名单解析直接忽略，鉴权一律
+// 走 URL token，不另校验飞书 sign。
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// feishuMsg 只声明翻译需要的字段（白名单解析），其余 payload 字段一律忽略。
+type feishuMsg struct {
+	MsgType string         `json:"msg_type"`
+	Content *feishuContent `json:"content"`
+	Card    *feishuCard    `json:"card"`
+}
+
+type feishuContent struct {
+	Text string                      `json:"text"`
+	Post map[string]feishuPostLocale `json:"post"`
+}
+
+type feishuPostLocale struct {
+	Title   string            `json:"title"`
+	Content [][]feishuPostTag `json:"content"`
+}
+
+type feishuPostTag struct {
+	Tag      string `json:"tag"`
+	Text     string `json:"text"`
+	Href     string `json:"href"`
+	UserName string `json:"user_name"`
+}
+
+type feishuCard struct {
+	Header *struct {
+		Title struct {
+			Content string `json:"content"`
+		} `json:"title"`
+	} `json:"header"`
+	Elements []feishuCardElement `json:"elements"`
+}
+
+// feishuCardElement：div 元素文本在 text.content；markdown 元素文本直接在 content。
+type feishuCardElement struct {
+	Tag  string `json:"tag"`
+	Text *struct {
+		Content string `json:"content"`
+	} `json:"text"`
+	Content string `json:"content"`
+}
+
+// parseFeishuPush 把飞书自定义机器人消息翻译成 native 推送请求（pushAdapter.parse）。
+// 与 GitHub/GitLab 不同，内容长度不钳制：消息体由调用方编写（非平台生成的事件），
+// 超过语义上限按既有 413 拒绝，调用方有能力也应当修短。
+func parseFeishuPush(_ http.Header, body []byte) (*pushPayloadReq, string, string) {
+	var msg feishuMsg
+	if err := json.Unmarshal(body, &msg); err != nil {
+		return nil, "", "json"
+	}
+	var content string
+	switch msg.MsgType {
+	case "text":
+		if msg.Content != nil {
+			content = msg.Content.Text
+		}
+	case "post":
+		if msg.Content != nil {
+			content = renderFeishuPost(msg.Content.Post)
+		}
+	case "interactive":
+		content = renderFeishuCard(msg.Card)
+	default:
+		// 空 msg_type 与 image / share_chat 等素材类：显式拒绝（理由见文件头注释）。
+		return nil, "", "msg_type"
+	}
+	if strings.TrimSpace(content) == "" {
+		return nil, "", "content"
+	}
+	return &pushPayloadReq{Content: content}, "", ""
+}
+
+// renderFeishuPost 把富文本降级为 markdown：标题加粗，每行内联拼接 text/a/at 标签，
+// 行间换行。优先 zh_cn 语言块，回退 en_us，再回退任意一个。
+func renderFeishuPost(post map[string]feishuPostLocale) string {
+	if len(post) == 0 {
+		return ""
+	}
+	loc := pickFeishuLocale(post)
+	var lines []string
+	if title := oneLine(loc.Title); title != "" {
+		lines = append(lines, "**"+title+"**")
+	}
+	for _, row := range loc.Content {
+		var sb strings.Builder
+		for _, tag := range row {
+			switch tag.Tag {
+			case "text":
+				sb.WriteString(tag.Text)
+			case "a":
+				text := oneLine(tag.Text)
+				// href 必须是 http(s)：飞书 a-tag 的 href 来自入站 payload，裸传会让
+				// `javascript:` / `data:` 等危险 scheme 渲染成投递给群内其它成员的可点击
+				// 链接（scheme 注入，#423 review，Jerry-Xin/mochashanyao）。非 http(s) 降级
+				// 为纯文本。链接文本里的 `]`/`[` 仍转义，避免破坏 markdown 链接结构。
+				if href := strings.TrimSpace(tag.Href); isHTTPURL(href) {
+					fmt.Fprintf(&sb, "[%s](%s)", mdLinkTextEscaper.Replace(text), href)
+				} else {
+					sb.WriteString(text)
+				}
+			case "at":
+				// user_name 是自由文本，进 `@X` 纯文本上下文须经 mdInertText 转义，
+				// 防止 `]`/`[`/`*` 等注入（同 glActor 的处理，#423 review）。
+				if tag.UserName != "" {
+					sb.WriteString("@" + mdInertText(tag.UserName, 64))
+				}
+			// img 等依赖 image_key 的标签：无法转存为 URL，丢弃（见文件头注释）。
+			default:
+			}
+		}
+		if line := strings.TrimRight(sb.String(), " "); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// pickFeishuLocale 选语言块：zh_cn 优先，en_us 次之，最后兜底任意一个（map 遍历序
+// 不稳定，仅作为「至少别丢消息」的最末兜底）。
+func pickFeishuLocale(post map[string]feishuPostLocale) feishuPostLocale {
+	if v, ok := post["zh_cn"]; ok {
+		return v
+	}
+	if v, ok := post["en_us"]; ok {
+		return v
+	}
+	for _, v := range post {
+		return v
+	}
+	return feishuPostLocale{}
+}
+
+// renderFeishuCard 把交互卡片降级为 markdown：标题加粗 + div/markdown 元素文本逐行
+// 拼接。按钮 / 图片 / 分隔线等交互或素材元素无法复现，丢弃。
+func renderFeishuCard(card *feishuCard) string {
+	if card == nil {
+		return ""
+	}
+	var lines []string
+	if card.Header != nil {
+		if title := oneLine(card.Header.Title.Content); title != "" {
+			lines = append(lines, "**"+title+"**")
+		}
+	}
+	for _, el := range card.Elements {
+		switch el.Tag {
+		case "div":
+			if el.Text != nil {
+				if t := strings.TrimSpace(el.Text.Content); t != "" {
+					lines = append(lines, t)
+				}
+			}
+		case "markdown":
+			if t := strings.TrimSpace(el.Content); t != "" {
+				lines = append(lines, t)
+			}
+		// action / img / hr / note 等：交互或素材元素，丢弃。
+		default:
+		}
+	}
+	return strings.Join(lines, "\n")
+}

--- a/modules/incomingwebhook/adapter_feishu_test.go
+++ b/modules/incomingwebhook/adapter_feishu_test.go
@@ -1,0 +1,139 @@
+package incomingwebhook
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 飞书适配器纯翻译单测（无 DB/Redis/IM 依赖）。feishu* 结构体是白名单解析，多余字段
+// （含 timestamp/sign）都被忽略。
+
+func TestParseFeishuPush_Text(t *testing.T) {
+	body := `{"msg_type":"text","content":{"text":"**Build #123** passed ✅"},"timestamp":"1700000000","sign":"xxx"}`
+	req, skip, invalid := parseFeishuPush(http.Header{}, []byte(body))
+	require.NotNil(t, req, "skip=%q invalid=%q", skip, invalid)
+	assert.Equal(t, "**Build #123** passed ✅", req.Content)
+	assert.Empty(t, req.MsgType, "feishu emits the plain-text path")
+}
+
+func TestParseFeishuPush_Post(t *testing.T) {
+	body := `{
+		"msg_type": "post",
+		"content": {"post": {"zh_cn": {
+			"title": "项目更新",
+			"content": [
+				[{"tag":"text","text":"第一行 "},{"tag":"a","text":"链接","href":"https://example.com"}],
+				[{"tag":"at","user_name":"someone"},{"tag":"text","text":" 请查收"}],
+				[{"tag":"img","image_key":"img_v2_xxx"}]
+			]
+		}}}
+	}`
+	req, skip, invalid := parseFeishuPush(http.Header{}, []byte(body))
+	require.NotNil(t, req, "skip=%q invalid=%q", skip, invalid)
+	assert.Contains(t, req.Content, "**项目更新**")
+	assert.Contains(t, req.Content, "第一行 [链接](https://example.com)")
+	assert.Contains(t, req.Content, "@someone 请查收")
+	assert.NotContains(t, req.Content, "img_v2_xxx", "image_key tags are dropped (cannot be re-hosted)")
+}
+
+// a-tag 的 href 必须是 http(s)：危险 scheme（javascript:/data:）降级为纯文本，不渲染
+// 成投递给群内其它成员的可点击链接（#423 review，Jerry-Xin/mochashanyao）。
+func TestParseFeishuPush_PostRejectsUnsafeHref(t *testing.T) {
+	for _, scheme := range []string{"javascript:alert(1)", "data:text/html,evil", "  JavaScript:alert(1)"} {
+		body := fmt.Sprintf(`{"msg_type":"post","content":{"post":{"zh_cn":{"content":[[{"tag":"a","text":"click","href":%q}]]}}}}`, scheme)
+		req, _, _ := parseFeishuPush(http.Header{}, []byte(body))
+		require.NotNil(t, req, "scheme=%q", scheme)
+		assert.Equal(t, "click", req.Content, "unsafe-scheme href must degrade to plain text; scheme=%q", scheme)
+		assert.NotContains(t, req.Content, "](", "no markdown link emitted for unsafe scheme; scheme=%q", scheme)
+	}
+}
+
+// post 的 at user_name 是自由文本，进 `@X` 必须经 mdInertText 转义。
+func TestParseFeishuPush_PostAtNameEscaped(t *testing.T) {
+	body := `{"msg_type":"post","content":{"post":{"zh_cn":{"content":[[{"tag":"at","user_name":"**ev** [x](http://a)"}]]}}}}`
+	req, _, _ := parseFeishuPush(http.Header{}, []byte(body))
+	require.NotNil(t, req)
+	assert.Contains(t, req.Content, `@\*\*ev\*\*`, "at name bold markers must be escaped")
+	assert.Contains(t, req.Content, `\[x\]`, "at name brackets must be escaped")
+}
+
+func TestParseFeishuPush_PostLocaleFallback(t *testing.T) {
+	t.Run("en_us when zh_cn absent", func(t *testing.T) {
+		body := `{"msg_type":"post","content":{"post":{"en_us":{"title":"Update","content":[[{"tag":"text","text":"hello"}]]}}}}`
+		req, _, _ := parseFeishuPush(http.Header{}, []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**Update**")
+		assert.Contains(t, req.Content, "hello")
+	})
+	t.Run("a tag without href degrades to plain text", func(t *testing.T) {
+		body := `{"msg_type":"post","content":{"post":{"zh_cn":{"content":[[{"tag":"a","text":"裸链接"}]]}}}}`
+		req, _, _ := parseFeishuPush(http.Header{}, []byte(body))
+		require.NotNil(t, req)
+		assert.Equal(t, "裸链接", req.Content)
+	})
+}
+
+func TestParseFeishuPush_Interactive(t *testing.T) {
+	body := `{
+		"msg_type": "interactive",
+		"card": {
+			"header": {"title": {"content": "告警"}},
+			"elements": [
+				{"tag": "div", "text": {"content": "CPU 超过阈值"}},
+				{"tag": "markdown", "content": "**节点**: node-1"},
+				{"tag": "action", "actions": [{"tag":"button","text":{"content":"忽略"}}]},
+				{"tag": "img", "img_key": "img_xxx"}
+			]
+		}
+	}`
+	req, skip, invalid := parseFeishuPush(http.Header{}, []byte(body))
+	require.NotNil(t, req, "skip=%q invalid=%q", skip, invalid)
+	assert.Contains(t, req.Content, "**告警**")
+	assert.Contains(t, req.Content, "CPU 超过阈值")
+	assert.Contains(t, req.Content, "**节点**: node-1")
+	assert.NotContains(t, req.Content, "忽略", "button/action elements are dropped")
+	assert.NotContains(t, req.Content, "img_xxx", "image elements are dropped")
+}
+
+func TestParseFeishuPush_Rejected(t *testing.T) {
+	t.Run("image type rejected", func(t *testing.T) {
+		body := `{"msg_type":"image","content":{"image_key":"img_v2_xxx"}}`
+		req, skip, invalid := parseFeishuPush(http.Header{}, []byte(body))
+		assert.Nil(t, req)
+		assert.Empty(t, skip)
+		assert.Equal(t, "msg_type", invalid)
+	})
+	t.Run("share_chat type rejected", func(t *testing.T) {
+		body := `{"msg_type":"share_chat","content":{"share_chat_id":"oc_xxx"}}`
+		req, _, invalid := parseFeishuPush(http.Header{}, []byte(body))
+		assert.Nil(t, req)
+		assert.Equal(t, "msg_type", invalid)
+	})
+	t.Run("empty msg_type rejected", func(t *testing.T) {
+		body := `{"content":{"text":"hi"}}`
+		req, _, invalid := parseFeishuPush(http.Header{}, []byte(body))
+		assert.Nil(t, req)
+		assert.Equal(t, "msg_type", invalid)
+	})
+	t.Run("empty rendered content rejected", func(t *testing.T) {
+		body := `{"msg_type":"text","content":{"text":"   "}}`
+		req, _, invalid := parseFeishuPush(http.Header{}, []byte(body))
+		assert.Nil(t, req)
+		assert.Equal(t, "content", invalid)
+	})
+	t.Run("malformed body is invalid json", func(t *testing.T) {
+		req, _, invalid := parseFeishuPush(http.Header{}, []byte(`{not json`))
+		assert.Nil(t, req)
+		assert.Equal(t, "json", invalid)
+	})
+	t.Run("post with only dropped img is empty content", func(t *testing.T) {
+		body := `{"msg_type":"post","content":{"post":{"zh_cn":{"content":[[{"tag":"img","image_key":"k"}]]}}}}`
+		req, _, invalid := parseFeishuPush(http.Header{}, []byte(body))
+		assert.Nil(t, req)
+		assert.Equal(t, "content", invalid)
+	})
+}

--- a/modules/incomingwebhook/adapter_gitlab.go
+++ b/modules/incomingwebhook/adapter_gitlab.go
@@ -1,0 +1,408 @@
+package incomingwebhook
+
+// GitLab 事件适配器（#297 Phase 4）。
+//
+// 路由：POST /v1/incoming-webhooks/:webhook_id/:token/gitlab
+// 在 GitLab 项目 Settings → Webhooks 把 URL 配成上述地址即可，无需中间转换层。
+//
+// 鉴权：除 URL 内的 128-bit token（与所有形态一致、由 handlePush 常量时间校验）外，
+// GitLab 形态【额外】要求把项目 webhook 的「Secret token」设为同一个 token——GitLab
+// 会以 X-Gitlab-Token 头回传，handlePush 经 verifyGitLabToken 常量时间比对。此闸在
+// URL token 已验证之后，能到这里说明调用方已持有 webhook 真正的密钥，故 header 不匹配
+// 是配置错误而非枚举探测（见 handlePush 注释 + #297 鉴权决定）。
+//
+// 渲染策略与 GitHub 适配器一致：按 X-Gitlab-Event 把常用事件翻译成 markdown 文本
+// （走 native 纯文本路径），刻意只渲染「人关心的」动作子集，刷屏动作（MR update /
+// pipeline running 等）返回 200 + skipped 落审计。所有 gl* 结构体只声明渲染需要的
+// 字段（白名单解析），其余 payload 字段一律忽略。
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// 渲染的提交列表上限（与 GitHub 适配器一致：全列会刷屏）。
+const maxRenderedGitLabCommits = 5
+
+// glActorMax 是 actor display name 进 `**X**` 粗体前的 rune 钳长（与 multica 的
+// shortFieldMax 同口径）。
+const glActorMax = 64
+
+// GitLab 事件 body 的字节上限。与 GitHub 同理：事件 JSON 由平台生成、普遍 >8KiB 且
+// 发送方无法修短，套用 native 的 8KiB 会把合法流量 413。默认 1MiB，读取发生在 token
+// 鉴权 + per-webhook 限流之后，不构成放大面。
+const (
+	envGitLabBodyMax      = "DM_INCOMINGWEBHOOK_GITLAB_MAX_BYTES"
+	defaultGitLabMaxBytes = 1 << 20 // 1MiB
+	// 与 github 同理（#297 Phase 3 review 跟进）：钳一个 25MiB 硬顶，避免一个被误填的
+	// 巨大 env 把单请求 body 缓冲放大到危险量级——上限本就是防御性的。
+	maxGitLabMaxBytes = 25 << 20 // 25MiB
+)
+
+func gitlabMaxBytes() int {
+	n := defaultGitLabMaxBytes
+	if v := os.Getenv(envGitLabBodyMax); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 {
+			n = parsed
+		}
+	}
+	if n > maxGitLabMaxBytes {
+		return maxGitLabMaxBytes
+	}
+	return n
+}
+
+// glIsZeroSHA 判断是否为 GitLab 的全零 SHA 占位（push 事件 before/after）：after 全零
+// =删除 ref，before 全零=新建 ref（与 GitHub created/deleted 等价）。SHA1 仓库是 40 个
+// 0、SHA256(object-format) 仓库是 64 个 0——按「非空且全 0」判定以兼容两种格式，否则
+// SHA256 仓库的建/删 ref 通知会丢失（#423 review，yujiawei P2.3）。空串（字段缺省）不算。
+func glIsZeroSHA(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if c != '0' {
+			return false
+		}
+	}
+	return true
+}
+
+// verifyGitLabToken 常量时间比对 X-Gitlab-Token 与 URL token。空头（未在 GitLab 配置
+// Secret token）长度不等，ConstantTimeCompare 返回 0 → false。
+func verifyGitLabToken(header http.Header, urlToken string) bool {
+	got := header.Get("X-Gitlab-Token")
+	return subtle.ConstantTimeCompare([]byte(got), []byte(urlToken)) == 1
+}
+
+type glProject struct {
+	PathWithNamespace string `json:"path_with_namespace"`
+	WebURL            string `json:"web_url"`
+}
+
+type glCommit struct {
+	ID      string `json:"id"`
+	Message string `json:"message"`
+	URL     string `json:"url"`
+}
+
+type glUser struct {
+	Username string `json:"username"`
+	Name     string `json:"name"`
+}
+
+type glPushEvent struct {
+	Ref          string     `json:"ref"`
+	Before       string     `json:"before"`
+	After        string     `json:"after"`
+	UserName     string     `json:"user_name"`
+	UserUsername string     `json:"user_username"`
+	Commits      []glCommit `json:"commits"`
+	TotalCommits int        `json:"total_commits_count"`
+	Project      glProject  `json:"project"`
+}
+
+type glMergeRequestEvent struct {
+	User             glUser `json:"user"`
+	ObjectAttributes struct {
+		IID    int    `json:"iid"`
+		Title  string `json:"title"`
+		URL    string `json:"url"`
+		Action string `json:"action"`
+	} `json:"object_attributes"`
+	Project glProject `json:"project"`
+}
+
+type glIssueEvent struct {
+	User             glUser `json:"user"`
+	ObjectAttributes struct {
+		IID    int    `json:"iid"`
+		Title  string `json:"title"`
+		URL    string `json:"url"`
+		Action string `json:"action"`
+	} `json:"object_attributes"`
+	Project glProject `json:"project"`
+}
+
+type glNoteEvent struct {
+	User             glUser `json:"user"`
+	ObjectAttributes struct {
+		Note         string `json:"note"`
+		NoteableType string `json:"noteable_type"`
+		URL          string `json:"url"`
+		// System=true 是 GitLab 的「系统备注」（改标签/指派人/状态等自动生成的 note），
+		// 与 GitHub 适配器只渲染人写的 issue_comment 一致，这类自动备注跳过免刷屏。
+		System bool `json:"system"`
+	} `json:"object_attributes"`
+	MergeRequest struct {
+		IID   int    `json:"iid"`
+		Title string `json:"title"`
+	} `json:"merge_request"`
+	Issue struct {
+		IID   int    `json:"iid"`
+		Title string `json:"title"`
+	} `json:"issue"`
+	Commit struct {
+		ID string `json:"id"`
+	} `json:"commit"`
+	Project glProject `json:"project"`
+}
+
+type glPipelineEvent struct {
+	ObjectAttributes struct {
+		ID     int    `json:"id"`
+		Ref    string `json:"ref"`
+		Status string `json:"status"`
+	} `json:"object_attributes"`
+	User    glUser    `json:"user"`
+	Project glProject `json:"project"`
+}
+
+// parseGitLabPush 把 GitLab webhook 事件翻译成 native 推送请求（pushAdapter.parse）。
+// X-Gitlab-Token 校验不在此处——它需要 URL token，由 handlePush 经 verifyGitLabToken
+// 在鉴权闸里完成；本函数只负责按 X-Gitlab-Event 渲染。
+func parseGitLabPush(header http.Header, body []byte) (*pushPayloadReq, string, string) {
+	event := strings.TrimSpace(header.Get("X-Gitlab-Event"))
+	if event == "" {
+		// 不带事件头的请求不可能来自 GitLab——按非法请求拒绝而非静默跳过，让误把
+		// native 流量打到 /gitlab 后缀的调用方立刻发现配置错误。与 github 一致用独立的
+		// no_event，与「事件在渲染子集之外」的 200 skipped(reason=event) 区分开。
+		return nil, "", "no_event"
+	}
+
+	var content string
+	var err error
+	switch event {
+	case "Push Hook":
+		content, err = renderGitLabPush(body)
+	case "Tag Push Hook":
+		content, err = renderGitLabTagPush(body)
+	case "Merge Request Hook":
+		content, err = renderGitLabMergeRequest(body)
+	case "Issue Hook":
+		content, err = renderGitLabIssue(body)
+	case "Note Hook":
+		content, err = renderGitLabNote(body)
+	case "Pipeline Hook":
+		content, err = renderGitLabPipeline(body)
+	default:
+		// 渲染子集之外的事件类型（Job Hook / Wiki Page Hook / ...）：通常只是订阅范围
+		// 大于我们渲染的子集，调用方无需修复 → 200 + skipped。
+		return nil, "event", ""
+	}
+	if err != nil {
+		return nil, "", "json"
+	}
+	if content == "" {
+		// 事件类型支持、但动作不在渲染子集内（MR update / pipeline running / ...）：skip。
+		return nil, "event", ""
+	}
+	return &pushPayloadReq{Content: clipRunes(content, maxContentRunes())}, "", ""
+}
+
+func renderGitLabPush(body []byte) (string, error) {
+	var ev glPushEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return "", err
+	}
+	who := glActor(ev.UserUsername, ev.UserName)
+	ref := glShortRef(ev.Ref)
+	switch {
+	case glIsZeroSHA(ev.After):
+		return glWithRepo(fmt.Sprintf("**%s** deleted branch `%s`", who, ref), ev.Project), nil
+	case glIsZeroSHA(ev.Before) && len(ev.Commits) == 0:
+		return glWithRepo(fmt.Sprintf("**%s** created branch `%s`", who, ref), ev.Project), nil
+	case len(ev.Commits) == 0:
+		// 退化 ref 更新（无提交、非建/删）：渲染 "pushed 0 commit(s)" 只是噪音 → skip。
+		return "", nil
+	}
+
+	// n = total_commits_count，但绝不小于实际渲染的 commits 数：total 缺省(0)时回退
+	// len，且钳住 total < len 的畸形 payload，否则尾注会算出负数「…and -N more」
+	//（#423 review，Jerry-Xin 🟡 hardening）。
+	n := max(ev.TotalCommits, len(ev.Commits))
+	var b strings.Builder
+	b.WriteString(glWithRepo(
+		fmt.Sprintf("**%s** pushed %d commit(s) to `%s`", who, n, ref), ev.Project))
+	for i, cm := range ev.Commits {
+		if i == maxRenderedGitLabCommits {
+			// 用 n（total_commits_count）而非 len(ev.Commits)：GitLab 把 commits 数组
+			// 截断到约 20 条，一次 100 提交的 push 里 len=20 但 total=100，用 len 会渲染
+			// 自相矛盾的「pushed 100 commit(s) … and 15 more」，应是「…and 95 more」
+			//（#423 review，yujiawei P1）。
+			fmt.Fprintf(&b, "\n- …and %d more", n-maxRenderedGitLabCommits)
+			break
+		}
+		fmt.Fprintf(&b, "\n- [`%s`](%s) %s", glShortSHA(cm.ID), cm.URL, clipRunes(firstLine(cm.Message), 120))
+	}
+	return b.String(), nil
+}
+
+func renderGitLabTagPush(body []byte) (string, error) {
+	var ev glPushEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return "", err
+	}
+	who := glActor(ev.UserUsername, ev.UserName)
+	tag := glShortRef(ev.Ref)
+	if glIsZeroSHA(ev.After) {
+		return glWithRepo(fmt.Sprintf("**%s** deleted tag `%s`", who, tag), ev.Project), nil
+	}
+	return glWithRepo(fmt.Sprintf("**%s** pushed tag `%s`", who, tag), ev.Project), nil
+}
+
+func renderGitLabMergeRequest(body []byte) (string, error) {
+	var ev glMergeRequestEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return "", err
+	}
+	verb := glActionVerb(ev.ObjectAttributes.Action)
+	if verb == "" {
+		// update / approved / unapproved / ... 刷屏动作不渲染 → skip。
+		return "", nil
+	}
+	return glWithRepo(fmt.Sprintf("**%s** %s merge request [!%d %s](%s)",
+		glActor(ev.User.Username, ev.User.Name), verb, ev.ObjectAttributes.IID,
+		mdLinkText(ev.ObjectAttributes.Title, 200), ev.ObjectAttributes.URL),
+		ev.Project), nil
+}
+
+func renderGitLabIssue(body []byte) (string, error) {
+	var ev glIssueEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return "", err
+	}
+	verb := glActionVerb(ev.ObjectAttributes.Action)
+	if verb == "" {
+		return "", nil
+	}
+	return glWithRepo(fmt.Sprintf("**%s** %s issue [#%d %s](%s)",
+		glActor(ev.User.Username, ev.User.Name), verb, ev.ObjectAttributes.IID,
+		mdLinkText(ev.ObjectAttributes.Title, 200), ev.ObjectAttributes.URL),
+		ev.Project), nil
+}
+
+func renderGitLabNote(body []byte) (string, error) {
+	var ev glNoteEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return "", err
+	}
+	if ev.ObjectAttributes.System {
+		// 系统备注（改标签/指派/状态等自动生成）：与 GitHub 只渲染人写评论一致，skip。
+		return "", nil
+	}
+	who := glActor(ev.User.Username, ev.User.Name)
+	url := ev.ObjectAttributes.URL
+	var target string
+	switch ev.ObjectAttributes.NoteableType {
+	case "MergeRequest":
+		target = fmt.Sprintf("[!%d %s](%s)", ev.MergeRequest.IID,
+			mdLinkText(ev.MergeRequest.Title, 200), url)
+	case "Issue":
+		target = fmt.Sprintf("[#%d %s](%s)", ev.Issue.IID,
+			mdLinkText(ev.Issue.Title, 200), url)
+	case "Commit":
+		target = fmt.Sprintf("[commit `%s`](%s)", glShortSHA(ev.Commit.ID), url)
+	default:
+		// Snippet 等少见目标：仍渲染一条通用评论，附链接。
+		target = fmt.Sprintf("[a comment](%s)", url)
+	}
+	line := glWithRepo(fmt.Sprintf("**%s** commented on %s", who, target), ev.Project)
+	if snippet := clipRunes(oneLine(ev.ObjectAttributes.Note), 300); snippet != "" {
+		line += "\n> " + snippet
+	}
+	return line, nil
+}
+
+func renderGitLabPipeline(body []byte) (string, error) {
+	var ev glPipelineEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return "", err
+	}
+	// 只渲染终态：running / pending / created / manual / skipped 都会刷屏 → skip。
+	switch ev.ObjectAttributes.Status {
+	case "success", "failed", "canceled":
+	default:
+		return "", nil
+	}
+	// Pipeline 是唯一自拼 URL 的事件（MR/Issue/Note 直接用 object_attributes.url 绝对
+	// 地址）。project.web_url 缺失时（白名单解析不保证字段必到）退化为不带链接的纯文本，
+	// 避免渲染出 [#99](/-/pipelines/99) 这种不可点击的相对路径（#423 review，lml2468）。
+	var line string
+	if ev.Project.WebURL != "" {
+		line = fmt.Sprintf("Pipeline [#%d](%s/-/pipelines/%d) %s on `%s`",
+			ev.ObjectAttributes.ID, ev.Project.WebURL, ev.ObjectAttributes.ID,
+			ev.ObjectAttributes.Status, glShortRef(ev.ObjectAttributes.Ref))
+	} else {
+		line = fmt.Sprintf("Pipeline #%d %s on `%s`",
+			ev.ObjectAttributes.ID, ev.ObjectAttributes.Status, glShortRef(ev.ObjectAttributes.Ref))
+	}
+	return glWithRepo(line, ev.Project), nil
+}
+
+// glActor 优先用 username（GitLab 用户名字符集受限：[a-zA-Z0-9_.-]，进 `**X**` 粗体
+// 无注入面），回退 display name，再兜底 "someone"。display name 是自由文本，进粗体上
+// 下文必须经 mdInertText 转义（`*`/`[`/`]`/`<` 等），否则一个名为
+// `**evil** [x](http://attacker)` 的用户能往群消息里注入粗体+可点击链接——与
+// adapter_multica.go 对 actor/identifier 的处理同口径（#423 review，Jerry-Xin/mochashanyao）。
+func glActor(username, name string) string {
+	if username != "" {
+		return username
+	}
+	if name != "" {
+		return mdInertText(name, glActorMax)
+	}
+	return "someone"
+}
+
+// glActionVerb 把 GitLab 的 MR/Issue object_attributes.action 映射为渲染动词；
+// 返回空表示该动作在渲染子集之外（调用方无需修复，走 skip）。
+func glActionVerb(action string) string {
+	switch action {
+	case "open":
+		return "opened"
+	case "close":
+		return "closed"
+	case "reopen":
+		return "reopened"
+	case "merge":
+		return "merged"
+	default:
+		return ""
+	}
+}
+
+// glWithRepo 给消息行追加 " · [namespace/project](url)" 尾注；项目信息缺失时原样返回。
+// path_with_namespace 进链接文本 / 纯文本尾注都过 mdInertText 转义——GitLab 项目路径
+// 字符集虽受限，但与 #421 对 ghWithRepo FullName 的处理同口径、消除注入面（#423
+// review，lml2468 should-fix）。
+func glWithRepo(line string, p glProject) string {
+	if p.PathWithNamespace == "" {
+		return line
+	}
+	name := mdInertText(p.PathWithNamespace, 200)
+	if p.WebURL == "" {
+		return line + " · " + name
+	}
+	return fmt.Sprintf("%s · [%s](%s)", line, name, p.WebURL)
+}
+
+// glShortRef 把 refs/heads/main → main、refs/tags/v1.0 → v1.0。
+func glShortRef(ref string) string {
+	ref = strings.TrimPrefix(ref, "refs/heads/")
+	ref = strings.TrimPrefix(ref, "refs/tags/")
+	return ref
+}
+
+// glShortSHA 取提交短哈希（8 位，GitLab 惯例）。
+func glShortSHA(sha string) string {
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
+}

--- a/modules/incomingwebhook/adapter_gitlab_test.go
+++ b/modules/incomingwebhook/adapter_gitlab_test.go
@@ -1,0 +1,351 @@
+package incomingwebhook
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// GitLab 适配器纯翻译单测（无 DB/Redis/IM 依赖）。fixture 取自 GitLab webhook 文档的
+// 字段子集——gl* 结构体本就是白名单解析，多余字段与缺省字段都不影响结果。
+
+func glHeader(event string) http.Header {
+	h := http.Header{}
+	if event != "" {
+		h.Set("X-Gitlab-Event", event)
+	}
+	return h
+}
+
+func TestVerifyGitLabToken(t *testing.T) {
+	h := http.Header{}
+	h.Set("X-Gitlab-Token", "secret-token-123")
+	assert.True(t, verifyGitLabToken(h, "secret-token-123"), "matching token passes")
+	assert.False(t, verifyGitLabToken(h, "secret-token-999"), "mismatched token fails")
+	assert.False(t, verifyGitLabToken(http.Header{}, "secret-token-123"), "missing header fails")
+	assert.False(t, verifyGitLabToken(h, ""), "empty url token fails")
+}
+
+func TestParseGitLabPush_HeaderGate(t *testing.T) {
+	t.Run("missing event header is invalid", func(t *testing.T) {
+		req, skip, invalid := parseGitLabPush(http.Header{}, []byte(`{}`))
+		assert.Nil(t, req)
+		assert.Empty(t, skip)
+		// 缺事件头是配置错误 → 独立 no_event（与 github 一致），与渲染子集之外的
+		// 200 skipped(event) 区分。
+		assert.Equal(t, "no_event", invalid)
+	})
+	t.Run("unsupported event is skipped", func(t *testing.T) {
+		req, skip, invalid := parseGitLabPush(glHeader("Wiki Page Hook"), []byte(`{}`))
+		assert.Nil(t, req)
+		assert.Equal(t, "event", skip)
+		assert.Empty(t, invalid)
+	})
+	t.Run("malformed body is invalid json", func(t *testing.T) {
+		req, skip, invalid := parseGitLabPush(glHeader("Push Hook"), []byte(`{not json`))
+		assert.Nil(t, req)
+		assert.Empty(t, skip)
+		assert.Equal(t, "json", invalid)
+	})
+}
+
+func TestParseGitLabPush_PushEvent(t *testing.T) {
+	body := []byte(`{
+		"ref": "refs/heads/main",
+		"before": "1111111111111111111111111111111111111111",
+		"after": "2222222222222222222222222222222222222222",
+		"user_username": "alice",
+		"user_name": "Alice Liddell",
+		"total_commits_count": 2,
+		"commits": [
+			{"id": "aaaabbbbccccdddd1111", "message": "feat: first\n\nbody", "url": "https://gitlab.com/o/r/-/commit/aaaabbbb"},
+			{"id": "1111222233334444aaaa", "message": "fix: second", "url": "https://gitlab.com/o/r/-/commit/11112222"}
+		],
+		"project": {"path_with_namespace": "octo/repo", "web_url": "https://gitlab.com/octo/repo"}
+	}`)
+	req, skip, invalid := parseGitLabPush(glHeader("Push Hook"), body)
+	require.NotNil(t, req, "skip=%q invalid=%q", skip, invalid)
+	assert.Contains(t, req.Content, "**alice** pushed 2 commit(s) to `main`")
+	assert.Contains(t, req.Content, "[octo/repo](https://gitlab.com/octo/repo)")
+	assert.Contains(t, req.Content, "[`aaaabbbb`](https://gitlab.com/o/r/-/commit/aaaabbbb) feat: first")
+	assert.NotContains(t, req.Content, "body", "only the first line of a commit message is rendered")
+	assert.Empty(t, req.MsgType, "adapters emit the plain-text path")
+}
+
+func TestParseGitLabPush_PushVariants(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"branch create", `{"ref":"refs/heads/dev","before":"0000000000000000000000000000000000000000","after":"abc","commits":[],"user_username":"bob"}`,
+			"**bob** created branch `dev`"},
+		{"branch delete", `{"ref":"refs/heads/dev","after":"0000000000000000000000000000000000000000","user_username":"bob"}`,
+			"**bob** deleted branch `dev`"},
+		{"display-name fallback", `{"ref":"refs/heads/main","commits":[{"id":"abcabcabc","message":"m","url":"u"}],"total_commits_count":1,"user_name":"Bob Builder"}`,
+			"**Bob Builder** pushed 1 commit(s)"},
+		{"missing user falls back", `{"ref":"refs/heads/main","commits":[{"id":"abc","message":"m","url":"u"}],"total_commits_count":1}`,
+			"**someone** pushed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, skip, invalid := parseGitLabPush(glHeader("Push Hook"), []byte(tc.body))
+			require.NotNil(t, req, "skip=%q invalid=%q", skip, invalid)
+			assert.Contains(t, req.Content, tc.want)
+		})
+	}
+}
+
+// 退化 ref 更新（无提交、非建/删）不渲染 "pushed 0 commit(s)"，走 skip。
+func TestParseGitLabPush_NoCommitRefUpdateSkipped(t *testing.T) {
+	body := `{"ref":"refs/heads/main","before":"aaa","after":"bbb","commits":[],"user_username":"bob"}`
+	req, skip, invalid := parseGitLabPush(glHeader("Push Hook"), []byte(body))
+	assert.Nil(t, req)
+	assert.Equal(t, "event", skip)
+	assert.Empty(t, invalid)
+}
+
+func TestParseGitLabPush_CommitListTruncated(t *testing.T) {
+	commits := make([]string, 0, 8)
+	for i := 0; i < 8; i++ {
+		commits = append(commits, fmt.Sprintf(`{"id":"sha%016d","message":"c%d","url":"u%d"}`, i, i, i))
+	}
+	body := fmt.Sprintf(`{"ref":"refs/heads/main","total_commits_count":8,"commits":[%s],"user_username":"a"}`, strings.Join(commits, ","))
+	req, _, _ := parseGitLabPush(glHeader("Push Hook"), []byte(body))
+	require.NotNil(t, req)
+	assert.Contains(t, req.Content, "pushed 8 commit(s)")
+	assert.Contains(t, req.Content, "…and 3 more", "only %d commits are listed", maxRenderedGitLabCommits)
+	assert.NotContains(t, req.Content, "c7", "commits beyond the cap are not rendered")
+}
+
+// GitLab 把 commits 数组截断到 ~20，total_commits_count 才是真实总数。溢出尾注必须用
+// total（与 header 一致），不能用截断后的 len(commits)（#423 review，yujiawei P1）。
+func TestParseGitLabPush_CommitOverflowUsesTotalCount(t *testing.T) {
+	commits := make([]string, 0, 20)
+	for i := 0; i < 20; i++ {
+		commits = append(commits, fmt.Sprintf(`{"id":"sha%016d","message":"c%d","url":"u%d"}`, i, i, i))
+	}
+	body := fmt.Sprintf(`{"ref":"refs/heads/main","total_commits_count":100,"commits":[%s],"user_username":"a"}`, strings.Join(commits, ","))
+	req, _, _ := parseGitLabPush(glHeader("Push Hook"), []byte(body))
+	require.NotNil(t, req)
+	assert.Contains(t, req.Content, "pushed 100 commit(s)")
+	assert.Contains(t, req.Content, "…and 95 more", "overflow must agree with total_commits_count (100-5), not the truncated array length")
+	assert.NotContains(t, req.Content, "…and 15 more", "must not use len(commits) for the overflow count")
+}
+
+// 畸形 payload：total_commits_count < len(commits)。n 钳到 len，绝不渲染负数尾注
+// （#423 review，Jerry-Xin 🟡 hardening）。
+func TestParseGitLabPush_CommitCountClampedWhenTotalBelowLen(t *testing.T) {
+	commits := make([]string, 0, 8)
+	for i := 0; i < 8; i++ {
+		commits = append(commits, fmt.Sprintf(`{"id":"sha%016d","message":"c%d","url":"u%d"}`, i, i, i))
+	}
+	body := fmt.Sprintf(`{"ref":"refs/heads/main","total_commits_count":3,"commits":[%s],"user_username":"a"}`, strings.Join(commits, ","))
+	req, _, _ := parseGitLabPush(glHeader("Push Hook"), []byte(body))
+	require.NotNil(t, req)
+	assert.Contains(t, req.Content, "pushed 8 commit(s)", "header clamps to the real commit count")
+	assert.Contains(t, req.Content, "…and 3 more")
+	assert.NotContains(t, req.Content, "and -", "never render a negative overflow count")
+}
+
+// actor 的 display-name 回退是自由文本，进 `**X**` 粗体必须转义，杜绝粗体/链接注入
+// （#423 review，Jerry-Xin/mochashanyao）。
+func TestParseGitLabPush_ActorNameEscaped(t *testing.T) {
+	// username 缺失 → 回退 user_name；该名是注入串。
+	body := `{"ref":"refs/heads/main","total_commits_count":1,"commits":[{"id":"abc","message":"m","url":"u"}],"user_name":"**evil** [x](http://attacker)"}`
+	req, _, _ := parseGitLabPush(glHeader("Push Hook"), []byte(body))
+	require.NotNil(t, req)
+	assert.Contains(t, req.Content, `\*\*evil\*\*`, "actor bold markers must be escaped")
+	assert.Contains(t, req.Content, `\[x\]`, "actor brackets must be escaped so no clickable link is injected")
+}
+
+// SHA256 object-format 仓库的全零占位是 64 个 0（SHA1 是 40）。建/删 ref 必须两种都认
+// （#423 review，yujiawei P2.3）。
+func TestParseGitLabPush_SHA256ZeroSentinel(t *testing.T) {
+	zero64 := strings.Repeat("0", 64)
+	t.Run("sha256 branch delete", func(t *testing.T) {
+		body := fmt.Sprintf(`{"ref":"refs/heads/dev","after":%q,"user_username":"bob"}`, zero64)
+		req, _, _ := parseGitLabPush(glHeader("Push Hook"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**bob** deleted branch `dev`")
+	})
+	t.Run("sha256 branch create", func(t *testing.T) {
+		body := fmt.Sprintf(`{"ref":"refs/heads/dev","before":%q,"after":"abc","commits":[],"user_username":"bob"}`, zero64)
+		req, _, _ := parseGitLabPush(glHeader("Push Hook"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**bob** created branch `dev`")
+	})
+}
+
+// path_with_namespace 是外部输入，进尾注（链接文本/纯文本）须经 mdInertText 转义，
+// 消除注入面（#423 review，lml2468 should-fix；与 #421 ghWithRepo 同口径）。
+func TestParseGitLabPush_ProjectNameEscaped(t *testing.T) {
+	body := `{"ref":"refs/heads/main","total_commits_count":1,"commits":[{"id":"abc","message":"m","url":"u"}],"user_username":"a","project":{"path_with_namespace":"o/[x]","web_url":"https://safe/p"}}`
+	req, _, _ := parseGitLabPush(glHeader("Push Hook"), []byte(body))
+	require.NotNil(t, req)
+	assert.Contains(t, req.Content, `\[x\]`, "project name brackets must be escaped")
+	assert.Contains(t, req.Content, "](https://safe/p)", "real link boundary preserved")
+}
+
+func TestParseGitLabPush_TagPush(t *testing.T) {
+	t.Run("push tag", func(t *testing.T) {
+		body := `{"ref":"refs/tags/v1.2.0","after":"abc","user_username":"bob","project":{"path_with_namespace":"o/r"}}`
+		req, _, _ := parseGitLabPush(glHeader("Tag Push Hook"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**bob** pushed tag `v1.2.0`")
+	})
+	t.Run("delete tag", func(t *testing.T) {
+		body := `{"ref":"refs/tags/v1.2.0","after":"0000000000000000000000000000000000000000","user_username":"bob"}`
+		req, _, _ := parseGitLabPush(glHeader("Tag Push Hook"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**bob** deleted tag `v1.2.0`")
+	})
+}
+
+func TestParseGitLabPush_MergeRequest(t *testing.T) {
+	tpl := `{
+		"user": {"username": "carol"},
+		"object_attributes": {"iid": 12, "title": "Add feature", "url": "https://gitlab.com/o/r/-/merge_requests/12", "action": "%s"},
+		"project": {"path_with_namespace": "o/r", "web_url": "https://gitlab.com/o/r"}
+	}`
+	t.Run("open", func(t *testing.T) {
+		req, _, _ := parseGitLabPush(glHeader("Merge Request Hook"), []byte(fmt.Sprintf(tpl, "open")))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**carol** opened merge request [!12 Add feature](https://gitlab.com/o/r/-/merge_requests/12)")
+	})
+	t.Run("merge", func(t *testing.T) {
+		req, _, _ := parseGitLabPush(glHeader("Merge Request Hook"), []byte(fmt.Sprintf(tpl, "merge")))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "merged merge request")
+	})
+	t.Run("update is skipped", func(t *testing.T) {
+		req, skip, invalid := parseGitLabPush(glHeader("Merge Request Hook"), []byte(fmt.Sprintf(tpl, "update")))
+		assert.Nil(t, req)
+		assert.Equal(t, "event", skip)
+		assert.Empty(t, invalid)
+	})
+}
+
+func TestParseGitLabPush_Issue(t *testing.T) {
+	t.Run("open", func(t *testing.T) {
+		body := `{"user":{"username":"dan"},"object_attributes":{"iid":3,"title":"Bug","url":"https://gitlab.com/o/r/-/issues/3","action":"open"}}`
+		req, _, _ := parseGitLabPush(glHeader("Issue Hook"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**dan** opened issue [#3 Bug](https://gitlab.com/o/r/-/issues/3)")
+	})
+	t.Run("update is skipped", func(t *testing.T) {
+		body := `{"user":{"username":"dan"},"object_attributes":{"iid":3,"title":"Bug","action":"update"}}`
+		req, skip, _ := parseGitLabPush(glHeader("Issue Hook"), []byte(body))
+		assert.Nil(t, req)
+		assert.Equal(t, "event", skip)
+	})
+}
+
+func TestParseGitLabPush_Note(t *testing.T) {
+	t.Run("merge request comment", func(t *testing.T) {
+		body := `{"user":{"username":"eve"},
+			"object_attributes":{"note":"line one\nline two","noteable_type":"MergeRequest","url":"https://gitlab.com/o/r/-/merge_requests/12#note_1"},
+			"merge_request":{"iid":12,"title":"Add feature"}}`
+		req, _, _ := parseGitLabPush(glHeader("Note Hook"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**eve** commented on [!12 Add feature](https://gitlab.com/o/r/-/merge_requests/12#note_1)")
+		assert.Contains(t, req.Content, "> line one line two", "note body is flattened to one line")
+	})
+	t.Run("issue comment", func(t *testing.T) {
+		body := `{"user":{"username":"eve"},
+			"object_attributes":{"note":"hi","noteable_type":"Issue","url":"https://gitlab.com/o/r/-/issues/3#note_2"},
+			"issue":{"iid":3,"title":"Bug"}}`
+		req, _, _ := parseGitLabPush(glHeader("Note Hook"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**eve** commented on [#3 Bug](https://gitlab.com/o/r/-/issues/3#note_2)")
+	})
+	t.Run("system note is skipped", func(t *testing.T) {
+		// GitLab 把改标签/指派等自动生成的「系统备注」也走 Note Hook 投递（system=true），
+		// 渲染它们会刷屏——与 GitHub 只渲染人写评论一致，跳过。
+		body := `{"user":{"username":"eve"},
+			"object_attributes":{"note":"changed the description","noteable_type":"Issue","system":true},
+			"issue":{"iid":3,"title":"Bug"}}`
+		req, skip, invalid := parseGitLabPush(glHeader("Note Hook"), []byte(body))
+		assert.Nil(t, req)
+		assert.Equal(t, "event", skip)
+		assert.Empty(t, invalid)
+	})
+}
+
+func TestParseGitLabPush_Pipeline(t *testing.T) {
+	tpl := `{"object_attributes":{"id":99,"ref":"main","status":"%s"},"project":{"path_with_namespace":"o/r","web_url":"https://gitlab.com/o/r"}}`
+	t.Run("failed is rendered", func(t *testing.T) {
+		req, _, _ := parseGitLabPush(glHeader("Pipeline Hook"), []byte(fmt.Sprintf(tpl, "failed")))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "Pipeline [#99](https://gitlab.com/o/r/-/pipelines/99) failed on `main`")
+	})
+	t.Run("success is rendered", func(t *testing.T) {
+		req, _, _ := parseGitLabPush(glHeader("Pipeline Hook"), []byte(fmt.Sprintf(tpl, "success")))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "Pipeline [#99](https://gitlab.com/o/r/-/pipelines/99) success on `main`")
+	})
+	t.Run("running is skipped", func(t *testing.T) {
+		req, skip, _ := parseGitLabPush(glHeader("Pipeline Hook"), []byte(fmt.Sprintf(tpl, "running")))
+		assert.Nil(t, req)
+		assert.Equal(t, "event", skip)
+	})
+	t.Run("missing web_url degrades to plain text (no broken relative link)", func(t *testing.T) {
+		body := `{"object_attributes":{"id":99,"ref":"main","status":"failed"},"project":{"path_with_namespace":"o/r"}}`
+		req, _, _ := parseGitLabPush(glHeader("Pipeline Hook"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "Pipeline #99 failed on `main`")
+		assert.NotContains(t, req.Content, "](/-/pipelines", "must not emit a relative-path link when web_url is absent")
+		assert.NotContains(t, req.Content, "[#99]", "no markdown link without an absolute base url")
+	})
+}
+
+// 平台事件里的超长字段被钳制，绝不让 GitLab 流量撞 413（调用方无法修短一个事件）。
+func TestParseGitLabPush_ContentClipped(t *testing.T) {
+	long := strings.Repeat("标", maxContentRunes()+500)
+	body := fmt.Sprintf(`{"user":{"username":"g"},"object_attributes":{"iid":1,"title":%q,"url":"u","action":"open"}}`, long)
+	req, _, _ := parseGitLabPush(glHeader("Issue Hook"), []byte(body))
+	require.NotNil(t, req)
+	assert.LessOrEqual(t, len([]rune(req.Content)), maxContentRunes())
+}
+
+// GitLab 事件 body 是平台生成的，其上限必须宽于 native 的调用方编写上限。两个 cap 的
+// env 都清空钉到默认值，结果不依赖宿主机环境变量。
+func TestGitLabMaxBytes_ExceedsNativeCap(t *testing.T) {
+	t.Setenv(envBodyMax, "")
+	t.Setenv(envGitLabBodyMax, "")
+	assert.Greater(t, gitlabMaxBytes(), maxBytes())
+	assert.Equal(t, defaultGitLabMaxBytes, gitlabMaxBytes())
+}
+
+// env 被手误填成天文数字时，gitlabMaxBytes 钳到 25MiB 硬顶（与 github 一致）。
+func TestGitLabMaxBytes_ClampsHugeEnv(t *testing.T) {
+	t.Run("fat-fingered huge value is clamped", func(t *testing.T) {
+		t.Setenv(envGitLabBodyMax, "999999999999")
+		assert.Equal(t, maxGitLabMaxBytes, gitlabMaxBytes())
+	})
+	t.Run("reasonable custom value passes through", func(t *testing.T) {
+		t.Setenv(envGitLabBodyMax, strconv.Itoa(4<<20))
+		assert.Equal(t, 4<<20, gitlabMaxBytes())
+	})
+	t.Run("invalid / non-positive falls back to default", func(t *testing.T) {
+		t.Setenv(envGitLabBodyMax, "-1")
+		assert.Equal(t, defaultGitLabMaxBytes, gitlabMaxBytes())
+	})
+}
+
+// 公开仓库可控的链接文本（MR/Issue 标题）里的 `]`/`[` 必须转义，避免破坏渲染出的
+// 链接（与 github 适配器同一处理）。
+func TestParseGitLabPush_LinkTextEscaped(t *testing.T) {
+	body := `{"user":{"username":"a"},"object_attributes":{"iid":1,"title":"pwn](http://evil) [x","url":"https://safe/mr/1","action":"open"}}`
+	req, skip, invalid := parseGitLabPush(glHeader("Merge Request Hook"), []byte(body))
+	require.NotNil(t, req, "skip=%q invalid=%q", skip, invalid)
+	assert.Contains(t, req.Content, `\]`, "closing bracket in title must be escaped")
+	assert.Contains(t, req.Content, `\[`, "opening bracket in title must be escaped")
+	assert.Contains(t, req.Content, "](https://safe/mr/1)")
+	assert.NotContains(t, req.Content, "pwn](", "title's closing bracket must be escaped, not left raw")
+}

--- a/modules/incomingwebhook/adapter_push_phase4_test.go
+++ b/modules/incomingwebhook/adapter_push_phase4_test.go
@@ -1,0 +1,149 @@
+package incomingwebhook_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Phase 4（GitLab / 飞书适配器）push 端到端用例。与 Phase 3 用例同风格走
+// testutil.NewTestServer（需 MySQL/Redis/WuKongIM，CI 执行）；成功路径只断言「通过
+// 鉴权/校验」（非 4xx），下游 SendMessage 可能 200 或 502。
+
+// create/regenerate 响应的 urls 现含 gitlab/feishu。
+func TestCreate_ReturnsPhase4AdapterURLs(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), map[string]interface{}{
+		"name": "p4-wh",
+	}))
+	require.Equalf(t, http.StatusOK, w.Code, "create body: %s", w.Body.String())
+	urls, ok := parseJSON(t, w)["urls"].(map[string]interface{})
+	require.True(t, ok, "create response must carry urls; body=%s", w.Body.String())
+	native, _ := urls["native"].(string)
+	assert.Equal(t, native+"/gitlab", urls["gitlab"])
+	assert.Equal(t, native+"/feishu", urls["feishu"])
+}
+
+// GitLab push（带正确 X-Gitlab-Token）通过鉴权/翻译（非 4xx）。
+func TestPush_GitLabPushEvent_Delivers(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	body := []byte(`{
+		"ref": "refs/heads/main",
+		"total_commits_count": 1,
+		"commits": [{"id": "aaaabbbbcccc", "message": "feat: hello", "url": "https://gitlab.com/o/r/-/commit/aaaabbbb"}],
+		"project": {"path_with_namespace": "o/r", "web_url": "https://gitlab.com/o/r"},
+		"user_username": "alice"
+	}`)
+	w := pushAdapterRaw(handler, whID, token, "gitlab", body, map[string]string{
+		"X-Gitlab-Event": "Push Hook",
+		"X-Gitlab-Token": token,
+	})
+	assert.NotEqualf(t, http.StatusBadRequest, w.Code, "valid push event must translate; body=%s", w.Body.String())
+	assert.NotEqualf(t, http.StatusUnauthorized, w.Code, "valid token must authorize; body=%s", w.Body.String())
+	if w.Code == http.StatusOK {
+		assert.Contains(t, w.Body.String(), "message_id")
+	}
+}
+
+// GitLab X-Gitlab-Token 与 URL token 不匹配 → 401（即便 URL token 正确）。
+func TestPush_GitLabBadGitlabToken_Unauthorized(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	w := pushAdapterRaw(handler, whID, token, "gitlab",
+		[]byte(`{"ref":"refs/heads/main","total_commits_count":1,"commits":[{"id":"a","message":"m","url":"u"}],"user_username":"a"}`),
+		map[string]string{"X-Gitlab-Event": "Push Hook", "X-Gitlab-Token": "not-the-url-token"})
+	assert.Equalf(t, http.StatusUnauthorized, w.Code, "mismatched X-Gitlab-Token must 401; body=%s", w.Body.String())
+}
+
+// GitLab 缺事件头 → 400 invalid（误配置要立刻可见）。X-Gitlab-Token 正确以越过鉴权闸。
+func TestPush_GitLabMissingEventHeader_Invalid(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	w := pushAdapterRaw(handler, whID, token, "gitlab", []byte(`{}`),
+		map[string]string{"X-Gitlab-Token": token})
+	assert.Equalf(t, http.StatusBadRequest, w.Code, "missing X-Gitlab-Event must 400; body=%s", w.Body.String())
+}
+
+// GitLab 渲染子集之外的事件：200 + skipped。
+func TestPush_GitLabUnsupportedEvent_Skipped(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	w := pushAdapterRaw(handler, whID, token, "gitlab", []byte(`{}`),
+		map[string]string{"X-Gitlab-Event": "Wiki Page Hook", "X-Gitlab-Token": token})
+	require.Equalf(t, http.StatusOK, w.Code, "unsupported event must 200; body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), `"skipped"`)
+}
+
+// GitLab token 不匹配落审计（reason=token），管理员可在 deliveries 里定位配置错误。
+func TestPush_GitLabBadGitlabToken_Audited(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	w := pushAdapterRaw(handler, whID, token, "gitlab",
+		[]byte(`{"ref":"refs/heads/main"}`),
+		map[string]string{"X-Gitlab-Event": "Push Hook", "X-Gitlab-Token": "wrong"})
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+
+	require.Eventually(t, func() bool {
+		dw := do(handler, authReq("GET", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s/deliveries", groupNo, whID), nil))
+		if dw.Code != http.StatusOK {
+			return false
+		}
+		list, _ := parseJSON(t, dw)["list"].([]interface{})
+		for _, item := range list {
+			row, _ := item.(map[string]interface{})
+			if row["adapter"] == "gitlab" && row["reason"] == "token" && int(row["http_status"].(float64)) == http.StatusUnauthorized {
+				return true
+			}
+		}
+		return false
+	}, 3*time.Second, 50*time.Millisecond, "token mismatch must be recorded as a failed delivery")
+}
+
+// 飞书 text 通过鉴权/翻译；成功响应附带 code=0（平台 SDK 兼容）。
+func TestPush_FeishuText_Delivers(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	w := pushAdapterRaw(handler, whID, token, "feishu",
+		[]byte(`{"msg_type":"text","content":{"text":"hello from feishu"}}`), nil)
+	assert.NotEqualf(t, http.StatusBadRequest, w.Code, "valid feishu text must translate; body=%s", w.Body.String())
+	assert.NotEqualf(t, http.StatusUnauthorized, w.Code, "valid token must authorize; body=%s", w.Body.String())
+	if w.Code == http.StatusOK {
+		assert.Contains(t, w.Body.String(), `"code":0`)
+	}
+}
+
+// 飞书素材类消息（image）→ 400 invalid（显式失败优于静默丢弃）。
+func TestPush_FeishuImage_Rejected(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	w := pushAdapterRaw(handler, whID, token, "feishu",
+		[]byte(`{"msg_type":"image","content":{"image_key":"img_v2_xxx"}}`), nil)
+	assert.Equalf(t, http.StatusBadRequest, w.Code, "feishu image must 400; body=%s", w.Body.String())
+}
+
+// 适配器路由沿用同一鉴权：错 URL token 统一 401（gitlab/feishu 与 native 同口径）。
+func TestPush_Phase4Route_AuthEnforced(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, _ := createWebhookWithToken(t, handler, groupNo)
+
+	w1 := pushAdapterRaw(handler, whID, "wrong-token", "gitlab",
+		[]byte(`{"ref":"refs/heads/main"}`),
+		map[string]string{"X-Gitlab-Event": "Push Hook", "X-Gitlab-Token": "wrong-token"})
+	assert.Equalf(t, http.StatusUnauthorized, w1.Code, "gitlab: bad url token must 401; body=%s", w1.Body.String())
+
+	w2 := pushAdapterRaw(handler, whID, "wrong-token", "feishu",
+		[]byte(`{"msg_type":"text","content":{"text":"hi"}}`), nil)
+	assert.Equalf(t, http.StatusUnauthorized, w2.Code, "feishu: bad url token must 401; body=%s", w2.Body.String())
+}

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -218,18 +218,20 @@ func (w *IncomingWebhook) Route(r *wkhttp.WKHttp) {
 	push := r.Group("/v1")
 	{
 		// requirePushEnabled 在最前：总开关关闭时直接 404，最廉价地短路（甚至不进 floor）。
-		// 三种推送形态（native / github / wecom）共享同一条中间件链与同一组限流桶：
-		// 适配器只是 body 解析方式不同，不是新的攻击面，不单独开配额（见 adapter.go）。
+		// 所有推送形态（native / github / wecom / gitlab / feishu）共享同一条中间件链与
+		// 同一组限流桶：适配器只是 body 解析方式不同，不是新的攻击面，不单独开配额
+		// （见 adapter.go）。
 		chain := func(h wkhttp.HandlerFunc) []wkhttp.HandlerFunc {
 			return []wkhttp.HandlerFunc{w.requirePushEnabled(), w.localFloorMiddleware(), ipLimit, w.ipFailureGateMiddleware(), h}
 		}
 		push.POST("/incoming-webhooks/:webhook_id/:token", chain(w.push)...)
-		// 平台适配器（#297 Phase 3 / #426）：GitHub 事件 / 企业微信群机器人格式 / Multica
-		// 出站 webhook。鉴权、限流、群校验与 native 完全一致，仅 body 解析不同
-		// （adapter_github.go / adapter_wecom.go / adapter_multica.go）。
+		// 平台适配器（#297 Phase 3/4、#426）：GitHub / 企业微信 / Multica / GitLab / 飞书。
+		// 鉴权、限流、群校验与 native 完全一致，仅 body 解析不同（adapter_*.go）。
 		push.POST("/incoming-webhooks/:webhook_id/:token/github", chain(w.pushGitHub)...)
 		push.POST("/incoming-webhooks/:webhook_id/:token/wecom", chain(w.pushWeCom)...)
 		push.POST("/incoming-webhooks/:webhook_id/:token/multica", chain(w.pushMultica)...)
+		push.POST("/incoming-webhooks/:webhook_id/:token/gitlab", chain(w.pushGitLab)...)
+		push.POST("/incoming-webhooks/:webhook_id/:token/feishu", chain(w.pushFeishu)...)
 	}
 }
 
@@ -394,8 +396,9 @@ func publicURL(webhookID, token string) string {
 	return fmt.Sprintf("/v1/incoming-webhooks/%s/%s", webhookID, token)
 }
 
-// publicURLs 构造各推送形态的对外路径（#297 顺延的 onboarding 项 / #426）：native 即
-// 历史契约的 url 字段，github / wecom / multica 为平台适配器后缀。与 publicURL 一样不含 host。
+// publicURLs 构造各推送形态的对外路径（#297 onboarding 项 / Phase 4 / #426）：native 即
+// 历史契约的 url 字段，github / wecom / multica / gitlab / feishu 为平台适配器后缀。
+// 与 publicURL 一样不含 host。
 func publicURLs(webhookID, token string) map[string]string {
 	base := publicURL(webhookID, token)
 	return map[string]string{
@@ -403,6 +406,8 @@ func publicURLs(webhookID, token string) map[string]string {
 		"github":  base + "/github",
 		"wecom":   base + "/wecom",
 		"multica": base + "/multica",
+		"gitlab":  base + "/gitlab",
+		"feishu":  base + "/feishu",
 	}
 }
 
@@ -1071,12 +1076,15 @@ func (w *IncomingWebhook) failAuth(c *wkhttp.Context, ip string) {
 	pushUnauthorized(c)
 }
 
-// push / pushGitHub / pushWeCom / pushMultica 是各种推送形态的路由入口，全部走 handlePush
-// 流水线，仅在 adapter（body 解析 / bodyLimit / successExtra）上分叉。
+// push / pushGitHub / pushWeCom / pushMultica / pushGitLab / pushFeishu 是各推送形态的
+// 路由入口，全部走 handlePush 流水线，仅在 adapter（body 解析 / bodyLimit / successExtra）
+// 上分叉。
 func (w *IncomingWebhook) push(c *wkhttp.Context)        { w.handlePush(c, nativeAdapter) }
 func (w *IncomingWebhook) pushGitHub(c *wkhttp.Context)  { w.handlePush(c, githubAdapter) }
 func (w *IncomingWebhook) pushWeCom(c *wkhttp.Context)   { w.handlePush(c, wecomAdapter) }
 func (w *IncomingWebhook) pushMultica(c *wkhttp.Context) { w.handlePush(c, multicaAdapter) }
+func (w *IncomingWebhook) pushGitLab(c *wkhttp.Context)  { w.handlePush(c, gitlabAdapter) }
+func (w *IncomingWebhook) pushFeishu(c *wkhttp.Context)  { w.handlePush(c, feishuAdapter) }
 
 func (w *IncomingWebhook) handlePush(c *wkhttp.Context, ad pushAdapter) {
 	// 仅用于"鉴权失败才计入"的 per-IP 失败预算（见 failAuth / ipFailureGateMiddleware）。
@@ -1185,6 +1193,17 @@ func (w *IncomingWebhook) handlePush(c *wkhttp.Context, ad pushAdapter) {
 				zap.String("webhook_id", m.WebhookID), zap.Error(dErr))
 		}
 		w.webhookCache.invalidate(m.WebhookID)
+		pushUnauthorized(c)
+		return
+	}
+
+	// 3.6) 平台 header token 二次校验（目前仅 GitLab 的 X-Gitlab-Token，须等于 URL token）。
+	// 此闸在 URL token 已验证、creator 成员资格已确认之后——能到这里说明调用方已持有
+	// webhook 真正的密钥，故 header 不匹配是【配置错误】而非枚举探测：落审计
+	// （reason=token，byteSize=0，body 尚未读）便于管理员在 deliveries 里定位，返回统一
+	// 401（不计 IP 失败预算——调用方持有效 URL token，非攻击者）。
+	if ad.verifyToken != nil && !ad.verifyToken(c.Request.Header, token) {
+		w.submitFailure(m, 0, ip, ad.name, "token", http.StatusUnauthorized)
 		pushUnauthorized(c)
 		return
 	}

--- a/modules/incomingwebhook/api_i18n_test.go
+++ b/modules/incomingwebhook/api_i18n_test.go
@@ -20,7 +20,8 @@ import (
 // file to the list below.
 func TestIncomingWebhookNoLegacyResponseError(t *testing.T) {
 	files := []string{"api.go", "api_i18n.go", "ratelimit.go", "localfloor.go", "cache.go",
-		"adapter.go", "adapter_github.go", "adapter_wecom.go", "adapter_multica.go"}
+		"adapter.go", "adapter_github.go", "adapter_wecom.go", "adapter_multica.go",
+		"adapter_gitlab.go", "adapter_feishu.go"}
 	banned := []string{
 		".ResponseError(",
 		".ResponseErrorf(",

--- a/modules/incomingwebhook/model.go
+++ b/modules/incomingwebhook/model.go
@@ -44,13 +44,15 @@ const (
 	auditSkipped = 3
 )
 
-// 投递来源/适配器（auditModel.Adapter）。后续扩展 gitlab/feishu。
+// 投递来源/适配器（auditModel.Adapter）。
 const (
 	adapterNative  = "native"  // 原生推送端点
 	adapterTest    = "test"    // 管理端「测试推送」
 	adapterGitHub  = "github"  // GitHub 事件适配器（#297 Phase 3）
 	adapterWeCom   = "wecom"   // 企业微信群机器人格式适配器（#297 Phase 3）
 	adapterMultica = "multica" // Multica 出站 webhook 适配器（#426）
+	adapterGitLab  = "gitlab"  // GitLab 事件适配器（#297 Phase 4）
+	adapterFeishu  = "feishu"  // 飞书自定义机器人格式适配器（#297 Phase 4）
 )
 
 // auditModel 对应 incoming_webhook_audit 表，记录【鉴权通过后】的每次投递结果

--- a/modules/incomingwebhook/sql/20260622000002_incomingwebhook_phase4_adapter_comment.sql
+++ b/modules/incomingwebhook/sql/20260622000002_incomingwebhook_phase4_adapter_comment.sql
@@ -1,0 +1,18 @@
+-- +migrate Up
+
+-- #297 Phase 4 平台适配器（gitlab/feishu）引入：
+--   - adapter 列新增取值 gitlab / feishu（在 20260622000001 的 multica 之后）；
+--   - reason 列新增取值 token（GitLab X-Gitlab-Token 与 URL token 不匹配的 401）。
+-- 复用既有列、无结构变更，仅刷新 COMMENT 让 schema 自文档化（同 20260610000001 的
+-- 做法）。本迁移刻意排在 multica 注释迁移（20260622000001）之后，以便 adapter 注释
+-- 收敛为 native/test/github/wecom/multica/gitlab/feishu 全集；reason 在 20260618000001
+-- 的 no_event 基础上再加 token。目标库 MySQL 8.0：仅改 COMMENT 的 MODIFY COLUMN 走
+-- INSTANT 算法、瞬时无锁。
+ALTER TABLE `incoming_webhook_audit`
+  MODIFY COLUMN `reason`  VARCHAR(32) NOT NULL DEFAULT ''       COMMENT '失败/跳过原因码（body/json/content/blocks/msg_type/no_event/token/too_large/delivery_failed/event/ping）；成功为空。限流429不入审计',
+  MODIFY COLUMN `adapter` VARCHAR(16) NOT NULL DEFAULT 'native' COMMENT '消息来源/适配器：native/test/github/wecom/multica/gitlab/feishu';
+
+-- +migrate Down
+ALTER TABLE `incoming_webhook_audit`
+  MODIFY COLUMN `reason`  VARCHAR(32) NOT NULL DEFAULT ''       COMMENT '失败/跳过原因码（body/json/content/blocks/msg_type/no_event/too_large/delivery_failed/event/ping）；成功为空。限流429不入审计',
+  MODIFY COLUMN `adapter` VARCHAR(16) NOT NULL DEFAULT 'native' COMMENT '消息来源/适配器：native/test/github/wecom/multica（后续扩展 gitlab/feishu）';


### PR DESCRIPTION
## Summary

Completes the final phase of #297 — the **GitLab** and **Feishu** platform adapters — on the shared `pushAdapter` pipeline introduced in #330. Two new push shapes; same auth / rate-limit / group / audit path, only body parsing differs (one file per adapter).

`Closes #297` (Phase 4 is the last open item on that issue).

## Changes

### GitLab (`.../:webhook_id/:token/gitlab`)
- Render by `X-Gitlab-Event`: **Push / Tag Push / Merge Request / Issue / Note / Pipeline** → markdown. Out-of-subset events and noisy actions (MR `update`, pipeline `running`, GitLab **system notes**) answer `200 + skipped`; missing `X-Gitlab-Event` → `400 reason=no_event` (consistent with GitHub).
- **Auth**: besides the URL token (verified by the shared pipeline), the project **Secret token must equal it** and is re-checked constant-time via `X-Gitlab-Token` (new optional `verifyToken` hook). A mismatch is a config error (the caller already holds the URL secret) → uniform `401`, audited as `reason=token` for `deliveries` troubleshooting, with no IP-budget burn.
- Platform-generated body → dedicated **1 MiB** cap (`DM_INCOMINGWEBHOOK_GITLAB_MAX_BYTES`, clamped to 25 MiB).

### Feishu (`.../:webhook_id/:token/feishu`)
- Accept the custom-bot outbound format: `text` → text; `post` → markdown (title + per-line `text`/`a`/`at`; `img` dropped — `image_key` can't be re-hosted); `interactive` card → markdown (`div`/`markdown` elements; buttons/images dropped). Media types (`image`/`share_chat`) rejected `400`.
- Success carries `code=0`/`msg=success` for Feishu SDK compatibility. `post` routes through the **text path (not RichText)** so links stay clickable — high-fidelity card rendering isn't feasible, same graceful-degradation contract as WeCom in #330. README documents that `timestamp`/`sign` are ignored and the URL token is the sole credential.

### Shared / docs
- `create`/`regenerate` `urls` now include `gitlab` + `feishu`; README documents both shapes; migration refreshes the audit `adapter`/`reason` column comments (adds `gitlab`/`feishu`/`token`, carries forward `no_event` from #421).
- Reused #421's `mdLinkText` escaping on GitLab/Feishu link text, and aligned GitLab's missing-event reason + the 25 MiB body-cap clamp with the GitHub adapter.

## Testing

Infra provisioned locally (Redis, MySQL 8.0; WuKongIM image unreachable under the env network policy, but the package's tests tolerate best-effort IM delivery):

- `go build` + `go vet` clean; `gofmt` clean on all new files.
- Full `go test ./modules/incomingwebhook/ ./pkg/errcode/...` — **PASS** (pure-translation unit tests for both adapters + integration push cases: auth, skip, reject, GitLab token-mismatch audit).
- Both new migrations applied against a fresh `test` DB; verified `no_event` + `token` + `gitlab`/`feishu` land in the live column comments.
- `make i18n-extract-check` + `make i18n-lint` — **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)