### PR TITLE
test(group): trace invite-members latency with per-segment timing + trace_id

### DIFF
--- a/main.go
+++ b/main.go
@@ -151,7 +151,7 @@ func runAPI(ctx *config.Context) {
 	// token parser 读）。让 GIN access log / token 解析 / handler / service 四条
 	// 分段慢日志能按 trace_id 串到同一次请求。复用入站 X-Request-ID（若有）。
 	route.UseGin(func(c *gin.Context) {
-		id := strings.TrimSpace(c.GetHeader("X-Request-ID"))
+		id := reqid.Sanitize(c.GetHeader("X-Request-ID"))
 		if id == "" {
 			id = reqid.New()
 		}

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/Mininglamp-OSS/octo-server/pkg/metrics"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	"github.com/Mininglamp-OSS/octo-server/pkg/reqid"
 	"github.com/gin-gonic/gin"
 	rd "github.com/go-redis/redis"
 	"github.com/judwhite/go-svc"
@@ -145,6 +146,20 @@ func runAPI(ctx *config.Context) {
 	if err != nil {
 		panic(err)
 	}
+	// trace_id 中间件（最前）：为每次请求生成/透传一个 trace_id，写进 gin.Context
+	// （供 access-log formatter 与 handler 读）和 request context（供 pkg/auth 的
+	// token parser 读）。让 GIN access log / token 解析 / handler / service 四条
+	// 分段慢日志能按 trace_id 串到同一次请求。复用入站 X-Request-ID（若有）。
+	route.UseGin(func(c *gin.Context) {
+		id := strings.TrimSpace(c.GetHeader("X-Request-ID"))
+		if id == "" {
+			id = reqid.New()
+		}
+		c.Set(reqid.GinKey, id)
+		c.Request = c.Request.WithContext(reqid.WithTraceID(c.Request.Context(), id))
+		c.Writer.Header().Set("X-Request-ID", id)
+		c.Next()
+	})
 	route.UseGin(octoi18n.EarlyMiddleware(octoi18n.MiddlewareOptions{
 		DefaultLanguage:        defaultLanguage,
 		TrustedLangHeaderCIDRs: trustedLangCIDRs,

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -996,10 +996,16 @@ func (g *Group) memberAdd(c *wkhttp.Context) {
 	// 一次往返，单独计时。pre_checks 各步的 *_ms 是「取连接 + 执行」之和；本探针把
 	// 「取连接」这一段单拎出来——若 conn_acquire_ms 很小但 get_group_ms 等仍大，说明
 	// 慢在查询执行；若本探针本身就大，说明慢在连接获取 / 复用到被服务端掐死的连接后重连。
+	var connProbeErr string
 	if sqlDB := g.ctx.DB().Connection.DB; sqlDB != nil {
 		tProbe := time.Now()
-		if conn, cErr := sqlDB.Conn(c.Request.Context()); cErr == nil {
-			_ = conn.PingContext(c.Request.Context())
+		conn, cErr := sqlDB.Conn(c.Request.Context())
+		if cErr != nil {
+			connProbeErr = cErr.Error()
+		} else {
+			if pErr := conn.PingContext(c.Request.Context()); pErr != nil {
+				connProbeErr = pErr.Error()
+			}
 			_ = conn.Close() // 归还连接池
 		}
 		connAcquireMs = time.Since(tProbe).Milliseconds()
@@ -1174,6 +1180,7 @@ func (g *Group) memberAdd(c *wkhttp.Context) {
 			zap.Int("requested", len(req.Members)),
 			zap.Int64("pre_checks_ms", preChecksMs),
 			zap.Int64("conn_acquire_ms", connAcquireMs),
+			zap.String("conn_probe_err", connProbeErr),
 			zap.Int64("get_group_ms", getGroupMs),
 			zap.Int64("exist_member_ms", existMemberMs),
 			zap.Int64("bot_ownership_ms", botOwnerMs),

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	"github.com/Mininglamp-OSS/octo-server/pkg/reqid"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"github.com/gin-gonic/gin"
@@ -974,7 +975,9 @@ func (g *Group) memberAdd(c *wkhttp.Context) {
 		appConfigMs   int64
 		botSpaceMs    int64
 		preChecksMs   int64
+		connAcquireMs int64
 	)
+	traceID := c.GetString(reqid.GinKey)
 	operator := c.MustGet("uid").(string)
 	operatorName := c.MustGet("name").(string)
 	var req memberAddReq
@@ -988,6 +991,20 @@ func (g *Group) memberAdd(c *wkhttp.Context) {
 		return
 	}
 	groupNo := c.Param("group_no")
+
+	// 连接获取探针（邀请慢二级定位）：显式从连接池取一条连接并 PingContext 强制
+	// 一次往返，单独计时。pre_checks 各步的 *_ms 是「取连接 + 执行」之和；本探针把
+	// 「取连接」这一段单拎出来——若 conn_acquire_ms 很小但 get_group_ms 等仍大，说明
+	// 慢在查询执行；若本探针本身就大，说明慢在连接获取 / 复用到被服务端掐死的连接后重连。
+	if sqlDB := g.ctx.DB().Connection.DB; sqlDB != nil {
+		tProbe := time.Now()
+		if conn, cErr := sqlDB.Conn(c.Request.Context()); cErr == nil {
+			_ = conn.PingContext(c.Request.Context())
+			_ = conn.Close() // 归还连接池
+		}
+		connAcquireMs = time.Since(tProbe).Milliseconds()
+	}
+
 	/**
 	判断群是否存在
 	**/
@@ -1118,6 +1135,7 @@ func (g *Group) memberAdd(c *wkhttp.Context) {
 		Members:      req.Members,
 		OperatorUID:  operator,
 		OperatorName: operatorName,
+		TraceID:      traceID,
 	})
 	if err != nil {
 		// AddGroupMembers 会返回业务拒绝（如 allow_external=0 群里普通成员邀请
@@ -1150,10 +1168,12 @@ func (g *Group) memberAdd(c *wkhttp.Context) {
 	// bot_space 分摊，定位「埋点之外那 ~4.5s」到底卡在哪一步。
 	if handlerTotalMs := time.Since(handlerStart).Milliseconds(); handlerTotalMs >= inviteSlowLogThresholdMS {
 		g.Warn("邀请成员 handler 链路耗时偏高",
+			zap.String("trace_id", traceID),
 			zap.String("group_no", groupNo),
 			zap.String("operator", operator),
 			zap.Int("requested", len(req.Members)),
 			zap.Int64("pre_checks_ms", preChecksMs),
+			zap.Int64("conn_acquire_ms", connAcquireMs),
 			zap.Int64("get_group_ms", getGroupMs),
 			zap.Int64("exist_member_ms", existMemberMs),
 			zap.Int64("bot_ownership_ms", botOwnerMs),

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -966,6 +966,7 @@ type AddGroupMembersServiceReq struct {
 	Members      []string // 待添加成员 UID 列表
 	OperatorUID  string   // 操作者 UID
 	OperatorName string   // 操作者名称
+	TraceID      string   // 请求级 trace_id（reqid），用于串联 handler/service/auth/GIN 分段慢日志
 }
 
 // AddGroupMembersServiceResp 添加群成员响应
@@ -1338,8 +1339,19 @@ func (s *Service) AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMemb
 	// 配合事务提交点与各 WuKongIM 调用的分段计时，区分 DB 阶段 vs IM 阶段。
 	startedAt := time.Now()
 
+	// db_ms 细分（邀请慢二级定位）：
+	//   query_ms   = 事务前的只读查询（群 / 用户 / 已存在成员 / 黑名单）累加；
+	//   genseq_ms  = GenSeq 累加——进程级 seqLock 全局锁 + 步长耗尽时查/写 seq 表，
+	//                锁竞争或 seq 表 I/O 慢会集中体现在这里；
+	//   insert_ms  = 事务内 ExistMemberDelete + Insert/recover + 外部群标记累加；
+	//   commit_ms  = tx.Commit()，含半同步复制等待 slave ACK。
+	// 四者 + space_check_ms 拼出 db_ms，定位 DB 阶段慢在读 / 取号 / 写 / 提交哪一段。
+	var queryMs, genSeqMs, insertMs, commitMs int64
+
 	// 群存在性 + 状态检查
+	qStart := time.Now()
 	groupModel, err := s.db.QueryWithGroupNo(req.GroupNo)
+	queryMs += time.Since(qStart).Milliseconds()
 	if err != nil {
 		s.Error("query group failed", zap.Error(err))
 		return nil, errors.New("failed to query group")
@@ -1401,14 +1413,18 @@ func (s *Service) AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMemb
 	spaceCheckMs := time.Since(spaceCheckStart).Milliseconds()
 
 	// 查询用户信息
+	qStart = time.Now()
 	memberUsers, err := s.userDB.QueryByUIDs(uniqueUIDs)
+	queryMs += time.Since(qStart).Milliseconds()
 	if err != nil {
 		s.Error("query member info failed", zap.Error(err))
 		return nil, errors.New("failed to query member info")
 	}
 
 	// 过滤已在群内的成员
+	qStart = time.Now()
 	existingMembers, err := s.db.QueryMembersWithUids(uniqueUIDs, req.GroupNo)
+	queryMs += time.Since(qStart).Milliseconds()
 	if err != nil {
 		s.Error("query existing members failed", zap.Error(err))
 		return nil, errors.New("failed to query existing members")
@@ -1421,7 +1437,9 @@ func (s *Service) AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMemb
 	}
 
 	// 过滤黑名单
+	qStart = time.Now()
 	blacklistMembers, _ := s.db.QueryMembersWithStatus(req.GroupNo, int(common.GroupMemberStatusBlacklist))
+	queryMs += time.Since(qStart).Milliseconds()
 	blacklistSet := make(map[string]bool)
 	for _, m := range blacklistMembers {
 		blacklistSet[m.UID] = true
@@ -1446,7 +1464,9 @@ func (s *Service) AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMemb
 		if existingSet[memberUser.UID] || blacklistSet[memberUser.UID] {
 			continue
 		}
+		genStart := time.Now()
 		memberVersion, err := s.ctx.GenSeq(common.GroupMemberSeqKey)
+		genSeqMs += time.Since(genStart).Milliseconds()
 		if err != nil {
 			s.Error("generate member version failed", zap.Error(err))
 			return nil, err
@@ -1460,6 +1480,7 @@ func (s *Service) AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMemb
 		}
 
 		// 检查是否之前被删除过（需要恢复）
+		insStart := time.Now()
 		existDelete, _ := s.db.ExistMemberDelete(memberUser.UID, req.GroupNo)
 		newMember := &MemberModel{
 			GroupNo:       req.GroupNo,
@@ -1478,6 +1499,7 @@ func (s *Service) AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMemb
 		} else {
 			err = s.db.InsertMemberTx(newMember, tx)
 		}
+		insertMs += time.Since(insStart).Milliseconds()
 		if err != nil {
 			s.Error("add group member failed", zap.Error(err), zap.String("uid", memberUser.UID))
 			continue
@@ -1496,7 +1518,10 @@ func (s *Service) AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMemb
 	// 首次出现外部成员时，在事务内将群标记为外部群，确保成员/群标记一致提交
 	markedExternal := false
 	if hasNewExternal && groupModel.IsExternalGroup == 0 {
-		if updateErr := s.db.UpdateIsExternalGroupTx(req.GroupNo, 1, tx); updateErr != nil {
+		updStart := time.Now()
+		updateErr := s.db.UpdateIsExternalGroupTx(req.GroupNo, 1, tx)
+		insertMs += time.Since(updStart).Milliseconds()
+		if updateErr != nil {
 			s.Error("update is_external_group failed", zap.Error(updateErr), zap.String("group_no", req.GroupNo))
 			return nil, errors.New("failed to update external group flag")
 		}
@@ -1504,8 +1529,11 @@ func (s *Service) AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMemb
 	}
 
 	// 提交事务
-	if err := tx.Commit(); err != nil {
-		s.Error("commit transaction failed", zap.Error(err))
+	commitStart := time.Now()
+	commitErr := tx.Commit()
+	commitMs = time.Since(commitStart).Milliseconds()
+	if commitErr != nil {
+		s.Error("commit transaction failed", zap.Error(commitErr))
 		return nil, errors.New("failed to commit transaction")
 	}
 	// 事务（GenSeq + insert/recover + commit）耗时。
@@ -1584,12 +1612,17 @@ func (s *Service) AddGroupMembers(req *AddGroupMembersServiceReq) (*AddGroupMemb
 	total := time.Since(startedAt)
 	if total.Milliseconds() >= inviteSlowLogThresholdMS {
 		s.Warn("邀请成员入群链路耗时偏高",
+			zap.String("trace_id", req.TraceID),
 			zap.String("group_no", req.GroupNo),
 			zap.String("operator", req.OperatorUID),
 			zap.Int("requested", len(req.Members)),
 			zap.Int("added", len(addedUIDs)),
 			zap.Int64("db_ms", dbDur.Milliseconds()),
 			zap.Int64("space_check_ms", spaceCheckMs),
+			zap.Int64("query_ms", queryMs),
+			zap.Int64("genseq_ms", genSeqMs),
+			zap.Int64("insert_ms", insertMs),
+			zap.Int64("commit_ms", commitMs),
 			zap.Int64("tx_ms", txMs),
 			zap.Int64("channel_update_ms", channelUpdateDur.Milliseconds()),
 			zap.Int64("im_add_subscriber_ms", imSubscriberDur.Milliseconds()),

--- a/pkg/accesslog/accesslog.go
+++ b/pkg/accesslog/accesslog.go
@@ -128,16 +128,22 @@ func Formatter(param gin.LogFormatterParams) string {
 		param.Latency = param.Latency.Truncate(time.Second)
 	}
 	// trace_id 串联同一次请求的各分段慢日志(auth/handler/service);由 reqid
-	// 中间件写入 gin.Context,经 param.Keys 透出。缺失时留空,不影响原格式。
+	// 中间件写入 gin.Context,经 param.Keys 透出。
+	// 追加在行尾(path 之后)而非插在中间:保持原有按 `|` 分列的位置不变,避免
+	// 破坏任何按列解析的下游日志管道(PR#479 F1)。缺失时整段省略。
 	traceID, _ := param.Keys[reqid.GinKey].(string)
-	return fmt.Sprintf("[GIN] %v |%s %3d %s| %13v | %15s | trace_id=%s |%s %-7s %s %#v\n%s",
+	traceSuffix := ""
+	if traceID != "" {
+		traceSuffix = " | trace_id=" + traceID
+	}
+	return fmt.Sprintf("[GIN] %v |%s %3d %s| %13v | %15s |%s %-7s %s %#v%s\n%s",
 		param.TimeStamp.Format("2006/01/02 - 15:04:05"),
 		statusColor, param.StatusCode, resetColor,
 		param.Latency,
 		param.ClientIP,
-		traceID,
 		methodColor, param.Method, resetColor,
 		ScrubPath(param.Path),
+		traceSuffix,
 		param.ErrorMessage,
 	)
 }

--- a/pkg/accesslog/accesslog.go
+++ b/pkg/accesslog/accesslog.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-server/pkg/reqid"
 	"github.com/gin-gonic/gin"
 )
 
@@ -126,11 +127,15 @@ func Formatter(param gin.LogFormatterParams) string {
 	if param.Latency > time.Minute {
 		param.Latency = param.Latency.Truncate(time.Second)
 	}
-	return fmt.Sprintf("[GIN] %v |%s %3d %s| %13v | %15s |%s %-7s %s %#v\n%s",
+	// trace_id 串联同一次请求的各分段慢日志(auth/handler/service);由 reqid
+	// 中间件写入 gin.Context,经 param.Keys 透出。缺失时留空,不影响原格式。
+	traceID, _ := param.Keys[reqid.GinKey].(string)
+	return fmt.Sprintf("[GIN] %v |%s %3d %s| %13v | %15s | trace_id=%s |%s %-7s %s %#v\n%s",
 		param.TimeStamp.Format("2006/01/02 - 15:04:05"),
 		statusColor, param.StatusCode, resetColor,
 		param.Latency,
 		param.ClientIP,
+		traceID,
 		methodColor, param.Method, resetColor,
 		ScrubPath(param.Path),
 		param.ErrorMessage,

--- a/pkg/auth/parser.go
+++ b/pkg/auth/parser.go
@@ -4,11 +4,34 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/cache"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/reqid"
+	"go.uber.org/zap"
 )
+
+// authSlowLog 仅在 token 解析整体耗时超阈值时打一行，定位 AuthMiddleware 在
+// 「~3.3s 中间件缺口」里的占比：token_ms=Cache.Get(Redis)、lang_ms=语言 resolver
+// （热缓存→DB）、role_ms=角色 resolver（热缓存→DB）。正常请求不打日志。
+var authSlowLog = log.NewTLog("authParser")
+
+// authSlowLogThresholdMS 慢阈值（毫秒），env DM_AUTH_SLOWLOG_MS 可调，默认 200ms。
+var authSlowLogThresholdMS = parseAuthSlowLogThresholdMS()
+
+func parseAuthSlowLogThresholdMS() int64 {
+	if v := strings.TrimSpace(os.Getenv("DM_AUTH_SLOWLOG_MS")); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 200
+}
 
 // LanguageResolver hydrates UserInfo.Language with the freshest user-language
 // preference (Redis cache → DB → ""). It is intentionally a tiny interface
@@ -101,7 +124,11 @@ func (p *CacheTokenParser) Parse(ctx context.Context, token string) (wkhttp.User
 	if strings.TrimSpace(token) == "" {
 		return wkhttp.UserInfo{}, wkhttp.ErrTokenMissing
 	}
+	parseStart := time.Now()
+	var tokenMs, langMs, roleMs int64
+	tokenStart := time.Now()
 	raw, err := p.Cache.Get(p.Prefix + token)
+	tokenMs = time.Since(tokenStart).Milliseconds()
 	if err != nil {
 		return wkhttp.UserInfo{}, fmt.Errorf("auth: load token from cache: %w", err)
 	}
@@ -131,7 +158,9 @@ func (p *CacheTokenParser) Parse(ctx context.Context, token string) (wkhttp.User
 		//     — a stale-read regression worth a dedicated test, see
 		//     parser_test.go::TestCacheTokenParserResolverEmptyClearsSnapshot.
 		//   * resolved != ""  → use the fresh authoritative value.
+		langStart := time.Now()
 		resolved, rerr := p.resolver.Resolve(ctx, info.UID)
+		langMs = time.Since(langStart).Milliseconds()
 		if rerr == nil {
 			language = resolved
 		}
@@ -150,10 +179,23 @@ func (p *CacheTokenParser) Parse(ctx context.Context, token string) (wkhttp.User
 		//     whole point of resolving per request rather than trusting the
 		//     baked-in role.
 		//   * resolved != "" → use the fresh authoritative role.
+		roleStart := time.Now()
 		resolved, rerr := p.roleResolver.ResolveRole(ctx, info.UID)
+		roleMs = time.Since(roleStart).Milliseconds()
 		if rerr == nil {
 			role = resolved
 		}
+	}
+	if totalMs := time.Since(parseStart).Milliseconds(); totalMs >= authSlowLogThresholdMS {
+		authSlowLog.Warn("token 解析链路耗时偏高",
+			zap.String("trace_id", reqid.FromContext(ctx)),
+			zap.String("uid", info.UID),
+			zap.Int64("token_ms", tokenMs),
+			zap.Int64("lang_ms", langMs),
+			zap.Int64("role_ms", roleMs),
+			zap.Int64("total_ms", totalMs),
+			zap.Int64("threshold_ms", authSlowLogThresholdMS),
+		)
 	}
 	return wkhttp.UserInfo{
 		UID:      info.UID,

--- a/pkg/reqid/reqid.go
+++ b/pkg/reqid/reqid.go
@@ -1,0 +1,47 @@
+// Package reqid threads a per-request trace id through one HTTP request so the
+// otherwise-separate slow logs (GIN access log, auth parser, group handler,
+// group service) can be stitched back to a single request. It mirrors the
+// existing modules/oidc/logging.go newTraceID pattern but is request-scoped and
+// reusable across packages (middleware + pkg/auth + modules/*).
+//
+// The id lives in two places per request:
+//   - gin.Context key (GinKey) → readable by the access-log formatter via
+//     gin.LogFormatterParams.Keys and by handlers via c.GetString(GinKey).
+//   - request context.Context (via WithTraceID) → readable by code that only
+//     sees a context.Context, e.g. pkg/auth's CacheTokenParser.Parse.
+package reqid
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+)
+
+type ctxKey struct{}
+
+// GinKey is the gin.Context / LogFormatterParams.Keys key holding the trace id.
+const GinKey = "trace_id"
+
+// New generates a 16-hex-char (8 random bytes) trace id. On the (practically
+// impossible) rand failure it returns a fixed sentinel rather than erroring —
+// a non-unique id is strictly better than failing the request for a log field.
+func New() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "0000000000000000"
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// WithTraceID returns a child context carrying id.
+func WithTraceID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, ctxKey{}, id)
+}
+
+// FromContext extracts the trace id, or "" if absent.
+func FromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(ctxKey{}).(string); ok {
+		return v
+	}
+	return ""
+}

--- a/pkg/reqid/reqid.go
+++ b/pkg/reqid/reqid.go
@@ -15,12 +15,36 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"strings"
 )
 
 type ctxKey struct{}
 
 // GinKey is the gin.Context / LogFormatterParams.Keys key holding the trace id.
 const GinKey = "trace_id"
+
+// maxInboundLen bounds a client-supplied X-Request-ID so it cannot inflate log
+// lines unboundedly.
+const maxInboundLen = 128
+
+// Sanitize cleans a client-supplied trace id (e.g. an inbound X-Request-ID)
+// before it is trusted for log correlation: it trims whitespace, drops control
+// characters (CR/LF/tab/etc.) that could forge or split log lines, and bounds
+// the length. Returns "" when nothing usable remains, so callers fall back to
+// New(). The value is only ever used for log correlation, never for auth or
+// routing (PR#479 F2).
+func Sanitize(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > maxInboundLen {
+		s = s[:maxInboundLen]
+	}
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, s)
+}
 
 // New generates a 16-hex-char (8 random bytes) trace id. On the (practically
 // impossible) rand failure it returns a fixed sentinel rather than erroring —

--- a/pkg/reqid/reqid_test.go
+++ b/pkg/reqid/reqid_test.go
@@ -1,0 +1,38 @@
+package reqid
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewIsUniqueHex16(t *testing.T) {
+	seen := make(map[string]bool, 100)
+	for i := 0; i < 100; i++ {
+		id := New()
+		if len(id) != 16 {
+			t.Fatalf("New() len = %d, want 16 (got %q)", len(id), id)
+		}
+		for _, c := range id {
+			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+				t.Fatalf("New() = %q contains non-hex char %q", id, c)
+			}
+		}
+		if seen[id] {
+			t.Fatalf("New() produced duplicate id %q within 100 calls", id)
+		}
+		seen[id] = true
+	}
+}
+
+func TestWithTraceIDRoundTrip(t *testing.T) {
+	ctx := WithTraceID(context.Background(), "abc123")
+	if got := FromContext(ctx); got != "abc123" {
+		t.Fatalf("FromContext = %q, want %q", got, "abc123")
+	}
+}
+
+func TestFromContextAbsentReturnsEmpty(t *testing.T) {
+	if got := FromContext(context.Background()); got != "" {
+		t.Fatalf("FromContext(empty) = %q, want \"\"", got)
+	}
+}

--- a/pkg/reqid/reqid_test.go
+++ b/pkg/reqid/reqid_test.go
@@ -2,6 +2,7 @@ package reqid
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -34,5 +35,27 @@ func TestWithTraceIDRoundTrip(t *testing.T) {
 func TestFromContextAbsentReturnsEmpty(t *testing.T) {
 	if got := FromContext(context.Background()); got != "" {
 		t.Fatalf("FromContext(empty) = %q, want \"\"", got)
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"trim", "  abc123  ", "abc123"},
+		{"strip_crlf_injection", "abc\r\nFAKE LOG LINE", "abcFAKE LOG LINE"},
+		{"strip_tab_and_controls", "a\tb\x00c", "abc"},
+		{"empty_after_clean", "\r\n\t ", ""},
+		{"truncate_over_128", strings.Repeat("x", 200), strings.Repeat("x", 128)},
+		{"keep_normal", "req-7f3a9c", "req-7f3a9c"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Sanitize(tc.in); got != tc.want {
+				t.Fatalf("Sanitize(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What

Adds diagnostic instrumentation to locate latency in the
`POST /v1/groups/:group_no/members` (invite members) request path. No
business-logic change — the new logs fire only above the existing invite
slow-log threshold.

## Why

Invite-members latency is intermittently high, and the current spans
(`pre_checks_ms`, `db_ms`, IM hops) are too coarse to tell whether time goes
to acquiring a DB connection, executing queries, generating sequences,
committing (semi-sync), or in auth/middleware. The separate slow logs also
could not be correlated to one request.

## Changes

- **pkg/reqid** (new): request-scoped `trace_id`, kept in both `gin.Context`
  and the request context so code that only sees a `context.Context` (the auth
  token parser) can read it too.
- **main.go**: `trace_id` middleware mounted first; reuses an inbound
  `X-Request-ID` when present and echoes it back on the response.
- **pkg/accesslog**: emit `trace_id` on the GIN access line.
- **pkg/auth**: split `CacheTokenParser.Parse` into `token_ms` / `lang_ms` /
  `role_ms`; logs only when total exceeds `DM_AUTH_SLOWLOG_MS` (default 200ms).
- **group handler**: connection-acquire probe (`Conn` + `Ping`) to separate
  connection acquisition from query execution; threads `trace_id` into the service.
- **group service**: split `db_ms` into `query_ms` / `genseq_ms` /
  `insert_ms` / `commit_ms`.

The four slow logs (GIN access, auth parser, handler, service) now share the
same `trace_id`, so one slow request can be reassembled end to end.

## Behavior / risk

- Pure observability except one added `Ping` round-trip per invite (the
  connection-acquire probe). Invites are low-frequency.
- New logs are gated by the existing slow-log threshold; normal requests are
  unaffected.

## Test plan

- [x] `go build ./...`, `go vet`, `gofmt` clean
- [x] `go test ./pkg/reqid/... ./pkg/accesslog/... ./pkg/auth/...`
- [ ] Deploy, trigger a slow invite, confirm the four logs share a `trace_id`
      and the new `*_ms` fields decompose the latency.
