### PR TITLE
docs(auth): harden pkg/auth Deprecated marker with explicit removal date

### DIFF
--- a/pkg/auth/aliases.go
+++ b/pkg/auth/aliases.go
@@ -51,40 +51,40 @@ import (
 
 // TokenInfo is an alias for [modulesauth.TokenInfo].
 //
-// Deprecated: use [modulesauth.TokenInfo].
+// Deprecated: use [modulesauth.TokenInfo]. To be removed on or after 2026-12-22 — see [octo-server#428].
 type TokenInfo = modulesauth.TokenInfo
 
 // LanguageResolver is an alias for [modulesauth.LanguageResolver].
 //
-// Deprecated: use [modulesauth.LanguageResolver].
+// Deprecated: use [modulesauth.LanguageResolver]. To be removed on or after 2026-12-22 — see [octo-server#428].
 type LanguageResolver = modulesauth.LanguageResolver
 
 // RoleResolver is an alias for [modulesauth.RoleResolver].
 //
-// Deprecated: use [modulesauth.RoleResolver].
+// Deprecated: use [modulesauth.RoleResolver]. To be removed on or after 2026-12-22 — see [octo-server#428].
 type RoleResolver = modulesauth.RoleResolver
 
 // CacheTokenParser is an alias for [modulesauth.CacheTokenParser].
 //
-// Deprecated: use [modulesauth.CacheTokenParser].
+// Deprecated: use [modulesauth.CacheTokenParser]. To be removed on or after 2026-12-22 — see [octo-server#428].
 type CacheTokenParser = modulesauth.CacheTokenParser
 
 // ParserOption is an alias for [modulesauth.ParserOption].
 //
-// Deprecated: use [modulesauth.ParserOption].
+// Deprecated: use [modulesauth.ParserOption]. To be removed on or after 2026-12-22 — see [octo-server#428].
 type ParserOption = modulesauth.ParserOption
 
 // ErrEmptyToken re-exports [modulesauth.ErrEmptyToken] by value so
 // `errors.Is(err, auth.ErrEmptyToken)` keeps matching errors produced by the
 // canonical package.
 //
-// Deprecated: use [modulesauth.ErrEmptyToken].
+// Deprecated: use [modulesauth.ErrEmptyToken]. To be removed on or after 2026-12-22 — see [octo-server#428].
 var ErrEmptyToken = modulesauth.ErrEmptyToken
 
 // ErrInvalidToken re-exports [modulesauth.ErrInvalidToken] by value; same
 // sentinel-identity contract as [ErrEmptyToken].
 //
-// Deprecated: use [modulesauth.ErrInvalidToken].
+// Deprecated: use [modulesauth.ErrInvalidToken]. To be removed on or after 2026-12-22 — see [octo-server#428].
 var ErrInvalidToken = modulesauth.ErrInvalidToken
 
 // Encode is a wrapper preserving the exported call signature for callers
@@ -92,7 +92,7 @@ var ErrInvalidToken = modulesauth.ErrInvalidToken
 // function immutable (unlike a `var = ...` re-export, which would let an
 // importer reassign the symbol package-globally).
 //
-// Deprecated: use [modulesauth.Encode].
+// Deprecated: use [modulesauth.Encode]. To be removed on or after 2026-12-22 — see [octo-server#428].
 func Encode(info TokenInfo) (string, error) {
 	return modulesauth.Encode(info)
 }
@@ -100,21 +100,21 @@ func Encode(info TokenInfo) (string, error) {
 // Decode is a wrapper mirroring [Encode]; see Encode for the wrapper-vs-var
 // rationale.
 //
-// Deprecated: use [modulesauth.Decode].
+// Deprecated: use [modulesauth.Decode]. To be removed on or after 2026-12-22 — see [octo-server#428].
 func Decode(raw string) (TokenInfo, error) {
 	return modulesauth.Decode(raw)
 }
 
 // WithLanguageResolver is a wrapper for [modulesauth.WithLanguageResolver].
 //
-// Deprecated: use [modulesauth.WithLanguageResolver].
+// Deprecated: use [modulesauth.WithLanguageResolver]. To be removed on or after 2026-12-22 — see [octo-server#428].
 func WithLanguageResolver(r LanguageResolver) ParserOption {
 	return modulesauth.WithLanguageResolver(r)
 }
 
 // WithRoleResolver is a wrapper for [modulesauth.WithRoleResolver].
 //
-// Deprecated: use [modulesauth.WithRoleResolver].
+// Deprecated: use [modulesauth.WithRoleResolver]. To be removed on or after 2026-12-22 — see [octo-server#428].
 func WithRoleResolver(r RoleResolver) ParserOption {
 	return modulesauth.WithRoleResolver(r)
 }
@@ -124,7 +124,7 @@ func WithRoleResolver(r RoleResolver) ParserOption {
 // `NewCacheTokenParser(c, prefix, WithLanguageResolver(r), WithRoleResolver(rr))`
 // keep compiling unchanged.
 //
-// Deprecated: use [modulesauth.NewCacheTokenParser].
+// Deprecated: use [modulesauth.NewCacheTokenParser]. To be removed on or after 2026-12-22 — see [octo-server#428].
 func NewCacheTokenParser(c cache.Cache, prefix string, opts ...ParserOption) *CacheTokenParser {
 	return modulesauth.NewCacheTokenParser(c, prefix, opts...)
 }

--- a/pkg/auth/aliases.go
+++ b/pkg/auth/aliases.go
@@ -6,11 +6,41 @@
 // This package is kept only so the six existing call sites (main.go,
 // modules/{group,message,user,qrcode}/api.go, modules/user/api_manager.go)
 // can be migrated incrementally and so out-of-tree forks have a deprecation
-// window. Six months after this shim was introduced it WILL be removed; new
-// code must import modules/auth directly.
+// window.
+//
+// # Removal schedule
+//
+// This shim is scheduled for removal on or after 2026-12-22 (six months
+// after the alias was introduced in PR-A1 / #429). The removal is tracked
+// alongside the Stage A epic [octo-server#428] so anyone touching pkg/auth
+// in the interim can see the deadline + see who owns the migration.
+//
+// What the removal entails:
+//   - Delete pkg/auth/aliases.go and pkg/auth/aliases_test.go.
+//   - The six callers listed above must by then have switched their imports
+//     to "github.com/Mininglamp-OSS/octo-server/modules/auth".
+//   - Out-of-tree forks that still import pkg/auth at removal time will
+//     get a clean compile error pointing them at the canonical path
+//     (the package itself disappears; no silent breakage).
+//
+// To migrate a caller today: change
+//
+//	import "github.com/Mininglamp-OSS/octo-server/pkg/auth"
+//
+// to
+//
+//	import "github.com/Mininglamp-OSS/octo-server/modules/auth"
+//
+// The exported surface is identical (types via Go `type =` aliases;
+// sentinel errors re-exported by value so [errors.Is] still works;
+// functions re-exported as wrapper funcs preserving variadic signatures).
+// `gofmt -r` or a one-shot `goimports` pass over the importing file is
+// enough — no further code edits are needed.
 //
 // Deprecated: import
-// "github.com/Mininglamp-OSS/octo-server/modules/auth" instead.
+// "github.com/Mininglamp-OSS/octo-server/modules/auth" instead. To be
+// removed on or after 2026-12-22 — see [octo-server#428] for the
+// migration tracker.
 package auth
 
 import (


### PR DESCRIPTION
## Summary

PR-D1 (server-side Stage D cleanup) of Stage A epic (#428). The PR-A1 shim's Deprecated marker said \"six months after this shim was introduced\" without giving the actual date — ambiguous when reviewers grep for upcoming removals. This PR pins:

- An explicit removal date (**2026-12-22** = 6 months from the alias introduction in PR-A1 #429).
- A pointer to the migration tracker (#428) so anyone touching pkg/auth in the interim can see who owns the migration.
- A concrete one-line migration recipe in the package doc, so a contributor reading the deprecation warning can act immediately.

**Stacked on top of #432 (PR-A4)**. Base = \`refactor/auth-verify-api-key\`.

## Changes

Comments only — single file (\`pkg/auth/aliases.go\`). No executable code touched.

## Effect on callers

The per-symbol Deprecated lines now show the removal date alongside the redirect, so godoc and the golangci-lint \`deprecated\` check produce a more actionable warning at every call site. Visible in the diagnostics on the six existing pkg/auth importers (main.go, modules/{group,message,user,qrcode}/api.go, modules/user/api_manager.go).

## Testing

- \`go build ./pkg/auth/...\` — clean
- \`go test ./pkg/auth/...\` — PASS
- \`golangci-lint run ./pkg/auth/...\` — 0 issues
- (Docs-only PR; full repo gates from PR-A1 / A2 / A3 / A4 unchanged.)

## Checklist

- [x] PR in English
- [x] No code change, only docs
- [x] Conventional Commits