### PR TITLE
fix(ci): raise MySQL max_connections to stop flaky test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,26 @@ jobs:
           echo "mysql did not become ready" >&2
           exit 1
 
+      - name: Raise MySQL max_connections
+        # Flaky "Error 1040: Too many connections" guard (#419).
+        #
+        # testutil.NewTestServer (octo-lib) builds a fresh *config.Context per
+        # call, each lazily opening its own *sql.DB pool sized 100 max / 10 idle
+        # (config.New() default — hardcoded, NOT env-tunable) with a 4h conn
+        # lifetime and no idle-reap. Nothing closes those pools, so a heavy
+        # package that calls NewTestServer dozens of times (modules/user ≈ 34)
+        # accumulates ~8 lingering connections per call and intermittently
+        # exhausts the mysql:8.0 default max_connections=151 — whichever test is
+        # unlucky under -shuffle=on then panics. Reproduced locally: the suite
+        # crosses 151 around the 19th NewTestServer call; at a 1000 ceiling it
+        # plateaus near the observed peak (~300) and stays green.
+        #
+        # max_connections is a dynamic GLOBAL, so set it at runtime (root is
+        # available and mysql-client is installed above). This unblocks every
+        # package at once; the proper O(1) fix — idle-reap in octo-lib testutil
+        # — is tracked upstream.
+        run: mysql -h 127.0.0.1 -uroot -pdemo -e "SET GLOBAL max_connections = 1000;"
+
       - name: Wait for WuKongIM
         run: |
           for _ in $(seq 1 30); do


### PR DESCRIPTION
## Summary

The `Test` job intermittently fails with `panic: Error 1040: Too many connections`. Root-caused to a per-test DB connection-pool leak that exhausts the `mysql:8.0` default `max_connections=151`. This raises the CI MySQL ceiling so the leaked pools stop flaking the run.

## Related Issue

Fixes #419

## Linked Spec

#419 — CI flake triage. Config-only change, no separate task brief.

## Changes

- `.github/workflows/ci.yml`: add a `Raise MySQL max_connections` step in the `Test` job (after MySQL is ready, before the test loop) that runs `SET GLOBAL max_connections = 1000`.

## Testing

Reproduced **and** fix-validated locally against MySQL 8.0 with `max_connections=151` (identical to the CI `mysql:8.0` service default), looping `testutil.NewTestServer()` the way a heavy package does:

| Scenario | Behaviour | Result |
|---|---|---|
| default 100/10 pool, `max_conn=151` | +8 conns per `NewTestServer`, linear | **`panic: Error 1040: Too many connections`** at the 19th call (152 > 151), thrown from `testutil/test.go:35` — same call site as the CI failures |
| pool bound to 12/2 + 1s idle-reap (the existing `modules/group` fix) | flat at ~16 | survives 40 calls ✅ |
| default pool + `max_conn=1000` | linear to ~320 at 40 calls | survives ✅ |

- [ ] Unit tests added/updated — N/A (CI config only)
- [x] Manually verified (repro + fix validation above)

## COMPREHENSION

1. **What it does to the load-bearing path:** adds one runtime `SET GLOBAL max_connections=1000` to the `Test` job. `testutil.NewTestServer` (octo-lib) builds a fresh `*config.Context` per call, each opening its own `*sql.DB` pool sized 100 max / 10 idle (`config.New()` default — hardcoded, not env-tunable) that is never closed. Heavy packages call it dozens of times (`modules/user` ≈ 34), accumulating ~8 lingering connections each until the 151 ceiling is hit; under `-shuffle=on` a random test then panics. Raising the ceiling to 1000 keeps the suite well above its observed peak (~300).

2. **What could break:** minimal — it only loosens a limit on an ephemeral CI service container, touching no product or test code. `1000` is comfortably under the image's `open_files_limit`, so it is not silently capped. It *masks* rather than removes the pool leak, so a future package adding >~100 `NewTestServer` calls could still approach the new ceiling.

3. **How I know it works:** reproduced the exact panic at 151 and confirmed the identical harness runs green at 1000 (numbers above). Since the pool size is baked into octo-lib and unreachable from this repo, this is the only within-repo lever; the proper O(1) root-cause fix (idle-reap in `octo-lib` `testutil`) is recommended as a separate upstream change.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [ ] Added tests for my changes — N/A (CI config only)
- [ ] Updated documentation — N/A
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrtB963YTomRqXcFAjUK3D

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrtB963YTomRqXcFAjUK3D)_