### PR TITLE
feat(incomingwebhook): add /multica adapter for multica outbound webhooks

### DIFF
--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -204,7 +204,9 @@ POST /v1/incoming-webhooks/:webhook_id/:token/multica
 
 子集之外的事件（`issue.created` / `comment.created` 等未来事件）返回 200 +
 `{"skipped":"event"}`（deliveries 里 `status=3`/`reason=event` 可见，与 github
-适配器一致）；payload 解析失败 → 400 `reason=json`；事件已识别但 issue 关键
+适配器一致）；缺 `event` 字段（配置错误）→ 400 `reason=no_event`（与 github 缺
+`X-GitHub-Event` 同语义，可在 deliveries 里与「不在渲染子集」的 200 skip 分开看）；
+payload 解析失败 → 400 `reason=json`；事件已识别但 issue 关键
 字段（identifier / status）缺失 → 400 `reason=content`。
 
 **body 上限：** 与 native 同为 8 KiB——Multica 信封比 GitHub 事件紧凑（只嵌

--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -47,6 +47,7 @@
 POST /v1/incoming-webhooks/:webhook_id/:token            # native（本文主体）
 POST /v1/incoming-webhooks/:webhook_id/:token/github     # GitHub 事件适配器
 POST /v1/incoming-webhooks/:webhook_id/:token/wecom      # 企业微信群机器人格式适配器
+POST /v1/incoming-webhooks/:webhook_id/:token/multica    # Multica 出站 webhook 适配器
 Content-Type: application/json
 ```
 
@@ -185,6 +186,42 @@ curl -X POST "$BASE/v1/incoming-webhooks/$WEBHOOK_ID/$TOKEN/wecom" \
   -d '{"msgtype":"markdown","markdown":{"content":"**Build #123** passed"}}'
 ```
 
+### Multica（出站 webhook 格式）
+
+```
+POST /v1/incoming-webhooks/:webhook_id/:token/multica
+```
+
+接受 [Multica](https://github.com/multica-ai/multica) 出站 webhook 的固定 JSON
+信封——在 Multica 工作区 Settings → Webhooks 把 URL 配成上述地址即可，无需中间
+转换层。鉴权沿用 URL 内 token；Multica 出站请求会带 `X-Multica-Signature-256`
+（与 GitHub 的 `X-Hub-Signature-256` 同算法），与 github 适配器对称——目前不校验，
+留作后续可选项。
+
+| `event` | 渲染 |
+|---------|------|
+| `issue.status_changed` | `**MUL-123** Title: ` + 状态变化（如 `` `todo` → `in_progress` ``） + actor 类型尾注 |
+
+子集之外的事件（`issue.created` / `comment.created` 等未来事件）返回 200 +
+`{"skipped":"event"}`（deliveries 里 `status=3`/`reason=event` 可见，与 github
+适配器一致）；payload 解析失败 → 400 `reason=json`；事件已识别但 issue 关键
+字段（identifier / status）缺失 → 400 `reason=content`。
+
+**body 上限：** 与 native 同为 8 KiB——Multica 信封比 GitHub 事件紧凑（只嵌
+单个 issue），不需要 github 那种 1 MiB 上限。
+
+**展示身份：** 与其它适配器一致，固定为 webhook 配置；信封里没有 `username` /
+`avatar_url` 字段。
+
+```bash
+# 把 Multica outbound webhook URL 配成 octo 适配器路径即可
+curl -X POST "$BASE/v1/incoming-webhooks/$WEBHOOK_ID/$TOKEN/multica" \
+  -H 'Content-Type: application/json' \
+  -d '{"event":"issue.status_changed","actor":{"type":"member","id":"u-1"},
+       "issue":{"identifier":"MUL-123","title":"Fix login","status":"in_progress"},
+       "previous_status":"todo"}'
+```
+
 ## 通用字段与安全
 
 - `username` / `avatar_url`：两种形态通用，服务端裁剪到字节上限（名 64B / 头像 255B）。
@@ -209,7 +246,7 @@ curl -X POST "$BASE/v1/incoming-webhooks/$WEBHOOK_ID/$TOKEN/wecom" \
 需登录态 + 群管理员权限，路径前缀 `/v1/groups/:group_no/incoming-webhooks`。
 
 创建 / 重置（regenerate）响应除历史的 `url`（native 路径）外，还带 `urls` 对象，
-按推送形态给出全部路径（`native` / `github` / `wecom`，不含 host，由前端拼接）。
+按推送形态给出全部路径（`native` / `github` / `wecom` / `multica`，不含 host，由前端拼接）。
 token 仅在这两处出现一次，list 不回显 token、也不回推送 URL。
 
 除创建/列出/更新/删除/重置外，Phase 2 新增两个：

--- a/modules/incomingwebhook/adapter.go
+++ b/modules/incomingwebhook/adapter.go
@@ -1,13 +1,14 @@
 package incomingwebhook
 
-// 推送形态适配层（#297 Phase 3）。
+// 推送形态适配层（#297 Phase 3 / #426）。
 //
-// 三种推送形态共享同一条鉴权 / 限流 / 群校验 / 投递 / 审计流水线（api.go handlePush），
+// 多种推送形态共享同一条鉴权 / 限流 / 群校验 / 投递 / 审计流水线（api.go handlePush），
 // 彼此只差「如何把请求 body 翻译成 native 推送请求」这一步：
 //
 //   - native（历史契约）   POST /v1/incoming-webhooks/:webhook_id/:token
 //   - GitHub 事件          POST .../:token/github   （adapter_github.go）
 //   - 企业微信群机器人格式  POST .../:token/wecom    （adapter_wecom.go）
+//   - Multica 出站事件     POST .../:token/multica  （adapter_multica.go）
 //
 // 适配器不是新的攻击面：URL token 鉴权、四层限流、群 Normal 校验、payload 白名单
 // 构造（buildPayload / buildRichTextPayload 注入 from.kind=webhook 与服务端 space_id）
@@ -50,6 +51,10 @@ var (
 		// 企业微信调用方普遍校验 errcode==0，附带平台习惯字段降低迁移摩擦。
 		successExtra: map[string]interface{}{"errcode": 0, "errmsg": "ok"},
 	}
+	// multicaAdapter 接收 multica 出站 webhook（issue.status_changed 等事件
+	// 的固定 JSON envelope）。multica envelope 比 GitHub 事件紧凑（不嵌入
+	// repository 对象），8 KiB 足够，沿用 native 的 bodyLimit。
+	multicaAdapter = pushAdapter{name: adapterMultica, parse: parseMulticaPush, bodyLimit: maxBytes}
 )
 
 // parseNativePush 是 native 形态的 parse：body 即 pushPayloadReq JSON 本身。

--- a/modules/incomingwebhook/adapter.go
+++ b/modules/incomingwebhook/adapter.go
@@ -22,7 +22,8 @@ import (
 
 // pushAdapter 描述一种推送形态。
 type pushAdapter struct {
-	// name 写入审计 adapter 列（adapterNative / adapterGitHub / adapterWeCom）。
+	// name 写入审计 adapter 列（adapterNative / adapterGitHub / adapterWeCom /
+	// adapterMultica）。新增适配器时把对应常量加进列表。
 	name string
 	// parse 把平台原始 body 翻译成 native 推送请求。三个返回值恰有一个生效：
 	//   - req     非 nil：照常走 msg_type 构造 / 投递；
@@ -127,4 +128,55 @@ var mdLinkTextEscaper = strings.NewReplacer(`\`, `\\`, `[`, `\[`, `]`, `\]`)
 // 钳约束的是可见长度，转义引入的反斜杠不该挤占可见字符预算。
 func mdLinkText(s string, max int) string {
 	return mdLinkTextEscaper.Replace(clipRunes(oneLine(s), max))
+}
+
+// mdInertTextEscaper 转义会让外部文本"越界"激活 markdown 语法的字符。覆盖：
+//   - 链接相关 `\` / `[` / `]`：与 mdLinkText 同源，避免拼成意外链接；
+//   - 强调相关 `*` / `_`：放进 `**X**`/`__X__` 包装或纯文本时不能让自身字符提前闭合
+//     或反生成强调；
+//   - HTML / 自动链接 `<` / `>`：CommonMark 会把 `<http://…>` 渲染成链接，
+//     `<script>` 在部分宽松渲染器里也会被转 HTML；
+//   - 表格管道 `|`：进表格单元格的字段不能裸传 `|`。
+//
+// 反引号「不转义、直接剥离」：CommonMark 单 backtick span 里 `\` 是字面反斜杠，
+// 用 `\“ 不能把反引号嵌进去；而双 backtick fence 又会引入二次转义难题。本模块
+// 用 mdInertText 处理的字段（multica 的 identifier / actor.type 等短标识符）按
+// 契约都是不含反引号的，剥离比转义更稳——与 GitHub adapter 处理短字段
+// （branch、sender.login）的口径一致。
+//
+// ⚠️ 不要把 mdInertText 用在 `...` code span 的内部：code span 内 `_` / `*`
+// 不被 markdown 解释，反斜杠转义会让客户端把 `\_` 当字面显示出来（in\_progress
+// 而非 in_progress）。code span 内只需 strip 反引号，请用 mdCodeSpanText。
+var mdInertTextEscaper = strings.NewReplacer(
+	`\`, `\\`,
+	"`", "",
+	`*`, `\*`,
+	`_`, `\_`,
+	`[`, `\[`,
+	`]`, `\]`,
+	`<`, `\<`,
+	`>`, `\>`,
+	`|`, `\|`,
+)
+
+// mdInertText 把不该激活 markdown 语法的短字段（identifier / 标签 / actor 类型）
+// 钳到 max rune 后转义为「inert」文本——拼到 `**X**` 或 `(by X)` 纯文本都不能
+// 逃出去开新 span / 链接。先钳后转义同 mdLinkText。
+//
+// 仅用于 **非** code span 上下文；code span 内字段请用 mdCodeSpanText（否则
+// `\_` 等转义序列会以字面形式回显，破坏显示）。
+func mdInertText(s string, max int) string {
+	return mdInertTextEscaper.Replace(clipRunes(oneLine(s), max))
+}
+
+// mdCodeSpanText 专用于 `...` 单反引号 code span 内部字段：只剥离反引号
+// （没法在单 backtick span 内安全转义反引号），其余字符在 code span 内不被
+// markdown 解释（`_` `*` `\` 都会按字面显示），无须转义——也绝不可转义，否则
+// 客户端会回显 `\_` 而非 `_`，破坏 status 等可读性。
+//
+// 与 mdInertText 不同：用法严格限定到 “ `X` “ 上下文，不要拿出去拼别处。
+var mdCodeSpanStripper = strings.NewReplacer("`", "")
+
+func mdCodeSpanText(s string, max int) string {
+	return mdCodeSpanStripper.Replace(clipRunes(oneLine(s), max))
 }

--- a/modules/incomingwebhook/adapter_multica.go
+++ b/modules/incomingwebhook/adapter_multica.go
@@ -1,0 +1,153 @@
+package incomingwebhook
+
+// Multica 事件适配器（#426）。
+//
+// 路由：POST /v1/incoming-webhooks/:webhook_id/:token/multica
+// 在 Multica 工作区 Settings → Webhooks 把 Webhook URL 配成上述地址即可，
+// 无需任何中间转换层。
+//
+// 鉴权沿用 URL 内的 128-bit token（与 native / github / wecom 一致）。Multica
+// 出站请求会带 X-Multica-Signature-256（与 GitHub 的 X-Hub-Signature-256 同
+// 算法），与 github 适配器对称——目前不校验，留作后续可选项。
+//
+// 渲染策略：按 envelope.event 把已支持事件翻译成 markdown 文本（走 native 纯
+// 文本路径，客户端按 markdown 渲染）。v1 只识别 issue.status_changed；未来
+// issue.created / issue.assigned / comment.created 等是【加性】的——新增 case 即可，
+// 不动既有契约。
+//
+// 子集之外的事件返回 200 + auditSkipped(reason=event)：Multica 侧投递成功
+// （不会把订阅标红），管理端 deliveries 里 reason=event 可见，与 github
+// 适配器的语义完全一致。
+//
+// mu* 结构体只声明渲染需要的字段（白名单解析），其余 payload 字段一律忽略。
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// muIssue 是 multica IssueResponse 渲染所需的最小字段子集（白名单）。
+// Identifier 形如 "MUL-123"；Status 是状态枚举（todo/in_progress/...）。
+type muIssue struct {
+	Identifier string `json:"identifier"`
+	Title      string `json:"title"`
+	Status     string `json:"status"`
+}
+
+// muActor 是事件触发者标识（{type,id}）。type ∈ member / agent 等；id 是
+// 触发者主键（uuid 或 agent slug）。当前 envelope 不带显示名，渲染只用 type。
+type muActor struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+// muEnvelope 是 multica 出站 webhook 的固定信封（见 multica
+// server/internal/integrations/outwebhook/dispatcher.go outboundPayload）。
+type muEnvelope struct {
+	Event          string  `json:"event"`
+	WorkspaceID    string  `json:"workspace_id"`
+	Actor          muActor `json:"actor"`
+	Issue          muIssue `json:"issue"`
+	PreviousStatus string  `json:"previous_status"`
+}
+
+// 已知事件类型。v1 只有 issue.status_changed；新增事件加 case 即可。
+const (
+	muEventIssueStatusChanged = "issue.status_changed"
+)
+
+// parseMulticaPush 把 multica envelope 翻译成 native 推送请求（pushAdapter.parse）。
+//
+// 三个返回值恰有一个生效（见 pushAdapter.parse 注释）：
+//   - req     非 nil：照常走纯文本路径投递；
+//   - skip    非空：合法但刻意不投递（事件类型不在渲染子集内 → "event"），
+//     返回 200 + auditSkipped，管理端 deliveries 里 reason=event 可见；
+//   - invalid 非空：解析失败 → 400 + auditFailed，reason 同 native：
+//     "json" / "content"（事件已识别但渲染结果为空）。
+//
+// header 当前未使用（X-Multica-Event 仅作辅助；事件分发以 body.event 为准，
+// 防止 header/body 不一致导致渲染走偏）。保留参数以匹配 pushAdapter.parse 签名，
+// 并预留未来按 header 做版本协商的余地。
+func parseMulticaPush(_ http.Header, body []byte) (*pushPayloadReq, string, string) {
+	var ev muEnvelope
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return nil, "", "json"
+	}
+	event := strings.TrimSpace(ev.Event)
+	if event == "" {
+		// 缺 event 字段是配置错误（不像合法 multica 出站流量），按 json 拒绝。
+		// 与 github 的 no_event 不同：github 那边事件名在 header，缺 header 与
+		// 缺 body 字段语义有别；multica 全在 body 里，统一走 json 即可。
+		return nil, "", "json"
+	}
+
+	var content string
+	switch event {
+	case muEventIssueStatusChanged:
+		content = renderMulticaIssueStatusChanged(ev)
+	default:
+		// 渲染子集之外（issue.created / comment.created / 未来未知事件）：
+		// multica 侧无需修复任何东西，200 + skip。
+		return nil, "event", ""
+	}
+	if content == "" {
+		// 事件类型已识别、但 payload 关键字段缺失渲染不出可读内容：按 400
+		// 拒绝而非静默跳过，让发送方能在 deliveries 里看到 reason=content
+		// 排查 payload 是否构造错（与 native content 为空的语义一致）。
+		return nil, "", "content"
+	}
+	// envelope 里的 title 长度由 multica 端控制（理论上可达 MySQL TEXT
+	// 上限）；钳到 maxContentRunes 内，绝不让 multica 流量 413。
+	return &pushPayloadReq{Content: clipRunes(content, maxContentRunes())}, "", ""
+}
+
+// renderMulticaIssueStatusChanged 渲染 issue.status_changed 事件。
+//
+// 输出形如（markdown，客户端会渲染）：
+//
+//	**MUL-123** Fix login redirect: `todo` → `in_progress` (by agent)
+//
+// 设计取舍：
+//   - 不拼 issue URL：envelope 当前不带 URL；服务端无法可靠推断 multica
+//     部署域名（self-hosted 路径多种）。需要可点链接时由 multica 后续在
+//     envelope 加 issue.url 字段，渲染层加链接即可，不破坏既有契约。
+//   - 标题与 identifier 之间用空格分隔，与 GitHub 适配器的 issue 渲染风格
+//     一致；状态用反引号包起来，避免下划线（in_progress）被 markdown 误
+//     当作斜体。
+//   - actor 名当前不在 envelope 里，只渲染 type（"by agent" / "by member"）；
+//     未显示触发者类型的情况下省略尾注。
+//   - 标题里的 `[` / `]` 经 mdLinkText 转义（即便当前没拼成链接也防御性
+//     处理，未来加链接时不必再回头改）。
+func renderMulticaIssueStatusChanged(ev muEnvelope) string {
+	id := strings.TrimSpace(ev.Issue.Identifier)
+	title := strings.TrimSpace(ev.Issue.Title)
+	status := strings.TrimSpace(ev.Issue.Status)
+	prev := strings.TrimSpace(ev.PreviousStatus)
+	// id 与 status 是渲染所必需的最小集；缺失任一无法生成可读消息，回退
+	// 让上层走 reason=content 而非凭空生造。
+	if id == "" || status == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "**%s**", id)
+	if title != "" {
+		// 钳到 200 rune 与 GitHub PR/issue 标题渲染保持一致。
+		b.WriteString(" ")
+		b.WriteString(mdLinkText(title, 200))
+	}
+	b.WriteString(": ")
+	if prev != "" && prev != status {
+		fmt.Fprintf(&b, "`%s` → `%s`", prev, status)
+	} else {
+		// 新建 issue 或事件 payload 缺 previous_status 时只显示当前状态，
+		// 不画"→ X"那种暗示状态变化的尾巴。
+		fmt.Fprintf(&b, "`%s`", status)
+	}
+	if actorType := strings.TrimSpace(ev.Actor.Type); actorType != "" {
+		fmt.Fprintf(&b, " (by %s)", actorType)
+	}
+	return b.String()
+}

--- a/modules/incomingwebhook/adapter_multica.go
+++ b/modules/incomingwebhook/adapter_multica.go
@@ -65,7 +65,7 @@ const (
 //   - skip    非空：合法但刻意不投递（事件类型不在渲染子集内 → "event"），
 //     返回 200 + auditSkipped，管理端 deliveries 里 reason=event 可见；
 //   - invalid 非空：解析失败 → 400 + auditFailed，reason 同 native：
-//     "json" / "content"（事件已识别但渲染结果为空）。
+//     "json" / "no_event" / "content"（事件已识别但渲染结果为空）。
 //
 // header 当前未使用（X-Multica-Event 仅作辅助；事件分发以 body.event 为准，
 // 防止 header/body 不一致导致渲染走偏）。保留参数以匹配 pushAdapter.parse 签名，
@@ -77,10 +77,12 @@ func parseMulticaPush(_ http.Header, body []byte) (*pushPayloadReq, string, stri
 	}
 	event := strings.TrimSpace(ev.Event)
 	if event == "" {
-		// 缺 event 字段是配置错误（不像合法 multica 出站流量），按 json 拒绝。
-		// 与 github 的 no_event 不同：github 那边事件名在 header，缺 header 与
-		// 缺 body 字段语义有别；multica 全在 body 里，统一走 json 即可。
-		return nil, "", "json"
+		// 缺 event 字段是「配置错误」（不像合法 multica 出站流量），与 github
+		// 适配器缺 X-GitHub-Event 头同语义——复用同一个 no_event 原因码，让
+		// deliveries 排障口径跨适配器一致（yujiawei review P2-2）：跟「事件已识别但
+		// 不在渲染子集内」的 200 skip(event) 区分开。reason 字典在 #330 时已经为
+		// no_event 注册了 i18n / DB 注释，无须新增。
+		return nil, "", "no_event"
 	}
 
 	var content string
@@ -98,8 +100,10 @@ func parseMulticaPush(_ http.Header, body []byte) (*pushPayloadReq, string, stri
 		// 排查 payload 是否构造错（与 native content 为空的语义一致）。
 		return nil, "", "content"
 	}
-	// envelope 里的 title 长度由 multica 端控制（理论上可达 MySQL TEXT
-	// 上限）；钳到 maxContentRunes 内，绝不让 multica 流量 413。
+	// 8 KiB body cap 已经在 handlePush 第 4 步前置拦掉超长 body（足够大的 title
+	// 会先 413，而不是到这里），所以此处的 clipRunes 不是「保 title 不被 413」的
+	// 兜底，而是渲染层对 maxContentRunes(4000 rune) 上限的本地约束——避免拼装后
+	// 的最终 content 越过 push 路径下游对 RichText 字数的语义钳位。
 	return &pushPayloadReq{Content: clipRunes(content, maxContentRunes())}, "", ""
 }
 
@@ -120,6 +124,19 @@ func parseMulticaPush(_ http.Header, body []byte) (*pushPayloadReq, string, stri
 //     未显示触发者类型的情况下省略尾注。
 //   - 标题里的 `[` / `]` 经 mdLinkText 转义（即便当前没拼成链接也防御性
 //     处理，未来加链接时不必再回头改）。
+//   - 其余进 markdown 的字段按上下文走对应 helper（详见 adapter.go 注释）：
+//   - identifier 在 `**...**` 粗体里 → mdInertText（转义 `*` 防止 bold-break，
+//     转义 `[]` 防止 link injection）；
+//   - status / previous_status 在 “ `...` “ code span 里 → mdCodeSpanText
+//     （只剥反引号防止逃逸 code span；`_`/`*` 在 code span 内本就不被解释，
+//     不转义否则会回显 `\_` 破坏显示）；
+//   - actor.type 在 `(by ...)` 纯文本上下文 → mdInertText（全量转义）。
+//     这些字段按 multica 契约都是受控枚举/标识符，escape 是 defense-in-depth
+//     （PR #427 review by yujiawei / mochashanyao / Jerry-Xin）。
+//   - 字段长度统一钳到 64 rune：identifier/status/actor 在 multica 端是短
+//     标识符（identifier 形如 "MUL-12345"、status 是枚举、actor.type 是
+//     "member"/"agent"），64 足够覆盖正常上限并把异常长度截短防御。title
+//     仍用 200 rune（与 GitHub PR/issue 标题钳值对齐）。
 func renderMulticaIssueStatusChanged(ev muEnvelope) string {
 	id := strings.TrimSpace(ev.Issue.Identifier)
 	title := strings.TrimSpace(ev.Issue.Title)
@@ -131,8 +148,10 @@ func renderMulticaIssueStatusChanged(ev muEnvelope) string {
 		return ""
 	}
 
+	const shortFieldMax = 64
+
 	var b strings.Builder
-	fmt.Fprintf(&b, "**%s**", id)
+	fmt.Fprintf(&b, "**%s**", mdInertText(id, shortFieldMax))
 	if title != "" {
 		// 钳到 200 rune 与 GitHub PR/issue 标题渲染保持一致。
 		b.WriteString(" ")
@@ -140,14 +159,16 @@ func renderMulticaIssueStatusChanged(ev muEnvelope) string {
 	}
 	b.WriteString(": ")
 	if prev != "" && prev != status {
-		fmt.Fprintf(&b, "`%s` → `%s`", prev, status)
+		fmt.Fprintf(&b, "`%s` → `%s`",
+			mdCodeSpanText(prev, shortFieldMax),
+			mdCodeSpanText(status, shortFieldMax))
 	} else {
 		// 新建 issue 或事件 payload 缺 previous_status 时只显示当前状态，
 		// 不画"→ X"那种暗示状态变化的尾巴。
-		fmt.Fprintf(&b, "`%s`", status)
+		fmt.Fprintf(&b, "`%s`", mdCodeSpanText(status, shortFieldMax))
 	}
 	if actorType := strings.TrimSpace(ev.Actor.Type); actorType != "" {
-		fmt.Fprintf(&b, " (by %s)", actorType)
+		fmt.Fprintf(&b, " (by %s)", mdInertText(actorType, shortFieldMax))
 	}
 	return b.String()
 }

--- a/modules/incomingwebhook/adapter_multica.go
+++ b/modules/incomingwebhook/adapter_multica.go
@@ -75,7 +75,11 @@ func parseMulticaPush(_ http.Header, body []byte) (*pushPayloadReq, string, stri
 	if err := json.Unmarshal(body, &ev); err != nil {
 		return nil, "", "json"
 	}
-	event := strings.TrimSpace(ev.Event)
+	// lower+trim 与 api.go 里的 msg_type 处理保持一致——避免发送方误用大小写
+	// 变体把合法事件（"Issue.Status_Changed"）静默降级成 200 skip(event)
+	// (yujiawei review P2-2)。事件名按 multica 契约本就是 lowercase-dotted 枚举，
+	// 这里做规范化只是 defense-in-depth。
+	event := strings.ToLower(strings.TrimSpace(ev.Event))
 	if event == "" {
 		// 缺 event 字段是「配置错误」（不像合法 multica 出站流量），与 github
 		// 适配器缺 X-GitHub-Event 头同语义——复用同一个 no_event 原因码，让
@@ -122,8 +126,12 @@ func parseMulticaPush(_ http.Header, body []byte) (*pushPayloadReq, string, stri
 //     当作斜体。
 //   - actor 名当前不在 envelope 里，只渲染 type（"by agent" / "by member"）；
 //     未显示触发者类型的情况下省略尾注。
-//   - 标题里的 `[` / `]` 经 mdLinkText 转义（即便当前没拼成链接也防御性
-//     处理，未来加链接时不必再回头改）。
+//   - title 在 `** identifier ** title:` 的「裸文本」上下文（注意：与 github
+//     适配器的 title 不同——github 把 title 包进 `[text](url)` 链接里，所以那边
+//     用只转 `\[]` 的 mdLinkText 是对的；这里 title 不进链接，必须用
+//     mdInertText 才能把 `*`/反引号/`<`/`|` 等元字符也防住，否则一个含反引号
+//     的 title 会让 content 里反引号总数变奇数、把后面的 status code-span 切坏，
+//     一个含 `**` 的 title 会注入真粗体（yujiawei review P1）。
 //   - 其余进 markdown 的字段按上下文走对应 helper（详见 adapter.go 注释）：
 //   - identifier 在 `**...**` 粗体里 → mdInertText（转义 `*` 防止 bold-break，
 //     转义 `[]` 防止 link injection）；
@@ -153,9 +161,11 @@ func renderMulticaIssueStatusChanged(ev muEnvelope) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "**%s**", mdInertText(id, shortFieldMax))
 	if title != "" {
-		// 钳到 200 rune 与 GitHub PR/issue 标题渲染保持一致。
+		// 钳到 200 rune 与 GitHub PR/issue 标题渲染保持一致；用 mdInertText 而
+		// 非 mdLinkText——title 在这里是裸文本，不在 `[text](url)` 里（详见上方
+		// 设计取舍）。
 		b.WriteString(" ")
-		b.WriteString(mdLinkText(title, 200))
+		b.WriteString(mdInertText(title, 200))
 	}
 	b.WriteString(": ")
 	if prev != "" && prev != status {

--- a/modules/incomingwebhook/adapter_multica_test.go
+++ b/modules/incomingwebhook/adapter_multica_test.go
@@ -76,6 +76,68 @@ func TestParseMulticaPush_TitleEscaping(t *testing.T) {
 	assert.Contains(t, req.Content, `\[enter\]`, "brackets must be markdown-escaped (mdLinkText)")
 }
 
+// 非链接上下文的字段（identifier 在 bold、actor.type 在 plain text）必须经
+// mdInertText 转义；status 在 backtick code span 走 mdCodeSpanText 单独 strip
+// 反引号。否则一个带 `*` 的 identifier 可以提前闭合 **...**、带反引号的 status
+// 可以逃出 code span、带 `[...](url)` 的 actor 可以注入链接。三位 reviewer
+// (Jerry-Xin / yujiawei / mochashanyao) 都点了这道防御。
+func TestParseMulticaPush_IdentifierMarkdownEscaping(t *testing.T) {
+	body := []byte(`{
+		"event": "issue.status_changed",
+		"issue": {"identifier": "MUL-1** [phish](http://evil.com) **", "title": "ok", "status": "done"},
+		"previous_status": "todo"
+	}`)
+	req, skip, invalid := parseMulticaPush(http.Header{}, body)
+	require.NotNil(t, req, "skip=%q invalid=%q", skip, invalid)
+	// `*` 必须被反斜杠转义，否则会提前关闭 **...** 的粗体并让后面的 `[phish](...)`
+	// 渲染成 markdown 链接。
+	assert.Contains(t, req.Content, `\*\*`,
+		"asterisks in identifier must be escaped to prevent bold-break + link injection")
+	assert.Contains(t, req.Content, `\[phish\]`,
+		"square brackets in identifier must be escaped to prevent link injection")
+	assert.NotContains(t, req.Content, `[phish](`,
+		"un-escaped link syntax must not leak through")
+}
+
+func TestParseMulticaPush_StatusBacktickStripping(t *testing.T) {
+	// status 渲染在 `...` code span 内；嵌入反引号无法用 \\` 安全转义
+	// （单 backtick fence 里 \\` 仍是字面反斜杠），按契约 strip 反引号
+	// （mdCodeSpanText 行为）。
+	body := []byte(`{
+		"event": "issue.status_changed",
+		"issue": {"identifier": "MUL-1", "title": "x", "status": "in_pro` + "`" + `gress"},
+		"previous_status": "to` + "`" + `do"
+	}`)
+	req, _, _ := parseMulticaPush(http.Header{}, body)
+	require.NotNil(t, req)
+	// 反引号被剥后 status="in_progress"、prev="todo"，渲染成 `todo` → `in_progress`。
+	// 关键不变量：原始反引号不能在最终 content 中以「跨 code-span 的 ` 字符」形式
+	// 出现，否则就破坏了 code span。
+	assert.Contains(t, req.Content, "`todo` → `in_progress`",
+		"backticks inside status/previous_status must be stripped, restoring the normal display")
+	// 进一步钉一下：内容里 ` 的总数必须是偶数（成对开闭 code span），
+	// 不应因 strip 出现奇数个反引号导致开/闭不平衡。
+	assert.Equalf(t, 0, strings.Count(req.Content, "`")%2,
+		"backticks must remain balanced (got odd count): %q", req.Content)
+}
+
+func TestParseMulticaPush_ActorTypeMarkdownEscaping(t *testing.T) {
+	// actor.type 在 `(by X)` 纯文本上下文；带 `[label](url)` 的恶意值必须
+	// 不能拼出可点链接。
+	body := []byte(`{
+		"event": "issue.status_changed",
+		"actor": {"type": "agent [click](http://evil.com)", "id": "a-1"},
+		"issue": {"identifier": "MUL-2", "title": "x", "status": "done"},
+		"previous_status": "todo"
+	}`)
+	req, _, _ := parseMulticaPush(http.Header{}, body)
+	require.NotNil(t, req)
+	assert.Contains(t, req.Content, `\[click\]`,
+		"square brackets in actor.type must be escaped to prevent link injection")
+	assert.NotContains(t, req.Content, `(click)(http`,
+		"the un-escaped link syntax must not survive")
+}
+
 func TestParseMulticaPush_LongTitleIsClipped(t *testing.T) {
 	// 标题字段由 multica 端控制，长度理论上不受 8KB body cap 约束（短信封下仍能塞下
 	// 几 KB title）；adapter 必须把过长内容钳到 mdLinkText 的 200 rune 范围内，
@@ -109,7 +171,9 @@ func TestParseMulticaPush_MissingEvent(t *testing.T) {
 	req, skip, invalid := parseMulticaPush(http.Header{}, body)
 	assert.Nil(t, req)
 	assert.Empty(t, skip)
-	assert.Equal(t, "json", invalid, "缺 event 字段按 json 拒绝（不是合法 multica 出站流量）")
+	// 与 github 适配器缺 X-GitHub-Event 头同语义——deliveries 里 reason=no_event
+	// 让运维一眼区分「配置错误」vs「事件不在渲染子集内」(yujiawei review P2-2)。
+	assert.Equal(t, "no_event", invalid)
 }
 
 func TestParseMulticaPush_MalformedJSON(t *testing.T) {

--- a/modules/incomingwebhook/adapter_multica_test.go
+++ b/modules/incomingwebhook/adapter_multica_test.go
@@ -1,0 +1,157 @@
+package incomingwebhook
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Multica 适配器纯翻译单测（无 DB/Redis/IM 依赖）。fixture 取自 multica
+// outboundPayload（server/internal/integrations/outwebhook/dispatcher.go）的
+// 字段子集——mu* 结构体本就是白名单解析，多余字段一律忽略。
+
+func TestParseMulticaPush_IssueStatusChanged_FullEnvelope(t *testing.T) {
+	body := []byte(`{
+		"event": "issue.status_changed",
+		"workspace_id": "550e8400-e29b-41d4-a716-446655440000",
+		"actor": {"type": "agent", "id": "agent-7"},
+		"issue": {
+			"identifier": "MUL-123",
+			"title": "Fix login redirect on mobile",
+			"status": "in_progress"
+		},
+		"previous_status": "todo",
+		"delivered_at": "2026-06-22T14:30:45Z"
+	}`)
+	req, skip, invalid := parseMulticaPush(http.Header{}, body)
+	require.NotNil(t, req, "skip=%q invalid=%q", skip, invalid)
+	// 期望渲染：**MUL-123** Fix login redirect on mobile: `todo` → `in_progress` (by agent)
+	assert.Contains(t, req.Content, "**MUL-123**")
+	assert.Contains(t, req.Content, "Fix login redirect on mobile")
+	assert.Contains(t, req.Content, "`todo` → `in_progress`")
+	assert.Contains(t, req.Content, "(by agent)")
+	assert.Empty(t, req.MsgType, "adapters emit the plain-text path")
+}
+
+func TestParseMulticaPush_IssueStatusChanged_NoPreviousStatus(t *testing.T) {
+	// previous_status 缺失（或与当前相同）：不渲染 "→ X" 尾巴。
+	body := []byte(`{
+		"event": "issue.status_changed",
+		"actor": {"type": "member", "id": "u-1"},
+		"issue": {"identifier": "MUL-9", "title": "First issue", "status": "todo"}
+	}`)
+	req, skip, invalid := parseMulticaPush(http.Header{}, body)
+	require.NotNil(t, req, "skip=%q invalid=%q", skip, invalid)
+	assert.Contains(t, req.Content, "**MUL-9**")
+	assert.Contains(t, req.Content, "First issue")
+	assert.Contains(t, req.Content, "`todo`")
+	assert.NotContains(t, req.Content, "→", "no arrow when previous_status is absent")
+	assert.Contains(t, req.Content, "(by member)")
+}
+
+func TestParseMulticaPush_NoActorType(t *testing.T) {
+	// actor.type 缺失：不渲染 "(by …)" 尾巴。
+	body := []byte(`{
+		"event": "issue.status_changed",
+		"issue": {"identifier": "MUL-3", "title": "no actor", "status": "done"},
+		"previous_status": "in_progress"
+	}`)
+	req, _, _ := parseMulticaPush(http.Header{}, body)
+	require.NotNil(t, req)
+	assert.NotContains(t, req.Content, "(by")
+}
+
+func TestParseMulticaPush_TitleEscaping(t *testing.T) {
+	// 标题里出现 `[` / `]`：未来若改为渲染成链接文本必须转义，现在已先转义防御。
+	body := []byte(`{
+		"event": "issue.status_changed",
+		"issue": {"identifier": "MUL-77", "title": "Crash on [enter] key", "status": "done"},
+		"previous_status": "in_progress"
+	}`)
+	req, _, _ := parseMulticaPush(http.Header{}, body)
+	require.NotNil(t, req)
+	assert.Contains(t, req.Content, `\[enter\]`, "brackets must be markdown-escaped (mdLinkText)")
+}
+
+func TestParseMulticaPush_LongTitleIsClipped(t *testing.T) {
+	// 标题字段由 multica 端控制，长度理论上不受 8KB body cap 约束（短信封下仍能塞下
+	// 几 KB title）；adapter 必须把过长内容钳到 mdLinkText 的 200 rune 范围内，
+	// 避免无意义刷屏。
+	longTitle := strings.Repeat("a", 500)
+	body := []byte(`{
+		"event": "issue.status_changed",
+		"issue": {"identifier": "MUL-1", "title": "` + longTitle + `", "status": "done"},
+		"previous_status": "todo"
+	}`)
+	req, _, _ := parseMulticaPush(http.Header{}, body)
+	require.NotNil(t, req)
+	// 收尾应是省略号；总长不应超过钳值（200 rune + 包装）+ 余量
+	assert.Contains(t, req.Content, "…")
+	assert.LessOrEqual(t, len([]rune(req.Content)), 260)
+}
+
+func TestParseMulticaPush_UnknownEventIsSkipped(t *testing.T) {
+	body := []byte(`{
+		"event": "issue.created",
+		"issue": {"identifier": "MUL-1", "title": "new", "status": "todo"}
+	}`)
+	req, skip, invalid := parseMulticaPush(http.Header{}, body)
+	assert.Nil(t, req)
+	assert.Equal(t, "event", skip, "未识别事件 → 200 + auditSkipped(reason=event)，与 github 适配器对称")
+	assert.Empty(t, invalid)
+}
+
+func TestParseMulticaPush_MissingEvent(t *testing.T) {
+	body := []byte(`{"issue": {"identifier": "MUL-1", "title": "x", "status": "todo"}}`)
+	req, skip, invalid := parseMulticaPush(http.Header{}, body)
+	assert.Nil(t, req)
+	assert.Empty(t, skip)
+	assert.Equal(t, "json", invalid, "缺 event 字段按 json 拒绝（不是合法 multica 出站流量）")
+}
+
+func TestParseMulticaPush_MalformedJSON(t *testing.T) {
+	req, skip, invalid := parseMulticaPush(http.Header{}, []byte(`{not json`))
+	assert.Nil(t, req)
+	assert.Empty(t, skip)
+	assert.Equal(t, "json", invalid)
+}
+
+func TestParseMulticaPush_MissingIssueIdentifier(t *testing.T) {
+	// identifier 是渲染最小集，缺失就生成不出可读内容：按 content 拒绝。
+	body := []byte(`{
+		"event": "issue.status_changed",
+		"issue": {"title": "no id", "status": "todo"}
+	}`)
+	req, skip, invalid := parseMulticaPush(http.Header{}, body)
+	assert.Nil(t, req)
+	assert.Empty(t, skip)
+	assert.Equal(t, "content", invalid)
+}
+
+func TestParseMulticaPush_MissingIssueStatus(t *testing.T) {
+	body := []byte(`{
+		"event": "issue.status_changed",
+		"issue": {"identifier": "MUL-1", "title": "no status"}
+	}`)
+	req, skip, invalid := parseMulticaPush(http.Header{}, body)
+	assert.Nil(t, req)
+	assert.Empty(t, skip)
+	assert.Equal(t, "content", invalid)
+}
+
+func TestMulticaAdapter_AdapterRegistration(t *testing.T) {
+	// 钉一下 adapter 全局变量没被改名：name、bodyLimit、parse 必须齐全。
+	assert.Equal(t, adapterMultica, multicaAdapter.name)
+	assert.NotNil(t, multicaAdapter.parse)
+	assert.NotNil(t, multicaAdapter.bodyLimit)
+	assert.Empty(t, multicaAdapter.successExtra, "multica adapter 不附带平台兼容字段")
+}
+
+func TestPublicURLs_HasMulticaEntry(t *testing.T) {
+	urls := publicURLs("iwh_abc", "deadbeef")
+	require.Contains(t, urls, "multica")
+	assert.Equal(t, "/v1/incoming-webhooks/iwh_abc/deadbeef/multica", urls["multica"])
+}

--- a/modules/incomingwebhook/adapter_multica_test.go
+++ b/modules/incomingwebhook/adapter_multica_test.go
@@ -1,6 +1,7 @@
 package incomingwebhook
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 	"testing"
@@ -65,7 +66,8 @@ func TestParseMulticaPush_NoActorType(t *testing.T) {
 }
 
 func TestParseMulticaPush_TitleEscaping(t *testing.T) {
-	// 标题里出现 `[` / `]`：未来若改为渲染成链接文本必须转义，现在已先转义防御。
+	// 标题里出现 `[` / `]`：mdInertText 会把 `[` / `]` 转义成 `\[` / `\]`，
+	// 即便未来 title 改为渲染成链接文本也安全。
 	body := []byte(`{
 		"event": "issue.status_changed",
 		"issue": {"identifier": "MUL-77", "title": "Crash on [enter] key", "status": "done"},
@@ -73,7 +75,85 @@ func TestParseMulticaPush_TitleEscaping(t *testing.T) {
 	}`)
 	req, _, _ := parseMulticaPush(http.Header{}, body)
 	require.NotNil(t, req)
-	assert.Contains(t, req.Content, `\[enter\]`, "brackets must be markdown-escaped (mdLinkText)")
+	assert.Contains(t, req.Content, `\[enter\]`, "brackets must be markdown-escaped")
+}
+
+// title 在「**identifier** title:」上下文是裸文本（不在 `[text](url)` 链接里），
+// 必须用 mdInertText 而非 mdLinkText 才能把 `*` / 反引号 / `<` / `|` 等元字符
+// 也防住。yujiawei review P1 给出了 4 个具体注入向量，每个要 hold。
+func TestParseMulticaPush_TitleInjectionVectors(t *testing.T) {
+	cases := []struct {
+		name        string
+		title       string
+		mustContain []string // 修复后期望出现的转义序列
+		mustNot     []string // 修复前漏掉的原始注入串
+	}{
+		{
+			name:        "asterisk_pair_injects_bold",
+			title:       "**hijack**",
+			mustContain: []string{`\*\*hijack\*\*`},
+			mustNot:     []string{"**hijack**"},
+		},
+		{
+			name:    "backtick_breaks_status_code_span",
+			title:   "a `b",
+			mustNot: []string{"a `b"}, // 反引号必须被剥（mdInertText 行为），否则总反引号数变奇数
+		},
+		{
+			name:        "html_autolink",
+			title:       "<script>alert(1)</script>",
+			mustContain: []string{`\<script\>`, `\</script\>`},
+		},
+		{
+			name:        "pipe_breaks_tables",
+			title:       "a | b",
+			mustContain: []string{`a \| b`},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := json.Marshal(map[string]any{
+				"event":           "issue.status_changed",
+				"actor":           map[string]any{"type": "member", "id": "u-1"},
+				"issue":           map[string]any{"identifier": "MUL-1", "title": tc.title, "status": "in_progress"},
+				"previous_status": "todo",
+			})
+			require.NoError(t, err)
+			req, _, _ := parseMulticaPush(http.Header{}, body)
+			require.NotNil(t, req)
+			for _, want := range tc.mustContain {
+				assert.Containsf(t, req.Content, want,
+					"escape must produce %q; got %q", want, req.Content)
+			}
+			for _, bad := range tc.mustNot {
+				assert.NotContainsf(t, req.Content, bad,
+					"raw injection sequence %q must not survive; got %q", bad, req.Content)
+			}
+			// 总反引号数始终偶数（成对开闭）—— mdCodeSpanText 已经在 status 字段
+			// 把反引号剥光；现在 title 也走 mdInertText 同样剥光，所以一个含反
+			// 引号的 title 不会让 content 反引号总数变奇数破坏 status code-span。
+			assert.Equalf(t, 0, strings.Count(req.Content, "`")%2,
+				"backticks must remain balanced (got odd count): %q", req.Content)
+		})
+	}
+}
+
+// 事件名 lower+trim 后匹配——与 msg_type 处理保持一致，避免大小写变体被静默
+// 折叠成 skip(event)（yujiawei review P2-2）。
+func TestParseMulticaPush_EventCaseInsensitive(t *testing.T) {
+	for _, name := range []string{"Issue.Status_Changed", "ISSUE.STATUS_CHANGED", " issue.status_changed "} {
+		t.Run(name, func(t *testing.T) {
+			body, err := json.Marshal(map[string]any{
+				"event":           name,
+				"actor":           map[string]any{"type": "member", "id": "u-1"},
+				"issue":           map[string]any{"identifier": "MUL-1", "title": "x", "status": "done"},
+				"previous_status": "todo",
+			})
+			require.NoError(t, err)
+			req, skip, invalid := parseMulticaPush(http.Header{}, body)
+			require.NotNilf(t, req, "case-variant event must render; skip=%q invalid=%q", skip, invalid)
+		})
+	}
 }
 
 // 非链接上下文的字段（identifier 在 bold、actor.type 在 plain text）必须经

--- a/modules/incomingwebhook/adapter_push_test.go
+++ b/modules/incomingwebhook/adapter_push_test.go
@@ -215,8 +215,11 @@ func TestPush_MulticaUnsupportedEvent_Skipped(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"skipped":"event"`)
 }
 
-// 缺 event 字段 → 400 invalid（reason=no_event，与 github 适配器对称——
-// 误配置要立刻可见，而非折叠成通用 json 错误）。
+// 缺 event 字段 → 400 invalid（reason=no_event 由 pushPayloadInvalid 路由，
+// 在 TestPushPayloadInvalidSurfacesReason 钉死；此处 e2e 不能断言 body 里的
+// reason 字段——testutil.NewTestServer 不挂 i18n ErrorRenderer，e2e 响应只
+// 渲染成 legacy {msg,status} 形态，details 不出现，详见 api_i18n_test.go
+// TestPushPayloadInvalidSurfacesReason 旁的注释）。
 func TestPush_MulticaMissingEvent_NoEventReason(t *testing.T) {
 	handler, _, groupNo := setupTestEnv(t)
 	whID, token := createWebhookWithToken(t, handler, groupNo)
@@ -224,6 +227,4 @@ func TestPush_MulticaMissingEvent_NoEventReason(t *testing.T) {
 	w := pushAdapterRaw(handler, whID, token, "multica",
 		[]byte(`{"issue":{"identifier":"MUL-1","title":"x","status":"todo"}}`), nil)
 	require.Equalf(t, http.StatusBadRequest, w.Code, "missing event must 400; body=%s", w.Body.String())
-	assert.Contains(t, w.Body.String(), `"reason":"no_event"`,
-		"missing event must use the same no_event reason as github adapter (yujiawei review P2-2)")
 }

--- a/modules/incomingwebhook/adapter_push_test.go
+++ b/modules/incomingwebhook/adapter_push_test.go
@@ -41,6 +41,7 @@ func TestCreate_ReturnsAdapterURLs(t *testing.T) {
 	assert.Equal(t, created["url"], native, "urls.native must equal the legacy url field")
 	assert.Equal(t, native+"/github", urls["github"])
 	assert.Equal(t, native+"/wecom", urls["wecom"])
+	assert.Equal(t, native+"/multica", urls["multica"])
 }
 
 // GitHub ping：200 + skipped，不投递消息，且异步记一条 status=3(skipped) 的投递。
@@ -114,7 +115,7 @@ func TestPush_AdapterRoute_AuthEnforced(t *testing.T) {
 	handler, _, groupNo := setupTestEnv(t)
 	whID, _ := createWebhookWithToken(t, handler, groupNo)
 
-	for _, suffix := range []string{"github", "wecom"} {
+	for _, suffix := range []string{"github", "wecom", "multica"} {
 		w := pushAdapterRaw(handler, whID, "wrong-token", suffix,
 			[]byte(`{"msgtype":"text","text":{"content":"hi"}}`),
 			map[string]string{"X-GitHub-Event": "push"})
@@ -180,4 +181,49 @@ func TestPush_WeComImage_Rejected(t *testing.T) {
 	w := pushAdapterRaw(handler, whID, token, "wecom",
 		[]byte(`{"msgtype":"image","image":{"base64":"...","md5":"..."}}`), nil)
 	assert.Equalf(t, http.StatusBadRequest, w.Code, "wecom image must 400; body=%s", w.Body.String())
+}
+
+// Multica issue.status_changed envelope 通过鉴权/翻译；成功响应含 message_id
+// 且不带平台兼容字段（multica 适配器无 successExtra）。
+func TestPush_MulticaIssueStatusChanged_Delivers(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	w := pushAdapterRaw(handler, whID, token, "multica",
+		[]byte(`{"event":"issue.status_changed","actor":{"type":"member","id":"u-1"},`+
+			`"issue":{"identifier":"MUL-123","title":"Fix login redirect","status":"in_progress"},`+
+			`"previous_status":"todo"}`), nil)
+	assert.NotEqualf(t, http.StatusBadRequest, w.Code, "valid multica envelope must translate; body=%s", w.Body.String())
+	assert.NotEqualf(t, http.StatusUnauthorized, w.Code, "valid token must authorize; body=%s", w.Body.String())
+	if w.Code == http.StatusOK {
+		assert.Contains(t, w.Body.String(), "message_id")
+		// multica 不附带 errcode/errmsg（与 native 同，区别于 wecom）。
+		assert.NotContains(t, w.Body.String(), `"errcode"`)
+	}
+}
+
+// 渲染子集之外的 multica 事件（issue.created 等）→ 200 + skipped=event，
+// 与 github 适配器对称。
+func TestPush_MulticaUnsupportedEvent_Skipped(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	w := pushAdapterRaw(handler, whID, token, "multica",
+		[]byte(`{"event":"issue.created","issue":{"identifier":"MUL-1","title":"new","status":"todo"}}`),
+		nil)
+	require.Equalf(t, http.StatusOK, w.Code, "unsupported event must 200; body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), `"skipped":"event"`)
+}
+
+// 缺 event 字段 → 400 invalid（reason=no_event，与 github 适配器对称——
+// 误配置要立刻可见，而非折叠成通用 json 错误）。
+func TestPush_MulticaMissingEvent_NoEventReason(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	w := pushAdapterRaw(handler, whID, token, "multica",
+		[]byte(`{"issue":{"identifier":"MUL-1","title":"x","status":"todo"}}`), nil)
+	require.Equalf(t, http.StatusBadRequest, w.Code, "missing event must 400; body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), `"reason":"no_event"`,
+		"missing event must use the same no_event reason as github adapter (yujiawei review P2-2)")
 }

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -224,10 +224,12 @@ func (w *IncomingWebhook) Route(r *wkhttp.WKHttp) {
 			return []wkhttp.HandlerFunc{w.requirePushEnabled(), w.localFloorMiddleware(), ipLimit, w.ipFailureGateMiddleware(), h}
 		}
 		push.POST("/incoming-webhooks/:webhook_id/:token", chain(w.push)...)
-		// 平台适配器（#297 Phase 3）：GitHub 事件 / 企业微信群机器人格式。鉴权、限流、
-		// 群校验与 native 完全一致，仅 body 解析不同（adapter_github.go / adapter_wecom.go）。
+		// 平台适配器（#297 Phase 3 / #426）：GitHub 事件 / 企业微信群机器人格式 / Multica
+		// 出站 webhook。鉴权、限流、群校验与 native 完全一致，仅 body 解析不同
+		// （adapter_github.go / adapter_wecom.go / adapter_multica.go）。
 		push.POST("/incoming-webhooks/:webhook_id/:token/github", chain(w.pushGitHub)...)
 		push.POST("/incoming-webhooks/:webhook_id/:token/wecom", chain(w.pushWeCom)...)
+		push.POST("/incoming-webhooks/:webhook_id/:token/multica", chain(w.pushMultica)...)
 	}
 }
 
@@ -237,6 +239,7 @@ func (w *IncomingWebhook) Route(r *wkhttp.WKHttp) {
 // 处理器可从 c.MustGet("uid") 取到操作者身份：
 //   - 用户侧（本模块 Route）：AuthMiddleware 写入登录 uid；
 //   - bot 侧（bot_api 模块）：authBot 后由适配中间件把 robot_id 写入 "uid"。
+//
 // 权限矩阵由 resolveActor + 各 handler 的所有权判断统一实施，与挂载面无关。
 func (w *IncomingWebhook) MountManagementRoutes(g *wkhttp.RouterGroup) {
 	// 总开关(system_setting incomingwebhook.enabled)关闭时，写操作一律 403 拒绝，
@@ -391,14 +394,15 @@ func publicURL(webhookID, token string) string {
 	return fmt.Sprintf("/v1/incoming-webhooks/%s/%s", webhookID, token)
 }
 
-// publicURLs 构造各推送形态的对外路径（#297 顺延的 onboarding 项）：native 即历史
-// 契约的 url 字段，github / wecom 为平台适配器后缀。与 publicURL 一样不含 host。
+// publicURLs 构造各推送形态的对外路径（#297 顺延的 onboarding 项 / #426）：native 即
+// 历史契约的 url 字段，github / wecom / multica 为平台适配器后缀。与 publicURL 一样不含 host。
 func publicURLs(webhookID, token string) map[string]string {
 	base := publicURL(webhookID, token)
 	return map[string]string{
-		"native": base,
-		"github": base + "/github",
-		"wecom":  base + "/wecom",
+		"native":  base,
+		"github":  base + "/github",
+		"wecom":   base + "/wecom",
+		"multica": base + "/multica",
 	}
 }
 
@@ -1067,11 +1071,12 @@ func (w *IncomingWebhook) failAuth(c *wkhttp.Context, ip string) {
 	pushUnauthorized(c)
 }
 
-// push / pushGitHub / pushWeCom 是三种推送形态的路由入口，全部走 handlePush 流水线，
-// 只差 body 解析（pushAdapter.parse，见 adapter.go）。
-func (w *IncomingWebhook) push(c *wkhttp.Context)       { w.handlePush(c, nativeAdapter) }
-func (w *IncomingWebhook) pushGitHub(c *wkhttp.Context) { w.handlePush(c, githubAdapter) }
-func (w *IncomingWebhook) pushWeCom(c *wkhttp.Context)  { w.handlePush(c, wecomAdapter) }
+// push / pushGitHub / pushWeCom / pushMultica 是各种推送形态的路由入口，全部走 handlePush
+// 流水线，仅在 adapter（body 解析 / bodyLimit / successExtra）上分叉。
+func (w *IncomingWebhook) push(c *wkhttp.Context)        { w.handlePush(c, nativeAdapter) }
+func (w *IncomingWebhook) pushGitHub(c *wkhttp.Context)  { w.handlePush(c, githubAdapter) }
+func (w *IncomingWebhook) pushWeCom(c *wkhttp.Context)   { w.handlePush(c, wecomAdapter) }
+func (w *IncomingWebhook) pushMultica(c *wkhttp.Context) { w.handlePush(c, multicaAdapter) }
 
 func (w *IncomingWebhook) handlePush(c *wkhttp.Context, ad pushAdapter) {
 	// 仅用于"鉴权失败才计入"的 per-IP 失败预算（见 failAuth / ipFailureGateMiddleware）。

--- a/modules/incomingwebhook/api_i18n_test.go
+++ b/modules/incomingwebhook/api_i18n_test.go
@@ -20,7 +20,7 @@ import (
 // file to the list below.
 func TestIncomingWebhookNoLegacyResponseError(t *testing.T) {
 	files := []string{"api.go", "api_i18n.go", "ratelimit.go", "localfloor.go", "cache.go",
-		"adapter.go", "adapter_github.go", "adapter_wecom.go"}
+		"adapter.go", "adapter_github.go", "adapter_wecom.go", "adapter_multica.go"}
 	banned := []string{
 		".ResponseError(",
 		".ResponseErrorf(",

--- a/modules/incomingwebhook/model.go
+++ b/modules/incomingwebhook/model.go
@@ -135,7 +135,7 @@ type createResp struct {
 	webhookResp
 	Token string `json:"token"`
 	URL   string `json:"url"`
-	// URLs 各推送形态的路径（native / github / wecom），与 URL 一样不含 host、由前端
+	// URLs 各推送形态的路径（native / github / wecom / multica），与 URL 一样不含 host、由前端
 	// 拼接基础域名。token 仅在 create/regenerate 时可见，故完整推送路径也只在这两处
 	// 下发（list 不回显 token，自然也不回推送 URL）。
 	URLs map[string]string `json:"urls"`

--- a/modules/incomingwebhook/model.go
+++ b/modules/incomingwebhook/model.go
@@ -46,10 +46,11 @@ const (
 
 // 投递来源/适配器（auditModel.Adapter）。后续扩展 gitlab/feishu。
 const (
-	adapterNative = "native" // 原生推送端点
-	adapterTest   = "test"   // 管理端「测试推送」
-	adapterGitHub = "github" // GitHub 事件适配器（#297 Phase 3）
-	adapterWeCom  = "wecom"  // 企业微信群机器人格式适配器（#297 Phase 3）
+	adapterNative  = "native"  // 原生推送端点
+	adapterTest    = "test"    // 管理端「测试推送」
+	adapterGitHub  = "github"  // GitHub 事件适配器（#297 Phase 3）
+	adapterWeCom   = "wecom"   // 企业微信群机器人格式适配器（#297 Phase 3）
+	adapterMultica = "multica" // Multica 出站 webhook 适配器（#426）
 )
 
 // auditModel 对应 incoming_webhook_audit 表，记录【鉴权通过后】的每次投递结果
@@ -63,7 +64,7 @@ type auditModel struct {
 	Status     int    // auditSuccess / auditFailed / auditSkipped
 	Reason     string // 失败/跳过原因码；成功为空
 	HTTPStatus int    // 返回给调用方的 HTTP 状态码
-	Adapter    string // 来源/适配器：adapterNative / adapterTest / adapterGitHub / adapterWeCom
+	Adapter    string // 来源/适配器：adapterNative / adapterTest / adapterGitHub / adapterWeCom / adapterMultica
 	db.BaseModel
 }
 

--- a/modules/incomingwebhook/sql/20260622000001_incomingwebhook_multica_adapter_comment.sql
+++ b/modules/incomingwebhook/sql/20260622000001_incomingwebhook_multica_adapter_comment.sql
@@ -1,0 +1,12 @@
+-- +migrate Up
+
+-- #426 / PR #427：新增 multica 出站 webhook 适配器（adapter_multica.go）。
+-- adapter 列新增取值 multica；status / reason 列无变化。仅刷新 COMMENT 让 schema
+-- 自文档化（同 20260610000001 / 20260618000001 的做法）。目标库 MySQL 8.0：仅改
+-- COMMENT 的 MODIFY COLUMN 走 INSTANT 算法、瞬时无锁。
+ALTER TABLE `incoming_webhook_audit`
+  MODIFY COLUMN `adapter` VARCHAR(16) NOT NULL DEFAULT 'native' COMMENT '消息来源/适配器：native/test/github/wecom/multica（后续扩展 gitlab/feishu）';
+
+-- +migrate Down
+ALTER TABLE `incoming_webhook_audit`
+  MODIFY COLUMN `adapter` VARCHAR(16) NOT NULL DEFAULT 'native' COMMENT '消息来源/适配器：native/test/github/wecom（后续扩展 gitlab/feishu）';


### PR DESCRIPTION
Closes #426.

## Summary
- Adds `POST /v1/incoming-webhooks/:webhook_id/:token/multica`, a fourth platform adapter parallel to `/github` and `/wecom`.
- Translates Multica's fixed outbound webhook envelope (`{event, workspace_id, actor, issue, previous_status, …}`) into a native markdown push so the message lands in the group as e.g. `**MUL-123** Fix login redirect: \`todo\` → \`in_progress\` (by agent)`.
- v1 only recognizes `issue.status_changed`; other events return `200 + {"skipped":"event"}` (same contract as `/github`'s rendering-subset behavior). Future events (`issue.created`, `comment.created`, …) are additive — just add a `case` to the renderer.
- `publicURLs` returns a `multica` entry alongside `native`/`github`/`wecom` so create/regenerate responses include the new path.
- Body cap stays at the native 8 KiB (Multica envelopes are far smaller than github event payloads — no need for the 1 MiB github cap).
- HMAC verification of `X-Multica-Signature-256` left for a follow-up (same status as `X-Hub-Signature-256` on the github adapter).

## Test plan
- [x] `go test ./modules/incomingwebhook/ -run 'TestParseMulticaPush|TestMulticaAdapter|TestPublicURLs'` — 12 new unit tests pass (parse + render for `issue.status_changed`, unknown event → `skip=event`, missing `event` / malformed JSON → `invalid=json`, missing required `identifier`/`status` → `invalid=content`, title escaping, long-title clipping, adapter registration, urls map).
- [x] Live E2E against the OOTB OCTO Docker stack from `Mininglamp-OSS/octo-deployment`:
  - Built `octo-server:multica-adapter` from this branch.
  - Brought up the stack, registered a user, created a group + incoming webhook.
  - POSTed sample multica envelopes via curl: success returns `200 {"status":0,"message_id":<int>}`; unknown event returns `200 {"skipped":"event"}`; missing identifier returns `400 reason=content`; malformed JSON returns `400 reason=json`.
  - Drove the multica side end-to-end (companion PR Mininglamp-OSS/multica#39, see "E2E harness" commit there): real `*outwebhook.Dispatcher` signed and POSTed the envelope to this adapter, the message landed in the group, and both sides' audit logs reconcile (`adapter=multica, status=1, http_status=200` on octo; `status=delivered, response_status=200` on multica).

## Out of scope
- HMAC signature verification of `X-Multica-Signature-256`.
- Renders for additional multica events beyond `issue.status_changed` (additive once multica emits them).