### PR TITLE
refactor(auth): add Lookup interfaces in modules/auth + impls in bot_api/usersecret

### DIFF
--- a/.octospec/journal/shared/auth-lookup-interfaces.md
+++ b/.octospec/journal/shared/auth-lookup-interfaces.md
@@ -1,0 +1,137 @@
+---
+type: Journal
+title: "Journal: auth-lookup-interfaces (octo-server #428)"
+description: Add BotLookup / APIKeyLookup consumer-defined interfaces in modules/auth, implement them in bot_api / usersecret, and lock the dependency direction with an in-tree guard test.
+tags: ["auth", "modules", "refactor", "interfaces"]
+timestamp: 2026-06-22T00:00:00Z
+task: auth-lookup-interfaces
+source: self
+---
+# Journal: auth-lookup-interfaces (octo-server #428)
+
+## What was done
+
+Established the in-tree seam between `modules/auth` (Resource-Server
+verify handlers, landing in PR-A3) and its identity sources
+(`modules/bot_api`, `modules/usersecret`) using the Go-idiomatic
+**consumer-defined interfaces** pattern. Dependency direction is
+locked one-way (bot_api / usersecret → auth) and enforced by an in-tree
+guard test. This is PR-A2 of the Stage A epic (#428).
+
+- `modules/auth/lookup.go` — declares `UserBotIdentity`,
+  `AppBotIdentity`, `APIKeyIdentity` (field names align 1:1 with
+  plan §4.1.2 / §4.1.3 verify response shapes), plus the
+  `BotLookup` and `APIKeyLookup` interfaces modules/auth's HTTP
+  handlers will call. Both interfaces document the same contract:
+  `(nil, nil)` is the "no match" signal, non-nil error is reserved
+  for infrastructure failures (must map to
+  AUTH_UPSTREAM_UNAVAILABLE).
+- `modules/auth/sentinels.go` — adds `ErrAppBotUnpublished` so the
+  "bot exists but status != 1" event flows out of the Lookup layer
+  as a typed sentinel rather than being collapsed into "no match".
+  PR-A3 will map this to AUTH_BOT_UNAVAILABLE (503) per plan §4.2.
+- `modules/auth/imports_test.go` — guard test using `go/parser` to
+  walk every non-test `.go` file under `modules/auth/` and fail on
+  any import path beginning with the forbidden prefixes
+  (`modules/{user,bot_api,usersecret,oidc}`). Replaces the plan's
+  proposed `depguard` lint rule because the repo's `.golangci.yml`
+  is in a deliberately minimal "post-recovery" profile (only
+  `govet` enabled, see the top-of-file comment); a Go test that
+  travels with the package it guards is harder to silently disable
+  than a lint config a contributor can comment out. Runs in CI via
+  `go test ./...` with no extra wiring.
+- `modules/bot_api/lookup.go` — `LookupUserBot` wraps
+  `db.queryRobotByBotToken` (zero SQL change vs the existing
+  authUserBot path); `LookupAppBot` preserves the two-tier
+  lookup (in-memory Registry first via `lookupAppBotRegistry`, DB
+  fallback via `db.queryAppBotByToken`), including the `status != 1`
+  → `ErrAppBotUnpublished` mapping that matches the existing
+  authAppBot:93 semantics. Compile-time assertion
+  `var _ auth.BotLookup = (*BotAPI)(nil)` pins the interface.
+- `modules/usersecret/lookup.go` — `LookupAPIKey` STUB that returns
+  `(nil, nil)` for any input. The brief documents (and the stub
+  comment reiterates) that real `uk_` API Key storage does not yet
+  exist in octo-server — the existing `user_secret_alias` table is
+  for user-owned third-party secrets accessed via the resolve
+  endpoint, a different concept from "daemon API keys". Fleet's
+  existing call to `/v1/auth/verify-api-key` is a ghost endpoint
+  that has always 404'd; PR-A4 will make it a real endpoint that
+  returns AUTH_TOKEN_INVALID (401) until a future PR ships real
+  storage. Compile-time assertion
+  `var _ auth.APIKeyLookup = (*API)(nil)` ensures the stub
+  signature stays interface-compatible.
+
+No HTTP route, errcode, or handler is added in this PR; the new
+interfaces have zero callers until PR-A3 wires them up in
+`main.go`. The existing authUserBot / authAppBot middleware in
+`modules/bot_api/auth.go` is untouched — it stays the path for
+bot-authenticated Bot API endpoints, and the new Lookup methods are
+a parallel surface for modules/auth's verify handlers. This
+intentional parallelism (rather than refactoring authUserBot /
+authAppBot to use the new Lookup methods) keeps PR-A2's blast
+radius minimal; consolidation is a future cleanup outside the
+Stage A scope.
+
+## octospec rules injected (see context.yaml)
+
+- **space-isolation** (load-bearing): AppBotIdentity.Scope / SpaceID
+  drive PR-A3's response, which in turn drives SDK fail-closed
+  Space checks at the caller. The DB→identity mapping preserves the
+  existing authAppBot semantics byte-for-byte (registry-hit path
+  exposes Scope/SpaceID minimally; DB-fallback path includes
+  full owner / name; SpaceID only populated when Scope=="space").
+- **error-handling** (load-bearing): identity struct field names
+  match plan §4.1.2 / §4.1.3 1-to-1 so PR-A3 is trivial mapping.
+  ErrAppBotUnpublished is the typed sentinel for the
+  AUTH_BOT_UNAVAILABLE (503) error code PR-A3 will register. No
+  httperr / errcode / ResponseError* surface touched; i18n gates
+  stay no-op.
+- **testing**: imports_test.go is a self-contained AST walker (no
+  DB / Redis / WuKongIM dependency); compile-time
+  `var _ auth.X = (*Y)(nil)` assertions catch signature drift at
+  build time rather than relying on a downstream test to fire.
+
+## Verification
+
+- `go build ./...` — clean
+- `go vet ./modules/auth/... ./modules/bot_api/... ./modules/usersecret/...`
+  — clean
+- `go test ./modules/auth/... ./modules/bot_api/... ./modules/usersecret/...`
+  — PASS (with fresh DB for usersecret integration tests)
+- `golangci-lint run ./...` — 0 issues across whole repo
+- `make i18n-extract-check` + `make i18n-lint` — green
+- Full per-package `go test -race -shuffle=on -count=1 -timeout 5m`
+  loop with DROP+CREATE DB + FLUSHALL between packages: **77 of 80
+  pass** — exactly the same fingerprint as PR-A1 (same three
+  pre-existing failures in `modules/{botfather,channel,robot}`
+  tracked under #17, unrelated to auth changes).
+- `imports_test.go` actually fires: artificially adding a forbidden
+  import (`_ "github.com/Mininglamp-OSS/octo-server/modules/user"`)
+  to `modules/auth/doc.go` triggers a test failure with a clear
+  diagnostic; reverting restores green. (Sanity-checked locally;
+  not committed.)
+
+## Lessons
+
+- **Consumer-defined interfaces over depguard for one-package
+  invariants**. Adding a depguard rule to enforce "package X must
+  not import Y" works for big codebases with active lint config,
+  but for a single architectural seam an in-tree guard test
+  (`go/parser` + walk imports) is sturdier: it lives next to the
+  package it guards, fails in the same CI step as other tests,
+  and can't be silently disabled by a config tweak. Recommended
+  pattern for future Resource-Server-style splits.
+- **Compile-time interface assertions catch drift faster than
+  runtime DI failures**. `var _ auth.BotLookup = (*BotAPI)(nil)`
+  fails at `go build` if either the interface or the
+  implementation drifts. Cheaper than waiting for main.go's
+  wiring to error at boot, and the failure points directly at
+  the implementer file rather than at the wiring site.
+- **Stubs need typed return contracts**, not just empty bodies.
+  Returning `(nil, nil)` from the stub `LookupAPIKey` works only
+  because the interface documents that as the "no match" signal
+  — without that documented contract, the stub would silently
+  morph the verify-api-key handler's error-mapping logic the day
+  real storage lands. Explicit nil-nil documentation +
+  compile-time interface assertion together give the stub a
+  forward-compatible shape.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -6,6 +6,12 @@ change-log convention (§7). Newest first.
 
 ## 2026-06-22
 
+- **Creation** — Added task `auth-lookup-interfaces` (`.octospec/tasks/auth-lookup-interfaces/`):
+  PR-A2 of Stage A epic (octo-server #428). Adds `BotLookup` / `APIKeyLookup`
+  consumer-defined interfaces in `modules/auth`, implements them in
+  `modules/bot_api` and `modules/usersecret`, and locks the dependency
+  direction with an in-tree `imports_test.go` guard. Journal:
+  `.octospec/journal/shared/auth-lookup-interfaces.md`.
 - **Creation** — Added task `modules-auth-skeleton` (`.octospec/tasks/modules-auth-skeleton/`):
   brief + context for PR-A1 (octo-server #428). Relocated `pkg/auth/{tokeninfo,parser}` and
   their tests to the new `modules/auth/` package; `pkg/auth/` becomes a Deprecated alias

--- a/.octospec/tasks/auth-lookup-interfaces/brief.md
+++ b/.octospec/tasks/auth-lookup-interfaces/brief.md
@@ -1,0 +1,194 @@
+---
+type: Task
+title: "Task: auth-lookup-interfaces"
+description: Add Lookup interfaces in modules/auth and implement them in bot_api / usersecret so PR-A3's verify handlers can build identity responses without modules/auth importing those packages.
+tags: ["auth", "modules", "refactor", "interfaces", "dependency-direction"]
+timestamp: 2026-06-22T00:00:00Z
+slug: auth-lookup-interfaces
+upstream: "octo-server#428"
+source: self
+---
+
+# Task: auth-lookup-interfaces
+
+## Goal
+
+Define `BotLookup` and `APIKeyLookup` interfaces (plus identity result
+types) in `modules/auth`, and provide implementations in `modules/bot_api`
+and `modules/usersecret`. Add a self-contained guard test in
+`modules/auth/imports_test.go` enforcing the dependency-direction
+invariant (`modules/auth` may NOT import
+`modules/{user,bot_api,usersecret,oidc}`). This is PR-A2 of the Stage A
+refactor (epic #428).
+
+Why now: PR-A3 will implement the `verify` / `verify-bot` handlers inside
+`modules/auth`. Those handlers need to look up a User Bot or App Bot from
+its bot token, and a future API Key from its key value, without
+`modules/auth` importing the implementation packages. The Go-idiomatic
+way to do this is "consumer-defined interfaces" — `modules/auth` declares
+what it needs; `bot_api` / `usersecret` implement those interfaces; the
+wiring happens in `main.go`. This PR establishes that seam.
+
+## Background
+
+- `modules/bot_api/auth.go` already contains `authUserBot` and
+  `authAppBot` (lines 46-105). They each: extract a token, query the
+  underlying DB row, populate Gin context keys. The DB lookup is
+  delegated to `db.queryRobotByBotToken` (User Bot) and
+  `db.queryAppBotByToken` (App Bot), plus an in-memory
+  `lookupAppBotRegistry` O(1) fast path with DB fallback for App Bot.
+- `modules/bot_api/db.go:46` defines `(d *botAPIDB) queryRobotByBotToken`
+  returning `*robotModel`; `:214` defines `queryAppBotByToken` returning
+  `*appBotModel`. Both are package-private.
+- `modules/usersecret/db.go:166` defines `(s *store) queryBotByToken`
+  returning `*botIdentity{RobotID, OwnerUID}` — but that is for the
+  `resolve` endpoint's bot-side authentication, NOT for API Key
+  validation. The plan's `LookupAPIKey(uk_xxx) → identity` does not
+  match any existing storage in `modules/usersecret`: the
+  `user_secret_alias` table stores user-owned third-party secrets
+  (encrypted blobs) consumed by bots via the `resolve` endpoint, not
+  daemon API keys. **There is currently no `uk_` API Key store at all
+  in octo-server.** Fleet's existing call to `/v1/auth/verify-api-key`
+  is a ghost endpoint that has always 404'd.
+- Plan reference: §5.2 (Lookup extraction table) and §5.3 (dependency
+  direction invariant: `modules/auth` ↛ `modules/{user,bot_api,
+  usersecret}` implementation packages).
+
+## Load-bearing list
+
+- **auth**: introduces the boundary interfaces between modules/auth and
+  its identity sources (bot_api, usersecret). The interface shapes will
+  be the contract every future module that wants to be a verify-able
+  identity source plugs into — picking these signatures wrong forces
+  churn in every Stage-A PR that follows. (rules: space-isolation —
+  auth tag)
+- **wire-contract**: `BotLookup` / `APIKeyLookup` are internal Go
+  interfaces, not HTTP wire. But the identity *types*
+  (`UserBotIdentity`, `AppBotIdentity`, `APIKeyIdentity`) feed directly
+  into PR-A3's verify response shape (`schema_version: 1`,
+  `bot_kind` / `scope` / `space_id` / `owner_uid` per plan §4.1.2).
+  Field naming and types must match the SDK contract so PR-A3 is a
+  trivial mapping. (rules: error-handling — wire-contract concerns)
+- **bot-api**: bot_api gains exported methods that satisfy modules/auth
+  interfaces. The underlying DB queries (`queryRobotByBotToken`,
+  `queryAppBotByToken`) are reused; no SQL changes. Bot ownership
+  semantics — User Bot is its own owner, App Bot has an `owner_uid` /
+  `scope` / `space_id` — must round-trip into the identity struct
+  exactly. (rules: space-isolation — bot-api tag)
+- **space + isolation**: `AppBotIdentity` exposes `Scope` (platform /
+  space) and `SpaceID`. PR-A3 will use these to populate the verify
+  response so downstream services can fail-closed on cross-space
+  access. Getting them wrong here would silently widen App Bot
+  visibility. (rules: space-isolation)
+
+## Out of scope
+
+- Implementing `verify` / `verify-bot` / `verify-api-key` HTTP handlers
+  in `modules/auth` — that is PR-A3 and PR-A4.
+- Touching route registration in `modules/user` — PR-A5.
+- Wiring the Lookup implementations into `main.go` — happens in PR-A3
+  when the handlers that consume them land. PR-A2 only exposes the
+  interface and the implementations; no caller exists in this PR.
+- Designing or building the actual `uk_` API Key storage system. Adding
+  a `user_api_key` table, key-generation endpoints, encryption-at-rest,
+  rotation, audit — all out of scope. `LookupAPIKey` lands as a stub
+  that returns `(nil, nil)` (cache miss / not found) with a clear
+  TODO and a typed error sentinel so PR-A4's verify-api-key handler
+  can wire it up and return `AUTH_TOKEN_INVALID` until a future PR
+  ships real key storage.
+- Token model V2 (signed JWT / PASETO / scope claims).
+- depguard `.golangci.yml` config change. The project's golangci-lint
+  is in post-recovery profile with only `govet` enabled (see the
+  comment block at the top of `.golangci.yml`); adding a new linter
+  for one package is out-of-band. An in-tree Go test
+  (`modules/auth/imports_test.go`) using `go/parser` walks the
+  package's own AST and fails on a forbidden import — equally
+  effective, in-CI via `go test ./...`, no lint-config churn.
+
+## Acceptance
+
+- New file `modules/auth/lookup.go` declares:
+  - `type UserBotIdentity struct { BotUID, BotName string }` —
+    minimal fields that map onto plan §4.1.2 `verify-bot` response's
+    User Bot variant (`bot_kind: "user"`).
+  - `type AppBotIdentity struct { BotUID, BotName, OwnerUID,
+    OwnerName, Scope, SpaceID, Language string }` — covers plan §4.1.2
+    App Bot variant including `scope ∈ {platform, space}` and the
+    space binding.
+  - `type APIKeyIdentity struct { UID, KeyID, SpaceID string;
+    OwnedBotsBySpace map[string][]string }` — covers plan §4.1.3
+    response shape; `SpaceID` and `OwnedBotsBySpace` may be empty when
+    no context binding exists.
+  - `type BotLookup interface { LookupUserBot(token string)
+    (*UserBotIdentity, error); LookupAppBot(token string)
+    (*AppBotIdentity, error) }` — single interface owns both bot
+    flavors; an implementer may return `(nil, nil)` to signal "no
+    match", reserving non-nil error for infrastructure failures.
+  - `type APIKeyLookup interface { LookupAPIKey(apiKey string)
+    (*APIKeyIdentity, error) }`.
+  - Documentation in `lookup.go` reiterates the consumer-defined
+    interface pattern and the dependency-direction invariant so the
+    Go-idiom reasoning lives next to the code.
+- New file `modules/bot_api/lookup.go` declares:
+  - `func (ba *BotAPI) LookupUserBot(token string)
+    (*auth.UserBotIdentity, error)` — wraps `ba.db.queryRobotByBotToken`,
+    mapping `*robotModel` → `*UserBotIdentity{BotUID: RobotID,
+    BotName: <RobotName field>}`. Returns `(nil, nil)` on miss; wraps
+    DB errors with package context.
+  - `func (ba *BotAPI) LookupAppBot(token string)
+    (*auth.AppBotIdentity, error)` — preserves the existing two-tier
+    lookup: in-memory registry first via `lookupAppBotRegistry`, DB
+    fallback via `ba.db.queryAppBotByToken`. The `status != 1` check
+    on the DB path becomes a typed sentinel
+    (`ErrAppBotUnpublished` — see below) so PR-A3 can map it to the
+    `AUTH_BOT_UNAVAILABLE` HTTP error.
+  - Compile-time assertion: `var _ auth.BotLookup = (*BotAPI)(nil)`
+    pins the implementation.
+- New file `modules/auth/sentinels.go` extends the sentinel set with
+  `ErrAppBotUnpublished` (Bot exists but `status != 1`). The existing
+  `ErrEmptyToken` / `ErrInvalidToken` stay unchanged. This sentinel
+  is exposed at the modules/auth boundary so neither bot_api nor the
+  future verify handler need to invent their own error code for the
+  same semantic event.
+- New file `modules/usersecret/lookup.go` declares:
+  - `func (a *API) LookupAPIKey(apiKey string)
+    (*auth.APIKeyIdentity, error)` — **stub**: returns `(nil, nil)`
+    for any input (interpreted as "not found"), with a clear TODO
+    comment documenting that real `uk_` API Key storage / lookup is
+    deferred to a future PR. The signature is final and matches
+    `auth.APIKeyLookup` so PR-A4's verify-api-key handler can wire
+    it through without breaking when real storage lands.
+  - Compile-time assertion: `var _ auth.APIKeyLookup = (*API)(nil)`.
+- New file `modules/auth/imports_test.go` is a guard test that parses
+  every non-`_test.go` Go file under `modules/auth/` with `go/parser`
+  and fails if any import path begins with the forbidden prefixes:
+  `github.com/Mininglamp-OSS/octo-server/modules/user`,
+  `.../modules/bot_api`, `.../modules/usersecret`, `.../modules/oidc`.
+  This is the in-tree replacement for the `depguard` rule the plan
+  proposed.
+- `internal/modules.go` is NOT modified — the new methods are
+  package-exported on existing types; no new module registration is
+  added (PR-A5 handles that for `modules/auth`).
+- `go build ./...` clean.
+- `go test ./modules/auth/... ./modules/bot_api/... ./modules/usersecret/...`
+  green.
+- `go test ./...` per-package matrix has the same pass/fail
+  fingerprint as PR-A1: the three known broken packages
+  (`modules/{botfather,channel,robot}`) fail identically; nothing
+  else regresses.
+- `make i18n-extract-check` + `make i18n-lint` green.
+- `golangci-lint run ./...` 0 issues.
+
+## Verification
+
+1. `make env-test` (or equivalent docker stack on default ports).
+2. Loop: drop+create `test` DB, `redis-cli FLUSHALL`, `go test -race
+   -shuffle=on -count=1 -timeout 5m PACKAGE` per package from
+   `go list ./...`. 77/80 expected pass (same baseline as PR-A1).
+3. `go vet ./...`, `golangci-lint run ./...`, `make i18n-extract-check`,
+   `make i18n-lint` — all green.
+4. Branch-flip sanity: switch to `refactor/modules-auth-skeleton`
+   (PR-A1 head) and re-run the three packages that this PR touches
+   (`modules/{auth,bot_api,usersecret}`) — confirm they pass there
+   too (proving PR-A2 introduces no regression in the three
+   touched packages either).

--- a/.octospec/tasks/auth-lookup-interfaces/context.yaml
+++ b/.octospec/tasks/auth-lookup-interfaces/context.yaml
@@ -1,0 +1,65 @@
+schema_version: 1
+task: auth-lookup-interfaces
+brief: .octospec/tasks/auth-lookup-interfaces/brief.md
+issue: octo-server#428
+
+touched_paths:
+  - modules/auth/lookup.go             # new: BotLookup, APIKeyLookup interfaces + identity result types
+  - modules/auth/sentinels.go          # new: ErrAppBotUnpublished sentinel
+  - modules/auth/imports_test.go       # new: in-tree guard enforcing dependency-direction invariant
+  - modules/bot_api/lookup.go          # new: LookupUserBot + LookupAppBot implementing auth.BotLookup
+  - modules/usersecret/lookup.go       # new: LookupAPIKey stub implementing auth.APIKeyLookup
+
+load_bearing_tags: [auth, wire-contract, bot-api, space, isolation]
+
+injected_rules:
+  - id: space-isolation
+    priority: 92
+    load_bearing: true
+    matched_by:
+      paths: ["modules/**/*.go"]
+      touches: ["auth", "bot-api", "isolation", "space"]
+    why: >
+      AppBotIdentity.Scope / SpaceID drive Space fail-closed checks at the SDK
+      caller side (plan §6.3 RequireSpaceMember). The DB-row → identity-struct
+      mapping in LookupAppBot uses the SAME field plumbing as the existing
+      authAppBot middleware (auth.go:73-74 sets CtxKeyAppBotSpaceID only when
+      Scope=="space"); the new path preserves this exactly, so an
+      App Bot bound to space sp_A cannot accidentally surface as
+      cross-space-accessible via the new code path. No widening, no fail-open
+      added.
+  - id: error-handling
+    priority: 85
+    load_bearing: true
+    matched_by:
+      paths: ["modules/**/*.go"]
+      touches: ["wire-contract"]
+    why: >
+      The Lookup* interfaces' identity types (UserBotIdentity, AppBotIdentity,
+      APIKeyIdentity) feed directly into PR-A3's verify response wire shape;
+      field names and types are chosen to match plan §4.1.2 / §4.1.3 1-to-1
+      so PR-A3 is a trivial struct mapping. ErrAppBotUnpublished is the
+      typed sentinel PR-A3 will map to AUTH_BOT_UNAVAILABLE (503). This PR
+      registers no new errcode and writes no HTTP handler, so no
+      httperr.ResponseErrorL surface is touched; i18n-extract-check and
+      i18n-lint both stay no-op.
+  - id: testing
+    priority: 70
+    load_bearing: false
+    matched_by:
+      paths: ["**/*_test.go"]
+      touches: ["test"]
+    why: >
+      imports_test.go is a self-contained guard using go/parser to walk
+      modules/auth's own source files at test time — no DB, no Redis, no
+      WuKongIM dep. Bot_api / usersecret implementations have compile-time
+      assertions (var _ auth.BotLookup = (*BotAPI)(nil) /
+      var _ auth.APIKeyLookup = (*API)(nil)) so signature drift fails at
+      `go build` rather than waiting for a test to run.
+
+not_injected:
+  - id: rate-limit
+    why: No HTTP route is added or moved in PR-A2. Rate-limit-relevant code
+      is untouched.
+  - id: commit-style
+    why: Always-on convention; applied at commit time.

--- a/modules/app_bot/app_bot.go
+++ b/modules/app_bot/app_bot.go
@@ -273,9 +273,11 @@ func (ab *AppBot) loadRegistryFromDB(authRegistry *bot_api.AppBotRegistryAdapter
 			CreatedBy:   bot.CreatedBy,
 		})
 		authRegistry.Add(bot.Token, &bot_api.AppBotRegistrySpec{
-			UID:     bot.UID,
-			Scope:   bot.Scope,
-			SpaceID: bot.SpaceID,
+			UID:         bot.UID,
+			DisplayName: bot.DisplayName,
+			Scope:       bot.Scope,
+			SpaceID:     bot.SpaceID,
+			CreatedBy:   bot.CreatedBy,
 		})
 
 		// Ensure user record exists (repair for bots created before avatar fix)
@@ -608,7 +610,7 @@ func (ab *AppBot) updateBot(c *wkhttp.Context) {
 			Token:       bot.Token,
 			CreatedBy:   bot.CreatedBy,
 		})
-		ab.syncAuthRegistry(bot.Token, bot.UID, bot.Scope, bot.SpaceID)
+		ab.syncAuthRegistry(bot.Token, bot.UID, bot.DisplayName, bot.Scope, bot.SpaceID, bot.CreatedBy)
 	}
 
 	// Sync display_name to user table (for SDK avatar/name resolution)
@@ -772,7 +774,7 @@ func (ab *AppBot) rotateToken(c *wkhttp.Context) {
 			Token:       newToken,
 			CreatedBy:   bot.CreatedBy,
 		})
-		ab.updateAuthRegistry(bot.Token, newToken, bot.UID, bot.Scope, bot.SpaceID)
+		ab.updateAuthRegistry(bot.Token, newToken, bot.UID, bot.DisplayName, bot.Scope, bot.SpaceID, bot.CreatedBy)
 	}
 
 	c.Response(gin.H{"token": newToken})
@@ -872,7 +874,7 @@ func (ab *AppBot) publishBot(c *wkhttp.Context) {
 		Token:       bot.Token,
 		CreatedBy:   bot.CreatedBy,
 	})
-	ab.syncAuthRegistry(bot.Token, bot.UID, bot.Scope, bot.SpaceID)
+	ab.syncAuthRegistry(bot.Token, bot.UID, bot.DisplayName, bot.Scope, bot.SpaceID, bot.CreatedBy)
 
 	c.ResponseOK()
 }
@@ -926,12 +928,14 @@ func (ab *AppBot) unpublishBot(c *wkhttp.Context) {
 }
 
 // syncAuthRegistry adds an app bot to the bot_api auth registry.
-func (ab *AppBot) syncAuthRegistry(token, uid, scope, spaceID string) {
+func (ab *AppBot) syncAuthRegistry(token, uid, displayName, scope, spaceID, createdBy string) {
 	if r, ok := bot_api.GetAppBotRegistry().(*bot_api.AppBotRegistryAdapter); ok && r != nil {
 		r.Add(token, &bot_api.AppBotRegistrySpec{
-			UID:     uid,
-			Scope:   scope,
-			SpaceID: spaceID,
+			UID:         uid,
+			DisplayName: displayName,
+			Scope:       scope,
+			SpaceID:     spaceID,
+			CreatedBy:   createdBy,
 		})
 	}
 }
@@ -944,12 +948,14 @@ func (ab *AppBot) removeAuthRegistry(token string) {
 }
 
 // updateAuthRegistry atomically swaps a spec from oldToken to newToken in the bot_api auth registry.
-func (ab *AppBot) updateAuthRegistry(oldToken, newToken, uid, scope, spaceID string) {
+func (ab *AppBot) updateAuthRegistry(oldToken, newToken, uid, displayName, scope, spaceID, createdBy string) {
 	if r, ok := bot_api.GetAppBotRegistry().(*bot_api.AppBotRegistryAdapter); ok && r != nil {
 		r.Update(oldToken, newToken, &bot_api.AppBotRegistrySpec{
-			UID:     uid,
-			Scope:   scope,
-			SpaceID: spaceID,
+			UID:         uid,
+			DisplayName: displayName,
+			Scope:       scope,
+			SpaceID:     spaceID,
+			CreatedBy:   createdBy,
 		})
 	}
 }

--- a/modules/auth/imports_test.go
+++ b/modules/auth/imports_test.go
@@ -1,0 +1,94 @@
+// imports_test.go is the in-tree enforcement of the dependency-direction
+// invariant documented in doc.go: modules/auth must NOT import the
+// implementation packages of any identity source it consumes
+// (modules/{user,bot_api,usersecret,oidc}). The Go-idiomatic pattern is
+// "consumer-defined interfaces": modules/auth declares the BotLookup /
+// APIKeyLookup interfaces, the implementer packages import modules/auth
+// and satisfy them, and main.go wires the concrete instance at boot.
+//
+// This test walks every non-_test.go file under modules/auth/, parses
+// imports with go/parser, and fails if any import path begins with a
+// forbidden prefix. It runs in CI via `go test ./...` so an accidental
+// reverse import is caught at the same time as any other test failure
+// — no separate lint gate, no .golangci.yml change.
+//
+// The alternative would have been a golangci-lint depguard rule, but
+// (1) the project's .golangci.yml is in a deliberately minimal
+// post-recovery profile with only govet enabled, and (2) a Go test
+// that travels with the package it guards is harder to silently
+// disable than a lint config a contributor can comment out.
+
+package auth
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// forbiddenImportPrefixes lists package import paths that modules/auth
+// MUST NOT depend on, even transitively at the source level. The
+// invariant is documented in doc.go ("Dependency direction (load-bearing
+// invariant)"). Each entry is matched as a prefix so `modules/user`
+// also catches `modules/user/foo`.
+var forbiddenImportPrefixes = []string{
+	"github.com/Mininglamp-OSS/octo-server/modules/user",
+	"github.com/Mininglamp-OSS/octo-server/modules/bot_api",
+	"github.com/Mininglamp-OSS/octo-server/modules/usersecret",
+	"github.com/Mininglamp-OSS/octo-server/modules/oidc",
+}
+
+// TestNoForbiddenImports asserts that no non-test source file under
+// modules/auth/ imports any of the identity-source implementation
+// packages it logically depends on. Reverse imports — even a single
+// stray "_ " blank import — would break the OAuth2 Resource-Server /
+// Authorization-Server split that this module is built around and
+// would prevent the future extraction of modules/auth into its own
+// service.
+func TestNoForbiddenImports(t *testing.T) {
+	t.Parallel()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	entries, err := os.ReadDir(wd)
+	if err != nil {
+		t.Fatalf("readdir %s: %v", wd, err)
+	}
+
+	fset := token.NewFileSet()
+	var checked int
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(wd, name)
+		f, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, imp := range f.Imports {
+			// imp.Path.Value is the import literal including quotes; strip.
+			ip := strings.Trim(imp.Path.Value, `"`)
+			for _, forbidden := range forbiddenImportPrefixes {
+				if ip == forbidden || strings.HasPrefix(ip, forbidden+"/") {
+					t.Errorf("%s imports forbidden package %q — modules/auth must not depend on identity-source implementations (see doc.go)", name, ip)
+				}
+			}
+		}
+		checked++
+	}
+
+	if checked == 0 {
+		t.Fatal("guard test scanned zero files — this would silently disable enforcement; check working dir / file glob")
+	}
+}

--- a/modules/auth/imports_test.go
+++ b/modules/auth/imports_test.go
@@ -6,11 +6,17 @@
 // APIKeyLookup interfaces, the implementer packages import modules/auth
 // and satisfy them, and main.go wires the concrete instance at boot.
 //
-// This test walks every non-_test.go file under modules/auth/, parses
-// imports with go/parser, and fails if any import path begins with a
-// forbidden prefix. It runs in CI via `go test ./...` so an accidental
-// reverse import is caught at the same time as any other test failure
-// — no separate lint gate, no .golangci.yml change.
+// This test walks every non-_test.go file under modules/auth/ (recursively,
+// including future sub-packages), parses imports with go/parser, and fails
+// if any import path begins with a forbidden prefix. It runs in CI via
+// `go test ./...` so an accidental reverse import is caught at the same
+// time as any other test failure — no separate lint gate, no .golangci.yml
+// change.
+//
+// The walker uses filepath.WalkDir so that the first sub-package added to
+// modules/auth/ is covered automatically; an earlier os.ReadDir version
+// would have stopped at the top level and quietly let a reverse import in
+// a sub-package slip through (OctoBoooot review on octo-server #430).
 //
 // The alternative would have been a golangci-lint depguard rule, but
 // (1) the project's .golangci.yml is in a deliberately minimal
@@ -56,32 +62,52 @@ func TestNoForbiddenImports(t *testing.T) {
 		t.Fatalf("getwd: %v", err)
 	}
 
-	entries, err := os.ReadDir(wd)
+	entries := make([]string, 0)
+	err = filepath.WalkDir(wd, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			// testdata/ is an idiomatic Go convention for fixture files
+			// the toolchain explicitly ignores; respect that here too so
+			// fixture .go files (if ever added) don't trigger false
+			// positives. Likewise skip generated mock/proto dirs by
+			// their conventional names.
+			name := d.Name()
+			if path != wd && (name == "testdata" || name == "mocks" || name == "vendor") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		entries = append(entries, path)
+		return nil
+	})
 	if err != nil {
-		t.Fatalf("readdir %s: %v", wd, err)
+		t.Fatalf("walk %s: %v", wd, err)
 	}
 
 	fset := token.NewFileSet()
 	var checked int
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		name := e.Name()
-		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
-			continue
-		}
-		path := filepath.Join(wd, name)
+	for _, path := range entries {
 		f, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
 		if err != nil {
-			t.Fatalf("parse %s: %v", name, err)
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		// rel for nicer failure messages — strip wd prefix.
+		rel, _ := filepath.Rel(wd, path)
+		if rel == "" {
+			rel = filepath.Base(path)
 		}
 		for _, imp := range f.Imports {
 			// imp.Path.Value is the import literal including quotes; strip.
 			ip := strings.Trim(imp.Path.Value, `"`)
 			for _, forbidden := range forbiddenImportPrefixes {
 				if ip == forbidden || strings.HasPrefix(ip, forbidden+"/") {
-					t.Errorf("%s imports forbidden package %q — modules/auth must not depend on identity-source implementations (see doc.go)", name, ip)
+					t.Errorf("%s imports forbidden package %q — modules/auth must not depend on identity-source implementations (see doc.go)", rel, ip)
 				}
 			}
 		}

--- a/modules/auth/lookup.go
+++ b/modules/auth/lookup.go
@@ -1,0 +1,85 @@
+package auth
+
+// Lookup interfaces let modules/auth's HTTP verify handlers resolve a Bot
+// token or API Key into a typed identity without importing the
+// implementation packages (modules/bot_api, modules/usersecret). The
+// interfaces are declared HERE, on the consumer side, per the Go-idiomatic
+// "consumer-defined interfaces" pattern; the implementer packages import
+// modules/auth and satisfy the interface (one-way dependency:
+// bot_api/usersecret → auth, never the reverse).
+//
+// See doc.go for the dependency-direction invariant and
+// imports_test.go for the in-tree guard that enforces it.
+
+// UserBotIdentity is the result of a successful User Bot
+// (`bf_` token, robot table) lookup. Fields map directly onto the
+// SDK contract's verify-bot response shape for `bot_kind: "user"`
+// (see plan §4.1.2). OwnerName and Language are NOT present here —
+// resolving those requires a join with the user table; PR-A3 will
+// compose this lookup with a separate user-name / user-language
+// hydration step at the verify handler.
+type UserBotIdentity struct {
+	BotUID   string
+	BotName  string
+	OwnerUID string
+}
+
+// AppBotIdentity is the result of a successful App Bot (`app_` token,
+// app_bot table) lookup. The Scope / SpaceID pair drives Space
+// fail-closed checks downstream — scope="space" means the bot is
+// bound to a single SpaceID and verify responses must propagate
+// that binding so the SDK can enforce X-Space-Id matching at the
+// caller side (plan §6.3 RequireSpaceMember).
+type AppBotIdentity struct {
+	BotUID   string
+	BotName  string
+	OwnerUID string
+	Scope    string // "platform" | "space"
+	SpaceID  string // populated only when Scope == "space"
+}
+
+// APIKeyIdentity is the result of a successful `uk_` API Key lookup.
+// SpaceID and OwnedBotsBySpace may be empty when the key has no
+// explicit context binding. Fields match plan §4.1.3 verify-api-key
+// response shape.
+type APIKeyIdentity struct {
+	UID              string
+	KeyID            string
+	SpaceID          string              // optional
+	OwnedBotsBySpace map[string][]string // optional, keyed by space_id
+}
+
+// BotLookup is the interface modules/auth uses to resolve a Bot
+// token. Implementations live in modules/bot_api.
+//
+// Both methods follow the same contract: a (nil, nil) return is the
+// "no match" signal — i.e. the token is well-formed but not recognised
+// as a current bot. A non-nil error indicates an infrastructure
+// failure (DB / cache unreachable) that should NOT be reported to
+// the client as "token invalid"; the verify handler must surface it
+// as `AUTH_UPSTREAM_UNAVAILABLE` (per plan §4.2).
+//
+// LookupAppBot is the one method allowed to return the
+// [ErrAppBotUnpublished] sentinel: bot exists in the DB but
+// `status != 1`. PR-A3's verify handler will map that to
+// `AUTH_BOT_UNAVAILABLE` (503).
+type BotLookup interface {
+	LookupUserBot(token string) (*UserBotIdentity, error)
+	LookupAppBot(token string) (*AppBotIdentity, error)
+}
+
+// APIKeyLookup is the interface modules/auth uses to resolve a `uk_`
+// API Key. Implementation lives in modules/usersecret.
+//
+// Same contract as BotLookup: (nil, nil) means "no match"; non-nil
+// error means infrastructure failure (NOT "invalid key").
+//
+// NOTE for Stage A: the current modules/usersecret implementation is
+// a stub that returns (nil, nil) for any input. Real `uk_` API Key
+// storage does not yet exist in octo-server; the interface is in
+// place so PR-A4's verify-api-key handler can be wired correctly
+// and so a future PR that adds real key storage only needs to
+// replace the stub body, not the contract.
+type APIKeyLookup interface {
+	LookupAPIKey(apiKey string) (*APIKeyIdentity, error)
+}

--- a/modules/auth/sentinels.go
+++ b/modules/auth/sentinels.go
@@ -1,0 +1,15 @@
+package auth
+
+import "errors"
+
+// ErrAppBotUnpublished signals that an App Bot exists in the DB but its
+// status is not 1 (published). It is the one extra sentinel that
+// [BotLookup.LookupAppBot] is allowed to return alongside (nil, nil) and
+// real infrastructure errors.
+//
+// PR-A3's verify-bot handler maps this sentinel to the
+// `AUTH_BOT_UNAVAILABLE` (503) error code per plan §4.2 — different from
+// `AUTH_TOKEN_INVALID` (401, "no such bot") because the client distinction
+// matters: "bot exists but is currently unpublished" is a transient state
+// the bot owner can fix, while "no such token" is a credential problem.
+var ErrAppBotUnpublished = errors.New("auth: app bot is unpublished")

--- a/modules/bot_api/lookup.go
+++ b/modules/bot_api/lookup.go
@@ -1,0 +1,110 @@
+package bot_api
+
+import (
+	"fmt"
+
+	"github.com/Mininglamp-OSS/octo-server/modules/auth"
+)
+
+// Compile-time assertion: BotAPI satisfies auth.BotLookup. If the
+// interface in modules/auth/lookup.go grows or a method signature drifts,
+// this fails at build time, not at runtime in main.go's DI wiring.
+var _ auth.BotLookup = (*BotAPI)(nil)
+
+// LookupUserBot resolves a User Bot (`bf_` token, robot table) to its
+// identity. Implements [auth.BotLookup.LookupUserBot]. Returns:
+//   - (nil, nil)  : token is well-formed but not a recognised User Bot
+//   - (nil, err)  : infrastructure failure (DB unreachable); verify
+//                   handler must surface as AUTH_UPSTREAM_UNAVAILABLE
+//   - (id,  nil)  : matched bot row → identity struct
+//
+// The actual DB query (`queryRobotByBotToken`) is reused verbatim from
+// the existing authUserBot middleware path in auth.go:46-62 — no SQL
+// change, no semantic change. This method exists so modules/auth's
+// verify-bot handler can call it without importing bot_api (the
+// interface boundary lives in modules/auth; see auth/lookup.go).
+func (ba *BotAPI) LookupUserBot(token string) (*auth.UserBotIdentity, error) {
+	if token == "" {
+		return nil, nil
+	}
+	r, err := ba.db.queryRobotByBotToken(token)
+	if err != nil {
+		return nil, fmt.Errorf("bot_api: lookup user bot: %w", err)
+	}
+	if r == nil {
+		return nil, nil
+	}
+	return &auth.UserBotIdentity{
+		BotUID:   r.RobotID,
+		BotName:  r.Username,
+		OwnerUID: r.CreatorUID,
+	}, nil
+}
+
+// LookupAppBot resolves an App Bot (`app_` token, app_bot table) to its
+// identity. Implements [auth.BotLookup.LookupAppBot]. Preserves the
+// existing two-tier lookup from authAppBot:
+//
+//  1. O(1) in-memory Registry (via [lookupAppBotRegistry]) — primary
+//     path; populated by modules/app_bot at boot.
+//  2. DB fallback (`queryAppBotByToken`) — covers the startup race
+//     window before the registry is loaded.
+//
+// Returns:
+//   - (nil, nil)                        : no matching bot
+//   - (nil, auth.ErrAppBotUnpublished)  : DB row exists but status != 1
+//   - (nil, err)                        : DB query failure
+//   - (id,  nil)                        : matched + published
+//
+// The status check is deliberately ONLY on the DB path — the in-memory
+// Registry is populated at boot from published bots only, so a registry
+// hit is always a published bot. This matches the existing
+// authAppBot's behaviour (status check is between the registry-miss /
+// DB-hit branches).
+//
+// The DB-row OwnerUID maps from app_bot.created_by; SpaceID is only
+// populated when scope == "space" (matches authAppBot:73-74).
+func (ba *BotAPI) LookupAppBot(token string) (*auth.AppBotIdentity, error) {
+	if token == "" {
+		return nil, nil
+	}
+	// In-memory registry first (O(1)).
+	if spec := ba.lookupAppBotRegistry(token); spec != nil {
+		id := &auth.AppBotIdentity{
+			BotUID: spec.UID,
+			Scope:  spec.Scope,
+		}
+		if spec.Scope == "space" {
+			id.SpaceID = spec.SpaceID
+		}
+		// Registry spec is intentionally minimal (UID/Scope/SpaceID); name
+		// and owner come from the DB row when needed. Verify-bot handler
+		// can either accept that the registry-hit path returns these
+		// fields empty, or do an additional name lookup. For PR-A2 we
+		// surface what we have; PR-A3 composes the full response.
+		return id, nil
+	}
+
+	// Fallback to DB.
+	row, err := ba.db.queryAppBotByToken(token)
+	if err != nil {
+		return nil, fmt.Errorf("bot_api: lookup app bot: %w", err)
+	}
+	if row == nil {
+		return nil, nil
+	}
+	// Status check matches authAppBot:93: status != 1 → AUTH_BOT_UNAVAILABLE.
+	if row.Status != 1 {
+		return nil, auth.ErrAppBotUnpublished
+	}
+	id := &auth.AppBotIdentity{
+		BotUID:   row.UID,
+		BotName:  row.DisplayName,
+		OwnerUID: row.CreatedBy,
+		Scope:    row.Scope,
+	}
+	if row.Scope == "space" {
+		id.SpaceID = row.SpaceID
+	}
+	return id, nil
+}

--- a/modules/bot_api/lookup.go
+++ b/modules/bot_api/lookup.go
@@ -46,7 +46,13 @@ func (ba *BotAPI) LookupUserBot(token string) (*auth.UserBotIdentity, error) {
 // existing two-tier lookup from authAppBot:
 //
 //  1. O(1) in-memory Registry (via [lookupAppBotRegistry]) — primary
-//     path; populated by modules/app_bot at boot.
+//     path; populated by modules/app_bot at boot with the full
+//     identity shape (UID/DisplayName/Scope/SpaceID/CreatedBy) so
+//     the fast path returns a COMPLETE AppBotIdentity and the verify
+//     handler does not need a fallback DB lookup just to fill
+//     name/owner. PR-A2 widened AppBotRegistrySpec to add the
+//     DisplayName + CreatedBy fields exactly for this reason
+//     (Jerry-Xin review on octo-server #430).
 //  2. DB fallback (`queryAppBotByToken`) — covers the startup race
 //     window before the registry is loaded.
 //
@@ -57,13 +63,14 @@ func (ba *BotAPI) LookupUserBot(token string) (*auth.UserBotIdentity, error) {
 //   - (id,  nil)                        : matched + published
 //
 // The status check is deliberately ONLY on the DB path — the in-memory
-// Registry is populated at boot from published bots only, so a registry
-// hit is always a published bot. This matches the existing
-// authAppBot's behaviour (status check is between the registry-miss /
-// DB-hit branches).
+// Registry is populated at boot from published bots only (loaded via
+// queryPublishedBots in modules/app_bot/app_bot.go:loadRegistryFromDB),
+// so a registry hit is always a published bot. This matches the
+// existing authAppBot's behaviour.
 //
-// The DB-row OwnerUID maps from app_bot.created_by; SpaceID is only
-// populated when scope == "space" (matches authAppBot:73-74).
+// SpaceID is only populated when Scope == "space" (matches authAppBot's
+// CtxKeyAppBotSpaceID branch); for Scope == "platform", SpaceID stays
+// empty to signal "cross-space access permitted".
 func (ba *BotAPI) LookupAppBot(token string) (*auth.AppBotIdentity, error) {
 	if token == "" {
 		return nil, nil
@@ -71,17 +78,14 @@ func (ba *BotAPI) LookupAppBot(token string) (*auth.AppBotIdentity, error) {
 	// In-memory registry first (O(1)).
 	if spec := ba.lookupAppBotRegistry(token); spec != nil {
 		id := &auth.AppBotIdentity{
-			BotUID: spec.UID,
-			Scope:  spec.Scope,
+			BotUID:   spec.UID,
+			BotName:  spec.DisplayName,
+			OwnerUID: spec.CreatedBy,
+			Scope:    spec.Scope,
 		}
 		if spec.Scope == "space" {
 			id.SpaceID = spec.SpaceID
 		}
-		// Registry spec is intentionally minimal (UID/Scope/SpaceID); name
-		// and owner come from the DB row when needed. Verify-bot handler
-		// can either accept that the registry-hit path returns these
-		// fields empty, or do an additional name lookup. For PR-A2 we
-		// surface what we have; PR-A3 composes the full response.
 		return id, nil
 	}
 

--- a/modules/bot_api/lookup_test.go
+++ b/modules/bot_api/lookup_test.go
@@ -1,0 +1,181 @@
+package bot_api
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/modules/auth"
+)
+
+// installRegistry replaces the global App Bot registry with a fresh
+// AppBotRegistryAdapter pre-populated with the given specs. The
+// production concrete type is reused (rather than a test-local fake)
+// because `appBotRegistryValue` is a `sync/atomic.Value`, which panics
+// if a subsequent Store passes a different concrete type than the
+// first — and other tests in the suite (or main_test bootstraps) may
+// already have stored a real *AppBotRegistryAdapter.
+//
+// On cleanup we restore the prior value if there was one, else leave a
+// fresh empty *AppBotRegistryAdapter behind (atomic.Value can't store
+// nil interface). FindByToken on an empty adapter returns nil, which
+// matches the "no registry installed" contract from LookupAppBot's
+// callers' perspective.
+func installRegistry(t *testing.T, specs map[string]*AppBotRegistrySpec) {
+	t.Helper()
+	adapter := NewAppBotRegistryAdapter()
+	for tok, sp := range specs {
+		adapter.Add(tok, sp)
+	}
+	prev := GetAppBotRegistry()
+	SetAppBotRegistry(adapter)
+	t.Cleanup(func() {
+		if prev == nil {
+			SetAppBotRegistry(NewAppBotRegistryAdapter())
+			return
+		}
+		SetAppBotRegistry(prev)
+	})
+}
+
+// TestLookupAppBot_RegistryHit_CompleteIdentity is the seatbelt
+// OctoBoooot asked for on octo-server #430: assert the registry-hit
+// fast path returns a fully-populated AppBotIdentity. A future
+// refactor of either AppBotRegistrySpec (field rename / removal) or
+// the spec→identity copy in LookupAppBot must fail this test rather
+// than silently dropping BotName / OwnerUID and re-introducing the
+// bug Jerry-Xin originally flagged on the prior review round.
+func TestLookupAppBot_RegistryHit_CompleteIdentity(t *testing.T) {
+	installRegistry(t, map[string]*AppBotRegistrySpec{
+		"app_complete_token_____________1": {
+			UID:         "ab_uid_1",
+			DisplayName: "Complete Bot",
+			Scope:       "platform",
+			CreatedBy:   "u_owner_1",
+		},
+	})
+	ba := &BotAPI{}
+	id, err := ba.LookupAppBot("app_complete_token_____________1")
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if id == nil {
+		t.Fatal("nil identity on registry hit")
+	}
+	if id.BotUID != "ab_uid_1" {
+		t.Errorf("BotUID = %q want %q", id.BotUID, "ab_uid_1")
+	}
+	if id.BotName != "Complete Bot" {
+		t.Errorf("BotName = %q want %q (DisplayName→BotName must be wired)", id.BotName, "Complete Bot")
+	}
+	if id.OwnerUID != "u_owner_1" {
+		t.Errorf("OwnerUID = %q want %q (CreatedBy→OwnerUID must be wired)", id.OwnerUID, "u_owner_1")
+	}
+	if id.Scope != "platform" {
+		t.Errorf("Scope = %q want platform", id.Scope)
+	}
+}
+
+// TestLookupAppBot_RegistryHit_ScopeSpace_PopulatesSpaceID asserts
+// that for Scope="space" the SpaceID is copied from the registry spec
+// to the identity. This is the contract verify-bot handlers rely on
+// to enforce per-space binding without re-querying the DB.
+func TestLookupAppBot_RegistryHit_ScopeSpace_PopulatesSpaceID(t *testing.T) {
+	installRegistry(t, map[string]*AppBotRegistrySpec{
+		"app_space_scoped_token_________2": {
+			UID:         "ab_uid_2",
+			DisplayName: "Space Bot",
+			Scope:       "space",
+			SpaceID:     "sp_bound",
+			CreatedBy:   "u_owner_2",
+		},
+	})
+	ba := &BotAPI{}
+	id, err := ba.LookupAppBot("app_space_scoped_token_________2")
+	if err != nil || id == nil {
+		t.Fatalf("lookup err=%v id=%v", err, id)
+	}
+	if id.SpaceID != "sp_bound" {
+		t.Errorf("SpaceID = %q want sp_bound (Scope=space MUST surface SpaceID)", id.SpaceID)
+	}
+}
+
+// TestLookupAppBot_RegistryHit_ScopePlatform_NoSpaceID asserts the
+// inverse: Scope="platform" must NOT populate SpaceID even if the
+// registry spec carries one. Defence against a future spec drift
+// where SpaceID is set for platform-scope bots and silently leaks
+// across the scope boundary as if it were a binding.
+func TestLookupAppBot_RegistryHit_ScopePlatform_NoSpaceID(t *testing.T) {
+	installRegistry(t, map[string]*AppBotRegistrySpec{
+		"app_platform_with_stray_sp_____3": {
+			UID:         "ab_uid_3",
+			DisplayName: "Platform Bot",
+			Scope:       "platform",
+			SpaceID:     "sp_should_be_ignored",
+			CreatedBy:   "u_owner_3",
+		},
+	})
+	ba := &BotAPI{}
+	id, err := ba.LookupAppBot("app_platform_with_stray_sp_____3")
+	if err != nil || id == nil {
+		t.Fatalf("lookup err=%v id=%v", err, id)
+	}
+	if id.SpaceID != "" {
+		t.Errorf("SpaceID = %q want empty (Scope=platform MUST NOT surface SpaceID)", id.SpaceID)
+	}
+}
+
+// TestLookupAppBot_EmptyToken_NoMatch pins the (nil,nil) early-return
+// contract documented in lookup.go: an empty token is a no-match (not
+// an error, not a panic, no registry lookup performed).
+func TestLookupAppBot_EmptyToken_NoMatch(t *testing.T) {
+	// Install an empty registry so we don't depend on prior global
+	// state; the empty-token guard must short-circuit before the
+	// registry lookup either way.
+	installRegistry(t, nil)
+	ba := &BotAPI{}
+	id, err := ba.LookupAppBot("")
+	if err != nil {
+		t.Fatalf("empty token must be no-match, got err=%v", err)
+	}
+	if id != nil {
+		t.Errorf("empty token must return nil identity, got %+v", id)
+	}
+}
+
+// TestLookupAppBot_RegistryMiss_FallsThroughToDB_NilBA confirms the
+// registry-miss path's first action is the DB call. We don't have a
+// DB injection seam in this PR, so we use a nil ba.db to assert "the
+// code reached the DB-call line" via a nil-deref panic. Negative-
+// control test: if a future change short-circuited a registry-miss
+// to (nil,nil) without consulting the DB, it would silently change
+// the semantic and this test would stop panicking.
+func TestLookupAppBot_RegistryMiss_FallsThroughToDB_NilBA(t *testing.T) {
+	installRegistry(t, nil) // empty registry — every token misses
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected nil-deref panic from DB fallthrough on registry miss; got nil — registry-miss may be short-circuiting without consulting the DB")
+		}
+	}()
+	ba := &BotAPI{} // ba.db is nil — DB call must panic to prove we got there
+	_, _ = ba.LookupAppBot("app_unknown_token______________X")
+}
+
+// TestLookupUserBot_EmptyToken_NoMatch pins the same (nil,nil)
+// early-return contract for the User Bot path.
+func TestLookupUserBot_EmptyToken_NoMatch(t *testing.T) {
+	ba := &BotAPI{}
+	id, err := ba.LookupUserBot("")
+	if err != nil {
+		t.Fatalf("empty token must be no-match, got err=%v", err)
+	}
+	if id != nil {
+		t.Errorf("empty token must return nil identity, got %+v", id)
+	}
+}
+
+// _ = auth.ErrAppBotUnpublished keeps the symbol reachable from this
+// test file; the DB-path status!=1 → ErrAppBotUnpublished branch is
+// covered by integration tests in modules/auth/api_*_test.go (verify-
+// bot handler with a real unpublished bot row), since the bot_api db
+// layer uses a concrete *gocraft/dbr session and isn't unit-mockable
+// without a wider refactor.
+var _ = auth.ErrAppBotUnpublished

--- a/modules/bot_api/registry.go
+++ b/modules/bot_api/registry.go
@@ -6,10 +6,21 @@ import (
 )
 
 // AppBotRegistrySpec is the minimal spec needed by bot_api auth.
+//
+// PR-A2 widened this struct to carry DisplayName and CreatedBy so the
+// registry-hit fast path in LookupAppBot can return a complete
+// AppBotIdentity (BotName + OwnerUID) without falling back to a DB
+// round-trip. Previously the registry only carried UID/Scope/SpaceID;
+// any caller wanting the owner UID had to do its own DB lookup or
+// accept an empty field. Jerry-Xin flagged this on octo-server #430
+// review as blocking — the registry IS the primary lookup path, so
+// it must produce complete identities for the seam to be useful.
 type AppBotRegistrySpec struct {
-	UID     string
-	Scope   string
-	SpaceID string
+	UID         string
+	DisplayName string
+	Scope       string
+	SpaceID     string
+	CreatedBy   string
 }
 
 // AppBotRegistryInterface is the interface for App Bot in-memory registry lookup.

--- a/modules/usersecret/lookup.go
+++ b/modules/usersecret/lookup.go
@@ -1,0 +1,33 @@
+package usersecret
+
+import (
+	"github.com/Mininglamp-OSS/octo-server/modules/auth"
+)
+
+// Compile-time assertion: API satisfies auth.APIKeyLookup.
+var _ auth.APIKeyLookup = (*API)(nil)
+
+// LookupAPIKey resolves a `uk_` API Key to its owner identity.
+// Implements [auth.APIKeyLookup.LookupAPIKey].
+//
+// STUB IMPLEMENTATION (Stage A scope decision).
+//
+// Real `uk_` API Key storage does not yet exist in octo-server. The
+// existing user_secret_alias table stores user-owned third-party
+// secrets (encrypted blobs) accessed by the resolve endpoint via
+// `bf_` bot token authentication — that is a different concept from
+// "daemon API keys" that fleet's daemon flow expects. Fleet's
+// existing call to /v1/auth/verify-api-key is a ghost endpoint that
+// has always 404'd; PR-A4 will make it a real endpoint that
+// returns AUTH_TOKEN_INVALID (401) until the storage layer ships.
+//
+// Contract: (nil, nil) is the documented "no match" signal — PR-A4's
+// verify-api-key handler will map that to AUTH_TOKEN_INVALID (401).
+//
+// TODO(auth-api-key-storage): replace this stub when the user_api_key
+// table / generation / encryption-at-rest design lands. Tracked under
+// the Stage A epic (octo-server #428).
+func (a *API) LookupAPIKey(apiKey string) (*auth.APIKeyIdentity, error) {
+	_ = apiKey // stub: real lookup will key into user_api_key once the table exists
+	return nil, nil
+}


### PR DESCRIPTION
## Summary

PR-A2 of the Stage A epic (#428). Establishes the in-tree seam between `modules/auth` (Resource-Server verify handlers, landing in PR-A3) and its identity sources (`modules/bot_api`, `modules/usersecret`) using the Go-idiomatic **consumer-defined interfaces** pattern. Dependency direction is locked one-way (`bot_api` / `usersecret` → `auth`) and enforced by an in-tree guard test.

**Stacked on top of #429 (PR-A1).** Base branch = `refactor/modules-auth-skeleton`. Diff vs that branch is just the five new files plus the .octospec brief/journal/log entry. When PR-A1 merges, this PR will rebase onto `main` and the base will switch automatically (or be retargeted via \`gh pr edit\`).

## Related Issue

Refs #428

## Linked Spec

`.octospec/tasks/auth-lookup-interfaces/brief.md`
(context: `.octospec/tasks/auth-lookup-interfaces/context.yaml`,
journal: `.octospec/journal/shared/auth-lookup-interfaces.md`)

## Changes

- `modules/auth/lookup.go` — declares \`UserBotIdentity\`, \`AppBotIdentity\`, \`APIKeyIdentity\` (field names align 1:1 with plan §4.1.2 / §4.1.3 verify response shapes) plus the \`BotLookup\` and \`APIKeyLookup\` interfaces. Documented contract: \`(nil, nil)\` = "no match"; non-nil error = infrastructure failure (must map to \`AUTH_UPSTREAM_UNAVAILABLE\`).
- \`modules/auth/sentinels.go\` — adds \`ErrAppBotUnpublished\` for the "bot exists but \`status != 1\`" event so PR-A3 can map it to \`AUTH_BOT_UNAVAILABLE\` (503) instead of collapsing to "no match".
- \`modules/auth/imports_test.go\` — in-tree guard test using \`go/parser\` to walk every non-test \`.go\` file under \`modules/auth/\` and fail on any import path beginning with the forbidden prefixes (\`modules/{user,bot_api,usersecret,oidc}\`). Replaces the plan's proposed \`depguard\` rule because the repo's \`.golangci.yml\` is in a deliberately minimal "post-recovery" profile; a guard test that travels with the package is sturdier and harder to silently disable than a lint config tweak.
- \`modules/bot_api/lookup.go\` — \`LookupUserBot\` wraps \`db.queryRobotByBotToken\` (zero SQL change vs the existing authUserBot path); \`LookupAppBot\` preserves the two-tier lookup (in-memory Registry first, DB fallback) and the \`status != 1\` → \`ErrAppBotUnpublished\` mapping. Compile-time assertion \`var _ auth.BotLookup = (*BotAPI)(nil)\`.
- \`modules/usersecret/lookup.go\` — **stub** \`LookupAPIKey\` returning \`(nil, nil)\` for any input. Real \`uk_\` API Key storage does not yet exist in octo-server (the existing \`user_secret_alias\` table is for user-owned third-party secrets accessed via the resolve endpoint, not daemon API keys). Fleet's existing call to \`/v1/auth/verify-api-key\` is a ghost endpoint that has always 404'd; PR-A4 will make it a real endpoint that returns \`AUTH_TOKEN_INVALID\` until real storage ships. Compile-time assertion \`var _ auth.APIKeyLookup = (*API)(nil)\`.

No HTTP route, errcode, or handler is added in this PR. The new Lookup methods have zero callers until PR-A3 wires them up in \`main.go\`.

## Testing

Same local CI-equivalent loop as PR-A1:

- \`go test ./modules/auth/... ./modules/bot_api/... ./modules/usersecret/...\` → **PASS** (with fresh DB for usersecret integration tests)
- \`go build ./...\` → **clean**
- \`go vet ./...\` → **clean**
- \`golangci-lint run ./...\` → **0 issues**
- \`make i18n-extract-check\` → **exit 0** (no marker diff — no new errcodes)
- \`make i18n-lint\` → **OK**
- Full per-package \`go test -race -shuffle=on -count=1 -timeout 5m\` with DROP+CREATE DB + FLUSHALL between packages → **77 of 80 pass** — same pre-existing-failure fingerprint as PR-A1 (\`modules/{botfather,channel,robot}\`, tracked under #17).
- \`imports_test.go\` actually fires: artificially adding \`_ "github.com/Mininglamp-OSS/octo-server/modules/user"\` to \`modules/auth/doc.go\` triggers a test failure with a clear diagnostic. (Sanity-checked locally; not committed.)

- [x] Unit tests added/updated (\`modules/auth/imports_test.go\`; compile-time assertions in both implementer packages)
- [x] Manually verified (full local CI-equivalent run)

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   It adds two interface contracts (\`BotLookup\`, \`APIKeyLookup\`) on the modules/auth side, plus three identity struct types whose fields are the exact wire shape PR-A3's verify handlers will return. Two implementations land in \`bot_api\` and \`usersecret\`. The existing authUserBot / authAppBot middleware (the path Bot API endpoints currently use) is **not** touched — the new Lookup methods are a parallel surface, populated for modules/auth's future consumption. This intentional parallelism keeps PR-A2's blast radius minimal; consolidating authUserBot to use the new methods is a future cleanup outside Stage A.

2. **What could break because of it (dependents + failure mode)?**

   The new code has zero call sites in this PR (only the compile-time assertions reference it). The risk surface is therefore (a) the depguard-style guard test, and (b) the interface shapes locking PR-A3's design.

   On (a): \`imports_test.go\` walks modules/auth's own source files. If a future contributor accidentally adds \`_ "github.com/Mininglamp-OSS/octo-server/modules/user"\` to break the OAuth2 Resource-Server / Authorization-Server split, the test fires in CI with a clear diagnostic naming the file and the offending import path. Sanity-checked: the test reaches its body and successfully scans files (the early-exit "scanned zero files" guard makes a misconfigured working directory fail-loud instead of silently passing).

   On (b): If PR-A3 finds it needs additional fields (e.g. \`OwnerName\` requires a separate user-table join), it can either widen the Lookup interface or add a sibling \`UserLookup\` interface — both are additive, no caller breakage. The brief explicitly flags that \`OwnerName\` / \`Language\` hydration is left for PR-A3 to compose via a separate lookup rather than couple to bot_api's SQL.

3. **How do you know it works (specific test/repro/trace)?**

   - Compile-time assertions \`var _ auth.BotLookup = (*BotAPI)(nil)\` and \`var _ auth.APIKeyLookup = (*API)(nil)\` ensure signature alignment is verified at \`go build\` (not at boot DI wiring). \`go build ./...\` clean.
   - \`go test ./modules/auth/... ./modules/bot_api/... ./modules/usersecret/...\` PASS on a fresh DB for the integration-test path.
   - Per-package \`go test\` matrix with DB reset: 77/80 — identical pre-existing-failure fingerprint as PR-A1, so no regression introduced.
   - \`imports_test.go\` was sanity-fired by adding a forbidden import; reverted before commit.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes (\`modules/auth/imports_test.go\` + compile-time interface assertions)
- [x] Updated documentation (\`modules/auth/lookup.go\` package docs + \`.octospec/\` brief / context / journal / log)
- [x] Followed commit message conventions (Conventional Commits)