### PR TITLE
feat(messages_search): project richtext (type=14) detail from payloadRaw

### DIFF
--- a/modules/messages_search/richtext_projection_test.go
+++ b/modules/messages_search/richtext_projection_test.go
@@ -1,0 +1,199 @@
+package messages_search
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestBuildRichTextDetail_ArrayContent covers the modern shape: content is a
+// block array carrying text/image/file blocks plus a server-generated plain
+// string. All canonical block fields must round-trip onto the typed projection.
+func TestBuildRichTextDetail_ArrayContent(t *testing.T) {
+	raw := json.RawMessage(`{
+	  "type": 14,
+	  "content": [
+	    {"type": "text", "text": "标题"},
+	    {"type": "image", "url": "http://x/y.png", "width": 640, "height": 480, "name": "y.png", "caption": "图说"},
+	    {"type": "file", "url": "http://x/a.pdf", "name": "a.pdf", "size": 12345, "extension": "pdf", "mime": "application/pdf", "caption": "合同"}
+	  ],
+	  "plain": "标题[图片][文件]"
+	}`)
+	d := buildRichTextDetail(raw)
+	if d == nil {
+		t.Fatalf("expected non-nil detail")
+	}
+	if d.Plain != "标题[图片][文件]" {
+		t.Errorf("plain: got %q", d.Plain)
+	}
+	if got := len(d.Content); got != 3 {
+		t.Fatalf("blocks: got %d", got)
+	}
+	if d.Content[0].Type != "text" || d.Content[0].Text != "标题" {
+		t.Errorf("text block: %+v", d.Content[0])
+	}
+	img := d.Content[1]
+	if img.Type != "image" || img.URL != "http://x/y.png" || img.Width != 640 || img.Height != 480 || img.Name != "y.png" || img.Caption != "图说" {
+		t.Errorf("image block: %+v", img)
+	}
+	f := d.Content[2]
+	if f.Type != "file" || f.URL != "http://x/a.pdf" || f.Name != "a.pdf" || f.Size != 12345 || f.Extension != "pdf" || f.Mime != "application/pdf" || f.Caption != "合同" {
+		t.Errorf("file block: %+v", f)
+	}
+	if d.Mention != nil {
+		t.Errorf("mention should be nil when absent, got %+v", d.Mention)
+	}
+}
+
+// TestBuildRichTextDetail_LegacyStringContent: old payloads stored content as
+// a plain JSON string; the builder must normalise that into a single text
+// block so the renderer never sees the legacy shape.
+func TestBuildRichTextDetail_LegacyStringContent(t *testing.T) {
+	raw := json.RawMessage(`{"type":14,"content":"hello world","plain":"hello world"}`)
+	d := buildRichTextDetail(raw)
+	if d == nil {
+		t.Fatalf("nil detail")
+	}
+	if len(d.Content) != 1 {
+		t.Fatalf("blocks: got %d", len(d.Content))
+	}
+	if d.Content[0].Type != "text" || d.Content[0].Text != "hello world" {
+		t.Errorf("normalised text block: %+v", d.Content[0])
+	}
+	if d.Plain != "hello world" {
+		t.Errorf("plain: got %q", d.Plain)
+	}
+}
+
+// TestBuildRichTextDetail_EmptyRaw guards the legacy / pre-payloadRaw fail-soft
+// case: the projection must be nil so the caller falls back to snippet.
+func TestBuildRichTextDetail_EmptyRaw(t *testing.T) {
+	if d := buildRichTextDetail(nil); d != nil {
+		t.Errorf("nil raw: want nil detail, got %+v", d)
+	}
+	if d := buildRichTextDetail(json.RawMessage{}); d != nil {
+		t.Errorf("empty raw: want nil detail, got %+v", d)
+	}
+}
+
+// TestBuildRichTextDetail_InvalidJSON: corrupt envelopes must fail-soft (nil)
+// rather than surface a half-parsed detail or propagate the error.
+func TestBuildRichTextDetail_InvalidJSON(t *testing.T) {
+	if d := buildRichTextDetail(json.RawMessage(`not-json`)); d != nil {
+		t.Errorf("garbage: want nil, got %+v", d)
+	}
+	// A legacy string content that is itself unparseable as a string (e.g.
+	// content is a JSON number) must drop content but keep the envelope.
+	d := buildRichTextDetail(json.RawMessage(`{"content": 42, "plain": "p"}`))
+	if d == nil {
+		t.Fatalf("envelope-valid number-content: want non-nil")
+	}
+	if len(d.Content) != 0 {
+		t.Errorf("number content must yield empty blocks, got %+v", d.Content)
+	}
+	if d.Plain != "p" {
+		t.Errorf("plain should still pass through, got %q", d.Plain)
+	}
+}
+
+// TestBuildRichTextDetail_Mention transports the mention object verbatim, both
+// the entity slice and the three @-all flags.
+func TestBuildRichTextDetail_Mention(t *testing.T) {
+	raw := json.RawMessage(`{
+	  "content": [{"type":"text","text":"@张三 你好"}],
+	  "plain": "@张三 你好",
+	  "mention": {
+	    "entities": [{"uid":"u_zhang","offset":0,"length":3}],
+	    "all": 1, "humans": 1, "ais": 0
+	  }
+	}`)
+	d := buildRichTextDetail(raw)
+	if d == nil || d.Mention == nil {
+		t.Fatalf("expected mention, got %+v", d)
+	}
+	if len(d.Mention.Entities) != 1 {
+		t.Fatalf("entities: got %d", len(d.Mention.Entities))
+	}
+	e := d.Mention.Entities[0]
+	if e.UID != "u_zhang" || e.Offset != 0 || e.Length != 3 {
+		t.Errorf("entity: %+v", e)
+	}
+	if d.Mention.All != 1 || d.Mention.Humans != 1 || d.Mention.Ais != 0 {
+		t.Errorf("flags: %+v", d.Mention)
+	}
+}
+
+// TestSingleMessageHit_RichText covers the projection contract on the hit:
+//   - type=14 + non-empty payloadRaw → rich_text populated, snippet still set
+//   - type=14 + missing payloadRaw   → rich_text nil, snippet/text untouched
+//   - non-richtext type              → rich_text nil regardless of payloadRaw
+func TestSingleMessageHit_RichText(t *testing.T) {
+	var h Handler
+	rt := payloadTypeRichText
+	raw := json.RawMessage(`{"type":14,"content":[{"type":"text","text":"标题"}],"plain":"标题"}`)
+
+	doc := Doc{
+		MessageID:  101,
+		MessageSeq: 9,
+		Payload:    &Payload{Type: &rt, RichText: &RichTextPayload{SearchText: "标题"}},
+		PayloadRaw: raw,
+	}
+	mh := h.singleMessageHit(doc, "g", nil)
+	if mh.RichText == nil {
+		t.Fatalf("rich_text must be populated for type=14 + payloadRaw")
+	}
+	if len(mh.RichText.Content) != 1 || mh.RichText.Content[0].Text != "标题" {
+		t.Errorf("rich_text.content: %+v", mh.RichText.Content)
+	}
+	if mh.RichText.Plain != "标题" {
+		t.Errorf("rich_text.plain: %q", mh.RichText.Plain)
+	}
+	// Snippet fallback still runs — searchText feeds fallbackSnippet so the
+	// hit is renderable even on a client that ignores rich_text.
+	if mh.Snippet != "标题" {
+		t.Errorf("snippet fallback should still emit searchText, got %q", mh.Snippet)
+	}
+	if mh.MessageKind != "text" {
+		t.Errorf("kind should fold into text, got %q", mh.MessageKind)
+	}
+
+	// Legacy doc indexed before payloadRaw existed: fail-soft to nil.
+	docNoRaw := Doc{
+		MessageID: 102,
+		Payload:   &Payload{Type: &rt, RichText: &RichTextPayload{SearchText: "标题"}},
+	}
+	mhNoRaw := h.singleMessageHit(docNoRaw, "g", nil)
+	if mhNoRaw.RichText != nil {
+		t.Errorf("missing payloadRaw must yield nil rich_text, got %+v", mhNoRaw.RichText)
+	}
+	if mhNoRaw.Snippet != "标题" {
+		t.Errorf("snippet fallback must still fire on legacy doc, got %q", mhNoRaw.Snippet)
+	}
+
+	// Non-richtext docs must never carry rich_text, even if a stray payloadRaw
+	// blob is present on the source.
+	tp := payloadTypeText
+	docText := Doc{
+		MessageID:  103,
+		Payload:    &Payload{Type: &tp, Text: &TextPayload{Content: "hi"}},
+		PayloadRaw: raw,
+	}
+	mhText := h.singleMessageHit(docText, "g", nil)
+	if mhText.RichText != nil {
+		t.Errorf("non-richtext type must not project rich_text, got %+v", mhText.RichText)
+	}
+}
+
+// TestMessageHit_RichTextOmitemptyOnWire pins the wire contract: rich_text
+// must NOT appear on plain text hits (otherwise old clients see an unexpected
+// field on every response).
+func TestMessageHit_RichTextOmitemptyOnWire(t *testing.T) {
+	mh := MessageHit{MessageID: "1", MessageKind: "text", SenderID: "u"}
+	out, err := json.Marshal(mh)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(out), `"rich_text"`) {
+		t.Errorf("nil rich_text must be omitted on the wire, got %s", string(out))
+	}
+}

--- a/modules/messages_search/search_messages.go
+++ b/modules/messages_search/search_messages.go
@@ -36,6 +36,12 @@ type MessageHit struct {
 	Width           int            `json:"width,omitempty"`
 	Height          int            `json:"height,omitempty"`
 	DurationMs      int64          `json:"duration_ms,omitempty"`
+	// RichText is the typed projection of a payload.type=14 rich-text message,
+	// emitted only when the hit is rich-text AND the indexer preserved
+	// `_source.payloadRaw`. Older docs (pre-payloadRaw indexer) leave it nil,
+	// in which case the client renders the existing snippet/text fallback.
+	// Non-richtext hits never carry this field.
+	RichText *RichTextDetail `json:"rich_text,omitempty"`
 }
 
 func init() {
@@ -267,6 +273,13 @@ func (h *Handler) singleMessageHit(doc Doc, reqChannelID string, hl map[string][
 		ChannelID:     encodeChannelID(reqChannelID),
 	}
 	applyMediaProjection(&mh, doc.Payload)
+	// Rich-text projection runs as an additive layer: message_kind stays "text"
+	// (the swagger enum is locked at ["text","forward"]) and snippet remains
+	// the highlight/text fallback. A non-nil rich_text signals the client to
+	// render via the structured pipeline; nil falls back to snippet.
+	if payloadType(doc.Payload) == payloadTypeRichText {
+		mh.RichText = buildRichTextDetail(doc.PayloadRaw)
+	}
 	return mh
 }
 

--- a/modules/messages_search/source.go
+++ b/modules/messages_search/source.go
@@ -1,6 +1,9 @@
 package messages_search
 
-import "strconv"
+import (
+	"encoding/json"
+	"strconv"
+)
 
 // Doc mirrors the OpenSearch `_source` shape produced by
 // wukongim-message-indexer (see indexer-os-changes.md §3.2). We only
@@ -63,6 +66,15 @@ type Doc struct {
 	// indexer write — see CONSTRAINTS-2026-06-12 for the transient
 	// fail-open while the field is unwritten.
 	Visibles []string `json:"visibles,omitempty"`
+	// PayloadRaw carries the indexer-preserved original message payload blob
+	// (wukongim-message-indexer writes the full source payload under
+	// `_source.payloadRaw` with mapping `enabled:false`, see indexer
+	// transform/doc.go). It is only consumed by the typed rich-text (type=14)
+	// projection in buildRichTextDetail — the legacy structured `payload.*`
+	// fields above stay authoritative for everything else. Absent on docs
+	// indexed before the indexer started writing the field; downstream
+	// projectors must fail-soft (nil RichText, snippet fallback) in that case.
+	PayloadRaw json.RawMessage `json:"payloadRaw,omitempty"`
 }
 
 // Payload is the structured projection of the message payload. Each typed
@@ -219,6 +231,97 @@ func payloadType(p *Payload) int {
 		return 0
 	}
 	return *p.Type
+}
+
+// RichTextBlock mirrors a single block in a payload.type=14 rich-text
+// message's `content[]`. The JSON tags are aligned with octo-web's
+// RichTextContent.ts / octo-lib common/richtext.go so the search projection
+// returns the same shape the existing channel/sync renderer already consumes.
+// Image/file-specific fields (extension/mime/caption) follow the octo-web
+// schema which extends octo-lib's MVP shape; unknown / unused fields stay
+// omitempty so unrelated block types serialise to the minimal `{type,text}`
+// or `{type,url,...}` form.
+type RichTextBlock struct {
+	Type      string `json:"type"`
+	Text      string `json:"text,omitempty"`
+	URL       string `json:"url,omitempty"`
+	Width     int    `json:"width,omitempty"`
+	Height    int    `json:"height,omitempty"`
+	Size      int64  `json:"size,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Extension string `json:"extension,omitempty"`
+	Mime      string `json:"mime,omitempty"`
+	Caption   string `json:"caption,omitempty"`
+}
+
+// RichTextMentionEntity is one @-mention anchor inside a text block, used by
+// the renderer to highlight the matching `[offset, offset+length)` rune range
+// of the surrounding text.
+type RichTextMentionEntity struct {
+	UID    string `json:"uid"`
+	Offset int    `json:"offset"`
+	Length int    `json:"length"`
+}
+
+// RichTextMention is the payload.mention object: per-user entities plus the
+// three @-all tri-state flags (all / humans / ais). Whole object is optional
+// and missing when the message has no @ mentions.
+type RichTextMention struct {
+	Entities []RichTextMentionEntity `json:"entities,omitempty"`
+	All      int                     `json:"all,omitempty"`
+	Humans   int                     `json:"humans,omitempty"`
+	Ais      int                     `json:"ais,omitempty"`
+}
+
+// RichTextDetail is the typed projection of a rich-text payload exposed under
+// MessageHit.rich_text. Shape matches the channel/sync payload contract so the
+// client can render search hits with the same components as the timeline.
+type RichTextDetail struct {
+	Content []RichTextBlock  `json:"content"`
+	Plain   string           `json:"plain,omitempty"`
+	Mention *RichTextMention `json:"mention,omitempty"`
+}
+
+// buildRichTextDetail extracts the rich-text projection from the indexer's
+// preserved `_source.payloadRaw` blob. Caller must guard with
+// payloadType(...) == payloadTypeRichText — this function does not re-check.
+//
+// Fail-soft contract: returns nil for the empty / unparseable / pre-payloadRaw
+// cases so the caller silently falls back to the existing snippet path:
+//
+//   - raw == nil / len(raw)==0  → nil  (legacy doc indexed before the field)
+//   - json.Unmarshal fails      → nil  (corrupt or unexpected envelope)
+//
+// Backwards compatibility: the rich-text payload's `content` was historically a
+// plain JSON string. New payloads emit an array of RichTextBlock. We branch on
+// the first non-space byte ('[' = array, anything else = string) and normalise
+// the legacy string form into a single `{type:"text", text:<s>}` block. Empty
+// strings collapse to a nil Content slice so the renderer doesn't get a
+// `{type:"text", text:""}` ghost block.
+func buildRichTextDetail(raw json.RawMessage) *RichTextDetail {
+	if len(raw) == 0 {
+		return nil
+	}
+	var p struct {
+		Content json.RawMessage  `json:"content"`
+		Plain   string           `json:"plain"`
+		Mention *RichTextMention `json:"mention"`
+	}
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil
+	}
+	d := &RichTextDetail{Plain: p.Plain, Mention: p.Mention}
+	if len(p.Content) > 0 {
+		if p.Content[0] == '[' {
+			_ = json.Unmarshal(p.Content, &d.Content)
+		} else {
+			var s string
+			if json.Unmarshal(p.Content, &s) == nil && s != "" {
+				d.Content = []RichTextBlock{{Type: "text", Text: s}}
+			}
+		}
+	}
+	return d
 }
 
 // InnerMessage is the per-child shape surfaced under MessageHit.inner_messages

--- a/modules/messages_search/swagger/api.yaml
+++ b/modules/messages_search/swagger/api.yaml
@@ -541,6 +541,15 @@ definitions:
           Only present when message_kind="video" — i.e. on /_search_all
           browse mode (no keyword) and /_search_around video hits. Omitted
           on image / text / forward hits.
+      rich_text:
+        $ref: "#/definitions/RichTextDetail"
+        description: |
+          Typed projection of a payload.type=14 rich-text message, extracted
+          from the indexer-preserved `_source.payloadRaw` blob. Emitted ONLY
+          when the hit is rich-text AND payloadRaw is present; older docs
+          (indexed before the field existed) leave it absent and the client
+          falls back to `snippet`. message_kind stays "text" on rich-text
+          hits so the swagger enum is unchanged.
 
   MediaHit:
     type: object
@@ -636,6 +645,114 @@ definitions:
         $ref: "#/definitions/MessageHit"
       file:
         $ref: "#/definitions/FileHit"
+
+  RichTextDetail:
+    type: object
+    description: |
+      Typed projection of a payload.type=14 rich-text message payload,
+      mirroring the channel/sync rendering contract. Returned under
+      MessageHit.rich_text on rich-text hits whose OS source preserved the
+      original `payloadRaw` blob.
+    required:
+      - content
+    properties:
+      content:
+        type: array
+        description: |
+          Ordered blocks (text / image / file). Block order is the rendered
+          interleave order. Legacy docs with a string `content` are normalised
+          into a single `{type:"text", text:<s>}` block server-side.
+        items:
+          $ref: "#/definitions/RichTextBlock"
+      plain:
+        type: string
+        description: |
+          Server-authoritative plain-text projection of the blocks (with
+          `[图片]` / `[文件]` placeholders), used for quote previews, copy
+          fallback, summarisation, etc. Distinct from the search-side
+          `snippet` — `snippet` is the highlight fragment, `plain` is the
+          payload's own plain string.
+      mention:
+        $ref: "#/definitions/RichTextMention"
+
+  RichTextBlock:
+    type: object
+    required:
+      - type
+    properties:
+      type:
+        type: string
+        description: |
+          Block kind. "text" / "image" / "file" today; renderers must tolerate
+          unknown values (forward-compatible — future block kinds may appear
+          without an API bump).
+      text:
+        type: string
+        description: "Text content (text block)."
+      url:
+        type: string
+        description: |
+          Resource reference (image src / file download). Passed through
+          verbatim from the payload — clients are responsible for resolving it
+          via the auth-aware file URL pipeline.
+      width:
+        type: integer
+        description: "Image width in pixels (image block)."
+      height:
+        type: integer
+        description: "Image height in pixels (image block)."
+      size:
+        type: integer
+        format: int64
+        description: "File size in bytes (file block; optional on image)."
+      name:
+        type: string
+        description: "Original filename / image alt text."
+      extension:
+        type: string
+        description: "File extension (file block) for icon / badge rendering."
+      mime:
+        type: string
+        description: "MIME type (file block, forward-compat)."
+      caption:
+        type: string
+        description: "Inline caption for image / file blocks."
+
+  RichTextMention:
+    type: object
+    description: |
+      @-mention metadata for a rich-text message. Absent when the payload
+      carries no mentions.
+    properties:
+      entities:
+        type: array
+        items:
+          $ref: "#/definitions/RichTextMentionEntity"
+      all:
+        type: integer
+        description: "Legacy @-all flag (compat with the per-channel @all)."
+      humans:
+        type: integer
+        description: "@all-humans tri-state flag."
+      ais:
+        type: integer
+        description: "@all-AIs tri-state flag."
+
+  RichTextMentionEntity:
+    type: object
+    required:
+      - uid
+      - offset
+      - length
+    properties:
+      uid:
+        type: string
+      offset:
+        type: integer
+        description: "Rune offset into the surrounding text block."
+      length:
+        type: integer
+        description: "Rune length of the @-anchor in the surrounding text."
 
   CursorList_MessageHit:
     type: object


### PR DESCRIPTION
## Summary

Project type=14 rich-text messages into search hits so that
`/v1/messages/_search`, `_search_all`, and `_search_around` return the same
structured shape that `api/v1/message/channel/sync` does — letting octo-web
render images, files, and `@`-mention highlights inside search results
instead of falling back to plain `snippet`.

The data was always there — `wukongim-message-indexer` writes the full
original payload to `_source.payloadRaw` (mapping is `enabled: false`, so it
is preserved in `_source` but not indexed) and the search queries already
fetch the full `_source`. The only missing piece was a typed projection in
octo-server's `MessageHit` response shape. This PR adds it as a purely
additive field — no schema change to existing fields, no re-indexing, no ES
query changes, no new dependencies.

## Related Issue

#476 

## Linked Spec

Design doc (local): `/tmp/octo-server-richtext-search-design.md` (Option A —
typed projection).

## Changes

- **`modules/messages_search/source.go`**
  - `Doc.PayloadRaw json.RawMessage` — captures the existing
    `_source.payloadRaw` blob that was previously dropped by `Doc`'s
    unmarshal.
  - New types mirroring octo-web `RichTextContent.ts` /
    octo-lib `common/richtext.go`: `RichTextBlock`, `RichTextMentionEntity`,
    `RichTextMention`, `RichTextDetail`.
  - `buildRichTextDetail(raw)` — extracts `content` / `plain` / `mention`
    from `payloadRaw`. Handles three legacy/edge cases:
    - empty or invalid JSON → returns `nil` (fail-soft, snippet fallback)
    - `content` as array → typed `[]RichTextBlock`
    - `content` as bare string (older payloads) → normalized to a single
      `{Type:"text", Text:s}` block
- **`modules/messages_search/search_messages.go`**
  - `MessageHit.RichText *RichTextDetail` (`json:"rich_text,omitempty"`).
  - `singleMessageHit` invokes `buildRichTextDetail(doc.PayloadRaw)` only
    when `payloadType(doc.Payload) == payloadTypeRichText`. Independent of
    the existing `applyMediaProjection` (media fires on type=2/5,
    rich-text fires on type=14).
  - `_search_all` and `_search_around` inherit the projection automatically
    because they call through `singleMessageHit`.
- **`modules/messages_search/swagger/api.yaml`**
  - Added `MessageHit.rich_text` property.
  - Added 4 new schemas: `RichTextDetail`, `RichTextBlock`, `RichTextMention`,
    `RichTextMentionEntity`.
- **`modules/messages_search/richtext_projection_test.go`** (new)
  - `buildRichTextDetail`: array `content`, legacy string `content`, empty
    raw, invalid JSON, with `mention`.
  - `singleMessageHit`: type=14 + `payloadRaw` → populated `rich_text`;
    type=14 without `payloadRaw` → `nil` + `snippet` fallback unchanged;
    non-rich-text types → no `rich_text` emitted.
  - `omitempty` serialization verified.

Net diff: +433 / −1 across 4 files.

## Testing

```
go build ./...                           # clean
go vet ./...                             # clean
go test ./modules/messages_search/...    # ok ~0.043s
make i18n-extract-check                  # passed
make i18n-lint                           # OK: no new direct error responses
                                         # OK: no inline codes
```

- [x] Unit tests added (`richtext_projection_test.go`, 6 cases covering happy
      path, legacy string content, missing `payloadRaw`, invalid JSON,
      mention pass-through, and the `singleMessageHit` projection branch).
- [x] Build / vet / package tests green.
- [ ] Manual end-to-end against `dmwork-test/dmworkim-develop` (recommended
      before merge — search a known type=14 message and confirm
      `rich_text.content` matches `channel/sync`).

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   On every search hit assembly (`/v1/messages/_search`, `_search_all`,
   `_search_around` all route through `singleMessageHit`) we do one extra
   `payloadType == payloadTypeRichText` check; on a hit we `json.Unmarshal`
   the already-fetched `payloadRaw` once into the typed projection struct.
   Net wire-format change: one additional `rich_text` object on rich-text
   hits; every other field is byte-identical. No new ES round-trips, no new
   DB round-trips, no DSL changes.

2. **What could break because of it (dependents + failure mode)?**

   - **Older documents** that pre-date the indexer writing `payloadRaw` →
     `rich_text` is `nil`, the field is omitted via `omitempty`, and the
     front-end falls back to the existing `snippet` path. No behavior
     change for legacy hits. (No backfill required; re-indexing optional.)
   - **Malformed `payloadRaw`** (shouldn't happen given indexer writes the
     raw bytes, but defensive): `buildRichTextDetail` returns `nil` → same
     fallback as above. No panic, no error propagated up the stack.
   - **Response size** grows on type=14 hits proportionally to the rich-text
     content (images / files contribute URLs, not bytes). Acceptable for
     the foreseeable hit-count cap; if it becomes a concern we can add an
     `include=rich_text` opt-in flag without breaking anything.
   - **Front-end** that doesn't yet know `rich_text`: ignores the field
     and continues using `snippet`. Strict additive change.
   - **Swagger consumers**: the four new schemas are additive; the existing
     `MessageHit` properties / `message_kind` enum are unchanged.

3. **How do you know it works (specific test/repro/trace)?**

   - `TestBuildRichTextDetail_*` covers the parser branches (array content,
     legacy string content, missing raw, invalid JSON, mention).
   - `TestSingleMessageHit_RichText*` exercises the projection wiring: a
     type=14 hit with `payloadRaw` returns a populated `rich_text`; the same
     hit without `payloadRaw` returns `rich_text: nil` and the legacy
     `snippet` path is unaffected; non-rich-text hits never carry the
     field.
   - All packages still build and `go vet` clean; `make i18n-*` linters
     pass. Recommended manual verification: pick one real type=14 message
     in `dmwork-test`, hit `/v1/messages/_search`, and diff
     `rich_text.content` against the corresponding
     `api/v1/message/channel/sync` payload field-by-field.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (swagger)
- [x] Followed commit message conventions (Conventional Commits)

Closes #476 