### PR TITLE
feat: serve Bot connect plugin package + API URL from backend (#446)

### DIFF
--- a/.octospec/tasks/bot-connect-plugin-package/brief.md
+++ b/.octospec/tasks/bot-connect-plugin-package/brief.md
@@ -1,0 +1,105 @@
+---
+type: Task
+title: "Task: bot-connect-plugin-package"
+description: Serve the Bot connect plugin package + public API URL from the backend instead of hardcoding them in the frontend.
+tags: ["app-bot", "botfather", "bot-connect", "plugin-package", "i18n", "wire-contract"]
+timestamp: 2026-06-24T00:00:00Z
+# --- octospec extension fields ---
+slug: bot-connect-plugin-package
+upstream: "octo-server#446"
+source: self
+---
+# Task: bot-connect-plugin-package
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+Upstream: octo-server #446 — the App Bot "connect guide" (`npx -y <pkg> bind ...`)
+is assembled entirely in the octo-admin frontend, which hardcodes two server-owned
+facts: the channel-adapter npm package (`openclaw-channel-dmwork`, now unmaintained)
+and an `api_url` that falls back to the **admin dashboard origin** rather than the
+Bot API entry. Both must move to the backend so a package rename/canary or a
+split admin/bot-api host never requires a frontend redeploy.
+
+## Goal
+The four App Bot read/create endpoints return a `connect` object so the frontend
+stops owning these facts:
+
+```jsonc
+"connect": { "plugin_package": "create-openclaw-octo", "api_url": "https://<bot-api>" }
+```
+
+- `plugin_package` is backend-configured: default the **maintained** package
+  `create-openclaw-octo` (the one BotFather already emits — the migration target
+  off the dead `openclaw-channel-dmwork`), overridable via `OCTO_BOT_PLUGIN_PACKAGE`.
+- `api_url` resolves to the **public Bot API entry** (`External.BaseURL`, fallback
+  `http://<ip>:8090`), never the admin origin.
+- The package name becomes a single backend source of truth (`pkg/botutil`) shared
+  with BotFather's connect prompts, so a rename touches exactly one place.
+- Data only: no localized guide prose, no token or other secret in `connect`.
+
+## Background
+- App Bot handlers: `modules/app_bot/app_bot.go` `createBot` (covers `POST
+  /v1/admin/app_bot` + `POST /v1/space/:space_id/app_bot`) and `getBotDetail`
+  (covers `GET /v1/admin/app_bot/:id` + `GET /v1/space/:space_id/app_bot/:id`).
+  Two response builders cover all four endpoints.
+- New source of truth: `pkg/botutil/connect.go` — `PluginPackage()` (env
+  `OCTO_BOT_PLUGIN_PACKAGE` → default `create-openclaw-octo`) and
+  `DeriveAPIURL(cfg)` (mirrors the existing `External.BaseURL`/`IP:8090` logic in
+  `bot_api/register.go` and `botfather/command.go`).
+- BotFather: the package name was frozen in the i18n templates
+  `modules/botfather/templates/{zh-CN,en-US}/command.tmpl` (connect_prompt /
+  created_prompt / quickstart / install) and rendered via `command.go`. These are
+  the msgtmpl outbound-message catalog (#304, the "fourth i18n category"), NOT the
+  HTTP error envelope.
+- Issue: octo-server #446.
+
+## Load-bearing list
+- **wire-contract**: `connect{plugin_package, api_url}` is a NEW response field on
+  4 endpoints consumed by octo-admin; it must be data-only, contain no secret, and
+  always be present. It is a **success-response** field — it does NOT pass through
+  the i18n error envelope, so no `pkg/errcode` code / `active.zh-CN.toml` /
+  `i18n-extract` is involved. (rules: error-handling — wire-contract)
+- **space**: `getBotDetail`/`createBot` keep their existing gates
+  (`checkSpaceAdmin` for the space route, `CheckLoginRole` for the platform route)
+  and the `botInRouteScope` cross-tenant IDOR guard. `connect` is identical
+  regardless of scope/tenant and adds no per-tenant data, so isolation is
+  unchanged — the field must not widen any query or gate. (rules: space-isolation)
+- **i18n (msgtmpl catalog)**: BotFather connect/created/quickstart/install
+  templates now render the injected `{{.PluginPackage}}`. The catalog runs with
+  `missingkey=error`, so every render site (`command.go` ×4) AND the completeness
+  probe must supply `PluginPackage`. (rules: error-handling — i18n)
+- **secret-handling**: `connect` must never carry the bot token; the masked
+  top-level `token` field stays unchanged.
+
+## Out of scope
+- octo-admin frontend (`connectGuide.ts`) — `bot.connect?.plugin_package ?? …` /
+  `?? getBotApiUrl()`; tracked separately under #446, ships after this.
+- `modules/botfather/skill.go` — the deprecated, static skill-doc generator still
+  hardcodes `create-openclaw-octo`; it is not part of the i18n connect-guide
+  catalog and is left for a separate decision.
+- `modules/bot_api/register.go` inline `api_url` fallback — behaviorally identical
+  to `DeriveAPIURL`, left unconsolidated to keep scope to app_bot + botfather.
+- octo-lib `config.Config` changes — the package name is a module-level env knob,
+  no cross-repo change.
+- Returning the localized guide prose from the backend (explicitly forbidden by #446).
+
+## Acceptance
+- All four endpoints return `connect{plugin_package, api_url}`; `plugin_package`
+  is read from config (default `create-openclaw-octo`, honors
+  `OCTO_BOT_PLUGIN_PACKAGE`); `api_url` is the public Bot API entry.
+- `connect` carries no secret: exactly the two public keys, token never present.
+- New tests pass:
+  - `pkg/botutil`: default / env-override / `DeriveAPIURL` (BaseURL + IP fallback).
+  - `modules/app_bot`: HTTP e2e (sqlmock+redis) — `connect` present, an
+    `OCTO_BOT_PLUGIN_PACKAGE` override reaches the client, and no token leaks into
+    `connect`.
+  - `modules/botfather`: the connect-guide templates render the injected package
+    (bind/install/quickstart), the completeness probe still renders, and a guard
+    asserts the old `create-openclaw-octo` literal no longer appears when a
+    different package is injected.
+- `go build ./...`, `go vet ./...`, `golangci-lint run`, `make i18n-extract-check`,
+  `make i18n-lint` all pass.
+- Full affected suites green under the CI recipe (master key + per-package DB
+  reset + `-race`): `pkg/botutil`, `modules/app_bot`, `modules/botfather`,
+  `modules/bot_api`.

--- a/.octospec/tasks/bot-connect-plugin-package/brief.md
+++ b/.octospec/tasks/bot-connect-plugin-package/brief.md
@@ -71,6 +71,12 @@ stops owning these facts:
   probe must supply `PluginPackage`. (rules: error-handling — i18n)
 - **secret-handling**: `connect` must never carry the bot token; the masked
   top-level `token` field stays unchanged.
+- **api_url single-source-of-truth**: `DeriveAPIURL(cfg)` replaces every inline
+  `External.BaseURL` / `http://<ip>:8090` copy across `app_bot`, `botfather`
+  (`command.go` + `api.go`) and `bot_api` (`register.go` + `commands.go`) —
+  behavior-identical, so the connect guide, BotFather docs, and `/bot/register`
+  stay consistent and a future derivation change touches exactly one place.
+  (rules: testing — `TestDeriveAPIURL`)
 
 ## Out of scope
 - octo-admin frontend (`connectGuide.ts`) — `bot.connect?.plugin_package ?? …` /
@@ -78,8 +84,6 @@ stops owning these facts:
 - `modules/botfather/skill.go` — the deprecated, static skill-doc generator still
   hardcodes `create-openclaw-octo`; it is not part of the i18n connect-guide
   catalog and is left for a separate decision.
-- `modules/bot_api/register.go` inline `api_url` fallback — behaviorally identical
-  to `DeriveAPIURL`, left unconsolidated to keep scope to app_bot + botfather.
 - octo-lib `config.Config` changes — the package name is a module-level env knob,
   no cross-repo change.
 - Returning the localized guide prose from the backend (explicitly forbidden by #446).
@@ -100,6 +104,8 @@ stops owning these facts:
     different package is injected.
 - `go build ./...`, `go vet ./...`, `golangci-lint run`, `make i18n-extract-check`,
   `make i18n-lint` all pass.
+- No inline `api_url` derivation remains: a grep for the `External.BaseURL` /
+  `http://<ip>:8090` fallback returns only `botutil.DeriveAPIURL`.
 - Full affected suites green under the CI recipe (master key + per-package DB
   reset + `-race`): `pkg/botutil`, `modules/app_bot`, `modules/botfather`,
   `modules/bot_api`.

--- a/modules/app_bot/app_bot.go
+++ b/modules/app_bot/app_bot.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/bot_api"
 	"github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/botutil"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
@@ -421,9 +422,10 @@ func (ab *AppBot) createBot(c *wkhttp.Context, scope, spaceID string) {
 	}
 
 	c.Response(gin.H{
-		"id":    req.ID,
-		"uid":   uid,
-		"token": token,
+		"id":      req.ID,
+		"uid":     uid,
+		"token":   token,
+		"connect": ab.connectInfo(),
 	})
 }
 
@@ -530,6 +532,7 @@ func (ab *AppBot) getBotDetail(c *wkhttp.Context) {
 		"created_by":   bot.CreatedBy,
 		"created_at":   bot.CreatedAt,
 		"updated_at":   bot.UpdatedAt,
+		"connect":      ab.connectInfo(),
 	})
 }
 
@@ -983,6 +986,19 @@ func (ab *AppBot) discoverBots(c *wkhttp.Context) {
 }
 
 // ==================== Helpers ====================
+
+// connectInfo returns the backend-owned facts the frontend needs to assemble the
+// Bot connect guide: the OpenClaw plugin package an Agent runs and this
+// environment's public Bot API entry. Both are server-owned (config/env), so a
+// package rename, canary rollout, or host change never requires a frontend
+// redeploy. It carries data only — the localized guide prose stays in the
+// frontend, and it never includes the token or any other secret.
+func (ab *AppBot) connectInfo() gin.H {
+	return gin.H{
+		"plugin_package": botutil.PluginPackage(),
+		"api_url":        botutil.DeriveAPIURL(ab.ctx.GetConfig()),
+	}
+}
 
 func (ab *AppBot) toBotListResp(bots []*appBotModel) []gin.H {
 	result := make([]gin.H, 0, len(bots))

--- a/modules/app_bot/app_bot_connect_test.go
+++ b/modules/app_bot/app_bot_connect_test.go
@@ -1,0 +1,95 @@
+package app_bot
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/botutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConnectInfo_DefaultAndOverride pins the value contract of the connect
+// object: plugin_package is the backend default (overridable by env) and api_url
+// is the configured public Bot API entry — never the admin origin.
+func TestConnectInfo_DefaultAndOverride(t *testing.T) {
+	cfg := config.New()
+	cfg.Test = true
+	cfg.External.BaseURL = "https://bot-api.example.com"
+	ab := &AppBot{ctx: config.NewContext(cfg)}
+
+	info := ab.connectInfo()
+	assert.Equal(t, "create-openclaw-octo", info["plugin_package"], "default plugin package")
+	assert.Equal(t, "https://bot-api.example.com", info["api_url"], "api_url is the configured Bot API entry")
+	// connect carries data only — no token / secret keys.
+	assert.Len(t, info, 2, "connect must contain exactly plugin_package + api_url")
+
+	t.Setenv(botutil.PluginPackageEnv, "create-openclaw-canary")
+	info = ab.connectInfo()
+	assert.Equal(t, "create-openclaw-canary", info["plugin_package"], "env override flows through")
+}
+
+// serveGetBotDetail mounts the platform admin route with a published platform bot
+// stubbed in sqlmock and returns the recorded GET /v1/admin/app_bot/{id} response.
+func serveGetBotDetail(t *testing.T, id string) *httptest.ResponseRecorder {
+	t.Helper()
+	route, mock, cleanup := newPlatformGateRouteWithMock(t, string(wkhttp.Admin))
+	t.Cleanup(cleanup)
+
+	// No WithArgs: dbr may interpolate the WHERE value into the SQL (0 bound
+	// args) rather than bind it, depending on process state; this test asserts
+	// the connect payload, not the WHERE clause, so match on the query shape only.
+	mock.ExpectQuery("app_bot").
+		WillReturnRows(sqlmock.NewRows(
+			[]string{"id", "uid", "display_name", "description", "scope", "space_id", "status", "token", "welcome_msg", "created_by"}).
+			AddRow(id, "app_"+id+"_bot", "My Bot", "desc", "platform", "", 1, "super-secret-token", "", "creator-1"))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/admin/app_bot/"+id, nil)
+	req.Header.Set("token", testutil.Token)
+	route.ServeHTTP(w, req)
+	return w
+}
+
+// TestGetBotDetail_IncludesConnect is the endpoint-level proof that the four App
+// Bot read/create endpoints (getBotDetail covers both GETs) now return a connect
+// object, that it carries no secret, and — via the env override — that the
+// package name is server-configured, the core of issue #446.
+func TestGetBotDetail_IncludesConnect(t *testing.T) {
+	w := serveGetBotDetail(t, "bot-1")
+	require.Equal(t, http.StatusOK, w.Code, "admin reaches the bot detail")
+
+	var resp struct {
+		Token   string         `json:"token"`
+		Connect map[string]any `json:"connect"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.NotNil(t, resp.Connect, "response carries a connect object")
+	assert.Equal(t, "create-openclaw-octo", resp.Connect["plugin_package"])
+	assert.NotEmpty(t, resp.Connect["api_url"], "api_url resolves to the public Bot API entry")
+	// No secret leaks into connect: exactly the two public keys, and the raw
+	// token never appears there (the top-level token stays masked).
+	assert.Len(t, resp.Connect, 2)
+	assert.NotContains(t, resp.Connect, "token")
+	assert.NotEqual(t, "super-secret-token", resp.Connect["api_url"])
+}
+
+func TestGetBotDetail_ConnectHonorsPackageOverride(t *testing.T) {
+	t.Setenv(botutil.PluginPackageEnv, "create-openclaw-canary")
+	w := serveGetBotDetail(t, "bot-2")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Connect map[string]any `json:"connect"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "create-openclaw-canary", resp.Connect["plugin_package"],
+		"a configured package name reaches the client without a frontend change")
+}

--- a/modules/app_bot/app_bot_connect_test.go
+++ b/modules/app_bot/app_bot_connect_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -57,10 +58,11 @@ func serveGetBotDetail(t *testing.T, id string) *httptest.ResponseRecorder {
 	return w
 }
 
-// TestGetBotDetail_IncludesConnect is the endpoint-level proof that the four App
-// Bot read/create endpoints (getBotDetail covers both GETs) now return a connect
-// object, that it carries no secret, and — via the env override — that the
-// package name is server-configured, the core of issue #446.
+// TestGetBotDetail_IncludesConnect is the read-path proof: getBotDetail backs
+// both GET /v1/admin/app_bot/:id and GET /v1/space/:space_id/app_bot/:id, and
+// must return a connect object that carries no secret — and, via the env
+// override, that the package name is server-configured (the core of #446). The
+// create path (POST) is pinned separately by TestCreatePlatformBot_IncludesConnect_E2E.
 func TestGetBotDetail_IncludesConnect(t *testing.T) {
 	w := serveGetBotDetail(t, "bot-1")
 	require.Equal(t, http.StatusOK, w.Code, "admin reaches the bot detail")
@@ -92,4 +94,46 @@ func TestGetBotDetail_ConnectHonorsPackageOverride(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Equal(t, "create-openclaw-canary", resp.Connect["plugin_package"],
 		"a configured package name reaches the client without a frontend change")
+}
+
+// TestCreatePlatformBot_IncludesConnect_E2E pins the create-side wire contract
+// (POST /v1/admin/app_bot) against the full server + real MySQL/IM
+// (NewTestServer): a successful create returns the same connect object, data
+// only, with the freshly-minted token never leaking into connect. Complements
+// the read-path coverage in TestGetBotDetail_IncludesConnect.
+func TestCreatePlatformBot_IncludesConnect_E2E(t *testing.T) {
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	// Log in as a system admin (the test server wires no RoleResolver, so the
+	// token's baked role is authoritative).
+	require.NoError(t, ctx.Cache().Set(
+		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.Admin)))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/v1/admin/app_bot",
+		strings.NewReader(`{"id":"connect-create-e2e","display_name":"Connect Create"}`))
+	req.Header.Set("token", testutil.Token)
+	req.Header.Set("Content-Type", "application/json")
+	s.GetRoute().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "admin create should succeed: %s", w.Body.String())
+
+	var resp struct {
+		Token   string         `json:"token"`
+		Connect map[string]any `json:"connect"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Connect, "create response carries a connect object")
+	assert.Equal(t, "create-openclaw-octo", resp.Connect["plugin_package"])
+	assert.NotEmpty(t, resp.Connect["api_url"], "api_url resolves to the public Bot API entry")
+	// Data only: exactly the two public keys, and the freshly-minted token
+	// (returned at top level on create) must never appear inside connect.
+	assert.Len(t, resp.Connect, 2)
+	assert.NotContains(t, resp.Connect, "token")
+	assert.NotEqual(t, resp.Token, resp.Connect["api_url"])
+	assert.NotEqual(t, resp.Token, resp.Connect["plugin_package"])
 }

--- a/modules/bot_api/commands.go
+++ b/modules/bot_api/commands.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/botutil"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/gin-gonic/gin"
@@ -84,11 +85,7 @@ func (ba *BotAPI) getUserInfo(c *wkhttp.Context) {
 		return
 	}
 
-	cfg := ba.ctx.GetConfig()
-	apiURL := cfg.External.BaseURL
-	if strings.TrimSpace(apiURL) == "" {
-		apiURL = fmt.Sprintf("http://%s:8090", cfg.External.IP)
-	}
+	apiURL := botutil.DeriveAPIURL(ba.ctx.GetConfig())
 
 	c.JSON(http.StatusOK, gin.H{
 		"uid":    userResp.UID,

--- a/modules/bot_api/register.go
+++ b/modules/bot_api/register.go
@@ -1,7 +1,6 @@
 package bot_api
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -103,10 +102,7 @@ func (ba *BotAPI) registerUserBot(c *wkhttp.Context, token string) {
 	}
 
 	cfg := ba.ctx.GetConfig()
-	apiURL := cfg.External.BaseURL
-	if strings.TrimSpace(apiURL) == "" {
-		apiURL = fmt.Sprintf("http://%s:8090", cfg.External.IP)
-	}
+	apiURL := botutil.DeriveAPIURL(cfg)
 	wsURL := botutil.DeriveWSURL(cfg)
 
 	botName := ""
@@ -163,10 +159,7 @@ func (ba *BotAPI) registerAppBot(c *wkhttp.Context, token string) {
 	}
 
 	cfg := ba.ctx.GetConfig()
-	apiURL := cfg.External.BaseURL
-	if strings.TrimSpace(apiURL) == "" {
-		apiURL = fmt.Sprintf("http://%s:8090", cfg.External.IP)
-	}
+	apiURL := botutil.DeriveAPIURL(cfg)
 	wsURL := botutil.DeriveWSURL(cfg)
 
 	c.Response(&BotRegisterResp{

--- a/modules/botfather/api.go
+++ b/modules/botfather/api.go
@@ -2,7 +2,6 @@ package botfather
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strings"
 	"sync"
@@ -107,10 +106,7 @@ func (bf *BotFather) Route(r *wkhttp.WKHttp) {
 // skillMD 返回skill.md文档
 func (bf *BotFather) skillMD(c *wkhttp.Context) {
 	cfg := bf.ctx.GetConfig()
-	apiURL := cfg.External.BaseURL
-	if strings.TrimSpace(apiURL) == "" {
-		apiURL = fmt.Sprintf("http://%s:8090", cfg.External.IP)
-	}
+	apiURL := botutil.DeriveAPIURL(cfg)
 	wsURL := botutil.DeriveWSURL(cfg)
 	content := generateSkillMD(apiURL, wsURL)
 	c.Header("Content-Type", "text/markdown; charset=utf-8")
@@ -126,11 +122,7 @@ func (bf *BotFather) cliGuideMD(c *wkhttp.Context) {
 
 // setupNewbotMD 返回 /newbot 设置流程文档
 func (bf *BotFather) setupNewbotMD(c *wkhttp.Context) {
-	cfg := bf.ctx.GetConfig()
-	apiURL := cfg.External.BaseURL
-	if strings.TrimSpace(apiURL) == "" {
-		apiURL = fmt.Sprintf("http://%s:8090", cfg.External.IP)
-	}
+	apiURL := botutil.DeriveAPIURL(bf.ctx.GetConfig())
 	content := generateSetupNewbotMD(apiURL)
 	c.Header("Content-Type", "text/markdown; charset=utf-8")
 	c.String(http.StatusOK, content)
@@ -138,11 +130,7 @@ func (bf *BotFather) setupNewbotMD(c *wkhttp.Context) {
 
 // setupQuickstartMD 返回 /quickstart 设置流程文档
 func (bf *BotFather) setupQuickstartMD(c *wkhttp.Context) {
-	cfg := bf.ctx.GetConfig()
-	apiURL := cfg.External.BaseURL
-	if strings.TrimSpace(apiURL) == "" {
-		apiURL = fmt.Sprintf("http://%s:8090", cfg.External.IP)
-	}
+	apiURL := botutil.DeriveAPIURL(bf.ctx.GetConfig())
 	content := generateSetupQuickstartMD(apiURL)
 	c.Header("Content-Type", "text/markdown; charset=utf-8")
 	c.String(http.StatusOK, content)

--- a/modules/botfather/command.go
+++ b/modules/botfather/command.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/base/app"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/botutil"
 	"go.uber.org/zap"
 )
 
@@ -423,18 +424,16 @@ func (h *commandHandler) handleQuickstart(fromUID string) {
 		return
 	}
 
-	cfg := h.ctx.GetConfig()
-	apiURL := cfg.External.BaseURL
-	if strings.TrimSpace(apiURL) == "" {
-		apiURL = fmt.Sprintf("http://%s:8090", cfg.External.IP)
-	}
-
-	h.replyL(fromUID, MsgQuickstart, map[string]any{"APIKey": apiKey, "APIURL": apiURL})
+	h.replyL(fromUID, MsgQuickstart, map[string]any{
+		"APIKey":        apiKey,
+		"APIURL":        botutil.DeriveAPIURL(h.ctx.GetConfig()),
+		"PluginPackage": botutil.PluginPackage(),
+	})
 }
 
 func (h *commandHandler) handleInstall(fromUID string) {
 	h.sm.Clear(fromUID, h.spaceID(fromUID))
-	h.replyL(fromUID, MsgInstall, nil)
+	h.replyL(fromUID, MsgInstall, map[string]any{"PluginPackage": botutil.PluginPackage()})
 }
 
 func (h *commandHandler) handleHelp(fromUID string) {
@@ -924,32 +923,22 @@ func (h *commandHandler) sendBotSelectionList(fromUID string, bots []*robotModel
 }
 
 func (h *commandHandler) sendConnectPrompt(toUID string, bot *robotModel) {
-	cfg := h.ctx.GetConfig()
-	apiURL := cfg.External.BaseURL
-	if strings.TrimSpace(apiURL) == "" {
-		apiURL = fmt.Sprintf("http://%s:8090", cfg.External.IP)
-	}
-
 	h.replyL(toUID, MsgConnectPrompt, map[string]any{
-		"DisplayName": h.getBotDisplayName(bot.RobotID),
-		"RobotID":     bot.RobotID,
-		"BotToken":    bot.BotToken,
-		"APIURL":      apiURL,
+		"DisplayName":   h.getBotDisplayName(bot.RobotID),
+		"RobotID":       bot.RobotID,
+		"BotToken":      bot.BotToken,
+		"APIURL":        botutil.DeriveAPIURL(h.ctx.GetConfig()),
+		"PluginPackage": botutil.PluginPackage(),
 	})
 }
 
 func (h *commandHandler) sendCreatedPrompt(toUID string, name string, bot *robotModel) {
-	cfg := h.ctx.GetConfig()
-	apiURL := cfg.External.BaseURL
-	if strings.TrimSpace(apiURL) == "" {
-		apiURL = fmt.Sprintf("http://%s:8090", cfg.External.IP)
-	}
-
 	h.replyL(toUID, MsgCreatedPrompt, map[string]any{
-		"Name":     name,
-		"RobotID":  bot.RobotID,
-		"BotToken": bot.BotToken,
-		"APIURL":   apiURL,
+		"Name":          name,
+		"RobotID":       bot.RobotID,
+		"BotToken":      bot.BotToken,
+		"APIURL":        botutil.DeriveAPIURL(h.ctx.GetConfig()),
+		"PluginPackage": botutil.PluginPackage(),
 	})
 }
 

--- a/modules/botfather/messages_test.go
+++ b/modules/botfather/messages_test.go
@@ -23,6 +23,7 @@ func renderProbe() map[string]any {
 		"DisplayName":   "probe",
 		"RobotID":       "probe",
 		"BotToken":      "probe",
+		"PluginPackage": "create-openclaw-octo",
 		"Prompt":        "probe",
 		"ApplicantName": "probe",
 		"ApplicantUID":  "probe",
@@ -48,9 +49,9 @@ func TestKeyMessageInterpolation(t *testing.T) {
 		data map[string]any
 		want []string // substrings that must appear
 	}{
-		{MsgCreatedPrompt, "en-US", map[string]any{"Name": "Alice", "RobotID": "bot_42", "BotToken": "tok_xyz", "APIURL": "https://api.x"},
+		{MsgCreatedPrompt, "en-US", map[string]any{"Name": "Alice", "RobotID": "bot_42", "BotToken": "tok_xyz", "APIURL": "https://api.x", "PluginPackage": "create-openclaw-octo"},
 			[]string{"Alice", "bot_42", "tok_xyz", "https://api.x", "npx -y create-openclaw-octo bind", "```"}},
-		{MsgCreatedPrompt, "zh-CN", map[string]any{"Name": "小爱", "RobotID": "bot_42", "BotToken": "tok_xyz", "APIURL": "https://api.x"},
+		{MsgCreatedPrompt, "zh-CN", map[string]any{"Name": "小爱", "RobotID": "bot_42", "BotToken": "tok_xyz", "APIURL": "https://api.x", "PluginPackage": "create-openclaw-octo"},
 			[]string{"小爱", "bot_42", "绑定"}},
 		{MsgNotifyOwnerNewApply, "en-US", map[string]any{"ApplicantName": "Bob", "ApplicantUID": "u_9", "RobotUID": "bot_1", "Remark": "please"},
 			[]string{"Bob", "u_9", "bot_1", "Note: please"}},
@@ -76,6 +77,40 @@ func TestKeyMessageInterpolation(t *testing.T) {
 			}
 		}
 		t.Logf("\n----- %s / %s -----\n%s\n", c.key, c.lang, got)
+	}
+}
+
+// TestConnectGuidePackageParameterized proves the OpenClaw package name is no
+// longer frozen in the localized templates: every connect-guide command (bind /
+// install / quickstart) renders the injected PluginPackage, so a backend rename
+// or canary flows into the DM prose without editing the i18n templates — and the
+// old hardcoded literal no longer appears.
+func TestConnectGuidePackageParameterized(t *testing.T) {
+	const pkg = "create-openclaw-canary"
+	cases := []struct {
+		key  string
+		data map[string]any
+		want string
+	}{
+		{MsgCreatedPrompt, map[string]any{"Name": "A", "RobotID": "b", "BotToken": "t", "APIURL": "u", "PluginPackage": pkg}, "npx -y create-openclaw-canary bind"},
+		{MsgConnectPrompt, map[string]any{"DisplayName": "A", "RobotID": "b", "BotToken": "t", "APIURL": "u", "PluginPackage": pkg}, "npx -y create-openclaw-canary bind"},
+		{MsgInstall, map[string]any{"PluginPackage": pkg}, "npx -y create-openclaw-canary install"},
+		{MsgQuickstart, map[string]any{"APIKey": "k", "APIURL": "u", "PluginPackage": pkg}, "npx -y create-openclaw-canary quickstart"},
+	}
+	for _, lang := range []string{"en-US", "zh-CN"} {
+		for _, c := range cases {
+			got, err := botMessages.Render(c.key, lang, c.data)
+			if err != nil {
+				t.Errorf("Render(%q,%q): %v", c.key, lang, err)
+				continue
+			}
+			if !strings.Contains(got, c.want) {
+				t.Errorf("Render(%q,%q) missing %q in:\n%s", c.key, lang, c.want, got)
+			}
+			if strings.Contains(got, "create-openclaw-octo") {
+				t.Errorf("Render(%q,%q) still carries the hardcoded create-openclaw-octo:\n%s", c.key, lang, got)
+			}
+		}
 	}
 }
 

--- a/modules/botfather/templates/en-US/command.tmpl
+++ b/modules/botfather/templates/en-US/command.tmpl
@@ -104,7 +104,7 @@ Create and bind an Octo bot for every one of your OpenClaw Agents in one shot, s
 
 ```
 Batch-create and bind Octo bots for all agents:
-npx -y create-openclaw-octo quickstart --api-key {{.APIKey}} --api-url {{.APIURL}}
+npx -y {{.PluginPackage}} quickstart --api-key {{.APIKey}} --api-url {{.APIURL}}
 ```{{end}}
 
 {{define "install"}}📦 **Install / update the Octo plugin**
@@ -114,7 +114,7 @@ npx -y create-openclaw-octo quickstart --api-key {{.APIKey}} --api-url {{.APIURL
 📋 **Send the following command to OpenClaw to run:**
 
 ```
-npx -y create-openclaw-octo install
+npx -y {{.PluginPackage}} install
 ```
 
 Once installed, use /newbot to create a single bot or /quickstart to batch-create.{{end}}
@@ -154,7 +154,7 @@ Bind Octo bot {{.RobotID}} to an Agent.
 By default it binds to the current Session's Agent; check the agent id with /status.
 If the user specifies another Agent, replace it with the user-specified id.
 
-npx -y create-openclaw-octo bind --bot-token {{.BotToken}} --api-url {{.APIURL}} --account-id {{.RobotID}} --agent <agent-id>
+npx -y {{.PluginPackage}} bind --bot-token {{.BotToken}} --api-url {{.APIURL}} --account-id {{.RobotID}} --agent <agent-id>
 ```
 
 💡 **To bind to a different Agent, just change the `--agent` argument.**
@@ -174,7 +174,7 @@ Bind Octo bot {{.RobotID}} to an Agent.
 By default it binds to the current Session's Agent; check the agent id with /status.
 If the user specifies another Agent, replace it with the user-specified id.
 
-npx -y create-openclaw-octo bind --bot-token {{.BotToken}} --api-url {{.APIURL}} --account-id {{.RobotID}} --agent <agent-id>
+npx -y {{.PluginPackage}} bind --bot-token {{.BotToken}} --api-url {{.APIURL}} --account-id {{.RobotID}} --agent <agent-id>
 ```
 
 💡 **To bind to a different Agent, just change the `--agent` argument.**{{end}}

--- a/modules/botfather/templates/zh-CN/command.tmpl
+++ b/modules/botfather/templates/zh-CN/command.tmpl
@@ -104,7 +104,7 @@
 
 ```
 为所有 agent 批量创建并绑定 Octo bot：
-npx -y create-openclaw-octo quickstart --api-key {{.APIKey}} --api-url {{.APIURL}}
+npx -y {{.PluginPackage}} quickstart --api-key {{.APIKey}} --api-url {{.APIURL}}
 ```{{end}}
 
 {{define "install"}}📦 **安装/更新 Octo 插件**
@@ -114,7 +114,7 @@ npx -y create-openclaw-octo quickstart --api-key {{.APIKey}} --api-url {{.APIURL
 📋 **把下面命令发给 OpenClaw 执行：**
 
 ```
-npx -y create-openclaw-octo install
+npx -y {{.PluginPackage}} install
 ```
 
 安装完成后，使用 /newbot 创建单个 bot 或 /quickstart 批量创建。{{end}}
@@ -154,7 +154,7 @@ npx -y create-openclaw-octo install
 默认绑定到当前 Session 的 Agent，agent 标识通过 /status 查看。
 如果用户指定了其他 Agent，使用用户指定的标识替换。
 
-npx -y create-openclaw-octo bind --bot-token {{.BotToken}} --api-url {{.APIURL}} --account-id {{.RobotID}} --agent <agent标识>
+npx -y {{.PluginPackage}} bind --bot-token {{.BotToken}} --api-url {{.APIURL}} --account-id {{.RobotID}} --agent <agent标识>
 ```
 
 💡 **如需绑定到其他 Agent，修改 `--agent` 参数即可。**
@@ -174,7 +174,7 @@ npx -y create-openclaw-octo bind --bot-token {{.BotToken}} --api-url {{.APIURL}}
 默认绑定到当前 Session 的 Agent，agent 标识通过 /status 查看。
 如果用户指定了其他 Agent，使用用户指定的标识替换。
 
-npx -y create-openclaw-octo bind --bot-token {{.BotToken}} --api-url {{.APIURL}} --account-id {{.RobotID}} --agent <agent标识>
+npx -y {{.PluginPackage}} bind --bot-token {{.BotToken}} --api-url {{.APIURL}} --account-id {{.RobotID}} --agent <agent标识>
 ```
 
 💡 **如需绑定到其他 Agent，修改 `--agent` 参数即可。**{{end}}

--- a/pkg/botutil/connect.go
+++ b/pkg/botutil/connect.go
@@ -23,7 +23,7 @@ const DefaultPluginPackage = "create-openclaw-octo"
 const PluginPackageEnv = "OCTO_BOT_PLUGIN_PACKAGE"
 
 // PluginPackage returns the configured OpenClaw plugin package name, honoring
-// the DM_BOT_PLUGIN_PACKAGE override and falling back to DefaultPluginPackage.
+// the OCTO_BOT_PLUGIN_PACKAGE override and falling back to DefaultPluginPackage.
 func PluginPackage() string {
 	if v := strings.TrimSpace(os.Getenv(PluginPackageEnv)); v != "" {
 		return v

--- a/pkg/botutil/connect.go
+++ b/pkg/botutil/connect.go
@@ -1,0 +1,43 @@
+package botutil
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+)
+
+// DefaultPluginPackage is the npm package an Agent runs (via `npx -y <pkg> ...`)
+// to install the OpenClaw channel adapter and bind a Bot. It is the single
+// backend-owned source of truth for the package name: the App Bot connect
+// responses (modules/app_bot) and the BotFather connect prompts
+// (modules/botfather) both resolve it through PluginPackage, so a package
+// rename or canary rollout only touches the backend — never the frontend, and
+// never the localized connect-guide prose.
+const DefaultPluginPackage = "create-openclaw-octo"
+
+// PluginPackageEnv overrides DefaultPluginPackage at runtime (rename / canary),
+// so operators can switch the package without a code change or redeploy of the
+// frontend.
+const PluginPackageEnv = "OCTO_BOT_PLUGIN_PACKAGE"
+
+// PluginPackage returns the configured OpenClaw plugin package name, honoring
+// the DM_BOT_PLUGIN_PACKAGE override and falling back to DefaultPluginPackage.
+func PluginPackage() string {
+	if v := strings.TrimSpace(os.Getenv(PluginPackageEnv)); v != "" {
+		return v
+	}
+	return DefaultPluginPackage
+}
+
+// DeriveAPIURL resolves the public Bot API entry for this deployment: the
+// configured External.BaseURL, falling back to the direct-access host:port when
+// BaseURL is unset. This is the value Agents pass as `--api-url` and the URL
+// returned in Bot connect/register responses — NOT the admin-dashboard origin.
+func DeriveAPIURL(cfg *config.Config) string {
+	if u := strings.TrimSpace(cfg.External.BaseURL); u != "" {
+		return u
+	}
+	return fmt.Sprintf("http://%s:8090", cfg.External.IP)
+}

--- a/pkg/botutil/connect_test.go
+++ b/pkg/botutil/connect_test.go
@@ -1,0 +1,47 @@
+package botutil
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+)
+
+func TestPluginPackage_DefaultAndOverride(t *testing.T) {
+	// Default: no env set → the canonical package.
+	t.Setenv(PluginPackageEnv, "")
+	if got := PluginPackage(); got != DefaultPluginPackage {
+		t.Fatalf("PluginPackage() default = %q, want %q", got, DefaultPluginPackage)
+	}
+	if DefaultPluginPackage != "create-openclaw-octo" {
+		t.Fatalf("DefaultPluginPackage = %q, want create-openclaw-octo", DefaultPluginPackage)
+	}
+
+	// Override: env wins (rename / canary touches only the backend).
+	t.Setenv(PluginPackageEnv, "openclaw-channel-canary")
+	if got := PluginPackage(); got != "openclaw-channel-canary" {
+		t.Fatalf("PluginPackage() override = %q, want openclaw-channel-canary", got)
+	}
+
+	// Whitespace-only override is ignored (falls back to default).
+	t.Setenv(PluginPackageEnv, "   ")
+	if got := PluginPackage(); got != DefaultPluginPackage {
+		t.Fatalf("PluginPackage() blank override = %q, want %q", got, DefaultPluginPackage)
+	}
+}
+
+func TestDeriveAPIURL(t *testing.T) {
+	cfg := config.New()
+
+	// Configured BaseURL is the public Bot API entry, used verbatim.
+	cfg.External.BaseURL = "https://api.example.com"
+	if got := DeriveAPIURL(cfg); got != "https://api.example.com" {
+		t.Fatalf("DeriveAPIURL(BaseURL set) = %q, want https://api.example.com", got)
+	}
+
+	// Empty BaseURL → direct-access fallback derived from External.IP.
+	cfg.External.BaseURL = ""
+	cfg.External.IP = "10.0.0.5"
+	if got := DeriveAPIURL(cfg); got != "http://10.0.0.5:8090" {
+		t.Fatalf("DeriveAPIURL(BaseURL empty) = %q, want http://10.0.0.5:8090", got)
+	}
+}


### PR DESCRIPTION
## Summary

The App Bot "connect guide" (`npx -y <pkg> bind ...`) was assembled entirely in the octo-admin frontend, which hardcoded two server-owned facts: the channel-adapter npm package (`openclaw-channel-dmwork`, now unmaintained) and an `api_url` that fell back to the **admin dashboard origin** instead of the Bot API entry. This moves both to the backend so a package rename/canary or a split admin/bot-api host never needs a frontend redeploy.

The four App Bot read/create endpoints now return a `connect` object, and the package name becomes a single backend source of truth shared with BotFather's connect prompts (de-frozen from the i18n templates). The default package is the **maintained** `create-openclaw-octo` (the migration target off the dead `openclaw-channel-dmwork`).

## Related Issue

Closes #446 — backend scope. The octo-admin `connectGuide.ts` follow-up is tracked separately and depends on this change.

## Linked Spec

`.octospec/tasks/bot-connect-plugin-package/brief.md`

## Changes

- **`pkg/botutil/connect.go`** (new): single source of truth — `PluginPackage()` (default `create-openclaw-octo`, override via `OCTO_BOT_PLUGIN_PACKAGE`) and `DeriveAPIURL(cfg)` (public Bot API entry = `External.BaseURL`, fallback `http://<ip>:8090`).
- **`modules/app_bot/app_bot.go`**: `createBot` + `getBotDetail` now return `connect{plugin_package, api_url}` — covers all four endpoints (`GET`/`POST` × admin/space). Data only, no secrets.
- **`modules/botfather`**: de-hardcode `create-openclaw-octo` in the connect / created / quickstart / install i18n templates (zh-CN + en-US) → injected `{{.PluginPackage}}`.
- **`api_url` single source of truth**: every inline `External.BaseURL` / `http://<ip>:8090` copy now routes through `botutil.DeriveAPIURL` — across `app_bot`, `botfather` (`command.go` + `api.go`), and `bot_api` (`register.go` ×2 + `commands.go`). A grep for the inline pattern returns **zero** residual copies, so a future derivation change (TLS default, dev port, IPv6 bracketing) touches exactly one place.
- Tests: botutil unit; app_bot HTTP e2e (sqlmock + redis) for the read path **plus a `NewTestServer` create-side e2e**; botfather template parameterization + completeness probe + de-hardcode guard.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

Full affected suites green under the CI recipe (`OCTO_MASTER_KEY` + per-package `test` DB reset to `utf8mb4_general_ci` + `-race`), against locally-provisioned MySQL 8.0 + Redis + WuKongIM:

```
pkg/botutil ✓ · modules/app_bot ✓ · modules/botfather ✓ · modules/bot_api ✓
```

Plus `go build ./...`, `go vet ./...`, `golangci-lint` (0 issues), `make i18n-extract-check`, `make i18n-lint`, and a grep confirming zero residual inline `api_url` derivations.

## COMPREHENSION

1. **What this change actually does to the load-bearing path** — it adds a `connect{plugin_package, api_url}` field to two App Bot **success** responses (`createBot`, `getBotDetail`, covering all four endpoints), replaces the frozen package literal in four BotFather i18n templates with an injected `{{.PluginPackage}}`, and routes every `api_url` derivation through one helper. It does NOT touch any auth gate (`checkSpaceAdmin` / `CheckLoginRole`), the `botInRouteScope` cross-tenant IDOR guard, or the i18n **error** envelope — `connect` is success-response data, so no `pkg/errcode` code / `active.zh-CN.toml` / `i18n-extract` is involved.

2. **What could break** — (a) the BotFather msgtmpl catalog runs with `missingkey=error`, so any render site that omits `PluginPackage` would error and silently drop the DM; mitigated by injecting it at all four `command.go` sites **and** the completeness probe, with a guard test. (b) Response is additive (new key only), so existing consumers are unaffected; `connect` deliberately excludes the token (asserted) so no secret widening. (c) The `api_url` consolidation is byte-for-byte behavior-preserving — `DeriveAPIURL` reproduces the exact `External.BaseURL` / `IP:8090` logic each callsite had inline (and that the adjacent `DeriveWSURL` already used), so the connect guide, BotFather docs, and `/bot/register` stay consistent; `TestDeriveAPIURL` pins the helper.

3. **How I know it works** — app_bot HTTP e2e asserts `connect` is present on **both** the read and create responses, that an `OCTO_BOT_PLUGIN_PACKAGE` override reaches the client end-to-end, and that no token leaks into `connect`; the botfather tests assert the injected package renders in the bind/install/quickstart commands and that the old literal no longer appears; a grep confirms zero residual inline derivations; the full `modules/app_bot`, `modules/botfather`, and `modules/bot_api` suites pass under the CI recipe with the race detector enabled.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgRGrhti2U882uGwujGgK5