### PR TITLE
fix(messages_search): strip Chinese stopwords + MSM 75% to kill multi…

### DIFF
--- a/docs/messages-search/2026-06-23-multimatch-or-trap-fix.md
+++ b/docs/messages-search/2026-06-23-multimatch-or-trap-fix.md
@@ -1,0 +1,232 @@
+# messages_search: multi_match OR-trap 修正
+
+- 日期: 2026-06-23
+- 范围: `modules/messages_search/`(reader 层 DSL)
+- 不涉及: `octo-search-indexer`(写入/字段投影,与方案 B 部署无关)
+
+## 1. 问题
+
+前端在群内搜索 `"按时缴纳时间的女性"` 这种无语义短语,后端 `_search_all` 返回大量
+"无关消息",高亮全打在 `的` 字上。换成其他含 `的` 的胡乱组合也复现。
+
+## 2. 根因
+
+ik_smart 把 `按时缴纳时间的女性` 切成 5 个 token:
+
+```
+按时 / 缴纳 / 时间 / 的 / 女性
+```
+
+reader 层用 `elastic.NewMultiMatchQuery(req.Keyword, ...)` 构造查询,go-elastic
+库默认 `type=best_fields`、`operator=OR`,**任一 token 命中即返回**。`的`
+是中文最高频虚词,命中近乎全库 → 实测 OR 召回 10000,AND 召回 0。
+
+## 3. 受影响位点(共 4 处,非 3 处)
+
+| 文件 | 行 | 上下文 | 备注 |
+|---|---|---|---|
+| `modules/messages_search/search_messages.go` | 135 | `b.Must(elastic.NewMultiMatchQuery(...))` | 搜消息 tab |
+| `modules/messages_search/search_all.go` | 137 | `b.Should(elastic.NewMultiMatchQuery(...))` text/mergeForward 分支 | 搜全部 tab |
+| `modules/messages_search/search_all.go` | 141 | `b.Should(elastic.NewMultiMatchQuery(...))` file 分支 | 搜全部 tab |
+| `modules/messages_search/search_files.go` | 139 | `b.Must(elastic.NewMultiMatchQuery(...))` | **同事漏掉的一处**,搜文件 tab |
+
+`search_media.go` 走 `validateKeywordMustBeEmpty`,不接 keyword,无影响。
+`search_around.go` 通过 `messageId` 锚定,不走 multi_match,无影响。
+
+> `search_all.go` 顶层的 `b.MinimumShouldMatch("1")` 只决定两个 Should 分支至少命中
+> 一个,**不**等于 multi_match 内部的 token MSM,所以仍然落在 OR-trap 里。
+
+## 4. 修复方案
+
+### 4.1 主推:reader 层条件性 stopword 剥离 + `_analyze`
+
+核心规则:**只在剥离后还剩内容词时才剥离,否则原 keyword 直查**——既屏蔽虚词
+噪音,又保留对纯虚词(`"的"`)的字面搜索能力。
+
+切词外包给 OpenSearch(避免 Go 端引 IK 依赖),停用词集合在 Go 这边维护。
+
+流程:
+
+```go
+// 1. 调 OS _analyze 拿 IK 切词结果(无索引依赖)
+tokens, _ := osClient.IndexAnalyze().
+    Analyzer("ik_smart").
+    Text(req.Keyword).
+    Do(ctx)
+// → ["按时","缴纳","时间","的","女性"]
+
+// 2. 滤掉停用词(in-memory set,见 §4.3)
+content := filterStopwords(tokens, stopwordsSet)
+// → ["按时","缴纳","时间","女性"]
+
+// 3. 分支构造 query
+var keywordClause elastic.Query
+if len(content) == 0 {
+    // 纯虚词路径:原 keyword 直查,不上 MSM
+    keywordClause = elastic.NewMultiMatchQuery(req.Keyword, fields...).
+        Type("cross_fields")
+} else {
+    // 内容词路径:用滤后版本,MSM 75% 屏蔽剩余噪音
+    filtered := strings.Join(content, " ")
+    keywordClause = elastic.NewMultiMatchQuery(filtered, fields...).
+        Type("cross_fields").
+        MinimumShouldMatch("75%")
+}
+b.Must(keywordClause)
+```
+
+**关键设计点**:
+
+- **stopword 不进 MSM 分母**。3 词查询 `"在公司"` → 滤后 2 词 `[公司]`(假设 "在"
+  在停用词集合),MSM 75% 作用于 1 词,trivially 满足,只看 "公司" 是否命中。
+  vs. 方案 C(详见 §4.4) MSM 单独的做法:3 词全留 → MSM 75% = ceil(0.75×3) = 3
+  = AND,"在" 被迫强制命中,反而误漏。
+- **`Type("cross_fields")` 仍然必要**。`best_fields` 下 MSM 作用域是单字段,跨字段
+  (text/file.name/file.caption)的 75% 判定按"最佳字段"算,行为反直觉。
+  `cross_fields` 把所有字段视作虚拟拼接,token 在哪个字段都算 1 次命中,75% 的
+  语义和"4 词中 3"一致。
+- **纯虚词路径仍跑 multi_match**(不上 MSM),走 OR 行为是符合直觉的——`"的"`
+  alone 就是想要"找含'的'的消息"。
+- **代价**:每次 keyword 查询多一次 `_analyze` roundtrip(LAN 内 ~3–8ms)。但因
+  为后续 `_search` 阶段命中集更小、回流数据更少,实测总体 RT 通常持平或更短。
+
+### 4.2 实现位点
+
+四处裸 `NewMultiMatchQuery` 都走同一套预处理。建议抽工具函数:
+
+```go
+// modules/messages_search/keyword_query.go (新建)
+func buildKeywordClause(ctx context.Context, osClient *elastic.Client,
+    keyword string, fields ...string) (elastic.Query, error) {
+    // ...上述流程
+}
+```
+
+四处改造:
+
+| 文件 | 行 | 字段集 |
+|---|---|---|
+| `search_messages.go` | 135 | `payload.text.content^3, payload.image.*, payload.file.*, payload.mergeForward.msgs.searchText` |
+| `search_all.go` | 137 | `payload.text.content^3, payload.mergeForward.msgs.searchText` |
+| `search_all.go` | 141 | `payload.file.name^2, payload.file.caption` |
+| `search_files.go` | 139 | `payload.file.name^2, payload.file.caption` |
+
+`search_all.go` 仍然是两条 Should 分支,只是每条内部都用 `buildKeywordClause`。
+
+### 4.3 停用词集合
+
+放 `modules/messages_search/stopwords.go`,从 hardcoded 列表起步,后续按需挪到配置:
+
+```go
+var defaultStopwords = map[string]struct{}{
+    "的": {}, "了": {}, "在": {}, "是": {}, "和": {}, "也": {},
+    "就": {}, "都": {}, "而": {}, "及": {}, "与": {}, "或": {},
+    "把": {}, "被": {}, "对": {}, "向": {}, "从": {}, "到": {},
+    "给": {}, "让": {}, "比": {}, "为": {}, "以": {}, "于": {}, "由": {},
+    // 多字虚词(IK smart 会切成整 token)
+    "的话": {}, "之类": {}, "之中": {},
+}
+```
+
+迭代建议:线上接入后,把"被 MSM 过滤掉但仍频繁出现在 OR-trap 召回里"的 token
+统计出来,逐步加进集合。
+
+### 4.4 退化方案:仅 MSM 75%(不剥离)
+
+如果 `_analyze` roundtrip 不可接受,或前期想最小化变更,可以只做 §4.1 的 step 3
+分支里"内容词路径"那一段,跳过 §4.1 step 1/2,直接 `req.Keyword` + MSM 75% +
+`cross_fields`。
+
+**这是当前 patch 的最初版本,有局限**:
+- 1 token 纯虚词 `"的"`:MSM trivially 满足 → ✓ 可搜
+- 5 token 含虚词的胡乱查询:MSM 4/5,虚词单独不够数 → ✓ 屏蔽
+- **2~4 token 含虚词的查询**:`"在公司"` 之类,MSM 75% 退化成 AND,"在" 强制命中
+  → ✗ 仍有噪音/误漏
+
+如果产品只关心截图里那种极端胡乱组合 case,退化方案够用;否则上 §4.1 主方案。
+
+### 4.5 不采用:indexer 层 `search_analyzer`
+
+考虑过给字段配 `search_analyzer = ik_smart_with_stopwords`(query-time only,
+不需要 reindex),被否,原因:
+
+- 纯虚词查询 `"的"` 经过 search_analyzer → 空 token 流 → 0 命中,与产品需求冲突
+- 要兼容只能 reader 层叠空结果重试,两次 RT + 状态判断,反而不如 §4.1 简洁
+- 集群 mapping 改动需要协调 search-indexer 团队
+
+留作未来选项,如果停用词集合稳定下来、不再需要"纯虚词可搜"语义,可以切到这条
+路减少 reader 复杂度。
+
+## 5. 测试用例
+
+回归 spec 拆两层:
+
+**单元(Go,纯逻辑,不连 OS)** — `modules/messages_search/keyword_query_test.go`:
+
+| 用例 | 输入 keyword | 输入 tokens(mock _analyze) | 预期产物 |
+|---|---|---|---|
+| 纯虚词 | `"的"` | `["的"]` | `multi_match`,query=`"的"`,无 MSM |
+| 纯虚词多 token | `"的话"` | `["的话"]` | 同上,query=`"的话"` |
+| 全为虚词 | `"的了"` | `["的","了"]` | 同上,query=`"的了"`(剥离后空,走纯虚词路径) |
+| 含虚词 | `"按时缴纳时间的女性"` | `["按时","缴纳","时间","的","女性"]` | `multi_match`,query=`"按时 缴纳 时间 女性"`,MSM=75%,type=cross_fields |
+| 短 mixed | `"在公司"` | `["在","公司"]` | query=`"公司"`,MSM=75% |
+| 纯内容词 | `"季度报告"` | `["季度","报告"]` | query=`"季度 报告"`,MSM=75% |
+
+**集成(连真 OS + IK,跑 `make env-test`)** — `modules/messages_search/or_trap_e2e_test.go`:
+
+| 用例 | 输入 | 预期 |
+|---|---|---|
+| OR-trap 复现 | `"按时缴纳时间的女性"` | 修复前命中 ≫ 10、修复后 ≤ 极少数(只命中字面 4 词都中的) |
+| 纯虚词字面 | `"的"` | 正常返回所有字面含 "的" 的消息,不为 0 |
+| 短 mixed | `"在公司"` | 不被 "在" 的高频拖垮,只命中真实含 "公司" 的消息 |
+| 正常单实词 | `"会议"` | 召回不退化(对比修复前后召回数差异 < 5%) |
+| 模糊 4 词 | `"明天 下午 三点 开会"` | 命中至少 3 词的消息(75%) |
+| 文件 tab | `"季度 报告"` | `search_files` 行为与上一致 |
+
+## 6. 上线步骤
+
+1. 新建 `keyword_query.go`(工具函数)+ `stopwords.go`(集合)+ 单测。
+2. 改 4 处 `NewMultiMatchQuery`,统一走 `buildKeywordClause`。
+3. 跑 `go test ./modules/messages_search/...`——预计 `search_all_test.go` /
+   `search_messages` 相关现存断言会因 query 形状变化失败,需要更新断言或改
+   mock。重点核对 `dsl_test.go` 里对 `multi_match` 的字面 JSON 断言。
+4. 跑 `make env-test` 起真 OS,验证 §5 集成用例。
+5. 跑 `make i18n-extract-check` + `make i18n-lint`(本次不动 errcode,应通过)。
+6. 灰度环境对照召回:用 §5 集成用例的输入,grafana / 业务侧验证 RT、召回数、误召
+   回数三个指标。
+7. 灰度过 → 全量。
+8. 灰度期间监控 `_analyze` API 调用 RT 和失败率,失败时降级到 §4.4(只 MSM,不剥
+   离),建议预留 feature flag `messages_search.stopword_strip.enabled`。
+
+## 7. 关联
+
+- 截图证据: 用户 2026-06-23 反馈,query `按时缴纳时间的女性` 高亮全在 `的` 字。
+- 同事原始诊断: 锁定 `multi_match` 默认 OR + ik_smart 切词,建议 MSM 75% + 停用词
+  预处理。
+- 本文勘误与定型:
+  - 补充 `search_files.go:139`(共 4 处而非 3 处)
+  - 主推方案改为 reader 层"条件性 stopword 剥离 + `_analyze`",而非纯 MSM 75%
+    或 indexer 层 stopword
+  - 显式 `Type("cross_fields")` 才能让 MSM 在跨字段场景下行为符合直觉
+  - 保留"纯虚词可搜"语义(用户搜 `"的"` 仍应返回字面命中结果)
+
+## 8. Ops kill switch — `OCTO_SEARCH_STOPWORD_STRIP_ENABLED`
+
+落实 §6.8 预留的 `messages_search.stopword_strip.enabled` feature flag,作为线上
+误判的一键回退手段,无需重新发版。
+
+- **位置**: `SearchConfig.StopwordStripEnabled`(`modules/messages_search/config.go`)。
+- **环境变量**: `OCTO_SEARCH_STOPWORD_STRIP_ENABLED`(`strconv.ParseBool` 规则,
+  接受 `true/false`、`1/0`、`TRUE/FALSE` 等)。
+- **默认值**: `true`(开启 stopword strip)。
+- **关闭路径**(`OCTO_SEARCH_STOPWORD_STRIP_ENABLED=false`):
+  - `search_messages` / `search_files` / `search_all` 三个端点的 keyword 查询
+    **完全跳过** `_analyze` roundtrip——这是配置开关,不只是 query shape 改动。
+  - keyword clause 直接走 §4.4 退化路径:
+    `elastic.NewMultiMatchQuery(rawKeyword, fields...).Type("cross_fields").MinimumShouldMatch("75%")`。
+  - 行为与"`_analyze` 不可达时的降级"等价,但省掉一次 IK 集群往返。
+- **使用建议**: stopword 集合误判某个真实查询时(例如把领域专名 token 当成虚词
+  剥离),先翻 flag 应急 → 再迭代 `defaultStopwords` 列表 → flag 翻回。
+- **可观测**: flag 关闭后 `_analyze` 调用计数应降到 0;关闭期间 `_search*` RT
+  曲线应观察到 ~3–8ms 的均值下行(取决于 LAN 延迟)。
+

--- a/modules/messages_search/config.go
+++ b/modules/messages_search/config.go
@@ -51,6 +51,20 @@ type SearchConfig struct {
 	//     `spaceId` field. Logged at WARN on every p2p request so the
 	//     deviation cannot stay enabled silently.
 	RequireSpaceID bool
+	// StopwordStripEnabled gates the conditional stopword strip + `_analyze`
+	// pre-processing introduced by
+	// docs/messages-search/2026-06-23-multimatch-or-trap-fix.md.
+	//
+	//   - true (default): the search_messages / search_files / search_all
+	//     keyword paths call OS `_analyze?analyzer=ik_smart` and drop
+	//     stopwords (defaultStopwords) before constructing multi_match.
+	//   - false: ops-only kill switch. Skip `_analyze` entirely and fall
+	//     back to the §4.4 degraded shape — raw keyword + cross_fields +
+	//     MSM 75% — on every keyword request, including the previously
+	//     branchless pure-stopword path. Use when the strip behavior is
+	//     misclassifying queries in production and a one-line config flip
+	//     is preferable to a redeploy.
+	StopwordStripEnabled bool
 }
 
 // RateLimitCfg drives the per-loginUID 5 QPS / 20 burst limiter.
@@ -76,6 +90,10 @@ func loadConfig() SearchConfig {
 		CursorHMAC:        os.Getenv("OCTO_SEARCH_CURSOR_HMAC"),
 		UserAvatarBaseURL: strings.TrimRight(os.Getenv("OCTO_USER_AVATAR_BASE_URL"), "/"),
 		RequireSpaceID:    parseBool(os.Getenv("OCTO_SEARCH_REQUIRE_SPACE_ID"), true),
+		// Default ON; flipping OCTO_SEARCH_STOPWORD_STRIP_ENABLED=false is
+		// the ops kill switch documented in
+		// docs/messages-search/2026-06-23-multimatch-or-trap-fix.md §8.
+		StopwordStripEnabled: parseBool(os.Getenv("OCTO_SEARCH_STOPWORD_STRIP_ENABLED"), true),
 	}
 }
 

--- a/modules/messages_search/dsl_test.go
+++ b/modules/messages_search/dsl_test.go
@@ -1,13 +1,24 @@
 package messages_search
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/olivere/elastic"
 )
+
+// fallbackTestAnalyzer triggers buildKeywordClause's fallback path (raw
+// keyword + cross_fields + MSM 75%), which is what shape tests for the
+// non-keyword DSL plumbing want — the original keyword stays intact in the
+// emitted query, so the historical substring assertions continue to apply.
+// Tests asserting branch-specific shape live in keyword_query_test.go.
+func fallbackTestAnalyzer() stubAnalyzer {
+	return stubAnalyzer{err: errors.New("test: analyze unavailable")}
+}
 
 // extractDSL serialises a query for asserting structural shape in tests.
 func extractDSL(t *testing.T, q interface {
@@ -38,7 +49,12 @@ func TestBuildSearchMessagesDSL_Shape(t *testing.T) {
 			SenderIDs: []string{"u1", "u2"},
 		},
 	}
-	q := buildSearchMessagesDSL(req, "groupNo", "")
+	// Fallback analyzer keeps the original keyword in the emitted query, so
+	// the historical substring assertions (the "hello" pin) still apply. The
+	// MSM 75% + cross_fields shape introduced by the OR-trap fix is asserted
+	// in keyword_query_test.go alongside the branch logic — duplicating it
+	// here would just couple this test to the fallback path.
+	q, _ := buildSearchMessagesDSL(context.Background(), fallbackTestAnalyzer(), true, req, "groupNo", "")
 	dsl := extractDSL(t, q.(interface {
 		Source() (any, error)
 	}))
@@ -64,7 +80,7 @@ func TestBuildSearchMessagesDSL_NoKeywordSkipsMultiMatch(t *testing.T) {
 		ChannelType: channelTypeGroup,
 		ChannelID:   "groupNo",
 	}
-	q := buildSearchMessagesDSL(req, "groupNo", "")
+	q, _ := buildSearchMessagesDSL(context.Background(), fallbackTestAnalyzer(), true, req, "groupNo", "")
 	js, _ := json.Marshal(extractDSL(t, q.(interface {
 		Source() (any, error)
 	})))
@@ -101,7 +117,7 @@ func TestBuildSearchMediaDSL_FiltersTypes(t *testing.T) {
 
 func TestBuildSearchFilesDSL_NoKeywordSkipsMultiMatch(t *testing.T) {
 	req := SearchFilesReq{ChannelType: channelTypeGroup, ChannelID: "g"}
-	q := buildSearchFilesDSL(req, "g", "")
+	q, _ := buildSearchFilesDSL(context.Background(), fallbackTestAnalyzer(), true, req, "g", "")
 	js, _ := json.Marshal(extractDSL(t, q.(interface {
 		Source() (any, error)
 	})))
@@ -116,7 +132,7 @@ func TestBuildSearchFilesDSL_NoKeywordSkipsMultiMatch(t *testing.T) {
 
 func TestBuildSearchFilesDSL_KeywordIncludesMultiMatch(t *testing.T) {
 	req := SearchFilesReq{ChannelType: channelTypeGroup, ChannelID: "g", Keyword: "report"}
-	q := buildSearchFilesDSL(req, "g", "")
+	q, _ := buildSearchFilesDSL(context.Background(), fallbackTestAnalyzer(), true, req, "g", "")
 	js, _ := json.Marshal(extractDSL(t, q.(interface {
 		Source() (any, error)
 	})))
@@ -131,7 +147,7 @@ func TestBuildSearchFilesDSL_KeywordIncludesMultiMatch(t *testing.T) {
 
 func TestBuildSearchAllDSL_TypeFilter(t *testing.T) {
 	req := SearchMessagesReq{ChannelType: channelTypeGroup, ChannelID: "g", Keyword: "k"}
-	q := buildSearchAllDSL(req, "g", "")
+	q, _ := buildSearchAllDSL(context.Background(), fallbackTestAnalyzer(), true, req, "g", "")
 	js, _ := json.Marshal(extractDSL(t, q.(interface {
 		Source() (any, error)
 	})))
@@ -150,7 +166,7 @@ func TestBuildSearchAllDSL_TypeFilter(t *testing.T) {
 
 func TestBuildSearchAllDSL_NoKeywordKeepsTypeFilter(t *testing.T) {
 	req := SearchMessagesReq{ChannelType: channelTypeGroup, ChannelID: "g"}
-	q := buildSearchAllDSL(req, "g", "")
+	q, _ := buildSearchAllDSL(context.Background(), fallbackTestAnalyzer(), true, req, "g", "")
 	js, _ := json.Marshal(extractDSL(t, q.(interface {
 		Source() (any, error)
 	})))

--- a/modules/messages_search/keyword_query.go
+++ b/modules/messages_search/keyword_query.go
@@ -1,0 +1,123 @@
+package messages_search
+
+import (
+	"context"
+	"strings"
+
+	"github.com/olivere/elastic"
+)
+
+// tokenAnalyzer abstracts the IK tokenization step so the keyword-clause
+// builders can be unit-tested without standing up an OpenSearch cluster.
+// Production wires in an osIKSmartAnalyzer that calls the cluster's
+// `_analyze` endpoint; tests provide a stub returning a fixed token slice
+// (or an error to exercise the fallback path).
+type tokenAnalyzer interface {
+	Analyze(ctx context.Context, text string) ([]string, error)
+}
+
+// osIKSmartAnalyzer drives OS `_analyze?analyzer=ik_smart`. The endpoint is
+// index-independent (we pass no Index()), so it works even when the
+// configured read alias is empty/down — the IK plugin lives at the cluster
+// level.
+type osIKSmartAnalyzer struct {
+	client *elastic.Client
+}
+
+func newOSIKSmartAnalyzer(c *elastic.Client) osIKSmartAnalyzer {
+	return osIKSmartAnalyzer{client: c}
+}
+
+// Analyze returns the IK-smart token sequence for `text`, dropping empty
+// tokens defensively.
+func (a osIKSmartAnalyzer) Analyze(ctx context.Context, text string) ([]string, error) {
+	resp, err := a.client.IndexAnalyze().
+		Analyzer("ik_smart").
+		Text(text).
+		Do(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, nil
+	}
+	tokens := make([]string, 0, len(resp.Tokens))
+	for _, t := range resp.Tokens {
+		if t.Token == "" {
+			continue
+		}
+		tokens = append(tokens, t.Token)
+	}
+	return tokens, nil
+}
+
+// AnalyzeKeyword runs IK-smart segmentation + stopword filtering against
+// `keyword` exactly once, returning the inputs needed by one or more
+// buildKeywordClauseFromAnalyzed calls. This lets a handler that issues
+// multiple multi_match clauses against the same keyword (e.g. _search_all
+// with separate text/file Should branches) reuse one `_analyze` roundtrip.
+//
+// Return contract per docs/messages-search/2026-06-23-multimatch-or-trap-fix.md §4.1:
+//
+//   - err != nil  → _analyze failed. effectiveKeyword == keyword, useMSM == true.
+//     Feeding this pair to buildKeywordClauseFromAnalyzed yields the §4.4
+//     degraded shape (raw keyword + cross_fields + MSM 75%). Caller may
+//     warn-log the error; the returned values are still safe to use.
+//   - post-strip token slice empty (pure stopwords like "的" / "的了"):
+//     effectiveKeyword == keyword (the original, unsplit string), useMSM == false.
+//     Builder emits raw keyword + cross_fields, no MSM — preserves the "user
+//     literally searches for a function word" semantic.
+//   - content tokens remain: effectiveKeyword == content tokens joined with
+//     spaces, useMSM == true. Builder emits the joined string + cross_fields +
+//     MSM 75%. Stopwords drop out of the MSM denominator so a 5-token query
+//     with one stopword becomes a 4-of-4 (75% ≈ 3) test on content words.
+func AnalyzeKeyword(ctx context.Context, a tokenAnalyzer, keyword string) (effectiveKeyword string, useMSM bool, err error) {
+	tokens, err := a.Analyze(ctx, keyword)
+	if err != nil {
+		return keyword, true, err
+	}
+	content := filterStopwords(tokens, defaultStopwords)
+	if len(content) == 0 {
+		return keyword, false, nil
+	}
+	return strings.Join(content, " "), true, nil
+}
+
+// buildKeywordClauseFromAnalyzed constructs the multi_match clause from a
+// previously-computed (effectiveKeyword, useMSM) pair — see AnalyzeKeyword.
+// Triggers no _analyze of its own, so a caller can issue multiple
+// field-specific clauses (text vs file) from a single analyze.
+//
+// type=cross_fields is required: under best_fields, MSM is evaluated per
+// field, and a token landing in any single field clears the bar, defeating
+// the threshold for multi-field corpora (text vs file.name etc).
+func buildKeywordClauseFromAnalyzed(effectiveKeyword string, useMSM bool, fields ...string) elastic.Query {
+	q := elastic.NewMultiMatchQuery(effectiveKeyword, fields...).Type("cross_fields")
+	if useMSM {
+		q = q.MinimumShouldMatch("75%")
+	}
+	return q
+}
+
+// buildKeywordClause is the thin wrapper preserved for callers that issue
+// exactly one multi_match per keyword (search_messages, search_files). The
+// signature, branch semantics, and returned error match the pre-split
+// implementation — see AnalyzeKeyword for the branch table.
+func buildKeywordClause(ctx context.Context, a tokenAnalyzer, keyword string, fields ...string) (elastic.Query, error) {
+	eff, useMSM, err := AnalyzeKeyword(ctx, a, keyword)
+	return buildKeywordClauseFromAnalyzed(eff, useMSM, fields...), err
+}
+
+// buildKeywordClauseGated is the flag-aware front door used by
+// buildSearchMessagesDSL / buildSearchFilesDSL.
+//
+// When stopwordStripEnabled is false, the `_analyze` call is skipped entirely
+// (no IK roundtrip RT) and the result degrades to the §4.4 shape — raw
+// keyword + cross_fields + MSM 75%. This is the ops kill switch for the
+// stopword-strip pipeline; see SearchConfig.StopwordStripEnabled.
+func buildKeywordClauseGated(ctx context.Context, a tokenAnalyzer, stopwordStripEnabled bool, keyword string, fields ...string) (elastic.Query, error) {
+	if !stopwordStripEnabled {
+		return buildKeywordClauseFromAnalyzed(keyword, true, fields...), nil
+	}
+	return buildKeywordClause(ctx, a, keyword, fields...)
+}

--- a/modules/messages_search/keyword_query_test.go
+++ b/modules/messages_search/keyword_query_test.go
@@ -1,0 +1,400 @@
+package messages_search
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// stubAnalyzer feeds buildKeywordClause a canned token list (or error) so the
+// keyword-DSL shape can be asserted without an OpenSearch cluster. Tests pass
+// either tokens (happy path) or err (fallback path); both can be set on the
+// same stub but tokens are ignored when err is non-nil — same as the real
+// IndexAnalyze().Do() contract.
+type stubAnalyzer struct {
+	tokens []string
+	err    error
+}
+
+func (s stubAnalyzer) Analyze(_ context.Context, _ string) ([]string, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.tokens, nil
+}
+
+// countingAnalyzer wraps a stubAnalyzer with a call counter. Used by the
+// flag-off tests to verify the `_analyze` roundtrip is actually skipped
+// (a query-shape assertion alone can't distinguish "analyze ran, fell back
+// to raw" from "analyze never ran").
+type countingAnalyzer struct {
+	inner stubAnalyzer
+	calls int
+}
+
+func (c *countingAnalyzer) Analyze(ctx context.Context, text string) ([]string, error) {
+	c.calls++
+	return c.inner.Analyze(ctx, text)
+}
+
+// keywordClauseBody marshals a buildKeywordClause result to JSON so substring
+// assertions stay legible. The wrapper returned by olivere matches the OS
+// wire shape ({ "multi_match": { ... } }), which is what we want to pin.
+func keywordClauseBody(t *testing.T, q interface {
+	Source() (any, error)
+}) string {
+	t.Helper()
+	src, err := q.Source()
+	if err != nil {
+		t.Fatalf("Source(): %v", err)
+	}
+	b, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+func TestBuildKeywordClause_PureStopword_SingleToken(t *testing.T) {
+	// "的" alone — user wants literal matches of the function word.
+	// Expected: original keyword, cross_fields, NO MSM.
+	a := stubAnalyzer{tokens: []string{"的"}}
+	q, err := buildKeywordClause(context.Background(), a, "的", "payload.text.content")
+	if err != nil {
+		t.Fatalf("unexpected analyze error: %v", err)
+	}
+	body := keywordClauseBody(t, q.(interface {
+		Source() (any, error)
+	}))
+	if !strings.Contains(body, `"query":"的"`) {
+		t.Errorf("pure stopword path must use the original keyword:\n%s", body)
+	}
+	if !strings.Contains(body, `"type":"cross_fields"`) {
+		t.Errorf("missing cross_fields type:\n%s", body)
+	}
+	if strings.Contains(body, "minimum_should_match") {
+		t.Errorf("pure stopword path must NOT set MSM (literal match semantic):\n%s", body)
+	}
+}
+
+func TestBuildKeywordClause_PureStopword_MultiCharToken(t *testing.T) {
+	// IK smart segments "的话" as a single token; it's in the stopword set
+	// and after filtering nothing remains → pure-stopword path.
+	a := stubAnalyzer{tokens: []string{"的话"}}
+	q, err := buildKeywordClause(context.Background(), a, "的话", "payload.text.content")
+	if err != nil {
+		t.Fatalf("unexpected analyze error: %v", err)
+	}
+	body := keywordClauseBody(t, q.(interface {
+		Source() (any, error)
+	}))
+	if !strings.Contains(body, `"query":"的话"`) {
+		t.Errorf("expected original keyword '的话':\n%s", body)
+	}
+	if strings.Contains(body, "minimum_should_match") {
+		t.Errorf("pure stopword must skip MSM:\n%s", body)
+	}
+}
+
+func TestBuildKeywordClause_PureStopword_AllStrippedAway(t *testing.T) {
+	// "的了" → ["的","了"] → after filter both gone. Must fall back to the
+	// original (unsplit) keyword so the user still gets literal hits.
+	a := stubAnalyzer{tokens: []string{"的", "了"}}
+	q, err := buildKeywordClause(context.Background(), a, "的了", "payload.text.content")
+	if err != nil {
+		t.Fatalf("unexpected analyze error: %v", err)
+	}
+	body := keywordClauseBody(t, q.(interface {
+		Source() (any, error)
+	}))
+	if !strings.Contains(body, `"query":"的了"`) {
+		t.Errorf("post-strip empty must use the ORIGINAL keyword, not the join:\n%s", body)
+	}
+	if strings.Contains(body, "minimum_should_match") {
+		t.Errorf("post-strip empty must NOT set MSM:\n%s", body)
+	}
+}
+
+func TestBuildKeywordClause_ContentWithStopword_OrTrapFix(t *testing.T) {
+	// The reproducer from the spec: 5-token query with a single stopword. The
+	// "的" must be dropped from the issued query so MSM 75% applies to the 4
+	// content words.
+	a := stubAnalyzer{tokens: []string{"按时", "缴纳", "时间", "的", "女性"}}
+	q, err := buildKeywordClause(context.Background(), a, "按时缴纳时间的女性",
+		"payload.text.content^3", "payload.mergeForward.msgs.searchText",
+	)
+	if err != nil {
+		t.Fatalf("unexpected analyze error: %v", err)
+	}
+	body := keywordClauseBody(t, q.(interface {
+		Source() (any, error)
+	}))
+	if !strings.Contains(body, `"query":"按时 缴纳 时间 女性"`) {
+		t.Errorf("filtered keyword must be the space-joined content tokens, no '的':\n%s", body)
+	}
+	if !strings.Contains(body, `"type":"cross_fields"`) {
+		t.Errorf("missing cross_fields type:\n%s", body)
+	}
+	if !strings.Contains(body, `"minimum_should_match":"75%"`) {
+		t.Errorf("missing MSM 75%%:\n%s", body)
+	}
+}
+
+func TestBuildKeywordClause_ShortMixed(t *testing.T) {
+	// "在公司" → ["在","公司"]. "在" is a stopword → MSM 75% on the lone
+	// content word "公司" trivially satisfies, the high-frequency "在"
+	// no longer drags noise into the result set.
+	a := stubAnalyzer{tokens: []string{"在", "公司"}}
+	q, err := buildKeywordClause(context.Background(), a, "在公司", "payload.text.content")
+	if err != nil {
+		t.Fatalf("unexpected analyze error: %v", err)
+	}
+	body := keywordClauseBody(t, q.(interface {
+		Source() (any, error)
+	}))
+	if !strings.Contains(body, `"query":"公司"`) {
+		t.Errorf("expected stripped query '公司':\n%s", body)
+	}
+	if !strings.Contains(body, `"minimum_should_match":"75%"`) {
+		t.Errorf("expected MSM 75%%:\n%s", body)
+	}
+}
+
+func TestBuildKeywordClause_AllContentWords(t *testing.T) {
+	// "季度报告" → ["季度","报告"]; both content words preserved → MSM 75%
+	// on the joined tokens.
+	a := stubAnalyzer{tokens: []string{"季度", "报告"}}
+	q, err := buildKeywordClause(context.Background(), a, "季度报告", "payload.file.name^2", "payload.file.caption")
+	if err != nil {
+		t.Fatalf("unexpected analyze error: %v", err)
+	}
+	body := keywordClauseBody(t, q.(interface {
+		Source() (any, error)
+	}))
+	if !strings.Contains(body, `"query":"季度 报告"`) {
+		t.Errorf("expected joined query '季度 报告':\n%s", body)
+	}
+	if !strings.Contains(body, `"type":"cross_fields"`) {
+		t.Errorf("missing cross_fields type:\n%s", body)
+	}
+	if !strings.Contains(body, `"minimum_should_match":"75%"`) {
+		t.Errorf("missing MSM 75%%:\n%s", body)
+	}
+	if !strings.Contains(body, `"payload.file.name^2"`) || !strings.Contains(body, `"payload.file.caption"`) {
+		t.Errorf("fields not propagated:\n%s", body)
+	}
+}
+
+func TestBuildKeywordClause_AnalyzeError_FallbackDegrades(t *testing.T) {
+	// Spec §4.4: when `_analyze` is unreachable, degrade to "raw keyword +
+	// cross_fields + MSM 75%" and surface the error so the handler can log.
+	a := stubAnalyzer{err: errors.New("ik unavailable")}
+	q, err := buildKeywordClause(context.Background(), a, "按时缴纳时间的女性", "payload.text.content")
+	if err == nil {
+		t.Fatalf("expected error to propagate so caller can warn-log")
+	}
+	body := keywordClauseBody(t, q.(interface {
+		Source() (any, error)
+	}))
+	if !strings.Contains(body, `"query":"按时缴纳时间的女性"`) {
+		t.Errorf("fallback must use the original keyword unmodified:\n%s", body)
+	}
+	if !strings.Contains(body, `"type":"cross_fields"`) {
+		t.Errorf("fallback must still apply cross_fields:\n%s", body)
+	}
+	if !strings.Contains(body, `"minimum_should_match":"75%"`) {
+		t.Errorf("fallback must still apply MSM 75%% to dampen OR-trap:\n%s", body)
+	}
+}
+
+// queryBody marshals a builder result for substring assertions. Same idea as
+// keywordClauseBody, but accepts the no-error builder return type.
+func queryBody(t *testing.T, q interface {
+	Source() (any, error)
+}) string {
+	t.Helper()
+	src, err := q.Source()
+	if err != nil {
+		t.Fatalf("Source(): %v", err)
+	}
+	b, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+// TestAnalyzeKeyword_PureStopword pins the second branch of the analyze
+// contract: when every token falls into the stopword set, return the
+// ORIGINAL keyword + useMSM=false so the builder downstream emits a raw
+// no-MSM clause (literal-stopword-search semantic).
+func TestAnalyzeKeyword_PureStopword(t *testing.T) {
+	a := stubAnalyzer{tokens: []string{"的", "了"}}
+	eff, useMSM, err := AnalyzeKeyword(context.Background(), a, "的了")
+	if err != nil {
+		t.Fatalf("unexpected analyze error: %v", err)
+	}
+	if eff != "的了" {
+		t.Errorf("pure-stopword branch must return the ORIGINAL keyword unsplit, got %q", eff)
+	}
+	if useMSM {
+		t.Errorf("pure-stopword branch must NOT request MSM (literal-search semantic)")
+	}
+}
+
+// TestAnalyzeKeyword_ContentWords pins the third branch: surviving content
+// tokens are space-joined and the builder must apply MSM 75%.
+func TestAnalyzeKeyword_ContentWords(t *testing.T) {
+	a := stubAnalyzer{tokens: []string{"按时", "缴纳", "时间", "的", "女性"}}
+	eff, useMSM, err := AnalyzeKeyword(context.Background(), a, "按时缴纳时间的女性")
+	if err != nil {
+		t.Fatalf("unexpected analyze error: %v", err)
+	}
+	if eff != "按时 缴纳 时间 女性" {
+		t.Errorf("expected stopword-stripped join, got %q", eff)
+	}
+	if !useMSM {
+		t.Errorf("content-word branch must request MSM 75%%")
+	}
+}
+
+// TestAnalyzeKeyword_FallbackOnError pins §4.4 degradation: when `_analyze`
+// is unreachable the caller receives (rawKeyword, useMSM=true, err) so the
+// downstream builder emits raw + cross_fields + MSM 75% and the handler can
+// warn-log the surfaced error.
+func TestAnalyzeKeyword_FallbackOnError(t *testing.T) {
+	a := stubAnalyzer{err: errors.New("ik unavailable")}
+	eff, useMSM, err := AnalyzeKeyword(context.Background(), a, "按时缴纳时间的女性")
+	if err == nil {
+		t.Fatalf("expected analyze error to propagate")
+	}
+	if eff != "按时缴纳时间的女性" {
+		t.Errorf("fallback must return the original keyword unmodified, got %q", eff)
+	}
+	if !useMSM {
+		t.Errorf("fallback must keep MSM 75%% (the §4.4 dampener)")
+	}
+}
+
+// TestAnalyzeKeyword_PostFilterEmpty: even when the post-filter content
+// slice is empty (every token stripped), the returned effectiveKeyword is
+// the ORIGINAL string — not the joined empty slice (which would be "") —
+// so the multi_match doesn't ship with an empty query body.
+func TestAnalyzeKeyword_PostFilterEmpty(t *testing.T) {
+	a := stubAnalyzer{tokens: []string{}}
+	eff, useMSM, err := AnalyzeKeyword(context.Background(), a, "literal")
+	if err != nil {
+		t.Fatalf("unexpected analyze error: %v", err)
+	}
+	if eff != "literal" {
+		t.Errorf("empty-token branch must fall back to the original keyword, got %q", eff)
+	}
+	if useMSM {
+		t.Errorf("empty-token branch must NOT request MSM")
+	}
+}
+
+// TestBuildKeywordClauseFromAnalyzed_OneAnalyzeManyClauses asserts the
+// followup #1 invariant: a caller can build any number of multi_match
+// clauses (different field sets) from a single AnalyzeKeyword result
+// without triggering a second analyze call.
+func TestBuildKeywordClauseFromAnalyzed_OneAnalyzeManyClauses(t *testing.T) {
+	a := &countingAnalyzer{inner: stubAnalyzer{tokens: []string{"季度", "报告"}}}
+	eff, useMSM, err := AnalyzeKeyword(context.Background(), a, "季度报告")
+	if err != nil {
+		t.Fatalf("unexpected analyze error: %v", err)
+	}
+	text := buildKeywordClauseFromAnalyzed(eff, useMSM, "payload.text.content^3", "payload.mergeForward.msgs.searchText")
+	file := buildKeywordClauseFromAnalyzed(eff, useMSM, "payload.file.name^2", "payload.file.caption")
+	if a.calls != 1 {
+		t.Fatalf("expected exactly one _analyze call for two clauses, got %d", a.calls)
+	}
+	textBody := queryBody(t, text.(interface {
+		Source() (any, error)
+	}))
+	fileBody := queryBody(t, file.(interface {
+		Source() (any, error)
+	}))
+	for _, want := range []string{`"query":"季度 报告"`, `"type":"cross_fields"`, `"minimum_should_match":"75%"`} {
+		if !strings.Contains(textBody, want) {
+			t.Errorf("text clause missing %q:\n%s", want, textBody)
+		}
+		if !strings.Contains(fileBody, want) {
+			t.Errorf("file clause missing %q:\n%s", want, fileBody)
+		}
+	}
+	if !strings.Contains(textBody, `"payload.text.content^3"`) {
+		t.Errorf("text clause missing text field set:\n%s", textBody)
+	}
+	if !strings.Contains(fileBody, `"payload.file.name^2"`) {
+		t.Errorf("file clause missing file field set:\n%s", fileBody)
+	}
+}
+
+// TestBuildKeywordClauseGated_FlagOffSkipsAnalyze pins the followup #2 kill
+// switch: when stopwordStripEnabled is false the gated builder must (a)
+// never call the analyzer (no `_analyze` roundtrip RT) and (b) emit the
+// §4.4 degraded shape — raw keyword + cross_fields + MSM 75%.
+func TestBuildKeywordClauseGated_FlagOffSkipsAnalyze(t *testing.T) {
+	a := &countingAnalyzer{inner: stubAnalyzer{tokens: []string{"按时", "缴纳", "时间", "的", "女性"}}}
+	q, err := buildKeywordClauseGated(context.Background(), a, false, "按时缴纳时间的女性",
+		"payload.text.content^3", "payload.mergeForward.msgs.searchText",
+	)
+	if err != nil {
+		t.Fatalf("flag-off path must never surface an analyze error: %v", err)
+	}
+	if a.calls != 0 {
+		t.Fatalf("flag-off path must NOT trigger _analyze, got %d calls", a.calls)
+	}
+	body := queryBody(t, q.(interface {
+		Source() (any, error)
+	}))
+	if !strings.Contains(body, `"query":"按时缴纳时间的女性"`) {
+		t.Errorf("flag-off must use the RAW keyword unmodified (no stopword strip):\n%s", body)
+	}
+	if !strings.Contains(body, `"type":"cross_fields"`) {
+		t.Errorf("flag-off must keep cross_fields:\n%s", body)
+	}
+	if !strings.Contains(body, `"minimum_should_match":"75%"`) {
+		t.Errorf("flag-off must keep MSM 75%% (§4.4 dampener):\n%s", body)
+	}
+}
+
+// TestBuildKeywordClauseGated_FlagOnPreservesStripBehavior is the
+// counter-test: flag=true keeps the existing buildKeywordClause path
+// (analyze runs, stopwords drop, MSM 75% applies to content tokens).
+func TestBuildKeywordClauseGated_FlagOnPreservesStripBehavior(t *testing.T) {
+	a := &countingAnalyzer{inner: stubAnalyzer{tokens: []string{"按时", "缴纳", "时间", "的", "女性"}}}
+	q, err := buildKeywordClauseGated(context.Background(), a, true, "按时缴纳时间的女性",
+		"payload.text.content^3",
+	)
+	if err != nil {
+		t.Fatalf("unexpected analyze error: %v", err)
+	}
+	if a.calls != 1 {
+		t.Fatalf("flag-on path must invoke _analyze exactly once, got %d", a.calls)
+	}
+	body := queryBody(t, q.(interface {
+		Source() (any, error)
+	}))
+	if !strings.Contains(body, `"query":"按时 缴纳 时间 女性"`) {
+		t.Errorf("flag-on must strip stopwords and join with spaces:\n%s", body)
+	}
+}
+
+// TestBuildSearchAllDSL_OneAnalyzePerKeyword is the followup #1 acceptance
+// test at the DSL level: _search_all has two Should branches against the
+// same keyword, and after the refactor must share one _analyze call.
+func TestBuildSearchAllDSL_OneAnalyzePerKeyword(t *testing.T) {
+	a := &countingAnalyzer{inner: stubAnalyzer{tokens: []string{"季度", "报告"}}}
+	req := SearchAllReq{ChannelType: channelTypeGroup, ChannelID: "g", Keyword: "季度报告"}
+	if _, err := buildSearchAllDSL(context.Background(), a, true, req, "g", ""); err != nil {
+		t.Fatalf("unexpected DSL error: %v", err)
+	}
+	if a.calls != 1 {
+		t.Fatalf("_search_all must reuse one _analyze across its two Should branches, got %d calls", a.calls)
+	}
+}
+

--- a/modules/messages_search/search_all.go
+++ b/modules/messages_search/search_all.go
@@ -62,7 +62,6 @@ func (h *Handler) searchAll(c *wkhttp.Context) {
 	}
 
 	normID := normalizedChannelID(req.ChannelType, req.ChannelID, loginUID)
-	dsl := buildSearchAllDSL(req, normID, spaceID)
 	isRelevance := req.Sort == "relevance"
 
 	initialAfter, ok := decodeCursorAsSearchAfter(h.cfg, req.Cursor, isRelevance)
@@ -77,6 +76,11 @@ func (h *Handler) searchAll(c *wkhttp.Context) {
 
 	ctx, cancel := context.WithTimeout(c.Request.Context(), h.cfg.Timeout)
 	defer cancel()
+
+	dsl, analyzeErr := buildSearchAllDSL(ctx, newOSIKSmartAnalyzer(client), h.cfg.StopwordStripEnabled, req, normID, spaceID)
+	if analyzeErr != nil {
+		h.Warn("messages_search: _analyze fallback (degraded keyword clause)", zap.Error(analyzeErr))
+	}
 
 	osQuery := func(searchAfter []any, size int) ([]*elastic.SearchHit, error) {
 		svc := client.Search().
@@ -122,7 +126,7 @@ func (h *Handler) searchAll(c *wkhttp.Context) {
 	c.Response(envelope(items, hasMore, nextCursor))
 }
 
-func buildSearchAllDSL(req SearchAllReq, normChannelID, spaceID string) elastic.Query {
+func buildSearchAllDSL(ctx context.Context, analyzer tokenAnalyzer, stopwordStripEnabled bool, req SearchAllReq, normChannelID, spaceID string) (elastic.Query, error) {
 	b := elastic.NewBoolQuery()
 	applyChannelAndRevoked(b, normChannelID)
 	applySpaceIDScope(b, req.ChannelType, spaceID)
@@ -132,20 +136,32 @@ func buildSearchAllDSL(req SearchAllReq, normChannelID, spaceID string) elastic.
 		payloadTypeMergeForward,
 	))
 	addCommonFilters(b, req.Filters)
+	var analyzeErr error
 	if req.Keyword != "" {
-		b.Should(
-			elastic.NewMultiMatchQuery(req.Keyword,
-				"payload.text.content^3",
-				"payload.mergeForward.msgs.searchText",
-			),
-			elastic.NewMultiMatchQuery(req.Keyword,
-				"payload.file.name^2",
-				"payload.file.caption",
-			),
+		eff, useMSM := req.Keyword, true
+		if stopwordStripEnabled {
+			// Single `_analyze` roundtrip feeds both Should branches — same
+			// keyword, same analyzer, so a second call would be redundant and
+			// double the IK-cluster RT cost of every _search_all hit.
+			var err error
+			eff, useMSM, err = AnalyzeKeyword(ctx, analyzer, req.Keyword)
+			analyzeErr = err
+		}
+		// When stopwordStripEnabled=false: skip _analyze entirely and emit the
+		// §4.4 degraded shape (raw keyword + cross_fields + MSM 75%) on both
+		// branches — the eff/useMSM defaults above match that contract.
+		textClause := buildKeywordClauseFromAnalyzed(eff, useMSM,
+			"payload.text.content^3",
+			"payload.mergeForward.msgs.searchText",
 		)
+		fileClause := buildKeywordClauseFromAnalyzed(eff, useMSM,
+			"payload.file.name^2",
+			"payload.file.caption",
+		)
+		b.Should(textClause, fileClause)
 		b.MinimumShouldMatch("1")
 	}
-	return b
+	return b, analyzeErr
 }
 
 func buildSearchAllHighlight() *elastic.Highlight {

--- a/modules/messages_search/search_files.go
+++ b/modules/messages_search/search_files.go
@@ -72,7 +72,6 @@ func (h *Handler) searchFiles(c *wkhttp.Context) {
 	}
 
 	normID := normalizedChannelID(req.ChannelType, req.ChannelID, loginUID)
-	dsl := buildSearchFilesDSL(req, normID, spaceID)
 	isRelevance := req.Sort == "relevance"
 
 	initialAfter, ok := decodeCursorAsSearchAfter(h.cfg, req.Cursor, isRelevance)
@@ -87,6 +86,11 @@ func (h *Handler) searchFiles(c *wkhttp.Context) {
 
 	ctx, cancel := context.WithTimeout(c.Request.Context(), h.cfg.Timeout)
 	defer cancel()
+
+	dsl, analyzeErr := buildSearchFilesDSL(ctx, newOSIKSmartAnalyzer(client), h.cfg.StopwordStripEnabled, req, normID, spaceID)
+	if analyzeErr != nil {
+		h.Warn("messages_search: _analyze fallback (degraded keyword clause)", zap.Error(analyzeErr))
+	}
 
 	osQuery := func(searchAfter []any, size int) ([]*elastic.SearchHit, error) {
 		svc := client.Search().
@@ -129,19 +133,22 @@ func (h *Handler) searchFiles(c *wkhttp.Context) {
 	c.Response(envelope(items, hasMore, nextCursor))
 }
 
-func buildSearchFilesDSL(req SearchFilesReq, normChannelID, spaceID string) elastic.Query {
+func buildSearchFilesDSL(ctx context.Context, analyzer tokenAnalyzer, stopwordStripEnabled bool, req SearchFilesReq, normChannelID, spaceID string) (elastic.Query, error) {
 	b := elastic.NewBoolQuery()
 	applyChannelAndRevoked(b, normChannelID)
 	applySpaceIDScope(b, req.ChannelType, spaceID)
 	b.Filter(elastic.NewTermQuery("payload.type", payloadTypeFile))
 	addCommonFilters(b, req.Filters)
+	var analyzeErr error
 	if req.Keyword != "" {
-		b.Must(elastic.NewMultiMatchQuery(req.Keyword,
+		clause, err := buildKeywordClauseGated(ctx, analyzer, stopwordStripEnabled, req.Keyword,
 			"payload.file.name^2",
 			"payload.file.caption",
-		))
+		)
+		b.Must(clause)
+		analyzeErr = err
 	}
-	return b
+	return b, analyzeErr
 }
 
 func (h *Handler) buildFileHits(ctx context.Context, hits []*elastic.SearchHit, req SearchFilesReq, loginUID string) []FileHit {

--- a/modules/messages_search/search_messages.go
+++ b/modules/messages_search/search_messages.go
@@ -67,7 +67,6 @@ func (h *Handler) searchMessages(c *wkhttp.Context) {
 	}
 
 	normID := normalizedChannelID(req.ChannelType, req.ChannelID, loginUID)
-	dsl := buildSearchMessagesDSL(req, normID, spaceID)
 	isRelevance := req.Sort == "relevance"
 
 	initialAfter, ok := decodeCursorAsSearchAfter(h.cfg, req.Cursor, isRelevance)
@@ -82,6 +81,11 @@ func (h *Handler) searchMessages(c *wkhttp.Context) {
 
 	ctx, cancel := context.WithTimeout(c.Request.Context(), h.cfg.Timeout)
 	defer cancel()
+
+	dsl, analyzeErr := buildSearchMessagesDSL(ctx, newOSIKSmartAnalyzer(client), h.cfg.StopwordStripEnabled, req, normID, spaceID)
+	if analyzeErr != nil {
+		h.Warn("messages_search: _analyze fallback (degraded keyword clause)", zap.Error(analyzeErr))
+	}
 
 	osQuery := func(searchAfter []any, size int) ([]*elastic.SearchHit, error) {
 		svc := client.Search().
@@ -128,22 +132,31 @@ func (h *Handler) searchMessages(c *wkhttp.Context) {
 	c.Response(envelope(items, hasMore, nextCursor))
 }
 
-// buildSearchMessagesDSL constructs the bool query for /_search.
-func buildSearchMessagesDSL(req SearchMessagesReq, normChannelID, spaceID string) elastic.Query {
+// buildSearchMessagesDSL constructs the bool query for /_search. Returns the
+// query plus a non-nil error iff the keyword path's `_analyze` call failed and
+// the keyword clause degraded to the fallback shape (raw keyword + MSM 75%);
+// the query is still safe to use, callers should warn-log the error.
+//
+// stopwordStripEnabled = false routes through the ops kill switch: skip the
+// `_analyze` call and emit the §4.4 degraded shape unconditionally.
+func buildSearchMessagesDSL(ctx context.Context, analyzer tokenAnalyzer, stopwordStripEnabled bool, req SearchMessagesReq, normChannelID, spaceID string) (elastic.Query, error) {
 	b := elastic.NewBoolQuery()
+	var analyzeErr error
 	if req.Keyword != "" {
-		b.Must(elastic.NewMultiMatchQuery(req.Keyword,
+		clause, err := buildKeywordClauseGated(ctx, analyzer, stopwordStripEnabled, req.Keyword,
 			"payload.text.content^3",
 			"payload.image.caption", "payload.image.name",
 			"payload.file.caption", "payload.file.name",
 			"payload.mergeForward.msgs.searchText",
-		))
+		)
+		b.Must(clause)
+		analyzeErr = err
 	}
 	applyChannelAndRevoked(b, normChannelID)
 	applySpaceIDScope(b, req.ChannelType, spaceID)
 	addCommonFilters(b, req.Filters)
 	b.MustNot(elastic.NewTermQuery("payload.type", payloadTypeCmd))
-	return b
+	return b, analyzeErr
 }
 
 // buildSearchMessagesHighlight returns the standard highlight config for

--- a/modules/messages_search/space_filter_test.go
+++ b/modules/messages_search/space_filter_test.go
@@ -1,6 +1,7 @@
 package messages_search
 
 import (
+	"context"
 	"encoding/json"
 	"net/http/httptest"
 	"strings"
@@ -38,7 +39,8 @@ func TestApplySpaceIDScope_P2PEmitsTermFilter(t *testing.T) {
 		ChannelID:   "peer",
 		Keyword:     "hi",
 	}
-	body := asJSONString(t, buildSearchMessagesDSL(req, "fake-cid", "spaceX").(interface {
+	q, _ := buildSearchMessagesDSL(context.Background(), fallbackTestAnalyzer(), true, req, "fake-cid", "spaceX")
+	body := asJSONString(t, q.(interface {
 		Source() (any, error)
 	}))
 	if !strings.Contains(body, `"spaceId":"spaceX"`) {
@@ -56,7 +58,8 @@ func TestApplySpaceIDScope_GroupBypassed(t *testing.T) {
 		ChannelID:   "G1",
 		Keyword:     "hi",
 	}
-	body := asJSONString(t, buildSearchMessagesDSL(req, "G1", "spaceX").(interface {
+	q, _ := buildSearchMessagesDSL(context.Background(), fallbackTestAnalyzer(), true, req, "G1", "spaceX")
+	body := asJSONString(t, q.(interface {
 		Source() (any, error)
 	}))
 	if strings.Contains(body, `spaceId`) {
@@ -70,7 +73,8 @@ func TestApplySpaceIDScope_ThreadBypassed(t *testing.T) {
 		ChannelID:   "G1____abcd",
 		Keyword:     "hi",
 	}
-	body := asJSONString(t, buildSearchMessagesDSL(req, "G1____abcd", "spaceX").(interface {
+	q, _ := buildSearchMessagesDSL(context.Background(), fallbackTestAnalyzer(), true, req, "G1____abcd", "spaceX")
+	body := asJSONString(t, q.(interface {
 		Source() (any, error)
 	}))
 	if strings.Contains(body, `spaceId`) {
@@ -88,7 +92,8 @@ func TestApplySpaceIDScope_P2PEmptySpaceIDIsNoOp(t *testing.T) {
 		ChannelID:   "peer",
 		Keyword:     "hi",
 	}
-	body := asJSONString(t, buildSearchMessagesDSL(req, "fake-cid", "").(interface {
+	q, _ := buildSearchMessagesDSL(context.Background(), fallbackTestAnalyzer(), true, req, "fake-cid", "")
+	body := asJSONString(t, q.(interface {
 		Source() (any, error)
 	}))
 	if strings.Contains(body, `spaceId`) {
@@ -100,6 +105,9 @@ func TestApplySpaceIDScope_P2PEmptySpaceIDIsNoOp(t *testing.T) {
 // route p2p through applySpaceIDScope. We pin all four explicitly because
 // future copies of the handler skeleton are easy to drift.
 func TestApplySpaceIDScope_AcrossEndpoints(t *testing.T) {
+	ctx := context.Background()
+	a := fallbackTestAnalyzer()
+
 	mediaReq := SearchMediaReq{ChannelType: channelTypePerson, ChannelID: "peer"}
 	if body := asJSONString(t, buildSearchMediaDSL(mediaReq, "fake", "S").(interface {
 		Source() (any, error)
@@ -107,13 +115,15 @@ func TestApplySpaceIDScope_AcrossEndpoints(t *testing.T) {
 		t.Errorf("search_media p2p DSL missing spaceId filter:\n%s", body)
 	}
 	filesReq := SearchFilesReq{ChannelType: channelTypePerson, ChannelID: "peer"}
-	if body := asJSONString(t, buildSearchFilesDSL(filesReq, "fake", "S").(interface {
+	filesQ, _ := buildSearchFilesDSL(ctx, a, true, filesReq, "fake", "S")
+	if body := asJSONString(t, filesQ.(interface {
 		Source() (any, error)
 	})); !strings.Contains(body, `"spaceId":"S"`) {
 		t.Errorf("search_files p2p DSL missing spaceId filter:\n%s", body)
 	}
 	allReq := SearchAllReq{ChannelType: channelTypePerson, ChannelID: "peer", Keyword: "k"}
-	if body := asJSONString(t, buildSearchAllDSL(allReq, "fake", "S").(interface {
+	allQ, _ := buildSearchAllDSL(ctx, a, true, allReq, "fake", "S")
+	if body := asJSONString(t, allQ.(interface {
 		Source() (any, error)
 	})); !strings.Contains(body, `"spaceId":"S"`) {
 		t.Errorf("search_all p2p DSL missing spaceId filter:\n%s", body)

--- a/modules/messages_search/stopwords.go
+++ b/modules/messages_search/stopwords.go
@@ -1,0 +1,33 @@
+package messages_search
+
+// defaultStopwords is the Chinese stopword set used by buildKeywordClause to
+// strip high-frequency function words (虚词) from an analyzed token stream
+// before constructing the multi_match clause.
+//
+// See docs/messages-search/2026-06-23-multimatch-or-trap-fix.md §4.3 — the
+// set is conservative and hardcoded for the first cut; once telemetry shows
+// which other tokens still drive OR-trap noise we can promote this to config.
+var defaultStopwords = map[string]struct{}{
+	"的": {}, "了": {}, "在": {}, "是": {}, "和": {}, "也": {},
+	"就": {}, "都": {}, "而": {}, "及": {}, "与": {}, "或": {},
+	"把": {}, "被": {}, "对": {}, "向": {}, "从": {}, "到": {},
+	"给": {}, "让": {}, "比": {}, "为": {}, "以": {}, "于": {}, "由": {},
+	"的话": {}, "之类": {}, "之中": {},
+}
+
+// filterStopwords returns the tokens not present in `set`, preserving the
+// original order. Returns a non-nil empty slice when every input token is a
+// stopword (callers branch on len == 0 to fall back to the original keyword).
+func filterStopwords(tokens []string, set map[string]struct{}) []string {
+	out := make([]string, 0, len(tokens))
+	for _, t := range tokens {
+		if t == "" {
+			continue
+		}
+		if _, drop := set[t]; drop {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}

--- a/modules/messages_search/stopwords_test.go
+++ b/modules/messages_search/stopwords_test.go
@@ -1,0 +1,61 @@
+package messages_search
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFilterStopwords_DropsConfigured(t *testing.T) {
+	in := []string{"按时", "缴纳", "时间", "的", "女性"}
+	got := filterStopwords(in, defaultStopwords)
+	want := []string{"按时", "缴纳", "时间", "女性"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestFilterStopwords_EmptyInput(t *testing.T) {
+	got := filterStopwords(nil, defaultStopwords)
+	if got == nil {
+		t.Fatalf("expected non-nil empty slice, got nil")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty result, got %v", got)
+	}
+}
+
+func TestFilterStopwords_AllStopwords(t *testing.T) {
+	in := []string{"的", "了"}
+	got := filterStopwords(in, defaultStopwords)
+	if len(got) != 0 {
+		t.Fatalf("all-stopwords input should yield empty result, got %v", got)
+	}
+}
+
+func TestFilterStopwords_AllContentWords(t *testing.T) {
+	in := []string{"季度", "报告"}
+	got := filterStopwords(in, defaultStopwords)
+	if !reflect.DeepEqual(got, in) {
+		t.Fatalf("content-only tokens must pass through unchanged: got %v want %v", got, in)
+	}
+}
+
+func TestFilterStopwords_DropsEmptyTokens(t *testing.T) {
+	in := []string{"", "公司", ""}
+	got := filterStopwords(in, defaultStopwords)
+	want := []string{"公司"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestDefaultStopwords_CoversCommonFunctionWords(t *testing.T) {
+	// Regression-pin a few entries that the OR-trap fix specifically targets.
+	// If the set is ever trimmed, callers must update this list to keep the
+	// trap-fix coverage explicit.
+	for _, tok := range []string{"的", "了", "在", "是", "和", "的话"} {
+		if _, ok := defaultStopwords[tok]; !ok {
+			t.Errorf("defaultStopwords must include %q for the OR-trap fix", tok)
+		}
+	}
+}


### PR DESCRIPTION
…_match OR-trap

Reader-layer fix for the OR-trap in /_search_messages, /_search_all, /_search_files.

Symptom: ik_smart tokenizes "按时缴纳时间的女性" into [按时,缴纳,时间,的,女性]; multi_match defaults to operator=OR so any single token (especially the high-frequency function word 的) matches and returns ~10k hits with highlights all landing on 的.

Fix (per docs/messages-search/2026-06-23-multimatch-or-trap-fix.md §4.1):
- AnalyzeKeyword → OS _analyze (ik_smart) + filterStopwords
- buildKeywordClauseFromAnalyzed → multi_match(cross_fields) + MinimumShouldMatch("75%") for content tokens; raw keyword + no MSM when every token is a stopword (preserves "search literally for 的" semantics)
- _analyze failure degrades to §4.4 (raw keyword + cross_fields + MSM 75%)
- search_all shares one _analyze across its two Should branches (2→1 RT)
- SearchConfig.StopwordStripEnabled flag (env OCTO_SEARCH_STOPWORD_STRIP_ENABLED, default true) kill-switches back to §4.4 without redeploy

Affects 4 call sites: search_messages.go, search_all.go (text+file), search_files.go. search_media.go (no keyword) and search_around.go (msgId anchor) unaffected.

Tests: keyword_query_test.go + stopwords_test.go cover spec §5 unit table plus calls==0 flag-off and calls==1 _search_all reuse assertions. Existing dsl_test.go / space_filter_test.go signature-migrated via fallbackTestAnalyzer preserving historical literal pins. e2e ("按时缴纳时间的女性" recall delta) left for make env-test per spec §6.

## Summary

<!-- What does this PR do? -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. Fixes #123 -->

## Linked Spec

<!-- Link to .octospec/tasks/<slug>/brief.md or the issue this implements.
     Required when the change touches load-bearing behavior. -->

## Changes

<!-- Bullet list of concrete changes -->

-
-

## Testing

<!-- How was this tested? Include commands, screenshots, or test output. -->

- [ ] Unit tests added/updated
- [ ] Manually verified

## COMPREHENSION

<!-- Required for load-bearing / architectural / P0 changes. Answer to substance,
     not boilerplate. Delete this section for trivial changes (typo/docs/lint/config). -->

1. **What does this change actually do** to the load-bearing path?

2. **What could break** because of it (dependents + failure mode)?

3. **How do you know it works** (specific test/repro/trace)?

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] PR description is in English
- [ ] Added tests for my changes
- [ ] Updated documentation
- [ ] Followed commit message conventions (Conventional Commits)
