### PR TITLE
feat(group): per-hop latency observability for the invite-member flow

### DIFF
--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -136,6 +136,21 @@ type Service struct {
 	userDB    *user.DB
 }
 
+// inviteSlowLogThresholdMS 是「邀请成员入群链路耗时」慢日志的阈值（毫秒）：
+// 只有 total_ms ≥ 该值时才打一条 Warn 分段耗时，正常流量不打日志，避免噪音。
+// 这是长期保留的观测，不是一次性探针；阈值可用环境变量
+// DM_GROUP_INVITE_SLOW_LOG_MS 覆盖（缺省 1000ms，<=0 表示每次都打，便于临时排查）。
+var inviteSlowLogThresholdMS = parseInviteSlowLogThresholdMS()
+
+func parseInviteSlowLogThresholdMS() int64 {
+	if v := os.Getenv("DM_GROUP_INVITE_SLOW_LOG_MS"); v != "" {
+		if ms, err := strconv.ParseInt(v, 10, 64); err == nil {
+			return ms
+		}
+	}
+	return 1000
+}
+
 // NewService NewService
 func NewService(ctx *config.Context) IService {
 	return &Service{
@@ -1556,23 +1571,27 @@ func (s *Service) AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMemb
 		go s.notifyBotJoinedGroup(memberUsers, addedUIDSet, req.GroupNo, req.OperatorUID, req.OperatorName)
 	}
 
-	// 邀请成员入群链路分段耗时。字段单位均为毫秒，便于在日志系统里按 total_ms
-	// 排序定位慢请求，再看具体是 im_add_subscriber_ms / send_member_add_ms /
-	// send_cmd_ms 哪一跳吃掉了时间（DB 阶段见 db_ms）。
+	// 邀请成员入群链路分段耗时（仅慢请求落日志）。字段单位均为毫秒，便于在日志
+	// 系统里按 total_ms 排序定位慢请求，再看具体是 im_add_subscriber_ms /
+	// send_member_add_ms / send_cmd_ms 哪一跳吃掉了时间（DB 阶段见 db_ms）。
+	// 正常（<阈值）请求不打日志，长期保留也不会产生噪音。
 	total := time.Since(startedAt)
-	s.Info("邀请成员入群链路耗时",
-		zap.String("group_no", req.GroupNo),
-		zap.String("operator", req.OperatorUID),
-		zap.Int("requested", len(req.Members)),
-		zap.Int("added", len(addedUIDs)),
-		zap.Int64("db_ms", dbDur.Milliseconds()),
-		zap.Int64("channel_update_ms", channelUpdateDur.Milliseconds()),
-		zap.Int64("im_add_subscriber_ms", imSubscriberDur.Milliseconds()),
-		zap.Int64("send_member_add_ms", sendMemberAddDur.Milliseconds()),
-		zap.Int64("send_cmd_ms", sendCMDDur.Milliseconds()),
-		zap.Int64("add_to_threads_ms", addToThreadsDur.Milliseconds()),
-		zap.Int64("total_ms", total.Milliseconds()),
-	)
+	if total.Milliseconds() >= inviteSlowLogThresholdMS {
+		s.Warn("邀请成员入群链路耗时偏高",
+			zap.String("group_no", req.GroupNo),
+			zap.String("operator", req.OperatorUID),
+			zap.Int("requested", len(req.Members)),
+			zap.Int("added", len(addedUIDs)),
+			zap.Int64("db_ms", dbDur.Milliseconds()),
+			zap.Int64("channel_update_ms", channelUpdateDur.Milliseconds()),
+			zap.Int64("im_add_subscriber_ms", imSubscriberDur.Milliseconds()),
+			zap.Int64("send_member_add_ms", sendMemberAddDur.Milliseconds()),
+			zap.Int64("send_cmd_ms", sendCMDDur.Milliseconds()),
+			zap.Int64("add_to_threads_ms", addToThreadsDur.Milliseconds()),
+			zap.Int64("total_ms", total.Milliseconds()),
+			zap.Int64("threshold_ms", inviteSlowLogThresholdMS),
+		)
+	}
 
 	return &AddGroupMembersServiceResp{
 		Added: len(addedUIDs),

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -1319,6 +1319,10 @@ func (s *Service) AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMemb
 		return nil, errors.New("members is required")
 	}
 
+	// 链路耗时定位（邀请成员入群慢排查）：startedAt 覆盖整条 AddGroupMembers，
+	// 配合事务提交点与各 WuKongIM 调用的分段计时，区分 DB 阶段 vs IM 阶段。
+	startedAt := time.Now()
+
 	// 群存在性 + 状态检查
 	groupModel, err := s.db.QueryWithGroupNo(req.GroupNo)
 	if err != nil {
@@ -1486,14 +1490,28 @@ func (s *Service) AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMemb
 		s.Error("commit transaction failed", zap.Error(err))
 		return nil, errors.New("failed to commit transaction")
 	}
+	// DB 阶段（查询 + 校验 + 事务）耗时——与下面的 IM 阶段分段对比。
+	dbDur := time.Since(startedAt)
+
+	var (
+		channelUpdateDur time.Duration
+		imSubscriberDur  time.Duration
+		sendMemberAddDur time.Duration
+		sendCMDDur       time.Duration
+		addToThreadsDur  time.Duration
+	)
 
 	if markedExternal {
+		t0 := time.Now()
 		s.ctx.SendChannelUpdateToGroup(req.GroupNo)
+		channelUpdateDur = time.Since(t0)
 	}
 
-	// IM 操作（事务提交之后）
+	// IM 操作（事务提交之后）。这一段是同步、串行、对 WuKongIM 的阻塞 HTTP 调用，
+	// 也是「邀请成员慢」的主要嫌疑段；逐跳计时以便从日志定位是哪一跳慢。
 	if len(addedUIDs) > 0 {
 		// 添加 IM 订阅
+		t0 := time.Now()
 		if err := s.ctx.IMAddSubscriber(&config.SubscriberAddReq{
 			ChannelID:   req.GroupNo,
 			ChannelType: common.ChannelTypeGroup.Uint8(),
@@ -1501,16 +1519,20 @@ func (s *Service) AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMemb
 		}); err != nil {
 			s.Error("add IM subscriber failed", zap.Error(err))
 		}
+		imSubscriberDur = time.Since(t0)
 
 		// 发布成员添加事件
+		t0 = time.Now()
 		s.ctx.SendGroupMemberAdd(&config.MsgGroupMemberAddReq{
 			Operator:     req.OperatorUID,
 			OperatorName: req.OperatorName,
 			GroupNo:      req.GroupNo,
 			Members:      addedVos,
 		})
+		sendMemberAddDur = time.Since(t0)
 
 		// 发送群成员更新 CMD
+		t0 = time.Now()
 		s.ctx.SendCMD(config.MsgCMDReq{
 			ChannelID:   req.GroupNo,
 			ChannelType: common.ChannelTypeGroup.Uint8(),
@@ -1519,9 +1541,12 @@ func (s *Service) AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMemb
 				"group_no": req.GroupNo,
 			},
 		})
+		sendCMDDur = time.Since(t0)
 
 		// 同步新成员到群内所有子区的 IM 订阅（直接 SQL 查 thread 表）
+		t0 = time.Now()
 		s.addUsersToGroupThreads(req.GroupNo, addedUIDs)
+		addToThreadsDur = time.Since(t0)
 
 		// 检查新增成员中是否有 Bot，推送 bot_joined_group 事件
 		addedUIDSet := make(map[string]bool, len(addedUIDs))
@@ -1530,6 +1555,24 @@ func (s *Service) AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMemb
 		}
 		go s.notifyBotJoinedGroup(memberUsers, addedUIDSet, req.GroupNo, req.OperatorUID, req.OperatorName)
 	}
+
+	// 邀请成员入群链路分段耗时。字段单位均为毫秒，便于在日志系统里按 total_ms
+	// 排序定位慢请求，再看具体是 im_add_subscriber_ms / send_member_add_ms /
+	// send_cmd_ms 哪一跳吃掉了时间（DB 阶段见 db_ms）。
+	total := time.Since(startedAt)
+	s.Info("邀请成员入群链路耗时",
+		zap.String("group_no", req.GroupNo),
+		zap.String("operator", req.OperatorUID),
+		zap.Int("requested", len(req.Members)),
+		zap.Int("added", len(addedUIDs)),
+		zap.Int64("db_ms", dbDur.Milliseconds()),
+		zap.Int64("channel_update_ms", channelUpdateDur.Milliseconds()),
+		zap.Int64("im_add_subscriber_ms", imSubscriberDur.Milliseconds()),
+		zap.Int64("send_member_add_ms", sendMemberAddDur.Milliseconds()),
+		zap.Int64("send_cmd_ms", sendCMDDur.Milliseconds()),
+		zap.Int64("add_to_threads_ms", addToThreadsDur.Milliseconds()),
+		zap.Int64("total_ms", total.Milliseconds()),
+	)
 
 	return &AddGroupMembersServiceResp{
 		Added: len(addedUIDs),


### PR DESCRIPTION
## 背景

排查「邀请成员入群很慢」（测试环境 ~6s、线上 ~3s，群里只有 4 个成员）。

**定位结论**：慢的不是业务代码，也不是 MySQL。`POST /v1/groups/:group_no/members` → `AddGroupMembers` 在事务提交后，于请求热路径上**串行**发起 3 个**同步、无客户端超时**的 WuKongIM HTTP 调用：

| 调用 | 动作 |
|---|---|
| `IMAddSubscriber` | `POST /channel/subscriber_add` |
| `SendGroupMemberAdd` → `SendMessage` | `POST /message/send`（持久化系统提示，全群扇出） |
| `SendCMD(member_update)` → `SendMessage` | `POST /message/send` |

证据：
- 本地健康 WuKongIM 下，同样的 4 人群整条邀请请求 ≈ **15–28ms**；
- DB 连接池监控显示 `in_use≈0`、无连接被占住 → MySQL 全程空闲；
- 耗时按环境（测试 6s > 线上 3s）而非成员数缩放 → 典型「等下游 IM 响应」。

调用数固定为 3，**与成员数无关**；octo-lib 的 `rest` client 是 `&http.Client{}`（**无 Timeout**），IM 一慢就无界阻塞。

## 这个 PR 做了什么

只加**观测**，不改任何控制流 / 返回值 / 对外行为：在 `AddGroupMembers` 末尾按分段记录耗时，便于在生产直接定位是哪一跳吃掉了秒级时间。

- 分段字段（毫秒）：`db_ms`（查询+校验+事务）/ `channel_update_ms` / `im_add_subscriber_ms` / `send_member_add_ms` / `send_cmd_ms` / `add_to_threads_ms` / `total_ms`。
- **慢阈值才落日志**：仅当 `total_ms >= 阈值` 时打一条 `Warn`，正常流量零噪音——长期保留，无需日后删除。
- 阈值默认 **1000ms**，可用环境变量 `DM_GROUP_INVITE_SLOW_LOG_MS` 覆盖（`<=0` 表示每次都打，便于临时排查）。

慢请求日志样例：
```json
{"level":"warn","msg":"【groupService】邀请成员入群链路耗时偏高",
 "group_no":"...","operator":"...","requested":1,"added":1,
 "db_ms":7,"channel_update_ms":0,"im_add_subscriber_ms":2980,
 "send_member_add_ms":2100,"send_cmd_ms":900,"add_to_threads_ms":0,
 "total_ms":5987,"threshold_ms":1000}
```

## 使用方式

线上出现慢邀请时，按 `total_ms` 排序捞慢请求，看 `db_ms` 是否仍是个位数（确认不是 MySQL），再看 `im_add_subscriber_ms` / `send_member_add_ms` / `send_cmd_ms` 哪个是秒级，直接锁定是 WuKongIM 的哪一跳。

## 测试

- `go build` / `go vet` 通过；
- 默认阈值（1000ms）：正常快请求**不打**日志（已验证）；
- `DM_GROUP_INVITE_SLOW_LOG_MS=0`：每次邀请**打 Warn** 且字段完整（已验证）；
- `modules/group` 全包测试绿（19s），无回归。

## 后续（不在本 PR）

真正能把 6s 降下来的根因修复，待确认哪一跳慢后再做：
1. 给 octo-lib `network` IM HTTP client 加客户端超时（当前无超时，一个慢 IM 能拖垮所有写接口）；
2. 把 `SendGroupMemberAdd` / `SendCMD` 这类通知移到事件池异步（`notifyBotJoinedGroup` 已是 `go`），从响应里摘掉 2 个串行 IM 往返；
3. 或把 3 个独立 IM 调用并发化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTmwnF18wfFgTAjufuMrXn)_