### PR TITLE
feat(incomingwebhook): return localized adapter examples

### DIFF
--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -355,9 +355,14 @@ POST /v1/incoming-webhooks/:webhook_id/:token/feishu
 
 需登录态 + 群管理员权限，路径前缀 `/v1/groups/:group_no/incoming-webhooks`。
 
-创建 / 重置（regenerate）响应除历史的 `url`（native 路径）外，还带 `urls` 对象，
-按推送形态给出全部路径（`native` / `github` / `wecom` / `multica` / `gitlab` / `feishu`，
-不含 host，由前端拼接）。token 仅在这两处出现一次，list 不回显 token、也不回推送 URL。
+创建 / 重置（regenerate）响应除历史的 `url`（native 路径）外，还带：
+
+- `urls`：按推送形态给出全部路径（`native` / `github` / `wecom` / `multica` / `gitlab` /
+  `feishu`），不含 host，由前端拼接。
+- `adapter_examples`：面向管理端「更多适配器」区域的本地化接入示例（title /
+  description / steps / auth / content_type），URL 与 `urls` 共享同一组 path。
+
+token 仅在这两处出现一次，list 不回显 token、推送 URL 或 `adapter_examples`。
 
 除创建/列出/更新/删除/重置外，Phase 2 新增两个：
 

--- a/modules/incomingwebhook/adapter_catalog.go
+++ b/modules/incomingwebhook/adapter_catalog.go
@@ -1,0 +1,127 @@
+package incomingwebhook
+
+import (
+	"embed"
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/base/common/msgtmpl"
+	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"go.uber.org/zap"
+)
+
+//go:embed templates
+var adapterTemplatesFS embed.FS
+
+var adapterMessages = msgtmpl.MustNew(adapterTemplatesFS, "templates")
+
+type adapterAuthResp struct {
+	Type        string `json:"type"`
+	Header      string `json:"header,omitempty"`
+	ValueSource string `json:"value_source,omitempty"`
+}
+
+type adapterExampleResp struct {
+	Key         string          `json:"key"`
+	Title       string          `json:"title"`
+	Description string          `json:"description"`
+	URL         string          `json:"url"`
+	ContentType string          `json:"content_type"`
+	Auth        adapterAuthResp `json:"auth"`
+	Steps       []string        `json:"steps"`
+}
+
+type publicAdapterDef struct {
+	Key         string
+	Suffix      string
+	ContentType string
+	Auth        adapterAuthResp
+	ShowExample bool
+}
+
+var publicAdapterCatalog = []publicAdapterDef{
+	{Key: adapterNative, ContentType: "application/json"},
+	{Key: adapterGitHub, Suffix: adapterGitHub, ContentType: "application/json", Auth: adapterAuthResp{Type: "url_token"}, ShowExample: true},
+	{Key: adapterGitLab, Suffix: adapterGitLab, ContentType: "application/json", Auth: adapterAuthResp{Type: "url_token_and_header", Header: "X-Gitlab-Token", ValueSource: "token"}, ShowExample: true},
+	{Key: adapterFeishu, Suffix: adapterFeishu, ContentType: "application/json", Auth: adapterAuthResp{Type: "url_token"}, ShowExample: true},
+	{Key: adapterMultica, Suffix: adapterMultica, ContentType: "application/json", Auth: adapterAuthResp{Type: "url_token"}, ShowExample: true},
+	{Key: adapterWeCom, Suffix: adapterWeCom, ContentType: "application/json", Auth: adapterAuthResp{Type: "url_token"}, ShowExample: true},
+}
+
+func publicAdapterExamples(webhookID, token, lang string) ([]adapterExampleResp, error) {
+	urls := publicURLs(webhookID, token)
+	examples := make([]adapterExampleResp, 0, len(publicAdapterCatalog)-1)
+	for _, def := range publicAdapterCatalog {
+		if !def.ShowExample {
+			continue
+		}
+		data := map[string]any{
+			"URL":         urls[def.Key],
+			"ContentType": def.ContentType,
+		}
+		title, err := adapterMessages.Render(adapterTemplateName(def.Key, "title"), lang, data)
+		if err != nil {
+			return nil, err
+		}
+		description, err := adapterMessages.Render(adapterTemplateName(def.Key, "description"), lang, data)
+		if err != nil {
+			return nil, err
+		}
+		rawSteps, err := adapterMessages.Render(adapterTemplateName(def.Key, "steps"), lang, data)
+		if err != nil {
+			return nil, err
+		}
+		examples = append(examples, adapterExampleResp{
+			Key:         def.Key,
+			Title:       strings.TrimSpace(title),
+			Description: strings.TrimSpace(description),
+			URL:         urls[def.Key],
+			ContentType: def.ContentType,
+			Auth:        def.Auth,
+			Steps:       splitAdapterSteps(rawSteps),
+		})
+	}
+	return examples, nil
+}
+
+func renderPublicAdapterExamples(w *IncomingWebhook, c *wkhttp.Context, webhookID, token string) []adapterExampleResp {
+	examples, err := publicAdapterExamples(webhookID, token, incomingWebhookResponseLanguage(c))
+	if err != nil {
+		w.Error("render incoming webhook adapter examples failed", zap.Error(err))
+		return []adapterExampleResp{}
+	}
+	return examples
+}
+
+func adapterTemplateName(key, part string) string {
+	return fmt.Sprintf("adapter.%s.%s", key, part)
+}
+
+func splitAdapterSteps(s string) []string {
+	lines := strings.Split(strings.TrimSpace(s), "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+func incomingWebhookResponseLanguage(c *wkhttp.Context) string {
+	def, err := octoi18n.DefaultLanguageFromEnv()
+	if err != nil {
+		def = octoi18n.DefaultLanguage
+	}
+	if c == nil || c.Request == nil {
+		return def
+	}
+	if decision, ok := octoi18n.LanguageFromContext(c.Request.Context()); ok {
+		return decision.Language
+	}
+	return octoi18n.NegotiateLanguage(c.Request, octoi18n.LanguageNegotiationOptions{
+		DefaultLanguage: def,
+	}).Language
+}

--- a/modules/incomingwebhook/adapter_catalog_test.go
+++ b/modules/incomingwebhook/adapter_catalog_test.go
@@ -1,0 +1,43 @@
+package incomingwebhook
+
+import (
+	"testing"
+
+	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdapterExamplesRenderSupportedLanguages(t *testing.T) {
+	for _, lang := range octoi18n.SupportedLanguages() {
+		t.Run(lang, func(t *testing.T) {
+			examples, err := publicAdapterExamples("iwh_abc", "deadbeef", lang)
+			require.NoError(t, err)
+
+			keys := make([]string, 0, len(examples))
+			urls := publicURLs("iwh_abc", "deadbeef")
+			for _, ex := range examples {
+				keys = append(keys, ex.Key)
+				assert.NotEmpty(t, ex.Title, "title for %s/%s", lang, ex.Key)
+				assert.NotEmpty(t, ex.Description, "description for %s/%s", lang, ex.Key)
+				assert.NotEmpty(t, ex.Steps, "steps for %s/%s", lang, ex.Key)
+				assert.Equal(t, "application/json", ex.ContentType)
+				assert.Equal(t, urls[ex.Key], ex.URL, "example URL must stay in sync with urls[%s]", ex.Key)
+			}
+			assert.Equal(t, []string{"github", "gitlab", "feishu", "multica", "wecom"}, keys)
+		})
+	}
+}
+
+func TestAdapterExamplesAreLocalized(t *testing.T) {
+	zh, err := publicAdapterExamples("iwh_abc", "deadbeef", "zh-CN")
+	require.NoError(t, err)
+	en, err := publicAdapterExamples("iwh_abc", "deadbeef", "en-US")
+	require.NoError(t, err)
+
+	require.NotEmpty(t, zh)
+	require.NotEmpty(t, en)
+	assert.Contains(t, zh[0].Description, "仓库")
+	assert.Contains(t, en[0].Description, "repository")
+	assert.NotEqual(t, zh[0].Steps[0], en[0].Steps[0])
+}

--- a/modules/incomingwebhook/adapter_push_test.go
+++ b/modules/incomingwebhook/adapter_push_test.go
@@ -44,6 +44,38 @@ func TestCreate_ReturnsAdapterURLs(t *testing.T) {
 	assert.Equal(t, native+"/multica", urls["multica"])
 }
 
+func TestCreate_ReturnsLocalizedAdapterExamples(t *testing.T) {
+	handler, _, groupNo := setupTestEnv(t)
+	w := do(handler, authReq("POST", fmt.Sprintf("/v1/groups/%s/incoming-webhooks?lang=en-US", groupNo), map[string]interface{}{
+		"name": "adapter-examples-wh",
+	}))
+	require.Equalf(t, http.StatusOK, w.Code, "create body: %s", w.Body.String())
+	created := parseJSON(t, w)
+
+	urls, ok := created["urls"].(map[string]interface{})
+	require.True(t, ok, "create response must carry urls; body=%s", w.Body.String())
+	rawExamples, ok := created["adapter_examples"].([]interface{})
+	require.True(t, ok, "create response must carry adapter_examples; body=%s", w.Body.String())
+
+	keys := make([]string, 0, len(rawExamples))
+	for _, raw := range rawExamples {
+		ex, ok := raw.(map[string]interface{})
+		require.True(t, ok, "adapter example must be object: %#v", raw)
+		key, _ := ex["key"].(string)
+		keys = append(keys, key)
+		assert.Equal(t, urls[key], ex["url"], "example URL must match urls[%s]", key)
+		assert.Equal(t, "application/json", ex["content_type"])
+		assert.NotEmpty(t, ex["title"])
+		assert.NotEmpty(t, ex["description"])
+		steps, ok := ex["steps"].([]interface{})
+		require.True(t, ok, "steps must be array for %s", key)
+		assert.NotEmpty(t, steps)
+	}
+	assert.Equal(t, []string{"github", "gitlab", "feishu", "multica", "wecom"}, keys)
+	firstDescription, _ := rawExamples[0].(map[string]interface{})["description"].(string)
+	assert.Contains(t, firstDescription, "repository")
+}
+
 // GitHub ping：200 + skipped，不投递消息，且异步记一条 status=3(skipped) 的投递。
 func TestPush_GitHubPing_SkippedAndAudited(t *testing.T) {
 	handler, _, groupNo := setupTestEnv(t)

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -488,14 +488,15 @@ func publicURL(webhookID, token string) string {
 // 与 publicURL 一样不含 host。
 func publicURLs(webhookID, token string) map[string]string {
 	base := publicURL(webhookID, token)
-	return map[string]string{
-		"native":  base,
-		"github":  base + "/github",
-		"wecom":   base + "/wecom",
-		"multica": base + "/multica",
-		"gitlab":  base + "/gitlab",
-		"feishu":  base + "/feishu",
+	urls := make(map[string]string, len(publicAdapterCatalog))
+	for _, def := range publicAdapterCatalog {
+		if def.Suffix == "" {
+			urls[def.Key] = base
+			continue
+		}
+		urls[def.Key] = base + "/" + def.Suffix
 	}
+	return urls
 }
 
 // ============================================================
@@ -835,10 +836,11 @@ func (w *IncomingWebhook) create(c *wkhttp.Context) {
 	}
 
 	resp := createResp{
-		webhookResp: toResp(m),
-		Token:       token,
-		URL:         publicURL(m.WebhookID, token),
-		URLs:        publicURLs(m.WebhookID, token),
+		webhookResp:     toResp(m),
+		Token:           token,
+		URL:             publicURL(m.WebhookID, token),
+		URLs:            publicURLs(m.WebhookID, token),
+		AdapterExamples: renderPublicAdapterExamples(w, c, m.WebhookID, token),
 	}
 	c.Response(resp)
 }
@@ -1086,10 +1088,11 @@ func (w *IncomingWebhook) regenerate(c *wkhttp.Context) {
 		return
 	}
 	c.Response(createResp{
-		webhookResp: toResp(updated),
-		Token:       token,
-		URL:         publicURL(webhookID, token),
-		URLs:        publicURLs(webhookID, token),
+		webhookResp:     toResp(updated),
+		Token:           token,
+		URL:             publicURL(webhookID, token),
+		URLs:            publicURLs(webhookID, token),
+		AdapterExamples: renderPublicAdapterExamples(w, c, webhookID, token),
 	})
 }
 

--- a/modules/incomingwebhook/model.go
+++ b/modules/incomingwebhook/model.go
@@ -56,9 +56,9 @@ type incomingWebhookModel struct {
 	// 与列名对不上导致读写静默落空。显式 `db:"mention_uids"` tag 兜底读路径：即便将来有人为
 	// 「命名一致」把字段改成 MentionUIDs，dbr Load 仍按 tag 命中列（写路径的 AttrToUnderscore 会
 	// 产出 mention_ui_ds 列名、INSERT 直接报错暴露，不会静默）。
-	MentionUids      string `db:"mention_uids"`
-	LastUsedAt       dbr.NullTime
-	CallCount        int64
+	MentionUids string `db:"mention_uids"`
+	LastUsedAt  dbr.NullTime
+	CallCount   int64
 	db.BaseModel
 }
 
@@ -193,6 +193,9 @@ type createResp struct {
 	// 拼接基础域名。token 仅在 create/regenerate 时可见，故完整推送路径也只在这两处
 	// 下发（list 不回显 token，自然也不回推送 URL）。
 	URLs map[string]string `json:"urls"`
+	// AdapterExamples 是管理端「更多适配器」的本地化接入示例。它复用 URLs 的同一组
+	// path，不含 host；仅在 token 可见的 create/regenerate 响应返回。
+	AdapterExamples []adapterExampleResp `json:"adapter_examples"`
 }
 
 // deliveryResp 是 deliveries 排障端点返回的单条投递记录（成功+失败）。绝不含 token。

--- a/modules/incomingwebhook/templates/en-US/adapter.tmpl
+++ b/modules/incomingwebhook/templates/en-US/adapter.tmpl
@@ -1,0 +1,39 @@
+{{define "adapter.github.title"}}GitHub Events{{end}}
+{{define "adapter.github.description"}}Register the following Payload URL in the GitHub repository Webhook settings; no curl wrapper is required.{{end}}
+{{define "adapter.github.steps"}}
+Open the repository -> Settings -> Webhooks -> Add webhook
+Paste the Payload URL, and set Content type to {{.ContentType}}
+Select the events to receive, such as push and pull_request, then save
+{{end}}
+
+{{define "adapter.gitlab.title"}}GitLab Events{{end}}
+{{define "adapter.gitlab.description"}}Add the following URL in the GitLab project Webhooks settings, and set Secret token to the same webhook token.{{end}}
+{{define "adapter.gitlab.steps"}}
+Open the project -> Settings -> Webhooks
+Paste the URL, and set Secret token to this webhook token
+Select the events to receive, such as push and Merge Request, then save
+{{end}}
+
+{{define "adapter.feishu.title"}}Feishu Bot Compatible{{end}}
+{{define "adapter.feishu.description"}}Compatible with Feishu custom bot payloads; replace the existing Feishu bot URL with the following URL without changing the message body.{{end}}
+{{define "adapter.feishu.steps"}}
+Open the existing Feishu custom bot configuration
+Replace the bot Webhook URL with the following URL
+Keep the existing message body and sender logic unchanged
+{{end}}
+
+{{define "adapter.multica.title"}}Multica Events{{end}}
+{{define "adapter.multica.description"}}Add the following URL in the Multica workspace Webhooks settings to receive issue status change events and related updates.{{end}}
+{{define "adapter.multica.steps"}}
+Open the Multica workspace Settings -> Webhooks
+Paste the following URL and save
+Select the issue events to receive
+{{end}}
+
+{{define "adapter.wecom.title"}}WeCom Bot Compatible{{end}}
+{{define "adapter.wecom.description"}}Compatible with WeCom custom bot payloads; replace the existing WeCom bot URL with the following URL to migrate.{{end}}
+{{define "adapter.wecom.steps"}}
+Open the existing WeCom custom bot configuration
+Replace the bot Webhook URL with the following URL
+Keep the existing message body and sender logic unchanged
+{{end}}

--- a/modules/incomingwebhook/templates/zh-CN/adapter.tmpl
+++ b/modules/incomingwebhook/templates/zh-CN/adapter.tmpl
@@ -1,0 +1,39 @@
+{{define "adapter.github.title"}}GitHub 事件{{end}}
+{{define "adapter.github.description"}}GitHub 仓库事件无需 curl，把下面这个 Payload URL 登记到仓库 Webhook 设置。{{end}}
+{{define "adapter.github.steps"}}
+进入仓库 -> Settings -> Webhooks -> Add webhook
+把 Payload URL 填入，Content type 选择 {{.ContentType}}
+勾选需要接收的事件，如 push、pull_request，保存
+{{end}}
+
+{{define "adapter.gitlab.title"}}GitLab 事件{{end}}
+{{define "adapter.gitlab.description"}}在 GitLab 项目 Webhooks 中填入下面地址，并把 Secret token 设为同一 token。{{end}}
+{{define "adapter.gitlab.steps"}}
+进入项目 -> Settings -> Webhooks
+填入 URL，并将 Secret token 设为该 webhook token
+勾选需要接收的事件，如 push、Merge Request，保存
+{{end}}
+
+{{define "adapter.feishu.title"}}飞书机器人兼容{{end}}
+{{define "adapter.feishu.description"}}兼容飞书自定义机器人格式，把现有飞书机器人 URL 换成下面地址即可迁移，消息体无需改动。{{end}}
+{{define "adapter.feishu.steps"}}
+打开已有飞书自定义机器人配置
+将机器人 Webhook URL 替换为下面地址
+保持原消息体和发送逻辑不变
+{{end}}
+
+{{define "adapter.multica.title"}}Multica 事件{{end}}
+{{define "adapter.multica.description"}}在 Multica 工作区 Webhooks 中填入下面地址，接收议题状态变更等事件。{{end}}
+{{define "adapter.multica.steps"}}
+进入 Multica 工作区 Settings -> Webhooks
+填入下面地址并保存
+选择需要接收的议题事件
+{{end}}
+
+{{define "adapter.wecom.title"}}企业微信机器人兼容{{end}}
+{{define "adapter.wecom.description"}}兼容企业微信自定义机器人格式，把现有企业微信机器人 URL 换成下面地址即可迁移。{{end}}
+{{define "adapter.wecom.steps"}}
+打开已有企业微信自定义机器人配置
+将机器人 Webhook URL 替换为下面地址
+保持原消息体和发送逻辑不变
+{{end}}


### PR DESCRIPTION
## Summary
- Add an incoming-webhook adapter catalog that drives public adapter URLs and onboarding examples from one source.
- Return localized `adapter_examples` on create/regenerate responses while keeping list responses free of token-bearing URLs.
- Add zh-CN/en-US adapter onboarding templates and update incoming webhook docs.

## Tests
- `go test ./modules/incomingwebhook -run 'TestCreate_ReturnsLocalizedAdapterExamples|TestAdapterExamplesRenderSupportedLanguages|TestAdapterExamplesAreLocalized|TestPublicURLs_HasMulticaEntry'`\n- `go test ./modules/incomingwebhook`