### PR TITLE
feat(messages_search): surface mergeForward children as inner_messages

### DIFF
--- a/modules/messages_search/inner_messages_test.go
+++ b/modules/messages_search/inner_messages_test.go
@@ -1,0 +1,227 @@
+package messages_search
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/olivere/elastic"
+)
+
+// TestSingleMessageHit_ForwardCarriesInnerMessages pins the projection step
+// for the forward (type=11) path: the outer hit is forward-kinded, carries
+// outer_preview.child_count, and surfaces every msgs[] entry as an
+// inner_messages[] item with sender_id / sent_at populated when the indexer
+// has written them.
+func TestSingleMessageHit_ForwardCarriesInnerMessages(t *testing.T) {
+	tp := payloadTypeMergeForward
+	doc := Doc{
+		MessageID:  500,
+		MessageSeq: 12,
+		From:       "u_outer",
+		Timestamp:  1717000500,
+		Payload: &Payload{
+			Type: &tp,
+			MergeForward: &MergeForwardPayload{
+				ChildCount: 2,
+				Msgs: []MergeForwardMsg{
+					{MessageID: 600, Type: 1, SearchText: "hello", From: "u1", Timestamp: 1717000060},
+					{MessageID: 601, Type: 8, SearchText: "doc.pdf", From: "u2", Timestamp: 1717000120},
+				},
+			},
+		},
+	}
+	h := &Handler{cfg: SearchConfig{}}
+	hit := h.singleMessageHit(doc, "G1", nil)
+
+	if hit.MessageKind != "forward" {
+		t.Fatalf("kind: got %q", hit.MessageKind)
+	}
+	if hit.OuterPreview == nil || hit.OuterPreview.ChildCount != 2 {
+		t.Fatalf("outer_preview: %+v", hit.OuterPreview)
+	}
+	if len(hit.InnerMessages) != 2 {
+		t.Fatalf("inner_messages len: got %d", len(hit.InnerMessages))
+	}
+	if hit.InnerMessages[0].MessageID != "600" || hit.InnerMessages[0].SenderID != "u1" {
+		t.Errorf("inner[0]: %+v", hit.InnerMessages[0])
+	}
+	if hit.InnerMessages[0].SentAt == "" {
+		t.Errorf("inner[0].sent_at must be populated when timestamp>0")
+	}
+	if hit.InnerMessages[1].SearchText != "doc.pdf" {
+		t.Errorf("inner[1].search_text: %q", hit.InnerMessages[1].SearchText)
+	}
+}
+
+// TestSingleMessageHit_NonForwardHasNoInnerMessages: text/file/etc must NOT
+// surface inner_messages. omitempty drops the key from the wire form.
+func TestSingleMessageHit_NonForwardHasNoInnerMessages(t *testing.T) {
+	tp := payloadTypeText
+	doc := Doc{
+		MessageID: 7,
+		Timestamp: 1717000000,
+		Payload:   &Payload{Type: &tp, Text: &TextPayload{Content: "plain"}},
+	}
+	h := &Handler{cfg: SearchConfig{}}
+	hit := h.singleMessageHit(doc, "G1", nil)
+	if hit.InnerMessages != nil {
+		t.Fatalf("text hit must not carry inner_messages: %+v", hit.InnerMessages)
+	}
+	out, err := json.Marshal(hit)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if got := string(out); contains(got, "inner_messages") {
+		t.Fatalf("wire form must omit inner_messages, got %s", got)
+	}
+}
+
+// TestBuildMessageHits_SenderJoinFillsInnerNames asserts the end-to-end
+// behaviour: a single page with both an outer sender and forward-child
+// senders triggers exactly ONE GetUsers/GetMembers round trip and the
+// resulting names land on inner_messages[].sender_name.
+func TestBuildMessageHits_SenderJoinFillsInnerNames(t *testing.T) {
+	uSvc := &stubUserSvc{
+		users: []*user.Resp{
+			{UID: "u_outer", Name: "Outer"},
+			{UID: "u1", Name: "Alice"},
+			{UID: "u2", Name: "Bob"},
+		},
+	}
+	gSvc := &stubGroupSvc{
+		members: []*group.MemberResp{
+			{UID: "u1", Remark: "AliceRemark"}, // group remark wins over user.Name
+		},
+	}
+	h := newTestHandler(uSvc, gSvc)
+
+	tp := payloadTypeMergeForward
+	src, _ := json.Marshal(map[string]any{
+		"messageId":  500,
+		"messageSeq": 12,
+		"from":       "u_outer",
+		"channelId":  "G1",
+		"timestamp":  int64(1717000500),
+		"payload": map[string]any{
+			"type": tp,
+			"mergeForward": map[string]any{
+				"childCount": 2,
+				"msgs": []map[string]any{
+					{"messageId": 600, "type": 1, "searchText": "hello", "from": "u1", "timestamp": int64(1717000060)},
+					{"messageId": 601, "type": 1, "searchText": "world", "from": "u2", "timestamp": int64(1717000120)},
+				},
+			},
+		},
+	})
+	rawSrc := json.RawMessage(src)
+	hits := []*elastic.SearchHit{{Source: &rawSrc}}
+
+	out := h.buildMessageHits(context.Background(), hits, SearchMessagesReq{
+		ChannelType: channelTypeGroup,
+		ChannelID:   "G1",
+	}, "viewer")
+	if len(out) != 1 {
+		t.Fatalf("len: got %d", len(out))
+	}
+	hit := out[0]
+	if hit.SenderName != "Outer" {
+		t.Errorf("outer sender_name: got %q", hit.SenderName)
+	}
+	if len(hit.InnerMessages) != 2 {
+		t.Fatalf("inner len: %d", len(hit.InnerMessages))
+	}
+	if hit.InnerMessages[0].SenderName != "AliceRemark" {
+		t.Errorf("inner[0] should pick group remark, got %q", hit.InnerMessages[0].SenderName)
+	}
+	if hit.InnerMessages[1].SenderName != "Bob" {
+		t.Errorf("inner[1] should fall back to user.Name, got %q", hit.InnerMessages[1].SenderName)
+	}
+	// Single page → single GetUsers / GetMembers batch (regression guard
+	// against per-child round trips).
+	if uSvc.calls != 1 {
+		t.Errorf("expected 1 GetUsers call, got %d", uSvc.calls)
+	}
+	if gSvc.calls != 1 {
+		t.Errorf("expected 1 GetMembers call, got %d", gSvc.calls)
+	}
+}
+
+// TestBuildMessageHits_PartialInnerSenderOmitted: when the indexer hasn't yet
+// written msgs[].from / msgs[].timestamp, the inner item must NOT carry a
+// sender_id (and therefore no sender_name lookup) on the wire.
+func TestBuildMessageHits_PartialInnerSenderOmitted(t *testing.T) {
+	uSvc := &stubUserSvc{users: []*user.Resp{{UID: "u_outer", Name: "Outer"}}}
+	gSvc := &stubGroupSvc{}
+	h := newTestHandler(uSvc, gSvc)
+
+	src, _ := json.Marshal(map[string]any{
+		"messageId":  501,
+		"messageSeq": 13,
+		"from":       "u_outer",
+		"channelId":  "G1",
+		"timestamp":  int64(1717000600),
+		"payload": map[string]any{
+			"type": payloadTypeMergeForward,
+			"mergeForward": map[string]any{
+				"childCount": 1,
+				"msgs": []map[string]any{
+					{"messageId": 700, "type": 1, "searchText": "legacy"},
+				},
+			},
+		},
+	})
+	rawSrc := json.RawMessage(src)
+	hits := []*elastic.SearchHit{{Source: &rawSrc}}
+
+	out := h.buildMessageHits(context.Background(), hits, SearchMessagesReq{
+		ChannelType: channelTypeGroup,
+		ChannelID:   "G1",
+	}, "viewer")
+	if len(out) != 1 || len(out[0].InnerMessages) != 1 {
+		t.Fatalf("shape: %+v", out)
+	}
+	im := out[0].InnerMessages[0]
+	if im.SenderID != "" || im.SenderName != "" || im.SentAt != "" {
+		t.Errorf("legacy inner item must not surface sender/timestamp: %+v", im)
+	}
+	wire, _ := json.Marshal(im)
+	for _, k := range []string{`"sender_id"`, `"sender_name"`, `"sent_at"`} {
+		if contains(string(wire), k) {
+			t.Errorf("legacy wire form must omit %s, got %s", k, wire)
+		}
+	}
+}
+
+// TestBuildMessageHits_EmptyMsgsHasNoInnerMessages: a forward card with
+// childCount but an empty msgs[] array (or msgs key absent) must omit the
+// inner_messages field entirely so the client can't read "[]" as a signal.
+func TestBuildMessageHits_EmptyMsgsHasNoInnerMessages(t *testing.T) {
+	tp := payloadTypeMergeForward
+	doc := Doc{
+		MessageID: 9,
+		Timestamp: 1717000000,
+		Payload: &Payload{
+			Type:         &tp,
+			MergeForward: &MergeForwardPayload{ChildCount: 3 /* msgs nil */},
+		},
+	}
+	h := &Handler{cfg: SearchConfig{}}
+	hit := h.singleMessageHit(doc, "G1", nil)
+	if hit.InnerMessages != nil {
+		t.Fatalf("empty msgs[] must not surface inner_messages: %+v", hit.InnerMessages)
+	}
+}
+
+// contains is a tiny helper to keep test imports lean (avoid pulling strings
+// into multiple test files).
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/modules/messages_search/search_all.go
+++ b/modules/messages_search/search_all.go
@@ -174,6 +174,17 @@ func (h *Handler) buildSearchAllHits(ctx context.Context, hits []*elastic.Search
 		entry := h.singleSearchAllHit(doc, req, hl)
 		items = append(items, entry)
 		senderIDs = append(senderIDs, doc.From)
+		// Forward children: their senders need the same batched name lookup
+		// as the outer hit so a 9-msg forward card doesn't trigger 9 extra
+		// DB round-trips. payloadType=11 only — file hits never carry
+		// inner_messages.
+		if entry.Message != nil {
+			for _, im := range entry.Message.InnerMessages {
+				if im.SenderID != "" {
+					senderIDs = append(senderIDs, im.SenderID)
+				}
+			}
+		}
 	}
 
 	if len(items) == 0 {
@@ -186,6 +197,11 @@ func (h *Handler) buildSearchAllHits(ctx context.Context, hits []*elastic.Search
 			if items[i].Message != nil {
 				items[i].Message.SenderName = join.Names[items[i].Message.SenderID]
 				items[i].Message.SenderAvatarURL = join.Avatars[items[i].Message.SenderID]
+				for j := range items[i].Message.InnerMessages {
+					if uid := items[i].Message.InnerMessages[j].SenderID; uid != "" {
+						items[i].Message.InnerMessages[j].SenderName = join.Names[uid]
+					}
+				}
 			}
 		case "file":
 			if items[i].File != nil {

--- a/modules/messages_search/search_messages.go
+++ b/modules/messages_search/search_messages.go
@@ -13,16 +13,17 @@ import (
 
 // MessageHit is the response shape per A doc §2.1.
 type MessageHit struct {
-	MessageID       string        `json:"message_id"`
-	MessageSeq      int64         `json:"message_seq"`
-	MessageKind     string        `json:"message_kind"`
-	Snippet         string        `json:"snippet,omitempty"`
-	SenderID        string        `json:"sender_id"`
-	SenderName      string        `json:"sender_name,omitempty"`
-	SenderAvatarURL string        `json:"sender_avatar_url,omitempty"`
-	SentAt          string        `json:"sent_at"`
-	OuterPreview    *OuterPreview `json:"outer_preview,omitempty"`
-	ChannelID       string        `json:"channel_id"`
+	MessageID       string         `json:"message_id"`
+	MessageSeq      int64          `json:"message_seq"`
+	MessageKind     string         `json:"message_kind"`
+	Snippet         string         `json:"snippet,omitempty"`
+	SenderID        string         `json:"sender_id"`
+	SenderName      string         `json:"sender_name,omitempty"`
+	SenderAvatarURL string         `json:"sender_avatar_url,omitempty"`
+	SentAt          string         `json:"sent_at"`
+	OuterPreview    *OuterPreview  `json:"outer_preview,omitempty"`
+	InnerMessages   []InnerMessage `json:"inner_messages,omitempty"`
+	ChannelID       string         `json:"channel_id"`
 }
 
 func init() {
@@ -160,7 +161,10 @@ func buildSearchMessagesHighlight() *elastic.Highlight {
 }
 
 // buildMessageHits maps the OS hits into the API response shape and joins
-// sender display name + avatar in a single batch.
+// sender display name + avatar in a single batch. The batch covers both the
+// outer message sender and any inner_messages[].sender_id (forward children),
+// so a single page incurs at most one MySQL round-trip for names regardless of
+// how many forward cards it contains.
 func (h *Handler) buildMessageHits(ctx context.Context, hits []*elastic.SearchHit, req SearchMessagesReq, loginUID string) []MessageHit {
 	if len(hits) == 0 {
 		return []MessageHit{}
@@ -174,8 +178,14 @@ func (h *Handler) buildMessageHits(ctx context.Context, hits []*elastic.SearchHi
 			continue
 		}
 		hl := map[string][]string(hit.Highlight)
-		items = append(items, h.singleMessageHit(doc, req.ChannelID, hl))
-		senderIDs = append(senderIDs, doc.From)
+		mh := h.singleMessageHit(doc, req.ChannelID, hl)
+		senderIDs = append(senderIDs, mh.SenderID)
+		for _, im := range mh.InnerMessages {
+			if im.SenderID != "" {
+				senderIDs = append(senderIDs, im.SenderID)
+			}
+		}
+		items = append(items, mh)
 	}
 
 	if len(items) == 0 {
@@ -185,6 +195,11 @@ func (h *Handler) buildMessageHits(ctx context.Context, hits []*elastic.SearchHi
 	for i := range items {
 		items[i].SenderName = join.Names[items[i].SenderID]
 		items[i].SenderAvatarURL = join.Avatars[items[i].SenderID]
+		for j := range items[i].InnerMessages {
+			if uid := items[i].InnerMessages[j].SenderID; uid != "" {
+				items[i].InnerMessages[j].SenderName = join.Names[uid]
+			}
+		}
 	}
 	return items
 }
@@ -194,13 +209,14 @@ func (h *Handler) buildMessageHits(ctx context.Context, hits []*elastic.SearchHi
 // standing up a full search loop, and so search_all can reuse it.
 func (h *Handler) singleMessageHit(doc Doc, reqChannelID string, hl map[string][]string) MessageHit {
 	return MessageHit{
-		MessageID:    strconv.FormatInt(doc.MessageID, 10),
-		MessageSeq:   int64(doc.MessageSeq),
-		MessageKind:  classifyKind(doc.Payload),
-		Snippet:      pickSnippet(hl),
-		SenderID:     doc.From,
-		SentAt:       msToRFC3339(doc.Timestamp),
-		OuterPreview: buildOuterPreview(doc.Payload),
-		ChannelID:    encodeChannelID(reqChannelID),
+		MessageID:     strconv.FormatInt(doc.MessageID, 10),
+		MessageSeq:    int64(doc.MessageSeq),
+		MessageKind:   classifyKind(doc.Payload),
+		Snippet:       pickSnippet(hl),
+		SenderID:      doc.From,
+		SentAt:        msToRFC3339(doc.Timestamp),
+		OuterPreview:  buildOuterPreview(doc.Payload),
+		InnerMessages: buildInnerMessages(doc.Payload),
+		ChannelID:     encodeChannelID(reqChannelID),
 	}
 }

--- a/modules/messages_search/source.go
+++ b/modules/messages_search/source.go
@@ -1,5 +1,7 @@
 package messages_search
 
+import "strconv"
+
 // Doc mirrors the OpenSearch `_source` shape produced by
 // wukongim-message-indexer (see indexer-os-changes.md §3.2). We only
 // deserialise structured `payload.*` subobjects — `payloadRaw` is
@@ -86,10 +88,17 @@ type MergeForwardPayload struct {
 	Msgs       []MergeForwardMsg `json:"msgs,omitempty"`
 }
 
+// MergeForwardMsg is the per-child projection from `payload.mergeForward.msgs[]`.
+// `from` and `timestamp` are forward-compat fields the indexer will start
+// writing in a follow-up release; both are omitempty so older OS docs (which
+// only carry messageId/type/searchText) deserialise to a zero value and the
+// API can degrade `sender_id` / `sent_at` to omitted on the wire.
 type MergeForwardMsg struct {
 	MessageID  int64  `json:"messageId"`
 	Type       int    `json:"type"`
 	SearchText string `json:"searchText,omitempty"`
+	From       string `json:"from,omitempty"`
+	Timestamp  int64  `json:"timestamp,omitempty"`
 }
 
 // Payload type IDs (mirroring dmwork-lib `common/msg.go::ContentType`). Kept
@@ -143,4 +152,46 @@ func payloadType(p *Payload) int {
 		return 0
 	}
 	return *p.Type
+}
+
+// InnerMessage is the per-child shape surfaced under MessageHit.inner_messages
+// for forward (type=11) hits. SenderName is filled in after senderJoin runs;
+// SenderID / SentAt are omitted when the indexer hasn't yet populated the
+// underlying msgs[].from / msgs[].timestamp fields.
+type InnerMessage struct {
+	MessageID  string `json:"message_id"`
+	Type       int    `json:"type"`
+	SearchText string `json:"search_text,omitempty"`
+	SenderID   string `json:"sender_id,omitempty"`
+	SenderName string `json:"sender_name,omitempty"`
+	SentAt     string `json:"sent_at,omitempty"`
+}
+
+// buildInnerMessages projects the forward card's child messages onto the API
+// shape. Returns nil for non-forward payloads or empty msgs[] so the response
+// field is omitted entirely (omitempty) rather than emitting `[]`.
+//
+// `sender_name` is left empty here — the caller batches all child uids into
+// the page's senderJoin and fills the names afterwards.
+func buildInnerMessages(p *Payload) []InnerMessage {
+	if p == nil || p.MergeForward == nil {
+		return nil
+	}
+	if len(p.MergeForward.Msgs) == 0 {
+		return nil
+	}
+	out := make([]InnerMessage, 0, len(p.MergeForward.Msgs))
+	for _, m := range p.MergeForward.Msgs {
+		im := InnerMessage{
+			MessageID:  strconv.FormatInt(m.MessageID, 10),
+			Type:       m.Type,
+			SearchText: m.SearchText,
+			SenderID:   m.From,
+		}
+		if m.Timestamp > 0 {
+			im.SentAt = msToRFC3339(m.Timestamp)
+		}
+		out = append(out, im)
+	}
+	return out
 }

--- a/modules/messages_search/source_test.go
+++ b/modules/messages_search/source_test.go
@@ -53,6 +53,139 @@ func TestUnmarshalDoc_MergeForward(t *testing.T) {
 	if len(doc.Payload.MergeForward.Msgs) != 2 {
 		t.Fatalf("msgs len: got %d", len(doc.Payload.MergeForward.Msgs))
 	}
+	// Legacy docs without msgs[].from / msgs[].timestamp must deserialise
+	// to zero values; the partial-shape contract relies on omitempty hiding
+	// these fields on the wire (see buildInnerMessages).
+	for _, m := range doc.Payload.MergeForward.Msgs {
+		if m.From != "" {
+			t.Errorf("legacy doc must not surface from, got %q", m.From)
+		}
+		if m.Timestamp != 0 {
+			t.Errorf("legacy doc must not surface timestamp, got %d", m.Timestamp)
+		}
+	}
+}
+
+// TestUnmarshalDoc_MergeForward_FutureFields covers the post-indexer-bump
+// shape where msgs[].from and msgs[].timestamp are populated. Both fields
+// flow through to buildInnerMessages → InnerMessage.SenderID / SentAt.
+func TestUnmarshalDoc_MergeForward_FutureFields(t *testing.T) {
+	src := `{
+	  "messageId": 7,
+	  "channelId": "g",
+	  "timestamp": 1717000000,
+	  "payload": {
+	    "type": 11,
+	    "mergeForward": {
+	      "childCount": 1,
+	      "msgs": [
+	        {"messageId": 99, "type": 1, "searchText": "hi",
+	         "from": "u_alice", "timestamp": 1717000099}
+	      ]
+	    }
+	  }
+	}`
+	var doc Doc
+	if err := json.Unmarshal([]byte(src), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	m := doc.Payload.MergeForward.Msgs[0]
+	if m.From != "u_alice" {
+		t.Errorf("from: got %q", m.From)
+	}
+	if m.Timestamp != 1717000099 {
+		t.Errorf("timestamp: got %d", m.Timestamp)
+	}
+}
+
+// TestBuildInnerMessages_FullShape exercises the full forward-card mapping
+// once msgs[].from / msgs[].timestamp are populated. Names are NOT filled
+// here — that's senderJoin's job; this test asserts the projection only.
+func TestBuildInnerMessages_FullShape(t *testing.T) {
+	tp := payloadTypeMergeForward
+	p := &Payload{
+		Type: &tp,
+		MergeForward: &MergeForwardPayload{
+			ChildCount: 2,
+			Msgs: []MergeForwardMsg{
+				{MessageID: 100, Type: 1, SearchText: "hello", From: "u1", Timestamp: 1717000000},
+				{MessageID: 101, Type: 8, SearchText: "doc.pdf", From: "u2", Timestamp: 1717000060},
+			},
+		},
+	}
+	inner := buildInnerMessages(p)
+	if len(inner) != 2 {
+		t.Fatalf("len: got %d", len(inner))
+	}
+	if inner[0].MessageID != "100" {
+		t.Errorf("messageId[0]: got %q", inner[0].MessageID)
+	}
+	if inner[0].Type != 1 {
+		t.Errorf("type[0]: got %d", inner[0].Type)
+	}
+	if inner[0].SearchText != "hello" {
+		t.Errorf("searchText[0]: got %q", inner[0].SearchText)
+	}
+	if inner[0].SenderID != "u1" {
+		t.Errorf("senderId[0]: got %q", inner[0].SenderID)
+	}
+	if inner[0].SenderName != "" {
+		t.Errorf("senderName must be unset until senderJoin: got %q", inner[0].SenderName)
+	}
+	if inner[0].SentAt == "" {
+		t.Errorf("sentAt[0] must be populated when timestamp>0")
+	}
+	if inner[1].MessageID != "101" || inner[1].SenderID != "u2" {
+		t.Errorf("msg[1]: %+v", inner[1])
+	}
+}
+
+// TestBuildInnerMessages_PartialFields covers the contract-v0 shape where
+// msgs[].from / msgs[].timestamp are absent — the API must omit
+// sender_id / sent_at entirely (omitempty + empty zero values).
+func TestBuildInnerMessages_PartialFields(t *testing.T) {
+	p := &Payload{
+		MergeForward: &MergeForwardPayload{
+			Msgs: []MergeForwardMsg{
+				{MessageID: 42, Type: 1, SearchText: "hi"},
+			},
+		},
+	}
+	inner := buildInnerMessages(p)
+	if len(inner) != 1 {
+		t.Fatalf("len: got %d", len(inner))
+	}
+	if inner[0].SenderID != "" {
+		t.Errorf("sender_id must be empty for partial doc: got %q", inner[0].SenderID)
+	}
+	if inner[0].SentAt != "" {
+		t.Errorf("sent_at must be empty when timestamp=0: got %q", inner[0].SentAt)
+	}
+	// Wire-level omitempty: the JSON form must not emit these keys.
+	out, err := json.Marshal(inner[0])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	wire := string(out)
+	for _, k := range []string{`"sender_id"`, `"sender_name"`, `"sent_at"`} {
+		if strings.Contains(wire, k) {
+			t.Errorf("partial-shape wire form must omit %s, got %s", k, wire)
+		}
+	}
+}
+
+// TestBuildInnerMessages_GuardClauses: returns nil for any non-forward shape
+// or empty msgs[] so the response field is omitted entirely (omitempty).
+func TestBuildInnerMessages_GuardClauses(t *testing.T) {
+	if got := buildInnerMessages(nil); got != nil {
+		t.Errorf("nil payload: got %+v", got)
+	}
+	if got := buildInnerMessages(&Payload{}); got != nil {
+		t.Errorf("non-forward payload: got %+v", got)
+	}
+	if got := buildInnerMessages(&Payload{MergeForward: &MergeForwardPayload{}}); got != nil {
+		t.Errorf("empty msgs[]: got %+v", got)
+	}
 }
 
 func TestUnmarshalDoc_Image(t *testing.T) {

--- a/modules/messages_search/swagger/api.yaml
+++ b/modules/messages_search/swagger/api.yaml
@@ -436,6 +436,33 @@ definitions:
       child_count:
         type: integer
 
+  InnerMessage:
+    type: object
+    description: |
+      Per-child projection of a forward (type=11) message's inner msgs[].
+      `sender_id` and `sent_at` are omitted while the indexer is still
+      writing the contract-v0 shape (only message_id / type / search_text).
+      Once the indexer fills msgs[].from / msgs[].timestamp, both fields
+      surface automatically — clients must tolerate either shape.
+    required:
+      - message_id
+      - type
+    properties:
+      message_id:
+        type: string
+      type:
+        type: integer
+        description: "Inner payload content type (1=text, 8=file, ...)."
+      search_text:
+        type: string
+      sender_id:
+        type: string
+      sender_name:
+        type: string
+      sent_at:
+        type: string
+        format: date-time
+
   MessageHit:
     type: object
     required:
@@ -468,6 +495,14 @@ definitions:
         format: date-time
       outer_preview:
         $ref: "#/definitions/OuterPreview"
+      inner_messages:
+        type: array
+        description: |
+          Forward-card child messages, only emitted when message_kind=forward
+          and the OS doc carries a non-empty payload.mergeForward.msgs[].
+          Omitted entirely (not "[]") on text hits or when msgs[] is missing.
+        items:
+          $ref: "#/definitions/InnerMessage"
       channel_id:
         type: string
 


### PR DESCRIPTION
Project the OS doc's payload.mergeForward.msgs[] onto a new MessageHit.inner_messages array (forward hits only, omitempty otherwise). Each child carries message_id/type/search_text now; sender_id and sent_at are forward-compat (omitempty) so older OS docs degrade cleanly until the indexer starts writing msgs[].from / msgs[].timestamp.

Inner sender uids are folded into the page's existing senderJoin batch so a 9-msg forward card adds at most one extra GetUsers call, regardless of how many forward cards a page contains.

Swagger: new InnerMessage definition wired into MessageHit (used by _search and _search_around alike).

## Summary

<!-- What does this PR do? -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. Fixes #123 -->

## Linked Spec

<!-- Link to .octospec/tasks/<slug>/brief.md or the issue this implements.
     Required when the change touches load-bearing behavior. -->

## Changes

<!-- Bullet list of concrete changes -->

-
-

## Testing

<!-- How was this tested? Include commands, screenshots, or test output. -->

- [ ] Unit tests added/updated
- [ ] Manually verified

## COMPREHENSION

<!-- Required for load-bearing / architectural / P0 changes. Answer to substance,
     not boilerplate. Delete this section for trivial changes (typo/docs/lint/config). -->

1. **What does this change actually do** to the load-bearing path?

2. **What could break** because of it (dependents + failure mode)?

3. **How do you know it works** (specific test/repro/trace)?

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] PR description is in English
- [ ] Added tests for my changes
- [ ] Updated documentation
- [ ] Followed commit message conventions (Conventional Commits)
