### PR TITLE
feat(bot_api): bot message reaction endpoints (#111)

### DIFF
--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -29,13 +29,13 @@ const (
 // BotAPI is the public Bot API gateway module.
 // It handles all bot-facing endpoints (/v1/bot/*) with unified auth.
 type BotAPI struct {
-	ctx                   *config.Context
-	db                    *botAPIDB
-	userService           user.IService
-	fileService           file.IService
-	groupService          group.IService
-	userDB                *user.DB
-	threadService         thread.IService
+	ctx           *config.Context
+	db            *botAPIDB
+	userService   user.IService
+	fileService   file.IService
+	groupService  group.IService
+	userDB        *user.DB
+	threadService thread.IService
 	// robotService gives the OBO fan-out path a way to enqueue synthetic
 	// events directly into a grantee bot's /v1/bot/events queue. The
 	// webhook layer drops NoPersist=1 messages before NotifyMessagesListeners
@@ -118,6 +118,13 @@ type BotAPI struct {
 	// path (nil override) goes through ba.ctx.SendCMD verbatim, so
 	// behaviour outside of tests is unchanged.
 	typingCMDDispatch func(req config.MsgCMDReq) error
+	// reactionCMDDispatch — #111 Sprint B. Test seam for the reaction
+	// handler's ctx.SendCMD call, mirroring typingCMDDispatch. Production
+	// path (nil) goes through ba.ctx.SendCMD verbatim.
+	reactionCMDDispatch func(req config.MsgCMDReq) error
+	// reactionStoreOverride — #111 Sprint B. Test seam letting handler-level
+	// tests drive applyReaction with a fake store (no live DB). Nil in prod.
+	reactionStoreOverride reactionStorer
 	// friendCheckOverride lets unit tests stub userService.IsFriend for the
 	// friend-gate decision in checkSendPermission / syncMessages, and for
 	// the OBO friend-gate bypass (see obo_friend_gate.go). Production path
@@ -213,6 +220,9 @@ func (ba *BotAPI) Route(r *wkhttp.WKHttp) {
 		botAPI.POST("/events/:event_id/ack", ba.eventAck)
 		botAPI.POST("/heartbeat", ba.heartbeat)
 		botAPI.POST("/messages/sync", ba.syncMessages)
+		// #111 Sprint B — bot message reactions
+		botAPI.POST("/messages/:message_id/reactions", ba.addReaction)
+		botAPI.DELETE("/messages/:message_id/reactions/:emoji", ba.removeReaction)
 		botAPI.GET("/groups", ba.getGroups)
 		botAPI.GET("/resolve/targets", ba.botResolveTargets)
 		botAPI.GET("/groups/:group_no", ba.getGroupInfo)
@@ -291,6 +301,9 @@ func (ba *BotAPI) resolveSpaceChannelID(robotID, channelID string, channelType u
 
 // resolveBotDisplayName queries the bot's display name, falls back to robotID.
 func (ba *BotAPI) resolveBotDisplayName(robotID string) string {
+	if ba.userDB == nil {
+		return robotID
+	}
 	botUser, err := ba.userDB.QueryByUID(robotID)
 	if err == nil && botUser != nil && botUser.Name != "" {
 		return botUser.Name

--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/file"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/message"
 	"github.com/Mininglamp-OSS/octo-server/modules/robot"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
@@ -36,6 +37,11 @@ type BotAPI struct {
 	groupService  group.IService
 	userDB        *user.DB
 	threadService thread.IService
+	// messageService resolves whether a message_id actually belongs to a
+	// channel, so the reaction handler can reject cross-channel message ids
+	// (see messageChannelChecker / applyReaction). Narrow interface, satisfied
+	// by *message.Service, to avoid widening message.IService for external fakes.
+	messageService messageChannelChecker
 	// robotService gives the OBO fan-out path a way to enqueue synthetic
 	// events directly into a grantee bot's /v1/bot/events queue. The
 	// webhook layer drops NoPersist=1 messages before NotifyMessagesListeners
@@ -125,6 +131,10 @@ type BotAPI struct {
 	// reactionStoreOverride — #111 Sprint B. Test seam letting handler-level
 	// tests drive applyReaction with a fake store (no live DB). Nil in prod.
 	reactionStoreOverride reactionStorer
+	// messageExistsOverride — #111 Sprint B. Test seam for the cross-channel
+	// reaction guard: handler-level tests inject message existence without a
+	// live message store. Nil in prod (goes through ba.messageService).
+	messageExistsOverride func(channelID string, channelType uint8, messageID string) (bool, error)
 	// friendCheckOverride lets unit tests stub userService.IsFriend for the
 	// friend-gate decision in checkSendPermission / syncMessages, and for
 	// the OBO friend-gate bypass (see obo_friend_gate.go). Production path
@@ -188,6 +198,7 @@ func NewBotAPI(ctx *config.Context) *BotAPI {
 		groupService:          group.NewService(ctx),
 		userDB:                user.NewDB(ctx),
 		threadService:         thread.NewService(ctx),
+		messageService:        message.NewService(ctx),
 		robotService:          robot.NewService(ctx),
 		speechClient:          voice_adapter.NewSpeechClient(speechURL, speechKey, time.Duration(timeoutSec)*time.Second),
 		maxVoiceContextLength: maxCtxLen,

--- a/modules/bot_api/reaction_store.go
+++ b/modules/bot_api/reaction_store.go
@@ -1,0 +1,93 @@
+package bot_api
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/db"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/gocraft/dbr/v2"
+)
+
+// reactionStore is the bot_api-local data access for message reactions.
+//
+// #111: reactions for bot actors reuse the SAME `reaction_users` table the
+// user-facing reaction API writes to (modules/message). We deliberately do NOT
+// import message's private messageReactionDB (keeping module DB access private
+// is the octo-server convention); instead we own a small, single-file SQL
+// surface here. The bot is recorded as the reaction actor via uid=robotID, with
+// the bot's display name in the name column so user clients render it normally.
+type reactionStore struct {
+	session *dbr.Session
+	ctx     *config.Context
+}
+
+func newReactionStore(ctx *config.Context) *reactionStore {
+	return &reactionStore{ctx: ctx, session: ctx.DB()}
+}
+
+// reactionRow mirrors the columns of reaction_users that the bot path touches.
+// (Same physical table as message.reactionModel; redeclared locally so we don't
+// reach into another module's private type.)
+type reactionRow struct {
+	MessageID   string
+	Seq         int64
+	ChannelID   string
+	ChannelType uint8
+	UID         string
+	Name        string
+	Emoji       string
+	IsDeleted   int
+	db.BaseModel
+}
+
+// queryByActorAndMessage returns the bot's existing reaction row for a message,
+// or nil when none exists. (uid, message_id) is effectively unique — the user
+// path enforces "one reaction row per actor per message", which we preserve.
+//
+// Concurrency: this is query-then-write with no row lock and no DB unique
+// constraint on (uid, message_id) — the same pattern the user-facing path
+// (modules/message addOrCancelReaction) has always used. Two concurrent adds
+// for the same (bot, message) could in principle insert two rows. For a
+// normally-serial bot actor this is low-probability and no worse than the
+// existing user-device race; hardening both paths would mean adding a
+// UNIQUE(uid, message_id) index in a later migration (it must also dedupe any
+// pre-existing duplicate rows), which is out of scope for this change.
+func (s *reactionStore) queryByActorAndMessage(uid, messageID string) (*reactionRow, error) {
+	var m *reactionRow
+	_, err := s.session.Select("*").
+		From("reaction_users").
+		Where("uid=? and message_id=?", uid, messageID).
+		Load(&m)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (s *reactionStore) insert(m *reactionRow) error {
+	_, err := s.session.InsertInto("reaction_users").
+		Columns(util.AttrToUnderscore(m)...).
+		Record(m).
+		Exec()
+	return err
+}
+
+func (s *reactionStore) update(m *reactionRow) error {
+	_, err := s.session.Update("reaction_users").
+		SetMap(map[string]interface{}{
+			"seq":        m.Seq,
+			"emoji":      m.Emoji,
+			"is_deleted": m.IsDeleted,
+			"name":       m.Name,
+		}).
+		Where("id=?", m.Id).
+		Exec()
+	return err
+}
+
+// genSeq mints the next reaction seq for a stored channel id, matching the
+// user-facing path (modules/message genMessageReactionSeq) so bot and user
+// reactions share one monotonic stream per channel.
+func (s *reactionStore) genSeq(storeChannelID string) (int64, error) {
+	return s.ctx.GenSeq(common.MessageReactionSeqKey + ":" + storeChannelID)
+}

--- a/modules/bot_api/reactions.go
+++ b/modules/bot_api/reactions.go
@@ -82,6 +82,23 @@ func (ba *BotAPI) removeReaction(c *wkhttp.Context) {
 	ba.applyReaction(c, messageID, channelID, channelType, emoji, true)
 }
 
+// messageChannelChecker is the narrow slice of message.Service the reaction
+// handler depends on: confirm a message_id belongs to a (channel_id, type).
+// Kept local (not message.IService) so adding it never forces external
+// IService fakes to grow a method.
+type messageChannelChecker interface {
+	MessageExistsInChannel(channelID string, channelType uint8, messageID string) (bool, error)
+}
+
+// messageExistsInChannel routes the cross-channel guard through the test seam
+// when set, else the live message service. Mirrors the other reaction seams.
+func (ba *BotAPI) messageExistsInChannel(channelID string, channelType uint8, messageID string) (bool, error) {
+	if ba.messageExistsOverride != nil {
+		return ba.messageExistsOverride(channelID, channelType, messageID)
+	}
+	return ba.messageService.MessageExistsInChannel(channelID, channelType, messageID)
+}
+
 // applyReaction is the shared add/remove state machine. Permission and the
 // channel-id store mapping mirror the user-facing reaction path so bot and
 // user reactions are indistinguishable to clients.
@@ -102,6 +119,28 @@ func (ba *BotAPI) applyReaction(c *wkhttp.Context, messageID, channelID string, 
 	// so reaction_users rows land in the same per-conversation bucket and the
 	// reaction seq stream is shared with the user path.
 	storeChannelID := resolveReactionStoreChannelID(channelID, channelType, robotID)
+
+	// Cross-channel guard: checkSendPermission only proved the bot may post to
+	// the REQUEST channel, but reaction_users rows are keyed by message_id and
+	// the message-load path joins reactions by message_id alone (no channel
+	// filter — see modules/message db_message_reaction.queryWithMessageIDs). So
+	// a bot could otherwise attach a reaction to a message in a channel it has
+	// no access to, just by knowing that message's id. Require the message to
+	// actually live in this conversation (storeChannelID matches the message
+	// table's per-conversation key, incl. the DM fake channel id) before any
+	// write or broadcast.
+	exists, err := ba.messageExistsInChannel(storeChannelID, channelType, messageID)
+	if err != nil {
+		ba.Error("校验消息归属失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		return
+	}
+	if !exists {
+		// Not a message of this conversation — reject as invalid input without
+		// revealing whether it exists elsewhere.
+		respondBotAPIRequestInvalid(c, "message_id")
+		return
+	}
 
 	store := ba.newReactionStorer()
 	existing, err := store.queryByActorAndMessage(robotID, messageID)

--- a/modules/bot_api/reactions.go
+++ b/modules/bot_api/reactions.go
@@ -1,0 +1,276 @@
+package bot_api
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"go.uber.org/zap"
+)
+
+// #111 Sprint B — bot reactions.
+//
+// POST   /v1/bot/messages/:message_id/reactions          body {channel_id, channel_type, emoji}
+// DELETE /v1/bot/messages/:message_id/reactions/:emoji    ?channel_id&channel_type
+//
+// Semantics: a bot is a single-reaction actor per message (the reaction_users
+// table is keyed (uid, message_id)). add(emoji) sets/replaces the bot's
+// reaction; remove(emoji) clears it only when the current emoji matches. Both
+// are idempotent — repeat/no-op cases return 200 without an extra broadcast.
+
+type botReactionReq struct {
+	ChannelID   string `json:"channel_id"`
+	ChannelType uint8  `json:"channel_type"`
+	Emoji       string `json:"emoji"`
+}
+
+// addReaction handles POST /v1/bot/messages/:message_id/reactions
+func (ba *BotAPI) addReaction(c *wkhttp.Context) {
+	messageID := strings.TrimSpace(c.Param("message_id"))
+	if messageID == "" {
+		respondBotAPIRequestInvalid(c, "message_id")
+		return
+	}
+	var req botReactionReq
+	if err := c.BindJSON(&req); err != nil {
+		respondBotAPIRequestInvalid(c, "")
+		return
+	}
+	emoji := strings.TrimSpace(req.Emoji)
+	if strings.TrimSpace(req.ChannelID) == "" {
+		respondBotAPIRequestInvalid(c, "channel_id")
+		return
+	}
+	if req.ChannelType == 0 {
+		respondBotAPIRequestInvalid(c, "channel_type")
+		return
+	}
+	if emoji == "" {
+		respondBotAPIRequestInvalid(c, "emoji")
+		return
+	}
+	ba.applyReaction(c, messageID, req.ChannelID, req.ChannelType, emoji, false)
+}
+
+// removeReaction handles DELETE /v1/bot/messages/:message_id/reactions/:emoji
+func (ba *BotAPI) removeReaction(c *wkhttp.Context) {
+	messageID := strings.TrimSpace(c.Param("message_id"))
+	if messageID == "" {
+		respondBotAPIRequestInvalid(c, "message_id")
+		return
+	}
+	emoji := strings.TrimSpace(c.Param("emoji"))
+	if emoji == "" {
+		respondBotAPIRequestInvalid(c, "emoji")
+		return
+	}
+	channelID := strings.TrimSpace(c.Query("channel_id"))
+	channelTypeRaw, _ := strconv.Atoi(strings.TrimSpace(c.Query("channel_type")))
+	channelType := uint8(channelTypeRaw)
+	if channelID == "" {
+		respondBotAPIRequestInvalid(c, "channel_id")
+		return
+	}
+	if channelType == 0 {
+		respondBotAPIRequestInvalid(c, "channel_type")
+		return
+	}
+	ba.applyReaction(c, messageID, channelID, channelType, emoji, true)
+}
+
+// applyReaction is the shared add/remove state machine. Permission and the
+// channel-id store mapping mirror the user-facing reaction path so bot and
+// user reactions are indistinguishable to clients.
+func (ba *BotAPI) applyReaction(c *wkhttp.Context, messageID, channelID string, channelType uint8, emoji string, remove bool) {
+	robotID := getRobotIDFromContext(c)
+	botKind := getBotKindFromContext(c)
+
+	// Permission: reuse the exact send-permission contract (handles group,
+	// CommunityTopic/thread parent-membership, App Bot DM-only, DM friend).
+	// Reactions carry no OBO semantics, so hasOBOContext is always false.
+	if err := ba.checkSendPermission(c, botKind, robotID, channelID, channelType, false); err != nil {
+		respondSendPermissionError(c, err)
+		return
+	}
+
+	// Store channel id: groups use the raw channel id; DMs use the fake
+	// channel id (peer, bot) — identical to modules/message addOrCancelReaction
+	// so reaction_users rows land in the same per-conversation bucket and the
+	// reaction seq stream is shared with the user path.
+	storeChannelID := resolveReactionStoreChannelID(channelID, channelType, robotID)
+
+	store := ba.newReactionStorer()
+	existing, err := store.queryByActorAndMessage(robotID, messageID)
+	if err != nil {
+		ba.Error("查询bot消息回应失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		return
+	}
+
+	changed, err := reactionStateTransitionImpl(store, ba.resolveBotDisplayName, existing, reactionInput{
+		messageID:      messageID,
+		storeChannelID: storeChannelID,
+		channelType:    channelType,
+		robotID:        robotID,
+		emoji:          emoji,
+		remove:         remove,
+	})
+	if err != nil {
+		ba.Error("写入bot消息回应失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
+		return
+	}
+
+	// Only broadcast a sync CMD when state actually changed. The CMD uses the
+	// ORIGINAL channel id (not the fake store id) so it routes to the real
+	// conversation, matching the user path.
+	if changed {
+		if err := ba.dispatchReactionCMD(config.MsgCMDReq{
+			NoPersist:   true,
+			ChannelID:   channelID,
+			ChannelType: channelType,
+			CMD:         common.CMDSyncMessageReaction,
+			FromUID:     robotID,
+		}); err != nil {
+			ba.Error("发送回应同步命令失败", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
+			return
+		}
+	}
+	c.ResponseOK()
+}
+
+// resolveReactionStoreChannelID maps a request channel id to the channel id
+// used for reaction_users storage + seq generation. Groups/threads store under
+// the raw channel id; DMs store under the fake channel id (peer, bot), matching
+// the user-facing reaction path so bot and user reactions share one bucket.
+func resolveReactionStoreChannelID(channelID string, channelType uint8, robotID string) string {
+	if channelType == common.ChannelTypePerson.Uint8() {
+		return common.GetFakeChannelIDWith(channelID, robotID)
+	}
+	return channelID
+}
+
+type reactionInput struct {
+	messageID      string
+	storeChannelID string
+	channelType    uint8
+	robotID        string
+	emoji          string
+	remove         bool
+}
+
+// newReactionStorer returns the reaction persistence surface. Overridable in
+// tests (reactionStoreOverride) so handler-level tests can drive applyReaction
+// without a live DB.
+func (ba *BotAPI) newReactionStorer() reactionStorer {
+	if ba.reactionStoreOverride != nil {
+		return ba.reactionStoreOverride
+	}
+	return newReactionStore(ba.ctx)
+}
+
+// reactionStorer is the full persistence surface applyReaction needs.
+type reactionStorer interface {
+	reactionStateStore
+	queryByActorAndMessage(uid, messageID string) (*reactionRow, error)
+}
+
+// reactionStateStore is the minimal persistence surface the state machine
+// needs; factored out so unit tests can drive every branch with a fake.
+type reactionStateStore interface {
+	genSeq(storeChannelID string) (int64, error)
+	insert(m *reactionRow) error
+	update(m *reactionRow) error
+}
+
+// reactionStateTransitionImpl is the pure add/remove state machine over the
+// single (uid, message_id) row. Returns whether a persisted change occurred
+// (and thus whether a sync CMD should be broadcast). nameResolver supplies the
+// bot display name lazily so the lookup only happens on an actual add.
+//
+// NOTE: bot reactions use SET semantics, deliberately different from the
+// user-facing path (modules/message addOrCancelReaction), which TOGGLES
+// (re-posting the same live emoji removes it). The bot has an explicit remove
+// (DELETE), so re-adding the same emoji is a safe no-op rather than a surprise
+// removal — important for agents that retry idempotently. Both write to the
+// same reaction_users rows, so consumers must not assume toggle-for-all.
+//
+// add(emoji):
+//   - no row            -> insert (emoji, is_deleted=0)            [changed]
+//   - row deleted       -> revive (emoji, is_deleted=0)           [changed]
+//   - row live, same    -> no-op                                   [unchanged]
+//   - row live, diff    -> overwrite emoji (bot holds one)        [changed]
+//
+// remove(emoji):
+//   - no row / deleted  -> no-op                                   [unchanged]
+//   - row live, match   -> soft-delete (is_deleted=1)             [changed]
+//   - row live, mismatch-> no-op (don't drop a different emoji)   [unchanged]
+func reactionStateTransitionImpl(
+	store reactionStateStore,
+	nameResolver func(robotID string) string,
+	existing *reactionRow,
+	in reactionInput,
+) (bool, error) {
+	if in.remove {
+		if existing == nil || existing.IsDeleted == 1 {
+			return false, nil
+		}
+		if existing.Emoji != in.emoji {
+			return false, nil
+		}
+		seq, err := store.genSeq(in.storeChannelID)
+		if err != nil {
+			return false, err
+		}
+		existing.Seq = seq
+		existing.IsDeleted = 1
+		if err := store.update(existing); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	// add
+	if existing != nil && existing.IsDeleted == 0 && existing.Emoji == in.emoji {
+		return false, nil // already reacting with this emoji
+	}
+	seq, err := store.genSeq(in.storeChannelID)
+	if err != nil {
+		return false, err
+	}
+	name := nameResolver(in.robotID)
+	if existing == nil {
+		return true, store.insert(&reactionRow{
+			MessageID:   in.messageID,
+			Seq:         seq,
+			ChannelID:   in.storeChannelID,
+			ChannelType: in.channelType,
+			UID:         in.robotID,
+			Name:        name,
+			Emoji:       in.emoji,
+			IsDeleted:   0,
+		})
+	}
+	existing.Seq = seq
+	existing.Emoji = in.emoji
+	existing.IsDeleted = 0
+	existing.Name = name
+	return true, store.update(existing)
+}
+
+// dispatchReactionCMD sends the reaction-sync CMD, with a test seam mirroring
+// dispatchTypingCMD so unit tests can capture the CMD without a live WuKongIM.
+func (ba *BotAPI) dispatchReactionCMD(req config.MsgCMDReq) error {
+	if ba.reactionCMDDispatch != nil {
+		return ba.reactionCMDDispatch(req)
+	}
+	if ba.ctx == nil {
+		return nil
+	}
+	return ba.ctx.SendCMD(req)
+}

--- a/modules/bot_api/reactions_test.go
+++ b/modules/bot_api/reactions_test.go
@@ -256,6 +256,7 @@ func TestReaction_Handler_DM_AddBroadcastsOriginalChannelID(t *testing.T) {
 		Log:                   log.NewTLog("BotAPI-reaction-test"),
 		reactionCMDDispatch:   cap.hook,
 		reactionStoreOverride: fs,
+		messageExistsOverride: func(string, uint8, string) (bool, error) { return true, nil },
 	}
 	peer := "u_bob"
 	// User Bot DM where the peer is the bot's creator → permission passes via
@@ -290,6 +291,7 @@ func TestReaction_Handler_NoOpSkipsCMD(t *testing.T) {
 		Log:                   log.NewTLog("BotAPI-reaction-test"),
 		reactionCMDDispatch:   cap.hook,
 		reactionStoreOverride: fs,
+		messageExistsOverride: func(string, uint8, string) (bool, error) { return true, nil },
 	}
 	peer := "u_bob"
 	c := buildReactionCtx(t, "bot1", BotKindUser, "m1",
@@ -297,6 +299,34 @@ func TestReaction_Handler_NoOpSkipsCMD(t *testing.T) {
 	ba.addReaction(c)
 	if cap.called {
 		t.Fatal("re-adding the same emoji is a no-op and must not broadcast a CMD")
+	}
+}
+
+// TestReaction_Handler_MessageNotInChannel_Rejected — a bot with send
+// permission to the request channel must NOT be able to react to a message_id
+// that does not belong to that channel (cross-channel reaction injection
+// guard). No store write, no CMD broadcast.
+func TestReaction_Handler_MessageNotInChannel_Rejected(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cap := &reactionCMDCapture{}
+	fs := &fakeReactionStore{}
+	ba := &BotAPI{
+		Log:                   log.NewTLog("BotAPI-reaction-test"),
+		reactionCMDDispatch:   cap.hook,
+		reactionStoreOverride: fs,
+		// Permission passes (peer == bot creator), but the message does not
+		// live in this conversation.
+		messageExistsOverride: func(string, uint8, string) (bool, error) { return false, nil },
+	}
+	peer := "u_bob"
+	c := buildReactionCtx(t, "bot1", BotKindUser, "m_in_other_channel",
+		[]byte(`{"channel_id":"`+peer+`","channel_type":1,"emoji":"👍"}`), "", peer)
+	ba.addReaction(c)
+	if cap.called {
+		t.Fatal("must not broadcast a CMD for a message_id that is not in this channel")
+	}
+	if fs.inserted != nil || fs.updated != nil {
+		t.Fatalf("must not write a reaction row for a cross-channel message_id, got inserted=%+v updated=%+v", fs.inserted, fs.updated)
 	}
 }
 

--- a/modules/bot_api/reactions_test.go
+++ b/modules/bot_api/reactions_test.go
@@ -1,0 +1,328 @@
+package bot_api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/gin-gonic/gin"
+)
+
+// fakeReactionStore implements reactionStorer for state-machine + handler tests.
+type fakeReactionStore struct {
+	seq       int64
+	existing  *reactionRow
+	inserted  *reactionRow
+	updated   *reactionRow
+	genSeqErr error
+}
+
+func (f *fakeReactionStore) genSeq(string) (int64, error) {
+	if f.genSeqErr != nil {
+		return 0, f.genSeqErr
+	}
+	f.seq++
+	return f.seq, nil
+}
+func (f *fakeReactionStore) insert(m *reactionRow) error { f.inserted = m; return nil }
+func (f *fakeReactionStore) update(m *reactionRow) error { f.updated = m; return nil }
+func (f *fakeReactionStore) queryByActorAndMessage(uid, messageID string) (*reactionRow, error) {
+	return f.existing, nil
+}
+
+func nameResolverStub(robotID string) string { return "BotDisplay(" + robotID + ")" }
+
+func baseInput(remove bool) reactionInput {
+	return reactionInput{
+		messageID:      "m1",
+		storeChannelID: "chan1",
+		channelType:    common.ChannelTypeGroup.Uint8(),
+		robotID:        "bot1",
+		emoji:          "👍",
+		remove:         remove,
+	}
+}
+
+// ---- add branches ----
+
+func TestReaction_Add_NoRow_Inserts(t *testing.T) {
+	f := &fakeReactionStore{}
+	changed, err := reactionStateTransitionImpl(f, nameResolverStub, nil, baseInput(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true for fresh add")
+	}
+	if f.inserted == nil {
+		t.Fatal("expected an insert")
+	}
+	if f.inserted.Emoji != "👍" || f.inserted.IsDeleted != 0 {
+		t.Fatalf("bad inserted row: %+v", f.inserted)
+	}
+	// name column must be populated so user clients render the reactor.
+	if f.inserted.Name == "" {
+		t.Fatal("expected reactor display name to be filled")
+	}
+}
+
+func TestReaction_Add_DeletedRow_Revives(t *testing.T) {
+	f := &fakeReactionStore{}
+	existing := &reactionRow{MessageID: "m1", UID: "bot1", Emoji: "👍", IsDeleted: 1}
+	changed, err := reactionStateTransitionImpl(f, nameResolverStub, existing, baseInput(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed || f.updated == nil {
+		t.Fatal("expected a reviving update")
+	}
+	if f.updated.IsDeleted != 0 || f.updated.Emoji != "👍" {
+		t.Fatalf("bad revived row: %+v", f.updated)
+	}
+}
+
+func TestReaction_Add_SameEmojiLive_NoOp(t *testing.T) {
+	f := &fakeReactionStore{}
+	existing := &reactionRow{MessageID: "m1", UID: "bot1", Emoji: "👍", IsDeleted: 0}
+	changed, err := reactionStateTransitionImpl(f, nameResolverStub, existing, baseInput(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatal("expected no-op for re-adding the same emoji")
+	}
+	if f.inserted != nil || f.updated != nil {
+		t.Fatal("expected no DB write on no-op")
+	}
+}
+
+func TestReaction_Add_DifferentEmojiLive_Overwrites(t *testing.T) {
+	f := &fakeReactionStore{}
+	existing := &reactionRow{MessageID: "m1", UID: "bot1", Emoji: "🎉", IsDeleted: 0}
+	changed, err := reactionStateTransitionImpl(f, nameResolverStub, existing, baseInput(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed || f.updated == nil {
+		t.Fatal("expected overwrite update")
+	}
+	if f.updated.Emoji != "👍" {
+		t.Fatalf("expected emoji overwritten to 👍, got %q", f.updated.Emoji)
+	}
+}
+
+// ---- remove branches ----
+
+func TestReaction_Remove_NoRow_NoOp(t *testing.T) {
+	f := &fakeReactionStore{}
+	changed, err := reactionStateTransitionImpl(f, nameResolverStub, nil, baseInput(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed || f.updated != nil {
+		t.Fatal("expected no-op removing a nonexistent reaction")
+	}
+}
+
+func TestReaction_Remove_DeletedRow_NoOp(t *testing.T) {
+	f := &fakeReactionStore{}
+	existing := &reactionRow{MessageID: "m1", UID: "bot1", Emoji: "👍", IsDeleted: 1}
+	changed, err := reactionStateTransitionImpl(f, nameResolverStub, existing, baseInput(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatal("expected no-op removing an already-deleted reaction")
+	}
+}
+
+func TestReaction_Remove_MatchingEmoji_SoftDeletes(t *testing.T) {
+	f := &fakeReactionStore{}
+	existing := &reactionRow{MessageID: "m1", UID: "bot1", Emoji: "👍", IsDeleted: 0}
+	changed, err := reactionStateTransitionImpl(f, nameResolverStub, existing, baseInput(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed || f.updated == nil {
+		t.Fatal("expected soft-delete update")
+	}
+	if f.updated.IsDeleted != 1 {
+		t.Fatalf("expected is_deleted=1, got %d", f.updated.IsDeleted)
+	}
+}
+
+func TestReaction_Remove_MismatchedEmoji_NoOp(t *testing.T) {
+	f := &fakeReactionStore{}
+	existing := &reactionRow{MessageID: "m1", UID: "bot1", Emoji: "🎉", IsDeleted: 0}
+	changed, err := reactionStateTransitionImpl(f, nameResolverStub, existing, baseInput(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed || f.updated != nil {
+		t.Fatal("expected no-op when removing an emoji the bot didn't set")
+	}
+}
+
+// ---- store channel id mapping ----
+
+func TestReaction_StoreChannelID_GroupUsesRaw(t *testing.T) {
+	got := resolveReactionStoreChannelID("g123", common.ChannelTypeGroup.Uint8(), "bot1")
+	if got != "g123" {
+		t.Fatalf("group reaction should store under raw channel id, got %q", got)
+	}
+}
+
+func TestReaction_StoreChannelID_DMUsesFakeChannel(t *testing.T) {
+	peer := "u_bob"
+	bot := "bot1"
+	got := resolveReactionStoreChannelID(peer, common.ChannelTypePerson.Uint8(), bot)
+	want := common.GetFakeChannelIDWith(peer, bot)
+	if got != want {
+		t.Fatalf("DM reaction should store under fake channel id %q, got %q", want, got)
+	}
+	if got == peer {
+		t.Fatal("DM store channel id must NOT be the raw peer id")
+	}
+}
+
+// ---- handler-level tests (permission, CMD routing, no-op) ----
+
+type reactionCMDCapture struct {
+	called bool
+	req    config.MsgCMDReq
+}
+
+func (rc *reactionCMDCapture) hook(req config.MsgCMDReq) error {
+	rc.called = true
+	rc.req = req
+	return nil
+}
+
+func buildReactionCtx(t *testing.T, robotID, botKind, messageID string, body []byte, query, dmCreator string) *wkhttp.Context {
+	t.Helper()
+	url := "/v1/bot/messages/" + messageID + "/reactions"
+	if query != "" {
+		url += "?" + query
+	}
+	method := http.MethodPost
+	if body == nil {
+		method = http.MethodDelete
+	}
+	httpReq := httptest.NewRequest(method, url, bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httpReq
+	gc.Params = gin.Params{{Key: "message_id", Value: messageID}}
+	c := &wkhttp.Context{Context: gc}
+	c.Set(CtxKeyRobotID, robotID)
+	c.Set(CtxKeyBotKind, botKind)
+	// For User Bot DM tests: mark the peer as the bot's creator so the
+	// permission check passes via the isCreator branch (no DB/userService).
+	c.Set(CtxKeyRobot, &robotModel{RobotID: robotID, CreatorUID: dmCreator})
+	return c
+}
+
+// TestReaction_Handler_AppBotGroupRejected — App Bot may only react in DMs.
+// Pure-logic permission branch (no DB), so it runs without a live ctx.
+func TestReaction_Handler_AppBotGroupRejected(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cap := &reactionCMDCapture{}
+	ba := &BotAPI{
+		Log:                   log.NewTLog("BotAPI-reaction-test"),
+		reactionCMDDispatch:   cap.hook,
+		reactionStoreOverride: &fakeReactionStore{},
+	}
+	c := buildReactionCtx(t, "app_bot1", BotKindApp, "m1",
+		[]byte(`{"channel_id":"g1","channel_type":2,"emoji":"👍"}`), "", "")
+	ba.addReaction(c)
+	if cap.called {
+		t.Fatal("App Bot group reaction must be rejected before any CMD broadcast")
+	}
+}
+
+// TestReaction_Handler_DM_AddBroadcastsOriginalChannelID — the sync CMD
+// must route to the ORIGINAL peer channel id (not the fake store id).
+func TestReaction_Handler_DM_AddBroadcastsOriginalChannelID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cap := &reactionCMDCapture{}
+	fs := &fakeReactionStore{}
+	ba := &BotAPI{
+		Log:                   log.NewTLog("BotAPI-reaction-test"),
+		reactionCMDDispatch:   cap.hook,
+		reactionStoreOverride: fs,
+	}
+	peer := "u_bob"
+	// User Bot DM where the peer is the bot's creator → permission passes via
+	// the isCreator branch (no userService/DB needed).
+	c := buildReactionCtx(t, "bot1", BotKindUser, "m1",
+		[]byte(`{"channel_id":"`+peer+`","channel_type":1,"emoji":"👍"}`), "", peer)
+	ba.addReaction(c)
+	if !cap.called {
+		t.Fatal("expected a sync CMD on a fresh add")
+	}
+	if cap.req.ChannelID != peer {
+		t.Fatalf("CMD must use original peer channel id %q, got %q", peer, cap.req.ChannelID)
+	}
+	if cap.req.FromUID != "bot1" {
+		t.Fatalf("CMD FromUID should be the bot, got %q", cap.req.FromUID)
+	}
+	// The stored row must use the fake channel id, not the raw peer.
+	if fs.inserted == nil || fs.inserted.ChannelID == peer {
+		t.Fatalf("DM reaction row must store under fake channel id, got %+v", fs.inserted)
+	}
+}
+
+// TestReaction_Handler_NoOpSkipsCMD — re-adding the same live emoji is a no-op
+// and must NOT broadcast a CMD.
+func TestReaction_Handler_NoOpSkipsCMD(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cap := &reactionCMDCapture{}
+	fs := &fakeReactionStore{
+		existing: &reactionRow{MessageID: "m1", UID: "bot1", Emoji: "👍", IsDeleted: 0},
+	}
+	ba := &BotAPI{
+		Log:                   log.NewTLog("BotAPI-reaction-test"),
+		reactionCMDDispatch:   cap.hook,
+		reactionStoreOverride: fs,
+	}
+	peer := "u_bob"
+	c := buildReactionCtx(t, "bot1", BotKindUser, "m1",
+		[]byte(`{"channel_id":"`+peer+`","channel_type":1,"emoji":"👍"}`), "", peer)
+	ba.addReaction(c)
+	if cap.called {
+		t.Fatal("re-adding the same emoji is a no-op and must not broadcast a CMD")
+	}
+}
+
+// TestReaction_Handler_DM_NonFriendRejected — a User Bot DM where the peer
+// is neither the bot's creator nor a friend must be rejected, with no store
+// write and no CMD. Uses friendCheckOverride (the seam isFriendOrOBOBypass
+// consults) so no live user service is needed.
+func TestReaction_Handler_DM_NonFriendRejected(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cap := &reactionCMDCapture{}
+	fs := &fakeReactionStore{}
+	ba := &BotAPI{
+		Log:                   log.NewTLog("BotAPI-reaction-test"),
+		reactionCMDDispatch:   cap.hook,
+		reactionStoreOverride: fs,
+		friendCheckOverride:   func(uid, toUID string) (bool, error) { return false, nil },
+	}
+	// dmCreator is a DIFFERENT uid than the peer, so the isCreator bypass does
+	// not apply and the (failing) friend check decides.
+	c := buildReactionCtx(t, "bot1", BotKindUser, "m1",
+		[]byte(`{"channel_id":"u_bob","channel_type":1,"emoji":"👍"}`), "", "someone_else")
+	ba.addReaction(c)
+	if cap.called {
+		t.Fatal("non-friend DM reaction must be rejected before any CMD broadcast")
+	}
+	if fs.inserted != nil || fs.updated != nil {
+		t.Fatal("rejected reaction must not write to the store")
+	}
+}

--- a/modules/message/service.go
+++ b/modules/message/service.go
@@ -39,6 +39,7 @@ type ChannelOffsetResp = channelOffsetResp
 type Service struct {
 	ctx *config.Context
 	log.Log
+	db                 *DB
 	messageExtraDB     *messageExtraDB
 	messageUserExtraDB *messageUserExtraDB
 	channelOffsetDB    *channelOffsetDB
@@ -49,10 +50,28 @@ func NewService(ctx *config.Context) *Service {
 	return &Service{
 		ctx:                ctx,
 		Log:                log.NewTLog("message.Service"),
+		db:                 NewDB(ctx),
 		messageExtraDB:     newMessageExtraDB(ctx),
 		messageUserExtraDB: newMessageUserExtraDB(ctx),
 		channelOffsetDB:    newChannelOffsetDB(ctx),
 	}
+}
+
+// MessageExistsInChannel reports whether messageID is a stored message under
+// (channelID, channelType). The bot reaction endpoint accepts an arbitrary
+// message_id while only proving the bot's permission on the request channel;
+// callers use this to reject a message_id that does not belong to that channel.
+// Without the guard a bot could attach a reaction to a message in a channel it
+// has no access to, because reaction_users rows are joined to messages by
+// message_id alone (db_message_reaction.queryWithMessageIDs). DM messages are
+// stored under the fake channel id, so callers must pass the same resolved
+// channel id used for reaction storage (resolveReactionStoreChannelID).
+func (s *Service) MessageExistsInChannel(channelID string, channelType uint8, messageID string) (bool, error) {
+	m, err := s.db.queryMessageByID(channelID, channelType, messageID)
+	if err != nil {
+		return false, err
+	}
+	return m != nil, nil
 }
 
 func (s *Service) GetChannelOffsetWithUID(uid string, channelIDs []string) ([]*channelOffsetResp, error) {


### PR DESCRIPTION
## Summary

Add bot-facing message reaction endpoints (backend of the three-end #111 reactions feature).

## Related Issue

#111

## Linked Spec

Message-adapter + reactions plan (issue #111).

## Changes

- `POST /v1/bot/messages/:message_id/reactions` — body `{channel_id, channel_type, emoji}`; a bot adds/replaces its single reaction on a message.
- `DELETE /v1/bot/messages/:message_id/reactions/:emoji?channel_id&channel_type` — removes it.
- Reactions reuse the existing `reaction_users` table and reaction seq stream, and broadcast `CMDSyncMessageReaction`, identical to the user-facing reaction path. Permission reuses `checkSendPermission` (group/thread/App-Bot/DM-friend). DM rows store under the fake channel id; the CMD broadcasts with the original channel id.
- Add/remove is a pure state machine over the single `(uid, message_id)` row with full branch coverage; a `reactionStateStore` seam keeps handler tests DB-free.
- Cross-channel write guard: before writing, verify the `message_id` actually belongs to the requested conversation via `message.Service.MessageExistsInChannel` (group = raw channel id, DM = fake channel id, matching how the message table stores DM rows). A mismatch is rejected as an invalid `message_id` with no store write and no broadcast — a bot cannot attach a reaction to a message in a channel it is not authorized for.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

`go test ./modules/bot_api -run '^TestReaction_'` passes (state-machine four branches, DM broadcast uses original channel id, no-op skips CMD, cross-channel message rejected). `go build ./modules/bot_api` clean.

## COMPREHENSION

1. **What it does to the load-bearing path**: adds a new bot-auth write path into `reaction_users` + reaction seq + `CMDSyncMessageReaction` broadcast, sharing the exact storage/broadcast contract as the user reaction path so clients treat bot and user reactions identically.

2. **What could break**: the message-load path joins reactions by `message_id` alone (no channel filter), so an unguarded bot write could surface a reaction on a message in another channel. Mitigated by the `MessageExistsInChannel` guard. Concurrency of the query-then-write `(uid, message_id)` row matches the pre-existing user path (documented; out of scope to harden here).

3. **How I know it works**: unit tests cover the state machine, DM channel-id resolution, no-op, and the cross-channel reject; three-end e2e verified (API 200 + row persisted + broadcast + web chip rendered).

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)

> Draft: reactions is a three-end feature — ships with octo-web (render) + openclaw-channel-octo (react action).