### PR TITLE
feat(incomingwebhook): visible mention render layer — broadcast pills + directed name resolution

### DIFF
--- a/.octospec/journal/shared/incoming-webhook-mention-broadcast.md
+++ b/.octospec/journal/shared/incoming-webhook-mention-broadcast.md
@@ -1,0 +1,98 @@
+---
+type: Journal
+title: "Journal: incoming-webhook-mention-broadcast (octo-server #448)"
+description: Record of the broadcast-pill auto-compose (deferred half of #448) and the rules/decisions it honored.
+tags: ["incomingwebhook", "mention", "wire-contract", "trust-boundary", "render-layer"]
+timestamp: 2026-06-24T00:00:00Z
+# --- octospec extension fields ---
+task: incoming-webhook-mention-broadcast
+upstream: Mininglamp-OSS/octo-server#448
+source: self
+---
+# Journal: incoming-webhook-mention-broadcast (octo-server #448)
+
+## What was done
+Closed the **broadcast** half of #448 item ② (after #445 shipped the flags and
+#449 the directed entities). When a native incoming-webhook push sets
+`mention.all` (humans) or `mention.bots` (ais) **and** the per-webhook capability
+bit is permitted, the server now prepends the canonical broadcast literal
+(`@所有人` / `@所有AI`) + a trailing space to the **text** content, so all three
+clients render a visible broadcast pill. Before this, those flags fired the
+red-dot / notify / bot-summon but no pill appeared unless the caller hand-wrote
+the literal into `content`.
+
+- `modules/incomingwebhook/mention.go`:
+  - New `broadcastTokenAll`/`broadcastTokenAIs`/`broadcastTokenSep` constants
+    (the canonical render labels for `mentionrewrite.HumansKey`/`AIsKey`).
+  - `composeBroadcastContent(content, wantAll, wantBots, allowAll, allowBots)
+    (string, int)` — prepends gated, idempotent (`strings.Contains` on the
+    canonical literal), humans-first; returns the new content and the prefix's
+    **UTF-16 code-unit** length. No-op returns `(content, 0)`.
+  - `shiftEntityOffsets(ents, by)` — shifts surviving directed-entity (#449)
+    offsets by the prefix length so web/Android keep binding the right member.
+  - `buildMention` now returns `(mention, content, ignored)`: computes
+    `allowAll`/`allowBots` once (shared by compose + assemble), composes on the
+    **text path only**, validates entities against the **original** `req.Content`
+    then shifts the survivors.
+- `modules/incomingwebhook/api.go`:
+  - `handlePush` writes the composed content back via the new shared
+    `payloadContentKey` const, **only when `content != req.Content`** — a
+    load-bearing guard (see Lessons).
+- Tests: `mention_broadcast_test.go` (pure `composeBroadcastContent` +
+  `shiftEntityOffsets`, bare-`w` `buildMention` wiring with no infra, and one
+  infra integration test for broadcast+entity offset-shift asserting
+  `buildMention`'s return directly — no WuKongIM read-back).
+
+## Cross-client grounding (re-verified against the three repos)
+**All three clients require the literal in the content text to render a pill —
+none fabricate one from the flag alone.** iOS `WKMentionService.parseMention`
+regex-scans content; Android `WKUIChatMsgItemEntity` uses the flag only to *gate*
+an `indexOf` highlight of a literal already in content; web `buildMessageMentions`
+synthesizes a render entry but `MarkdownContent.segmentText` only styles it where
+the name matches the content text. So server-prepending the canonical literal is
+the correct, double-render-safe fix universally.
+
+## octospec rules injected (see context.yaml)
+- **trust-boundary** (load-bearing): the prepend is a server-controlled
+  compile-time constant with no markdown/regex metacharacters (caller only flips
+  a boolean) → no new injection/escape surface; native-only (siblings don't set
+  the flags) so adapter parity holds; bounded (≤11 UTF-16 units).
+- **error-handling** (load-bearing): no new error codes; compose is non-fatal
+  render-layer text, never an error response; `NoLegacyResponseError` guard holds
+  (no new handler file). `golangci-lint` (govet gate) clean.
+- **space-isolation** (load-bearing): no new identity/data access; only content
+  text + already-gated humans/ais flags are touched.
+- **testing**: pure unit tests + bare-`w` wiring tests + one testutil integration.
+
+## Verification
+- `go test ./modules/incomingwebhook/ -count=1` → PASS (live MySQL/Redis/WuKongIM)
+- `go vet ./modules/incomingwebhook/...` → clean
+- `golangci-lint run ./modules/incomingwebhook/...` → 0 issues
+- High-effort adversarial code-review (8 finder angles + verify) → see Lessons.
+
+## Lessons
+- **The `content != req.Content` write-back guard is load-bearing, not
+  redundant.** A review angle flagged it as a removable no-op. It is not: the
+  richtext payload stores a **blocks array** under the same `content` key
+  (`richtext.go:84`); `buildMention` never composes for richtext
+  (`content == req.Content`), so the guard is false and the array is preserved.
+  Making the write unconditional would clobber the array with a string and
+  corrupt every richtext message. Comment now spells this out so it is never
+  "simplified" away.
+- **Offset shift must be by the *actual* prepended prefix length.** With
+  per-token idempotency, the prefix may be only one token (or none); the shift is
+  `len(utf16.Encode([]rune(prefix)))` computed from exactly what was written, and
+  a prepend at offset 0 keeps every entity's `'@'` anchor valid at
+  `offset+prefixLen`. Deriving the length from `utf16.Encode` (not a hardcoded
+  5/6/11) keeps it correct-by-construction if a literal ever changes.
+- **Idempotency can only be canonical-literal-deep, by design.** Clients also
+  recognize English aliases (`@all`, `@All AIs`) and a per-locale label the
+  server cannot know, so the server cannot fully replicate client tokenization.
+  Checking `strings.Contains` on the *canonical* literal is the safe choice:
+  extending it to `@all` would false-positive on member names like `@allen` and
+  *suppress* a legitimate pill (worse than the rare manual-alias double-pill,
+  which is documented as out-of-scope).
+- **`buildMention` is the reliable seam to test the wiring**, not a WuKongIM
+  read-back — it returns content+mention directly, and broadcast-only cases never
+  query the member gate, so a bare `*IncomingWebhook` (no infra) exercises the
+  text-path/gate/return logic.

--- a/.octospec/journal/shared/incoming-webhook-mention-directed-render.md
+++ b/.octospec/journal/shared/incoming-webhook-mention-directed-render.md
@@ -1,0 +1,107 @@
+---
+type: Journal
+title: "Journal: incoming-webhook-mention-directed-render (octo-server #448)"
+description: Record of the opt-in server-side directed @mention name-resolution (#448 item ① b) and the adversarial-review hardening it received.
+tags: ["incomingwebhook", "mention", "wire-contract", "trust-boundary", "render-layer"]
+timestamp: 2026-06-24T00:00:00Z
+# --- octospec extension fields ---
+task: incoming-webhook-mention-directed-render
+upstream: Mininglamp-OSS/octo-server#448
+source: self
+---
+# Journal: incoming-webhook-mention-directed-render (octo-server #448)
+
+## What was done
+Implemented #448 item ① option (b): an incoming-webhook caller can render a
+directed `@member` pill by sending **only the uid** + `mention.render:true`. The
+server resolves the member display name, prepends `@<name> ` to the **text**
+content, and **generates** the UTF-16 `mention.entities` element. Shipped in the
+same PR as the broadcast half (#450), so together they close #448.
+
+- `model.go`: `mentionReq.Render` — opt-in request flag (default off → #445/#449
+  callers unchanged; request-only, not on the wire).
+- `db.go`: `filterGroupMembers` now returns `map[uid]name` via `LEFT JOIN user`
+  (`IFNULL(user.name,'')`), matching the group member-list resolution. Membership
+  is still key-presence; the name is only used by render.
+- `mention.go`: `composeBroadcastContent` refactored into the unified
+  `composeMentionContent` (broadcast literals + directed `@name`s in one prepend
+  pass; broadcast first, directed after). `buildMention` returns
+  `(mention, content, ignored)`, computes the render set (member uids in caller
+  order), and — `render` and caller-supplied `entities` being mutually exclusive
+  (#449 authoritative) — attaches either the generated entities or the
+  shifted caller entities.
+- Tests: `mention_directed_render_test.go` (pure compose: order / non-member &
+  empty-name skip / idempotency / budget / broadcast+directed combo / the
+  forged-broadcast guard; integration via `buildMention` with seeded
+  `group_member` + `user` rows).
+
+## Grounding
+Client send-path (`octo-web mentionSendParse.ts`): a user-typed @ emits `content`
+with `@<displayName>` inline + `entities.push({uid, offset, length})` (UTF-16) +
+`uids`. The server generates the **same** shape for a bare uid, so a
+webhook-rendered directed @ is wire-identical to a client-sent one. Display name =
+`user.name` (the group member-list source); `remark` (viewer-specific) and the
+verified-`real_name` chain (#344) are out of scope for v1.
+
+## Adversarial review (3 finder agents) → hardening applied
+- **Forged broadcast pill (security + cleanup agents, CONFIRMED).** A member whose
+  display name *is* a broadcast label (`所有人`/`所有AI`/`All People`/`All AIs`/
+  `all`) would compose to `@所有人` etc. — which all three clients render as a
+  broadcast pill **by scanning content text**, independent of `humans/ais`. That
+  forges an all-hands broadcast that bypasses the `allow_mention_*` capability gate
+  (directed @ is deliberately not capability-gated). **Fix:** skip render when the
+  name hits `isBroadcastLabel` (the clients' own broadcast-label set) **or contains
+  `@`** (the latter also defends the pre-existing WeChat-nickname path that doesn't
+  strip `@`). The uid still routes via `mention.uids`; only the auto-pill is
+  suppressed. Locked by a unit test.
+- **O(n²) prefix recompute (cleanup agent).** The rune budget recomputed
+  `prefix.String()` length each iteration. Switched to incremental `prefixU16`/
+  `prefixRunes` accumulators (note: `strings.Builder.String()` does not allocate —
+  the cost was CPU re-scans, not memory).
+- **Content cap (correctness + security agents).** The rune budget keeps the
+  composed content ≤ `maxContentRunes`; with utf8mb4 emoji names the byte size can
+  be ~4× but stays far below the downstream serialization cap — documented, no
+  byte cap added.
+- **iOS spaced-name pill (cleanup agent).** A name with an internal space (e.g.
+  "Bob Smith") renders fully on web/Android (entity-bound) but iOS — which ignores
+  entities and re-parses `@\S+` positionally — shows a pill truncated at the first
+  space; the tap still binds to the correct uid by position. Documented as the same
+  accepted iOS behavior as #449, not a mis-binding.
+- **Markdown-in-name injection (security agent).** The composed `@<name>`
+  replicates exactly what clients already write into content for any @-mention, so
+  it adds no novel surface; the render layer (`rehypeSanitize` + `isSafeUrl`) is the
+  controlling boundary. Not escaped server-side (would diverge from how the same
+  name renders everywhere else). The WeChat-nickname `@` non-sanitization is a
+  pre-existing `modules/user` gap (out of scope here); the render `@`-skip guard
+  defends this module regardless.
+- Correctness agent: **clean** (`[]`) on the db JOIN/type change, the budget/offset
+  math, and the render↔caller-entities mutual exclusion + routing.
+
+## octospec rules injected (see context.yaml)
+- **trust-boundary** (load-bearing): name from server-side member data; forged-
+  broadcast guard; render-side sanitization is the boundary.
+- **space-isolation** (load-bearing): names resolved only for current internal
+  members of the group; non-members drop silently.
+- **error-handling** (load-bearing): no new codes / raw responses; render is a
+  request-only, non-fatal field.
+- **testing**: pure + integration tests proportional to the trust-boundary risk.
+
+## Verification
+- `go test ./modules/incomingwebhook/ -count=1` → PASS (live MySQL/Redis/WuKongIM)
+- `go vet` clean; `golangci-lint run ./modules/incomingwebhook/...` → 0 issues
+
+## Lessons
+- **A caller-influenced value spliced into content can re-enter a sibling
+  protocol.** The broadcast literal was safe *as a constant*; routing `user.name`
+  through the same prepend re-introduced the literal from attacker-selectable data
+  and re-collided with the broadcast token scan. When generating content that
+  another layer re-parses (clients scan text for broadcast tokens), guard the
+  generated text against that layer's reserved vocabulary.
+- **The cross-client render contract is the spec for server-generated content.**
+  Because web binds by offset, Android validates, and iOS re-parses `@\S+`
+  positionally, the server must emit a single-token `@name` (no internal-space
+  guarantees) and UTF-16 offsets — the same constraints that made the broadcast
+  literals space-free.
+- `buildMention` (returning content+mention directly) is again the reliable test
+  seam — broadcast-only cases need no infra; render/entity cases seed
+  `group_member` + a `user` row for the `user.name` JOIN.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -14,6 +14,16 @@ change-log convention (§7). Newest first.
   length. Text-path only; routing / red-dot / bot-summon unchanged. Brief +
   context + journal under `.octospec/tasks/incoming-webhook-mention-broadcast/`
   and `.octospec/journal/shared/incoming-webhook-mention-broadcast.md`.
+- **Add** — Task `incoming-webhook-mention-directed-render` (#448 item ① b):
+  opt-in server-side directed @mention name-resolution. `mention.render:true`
+  resolves each member uid → `user.name`, prepends `@<name> ` to text content, and
+  generates the UTF-16 `mention.entities`. Refactored the broadcast compose into one
+  `composeMentionContent`. Adversarial review added a forged-broadcast guard (skip
+  names that are broadcast labels or contain `@`), incremental budget tracking, and
+  cap/iOS/byte-size docs. Ships in the same PR as the broadcast half (#450) → the
+  two close #448. Brief + context + journal under
+  `.octospec/tasks/incoming-webhook-mention-directed-render/` and
+  `.octospec/journal/shared/incoming-webhook-mention-directed-render.md`.
 
 ## 2026-06-23
 

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,17 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-06-24
+
+- **Add** — Task `incoming-webhook-mention-broadcast` (#448 item ②): broadcast-pill
+  auto-compose on the native incoming-webhook push endpoint. When a permitted
+  `mention.all`/`mention.bots` is set, the server prepends the canonical broadcast
+  literal (`@所有人`/`@所有AI`) + a space to the text content so all three clients
+  render a pill; directed-entity (#449) offsets shift by the prefix's UTF-16
+  length. Text-path only; routing / red-dot / bot-summon unchanged. Brief +
+  context + journal under `.octospec/tasks/incoming-webhook-mention-broadcast/`
+  and `.octospec/journal/shared/incoming-webhook-mention-broadcast.md`.
+
 ## 2026-06-23
 
 - **Add** — Task `upstream-dep-metrics` (#440 P0-a): upstream-dependency

--- a/.octospec/tasks/incoming-webhook-mention-broadcast/brief.md
+++ b/.octospec/tasks/incoming-webhook-mention-broadcast/brief.md
@@ -1,0 +1,138 @@
+---
+type: Task
+title: "Task: incoming-webhook-mention-broadcast"
+description: Auto-compose the visible broadcast pill (@所有人 / @所有AI) into native incoming-webhook text content when the capability-gated broadcast flag is set, so all three clients render a pill instead of only firing the red-dot.
+tags: ["incomingwebhook", "mention", "wire-contract", "trust-boundary", "render-layer"]
+timestamp: 2026-06-24T06:30:00Z
+# --- octospec extension fields ---
+slug: incoming-webhook-mention-broadcast
+upstream: Mininglamp-OSS/octo-server#448
+source: self
+---
+
+# Task: incoming-webhook-mention-broadcast
+
+> Follow-up to incoming-webhook-mention (#445 functional layer, #449 directed
+> entities). This is the deferred **broadcast** half of #448 item ②.
+
+## Goal
+
+When a native incoming-webhook push sets `mention.all` (@所有人 / humans) or
+`mention.bots` (@所有AI / ais) **and** the per-webhook capability bit is permitted
+(`broadcastPermitted`), the server **prepends the canonical broadcast literal**
+(`@所有人` for humans, `@所有AI` for ais) + a trailing space to the **text**
+content, so every client renders a visible broadcast pill.
+
+Today (#445) those flags fire the red-dot / notify / bot-summon but render **no
+pill** unless the caller also writes the literal into `content` (the #448 item ②
+gap). This task closes that gap at the render layer only — routing semantics
+(`humans`/`ais` flags, red-dot, bot expansion) are untouched.
+
+## Background
+
+- **#448 item ②** ("Broadcast ergonomics"): `mention.all` / `mention.bots`
+  "fires the notify/bot but renders no pill unless the caller also writes
+  `@所有人` / `@所有AI` into `content`. Option: backend auto-prepends the fixed
+  broadcast strings when the capability-gated flag is set." This task takes that
+  option.
+- **Cross-client analysis** (posted on #448; re-verified against the three
+  client repos): **all three clients require the broadcast literal to be present
+  in the content text to render a pill — none fabricate a pill from the flag
+  alone.**
+  - iOS `WKMentionService.parseMention` regex-scans `content` for a
+    locale-independent broadcast-label set; absent literal → no token.
+  - Android `WKUIChatMsgItemEntity` uses the flags (`mentionAll==1` /
+    `mentionHumans==1` / `mentionAis==1`) only to **gate** an `indexOf`
+    highlight of a literal **already in content**; absent literal → no pill.
+  - Web `buildMessageMentions` synthesizes a `{name:"@所有人",uid:"all"}` render
+    entry from the flag, but `MarkdownContent.segmentText` only styles it where
+    the **name matches the content text** (regex over `content`); absent literal
+    → inert entry, no pill.
+- **Canonical literals**: `@所有人` (humans), `@所有AI` (ais) — confirmed by
+  Android `strings.xml` (`所有人` / `所有AI`) and the iOS/Android hardcoded
+  locale-independent token sets. Clients also recognize English aliases
+  (`@All People` / `@All AIs` / `@all`) on **read**, but the canonical token the
+  pickers **insert** is the Chinese one; the server emits the Chinese canonical.
+- **Capability gate** is already computed in `handlePush`
+  (`broadcastPermitted = settings.IncomingWebhookMemberCanBroadcast() ||
+  creatorIsAdmin`) and applied in `assembleMention`
+  (`AllowMentionAll==1 && broadcastPermitted`, same for bots). Auto-compose must
+  fire **only** for a flag that survives that gate — a flag reported in
+  `mention_ignored` must NOT compose a pill.
+- **Trailing space is mandatory**: Android's highlight skips a hit whose next
+  char is a letter/digit/`_` (CJK counts as a letter, so `@所有人执行` would be
+  skipped); iOS `@\S+`/`\b` and web regex also need the delimiter. A single ASCII
+  space delimits the token from the following text.
+- **Coexistence with directed entities (#449)**: web and Android bind directed
+  pills by **UTF-16 offset**. Prepending text shifts the content, so every
+  surviving directed-entity offset must be increased by the prepended prefix's
+  **UTF-16 code-unit** length. iOS binds directed mentions **positionally** and
+  skips broadcast tokens for the `uids` index, so iOS is unaffected either way.
+
+## Load-bearing list
+
+- **wire-contract** — only the text `content` and the existing
+  `mention.{humans,ais,entities}` keys are touched. The prepended token is the
+  exact canonical literal the clients parse; no new wire field. With no broadcast
+  flag set (or none permitted), `content` and the payload are **byte-identical**
+  to today.
+- **trust-boundary / external-content / webhook** — the push endpoint is an
+  attacker-controlled, token-in-URL ingress. The prepend is **server-controlled
+  fixed text** (a compile-time constant; the caller only flips a boolean), gated
+  by the per-webhook capability bit. The literal contains no markdown/regex
+  metacharacters, so it adds no injection/escape surface (trust-boundary escape
+  rule still satisfied — structured token, not caller-rendered markdown).
+- **broadcast capability gate** — compose fires only when the flag survives
+  `AllowMention* == 1 && broadcastPermitted`; an un-permitted (ignored) flag must
+  not compose a pill (no pill for a broadcast that did not route).
+- **render-layer / entities offset consistency (#449)** — prepending shifts
+  `content`; directed-entity offsets emitted by `finalizeEntities` must shift by
+  the prefix's UTF-16 length so web/Android keep binding the right member; the
+  `'@'` anchor still holds at `offset+prefixLen` because a prepend only moves
+  text rightward.
+- **adapter parity (native-only)** — compose only on the native path
+  (`ad.allowMention`); sibling adapters (wecom/feishu/github/gitlab/multica)
+  neither set the flags nor compose.
+- existing push pipeline (auth → rate-limit → group-active → creator-membership
+  → length cap → audit) and the `richtext` path must be unaffected except the
+  new text-path content prepend.
+
+## Out of scope
+
+- **Richtext broadcast pills** — compose is **text-path only** (mirrors entities,
+  which are text-only); the richtext path keeps today's flags-only behavior
+  (humans/ais set, no literal). A future task can add block-level broadcast pills.
+- **i18n / English-alias canonicalization of the inserted literal** — the server
+  always emits the Chinese canonical (`@所有人` / `@所有AI`), which every client
+  recognizes locale-independently. No per-locale token.
+- **De-dup against caller-written English aliases** — idempotency checks only the
+  canonical literal. A caller that both writes an English alias (`@all`) AND sets
+  the flag may see a minor double-pill; documented, not handled (keeps the server
+  decoupled from the clients' alias list).
+- **Routing semantics** — red-dot / notify / bot-summon / `ExpandAisToBotUIDs`
+  are unchanged; this is purely the visible render layer.
+- Name resolution; directed-uid / entities validation behavior (#445/#449).
+
+## Acceptance
+
+- `all=true` + `allow_mention_all` permitted + literal absent → delivered
+  `content == "@所有人 " + original`; `mention.humans == 1`.
+- `bots=true` + `allow_mention_bots` permitted + literal absent → `content`
+  prepended `"@所有AI "`; `mention.ais == 1`.
+- both permitted + both absent → `content` prepended `"@所有人 @所有AI "`
+  (humans first).
+- flag set but **not** permitted (capability off) → `content` unchanged, no
+  prepend, flag still surfaced in `mention_ignored` (existing behavior), no pill.
+- idempotency: canonical literal already present in `content` → that token is
+  **not** prepended again (exactly one occurrence remains).
+- directed entities (#449) coexisting with a prepend → every surviving entity
+  `offset` is increased by the prefix's UTF-16 length, and the entity still
+  anchors a `'@'` in the final content (parity test with an emoji/CJK prefix).
+- `richtext` path with broadcast flags → no content prepend (no top-level
+  `content` key mutated); `humans`/`ais` still set.
+- no broadcast flag / flags unset → `content` byte-identical to today (backward
+  compatibility with existing native callers, incl. directed-only and plain).
+- non-native adapter with broadcast fields → no compose.
+- `go test ./modules/incomingwebhook/...` passes incl. new broadcast tests +
+  `TestIncomingWebhookNoLegacyResponseError`; `golangci-lint run
+  ./modules/incomingwebhook/...` clean (govet, the CI gate).

--- a/.octospec/tasks/incoming-webhook-mention-broadcast/context.yaml
+++ b/.octospec/tasks/incoming-webhook-mention-broadcast/context.yaml
@@ -1,0 +1,44 @@
+slug: incoming-webhook-mention-broadcast
+rules_injected:
+  - id: trust-boundary
+    tier: repo
+    load_bearing: true
+    why: incomingwebhook push is attacker-controlled ingress; the prepended broadcast
+         literal is a server-controlled compile-time CONSTANT (@所有人/@所有AI) with no
+         markdown/regex metacharacters — the caller only flips a boolean flag, so no new
+         escape/injection surface; compose is gated to the native adapter (parity preserved:
+         siblings neither set the flags nor compose) and bounded (~11 UTF-16 units max).
+  - id: error-handling
+    tier: repo
+    load_bearing: true
+    why: no new error codes; compose is non-fatal render-layer text and never produces an
+         error response; an un-permitted flag keeps its existing non-fatal mention_ignored
+         200-body feedback. No legacy/raw responses added (NoLegacyResponseError guard holds).
+  - id: space-isolation
+    tier: repo
+    load_bearing: true
+    why: compose adds no new identity/data access — it touches only content text and the
+         already-gated humans/ais flags; the member gate / Space scoping from #445/#449 is
+         unchanged.
+  - id: testing
+    tier: repo
+    load_bearing: false
+    why: new mention_broadcast_test.go (pure compose unit tests) + entity offset-shift parity
+         in mention_entities_test.go + e2e cases in mention_e2e_test.go; extend
+         TestIncomingWebhookNoLegacyResponseError file list if a new handler file is added
+         (none expected — compose lives in mention.go).
+  - id: commit-style
+    tier: repo
+    load_bearing: false
+    why: Conventional Commits, English.
+files_touched:
+  - modules/incomingwebhook/mention.go          # composeBroadcastContent + constants; buildMention returns composed content; finalizeEntities baseOffset shift
+  - modules/incomingwebhook/api.go              # handlePush: consume composed content into payload[content] (text path)
+  - modules/incomingwebhook/mention_broadcast_test.go  # NEW: compose unit tests (gate/idempotency/order/trailing-space/text-only)
+  - modules/incomingwebhook/mention_entities_test.go   # entity offset-shift (baseOffset) parity + emoji/CJK prefix
+  - modules/incomingwebhook/mention_e2e_test.go        # e2e: pill prepended; not-permitted no-prepend; richtext no-prepend; backward-compat byte-identical
+parity_decisions:
+  - "Canonical broadcast literals @所有人 (humans) / @所有AI (ais) confirmed against octo-ios WKMentionService.m, octo-android WKUIChatMsgItemEntity.java + strings.xml, octo-web mentionRender.ts/MarkdownContent.tsx — all three require the literal in content text to render a pill (none fabricate from the flag)."
+  - "Trailing ASCII space after the literal is mandatory: Android skips a highlight whose next char is letter/digit/_ (CJK is a letter); iOS @\\S+/\\b and web regex need the delimiter."
+  - "Directed-entity (#449) offsets are UTF-16 code units and bound authoritatively on web/Android; a prepend shifts them by the prefix's UTF-16 length (finalizeEntities baseOffset). iOS binds positionally and skips broadcast tokens for the uids index → unaffected."
+  - "Compose is text-path only (mirrors entities); richtext keeps flags-only behavior. Routing (red-dot/notify/ExpandAisToBotUIDs) unchanged — pure render layer."

--- a/.octospec/tasks/incoming-webhook-mention-directed-render/brief.md
+++ b/.octospec/tasks/incoming-webhook-mention-directed-render/brief.md
@@ -118,8 +118,12 @@ server emits (existing wire fields only — zero client change):
   `maxContentRunes`.
 - **forged-broadcast guard** (adversarial-review hardening): a member whose display
   name is a broadcast label (`所有人`/`所有AI`/`All People`/`All AIs`/`all`,
-  case-insensitive) or contains `@` is **skipped** for render — else `@<name>`
+  case-insensitive), **or starts with one at a non-word boundary** (e.g. `所有人 X`
+  / `所有人:` / `all-hands` — iOS `@\S+` would emit a standalone `@所有人`/`@all`
+  broadcast token), or contains `@`, is **skipped** for render — else `@<name>`
   would render as a broadcast pill and bypass the `allow_mention_*` capability gate
   (or break client `@`-tokenization); the uid still routes via `mention.uids`.
+  Names that merely continue a label into a longer word (`所有人事部`, `allen`) still
+  render (boundary check, not prefix match).
 - `go test ./modules/incomingwebhook/...` passes incl. new render tests +
   `TestIncomingWebhookNoLegacyResponseError`; `golangci-lint` clean.

--- a/.octospec/tasks/incoming-webhook-mention-directed-render/brief.md
+++ b/.octospec/tasks/incoming-webhook-mention-directed-render/brief.md
@@ -1,0 +1,125 @@
+---
+type: Task
+title: "Task: incoming-webhook-mention-directed-render"
+description: Opt-in server-side resolution of directed mention.uids into visible @name pills (resolve display name → compose into content → generate UTF-16 entities) on the native incoming-webhook push endpoint.
+tags: ["incomingwebhook", "mention", "wire-contract", "trust-boundary", "render-layer"]
+timestamp: 2026-06-24T08:00:00Z
+# --- octospec extension fields ---
+slug: incoming-webhook-mention-directed-render
+upstream: Mininglamp-OSS/octo-server#448
+source: self
+---
+
+# Task: incoming-webhook-mention-directed-render
+
+> #448 item ① option (b). Ships in the SAME PR as the broadcast half
+> (`incoming-webhook-mention-broadcast`), reusing its compose/offset machinery;
+> together they close #448.
+
+## Goal
+
+Let a native incoming-webhook caller render a directed `@member` pill by sending
+**only the uid** — the server resolves the member's display name, composes
+`@<name>` into the text content, and **generates** the matching UTF-16
+`mention.entities` element. Today (#449) the caller must supply the `@name` text
+and the offsets itself; this does it server-side.
+
+Opt-in via `mention.render` (default off) so existing #445 callers that send
+`mention.uids` purely for red-dot/bot routing keep their content untouched.
+
+Target shape — caller sends:
+```json
+{ "content": "执行吧", "mention": { "uids": ["27o…_bot"], "render": true } }
+```
+server emits (existing wire fields only — zero client change):
+```json
+{ "content": "@我的天 执行吧",
+  "mention": { "uids": ["27o…_bot"],
+    "entities": [{ "uid": "27o…_bot", "offset": 0, "length": 4 }] } }
+```
+
+## Background
+
+- **#448 item ①** asks for directed-@ label/uid consistency, with option (b):
+  "backend resolves uid→display name and composes/validates the `@name` text,
+  optionally adding `entities`." This task is option (b).
+- **Client send-side grounding** (octo-web `mentionSendParse.ts`): when a user @s
+  a member, the client emits `content` containing `@<displayName>` inline +
+  `entities.push({uid, offset, length})` (offset = UTF-16 position) + `uids`.
+  The server must **generate the same shape** for a bare uid.
+- **Display name source**: the group module resolves a member's shown name via
+  `LEFT JOIN user … IFNULL(user.name,'')` (see `modules/group/db.go`). v1 uses
+  that `user.name`. `remark` is viewer-specific (a webhook has no viewer; the
+  composed literal is shown to all recipients as-is) and the verified-`real_name`
+  override is a space-member-list refinement (#344) — both out of scope for v1.
+- **Shared machinery**: reuses the broadcast half's prefix-compose + UTF-16
+  offset handling. The two prepends compose in one pass: broadcast literals
+  first, then directed `@name`s, then the original content; generated directed
+  entities carry offsets into that combined prefix.
+
+## Load-bearing list
+
+- **wire-contract** — output uses only existing fields (`content`, `mention.uids`,
+  `mention.entities`); `mention.render` is a new **request-only** boolean (does
+  not reach the wire / clients). With `render` off, output is byte-identical to
+  today.
+- **trust-boundary / external-content / webhook** — the composed `@name` text is
+  **derived from server-side group data** (the member's `user.name`), not from
+  caller-controlled strings, and only for uids that pass the existing member
+  gate; the only caller input is the boolean flag + the uid list (already gated).
+  No markdown/regex metacharacters are introduced by the server (the `@` + name +
+  space are inserted literally; the name is group data, same as any rendered
+  message author name).
+- **space / isolation** — names are resolved ONLY for current internal-normal
+  members of the webhook's `group_no` (same gate as #445/#449); a token cannot
+  resolve or render a cross-group / cross-Space identity.
+- **render-layer offset consistency** — generated entity offsets are **UTF-16
+  code units** into the final content; when broadcast literals also prepend, the
+  directed offsets account for the broadcast prefix length.
+- **content length cap** — directed render can prepend up to `maxMentionUIDs`
+  (50) `@name` tokens; the compose stops adding names once the composed content
+  would exceed `maxContentRunes`, so the cap stays authoritative (remaining uids
+  still route via `mention.uids`, just without a pill).
+- existing push pipeline + the `richtext` path must be unaffected (render is
+  text-path only).
+
+## Out of scope
+
+- **Inline placement / placeholder grammar** — v1 prepends `@name`s at the
+  content head (matches the example); a caller-controlled inline position is a
+  later option.
+- **`remark` / verified-`real_name` precedence** — v1 uses the group member
+  `user.name`; richer display-name precedence (incl. the #344 chain) is deferred.
+- **Richtext** directed render (text path only, mirrors entities/broadcast).
+- **Caller-supplied `entities` coexisting with `render`** — if the caller sends
+  `entities`, they are authoritative (#449) and `render` is ignored (no
+  auto-generation); the two are mutually exclusive per push.
+- Routing semantics (red-dot / notify / `ExpandAisToBotUIDs`) — unchanged; the
+  directed uids still populate `mention.uids` for routing.
+
+## Acceptance
+
+- `render:true` + `uids:[member]` + member name resolves → delivered
+  `content == "@<name> " + original`; `mention.entities` has one element
+  `{uid, offset:0, length: utf16Len("@<name>")}`; `mention.uids` still carries
+  the uid (routing unchanged).
+- multiple member uids → prepended in caller order; each entity offset points at
+  its own `@` in the final content (UTF-16).
+- `render:true` but a uid is a non-member / has an empty name → that uid is
+  skipped silently (no `@ ` pill), still routed via `mention.uids`.
+- `render` absent/false → content byte-identical to today; no entities generated
+  (full backward compatibility with #445/#449 callers).
+- `render:true` AND caller-supplied `entities` → caller entities win; no
+  auto-generation (they may still shift if a broadcast literal prepends).
+- `render:true` + broadcast permitted → `content == "@所有人 …" + "@<name> " +
+  original`; broadcast literals first, directed `@name`s after, offsets correct.
+- richtext push with `render:true` → no content compose, no generated entities.
+- compose stops adding `@name`s before the composed content exceeds
+  `maxContentRunes`.
+- **forged-broadcast guard** (adversarial-review hardening): a member whose display
+  name is a broadcast label (`所有人`/`所有AI`/`All People`/`All AIs`/`all`,
+  case-insensitive) or contains `@` is **skipped** for render — else `@<name>`
+  would render as a broadcast pill and bypass the `allow_mention_*` capability gate
+  (or break client `@`-tokenization); the uid still routes via `mention.uids`.
+- `go test ./modules/incomingwebhook/...` passes incl. new render tests +
+  `TestIncomingWebhookNoLegacyResponseError`; `golangci-lint` clean.

--- a/.octospec/tasks/incoming-webhook-mention-directed-render/context.yaml
+++ b/.octospec/tasks/incoming-webhook-mention-directed-render/context.yaml
@@ -1,0 +1,44 @@
+slug: incoming-webhook-mention-directed-render
+rules_injected:
+  - id: trust-boundary
+    tier: repo
+    load_bearing: true
+    why: webhook push is attacker-controlled ingress. The composed "@<name>" name comes from
+         server-side group data (user.name of a CURRENT internal-normal member), not caller strings —
+         the caller only supplies the boolean render flag + the (member-gated) uid list. ADVERSARIAL
+         REVIEW HARDENING:a member display name that is itself a broadcast label (所有人/所有AI/
+         All People/All AIs/all) or contains '@' is SKIPPED, else "@<name>" would render as a forged
+         @所有人/@所有AI broadcast pill bypassing the allow_mention_* capability gate. Render-side
+         sanitization (web rehypeSanitize + isSafeUrl) remains the boundary for markdown in names —
+         identical to how any @-mention / message author name is already rendered (no new surface).
+  - id: space-isolation
+    tier: repo
+    load_bearing: true
+    why: names resolved ONLY for current internal-normal members of the webhook's group_no (same gate
+         as #445/#449; LEFT JOIN user only adds the name column, does not widen the row set). A token
+         cannot resolve/render a cross-group or cross-Space identity; non-members drop silently.
+  - id: error-handling
+    tier: repo
+    load_bearing: true
+    why: no new error codes; render is non-fatal render-layer text (never an error response). render is
+         a request-only field, not on the wire; NoLegacyResponseError guard holds (no new handler file).
+  - id: testing
+    tier: repo
+    load_bearing: false
+    why: pure composeMentionContent directed tests (order / skip / idempotency / budget / broadcast-combo /
+         broadcast-label+@ guard) + integration via buildMention with seeded group_member + user rows.
+  - id: commit-style
+    tier: repo
+    load_bearing: false
+    why: Conventional Commits, English.
+files_touched:
+  - modules/incomingwebhook/model.go        # mentionReq.Render request flag (opt-in)
+  - modules/incomingwebhook/db.go           # filterGroupMembers → map[uid]name (LEFT JOIN user.name)
+  - modules/incomingwebhook/mention.go      # composeMentionContent (unified broadcast+directed+budget+guard); buildMention render wiring
+  - modules/incomingwebhook/mention_directed_render_test.go  # NEW pure + integration tests
+  - modules/incomingwebhook/mention_broadcast_test.go        # compose tests updated to composeMentionContent
+parity_decisions:
+  - "Display name source = user.name via group_member LEFT JOIN user (IFNULL(user.name,'')), matching modules/group's member-list resolution. remark (viewer-specific) and verified-real_name (#344 space-list refinement) are out of scope for v1."
+  - "Generated entity shape {uid,offset,length} (UTF-16) mirrors what octo-web mentionSendParse emits when a user @s a member — so the server-rendered directed @ is wire-identical to a client-sent one (web offset-authoritative, Android validates, iOS positional)."
+  - "render is opt-in (default off) and NOT capability-gated — directed @ is not a broadcast; it is bounded by the member gate. Broadcast flags (humans/ais) remain capability-gated and independent."
+  - "Adversarial-review hardening (3 finder agents): forged-broadcast guard (name==broadcast label / contains '@'); O(n²)→incremental prefix length tracking; rune budget keeps composed content ≤ maxContentRunes (utf8mb4 byte size ≤~4× but well under serialization cap, documented); iOS truncates spaced-name pill text but still binds by position (documented, == #449). WeChat-nickname '@' non-sanitization is a PRE-EXISTING modules/user gap (out of scope); the render '@'-skip guard defends this module regardless."

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -1328,8 +1328,16 @@ func (w *IncomingWebhook) handlePush(c *wkhttp.Context, ad pushAdapter) {
 		// 关掉设置即把全部【成员】创建的 webhook 的广播位立即剥离；管理员建的不受影响。
 		// 定向 @uid 不走此闸（不是广播、风险低）。
 		broadcastPermitted := w.settings.IncomingWebhookMemberCanBroadcast() || creatorIsAdmin
-		mention, ignored := w.buildMention(m, req, broadcastPermitted)
+		mention, content, ignored := w.buildMention(m, req, broadcastPermitted)
 		mentionIgnored = ignored
+		// 广播补文案可能在 content 文首前置了 @所有人/@所有AI（仅 text 路径）。仅当 content 确被
+		// 改写（!= req.Content）才回写 payload[content]，使前置后的正文进入 wire。
+		// 这个守卫【必须保留】：richtext 路径 payload[content] 存的是 blocks 数组（buildRichTextPayload），
+		// 而 buildMention 对 richtext 不补文案（content==req.Content）→ 守卫为假、不覆盖，数组得以保全；
+		// 去掉守卫会把数组覆盖成字符串、毁掉富文本消息。无补文案时同样不触发覆盖，payload 字节不变。
+		if content != req.Content {
+			payload[payloadContentKey] = content
+		}
 		if mention != nil {
 			payload[mentionrewrite.MentionKey] = mention
 			// 与 message/robot/bot_api 入口一致：在 clone 上做 ais→bot uid 展开，避免就地
@@ -1398,6 +1406,12 @@ func truncateUTF8(s string, max int) string {
 	return ""
 }
 
+// payloadContentKey 是群消息 payload 的正文键。抽成常量是因为有【两个】写点必须一致：
+// buildPayload（text 路径初次写入）与 handlePush 的广播补文案回写——后者写到一个错键会让
+// 前置的 @所有人/@所有AI 静默不进 wire（气泡永不出现），编译器不会报错。用同一常量把这层
+// 耦合交给编译器，免去手写「与 buildPayload 一致」的口头不变量。
+const payloadContentKey = "content"
+
 // buildPayload 把 webhook 请求映射到群消息 payload。
 //   - WuKongIM 只有 Text 类型，所有 webhook 消息都用 Text(1) 投递。
 //   - 注入 from.kind=webhook 元信息，便于客户端识别非真实用户消息；
@@ -1414,8 +1428,8 @@ func truncateUTF8(s string, max int) string {
 func buildPayload(m *incomingWebhookModel, req *pushPayloadReq, allowOverride bool) map[string]interface{} {
 	name, avatar := resolveFromIdentity(m, req, allowOverride)
 	return map[string]interface{}{
-		"type":    int(common.Text),
-		"content": req.Content,
+		"type":            int(common.Text),
+		payloadContentKey: req.Content,
 		"from": map[string]interface{}{
 			"kind":       extraKindValue,
 			"webhook_id": m.WebhookID,

--- a/modules/incomingwebhook/db.go
+++ b/modules/incomingwebhook/db.go
@@ -199,36 +199,48 @@ func (d *incomingWebhookDB) queryMemberRole(groupNo, uid string) (isMember, isAd
 	return true, roles[0] == group.MemberRoleCreator || roles[0] == group.MemberRoleManager, nil
 }
 
-// filterGroupMembers 返回 uids 中【当前是 groupNo 内部正常成员】的子集（成员闸）。
-// 用于 push 路径的定向 @ 校验：webhook token 是写进 CI/平台配置的低信任共享密钥，必须
-// 把 @ 目标收敛到本群成员，杜绝「泄露的 token @ 任意平台用户 / 跨 Space 身份」以及借
-// 「@<uid> 是否被保留」探测成员归属。成员定义与 queryMemberRole 同口径（is_deleted=0
-// + is_external=0 + status=Normal）——外部成员在 v1 刻意不可被 @（空间隔离保守取舍）。
+// filterGroupMembers 返回 uids 中【当前是 groupNo 内部正常成员】的子集,映射到各自的
+// 展示昵称(uid → user.name)。返回值【既是成员闸又是昵称表】:key 存在 = 是本群成员
+// (assembleMention / finalizeEntities 只看 key 判归属),value = 昵称(仅 mention.render 的
+// 定向 @气泡渲染用,可能为空串——未 join 到 user 行时)。
 //
-// 直接点读 group_member 表（与 queryMemberRole 一致，该表已是跨模块既有读取面），用
-// IN 一次取回命中子集；uids 由调用方先去重并钳到上限，IN 列表有界。空入参短路返回。
+// 用于 push 路径的定向 @ 校验:webhook token 是写进 CI/平台配置的低信任共享密钥,必须
+// 把 @ 目标收敛到本群成员,杜绝「泄露的 token @ 任意平台用户 / 跨 Space 身份」以及借
+// 「@<uid> 是否被保留」探测成员归属。成员定义与 queryMemberRole 同口径(is_deleted=0
+// + is_external=0 + status=Normal)——外部成员在 v1 刻意不可被 @(空间隔离保守取舍)。
 //
-// ⚠️ 与 @所有 AI 的非对称是【有意】的：定向 @uid 走本闸、排除外部成员（保守）；而
-// @所有 AI(ais) 的 bot 展开走 fetchBotMemberUIDs→GetMembers，与 message/bot_api 入口
-// 同源、只排除已删成员（故可能含外部 bot 成员）——广播侧取 parity。两条路径都不越群/
-// 越 Space（都以本群成员为界，外部 bot 也确是本群成员），差异仅是「定向保守 vs 广播对齐
-// 其它入口」的取舍，非遗漏。
-func (d *incomingWebhookDB) filterGroupMembers(groupNo string, uids []string) (map[string]struct{}, error) {
-	out := make(map[string]struct{}, len(uids))
+// 昵称口径与群成员列表一致:LEFT JOIN user → IFNULL(user.name,”)(见 group/db.go 的
+// queryMembers*)。LEFT JOIN 不影响成员判定(只 group_member 的 WHERE 决定行集),仅补昵称;
+// 未 join 到 user 行(如某些 bot)→ 空串,render 侧据此跳过、绝不渲染 "@ "。uids 由调用方
+// 先去重并钳到上限,IN 列表有界。空入参短路返回。
+//
+// ⚠️ 与 @所有 AI 的非对称是【有意】的:定向 @uid 走本闸、排除外部成员(保守);而
+// @所有 AI(ais) 的 bot 展开走 fetchBotMemberUIDs→GetMembers,与 message/bot_api 入口
+// 同源、只排除已删成员(故可能含外部 bot 成员)——广播侧取 parity。两条路径都不越群/
+// 越 Space(都以本群成员为界,外部 bot 也确是本群成员),差异仅是「定向保守 vs 广播对齐
+// 其它入口」的取舍,非遗漏。
+func (d *incomingWebhookDB) filterGroupMembers(groupNo string, uids []string) (map[string]string, error) {
+	out := make(map[string]string, len(uids))
 	if groupNo == "" || len(uids) == 0 {
 		return out, nil
 	}
-	var got []string
-	_, err := d.session.Select("uid").From("group_member").
-		Where("group_no=?", groupNo).
-		Where("uid in ?", uids).
-		Where("is_deleted=0 AND is_external=0 AND status=?", int(common.GroupMemberStatusNormal)).
+	type memberRow struct {
+		UID  string `db:"uid"`
+		Name string `db:"name"`
+	}
+	var got []memberRow
+	_, err := d.session.Select("group_member.uid", "IFNULL(user.name,'') AS name").
+		From("group_member").
+		LeftJoin("user", "group_member.uid=user.uid").
+		Where("group_member.group_no=?", groupNo).
+		Where("group_member.uid in ?", uids).
+		Where("group_member.is_deleted=0 AND group_member.is_external=0 AND group_member.status=?", int(common.GroupMemberStatusNormal)).
 		Load(&got)
 	if err != nil {
 		return nil, err
 	}
-	for _, u := range got {
-		out[u] = struct{}{}
+	for _, r := range got {
+		out[r.UID] = r.Name
 	}
 	return out, nil
 }

--- a/modules/incomingwebhook/mention.go
+++ b/modules/incomingwebhook/mention.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"unicode"
 	"unicode/utf16"
 	"unicode/utf8"
 
@@ -75,10 +76,30 @@ var broadcastLabels = map[string]struct{}{
 	"所有人": {}, "所有ai": {}, "all": {}, "all people": {}, "all ais": {},
 }
 
-// isBroadcastLabel 报告 name（trim+小写后）是否命中端上广播标签集。
-func isBroadcastLabel(name string) bool {
-	_, ok := broadcastLabels[strings.ToLower(strings.TrimSpace(name))]
-	return ok
+// isBroadcastLikeName 报告 name（trim+小写后）会不会被端上当成广播 token——不止【精确】命中标签集,
+// 还包括「以广播标签开头、其后紧跟非字边界」。因为 iOS 按 @\S+ 切词:名 "所有人 X" 会切出独立
+// token "@所有人"、名 "所有人:" 同理,都会渲染成广播气泡(伪造一次绕过 allow_mention_* 的全员广播)。
+// 仅当标签后紧跟字母/数字/CJK 时(如 "所有人事部"/"allen")才是另一个真实词、不算广播,照常渲染定向气泡。
+// 单字标签(所有人/所有ai/all)即覆盖多字标签(all people/all ais)的边界,因 iOS 首个 @\S+ token 止于空格。
+func isBroadcastLikeName(name string) bool {
+	n := strings.ToLower(strings.TrimSpace(name))
+	if n == "" {
+		return false
+	}
+	for label := range broadcastLabels {
+		if !strings.HasPrefix(n, label) {
+			continue
+		}
+		rest := n[len(label):]
+		if rest == "" {
+			return true // 精确命中
+		}
+		// 标签后紧跟非字（字母/数字/CJK 之外）→ 端上会把 "@<label>" 切成独立广播 token。
+		if r, _ := utf8.DecodeRuneInString(rest); !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			return true
+		}
+	}
+	return false
 }
 
 // utf16Len 返回 s 的 UTF-16 码元长度（= JS String.length / NSString length / Kotlin
@@ -104,9 +125,10 @@ func utf16Len(s string) int {
 // 不变量与边界：
 //   - prefixU16 供调用方把【调用方自带】的 entities(#449) 整体右移（前置改变了 content）；render
 //     与自带 entities 互斥，故二者不会同时出现。
-//   - 防伪造广播：昵称命中端上广播标签集（isBroadcastLabel）或含 '@'（WeChat 昵称路径不过滤 @）时
-//     【跳过】render——否则 "@<昵称>" 会被端上当成 @所有人/@所有AI 广播 token 渲染，伪造一次绕过
-//     allow_mention_* 能力位的全员广播气泡。命中者仍按 uid 路由、只是不出气泡。
+//   - 防伪造广播：昵称会被端上当成广播 token（isBroadcastLikeName：精确命中标签集，或以标签开头且
+//     后接非字边界如 "所有人 X"/"所有人:"——iOS @\S+ 会切出独立 "@所有人"）或含 '@'（WeChat 昵称
+//     路径不过滤 @）时【跳过】render——否则 "@<昵称>" 会被渲染成 @所有人/@所有AI 气泡，伪造一次绕过
+//     allow_mention_* 能力位的全员广播。命中者仍按 uid 路由、只是不出气泡。
 //   - 幂等：广播按 canonical 字面量、定向按 "@<昵称>" 在【原始 content】里 Contains 去重（避免双
 //     气泡）。子串误判（名是另一段文本的前缀，如名 "张" 撞 "@张三"）会保守跳过该气泡、uid 仍路由——可接受。
 //   - 空昵称（非成员/未 join 到 user.name）跳过——绝不补 "@ "。
@@ -142,7 +164,7 @@ func composeMentionContent(content string, wantAll, wantBots, allowAll, allowBot
 			if name == "" {
 				continue // 非成员 / 未解析到昵称 → 不渲染（绝不补 "@ "）
 			}
-			if isBroadcastLabel(name) || strings.Contains(name, "@") {
+			if isBroadcastLikeName(name) || strings.Contains(name, "@") {
 				continue // 防伪造广播 / 嵌入式 @：昵称会被端上当成广播 token 或破坏 @ 分词
 			}
 			atName := "@" + name

--- a/modules/incomingwebhook/mention.go
+++ b/modules/incomingwebhook/mention.go
@@ -44,8 +44,69 @@ func maxMentionUIDs() int {
 	return defaultMaxMentionUIDs
 }
 
+// 三态广播的【中文 canonical】@ 字面量 + 末尾定界空格。
+//
+// 为什么是这两个字面量、为什么必须带空格：
+//   - web/iOS/Android 三端渲染广播气泡都要求 content 文本里【存在】该字面量——没有任何一端
+//     仅凭 mention.humans/ais 标志位凭空合成气泡（web 的 buildMessageMentions 合成的是「若文本
+//     里出现 @所有人 就高亮」的元数据，segmentText 仍按文本匹配；iOS/Android 直接扫 content）。
+//     故服务端在标志位获批时把字面量【前置】到 content，三端即可渲染气泡。
+//   - 端上识别的广播 token 集是 locale-independent 的（中文 @所有人/@所有AI + 英文别名
+//     @All People/@All AIs/@all）；选择器插入、服务端发出的都是【中文 canonical】，所有端都
+//     识别，无需按 locale 切换。
+//   - 末尾空格是【必须】的定界符：Android 高亮命中后会检查下一字符不是字母/数字/_（CJK 视作
+//     字母，"@所有人执行" 会被跳过不高亮）；iOS @\S+/\b、web 正则同样需要定界。
+//   - 这两个 label 与 mentionrewrite.HumansKey/AIsKey 一一对应：标志位驱动路由/红点/bot 展开，
+//     label 驱动可见气泡。label 刻意留在本模块（而非 mentionrewrite）——它是「广播补文案」这个
+//     render 行为的实现细节、目前仅本模块 compose，且三端各自也硬编码同一套 token；mentionrewrite
+//     只拥有 wire key 词汇表（humans/ais/...），不拥有渲染 label。
+const (
+	broadcastTokenAll = "@所有人"  // 真人广播（mention.humans）
+	broadcastTokenAIs = "@所有AI" // AI 广播（mention.ais）
+	broadcastTokenSep = " "     // 定界空格（见上）
+)
+
+// composeBroadcastContent 在【获批】的广播位生效时，把对应的 canonical 广播字面量前置到
+// content，使三端渲染出广播气泡。返回（可能改写后的 content，本次前置前缀的 UTF-16 码元长度）。
+//
+// prefixU16Len 供调用方把定向 entities(#449) 的 offset 整体右移——前置改变了 content 文本，
+// 而 entities 的 offset 是相对 content 的 UTF-16 码元绝对位置，必须同步右移才不会错绑气泡。
+//
+//   - 仅当 want* 且 allow*（= AllowMention*==1 && broadcastPermitted）同时成立才前置；未获批的
+//     广播位不前置（它已进 mention_ignored，没有真正广播、不应出现气泡）。
+//   - 幂等：content 已含该 canonical 字面量则不再前置该 token（否则三端会渲染两个气泡）。用
+//     strings.Contains（任意位置）而非仅前缀：调用方可能把 @所有人 写在句中，仍应避免重复气泡。
+//     （极端误判：文本恰含 "@所有人" 子串如成员名 "@所有人事部" 时会保守地不前置——此时端上同样
+//     不会把该子串当广播 token 高亮，结果一致：无自动气泡、标志位仍照常路由。）
+//   - humans 在前、ais 在后（稳定顺序）。
+//   - 仅文本路径调用（richtext 无顶层 content，调用方据 isTextMention 决定是否调用）。
+//
+// 前缀是服务端定值（≤11 UTF-16 码元）：刻意在 handlePush 的 maxContentRunes 上限校验【之后】追加，
+// 相对默认 4000 上限可忽略、且 8KB body / 序列化上限仍兜底——故不为这点定长前缀重算上限。
+//
+// 不前置任何 token 时返回 (content, 0)——原样字符串、零位移，保证无广播位的历史调用 payload
+// 完全不变（向后兼容）。
+func composeBroadcastContent(content string, wantAll, wantBots, allowAll, allowBots bool) (string, int) {
+	var prefix strings.Builder
+	if wantAll && allowAll && !strings.Contains(content, broadcastTokenAll) {
+		prefix.WriteString(broadcastTokenAll)
+		prefix.WriteString(broadcastTokenSep)
+	}
+	if wantBots && allowBots && !strings.Contains(content, broadcastTokenAIs) {
+		prefix.WriteString(broadcastTokenAIs)
+		prefix.WriteString(broadcastTokenSep)
+	}
+	p := prefix.String()
+	if p == "" {
+		return content, 0
+	}
+	return p + content, len(utf16.Encode([]rune(p)))
+}
+
 // buildMention 把 native 推送请求里的 mentionReq 翻译成消息 payload 的 mention 子对象
-// （线协议 {uids,humans,ais}），返回值可直接挂到 payload[mentionrewrite.MentionKey]。
+// （线协议 {uids,humans,ais,entities}）。返回 (mention, content, ignored)：mention 可直接挂到
+// payload[mentionrewrite.MentionKey]；content 是【可能前置了广播补文案的】正文，调用方据此
+// 覆盖 payload 的 content（无补文案时与 req.Content 全等，payload 字节不变）。
 //
 // 处理（每步都对应 brief 的 acceptance）：
 //  1. 定向 uids：去重 + 钳到上限 → 经群成员闸过滤（只保留本群当前成员），命中集做成
@@ -53,6 +114,8 @@ func maxMentionUIDs() int {
 //  2. @所有人(All)：webhook 的 allow_mention_all 开【且 broadcastPermitted】则写 humans=1，否则记入 ignored。
 //  3. @所有 AI(Bots)：allow_mention_bots 开【且 broadcastPermitted】则写 ais=1（稍后由调用方
 //     ExpandAisToBotUIDs 展开为群内全部 bot 成员 UID），否则记入 ignored。
+//  4. 广播补文案（仅 text 路径）：获批的 all/bots 还会把 canonical 字面量(@所有人/@所有AI)
+//     前置到 content，使三端渲染出可见广播气泡（见 composeBroadcastContent）；未获批不前置。
 //
 // broadcastPermitted 由调用方传入：system_setting member_can_broadcast || 创建者当前为管理员。
 // 关掉该设置即可即时收回所有【成员】创建的 webhook 的广播能力，管理员创建的不受影响。
@@ -66,7 +129,7 @@ func maxMentionUIDs() int {
 //
 // best-effort：成员闸查询失败时降级为「不带定向 @」（仅记 Warn），绝不因此让整条推送失败
 // ——这与 mention 其余环节的「失败即降级、不丢消息」一致。
-func (w *IncomingWebhook) buildMention(m *incomingWebhookModel, req *pushPayloadReq, broadcastPermitted bool) (map[string]interface{}, []string) {
+func (w *IncomingWebhook) buildMention(m *incomingWebhookModel, req *pushPayloadReq, broadcastPermitted bool) (map[string]interface{}, string, []string) {
 	mr, ok := decodeMention(req.Mention)
 	if !ok {
 		// 缺省即无 mention；【存在但畸形】按 acceptance #6 降级为无 mention（消息照投），
@@ -75,8 +138,13 @@ func (w *IncomingWebhook) buildMention(m *incomingWebhookModel, req *pushPayload
 			w.Warn("malformed mention payload ignored; delivering message without mention",
 				zap.String("webhook_id", m.WebhookID))
 		}
-		return nil, nil
+		return nil, req.Content, nil
 	}
+	// 广播位有效性 = webhook 能力位 AND 策略放行（broadcastPermitted = system_setting
+	// member_can_broadcast || 创建者当前为管理员，由 handlePush 计算）。compose（补文案）与
+	// assemble（置 humans/ais 标志位）共用这对布尔，保证二者严格同条件触发。
+	allowAll := m.AllowMentionAll == 1 && broadcastPermitted
+	allowBots := m.AllowMentionBots == 1 && broadcastPermitted
 	// IO 步骤：去重+钳上限后，把定向 uids 过一遍群成员闸。失败即降级为空成员集（→丢弃
 	// 全部定向 @），仅记 Warn、不让整条推送失败。纯决策（能力位放行 / 装配线协议）下沉到
 	// assembleMention，无 DB 依赖，便于单测穷举各分支。
@@ -105,26 +173,31 @@ func (w *IncomingWebhook) buildMention(m *incomingWebhookModel, req *pushPayload
 			members = got
 		}
 	}
-	// 广播位有效性 = webhook 能力位 AND 策略放行（broadcastPermitted = system_setting
-	// member_can_broadcast || 创建者当前为管理员，由 handlePush 计算）。关掉设置即可即时
-	// 收回成员 webhook 的广播（管理员建的因 creatorIsAdmin 仍放行），无需迁移存量列。
-	mention, ignored := assembleMention(uids, members,
-		mr.All, mr.Bots,
-		m.AllowMentionAll == 1 && broadcastPermitted,
-		m.AllowMentionBots == 1 && broadcastPermitted)
+	// 广播补文案【仅 text 路径】：获批的 all/bots 把 canonical 字面量前置到 content，使三端
+	// 渲染广播气泡（richtext 无顶层 content → isTextMention=false → 不补、content 原样）。
+	// prefixU16 用于把下面定向 entities 的 offset 整体右移（前置改变了 content）。
+	content := req.Content
+	prefixU16 := 0
+	if isTextMention(req) {
+		content, prefixU16 = composeBroadcastContent(req.Content, mr.All, mr.Bots, allowAll, allowBots)
+	}
+
+	mention, ignored := assembleMention(uids, members, mr.All, mr.Bots, allowAll, allowBots)
 
 	// 校验通过的 entities 原样挂到 mention.entities（与 uids 正交，ExpandAisToBotUIDs 只动
-	// uids、不碰 entities）。ents 仅在 text 路径非空，故此处无需再判 msg_type；content 在
-	// text 路径原样透传（PR-1 不改写 content），offset 与落地一致。
+	// uids、不碰 entities）。ents 仅在 text 路径非空，故此处无需再判 msg_type。校验【相对原始
+	// req.Content】（offset/'@' 锚点都按未前置文本），再把存活区间整体右移 prefixU16——前置只在
+	// 文首插入，故 offset+prefixU16 仍精确指向同一 '@'（广播补文案与定向气泡共存时不错绑）。
 	if len(ents) > 0 {
 		if validEnts := finalizeEntities(ents, members, req.Content); len(validEnts) > 0 {
+			shiftEntityOffsets(validEnts, prefixU16)
 			if mention == nil {
 				mention = map[string]interface{}{}
 			}
 			mention[mentionrewrite.EntitiesKey] = validEnts
 		}
 	}
-	return mention, ignored
+	return mention, content, ignored
 }
 
 // mentionEntity 是调用方传入的单条【渲染层】@ 区间（线协议 mention.entities 的元素）：
@@ -249,6 +322,25 @@ func rangeClaimed(claimed []bool, offset, length int) bool {
 func markClaimed(claimed []bool, offset, length int) {
 	for i := offset; i < offset+length; i++ {
 		claimed[i] = true
+	}
+}
+
+// shiftEntityOffsets 把 finalizeEntities 产出的线协议 entities 的 offset 整体右移 by 个
+// UTF-16 码元（就地）。广播补文案在文首前置了前缀、改变了 content 时，定向 entities 的 offset
+// 必须右移同样长度，否则 web/Android 会按旧 offset 把气泡错绑到前缀文本上。by<=0 为空操作；
+// 只移 offset、不动 length（区间长度不变），uid 不变。
+func shiftEntityOffsets(ents []interface{}, by int) {
+	if by <= 0 || len(ents) == 0 {
+		return
+	}
+	for _, e := range ents {
+		m, ok := e.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if off, ok := m[entityKeyOffset].(int); ok {
+			m[entityKeyOffset] = off + by
+		}
 	}
 }
 

--- a/modules/incomingwebhook/mention.go
+++ b/modules/incomingwebhook/mention.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"unicode/utf16"
+	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
 	"go.uber.org/zap"
@@ -66,41 +67,106 @@ const (
 	broadcastTokenSep = " "     // 定界空格（见上）
 )
 
-// composeBroadcastContent 在【获批】的广播位生效时，把对应的 canonical 广播字面量前置到
-// content，使三端渲染出广播气泡。返回（可能改写后的 content，本次前置前缀的 UTF-16 码元长度）。
+// broadcastLabels 是端上识别的广播标签集（@ 去前缀、小写；与 web/iOS/Android 的
+// isBroadcastMentionName 同口径：中文 canonical + 英文别名）。定向 render 时昵称命中此集 → 跳过，
+// 否则 "@<昵称>" 会被端上当成广播 token 渲染成 @所有人/@所有AI 气泡——伪造一次绕过
+// allow_mention_* 能力位的全员广播。
+var broadcastLabels = map[string]struct{}{
+	"所有人": {}, "所有ai": {}, "all": {}, "all people": {}, "all ais": {},
+}
+
+// isBroadcastLabel 报告 name（trim+小写后）是否命中端上广播标签集。
+func isBroadcastLabel(name string) bool {
+	_, ok := broadcastLabels[strings.ToLower(strings.TrimSpace(name))]
+	return ok
+}
+
+// utf16Len 返回 s 的 UTF-16 码元长度（= JS String.length / NSString length / Kotlin
+// String length），与端上 mention.entities 的 offset/length 单位一致——【绝不能】用字节
+// len() 或 rune 数（含 emoji 时三者分叉）。
+func utf16Len(s string) int {
+	return len(utf16.Encode([]rune(s)))
+}
+
+// composeMentionContent 把服务端生成的 @ 前缀补到 content 文首，使三端渲染气泡。两类前缀按
+// 固定顺序拼成一段、一次性前置（广播在前、定向在后、原 content 最后）：
 //
-// prefixU16Len 供调用方把定向 entities(#449) 的 offset 整体右移——前置改变了 content 文本，
-// 而 entities 的 offset 是相对 content 的 UTF-16 码元绝对位置，必须同步右移才不会错绑气泡。
+//   - 广播字面量（@所有人/@所有AI，#448 ②）：want* && allow*（= AllowMention*==1 &&
+//     broadcastPermitted）且 content 未含该 canonical 时前置。广播气泡由端上据 humans/ais
+//     标志位 + 文本里的字面量渲染，故【不】生成 entity。
+//   - 定向昵称（render，#448 ① b）：把 renderUIDs（已是本群成员、按调用方顺序）逐个解析昵称、
+//     前置 "@<昵称> "，并【生成】对应线协议 entity（offset/length 为 UTF-16 码元、指向前缀里该
+//     @ 段）——让只传 uid 的调用方也能渲染可点击 @气泡。
 //
-//   - 仅当 want* 且 allow*（= AllowMention*==1 && broadcastPermitted）同时成立才前置；未获批的
-//     广播位不前置（它已进 mention_ignored，没有真正广播、不应出现气泡）。
-//   - 幂等：content 已含该 canonical 字面量则不再前置该 token（否则三端会渲染两个气泡）。用
-//     strings.Contains（任意位置）而非仅前缀：调用方可能把 @所有人 写在句中，仍应避免重复气泡。
-//     （极端误判：文本恰含 "@所有人" 子串如成员名 "@所有人事部" 时会保守地不前置——此时端上同样
-//     不会把该子串当广播 token 高亮，结果一致：无自动气泡、标志位仍照常路由。）
-//   - humans 在前、ais 在后（稳定顺序）。
-//   - 仅文本路径调用（richtext 无顶层 content，调用方据 isTextMention 决定是否调用）。
+// 返回（改写后的 content，前缀的 UTF-16 码元长度，定向 render 生成的 entities）。前缀为空 →
+// (content, 0, nil)，保证无补文案的历史调用 payload 字节不变（向后兼容）。
 //
-// 前缀是服务端定值（≤11 UTF-16 码元）：刻意在 handlePush 的 maxContentRunes 上限校验【之后】追加，
-// 相对默认 4000 上限可忽略、且 8KB body / 序列化上限仍兜底——故不为这点定长前缀重算上限。
-//
-// 不前置任何 token 时返回 (content, 0)——原样字符串、零位移，保证无广播位的历史调用 payload
-// 完全不变（向后兼容）。
-func composeBroadcastContent(content string, wantAll, wantBots, allowAll, allowBots bool) (string, int) {
+// 不变量与边界：
+//   - prefixU16 供调用方把【调用方自带】的 entities(#449) 整体右移（前置改变了 content）；render
+//     与自带 entities 互斥，故二者不会同时出现。
+//   - 防伪造广播：昵称命中端上广播标签集（isBroadcastLabel）或含 '@'（WeChat 昵称路径不过滤 @）时
+//     【跳过】render——否则 "@<昵称>" 会被端上当成 @所有人/@所有AI 广播 token 渲染，伪造一次绕过
+//     allow_mention_* 能力位的全员广播气泡。命中者仍按 uid 路由、只是不出气泡。
+//   - 幂等：广播按 canonical 字面量、定向按 "@<昵称>" 在【原始 content】里 Contains 去重（避免双
+//     气泡）。子串误判（名是另一段文本的前缀，如名 "张" 撞 "@张三"）会保守跳过该气泡、uid 仍路由——可接受。
+//   - 空昵称（非成员/未 join 到 user.name）跳过——绝不补 "@ "。
+//   - 含空格的昵称（如 "Bob Smith"）：web/Android 用 entity 精确绑定整段；iOS 忽略 entity、按 @\S+
+//     定位，气泡文本会截到首个空格（点击仍按位次绑定到正确 uid）——与 #449 的 iOS 已知行为一致、非错绑。
+//   - 预算 maxRunes>0：增量维护 prefixRunes（含已前置的广播段，故定向段按剩余额度收敛），补每个
+//     @昵称前估算「前缀+原文」总 rune 数，超限即停止再补（剩余 uid 仍由 mention.uids 路由）,保证
+//     补文案后 content 不破 maxContentRunes。rune 数有界（≤maxContentRunes）；utf8mb4 昵称下字节
+//     最坏约 4×，仍远低于下游序列化上限。
+func composeMentionContent(content string, wantAll, wantBots, allowAll, allowBots, render bool, renderUIDs []string, namesByUID map[string]string, maxRunes int) (string, int, []interface{}) {
 	var prefix strings.Builder
+	prefixU16, prefixRunes := 0, 0 // 增量维护，避免每轮重算 prefix.String()（O(n²)）
+	appendToken := func(tok string) {
+		prefix.WriteString(tok)
+		prefixU16 += utf16Len(tok)
+		prefixRunes += utf8.RuneCountInString(tok)
+	}
 	if wantAll && allowAll && !strings.Contains(content, broadcastTokenAll) {
-		prefix.WriteString(broadcastTokenAll)
-		prefix.WriteString(broadcastTokenSep)
+		appendToken(broadcastTokenAll + broadcastTokenSep)
 	}
 	if wantBots && allowBots && !strings.Contains(content, broadcastTokenAIs) {
-		prefix.WriteString(broadcastTokenAIs)
-		prefix.WriteString(broadcastTokenSep)
+		appendToken(broadcastTokenAIs + broadcastTokenSep)
 	}
-	p := prefix.String()
-	if p == "" {
-		return content, 0
+	var genEntities []interface{}
+	if render {
+		contentRunes := utf8.RuneCountInString(content)
+		seen := make(map[string]struct{}, len(renderUIDs))
+		for _, uid := range renderUIDs {
+			if _, dup := seen[uid]; dup {
+				continue
+			}
+			name := strings.TrimSpace(namesByUID[uid])
+			if name == "" {
+				continue // 非成员 / 未解析到昵称 → 不渲染（绝不补 "@ "）
+			}
+			if isBroadcastLabel(name) || strings.Contains(name, "@") {
+				continue // 防伪造广播 / 嵌入式 @：昵称会被端上当成广播 token 或破坏 @ 分词
+			}
+			atName := "@" + name
+			if strings.Contains(content, atName) {
+				continue // 幂等：调用方已把该 @昵称写进 content
+			}
+			seg := atName + broadcastTokenSep
+			// 预算：补这一段后「前缀+原文」rune 数不得超过 maxContentRunes（prefixRunes 已含广播段）。
+			if maxRunes > 0 && prefixRunes+utf8.RuneCountInString(seg)+contentRunes > maxRunes {
+				break // 余下 uid 不再出气泡，仍由 mention.uids 路由
+			}
+			seen[uid] = struct{}{}
+			genEntities = append(genEntities, map[string]interface{}{
+				entityKeyUID:    uid,
+				entityKeyOffset: prefixU16, // 该 @ 段在前缀里的 UTF-16 起点（append 前捕获）
+				entityKeyLength: utf16Len(atName),
+			})
+			appendToken(seg)
+		}
 	}
-	return p + content, len(utf16.Encode([]rune(p)))
+	if prefix.Len() == 0 {
+		return content, 0, nil
+	}
+	return prefix.String() + content, prefixU16, genEntities
 }
 
 // buildMention 把 native 推送请求里的 mentionReq 翻译成消息 payload 的 mention 子对象
@@ -114,8 +180,11 @@ func composeBroadcastContent(content string, wantAll, wantBots, allowAll, allowB
 //  2. @所有人(All)：webhook 的 allow_mention_all 开【且 broadcastPermitted】则写 humans=1，否则记入 ignored。
 //  3. @所有 AI(Bots)：allow_mention_bots 开【且 broadcastPermitted】则写 ais=1（稍后由调用方
 //     ExpandAisToBotUIDs 展开为群内全部 bot 成员 UID），否则记入 ignored。
-//  4. 广播补文案（仅 text 路径）：获批的 all/bots 还会把 canonical 字面量(@所有人/@所有AI)
-//     前置到 content，使三端渲染出可见广播气泡（见 composeBroadcastContent）；未获批不前置。
+//  4. 广播补文案（仅 text 路径）：获批的 all/bots 把 canonical 字面量(@所有人/@所有AI)前置到
+//     content，使三端渲染出可见广播气泡（见 composeMentionContent）；未获批不前置。
+//  5. 定向昵称渲染（mention.render，opt-in，仅 text 路径）：把【本群成员】uids 解析成展示昵称、
+//     前置 "@<昵称> " 并生成对应 entities，让只传 uid 的调用方也渲染出 @气泡；与调用方自带
+//     entities 互斥（后者权威，见 composeMentionContent）。
 //
 // broadcastPermitted 由调用方传入：system_setting member_can_broadcast || 创建者当前为管理员。
 // 关掉该设置即可即时收回所有【成员】创建的 webhook 的广播能力，管理员创建的不受影响。
@@ -152,8 +221,9 @@ func (w *IncomingWebhook) buildMention(m *incomingWebhookModel, req *pushPayload
 	// 渲染层 entities（调用方传入的 @ 区间）【仅 text 路径】处理：offset/length 是对纯文本
 	// content 的 UTF-16 偏移，richtext 的块结构参考系不同（且跨端已知 caption/plain 错位），
 	// 本期不碰。逐条宽松解码后，其 uid 也并入下面同一次成员闸查询，避免二次查询。
+	isText := isTextMention(req)
 	var ents []mentionEntity
-	if isTextMention(req) {
+	if isText {
 		ents = decodeEntities(mr.Entities, maxMentionUIDs())
 	}
 	gateUIDs := uids
@@ -163,32 +233,63 @@ func (w *IncomingWebhook) buildMention(m *incomingWebhookModel, req *pushPayload
 		// 一次查询」而非两次。
 		gateUIDs = dedupNonEmpty(append(append([]string{}, uids...), entityUIDsOf(ents)...), maxMentionUIDs()*2)
 	}
-	members := map[string]struct{}{}
+	// 成员闸：返回 uid→展示昵称（key 即成员归属判定；昵称仅 render 取用）。失败即降级为空集
+	// （→丢弃全部定向 @），仅记 Warn、不让整条推送失败。
+	membersByName := map[string]string{}
 	if len(gateUIDs) > 0 {
 		got, err := w.db.filterGroupMembers(m.GroupNo, gateUIDs)
 		if err != nil {
 			w.Warn("filter group members for mention failed; dropping targeted @uids",
 				zap.String("webhook_id", m.WebhookID), zap.Error(err))
 		} else {
-			members = got
+			membersByName = got
 		}
 	}
-	// 广播补文案【仅 text 路径】：获批的 all/bots 把 canonical 字面量前置到 content，使三端
-	// 渲染广播气泡（richtext 无顶层 content → isTextMention=false → 不补、content 原样）。
-	// prefixU16 用于把下面定向 entities 的 offset 整体右移（前置改变了 content）。
+	// 成员集（key 即成员）供 assembleMention / finalizeEntities 判定归属；昵称仅 render 取用。
+	members := make(map[string]struct{}, len(membersByName))
+	for u := range membersByName {
+		members[u] = struct{}{}
+	}
+
+	// 定向昵称渲染（opt-in、仅 text 路径、且与调用方自带 entities 互斥——后者权威）。renderUIDs 是
+	// uids 里的本群成员、保持调用方顺序，由 composeMentionContent 逐个解析昵称、前置 "@<昵称> "
+	// 并生成对应 entity。
+	renderEffective := mr.Render && isText && len(ents) == 0
+	var renderUIDs []string
+	if renderEffective {
+		for _, u := range uids {
+			if _, ok := membersByName[u]; ok {
+				renderUIDs = append(renderUIDs, u)
+			}
+		}
+	}
+
+	// 服务端补 @ 前缀【仅 text 路径】：广播字面量（获批的 all/bots）+ 定向 @昵称（render）。
+	// content 为改写后的正文；prefixU16 供下面把调用方自带 entities 右移；genEntities 是 render
+	// 生成的定向 entities。richtext（isText=false）不补、content 原样、payload 字节不变。
 	content := req.Content
 	prefixU16 := 0
-	if isTextMention(req) {
-		content, prefixU16 = composeBroadcastContent(req.Content, mr.All, mr.Bots, allowAll, allowBots)
+	var genEntities []interface{}
+	if isText {
+		content, prefixU16, genEntities = composeMentionContent(
+			req.Content, mr.All, mr.Bots, allowAll, allowBots,
+			renderEffective, renderUIDs, membersByName, maxContentRunes())
 	}
 
 	mention, ignored := assembleMention(uids, members, mr.All, mr.Bots, allowAll, allowBots)
 
-	// 校验通过的 entities 原样挂到 mention.entities（与 uids 正交，ExpandAisToBotUIDs 只动
-	// uids、不碰 entities）。ents 仅在 text 路径非空，故此处无需再判 msg_type。校验【相对原始
-	// req.Content】（offset/'@' 锚点都按未前置文本），再把存活区间整体右移 prefixU16——前置只在
-	// 文首插入，故 offset+prefixU16 仍精确指向同一 '@'（广播补文案与定向气泡共存时不错绑）。
-	if len(ents) > 0 {
+	// mention.entities 二选一（render 与调用方自带 entities 互斥）：
+	//   - render 生成的定向 entities：offset 已含全部前缀长度（compose 内按前缀位置算），无需再移；
+	//   - 调用方自带 entities（#449）：相对【原始 req.Content】校验（offset/'@' 锚点按未前置文本），
+	//     再整体右移 prefixU16——前置只在文首插入，故 offset+prefixU16 仍精确指向同一 '@'。
+	// 与 uids 正交，ExpandAisToBotUIDs 只动 uids、不碰 entities。
+	switch {
+	case len(genEntities) > 0:
+		if mention == nil {
+			mention = map[string]interface{}{}
+		}
+		mention[mentionrewrite.EntitiesKey] = genEntities
+	case len(ents) > 0:
 		if validEnts := finalizeEntities(ents, members, req.Content); len(validEnts) > 0 {
 			shiftEntityOffsets(validEnts, prefixU16)
 			if mention == nil {

--- a/modules/incomingwebhook/mention_broadcast_test.go
+++ b/modules/incomingwebhook/mention_broadcast_test.go
@@ -1,0 +1,219 @@
+package incomingwebhook
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"unicode/utf16"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 广播补文案（#448 item ②）的测试：把获批的 canonical 广播字面量(@所有人/@所有AI)前置到
+// content，使三端渲染广播气泡。核心 compose / offset-shift 是纯函数（无 DB）；buildMention
+// 的「仅 text 路径 + 同条件 + 返回改写后 content」的接线用 bare-w 单测覆盖（广播 only 不触
+// 成员闸，无需 infra）；广播与定向 entities 共存的 offset 右移用一条 infra 集成测试钉死。
+
+func TestComposeBroadcastContent(t *testing.T) {
+	const content = "deploy done"
+
+	t.Run("permitted all, no literal -> prepend @所有人 + space (5 utf16)", func(t *testing.T) {
+		got, n := composeBroadcastContent(content, true, false, true, false)
+		assert.Equal(t, "@所有人 "+content, got)
+		assert.Equal(t, 5, n) // @所有人 + space = 5 UTF-16 code units
+		assert.True(t, strings.HasPrefix(got, broadcastTokenAll+broadcastTokenSep))
+	})
+
+	t.Run("permitted bots, no literal -> prepend @所有AI + space (6 utf16)", func(t *testing.T) {
+		got, n := composeBroadcastContent(content, false, true, false, true)
+		assert.Equal(t, "@所有AI "+content, got)
+		assert.Equal(t, 6, n)
+	})
+
+	t.Run("both permitted -> humans first then ais (11 utf16)", func(t *testing.T) {
+		got, n := composeBroadcastContent(content, true, true, true, true)
+		assert.Equal(t, "@所有人 @所有AI "+content, got)
+		assert.Equal(t, 11, n)
+	})
+
+	t.Run("wanted but not permitted -> no prepend, zero shift", func(t *testing.T) {
+		got, n := composeBroadcastContent(content, true, true, false, false)
+		assert.Equal(t, content, got)
+		assert.Equal(t, 0, n)
+	})
+
+	t.Run("permitted but not wanted -> no prepend", func(t *testing.T) {
+		got, n := composeBroadcastContent(content, false, false, true, true)
+		assert.Equal(t, content, got)
+		assert.Equal(t, 0, n)
+	})
+
+	t.Run("idempotent: literal already present anywhere -> token not re-prepended", func(t *testing.T) {
+		c := "ping @所有人 now"
+		got, n := composeBroadcastContent(c, true, false, true, false)
+		assert.Equal(t, c, got)
+		assert.Equal(t, 0, n)
+	})
+
+	t.Run("idempotent per token: all present, ais absent -> prepend only @所有AI", func(t *testing.T) {
+		c := "ping @所有人 now"
+		got, n := composeBroadcastContent(c, true, true, true, true)
+		assert.Equal(t, "@所有AI "+c, got)
+		assert.Equal(t, 6, n)
+		assert.Equal(t, 1, strings.Count(got, broadcastTokenAll), "existing @所有人 not duplicated")
+	})
+
+	t.Run("no-op returns original (byte-identical, backward compat)", func(t *testing.T) {
+		got, n := composeBroadcastContent(content, false, false, false, false)
+		assert.Equal(t, content, got)
+		assert.Equal(t, 0, n)
+	})
+}
+
+func TestShiftEntityOffsets(t *testing.T) {
+	mk := func(uid string, off, length int) map[string]interface{} {
+		return map[string]interface{}{entityKeyUID: uid, entityKeyOffset: off, entityKeyLength: length}
+	}
+
+	t.Run("shifts every offset by N, leaves uid/length", func(t *testing.T) {
+		ents := []interface{}{mk("u1", 0, 3), mk("u2", 4, 3)}
+		shiftEntityOffsets(ents, 5)
+		assert.Equal(t, 5, ents[0].(map[string]interface{})[entityKeyOffset])
+		assert.Equal(t, 9, ents[1].(map[string]interface{})[entityKeyOffset])
+		assert.Equal(t, 3, ents[0].(map[string]interface{})[entityKeyLength])
+		assert.Equal(t, "u1", ents[0].(map[string]interface{})[entityKeyUID])
+	})
+
+	t.Run("zero / negative shift is a no-op", func(t *testing.T) {
+		ents := []interface{}{mk("u1", 2, 3)}
+		shiftEntityOffsets(ents, 0)
+		shiftEntityOffsets(ents, -1)
+		assert.Equal(t, 2, ents[0].(map[string]interface{})[entityKeyOffset])
+	})
+
+	t.Run("nil / empty safe", func(t *testing.T) {
+		shiftEntityOffsets(nil, 5)
+		shiftEntityOffsets([]interface{}{}, 5)
+	})
+}
+
+// TestBuildMentionBroadcastCompose covers the buildMention wiring for broadcast-only
+// pushes (no uids/entities → the group-member gate is never queried, so a bare *IncomingWebhook
+// suffices — no DB/Redis/IM needed): compose runs only on the text path and only for a flag that
+// survives the capability gate, and the (possibly rewritten) content is returned for the caller
+// to write back.
+func TestBuildMentionBroadcastCompose(t *testing.T) {
+	w := &IncomingWebhook{Log: log.NewTLog("test")}
+	model := &incomingWebhookModel{WebhookID: "iwh_t", GroupNo: "g", AllowMentionAll: 1, AllowMentionBots: 1}
+	newReq := func(mention string) *pushPayloadReq {
+		return &pushPayloadReq{Content: "deploy done", Mention: json.RawMessage(mention)}
+	}
+
+	t.Run("permitted all -> content prepended, humans=1", func(t *testing.T) {
+		mention, content, ignored := w.buildMention(model, newReq(`{"all":true}`), true)
+		assert.Equal(t, "@所有人 deploy done", content)
+		require.NotNil(t, mention)
+		assert.Equal(t, 1, mention[mentionrewrite.HumansKey])
+		assert.Empty(t, ignored)
+	})
+
+	t.Run("permitted both -> humans-first prefix, humans+ais set", func(t *testing.T) {
+		mention, content, _ := w.buildMention(model, newReq(`{"all":true,"bots":true}`), true)
+		assert.Equal(t, "@所有人 @所有AI deploy done", content)
+		assert.Equal(t, 1, mention[mentionrewrite.HumansKey])
+		assert.Equal(t, 1, mention[mentionrewrite.AIsKey])
+	})
+
+	t.Run("broadcast not permitted -> no prepend, both reported ignored", func(t *testing.T) {
+		mention, content, ignored := w.buildMention(model, newReq(`{"all":true,"bots":true}`), false)
+		assert.Equal(t, "deploy done", content)
+		assert.Nil(t, mention)
+		assert.ElementsMatch(t, []string{"all", "bots"}, ignored)
+	})
+
+	t.Run("capability bit off -> no prepend even when policy permits", func(t *testing.T) {
+		off := &incomingWebhookModel{WebhookID: "iwh_off", GroupNo: "g"} // AllowMention* default 0
+		_, content, ignored := w.buildMention(off, newReq(`{"all":true}`), true)
+		assert.Equal(t, "deploy done", content)
+		assert.Equal(t, []string{"all"}, ignored)
+	})
+
+	t.Run("richtext path -> content never composed, flags still assembled", func(t *testing.T) {
+		req := &pushPayloadReq{MsgType: msgTypeRichText, Content: "deploy done",
+			Mention: json.RawMessage(`{"all":true,"bots":true}`)}
+		mention, content, _ := w.buildMention(model, req, true)
+		assert.Equal(t, "deploy done", content, "richtext has no top-level content to compose")
+		assert.Equal(t, 1, mention[mentionrewrite.HumansKey])
+		assert.Equal(t, 1, mention[mentionrewrite.AIsKey])
+	})
+
+	t.Run("idempotent: caller already wrote @所有人 -> not duplicated", func(t *testing.T) {
+		req := &pushPayloadReq{Content: "@所有人 ship it", Mention: json.RawMessage(`{"all":true}`)}
+		_, content, _ := w.buildMention(model, req, true)
+		assert.Equal(t, "@所有人 ship it", content)
+		assert.Equal(t, 1, strings.Count(content, broadcastTokenAll))
+	})
+
+	t.Run("no broadcast flags -> content byte-identical (backward compat)", func(t *testing.T) {
+		_, content, ignored := w.buildMention(model, newReq(`{}`), true)
+		assert.Equal(t, "deploy done", content)
+		assert.Empty(t, ignored)
+	})
+
+	t.Run("malformed mention -> content unchanged, nil mention, no panic", func(t *testing.T) {
+		req := &pushPayloadReq{Content: "deploy done", Mention: json.RawMessage(`"garbage"`)}
+		mention, content, ignored := w.buildMention(model, req, true)
+		assert.Nil(t, mention)
+		assert.Equal(t, "deploy done", content)
+		assert.Empty(t, ignored)
+	})
+}
+
+// TestBuildMentionBroadcastShiftsEntities is the integration seam (needs MySQL): when a broadcast
+// prepend and a directed entity (#449) coexist, the entity offset must shift by the prefix's UTF-16
+// length so web/Android keep binding the right member. Asserts buildMention's returned content +
+// mention directly — no WuKongIM read-back (the env does not register subscribers; see #449).
+func TestBuildMentionBroadcastShiftsEntities(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+	w := newIncomingWebhook(ctx)
+
+	const groupNo = "g_bcast"
+	const uid = "u_member_bcast"
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO group_member(group_no, uid, role, status, is_deleted, version) VALUES(?, ?, 0, 1, 0, 1)",
+		groupNo, uid).Exec()
+	require.NoError(t, err)
+
+	m := &incomingWebhookModel{WebhookID: "iwh_bcast", GroupNo: groupNo, AllowMentionAll: 1}
+	// content "@张三 hi": @(0)张(1)三(2) space(3) h(4)i(5); entity offset0 length3 -> "@张三".
+	req := &pushPayloadReq{
+		Content: "@张三 hi",
+		Mention: json.RawMessage(fmt.Sprintf(
+			`{"all":true,"uids":["%s"],"entities":[{"uid":"%s","offset":0,"length":3}]}`, uid, uid)),
+	}
+	mention, content, ignored := w.buildMention(m, req, true)
+	require.NotNil(t, mention)
+	assert.Empty(t, ignored)
+
+	// 广播补文案前置 "@所有人 "（5 UTF-16 码元）。
+	assert.Equal(t, "@所有人 @张三 hi", content)
+	assert.Equal(t, 1, mention[mentionrewrite.HumansKey])
+
+	// 定向 entity 的 offset 由 0 右移到 5，正好指向最终 content 里 @张三 的 '@'。
+	ents, ok := mention[mentionrewrite.EntitiesKey].([]interface{})
+	require.Truef(t, ok, "entities present; mention=%v", mention)
+	require.Len(t, ents, 1)
+	e := ents[0].(map[string]interface{})
+	assert.Equal(t, uid, e[entityKeyUID])
+	assert.Equal(t, 5, e[entityKeyOffset])
+	assert.Equal(t, 3, e[entityKeyLength])
+	u16 := utf16.Encode([]rune(content))
+	require.Greater(t, len(u16), 5)
+	assert.Equal(t, uint16('@'), u16[5], "shifted offset must still anchor a '@' in the final content")
+}

--- a/modules/incomingwebhook/mention_broadcast_test.go
+++ b/modules/incomingwebhook/mention_broadcast_test.go
@@ -21,55 +21,61 @@ import (
 
 func TestComposeBroadcastContent(t *testing.T) {
 	const content = "deploy done"
+	// broadcast-only compose (render off): assert no entities are generated, return (content, prefixLen).
+	compose := func(c string, all, bots, allowAll, allowBots bool) (string, int) {
+		got, n, ents := composeMentionContent(c, all, bots, allowAll, allowBots, false, nil, nil, 0)
+		require.Nil(t, ents, "broadcast-only compose must not generate entities")
+		return got, n
+	}
 
 	t.Run("permitted all, no literal -> prepend @所有人 + space (5 utf16)", func(t *testing.T) {
-		got, n := composeBroadcastContent(content, true, false, true, false)
+		got, n := compose(content, true, false, true, false)
 		assert.Equal(t, "@所有人 "+content, got)
 		assert.Equal(t, 5, n) // @所有人 + space = 5 UTF-16 code units
 		assert.True(t, strings.HasPrefix(got, broadcastTokenAll+broadcastTokenSep))
 	})
 
 	t.Run("permitted bots, no literal -> prepend @所有AI + space (6 utf16)", func(t *testing.T) {
-		got, n := composeBroadcastContent(content, false, true, false, true)
+		got, n := compose(content, false, true, false, true)
 		assert.Equal(t, "@所有AI "+content, got)
 		assert.Equal(t, 6, n)
 	})
 
 	t.Run("both permitted -> humans first then ais (11 utf16)", func(t *testing.T) {
-		got, n := composeBroadcastContent(content, true, true, true, true)
+		got, n := compose(content, true, true, true, true)
 		assert.Equal(t, "@所有人 @所有AI "+content, got)
 		assert.Equal(t, 11, n)
 	})
 
 	t.Run("wanted but not permitted -> no prepend, zero shift", func(t *testing.T) {
-		got, n := composeBroadcastContent(content, true, true, false, false)
+		got, n := compose(content, true, true, false, false)
 		assert.Equal(t, content, got)
 		assert.Equal(t, 0, n)
 	})
 
 	t.Run("permitted but not wanted -> no prepend", func(t *testing.T) {
-		got, n := composeBroadcastContent(content, false, false, true, true)
+		got, n := compose(content, false, false, true, true)
 		assert.Equal(t, content, got)
 		assert.Equal(t, 0, n)
 	})
 
 	t.Run("idempotent: literal already present anywhere -> token not re-prepended", func(t *testing.T) {
 		c := "ping @所有人 now"
-		got, n := composeBroadcastContent(c, true, false, true, false)
+		got, n := compose(c, true, false, true, false)
 		assert.Equal(t, c, got)
 		assert.Equal(t, 0, n)
 	})
 
 	t.Run("idempotent per token: all present, ais absent -> prepend only @所有AI", func(t *testing.T) {
 		c := "ping @所有人 now"
-		got, n := composeBroadcastContent(c, true, true, true, true)
+		got, n := compose(c, true, true, true, true)
 		assert.Equal(t, "@所有AI "+c, got)
 		assert.Equal(t, 6, n)
 		assert.Equal(t, 1, strings.Count(got, broadcastTokenAll), "existing @所有人 not duplicated")
 	})
 
 	t.Run("no-op returns original (byte-identical, backward compat)", func(t *testing.T) {
-		got, n := composeBroadcastContent(content, false, false, false, false)
+		got, n := compose(content, false, false, false, false)
 		assert.Equal(t, content, got)
 		assert.Equal(t, 0, n)
 	})

--- a/modules/incomingwebhook/mention_directed_render_test.go
+++ b/modules/incomingwebhook/mention_directed_render_test.go
@@ -86,14 +86,20 @@ func TestComposeMentionContentDirected(t *testing.T) {
 		assert.Equal(t, "@AAAA body", c)
 	})
 
-	t.Run("name == broadcast label or containing '@' is skipped (no forged broadcast pill)", func(t *testing.T) {
-		// 所有人 / All AIs collide with broadcast tokens; "@x" would break @-tokenization. Only 我的天 is safe.
-		nm := map[string]string{"a": "所有人", "b": "All AIs", "c": "@x", "d": "我的天"}
+	t.Run("broadcast-like names skipped (exact + boundary + embedded '@'); real names still render", func(t *testing.T) {
+		// Skipped: exact label (所有人 / All AIs), label + non-word boundary (所有人 X / 所有人: / all-hands —
+		// iOS @\S+ would emit a standalone @所有人 / @all broadcast token), and any name containing '@'.
+		// Rendered: a label that continues into a longer word (所有人事部 = HR dept; allen) is a real name.
+		nm := map[string]string{
+			"a": "所有人", "b": "所有人 X", "c": "所有人:", "d": "All AIs", "e": "@x", "f": "all-hands",
+			"g": "所有人事部", "h": "allen",
+		}
 		c, _, ents := composeMentionContent("body", false, false, false, false, true,
-			[]string{"a", "b", "c", "d"}, nm, 0)
-		assert.Equal(t, "@我的天 body", c, "broadcast-label and @-containing names skipped; only the safe name renders")
-		require.Len(t, ents, 1)
-		assert.Equal(t, "d", ents[0].(map[string]interface{})[entityKeyUID])
+			[]string{"a", "b", "c", "d", "e", "f", "g", "h"}, nm, 0)
+		assert.Equal(t, "@所有人事部 @allen body", c, "only non-broadcast-like names render, in caller order")
+		require.Len(t, ents, 2)
+		assert.Equal(t, "g", ents[0].(map[string]interface{})[entityKeyUID])
+		assert.Equal(t, "h", ents[1].(map[string]interface{})[entityKeyUID])
 	})
 }
 

--- a/modules/incomingwebhook/mention_directed_render_test.go
+++ b/modules/incomingwebhook/mention_directed_render_test.go
@@ -1,0 +1,175 @@
+package incomingwebhook
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"unicode/utf16"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 定向 @ 昵称渲染（#448 ① b, mention.render）的测试：把【本群成员】uid 解析成展示昵称、
+// 前置 "@<昵称> " 并【生成】对应 entity。compose 是纯函数(给定 namesByUID,无 DB);buildMention
+// 的「成员闸取昵称 → 渲染」端到端走 infra(种 group_member + user 行,LEFT JOIN user.name)。
+
+func TestComposeMentionContentDirected(t *testing.T) {
+	names := map[string]string{"u1": "我的天", "u2": "Bob", "u3": ""}
+
+	t.Run("single member -> @name prepended + entity generated (UTF-16)", func(t *testing.T) {
+		c, n, ents := composeMentionContent("执行吧", false, false, false, false, true, []string{"u1"}, names, 0)
+		assert.Equal(t, "@我的天 执行吧", c)
+		assert.Equal(t, 5, n) // "@我的天 " = @我的天(4) + space(1) = 5 UTF-16 code units
+		require.Len(t, ents, 1)
+		assert.Equal(t, map[string]interface{}{entityKeyUID: "u1", entityKeyOffset: 0, entityKeyLength: 4}, ents[0])
+	})
+
+	t.Run("multiple members -> caller order, each offset anchors its own '@'", func(t *testing.T) {
+		c, n, ents := composeMentionContent("hi", false, false, false, false, true, []string{"u1", "u2"}, names, 0)
+		assert.Equal(t, "@我的天 @Bob hi", c)
+		assert.Equal(t, utf16Len("@我的天 @Bob "), n)
+		require.Len(t, ents, 2)
+		assert.Equal(t, map[string]interface{}{entityKeyUID: "u1", entityKeyOffset: 0, entityKeyLength: 4}, ents[0])
+		assert.Equal(t, map[string]interface{}{entityKeyUID: "u2", entityKeyOffset: 5, entityKeyLength: 4}, ents[1])
+		u16 := utf16.Encode([]rune(c))
+		assert.Equal(t, uint16('@'), u16[0])
+		assert.Equal(t, uint16('@'), u16[5])
+	})
+
+	t.Run("non-member / empty name skipped (never composes '@ ')", func(t *testing.T) {
+		// u3 has empty name; "uX" is absent from the map (non-member) -> both skipped, only u1 renders.
+		c, n, ents := composeMentionContent("body", false, false, false, false, true, []string{"u3", "uX", "u1"}, names, 0)
+		assert.Equal(t, "@我的天 body", c)
+		assert.Equal(t, 5, n)
+		require.Len(t, ents, 1)
+		assert.Equal(t, "u1", ents[0].(map[string]interface{})[entityKeyUID])
+	})
+
+	t.Run("idempotent: @name already in content -> not re-prepended", func(t *testing.T) {
+		c, n, ents := composeMentionContent("cc @我的天 ok", false, false, false, false, true, []string{"u1"}, names, 0)
+		assert.Equal(t, "cc @我的天 ok", c)
+		assert.Equal(t, 0, n)
+		assert.Nil(t, ents)
+	})
+
+	t.Run("same uid twice -> one pill (dedup)", func(t *testing.T) {
+		c, _, ents := composeMentionContent("x", false, false, false, false, true, []string{"u1", "u1"}, names, 0)
+		assert.Equal(t, "@我的天 x", c)
+		require.Len(t, ents, 1)
+	})
+
+	t.Run("render off -> no compose, no entities", func(t *testing.T) {
+		c, n, ents := composeMentionContent("y", false, false, false, false, false, []string{"u1"}, names, 0)
+		assert.Equal(t, "y", c)
+		assert.Equal(t, 0, n)
+		assert.Nil(t, ents)
+	})
+
+	t.Run("broadcast + directed compose together: broadcast first, directed offset accounts for it", func(t *testing.T) {
+		c, n, ents := composeMentionContent("go", true, false, true, false, true, []string{"u1"}, names, 0)
+		assert.Equal(t, "@所有人 @我的天 go", c)
+		assert.Equal(t, utf16Len("@所有人 @我的天 "), n)
+		require.Len(t, ents, 1)
+		assert.Equal(t, map[string]interface{}{entityKeyUID: "u1", entityKeyOffset: 5, entityKeyLength: 4}, ents[0])
+		u16 := utf16.Encode([]rune(c))
+		assert.Equal(t, uint16('@'), u16[5], "directed '@' anchors correctly after the broadcast prefix")
+	})
+
+	t.Run("budget: stop adding @names before composed content exceeds maxRunes", func(t *testing.T) {
+		nm := map[string]string{"a": "AAAA", "b": "BBBB"} // each "@AAAA " = 6 runes
+		// content "body" = 4 runes; maxRunes 10 fits exactly one "@AAAA " (6) + body (4); the 2nd breaks.
+		c, _, ents := composeMentionContent("body", false, false, false, false, true, []string{"a", "b"}, nm, 10)
+		require.Len(t, ents, 1, "only the first @name fits the budget; the rest still route via mention.uids")
+		assert.Equal(t, "@AAAA body", c)
+	})
+
+	t.Run("name == broadcast label or containing '@' is skipped (no forged broadcast pill)", func(t *testing.T) {
+		// 所有人 / All AIs collide with broadcast tokens; "@x" would break @-tokenization. Only 我的天 is safe.
+		nm := map[string]string{"a": "所有人", "b": "All AIs", "c": "@x", "d": "我的天"}
+		c, _, ents := composeMentionContent("body", false, false, false, false, true,
+			[]string{"a", "b", "c", "d"}, nm, 0)
+		assert.Equal(t, "@我的天 body", c, "broadcast-label and @-containing names skipped; only the safe name renders")
+		require.Len(t, ents, 1)
+		assert.Equal(t, "d", ents[0].(map[string]interface{})[entityKeyUID])
+	})
+}
+
+// TestBuildMentionDirectedRender is the end-to-end seam (needs MySQL): a bare uid + render:true
+// resolves the member's display name (group_member LEFT JOIN user.name), prepends "@<name> ", and
+// generates the entity — asserting buildMention's returned content/mention directly.
+func TestBuildMentionDirectedRender(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+	w := newIncomingWebhook(ctx)
+
+	const groupNo = "g_render"
+	const uid = "u_render_bot"
+	const name = "我的天"
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO group_member(group_no, uid, role, status, is_deleted, version) VALUES(?, ?, 0, 1, 0, 1)",
+		groupNo, uid).Exec()
+	require.NoError(t, err)
+	// display name resolves from user.name via the gate's LEFT JOIN.
+	_, err = ctx.DB().InsertInto("user").Columns("uid", "name", "username", "short_no", "status").
+		Values(uid, name, uid, "sn_"+uid, 1).Exec()
+	require.NoError(t, err)
+
+	m := &incomingWebhookModel{WebhookID: "iwh_render", GroupNo: groupNo}
+
+	t.Run("uid + render:true -> @name composed + entity generated; uid still routes", func(t *testing.T) {
+		req := &pushPayloadReq{
+			Content: "执行吧",
+			Mention: json.RawMessage(fmt.Sprintf(`{"uids":["%s"],"render":true}`, uid)),
+		}
+		// render is NOT capability-gated (directed, not broadcast) -> broadcastPermitted=false is fine.
+		mention, content, ignored := w.buildMention(m, req, false)
+		require.NotNil(t, mention)
+		assert.Empty(t, ignored)
+		assert.Equal(t, "@我的天 执行吧", content)
+
+		uidsOut, _ := mention[mentionrewrite.UIDsKey].([]interface{})
+		assert.Contains(t, uidsOut, uid, "uid still carried for routing/red-dot")
+
+		ents, ok := mention[mentionrewrite.EntitiesKey].([]interface{})
+		require.Truef(t, ok, "entities generated; mention=%v", mention)
+		require.Len(t, ents, 1)
+		e := ents[0].(map[string]interface{})
+		assert.Equal(t, uid, e[entityKeyUID])
+		assert.Equal(t, 0, e[entityKeyOffset])
+		assert.Equal(t, 4, e[entityKeyLength]) // "@我的天" = 4 UTF-16
+		u16 := utf16.Encode([]rune(content))
+		assert.Equal(t, uint16('@'), u16[0])
+	})
+
+	t.Run("render + caller entities -> caller entities win, no auto-generate, no prepend", func(t *testing.T) {
+		// caller wrote their own "@x" + supplied the entity; #449 path is authoritative -> render is ignored.
+		req := &pushPayloadReq{
+			Content: "@x hi",
+			Mention: json.RawMessage(fmt.Sprintf(
+				`{"uids":["%s"],"render":true,"entities":[{"uid":"%s","offset":0,"length":2}]}`, uid, uid)),
+		}
+		mention, content, _ := w.buildMention(m, req, false)
+		require.NotNil(t, mention)
+		assert.Equal(t, "@x hi", content, "caller entities present -> render does not prepend names")
+		ents, ok := mention[mentionrewrite.EntitiesKey].([]interface{})
+		require.True(t, ok)
+		require.Len(t, ents, 1)
+		e := ents[0].(map[string]interface{})
+		assert.Equal(t, 0, e[entityKeyOffset], "caller offset preserved (no prepend, no shift)")
+		assert.Equal(t, 2, e[entityKeyLength])
+	})
+
+	t.Run("render:true but uid is a non-member -> no pill, nothing routed", func(t *testing.T) {
+		req := &pushPayloadReq{
+			Content: "执行吧",
+			Mention: json.RawMessage(`{"uids":["ghost_not_member"],"render":true}`),
+		}
+		mention, content, ignored := w.buildMention(m, req, false)
+		assert.Equal(t, "执行吧", content, "non-member resolves no name -> no compose")
+		assert.Nil(t, mention)
+		assert.Empty(t, ignored)
+	})
+}

--- a/modules/incomingwebhook/model.go
+++ b/modules/incomingwebhook/model.go
@@ -119,11 +119,22 @@ type pushPayloadReq struct {
 //   - Uids     ：要 @ 的成员 UID（用户或 bot），去重后受上限约束，且必须是本群当前成员。
 //   - All      ：@所有人（真人广播），受 webhook 的 allow_mention_all 能力位约束。
 //   - Bots     ：@所有 AI（bot 广播），受 webhook 的 allow_mention_bots 能力位约束。
+//   - Render   ：opt-in，请求服务端把 Uids 解析成可见 @昵称气泡（详见字段注释）。
 //   - Entities ：渲染层 @ 区间（详见字段注释）；定向渲染、不受广播能力位约束。
 type mentionReq struct {
 	Uids []string `json:"uids,omitempty"`
 	All  bool     `json:"all,omitempty"`
 	Bots bool     `json:"bots,omitempty"`
+	// Render 是【定向 @ 昵称渲染】的 opt-in 开关（默认 false）。置 true 时，服务端把 Uids 里
+	// 的【本群成员】解析成展示昵称（group_member LEFT JOIN user → user.name，与群成员列表口径
+	// 一致）、在【纯文本】content 文首补 "@<昵称> "、并【生成】对应的线协议 mention.entities
+	// 元素（offset/length 为 UTF-16 码元）——让只传 uid 的调用方也能渲染出可点击 @气泡，而无需
+	// 自己写昵称文本与偏移（那是 Entities 的【调用方自管】路径）。
+	//
+	// 默认关：#445 老调用方传 uids 只为刷红点 / 唤起 bot、不期望 content 被改写,opt-in 保其行为
+	// 不变。它是【请求侧】字段、不进线协议,客户端不感知;关闭时 content 与 payload 完全不变。
+	// 与 Entities 互斥:调用方自带 Entities 时以其为准、Render 不再自动生成(见 buildMention)。
+	Render bool `json:"render,omitempty"`
 	// Entities 是【渲染层】的 @ 区间（线协议 mention.entities：[{uid,offset,length}]），
 	// 与 uids（路由层）正交：调用方自带 content 文本与每个 @ 的 offset/length，服务端只校验
 	// 每条 entity 的 uid 是本群成员、offset/length 落在 content 的 UTF-16 码元范围内且 offset


### PR DESCRIPTION
## Summary

Closes #448 — the **visible @mention pill** follow-up to #445 (functional flags) and #449 (caller-supplied entities). It ships the two halves #448 asked for, both at the render layer of the **native** incoming-webhook push, using only existing wire fields (zero client change):

- **① Directed name-resolution** (`mention.render`, item ① b): a caller that sends only `mention.uids` gets the server to resolve each member's display name, prepend `@<name> ` to the text content, and **generate** the UTF-16 `mention.entities` — so a bare uid renders a clickable, correctly-bound pill without the caller writing the name/offsets itself.
- **② Broadcast pills** (item ②): when a permitted `mention.all`/`mention.bots` is set, the server prepends the canonical broadcast label (the 所有人 / 所有AI tokens) so every client renders the broadcast pill (previously the flags fired the red-dot/notify/bot-summon but showed no pill).

Both compose in one prepend pass (broadcast first, directed after); routing — red-dot / notify / `ExpandAisToBotUIDs` — is unchanged, and a push that uses neither is byte-identical to today.

## Why this shape (cross-client grounding)

Re-verified against the three client repos: **all three render a pill only from the literal in the content text** — none fabricate one from a flag. iOS regex-scans content; Android `indexOf`-highlights (flag-gated); web `segmentText` regex-matches the name in content. And the directed wire shape (`content` + `{uid,offset,length}` + `uids`) is exactly what `octo-web mentionSendParse` emits when a human @s a member — so a server-rendered directed @ is wire-identical to a client-sent one (web offset-authoritative, Android validates, iOS positional). Offsets are **UTF-16 code units**.

## Changes

- `model.go`: `mentionReq.Render` (opt-in, default off, **request-only** — not on the wire; #445/#449 callers unchanged).
- `db.go`: `filterGroupMembers` now returns `uid→name` (`LEFT JOIN user`, `IFNULL(user.name,'')`, the group member-list source); membership is still key-presence.
- `mention.go`: unified `composeMentionContent` (broadcast literals + directed `@name`s + generated entities + a rune budget). `buildMention` returns `(mention, content, ignored)` and attaches **either** the generated directed entities **or** the shifted caller entities (`render` and caller `entities` are mutually exclusive — #449 is authoritative).
- `api.go`: `handlePush` writes the composed content back via a shared `payloadContentKey` const, guarded by `content != req.Content` — **load-bearing**: the richtext payload stores a blocks *array* under the same key, and richtext never composes, so the guard preserves it.

## Security hardening (from a 3-agent adversarial review)

- **Forged-broadcast guard:** a member whose display name is itself a broadcast label (所有人 / 所有AI / All People / All AIs / all, case-insensitive) or contains `@` is **skipped** for render — otherwise `@<name>` would render as a broadcast pill and bypass the `allow_mention_*` capability gate (or break client `@`-tokenization). The uid still routes via `mention.uids`.
- **Bounds:** the rune budget keeps composed content within `maxContentRunes` (utf8mb4 names → byte size ≤ ~4×, still far below the serialization cap); incremental prefix-length tracking (no `O(n²)` rescan).
- The composed `@<name>` replicates what clients already write into content for any @-mention, so it adds **no novel injection surface** — the render layer (`rehypeSanitize` + `isSafeUrl`) is the controlling boundary; the server does not escape (matching how the same name renders everywhere else). (Aside: the WeChat-nickname path not stripping `@` is a pre-existing `modules/user` gap, out of scope here; the render `@`-skip guard defends this module regardless.)

## Linked Spec

- `.octospec/tasks/incoming-webhook-mention-broadcast/brief.md` (② broadcast)
- `.octospec/tasks/incoming-webhook-mention-directed-render/brief.md` (① directed render)
- journals under `.octospec/journal/shared/incoming-webhook-mention-*.md`

## Testing

```
go test ./modules/incomingwebhook/ -count=1     # ok (live MySQL/Redis/WuKongIM)
golangci-lint run ./modules/incomingwebhook/... # 0 issues (govet, the CI gate)
```

- Pure (no infra): `composeMentionContent` broadcast + directed (gate / idempotency incl. per-token / order / trailing-space / UTF-16 length / budget / **forged-broadcast guard** / no-op identity); `shiftEntityOffsets`.
- Wiring (bare instance): `buildMention` text-path compose, not-permitted, **richtext no-compose**, malformed-mention, backward-compat.
- Integration (live MySQL): broadcast + entity offset-shift; directed render resolving `user.name` → `@name` + generated entity + routing; render↔caller-entities mutual exclusion; non-member skip — asserting `buildMention`'s return directly (no WuKongIM read-back; env limitation per #449).

## COMPREHENSION

1. **Load-bearing path.** On `handlePush → buildMention`, for a **text** push the server prepends a server-built `@`-prefix (gated broadcast literals + opt-in resolved directed `@name`s) to `content`, generating UTF-16 entities for the directed names and shifting any caller entities by the prefix length. Purely additive at the render layer; `mention.{uids,humans,ais}` routing is untouched.
2. **What could break (+ mitigation).** (a) **forged broadcast** via a broadcast-label/`@`-bearing display name → skipped by the guard. (b) **richtext clobber** → the `content != req.Content` guard preserves the blocks array. (c) **double pill** → idempotency on the original content. (d) **mis-bound pill** when broadcast + directed coexist → UTF-16 offset accounting in one pass. (e) **content cap** → rune budget. (f) **backward compat** → no flags / no render ⇒ `content == req.Content`, byte-identical.
3. **How I know it works.** Pure suite proves compose/guard/budget/offsets; bare-instance + live-MySQL integration prove the wiring, the `user.name` resolution, mutual exclusion, and routing; full `go test` + `golangci-lint` green; correctness review returned clean and the security/cleanup findings were applied.

## Known, scoped limitations

- Directed render is **text-path only**; v1 prepends `@name`s at the content head (no caller-controlled inline placement). Display name = `user.name` (`remark` / verified-`real_name` precedence deferred). A name with an internal space renders fully on web/Android but iOS truncates the pill text at the first space (still binds the tap by position — same accepted iOS behavior as #449).
- Idempotency checks the canonical literal / `@name` only (documented substring caveat).

## Checklist

- [x] PR description is in English
- [x] Added tests for my changes
- [x] Followed commit message conventions (Conventional Commits)
- [ ] Updated documentation (swagger note for the mention contract to follow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKr5U3bnKZb3oFDfC9765A