### PR TITLE
feat(incomingwebhook): add /v1/webhooks push route alias for /v1/incoming-webhooks

### DIFF
--- a/.octospec/journal/shared/incomingwebhook-webhooks-alias.md
+++ b/.octospec/journal/shared/incomingwebhook-webhooks-alias.md
@@ -1,0 +1,65 @@
+---
+type: Journal
+title: "Journal: incomingwebhook-webhooks-alias (octo-server #455)"
+description: Record of the /v1/webhooks push route alias + token-scrub generalization and the rules honored.
+tags: ["webhook", "trust-boundary", "routing", "accesslog"]
+timestamp: 2026-06-24T13:00:00Z
+# --- octospec extension fields ---
+task: incomingwebhook-webhooks-alias
+upstream: Mininglamp-OSS/octo-server#455
+source: self
+---
+# Journal: incomingwebhook-webhooks-alias (octo-server #455)
+
+## What was done
+Added a shorter push-route alias so the incoming-webhook push endpoints are
+reachable at both `/v1/incoming-webhooks/{id}/{token}[/adapter]` (canonical,
+unchanged) and `/v1/webhooks/{id}/{token}[/adapter]` (new alias). Purely
+additive — same handlers, same middleware chain, same behavior.
+
+1. **Routes** — `modules/incomingwebhook/api.go` `Route`: factored the 6 push
+   registrations (native + github/wecom/multica/gitlab/feishu) into a
+   `mountPush(prefix)` closure and called it for both `/incoming-webhooks` and
+   `/webhooks` on the same `push` group via the identical `chain(...)`
+   (`requirePushEnabled → localFloorMiddleware → ipLimit →
+   ipFailureGateMiddleware`). No auth/rate-limit/quota divergence between paths.
+
+2. **Token-in-path scrubbing (security, #246)** — `pkg/accesslog/accesslog.go`:
+   replaced the single `incomingWebhookPrefix` const with a
+   `webhookPushPrefixes` slice (`/v1/incoming-webhooks/`, `/v1/webhooks/`);
+   `ScrubPath` now loops over both. Generalized the panic-dump `tokenInText`
+   regex to `(/v1/(?:incoming-)?webhooks/[^/\s?"']+/)[^\s?"']+`. Both stay
+   case-insensitive. Without this the alias would leak plaintext tokens into
+   access logs and the `gin.Recovery` panic dump.
+
+3. **Canonical URL unchanged** — `publicURL`/`publicURLs` still advertise
+   `/v1/incoming-webhooks/...` (alias is backward-compatible only).
+
+4. **Tests** — `modules/incomingwebhook/alias_push_test.go` (alias native push
+   passes auth+validation; wrong token → 401 proving the same chain; github ping
+   → 200 skipped like canonical). `pkg/accesslog/accesslog_test.go` added alias
+   table cases + panic-dump scrub + two false-positive guards (`/v1/webhook` and
+   `/v1/groups/.../incoming-webhooks` must NOT be scrubbed).
+
+## Rules honored
+- **trust-boundary** (load-bearing): adapter/path parity — the token-scrub
+  defense added for the canonical path now holds for the sibling alias; the alias
+  reuses the exact same middleware chain rather than a divergent one.
+- **testing**: e2e via `testutil.NewTestServer`; accesslog table cases for both
+  prefixes incl. negative guards.
+- **commit-style**: Conventional Commits, English.
+
+## Verification
+`go test ./modules/incomingwebhook/... ./modules/webhook/... ./pkg/accesslog/...`
+all green (full integration stack: MySQL 8.0 + Redis + WuKongIM
+v2.2.4-20260313). `go vet`, `golangci-lint`, `make i18n-extract-check`, and
+`make i18n-lint` all clean. No gin route-registration panic (the
+`NewTestServer` route build exercises it).
+
+## Learning
+The `/v1/` segment has only static children, so a new static `webhooks` segment
+cannot collide with a sibling wildcard in gin's httprouter radix tree — the
+divergence from the existing singular `/v1/webhook` is just the char `s` (a node
+can be both a handler and have children). This made the alias safe to add with no
+route restructuring. Worth remembering when adding sibling prefixes: the risk is
+wildcard-vs-static at the same tree level, which does not exist here.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -6,6 +6,12 @@ change-log convention (§7). Newest first.
 
 ## 2026-06-24
 
+- **Add** — Task `incomingwebhook-webhooks-alias` (#455): `/v1/webhooks/{id}/{token}`
+  push-route alias for the canonical `/v1/incoming-webhooks/...` (native + 5
+  adapters), reusing the identical middleware chain. Generalized `pkg/accesslog`
+  token scrubbing (`ScrubPath` + panic-dump regex) to mask BOTH prefixes (#246
+  parity). Brief + context under `.octospec/tasks/incomingwebhook-webhooks-alias/`,
+  journal `.octospec/journal/shared/incomingwebhook-webhooks-alias.md`.
 - **Add** — Task `incoming-webhook-mention-broadcast` (#448 item ②): broadcast-pill
   auto-compose on the native incoming-webhook push endpoint. When a permitted
   `mention.all`/`mention.bots` is set, the server prepends the canonical broadcast

--- a/.octospec/tasks/incomingwebhook-webhooks-alias/brief.md
+++ b/.octospec/tasks/incomingwebhook-webhooks-alias/brief.md
@@ -1,0 +1,70 @@
+---
+type: Task
+title: "Task: incomingwebhook-webhooks-alias"
+description: Add /v1/webhooks/{id}/{token} push route alias for /v1/incoming-webhooks/... with matching token scrubbing.
+tags: ["webhook", "trust-boundary", "wire-contract"]
+timestamp: 2026-06-24T00:00:00Z
+# --- octospec extension fields ---
+slug: incomingwebhook-webhooks-alias
+upstream: Mininglamp-OSS/octo-server#455
+source: self
+---
+
+# Task: incomingwebhook-webhooks-alias
+
+## Goal
+Make the incoming-webhook **push** endpoints reachable at a shorter alias path in
+addition to the existing canonical path:
+
+- `/v1/incoming-webhooks/{webhook_id}/{token}[/...]` — canonical, unchanged.
+- `/v1/webhooks/{webhook_id}/{token}[/...]` — new alias (native + 5 adapters).
+
+Same handlers, same middleware chain, same behavior — purely an additional
+accepted path. Only the push ingress is aliased; management endpoints unchanged.
+
+## Background
+Follow-up to #454. `/v1/webhooks` (plural) is currently unused; only singular
+`/v1/webhook*` exists in `modules/webhook/api.go`. Conflict analysis (issue #455 +
+my diagnosis comment) confirms no gin route-registration conflict: `/v1/` has only
+static children, so a new static `webhooks` segment cannot collide with a sibling
+wildcard, and `:webhook_id` appears only after `webhooks/`.
+
+## Load-bearing list
+- **webhook / trust-boundary**: the push ingress is the unauthenticated,
+  token-in-URL attack surface. The new alias must inherit the **identical**
+  middleware chain (`requirePushEnabled → localFloorMiddleware → ipLimit →
+  ipFailureGateMiddleware`) — no auth/rate-limit divergence between the two paths.
+- **trust-boundary (token-in-path scrubbing, #246)**: `pkg/accesslog` masks tokens
+  ONLY for `/v1/incoming-webhooks/`. The alias would otherwise leak plaintext
+  tokens into access logs + `gin.Recovery` panic dumps. Both `ScrubPath`
+  (`incomingWebhookPrefix`) and the `tokenInText` regex MUST cover both prefixes.
+  This is the adapter-parity invariant: a defense for one path must hold for its
+  sibling.
+- **wire-contract**: push request/response shape and status codes must be
+  byte-identical across both prefixes (additive, backward-compatible).
+
+## Out of scope
+- Changing the canonical push URL or `publicURL`/`publicURLs` (still advertise
+  `/v1/incoming-webhooks/...`).
+- Any management endpoint (`/v1/groups/.../incoming-webhooks`).
+- The separate `modules/webhook` (`/v1/webhook*`) module.
+
+## Acceptance
+- `POST /v1/webhooks/{id}/{token}` and `.../{adapter}` (github/wecom/multica/
+  gitlab/feishu) behave identically to their `/v1/incoming-webhooks/...`
+  equivalents (same auth / rate-limit / delivery).
+- `pkg/accesslog`: `ScrubPath`, the panic-dump `scrubbingErrorWriter`, and
+  `Formatter` mask the token for BOTH prefixes; management/singular/unrelated
+  paths still pass through unchanged. New table cases prove it.
+- No gin route-registration panic (covered by `NewTestServer` route build).
+- `go test ./modules/incomingwebhook/... ./modules/webhook/... ./pkg/accesslog/...`
+  passes; `golangci-lint run` clean on touched files.
+
+## Implementation notes
+- `modules/incomingwebhook/api.go` `Route`: factor the 6 push registrations into a
+  small helper `mountPush(prefix)` (or a loop over the adapter-suffix list) and
+  call it for both `/incoming-webhooks` and `/webhooks` on the same `push` group
+  with the same `chain(...)`.
+- `pkg/accesslog/accesslog.go`: generalize prefix matching to
+  `/v1/(incoming-)?webhooks/`. Verified no false positives for
+  `/v1/groups/.../incoming-webhooks`, `/v1/webhook`, `/v1/webhook/github`.

--- a/.octospec/tasks/incomingwebhook-webhooks-alias/context.yaml
+++ b/.octospec/tasks/incomingwebhook-webhooks-alias/context.yaml
@@ -20,5 +20,5 @@ rules_applied:
 files_touched:
   - modules/incomingwebhook/api.go        # mount push routes for both prefixes
   - pkg/accesslog/accesslog.go            # generalize ScrubPath + tokenInText to both prefixes
-  - modules/incomingwebhook/api_test.go   # alias push e2e (native + adapter)
+  - modules/incomingwebhook/alias_push_test.go  # alias push e2e (native + adapter)
   - pkg/accesslog/accesslog_test.go       # alias scrub table cases

--- a/.octospec/tasks/incomingwebhook-webhooks-alias/context.yaml
+++ b/.octospec/tasks/incomingwebhook-webhooks-alias/context.yaml
@@ -1,0 +1,24 @@
+slug: incomingwebhook-webhooks-alias
+upstream: Mininglamp-OSS/octo-server#455
+rules_applied:
+  - id: trust-boundary
+    tier: repo
+    load_bearing: true
+    why: >
+      Push ingress is the unauthenticated token-in-URL attack surface. Alias must
+      inherit the identical middleware chain (parity), and the access-log token
+      scrubbing (#246) must cover the new prefix too — a defense for one path must
+      hold for its sibling.
+  - id: testing
+    tier: repo
+    load_bearing: false
+    why: Alias push e2e tests + accesslog table cases for both prefixes.
+  - id: commit-style
+    tier: repo
+    load_bearing: false
+    why: Conventional Commits, English.
+files_touched:
+  - modules/incomingwebhook/api.go        # mount push routes for both prefixes
+  - pkg/accesslog/accesslog.go            # generalize ScrubPath + tokenInText to both prefixes
+  - modules/incomingwebhook/api_test.go   # alias push e2e (native + adapter)
+  - pkg/accesslog/accesslog_test.go       # alias scrub table cases

--- a/modules/incomingwebhook/adapter.go
+++ b/modules/incomingwebhook/adapter.go
@@ -1,14 +1,18 @@
 package incomingwebhook
 
-// 推送形态适配层（#297 Phase 3 / #426）。
+// 推送形态适配层（#297 Phase 3/4 / #426）。
 //
 // 多种推送形态共享同一条鉴权 / 限流 / 群校验 / 投递 / 审计流水线（api.go handlePush），
-// 彼此只差「如何把请求 body 翻译成 native 推送请求」这一步：
+// 彼此只差「如何把请求 body 翻译成 native 推送请求」这一步。下列路径同时挂在 canonical
+// 前缀 /v1/incoming-webhooks 与短别名 /v1/webhooks 上（#455，两前缀共用同一套 handler/
+// 中间件，见 api.go 的 mountPush）：
 //
 //   - native（历史契约）   POST /v1/incoming-webhooks/:webhook_id/:token
 //   - GitHub 事件          POST .../:token/github   （adapter_github.go）
 //   - 企业微信群机器人格式  POST .../:token/wecom    （adapter_wecom.go）
 //   - Multica 出站事件     POST .../:token/multica  （adapter_multica.go）
+//   - GitLab 事件          POST .../:token/gitlab   （adapter_gitlab.go）
+//   - 飞书自定义机器人格式  POST .../:token/feishu   （adapter_feishu.go）
 //
 // 适配器不是新的攻击面：URL token 鉴权、四层限流、群 Normal 校验、payload 白名单
 // 构造（buildPayload / buildRichTextPayload 注入 from.kind=webhook 与服务端 space_id）

--- a/modules/incomingwebhook/alias_push_test.go
+++ b/modules/incomingwebhook/alias_push_test.go
@@ -67,11 +67,24 @@ func TestAliasPush_GitHubPing_SkippedLikeCanonical(t *testing.T) {
 // multica/gitlab/feishu 4 个适配器后缀未在别名上单测——mountPush 闭包让 6 条统一注册、
 // 结构上不可能漏挂，这条遍历测试把该不变量显式钉死（belt & suspenders）。
 func TestAliasPush_AllPushRoutesRegistered(t *testing.T) {
+	// 固定宽松的限流 env，让本测试自包含、不受 CI 全局调低 burst 影响（#456 review
+	// Jerry-Xin 🟡）：6 次错误 token 在默认 burst(60) 下本就安全，但若某环境全局压低
+	// IP_FAIL_BURST / IP_BURST / local-floor 桶，401 可能翻成 429。strict 限流器与
+	// local floor 在 Route()/New() 构造时读 env，故必须在 setupTestEnv 之前 Setenv。
+	t.Setenv("DM_INCOMINGWEBHOOK_IP_FAIL_RPS", "10000")
+	t.Setenv("DM_INCOMINGWEBHOOK_IP_FAIL_BURST", "10000")
+	t.Setenv("DM_INCOMINGWEBHOOK_IP_RPS", "10000")
+	t.Setenv("DM_INCOMINGWEBHOOK_IP_BURST", "10000")
+	t.Setenv("DM_INCOMINGWEBHOOK_LOCAL_RPS", "10000")
+	t.Setenv("DM_INCOMINGWEBHOOK_LOCAL_BURST", "10000")
+	t.Setenv("DM_INCOMINGWEBHOOK_LOCAL_PERIP_RPS", "10000")
+	t.Setenv("DM_INCOMINGWEBHOOK_LOCAL_PERIP_BURST", "10000")
+
 	handler, ctx, groupNo := setupTestEnv(t)
 	whID, _ := createWebhookWithToken(t, handler, groupNo)
 
-	// 固定 IP + 重置失败/限流桶：6 次错误 token 会消耗 per-IP 失败预算（默认 burst 60，
-	// 6 次远未触顶），固定 IP 让本测试与并发的其它匿名推送测试互不串桶。
+	// 固定 IP + 重置失败/限流桶：6 次错误 token 走同一 IP，重置桶让本测试与并发的其它
+	// 匿名推送测试互不串桶（env 已宽松，桶容量也足够）。
 	const ip = "203.0.113.201"
 	resetIPFailBucket(t, ctx, ip)
 	resetStrictIPBucket(t, ctx, ip)

--- a/modules/incomingwebhook/alias_push_test.go
+++ b/modules/incomingwebhook/alias_push_test.go
@@ -1,0 +1,63 @@
+package incomingwebhook_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #455：/v1/webhooks/{id}/{token} 是 canonical /v1/incoming-webhooks/... 推送端点的
+// 短别名，共用同一套 handler / 中间件链 / 限流桶。这里端到端验证别名行为与 canonical
+// 一致（同鉴权 / 同校验 / 同投递），并锁住「别名也走同一条鉴权链」这一安全不变量。
+// 与既有 push 测试同口径：成功路径只断言「未被 4xx 挡下」，下游 SendMessage 在测试桩
+// 下可能 200/502。
+
+// aliasPush 向 /v1/webhooks 别名前缀发原始 body（suffix 为空走 native，否则走适配器）。
+func aliasPush(handler http.Handler, whID, token, suffix string, body []byte) *httptest.ResponseRecorder {
+	path := fmt.Sprintf("/v1/webhooks/%s/%s", whID, token)
+	if suffix != "" {
+		path += "/" + suffix
+	}
+	return do(handler, anonReq("POST", path, body))
+}
+
+// 别名 native 推送：与 canonical 一样通过鉴权 + 校验（非 4xx）。
+func TestAliasPush_Native_Success(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	body := []byte(`{"content":"hello via alias"}`)
+	w := aliasPush(handler, whID, token, "", body)
+
+	assert.NotEqualf(t, http.StatusUnauthorized, w.Code, "valid token must authorize via alias; body=%s", w.Body.String())
+	assert.NotEqualf(t, http.StatusBadRequest, w.Code, "valid body must pass validation via alias; body=%s", w.Body.String())
+	assert.NotEqualf(t, http.StatusNotFound, w.Code, "alias route must be registered; body=%s", w.Body.String())
+}
+
+// 别名鉴权链与 canonical 完全一致：错误 token 必须 401（证明别名没有绕过鉴权）。
+func TestAliasPush_WrongToken_Unauthorized(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, _ := createWebhookWithToken(t, handler, groupNo)
+
+	w := aliasPush(handler, whID, "wrong-token", "", []byte(`{"content":"x"}`))
+	assert.Equalf(t, http.StatusUnauthorized, w.Code, "wrong token must 401 via alias; body=%s", w.Body.String())
+}
+
+// 别名适配器路由（GitHub ping）：与 canonical 一致 200 + skipped，证明 6 条推送形态都
+// 在别名前缀下注册并走同一条链。
+func TestAliasPush_GitHubPing_SkippedLikeCanonical(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	whID, token := createWebhookWithToken(t, handler, groupNo)
+
+	r := anonReq("POST", fmt.Sprintf("/v1/webhooks/%s/%s/github", whID, token),
+		[]byte(`{"zen":"Keep it logically awesome.","hook_id":1}`))
+	r.Header.Set("X-GitHub-Event", "ping")
+	w := do(handler, r)
+
+	require.Equalf(t, http.StatusOK, w.Code, "alias github ping must 200; body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), `"skipped"`, "alias ping must mark delivery skipped, same as canonical")
+}

--- a/modules/incomingwebhook/alias_push_test.go
+++ b/modules/incomingwebhook/alias_push_test.go
@@ -61,3 +61,28 @@ func TestAliasPush_GitHubPing_SkippedLikeCanonical(t *testing.T) {
 	require.Equalf(t, http.StatusOK, w.Code, "alias github ping must 200; body=%s", w.Body.String())
 	assert.Contains(t, w.Body.String(), `"skipped"`, "alias ping must mark delivery skipped, same as canonical")
 }
+
+// 别名前缀下全部 6 条推送形态（native + 5 个适配器）都已注册并走同一条鉴权链：错误 token
+// 一律 401，证明每条别名路由都存在且经过 token 校验。#456 review (Octo-Q P2) 指出 wecom/
+// multica/gitlab/feishu 4 个适配器后缀未在别名上单测——mountPush 闭包让 6 条统一注册、
+// 结构上不可能漏挂，这条遍历测试把该不变量显式钉死（belt & suspenders）。
+func TestAliasPush_AllPushRoutesRegistered(t *testing.T) {
+	handler, ctx, groupNo := setupTestEnv(t)
+	whID, _ := createWebhookWithToken(t, handler, groupNo)
+
+	// 固定 IP + 重置失败/限流桶：6 次错误 token 会消耗 per-IP 失败预算（默认 burst 60，
+	// 6 次远未触顶），固定 IP 让本测试与并发的其它匿名推送测试互不串桶。
+	const ip = "203.0.113.201"
+	resetIPFailBucket(t, ctx, ip)
+	resetStrictIPBucket(t, ctx, ip)
+
+	for _, suffix := range []string{"", "github", "wecom", "multica", "gitlab", "feishu"} {
+		path := fmt.Sprintf("/v1/webhooks/%s/%s", whID, "wrong-token")
+		if suffix != "" {
+			path += "/" + suffix
+		}
+		w := do(handler, anonReqIP("POST", path, []byte(`{"content":"x"}`), ip))
+		assert.Equalf(t, http.StatusUnauthorized, w.Code,
+			"alias route %q must be registered and reject a wrong token with 401; body=%s", path, w.Body.String())
+	}
+}

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -248,14 +248,26 @@ func (w *IncomingWebhook) Route(r *wkhttp.WKHttp) {
 		chain := func(h wkhttp.HandlerFunc) []wkhttp.HandlerFunc {
 			return []wkhttp.HandlerFunc{w.requirePushEnabled(), w.localFloorMiddleware(), ipLimit, w.ipFailureGateMiddleware(), h}
 		}
-		push.POST("/incoming-webhooks/:webhook_id/:token", chain(w.push)...)
-		// 平台适配器（#297 Phase 3/4、#426）：GitHub / 企业微信 / Multica / GitLab / 飞书。
-		// 鉴权、限流、群校验与 native 完全一致，仅 body 解析不同（adapter_*.go）。
-		push.POST("/incoming-webhooks/:webhook_id/:token/github", chain(w.pushGitHub)...)
-		push.POST("/incoming-webhooks/:webhook_id/:token/wecom", chain(w.pushWeCom)...)
-		push.POST("/incoming-webhooks/:webhook_id/:token/multica", chain(w.pushMultica)...)
-		push.POST("/incoming-webhooks/:webhook_id/:token/gitlab", chain(w.pushGitLab)...)
-		push.POST("/incoming-webhooks/:webhook_id/:token/feishu", chain(w.pushFeishu)...)
+		// 把全部推送形态（native + 5 个平台适配器）一次性挂到给定前缀上。两个前缀共用
+		// 【同一组】中间件链与限流桶，保证 canonical 与 alias 行为字节级一致（#455）：别名
+		// 只是多接受一条路径，不是新攻击面，不单独开鉴权/限流/配额。
+		mountPush := func(prefix string) {
+			base := prefix + "/:webhook_id/:token"
+			push.POST(base, chain(w.push)...)
+			// 平台适配器（#297 Phase 3/4、#426）：GitHub / 企业微信 / Multica / GitLab / 飞书。
+			// 鉴权、限流、群校验与 native 完全一致，仅 body 解析不同（adapter_*.go）。
+			push.POST(base+"/github", chain(w.pushGitHub)...)
+			push.POST(base+"/wecom", chain(w.pushWeCom)...)
+			push.POST(base+"/multica", chain(w.pushMultica)...)
+			push.POST(base+"/gitlab", chain(w.pushGitLab)...)
+			push.POST(base+"/feishu", chain(w.pushFeishu)...)
+		}
+		// canonical 路径（历史契约，不变）+ /v1/webhooks 短别名（#455）。别名为纯附加、
+		// 向后兼容；canonical 仍是 publicURL/publicURLs 对外广告的形态。/v1/webhooks（复数）
+		// 此前未被占用，且 /v1/ 同层全是静态段，新增静态段 webhooks 不与任何通配冲突，
+		// 故无路由注册 panic（详见 #455 冲突分析）。
+		mountPush("/incoming-webhooks")
+		mountPush("/webhooks")
 	}
 }
 

--- a/modules/incomingwebhook/localfloor.go
+++ b/modules/incomingwebhook/localfloor.go
@@ -9,8 +9,9 @@ import (
 
 // Redis-independent, process-local rate ceiling for the public push endpoint.
 //
-// `POST /v1/incoming-webhooks/:webhook_id/:token` is the only unauthenticated,
-// publicly reachable route in this module. Its per-IP and per-webhook limiters
+// `POST /v1/incoming-webhooks/:webhook_id/:token` (and its shorter alias
+// `/v1/webhooks/:webhook_id/:token`, #455) are the only unauthenticated,
+// publicly reachable routes in this module. Their per-IP and per-webhook limiters
 // are both Redis-backed and fail-open: when Redis is unavailable (or its
 // connection pool is saturated) they silently stop limiting, leaving the
 // endpoint — which still performs 2 DB reads + 1 WuKongIM send per call — open

--- a/pkg/accesslog/accesslog.go
+++ b/pkg/accesslog/accesslog.go
@@ -3,9 +3,10 @@
 //
 // Motivation: the incoming-webhook push route is /v1/incoming-webhooks/
 // {webhook_id}/{token} — a Discord-style URL with a PLAINTEXT bearer token in
-// the path (#246). gin's default access logger writes the full request path,
-// which would persist live tokens into access logs. Formatter mirrors gin's
-// default line format exactly but masks the token segment.
+// the path (#246). It is also reachable via the shorter /v1/webhooks/ alias
+// (#455). gin's default access logger writes the full request path, which would
+// persist live tokens into access logs. Formatter mirrors gin's default line
+// format exactly but masks the token segment for BOTH prefixes.
 package accesslog
 
 import (
@@ -21,18 +22,26 @@ import (
 const (
 	// maskedToken replaces a plaintext token segment in logged paths.
 	maskedToken = "***"
-	// incomingWebhookPrefix is the push route whose trailing path segment is a
-	// plaintext webhook token.
-	incomingWebhookPrefix = "/v1/incoming-webhooks/"
 )
+
+// webhookPushPrefixes are the push-route prefixes whose trailing path segment is
+// a plaintext webhook token and therefore must be masked. The canonical path is
+// /v1/incoming-webhooks/; /v1/webhooks/ is the shorter alias (#455). Both reach
+// the same token-bearing handlers, so both must be scrubbed — masking only one
+// would leak tokens via the alias (the #246 token-in-path concern).
+var webhookPushPrefixes = []string{
+	"/v1/incoming-webhooks/",
+	"/v1/webhooks/",
+}
 
 // ScrubPath masks secrets embedded in a request path before it is logged.
 //
-// It targets the incoming-webhook push route
-// /v1/incoming-webhooks/{webhook_id}/{token}: the trailing {token} segment (and
-// anything after it, e.g. a stray query string) is replaced with "***". The
-// non-secret {webhook_id} is preserved so logs remain useful for correlation.
-// Any path without the prefix, or with no token segment, is returned unchanged.
+// It targets the incoming-webhook push routes
+// /v1/incoming-webhooks/{webhook_id}/{token} and the /v1/webhooks/... alias: the
+// trailing {token} segment (and anything after it, e.g. a stray query string) is
+// replaced with "***". The non-secret {webhook_id} is preserved so logs remain
+// useful for correlation. Any path without a push prefix, or with no token
+// segment, is returned unchanged.
 //
 // The prefix match is case-INSENSITIVE: gin logs c.Request.URL.Path verbatim
 // for every request including 404s (the access logger runs after c.Next()
@@ -42,18 +51,21 @@ const (
 // path-casing variants. Original casing of the prefix/webhook_id is preserved
 // in the output; only the token segment is replaced.
 func ScrubPath(path string) string {
-	if len(path) < len(incomingWebhookPrefix) ||
-		!strings.EqualFold(path[:len(incomingWebhookPrefix)], incomingWebhookPrefix) {
-		return path
+	for _, prefix := range webhookPushPrefixes {
+		if len(path) < len(prefix) || !strings.EqualFold(path[:len(prefix)], prefix) {
+			continue
+		}
+		rest := path[len(prefix):]
+		// rest == "{webhook_id}/{token}[?query]". The token is everything after
+		// the first '/'. No '/' means only {webhook_id} is present — nothing to
+		// mask.
+		slash := strings.IndexByte(rest, '/')
+		if slash < 0 {
+			return path
+		}
+		return path[:len(prefix)] + rest[:slash] + "/" + maskedToken
 	}
-	rest := path[len(incomingWebhookPrefix):]
-	// rest == "{webhook_id}/{token}[?query]". The token is everything after the
-	// first '/'. No '/' means only {webhook_id} is present — nothing to mask.
-	slash := strings.IndexByte(rest, '/')
-	if slash < 0 {
-		return path
-	}
-	return path[:len(incomingWebhookPrefix)] + rest[:slash] + "/" + maskedToken
+	return path
 }
 
 // tokenInText matches a webhook push path embedded anywhere in free-form log
@@ -62,8 +74,10 @@ func ScrubPath(path string) string {
 // Used to scrub tokens from the gin.Recovery panic dump, which writes the full
 // request line (httputil.DumpRequest) including the token-bearing path.
 // Case-insensitive ((?i)) for the same reason as ScrubPath — a non-canonical
-// path casing must not slip a token past the mask.
-var tokenInText = regexp.MustCompile(`(?i)(/v1/incoming-webhooks/[^/\s?"']+/)[^\s?"']+`)
+// path casing must not slip a token past the mask. Matches BOTH the canonical
+// /v1/incoming-webhooks/ and the /v1/webhooks/ alias (#455) via the optional
+// "incoming-" group; keep this in sync with webhookPushPrefixes.
+var tokenInText = regexp.MustCompile(`(?i)(/v1/(?:incoming-)?webhooks/[^/\s?"']+/)[^\s?"']+`)
 
 // scrubbingErrorWriter wraps an io.Writer and masks incoming-webhook tokens in
 // everything written through it. ScrubPath only covers the access-log line;

--- a/pkg/accesslog/accesslog.go
+++ b/pkg/accesslog/accesslog.go
@@ -76,7 +76,10 @@ func ScrubPath(path string) string {
 // Case-insensitive ((?i)) for the same reason as ScrubPath — a non-canonical
 // path casing must not slip a token past the mask. Matches BOTH the canonical
 // /v1/incoming-webhooks/ and the /v1/webhooks/ alias (#455) via the optional
-// "incoming-" group; keep this in sync with webhookPushPrefixes.
+// "incoming-" group. This regex and webhookPushPrefixes are two independent
+// encodings of the same prefix set — TestTokenInText_CoversEveryPrefix enforces
+// that the regex masks every prefix in the slice, so adding a prefix to the
+// slice without widening the regex fails the build (PR #456 review).
 var tokenInText = regexp.MustCompile(`(?i)(/v1/(?:incoming-)?webhooks/[^/\s?"']+/)[^\s?"']+`)
 
 // scrubbingErrorWriter wraps an io.Writer and masks incoming-webhook tokens in

--- a/pkg/accesslog/accesslog_test.go
+++ b/pkg/accesslog/accesslog_test.go
@@ -95,6 +95,28 @@ func TestScrubPath(t *testing.T) {
 	}
 }
 
+// TestTokenInText_CoversEveryPrefix pins the single-source invariant flagged in
+// PR #456 review: webhookPushPrefixes (used by ScrubPath) and the panic-dump
+// tokenInText regex independently encode the set of webhook push prefixes. They
+// must stay in sync — a prefix added to the slice but not covered by the regex
+// would silently leak tokens from the gin.Recovery panic dump. This fails loudly
+// if the regex stops covering any prefix in the slice.
+func TestTokenInText_CoversEveryPrefix(t *testing.T) {
+	const token = "SyncGuardTokenMustMask"
+	for _, prefix := range webhookPushPrefixes {
+		line := []byte("POST " + prefix + "wid123/" + token + " HTTP/1.1")
+		got := string(tokenInText.ReplaceAll(line, []byte("${1}***")))
+		if strings.Contains(got, token) {
+			t.Fatalf("prefix %q: panic-dump regex must mask the token but did not "+
+				"(regex out of sync with webhookPushPrefixes); got %q", prefix, got)
+		}
+		want := prefix + "wid123/***"
+		if !strings.Contains(got, want) {
+			t.Fatalf("prefix %q: expected masked path %q in %q", prefix, want, got)
+		}
+	}
+}
+
 // TestScrubPath_NeverLeaksToken guards the security invariant: for any push
 // path, the plaintext token must not survive scrubbing.
 func TestScrubPath_NeverLeaksToken(t *testing.T) {

--- a/pkg/accesslog/accesslog_test.go
+++ b/pkg/accesslog/accesslog_test.go
@@ -41,9 +41,39 @@ func TestScrubPath(t *testing.T) {
 			want: "/v1/incoming-webhooks/iwh_abc123",
 		},
 		{
+			name: "alias push path masks token, keeps webhook_id (#455)",
+			in:   "/v1/webhooks/iwh_abc123/deadbeefcafetoken",
+			want: "/v1/webhooks/iwh_abc123/***",
+		},
+		{
+			name: "alias adapter suffix is fully masked after id (#455)",
+			in:   "/v1/webhooks/iwh_abc123/secrettoken/github",
+			want: "/v1/webhooks/iwh_abc123/***",
+		},
+		{
+			name: "alias path with trailing query is fully masked after id (#455)",
+			in:   "/v1/webhooks/iwh_abc123/secrettoken?foo=bar",
+			want: "/v1/webhooks/iwh_abc123/***",
+		},
+		{
+			name: "alias uppercase prefix still masks token, original case kept (#455)",
+			in:   "/V1/WEBHOOKS/iwh_abc123/secrettoken",
+			want: "/V1/WEBHOOKS/iwh_abc123/***",
+		},
+		{
+			name: "alias webhook_id only, no token segment, unchanged (#455)",
+			in:   "/v1/webhooks/iwh_abc123",
+			want: "/v1/webhooks/iwh_abc123",
+		},
+		{
 			name: "management route is not a push path, unchanged",
 			in:   "/v1/groups/g_1/incoming-webhooks",
 			want: "/v1/groups/g_1/incoming-webhooks",
+		},
+		{
+			name: "singular /v1/webhook (different module) is not a push path, unchanged",
+			in:   "/v1/webhook/github",
+			want: "/v1/webhook/github",
 		},
 		{
 			name: "unrelated path unchanged",
@@ -116,6 +146,43 @@ func TestErrorWriter_ScrubsUppercasePath(t *testing.T) {
 	}
 	if strings.Contains(buf.String(), token) {
 		t.Fatalf("uppercase-path panic dump leaks token: %q", buf.String())
+	}
+}
+
+// TestErrorWriter_ScrubsAliasPanicDump asserts the panic-dump scrubber masks the
+// token for the /v1/webhooks/ alias too (#455) — the alias reaches the same
+// token-bearing handlers, so a panic while serving it must not leak the token.
+func TestErrorWriter_ScrubsAliasPanicDump(t *testing.T) {
+	const token = "aliasPANICtokenLEAK"
+	var buf bytes.Buffer
+	w := NewErrorWriter(&buf)
+	dump := "[Recovery] panic recovered:\n" +
+		"POST /v1/webhooks/iwh_abc/" + token + " HTTP/1.1\r\n" +
+		"Host: example\r\n"
+	if _, err := w.Write([]byte(dump)); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	got := buf.String()
+	if strings.Contains(got, token) {
+		t.Fatalf("alias panic dump leaks token: %q", got)
+	}
+	if !strings.Contains(got, "/v1/webhooks/iwh_abc/***") {
+		t.Fatalf("expected masked alias path in dump, got: %q", got)
+	}
+}
+
+// TestErrorWriter_DoesNotScrubSingularWebhook guards against a false positive:
+// the singular /v1/webhook* routes (the separate modules/webhook module) carry
+// no path token and must pass through the alias-aware regex unchanged (#455).
+func TestErrorWriter_DoesNotScrubSingularWebhook(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewErrorWriter(&buf)
+	const text = "POST /v1/webhook/github HTTP/1.1\r\nHost: example\r\n"
+	if _, err := w.Write([]byte(text)); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	if buf.String() != text {
+		t.Fatalf("singular /v1/webhook path mutated: got %q want %q", buf.String(), text)
 	}
 }
 


### PR DESCRIPTION
## Summary

Make the incoming-webhook **push** endpoints reachable at a shorter alias path in
addition to the existing canonical path — purely additive, same handlers, same
middleware chain, same behavior:

- `/v1/incoming-webhooks/{webhook_id}/{token}[/adapter]` — canonical, unchanged.
- `/v1/webhooks/{webhook_id}/{token}[/adapter]` — new alias.

Only the push ingress is aliased; management endpoints are out of scope.

## Related Issue

Closes #455

## Linked Spec

`.octospec/tasks/incomingwebhook-webhooks-alias/brief.md` (load-bearing:
trust-boundary / token-in-path scrubbing / wire-contract).

## Changes

- **Routes** (`modules/incomingwebhook/api.go` `Route`): factored the 6 push
  registrations (native + github/wecom/multica/gitlab/feishu) into a
  `mountPush(prefix)` closure and mounted it for both `/incoming-webhooks` and
  `/webhooks` on the same `push` group via the identical `chain(...)`
  (`requirePushEnabled → localFloorMiddleware → ipLimit → ipFailureGateMiddleware`).
  No auth / rate-limit / quota divergence between the two prefixes.
- **Access-log token scrubbing (security, #246)** (`pkg/accesslog/accesslog.go`):
  replaced the single `incomingWebhookPrefix` const with a `webhookPushPrefixes`
  slice and generalized the panic-dump `tokenInText` regex to match both prefixes,
  so the plaintext token is masked for **both** prefixes in access logs and the
  `gin.Recovery` panic dump. Without this the alias would leak tokens. A
  `TestTokenInText_CoversEveryPrefix` sync-guard fails the build if the slice and
  regex ever drift.
- **Canonical URL unchanged**: `publicURL` / `publicURLs` still advertise
  `/v1/incoming-webhooks/...` (alias is backward-compatible only).
- **Tests**: `modules/incomingwebhook/alias_push_test.go` (alias native + adapter
  push parity, wrong-token → 401, and all 6 push routes registered under the
  alias); `pkg/accesslog/accesslog_test.go` alias table cases + false-positive
  guards for `/v1/webhook` (the singular `modules/webhook` module) and
  `/v1/groups/.../incoming-webhooks` (management) + the prefix-sync guard.

## Testing

Full integration stack (MySQL 8.0 + Redis + WuKongIM v2.2.4-20260313):

- `go test ./modules/incomingwebhook/... ./modules/webhook/... ./pkg/accesslog/...` — all green.
- `go vet`, `golangci-lint` (touched packages, 0 issues), `make i18n-extract-check`, `make i18n-lint` — clean.
- No gin route-registration panic (exercised by the `NewTestServer` route build).

- [x] Unit tests added/updated
- [x] Manually verified

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   It adds a second accepted URL prefix (`/v1/webhooks/`) that resolves to the
   exact same push handlers behind the exact same four-layer middleware chain and
   rate-limit buckets as the canonical `/v1/incoming-webhooks/`. The
   token-in-path access-log/panic-dump scrubbing — the #246 security control — is
   generalized so it masks tokens for the new prefix too. The push request/
   response contract and status codes are byte-identical across both prefixes.

2. **What could break (dependents + failure mode)?**
   - *Route registration*: a gin httprouter panic at boot if `webhooks` collided
     with a sibling wildcard. It cannot — `/v1/` has only static children, so the
     new static segment is conflict-free; the `NewTestServer` route build would
     panic the test suite otherwise, and it passes.
   - *Token leak via the alias*: if scrubbing weren't generalized, the alias path
     would write plaintext tokens to access logs / panic dumps. Covered by new
     `ScrubPath` + panic-dump alias cases, plus the slice/regex sync guard.
   - *False-positive scrubbing*: the broadened regex could over-match
     `/v1/webhook` (different module) or `/v1/groups/.../incoming-webhooks`
     (management). Guarded by explicit negative tests; neither is mutated.

3. **How do you know it works?**
   `TestAliasPush_Native_Success` / `_WrongToken_Unauthorized` /
   `_GitHubPing_SkippedLikeCanonical` / `_AllPushRoutesRegistered` prove the alias
   goes through the same auth + rate-limit + delivery path as canonical for all 6
   push forms. `TestScrubPath`, `TestErrorWriter_ScrubsAliasPanicDump`,
   `TestErrorWriter_DoesNotScrubSingularWebhook`, and
   `TestTokenInText_CoversEveryPrefix` prove the scrubbing parity, no false
   positives, and no slice/regex drift. All run on the full MySQL+Redis+WuKongIM
   stack.

## Checklist

- [x] PR description is in English
- [x] Added tests for my changes
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dj1nYn6Arq6H7TskJbHk1Y