### PR TITLE
feat(incomingwebhook): caller-supplied mention.entities (directed @-pills) on native push

### DIFF
--- a/modules/incomingwebhook/mention.go
+++ b/modules/incomingwebhook/mention.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"unicode/utf16"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
 	"go.uber.org/zap"
@@ -80,9 +81,23 @@ func (w *IncomingWebhook) buildMention(m *incomingWebhookModel, req *pushPayload
 	// 全部定向 @），仅记 Warn、不让整条推送失败。纯决策（能力位放行 / 装配线协议）下沉到
 	// assembleMention，无 DB 依赖，便于单测穷举各分支。
 	uids := dedupNonEmpty(mr.Uids, maxMentionUIDs())
+	// 渲染层 entities（调用方传入的 @ 区间）【仅 text 路径】处理：offset/length 是对纯文本
+	// content 的 UTF-16 偏移，richtext 的块结构参考系不同（且跨端已知 caption/plain 错位），
+	// 本期不碰。逐条宽松解码后，其 uid 也并入下面同一次成员闸查询，避免二次查询。
+	var ents []mentionEntity
+	if isTextMention(req) {
+		ents = decodeEntities(mr.Entities, maxMentionUIDs())
+	}
+	gateUIDs := uids
+	if len(ents) > 0 {
+		// 上限 2*maxMentionUIDs：uids 与 entity uids 各自已先钳到 maxMentionUIDs，合并去重后
+		// 成员闸 IN 查询最多约 2N 个 uid（仍有界、量级与单查询无异），换取「定向 uids + entities
+		// 一次查询」而非两次。
+		gateUIDs = dedupNonEmpty(append(append([]string{}, uids...), entityUIDsOf(ents)...), maxMentionUIDs()*2)
+	}
 	members := map[string]struct{}{}
-	if len(uids) > 0 {
-		got, err := w.db.filterGroupMembers(m.GroupNo, uids)
+	if len(gateUIDs) > 0 {
+		got, err := w.db.filterGroupMembers(m.GroupNo, gateUIDs)
 		if err != nil {
 			w.Warn("filter group members for mention failed; dropping targeted @uids",
 				zap.String("webhook_id", m.WebhookID), zap.Error(err))
@@ -93,10 +108,159 @@ func (w *IncomingWebhook) buildMention(m *incomingWebhookModel, req *pushPayload
 	// 广播位有效性 = webhook 能力位 AND 策略放行（broadcastPermitted = system_setting
 	// member_can_broadcast || 创建者当前为管理员，由 handlePush 计算）。关掉设置即可即时
 	// 收回成员 webhook 的广播（管理员建的因 creatorIsAdmin 仍放行），无需迁移存量列。
-	return assembleMention(uids, members,
+	mention, ignored := assembleMention(uids, members,
 		mr.All, mr.Bots,
 		m.AllowMentionAll == 1 && broadcastPermitted,
 		m.AllowMentionBots == 1 && broadcastPermitted)
+
+	// 校验通过的 entities 原样挂到 mention.entities（与 uids 正交，ExpandAisToBotUIDs 只动
+	// uids、不碰 entities）。ents 仅在 text 路径非空，故此处无需再判 msg_type；content 在
+	// text 路径原样透传（PR-1 不改写 content），offset 与落地一致。
+	if len(ents) > 0 {
+		if validEnts := finalizeEntities(ents, members, req.Content); len(validEnts) > 0 {
+			if mention == nil {
+				mention = map[string]interface{}{}
+			}
+			mention[mentionrewrite.EntitiesKey] = validEnts
+		}
+	}
+	return mention, ignored
+}
+
+// mentionEntity 是调用方传入的单条【渲染层】@ 区间（线协议 mention.entities 的元素）：
+// offset/length 单位是 UTF-16 码元、相对消息文本，uid 必须是本群成员。
+type mentionEntity struct {
+	UID    string `json:"uid"`
+	Offset int    `json:"offset"`
+	Length int    `json:"length"`
+}
+
+// entity 线协议字段名（与 web/Android 解析、用户给的 native 示例一致：{uid,offset,length}）。
+const (
+	entityKeyUID    = "uid"
+	entityKeyOffset = "offset"
+	entityKeyLength = "length"
+)
+
+// decodeEntities 逐条宽松解码 mention.entities：单条 JSON 形状非法 / uid 空 / offset<0 /
+// length<=0 只丢该条，绝不影响其余 entity 或 mention 的 uids/all/bots（acceptance #6 的延伸）。
+// 这里只做结构 + 基本数值 sanity；成员闸与「offset 越界 / 指向 '@'」校验在 finalizeEntities
+// （那两步需要成员集 + content）。limit<=0 不限；>0 时按出现顺序最多保留 limit 条（兜底膨胀）。
+func decodeEntities(raw []json.RawMessage, limit int) []mentionEntity {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]mentionEntity, 0, len(raw))
+	for _, r := range raw {
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+		var e mentionEntity
+		if err := json.Unmarshal(r, &e); err != nil {
+			continue
+		}
+		if e.UID == "" || e.Offset < 0 || e.Length <= 0 {
+			continue
+		}
+		out = append(out, e)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// entityUIDsOf 抽出 entities 的 uid 列表，用于并入成员闸查询（顺序无关，后续会去重）。
+func entityUIDsOf(ents []mentionEntity) []string {
+	if len(ents) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(ents))
+	for _, e := range ents {
+		out = append(out, e.UID)
+	}
+	return out
+}
+
+// finalizeEntities 把已基本解码的 entities 做【权威校验】并构造线协议形态。每条须满足：
+//   - uid 是本群成员（复用成员闸结果；非成员【静默丢弃】，与定向 uids 反枚举同源）；
+//   - offset/length 落在 content 的 UTF-16 码元范围内（offset 指向真实码元、length 不越界）；
+//   - content 在 offset 处确为 '@'（与 Android plain[offset]=='@' 对齐，挡掉调用方算错的偏移、
+//     避免把气泡错绑到非 @ 文本）；
+//   - 区间不与已接受的 entity 重叠（首条占位者胜）——去重/防重叠，与 uids 的 dedupNonEmpty
+//     对称，且与端上 dedup（web parseMentionWithEntities 的 lastEnd 跳过、Android claimed[]）
+//     一致，避免同一段文本叠多个气泡。
+//
+// 单位刻意用 UTF-16 码元——与 web(String.substring/.length)/Android(Kotlin String)/iOS(NSRange)
+// 一致；故用 utf16.Encode 量度，【绝不能】用字节 len() 或 rune 数（含 emoji 时三者分叉）。
+// 返回 []interface{}（每项 map{uid,offset,length}），可直接挂到 mention[EntitiesKey]；无合法项 → nil。
+func finalizeEntities(ents []mentionEntity, members map[string]struct{}, content string) []interface{} {
+	if len(ents) == 0 {
+		return nil
+	}
+	u16 := utf16.Encode([]rune(content))
+	claimed := make([]bool, len(u16)) // 已被先前 entity 覆盖的码元位，用于防重叠/重复
+	out := make([]interface{}, 0, len(ents))
+	for _, e := range ents {
+		if e.UID == "" {
+			continue
+		}
+		if _, ok := members[e.UID]; !ok {
+			continue
+		}
+		if e.Offset < 0 || e.Length <= 0 {
+			continue
+		}
+		// 越界判断写成减法形式，避免 offset+length 在异常大入参下整型溢出。
+		if e.Offset >= len(u16) || e.Length > len(u16)-e.Offset {
+			continue
+		}
+		if u16[e.Offset] != '@' {
+			continue
+		}
+		if rangeClaimed(claimed, e.Offset, e.Length) {
+			continue // 与已接受区间重叠 / 完全重复 → 丢弃
+		}
+		markClaimed(claimed, e.Offset, e.Length)
+		out = append(out, map[string]interface{}{
+			entityKeyUID:    e.UID,
+			entityKeyOffset: e.Offset,
+			entityKeyLength: e.Length,
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// rangeClaimed 报告 [offset, offset+length) 内是否有任一码元已被占用。调用前提：区间已通过
+// finalizeEntities 的越界校验，故下标恒在 claimed 范围内。
+func rangeClaimed(claimed []bool, offset, length int) bool {
+	for i := offset; i < offset+length; i++ {
+		if claimed[i] {
+			return true
+		}
+	}
+	return false
+}
+
+// markClaimed 把 [offset, offset+length) 标记为已占用。
+func markClaimed(claimed []bool, offset, length int) {
+	for i := offset; i < offset+length; i++ {
+		claimed[i] = true
+	}
+}
+
+// isTextMention 报告本次推送是否走纯文本路径（mention.entities 仅在该路径校验/透传）。
+// 与 handlePush 的 msg_type 分发同口径：缺省 / "text" 即文本。
+func isTextMention(req *pushPayloadReq) bool {
+	switch strings.ToLower(strings.TrimSpace(req.MsgType)) {
+	case "", msgTypeText:
+		return true
+	default:
+		return false
+	}
 }
 
 // assembleMention 是 mention 装配的【纯决策核心】（无 IO，便于单测）：把已去重的定向

--- a/modules/incomingwebhook/mention_e2e_test.go
+++ b/modules/incomingwebhook/mention_e2e_test.go
@@ -234,3 +234,44 @@ func TestMentionPush_NoMentionFieldBackwardCompatible(t *testing.T) {
 	_, hasIgnored := parseJSON(t, pw)["mention_ignored"]
 	assert.False(t, hasIgnored)
 }
+
+// TestMentionPush_EntitiesAccepted：native 文本路径带【调用方提供的】mention.entities
+// （渲染层 @ 区间 {uid,offset,length}）→ 200 且无 mention_ignored。entities 不受广播能力位
+// 约束（定向渲染，非广播），非成员 entity 静默丢弃。entities 是否落到 wire、是否按成员闸
+// 过滤是【刻意不经 HTTP 回显】的（反枚举 + 落在 WuKongIM payload），由纯单测 finalizeEntities
+// 穷举（含 UTF-16 offset parity），此处只冒烟覆盖 push 路径接受 entities 不出错。
+func TestMentionPush_EntitiesAccepted(t *testing.T) {
+	handler, _, groupNo := setupMemberEnv(t)
+	created := adminCreateWebhook(t, handler, groupNo, map[string]interface{}{"name": "ci"})
+	pushURL := fmt.Sprintf("/v1/incoming-webhooks/%s/%s", created["webhook_id"], created["token"])
+
+	// content "@x ok"：@(0)x(1) → entity offset0 length2 指向 "@x"，uid 为本群成员。
+	body := fmt.Sprintf(
+		`{"content":"@x ok","mention":{"uids":["%s"],"entities":[{"uid":"%s","offset":0,"length":2}]}}`,
+		memberAUID, memberAUID)
+	pw := do(handler, anonReq("POST", pushURL, []byte(body)))
+	require.Equalf(t, http.StatusOK, pw.Code, "push body: %s", pw.Body.String())
+	_, hasIgnored := parseJSON(t, pw)["mention_ignored"]
+	assert.False(t, hasIgnored, "entities are not capability-gated; non-members dropped silently")
+}
+
+// TestMentionPush_MalformedEntitiesDelivered：entities 形状非法不得把推送 400（acceptance #6）。
+//   - entities 为非数组标量 → 整个 mention 降级为「无」、消息照投；
+//   - entities 数组里单条非法（offset 类型错 / 空对象）→ 仅丢该条，不连累其余 mention 字段。
+func TestMentionPush_MalformedEntitiesDelivered(t *testing.T) {
+	handler, _, groupNo := setupMemberEnv(t)
+	created := adminCreateWebhook(t, handler, groupNo, map[string]interface{}{"name": "ci"})
+	pushURL := fmt.Sprintf("/v1/incoming-webhooks/%s/%s", created["webhook_id"], created["token"])
+
+	for _, body := range []string{
+		`{"content":"hi","mention":{"entities":"garbage"}}`,
+		fmt.Sprintf(`{"content":"@x ok","mention":{"uids":["%s"],"entities":[{"uid":"x","offset":"y"}]}}`, memberAUID),
+		fmt.Sprintf(`{"content":"@x ok","mention":{"uids":["%s"],"entities":[{}]}}`, memberAUID),
+	} {
+		pw := do(handler, anonReq("POST", pushURL, []byte(body)))
+		require.Equalf(t, http.StatusOK, pw.Code,
+			"malformed entities must still deliver (200), body=%s resp=%s", body, pw.Body.String())
+		_, hasIgnored := parseJSON(t, pw)["mention_ignored"]
+		assert.Falsef(t, hasIgnored, "malformed entities are dropped, not reported: %s", body)
+	}
+}

--- a/modules/incomingwebhook/mention_entities_test.go
+++ b/modules/incomingwebhook/mention_entities_test.go
@@ -1,0 +1,237 @@
+package incomingwebhook
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 渲染层 mention.entities 的纯单测（无 DB 依赖）：逐条宽松解码 + 成员闸/越界/指向'@' 校验，
+// 以及【offset 单位是 UTF-16 码元】的关键 parity（emoji 前缀场景下 rune/byte 偏移必须被拒）。
+// 成员闸的真实查询（filterGroupMembers）与端到端透传由集成测试覆盖。
+
+func rawEntities(jsons ...string) []json.RawMessage {
+	out := make([]json.RawMessage, 0, len(jsons))
+	for _, j := range jsons {
+		out = append(out, json.RawMessage(j))
+	}
+	return out
+}
+
+func TestDecodeEntities(t *testing.T) {
+	t.Run("valid entities decode in order", func(t *testing.T) {
+		ents := decodeEntities(rawEntities(
+			`{"uid":"u1","offset":0,"length":3}`,
+			`{"uid":"u2","offset":4,"length":3}`,
+		), 0)
+		require.Len(t, ents, 2)
+		assert.Equal(t, mentionEntity{UID: "u1", Offset: 0, Length: 3}, ents[0])
+		assert.Equal(t, mentionEntity{UID: "u2", Offset: 4, Length: 3}, ents[1])
+	})
+
+	t.Run("per-entity leniency: bad ones skipped, good kept (acceptance #6)", func(t *testing.T) {
+		ents := decodeEntities(rawEntities(
+			`{"uid":"u1","offset":0,"length":3}`,   // good
+			`"garbage"`,                            // not an object
+			`{"uid":"","offset":0,"length":3}`,     // empty uid
+			`{"uid":"u3","offset":-1,"length":3}`,  // negative offset
+			`{"uid":"u4","offset":0,"length":0}`,   // zero length
+			`{"uid":"u5","offset":"x","length":3}`, // offset wrong type
+			`{"uid":"u6","offset":1,"length":2}`,   // good
+		), 0)
+		require.Len(t, ents, 2)
+		assert.Equal(t, "u1", ents[0].UID)
+		assert.Equal(t, "u6", ents[1].UID)
+	})
+
+	t.Run("cap limits count", func(t *testing.T) {
+		ents := decodeEntities(rawEntities(
+			`{"uid":"u1","offset":0,"length":1}`,
+			`{"uid":"u2","offset":1,"length":1}`,
+			`{"uid":"u3","offset":2,"length":1}`,
+		), 2)
+		require.Len(t, ents, 2)
+	})
+
+	t.Run("empty / all-bad input -> nil", func(t *testing.T) {
+		assert.Nil(t, decodeEntities(nil, 0))
+		assert.Nil(t, decodeEntities(rawEntities(), 0))
+		assert.Nil(t, decodeEntities(rawEntities(`"x"`, `{"uid":""}`), 0))
+	})
+}
+
+func TestEntityUIDsOf(t *testing.T) {
+	assert.Nil(t, entityUIDsOf(nil))
+	got := entityUIDsOf([]mentionEntity{{UID: "a"}, {UID: "b"}})
+	assert.Equal(t, []string{"a", "b"}, got)
+}
+
+func TestFinalizeEntities(t *testing.T) {
+	members := memberSet("u1", "u2") // helper from mention_test.go
+
+	t.Run("keeps member entities pointing at '@', builds wire maps", func(t *testing.T) {
+		// "@张三 @李四": @(0)张(1)三(2) space(3) @(4)李(5)四(6)
+		content := "@张三 @李四"
+		ents := []mentionEntity{
+			{UID: "u1", Offset: 0, Length: 3},
+			{UID: "u2", Offset: 4, Length: 3},
+		}
+		got := finalizeEntities(ents, members, content)
+		require.Len(t, got, 2)
+		assert.Equal(t, map[string]interface{}{entityKeyUID: "u1", entityKeyOffset: 0, entityKeyLength: 3}, got[0])
+		assert.Equal(t, map[string]interface{}{entityKeyUID: "u2", entityKeyOffset: 4, entityKeyLength: 3}, got[1])
+	})
+
+	t.Run("drops non-member uid (anti-enumeration, silent)", func(t *testing.T) {
+		got := finalizeEntities([]mentionEntity{{UID: "ghost", Offset: 0, Length: 3}}, members, "@张三")
+		assert.Nil(t, got)
+	})
+
+	t.Run("drops out-of-range offset/length (UTF-16 bounds)", func(t *testing.T) {
+		content := "@张三" // utf16 len = 3
+		assert.Nil(t, finalizeEntities([]mentionEntity{{UID: "u1", Offset: 0, Length: 4}}, members, content))
+		assert.Nil(t, finalizeEntities([]mentionEntity{{UID: "u1", Offset: 3, Length: 1}}, members, content))
+		assert.Nil(t, finalizeEntities([]mentionEntity{{UID: "u1", Offset: 99, Length: 1}}, members, content))
+	})
+
+	t.Run("drops entity not pointing at '@'", func(t *testing.T) {
+		// "x@张三": x(0)@(1)张(2)三(3)
+		content := "x@张三"
+		assert.Nil(t, finalizeEntities([]mentionEntity{{UID: "u1", Offset: 0, Length: 3}}, members, content))
+		got := finalizeEntities([]mentionEntity{{UID: "u1", Offset: 1, Length: 3}}, members, content)
+		require.Len(t, got, 1)
+		assert.Equal(t, 1, got[0].(map[string]interface{})[entityKeyOffset])
+	})
+
+	// 关键 parity：offset 单位必须是 UTF-16 码元，不是 rune、也不是字节。
+	// "👍@张三" 的 UTF-16: 👍=2 码元(代理对) → @张三 起于 offset 2；rune 偏移会是 1、UTF-8 字节偏移会是 4。
+	t.Run("offset unit is UTF-16 code units, not rune or byte (emoji prefix)", func(t *testing.T) {
+		content := "👍@张三"
+		ok := finalizeEntities([]mentionEntity{{UID: "u1", Offset: 2, Length: 3}}, members, content)
+		require.Len(t, ok, 1, "UTF-16 offset 2 must point at '@'")
+		assert.Equal(t, map[string]interface{}{entityKeyUID: "u1", entityKeyOffset: 2, entityKeyLength: 3}, ok[0])
+
+		assert.Nil(t, finalizeEntities([]mentionEntity{{UID: "u1", Offset: 1, Length: 3}}, members, content),
+			"rune-based offset 1 lands inside the surrogate pair -> must be rejected (proves not rune)")
+		assert.Nil(t, finalizeEntities([]mentionEntity{{UID: "u1", Offset: 4, Length: 3}}, members, content),
+			"byte-based offset 4 is out of range -> must be rejected (proves not byte)")
+	})
+
+	t.Run("mixed valid + invalid: keep only valid", func(t *testing.T) {
+		content := "@张三 @李四"
+		ents := []mentionEntity{
+			{UID: "u1", Offset: 0, Length: 3},    // valid
+			{UID: "ghost", Offset: 4, Length: 3}, // non-member -> drop
+		}
+		got := finalizeEntities(ents, members, content)
+		require.Len(t, got, 1)
+		assert.Equal(t, "u1", got[0].(map[string]interface{})[entityKeyUID])
+	})
+
+	t.Run("exact-fit span at content end is accepted (boundary)", func(t *testing.T) {
+		// "@a": @(0)a(1), utf16 len 2 → offset0 length2 fits exactly to the end.
+		got := finalizeEntities([]mentionEntity{{UID: "u1", Offset: 0, Length: 2}}, members, "@a")
+		require.Len(t, got, 1)
+		assert.Equal(t, map[string]interface{}{entityKeyUID: "u1", entityKeyOffset: 0, entityKeyLength: 2}, got[0])
+	})
+
+	t.Run("rejects duplicate + overlapping spans, keeps disjoint (first-wins)", func(t *testing.T) {
+		// "@a @b": @(0)a(1) space(2) @(3)b(4)
+		content := "@a @b"
+		ents := []mentionEntity{
+			{UID: "u1", Offset: 0, Length: 2}, // accepted "@a"
+			{UID: "u1", Offset: 0, Length: 2}, // exact duplicate -> drop
+			{UID: "u2", Offset: 0, Length: 2}, // overlaps accepted [0,2) (even though at '@') -> drop
+			{UID: "u2", Offset: 3, Length: 2}, // accepted "@b" (disjoint)
+		}
+		got := finalizeEntities(ents, members, content)
+		require.Len(t, got, 2)
+		assert.Equal(t, map[string]interface{}{entityKeyUID: "u1", entityKeyOffset: 0, entityKeyLength: 2}, got[0])
+		assert.Equal(t, map[string]interface{}{entityKeyUID: "u2", entityKeyOffset: 3, entityKeyLength: 2}, got[1])
+	})
+
+	t.Run("non-member and bad-offset drops are indistinguishable in output (anti-enumeration)", func(t *testing.T) {
+		// "@张三 @李四": valid keep (u1@0); non-member drop (ghost@4); bad-'@' drop (u2@3 is the space)
+		content := "@张三 @李四"
+		ents := []mentionEntity{
+			{UID: "u1", Offset: 0, Length: 3},    // valid keep
+			{UID: "ghost", Offset: 4, Length: 3}, // non-member -> drop
+			{UID: "u2", Offset: 3, Length: 1},    // offset 3 is the space (not '@') -> drop
+		}
+		got := finalizeEntities(ents, members, content)
+		require.Len(t, got, 1)
+		assert.Equal(t, "u1", got[0].(map[string]interface{})[entityKeyUID])
+	})
+
+	t.Run("empty -> nil", func(t *testing.T) {
+		assert.Nil(t, finalizeEntities(nil, members, "@张三"))
+		assert.Nil(t, finalizeEntities([]mentionEntity{}, members, "@张三"))
+	})
+}
+
+func TestIsTextMention(t *testing.T) {
+	assert.True(t, isTextMention(&pushPayloadReq{MsgType: ""}))
+	assert.True(t, isTextMention(&pushPayloadReq{MsgType: "text"}))
+	assert.True(t, isTextMention(&pushPayloadReq{MsgType: "  Text "}))
+	assert.False(t, isTextMention(&pushPayloadReq{MsgType: "richtext"}))
+}
+
+// TestMentionEntitiesSurviveAisExpansion is the integration-seam guard: the way
+// entities reach the wire is handlePush's `CloneForExpansion` → `ExpandAisToBotUIDs`
+// chain. This proves entities pass through that chain verbatim (offset/length/uid
+// unchanged) even when ais-expansion appends bot UIDs to mention.uids, AND that the
+// clone isolates the original payload (no in-place mutation). No DB/WuKongIM needed —
+// it locks the only transformation between finalizeEntities and the serialized wire.
+func TestMentionEntitiesSurviveAisExpansion(t *testing.T) {
+	entity := map[string]interface{}{entityKeyUID: "u1", entityKeyOffset: 0, entityKeyLength: 3}
+	mention := map[string]interface{}{
+		mentionrewrite.UIDsKey:     []interface{}{"u1"},
+		mentionrewrite.AIsKey:      1,
+		mentionrewrite.EntitiesKey: []interface{}{entity},
+	}
+	payload := map[string]interface{}{mentionrewrite.MentionKey: mention}
+
+	wire := mentionrewrite.CloneForExpansion(payload)
+	wire = mentionrewrite.ExpandAisToBotUIDs(
+		wire, common.ChannelTypeGroup.Uint8(), "g1",
+		func(string) ([]string, error) { return []string{"bot_x"}, nil })
+
+	mm, ok := wire[mentionrewrite.MentionKey].(map[string]interface{})
+	require.True(t, ok)
+
+	// entities survive verbatim through clone + ais expansion.
+	ents, ok := mm[mentionrewrite.EntitiesKey].([]interface{})
+	require.Truef(t, ok, "entities must survive clone+expand; mention=%v", mm)
+	require.Len(t, ents, 1)
+	assert.Equal(t, entity, ents[0])
+
+	// ais expansion appended the bot uid; the directed uid is still there.
+	uids, _ := mm[mentionrewrite.UIDsKey].([]interface{})
+	assert.Contains(t, uids, "u1")
+	assert.Contains(t, uids, "bot_x")
+
+	// clone isolation: the original payload's uids are NOT mutated by the wire expansion.
+	origUIDs, _ := mention[mentionrewrite.UIDsKey].([]interface{})
+	assert.NotContains(t, origUIDs, "bot_x", "wire expansion must not mutate the original payload")
+}
+
+// TestDecodeMentionWithEntities pins that adding the Entities field keeps the
+// lenient decode contract: valid entities decode; a malformed entities VALUE
+// (non-array) degrades the whole mention to not-ok (message still delivered),
+// while a malformed single entity is handled later by decodeEntities, not here.
+func TestDecodeMentionWithEntities(t *testing.T) {
+	mr, ok := decodeMention(json.RawMessage(
+		`{"uids":["a"],"entities":[{"uid":"a","offset":0,"length":2}]}`))
+	require.True(t, ok)
+	assert.Equal(t, []string{"a"}, mr.Uids)
+	require.Len(t, mr.Entities, 1)
+
+	// entities as a non-array scalar -> whole mention fails to decode (acceptance
+	// #6: degrade to no-mention, never 400). decodeEntities never even runs.
+	_, ok = decodeMention(json.RawMessage(`{"uids":["a"],"entities":5}`))
+	assert.False(t, ok)
+}

--- a/modules/incomingwebhook/model.go
+++ b/modules/incomingwebhook/model.go
@@ -111,12 +111,15 @@ type pushPayloadReq struct {
 	Mention json.RawMessage `json:"mention,omitempty"`
 }
 
-// mentionReq 是 native 推送请求里的 @ 描述（对外契约）。刻意不暴露内部线协议的
-// humans/ais/entities 字段名：调用方只描述「@ 谁(uids) / @所有人(all) / @所有 AI(bots)」，
-// 由服务端 buildMention 翻译为 mention.{uids,humans,ais} 并做权限/成员校验。
-//   - Uids ：要 @ 的成员 UID（用户或 bot），去重后受上限约束，且必须是本群当前成员。
-//   - All  ：@所有人（真人广播），受 webhook 的 allow_mention_all 能力位约束。
-//   - Bots ：@所有 AI（bot 广播），受 webhook 的 allow_mention_bots 能力位约束。
+// mentionReq 是 native 推送请求里的 @ 描述（对外契约）。两个广播位刻意不暴露内部线协议的
+// humans/ais 字段名：调用方只写「@所有人(all) / @所有 AI(bots)」，由服务端 buildMention 翻译
+// 为 mention.{humans,ais} 并做能力位校验。Entities 则【直接以线协议字段名 entities 接收】——
+// 它是渲染层 [{uid,offset,length}]，本就是端上要消费的形态、无可翻译语义，服务端只做成员闸 +
+// 越界/锚点校验后原样透传（见 Entities 字段注释）。
+//   - Uids     ：要 @ 的成员 UID（用户或 bot），去重后受上限约束，且必须是本群当前成员。
+//   - All      ：@所有人（真人广播），受 webhook 的 allow_mention_all 能力位约束。
+//   - Bots     ：@所有 AI（bot 广播），受 webhook 的 allow_mention_bots 能力位约束。
+//   - Entities ：渲染层 @ 区间（详见字段注释）；定向渲染、不受广播能力位约束。
 type mentionReq struct {
 	Uids []string `json:"uids,omitempty"`
 	All  bool     `json:"all,omitempty"`

--- a/modules/incomingwebhook/model.go
+++ b/modules/incomingwebhook/model.go
@@ -121,6 +121,17 @@ type mentionReq struct {
 	Uids []string `json:"uids,omitempty"`
 	All  bool     `json:"all,omitempty"`
 	Bots bool     `json:"bots,omitempty"`
+	// Entities 是【渲染层】的 @ 区间（线协议 mention.entities：[{uid,offset,length}]），
+	// 与 uids（路由层）正交：调用方自带 content 文本与每个 @ 的 offset/length，服务端只校验
+	// 每条 entity 的 uid 是本群成员、offset/length 落在 content 的 UTF-16 码元范围内且 offset
+	// 处确为 '@'，合法者原样透传到线协议供端上权威渲染气泡（web 用 entities 精确绑定、Android
+	// 校验后保留、iOS 忽略改按位置解析）。offset/length 单位是 UTF-16 码元（= JS .length /
+	// Java/Kotlin String / NSString），不是字节、也不是 rune。
+	//
+	// 类型是 []json.RawMessage 以做【逐条】宽松解码：单条形状非法（如 offset 传字符串）只丢
+	// 该条，不连累其余 entity，也不影响 mention 的 uids/all/bots——与 decodeMention 的宽松
+	// 契约（malformed → 降级、不 400、不丢消息）一致。
+	Entities []json.RawMessage `json:"entities,omitempty"`
 }
 
 // webhookBlock 是富文本消息的单个有序块（对外契约）。字段刻意与 octo-lib

--- a/pkg/mentionrewrite/clone.go
+++ b/pkg/mentionrewrite/clone.go
@@ -99,6 +99,11 @@ func CloneForExpansion(payload map[string]interface{}) map[string]interface{} {
 	if !ok {
 		return out
 	}
+	// Only `uids` is deep-copied below because it is the only key
+	// ExpandAisToBotUIDs mutates. Other mention keys (humans / ais /
+	// entities) are shared by reference — safe precisely because the
+	// helper forwards them untouched (see ExpandAisToBotUIDs clause 2). If a
+	// future helper starts mutating e.g. `entities`, deep-copy it here too.
 	mentionCopy := make(map[string]interface{}, len(mention))
 	for k, v := range mention {
 		mentionCopy[k] = v

--- a/pkg/mentionrewrite/expand_ais.go
+++ b/pkg/mentionrewrite/expand_ais.go
@@ -64,7 +64,10 @@ const UIDsKey = "uids"
 //     scope per the issue body — bots in DMs have a different
 //     dispatch path, and community-topic bots are out of v0.
 //  2. ONLY `mention.uids` is touched. `mention.all`, `mention.humans`,
-//     and `mention.ais` are forwarded untouched. The issue body
+//     `mention.ais`, and `mention.entities` are forwarded untouched —
+//     `entities` (the render-layer @-span list) MUST stay verbatim so the
+//     shallow copy in CloneForExpansion remains safe and the caller-supplied
+//     offsets keep pointing at the unchanged message text. The issue body
 //     constraint "Do NOT modify mention.all, mention.humans, or
 //     mention.ais — only mention.uids" is intentional: those fields
 //     drive other read-side behaviors (legacy `@所有人` rendering,

--- a/pkg/mentionrewrite/rewrite.go
+++ b/pkg/mentionrewrite/rewrite.go
@@ -76,6 +76,16 @@ const HumansKey = "humans"
 // client; it is no longer inferred from legacy `all=1`.
 const AIsKey = "ais"
 
+// EntitiesKey is the render-layer mention span list inside the `mention`
+// sub-map: an array of `{uid, offset, length}` objects that bind a visible
+// `@name` substring of the message text to a member uid. `offset`/`length`
+// are UTF-16 code units relative to the message text — the unit JS
+// (`String.length`/`substring`), Java/Kotlin `String`, and ObjC `NSRange`
+// all index by, NOT bytes and NOT runes. The chokepoint helpers
+// (RewriteMention / ExpandAisToBotUIDs) pass this field through untouched;
+// it is exposed so callers and tests share one constant.
+const EntitiesKey = "entities"
+
 // RewriteMention is the (now pass-through) normalizer for the
 // payload's `mention` sub-map. The signature is preserved so all three
 // ingress chokepoints (modules/message/api.go, modules/bot_api/send.go,


### PR DESCRIPTION
## Summary

Adds the **visible render layer** for directed @mentions on the native incoming-webhook push endpoint. #445 shipped the functional layer (red-dot / bot summon via `mention.uids`); this lets a caller also render a **clickable @-pill bound to the right member** by supplying `mention.entities` (`[{uid, offset, length}]`) alongside `content` + `mention.uids`. The server validates and passes entities through verbatim — **no name resolution, no `content` mutation**.

Target wire shape (a directed @ of a bot — exactly what an app client already emits):

```json
{
  "content": "@example-bot run it",
  "type": 1,
  "mention": {
    "uids": ["27oErgk8Leib2d99669_bot"],
    "entities": [{ "uid": "27oErgk8Leib2d99669_bot", "offset": 0, "length": 11 }]
  }
}
```

## Related Issue

Addresses the **directed-@ half of #448** (visible-pill consistency). Cross-client analysis posted on #448 confirms all three clients consume this exact shape: web binds authoritatively by offset (`parseMentionWithEntities`), Android validates/keeps the wire entity (`MentionEntityHelper`), iOS ignores entities and re-parses by position — so the shape is universal and needs **zero client changes**. The broadcast-pill auto-compose (the other half of #448) is a deliberate follow-up.

## Linked Spec

- `.octospec/tasks/incoming-webhook-mention/brief.md` — this extends the #445 brief with the render-layer (`entities`) the brief deferred.
- #448 — v2 follow-up tracking the visible layer.

## Changes

- `model.go`: `mentionReq` gains `Entities []json.RawMessage` (per-item lenient decode).
- `mention.go`: `decodeEntities` (structural sanity, per-item drop, capped), `finalizeEntities` (member gate + UTF-16 in-bounds + must point at `@` + de-overlap, first-wins), wired into `buildMention` — text msg_type only; entity uids join the **same single** `filterGroupMembers` query as directed uids.
- `pkg/mentionrewrite/rewrite.go`: new `EntitiesKey` constant (the package already documents `mention.entities` as pass-through).
- No `api.go` / `db.go` changes: entities ride the existing `handlePush` → `CloneForExpansion` → `ExpandAisToBotUIDs` path, which preserves all `mention` sub-keys and only mutates `uids`.

Key contract points: `offset`/`length` are **UTF-16 code units** (web JS `String`, Android Kotlin `String`, iOS `NSRange`) — not bytes, not runes. Non-member / malformed / out-of-bounds / non-`@` / overlapping entities are dropped **silently** (anti-enumeration — indistinguishable from any other drop). Only contract-existing wire fields are used; with no entities the payload is byte-identical to today.

## Testing

```
go test ./modules/incomingwebhook/ ./pkg/mentionrewrite/ -count=1   # ok (live MySQL/Redis/WuKongIM)
golangci-lint run ./modules/incomingwebhook/... ./pkg/mentionrewrite/...   # 0 issues (govet, the CI gate)
```

- Unit: UTF-16 parity (emoji prefix — rune-offset and byte-offset interpretations are both rejected); member-gate drop; `@`-anchor check; overlap/duplicate de-overlap; non-member-vs-bad-offset drops are indistinguishable; per-item lenient decode; backward-compat decode.
- Integration seam: `mention.entities` survives `CloneForExpansion` + `ExpandAisToBotUIDs` verbatim, original payload not mutated.
- E2E (live infra): entities accepted (200, no false `mention_ignored`); malformed entities degrade and still deliver (200).
- A throwaway WuKongIM read-back probe was used during development but not committed (the test env inserts `group_member` rows without registering WuKongIM subscribers, so subscriber-scoped `messagesync` returns nothing — an env limitation, not a feature gap; the seam test covers the wire path reliably).

- [x] Unit tests added/updated
- [x] Manually verified

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?** On `handlePush`, `buildMention` now reads a caller-supplied `mention.entities`, validates each entity's `uid` through the **same group-member gate** as directed `uids` and its `offset`/`length` against the `content`'s UTF-16 bounds (must index a `@`, no overlap), and attaches the survivors to the payload's `mention` map. It is purely additive to the wire: routing (`uids`/`humans`/`ais`) and `content` are untouched.

2. **What could break (dependents + failure mode)?** (a) Clients reading `mention.entities` — but the field/shape already exist and are already consumed; no client change, and a bad offset can't produce a mis-bound pill because of the in-bounds + `@`-anchor validation. (b) The member gate is the trust boundary; a leak would render a pill for a cross-group uid — prevented by routing entity uids through `filterGroupMembers` and re-checking membership in `finalizeEntities`. (c) Backward compat — no-entities messages must be byte-identical; `EntitiesKey` is written only when ≥1 valid entity exists. (d) ais-expansion must not clobber entities — `CloneForExpansion` copies all `mention` keys and `ExpandAisToBotUIDs` only writes `uids` (locked by a test).

3. **How do you know it works?** The unit suite proves the validation (incl. the UTF-16 emoji parity that rejects both rune- and byte-offset interpretations) and the anti-enumeration indistinguishability; the seam test proves entities reach the wire unmutated through the clone/expand chain with the original payload isolated; and the e2e cases exercise the full HTTP push path against live MySQL/Redis/WuKongIM.

## Checklist

- [x] PR description is in English
- [x] Added tests for my changes
- [x] Followed commit message conventions (Conventional Commits)
- [ ] Updated documentation (swagger note for the `entities` contract to follow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKr5U3bnKZb3oFDfC9765A

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKr5U3bnKZb3oFDfC9765A)_