### PR TITLE
feat(file): expand upload extension whitelist with low-risk formats (closes #460)

### DIFF
--- a/modules/file/const.go
+++ b/modules/file/const.go
@@ -175,14 +175,24 @@ var allowedExtensions = map[string]bool{
 	// 图片
 	".jpg": true, ".jpeg": true, ".png": true, ".gif": true,
 	".bmp": true, ".webp": true, ".ico": true,
+	".heic": true, ".heif": true, ".tiff": true, ".tif": true,
 	// 文档
 	".pdf": true, ".doc": true, ".docx": true, ".xls": true,
 	".xlsx": true, ".ppt": true, ".pptx": true, ".txt": true,
 	".csv": true, ".rtf": true, ".odt": true, ".ods": true,
-	".md": true, ".html": true, ".htm": true,
+	".odp": true, ".md": true, ".html": true, ".htm": true,
+	// Apple iWork（基于 zip 的文档，无执行风险）
+	".key": true, ".numbers": true, ".pages": true,
+	// 电子书
+	".epub": true, ".mobi": true,
+	// 纯文本/数据
+	".toml": true, ".ini": true, ".log": true, ".tsv": true, ".ndjson": true,
+	// 字幕
+	".srt": true, ".vtt": true, ".ass": true,
 	// 音频
 	".mp3": true, ".wav": true, ".aac": true, ".flac": true,
 	".ogg": true, ".wma": true, ".m4a": true, ".amr": true,
+	".opus": true, ".aiff": true,
 	// 视频
 	".mp4": true, ".avi": true, ".mov": true, ".wmv": true,
 	".flv": true, ".mkv": true, ".webm": true, ".m4v": true,

--- a/modules/file/const_test.go
+++ b/modules/file/const_test.go
@@ -176,6 +176,36 @@ func TestIsAllowedExtension_BlockedTakesPriority(t *testing.T) {
 	}
 }
 
+func TestIsAllowedExtension_NewlyAddedExtensions(t *testing.T) {
+	// 新增的低/无执行风险扩展名应被允许上传
+	added := []string{
+		// Apple iWork
+		".key", ".numbers", ".pages",
+		// 现代图片
+		".heic", ".heif", ".tiff", ".tif",
+		// OpenDocument 演示文稿
+		".odp",
+		// 电子书
+		".epub", ".mobi",
+		// 纯文本/数据
+		".toml", ".ini", ".log", ".tsv", ".ndjson",
+		// 字幕
+		".srt", ".vtt", ".ass",
+		// 音频
+		".opus", ".aiff",
+	}
+	for _, ext := range added {
+		assert.True(t, IsAllowedExtension(ext), "%s should be allowed", ext)
+		assert.False(t, IsBlockedExtension(ext), "%s should not be blocked", ext)
+	}
+
+	// 有执行/XSS 风险，刻意排除的扩展名不应被允许
+	excluded := []string{".svg", ".xlsm", ".docm", ".pptm", ".iso", ".img"}
+	for _, ext := range excluded {
+		assert.False(t, IsAllowedExtension(ext), "%s should not be allowed", ext)
+	}
+}
+
 func TestSanitizeFilename(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -317,9 +347,15 @@ func TestIsBlockedExtension_AllEntries(t *testing.T) {
 func TestIsAllowedExtension_AllEntries(t *testing.T) {
 	allAllowed := []string{
 		".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp", ".ico",
+		".heic", ".heif", ".tiff", ".tif",
 		".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
-		".txt", ".csv", ".rtf", ".odt", ".ods", ".md", ".html", ".htm",
+		".txt", ".csv", ".rtf", ".odt", ".ods", ".odp", ".md", ".html", ".htm",
+		".key", ".numbers", ".pages",
+		".epub", ".mobi",
+		".toml", ".ini", ".log", ".tsv", ".ndjson",
+		".srt", ".vtt", ".ass",
 		".mp3", ".wav", ".aac", ".flac", ".ogg", ".wma", ".m4a", ".amr",
+		".opus", ".aiff",
 		".mp4", ".avi", ".mov", ".wmv", ".flv", ".mkv", ".webm", ".m4v",
 		".zip", ".rar", ".7z", ".tar", ".gz", ".bz2", ".xz",
 		".json", ".xml", ".yaml", ".yml",


### PR DESCRIPTION
## What

Expands the server-side upload extension whitelist (`allowedExtensions` in `modules/file/const.go`) to cover common low/no-execution-risk formats that were previously rejected with `不支持上传<ext>类型的文件` (400).

Closes #460.

## Why

The real upload gate is a **whitelist** — anything not listed is rejected. It was missing a lot of safe everyday formats, most notably Apple iWork files (`.key` triggered this) and the iPhone-default `.heic` photo format.

## Added (low/no execution risk)

- **Apple iWork** (zip-based documents): `.key` `.numbers` `.pages`
- **Modern images**: `.heic` `.heif` `.tiff` `.tif`
- **OpenDocument presentation** (odt/ods were present, odp missing): `.odp`
- **Ebooks**: `.epub` `.mobi`
- **Text / data**: `.toml` `.ini` `.log` `.tsv` `.ndjson`
- **Subtitles**: `.srt` `.vtt` `.ass`
- **Audio**: `.opus` `.aiff`

## Intentionally NOT added (execution / XSS risk)

`.svg` (embeddable `<script>`, stored-XSS), `.xlsm` / `.docm` / `.pptm` (Office macros), `.iso` / `.img` (mountable disk images). These need separate security review and are out of scope here.

## Tests

- Updated `TestIsAllowedExtension_AllEntries` to include the new extensions.
- Added `TestIsAllowedExtension_NewlyAddedExtensions`: asserts each new extension is allowed and not blocked, and that the deliberately-excluded risky ones return `false`.
- `go build ./...` → OK
- `go test ./modules/file/...` → ok

## Notes

None of the added extensions collide with `blockedExtensions`. The change is confined to the whitelist map + its tests; no unrelated refactoring.
