### PR TITLE
feat(search): expose video url in message search hits

### DIFF
--- a/modules/messages_search/search_all_test.go
+++ b/modules/messages_search/search_all_test.go
@@ -219,6 +219,9 @@ func TestSingleSearchAllHit_Video(t *testing.T) {
 	if got.Message.ThumbURL != "https://cdn/v.jpg" {
 		t.Errorf("thumb_url must mirror payload.video.cover: got %q", got.Message.ThumbURL)
 	}
+	if got.Message.VideoURL != "https://cdn/v.mp4" {
+		t.Errorf("video_url must mirror payload.video.url: got %q", got.Message.VideoURL)
+	}
 	if got.Message.Width != 1280 || got.Message.Height != 720 {
 		t.Errorf("dimensions: got %dx%d want 1280x720", got.Message.Width, got.Message.Height)
 	}

--- a/modules/messages_search/search_media.go
+++ b/modules/messages_search/search_media.go
@@ -23,6 +23,7 @@ type MediaHit struct {
 	MessageSeq  int64  `json:"message_seq"`
 	MediaKind   string `json:"media_kind"`
 	ThumbURL    string `json:"thumb_url,omitempty"`
+	VideoURL    string `json:"video_url,omitempty"`
 	Width       int    `json:"width,omitempty"`
 	Height      int    `json:"height,omitempty"`
 	DurationMs  int64  `json:"duration_ms,omitempty"`
@@ -190,6 +191,7 @@ func (h *Handler) singleMediaHit(doc Doc, req SearchMediaReq) MediaHit {
 		if vid := videoPayloadOf(doc.Payload); vid != nil {
 			mh.MediaKind = "video"
 			mh.ThumbURL = vid.Cover
+			mh.VideoURL = vid.URL
 			mh.Width = vid.Width
 			mh.Height = vid.Height
 			mh.DurationMs = int64(vid.Second) * 1000

--- a/modules/messages_search/search_media_test.go
+++ b/modules/messages_search/search_media_test.go
@@ -43,13 +43,16 @@ func TestBuildMediaHits_VideoCoverIsThumbAndSecondToMs(t *testing.T) {
 	doc := Doc{
 		Payload: &Payload{
 			Type:  &tp,
-			Video: &VideoPayload{Cover: "cover.jpg", Second: 5, Width: 1920, Height: 1080},
+			Video: &VideoPayload{URL: "https://cdn/v.mp4", Cover: "cover.jpg", Second: 5, Width: 1920, Height: 1080},
 		},
 	}
 	h := &Handler{cfg: SearchConfig{}, cache: newSenderCache(8, 0)}
 	got := h.singleMediaHit(doc, SearchMediaReq{ChannelType: channelTypeGroup, ChannelID: "g"})
 	if got.ThumbURL != "cover.jpg" {
 		t.Errorf("expected cover as thumb_url, got %q", got.ThumbURL)
+	}
+	if got.VideoURL != "https://cdn/v.mp4" {
+		t.Errorf("expected payload.video.url as video_url, got %q", got.VideoURL)
 	}
 	// v1.8: indexer stores second (s); BFF surfaces duration_ms (ms).
 	if got.DurationMs != 5000 {
@@ -72,5 +75,25 @@ func TestBuildMediaHits_VideoZeroSecondOmitsDuration(t *testing.T) {
 	got := h.singleMediaHit(doc, SearchMediaReq{ChannelType: channelTypeGroup, ChannelID: "g"})
 	if got.DurationMs != 0 {
 		t.Errorf("missing second should yield duration_ms=0, got %d", got.DurationMs)
+	}
+}
+
+// Video without a cover still surfaces video_url — the play URL is the
+// primary renderable, cover is only a poster.
+func TestBuildMediaHits_VideoNoCoverStillHasVideoURL(t *testing.T) {
+	tp := payloadTypeVideo
+	doc := Doc{
+		Payload: &Payload{
+			Type:  &tp,
+			Video: &VideoPayload{URL: "https://cdn/v.mp4"},
+		},
+	}
+	h := &Handler{cfg: SearchConfig{}, cache: newSenderCache(8, 0)}
+	got := h.singleMediaHit(doc, SearchMediaReq{ChannelType: channelTypeGroup, ChannelID: "g"})
+	if got.ThumbURL != "" {
+		t.Errorf("thumb_url should be empty when cover missing, got %q", got.ThumbURL)
+	}
+	if got.VideoURL != "https://cdn/v.mp4" {
+		t.Errorf("video_url must be populated even without cover, got %q", got.VideoURL)
 	}
 }

--- a/modules/messages_search/search_messages.go
+++ b/modules/messages_search/search_messages.go
@@ -33,6 +33,7 @@ type MessageHit struct {
 	InnerMessages   []InnerMessage `json:"inner_messages,omitempty"`
 	ChannelID       string         `json:"channel_id"`
 	ThumbURL        string         `json:"thumb_url,omitempty"`
+	VideoURL        string         `json:"video_url,omitempty"`
 	Width           int            `json:"width,omitempty"`
 	Height          int            `json:"height,omitempty"`
 	DurationMs      int64          `json:"duration_ms,omitempty"`
@@ -304,6 +305,7 @@ func applyMediaProjection(mh *MessageHit, p *Payload) {
 	case payloadTypeVideo:
 		if vid := videoPayloadOf(p); vid != nil {
 			mh.ThumbURL = vid.Cover
+			mh.VideoURL = vid.URL
 			mh.Width = vid.Width
 			mh.Height = vid.Height
 			if vid.Second > 0 {

--- a/modules/messages_search/swagger/api.yaml
+++ b/modules/messages_search/swagger/api.yaml
@@ -519,6 +519,15 @@ definitions:
           when message_kind ∈ ["image", "video"] — i.e. on /_search_all
           browse mode (no keyword) and /_search_around media hits. Omitted
           on text / forward hits.
+      video_url:
+        type: string
+        format: uri
+        description: |
+          Video playback URL (mirrors MediaHit.video_url; distinct from the
+          poster/cover surfaced via thumb_url). Only present when
+          message_kind="video" — i.e. on /_search_all browse mode (no
+          keyword) and /_search_around video hits. Omitted on image / text /
+          forward hits.
       width:
         type: integer
         description: |
@@ -572,6 +581,13 @@ definitions:
       thumb_url:
         type: string
         format: uri
+      video_url:
+        type: string
+        format: uri
+        description: |
+          Video playback URL, distinct from the poster/cover surfaced via
+          thumb_url. Only present when media_kind="video". Omitted on image
+          hits.
       width:
         type: integer
       height:


### PR DESCRIPTION
Fixes #<issue-number>

## Problem

Video message hits in message search results don't carry a playable url: the media tab can't preview, and video hits in browse / context views are missing the url too.

## Root cause

The index layer is fine (`payload.video.url` / `cover` are fully written to ES). The gap is in **result projection**: `MediaHit` / `MessageHit` have no field to carry the video url, so the video branch only fills `thumb_url = cover`. Videos without a cover show nothing at all.

## Changes

`modules/messages_search/`

- **`search_media.go`** — add `VideoURL string` (`json:"video_url,omitempty"`) to `MediaHit`; the video projection branch fills `mh.VideoURL = vid.URL`.
- **`search_messages.go`** — add `VideoURL string` (`json:"video_url,omitempty"`) to `MessageHit`; `applyMediaProjection`'s video branch fills `mh.VideoURL = vid.URL`.
- **`swagger/api.yaml`** — mirror the existing `thumb_url` phrasing to describe `video_url` in both the media and message schemas (semantic: "playable video url; distinct from the cover in `thumb_url`").

`video_url` is used rather than reusing `thumb_url` because `thumb_url` is poster semantics (image cover); image vs. video need to be distinguishable, and the downstream `octo-web` `MediaSearchHit` already declares and prefers `video_url`.

## Affected endpoints

The same projection is shared by three endpoints, so all three benefit:

| Endpoint | Change |
|---|---|
| `POST /v1/messages/_search_media` | `MediaHit.video_url` populated on video hits |
| `POST /v1/messages/_search_all` (browse mode, empty keyword) | `MessageHit.video_url` populated on video hits |
| `POST /v1/messages/_search_around` | Same as above (shares `buildMessageHits`) |

`POST /v1/messages/_search` is **not affected**: the type whitelist only includes text / mergeForward / richText, so video hits never reach projection.

## Compatibility

- Both new fields are `omitempty`, so non-video responses are byte-identical and old clients see no change.
- Videos without a cover: previously returned an empty `thumb_url` and nothing playable; now they at least carry `video_url`.
- No changes to ES mapping, indexer, or query DSL.

## Tests

- `TestSingleSearchAllHit_Video` (`search_all_test.go`) now asserts `got.Message.VideoURL == "https://cdn/v.mp4"` — PASS.
- New `TestBuildMediaHits_VideoNoCoverStillHasVideoURL` (`search_media_test.go`) covers the no-cover video fallback — PASS.
- `go test ./modules/messages_search/` all green; `go vet ./...` clean.

## Rollout

Backend-first is safe: old frontends that don't know about `video_url` simply ignore it, which is equivalent to today's behavior. The paired frontend change will be filed separately against `octo-web` (this PR is backend-only).

## Checklist

- [x] `go test ./modules/messages_search/` PASS
- [x] `go vet ./...` clean
- [x] Swagger description aligned with existing `thumb_url` phrasing
- [x] No ES / indexer / query-side changes
- [x] New fields `omitempty` — zero impact on existing clients


Fixes #514
