### PR TITLE
fix(avatarrender): transparent corners on rendered default avatars

### DIFF
--- a/.octospec/journal/shared/group-default-avatar.md
+++ b/.octospec/journal/shared/group-default-avatar.md
@@ -234,3 +234,20 @@ PR #486 评审,**必修阻断项**:渲染字节变了但 **ETag/cache 版本 tag
 - 验证:`go build ./...`;avatarrender(timing 默认 skip)+ group + user 头像端点全绿;golangci-lint
   0 issues;i18n-lint 过。stale-test-DB 迁移 panic 是既有 harness 状态问题(非本改动),drop+recreate
   `test` 库后各模块单独跑均过。
+
+### PR #486 评审第二轮:端点版本 pin 测试(Jerry-Xin 非阻塞建议)
+d169ffc7 后 4 位 reviewer 全 Approve,唯一开放项是 Jerry-Xin(两轮均提)的非阻塞 🔵:现有测试覆盖
+ETag **函数**,但没有任何测试 pin 端点实际接线的版本段。真实缺口——若后人把 handler 里
+`group-name-v3`/`group-icon-v3`/`name-v4` 误改回旧版(或下次改渲染漏 bump),当前无测试会挂,客户端
+会 304 到陈旧图(正是上一轮的阻断根因)。补两个端点级 pin:
+- `modules/group/avatar_version_pin_test.go` `TestGroupAvatarGetPinsRenderVersion`:命名群→断言响应
+  ETag == `avatarrender.ETag("group-name-v3", groupNo, "seed", GroupText(name))`;空名→图标兜底→断言
+  == `ETag("group-icon-v3", groupNo, "seed")`。
+- `modules/user/avatar_version_pin_test.go` `TestUserAvatarGetPinsRenderVersion`:可渲染昵称→断言响应
+  ETag == `avatarETag("name-v4", uid, IndividualText(name))`。`ascii-v1` 故意不 pin(走未改的
+  `generateDefaultAvatar`)。
+- 设计:测试里的版本字面量与 handler 内联字面量**相互独立**,故单边漂移即不等→失败(非同源恒真);
+  `GroupText`/`IndividualText` 复用 handler 同一函数,取字规则将来合法变更时测试与 handler 同步移动,
+  **只 pin 版本段**。复用现有 `doAvatarGet`/`getAvatarForTest` 端点桩,无新 handler→不触 NoLegacy 守卫。
+- 验证:`go vet`、`go build ./...`、两端点 pin + 既有 avatar 测试全绿、NoLegacyResponseError 守卫
+  group/user 均 ok、golangci-lint 0 issues。

--- a/.octospec/journal/shared/group-default-avatar.md
+++ b/.octospec/journal/shared/group-default-avatar.md
@@ -216,3 +216,21 @@ draw.Src)` 铺白底再画圆(当年为「任意背景不透底色」+ 输出无
   group/icon 各加圆外 alpha=0 断言;`inkBox` 仅采圆内核心区不受影响,仅更注释。group/user 端点
   逐字节比对(handler==Render*)两边同源保持一致。**不在本次范围**:未命名群→双人图标、取字规则
   (`Bug反`→`Bu`/`g反`,待设计)。
+
+### PR #486 评审轮修复(6 位 reviewer)
+PR #486 评审,**必修阻断项**:渲染字节变了但 **ETag/cache 版本 tag 没 bump** —— ETag 是对**因子串**
+做 CRC32(非像素),同因子→同 ETag→已缓存旧图的客户端 `If-None-Match` 命中→304→`must-revalidate`
+下**永远返旧白角图**(进程 LRU 同样陈旧到重启)。这正是 #349 当初加白底时 bump 到 `name-v3` 的同
+类动作。修复:
+- bump 渲染版本 tag(ETag + CacheKey 两处同步):`modules/group/api.go` `group-name-v2`→`v3`、
+  `group-icon-v2`→`v3`;`modules/user/api.go` `name-v3`→`v4`。**`ascii-v1` 不动** —— ASCII 兜底
+  `generateDefaultAvatar` 本次未改、字节没变(Octo-Q/QA/yujiawei 三方确认;只在像素真变时才 bump)。
+  两处 ETag 站点加注释:视觉改动(像素变因子不变)必须 bump 版本段。
+- 修两处 stale helper 注释(`render.go` `drawCircle`/`drawCircleFilledStroked`「调用方先铺白底」)——
+  它们是 precondition 措辞,后人照做会把白底加回、静默回归。
+- gate `starvation_repro_test.go` 两个 wall-clock timing 测试(`TestRenderFanoutStarvesVictim`、
+  `TestCacheEliminatesStarvation`)到 `OCTO_TIMING_TESTS=1`,对齐 #478 的群版。QA 实测后者在 main
+  基线一样挂(newFailures=0,既有噪声非回归),gate 后 `go test ./pkg/avatarrender/...` 不再 flake。
+- 验证:`go build ./...`;avatarrender(timing 默认 skip)+ group + user 头像端点全绿;golangci-lint
+  0 issues;i18n-lint 过。stale-test-DB 迁移 panic 是既有 harness 状态问题(非本改动),drop+recreate
+  `test` 库后各模块单独跑均过。

--- a/.octospec/journal/shared/group-default-avatar.md
+++ b/.octospec/journal/shared/group-default-avatar.md
@@ -201,3 +201,18 @@ i18n-lint + 源码守卫；全仓无残留引用（仅说明性注释）。
 判为非阻断(group_no 是不可枚举 UUID;与已上线的 user-avatar 渲染昵称同型;本 PR 反而以
 disband/不存在→404 收紧了面),但因 security-sensitive 标签,留待人类显式 ack。其余延后项
 同前(groupUpdate 跨步原子性、强 ETag、公开端点限流与 UserAvatar 一起做)。
+
+## Post-merge 跟进:透明四角(group + user 头像)
+合并后线上观察:渲染的默认头像**圆外是不透明白底**,在不裁圆/深色 surface 上露白方块。
+根因:`RenderGroup`/`RenderIcon`/`Render` 三个函数都先 `draw.Draw(canvas, …, color.White, …,
+draw.Src)` 铺白底再画圆(当年为「任意背景不透底色」+ 输出无 alpha 的 RGB,与旧 ASCII/bot
+头像一致)。`image.NewRGBA` 零值即全透明,故**删掉那行铺白底**即可:圆外保持透明,`png.Encode`
+自动输出带 alpha 的 RGBA PNG。三函数各删一行 + 去掉随之 unused 的 `image/draw` import + 改文档
+注释。**范围 group + user 一起**(`avatarrender.Render` 生产仅 `modules/user/api.go` 调,波及干净)。
+- 方案选型:服务端直接透明 vs 客户端加遮罩 → 取**服务端透明**。描边圆环已把形状焊死成圆
+  (裁成非圆会切坏环),客户端遮罩换形状是伪需求;服务端一次改、所有 surface 立即正确、不依赖
+  各端正确裁圆、零副作用。
+- 测试:`TestRenderOpaque`→`TestRenderTransparentCorners`(四角 alpha=0 + 整图非 Opaque);
+  group/icon 各加圆外 alpha=0 断言;`inkBox` 仅采圆内核心区不受影响,仅更注释。group/user 端点
+  逐字节比对(handler==Render*)两边同源保持一致。**不在本次范围**:未命名群→双人图标、取字规则
+  (`Bug反`→`Bu`/`g反`,待设计)。

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -456,9 +456,12 @@ func (g *Group) writeGroupDefaultAvatar(c *wkhttp.Context, groupNo string, group
 
 	// ETag 覆盖决定图像内容的因子：渲染模式版本 + group_no(派生色) + 实际色 + 文字。
 	// 改名/改自定义文字 → text 变 → ETag 变；改自定义色 → colorTag 变 → ETag 变。
-	etag := avatarrender.ETag("group-icon-v2", groupNo, colorTag)
+	// 渲染**视觉**改动(像素变但因子不变，如 #486 透明四角)必须 bump 版本段(…-v2→…-v3)，
+	// 否则已缓存旧图的客户端 If-None-Match 命中同一 ETag → 304 → 一直返旧图。
+
+	etag := avatarrender.ETag("group-icon-v3", groupNo, colorTag)
 	if renderable {
-		etag = avatarrender.ETag("group-name-v2", groupNo, colorTag, text)
+		etag = avatarrender.ETag("group-name-v3", groupNo, colorTag, text)
 	}
 	c.Header("Content-Disposition", "inline; filename=avatar.png")
 	c.Header("ETag", etag)
@@ -475,7 +478,7 @@ func (g *Group) writeGroupDefaultAvatar(c *wkhttp.Context, groupNo string, group
 	// 一张。缓存 key 用 CacheKey（完整原始因子，与 ETag 同因子但**非** CRC32 弱指纹），
 	// 避免 32 位碰撞跨群串图。
 	if renderable {
-		nameKey := avatarrender.CacheKey("group-name-v2", groupNo, colorTag, text)
+		nameKey := avatarrender.CacheKey("group-name-v3", groupNo, colorTag, text)
 		imageData, genErr := avatarrender.GetOrRender(nameKey, func() ([]byte, error) {
 			return avatarrender.RenderGroup(text, style, avatarrender.DefaultSize)
 		})
@@ -485,11 +488,11 @@ func (g *Group) writeGroupDefaultAvatar(c *wkhttp.Context, groupNo string, group
 		}
 		// 渲染失败不直接 500，记录后回退群组图标；ETag 改回 icon 模式与内容一致。
 		g.Error("生成群名默认头像失败，回退群组图标", zap.Error(genErr), zap.String("group_no", groupNo))
-		c.Header("ETag", avatarrender.ETag("group-icon-v2", groupNo, colorTag))
+		c.Header("ETag", avatarrender.ETag("group-icon-v3", groupNo, colorTag))
 	}
 
 	// 群名为空 / 不可渲染（如纯 emoji）/ 渲染失败 → 群组图标。
-	iconKey := avatarrender.CacheKey("group-icon-v2", groupNo, colorTag)
+	iconKey := avatarrender.CacheKey("group-icon-v3", groupNo, colorTag)
 	iconData, iconErr := avatarrender.GetOrRender(iconKey, func() ([]byte, error) {
 		return avatarrender.RenderIcon(style)
 	})

--- a/modules/group/avatar_version_pin_test.go
+++ b/modules/group/avatar_version_pin_test.go
@@ -1,0 +1,48 @@
+package group
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/avatarrender"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGroupAvatarGetPinsRenderVersion pins the render-mode version tokens the group
+// default-avatar endpoint wires into the ETag. The ETag is a CRC32 over the content
+// *factors* (mode-version + group_no + color + text), NOT the PNG bytes — so a future
+// drift of a version token (an accidental revert group-name-v3 -> v2, or a forgotten
+// bump on the next visual change) would silently change the served image's cache
+// identity with no other test failing, and clients holding the old ETag would 304
+// onto a stale image. That is exactly the #486 staleness root cause (precedent #349).
+//
+// Existing endpoint tests assert the ETag is present / weak / changes on rename, but
+// none pin the version literal. This recomputes the expected ETag with the expected
+// version string and asserts the endpoint emits exactly it, so any token drift fails
+// loudly here. GroupText is the same helper the handler uses, so a legitimate change
+// to the first-N-runes text rule moves test and handler in lockstep — only the version
+// segment is pinned.
+func TestGroupAvatarGetPinsRenderVersion(t *testing.T) {
+	s, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	g := New(ctx)
+
+	// Named, renderable group, no custom color -> name render mode, default colorTag "seed".
+	const namedNo = "avatar_pin_named_1"
+	require.NoError(t, g.db.Insert(&Model{GroupNo: namedNo, Name: "后端架构讨论", Creator: "c1", Status: 1}))
+	named := doAvatarGet(t, s.GetRoute(), namedNo, "")
+	require.Equal(t, http.StatusOK, named.Code)
+	wantName := avatarrender.ETag("group-name-v3", namedNo, "seed", avatarrender.GroupText("后端架构讨论"))
+	require.Equal(t, wantName, named.Header().Get("ETag"),
+		"group name-avatar endpoint must wire render version group-name-v3 (keep in sync with the rendered bytes)")
+
+	// Empty name -> icon fallback mode -> "group-icon-v3".
+	const iconNo = "avatar_pin_icon_1"
+	require.NoError(t, g.db.Insert(&Model{GroupNo: iconNo, Name: "", Creator: "c1", Status: 1}))
+	icon := doAvatarGet(t, s.GetRoute(), iconNo, "")
+	require.Equal(t, http.StatusOK, icon.Code)
+	wantIcon := avatarrender.ETag("group-icon-v3", iconNo, "seed")
+	require.Equal(t, wantIcon, icon.Header().Get("ETag"),
+		"group icon-avatar endpoint must wire render version group-icon-v3")
+}

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -589,9 +589,11 @@ func (u *User) UserAvatar(c *wkhttp.Context) {
 			text := avatarrender.IndividualText(userInfo.Name)
 			nameMode := avatarrender.Renderable(text)
 			// ETag 覆盖决定内容的因子：渲染模式版本 + uid(决定颜色) + 展示文字。
+			// 渲染**视觉**改动(像素变但因子不变，如 #486 透明四角)必须 bump 版本段(name-v3→
+			// name-v4)；ascii-v1 走 generateDefaultAvatar，本次未改其像素，故不 bump。
 			etag := avatarETag("ascii-v1", uid)
 			if nameMode {
-				etag = avatarETag("name-v3", uid, text)
+				etag = avatarETag("name-v4", uid, text)
 			}
 			setAvatarHeaders(etag)
 			if ifNoneMatchSatisfied(c.GetHeader("If-None-Match"), etag) {
@@ -609,7 +611,7 @@ func (u *User) UserAvatar(c *wkhttp.Context) {
 			// ETag 是 32 位弱指纹，作共享缓存身份会碰撞→跨用户串图（PR#481 评审）。
 			// 两者覆盖同一组因子（渲染版本/uid→色/文字），仅 ETag 头继续用 CRC32。
 			if nameMode {
-				nameKey := avatarCacheKey("name-v3", uid, text)
+				nameKey := avatarCacheKey("name-v4", uid, text)
 				imageData, genErr := avatarrender.GetOrRender(nameKey, func() ([]byte, error) {
 					return avatarrender.Render(avatarrender.Options{
 						Text: text,

--- a/modules/user/avatar_version_pin_test.go
+++ b/modules/user/avatar_version_pin_test.go
@@ -1,0 +1,36 @@
+package user
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/avatarrender"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUserAvatarGetPinsRenderVersion pins the render-mode version token (name-v4) the
+// personal default-avatar endpoint wires into the ETag. Same rationale as the group
+// pin: the ETag is a CRC32 over content factors (mode-version + uid + text), NOT the
+// PNG bytes, so a silent version drift (accidental revert name-v4 -> name-v3, or a
+// forgotten bump on the next visual change) would change the served image's cache
+// identity with no other test catching it — clients on the old ETag would 304 onto a
+// stale image (#486 root cause). IndividualText is the same helper the handler uses,
+// so only the version segment is pinned here. ascii-v1 is intentionally not pinned: it
+// renders via the unchanged generateDefaultAvatar path and was correctly left un-bumped.
+func TestUserAvatarGetPinsRenderVersion(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	ctx.GetConfig().Avatar.Default = ""
+	ctx.GetConfig().Avatar.DefaultBaseURL = "" // force the local server-side render path
+
+	u := New(ctx)
+	const uid = "avatar_pin_name_1"
+	require.NoError(t, u.db.Insert(&Model{UID: uid, Name: "张三丰", Username: uid, ShortNo: "avpin001", Status: 1}))
+
+	w := getAvatarForTest(t, s.GetRoute(), uid) // asserts 200 + image/png
+	text := avatarrender.IndividualText("张三丰")
+	require.True(t, avatarrender.Renderable(text), "precondition: nickname must be renderable to hit name-v4 mode")
+	want := avatarETag("name-v4", uid, text)
+	require.Equal(t, want, w.Header().Get("ETag"),
+		"personal name-avatar endpoint must wire render version name-v4 (keep in sync with the rendered bytes)")
+}

--- a/pkg/avatarrender/fontsize_test.go
+++ b/pkg/avatarrender/fontsize_test.go
@@ -22,8 +22,8 @@ func decodePNG(t *testing.T, data []byte) image.Image {
 }
 
 // inkBox 返回白色文字墨迹的包围盒及其相对边长的宽高比例。仅在圆内核心区采样，
-// 排除圆外底色（不透明输出后圆外为白）与圆边抗锯齿环——文字受墨迹盒/字号上限
-// 约束，恒落在核心区内。背景须为非白色（testBg）。
+// 排除圆外（现为透明）与圆边抗锯齿环——文字受墨迹盒/字号上限约束，恒落在核心区内。
+// 背景圆须为非白色（testBg）。
 func inkBox(t *testing.T, data []byte) (minX, minY, maxX, maxY int, wRatio, hRatio float64) {
 	t.Helper()
 	img := decodePNG(t, data)
@@ -117,10 +117,9 @@ func TestInkStaysInsideCircle(t *testing.T) {
 	}
 }
 
-// TestRenderOpaque 输出必须不透明（圆外为白底，非透明）——与旧 ASCII 兜底、
-// 13 色 Bot 头像一致，客户端在任意背景下都不会透出底色。验证四角为不透明白、
-// 且整图 Opaque。
-func TestRenderOpaque(t *testing.T) {
+// TestRenderTransparentCorners 输出圆外必须**透明**（带 alpha 通道的 RGBA PNG）：四角
+// alpha=0，且整图非 Opaque——客户端在任意背景上合成时圆外不出白方块。
+func TestRenderTransparentCorners(t *testing.T) {
 	for _, text := range []string{"一序", "aw", "王", "W序"} {
 		data, err := Render(Options{Text: text, Bg: testBg, Size: 200})
 		if err != nil {
@@ -135,14 +134,13 @@ func TestRenderOpaque(t *testing.T) {
 			{b.Max.X - 1, b.Max.Y - 1},
 		}
 		for _, c := range corners {
-			r, g, bb, a := img.At(c[0], c[1]).RGBA()
-			if a != 0xffff || r < 0xe000 || g < 0xe000 || bb < 0xe000 {
-				t.Errorf("text %q: corner (%d,%d) not opaque white: rgba=%04x,%04x,%04x,%04x",
-					text, c[0], c[1], r, g, bb, a)
+			_, _, _, a := img.At(c[0], c[1]).RGBA()
+			if a != 0 {
+				t.Errorf("text %q: corner (%d,%d) not transparent: alpha=%04x", text, c[0], c[1], a)
 			}
 		}
-		if oi, ok := img.(interface{ Opaque() bool }); ok && !oi.Opaque() {
-			t.Errorf("text %q: rendered image is not opaque", text)
+		if oi, ok := img.(interface{ Opaque() bool }); ok && oi.Opaque() {
+			t.Errorf("text %q: rendered image must not be opaque (corners should be transparent)", text)
 		}
 	}
 }

--- a/pkg/avatarrender/group.go
+++ b/pkg/avatarrender/group.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"image"
 	"image/color"
-	"image/draw"
 	"image/png"
 	"math"
 
@@ -57,9 +56,10 @@ func isWideRune(r rune) bool {
 		(r >= 0xFF00 && r <= 0xFF60) // 全角 ASCII 变体
 }
 
-// RenderGroup 渲染群默认头像「白底 + 浅底描边圆 + 居中主题色文字」，文字按
-// GroupAvatarLines 决定单行或两行（2×2）。个人头像继续走 Render（单行实心圆），
-// 本函数仅供群头像使用，故可独立调整视觉而不影响个人头像。
+// RenderGroup 渲染群默认头像「浅底描边圆 + 居中主题色文字」，圆外**透明**（输出带 alpha
+// 通道的 RGBA PNG，客户端在任意背景上合成时圆外不出白方块），文字按 GroupAvatarLines
+// 决定单行或两行（2×2）。个人头像继续走 Render（单行实心圆），本函数仅供群头像使用，
+// 故可独立调整视觉而不影响个人头像。
 func RenderGroup(text string, style GroupStyle, size int) ([]byte, error) {
 	if text == "" {
 		return nil, fmt.Errorf("avatarrender: empty text")
@@ -74,8 +74,8 @@ func RenderGroup(text string, style GroupStyle, size int) ([]byte, error) {
 	lines := GroupAvatarLines(text)
 
 	big := size * supersample
+	// 画布零值即全透明，不再铺白底：圆外保持透明，png.Encode 自动输出带 alpha 的 RGBA PNG。
 	canvas := image.NewRGBA(image.Rect(0, 0, big, big))
-	draw.Draw(canvas, canvas.Bounds(), image.NewUniform(color.White), image.Point{}, draw.Src)
 	drawCircleFilledStroked(canvas, style.Fill, style.Main, groupCircleStrokeRatio)
 
 	if err := drawCenteredLines(canvas, fnt, lines, big, style.Main); err != nil {

--- a/pkg/avatarrender/group_test.go
+++ b/pkg/avatarrender/group_test.go
@@ -64,7 +64,8 @@ func TestRenderGroupUsesGroupStyleFillAndStroke(t *testing.T) {
 	}
 	assertCloseColor(t, img.At(100, 20), style.Fill, "circle fill")
 	assertCloseColor(t, img.At(100, 2), style.Main, "circle stroke")
-	assertCloseColor(t, img.At(0, 0), color.RGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}, "outside circle")
+	// 圆外透明（alpha=0）：不再铺白底，输出带 alpha 通道的 RGBA PNG。
+	assertCloseColor(t, img.At(0, 0), color.RGBA{R: 0, G: 0, B: 0, A: 0}, "outside circle transparent")
 }
 
 func TestRenderGroupEmptyTextErrors(t *testing.T) {

--- a/pkg/avatarrender/icon_etag_test.go
+++ b/pkg/avatarrender/icon_etag_test.go
@@ -32,6 +32,10 @@ func TestRenderIconUsesGroupStyleAndTwoToneGlyph(t *testing.T) {
 	}
 	assertCloseColor(t, img.At(100, 20), style.Fill, "icon circle fill")
 	assertCloseColor(t, img.At(100, 2), style.Main, "icon circle stroke")
+	// 圆外透明（alpha=0）：图标头像同样不铺白底，输出带 alpha 通道的 RGBA PNG。
+	if _, _, _, a := img.At(0, 0).RGBA(); a != 0 {
+		t.Errorf("icon corner (0,0) not transparent: alpha=%04x", a)
+	}
 	if got := countClosePixels(img, style.IconBack); got < 30 {
 		t.Fatalf("icon back color pixels = %d, want >= 30", got)
 	}

--- a/pkg/avatarrender/render.go
+++ b/pkg/avatarrender/render.go
@@ -137,7 +137,7 @@ func Render(opts Options) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// drawCircle 在 img 上填充一个充满边界的实心圆；圆外像素保持调用方预先铺好的底色。
+// drawCircle 在 img 上填充一个充满边界的实心圆；圆外像素不动（画布零值即透明，调用方不铺底色）。
 func drawCircle(img *image.RGBA, c color.RGBA) {
 	b := img.Bounds()
 	d := float64(b.Dx())
@@ -156,7 +156,7 @@ func drawCircle(img *image.RGBA, c color.RGBA) {
 }
 
 // drawCircleFilledStroked 在 img 上绘制群头像专用圆：浅色填充 + 主题色描边。
-// img 应由调用方先铺白底；本函数只改圆内像素，圆外保持原底色。
+// 本函数只改圆内像素，圆外不动（画布零值即透明，调用方不铺底色）。
 func drawCircleFilledStroked(img *image.RGBA, fill, stroke color.RGBA, strokeRatio float64) {
 	b := img.Bounds()
 	d := float64(b.Dx())

--- a/pkg/avatarrender/render.go
+++ b/pkg/avatarrender/render.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"image"
 	"image/color"
-	"image/draw"
 	"image/png"
 	"math"
 	"sync"
@@ -99,9 +98,8 @@ type Options struct {
 	Size int
 }
 
-// Render 渲染一张「白底 + 纯色圆 + 居中白色文字」的 PNG，返回编码后的字节。
-// 圆外为白色，输出不透明（整图 alpha 全 255，png.Encode 会编码为不带 alpha
-// 通道的 RGB PNG）——与旧 ASCII 兜底、13 色 Bot 头像一致。
+// Render 渲染一张「纯色圆 + 居中白色文字」的 PNG，返回编码后的字节。圆外**透明**
+//（png.Encode 输出带 alpha 通道的 RGBA PNG），客户端在任意背景上合成时圆外不出白方块。
 // 文字颜色固定为白色（与设计稿一致，不做对比度切换）。
 func Render(opts Options) ([]byte, error) {
 	if opts.Text == "" {
@@ -118,11 +116,9 @@ func Render(opts Options) ([]byte, error) {
 
 	big := size * supersample
 
-	// 1. 先用白底铺满画布，再画硬边圆。圆外保持白色，使输出为不透明 PNG
-	//（与旧 ASCII 兜底、13 色 Bot 头像一致），客户端在任意背景下都不会透出底色。
-	// 整图 alpha 全 255 → png.Encode 自动编码为不带 alpha 通道的 RGB PNG。
+	// 1. 画布零值即全透明，不铺底色，直接画硬边圆。圆外保持透明，png.Encode 自动输出
+	// 带 alpha 通道的 RGBA PNG（客户端在任意背景上合成时圆外不出白方块）。
 	canvas := image.NewRGBA(image.Rect(0, 0, big, big))
-	draw.Draw(canvas, canvas.Bounds(), image.NewUniform(color.White), image.Point{}, draw.Src)
 	drawCircle(canvas, opts.Bg)
 
 	// 2. 居中渲染白色文字。
@@ -275,7 +271,7 @@ func loadGroupIconMasks() (image.Image, image.Image, error) {
 	return groupIconFrontImg, groupIconBackImg, groupIconErr
 }
 
-// RenderIcon 渲染「白底 + 浅底描边圆 + 双色群组图标」的 PNG，用于群名为空或
+// RenderIcon 渲染「浅底描边圆 + 双色群组图标」的 PNG，圆外**透明**，用于群名为空或
 // 无法取字时的兜底。style 来自群头像专用色板，不影响个人头像 Render。
 func RenderIcon(style GroupStyle) ([]byte, error) {
 	return renderIconSized(style, DefaultSize)
@@ -291,8 +287,8 @@ func renderIconSized(style GroupStyle, size int) ([]byte, error) {
 	}
 
 	big := size * supersample
+	// 画布零值即全透明，不铺白底：圆外保持透明，输出带 alpha 的 RGBA PNG。
 	canvas := image.NewRGBA(image.Rect(0, 0, big, big))
-	draw.Draw(canvas, canvas.Bounds(), image.NewUniform(color.White), image.Point{}, draw.Src)
 	drawCircleFilledStroked(canvas, style.Fill, style.Main, groupCircleStrokeRatio)
 
 	backTint := tintMask(back, style.IconBack)

--- a/pkg/avatarrender/starvation_repro_test.go
+++ b/pkg/avatarrender/starvation_repro_test.go
@@ -1,6 +1,7 @@
 package avatarrender
 
 import (
+	"os"
 	"runtime"
 	"sort"
 	"sync"
@@ -108,6 +109,12 @@ func TestRenderFanoutStarvesVictim(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip starvation repro in -short")
 	}
+	// 本测断言 wall-clock 放大倍数(ratio>=2x)，在共享/受压 runner 上抖动(快/空闲机不饿死、
+	// 慢机更饿)，会让 `go test ./pkg/avatarrender/...` flaky(#486 评审实测)。它**演示** #480
+	// 饿死、不在 CI 钉死任何不变量，故默认跳过，仅 OCTO_TIMING_TESTS=1 手动复现。
+	if os.Getenv("OCTO_TIMING_TESTS") != "1" {
+		t.Skip("set OCTO_TIMING_TESTS=1 to run the wall-clock starvation repro (timing-fragile on shared runners)")
+	}
 	prev := runtime.GOMAXPROCS(2) // 模拟生产 2 核 pod
 	defer runtime.GOMAXPROCS(prev)
 
@@ -159,6 +166,12 @@ func TestRenderFanoutStarvesVictim(t *testing.T) {
 func TestCacheEliminatesStarvation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip cache validation in -short")
+	}
+	// 同 TestRenderFanoutStarvesVictim：断言 under/base 放大倍数(<=1.8x)，在受压 runner 上
+	// 抖动误报(#486 评审实测在 main 基线上一样挂 ~2.5x，newFailures=0 → 既有噪声非回归)。
+	// 缓存收敛的确定性证明见 group_starvation_test.go 的 TestGroupRenderCacheCollapsesRenders。
+	if os.Getenv("OCTO_TIMING_TESTS") != "1" {
+		t.Skip("set OCTO_TIMING_TESTS=1 to run the wall-clock cache-vs-starvation validation (timing-fragile on shared runners)")
 	}
 	prev := runtime.GOMAXPROCS(2)
 	defer runtime.GOMAXPROCS(prev)


### PR DESCRIPTION
## Summary

Server-rendered default avatars (group text/icon and personal) painted an opaque white background outside the circle, so the PNG corners showed as white squares on any surface that doesn't clip the avatar to a circle (e.g. dark-theme list rows). This makes the corners transparent instead.

## Related Issue

N/A — post-merge follow-up to #478, reported from the test environment.

## Linked Spec

`.octospec/journal/shared/group-default-avatar.md` → "Post-merge 跟进: 透明四角 (group + user 头像)".

## Changes

- `RenderGroup`, `RenderIcon`, `Render` no longer fill the canvas with opaque `color.White` before drawing the circle. `image.NewRGBA` is zero-initialized to fully transparent, so the circle (fill + stroke + text/icon) is drawn on a transparent canvas and `png.Encode` now emits an RGBA (alpha) PNG with transparent corners.
- Drop the now-unused `image/draw` import in both files; update the doc comments.
- Covers **both group and user avatars** — `avatarrender.Render` is called in production only by `modules/user`, so one change keeps the two consistent.

## Why server-side transparency (not client-side masking)

The avatar's designed stroke ring commits it to a circular shape — clipping the PNG to a non-circle (rounded-square) would cut the ring. So one server change renders correctly on every surface without depending on each client to clip; clients that already clip to a circle are unaffected.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified (composited onto dark + checkerboard backgrounds; corners show the background through)

Commands run:

- `go build ./...`
- `go test ./pkg/avatarrender/...`
- `go test ./modules/group/ -run TestGroupAvatarGet` and `go test ./modules/user/ -run Avatar`
- `golangci-lint run ./pkg/avatarrender/...`

Test changes: `TestRenderOpaque` → `TestRenderTransparentCorners` (four corners alpha=0, image not `Opaque`); the group and icon tests gain an outside-circle alpha=0 assertion; `inkBox` samples only the in-circle core so the font-size tests are unaffected. The group/user avatar endpoint byte-exact comparisons stay consistent (both sides share the render functions).

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   The avatar render functions stop pre-filling the canvas white. The visible circle (fill/stroke/text/icon) is unchanged; only the previously-white corners become transparent, and the output PNG gains an alpha channel (RGBA instead of RGB). The `GET /v1/groups/:group_no/avatar` and `GET /v1/users/:uid/avatar` handlers are untouched — they pass the render bytes through, and their content-derived ETags still match (same factors, different pixel bytes).

2. **What could break** because of it (dependents + failure mode)?

   Any consumer that assumed an opaque/RGB avatar PNG. In practice clients display avatars clipped to a circle (uploaded photos are already square sources that get clipped), so transparent corners render correctly; the only behavioral change is that unclipped / dark surfaces no longer show a white square. PNG size grows marginally (alpha channel). No DB / auth / route / contract change.

3. **How do you know it works** (specific test/repro/trace)?

   New `TestRenderTransparentCorners` asserts all four corners have alpha=0 and the image is not `Opaque`; `TestRenderGroupUsesGroupStyleFillAndStroke` and `TestRenderIconUsesGroupStyleAndTwoToneGlyph` assert the outside-circle pixel is transparent while fill/stroke are unchanged. Visually verified by compositing group + personal avatars onto dark and checkerboard backgrounds. Group/user avatar endpoint integration tests pass (byte-exact handler-vs-render comparison).

## Out of scope (separate follow-ups)

- Unnamed groups (auto member-name display name) rendering text instead of the two-person icon.
- The first-4-runes text rule producing awkward mixed-script avatars (e.g. `Bug反` → `Bu` / `g反`) — pending a design decision.

## Checklist

- [x] PR description is in English
- [x] Added tests for my changes
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtR4joR4kcbPSVGHyxBYkC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtR4joR4kcbPSVGHyxBYkC)_