### PR TITLE
fix: split health liveness from readiness

### DIFF
--- a/.octospec/tasks/health-readiness-split/brief.md
+++ b/.octospec/tasks/health-readiness-split/brief.md
@@ -1,0 +1,49 @@
+---
+type: Task
+title: "Task: health-readiness-split"
+description: Split cheap liveness from bounded DB/Redis readiness checks.
+tags: ["health", "readiness", "rate-limit"]
+timestamp: 2026-06-23T00:00:00Z
+slug: health-readiness-split
+upstream: "Mininglamp-OSS/octo-server#436"
+source: self
+---
+
+# Task: health-readiness-split
+
+## Goal
+
+Make `/v1/health` a cheap process liveness endpoint for frontend/LB probes, and
+move DB/Redis dependency probing to a bounded readiness endpoint.
+
+## Background
+
+Issue #436: frontend status-tower polling `/v1/health` shows TTFB jitter because
+the current handler synchronously runs global Redis-backed rate limiting,
+MySQL `Ping()`, and Redis `Ping()`.
+
+## Load-bearing list
+
+- `/v1/health` response semantics change from dependency probe to process
+  liveness.
+- Add `/v1/ready` as the dependency readiness endpoint.
+- Global Redis-backed rate limiting must not add Redis latency to health or
+  readiness probe paths.
+- Dependency errors must be logged server-side and not exposed as raw response
+  strings.
+
+## Out of scope
+
+- Background cached dependency probing.
+- New Prometheus dependency health metrics.
+- Deployment manifest changes for k8s probes.
+
+## Acceptance
+
+- `/v1/health` does not call DB or Redis and returns `200 {"status":"up"}`.
+- `/v1/ready` checks DB/Redis with bounded timeout and returns `503` when any
+  dependency is down.
+- `/v1/ready` response includes safe `up/down` status fields only.
+- `/v1/health` and `/v1/ready` are excluded from the global Redis-backed IP
+  limiter.
+- Focused Go tests pass for `./modules/common`.

--- a/.octospec/tasks/health-readiness-split/brief.md
+++ b/.octospec/tasks/health-readiness-split/brief.md
@@ -27,8 +27,9 @@ MySQL `Ping()`, and Redis `Ping()`.
 - `/v1/health` response semantics change from dependency probe to process
   liveness.
 - Add `/v1/ready` as the dependency readiness endpoint.
-- Global Redis-backed rate limiting must not add Redis latency to health or
-  readiness probe paths.
+- Global Redis-backed rate limiting must not add Redis latency to the liveness
+  probe path. Readiness intentionally keeps the global limiter because it
+  touches DB/Redis dependencies.
 - Dependency errors must be logged server-side and not exposed as raw response
   strings.
 

--- a/.octospec/tasks/health-readiness-split/brief.md
+++ b/.octospec/tasks/health-readiness-split/brief.md
@@ -44,6 +44,7 @@ MySQL `Ping()`, and Redis `Ping()`.
 - `/v1/ready` checks DB/Redis with bounded timeout and returns `503` when any
   dependency is down.
 - `/v1/ready` response includes safe `up/down` status fields only.
-- `/v1/health` and `/v1/ready` are excluded from the global Redis-backed IP
-  limiter.
+- `/v1/health` is excluded from the global Redis-backed IP limiter; `/v1/ready`
+  keeps the global limiter because it touches DB/Redis dependencies.
+- `/v1/health` and `/v1/ready` are excluded from high-volume access logging.
 - Focused Go tests pass for `./modules/common`.

--- a/.octospec/tasks/health-readiness-split/brief.md
+++ b/.octospec/tasks/health-readiness-split/brief.md
@@ -41,7 +41,8 @@ MySQL `Ping()`, and Redis `Ping()`.
 
 ## Acceptance
 
-- `/v1/health` does not call DB or Redis and returns `200 {"status":"up"}`.
+- `/v1/health` does not call DB or Redis and keeps the legacy success shape:
+  `200 {"status":"up","db":"up","redis":"up"}`.
 - `/v1/ready` checks DB/Redis with bounded timeout and returns `503` when any
   dependency is down.
 - `/v1/ready` response includes safe `up/down` status fields only.

--- a/main.go
+++ b/main.go
@@ -41,6 +41,10 @@ var Commit string     // git commit id
 var CommitDate string // git commit date
 var TreeState string  // git tree state
 
+func globalRateLimitExcludePaths() []string {
+	return []string{"/v1/ping", "/v1/health", "/v1/ready"}
+}
+
 func loadConfigFromFile(cfgFile string) *viper.Viper {
 	vp := viper.New()
 	vp.SetConfigFile(cfgFile)
@@ -182,7 +186,7 @@ func runAPI(ctx *config.Context) {
 		o.MaxRetries = 1
 		o.PoolSize = 10
 	}))
-	route.Use(route.RateLimitMiddleware(context.Background(), rlRedis, rps, burst, "/v1/ping"))
+	route.Use(route.RateLimitMiddleware(context.Background(), rlRedis, rps, burst, globalRateLimitExcludePaths()...))
 	// CORS 白名单覆盖：dmwork-lib 的 server.New 默认注入 "*" + Credentials:true，
 	// 本中间件在其后执行，按 DM_CORS_ALLOWED_ORIGINS 重写/剥离 Allow-Origin/Credentials。
 	// 未配置时等价于禁用跨域（剥离所有 CORS 响应头），仅允许同源调用。

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ var CommitDate string // git commit date
 var TreeState string  // git tree state
 
 func globalRateLimitExcludePaths() []string {
-	return []string{"/v1/ping", "/v1/health", "/v1/ready"}
+	return []string{"/v1/ping", "/v1/health"}
 }
 
 func loadConfigFromFile(cfgFile string) *viper.Viper {
@@ -357,6 +357,8 @@ func ingorePaths() []string {
 	return []string{
 		"/v1/robots/:robot_id/:app_key/events",
 		"/v1/ping",
+		"/v1/health",
+		"/v1/ready",
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGlobalRateLimitExcludePathsIncludesProbeEndpoints(t *testing.T) {
+	paths := globalRateLimitExcludePaths()
+
+	require.Contains(t, paths, "/v1/ping")
+	require.Contains(t, paths, "/v1/health")
+	require.Contains(t, paths, "/v1/ready")
+}

--- a/main_test.go
+++ b/main_test.go
@@ -11,5 +11,13 @@ func TestGlobalRateLimitExcludePathsIncludesProbeEndpoints(t *testing.T) {
 
 	require.Contains(t, paths, "/v1/ping")
 	require.Contains(t, paths, "/v1/health")
+	require.NotContains(t, paths, "/v1/ready")
+}
+
+func TestAccessLogIgnorePathsIncludesProbeEndpoints(t *testing.T) {
+	paths := ingorePaths()
+
+	require.Contains(t, paths, "/v1/ping")
+	require.Contains(t, paths, "/v1/health")
 	require.Contains(t, paths, "/v1/ready")
 }

--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -32,10 +32,11 @@ import (
 type Common struct {
 	ctx *config.Context
 	log.Log
-	db             *db
-	appConfigDB    *appConfigDB
-	systemSettings *SystemSettings
-	threadOn       int // 缓存 DM_THREAD_ON 环境变量
+	db               *db
+	appConfigDB      *appConfigDB
+	systemSettings   *SystemSettings
+	readinessChecker readinessChecker
+	threadOn         int // 缓存 DM_THREAD_ON 环境变量
 }
 
 // New New
@@ -44,13 +45,15 @@ func New(ctx *config.Context) *Common {
 	if t := strings.ToLower(os.Getenv("DM_THREAD_ON")); t == "true" || t == "1" {
 		threadOn = 1
 	}
+	database := newDB(ctx.DB())
 	return &Common{
-		ctx:            ctx,
-		db:             newDB(ctx.DB()),
-		appConfigDB:    newAppConfigDB(ctx),
-		systemSettings: EnsureSystemSettings(ctx),
-		Log:            log.NewTLog("common"),
-		threadOn:       threadOn,
+		ctx:              ctx,
+		db:               database,
+		appConfigDB:      newAppConfigDB(ctx),
+		systemSettings:   EnsureSystemSettings(ctx),
+		readinessChecker: newDependencyReadinessChecker(ctx, database),
+		Log:              log.NewTLog("common"),
+		threadOn:         threadOn,
 	}
 }
 
@@ -82,37 +85,8 @@ func (cn *Common) Route(r *wkhttp.WKHttp) {
 		commonNoAuth.GET("/changelog", cn.changelog)           // 版本更新日志（公开）
 	}
 
-	r.GET("/v1/health", func(c *wkhttp.Context) {
-		var (
-			statusMap = map[string]string{
-				"status": "up",
-				"db":     "up",
-				"redis":  "up",
-			}
-			lastError error
-		)
-
-		err := cn.db.session.Ping()
-		if err != nil {
-			cn.Error("db ping error", zap.Error(err))
-			lastError = err
-			statusMap["db"] = "down"
-		}
-
-		_, err = cn.ctx.GetRedisConn().Ping()
-		if err != nil {
-			cn.Error("redis ping error", zap.Error(err))
-			lastError = err
-			statusMap["redis"] = "down"
-		}
-
-		if lastError != nil {
-			statusMap["status"] = "down"
-			statusMap["error"] = lastError.Error()
-		}
-
-		c.JSON(http.StatusOK, statusMap)
-	})
+	r.GET("/v1/health", cn.health)
+	r.GET("/v1/ready", cn.ready)
 
 	appConfigM, err := cn.insertAppConfigIfNeed()
 	if err != nil {

--- a/modules/common/health.go
+++ b/modules/common/health.go
@@ -56,6 +56,7 @@ func readinessRedisOptions(cfg *config.Config) *rd.Options {
 }
 
 func (cn *Common) health(c *wkhttp.Context) {
+	// db/redis are static legacy-shape fields; liveness must stay dependency-free.
 	c.JSON(http.StatusOK, map[string]string{
 		"status": healthStatusUp,
 		"db":     healthStatusUp,

--- a/modules/common/health.go
+++ b/modules/common/health.go
@@ -18,7 +18,8 @@ const (
 	healthStatusUp   = "up"
 	healthStatusDown = "down"
 
-	readinessProbeTimeout = 500 * time.Millisecond
+	readinessProbeTimeout     = 500 * time.Millisecond
+	readinessRedisPoolTimeout = 100 * time.Millisecond
 )
 
 type readinessResult struct {
@@ -37,17 +38,21 @@ type dependencyReadinessChecker struct {
 }
 
 func newDependencyReadinessChecker(ctx *config.Context, db *db) readinessChecker {
-	redisClient := rd.NewClient(octoredis.MustBuildOptions(ctx.GetConfig(), func(o *rd.Options) {
+	return &dependencyReadinessChecker{
+		db:          db,
+		redisClient: rd.NewClient(readinessRedisOptions(ctx.GetConfig())),
+	}
+}
+
+func readinessRedisOptions(cfg *config.Config) *rd.Options {
+	return octoredis.MustBuildOptions(cfg, func(o *rd.Options) {
 		o.MaxRetries = 0
 		o.PoolSize = 2
 		o.DialTimeout = readinessProbeTimeout
 		o.ReadTimeout = readinessProbeTimeout
 		o.WriteTimeout = readinessProbeTimeout
-	}))
-	return &dependencyReadinessChecker{
-		db:          db,
-		redisClient: redisClient,
-	}
+		o.PoolTimeout = readinessRedisPoolTimeout
+	})
 }
 
 func (cn *Common) health(c *wkhttp.Context) {
@@ -72,7 +77,24 @@ func (cn *Common) ready(c *wkhttp.Context) {
 		return
 	}
 
-	result := checker.Check(ctx)
+	resultCh := make(chan readinessResult, 1)
+	go func() {
+		resultCh <- checker.Check(ctx)
+	}()
+
+	var result readinessResult
+	select {
+	case result = <-resultCh:
+	case <-ctx.Done():
+		result = readinessResult{
+			Status: healthStatusDown,
+			Dependencies: map[string]string{
+				"db":    healthStatusDown,
+				"redis": healthStatusDown,
+			},
+			Errors: map[string]error{"readiness": ctx.Err()},
+		}
+	}
 	cn.logReadinessErrors(result.Errors)
 	statusCode := http.StatusOK
 	if result.Status != healthStatusUp {

--- a/modules/common/health.go
+++ b/modules/common/health.go
@@ -1,0 +1,150 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
+	"go.uber.org/zap"
+)
+
+const (
+	healthStatusUp   = "up"
+	healthStatusDown = "down"
+
+	readinessProbeTimeout = 500 * time.Millisecond
+)
+
+type readinessResult struct {
+	Status       string            `json:"status"`
+	Dependencies map[string]string `json:"dependencies,omitempty"`
+	Errors       map[string]error  `json:"-"`
+}
+
+type readinessChecker interface {
+	Check(ctx context.Context) readinessResult
+}
+
+type dependencyReadinessChecker struct {
+	db          *db
+	redisClient *rd.Client
+}
+
+func newDependencyReadinessChecker(ctx *config.Context, db *db) readinessChecker {
+	redisClient := rd.NewClient(octoredis.MustBuildOptions(ctx.GetConfig(), func(o *rd.Options) {
+		o.MaxRetries = 0
+		o.PoolSize = 2
+		o.DialTimeout = readinessProbeTimeout
+		o.ReadTimeout = readinessProbeTimeout
+		o.WriteTimeout = readinessProbeTimeout
+	}))
+	return &dependencyReadinessChecker{
+		db:          db,
+		redisClient: redisClient,
+	}
+}
+
+func (cn *Common) health(c *wkhttp.Context) {
+	c.JSON(http.StatusOK, map[string]string{"status": healthStatusUp})
+}
+
+func (cn *Common) ready(c *wkhttp.Context) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), readinessProbeTimeout)
+	defer cancel()
+
+	checker := cn.readinessChecker
+	if checker == nil {
+		result := readinessResult{
+			Status:       healthStatusDown,
+			Dependencies: map[string]string{"db": healthStatusDown, "redis": healthStatusDown},
+			Errors:       map[string]error{"readiness": errors.New("readiness checker unavailable")},
+		}
+		cn.logReadinessErrors(result.Errors)
+		// Readiness is an infra probe contract, not a user-facing business error.
+		// Keep the wire body small and safe instead of returning the i18n envelope.
+		c.JSON(http.StatusServiceUnavailable, result)
+		return
+	}
+
+	result := checker.Check(ctx)
+	cn.logReadinessErrors(result.Errors)
+	statusCode := http.StatusOK
+	if result.Status != healthStatusUp {
+		statusCode = http.StatusServiceUnavailable
+	}
+	// Readiness is an infra probe contract, not a user-facing business error.
+	// Keep the wire body small and safe instead of returning the i18n envelope.
+	c.JSON(statusCode, result)
+}
+
+func (cn *Common) logReadinessErrors(errs map[string]error) {
+	if len(errs) == 0 || cn == nil || cn.Log == nil {
+		return
+	}
+	for dependency, err := range errs {
+		if err == nil {
+			continue
+		}
+		cn.Error("readiness dependency check failed", zap.String("dependency", dependency), zap.Error(err))
+	}
+}
+
+func (c *dependencyReadinessChecker) Check(ctx context.Context) readinessResult {
+	result := readinessResult{
+		Status: healthStatusUp,
+		Dependencies: map[string]string{
+			"db":    healthStatusUp,
+			"redis": healthStatusUp,
+		},
+		Errors: map[string]error{},
+	}
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		if err := c.pingDB(ctx); err != nil {
+			mu.Lock()
+			result.Dependencies["db"] = healthStatusDown
+			result.Errors["db"] = err
+			mu.Unlock()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		if err := c.pingRedis(ctx); err != nil {
+			mu.Lock()
+			result.Dependencies["redis"] = healthStatusDown
+			result.Errors["redis"] = err
+			mu.Unlock()
+		}
+	}()
+	wg.Wait()
+
+	if len(result.Errors) > 0 {
+		result.Status = healthStatusDown
+	}
+	return result
+}
+
+func (c *dependencyReadinessChecker) pingDB(ctx context.Context) error {
+	if c == nil || c.db == nil || c.db.session == nil || c.db.session.DB == nil {
+		return errors.New("db session unavailable")
+	}
+	return c.db.session.DB.PingContext(ctx)
+}
+
+func (c *dependencyReadinessChecker) pingRedis(ctx context.Context) error {
+	if c == nil || c.redisClient == nil {
+		return errors.New("redis client unavailable")
+	}
+	_, err := c.redisClient.WithContext(ctx).Ping().Result()
+	return err
+}

--- a/modules/common/health.go
+++ b/modules/common/health.go
@@ -56,7 +56,11 @@ func readinessRedisOptions(cfg *config.Config) *rd.Options {
 }
 
 func (cn *Common) health(c *wkhttp.Context) {
-	c.JSON(http.StatusOK, map[string]string{"status": healthStatusUp})
+	c.JSON(http.StatusOK, map[string]string{
+		"status": healthStatusUp,
+		"db":     healthStatusUp,
+		"redis":  healthStatusUp,
+	})
 }
 
 func (cn *Common) ready(c *wkhttp.Context) {

--- a/modules/common/health_test.go
+++ b/modules/common/health_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/stretchr/testify/require"
 )
@@ -98,4 +99,33 @@ func TestReadyBoundsCheckerWithTimeout(t *testing.T) {
 	require.Equal(t, http.StatusServiceUnavailable, w.Code)
 	require.Less(t, time.Since(started), time.Second, "readiness timeout must stay bounded")
 	require.Equal(t, int32(1), atomic.LoadInt32(&checker.calls))
+}
+
+func TestReadyReturnsWhenCheckerIgnoresContext(t *testing.T) {
+	checker := &fakeReadinessChecker{
+		check: func(context.Context) readinessResult {
+			time.Sleep(readinessProbeTimeout * 2)
+			return readinessResult{Status: healthStatusUp}
+		},
+	}
+	cn := &Common{readinessChecker: checker}
+	r := wkhttp.New()
+	r.GET("/v1/ready", cn.ready)
+
+	started := time.Now()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/ready", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	require.Less(t, time.Since(started), 750*time.Millisecond, "readiness must return on its own deadline even if a checker ignores ctx")
+	require.JSONEq(t, `{"status":"down","dependencies":{"db":"down","redis":"down"}}`, w.Body.String())
+	require.Equal(t, int32(1), atomic.LoadInt32(&checker.calls))
+}
+
+func TestReadinessRedisOptionsUseBoundedPoolTimeout(t *testing.T) {
+	opts := readinessRedisOptions(config.New())
+
+	require.Equal(t, readinessRedisPoolTimeout, opts.PoolTimeout)
+	require.Less(t, opts.PoolTimeout, readinessProbeTimeout)
 }

--- a/modules/common/health_test.go
+++ b/modules/common/health_test.go
@@ -1,0 +1,101 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeReadinessChecker struct {
+	calls  int32
+	result readinessResult
+	check  func(context.Context) readinessResult
+}
+
+func (f *fakeReadinessChecker) Check(ctx context.Context) readinessResult {
+	atomic.AddInt32(&f.calls, 1)
+	if f.check != nil {
+		return f.check(ctx)
+	}
+	return f.result
+}
+
+func TestHealthIsPureLiveness(t *testing.T) {
+	checker := &fakeReadinessChecker{
+		result: readinessResult{
+			Status:       healthStatusDown,
+			Dependencies: map[string]string{"db": healthStatusDown, "redis": healthStatusDown},
+			Errors:       map[string]error{"db": errors.New("should not be called")},
+		},
+	}
+	cn := &Common{readinessChecker: checker}
+	r := wkhttp.New()
+	r.GET("/v1/health", cn.health)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.JSONEq(t, `{"status":"up"}`, w.Body.String())
+	require.Equal(t, int32(0), atomic.LoadInt32(&checker.calls), "liveness must not call dependency readiness checker")
+}
+
+func TestReadyReturnsSafeDependencyStatus(t *testing.T) {
+	checker := &fakeReadinessChecker{
+		result: readinessResult{
+			Status:       healthStatusDown,
+			Dependencies: map[string]string{"db": healthStatusDown, "redis": healthStatusUp},
+			Errors:       map[string]error{"db": errors.New("mysql dsn contains secret password")},
+		},
+	}
+	cn := &Common{readinessChecker: checker}
+	r := wkhttp.New()
+	r.GET("/v1/ready", cn.ready)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/ready", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	require.JSONEq(t, `{"status":"down","dependencies":{"db":"down","redis":"up"}}`, w.Body.String())
+	require.NotContains(t, strings.ToLower(w.Body.String()), "secret")
+	require.NotContains(t, strings.ToLower(w.Body.String()), "password")
+	require.Equal(t, int32(1), atomic.LoadInt32(&checker.calls))
+}
+
+func TestReadyBoundsCheckerWithTimeout(t *testing.T) {
+	checker := &fakeReadinessChecker{
+		check: func(ctx context.Context) readinessResult {
+			deadline, ok := ctx.Deadline()
+			require.True(t, ok, "readiness checker must receive a bounded context")
+			require.LessOrEqual(t, time.Until(deadline), readinessProbeTimeout)
+			<-ctx.Done()
+			return readinessResult{
+				Status:       healthStatusDown,
+				Dependencies: map[string]string{"db": healthStatusDown, "redis": healthStatusDown},
+				Errors:       map[string]error{"timeout": ctx.Err()},
+			}
+		},
+	}
+	cn := &Common{readinessChecker: checker}
+	r := wkhttp.New()
+	r.GET("/v1/ready", cn.ready)
+
+	started := time.Now()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/ready", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	require.Less(t, time.Since(started), time.Second, "readiness timeout must stay bounded")
+	require.Equal(t, int32(1), atomic.LoadInt32(&checker.calls))
+}

--- a/modules/common/health_test.go
+++ b/modules/common/health_test.go
@@ -46,7 +46,7 @@ func TestHealthIsPureLiveness(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
-	require.JSONEq(t, `{"status":"up"}`, w.Body.String())
+	require.JSONEq(t, `{"status":"up","db":"up","redis":"up"}`, w.Body.String())
 	require.Equal(t, int32(0), atomic.LoadInt32(&checker.calls), "liveness must not call dependency readiness checker")
 }
 


### PR DESCRIPTION
## Summary

Split the public health probe into cheap process liveness and bounded dependency readiness so frontend status-tower polling no longer synchronously waits on DB/Redis.

## Related Issue

Fixes #436

## Linked Spec

`.octospec/tasks/health-readiness-split/brief.md`

## Changes

- Change `GET /v1/health` to pure liveness without DB/Redis pings while preserving the legacy success response shape: `200 {"status":"up","db":"up","redis":"up"}`.
- Add `GET /v1/ready` for readiness with parallel MySQL `PingContext` and Redis `PING`, bounded by a 500ms request context.
- Keep raw dependency errors out of readiness responses while logging them server-side.
- Exclude `/v1/health` from global Redis-backed IP rate limiting; keep `/v1/ready` rate limited because it touches shared dependencies.
- Suppress access logs for `/v1/health` and `/v1/ready` to avoid high-frequency probe log noise.
- Add focused tests for liveness purity, readiness safe output/timeout behavior, rate-limit exclusions, and access-log ignore paths.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

Commands run:

```bash
go test . -run 'TestGlobalRateLimitExcludePathsIncludesProbeEndpoints|TestAccessLogIgnorePathsIncludesProbeEndpoints'
go test ./modules/common -run 'TestHealthIsPureLiveness|TestReadyReturnsSafeDependencyStatus|TestReadyBoundsCheckerWithTimeout'
go test ./tools/lint-direct-error-response
go test ./modules/common
```

Note: local `go test ./modules/common` initially hit the known shared `test` database migration-ledger issue (`unknown migration in database`). I reset the local Docker `octo-test-mysql` `test` database using the same drop/recreate pattern documented in CI, then reran `go test ./modules/common` successfully.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   `/v1/health` no longer enters DB/Redis dependency checks or the Redis-backed global IP limiter, so status-tower/liveness traffic measures process HTTP responsiveness instead of transient dependency load. It preserves the legacy success fields (`db`, `redis`, `status`) for response-shape compatibility, but those fields now represent liveness compatibility only. Real dependency probing moves to `/v1/ready`, where DB and Redis are checked in parallel with a bounded context.

2. **What could break** because of it (dependents + failure mode)?

   Any consumer that treated `/v1/health` as a dependency-health endpoint will continue to see the legacy success fields but no longer receives real-time DB/Redis status there. Those consumers should move to `/v1/ready`. `/v1/ready` returns `503` when DB or Redis is down and remains globally rate limited, so callers must treat it as an infra readiness probe rather than a high-frequency public polling endpoint.

3. **How do you know it works** (specific test/repro/trace)?

   The new `modules/common` tests prove `/v1/health` does not call the readiness checker, `/v1/ready` returns safe dependency status without leaking raw errors, and readiness receives a bounded context. The main-package tests pin the global rate-limit and access-log path lists so `/v1/health` stays cheap while `/v1/ready` remains protected.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
