### PR TITLE
feat(group): default new groups to icon avatar; grandfather existing via is_named

### DIFF
--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,23 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-06-29
+
+- **Change** — Task `group-avatar-name-no-text` (client-coordination; repurposes
+  `group-avatar-icon-default` S2): newly created groups now default to the
+  two-person icon — the group **name is never rendered as avatar text**; text
+  appears only when the user sets a custom `avatar_text`. Implemented by changing
+  **who gets `is_named=1`**, not the render rule (`writeGroupDefaultAvatar`
+  unchanged: `avatar_text > is_named==1 name-text > icon`). `is_named` is
+  repurposed from "user named it" to "**pre-cutover legacy group**": all new
+  inserts (`CreateGroup`/`AddGroup`/`event.go` system+org+dept) persist
+  `is_named=0`, and rename no longer flips it; existing groups keep `is_named=1`
+  (already backfilled by migration `20260629000001`) so they are **grandfathered**
+  onto their current name-text avatar (no historical group flips to an icon).
+  `is_named` stays load-bearing (not deprecated) as the legacy/new discriminator;
+  `GroupResp.is_named` re-documented as 1=legacy/0=new predictor. No render-version
+  bump, no new migration. Brief under `.octospec/tasks/group-avatar-name-no-text/`.
+
 ## 2026-06-27
 
 - **Add** — Task `default-avatar-text-rule`: script-aware 2-glyph text rule for

--- a/.octospec/tasks/group-avatar-name-no-text/brief.md
+++ b/.octospec/tasks/group-avatar-name-no-text/brief.md
@@ -75,8 +75,25 @@ legacy avatars (rename would no longer follow).
 - **Migration `20260629000001` is reused as-is, not modified.** Its backfill-to-1
   is exactly the legacy marker this task needs. The file is already merged/applied;
   its in-file comments still describe the #500 "user-named" intent (now reinterpreted
-  as "legacy") — left as the historical record; the Go `Model.IsNamed` comment is
-  the source of truth.
+  as "legacy"). Since several reviewers flagged the stale *live* column COMMENTs
+  (schema introspection would carry old guidance), a follow-up **comment-only
+  migration `20260629000002`** `MODIFY COLUMN`s `is_named` + `avatar_text` to refresh
+  their COMMENTs to the legacy/new semantic (no type/constraint/data change,
+  reentrant via INFORMATION_SCHEMA guard). The historical migration files' `--`
+  comments stay as the record; the Go `Model.IsNamed` comment + the live column
+  COMMENT are the source of truth.
+
+## Follow-ups (out of scope — separate PR/issue)
+- **`UpdateGroupInfo` full-row `UpdateTx` → column-level** (yujiawei, non-blocking):
+  a rename's full-row writeback could clobber a concurrent `invite` toggle with a
+  stale loaded value (the inverse of #500's P1, which was fixed for the invite
+  branch only). Pre-existing; converting `UpdateGroupInfo` to a column-scoped write
+  closes the remaining read-modify-write window.
+- **Public avatar endpoint enumeration / name-prefix disclosure** (yujiawei,
+  non-blocking): the unauthenticated `GET /:group_no/avatar` distinguishes
+  existing vs nonexistent/disbanded groups and renders a legacy group's first-2
+  name glyphs. Pre-existing and intentionally preserved by grandfather; hardening
+  (auth or constant-shape response) is separate scope.
 
 ## Out of scope
 - Any change to the render logic, `avatar_text`/`avatar_color` APIs, validation,

--- a/.octospec/tasks/group-avatar-name-no-text/brief.md
+++ b/.octospec/tasks/group-avatar-name-no-text/brief.md
@@ -1,0 +1,100 @@
+---
+type: Task
+title: "Task: group-avatar-name-no-text"
+description: New groups default to the two-person icon (group name is not avatar text; only custom avatar_text renders text). Existing groups are grandfathered via the is_named flag so they keep their current name-text avatar.
+tags: [group, avatar, render, grandfather, product-pivot]
+timestamp: 2026-06-29T12:00:00Z
+# --- octospec extension fields ---
+slug: group-avatar-name-no-text
+upstream: group-chat-avatar-gen (client-coordination change, 2026-06-29)
+supersedes: group-avatar-icon-default (S2 — is_named meaning is repurposed, not deprecated)
+source: self
+---
+
+# Task: group-avatar-name-no-text
+
+> Server change to match the client: a **newly created** group defaults to the
+> two-person icon; the group **name is never rendered as avatar text**; text
+> appears only when the user explicitly sets a custom `avatar_text`. Existing
+> groups are grandfathered (kept on their current name-text avatar) so the change
+> does not flip every historical group to an icon at once.
+
+## Goal
+Change **who gets `is_named=1`**, not the render rule.
+
+- **Render rule is unchanged from #500:** `avatar_text` (custom) > `is_named==1`
+  → `GroupNameText(name)` (first-2 glyphs) > two-person icon. `writeGroupDefaultAvatar`
+  is untouched in logic.
+- **`is_named` is repurposed** from "user explicitly named the group" to
+  "**pre-cutover legacy group**":
+  - **New groups → `is_named=0` always** (regardless of whether a name was given).
+    So a freshly created group defaults to the icon; setting `avatar_text` is the
+    only way to get text. Matches the client preview (icon when `avatar_text` empty).
+  - **Existing groups → `is_named=1`** — already backfilled by #500's migration
+    (`20260629000001`, conservative backfill-to-1). They keep rendering their name
+    as before (grandfather), so no historical group flips to an icon.
+
+This is the **甲案** chosen by the maintainer (2026-06-29): keep `is_named`
+load-bearing (NOT deprecated) as the legacy/new discriminator. The alternative
+(retire `is_named` + a one-time backfill of name→`avatar_text`) was rejected because
+it requires Go-side script-aware derivation (not expressible in SQL) and freezes
+legacy avatars (rename would no longer follow).
+
+## Background
+- #500 added `is_named` meaning "user named it" and gated name-text on it. The
+  client then changed its create/edit preview to show the icon when `avatar_text`
+  is empty. To match, the server must default new groups to the icon — but #500
+  set `is_named=1` for any explicitly-named new group, so new named groups still
+  rendered name-text. Flipping ALL groups to icon (the global approach, prior PR
+  #503 head) was rejected by product because it changes every existing group's
+  avatar at once. Grandfather is the resolution.
+
+## Load-bearing list
+- **`is_named` write-policy (the whole change).** New groups must persist
+  `is_named=0`:
+  - `Service.CreateGroup` (`service.go`): removed the `isNamedVal = (name != "")`
+    computation; the insert sets `IsNamed: 0`.
+  - `Service.AddGroup` (`service.go`): removed the name-based computation; insert
+    sets `IsNamed: 0`.
+  - `event.go` system-group + org/dept inserts: `IsNamed: 0` (they are served
+    static PNGs and never hit the render path; set to 0 to keep the invariant
+    "`is_named=1` ⟺ pre-cutover legacy row" clean).
+  - `Service.UpdateGroupInfo` rename: removed `groupModel.IsNamed = 1`. Rename no
+    longer flips the flag — it preserves the loaded value (legacy stays 1 and its
+    name-text follows the new name; new stays 0 and stays an icon). `UpdateTx`'s
+    full-row SetMap still writes the (unchanged) loaded `is_named` back.
+- **Render rule unchanged (`writeGroupDefaultAvatar`, `api.go`).** Still
+  `avatar_text > is_named==1 name-text > icon`. Only the comments are reworded to
+  the legacy/new semantic. ETag factors unchanged: text present (legacy name or
+  custom) → `group-name-v4`; no text (new group) → `group-icon-v3`.
+- **`is_named` is read-only after creation.** Only set by #500's migration
+  backfill (legacy → 1); every app insert writes 0; rename/invite never change it.
+  So `is_named=1` strictly identifies pre-cutover groups.
+- **`GroupResp.is_named` kept** (additive, #500). Re-documented as
+  "1=legacy/name-text, 0=new/icon"; clients can still locally predict the default.
+- **Migration `20260629000001` is reused as-is, not modified.** Its backfill-to-1
+  is exactly the legacy marker this task needs. The file is already merged/applied;
+  its in-file comments still describe the #500 "user-named" intent (now reinterpreted
+  as "legacy") — left as the historical record; the Go `Model.IsNamed` comment is
+  the source of truth.
+
+## Out of scope
+- Any change to the render logic, `avatar_text`/`avatar_color` APIs, validation,
+  upload path, palette endpoint/values.
+- Dropping or re-migrating the `is_named` column (kept, repurposed).
+- octo-web (already shows the icon when `avatar_text` is empty).
+
+## Acceptance
+- `CreateGroup` / `AddGroup` with or without a name → `is_named=0` (new groups
+  default to the icon). `UpdateGroupInfo` rename → `is_named` unchanged (new stays
+  0, legacy stays 1).
+- `writeGroupDefaultAvatar`: `is_named=1` (legacy) + no `avatar_text` →
+  `RenderGroup(GroupNameText(name))`; `is_named=0` (new) + no `avatar_text` →
+  `RenderIcon`; custom `avatar_text` always overrides; custom color honored in both.
+- Tests: `TestCreateGroup_Success`/`_AutoGenerateName` assert `is_named=0`;
+  `TestUpdateGroupInfo_RenameDoesNotChangeIsNamed`;
+  `TestRenameThenInviteUpdate_KeepsNameAndIsNamed` (P1 clobber regression, legacy
+  group); `TestAddGroup_DefaultsIsNamedZero`; `TestGroupAvatarGetNamedRenders*`
+  (legacy → name-text) and `...AutoNamedRendersIcon` (new → icon) pass.
+- `go build ./...`, `go vet`, `golangci-lint`, `make i18n-lint` green. Endpoint
+  tests needing MySQL/Redis/WuKongIM run in CI.

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -425,12 +425,14 @@ func (g *Group) avatarGet(c *wkhttp.Context) {
 	}
 
 	// 无自定义上传（含历史合成群、新建群）：服务端实时渲染默认头像——有自定义文字则渲染
-	// 该文字；否则命名群（is_named=1）取群名前 2 字，自动名群（is_named=0）回退双人图标。
+	// 该文字；否则老群（is_named=1，改版前存量群）取群名前 2 字，新群（is_named=0）回退双人图标。
 	g.writeGroupDefaultAvatar(c, groupNo, groupInfo)
 }
 
 // writeGroupDefaultAvatar 服务端渲染并返回群默认头像（无自定义上传时）。文字优先级：
-// 自定义 avatar_text > 命名群（is_named=1）的群名前 2 字 > 空（自动名群 → 双人图标）。
+// 自定义 avatar_text > 老群（is_named=1，改版前存量群）的群名前 2 字 > 空（新群 is_named=0
+// → 双人图标）。产品 2026-06-29 改版：新建群默认双人图标、群名不作为头像文字，仅 avatar_text
+// 才渲染文字；is_named=1 仅由 #500 迁移回填给存量老群，让它们保留原群名文字头像（grandfather）。
 // 颜色优先自定义 avatar_color，否则按 group_no 稳定派生（改名不变色、跨页面一致）。
 //
 // URL 稳定为 groups/{group_no}/avatar，内容随群名/自定义变化，故用内容相关弱 ETag +
@@ -441,11 +443,12 @@ func (g *Group) writeGroupDefaultAvatar(c *wkhttp.Context, groupNo string, group
 	colorTag := "seed"
 	var text string
 	if groupInfo != nil {
-		// 默认头像取字规则(产品 2026-06-29 定稿)：
+		// 默认头像取字规则(产品 2026-06-29 改版)：
 		//   1. 用户在「修改头像」显式设了自定义文字 → 原样渲染(写入时已 ≤4 规范化、不取字);
-		//   2. 否则群是用户**显式起名**(is_named=1) → 取群名前 2 字(script 感知);
-		//   3. 否则(成员名拼接的自动默认名 is_named=0) → text 留空 → 回退双人图标
-		//      (不把「张三、李四、王五」这类拼接名渲成头像文字)。
+		//   2. 否则是**改版前的存量老群**(is_named=1) → 取群名前 2 字(script 感知)，保留其原有
+		//      群名文字头像(grandfather，避免老群一夜全变小人);
+		//   3. 否则(新群 is_named=0) → text 留空 → 回退双人图标(群名不作为头像文字，要文字请设
+		//      avatar_text)。
 		if groupInfo.AvatarText != "" {
 			text = avatarrender.GroupText(groupInfo.AvatarText)
 		} else if groupInfo.IsNamed == 1 {
@@ -461,10 +464,10 @@ func (g *Group) writeGroupDefaultAvatar(c *wkhttp.Context, groupNo string, group
 	renderable := avatarrender.Renderable(text)
 
 	// ETag 覆盖决定图像内容的因子：渲染模式版本 + group_no(派生色) + 实际色 + 文字。
-	// 改名/改自定义文字/改 is_named → text 变(或在 name 模式与 icon 模式间切换) → ETag 变；
-	// 改自定义色 → colorTag 变 → ETag 变。命名群走 group-name-v4(+text)、自动名群走
-	// group-icon-v3(无 text)，模式不同因子串天然不同，故两类切换无需 bump 版本。渲染
-	// **视觉**改动(像素变但因子不变，如 #486 透明四角)才必须 bump 版本段。
+	// 老群改名 → text 变 → ETag 变；改/清自定义文字(或在 text 模式与 icon 模式间切换) →
+	// ETag 变；改自定义色 → colorTag 变 → ETag 变。有文字(老群群名/自定义)走 group-name-v4
+	// (+text)、无文字(新群)走 group-icon-v3(无 text)，模式不同因子串天然不同，故两类切换无需
+	// bump 版本。渲染**视觉**改动(像素变但因子不变，如 #486 透明四角)才必须 bump 版本段。
 
 	etag := avatarrender.ETag("group-icon-v3", groupNo, colorTag)
 	if renderable {
@@ -4210,7 +4213,7 @@ type groupReq struct {
 	Members     []string `json:"members"`      // 成员uid
 	SpaceID     string   `json:"space_id"`     // Space ID（可选）
 	CategoryID  string   `json:"category_id"`  // 群聊分组 ID（可选，需配合 space_id 使用）
-	AvatarText  string   `json:"avatar_text"`  // 自定义群头像文字（可选，最多 4 个中文/英文字符；空=按 is_named 回退：命名群群名/自动名群双人图标）
+	AvatarText  string   `json:"avatar_text"`  // 自定义群头像文字（可选，最多 4 个中文/英文字符；空=按 is_named 回退：老群渲染群名/新群双人图标）
 	AvatarColor *int     `json:"avatar_color"` // 自定义群头像色板下标（可选，[0,palette)；不传=按 group_no 派生）
 }
 
@@ -4223,7 +4226,8 @@ func (g groupReq) Check() error {
 
 // checkAvatar 校验二次弹窗的自定义头像参数，返回越界字段名（供 Details.field）。
 // ok=true 表示合法。两者均为可选：avatar_text 空、avatar_color 不传即“未自定义”，
-// 渲染时分别回退到群名前 2 字 / ColorForSeed(group_no)。不静默截断，超限直接拒绝。
+// 渲染时分别回退到 is_named 规则(老群群名前2字/新群双人图标) / ColorForSeed(group_no)。
+// 不静默截断，超限直接拒绝。
 //
 // 哨兵约定（创建 vs 改群刻意不对称）：创建无既有值可清除，故 avatar_color 仅接受
 // [0,palette)（-1 在此被拒）；改群额外接受 "-1" / "" 表示清除自定义色回退派生。

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -1032,7 +1032,7 @@ func (g *Group) groupUpdate(c *wkhttp.Context) {
 	// 自定义群头像文字/颜色（二次弹窗保存）：先在任何 mutation 之前完成解析与校验，构造
 	// avatarReq。这样非法的 avatar 字段会在 name/notice/invite 落库之前返回 400，避免
 	// 「返回 400 却已部分写入群名」的非原子部分写入。avatar_text 空串清除自定义文字（回退
-	// 群名），avatar_color "" / "-1" 清除自定义色（回退派生）。超限直接拒绝，不静默截断。
+	// is_named 规则:老群群名/新群双人图标），avatar_color "" / "-1" 清除自定义色（回退派生）。超限直接拒绝，不静默截断。
 	avatarTextValue, hasAvatarText := groupMap[attrKeyAvatarText]
 	avatarColorValue, hasAvatarColor := groupMap[attrKeyAvatarColor]
 	var avatarReq *UpdateGroupAvatarCustomServiceReq

--- a/modules/group/avatar_custom_test.go
+++ b/modules/group/avatar_custom_test.go
@@ -60,7 +60,7 @@ func TestGroupReqCheckAvatar(t *testing.T) {
 
 // TestGroupAvatarCustomDBRoundTrip 覆盖自定义头像文字/颜色的落库读回：
 //   - 默认建群（未自定义）写入 avatar_text=” / avatar_color=NULL（*int=nil），
-//     这是渲染时回退“群名前 2 字（script 感知取字）+ ColorForSeed(group_no)”的哨兵；
+//     这是渲染时回退“is_named 规则(老群群名前2字/新群双人图标) + ColorForSeed(group_no)”的哨兵；
 //   - 显式自定义写入文字与色板下标，QueryWithGroupNo 原样读回。
 //
 // *int 的 nil→NULL 依赖 dbr Record() 对指针字段的处理（与 group_md *string 同理）。

--- a/modules/group/avatar_get_test.go
+++ b/modules/group/avatar_get_test.go
@@ -25,9 +25,9 @@ func doAvatarGet(t *testing.T, h http.Handler, groupNo, ifNoneMatch string) *htt
 	return w
 }
 
-// TestGroupAvatarGetAutoNamedRendersIcon 覆盖核心规则（产品 2026-06-29 定稿）：成员名
-// 拼接的**自动默认名**（is_named=0）且无自定义文字 → 双人图标（不把拼接名渲成头像文字），
-// 即使 name 字段非空。带弱 ETag + must-revalidate；命中 If-None-Match 时 304。
+// TestGroupAvatarGetAutoNamedRendersIcon 覆盖核心规则（产品 2026-06-29 改版）：新群
+// （is_named=0）且无自定义文字 → 双人图标（群名不作为头像文字），即使 name 字段非空。
+// 带弱 ETag + must-revalidate；命中 If-None-Match 时 304。
 func TestGroupAvatarGetAutoNamedRendersIcon(t *testing.T) {
 	s, ctx := newTestServer(t)
 	require.NoError(t, testutil.CleanAllTables(ctx))
@@ -61,8 +61,8 @@ func TestGroupAvatarGetAutoNamedRendersIcon(t *testing.T) {
 	require.Empty(t, w2.Body.Bytes())
 }
 
-// TestGroupAvatarGetNamedRendersNameText 覆盖：用户**显式起名**（is_named=1）且无自定义
-// 文字 → 取群名前 2 字（script 感知）渲染文字，而非双人图标。
+// TestGroupAvatarGetNamedRendersNameText 覆盖 grandfather：**改版前的存量老群**（is_named=1）
+// 且无自定义文字 → 取群名前 2 字（script 感知）渲染文字，保留其原有群名文字头像，而非双人图标。
 func TestGroupAvatarGetNamedRendersNameText(t *testing.T) {
 	s, ctx := newTestServer(t)
 	require.NoError(t, testutil.CleanAllTables(ctx))
@@ -75,7 +75,7 @@ func TestGroupAvatarGetNamedRendersNameText(t *testing.T) {
 
 	w := doAvatarGet(t, s.GetRoute(), groupNo, "")
 	require.Equal(t, http.StatusOK, w.Code)
-	// 命名群也走内容相关弱 ETag：保护改名 / 切自定义触发的缓存失效契约（Jerry-Xin 🔵）。
+	// 老群文字头像也走内容相关弱 ETag：保护改名 / 切自定义触发的缓存失效契约（Jerry-Xin 🔵）。
 	etag := w.Header().Get("ETag")
 	require.True(t, strings.HasPrefix(etag, `W/"`), "named group avatar must carry a weak ETag, got %q", etag)
 	require.Contains(t, w.Header().Get("Cache-Control"), "must-revalidate")
@@ -87,9 +87,9 @@ func TestGroupAvatarGetNamedRendersNameText(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, want, w.Body.Bytes(),
-		"named group (is_named=1) without custom text must render script-aware first-2 of the name")
+		"legacy group (is_named=1) without custom text must render script-aware first-2 of the name")
 
-	// 命中的 If-None-Match → 304 无 body（命名群路径同样支持条件请求省渲染）。
+	// 命中的 If-None-Match → 304 无 body（老群文字路径同样支持条件请求省渲染）。
 	w2 := doAvatarGet(t, s.GetRoute(), groupNo, etag)
 	require.Equal(t, http.StatusNotModified, w2.Code)
 	require.Empty(t, w2.Body.Bytes())
@@ -135,9 +135,9 @@ func TestGroupAvatarGetCustomOverrides(t *testing.T) {
 	require.Equal(t, want, w.Body.Bytes(), "custom text+color must override name/seed")
 }
 
-// TestGroupAvatarGetCustomColorIconNoText 覆盖 S2:自动名群(is_named=0)设了自定义颜色但
-// **无**自定义文字 → 渲染该颜色的双人图标(自动名群默认头像与群名无关,但自定义颜色仍被
-// 尊重)。fixture 显式 IsNamed=0,名字取「自动名群」以贴合意图(避免与 is_named=1 混淆)。
+// TestGroupAvatarGetCustomColorIconNoText 覆盖:新群(is_named=0)设了自定义颜色但**无**自定义
+// 文字 → 渲染该颜色的双人图标(新群默认头像与群名无关,但自定义颜色仍被尊重)。fixture 显式
+// IsNamed=0,名字取「自动名群」以贴合意图(避免与老群 is_named=1 混淆)。
 func TestGroupAvatarGetCustomColorIconNoText(t *testing.T) {
 	s, ctx := newTestServer(t)
 	require.NoError(t, testutil.CleanAllTables(ctx))
@@ -159,8 +159,8 @@ func TestGroupAvatarGetCustomColorIconNoText(t *testing.T) {
 }
 
 // TestGroupAvatarGetNamedCustomColorRendersNameText 锁定三因子交互(Octo-Q P2-1 建议):
-// 命名群(is_named=1) + 自定义颜色 + **无**自定义文字 → 以该自定义颜色渲染群名前 2 字
-// (而非派生色、而非图标)。补全 is_named=1 与 custom_color 的组合覆盖。
+// 老群(is_named=1) + 自定义颜色 + **无**自定义文字 → 以该自定义颜色渲染群名前 2 字
+// (而非派生色、而非图标)。补全 is_named=1(老群) 与 custom_color 的组合覆盖。
 func TestGroupAvatarGetNamedCustomColorRendersNameText(t *testing.T) {
 	s, ctx := newTestServer(t)
 	require.NoError(t, testutil.CleanAllTables(ctx))
@@ -183,7 +183,7 @@ func TestGroupAvatarGetNamedCustomColorRendersNameText(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, want, w.Body.Bytes(),
-		"named group (is_named=1) with custom color + no text must render name first-2 in that custom color")
+		"legacy group (is_named=1) with custom color + no text must render name first-2 in that custom color")
 }
 
 // TestGroupAvatarGetCustomTextNotTruncated 回归 PR#494 评审(Jerry-Xin):用户显式

--- a/modules/group/avatar_version_pin_test.go
+++ b/modules/group/avatar_version_pin_test.go
@@ -28,8 +28,9 @@ func TestGroupAvatarGetPinsRenderVersion(t *testing.T) {
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	g := New(ctx)
 
-	// Custom avatar_text is the ONLY path to text-render now that the group name no
-	// longer drives the default avatar -> name render mode, default colorTag "seed".
+	// This fixture uses custom avatar_text -> name render mode, default colorTag "seed".
+	// (Legacy is_named=1 groups also render group-name text; new groups fall back to icon.
+	//  This test pins the version segment of the text-render mode, regardless of text source.)
 	const namedNo = "avatar_pin_named_1"
 	require.NoError(t, g.db.Insert(&Model{GroupNo: namedNo, Name: "后端架构讨论", Creator: "c1", Status: 1, AvatarText: "研发"}))
 	named := doAvatarGet(t, s.GetRoute(), namedNo, "")

--- a/modules/group/const.go
+++ b/modules/group/const.go
@@ -47,7 +47,7 @@ const (
 // 群信息更新（PUT /v1/group/:group_no）中自定义群头像的 map key，与创建接口
 // groupReq 的 JSON 字段名保持一致。avatar_color 值为色板下标字符串，"" 或 "-1"
 // 表示清除自定义色（回退按 group_no 派生）；avatar_text 为空字符串表示清除自定义
-// 文字（回退：命名群取群名前 2 字，自动名群双人图标）。
+// 文字（回退：老群取群名前 2 字，新群双人图标）。
 const (
 	attrKeyAvatarText  = "avatar_text"
 	attrKeyAvatarColor = "avatar_color"

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -280,7 +280,7 @@ func (d *DB) queryUserSupers(uid string) ([]*Model, error) {
 func (d *DB) UpdateTx(model *Model, tx *dbr.Tx) error {
 	_, err := tx.Update("group").SetMap(map[string]interface{}{
 		"name":      model.Name,
-		"is_named":  model.IsNamed, // 改名置 1（用户起名）；其它更新原样回写当前值
+		"is_named":  model.IsNamed, // 原样回写当前值（改名不再改动 is_named；仅 #500 迁移回填存量老群为 1）
 		"notice":    model.Notice,
 		"creator":   model.Creator,
 		"status":    model.Status,

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -293,10 +293,9 @@ func (d *DB) UpdateTx(model *Model, tx *dbr.Tx) error {
 
 // UpdateInviteTx 仅更新「进群邀请开关」与群版本（列级写，事务内）。
 // 不能用 UpdateTx 整行回写：groupUpdate 在同一请求里若同时带 name 与 invite，name 分支
-// 已通过 UpdateGroupInfo（独立 fresh load）提交 name/is_named=1，而 invite 分支若再用
-// 建链时载入的旧快照经 UpdateTx 全列回写，会把刚提交的 name/is_named 用旧值覆盖回去
-// （改名 + is_named 被回滚成 0 → 头像静默退回双人图标）。列级写只动 invite/version，
-// 与并发的改名互不踩踏，也消除该读改写竞态。
+// 已通过 UpdateGroupInfo（独立 fresh load）提交了新 name，而 invite 分支若再用建链时载入
+// 的旧快照经 UpdateTx 全列回写，会把刚提交的 name 用旧值覆盖回去（改名被静默回滚）。
+// 列级写只动 invite/version，与并发的改名互不踩踏，也消除该读改写竞态。
 func (d *DB) UpdateInviteTx(groupNo string, invite int, version int64, tx *dbr.Tx) error {
 	_, err := tx.Update("group").SetMap(map[string]interface{}{
 		"invite":  invite,
@@ -336,7 +335,7 @@ func (d *DB) updateAvatar(avatar string, avatarVersion int64, groupNo string) er
 // updateAvatarCustom 更新自定义群头像文字/颜色与群版本（不触碰 is_upload_avatar：
 // 自定义文字/色仍是「默认头像」范畴，渲染时实时出图，不同于上传图片）。color 为
 // *int，nil → NULL（清除自定义色，回退按 group_no 派生）。text 为空串表示清除自定义
-// 文字（回退：命名群取群名前 2 字，自动名群双人图标）。
+// 文字（回退：老群取群名前 2 字，新群双人图标）。
 // updateAvatarCustom 只更新本次实际提供的列：text 非 nil 时写 avatar_text，setColor
 // 为 true 时写 avatar_color（*int，nil → NULL 清除自定义色）；始终 bump version。
 // 列级更新避免「读-改-写」竞态——并发只改文字 / 只改色不会互相覆盖对方的列。
@@ -608,11 +607,11 @@ type Model struct {
 	GroupNo                  string     // 群编号
 	GroupType                int        // 群类型 0.普通群 1.超大群
 	Name                     string     // 群名称
-	IsNamed                  int        // 群名是否用户显式起名(1)/成员拼接自动名(0)；默认头像取字仅对 1 生效
+	IsNamed                  int        // 1=改版前老群/0=新群；由 #500 迁移回填，新群恒为 0。默认头像取群名文字仅对 1 生效（grandfather 老群），新群一律双人图标
 	Avatar                   string     // 群头像
 	AvatarVersion            int64      // 群头像对象版本，0 表示旧版稳定路径
 	IsUploadAvatar           int        // 群头像是否已经被用户上传
-	AvatarText               string     // 自定义群头像文字；空时按 is_named 回退（命名群取群名前2字，自动名群双人图标）
+	AvatarText               string     // 自定义群头像文字；空时按 is_named 回退（老群取群名前2字，新群双人图标）
 	AvatarColor              *int       // 自定义群头像色板下标，nil(NULL) 表示按 group_no 派生
 	Notice                   string     // 群公告
 	Creator                  string     // 创建者uid

--- a/modules/group/event.go
+++ b/modules/group/event.go
@@ -173,7 +173,7 @@ func (g *Group) handleRegisterUserEvent(data []byte, commit config.EventCommit) 
 		err = g.db.InsertTx(&Model{
 			GroupNo:        g.ctx.GetConfig().Account.SystemGroupID,
 			Name:           g.ctx.GetConfig().Account.SystemGroupName,
-			IsNamed:        1, // 系统群有显式配置名 → 命名群（与 CreateGroup 的 is_named 语义一致）
+			IsNamed:        0, // 新群默认 0（与 CreateGroup 口径一致）；系统群本就走静态 PNG，不经 is_named 渲染路径
 			Creator:        g.ctx.GetConfig().Account.SystemUID,
 			Status:         GroupStatusNormal,
 			Version:        version,
@@ -316,7 +316,7 @@ func (g *Group) handleOrgOrDeptCreateEvent(data []byte, commit config.EventCommi
 		err = g.db.InsertTx(&Model{
 			GroupNo:             req.GroupNo,
 			Name:                req.Name,
-			IsNamed:             1, // 组织/部门群有显式名 → 命名群（与 CreateGroup 的 is_named 语义一致）
+			IsNamed:             0, // 新群默认 0（与 CreateGroup 口径一致）；org_/dept_ 群本就走静态 PNG，不经 is_named 渲染路径
 			Creator:             req.Operator,
 			Status:              GroupStatusNormal,
 			Version:             version,

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -1015,7 +1015,7 @@ type UpdateGroupAvatarCustomServiceReq struct {
 	GroupNo      string
 	OperatorUID  string
 	OperatorName string
-	// AvatarText：nil 表示不更新文字；非 nil（含 ""）表示设置，"" 即清除自定义文字（回退群名）。
+	// AvatarText：nil 表示不更新文字；非 nil（含 ""）表示设置，"" 即清除自定义文字（回退 is_named 规则:老群群名/新群双人图标）。
 	AvatarText *string
 	// SetAvatarColor：是否更新颜色。为 true 时按 AvatarColor 设置：nil 清除（NULL，回退派生），
 	// 非 nil 为色板下标。为 false 时不动颜色。

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -198,16 +198,12 @@ func (s *Service) GetCreatedCountWithDate(date string) (int64, error) {
 
 // AddGroup 添加一个群
 func (s *Service) AddGroup(model *AddGroupReq) error {
-	// 显式传名 → 命名群（is_named=1，默认头像取群名前2字）；空名 → 0（回退双人图标）。
-	// 与 CreateGroup 的 is_named 推断口径一致，避免直插路径漏置导致命名群退回图标。
-	isNamed := 0
-	if strings.TrimSpace(model.Name) != "" {
-		isNamed = 1
-	}
+	// 新建群一律 is_named=0 → 默认头像双人图标（产品 2026-06-29 改版，与 CreateGroup 口径
+	// 一致）。is_named=1 仅由 #500 迁移回填给改版前的存量老群，使其保留群名文字头像。
 	err := s.db.Insert(&Model{
 		GroupNo:        model.GroupNo,
 		Name:           model.Name,
-		IsNamed:        isNamed,
+		IsNamed:        0, // 新群默认 0 → 双人图标；is_named=1 仅存量老群（#500 迁移回填）
 		AllowExternal:  1, // 向后兼容：默认允许外部成员
 		AllowNoMention: 1, // 向后兼容：默认允许群级免@
 	})
@@ -803,8 +799,8 @@ type GroupResp struct {
 	GroupType                GroupType `json:"group_type"`                  // 群类型
 	Category                 string    `json:"category"`                    // 群分类
 	Name                     string    `json:"name"`                        // 群名称
-	IsNamed                  int       `json:"is_named"`                    // 群名是否用户显式起名(1)/成员拼接自动名(0)；客户端据此本地预判默认头像取名字/双人图标
-	AvatarText               string    `json:"avatar_text"`                 // 自定义群头像文字（空=按 is_named 回退：命名群群名/自动名群双人图标）
+	IsNamed                  int       `json:"is_named"`                    // 1=改版前老群(默认渲染群名文字)/0=新群(默认双人图标)；由 #500 迁移回填，新群恒为 0；客户端可据此本地预判默认头像取群名文字 vs 双人图标
+	AvatarText               string    `json:"avatar_text"`                 // 自定义群头像文字（空=按 is_named 回退：老群渲染群名/新群双人图标）
 	AvatarColor              *int      `json:"avatar_color"`                // 自定义群头像色板下标（null=按 group_no 派生）
 	Remark                   string    `json:"remark"`                      // 群备注
 	Notice                   string    `json:"notice"`                      // 群公告
@@ -966,7 +962,7 @@ type CreateGroupServiceReq struct {
 	SpaceID     string   // Space ID（可为空）
 	BotUID      string   // Bot UID（可为空；非空时自动加入群并设为 bot_admin）
 	CategoryID  string   // 群聊分组 ID（可为空；非空时自动设置创建者的 group_setting）
-	AvatarText  string   // 自定义群头像文字（可为空；空=按 is_named 回退：命名群群名/自动名群双人图标）
+	AvatarText  string   // 自定义群头像文字（可为空；空=按 is_named 回退：老群渲染群名/新群双人图标）
 	AvatarColor *int     // 自定义群头像色板下标（nil=渲染时按 group_no 派生）
 }
 
@@ -1118,13 +1114,12 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 		return nil, errors.New("no valid member found")
 	}
 
-	// 群名生成。建群传了 name = 用户显式起名(is_named=1，默认头像取群名前2字)；没传 =
-	// 用成员名拼接的自动默认名(is_named=0，默认头像回退双人图标，不把拼接名渲成文字)。
+	// 群名生成。建群传了 name = 用户显式起名；没传 = 用成员名拼接的自动默认名。
+	// 注(产品 2026-06-29 改版)：新建群一律 is_named=0 → 默认头像双人图标，群名不作为头像
+	// 文字；用户在「修改头像」填了 avatar_text 才渲染文字。is_named=1 不再由建群产生——它
+	// 仅由 #500 迁移回填给「改版前的存量老群」，使这些老群保留其原有的群名文字头像
+	// （grandfather，避免存量群一夜全变小人）。
 	groupName := strings.TrimSpace(req.Name)
-	isNamedVal := 0
-	if groupName != "" {
-		isNamedVal = 1
-	}
 	if groupName == "" {
 		names := make([]string, 0, len(memberUsers))
 		for _, u := range memberUsers {
@@ -1173,7 +1168,7 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 	err = s.db.InsertTx(&Model{
 		GroupNo:             groupNo,
 		Name:                groupName,
-		IsNamed:             isNamedVal,
+		IsNamed:             0, // 新群默认 0 → 双人图标；is_named=1 仅存量老群（#500 迁移回填）
 		Creator:             req.Creator,
 		Status:              GroupStatusNormal,
 		Version:             version,
@@ -1182,7 +1177,7 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 		AllowExternal:       1, // 向后兼容：默认允许外部成员
 		AllowNoMention:      1, // 向后兼容：默认允许群级免@
 		IsExternalGroup:     isExternalGroup,
-		AvatarText:          req.AvatarText,  // 空=按 is_named 回退（命名群群名/自动名群双人图标）
+		AvatarText:          req.AvatarText,  // 空=按 is_named 回退（老群渲染群名/新群双人图标）
 		AvatarColor:         req.AvatarColor, // nil=渲染时按 group_no 派生
 	}, tx)
 	if err != nil {
@@ -1887,7 +1882,9 @@ func (s *Service) UpdateGroupInfo(req *UpdateGroupInfoServiceReq) error {
 			*req.Name = string(nameRunes[:MaxGroupNameLen])
 		}
 		groupModel.Name = *req.Name
-		groupModel.IsNamed = 1 // 用户显式改名 → 命名群（默认头像改取新群名前 2 字）
+		// 改名不再改动 is_named（产品 2026-06-29 改版）：is_named 是「改版前老群」标记，
+		// 不随改名翻转。老群(is_named=1)改名后仍渲染新群名文字；新群(is_named=0)改名后仍是
+		// 双人图标（群名不作为头像文字，要文字请设 avatar_text）。保留 groupModel 的既有值回写。
 	}
 	if req.Notice != nil {
 		groupModel.Notice = *req.Notice

--- a/modules/group/service_test.go
+++ b/modules/group/service_test.go
@@ -77,7 +77,7 @@ func TestCreateGroup_Success(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "测试群", model.Name)
 	assert.Equal(t, testutil.UID, model.Creator)
-	assert.Equal(t, 1, model.IsNamed, "建群传了 name → is_named=1（默认头像取群名）")
+	assert.Equal(t, 0, model.IsNamed, "新建群一律 is_named=0（默认双人图标，群名不作为头像文字；is_named=1 仅存量老群）")
 
 	members, err := s.db.QueryMembersFirstNine(resp.GroupNo)
 	assert.NoError(t, err)
@@ -96,55 +96,70 @@ func TestCreateGroup_AutoGenerateName(t *testing.T) {
 	assert.NotEmpty(t, resp.Name)
 	assert.Contains(t, resp.Name, "user_")
 
-	// 没传 name → 成员名拼接的自动默认名 → is_named=0（默认头像回退双人图标）。
+	// 没传 name → 成员名拼接的自动默认名 → is_named=0（新群一律 0，默认双人图标）。
 	s := svc.(*Service)
 	model, err := s.db.QueryWithGroupNo(resp.GroupNo)
 	assert.NoError(t, err)
-	assert.Equal(t, 0, model.IsNamed, "未传 name → is_named=0（默认头像双人图标）")
+	assert.Equal(t, 0, model.IsNamed, "新建群一律 is_named=0（默认双人图标）")
 }
 
-// TestUpdateGroupInfo_RenameMarksIsNamed 验证用户改名后 is_named 置 1：自动名群（图标）
-// 被显式改名后变为命名群，默认头像随即可按新群名取字（改名→新默认头像的前提）。
-func TestUpdateGroupInfo_RenameMarksIsNamed(t *testing.T) {
+// TestUpdateGroupInfo_RenameDoesNotChangeIsNamed 验证产品 2026-06-29 改版后改名**不**翻转
+// is_named：is_named 是「改版前老群」标记（由 #500 迁移回填），不随改名变化。新群(is_named=0)
+// 改名后仍是 0（默认双人图标，要文字请设 avatar_text）；老群(is_named=1)改名后仍是 1，且其
+// 群名文字头像随新名更新。
+func TestUpdateGroupInfo_RenameDoesNotChangeIsNamed(t *testing.T) {
 	svc, userDB := setupServiceTest(t)
 	insertTestUsers(t, userDB, testutil.UID)
 	s := svc.(*Service)
 
-	const groupNo = "grp_rename_isnamed"
+	// 新群（is_named=0）改名 → 仍为 0。
+	const newNo = "grp_rename_new"
 	assert.NoError(t, s.db.Insert(&Model{
-		GroupNo: groupNo, Name: "张三、李四", Creator: testutil.UID, Status: 1, Version: 1, IsNamed: 0,
+		GroupNo: newNo, Name: "张三、李四", Creator: testutil.UID, Status: 1, Version: 1, IsNamed: 0,
 	}))
-
 	newName := "后端架构讨论"
 	assert.NoError(t, svc.UpdateGroupInfo(&UpdateGroupInfoServiceReq{
-		GroupNo: groupNo, OperatorUID: testutil.UID, OperatorName: "op", Name: &newName,
+		GroupNo: newNo, OperatorUID: testutil.UID, OperatorName: "op", Name: &newName,
 	}))
-
-	model, err := s.db.QueryWithGroupNo(groupNo)
+	m, err := s.db.QueryWithGroupNo(newNo)
 	assert.NoError(t, err)
-	assert.Equal(t, newName, model.Name)
-	assert.Equal(t, 1, model.IsNamed, "用户显式改名 → is_named=1（默认头像改取新群名）")
+	assert.Equal(t, newName, m.Name)
+	assert.Equal(t, 0, m.IsNamed, "新群改名后 is_named 仍为 0（不再因改名翻转）")
+
+	// 老群（is_named=1）改名 → 仍为 1（继续渲染新群名文字）。
+	const oldNo = "grp_rename_legacy"
+	assert.NoError(t, s.db.Insert(&Model{
+		GroupNo: oldNo, Name: "旧群名", Creator: testutil.UID, Status: 1, Version: 1, IsNamed: 1,
+	}))
+	legacyNewName := "技术评审"
+	assert.NoError(t, svc.UpdateGroupInfo(&UpdateGroupInfoServiceReq{
+		GroupNo: oldNo, OperatorUID: testutil.UID, OperatorName: "op", Name: &legacyNewName,
+	}))
+	m, err = s.db.QueryWithGroupNo(oldNo)
+	assert.NoError(t, err)
+	assert.Equal(t, legacyNewName, m.Name)
+	assert.Equal(t, 1, m.IsNamed, "老群改名后 is_named 仍为 1（保留群名文字头像）")
 }
 
-// TestRenameThenInviteUpdate_KeepsIsNamed 回归 PR#500 P1（yujiawei / OctoBoooot 复核确认）：
-// groupUpdate 同一请求同时带 name 与 invite 时——name 分支（UpdateGroupInfo，fresh load）
-// 已提交 name/is_named=1，invite 分支若再用建链旧快照经**全列** UpdateTx 回写，会把 name 与
-// is_named 打回旧值（改名 + is_named 被回滚成 0 → 默认头像静默退回双人图标）。改用列级
-// UpdateInviteTx（仅动 invite/version）后，两者必须保留。本测试复刻该两步写序（name 分支
-// → invite 分支），因 invite 分支真身依赖未在 testutil 初始化的 ctx.Event，故在 service/DB
-// 层验证修复的核心性质（列级写不回写 name/is_named）。
-func TestRenameThenInviteUpdate_KeepsIsNamed(t *testing.T) {
+// TestRenameThenInviteUpdate_KeepsNameAndIsNamed 回归 PR#500 P1（yujiawei / OctoBoooot 复核
+// 确认）：groupUpdate 同一请求同时带 name 与 invite 时——name 分支（UpdateGroupInfo，fresh
+// load）已提交新 name，invite 分支若再用建链旧快照经**全列** UpdateTx 回写，会把刚提交的 name
+// 用旧值覆盖回去（改名被静默回滚），并连带把 is_named 等列也按旧快照重写。改用列级
+// UpdateInviteTx（仅动 invite/version）后，name 与 is_named 都不被触碰。本测试用一个老群
+// (is_named=1)复刻该两步写序（name 分支 → invite 分支），因 invite 分支真身依赖未在 testutil
+// 初始化的 ctx.Event，故在 service/DB 层验证修复的核心性质（列级写不回写 name/is_named）。
+func TestRenameThenInviteUpdate_KeepsNameAndIsNamed(t *testing.T) {
 	svc, userDB, ctx := setupServiceTestWithCtx(t)
 	insertTestUsers(t, userDB, testutil.UID)
 	s := svc.(*Service)
 
 	const groupNo = "rename_then_invite_1"
-	// 自动名群（is_named=0），invite=0。
+	// 老群（is_named=1，改版前存量群，渲染群名文字），invite=0。
 	assert.NoError(t, s.db.Insert(&Model{
-		GroupNo: groupNo, Name: "张三、李四", Creator: testutil.UID, Status: 1, Version: 1, IsNamed: 0, Invite: 0,
+		GroupNo: groupNo, Name: "旧群名", Creator: testutil.UID, Status: 1, Version: 1, IsNamed: 1, Invite: 0,
 	}))
 
-	// name 分支：改名 → is_named=1 落库。
+	// name 分支：改名落库（is_named 保持 1，改版后改名不再翻转它）。
 	newName := "后端架构讨论"
 	assert.NoError(t, svc.UpdateGroupInfo(&UpdateGroupInfoServiceReq{
 		GroupNo: groupNo, OperatorUID: testutil.UID, OperatorName: "op", Name: &newName,
@@ -158,17 +173,16 @@ func TestRenameThenInviteUpdate_KeepsIsNamed(t *testing.T) {
 
 	model, err := s.db.QueryWithGroupNo(groupNo)
 	assert.NoError(t, err)
-	assert.Equal(t, newName, model.Name, "invite 更新不得回写旧 name")
-	assert.Equal(t, 1, model.IsNamed, "invite 更新不得把 is_named 打回 0（P1 回归）")
+	assert.Equal(t, newName, model.Name, "invite 更新不得回写旧 name（P1 回归）")
+	assert.Equal(t, 1, model.IsNamed, "invite 更新不得触碰 is_named（列级写只动 invite/version）")
 	assert.Equal(t, 1, model.Invite, "invite 必须落库为 1")
 	assert.Equal(t, int64(999), model.Version)
 }
 
-// TestAddGroup_SetsIsNamed 回归 PR#500（Jerry-Xin / OctoBoooot）：非 CreateGroup 的直插建群
-// 路径（Service.AddGroup）也须按是否有显式名设置 is_named，否则命名群漏置 0 → 默认头像退回
-// 双人图标。系统群 / org_ / dept_ 直插路径（event.go）同此修复，但它们在 avatarGet 被前缀
-// 静态 PNG 分支拦截、不进 is_named 渲染路径，故此处以可独立验证的 AddGroup 锁定该不变式。
-func TestAddGroup_SetsIsNamed(t *testing.T) {
+// TestAddGroup_DefaultsIsNamedZero 验证产品 2026-06-29 改版后非 CreateGroup 的直插建群路径
+// （Service.AddGroup）同样**一律 is_named=0**（与 CreateGroup 口径一致）——新群默认双人图标，
+// 群名不作为头像文字，无论是否传入显式名。is_named=1 仅由 #500 迁移回填给改版前的存量老群。
+func TestAddGroup_DefaultsIsNamedZero(t *testing.T) {
 	svc, _ := setupServiceTest(t)
 	s := svc.(*Service)
 
@@ -176,13 +190,13 @@ func TestAddGroup_SetsIsNamed(t *testing.T) {
 	assert.NoError(t, s.AddGroup(&AddGroupReq{GroupNo: namedNo, Name: "产品评审群"}))
 	m, err := s.db.QueryWithGroupNo(namedNo)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, m.IsNamed, "显式名 → is_named=1（命名群默认头像取群名）")
+	assert.Equal(t, 0, m.IsNamed, "新建群（含显式名）一律 is_named=0（默认双人图标）")
 
 	const autoNo = "addgroup_auto_1"
 	assert.NoError(t, s.AddGroup(&AddGroupReq{GroupNo: autoNo, Name: ""}))
 	m, err = s.db.QueryWithGroupNo(autoNo)
 	assert.NoError(t, err)
-	assert.Equal(t, 0, m.IsNamed, "空名 → is_named=0（回退双人图标）")
+	assert.Equal(t, 0, m.IsNamed, "新建群（空名）一律 is_named=0（默认双人图标）")
 }
 
 func TestCreateGroup_DeduplicateMembers(t *testing.T) {

--- a/modules/group/sql/20260629000002_refresh_avatar_comments.sql
+++ b/modules/group/sql/20260629000002_refresh_avatar_comments.sql
@@ -1,0 +1,68 @@
+-- +migrate Up
+-- 仅刷新列 COMMENT，使其与 2026-06-29 改版后的语义一致（comment-only，不改类型/约束/默认值，
+-- 不改任何行数据）。背景：改版后群名不再作为新群头像文字，is_named 含义从「用户显式起名」
+-- 重定义为「改版前的存量老群」标记（新群恒为 0、仅迁移回填老群为 1；渲染:老群群名文字、新群
+-- 双人图标）。原迁移 20260629000001 / 20260625000001 的列 COMMENT 仍是旧措辞，schema 自省会
+-- 携带过期运营说明（评审 Octo-Q / yujiawei / OctoBoooot / Jerry-Xin 一致指出）。已应用的历史
+-- 迁移不可改，故用本 no-op COMMENT 迁移刷新。INFORMATION_SCHEMA 守卫 + MODIFY 本身幂等，可重入。
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_refresh_avatar_comments;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __group_refresh_avatar_comments()
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND COLUMN_NAME = 'is_named') THEN
+    ALTER TABLE `group`
+      MODIFY COLUMN `is_named` TINYINT NOT NULL DEFAULT 0
+        COMMENT '1=改版前老群/0=新群(2026-06-29改版);老群渲染群名前2字、新群双人图标;新建群恒为0,is_named=1仅由迁移回填存量老群';
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND COLUMN_NAME = 'avatar_text') THEN
+    ALTER TABLE `group`
+      MODIFY COLUMN `avatar_text` VARCHAR(16) NOT NULL DEFAULT ''
+        COMMENT '自定义群头像文字;空=按 is_named 回退(老群群名前2字/新群双人图标)';
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __group_refresh_avatar_comments();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_refresh_avatar_comments;
+-- +migrate StatementEnd
+
+-- +migrate Down
+-- 还原为改版前的列 COMMENT（comment-only 逆操作；类型/约束不变）。
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_refresh_avatar_comments_down;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __group_refresh_avatar_comments_down()
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND COLUMN_NAME = 'is_named') THEN
+    ALTER TABLE `group`
+      MODIFY COLUMN `is_named` TINYINT NOT NULL DEFAULT 0
+        COMMENT '群名是否用户显式起名(1)/成员拼接自动名(0);默认头像取字仅对1生效';
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND COLUMN_NAME = 'avatar_text') THEN
+    ALTER TABLE `group`
+      MODIFY COLUMN `avatar_text` VARCHAR(16) NOT NULL DEFAULT ''
+        COMMENT '自定义群头像文字，空表示用群名派生';
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __group_refresh_avatar_comments_down();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_refresh_avatar_comments_down;
+-- +migrate StatementEnd

--- a/modules/group/swagger/api.yaml
+++ b/modules/group/swagger/api.yaml
@@ -320,7 +320,7 @@ paths:
                   description: "成员名称"
               avatar_text:
                 type: string
-                description: "自定义群头像文字（≤4 可见字符；空/缺省时按 is_named 回退：传入 name(命名群)取群名前 2 字（script 感知取字），未传 name(成员拼接自动名)回退双人图标）"
+                description: "自定义群头像文字（≤4 可见字符；空/缺省时按 is_named 回退：老群(is_named=1，改版前存量群)取群名前 2 字，新群(is_named=0)回退双人图标。新建群恒为新群→双人图标，群名不作为头像文字）"
               avatar_color:
                 type: integer
                 description: "自定义群头像色板下标 [0, 调色板大小)；缺省时按 group_no 派生颜色"
@@ -528,7 +528,7 @@ paths:
                 description: "修改群名称 notice(修改群备注) invite(是否开启进群邀请) 等"
               avatar_text:
                 type: string
-                description: "自定义群头像文字（≤4 可见字符；空串清除→按 is_named 回退：命名群取群名前2字、自动名群双人图标）"
+                description: "自定义群头像文字（≤4 可见字符；空串清除→按 is_named 回退：老群取群名前2字、新群双人图标）"
               avatar_color:
                 type: integer
                 description: "自定义群头像色板下标 [0, 调色板大小)；空串或 -1 清除→回退按 group_no 派生"
@@ -1216,8 +1216,9 @@ paths:
       summary: "获取群头像"
       description: >-
         公开（不鉴权）端点。未上传自定义头像的群在服务端实时渲染默认头像（彩色描边圆）：
-        优先自定义 avatar_text；否则按 is_named 回退——命名群(is_named=1)取群名前 2 字
-        （script 感知取字），自动名群(is_named=0)或空名回退双人图标；avatar_color 控制配色。返回 image/png。
+        优先自定义 avatar_text；否则按 is_named 回退——老群(is_named=1，改版前存量群)取群名前 2 字
+        （script 感知取字，grandfather 保留其原头像），新群(is_named=0)或空名回退双人图标；avatar_color
+        控制配色。返回 image/png。注：新建群恒为新群→双人图标，群名不作为头像文字（产品 2026-06-29 改版）。
         已上传头像（is_upload_avatar=1）的群 302 重定向到对象存储。群不存在或已解散返回
         404。响应带内容相关弱 ETag，命中 If-None-Match 时返回 304。
       operationId: "get avatar"
@@ -1397,7 +1398,7 @@ definitions:
         description: "群名称"
       is_named:
         type: integer
-        description: "群名是否用户显式起名(1)/成员拼接自动名(0)；客户端据此本地预判默认头像取群名前2字 vs 双人图标"
+        description: "1=改版前老群(默认渲染群名文字)/0=新群(默认双人图标)；由 #500 迁移回填，新建群恒为 0；客户端可据此本地预判默认头像取群名文字 vs 双人图标"
       remark:
         type: string
         description: "群备注"
@@ -1472,7 +1473,7 @@ definitions:
         description: "群数据版本"
       avatar_text:
         type: string
-        description: "自定义群头像文字（空=未自定义，按 is_named 回退：命名群(is_named=1)取群名前 2 字（script 感知取字），自动名群(is_named=0)回退双人图标）"
+        description: "自定义群头像文字（空=未自定义，按 is_named 回退：老群(is_named=1)取群名前 2 字，新群(is_named=0)回退双人图标）"
       avatar_color:
         type: integer
         description: "自定义群头像色板下标（null 表示未自定义，按 group_no 派生）"

--- a/pkg/avatarrender/text.go
+++ b/pkg/avatarrender/text.go
@@ -137,8 +137,8 @@ func initials(name string, limit int) string {
 // 不经过本规则。返回结果可能仍含本字体无字形的字符(罕见生僻字),调用方应配合
 // Renderable 判断,对不可渲染的结果回退到群组图标。
 //
-// 仅用于「命名群(is_named=1)」的群名自动取字;成员拼接的自动名(is_named=0)不调用本函数、
-// 直接回退双人图标(见 modules/group writeGroupDefaultAvatar)。
+// 仅用于「改版前的存量老群(is_named=1)」的群名自动取字;新群(is_named=0)不调用本函数、
+// 直接回退双人图标(见 modules/group writeGroupDefaultAvatar，2026-06-29 改版)。
 func GroupNameText(name string) string {
 	return extractAvatarText(name, false, 2)
 }


### PR DESCRIPTION
## Summary

Match the client: a **newly created** group defaults to the two-person icon — the group **name is never rendered as avatar text**; text appears only when the user sets a custom `avatar_text`. **Existing groups are grandfathered** so the change does not flip every historical group to an icon at once.

Implemented by changing **who gets `is_named=1`**, *not* the render rule. The render priority is unchanged from #500: `avatar_text` (custom) > `is_named==1` → name first-2 glyphs > two-person icon. `is_named` is **repurposed** from "user named it" to "**pre-cutover legacy group**" (it stays load-bearing — not deprecated).

## Related Issue

N/A — client-coordination change relayed by the frontend (2026-06-29). Repurposes the S2 behavior from #500.

## Linked Spec

`.octospec/tasks/group-avatar-name-no-text/brief.md` (supersedes `group-avatar-icon-default` S2). Load-bearing render-path/data change → COMPREHENSION filled below.

## Changes

- **`is_named` write-policy (the whole change):**
  - `CreateGroup` (`service.go`): new groups persist `IsNamed: 0` (removed the name-based computation) → default to the icon regardless of name.
  - `AddGroup` (`service.go`): `IsNamed: 0`.
  - `event.go` system-group + org/dept inserts: `IsNamed: 0` (served static PNGs; set to 0 to keep "`is_named=1` ⟺ legacy" clean).
  - `UpdateGroupInfo` rename (`service.go`): removed `groupModel.IsNamed = 1` → rename no longer flips the flag; it preserves the loaded value (legacy stays 1 and its name-text follows the new name; new stays 0).
- **Render rule unchanged** (`writeGroupDefaultAvatar`, `api.go`): still `avatar_text > is_named==1 name-text > icon`; only comments reworded to the legacy/new semantic. ETag factors unchanged.
- **Existing groups** keep `is_named=1` (already backfilled by migration `20260629000001`) → keep their current name-text avatar (grandfather). The grandfather behavior itself needs **no schema/data migration** — it reuses #500's existing backfill as the legacy marker.
- **One comment-only migration** `20260629000002_refresh_avatar_comments.sql` (added in a review-nit follow-up): `MODIFY COLUMN` refreshes the live `is_named` + `avatar_text` column COMMENTs to the post-pivot semantics. **No type/constraint/default/data change** (`TINYINT NOT NULL DEFAULT 0`, `VARCHAR(16) NOT NULL DEFAULT ''` preserved), reentrant via INFORMATION_SCHEMA guard, with a Down that restores the prior comments. The already-applied `20260629000001` / `20260625000001` files are left immutable; this only refreshes what schema introspection shows.
- **Docs:** comments in `modules/group/{api.go,db.go,service.go,const.go,event.go}` + `pkg/avatarrender/text.go` + `swagger/api.yaml` reworded to the legacy/new semantic; `GroupResp.is_named` re-documented (1=legacy/0=new). New octospec brief + changelog entry. (Follow-up commits also cleaned up the stale comments reviewers flagged.)
- **Tests** updated for the new write-policy (see below).

## Testing

- `go build ./...`, `go vet ./modules/group/` — clean.
- `golangci-lint run ./modules/group/...` — 0 issues.
- `make i18n-lint` — OK (no error-code/response changes).
- `go test ./pkg/avatarrender/...` — pass.
- Group endpoint tests (which also apply the new migration) require MySQL/Redis/WuKongIM — run in CI (no local infra).

- [x] Unit tests added/updated
- [ ] Manually verified (endpoint tests via CI; locally limited to build/lint/avatarrender unit tests — no MySQL/Redis in dev env)

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   It changes only the persisted value of `is_named` for newly created groups (and stops rename from flipping it). New groups now store `is_named=0`, so the unchanged render rule (`avatar_text > is_named==1 name-text > icon`) takes them down the icon branch by default — the group name is no longer rendered as avatar text. Existing rows remain `is_named=1` (from #500's backfill) and continue to render their name-text. `is_named` becomes read-only after creation, meaning strictly "this group existed before the cutover."

2. **What could break because of it (dependents + failure mode)?**
   Behavior changes only for *new* groups (icon instead of name-text); existing groups are untouched, so there is no mass historical flip. No API/contract break: `is_named` is still persisted and exposed (`GroupResp.is_named`, now meaning legacy=1/new=0); create/update/palette endpoints and error codes are unchanged. The only migration is the **comment-only** COMMENT refresh (`20260629000002`) — no schema/data change. The P1 combined `{name, invite}` clobber fix from #500 (`UpdateInviteTx` column-scoped write) is retained — failure mode would be an invite update reverting a concurrent rename, which the column-scoped write prevents. Static-PNG groups (system/`org_`/`dept_`) and uploaded-image groups never reach the render path and are unaffected.

3. **How do you know it works (specific test/repro/trace)?**
   `TestCreateGroup_Success` / `_AutoGenerateName` assert `is_named=0` for new groups (named and auto). `TestUpdateGroupInfo_RenameDoesNotChangeIsNamed` asserts rename preserves the flag for both new (0→0) and legacy (1→1) groups. `TestAddGroup_DefaultsIsNamedZero` covers the direct-insert path. `TestRenameThenInviteUpdate_KeepsNameAndIsNamed` is the P1 clobber regression on a legacy group. Render: `TestGroupAvatarGetNamedRendersNameText` / `...NamedCustomColorRendersNameText` assert `is_named=1` (legacy) → name-text; `TestGroupAvatarGetAutoNamedRendersIcon` / `...CustomColorIconNoText` assert `is_named=0` (new) → icon; `...CustomOverrides` / `...CustomTextNotTruncated` assert `avatar_text` always wins. Build/vet/golangci-lint/i18n-lint green locally; endpoint tests run in CI.

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)