### PR TITLE
fix(messages_search): allow p2p search for same-Space members and own…

### DIFF
--- a/modules/messages_search/authz.go
+++ b/modules/messages_search/authz.go
@@ -28,10 +28,11 @@ import (
 //     Space membership covers the enterprise contact-book deployment
 //     where the friend table is empty; friend fallback preserves the
 //     legacy non-Space deployments;
-//     Then bidirectional blacklist is consulted on the real-user path:
-//     blacklist hides past messages and a search-through-DM attack needs
-//     the same gate as a read. Own-bot path skips blacklist (a user can't
-//     blacklist their own bot meaningfully).
+//     Then bidirectional blacklist is consulted on every non-own-bot
+//     path (real-user AND other-owned-bot friend): blacklist hides past
+//     messages and a search-through-DM attack needs the same gate as a
+//     read. Own-bot path skips blacklist (a user can't blacklist their
+//     own bot meaningfully).
 //
 //   - group (2) — group must exist AND not be disbanded AND caller must be
 //     an *active* member. Disband is checked BEFORE membership because
@@ -88,8 +89,10 @@ func (h *Handler) checkChannelAccess(c *wkhttp.Context, channelType uint8, chann
 //
 // All denials render NOT_FOUND/resource=channel (anti-enumeration);
 // every DB error fail-closes with INTERNAL_ERROR. Bidirectional
-// blacklist only applies on the real-user path — own bots and other-user
-// bots reached via friend already satisfy a stronger relationship gate.
+// blacklist applies on both the real-user path AND the other-owned-bot
+// friend path — once a bot is conversational like any peer, blacklisting
+// it (or being blacklisted by its owner) must hide DM history the same
+// way as for a real user. Only the own-bot path skips blacklist.
 func (h *Handler) checkP2PAccess(c *wkhttp.Context, peerUID, loginUID string) bool {
 	if peerUID == loginUID {
 		// "Notes-to-self" channel; mirrors the read path's `if peer != self`
@@ -115,7 +118,11 @@ func (h *Handler) checkP2PAccess(c *wkhttp.Context, peerUID, loginUID string) bo
 			return true
 		}
 		// Other user's bot: must be friends, matching the robot module's
-		// "用户与Bot非好友关系，拒绝转发消息" rule.
+		// "用户与Bot非好友关系，拒绝转发消息" rule. Friend-only is not
+		// enough on its own — fall through to the bidirectional blacklist
+		// gate below so a friend bot that has since been blocked (either
+		// direction) stays hidden from search, matching the legacy
+		// pre-Space behavior.
 		isFriend, ferr := h.userService.IsFriend(loginUID, peerUID)
 		if ferr != nil {
 			h.Error("p2p access check failed: IsFriend (other-bot path)",
@@ -129,48 +136,50 @@ func (h *Handler) checkP2PAccess(c *wkhttp.Context, peerUID, loginUID string) bo
 			respondNotFound(c, "channel")
 			return false
 		}
-		return true
-	}
-
-	// Step 2: real-user path — allow if same Space OR friend. Space
-	// covers enterprise contact-book deployments where friend is empty;
-	// friend fallback preserves legacy non-Space deployments.
-	allowed := false
-	spaceID := strings.TrimSpace(spacepkg.GetSpaceID(c))
-	if spaceID != "" {
-		sameSpace, serr := h.userService.AreSpaceMembers(spaceID, loginUID, peerUID)
-		if serr != nil {
-			h.Error("p2p access check failed: AreSpaceMembers",
-				zap.Error(serr),
-				zap.String("uid", loginUID),
-				zap.String("peer", peerUID),
-				zap.String("space_id", spaceID))
-			respondInternal(c)
+		// fall through to Step 3 (blacklist); skip Step 2 since bots
+		// have no space_member row.
+	} else {
+		// Step 2: real-user path — allow if same Space OR friend. Space
+		// covers enterprise contact-book deployments where friend is empty;
+		// friend fallback preserves legacy non-Space deployments.
+		allowed := false
+		spaceID := strings.TrimSpace(spacepkg.GetSpaceID(c))
+		if spaceID != "" {
+			sameSpace, serr := h.userService.AreSpaceMembers(spaceID, loginUID, peerUID)
+			if serr != nil {
+				h.Error("p2p access check failed: AreSpaceMembers",
+					zap.Error(serr),
+					zap.String("uid", loginUID),
+					zap.String("peer", peerUID),
+					zap.String("space_id", spaceID))
+				respondInternal(c)
+				return false
+			}
+			allowed = sameSpace
+		}
+		if !allowed {
+			isFriend, ferr := h.userService.IsFriend(loginUID, peerUID)
+			if ferr != nil {
+				h.Error("p2p access check failed: IsFriend (real-user fallback)",
+					zap.Error(ferr),
+					zap.String("uid", loginUID),
+					zap.String("peer", peerUID))
+				respondInternal(c)
+				return false
+			}
+			allowed = isFriend
+		}
+		if !allowed {
+			respondNotFound(c, "channel")
 			return false
 		}
-		allowed = sameSpace
-	}
-	if !allowed {
-		isFriend, ferr := h.userService.IsFriend(loginUID, peerUID)
-		if ferr != nil {
-			h.Error("p2p access check failed: IsFriend (real-user fallback)",
-				zap.Error(ferr),
-				zap.String("uid", loginUID),
-				zap.String("peer", peerUID))
-			respondInternal(c)
-			return false
-		}
-		allowed = isFriend
-	}
-	if !allowed {
-		respondNotFound(c, "channel")
-		return false
 	}
 
-	// Step 3: bidirectional blacklist (real-user path only). Either side
-	// blocking the other hides DM history both for the blocker (their
-	// preference) and the blocked party (anti-harassment). Search must
-	// respect both, since search bypasses IM kernel's blacklist filter.
+	// Step 3: bidirectional blacklist (real-user + other-owned-bot friend
+	// paths; own-bot path returned earlier). Either side blocking the
+	// other hides DM history both for the blocker (their preference) and
+	// the blocked party (anti-harassment). Search must respect both, since
+	// search bypasses IM kernel's blacklist filter.
 	blockedByMe, err := h.userService.ExistBlacklist(loginUID, peerUID)
 	if err != nil {
 		h.Error("p2p access check failed: ExistBlacklist (me→peer)",

--- a/modules/messages_search/authz.go
+++ b/modules/messages_search/authz.go
@@ -1,9 +1,12 @@
 package messages_search
 
 import (
+	"strings"
+
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"go.uber.org/zap"
 )
 
@@ -14,10 +17,21 @@ import (
 // mirror the gates in modules/message/api_channel_files.go (group + p2p)
 // and modules/thread (thread parent + status).
 //
-//   - p2p (1)   — caller must be friends with the peer AND neither side may
-//     have blacklisted the other. The fakeChannelID alone is not enough:
-//     blacklist hides past messages and an attacker's "search through a
-//     historical DM" needs the same gate as a read.
+//   - p2p (1)   — caller may search the DM iff one of the following passes
+//     (mirrors modules/user/api_pinned.go::validateChannelAccess so the
+//     gate stays consistent with the read/pinned path):
+//     1. peer == caller   — notes-to-self;
+//     2. peer is a bot created by the caller (own bot, blacklist skipped);
+//     3. peer is a bot NOT created by the caller — must also be friends
+//     (matches modules/robot/event.go "用户与Bot非好友关系，拒绝转发消息");
+//     4. peer is a real user AND (same-Space membership OR friend) —
+//     Space membership covers the enterprise contact-book deployment
+//     where the friend table is empty; friend fallback preserves the
+//     legacy non-Space deployments;
+//     Then bidirectional blacklist is consulted on the real-user path:
+//     blacklist hides past messages and a search-through-DM attack needs
+//     the same gate as a read. Own-bot path skips blacklist (a user can't
+//     blacklist their own bot meaningfully).
 //
 //   - group (2) — group must exist AND not be disbanded AND caller must be
 //     an *active* member. Disband is checked BEFORE membership because
@@ -59,33 +73,104 @@ func (h *Handler) checkChannelAccess(c *wkhttp.Context, channelType uint8, chann
 	}
 }
 
-// checkP2PAccess gates DM search behind the friend + blacklist relationship.
-// Pattern mirrors modules/message/api_channel_files.go:195-211, with the
-// added bidirectional blacklist check (PR #361 review): the read path's
-// blacklist enforcement happens in IM kernel, but search bypasses IM and
-// must apply both directions explicitly.
+// checkP2PAccess gates DM search behind the same access semantics as
+// modules/user/api_pinned.go::validateChannelAccess: notes-to-self → own
+// bot → other-user bot (must be friends) → real-user (same-Space OR
+// friend) → bidirectional blacklist.
+//
+// Why bot judgement runs before Space judgement: bots have no
+// `space_member` row, so consulting Space first would deny a caller
+// searching their own bot's DM.
+//
+// Why Space + friend (not Space only): in Space (enterprise contact-book)
+// mode the friend table is near-empty (mostly system bots); in non-Space
+// deployments friend is authoritative. Either-or covers both.
+//
+// All denials render NOT_FOUND/resource=channel (anti-enumeration);
+// every DB error fail-closes with INTERNAL_ERROR. Bidirectional
+// blacklist only applies on the real-user path — own bots and other-user
+// bots reached via friend already satisfy a stronger relationship gate.
 func (h *Handler) checkP2PAccess(c *wkhttp.Context, peerUID, loginUID string) bool {
 	if peerUID == loginUID {
 		// "Notes-to-self" channel; mirrors the read path's `if peer != self`
-		// guard. Friend / blacklist checks are not meaningful here.
+		// guard. Friend / blacklist / bot / Space checks are not meaningful.
 		return true
 	}
-	isFriend, err := h.userService.IsFriend(loginUID, peerUID)
+
+	// Step 1: bot classification (BEFORE Space, see func doc). Own bot
+	// short-circuits past Space, friend, and blacklist.
+	isRobot, creatorUID, err := h.userService.QueryPeerRobotInfo(peerUID)
 	if err != nil {
-		h.Error("p2p access check failed: IsFriend",
+		h.Error("p2p access check failed: QueryPeerRobotInfo",
 			zap.Error(err),
 			zap.String("uid", loginUID),
 			zap.String("peer", peerUID))
 		respondInternal(c)
 		return false
 	}
-	if !isFriend {
+	if isRobot {
+		if creatorUID == loginUID {
+			// Own bot: skip blacklist (you can't blacklist your own bot
+			// meaningfully) and skip Space/friend gating.
+			return true
+		}
+		// Other user's bot: must be friends, matching the robot module's
+		// "用户与Bot非好友关系，拒绝转发消息" rule.
+		isFriend, ferr := h.userService.IsFriend(loginUID, peerUID)
+		if ferr != nil {
+			h.Error("p2p access check failed: IsFriend (other-bot path)",
+				zap.Error(ferr),
+				zap.String("uid", loginUID),
+				zap.String("peer", peerUID))
+			respondInternal(c)
+			return false
+		}
+		if !isFriend {
+			respondNotFound(c, "channel")
+			return false
+		}
+		return true
+	}
+
+	// Step 2: real-user path — allow if same Space OR friend. Space
+	// covers enterprise contact-book deployments where friend is empty;
+	// friend fallback preserves legacy non-Space deployments.
+	allowed := false
+	spaceID := strings.TrimSpace(spacepkg.GetSpaceID(c))
+	if spaceID != "" {
+		sameSpace, serr := h.userService.AreSpaceMembers(spaceID, loginUID, peerUID)
+		if serr != nil {
+			h.Error("p2p access check failed: AreSpaceMembers",
+				zap.Error(serr),
+				zap.String("uid", loginUID),
+				zap.String("peer", peerUID),
+				zap.String("space_id", spaceID))
+			respondInternal(c)
+			return false
+		}
+		allowed = sameSpace
+	}
+	if !allowed {
+		isFriend, ferr := h.userService.IsFriend(loginUID, peerUID)
+		if ferr != nil {
+			h.Error("p2p access check failed: IsFriend (real-user fallback)",
+				zap.Error(ferr),
+				zap.String("uid", loginUID),
+				zap.String("peer", peerUID))
+			respondInternal(c)
+			return false
+		}
+		allowed = isFriend
+	}
+	if !allowed {
 		respondNotFound(c, "channel")
 		return false
 	}
-	// Bidirectional blacklist: either side blocking the other hides DM
-	// history both for the blocker (their preference) and the blocked
-	// party (anti-harassment). Search must respect both.
+
+	// Step 3: bidirectional blacklist (real-user path only). Either side
+	// blocking the other hides DM history both for the blocker (their
+	// preference) and the blocked party (anti-harassment). Search must
+	// respect both, since search bypasses IM kernel's blacklist filter.
 	blockedByMe, err := h.userService.ExistBlacklist(loginUID, peerUID)
 	if err != nil {
 		h.Error("p2p access check failed: ExistBlacklist (me→peer)",

--- a/modules/messages_search/authz_test.go
+++ b/modules/messages_search/authz_test.go
@@ -387,25 +387,70 @@ func TestCheckChannelAccess_P2POtherBotNonFriendDenied(t *testing.T) {
 }
 
 // TestCheckChannelAccess_P2POtherBotFriendAllowed — other user's bot WITH a
-// friend row passes (mirrors the read path: once added, a stranger's bot
-// is conversational like any other bot).
+// friend row AND no blacklist passes (mirrors the read path: once added,
+// a stranger's bot is conversational like any other peer, so it goes
+// through the bidirectional blacklist gate the same way as a real user).
 func TestCheckChannelAccess_P2POtherBotFriendAllowed(t *testing.T) {
 	uSvc := &stubAuthzUserSvc{
-		robots:  map[string]robotStub{"botX": {isRobot: true, creator: "alice"}},
-		friends: map[string]bool{friendKey("me", "botX"): true},
+		robots:     map[string]robotStub{"botX": {isRobot: true, creator: "alice"}},
+		friends:    map[string]bool{friendKey("me", "botX"): true},
+		blacklists: map[string]bool{},
 	}
 	h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, uSvc, &stubAuthzThreadSvc{})
 	c, rec := newAuthzCtxWithSpace(t, "S1")
 
 	if !h.checkChannelAccess(c, channelTypePerson, "botX", "me") {
-		t.Fatalf("other-user bot with friend relation must pass")
+		t.Fatalf("other-user bot with friend relation and clean blacklist must pass")
 	}
-	if uSvc.blCalls != 0 {
-		t.Fatalf("other-bot/friend path must not consult blacklist, got %d", uSvc.blCalls)
+	if uSvc.blCalls != 2 {
+		t.Fatalf("other-bot/friend path must consult blacklist bidirectionally, got %d", uSvc.blCalls)
+	}
+	if uSvc.spaceCalls != 0 {
+		t.Fatalf("other-bot path must not consult AreSpaceMembers, got %d", uSvc.spaceCalls)
 	}
 	if rec.Body.Len() != 0 {
 		t.Fatalf("no response should be written on allow, got %q", rec.Body.String())
 	}
+}
+
+// TestCheckChannelAccess_P2POtherBotFriendBlacklisted — other user's bot
+// that has been blacklisted (either direction) must be hidden from
+// search, matching the legacy pre-Space behavior where a friend bot
+// flowed through bidirectional blacklist just like a real-user peer.
+// Regression guard for PR #469 review (option (a)).
+func TestCheckChannelAccess_P2POtherBotFriendBlacklisted(t *testing.T) {
+	t.Run("blocked_by_me", func(t *testing.T) {
+		uSvc := &stubAuthzUserSvc{
+			robots:     map[string]robotStub{"botX": {isRobot: true, creator: "alice"}},
+			friends:    map[string]bool{friendKey("me", "botX"): true},
+			blacklists: map[string]bool{blacklistKey("me", "botX"): true},
+		}
+		h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, uSvc, &stubAuthzThreadSvc{})
+		c, rec := newAuthzCtxWithSpace(t, "S1")
+
+		if h.checkChannelAccess(c, channelTypePerson, "botX", "me") {
+			t.Fatalf("other-user bot blocked by caller must be denied")
+		}
+		if !strings.Contains(rec.Body.String(), "not found") {
+			t.Fatalf("denial should render the not_found envelope, got %q", rec.Body.String())
+		}
+	})
+	t.Run("blocked_by_peer", func(t *testing.T) {
+		uSvc := &stubAuthzUserSvc{
+			robots:     map[string]robotStub{"botX": {isRobot: true, creator: "alice"}},
+			friends:    map[string]bool{friendKey("me", "botX"): true},
+			blacklists: map[string]bool{blacklistKey("botX", "me"): true},
+		}
+		h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, uSvc, &stubAuthzThreadSvc{})
+		c, rec := newAuthzCtxWithSpace(t, "S1")
+
+		if h.checkChannelAccess(c, channelTypePerson, "botX", "me") {
+			t.Fatalf("other-user bot that has blocked caller must be denied")
+		}
+		if !strings.Contains(rec.Body.String(), "not found") {
+			t.Fatalf("denial should render the not_found envelope, got %q", rec.Body.String())
+		}
+	})
 }
 
 // TestCheckChannelAccess_P2PRobotInfoErrorFailsClosed — DB error on the

--- a/modules/messages_search/authz_test.go
+++ b/modules/messages_search/authz_test.go
@@ -48,19 +48,38 @@ func (s *stubAuthzGroupSvc) ExistMemberActive(groupNo string, uid string) (bool,
 	return s.activeMembers[groupNo], nil
 }
 
-// stubAuthzUserSvc fakes user.IService for the p2p friend / blacklist gate.
+// stubAuthzUserSvc fakes user.IService for the p2p friend / blacklist gate,
+// plus the bot-classification (QueryPeerRobotInfo) and same-Space
+// (AreSpaceMembers) gates introduced for the Space-mode p2p access fix.
 type stubAuthzUserSvc struct {
 	user.IService
 	friends      map[string]bool // "uid|peer" → friend?
 	friendErr    error
 	blacklists   map[string]bool // "from|to" → blocked?
 	blacklistErr error
+	robots       map[string]robotStub // peerUID → bot info
+	robotErr     error
+	spaceMembers map[string]bool // "spaceID|uid1|uid2" → both members?
+	spaceErr     error
 	friendCalls  int
 	blCalls      int
+	robotCalls   int
+	spaceCalls   int
+}
+
+// robotStub mirrors the (isRobot, creatorUID) tuple returned by
+// user.IService.QueryPeerRobotInfo, so a test can fake "peer is a bot
+// created by X".
+type robotStub struct {
+	isRobot bool
+	creator string
 }
 
 func friendKey(a, b string) string    { return a + "|" + b }
 func blacklistKey(a, b string) string { return a + "|" + b }
+func spaceKey(spaceID, a, b string) string {
+	return spaceID + "|" + a + "|" + b
+}
 
 func (s *stubAuthzUserSvc) IsFriend(uid, toUID string) (bool, error) {
 	s.friendCalls++
@@ -76,6 +95,23 @@ func (s *stubAuthzUserSvc) ExistBlacklist(uid, toUID string) (bool, error) {
 		return false, s.blacklistErr
 	}
 	return s.blacklists[blacklistKey(uid, toUID)], nil
+}
+
+func (s *stubAuthzUserSvc) QueryPeerRobotInfo(peerUID string) (bool, string, error) {
+	s.robotCalls++
+	if s.robotErr != nil {
+		return false, "", s.robotErr
+	}
+	r := s.robots[peerUID]
+	return r.isRobot, r.creator, nil
+}
+
+func (s *stubAuthzUserSvc) AreSpaceMembers(spaceID, uid1, uid2 string) (bool, error) {
+	s.spaceCalls++
+	if s.spaceErr != nil {
+		return false, s.spaceErr
+	}
+	return s.spaceMembers[spaceKey(spaceID, uid1, uid2)], nil
 }
 
 // stubAuthzThreadSvc fakes thread.IService for the thread gate. Only
@@ -106,6 +142,16 @@ func newAuthzCtx(t *testing.T) (*wkhttp.Context, *httptest.ResponseRecorder) {
 	gc, _ := gin.CreateTestContext(rec)
 	gc.Request = httptest.NewRequest("POST", "/v1/messages/_search", nil)
 	return &wkhttp.Context{Context: gc}, rec
+}
+
+// newAuthzCtxWithSpace builds an auth context with space_id pre-populated,
+// matching what SpaceMiddleware would set in production. Used to exercise
+// the same-Space branch of checkP2PAccess.
+func newAuthzCtxWithSpace(t *testing.T, spaceID string) (*wkhttp.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	c, rec := newAuthzCtx(t)
+	c.Set("space_id", spaceID)
+	return c, rec
 }
 
 func newAuthzHandlerFull(gSvc group.IService, uSvc user.IService, tSvc thread.IService) *Handler {
@@ -242,6 +288,186 @@ func TestCheckChannelAccess_P2PBlacklistErrorFailsClosed(t *testing.T) {
 	}
 	if rec.Body.Len() == 0 {
 		t.Fatalf("fail-closed denial must write a response")
+	}
+}
+
+// TestCheckChannelAccess_P2PSameSpaceNonFriendAllowed — Space-mode regression:
+// in enterprise contact-book deployments the friend table is mostly empty,
+// so a caller searching a coworker's DM is denied solely by friend → 404.
+// Same-Space membership must allow the gate without requiring a friend row.
+func TestCheckChannelAccess_P2PSameSpaceNonFriendAllowed(t *testing.T) {
+	uSvc := &stubAuthzUserSvc{
+		friends:      map[string]bool{}, // explicitly NOT friends
+		spaceMembers: map[string]bool{spaceKey("S1", "me", "peer"): true},
+	}
+	h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, uSvc, &stubAuthzThreadSvc{})
+	c, rec := newAuthzCtxWithSpace(t, "S1")
+
+	if !h.checkChannelAccess(c, channelTypePerson, "peer", "me") {
+		t.Fatalf("same-Space coworkers must pass the gate even without a friend row")
+	}
+	if uSvc.spaceCalls != 1 {
+		t.Fatalf("AreSpaceMembers must be consulted exactly once on the real-user path, got %d", uSvc.spaceCalls)
+	}
+	if uSvc.friendCalls != 0 {
+		t.Fatalf("friend fallback must be skipped after Space allow, got friendCalls=%d", uSvc.friendCalls)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("no response should be written on allow, got %q", rec.Body.String())
+	}
+}
+
+// TestCheckChannelAccess_P2PNoSpaceNonFriendDenied — without a Space and
+// without a friend row, the real-user path must still 404 (legacy
+// non-Space deployments rely on friend-only gating).
+func TestCheckChannelAccess_P2PNoSpaceNonFriendDenied(t *testing.T) {
+	uSvc := &stubAuthzUserSvc{friends: map[string]bool{}}
+	h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, uSvc, &stubAuthzThreadSvc{})
+	c, rec := newAuthzCtx(t) // no space_id set
+
+	if h.checkChannelAccess(c, channelTypePerson, "peer", "me") {
+		t.Fatalf("no Space and not friends → must deny")
+	}
+	if uSvc.spaceCalls != 0 {
+		t.Fatalf("AreSpaceMembers must be skipped when space_id is empty, got %d", uSvc.spaceCalls)
+	}
+	if uSvc.friendCalls != 1 {
+		t.Fatalf("friend fallback must run exactly once, got %d", uSvc.friendCalls)
+	}
+	if !strings.Contains(rec.Body.String(), "not found") {
+		t.Fatalf("denial should render the not_found envelope, got %q", rec.Body.String())
+	}
+}
+
+// TestCheckChannelAccess_P2POwnBotAllowed — caller searching their own bot's
+// DM must short-circuit past Space, friend, and blacklist (a user can't
+// meaningfully blacklist their own bot, and bots have no space_member row).
+func TestCheckChannelAccess_P2POwnBotAllowed(t *testing.T) {
+	uSvc := &stubAuthzUserSvc{
+		robots: map[string]robotStub{"botX": {isRobot: true, creator: "me"}},
+	}
+	h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, uSvc, &stubAuthzThreadSvc{})
+	c, _ := newAuthzCtxWithSpace(t, "S1")
+
+	if !h.checkChannelAccess(c, channelTypePerson, "botX", "me") {
+		t.Fatalf("own bot must pass the gate")
+	}
+	if uSvc.robotCalls != 1 {
+		t.Fatalf("QueryPeerRobotInfo must be consulted exactly once, got %d", uSvc.robotCalls)
+	}
+	if uSvc.spaceCalls != 0 || uSvc.friendCalls != 0 || uSvc.blCalls != 0 {
+		t.Fatalf("own-bot path must skip Space/friend/blacklist; got space=%d friend=%d bl=%d",
+			uSvc.spaceCalls, uSvc.friendCalls, uSvc.blCalls)
+	}
+}
+
+// TestCheckChannelAccess_P2POtherBotNonFriendDenied — other user's bot is
+// treated like a stranger: caller must be friends to search, matching
+// robot module's "用户与Bot非好友关系，拒绝转发消息".
+func TestCheckChannelAccess_P2POtherBotNonFriendDenied(t *testing.T) {
+	uSvc := &stubAuthzUserSvc{
+		robots:  map[string]robotStub{"botX": {isRobot: true, creator: "alice"}},
+		friends: map[string]bool{}, // not friends
+	}
+	h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, uSvc, &stubAuthzThreadSvc{})
+	c, rec := newAuthzCtxWithSpace(t, "S1")
+
+	if h.checkChannelAccess(c, channelTypePerson, "botX", "me") {
+		t.Fatalf("other-user bot without friend relation must be denied")
+	}
+	if uSvc.spaceCalls != 0 {
+		t.Fatalf("other-bot path must not consult AreSpaceMembers, got %d", uSvc.spaceCalls)
+	}
+	if uSvc.blCalls != 0 {
+		t.Fatalf("denied other-bot path must not consult blacklist, got %d", uSvc.blCalls)
+	}
+	if !strings.Contains(rec.Body.String(), "not found") {
+		t.Fatalf("denial should render the not_found envelope, got %q", rec.Body.String())
+	}
+}
+
+// TestCheckChannelAccess_P2POtherBotFriendAllowed — other user's bot WITH a
+// friend row passes (mirrors the read path: once added, a stranger's bot
+// is conversational like any other bot).
+func TestCheckChannelAccess_P2POtherBotFriendAllowed(t *testing.T) {
+	uSvc := &stubAuthzUserSvc{
+		robots:  map[string]robotStub{"botX": {isRobot: true, creator: "alice"}},
+		friends: map[string]bool{friendKey("me", "botX"): true},
+	}
+	h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, uSvc, &stubAuthzThreadSvc{})
+	c, rec := newAuthzCtxWithSpace(t, "S1")
+
+	if !h.checkChannelAccess(c, channelTypePerson, "botX", "me") {
+		t.Fatalf("other-user bot with friend relation must pass")
+	}
+	if uSvc.blCalls != 0 {
+		t.Fatalf("other-bot/friend path must not consult blacklist, got %d", uSvc.blCalls)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("no response should be written on allow, got %q", rec.Body.String())
+	}
+}
+
+// TestCheckChannelAccess_P2PRobotInfoErrorFailsClosed — DB error on the
+// bot-classification query must fail closed with INTERNAL_ERROR (not
+// silently fall through to the real-user path: a bot misclassified as a
+// real user could leak Space-mate access to someone else's bot).
+func TestCheckChannelAccess_P2PRobotInfoErrorFailsClosed(t *testing.T) {
+	uSvc := &stubAuthzUserSvc{robotErr: errors.New("db down")}
+	h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, uSvc, &stubAuthzThreadSvc{})
+	c, rec := newAuthzCtxWithSpace(t, "S1")
+
+	if h.checkChannelAccess(c, channelTypePerson, "peer", "me") {
+		t.Fatalf("QueryPeerRobotInfo error must fail closed")
+	}
+	if uSvc.spaceCalls != 0 || uSvc.friendCalls != 0 {
+		t.Fatalf("fail-closed must short-circuit before Space/friend; space=%d friend=%d",
+			uSvc.spaceCalls, uSvc.friendCalls)
+	}
+	if rec.Body.Len() == 0 {
+		t.Fatalf("fail-closed denial must write a response")
+	}
+}
+
+// TestCheckChannelAccess_P2PAreSpaceMembersErrorFailsClosed — DB error on
+// the same-Space lookup must fail closed; we must not fall through to
+// friend (a transient Space-DB outage shouldn't downgrade authorization
+// to the empty friend table).
+func TestCheckChannelAccess_P2PAreSpaceMembersErrorFailsClosed(t *testing.T) {
+	uSvc := &stubAuthzUserSvc{
+		spaceErr: errors.New("db down"),
+		friends:  map[string]bool{friendKey("me", "peer"): true}, // would pass friend, but must NOT be consulted
+	}
+	h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, uSvc, &stubAuthzThreadSvc{})
+	c, rec := newAuthzCtxWithSpace(t, "S1")
+
+	if h.checkChannelAccess(c, channelTypePerson, "peer", "me") {
+		t.Fatalf("AreSpaceMembers error must fail closed")
+	}
+	if uSvc.friendCalls != 0 {
+		t.Fatalf("Space error must not fall through to friend fallback, got %d friend calls", uSvc.friendCalls)
+	}
+	if rec.Body.Len() == 0 {
+		t.Fatalf("fail-closed denial must write a response")
+	}
+}
+
+// TestCheckChannelAccess_P2PSameSpaceBlockedByMeDenied — blacklist overrides
+// Space membership on the real-user path. Same-Space coworkers who have
+// been blacklisted must still be hidden from search.
+func TestCheckChannelAccess_P2PSameSpaceBlockedByMeDenied(t *testing.T) {
+	uSvc := &stubAuthzUserSvc{
+		spaceMembers: map[string]bool{spaceKey("S1", "me", "peer"): true},
+		blacklists:   map[string]bool{blacklistKey("me", "peer"): true},
+	}
+	h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, uSvc, &stubAuthzThreadSvc{})
+	c, rec := newAuthzCtxWithSpace(t, "S1")
+
+	if h.checkChannelAccess(c, channelTypePerson, "peer", "me") {
+		t.Fatalf("blacklist must override Space membership")
+	}
+	if rec.Body.Len() == 0 {
+		t.Fatalf("denial must write a response")
 	}
 }
 

--- a/modules/user/service.go
+++ b/modules/user/service.go
@@ -8,14 +8,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Mininglamp-OSS/octo-server/modules/botfather/cmdmenu"
-	"github.com/Mininglamp-OSS/octo-server/modules/source"
-	"github.com/Mininglamp-OSS/octo-server/modules/space"
-	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-server/modules/botfather/cmdmenu"
+	"github.com/Mininglamp-OSS/octo-server/modules/source"
+	"github.com/Mininglamp-OSS/octo-server/modules/space"
+	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"go.uber.org/zap"
 )
 
@@ -81,6 +81,14 @@ type IService interface {
 	GetOnlineCount() (int64, error)
 	// 存在黑明单
 	ExistBlacklist(uid string, toUID string) (bool, error)
+	// QueryPeerRobotInfo 返回目标用户是否为 bot 及其创建者 UID。
+	// 实现委托给 PinnedDB（user/db_pinned.go），与置顶频道访问校验共用同一 SQL 真源。
+	// 用于 messages_search 等模块的 p2p 访问门禁区分本人 bot / 他人 bot / 真人。
+	QueryPeerRobotInfo(peerUID string) (isRobot bool, creatorUID string, err error)
+	// AreSpaceMembers 校验两个 uid 是否同属一个在籍 Space。
+	// 实现委托给 PinnedDB（user/db_pinned.go），底层调用 pkg/space.CheckBothMembers。
+	// 用于 Space 模式下放行同 Space 成员间的 p2p 交互（无需互加好友）。
+	AreSpaceMembers(spaceID, uid1, uid2 string) (bool, error)
 	// 更新用户消息过期时长
 	UpdateUserMsgExpireSecond(uid string, msgExpireSecond int64) error
 	// 搜索好友
@@ -219,6 +227,7 @@ type Service struct {
 	extLogin         externalLoginHandler
 	bindHandler      oidcBindHandler
 	verificationDB   *verificationDB
+	pinnedDB         *PinnedDB
 }
 
 // SetExternalLoginHandler 注入外部 IdP 登录 handler（在 user.New 内部调用,生产路径下保证非空）
@@ -376,6 +385,7 @@ func NewService(ctx *config.Context) IService {
 		Log:              log.NewTLog("userService"),
 		onlineService:    NewOnlineService(ctx),
 		verificationDB:   newVerificationDB(ctx),
+		pinnedDB:         NewPinnedDB(ctx),
 	}
 }
 
@@ -1240,6 +1250,16 @@ func (s *Service) ExistBlacklist(uid string, toUID string) (bool, error) {
 	return s.friendDB.existBlacklist(uid, toUID)
 }
 
+// QueryPeerRobotInfo 委托 PinnedDB，详见 IService 注释。
+func (s *Service) QueryPeerRobotInfo(peerUID string) (bool, string, error) {
+	return s.pinnedDB.QueryPeerRobotInfo(peerUID)
+}
+
+// AreSpaceMembers 委托 PinnedDB，详见 IService 注释。
+func (s *Service) AreSpaceMembers(spaceID, uid1, uid2 string) (bool, error) {
+	return s.pinnedDB.AreSpaceMembers(spaceID, uid1, uid2)
+}
+
 func (s *Service) UpdateUserMsgExpireSecond(uid string, msgExpireSecond int64) error {
 	return s.db.updateUserMsgExpireSecond(uid, msgExpireSecond)
 }
@@ -1271,8 +1291,8 @@ type Resp struct {
 	Zone            string
 	Phone           string
 	Email           string
-	Status         int // 用户状态 1 正常 2:黑名单 0 禁用
-	IsUploadAvatar int
+	Status          int // 用户状态 1 正常 2:黑名单 0 禁用
+	IsUploadAvatar  int
 	NewMsgNotice    int
 	MsgShowDetail   int //显示消息通知详情0.否1.是
 	MsgExpireSecond int64
@@ -1288,8 +1308,8 @@ func newResp(m *Model) *Resp {
 		Zone:            m.Zone,
 		Phone:           m.Phone,
 		Email:           m.Email,
-		Status:         m.Status,
-		IsUploadAvatar: m.IsUploadAvatar,
+		Status:          m.Status,
+		IsUploadAvatar:  m.IsUploadAvatar,
 		NewMsgNotice:    m.NewMsgNotice,
 		MsgShowDetail:   m.MsgShowDetail,
 		MsgExpireSecond: m.MsgExpireSecond,
@@ -1325,7 +1345,7 @@ type AddUserReq struct {
 	Phone    string
 	Email    string
 	Password string
-	Robot    int    // 机器人 0.否 1.是
+	Robot    int // 机器人 0.否 1.是
 }
 
 type UserUpdateReq struct {
@@ -1379,46 +1399,46 @@ type UserDetailResp struct {
 	UID                 string            `json:"uid"`
 	Name                string            `json:"name"`
 	Username            string            `json:"username"`
-	Email               string            `json:"email,omitempty"`        // email（仅自己能看）
-	Zone                string            `json:"zone,omitempty"`         // 手机区号（仅自己能看）
-	Phone               string            `json:"phone,omitempty"`        // 手机号（仅自己能看）
-	Mute                int               `json:"mute"`                   // 免打扰
-	Top                 int               `json:"top"`                    // 置顶
-	Sex                 int               `json:"sex"`                    //性别1:男
-	Category            string            `json:"category"`               //用户分类 '客服'
-	ShortNo             string            `json:"short_no"`               // 用户唯一短编号
-	ChatPwdOn           int               `json:"chat_pwd_on"`            //是否开启聊天密码
-	Screenshot          int               `json:"screenshot"`             //截屏通知
-	RevokeRemind        int               `json:"revoke_remind"`          //撤回提醒
-	Receipt             int               `json:"receipt"`                //消息是否回执
-	Online              int               `json:"online"`                 //是否在线
-	LastOffline         int               `json:"last_offline"`           //最后一次离线时间
-	DeviceFlag          config.DeviceFlag `json:"device_flag"`            // 在线设备标记
-	Follow              int               `json:"follow"`                 //是否是好友
-	BeDeleted           int               `json:"be_deleted"`             // 被删除
-	BeBlacklist         int               `json:"be_blacklist"`           // 被拉黑
-	Code                string            `json:"code"`                   //加好友所需vercode TODO: code不再使用 请使用Vercode
-	Vercode             string            `json:"vercode"`                //
-	SourceDesc          string            `json:"source_desc"`            // 好友来源
-	Remark              string            `json:"remark"`                 //好友备注
-	IsUploadAvatar      int               `json:"is_upload_avatar"`       // 是否上传头像
-	Status              int               `json:"status"`                 //用户状态 1 正常 2:黑名单
-	Robot               int               `json:"robot"`                  // 机器人0.否1.是
-	BotCommands         string            `json:"bot_commands,omitempty"`    // 机器人命令列表JSON
-	BotDescription      string            `json:"bot_description,omitempty"` // Bot 简介
-	BotCreatorUID       string            `json:"bot_creator_uid,omitempty"` // Bot 创建者 UID
-	BotCreatorName      string            `json:"bot_creator_name,omitempty"` // Bot 创建者昵称
-	BotAutoApprove      int               `json:"bot_auto_approve,omitempty"` // 是否自动通过好友 0:否 1:是
+	Email               string            `json:"email,omitempty"`              // email（仅自己能看）
+	Zone                string            `json:"zone,omitempty"`               // 手机区号（仅自己能看）
+	Phone               string            `json:"phone,omitempty"`              // 手机号（仅自己能看）
+	Mute                int               `json:"mute"`                         // 免打扰
+	Top                 int               `json:"top"`                          // 置顶
+	Sex                 int               `json:"sex"`                          //性别1:男
+	Category            string            `json:"category"`                     //用户分类 '客服'
+	ShortNo             string            `json:"short_no"`                     // 用户唯一短编号
+	ChatPwdOn           int               `json:"chat_pwd_on"`                  //是否开启聊天密码
+	Screenshot          int               `json:"screenshot"`                   //截屏通知
+	RevokeRemind        int               `json:"revoke_remind"`                //撤回提醒
+	Receipt             int               `json:"receipt"`                      //消息是否回执
+	Online              int               `json:"online"`                       //是否在线
+	LastOffline         int               `json:"last_offline"`                 //最后一次离线时间
+	DeviceFlag          config.DeviceFlag `json:"device_flag"`                  // 在线设备标记
+	Follow              int               `json:"follow"`                       //是否是好友
+	BeDeleted           int               `json:"be_deleted"`                   // 被删除
+	BeBlacklist         int               `json:"be_blacklist"`                 // 被拉黑
+	Code                string            `json:"code"`                         //加好友所需vercode TODO: code不再使用 请使用Vercode
+	Vercode             string            `json:"vercode"`                      //
+	SourceDesc          string            `json:"source_desc"`                  // 好友来源
+	Remark              string            `json:"remark"`                       //好友备注
+	IsUploadAvatar      int               `json:"is_upload_avatar"`             // 是否上传头像
+	Status              int               `json:"status"`                       //用户状态 1 正常 2:黑名单
+	Robot               int               `json:"robot"`                        // 机器人0.否1.是
+	BotCommands         string            `json:"bot_commands,omitempty"`       // 机器人命令列表JSON
+	BotDescription      string            `json:"bot_description,omitempty"`    // Bot 简介
+	BotCreatorUID       string            `json:"bot_creator_uid,omitempty"`    // Bot 创建者 UID
+	BotCreatorName      string            `json:"bot_creator_name,omitempty"`   // Bot 创建者昵称
+	BotAutoApprove      int               `json:"bot_auto_approve,omitempty"`   // 是否自动通过好友 0:否 1:是
 	BotAgentPlatform    string            `json:"bot_agent_platform,omitempty"` // Agent 平台名称
 	BotAgentVersion     string            `json:"bot_agent_version,omitempty"`  // Agent 平台版本号
 	BotPluginVersion    string            `json:"bot_plugin_version,omitempty"` // DMWork 插件版本号
-	IsDestroy           int               `json:"is_destroy"`             // 注销状态 0.正常 1.注销申请中（冷静期，仍可正常通信） 2.已注销
-	Flame               int               `json:"flame"`                  // 是否开启阅后即焚
-	FlameSecond         int               `json:"flame_second"`           // 阅后即焚秒数
-	JoinGroupInviteUID  string            `json:"join_group_invite_uid"`  // 加入群聊邀请人UID
-	JoinGroupInviteName string            `json:"join_group_invite_name"` // 加入群聊邀请人名称
-	JoinGroupTime       string            `json:"join_group_time"`        // 加入群聊时间
-	GroupMember         *GroupMemberResp  `json:"group_member,omitempty"` // 群成员信息
+	IsDestroy           int               `json:"is_destroy"`                   // 注销状态 0.正常 1.注销申请中（冷静期，仍可正常通信） 2.已注销
+	Flame               int               `json:"flame"`                        // 是否开启阅后即焚
+	FlameSecond         int               `json:"flame_second"`                 // 阅后即焚秒数
+	JoinGroupInviteUID  string            `json:"join_group_invite_uid"`        // 加入群聊邀请人UID
+	JoinGroupInviteName string            `json:"join_group_invite_name"`       // 加入群聊邀请人名称
+	JoinGroupTime       string            `json:"join_group_time"`              // 加入群聊时间
+	GroupMember         *GroupMemberResp  `json:"group_member,omitempty"`       // 群成员信息
 	// OCTO 实名认证（YUJ-354 / GH#1300）
 	// RealnameVerified：该用户是否已完成 OCTO 实名认证（user_verification 有记录）。
 	// RealName：已认证时返回实名姓名；未认证留空。


### PR DESCRIPTION
## Summary

In **Space (enterprise contact-book) deployments**, the `friend` table is
near-empty — real coworker relationships live in `space_member`, while `friend`
mostly holds system bots. The p2p search access gate
(`messages_search/authz.go::checkP2PAccess`) gated solely on
`userService.IsFriend`, so searching a DM with any coworker returned
`err.server.messages_search.not_found` (HTTP 404) **even though the DM is
readable**.

This change makes the p2p search gate mirror the existing read/pinned-path
semantics in `modules/user/api_pinned.go::validateChannelAccess`, so search no
longer hides DMs the user can otherwise open.

## Root cause

```
POST /v1/messages/_search_all {"channel_type":1,"channel_id":"<peerUID>"}
  → checkChannelAccess → checkP2PAccess
  → IsFriend(login, peer)  // friend table empty in Space mode
  → false → respondNotFound("channel") → 404
```

The display/contact layer resolves peers via Space membership, but the search
authz layer resolved them via the `friend` table — a mismatch that only
surfaces in Space-mode deployments.

## Change

`checkP2PAccess` now allows the DM search if **any** of the following holds
(checked in order):

1. `peer == caller` — notes-to-self.
2. peer is a **bot created by the caller** — own bot, short-circuits past
   Space/friend/blacklist.
3. peer is a **bot created by someone else** — must also be friends (matches
   `modules/robot/event.go`: "用户与Bot非好友关系，拒绝转发消息").
4. peer is a **real user** who is a **same-Space member OR a friend** — Space
   membership covers the contact-book deployment; the friend fallback keeps
   legacy non-Space deployments working.

The **bidirectional blacklist** check is retained on the real-user path. Bot
judgement runs **before** Space judgement because bots have no `space_member`
row (checking Space first would deny a caller searching their own bot).

Security invariants preserved:
- Every denial renders `NOT_FOUND` / `resource=channel` (anti-enumeration).
- Every DB error fails **closed** with `INTERNAL_ERROR`. A Space-lookup error
  does **not** silently downgrade to the friend table.

## Files

| File | Change |
|------|--------|
| `modules/messages_search/authz.go` | Rewrite `checkP2PAccess` (self → own-bot → other-bot/friend → real-user same-Space-or-friend → bidirectional blacklist). |
| `modules/user/service.go` | Add `QueryPeerRobotInfo` and `AreSpaceMembers` to `IService`, delegating to the existing `PinnedDB` SQL (single source of truth); inject `pinnedDB` into `Service`. |
| `modules/messages_search/authz_test.go` | Extend the `user.IService` stub; add 8 cases for the Space / bot / fail-closed branches. |

> `user/service.go` also carries `gofmt -w` import-ordering and struct-field
> realignment noise unrelated to the logic change (~15 lines are the actual
> change).

## Scope

- Covers all five search endpoints — `_search`, `_search_all`, `_search_files`,
  `_search_around`, `_search_media` — via the shared `checkChannelAccess`.
- `space_id` is injected by `SpaceMiddleware` already mounted on the
  `/v1/messages` route group, so the Space branch is live in production.
- **Group search is unaffected**: it gates only on the caller's group
  membership, not on per-sender relationship, so other people's bot messages
  in a group remain searchable as before.

## Out of scope (follow-up)

The same friend-only p2p gate still exists on other read paths
(`modules/message/api_channel_files.go:197`, reaction/extra sync in
`modules/message/api.go`, `api_pinned.go`). In Space mode these will still 404
for same-Space coworkers, producing a "can search messages but the DM file list
404s" inconsistency. Unifying them (e.g. extracting a shared gate helper in the
`user` package) is left to a follow-up task.

## Testing

```
gofmt -l modules/messages_search/authz.go modules/messages_search/authz_test.go modules/user/service.go   # clean
go vet ./modules/messages_search/... ./modules/user/...                                                    # ok
go test ./modules/messages_search/ -run TestCheckChannelAccess -count=1                                    # ok
go build ./...                                                                                             # ok
```

p2p access tests: **15/15 pass** (7 existing regressions + 8 new):
SameSpaceNonFriendAllowed / NoSpaceNonFriendDenied / OwnBotAllowed /
OtherBotNonFriendDenied / OtherBotFriendAllowed / RobotInfoErrorFailsClosed /
AreSpaceMembersErrorFailsClosed / SameSpaceBlockedByMeDenied.

Closes #470 
