### PR TITLE
feat(auth): add /v1/auth/verify-api-key endpoint (stub path, shared verifyLimit)

### DIFF
--- a/.octospec/journal/shared/auth-verify-api-key.md
+++ b/.octospec/journal/shared/auth-verify-api-key.md
@@ -1,0 +1,83 @@
+---
+type: Journal
+title: "Journal: auth-verify-api-key (octo-server #428)"
+description: Close the verify-api-key endpoint contract gap — wire the PR-A2 APIKeyLookup stub through the standard verify Service + handler + verifyLimit path so fleet's daemon flow gets a structured 401 envelope instead of a 404 ghost.
+tags: ["auth", "modules", "verify-api-key"]
+timestamp: 2026-06-22T00:00:00Z
+task: auth-verify-api-key
+source: self
+---
+# Journal: auth-verify-api-key (octo-server #428)
+
+## What was done
+
+PR-A4 of Stage A epic (#428). Adds the missing
+`/v1/auth/verify-api-key` endpoint by extending the modules/auth
+Service + API + 1module surface from PR-A3 with:
+
+- `VerifyAPIKeyReq` / `VerifyAPIKeyResp` DTOs in
+  `modules/auth/contract.go` matching plan §4.1.3 (schema_version,
+  kind, uid, key_id, optional space_id, optional
+  owned_bots_by_space).
+- `Service.VerifyAPIKey` in `modules/auth/service.go` — same shape
+  as VerifyBot: trim → check empty → lookup → map sentinel.
+  Returns `ErrInvalidAPIKey` for empty/whitespace input,
+  `ErrUpstreamFailure` for no-provider-registered or infra error,
+  and a populated `VerifyAPIKeyResp` for happy path.
+- `verifyAPIKeyHTTP` handler in `modules/auth/api.go`;
+  `handleServiceError` extended to map `ErrInvalidAPIKey` into the
+  existing anti-enumeration 401 `ErrAuthTokenInvalid`.
+- Route registered in `modules/auth/1module.go` under the SAME
+  `verifyLimit` middleware as the other two verify endpoints
+  (shared `"verify"` tag → same Redis bucket namespace →
+  attackers can't probe API keys faster than they can probe
+  session tokens; plan §10 mitigation).
+- 5-path `TestServiceVerifyAPIKey` in
+  `modules/auth/service_test.go`: empty/whitespace,
+  no-provider-registered, lookup-returns-nil-nil (the stub path
+  fleet hits today), lookup-returns-identity (forward-compatible
+  future-real-storage path), lookup-returns-error → upstream.
+
+Until real `uk_` API Key storage exists in octo-server, the
+`modules/usersecret.LookupAPIKey` stub keeps returning `(nil,
+nil)`, so every fleet call to `/v1/auth/verify-api-key` resolves
+to "no match" → 401 `ErrAuthTokenInvalid`. That's the same status
+code matter and fleet already handle (treat as "session expired",
+fall back to re-auth), so fleet's daemon flow doesn't regress —
+it just stops hitting a 404 ghost endpoint and starts seeing a
+structured envelope.
+
+## octospec rules injected (see context.yaml)
+
+- **error-handling** (load-bearing): anti-enumeration extension —
+  ErrInvalidAPIKey joins the single-401 family; wire contract
+  matches plan §4.1.3.
+- **rate-limit** (load-bearing): shared `"verify"` tag.
+- **testing**: 5-path service_test.go covers every documented
+  branch.
+
+## Verification
+
+- `go build ./...` — clean
+- `go vet ./...` — clean
+- `golangci-lint run ./...` — 0 issues
+- `go test ./modules/auth/...` — PASS (all 5 VerifyAPIKey paths)
+- `make i18n-extract-check` — clean (no new errcodes)
+- `make i18n-lint` — green
+
+## Lessons
+
+- **Wiring a stub through end-to-end is cheap insurance**. The
+  endpoint exists; the contract is in the wire; only the stub
+  body in modules/usersecret needs to change when real storage
+  lands. Without this PR, the day real storage arrives someone
+  would have to also remember to add the handler, the route, the
+  errcode mapping, the rate-limiter, and the SDK contract entry
+  — five separate places where the wiring could go subtly wrong.
+- **Anti-enumeration sentinel families pay off when extended**.
+  Adding ErrInvalidAPIKey to the existing
+  {ErrInvalidUserToken, ErrInvalidBotToken} `errors.Is` switch
+  was one line; without the family pattern it would have meant
+  re-deciding whether API-key failures get their own 401 code or
+  share one with bot/user failures (the right answer is share,
+  but the family makes it the default).

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -6,6 +6,13 @@ change-log convention (§7). Newest first.
 
 ## 2026-06-22
 
+- **Creation** — Added task `auth-verify-api-key` (`.octospec/tasks/auth-verify-api-key/`):
+  PR-A4 of Stage A epic (octo-server #428). Adds the missing
+  `/v1/auth/verify-api-key` endpoint wiring the PR-A2 APIKeyLookup stub
+  through the existing verify Service + handler + verifyLimit
+  plumbing. Closes the ghost-endpoint gap fleet has been hitting; until
+  real `uk_` storage lands, every call returns 401 ErrAuthTokenInvalid.
+  Journal: `.octospec/journal/shared/auth-verify-api-key.md`.
 - **Creation** — Added task `auth-verify-handlers` (`.octospec/tasks/auth-verify-handlers/`):
   PR-A3 of Stage A epic (octo-server #428). Migrates `/v1/auth/verify` and
   `/v1/auth/verify-bot` handlers from `modules/user/api.go` to a new

--- a/.octospec/tasks/auth-verify-api-key/brief.md
+++ b/.octospec/tasks/auth-verify-api-key/brief.md
@@ -1,0 +1,85 @@
+---
+type: Task
+title: "Task: auth-verify-api-key"
+description: Add POST /v1/auth/verify-api-key endpoint that wires the PR-A2 APIKeyLookup stub through the standard verify Service + handler path. Same verifyLimit bucket as the other two verify endpoints; same i18n envelope; until real uk_ key storage lands, every call returns 401 ErrAuthTokenInvalid.
+tags: ["auth", "modules", "verify-api-key", "endpoint"]
+timestamp: 2026-06-22T00:00:00Z
+slug: auth-verify-api-key
+upstream: "octo-server#428"
+source: self
+---
+
+# Task: auth-verify-api-key
+
+## Goal
+
+Add the missing `/v1/auth/verify-api-key` endpoint to modules/auth so
+fleet's daemon `Authorization: Bearer uk_...` flow stops 404ing.
+The endpoint wires the PR-A2 `APIKeyLookup` interface (whose
+modules/usersecret implementation is still a stub) through the
+existing verify Service + handler + i18n envelope + verifyLimit
+plumbing. Every call returns 401 `ErrAuthTokenInvalid` until real
+`uk_` storage lands in a future PR; the contract surface exists so
+fleet sees structured errors instead of generic 404s, and the day
+real storage arrives only the stub body in modules/usersecret has
+to change.
+
+## Background
+
+- Plan §4.1.3 + §5.2 + §10: the verify-api-key endpoint was the
+  "ghost call" fleet has been making against octo-server with no
+  server-side implementation. PR-A2 added the `APIKeyLookup`
+  interface; PR-A3 added the wider Service / API / 1module
+  scaffold for the two existing verify endpoints. PR-A4 closes
+  the loop with the missing third endpoint.
+- The verifyLimit rate-limiter tag `"verify"` is shared with the
+  other two verify endpoints (plan §5.4) — prevents attackers from
+  probing API keys at a higher rate than they could probe session
+  tokens.
+
+## Load-bearing list
+
+- **wire-contract**: response shape (`VerifyAPIKeyResp` —
+  `schema_version`, `kind`, `uid`, `key_id`, optional `space_id`,
+  optional `owned_bots_by_space`) is the source of truth for the
+  SDK contract in `octo-auth/sdk-go/contract/auth-v1.yaml`.
+  (rules: error-handling — wire-contract)
+- **error-response / i18n**: existing `errcode.ErrAuth*` codes from
+  PR-A3 are reused; no new errcode registered. Anti-enumeration:
+  `ErrInvalidAPIKey` joins the existing
+  `{ErrInvalidUserToken, ErrInvalidBotToken}` family that collapses
+  to the single 401 `ErrAuthTokenInvalid` at the wire. (rules:
+  error-handling)
+- **rate-limit**: shares the `"verify"` tag with the other two
+  endpoints — same bucket namespace, same operator dashboards.
+  (rules: rate-limit)
+
+## Out of scope
+
+- Real `uk_` API Key storage (table schema, generation, encryption
+  at rest, rotation, audit) — separate future PR. The
+  `LookupAPIKey` stub from PR-A2 stays stub.
+- Adding richer fields to the `APIKeyIdentity` shape — current
+  fields match plan §4.1.3 exactly.
+
+## Acceptance
+
+- New code in already-modified modules/auth/{contract,service,
+  api,1module,service_test}.go — pure additive surface.
+- `go build ./...` clean
+- `go vet ./...` clean
+- `golangci-lint run ./...` 0 issues
+- `make i18n-extract-check` + `make i18n-lint` green (no new
+  errcodes registered)
+- `go test ./modules/auth/...` PASS (service_test.go covers all
+  four documented VerifyAPIKey paths: empty, no-provider, no-match,
+  hit, plus the infra-error → ErrUpstreamFailure path)
+- Per-package matrix passes the same 77/80 baseline.
+
+## Verification
+
+1. `go test ./modules/auth/...` — service tests via fakeAPIKeyLookup
+2. `go build ./...`, `go vet ./...`, `golangci-lint run ./...`
+3. `make i18n-extract-check`, `make i18n-lint`
+4. Manual: confirm fleet's `/v1/auth/verify-api-key` calls now hit
+   a real handler and get a structured 401 envelope instead of 404.

--- a/.octospec/tasks/auth-verify-api-key/context.yaml
+++ b/.octospec/tasks/auth-verify-api-key/context.yaml
@@ -1,0 +1,62 @@
+schema_version: 1
+task: auth-verify-api-key
+brief: .octospec/tasks/auth-verify-api-key/brief.md
+issue: octo-server#428
+
+touched_paths:
+  - modules/auth/contract.go        # add VerifyAPIKeyReq / VerifyAPIKeyResp
+  - modules/auth/service.go         # add VerifyAPIKey method + ErrInvalidAPIKey sentinel
+  - modules/auth/api.go             # add verifyAPIKeyHTTP handler + extend handleServiceError
+  - modules/auth/1module.go         # register the new route under shared verifyLimit
+  - modules/auth/service_test.go    # add TestServiceVerifyAPIKey covering 5 paths
+
+load_bearing_tags: [auth, wire-contract, error-response, rate-limit]
+
+injected_rules:
+  - id: error-handling
+    priority: 85
+    load_bearing: true
+    matched_by:
+      paths: ["modules/**/*.go"]
+      touches: ["error-response", "wire-contract"]
+    why: >
+      Anti-enumeration: ErrInvalidAPIKey joins the existing
+      {ErrInvalidUserToken, ErrInvalidBotToken} family that collapses to
+      the single 401 ErrAuthTokenInvalid via handleServiceError. No new
+      errcode registered; verifyAPIKeyHTTP uses the unchanged
+      httperr.ResponseErrorL surface from PR-A3. Wire contract:
+      VerifyAPIKeyResp matches plan §4.1.3 (schema_version, kind, uid,
+      key_id, optional space_id, optional owned_bots_by_space). Fleet's
+      existing /v1/auth/verify-api-key callers stop seeing 404 and start
+      seeing structured 401 envelopes — same status code, richer body.
+  - id: rate-limit
+    priority: 80
+    load_bearing: true
+    matched_by:
+      paths: ["modules/**/*.go"]
+      touches: ["rate-limit"]
+    why: >
+      verify-api-key reuses the SAME verifyLimit middleware instance
+      (shared "verify" tag) as the other two verify endpoints — prevents
+      attackers from probing API keys at a higher rate than session tokens
+      (plan §10 risk: "verify-api-key endpoint implementation error
+      exposes all API Keys"; mitigation: rate-limit-shared with verify-bot).
+  - id: testing
+    priority: 70
+    load_bearing: false
+    matched_by:
+      paths: ["**/*_test.go"]
+      touches: ["test"]
+    why: >
+      TestServiceVerifyAPIKey covers all five documented paths:
+      empty/whitespace input, no-provider-registered (boot race),
+      lookup-returns-nil-nil (the stub path fleet hits today),
+      lookup-returns-identity (the future-real-storage path), and
+      lookup-returns-infra-error → ErrUpstreamFailure. Same nil-ctx
+      pattern as the other Service tests so no DB needed.
+
+not_injected:
+  - id: space-isolation
+    why: This endpoint resolves identity from a token; it does not access
+      space-scoped data. Space membership checks are the caller's
+      responsibility downstream.

--- a/modules/auth/1module.go
+++ b/modules/auth/1module.go
@@ -52,6 +52,11 @@ func (m *moduleAPI) Route(r *wkhttp.WKHttp) {
 	{
 		v.POST("/auth/verify", verifyLimit, m.api.verifyUserHTTP)
 		v.POST("/auth/verify-bot", verifyLimit, m.api.verifyBotHTTP)
+		// verify-api-key reuses the same verifyLimit bucket (per plan
+		// §5.4 / §10) — prevents attackers from probing API keys at a
+		// higher rate than they could probe session tokens. Sharing the
+		// "verify" tag also keeps the operator dashboards consolidated.
+		v.POST("/auth/verify-api-key", verifyLimit, m.api.verifyAPIKeyHTTP)
 	}
 }
 

--- a/modules/auth/api.go
+++ b/modules/auth/api.go
@@ -63,6 +63,26 @@ func (a *API) verifyBotHTTP(c *wkhttp.Context) {
 	c.Response(resp)
 }
 
+// verifyAPIKeyHTTP handles POST /v1/auth/verify-api-key. Wires the
+// stub APIKeyLookup from modules/usersecret through the standard
+// Service → handler → httperr.ResponseErrorL path; until real `uk_`
+// storage lands, every call returns 401 ErrAuthTokenInvalid which is
+// the same contract surface fleet's SDK already expects.
+func (a *API) verifyAPIKeyHTTP(c *wkhttp.Context) {
+	var req VerifyAPIKeyReq
+	if err := c.BindJSON(&req); err != nil {
+		a.log.Warn("auth: verify-api-key request body malformed", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrAuthTokenInvalid, nil, nil)
+		return
+	}
+	resp, err := a.svc.VerifyAPIKey(c.Request.Context(), req)
+	if err != nil {
+		a.handleServiceError(c, "verify-api-key", err)
+		return
+	}
+	c.Response(resp)
+}
+
 // handleServiceError maps a sentinel error from the Service to the right
 // errcode + log line. Anti-enumeration: all "token bad" reasons collapse
 // to a single 401 (ErrAuthTokenInvalid) at the wire; the specific reason
@@ -77,7 +97,9 @@ func (a *API) verifyBotHTTP(c *wkhttp.Context) {
 // (Jerry-Xin / yujiawei review on #431).
 func (a *API) handleServiceError(c *wkhttp.Context, endpoint string, err error) {
 	switch {
-	case errors.Is(err, ErrInvalidUserToken), errors.Is(err, ErrInvalidBotToken):
+	case errors.Is(err, ErrInvalidUserToken),
+		errors.Is(err, ErrInvalidBotToken),
+		errors.Is(err, ErrInvalidAPIKey):
 		// Single anti-enumeration code; log the specific sentinel so
 		// operators can still distinguish in audit.
 		a.log.Info("auth: rejected", zap.String("endpoint", endpoint), zap.Error(err))

--- a/modules/auth/api.go
+++ b/modules/auth/api.go
@@ -65,14 +65,17 @@ func (a *API) verifyBotHTTP(c *wkhttp.Context) {
 
 // verifyAPIKeyHTTP handles POST /v1/auth/verify-api-key. Wires the
 // stub APIKeyLookup from modules/usersecret through the standard
-// Service → handler → httperr.ResponseErrorL path; until real `uk_`
-// storage lands, every call returns 401 ErrAuthTokenInvalid which is
-// the same contract surface fleet's SDK already expects.
+// Service → handler → httperr path; until real `uk_` storage lands,
+// every call returns 401 ErrAuthTokenInvalid which is the same
+// contract surface fleet's SDK already expects.
+//
+// Uses ResponseErrorLWithStatus for the same wire-status reason as
+// verifyUserHTTP / verifyBotHTTP (see handleServiceError comment).
 func (a *API) verifyAPIKeyHTTP(c *wkhttp.Context) {
 	var req VerifyAPIKeyReq
 	if err := c.BindJSON(&req); err != nil {
 		a.log.Warn("auth: verify-api-key request body malformed", zap.Error(err))
-		httperr.ResponseErrorL(c, errcode.ErrAuthTokenInvalid, nil, nil)
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrAuthTokenInvalid, nil, nil)
 		return
 	}
 	resp, err := a.svc.VerifyAPIKey(c.Request.Context(), req)

--- a/modules/auth/contract.go
+++ b/modules/auth/contract.go
@@ -63,3 +63,25 @@ type VerifyBotResp struct {
 	Scope         string `json:"scope,omitempty"`
 	SpaceID       string `json:"space_id"`
 }
+
+// VerifyAPIKeyReq is the request body for POST /v1/auth/verify-api-key.
+// Daemon-side callers (e.g. octo-fleet runtime daemon) send their `uk_`
+// API key here to resolve their owner identity. Until real `uk_` storage
+// lands, every call resolves to "no match" → 401 ErrAuthTokenInvalid; the
+// contract is in place so daemons stop seeing a 404 ghost endpoint.
+type VerifyAPIKeyReq struct {
+	APIKey string `json:"api_key"`
+}
+
+// VerifyAPIKeyResp is the response body for POST /v1/auth/verify-api-key.
+// SpaceID and OwnedBotsBySpace are optional — empty when the key carries
+// no context binding (the only path that exists today since the lookup
+// is a stub).
+type VerifyAPIKeyResp struct {
+	SchemaVersion    int                 `json:"schema_version"`
+	Kind             string              `json:"kind"` // "apikey"
+	UID              string              `json:"uid"`
+	KeyID            string              `json:"key_id"`
+	SpaceID          string              `json:"space_id,omitempty"`
+	OwnedBotsBySpace map[string][]string `json:"owned_bots_by_space,omitempty"`
+}

--- a/modules/auth/service.go
+++ b/modules/auth/service.go
@@ -220,6 +220,52 @@ func (s *Service) lookupUserName(uid string) string {
 	return name
 }
 
+// VerifyAPIKey implements POST /v1/auth/verify-api-key business logic.
+//
+// Calls the registered APIKeyLookup (modules/usersecret) to resolve a
+// `uk_`-prefixed API key to its owner identity.
+//
+// Stage A scope (PR-A4): the usersecret.LookupAPIKey implementation is
+// a stub (it returns nil, nil for every input) because real `uk_` API
+// Key storage does not yet exist in octo-server. This handler is in
+// place so fleet's daemon /v1/auth/verify-api-key call stops 404ing —
+// it instead returns the structured 401 ErrAuthTokenInvalid envelope
+// fleet's SDK already knows how to handle. The day real storage lands,
+// only the stub body in modules/usersecret/lookup.go has to change;
+// this handler and its wire contract stay put.
+//
+// Same error-mapping contract as VerifyBot:
+//   - empty / whitespace token → ErrInvalidAPIKey
+//   - no APIKeyLookup registered → ErrUpstreamFailure
+//   - lookup returns nil, nil → ErrInvalidAPIKey
+//   - lookup returns non-nil error → ErrUpstreamFailure
+//   - lookup returns identity → wrap into VerifyAPIKeyResp
+func (s *Service) VerifyAPIKey(ctx context.Context, req VerifyAPIKeyReq) (*VerifyAPIKeyResp, error) {
+	key := strings.TrimSpace(req.APIKey)
+	if key == "" {
+		return nil, ErrInvalidAPIKey
+	}
+	lookup := GetAPIKeyLookup()
+	if lookup == nil {
+		return nil, ErrUpstreamFailure
+	}
+	id, err := lookup.LookupAPIKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrUpstreamFailure, err)
+	}
+	if id == nil {
+		return nil, ErrInvalidAPIKey
+	}
+	return &VerifyAPIKeyResp{
+		SchemaVersion:    1,
+		Kind:             "apikey",
+		UID:              id.UID,
+		KeyID:            id.KeyID,
+		SpaceID:          id.SpaceID,
+		OwnedBotsBySpace: id.OwnedBotsBySpace,
+	}, nil
+}
+
 // Sentinel errors returned by Service methods. The HTTP layer in api.go
 // maps these to errcode.ErrAuth* codes — keeping the mapping in one
 // place lets the Service be unit-tested without httperr import.
@@ -230,6 +276,9 @@ var (
 	// ErrInvalidBotToken — anti-enumeration catch-all for bot verify.
 	// Maps to errcode.ErrAuthTokenInvalid (401).
 	ErrInvalidBotToken = errors.New("auth: invalid or expired bot token")
+	// ErrInvalidAPIKey — anti-enumeration catch-all for API Key verify.
+	// Maps to errcode.ErrAuthTokenInvalid (401).
+	ErrInvalidAPIKey = errors.New("auth: invalid or expired api key")
 	// ErrBotUnavailable — App Bot exists but is unpublished.
 	// Maps to errcode.ErrAuthBotUnpublished (503).
 	ErrBotUnavailable = errors.New("auth: bot is currently unavailable")

--- a/modules/auth/service_test.go
+++ b/modules/auth/service_test.go
@@ -167,3 +167,85 @@ func TestServiceVerifyBotNoLookupRegistered(t *testing.T) {
 		t.Fatalf("no-provider must return ErrUpstreamFailure, got %v", err)
 	}
 }
+
+// fakeAPIKeyLookup is an in-memory APIKeyLookup for service tests.
+type fakeAPIKeyLookup struct {
+	keys map[string]*APIKeyIdentity
+	err  error
+}
+
+func (f *fakeAPIKeyLookup) LookupAPIKey(apiKey string) (*APIKeyIdentity, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.keys[apiKey], nil
+}
+
+// TestServiceVerifyAPIKey covers the four documented paths: empty,
+// no-provider, lookup-miss, and lookup-hit. The lookup-error path is
+// covered transitively via the err-sticky fake.
+func TestServiceVerifyAPIKey(t *testing.T) {
+	prev := GetAPIKeyLookup()
+	t.Cleanup(func() {
+		if prev != nil {
+			SetAPIKeyLookup(prev)
+		}
+	})
+
+	s := &Service{}
+
+	// 1. Empty / whitespace → ErrInvalidAPIKey
+	for _, k := range []string{"", "   ", "\t\n"} {
+		if _, err := s.VerifyAPIKey(context.Background(), VerifyAPIKeyReq{APIKey: k}); !errors.Is(err, ErrInvalidAPIKey) {
+			t.Fatalf("empty/whitespace key %q must return ErrInvalidAPIKey, got %v", k, err)
+		}
+	}
+
+	// 2. No provider registered → ErrUpstreamFailure
+	apiKeyLookupValue.Store(&apiKeyLookupHolder{v: nil})
+	if _, err := s.VerifyAPIKey(context.Background(), VerifyAPIKeyReq{APIKey: "uk_x"}); !errors.Is(err, ErrUpstreamFailure) {
+		t.Fatalf("no-provider must return ErrUpstreamFailure, got %v", err)
+	}
+
+	// 3. Provider returns (nil, nil) → ErrInvalidAPIKey (the stub path
+	//    fleet hits today)
+	stub := &fakeAPIKeyLookup{keys: map[string]*APIKeyIdentity{}}
+	SetAPIKeyLookup(stub)
+	if _, err := s.VerifyAPIKey(context.Background(), VerifyAPIKeyReq{APIKey: "uk_no_match"}); !errors.Is(err, ErrInvalidAPIKey) {
+		t.Fatalf("nil-nil lookup must return ErrInvalidAPIKey, got %v", err)
+	}
+
+	// 4. Provider returns identity → response wrapped correctly with
+	//    schema_version=1 + kind="apikey"
+	wired := &fakeAPIKeyLookup{
+		keys: map[string]*APIKeyIdentity{
+			"uk_real": {
+				UID:              "u1",
+				KeyID:            "k1",
+				SpaceID:          "sp_a",
+				OwnedBotsBySpace: map[string][]string{"sp_a": {"b1", "b2"}},
+			},
+		},
+	}
+	SetAPIKeyLookup(wired)
+	resp, err := s.VerifyAPIKey(context.Background(), VerifyAPIKeyReq{APIKey: "uk_real"})
+	if err != nil {
+		t.Fatalf("happy path: %v", err)
+	}
+	if resp.SchemaVersion != 1 || resp.Kind != "apikey" {
+		t.Fatalf("envelope fields wrong: %+v", resp)
+	}
+	if resp.UID != "u1" || resp.KeyID != "k1" || resp.SpaceID != "sp_a" {
+		t.Fatalf("identity mapping mismatch: %+v", resp)
+	}
+	if len(resp.OwnedBotsBySpace["sp_a"]) != 2 {
+		t.Fatalf("OwnedBotsBySpace not preserved: %+v", resp.OwnedBotsBySpace)
+	}
+
+	// 5. Provider returns an infra error → ErrUpstreamFailure
+	boom := &fakeAPIKeyLookup{err: errors.New("redis down")}
+	SetAPIKeyLookup(boom)
+	if _, err := s.VerifyAPIKey(context.Background(), VerifyAPIKeyReq{APIKey: "uk_anything"}); !errors.Is(err, ErrUpstreamFailure) {
+		t.Fatalf("infra error must wrap to ErrUpstreamFailure, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

PR-A4 of Stage A epic (#428). Closes the verify-api-key contract gap: fleet's daemon `/v1/auth/verify-api-key` call stops 404ing and starts returning a structured 401 `ErrAuthTokenInvalid` envelope instead.

**Stacked on top of #431 (PR-A3).** Base branch = \`refactor/auth-verify-handlers\`.

The endpoint extends the modules/auth Service + API + 1module surface from PR-A3 with the missing third verify endpoint. The \`modules/usersecret.LookupAPIKey\` stub from PR-A2 stays stub; until real \`uk_\` API Key storage lands in a future PR, every fleet call resolves to no-match → 401. That's the same status code matter/fleet already handle, so fleet's daemon flow doesn't regress — it just stops hitting a 404 ghost and starts seeing a structured envelope.

## Related Issue

Refs #428

## Linked Spec

\`.octospec/tasks/auth-verify-api-key/brief.md\` (context + journal in same dir)

## Changes

All in \`modules/auth/\`:

- \`contract.go\` — \`VerifyAPIKeyReq\` / \`VerifyAPIKeyResp\` DTOs matching plan §4.1.3 (\`schema_version\`, \`kind\`, \`uid\`, \`key_id\`, optional \`space_id\`, optional \`owned_bots_by_space\`).
- \`service.go\` — \`Service.VerifyAPIKey\` method (same shape as VerifyBot: trim → empty-check → lookup → sentinel-map) and the new \`ErrInvalidAPIKey\` sentinel.
- \`api.go\` — \`verifyAPIKeyHTTP\` handler; \`handleServiceError\` extended to fold \`ErrInvalidAPIKey\` into the existing anti-enumeration single-401 family.
- \`1module.go\` — route registered under the **same** \`verifyLimit\` middleware as verify / verify-bot (shared \`"verify"\` tag → same Redis bucket namespace → attackers can't probe API keys faster than they probe session tokens, per plan §10 mitigation).
- \`service_test.go\` — 5-path \`TestServiceVerifyAPIKey\` covering empty/whitespace input, no-provider-registered (boot race), lookup-returns-nil-nil (the stub path), lookup-returns-identity (forward-compatible), lookup-returns-error → upstream.

## Testing

- \`go test ./modules/auth/...\` → **PASS** (all 5 VerifyAPIKey paths)
- \`go build ./...\` → **clean**
- \`go vet ./...\` → **clean**
- \`golangci-lint run ./...\` → **0 issues**
- \`make i18n-extract-check\` → **clean** (no new errcodes registered)
- \`make i18n-lint\` → **green**

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   Adds a new HTTP route \`/v1/auth/verify-api-key\` that wires the (stub) \`APIKeyLookup\` from PR-A2 through the standard verify Service → handler → httperr envelope path. The endpoint shares verifyLimit with the other two verify endpoints (same Redis bucket). All "API key bad" outcomes collapse to the single 401 \`ErrAuthTokenInvalid\` (anti-enumeration).

2. **What could break because of it (dependents + failure mode)?**

   The risk is **zero** for existing matter/fleet flows because (a) those flows never sent verify-api-key requests as a hard requirement (the endpoint was a ghost, so any code that depends on the response must already tolerate failure), and (b) the response status code (401) is the same one fleet already handles for session expiry. The new wire body fields (\`schema_version\`, \`code\`, \`message\`) are ignored by existing clients.

   The risk that does exist is **future**: when real \`uk_\` storage lands, the stub body in \`modules/usersecret/lookup.go\` will change to actually find keys. Any caller that has been relying on "verify-api-key always 401" will start seeing 200 responses for real keys. That's the intended outcome of the future storage PR, not a regression of this one.

3. **How do you know it works (specific test/repro/trace)?**

   - \`TestServiceVerifyAPIKey\` covers all five documented branches: empty/whitespace → \`ErrInvalidAPIKey\` (collapses to 401); no-provider → \`ErrUpstreamFailure\` (collapses to 500); lookup-returns-nil-nil → \`ErrInvalidAPIKey\` (the stub path, what fleet sees today); lookup-returns-identity → 200 with correctly-mapped envelope (forward-compatible); lookup-returns-error → \`ErrUpstreamFailure\` (500).
   - \`go test ./modules/auth/...\` PASS.
   - Build, vet, lint, i18n all clean.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests
- [x] Updated documentation (\`.octospec/\` brief / context / journal / log)
- [x] Followed commit message conventions