### PR TITLE
fix(messages_search): hard-filter system messages (payload.type 1000-2000) from /_search_messages and /_search_around

### DIFF
--- a/docs/messages-search/2026-06-23-system-msg-hard-filter.md
+++ b/docs/messages-search/2026-06-23-system-msg-hard-filter.md
@@ -1,0 +1,74 @@
+# messages_search: hard-filter system messages from `_search_messages`
+
+Date: 2026-06-23
+Surface: `POST /v1/messages/_search` (`_search_messages` reader path)
+
+## 1. Problem
+
+Empty-keyword "browse" mode on `/v1/messages/_search` (legacy `_search` surface)
+recalled control-plane events — "GroupCreate", "GroupMemberAdd", "Tip",
+"FriendApply", etc. — instead of being limited to user-authored content. This
+violates the indexer's "搜索硬过滤" contract for the 1000-2000 system-message
+range.
+
+## 2. Root cause
+
+`buildSearchMessagesDSL` only excluded `payload.type == 99` (Cmd):
+
+```go
+b.MustNot(elastic.NewTermQuery("payload.type", payloadTypeCmd))
+```
+
+It did not exclude the **1000-2000 system range** defined by the indexer
+(`FriendApply=1000` … `Tip=2000`). When the keyword is empty, the only
+discriminator left is the channel filter + `revoked=false`, so every system
+event indexed in the channel surfaced as a "hit".
+
+## 3. Fix
+
+Add a single `RangeQuery` to `must_not` in `buildSearchMessagesDSL`:
+
+```go
+b.MustNot(elastic.NewTermQuery("payload.type", payloadTypeCmd))
+b.MustNot(elastic.NewRangeQuery("payload.type").Gte(payloadTypeSystemMin).Lte(payloadTypeSystemMax))
+```
+
+Constants `payloadTypeSystemMin = 1000` / `payloadTypeSystemMax = 2000` are
+added to `modules/messages_search/source.go` alongside the existing
+`payloadType*` family, with a comment that points back to the indexer spec
+(§2.2) as the source of truth.
+
+## 4. Affected endpoints
+
+| Endpoint | Status | Why |
+|---|---|---|
+| `POST /v1/messages/_search` (`_search_messages`) | **Fixed** — adds 1000-2000 must_not range | Only surface that previously matched system events |
+| `POST /v1/messages/_search_all` | Unchanged — already safe | Whitelist filter `terms payload.type in [1, 8, 11]` excludes anything outside text/file/mergeForward |
+| `POST /v1/messages/_search_files` | N/A | Hard-filters `payload.type == 8` |
+| `POST /v1/messages/_search_media` | N/A | Hard-filters `payload.type in [2, 5]` |
+| `POST /v1/messages/_search_around` | Out of scope here | `buildAnchorDSL` is a separate code path; review tracked separately if needed |
+
+## 5. Tests
+
+- `TestBuildSearchMessagesDSL_FiltersSystemMessages` (new, `dsl_test.go`):
+  asserts both the term (`payload.type == 99`) and range (`payload.type ∈
+  [1000, 2000]`) clauses are emitted in `must_not`, in both keyword and
+  empty-keyword (browse) branches. Walks the parsed query tree rather than
+  relying on substring pins so the assertion survives unrelated DSL
+  formatting changes.
+- `TestBuildSearchMessagesDSL_Shape` and
+  `TestBuildSearchMessagesDSL_NoKeywordSkipsMultiMatch` updated to also
+  require `"gte":1000` / `"lte":2000` in the emitted DSL — keeps the
+  literal-JSON pins in sync without dropping the existing `payload.type=99`
+  pin.
+- Staging verification (TODO): seed a channel with a `GroupMemberAdd`
+  (`payload.type=1002`) event and a regular text message, hit
+  `/_search_messages` with empty keyword, confirm only the text message is
+  returned.
+
+## 6. References
+
+- Indexer spec §2.2 (search hard-filter contract):
+  `~/Projects/_refs/wukongim-message-indexer/docs/specs/2026-06-04-v1.6-decisions.md`
+- Code: `modules/messages_search/search_messages.go::buildSearchMessagesDSL`,
+  `modules/messages_search/source.go` (`payloadTypeSystemMin`/`Max`)

--- a/docs/messages-search/2026-06-23-system-msg-hard-filter.md
+++ b/docs/messages-search/2026-06-23-system-msg-hard-filter.md
@@ -1,7 +1,8 @@
-# messages_search: hard-filter system messages from `_search_messages`
+# messages_search: hard-filter system messages from `_search_messages` and `_search_around`
 
 Date: 2026-06-23
-Surface: `POST /v1/messages/_search` (`_search_messages` reader path)
+Surface: `POST /v1/messages/_search` (`_search_messages` reader path),
+`POST /v1/messages/_search_around` (anchor + window)
 
 ## 1. Problem
 
@@ -11,64 +12,116 @@ recalled control-plane events — "GroupCreate", "GroupMemberAdd", "Tip",
 violates the indexer's "搜索硬过滤" contract for the 1000-2000 system-message
 range.
 
+Follow-up review found the same gap in `/_search_around`: both the anchor
+lookup and the window query only excluded `payload.type == 99`, so an anchor on
+a system event could be located and the surrounding window would surface
+control-plane noise. The around path was not believed to be wired up from the
+current frontend, but the endpoint is mounted and the fix is cheap, so it is
+folded into this remediation.
+
 ## 2. Root cause
 
-`buildSearchMessagesDSL` only excluded `payload.type == 99` (Cmd):
+`buildSearchMessagesDSL` (and, as it turned out on review, `buildAnchorDSL` and
+`buildAroundDSL`) only excluded `payload.type == 99` (Cmd):
 
 ```go
 b.MustNot(elastic.NewTermQuery("payload.type", payloadTypeCmd))
 ```
 
-It did not exclude the **1000-2000 system range** defined by the indexer
+None of them excluded the **1000-2000 system range** defined by the indexer
 (`FriendApply=1000` … `Tip=2000`). When the keyword is empty, the only
 discriminator left is the channel filter + `revoked=false`, so every system
-event indexed in the channel surfaced as a "hit".
+event indexed in the channel surfaced as a "hit". For around, the same hole
+exists structurally: window queries have no keyword by design, so the system
+range bleed-through is unconditional.
 
 ## 3. Fix
 
-Add a single `RangeQuery` to `must_not` in `buildSearchMessagesDSL`:
+Add a single `RangeQuery` to `must_not` alongside the existing cmd term, on
+both surfaces, via a shared helper (see §7):
 
 ```go
-b.MustNot(elastic.NewTermQuery("payload.type", payloadTypeCmd))
-b.MustNot(elastic.NewRangeQuery("payload.type").Gte(payloadTypeSystemMin).Lte(payloadTypeSystemMax))
+applySystemMessageHardFilter(b)
+// ↓ expands to
+// b.MustNot(elastic.NewTermQuery("payload.type", payloadTypeCmd))
+// b.MustNot(elastic.NewRangeQuery("payload.type").Gte(payloadTypeSystemMin).Lte(payloadTypeSystemMax))
 ```
 
 Constants `payloadTypeSystemMin = 1000` / `payloadTypeSystemMax = 2000` are
 added to `modules/messages_search/source.go` alongside the existing
 `payloadType*` family, with a comment that points back to the indexer spec
-(§2.2) as the source of truth.
+(§2.4) as the source of truth.
 
 ## 4. Affected endpoints
 
 | Endpoint | Status | Why |
 |---|---|---|
-| `POST /v1/messages/_search` (`_search_messages`) | **Fixed** — adds 1000-2000 must_not range | Only surface that previously matched system events |
+| `POST /v1/messages/_search` (`_search_messages`) | **Fixed** — adds 1000-2000 must_not range | Keyword + browse surface; only one that previously matched system events from the user-facing path |
+| `POST /v1/messages/_search_around` | **Fixed in this PR (continuation)** — `buildAnchorDSL` + `buildAroundDSL` both pick up the range via shared helper | Window query carries no keyword by design, so the system-range bleed-through is structural; anchor lookup must hold to the same contract so a system event is never a valid anchor |
 | `POST /v1/messages/_search_all` | Unchanged — already safe | Whitelist filter `terms payload.type in [1, 8, 11]` excludes anything outside text/file/mergeForward |
 | `POST /v1/messages/_search_files` | N/A | Hard-filters `payload.type == 8` |
 | `POST /v1/messages/_search_media` | N/A | Hard-filters `payload.type in [2, 5]` |
-| `POST /v1/messages/_search_around` | Out of scope here | `buildAnchorDSL` is a separate code path; review tracked separately if needed |
 
 ## 5. Tests
 
-- `TestBuildSearchMessagesDSL_FiltersSystemMessages` (new, `dsl_test.go`):
+- `TestApplySystemMessageHardFilter` (new, `dsl_test.go`): unit test for the
+  shared helper — walks the parsed bool query and asserts both must_not
+  clauses are emitted given an empty `BoolQuery` input.
+- `TestBuildSearchMessagesDSL_FiltersSystemMessages` (existing, `dsl_test.go`):
   asserts both the term (`payload.type == 99`) and range (`payload.type ∈
   [1000, 2000]`) clauses are emitted in `must_not`, in both keyword and
   empty-keyword (browse) branches. Walks the parsed query tree rather than
   relying on substring pins so the assertion survives unrelated DSL
   formatting changes.
-- `TestBuildSearchMessagesDSL_Shape` and
-  `TestBuildSearchMessagesDSL_NoKeywordSkipsMultiMatch` updated to also
-  require `"gte":1000` / `"lte":2000` in the emitted DSL — keeps the
-  literal-JSON pins in sync without dropping the existing `payload.type=99`
-  pin.
+- `TestBuildAroundDSL_FiltersSystemMessages` (new, `search_around_test.go`):
+  same assertion against `buildAroundDSL` — the around window.
+- `TestBuildAnchorDSL_FiltersSystemMessages` (new, `search_around_test.go`):
+  same assertion against `buildAnchorDSL` — the around anchor lookup.
+- `TestBuildSearchMessagesDSL_Shape` /
+  `TestBuildSearchMessagesDSL_NoKeywordSkipsMultiMatch` continue to require
+  `"gte":1000` / `"lte":2000` in the emitted DSL — keeps the literal-JSON
+  pins in sync without dropping the existing `payload.type=99` pin.
 - Staging verification (TODO): seed a channel with a `GroupMemberAdd`
   (`payload.type=1002`) event and a regular text message, hit
-  `/_search_messages` with empty keyword, confirm only the text message is
-  returned.
+  `/_search_messages` with empty keyword AND `/_search_around` anchored
+  before/after the event, confirm only the text message is returned in
+  either surface.
 
 ## 6. References
 
-- Indexer spec §2.2 (search hard-filter contract):
+- Indexer spec §2.4 (search hard-filter contract):
   `~/Projects/_refs/wukongim-message-indexer/docs/specs/2026-06-04-v1.6-decisions.md`
-- Code: `modules/messages_search/search_messages.go::buildSearchMessagesDSL`,
-  `modules/messages_search/source.go` (`payloadTypeSystemMin`/`Max`)
+- Code: `modules/messages_search/dsl.go::applySystemMessageHardFilter`,
+  `modules/messages_search/search_messages.go::buildSearchMessagesDSL`,
+  `modules/messages_search/search_around.go::buildAnchorDSL` /
+  `buildAroundDSL`, `modules/messages_search/source.go`
+  (`payloadTypeSystemMin`/`Max`).
+
+## 7. Shared helper
+
+The fix factors the two `must_not` clauses into
+`applySystemMessageHardFilter(*elastic.BoolQuery)` in `dsl.go`. Rationale:
+
+- The contract is defined once by the indexer spec (§2.4) and must hold on
+  both `_search_messages` and `_search_around`. Duplicating the literal
+  `MustNot(...)` calls in three call sites (search_messages window,
+  search_around window, search_around anchor) created the original drift —
+  the around builders were written with only the cmd term while
+  `_search_messages` got both clauses. The helper removes that drift surface.
+- Scope is deliberately narrow: the helper covers ONLY the
+  `payload.type`-based negations. `revoked` is a message-level state — a
+  different semantic layer — and stays in `applyChannelAndRevoked`. Callers
+  on a search/browse path are expected to call both.
+- When the indexer pins down the RTC range (§8 below) the helper picks up
+  the extra clause and all three call sites benefit at once.
+
+## 8. RTC 9989-9999 follow-up (TODO)
+
+The indexer spec §2.3 reserves a Webhook / RTC range (provisionally
+`9989-9999`) that is not yet finalised by the indexer owners. Once §2.3 is
+pinned, `applySystemMessageHardFilter` should add the corresponding
+`must_not` clause (likely another `RangeQuery`) so both surfaces pick it up
+at the same time. This PR intentionally does NOT add the clause — adding a
+speculative range filter risks dropping legitimate hits if the boundary
+moves.
+

--- a/modules/messages_search/dsl.go
+++ b/modules/messages_search/dsl.go
@@ -61,6 +61,33 @@ func applyChannelAndRevoked(b *elastic.BoolQuery, normChannelID string) {
 	b.MustNot(elastic.NewTermQuery("revoked", true))
 }
 
+// applySystemMessageHardFilter layers the indexer-spec §2.4 "搜索硬过滤"
+// contract for control-plane / system payload types onto a bool query. Per
+// ~/Projects/_refs/wukongim-message-indexer/docs/specs/2026-06-04-v1.6-decisions.md §2.4:
+//
+//	must_not:
+//	  - { term:  { payload.type: 99 } }                            # Cmd
+//	  - { range: { payload.type: { gte: 1000, lte: 2000 } } }      # FriendApply..Tip
+//
+// Both /_search_messages (the legacy keyword/browse surface) and
+// /_search_around (anchor + window) need this — without it the empty-keyword
+// browse path and the around window both surface GroupCreate / Tip /
+// FriendApply events that the user never authored.
+//
+// Scope: this helper covers ONLY the payload.type negations. The `revoked`
+// negation is a separate concern (message-level state, not control-plane
+// type) and lives in applyChannelAndRevoked; search/browse paths should call
+// both.
+//
+// Note (RTC 9989-9999): the spec also reserves a Webhook/RTC range that is
+// not yet pinned by the indexer owners. Once §2.3 is finalised this helper
+// should add the matching `must_not` clause so both endpoints pick it up at
+// the same time.
+func applySystemMessageHardFilter(b *elastic.BoolQuery) {
+	b.MustNot(elastic.NewTermQuery("payload.type", payloadTypeCmd))
+	b.MustNot(elastic.NewRangeQuery("payload.type").Gte(payloadTypeSystemMin).Lte(payloadTypeSystemMax))
+}
+
 // applySpaceIDScope layers the per-Space term filter onto the bool query for
 // p2p (channel_type=1) search only. Group and thread searches are already
 // space-scoped at the channel level (channel_id encodes the parent space) so

--- a/modules/messages_search/dsl_test.go
+++ b/modules/messages_search/dsl_test.go
@@ -193,6 +193,72 @@ func TestBuildSearchMessagesDSL_FiltersSystemMessages(t *testing.T) {
 	}
 }
 
+// TestApplySystemMessageHardFilter pins the shared helper that both
+// /_search_messages and /_search_around use to satisfy the indexer §2.4
+// "搜索硬过滤" contract. Empty bool query in, two must_not clauses out:
+// term(payload.type=99) and range(payload.type ∈ [1000, 2000]).
+func TestApplySystemMessageHardFilter(t *testing.T) {
+	b := elastic.NewBoolQuery()
+	applySystemMessageHardFilter(b)
+
+	src, err := b.Source()
+	if err != nil {
+		t.Fatalf("Source(): %v", err)
+	}
+	raw, _ := json.Marshal(src)
+	var normalized map[string]any
+	if err := json.Unmarshal(raw, &normalized); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	boolNode, ok := normalized["bool"].(map[string]any)
+	if !ok {
+		t.Fatalf("query has no bool node: %s", raw)
+	}
+	rawMN, ok := boolNode["must_not"]
+	if !ok {
+		t.Fatalf("bool has no must_not: %s", raw)
+	}
+	var mustNot []any
+	switch v := rawMN.(type) {
+	case []any:
+		mustNot = v
+	case map[string]any:
+		mustNot = []any{v}
+	default:
+		t.Fatalf("must_not has unexpected shape %T: %s", rawMN, raw)
+	}
+
+	var seenCmd, seenRange bool
+	for _, clause := range mustNot {
+		m, ok := clause.(map[string]any)
+		if !ok {
+			continue
+		}
+		if term, ok := m["term"].(map[string]any); ok {
+			if pt, ok := term["payload.type"].(float64); ok && int(pt) == payloadTypeCmd {
+				seenCmd = true
+			}
+		}
+		if rng, ok := m["range"].(map[string]any); ok {
+			if pt, ok := rng["payload.type"].(map[string]any); ok {
+				lo, loOK := pt["from"].(float64)
+				hi, hiOK := pt["to"].(float64)
+				incLo, _ := pt["include_lower"].(bool)
+				incHi, _ := pt["include_upper"].(bool)
+				if loOK && hiOK && int(lo) == payloadTypeSystemMin && int(hi) == payloadTypeSystemMax && incLo && incHi {
+					seenRange = true
+				}
+			}
+		}
+	}
+	if !seenCmd {
+		t.Errorf("must_not missing term payload.type=%d in:\n%s", payloadTypeCmd, raw)
+	}
+	if !seenRange {
+		t.Errorf("must_not missing range payload.type [%d,%d] in:\n%s", payloadTypeSystemMin, payloadTypeSystemMax, raw)
+	}
+}
+
 func TestBuildSearchMediaDSL_FiltersTypes(t *testing.T) {
 	req := SearchMediaReq{ChannelType: channelTypeGroup, ChannelID: "g"}
 	q := buildSearchMediaDSL(req, "g", "")

--- a/modules/messages_search/dsl_test.go
+++ b/modules/messages_search/dsl_test.go
@@ -68,6 +68,10 @@ func TestBuildSearchMessagesDSL_Shape(t *testing.T) {
 		`"channelId":"groupNo"`,
 		`"revoked":true`,
 		`"payload.type":99`,
+		`"from":1000`,
+		`"to":2000`,
+		`"include_lower":true`,
+		`"include_upper":true`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("DSL missing %q in:\n%s", want, body)
@@ -92,10 +96,100 @@ func TestBuildSearchMessagesDSL_NoKeywordSkipsMultiMatch(t *testing.T) {
 		`"channelId":"groupNo"`,
 		`"revoked":true`,
 		`"payload.type":99`,
+		`"from":1000`,
+		`"to":2000`,
+		`"include_lower":true`,
+		`"include_upper":true`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("empty-keyword DSL missing %q in:\n%s", want, body)
 		}
+	}
+}
+
+// TestBuildSearchMessagesDSL_FiltersSystemMessages pins the indexer §2.2
+// "搜索硬过滤" contract: payload.type 1000-2000 (FriendApply / Group* / Hotline*
+// / Tip) MUST be excluded from /_search_messages, alongside the existing
+// type==99 (Cmd) exclusion. Regression test for the empty-keyword browse path
+// leaking "GroupCreate" / "GroupMemberAdd" system events to the client.
+func TestBuildSearchMessagesDSL_FiltersSystemMessages(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		keyword string
+	}{
+		{"keyword", "hello"},
+		{"browse", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := SearchMessagesReq{
+				ChannelType: channelTypeGroup,
+				ChannelID:   "groupNo",
+				Keyword:     tc.keyword,
+			}
+			q, _ := buildSearchMessagesDSL(context.Background(), fallbackTestAnalyzer(), true, req, "groupNo", "")
+			src, err := q.(interface{ Source() (any, error) }).Source()
+			if err != nil {
+				t.Fatalf("Source(): %v", err)
+			}
+			b, _ := json.Marshal(src)
+			body := string(b)
+
+			// JSON-roundtrip so all numeric values normalize to float64 and
+			// nested objects to map[string]any, regardless of what concrete
+			// Go types elastic.BoolQuery.Source() chose to emit.
+			var normalized map[string]any
+			if err := json.Unmarshal(b, &normalized); err != nil {
+				t.Fatalf("normalize: %v", err)
+			}
+			boolNode, ok := normalized["bool"].(map[string]any)
+			if !ok {
+				t.Fatalf("query has no bool node: %s", body)
+			}
+			rawMN, ok := boolNode["must_not"]
+			if !ok {
+				t.Fatalf("bool has no must_not: %s", body)
+			}
+			var mustNot []any
+			switch v := rawMN.(type) {
+			case []any:
+				mustNot = v
+			case map[string]any:
+				mustNot = []any{v}
+			default:
+				t.Fatalf("must_not has unexpected shape %T: %s", rawMN, body)
+			}
+
+			var seenCmd, seenRange bool
+			for _, clause := range mustNot {
+				m, ok := clause.(map[string]any)
+				if !ok {
+					continue
+				}
+				if term, ok := m["term"].(map[string]any); ok {
+					if pt, ok := term["payload.type"].(float64); ok && int(pt) == payloadTypeCmd {
+						seenCmd = true
+					}
+				}
+				if rng, ok := m["range"].(map[string]any); ok {
+					if pt, ok := rng["payload.type"].(map[string]any); ok {
+						// elastic encodes Gte/Lte as from/to + include_lower/include_upper.
+						lo, loOK := pt["from"].(float64)
+						hi, hiOK := pt["to"].(float64)
+						incLo, _ := pt["include_lower"].(bool)
+						incHi, _ := pt["include_upper"].(bool)
+						if loOK && hiOK && int(lo) == payloadTypeSystemMin && int(hi) == payloadTypeSystemMax && incLo && incHi {
+							seenRange = true
+						}
+					}
+				}
+			}
+			if !seenCmd {
+				t.Errorf("must_not missing term payload.type=%d in:\n%s", payloadTypeCmd, body)
+			}
+			if !seenRange {
+				t.Errorf("must_not missing range payload.type [%d,%d] in:\n%s", payloadTypeSystemMin, payloadTypeSystemMax, body)
+			}
+		})
 	}
 }
 

--- a/modules/messages_search/search_around.go
+++ b/modules/messages_search/search_around.go
@@ -150,10 +150,11 @@ func (h *Handler) searchAround(c *wkhttp.Context) {
 // out of Space, or filtered out; (hit, nil) when the anchor is visible.
 //
 // The lookup applies the SAME structural negations the window query uses
-// (revoked + cmd exclusion) so the anchor is held to the exact visibility
-// contract of the stream it anchors: a command message (payload.type=99) is
-// never a valid anchor, mirroring buildAroundDSL's MustNot(cmd). filterVisible
-// then layers the MySQL-resident gates (revoke/delete/offset/visibles) on top.
+// (revoked + system-message hard filter) so the anchor is held to the exact
+// visibility contract of the stream it anchors: a command message
+// (payload.type=99) or a system event (payload.type ∈ [1000, 2000]) is never
+// a valid anchor, mirroring buildAroundDSL. filterVisible then layers the
+// MySQL-resident gates (revoke/delete/offset/visibles) on top.
 func (h *Handler) fetchAnchor(ctx context.Context, client *elastic.Client, req SearchAroundReq, normID, spaceID, loginUID string, anchorID int64) (*elastic.SearchHit, error) {
 	b := buildAnchorDSL(req, normID, spaceID, anchorID)
 
@@ -225,10 +226,11 @@ func (h *Handler) aroundDirection(ctx context.Context, client *elastic.Client, r
 }
 
 // buildAnchorDSL builds the single-doc anchor lookup. It applies the same
-// structural visibility negations as the window (revoked + cmd exclusion) plus
-// the Space scope, so the anchor is held to the exact contract of the stream it
-// anchors — a command (payload.type=99) or revoked doc can never be a valid
-// anchor, mirroring buildAroundDSL. MySQL-resident gates are layered on top by
+// structural visibility negations as the window (revoked + system-message hard
+// filter) plus the Space scope, so the anchor is held to the exact contract of
+// the stream it anchors — a command (payload.type=99) or system event
+// (payload.type ∈ [1000, 2000]) or revoked doc can never be a valid anchor,
+// mirroring buildAroundDSL. MySQL-resident gates are layered on top by
 // filterVisible in fetchAnchor.
 func buildAnchorDSL(req SearchAroundReq, normChannelID, spaceID string, anchorID int64) *elastic.BoolQuery {
 	b := elastic.NewBoolQuery()
@@ -236,20 +238,21 @@ func buildAnchorDSL(req SearchAroundReq, normChannelID, spaceID string, anchorID
 	b.Filter(elastic.NewTermQuery("messageId", anchorID))
 	applySpaceIDScope(b, req.ChannelType, spaceID)
 	b.MustNot(elastic.NewTermQuery("revoked", true))
-	b.MustNot(elastic.NewTermQuery("payload.type", payloadTypeCmd))
+	applySystemMessageHardFilter(b)
 	return b
 }
 
-// buildAroundDSL is the window query (no keyword, no payload.type filter): the
-// full visible message stream of the channel, scoped to Space for p2p, with the
-// standard revoked/cmd negations. The anchor itself is excluded so it is not
-// duplicated into either wing.
+// buildAroundDSL is the window query (no keyword, no payload-type whitelist):
+// the full visible message stream of the channel, scoped to Space for p2p, with
+// the standard revoked negation and the indexer §2.4 system-message hard
+// filter. The anchor itself is excluded so it is not duplicated into either
+// wing.
 func buildAroundDSL(req SearchAroundReq, normChannelID, spaceID string) elastic.Query {
 	b := elastic.NewBoolQuery()
 	applyChannelAndRevoked(b, normChannelID)
 	applySpaceIDScope(b, req.ChannelType, spaceID)
 	addCommonFilters(b, req.Filters)
-	b.MustNot(elastic.NewTermQuery("payload.type", payloadTypeCmd))
+	applySystemMessageHardFilter(b)
 	return b
 }
 

--- a/modules/messages_search/search_around_test.go
+++ b/modules/messages_search/search_around_test.go
@@ -168,3 +168,88 @@ func TestBuildAnchorDSL_P2PSpaceScoped(t *testing.T) {
 		t.Fatalf("p2p anchor DSL must be Space-scoped, got:\n%s", body)
 	}
 }
+
+// assertSystemMessageHardFilter walks a query's bool.must_not and reports
+// whether both the term(payload.type=99) and range(payload.type ∈ [1000,2000])
+// clauses are present — the indexer §2.4 hard-filter contract.
+func assertSystemMessageHardFilter(t *testing.T, q interface {
+	Source() (any, error)
+}) {
+	t.Helper()
+	src, err := q.Source()
+	if err != nil {
+		t.Fatalf("Source(): %v", err)
+	}
+	raw, _ := json.Marshal(src)
+	var normalized map[string]any
+	if err := json.Unmarshal(raw, &normalized); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	boolNode, ok := normalized["bool"].(map[string]any)
+	if !ok {
+		t.Fatalf("query has no bool node: %s", raw)
+	}
+	rawMN, ok := boolNode["must_not"]
+	if !ok {
+		t.Fatalf("bool has no must_not: %s", raw)
+	}
+	var mustNot []any
+	switch v := rawMN.(type) {
+	case []any:
+		mustNot = v
+	case map[string]any:
+		mustNot = []any{v}
+	default:
+		t.Fatalf("must_not has unexpected shape %T: %s", rawMN, raw)
+	}
+	var seenCmd, seenRange bool
+	for _, clause := range mustNot {
+		m, ok := clause.(map[string]any)
+		if !ok {
+			continue
+		}
+		if term, ok := m["term"].(map[string]any); ok {
+			if pt, ok := term["payload.type"].(float64); ok && int(pt) == payloadTypeCmd {
+				seenCmd = true
+			}
+		}
+		if rng, ok := m["range"].(map[string]any); ok {
+			if pt, ok := rng["payload.type"].(map[string]any); ok {
+				lo, loOK := pt["from"].(float64)
+				hi, hiOK := pt["to"].(float64)
+				incLo, _ := pt["include_lower"].(bool)
+				incHi, _ := pt["include_upper"].(bool)
+				if loOK && hiOK && int(lo) == payloadTypeSystemMin && int(hi) == payloadTypeSystemMax && incLo && incHi {
+					seenRange = true
+				}
+			}
+		}
+	}
+	if !seenCmd {
+		t.Errorf("must_not missing term payload.type=%d in:\n%s", payloadTypeCmd, raw)
+	}
+	if !seenRange {
+		t.Errorf("must_not missing range payload.type [%d,%d] in:\n%s", payloadTypeSystemMin, payloadTypeSystemMax, raw)
+	}
+}
+
+// TestBuildAroundDSL_FiltersSystemMessages pins the indexer §2.4 hard-filter
+// contract for the around window query: it must exclude payload.type=99 (Cmd)
+// AND payload.type ∈ [1000, 2000] (FriendApply..Tip). Companion to the
+// _search_messages regression — without this the around window leaks
+// GroupCreate / Tip / FriendApply system events.
+func TestBuildAroundDSL_FiltersSystemMessages(t *testing.T) {
+	req := SearchAroundReq{ChannelType: channelTypeGroup, ChannelID: "G1"}
+	assertSystemMessageHardFilter(t, buildAroundDSL(req, "G1", "").(interface {
+		Source() (any, error)
+	}))
+}
+
+// TestBuildAnchorDSL_FiltersSystemMessages pins the same §2.4 contract on the
+// anchor lookup: a system event must not be a valid anchor (cross-page
+// disclosure oracle would otherwise emit a NOT_FOUND that depends on whether
+// the system event exists for the channel).
+func TestBuildAnchorDSL_FiltersSystemMessages(t *testing.T) {
+	req := SearchAroundReq{ChannelType: channelTypeGroup, ChannelID: "G1"}
+	assertSystemMessageHardFilter(t, buildAnchorDSL(req, "G1", "", 42))
+}

--- a/modules/messages_search/search_messages.go
+++ b/modules/messages_search/search_messages.go
@@ -157,6 +157,7 @@ func buildSearchMessagesDSL(ctx context.Context, analyzer tokenAnalyzer, stopwor
 	applySpaceIDScope(b, req.ChannelType, spaceID)
 	addCommonFilters(b, req.Filters)
 	b.MustNot(elastic.NewTermQuery("payload.type", payloadTypeCmd))
+	b.MustNot(elastic.NewRangeQuery("payload.type").Gte(payloadTypeSystemMin).Lte(payloadTypeSystemMax))
 	return b, analyzeErr
 }
 

--- a/modules/messages_search/search_messages.go
+++ b/modules/messages_search/search_messages.go
@@ -156,8 +156,7 @@ func buildSearchMessagesDSL(ctx context.Context, analyzer tokenAnalyzer, stopwor
 	applyChannelAndRevoked(b, normChannelID)
 	applySpaceIDScope(b, req.ChannelType, spaceID)
 	addCommonFilters(b, req.Filters)
-	b.MustNot(elastic.NewTermQuery("payload.type", payloadTypeCmd))
-	b.MustNot(elastic.NewRangeQuery("payload.type").Gte(payloadTypeSystemMin).Lte(payloadTypeSystemMax))
+	applySystemMessageHardFilter(b)
 	return b, analyzeErr
 }
 

--- a/modules/messages_search/source.go
+++ b/modules/messages_search/source.go
@@ -113,6 +113,15 @@ const (
 	payloadTypeFile         = 8
 	payloadTypeMergeForward = 11
 	payloadTypeCmd          = 99
+
+	// System message range per indexer spec
+	// (~/Projects/_refs/wukongim-message-indexer/docs/specs/2026-06-04-v1.6-decisions.md §2.2):
+	// payload.type 1000-2000 covers FriendApply / Group* / Hotline* / Tip etc.
+	// These are control-plane events emitted by WuKongIM and MUST be hard-filtered
+	// from /_search_messages (the legacy `_search` surface) per the indexer's
+	// "搜索硬过滤" contract.
+	payloadTypeSystemMin = 1000
+	payloadTypeSystemMax = 2000
 )
 
 // classifyKind decides the response `message_kind` for /v1/messages/_search.


### PR DESCRIPTION
## Summary

Hard-filter `payload.type ∈ [1000, 2000]` (system messages) out of `/_search_messages` **and** `/_search_around`. The wukongim-message-indexer spec defines this range as the system-message range (FriendApply / GroupCreate / GroupMemberAdd|Remove|Invite / GroupUpdate / RevokeMessage / GroupMemberQuit / HotlineAssignTo|Solved|Reopen / Tip etc.) and stipulates "搜索硬过滤" (search must hard-filter them out).

octo-server reader had `MustNot(term=99 cmd)` wired in three builders (`buildSearchMessagesDSL` for `/_search_messages`, `buildAnchorDSL` and `buildAroundDSL` for `/_search_around`), but none covered the [1000, 2000] system range. Reported in test env as "invite-member / create-thread system notifications appearing in chat search". Same leak existed on `/_search_around` window/anchor queries.

## Related Issue

(internal — test env report, 2026-06-23: `/_search_messages` empty-keyword browse on group `d2231780e4...` returned "邀请成员加入了群" / "创建了子区" entries alongside real messages; review caught `/_search_around` had the same gap.)

## Linked Spec

`docs/messages-search/2026-06-23-system-msg-hard-filter.md` (added in this PR).

Authoritative source: `wukongim-message-indexer/docs/specs/2026-06-04-v1.6-decisions.md §2.4` — "系统类（1000-2000，搜索硬过滤）".

## Changes

Two commits:

**Commit 1** (`63bc971`): initial fix on `/_search_messages` only.
- `modules/messages_search/source.go`: add `payloadTypeSystemMin = 1000` / `payloadTypeSystemMax = 2000` constants.
- `modules/messages_search/search_messages.go::buildSearchMessagesDSL`: add `b.MustNot(NewRangeQuery("payload.type").Gte(payloadTypeSystemMin).Lte(payloadTypeSystemMax))`.

**Commit 2** (`01104bf`): extend to `/_search_around` + extract shared helper.
- `modules/messages_search/dsl.go`: new `applySystemMessageHardFilter(b *elastic.BoolQuery)` helper, layered next to the existing `applyChannelAndRevoked` / `applySpaceIDScope` / `addCommonFilters` family.
- `modules/messages_search/search_messages.go::buildSearchMessagesDSL`: refactor the two `MustNot` lines into a single `applySystemMessageHardFilter(b)` call (DSL output byte-identical).
- `modules/messages_search/search_around.go::buildAnchorDSL`: same helper call.
- `modules/messages_search/search_around.go::buildAroundDSL`: same helper call. Both builders previously only had `MustNot(==99)` — now cover the full 1000-2000 range.
- `fetchAnchor` docstring updated to match the new shared semantic.

The helper **does not** subsume `revoked=true` filtering. `revoked` is a message-level state (per-message revocation), not a control-plane payload-type concern, so it stays in `applyChannelAndRevoked`. Callers on a search / browse path apply both.

Endpoint matrix:

| Endpoint | Status | Why |
|---|---|---|
| `/_search_messages` | Fixed (commit 1, refactored in commit 2) | Three builders now share `applySystemMessageHardFilter` |
| `/_search_around` (anchor) | Fixed (commit 2) | Anchor point lookup previously only filtered `==99` |
| `/_search_around` (window) | Fixed (commit 2) | Window before/after queries previously only filtered `==99` |
| `/_search_all` | Already safe | `Filter(payload.type ∈ {1, 8, 11})` allowlist — system types never pass |
| `/_search_files` | N/A | Filter to file payload-type only |
| `/_search_media` | N/A | Filter to image/video payload-types only |

## Testing

- `go test ./modules/messages_search/... -count=1` → PASS (~42ms)
- `go vet ./modules/messages_search/...` → clean
- `go build ./...` → clean

Tests:

- **New** `TestApplySystemMessageHardFilter` (dsl_test.go): walks a blank `BoolQuery` after helper application; asserts both `term(==99)` and `range[1000, 2000]` `must_not` clauses present.
- **New** `TestBuildAroundDSL_FiltersSystemMessages` (search_around_test.go): builds an around-window DSL and walks its `must_not` for the same two clauses.
- **New** `TestBuildAnchorDSL_FiltersSystemMessages` (search_around_test.go): same for the anchor-lookup DSL.
- **New** `TestBuildSearchMessagesDSL_FiltersSystemMessages` (commit 1, dsl_test.go, table: keyword + browse): walks parsed query tree; asserts range clause on `payload.type` with `from=1000` / `to=2000` present.
- **Updated** existing pin tests:
  - `TestBuildSearchMessagesDSL_Shape` and `TestBuildSearchMessagesDSL_NoKeywordSkipsMultiMatch`: extended substring-pin lists with `"from":1000` / `"to":2000` / `"include_lower":true` / `"include_upper":true` (olivere/elastic v7 serializes `Gte/Lte` to ES's older `from`/`to`/`include_*` form; semantically equivalent to modern `gte`/`lte`).
- **Unchanged** (and still passing): all `_search_all`, `_search_files`, `_search_media` DSL tests — confirms the change is properly scoped.

Not in this PR (deliberate):
- Real-OS recall validation in a channel that has known type∈[1000,2000] documents — left to `make env-test` integration in staging.
- **RTC 9989-9999 follow-up**: the indexer spec hints at a potential additional system-type range (RealTimeCommunication codes 9989-9999); not currently in the spec's "搜索硬过滤" definition. Recorded in the spec doc §8 as a TODO pending indexer-spec owner confirmation.

- [x] Unit tests added/updated
- [ ] Manually verified (needs staging `make env-test` or port-forward repro on test env)

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   Adds one additional `must_not range` clause to three ES bool queries: the `/v1/messages/_search` query, plus `/v1/messages/_search_around`'s anchor point lookup and its before/after window queries. The clauses are pure server-side filters in filter context (no scoring impact, no extra OS roundtrip, no change to response shape / cursor / highlight / sort). Documents with `payload.type` in [1000, 2000] that previously appeared in any of these three endpoints' results no longer do; everything else is byte-identical.

2. **What could break because of it (dependents + failure mode)?**
   - **Clients that explicitly relied on system messages appearing in search/around results** would now miss them. Per indexer spec §2.4 "搜索硬过滤" contract, this is the documented intended behavior — clients should not have been depending on the leak. Worth flagging in release notes regardless.
   - **Performance**: `must_not range` on a numeric field is one of ES's cheapest filters. Unmeasurable at current keyword-search and around-jump workload scale.
   - **`payload.type` field type assumption**: clauses assume `payload.type` is indexed as numeric. Confirmed via `wukongim-message-indexer/docs/specs/opensearch-mapping-and-init.md` (`integer`). If the mapping ever flips, the clause silently matches nothing — degrades to current leaky behavior, doesn't break the query.
   - **Future system-msg types outside [1000, 2000]**: not caught by this PR. The indexer spec reserves the whole 1000-2000 range for system events; new types are expected to land inside it. Out-of-range additions would need a coordinated indexer-spec + reader update (see §8 RTC 9989-9999 TODO).
   - **Helper refactor regression risk**: zero — the helper is pure encapsulation, emitted DSL JSON is byte-identical to inline. All existing DSL pin tests pass without modification.

3. **How do you know it works (specific test/repro/trace)?**
   - **Unit**: four new tests across two test files. Each constructs the relevant DSL builder, JSON-roundtrips `Source()` to a generic tree (normalizes whatever concrete numeric types the elastic library happens to emit), walks the `must_not` array, and asserts both `term(==99)` and `range(1000..2000)` clauses are present on `payload.type`. Existing substring-pin tests extended to include the new range subexpressions.
   - **Helper-equivalence trace**: before commit 2, `buildSearchMessagesDSL` had the two `MustNot` lines inline. Commit 2 swaps them for `applySystemMessageHardFilter(b)`. The helper body is verbatim those two lines. Existing `TestBuildSearchMessagesDSL_Shape` / `_NoKeywordSkipsMultiMatch` / `_FiltersSystemMessages` all still pass without modification — proves the refactor is byte-identical, then the new `_FiltersSystemMessages` tests on around/anchor prove the helper is wired into the previously-leaking builders.
   - **Reasoning trace**: indexer spec §2.4 documents the 15 system types in [1000, 2000] and the "搜索硬过滤" contract. The previous code only handled `==99` (Cmd) — a single point exclusion. The new clause covers the entire reserved system range in one range filter; no per-type enumeration needed. Helper centralization ensures the next reader builder that goes through this code path can't accidentally miss the contract.
   - **Staging recall validation deferred**: end-to-end repro requires either staging `make env-test` or port-forward on test env (previous local-boot attempt hit the read-only MySQL replica wall). This PR adds the code, tests, and spec; recall validation is the rollout gate.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (spec doc covers both endpoints)
- [x] Followed commit message conventions (Conventional Commits)
