### PR TITLE
feat(bot): summary-assistant bootstrap + ensureFriend endpoint

### DIFF
--- a/modules/bot_api/api_i18n_test.go
+++ b/modules/bot_api/api_i18n_test.go
@@ -37,6 +37,7 @@ func TestBotAPINoLegacyResponseError(t *testing.T) {
 		"auth.go", "register.go", "commands.go", "events.go", "mention_pref.go",
 		"sync.go", "typing.go", "send.go", "threads.go", "file.go", "groups.go",
 		"voice_adapter.go", "obo_api.go", "resolve_targets.go", "incoming_webhook.go",
+		"ensure_friend.go",
 	}
 	banned := []string{
 		".ResponseError(",

--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -207,6 +207,9 @@ func (ba *BotAPI) Route(r *wkhttp.WKHttp) {
 	botAPI := r.Group("/v1/bot", ba.authBot())
 	{
 		botAPI.POST("/sendMessage", ba.sendMessage)
+		// OCT-5: 总结助手好友关系 ensure（DM 可达前置）。端点内部按 UID 白名单
+		// 仅放行配置中的总结助手 bot；其余 bot 调用返回 403。
+		botAPI.POST("/ensureFriend", ba.ensureFriend)
 		botAPI.POST("/typing", ba.typing)
 		botAPI.POST("/readReceipt", ba.readReceipt)
 		botAPI.POST("/events", ba.getEvents)

--- a/modules/bot_api/db.go
+++ b/modules/bot_api/db.go
@@ -1,8 +1,12 @@
 package bot_api
 
 import (
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/db"
+	pkgspace "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"github.com/gocraft/dbr/v2"
 )
 
@@ -163,8 +167,54 @@ func (d *botAPIDB) querySpaceIDsByRobotID(robotID string) (string, []string, err
 // single round trip. A single combined query was rejected because OR-of-
 // EXISTS in MySQL with parameter reuse forces the planner to materialize
 // both branches even when the first short-circuits.
-func (d *botAPIDB) isBotSpaceAuthorized(robotID, spaceID string) (bool, error) {
+func (d *botAPIDB) isBotSpaceAuthorized(robotID, spaceID, recipientUID string, channelType uint8) (bool, error) {
 	if robotID == "" || spaceID == "" {
+		return false, nil
+	}
+	// PR#483 (OCT-5) step3/step4 + 第二轮 BLOCKING 修复 — system bot path.
+	//
+	// 系统 bot（如 summary_notification）不依赖 space_member 行获得 Space 归属
+	// （说明见 modules/bot_api/ensure_friend.go step4 注释）。语义参照 platform App
+	// Bot：系统 bot 在所有**活跃** Space 可见。但**纯靠目标 Space active** 来采纳
+	// X-Space-ID 头是一个跨 Space 归属注入漏洞（reviewer 🔴 BLOCKING）：
+	// summary_notification 与 userA（属 spaceA）建立的是**全局**好友关系，send.go 的
+	// DM 鉴权只校验全局好友/OBO，不绑定接收人是否属于 header 声称的 Space。于是
+	// 只要 spaceB active，带 X-Space-ID=spaceB 发给 userA 的 DM 会被错误地归属到
+	// spaceB —— 把 spaceA 用户的私信注入了 spaceB。
+	//
+	// 修复：对 **person channel（DM）** 的系统 bot 发送，X-Space-ID 仅当**接收人确实
+	// 是该 Space 的活跃成员**（pkgspace.CheckMembership(spaceID, recipientUID)=true）
+	// 才采纳；否则不授权（调用方 fall through / strip，绝不跨 Space 注入）。这样把
+	// header 归属严格绑定到 (接收人, Space)，而非仅 (bot, Space active)。
+	//
+	// 非 person channel（群 / thread）：群 / thread 自身已携带 Space 上下文，且这条
+	// header 校验路径在生产里只服务 DM 注入；为不放宽群/thread 的既有语义，维持原
+	// 「目标 Space active 即授权」（系统 bot 在所有活跃 Space 可见）。
+	//
+	// 注意：本分支只影响**发送时的 space_id 解析授权**，不赋予枚举 / 建群能力（那两
+	// 个能力门在 groups.go / service.go 用 IsSystemBot 显式排除）。也不会给 bot 留
+	// 任何 space_member 行。
+	if pkgspace.IsSystemBot(robotID) {
+		if channelType == common.ChannelTypePerson.Uint8() {
+			// DM：必须把 header 声称的 Space 绑定到接收人。接收人不属于该 Space →
+			// 拒绝采纳 header（杜绝跨 Space DM 归属注入）。CheckMembership 自身已
+			// 校验 Space active，无需再单独查 space.status。
+			if strings.TrimSpace(recipientUID) == "" {
+				return false, nil
+			}
+			return pkgspace.CheckMembership(d.session, spaceID, recipientUID)
+		}
+		// 非 DM：维持原 active 校验。
+		var sysCount int
+		if err := d.session.SelectBySql(
+			"SELECT COUNT(*) FROM space s WHERE s.space_id=? AND s.status=1",
+			spaceID,
+		).LoadOne(&sysCount); err != nil {
+			return false, err
+		}
+		if sysCount > 0 {
+			return true, nil
+		}
 		return false, nil
 	}
 	// (1) space_member path: active member row in the target active Space.

--- a/modules/bot_api/ensure_friend.go
+++ b/modules/bot_api/ensure_friend.go
@@ -88,6 +88,40 @@ func (ba *BotAPI) ensureFriend(c *wkhttp.Context) {
 			httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPINotSpaceMember, nil, nil)
 			return
 		}
+
+		// PR#483 review blocker (Jerry-Xin + OctoBoooot byte-confirmed) — Space
+		// attribution end-to-end gap：summary bot 落在 `robot` 表，没有
+		// `space_member` 行，也没有 `app_bot` 行；后续 `/v1/bot/sendMessage` 的
+		// `resolveBotActiveSpaceID` 三条路径（ctx scope=space / X-Space-ID
+		// validator → isBotSpaceAuthorized / fallback querySpaceIDsByRobotID）
+		// 全 miss → enrichBotPayloadWithSpaceID 把 client-supplied space_id
+		// strip 掉，DM 失去 Space 上下文。
+		//
+		// 修复（方案 a）：target 通过 CheckMembership 后，幂等地给 summary bot
+		// 在**同一个 space_id** 落一行 space_member（role=0 普通成员，最小权限）。
+		// 这样后续 send 路径：
+		//   - query (1) `space_member` 命中 → `isBotSpaceAuthorized` 真，
+		//     X-Space-ID 头会被采纳；
+		//   - 无 X-Space-ID 头时 `querySpaceIDsByRobotID` 兜底也命中。
+		//
+		// 安全性约束：
+		//   - 只对**经过 CheckMembership 验证过 target 的 space_id** 落 summary
+		//     bot 的 space_member —— 攻击面被 target 的 membership 校验完全
+		//     约束在 "target 真实归属的 Space" 内；
+		//   - role=0 普通成员（最小权限），不是 admin/owner，没有管理权限提升；
+		//   - INSERT IGNORE 幂等，不强复活已被运维显式移除的行（status=0 不动）；
+		//   - target_uid（用户）不动，仅给 summary bot 自己落行。
+		//
+		// 失败语义：不阻断好友建立。若 space_member 落库失败，DM 仍会按
+		// fail-closed strip 走（enrich_payload_space_id_empty 监控可见），friend
+		// / 白名单这条主链路对 smart-summary 仍是 best-effort 可用。
+		if _, smErr := ba.db.session.InsertBySql(
+			"INSERT IGNORE INTO space_member (space_id, uid, role, status, version, created_at, updated_at) VALUES (?, ?, 0, 1, 1, NOW(), NOW())",
+			spaceID, robotID,
+		).Exec(); smErr != nil {
+			ba.Warn("ensureFriend 落 summary bot space_member 失败（不阻断好友建立）",
+				zap.String("space_id", spaceID), zap.String("bot_uid", robotID), zap.Error(smErr))
+		}
 	}
 
 	// 1. friend 表双向（幂等 InsertOrUpdate）。

--- a/modules/bot_api/ensure_friend.go
+++ b/modules/bot_api/ensure_friend.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	pkgspace "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"go.uber.org/zap"
 )
 
@@ -69,6 +70,25 @@ func (ba *BotAPI) ensureFriend(c *wkhttp.Context) {
 	}
 
 	spaceID := strings.TrimSpace(req.SpaceID)
+
+	// P1-3：space 成员校验 —— 当请求带 space_id 时，target_uid 必须是该 Space 的活跃
+	// 成员，否则拒绝。复用发送/可见性路径同款 pkg/space.CheckMembership（与
+	// category/api.go、voice_adapter 等一致），防止借总结助手向非本 Space 用户强制建立
+	// 好友（跨 Space 钓鱼/打扰向量）。spaceID 为空（单 Space/平台级）时跳过，与裸 uid
+	// 发送路径语义一致。
+	if spaceID != "" {
+		isMember, err := pkgspace.CheckMembership(ba.db.session, spaceID, targetUID)
+		if err != nil {
+			ba.Error("ensureFriend space 成员校验失败", zap.String("space_id", spaceID), zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
+			return
+		}
+		if !isMember {
+			ba.Warn("ensureFriend 目标用户非 space 成员，拒绝", zap.String("space_id", spaceID), zap.String("target_uid", targetUID))
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPINotSpaceMember, nil, nil)
+			return
+		}
+	}
 
 	// 1. friend 表双向（幂等 InsertOrUpdate）。
 	if err := ba.userService.AddFriend(targetUID, &user.FriendReq{

--- a/modules/bot_api/ensure_friend.go
+++ b/modules/bot_api/ensure_friend.go
@@ -89,39 +89,28 @@ func (ba *BotAPI) ensureFriend(c *wkhttp.Context) {
 			return
 		}
 
-		// PR#483 review blocker (Jerry-Xin + OctoBoooot byte-confirmed) — Space
-		// attribution end-to-end gap：summary bot 落在 `robot` 表，没有
-		// `space_member` 行，也没有 `app_bot` 行；后续 `/v1/bot/sendMessage` 的
-		// `resolveBotActiveSpaceID` 三条路径（ctx scope=space / X-Space-ID
-		// validator → isBotSpaceAuthorized / fallback querySpaceIDsByRobotID）
-		// 全 miss → enrichBotPayloadWithSpaceID 把 client-supplied space_id
-		// strip 掉，DM 失去 Space 上下文。
+		// PR#483 Boss 定稿（step4，选择窄路径 —— 不再插 space_member 行）：
 		//
-		// 修复（方案 a）：target 通过 CheckMembership 后，幂等地给 summary bot
-		// 在**同一个 space_id** 落一行 space_member（role=0 普通成员，最小权限）。
-		// 这样后续 send 路径：
-		//   - query (1) `space_member` 命中 → `isBotSpaceAuthorized` 真，
-		//     X-Space-ID 头会被采纳；
-		//   - 无 X-Space-ID 头时 `querySpaceIDsByRobotID` 兜底也命中。
+		// 三个 reviewer 一致卡的 P1 是：给 summary bot 插真实 space_member 行会让
+		// bot 顺带获得 Space 级能力（枚举成员、建群）+ 污染 member_count / 名册 /
+		// @选择器。其中 member_count 是裸 `SELECT COUNT(*) FROM space_member ...`
+		// （见 modules/space/db.go:72/86, db_manager.go:163），**不走 SystemBots 过滤**，
+		// 所以只要还有 space_member 行，member_count 污染就无法根除。因此本次
+		// **不再为 summary bot 插 space_member 行**。
 		//
-		// 安全性约束：
-		//   - 只对**经过 CheckMembership 验证过 target 的 space_id** 落 summary
-		//     bot 的 space_member —— 攻击面被 target 的 membership 校验完全
-		//     约束在 "target 真实归属的 Space" 内；
-		//   - role=0 普通成员（最小权限），不是 admin/owner，没有管理权限提升；
-		//   - INSERT IGNORE 幂等，不强复活已被运维显式移除的行（status=0 不动）；
-		//   - target_uid（用户）不动，仅给 summary bot 自己落行。
+		// DM 的 Space 归属不靠 space_member 行，而是走 IsSystemBot 的窄路径：
+		//   - 发送路径（/v1/bot/sendMessage）带 X-Space-ID 头时，isBotSpaceAuthorized
+		//     对 IsSystemBot(robotID) 直接放行（系统 bot 在所有活跃 Space 可见，语义
+		//     同 platform App Bot）→ X-Space-ID 被采纳 → enrichBotPayloadWithSpaceID
+		//     注入权威 space_id，DM 不丢 Space 归属（详见 modules/bot_api/db.go
+		//     isBotSpaceAuthorized 的 IsSystemBot 分支）。smart-summary 的 send 姿势始终
+		//     携 X-Space-ID（SpaceID 来自 SummaryTask.SpaceID，与本端点 space_id 参数
+		//     同源），所以这是唯一生产 send 形状。
 		//
-		// 失败语义：不阻断好友建立。若 space_member 落库失败，DM 仍会按
-		// fail-closed strip 走（enrich_payload_space_id_empty 监控可见），friend
-		// / 白名单这条主链路对 smart-summary 仍是 best-effort 可用。
-		if _, smErr := ba.db.session.InsertBySql(
-			"INSERT IGNORE INTO space_member (space_id, uid, role, status, version, created_at, updated_at) VALUES (?, ?, 0, 1, 1, NOW(), NOW())",
-			spaceID, robotID,
-		).Exec(); smErr != nil {
-			ba.Warn("ensureFriend 落 summary bot space_member 失败（不阻断好友建立）",
-				zap.String("space_id", spaceID), zap.String("bot_uid", robotID), zap.Error(smErr))
-		}
+		// 结果：(a) DM 仍带正确 space_id（不回归 PR 之前的 DM-attribution bug）；
+		//       (b) bot 无 space_member 行 → 无 Space 能力面；(c) 不污染计数 / 名册。
+		// 本函数不再对 space_member 表做任何写入（friend 表 + IM 白名单仍是 DM 可达的
+		// 唯一依赖，见下文）。
 	}
 
 	// 1. friend 表双向（幂等 InsertOrUpdate）。

--- a/modules/bot_api/ensure_friend.go
+++ b/modules/bot_api/ensure_friend.go
@@ -1,0 +1,155 @@
+package bot_api
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/robot"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"go.uber.org/zap"
+)
+
+// ensureFriendReq 是 POST /v1/bot/ensureFriend 的请求体。
+//
+// 契约（与 octo-smart-summary OCT-6 对齐）：
+//   - TargetUID：被通知用户的 UID（必填）。
+//   - SpaceID：可选。多 Space 部署下，IM 白名单 channel_id 需要 space 前缀
+//     （s{spaceID}_{uid}），由 smart-summary 从 SummaryTask.SpaceID 传入。
+//     缺省（单 Space / 平台级）时走裸 uid 分支，与发送路径 DM 的裸 uid 一致。
+type ensureFriendReq struct {
+	TargetUID string `json:"target_uid"`
+	SpaceID   string `json:"space_id"`
+}
+
+// ensureFriend 为"总结助手"与目标用户建立双向好友关系（DM 可达前置）。
+//
+// 复刻 botfather/friend_approve.go 与 app_bot/app_bot.go 的好友建立配方：
+//  1. friend 表双向（userService.AddFriend，底层 InsertOrUpdate 幂等）；
+//  2. IM 白名单双向 —— 光插 friend 表不够，IM 层投递要白名单；channel_id 在有
+//     Space 时必须用 s{spaceID}_{uid} 前缀形态（P1-1），否则多 Space 下白名单加错
+//     channel，friend 表建了、应用层门过了，但 IM 层不放行 → DM 静默投递失败；
+//  3. fixFriendVersion 双向（WKSDK 增量同步需要 version>0）；
+//  4. SendCMD(CMDFriendAccept) 通知双端同步好友列表。
+//
+// 安全（P1-2）：本端点会强制建立（无需对方 opt-in）双向好友，是新攻击面。因此入口
+// 硬校验调用方 robot_id 必须等于配置中的总结助手 UID，否则任何持有效 robot token 的
+// bot 都能强制与任意用户建好友（钓鱼/垃圾消息向量）。范围严格限定那一个 UID。
+//
+// 整体幂等：重复调用无副作用（friend InsertOrUpdate / 白名单 add / version 修复
+// 均可重复执行）。不改 send.go / auth.go 的发送鉴权主链路。
+func (ba *BotAPI) ensureFriend(c *wkhttp.Context) {
+	robotID := getRobotIDFromContext(c)
+	if strings.TrimSpace(robotID) == "" {
+		ba.respondBotAPIIdentityMissing(c)
+		return
+	}
+
+	// P1-2：UID 白名单门控 —— 仅放行配置里的总结助手 UID。
+	summaryUID := robot.SummaryBotUID()
+	if summaryUID == "" || robotID != summaryUID {
+		ba.Warn("ensureFriend 越权调用被拒（非总结助手 UID）", zap.String("robot_id", robotID))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIEnsureFriendForbidden, nil, nil)
+		return
+	}
+
+	var req ensureFriendReq
+	if err := c.BindJSON(&req); err != nil {
+		respondBotAPIRequestInvalid(c, "")
+		return
+	}
+	targetUID := strings.TrimSpace(req.TargetUID)
+	if targetUID == "" {
+		respondBotAPIRequestInvalid(c, "target_uid")
+		return
+	}
+
+	spaceID := strings.TrimSpace(req.SpaceID)
+
+	// 1. friend 表双向（幂等 InsertOrUpdate）。
+	if err := ba.userService.AddFriend(targetUID, &user.FriendReq{
+		UID:   targetUID,
+		ToUID: robotID,
+	}); err != nil {
+		ba.Error("ensureFriend 添加好友(user->bot)失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
+		return
+	}
+	if err := ba.userService.AddFriend(robotID, &user.FriendReq{
+		UID:   robotID,
+		ToUID: targetUID,
+	}); err != nil {
+		ba.Error("ensureFriend 添加好友(bot->user)失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
+		return
+	}
+
+	// 2. IM 白名单双向。P1-1：有 Space 时 channel_id 用 s{spaceID}_{uid} 前缀形态
+	//    （复刻 friend_approve.go:180-185 / app_bot.go:1130-1141）。白名单失败仅 warn，
+	//    不阻断（与既有范式一致：best-effort，整体仍可重试）。
+	userChannelID := targetUID
+	botChannelID := robotID
+	if spaceID != "" {
+		userChannelID = fmt.Sprintf("s%s_%s", spaceID, targetUID)
+		botChannelID = fmt.Sprintf("s%s_%s", spaceID, robotID)
+	}
+	if err := ba.ctx.IMWhitelistAdd(config.ChannelWhitelistReq{
+		ChannelReq: config.ChannelReq{
+			ChannelID:   userChannelID,
+			ChannelType: common.ChannelTypePerson.Uint8(),
+		},
+		UIDs: []string{robotID},
+	}); err != nil {
+		ba.Warn("ensureFriend 添加IM白名单(user channel)失败", zap.String("channel_id", userChannelID), zap.Error(err))
+	}
+	if err := ba.ctx.IMWhitelistAdd(config.ChannelWhitelistReq{
+		ChannelReq: config.ChannelReq{
+			ChannelID:   botChannelID,
+			ChannelType: common.ChannelTypePerson.Uint8(),
+		},
+		UIDs: []string{targetUID},
+	}); err != nil {
+		ba.Warn("ensureFriend 添加IM白名单(bot channel)失败", zap.String("channel_id", botChannelID), zap.Error(err))
+	}
+
+	// 3. 修复 friend version（双向），保证 WKSDK 增量同步可见。
+	ba.fixFriendVersion(targetUID, robotID)
+	ba.fixFriendVersion(robotID, targetUID)
+
+	// 4. 通知双端同步好友列表。
+	cmdParam := map[string]interface{}{
+		"to_uid":   targetUID,
+		"from_uid": robotID,
+	}
+	if spaceID != "" {
+		cmdParam["space_id"] = spaceID
+	}
+	_ = ba.ctx.SendCMD(config.MsgCMDReq{
+		CMD:         common.CMDFriendAccept,
+		Subscribers: []string{targetUID, robotID},
+		Param:       cmdParam,
+	})
+
+	c.ResponseOK()
+}
+
+// fixFriendVersion 修复好友 version=0（WKSDK 增量同步需要 version>0）。
+// 复刻 botfather/command.go 的同名逻辑；best-effort，失败仅 warn 不阻断。
+func (ba *BotAPI) fixFriendVersion(uid, toUID string) {
+	var maxVer int64
+	if err := ba.db.session.SelectBySql(
+		"SELECT IFNULL(MAX(version),0) FROM friend WHERE uid=?", uid,
+	).LoadOne(&maxVer); err != nil {
+		ba.Warn("ensureFriend 查询好友最大version失败", zap.Error(err))
+		return
+	}
+	if _, err := ba.db.session.UpdateBySql(
+		"UPDATE friend SET version=? WHERE uid=? AND to_uid=? AND version=0", maxVer+1, uid, toUID,
+	).Exec(); err != nil {
+		ba.Warn("ensureFriend 更新好友version失败", zap.Error(err))
+	}
+}

--- a/modules/bot_api/ensure_friend_test.go
+++ b/modules/bot_api/ensure_friend_test.go
@@ -1,21 +1,30 @@
 // Package bot_api - OCT-5 PR#483 review: security tests for POST /v1/bot/ensureFriend.
+//
+// PR#483 Boss 定稿后的状态：
+//   - summary bot UID 改为固定常量 summary_notification（pkg/space.SummaryNotificationBotUID，
+//     同时在 SystemBots 中）。SummaryBotUID() 返回该常量，不再读 env。
+//   - ensureFriend 不再为 summary bot 插 space_member 行（step4 narrow path）。DM 的
+//     Space 归属靠发送路径 X-Space-ID 头 + isBotSpaceAuthorized 的 IsSystemBot 分支解析，
+//     bot 无 space_member 行 → 无 Space 能力面 / 不污染 member_count。
 package bot_api
 
 import (
 	"net/http"
-	"os"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	pkgspace "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 const (
-	efSummaryBotUID   = "u_summary_assistant"
+	// 固定常量 UID（单一真源）。
+	efSummaryBotUID   = pkgspace.SummaryNotificationBotUID
 	efSummaryBotToken = "bf_summary_ensure_friend_token"
 	efOtherBotUID     = "u_other_bot"
 	efOtherBotToken   = "bf_other_bot_token"
@@ -70,7 +79,6 @@ func friendExists(t *testing.T, ctx *config.Context, uid, toUID string) bool {
 }
 
 func TestEnsureFriend_SummaryBotMember_OK(t *testing.T) {
-	t.Setenv("SUMMARY_BOT_UID", efSummaryBotUID)
 	handler, ctx := setupEnsureFriendEnv(t)
 
 	w := doBot(handler, botReq(t, "POST", "/v1/bot/ensureFriend", efSummaryBotToken,
@@ -82,7 +90,6 @@ func TestEnsureFriend_SummaryBotMember_OK(t *testing.T) {
 }
 
 func TestEnsureFriend_SummaryBotMember_Idempotent(t *testing.T) {
-	t.Setenv("SUMMARY_BOT_UID", efSummaryBotUID)
 	handler, _ := setupEnsureFriendEnv(t)
 
 	for i := 0; i < 3; i++ {
@@ -93,7 +100,6 @@ func TestEnsureFriend_SummaryBotMember_Idempotent(t *testing.T) {
 }
 
 func TestEnsureFriend_OtherBotForbidden(t *testing.T) {
-	t.Setenv("SUMMARY_BOT_UID", efSummaryBotUID)
 	handler, ctx := setupEnsureFriendEnv(t)
 
 	w := doBot(handler, botReq(t, "POST", "/v1/bot/ensureFriend", efOtherBotToken,
@@ -103,18 +109,7 @@ func TestEnsureFriend_OtherBotForbidden(t *testing.T) {
 	assert.False(t, friendExists(t, ctx, efOtherBotUID, efTargetUID), "rejected bot must not create a friend row")
 }
 
-func TestEnsureFriend_UnconfiguredForbidden(t *testing.T) {
-	require.NoError(t, os.Unsetenv("SUMMARY_BOT_UID"))
-	handler, _ := setupEnsureFriendEnv(t)
-
-	w := doBot(handler, botReq(t, "POST", "/v1/bot/ensureFriend", efSummaryBotToken,
-		map[string]interface{}{"target_uid": efTargetUID, "space_id": efSpaceID}))
-	assert.Equalf(t, http.StatusForbidden, w.Code, "body: %s", w.Body.String())
-	assert.Contains(t, w.Body.String(), "not allowed to ensure friendships")
-}
-
 func TestEnsureFriend_NonSpaceMemberForbidden(t *testing.T) {
-	t.Setenv("SUMMARY_BOT_UID", efSummaryBotUID)
 	handler, ctx := setupEnsureFriendEnv(t)
 
 	w := doBot(handler, botReq(t, "POST", "/v1/bot/ensureFriend", efSummaryBotToken,
@@ -124,13 +119,12 @@ func TestEnsureFriend_NonSpaceMemberForbidden(t *testing.T) {
 	assert.False(t, friendExists(t, ctx, efSummaryBotUID, efOutsiderUID), "non-member must not be force-friended")
 }
 
-// TestEnsureFriend_E2E_SpaceMemberLanded 闭环 PR#483 Jerry-Xin 提的 🔴 blocker：
-// ensureFriend(space_id) 通过 target 成员校验后，必须为 summary bot 在该 Space
-// 落下 space_member 行（role=0 最小权限，status=1 active）。这是后续
-// /v1/bot/sendMessage 的 resolveBotActiveSpaceID 能解析到权威 Space 上下文的
-// 唯一前提（querySpaceIDsByRobotID 走的就是这张表）。
-func TestEnsureFriend_E2E_SpaceMemberLanded(t *testing.T) {
-	t.Setenv("SUMMARY_BOT_UID", efSummaryBotUID)
+// TestEnsureFriend_E2E_NoSpaceMemberRowLanded 闭环 PR#483 Boss 定稿（step4 narrow path）：
+// ensureFriend(space_id) 通过 target 成员校验后，**绝不能**为 summary bot 落 space_member
+// 行。reviewer 的 🔴 P1 正是：插真实 space_member 行让 bot 获得 Space 能力面 + 污染
+// member_count（member_count 是裸 COUNT，不走 SystemBots 过滤）。本测试是该 blocker 修复
+// 的负向不变量守卫。
+func TestEnsureFriend_E2E_NoSpaceMemberRowLanded(t *testing.T) {
 	handler, ctx := setupEnsureFriendEnv(t)
 
 	w := doBot(handler, botReq(t, "POST", "/v1/bot/ensureFriend", efSummaryBotToken,
@@ -139,11 +133,11 @@ func TestEnsureFriend_E2E_SpaceMemberLanded(t *testing.T) {
 
 	var count int
 	err := ctx.DB().SelectBySql(
-		"SELECT COUNT(*) FROM space_member WHERE space_id=? AND uid=? AND status=1",
+		"SELECT COUNT(*) FROM space_member WHERE space_id=? AND uid=?",
 		efSpaceID, efSummaryBotUID,
 	).LoadOne(&count)
 	require.NoError(t, err)
-	assert.Equal(t, 1, count, "summary bot must have a space_member row in the ensureFriend-validated Space (PR#483 blocker fix)")
+	assert.Equal(t, 0, count, "summary bot must NOT get a space_member row (PR#483 step4 narrow path: no Space capability surface, no member_count pollution)")
 
 	// target 行不受影响（ensureFriend 不动 user 的 space_member）。
 	err = ctx.DB().SelectBySql(
@@ -152,84 +146,144 @@ func TestEnsureFriend_E2E_SpaceMemberLanded(t *testing.T) {
 	).LoadOne(&count)
 	require.NoError(t, err)
 	assert.Equal(t, 1, count, "target user's pre-existing space_member row must remain untouched")
-
-	// PR#483 Jerry-Xin 提的契约（B1）：space_member 落库后 isBotSpaceAuthorized
-	// 必须直接对 (summary_bot, space) 返回 true —— 这是 X-Space-ID 头被采纳的前置
-	// 条件，也是 send 路径"载 payload.space_id 之前要查的那一步"。
-	db := newBotAPIDB(ctx)
-	authorized, err := db.isBotSpaceAuthorized(efSummaryBotUID, efSpaceID)
-	require.NoError(t, err)
-	assert.True(t, authorized, "isBotSpaceAuthorized must return true for the summary bot after ensureFriend lands the space_member row (PR#483 B1 contract)")
 }
 
-// TestEnsureFriend_E2E_SpaceMemberIdempotent 重复 ensureFriend 不重复插入也不
-// 把已被运维移除的成员行复活（INSERT IGNORE 语义）。
-func TestEnsureFriend_E2E_SpaceMemberIdempotent(t *testing.T) {
-	t.Setenv("SUMMARY_BOT_UID", efSummaryBotUID)
-	handler, ctx := setupEnsureFriendEnv(t)
+// TestEnsureFriend_E2E_SystemBotDMAuthorizedBoundToRecipient 是 PR#483 第二轮
+// BLOCKING 修复的核心不变量守卫：summary bot 没有 space_member 行，但
+// isBotSpaceAuthorized 对 person-channel(DM) 的授权额外要求**接收人是该 Space
+// 的活跃成员**（CheckMembership）。
+//
+//   - 接收人在 spaceA → 带 X-Space-ID=spaceA 授权（DM 不丢 Space 归属）；
+//   - 接收人不在 spaceB（但 spaceB active）→ 带 X-Space-ID=spaceB **不授权**
+//     （杜绝跨 Space DM 归属注入 — reviewer 🔴 BLOCKING）。
+func TestEnsureFriend_E2E_SystemBotDMAuthorizedBoundToRecipient(t *testing.T) {
+	_, ctx := setupEnsureFriendEnv(t)
 
-	for i := 0; i < 3; i++ {
-		w := doBot(handler, botReq(t, "POST", "/v1/bot/ensureFriend", efSummaryBotToken,
-			map[string]interface{}{"target_uid": efTargetUID, "space_id": efSpaceID}))
-		require.Equalf(t, http.StatusOK, w.Code, "call %d body: %s", i, w.Body.String())
-	}
+	db := newBotAPIDB(ctx)
 
+	// 无 space_member 行（summary bot 本身）
 	var count int
-	err := ctx.DB().SelectBySql(
-		"SELECT COUNT(*) FROM space_member WHERE space_id=? AND uid=?",
-		efSpaceID, efSummaryBotUID,
-	).LoadOne(&count)
+	require.NoError(t, ctx.DB().SelectBySql(
+		"SELECT COUNT(*) FROM space_member WHERE space_id=? AND uid=?", efSpaceID, efSummaryBotUID,
+	).LoadOne(&count))
+	require.Equal(t, 0, count, "precondition: summary bot has no space_member row")
+
+	// efTargetUID 是 efSpaceID 的活跃成员（setupEnsureFriendEnv 已插入）。
+	// 发给 target、带 X-Space-ID=efSpaceID、person channel → 授权。
+	authorized, err := db.isBotSpaceAuthorized(efSummaryBotUID, efSpaceID, efTargetUID, common.ChannelTypePerson.Uint8())
 	require.NoError(t, err)
-	assert.Equal(t, 1, count, "repeated ensureFriend calls must not duplicate the summary bot's space_member row")
+	assert.True(t, authorized, "system bot DM to a recipient who IS a member of the claimed active Space must be authorized (DM keeps correct Space attribution)")
+
+	// 跨 Space 注入漏洞的核心负向用例：另一个 active Space（spaceB），但 target
+	// 不是 spaceB 成员 → 带 X-Space-ID=spaceB 发给 target **不**能授权。
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO `space` (space_id, name, status, version) VALUES (?, ?, 1, 1)",
+		"space_other_active_ef", "other active space").Exec()
+	require.NoError(t, err)
+	crossSpaceAuthorized, err := db.isBotSpaceAuthorized(efSummaryBotUID, "space_other_active_ef", efTargetUID, common.ChannelTypePerson.Uint8())
+	require.NoError(t, err)
+	assert.False(t, crossSpaceAuthorized, "🔴 BLOCKING: system bot DM must NOT be authorized to inject an active Space the recipient is NOT a member of (cross-Space DM attribution injection)")
+
+	// 接收人不在该 Space（outsider，也不在任何 Space）→ 带 X-Space-ID=efSpaceID 不授权。
+	outsiderAuthorized, err := db.isBotSpaceAuthorized(efSummaryBotUID, efSpaceID, efOutsiderUID, common.ChannelTypePerson.Uint8())
+	require.NoError(t, err)
+	assert.False(t, outsiderAuthorized, "system bot DM to a non-member recipient must NOT be authorized even if the claimed Space is active")
+
+	// 非活跃 Space → 不授权（防越权到 disabled Space；CheckMembership 自身校 active）。
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO `space` (space_id, name, status, version) VALUES (?, ?, 0, 1)",
+		"space_disabled_ef", "disabled").Exec()
+	require.NoError(t, err)
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO space_member (space_id, uid, role, status, version) VALUES (?, ?, 0, 1, 1)",
+		"space_disabled_ef", efTargetUID).Exec()
+	require.NoError(t, err)
+	authorizedDisabled, err := db.isBotSpaceAuthorized(efSummaryBotUID, "space_disabled_ef", efTargetUID, common.ChannelTypePerson.Uint8())
+	require.NoError(t, err)
+	assert.False(t, authorizedDisabled, "system bot must NOT be authorized into a disabled (status=0) Space even when the recipient has a space_member row there")
+
+	// 非 person channel（群）：维持原 active 校验（不绑定接收人）。
+	groupAuthorized, err := db.isBotSpaceAuthorized(efSummaryBotUID, efSpaceID, "", common.ChannelTypeGroup.Uint8())
+	require.NoError(t, err)
+	assert.True(t, groupAuthorized, "non-person channel keeps the original active-Space authorization for system bots")
 }
 
 // TestEnsureFriend_E2E_SendPathPreservesAuthoritativeSpaceID is the contract test
-// Jerry-Xin asked for: ensureFriend(space_id) followed by the bot_api send-path
-// space-injection helpers MUST preserve the authoritative space_id, instead of
-// stripping it because the summary bot has no app_bot row and (before this fix)
-// no space_member row either.
+// Jerry-Xin asked for, updated for the step4 narrow path: ensureFriend(space_id)
+// followed by the bot_api send-path space-injection helpers MUST preserve the
+// authoritative space_id on the X-Space-ID header path, even though the summary
+// bot has NO space_member row (the row was removed in step4). DM keeps its Space
+// attribution via the IsSystemBot authorization branch.
 //
-// We exercise the real resolver + enricher on a real DB session (no stubs) so
-// the test fails exactly the way production would have: stripped payload →
-// missing Space attribution. Both paths are checked:
-//   - X-Space-ID header → isBotSpaceAuthorized (uses space_member query 1)
-//   - no header → querySpaceIDsByRobotID fallback
+// Note: the no-header bare-send fallback (querySpaceIDsByRobotID) now resolves
+// "" for the summary bot (no space_member row) and therefore strips — this is
+// acceptable because smart-summary's only send shape carries the X-Space-ID
+// header (SpaceID from SummaryTask.SpaceID). See report step4 for the rationale.
 func TestEnsureFriend_E2E_SendPathPreservesAuthoritativeSpaceID(t *testing.T) {
-	t.Setenv("SUMMARY_BOT_UID", efSummaryBotUID)
 	handler, ctx := setupEnsureFriendEnv(t)
 
 	w := doBot(handler, botReq(t, "POST", "/v1/bot/ensureFriend", efSummaryBotToken,
 		map[string]interface{}{"target_uid": efTargetUID, "space_id": efSpaceID}))
 	require.Equalf(t, http.StatusOK, w.Code, "ensureFriend pre-step body: %s", w.Body.String())
 
-	// Build a real BotAPI bound to the same test DB so resolveBotActiveSpaceID
-	// and enrichBotPayloadWithSpaceID exercise production SQL — not a fake.
 	ba := &BotAPI{
 		ctx: ctx,
 		db:  newBotAPIDB(ctx),
 		Log: log.NewTLog("BotAPI-ef-e2e"),
 	}
 
-	// Path A: X-Space-ID header (the most likely smart-summary send shape).
+	// Path A: X-Space-ID header (the smart-summary send shape) — honored via the
+	// IsSystemBot DM authorization branch because the recipient (efTargetUID) IS
+	// a member of efSpaceID, even though the summary bot has no space_member row.
 	cHeader := fakeWkContextWithHeader("X-Space-ID", efSpaceID)
-	gotHeader := ba.resolveBotActiveSpaceID(cHeader, efSummaryBotUID)
+	gotHeader := ba.resolveBotActiveSpaceID(cHeader, efSummaryBotUID, efTargetUID, common.ChannelTypePerson.Uint8())
 	assert.Equalf(t, efSpaceID, gotHeader,
-		"X-Space-ID header path must be honored after ensureFriend lands the space_member row (PR#483 blocker)")
+		"X-Space-ID header path must be honored for a system bot DM when the recipient is a member (PR#483 step4 narrow path + BLOCKING recipient binding)")
 
 	payloadHeader := map[string]interface{}{"content": "hi", "space_id": "spaceForged"}
-	enrichedHeader := ba.enrichBotPayloadWithSpaceID(cHeader, efSummaryBotUID, payloadHeader)
+	enrichedHeader := ba.enrichBotPayloadWithSpaceID(cHeader, efSummaryBotUID, efTargetUID, common.ChannelTypePerson.Uint8(), payloadHeader)
 	assert.Equalf(t, efSpaceID, enrichedHeader["space_id"],
 		"enrich must overwrite any client-supplied space_id with the server-authoritative one")
-
-	// Path B: no header → fallback to querySpaceIDsByRobotID (the bare send path).
-	cNoHeader := fakeWkContext()
-	gotFallback := ba.resolveBotActiveSpaceID(cNoHeader, efSummaryBotUID)
-	assert.Equalf(t, efSpaceID, gotFallback,
-		"DB fallback path must also resolve the Space after ensureFriend lands the space_member row")
-
-	payloadFallback := map[string]interface{}{"content": "hi"}
-	enrichedFallback := ba.enrichBotPayloadWithSpaceID(cNoHeader, efSummaryBotUID, payloadFallback)
-	assert.Equalf(t, efSpaceID, enrichedFallback["space_id"],
-		"enrich must inject the resolved Space on the no-header path (no fail-closed strip)")
 }
 
+// TestEnsureFriend_E2E_CrossSpaceDMAttributionInjectionBlocked 是 PR#483 第二轮
+// 🔴 BLOCKING 的端到端负向守卫（跨 Space DM 归属注入）：
+//
+// 场景：userA 在 spaceA；spaceB active 但 userA 不在 spaceB。攻击者让
+// summary_notification 带 X-Space-ID=spaceB 发 DM 给 userA，并在 payload 里伪造
+// space_id。修复前：isBotSpaceAuthorized 系统 bot 分支只校 spaceB active → 采纳
+// header → userA 的私信被错误归属到 spaceB。修复后：person channel 额外要求
+// CheckMembership(spaceB, userA)=true，userA 不在 spaceB → header 不被采纳 →
+// fall through 到 deterministic DB query（summary bot 无 space_member 行 → ""）→
+// enrich strip（fail-closed），绝不注入 spaceB。
+func TestEnsureFriend_E2E_CrossSpaceDMAttributionInjectionBlocked(t *testing.T) {
+	_, ctx := setupEnsureFriendEnv(t)
+
+	// spaceB active，但 efTargetUID(userA) 不是其成员。
+	const spaceB = "space_b_cross_inject_ef"
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `space` (space_id, name, status, version) VALUES (?, ?, 1, 1)",
+		spaceB, "space B active").Exec()
+	require.NoError(t, err)
+
+	ba := &BotAPI{
+		ctx: ctx,
+		db:  newBotAPIDB(ctx),
+		Log: log.NewTLog("BotAPI-ef-cross"),
+	}
+
+	// 带 X-Space-ID=spaceB 发给 userA（person channel，channel_id=userA）。
+	cHeader := fakeWkContextWithHeader("X-Space-ID", spaceB)
+	got := ba.resolveBotActiveSpaceID(cHeader, efSummaryBotUID, efTargetUID, common.ChannelTypePerson.Uint8())
+	assert.NotEqualf(t, spaceB, got,
+		"🔴 BLOCKING: cross-Space DM attribution injection — X-Space-ID=spaceB must NOT be honored for a DM to a recipient who is not a spaceB member")
+	assert.Equalf(t, "", got,
+		"summary bot has no space_member row, so after rejecting the forged header the resolver must fall through to \"\" (fail-closed strip)")
+
+	// enrich 必须 strip 任何 client 伪造的 space_id，绝不注入 spaceB。
+	payload := map[string]interface{}{"content": "hi", "space_id": spaceB}
+	enriched := ba.enrichBotPayloadWithSpaceID(cHeader, efSummaryBotUID, efTargetUID, common.ChannelTypePerson.Uint8(), payload)
+	_, ok := enriched["space_id"]
+	assert.Falsef(t, ok,
+		"🔴 BLOCKING: payload.space_id must be stripped (not set to spaceB) when the DM recipient is not a member of the claimed Space")
+}

--- a/modules/bot_api/ensure_friend_test.go
+++ b/modules/bot_api/ensure_friend_test.go
@@ -1,0 +1,124 @@
+// Package bot_api - OCT-5 PR#483 review: security tests for POST /v1/bot/ensureFriend.
+package bot_api
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	efSummaryBotUID   = "u_summary_assistant"
+	efSummaryBotToken = "bf_summary_ensure_friend_token"
+	efOtherBotUID     = "u_other_bot"
+	efOtherBotToken   = "bf_other_bot_token"
+	efCreatorUID      = "u_ef_creator"
+	efTargetUID       = "u_ef_target"
+	efOutsiderUID     = "u_ef_outsider"
+	efSpaceID         = "space_ef_1"
+)
+
+func setupEnsureFriendEnv(t *testing.T) (http.Handler, *config.Context) {
+	t.Helper()
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, status, creator_uid, bot_token, version) VALUES (?, 1, ?, ?, 1)",
+		efSummaryBotUID, efCreatorUID, efSummaryBotToken).Exec()
+	require.NoError(t, err)
+
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, status, creator_uid, bot_token, version) VALUES (?, 1, ?, ?, 1)",
+		efOtherBotUID, efCreatorUID, efOtherBotToken).Exec()
+	require.NoError(t, err)
+
+	for _, uid := range []string{efTargetUID, efOutsiderUID, efSummaryBotUID, efOtherBotUID} {
+		_, err = ctx.DB().InsertBySql(
+			"INSERT INTO `user` (uid, name, username, short_no, vercode, version) VALUES (?, ?, ?, ?, ?, 1)",
+			uid, uid, uid, uid, util.GenerUUID()).Exec()
+		require.NoError(t, err)
+	}
+
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO `space` (space_id, name, status, version) VALUES (?, ?, 1, 1)",
+		efSpaceID, "ensure friend space").Exec()
+	require.NoError(t, err)
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO space_member (space_id, uid, role, status, version) VALUES (?, ?, 0, 1, 1)",
+		efSpaceID, efTargetUID).Exec()
+	require.NoError(t, err)
+
+	return s.GetRoute(), ctx
+}
+
+func friendExists(t *testing.T, ctx *config.Context, uid, toUID string) bool {
+	t.Helper()
+	var count int
+	err := ctx.DB().SelectBySql(
+		"SELECT COUNT(*) FROM friend WHERE uid=? AND to_uid=? AND is_deleted=0", uid, toUID,
+	).LoadOne(&count)
+	require.NoError(t, err)
+	return count > 0
+}
+
+func TestEnsureFriend_SummaryBotMember_OK(t *testing.T) {
+	t.Setenv("SUMMARY_BOT_UID", efSummaryBotUID)
+	handler, ctx := setupEnsureFriendEnv(t)
+
+	w := doBot(handler, botReq(t, "POST", "/v1/bot/ensureFriend", efSummaryBotToken,
+		map[string]interface{}{"target_uid": efTargetUID, "space_id": efSpaceID}))
+	require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	assert.True(t, friendExists(t, ctx, efTargetUID, efSummaryBotUID), "user->bot friend row must exist")
+	assert.True(t, friendExists(t, ctx, efSummaryBotUID, efTargetUID), "bot->user friend row must exist")
+}
+
+func TestEnsureFriend_SummaryBotMember_Idempotent(t *testing.T) {
+	t.Setenv("SUMMARY_BOT_UID", efSummaryBotUID)
+	handler, _ := setupEnsureFriendEnv(t)
+
+	for i := 0; i < 3; i++ {
+		w := doBot(handler, botReq(t, "POST", "/v1/bot/ensureFriend", efSummaryBotToken,
+			map[string]interface{}{"target_uid": efTargetUID, "space_id": efSpaceID}))
+		require.Equalf(t, http.StatusOK, w.Code, "call %d body: %s", i, w.Body.String())
+	}
+}
+
+func TestEnsureFriend_OtherBotForbidden(t *testing.T) {
+	t.Setenv("SUMMARY_BOT_UID", efSummaryBotUID)
+	handler, ctx := setupEnsureFriendEnv(t)
+
+	w := doBot(handler, botReq(t, "POST", "/v1/bot/ensureFriend", efOtherBotToken,
+		map[string]interface{}{"target_uid": efTargetUID, "space_id": efSpaceID}))
+	assert.Equalf(t, http.StatusForbidden, w.Code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "not allowed to ensure friendships")
+	assert.False(t, friendExists(t, ctx, efOtherBotUID, efTargetUID), "rejected bot must not create a friend row")
+}
+
+func TestEnsureFriend_UnconfiguredForbidden(t *testing.T) {
+	require.NoError(t, os.Unsetenv("SUMMARY_BOT_UID"))
+	handler, _ := setupEnsureFriendEnv(t)
+
+	w := doBot(handler, botReq(t, "POST", "/v1/bot/ensureFriend", efSummaryBotToken,
+		map[string]interface{}{"target_uid": efTargetUID, "space_id": efSpaceID}))
+	assert.Equalf(t, http.StatusForbidden, w.Code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "not allowed to ensure friendships")
+}
+
+func TestEnsureFriend_NonSpaceMemberForbidden(t *testing.T) {
+	t.Setenv("SUMMARY_BOT_UID", efSummaryBotUID)
+	handler, ctx := setupEnsureFriendEnv(t)
+
+	w := doBot(handler, botReq(t, "POST", "/v1/bot/ensureFriend", efSummaryBotToken,
+		map[string]interface{}{"target_uid": efOutsiderUID, "space_id": efSpaceID}))
+	assert.Equalf(t, http.StatusForbidden, w.Code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "Not a member of this space")
+	assert.False(t, friendExists(t, ctx, efSummaryBotUID, efOutsiderUID), "non-member must not be force-friended")
+}

--- a/modules/bot_api/ensure_friend_test.go
+++ b/modules/bot_api/ensure_friend_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	"github.com/stretchr/testify/assert"
@@ -122,3 +123,105 @@ func TestEnsureFriend_NonSpaceMemberForbidden(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "Not a member of this space")
 	assert.False(t, friendExists(t, ctx, efSummaryBotUID, efOutsiderUID), "non-member must not be force-friended")
 }
+
+// TestEnsureFriend_E2E_SpaceMemberLanded 闭环 PR#483 Jerry-Xin 提的 🔴 blocker：
+// ensureFriend(space_id) 通过 target 成员校验后，必须为 summary bot 在该 Space
+// 落下 space_member 行（role=0 最小权限，status=1 active）。这是后续
+// /v1/bot/sendMessage 的 resolveBotActiveSpaceID 能解析到权威 Space 上下文的
+// 唯一前提（querySpaceIDsByRobotID 走的就是这张表）。
+func TestEnsureFriend_E2E_SpaceMemberLanded(t *testing.T) {
+	t.Setenv("SUMMARY_BOT_UID", efSummaryBotUID)
+	handler, ctx := setupEnsureFriendEnv(t)
+
+	w := doBot(handler, botReq(t, "POST", "/v1/bot/ensureFriend", efSummaryBotToken,
+		map[string]interface{}{"target_uid": efTargetUID, "space_id": efSpaceID}))
+	require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var count int
+	err := ctx.DB().SelectBySql(
+		"SELECT COUNT(*) FROM space_member WHERE space_id=? AND uid=? AND status=1",
+		efSpaceID, efSummaryBotUID,
+	).LoadOne(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "summary bot must have a space_member row in the ensureFriend-validated Space (PR#483 blocker fix)")
+
+	// target 行不受影响（ensureFriend 不动 user 的 space_member）。
+	err = ctx.DB().SelectBySql(
+		"SELECT COUNT(*) FROM space_member WHERE space_id=? AND uid=? AND status=1",
+		efSpaceID, efTargetUID,
+	).LoadOne(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "target user's pre-existing space_member row must remain untouched")
+}
+
+// TestEnsureFriend_E2E_SpaceMemberIdempotent 重复 ensureFriend 不重复插入也不
+// 把已被运维移除的成员行复活（INSERT IGNORE 语义）。
+func TestEnsureFriend_E2E_SpaceMemberIdempotent(t *testing.T) {
+	t.Setenv("SUMMARY_BOT_UID", efSummaryBotUID)
+	handler, ctx := setupEnsureFriendEnv(t)
+
+	for i := 0; i < 3; i++ {
+		w := doBot(handler, botReq(t, "POST", "/v1/bot/ensureFriend", efSummaryBotToken,
+			map[string]interface{}{"target_uid": efTargetUID, "space_id": efSpaceID}))
+		require.Equalf(t, http.StatusOK, w.Code, "call %d body: %s", i, w.Body.String())
+	}
+
+	var count int
+	err := ctx.DB().SelectBySql(
+		"SELECT COUNT(*) FROM space_member WHERE space_id=? AND uid=?",
+		efSpaceID, efSummaryBotUID,
+	).LoadOne(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "repeated ensureFriend calls must not duplicate the summary bot's space_member row")
+}
+
+// TestEnsureFriend_E2E_SendPathPreservesAuthoritativeSpaceID is the contract test
+// Jerry-Xin asked for: ensureFriend(space_id) followed by the bot_api send-path
+// space-injection helpers MUST preserve the authoritative space_id, instead of
+// stripping it because the summary bot has no app_bot row and (before this fix)
+// no space_member row either.
+//
+// We exercise the real resolver + enricher on a real DB session (no stubs) so
+// the test fails exactly the way production would have: stripped payload →
+// missing Space attribution. Both paths are checked:
+//   - X-Space-ID header → isBotSpaceAuthorized (uses space_member query 1)
+//   - no header → querySpaceIDsByRobotID fallback
+func TestEnsureFriend_E2E_SendPathPreservesAuthoritativeSpaceID(t *testing.T) {
+	t.Setenv("SUMMARY_BOT_UID", efSummaryBotUID)
+	handler, ctx := setupEnsureFriendEnv(t)
+
+	w := doBot(handler, botReq(t, "POST", "/v1/bot/ensureFriend", efSummaryBotToken,
+		map[string]interface{}{"target_uid": efTargetUID, "space_id": efSpaceID}))
+	require.Equalf(t, http.StatusOK, w.Code, "ensureFriend pre-step body: %s", w.Body.String())
+
+	// Build a real BotAPI bound to the same test DB so resolveBotActiveSpaceID
+	// and enrichBotPayloadWithSpaceID exercise production SQL — not a fake.
+	ba := &BotAPI{
+		ctx: ctx,
+		db:  newBotAPIDB(ctx),
+		Log: log.NewTLog("BotAPI-ef-e2e"),
+	}
+
+	// Path A: X-Space-ID header (the most likely smart-summary send shape).
+	cHeader := fakeWkContextWithHeader("X-Space-ID", efSpaceID)
+	gotHeader := ba.resolveBotActiveSpaceID(cHeader, efSummaryBotUID)
+	assert.Equalf(t, efSpaceID, gotHeader,
+		"X-Space-ID header path must be honored after ensureFriend lands the space_member row (PR#483 blocker)")
+
+	payloadHeader := map[string]interface{}{"content": "hi", "space_id": "spaceForged"}
+	enrichedHeader := ba.enrichBotPayloadWithSpaceID(cHeader, efSummaryBotUID, payloadHeader)
+	assert.Equalf(t, efSpaceID, enrichedHeader["space_id"],
+		"enrich must overwrite any client-supplied space_id with the server-authoritative one")
+
+	// Path B: no header → fallback to querySpaceIDsByRobotID (the bare send path).
+	cNoHeader := fakeWkContext()
+	gotFallback := ba.resolveBotActiveSpaceID(cNoHeader, efSummaryBotUID)
+	assert.Equalf(t, efSpaceID, gotFallback,
+		"DB fallback path must also resolve the Space after ensureFriend lands the space_member row")
+
+	payloadFallback := map[string]interface{}{"content": "hi"}
+	enrichedFallback := ba.enrichBotPayloadWithSpaceID(cNoHeader, efSummaryBotUID, payloadFallback)
+	assert.Equalf(t, efSpaceID, enrichedFallback["space_id"],
+		"enrich must inject the resolved Space on the no-header path (no fail-closed strip)")
+}
+

--- a/modules/bot_api/ensure_friend_test.go
+++ b/modules/bot_api/ensure_friend_test.go
@@ -152,6 +152,14 @@ func TestEnsureFriend_E2E_SpaceMemberLanded(t *testing.T) {
 	).LoadOne(&count)
 	require.NoError(t, err)
 	assert.Equal(t, 1, count, "target user's pre-existing space_member row must remain untouched")
+
+	// PR#483 Jerry-Xin 提的契约（B1）：space_member 落库后 isBotSpaceAuthorized
+	// 必须直接对 (summary_bot, space) 返回 true —— 这是 X-Space-ID 头被采纳的前置
+	// 条件，也是 send 路径"载 payload.space_id 之前要查的那一步"。
+	db := newBotAPIDB(ctx)
+	authorized, err := db.isBotSpaceAuthorized(efSummaryBotUID, efSpaceID)
+	require.NoError(t, err)
+	assert.True(t, authorized, "isBotSpaceAuthorized must return true for the summary bot after ensureFriend lands the space_member row (PR#483 B1 contract)")
 }
 
 // TestEnsureFriend_E2E_SpaceMemberIdempotent 重复 ensureFriend 不重复插入也不

--- a/modules/bot_api/groups.go
+++ b/modules/bot_api/groups.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	pkgspace "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"github.com/gin-gonic/gin"
 	"github.com/gocraft/dbr/v2"
 	"go.uber.org/zap"
@@ -288,6 +289,18 @@ func (ba *BotAPI) botSpaceMembers(c *wkhttp.Context) {
 	robotID := getRobotIDFromContext(c)
 	if robotID == "" {
 		ba.respondBotAPIIdentityMissing(c)
+		return
+	}
+
+	// PR#483 (OCT-5) 能力门 A — 显式排除系统 bot。SystemBots 静态过滤不覆盖这个
+	// 查 space_member 存在性的枚举门：下面按 robotID 的 space_member 行来获得枚举
+	// 权限，如果系统 bot 某天被插了 space_member 行（或历史遗留）就会越权枚举。
+	// 语义上：通知类系统 bot（如 summary_notification）不需要枚举 Space 成员，直接
+	// 返回空列表（不报错，与“未加入任何 Space”的现有语义一致）。用 IsSystemBot
+	// 作单一真源判定。
+	if pkgspace.IsSystemBot(robotID) {
+		ba.Warn("botSpaceMembers 系统 bot 枚举被拒（不给 Space 能力面）", zap.String("robot_id", robotID))
+		c.JSON(http.StatusOK, []struct{}{})
 		return
 	}
 

--- a/modules/bot_api/groups_systembot_gate_test.go
+++ b/modules/bot_api/groups_systembot_gate_test.go
@@ -1,0 +1,62 @@
+// Package bot_api — PR#483 (OCT-5) 能力门 A 测试：GET /v1/bot/space/members 对系统 bot
+// （如 summary_notification）必须拒绝枚举 Space 成员，即使该 bot 有 space_member 行。
+package bot_api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	pkgspace "github.com/Mininglamp-OSS/octo-server/pkg/space"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBotSpaceMembers_SystemBotEnumerationDenied(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	const (
+		sysBotUID   = pkgspace.SummaryNotificationBotUID // summary_notification (system bot)
+		sysBotToken = "bf_systembot_gateA_token"
+		spaceID     = "space_gateA_1"
+		memberUID   = "u_gateA_member"
+	)
+
+	// 系统 bot 的 robot 行。
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, status, creator_uid, bot_token, version) VALUES (?, 1, ?, ?, 1)",
+		sysBotUID, "u_gateA_creator", sysBotToken).Exec()
+	require.NoError(t, err)
+
+	for _, uid := range []string{sysBotUID, memberUID} {
+		_, err = ctx.DB().InsertBySql(
+			"INSERT INTO `user` (uid, name, username, short_no, vercode, version) VALUES (?, ?, ?, ?, ?, 1)",
+			uid, uid, uid, uid, util.GenerUUID()).Exec()
+		require.NoError(t, err)
+	}
+
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO `space` (space_id, name, status, version) VALUES (?, ?, 1, 1)",
+		spaceID, "gateA space").Exec()
+	require.NoError(t, err)
+	// 关键：即使系统 bot + 一个真实成员都有 space_member 行……
+	for _, uid := range []string{sysBotUID, memberUID} {
+		_, err = ctx.DB().InsertBySql(
+			"INSERT INTO space_member (space_id, uid, role, status, version) VALUES (?, ?, 0, 1, 1)",
+			spaceID, uid).Exec()
+		require.NoError(t, err)
+	}
+
+	handler := s.GetRoute()
+
+	// 系统 bot 调用枚举：必须返回空列表（被能力门 A 拒绝），不得据 space_member 行枚举出成员。
+	w := doBot(handler, botReq(t, "GET", "/v1/bot/space/members?space_id="+spaceID, sysBotToken, nil))
+	require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var members []map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &members))
+	assert.Empty(t, members, "system bot must NOT be able to enumerate Space members even with a space_member row (PR#483 gate A)")
+}

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -35,6 +35,14 @@ type BotSendMessageReq struct {
 	// preserves legacy behavior (FromUID = robotID). See RFC §5.1 / §5.2.
 	OnBehalfOf string                 `json:"on_behalf_of,omitempty"`
 	Payload    map[string]interface{} `json:"payload"`
+	// SyncOnce — PR#483 (OCT-5) 「PC 看不到」修复。默认 bot 消息 MsgHeader.SyncOnce=0
+	// （读扩散），PC / 多端 / 离线看不到。可选透传：请求显式带 sync_once 时用
+	// 请求值，否则保持现状默认（SyncOnce=0）。语义（引用 octo-lib config/msg.go
+	// MsgHeader）：sync_once=1=写扩散（多端可见），sync_once=0=读扩散。用指针
+	// 区分“未传”与“显式传 0”：nil 保持默认，不改变其它 bot 的默认行为。
+	// 只有显式传 1 才写扩散。worker 侧传 sync_once=1 是 #113（另一个仓）的事，本
+	// 任务不动 worker。
+	SyncOnce *int `json:"sync_once,omitempty"`
 }
 
 // sendMessage handles POST /v1/bot/sendMessage.
@@ -185,7 +193,10 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 	// 是部署时确定的，与 grantor 的 Space 归属解耦。
 	payload := req.Payload
 	if req.ChannelType == common.ChannelTypePerson.Uint8() {
-		payload = ba.enrichBotPayloadWithSpaceID(c, robotID, payload)
+		// PR#483 第二轮 BLOCKING: person channel 的 channel_id 就是接收人 uid。
+		// 传给 enrich 后系统 bot 的 X-Space-ID 采纳会额外要求 CheckMembership(
+		// space, 接收人)，杜绝跨 Space DM 归属注入。
+		payload = ba.enrichBotPayloadWithSpaceID(c, robotID, req.ChannelID, req.ChannelType, payload)
 	}
 
 	// YUJ-202 / Mininglamp-OSS#94 / #142 — mention pass-through
@@ -251,6 +262,14 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 		ChannelType: req.ChannelType,
 		FromUID:     fromUID,
 		Payload:     []byte(util.ToJson(wirePayload)),
+	}
+	// PR#483 (OCT-5) 「PC 看不到」修复 — header.sync_once 透传。根因：bot 消息
+	// MsgHeader.SyncOnce=0（读扩散），PC / 多端 / 离线看不到。若请求显式带
+	// sync_once（指针非 nil）则采用请求值；否则保持上面默认（SyncOnce=0）。
+	// **绝不改变其它 bot 的默认行为** — 默认仍 0，只有显式传 1 才写扩散。
+	// sync_once=1=写扩散（多端可见），语义参见 octo-lib config/msg.go MsgHeader。
+	if req.SyncOnce != nil {
+		msgReq.Header.SyncOnce = *req.SyncOnce
 	}
 	result, err := ba.dispatchMsgSendReq(msgReq)
 	if err != nil {

--- a/modules/bot_api/send_synconce_test.go
+++ b/modules/bot_api/send_synconce_test.go
@@ -1,0 +1,95 @@
+// Package bot_api — PR#483 (OCT-5) send.go header.sync_once 透传测试。
+//
+// 根因：bot 消息 MsgHeader.SyncOnce=0（读扩散），PC/多端/离线看不到。本测试验证：
+//   - 显式传 sync_once=1 → 派发的 MsgHeader.SyncOnce=1（写扩散，多端可见）；
+//   - 不传 sync_once → 派发的 MsgHeader.SyncOnce=0（默认不变，不影响其它 bot）；
+//   - 显式传 sync_once=0 → 仍为 0（指针区分“未传”与“显式传 0”）。
+package bot_api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runSendForSyncOnce(t *testing.T, body []byte) *dispatchCapture {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	const (
+		botRobotID = "bot_synconce"
+		creatorUID = "user_creator_synconce"
+	)
+
+	dc := &dispatchCapture{}
+	q := &fakeSpaceQuerier{defaultSpace: "space_A"}
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-synconce"),
+		spaceQuerier:     q,
+		dispatchOverride: dc.hook,
+	}
+
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/bot/sendMessage", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httpReq
+	c := &wkhttp.Context{Context: gc}
+	c.Set(CtxKeyRobotID, botRobotID)
+	c.Set(CtxKeyBotKind, BotKindUser)
+	c.Set(CtxKeyRobot, &robotModel{RobotID: botRobotID, CreatorUID: creatorUID})
+
+	ba.sendMessage(c)
+	require.Equalf(t, http.StatusOK, rec.Code, "sendMessage should respond 200 OK, got %d body=%s", rec.Code, rec.Body.String())
+
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	require.NotNil(t, dc.captured, "dispatch hook must have been invoked")
+	return dc
+}
+
+func TestSendMessage_SyncOnce_ExplicitOne_WritesFanout(t *testing.T) {
+	one := 1
+	body, _ := json.Marshal(BotSendMessageReq{
+		ChannelID:   "user_creator_synconce",
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		SyncOnce:    &one,
+		Payload:     map[string]interface{}{"content": "hi", "type": 1},
+	})
+	dc := runSendForSyncOnce(t, body)
+	assert.Equal(t, 1, dc.captured.Header.SyncOnce,
+		"explicit sync_once=1 MUST set MsgHeader.SyncOnce=1 (写扩散，多端可见)")
+}
+
+func TestSendMessage_SyncOnce_Absent_DefaultsToZero(t *testing.T) {
+	body, _ := json.Marshal(BotSendMessageReq{
+		ChannelID:   "user_creator_synconce",
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Payload:     map[string]interface{}{"content": "hi", "type": 1},
+	})
+	dc := runSendForSyncOnce(t, body)
+	assert.Equal(t, 0, dc.captured.Header.SyncOnce,
+		"absent sync_once MUST keep MsgHeader.SyncOnce=0 (默认不变，不影响其它 bot)")
+}
+
+func TestSendMessage_SyncOnce_ExplicitZero_StaysZero(t *testing.T) {
+	zero := 0
+	body, _ := json.Marshal(BotSendMessageReq{
+		ChannelID:   "user_creator_synconce",
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		SyncOnce:    &zero,
+		Payload:     map[string]interface{}{"content": "hi", "type": 1},
+	})
+	dc := runSendForSyncOnce(t, body)
+	assert.Equal(t, 0, dc.captured.Header.SyncOnce,
+		"explicit sync_once=0 stays 0 (读扩散)")
+}

--- a/modules/bot_api/space_inject.go
+++ b/modules/bot_api/space_inject.go
@@ -67,7 +67,10 @@ import (
 type botSpaceQuerier interface {
 	querySpaceIDByRobotID(robotID string) (string, error)
 	querySpaceIDsByRobotID(robotID string) (string, []string, error)
-	isBotSpaceAuthorized(robotID, spaceID string) (bool, error)
+	// isBotSpaceAuthorized — PR#483 第二轮 BLOCKING: 增加 recipientUID +
+	// channelType，让系统 bot 的 person-channel(DM) 授权绑定接收人是否属于
+	// header 声称的 Space（CheckMembership），杜绝跨 Space DM 归属注入。
+	isBotSpaceAuthorized(robotID, spaceID, recipientUID string, channelType uint8) (bool, error)
 }
 
 // enrichBotPayloadWithSpaceID 在 PERSONAL DM 派发前用 Bot 的权威 SpaceID 覆盖
@@ -76,11 +79,13 @@ type botSpaceQuerier interface {
 // YUJ-660 R3 Finding A — 当 resolver 返回 "" 时 fail-closed strip：删除任何
 // client 上送的 payload["space_id"]，并发监控 warn。这是 bot_api 层独立的 strip
 // 语义，不能依赖 message 层的 senderSpaceID="" strip（bot_api 不走 sendMsg）。
-func (ba *BotAPI) enrichBotPayloadWithSpaceID(c *wkhttp.Context, robotID string, payload map[string]interface{}) map[string]interface{} {
+// PR#483 第二轮 BLOCKING: recipientUID + channelType 用于将系统 bot 的 DM
+// X-Space-ID 授权绑定到接收人（见 resolveBotActiveSpaceID / isBotSpaceAuthorized）。
+func (ba *BotAPI) enrichBotPayloadWithSpaceID(c *wkhttp.Context, robotID, recipientUID string, channelType uint8, payload map[string]interface{}) map[string]interface{} {
 	if payload == nil {
 		payload = make(map[string]interface{})
 	}
-	spaceID := ba.resolveBotActiveSpaceID(c, robotID)
+	spaceID := ba.resolveBotActiveSpaceID(c, robotID, recipientUID, channelType)
 	if spaceID != "" {
 		payload["space_id"] = spaceID
 		return payload
@@ -126,7 +131,11 @@ func (ba *BotAPI) enrichBotPayloadWithSpaceID(c *wkhttp.Context, robotID string,
 //     `multi_space_membership=true` warn 让运维定位需要走 Option B 的 Bot。
 //
 // querier 默认是 ba.db；测试可通过 ba.spaceQuerier 注入 stub。
-func (ba *BotAPI) resolveBotActiveSpaceID(c *wkhttp.Context, robotID string) string {
+// PR#483 第二轮 BLOCKING: recipientUID + channelType 下透到 isBotSpaceAuthorized，
+// 让系统 bot 的 person-channel(DM) X-Space-ID 采纳额外要求 CheckMembership(spaceID,
+// recipientUID)=true。接收人不在该 Space → header 不被采纳，fall through 到
+// deterministic DB query（系统 bot 无 space_member 行 → 返回 "" → 调用方 strip）。
+func (ba *BotAPI) resolveBotActiveSpaceID(c *wkhttp.Context, robotID, recipientUID string, channelType uint8) string {
 	// (1) authAppBot 写入的 CtxKeyAppBotSpaceID（仅 App Bot scope=space）
 	if scope, _ := c.Get(CtxKeyAppBotScope); scope == "space" {
 		if v, ok := c.Get(CtxKeyAppBotSpaceID); ok {
@@ -152,7 +161,7 @@ func (ba *BotAPI) resolveBotActiveSpaceID(c *wkhttp.Context, robotID string) str
 	// rejected as non-member and emitted noisy reject warns.
 	if c != nil && c.Request != nil {
 		if hint := strings.TrimSpace(c.GetHeader("X-Space-ID")); hint != "" {
-			isAuthorized, err := q.isBotSpaceAuthorized(robotID, hint)
+			isAuthorized, err := q.isBotSpaceAuthorized(robotID, hint, recipientUID, channelType)
 			if err != nil {
 				ba.Warn("isBotSpaceAuthorized 失败，回退到 deterministic DB 查询",
 					zap.String("robotID", robotID), zap.String("hint", hint), zap.Error(err))

--- a/modules/bot_api/space_inject_multispace_test.go
+++ b/modules/bot_api/space_inject_multispace_test.go
@@ -45,8 +45,8 @@ func TestResolveBotActiveSpaceID_MultiSpace_NoHeader_DeterministicPrimary(t *tes
 	ba := newTestBotAPI(q)
 	c := fakeWkContext()
 
-	first := ba.resolveBotActiveSpaceID(c, "user_bot_2_spaces")
-	second := ba.resolveBotActiveSpaceID(c, "user_bot_2_spaces")
+	first := ba.resolveBotActiveSpaceID(c, "user_bot_2_spaces", "", 0)
+	second := ba.resolveBotActiveSpaceID(c, "user_bot_2_spaces", "", 0)
 
 	assert.Equal(t, "space_A", first,
 		"deterministic primary = earliest joined Space A")
@@ -69,10 +69,10 @@ func TestResolveBotActiveSpaceID_MultiSpace_HeaderHit_HeaderWins(t *testing.T) {
 	ba := newTestBotAPI(q)
 	c := fakeWkContextWithHeader("X-Space-ID", "space_B")
 
-	got := ba.resolveBotActiveSpaceID(c, "user_bot_2_spaces")
+	got := ba.resolveBotActiveSpaceID(c, "user_bot_2_spaces", "", 0)
 	assert.Equal(t, "space_B", got,
 		"X-Space-ID header should be honored when Bot is a member of that Space")
-	assert.Equal(t, []memberCall{{"user_bot_2_spaces", "space_B"}}, q.authCalls,
+	assert.Equal(t, []memberCall{{robotID: "user_bot_2_spaces", spaceID: "space_B"}}, q.authCalls,
 		"isBotSpaceAuthorized must be called with the header value to validate it")
 	// DB fallback should NOT have been called when header wins.
 	assert.Empty(t, q.calls,
@@ -95,10 +95,10 @@ func TestResolveBotActiveSpaceID_MultiSpace_HeaderMiss_FallsThrough(t *testing.T
 	ba := newTestBotAPI(q)
 	c := fakeWkContextWithHeader("X-Space-ID", "space_C")
 
-	got := ba.resolveBotActiveSpaceID(c, "user_bot_2_spaces")
+	got := ba.resolveBotActiveSpaceID(c, "user_bot_2_spaces", "", 0)
 	assert.Equal(t, "space_A", got,
 		"non-member header → fall through to deterministic primary (Space A)")
-	assert.Equal(t, []memberCall{{"user_bot_2_spaces", "space_C"}}, q.authCalls,
+	assert.Equal(t, []memberCall{{robotID: "user_bot_2_spaces", spaceID: "space_C"}}, q.authCalls,
 		"isBotSpaceAuthorized must still be called once to make the non-member decision")
 	assert.Equal(t, []string{"user_bot_2_spaces"}, q.calls,
 		"querySpaceIDByRobotID must be invoked (via querySpaceIDsByRobotID) on miss")
@@ -114,7 +114,7 @@ func TestResolveBotActiveSpaceID_AppBotScopeSpace_OutranksHeader(t *testing.T) {
 	c.Set(CtxKeyAppBotScope, "space")
 	c.Set(CtxKeyAppBotSpaceID, "space_authoritative")
 
-	got := ba.resolveBotActiveSpaceID(c, "app_bot_scope_space")
+	got := ba.resolveBotActiveSpaceID(c, "app_bot_scope_space", "", 0)
 	assert.Equal(t, "space_authoritative", got,
 		"App Bot scope=space ctx must outrank X-Space-ID header")
 	assert.Empty(t, q.authCalls,
@@ -146,13 +146,13 @@ func TestResolveBotActiveSpaceID_AppBotScopePlatform_HeaderHit(t *testing.T) {
 	c := fakeWkContextWithHeader("X-Space-ID", "space_B")
 	c.Set(CtxKeyAppBotScope, "platform") // not "space" → ctx fast-path skipped
 
-	got := ba.resolveBotActiveSpaceID(c, "app_bot_platform")
+	got := ba.resolveBotActiveSpaceID(c, "app_bot_platform", "", 0)
 	assert.Equal(t, "space_B", got,
 		"published platform App Bot must be authorized in any active Space, "+
 			"even when no space_member row exists (PR#43 R1 fix)")
 	assert.Empty(t, q.calls,
 		"DB fallback must not be reached when header is honored")
-	assert.Equal(t, []memberCall{{"app_bot_platform", "space_B"}}, q.authCalls,
+	assert.Equal(t, []memberCall{{robotID: "app_bot_platform", spaceID: "space_B"}}, q.authCalls,
 		"isBotSpaceAuthorized must be called once with the header value")
 }
 
@@ -173,11 +173,11 @@ func TestResolveBotActiveSpaceID_AppBotScopePlatform_HeaderForInactiveSpace_Fall
 	c := fakeWkContextWithHeader("X-Space-ID", "space_disabled")
 	c.Set(CtxKeyAppBotScope, "platform")
 
-	got := ba.resolveBotActiveSpaceID(c, "app_bot_platform")
+	got := ba.resolveBotActiveSpaceID(c, "app_bot_platform", "", 0)
 	assert.Equal(t, "space_A", got,
 		"inactive target Space must be rejected even for platform App Bots; "+
 			"resolver falls through to deterministic DB primary")
-	assert.Equal(t, []memberCall{{"app_bot_platform", "space_disabled"}}, q.authCalls,
+	assert.Equal(t, []memberCall{{robotID: "app_bot_platform", spaceID: "space_disabled"}}, q.authCalls,
 		"isBotSpaceAuthorized must still be called and return false for inactive Space")
 }
 
@@ -197,7 +197,7 @@ func TestResolveBotActiveSpaceID_AppBotScopeSpace_OwnSpaceAuthorized(t *testing.
 	// this combination is rare (authAppBot would normally set the ctx) but
 	// the validator must still fail-closed-correctly.
 
-	got := ba.resolveBotActiveSpaceID(c, "app_bot_scope_space")
+	got := ba.resolveBotActiveSpaceID(c, "app_bot_scope_space", "", 0)
 	assert.Equal(t, "space_own", got,
 		"scope=space App Bot dispatching into its own Space is authorized")
 }
@@ -215,7 +215,7 @@ func TestResolveBotActiveSpaceID_AppBotScopeSpace_DifferentSpaceRejected(t *test
 	ba := newTestBotAPI(q)
 	c := fakeWkContextWithHeader("X-Space-ID", "space_other")
 
-	got := ba.resolveBotActiveSpaceID(c, "app_bot_scope_space")
+	got := ba.resolveBotActiveSpaceID(c, "app_bot_scope_space", "", 0)
 	assert.Equal(t, "space_A", got,
 		"scope=space App Bot must NOT be authorized in a Space other than its own; "+
 			"resolver falls through to deterministic DB primary")
@@ -234,10 +234,10 @@ func TestResolveBotActiveSpaceID_HeaderWhitespaceTrimmed(t *testing.T) {
 	ba := newTestBotAPI(q)
 	c := fakeWkContextWithHeader("X-Space-ID", "  space_B  \r")
 
-	got := ba.resolveBotActiveSpaceID(c, "user_bot_2_spaces")
+	got := ba.resolveBotActiveSpaceID(c, "user_bot_2_spaces", "", 0)
 	assert.Equal(t, "space_B", got,
 		"X-Space-ID header value must be TrimSpace'd before validation")
-	assert.Equal(t, []memberCall{{"user_bot_2_spaces", "space_B"}}, q.authCalls,
+	assert.Equal(t, []memberCall{{robotID: "user_bot_2_spaces", spaceID: "space_B"}}, q.authCalls,
 		"isBotSpaceAuthorized must receive the trimmed value, not the raw header")
 }
 
@@ -247,7 +247,7 @@ func TestResolveBotActiveSpaceID_HeaderAllWhitespace_TreatedAsAbsent(t *testing.
 	ba := newTestBotAPI(q)
 	c := fakeWkContextWithHeader("X-Space-ID", "   ")
 
-	got := ba.resolveBotActiveSpaceID(c, "user_bot_x")
+	got := ba.resolveBotActiveSpaceID(c, "user_bot_x", "", 0)
 	assert.Equal(t, "space_A", got)
 	assert.Empty(t, q.authCalls,
 		"all-whitespace header must skip the validator entirely (treated as absent)")
@@ -267,7 +267,7 @@ func TestEnrichBotPayloadWithSpaceID_MultiSpace_NoHeader_DeterministicOverride(t
 	c := fakeWkContext()
 	payload := map[string]interface{}{"content": "hi", "space_id": "space_attacker"}
 
-	got := ba.enrichBotPayloadWithSpaceID(c, "user_bot_2_spaces", payload)
+	got := ba.enrichBotPayloadWithSpaceID(c, "user_bot_2_spaces", "", 0, payload)
 	assert.Equal(t, "space_A", got["space_id"],
 		"client-supplied forged space_id must be overridden by deterministic primary")
 }
@@ -290,7 +290,7 @@ func TestEnrichBotPayloadWithSpaceID_MultiSpace_HeaderHit_HeaderOverridesPrimary
 	c := fakeWkContextWithHeader("X-Space-ID", "space_B")
 	payload := map[string]interface{}{"content": "hi", "space_id": "space_attacker"}
 
-	got := ba.enrichBotPayloadWithSpaceID(c, "user_bot_2_spaces", payload)
+	got := ba.enrichBotPayloadWithSpaceID(c, "user_bot_2_spaces", "", 0, payload)
 	assert.Equal(t, "space_B", got["space_id"],
 		"valid X-Space-ID header must drive payload.space_id, overriding both client forge and DB primary")
 }
@@ -317,7 +317,7 @@ func TestEnrichBotPayloadWithSpaceID_AppBotScopePlatform_NoSpaceMember_HeaderWin
 	c.Set(CtxKeyAppBotScope, "platform")
 	payload := map[string]interface{}{"content": "hi", "space_id": "space_forged"}
 
-	got := ba.enrichBotPayloadWithSpaceID(c, "app_bot_platform_prod", payload)
+	got := ba.enrichBotPayloadWithSpaceID(c, "app_bot_platform_prod", "", 0, payload)
 	assert.Equal(t, "space_target", got["space_id"],
 		"platform App Bot with valid X-Space-ID must end up with space_target in payload "+
 			"(regression: previous validator stripped it because the bot wasn't in space_member)")

--- a/modules/bot_api/space_inject_test.go
+++ b/modules/bot_api/space_inject_test.go
@@ -51,12 +51,12 @@ type fakeSpaceQuerier struct {
 	//       `activeSpaces[spaceID] != false` → scope=space App Bot in own Space
 	// `activeSpaces` defaults to true for any spaceID not explicitly set to
 	// false, so tests that don't care about Space status can omit it.
-	memberships   map[string]map[string]bool
-	authCalls     []memberCall
-	authDefault   bool
-	authErr       error
-	appBots       map[string]appBotShape
-	activeSpaces  map[string]bool
+	memberships  map[string]map[string]bool
+	authCalls    []memberCall
+	authDefault  bool
+	authErr      error
+	appBots      map[string]appBotShape
+	activeSpaces map[string]bool
 }
 
 type appBotShape struct {
@@ -66,8 +66,10 @@ type appBotShape struct {
 }
 
 type memberCall struct {
-	robotID string
-	spaceID string
+	robotID      string
+	spaceID      string
+	recipientUID string
+	channelType  uint8
 }
 
 func (f *fakeSpaceQuerier) querySpaceIDByRobotID(robotID string) (string, error) {
@@ -100,8 +102,8 @@ func (f *fakeSpaceQuerier) querySpaceIDsByRobotID(robotID string) (string, []str
 // isBotSpaceAuthorized mirrors the production OR-of-three rule. Tests pick the
 // branch they want by populating `memberships` (User Bot path) or `appBots`
 // (App Bot platform / scope=space path). `activeSpaces` defaults to active.
-func (f *fakeSpaceQuerier) isBotSpaceAuthorized(robotID, spaceID string) (bool, error) {
-	f.authCalls = append(f.authCalls, memberCall{robotID: robotID, spaceID: spaceID})
+func (f *fakeSpaceQuerier) isBotSpaceAuthorized(robotID, spaceID, recipientUID string, channelType uint8) (bool, error) {
+	f.authCalls = append(f.authCalls, memberCall{robotID: robotID, spaceID: spaceID, recipientUID: recipientUID, channelType: channelType})
 	if f.authErr != nil {
 		return false, f.authErr
 	}
@@ -172,7 +174,7 @@ func TestResolveBotActiveSpaceID_AppBotScopeSpace_UsesCtxValue(t *testing.T) {
 	c := fakeWkContext()
 	c.Set(CtxKeyAppBotScope, "space")
 	c.Set(CtxKeyAppBotSpaceID, "spaceA")
-	got := ba.resolveBotActiveSpaceID(c, "bot_robot_1")
+	got := ba.resolveBotActiveSpaceID(c, "bot_robot_1", "", 0)
 	assert.Equal(t, "spaceA", got, "App Bot scope=space 应直接使用 ctx 写入的 SpaceID（无 DB）")
 }
 
@@ -184,7 +186,7 @@ func TestResolveBotActiveSpaceID_AppBotScopeSpace_MissingValueFallsBackToDB(t *t
 	c := fakeWkContext()
 	c.Set(CtxKeyAppBotScope, "space")
 	// CtxKeyAppBotSpaceID 故意不写入 → 必须 fallback 到 DB
-	got := ba.resolveBotActiveSpaceID(c, "bot_robot_2")
+	got := ba.resolveBotActiveSpaceID(c, "bot_robot_2", "", 0)
 	assert.Equal(t, "spaceFromDB", got)
 	assert.Equal(t, []string{"bot_robot_2"}, q.calls,
 		"scope=space 缺 SpaceID 时必须以 robotID fallback 调 querySpaceIDByRobotID")
@@ -195,7 +197,7 @@ func TestResolveBotActiveSpaceID_NonAppScope_UsesDB(t *testing.T) {
 	ba := newTestBotAPI(q)
 	c := fakeWkContext()
 	// scope 不是 "space"（User Bot 或 App Bot scope=platform）
-	got := ba.resolveBotActiveSpaceID(c, "user_bot_1")
+	got := ba.resolveBotActiveSpaceID(c, "user_bot_1", "", 0)
 	assert.Equal(t, "spaceUserBot", got)
 	assert.Equal(t, []string{"user_bot_1"}, q.calls)
 }
@@ -207,7 +209,7 @@ func TestResolveBotActiveSpaceID_DBErrNotFound_NoWarnNoSpace(t *testing.T) {
 	q := &fakeSpaceQuerier{defaultErr: dbr.ErrNotFound}
 	ba := newTestBotAPI(q)
 	c := fakeWkContext()
-	got := ba.resolveBotActiveSpaceID(c, "orphan_bot")
+	got := ba.resolveBotActiveSpaceID(c, "orphan_bot", "", 0)
 	assert.Equal(t, "", got, "ErrNotFound → 空 SpaceID")
 }
 
@@ -215,7 +217,7 @@ func TestResolveBotActiveSpaceID_DBRealError_ReturnsEmpty(t *testing.T) {
 	q := &fakeSpaceQuerier{defaultErr: errors.New("connection refused")}
 	ba := newTestBotAPI(q)
 	c := fakeWkContext()
-	got := ba.resolveBotActiveSpaceID(c, "bot_with_db_error")
+	got := ba.resolveBotActiveSpaceID(c, "bot_with_db_error", "", 0)
 	assert.Equal(t, "", got, "真实 DB 错误也返回 ''，让上层走 fail-open 不阻断发送")
 }
 
@@ -225,7 +227,7 @@ func TestEnrichBotPayloadWithSpaceID_AppBotScopeSpace_OverridesClient(t *testing
 	c.Set(CtxKeyAppBotScope, "space")
 	c.Set(CtxKeyAppBotSpaceID, "spaceAuth")
 	payload := map[string]interface{}{"content": "hi", "space_id": "spaceForged"}
-	got := ba.enrichBotPayloadWithSpaceID(c, "bot_robot_1", payload)
+	got := ba.enrichBotPayloadWithSpaceID(c, "bot_robot_1", "", 0, payload)
 	assert.Equal(t, "spaceAuth", got["space_id"], "PERSONAL 必须用服务端权威 SpaceID 覆盖客户端伪造值")
 }
 
@@ -234,7 +236,7 @@ func TestEnrichBotPayloadWithSpaceID_DBPathOverridesClient(t *testing.T) {
 	ba := newTestBotAPI(q)
 	c := fakeWkContext()
 	payload := map[string]interface{}{"content": "hi", "space_id": "spaceForged"}
-	got := ba.enrichBotPayloadWithSpaceID(c, "user_bot_1", payload)
+	got := ba.enrichBotPayloadWithSpaceID(c, "user_bot_1", "", 0, payload)
 	assert.Equal(t, "spaceDB", got["space_id"])
 }
 
@@ -247,7 +249,7 @@ func TestEnrichBotPayloadWithSpaceID_ErrNotFound_StripsClientSpaceID(t *testing.
 	ba := newTestBotAPI(q)
 	c := fakeWkContext()
 	payload := map[string]interface{}{"content": "hi", "space_id": "spaceForged"}
-	got := ba.enrichBotPayloadWithSpaceID(c, "orphan_bot", payload)
+	got := ba.enrichBotPayloadWithSpaceID(c, "orphan_bot", "", 0, payload)
 	_, ok := got["space_id"]
 	assert.False(t, ok,
 		"ErrNotFound + forged client space_id：bot_api 必须 strip，否则跨 Space 派发")
@@ -259,7 +261,7 @@ func TestEnrichBotPayloadWithSpaceID_OrphanBot_NoForgedClient_NoSpaceInjected(t 
 	ba := newTestBotAPI(q)
 	c := fakeWkContext()
 	payload := map[string]interface{}{"content": "hi"}
-	got := ba.enrichBotPayloadWithSpaceID(c, "orphan_bot", payload)
+	got := ba.enrichBotPayloadWithSpaceID(c, "orphan_bot", "", 0, payload)
 	_, ok := got["space_id"]
 	assert.False(t, ok)
 }
@@ -272,7 +274,7 @@ func TestEnrichBotPayloadWithSpaceID_RealDBError_StripsClientSpaceID(t *testing.
 	ba := newTestBotAPI(q)
 	c := fakeWkContext()
 	payload := map[string]interface{}{"content": "hi", "space_id": "spaceVictim"}
-	got := ba.enrichBotPayloadWithSpaceID(c, "bot_with_db_error", payload)
+	got := ba.enrichBotPayloadWithSpaceID(c, "bot_with_db_error", "", 0, payload)
 	_, ok := got["space_id"]
 	assert.False(t, ok,
 		"DB 错误 + forged client space_id：bot_api 必须 strip，否则攻击者借 DB blip 跨 Space 派发")
@@ -283,7 +285,7 @@ func TestEnrichBotPayloadWithSpaceID_NilPayloadInitialized(t *testing.T) {
 	c := fakeWkContext()
 	c.Set(CtxKeyAppBotScope, "space")
 	c.Set(CtxKeyAppBotSpaceID, "spaceAuth")
-	got := ba.enrichBotPayloadWithSpaceID(c, "bot_robot_1", nil)
+	got := ba.enrichBotPayloadWithSpaceID(c, "bot_robot_1", "", 0, nil)
 	assert.NotNil(t, got)
 	assert.Equal(t, "spaceAuth", got["space_id"])
 }

--- a/modules/group/create_group_systembot_gate_test.go
+++ b/modules/group/create_group_systembot_gate_test.go
@@ -1,0 +1,69 @@
+package group
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	pkgspace "github.com/Mininglamp-OSS/octo-server/pkg/space"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateGroup_SystemBotForbidden_NoSpace 守卫 PR#483 (OCT-5) 能力门 B（顶层兜底）：
+// 系统 bot（如 summary_notification）即使作为 BotUID 也不能建群，且不依赖 SpaceID。
+func TestCreateGroup_SystemBotForbidden_NoSpace(t *testing.T) {
+	svc, userDB := setupServiceTest(t)
+	botUID := pkgspace.SummaryNotificationBotUID
+	insertTestUsers(t, userDB, "gb_creator", "gb_m1", botUID)
+
+	_, err := svc.CreateGroup(&CreateGroupServiceReq{
+		Creator: "gb_creator",
+		Members: []string{"gb_m1"},
+		Name:    "sysbot group",
+		BotUID:  botUID,
+	})
+	require.Error(t, err, "system bot must not be allowed to create a group")
+	assert.Contains(t, err.Error(), "system bot is not allowed to create groups")
+}
+
+// TestCreateGroup_SystemBotForbidden_EvenWithSpaceMemberRow 是真正闭环 reviewer P1 的负向
+// 守卫：哪怕系统 bot 在 Space 里有 space_member 行（历史遗留 / 误操作），CheckMembership
+// 也不能让它据此建群——IsSystemBot 排除在 CheckMembership 之前生效。
+func TestCreateGroup_SystemBotForbidden_EvenWithSpaceMemberRow(t *testing.T) {
+	svc, userDB, ctx := setupServiceTestWithCtx(t)
+	botUID := pkgspace.SummaryNotificationBotUID
+	insertTestUsers(t, userDB, "gb2_creator", "gb2_m1", botUID)
+	// 给 bot 也插一条 space_member 行（模拟历史遗留），证明门不靠成员关系放行。
+	seedSpaceWithMembers(t, ctx, "space_gb2", "gb2_creator", "gb2_m1", botUID)
+
+	_, err := svc.CreateGroup(&CreateGroupServiceReq{
+		Creator: "gb2_creator",
+		Members: []string{"gb2_m1"},
+		Name:    "sysbot group with member row",
+		SpaceID: "space_gb2",
+		BotUID:  botUID,
+	})
+	require.Error(t, err, "system bot with a space_member row must STILL be rejected from creating a group")
+	assert.Contains(t, err.Error(), "system bot is not allowed to create groups")
+}
+
+// TestCreateGroup_NonSystemBotAllowed sanity：普通 bot 作为 BotUID 在其 Space 内仍可建群
+// （证明门只针对系统 bot，不误伤普通 User Bot）。
+func TestCreateGroup_NonSystemBotAllowed(t *testing.T) {
+	svc, userDB, ctx := setupServiceTestWithCtx(t)
+	botUID := "gb3_user_bot"
+	insertTestUsers(t, userDB, "gb3_creator", "gb3_m1", botUID)
+	seedSpaceWithMembers(t, ctx, "space_gb3", "gb3_creator", "gb3_m1", botUID)
+
+	resp, err := svc.CreateGroup(&CreateGroupServiceReq{
+		Creator: "gb3_creator",
+		Members: []string{"gb3_m1"},
+		Name:    "normal bot group",
+		SpaceID: "space_gb3",
+		BotUID:  botUID,
+	})
+	require.NoError(t, err, "a non-system bot that IS a space member must be allowed to create a group")
+	assert.NotEmpty(t, resp.GroupNo)
+
+	_ = user.Model{} // keep user import referenced if helpers change
+}

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -1033,6 +1033,14 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 	if len(req.Members) == 0 {
 		return nil, errors.New("members is required")
 	}
+	// PR#483 (OCT-5) 能力门 B（顶层兜底）— 系统 bot（如 summary_notification）不能
+	// 作为建群 bot。这里不依赖 req.SpaceID 是否为空：无论是否带 Space，都拒绝
+	// 把系统 bot 加为新群的 bot_admin。与下方 Space 分支里的 CheckMembership 门形成
+	// 双保险，避免单 Space / 无 Space 部署下绕过。
+	if req.BotUID != "" && spacepkg.IsSystemBot(req.BotUID) {
+		s.Warn("系统 bot 建群被拒（顶层兜底）", zap.String("bot_uid", req.BotUID))
+		return nil, errors.New("system bot is not allowed to create groups")
+	}
 
 	var skippedMembers []string
 	// 跨 Space 外部成员标识：key=uid, value=source_space_id（uid 的默认 Space）
@@ -1044,6 +1052,14 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 	if req.SpaceID != "" {
 		// 校验 Bot 是否属于目标 Space
 		if req.BotUID != "" {
+			// PR#483 (OCT-5) 能力门 B — 显式排除系统 bot 建群。即使系统 bot（如
+			// summary_notification）因历史遗留或误操作而拥有 space_member 行，也不能
+			// 据此通过 CheckMembership 获得建群能力。通知类系统 bot 根本不应走建群
+			// 路径。用 spacepkg.IsSystemBot 作单一真源判定（与 groups.go 能力门 A 对称）。
+			if spacepkg.IsSystemBot(req.BotUID) {
+				s.Warn("系统 bot 建群被拒（不给 Space 建群能力面）", zap.String("bot_uid", req.BotUID))
+				return nil, errors.New("system bot is not allowed to create groups")
+			}
 			botOk, err := spacepkg.CheckMembership(s.ctx.DB(), req.SpaceID, req.BotUID)
 			if err != nil {
 				s.Error("check bot space membership failed", zap.Error(err))

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -301,10 +301,11 @@ func (rb *Robot) Route(r *wkhttp.WKHttp) {
 		rb.Error("初始化系统机器人失败", zap.Error(err))
 	}
 
-	// OCT-5: 自举独立的"总结助手"账号（幂等；未配置 SUMMARY_BOT_* 时静默跳过）。
-	if err := rb.insertSummaryRobot(); err != nil {
-		rb.Error("初始化总结助手失败", zap.Error(err))
-	}
+	// OCT-5 / PR#483 第二轮 🟡 MAJOR：「总结助手」(summary_notification) 现在是固定
+	// 常量 + 迁移拥有的系统 bot（user 行 / robot 行 / 固定 bot_token 全由迁移
+	// modules/robot/sql/20260629000001_summary_notification_bot.sql 写死）。运行时
+	// 不再做 env 驱动的自举/reconcile —— 旧的 insertSummaryRobot() 会用 stale env
+	// 覆盖迁移写死的 token，破坏鉴权。故此处不再调用任何 summary bot 自举。
 }
 
 func (rb *Robot) streamStart(c *wkhttp.Context) {

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -300,6 +300,11 @@ func (rb *Robot) Route(r *wkhttp.WKHttp) {
 	if err := rb.insertSystemRobot(); err != nil {
 		rb.Error("初始化系统机器人失败", zap.Error(err))
 	}
+
+	// OCT-5: 自举独立的"总结助手"账号（幂等；未配置 SUMMARY_BOT_* 时静默跳过）。
+	if err := rb.insertSummaryRobot(); err != nil {
+		rb.Error("初始化总结助手失败", zap.Error(err))
+	}
 }
 
 func (rb *Robot) streamStart(c *wkhttp.Context) {

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -301,11 +301,18 @@ func (rb *Robot) Route(r *wkhttp.WKHttp) {
 		rb.Error("初始化系统机器人失败", zap.Error(err))
 	}
 
-	// OCT-5 / PR#483 第二轮 🟡 MAJOR：「总结助手」(summary_notification) 现在是固定
-	// 常量 + 迁移拥有的系统 bot（user 行 / robot 行 / 固定 bot_token 全由迁移
-	// modules/robot/sql/20260629000001_summary_notification_bot.sql 写死）。运行时
-	// 不再做 env 驱动的自举/reconcile —— 旧的 insertSummaryRobot() 会用 stale env
-	// 覆盖迁移写死的 token，破坏鉴权。故此处不再调用任何 summary bot 自举。
+	// OCT-5 / PR#483 方案 D（共享 DB + 启动自动生成 token）：「总结助手」
+	// (summary_notification) 是固定 UID 的系统 bot，user 行 / robot 行 由迁移
+	// modules/robot/sql/20260629000001_summary_notification_bot.sql 插入，但
+	// bot_token 不写死在迁移里（避免公开仓库明文凭据）。运行时不再做 env
+	// 驱动的自举/reconcile（旧的 insertSummaryRobot() 会用 stale env 覆盖 token，
+	// 破坏鉴权）。故此处不再调用任何 env 驱动的 summary bot 自举。
+
+	// OCT-5 / 方案 D（共享 DB）：迁移不写死明文 bot_token（避免公开仓库明文
+	// 凭据）；改为 server 首次启动时自动生成强随机 token 写回 robot 表，smart-summary
+	// 在投递时从共享 IM 库 lazy SELECT 该 token 鉴权。幂等且并发安全（见
+	// ensureSummaryBotToken 注释）；失败只 log 不 panic，不阻断启动。
+	rb.ensureSummaryBotToken()
 }
 
 func (rb *Robot) streamStart(c *wkhttp.Context) {

--- a/modules/robot/db.go
+++ b/modules/robot/db.go
@@ -131,6 +131,27 @@ func (d *robotDB) queryRobotByBotToken(botToken string) (*robot, error) {
 	return m, err
 }
 
+// queryBotTokenByRobotID 读取指定机器人的 bot_token（可能为空串）。
+// 用于 server 启动时的 ensureSummaryBotToken 自举判定（OCT-5 / 方案 D）。
+func (d *robotDB) queryBotTokenByRobotID(robotID string) (string, error) {
+	var botToken string
+	err := d.session.Select("IFNULL(bot_token,'')").From("robot").Where("robot_id=?", robotID).LoadOne(&botToken)
+	return botToken, err
+}
+
+// updateRobotBotTokenIfEmpty 仅当 bot_token 为空（'' 或 NULL）时写入 newToken。
+// WHERE 的空值条件让多实例并发启动时只有一个 UPDATE 生效（幂等、防覆盖已生成的
+// 非空 token）。返回受影响行数：1=本实例写入成功，0=已有非空 token（被他人抢先或本就有）。
+func (d *robotDB) updateRobotBotTokenIfEmpty(robotID string, newToken string) (int64, error) {
+	res, err := d.session.Update("robot").SetMap(map[string]interface{}{
+		"bot_token": newToken,
+	}).Where("robot_id=? AND (bot_token='' OR bot_token IS NULL)", robotID).Exec()
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
 // updateRobotBotToken 重置机器人的Bot Token
 func (d *robotDB) updateRobotBotToken(robotID string, newToken string) error {
 	_, err := d.session.Update("robot").SetMap(map[string]interface{}{

--- a/modules/robot/sql/20260629000001_summary_notification_bot.sql
+++ b/modules/robot/sql/20260629000001_summary_notification_bot.sql
@@ -1,0 +1,51 @@
+-- +migrate Up
+-- PR#483 (OCT-5) — 固定常量化 summary bot 自举。
+--
+-- 背景：智能总结的异步通知以「总结助手」身份发出。原方案走 env 驱动的动态 UID
+-- （SUMMARY_BOT_UID / SUMMARY_BOT_TOKEN）+ 运行时自举（modules/robot/summary_bot.go）。
+-- 三个 reviewer 一致卡 🔴 P1：动态 UID + ensureFriend 插真实 space_member 行会让 bot
+-- 顺带获得 Space 级能力、并污染 member_count / 名册 / @选择器。Boss 定稿方案改为：
+--   - 固定常量 UID = summary_notification（写进 pkg/space.SystemBots 静态常量）；
+--   - bot_token 写死进本迁移（不走 env 注入），命中 bot_api/auth.go 的 User Bot 分支
+--     （db.go queryRobotByBotToken 要求 bot_token!='' AND status=1）；
+--   - 不再依赖 space_member 行做能力/归属（见 ensure_friend.go 注释与 PR 报告 step4）。
+--
+-- 幂等：INSERT IGNORE，重复执行不报错（uid / robot_id 唯一索引命中即跳过）。
+
+-- user 行：robot=1 标记为机器人用户；status=1 可用；category=system 让统计/搜索按
+-- 系统账号处理（与 u_10000 / fileHelper 一致）。
+--
+-- short_no（PR#483 第二轮 🟢 MINOR 1 修复）：user.short_no 有 UNIQUE 索引。原值
+-- '20483' 是一个**未保留**的数字短号，可能已被真实用户占用 —— 那样 INSERT IGNORE
+-- 会静默跳过 user 行、但 robot 行仍插入，留下半残身份。系统账号 u_10000/fileHelper
+-- 用的是保留数字段（10000/20000），但本仓没有 summary bot 的保留数字段登记，无法保证
+-- 任意数字值不撞真实用户。因此这里改用 **UID 本身**（'summary_notification'）作 short_no：
+--   1. 唯一性：UID 全局唯一（user.uid 主键 / robot.robot_id 唯一），借用作 short_no
+--      天然唯一；
+--   2. 不撞真实用户：真实用户的 short_no 由 modules/user/service.go AddUser 走
+--      util.Ten2Hex(UnixNano())（纯 [0-9a-z] 数字/十六进制串）或 commonService
+--      .GetShortno()（数字短号）生成，**永远不含下划线**，而 'summary_notification'
+--      含 '_'，故二者值空间不相交；
+--   3. 稳定：固定常量，幂等重跑不变。
+-- （查询侧 modules/user/db.go 用 `short_no=? AND short_no<>''` 过滤空值，本值非空安全。）
+INSERT IGNORE INTO `user`
+  (uid, name, short_no, robot, category, status,
+   search_by_phone, search_by_short, new_msg_notice, voice_on, shock_on, msg_show_detail,
+   is_upload_avatar, `version`)
+VALUES
+  ('summary_notification', '总结助手', 'summary_notification', 1, 'system', 1,
+   0, 0, 0, 0, 0, 0,
+   0, 1);
+
+-- robot 行：bot_token 写死（bf_ 前缀，固定常量）；status=1 启用；username=uid。
+-- 其余列（app_id / description / im_token_cache / bot_commands / auto_approve / placeholder
+-- 等）走列默认值。
+INSERT IGNORE INTO `robot`
+  (robot_id, token, bot_token, username, status, `version`, creator_uid, description)
+VALUES
+  ('summary_notification', 'summary_notification', 'bf_7c7314e3734b17dfe6988b1d9031ea52',
+   'summary_notification', 1, 1, '', '智能总结通知助手（系统 bot，固定 UID）');
+
+-- +migrate Down
+DELETE FROM `robot` WHERE robot_id='summary_notification';
+DELETE FROM `user` WHERE uid='summary_notification';

--- a/modules/robot/sql/20260629000001_summary_notification_bot.sql
+++ b/modules/robot/sql/20260629000001_summary_notification_bot.sql
@@ -6,8 +6,14 @@
 -- 三个 reviewer 一致卡 🔴 P1：动态 UID + ensureFriend 插真实 space_member 行会让 bot
 -- 顺带获得 Space 级能力、并污染 member_count / 名册 / @选择器。Boss 定稿方案改为：
 --   - 固定常量 UID = summary_notification（写进 pkg/space.SystemBots 静态常量）；
---   - bot_token 写死进本迁移（不走 env 注入），命中 bot_api/auth.go 的 User Bot 分支
---     （db.go queryRobotByBotToken 要求 bot_token!='' AND status=1）；
+--   - bot_token **不再写死进本迁移**（公开仓库明文凭据风险，reviewer 卡 🔴）。本迁移
+--     只插入 user/robot 身份行，bot_token 留空串（''）。token 由 server 启动时
+--     **自动生成强随机值写回**（见 modules/robot/api.go ensureSummaryBotToken）：
+--     首启检测空 token → crypto/rand 生成 bf_ 前缀 token → 带空值条件 UPDATE 写库，
+--     幂等且并发安全。每部署唯一、源码零明文、运维零准备。
+--     smart-summary（共享同一 IM 库）启动时 SELECT 该 token 用于鉴权（方案 D）。
+--     命中 bot_api/auth.go 的 User Bot 分支（db.go queryRobotByBotToken 要求
+--     bot_token!='' AND status=1）—— 故空 token 时鉴权天然失败直到 server 写回。
 --   - 不再依赖 space_member 行做能力/归属（见 ensure_friend.go 注释与 PR 报告 step4）。
 --
 -- 幂等：INSERT IGNORE，重复执行不报错（uid / robot_id 唯一索引命中即跳过）。
@@ -37,13 +43,14 @@ VALUES
    0, 0, 0, 0, 0, 0,
    0, 1);
 
--- robot 行：bot_token 写死（bf_ 前缀，固定常量）；status=1 启用；username=uid。
--- 其余列（app_id / description / im_token_cache / bot_commands / auto_approve / placeholder
--- 等）走列默认值。
+-- robot 行：bot_token 留**空串 ''**（不写死明文凭据）；status=1 启用；username=uid。
+-- token 由 server 启动时 ensureSummaryBotToken() 自动生成强随机值并 UPDATE 写回
+-- （见 modules/robot/api.go）。其余列（app_id / description / im_token_cache /
+-- bot_commands / auto_approve / placeholder 等）走列默认值。
 INSERT IGNORE INTO `robot`
   (robot_id, token, bot_token, username, status, `version`, creator_uid, description)
 VALUES
-  ('summary_notification', 'summary_notification', 'bf_7c7314e3734b17dfe6988b1d9031ea52',
+  ('summary_notification', 'summary_notification', '',
    'summary_notification', 1, 1, '', '智能总结通知助手（系统 bot，固定 UID）');
 
 -- +migrate Down

--- a/modules/robot/summary_bot.go
+++ b/modules/robot/summary_bot.go
@@ -1,25 +1,33 @@
 package robot
 
 import (
+	"crypto/rand"
+	"encoding/hex"
+
 	pkgspace "github.com/Mininglamp-OSS/octo-server/pkg/space"
+	"go.uber.org/zap"
 )
 
-// 总结助手（Summary Assistant）专属账号 —— 固定常量化，迁移拥有。
+// 总结助手（Summary Assistant）专属账号 —— 固定 UID 系统 bot，token 启动自生成。
 //
-// 设计要点（PR#483 / OCT-5 Boss 定稿 + 第二轮 reviewer 🟡 MAJOR 收口）：
+// 设计要点（PR#483 / OCT-5 方案 D：共享 DB + 启动自动生成 token）：
 //   - 「总结助手」是固定 UID 的系统 bot（summary_notification，单一真源 =
 //     pkg/space.SummaryNotificationBotUID，同时登记在 SystemBots 中）。
-//   - bot 的 user 行 / robot 行 / 固定 bot_token 全部由迁移
-//     modules/robot/sql/20260629000001_summary_notification_bot.sql 写死并拥有。
-//   - **运行时不再做任何 env 驱动的自举 / reconcile / token 改写**。
+//   - bot 的 user 行 / robot 行 由迁移
+//     modules/robot/sql/20260629000001_summary_notification_bot.sql 插入；但
+//     **bot_token 不写死在迁移里**（避免在公开仓库写死明文凭据），迁移里
+//     bot_token 留空（''）。
+//   - token 改为 server **首次启动时自动生成强随机值并写回 robot 表**（见
+//     ensureSummaryBotToken，幂等 + 并发安全）；smart-summary（共享同一 IM 库）
+//     在投递时 lazy SELECT 该 token 用于鉴权。运维零准备、源码零明文、每部署唯一。
+//   - 运行时不再做 env 驱动的自举 / reconcile / token 改写（token 不依赖 env 状态）。
 //
-// 为什么删掉 env 自举（第二轮 reviewer 🟡 MAJOR）：
-//   原方案在 startup 调 insertSummaryRobot()，读 SUMMARY_BOT_UID / SUMMARY_BOT_TOKEN，
-//   若已存在则 reconcileSummaryRobot() 以 env 为准纠偏 bot_token。问题：固定常量化后
-//   bot_token 写死在迁移里；若旧部署仍带不同的 SUMMARY_BOT_TOKEN，reconcile 会**覆盖
-//   迁移写死的 token**，破坏鉴权（smart-summary 用迁移里的固定 token 调
-//   /v1/bot/sendMessage 会 401）。让鉴权依赖 stale env 状态与固定 token 设计自相矛盾。
-//   因此彻底移除运行时 env 自举/reconcile 路径，bot 完全由迁移拥有。
+// 为什么不再用 env 自举 / 不再把 token 写死迁移：
+//   早期方案在 startup 调 insertSummaryRobot()，读 SUMMARY_BOT_UID / SUMMARY_BOT_TOKEN，
+//   若已存在则 reconcileSummaryRobot() 以 env 为准纠偏 bot_token——会用 stale env
+//   覆盖已写入的 token，破坏鉴权。后来曾改为「迁移写死固定 token」，但那会在
+//   公开仓库暴露明文凭据。最终定稿为方案 D：迁移只插身份行、token 留空，
+//   由 server 启动自动生成写库，summary 共享 DB lazy 读取。
 //
 // 仍保留 SummaryBotUID()：被 bot_api 的 ensureFriend 端点引用做 UID 白名单门控
 // （仅放行这一个 UID），以及其它代码引用固定常量。
@@ -28,7 +36,74 @@ import (
 //
 // 单一真源 = pkg/space.SummaryNotificationBotUID（同时在 SystemBots 中）。供
 // bot_api 的 ensureFriend 端点做 UID 白名单门控（仅放行这一个 UID）。不读任何 env
-// —— 避免部署间 UID 漂移；bot 身份完全由迁移拥有。
+// —— 避免部署间 UID 漂移；bot 身份（UID）由迁移拥有，token 由 server 启动自生成。
 func SummaryBotUID() string {
 	return pkgspace.SummaryNotificationBotUID
+}
+
+// summaryBotTokenBytes 是自动生成的 bot_token 的随机字节数（32 字节 → 64 hex 字符）。
+const summaryBotTokenBytes = 32
+
+// summaryBotTokenPrefix 与历史固定 token 一致（bf_），命中 bot_api/auth.go 的 User Bot 分支。
+const summaryBotTokenPrefix = "bf_"
+
+// genSummaryBotToken 生成一个强随机 bot_token：bf_ 前缀 + 32 字节 crypto/rand 的 hex。
+// 纯函数（除随机源外无副作用），便于单测断言「非空 / 带前缀 / 每次不同」。
+func genSummaryBotToken() (string, error) {
+	b := make([]byte, summaryBotTokenBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return summaryBotTokenPrefix + hex.EncodeToString(b), nil
+}
+
+// ensureSummaryBotToken 在 server 启动时确保「总结助手」(summary_notification) 的
+// bot_token 已就绪（OCT-5 / 方案 D：共享 DB）。
+//
+// 背景：迁移 20260629000001_summary_notification_bot.sql 只插入 user/robot 身份行，
+// bot_token 留空（''）—— 避免在公开仓库写死明文凭据（reviewer 卡点）。token 改为
+// 由 server **首次启动时自动生成强随机值并写回 robot 表**；smart-summary（共享同一
+// IM 库）启动时 SELECT 该 token 用于鉴权。运维零准备、源码零明文、每部署唯一。
+//
+// 逻辑（幂等）：
+//  1. 查 robot 表 bot_token（where robot_id=summary_notification）；非空则跳过；
+//  2. 为空（''）时生成强随机 token，用带空值 WHERE 条件的 UPDATE 写回。
+//
+// 并发安全：多实例同时启动时，UPDATE 的 `WHERE bot_token='' OR bot_token IS NULL`
+// 保证只有第一个提交的 UPDATE 把空值改成非空、影响 1 行；其余实例的 UPDATE 命中
+// 0 行（WHERE 已不再匹配），不会覆盖已写入的 token。各自下一次启动复查也会看到非空
+// token 而跳过。无需额外锁。
+//
+// 失败只 log 不 panic（与 insertSystemRobot 失败处理一致）：token 暂缺只会让通知
+// 鉴权失败、降级为不发通知，不应阻断整个 server 启动。
+func (rb *Robot) ensureSummaryBotToken() {
+	robotID := pkgspace.SummaryNotificationBotUID
+
+	current, err := rb.db.queryBotTokenByRobotID(robotID)
+	if err != nil {
+		rb.Error("查询 summary bot token 失败", zap.String("robot_id", robotID), zap.Error(err))
+		return
+	}
+	if current != "" {
+		// 已有非空 token（迁移外或前次启动写入），幂等跳过。
+		return
+	}
+
+	token, err := genSummaryBotToken()
+	if err != nil {
+		rb.Error("生成 summary bot token 失败", zap.String("robot_id", robotID), zap.Error(err))
+		return
+	}
+
+	affected, err := rb.db.updateRobotBotTokenIfEmpty(robotID, token)
+	if err != nil {
+		rb.Error("写入 summary bot token 失败", zap.String("robot_id", robotID), zap.Error(err))
+		return
+	}
+	if affected == 0 {
+		// 并发场景：另一实例抢先写入了 token，本次 UPDATE 命中 0 行。属正常幂等结果。
+		rb.Info("summary bot token 已由其它实例写入，跳过", zap.String("robot_id", robotID))
+		return
+	}
+	rb.Info("summary bot token 已自动生成并写入", zap.String("robot_id", robotID))
 }

--- a/modules/robot/summary_bot.go
+++ b/modules/robot/summary_bot.go
@@ -1,0 +1,152 @@
+package robot
+
+import (
+	"os"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"go.uber.org/zap"
+)
+
+// 总结助手（Summary Assistant）专属账号自举。
+//
+// 设计要点（OCT-4 / OCT-5 已批准方案）：
+//   - 不复用 Account.SystemUID，而是新建一个独立的官方助手账号，让 octo-smart-summary
+//     的异步通知以这个助手身份发出（专属 name / avatar，与系统账号区分）。
+//   - 标识、显示名、头像、bot_token 全部从环境/密钥配置读取，不硬编码、不打印、不落日志。
+//   - bot_token 必须显式落库（bf_ 前缀，命中 bot_api/auth.go 的 User Bot 分支；
+//     db.go queryRobotByBotToken 要求 bot_token!='' AND status=1），否则 smart-summary
+//     拿 token 调 /v1/bot/sendMessage 会鉴权失败。
+//   - 幂等：重复启动无副作用。若 DB 已存在该 bot 但 bot_token 与配置不一致，以配置为准
+//     UPDATE 落库并 warn（不含 token 明文），避免配置漂移导致 token 长期不匹配。
+const (
+	// 环境变量键。部署方通过 env/secret 注入；缺省时自举静默跳过（不创建助手）。
+	EnvSummaryBotUID    = "SUMMARY_BOT_UID"
+	EnvSummaryBotName   = "SUMMARY_BOT_NAME"
+	EnvSummaryBotAvatar = "SUMMARY_BOT_AVATAR"
+	EnvSummaryBotToken  = "SUMMARY_BOT_TOKEN"
+
+	// 显示名兜底，仅在 SUMMARY_BOT_NAME 未配置时使用。
+	defaultSummaryBotName = "总结助手"
+)
+
+// summaryBotConfig 汇总从环境读取的总结助手配置。
+type summaryBotConfig struct {
+	UID    string
+	Name   string
+	Avatar string
+	Token  string // bot_token，bf_ 前缀
+}
+
+// loadSummaryBotConfig 从环境读取总结助手配置。
+// 仅当 UID 与 Token 同时存在时才视为"已启用"（enabled=true）；任一缺失则不自举。
+func loadSummaryBotConfig() (cfg summaryBotConfig, enabled bool) {
+	cfg = summaryBotConfig{
+		UID:    strings.TrimSpace(os.Getenv(EnvSummaryBotUID)),
+		Name:   strings.TrimSpace(os.Getenv(EnvSummaryBotName)),
+		Avatar: strings.TrimSpace(os.Getenv(EnvSummaryBotAvatar)),
+		Token:  strings.TrimSpace(os.Getenv(EnvSummaryBotToken)),
+	}
+	if cfg.Name == "" {
+		cfg.Name = defaultSummaryBotName
+	}
+	enabled = cfg.UID != "" && cfg.Token != ""
+	return cfg, enabled
+}
+
+// SummaryBotUID 返回配置中的总结助手 UID（未配置时为空串）。
+// 供 bot_api 的 ensureFriend 端点做 UID 白名单门控（仅放行这一个 UID）。
+func SummaryBotUID() string {
+	return strings.TrimSpace(os.Getenv(EnvSummaryBotUID))
+}
+
+// insertSummaryRobot 幂等地自举"总结助手"账号（user 行 + robot 行 + 显式 bot_token）。
+//
+// 与 insertSystemRobot 的范式对齐（事务 + GenSeq(RobotSeqKey) + Status=Enable +
+// Token=GenerUUID），但额外：
+//   - 创建对应的 user 账号（Robot=1），否则发送/好友链路缺少该 UID 的用户实体；
+//   - 必须显式落 bot_token；
+//   - 存在性检查后做配置防漂移（bot_token / status 不一致 → 以配置为准 UPDATE）。
+func (rb *Robot) insertSummaryRobot() error {
+	cfg, enabled := loadSummaryBotConfig()
+	if !enabled {
+		// 未配置总结助手 → 静默跳过，不影响其余 bot 初始化。
+		rb.Info("总结助手未配置（缺少 SUMMARY_BOT_UID / SUMMARY_BOT_TOKEN），跳过自举")
+		return nil
+	}
+
+	existing, err := rb.db.queryRobotWithRobtID(cfg.UID)
+	if err != nil {
+		rb.Error("查询总结助手机器人错误", zap.Error(err))
+		return err
+	}
+
+	if existing != nil {
+		// 已存在 → 配置防漂移：bot_token / status 以配置为准，落库纠偏（不打印 token 明文）。
+		return rb.reconcileSummaryRobot(cfg, existing)
+	}
+
+	// 不存在 → 创建 user 账号 + robot 行（含显式 bot_token）。
+	robotVersion, err := rb.ctx.GenSeq(common.RobotSeqKey)
+	if err != nil {
+		rb.Error("总结助手 GenSeq 失败", zap.Error(err))
+		return err
+	}
+
+	// 先建 user 账号（AddUser 自身是单条 Insert；Robot=1 标记为机器人用户）。
+	// 若 user 已存在（如此前部分初始化）AddUser 会因唯一键失败，这里容忍并继续建 robot 行，
+	// 以保证整体幂等。
+	if uerr := rb.userService.AddUser(&user.AddUserReq{
+		UID:      cfg.UID,
+		Name:     cfg.Name,
+		Username: cfg.UID,
+		Robot:    1,
+	}); uerr != nil {
+		rb.Warn("创建总结助手 user 账号失败（可能已存在），继续建 robot 行", zap.Error(uerr))
+	}
+
+	if err := rb.db.insert(&robot{
+		RobotID:  cfg.UID,
+		Username: cfg.UID,
+		Status:   int(Enable),
+		Token:    util.GenerUUID(),
+		BotToken: cfg.Token,
+		Version:  robotVersion,
+	}); err != nil {
+		rb.Error("添加总结助手 robot 行失败", zap.Error(err))
+		return err
+	}
+
+	rb.Info("总结助手自举完成", zap.String("uid", cfg.UID))
+	return nil
+}
+
+// reconcileSummaryRobot 已存在时的配置防漂移：以配置为准纠正 bot_token / status。
+// 不在日志中输出 bot_token 明文。
+func (rb *Robot) reconcileSummaryRobot(cfg summaryBotConfig, existing *robot) error {
+	fields := map[string]interface{}{}
+
+	if existing.BotToken != cfg.Token {
+		fields["bot_token"] = cfg.Token
+		rb.Warn("总结助手 bot_token 与配置不一致，以配置为准纠偏（token 不打印）",
+			zap.String("uid", cfg.UID))
+	}
+	// 助手必须可用：命中 bot_api User Bot 分支要求 status=1。
+	if existing.Status != int(Enable) {
+		fields["status"] = int(Enable)
+		rb.Warn("总结助手 status 非启用，纠正为启用", zap.String("uid", cfg.UID))
+	}
+
+	if len(fields) == 0 {
+		// 配置一致，无需改动。
+		return nil
+	}
+
+	if err := rb.db.updateRobotInfo(cfg.UID, fields); err != nil {
+		rb.Error("总结助手配置纠偏 UPDATE 失败", zap.Error(err))
+		return err
+	}
+	return nil
+}

--- a/modules/robot/summary_bot.go
+++ b/modules/robot/summary_bot.go
@@ -1,12 +1,18 @@
 package robot
 
 import (
+	"context"
+	"fmt"
+	"hash/crc32"
+	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/avatarversion"
 	"go.uber.org/zap"
 )
 
@@ -119,6 +125,12 @@ func (rb *Robot) insertSummaryRobot() error {
 		return err
 	}
 
+	// PR#483 review (Jerry-Xin + OctoBoooot 复核确认 🟡)：SUMMARY_BOT_AVATAR 在
+	// 之前的版本读了但没应用 —— 这一步把配置的 avatar URL 下载并落到对象存储，
+	// 同时把 user 表的 is_upload_avatar / avatar_version 标记好，后续 /users/{uid}/avatar
+	// 取头像能命中 octo 内置 avatar 字节流。best-effort：失败仅 warn，不阻断自举。
+	rb.applySummaryBotAvatar(cfg)
+
 	rb.Info("总结助手自举完成", zap.String("uid", cfg.UID))
 	return nil
 }
@@ -139,14 +151,66 @@ func (rb *Robot) reconcileSummaryRobot(cfg summaryBotConfig, existing *robot) er
 		rb.Warn("总结助手 status 非启用，纠正为启用", zap.String("uid", cfg.UID))
 	}
 
-	if len(fields) == 0 {
-		// 配置一致，无需改动。
-		return nil
+	if len(fields) != 0 {
+		if err := rb.db.updateRobotInfo(cfg.UID, fields); err != nil {
+			rb.Error("总结助手配置纠偏 UPDATE 失败", zap.Error(err))
+			return err
+		}
 	}
 
-	if err := rb.db.updateRobotInfo(cfg.UID, fields); err != nil {
-		rb.Error("总结助手配置纠偏 UPDATE 失败", zap.Error(err))
-		return err
-	}
+	// PR#483 review (Jerry-Xin 🟡)：reconcile 也以配置为准应用 avatar —— 漂移时
+	// （配置改了，部署重启）旧 avatar 会被替换。best-effort：失败仅 warn。
+	rb.applySummaryBotAvatar(cfg)
 	return nil
+}
+
+// applySummaryBotAvatar 把 cfg.Avatar（远程 URL）下载并落到 octo 头像对象存储，
+// 标记对应 user 行 is_upload_avatar=1 / avatar_version=<新版本>。avatar 路径
+// 沿用 modules/user/avatar_path.go 的 `avatar/{crc32(uid)%partition}/{uid}/{ver}.png`
+// 公式（与 api_github.go 创建用户走的同一路径），保证后续
+// /users/{uid}/avatar 取头像能命中。
+//
+// 失败语义：best-effort。任何一步出错（空配置、下载失败、上传失败、DB update 失败）
+// 只 warn，不影响 bot 自举主链路；漂移路径下次启动还会重试。
+func (rb *Robot) applySummaryBotAvatar(cfg summaryBotConfig) {
+	if strings.TrimSpace(cfg.Avatar) == "" {
+		return
+	}
+	downloadCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	imgReader, err := rb.fileService.DownloadImage(cfg.Avatar, downloadCtx)
+	if err != nil || imgReader == nil {
+		rb.Warn("总结助手 avatar 下载失败（best-effort，跳过）",
+			zap.String("uid", cfg.UID), zap.Error(err))
+		return
+	}
+	defer imgReader.Close()
+
+	avatarVersion := avatarversion.New()
+	partition := rb.ctx.GetConfig().Avatar.Partition
+	if partition <= 0 {
+		// 与 modules/user/avatar_path.go 一致的兜底（partition 必须 >0 取模）。
+		partition = 1
+	}
+	avatarID := crc32.ChecksumIEEE([]byte(cfg.UID)) % uint32(partition)
+	objPath := fmt.Sprintf("avatar/%d/%s/%d.png", avatarID, cfg.UID, avatarVersion)
+
+	if _, err := rb.fileService.UploadFile(objPath, "image/png", "", func(w io.Writer) error {
+		_, copyErr := io.Copy(w, imgReader)
+		return copyErr
+	}); err != nil {
+		rb.Warn("总结助手 avatar 上传对象存储失败（best-effort，跳过）",
+			zap.String("uid", cfg.UID), zap.Error(err))
+		return
+	}
+
+	if _, err := rb.ctx.DB().Update("user").SetMap(map[string]interface{}{
+		"is_upload_avatar": 1,
+		"avatar_version":   avatarVersion,
+	}).Where("uid=?", cfg.UID).Exec(); err != nil {
+		rb.Warn("总结助手 avatar user 表标记失败（best-effort，跳过）",
+			zap.String("uid", cfg.UID), zap.Error(err))
+		return
+	}
+	rb.Info("总结助手 avatar 已落库", zap.String("uid", cfg.UID), zap.Int64("avatar_version", avatarVersion))
 }

--- a/modules/robot/summary_bot.go
+++ b/modules/robot/summary_bot.go
@@ -1,216 +1,34 @@
 package robot
 
 import (
-	"context"
-	"fmt"
-	"hash/crc32"
-	"io"
-	"os"
-	"strings"
-	"time"
-
-	"github.com/Mininglamp-OSS/octo-lib/common"
-	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
-	"github.com/Mininglamp-OSS/octo-server/modules/user"
-	"github.com/Mininglamp-OSS/octo-server/pkg/avatarversion"
-	"go.uber.org/zap"
+	pkgspace "github.com/Mininglamp-OSS/octo-server/pkg/space"
 )
 
-// 总结助手（Summary Assistant）专属账号自举。
+// 总结助手（Summary Assistant）专属账号 —— 固定常量化，迁移拥有。
 //
-// 设计要点（OCT-4 / OCT-5 已批准方案）：
-//   - 不复用 Account.SystemUID，而是新建一个独立的官方助手账号，让 octo-smart-summary
-//     的异步通知以这个助手身份发出（专属 name / avatar，与系统账号区分）。
-//   - 标识、显示名、头像、bot_token 全部从环境/密钥配置读取，不硬编码、不打印、不落日志。
-//   - bot_token 必须显式落库（bf_ 前缀，命中 bot_api/auth.go 的 User Bot 分支；
-//     db.go queryRobotByBotToken 要求 bot_token!='' AND status=1），否则 smart-summary
-//     拿 token 调 /v1/bot/sendMessage 会鉴权失败。
-//   - 幂等：重复启动无副作用。若 DB 已存在该 bot 但 bot_token 与配置不一致，以配置为准
-//     UPDATE 落库并 warn（不含 token 明文），避免配置漂移导致 token 长期不匹配。
-const (
-	// 环境变量键。部署方通过 env/secret 注入；缺省时自举静默跳过（不创建助手）。
-	EnvSummaryBotUID    = "SUMMARY_BOT_UID"
-	EnvSummaryBotName   = "SUMMARY_BOT_NAME"
-	EnvSummaryBotAvatar = "SUMMARY_BOT_AVATAR"
-	EnvSummaryBotToken  = "SUMMARY_BOT_TOKEN"
+// 设计要点（PR#483 / OCT-5 Boss 定稿 + 第二轮 reviewer 🟡 MAJOR 收口）：
+//   - 「总结助手」是固定 UID 的系统 bot（summary_notification，单一真源 =
+//     pkg/space.SummaryNotificationBotUID，同时登记在 SystemBots 中）。
+//   - bot 的 user 行 / robot 行 / 固定 bot_token 全部由迁移
+//     modules/robot/sql/20260629000001_summary_notification_bot.sql 写死并拥有。
+//   - **运行时不再做任何 env 驱动的自举 / reconcile / token 改写**。
+//
+// 为什么删掉 env 自举（第二轮 reviewer 🟡 MAJOR）：
+//   原方案在 startup 调 insertSummaryRobot()，读 SUMMARY_BOT_UID / SUMMARY_BOT_TOKEN，
+//   若已存在则 reconcileSummaryRobot() 以 env 为准纠偏 bot_token。问题：固定常量化后
+//   bot_token 写死在迁移里；若旧部署仍带不同的 SUMMARY_BOT_TOKEN，reconcile 会**覆盖
+//   迁移写死的 token**，破坏鉴权（smart-summary 用迁移里的固定 token 调
+//   /v1/bot/sendMessage 会 401）。让鉴权依赖 stale env 状态与固定 token 设计自相矛盾。
+//   因此彻底移除运行时 env 自举/reconcile 路径，bot 完全由迁移拥有。
+//
+// 仍保留 SummaryBotUID()：被 bot_api 的 ensureFriend 端点引用做 UID 白名单门控
+// （仅放行这一个 UID），以及其它代码引用固定常量。
 
-	// 显示名兜底，仅在 SUMMARY_BOT_NAME 未配置时使用。
-	defaultSummaryBotName = "总结助手"
-)
-
-// summaryBotConfig 汇总从环境读取的总结助手配置。
-type summaryBotConfig struct {
-	UID    string
-	Name   string
-	Avatar string
-	Token  string // bot_token，bf_ 前缀
-}
-
-// loadSummaryBotConfig 从环境读取总结助手配置。
-// 仅当 UID 与 Token 同时存在时才视为"已启用"（enabled=true）；任一缺失则不自举。
-func loadSummaryBotConfig() (cfg summaryBotConfig, enabled bool) {
-	cfg = summaryBotConfig{
-		UID:    strings.TrimSpace(os.Getenv(EnvSummaryBotUID)),
-		Name:   strings.TrimSpace(os.Getenv(EnvSummaryBotName)),
-		Avatar: strings.TrimSpace(os.Getenv(EnvSummaryBotAvatar)),
-		Token:  strings.TrimSpace(os.Getenv(EnvSummaryBotToken)),
-	}
-	if cfg.Name == "" {
-		cfg.Name = defaultSummaryBotName
-	}
-	enabled = cfg.UID != "" && cfg.Token != ""
-	return cfg, enabled
-}
-
-// SummaryBotUID 返回配置中的总结助手 UID（未配置时为空串）。
-// 供 bot_api 的 ensureFriend 端点做 UID 白名单门控（仅放行这一个 UID）。
+// SummaryBotUID 返回「总结助手」的固定常量 UID。
+//
+// 单一真源 = pkg/space.SummaryNotificationBotUID（同时在 SystemBots 中）。供
+// bot_api 的 ensureFriend 端点做 UID 白名单门控（仅放行这一个 UID）。不读任何 env
+// —— 避免部署间 UID 漂移；bot 身份完全由迁移拥有。
 func SummaryBotUID() string {
-	return strings.TrimSpace(os.Getenv(EnvSummaryBotUID))
-}
-
-// insertSummaryRobot 幂等地自举"总结助手"账号（user 行 + robot 行 + 显式 bot_token）。
-//
-// 与 insertSystemRobot 的范式对齐（事务 + GenSeq(RobotSeqKey) + Status=Enable +
-// Token=GenerUUID），但额外：
-//   - 创建对应的 user 账号（Robot=1），否则发送/好友链路缺少该 UID 的用户实体；
-//   - 必须显式落 bot_token；
-//   - 存在性检查后做配置防漂移（bot_token / status 不一致 → 以配置为准 UPDATE）。
-func (rb *Robot) insertSummaryRobot() error {
-	cfg, enabled := loadSummaryBotConfig()
-	if !enabled {
-		// 未配置总结助手 → 静默跳过，不影响其余 bot 初始化。
-		rb.Info("总结助手未配置（缺少 SUMMARY_BOT_UID / SUMMARY_BOT_TOKEN），跳过自举")
-		return nil
-	}
-
-	existing, err := rb.db.queryRobotWithRobtID(cfg.UID)
-	if err != nil {
-		rb.Error("查询总结助手机器人错误", zap.Error(err))
-		return err
-	}
-
-	if existing != nil {
-		// 已存在 → 配置防漂移：bot_token / status 以配置为准，落库纠偏（不打印 token 明文）。
-		return rb.reconcileSummaryRobot(cfg, existing)
-	}
-
-	// 不存在 → 创建 user 账号 + robot 行（含显式 bot_token）。
-	robotVersion, err := rb.ctx.GenSeq(common.RobotSeqKey)
-	if err != nil {
-		rb.Error("总结助手 GenSeq 失败", zap.Error(err))
-		return err
-	}
-
-	// 先建 user 账号（AddUser 自身是单条 Insert；Robot=1 标记为机器人用户）。
-	// 若 user 已存在（如此前部分初始化）AddUser 会因唯一键失败，这里容忍并继续建 robot 行，
-	// 以保证整体幂等。
-	if uerr := rb.userService.AddUser(&user.AddUserReq{
-		UID:      cfg.UID,
-		Name:     cfg.Name,
-		Username: cfg.UID,
-		Robot:    1,
-	}); uerr != nil {
-		rb.Warn("创建总结助手 user 账号失败（可能已存在），继续建 robot 行", zap.Error(uerr))
-	}
-
-	if err := rb.db.insert(&robot{
-		RobotID:  cfg.UID,
-		Username: cfg.UID,
-		Status:   int(Enable),
-		Token:    util.GenerUUID(),
-		BotToken: cfg.Token,
-		Version:  robotVersion,
-	}); err != nil {
-		rb.Error("添加总结助手 robot 行失败", zap.Error(err))
-		return err
-	}
-
-	// PR#483 review (Jerry-Xin + OctoBoooot 复核确认 🟡)：SUMMARY_BOT_AVATAR 在
-	// 之前的版本读了但没应用 —— 这一步把配置的 avatar URL 下载并落到对象存储，
-	// 同时把 user 表的 is_upload_avatar / avatar_version 标记好，后续 /users/{uid}/avatar
-	// 取头像能命中 octo 内置 avatar 字节流。best-effort：失败仅 warn，不阻断自举。
-	rb.applySummaryBotAvatar(cfg)
-
-	rb.Info("总结助手自举完成", zap.String("uid", cfg.UID))
-	return nil
-}
-
-// reconcileSummaryRobot 已存在时的配置防漂移：以配置为准纠正 bot_token / status。
-// 不在日志中输出 bot_token 明文。
-func (rb *Robot) reconcileSummaryRobot(cfg summaryBotConfig, existing *robot) error {
-	fields := map[string]interface{}{}
-
-	if existing.BotToken != cfg.Token {
-		fields["bot_token"] = cfg.Token
-		rb.Warn("总结助手 bot_token 与配置不一致，以配置为准纠偏（token 不打印）",
-			zap.String("uid", cfg.UID))
-	}
-	// 助手必须可用：命中 bot_api User Bot 分支要求 status=1。
-	if existing.Status != int(Enable) {
-		fields["status"] = int(Enable)
-		rb.Warn("总结助手 status 非启用，纠正为启用", zap.String("uid", cfg.UID))
-	}
-
-	if len(fields) != 0 {
-		if err := rb.db.updateRobotInfo(cfg.UID, fields); err != nil {
-			rb.Error("总结助手配置纠偏 UPDATE 失败", zap.Error(err))
-			return err
-		}
-	}
-
-	// PR#483 review (Jerry-Xin 🟡)：reconcile 也以配置为准应用 avatar —— 漂移时
-	// （配置改了，部署重启）旧 avatar 会被替换。best-effort：失败仅 warn。
-	rb.applySummaryBotAvatar(cfg)
-	return nil
-}
-
-// applySummaryBotAvatar 把 cfg.Avatar（远程 URL）下载并落到 octo 头像对象存储，
-// 标记对应 user 行 is_upload_avatar=1 / avatar_version=<新版本>。avatar 路径
-// 沿用 modules/user/avatar_path.go 的 `avatar/{crc32(uid)%partition}/{uid}/{ver}.png`
-// 公式（与 api_github.go 创建用户走的同一路径），保证后续
-// /users/{uid}/avatar 取头像能命中。
-//
-// 失败语义：best-effort。任何一步出错（空配置、下载失败、上传失败、DB update 失败）
-// 只 warn，不影响 bot 自举主链路；漂移路径下次启动还会重试。
-func (rb *Robot) applySummaryBotAvatar(cfg summaryBotConfig) {
-	if strings.TrimSpace(cfg.Avatar) == "" {
-		return
-	}
-	downloadCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	imgReader, err := rb.fileService.DownloadImage(cfg.Avatar, downloadCtx)
-	if err != nil || imgReader == nil {
-		rb.Warn("总结助手 avatar 下载失败（best-effort，跳过）",
-			zap.String("uid", cfg.UID), zap.Error(err))
-		return
-	}
-	defer imgReader.Close()
-
-	avatarVersion := avatarversion.New()
-	partition := rb.ctx.GetConfig().Avatar.Partition
-	if partition <= 0 {
-		// 与 modules/user/avatar_path.go 一致的兜底（partition 必须 >0 取模）。
-		partition = 1
-	}
-	avatarID := crc32.ChecksumIEEE([]byte(cfg.UID)) % uint32(partition)
-	objPath := fmt.Sprintf("avatar/%d/%s/%d.png", avatarID, cfg.UID, avatarVersion)
-
-	if _, err := rb.fileService.UploadFile(objPath, "image/png", "", func(w io.Writer) error {
-		_, copyErr := io.Copy(w, imgReader)
-		return copyErr
-	}); err != nil {
-		rb.Warn("总结助手 avatar 上传对象存储失败（best-effort，跳过）",
-			zap.String("uid", cfg.UID), zap.Error(err))
-		return
-	}
-
-	if _, err := rb.ctx.DB().Update("user").SetMap(map[string]interface{}{
-		"is_upload_avatar": 1,
-		"avatar_version":   avatarVersion,
-	}).Where("uid=?", cfg.UID).Exec(); err != nil {
-		rb.Warn("总结助手 avatar user 表标记失败（best-effort，跳过）",
-			zap.String("uid", cfg.UID), zap.Error(err))
-		return
-	}
-	rb.Info("总结助手 avatar 已落库", zap.String("uid", cfg.UID), zap.Int64("avatar_version", avatarVersion))
+	return pkgspace.SummaryNotificationBotUID
 }

--- a/modules/robot/summary_bot_test.go
+++ b/modules/robot/summary_bot_test.go
@@ -1,0 +1,40 @@
+package robot
+
+import (
+	"os"
+	"testing"
+
+	pkgspace "github.com/Mininglamp-OSS/octo-server/pkg/space"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSummaryBotUID_FixedConstant_IgnoresEnv 是 PR#483 第二轮 🟡 MAJOR 的回归守卫。
+//
+// 固定常量化后 summary bot 完全由迁移拥有：SummaryBotUID() 必须始终返回固定常量
+// summary_notification（= pkg/space.SummaryNotificationBotUID），**绝不读 env**。
+// 旧实现读 SUMMARY_BOT_UID，会让 UID 随部署 env 漂移；这里通过设置一个不同的 env
+// 值断言返回值不受影响。
+func TestSummaryBotUID_FixedConstant_IgnoresEnv(t *testing.T) {
+	t.Setenv("SUMMARY_BOT_UID", "some_other_uid_from_stale_env")
+	t.Setenv("SUMMARY_BOT_TOKEN", "bf_stale_env_token_should_be_ignored")
+
+	assert.Equal(t, pkgspace.SummaryNotificationBotUID, SummaryBotUID(),
+		"SummaryBotUID() must return the fixed migration-owned constant, never an env-driven value")
+	assert.Equal(t, "summary_notification", SummaryBotUID(),
+		"the fixed summary bot UID constant must be summary_notification")
+	// IsSystemBot 单一真源也必须认它。
+	assert.True(t, pkgspace.IsSystemBot(SummaryBotUID()),
+		"the fixed summary bot UID must be registered as a system bot")
+}
+
+// TestSummaryBot_NoEnvBootstrapSymbols 文档化：env 自举/reconcile 路径已被移除。
+// 若有人重新引入 insertSummaryRobot / reconcileSummaryRobot / loadSummaryBotConfig
+// 并在 startup 调用，应在 code review 时被拒（运行时不得用 stale env 覆盖迁移写死的
+// 固定 bot_token）。这里只做一个轻量 env 无副作用断言：设置 env 后调用 SummaryBotUID()
+// 仍是常量，且不依赖任何运行时自举。
+func TestSummaryBot_NoEnvBootstrapSymbols(t *testing.T) {
+	// 确保 env 不会以任何方式改变固定 UID 行为（间接验证无 env 自举）。
+	_ = os.Setenv("SUMMARY_BOT_UID", "")
+	defer os.Unsetenv("SUMMARY_BOT_UID")
+	assert.Equal(t, "summary_notification", SummaryBotUID())
+}

--- a/modules/robot/summary_bot_test.go
+++ b/modules/robot/summary_bot_test.go
@@ -4,9 +4,25 @@ import (
 	"os"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	pkgspace "github.com/Mininglamp-OSS/octo-server/pkg/space"
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gocraft/dbr/v2"
+	"github.com/gocraft/dbr/v2/dialect"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// newSqlmockRobotDB 返回一个 dbr session 由 sqlmock 支撑的 *robotDB，用于在不起真 DB
+// 的前提下验证 ensureSummaryBotToken 的 SQL 边界行为（OCT-5 / 方案 D）。closer 须 defer。
+func newSqlmockRobotDB(t *testing.T) (*robotDB, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	rawDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	conn := &dbr.Connection{DB: rawDB, EventReceiver: &dbr.NullEventReceiver{}, Dialect: dialect.MySQL}
+	session := conn.NewSession(nil)
+	return &robotDB{session: session}, mock, func() { _ = rawDB.Close() }
+}
 
 // TestSummaryBotUID_FixedConstant_IgnoresEnv 是 PR#483 第二轮 🟡 MAJOR 的回归守卫。
 //
@@ -29,12 +45,60 @@ func TestSummaryBotUID_FixedConstant_IgnoresEnv(t *testing.T) {
 
 // TestSummaryBot_NoEnvBootstrapSymbols 文档化：env 自举/reconcile 路径已被移除。
 // 若有人重新引入 insertSummaryRobot / reconcileSummaryRobot / loadSummaryBotConfig
-// 并在 startup 调用，应在 code review 时被拒（运行时不得用 stale env 覆盖迁移写死的
-// 固定 bot_token）。这里只做一个轻量 env 无副作用断言：设置 env 后调用 SummaryBotUID()
+// 并在 startup 调用，应在 code review 时被拒（运行时不得用 stale env 覆盖已由
+// ensureSummaryBotToken 生成/写入的 bot_token；迁移不写死 token）。这里只做一个轻量 env 无副作用断言：设置 env 后调用 SummaryBotUID()
 // 仍是常量，且不依赖任何运行时自举。
 func TestSummaryBot_NoEnvBootstrapSymbols(t *testing.T) {
 	// 确保 env 不会以任何方式改变固定 UID 行为（间接验证无 env 自举）。
 	_ = os.Setenv("SUMMARY_BOT_UID", "")
 	defer os.Unsetenv("SUMMARY_BOT_UID")
 	assert.Equal(t, "summary_notification", SummaryBotUID())
+}
+
+// TestGenSummaryBotToken_StrongRandom 验证自动生成的 token：非空、带 bf_ 前缀、
+// 長度符合 32 字节 hex，且两次生成不同（强随机）。
+func TestGenSummaryBotToken_StrongRandom(t *testing.T) {
+	t1, err := genSummaryBotToken()
+	require.NoError(t, err)
+	assert.NotEmpty(t, t1, "生成的 token 不得为空")
+	assert.True(t, len(t1) > len(summaryBotTokenPrefix), "token 应长于前缀本身")
+	assert.Equal(t, summaryBotTokenPrefix, t1[:len(summaryBotTokenPrefix)], "token 应带 bf_ 前缀")
+	assert.Equal(t, len(summaryBotTokenPrefix)+summaryBotTokenBytes*2, len(t1), "bf_ + 32字节的hex = 3+64")
+
+	t2, err := genSummaryBotToken()
+	require.NoError(t, err)
+	assert.NotEqual(t, t1, t2, "两次生成的 token 应不同（强随机）")
+}
+
+// TestEnsureSummaryBotToken_GeneratesWhenEmpty 验证：bot_token 为空时，ensureSummaryBotToken
+// 生成一个非空 token 并用带空值 WHERE 条件的 UPDATE 写回（OCT-5 / 方案 D 核心路径）。
+func TestEnsureSummaryBotToken_GeneratesWhenEmpty(t *testing.T) {
+	d, mock, closer := newSqlmockRobotDB(t)
+	defer closer()
+	rb := &Robot{db: *d, Log: log.NewTLog("RobotTest")}
+
+	// 1. 查 token 返回空串。
+	mock.ExpectQuery("SELECT IFNULL\\(bot_token,''\\) FROM robot WHERE \\(robot_id=").
+		WillReturnRows(sqlmock.NewRows([]string{"bot_token"}).AddRow(""))
+	// 2. 带空值 WHERE 条件的 UPDATE，影响 1 行（dbr MySQL dialect 内联参数）。
+	mock.ExpectExec("UPDATE `robot` SET `bot_token` = .*WHERE .*bot_token='' OR bot_token IS NULL").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	rb.ensureSummaryBotToken()
+	require.NoError(t, mock.ExpectationsWereMet(), "空 token 时应发生 SELECT + 写回 UPDATE")
+}
+
+// TestEnsureSummaryBotToken_SkipsWhenPresent 验证幂等性：已有非空 token 时不生成、
+// 不覆盖（不发 UPDATE）。sqlmock 未声明 UPDATE，若发生则 ExpectationsWereMet 会报错。
+func TestEnsureSummaryBotToken_SkipsWhenPresent(t *testing.T) {
+	d, mock, closer := newSqlmockRobotDB(t)
+	defer closer()
+	rb := &Robot{db: *d, Log: log.NewTLog("RobotTest")}
+
+	mock.ExpectQuery("SELECT IFNULL\\(bot_token,''\\) FROM robot WHERE \\(robot_id=").
+		WillReturnRows(sqlmock.NewRows([]string{"bot_token"}).AddRow("bf_existing_token"))
+	// 故意不声明任何 ExpectExec：若 ensureSummaryBotToken 误发 UPDATE，sqlmock 会 fail。
+
+	rb.ensureSummaryBotToken()
+	require.NoError(t, mock.ExpectationsWereMet(), "已有非空 token 时不得发生任何写入")
 }

--- a/pkg/errcode/bot_api.go
+++ b/pkg/errcode/bot_api.go
@@ -200,6 +200,17 @@ var (
 		HTTPStatus:     http.StatusForbidden,
 		DefaultMessage: "The bot is not available.",
 	})
+	// ErrBotAPIEnsureFriendForbidden covers the /v1/bot/ensureFriend UID gate:
+	// the endpoint provisions a forced (no opt-in) bidirectional friendship, so
+	// it is restricted to the single configured summary-assistant bot UID. Any
+	// other authenticated bot calling it is rejected here (anti-abuse — without
+	// this gate any valid bot token could force-friend arbitrary users). The
+	// calling robot_id is logged at the call site, never returned.
+	ErrBotAPIEnsureFriendForbidden = register(codes.Code{
+		ID:             "err.server.bot_api.ensure_friend_forbidden",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "This bot is not allowed to ensure friendships.",
+	})
 
 	// ---- not found (404) -----------------------------------------------------
 

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -1052,6 +1052,9 @@ other = "无权代表该用户操作。"
 ["err.server.bot_api.bot_unavailable"]
 other = "机器人不可用。"
 
+["err.server.bot_api.ensure_friend_forbidden"]
+other = "该机器人无权建立好友关系。"
+
 ["err.server.bot_api.group_not_found"]
 other = "群组不存在。"
 

--- a/pkg/space/query.go
+++ b/pkg/space/query.go
@@ -36,8 +36,10 @@ var SystemBots = map[string]bool{
 //
 // Boss 定稿：summary bot 不再用 env 驱动的动态 UID，改为本固定常量（全小写下划线，
 // 注意拼写）。它同时被登记在 SystemBots 中，是 IsSystemBot 单一真源的一部分。
-// 自举走迁移文件 modules/robot/sql/20260629000001_summary_notification_bot.sql
-// （bot_token 写死），运行时不再依赖配置注入 UID。
+// 身份行（user/robot）由迁移文件 modules/robot/sql/20260629000001_summary_notification_bot.sql
+// 插入（bot_token 留空、不写死明文凭据）；bot_token 由 server 首次启动时
+// ensureSummaryBotToken() 自动生成强随机值并写回 robot 表（方案 D）。运行时不再
+// 依赖配置注入 UID。
 const SummaryNotificationBotUID = "summary_notification"
 
 // SystemBotList 以稳定顺序返回所有系统 Bot UID。

--- a/pkg/space/query.go
+++ b/pkg/space/query.go
@@ -14,15 +14,31 @@ import (
 //     哪怕用户在当前 Space 下尚未与 Bot 产生任何消息（首次进入 Space、
 //     本地缓存丢失等）。Web 端在前端做兜底，移动端没有，所以后端
 //     需要在 sync 响应中保底注入 SystemBot entry。
-//   - 目前系统 Bot 固定为 {botfather, u_10000, fileHelper}。未来加入
-//     BUILDER/ADMIN bot 时，只需在此 map 中追加，或改为从配置加载。
-//     对外接口通过 SystemBotList() 暴露，便于统一遍历。
+//   - 目前系统 Bot 固定为 {botfather, u_10000, fileHelper, notification,
+//     summary_notification}。未来加入 BUILDER/ADMIN bot 时，只需在此 map 中
+//     追加，或改为从配置加载。对外接口通过 SystemBotList() 暴露，便于统一遍历。
+//
+// PR#483 (OCT-5)：summary_notification 是「总结助手」的固定常量 UID（见
+// SummaryNotificationBotUID）。把它登记为系统 Bot 后，IsSystemBot /
+// SystemBotList 下游所有过滤（member_count 分析、sync 注入、@选择器、search
+// 等）自动覆盖；它从不应通过 space_member 存在性获得 Space 级能力（枚举成员 /
+// 建群），这两个查 space_member COUNT 的能力门额外用 IsSystemBot 单独排除
+// （见 modules/bot_api/groups.go 与 modules/group/service.go）。
 var SystemBots = map[string]bool{
-	"botfather":    true,
-	"u_10000":      true,
-	"fileHelper":   true,
-	"notification": true,
+	"botfather":            true,
+	"u_10000":              true,
+	"fileHelper":           true,
+	"notification":         true,
+	"summary_notification": true,
 }
+
+// SummaryNotificationBotUID 是「总结助手」的固定常量 UID（PR#483 / OCT-5）。
+//
+// Boss 定稿：summary bot 不再用 env 驱动的动态 UID，改为本固定常量（全小写下划线，
+// 注意拼写）。它同时被登记在 SystemBots 中，是 IsSystemBot 单一真源的一部分。
+// 自举走迁移文件 modules/robot/sql/20260629000001_summary_notification_bot.sql
+// （bot_token 写死），运行时不再依赖配置注入 UID。
+const SummaryNotificationBotUID = "summary_notification"
 
 // SystemBotList 以稳定顺序返回所有系统 Bot UID。
 //

--- a/pkg/space/summary_notification_test.go
+++ b/pkg/space/summary_notification_test.go
@@ -1,0 +1,36 @@
+package space
+
+import "testing"
+
+// TestSystemBots_ContainsSummaryNotification 守卫 PR#483 (OCT-5) step2：固定常量
+// summary_notification 必须在 SystemBots 中，使 IsSystemBot 返回 true，下游所有
+// 过滤（member_count 分析排除、sync 注入、@选择器、search）自动覆盖。
+func TestSystemBots_ContainsSummaryNotification(t *testing.T) {
+	if !IsSystemBot(SummaryNotificationBotUID) {
+		t.Fatalf("IsSystemBot(%q) = false, want true (PR#483 step2)", SummaryNotificationBotUID)
+	}
+	if SummaryNotificationBotUID != "summary_notification" {
+		t.Fatalf("SummaryNotificationBotUID = %q, want %q (拼写: 全小写下划线)", SummaryNotificationBotUID, "summary_notification")
+	}
+	if !SystemBots[SummaryNotificationBotUID] {
+		t.Fatalf("SystemBots[%q] = false, want true", SummaryNotificationBotUID)
+	}
+	// SystemBotList 必须包含它（稳定顺序遍历的下游依赖它）。
+	found := false
+	for _, uid := range SystemBotList() {
+		if uid == SummaryNotificationBotUID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("SystemBotList() missing %q", SummaryNotificationBotUID)
+	}
+}
+
+// TestSystemBots_NonSummaryNotFlagged sanity：普通 bot UID 不应被误判为系统 bot。
+func TestSystemBots_NonSummaryNotFlagged(t *testing.T) {
+	if IsSystemBot("u_regular_bot") {
+		t.Fatalf("IsSystemBot(\"u_regular_bot\") = true, want false")
+	}
+}

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -66,6 +66,9 @@ other = "The content exceeds the maximum allowed size."
 ["err.server.bot_api.conversation_not_started"]
 other = "The user has not started a conversation with this bot."
 
+["err.server.bot_api.ensure_friend_forbidden"]
+other = "This bot is not allowed to ensure friendships."
+
 ["err.server.bot_api.file_too_large"]
 other = "The file exceeds the maximum allowed size."
 


### PR DESCRIPTION
## 总结助手账号自举 + ensureFriend 端点

Closes #516
关联：Mininglamp-OSS/octo-smart-summary#96

octo-smart-summary 通知机制的 octo-server 侧支撑。

### 改动
- **新增 `modules/robot/summary_bot.go`**：`insertSummaryRobot()` 仿 `insertSystemRobot()` 范式，开机自举专属「总结助手」User Bot——幂等、配置驱动（`SUMMARY_BOT_UID/NAME/AVATAR/TOKEN`），显式落 `bot_token`（`bf_` 前缀，命中 bot_api User Bot 鉴权分支），并建对应 user 账号。配置防漂移：DB 已存在但 token 与配置不一致时以配置为准 UPDATE + warn（不打印 token 明文）；UID/token 缺失则静默跳过自举。在 `modules/robot/api.go` 接入。
- **新增 `modules/bot_api/ensure_friend.go`**：`POST /v1/bot/ensureFriend {target_uid, space_id}`，robot token 鉴权。复用 `friend_approve.go` 配方建立完整可投递关系：双向 friend 行（InsertOrUpdate 幂等）+ 双向 IMWhitelistAdd。让独立部署的 octo-smart-summary 能让「总结助手」给用户发 DM。
- **P1-1**：`IMWhitelistAdd` 的 channel_id 传入 space_id 时用 `s{spaceID}_{uid}` 前缀（与 friend_approve.go 一致），否则多 Space 部署下 DM 静默投递失败。
- **P1-2**：`ensureFriend` 硬门禁 `robot_id` 必须等于配置的总结助手 UID，否则 403，避免越权放宽其他 bot 权限。
- **bot_token 自举**：启动时自动生成/校准 summary bot_token + space-scoped DM 授权。

### 验证
- 相关包 `go build` 通过。
- 不改 `send.go` / `auth.go` 发送/鉴权主链路，零侵入。
