### PR TITLE
feat(group): user-named default avatar (is_named) + public avatar color palette endpoint

### DIFF
--- a/.octospec/tasks/group-avatar-icon-default/brief.md
+++ b/.octospec/tasks/group-avatar-icon-default/brief.md
@@ -67,6 +67,29 @@ Two server changes:
   *before* the member-concat fallback overwrites `groupName`. Rename
   (`UpdateGroupInfo`, `req.Name != nil`) → `is_named = 1`; persisted by adding
   `is_named` to `DB.UpdateTx`'s `SetMap` (it used an explicit column list).
+- **All direct creation paths set `is_named` (review #500, Jerry-Xin + OctoBoooot
+  🔴).** `CreateGroup` is not the only insert path: `event.go` system-group
+  (`handleRegisterUserEvent`) + org/dept (`handleOrgOrDeptCreateEvent`) and
+  `Service.AddGroup` insert named groups directly; left at the Go zero value they
+  persist `is_named=0`. Set `IsNamed: 1` on the system/org/dept inserts (they carry
+  an explicit configured name) and `AddGroup` infers it from `TrimSpace(name)!=""`.
+  Note: system/`org_`/`dept_` groups are served *static PNGs* by the prefix-gated
+  branches in `avatarGet` (`api.go:360-394`) and never reach the `is_named` render
+  path, so this is data-correctness/robustness, not a live avatar regression — but
+  the persisted flag must still be right (a removed prefix-branch would otherwise
+  silently break them).
+- **Combined `{name, invite}` update must not revert the rename / `is_named`
+  (review #500 P1, yujiawei + OctoBoooot).** `groupUpdate` (`api.go`) loads the row
+  once, then the name branch commits `name`+`is_named=1` via `UpdateGroupInfo`
+  (its own fresh load) and the invite branch wrote the **stale** snapshot back via
+  the full-column `UpdateTx` — clobbering both. Fix: invite branch uses a
+  column-scoped `DB.UpdateInviteTx` (only `invite`+`version`); the handler no longer
+  caches the full row (existence-check only). This also removes the pre-existing
+  `name`-revert on the same path and the read-modify-write race.
+- **`GroupResp.is_named` exposed (review #500 🟡).** Read-only `is_named` added to
+  `GroupResp` (both `from`/`fromModel` populators) so web clients can locally
+  predict name-text vs icon for an existing group when clearing `avatar_text`
+  (preview parity). Additive, backward-compatible.
 - **Avatar ETag / cache identity.** ETag is CRC32 over content *factors*
   (mode-version + group_no + color + text), not pixels. Named groups use the
   `group-name-v4` factor set (with text); auto-named/empty use `group-icon-v3`

--- a/.octospec/tasks/group-avatar-icon-default/brief.md
+++ b/.octospec/tasks/group-avatar-icon-default/brief.md
@@ -1,0 +1,91 @@
+---
+type: Task
+title: "Task: group-avatar-icon-default"
+description: Default group avatar becomes the two-person icon (name-independent); expose the avatar color palette to clients for local preview parity.
+tags: [group, avatar, render, cache, wire-contract]
+timestamp: 2026-06-29T00:00:00Z
+# --- octospec extension fields ---
+slug: group-avatar-icon-default
+upstream: group-chat-avatar-gen (product, 2026-06-29)
+source: self
+---
+
+# Task: group-avatar-icon-default
+
+> Server-side increment of the "group chat avatar" redesign. Web (octo-web) is a
+> separate follow-up: the 修改头像 secondary dialog + 发起群聊 create dialog with
+> live local preview consuming the palette endpoint below.
+
+## Goal
+Two server changes:
+
+1. **S2 — default avatar is the two-person icon, independent of the group name.**
+   Today an un-uploaded group with no custom `avatar_text` renders its name's
+   leading 2 glyphs (`GroupNameText`), falling back to the two-person icon only
+   when the name yields no renderable glyphs (PR #494). Product (2026-06-29) has
+   reversed this: the default avatar must be the two-person icon **regardless of
+   the group name**; text is rendered **only** when the user has explicitly set a
+   custom `avatar_text` via the 修改头像 dialog.
+
+2. **S1 — expose the avatar color palette over HTTP.** The 10-color palette
+   (`main` / `fill` / `iconBack`) lives only in `pkg/avatarrender/palette.go`.
+   The web color picker + local live preview must render the *same* colors as the
+   server PNG. Add a read endpoint so the palette has a single source of truth and
+   never drifts between server and client.
+
+## Background
+- Avatar render pipeline + custom `avatar_text`/`avatar_color` + the fixed palette
+  shipped in PRs #478 / #486 / #494 (journals: `group-default-avatar`,
+  `default-avatar-text-rule`). Default rendering decision is in
+  `modules/group/api.go` `writeGroupDefaultAvatar`.
+- The default-avatar-text-rule journal already flagged "unnamed groups → icon" as
+  a deferred follow-up needing an `is_named` flag. S2 makes that flag unnecessary:
+  **all** un-customized groups (named or not) use the icon.
+- Web research: there is no avatar dialog in octo-web today (image upload only);
+  the create flow (`OrganizationalGroupNew`) sends members only — no name/avatar.
+  Those are the web follow-up, not this task.
+
+## Load-bearing list
+- `writeGroupDefaultAvatar` text-selection branch (`modules/group/api.go`) — the
+  exact behavior being changed. Custom-text path (`GroupText`, ≤4, as-is) is
+  unchanged; only the no-custom-text fallback flips from `GroupNameText(name)` to
+  empty → icon.
+- **Avatar ETag / cache identity.** ETag is CRC32 over content *factors*
+  (mode-version + group_no + color + text), not pixels. Named groups switch from
+  the `group-name-v4` factor set (with text) to the `group-icon-v3` factor set
+  (no text) → the ETag **changes** on its own, so a stale `If-None-Match` cannot
+  match → clients revalidate to the fresh icon. The `RenderIcon` bytes are NOT
+  touched, so **no version bump is required** (contrast #486: there the icon
+  *pixels* changed). `group-name-v4` is retained for the custom-text path.
+- `GroupNameText` (`pkg/avatarrender/text.go`) — no longer called by the handler
+  after S2; kept (still unit-tested, may serve future use). No behavior change to
+  the function itself.
+- Stale comments in `modules/group/{api.go,db.go,service.go}` that say
+  "空=渲染时回退群名前 2 字派生" — updated to "空=双人图标(默认头像与群名无关)"
+  so future readers don't re-introduce name derivation.
+- **Wire contract (new):** `GET /v1/group/avatar_palette` (public, static design
+  tokens — mirrors the already-public avatar render endpoint). Response:
+  `{ "size": 10, "colors": [ { "index", "main", "fill", "icon_back" } ... ] }`,
+  hex `#RRGGBB`, ordered by palette index. Pure read, no error path → no errcode.
+
+## Out of scope
+- Server default-render rule per named/unnamed distinction (`is_named`) — obviated.
+- Any change to custom `avatar_text`/`avatar_color` create/update APIs, validation,
+  upload path, or the palette *values*/order.
+- All octo-web work (修改头像 dialog, 发起群聊 dialog, local preview component,
+  palette consumption) — separate task in octo-web.
+- Render version bump (intentionally none — see load-bearing list).
+
+## Acceptance
+- `writeGroupDefaultAvatar`: with no custom `avatar_text`, renders `RenderIcon`
+  (two-person icon) for BOTH a named and an empty-name group; renders text ONLY
+  when `avatar_text` is set. Custom color still honored for the icon.
+- `GET /v1/group/avatar_palette` returns `PaletteSize()` (=10) entries; each entry's
+  `main`/`fill`/`icon_back` equals `avatarrender.PaletteHex()`; `colors[0].main == "#14C0FF"`.
+- Updated `TestGroupAvatarGet*` (named, no custom text → icon) and
+  `TestGroupAvatarGetPinsRenderVersion` (text-render version pinned via a
+  custom-text group, since name no longer triggers text). Custom-text not-truncated
+  + uploaded-redirect + 404/disband regressions still pass.
+- `go build ./...`, `go vet`, `golangci-lint`, `make i18n-lint` +
+  `i18n-extract-check`, `TestGroupNoLegacyResponseError` guard all green.
+  (Endpoint tests needing MySQL/Redis/WuKongIM run in CI per prior increments.)

--- a/.octospec/tasks/group-avatar-icon-default/brief.md
+++ b/.octospec/tasks/group-avatar-icon-default/brief.md
@@ -19,13 +19,18 @@ source: self
 ## Goal
 Two server changes:
 
-1. **S2 — default avatar is the two-person icon, independent of the group name.**
-   Today an un-uploaded group with no custom `avatar_text` renders its name's
-   leading 2 glyphs (`GroupNameText`), falling back to the two-person icon only
-   when the name yields no renderable glyphs (PR #494). Product (2026-06-29) has
-   reversed this: the default avatar must be the two-person icon **regardless of
-   the group name**; text is rendered **only** when the user has explicitly set a
-   custom `avatar_text` via the 修改头像 dialog.
+1. **S2 — default avatar follows a *user-given* name; an auto-generated
+   (member-concat) name renders the two-person icon.** Today an un-uploaded group
+   with no custom `avatar_text` always renders its `name`'s leading 2 glyphs
+   (`GroupNameText`), including the member-concatenated default name like
+   `张三、李四、王五` (PR #494). Product (2026-06-29): the default avatar should take
+   the name's first 2 glyphs **only when the user explicitly named the group**; a
+   group left on the auto member-concat name renders the two-person icon (don't
+   render a concat name as avatar text). A new `is_named` flag distinguishes the
+   two (set at create from whether `name` was provided, and on rename). Priority:
+   custom `avatar_text` > named-group name (`is_named=1`) > two-person icon.
+   Existing groups are backfilled `is_named=1` (conservative — no existing avatar
+   changes; only new auto-named groups get the icon).
 
 2. **S1 — expose the avatar color palette over HTTP.** The 10-color palette
    (`main` / `fill` / `iconBack`) lives only in `pkg/avatarrender/palette.go`.
@@ -38,38 +43,39 @@ Two server changes:
   shipped in PRs #478 / #486 / #494 (journals: `group-default-avatar`,
   `default-avatar-text-rule`). Default rendering decision is in
   `modules/group/api.go` `writeGroupDefaultAvatar`.
-- The default-avatar-text-rule journal already flagged "unnamed groups → icon" as
-  a deferred follow-up needing an `is_named` flag. S2 makes that flag unnecessary:
-  **all** un-customized groups (named or not) use the icon.
+- The default-avatar-text-rule journal flagged "unnamed/auto-member-name groups
+  using the icon instead of text" as a deferred follow-up needing an `is_named`
+  flag. S2 implements exactly that: `is_named` is added now (migration backfills
+  existing rows to 1).
 - Web research: there is no avatar dialog in octo-web today (image upload only);
   the create flow (`OrganizationalGroupNew`) sends members only — no name/avatar.
   Those are the web follow-up, not this task.
 
 ## Load-bearing list
-- `writeGroupDefaultAvatar` text-selection branch (`modules/group/api.go`) — the
-  exact behavior being changed. Custom-text path (`GroupText`, ≤4, as-is) is
-  unchanged; only the no-custom-text fallback flips from `GroupNameText(name)` to
-  empty → icon.
+- `writeGroupDefaultAvatar` text-selection branch (`modules/group/api.go`):
+  `avatar_text` → as-is; else `is_named==1` → `GroupNameText(name)`; else icon.
+- **`is_named` lifecycle.** New column (migration `20260629000001`, backfill
+  existing → 1). `CreateGroup`: `is_named = (trimmed req.Name != "")` computed
+  *before* the member-concat fallback overwrites `groupName`. Rename
+  (`UpdateGroupInfo`, `req.Name != nil`) → `is_named = 1`; persisted by adding
+  `is_named` to `DB.UpdateTx`'s `SetMap` (it used an explicit column list).
 - **Avatar ETag / cache identity.** ETag is CRC32 over content *factors*
-  (mode-version + group_no + color + text), not pixels. Named groups switch from
-  the `group-name-v4` factor set (with text) to the `group-icon-v3` factor set
-  (no text) → the ETag **changes** on its own, so a stale `If-None-Match` cannot
-  match → clients revalidate to the fresh icon. The `RenderIcon` bytes are NOT
-  touched, so **no version bump is required** (contrast #486: there the icon
-  *pixels* changed). `group-name-v4` is retained for the custom-text path.
-- `GroupNameText` (`pkg/avatarrender/text.go`) — no longer called by the handler
-  after S2; kept (still unit-tested, may serve future use). No behavior change to
-  the function itself.
-- Stale comments in `modules/group/{api.go,db.go,service.go}` that say
-  "空=渲染时回退群名前 2 字派生" — updated to "空=双人图标(默认头像与群名无关)"
-  so future readers don't re-introduce name derivation.
+  (mode-version + group_no + color + text), not pixels. Named groups use the
+  `group-name-v4` factor set (with text); auto-named/empty use `group-icon-v3`
+  (no text) — different modes → different factor strings, so a rename or an
+  is_named flip changes the text factor and the ETag on its own; clients
+  revalidate to the fresh image. `RenderIcon`/`RenderGroup` bytes are untouched →
+  **no version bump required** (contrast #486: there the icon *pixels* changed).
+- `GroupNameText` (`pkg/avatarrender/text.go`) — still called by the handler for
+  `is_named=1` groups; unchanged behavior.
+- Comments in `modules/group/{api.go,db.go,service.go,const.go}` + swagger updated
+  to the is_named rule ("空=按 is_named 回退：命名群群名/自动名群双人图标").
 - **Wire contract (new):** `GET /v1/group/avatar_palette` (public, static design
   tokens — mirrors the already-public avatar render endpoint). Response:
   `{ "size": 10, "colors": [ { "index", "main", "fill", "icon_back" } ... ] }`,
   hex `#RRGGBB`, ordered by palette index. Pure read, no error path → no errcode.
 
 ## Out of scope
-- Server default-render rule per named/unnamed distinction (`is_named`) — obviated.
 - Any change to custom `avatar_text`/`avatar_color` create/update APIs, validation,
   upload path, or the palette *values*/order.
 - All octo-web work (修改头像 dialog, 发起群聊 dialog, local preview component,
@@ -77,15 +83,18 @@ Two server changes:
 - Render version bump (intentionally none — see load-bearing list).
 
 ## Acceptance
-- `writeGroupDefaultAvatar`: with no custom `avatar_text`, renders `RenderIcon`
-  (two-person icon) for BOTH a named and an empty-name group; renders text ONLY
-  when `avatar_text` is set. Custom color still honored for the icon.
+- `writeGroupDefaultAvatar` with no custom `avatar_text`: `is_named=1` group →
+  `RenderGroup(GroupNameText(name))` (name first-2); `is_named=0` group (or empty
+  name) → `RenderIcon` (two-person). Custom color honored in both. Custom
+  `avatar_text` always overrides.
+- `CreateGroup`: explicit `name` → `is_named=1`; omitted (member-concat) →
+  `is_named=0`. `UpdateGroupInfo` with a name → `is_named=1` (persisted).
 - `GET /v1/group/avatar_palette` returns `PaletteSize()` (=10) entries; each entry's
   `main`/`fill`/`icon_back` equals `avatarrender.PaletteHex()`; `colors[0].main == "#14C0FF"`.
-- Updated `TestGroupAvatarGet*` (named, no custom text → icon) and
-  `TestGroupAvatarGetPinsRenderVersion` (text-render version pinned via a
-  custom-text group, since name no longer triggers text). Custom-text not-truncated
-  + uploaded-redirect + 404/disband regressions still pass.
+- Tests: `TestGroupAvatarGetAutoNamedRendersIcon`, `TestGroupAvatarGetNamedRendersNameText`,
+  `TestCreateGroup_{Success,AutoGenerateName}` is_named asserts,
+  `TestUpdateGroupInfo_RenameMarksIsNamed`; custom-text/uploaded/404/disband + palette
+  + version-pin regressions still pass.
 - `go build ./...`, `go vet`, `golangci-lint`, `make i18n-lint` +
   `i18n-extract-check`, `TestGroupNoLegacyResponseError` guard all green.
   (Endpoint tests needing MySQL/Redis/WuKongIM run in CI per prior increments.)

--- a/.octospec/tasks/group-avatar-icon-default/brief.md
+++ b/.octospec/tasks/group-avatar-icon-default/brief.md
@@ -55,7 +55,15 @@ Two server changes:
 - `writeGroupDefaultAvatar` text-selection branch (`modules/group/api.go`):
   `avatar_text` → as-is; else `is_named==1` → `GroupNameText(name)`; else icon.
 - **`is_named` lifecycle.** New column (migration `20260629000001`, backfill
-  existing → 1). `CreateGroup`: `is_named = (trimmed req.Name != "")` computed
+  existing → 1). The migration is **recovery-safe** (review #500, Jerry-Xin +
+  OctoBoooot 🔴): because MySQL `ALTER TABLE` auto-commits, the backfill must NOT
+  live inside the column-exists guard (a crash between the committed ALTER and the
+  backfill would skip it on retry, leaving existing rows at `DEFAULT 0` =
+  auto-named → icon, violating "no existing avatar changes"). Pattern: (1) add
+  column **NULL** (no default) → existing rows = NULL sentinel; (2) `UPDATE ... SET
+  is_named=1 WHERE is_named IS NULL` run unconditionally (idempotent, only touches
+  not-yet-backfilled rows, converges on any partial-failure retry); (3) `MODIFY` to
+  `NOT NULL DEFAULT 0` for new inserts. `CreateGroup`: `is_named = (trimmed req.Name != "")` computed
   *before* the member-concat fallback overwrites `groupName`. Rename
   (`UpdateGroupInfo`, `req.Name != nil`) → `is_named = 1`; persisted by adding
   `is_named` to `DB.UpdateTx`'s `SetMap` (it used an explicit column list).

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -164,6 +164,7 @@ func (g *Group) Route(r *wkhttp.WKHttp) {
 		openGroup.POST("invite/sure", g.groupMemberInviteSure)                 // 确认邀请
 		openGroup.GET("/invite", groupInviteLimit, g.groupInvitePage)          // H5 邀请落地页（公开）
 		openGroup.GET("/invite/detail", groupInviteLimit, g.groupInviteDetail) // 群邀请预览信息（公开）
+		openGroup.GET("/avatar_palette", g.avatarPalette)                      // 群头像色板（公开静态设计色，供前端本地预览/色圈与服务端渲染一致）
 	}
 	// 邀请详情需要认证
 	group.GET("/invites/:invite_no", g.groupMemberInviteDetail) // 获取邀请详情
@@ -423,14 +424,14 @@ func (g *Group) avatarGet(c *wkhttp.Context) {
 		return
 	}
 
-	// 无自定义上传（含历史合成群、新建群）：服务端实时渲染默认头像——
-	// 浅底描边圆 + 群名前 2 字（或自定义文字），群名为空/不可渲染时回退群组图标。
+	// 无自定义上传（含历史合成群、新建群）：服务端实时渲染默认头像——有自定义文字则
+	// 渲染「浅底描边圆 + 该文字」，否则一律双人图标（默认头像与群名无关）。
 	g.writeGroupDefaultAvatar(c, groupNo, groupInfo)
 }
 
-// writeGroupDefaultAvatar 服务端渲染并返回群默认头像（无自定义上传时）。文字优先
-// 自定义 avatar_text，否则群名前 2 字；颜色优先自定义 avatar_color，否则按 group_no
-// 稳定派生（改名不变色、跨页面一致）。群名为空或不可渲染时回退群组图标。
+// writeGroupDefaultAvatar 服务端渲染并返回群默认头像（无自定义上传时）。仅当用户显式
+// 设置了 avatar_text 时渲染文字，否则一律回退双人图标（默认头像与群名无关）；颜色优先
+// 自定义 avatar_color，否则按 group_no 稳定派生（改名不变色、跨页面一致）。
 //
 // URL 稳定为 groups/{group_no}/avatar，内容随群名/自定义变化，故用内容相关弱 ETag +
 // 短缓存 + must-revalidate：改名后最多 5 分钟内 revalidate 到新图，并支持 304 省渲染。
@@ -440,14 +441,11 @@ func (g *Group) writeGroupDefaultAvatar(c *wkhttp.Context, groupNo string, group
 	colorTag := "seed"
 	var text string
 	if groupInfo != nil {
+		// 默认头像与群名**无关**(产品 2026-06-29 定稿)：仅当用户在「修改头像」里**显式
+		// 设置**了自定义文字时才渲染文字(原样、写入时已按 ≤4 规范化、不做取字/缩写);否则
+		// text 留空 → 不可渲染 → 一律回退双人图标。群名不再参与默认头像取字。
 		if groupInfo.AvatarText != "" {
-			// 用户**显式设置**的自定义文字：原样渲染(写入时已按 ≤4 规范化)，不走群名
-			// 自动取字规则(不截成 2 字、不做首字母缩写)。
 			text = avatarrender.GroupText(groupInfo.AvatarText)
-		} else {
-			// 无自定义文字：按群名**自动取字**(script 感知 —— 汉字前2 / 纯数字前2 /
-			// 纯英文首字母缩写 / 否则空→回退群组图标)。
-			text = avatarrender.GroupNameText(groupInfo.Name)
 		}
 		if groupInfo.AvatarColor != nil {
 			if customStyle, ok := avatarrender.GroupStyleByIndex(*groupInfo.AvatarColor); ok {
@@ -459,10 +457,12 @@ func (g *Group) writeGroupDefaultAvatar(c *wkhttp.Context, groupNo string, group
 	renderable := avatarrender.Renderable(text)
 
 	// ETag 覆盖决定图像内容的因子：渲染模式版本 + group_no(派生色) + 实际色 + 文字。
-	// 改名/改自定义文字 → text 变 → ETag 变；改自定义色 → colorTag 变 → ETag 变。
-	// 渲染**视觉/取字规则**改动(像素变但因子不变，如 #486 透明四角、本次取字改版)必须
-	// bump 版本段，否则已缓存旧图的客户端 If-None-Match 命中同一 ETag → 304 → 一直返旧图。
-	// group-name-v4: 群名取字改为 script 感知前 2 字(原 v3 取前 4)。
+	// 改/清自定义文字 → text 变(或在 name 模式与 icon 模式间切换) → ETag 变；改自定义色
+	// → colorTag 变 → ETag 变。群名不再参与默认头像，故**改名不影响默认头像 ETag**。
+	// 把默认头像由「群名取字」改为「双人图标」无需 bump 版本：有名群的因子串从
+	// group-name-v4(+text) 变为 group-icon-v3(无 text)，ETag 自然变 → 旧 If-None-Match
+	// 不命中 → 拉到新图标；RenderIcon 字节未动。渲染**视觉**改动(像素变但因子不变，如
+	// #486 透明四角)才必须 bump 版本段。group-name-v4 现仅用于自定义文字渲染。
 
 	etag := avatarrender.ETag("group-icon-v3", groupNo, colorTag)
 	if renderable {
@@ -496,7 +496,7 @@ func (g *Group) writeGroupDefaultAvatar(c *wkhttp.Context, groupNo string, group
 		c.Header("ETag", avatarrender.ETag("group-icon-v3", groupNo, colorTag))
 	}
 
-	// 群名为空 / 不可渲染（如纯 emoji）/ 渲染失败 → 群组图标。
+	// 无自定义文字 / 自定义文字不可渲染（如纯 emoji）/ 渲染失败 → 双人图标。
 	iconKey := avatarrender.CacheKey("group-icon-v3", groupNo, colorTag)
 	iconData, iconErr := avatarrender.GetOrRender(iconKey, func() ([]byte, error) {
 		return avatarrender.RenderIcon(style)
@@ -507,6 +507,36 @@ func (g *Group) writeGroupDefaultAvatar(c *wkhttp.Context, groupNo string, group
 		return
 	}
 	c.Data(http.StatusOK, "image/png", iconData)
+}
+
+// avatarPaletteColorResp 是单档群头像配色的对外（JSON）形式，字段下划线命名，与
+// avatarrender.GroupColorHex 一一对应。
+type avatarPaletteColorResp struct {
+	Index    int    `json:"index"`     // 色板下标，与 avatar_color 取值一致
+	Main     string `json:"main"`      // 主题主色 #RRGGBB
+	Fill     string `json:"fill"`      // 圆填充浅色 #RRGGBB
+	IconBack string `json:"icon_back"` // 双人图标后景人浅色 #RRGGBB
+}
+
+// avatarPaletteResp 是 GET /v1/group/avatar_palette 的响应：固定色板的对外契约。
+type avatarPaletteResp struct {
+	Size   int                      `json:"size"`   // 色板档数（= avatar_color 合法上界）
+	Colors []avatarPaletteColorResp `json:"colors"` // 按下标 0..Size 有序
+}
+
+// avatarPalette 返回固定的群头像色板（公开、静态设计 token）。前端用它渲染「修改头像」
+// 的色圈与本地实时预览，使预览与建群/改群后服务端渲染的 PNG 配色完全一致——色板的
+// **唯一数据源**在服务端 avatarrender.palette，前端不再硬编码、不会漂移。公开（不鉴权）：
+// 与已公开的 /v1/groups/:group_no/avatar 渲染端点同级，内容非敏感且需在登录前即可取用。
+func (g *Group) avatarPalette(c *wkhttp.Context) {
+	hex := avatarrender.PaletteHex()
+	colors := make([]avatarPaletteColorResp, len(hex))
+	for i, h := range hex {
+		colors[i] = avatarPaletteColorResp{Index: h.Index, Main: h.Main, Fill: h.Fill, IconBack: h.IconBack}
+	}
+	// 固定设计 token，可长缓存（含共享缓存）。
+	c.Header("Cache-Control", "public, max-age=86400")
+	c.Response(avatarPaletteResp{Size: len(colors), Colors: colors})
 }
 
 func (g *Group) avatarUpload(c *wkhttp.Context) {
@@ -4168,7 +4198,7 @@ type groupReq struct {
 	Members     []string `json:"members"`      // 成员uid
 	SpaceID     string   `json:"space_id"`     // Space ID（可选）
 	CategoryID  string   `json:"category_id"`  // 群聊分组 ID（可选，需配合 space_id 使用）
-	AvatarText  string   `json:"avatar_text"`  // 自定义群头像文字（可选，最多 4 个中文/英文字符；空=用群名派生）
+	AvatarText  string   `json:"avatar_text"`  // 自定义群头像文字（可选，最多 4 个中文/英文字符；空=双人图标，默认头像与群名无关）
 	AvatarColor *int     `json:"avatar_color"` // 自定义群头像色板下标（可选，[0,palette)；不传=按 group_no 派生）
 }
 

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -1003,9 +1003,9 @@ func (g *Group) groupUpdate(c *wkhttp.Context) {
 		respondGroupRequestInvalid(c, "")
 		return
 	}
-	// 查询群信息
-	group, err := g.getGroupInfo(groupNo)
-	if err != nil {
+	// 群存在性 + 状态检查（不缓存整行：下方 invite 分支改用列级写，避免用旧快照全列回写
+	// 覆盖掉 name 分支刚提交的 name/is_named，见 DB.UpdateInviteTx 注释）。
+	if _, err := g.getGroupInfo(groupNo); err != nil {
 		respondGroupInfoError(c, err)
 		return
 	}
@@ -1091,17 +1091,16 @@ func (g *Group) groupUpdate(c *wkhttp.Context) {
 		}
 	}
 
-	// invite 属性单独处理（保留原有事务逻辑）
+	// invite 属性单独处理（保留原有事务逻辑）。列级写仅更新 invite/version，避免覆盖
+	// name 分支刚提交的 name/is_named（见 DB.UpdateInviteTx）。
 	if hasInvite {
 		invite, _ := strconv.ParseInt(inviteValue, 10, 64)
-		group.Invite = int(invite)
 		version, err := g.ctx.GenSeq(common.GroupSeqKey)
 		if err != nil {
 			g.Error("生成序列号失败", zap.Error(err))
 			httperr.ResponseErrorL(c, errcode.ErrGroupStoreFailed, nil, nil)
 			return
 		}
-		group.Version = version
 
 		tx, err := g.ctx.DB().Begin()
 		if err != nil {
@@ -1115,10 +1114,10 @@ func (g *Group) groupUpdate(c *wkhttp.Context) {
 				fmt.Fprintf(os.Stderr, "recovered panic in goroutine: %v\n%s\n", err, debug.Stack())
 			}
 		}()
-		err = g.db.UpdateTx(group, tx)
+		err = g.db.UpdateInviteTx(groupNo, int(invite), version, tx)
 		if err != nil {
 			tx.Rollback()
-			g.Error("更新群信息失败！", zap.Error(err), zap.String("group_no", group.GroupNo))
+			g.Error("更新群信息失败！", zap.Error(err), zap.String("group_no", groupNo))
 			httperr.ResponseErrorL(c, errcode.ErrGroupStoreFailed, nil, nil)
 			return
 		}

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -531,11 +531,22 @@ type avatarPaletteResp struct {
 func (g *Group) avatarPalette(c *wkhttp.Context) {
 	hex := avatarrender.PaletteHex()
 	colors := make([]avatarPaletteColorResp, len(hex))
+	// 内容相关弱 ETag：把色板版本段 + 全部色值作为因子，色板任意改动即 ETag 变 → 已缓存
+	// 客户端 revalidate 到新色（不会被长缓存钉死旧色，对齐「单一数据源、不漂移」目标）。
+	etagParts := make([]string, 0, len(hex)*3+1)
+	etagParts = append(etagParts, "avatar-palette-v1")
 	for i, h := range hex {
 		colors[i] = avatarPaletteColorResp{Index: h.Index, Main: h.Main, Fill: h.Fill, IconBack: h.IconBack}
+		etagParts = append(etagParts, h.Main, h.Fill, h.IconBack)
 	}
-	// 固定设计 token，可长缓存（含共享缓存）。
-	c.Header("Cache-Control", "public, max-age=86400")
+	etag := avatarrender.ETag(etagParts...)
+	// 固定设计 token：可缓存，但带内容 ETag + must-revalidate，色板变更可及时失效。
+	c.Header("ETag", etag)
+	c.Header("Cache-Control", "public, max-age=300, must-revalidate")
+	if avatarrender.IfNoneMatch(c.GetHeader("If-None-Match"), etag) {
+		c.Status(http.StatusNotModified)
+		return
+	}
 	c.Response(avatarPaletteResp{Size: len(colors), Colors: colors})
 }
 

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -424,14 +424,14 @@ func (g *Group) avatarGet(c *wkhttp.Context) {
 		return
 	}
 
-	// 无自定义上传（含历史合成群、新建群）：服务端实时渲染默认头像——有自定义文字则
-	// 渲染「浅底描边圆 + 该文字」，否则一律双人图标（默认头像与群名无关）。
+	// 无自定义上传（含历史合成群、新建群）：服务端实时渲染默认头像——有自定义文字则渲染
+	// 该文字；否则命名群（is_named=1）取群名前 2 字，自动名群（is_named=0）回退双人图标。
 	g.writeGroupDefaultAvatar(c, groupNo, groupInfo)
 }
 
-// writeGroupDefaultAvatar 服务端渲染并返回群默认头像（无自定义上传时）。仅当用户显式
-// 设置了 avatar_text 时渲染文字，否则一律回退双人图标（默认头像与群名无关）；颜色优先
-// 自定义 avatar_color，否则按 group_no 稳定派生（改名不变色、跨页面一致）。
+// writeGroupDefaultAvatar 服务端渲染并返回群默认头像（无自定义上传时）。文字优先级：
+// 自定义 avatar_text > 命名群（is_named=1）的群名前 2 字 > 空（自动名群 → 双人图标）。
+// 颜色优先自定义 avatar_color，否则按 group_no 稳定派生（改名不变色、跨页面一致）。
 //
 // URL 稳定为 groups/{group_no}/avatar，内容随群名/自定义变化，故用内容相关弱 ETag +
 // 短缓存 + must-revalidate：改名后最多 5 分钟内 revalidate 到新图，并支持 304 省渲染。
@@ -441,11 +441,15 @@ func (g *Group) writeGroupDefaultAvatar(c *wkhttp.Context, groupNo string, group
 	colorTag := "seed"
 	var text string
 	if groupInfo != nil {
-		// 默认头像与群名**无关**(产品 2026-06-29 定稿)：仅当用户在「修改头像」里**显式
-		// 设置**了自定义文字时才渲染文字(原样、写入时已按 ≤4 规范化、不做取字/缩写);否则
-		// text 留空 → 不可渲染 → 一律回退双人图标。群名不再参与默认头像取字。
+		// 默认头像取字规则(产品 2026-06-29 定稿)：
+		//   1. 用户在「修改头像」显式设了自定义文字 → 原样渲染(写入时已 ≤4 规范化、不取字);
+		//   2. 否则群是用户**显式起名**(is_named=1) → 取群名前 2 字(script 感知);
+		//   3. 否则(成员名拼接的自动默认名 is_named=0) → text 留空 → 回退双人图标
+		//      (不把「张三、李四、王五」这类拼接名渲成头像文字)。
 		if groupInfo.AvatarText != "" {
 			text = avatarrender.GroupText(groupInfo.AvatarText)
+		} else if groupInfo.IsNamed == 1 {
+			text = avatarrender.GroupNameText(groupInfo.Name)
 		}
 		if groupInfo.AvatarColor != nil {
 			if customStyle, ok := avatarrender.GroupStyleByIndex(*groupInfo.AvatarColor); ok {
@@ -457,12 +461,10 @@ func (g *Group) writeGroupDefaultAvatar(c *wkhttp.Context, groupNo string, group
 	renderable := avatarrender.Renderable(text)
 
 	// ETag 覆盖决定图像内容的因子：渲染模式版本 + group_no(派生色) + 实际色 + 文字。
-	// 改/清自定义文字 → text 变(或在 name 模式与 icon 模式间切换) → ETag 变；改自定义色
-	// → colorTag 变 → ETag 变。群名不再参与默认头像，故**改名不影响默认头像 ETag**。
-	// 把默认头像由「群名取字」改为「双人图标」无需 bump 版本：有名群的因子串从
-	// group-name-v4(+text) 变为 group-icon-v3(无 text)，ETag 自然变 → 旧 If-None-Match
-	// 不命中 → 拉到新图标；RenderIcon 字节未动。渲染**视觉**改动(像素变但因子不变，如
-	// #486 透明四角)才必须 bump 版本段。group-name-v4 现仅用于自定义文字渲染。
+	// 改名/改自定义文字/改 is_named → text 变(或在 name 模式与 icon 模式间切换) → ETag 变；
+	// 改自定义色 → colorTag 变 → ETag 变。命名群走 group-name-v4(+text)、自动名群走
+	// group-icon-v3(无 text)，模式不同因子串天然不同，故两类切换无需 bump 版本。渲染
+	// **视觉**改动(像素变但因子不变，如 #486 透明四角)才必须 bump 版本段。
 
 	etag := avatarrender.ETag("group-icon-v3", groupNo, colorTag)
 	if renderable {
@@ -4209,7 +4211,7 @@ type groupReq struct {
 	Members     []string `json:"members"`      // 成员uid
 	SpaceID     string   `json:"space_id"`     // Space ID（可选）
 	CategoryID  string   `json:"category_id"`  // 群聊分组 ID（可选，需配合 space_id 使用）
-	AvatarText  string   `json:"avatar_text"`  // 自定义群头像文字（可选，最多 4 个中文/英文字符；空=双人图标，默认头像与群名无关）
+	AvatarText  string   `json:"avatar_text"`  // 自定义群头像文字（可选，最多 4 个中文/英文字符；空=按 is_named 回退：命名群群名/自动名群双人图标）
 	AvatarColor *int     `json:"avatar_color"` // 自定义群头像色板下标（可选，[0,palette)；不传=按 group_no 派生）
 }
 

--- a/modules/group/avatar_get_test.go
+++ b/modules/group/avatar_get_test.go
@@ -25,17 +25,17 @@ func doAvatarGet(t *testing.T, h http.Handler, groupNo, ifNoneMatch string) *htt
 	return w
 }
 
-// TestGroupAvatarGetNamedNoCustomRendersIcon 覆盖核心规则（产品 2026-06-29 定稿）：
-// 无自定义上传、无自定义文字时，**无论群名是否有内容**都渲染双人图标——默认头像与群名
-// 无关，区别于历史「群名取字前 2」行为。带弱 ETag + must-revalidate；命中 If-None-Match 时 304。
-func TestGroupAvatarGetNamedNoCustomRendersIcon(t *testing.T) {
+// TestGroupAvatarGetAutoNamedRendersIcon 覆盖核心规则（产品 2026-06-29 定稿）：成员名
+// 拼接的**自动默认名**（is_named=0）且无自定义文字 → 双人图标（不把拼接名渲成头像文字），
+// 即使 name 字段非空。带弱 ETag + must-revalidate；命中 If-None-Match 时 304。
+func TestGroupAvatarGetAutoNamedRendersIcon(t *testing.T) {
 	s, ctx := newTestServer(t)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	g := New(ctx)
 
-	const groupNo = "avatar_get_named_1"
+	const groupNo = "avatar_get_autoname_1"
 	require.NoError(t, g.db.Insert(&Model{
-		GroupNo: groupNo, Name: "后端架构讨论", Creator: "c1", Status: 1,
+		GroupNo: groupNo, Name: "张三、李四、王五", Creator: "c1", Status: 1, IsNamed: 0,
 	}))
 
 	w := doAvatarGet(t, s.GetRoute(), groupNo, "")
@@ -49,17 +49,41 @@ func TestGroupAvatarGetNamedNoCustomRendersIcon(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, avatarrender.DefaultSize, img.Bounds().Dx())
 
-	// 默认头像与群名无关：有群名但无自定义文字 → 双人图标（按 group_no 派生色），
-	// 而非历史的「群名前 2 字」。
+	// 自动名（is_named=0）→ 双人图标（按 group_no 派生色），不渲染拼接名文字。
 	wantIcon, err := avatarrender.RenderIcon(avatarrender.GroupStyleForSeed(groupNo))
 	require.NoError(t, err)
 	require.Equal(t, wantIcon, w.Body.Bytes(),
-		"named group without custom text must render the two-person icon, not name-derived text")
+		"auto-named group (is_named=0) without custom text must render the two-person icon")
 
 	// 304：带命中的 If-None-Match → 304 无 body。
 	w2 := doAvatarGet(t, s.GetRoute(), groupNo, etag)
 	require.Equal(t, http.StatusNotModified, w2.Code)
 	require.Empty(t, w2.Body.Bytes())
+}
+
+// TestGroupAvatarGetNamedRendersNameText 覆盖：用户**显式起名**（is_named=1）且无自定义
+// 文字 → 取群名前 2 字（script 感知）渲染文字，而非双人图标。
+func TestGroupAvatarGetNamedRendersNameText(t *testing.T) {
+	s, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	g := New(ctx)
+
+	const groupNo = "avatar_get_named_text_1"
+	require.NoError(t, g.db.Insert(&Model{
+		GroupNo: groupNo, Name: "后端架构讨论", Creator: "c1", Status: 1, IsNamed: 1,
+	}))
+
+	w := doAvatarGet(t, s.GetRoute(), groupNo, "")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	want, err := avatarrender.RenderGroup(
+		avatarrender.GroupNameText("后端架构讨论"),
+		avatarrender.GroupStyleForSeed(groupNo),
+		avatarrender.DefaultSize,
+	)
+	require.NoError(t, err)
+	require.Equal(t, want, w.Body.Bytes(),
+		"named group (is_named=1) without custom text must render script-aware first-2 of the name")
 }
 
 // TestGroupAvatarGetIconFallback 覆盖群名为空 → 同样回退双人图标渲染。

--- a/modules/group/avatar_get_test.go
+++ b/modules/group/avatar_get_test.go
@@ -75,6 +75,10 @@ func TestGroupAvatarGetNamedRendersNameText(t *testing.T) {
 
 	w := doAvatarGet(t, s.GetRoute(), groupNo, "")
 	require.Equal(t, http.StatusOK, w.Code)
+	// 命名群也走内容相关弱 ETag：保护改名 / 切自定义触发的缓存失效契约（Jerry-Xin 🔵）。
+	etag := w.Header().Get("ETag")
+	require.True(t, strings.HasPrefix(etag, `W/"`), "named group avatar must carry a weak ETag, got %q", etag)
+	require.Contains(t, w.Header().Get("Cache-Control"), "must-revalidate")
 
 	want, err := avatarrender.RenderGroup(
 		avatarrender.GroupNameText("后端架构讨论"),
@@ -84,6 +88,11 @@ func TestGroupAvatarGetNamedRendersNameText(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, want, w.Body.Bytes(),
 		"named group (is_named=1) without custom text must render script-aware first-2 of the name")
+
+	// 命中的 If-None-Match → 304 无 body（命名群路径同样支持条件请求省渲染）。
+	w2 := doAvatarGet(t, s.GetRoute(), groupNo, etag)
+	require.Equal(t, http.StatusNotModified, w2.Code)
+	require.Empty(t, w2.Body.Bytes())
 }
 
 // TestGroupAvatarGetIconFallback 覆盖群名为空 → 同样回退双人图标渲染。

--- a/modules/group/avatar_get_test.go
+++ b/modules/group/avatar_get_test.go
@@ -126,8 +126,9 @@ func TestGroupAvatarGetCustomOverrides(t *testing.T) {
 	require.Equal(t, want, w.Body.Bytes(), "custom text+color must override name/seed")
 }
 
-// TestGroupAvatarGetCustomColorIconNoText 覆盖 S2:设了自定义颜色但**无**自定义文字 →
-// 渲染该颜色的双人图标(默认头像与群名无关,但自定义颜色仍被尊重)。
+// TestGroupAvatarGetCustomColorIconNoText 覆盖 S2:自动名群(is_named=0)设了自定义颜色但
+// **无**自定义文字 → 渲染该颜色的双人图标(自动名群默认头像与群名无关,但自定义颜色仍被
+// 尊重)。fixture 显式 IsNamed=0,名字取「自动名群」以贴合意图(避免与 is_named=1 混淆)。
 func TestGroupAvatarGetCustomColorIconNoText(t *testing.T) {
 	s, ctx := newTestServer(t)
 	require.NoError(t, testutil.CleanAllTables(ctx))
@@ -135,7 +136,7 @@ func TestGroupAvatarGetCustomColorIconNoText(t *testing.T) {
 
 	const groupNo = "avatar_get_coloricon_1"
 	require.NoError(t, g.db.Insert(&Model{
-		GroupNo: groupNo, Name: "有名群", Creator: "c1", Status: 1, AvatarColor: intPtr(7),
+		GroupNo: groupNo, Name: "自动名群", Creator: "c1", Status: 1, IsNamed: 0, AvatarColor: intPtr(7),
 	}))
 
 	w := doAvatarGet(t, s.GetRoute(), groupNo, "")
@@ -145,7 +146,35 @@ func TestGroupAvatarGetCustomColorIconNoText(t *testing.T) {
 	require.True(t, ok)
 	wantIcon, err := avatarrender.RenderIcon(style)
 	require.NoError(t, err)
-	require.Equal(t, wantIcon, w.Body.Bytes(), "custom color + no text must render the two-person icon in that color")
+	require.Equal(t, wantIcon, w.Body.Bytes(), "auto-named group (is_named=0) with custom color + no text must render the two-person icon in that color")
+}
+
+// TestGroupAvatarGetNamedCustomColorRendersNameText 锁定三因子交互(Octo-Q P2-1 建议):
+// 命名群(is_named=1) + 自定义颜色 + **无**自定义文字 → 以该自定义颜色渲染群名前 2 字
+// (而非派生色、而非图标)。补全 is_named=1 与 custom_color 的组合覆盖。
+func TestGroupAvatarGetNamedCustomColorRendersNameText(t *testing.T) {
+	s, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	g := New(ctx)
+
+	const groupNo = "avatar_get_named_color_1"
+	require.NoError(t, g.db.Insert(&Model{
+		GroupNo: groupNo, Name: "后端架构讨论", Creator: "c1", Status: 1, IsNamed: 1, AvatarColor: intPtr(7),
+	}))
+
+	w := doAvatarGet(t, s.GetRoute(), groupNo, "")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	style, ok := avatarrender.GroupStyleByIndex(7)
+	require.True(t, ok)
+	want, err := avatarrender.RenderGroup(
+		avatarrender.GroupNameText("后端架构讨论"),
+		style,
+		avatarrender.DefaultSize,
+	)
+	require.NoError(t, err)
+	require.Equal(t, want, w.Body.Bytes(),
+		"named group (is_named=1) with custom color + no text must render name first-2 in that custom color")
 }
 
 // TestGroupAvatarGetCustomTextNotTruncated 回归 PR#494 评审(Jerry-Xin):用户显式

--- a/modules/group/avatar_get_test.go
+++ b/modules/group/avatar_get_test.go
@@ -102,6 +102,28 @@ func TestGroupAvatarGetCustomOverrides(t *testing.T) {
 	require.Equal(t, want, w.Body.Bytes(), "custom text+color must override name/seed")
 }
 
+// TestGroupAvatarGetCustomColorIconNoText 覆盖 S2:设了自定义颜色但**无**自定义文字 →
+// 渲染该颜色的双人图标(默认头像与群名无关,但自定义颜色仍被尊重)。
+func TestGroupAvatarGetCustomColorIconNoText(t *testing.T) {
+	s, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	g := New(ctx)
+
+	const groupNo = "avatar_get_coloricon_1"
+	require.NoError(t, g.db.Insert(&Model{
+		GroupNo: groupNo, Name: "有名群", Creator: "c1", Status: 1, AvatarColor: intPtr(7),
+	}))
+
+	w := doAvatarGet(t, s.GetRoute(), groupNo, "")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	style, ok := avatarrender.GroupStyleByIndex(7)
+	require.True(t, ok)
+	wantIcon, err := avatarrender.RenderIcon(style)
+	require.NoError(t, err)
+	require.Equal(t, wantIcon, w.Body.Bytes(), "custom color + no text must render the two-person icon in that color")
+}
+
 // TestGroupAvatarGetCustomTextNotTruncated 回归 PR#494 评审(Jerry-Xin):用户显式
 // 自定义文字必须**原样渲染**(≤4),不得被群名自动取字规则(script 感知前 2)截断 ——
 // 4 字自定义渲染全 4 字「研发中心」,而非前 2「研发」。

--- a/modules/group/avatar_get_test.go
+++ b/modules/group/avatar_get_test.go
@@ -25,11 +25,10 @@ func doAvatarGet(t *testing.T, h http.Handler, groupNo, ifNoneMatch string) *htt
 	return w
 }
 
-// TestGroupAvatarGetDefaultRender 覆盖无自定义上传、有群名时 avatarGet 的服务端
-// 渲染：返回「浅底描边圆 + 群名取字(script 感知前 2)」PNG（200，非重定向），内容等于
-// RenderGroup(GroupNameText(name), GroupStyleForSeed(group_no))，并带弱 ETag + must-revalidate；
-// 命中 If-None-Match 时 304。
-func TestGroupAvatarGetDefaultRender(t *testing.T) {
+// TestGroupAvatarGetNamedNoCustomRendersIcon 覆盖核心规则（产品 2026-06-29 定稿）：
+// 无自定义上传、无自定义文字时，**无论群名是否有内容**都渲染双人图标——默认头像与群名
+// 无关，区别于历史「群名取字前 2」行为。带弱 ETag + must-revalidate；命中 If-None-Match 时 304。
+func TestGroupAvatarGetNamedNoCustomRendersIcon(t *testing.T) {
 	s, ctx := newTestServer(t)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	g := New(ctx)
@@ -50,14 +49,12 @@ func TestGroupAvatarGetDefaultRender(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, avatarrender.DefaultSize, img.Bounds().Dx())
 
-	// 正确性：取前 2 字「后端」(script 感知) + 按 group_no 派生色。
-	want, err := avatarrender.RenderGroup(
-		avatarrender.GroupNameText("后端架构讨论"),
-		avatarrender.GroupStyleForSeed(groupNo),
-		avatarrender.DefaultSize,
-	)
+	// 默认头像与群名无关：有群名但无自定义文字 → 双人图标（按 group_no 派生色），
+	// 而非历史的「群名前 2 字」。
+	wantIcon, err := avatarrender.RenderIcon(avatarrender.GroupStyleForSeed(groupNo))
 	require.NoError(t, err)
-	require.Equal(t, want, w.Body.Bytes(), "rendered avatar must be script-aware first-2 + seed color")
+	require.Equal(t, wantIcon, w.Body.Bytes(),
+		"named group without custom text must render the two-person icon, not name-derived text")
 
 	// 304：带命中的 If-None-Match → 304 无 body。
 	w2 := doAvatarGet(t, s.GetRoute(), groupNo, etag)
@@ -65,7 +62,7 @@ func TestGroupAvatarGetDefaultRender(t *testing.T) {
 	require.Empty(t, w2.Body.Bytes())
 }
 
-// TestGroupAvatarGetIconFallback 覆盖群名为空 → 回退群组图标渲染。
+// TestGroupAvatarGetIconFallback 覆盖群名为空 → 同样回退双人图标渲染。
 func TestGroupAvatarGetIconFallback(t *testing.T) {
 	s, ctx := newTestServer(t)
 	require.NoError(t, testutil.CleanAllTables(ctx))

--- a/modules/group/avatar_palette_test.go
+++ b/modules/group/avatar_palette_test.go
@@ -1,0 +1,50 @@
+package group
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/avatarrender"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGroupAvatarPalette 覆盖公开色板端点 GET /v1/group/avatar_palette：返回 PaletteSize
+// 档、按下标有序、三套色为 #RRGGBB，且与 avatarrender.PaletteHex()（服务端唯一数据源）
+// 完全一致——前端据此渲染色圈与本地预览，保证与服务端渲染配色不漂移。无需鉴权。
+func TestGroupAvatarPalette(t *testing.T) {
+	s, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/v1/group/avatar_palette", nil)
+	require.NoError(t, err)
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Size   int `json:"size"`
+		Colors []struct {
+			Index    int    `json:"index"`
+			Main     string `json:"main"`
+			Fill     string `json:"fill"`
+			IconBack string `json:"icon_back"`
+		} `json:"colors"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.Equal(t, avatarrender.PaletteSize(), resp.Size)
+	require.Len(t, resp.Colors, avatarrender.PaletteSize())
+
+	hex := avatarrender.PaletteHex()
+	for i, cc := range resp.Colors {
+		require.Equal(t, i, cc.Index, "colors must be ordered by palette index")
+		require.Equal(t, hex[i].Main, cc.Main)
+		require.Equal(t, hex[i].Fill, cc.Fill)
+		require.Equal(t, hex[i].IconBack, cc.IconBack)
+	}
+	// 钉死设计稿首档，捕获顺序/取值漂移。
+	require.Equal(t, "#14C0FF", resp.Colors[0].Main)
+}

--- a/modules/group/avatar_palette_test.go
+++ b/modules/group/avatar_palette_test.go
@@ -47,4 +47,15 @@ func TestGroupAvatarPalette(t *testing.T) {
 	}
 	// 钉死设计稿首档，捕获顺序/取值漂移。
 	require.Equal(t, "#14C0FF", resp.Colors[0].Main)
+
+	// 内容相关弱 ETag + 304：带命中的 If-None-Match → 304 无 body（色板变更才会换 ETag）。
+	etag := w.Header().Get("ETag")
+	require.NotEmpty(t, etag)
+	w2 := httptest.NewRecorder()
+	req2, err := http.NewRequest("GET", "/v1/group/avatar_palette", nil)
+	require.NoError(t, err)
+	req2.Header.Set("If-None-Match", etag)
+	s.GetRoute().ServeHTTP(w2, req2)
+	require.Equal(t, http.StatusNotModified, w2.Code)
+	require.Empty(t, w2.Body.Bytes())
 }

--- a/modules/group/avatar_version_pin_test.go
+++ b/modules/group/avatar_version_pin_test.go
@@ -20,22 +20,23 @@ import (
 // Existing endpoint tests assert the ETag is present / weak / changes on rename, but
 // none pin the version literal. This recomputes the expected ETag with the expected
 // version string and asserts the endpoint emits exactly it, so any token drift fails
-// loudly here. GroupNameText is the same helper the handler uses, so a legitimate
-// change to the script-aware text rule moves test and handler in lockstep — only the
-// version segment is pinned.
+// loudly here. GroupText is the same helper the handler uses for custom text, so a
+// legitimate change to the normalize rule moves test and handler in lockstep — only
+// the version segment is pinned.
 func TestGroupAvatarGetPinsRenderVersion(t *testing.T) {
 	s, ctx := newTestServer(t)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	g := New(ctx)
 
-	// Named, renderable group, no custom color -> name render mode, default colorTag "seed".
+	// Custom avatar_text is the ONLY path to text-render now that the group name no
+	// longer drives the default avatar -> name render mode, default colorTag "seed".
 	const namedNo = "avatar_pin_named_1"
-	require.NoError(t, g.db.Insert(&Model{GroupNo: namedNo, Name: "后端架构讨论", Creator: "c1", Status: 1}))
+	require.NoError(t, g.db.Insert(&Model{GroupNo: namedNo, Name: "后端架构讨论", Creator: "c1", Status: 1, AvatarText: "研发"}))
 	named := doAvatarGet(t, s.GetRoute(), namedNo, "")
 	require.Equal(t, http.StatusOK, named.Code)
-	wantName := avatarrender.ETag("group-name-v4", namedNo, "seed", avatarrender.GroupNameText("后端架构讨论"))
+	wantName := avatarrender.ETag("group-name-v4", namedNo, "seed", avatarrender.GroupText("研发"))
 	require.Equal(t, wantName, named.Header().Get("ETag"),
-		"group name-avatar endpoint must wire render version group-name-v4 (keep in sync with the rendered bytes)")
+		"group text-avatar endpoint must wire render version group-name-v4 (keep in sync with the rendered bytes)")
 
 	// Empty name -> icon fallback mode -> "group-icon-v3".
 	const iconNo = "avatar_pin_icon_1"

--- a/modules/group/const.go
+++ b/modules/group/const.go
@@ -47,7 +47,7 @@ const (
 // 群信息更新（PUT /v1/group/:group_no）中自定义群头像的 map key，与创建接口
 // groupReq 的 JSON 字段名保持一致。avatar_color 值为色板下标字符串，"" 或 "-1"
 // 表示清除自定义色（回退按 group_no 派生）；avatar_text 为空字符串表示清除自定义
-// 文字（回退双人图标，默认头像与群名无关）。
+// 文字（回退：命名群取群名前 2 字，自动名群双人图标）。
 const (
 	attrKeyAvatarText  = "avatar_text"
 	attrKeyAvatarColor = "avatar_color"

--- a/modules/group/const.go
+++ b/modules/group/const.go
@@ -47,7 +47,7 @@ const (
 // 群信息更新（PUT /v1/group/:group_no）中自定义群头像的 map key，与创建接口
 // groupReq 的 JSON 字段名保持一致。avatar_color 值为色板下标字符串，"" 或 "-1"
 // 表示清除自定义色（回退按 group_no 派生）；avatar_text 为空字符串表示清除自定义
-// 文字（回退群名前 2 字）。
+// 文字（回退双人图标，默认头像与群名无关）。
 const (
 	attrKeyAvatarText  = "avatar_text"
 	attrKeyAvatarColor = "avatar_color"

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -291,6 +291,20 @@ func (d *DB) UpdateTx(model *Model, tx *dbr.Tx) error {
 	return err
 }
 
+// UpdateInviteTx 仅更新「进群邀请开关」与群版本（列级写，事务内）。
+// 不能用 UpdateTx 整行回写：groupUpdate 在同一请求里若同时带 name 与 invite，name 分支
+// 已通过 UpdateGroupInfo（独立 fresh load）提交 name/is_named=1，而 invite 分支若再用
+// 建链时载入的旧快照经 UpdateTx 全列回写，会把刚提交的 name/is_named 用旧值覆盖回去
+// （改名 + is_named 被回滚成 0 → 头像静默退回双人图标）。列级写只动 invite/version，
+// 与并发的改名互不踩踏，也消除该读改写竞态。
+func (d *DB) UpdateInviteTx(groupNo string, invite int, version int64, tx *dbr.Tx) error {
+	_, err := tx.Update("group").SetMap(map[string]interface{}{
+		"invite":  invite,
+		"version": version,
+	}).Where("group_no=?", groupNo).Exec()
+	return err
+}
+
 // Update 更新群信息
 func (d *DB) Update(model *Model) error {
 	_, err := d.session.Update("group").SetMap(map[string]interface{}{

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -321,7 +321,7 @@ func (d *DB) updateAvatar(avatar string, avatarVersion int64, groupNo string) er
 // updateAvatarCustom 更新自定义群头像文字/颜色与群版本（不触碰 is_upload_avatar：
 // 自定义文字/色仍是「默认头像」范畴，渲染时实时出图，不同于上传图片）。color 为
 // *int，nil → NULL（清除自定义色，回退按 group_no 派生）。text 为空串表示清除自定义
-// 文字（回退群名前 2 字）。
+// 文字（回退双人图标，默认头像与群名无关）。
 // updateAvatarCustom 只更新本次实际提供的列：text 非 nil 时写 avatar_text，setColor
 // 为 true 时写 avatar_color（*int，nil → NULL 清除自定义色）；始终 bump version。
 // 列级更新避免「读-改-写」竞态——并发只改文字 / 只改色不会互相覆盖对方的列。
@@ -596,7 +596,7 @@ type Model struct {
 	Avatar                   string     // 群头像
 	AvatarVersion            int64      // 群头像对象版本，0 表示旧版稳定路径
 	IsUploadAvatar           int        // 群头像是否已经被用户上传
-	AvatarText               string     // 自定义群头像文字，空表示用群名前 2 字派生
+	AvatarText               string     // 自定义群头像文字，空表示双人图标（默认头像与群名无关）
 	AvatarColor              *int       // 自定义群头像色板下标，nil(NULL) 表示按 group_no 派生
 	Notice                   string     // 群公告
 	Creator                  string     // 创建者uid

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -280,6 +280,7 @@ func (d *DB) queryUserSupers(uid string) ([]*Model, error) {
 func (d *DB) UpdateTx(model *Model, tx *dbr.Tx) error {
 	_, err := tx.Update("group").SetMap(map[string]interface{}{
 		"name":      model.Name,
+		"is_named":  model.IsNamed, // 改名置 1（用户起名）；其它更新原样回写当前值
 		"notice":    model.Notice,
 		"creator":   model.Creator,
 		"status":    model.Status,
@@ -321,7 +322,7 @@ func (d *DB) updateAvatar(avatar string, avatarVersion int64, groupNo string) er
 // updateAvatarCustom 更新自定义群头像文字/颜色与群版本（不触碰 is_upload_avatar：
 // 自定义文字/色仍是「默认头像」范畴，渲染时实时出图，不同于上传图片）。color 为
 // *int，nil → NULL（清除自定义色，回退按 group_no 派生）。text 为空串表示清除自定义
-// 文字（回退双人图标，默认头像与群名无关）。
+// 文字（回退：命名群取群名前 2 字，自动名群双人图标）。
 // updateAvatarCustom 只更新本次实际提供的列：text 非 nil 时写 avatar_text，setColor
 // 为 true 时写 avatar_color（*int，nil → NULL 清除自定义色）；始终 bump version。
 // 列级更新避免「读-改-写」竞态——并发只改文字 / 只改色不会互相覆盖对方的列。
@@ -593,10 +594,11 @@ type Model struct {
 	GroupNo                  string     // 群编号
 	GroupType                int        // 群类型 0.普通群 1.超大群
 	Name                     string     // 群名称
+	IsNamed                  int        // 群名是否用户显式起名(1)/成员拼接自动名(0)；默认头像取字仅对 1 生效
 	Avatar                   string     // 群头像
 	AvatarVersion            int64      // 群头像对象版本，0 表示旧版稳定路径
 	IsUploadAvatar           int        // 群头像是否已经被用户上传
-	AvatarText               string     // 自定义群头像文字，空表示双人图标（默认头像与群名无关）
+	AvatarText               string     // 自定义群头像文字；空时按 is_named 回退（命名群取群名前2字，自动名群双人图标）
 	AvatarColor              *int       // 自定义群头像色板下标，nil(NULL) 表示按 group_no 派生
 	Notice                   string     // 群公告
 	Creator                  string     // 创建者uid

--- a/modules/group/event.go
+++ b/modules/group/event.go
@@ -173,6 +173,7 @@ func (g *Group) handleRegisterUserEvent(data []byte, commit config.EventCommit) 
 		err = g.db.InsertTx(&Model{
 			GroupNo:        g.ctx.GetConfig().Account.SystemGroupID,
 			Name:           g.ctx.GetConfig().Account.SystemGroupName,
+			IsNamed:        1, // 系统群有显式配置名 → 命名群（与 CreateGroup 的 is_named 语义一致）
 			Creator:        g.ctx.GetConfig().Account.SystemUID,
 			Status:         GroupStatusNormal,
 			Version:        version,
@@ -315,6 +316,7 @@ func (g *Group) handleOrgOrDeptCreateEvent(data []byte, commit config.EventCommi
 		err = g.db.InsertTx(&Model{
 			GroupNo:             req.GroupNo,
 			Name:                req.Name,
+			IsNamed:             1, // 组织/部门群有显式名 → 命名群（与 CreateGroup 的 is_named 语义一致）
 			Creator:             req.Operator,
 			Status:              GroupStatusNormal,
 			Version:             version,

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -796,7 +796,7 @@ type GroupResp struct {
 	GroupType                GroupType `json:"group_type"`                  // 群类型
 	Category                 string    `json:"category"`                    // 群分类
 	Name                     string    `json:"name"`                        // 群名称
-	AvatarText               string    `json:"avatar_text"`                 // 自定义群头像文字（空=双人图标，默认头像与群名无关）
+	AvatarText               string    `json:"avatar_text"`                 // 自定义群头像文字（空=按 is_named 回退：命名群群名/自动名群双人图标）
 	AvatarColor              *int      `json:"avatar_color"`                // 自定义群头像色板下标（null=按 group_no 派生）
 	Remark                   string    `json:"remark"`                      // 群备注
 	Notice                   string    `json:"notice"`                      // 群公告
@@ -956,7 +956,7 @@ type CreateGroupServiceReq struct {
 	SpaceID     string   // Space ID（可为空）
 	BotUID      string   // Bot UID（可为空；非空时自动加入群并设为 bot_admin）
 	CategoryID  string   // 群聊分组 ID（可为空；非空时自动设置创建者的 group_setting）
-	AvatarText  string   // 自定义群头像文字（可为空；空=渲染时回退双人图标，默认头像与群名无关）
+	AvatarText  string   // 自定义群头像文字（可为空；空=按 is_named 回退：命名群群名/自动名群双人图标）
 	AvatarColor *int     // 自定义群头像色板下标（nil=渲染时按 group_no 派生）
 }
 
@@ -1108,8 +1108,13 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 		return nil, errors.New("no valid member found")
 	}
 
-	// 群名生成
+	// 群名生成。建群传了 name = 用户显式起名(is_named=1，默认头像取群名前2字)；没传 =
+	// 用成员名拼接的自动默认名(is_named=0，默认头像回退双人图标，不把拼接名渲成文字)。
 	groupName := strings.TrimSpace(req.Name)
+	isNamedVal := 0
+	if groupName != "" {
+		isNamedVal = 1
+	}
 	if groupName == "" {
 		names := make([]string, 0, len(memberUsers))
 		for _, u := range memberUsers {
@@ -1158,6 +1163,7 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 	err = s.db.InsertTx(&Model{
 		GroupNo:             groupNo,
 		Name:                groupName,
+		IsNamed:             isNamedVal,
 		Creator:             req.Creator,
 		Status:              GroupStatusNormal,
 		Version:             version,
@@ -1166,7 +1172,7 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 		AllowExternal:       1, // 向后兼容：默认允许外部成员
 		AllowNoMention:      1, // 向后兼容：默认允许群级免@
 		IsExternalGroup:     isExternalGroup,
-		AvatarText:          req.AvatarText,  // 空=渲染时回退双人图标（默认头像与群名无关）
+		AvatarText:          req.AvatarText,  // 空=按 is_named 回退（命名群群名/自动名群双人图标）
 		AvatarColor:         req.AvatarColor, // nil=渲染时按 group_no 派生
 	}, tx)
 	if err != nil {
@@ -1871,6 +1877,7 @@ func (s *Service) UpdateGroupInfo(req *UpdateGroupInfoServiceReq) error {
 			*req.Name = string(nameRunes[:MaxGroupNameLen])
 		}
 		groupModel.Name = *req.Name
+		groupModel.IsNamed = 1 // 用户显式改名 → 命名群（默认头像改取新群名前 2 字）
 	}
 	if req.Notice != nil {
 		groupModel.Notice = *req.Notice

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -198,9 +198,16 @@ func (s *Service) GetCreatedCountWithDate(date string) (int64, error) {
 
 // AddGroup 添加一个群
 func (s *Service) AddGroup(model *AddGroupReq) error {
+	// 显式传名 → 命名群（is_named=1，默认头像取群名前2字）；空名 → 0（回退双人图标）。
+	// 与 CreateGroup 的 is_named 推断口径一致，避免直插路径漏置导致命名群退回图标。
+	isNamed := 0
+	if strings.TrimSpace(model.Name) != "" {
+		isNamed = 1
+	}
 	err := s.db.Insert(&Model{
 		GroupNo:        model.GroupNo,
 		Name:           model.Name,
+		IsNamed:        isNamed,
 		AllowExternal:  1, // 向后兼容：默认允许外部成员
 		AllowNoMention: 1, // 向后兼容：默认允许群级免@
 	})
@@ -796,6 +803,7 @@ type GroupResp struct {
 	GroupType                GroupType `json:"group_type"`                  // 群类型
 	Category                 string    `json:"category"`                    // 群分类
 	Name                     string    `json:"name"`                        // 群名称
+	IsNamed                  int       `json:"is_named"`                    // 群名是否用户显式起名(1)/成员拼接自动名(0)；客户端据此本地预判默认头像取名字/双人图标
 	AvatarText               string    `json:"avatar_text"`                 // 自定义群头像文字（空=按 is_named 回退：命名群群名/自动名群双人图标）
 	AvatarColor              *int      `json:"avatar_color"`                // 自定义群头像色板下标（null=按 group_no 派生）
 	Remark                   string    `json:"remark"`                      // 群备注
@@ -842,6 +850,7 @@ func (g *GroupResp) from(model *DetailModel) *GroupResp {
 		GroupType:                GroupType(model.GroupType),
 		Category:                 model.Category,
 		Name:                     model.Name,
+		IsNamed:                  model.IsNamed,
 		AvatarText:               model.AvatarText,
 		AvatarColor:              model.AvatarColor,
 		Notice:                   model.Notice,
@@ -886,6 +895,7 @@ func (g *GroupResp) fromModel(model *Model) *GroupResp {
 		GroupType:                GroupType(model.GroupType),
 		Category:                 model.Category,
 		Name:                     model.Name,
+		IsNamed:                  model.IsNamed,
 		AvatarText:               model.AvatarText,
 		AvatarColor:              model.AvatarColor,
 		Notice:                   model.Notice,

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -796,7 +796,7 @@ type GroupResp struct {
 	GroupType                GroupType `json:"group_type"`                  // 群类型
 	Category                 string    `json:"category"`                    // 群分类
 	Name                     string    `json:"name"`                        // 群名称
-	AvatarText               string    `json:"avatar_text"`                 // 自定义群头像文字（空=用群名前 2 字派生）
+	AvatarText               string    `json:"avatar_text"`                 // 自定义群头像文字（空=双人图标，默认头像与群名无关）
 	AvatarColor              *int      `json:"avatar_color"`                // 自定义群头像色板下标（null=按 group_no 派生）
 	Remark                   string    `json:"remark"`                      // 群备注
 	Notice                   string    `json:"notice"`                      // 群公告
@@ -956,7 +956,7 @@ type CreateGroupServiceReq struct {
 	SpaceID     string   // Space ID（可为空）
 	BotUID      string   // Bot UID（可为空；非空时自动加入群并设为 bot_admin）
 	CategoryID  string   // 群聊分组 ID（可为空；非空时自动设置创建者的 group_setting）
-	AvatarText  string   // 自定义群头像文字（可为空；空=渲染时用群名前 2 字派生）
+	AvatarText  string   // 自定义群头像文字（可为空；空=渲染时回退双人图标，默认头像与群名无关）
 	AvatarColor *int     // 自定义群头像色板下标（nil=渲染时按 group_no 派生）
 }
 
@@ -1166,7 +1166,7 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 		AllowExternal:       1, // 向后兼容：默认允许外部成员
 		AllowNoMention:      1, // 向后兼容：默认允许群级免@
 		IsExternalGroup:     isExternalGroup,
-		AvatarText:          req.AvatarText,  // 空=渲染时回退群名前 2 字
+		AvatarText:          req.AvatarText,  // 空=渲染时回退双人图标（默认头像与群名无关）
 		AvatarColor:         req.AvatarColor, // nil=渲染时按 group_no 派生
 	}, tx)
 	if err != nil {

--- a/modules/group/service_test.go
+++ b/modules/group/service_test.go
@@ -77,6 +77,7 @@ func TestCreateGroup_Success(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "测试群", model.Name)
 	assert.Equal(t, testutil.UID, model.Creator)
+	assert.Equal(t, 1, model.IsNamed, "建群传了 name → is_named=1（默认头像取群名）")
 
 	members, err := s.db.QueryMembersFirstNine(resp.GroupNo)
 	assert.NoError(t, err)
@@ -94,6 +95,35 @@ func TestCreateGroup_AutoGenerateName(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp.Name)
 	assert.Contains(t, resp.Name, "user_")
+
+	// 没传 name → 成员名拼接的自动默认名 → is_named=0（默认头像回退双人图标）。
+	s := svc.(*Service)
+	model, err := s.db.QueryWithGroupNo(resp.GroupNo)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, model.IsNamed, "未传 name → is_named=0（默认头像双人图标）")
+}
+
+// TestUpdateGroupInfo_RenameMarksIsNamed 验证用户改名后 is_named 置 1：自动名群（图标）
+// 被显式改名后变为命名群，默认头像随即可按新群名取字（改名→新默认头像的前提）。
+func TestUpdateGroupInfo_RenameMarksIsNamed(t *testing.T) {
+	svc, userDB := setupServiceTest(t)
+	insertTestUsers(t, userDB, testutil.UID)
+	s := svc.(*Service)
+
+	const groupNo = "grp_rename_isnamed"
+	assert.NoError(t, s.db.Insert(&Model{
+		GroupNo: groupNo, Name: "张三、李四", Creator: testutil.UID, Status: 1, Version: 1, IsNamed: 0,
+	}))
+
+	newName := "后端架构讨论"
+	assert.NoError(t, svc.UpdateGroupInfo(&UpdateGroupInfoServiceReq{
+		GroupNo: groupNo, OperatorUID: testutil.UID, OperatorName: "op", Name: &newName,
+	}))
+
+	model, err := s.db.QueryWithGroupNo(groupNo)
+	assert.NoError(t, err)
+	assert.Equal(t, newName, model.Name)
+	assert.Equal(t, 1, model.IsNamed, "用户显式改名 → is_named=1（默认头像改取新群名）")
 }
 
 func TestCreateGroup_DeduplicateMembers(t *testing.T) {

--- a/modules/group/service_test.go
+++ b/modules/group/service_test.go
@@ -126,6 +126,65 @@ func TestUpdateGroupInfo_RenameMarksIsNamed(t *testing.T) {
 	assert.Equal(t, 1, model.IsNamed, "用户显式改名 → is_named=1（默认头像改取新群名）")
 }
 
+// TestRenameThenInviteUpdate_KeepsIsNamed 回归 PR#500 P1（yujiawei / OctoBoooot 复核确认）：
+// groupUpdate 同一请求同时带 name 与 invite 时——name 分支（UpdateGroupInfo，fresh load）
+// 已提交 name/is_named=1，invite 分支若再用建链旧快照经**全列** UpdateTx 回写，会把 name 与
+// is_named 打回旧值（改名 + is_named 被回滚成 0 → 默认头像静默退回双人图标）。改用列级
+// UpdateInviteTx（仅动 invite/version）后，两者必须保留。本测试复刻该两步写序（name 分支
+// → invite 分支），因 invite 分支真身依赖未在 testutil 初始化的 ctx.Event，故在 service/DB
+// 层验证修复的核心性质（列级写不回写 name/is_named）。
+func TestRenameThenInviteUpdate_KeepsIsNamed(t *testing.T) {
+	svc, userDB, ctx := setupServiceTestWithCtx(t)
+	insertTestUsers(t, userDB, testutil.UID)
+	s := svc.(*Service)
+
+	const groupNo = "rename_then_invite_1"
+	// 自动名群（is_named=0），invite=0。
+	assert.NoError(t, s.db.Insert(&Model{
+		GroupNo: groupNo, Name: "张三、李四", Creator: testutil.UID, Status: 1, Version: 1, IsNamed: 0, Invite: 0,
+	}))
+
+	// name 分支：改名 → is_named=1 落库。
+	newName := "后端架构讨论"
+	assert.NoError(t, svc.UpdateGroupInfo(&UpdateGroupInfoServiceReq{
+		GroupNo: groupNo, OperatorUID: testutil.UID, OperatorName: "op", Name: &newName,
+	}))
+
+	// invite 分支（修复后）：列级写，仅动 invite/version。
+	tx, err := ctx.DB().Begin()
+	assert.NoError(t, err)
+	assert.NoError(t, s.db.UpdateInviteTx(groupNo, 1, 999, tx))
+	assert.NoError(t, tx.Commit())
+
+	model, err := s.db.QueryWithGroupNo(groupNo)
+	assert.NoError(t, err)
+	assert.Equal(t, newName, model.Name, "invite 更新不得回写旧 name")
+	assert.Equal(t, 1, model.IsNamed, "invite 更新不得把 is_named 打回 0（P1 回归）")
+	assert.Equal(t, 1, model.Invite, "invite 必须落库为 1")
+	assert.Equal(t, int64(999), model.Version)
+}
+
+// TestAddGroup_SetsIsNamed 回归 PR#500（Jerry-Xin / OctoBoooot）：非 CreateGroup 的直插建群
+// 路径（Service.AddGroup）也须按是否有显式名设置 is_named，否则命名群漏置 0 → 默认头像退回
+// 双人图标。系统群 / org_ / dept_ 直插路径（event.go）同此修复，但它们在 avatarGet 被前缀
+// 静态 PNG 分支拦截、不进 is_named 渲染路径，故此处以可独立验证的 AddGroup 锁定该不变式。
+func TestAddGroup_SetsIsNamed(t *testing.T) {
+	svc, _ := setupServiceTest(t)
+	s := svc.(*Service)
+
+	const namedNo = "addgroup_named_1"
+	assert.NoError(t, s.AddGroup(&AddGroupReq{GroupNo: namedNo, Name: "产品评审群"}))
+	m, err := s.db.QueryWithGroupNo(namedNo)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, m.IsNamed, "显式名 → is_named=1（命名群默认头像取群名）")
+
+	const autoNo = "addgroup_auto_1"
+	assert.NoError(t, s.AddGroup(&AddGroupReq{GroupNo: autoNo, Name: ""}))
+	m, err = s.db.QueryWithGroupNo(autoNo)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, m.IsNamed, "空名 → is_named=0（回退双人图标）")
+}
+
 func TestCreateGroup_DeduplicateMembers(t *testing.T) {
 	svc, userDB := setupServiceTest(t)
 	insertTestUsers(t, userDB, testutil.UID, "m1")

--- a/modules/group/sql/20260629000001_group_is_named.sql
+++ b/modules/group/sql/20260629000001_group_is_named.sql
@@ -4,7 +4,15 @@
 -- 双人图标（避免把「张三、李四、王五」这种拼接名渲成头像文字）。
 -- 存量群事后无法区分两类名（都存在 name 里），按产品决策**保守回填为 1**——一律视为
 -- 命名群、保留现状（按群名取字），不改变任何既有头像；仅新建群按建群是否传入 name 计算。
--- 使用 INFORMATION_SCHEMA 守卫保证迁移在部分执行后重试时仍可重入。
+--
+-- 恢复安全（recovery-safe）三步法：MySQL 的 ALTER TABLE 隐式提交、不可回滚，因此不能把
+-- 回填放进「列是否存在」的守卫里——一旦 ADD COLUMN 已提交、回填 UPDATE 中途失败
+-- （崩溃 / 锁超时 / 死锁），重试时列已存在、整块被跳过，存量行将停留在 DEFAULT 0
+-- （= 自动名 → 双人图标），与「不改变既有头像」相悖。改用可空哨兵：
+--   1) 先以 NULL（无默认）建列：存量行得到 NULL = 「尚未回填」；
+--   2) 无条件回填 `WHERE is_named IS NULL`：幂等、只动未回填行，任意中断后重试都能补完；
+--   3) 再 MODIFY 为 NOT NULL DEFAULT 0：新建群默认 0，由建群逻辑显式写 0/1。
+-- 每步各自带幂等守卫，跨「隐式提交边界」的部分失败重试都能正确收敛。
 -- +migrate StatementBegin
 DROP PROCEDURE IF EXISTS __group_is_named;
 -- +migrate StatementEnd
@@ -12,13 +20,26 @@ DROP PROCEDURE IF EXISTS __group_is_named;
 -- +migrate StatementBegin
 CREATE PROCEDURE __group_is_named()
 BEGIN
+  -- Step 1: 以可空（无默认）建列——存量行 = NULL「尚未回填」。守卫保证可重入。
   IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
          AND COLUMN_NAME = 'is_named') THEN
     ALTER TABLE `group`
-      ADD COLUMN `is_named` TINYINT NOT NULL DEFAULT 0 COMMENT '群名是否用户显式起名(1)/成员拼接自动名(0);默认头像取字仅对1生效';
-    -- 存量群保守回填为 1：保留现状（按群名取字），不改变既有头像。
-    UPDATE `group` SET `is_named` = 1;
+      ADD COLUMN `is_named` TINYINT NULL COMMENT '群名是否用户显式起名(1)/成员拼接自动名(0);默认头像取字仅对1生效';
+  END IF;
+
+  -- Step 2: 回填存量行为 1（保留现状、不改既有头像）。无条件执行但仅命中 NULL 行——
+  -- 幂等、可重复，任意中断后重试都能补完剩余未回填行，且不会覆盖已落定的 0/1。
+  -- 注：单条全表 UPDATE 仅命中存量 NULL 行，一次性回填；迁移在服务对外前运行，无并发写。
+  UPDATE `group` SET `is_named` = 1 WHERE `is_named` IS NULL;
+
+  -- Step 3: 收紧为 NOT NULL DEFAULT 0（新建群默认 0）。守卫在「当前可空」时才执行，
+  -- 使 Step 2 完成后的重试安全收敛。
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND COLUMN_NAME = 'is_named' AND IS_NULLABLE = 'YES') THEN
+    ALTER TABLE `group`
+      MODIFY COLUMN `is_named` TINYINT NOT NULL DEFAULT 0 COMMENT '群名是否用户显式起名(1)/成员拼接自动名(0);默认头像取字仅对1生效';
   END IF;
 END;
 -- +migrate StatementEnd

--- a/modules/group/sql/20260629000001_group_is_named.sql
+++ b/modules/group/sql/20260629000001_group_is_named.sql
@@ -1,0 +1,52 @@
+-- +migrate Up
+-- 区分「用户显式起的群名」(is_named=1) 与「成员名拼接的自动默认名」(is_named=0)。
+-- 默认头像取字仅对 is_named=1 生效：命名群取群名前 2 字（script 感知），自动名群回退
+-- 双人图标（避免把「张三、李四、王五」这种拼接名渲成头像文字）。
+-- 存量群事后无法区分两类名（都存在 name 里），按产品决策**保守回填为 1**——一律视为
+-- 命名群、保留现状（按群名取字），不改变任何既有头像；仅新建群按建群是否传入 name 计算。
+-- 使用 INFORMATION_SCHEMA 守卫保证迁移在部分执行后重试时仍可重入。
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_is_named;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __group_is_named()
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND COLUMN_NAME = 'is_named') THEN
+    ALTER TABLE `group`
+      ADD COLUMN `is_named` TINYINT NOT NULL DEFAULT 0 COMMENT '群名是否用户显式起名(1)/成员拼接自动名(0);默认头像取字仅对1生效';
+    -- 存量群保守回填为 1：保留现状（按群名取字），不改变既有头像。
+    UPDATE `group` SET `is_named` = 1;
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __group_is_named();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_is_named;
+-- +migrate StatementEnd
+
+-- +migrate Down
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_is_named_down;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __group_is_named_down()
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND COLUMN_NAME = 'is_named') THEN
+    ALTER TABLE `group` DROP COLUMN `is_named`;
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __group_is_named_down();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_is_named_down;
+-- +migrate StatementEnd

--- a/modules/group/swagger/api.yaml
+++ b/modules/group/swagger/api.yaml
@@ -320,7 +320,7 @@ paths:
                   description: "成员名称"
               avatar_text:
                 type: string
-                description: "自定义群头像文字（≤4 可见字符；空/缺省时取群名前 2 字（script 感知取字）渲染默认头像）"
+                description: "自定义群头像文字（≤4 可见字符；空/缺省时按 is_named 回退：传入 name(命名群)取群名前 2 字（script 感知取字），未传 name(成员拼接自动名)回退双人图标）"
               avatar_color:
                 type: integer
                 description: "自定义群头像色板下标 [0, 调色板大小)；缺省时按 group_no 派生颜色"
@@ -1215,8 +1215,9 @@ paths:
         - "group"
       summary: "获取群头像"
       description: >-
-        公开（不鉴权）端点。未上传自定义头像的群在服务端实时渲染默认头像（彩色描边圆 +
-        群名前 2 字（script 感知取字），或自定义 avatar_text/avatar_color；空名回退群组图标），返回 image/png。
+        公开（不鉴权）端点。未上传自定义头像的群在服务端实时渲染默认头像（彩色描边圆）：
+        优先自定义 avatar_text；否则按 is_named 回退——命名群(is_named=1)取群名前 2 字
+        （script 感知取字），自动名群(is_named=0)或空名回退双人图标；avatar_color 控制配色。返回 image/png。
         已上传头像（is_upload_avatar=1）的群 302 重定向到对象存储。群不存在或已解散返回
         404。响应带内容相关弱 ETag，命中 If-None-Match 时返回 304。
       operationId: "get avatar"
@@ -1244,6 +1245,34 @@ paths:
           description: "If-None-Match 命中，内容未变更"
         404:
           description: "群不存在或已解散"
+  /group/avatar_palette:
+    get:
+      tags:
+        - "group"
+      summary: "获取群头像色板"
+      description: >-
+        公开（不鉴权）端点。返回服务端固定的群头像设计色板（main/fill/icon_back，#RRGGBB），
+        作为唯一数据源供前端「修改头像」色圈与本地实时预览使用，使预览配色与服务端渲染的
+        PNG 完全一致、不漂移。无入参、无敏感数据，按下标有序。响应带内容相关弱 ETag 与
+        Cache-Control: public, max-age=300, must-revalidate；命中 If-None-Match 时返回 304。
+      operationId: "get avatar palette"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "header"
+          name: "If-None-Match"
+          type: string
+          description: "条件请求；与当前弱 ETag 匹配时返回 304"
+          required: false
+      responses:
+        200:
+          description: "固定群头像色板"
+          schema:
+            $ref: "#/definitions/avatarPaletteResp"
+        304:
+          description: "If-None-Match 命中，色板未变更"
   /groups/{group_no}/scanjoin:
     get:
       tags:
@@ -1283,6 +1312,32 @@ securityDefinitions:
     description: "用户token"
 
 definitions:
+  avatarPaletteColorResp:
+    type: object
+    properties:
+      index:
+        type: integer
+        description: "色板下标，与 avatar_color 取值一致"
+      main:
+        type: string
+        description: "主题主色 #RRGGBB"
+      fill:
+        type: string
+        description: "圆填充浅色 #RRGGBB"
+      icon_back:
+        type: string
+        description: "双人图标后景人浅色 #RRGGBB"
+  avatarPaletteResp:
+    type: object
+    properties:
+      size:
+        type: integer
+        description: "色板档数（= avatar_color 合法上界）"
+      colors:
+        type: array
+        description: "按下标 0..size 有序的色板项"
+        items:
+          $ref: "#/definitions/avatarPaletteColorResp"
   memberManagerResp:
     type: object
     properties:

--- a/modules/group/swagger/api.yaml
+++ b/modules/group/swagger/api.yaml
@@ -528,7 +528,7 @@ paths:
                 description: "修改群名称 notice(修改群备注) invite(是否开启进群邀请) 等"
               avatar_text:
                 type: string
-                description: "自定义群头像文字（≤4 可见字符；空串清除→回退双人图标，默认头像与群名无关）"
+                description: "自定义群头像文字（≤4 可见字符；空串清除→按 is_named 回退：命名群取群名前2字、自动名群双人图标）"
               avatar_color:
                 type: integer
                 description: "自定义群头像色板下标 [0, 调色板大小)；空串或 -1 清除→回退按 group_no 派生"

--- a/modules/group/swagger/api.yaml
+++ b/modules/group/swagger/api.yaml
@@ -528,7 +528,7 @@ paths:
                 description: "修改群名称 notice(修改群备注) invite(是否开启进群邀请) 等"
               avatar_text:
                 type: string
-                description: "自定义群头像文字（≤4 可见字符；空串清除→回退群名前 2 字（script 感知取字））"
+                description: "自定义群头像文字（≤4 可见字符；空串清除→回退双人图标，默认头像与群名无关）"
               avatar_color:
                 type: integer
                 description: "自定义群头像色板下标 [0, 调色板大小)；空串或 -1 清除→回退按 group_no 派生"

--- a/modules/group/swagger/api.yaml
+++ b/modules/group/swagger/api.yaml
@@ -1395,6 +1395,9 @@ definitions:
       name:
         type: string
         description: "群名称"
+      is_named:
+        type: integer
+        description: "群名是否用户显式起名(1)/成员拼接自动名(0)；客户端据此本地预判默认头像取群名前2字 vs 双人图标"
       remark:
         type: string
         description: "群备注"
@@ -1469,7 +1472,7 @@ definitions:
         description: "群数据版本"
       avatar_text:
         type: string
-        description: "自定义群头像文字（空表示未自定义，按群名前 2 字（script 感知取字）派生）"
+        description: "自定义群头像文字（空=未自定义，按 is_named 回退：命名群(is_named=1)取群名前 2 字（script 感知取字），自动名群(is_named=0)回退双人图标）"
       avatar_color:
         type: integer
         description: "自定义群头像色板下标（null 表示未自定义，按 group_no 派生）"

--- a/pkg/avatarrender/palette.go
+++ b/pkg/avatarrender/palette.go
@@ -1,6 +1,7 @@
 package avatarrender
 
 import (
+	"fmt"
 	"hash/crc32"
 	"image/color"
 )
@@ -107,4 +108,35 @@ func ColorByIndex(i int) (color.RGBA, bool) {
 		return color.RGBA{}, false
 	}
 	return palette[i], true
+}
+
+// GroupColorHex 是一档群头像配色的十六进制（#RRGGBB）形式，供**客户端本地渲染**
+// （如「修改头像」实时预览、色圈选择）使用：客户端用 Index 选色、用 Main/Fill/IconBack
+// 复刻服务端 PNG 的视觉（主色描边/文字、浅底圆、图标后景人），保证预览与建群/改群后
+// 服务端渲染出的真图一致。
+type GroupColorHex struct {
+	Index    int    // 色板下标 [0,PaletteSize)，与 avatar_color 取值一致
+	Main     string // 主题主色：圆描边 + 文字 + 图标前景人
+	Fill     string // 圆填充浅色
+	IconBack string // 图标兜底（双人剪影）后景人浅色
+}
+
+// PaletteHex 返回整套群头像色板的十六进制形式（按下标 0..PaletteSize 顺序），作为
+// 色板的**唯一数据源**对客户端暴露——前端不再硬编码色值，避免与服务端 palette.go 漂移。
+func PaletteHex() []GroupColorHex {
+	out := make([]GroupColorHex, len(palette))
+	for i := range palette {
+		out[i] = GroupColorHex{
+			Index:    i,
+			Main:     hexOf(palette[i]),
+			Fill:     hexOf(groupFillPalette[i]),
+			IconBack: hexOf(groupIconBackPalette[i]),
+		}
+	}
+	return out
+}
+
+// hexOf 把 RGBA 主色格式化为 #RRGGBB（忽略 alpha——色板均为不透明设计色）。
+func hexOf(c color.RGBA) string {
+	return fmt.Sprintf("#%02X%02X%02X", c.R, c.G, c.B)
 }

--- a/pkg/avatarrender/palette_hex_test.go
+++ b/pkg/avatarrender/palette_hex_test.go
@@ -1,0 +1,36 @@
+package avatarrender
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPaletteHex 校验对客户端暴露的色板十六进制视图：长度=PaletteSize、按下标有序、
+// 三套色均为 #RRGGBB，且与内部 palette/groupFillPalette/groupIconBackPalette 同源
+// （首档钉死设计稿色，防止有人改了内部色板却忘了它是对外契约）。
+func TestPaletteHex(t *testing.T) {
+	hex := PaletteHex()
+	require.Len(t, hex, PaletteSize())
+
+	hexRe := regexp.MustCompile(`^#[0-9A-F]{6}$`)
+	for i, h := range hex {
+		require.Equal(t, i, h.Index, "entries must be ordered by palette index")
+		require.Regexp(t, hexRe, h.Main, "main must be #RRGGBB")
+		require.Regexp(t, hexRe, h.Fill, "fill must be #RRGGBB")
+		require.Regexp(t, hexRe, h.IconBack, "icon_back must be #RRGGBB")
+
+		// 同源:与 GroupStyleByIndex 解出的同一档 RGBA 一致。
+		style, ok := GroupStyleByIndex(i)
+		require.True(t, ok)
+		require.Equal(t, hexOf(style.Main), h.Main)
+		require.Equal(t, hexOf(style.Fill), h.Fill)
+		require.Equal(t, hexOf(style.IconBack), h.IconBack)
+	}
+
+	// 钉死设计稿首档(#14C0FF ← palette[0])，捕获顺序/取值漂移。
+	require.Equal(t, "#14C0FF", hex[0].Main)
+	require.Equal(t, "#ECF9FE", hex[0].Fill)
+	require.Equal(t, "#7EDAFB", hex[0].IconBack)
+}

--- a/pkg/avatarrender/text.go
+++ b/pkg/avatarrender/text.go
@@ -136,6 +136,9 @@ func initials(name string, limit int) string {
 // 仅用于「群名自动取字」。用户显式设置的自定义头像文字走 GroupText(原样渲染、≤4),
 // 不经过本规则。返回结果可能仍含本字体无字形的字符(罕见生僻字),调用方应配合
 // Renderable 判断,对不可渲染的结果回退到群组图标。
+//
+// NOTE(2026-06-29):「默认群头像改为双人图标(与群名无关)」后,本函数已无生产调用方
+// (仅单测保留);默认头像不再按群名取字。保留以备将来可能重新启用。
 func GroupNameText(name string) string {
 	return extractAvatarText(name, false, 2)
 }

--- a/pkg/avatarrender/text.go
+++ b/pkg/avatarrender/text.go
@@ -137,8 +137,8 @@ func initials(name string, limit int) string {
 // 不经过本规则。返回结果可能仍含本字体无字形的字符(罕见生僻字),调用方应配合
 // Renderable 判断,对不可渲染的结果回退到群组图标。
 //
-// NOTE(2026-06-29):「默认群头像改为双人图标(与群名无关)」后,本函数已无生产调用方
-// (仅单测保留);默认头像不再按群名取字。保留以备将来可能重新启用。
+// 仅用于「命名群(is_named=1)」的群名自动取字;成员拼接的自动名(is_named=0)不调用本函数、
+// 直接回退双人图标(见 modules/group writeGroupDefaultAvatar)。
 func GroupNameText(name string) string {
 	return extractAvatarText(name, false, 2)
 }


### PR DESCRIPTION
## Summary

Make the default group avatar follow a **user-given** group name, while a group left on the auto member-name-concatenated default name renders the two-person icon. Also add a public endpoint exposing the fixed avatar color palette so web clients can render local previews that match the server PNG.

Backward-compatible: existing groups are backfilled `is_named=1`, so **no existing avatar changes**; only newly created *unnamed* groups now get the icon.

## Related Issue

N/A — product task "group-chat-avatar-gen" (2026-06-29). See Linked Spec.

## Linked Spec

`.octospec/tasks/group-avatar-icon-default/brief.md`

## Changes

- Add `is_named` column (migration `20260629000001`, reentrant; existing rows backfilled to `1`) distinguishing a user-given name from the member-concat auto default.
- `CreateGroup` infers `is_named` from whether `name` was provided (computed before the member-concat fallback); rename (`UpdateGroupInfo`) sets `is_named=1`, persisted via `DB.UpdateTx`.
- `writeGroupDefaultAvatar` text priority: custom `avatar_text` > named group's name first-2 glyphs (`GroupNameText`) > two-person icon.
- New public endpoint `GET /v1/group/avatar_palette` returning the 10-color palette (`main`/`fill`/`icon_back` hex) with a content-derived weak ETag + `304`; `avatarrender.PaletteHex()` added.
- Comments / swagger / octospec brief synced to the `is_named` rule. No render-version bump (named = `group-name-v4`+text, auto-named = `group-icon-v3`; modes differ by ETag factors).

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

Local run against real MySQL 8 + Redis + WuKongIM: `go build ./...`, `go vet ./...`, `golangci-lint` (0 issues), `make i18n-lint`, `go test ./modules/group/...` (full suite ~21s), `go test ./pkg/avatarrender/...`.

New/updated tests: `TestGroupAvatarGetAutoNamedRendersIcon`, `TestGroupAvatarGetNamedRendersNameText`, `TestCreateGroup_{Success,AutoGenerateName}` is_named asserts, `TestUpdateGroupInfo_RenameMarksIsNamed`, `TestGroupAvatarPalette` (+ ETag/304), `TestPaletteHex`; custom-text / uploaded-redirect / 404 / disband / version-pin regressions still pass.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   The default group-avatar render branch (`writeGroupDefaultAvatar`): with no custom `avatar_text`, it now picks text by the new `is_named` flag — a user-named group (`1`) renders the name's first 2 glyphs, an auto member-concat-named group (`0`) renders the two-person icon. `is_named` is inferred at create (was a name provided?) and set to `1` on rename. A separate, additive, public read-only endpoint exposes the palette; no existing render path or route is touched.

2. **What could break** because of it (dependents + failure mode)?

   The load-bearing surface is the default-avatar PNG and its cache. Existing groups are backfilled `is_named=1`, so their rendered bytes and ETags are identical to before (#494 name-derived) — no stale-cache risk and zero visual change. The only behavior change is that **newly created unnamed groups** switch from concat-name text to the icon (intended). Mode switches (named↔auto, or a rename) change the ETag's text factor, so clients revalidate to the fresh image without a version bump. The new endpoint is purely additive, public, static, and route-conflict-free (mounted under `/v1/group` on a non-wildcard segment).

3. **How do you know it works** (specific test/repro/trace)?

   Endpoint tests byte-compare the rendered PNG against the expected renderer on real infra: `...NamedRendersNameText` asserts a named group == `RenderGroup(GroupNameText(name))`; `...AutoNamedRendersIcon` asserts an auto-named group == `RenderIcon`; `TestUpdateGroupInfo_RenameMarksIsNamed` proves rename persists `is_named=1`; the two `CreateGroup` tests prove create-time inference. The migration is auto-applied by `NewTestServer`. Full group + avatarrender suites, golangci (0 issues), and i18n-lint are green.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (swagger + octospec brief)
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017D9g64sSjENNaXdnfCnjwr

---
_Generated by [Claude Code](https://claude.ai/code/session_017D9g64sSjENNaXdnfCnjwr)_