### PR TITLE
test(group): widen invite-latency tracing to the whole POST handler

### DIFF
--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -961,6 +961,20 @@ func (g *Group) groupUpdate(c *wkhttp.Context) {
 
 // 添加成员
 func (g *Group) memberAdd(c *wkhttp.Context) {
+	// 链路耗时定位（邀请成员 POST 慢排查）：handlerStart 覆盖整个 handler。
+	// service 内 AddGroupMembers 的分段日志只量到 service 那一段，handler 在
+	// 调 service 之前的写前校验（getGroupInfo / ExistMember / checkBotOwnership
+	// / GetAppConfig / Bot Space 隔离循环）此前没人测——这里把那段补齐，
+	// 复用 inviteSlowLogThresholdMS 同一慢阈值，仅慢请求落日志。
+	handlerStart := time.Now()
+	var (
+		getGroupMs    int64
+		existMemberMs int64
+		botOwnerMs    int64
+		appConfigMs   int64
+		botSpaceMs    int64
+		preChecksMs   int64
+	)
 	operator := c.MustGet("uid").(string)
 	operatorName := c.MustGet("name").(string)
 	var req memberAddReq
@@ -977,13 +991,17 @@ func (g *Group) memberAdd(c *wkhttp.Context) {
 	/**
 	判断群是否存在
 	**/
+	tStep := time.Now()
 	group, err := g.getGroupInfo(groupNo)
+	getGroupMs = time.Since(tStep).Milliseconds()
 	if err != nil {
 		respondGroupInfoError(c, err)
 		return
 	}
 	// 校验操作者是群成员,防止任意用户向任意群添加成员(issue#1018)
+	tStep = time.Now()
 	isMember, err := g.db.ExistMember(operator, groupNo)
+	existMemberMs = time.Since(tStep).Milliseconds()
 	if err != nil {
 		g.Error("查询群成员关系失败", zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
@@ -1001,7 +1019,10 @@ func (g *Group) memberAdd(c *wkhttp.Context) {
 	// 白名单，一律走 creator 路径。参见 checkBotOwnership 函数注释。
 	// 注意：该检查故意放在系统账号 / Invite 模式等策略检查之前，以最小化
 	// 攻击面——非授权方对 bot 的探测请求应尽早被拒绝。
-	if botErr := checkBotOwnership(g.ctx.DB(), operator, req.Members); botErr != nil {
+	tStep = time.Now()
+	botErr := checkBotOwnership(g.ctx.DB(), operator, req.Members)
+	botOwnerMs = time.Since(tStep).Milliseconds()
+	if botErr != nil {
 		if errors.Is(botErr, ErrBotOwnershipDenied) {
 			httperr.ResponseErrorL(c, errcode.ErrGroupBotOwnershipDenied, nil, nil)
 			return
@@ -1012,7 +1033,9 @@ func (g *Group) memberAdd(c *wkhttp.Context) {
 	}
 
 	// 判断是否允许系统账号进入群聊
+	tStep = time.Now()
 	appConfig, err := g.commonService.GetAppConfig()
+	appConfigMs = time.Since(tStep).Milliseconds()
 	if err != nil {
 		g.Error("查询应用设置错误", zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
@@ -1049,6 +1072,7 @@ func (g *Group) memberAdd(c *wkhttp.Context) {
 
 	// Bot Space 隔离检查：如果群属于某个 Space，Bot 必须在邀请人的有效 Space 中
 	// （内部成员：群的 Space；外部成员：来源 Space）
+	tStep = time.Now()
 	if group.SpaceID != "" {
 		inviterSpaceID := group.SpaceID
 		operatorMember, opErr := g.db.QueryMemberWithUID(operator, groupNo)
@@ -1083,6 +1107,11 @@ func (g *Group) memberAdd(c *wkhttp.Context) {
 		}
 	}
 
+	botSpaceMs = time.Since(tStep).Milliseconds()
+
+	// 至此为 handler 在调 service 之前的全部写前校验耗时。
+	preChecksMs = time.Since(handlerStart).Milliseconds()
+
 	// 调用 Service 添加群成员
 	_, err = g.groupService.AddGroupMembers(&AddGroupMembersServiceReq{
 		GroupNo:      groupNo,
@@ -1112,6 +1141,27 @@ func (g *Group) memberAdd(c *wkhttp.Context) {
 		g.Error("添加群成员失败", zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrGroupStoreFailed, nil, nil)
 		return
+	}
+
+	// handler 级链路耗时（仅慢请求落日志）。与 GIN 访问日志的总耗时对照：
+	//   GIN_total - handler_total ≈ 中间件耗时；
+	//   handler_total - service total_ms ≈ handler 写前校验耗时（= pre_checks_ms）。
+	// pre_checks_ms 再按 get_group / exist_member / bot_ownership / app_config /
+	// bot_space 分摊，定位「埋点之外那 ~4.5s」到底卡在哪一步。
+	if handlerTotalMs := time.Since(handlerStart).Milliseconds(); handlerTotalMs >= inviteSlowLogThresholdMS {
+		g.Warn("邀请成员 handler 链路耗时偏高",
+			zap.String("group_no", groupNo),
+			zap.String("operator", operator),
+			zap.Int("requested", len(req.Members)),
+			zap.Int64("pre_checks_ms", preChecksMs),
+			zap.Int64("get_group_ms", getGroupMs),
+			zap.Int64("exist_member_ms", existMemberMs),
+			zap.Int64("bot_ownership_ms", botOwnerMs),
+			zap.Int64("app_config_ms", appConfigMs),
+			zap.Int64("bot_space_ms", botSpaceMs),
+			zap.Int64("handler_total_ms", handlerTotalMs),
+			zap.Int64("threshold_ms", inviteSlowLogThresholdMS),
+		)
 	}
 
 	c.ResponseOK()

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -1369,6 +1369,7 @@ func (s *Service) AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMemb
 	// 同时当群的 AllowExternal==0 时，非 admin/creator 不能邀请外部成员。
 	externalMap := make(map[string]bool)
 	sourceSpaceMap := make(map[string]string)
+	spaceCheckStart := time.Now()
 	if groupModel.SpaceID != "" {
 		var operatorMember *MemberModel
 		if req.OperatorUID != "" {
@@ -1397,6 +1398,7 @@ func (s *Service) AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMemb
 			}
 		}
 	}
+	spaceCheckMs := time.Since(spaceCheckStart).Milliseconds()
 
 	// 查询用户信息
 	memberUsers, err := s.userDB.QueryByUIDs(uniqueUIDs)
@@ -1426,6 +1428,7 @@ func (s *Service) AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMemb
 	}
 
 	// 开启事务
+	txStart := time.Now()
 	tx, err := s.ctx.DB().Begin()
 	if err != nil {
 		s.Error("begin transaction failed", zap.Error(err))
@@ -1505,7 +1508,10 @@ func (s *Service) AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMemb
 		s.Error("commit transaction failed", zap.Error(err))
 		return nil, errors.New("failed to commit transaction")
 	}
-	// DB 阶段（查询 + 校验 + 事务）耗时——与下面的 IM 阶段分段对比。
+	// 事务（GenSeq + insert/recover + commit）耗时。
+	txMs := time.Since(txStart).Milliseconds()
+	// DB 阶段（查询 + 校验 + 事务）总耗时——与下面的 IM 阶段分段对比。
+	// db_ms 进一步拆成 space_check_ms（每成员 CheckMembership 循环）与 tx_ms。
 	dbDur := time.Since(startedAt)
 
 	var (
@@ -1583,6 +1589,8 @@ func (s *Service) AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMemb
 			zap.Int("requested", len(req.Members)),
 			zap.Int("added", len(addedUIDs)),
 			zap.Int64("db_ms", dbDur.Milliseconds()),
+			zap.Int64("space_check_ms", spaceCheckMs),
+			zap.Int64("tx_ms", txMs),
 			zap.Int64("channel_update_ms", channelUpdateDur.Milliseconds()),
 			zap.Int64("im_add_subscriber_ms", imSubscriberDur.Milliseconds()),
 			zap.Int64("send_member_add_ms", sendMemberAddDur.Milliseconds()),


### PR DESCRIPTION
## 背景

上一版埋点(#471)只埋在 `AddGroupMembers` **service 方法入口**,导致漏测。线上实测:

| 来源 | 耗时 | 覆盖 |
|---|---|---|
| service 链路日志(#471) | `total_ms:1526`(`db_ms:1398`) | 只到 service 那一段 |
| **GIN 访问日志** | **6.02s** | 整个请求 |
| **差值** | **≈4.5s** | **落在 handler 写前校验,没人测** |

实测 warn:`db_ms:1398, im_add_subscriber_ms:91, send_member_add_ms:33, total_ms:1526` —— **这次 IM 不慢**,大头是 handler 在调 service **之前**的写前校验(`getGroupInfo` / `ExistMember` / `checkBotOwnership` / `GetAppConfig` / Bot Space 隔离循环),全在旧埋点之外。同群同时段 GET /members 仅 9.9ms,走同样中间件 → 4.5s 不在中间件,在 POST handler 自身逻辑里。

## 这个 PR 做了什么(只加观测,不改控制流)

1. **handler 级埋点**(`memberAdd`):新增 `handler_total_ms`、`pre_checks_ms`,以及每步 `get_group_ms` / `exist_member_ms` / `bot_ownership_ms` / `app_config_ms` / `bot_space_ms`。
2. **拆分 service 的 `db_ms`**:新增 `space_check_ms`(每成员 `CheckMembership` 循环)+ `tx_ms`(GenSeq + insert + commit)。
3. 两条日志共用同一慢阈值 `DM_GROUP_INVITE_SLOW_LOG_MS`(缺省 1000ms,`<=0` 每次都打)、同一 `group_no`,便于关联。

## 如何用它把 6s 拆干净

```
中间件耗时        ≈ GIN_total − handler_total_ms
handler 写前校验   = pre_checks_ms（再按 get_group/exist_member/bot_ownership/app_config/bot_space 分摊）
service 段        = service 日志 total_ms（db_ms 再拆 space_check_ms / tx_ms，加 IM 各跳）
```
关系:`handler_total_ms ≈ pre_checks_ms + service.total_ms`。

handler 日志样例(本地,群不在 space):
```json
{"level":"warn","msg":"【Group】邀请成员 handler 链路耗时偏高",
 "group_no":"...","operator":"...","requested":1,
 "pre_checks_ms":1,"get_group_ms":0,"exist_member_ms":0,"bot_ownership_ms":0,
 "app_config_ms":0,"bot_space_ms":0,"handler_total_ms":24,"threshold_ms":0}
```
service 日志样例(已含新拆分字段):
```json
{"level":"warn","msg":"【groupService】邀请成员入群链路耗时偏高",
 "db_ms":6,"space_check_ms":0,"tx_ms":5,"im_add_subscriber_ms":14,
 "send_member_add_ms":1,"send_cmd_ms":0,"total_ms":23,"threshold_ms":0}
```

## 测试

- `gofmt` / `go build` / `go vet` 通过;
- `DM_GROUP_INVITE_SLOW_LOG_MS=0` 跑真实 HTTP POST /members:**两条日志都打、字段齐全、`handler_total ≈ pre_checks + service total`**(已验证);
- `modules/group` 全包测试绿(21s),无回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTmwnF18wfFgTAjufuMrXn)_