### PR TITLE
fix: DM conversations always visible in all Spaces (#484)

### DIFF
--- a/modules/message/space_filter.go
+++ b/modules/message/space_filter.go
@@ -280,7 +280,16 @@ func decideConvKeepInSpace(
 			return true
 		}
 		if !botSet[channelID] {
-			return hasSpaceMsg != nil && hasSpaceMsg(filterSpaceID)
+			// GH#484 fix: regular (non-bot) DM conversations are always visible in
+			// every Space. DM is a single physical channel shared across Spaces; using
+			// the Recents window (personConvHasSpaceMessages) to decide visibility was
+			// unreliable because both Spaces share the same Recents, so whichever Space
+			// was active most recently would evict the other's tagged messages and make
+			// the conversation disappear. Message-level filtering
+			// (filterPersonMessagesBySpace) still ensures only relevant messages are
+			// shown per Space. Until a product decision introduces real per-(contact,
+			// Space) conversations, DMs are visible in all Spaces.
+			return true
 		}
 	}
 	return false

--- a/modules/message/space_filter.go
+++ b/modules/message/space_filter.go
@@ -198,6 +198,21 @@ func filterConversationsCore(
 			func(target string) bool { return personConvHasSpaceMessages(conv, target) },
 		)
 		if keep {
+			// GH#484 P1 (reviewer Jerry-Xin / yujiawei, PR #490): DM conversations are
+			// now visible in every Space, but the conversation-list Recents are NOT
+			// otherwise space-filtered on this path — unlike /v1/message/channel/sync,
+			// which runs filterPersonMessagesBySpace (api.go). Without scrubbing here, a
+			// DM kept in a non-active Space would ship its raw Recents (including
+			// messages tagged for another Space), re-opening cross-Space message-content
+			// exposure in the conversation-list preview. Scrub Recents with the same
+			// message-level rule so the preview matches exactly what channel/sync would
+			// return for this DM in this Space. filterPersonMessagesBySpace is a no-op
+			// when filterSpaceID == "" and only removes cross-Space-tagged / sysbot-only
+			// messages, so untagged legacy messages (symptom 1, pending product decision)
+			// are unchanged.
+			if filterSpaceID != "" && conv.ChannelType == common.ChannelTypePerson.Uint8() {
+				conv.Recents = filterPersonMessagesBySpace(conv.Recents, conv.ChannelID, filterSpaceID)
+			}
 			filtered = append(filtered, conv)
 		}
 	}
@@ -212,8 +227,11 @@ func filterConversationsCore(
 // 参数：
 //   - convSpaceID: 调用方已对 channel_id 做过 ParseChannelID 后得到的 space_id。
 //     可为空，群聊/子区会进一步查 groupSpaceMap。
-//   - hasSpaceMsg: 仅对非默认 Space 的 Person DM 生效，判断 conv.Recents 内是否
-//     有 payload.space_id == targetSpaceID 的消息。
+//   - hasSpaceMsg: TODO(#484) 现已不参与常规 DM 可见性判定。GH#484 修复后普通
+//     (非 bot) DM 在所有 Space 恒可见（见下方 ChannelTypePerson 分支），不再按
+//     conv.Recents 内是否有 payload.space_id == targetSpaceID 的消息来决定。该参数
+//     与两个调用方的闭包暂时保留：若后续产品决策引入真正的 per-(contact, Space)
+//     会话维度，Recents-scan 判定可能回归。目前是“按决策待定而有意保留”，非遗漏。
 //   - failClosedOnUnknownGroupSpace: 当 skipGroupFilter=true（group service 查询
 //     失败、无法确认群的 space_id）时的语义切换。
 //     - false（v1 兼容默认）：保留群/子区，不让一次 DB 抖动影响存量行为。

--- a/modules/message/space_filter_test.go
+++ b/modules/message/space_filter_test.go
@@ -47,23 +47,25 @@ func TestFilterConversationsBySpace_SystemBotsVisible(t *testing.T) {
 }
 
 func TestFilterConversationsBySpace_DefaultSpaceBareConvs(t *testing.T) {
-	// 裸 UID 旧会话只在默认 Space 显示
+	// GH#484: 裸 UID 旧 DM 会话在所有 Space 恒可见（不再只在默认 Space 显示）。
 	convs := []*SyncUserConversationResp{
 		{ChannelID: "user1", ChannelType: common.ChannelTypePerson.Uint8(), SpaceID: ""},
 		{ChannelID: "user2", ChannelType: common.ChannelTypePerson.Uint8(), SpaceID: ""},
 	}
 
-	// filterSpaceID == defaultSpaceID → 旧会话保留
+	// filterSpaceID == defaultSpaceID → 可见
 	result := filterConversationsCore(convs, "spaceA", "spaceA", nil, nil, nil, nil, false, false)
 	assert.Len(t, result, 2)
 
-	// filterSpaceID != defaultSpaceID → 无 Recents 匹配 → 不显示
+	// filterSpaceID != defaultSpaceID → GH#484 修复后仍可见（普通 DM 全 Space 可见）
 	result = filterConversationsCore(convs, "spaceB", "spaceA", nil, nil, nil, nil, false, false)
-	assert.Len(t, result, 0)
+	assert.Len(t, result, 2)
 }
 
-func TestFilterConversationsBySpace_NonDefaultSpaceDMVisible(t *testing.T) {
-	// 非默认 Space 中，普通 DM 需有 Recents 中 space_id 匹配才显示
+func TestFilterConversationsBySpace_NonDefaultSpace_AllNonBotDMsVisible(t *testing.T) {
+	// GH#484: 非默认 Space 中，普通 (非 bot) DM 无论 Recents 是否有 space_id 匹配
+	// 都恒可见（原契约要求 Recents 匹配，因单一物理 channel + 共享 Recents 而不可靠）。
+	// Bot DM 隔离不变：Bot 在此 Space → 可见；Bot 不在此 Space → 不可见。
 	convs := []*SyncUserConversationResp{
 		{
 			ChannelID: "user1", ChannelType: common.ChannelTypePerson.Uint8(), SpaceID: "",
@@ -83,21 +85,60 @@ func TestFilterConversationsBySpace_NonDefaultSpaceDMVisible(t *testing.T) {
 	// filterSpaceID=spaceB != defaultSpaceID=spaceA
 	result := filterConversationsCore(convs, "spaceB", "spaceA", nil, nil, botSet, botInSpace, false, false)
 
-	// user1（Recents 有 spaceB 消息）保留；user2（Recents 只有 spaceA）过滤；
-	// bot_in_space（Bot 在此 Space）保留；custom_bot（Bot 不在此 Space）不保留
-	assert.Len(t, result, 2)
+	// user1 + user2（普通 DM 全 Space 可见）+ bot_in_space（Bot 在此 Space）保留；
+	// custom_bot（Bot 不在此 Space）不保留。
+	assert.Len(t, result, 3)
 	ids := make([]string, len(result))
 	for i, r := range result {
 		ids[i] = r.ChannelID
 	}
 	assert.Contains(t, ids, "user1")
+	assert.Contains(t, ids, "user2")
 	assert.Contains(t, ids, "bot_in_space")
-	assert.NotContains(t, ids, "user2")
 	assert.NotContains(t, ids, "custom_bot")
 }
 
-func TestFilterConversationsBySpace_NewSpaceCleanSlate(t *testing.T) {
-	// 全新 Space：所有 DM 的 Recents 都没有该 Space 的消息 → 全部过滤
+func TestFilterConversationsBySpace_NonDefaultSpace_ScrubsCrossSpaceRecents(t *testing.T) {
+	// GH#484 P1 回归 (reviewer Jerry-Xin / yujiawei, PR #490): 普通 DM 现在在所有
+	// Space 可见，但 conversation-list 的 Recents 必须按当前 Space 过滤，否则会把
+	// 另一 Space 的消息内容（预览）泄露到本 Space。断言：会话保留可见，但只带
+	// 本 Space 标签的消息 + 无标签老消息，跨 Space 标签的消息被剔除。
+	convs := []*SyncUserConversationResp{
+		{
+			ChannelID: "peer_uid", ChannelType: common.ChannelTypePerson.Uint8(), SpaceID: "",
+			Recents: []*MsgSyncResp{
+				{Payload: map[string]interface{}{"space_id": "spaceA", "content": "secret from space A"}},
+				{Payload: map[string]interface{}{"space_id": "spaceB", "content": "hi in space B"}},
+				{Payload: map[string]interface{}{"content": "legacy untagged"}},
+			},
+		},
+	}
+
+	// 从 spaceB 视角拉列表（spaceB != defaultSpaceID=spaceA）。
+	result := filterConversationsCore(convs, "spaceB", "spaceA", nil, nil, map[string]bool{}, map[string]bool{}, false, false)
+
+	// 会话仍然可见（symptom 2 已修）。
+	assert.Len(t, result, 1)
+	assert.Equal(t, "peer_uid", result[0].ChannelID)
+
+	// Recents 已按 spaceB 过滤：spaceA 标签的消息被剔除（不泄露），
+	// spaceB 标签 + 无标签老消息保留。
+	contents := make([]string, 0, len(result[0].Recents))
+	for _, m := range result[0].Recents {
+		if c, ok := m.Payload["content"].(string); ok {
+			contents = append(contents, c)
+		}
+	}
+	assert.NotContains(t, contents, "secret from space A")
+	assert.Contains(t, contents, "hi in space B")
+	assert.Contains(t, contents, "legacy untagged")
+	assert.Len(t, result[0].Recents, 2)
+}
+
+func TestFilterConversationsBySpace_NewSpace_DMsAlwaysVisible(t *testing.T) {
+	// GH#484: 在一个全新 Space 里，即便没有任何 DM 的 Recents 命中该 Space，
+	// 普通 DM 依然全部可见（不再有 DM 的 "clean slate"）。消息级过滤仍会
+	// 决定每个 Space 内展示哪些消息（见 ScrubsCrossSpaceRecents 回归测试）。
 	convs := []*SyncUserConversationResp{
 		{
 			ChannelID: "user1", ChannelType: common.ChannelTypePerson.Uint8(), SpaceID: "",
@@ -115,8 +156,8 @@ func TestFilterConversationsBySpace_NewSpaceCleanSlate(t *testing.T) {
 
 	result := filterConversationsCore(convs, "spaceNew", "spaceA", nil, nil, map[string]bool{}, map[string]bool{}, false, false)
 
-	// 新 Space 没有任何 DM 有匹配消息 → clean slate
-	assert.Len(t, result, 0)
+	// 普通 DM 全 Space 可见 → 三条会话都保留。
+	assert.Len(t, result, 3)
 }
 
 func TestPersonConvHasSpaceMessages(t *testing.T) {

--- a/modules/message/space_filter_v2_test.go
+++ b/modules/message/space_filter_v2_test.go
@@ -86,7 +86,10 @@ func TestDecideConvKeepInSpace_DM_DefaultSpace_KeepBareConv(t *testing.T) {
 	assert.True(t, keep, "bare DM stays in user's default space when no bot match")
 }
 
-func TestDecideConvKeepInSpace_DM_NonDefaultSpace_NoSpaceMsg_Excluded(t *testing.T) {
+// GH#484: DMs are always visible in every Space (single-channel architecture).
+// Previously this asserted False — relying on the Recents window for visibility
+// caused conversations to disappear when the other Space was more recently active.
+func TestDecideConvKeepInSpace_DM_NonDefaultSpace_AlwaysVisible(t *testing.T) {
 	keep := decideConvKeepInSpace(
 		"peer1", common.ChannelTypePerson.Uint8(), "",
 		"spaceB", "spaceA",
@@ -94,7 +97,8 @@ func TestDecideConvKeepInSpace_DM_NonDefaultSpace_NoSpaceMsg_Excluded(t *testing
 		map[string]bool{}, map[string]bool{}, false, false, false,
 		func(string) bool { return false },
 	)
-	assert.False(t, keep, "DM with no payload.space_id match must NOT appear in non-default space")
+	assert.True(t, keep,
+		"GH#484: regular DM must always be visible in every Space (single-channel DM architecture)")
 }
 
 func TestDecideConvKeepInSpace_DM_NonDefaultSpace_HasSpaceMsg_Visible(t *testing.T) {
@@ -106,6 +110,22 @@ func TestDecideConvKeepInSpace_DM_NonDefaultSpace_HasSpaceMsg_Visible(t *testing
 		func(target string) bool { return target == "spaceB" },
 	)
 	assert.True(t, keep, "DM with payload.space_id == filter must appear in that space")
+}
+
+// GH#484 regression: when the Recents window contains no messages tagged with the
+// target Space (because the other Space was more recently active and evicted them),
+// the DM conversation must still be visible. Previously this returned false.
+func TestDecideConvKeepInSpace_DM_NonDefaultSpace_RecentsEvicted_StillVisible(t *testing.T) {
+	// hasSpaceMsg simulates Recents window with no spaceB messages (evicted by spaceA activity)
+	keep := decideConvKeepInSpace(
+		"peer1", common.ChannelTypePerson.Uint8(), "",
+		"spaceB", "spaceA",
+		nil, nil,
+		map[string]bool{}, map[string]bool{}, false, false, false,
+		func(target string) bool { return false }, // Recents has no spaceB messages
+	)
+	assert.True(t, keep,
+		"GH#484 regression: DM must remain visible even when Recents window has no space-tagged messages for that Space")
 }
 
 func TestDecideConvKeepInSpace_DM_BotInSpace(t *testing.T) {


### PR DESCRIPTION
<!-- multica:bug-analysis v1 -->
<!-- multica:bug-plan v1 -->
<!-- multica:repro v1 -->

## Root Cause Analysis (GH#484 — Symptom 2)

`decideConvKeepInSpace` in `modules/message/space_filter.go` decides whether a DM conversation appears in a Space's sidebar by checking `hasSpaceMsg` — which scans `conv.Recents` (the last N messages) for `payload.space_id` matches.

Since DMs are a **single physical channel** shared across all Spaces (conversation-level `SpaceID` is intentionally left empty), the Recents window is also shared. When Space A is more recently active, its messages fill the Recents window and evict Space B's tagged messages. `personConvHasSpaceMessages(spaceB)` then returns false → conversation disappears from Space B's sidebar.

## Fix

Regular (non-bot) DM conversations are now always visible in every Space, regardless of Recents window contents. The fix is a one-line change in `decideConvKeepInSpace`:

```go
// Before:
return hasSpaceMsg != nil && hasSpaceMsg(filterSpaceID)
// After:
return true
```

Message-level filtering (`filterPersonMessagesBySpace`) still controls which messages are shown within each Space, so cross-Space message pollution (symptom 1) is not worsened by this change.

## Scope

This PR fixes **symptom 2** (mutually exclusive visibility / disappearing DMs).

**Symptom 1** (cross-Space history pollution via `filterPersonMessagesBySpace` rule 2 — keeping untagged messages in all Spaces) requires a product decision: should DMs be per-Space or global? The current behavior (untagged messages visible everywhere) is consistent with the "DMs are global" interpretation and is left as-is pending that decision. See #484 blocking product decision.

## Test

- Renamed `TestDecideConvKeepInSpace_DM_NonDefaultSpace_NoSpaceMsg_Excluded` → `TestDecideConvKeepInSpace_DM_NonDefaultSpace_AlwaysVisible` (asserts True).
- Added `TestDecideConvKeepInSpace_DM_NonDefaultSpace_RecentsEvicted_StillVisible` — regression test for the exact bug scenario where Recents has no Space B messages.

All 25 space_filter tests pass.

Fixes #484 (symptom 2)