### PR TITLE
test(metrics): synthetic db/redis ping prober + rename namespace to octo_server

### DIFF
--- a/main.go
+++ b/main.go
@@ -194,6 +194,14 @@ func runAPI(ctx *config.Context) {
 	metrics.RegisterPoolCollectors(prometheus.DefaultRegisterer, ctx.DB().DB, map[string]*rd.Client{
 		"ratelimit": rlRedis,
 	})
+	// 合成探针(连接层过路费 SLI):周期性 Ping MySQL / Redis,把「取/建连接 + 一次
+	// 往返」的耗时打进 dependency 直方图(dependency="ping")。线上 health 的 db.Ping
+	// 偶发卡 ~2s,而 SQL 执行很快——这把那笔过路费做成常开、可告警的指标,与慢请求
+	// 时间线对照。复用既有 DependencyMetrics,不新增指标族。15s 一轮、单次 3s 超时。
+	metrics.NewPingProber(15*time.Second, 3*time.Second).
+		Add("mysql", func(c context.Context) error { return ctx.DB().DB.PingContext(c) }).
+		Add("redis_ratelimit", func(context.Context) error { return rlRedis.Ping().Err() }).
+		Start(context.Background())
 	// 在所有指标族注册完成后再起 scrape 端点,避免启动窗口内的 scrape 漏掉
 	// 依赖/连接池指标族(Jerry-Xin #442 review)。
 	metricsSrv := startMetricsScrapeServer()

--- a/pkg/metrics/dependency_test.go
+++ b/pkg/metrics/dependency_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// histSampleCount 在 reg 中找 dmwork_dependency_duration_seconds,返回带指定
+// histSampleCount 在 reg 中找 octo_server_dependency_duration_seconds,返回带指定
 // status label 的 histogram 的观测次数(SampleCount)。找不到返回 0。
 func histSampleCount(t *testing.T, reg *prometheus.Registry, status string) uint64 {
 	t.Helper()
@@ -17,7 +17,7 @@ func histSampleCount(t *testing.T, reg *prometheus.Registry, status string) uint
 		t.Fatal(err)
 	}
 	for _, mf := range mfs {
-		if mf.GetName() != "dmwork_dependency_duration_seconds" {
+		if mf.GetName() != "octo_server_dependency_duration_seconds" {
 			continue
 		}
 		for _, m := range mf.GetMetric() {
@@ -74,7 +74,7 @@ func TestDependencyMetrics_Naming(t *testing.T) {
 	m := NewDependencyMetrics(reg)
 	m.Observe(DependencyObjectStore, OpGetFile, "minio", time.Now(), nil)
 
-	const want = "dmwork_dependency_duration_seconds"
+	const want = "octo_server_dependency_duration_seconds"
 	mfs, err := reg.Gather()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -1,4 +1,4 @@
-// Package metrics 收集 dmwork 进程级 Prometheus 指标。
+// Package metrics 收集 octo-server 进程级 Prometheus 指标。
 //
 // HTTP 中间件提供 per-route 的延迟直方图、并发请求计数,
 // 以及"业务错误"计数 —— 后者通过解析响应 body 的 envelope `status` 字段
@@ -23,7 +23,9 @@ import (
 )
 
 const (
-	metricNamespace = "dmwork"
+	// metricNamespace 是所有 pkg/metrics 指标名的前缀(BuildFQName 以 _ 连接,
+	// 故必须是合法 Prometheus 标识符 —— 用下划线形式 octo_server,不能用连字符)。
+	metricNamespace = "octo_server"
 	metricSubsystem = "http"
 
 	// metricsEndpointPath 抓取端点本身在中间件中跳过埋点,

--- a/pkg/metrics/http_test.go
+++ b/pkg/metrics/http_test.go
@@ -156,7 +156,7 @@ func TestGinMiddleware_RecordsRequest(t *testing.T) {
 			rec := httptest.NewRecorder()
 			r.ServeHTTP(rec, req)
 
-			got := histogramSampleCount(t, reg, "dmwork_http_request_duration_seconds",
+			got := histogramSampleCount(t, reg, "octo_server_http_request_duration_seconds",
 				map[string]string{
 					"method": tc.wantMethod,
 					"path":   tc.wantPath,
@@ -184,7 +184,7 @@ func TestGinMiddleware_SkipsMetricsEndpoint(t *testing.T) {
 		t.Fatalf("gather: %v", err)
 	}
 	for _, mf := range families {
-		if mf.GetName() == "dmwork_http_request_duration_seconds" {
+		if mf.GetName() == "octo_server_http_request_duration_seconds" {
 			t.Errorf("expected no histogram samples after /metrics scrape, got %d series",
 				len(mf.GetMetric()))
 		}
@@ -264,9 +264,9 @@ func TestNewHTTPMetrics_RegistersOnProvidedRegistry(t *testing.T) {
 		t.Fatalf("gather: %v", err)
 	}
 	want := map[string]bool{
-		"dmwork_http_request_duration_seconds": false,
-		"dmwork_http_requests_in_flight":       false,
-		"dmwork_http_business_error_total":     false,
+		"octo_server_http_request_duration_seconds": false,
+		"octo_server_http_requests_in_flight":       false,
+		"octo_server_http_business_error_total":     false,
 	}
 	for _, mf := range families {
 		if _, ok := want[mf.GetName()]; ok {
@@ -365,7 +365,7 @@ func TestBusinessError_FromEnvelopeStatus(t *testing.T) {
 			r.ServeHTTP(rec, req)
 
 			if tc.wantIncrease {
-				got := counterValue(t, reg, "dmwork_http_business_error_total",
+				got := counterValue(t, reg, "octo_server_http_business_error_total",
 					map[string]string{"path": tc.wantPath, "code": tc.wantCode})
 				if got != 1 {
 					t.Errorf("expected counter=1 for {path=%s, code=%s}, got %v",
@@ -374,7 +374,7 @@ func TestBusinessError_FromEnvelopeStatus(t *testing.T) {
 			} else {
 				families, _ := reg.Gather()
 				for _, mf := range families {
-					if mf.GetName() == "dmwork_http_business_error_total" && len(mf.GetMetric()) > 0 {
+					if mf.GetName() == "octo_server_http_business_error_total" && len(mf.GetMetric()) > 0 {
 						t.Errorf("expected no business_error_total samples, got %d series",
 							len(mf.GetMetric()))
 					}
@@ -399,7 +399,7 @@ func TestBusinessError_FallbackToHTTPStatus(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	got := counterValue(t, reg, "dmwork_http_business_error_total",
+	got := counterValue(t, reg, "octo_server_http_business_error_total",
 		map[string]string{"path": "/v1/auth", "code": "401"})
 	if got != 1 {
 		t.Errorf("expected counter=1 for {path=/v1/auth, code=401}, got %v", got)
@@ -416,7 +416,7 @@ func TestBusinessError_PanicCountedAs500(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	got := counterValue(t, reg, "dmwork_http_business_error_total",
+	got := counterValue(t, reg, "octo_server_http_business_error_total",
 		map[string]string{"path": "/v1/panic", "code": "500"})
 	if got != 1 {
 		t.Errorf("expected counter=1 for {path=/v1/panic, code=500}, got %v", got)
@@ -439,7 +439,7 @@ func TestBusinessError_SuccessPathNotCounted(t *testing.T) {
 
 	families, _ := reg.Gather()
 	for _, mf := range families {
-		if mf.GetName() == "dmwork_http_business_error_total" && len(mf.GetMetric()) > 0 {
+		if mf.GetName() == "octo_server_http_business_error_total" && len(mf.GetMetric()) > 0 {
 			t.Errorf("expected no business_error_total samples on 200, got %d series",
 				len(mf.GetMetric()))
 		}
@@ -468,7 +468,7 @@ func TestBusinessError_TruncatedBodyFallsBack(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	got := counterValue(t, reg, "dmwork_http_business_error_total",
+	got := counterValue(t, reg, "octo_server_http_business_error_total",
 		map[string]string{"path": "/v1/big", "code": "400"})
 	if got != 1 {
 		t.Errorf("expected fallback counter=1 for truncated body, got %v", got)
@@ -484,7 +484,7 @@ func TestBusinessError_UnmatchedRouteUses404(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	got := counterValue(t, reg, "dmwork_http_business_error_total",
+	got := counterValue(t, reg, "octo_server_http_business_error_total",
 		map[string]string{"path": "unmatched", "code": "404"})
 	if got != 1 {
 		t.Errorf("expected counter=1 for {path=unmatched, code=404}, got %v", got)

--- a/pkg/metrics/pool_test.go
+++ b/pkg/metrics/pool_test.go
@@ -24,12 +24,12 @@ func TestRedisPoolCollector_EmitsSeries(t *testing.T) {
 	// 六个序列(total/idle gauge + hits/misses/timeouts/stale counter)均应出现,
 	// 且带 client="ratelimit" label。
 	wantNames := []string{
-		"dmwork_redis_pool_total_connections",
-		"dmwork_redis_pool_idle_connections",
-		"dmwork_redis_pool_hits_total",
-		"dmwork_redis_pool_misses_total",
-		"dmwork_redis_pool_timeouts_total",
-		"dmwork_redis_pool_stale_connections_total",
+		"octo_server_redis_pool_total_connections",
+		"octo_server_redis_pool_idle_connections",
+		"octo_server_redis_pool_hits_total",
+		"octo_server_redis_pool_misses_total",
+		"octo_server_redis_pool_timeouts_total",
+		"octo_server_redis_pool_stale_connections_total",
 	}
 	mfs, err := reg.Gather()
 	if err != nil {
@@ -75,7 +75,7 @@ func TestRegisterPoolCollectors_NoInputsNoPanic(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, mf := range mfs {
-		if strings.HasPrefix(mf.GetName(), "dmwork_redis_pool") || strings.HasPrefix(mf.GetName(), "go_sql") {
+		if strings.HasPrefix(mf.GetName(), "octo_server_redis_pool") || strings.HasPrefix(mf.GetName(), "go_sql") {
 			t.Errorf("unexpected family %q registered with no inputs", mf.GetName())
 		}
 	}

--- a/pkg/metrics/prober.go
+++ b/pkg/metrics/prober.go
@@ -1,0 +1,103 @@
+package metrics
+
+import (
+	"context"
+	"time"
+)
+
+// DependencyPing 是合成探针的 dependency label 值。探针周期性 Ping 上游
+// (MySQL / Redis),把「取连接 + 一次往返」的耗时打进与业务调用同一个
+// dependency 直方图(octo_server_dependency_duration_seconds),无需新增指标族。
+//
+// 背景(连接层过路费排查):线上观测到 health 的 db.Ping 偶发卡 ~2s,而真正
+// 的 SQL 执行很快 —— 慢的是「取/建连接 + RTT」这一跳。把它做成常开 SLI,就能
+// 持续量这笔过路费、设告警,并与慢请求时间线对照,无需逐调用点埋日志。
+const DependencyPing = "ping"
+
+// ObservePing 记录一次合成探针调用。backend 为低基数枚举(如 mysql /
+// redis_ratelimit),op 固定为 "probe"。未初始化默认 DependencyMetrics 时为
+// no-op(指标关闭 / 单测未初始化),绝不 panic —— 与 ObserveObjectStore 同语义。
+func ObservePing(backend string, start time.Time, err error) {
+	if m := defaultDependencyMetrics.Load(); m != nil {
+		m.Observe(DependencyPing, "probe", backend, start, err)
+	}
+}
+
+// pingTarget 是一个被周期性探测的上游。ping 接收带超时的 context,返回 error
+// 即视为一次失败探测(status=error),但循环本身不因单次失败中断。
+type pingTarget struct {
+	backend string
+	ping    func(context.Context) error
+}
+
+// PingProber 周期性对一组上游做 Ping,并把每次耗时灌进 ObservePing。
+// 它只产生指标、不打日志;Start 起一个遵守 context 取消的后台 goroutine。
+//
+// 设计取舍:
+//   - 复用业务依赖直方图(加 dependency="ping" label),不新增指标族,符合
+//     pkg/metrics「新依赖加 label 值即可」的约定。
+//   - 每次探测套独立超时,避免某个上游卡死拖垮整个探测循环 / 泄漏 goroutine。
+//   - interval 取相对稀疏(默认调用方传 15s):过路费是分钟级的间歇抖动,过密
+//     探测只会徒增连接开销而不提升信噪比。
+type PingProber struct {
+	interval time.Duration
+	timeout  time.Duration
+	targets  []pingTarget
+}
+
+// NewPingProber 构造一个探针。interval 是相邻探测轮的间隔,timeout 是单次探测
+// 的上限(应 < interval)。两者非正值时回退到安全默认(15s / 3s)。
+func NewPingProber(interval, timeout time.Duration) *PingProber {
+	if interval <= 0 {
+		interval = 15 * time.Second
+	}
+	if timeout <= 0 {
+		timeout = 3 * time.Second
+	}
+	return &PingProber{interval: interval, timeout: timeout}
+}
+
+// Add 注册一个待探测上游。backend 必须是低基数枚举值(进 Prometheus label)。
+// 返回自身以便链式调用。
+func (p *PingProber) Add(backend string, ping func(context.Context) error) *PingProber {
+	if ping == nil || backend == "" {
+		return p
+	}
+	p.targets = append(p.targets, pingTarget{backend: backend, ping: ping})
+	return p
+}
+
+// Start 在后台起探测循环,随 ctx 取消而退出。无 target 时不起 goroutine。
+func (p *PingProber) Start(ctx context.Context) {
+	if len(p.targets) == 0 {
+		return
+	}
+	go p.loop(ctx)
+}
+
+func (p *PingProber) loop(ctx context.Context) {
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+	// 启动即探一次,不必等满一个 interval 才有数据。
+	p.probeAll(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.probeAll(ctx)
+		}
+	}
+}
+
+// probeAll 串行探测全部 target 并各记一次耗时。导出供测试直接驱动一轮探测,
+// 无需起 goroutine / 等 ticker。
+func (p *PingProber) probeAll(ctx context.Context) {
+	for _, t := range p.targets {
+		probeCtx, cancel := context.WithTimeout(ctx, p.timeout)
+		start := time.Now()
+		err := t.ping(probeCtx)
+		cancel()
+		ObservePing(t.backend, start, err)
+	}
+}

--- a/pkg/metrics/prober_test.go
+++ b/pkg/metrics/prober_test.go
@@ -1,0 +1,96 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// pingHistSampleCount 在 reg 中找 octo_server_dependency_duration_seconds,
+// 返回 dependency="ping" + 指定 backend/status 的样本计数。
+func pingHistSampleCount(t *testing.T, reg *prometheus.Registry, backend, status string) uint64 {
+	t.Helper()
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != "octo_server_dependency_duration_seconds" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			var dep, backendL, statusL string
+			for _, l := range m.GetLabel() {
+				switch l.GetName() {
+				case "dependency":
+					dep = l.GetValue()
+				case "backend":
+					backendL = l.GetValue()
+				case "status":
+					statusL = l.GetValue()
+				}
+			}
+			if dep == DependencyPing && backendL == backend && statusL == status {
+				return m.GetHistogram().GetSampleCount()
+			}
+		}
+	}
+	return 0
+}
+
+// TestPingProber_ObservesOKAndError 驱动一轮探测,断言成功/失败各记一次到
+// 与业务依赖同一个直方图(dependency="ping")。
+func TestPingProber_ObservesOKAndError(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	NewDependencyMetrics(reg) // 注册并登记为包级默认,供 ObservePing 使用
+
+	probe := NewPingProber(time.Hour, time.Second). // interval 设大,只手动驱动一轮
+							Add("mysql", func(context.Context) error { return nil }).
+							Add("redis_ratelimit", func(context.Context) error { return errors.New("boom") })
+
+	probe.probeAll(context.Background())
+
+	if got := pingHistSampleCount(t, reg, "mysql", "ok"); got != 1 {
+		t.Errorf("mysql ok sample count = %d, want 1", got)
+	}
+	if got := pingHistSampleCount(t, reg, "redis_ratelimit", "error"); got != 1 {
+		t.Errorf("redis_ratelimit error sample count = %d, want 1", got)
+	}
+}
+
+// TestPingProber_PassesTimeoutContext 断言探测函数拿到的是带 deadline 的 ctx
+// (单次探测套了超时,避免卡死拖垮循环)。
+func TestPingProber_PassesTimeoutContext(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	NewDependencyMetrics(reg)
+
+	var hadDeadline bool
+	NewPingProber(time.Hour, 50*time.Millisecond).
+		Add("mysql", func(c context.Context) error {
+			_, hadDeadline = c.Deadline()
+			return nil
+		}).
+		probeAll(context.Background())
+
+	if !hadDeadline {
+		t.Error("probe ctx 应带 deadline(单次探测超时),实际没有")
+	}
+}
+
+// TestObservePing_NoDefaultIsNoop 未初始化默认 DependencyMetrics 时 ObservePing
+// 必须是安全 no-op,不 panic。
+func TestObservePing_NoDefaultIsNoop(t *testing.T) {
+	defaultDependencyMetrics.Store(nil)
+	ObservePing("mysql", time.Now(), nil) // 不 panic 即通过
+}
+
+// TestPingProber_StartNoTargetsNoGoroutine 无 target 时 Start 不应起 goroutine
+// (退化为安全空操作)。这里只验证调用不 panic、可立即返回。
+func TestPingProber_StartNoTargetsNoGoroutine(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	NewPingProber(time.Hour, time.Second).Start(ctx) // 无 target
+}


### PR DESCRIPTION
## 背景

邀请慢的链路三层对账已收敛到:**慢的不是业务逻辑,是「凡碰 DB/Redis 每次都付 200~500ms 取/建连接 + RTT 的固定过路费」**,被请求里大量串行依赖访问乘出 5.8s。线上 health 的 `db.Ping` 偶发卡 ~2s 与之同源。这个 PR 把那笔过路费做成**常开、可告警的 SLI**——octo-server 侧能独立落地的部分(B)。

> 真正能逐跳归因的客户端接缝插桩(MySQL driver wrapper 拆 connect/exec、Cache/Redis hook)属于 octo-lib(`ctx.DB()`/`ctx.Cache()` 的出生地),单独走 octo-lib PR;本 PR 不含。

## 改动 1:合成 ping 探针(`pkg/metrics/prober.go`)

- 后台 goroutine 周期性 `Ping` **MySQL** 和**限流 Redis**,把「取/建连接 + 一次往返」耗时打进**既有** `dependency` 直方图,label `dependency="ping"`、`backend=mysql|redis_ratelimit`、`op="probe"`——**不新增指标族**(复用 #442 的 `DependencyMetrics`,符合「新依赖加 label」约定)。
- 15s 一轮、单次 3s 超时、随 `context` 取消退出;单次失败不中断循环、不 panic(默认实例未初始化时 `ObservePing` 为 no-op)。
- 直接量那笔过路费,可设告警(如 `histogram_quantile(0.99, ...{dependency="ping"})` > 0.5s),并与慢请求时间线对照,坐实「连接层慢」而非 SQL 慢。
- 接线在 `main.go`,紧跟 `RegisterPoolCollectors` 之后、scrape 端点启动之前。

## 改动 2:指标命名空间 `dmwork` → `octo_server`

- `pkg/metrics` 的 Prometheus 命名空间从 `dmwork` 改为 **`octo_server`**(下划线形式——**连字符 `octo-server` 是非法 Prometheus 指标名,注册即 panic**)。
- 同步更新 `pkg/metrics/*_test.go` 里的指标名断言。
- ⚠️ **破坏性**:所有 `dmwork_*` series 改名为 `octo_server_*`,**现有查询 `dmwork_*` 的看板/告警需要同步改名**。指标是 #442 新引入的,影响面有限。
- `modules/oidc` 用的是自己独立的 `oidc` 命名空间,不受影响。
- `.octospec/` 里 #442 的 journal/brief 仍记旧名(历史记录),本次不改写;以代码与本 PR 为准。

## 测试

- `gofmt` / `go build ./...` / `go vet ./pkg/metrics/` 通过;
- `pkg/metrics` 全包测试绿,新增 `prober_test.go`:成功/失败各记一次、探测 ctx 带 deadline、无 target 不起 goroutine、未初始化 no-op;
- 重命名后 `octo_server_*` 断言全绿,仓库内无残留 `dmwork_` 指标引用(代码/测试)。

## 关于前两轮 #471/#472

**先留着**:它们是慢阈值才打的日志(正常流量零噪音),在 octo-lib 接缝插桩落地前,仍是唯一能给「邀请路径 per-step(尤其 `bot_space_ms`)」拆分的东西。等接缝级 trace/指标证明其冗余,再开小 PR 撤掉。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTmwnF18wfFgTAjufuMrXn)_