### PR TITLE
refactor(incomingwebhook): harden directed-render guard + wire-seam test (#450 follow-up)

### DIFF
--- a/.octospec/tasks/incoming-webhook-mention-hardening/brief.md
+++ b/.octospec/tasks/incoming-webhook-mention-hardening/brief.md
@@ -1,0 +1,69 @@
+---
+type: Task
+title: "Task: incoming-webhook-mention-hardening"
+description: Post-merge follow-up to #450 — fold invisible/confusable display names into the forged-broadcast guard, and add a handler→wire seam test, both flagged non-blocking on #450.
+tags: ["incomingwebhook", "mention", "trust-boundary", "render-layer", "follow-up"]
+timestamp: 2026-06-24T10:00:00Z
+slug: incoming-webhook-mention-hardening
+upstream: Mininglamp-OSS/octo-server#448
+source: self
+---
+
+# Task: incoming-webhook-mention-hardening
+
+> Follow-up PR after #450 (which closed #448). Picks up the two non-blocking P2s
+> reviewers (yujiawei, Jerry-Xin, Octo-Q) recommended landing as a fast-follow.
+
+## Goal
+
+1. **Invisible/confusable guard.** `isBroadcastLikeName` (the forged-broadcast guard)
+   matched on `strings.ToLower(strings.TrimSpace(name))` only. A display name that
+   embeds a zero-width / bidi / full-width confusable — e.g. `所有<U+200B>人` (ZWSP
+   *inside* the label) — slipped the prefix match yet renders as the visually-identical
+   `@所有人`. Harden: NFKC-fold + strip Unicode format runes (category `Cf`) before the
+   compare, and strip invisibles from the rendered `@name` too, so neither the
+   comparison nor the emitted pill carries an invisible confusable.
+2. **Wire-seam test.** Reviewers flagged that the composed content + generated entities
+   were asserted at `buildMention`'s return, one layer below the wire. Extract
+   `handlePush`'s payload assembly into a behavior-preserving `assemblePushPayload`, and
+   add a MySQL test asserting the composed `payload["content"]` + entities reach the map
+   handed to `SendMessageWithResult` — without a live WuKongIM send.
+
+## Background
+
+- Both items are **cosmetic / completeness**, not security-critical: the invisible-name
+  spoof affects only the *visible* pill — broadcast routing (`humans`/`ais`) is set
+  exclusively by the capability-gated `assembleMention`, never derived from pill text —
+  so it cannot escalate to a real all-member ping. Closed as defense-in-depth on the
+  token-in-URL push ingress. (Jerry-Xin's #450 comment pinned the exact `所有<U+200B>人`
+  inside-label vector.)
+
+## Load-bearing list
+
+- **trust-boundary** — `isBroadcastLikeName` is the forged-broadcast guard; the fold must
+  catch zero-width/bidi (`Cf`) + full-width (NFKC) confusables without over-blocking real
+  names that merely continue a label into a longer word (`所有人事部`, `allen`).
+- **wire-contract** — `assemblePushPayload` is a pure extraction; the outbound payload
+  shape (content + `mention.{uids,entities}`) and the `content != req.Content` richtext
+  write-back guard are byte-for-byte unchanged.
+- **render-layer** — the rendered `@name` is stripped of invisibles; entity offsets/length
+  remain UTF-16 over the (sanitized) composed content.
+
+## Out of scope
+
+- The other #450 P2 trust-model notes (raw `@所有人` literal in content without the
+  capability bit; markdown inert-escaping of `@name`) — documented-intentional design,
+  human-confirmed; no code change.
+- The broadcast-prefix-vs-`maxContentRunes` ≤11 overshoot — accepted documented tradeoff.
+
+## Acceptance
+
+- `所有<U+200B>人` / `<U+202E>所有AI` / full-width `ａｌｌ` → skipped for render (folded to a
+  broadcast label); a real name with an embedded ZWSP (`Bob<U+200B>`) → renders as `@Bob`
+  (invisible stripped), entity length over the sanitized text.
+- `所有人事部`, `allen` still render (boundary check preserved, no over-block).
+- `assemblePushPayload`: composed `content` + generated entities land in the returned
+  payload; richtext blocks array preserved (guard unchanged); behavior identical to the
+  prior inline block.
+- No literal invisible runes in module source; `go test ./modules/incomingwebhook/...`
+  (DB-backed) + pure tests pass; `golangci-lint` clean.

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -1101,6 +1101,37 @@ func (w *IncomingWebhook) failAuth(c *wkhttp.Context, ip string) {
 	pushUnauthorized(c)
 }
 
+// assemblePushPayload 把 buildMention 的产出落到出站 payload：回写补文案后的 content（带
+// content!=req.Content 守卫，绝不覆盖 richtext 的 blocks 数组）、挂上 mention 子对象、并在
+// clone 上把 @所有AI 展开成 bot uid。返回（可能被替换的）payload 与 mention_ignored 反馈。
+//
+// 从 handlePush 抽出，使「handler→wire 接缝」——补文案后的 content + 生成的 entities 真正进入
+// payload——可在【不依赖 WuKongIM 发送】的前提下单测（#450 follow-up，回应 reviewer 的 wire-bytes
+// 测试缺口）。行为与原内联块逐字一致。
+func (w *IncomingWebhook) assemblePushPayload(
+	m *incomingWebhookModel, req *pushPayloadReq, payload map[string]interface{}, broadcastPermitted bool,
+) (map[string]interface{}, []string) {
+	mention, content, ignored := w.buildMention(m, req, broadcastPermitted)
+	// 广播/定向补文案可能在 content 文首前置了 @所有人/@所有AI/@<昵称>（仅 text 路径）。仅当 content
+	// 确被改写（!= req.Content）才回写 payload[content]，使前置后的正文进入 wire。
+	// 这个守卫【必须保留】：richtext 路径 payload[content] 存的是 blocks 数组（buildRichTextPayload），
+	// 而 buildMention 对 richtext 不补文案（content==req.Content）→ 守卫为假、不覆盖，数组得以保全；
+	// 去掉守卫会把数组覆盖成字符串、毁掉富文本消息。无补文案时同样不触发覆盖，payload 字节不变。
+	if content != req.Content {
+		payload[payloadContentKey] = content
+	}
+	if mention != nil {
+		payload[mentionrewrite.MentionKey] = mention
+		// 与 message/robot/bot_api 入口一致：在 clone 上做 ais→bot uid 展开，避免就地
+		// 改写共享 map（本路径 payload 随即序列化、当前无下游读取，但仍守该约定，PR #145）。
+		wire := mentionrewrite.CloneForExpansion(payload)
+		wire = mentionrewrite.ExpandAisToBotUIDs(
+			wire, common.ChannelTypeGroup.Uint8(), m.GroupNo, w.fetchBotMemberUIDs)
+		payload = wire
+	}
+	return payload, ignored
+}
+
 // push / pushGitHub / pushWeCom / pushMultica / pushGitLab / pushFeishu 是各推送形态的
 // 路由入口，全部走 handlePush 流水线，仅在 adapter（body 解析 / bodyLimit / successExtra）
 // 上分叉。
@@ -1328,25 +1359,7 @@ func (w *IncomingWebhook) handlePush(c *wkhttp.Context, ad pushAdapter) {
 		// 关掉设置即把全部【成员】创建的 webhook 的广播位立即剥离；管理员建的不受影响。
 		// 定向 @uid 不走此闸（不是广播、风险低）。
 		broadcastPermitted := w.settings.IncomingWebhookMemberCanBroadcast() || creatorIsAdmin
-		mention, content, ignored := w.buildMention(m, req, broadcastPermitted)
-		mentionIgnored = ignored
-		// 广播补文案可能在 content 文首前置了 @所有人/@所有AI（仅 text 路径）。仅当 content 确被
-		// 改写（!= req.Content）才回写 payload[content]，使前置后的正文进入 wire。
-		// 这个守卫【必须保留】：richtext 路径 payload[content] 存的是 blocks 数组（buildRichTextPayload），
-		// 而 buildMention 对 richtext 不补文案（content==req.Content）→ 守卫为假、不覆盖，数组得以保全；
-		// 去掉守卫会把数组覆盖成字符串、毁掉富文本消息。无补文案时同样不触发覆盖，payload 字节不变。
-		if content != req.Content {
-			payload[payloadContentKey] = content
-		}
-		if mention != nil {
-			payload[mentionrewrite.MentionKey] = mention
-			// 与 message/robot/bot_api 入口一致：在 clone 上做 ais→bot uid 展开，避免就地
-			// 改写共享 map（本路径 payload 随即序列化、当前无下游读取，但仍守该约定，PR #145）。
-			wire := mentionrewrite.CloneForExpansion(payload)
-			wire = mentionrewrite.ExpandAisToBotUIDs(
-				wire, common.ChannelTypeGroup.Uint8(), m.GroupNo, w.fetchBotMemberUIDs)
-			payload = wire
-		}
+		payload, mentionIgnored = w.assemblePushPayload(m, req, payload, broadcastPermitted)
 	}
 
 	resp, err := w.ctx.SendMessageWithResult(&config.MsgSendReq{

--- a/modules/incomingwebhook/mention.go
+++ b/modules/incomingwebhook/mention.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
 	"go.uber.org/zap"
+	"golang.org/x/text/unicode/norm"
 )
 
 // decodeMention 宽松解码 native 请求里的 mention 原始字节（acceptance #6）：
@@ -76,13 +77,29 @@ var broadcastLabels = map[string]struct{}{
 	"所有人": {}, "所有ai": {}, "all": {}, "all people": {}, "all ais": {},
 }
 
-// isBroadcastLikeName 报告 name（trim+小写后）会不会被端上当成广播 token——不止【精确】命中标签集,
-// 还包括「以广播标签开头、其后紧跟非字边界」。因为 iOS 按 @\S+ 切词:名 "所有人 X" 会切出独立
-// token "@所有人"、名 "所有人:" 同理,都会渲染成广播气泡(伪造一次绕过 allow_mention_* 的全员广播)。
-// 仅当标签后紧跟字母/数字/CJK 时(如 "所有人事部"/"allen")才是另一个真实词、不算广播,照常渲染定向气泡。
-// 单字标签(所有人/所有ai/all)即覆盖多字标签(all people/all ais)的边界,因 iOS 首个 @\S+ token 止于空格。
+// stripFormatRunes 删除 Unicode 格式字符（category Cf：零宽 ZWSP/ZWNJ/ZWJ、BOM、word-joiner
+// 及 LRE/RLE/PDF/LRI… 等 bidi 控制符）。它们不可见,昵称可借此把零宽字符塞进广播标签【内部】
+// （"所有<U+200B>人"）骗过 HasPrefix 比对、却渲染成视觉一模一样的 "@所有人"。guard 比对与渲染昵称
+// 都先过它,确保比对不被绕过、且生成的气泡文本绝不携带不可见混淆字符。
+func stripFormatRunes(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.Is(unicode.Cf, r) {
+			return -1 // 丢弃
+		}
+		return r
+	}, s)
+}
+
+// isBroadcastLikeName 报告 name 会不会被端上当成广播 token——不止【精确】命中标签集,还包括
+// 「以广播标签开头、其后紧跟非字边界」。因为 iOS 按 @\S+ 切词:"所有人 X" 会切出独立 token
+// "@所有人"、"所有人:" 同理,都会渲染成广播气泡(伪造一次绕过 allow_mention_* 的全员广播)。
+// 仅当标签后紧跟字母/数字/CJK 时(如 "所有人事部"/"allen")才是另一个真实词、不算广播,照常渲染。
+// 单字标签(所有人/所有ai/all)即覆盖多字标签(all people/all ais)的边界,因 iOS 首个 token 止于空格。
+//
+// 比对前先 NFKC 折叠(全角 "ａｌｌ"→"all" 等【可见】混淆)+ stripFormatRunes(剥离【不可见】混淆)
+// + 小写,把零宽/bidi/全角 confusable 都收敛到 canonical 形式再比,杜绝绕过(yujiawei/Jerry-Xin #450)。
 func isBroadcastLikeName(name string) bool {
-	n := strings.ToLower(strings.TrimSpace(name))
+	n := strings.ToLower(strings.TrimSpace(stripFormatRunes(norm.NFKC.String(name))))
 	if n == "" {
 		return false
 	}
@@ -160,9 +177,11 @@ func composeMentionContent(content string, wantAll, wantBots, allowAll, allowBot
 			if _, dup := seen[uid]; dup {
 				continue
 			}
-			name := strings.TrimSpace(namesByUID[uid])
+			// 先剥离不可见格式字符（零宽/bidi）再 trim：渲染出的气泡不带不可见混淆字符，且下面
+			// 的 broadcast-like 比对看到的是 canonical 形式（"所有<U+200B>人"→"所有人"，无法夹零宽绕过）。
+			name := strings.TrimSpace(stripFormatRunes(namesByUID[uid]))
 			if name == "" {
-				continue // 非成员 / 未解析到昵称 → 不渲染（绝不补 "@ "）
+				continue // 非成员 / 未解析到昵称 / 仅由格式字符构成 → 不渲染（绝不补 "@ "）
 			}
 			if isBroadcastLikeName(name) || strings.Contains(name, "@") {
 				continue // 防伪造广播 / 嵌入式 @：昵称会被端上当成广播 token 或破坏 @ 分词

--- a/modules/incomingwebhook/mention_directed_render_test.go
+++ b/modules/incomingwebhook/mention_directed_render_test.go
@@ -88,7 +88,7 @@ func TestComposeMentionContentDirected(t *testing.T) {
 
 	t.Run("broadcast-like names skipped (exact + boundary + embedded '@'); real names still render", func(t *testing.T) {
 		// Skipped: exact label (所有人 / All AIs), label + non-word boundary (所有人 X / 所有人: / all-hands —
-		// iOS @\S+ would emit a standalone @所有人 / @all broadcast token), and any name containing '@'.
+		// iOS @-token scanning would emit a standalone @所有人 / @all broadcast token), and any name with '@'.
 		// Rendered: a label that continues into a longer word (所有人事部 = HR dept; allen) is a real name.
 		nm := map[string]string{
 			"a": "所有人", "b": "所有人 X", "c": "所有人:", "d": "All AIs", "e": "@x", "f": "all-hands",
@@ -100,6 +100,26 @@ func TestComposeMentionContentDirected(t *testing.T) {
 		require.Len(t, ents, 2)
 		assert.Equal(t, "g", ents[0].(map[string]interface{})[entityKeyUID])
 		assert.Equal(t, "h", ents[1].(map[string]interface{})[entityKeyUID])
+	})
+
+	t.Run("invisible/bidi/full-width confusables: folded for the guard, stripped from the pill", func(t *testing.T) {
+		// zwsp/rlo are built via rune() so there are no literal invisible bytes in source. A ZWSP *inside*
+		// a label, an RLO bidi prefix, and a full-width spelling all fold to a broadcast label and are
+		// skipped; a real name still renders but with the invisible rune stripped from the pill.
+		zwsp, rlo := string(rune(0x200B)), string(rune(0x202E))
+		nm := map[string]string{
+			"a": "所有" + zwsp + "人", // ZWSP (U+200B) inside the label -> folds to 所有人 -> skipped
+			"b": rlo + "所有AI",      // RLO (U+202E) bidi prefix -> 所有AI -> skipped
+			"c": "ａｌｌ",             // full-width letters -> NFKC "all" -> skipped
+			"d": "Bob" + zwsp,      // ZWSP in a real name -> renders, invisible stripped from the pill
+		}
+		c, _, ents := composeMentionContent("body", false, false, false, false, true,
+			[]string{"a", "b", "c", "d"}, nm, 0)
+		assert.Equal(t, "@Bob body", c, "confusable broadcast-likes skipped; real name renders with the invisible rune stripped")
+		require.Len(t, ents, 1)
+		e := ents[0].(map[string]interface{})
+		assert.Equal(t, "d", e[entityKeyUID])
+		assert.Equal(t, 4, e[entityKeyLength]) // "@Bob" = 4 UTF-16 (ZWSP gone)
 	})
 }
 
@@ -178,4 +198,50 @@ func TestBuildMentionDirectedRender(t *testing.T) {
 		assert.Nil(t, mention)
 		assert.Empty(t, ignored)
 	})
+}
+
+// TestAssemblePushPayload_DirectedRenderReachesWire is the handler→wire seam (needs MySQL, no
+// WuKongIM): it asserts the composed content + generated entities actually land in the payload
+// map that handlePush hands to SendMessageWithResult — closing the wire-bytes gap reviewers
+// flagged on #450 (buildMention's return was asserted one layer below this).
+func TestAssemblePushPayload_DirectedRenderReachesWire(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+	w := newIncomingWebhook(ctx)
+
+	const groupNo = "g_wire"
+	const uid = "u_wire_bot"
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO group_member(group_no, uid, role, status, is_deleted, version) VALUES(?, ?, 0, 1, 0, 1)",
+		groupNo, uid).Exec()
+	require.NoError(t, err)
+	_, err = ctx.DB().InsertInto("user").Columns("uid", "name", "username", "short_no", "status").
+		Values(uid, "我的天", uid, "sn_"+uid, 1).Exec()
+	require.NoError(t, err)
+
+	m := &incomingWebhookModel{WebhookID: "iwh_wire", GroupNo: groupNo}
+	req := &pushPayloadReq{
+		Content: "执行吧",
+		Mention: json.RawMessage(fmt.Sprintf(`{"uids":["%s"],"render":true}`, uid)),
+	}
+	// base payload mirrors the text-path payload handlePush builds before mention assembly.
+	base := map[string]interface{}{payloadContentKey: req.Content}
+
+	payload, ignored := w.assemblePushPayload(m, req, base, false)
+	assert.Empty(t, ignored)
+
+	// composed content reached the wire payload under the shared content key.
+	assert.Equal(t, "@我的天 执行吧", payload[payloadContentKey])
+
+	mention, ok := payload[mentionrewrite.MentionKey].(map[string]interface{})
+	require.Truef(t, ok, "mention attached to payload; got %v", payload)
+	uids, _ := mention[mentionrewrite.UIDsKey].([]interface{})
+	assert.Contains(t, uids, uid, "uid carried for routing")
+	ents, ok := mention[mentionrewrite.EntitiesKey].([]interface{})
+	require.True(t, ok, "generated entities reached the wire")
+	require.Len(t, ents, 1)
+	e := ents[0].(map[string]interface{})
+	assert.Equal(t, uid, e[entityKeyUID])
+	assert.Equal(t, 0, e[entityKeyOffset])
+	assert.Equal(t, 4, e[entityKeyLength])
 }


### PR DESCRIPTION
## Summary

Post-merge follow-up to #450 (which closed #448). Lands the two **non-blocking** P2 hardenings reviewers (yujiawei / Jerry-Xin / Octo-Q) recommended as a fast-follow. No behavior change for valid inputs; the payload wire shape is unchanged.

### 1. Invisible/confusable display-name guard (`mention.go`)
The forged-broadcast guard `isBroadcastLikeName` matched on `ToLower(TrimSpace(name))` only. A display name embedding a zero-width / bidi / full-width confusable — e.g. `所有<U+200B>人` (a ZWSP **inside** the label, the exact vector Jerry-Xin pinned on #450) — slipped the prefix match yet rendered as the visually-identical `@所有人`.

- `isBroadcastLikeName` now **NFKC-folds + strips Unicode format runes** (category `Cf`: zero-width ZWSP/ZWNJ/ZWJ/BOM/word-joiner + the LRE/RLE/…/bidi controls) before the label compare.
- The **rendered `@name`** is likewise stripped of invisibles, so the emitted pill can't carry an invisible confusable.
- Names that merely continue a label into a longer word (`所有人事部`, `allen`) still render — the boundary check is preserved, no over-block.

**Severity: cosmetic only.** Broadcast routing (`humans`/`ais`) is set exclusively by the capability-gated `assembleMention`, never derived from pill text — so this never could escalate to a real all-member ping. Closed as defense-in-depth on the token-in-URL push ingress.

### 2. Wire-seam test (`api.go`)
Reviewers flagged that the composed content + generated entities were asserted at `buildMention`'s return — one layer below the wire. Extracted `handlePush`'s payload assembly into a **behavior-preserving** `assemblePushPayload`; a new MySQL test (`TestAssemblePushPayload_DirectedRenderReachesWire`) asserts the composed `payload["content"]` + entities reach the map handed to `SendMessageWithResult` — with **no live WuKongIM send**.

## Testing
- **Pure:** `isBroadcastLikeName` boundary + NFKC / invisible / bidi / full-width confusables (inputs built via `rune()` so there are **no literal invisible bytes in source**); a real ZWSP-bearing name renders with the invisible stripped.
- **DB-backed (MySQL):** the `assemblePushPayload` wire-seam; existing `buildMention` directed-render + mutual-exclusion + non-member tests.
- `golangci-lint` clean; module source scanned for stray invisible runes (none).
- The WuKongIM-dependent `TestMentionPush_*` e2e tests run in CI; the `assemblePushPayload` extraction is behavior-preserving, so they exercise the same path.

## Linked Spec
- `.octospec/tasks/incoming-webhook-mention-hardening/brief.md`

Follow-up to #450 / #448 — does not close a new issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKr5U3bnKZb3oFDfC9765A

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKr5U3bnKZb3oFDfC9765A)_