### PR TITLE
chore(octospec): fix base path glob + add trust-boundary rule

### DIFF
--- a/.octospec/rules/_index.yaml
+++ b/.octospec/rules/_index.yaml
@@ -14,13 +14,13 @@ rules:
     priority: 85
     load_bearing: true
     inject_when:
-      paths: ["modules/**/*.go", "base/**/*.go", "pkg/errcode/**", "pkg/**/httperr/**"]
+      paths: ["modules/**/*.go", "modules/base/**/*.go", "pkg/errcode/**", "pkg/**/httperr/**"]
       touches: ["error-response", "i18n", "wire-contract"]
   - id: rate-limit
     priority: 80
     load_bearing: true
     inject_when:
-      paths: ["modules/**/*.go", "base/common/service_*.go", "internal/**/*.go"]
+      paths: ["modules/**/*.go", "modules/base/common/service_*.go", "internal/**/*.go"]
       touches: ["rate-limit", "throttle"]
   - id: space-isolation
     priority: 92
@@ -28,6 +28,12 @@ rules:
     inject_when:
       paths: ["modules/**/*.go", "internal/**/*.go"]
       touches: ["space", "isolation", "auth", "bot-api", "thread", "acl"]
+  - id: trust-boundary
+    priority: 90
+    load_bearing: true
+    inject_when:
+      paths: ["modules/incomingwebhook/**/*.go", "modules/webhook/**/*.go", "modules/*adapter*/**/*.go", "pkg/richtext/**/*.go", "adapters/**"]
+      touches: ["adapter", "webhook", "external-content", "trust-boundary", "escape", "markdown", "url-destination", "wire-contract"]
   - id: testing
     priority: 70
     load_bearing: false

--- a/.octospec/rules/error-handling.md
+++ b/.octospec/rules/error-handling.md
@@ -10,7 +10,7 @@ tier: repo
 priority: 85
 load_bearing: true
 inject_when:
-  paths: ["modules/**/*.go", "base/**/*.go", "pkg/errcode/**", "pkg/**/httperr/**"]
+  paths: ["modules/**/*.go", "modules/base/**/*.go", "pkg/errcode/**", "pkg/**/httperr/**"]
   touches: ["error-response", "i18n", "wire-contract"]
 source: self
 supersedes: []

--- a/.octospec/rules/rate-limit.md
+++ b/.octospec/rules/rate-limit.md
@@ -10,7 +10,7 @@ tier: repo
 priority: 80
 load_bearing: true
 inject_when:
-  paths: ["modules/**/*.go", "base/common/service_*.go", "internal/**/*.go"]
+  paths: ["modules/**/*.go", "modules/base/common/service_*.go", "internal/**/*.go"]
   touches: ["rate-limit", "throttle"]
 source: self
 supersedes: []

--- a/.octospec/rules/trust-boundary.md
+++ b/.octospec/rules/trust-boundary.md
@@ -1,0 +1,53 @@
+---
+type: Rule
+title: Trust boundaries for adapters & external content
+description: Inbound adapters must escape/validate at the boundary the caller cannot cross, and keep parity across adapters; never block one adapter while leaving a sibling open.
+tags: ["security", "trust-boundary", "adapter", "webhook", "markdown-injection"]
+timestamp: 2026-06-23T00:00:00Z
+# --- octospec extension fields (OKF-permitted; consumers must preserve) ---
+id: trust-boundary
+tier: repo
+priority: 90
+load_bearing: true
+inject_when:
+  paths: ["modules/incomingwebhook/**/*.go", "modules/webhook/**/*.go", "modules/*adapter*/**/*.go", "pkg/richtext/**/*.go", "adapters/**"]
+  touches: ["adapter", "webhook", "external-content", "trust-boundary", "escape", "markdown", "url-destination", "wire-contract"]
+source: self
+supersedes: []
+---
+
+# Trust boundaries for adapters & external content
+
+Inbound adapters (incomingwebhook GitHub/WeCom, webhook push, voice/other
+adapters) carry attacker-controlled content into native message payloads. The
+rendering/escaping decision must be made at the boundary the **caller cannot
+cross**, and must be **consistent across sibling adapters**.
+
+## Rules
+
+- **Escape at the right boundary.** Apply escaping/encoding only where a
+  downstream caller cannot undo or bypass it. Do not push the responsibility
+  onto a caller that has no way to enforce it. If the native render layer is the
+  last place that controls the output contract, escape there — not in one adapter
+  and hope the others did the same.
+- **Adapter parity.** A defense added for one adapter (e.g. GitHub) must hold for
+  every sibling adapter (WeCom, push, future ones). Never block adapter A while
+  leaving adapter B open to the same input — divergent escaping across adapters
+  is a vulnerability, not a feature.
+- **URL destination breakout.** When emitting a markdown/link destination, an
+  unescaped `)` (or other delimiter) can close the destination early and inject
+  attacker markup. Percent-encode the destination; do not rely on naive string
+  interpolation.
+- **Markdown / richtext injection.** External text rendered through richtext
+  blocks must not be able to forge native formatting or links. Validate block
+  structure (count/shape) AND escape leaf text content.
+- **Bound the payload.** Enforce explicit structural limits (e.g. block count)
+  in addition to byte caps, so a well-formed-but-pathological payload cannot
+  exhaust validation.
+
+## Why load-bearing
+
+Adapters are the primary externally-reachable attack surface. A
+markdown-injection or URL-destination breakout reaches end users' clients; an
+escaping gap that exists in one adapter but not its siblings is a real
+cross-channel vulnerability.


### PR DESCRIPTION
## What

Two `.octospec/rules` fixes. **No code changes** — knowledge files only.

### 1. Fix dead `inject_when` path globs
`error-handling` used `base/**/*.go` and `rate-limit` used `base/common/service_*.go`, but this repo's base package lives at `modules/base/`. Those globs never matched, so the rules were silently **not injected** when editing `modules/base/**`. Corrected to `modules/base/**` (+ mirror in `_index.yaml`).

### 2. Add `trust-boundary` rule (load-bearing, P90)
Covers inbound adapters (`incomingwebhook` GitHub/WeCom, `webhook` push, `pkg/richtext`, `adapters/`) — currently uncovered by any rule despite being the primary externally-reachable attack surface:
- Escape at the boundary the caller cannot cross
- Adapter parity (don't defend adapter A while leaving sibling B open)
- URL-destination percent-encoding (delimiter breakout)
- Richtext/markdown injection (validate structure + escape leaf text)
- Payload structural limits (block count, not just byte cap)

## Verification
`octospec-lint: OK (8 knowledge file(s) conform to OKF)`

## Why now
Multiple feature PRs already follow the octospec 4-phase flow; the dead globs meant two load-bearing rules weren't reaching authors editing `modules/base/**`, and the adapter surface had no rule at all.

Closes #439