### PR TITLE
perf: shared avatar render cache to stop CPU starvation under fanout (#480)

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/accesslog"
 	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
+	"github.com/Mininglamp-OSS/octo-server/pkg/avatarrender"
 	octodb "github.com/Mininglamp-OSS/octo-server/pkg/db"
 	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/Mininglamp-OSS/octo-server/pkg/metrics"
@@ -208,6 +209,29 @@ func runAPI(ctx *config.Context) {
 	// scrape 时读取的 Collector,不起后台 goroutine。此处 rlRedis 与 ctx.DB().DB
 	// 均已就绪,且在 api.Route 之前完成注册。
 	metrics.NewDependencyMetrics(prometheus.DefaultRegisterer)
+	// 头像渲染缓存指标(issue#480):命中率 / 渲染耗时 / inflight / 信号量等待 /
+	// singleflight 合并 / 304。由 modules/user 的 avatarCache 经包级 Observe 函数灌入;
+	// 此处注册即可,未注册前这些 Observe 为 no-op,不影响已构造的 cache。
+	metrics.NewAvatarMetrics(prometheus.DefaultRegisterer)
+	// 构造进程级共享头像渲染缓存,并把观测 hooks 接到上面注册的头像指标。所有头像端点
+	// (user 的 UserAvatar;群组头像渲染合并后亦然——#478)经 avatarrender.GetOrRender
+	// 共用这一个实例:共享 LRU + 同一个渲染信号量(后者唯一,才是真正的进程级渲染并发
+	// 上限)。hooks 在组合根注入,使 pkg/avatarrender 不依赖 pkg/metrics。构造失败则不设
+	// 默认,GetOrRender 退化为直接渲染,不阻断启动。
+	avatarCfg := avatarrender.ConfigFromEnv()
+	avatarCfg.Hooks = avatarrender.Hooks{
+		OnHit:           metrics.ObserveAvatarCacheHit,
+		OnMiss:          metrics.ObserveAvatarCacheMiss,
+		OnShared:        metrics.ObserveAvatarSingleflightShared,
+		OnRender:        metrics.ObserveAvatarRender,
+		OnSemaphoreWait: metrics.ObserveAvatarSemaphoreWait,
+		OnInflight:      metrics.AddAvatarRenderInflight,
+	}
+	if avatarCache, err := avatarrender.NewCache(avatarCfg); err != nil {
+		log.Warn("构造头像渲染缓存失败,退化为无缓存", zap.Error(err))
+	} else {
+		avatarrender.SetDefaultCache(avatarCache)
+	}
 	// 把 octo-lib 客户端接缝的耗时回调接到 DependencyMetrics:
 	//   - MySQL: db.NewMySQL 的 connect/query 计时 → dependency="mysql"
 	//   - Redis: pkg/redis 客户端每条命令计时 → dependency="redis"

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/source"
 	"github.com/Mininglamp-OSS/octo-server/pkg/avatarrender"
 	"github.com/Mininglamp-OSS/octo-server/pkg/avatarversion"
+	"github.com/Mininglamp-OSS/octo-server/pkg/metrics"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	rd "github.com/go-redis/redis"
@@ -594,14 +595,22 @@ func (u *User) UserAvatar(c *wkhttp.Context) {
 			}
 			setAvatarHeaders(etag)
 			if ifNoneMatchSatisfied(c.GetHeader("If-None-Match"), etag) {
+				metrics.ObserveAvatarNotModified()
 				c.Status(http.StatusNotModified)
 				return
 			}
 
+			// 非条件 GET（disable-cache / 首屏 / 共享缓存 miss）会绕过上面的 304 快路径，
+			// 落到这里真渲染。成员列表扇出下大量并发非条件 GET 会把 CPU 打满、饿死同机
+			// 其它请求（issue#480）。渲染统一走 avatarCache：相同内容 key 命中复用字节、
+			// singleflight 合并并发冷渲染、渲染信号量限并发，确保一次扇出最多渲一张。
+			// key 复用上面算好的 ETag —— 它已覆盖决定图像内容的全部因子，语义与缓存一致。
 			if nameMode {
-				imageData, genErr := avatarrender.Render(avatarrender.Options{
-					Text: text,
-					Bg:   avatarrender.ColorForSeed(uid),
+				imageData, genErr := avatarrender.GetOrRender(etag, func() ([]byte, error) {
+					return avatarrender.Render(avatarrender.Options{
+						Text: text,
+						Bg:   avatarrender.ColorForSeed(uid),
+					})
 				})
 				if genErr == nil {
 					c.Data(http.StatusOK, "image/png", imageData)
@@ -611,7 +620,10 @@ func (u *User) UserAvatar(c *wkhttp.Context) {
 				u.Error("生成昵称默认头像失败，回退兜底", zap.Error(genErr), zap.String("uid", uid))
 				c.Header("ETag", avatarETag("ascii-v1", uid))
 			}
-			imageData, genErr := generateDefaultAvatar(uid)
+			asciiETag := avatarETag("ascii-v1", uid)
+			imageData, genErr := avatarrender.GetOrRender(asciiETag, func() ([]byte, error) {
+				return generateDefaultAvatar(uid)
+			})
 			if genErr != nil {
 				u.Error("生成默认头像失败", zap.Error(genErr))
 				c.Writer.WriteHeader(http.StatusInternalServerError)

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -602,11 +602,15 @@ func (u *User) UserAvatar(c *wkhttp.Context) {
 
 			// 非条件 GET（disable-cache / 首屏 / 共享缓存 miss）会绕过上面的 304 快路径，
 			// 落到这里真渲染。成员列表扇出下大量并发非条件 GET 会把 CPU 打满、饿死同机
-			// 其它请求（issue#480）。渲染统一走 avatarCache：相同内容 key 命中复用字节、
+			// 其它请求（issue#480）。渲染统一走共享缓存：相同内容 key 命中复用字节、
 			// singleflight 合并并发冷渲染、渲染信号量限并发，确保一次扇出最多渲一张。
-			// key 复用上面算好的 ETag —— 它已覆盖决定图像内容的全部因子，语义与缓存一致。
+			//
+			// 缓存 key 用 avatarCacheKey（完整原始因子），**不是**上面的 CRC32 ETag：
+			// ETag 是 32 位弱指纹，作共享缓存身份会碰撞→跨用户串图（PR#481 评审）。
+			// 两者覆盖同一组因子（渲染版本/uid→色/文字），仅 ETag 头继续用 CRC32。
 			if nameMode {
-				imageData, genErr := avatarrender.GetOrRender(etag, func() ([]byte, error) {
+				nameKey := avatarCacheKey("name-v3", uid, text)
+				imageData, genErr := avatarrender.GetOrRender(nameKey, func() ([]byte, error) {
 					return avatarrender.Render(avatarrender.Options{
 						Text: text,
 						Bg:   avatarrender.ColorForSeed(uid),
@@ -620,8 +624,8 @@ func (u *User) UserAvatar(c *wkhttp.Context) {
 				u.Error("生成昵称默认头像失败，回退兜底", zap.Error(genErr), zap.String("uid", uid))
 				c.Header("ETag", avatarETag("ascii-v1", uid))
 			}
-			asciiETag := avatarETag("ascii-v1", uid)
-			imageData, genErr := avatarrender.GetOrRender(asciiETag, func() ([]byte, error) {
+			asciiKey := avatarCacheKey("ascii-v1", uid)
+			imageData, genErr := avatarrender.GetOrRender(asciiKey, func() ([]byte, error) {
 				return generateDefaultAvatar(uid)
 			})
 			if genErr != nil {

--- a/modules/user/avatar_etag_test.go
+++ b/modules/user/avatar_etag_test.go
@@ -100,6 +100,20 @@ func TestAvatarCacheKeyDistinguishesFactors(t *testing.T) {
 	}
 }
 
+// TestAvatarCacheKeyInjectiveAcrossPartBoundaries pins the PR#481 hardening:
+// the key encoding must stay injective even when a part contains the separator
+// byte. A naive strings.Join(parts, "\x00") would map these two distinct
+// factor lists to the same key; length-framing keeps them distinct.
+func TestAvatarCacheKeyInjectiveAcrossPartBoundaries(t *testing.T) {
+	if avatarCacheKey("name-v3", "u", "a\x00b") == avatarCacheKey("name-v3", "u\x00a", "b") {
+		t.Fatal("cache key must stay injective across part boundaries (NUL in a part)")
+	}
+	// Empty-vs-absent part must also not alias.
+	if avatarCacheKey("x", "") == avatarCacheKey("x") {
+		t.Fatal("trailing empty part must change the key")
+	}
+}
+
 func TestIfNoneMatchSatisfied(t *testing.T) {
 	etag := `W/"abc12345"`
 	tests := []struct {

--- a/modules/user/avatar_etag_test.go
+++ b/modules/user/avatar_etag_test.go
@@ -1,8 +1,11 @@
 package user
 
 import (
+	"math/rand"
 	"strings"
 	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/avatarrender"
 )
 
 func TestAvatarETag(t *testing.T) {
@@ -26,6 +29,74 @@ func TestAvatarETag(t *testing.T) {
 	got := avatarETag("name-v1", "uid1", "三丰")
 	if !strings.HasPrefix(got, `W/"`) || !strings.HasSuffix(got, `"`) {
 		t.Fatalf("avatarETag should be a quoted weak ETag, got %s", got)
+	}
+}
+
+// TestAvatarCacheKeyResistsETagCollision pins the PR#481 fix: the shared render
+// cache key must NOT be the 32-bit CRC32 ETag. We search for two distinct display
+// texts whose avatarETag collides, then assert (a) their avatarCacheKey does NOT
+// collide and (b) a real shared avatarrender.Cache does not cross-serve A's bytes
+// to B. Before the fix the ETag was the cache key, so a collision meant user B was
+// served user A's cached avatar.
+//
+// Note: CRC32 is linear, so structured/sequential inputs barely collide — we use a
+// fixed-seed PRNG over fixed-length random text, where collisions follow the 32-bit
+// birthday bound (~tens of thousands of tries; 1<<20 budget is ample). Fixed seed
+// keeps it deterministic.
+func TestAvatarCacheKeyResistsETagCollision(t *testing.T) {
+	const uid = "u_collide"
+	r := rand.New(rand.NewSource(42))
+	seen := make(map[string]string) // etag -> text
+	var a, b string
+	for i := 0; i < 1<<20 && a == ""; i++ {
+		buf := make([]byte, 8)
+		for j := range buf {
+			buf[j] = byte('a' + r.Intn(26))
+		}
+		text := string(buf)
+		et := avatarETag("name-v3", uid, text)
+		if prev, ok := seen[et]; ok && prev != text {
+			a, b = prev, text
+		} else {
+			seen[et] = text
+		}
+	}
+	if a == "" {
+		t.Skip("no CRC32 ETag collision found within budget (unexpected for 32-bit)")
+	}
+	// Precondition: the weak ETags really do collide — that's the hazard.
+	if avatarETag("name-v3", uid, a) != avatarETag("name-v3", uid, b) {
+		t.Fatalf("expected colliding ETags for %q/%q", a, b)
+	}
+	// The fix: cache keys for distinct inputs must stay distinct despite the ETag collision.
+	keyA := avatarCacheKey("name-v3", uid, a)
+	keyB := avatarCacheKey("name-v3", uid, b)
+	if keyA == keyB {
+		t.Fatalf("cache key collides for distinct inputs %q/%q sharing a CRC32 ETag", a, b)
+	}
+	// End-to-end: a real shared cache must not serve B user A's cached bytes.
+	cache, err := avatarrender.NewCache(avatarrender.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bytesA, _ := cache.GetOrRender(keyA, func() ([]byte, error) { return []byte("avatar-A:" + a), nil })
+	bytesB, _ := cache.GetOrRender(keyB, func() ([]byte, error) { return []byte("avatar-B:" + b), nil })
+	if string(bytesA) == string(bytesB) {
+		t.Fatalf("shared cache cross-served: B got A's bytes for ETag-colliding inputs %q/%q", a, b)
+	}
+}
+
+// TestAvatarCacheKeyDistinguishesFactors:不同模式/uid/文字都应得到不同 key。
+func TestAvatarCacheKeyDistinguishesFactors(t *testing.T) {
+	base := avatarCacheKey("name-v3", "uid1", "三丰")
+	if base == avatarCacheKey("name-v3", "uid1", "丰丰") {
+		t.Fatal("text change must change cache key")
+	}
+	if base == avatarCacheKey("name-v3", "uid2", "三丰") {
+		t.Fatal("uid change must change cache key")
+	}
+	if avatarCacheKey("name-v3", "uid1") == avatarCacheKey("ascii-v1", "uid1") {
+		t.Fatal("render mode must change cache key")
 	}
 }
 

--- a/modules/user/avatar_path.go
+++ b/modules/user/avatar_path.go
@@ -3,6 +3,7 @@ package user
 import (
 	"fmt"
 	"hash/crc32"
+	"strconv"
 	"strings"
 )
 
@@ -36,10 +37,21 @@ func avatarETag(parts ...string) string {
 // 作弱 ETag 没问题（HTTP 304 撞了顶多多渲一次，无害）；但缓存 key 是**跨所有用户
 // 的进程级 []byte 存储身份**，一旦碰撞就会把 A 用户已缓存的头像返回给 B 用户
 // （串图 / 轻度信息泄露）。而且 text=昵称末两字用户可控、CRC32 线性可构造，可被
-// 对抗性投毒。故 key 用 NUL 分隔的完整原始 parts（单射），把碰撞域从 2^32 降到
-// 实际不可碰撞；ETag 头仍用 CRC32 不变。详见 PR#481 评审。
+// 对抗性投毒。故 key 编码完整原始 parts 而非摘要。详见 PR#481 评审。
+//
+// 编码用**长度分帧**（每段 `<len>:<bytes>`）而非 NUL 分隔：后者对任意 parts 非
+// 单射（如 ["u","a\x00b"] 与 ["u\x00a","b"] 会撞）。今天的因子（uid 来自 HTTP path
+// 不含 NUL、text 经 IndividualText 已剥离控制字符）即便用 NUL 也安全，但长度分帧对
+// **任意**字节都单射，避免将来新增可能含 NUL 的因子（或 #478 群头像接入同一 key
+// 构造）时踩雷（PR#481 评审）。
 func avatarCacheKey(parts ...string) string {
-	return strings.Join(parts, "\x00")
+	var b strings.Builder
+	for _, p := range parts {
+		b.WriteString(strconv.Itoa(len(p)))
+		b.WriteByte(':')
+		b.WriteString(p)
+	}
+	return b.String()
 }
 
 // ifNoneMatchSatisfied 报告 If-None-Match 头是否匹配 etag（RFC 7232 §3.2 弱比较：

--- a/modules/user/avatar_path.go
+++ b/modules/user/avatar_path.go
@@ -29,6 +29,19 @@ func avatarETag(parts ...string) string {
 	return fmt.Sprintf(`W/"%08x"`, h.Sum32())
 }
 
+// avatarCacheKey 为进程级共享渲染缓存（avatarrender.Cache）算 key。parts 与
+// avatarETag 取同一组决定图像内容的因子（渲染版本、uid→颜色、展示文字）。
+//
+// 关键：这里**不能**复用 avatarETag 的 CRC32 摘要。avatarETag 是 32 位 CRC32，
+// 作弱 ETag 没问题（HTTP 304 撞了顶多多渲一次，无害）；但缓存 key 是**跨所有用户
+// 的进程级 []byte 存储身份**，一旦碰撞就会把 A 用户已缓存的头像返回给 B 用户
+// （串图 / 轻度信息泄露）。而且 text=昵称末两字用户可控、CRC32 线性可构造，可被
+// 对抗性投毒。故 key 用 NUL 分隔的完整原始 parts（单射），把碰撞域从 2^32 降到
+// 实际不可碰撞；ETag 头仍用 CRC32 不变。详见 PR#481 评审。
+func avatarCacheKey(parts ...string) string {
+	return strings.Join(parts, "\x00")
+}
+
 // ifNoneMatchSatisfied 报告 If-None-Match 头是否匹配 etag（RFC 7232 §3.2 弱比较：
 // 忽略 W/ 前缀）。支持逗号分隔的多个验证符与通配 "*"。
 func ifNoneMatchSatisfied(header, etag string) bool {

--- a/pkg/avatarrender/cache.go
+++ b/pkg/avatarrender/cache.go
@@ -1,0 +1,161 @@
+package avatarrender
+
+import (
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"golang.org/x/sync/singleflight"
+)
+
+// 头像「按需渲染」在成员列表扇出下会把 pod 的 CPU 打满,饿死同机的其它请求
+// goroutine(见 issue#480)。Cache 用三层防御把"一次扇出 N 张 = N 次渲染"压成
+// 最多一次:
+//
+//   - bytes LRU:渲染结果按内容 key 缓存,命中直接复用字节,零 CPU;
+//   - singleflight:同 key 的并发请求只触发一次渲染,其余复用同一结果(防冷启动
+//     惊群——首屏 N 个并发请求打到同一张未缓存头像时只渲一次);
+//   - render 信号量:限制全局并发渲染数,即使大量"不同 key"的冷头像同时到达,也不
+//     会占满所有 P 把其它流量饿死(信号量必须配合前两层,否则只是把惊群变成慢排队)。
+//
+// key 由调用方按"决定图像内容的全部因子"生成(与 ETag 同源),Cache 不关心其语义。
+
+// DefaultCacheSize 是未配置时的 LRU 容量(条目数)。默认头像是 200×200 的简单 PNG
+// (数 KB 量级),数千条目的常驻内存在十几 MB 级,足够覆盖活跃用户集。
+const DefaultCacheSize = 4096
+
+// Hooks 是可观测性回调,全部可选(nil 即 no-op)。刻意用函数字段而非接口,使本包
+// 不依赖 pkg/metrics —— 由上层(modules/user)在构造时把 prometheus 观测点接进来。
+type Hooks struct {
+	// OnHit / OnMiss:LRU 命中 / 未命中各记一次。
+	OnHit  func()
+	OnMiss func()
+	// OnShared:本次渲染结果被并发调用方复用(singleflight 合并),记一次。
+	OnShared func()
+	// OnRender:一次真实渲染完成,带耗时与错误(用于渲染延迟直方图)。
+	OnRender func(dur time.Duration, err error)
+	// OnSemaphoreWait:获取渲染信号量的等待耗时(>0 说明渲染并发已饱和、在排队)。
+	OnSemaphoreWait func(dur time.Duration)
+	// OnInflight:正在进行的渲染数变化(+1 开始 / -1 结束),用于 inflight gauge。
+	OnInflight func(delta float64)
+}
+
+func (h *Hooks) normalize() {
+	if h.OnHit == nil {
+		h.OnHit = func() {}
+	}
+	if h.OnMiss == nil {
+		h.OnMiss = func() {}
+	}
+	if h.OnShared == nil {
+		h.OnShared = func() {}
+	}
+	if h.OnRender == nil {
+		h.OnRender = func(time.Duration, error) {}
+	}
+	if h.OnSemaphoreWait == nil {
+		h.OnSemaphoreWait = func(time.Duration) {}
+	}
+	if h.OnInflight == nil {
+		h.OnInflight = func(float64) {}
+	}
+}
+
+// Config 配置 Cache。
+type Config struct {
+	// Size 是 LRU 最大条目数;<=0 用 DefaultCacheSize。
+	Size int
+	// MaxConcurrentRenders 是同时进行的真实渲染数上限(信号量容量);<=0 表示不限。
+	// 取值应 < GOMAXPROCS,给非头像流量留核;配合缓存后,渲染只在冷 key 时发生,
+	// 串行化冷渲染的代价是一次性的(之后命中缓存),换来洪峰下不饿死其它请求。
+	MaxConcurrentRenders int
+	// Hooks 是可观测性回调。
+	Hooks Hooks
+}
+
+// Cache 是带 singleflight 与渲染信号量的头像 bytes 缓存。零值不可用,须经 NewCache 构造;
+// 方法对 nil 接收者安全(直接渲染,无缓存),便于在未配置缓存时退化。
+type Cache struct {
+	lru   *lru.Cache[string, []byte]
+	group singleflight.Group
+	sem   chan struct{}
+	hooks Hooks
+}
+
+// NewCache 构造一个 Cache。
+func NewCache(cfg Config) (*Cache, error) {
+	size := cfg.Size
+	if size <= 0 {
+		size = DefaultCacheSize
+	}
+	l, err := lru.New[string, []byte](size)
+	if err != nil {
+		return nil, err
+	}
+	cfg.Hooks.normalize()
+	c := &Cache{lru: l, hooks: cfg.Hooks}
+	if cfg.MaxConcurrentRenders > 0 {
+		c.sem = make(chan struct{}, cfg.MaxConcurrentRenders)
+	}
+	return c, nil
+}
+
+// GetOrRender 返回 key 对应的头像字节:命中 LRU 直接返回;否则经 singleflight 合并、
+// 在渲染信号量约束下调用 render 生成一次,成功后写入 LRU。render 必须是确定性的
+// (相同 key → 相同字节),否则缓存会返回过期内容。
+//
+// nil 接收者时直接调用 render(无缓存/合并/限流),用于缓存未配置的退化路径。
+func (c *Cache) GetOrRender(key string, render func() ([]byte, error)) ([]byte, error) {
+	if c == nil {
+		return render()
+	}
+	if v, ok := c.lru.Get(key); ok {
+		c.hooks.OnHit()
+		return v, nil
+	}
+	c.hooks.OnMiss()
+
+	v, err, shared := c.group.Do(key, func() (interface{}, error) {
+		// 双检:在等待 singleflight 期间,可能已有同 key 的先行渲染填好了缓存。
+		if v, ok := c.lru.Get(key); ok {
+			return v, nil
+		}
+		b, rerr := c.renderWithSem(render)
+		if rerr != nil {
+			return nil, rerr
+		}
+		c.lru.Add(key, b)
+		return b, nil
+	})
+	if shared {
+		c.hooks.OnShared()
+	}
+	if err != nil {
+		return nil, err
+	}
+	return v.([]byte), nil
+}
+
+// renderWithSem 在渲染信号量(若配置)约束下执行一次渲染,并打点等待/耗时/inflight。
+func (c *Cache) renderWithSem(render func() ([]byte, error)) ([]byte, error) {
+	if c.sem != nil {
+		start := time.Now()
+		c.sem <- struct{}{}
+		c.hooks.OnSemaphoreWait(time.Since(start))
+		defer func() { <-c.sem }()
+	}
+	c.hooks.OnInflight(1)
+	defer c.hooks.OnInflight(-1)
+
+	start := time.Now()
+	b, err := render()
+	c.hooks.OnRender(time.Since(start), err)
+	return b, err
+}
+
+// Len 返回当前缓存的条目数(测试/诊断用)。nil 接收者返回 0。
+func (c *Cache) Len() int {
+	if c == nil {
+		return 0
+	}
+	return c.lru.Len()
+}

--- a/pkg/avatarrender/cache.go
+++ b/pkg/avatarrender/cache.go
@@ -1,6 +1,7 @@
 package avatarrender
 
 import (
+	"fmt"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -19,8 +20,12 @@ import (
 //
 // key 由调用方按"决定图像内容的全部因子"生成(与 ETag 同源),Cache 不关心其语义。
 
-// DefaultCacheSize 是未配置时的 LRU 容量(条目数)。默认头像是 200×200 的简单 PNG
-// (数 KB 量级),数千条目的常驻内存在十几 MB 级,足够覆盖活跃用户集。
+// DefaultCacheSize 是未配置时的 LRU 容量(条目数)。
+//
+// 注意:LRU 按**条目数**而非字节计 bound。当前所有渲染输出都是 200×200 的简单 PNG
+// (数 KB 量级),故 4096 条目 ≈ 十几 MB,足够覆盖活跃用户集。若将来有调用方(如
+// #478 群头像)缓存尺寸差异很大的图,常驻内存会随 entries×单图尺寸增长,届时应改为
+// 按字节预算的缓存或下调容量(PR#481 评审)。
 const DefaultCacheSize = 4096
 
 // Hooks 是可观测性回调,全部可选(nil 即 no-op)。刻意用函数字段而非接口,使本包
@@ -136,7 +141,7 @@ func (c *Cache) GetOrRender(key string, render func() ([]byte, error)) ([]byte, 
 }
 
 // renderWithSem 在渲染信号量(若配置)约束下执行一次渲染,并打点等待/耗时/inflight。
-func (c *Cache) renderWithSem(render func() ([]byte, error)) ([]byte, error) {
+func (c *Cache) renderWithSem(render func() ([]byte, error)) (b []byte, err error) {
 	if c.sem != nil {
 		start := time.Now()
 		c.sem <- struct{}{}
@@ -146,10 +151,17 @@ func (c *Cache) renderWithSem(render func() ([]byte, error)) ([]byte, error) {
 	c.hooks.OnInflight(1)
 	defer c.hooks.OnInflight(-1)
 
+	// 用 defer 记录渲染耗时/结果,这样 render() panic 时指标也能落点(否则 Prometheus
+	// 看不到系统性渲染崩溃)。捕获后原样重抛,保持 panic 传播语义不变(PR#481 评审 P2)。
 	start := time.Now()
-	b, err := render()
-	c.hooks.OnRender(time.Since(start), err)
-	return b, err
+	defer func() {
+		if r := recover(); r != nil {
+			c.hooks.OnRender(time.Since(start), fmt.Errorf("avatarrender: render panicked: %v", r))
+			panic(r)
+		}
+		c.hooks.OnRender(time.Since(start), err)
+	}()
+	return render()
 }
 
 // Len 返回当前缓存的条目数(测试/诊断用)。nil 接收者返回 0。

--- a/pkg/avatarrender/cache.go
+++ b/pkg/avatarrender/cache.go
@@ -119,11 +119,16 @@ func (c *Cache) GetOrRender(key string, render func() ([]byte, error)) ([]byte, 
 	}
 	c.hooks.OnMiss()
 
+	// ranRender 标记本次调用是否真的执行了渲染。singleflight 只会运行 leader 的闭包,
+	// 故只有 leader 这里被置 true;等待者的闭包不运行,保持 false。各 goroutine 持有
+	// 自己的局部 ranRender,无跨协程访问,无需同步。
+	ranRender := false
 	v, err, shared := c.group.Do(key, func() (interface{}, error) {
 		// 双检:在等待 singleflight 期间,可能已有同 key 的先行渲染填好了缓存。
 		if v, ok := c.lru.Get(key); ok {
 			return v, nil
 		}
+		ranRender = true
 		b, rerr := c.renderWithSem(render)
 		if rerr != nil {
 			return nil, rerr
@@ -131,7 +136,10 @@ func (c *Cache) GetOrRender(key string, render func() ([]byte, error)) ([]byte, 
 		c.lru.Add(key, b)
 		return b, nil
 	})
-	if shared {
+	// singleflight 的 shared 对 leader 也为 true。OnShared 只应计"被合并到他人渲染
+	// 上的请求"(真正搭便车的等待者),故排除自己执行了渲染的 leader,避免每次 flight
+	// 多计一次(PR#481 评审)。
+	if shared && !ranRender {
 		c.hooks.OnShared()
 	}
 	if err != nil {
@@ -145,8 +153,10 @@ func (c *Cache) renderWithSem(render func() ([]byte, error)) (b []byte, err erro
 	if c.sem != nil {
 		start := time.Now()
 		c.sem <- struct{}{}
-		c.hooks.OnSemaphoreWait(time.Since(start))
+		// 先注册释放,再打点等待耗时:即使 OnSemaphoreWait hook panic,已获取的令牌
+		// 也必被归还,不会泄漏导致信号量逐渐枯竭/死锁(PR#481 评审,防御性)。
 		defer func() { <-c.sem }()
+		c.hooks.OnSemaphoreWait(time.Since(start))
 	}
 	c.hooks.OnInflight(1)
 	defer c.hooks.OnInflight(-1)

--- a/pkg/avatarrender/cache_test.go
+++ b/pkg/avatarrender/cache_test.go
@@ -1,0 +1,150 @@
+package avatarrender
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestCacheHitMiss:首次未命中触发渲染,二次命中直接复用,不再渲染。
+func TestCacheHitMiss(t *testing.T) {
+	var hits, misses, renders int64
+	c, err := NewCache(Config{Hooks: Hooks{
+		OnHit:    func() { atomic.AddInt64(&hits, 1) },
+		OnMiss:   func() { atomic.AddInt64(&misses, 1) },
+		OnRender: func(time.Duration, error) { atomic.AddInt64(&renders, 1) },
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	render := func() ([]byte, error) { return []byte("png-A"), nil }
+
+	b, err := c.GetOrRender("k1", render)
+	if err != nil || string(b) != "png-A" {
+		t.Fatalf("first get: %q %v", b, err)
+	}
+	b, err = c.GetOrRender("k1", render)
+	if err != nil || string(b) != "png-A" {
+		t.Fatalf("second get: %q %v", b, err)
+	}
+	if got := atomic.LoadInt64(&renders); got != 1 {
+		t.Fatalf("expected exactly 1 render, got %d", got)
+	}
+	if hits != 1 || misses != 1 {
+		t.Fatalf("expected 1 hit / 1 miss, got %d / %d", hits, misses)
+	}
+	if c.Len() != 1 {
+		t.Fatalf("expected 1 cached entry, got %d", c.Len())
+	}
+}
+
+// TestCacheErrorNotCached:渲染失败不写缓存,下次重试。
+func TestCacheErrorNotCached(t *testing.T) {
+	c, _ := NewCache(Config{})
+	var calls int64
+	render := func() ([]byte, error) {
+		if atomic.AddInt64(&calls, 1) == 1 {
+			return nil, errors.New("boom")
+		}
+		return []byte("ok"), nil
+	}
+	if _, err := c.GetOrRender("k", render); err == nil {
+		t.Fatal("expected error on first render")
+	}
+	b, err := c.GetOrRender("k", render)
+	if err != nil || string(b) != "ok" {
+		t.Fatalf("expected retry to succeed, got %q %v", b, err)
+	}
+	if c.Len() != 1 {
+		t.Fatalf("expected entry cached after success, got %d", c.Len())
+	}
+}
+
+// TestCacheSingleflight:同 key 的大量并发请求只触发一次渲染,其余复用。
+func TestCacheSingleflight(t *testing.T) {
+	c, _ := NewCache(Config{})
+	var renders int64
+	var shared int64
+	c.hooks.OnShared = func() { atomic.AddInt64(&shared, 1) }
+	render := func() ([]byte, error) {
+		atomic.AddInt64(&renders, 1)
+		time.Sleep(30 * time.Millisecond) // 拉长渲染窗口,让并发请求都挤进同一次 flight
+		return []byte("png"), nil
+	}
+
+	const n = 50
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if b, err := c.GetOrRender("same", render); err != nil || string(b) != "png" {
+				t.Errorf("get: %q %v", b, err)
+			}
+		}()
+	}
+	wg.Wait()
+	if got := atomic.LoadInt64(&renders); got != 1 {
+		t.Fatalf("expected exactly 1 render for %d concurrent same-key requests, got %d", n, got)
+	}
+	if atomic.LoadInt64(&shared) == 0 {
+		t.Fatal("expected some requests to be coalesced (shared), got 0")
+	}
+}
+
+// TestCacheSemaphoreBoundsConcurrency:MaxConcurrentRenders 限制同时进行的真实
+// 渲染数 —— 即使大量不同 key 同时到达,inflight 也不超过上限。
+func TestCacheSemaphoreBoundsConcurrency(t *testing.T) {
+	const limit = 2
+	var inflight, maxInflight int64
+	c, _ := NewCache(Config{
+		MaxConcurrentRenders: limit,
+		Hooks: Hooks{
+			OnInflight: func(delta float64) {
+				cur := atomic.AddInt64(&inflight, int64(delta))
+				for {
+					m := atomic.LoadInt64(&maxInflight)
+					if cur <= m || atomic.CompareAndSwapInt64(&maxInflight, m, cur) {
+						break
+					}
+				}
+			},
+		},
+	})
+	render := func() ([]byte, error) {
+		time.Sleep(20 * time.Millisecond)
+		return []byte("x"), nil
+	}
+
+	const n = 20
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := string(rune('a' + i)) // 全部不同 key,绕过 singleflight 合并
+			_, _ = c.GetOrRender(key, render)
+		}(i)
+	}
+	wg.Wait()
+	if got := atomic.LoadInt64(&maxInflight); got > limit {
+		t.Fatalf("max concurrent renders %d exceeded semaphore limit %d", got, limit)
+	}
+	if atomic.LoadInt64(&maxInflight) == 0 {
+		t.Fatal("expected renders to run")
+	}
+}
+
+// TestCacheNilReceiver:nil 接收者直接渲染,不 panic(缓存未配置时的退化路径)。
+func TestCacheNilReceiver(t *testing.T) {
+	var c *Cache
+	b, err := c.GetOrRender("k", func() ([]byte, error) { return []byte("raw"), nil })
+	if err != nil || string(b) != "raw" {
+		t.Fatalf("nil receiver get: %q %v", b, err)
+	}
+	if c.Len() != 0 {
+		t.Fatal("nil cache Len should be 0")
+	}
+}

--- a/pkg/avatarrender/default.go
+++ b/pkg/avatarrender/default.go
@@ -1,0 +1,64 @@
+package avatarrender
+
+import (
+	"os"
+	"runtime"
+	"strconv"
+	"sync/atomic"
+)
+
+// 进程级共享头像缓存。所有头像端点(当前是 user 的 UserAvatar;未来 group 等任何
+// 加入按需渲染的端点)都经包级 GetOrRender 共用这一个 Cache 实例,从而:
+//
+//   - 共享同一个 LRU(一份内存预算,不按端点翻倍);
+//   - 共享同一个渲染信号量 —— 这点是关键:信号量只有进程级唯一,才是真正的"全机
+//     渲染并发上限"。若每个端点各建一个 Cache 各限 N,合起来就是 2N 并发渲染,等于
+//     没限住,issue#480 的 CPU 饿死照样发生。
+//
+// 用 atomic.Pointer 持有,未设置时 GetOrRender 退化为直接渲染(Cache 方法对 nil
+// 接收者安全),与 pkg/metrics 的包级默认实例约定一致。
+
+var defaultCache atomic.Pointer[Cache]
+
+// SetDefaultCache 设置进程级共享头像缓存(组合根在启动时调用一次)。
+func SetDefaultCache(c *Cache) { defaultCache.Store(c) }
+
+// DefaultCache 返回当前进程级共享缓存(未设置时为 nil)。
+func DefaultCache() *Cache { return defaultCache.Load() }
+
+// GetOrRender 用进程级共享缓存渲染 key 对应的头像;未设置默认缓存时直接渲染。
+// 各端点 handler 应调用本函数,而不是各自持有 Cache。
+func GetOrRender(key string, render func() ([]byte, error)) ([]byte, error) {
+	return defaultCache.Load().GetOrRender(key, render)
+}
+
+// ConfigFromEnv 从环境变量读取共享缓存配置(不含 Hooks —— 观测点由组合根注入,
+// 以免本包依赖 pkg/metrics):
+//
+//   - DM_AVATAR_CACHE_SIZE: LRU 条目数,缺省/非法用 DefaultCacheSize;
+//   - DM_AVATAR_RENDER_MAX_CONCURRENCY: 最大并发真实渲染数,缺省 max(1, GOMAXPROCS-1)。
+func ConfigFromEnv() Config {
+	return Config{
+		Size:                 envPositiveInt("DM_AVATAR_CACHE_SIZE", 0),
+		MaxConcurrentRenders: envPositiveInt("DM_AVATAR_RENDER_MAX_CONCURRENCY", defaultRenderConcurrency()),
+	}
+}
+
+// defaultRenderConcurrency 默认渲染并发上限:给非头像流量至少留一个 P,防止冷头像
+// 洪峰占满所有核饿死其它请求。
+func defaultRenderConcurrency() int {
+	if n := runtime.GOMAXPROCS(0) - 1; n > 0 {
+		return n
+	}
+	return 1
+}
+
+// envPositiveInt 读取一个正整数环境变量,缺省/非法时返回 def。
+func envPositiveInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}

--- a/pkg/avatarrender/starvation_repro_test.go
+++ b/pkg/avatarrender/starvation_repro_test.go
@@ -1,0 +1,211 @@
+package avatarrender
+
+import (
+	"runtime"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// 本文件复现 issue#480 的真实根因:头像「按需渲染」在成员列表扇出(member-list
+// fanout)下把 pod 的 CPU 打满,使同机的「邀请成员」请求 goroutine 被调度饿死。
+//
+// 复现不依赖 MySQL/Redis/WuKongIM —— 饿死发生在 Go 调度器层,与外部基础设施无关
+// (这正是之前 SELECT 1 / ping / 网络探针都照不到、却把整请求三段等比拖慢的原因)。
+// 用 GOMAXPROCS=2 模拟生产 2 核 pod;渲染洪峰 = avatarrender.Render 的并发循环;
+// 受害者 = 模拟邀请 handler 的「~20 次串行 I/O 往返 + 每次唤醒后少量工作」。
+//
+// 受害者每次 I/O 往返用 time.Sleep(park) 模拟:I/O 返回后 goroutine 变为可运行,
+// 但两个 P 都被渲染占满 → 唤醒要排队等 P。这一段排队 = 邀请慢的本质,且对
+// SELECT 1 之类的独立进程探针不可见。
+
+// victimWork 模拟一次「邀请成员」请求:ioRounds 次串行 I/O 往返,每次 park 后做
+// 极少量 CPU 工作。理想耗时 ≈ ioRounds × ioRTT;被饿死时,park 后的唤醒等 P 的
+// 时间会叠加进来,整体被放大。
+func victimWork(ioRounds int, ioRTT time.Duration) time.Duration {
+	start := time.Now()
+	for i := 0; i < ioRounds; i++ {
+		time.Sleep(ioRTT) // 一次 DB/Redis/WuKongIM 往返:goroutine park
+		// I/O 返回后的少量工作(解析/拼装)。被饿死时,能跑到这里本身就被延迟了。
+		sink := 0
+		for j := 0; j < 2000; j++ {
+			sink += j
+		}
+		_ = sink
+	}
+	return time.Since(start)
+}
+
+// medianVictim 连续测 n 次受害者耗时取中位数,降低单次抖动。
+func medianVictim(n, ioRounds int, ioRTT time.Duration) time.Duration {
+	ds := make([]time.Duration, n)
+	for i := range ds {
+		ds[i] = victimWork(ioRounds, ioRTT)
+	}
+	sort.Slice(ds, func(i, j int) bool { return ds[i] < ds[j] })
+	return ds[n/2]
+}
+
+// startRenderFanout 启动 workers 个 goroutine 持续并发渲染头像,模拟成员列表扇出
+// 下大量并发的 /users/{uid}/avatar 200 响应(无 If-None-Match,绕过 304 快路径,
+// 每次真渲染)。返回停止函数,返回时已确保所有渲染 goroutine 退出。
+func startRenderFanout(t *testing.T, workers int) (stop func(), rendered *int64) {
+	t.Helper()
+	var done int32
+	var count int64
+	var wg sync.WaitGroup
+	seeds := []string{"u_alice", "u_bob", "u_carol", "u_dave", "u_erin"}
+	texts := []string{"甲乙", "丙丁", "戊己", "庚辛", "壬癸"}
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		seed := seeds[w%len(seeds)]
+		text := texts[w%len(texts)]
+		go func() {
+			defer wg.Done()
+			for atomic.LoadInt32(&done) == 0 {
+				if _, err := Render(Options{Text: text, Bg: ColorForSeed(seed)}); err == nil {
+					atomic.AddInt64(&count, 1)
+				}
+			}
+		}()
+	}
+	return func() {
+		atomic.StoreInt32(&done, 1)
+		wg.Wait()
+	}, &count
+}
+
+// TestRenderCost 量化单次渲染的 CPU 成本,坐实「渲染重」这一前提:
+// 800×800 超采样 + CatmullRom 缩小 + PNG 编码。
+func TestRenderCost(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip render cost in -short")
+	}
+	// 预热(字体一次性解析)。
+	if _, err := Render(Options{Text: "甲乙", Bg: ColorForSeed("warm")}); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	const n = 30
+	start := time.Now()
+	for i := 0; i < n; i++ {
+		if _, err := Render(Options{Text: "甲乙", Bg: ColorForSeed("seed")}); err != nil {
+			t.Fatalf("render: %v", err)
+		}
+	}
+	per := time.Since(start) / n
+	t.Logf("单次 Render ≈ %v (n=%d, 串行)", per, n)
+	if per < 1*time.Millisecond {
+		t.Logf("注意:本机单次渲染异常快(%v),洪峰效应会相应减弱", per)
+	}
+}
+
+// TestRenderFanoutStarvesVictim 是核心复现:GOMAXPROCS=2 下,渲染洪峰开启前后
+// 对比「邀请」受害者的耗时。开启洪峰后受害者被显著放大 —— 这就是邀请变慢的根因,
+// 且 DB/网络全程空闲。
+func TestRenderFanoutStarvesVictim(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip starvation repro in -short")
+	}
+	prev := runtime.GOMAXPROCS(2) // 模拟生产 2 核 pod
+	defer runtime.GOMAXPROCS(prev)
+
+	const (
+		ioRounds = 20                   // 邀请链路 ~14 DB + 3 redis + 3 wukongim
+		ioRTT    = 1 * time.Millisecond // 单次往返(局域网级)
+		samples  = 7
+		workers  = 16 // 成员列表扇出的并发渲染数(远超 2 个 P)
+	)
+
+	// 1) 基线:无洪峰。
+	base := medianVictim(samples, ioRounds, ioRTT)
+
+	// 2) 洪峰下。
+	stop, rendered := startRenderFanout(t, workers)
+	// 让洪峰先把两个 P 占满再测量。
+	time.Sleep(50 * time.Millisecond)
+	under := medianVictim(samples, ioRounds, ioRTT)
+	stop()
+
+	ratio := float64(under) / float64(base)
+	t.Logf("受害者(邀请模拟,理想 ≈ %v):", time.Duration(ioRounds)*ioRTT)
+	t.Logf("  基线(无洪峰)         = %v", base)
+	t.Logf("  渲染洪峰下           = %v", under)
+	t.Logf("  放大倍数             = %.1fx", ratio)
+	t.Logf("  洪峰期间共渲染头像   = %d 张 (workers=%d, GOMAXPROCS=2)", atomic.LoadInt64(rendered), workers)
+
+	// 保守断言:被饿死时受害者至少放大 2x(实测通常远大于此;真实生产渲染更重、
+	// 并发更高,放大到秒级)。阈值取保守值以免 CI 抖动误报。
+	if ratio < 2.0 {
+		t.Fatalf("期望渲染洪峰把受害者放大 ≥2x,实测 %.1fx(base=%v under=%v);"+
+			"若本机渲染过快或核数受限,可调高 workers 重试", ratio, base, under)
+	}
+}
+
+// TestCacheEliminatesStarvation 验证修复:同样的扇出,但渲染走真实的 avatarrender.Cache
+// (LRU + singleflight + 渲染信号量)后,CPU 不再被反复渲染占满,受害者基本回到基线。
+// 这测的是实际发布的修复代码,而非临时缓存桩。
+func TestCacheEliminatesStarvation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip cache validation in -short")
+	}
+	prev := runtime.GOMAXPROCS(2)
+	defer runtime.GOMAXPROCS(prev)
+
+	const (
+		ioRounds = 20
+		ioRTT    = 1 * time.Millisecond
+		samples  = 7
+		workers  = 16
+	)
+
+	base := medianVictim(samples, ioRounds, ioRTT)
+
+	// 真实修复路径:头像经 Cache.GetOrRender,相同内容 key 命中复用字节、并发冷渲染
+	// 由 singleflight 合并、渲染并发由信号量限制(模拟 2 核留 1 核给其它流量)。
+	cache, err := NewCache(Config{MaxConcurrentRenders: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	getCached := func(seed, text string) {
+		key := text + "|" + seed // 与 ETag 同源的内容 key(此处简化)
+		_, _ = cache.GetOrRender(key, func() ([]byte, error) {
+			return Render(Options{Text: text, Bg: ColorForSeed(seed)})
+		})
+	}
+
+	var done int32
+	var served int64
+	var wg sync.WaitGroup
+	seeds := []string{"u_alice", "u_bob", "u_carol", "u_dave", "u_erin"}
+	texts := []string{"甲乙", "丙丁", "戊己", "庚辛", "壬癸"}
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		seed := seeds[w%len(seeds)]
+		text := texts[w%len(texts)]
+		go func() {
+			defer wg.Done()
+			for atomic.LoadInt32(&done) == 0 {
+				getCached(seed, text)
+				atomic.AddInt64(&served, 1)
+			}
+		}()
+	}
+	time.Sleep(50 * time.Millisecond)
+	under := medianVictim(samples, ioRounds, ioRTT)
+	atomic.StoreInt32(&done, 1)
+	wg.Wait()
+
+	ratio := float64(under) / float64(base)
+	t.Logf("经 avatarrender.Cache 的扇出:")
+	t.Logf("  基线                 = %v", base)
+	t.Logf("  缓存扇出下           = %v", under)
+	t.Logf("  放大倍数             = %.1fx (期望接近 1x)", ratio)
+	t.Logf("  缓存命中服务次数     = %d (仅首次每 key 渲染, 共 %d 个 key)", atomic.LoadInt64(&served), cache.Len())
+
+	// 缓存后扇出几乎零 CPU,受害者不应被显著放大。给宽松上限避免抖动误报。
+	if ratio > 1.8 {
+		t.Fatalf("期望缓存消除饿死(放大接近 1x),实测 %.1fx(base=%v under=%v)", ratio, base, under)
+	}
+}

--- a/pkg/avatarrender/starvation_repro_test.go
+++ b/pkg/avatarrender/starvation_repro_test.go
@@ -118,8 +118,18 @@ func TestRenderFanoutStarvesVictim(t *testing.T) {
 		workers  = 16 // 成员列表扇出的并发渲染数(远超 2 个 P)
 	)
 
+	// warmup:先跑一轮丢弃,稳定计时/字体缓存,降低首测抖动(PR#481 评审 P2-3)。
+	_ = victimWork(ioRounds, ioRTT)
+
 	// 1) 基线:无洪峰。
 	base := medianVictim(samples, ioRounds, ioRTT)
+
+	// 若基线本身已远高于理想值,说明 runner 已被其它负载/cgroup 压制,GOMAXPROCS=2
+	// 下的洪峰对比失去意义(还会压低 under/base 比值导致误判)。跳过而非误报。
+	ideal := time.Duration(ioRounds) * ioRTT
+	if base > 3*ideal {
+		t.Skipf("runner 过载:基线 %v 已远高于理想 %v,跳过 timing 对比", base, ideal)
+	}
 
 	// 2) 洪峰下。
 	stop, rendered := startRenderFanout(t, workers)

--- a/pkg/metrics/avatar.go
+++ b/pkg/metrics/avatar.go
@@ -1,0 +1,138 @@
+package metrics
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// 头像渲染缓存指标(issue#480)。头像「按需渲染」在成员列表扇出下会打满 CPU、
+// 饿死其它请求;pkg/avatarrender.Cache 用 LRU + singleflight + 渲染信号量防御之。
+// 这些指标用于验证防御生效(命中率、渲染并发、信号量等待)并对回归告警。
+//
+// label 维度收窄到低基数枚举(result / status),不放 uid 等高基数内容。
+
+// AvatarMetrics 持有头像渲染缓存指标。每进程一个实例,注册到一个 Registerer。
+type AvatarMetrics struct {
+	// CacheEvents 按 result(hit/miss)计数 LRU 命中情况;命中率 = hit/(hit+miss)。
+	CacheEvents *prometheus.CounterVec
+	// SingleflightShared 计数被 singleflight 合并(复用在途渲染)的请求数。
+	SingleflightShared prometheus.Counter
+	// NotModified 计数 If-None-Match 命中返回 304 的请求(客户端缓存生效的体现)。
+	NotModified prometheus.Counter
+	// RenderDuration 按 status(ok/error)切分的单次真实渲染耗时直方图。
+	RenderDuration *prometheus.HistogramVec
+	// RenderInflight 当前正在进行的真实渲染数(gauge)。
+	RenderInflight prometheus.Gauge
+	// SemaphoreWait 获取渲染信号量的等待耗时直方图(>0 表示渲染并发饱和、排队)。
+	SemaphoreWait prometheus.Histogram
+}
+
+// defaultAvatarMetrics 是供包级 Observe 函数使用的进程默认实例。未设置时 Observe
+// 为安全 no-op(同 dependency.go 的 atomic.Pointer 约定)。
+var defaultAvatarMetrics atomic.Pointer[AvatarMetrics]
+
+// NewAvatarMetrics 在 reg 上注册头像渲染缓存指标,并登记为包级默认。
+// 调用契约同 NewDependencyMetrics:同一 Registerer 只应调用一次。
+func NewAvatarMetrics(reg prometheus.Registerer) *AvatarMetrics {
+	m := &AvatarMetrics{
+		CacheEvents: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: "avatar",
+			Name:      "cache_events_total",
+			Help:      "Avatar render-cache lookups, labeled by result (hit/miss).",
+		}, []string{"result"}),
+		SingleflightShared: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: "avatar",
+			Name:      "render_singleflight_shared_total",
+			Help:      "Avatar requests whose render was coalesced onto an in-flight render (singleflight).",
+		}),
+		NotModified: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: "avatar",
+			Name:      "not_modified_total",
+			Help:      "Avatar requests answered 304 via If-None-Match (client cache hit).",
+		}),
+		RenderDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: metricNamespace,
+			Subsystem: "avatar",
+			Name:      "render_duration_seconds",
+			Help:      "Latency of a single actual avatar render (supersample + downscale + PNG encode), labeled by ok/error.",
+			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1},
+		}, []string{"status"}),
+		RenderInflight: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: "avatar",
+			Name:      "render_inflight",
+			Help:      "Number of avatar renders currently in progress.",
+		}),
+		SemaphoreWait: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: metricNamespace,
+			Subsystem: "avatar",
+			Name:      "render_semaphore_wait_seconds",
+			Help:      "Time spent waiting on the avatar render-concurrency semaphore before a render starts.",
+			Buckets:   []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5},
+		}),
+	}
+	reg.MustRegister(m.CacheEvents, m.SingleflightShared, m.NotModified, m.RenderDuration, m.RenderInflight, m.SemaphoreWait)
+	defaultAvatarMetrics.Store(m)
+	return m
+}
+
+// 下列包级函数是头像缓存的便捷入口,签名与 avatarrender.Hooks 的字段一致,便于在
+// modules/user 构造 Cache 时直接接入。未初始化默认实例时全部为 no-op。
+
+// ObserveAvatarCacheHit 记录一次 LRU 命中。
+func ObserveAvatarCacheHit() {
+	if m := defaultAvatarMetrics.Load(); m != nil {
+		m.CacheEvents.WithLabelValues("hit").Inc()
+	}
+}
+
+// ObserveAvatarCacheMiss 记录一次 LRU 未命中。
+func ObserveAvatarCacheMiss() {
+	if m := defaultAvatarMetrics.Load(); m != nil {
+		m.CacheEvents.WithLabelValues("miss").Inc()
+	}
+}
+
+// ObserveAvatarSingleflightShared 记录一次被 singleflight 合并的请求。
+func ObserveAvatarSingleflightShared() {
+	if m := defaultAvatarMetrics.Load(); m != nil {
+		m.SingleflightShared.Inc()
+	}
+}
+
+// ObserveAvatarNotModified 记录一次 304 响应。
+func ObserveAvatarNotModified() {
+	if m := defaultAvatarMetrics.Load(); m != nil {
+		m.NotModified.Inc()
+	}
+}
+
+// ObserveAvatarRender 记录一次真实渲染的耗时与结果。
+func ObserveAvatarRender(dur time.Duration, err error) {
+	if m := defaultAvatarMetrics.Load(); m != nil {
+		status := dependencyStatusOK
+		if err != nil {
+			status = dependencyStatusError
+		}
+		m.RenderDuration.WithLabelValues(status).Observe(dur.Seconds())
+	}
+}
+
+// AddAvatarRenderInflight 调整正在进行的渲染数(+1 开始 / -1 结束)。
+func AddAvatarRenderInflight(delta float64) {
+	if m := defaultAvatarMetrics.Load(); m != nil {
+		m.RenderInflight.Add(delta)
+	}
+}
+
+// ObserveAvatarSemaphoreWait 记录一次渲染信号量等待耗时。
+func ObserveAvatarSemaphoreWait(dur time.Duration) {
+	if m := defaultAvatarMetrics.Load(); m != nil {
+		m.SemaphoreWait.Observe(dur.Seconds())
+	}
+}

--- a/pkg/metrics/avatar_test.go
+++ b/pkg/metrics/avatar_test.go
@@ -1,0 +1,104 @@
+package metrics
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// counterValue 在 reg 中按名找一个无 label(或单 label 匹配)的 counter 值。
+func counterValue(t *testing.T, reg *prometheus.Registry, name, labelName, labelVal string) float64 {
+	t.Helper()
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			if labelName == "" {
+				return m.GetCounter().GetValue()
+			}
+			for _, l := range m.GetLabel() {
+				if l.GetName() == labelName && l.GetValue() == labelVal {
+					return m.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+	return 0
+}
+
+func TestAvatarMetrics_RegisterAndObserve(t *testing.T) {
+	prev := defaultAvatarMetrics.Load()
+	t.Cleanup(func() { defaultAvatarMetrics.Store(prev) })
+
+	reg := prometheus.NewRegistry()
+	NewAvatarMetrics(reg) // 同时登记为包级默认
+
+	ObserveAvatarCacheHit()
+	ObserveAvatarCacheHit()
+	ObserveAvatarCacheMiss()
+	ObserveAvatarSingleflightShared()
+	ObserveAvatarNotModified()
+	ObserveAvatarRender(8*time.Millisecond, nil)
+	ObserveAvatarRender(3*time.Millisecond, errors.New("boom"))
+	ObserveAvatarSemaphoreWait(2 * time.Millisecond)
+	AddAvatarRenderInflight(1)
+	AddAvatarRenderInflight(-1)
+
+	if got := counterValue(t, reg, "dmwork_avatar_cache_events_total", "result", "hit"); got != 2 {
+		t.Fatalf("cache hit = %v, want 2", got)
+	}
+	if got := counterValue(t, reg, "dmwork_avatar_cache_events_total", "result", "miss"); got != 1 {
+		t.Fatalf("cache miss = %v, want 1", got)
+	}
+	if got := counterValue(t, reg, "dmwork_avatar_render_singleflight_shared_total", "", ""); got != 1 {
+		t.Fatalf("singleflight shared = %v, want 1", got)
+	}
+	if got := counterValue(t, reg, "dmwork_avatar_not_modified_total", "", ""); got != 1 {
+		t.Fatalf("not_modified = %v, want 1", got)
+	}
+
+	// 渲染直方图按 status 各记一次。
+	mfs, _ := reg.Gather()
+	var okN, errN uint64
+	for _, mf := range mfs {
+		if mf.GetName() != "dmwork_avatar_render_duration_seconds" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "status" {
+					switch l.GetValue() {
+					case dependencyStatusOK:
+						okN = m.GetHistogram().GetSampleCount()
+					case dependencyStatusError:
+						errN = m.GetHistogram().GetSampleCount()
+					}
+				}
+			}
+		}
+	}
+	if okN != 1 || errN != 1 {
+		t.Fatalf("render duration samples ok=%d err=%d, want 1/1", okN, errN)
+	}
+}
+
+func TestAvatarObserve_NoDefaultIsNoop(t *testing.T) {
+	prev := defaultAvatarMetrics.Load()
+	t.Cleanup(func() { defaultAvatarMetrics.Store(prev) })
+	defaultAvatarMetrics.Store(nil)
+	// 未初始化默认实例时必须是纯 no-op,不得 panic。
+	ObserveAvatarCacheHit()
+	ObserveAvatarCacheMiss()
+	ObserveAvatarSingleflightShared()
+	ObserveAvatarNotModified()
+	ObserveAvatarRender(time.Millisecond, nil)
+	ObserveAvatarSemaphoreWait(time.Millisecond)
+	AddAvatarRenderInflight(1)
+}


### PR DESCRIPTION
## Summary

Fixes the root cause behind #480 (invite / member-list slowness). On-demand
avatar rendering had **no server-side defense on the non-conditional GET path**.
Under a member-list fanout, hundreds of concurrent renders saturate the pod's
cores and starve co-scheduled request goroutines (e.g. the invite endpoint) on
the Go scheduler run queue — invisible to DB/network probes, which is why the
earlier SQL/round-trip investigation came up empty.

Controlled experiment that isolated it: toggling DevTools "Disable cache" **off**
dropped the same `POST /v1/groups/:group_no/members` from **8.7s → 47ms** with no
change to the invite path. "Disable cache" suppresses the avatar `If-None-Match`/304
fast path, so every avatar re-renders.

This PR adds a **process-global shared render cache** so a fanout can never
multiply renders or take all cores.

## Related Issue

- #480 (root cause + diagnosis in the issue thread)
- Coordinates with #478 (server-rendered group avatars) — see **Coordination** below.

## Changes

- `pkg/avatarrender/cache.go` — `Cache`: bytes LRU keyed by the same content
  factors as the ETag, **singleflight** to collapse concurrent cold renders, and
  a **render-concurrency semaphore** (default `max(1, GOMAXPROCS-1)`) so a fanout
  can never take all Ps. nil-receiver safe (degrades to direct render).
- `pkg/avatarrender/default.go` — process-global singleton: `GetOrRender` /
  `SetDefaultCache` / `ConfigFromEnv`. One shared LRU and — critically — **one
  semaphore** across all avatar endpoints. Per-endpoint caches would each cap
  renders at N, making the real process ceiling 2N and defeating the guard.
- `modules/user/api.go` — `UserAvatar` routes both renders (nameMode +
  ASCII fallback) through `avatarrender.GetOrRender`; counts 304s. The ETag/304
  fast path is unchanged — this protects the non-conditional GETs it can't.
- `pkg/metrics/avatar.go` — avatar metrics: cache hit/miss, render duration,
  inflight, semaphore wait, singleflight shared, 304 count.
- `main.go` — builds the single shared cache, injects metrics hooks (keeps
  `pkg/avatarrender` free of `pkg/metrics`), `SetDefaultCache`.

Tunable via `DM_AVATAR_CACHE_SIZE` / `DM_AVATAR_RENDER_MAX_CONCURRENCY`.

## Coordination with #478

#478 makes group `avatarGet` render on demand (`avatarrender.RenderGroup` /
`RenderIcon`). To stay protected, those two call sites should route through the
shared cache (keyed by the ETag #478 already computes):

```go
imageData, genErr := avatarrender.GetOrRender(etag, func() ([]byte, error) {
    return avatarrender.RenderGroup(text, style, avatarrender.DefaultSize)
})
iconData, iconErr := avatarrender.GetOrRender(iconEtag, func() ([]byte, error) {
    return avatarrender.RenderIcon(style)
})
```

Proposed order: **merge this fix first**, then #478 adapts (the new files here
don't conflict with #478 — different files in `pkg/avatarrender`).

## Testing

```
go build ./...
go vet ./pkg/avatarrender/ ./pkg/metrics/ ./modules/user/ .
go test ./pkg/avatarrender/ ./pkg/metrics/
go test ./modules/user/ -run 'NoLegacyResponseError|TestAvatarETag|TestIfNoneMatchSatisfied'
golangci-lint run ./pkg/avatarrender/... ./pkg/metrics/...   # 0 issues
```

- **Cache unit tests**: hit/miss, error-not-cached, singleflight (50 concurrent
  same-key → exactly 1 render), semaphore bounds concurrency, nil-receiver.
- **Metrics tests**: registration/counts, no-op when unregistered.
- **Repro + fix validation** (`GOMAXPROCS=2`, no external deps):
  `TestRenderFanoutStarvesVictim` — 16-render fanout inflates a simulated invite
  22ms → ~370ms (~16×); `TestCacheEliminatesStarvation` — routing through the real
  `avatarrender.Cache` returns it to ~1×.

Not run: `modules/user` / `modules/group` integration tests (need MySQL/Redis/WuKongIM,
not available in this environment); test binaries compile.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   Avatar default renders go through a process-global cache: LRU hit returns bytes
   with zero CPU; concurrent cold renders for the same key are coalesced by
   singleflight; the number of simultaneous real renders is bounded by a semaphore.
   The ETag/304 conditional fast path is untouched. Net effect: a member-list
   fanout triggers at most one render per distinct avatar instead of N, and can
   never consume all CPU.

2. **What could break (dependents + failure mode)?**
   The cache key must capture all content-deciding factors; it reuses the exact
   factors the ETag already enumerates (mode-version / uid / text), so a rename or
   recolor produces a new key — no stale image. The render closure must be
   deterministic (it is). If cache construction ever failed, `SetDefaultCache` is
   not called and `GetOrRender` degrades to direct render (no behavior change, just
   no protection). A too-low semaphore could serialize cold renders, but cached
   content makes that one-time and keeps non-avatar traffic responsive (the
   explicit tradeoff; tunable via env).

3. **How do you know it works (specific test/repro/trace)?**
   The controlled production experiment (disable-cache toggle: 8.7s ↔ 47ms) plus
   the deterministic `GOMAXPROCS=2` tests: a render fanout inflates a simulated
   invite ~16×, and routing the same fanout through `avatarrender.Cache` returns it
   to ~1×. Cache/singleflight/semaphore behaviors are pinned by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTmwnF18wfFgTAjufuMrXn)_