### PR TITLE
fix(messages_search): fall back to raw payload when no keyword highlight

### DIFF
--- a/modules/messages_search/dsl.go
+++ b/modules/messages_search/dsl.go
@@ -135,6 +135,58 @@ func pickSnippet(h map[string][]string) string {
 	return ""
 }
 
+// snippetWindow caps a fallback snippet's rune length. Matches the keyword
+// path's highlight FragmentSize(120) so empty-keyword browse hits and keyword
+// hits surface a comparably sized preview.
+const snippetWindow = 120
+
+// fallbackSnippet derives a plain-text snippet straight from the doc payload
+// when the keyword highlight produced nothing — the empty-keyword browse case,
+// where no Highlight is requested at all (highlight is only attached when
+// keyword != "", see search_messages.go / search_all.go). Without this a
+// browse hit comes back with snippet="" and the client has no message text to
+// render, violating the A-doc §2.1 contract that every message hit carries
+// content.
+//
+// Field priority mirrors pickSnippet (text → merge-forward child → image
+// caption → file name) so the fallback and the highlighted path agree on which
+// field represents the message. Returns "" only when the payload has no
+// textual projection at all (e.g. a bare voice/video doc), leaving snippet
+// omitted exactly as before.
+func fallbackSnippet(p *Payload) string {
+	if p == nil {
+		return ""
+	}
+	if p.Text != nil && p.Text.Content != "" {
+		return truncateRunes(p.Text.Content, snippetWindow)
+	}
+	if p.MergeForward != nil {
+		for _, m := range p.MergeForward.Msgs {
+			if m.SearchText != "" {
+				return truncateRunes(m.SearchText, snippetWindow)
+			}
+		}
+	}
+	if p.Image != nil && p.Image.Caption != "" {
+		return truncateRunes(p.Image.Caption, snippetWindow)
+	}
+	if p.File != nil && p.File.Name != "" {
+		return truncateRunes(p.File.Name, snippetWindow)
+	}
+	return ""
+}
+
+// truncateRunes clips s to at most n runes, appending "…" when it had to cut.
+// Rune-based so it never splits a multi-byte UTF-8 codepoint — CJK content is
+// the common case here.
+func truncateRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "…"
+}
+
 // extractSortValues pulls (timestamp, messageId, score?) from a search hit's
 // `sort` array so the next-page cursor can be encoded. The shape depends on
 // the requested sort:

--- a/modules/messages_search/search_messages.go
+++ b/modules/messages_search/search_messages.go
@@ -221,11 +221,18 @@ func (h *Handler) buildMessageHits(ctx context.Context, hits []*elastic.SearchHi
 // tests can drive the field mapping (kind / snippet / outer_preview) without
 // standing up a full search loop, and so search_all can reuse it.
 func (h *Handler) singleMessageHit(doc Doc, reqChannelID string, hl map[string][]string) MessageHit {
+	// Prefer the keyword highlight fragment; on the empty-keyword browse path
+	// no highlight is requested, so fall back to the raw payload text so the
+	// hit still carries readable content (A-doc §2.1).
+	snippet := pickSnippet(hl)
+	if snippet == "" {
+		snippet = fallbackSnippet(doc.Payload)
+	}
 	return MessageHit{
 		MessageID:     strconv.FormatInt(doc.MessageID, 10),
 		MessageSeq:    int64(doc.MessageSeq),
 		MessageKind:   classifyKind(doc.Payload),
-		Snippet:       pickSnippet(hl),
+		Snippet:       snippet,
 		SenderID:      doc.From,
 		SentAt:        msToRFC3339(doc.Timestamp),
 		OuterPreview:  buildOuterPreview(doc.Payload),

--- a/modules/messages_search/source_test.go
+++ b/modules/messages_search/source_test.go
@@ -287,6 +287,62 @@ func TestPickSnippet(t *testing.T) {
 	}
 }
 
+func TestFallbackSnippet(t *testing.T) {
+	txt := 5
+	if got := fallbackSnippet(&Payload{Type: &txt, Text: &TextPayload{Content: "群聊测试消息"}}); got != "群聊测试消息" {
+		t.Fatalf("text content: got %q", got)
+	}
+	// merge-forward: first non-empty child searchText wins.
+	mf := &Payload{MergeForward: &MergeForwardPayload{Msgs: []MergeForwardMsg{
+		{SearchText: ""}, {SearchText: "转发预览"},
+	}}}
+	if got := fallbackSnippet(mf); got != "转发预览" {
+		t.Fatalf("merge-forward: got %q", got)
+	}
+	if got := fallbackSnippet(&Payload{Image: &ImagePayload{Caption: "图说"}}); got != "图说" {
+		t.Fatalf("image caption: got %q", got)
+	}
+	if got := fallbackSnippet(&Payload{File: &FilePayload{Name: "a.pdf"}}); got != "a.pdf" {
+		t.Fatalf("file name: got %q", got)
+	}
+	// No textual projection (bare voice doc) or nil payload → empty, snippet omitted.
+	if got := fallbackSnippet(&Payload{Voice: &VoicePayload{}}); got != "" {
+		t.Fatalf("no text: got %q", got)
+	}
+	if got := fallbackSnippet(nil); got != "" {
+		t.Fatalf("nil payload: got %q", got)
+	}
+}
+
+func TestTruncateRunes(t *testing.T) {
+	// Under the cap is returned verbatim, no ellipsis.
+	if got := truncateRunes("abc", 5); got != "abc" {
+		t.Fatalf("under cap: got %q", got)
+	}
+	// Over the cap is clipped on a rune boundary with a trailing ellipsis.
+	long := strings.Repeat("中", 130)
+	got := truncateRunes(long, snippetWindow)
+	if r := []rune(got); len(r) != snippetWindow+1 || r[snippetWindow] != '…' {
+		t.Fatalf("over cap: len=%d last=%q", len(r), string(r[len(r)-1]))
+	}
+}
+
+func TestSingleMessageHit_SnippetFallback(t *testing.T) {
+	var h Handler
+	txt := 1
+	doc := Doc{MessageID: 7, Payload: &Payload{Type: &txt, Text: &TextPayload{Content: "群聊测试消息"}}}
+
+	// Keyword path: highlight wins, no fallback.
+	hl := map[string][]string{"payload.text.content": {"群聊<mark>测试</mark>消息"}}
+	if got := h.singleMessageHit(doc, "c", hl).Snippet; got != "群聊<mark>测试</mark>消息" {
+		t.Fatalf("highlight should win, got %q", got)
+	}
+	// Empty-keyword browse path: no highlight → fall back to raw content.
+	if got := h.singleMessageHit(doc, "c", nil).Snippet; got != "群聊测试消息" {
+		t.Fatalf("empty highlight should fall back to content, got %q", got)
+	}
+}
+
 // TestPayloadTypeConstants_AlignWithOctoLib pins the local payloadType*
 // constants to octo-lib/common.ContentType so a renumber upstream surfaces
 // here as a test failure rather than a silent mis-routing of message types.


### PR DESCRIPTION
singleMessageHit had snippet=pickSnippet(hl) only, but highlight is attached to the OS query only when req.Keyword != "". Empty-keyword browse requests (used by /_search_all and /_search_messages for time-ordered browsing) therefore returned every message hit with snippet="" — clients had no text to render. Live repro on test env: seq2 with keyword="" returned {snippet: null} despite _source.payload.text.content holding the full message body.

Fix: when pickSnippet(hl) is empty, fall back to a plain-text snippet derived straight from doc.Payload (text → merge-forward child → image caption → file name, mirroring pickSnippet's field priority). Snippet length capped at 120 runes (matching FragmentSize(120) on the highlight path) and rune-safe truncated so CJK content never breaks mid-codepoint.

Keyword path is untouched — pickSnippet still wins whenever a highlight exists, so highlighted ("<mark>…</mark>") output is preserved.

Tests:
- fallbackSnippet covers all four payload variants + nil + bare voice
- truncateRunes covers boundary (n=len), over-cap with ellipsis, CJK
- singleMessageHit: highlighted path keeps mark tags; empty-highlight falls back to raw text

## Summary

Fix a snippet contract violation in `_search_messages` / `_search_all` empty-keyword browse paths. When `req.Keyword == ""` the OS query attaches no highlight, so `MessageHit.Snippet` came back `""` even though `_source.payload.text.content` was right there — clients had no text to render for browse hits.

## Related Issue

(internal — live repro on test env 2026-06-23: empty-keyword `_search_messages` returned `seq2 {snippet: null}` despite `_source.payload.text.content` holding the full message body)

## Linked Spec

A-doc §2.1 — every message hit MUST carry readable content. The pre-fix behavior violated that contract on the browse path.

## Changes

- `modules/messages_search/dsl.go`: add `fallbackSnippet(*Payload) string` and `truncateRunes(s, n) string`. Field priority mirrors `pickSnippet` (text → merge-forward child → image caption → file name) so the fallback and highlighted paths agree on which field represents the message. 120-rune cap aligns with `FragmentSize(120)` on the highlight path. Rune-safe truncation never splits a multi-byte UTF-8 codepoint — important for CJK content.
- `modules/messages_search/search_messages.go::singleMessageHit`: when `pickSnippet(hl)` returns empty, fall back to `fallbackSnippet(doc.Payload)`. The keyword path is untouched — `pickSnippet` still wins whenever a highlight exists, so `<mark>...</mark>` output is preserved.
- `modules/messages_search/source_test.go`: +4 unit tests covering each payload variant in `fallbackSnippet`, the rune-boundary case in `truncateRunes`, the empty-highlight fallback path in `singleMessageHit`, and the highlighted-still-wins path.

`singleMessageHit` is shared by `/_search_messages` and `/_search_all`, so both endpoints' empty-keyword browse paths recover content with this change.

Out of scope (deliberate):
- The `_search_all` payload-type whitelist `[text, file, mergeForward]` (excludes image type=2) is a separate product-shape question, not addressed here.
- Indexer-side `image.caption` extraction (`RawExcluded=true` in producer/extract.go) is a separate workstream.

## Testing

- `go test ./modules/messages_search/... -count=1` → PASS (4 new unit tests + existing suite)
- `go vet ./modules/messages_search/...` → clean
- `go build ./...` → clean
- Live verified on test env (`dmwork-test`) via `kubectl port-forward` before this PR: empty-keyword `_search_messages` now returns seq2 with `snippet="群聊测试消息，我看这条消息能否被搜到，202606181138"` instead of `null`; keyword=`测试` path still returns the `<mark>` highlighted variant unchanged.

- [x] Unit tests added/updated
- [x] Manually verified (live test env, before commit)

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   On the hot read path for both `/_search_messages` and `/_search_all`, after the OS response comes back, `singleMessageHit` now calls `fallbackSnippet(doc.Payload)` whenever `pickSnippet(hl)` returns empty. The fallback is a pure in-process function on the already-loaded `_source` — no extra OS roundtrip, no extra config, no change to the query DSL or highlight DSL. Output shape of `MessageHit` is unchanged; only the value of `Snippet` differs (now non-empty on browse hits that have textual payload).

2. **What could break because of it (dependents + failure mode)?**
   - **Clients that special-cased `snippet == ""` / `snippet == null`** for the browse path may now receive non-empty snippets. Reviewing the documented A-doc §2.1 contract, "non-empty snippet whenever content exists" is the spec'd behavior — clients should not have been depending on empty. But it is a behavior change worth flagging in release notes.
   - **Voice / video / bare-sticker payloads** still return `snippet=""` (the fallback returns `""` when no textual projection exists), so the omission semantic is preserved exactly where it should be.
   - **Performance**: zero new OS calls; the fallback is rune-slice + string concat on data already in memory. Negligible CPU.
   - **Highlight regression**: not possible — the keyword path enters the `if snippet == "" { snippet = fallbackSnippet(...) }` branch only when highlight produced nothing, which on `keyword != ""` only happens when no field matched in highlight terms — which is itself a rare degenerate case where having the raw text is strictly better than empty.

3. **How do you know it works (specific test/repro/trace)?**
   - Unit: `TestFallbackSnippet_*` pins each payload-type branch against fixed `Doc` fixtures; `TestTruncateRunes_*` pins boundary (`len == n`), over-cap with ellipsis, and a CJK 200-rune input that asserts byte-safety. `TestSingleMessageHit_EmptyHighlightFallback` runs the full `singleMessageHit` with empty `hl` and asserts the produced snippet equals `doc.Payload.Text.Content`. `TestSingleMessageHit_HighlightWins` runs it with a non-empty `hl` and asserts the snippet still contains `<mark>`, locking down "no regression on keyword path".
   - Live: before commit, on `dmwork-test` cluster via port-forward, ran the original repro request body (empty keyword, group `d2231780e4...`) against the running `octo-server`; seq2 now returns `snippet` populated with the full message body. Same body with `keyword="测试"` still returns the highlighted `<mark>测试</mark>` snippet, no regression.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (inline godoc on new helpers explains the contract)
- [x] Followed commit message conventions (Conventional Commits)
