### PR TITLE
feat(incomingwebhook): render Multica issue link + assignee (multi-line)

### DIFF
--- a/modules/incomingwebhook/adapter.go
+++ b/modules/incomingwebhook/adapter.go
@@ -21,7 +21,9 @@ package incomingwebhook
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"strings"
+	"unicode"
 )
 
 // pushAdapter 描述一种推送形态。
@@ -145,6 +147,45 @@ func firstLine(s string) string {
 func isHTTPURL(s string) bool {
 	l := strings.ToLower(strings.TrimSpace(s))
 	return strings.HasPrefix(l, "http://") || strings.HasPrefix(l, "https://")
+}
+
+// safeMarkdownURL validates an externally-supplied URL for safe interpolation
+// into a markdown link DESTINATION `](url)`. isHTTPURL alone is insufficient:
+// the destination is a distinct injection context — a value like
+// `https://ok/) [phish](https://evil` passes a scheme prefix check yet closes
+// the intended link and injects a second attacker-controlled link into the
+// message (#496 review). CommonMark also forbids/encodes spaces and control
+// chars in a bare destination, and a literal `)` ends it.
+//
+// Returns (url, true) only when the value: parses via net/url, is http(s), is
+// host-bearing, and contains no ASCII space, control char, or any of the
+// destination-breaking metacharacters `< > ( ) [ ] " \`. Otherwise (",", false)
+// so the caller downgrades to a plain-text (non-link) title — same degrade
+// contract as a non-http scheme.
+func safeMarkdownURL(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if !isHTTPURL(raw) {
+		return "", false
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return "", false
+	}
+	for _, r := range raw {
+		if r > unicode.MaxASCII {
+			// Non-ASCII (e.g. an IDN host or a unicode path) can't appear in a
+			// bare destination unescaped; reject rather than risk mis-rendering.
+			return "", false
+		}
+		if unicode.IsSpace(r) || unicode.IsControl(r) {
+			return "", false
+		}
+		switch r {
+		case '<', '>', '(', ')', '[', ']', '"', '\\':
+			return "", false
+		}
+	}
+	return raw, true
 }
 
 // oneLine 把多行文本压成单行，避免标题 / 评论里的换行破坏 markdown 链接结构。

--- a/modules/incomingwebhook/adapter_multica.go
+++ b/modules/incomingwebhook/adapter_multica.go
@@ -138,6 +138,7 @@ func renderMulticaIssueStatusChanged(ev muEnvelope) string {
 	prev := strings.TrimSpace(ev.PreviousStatus)
 	issueURL := strings.TrimSpace(ev.IssueURL)
 	assignee := strings.TrimSpace(ev.AssigneeName)
+	assigneeType := strings.TrimSpace(ev.AssigneeType)
 	actorType := strings.TrimSpace(ev.Actor.Type)
 	// id 与 status 是渲染所必需的最小集；缺失任一无法生成可读消息，回退
 	// 让上层走 reason=content 而非凭空生造。
@@ -150,16 +151,23 @@ func renderMulticaIssueStatusChanged(ev muEnvelope) string {
 	var b strings.Builder
 
 	// --- 标题行 ---
-	// 链接文本是 "{identifier} {title}"（title 可空）。有合法 http(s) url 时整体
-	// 包成 markdown 链接（mdLinkText 防 `]` 闭合）；否则降级纯文本（identifier
-	// 加粗，mdInertText 防 `*`/反引号 注入）。url 过 isHTTPURL 白名单杜绝
-	// `javascript:` 等 scheme 注入。
-	if issueURL != "" && isHTTPURL(issueURL) {
+	// 链接文本是 "{identifier} {title}"（title 可空）。有合法 url 时整体包成
+	// markdown 链接；否则降级纯文本。
+	//   - 链接文本用 mdInertText（不是 mdLinkText）：CommonMark 会在链接文本
+	//     内部解析强调/代码 span,所以文本里的 `*`/反引号/`[]` 必须按 inert 处理,
+	//     否则一个含 `**` 的 title 注入真粗体、一个含反引号的 title 把后面 status
+	//     code-span 切坏（#496 yujiawei/OctoBoooot review）。mdInertText 转义
+	//     `*_[]<>|` 并剥反引号——转义后的 `\]` 是字面右括号,不会闭合链接,对链接
+	//     文本同样安全。
+	//   - 链接目标用 safeMarkdownURL:仅 isHTTPURL 不够,目标是独立注入上下文,
+	//     `https://ok/) [phish](https://evil` 会闭合链接再注入第二个链接
+	//     （#496 Jerry-Xin/OctoBoooot review）。校验失败则降级纯文本标题。
+	if safeURL, ok := safeMarkdownURL(issueURL); ok {
 		linkText := id
 		if title != "" {
 			linkText = id + " " + title
 		}
-		fmt.Fprintf(&b, "**[%s](%s)**", mdLinkText(linkText, 200), issueURL)
+		fmt.Fprintf(&b, "**[%s](%s)**", mdInertText(linkText, 200), safeURL)
 	} else {
 		fmt.Fprintf(&b, "**%s**", mdInertText(id, shortFieldMax))
 		if title != "" {
@@ -182,9 +190,15 @@ func renderMulticaIssueStatusChanged(ev muEnvelope) string {
 
 	// --- 指派 / 触发行（任一非空才渲染整行）---
 	// assignee_name 由 multica 富集发来（octo 只收到 UUID，无法自解析人名）。
+	// assignee_type（member/agent/squad）附在名字后,让群里能区分指派给「人」
+	// 还是「Agent/Squad」(#496 yujiawei review:type 之前解析了却没用)。
 	var meta []string
 	if assignee != "" {
-		meta = append(meta, "指派: "+mdInertText(assignee, shortFieldMax))
+		label := "指派: " + mdInertText(assignee, shortFieldMax)
+		if assigneeType != "" {
+			label += " (" + mdInertText(assigneeType, shortFieldMax) + ")"
+		}
+		meta = append(meta, label)
 	}
 	if actorType != "" {
 		meta = append(meta, "触发: "+mdInertText(actorType, shortFieldMax))

--- a/modules/incomingwebhook/adapter_multica.go
+++ b/modules/incomingwebhook/adapter_multica.go
@@ -45,11 +45,19 @@ type muActor struct {
 
 // muEnvelope 是 multica 出站 webhook 的固定信封（见 multica
 // server/internal/integrations/outwebhook/dispatcher.go outboundPayload）。
+//
+// issue_url / assignee_type / assignee_name 是 multica 侧富集字段（后端用
+// PublicURL+slug+identifier 拼好 url、join 出 assignee 显示名后发来）——octo
+// 侧无法从 UUID/workspace_id 自行推断,所以直接消费。三者都是【加性】的:
+// 旧版 multica 不发 → 留空,渲染降级（无链接 / 无指派行）。
 type muEnvelope struct {
 	Event          string  `json:"event"`
 	WorkspaceID    string  `json:"workspace_id"`
 	Actor          muActor `json:"actor"`
 	Issue          muIssue `json:"issue"`
+	IssueURL       string  `json:"issue_url"`
+	AssigneeType   string  `json:"assignee_type"`
+	AssigneeName   string  `json:"assignee_name"`
 	PreviousStatus string  `json:"previous_status"`
 }
 
@@ -113,43 +121,24 @@ func parseMulticaPush(_ http.Header, body []byte) (*pushPayloadReq, string, stri
 
 // renderMulticaIssueStatusChanged 渲染 issue.status_changed 事件。
 //
-// 输出形如（markdown，客户端会渲染）：
+// 输出形如（markdown，客户端会渲染），多行结构化：
 //
-//	**MUL-123** Fix login redirect: `todo` → `in_progress` (by agent)
+//	**[MUL-123 Fix login redirect](https://app.multica.ai/acme/issues/MUL-123)**
+//	状态: `todo` → `in_progress`
+//	指派: 张三 · 触发: agent
 //
-// 设计取舍：
-//   - 不拼 issue URL：envelope 当前不带 URL；服务端无法可靠推断 multica
-//     部署域名（self-hosted 路径多种）。需要可点链接时由 multica 后续在
-//     envelope 加 issue.url 字段，渲染层加链接即可，不破坏既有契约。
-//   - 标题与 identifier 之间用空格分隔，与 GitHub 适配器的 issue 渲染风格
-//     一致；状态用反引号包起来，避免下划线（in_progress）被 markdown 误
-//     当作斜体。
-//   - actor 名当前不在 envelope 里，只渲染 type（"by agent" / "by member"）；
-//     未显示触发者类型的情况下省略尾注。
-//   - title 在 `** identifier ** title:` 的「裸文本」上下文（注意：与 github
-//     适配器的 title 不同——github 把 title 包进 `[text](url)` 链接里，所以那边
-//     用只转 `\[]` 的 mdLinkText 是对的；这里 title 不进链接，必须用
-//     mdInertText 才能把 `*`/反引号/`<`/`|` 等元字符也防住，否则一个含反引号
-//     的 title 会让 content 里反引号总数变奇数、把后面的 status code-span 切坏，
-//     一个含 `**` 的 title 会注入真粗体（yujiawei review P1）。
-//   - 其余进 markdown 的字段按上下文走对应 helper（详见 adapter.go 注释）：
-//   - identifier 在 `**...**` 粗体里 → mdInertText（转义 `*` 防止 bold-break，
-//     转义 `[]` 防止 link injection）；
-//   - status / previous_status 在 “ `...` “ code span 里 → mdCodeSpanText
-//     （只剥反引号防止逃逸 code span；`_`/`*` 在 code span 内本就不被解释，
-//     不转义否则会回显 `\_` 破坏显示）；
-//   - actor.type 在 `(by ...)` 纯文本上下文 → mdInertText（全量转义）。
-//     这些字段按 multica 契约都是受控枚举/标识符，escape 是 defense-in-depth
-//     （PR #427 review by yujiawei / mochashanyao / Jerry-Xin）。
-//   - 字段长度统一钳到 64 rune：identifier/status/actor 在 multica 端是短
-//     标识符（identifier 形如 "MUL-12345"、status 是枚举、actor.type 是
-//     "member"/"agent"），64 足够覆盖正常上限并把异常长度截短防御。title
-//     仍用 200 rune（与 GitHub PR/issue 标题钳值对齐）。
+// 三行分别是「标题（带链接）/ 状态变更 / 指派·触发」；缺字段的行自动省略。
+// issue_url 与 assignee_name 是 multica 侧富集字段（octo 无法从 UUID/
+// workspace_id 自行推断域名、slug、人名），渲染层直接消费、并对 url 做
+// http(s) 白名单。各字段的转义/钳长策略见函数内逐行注释。
 func renderMulticaIssueStatusChanged(ev muEnvelope) string {
 	id := strings.TrimSpace(ev.Issue.Identifier)
 	title := strings.TrimSpace(ev.Issue.Title)
 	status := strings.TrimSpace(ev.Issue.Status)
 	prev := strings.TrimSpace(ev.PreviousStatus)
+	issueURL := strings.TrimSpace(ev.IssueURL)
+	assignee := strings.TrimSpace(ev.AssigneeName)
+	actorType := strings.TrimSpace(ev.Actor.Type)
 	// id 与 status 是渲染所必需的最小集；缺失任一无法生成可读消息，回退
 	// 让上层走 reason=content 而非凭空生造。
 	if id == "" || status == "" {
@@ -159,26 +148,51 @@ func renderMulticaIssueStatusChanged(ev muEnvelope) string {
 	const shortFieldMax = 64
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "**%s**", mdInertText(id, shortFieldMax))
-	if title != "" {
-		// 钳到 200 rune 与 GitHub PR/issue 标题渲染保持一致；用 mdInertText 而
-		// 非 mdLinkText——title 在这里是裸文本，不在 `[text](url)` 里（详见上方
-		// 设计取舍）。
-		b.WriteString(" ")
-		b.WriteString(mdInertText(title, 200))
+
+	// --- 标题行 ---
+	// 链接文本是 "{identifier} {title}"（title 可空）。有合法 http(s) url 时整体
+	// 包成 markdown 链接（mdLinkText 防 `]` 闭合）；否则降级纯文本（identifier
+	// 加粗，mdInertText 防 `*`/反引号 注入）。url 过 isHTTPURL 白名单杜绝
+	// `javascript:` 等 scheme 注入。
+	if issueURL != "" && isHTTPURL(issueURL) {
+		linkText := id
+		if title != "" {
+			linkText = id + " " + title
+		}
+		fmt.Fprintf(&b, "**[%s](%s)**", mdLinkText(linkText, 200), issueURL)
+	} else {
+		fmt.Fprintf(&b, "**%s**", mdInertText(id, shortFieldMax))
+		if title != "" {
+			b.WriteString(" ")
+			b.WriteString(mdInertText(title, 200))
+		}
 	}
-	b.WriteString(": ")
+
+	// --- 状态行 ---
+	// 反引号包起来避免下划线（in_progress）被当斜体；prev 缺失或与 status 相同
+	// 时只显示当前状态，不画 "→ X" 暗示变化的尾巴。
+	b.WriteString("\n状态: ")
 	if prev != "" && prev != status {
 		fmt.Fprintf(&b, "`%s` → `%s`",
 			mdCodeSpanText(prev, shortFieldMax),
 			mdCodeSpanText(status, shortFieldMax))
 	} else {
-		// 新建 issue 或事件 payload 缺 previous_status 时只显示当前状态，
-		// 不画"→ X"那种暗示状态变化的尾巴。
 		fmt.Fprintf(&b, "`%s`", mdCodeSpanText(status, shortFieldMax))
 	}
-	if actorType := strings.TrimSpace(ev.Actor.Type); actorType != "" {
-		fmt.Fprintf(&b, " (by %s)", mdInertText(actorType, shortFieldMax))
+
+	// --- 指派 / 触发行（任一非空才渲染整行）---
+	// assignee_name 由 multica 富集发来（octo 只收到 UUID，无法自解析人名）。
+	var meta []string
+	if assignee != "" {
+		meta = append(meta, "指派: "+mdInertText(assignee, shortFieldMax))
 	}
+	if actorType != "" {
+		meta = append(meta, "触发: "+mdInertText(actorType, shortFieldMax))
+	}
+	if len(meta) > 0 {
+		b.WriteString("\n")
+		b.WriteString(strings.Join(meta, " · "))
+	}
+
 	return b.String()
 }

--- a/modules/incomingwebhook/adapter_multica_test.go
+++ b/modules/incomingwebhook/adapter_multica_test.go
@@ -60,8 +60,8 @@ func TestParseMulticaPush_IssueStatusChanged_WithLinkAndAssignee(t *testing.T) {
 	require.NotNil(t, req, "skip=%q invalid=%q", skip, invalid)
 	// 标题行渲染成 markdown 链接，链接文本是 "identifier title"。
 	assert.Contains(t, req.Content, "**[MUL-123 Fix login redirect](https://app.multica.ai/acme/issues/MUL-123)**")
-	// 指派与触发同在一行，用 " · " 连接。
-	assert.Contains(t, req.Content, "指派: 张三 · 触发: agent")
+	// 指派(带 type)与触发同在一行，用 " · " 连接。
+	assert.Contains(t, req.Content, "指派: 张三 (member) · 触发: agent")
 }
 
 func TestParseMulticaPush_AssigneeWithoutActor(t *testing.T) {
@@ -107,6 +107,68 @@ func TestParseMulticaPush_NoIssueURL_PlainTextTitle(t *testing.T) {
 	require.NotNil(t, req)
 	assert.Contains(t, req.Content, "**MUL-4** no link")
 	assert.NotContains(t, req.Content, "](", "no link without issue_url")
+}
+
+// TestParseMulticaPush_IssueURLDestinationInjection is the #496 blocker regression:
+// a URL that passes a naive http(s) prefix check but carries link-breaking
+// characters (`)`, space, etc.) must NOT be rendered as a link — it would close
+// the intended destination and inject a second attacker-controlled link.
+func TestParseMulticaPush_IssueURLDestinationInjection(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"close_and_inject", "https://ok.com/) [phish](https://evil.com"},
+		{"trailing_paren", "https://ok.com/issue)"},
+		{"embedded_space", "https://ok.com/a b"},
+		{"newline", "https://ok.com/a\nb"},
+		{"angle_brackets", "https://ok.com/<script>"},
+		{"bracket", "https://ok.com/]injected"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := json.Marshal(map[string]any{
+				"event":           "issue.status_changed",
+				"issue":           map[string]any{"identifier": "MUL-1", "title": "hi", "status": "done"},
+				"issue_url":       tc.url,
+				"previous_status": "todo",
+			})
+			require.NoError(t, err)
+			req, _, _ := parseMulticaPush(http.Header{}, body)
+			require.NotNil(t, req)
+			// The malicious destination must never be rendered as a markdown link.
+			assert.NotContains(t, req.Content, "](", "unsafe url must not become a markdown link: %q", req.Content)
+			assert.NotContains(t, req.Content, "[phish]", "second injected link must not appear")
+			// Degrades to a plain-text bold identifier instead.
+			assert.Contains(t, req.Content, "**MUL-1**", "title falls back to bold plain text")
+		})
+	}
+}
+
+// TestParseMulticaPush_LinkTextInjection is the #496 second blocker: when the
+// title IS rendered inside a link (`[text](url)`), CommonMark still parses
+// emphasis/code spans in the text, so a title with `**` or a backtick must be
+// neutralized — the link-text path uses mdInertText (escapes `*`, strips
+// backtick), not mdLinkText (which only escapes `\[]`).
+func TestParseMulticaPush_LinkTextInjection(t *testing.T) {
+	body, err := json.Marshal(map[string]any{
+		"event":           "issue.status_changed",
+		"issue":           map[string]any{"identifier": "MUL-1", "title": "a **bold** `tick", "status": "in_progress"},
+		"issue_url":       "https://app.multica.ai/acme/issues/MUL-1",
+		"previous_status": "todo",
+	})
+	require.NoError(t, err)
+	req, _, _ := parseMulticaPush(http.Header{}, body)
+	require.NotNil(t, req)
+	// asterisks escaped → no injected bold inside the link text.
+	assert.Contains(t, req.Content, `\*\*bold\*\*`, "asterisks in link text must be escaped")
+	assert.NotContains(t, req.Content, "a **bold**", "raw bold must not survive in link text")
+	// Backticks remain balanced (the title's lone backtick is stripped), so the
+	// downstream status code-span is not corrupted.
+	assert.Equalf(t, 0, strings.Count(req.Content, "`")%2,
+		"backticks must remain balanced (got odd count): %q", req.Content)
+	// Still a valid single link to the safe destination.
+	assert.Contains(t, req.Content, "](https://app.multica.ai/acme/issues/MUL-1)")
 }
 
 func TestParseMulticaPush_IssueStatusChanged_NoPreviousStatus(t *testing.T) {

--- a/modules/incomingwebhook/adapter_multica_test.go
+++ b/modules/incomingwebhook/adapter_multica_test.go
@@ -29,12 +29,84 @@ func TestParseMulticaPush_IssueStatusChanged_FullEnvelope(t *testing.T) {
 	}`)
 	req, skip, invalid := parseMulticaPush(http.Header{}, body)
 	require.NotNil(t, req, "skip=%q invalid=%q", skip, invalid)
-	// 期望渲染：**MUL-123** Fix login redirect on mobile: `todo` → `in_progress` (by agent)
+	// 多行渲染：
+	//   **MUL-123** Fix login redirect on mobile
+	//   状态: `todo` → `in_progress`
+	//   触发: agent
 	assert.Contains(t, req.Content, "**MUL-123**")
 	assert.Contains(t, req.Content, "Fix login redirect on mobile")
-	assert.Contains(t, req.Content, "`todo` → `in_progress`")
-	assert.Contains(t, req.Content, "(by agent)")
+	assert.Contains(t, req.Content, "状态: `todo` → `in_progress`")
+	assert.Contains(t, req.Content, "触发: agent")
 	assert.Empty(t, req.MsgType, "adapters emit the plain-text path")
+}
+
+func TestParseMulticaPush_IssueStatusChanged_WithLinkAndAssignee(t *testing.T) {
+	// multica 富集 issue_url + assignee_name 时：标题成可点链接，多一行指派。
+	body := []byte(`{
+		"event": "issue.status_changed",
+		"workspace_id": "550e8400-e29b-41d4-a716-446655440000",
+		"actor": {"type": "agent", "id": "agent-7"},
+		"issue": {
+			"identifier": "MUL-123",
+			"title": "Fix login redirect",
+			"status": "in_progress"
+		},
+		"issue_url": "https://app.multica.ai/acme/issues/MUL-123",
+		"assignee_type": "member",
+		"assignee_name": "张三",
+		"previous_status": "todo"
+	}`)
+	req, skip, invalid := parseMulticaPush(http.Header{}, body)
+	require.NotNil(t, req, "skip=%q invalid=%q", skip, invalid)
+	// 标题行渲染成 markdown 链接，链接文本是 "identifier title"。
+	assert.Contains(t, req.Content, "**[MUL-123 Fix login redirect](https://app.multica.ai/acme/issues/MUL-123)**")
+	// 指派与触发同在一行，用 " · " 连接。
+	assert.Contains(t, req.Content, "指派: 张三 · 触发: agent")
+}
+
+func TestParseMulticaPush_AssigneeWithoutActor(t *testing.T) {
+	// 只有 assignee_name、没有 actor.type：指派行只渲染指派段，不带 " · 触发"。
+	body := []byte(`{
+		"event": "issue.status_changed",
+		"issue": {"identifier": "MUL-5", "title": "x", "status": "done"},
+		"assignee_type": "agent",
+		"assignee_name": "Codex Bot",
+		"previous_status": "todo"
+	}`)
+	req, _, _ := parseMulticaPush(http.Header{}, body)
+	require.NotNil(t, req)
+	assert.Contains(t, req.Content, "指派: Codex Bot")
+	assert.NotContains(t, req.Content, "·", "no separator when actor is absent")
+	assert.NotContains(t, req.Content, "触发:")
+}
+
+func TestParseMulticaPush_MaliciousIssueURLDowngraded(t *testing.T) {
+	// issue_url 必须过 http(s) 白名单：javascript: 等 scheme 不能渲染成链接，
+	// 标题降级为纯文本（identifier 加粗），且恶意 url 不出现在 content 里。
+	body := []byte(`{
+		"event": "issue.status_changed",
+		"issue": {"identifier": "MUL-9", "title": "evil", "status": "done"},
+		"issue_url": "javascript:alert(1)",
+		"previous_status": "todo"
+	}`)
+	req, _, _ := parseMulticaPush(http.Header{}, body)
+	require.NotNil(t, req)
+	assert.NotContains(t, req.Content, "javascript:", "non-http(s) url must not be rendered")
+	assert.NotContains(t, req.Content, "](", "url must not become a markdown link")
+	assert.Contains(t, req.Content, "**MUL-9**", "title falls back to bold plain text")
+}
+
+func TestParseMulticaPush_NoIssueURL_PlainTextTitle(t *testing.T) {
+	// 无 issue_url（旧版 multica）：标题回退纯文本 `**id** title`，不是链接。
+	body := []byte(`{
+		"event": "issue.status_changed",
+		"issue": {"identifier": "MUL-4", "title": "no link", "status": "done"},
+		"previous_status": "todo"
+	}`)
+	req, _, _ := parseMulticaPush(http.Header{}, body)
+	require.NotNil(t, req)
+	assert.Contains(t, req.Content, "**MUL-4** no link")
+	assert.NotContains(t, req.Content, "](", "no link without issue_url")
 }
 
 func TestParseMulticaPush_IssueStatusChanged_NoPreviousStatus(t *testing.T) {
@@ -50,11 +122,11 @@ func TestParseMulticaPush_IssueStatusChanged_NoPreviousStatus(t *testing.T) {
 	assert.Contains(t, req.Content, "First issue")
 	assert.Contains(t, req.Content, "`todo`")
 	assert.NotContains(t, req.Content, "→", "no arrow when previous_status is absent")
-	assert.Contains(t, req.Content, "(by member)")
+	assert.Contains(t, req.Content, "触发: member")
 }
 
 func TestParseMulticaPush_NoActorType(t *testing.T) {
-	// actor.type 缺失：不渲染 "(by …)" 尾巴。
+	// actor.type 缺失且无 assignee：整个指派/触发行省略。
 	body := []byte(`{
 		"event": "issue.status_changed",
 		"issue": {"identifier": "MUL-3", "title": "no actor", "status": "done"},
@@ -62,7 +134,8 @@ func TestParseMulticaPush_NoActorType(t *testing.T) {
 	}`)
 	req, _, _ := parseMulticaPush(http.Header{}, body)
 	require.NotNil(t, req)
-	assert.NotContains(t, req.Content, "(by")
+	assert.NotContains(t, req.Content, "触发:")
+	assert.NotContains(t, req.Content, "指派:")
 }
 
 func TestParseMulticaPush_TitleEscaping(t *testing.T) {

--- a/modules/incomingwebhook/adapter_test.go
+++ b/modules/incomingwebhook/adapter_test.go
@@ -60,3 +60,35 @@ func TestFirstLineAndOneLine(t *testing.T) {
 	assert.Equal(t, "no newline", firstLine("no newline"))
 	assert.Equal(t, "a b c", oneLine("a\r\nb\nc"))
 }
+
+func TestSafeMarkdownURL(t *testing.T) {
+	ok := []string{
+		"https://app.multica.ai/acme/issues/MUL-1",
+		"http://localhost:3000/x/issues/Y-2",
+		"https://app.multica.ai/acme%20corp/issues/MUL%207", // pre-escaped segments
+	}
+	for _, u := range ok {
+		got, valid := safeMarkdownURL(u)
+		assert.Truef(t, valid, "%q should be accepted", u)
+		assert.Equal(t, u, got)
+	}
+
+	bad := []string{
+		"",
+		"javascript:alert(1)",                       // non-http scheme
+		"data:text/html,x",                          // non-http scheme
+		"https://ok.com/) [phish](https://evil.com", // link-destination injection
+		"https://ok.com/issue)",                     // trailing paren ends destination
+		"https://ok.com/a b",                        // embedded space
+		"https://ok.com/a\nb",                       // newline
+		"https://ok.com/<script>",                   // angle brackets
+		"https://ok.com/]x",                         // bracket
+		"https://",                                  // no host
+		"https://例子.com/x",                          // non-ASCII (IDN) — reject rather than mis-render
+	}
+	for _, u := range bad {
+		got, valid := safeMarkdownURL(u)
+		assert.Falsef(t, valid, "%q should be rejected", u)
+		assert.Empty(t, got)
+	}
+}


### PR DESCRIPTION
Closes #497

## Summary

The Multica adapter now consumes the `issue_url` + `assignee_name` fields Multica enriches its outbound webhook with, and renders a **structured multi-line** notification instead of the previous single line:

```
**[MUL-123 Fix login redirect](https://app.multica.ai/acme/issues/MUL-123)**
状态: `todo` → `in_progress`
指派: 张三 · 触发: agent
```

This is the **octo-server half** of a two-repo change; the Multica half is [Mininglamp-OSS/multica#49](https://github.com/Mininglamp-OSS/multica/pull/49).

## Changes
- `muEnvelope` gains `issue_url` / `assignee_type` / `assignee_name` (whitelist parse).
- `renderMulticaIssueStatusChanged`:
  - **Title line** links to `issue_url` when present, guarded by `isHTTPURL` (a `javascript:` / `data:` scheme downgrades to a plain-text title); link text via `mdLinkText`.
  - **Status line** on its own line.
  - **指派 · 触发 line** omitted entirely when both assignee and actor are empty.
  - Escaping contract unchanged: `mdLinkText` for link text, `mdInertText` for plain-text fields, `mdCodeSpanText` inside code spans.
- **Additive + backward compatible**: an older Multica that doesn't send the new fields renders the no-link / no-assignee form.

## Verification
- `go build ./...`
- `go test ./modules/incomingwebhook/ -run 'TestParseMulticaPush|TestMulticaAdapter|TestPublicURLs'` — all pass (new cases: link+assignee, assignee-without-actor, malicious-url downgrade, no-url plain-text fallback). The MySQL-dependent `TestDisableByGroupNo` is a pre-existing local-only skip.
