### PR TITLE
feat(metrics): record MySQL/Redis dependency latency via octo-lib observers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	firebase.google.com/go/v4 v4.13.0
 	github.com/BurntSushi/toml v1.6.0
 	github.com/DATA-DOG/go-sqlmock v1.5.0
-	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260618083705-a57dc301cbf3
+	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260626063251-cff4d7a48f55
 	github.com/alibabacloud-go/darabonba-openapi v0.2.1
 	github.com/alibabacloud-go/sms-intl-20180501 v1.0.1
 	github.com/alibabacloud-go/tea v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,12 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260618083705-a57dc301cbf3 h1:bdZVEI6F7b60DVtHB3G4N8aJ4ikzAywepS5Ebyk5oH0=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260618083705-a57dc301cbf3/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260626053045-e53d3c79ba8a h1:mrq/juKm1hnZOoyPUkbGr8Frp86cjHZAfxLCuZGm7ZM=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260626053045-e53d3c79ba8a/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260626061615-1dd2fe0df345 h1:rvTUY535L2kELV8MPKzgqBZfkSjJDULAWCQm7m9zY3k=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260626061615-1dd2fe0df345/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260626063251-cff4d7a48f55 h1:2reLrd1tHsMwGRaGVXbHVpIzqnlVajkOPwn8hclDraI=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260626063251-cff4d7a48f55/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae h1:DcFpTQBYQ9Ct2d6sC7ol0/ynxc2pO1cpGUM+f4t5adg=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae/go.mod h1:rJJ84PyA/Wlmw1hO+xTzV2wsSUon6J5ktg0g8BF2PuU=
 github.com/RichardKnop/machinery/v2 v2.0.11 h1:BTfLGOmOju3W/OtlZmLX26OjYNZsU4PJo04pQReycdc=

--- a/go.sum
+++ b/go.sum
@@ -65,10 +65,6 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260626053045-e53d3c79ba8a h1:mrq/juKm1hnZOoyPUkbGr8Frp86cjHZAfxLCuZGm7ZM=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260626053045-e53d3c79ba8a/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260626061615-1dd2fe0df345 h1:rvTUY535L2kELV8MPKzgqBZfkSjJDULAWCQm7m9zY3k=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260626061615-1dd2fe0df345/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
 github.com/Mininglamp-OSS/octo-lib v0.0.0-20260626063251-cff4d7a48f55 h1:2reLrd1tHsMwGRaGVXbHVpIzqnlVajkOPwn8hclDraI=
 github.com/Mininglamp-OSS/octo-lib v0.0.0-20260626063251-cff4d7a48f55/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae h1:DcFpTQBYQ9Ct2d6sC7ol0/ynxc2pO1cpGUM+f4t5adg=

--- a/main.go
+++ b/main.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/module"
+	libdb "github.com/Mininglamp-OSS/octo-lib/pkg/db"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	libredis "github.com/Mininglamp-OSS/octo-lib/pkg/redis"
 	libwkhttp "github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-lib/server"
 	_ "github.com/Mininglamp-OSS/octo-server/internal"
@@ -191,6 +193,14 @@ func runAPI(ctx *config.Context) {
 	// scrape 时读取的 Collector,不起后台 goroutine。此处 rlRedis 与 ctx.DB().DB
 	// 均已就绪,且在 api.Route 之前完成注册。
 	metrics.NewDependencyMetrics(prometheus.DefaultRegisterer)
+	// 把 octo-lib 客户端接缝的耗时回调接到 DependencyMetrics:
+	//   - MySQL: db.NewMySQL 的 connect/query 计时 → dependency="mysql"
+	//   - Redis: pkg/redis 客户端每条命令计时 → dependency="redis"
+	// observer 在调用时按 atomic 解析,construct 时即已挂 hook,故放在此处(指标族
+	// 注册之后、serve 之前)即可,不会漏掉后续流量。注:限流用的 rlRedis 是裸
+	// *rd.Client,绕过 pkg/redis,其单命令延迟不在此覆盖(池指标已覆盖),见 octo-lib#96。
+	libdb.SetDBObserver(metrics.ObserveDB)
+	libredis.SetRedisObserver(metrics.ObserveRedisCmd)
 	metrics.RegisterPoolCollectors(prometheus.DefaultRegisterer, ctx.DB().DB, map[string]*rd.Client{
 		"ratelimit": rlRedis,
 	})

--- a/main.go
+++ b/main.go
@@ -197,8 +197,15 @@ func runAPI(ctx *config.Context) {
 	//   - MySQL: db.NewMySQL 的 connect/query 计时 → dependency="mysql"
 	//   - Redis: pkg/redis 客户端每条命令计时 → dependency="redis"
 	// observer 在调用时按 atomic 解析,construct 时即已挂 hook,故放在此处(指标族
-	// 注册之后、serve 之前)即可,不会漏掉后续流量。注:限流用的 rlRedis 是裸
-	// *rd.Client,绕过 pkg/redis,其单命令延迟不在此覆盖(池指标已覆盖),见 octo-lib#96。
+	// 注册之后、serve 之前)即可,不会漏掉后续流量。
+	//
+	// 覆盖范围(重要):dependency="redis" 只覆盖经 pkg/redis 构造的客户端 ——
+	// 主要是共享缓存 ctx.GetRedisConn()(数据面大头)。全仓还有约 15 处裸
+	// rd.NewClient(octoredis.MustBuildOptions(...))(限流 rlRedis、OIDC state/bind/
+	// logout/sync_lock、bot registry、user/group/space auth、health、各类 Lua 锁等),
+	// 它们需要 Eval/Script/SetNX 等 pkg/redis 包装未暴露的原语,因此都绕过插桩,
+	// 其单命令延迟不进本指标(连接池指标仍覆盖)。在 dependency="redis" 上做告警时
+	// 要知道 auth/OIDC/限流/锁/health 这些路径不可见。通用治理见 octo-lib#96。
 	libdb.SetDBObserver(metrics.ObserveDB)
 	libredis.SetRedisObserver(metrics.ObserveRedisCmd)
 	metrics.RegisterPoolCollectors(prometheus.DefaultRegisterer, ctx.DB().DB, map[string]*rd.Client{

--- a/pkg/metrics/dependency.go
+++ b/pkg/metrics/dependency.go
@@ -21,6 +21,15 @@ const (
 
 	// DependencyObjectStore 是对象存储类依赖的 dependency label 值。
 	DependencyObjectStore = "objectstore"
+	// DependencyMySQL / DependencyRedis 是 DB / 缓存依赖的 dependency label 值,
+	// 由 octo-lib 客户端接缝(db.SetDBObserver / redis.SetRedisObserver)灌入。
+	DependencyMySQL = "mysql"
+	DependencyRedis = "redis"
+
+	// backendMain 是单库 / 单缓存现状下 mysql/redis 的固定 backend label。
+	// 这两类依赖没有像对象存储那样的多后端实现,固定一个低基数值即可;若将来引入
+	// 读副本 / 多缓存实例,再按实例参数化。
+	backendMain = "main"
 	// OpUploadFile / OpGetFile 是对象存储上「真正发生网络 I/O」的两个操作的 op
 	// label 值:上传(PutObject 等)与读取对象(GetObject+Stat 等)。
 	// 注意:不为 DownloadURL 打点 —— 各后端的 DownloadURL 只是从 config 本地拼出
@@ -65,11 +74,17 @@ func NewDependencyMetrics(reg prometheus.Registerer) *DependencyMetrics {
 
 // Observe 记录一次依赖调用。status 由 err 是否为 nil 决定。
 func (m *DependencyMetrics) Observe(dependency, op, backend string, start time.Time, err error) {
+	m.ObserveDuration(dependency, op, backend, time.Since(start), err)
+}
+
+// ObserveDuration 同 Observe,但直接接收耗时而非起始时间。用于适配 octo-lib 客户端
+// 接缝的 observer 回调签名(dbr 给的是纳秒耗时,而非 start time)。
+func (m *DependencyMetrics) ObserveDuration(dependency, op, backend string, dur time.Duration, err error) {
 	status := dependencyStatusOK
 	if err != nil {
 		status = dependencyStatusError
 	}
-	m.Duration.WithLabelValues(dependency, op, backend, status).Observe(time.Since(start).Seconds())
+	m.Duration.WithLabelValues(dependency, op, backend, status).Observe(dur.Seconds())
 }
 
 // ObserveObjectStore 是对象存储调用的包级便捷入口,供 modules/file 等调用方使用,
@@ -84,5 +99,23 @@ func (m *DependencyMetrics) Observe(dependency, op, backend string, start time.T
 func ObserveObjectStore(op, backend string, start time.Time, err error) {
 	if m := defaultDependencyMetrics.Load(); m != nil {
 		m.Observe(DependencyObjectStore, op, backend, start, err)
+	}
+}
+
+// ObserveDB 是 MySQL 客户端调用的包级入口,签名精确匹配 octo-lib 的 db.DBObserver。
+// 在 main 里用 db.SetDBObserver(metrics.ObserveDB) 注入。op 取值 "connect" / "query"。
+// 未初始化默认实例时为 no-op。
+func ObserveDB(op string, dur time.Duration, err error) {
+	if m := defaultDependencyMetrics.Load(); m != nil {
+		m.ObserveDuration(DependencyMySQL, op, backendMain, dur, err)
+	}
+}
+
+// ObserveRedisCmd 是 Redis 命令的包级入口,签名精确匹配 octo-lib 的 redis.RedisObserver。
+// 在 main 里用 redis.SetRedisObserver(metrics.ObserveRedisCmd) 注入。op 为命令名(已小写)。
+// 未初始化默认实例时为 no-op。
+func ObserveRedisCmd(op string, dur time.Duration, err error) {
+	if m := defaultDependencyMetrics.Load(); m != nil {
+		m.ObserveDuration(DependencyRedis, op, backendMain, dur, err)
 	}
 }

--- a/pkg/metrics/dependency_test.go
+++ b/pkg/metrics/dependency_test.go
@@ -69,13 +69,16 @@ func TestObserveObjectStore_UsesDefault(t *testing.T) {
 	}
 }
 
-// histSampleCountByDepOp 返回带指定 dependency+op label 的 histogram 观测次数。
+// histSampleCountByDepOp 返回带指定 dependency+op label 的 histogram 观测次数,
+// 跨 status 累加。dependency+op 下可能同时存在 status=ok 与 status=error 两条序列;
+// 若只取首个匹配会按 protobuf 顺序漏数,故这里把所有匹配序列的 SampleCount 相加。
 func histSampleCountByDepOp(t *testing.T, reg *prometheus.Registry, dependency, op string) uint64 {
 	t.Helper()
 	mfs, err := reg.Gather()
 	if err != nil {
 		t.Fatal(err)
 	}
+	var total uint64
 	for _, mf := range mfs {
 		if mf.GetName() != "dmwork_dependency_duration_seconds" {
 			continue
@@ -91,11 +94,11 @@ func histSampleCountByDepOp(t *testing.T, reg *prometheus.Registry, dependency, 
 				}
 			}
 			if gotDep == dependency && gotOp == op {
-				return m.GetHistogram().GetSampleCount()
+				total += m.GetHistogram().GetSampleCount()
 			}
 		}
 	}
-	return 0
+	return total
 }
 
 func TestDependencyMetrics_ObserveDuration(t *testing.T) {

--- a/pkg/metrics/dependency_test.go
+++ b/pkg/metrics/dependency_test.go
@@ -69,6 +69,79 @@ func TestObserveObjectStore_UsesDefault(t *testing.T) {
 	}
 }
 
+// histSampleCountByDepOp 返回带指定 dependency+op label 的 histogram 观测次数。
+func histSampleCountByDepOp(t *testing.T, reg *prometheus.Registry, dependency, op string) uint64 {
+	t.Helper()
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != "dmwork_dependency_duration_seconds" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			var gotDep, gotOp string
+			for _, l := range m.GetLabel() {
+				switch l.GetName() {
+				case "dependency":
+					gotDep = l.GetValue()
+				case "op":
+					gotOp = l.GetValue()
+				}
+			}
+			if gotDep == dependency && gotOp == op {
+				return m.GetHistogram().GetSampleCount()
+			}
+		}
+	}
+	return 0
+}
+
+func TestDependencyMetrics_ObserveDuration(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewDependencyMetrics(reg)
+
+	m.ObserveDuration(DependencyMySQL, "query", backendMain, 5*time.Millisecond, nil)
+	m.ObserveDuration(DependencyMySQL, "connect", backendMain, 2*time.Millisecond, errors.New("dial fail"))
+
+	if got := histSampleCountByDepOp(t, reg, DependencyMySQL, "query"); got != 1 {
+		t.Fatalf("mysql query sample count = %d, want 1", got)
+	}
+	if got := histSampleCountByDepOp(t, reg, DependencyMySQL, "connect"); got != 1 {
+		t.Fatalf("mysql connect sample count = %d, want 1", got)
+	}
+	if got := histSampleCount(t, reg, dependencyStatusError); got != 1 {
+		t.Fatalf("error sample count = %d, want 1 (failed connect)", got)
+	}
+}
+
+func TestObserveDBAndRedis_UsesDefault(t *testing.T) {
+	prev := defaultDependencyMetrics.Load()
+	t.Cleanup(func() { defaultDependencyMetrics.Store(prev) })
+	reg := prometheus.NewRegistry()
+	NewDependencyMetrics(reg) // 同时把自己设为包级默认
+
+	ObserveDB("query", 3*time.Millisecond, nil)
+	ObserveRedisCmd("get", time.Millisecond, nil)
+
+	if got := histSampleCountByDepOp(t, reg, DependencyMySQL, "query"); got != 1 {
+		t.Fatalf("ObserveDB recorded %d mysql/query samples, want 1", got)
+	}
+	if got := histSampleCountByDepOp(t, reg, DependencyRedis, "get"); got != 1 {
+		t.Fatalf("ObserveRedisCmd recorded %d redis/get samples, want 1", got)
+	}
+}
+
+func TestObserveDBAndRedis_NoDefaultIsNoop(t *testing.T) {
+	prev := defaultDependencyMetrics.Load()
+	t.Cleanup(func() { defaultDependencyMetrics.Store(prev) })
+	defaultDependencyMetrics.Store(nil)
+	// 未初始化默认实例时必须是纯 no-op,不得 panic。
+	ObserveDB("query", time.Millisecond, nil)
+	ObserveRedisCmd("set", time.Millisecond, errors.New("boom"))
+}
+
 func TestDependencyMetrics_Naming(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	m := NewDependencyMetrics(reg)


### PR DESCRIPTION
## Summary

Consume octo-lib's new client-seam observers (octo-lib#97, merged) so MySQL connect/query and Redis command latency land in the existing `DependencyMetrics` histogram — no new metric family, just `dependency=mysql/redis` label values. Combined with the pool `WaitDuration`, this completes the **connect handshake / pool-wait / execute** three-way split for DB latency root-causing.

## Related Issue

Extends the dependency-observability work in #442 / #440. Depends on octo-lib#97 (merged). Follow-ups tracked in octo-lib#96.

## Linked Spec

octo-lib#97 (the library seam) + #442 `DependencyMetrics`. octo-lib only exposes no-op-by-default callbacks; this PR injects the real implementations.

## Changes

- **`pkg/metrics/dependency.go`** — add `ObserveDuration` (duration-based sibling of `Observe`, matching octo-lib's callback signature, since dbr/driver hand us a duration not a start time); `Observe` now delegates to it. Add package-level `ObserveDB` / `ObserveRedisCmd` entrypoints and `DependencyMySQL` / `DependencyRedis` / `backendMain` label constants. `status` is derived from `err != nil` **only** — the raw driver error never enters a label.
- **`main.go`** — inject `db.SetDBObserver(metrics.ObserveDB)` and `redis.SetRedisObserver(metrics.ObserveRedisCmd)` right after `NewDependencyMetrics`. Note: the rate-limit `rd.NewClient` is a raw client that bypasses `pkg/redis` instrumentation (pool stats still cover it); tracked in octo-lib#96.
- **`go.mod`** — pin octo-lib to the merged #97 commit.
- **tests** — `ObserveDuration` (ok/error) + `ObserveDB`/`ObserveRedisCmd` default-instance and no-op paths.

Produces `dmwork_dependency_duration_seconds{dependency=mysql,op=connect|query}` and `{dependency=redis,op=<cmd>}`.

## Testing

```
go build ./...        # ok
go vet ./pkg/metrics  # clean
go test ./pkg/metrics # ok
```

- [x] Unit tests added/updated
- [ ] Manually verified (metrics wiring; exercised via unit tests against the merged octo-lib)

## COMPREHENSION

1. **What it does to the load-bearing path** — registers two process-global observer callbacks at startup. Every MySQL connect/query and Redis command then also invokes `ObserveDB`/`ObserveRedisCmd`, which does one `HistogramVec.WithLabelValues(...).Observe(dur)` into the existing `DependencyMetrics`. No change to query/command results or control flow; the callbacks only measure.

2. **What could break** — the observer runs synchronously on every DB/Redis call, so a slow or panicking observer would add latency / crash the caller. Mitigations: octo-lib wraps the dispatch in `defer/recover` (a panic is contained to one dropped sample), and our callback does only an in-memory Prometheus `Observe` (no I/O, no allocation beyond the label lookup). Cardinality/PII: labels are low-card enums (`dependency`/`op`/`backend`/`status`); the raw `err` is used only as an ok/error boolean and is **never** placed in a label or log field, so no series blow-up and no leak of SQL text / row data. Coverage gap (documented): the rate-limit raw redis client isn't instrumented.

3. **How I know it works** — unit tests assert the metric family `dmwork_dependency_duration_seconds` records ok/error samples under the right `dependency`/`op` labels for both `ObserveDuration` and the package-level `ObserveDB`/`ObserveRedisCmd`, plus the safe no-op when the default instance is unset. `go build`/`vet`/`test` green against the merged octo-lib (`v0.0.0-...-cff4d7a48f55`); octo-server needed zero code changes beyond this wiring, confirming the observer API is consumed as designed.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (code comments; metric semantics in PR + octo-lib#96)
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHTDHbMPAVkNvYdQkh2ts3)_