### PR TITLE
feat(incomingwebhook): mention support on the native push endpoint

### DIFF
--- a/.octospec/tasks/incoming-webhook-mention/brief.md
+++ b/.octospec/tasks/incoming-webhook-mention/brief.md
@@ -1,0 +1,110 @@
+---
+type: Task
+title: "Task: incoming-webhook-mention"
+description: Add caller-controlled @mention (users + bots, one or many) to the native incoming-webhook push endpoint, with per-webhook capability switches for the two broadcast forms.
+tags: ["incomingwebhook", "mention", "wire-contract", "trust-boundary"]
+timestamp: 2026-06-23T13:15:14Z
+# --- octospec extension fields ---
+slug: incoming-webhook-mention
+upstream: self
+source: self
+---
+
+# Task: incoming-webhook-mention
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work.
+
+## Goal
+
+Let an incoming-webhook caller @mention **specific group members (users and/or
+bots, one or many)** and optionally broadcast **@所有人 (humans)** and
+**@所有 AI (bots)** from the **native** push endpoint. Mentioned humans get the
+existing `[有人@我]` red-dot; mentioned bots get delivery (no red-dot), all via
+the **existing** message-module reminder listener — this task only puts a
+well-formed `mention` map on the wire.
+
+The two broadcast forms are abuse-sensitive (a leaked webhook token spamming the
+whole group), so each is gated by a **per-webhook capability switch**, default
+**off**, toggled through the management API by any legitimate member who manages
+the webhook (its creator, or a group admin) — the per-webhook, default-off switch
+is the control, not a separate admin grant. Targeted `@uid` needs no switch but is
+constrained to current group members + a hard cap. (Revoking members' ability to
+flip these later is an additive group-level or system-setting policy ANDed at the
+push read path — see the journal/notes; no schema change.)
+
+## Background
+
+- Today `buildPayload` (`modules/incomingwebhook/api.go`) emits only
+  `type/content/from/space_id` and **discards `extra`**; there is no mention
+  support (`@all/@here` is left as literal text). The code comment there is the
+  sanctioned extension point: add an **explicitly whitelisted** field, never a
+  passthrough.
+- The wire mention contract is the `mention` sub-map (`uids/humans/ais/entities`)
+  owned by `pkg/mentionrewrite` and read by `modules/message/api_reminders.go`
+  (`getMention`). Reminder generation is **sender-agnostic** (a WuKongIM message
+  listener), so a webhook message carrying `mention.uids/humans` fires reminders
+  with no message-module change.
+- `mention.ais=1` is expanded to bot-member UIDs by
+  `pkg/mentionrewrite.ExpandAisToBotUIDs`, fed by a per-ingress composer
+  (`GetMembers` + `robot.ExistRobot`) — mirror `modules/bot_api/mention_expand.go`.
+- Decisions locked with maintainer: native endpoint only; caller supplies UIDs
+  (no name resolution); both broadcast switches default off; UID cap = 50.
+- Industry parity: structured-field opt-in (caller must set `all/bots:true`) ≈
+  Discord `allowed_mentions`; the per-webhook capability ≈ Slack "who can
+  @channel" but at webhook-resource granularity.
+
+## Load-bearing list
+
+- **wire-contract** — `mention.{uids,humans,ais}` shape must match what
+  `pkg/mentionrewrite` + `message/api_reminders.go getMention` already consume
+  (UID strings; truthy-one flags). Do not invent a new shape.
+- **external-content / trust-boundary / webhook** — the push endpoint is an
+  attacker-controlled, unauthenticated (token-in-URL) ingress. New field must be
+  validated at the boundary: membership gate, dedup, count cap; mention is a
+  **whitelisted structured field**, never `extra` passthrough.
+- **space / isolation** — mention targets MUST be filtered to current members of
+  the webhook's `group_no`; a token must not ping arbitrary platform users or
+  cross-Space identities.
+- **error-response / i18n** — any new management-side validation reuses
+  `httperr.ResponseErrorL` + a registered `pkg/errcode` code; push-side
+  "ignored/unresolved" feedback is non-fatal data in the 200 body, not an error.
+- **adapter parity (native-only)** — mention is gated to the native adapter via a
+  `pushAdapter` capability flag; sibling adapters (wecom/feishu/github/gitlab/
+  multica) neither parse nor emit mention. Adding a feature only to native is
+  safe (no new attack surface for siblings); the parity rule about *escaping*
+  still holds because mention carries structured UIDs, not rendered markdown.
+- **bot-api / robot wiring** — `IncomingWebhook` gains a robot dependency
+  (`ExistRobot` / bot-member enumeration) it does not currently hold.
+- existing push pipeline (auth → rate-limit → group-active → creator-membership
+  → audit) and `buildRichTextPayload` must be unaffected except for the new
+  mention insertion point.
+
+## Out of scope
+
+- Name/username/email → UID resolution (`mention.names`).
+- Mention via platform adapters (WeCom/Feishu/GitHub/GitLab/Multica).
+- `mention.entities` offset/pill generation (v1: `uids` drive the ping; the
+  literal `@name` in `content` is plain text). Pills are a later phase.
+- `mention.all` legacy field semantics and any change to the message-module
+  reminder/read path.
+- Group-level mention policy (`allow_no_mention` / `bot_mention_pref`).
+
+## Acceptance
+
+- Native push with `mention.uids=[<member uids>]` → delivered payload carries
+  `mention.uids` containing **only** current group members, **deduped**, **≤50**;
+  non-members and blanks dropped.
+- `mention.all=true` + webhook `allow_mention_all=1` → payload `mention.humans=1`;
+  with `allow_mention_all=0` → no `humans`, and 200 body reports it ignored.
+- `mention.bots=true` + webhook `allow_mention_bots=1` → `ExpandAisToBotUIDs`
+  appends bot-member UIDs; with `allow_mention_bots=0` → not expanded + reported.
+- A non-native adapter (e.g. wecom) with a `mention` field in its body → no
+  `mention` in the delivered payload.
+- `create`/`update` accept + persist `allow_mention_all` / `allow_mention_bots`
+  (default 0); `webhookResp` surfaces them.
+- Empty/absent `mention`, malformed `mention.uids` → no panic, no `mention` key
+  (full backward compatibility with existing native callers).
+- `go test ./modules/incomingwebhook/...` passes incl. a new mention test +
+  `TestIncomingWebhookNoLegacyResponseError`; `make i18n-extract-check` +
+  `make i18n-lint` pass; `golangci-lint run ./modules/incomingwebhook/...` clean.

--- a/.octospec/tasks/incoming-webhook-mention/context.yaml
+++ b/.octospec/tasks/incoming-webhook-mention/context.yaml
@@ -1,0 +1,38 @@
+slug: incoming-webhook-mention
+rules_injected:
+  - id: trust-boundary
+    tier: repo
+    load_bearing: true
+    why: incomingwebhook push is attacker-controlled ingress; mention is a whitelisted
+         structured field (never extra passthrough); uids bounded + member-gated;
+         feature gated to native adapter (parity preserved — structured UIDs, not markdown).
+  - id: space-isolation
+    tier: repo
+    load_bearing: true
+    why: mention targets filtered to current internal-normal members of the webhook's
+         group_no; a group-scoped token cannot ping arbitrary or cross-Space identities.
+  - id: error-handling
+    tier: repo
+    load_bearing: true
+    why: management-side capability gate reuses mgmtRequestInvalid (ErrIncomingWebhookRequestInvalid);
+         no new error codes added; push-side ignored/dropped feedback is non-fatal 200 body, not an error.
+  - id: testing
+    tier: repo
+    load_bearing: false
+    why: new mention_test.go + extend TestIncomingWebhookNoLegacyResponseError file list.
+  - id: commit-style
+    tier: repo
+    load_bearing: false
+    why: Conventional Commits, English.
+files_touched:
+  - modules/incomingwebhook/model.go        # mentionReq, model+req+resp switch fields
+  - modules/incomingwebhook/api.go          # struct wiring, handlePush mention attach, create/update gates, toResp
+  - modules/incomingwebhook/adapter.go      # pushAdapter.allowMention (native-only)
+  - modules/incomingwebhook/mention.go      # buildMention + helpers (new)
+  - modules/incomingwebhook/mention_expand.go # fetchBotMemberUIDs composer (new)
+  - modules/incomingwebhook/db.go           # filterGroupMembers
+  - modules/incomingwebhook/sql/20260623000001_incomingwebhook_mention_switches.sql # new columns
+parity_decisions:
+  - "@所有 AI expansion reuses pkg/mentionrewrite.ExpandAisToBotUIDs with GetMembers+ExistRobot, identical to modules/bot_api + modules/message ingresses."
+  - "wire mention shape {uids:[]interface{}, humans:1, ais:1} matches message/api_reminders.go getMention + pkg/mentionrewrite keys."
+  - "reminders/red-dot/bot-summon happen downstream via the sender-agnostic message listener — no message-module change."

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -117,6 +117,8 @@ var systemSettingSchema = []settingDef{
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.IncomingWebhookMaxPerGroup()) }},
 	{Category: "incomingwebhook", Key: "max_per_creator", Type: settingTypeInt, Description: "单个普通成员/机器人在一个群内最多可创建的 Webhook 数量（群主/管理员不受限）", Positive: true,
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.IncomingWebhookMaxPerCreator()) }},
+	{Category: "incomingwebhook", Key: "member_can_broadcast", Type: settingTypeBool, Description: "非管理员成员创建的 Webhook 是否可用广播型 @（@所有人/@所有 AI）；关闭后即时收回成员广播，管理员创建的不受影响",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.IncomingWebhookMemberCanBroadcast()) }},
 
 	// Email server config — formerly yaml-only (Support.* in config.go).
 	{Category: "support", Key: "email", Type: settingTypeString, Description: "技术支持邮箱（发件人）",

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -561,12 +561,15 @@ const (
 	envIncomingWebhookPerWebhookBurst = "DM_INCOMINGWEBHOOK_BURST"
 	envIncomingWebhookMaxPerGroup     = "DM_INCOMINGWEBHOOK_MAX_PER_GROUP"
 	envIncomingWebhookMaxPerCreator   = "DM_INCOMINGWEBHOOK_MAX_PER_CREATOR"
+	// 控制非管理员成员创建的 webhook 是否可用广播型 @（@所有人 / @所有 AI）。
+	envIncomingWebhookMemberCanBroadcast = "OCTO_INCOMINGWEBHOOK_MEMBER_CAN_BROADCAST"
 
-	defaultIncomingWebhookEnabled         = true
-	defaultIncomingWebhookPerWebhookRPS   = 5.0
-	defaultIncomingWebhookPerWebhookBurst = 10
-	defaultIncomingWebhookMaxPerGroup     = 10
-	defaultIncomingWebhookMaxPerCreator   = 5
+	defaultIncomingWebhookEnabled            = true
+	defaultIncomingWebhookPerWebhookRPS      = 5.0
+	defaultIncomingWebhookPerWebhookBurst    = 10
+	defaultIncomingWebhookMaxPerGroup        = 10
+	defaultIncomingWebhookMaxPerCreator      = 5
+	defaultIncomingWebhookMemberCanBroadcast = true
 )
 
 // IncomingWebhookEnabled 是群入站 Webhook 功能的总开关。关闭后 push 端点返回 404、
@@ -574,6 +577,15 @@ const (
 // 回退链：DB → env(DM_INCOMINGWEBHOOK_ENABLED) → 默认开启(true)。
 func (s *SystemSettings) IncomingWebhookEnabled() bool {
 	return s.getBool("incomingwebhook", "enabled", incomingWebhookEnabledEnvDefault())
+}
+
+// IncomingWebhookMemberCanBroadcast 控制【非管理员成员】创建的 webhook 是否可使用广播型
+// @（@所有人 / @所有 AI）。关闭后，成员建的 webhook 即便已置 allow_mention_* 能力位，其
+// 广播也在 push 读路径被剥离（mention_ignored 回报）；【管理员创建】的 webhook 不受影响。
+// 因为是 push 读侧 AND（参见 incomingwebhook.buildMention），翻此开关可【即时收回】全部成员
+// 广播、无需迁移存量列。回退链：DB → env(OCTO_INCOMINGWEBHOOK_MEMBER_CAN_BROADCAST) → 默认开启(true)。
+func (s *SystemSettings) IncomingWebhookMemberCanBroadcast() bool {
+	return s.getBool("incomingwebhook", "member_can_broadcast", incomingWebhookMemberCanBroadcastEnvDefault())
 }
 
 // IncomingWebhookPerWebhookRPS 单个 webhook 令牌桶速率(rps)。DB → env → 默认 5。
@@ -636,6 +648,22 @@ func incomingWebhookEnabledEnvDefault() bool {
 		return true
 	}
 	return defaultIncomingWebhookEnabled
+}
+
+// incomingWebhookMemberCanBroadcastEnvDefault 解析 OCTO_INCOMINGWEBHOOK_MEMBER_CAN_BROADCAST
+// （缺省/无法识别视为开启），作为 DB 未配置时的 fallback。语义同 incomingWebhookEnabledEnvDefault。
+func incomingWebhookMemberCanBroadcastEnvDefault() bool {
+	v := strings.TrimSpace(os.Getenv(envIncomingWebhookMemberCanBroadcast))
+	if v == "" {
+		return defaultIncomingWebhookMemberCanBroadcast
+	}
+	switch strings.ToLower(v) {
+	case "0", "false", "no", "off":
+		return false
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return defaultIncomingWebhookMemberCanBroadcast
 }
 
 // incomingWebhookMaxPerGroupEnvDefault 解析 DM_INCOMINGWEBHOOK_MAX_PER_GROUP；仅

--- a/modules/common/system_settings_test.go
+++ b/modules/common/system_settings_test.go
@@ -145,6 +145,26 @@ func TestSystemSettings_IncomingWebhookEnabled_EnvFallbackWhenDBUnset(t *testing
 	assert.False(t, s.IncomingWebhookEnabled(), "DB 未配置 → env=false 生效")
 }
 
+func TestSystemSettings_IncomingWebhookMemberCanBroadcast_DefaultsTrue(t *testing.T) {
+	t.Setenv(envIncomingWebhookMemberCanBroadcast, "")
+	s := newTestSystemSettings(t, nil)
+	assert.True(t, s.IncomingWebhookMemberCanBroadcast(), "DB+env 缺失时默认开启")
+}
+
+func TestSystemSettings_IncomingWebhookMemberCanBroadcast_DBOverridesToFalse(t *testing.T) {
+	t.Setenv(envIncomingWebhookMemberCanBroadcast, "")
+	s := newTestSystemSettings(t, nil)
+	require.NoError(t, s.db.upsert("incomingwebhook", "member_can_broadcast", "0", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+	assert.False(t, s.IncomingWebhookMemberCanBroadcast(), "DB 0 必须压制默认 true")
+}
+
+func TestSystemSettings_IncomingWebhookMemberCanBroadcast_EnvFallbackWhenDBUnset(t *testing.T) {
+	t.Setenv(envIncomingWebhookMemberCanBroadcast, "false")
+	s := newTestSystemSettings(t, nil)
+	assert.False(t, s.IncomingWebhookMemberCanBroadcast(), "DB 未配置 → env=false 生效")
+}
+
 func TestSystemSettings_IncomingWebhookThresholds_DefaultsAndDBOverride(t *testing.T) {
 	t.Setenv(envIncomingWebhookPerWebhookRPS, "")
 	t.Setenv(envIncomingWebhookPerWebhookBurst, "")

--- a/modules/incomingwebhook/adapter.go
+++ b/modules/incomingwebhook/adapter.go
@@ -45,10 +45,16 @@ type pushAdapter struct {
 	// 说明 URL token 已验证、调用方已持有 webhook 真正密钥，故不匹配是配置错误而非枚举
 	// 探测（见 handlePush）。nil 表示该形态无需 header token 二次校验。
 	verifyToken func(header http.Header, urlToken string) bool
+	// allowMention 标记该形态是否处理请求里的 mention（@ 群成员/广播）。仅 native 置真：
+	// @ 由调用方在 native payload 里显式描述（mentionReq），平台适配器(github/wecom/…)
+	// 的 body 是平台生成的事件、没有 octo 成员 UID 语义，强行支持 @ 需要平台身份↔群成员
+	// 的映射表，超出本期范围。置假的形态即便 parse 出 req.Mention 也一律忽略（防御纵深）。
+	allowMention bool
 }
 
 var (
-	nativeAdapter = pushAdapter{name: adapterNative, parse: parseNativePush, bodyLimit: maxBytes}
+	// 仅 native 形态支持 @：调用方在 payload 里用 mention{uids,all,bots} 显式描述。
+	nativeAdapter = pushAdapter{name: adapterNative, parse: parseNativePush, bodyLimit: maxBytes, allowMention: true}
 	githubAdapter = pushAdapter{name: adapterGitHub, parse: parseGitHubPush, bodyLimit: githubMaxBytes}
 	wecomAdapter  = pushAdapter{
 		name:      adapterWeCom,

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -26,7 +26,9 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	commonmod "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/robot"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"github.com/go-redis/redis"
@@ -70,9 +72,14 @@ const (
 type IncomingWebhook struct {
 	ctx *config.Context
 	log.Log
-	db        *incomingWebhookDB
-	groupDB   *group.DB
-	rateRedis *redis.Client
+	db      *incomingWebhookDB
+	groupDB *group.DB
+	// groupService / robotService 仅服务 @所有 AI 的展开（fetchBotMemberUIDs：
+	// GetMembers + ExistRobot）。复用与 message / bot_api 入口相同的这对接口，保证
+	// webhook 的 @所有 AI 与其它入口解析出的 bot 集合一致（parity）。
+	groupService group.IService
+	robotService robot.IService
+	rateRedis    *redis.Client
 	// auditSem 给 push 成功后的异步审计(recordSuccess)限并发：每次推送有两次 DB 写，
 	// 无界 `go recordSuccess` 在 Redis 限流 fail-open + 推送洪峰下会无限堆 goroutine、
 	// 压垮 DB 连接池。用带缓冲 channel 作信号量给审计的 DB 操作总并发封顶——满了就**丢弃**
@@ -176,6 +183,8 @@ func newIncomingWebhook(ctx *config.Context) *IncomingWebhook {
 		Log:          log.NewTLog("IncomingWebhook"),
 		db:           newDB(ctx),
 		groupDB:      group.NewDB(ctx),
+		groupService: group.NewService(ctx),
+		robotService: robot.NewService(ctx),
 		rateRedis:    sharedRateRedis(ctx.GetConfig()),
 		auditSem:     make(chan struct{}, auditConcurrency()),
 		floor:        newLocalFloor(),
@@ -376,14 +385,16 @@ func autoWebhookName(webhookID string) string {
 
 func toResp(m *incomingWebhookModel) webhookResp {
 	r := webhookResp{
-		WebhookID:  m.WebhookID,
-		GroupNo:    m.GroupNo,
-		Name:       m.Name,
-		Avatar:     m.Avatar,
-		CreatorUID: m.CreatorUID,
-		Status:     m.Status,
-		CallCount:  m.CallCount,
-		CreatedAt:  time.Time(m.CreatedAt).Unix(),
+		WebhookID:        m.WebhookID,
+		GroupNo:          m.GroupNo,
+		Name:             m.Name,
+		Avatar:           m.Avatar,
+		CreatorUID:       m.CreatorUID,
+		Status:           m.Status,
+		AllowMentionAll:  m.AllowMentionAll,
+		AllowMentionBots: m.AllowMentionBots,
+		CallCount:        m.CallCount,
+		CreatedAt:        time.Time(m.CreatedAt).Unix(),
 	}
 	if m.LastUsedAt.Valid {
 		r.LastUsedAt = m.LastUsedAt.Time.Unix()
@@ -620,6 +631,9 @@ func (w *IncomingWebhook) create(c *wkhttp.Context) {
 		mgmtRequestInvalid(c, "avatar")
 		return
 	}
+	// 广播能力位（@所有人 / @所有 AI）可由任意合法成员在自建 webhook 上开启——与「成员可
+	// 自建/自管 webhook」一致。能力位仍是 per-webhook 粒度、默认关、需显式打开，作为广播
+	// 这类高噪声能力的唯一闸（不再额外要求管理员授予）。
 
 	// 查询 group 拿 space_id；同时确保群处于 Normal 状态。
 	// 已解散/已禁用的群禁止创建新 webhook，避免 disband 后被 stale 管理员复活。
@@ -648,14 +662,16 @@ func (w *IncomingWebhook) create(c *wkhttp.Context) {
 	}
 
 	m := &incomingWebhookModel{
-		WebhookID:  webhookID,
-		TokenHash:  hash,
-		GroupNo:    groupNo,
-		SpaceID:    g.SpaceID,
-		Name:       req.Name,
-		Avatar:     req.Avatar,
-		CreatorUID: actor.uid,
-		Status:     statusEnabled,
+		WebhookID:        webhookID,
+		TokenHash:        hash,
+		GroupNo:          groupNo,
+		SpaceID:          g.SpaceID,
+		Name:             req.Name,
+		Avatar:           req.Avatar,
+		CreatorUID:       actor.uid,
+		Status:           statusEnabled,
+		AllowMentionAll:  boolToInt(boolPtrTrue(req.AllowMentionAll)),
+		AllowMentionBots: boolToInt(boolPtrTrue(req.AllowMentionBots)),
 	}
 	// 配额校验 + 写入在事务内原子完成；FOR UPDATE 锁住 group_no 范围，防止并发越限。
 	//
@@ -795,6 +811,15 @@ func (w *IncomingWebhook) update(c *wkhttp.Context) {
 			}
 		}
 		fields["status"] = *req.Status
+	}
+	// 广播能力位可由 webhook 的合法成员自行开关（requireOwnership 已确认调用方是创建者
+	// 或管理员，即只能改自己有权管理的 webhook）——与 create 同口径，能力位仍默认关、
+	// per-webhook 粒度、需显式打开。
+	if req.AllowMentionAll != nil {
+		fields["allow_mention_all"] = boolToInt(*req.AllowMentionAll)
+	}
+	if req.AllowMentionBots != nil {
+		fields["allow_mention_bots"] = boolToInt(*req.AllowMentionBots)
 	}
 	if len(fields) == 0 {
 		c.Response(toResp(m))
@@ -1289,6 +1314,33 @@ func (w *IncomingWebhook) handlePush(c *wkhttp.Context, ad pushAdapter) {
 		return
 	}
 
+	// 6.5) @ 提及：仅 native 形态处理（ad.allowMention）。buildMention 把调用方的
+	// mention{uids,all,bots} 翻译成消息 payload 的 mention 子对象——定向 uids 过群成员闸、
+	// 广播位过 per-webhook 能力位；mention 作为【显式白名单字段】挂进 payload（绝不走 Extra
+	// 透传，见 buildPayload 注释）。挂上后对 @所有 AI 调 ExpandAisToBotUIDs 展开为群内全部
+	// bot 成员 UID（GROUP-only，与 message/bot_api 入口同一 helper，bot 集合一致）。
+	// 其余 mention 语义（真人红点、唤起 bot）全由下游既有 message 监听器完成，本模块零参与。
+	// mention 与 msg_type 无关：text / richtext 两条 native 路径都接 @（语义一致）。
+	var mentionIgnored []string
+	if ad.allowMention {
+		// 广播放行策略（即时可收回，无需迁移）：system_setting member_can_broadcast 开，
+		// 或该 webhook 的创建者当前仍是群管理员（creatorIsAdmin，取自上面的成员闸查询）。
+		// 关掉设置即把全部【成员】创建的 webhook 的广播位立即剥离；管理员建的不受影响。
+		// 定向 @uid 不走此闸（不是广播、风险低）。
+		broadcastPermitted := w.settings.IncomingWebhookMemberCanBroadcast() || creatorIsAdmin
+		mention, ignored := w.buildMention(m, req, broadcastPermitted)
+		mentionIgnored = ignored
+		if mention != nil {
+			payload[mentionrewrite.MentionKey] = mention
+			// 与 message/robot/bot_api 入口一致：在 clone 上做 ais→bot uid 展开，避免就地
+			// 改写共享 map（本路径 payload 随即序列化、当前无下游读取，但仍守该约定，PR #145）。
+			wire := mentionrewrite.CloneForExpansion(payload)
+			wire = mentionrewrite.ExpandAisToBotUIDs(
+				wire, common.ChannelTypeGroup.Uint8(), m.GroupNo, w.fetchBotMemberUIDs)
+			payload = wire
+		}
+	}
+
 	resp, err := w.ctx.SendMessageWithResult(&config.MsgSendReq{
 		// RedDot=1 让 webhook 消息触发未读红点和推送，与 botfather/robot 一致。
 		Header:      config.MsgHeader{RedDot: 1},
@@ -1315,7 +1367,13 @@ func (w *IncomingWebhook) handlePush(c *wkhttp.Context, ad pushAdapter) {
 	// 真实推送成功累加 call_count / last_used_at。
 	w.submitSuccess(m, len(body), ip, msgID, ad.name, true)
 
-	c.Response(successBody(ad, msgID, ""))
+	respBody := successBody(ad, msgID, "")
+	// mention_ignored 回报因能力位未开而被忽略的广播位（all / bots），便于调用方排障；
+	// 定向 uids 中的非成员已在 buildMention 静默丢弃（反枚举），不在此回显。
+	if len(mentionIgnored) > 0 {
+		respBody["mention_ignored"] = mentionIgnored
+	}
+	c.Response(respBody)
 }
 
 // 与 create/update 路径的 webhook 名称/头像列长度约束一致，避免 push 路径成为绕过。

--- a/modules/incomingwebhook/api_i18n_test.go
+++ b/modules/incomingwebhook/api_i18n_test.go
@@ -21,7 +21,7 @@ import (
 func TestIncomingWebhookNoLegacyResponseError(t *testing.T) {
 	files := []string{"api.go", "api_i18n.go", "ratelimit.go", "localfloor.go", "cache.go",
 		"adapter.go", "adapter_github.go", "adapter_wecom.go", "adapter_multica.go",
-		"adapter_gitlab.go", "adapter_feishu.go"}
+		"adapter_gitlab.go", "adapter_feishu.go", "mention.go", "mention_expand.go"}
 	banned := []string{
 		".ResponseError(",
 		".ResponseErrorf(",

--- a/modules/incomingwebhook/db.go
+++ b/modules/incomingwebhook/db.go
@@ -126,10 +126,12 @@ func (d *incomingWebhookDB) queryByGroupNo(groupNo string) ([]*incomingWebhookMo
 // updateFieldsAllowed 限定 updateFields 可写的列，防御未来调用方误传用户输入作 key
 // 触发任意列改写。新增可更新列时显式在此追加。
 var updateFieldsAllowed = map[string]struct{}{
-	"name":       {},
-	"avatar":     {},
-	"status":     {},
-	"token_hash": {},
+	"name":               {},
+	"avatar":             {},
+	"status":             {},
+	"token_hash":         {},
+	"allow_mention_all":  {},
+	"allow_mention_bots": {},
 }
 
 // updateFields 更新单个 webhook 的允许列。带 status != statusDeleted 守卫：对已软删除
@@ -195,6 +197,40 @@ func (d *incomingWebhookDB) queryMemberRole(groupNo, uid string) (isMember, isAd
 		return false, false, err
 	}
 	return true, roles[0] == group.MemberRoleCreator || roles[0] == group.MemberRoleManager, nil
+}
+
+// filterGroupMembers 返回 uids 中【当前是 groupNo 内部正常成员】的子集（成员闸）。
+// 用于 push 路径的定向 @ 校验：webhook token 是写进 CI/平台配置的低信任共享密钥，必须
+// 把 @ 目标收敛到本群成员，杜绝「泄露的 token @ 任意平台用户 / 跨 Space 身份」以及借
+// 「@<uid> 是否被保留」探测成员归属。成员定义与 queryMemberRole 同口径（is_deleted=0
+// + is_external=0 + status=Normal）——外部成员在 v1 刻意不可被 @（空间隔离保守取舍）。
+//
+// 直接点读 group_member 表（与 queryMemberRole 一致，该表已是跨模块既有读取面），用
+// IN 一次取回命中子集；uids 由调用方先去重并钳到上限，IN 列表有界。空入参短路返回。
+//
+// ⚠️ 与 @所有 AI 的非对称是【有意】的：定向 @uid 走本闸、排除外部成员（保守）；而
+// @所有 AI(ais) 的 bot 展开走 fetchBotMemberUIDs→GetMembers，与 message/bot_api 入口
+// 同源、只排除已删成员（故可能含外部 bot 成员）——广播侧取 parity。两条路径都不越群/
+// 越 Space（都以本群成员为界，外部 bot 也确是本群成员），差异仅是「定向保守 vs 广播对齐
+// 其它入口」的取舍，非遗漏。
+func (d *incomingWebhookDB) filterGroupMembers(groupNo string, uids []string) (map[string]struct{}, error) {
+	out := make(map[string]struct{}, len(uids))
+	if groupNo == "" || len(uids) == 0 {
+		return out, nil
+	}
+	var got []string
+	_, err := d.session.Select("uid").From("group_member").
+		Where("group_no=?", groupNo).
+		Where("uid in ?", uids).
+		Where("is_deleted=0 AND is_external=0 AND status=?", int(common.GroupMemberStatusNormal)).
+		Load(&got)
+	if err != nil {
+		return nil, err
+	}
+	for _, u := range got {
+		out[u] = struct{}{}
+	}
+	return out, nil
 }
 
 // disableEnabledByWebhookID 把【仍处于启用态】的单个 webhook 置为禁用，用于 push

--- a/modules/incomingwebhook/mention.go
+++ b/modules/incomingwebhook/mention.go
@@ -1,0 +1,186 @@
+package incomingwebhook
+
+import (
+	"encoding/json"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
+	"go.uber.org/zap"
+)
+
+// decodeMention 宽松解码 native 请求里的 mention 原始字节（acceptance #6）：
+//   - 缺省（len==0）→ (nil,false)：无 mention。
+//   - 存在但 JSON 形状非法（mention 非对象 / uids 非字符串数组 / all|bots 非布尔 等）→
+//     (nil,false)：降级为「无 mention」、消息照常投递，绝不因相邻字段形状把整条推送 400。
+//   - 合法 → (*mentionReq,true)。`{"mention":null}` 合法且解出零值（等价无 mention）。
+func decodeMention(raw json.RawMessage) (*mentionReq, bool) {
+	if len(raw) == 0 {
+		return nil, false
+	}
+	var mr mentionReq
+	if err := json.Unmarshal(raw, &mr); err != nil {
+		return nil, false
+	}
+	return &mr, true
+}
+
+// @ 目标数量上限（去重后）。定向 @uid 是低风险能力，但仍需上限兜底：防止单条推送塞入
+// 上千 uid 撑大成员闸的 IN 查询与 payload。50 与「一条消息合理 @ 的人数」量级相符，
+// 可经 env 调整（与 maxContentRunes 等阈值同走 env 兜底）。
+const (
+	envMaxMentionUIDs     = "OCTO_INCOMINGWEBHOOK_MAX_MENTION_UIDS"
+	defaultMaxMentionUIDs = 50
+)
+
+func maxMentionUIDs() int {
+	if v := os.Getenv(envMaxMentionUIDs); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultMaxMentionUIDs
+}
+
+// buildMention 把 native 推送请求里的 mentionReq 翻译成消息 payload 的 mention 子对象
+// （线协议 {uids,humans,ais}），返回值可直接挂到 payload[mentionrewrite.MentionKey]。
+//
+// 处理（每步都对应 brief 的 acceptance）：
+//  1. 定向 uids：去重 + 钳到上限 → 经群成员闸过滤（只保留本群当前成员），命中集做成
+//     []interface{}（ExpandAisToBotUIDs 要求 uids 是 []interface{} 才会就地追加 bot）。
+//  2. @所有人(All)：webhook 的 allow_mention_all 开【且 broadcastPermitted】则写 humans=1，否则记入 ignored。
+//  3. @所有 AI(Bots)：allow_mention_bots 开【且 broadcastPermitted】则写 ais=1（稍后由调用方
+//     ExpandAisToBotUIDs 展开为群内全部 bot 成员 UID），否则记入 ignored。
+//
+// broadcastPermitted 由调用方传入：system_setting member_can_broadcast || 创建者当前为管理员。
+// 关掉该设置即可即时收回所有【成员】创建的 webhook 的广播能力，管理员创建的不受影响。
+//
+// mention 为空（无有效定向目标、无获批广播）时返回 nil——调用方据此决定是否挂 mention，
+// 保证「无 @ 的历史 native 调用」payload 形态完全不变（向后兼容）。
+//
+// ignored 是非致命反馈（哪些广播位因能力位未开而被忽略），由调用方放进成功响应体；
+// 定向 uids 中的非成员【静默丢弃】、不回显具体 uid——避免把推送端点变成「逐个 uid 探测
+// 是否本群成员」的枚举 oracle（成员闸的反枚举取舍，与 push 路径的统一 401 同源）。
+//
+// best-effort：成员闸查询失败时降级为「不带定向 @」（仅记 Warn），绝不因此让整条推送失败
+// ——这与 mention 其余环节的「失败即降级、不丢消息」一致。
+func (w *IncomingWebhook) buildMention(m *incomingWebhookModel, req *pushPayloadReq, broadcastPermitted bool) (map[string]interface{}, []string) {
+	mr, ok := decodeMention(req.Mention)
+	if !ok {
+		// 缺省即无 mention；【存在但畸形】按 acceptance #6 降级为无 mention（消息照投），
+		// 仅此情形记 Warn 以便排障——绝不让畸形 mention 把整条推送 400。
+		if len(req.Mention) > 0 {
+			w.Warn("malformed mention payload ignored; delivering message without mention",
+				zap.String("webhook_id", m.WebhookID))
+		}
+		return nil, nil
+	}
+	// IO 步骤：去重+钳上限后，把定向 uids 过一遍群成员闸。失败即降级为空成员集（→丢弃
+	// 全部定向 @），仅记 Warn、不让整条推送失败。纯决策（能力位放行 / 装配线协议）下沉到
+	// assembleMention，无 DB 依赖，便于单测穷举各分支。
+	uids := dedupNonEmpty(mr.Uids, maxMentionUIDs())
+	members := map[string]struct{}{}
+	if len(uids) > 0 {
+		got, err := w.db.filterGroupMembers(m.GroupNo, uids)
+		if err != nil {
+			w.Warn("filter group members for mention failed; dropping targeted @uids",
+				zap.String("webhook_id", m.WebhookID), zap.Error(err))
+		} else {
+			members = got
+		}
+	}
+	// 广播位有效性 = webhook 能力位 AND 策略放行（broadcastPermitted = system_setting
+	// member_can_broadcast || 创建者当前为管理员，由 handlePush 计算）。关掉设置即可即时
+	// 收回成员 webhook 的广播（管理员建的因 creatorIsAdmin 仍放行），无需迁移存量列。
+	return assembleMention(uids, members,
+		mr.All, mr.Bots,
+		m.AllowMentionAll == 1 && broadcastPermitted,
+		m.AllowMentionBots == 1 && broadcastPermitted)
+}
+
+// assembleMention 是 mention 装配的【纯决策核心】（无 IO，便于单测）：把已去重的定向
+// uids 过成员闸、按能力位放行广播位，组装成线协议 mention 子对象 {uids,humans,ais}。
+//   - uids     ：已 dedupNonEmpty 处理过的候选定向目标（保持顺序）。
+//   - members  ：本群成员集（filterGroupMembers 的结果）；不在集内的 uid 被静默丢弃。
+//   - wantAll/wantBots ：调用方是否请求 @所有人 / @所有 AI。
+//   - allowAll/allowBots：该 webhook 是否获批对应广播能力位。
+//
+// kept 刻意构造为 []interface{}：ExpandAisToBotUIDs 要求 mention.uids 是 []interface{}
+// 才会就地追加 bot UID（其它类型会被它当作畸形而跳过展开）。mention 为空（无有效定向、
+// 无获批广播）→ 返回 nil，调用方据此不挂 mention，保证无 @ 的历史调用 payload 不变。
+func assembleMention(uids []string, members map[string]struct{}, wantAll, wantBots, allowAll, allowBots bool) (map[string]interface{}, []string) {
+	var ignored []string
+	mention := map[string]interface{}{}
+
+	if len(uids) > 0 {
+		kept := make([]interface{}, 0, len(uids))
+		for _, u := range uids {
+			if _, ok := members[u]; ok {
+				kept = append(kept, u)
+			}
+		}
+		if len(kept) > 0 {
+			mention[mentionrewrite.UIDsKey] = kept
+		}
+	}
+
+	if wantAll {
+		if allowAll {
+			mention[mentionrewrite.HumansKey] = 1
+		} else {
+			ignored = append(ignored, "all")
+		}
+	}
+	if wantBots {
+		if allowBots {
+			mention[mentionrewrite.AIsKey] = 1
+		} else {
+			ignored = append(ignored, "bots")
+		}
+	}
+
+	if len(mention) == 0 {
+		return nil, ignored
+	}
+	return mention, ignored
+}
+
+// dedupNonEmpty 去掉空白项并去重，保持首次出现顺序，最多保留 limit 个（limit<=0 不限）。
+func dedupNonEmpty(in []string, limit int) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+	}
+	if len(out) == 0 {
+		// 全为空白项时与「空输入」同口径返回 nil，让调用方的 len()>0 判断一致。
+		return nil
+	}
+	return out
+}
+
+// boolPtrTrue 报告 *bool 是否显式为 true（nil / *false 均为 false）。
+func boolPtrTrue(b *bool) bool { return b != nil && *b }
+
+// boolToInt 把布尔映射到 0/1，供能力位列写入。
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/modules/incomingwebhook/mention_e2e_test.go
+++ b/modules/incomingwebhook/mention_e2e_test.go
@@ -1,0 +1,236 @@
+package incomingwebhook_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	modulescommon "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mention 的 E2E（需 MySQL/Redis/WuKongIM，CI 提供）：覆盖 HTTP 可观测的行为——
+// 广播能力位的持久化 / 管理端判权 / push 时能力位未开的 mention_ignored 回报，以及
+// 无 mention 字段的向后兼容。定向 uids 的成员闸 / ais 展开是【刻意不经 HTTP 回显】的
+// （反枚举 + 落在 WuKongIM payload），由 mention_test.go 的纯单测穷举，不在此重复。
+
+// adminCreateWebhook 以群主（admin）创建一个 webhook，可选带广播能力位，返回响应体。
+func adminCreateWebhook(t *testing.T, handler http.Handler, groupNo string, body map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), body))
+	require.Equalf(t, http.StatusOK, w.Code, "admin create body: %s", w.Body.String())
+	return parseJSON(t, w)
+}
+
+// TestMention_AdminCreateWithSwitchesPersist：管理员可在 create 时开启两个广播能力位，
+// 响应与后续 list 都如实回显 1/1。
+func TestMention_AdminCreateWithSwitchesPersist(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	created := adminCreateWebhook(t, handler, groupNo, map[string]interface{}{
+		"name":               "ci",
+		"allow_mention_all":  true,
+		"allow_mention_bots": true,
+	})
+	assert.EqualValues(t, 1, created["allow_mention_all"])
+	assert.EqualValues(t, 1, created["allow_mention_bots"])
+
+	// list 回显同样的能力位。
+	lw := do(handler, authReq("GET", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo), nil))
+	require.Equalf(t, http.StatusOK, lw.Code, "list body: %s", lw.Body.String())
+	list, _ := parseJSON(t, lw)["list"].([]interface{})
+	require.Len(t, list, 1)
+	first, _ := list[0].(map[string]interface{})
+	assert.EqualValues(t, 1, first["allow_mention_all"])
+	assert.EqualValues(t, 1, first["allow_mention_bots"])
+}
+
+// TestMention_DefaultSwitchesOff：不带能力位字段创建 → 两个开关默认关闭（0）。
+func TestMention_DefaultSwitchesOff(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	created := adminCreateWebhook(t, handler, groupNo, map[string]interface{}{"name": "ci"})
+	assert.EqualValues(t, 0, created["allow_mention_all"])
+	assert.EqualValues(t, 0, created["allow_mention_bots"])
+}
+
+// TestMention_MemberCanEnableSwitches：任意合法成员（role=0，非管理员）可在自建 webhook
+// 上开启广播能力位（与「成员可自建/自管 webhook」一致，不再要求管理员）；缺省则默认关闭。
+func TestMention_MemberCanEnableSwitches(t *testing.T) {
+	handler, _, groupNo := setupMemberEnv(t)
+
+	wOn := do(handler, userReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo),
+		map[string]interface{}{"allow_mention_all": true, "allow_mention_bots": true}, memberAToken))
+	require.Equalf(t, http.StatusOK, wOn.Code, "body: %s", wOn.Body.String())
+	on := parseJSON(t, wOn)
+	assert.EqualValues(t, 1, on["allow_mention_all"])
+	assert.EqualValues(t, 1, on["allow_mention_bots"])
+
+	// 不带开关 → 默认关闭。
+	wOK := do(handler, userReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo),
+		map[string]interface{}{}, memberAToken))
+	require.Equalf(t, http.StatusOK, wOK.Code, "body: %s", wOK.Body.String())
+	def := parseJSON(t, wOK)
+	assert.EqualValues(t, 0, def["allow_mention_all"])
+	assert.EqualValues(t, 0, def["allow_mention_bots"])
+}
+
+// TestMention_UpdateTogglesSwitches：管理员可经 update 开/关能力位；普通成员同样可改
+// 自己创建的 webhook 的能力位（与「成员可自建/自管 webhook」一致）。
+func TestMention_UpdateTogglesSwitches(t *testing.T) {
+	handler, _, groupNo := setupMemberEnv(t)
+
+	// 管理员建（默认 0/0）→ 开启 → 关闭。
+	created := adminCreateWebhook(t, handler, groupNo, map[string]interface{}{"name": "ci"})
+	whID, _ := created["webhook_id"].(string)
+
+	on := do(handler, authReq("PUT", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID),
+		map[string]interface{}{"allow_mention_all": true, "allow_mention_bots": true}))
+	require.Equalf(t, http.StatusOK, on.Code, "body: %s", on.Body.String())
+	onRes := parseJSON(t, on)
+	assert.EqualValues(t, 1, onRes["allow_mention_all"])
+	assert.EqualValues(t, 1, onRes["allow_mention_bots"])
+
+	off := do(handler, authReq("PUT", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, whID),
+		map[string]interface{}{"allow_mention_all": false}))
+	require.Equalf(t, http.StatusOK, off.Code, "body: %s", off.Body.String())
+	assert.EqualValues(t, 0, parseJSON(t, off)["allow_mention_all"])
+	assert.EqualValues(t, 1, parseJSON(t, off)["allow_mention_bots"], "untouched switch keeps its value")
+
+	// 普通成员对【自己创建】的 webhook 改能力位 → 200 且生效（成员可自管自建 webhook）。
+	mCreated := memberCreate(t, handler, groupNo)
+	mID, _ := mCreated["webhook_id"].(string)
+	mw := do(handler, userReq("PUT", fmt.Sprintf("/v1/groups/%s/incoming-webhooks/%s", groupNo, mID),
+		map[string]interface{}{"allow_mention_all": true}, memberAToken))
+	require.Equalf(t, http.StatusOK, mw.Code, "body: %s", mw.Body.String())
+	assert.EqualValues(t, 1, parseJSON(t, mw)["allow_mention_all"])
+}
+
+// TestMentionPush_BroadcastIgnoredWhenCapabilityOff：能力位关闭时 push 带 all/bots，
+// 消息照发（200），但响应体 mention_ignored 回报这两个广播位被忽略。
+func TestMentionPush_BroadcastIgnoredWhenCapabilityOff(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	created := adminCreateWebhook(t, handler, groupNo, map[string]interface{}{"name": "ci"}) // 默认 0/0
+	pushURL := fmt.Sprintf("/v1/incoming-webhooks/%s/%s", created["webhook_id"], created["token"])
+
+	pw := do(handler, anonReq("POST", pushURL,
+		[]byte(`{"content":"hi","mention":{"all":true,"bots":true}}`)))
+	require.Equalf(t, http.StatusOK, pw.Code, "push body: %s", pw.Body.String())
+	body := parseJSON(t, pw)
+	ignored, ok := body["mention_ignored"].([]interface{})
+	require.Truef(t, ok, "expected mention_ignored array, body: %s", pw.Body.String())
+	assert.ElementsMatch(t, []interface{}{"all", "bots"}, ignored)
+}
+
+// TestMentionPush_BroadcastAllowedWhenCapabilityOn：能力位开启时 push 带 all/bots →
+// 200 且【无】mention_ignored（广播被接受）。
+func TestMentionPush_BroadcastAllowedWhenCapabilityOn(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	created := adminCreateWebhook(t, handler, groupNo, map[string]interface{}{
+		"name":               "ci",
+		"allow_mention_all":  true,
+		"allow_mention_bots": true,
+	})
+	pushURL := fmt.Sprintf("/v1/incoming-webhooks/%s/%s", created["webhook_id"], created["token"])
+
+	pw := do(handler, anonReq("POST", pushURL,
+		[]byte(`{"content":"hi","mention":{"all":true,"bots":true}}`)))
+	require.Equalf(t, http.StatusOK, pw.Code, "push body: %s", pw.Body.String())
+	_, hasIgnored := parseJSON(t, pw)["mention_ignored"]
+	assert.Falsef(t, hasIgnored, "no broadcast should be ignored, body: %s", pw.Body.String())
+}
+
+// TestMentionPush_TargetedUIDsSucceed：定向 @ 群成员 → 200 且无 mention_ignored
+// （定向 @ 不受能力位约束；非成员静默丢弃不回显）。冒烟覆盖 push 路径接 mention 不出错。
+func TestMentionPush_TargetedUIDsSucceed(t *testing.T) {
+	handler, _, groupNo := setupMemberEnv(t)
+	created := adminCreateWebhook(t, handler, groupNo, map[string]interface{}{"name": "ci"})
+	pushURL := fmt.Sprintf("/v1/incoming-webhooks/%s/%s", created["webhook_id"], created["token"])
+
+	body := fmt.Sprintf(`{"content":"hi","mention":{"uids":["%s","not_a_member"]}}`, memberAUID)
+	pw := do(handler, anonReq("POST", pushURL, []byte(body)))
+	require.Equalf(t, http.StatusOK, pw.Code, "push body: %s", pw.Body.String())
+	_, hasIgnored := parseJSON(t, pw)["mention_ignored"]
+	assert.False(t, hasIgnored, "targeted uids are not capability-gated; non-members dropped silently")
+}
+
+// TestMentionPush_MemberBroadcastRevokedBySystemSetting 验证「预埋的收回开关」(option C)：
+// system_setting incomingwebhook.member_can_broadcast=0 时，【成员】创建的 webhook 的广播
+// (@所有人/@所有 AI) 在 push 读路径被即时剥离（mention_ignored 回报），而【管理员】创建的
+// webhook 不受影响——无需迁移已置 1 的能力位列、改个后台值即可收回。
+func TestMentionPush_MemberBroadcastRevokedBySystemSetting(t *testing.T) {
+	handler, ctx, groupNo := setupMemberEnv(t)
+	t.Setenv("OCTO_INCOMINGWEBHOOK_MEMBER_CAN_BROADCAST", "") // 证明纯由 DB 驱动
+
+	// 成员（非管理员）建一个开了两个广播位的 webhook。
+	mw := do(handler, userReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks", groupNo),
+		map[string]interface{}{"allow_mention_all": true, "allow_mention_bots": true}, memberAToken))
+	require.Equalf(t, http.StatusOK, mw.Code, "member create: %s", mw.Body.String())
+	mRes := parseJSON(t, mw)
+	memberPush := fmt.Sprintf("/v1/incoming-webhooks/%s/%s", mRes["webhook_id"], mRes["token"])
+
+	// 管理员建一个开了广播位的 webhook。
+	aRes := adminCreateWebhook(t, handler, groupNo, map[string]interface{}{
+		"name": "admin-ci", "allow_mention_all": true, "allow_mention_bots": true})
+	adminPush := fmt.Sprintf("/v1/incoming-webhooks/%s/%s", aRes["webhook_id"], aRes["token"])
+
+	// 收回：member_can_broadcast=0 + Reload 共享快照（与 TestFeatureToggle 同法）。
+	_, err := ctx.DB().InsertInto("system_setting").
+		Pair("category", "incomingwebhook").Pair("key_name", "member_can_broadcast").
+		Pair("value", "0").Pair("value_type", "bool").Pair("description", "").Exec()
+	require.NoError(t, err)
+	settings := modulescommon.EnsureSystemSettings(ctx)
+	require.NoError(t, settings.Reload())
+	defer func() {
+		_, _ = ctx.DB().DeleteFrom("system_setting").Where("category=?", "incomingwebhook").Exec()
+		_ = settings.Reload()
+	}()
+
+	// 成员 webhook 广播被即时剥离 → mention_ignored 回报 all+bots（无需改其能力位列）。
+	mp := do(handler, anonReq("POST", memberPush, []byte(`{"content":"hi","mention":{"all":true,"bots":true}}`)))
+	require.Equalf(t, http.StatusOK, mp.Code, "member push: %s", mp.Body.String())
+	ig, ok := parseJSON(t, mp)["mention_ignored"].([]interface{})
+	require.Truef(t, ok, "member broadcast must be reported ignored, body: %s", mp.Body.String())
+	assert.ElementsMatch(t, []interface{}{"all", "bots"}, ig)
+
+	// 管理员 webhook 不受影响 → 无 mention_ignored（creatorIsAdmin 仍放行）。
+	ap := do(handler, anonReq("POST", adminPush, []byte(`{"content":"hi","mention":{"all":true,"bots":true}}`)))
+	require.Equalf(t, http.StatusOK, ap.Code, "admin push: %s", ap.Body.String())
+	_, adminIgnored := parseJSON(t, ap)["mention_ignored"]
+	assert.Falsef(t, adminIgnored, "admin-created webhook broadcast must be unaffected, body: %s", ap.Body.String())
+}
+
+// TestMentionPush_MalformedMentionIgnored 钉 acceptance #6（review #445 的 P1 阻塞）：
+// 形状非法的 mention（uids 非数组 / mention 非对象 等）必须【降级为无 mention、消息照投
+// 200】，而不是把整条推送 400 掉（修复前这些都返回 400，把相邻的合法 content 也连累丢弃）。
+func TestMentionPush_MalformedMentionIgnored(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	created := adminCreateWebhook(t, handler, groupNo, map[string]interface{}{"name": "ci"})
+	pushURL := fmt.Sprintf("/v1/incoming-webhooks/%s/%s", created["webhook_id"], created["token"])
+
+	for _, body := range []string{
+		`{"content":"hi","mention":"please"}`,
+		`{"content":"hi","mention":{"uids":"alice"}}`,
+		`{"content":"hi","mention":{"uids":[1,2]}}`,
+		`{"content":"hi","mention":{"all":1}}`,
+		`{"content":"hi","mention":[]}`,
+	} {
+		pw := do(handler, anonReq("POST", pushURL, []byte(body)))
+		require.Equalf(t, http.StatusOK, pw.Code,
+			"malformed mention must still deliver (200), body=%s resp=%s", body, pw.Body.String())
+		_, hasIgnored := parseJSON(t, pw)["mention_ignored"]
+		assert.Falsef(t, hasIgnored, "malformed mention is dropped, not reported: %s", body)
+	}
+}
+
+// TestMentionPush_NoMentionFieldBackwardCompatible：不带 mention 字段的历史 native 调用
+// 行为不变（200，无 mention_ignored）。
+func TestMentionPush_NoMentionFieldBackwardCompatible(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	created := adminCreateWebhook(t, handler, groupNo, map[string]interface{}{"name": "ci"})
+	pushURL := fmt.Sprintf("/v1/incoming-webhooks/%s/%s", created["webhook_id"], created["token"])
+
+	pw := do(handler, anonReq("POST", pushURL, []byte(`{"content":"hi"}`)))
+	require.Equalf(t, http.StatusOK, pw.Code, "push body: %s", pw.Body.String())
+	_, hasIgnored := parseJSON(t, pw)["mention_ignored"]
+	assert.False(t, hasIgnored)
+}

--- a/modules/incomingwebhook/mention_expand.go
+++ b/modules/incomingwebhook/mention_expand.go
@@ -1,0 +1,51 @@
+// Module-side composer that wires (*IncomingWebhook).groupService.GetMembers +
+// (*IncomingWebhook).robotService.ExistRobot into the
+// pkg/mentionrewrite.ExpandAisToBotUIDs callback shape.
+//
+// See modules/message/mention_expand.go and modules/bot_api/mention_expand.go
+// for the design rationale — the leaf helper in pkg/mentionrewrite stays free
+// of any modules/* dependency to preserve the import-cycle-free invariant
+// called out in pkg/mentionrewrite/rewrite.go, so each ingress chokepoint owns
+// its own thin composer. This is the incoming-webhook ingress version; reusing
+// the SAME GetMembers + ExistRobot pair guarantees `@所有 AI` from a webhook
+// resolves to the identical bot set as the user / bot-API ingresses (parity).
+package incomingwebhook
+
+import (
+	"go.uber.org/zap"
+)
+
+// fetchBotMemberUIDs enumerates the bot members of groupNo for the
+// ExpandAisToBotUIDs chokepoint. Contract is identical to
+// (*Message).fetchBotMemberUIDs / (*BotAPI).fetchBotMemberUIDs — see those
+// files for the best-effort / per-row error rationale: a single failed
+// ExistRobot lookup is treated as "not a bot" rather than aborting the whole
+// expansion, and a non-nil error degrades the expansion to a no-op upstream
+// (pkg/mentionrewrite/expand_ais.go clause 5) instead of dropping the message.
+func (w *IncomingWebhook) fetchBotMemberUIDs(groupNo string) ([]string, error) {
+	members, err := w.groupService.GetMembers(groupNo)
+	if err != nil {
+		return nil, err
+	}
+	if len(members) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(members))
+	for _, mem := range members {
+		if mem == nil || mem.UID == "" {
+			continue
+		}
+		ok, existErr := w.robotService.ExistRobot(mem.UID)
+		if existErr != nil {
+			w.Warn("ExistRobot lookup failed during mention.ais expansion; treating member as non-bot",
+				zap.String("group_no", groupNo),
+				zap.String("uid", mem.UID),
+				zap.Error(existErr))
+			continue
+		}
+		if ok {
+			out = append(out, mem.UID)
+		}
+	}
+	return out, nil
+}

--- a/modules/incomingwebhook/mention_test.go
+++ b/modules/incomingwebhook/mention_test.go
@@ -1,0 +1,239 @@
+package incomingwebhook
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mention 核心逻辑的纯单测（无 DB/Redis/IM 依赖）：装配决策矩阵、去重/上限、布尔助手、
+// native body 解析，以及【与 ExpandAisToBotUIDs 的 parity】——装配出的线协议形态必须能被
+// 真实展开器消费。IO（成员闸 filterGroupMembers / fetchBotMemberUIDs）由集成测试覆盖。
+
+func memberSet(uids ...string) map[string]struct{} {
+	m := make(map[string]struct{}, len(uids))
+	for _, u := range uids {
+		m[u] = struct{}{}
+	}
+	return m
+}
+
+func TestAssembleMention(t *testing.T) {
+	t.Run("nil when nothing requested", func(t *testing.T) {
+		mention, ignored := assembleMention(nil, memberSet(), false, false, false, false)
+		assert.Nil(t, mention)
+		assert.Empty(t, ignored)
+	})
+
+	t.Run("targeted uids: keep members, drop non-members, preserve order", func(t *testing.T) {
+		uids := []string{"u_alice", "u_ghost", "bot_ci", "u_bob"}
+		mention, ignored := assembleMention(uids, memberSet("u_alice", "bot_ci", "u_bob"), false, false, false, false)
+		require.NotNil(t, mention)
+		assert.Empty(t, ignored)
+		// kept 必须是 []interface{}（ExpandAisToBotUIDs 的要求），且顺序保持、非成员被剔除。
+		got, ok := mention[mentionrewrite.UIDsKey].([]interface{})
+		require.True(t, ok, "uids must be []interface{} for ExpandAisToBotUIDs compatibility")
+		assert.Equal(t, []interface{}{"u_alice", "bot_ci", "u_bob"}, got)
+		// 无广播位时不应出现 humans/ais。
+		assert.NotContains(t, mention, mentionrewrite.HumansKey)
+		assert.NotContains(t, mention, mentionrewrite.AIsKey)
+	})
+
+	t.Run("all uids are non-members: no uids key, nil mention", func(t *testing.T) {
+		mention, ignored := assembleMention([]string{"u_ghost"}, memberSet("u_alice"), false, false, false, false)
+		assert.Nil(t, mention)
+		assert.Empty(t, ignored)
+	})
+
+	t.Run("@所有人 allowed -> humans=1", func(t *testing.T) {
+		mention, ignored := assembleMention(nil, memberSet(), true, false, true, false)
+		require.NotNil(t, mention)
+		assert.Equal(t, 1, mention[mentionrewrite.HumansKey])
+		assert.Empty(t, ignored)
+	})
+
+	t.Run("@所有人 denied -> ignored, no humans, nil mention", func(t *testing.T) {
+		mention, ignored := assembleMention(nil, memberSet(), true, false, false, false)
+		assert.Nil(t, mention)
+		assert.Equal(t, []string{"all"}, ignored)
+	})
+
+	t.Run("@所有 AI allowed -> ais=1", func(t *testing.T) {
+		mention, ignored := assembleMention(nil, memberSet(), false, true, false, true)
+		require.NotNil(t, mention)
+		assert.Equal(t, 1, mention[mentionrewrite.AIsKey])
+		assert.Empty(t, ignored)
+	})
+
+	t.Run("@所有 AI denied -> ignored", func(t *testing.T) {
+		mention, ignored := assembleMention(nil, memberSet(), false, true, false, false)
+		assert.Nil(t, mention)
+		assert.Equal(t, []string{"bots"}, ignored)
+	})
+
+	t.Run("both broadcasts denied -> ignored order [all, bots]", func(t *testing.T) {
+		mention, ignored := assembleMention(nil, memberSet(), true, true, false, false)
+		assert.Nil(t, mention)
+		assert.Equal(t, []string{"all", "bots"}, ignored)
+	})
+
+	t.Run("uids + both broadcasts allowed -> full mention", func(t *testing.T) {
+		mention, ignored := assembleMention([]string{"u_alice"}, memberSet("u_alice"), true, true, true, true)
+		require.NotNil(t, mention)
+		assert.Empty(t, ignored)
+		assert.Equal(t, []interface{}{"u_alice"}, mention[mentionrewrite.UIDsKey])
+		assert.Equal(t, 1, mention[mentionrewrite.HumansKey])
+		assert.Equal(t, 1, mention[mentionrewrite.AIsKey])
+	})
+
+	t.Run("targeted uids kept but @所有人 denied -> mention has uids, ignored has all", func(t *testing.T) {
+		mention, ignored := assembleMention([]string{"u_alice"}, memberSet("u_alice"), true, false, false, false)
+		require.NotNil(t, mention)
+		assert.Equal(t, []interface{}{"u_alice"}, mention[mentionrewrite.UIDsKey])
+		assert.NotContains(t, mention, mentionrewrite.HumansKey)
+		assert.Equal(t, []string{"all"}, ignored)
+	})
+}
+
+// TestAssembleMentionFeedsExpandAis is the parity gate: a mention assembled with
+// ais=1 must be consumable by the REAL pkg/mentionrewrite.ExpandAisToBotUIDs so
+// `@所有 AI` from a webhook resolves to the same bot-UID list as the user / bot
+// ingresses. Uses a stub fetchBotUIDs callback (the helper takes a callback, so
+// no DB/services are needed) — this locks the wire shape, not the lookup.
+func TestAssembleMentionFeedsExpandAis(t *testing.T) {
+	groupNo := "g_123"
+	mention, _ := assembleMention([]string{"u_alice"}, memberSet("u_alice"), false, true, false, true)
+	require.NotNil(t, mention)
+	require.Equal(t, 1, mention[mentionrewrite.AIsKey])
+
+	payload := map[string]interface{}{mentionrewrite.MentionKey: mention}
+	stub := func(string) ([]string, error) { return []string{"bot_x", "u_alice", "bot_y"}, nil }
+	out := mentionrewrite.ExpandAisToBotUIDs(payload, common.ChannelTypeGroup.Uint8(), groupNo, stub)
+
+	mm := out[mentionrewrite.MentionKey].(map[string]interface{})
+	uids := mm[mentionrewrite.UIDsKey].([]interface{})
+	// 原有 u_alice 保留、bot_x/bot_y 追加、u_alice 不重复（ExpandAisToBotUIDs 幂等去重）。
+	assert.Equal(t, []interface{}{"u_alice", "bot_x", "bot_y"}, uids)
+}
+
+func TestDedupNonEmpty(t *testing.T) {
+	t.Run("trim, drop blanks, dedup, preserve order", func(t *testing.T) {
+		got := dedupNonEmpty([]string{" u1 ", "u2", "u1", "", "  ", "u3", "u2"}, 0)
+		assert.Equal(t, []string{"u1", "u2", "u3"}, got)
+	})
+	t.Run("cap limits count after dedup", func(t *testing.T) {
+		got := dedupNonEmpty([]string{"u1", "u2", "u3", "u4"}, 2)
+		assert.Equal(t, []string{"u1", "u2"}, got)
+	})
+	t.Run("empty input -> nil", func(t *testing.T) {
+		assert.Nil(t, dedupNonEmpty(nil, 50))
+		assert.Nil(t, dedupNonEmpty([]string{"", "   "}, 50))
+	})
+}
+
+func TestBoolHelpers(t *testing.T) {
+	tr, fa := true, false
+	assert.False(t, boolPtrTrue(nil))
+	assert.False(t, boolPtrTrue(&fa))
+	assert.True(t, boolPtrTrue(&tr))
+	assert.Equal(t, 0, boolToInt(false))
+	assert.Equal(t, 1, boolToInt(true))
+}
+
+func TestMaxMentionUIDs(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		t.Setenv(envMaxMentionUIDs, "")
+		assert.Equal(t, defaultMaxMentionUIDs, maxMentionUIDs())
+	})
+	t.Run("env override", func(t *testing.T) {
+		t.Setenv(envMaxMentionUIDs, "7")
+		assert.Equal(t, 7, maxMentionUIDs())
+	})
+	t.Run("invalid env falls back to default", func(t *testing.T) {
+		t.Setenv(envMaxMentionUIDs, "-3")
+		assert.Equal(t, defaultMaxMentionUIDs, maxMentionUIDs())
+		t.Setenv(envMaxMentionUIDs, "abc")
+		assert.Equal(t, defaultMaxMentionUIDs, maxMentionUIDs())
+	})
+}
+
+// TestParseNativePushMention verifies the `mention` field is captured as raw JSON
+// by the native parser and — crucially — that a MALFORMED mention never fails the
+// parse (acceptance #6: it must degrade to "no mention", not 400 the whole push).
+func TestParseNativePushMention(t *testing.T) {
+	t.Run("valid mention captured raw and decodes", func(t *testing.T) {
+		req, skip, invalid := parseNativePush(nil,
+			[]byte(`{"content":"hi","mention":{"uids":["u1","u2"],"all":true,"bots":true}}`))
+		require.NotNil(t, req)
+		assert.Empty(t, skip)
+		assert.Empty(t, invalid)
+		mr, ok := decodeMention(req.Mention)
+		require.True(t, ok)
+		assert.Equal(t, []string{"u1", "u2"}, mr.Uids)
+		assert.True(t, mr.All)
+		assert.True(t, mr.Bots)
+	})
+	t.Run("mention absent -> empty raw, decode not ok (backward compatible)", func(t *testing.T) {
+		req, _, invalid := parseNativePush(nil, []byte(`{"content":"hi"}`))
+		require.NotNil(t, req)
+		assert.Empty(t, invalid)
+		assert.Empty(t, req.Mention)
+		_, ok := decodeMention(req.Mention)
+		assert.False(t, ok)
+	})
+	t.Run("malformed mention does NOT fail the parse (acceptance #6)", func(t *testing.T) {
+		for _, body := range []string{
+			`{"content":"hi","mention":"please"}`,
+			`{"content":"hi","mention":{"uids":"alice"}}`,
+			`{"content":"hi","mention":{"uids":[1,2]}}`,
+			`{"content":"hi","mention":{"all":1}}`,
+			`{"content":"hi","mention":[]}`,
+		} {
+			req, _, invalid := parseNativePush(nil, []byte(body))
+			require.NotNilf(t, req, "body=%s", body)
+			assert.Emptyf(t, invalid, "malformed mention must not invalidate the parse: %s", body)
+			_, ok := decodeMention(req.Mention)
+			assert.Falsef(t, ok, "malformed mention must decode as not-ok: %s", body)
+		}
+	})
+}
+
+// TestDecodeMention pins the lenient decode contract used by buildMention.
+func TestDecodeMention(t *testing.T) {
+	_, ok := decodeMention(nil)
+	assert.False(t, ok, "absent → not ok")
+
+	mr, ok := decodeMention(json.RawMessage(`null`))
+	assert.True(t, ok, "explicit null is valid JSON → ok with zero value")
+	assert.Nil(t, mr.Uids)
+
+	mr, ok = decodeMention(json.RawMessage(`{"uids":["a"],"all":true}`))
+	require.True(t, ok)
+	assert.Equal(t, []string{"a"}, mr.Uids)
+	assert.True(t, mr.All)
+
+	for _, bad := range []string{`"x"`, `[]`, `{"uids":3}`, `{"uids":["a",1]}`, `{"all":1}`} {
+		_, ok := decodeMention(json.RawMessage(bad))
+		assert.Falsef(t, ok, "malformed %s → not ok", bad)
+	}
+}
+
+// TestOnlyNativeAdapterAllowsMention pins acceptance #4: mention is processed only
+// by the native adapter; every sibling adapter must keep allowMention=false so a
+// future edit to a platform adapter can't silently start emitting mentions.
+func TestOnlyNativeAdapterAllowsMention(t *testing.T) {
+	assert.True(t, nativeAdapter.allowMention, "native adapter must process mention")
+	for name, ad := range map[string]pushAdapter{
+		"wecom":   wecomAdapter,
+		"github":  githubAdapter,
+		"gitlab":  gitlabAdapter,
+		"feishu":  feishuAdapter,
+		"multica": multicaAdapter,
+	} {
+		assert.Falsef(t, ad.allowMention, "%s adapter must NOT process mention (acceptance #4)", name)
+	}
+}

--- a/modules/incomingwebhook/model.go
+++ b/modules/incomingwebhook/model.go
@@ -1,6 +1,8 @@
 package incomingwebhook
 
 import (
+	"encoding/json"
+
 	"github.com/Mininglamp-OSS/octo-lib/pkg/db"
 	"github.com/gocraft/dbr/v2"
 )
@@ -28,8 +30,16 @@ type incomingWebhookModel struct {
 	Avatar     string
 	CreatorUID string
 	Status     int
-	LastUsedAt dbr.NullTime
-	CallCount  int64
+	// AllowMentionAll / AllowMentionBots 是【广播型 @】的 per-webhook 能力位
+	// （0=否[默认] / 1=是）：分别授权该 webhook 推送 @所有人(真人广播,→mention.humans)
+	// 与 @所有 AI(bot 广播,→mention.ais)。广播会刷全群红点 / 唤起全部 bot，是高噪声能力，
+	// 故默认关闭、需显式打开；由 webhook 的合法成员（创建者，或群管理员）在 create/update
+	// 时开关——与「成员可自建/自管 webhook」一致，能力位本身即该广播能力的唯一闸。
+	// 定向 @uid（指定一个/多个成员）不受这两个开关约束，但受「群成员闸 + 去重 + 上限」。
+	AllowMentionAll  int
+	AllowMentionBots int
+	LastUsedAt       dbr.NullTime
+	CallCount        int64
 	db.BaseModel
 }
 
@@ -87,6 +97,30 @@ type pushPayloadReq struct {
 	Username  string                 `json:"username,omitempty"`
 	AvatarURL string                 `json:"avatar_url,omitempty"`
 	Extra     map[string]interface{} `json:"extra,omitempty"`
+	// Mention 让调用方 @ 群成员（用户/bot 同一 UID 命名空间，一个或多个）并可选广播。
+	// 仅 native 端点解析（pushAdapter.allowMention），适配器(企业微信/飞书/GitHub…)不支持。
+	// 服务端把它翻译成消息 payload 的 mention 子对象（buildMention），定向 uids 经群成员闸
+	// 过滤、广播位经 per-webhook 能力位放行；其余 mention 语义（红点/唤起 bot）全由下游
+	// 既有 message 监听器完成。绝不透传到 payload，与 Extra 被丢弃同源（见 buildPayload）。
+	//
+	// 类型刻意是 json.RawMessage 而非 *mentionReq：mention 是【可选】字段，其形状非法
+	// （如 uids 传成字符串）不能把整条推送 400 掉——否则相邻的合法 content 也被连累丢弃，
+	// 违反 acceptance #6「malformed mention.uids → no panic, no mention key, 消息照投」。
+	// 故此处只做惰性捕获，真正的宽松解码在 buildMention/decodeMention：解码失败即降级为
+	// 「无 mention」、消息照常投递。
+	Mention json.RawMessage `json:"mention,omitempty"`
+}
+
+// mentionReq 是 native 推送请求里的 @ 描述（对外契约）。刻意不暴露内部线协议的
+// humans/ais/entities 字段名：调用方只描述「@ 谁(uids) / @所有人(all) / @所有 AI(bots)」，
+// 由服务端 buildMention 翻译为 mention.{uids,humans,ais} 并做权限/成员校验。
+//   - Uids ：要 @ 的成员 UID（用户或 bot），去重后受上限约束，且必须是本群当前成员。
+//   - All  ：@所有人（真人广播），受 webhook 的 allow_mention_all 能力位约束。
+//   - Bots ：@所有 AI（bot 广播），受 webhook 的 allow_mention_bots 能力位约束。
+type mentionReq struct {
+	Uids []string `json:"uids,omitempty"`
+	All  bool     `json:"all,omitempty"`
+	Bots bool     `json:"bots,omitempty"`
 }
 
 // webhookBlock 是富文本消息的单个有序块（对外契约）。字段刻意与 octo-lib
@@ -106,16 +140,22 @@ type webhookBlock struct {
 }
 
 // createReq 管理端创建 webhook 的请求体。
+// AllowMention* 为广播能力位，任意合法成员均可设置；缺省/false 即默认关闭。
 type createReq struct {
-	Name   string `json:"name"`
-	Avatar string `json:"avatar,omitempty"`
+	Name             string `json:"name"`
+	Avatar           string `json:"avatar,omitempty"`
+	AllowMentionAll  *bool  `json:"allow_mention_all,omitempty"`
+	AllowMentionBots *bool  `json:"allow_mention_bots,omitempty"`
 }
 
 // updateReq 修改 webhook 的请求体。零值字段不更新。
+// AllowMention* 由 webhook 的合法成员（创建者/管理员）可改。
 type updateReq struct {
-	Name   *string `json:"name,omitempty"`
-	Avatar *string `json:"avatar,omitempty"`
-	Status *int    `json:"status,omitempty"`
+	Name             *string `json:"name,omitempty"`
+	Avatar           *string `json:"avatar,omitempty"`
+	Status           *int    `json:"status,omitempty"`
+	AllowMentionAll  *bool   `json:"allow_mention_all,omitempty"`
+	AllowMentionBots *bool   `json:"allow_mention_bots,omitempty"`
 }
 
 // webhookResp 对外暴露的 webhook 元信息（不含 token / token_hash）。
@@ -127,9 +167,12 @@ type webhookResp struct {
 	Avatar     string `json:"avatar"`
 	CreatorUID string `json:"creator_uid"`
 	Status     int    `json:"status"`
-	LastUsedAt int64  `json:"last_used_at"`
-	CallCount  int64  `json:"call_count"`
-	CreatedAt  int64  `json:"created_at"`
+	// AllowMentionAll / AllowMentionBots 回显广播能力位（0/1），便于管理端 UI 渲染开关。
+	AllowMentionAll  int   `json:"allow_mention_all"`
+	AllowMentionBots int   `json:"allow_mention_bots"`
+	LastUsedAt       int64 `json:"last_used_at"`
+	CallCount        int64 `json:"call_count"`
+	CreatedAt        int64 `json:"created_at"`
 }
 
 // createResp 创建/重置返回；token 仅此一次出现。

--- a/modules/incomingwebhook/sql/20260623000001_incomingwebhook_mention_switches.sql
+++ b/modules/incomingwebhook/sql/20260623000001_incomingwebhook_mention_switches.sql
@@ -1,0 +1,18 @@
+-- +migrate Up
+
+-- @ 提及（native 端点）引入两个 per-webhook 广播能力位：
+--   - allow_mention_all  ：是否允许该 webhook 推送 @所有人(真人广播 → mention.humans)；
+--   - allow_mention_bots ：是否允许该 webhook 推送 @所有 AI(bot 广播 → mention.ais)。
+-- 广播会刷全群红点 / 唤起全部 bot，是高噪声能力，故默认关闭(0)、需显式打开；由 webhook
+-- 的合法成员（创建者/管理员）经管理端开关。定向 @uid（指定成员）不受这两列约束（受群成员闸 + 上限）。
+--
+-- 目标库 MySQL 8.0：在表末尾 ADD COLUMN 走 INSTANT 算法、瞬时无锁，无需显式 pin
+-- ALGORITHM/LOCK。历史行按默认值 0 回填即「广播默认关闭」，与新建行口径一致。
+ALTER TABLE `incoming_webhook`
+  ADD COLUMN `allow_mention_all`  SMALLINT NOT NULL DEFAULT 0 COMMENT '是否允许推送 @所有人(真人广播)：0=否(默认),1=是；由 webhook 合法成员可改',
+  ADD COLUMN `allow_mention_bots` SMALLINT NOT NULL DEFAULT 0 COMMENT '是否允许推送 @所有 AI(bot广播)：0=否(默认),1=是；由 webhook 合法成员可改';
+
+-- +migrate Down
+ALTER TABLE `incoming_webhook`
+  DROP COLUMN `allow_mention_all`,
+  DROP COLUMN `allow_mention_bots`;


### PR DESCRIPTION
## Summary

Adds opt-in mention support to the **native** incoming-webhook push endpoint. A
caller can mention specific group members (users and/or bots, one or many) via a
structured `mention` field, and optionally broadcast to all human members and/or
all bot (AI) members of the group. Notifications (red-dots) and bot delivery are
produced downstream by the existing sender-agnostic message listener — this
change only assembles a well-formed `mention` sub-map on the wire.

## Related Issue

Internal feature request (no public issue).

## Linked Spec

`.octospec/tasks/incoming-webhook-mention/brief.md` (goal / load-bearing list /
out-of-scope / acceptance). Rule context in
`.octospec/tasks/incoming-webhook-mention/context.yaml`.

## Changes

- Native payload gains `mention: { uids: [...], all: bool, bots: bool }` — parsed
  only by the native adapter; wecom/feishu/github/gitlab/multica neither parse
  nor emit it (`pushAdapter.allowMention`).
- `mention.uids` (users + bots, one common UID namespace) are filtered to current
  group members (space-isolation boundary), deduped, and capped (default 50,
  `OCTO_INCOMINGWEBHOOK_MAX_MENTION_UIDS`).
- The two broadcast forms map to `mention.humans` / `mention.ais` and are gated by
  per-webhook capability columns `allow_mention_all` / `allow_mention_bots`
  (default off; settable on create/update by any legitimate member who manages the
  webhook). When a broadcast is requested but the capability is off, it is dropped
  and reported in the 200 response body's `mention_ignored`. A targeted member
  mention is not capability-gated.
- The all-bots broadcast reuses `pkg/mentionrewrite.ExpandAisToBotUIDs` with the
  same `GetMembers` + `ExistRobot` pair as the message / bot_api ingresses, so the
  resolved bot set is identical across ingresses.
- Pre-wired revocation lever: system setting `incomingwebhook.member_can_broadcast`
  (default on), ANDed at the push read path — turning it off instantly revokes
  broadcast for all member-created webhooks (admin-created ones keep it), with no
  column migration.
- `mention` is an explicitly whitelisted payload field; `extra` stays discarded,
  so no other payload keys can be smuggled in.
- New SQL migration adds the two `SMALLINT` columns (default 0, INSTANT add).

## Testing

Verified against MySQL 8.0 + Redis + WuKongIM (v2.2.4-20260313):

- `go test ./modules/incomingwebhook/... -count=1` → ok
- `go test ./modules/common/... -count=1` → ok
- `golangci-lint run ./modules/common/... ./modules/incomingwebhook/...` → 0 issues
- `make i18n-lint` → OK (no new error codes)

- [x] Unit tests added/updated (decision-core matrix, dedup, ExpandAisToBotUIDs parity, native-body parse, system-setting getters)
- [x] e2e tests added (capability persistence, member-settable switch, revocation lever, `mention_ignored`, backward-compat)
- [x] Manually verified end-to-end (push path through WuKongIM)

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   On the unauthenticated webhook push path, after the existing
   auth / rate-limit / group-active / creator-membership gates, the native handler
   assembles a `mention` sub-map and attaches it to the outbound payload, then runs
   the ais→bot-UID expansion. Targeted UIDs are intersected with the webhook's own
   `group_no` membership; a broadcast takes effect only when both the per-webhook
   capability bit and the `member_can_broadcast` policy (or an admin creator)
   allow it. The message module's reminder/read path is unchanged.

2. **What could break (dependents + failure mode)?**
   - Existing native callers that send no `mention` field: payload shape is
     unchanged (pinned by a backward-compat test).
   - A leaked/misconfigured token cannot mention outside its group or cross-Space —
     the membership filter uses the server-side `group_no`, never caller input.
   - The bot-set lookup for the all-bots broadcast degrades to a no-op on error
     (best-effort), so it never drops a message.
   - Sibling adapters are unaffected (mention is gated to the native adapter).

3. **How do you know it works (specific test/repro/trace)?**
   Pure unit tests exhaustively cover the assemble/gate matrix and prove the wire
   shape is consumable by the real `ExpandAisToBotUIDs`. e2e tests drive the full
   HTTP→WuKongIM path: capability persistence + member-settable switch, the
   `member_can_broadcast` revocation (member-created webhook's broadcast stripped
   and reported, admin-created unaffected), `mention_ignored` on capability-off,
   and the no-mention backward-compat case. Full `incomingwebhook` and `common`
   packages pass on a fresh DB; golangci-lint and i18n-lint clean.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (godoc + SQL comments + octospec brief)
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKr5U3bnKZb3oFDfC9765A)_