### PR TITLE
feat(messages_search): gate image/video in /_search_all by keyword pr…

### DIFF
--- a/docs/messages-search/octo-server-search-dev.md
+++ b/docs/messages-search/octo-server-search-dev.md
@@ -544,29 +544,39 @@ func resolveFileExt(f *FilePayload) string {
 
 差异（vs `_search`）：
 
-- DSL：`should[multi_match(text+plain+forward), multi_match(file.name+caption)] + filter[payload.type IN {1, 8, 11}]`（text / file / mergeForward）
-- 响应字段：`result_type` 判别式（`payload.type` → "message" / "file"）+ 嵌套 `message` / `file` 子对象 + `sorted_at`（=内层 `sent_at`）
+- DSL：`should[multi_match(text+richText+forward), multi_match(file.name+caption)] + filter[payload.type IN ?]`，其中 `payload.type` 白名单按 keyword 是否为空分两段：
+  - keyword 非空：`{1, 8, 11, 14}`（text / file / mergeForward / richText）— 媒体 payload 在 `should` 上没有可命中的字段，会被 MSM=1 过滤掉或者落成零分噪声，索性硬剔除
+  - keyword 为空（浏览模式）：`{1, 8, 11, 14, 2, 5}` — 多加 image / video，统一信息流里能看到最近的图片和视频
+- 响应字段：`result_type` 判别式（`payload.type` → "message" / "file"）+ 嵌套 `message` / `file` 子对象 + `sorted_at`（=内层 `sent_at`）。浏览模式的 image / video 走 `result_type=message`，`message.message_kind` 取 `"image"` / `"video"`，并附 `thumb_url` / `width` / `height` / `duration_ms`（仅 video）——同 `MediaHit` 的渲染字段保持一致
 
 DSL 关键片段：
 
 ```go
 b := elastic.NewBoolQuery()
 b.Filter(elastic.NewTermQuery("channelId", normalizedChannelID(req, loginUID)))
-b.Filter(elastic.NewTermsQuery("payload.type", 1, 8, 11))
+// 浏览模式额外注入 image(2) + video(5)
+allowed := []any{1, 8, 11, 14}
+if req.Keyword == "" {
+    allowed = append(allowed, 2, 5)
+}
+b.Filter(elastic.NewTermsQuery("payload.type", allowed...))
 b.MustNot(elastic.NewTermQuery("revoked", true))
 
-// should 必须至少命中一个
-should := []elastic.Query{
-    elastic.NewMultiMatchQuery(req.Keyword,
-        "payload.text.content^3",
-        "payload.mergeForward.msgs.searchText",
-    ),
-    elastic.NewMultiMatchQuery(req.Keyword,
-        "payload.file.name^2",
-        "payload.file.caption",
-    ),
+// keyword 路径才挂 should（含 richText.searchText）
+if req.Keyword != "" {
+    should := []elastic.Query{
+        elastic.NewMultiMatchQuery(req.Keyword,
+            "payload.text.content^3",
+            "payload.richText.searchText^3",
+            "payload.mergeForward.msgs.searchText",
+        ),
+        elastic.NewMultiMatchQuery(req.Keyword,
+            "payload.file.name^2",
+            "payload.file.caption",
+        ),
+    }
+    b.Should(should...).MinimumShouldMatch("1")
 }
-b.Should(should...).MinimumShouldMatch("1")
 ```
 
 响应映射：

--- a/modules/messages_search/dsl.go
+++ b/modules/messages_search/dsl.go
@@ -254,6 +254,13 @@ func fallbackSnippet(p *Payload) string {
 	if p.File != nil && p.File.Name != "" {
 		return truncateRunes(p.File.Name, snippetWindow)
 	}
+	// Video has no text-bearing field in the v1.8 indexer projection
+	// (VideoPayload carries url/cover/width/height/second only — see
+	// source.go), so there is nothing to clip into a snippet. Browse-mode
+	// /_search_all and /_search_around now surface the renderable bits
+	// (thumb_url, duration_ms, dimensions) directly on MessageHit via
+	// applyMediaProjection — the empty snippet here is intentional, not a
+	// missed branch.
 	return ""
 }
 

--- a/modules/messages_search/dsl_test.go
+++ b/modules/messages_search/dsl_test.go
@@ -595,10 +595,118 @@ func TestBuildSearchAllDSL_NoKeywordKeepsTypeFilter(t *testing.T) {
 			t.Errorf("empty-keyword search_all DSL missing %q in:\n%s", want, body)
 		}
 	}
-	// type filter must still segment message vs file
-	if !strings.Contains(body, `"payload.type":[1,8,11,14]`) && !strings.Contains(body, `"payload.type":[1, 8, 11, 14]`) {
-		t.Errorf("empty-keyword search_all DSL must still filter payload.type [1,8,11,14]:\n%s", body)
+	// Browse mode (keyword="") layers image(2) + video(5) onto the type
+	// whitelist so the unified feed shows recent media alongside text.
+	if !strings.Contains(body, `"payload.type":[1,8,11,14,2,5]`) && !strings.Contains(body, `"payload.type":[1, 8, 11, 14, 2, 5]`) {
+		t.Errorf("empty-keyword search_all DSL must filter payload.type [1,8,11,14,2,5]:\n%s", body)
 	}
+}
+
+// TestBuildSearchAllDSL_ImageVideoGatedByKeyword pins the contract that
+// image (payload.type=2) and video (payload.type=5) appear in the
+// /_search_all type filter ONLY when keyword is empty. The keyword path
+// hard-excludes them because the should[textClause, fileClause] + MSM=1
+// keyword clause has no field on a media payload and would emit
+// zero-relevance hits.
+func TestBuildSearchAllDSL_ImageVideoGatedByKeyword(t *testing.T) {
+	extractTypes := func(t *testing.T, raw []byte) []int {
+		t.Helper()
+		var normalized map[string]any
+		if err := json.Unmarshal(raw, &normalized); err != nil {
+			t.Fatalf("normalize: %v", err)
+		}
+		boolNode, ok := normalized["bool"].(map[string]any)
+		if !ok {
+			t.Fatalf("query has no bool node: %s", raw)
+		}
+		rawFilter, ok := boolNode["filter"]
+		if !ok {
+			t.Fatalf("bool has no filter: %s", raw)
+		}
+		var filters []any
+		switch v := rawFilter.(type) {
+		case []any:
+			filters = v
+		case map[string]any:
+			filters = []any{v}
+		default:
+			t.Fatalf("filter has unexpected shape %T: %s", rawFilter, raw)
+		}
+		for _, clause := range filters {
+			m, ok := clause.(map[string]any)
+			if !ok {
+				continue
+			}
+			terms, ok := m["terms"].(map[string]any)
+			if !ok {
+				continue
+			}
+			arr, ok := terms["payload.type"].([]any)
+			if !ok {
+				continue
+			}
+			out := make([]int, 0, len(arr))
+			for _, v := range arr {
+				out = append(out, int(v.(float64)))
+			}
+			return out
+		}
+		t.Fatalf("bool.filter has no terms(payload.type) clause:\n%s", raw)
+		return nil
+	}
+
+	t.Run("keyword excludes image and video", func(t *testing.T) {
+		req := SearchMessagesReq{ChannelType: channelTypeGroup, ChannelID: "g", Keyword: "hello"}
+		q, _ := buildSearchAllDSL(context.Background(), fallbackTestAnalyzer(), true, req, "g", "")
+		src, err := q.(interface{ Source() (any, error) }).Source()
+		if err != nil {
+			t.Fatalf("Source(): %v", err)
+		}
+		raw, _ := json.Marshal(src)
+		got := extractTypes(t, raw)
+		for _, banned := range []int{payloadTypeImage, payloadTypeVideo} {
+			for _, v := range got {
+				if v == banned {
+					t.Errorf("keyword path must not include payload.type=%d (got %v): %s", banned, got, raw)
+				}
+			}
+		}
+		for _, want := range []int{payloadTypeText, payloadTypeFile, payloadTypeMergeForward, payloadTypeRichText} {
+			found := false
+			for _, v := range got {
+				if v == want {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("keyword path must include payload.type=%d (got %v)", want, got)
+			}
+		}
+	})
+
+	t.Run("empty keyword includes image and video", func(t *testing.T) {
+		req := SearchMessagesReq{ChannelType: channelTypeGroup, ChannelID: "g"}
+		q, _ := buildSearchAllDSL(context.Background(), fallbackTestAnalyzer(), true, req, "g", "")
+		src, err := q.(interface{ Source() (any, error) }).Source()
+		if err != nil {
+			t.Fatalf("Source(): %v", err)
+		}
+		raw, _ := json.Marshal(src)
+		got := extractTypes(t, raw)
+		for _, want := range []int{payloadTypeImage, payloadTypeVideo} {
+			found := false
+			for _, v := range got {
+				if v == want {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("empty-keyword path must include payload.type=%d (got %v)", want, got)
+			}
+		}
+	})
 }
 
 func TestExtractSortValues(t *testing.T) {

--- a/modules/messages_search/dsl_test.go
+++ b/modules/messages_search/dsl_test.go
@@ -570,13 +570,15 @@ func TestBuildSearchAllDSL_TypeFilter(t *testing.T) {
 	}
 }
 
-func TestBuildSearchAllDSL_NoKeywordKeepsTypeFilter(t *testing.T) {
+func TestBuildSearchAllDSL_BrowseModeIncludesMediaTypes(t *testing.T) {
 	req := SearchMessagesReq{ChannelType: channelTypeGroup, ChannelID: "g"}
 	q, _ := buildSearchAllDSL(context.Background(), fallbackTestAnalyzer(), true, req, "g", "")
-	js, _ := json.Marshal(extractDSL(t, q.(interface {
-		Source() (any, error)
-	})))
-	body := string(js)
+	src, err := q.(interface{ Source() (any, error) }).Source()
+	if err != nil {
+		t.Fatalf("Source(): %v", err)
+	}
+	raw, _ := json.Marshal(src)
+	body := string(raw)
 	if strings.Contains(body, "multi_match") {
 		t.Errorf("search_all DSL with empty keyword must not include multi_match:\n%s", body)
 	}
@@ -597,8 +599,30 @@ func TestBuildSearchAllDSL_NoKeywordKeepsTypeFilter(t *testing.T) {
 	}
 	// Browse mode (keyword="") layers image(2) + video(5) onto the type
 	// whitelist so the unified feed shows recent media alongside text.
-	if !strings.Contains(body, `"payload.type":[1,8,11,14,2,5]`) && !strings.Contains(body, `"payload.type":[1, 8, 11, 14, 2, 5]`) {
-		t.Errorf("empty-keyword search_all DSL must filter payload.type [1,8,11,14,2,5]:\n%s", body)
+	// Order-independent: the previous string-substring assertion was brittle
+	// and forced callers to know the exact emission order.
+	got := extractSearchAllTypes(t, raw)
+	for _, want := range []int{
+		payloadTypeText,
+		payloadTypeFile,
+		payloadTypeMergeForward,
+		payloadTypeRichText,
+		payloadTypeImage,
+		payloadTypeVideo,
+	} {
+		found := false
+		for _, v := range got {
+			if v == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("empty-keyword search_all DSL must include payload.type=%d (got %v): %s", want, got, raw)
+		}
+	}
+	if len(got) != 6 {
+		t.Errorf("empty-keyword search_all DSL payload.type whitelist must have exactly 6 entries; got %d (%v)", len(got), got)
 	}
 }
 
@@ -609,52 +633,6 @@ func TestBuildSearchAllDSL_NoKeywordKeepsTypeFilter(t *testing.T) {
 // keyword clause has no field on a media payload and would emit
 // zero-relevance hits.
 func TestBuildSearchAllDSL_ImageVideoGatedByKeyword(t *testing.T) {
-	extractTypes := func(t *testing.T, raw []byte) []int {
-		t.Helper()
-		var normalized map[string]any
-		if err := json.Unmarshal(raw, &normalized); err != nil {
-			t.Fatalf("normalize: %v", err)
-		}
-		boolNode, ok := normalized["bool"].(map[string]any)
-		if !ok {
-			t.Fatalf("query has no bool node: %s", raw)
-		}
-		rawFilter, ok := boolNode["filter"]
-		if !ok {
-			t.Fatalf("bool has no filter: %s", raw)
-		}
-		var filters []any
-		switch v := rawFilter.(type) {
-		case []any:
-			filters = v
-		case map[string]any:
-			filters = []any{v}
-		default:
-			t.Fatalf("filter has unexpected shape %T: %s", rawFilter, raw)
-		}
-		for _, clause := range filters {
-			m, ok := clause.(map[string]any)
-			if !ok {
-				continue
-			}
-			terms, ok := m["terms"].(map[string]any)
-			if !ok {
-				continue
-			}
-			arr, ok := terms["payload.type"].([]any)
-			if !ok {
-				continue
-			}
-			out := make([]int, 0, len(arr))
-			for _, v := range arr {
-				out = append(out, int(v.(float64)))
-			}
-			return out
-		}
-		t.Fatalf("bool.filter has no terms(payload.type) clause:\n%s", raw)
-		return nil
-	}
-
 	t.Run("keyword excludes image and video", func(t *testing.T) {
 		req := SearchMessagesReq{ChannelType: channelTypeGroup, ChannelID: "g", Keyword: "hello"}
 		q, _ := buildSearchAllDSL(context.Background(), fallbackTestAnalyzer(), true, req, "g", "")
@@ -663,7 +641,7 @@ func TestBuildSearchAllDSL_ImageVideoGatedByKeyword(t *testing.T) {
 			t.Fatalf("Source(): %v", err)
 		}
 		raw, _ := json.Marshal(src)
-		got := extractTypes(t, raw)
+		got := extractSearchAllTypes(t, raw)
 		for _, banned := range []int{payloadTypeImage, payloadTypeVideo} {
 			for _, v := range got {
 				if v == banned {
@@ -693,7 +671,7 @@ func TestBuildSearchAllDSL_ImageVideoGatedByKeyword(t *testing.T) {
 			t.Fatalf("Source(): %v", err)
 		}
 		raw, _ := json.Marshal(src)
-		got := extractTypes(t, raw)
+		got := extractSearchAllTypes(t, raw)
 		for _, want := range []int{payloadTypeImage, payloadTypeVideo} {
 			found := false
 			for _, v := range got {
@@ -707,6 +685,56 @@ func TestBuildSearchAllDSL_ImageVideoGatedByKeyword(t *testing.T) {
 			}
 		}
 	})
+}
+
+// extractSearchAllTypes reads the payload.type whitelist from a marshalled
+// /_search_all DSL. Used by the browse-mode and keyword-gating tests so each
+// stays order-independent (the previous string-substring assertion forced
+// callers to know the exact emission order).
+func extractSearchAllTypes(t *testing.T, raw []byte) []int {
+	t.Helper()
+	var normalized map[string]any
+	if err := json.Unmarshal(raw, &normalized); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	boolNode, ok := normalized["bool"].(map[string]any)
+	if !ok {
+		t.Fatalf("query has no bool node: %s", raw)
+	}
+	rawFilter, ok := boolNode["filter"]
+	if !ok {
+		t.Fatalf("bool has no filter: %s", raw)
+	}
+	var filters []any
+	switch v := rawFilter.(type) {
+	case []any:
+		filters = v
+	case map[string]any:
+		filters = []any{v}
+	default:
+		t.Fatalf("filter has unexpected shape %T: %s", rawFilter, raw)
+	}
+	for _, clause := range filters {
+		m, ok := clause.(map[string]any)
+		if !ok {
+			continue
+		}
+		terms, ok := m["terms"].(map[string]any)
+		if !ok {
+			continue
+		}
+		arr, ok := terms["payload.type"].([]any)
+		if !ok {
+			continue
+		}
+		out := make([]int, 0, len(arr))
+		for _, v := range arr {
+			out = append(out, int(v.(float64)))
+		}
+		return out
+	}
+	t.Fatalf("bool.filter has no terms(payload.type) clause:\n%s", raw)
+	return nil
 }
 
 func TestExtractSortValues(t *testing.T) {

--- a/modules/messages_search/search_all.go
+++ b/modules/messages_search/search_all.go
@@ -131,12 +131,22 @@ func buildSearchAllDSL(ctx context.Context, analyzer tokenAnalyzer, stopwordStri
 	applyChannelAndRevoked(b, normChannelID)
 	applySpaceIDScope(b, req.ChannelType, spaceID)
 	applyExcludeVirtual(b)
-	b.Filter(elastic.NewTermsQuery("payload.type",
+	// Image (2) / video (5) are surfaced ONLY on the empty-keyword browse
+	// path. With a keyword, the should[textClause, fileClause] + MSM=1 has no
+	// field to hit on media payloads — they would either drop on MSM or
+	// surface as zero-relevance noise — so the keyword path keeps the
+	// text-bearing whitelist [1, 8, 11, 14]. Browse mode (keyword="") layers
+	// media in so the unified feed shows recent photos/videos alongside text.
+	allowedTypes := []any{
 		payloadTypeText,
 		payloadTypeFile,
 		payloadTypeMergeForward,
 		payloadTypeRichText,
-	))
+	}
+	if req.Keyword == "" {
+		allowedTypes = append(allowedTypes, payloadTypeImage, payloadTypeVideo)
+	}
+	b.Filter(elastic.NewTermsQuery("payload.type", allowedTypes...))
 	addCommonFilters(b, req.Filters)
 	var analyzeErr error
 	if req.Keyword != "" {

--- a/modules/messages_search/search_all_test.go
+++ b/modules/messages_search/search_all_test.go
@@ -126,3 +126,109 @@ func TestSingleSearchAllHit_RichTextKeepsMessageType(t *testing.T) {
 		t.Errorf("file should be nil for richtext result")
 	}
 }
+
+// Image (payload.type=2) surfaces in /_search_all browse mode (keyword="")
+// and must come back as a renderable MessageHit:
+//   - result_type=message (SearchAllHit dispatcher keeps the message slot)
+//   - message_kind=image so the client switches to the media renderer
+//   - thumb_url / width / height mirror MediaHit's projection (v1.8 has no
+//     separate thumb URL — the original image URL is what gets surfaced)
+//   - snippet falls back to the image caption when present
+//
+// Regression for PR #467: before this change the projection stamped image
+// docs as kind="text" with snippet="" and no renderable URL, leaving the
+// client with no way to distinguish or render media in the unified feed.
+func TestSingleSearchAllHit_Image(t *testing.T) {
+	tp := payloadTypeImage
+	doc := Doc{
+		MessageID:  201,
+		MessageSeq: 21,
+		From:       "u4",
+		Timestamp:  1717000010,
+		Payload: &Payload{
+			Type: &tp,
+			Image: &ImagePayload{
+				URL:     "https://cdn/x.jpg",
+				Caption: "野餐合影",
+				Width:   1080,
+				Height:  720,
+			},
+		},
+	}
+	h := &Handler{cfg: SearchConfig{}, cache: newSenderCache(8, 0)}
+	got := h.singleSearchAllHit(doc, SearchAllReq{ChannelType: channelTypeGroup, ChannelID: "g"}, nil)
+	if got.ResultType != "message" {
+		t.Errorf("result_type: got %q want message", got.ResultType)
+	}
+	if got.Message == nil {
+		t.Fatalf("message must be populated for image hit")
+	}
+	if got.Message.MessageKind != "image" {
+		t.Errorf("kind: got %q want image", got.Message.MessageKind)
+	}
+	if got.Message.ThumbURL != "https://cdn/x.jpg" {
+		t.Errorf("thumb_url must mirror payload.image.url: got %q", got.Message.ThumbURL)
+	}
+	if got.Message.Width != 1080 || got.Message.Height != 720 {
+		t.Errorf("dimensions: got %dx%d want 1080x720", got.Message.Width, got.Message.Height)
+	}
+	if got.Message.DurationMs != 0 {
+		t.Errorf("image must not carry duration_ms: got %d", got.Message.DurationMs)
+	}
+	if got.Message.Snippet != "野餐合影" {
+		t.Errorf("snippet must fall back to caption in browse mode: got %q", got.Message.Snippet)
+	}
+	if got.File != nil {
+		t.Errorf("file should be nil for image result")
+	}
+}
+
+// Video (payload.type=5) — same shape as image plus duration_ms (seconds → ms).
+// Empty Snippet is intentional: VideoPayload has no caption/title field in the
+// v1.8 indexer projection, so the renderable bits are delivered via
+// thumb_url / duration_ms instead of the snippet (see fallbackSnippet).
+func TestSingleSearchAllHit_Video(t *testing.T) {
+	tp := payloadTypeVideo
+	doc := Doc{
+		MessageID:  202,
+		MessageSeq: 22,
+		From:       "u5",
+		Timestamp:  1717000020,
+		Payload: &Payload{
+			Type: &tp,
+			Video: &VideoPayload{
+				URL:    "https://cdn/v.mp4",
+				Cover:  "https://cdn/v.jpg",
+				Width:  1280,
+				Height: 720,
+				Second: 42,
+			},
+		},
+	}
+	h := &Handler{cfg: SearchConfig{}, cache: newSenderCache(8, 0)}
+	got := h.singleSearchAllHit(doc, SearchAllReq{ChannelType: channelTypeGroup, ChannelID: "g"}, nil)
+	if got.ResultType != "message" {
+		t.Errorf("result_type: got %q want message", got.ResultType)
+	}
+	if got.Message == nil {
+		t.Fatalf("message must be populated for video hit")
+	}
+	if got.Message.MessageKind != "video" {
+		t.Errorf("kind: got %q want video", got.Message.MessageKind)
+	}
+	if got.Message.ThumbURL != "https://cdn/v.jpg" {
+		t.Errorf("thumb_url must mirror payload.video.cover: got %q", got.Message.ThumbURL)
+	}
+	if got.Message.Width != 1280 || got.Message.Height != 720 {
+		t.Errorf("dimensions: got %dx%d want 1280x720", got.Message.Width, got.Message.Height)
+	}
+	if got.Message.DurationMs != 42000 {
+		t.Errorf("duration_ms: got %d want 42000 (42s * 1000)", got.Message.DurationMs)
+	}
+	if got.Message.Snippet != "" {
+		t.Errorf("video snippet must be empty (VideoPayload has no text field): got %q", got.Message.Snippet)
+	}
+	if got.File != nil {
+		t.Errorf("file should be nil for video result")
+	}
+}

--- a/modules/messages_search/search_messages.go
+++ b/modules/messages_search/search_messages.go
@@ -12,6 +12,14 @@ import (
 )
 
 // MessageHit is the response shape per A doc §2.1.
+//
+// MediaKind / ThumbURL / Width / Height / DurationMs are populated only for
+// image (payload.type=2) and video (payload.type=5) hits surfaced by
+// /_search_all browse mode (or by /_search_around, which has no type
+// whitelist). They mirror MediaHit's renderable fields so the client can
+// render a media card directly from a MessageHit without a separate
+// projection. All are omitempty so plain text / forward hits keep their wire
+// shape unchanged.
 type MessageHit struct {
 	MessageID       string         `json:"message_id"`
 	MessageSeq      int64          `json:"message_seq"`
@@ -24,6 +32,10 @@ type MessageHit struct {
 	OuterPreview    *OuterPreview  `json:"outer_preview,omitempty"`
 	InnerMessages   []InnerMessage `json:"inner_messages,omitempty"`
 	ChannelID       string         `json:"channel_id"`
+	ThumbURL        string         `json:"thumb_url,omitempty"`
+	Width           int            `json:"width,omitempty"`
+	Height          int            `json:"height,omitempty"`
+	DurationMs      int64          `json:"duration_ms,omitempty"`
 }
 
 func init() {
@@ -159,7 +171,8 @@ func buildSearchMessagesDSL(ctx context.Context, analyzer tokenAnalyzer, stopwor
 	// dedicated /_search_media and /_search_files surfaces — surfacing them
 	// on the legacy /_search response was confusing the client UI which can
 	// only render text/richText/mergeForward snippets. Sibling endpoints
-	// already use the same `terms` shape: /_search_all → [1,8,11,14],
+	// already use the same `terms` shape: /_search_all → [1,8,11,14] in the
+	// keyword path and [1,8,11,14,2,5] in browse mode (keyword=""),
 	// /_search_media → [2,5], /_search_files → [8].
 	b.Filter(elastic.NewTermsQuery("payload.type",
 		payloadTypeText,
@@ -242,7 +255,7 @@ func (h *Handler) singleMessageHit(doc Doc, reqChannelID string, hl map[string][
 	if snippet == "" {
 		snippet = fallbackSnippet(doc.Payload)
 	}
-	return MessageHit{
+	mh := MessageHit{
 		MessageID:     strconv.FormatInt(doc.MessageID, 10),
 		MessageSeq:    int64(doc.MessageSeq),
 		MessageKind:   classifyKind(doc.Payload),
@@ -252,5 +265,32 @@ func (h *Handler) singleMessageHit(doc Doc, reqChannelID string, hl map[string][
 		OuterPreview:  buildOuterPreview(doc.Payload),
 		InnerMessages: buildInnerMessages(doc.Payload),
 		ChannelID:     encodeChannelID(reqChannelID),
+	}
+	applyMediaProjection(&mh, doc.Payload)
+	return mh
+}
+
+// applyMediaProjection mirrors MediaHit's renderable fields onto a MessageHit
+// for image (payload.type=2) and video (payload.type=5) hits. Image surfaces
+// payload.image.url as ThumbURL (v1.8 mapping has no separate thumb URL field;
+// the original URL is always renderable and the client can apply CDN sizing
+// parameters); video surfaces payload.video.cover and the second→ms duration
+// conversion. Both use omitempty fields, so plain text / forward / file hits
+// keep their existing wire shape byte-identical.
+func applyMediaProjection(mh *MessageHit, p *Payload) {
+	switch payloadType(p) {
+	case payloadTypeImage:
+		if img := imagePayloadOf(p); img != nil {
+			mh.ThumbURL = img.URL
+			mh.Width = img.Width
+			mh.Height = img.Height
+		}
+	case payloadTypeVideo:
+		if vid := videoPayloadOf(p); vid != nil {
+			mh.ThumbURL = vid.Cover
+			mh.Width = vid.Width
+			mh.Height = vid.Height
+			mh.DurationMs = int64(vid.Second) * 1000
+		}
 	}
 }

--- a/modules/messages_search/search_messages.go
+++ b/modules/messages_search/search_messages.go
@@ -13,7 +13,7 @@ import (
 
 // MessageHit is the response shape per A doc §2.1.
 //
-// MediaKind / ThumbURL / Width / Height / DurationMs are populated only for
+// MessageKind / ThumbURL / Width / Height / DurationMs are populated only for
 // image (payload.type=2) and video (payload.type=5) hits surfaced by
 // /_search_all browse mode (or by /_search_around, which has no type
 // whitelist). They mirror MediaHit's renderable fields so the client can
@@ -278,6 +278,9 @@ func (h *Handler) singleMessageHit(doc Doc, reqChannelID string, hl map[string][
 // conversion. Both use omitempty fields, so plain text / forward / file hits
 // keep their existing wire shape byte-identical.
 func applyMediaProjection(mh *MessageHit, p *Payload) {
+	if p == nil || p.MergeForward != nil {
+		return
+	}
 	switch payloadType(p) {
 	case payloadTypeImage:
 		if img := imagePayloadOf(p); img != nil {
@@ -290,7 +293,9 @@ func applyMediaProjection(mh *MessageHit, p *Payload) {
 			mh.ThumbURL = vid.Cover
 			mh.Width = vid.Width
 			mh.Height = vid.Height
-			mh.DurationMs = int64(vid.Second) * 1000
+			if vid.Second > 0 {
+				mh.DurationMs = int64(vid.Second) * 1000
+			}
 		}
 	}
 }

--- a/modules/messages_search/source.go
+++ b/modules/messages_search/source.go
@@ -167,12 +167,27 @@ const (
 	payloadTypeSystemMax = 2000
 )
 
-// classifyKind decides the response `message_kind` for /v1/messages/_search.
-// Per A doc v4.2 we only emit "forward" or "text"; quote/reply messages get
-// folded into "text" because the outer payload.text is what matched.
+// classifyKind decides the response `message_kind` for /v1/messages/_search
+// and /v1/messages/_search_all (browse mode surfaces image/video here too).
+// Priority: mergeForward beats raw payload.type so a forward card whose
+// payload also happens to mention an image still renders as a forward.
+// Image (2) / video (5) surface as their own kinds so the client can switch
+// to the media renderer instead of trying to render an empty text snippet —
+// this also reaches /_search_around, which is the intended behaviour (the
+// around window already returns image/file docs and previously stamped them
+// as "text"). Everything else folds into "text".
 func classifyKind(p *Payload) string {
-	if p != nil && p.MergeForward != nil {
+	if p == nil {
+		return "text"
+	}
+	if p.MergeForward != nil {
 		return "forward"
+	}
+	switch payloadType(p) {
+	case payloadTypeImage:
+		return "image"
+	case payloadTypeVideo:
+		return "video"
 	}
 	return "text"
 }

--- a/modules/messages_search/source_test.go
+++ b/modules/messages_search/source_test.go
@@ -326,11 +326,42 @@ func TestClassifyKind_Text(t *testing.T) {
 	if got := classifyKind(p); got != "text" {
 		t.Fatalf("text: got %q", got)
 	}
-	// Quote / reply (any non-mergeForward case) folds into "text".
-	tp = 2
-	p = &Payload{Type: &tp, Image: &ImagePayload{}}
-	if got := classifyKind(p); got != "text" {
-		t.Fatalf("image folds to text: got %q", got)
+}
+
+// Image (payload.type=2) gets its own kind so the client can dispatch to the
+// media renderer. Reaches both /_search_all browse mode (DSL whitelists 2 when
+// keyword="") and /_search_around (no type whitelist).
+func TestClassifyKind_Image(t *testing.T) {
+	tp := payloadTypeImage
+	p := &Payload{Type: &tp, Image: &ImagePayload{URL: "http://x"}}
+	if got := classifyKind(p); got != "image" {
+		t.Fatalf("image kind: got %q", got)
+	}
+}
+
+// Video (payload.type=5) — same as image. Both reach singleMessageHit only
+// through /_search_all browse and /_search_around (the legacy /_search keeps
+// its [1,11,14] whitelist).
+func TestClassifyKind_Video(t *testing.T) {
+	tp := payloadTypeVideo
+	p := &Payload{Type: &tp, Video: &VideoPayload{Cover: "http://c"}}
+	if got := classifyKind(p); got != "video" {
+		t.Fatalf("video kind: got %q", got)
+	}
+}
+
+// Forward beats image/video: a forward card whose first child is media still
+// renders as a forward, because the outer mergeForward is what the row stands
+// for.
+func TestClassifyKind_ForwardBeatsMedia(t *testing.T) {
+	tp := payloadTypeImage
+	p := &Payload{
+		Type:         &tp,
+		Image:        &ImagePayload{URL: "http://x"},
+		MergeForward: &MergeForwardPayload{ChildCount: 1},
+	}
+	if got := classifyKind(p); got != "forward" {
+		t.Fatalf("forward must beat image: got %q", got)
 	}
 }
 

--- a/modules/messages_search/swagger/api.yaml
+++ b/modules/messages_search/swagger/api.yaml
@@ -480,7 +480,13 @@ definitions:
         format: int64
       message_kind:
         type: string
-        enum: ["text", "forward"]
+        enum: ["text", "forward", "image", "video"]
+        description: |
+          Classification of the hit's renderable kind. "image" / "video" only
+          appear on /_search_all browse mode (empty keyword) and on
+          /_search_around, where the response includes media docs alongside
+          text/forward. The keyword-bearing /_search and /_search_all paths
+          stay limited to "text" / "forward".
       snippet:
         type: string
       sender_id:
@@ -505,6 +511,36 @@ definitions:
           $ref: "#/definitions/InnerMessage"
       channel_id:
         type: string
+      thumb_url:
+        type: string
+        format: uri
+        description: |
+          Image/video thumbnail (mirrors MediaHit.thumb_url). Only present
+          when message_kind ∈ ["image", "video"] — i.e. on /_search_all
+          browse mode (no keyword) and /_search_around media hits. Omitted
+          on text / forward hits.
+      width:
+        type: integer
+        description: |
+          Image/video pixel width (mirrors MediaHit.width). Only present
+          when message_kind ∈ ["image", "video"] — i.e. on /_search_all
+          browse mode (no keyword) and /_search_around media hits. Omitted
+          on text / forward hits.
+      height:
+        type: integer
+        description: |
+          Image/video pixel height (mirrors MediaHit.height). Only present
+          when message_kind ∈ ["image", "video"] — i.e. on /_search_all
+          browse mode (no keyword) and /_search_around media hits. Omitted
+          on text / forward hits.
+      duration_ms:
+        type: integer
+        format: int64
+        description: |
+          Video duration in milliseconds (mirrors MediaHit.duration_ms).
+          Only present when message_kind="video" — i.e. on /_search_all
+          browse mode (no keyword) and /_search_around video hits. Omitted
+          on image / text / forward hits.
 
   MediaHit:
     type: object


### PR DESCRIPTION

## Summary

Branch the `payload.type` whitelist in `/_search_all` on whether the request carries a keyword. With a keyword we keep the existing text-bearing whitelist `[1, 8, 11, 14]`; with an empty keyword (browse mode) we layer in image (`2`) and video (`5`) so the unified feed surfaces recent photos/videos alongside text.

## Related Issue

<!-- TODO: link the tracking issue if one exists; otherwise leave blank. -->

## Linked Spec

<!-- TODO: link `.octospec/tasks/<slug>/brief.md` if applicable. -->

## Changes

- `modules/messages_search/search_all.go` — in `buildSearchAllDSL`, build `allowedTypes` from the text-bearing set `[Text, File, MergeForward, RichText]` and append `Image, Video` only when `req.Keyword == ""`. Added an inline comment explaining why media is gated.
- `modules/messages_search/dsl_test.go`:
  - Update `TestBuildSearchAllDSL_NoKeywordKeepsTypeFilter` to expect `[1, 8, 11, 14, 2, 5]` (browse mode now includes media).
  - Add `TestBuildSearchAllDSL_ImageVideoGatedByKeyword` with two sub-cases: keyword `"hello"` excludes `2/5`; empty keyword includes `2/5`.

## Testing

- `go build ./...` — clean
- `go test ./modules/messages_search/... -count=1` — passes (both updated and new cases)
- Full-repo `go test ./...` not run locally (requires MySQL/Redis/WuKongIM).

- [x] Unit tests added/updated
- [x] Manually verified (DSL-level assertions on built ES query)

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   `/_search_all` is the unified browse + search endpoint. The DSL builder previously always filtered `payload.type IN [1, 8, 11, 14]`, so image and video messages never appeared regardless of keyword. This PR splits that filter on `req.Keyword`: keyword-driven queries keep the text-bearing whitelist; browse mode (no keyword) widens the filter to include image (`2`) and video (`5`). All other clauses — channel scope, space scope, virtual-doc exclusion, revoked filter, `should[textClause, fileClause]` + `minimum_should_match=1` for keyword queries, common filters, sort — are untouched.

2. **What could break because of it (dependents + failure mode)?**
   - **Browse-mode result-shape change**: image/video now show up in `/_search_all` with empty keyword. They render through `singleMessageHit` → `result_type="message"`. Snippet comes from `fallbackSnippet`: image uses `payload.image.caption`, video has no text field → empty snippet. Frontends that assumed `/_search_all` browse only returns text-ish results will see new payload shapes.
   - **No effect on keyword search**: the keyword branch whitelist is unchanged; existing keyword queries continue to filter image/video out, matching prior behavior.
   - **Other endpoints**: `/_search_messages`, `/_search_around`, `/_search_media`, `/_search_files` are not touched; their filters, snippets, and result shapes are unchanged.
   - **No ES mapping or indexer change**: this is purely a query-side filter change. No reindex required, no data migration, no schema change.

3. **How do you know it works (specific test/repro/trace)?**
   - `TestBuildSearchAllDSL_NoKeywordKeepsTypeFilter` (updated): asserts the built DSL's `payload.type` terms filter equals `[1, 8, 11, 14, 2, 5]` when `keyword == ""`.
   - `TestBuildSearchAllDSL_ImageVideoGatedByKeyword` (new): two sub-cases — `keyword="hello"` asserts the terms filter contains `[1, 8, 11, 14]` and does **not** contain `2` or `5`; `keyword=""` asserts the filter contains both `2` and `5`.
   - `go test ./modules/messages_search/... -count=1` green (covers both updated and new cases plus pre-existing DSL tests for other endpoints).

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation (no public docs reference the previous filter; swagger annotations for `/_search_all` do not enumerate `payload.type` and remain accurate)
- [x] Followed commit message conventions (Conventional Commits)

---

## Diff

```diff
diff --git a/modules/messages_search/search_all.go b/modules/messages_search/search_all.go
@@ -131,12 +131,22 @@ func buildSearchAllDSL(ctx context.Context, analyzer tokenAnalyzer, stopwordStri
 	applyChannelAndRevoked(b, normChannelID)
 	applySpaceIDScope(b, req.ChannelType, spaceID)
 	applyExcludeVirtual(b)
-	b.Filter(elastic.NewTermsQuery("payload.type",
+	// Image (2) / video (5) are surfaced ONLY on the empty-keyword browse
+	// path. With a keyword, the should[textClause, fileClause] + MSM=1 has no
+	// field to hit on media payloads — they would either drop on MSM or
+	// surface as zero-relevance noise — so the keyword path keeps the
+	// text-bearing whitelist [1, 8, 11, 14]. Browse mode (keyword="") layers
+	// media in so the unified feed shows recent photos/videos alongside text.
+	allowedTypes := []any{
 		payloadTypeText,
 		payloadTypeFile,
 		payloadTypeMergeForward,
 		payloadTypeRichText,
-	))
+	}
+	if req.Keyword == "" {
+		allowedTypes = append(allowedTypes, payloadTypeImage, payloadTypeVideo)
+	}
+	b.Filter(elastic.NewTermsQuery("payload.type", allowedTypes...))
 	addCommonFilters(b, req.Filters)
 	var analyzeErr error
 	if req.Keyword != "" {
```

Closes #468 