### PR TITLE
fix(bot_api): propagate App Bot token revocation across replicas via shared Redis cache

### DIFF
--- a/.octospec/journal/shared/appbot-token-revocation-redis.md
+++ b/.octospec/journal/shared/appbot-token-revocation-redis.md
@@ -90,17 +90,50 @@ window):
   (`MySQLMaxOpenConns=2 / MaxIdleConns=1`) so it stops aggravating the parallel-CI
   "Error 1040: Too many connections" flake (#419).
 
+## P1 closure — tombstone revocation (review round)
+
+A re-review (yujiawei, CHANGES_REQUESTED) escalated the re-populate race to a P1
+on the auth boundary: because the new auth-path write-through repopulate (`go
+reg.Add`) wrote unconditionally and the cache-hit path never re-validates, a
+warm-up that read the DB as valid just before a concurrent **delete/unpublish**
+could re-create the just-revoked key cluster-wide for up to the TTL — and a failed
+revocation DEL was silently honored until TTL. Maintainer decision: **close before
+merge** (not accept the residual). Implemented:
+
+- **Revocation writes a TOMBSTONE, not a DEL** (`RedisAppBotRegistry.Remove`):
+  `SET key=<sentinel> EX ttl`. A tombstone positively denies on every replica and
+  `FindByToken` returns nil on it (→ authoritative DB fallback → rejected). Bounded
+  retry + loud-on-failure so a transient blip can't silently delay revocation.
+- **Warm-ups use SETNX** (`RedisAppBotRegistry.Warm`, used by the auth-path
+  repopulate and startup `loadRegistryFromDB`): they only fill an ABSENT key, so a
+  delayed warm-up can never overwrite a tombstone → **resurrection race closed**
+  regardless of interleaving (tombstone-then-warm: SETNX no-ops; warm-then-revoke:
+  the revoke's authoritative SET overwrites).
+- **Authoritative `Add`** (publish / rotate-new) stays an unconditional SET so a
+  re-publish clears the tombstone at once. The write asymmetry — best-effort Warm
+  is circuit-gated, authoritative Add/Remove are not — is now explicit.
+- **Max TTL tightened 86400s → 600s**: revocation no longer relies on TTL expiry
+  (the tombstone is instant), so the TTL is only an orphan / failed-write backstop;
+  a tight max bounds the worst-case misconfiguration window.
+- **Regression coverage:** `TestAppBotWarmDoesNotResurrectRevokedToken` (a late
+  warm-up after delete + revoke leaves the token rejected on the peer) and
+  `TestAppBotRepublishClearsTombstone`; plus a no-infra read-side clamp test for
+  the tightened TTL bound in `modules/common`.
+
 ## Learnings / decisions
 
 - **Fail-safe direction matters for an auth cache.** A cache backend error must
   degrade to the authoritative DB (return nil → fallback), never fail open. This
   is the load-bearing space-isolation/auth invariant for the whole change.
-- **Documented bounded-staleness residual** (mirrors
-  `modules/incomingwebhook/cache.go`): an auth miss that read the DB as valid
-  immediately before a concurrent revocation can re-populate the just-deleted
-  key; it expires within the safety-net TTL. Instant revocation still holds for
-  the overwhelming common case via the shared DEL; the TTL also self-heals a
-  failed DEL.
+- **A shared write-through cache on an auth path must not let a best-effort write
+  outrace a revocation.** The first cut repopulated the cache from the auth
+  fallback with an unconditional write; on a shared store that re-introduced a
+  (smaller) instance of the very cross-replica staleness #309 set out to fix. The
+  tombstone + SETNX pairing makes revocation strictly win the race without needing
+  a DB re-check on every cache hit.
+- **Residual (now much narrower):** a revocation *write* that fails on a transient
+  Redis error after retries; bounded by the key TTL and moot when Redis is fully
+  down (FindByToken then errors → DB fallback → rejected).
 - **Out of scope (follow-up):** the app_bot internal `ab.registry`
   (`byUID`/`byID`, used by `user.SetAppBotResolver` for display-name resolution)
   has the same cross-instance staleness but only affects a cosmetic display name,

--- a/.octospec/journal/shared/appbot-token-revocation-redis.md
+++ b/.octospec/journal/shared/appbot-token-revocation-redis.md
@@ -40,7 +40,7 @@ Option A by the maintainer:
   (it previously didn't), so an active token returns to O(1) after a miss while
   only ever caching a DB-confirmed valid+published spec.
 - The safety-net key TTL is read live from **system_settings**
-  (`AppBotAuthCacheTTLSeconds`, category `app_bot`, default 300s, clamped
+  (`AppBotAuthCacheTTLSeconds`, category `app_bot`, default 60s, clamped
   [30, 86400]) — no new env var; injected into bot_api as a
   `func() time.Duration` so bot_api stays decoupled from modules/common.
 

--- a/.octospec/journal/shared/appbot-token-revocation-redis.md
+++ b/.octospec/journal/shared/appbot-token-revocation-redis.md
@@ -1,0 +1,75 @@
+---
+type: Journal
+title: "Journal: appbot-token-revocation-redis (octo-server #309)"
+description: Record of replacing the per-process App Bot auth registry with a shared Redis write-through cache so token revocation propagates across replicas.
+tags: ["auth", "bot-api", "space", "isolation", "multi-instance", "redis"]
+timestamp: 2026-06-25T02:00:00Z
+# --- octospec extension fields ---
+task: appbot-token-revocation-redis
+upstream: mininglamp-oss/octo-server#309
+source: self
+---
+# Journal: appbot-token-revocation-redis (octo-server #309)
+
+## What was done
+
+App Bot API auth resolved a presented token to `{UID, Scope, SpaceID}` through a
+**per-process in-memory map** (`bot_api.AppBotRegistryAdapter`). Revocations
+(rotate / unpublish / delete) only mutated the registry of the instance that
+handled the admin request, and on the auth path an in-memory hit short-circuited
+the authoritative DB check — so under multiple replicas a revoked token kept
+authenticating on every peer until that peer restarted (#309, reproduced
+end-to-end in the multi-instance audit).
+
+Replaced the in-memory registry with a **shared Redis write-through cache**
+(`RedisAppBotRegistry`, new `modules/bot_api/registry_redis.go`), chosen as
+Option A by the maintainer:
+
+- `AppBotRegistryInterface` was widened from `FindByToken` to also include
+  `Add/Remove/Update` so the app_bot admin helpers drive the registry through the
+  interface (the in-memory `AppBotRegistryAdapter` still satisfies it and is kept
+  for unit tests).
+- `FindByToken` does `GET appbot:auth:{token}`; a miss (`redis.Nil`) **or any
+  Redis error** returns nil so `authAppBot` falls through to the existing
+  authoritative DB lookup — auth fails safe, never serves a stale/revoked spec on
+  a degraded backend.
+- `Add/Remove/Update` write-through to the shared store, so a revoke (DEL) is
+  visible to every replica immediately. The DB write in the admin handler stays
+  the source of truth; cache writes are best-effort.
+- `authAppBot`'s DB-fallback success path now write-through repopulates the cache
+  (it previously didn't), so an active token returns to O(1) after a miss while
+  only ever caching a DB-confirmed valid+published spec.
+- The safety-net key TTL is read live from **system_settings**
+  (`AppBotAuthCacheTTLSeconds`, category `app_bot`, default 300s, clamped
+  [30, 86400]) — no new env var; injected into bot_api as a
+  `func() time.Duration` so bot_api stays decoupled from modules/common.
+
+## Verification
+
+- New regression test `modules/bot_api/registry_redis_multiinstance_test.go`:
+  - `TestAppBotTokenRevocationPropagatesToPeer` — two `RedisAppBotRegistry` over
+    one Redis + DB; after a rotate on replica A, the peer replica B **rejects**
+    the revoked old token (shared DEL → DB fallback → gone) and **accepts** the
+    new token (shared hit). PASS.
+  - `TestAppBotAuthFailsSafeWhenRedisDown` — registry pointed at a dead Redis:
+    `FindByToken` safely misses, a valid token still auths via DB fallback, an
+    unknown token is rejected. PASS.
+- Gates: `go build ./...` ok; `golangci-lint` 0 issues; `make i18n-extract-check`
+  + `make i18n-lint` clean (no new error codes / raw responses); existing
+  bot_api adapter unit tests pass.
+
+## Learnings / decisions
+
+- **Fail-safe direction matters for an auth cache.** A cache backend error must
+  degrade to the authoritative DB (return nil → fallback), never fail open. This
+  is the load-bearing space-isolation/auth invariant for the whole change.
+- **Documented bounded-staleness residual** (mirrors
+  `modules/incomingwebhook/cache.go`): an auth miss that read the DB as valid
+  immediately before a concurrent revocation can re-populate the just-deleted
+  key; it expires within the safety-net TTL. Instant revocation still holds for
+  the overwhelming common case via the shared DEL; the TTL also self-heals a
+  failed DEL.
+- **Out of scope (follow-up):** the app_bot internal `ab.registry`
+  (`byUID`/`byID`, used by `user.SetAppBotResolver` for display-name resolution)
+  has the same cross-instance staleness but only affects a cosmetic display name,
+  not auth — left for a separate change.

--- a/.octospec/journal/shared/appbot-token-revocation-redis.md
+++ b/.octospec/journal/shared/appbot-token-revocation-redis.md
@@ -58,6 +58,38 @@ Option A by the maintainer:
   + `make i18n-lint` clean (no new error codes / raw responses); existing
   bot_api adapter unit tests pass.
 
+## Review hardening (PR #458)
+
+Four reviewer approvals surfaced fixes folded into the same PR (no behaviour
+change to the fix's contract; all reduce blast radius / tighten the staleness
+window):
+
+- **Token never stored verbatim in a Redis key.** `appBotAuthKey` now hashes the
+  bearer token with SHA-256 (`appbot:auth:{sha256hex(token)}`) so a live
+  credential can't leak via `KEYS`/`MONITOR`/RDB dumps. The hash is stable, so
+  every replica still derives the same key.
+- **Default safety-net TTL lowered 300s → 60s** (both `defaultAppBotAuthCacheTTL`
+  in registry_redis.go and `defaultAppBotAuthCacheTTLSeconds` in
+  modules/common, kept in sync). Tightens the worst-case window for a failed DEL
+  or the re-populate race from 5 min to 1 min; operators can still retune via
+  `app_bot.auth_cache_ttl_seconds` (clamped [30, 86400]).
+- **The TTL knob is now registered in `systemSettingSchema`** (category `app_bot`,
+  `Positive: true` to opt out of the day-window [0,3650] int bound) so the admin
+  API accepts writes to it instead of rejecting an unknown key.
+- **DB-fallback write-through Add is fire-and-forget** (`go reg.Add(...)`). The DB
+  lookup already produced the authoritative answer; the cache warm-up must not
+  block the auth response on a Redis SET — critical when Redis is degraded (the
+  exact condition that drove the fallback), where an inline SET would add the
+  client write-timeout to every request.
+- **Global registry slot switched to `atomic.Pointer[regHolder]`** so it accepts a
+  nil/clearing Store and differing concrete types — `atomic.Value` type-locked the
+  slot to the first implementation stored, which prevented a test from restoring
+  the previous (possibly nil) registry. Lock-free reads on the hot path preserved.
+- **Test hygiene:** the multi-instance test now `t.Cleanup`-restores the global
+  registry (no leak into sibling tests) and bounds its `*config.Context` pool
+  (`MySQLMaxOpenConns=2 / MaxIdleConns=1`) so it stops aggravating the parallel-CI
+  "Error 1040: Too many connections" flake (#419).
+
 ## Learnings / decisions
 
 - **Fail-safe direction matters for an auth cache.** A cache backend error must

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,15 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-06-25
+
+- **Add** — Task `appbot-token-revocation-redis` (#309): replace the per-process
+  in-memory App Bot auth registry with a shared Redis write-through cache so
+  token revocation (rotate/unpublish/delete) takes effect on every replica
+  immediately; DB stays authoritative (auth fails safe to DB on Redis error).
+  Safety-net TTL via system_settings (`app_bot.auth_cache_ttl_seconds`, no new
+  env var). Regression test asserts a revoked token is rejected on a peer replica.
+
 ## 2026-06-24
 
 - **Add** — Task `incomingwebhook-webhooks-alias` (#455): `/v1/webhooks/{id}/{token}`

--- a/.octospec/tasks/appbot-token-revocation-redis/brief.md
+++ b/.octospec/tasks/appbot-token-revocation-redis/brief.md
@@ -1,0 +1,110 @@
+---
+type: Task
+title: "Task: appbot-token-revocation-redis"
+description: Propagate App Bot token revocation across instances via a shared Redis write-through auth cache
+tags: [auth, bot-api, space, isolation, multi-instance]
+timestamp: 2026-06-25T01:52:00Z
+# --- octospec extension fields ---
+slug: appbot-token-revocation-redis
+upstream: mininglamp-oss/octo-server#309
+source: self
+---
+
+# Task: appbot-token-revocation-redis
+
+## Goal
+
+App Bot API authentication resolves a presented token to `{UID, Scope, SpaceID}`
+through a **per-process in-memory registry** (`bot_api.AppBotRegistryAdapter`).
+Token revocation operations (rotate / unpublish / delete) only mutate the
+registry of the **instance that handled the admin request**; there is no
+cross-instance propagation and no periodic reload, and on the auth path an
+in-memory hit short-circuits the authoritative DB check. Under multiple replicas
+a revoked App Bot token therefore keeps authenticating on every peer replica
+until that replica restarts (a security-relevant staleness — see #309, which has
+an end-to-end reproduction).
+
+Replace the per-process in-memory auth registry with a **shared Redis
+write-through cache** (Option A, chosen by maintainer): the fast-path lookup and
+all mutations go through one shared Redis store, so rotate/unpublish/delete take
+effect **instantly on all replicas**. The DB (`app_bot` table via
+`queryAppBotByToken`, with the `status=1` published gate) remains the
+authoritative fallback, so a Redis outage degrades to a correct-but-slower DB
+lookup rather than failing closed or serving stale auth.
+
+## Background
+
+- Issue: mininglamp-oss/octo-server#309 (filed from this multi-instance audit;
+  includes an end-to-end reproduction showing a revoked token still authorized on
+  a peer instance).
+- Defect site: `modules/bot_api/auth.go:authAppBot` (in-memory hit returns before
+  the DB fallback at lines ~80-104), `modules/bot_api/registry.go`
+  (`AppBotRegistryAdapter` = in-memory `map[string]*AppBotRegistrySpec`, mutated
+  locally only), `modules/app_bot/app_bot.go` (`syncAuthRegistry` /
+  `removeAuthRegistry` / `updateAuthRegistry` write the local process only;
+  `loadRegistryFromDB` runs once at startup).
+- DB fallback already exists and is authoritative; the availability direction
+  (new/rotated tokens reaching peers) already works via that fallback. This task
+  fixes the **revocation direction** (stale tokens lingering on peers).
+- Redis client is built the same way `modules/opanalytics/etl_lock.go` does:
+  `rd.NewClient(octoredis.MustBuildOptions(ctx.GetConfig(), ...))`
+  (`pkg/redis/options.go`).
+- Config knob (cache TTL safety-net) goes through `modules/common/system_settings.go`
+  (DB-backed, hot-reloaded every ~60s, typed getters), **not** a new env var.
+
+## Load-bearing list
+
+- `auth` — App Bot API authentication decision (token → identity); security
+  boundary. Must fail safe (Redis error → authoritative DB fallback, never
+  serve-stale-on-error or fail-open on a revoked token).
+- `bot-api` — `bot_api.authAppBot` / `AppBotRegistryInterface` /
+  `GetAppBotRegistry` / `SetAppBotRegistry` contract; bot ownership/identity.
+- `space` / `isolation` — the cached spec carries `Scope` + `SpaceID`, which gate
+  space-scoped App Bot send permission downstream; a stale/incorrect spec must
+  not leak a bot across spaces. Cache value must stay consistent with the DB row.
+- `error-response` — `modules/bot_api/auth.go` is touched; auth failures must keep
+  using the existing i18n helpers (`respondBotAPIAuthFailed` /
+  `respondBotAPIAuthCheckFailed` / `respondBotAPIBotUnavailable`), no raw
+  responses, no new per-reason auth codes (anti-enumeration: one generic failure).
+- `wire-contract` — the anti-enumeration / fixed auth-failure response shape on
+  the bot API must not change.
+- App Bot admin handlers (`rotateToken` / `publishBot` / `unpublishBot` /
+  `deleteBot` / `updateBot`) and their existing DB-then-registry ordering and
+  rollback semantics (DB stays the source of truth; cache write is best-effort).
+- `system_settings` config surface (new typed getter + category `app_bot`).
+- The existing reproduction in the audit (to be converted into a committed
+  regression test).
+
+## Out of scope
+
+- The app_bot module's **internal** registry `ab.registry` (`byUID`/`byID`) used
+  by `user.SetAppBotResolver` for display-name resolution — it has the same
+  cross-instance staleness but only affects a cosmetic display name, not auth.
+  Left as a noted follow-up.
+- The other multi-instance findings from the audit (event-timer duplicate,
+  read-count aggregator) — tracked separately; not touched here.
+- User Bot (`bf_` token / robot table) auth path — unchanged.
+- Redis pub/sub or any new background goroutine — the write-through model needs
+  neither.
+- Changing the bot API auth-failure wire status / error codes.
+
+## Acceptance
+
+- A revoked App Bot token (after rotate / unpublish / delete on one instance) is
+  rejected on a **peer instance** that shares the same Redis — asserted by a
+  committed regression test using two registry instances + shared Redis + real
+  `authAppBot` (the audit reproduction, inverted to assert the fix).
+- A newly rotated/published token authenticates on a peer instance (availability
+  direction preserved), via Redis hit or DB fallback.
+- Redis outage path: `FindByToken` Redis error → returns nil → existing DB
+  fallback authenticates a valid token and rejects a revoked one (fail-safe to
+  DB, never serve stale on error). Covered by a test.
+- Auth failures still render through the existing i18n helpers; no new error
+  codes; `make i18n-lint` / `make i18n-extract-check` still pass (expected: no
+  code changes needed, confirm clean).
+- Cache TTL safety-net is read from `system_settings` (category `app_bot`), no new
+  env var; `messageSaveAcrossDevice`-style getter with a code default.
+- `go build ./...`, `go test ./modules/bot_api/... ./modules/app_bot/...`, and
+  `golangci-lint run ./modules/bot_api/... ./modules/app_bot/...` pass.
+- No behavior change to single-replica deployments (registry semantics identical
+  from a single process's view; just backed by Redis instead of a local map).

--- a/.octospec/tasks/appbot-token-revocation-redis/context.yaml
+++ b/.octospec/tasks/appbot-token-revocation-redis/context.yaml
@@ -1,0 +1,50 @@
+# Rules resolved for this task (octospec Implement phase).
+slug: appbot-token-revocation-redis
+resolved_at: 2026-06-25T01:52:00Z
+
+rules_injected:
+  - id: space-isolation
+    tier: repo
+    load_bearing: true
+    why: >
+      App Bot auth resolves token -> {UID, Scope, SpaceID}; Scope/SpaceID gate
+      space-scoped bot send permission downstream. The cached value must stay
+      consistent with the DB row and must fail SAFE (Redis error -> authoritative
+      DB fallback, never fail-open on a revoked token). Bot ownership/identity is
+      the security boundary.
+    applied:
+      - Redis FindByToken returns nil on miss AND on Redis error -> existing DB
+        fallback (queryAppBotByToken + status==1 gate) remains the authority.
+      - Revocation (rotate/unpublish/delete) DELs the shared Redis key so all
+        replicas stop serving the spec; DB stays source of truth.
+  - id: error-handling
+    tier: repo
+    load_bearing: true
+    why: modules/bot_api/auth.go is touched; auth-failure responses are a client wire contract.
+    applied:
+      - No new error codes; auth path keeps existing i18n helpers
+        (respondBotAPIAuthFailed / AuthCheckFailed / BotUnavailable).
+      - Redis cache errors are internal (logged, throttled), never surfaced as a
+        new user-facing error; anti-enumeration single-failure response unchanged.
+      - Run make i18n-extract-check + i18n-lint (expect clean; no code changes).
+  - id: testing
+    tier: repo
+    load_bearing: false
+    applied:
+      - Regression test bounds its own DB pool via config; cleans app_bot rows.
+      - Requires MySQL(+MariaDB-compatible) + Redis; gated by env, skips otherwise.
+  - id: commit-style
+    tier: repo
+    load_bearing: false
+    applied:
+      - Conventional Commits (fix:), English; PR links Fixes #309.
+
+notes:
+  - bot_api stays decoupled from modules/common: the TTL is injected as a
+    func() time.Duration provider; app_bot (which wires the registry) builds the
+    closure over common.EnsureSystemSettings(ctx).
+  - Accepted, documented residual: a cache-invalidation race where an auth miss
+    that read the DB as valid just before a concurrent revocation can re-populate
+    the just-deleted key; bounded by the safety-net TTL (system_settings
+    app_bot.auth_cache_ttl_seconds, default 300s). Mirrors the documented
+    bounded-staleness contract of modules/incomingwebhook/cache.go.

--- a/.octospec/tasks/appbot-token-revocation-redis/context.yaml
+++ b/.octospec/tasks/appbot-token-revocation-redis/context.yaml
@@ -46,5 +46,5 @@ notes:
   - Accepted, documented residual: a cache-invalidation race where an auth miss
     that read the DB as valid just before a concurrent revocation can re-populate
     the just-deleted key; bounded by the safety-net TTL (system_settings
-    app_bot.auth_cache_ttl_seconds, default 300s). Mirrors the documented
+    app_bot.auth_cache_ttl_seconds, default 60s). Mirrors the documented
     bounded-staleness contract of modules/incomingwebhook/cache.go.

--- a/modules/app_bot/app_bot.go
+++ b/modules/app_bot/app_bot.go
@@ -280,7 +280,10 @@ func (ab *AppBot) loadRegistryFromDB(authRegistry bot_api.AppBotRegistryInterfac
 			Token:       bot.Token,
 			CreatedBy:   bot.CreatedBy,
 		})
-		authRegistry.Add(bot.Token, &bot_api.AppBotRegistrySpec{
+		// Warm (best-effort SETNX), not Add: startup loads the published set, but a
+		// bot could be concurrently revoked while this loop runs. SETNX won't clobber
+		// that revocation's tombstone, so startup can't resurrect a just-revoked bot.
+		authRegistry.Warm(bot.Token, &bot_api.AppBotRegistrySpec{
 			UID:     bot.UID,
 			Scope:   bot.Scope,
 			SpaceID: bot.SpaceID,

--- a/modules/app_bot/app_bot.go
+++ b/modules/app_bot/app_bot.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/bot_api"
+	octocommon "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/botutil"
@@ -88,9 +89,15 @@ func NewAppBot(ctx *config.Context) *AppBot {
 		return spec.DisplayName
 	})
 
-	// Eagerly initialize auth registry so operations never encounter nil.
-	// loadRegistryFromDB will populate this same adapter from DB.
-	authRegistry := bot_api.NewAppBotRegistryAdapter()
+	// Eagerly initialize the shared Redis auth registry so operations never
+	// encounter nil; loadRegistryFromDB warms it from DB. Using a SHARED Redis
+	// store (instead of a per-process map) is what makes token revocation take
+	// effect on every replica immediately — see issue #309. The safety-net TTL is
+	// pulled live from system_settings so an operator can retune it without a
+	// deploy (bot_api stays decoupled from the settings package via this closure).
+	authRegistry := bot_api.NewRedisAppBotRegistry(ctx, func() time.Duration {
+		return time.Duration(octocommon.EnsureSystemSettings(ctx).AppBotAuthCacheTTLSeconds()) * time.Second
+	})
 	bot_api.SetAppBotRegistry(authRegistry)
 
 	// Populate registry from DB in background
@@ -243,8 +250,8 @@ func (r *Registry) Remove(id, uid string) {
 	delete(r.byID, id)
 }
 
-// loadRegistryFromDB loads all published App Bots into memory.
-func (ab *AppBot) loadRegistryFromDB(authRegistry *bot_api.AppBotRegistryAdapter) {
+// loadRegistryFromDB warms the shared auth registry with all published App Bots.
+func (ab *AppBot) loadRegistryFromDB(authRegistry bot_api.AppBotRegistryInterface) {
 	var bots []*appBotModel
 	var err error
 	for attempt := 1; attempt <= 3; attempt++ {
@@ -928,9 +935,11 @@ func (ab *AppBot) unpublishBot(c *wkhttp.Context) {
 	c.ResponseOK()
 }
 
-// syncAuthRegistry adds an app bot to the bot_api auth registry.
+// syncAuthRegistry write-throughs an app bot into the shared auth registry.
+// Goes through the interface (not a concrete type) so the production Redis
+// registry and the in-memory test adapter are both driven identically.
 func (ab *AppBot) syncAuthRegistry(token, uid, scope, spaceID string) {
-	if r, ok := bot_api.GetAppBotRegistry().(*bot_api.AppBotRegistryAdapter); ok && r != nil {
+	if r := bot_api.GetAppBotRegistry(); r != nil {
 		r.Add(token, &bot_api.AppBotRegistrySpec{
 			UID:     uid,
 			Scope:   scope,
@@ -939,16 +948,16 @@ func (ab *AppBot) syncAuthRegistry(token, uid, scope, spaceID string) {
 	}
 }
 
-// removeAuthRegistry removes an app bot from the bot_api auth registry.
+// removeAuthRegistry revokes an app bot's token in the shared auth registry.
 func (ab *AppBot) removeAuthRegistry(token string) {
-	if r, ok := bot_api.GetAppBotRegistry().(*bot_api.AppBotRegistryAdapter); ok && r != nil {
+	if r := bot_api.GetAppBotRegistry(); r != nil {
 		r.Remove(token)
 	}
 }
 
-// updateAuthRegistry atomically swaps a spec from oldToken to newToken in the bot_api auth registry.
+// updateAuthRegistry revokes oldToken and write-throughs newToken in the shared auth registry.
 func (ab *AppBot) updateAuthRegistry(oldToken, newToken, uid, scope, spaceID string) {
-	if r, ok := bot_api.GetAppBotRegistry().(*bot_api.AppBotRegistryAdapter); ok && r != nil {
+	if r := bot_api.GetAppBotRegistry(); r != nil {
 		r.Update(oldToken, newToken, &bot_api.AppBotRegistrySpec{
 			UID:     uid,
 			Scope:   scope,

--- a/modules/bot_api/auth.go
+++ b/modules/bot_api/auth.go
@@ -103,12 +103,20 @@ func (ba *BotAPI) authAppBot(c *wkhttp.Context, token string) {
 	// revocation landing between the DB read and this Add can briefly re-add the
 	// just-deleted key; it expires within the safety-net TTL — see
 	// RedisAppBotRegistry.)
+	//
+	// FIRE-AND-FORGET: this Add is a best-effort cache warm-up off the hot auth
+	// path. Running it inline would block every DB-fallback auth on a Redis SET —
+	// and when Redis is degraded (the exact case driving the fallback), that adds
+	// the client's write-timeout to each request. The DB lookup already produced
+	// the authoritative answer this request needs, so the repopulate runs in the
+	// background and the handler proceeds immediately.
 	if reg := GetAppBotRegistry(); reg != nil {
-		reg.Add(token, &AppBotRegistrySpec{
+		spec := &AppBotRegistrySpec{
 			UID:     appBot.UID,
 			Scope:   appBot.Scope,
 			SpaceID: appBot.SpaceID,
-		})
+		}
+		go reg.Add(token, spec)
 	}
 
 	c.Set(CtxKeyRobotID, appBot.UID)

--- a/modules/bot_api/auth.go
+++ b/modules/bot_api/auth.go
@@ -110,6 +110,10 @@ func (ba *BotAPI) authAppBot(c *wkhttp.Context, token string) {
 	// the client's write-timeout to each request. The DB lookup already produced
 	// the authoritative answer this request needs, so the repopulate runs in the
 	// background and the handler proceeds immediately.
+	//
+	// The detached goroutine can't pile up under a sustained Redis outage:
+	// RedisAppBotRegistry.Add drops the write while its circuit is open (a recent
+	// Redis-command failure), so the goroutine returns without touching the pool.
 	if reg := GetAppBotRegistry(); reg != nil {
 		spec := &AppBotRegistrySpec{
 			UID:     appBot.UID,

--- a/modules/bot_api/auth.go
+++ b/modules/bot_api/auth.go
@@ -62,8 +62,9 @@ func (ba *BotAPI) authUserBot(c *wkhttp.Context, token string) {
 }
 
 // authAppBot authenticates an App Bot.
-// Primary path: O(1) in-memory Registry lookup (design doc §4.1).
-// Fallback: DB query (covers startup race where registry not yet loaded).
+// Primary path: O(1) shared registry/cache lookup (design doc §4.1).
+// Fallback: DB query (covers a cache miss/error or a startup race where the
+// registry is not yet loaded); the DB row + status==1 gate stays authoritative.
 func (ba *BotAPI) authAppBot(c *wkhttp.Context, token string) {
 	// Try in-memory Registry first (O(1))
 	if spec := ba.lookupAppBotRegistry(token); spec != nil {
@@ -132,8 +133,9 @@ func (ba *BotAPI) authAppBot(c *wkhttp.Context, token string) {
 	c.Next()
 }
 
-// lookupAppBotRegistry queries the global App Bot Registry (O(1) memory lookup).
-// Returns nil if registry not initialized or token not found.
+// lookupAppBotRegistry queries the global App Bot registry (O(1) shared
+// registry/cache lookup). Returns nil if the registry is not initialized or the
+// token is not found (a miss/error falls through to the authoritative DB lookup).
 func (ba *BotAPI) lookupAppBotRegistry(token string) *AppBotRegistrySpec {
 	reg := GetAppBotRegistry()
 	if reg == nil {

--- a/modules/bot_api/auth.go
+++ b/modules/bot_api/auth.go
@@ -96,32 +96,28 @@ func (ba *BotAPI) authAppBot(c *wkhttp.Context, token string) {
 		return
 	}
 
-	// Write-through repopulate the shared cache after an authoritative DB hit so
+	// Write-through WARM the shared cache after an authoritative DB hit so
 	// subsequent auths for this (valid, published) token are served from cache.
-	// Only ever caches a DB-confirmed valid+published spec, so a revoked token —
-	// whose DB row is gone (delete/rotate) or status!=1 (unpublish) — is rejected
-	// above and never re-added here. (Bounded-staleness note: a concurrent
-	// revocation landing between the DB read and this Add can briefly re-add the
-	// just-deleted key; it expires within the safety-net TTL — see
-	// RedisAppBotRegistry.)
 	//
-	// FIRE-AND-FORGET: this Add is a best-effort cache warm-up off the hot auth
-	// path. Running it inline would block every DB-fallback auth on a Redis SET —
-	// and when Redis is degraded (the exact case driving the fallback), that adds
-	// the client's write-timeout to each request. The DB lookup already produced
-	// the authoritative answer this request needs, so the repopulate runs in the
-	// background and the handler proceeds immediately.
+	// Warm (not Add) is deliberate and load-bearing: it is a best-effort SETNX that
+	// only fills an ABSENT key. A concurrent revoke writes a tombstone, which Warm
+	// won't overwrite (and FindByToken denies), so a warm-up that read the DB as
+	// valid just before a concurrent delete/unpublish can NOT resurrect the
+	// just-revoked key — closing the cross-replica repopulate race.
 	//
-	// The detached goroutine can't pile up under a sustained Redis outage:
-	// RedisAppBotRegistry.Add drops the write while its circuit is open (a recent
-	// Redis-command failure), so the goroutine returns without touching the pool.
+	// FIRE-AND-FORGET: running it inline would block every DB-fallback auth on a
+	// Redis write — and when Redis is degraded (the exact case driving the
+	// fallback), that adds the client's write-timeout to each request. The DB lookup
+	// already produced the authoritative answer this request needs, so the warm-up
+	// runs in the background. It can't pile up under a sustained outage either:
+	// RedisAppBotRegistry.Warm drops the write while its circuit is open.
 	if reg := GetAppBotRegistry(); reg != nil {
 		spec := &AppBotRegistrySpec{
 			UID:     appBot.UID,
 			Scope:   appBot.Scope,
 			SpaceID: appBot.SpaceID,
 		}
-		go reg.Add(token, spec)
+		go reg.Warm(token, spec)
 	}
 
 	c.Set(CtxKeyRobotID, appBot.UID)

--- a/modules/bot_api/auth.go
+++ b/modules/bot_api/auth.go
@@ -95,6 +95,22 @@ func (ba *BotAPI) authAppBot(c *wkhttp.Context, token string) {
 		return
 	}
 
+	// Write-through repopulate the shared cache after an authoritative DB hit so
+	// subsequent auths for this (valid, published) token are served from cache.
+	// Only ever caches a DB-confirmed valid+published spec, so a revoked token —
+	// whose DB row is gone (delete/rotate) or status!=1 (unpublish) — is rejected
+	// above and never re-added here. (Bounded-staleness note: a concurrent
+	// revocation landing between the DB read and this Add can briefly re-add the
+	// just-deleted key; it expires within the safety-net TTL — see
+	// RedisAppBotRegistry.)
+	if reg := GetAppBotRegistry(); reg != nil {
+		reg.Add(token, &AppBotRegistrySpec{
+			UID:     appBot.UID,
+			Scope:   appBot.Scope,
+			SpaceID: appBot.SpaceID,
+		})
+	}
+
 	c.Set(CtxKeyRobotID, appBot.UID)
 	c.Set(CtxKeyBotKind, BotKindApp)
 	c.Set(CtxKeyAppBotScope, appBot.Scope)

--- a/modules/bot_api/incoming_webhook_test.go
+++ b/modules/bot_api/incoming_webhook_test.go
@@ -231,13 +231,9 @@ func TestBotWebhook_AppBotAlwaysForbidden(t *testing.T) {
 	adapter.Add(appBotToken, &AppBotRegistrySpec{UID: appBotUID, Scope: "platform"})
 	prev := GetAppBotRegistry()
 	SetAppBotRegistry(adapter)
-	t.Cleanup(func() {
-		if prev != nil {
-			SetAppBotRegistry(prev)
-		} else {
-			SetAppBotRegistry(NewAppBotRegistryAdapter()) // atomic.Value 不可存 nil，置空注册表即可
-		}
-	})
+	// Restore unconditionally — the registry slot is an atomic.Pointer[regHolder],
+	// so SetAppBotRegistry(nil) is safe (restores the "no registry" state).
+	t.Cleanup(func() { SetAppBotRegistry(prev) })
 
 	// 鉴权通过（非 401），但非群成员 → 创建/列表一律 403。
 	w := doBot(handler, botReq(t, "POST", botWebhookBase(), appBotToken, map[string]interface{}{}))

--- a/modules/bot_api/registry.go
+++ b/modules/bot_api/registry.go
@@ -24,7 +24,14 @@ type AppBotRegistrySpec struct {
 // safe, never serve a stale spec when the backend is degraded.
 type AppBotRegistryInterface interface {
 	FindByToken(token string) *AppBotRegistrySpec
+	// Add is an AUTHORITATIVE write (publish / rotate-new): it must establish the
+	// spec, overwriting any prior value (e.g. a revocation tombstone on re-publish).
 	Add(token string, spec *AppBotRegistrySpec)
+	// Warm is a BEST-EFFORT, NON-BLOCKING/BOUNDED warm-up (auth-path repopulate +
+	// startup load). It must never overwrite a concurrent revocation, and callers
+	// may invoke it from a detached goroutine on the hot path — implementations
+	// must keep it bounded (never an unbounded blocking write per call).
+	Warm(token string, spec *AppBotRegistrySpec)
 	Remove(token string)
 	Update(oldToken, newToken string, spec *AppBotRegistrySpec)
 }
@@ -81,6 +88,13 @@ func (a *AppBotRegistryAdapter) Add(token string, spec *AppBotRegistrySpec) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.byToken[token] = spec
+}
+
+// Warm mirrors Add for the in-memory adapter: it is single-process, so the
+// tombstone / SETNX semantics the shared Redis registry needs to close the
+// cross-replica resurrection race don't apply here.
+func (a *AppBotRegistryAdapter) Warm(token string, spec *AppBotRegistrySpec) {
+	a.Add(token, spec)
 }
 
 // Remove removes a spec by token.

--- a/modules/bot_api/registry.go
+++ b/modules/bot_api/registry.go
@@ -12,9 +12,21 @@ type AppBotRegistrySpec struct {
 	SpaceID string
 }
 
-// AppBotRegistryInterface is the interface for App Bot in-memory registry lookup.
+// AppBotRegistryInterface is the App Bot auth registry: a token -> spec lookup
+// plus the mutators the app_bot admin handlers call on publish/rotate/unpublish/
+// delete. Two implementations satisfy it: AppBotRegistryAdapter (in-memory,
+// single-process — used by unit tests) and RedisAppBotRegistry (shared write-
+// through cache — used in production so revocations propagate across replicas;
+// see issue #309).
+//
+// FindByToken returns nil on a miss AND on any backend error, so the caller
+// (authAppBot) falls through to the authoritative DB lookup — auth must fail
+// safe, never serve a stale spec when the backend is degraded.
 type AppBotRegistryInterface interface {
 	FindByToken(token string) *AppBotRegistrySpec
+	Add(token string, spec *AppBotRegistrySpec)
+	Remove(token string)
+	Update(oldToken, newToken string, spec *AppBotRegistrySpec)
 }
 
 // appBotRegistryValue stores AppBotRegistryInterface, set by the app_bot module on init.

--- a/modules/bot_api/registry.go
+++ b/modules/bot_api/registry.go
@@ -29,21 +29,30 @@ type AppBotRegistryInterface interface {
 	Update(oldToken, newToken string, spec *AppBotRegistrySpec)
 }
 
-// appBotRegistryValue stores AppBotRegistryInterface, set by the app_bot module on init.
-var appBotRegistryValue atomic.Value
+// regHolder wraps the registry interface so the global can be stored through an
+// atomic.Pointer of a single concrete type. Using atomic.Value directly would
+// type-lock the slot to the first concrete implementation stored and panic if a
+// later Store used a different one (or nil) — which a test that swaps the
+// registry and then restores the previous (possibly nil) value needs to do.
+type regHolder struct{ r AppBotRegistryInterface }
+
+// appBotRegistry stores the global App Bot registry, set by the app_bot module
+// on init. Lock-free reads on the bot-auth hot path; Store(nil-holder safe).
+var appBotRegistry atomic.Pointer[regHolder]
 
 // SetAppBotRegistry sets the global App Bot registry (called by app_bot module).
+// A nil r is allowed (clears the slot back to "no registry").
 func SetAppBotRegistry(r AppBotRegistryInterface) {
-	appBotRegistryValue.Store(r)
+	appBotRegistry.Store(&regHolder{r: r})
 }
 
-// GetAppBotRegistry returns the global App Bot registry.
+// GetAppBotRegistry returns the global App Bot registry, or nil if unset/cleared.
 func GetAppBotRegistry() AppBotRegistryInterface {
-	v := appBotRegistryValue.Load()
-	if v == nil {
+	h := appBotRegistry.Load()
+	if h == nil {
 		return nil
 	}
-	return v.(AppBotRegistryInterface)
+	return h.r
 }
 
 // AppBotRegistryAdapter adapts an external registry to AppBotRegistryInterface.

--- a/modules/bot_api/registry_redis.go
+++ b/modules/bot_api/registry_redis.go
@@ -29,11 +29,27 @@ const appBotDegradeWarnInterval = 30 * time.Second
 
 // appBotDegradedCooldown is how long a Redis-command failure keeps the
 // best-effort write circuit open: while open, the DB-fallback cache warm-up
-// (Add) is skipped so a sustained Redis outage can't launch one blocking SET
+// (Warm) is skipped so a sustained Redis outage can't launch one blocking SETNX
 // (dial/write timeout × retries + pool wait) per auth request. The very request
 // that observes the failure trips the circuit before its own warm-up runs, so no
-// SET storm accumulates; writes resume once Redis has been healthy this long.
+// write storm accumulates; warm-ups resume once Redis has been healthy this long.
+// Authoritative writes (Add publish / Remove revoke) are NOT gated by it.
 const appBotDegradedCooldown = 5 * time.Second
+
+// appBotTombstone is the sentinel value a revocation writes to the shared key
+// instead of deleting it. A tombstone (a) positively denies the token on every
+// replica immediately, and (b) survives a racing best-effort Warm — which uses
+// SETNX and so cannot overwrite it — closing the repopulate-resurrection race
+// (a delayed auth-path warm-up landing just after a delete/unpublish DEL used to
+// re-create the just-revoked key). It is not valid spec JSON, so FindByToken
+// distinguishes it with an exact-value check before unmarshalling.
+const appBotTombstone = "\x00appbot:revoked"
+
+// appBotRevokeMaxAttempts bounds the retry on a revocation (tombstone) write so a
+// transient Redis blip doesn't silently leave a revoked token authenticating
+// until its key TTL. Kept small (the go-redis client already retries internally)
+// so an admin revoke isn't blocked too long on a degraded backend.
+const appBotRevokeMaxAttempts = 2
 
 // RedisAppBotRegistry is a SHARED, write-through Redis cache for App Bot auth
 // (issue #309). Replacing the per-process in-memory map with one shared store
@@ -43,20 +59,25 @@ const appBotDegradedCooldown = 5 * time.Second
 //
 // Authority model: the app_bot table (queryAppBotByToken + status==1 gate) is
 // the source of truth. This cache is a fast path in front of it:
-//   - FindByToken miss OR any Redis error -> nil -> authAppBot's DB fallback
-//     runs (fail safe; a Redis outage degrades to a correct, slower DB lookup,
-//     never to serving a stale/revoked spec).
-//   - mutators are best-effort write-through; the DB write in the admin handler
-//     already happened and is authoritative, so a Redis write error only costs
-//     a bounded window of staleness (keys carry the safety-net TTL below).
+//   - FindByToken miss, tombstone, OR any Redis error -> nil -> authAppBot's DB
+//     fallback runs (fail safe; a Redis outage degrades to a correct, slower DB
+//     lookup, never to serving a stale/revoked spec).
 //
-// Bounded-staleness contract (mirrors modules/incomingwebhook/cache.go):
-//   - Revocation is instant cross-instance via the shared DEL.
-//   - The only residual is a narrow cache-invalidation race: an auth miss that
-//     read the DB as still-valid immediately before a concurrent revocation can
-//     re-populate the just-deleted key. That re-add is bounded by the safety-net
-//     TTL (ttl()), after which the key expires and the next auth re-validates
-//     against the DB. The TTL also self-heals any drift from a failed DEL.
+// Write model (the asymmetry is load-bearing):
+//   - Add (authoritative publish / rotate-new): SET, overwrites any tombstone.
+//   - Warm (best-effort warm-up: auth-path repopulate + startup load): SETNX,
+//     never overwrites a tombstone or a fresher spec; circuit-gated so a Redis
+//     outage can't pile up blocking writes on the auth hot path.
+//   - Remove (revoke: unpublish / delete / rotate-old): writes a short-lived
+//     TOMBSTONE (not a DEL), with bounded retry + loud-on-failure.
+//
+// Revocation-resurrection is closed by the tombstone + SETNX pairing: a delayed
+// auth-path Warm can no longer re-create a just-revoked key, because Remove left
+// a tombstone there and SETNX won't overwrite it (and FindByToken denies on a
+// tombstone regardless). The only residual is a failed revocation WRITE on a
+// transient Redis error after retries — bounded by the key TTL, and moot when
+// Redis is fully down (FindByToken then errors -> DB fallback -> rejected). The
+// safety-net TTL (ttl(), clamped) also self-heals any orphaned key.
 type RedisAppBotRegistry struct {
 	log.Log
 	client *rd.Client
@@ -110,6 +131,11 @@ func (r *RedisAppBotRegistry) FindByToken(token string) *AppBotRegistrySpec {
 		r.noteRedisFailure("app bot auth cache GET failed, fail-safe to DB", err)
 		return nil
 	}
+	if val == appBotTombstone {
+		// Revoked: deny the cache hit and fall through to the DB, which is
+		// authoritative and will reject the deleted/unpublished bot.
+		return nil
+	}
 	var spec AppBotRegistrySpec
 	if uerr := json.Unmarshal([]byte(val), &spec); uerr != nil {
 		// Corrupt entry: drop it and miss to DB rather than trusting garbage.
@@ -120,45 +146,23 @@ func (r *RedisAppBotRegistry) FindByToken(token string) *AppBotRegistrySpec {
 	return &spec
 }
 
-// Add write-throughs a spec with the safety-net TTL. Best-effort: a failure is
-// logged (throttled) and ignored — the DB remains authoritative. The write and
-// the degraded-circuit skip both happen in set().
+// Add authoritatively write-throughs a spec (publish / rotate-new): an
+// unconditional SET that overwrites any tombstone so a re-publish re-enables the
+// token cluster-wide at once. Not circuit-gated — it is a low-frequency admin
+// write that must establish authoritative state even on a slow backend.
 func (r *RedisAppBotRegistry) Add(token string, spec *AppBotRegistrySpec) {
 	r.set(token, spec)
 }
 
-// Remove deletes the shared key, instantly revoking the token on every replica.
-func (r *RedisAppBotRegistry) Remove(token string) {
-	if token == "" {
-		return
-	}
-	if err := r.client.Del(appBotAuthKey(token)).Err(); err != nil {
-		// A failed DEL leaves a stale key until its TTL expires; log so ops can
-		// see it, but the bounded TTL is the backstop. Also trips the write circuit
-		// so concurrent warm-ups stop hammering a backend that's clearly degraded.
-		r.noteRedisFailure("app bot auth cache DEL failed (stale until TTL)", err)
-	}
-}
-
-// Update revokes the old token and write-throughs the new one. The DEL+SET are
-// not atomic, but each is on the shared store, so peers converge immediately;
-// the brief window only affects the rotating bot's own old/new tokens.
-func (r *RedisAppBotRegistry) Update(oldToken, newToken string, spec *AppBotRegistrySpec) {
-	r.Remove(oldToken)
-	r.set(newToken, spec)
-}
-
-func (r *RedisAppBotRegistry) set(token string, spec *AppBotRegistrySpec) {
+// Warm is a best-effort cache warm-up (DB-fallback auth-path repopulate + startup
+// load). It uses SETNX so it only ever fills an ABSENT key — it never overwrites
+// a concurrent revocation's tombstone or a fresher authoritative spec, so a
+// delayed warm-up cannot resurrect a just-revoked token. Circuit-gated so a Redis
+// outage can't pile up blocking writes on the auth hot path.
+func (r *RedisAppBotRegistry) Warm(token string, spec *AppBotRegistrySpec) {
 	if token == "" || spec == nil {
 		return
 	}
-	// Skip the best-effort write while the circuit is open (a recent Redis-command
-	// failure). This bounds BOTH the hot-path warm-up (Add, called via `go reg.Add`
-	// on the DB-fallback auth path) AND the rotate path (Update's new-token SET):
-	// under a sustained outage neither launches a doomed blocking SET (dial/write
-	// timeout × retries + pool wait); the DB is already authoritative and the next
-	// miss re-attempts once Redis heals. Remove's revocation DEL is deliberately NOT
-	// gated, so opening the circuit can never suppress a revocation's propagation.
 	if r.writesDegraded() {
 		return
 	}
@@ -167,8 +171,54 @@ func (r *RedisAppBotRegistry) set(token string, spec *AppBotRegistrySpec) {
 		r.warnDegraded("app bot auth spec marshal failed", err)
 		return
 	}
+	if err := r.client.SetNX(appBotAuthKey(token), payload, r.safeTTL()).Err(); err != nil {
+		r.noteRedisFailure("app bot auth cache warm (SETNX) failed", err)
+	}
+}
+
+// Remove revokes a token by writing a short-lived TOMBSTONE (not a DEL), so every
+// replica denies it immediately AND a racing Warm (SETNX) can't re-create the key.
+// Bounded retry + loud-on-failure: a transient blip must not silently leave the
+// token authenticating until TTL. Not circuit-gated — a revocation must always be
+// attempted, even when the backend is degraded.
+func (r *RedisAppBotRegistry) Remove(token string) {
+	if token == "" {
+		return
+	}
 	ttl := r.safeTTL()
-	if err := r.client.Set(appBotAuthKey(token), payload, ttl).Err(); err != nil {
+	var err error
+	for attempt := 1; attempt <= appBotRevokeMaxAttempts; attempt++ {
+		if err = r.client.Set(appBotAuthKey(token), appBotTombstone, ttl).Err(); err == nil {
+			return
+		}
+	}
+	// All attempts failed. When Redis is fully unreachable, FindByToken also errors
+	// → DB fallback → the revoked bot is rejected anyway; the only exposed case is a
+	// transient failure leaving an earlier spec key readable, bounded by its TTL.
+	r.noteRedisFailure("app bot auth cache revoke (tombstone SET) failed after retries; token may auth until key TTL", err)
+}
+
+// Update revokes the old token (tombstone) and authoritatively write-throughs the
+// new one. The two writes are not atomic, but each is on the shared store so peers
+// converge immediately; the new token is brand-new (no tombstone) so the SET wins.
+func (r *RedisAppBotRegistry) Update(oldToken, newToken string, spec *AppBotRegistrySpec) {
+	r.Remove(oldToken)
+	r.set(newToken, spec)
+}
+
+// set is the authoritative SET shared by Add and Update's new-token write. It is
+// NOT circuit-gated (see Add); a marshal failure is non-availability so it only
+// warns. A Redis-command failure trips the circuit (so best-effort Warms back off).
+func (r *RedisAppBotRegistry) set(token string, spec *AppBotRegistrySpec) {
+	if token == "" || spec == nil {
+		return
+	}
+	payload, err := json.Marshal(spec)
+	if err != nil {
+		r.warnDegraded("app bot auth spec marshal failed", err)
+		return
+	}
+	if err := r.client.Set(appBotAuthKey(token), payload, r.safeTTL()).Err(); err != nil {
 		r.noteRedisFailure("app bot auth cache SET failed", err)
 	}
 }

--- a/modules/bot_api/registry_redis.go
+++ b/modules/bot_api/registry_redis.go
@@ -1,0 +1,171 @@
+package bot_api
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
+	"go.uber.org/zap"
+)
+
+// appBotAuthKeyPrefix namespaces the App Bot auth cache in Redis. One key per
+// token: appbot:auth:{token} -> JSON(AppBotRegistrySpec).
+const appBotAuthKeyPrefix = "appbot:auth:"
+
+// degradeWarnInterval throttles fail-open warnings so a sustained Redis outage
+// on the bot-auth hot path logs at most once per interval instead of once per
+// request (mirrors modules/incomingwebhook warnDegraded).
+const appBotDegradeWarnInterval = 30 * time.Second
+
+// RedisAppBotRegistry is a SHARED, write-through Redis cache for App Bot auth
+// (issue #309). Replacing the per-process in-memory map with one shared store
+// makes token revocation (rotate / unpublish / delete) take effect on every
+// replica the instant the admin request commits, instead of lingering on peer
+// replicas until they restart.
+//
+// Authority model: the app_bot table (queryAppBotByToken + status==1 gate) is
+// the source of truth. This cache is a fast path in front of it:
+//   - FindByToken miss OR any Redis error -> nil -> authAppBot's DB fallback
+//     runs (fail safe; a Redis outage degrades to a correct, slower DB lookup,
+//     never to serving a stale/revoked spec).
+//   - mutators are best-effort write-through; the DB write in the admin handler
+//     already happened and is authoritative, so a Redis write error only costs
+//     a bounded window of staleness (keys carry the safety-net TTL below).
+//
+// Bounded-staleness contract (mirrors modules/incomingwebhook/cache.go):
+//   - Revocation is instant cross-instance via the shared DEL.
+//   - The only residual is a narrow cache-invalidation race: an auth miss that
+//     read the DB as still-valid immediately before a concurrent revocation can
+//     re-populate the just-deleted key. That re-add is bounded by the safety-net
+//     TTL (ttl()), after which the key expires and the next auth re-validates
+//     against the DB. The TTL also self-heals any drift from a failed DEL.
+type RedisAppBotRegistry struct {
+	log.Log
+	client *rd.Client
+	// ttl returns the safety-net expiry written with every key. Injected (rather
+	// than reading modules/common directly) so bot_api stays decoupled from the
+	// system-settings package; app_bot wires it over the hot-reloaded snapshot.
+	ttl func() time.Duration
+
+	degradeMu   sync.Mutex
+	degradeLast time.Time
+}
+
+// NewRedisAppBotRegistry builds the shared registry. The Redis client is built
+// the same way modules/opanalytics does (octoredis.MustBuildOptions over the
+// process config). ttl supplies the safety-net key expiry; a non-positive value
+// is coerced to a sane floor in set().
+func NewRedisAppBotRegistry(ctx *config.Context, ttl func() time.Duration) *RedisAppBotRegistry {
+	client := rd.NewClient(octoredis.MustBuildOptions(ctx.GetConfig(), func(o *rd.Options) {
+		o.MaxRetries = 2
+		o.DialTimeout = 3 * time.Second
+		o.ReadTimeout = 2 * time.Second
+		o.WriteTimeout = 2 * time.Second
+	}))
+	return &RedisAppBotRegistry{
+		Log:    log.NewTLog("RedisAppBotRegistry"),
+		client: client,
+		ttl:    ttl,
+	}
+}
+
+func appBotAuthKey(token string) string { return appBotAuthKeyPrefix + token }
+
+// FindByToken reads the shared cache. Miss (redis.Nil) and any other Redis error
+// both return nil so the caller falls through to the authoritative DB lookup —
+// auth must never fail open on a degraded backend.
+func (r *RedisAppBotRegistry) FindByToken(token string) *AppBotRegistrySpec {
+	if token == "" {
+		return nil
+	}
+	val, err := r.client.Get(appBotAuthKey(token)).Result()
+	if err == rd.Nil {
+		return nil // genuine miss -> DB fallback populates it
+	}
+	if err != nil {
+		r.warnDegraded("app bot auth cache GET failed, fail-safe to DB", err)
+		return nil
+	}
+	var spec AppBotRegistrySpec
+	if uerr := json.Unmarshal([]byte(val), &spec); uerr != nil {
+		// Corrupt entry: drop it and miss to DB rather than trusting garbage.
+		r.warnDegraded("app bot auth cache entry corrupt, dropping", uerr)
+		_ = r.client.Del(appBotAuthKey(token)).Err()
+		return nil
+	}
+	return &spec
+}
+
+// Add write-throughs a spec with the safety-net TTL. Best-effort: a failure is
+// logged (throttled) and ignored — the DB remains authoritative.
+func (r *RedisAppBotRegistry) Add(token string, spec *AppBotRegistrySpec) {
+	r.set(token, spec)
+}
+
+// Remove deletes the shared key, instantly revoking the token on every replica.
+func (r *RedisAppBotRegistry) Remove(token string) {
+	if token == "" {
+		return
+	}
+	if err := r.client.Del(appBotAuthKey(token)).Err(); err != nil {
+		// A failed DEL leaves a stale key until its TTL expires; log so ops can
+		// see it, but the bounded TTL is the backstop.
+		r.warnDegraded("app bot auth cache DEL failed (stale until TTL)", err)
+	}
+}
+
+// Update revokes the old token and write-throughs the new one. The DEL+SET are
+// not atomic, but each is on the shared store, so peers converge immediately;
+// the brief window only affects the rotating bot's own old/new tokens.
+func (r *RedisAppBotRegistry) Update(oldToken, newToken string, spec *AppBotRegistrySpec) {
+	r.Remove(oldToken)
+	r.set(newToken, spec)
+}
+
+func (r *RedisAppBotRegistry) set(token string, spec *AppBotRegistrySpec) {
+	if token == "" || spec == nil {
+		return
+	}
+	payload, err := json.Marshal(spec)
+	if err != nil {
+		r.warnDegraded("app bot auth spec marshal failed", err)
+		return
+	}
+	ttl := r.safeTTL()
+	if err := r.client.Set(appBotAuthKey(token), payload, ttl).Err(); err != nil {
+		r.warnDegraded("app bot auth cache SET failed", err)
+	}
+}
+
+// safeTTL coerces a missing/invalid TTL provider result to a 5-minute floor so a
+// misconfiguration can never write a never-expiring (0) or negative key.
+func (r *RedisAppBotRegistry) safeTTL() time.Duration {
+	if r.ttl == nil {
+		return defaultAppBotAuthCacheTTL
+	}
+	d := r.ttl()
+	if d <= 0 {
+		return defaultAppBotAuthCacheTTL
+	}
+	return d
+}
+
+// defaultAppBotAuthCacheTTL is the fallback safety-net expiry when the injected
+// provider yields a non-positive value. Kept in sync with the system-settings
+// default in modules/common.
+const defaultAppBotAuthCacheTTL = 5 * time.Minute
+
+func (r *RedisAppBotRegistry) warnDegraded(msg string, err error) {
+	r.degradeMu.Lock()
+	if !r.degradeLast.IsZero() && time.Since(r.degradeLast) < appBotDegradeWarnInterval {
+		r.degradeMu.Unlock()
+		return
+	}
+	r.degradeLast = time.Now()
+	r.degradeMu.Unlock()
+	r.Warn(msg, zap.Error(err))
+}

--- a/modules/bot_api/registry_redis.go
+++ b/modules/bot_api/registry_redis.go
@@ -27,6 +27,14 @@ const appBotAuthKeyPrefix = "appbot:auth:"
 // request (mirrors modules/incomingwebhook warnDegraded).
 const appBotDegradeWarnInterval = 30 * time.Second
 
+// appBotDegradedCooldown is how long a Redis-command failure keeps the
+// best-effort write circuit open: while open, the DB-fallback cache warm-up
+// (Add) is skipped so a sustained Redis outage can't launch one blocking SET
+// (dial/write timeout × retries + pool wait) per auth request. The very request
+// that observes the failure trips the circuit before its own warm-up runs, so no
+// SET storm accumulates; writes resume once Redis has been healthy this long.
+const appBotDegradedCooldown = 5 * time.Second
+
 // RedisAppBotRegistry is a SHARED, write-through Redis cache for App Bot auth
 // (issue #309). Replacing the per-process in-memory map with one shared store
 // makes token revocation (rotate / unpublish / delete) take effect on every
@@ -57,8 +65,9 @@ type RedisAppBotRegistry struct {
 	// system-settings package; app_bot wires it over the hot-reloaded snapshot.
 	ttl func() time.Duration
 
-	degradeMu   sync.Mutex
-	degradeLast time.Time
+	degradeMu     sync.Mutex
+	degradeLast   time.Time // last WARN emit (log throttle)
+	degradedUntil time.Time // best-effort writes are skipped until this instant after a Redis-command failure
 }
 
 // NewRedisAppBotRegistry builds the shared registry. The Redis client is built
@@ -98,7 +107,7 @@ func (r *RedisAppBotRegistry) FindByToken(token string) *AppBotRegistrySpec {
 		return nil // genuine miss -> DB fallback populates it
 	}
 	if err != nil {
-		r.warnDegraded("app bot auth cache GET failed, fail-safe to DB", err)
+		r.noteRedisFailure("app bot auth cache GET failed, fail-safe to DB", err)
 		return nil
 	}
 	var spec AppBotRegistrySpec
@@ -113,7 +122,18 @@ func (r *RedisAppBotRegistry) FindByToken(token string) *AppBotRegistrySpec {
 
 // Add write-throughs a spec with the safety-net TTL. Best-effort: a failure is
 // logged (throttled) and ignored — the DB remains authoritative.
+//
+// While the write circuit is open (a recent Redis-command failure), the warm-up
+// is skipped entirely. The DB-fallback auth path calls Add via `go reg.Add(...)`;
+// without this guard a sustained Redis outage would spawn one goroutine blocking
+// on a doomed SET (dial/write timeout × retries + pool wait) per auth request,
+// piling up goroutines and pool waiters for the exact failure this cache rides
+// out. Dropping the warm-up is harmless — the DB already produced the
+// authoritative answer, and the next miss re-attempts once Redis heals.
 func (r *RedisAppBotRegistry) Add(token string, spec *AppBotRegistrySpec) {
+	if r.writesDegraded() {
+		return
+	}
 	r.set(token, spec)
 }
 
@@ -124,8 +144,9 @@ func (r *RedisAppBotRegistry) Remove(token string) {
 	}
 	if err := r.client.Del(appBotAuthKey(token)).Err(); err != nil {
 		// A failed DEL leaves a stale key until its TTL expires; log so ops can
-		// see it, but the bounded TTL is the backstop.
-		r.warnDegraded("app bot auth cache DEL failed (stale until TTL)", err)
+		// see it, but the bounded TTL is the backstop. Also trips the write circuit
+		// so concurrent warm-ups stop hammering a backend that's clearly degraded.
+		r.noteRedisFailure("app bot auth cache DEL failed (stale until TTL)", err)
 	}
 }
 
@@ -148,7 +169,7 @@ func (r *RedisAppBotRegistry) set(token string, spec *AppBotRegistrySpec) {
 	}
 	ttl := r.safeTTL()
 	if err := r.client.Set(appBotAuthKey(token), payload, ttl).Err(); err != nil {
-		r.warnDegraded("app bot auth cache SET failed", err)
+		r.noteRedisFailure("app bot auth cache SET failed", err)
 	}
 }
 
@@ -170,6 +191,9 @@ func (r *RedisAppBotRegistry) safeTTL() time.Duration {
 // default (defaultAppBotAuthCacheTTLSeconds) in modules/common.
 const defaultAppBotAuthCacheTTL = 60 * time.Second
 
+// warnDegraded emits a throttled WARN without tripping the write circuit. Used
+// for non-availability problems (corrupt cache entry, spec marshal failure) where
+// the backend is reachable and pausing warm-up writes would be pointless.
 func (r *RedisAppBotRegistry) warnDegraded(msg string, err error) {
 	r.degradeMu.Lock()
 	if !r.degradeLast.IsZero() && time.Since(r.degradeLast) < appBotDegradeWarnInterval {
@@ -179,4 +203,30 @@ func (r *RedisAppBotRegistry) warnDegraded(msg string, err error) {
 	r.degradeLast = time.Now()
 	r.degradeMu.Unlock()
 	r.Warn(msg, zap.Error(err))
+}
+
+// noteRedisFailure records an actual Redis-command failure (GET/SET/DEL): it
+// opens the best-effort write circuit for appBotDegradedCooldown (so warm-up
+// Adds are skipped, preventing a per-request SET storm under a sustained outage)
+// AND emits the same throttled WARN as warnDegraded.
+func (r *RedisAppBotRegistry) noteRedisFailure(msg string, err error) {
+	now := time.Now()
+	r.degradeMu.Lock()
+	r.degradedUntil = now.Add(appBotDegradedCooldown)
+	shouldWarn := r.degradeLast.IsZero() || now.Sub(r.degradeLast) >= appBotDegradeWarnInterval
+	if shouldWarn {
+		r.degradeLast = now
+	}
+	r.degradeMu.Unlock()
+	if shouldWarn {
+		r.Warn(msg, zap.Error(err))
+	}
+}
+
+// writesDegraded reports whether a recent Redis-command failure still has the
+// best-effort write circuit open (skip warm-up writes until the cooldown lapses).
+func (r *RedisAppBotRegistry) writesDegraded() bool {
+	r.degradeMu.Lock()
+	defer r.degradeMu.Unlock()
+	return !r.degradedUntil.IsZero() && time.Now().Before(r.degradedUntil)
 }

--- a/modules/bot_api/registry_redis.go
+++ b/modules/bot_api/registry_redis.go
@@ -121,19 +121,9 @@ func (r *RedisAppBotRegistry) FindByToken(token string) *AppBotRegistrySpec {
 }
 
 // Add write-throughs a spec with the safety-net TTL. Best-effort: a failure is
-// logged (throttled) and ignored — the DB remains authoritative.
-//
-// While the write circuit is open (a recent Redis-command failure), the warm-up
-// is skipped entirely. The DB-fallback auth path calls Add via `go reg.Add(...)`;
-// without this guard a sustained Redis outage would spawn one goroutine blocking
-// on a doomed SET (dial/write timeout × retries + pool wait) per auth request,
-// piling up goroutines and pool waiters for the exact failure this cache rides
-// out. Dropping the warm-up is harmless — the DB already produced the
-// authoritative answer, and the next miss re-attempts once Redis heals.
+// logged (throttled) and ignored — the DB remains authoritative. The write and
+// the degraded-circuit skip both happen in set().
 func (r *RedisAppBotRegistry) Add(token string, spec *AppBotRegistrySpec) {
-	if r.writesDegraded() {
-		return
-	}
 	r.set(token, spec)
 }
 
@@ -160,6 +150,16 @@ func (r *RedisAppBotRegistry) Update(oldToken, newToken string, spec *AppBotRegi
 
 func (r *RedisAppBotRegistry) set(token string, spec *AppBotRegistrySpec) {
 	if token == "" || spec == nil {
+		return
+	}
+	// Skip the best-effort write while the circuit is open (a recent Redis-command
+	// failure). This bounds BOTH the hot-path warm-up (Add, called via `go reg.Add`
+	// on the DB-fallback auth path) AND the rotate path (Update's new-token SET):
+	// under a sustained outage neither launches a doomed blocking SET (dial/write
+	// timeout × retries + pool wait); the DB is already authoritative and the next
+	// miss re-attempts once Redis heals. Remove's revocation DEL is deliberately NOT
+	// gated, so opening the circuit can never suppress a revocation's propagation.
+	if r.writesDegraded() {
 		return
 	}
 	payload, err := json.Marshal(spec)

--- a/modules/bot_api/registry_redis.go
+++ b/modules/bot_api/registry_redis.go
@@ -1,6 +1,8 @@
 package bot_api
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"sync"
 	"time"
@@ -13,7 +15,11 @@ import (
 )
 
 // appBotAuthKeyPrefix namespaces the App Bot auth cache in Redis. One key per
-// token: appbot:auth:{token} -> JSON(AppBotRegistrySpec).
+// token: appbot:auth:{sha256hex(token)} -> JSON(AppBotRegistrySpec). The token
+// is HASHED rather than embedded verbatim so a live bearer credential never
+// lands in a Redis key (visible to KEYS/MONITOR/RDB dumps/ops tooling). SHA-256
+// over the high-entropy token is sufficient — no salt needed, and the hash is
+// stable so every replica derives the same key.
 const appBotAuthKeyPrefix = "appbot:auth:"
 
 // degradeWarnInterval throttles fail-open warnings so a sustained Redis outage
@@ -73,7 +79,12 @@ func NewRedisAppBotRegistry(ctx *config.Context, ttl func() time.Duration) *Redi
 	}
 }
 
-func appBotAuthKey(token string) string { return appBotAuthKeyPrefix + token }
+// appBotAuthKey derives the Redis key for a token. The token is SHA-256 hashed
+// so the raw bearer credential never appears in a Redis key (see prefix doc).
+func appBotAuthKey(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return appBotAuthKeyPrefix + hex.EncodeToString(sum[:])
+}
 
 // FindByToken reads the shared cache. Miss (redis.Nil) and any other Redis error
 // both return nil so the caller falls through to the authoritative DB lookup —
@@ -141,7 +152,7 @@ func (r *RedisAppBotRegistry) set(token string, spec *AppBotRegistrySpec) {
 	}
 }
 
-// safeTTL coerces a missing/invalid TTL provider result to a 5-minute floor so a
+// safeTTL coerces a missing/invalid TTL provider result to a sane floor so a
 // misconfiguration can never write a never-expiring (0) or negative key.
 func (r *RedisAppBotRegistry) safeTTL() time.Duration {
 	if r.ttl == nil {
@@ -156,8 +167,8 @@ func (r *RedisAppBotRegistry) safeTTL() time.Duration {
 
 // defaultAppBotAuthCacheTTL is the fallback safety-net expiry when the injected
 // provider yields a non-positive value. Kept in sync with the system-settings
-// default in modules/common.
-const defaultAppBotAuthCacheTTL = 5 * time.Minute
+// default (defaultAppBotAuthCacheTTLSeconds) in modules/common.
+const defaultAppBotAuthCacheTTL = 60 * time.Second
 
 func (r *RedisAppBotRegistry) warnDegraded(msg string, err error) {
 	r.degradeMu.Lock()

--- a/modules/bot_api/registry_redis_multiinstance_test.go
+++ b/modules/bot_api/registry_redis_multiinstance_test.go
@@ -315,8 +315,92 @@ func TestAppBotDeletePropagatesToPeer(t *testing.T) {
 	}
 	regA.Remove(token)
 
-	// FIX assertion: peer rejects the deleted token (shared DEL -> DB fallback -> no row).
+	// FIX assertion: peer rejects the deleted token (shared revoke -> DB fallback -> no row).
 	if got := authStatus(t, ba, regB, token); got == http.StatusOK {
 		t.Errorf("🔴 peer replica still authorizes a DELETED token (HTTP %d)", got)
+	}
+}
+
+// TestAppBotWarmDoesNotResurrectRevokedToken is the regression for the P1 race:
+// a DB-fallback warm-up that read the bot as valid just before a concurrent
+// delete/unpublish must NOT re-create the just-revoked key cluster-wide. The fix:
+// a revoke writes a tombstone and Warm uses SETNX, so a late warm-up is a no-op and
+// FindByToken denies the tombstone. (Pre-fix, the warm-up was an unconditional SET
+// and would resurrect the key until TTL — authorizing a deleted bot on every peer.)
+func TestAppBotWarmDoesNotResurrectRevokedToken(t *testing.T) {
+	ctx := redisRegCtx(t)
+	ensureAppBotTable(t, ctx)
+	ba := &BotAPI{ctx: ctx, db: newBotAPIDB(ctx), Log: log.NewTLog("repro-309-resurrect")}
+	sqlDB := ctx.DB().DB
+
+	const (
+		id    = "repro309res_bot"
+		uid   = "repro309res_uid"
+		token = "app_res_309_tok_11111111"
+	)
+	spec := &AppBotRegistrySpec{UID: uid, Scope: "platform"}
+	regA := NewRedisAppBotRegistry(ctx, ttl5min)
+	regB := NewRedisAppBotRegistry(ctx, ttl5min)
+
+	cleanup := func() {
+		_, _ = sqlDB.Exec("DELETE FROM app_bot WHERE id=? OR uid=?", id, uid)
+		regA.Remove(token)
+	}
+	cleanup()
+	defer cleanup()
+
+	if _, err := sqlDB.Exec(
+		"INSERT INTO app_bot (id,uid,display_name,scope,space_id,status,token,created_by) "+
+			"VALUES (?,?,?,?,'',1,?,?)",
+		id, uid, "Repro 309 Resurrect Bot", "platform", token, "admin",
+	); err != nil {
+		t.Fatalf("insert app_bot: %v", err)
+	}
+	regA.Add(token, spec) // published + warm (authoritative SET clears the cleanup tombstone)
+
+	// Baseline: peer authorizes the published token (shared cache hit).
+	if got := authStatus(t, ba, regB, token); got != http.StatusOK {
+		t.Fatalf("baseline: peer should authorize published token, got HTTP %d", got)
+	}
+
+	// ---- Delete the bot on replica A: DB row removed + shared revoke (tombstone) ----
+	if _, err := sqlDB.Exec("DELETE FROM app_bot WHERE id=?", id); err != nil {
+		t.Fatalf("delete DB: %v", err)
+	}
+	regA.Remove(token)
+
+	// ---- A DELAYED warm-up now lands (model: a peer's auth read the DB as valid
+	// just before the delete and is only now repopulating). It must be a no-op. ----
+	regB.Warm(token, spec)
+
+	// The tombstone must survive the warm-up (SETNX did not overwrite it)...
+	if s := regB.FindByToken(token); s != nil {
+		t.Errorf("🔴 resurrection: warm-up re-created a revoked key (FindByToken returned %+v)", s)
+	}
+	// ...and auth must reject the deleted token on every replica.
+	if got := authStatus(t, ba, regB, token); got == http.StatusOK {
+		t.Errorf("🔴 resurrection: peer still authorizes a DELETED token after a racing warm-up (HTTP %d)", got)
+	}
+}
+
+// TestAppBotRepublishClearsTombstone asserts the authoritative Add (publish) path
+// overwrites a revocation tombstone, so a re-published token is served from the
+// cache again — i.e. the publish path must NOT use Warm's SETNX (which would leave
+// the tombstone in place until TTL).
+func TestAppBotRepublishClearsTombstone(t *testing.T) {
+	ctx := redisRegCtx(t)
+	reg := NewRedisAppBotRegistry(ctx, ttl5min)
+
+	const token = "app_republish_309_tok_22222222"
+	spec := &AppBotRegistrySpec{UID: "repub_uid", Scope: "platform"}
+	defer reg.Remove(token)
+
+	reg.Remove(token) // revoke -> tombstone
+	if s := reg.FindByToken(token); s != nil {
+		t.Fatalf("after revoke, FindByToken should deny (nil), got %+v", s)
+	}
+	reg.Add(token, spec) // authoritative re-publish overwrites the tombstone
+	if got := reg.FindByToken(token); got == nil || got.UID != "repub_uid" {
+		t.Errorf("re-publish should clear the tombstone and serve the spec, got %+v", got)
 	}
 }

--- a/modules/bot_api/registry_redis_multiinstance_test.go
+++ b/modules/bot_api/registry_redis_multiinstance_test.go
@@ -216,3 +216,107 @@ func TestAppBotAuthFailsSafeWhenRedisDown(t *testing.T) {
 		t.Errorf("with Redis down, unknown token must be rejected, got HTTP %d", got)
 	}
 }
+
+// TestAppBotUnpublishPropagatesToPeer covers the #309 acceptance criterion for the
+// UNPUBLISH path, which is structurally distinct from rotate/delete: unpublish only
+// flips status (the DB row REMAINS), so the peer's rejection depends entirely on the
+// published-status gate in authAppBot (status!=1 -> BotUnavailable), not on a missing
+// row. That cross-replica status-gate rejection had no coverage before this test.
+func TestAppBotUnpublishPropagatesToPeer(t *testing.T) {
+	ctx := redisRegCtx(t)
+	ensureAppBotTable(t, ctx)
+	ba := &BotAPI{ctx: ctx, db: newBotAPIDB(ctx), Log: log.NewTLog("repro-309-unpub")}
+	sqlDB := ctx.DB().DB
+
+	const (
+		id    = "repro309up_bot"
+		uid   = "repro309up_uid"
+		token = "app_unpub_309_tok_eeeeeeee"
+	)
+	regA := NewRedisAppBotRegistry(ctx, ttl5min)
+	regB := NewRedisAppBotRegistry(ctx, ttl5min)
+
+	cleanup := func() {
+		_, _ = sqlDB.Exec("DELETE FROM app_bot WHERE id=? OR uid=?", id, uid)
+		regA.Remove(token)
+	}
+	cleanup()
+	defer cleanup()
+
+	// Publish: DB row (status=1) + warm the shared cache.
+	if _, err := sqlDB.Exec(
+		"INSERT INTO app_bot (id,uid,display_name,scope,space_id,status,token,created_by) "+
+			"VALUES (?,?,?,?,'',1,?,?)",
+		id, uid, "Repro 309 Unpub Bot", "platform", token, "admin",
+	); err != nil {
+		t.Fatalf("insert app_bot: %v", err)
+	}
+	regA.Add(token, &AppBotRegistrySpec{UID: uid, Scope: "platform"})
+
+	// Baseline: peer authorizes the published token (shared cache hit).
+	if got := authStatus(t, ba, regB, token); got != http.StatusOK {
+		t.Fatalf("baseline: peer should authorize published token, got HTTP %d", got)
+	}
+
+	// ---- Unpublish on replica A: DB status -> 2 (row stays) + shared-cache Remove (DEL) ----
+	if _, err := sqlDB.Exec("UPDATE app_bot SET status=2 WHERE id=?", id); err != nil {
+		t.Fatalf("unpublish DB: %v", err)
+	}
+	regA.Remove(token)
+
+	// FIX assertion: peer rejects the unpublished token. Shared DEL -> peer misses ->
+	// DB fallback finds the row but status!=1 -> respondBotAPIBotUnavailable.
+	if got := authStatus(t, ba, regB, token); got == http.StatusOK {
+		t.Errorf("🔴 peer replica still authorizes an UNPUBLISHED token (HTTP %d) — cross-replica status gate not enforced", got)
+	}
+}
+
+// TestAppBotDeletePropagatesToPeer covers the #309 acceptance criterion for the
+// DELETE path: after a delete on one replica (DB row removed + shared DEL), the peer
+// rejects the token via DB fallback (no row -> AuthFailed).
+func TestAppBotDeletePropagatesToPeer(t *testing.T) {
+	ctx := redisRegCtx(t)
+	ensureAppBotTable(t, ctx)
+	ba := &BotAPI{ctx: ctx, db: newBotAPIDB(ctx), Log: log.NewTLog("repro-309-del")}
+	sqlDB := ctx.DB().DB
+
+	const (
+		id    = "repro309del_bot"
+		uid   = "repro309del_uid"
+		token = "app_del_309_tok_ffffffff"
+	)
+	regA := NewRedisAppBotRegistry(ctx, ttl5min)
+	regB := NewRedisAppBotRegistry(ctx, ttl5min)
+
+	cleanup := func() {
+		_, _ = sqlDB.Exec("DELETE FROM app_bot WHERE id=? OR uid=?", id, uid)
+		regA.Remove(token)
+	}
+	cleanup()
+	defer cleanup()
+
+	if _, err := sqlDB.Exec(
+		"INSERT INTO app_bot (id,uid,display_name,scope,space_id,status,token,created_by) "+
+			"VALUES (?,?,?,?,'',1,?,?)",
+		id, uid, "Repro 309 Del Bot", "platform", token, "admin",
+	); err != nil {
+		t.Fatalf("insert app_bot: %v", err)
+	}
+	regA.Add(token, &AppBotRegistrySpec{UID: uid, Scope: "platform"})
+
+	// Baseline: peer authorizes the published token.
+	if got := authStatus(t, ba, regB, token); got != http.StatusOK {
+		t.Fatalf("baseline: peer should authorize published token, got HTTP %d", got)
+	}
+
+	// ---- Delete on replica A: DB row removed + shared-cache Remove (DEL) ----
+	if _, err := sqlDB.Exec("DELETE FROM app_bot WHERE id=?", id); err != nil {
+		t.Fatalf("delete DB: %v", err)
+	}
+	regA.Remove(token)
+
+	// FIX assertion: peer rejects the deleted token (shared DEL -> DB fallback -> no row).
+	if got := authStatus(t, ba, regB, token); got == http.StatusOK {
+		t.Errorf("🔴 peer replica still authorizes a DELETED token (HTTP %d)", got)
+	}
+}

--- a/modules/bot_api/registry_redis_multiinstance_test.go
+++ b/modules/bot_api/registry_redis_multiinstance_test.go
@@ -41,6 +41,13 @@ func redisRegCtx(t *testing.T) *config.Context {
 	cfg := config.New()
 	cfg.DB.MySQLAddr = envOr("DM_REPRO_MYSQL", "root:demo@tcp(127.0.0.1:3306)/test?charset=utf8mb4&parseTime=true")
 	cfg.DB.RedisAddr = envOr("DM_REPRO_REDIS", "127.0.0.1:6379")
+	// Bound the pool: this test opens a fresh *config.Context (its own pool) on top
+	// of whatever the rest of the suite holds, all against one MySQL. The default
+	// 100 max-open conns × N such contexts can exhaust max_connections under the
+	// CI's parallel job (the "Error 1040: Too many connections" flake, #419). Two
+	// connections is plenty for this serial probe.
+	cfg.DB.MySQLMaxOpenConns = 2
+	cfg.DB.MySQLMaxIdleConns = 1
 	ctx := config.NewContext(cfg)
 	if err := ctx.DB().DB.Ping(); err != nil {
 		t.Skipf("MySQL unreachable (%s): %v", cfg.DB.MySQLAddr, err)
@@ -79,6 +86,11 @@ func ensureAppBotTable(t *testing.T, ctx *config.Context) {
 // reg, with the given bearer token. 200 = authorized, non-200 = rejected.
 func authStatus(t *testing.T, ba *BotAPI, reg AppBotRegistryInterface, token string) int {
 	t.Helper()
+	// Save and restore the process-global registry so this test doesn't leak its
+	// RedisAppBotRegistry into sibling tests in the package (restoring a nil prev
+	// is safe now that the slot is an atomic.Pointer holder).
+	prev := GetAppBotRegistry()
+	t.Cleanup(func() { SetAppBotRegistry(prev) })
 	SetAppBotRegistry(reg) // route the request to "this replica"
 
 	r := wkhttp.New()

--- a/modules/bot_api/registry_redis_multiinstance_test.go
+++ b/modules/bot_api/registry_redis_multiinstance_test.go
@@ -1,0 +1,206 @@
+package bot_api
+
+// Regression test for issue #309: App Bot token revocation must take effect on a
+// PEER replica, not linger until that replica restarts.
+//
+// The pre-fix bug: the auth registry was a per-process in-memory map, mutated
+// only on the instance that handled the admin request, so a revoked token kept
+// authenticating on every other replica. The fix backs the registry with a
+// SHARED Redis cache (RedisAppBotRegistry), so a revoke (DEL of the shared key)
+// is visible to every replica immediately; the DB remains the authority via the
+// existing fallback.
+//
+// This test models two replicas as two RedisAppBotRegistry instances over the
+// same Redis + a shared DB, and drives the REAL authBot middleware. It runs
+// against the same MySQL+Redis the suite uses (testutil defaults); override with
+// DM_REPRO_MYSQL / DM_REPRO_REDIS, and it skips if neither is reachable.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/gin-gonic/gin"
+)
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func redisRegCtx(t *testing.T) *config.Context {
+	t.Helper()
+	cfg := config.New()
+	cfg.DB.MySQLAddr = envOr("DM_REPRO_MYSQL", "root:demo@tcp(127.0.0.1:3306)/test?charset=utf8mb4&parseTime=true")
+	cfg.DB.RedisAddr = envOr("DM_REPRO_REDIS", "127.0.0.1:6379")
+	ctx := config.NewContext(cfg)
+	if err := ctx.DB().DB.Ping(); err != nil {
+		t.Skipf("MySQL unreachable (%s): %v", cfg.DB.MySQLAddr, err)
+	}
+	if _, err := ctx.GetRedisConn().GetKeys("appbot_auth_probe_nonexist:*"); err != nil {
+		t.Skipf("Redis unreachable (%s): %v", cfg.DB.RedisAddr, err)
+	}
+	return ctx
+}
+
+// ensureAppBotTable creates the app_bot table if the suite migrations haven't
+// (CREATE TABLE IF NOT EXISTS is a no-op when the real schema is already there).
+func ensureAppBotTable(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	_, err := ctx.DB().DB.Exec(`CREATE TABLE IF NOT EXISTS app_bot (
+		id           VARCHAR(40) PRIMARY KEY,
+		uid          VARCHAR(40) UNIQUE NOT NULL,
+		display_name VARCHAR(100) NOT NULL,
+		description  VARCHAR(500) DEFAULT '',
+		avatar       VARCHAR(200) DEFAULT '',
+		scope        VARCHAR(20) NOT NULL DEFAULT 'platform',
+		space_id     VARCHAR(40) DEFAULT NULL,
+		status       TINYINT NOT NULL DEFAULT 0,
+		token        VARCHAR(100) UNIQUE NOT NULL,
+		welcome_msg  VARCHAR(500) DEFAULT '',
+		created_by   VARCHAR(40) NOT NULL,
+		created_at   DATETIME NOT NULL DEFAULT NOW(),
+		updated_at   DATETIME NOT NULL DEFAULT NOW() ON UPDATE NOW()
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`)
+	if err != nil {
+		t.Fatalf("create app_bot table: %v", err)
+	}
+}
+
+// authStatus drives the REAL authBot middleware on the replica holding registry
+// reg, with the given bearer token. 200 = authorized, non-200 = rejected.
+func authStatus(t *testing.T, ba *BotAPI, reg AppBotRegistryInterface, token string) int {
+	t.Helper()
+	SetAppBotRegistry(reg) // route the request to "this replica"
+
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	r.GET("/probe", ba.authBot(), func(c *wkhttp.Context) {
+		c.JSON(http.StatusOK, gin.H{"uid": getRobotIDFromContext(c)})
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	r.ServeHTTP(w, req)
+	return w.Code
+}
+
+func ttl5min() time.Duration { return 5 * time.Minute }
+
+// TestAppBotTokenRevocationPropagatesToPeer asserts the #309 fix: a token revoked
+// on one replica is rejected on a PEER replica immediately (via the shared Redis
+// store), while a newly rotated token is accepted on the peer.
+func TestAppBotTokenRevocationPropagatesToPeer(t *testing.T) {
+	ctx := redisRegCtx(t)
+	ensureAppBotTable(t, ctx)
+	ba := &BotAPI{ctx: ctx, db: newBotAPIDB(ctx), Log: log.NewTLog("repro-309")}
+	sqlDB := ctx.DB().DB
+
+	const (
+		id   = "repro309_bot"
+		uid  = "repro309_uid"
+		tOld = "app_old_309_tok_aaaaaaaa"
+		tNew = "app_new_309_tok_bbbbbbbb"
+	)
+	spec := &AppBotRegistrySpec{UID: uid, Scope: "platform"}
+
+	// Two replicas over the SAME Redis + DB.
+	regA := NewRedisAppBotRegistry(ctx, ttl5min)
+	regB := NewRedisAppBotRegistry(ctx, ttl5min)
+
+	// cleanup
+	cleanup := func() {
+		_, _ = sqlDB.Exec("DELETE FROM app_bot WHERE id=? OR uid=?", id, uid)
+		regA.Remove(tOld)
+		regA.Remove(tNew)
+	}
+	cleanup()
+	defer cleanup()
+
+	// Publish: DB row (published) + warm the shared cache (as the publishing
+	// replica's syncAuthRegistry would).
+	if _, err := sqlDB.Exec(
+		"INSERT INTO app_bot (id,uid,display_name,scope,space_id,status,token,created_by) "+
+			"VALUES (?,?,?,?,'',1,?,?)",
+		id, uid, "Repro 309 Bot", "platform", tOld, "admin",
+	); err != nil {
+		t.Fatalf("insert app_bot: %v", err)
+	}
+	regA.Add(tOld, spec)
+
+	// Baseline: peer replica B authorizes the published token (shared cache hit).
+	if got := authStatus(t, ba, regB, tOld); got != http.StatusOK {
+		t.Fatalf("baseline: peer should authorize published token, got HTTP %d", got)
+	}
+
+	// ---- Rotate on replica A: DB swap + shared-cache Update (DEL old + SET new) ----
+	if _, err := sqlDB.Exec("UPDATE app_bot SET token=? WHERE id=? AND token=?", tNew, id, tOld); err != nil {
+		t.Fatalf("rotate DB: %v", err)
+	}
+	regA.Update(tOld, tNew, spec)
+
+	// FIX assertion: peer replica B now REJECTS the revoked old token
+	// (shared Redis miss -> DB fallback -> old token no longer in DB).
+	if got := authStatus(t, ba, regB, tOld); got == http.StatusOK {
+		t.Errorf("🔴 #309 NOT fixed: peer replica still authorizes the revoked old token (HTTP %d)", got)
+	}
+	// Availability preserved: peer replica B accepts the new token (shared hit).
+	if got := authStatus(t, ba, regB, tNew); got != http.StatusOK {
+		t.Errorf("peer replica should authorize the rotated new token, got HTTP %d", got)
+	}
+}
+
+// TestAppBotAuthFailsSafeWhenRedisDown asserts that with the cache backend
+// unavailable, auth degrades to the authoritative DB (never serves stale): a
+// valid token is accepted via DB fallback and an unknown token rejected.
+func TestAppBotAuthFailsSafeWhenRedisDown(t *testing.T) {
+	ctx := redisRegCtx(t)
+	ensureAppBotTable(t, ctx)
+	ba := &BotAPI{ctx: ctx, db: newBotAPIDB(ctx), Log: log.NewTLog("repro-309-faildown")}
+	sqlDB := ctx.DB().DB
+
+	const (
+		id    = "repro309fs_bot"
+		uid   = "repro309fs_uid"
+		token = "app_fs_309_tok_cccccccc"
+	)
+	cleanup := func() { _, _ = sqlDB.Exec("DELETE FROM app_bot WHERE id=? OR uid=?", id, uid) }
+	cleanup()
+	defer cleanup()
+	if _, err := sqlDB.Exec(
+		"INSERT INTO app_bot (id,uid,display_name,scope,space_id,status,token,created_by) "+
+			"VALUES (?,?,?,?,'',1,?,?)",
+		id, uid, "Repro 309 FS Bot", "platform", token, "admin",
+	); err != nil {
+		t.Fatalf("insert app_bot: %v", err)
+	}
+
+	// A registry pointed at a dead Redis: every FindByToken errors -> nil -> DB fallback.
+	deadCfg := config.New()
+	deadCfg.DB.RedisAddr = "127.0.0.1:1" // nothing listening
+	deadCtx := config.NewContext(deadCfg)
+	deadReg := NewRedisAppBotRegistry(deadCtx, ttl5min)
+
+	// FindByToken on a dead backend must be a safe miss (nil), not an error/panic.
+	if spec := deadReg.FindByToken(token); spec != nil {
+		t.Fatalf("dead-Redis FindByToken should miss (nil), got %+v", spec)
+	}
+
+	// Auth still works via the DB fallback for a valid token...
+	if got := authStatus(t, ba, deadReg, token); got != http.StatusOK {
+		t.Errorf("with Redis down, valid token should auth via DB fallback, got HTTP %d", got)
+	}
+	// ...and an unknown token is still rejected.
+	if got := authStatus(t, ba, deadReg, "app_unknown_309_tok_dddddddd"); got == http.StatusOK {
+		t.Errorf("with Redis down, unknown token must be rejected, got HTTP %d", got)
+	}
+}

--- a/modules/bot_api/resolve_targets_test.go
+++ b/modules/bot_api/resolve_targets_test.go
@@ -339,13 +339,9 @@ func TestResolveTargets_AppBotReturnsEmpty(t *testing.T) {
 	reg.Add(appToken, &AppBotRegistrySpec{UID: "appbot_rt_uid", Scope: "platform"})
 	prev := GetAppBotRegistry()
 	SetAppBotRegistry(reg)
-	t.Cleanup(func() {
-		if prev != nil {
-			SetAppBotRegistry(prev)
-		} else {
-			SetAppBotRegistry(NewAppBotRegistryAdapter())
-		}
-	})
+	// Restore unconditionally — the registry slot is an atomic.Pointer[regHolder],
+	// so SetAppBotRegistry(nil) is safe (restores the "no registry" state).
+	t.Cleanup(func() { SetAppBotRegistry(prev) })
 
 	// Seed a group with a matching name but no app-bot membership.
 	seedGroup(t, ctx, "g_rt_app", "应用群", "space_1")

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -124,7 +124,7 @@ var systemSettingSchema = []settingDef{
 	// DEL 失败 / 极窄的失效-回填竞态（见 modules/bot_api/registry_redis.go）。实时热更新
 	// 无需重启；读取侧再夹紧到 [30, 86400]，超界回落默认值。标记 Positive 以放开
 	// settingTypeInt 默认的 [0,3650] 上界（本键上限 86400）。
-	{Category: "app_bot", Key: "auth_cache_ttl_seconds", Type: settingTypeInt, Description: "App Bot 鉴权缓存安全网 TTL(秒)，吊销即时生效，此值仅兜底失效竞态；调高会按比例拉长被吊销 token 在该竞态下仍可全簇鉴权的最坏窗口；有效范围[30,86400]，超出范围的写入会被接受但运行时回落默认 60s", Positive: true,
+	{Category: "app_bot", Key: "auth_cache_ttl_seconds", Type: settingTypeInt, Description: "App Bot 鉴权缓存安全网 TTL(秒)，吊销经共享墓碑即时生效，此值仅兜底孤儿键/撤销写失败；调高会按比例拉长撤销写失败时被吊销 token 仍可全簇鉴权的最坏窗口；有效范围[30,600]，超出范围的写入会被接受但运行时回落默认 60s", Positive: true,
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.AppBotAuthCacheTTLSeconds()) }},
 
 	// Email server config — formerly yaml-only (Support.* in config.go).

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -120,6 +120,13 @@ var systemSettingSchema = []settingDef{
 	{Category: "incomingwebhook", Key: "member_can_broadcast", Type: settingTypeBool, Description: "非管理员成员创建的 Webhook 是否可用广播型 @（@所有人/@所有 AI）；关闭后即时收回成员广播，管理员创建的不受影响",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.IncomingWebhookMemberCanBroadcast()) }},
 
+	// App Bot 共享鉴权缓存的安全网 TTL（秒）。吊销靠共享 DEL 即时生效，此 TTL 仅兜底
+	// DEL 失败 / 极窄的失效-回填竞态（见 modules/bot_api/registry_redis.go）。实时热更新
+	// 无需重启；读取侧再夹紧到 [30, 86400]，超界回落默认值。标记 Positive 以放开
+	// settingTypeInt 默认的 [0,3650] 上界（本键上限 86400）。
+	{Category: "app_bot", Key: "auth_cache_ttl_seconds", Type: settingTypeInt, Description: "App Bot 鉴权缓存安全网 TTL(秒)，吊销即时生效，此值仅兜底失效竞态；范围[30,86400]", Positive: true,
+		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.AppBotAuthCacheTTLSeconds()) }},
+
 	// Email server config — formerly yaml-only (Support.* in config.go).
 	{Category: "support", Key: "email", Type: settingTypeString, Description: "技术支持邮箱（发件人）",
 		Effective: func(s *SystemSettings) string { return s.SupportEmail() }},

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -124,7 +124,7 @@ var systemSettingSchema = []settingDef{
 	// DEL 失败 / 极窄的失效-回填竞态（见 modules/bot_api/registry_redis.go）。实时热更新
 	// 无需重启；读取侧再夹紧到 [30, 86400]，超界回落默认值。标记 Positive 以放开
 	// settingTypeInt 默认的 [0,3650] 上界（本键上限 86400）。
-	{Category: "app_bot", Key: "auth_cache_ttl_seconds", Type: settingTypeInt, Description: "App Bot 鉴权缓存安全网 TTL(秒)，吊销即时生效，此值仅兜底失效竞态；调高会按比例拉长被吊销 token 在该竞态下仍可全簇鉴权的最坏窗口；范围[30,86400]", Positive: true,
+	{Category: "app_bot", Key: "auth_cache_ttl_seconds", Type: settingTypeInt, Description: "App Bot 鉴权缓存安全网 TTL(秒)，吊销即时生效，此值仅兜底失效竞态；调高会按比例拉长被吊销 token 在该竞态下仍可全簇鉴权的最坏窗口；有效范围[30,86400]，超出范围的写入会被接受但运行时回落默认 60s", Positive: true,
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.AppBotAuthCacheTTLSeconds()) }},
 
 	// Email server config — formerly yaml-only (Support.* in config.go).

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -124,7 +124,7 @@ var systemSettingSchema = []settingDef{
 	// DEL 失败 / 极窄的失效-回填竞态（见 modules/bot_api/registry_redis.go）。实时热更新
 	// 无需重启；读取侧再夹紧到 [30, 86400]，超界回落默认值。标记 Positive 以放开
 	// settingTypeInt 默认的 [0,3650] 上界（本键上限 86400）。
-	{Category: "app_bot", Key: "auth_cache_ttl_seconds", Type: settingTypeInt, Description: "App Bot 鉴权缓存安全网 TTL(秒)，吊销即时生效，此值仅兜底失效竞态；范围[30,86400]", Positive: true,
+	{Category: "app_bot", Key: "auth_cache_ttl_seconds", Type: settingTypeInt, Description: "App Bot 鉴权缓存安全网 TTL(秒)，吊销即时生效，此值仅兜底失效竞态；调高会按比例拉长被吊销 token 在该竞态下仍可全簇鉴权的最坏窗口；范围[30,86400]", Positive: true,
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.AppBotAuthCacheTTLSeconds()) }},
 
 	// Email server config — formerly yaml-only (Support.* in config.go).

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -708,9 +708,11 @@ const (
 	// defaultAppBotAuthCacheTTLSeconds is the safety-net expiry (seconds) for the
 	// shared Redis App Bot auth cache. Revocation is instant via the shared DEL;
 	// this TTL only bounds drift / the narrow re-populate race (see
-	// modules/bot_api/registry_redis.go). 5 min balances a tight revocation bound
-	// against re-validating active tokens against the DB only ~once per TTL.
-	defaultAppBotAuthCacheTTLSeconds = 300
+	// modules/bot_api/registry_redis.go). 60s keeps the worst-case staleness
+	// window (a failed DEL, or the re-populate race) tight while still serving
+	// active tokens from cache between DB re-validations. Kept in sync with
+	// defaultAppBotAuthCacheTTL in modules/bot_api/registry_redis.go.
+	defaultAppBotAuthCacheTTLSeconds = 60
 	// appBotAuthCacheTTLMinSeconds / Max bound an admin override to a sane window
 	// (does not use getIntClamped, whose [0,3650] range is tuned for "days").
 	appBotAuthCacheTTLMinSeconds = 30

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -715,8 +715,11 @@ const (
 	defaultAppBotAuthCacheTTLSeconds = 60
 	// appBotAuthCacheTTLMinSeconds / Max bound an admin override to a sane window
 	// (does not use getIntClamped, whose [0,3650] range is tuned for "days").
+	// Revocation propagates instantly via the shared tombstone, so this TTL is only
+	// an orphan / failed-revocation-write backstop — the max is kept tight (10 min)
+	// so a misconfiguration can't widen the worst-case revoked-token window.
 	appBotAuthCacheTTLMinSeconds = 30
-	appBotAuthCacheTTLMaxSeconds = 86400
+	appBotAuthCacheTTLMaxSeconds = 600
 )
 
 // AppBotAuthCacheTTLSeconds is the safety-net TTL (seconds) written with each

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -699,3 +699,33 @@ func incomingWebhookMaxPerCreatorEnvDefault() int {
 	}
 	return defaultIncomingWebhookMaxPerCreator
 }
+
+// ---------------------------------------------------------------------------
+// App Bot auth cache (issue #309)
+// ---------------------------------------------------------------------------
+
+const (
+	// defaultAppBotAuthCacheTTLSeconds is the safety-net expiry (seconds) for the
+	// shared Redis App Bot auth cache. Revocation is instant via the shared DEL;
+	// this TTL only bounds drift / the narrow re-populate race (see
+	// modules/bot_api/registry_redis.go). 5 min balances a tight revocation bound
+	// against re-validating active tokens against the DB only ~once per TTL.
+	defaultAppBotAuthCacheTTLSeconds = 300
+	// appBotAuthCacheTTLMinSeconds / Max bound an admin override to a sane window
+	// (does not use getIntClamped, whose [0,3650] range is tuned for "days").
+	appBotAuthCacheTTLMinSeconds = 30
+	appBotAuthCacheTTLMaxSeconds = 86400
+)
+
+// AppBotAuthCacheTTLSeconds is the safety-net TTL (seconds) written with each
+// shared App Bot auth cache key. Read from system_setting (category "app_bot",
+// key "auth_cache_ttl_seconds"); hot-reloaded with the rest of the snapshot, so
+// an operator can retune it without a deploy. Out-of-range values fall back to
+// the code default rather than being served verbatim (defence in depth).
+func (s *SystemSettings) AppBotAuthCacheTTLSeconds() int {
+	v := s.getInt("app_bot", "auth_cache_ttl_seconds", defaultAppBotAuthCacheTTLSeconds)
+	if v < appBotAuthCacheTTLMinSeconds || v > appBotAuthCacheTTLMaxSeconds {
+		return defaultAppBotAuthCacheTTLSeconds
+	}
+	return v
+}

--- a/modules/common/system_settings_test.go
+++ b/modules/common/system_settings_test.go
@@ -252,6 +252,44 @@ func TestSystemSettings_IncomingWebhook_ReadSideClamp_NoInfra(t *testing.T) {
 	assert.Equal(t, 3, s.IncomingWebhookMaxPerGroup())
 }
 
+// TestSystemSettings_AppBotAuthCacheTTL_ReadSideClamp_NoInfra pins the read-side
+// defence for app_bot.auth_cache_ttl_seconds: an in-range value is served as-is,
+// and anything outside the tightened [30, 600] window (incl. the old 24h max, 0,
+// negative, non-int) falls back to the 60s default rather than being honored.
+// Drives the snapshot directly, no infra.
+func TestSystemSettings_AppBotAuthCacheTTL_ReadSideClamp_NoInfra(t *testing.T) {
+	const key = "app_bot.auth_cache_ttl_seconds"
+
+	// In-range value served verbatim.
+	s := &SystemSettings{}
+	snap := map[string]string{key: "120"}
+	s.snapshot.Store(&snap)
+	assert.Equal(t, 120, s.AppBotAuthCacheTTLSeconds())
+
+	// Out-of-range / non-int → default (60). "86400" pins the lowered max bound.
+	for _, bad := range []string{"29", "601", "0", "-5", "86400", "abc"} {
+		s := &SystemSettings{}
+		snap := map[string]string{key: bad}
+		s.snapshot.Store(&snap)
+		assert.Equalf(t, defaultAppBotAuthCacheTTLSeconds, s.AppBotAuthCacheTTLSeconds(),
+			"ttl=%q must fall back to the default", bad)
+	}
+
+	// Boundary values are accepted.
+	for in, want := range map[string]int{"30": 30, "600": 600} {
+		s := &SystemSettings{}
+		snap := map[string]string{key: in}
+		s.snapshot.Store(&snap)
+		assert.Equalf(t, want, s.AppBotAuthCacheTTLSeconds(), "boundary ttl=%q must be accepted", in)
+	}
+
+	// Missing key → default.
+	empty := &SystemSettings{}
+	em := map[string]string{}
+	empty.snapshot.Store(&em)
+	assert.Equal(t, defaultAppBotAuthCacheTTLSeconds, empty.AppBotAuthCacheTTLSeconds())
+}
+
 // TestSystemSettings_IncomingWebhook_GetterChain_NoInfra exercises the full
 // snapshot(DB) → env → code-default fallback for the incomingwebhook getters
 // WITHOUT a test server: it drives the snapshot map directly. This lets the


### PR DESCRIPTION
## Summary

App Bot API auth resolved a presented token to `{UID, Scope, SpaceID}` through a **per-process in-memory map** (`bot_api.AppBotRegistryAdapter`). Revocations (rotate / unpublish / delete) only mutated the registry of the instance that handled the admin request, and on the auth path an in-memory hit short-circuited the authoritative DB check — so under multiple replicas a revoked App Bot token kept authenticating on every peer until that peer restarted (security-relevant staleness).

This replaces the in-memory registry with a **shared Redis write-through cache**, so a revoke is visible to every replica the instant the admin request commits. The DB (`app_bot` table) stays the authority via the existing fallback, and auth **fails safe** to the DB when Redis is unavailable. The bearer token is **SHA-256 hashed** in the Redis key (never stored verbatim). Revocation writes a **shared tombstone** (a positive cross-replica deny), and the best-effort cache warm-up uses **SETNX** so a delayed warm-up can never resurrect a just-revoked token; the warm-up is also **bounded by a degraded-Redis circuit breaker** so an outage can't amplify into goroutine / connection-pool pressure on the auth hot path.

## Related Issue

Fixes #309

## Linked Spec

`.octospec/tasks/appbot-token-revocation-redis/brief.md` (load-bearing: `auth`, `bot-api`, `space`/`isolation`). Journal: `.octospec/journal/shared/appbot-token-revocation-redis.md`.

## Changes

- New `modules/bot_api/registry_redis.go` — `RedisAppBotRegistry` over a shared Redis store (`appbot:auth:{sha256hex(token)}` → JSON spec; the token is **SHA-256 hashed** so a live bearer credential never lands in a Redis key). The write model is deliberately asymmetric:
  - `FindByToken` returns nil on a miss, on a **tombstone**, or on **any Redis error** → `authAppBot` falls through to the authoritative DB lookup (fail-safe; never serves a stale/revoked spec on a degraded backend).
  - `Add` (authoritative publish / rotate-new) — unconditional `SET`, overwrites any tombstone so a re-publish re-enables the token at once.
  - `Warm` (best-effort warm-up: DB-fallback repopulate + startup load) — `SETNX`, only fills an **absent** key, so it can never overwrite a concurrent revocation's tombstone; circuit-gated so a Redis outage can't pile up blocking writes on the auth hot path.
  - `Remove` (revoke: unpublish / delete / rotate-old) — writes a short-lived **tombstone** (not a DEL) with bounded retry + loud-on-failure, so every replica denies the token immediately and a racing warm-up cannot resurrect it.
- `modules/bot_api/registry.go` — `AppBotRegistryInterface` (`FindByToken` + `Add` + `Warm` + `Remove` + `Update`); the in-memory `AppBotRegistryAdapter` still satisfies it (kept for unit tests). The global registry slot uses `atomic.Pointer[regHolder]` (accepts a nil/clearing store + differing concrete types; lock-free hot-path reads).
- `modules/bot_api/auth.go` — the DB-fallback success path fires a **best-effort `go reg.Warm(token, spec)`** (only ever caching a DB-confirmed valid+published spec).
- `modules/app_bot/app_bot.go` — wire `NewRedisAppBotRegistry`; admin helpers go through the interface (`syncAuthRegistry`→`Add`, `removeAuthRegistry`→`Remove`, `updateAuthRegistry`→`Update`); startup `loadRegistryFromDB`→`Warm`. The safety-net key TTL is injected as a `func() time.Duration` over the hot-reloaded system-settings snapshot (keeps `bot_api` decoupled from `modules/common`).
- `modules/common/system_settings.go` + `system_setting_schema.go` — new `AppBotAuthCacheTTLSeconds()` (category `app_bot`, key `auth_cache_ttl_seconds`, default **60s**, clamped **[30, 600]**, registered in the admin schema); hot-reloaded, **no new env var**. The max is tight because revocation propagates instantly via the tombstone — the TTL is only an orphan / failed-write backstop.
- `modules/bot_api/registry_redis_multiinstance_test.go` + `modules/common/system_settings_test.go` — regression tests (below).

## Testing

- `modules/bot_api/registry_redis_multiinstance_test.go` (real MySQL + real Redis + the real `authBot` middleware; two `RedisAppBotRegistry` over one Redis = two replicas):
  - `TestAppBotTokenRevocationPropagatesToPeer` — after a **rotate** on A, peer B rejects the old token and accepts the new one.
  - `TestAppBotUnpublishPropagatesToPeer` — after an **unpublish** (status→2, DB row remains), peer B rejects via the published-status gate (the structurally distinct `status != 1` branch).
  - `TestAppBotDeletePropagatesToPeer` — after a **delete** (row removed), peer B rejects via DB fallback.
  - `TestAppBotWarmDoesNotResurrectRevokedToken` — a **delayed warm-up landing just after a delete + revoke** must NOT re-create the key: the tombstone survives (SETNX no-op) and the peer keeps rejecting. (Closes the P1 resurrection race.)
  - `TestAppBotRepublishClearsTombstone` — authoritative `Add` overwrites a tombstone so a re-published token is served again.
  - `TestAppBotAuthFailsSafeWhenRedisDown` — dead Redis: `FindByToken` safely misses, a valid token still auths via DB fallback, an unknown token is rejected.
  - All **PASS** (deterministic) against local MySQL + Redis.
- `modules/common/system_settings_test.go::TestSystemSettings_AppBotAuthCacheTTL_ReadSideClamp_NoInfra` — no-infra: in-range served, out-of-range / non-int / the old 24h value → 60s default, `[30, 600]` boundaries accepted.
- Gates: `go build ./...` ok; `golangci-lint run` 0 issues; `make i18n-extract-check` + `make i18n-lint` clean (no new error codes / raw responses); existing `bot_api`/`app_bot` registry + auth unit tests pass.
- Not run locally: the `testutil.NewTestServer`-based App Bot **handler** integration tests require a running WuKongIM, which could not be started in the dev sandbox — they are covered by CI. The handler change is the sync-helper call (now write-through to the shared registry), whose behavior is exercised directly by the regression tests above; the handlers' DB / rollback / `UpdateIMToken` / response logic is unchanged.

- [x] Unit tests added/updated
- [x] Manually verified (DB+Redis integration; see above)

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   App Bot auth (`authAppBot`) now resolves a token through a shared Redis cache instead of a per-process map. Lookup order is unchanged in spirit — cache first, authoritative DB on miss — but because the cache is now shared, a revoke (rotate/unpublish/delete) writes one shared tombstone and every replica stops honoring the token immediately, instead of lingering on un-restarted peers. Single-replica behavior is identical.

2. **What could break because of it (dependents + failure mode)?**
   The auth fast path now depends on Redis (already required app-wide). Failure mode is bounded by design: a Redis error in `FindByToken` returns nil → the authoritative DB lookup runs, so a Redis outage degrades to a correct, slower DB-per-auth path — never fails open on a revoked token, never blocks a valid one. The revocation-resurrection race (a warm-up re-creating a just-revoked key) is closed by the tombstone + `SETNX` pairing: a best-effort warm-up can never overwrite a tombstone, and `FindByToken` denies a tombstone outright. The degraded-write circuit keeps the fire-and-forget warm-up from piling up goroutines / pool waiters during an outage; revocation writes stay ungated (bounded retry + loud-on-failure). The exported interface gained `Warm` with no external implementers. Residual (now narrow): a revocation *write* that fails on a transient Redis error after retries — bounded by the key TTL (max 600s), and moot when Redis is fully down (`FindByToken` then errors → DB fallback → rejected).

3. **How do you know it works (specific test/repro/trace)?**
   Six multi-instance regression tests reproduce the original bug's topology (two registries, shared Redis + DB, real `authBot`) and assert the fix across all three revocation paths (rotate / unpublish status-gate / delete), the **resurrection race** (a delayed warm-up after a delete + revoke leaves the peer rejecting), re-publish-clears-tombstone, and the Redis-down fail-safe. A no-infra unit test pins the read-side TTL clamp. All pass deterministically; build/lint/i18n gates are green.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (octospec brief/journal/log)
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gNwk92A9ps6y7rLtD3d9T

---
_Generated by [Claude Code](https://claude.ai/code/session_016gNwk92A9ps6y7rLtD3d9T)_