### PR TITLE
fix(message): DM per-Space isolation + recent-list cross-Space fixes (#484)

### DIFF
--- a/.octospec/journal/shared/conv-space-catchall-484.md
+++ b/.octospec/journal/shared/conv-space-catchall-484.md
@@ -1,0 +1,136 @@
+---
+type: Journal
+title: "conv-space-catchall-484: default-Space DM catch-all + spaceless group/topic isolation"
+description: Close the two deterministically reproducible cross-Space paths in the recent-conversation list
+tags: [space, isolation, message, conversation, sidebar]
+timestamp: 2026-07-02T00:00:00Z
+---
+
+# conv-space-catchall-484
+
+Branch `fix/conv-space-catchall-484` (based on origin/main 236b78b; stacked-free —
+presence infra re-introduced byte-identical to the unmerged #484 branch by user
+decision, so the eventual merge dedupes).
+
+## What was done
+
+1. **Default-Space DM catch-all tightened** (production-reproducible leak): the
+   catch-all in `decideConvKeepInSpace` kept every bare DM in the default Space.
+   Now a post-filter pass (`space_filter_default_catchall.go`) hides a bare DM
+   from the default Space iff `dm_space_presence` has rows for the pair and none
+   of them is the default Space and the Recents window carries no untagged /
+   default-tagged counter-evidence. No presence rows → legacy catch-all kept.
+   System bots exempt; bot visibility stays with the catch-all bot sub-check;
+   `skipBotFilter` or any query failure disables the pass (never hide on doubt).
+   Self-heals: one default-Space message re-adds visibility.
+2. **Spaceless groups/topics attributed to the default Space only** (the exact
+   path a production client diagnostic showed rendering in every Space): the
+   `spaceID == "" → return true` fail-open in the group branch, the
+   `parentSpaceID == ""` fail-open in `filterThreadConvCore`, and the legacy-keep
+   in sidebar `filterThreadExtsBySpace` all now show the conversation only when
+   `filterSpaceID == defaultSpaceID` — same policy as #337 bare DMs and #484
+   untagged DM history.
+3. Both v1 (`/v1/conversation/sync`) and v2 (`/v1/sidebar/sync`) paths switched
+   to `GetUserDefaultSpaceIDE`; on lookup error the conv filters fall open for
+   the request (defaultSpaceID=filterSpaceID, catch-all pass disabled) so a DB
+   hiccup never hides more than today; `filterThreadExtsBySpace` keeps its
+   fail-closed error contract.
+
+## Verification
+
+- Unit: new `space_filter_default_catchall_test.go` (evidence gates, fail-open
+  gates, counter-evidence, bot exemptions); two legacy assertions deliberately
+  flipped (`...ThreadChannelLegacyParent`, `...Group_LegacyNoSpace_*`).
+- Integration (real handlers + webhook-written presence):
+  `TestConvSpaceCatchall_DefaultSpaceHidesElsewhereOnlyDM`,
+  `TestConvSpaceCatchall_SpacelessGroupAndTopicOnlyDefault` — both PASS; suite
+  helpers are cs-prefixed to avoid collisions with the #484 branch harness.
+- `go build ./...`, `go vet`, `make i18n-lint`, `make i18n-extract-check` green.
+
+## Consolidation (2026-07-02)
+
+Merged the base `fix/dm-space-isolation-484` work into this branch (user request:
+one branch / one PR for all of #484). The presence infra was already byte-identical
+so it deduped; the only hand-merge was `space_filter.go` — branch-1's `dmPresentSet`
+threading + non-default DM presence-OR now coexists with this branch's group/topic
+default-Space attribution and the default-Space catch-all post-pass. The two
+integration suites were unified onto one fake-IM + webhook secret (the message
+handlers bind modules once per process via `register.GetModules` sync.Once, so two
+independent fake-IM servers made the second suite lose its IM binding). Deleted the
+obsolete `TestRepro484_ProdTrace_SpacelessGroupShownInEverySpace` (it characterized
+the pre-fix bug now fixed here; `TestConvSpaceCatchall_SpacelessGroupAndTopicOnlyDefault`
+covers the fixed behavior). All 10 integration tests + unit suites green together.
+
+## Learnings
+
+- Topic conversations must ALSO pass the thread liveness whitelist
+  (`QueryActiveShortIDs`, status=1) — integration tests seeding topics need a
+  `thread` row, not just `group_member`.
+- The shared `test` DB across test binaries still causes cross-binary migration
+  clashes; DROP/CREATE between package runs remains mandatory.
+- `personConvHasSpaceMessages(conv, "")` does NOT match untagged messages (they
+  lack the key) — untagged counter-evidence needs its own scan.
+
+## Review round (2026-07-02, PR #519)
+
+First pass: three reviewers, no blocking findings. Re-review on the squashed head
+surfaced a real **P1 cross-Space DM leak** (below), fixed. Addressed items:
+
+3. **P1 — default-Space-lookup error must fail *closed* for the DM catch-all**
+   (`space_filter.go`, both v1 `:38-42` and v2 `:711-715`). yujiawei + OctoBoooot
+   caught that the fail-open branch set `defaultSpaceID = filterSpaceID`, which
+   makes `filterSpaceID == defaultSpaceID` true for a **non-default** request during
+   a `space_member` DB error → the bare-DM catch-all (`decideConvKeepInSpace:332`)
+   fires and returns **every** bare DM (including other-Space-only DMs) in that
+   Space — a cross-Space leak, and a regression vs pre-PR (old `GetUserDefaultSpaceID`
+   returned `""` on error). Fix: set `defaultSpaceID = ""` — a sentinel that can
+   never equal a real `filterSpaceID` (the filter only runs when `spaceID != ""`),
+   so the DM catch-all cannot fire on the error path and bare DMs fall through to
+   the presence/Recents scan (isolated); spaceless groups/topics fail-closed
+   (hidden — a subset of pre-PR "visible everywhere", not a regression). Note the
+   *soft* group-attribution paths that are NOT a catch-all gate keep `= spaceID`
+   (`api.go` untagged-history, `api_sidebar.go` thread-ext) — those only ever show
+   current-Space-subset content, never leak. Regression guard:
+   `TestFilterConversationsBySpace_DefaultLookupError_BareDMFailsClosed` asserts a
+   bare cross-Space DM is dropped when `defaultSpaceID == ""` and documents the
+   pre-fix leak.
+
+1. **D — `filterThreadExtsBySpace` default-Space lookup now fail-open**
+   (`api_sidebar.go`). The `GetUserDefaultSpaceIDE` call there only drives the
+   *soft* "spaceless parent group shows in which Space" heuristic, not a real
+   auth boundary, yet a transient `space_member` blip used to 500 the whole
+   follow tab. It now logs + falls back to `defaultSpaceID = spaceID` (same
+   fail-open口径 as `FilterConversationsBySpace`); the genuine boundary queries
+   (group table, external-group map) stay fail-closed. Safe against the
+   authoritative-membership contract because `/v1/sidebar/sync` does **not**
+   emit `space_memberships` (only `/v1/conversation/sync` does — see below).
+2. **C — DB-level accessor tests** (`dm_presence_accessor_test.go`, integration
+   tag): lock down `UpsertDMSpacePresence` (GREATEST monotonic, empty no-op),
+   `DMSpacePresenceSet` (per-Space IN filter), `DMSpacePresenceAnySet`
+   (any-Space set + elsewhere-only derivation) directly against MySQL.
+
+### Known boundaries (surfaced in review — by design, not regressions)
+
+- **Encrypted (Signal) DMs skip the presence write** (`webhook/api.go`): payload
+  is unparseable, so a DM that exists *only* as encrypted messages in Space B
+  gets no presence row and the default-Space catch-all cannot hide it. This is
+  the fail-open contract (never hide without positive evidence); the leak is not
+  *introduced* here, just not closed for encrypted-only DMs.
+- **Spaceless-group → default-Space-only is a user-visible change**: a group that
+  genuinely belongs to Space B but has empty `group.space_id` (missing backfill)
+  disappears from B until backfilled. Direction is fail-closed (safer for a leak
+  fix) and self-heals on `group.space_id` backfill.
+- **`/v1/sidebar/sync` returns only `{items, version, follow_version}`** — it does
+  NOT emit `space_memberships`. Only `/v1/conversation/sync` (`buildSpaceMemberships`)
+  carries the authoritative wipe-replace membership list. Any client treating the
+  sidebar response as a `space_memberships` source is reading a field the server
+  never sends.
+
+### Deferred
+
+- Per-conversation decision observability for production triage. A global
+  DEBUG-log switch was rejected (needs redeploy to flip, floods all users, can't
+  target an after-the-fact report). Next round: a `X-Internal-Token`-gated
+  read-only "explain" path that replays the filter for a given uid+space and
+  returns per-conversation kept/dropped + reason, so ops can diagnose from the
+  response without packet capture. Not in this PR.

--- a/.octospec/journal/shared/dm-space-isolation-484.md
+++ b/.octospec/journal/shared/dm-space-isolation-484.md
@@ -1,0 +1,79 @@
+---
+type: Journal
+title: "Journal: dm-space-isolation-484 (octo-server #484)"
+description: Authoritative per-Space DM presence index — fixes cross-Space DM history leak (symptom 1) and mutual conversation hiding (symptom 2).
+tags: ["space", "isolation", "dm", "webhook", "p1"]
+timestamp: 2026-06-27T00:00:00Z
+# --- octospec extension fields ---
+task: dm-space-isolation-484
+upstream: Mininglamp-OSS/octo-server#484
+source: self
+---
+# Journal: dm-space-isolation-484 (octo-server #484)
+
+## What was done
+
+DMs are a single physical WuKongIM Person channel per user-pair; multi-Space
+isolation was emulated by a soft `payload.space_id` tag plus filters that
+**scanned messages** to infer Space. That produced two P1 defects (reproduced
+end-to-end first): cross-Space history leak (symptom 1) and DMs mutually hiding
+between Spaces (symptom 2). Product decision: DMs are per-Space isolated. Fixed
+server-side, authoritatively, without any client change.
+
+1. **Authoritative presence index** — new table `dm_space_presence(fake_channel_id,
+   space_id, last_timestamp)` (`modules/space/sql/20260627000001_dm_space_presence.sql`)
+   + accessor `pkg/space/dm_presence.go` (`UpsertDMSpacePresence`, batch
+   `DMSpacePresenceSet`). Keyed by the **symmetric** `common.GetFakeChannelIDWith`
+   pair id, so the webhook write side `(sender, peer)` and the conversation read
+   side `(viewer, peer)` compute the same key.
+
+2. **Write at ingest** — `modules/webhook/api.go handleMessageNotify` collects
+   `(fakeChannelID, space_id)` for non-signal Person messages carrying
+   `payload.space_id` and upserts them **after `tx.Commit()`, best-effort**
+   (log-and-continue). It never rolls back message persistence; a missed write
+   self-heals on the next message because readers OR it with the Recents scan.
+
+3. **Symptom 2 read** — `resolveDMPresence` batch-resolves presence for all bare
+   DM pair-ids vs `filterSpaceID` (one query, mirroring `resolveBotFilter`) and
+   **ORs** it with the existing Recents-window scan inside `decideConvKeepInSpace`
+   (both v1 `FilterConversationsBySpace` and v2 `FilterRawConversationsBySpace`).
+   Visibility becomes a strict superset of before → no regression, and a DM is
+   visible in every Space it has messages in, simultaneously.
+
+4. **Symptom 1 read** — `filterPersonMessagesBySpace` gained `defaultSpaceID`;
+   an untagged non-systembot DM message is kept only when
+   `spaceID == defaultSpaceID`. Caller `syncChannelMessage` passes
+   `space.GetUserDefaultSpaceID(ctx, loginUID)`.
+
+## How it was verified
+
+- Reproduced both symptoms first (`TestRepro484`, integration-tagged, real
+  handlers + MySQL/Redis + mocked WuKongIM), then **flipped to post-fix
+  assertions**: a DM with presence in spaceB AND spaceC is visible in both at
+  once (presence written via the REAL `POST /v1/webhook/message/notify`, HMAC
+  signed); a DM with presence only in spaceB is absent from spaceC; untagged
+  history shows only in the default Space.
+- `go test -tags=integration ./modules/message/ -run TestRepro484 -v` → PASS (3).
+- Unit: `go test ./modules/message/...`, `./pkg/space/...`, `./modules/webhook/...`,
+  `./modules/space/...` → PASS (fresh-DB per package to avoid the shared
+  gorp_migrations cross-binary state issue).
+- Gates: `make i18n-lint`, `make i18n-extract-check`, `lint-personal-msgsendreq` → OK.
+
+## Learnings
+
+- octo-server **does** persist every message server-side via the WuKongIM
+  webhook (`handleMessageNotify`), which is the authoritative, sender-path-
+  independent hook for per-message derived state — better than the send
+  chokepoint (it also captures the peer's messages, forwards, card messages).
+- `common.GetFakeChannelIDWith` is symmetric (CRC32-sorted pair), which is what
+  makes a single presence key reproducible from either participant's viewpoint.
+- OR-ing a new authoritative signal with the legacy heuristic (rather than
+  replacing it) makes visibility a strict superset — fixes the defect with zero
+  regression risk and no backfill.
+
+## Out of scope (follow-ups)
+
+- Per-message authoritative history via `message_id` cross-ref (kept the
+  payload-tag history filter + default-Space policy here).
+- Existing-DM presence backfill (relying on OR-with-Recents fallback).
+- Physical per-Space DM channel split; any client change; `space_unread.go`.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,21 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-02
+
+- **Change** — Task `conv-space-catchall-484` (issue #484 follow-up): closed the
+  two deterministically reproducible cross-Space paths in the recent-conversation
+  list. (1) The default-Space DM catch-all no longer lists a bare DM whose
+  `dm_space_presence` rows point exclusively at other Spaces (positive-evidence
+  post-pass; legacy no-presence DMs keep the catch-all; system bots exempt; any
+  query failure disables the pass). (2) Groups with empty `group.space_id` — and
+  their topics, in the conv filter AND sidebar thread-ext filter — now show only
+  in the user's default Space instead of every Space (same policy as #337 bare
+  DMs / #484 untagged history). This branch also carries the base
+  `dm-space-isolation-484` fix (merged in — see the 2026-06-27 entry below), so
+  the presence infra is authored once here. Journal:
+  `journal/shared/conv-space-catchall-484.md`.
+
 ## 2026-06-29
 
 - **Change** — Task `group-avatar-name-no-text` (client-coordination; repurposes
@@ -41,6 +56,12 @@ change-log convention (§7). Newest first.
   `group-name-v3→v4` and `name-v4→v5` (ETag + CacheKey). Brief + context under
   `.octospec/tasks/default-avatar-text-rule/`, journal
   `.octospec/journal/shared/default-avatar-text-rule.md`.
+- **Fix** — Task `dm-space-isolation-484` (#484): authoritative per-Space DM
+  presence index (`dm_space_presence`, written at the WuKongIM message webhook,
+  read by the conversation Space filter) — fixes cross-Space DM history leak
+  (symptom 1, via default-Space policy for untagged messages) and DMs mutually
+  hiding between Spaces (symptom 2, window-independent visibility OR-ed with the
+  legacy Recents scan). Server-only; no client change.
 
 ## 2026-06-25
 

--- a/.octospec/tasks/conv-space-catchall-484/brief.md
+++ b/.octospec/tasks/conv-space-catchall-484/brief.md
@@ -1,0 +1,99 @@
+---
+type: Task
+title: "Task: conv-space-catchall-484"
+description: Fix the two deterministically reproducible cross-Space paths in the recent-conversation list (default-Space DM catch-all; spaceless group shown everywhere)
+tags: [space, isolation, message, conversation]
+timestamp: 2026-07-02T00:00:00Z
+# --- octospec extension fields ---
+slug: conv-space-catchall-484
+upstream: octo-server#484 (follow-up; production trace + client SpaceFilter diagnostic)
+source: self
+---
+
+# Task: conv-space-catchall-484
+
+## Goal
+
+Close the two cross-Space paths in `POST /v1/conversation/sync` / `POST /v1/sidebar/sync`
+that reproduce **with a fully well-formed request** (space_id present and valid):
+
+1. **Default-Space DM catch-all** (`decideConvKeepInSpace`, `space_filter.go:305`):
+   when `filterSpaceID == defaultSpaceID`, every bare non-bot DM is kept
+   unconditionally — including DMs whose messages are known (via the #484
+   authoritative `dm_space_presence` index) to belong **exclusively to other
+   Spaces**. Fix: in the default Space, hide a bare DM iff it has ≥1 presence row,
+   none of them for the default Space, and its Recents window carries neither a
+   default-Space-tagged nor an untagged message. DMs with **no presence rows at
+   all** (pre-#484 / legacy / untagged-only) keep today's catch-all — the fix
+   only acts on positive, durable evidence, and self-heals (one message in the
+   default Space re-adds visibility).
+
+2. **Spaceless group / topic fail-open** (`decideConvKeepInSpace` group branch
+   `if spaceID == "" { return true }` and `filterThreadConvCore:369`
+   `return parentSpaceID == ""`): a group whose `group.space_id` is empty (and any
+   topic under it) is listed in **every** Space. Fix: attribute spaceless
+   groups/topics to the user's **default Space only** — consistent with the
+   existing policy for legacy DMs (#337) and untagged DM history (#484 symptom 1).
+
+Both fixes follow the established product decision (per-Space isolation; legacy /
+unattributable content lives in the default Space, not everywhere).
+
+## Background
+
+- Issue #484 fixed DM mutual-hide + untagged history leak (branch
+  `fix/dm-space-isolation-484`, not yet merged).
+- A production incident + an Android SpaceFilter diagnostic log identified three
+  deterministic cross-Space paths; two reproduce with a well-formed request and
+  are locked by integration tests `TestRepro484_DefaultSpaceListsOtherSpaceOnlyDM`,
+  `TestRepro484_ProdTrace_DefaultSpaceCatchAll_ShowsAllDMs`,
+  `TestRepro484_ProdTrace_SpacelessGroupShownInEverySpace` (currently asserting
+  the buggy behavior; this task flips them).
+- The client renders DMs with zero local filtering (`person-pass`) because DM
+  conversations carry no space_id — the server list is the only line of defense.
+- **Dependency**: fix 1 requires `dm_space_presence` (+ webhook write + test
+  harness), which exists only on `fix/dm-space-isolation-484`. This branch is
+  therefore stacked: `origin/main (236b78b)` + rebased #484 commits + this work.
+
+## Load-bearing list
+
+- `space` / `isolation`: conversation-list Space visibility for Person, Group,
+  CommunityTopic (`decideConvKeepInSpace`, `filterThreadConvCore`,
+  `filterConversationsCore`, v1 `FilterConversationsBySpace`, v2
+  `FilterRawConversationsBySpace` → both `/v1/conversation/sync` and
+  `/v1/sidebar/sync`).
+- System bots (`SystemBots` + `EnsureSystemBotsPresent`): must remain visible in
+  every Space even when their presence rows point elsewhere (e.g. botfather with
+  activity only in one non-default Space).
+- Regular bots: default-Space visibility is still gated by the existing bot
+  membership sub-check; the new hide rule must not apply when `skipBotFilter`
+  (bot resolution DB error) since bot identity is unknown.
+- Fail-open ethos on infra errors: presence lookup failure ⇒ no new hiding;
+  default-Space lookup failure ⇒ behave as before (`GetUserDefaultSpaceIDE` +
+  fallback), never hide more than today on a DB hiccup.
+- `test`: existing `TestRepro484_*` integration suite semantics.
+
+## Out of scope
+
+- The **missing-space_id** path (request without `?space_id`/`X-Space-ID` skips
+  filtering entirely). That skip is documented intentional legacy-client compat
+  (YUJ-226 / lml P1-1); changing it is a client-contract decision, not a bug fix.
+- Backfilling `group.space_id` data or `dm_space_presence` history.
+- Sending a conversation-level `space_id` for DMs to the client (structural
+  follow-up, separate task).
+- Message-history filtering (`/v1/message/channel/sync`) — unchanged by this task.
+- Client (Android/iOS/Web) changes.
+
+## Acceptance
+
+- Flipped integration tests pass (real handlers, real MySQL/Redis, mocked IM):
+  - Default Space **hides** a bare DM whose presence rows exist only for other
+    Spaces (and whose Recents carry no default/untagged message).
+  - Default Space **keeps**: DMs with no presence rows (legacy), DMs with a
+    default-Space presence row, DMs whose Recents contain an untagged or
+    default-tagged message, and system bots regardless of presence.
+  - A spaceless group (and its topic) is listed **only** in the user's default
+    Space; groups with a real space_id stay isolated to their own Space.
+- All pre-existing `TestRepro484_*` tests still pass (symptom 1/2 fixes, bot
+  scenarios, missing-space_id path unchanged).
+- Unit suites `go test ./modules/message/ ./pkg/space/` green; `go vet`/gofmt
+  clean; `make i18n-lint` unaffected (no new error responses).

--- a/.octospec/tasks/conv-space-catchall-484/context.yaml
+++ b/.octospec/tasks/conv-space-catchall-484/context.yaml
@@ -1,0 +1,33 @@
+# What was injected/consulted while implementing conv-space-catchall-484.
+task: conv-space-catchall-484
+rules_used:
+  - id: space-isolation   # load_bearing; both fixes tighten the space boundary
+  - id: trust-boundary    # webhook presence write (byte-identical to reviewed #484 code)
+  - id: testing           # testutil.NewTestServer + CleanAllTables harness conventions
+  - id: commit-style      # conventional commits
+code_read:
+  - modules/message/space_filter.go          # decideConvKeepInSpace / filterThreadConvCore / v1+v2 entries
+  - modules/message/api_sidebar.go           # filterThreadExtsBySpace (third spaceless fail-open)
+  - modules/message/api_conversation.go      # topic liveness whitelist (QueryActiveShortIDs), member gates
+  - modules/message/space_unread.go          # confirmed window-scan only — NOT a durable presence substitute
+  - modules/group/db.go                      # ExistMembersActive whitelist (status=GroupMemberStatusNormal)
+  - modules/thread/const.go, modules/thread/sql/  # ThreadStatusActive=1, thread schema for test seeding
+  - pkg/space/dm_presence.go                 # accessor idiom to mirror in DMSpacePresenceAnySet
+decisions:
+  - base: origin/main (236b78b), per user choice "纯 main,两个都修"; presence infra
+    (migration + pkg/space/dm_presence.go + webhook write) re-introduced BYTE-IDENTICAL
+    to fix/dm-space-isolation-484 so a future merge dedupes as identical add-add;
+    all genuinely new code lives in NEW files to minimize the conflict surface.
+  - fix 1 (DM catch-all) is a post-filter pass, NOT a decideConvKeepInSpace signature
+    change — keeps existing unit-test call sites intact and conflict surface small.
+  - hide requires positive durable evidence: presence rows exist AND none for the
+    default Space AND no untagged/default-tagged Recents counter-evidence; system
+    bots exempt; bots exempt (catch-all bot sub-check remains the authority);
+    skipBotFilter or any presence/default-space query failure disables the pass.
+  - fix 2 attributes spaceless groups/topics (conv core + thread core + sidebar
+    thread-ext) to the default Space only; default-space lookup failure falls open
+    per request (defaultSpaceID=filterSpaceID) in conv filters, fail-closed in
+    filterThreadExtsBySpace per that function's existing error contract.
+out_of_scope_confirmed:
+  - missing-space_id skip (documented legacy-client compat, YUJ-226) untouched.
+  - no conversation-level space_id emitted for DMs (separate structural task).

--- a/.octospec/tasks/dm-space-isolation-484/brief.md
+++ b/.octospec/tasks/dm-space-isolation-484/brief.md
@@ -1,0 +1,118 @@
+---
+type: Task
+title: "Task: dm-space-isolation-484"
+description: Make DM (Person) Space isolation authoritative — stop cross-Space history leak and mutual conversation hiding.
+tags: ["space", "isolation", "webhook", "dm", "p1"]
+timestamp: 2026-06-27T00:00:00Z
+# --- octospec extension fields ---
+slug: dm-space-isolation-484
+upstream: octo-server#484
+source: self
+---
+
+# Task: dm-space-isolation-484
+
+## Goal
+
+Fix issue #484: a DM with the same contact (1) leaks history across Spaces and
+(2) mutually hides between Spaces. Product decision: **DMs are per-Space
+isolated** (a DM is an independent conversation per `(contact, Space)`).
+
+Replace the two soft-tag-scanning filters with a server-authoritative signal so
+DM Space visibility is **window-independent** and untagged messages stop leaking
+into every Space.
+
+- **Symptom 2 (mutual hide):** conversation visibility in a non-default Space is
+  currently decided by scanning the single shared `Recents` window
+  (`personConvHasSpaceMessages` → `decideConvKeepInSpace`,
+  `modules/message/space_filter.go:283/347`). Both Spaces share one window, so
+  the most-recently-active Space wins and the other hides. → Make visibility
+  query a durable per-`(dm-pair, space)` presence record instead.
+- **Symptom 1 (history leak):** untagged DM messages are kept in **every** Space
+  by rule 2 of `filterPersonMessagesBySpace` (`space_filter.go:457`). → Keep
+  untagged DM messages only in the user's **default** Space.
+
+## Background
+
+- DM is a single physical WuKongIM Person channel; conversation-level `SpaceID`
+  is intentionally empty (`api_conversation.go:1584`). Isolation is emulated by
+  the per-message `payload.space_id` soft tag + filtering.
+- Send-side authoritative `space_id` injection is already hardened (#33/#37 via
+  `NewPersonalMsgSendReq` + CI lint); #153 backfilled conversation-level
+  `space_id` for **groups only**. Neither touches the DM single-channel + scan
+  mechanism. Symptom 2 (per-Space *loss* of a DM) is new — no prior issue.
+- octo-server already persists every message server-side via the WuKongIM
+  webhook `POST /v1/webhook/message/notify` → `handleMessageNotify`
+  (`modules/webhook/api.go:234`), which is the authoritative, sender-path-
+  independent write point. For a Person message it persists under
+  `common.GetFakeChannelIDWith(FromUID, ChannelID)` — a **symmetric** canonical
+  pair id (CRC32-sorted), so the same key is reproducible on the read side from
+  `(loginUID, peerUID)`.
+- Reproduced end-to-end in `modules/message/dm_cross_space_repro_test.go`
+  (`TestRepro484`, integration-tagged).
+
+## Design (server-only)
+
+1. **Presence table** `dm_space_presence(fake_channel_id, space_id,
+   last_timestamp)`, PK `(fake_channel_id, space_id)`. Migration in
+   `modules/space/sql/`. Accessor in `pkg/space` (both `webhook` and `message`
+   already import `pkg/space`; leaf package, no import cycle):
+   - `UpsertDMSpacePresenceTx(tx, fakeChannelID, spaceID, ts)`
+   - `DMSpacePresence(session, fakeChannelIDs, spaceID) -> set` (batch read).
+2. **Write (authoritative):** in `handleMessageNotify`, for `ChannelTypePerson`
+   messages whose `payload.space_id != ""`, upsert presence inside the existing
+   tx, keyed by the `fakeChannelID` already computed there.
+3. **Read — symptom 2:** in `FilterConversationsBySpace` /
+   `FilterRawConversationsBySpace`, batch-resolve presence for all bare Person
+   conv pair-ids against `filterSpaceID` (one query, mirroring the existing
+   bot/group batch lookups), and feed the result into `decideConvKeepInSpace`'s
+   `hasSpaceMsg` callback — replacing the Recents-window scan. Fail-open vs
+   fail-closed on DB error: follow the existing per-entrypoint convention
+   (v1 fail-open, v2 sidebar fail-closed) used for group lookups.
+4. **Read — symptom 1:** `filterPersonMessagesBySpace` gains a `defaultSpaceID`
+   param; rule 2 keeps an untagged non-systembot message only when
+   `spaceID == defaultSpaceID`. Caller `syncChannelMessage` (`api.go:1277`)
+   passes `space.GetUserDefaultSpaceID(ctx, loginUID)`.
+
+## Load-bearing list
+
+- `space` / `isolation` — core multi-tenant boundary; the whole change is a
+  Space-isolation correctness fix (space-isolation rule).
+- `webhook` / `trust-boundary` / `wire-contract` — adds a write inside the
+  HMAC-authenticated message webhook ingest (trust-boundary rule).
+- DM conversation visibility filter (`decideConvKeepInSpace`, both v1 and v2
+  sidebar entrypoints) — must stay consistent across v1/v2.
+- DM history message filter (`filterPersonMessagesBySpace`) and its callers.
+- DB migration (new table; idempotent, additive).
+- `test` — flip the integration repro to post-fix assertions.
+
+## Out of scope
+
+- Physical per-Space DM channel split (the "A1" long-term direction).
+- Changing send-side `space_id` injection (`enrichPayloadWithSpaceID` /
+  `NewPersonalMsgSendReq`) — already hardened.
+- Full per-message history authority via `message_id` cross-reference to the
+  persisted table (follow-up; this change keeps the payload-tag history filter
+  but fixes the untagged-everywhere leak via the default-Space policy).
+- Any client (Web/Android/iOS) change — server remains the authoritative source.
+- Per-Space unread rework in `space_unread.go` (separate concern).
+- The pre-existing legacy `c.ResponseError` in `webhook.messageNotify` (not our
+  lines; leaving the protocol endpoint as-is).
+
+## Acceptance
+
+`go test -tags=integration ./modules/message/ -run TestRepro484 -v` passes with
+post-fix assertions:
+
+- **Symptom 2 fixed:** a DM with persisted presence in BOTH spaceB and spaceC is
+  visible in spaceB AND spaceC **simultaneously** (no mutual hide), independent
+  of which Space last filled the Recents window. A DM with presence only in
+  spaceB is visible in spaceB and absent from spaceC (correct isolation — it
+  genuinely has no spaceC messages).
+- **Symptom 1 fixed:** with history `[tagged-B, UNTAGGED, tagged-C]` and default
+  Space = spaceDefault: sync under spaceB returns `tagged-B` only (NOT
+  `UNTAGGED`, NOT `tagged-C`); sync under spaceDefault returns `UNTAGGED`.
+- Existing message-package unit tests still pass
+  (`go test ./modules/message/...`).
+- New presence write is exercised through the real webhook endpoint (or a direct
+  presence insert) in the integration test.

--- a/.octospec/tasks/dm-space-isolation-484/context.yaml
+++ b/.octospec/tasks/dm-space-isolation-484/context.yaml
@@ -1,0 +1,43 @@
+slug: dm-space-isolation-484
+upstream: Mininglamp-OSS/octo-server#484
+rules_applied:
+  - id: space-isolation
+    tier: repo
+    load_bearing: true
+    why: >
+      The whole change is a Space-isolation correctness fix for DMs. Visibility is
+      now decided by an authoritative per-(pair, space) presence index instead of
+      scanning the shared Recents window, and untagged DM history is confined to
+      the default Space. The presence read fails open to the existing Recents
+      scan (never worse than today); the write is authoritative from the
+      server-injected payload.space_id. Conversation/message handlers still go
+      through the existing Space middleware (unchanged).
+  - id: trust-boundary
+    tier: repo
+    load_bearing: true
+    why: >
+      The presence write is added inside the HMAC-authenticated WuKongIM message
+      webhook (handleMessageNotify). It only reads a server-injected authoritative
+      field (payload.space_id) and writes an internal index key — no external
+      content is rendered/echoed, no markdown/URL emitted. Best-effort post-commit
+      so it can never roll back message persistence.
+  - id: testing
+    tier: repo
+    load_bearing: false
+    why: >
+      Unit tests for the symptom-1 default-Space drop and the symptom-2
+      presence-driven visibility; integration repro flipped to post-fix
+      assertions driving the REAL webhook write + both read paths.
+  - id: commit-style
+    tier: repo
+    load_bearing: false
+    why: Conventional Commits, English.
+files_touched:
+  - modules/space/sql/20260627000001_dm_space_presence.sql   # new dm_space_presence table
+  - pkg/space/dm_presence.go                                 # UpsertDMSpacePresence + DMSpacePresenceSet
+  - modules/webhook/api.go                                   # authoritative presence write at ingest (post-commit, best-effort)
+  - modules/message/space_filter.go                          # resolveDMPresence + OR into decideConvKeepInSpace; default-Space untagged policy
+  - modules/message/api.go                                   # pass defaultSpaceID into filterPersonMessagesBySpace; import modules/space
+  - modules/message/space_filter_test.go                     # signature updates + symptom-1 drop / symptom-2 presence cases
+  - modules/message/space_filter_v2_test.go                  # decideConvKeepInSpace dmPresentSet param + presence case
+  - modules/message/dm_cross_space_repro_test.go             # post-fix integration repro (real webhook + sync handlers)

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/file"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/robot"
+	"github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
@@ -1356,7 +1357,17 @@ func (m *Message) syncChannelMessage(c *wkhttp.Context) {
 	// 否则 hardening 会被绕过。
 	if req.ChannelType == common.ChannelTypePerson.Uint8() {
 		if spaceID := spacepkg.GetSpaceID(c); spaceID != "" {
-			syncResp.Messages = filterPersonMessagesBySpace(syncResp.Messages, req.ChannelID, spaceID)
+			// issue #484：无标签 DM 历史只在用户默认 Space 保留，避免跨 Space 泄漏。
+			// 用 error-returning 变体：默认 Space 查询失败时无法判定归属，按兼容
+			// 口径 fail-open（defaultSpaceID=spaceID → 保留无标签历史）并记日志，
+			// 避免一次 DB 抖动静默截断合法 DM 历史（与会话过滤“不比现状更差”同口径）。
+			defaultSpaceID, derr := space.GetUserDefaultSpaceIDE(m.ctx, req.LoginUID)
+			if derr != nil {
+				m.Warn("查询默认 Space 失败，DM 无标签历史按兼容口径保留",
+					zap.Error(derr), zap.String("loginUID", req.LoginUID))
+				defaultSpaceID = spaceID
+			}
+			syncResp.Messages = filterPersonMessagesBySpace(syncResp.Messages, req.ChannelID, spaceID, defaultSpaceID)
 		}
 	}
 

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -824,13 +824,30 @@ func extractGroupNos(convs []*config.SyncUserConversationResp) []string {
 // 前显式按父群 space_id 过滤，规则与 FilterRawConversationsBySpace 的 group 分支一致：
 //   - 内部群：parent.space_id == spaceID 才保留
 //   - 外部群：当前 user 作为外部成员加入该群且 sourceSpaceID == spaceID 才保留
-//   - 旧群 (parent.space_id == "")：保留（沿用历史"所有 Space 可见"语义）
+//   - 旧群 (parent.space_id == "")：只在用户默认 Space 保留（issue #484 follow-up，
+//     与 filterThreadConvCore 同口径；此前"所有 Space 可见"是串空间路径）
 //
-// fail-closed：群表查询失败时返回 error，调用方 follow tab 整体退避，避免半结果泄露。
+// fail-closed：群表 / 外部群查询失败时返回 error，调用方 follow tab 整体退避，避免
+// 半结果泄露——这两个查询划定真正的跨 Space 鉴权边界（内部群 parent.space_id==spaceID、
+// 外部群 sourceSpaceID==spaceID）。
+//
+// 例外——默认 Space 查询（GetUserDefaultSpaceIDE）只用于「空 space_id 父群露在哪个
+// Space」这个软启发式，不是鉴权边界，故单独 fail-open（视 filterSpaceID 为默认，与
+// FilterConversationsBySpace 同口径）：空 space_id 群此时归到当前 Space，是 legacy
+// 「全 Space 可见」的子集、不构成跨 Space 泄露；一次 space_member 抖动不再把整个
+// follow tab 打黑（#519 reviewer 反馈：默认 Space 查询失败拖垮 follow tab）。
 func (sb *Sidebar) filterThreadExtsBySpace(rows []*convext.Model, spaceID, loginUID string) ([]*convext.Model, error) {
 	parentNos := uniqueThreadParentGroupNos(rows)
 	if len(parentNos) == 0 {
 		return rows, nil
+	}
+	defaultSpaceID, err := space.GetUserDefaultSpaceIDE(sb.ctx, loginUID)
+	if err != nil {
+		// 软启发式查询失败 → fail-open（不牵连整个 follow tab），空 space_id 父群按
+		// 当前 Space 归属；真正的边界（群表/外部群查询）仍在下方 fail-closed。
+		sb.Warn("sidebar sync: thread ext default-space lookup failed, fail-open to current space",
+			zap.Error(err), zap.String("loginUID", loginUID))
+		defaultSpaceID = spaceID
 	}
 	groupInfos, err := sb.groupService.GetGroups(parentNos)
 	if err != nil {
@@ -858,8 +875,11 @@ func (sb *Sidebar) filterThreadExtsBySpace(rows []*convext.Model, spaceID, login
 			continue
 		}
 		if parentSpaceID == "" {
-			// Legacy group without space_id: keep (mirrors v1 visibility).
-			kept = append(kept, ext)
+			// issue #484 follow-up：空 space_id 父群只在默认 Space 露出（与
+			// filterThreadConvCore 同口径），不再全 Space 可见。
+			if spaceID == defaultSpaceID {
+				kept = append(kept, ext)
+			}
 			continue
 		}
 		if parentSpaceID == spaceID {

--- a/modules/message/conv_space_catchall_repro_test.go
+++ b/modules/message/conv_space_catchall_repro_test.go
@@ -1,0 +1,335 @@
+//go:build integration
+
+package message
+
+// End-to-end coverage for the issue #484 follow-up (task conv-space-catchall-484):
+// the two deterministic cross-Space paths in the recent-conversation list, driven
+// through the REAL registered handlers against MySQL/Redis with WuKongIM mocked.
+//
+//  1. Default-Space DM catch-all: a bare DM whose dm_space_presence rows point
+//     exclusively at other Spaces (and whose Recents carry no default/untagged
+//     counter-evidence) is now HIDDEN from the default Space; DMs without any
+//     presence rows keep the legacy catch-all.
+//  2. Spaceless group/topic: a group with empty group.space_id (and its topics)
+//     is now listed ONLY in the user's default Space, no longer in every Space.
+//
+// Helpers are cs-prefixed to sit alongside the base #484 repro harness
+// (dm_cross_space_repro_test.go) in the same package; this suite shares that
+// harness's fake WuKongIM + webhook secret (see csSetup) so both run together.
+//
+// Build-tagged `integration` (NOT compiled in the default CI `go test` job):
+//
+//	go test -tags=integration ./modules/message/ -run TestConvSpaceCatchall -v
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/server"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	csSpaceDefault = "csSpaceDefault" // joined first → the user's default Space
+	csSpaceB       = "csSpaceB"
+	csSpaceC       = "csSpaceC"
+)
+
+// This suite shares the repro harness's single fake WuKongIM (reproFakeIM) and
+// webhook secret (reproWebhookSecret) rather than standing up its own. The
+// message-module handlers bind to the FIRST NewTestServer's ctx/config in the
+// process (register.GetModules sync.Once), so two independent fake-IM servers /
+// secrets would make whichever suite runs second lose its IM URL and signature
+// validation. Sharing one server + one secret lets both suites run in a single
+// `go test -tags=integration ./modules/message/` invocation. Conversations are
+// published via the shared reproIMConvs var.
+
+// csMsg builds an IM message for peer with an optional payload.space_id tag.
+func csMsg(peer string, seq uint32, spaceID string) *config.MessageResp {
+	payload := map[string]interface{}{"type": 1, "content": fmt.Sprintf("m%d", seq)}
+	if spaceID != "" {
+		payload["space_id"] = spaceID
+	}
+	return &config.MessageResp{
+		MessageID:   int64(seq),
+		MessageSeq:  seq,
+		ClientMsgNo: fmt.Sprintf("cs-%s-%d", peer, seq),
+		FromUID:     peer,
+		ChannelID:   peer,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Timestamp:   1700000000 + int32(seq),
+		Payload:     []byte(util.ToJson(payload)),
+	}
+}
+
+// csDMConv builds a DM conversation whose Recents are the given tagged messages.
+func csDMConv(peer string, recentSpaceIDs ...string) *config.SyncUserConversationResp {
+	recents := make([]*config.MessageResp, 0, len(recentSpaceIDs))
+	for i, sid := range recentSpaceIDs {
+		recents = append(recents, csMsg(peer, uint32(i+1), sid))
+	}
+	return &config.SyncUserConversationResp{
+		ChannelID:   peer,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Timestamp:   1700000099,
+		LastMsgSeq:  1,
+		Version:     100,
+		Recents:     recents,
+	}
+}
+
+// csChannelConv builds a GROUP or CommunityTopic conversation (bare channel id).
+func csChannelConv(channelID string, channelType uint8) *config.SyncUserConversationResp {
+	return &config.SyncUserConversationResp{
+		ChannelID:   channelID,
+		ChannelType: channelType,
+		Timestamp:   1700000099,
+		LastMsgSeq:  1,
+		Version:     100,
+		Recents: []*config.MessageResp{{
+			MessageID: 1, MessageSeq: 1, ClientMsgNo: "cs-" + channelID,
+			FromUID: testutil.UID, ChannelID: channelID, ChannelType: channelType,
+			Timestamp: 1700000001,
+			Payload:   []byte(util.ToJson(map[string]interface{}{"type": 1, "content": "g"})),
+		}},
+	}
+}
+
+func csSeedSpace(t *testing.T, ctx *config.Context, spaceID, createdAt string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO space (space_id, name, creator, status, created_at, updated_at) VALUES (?, ?, ?, 1, ?, ?)",
+		spaceID, spaceID, testutil.UID, createdAt, createdAt,
+	).Exec()
+	require.NoError(t, err)
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO space_member (space_id, uid, role, status, created_at, updated_at) VALUES (?, ?, 0, 1, ?, ?)",
+		spaceID, testutil.UID, createdAt, createdAt,
+	).Exec()
+	require.NoError(t, err)
+}
+
+func csSeedGroup(t *testing.T, ctx *config.Context, groupNo, spaceID string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `group` (group_no, name, status, space_id) VALUES (?, ?, 1, ?)",
+		groupNo, groupNo, spaceID,
+	).Exec()
+	require.NoError(t, err)
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO group_member (group_no, uid, role, status, is_deleted, version) VALUES (?, ?, 0, 1, 0, 1)",
+		groupNo, testutil.UID,
+	).Exec()
+	require.NoError(t, err)
+}
+
+// csSeedThread inserts an ACTIVE thread row so the conv-sync liveness whitelist
+// (QueryActiveShortIDs, status=1) keeps the topic conversation — orthogonal to
+// the Space filter under test.
+func csSeedThread(t *testing.T, ctx *config.Context, groupNo, shortID string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO thread (short_id, group_no, name, creator_uid, status) VALUES (?, ?, ?, ?, 1)",
+		shortID, groupNo, "cs-topic", testutil.UID,
+	).Exec()
+	require.NoError(t, err)
+}
+
+// csEnsureAppBotTable stubs an empty app_bot table: resolveBotFilter →
+// CheckBotsInSpace always queries it, but this test binary doesn't load the
+// app_bot module. Without the table the query errors → skipBotFilter=true →
+// both the bot sub-check AND the catch-all tightening are skipped (fail-open),
+// masking the behavior under test.
+func csEnsureAppBotTable(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"CREATE TABLE IF NOT EXISTS app_bot (" +
+			"uid VARCHAR(40) NOT NULL, status TINYINT NOT NULL DEFAULT 0, " +
+			"scope VARCHAR(20) NOT NULL DEFAULT 'platform', space_id VARCHAR(40) DEFAULT NULL)",
+	).Exec()
+	require.NoError(t, err)
+}
+
+func csSetup(t *testing.T) (*server.Server, *config.Context) {
+	t.Helper()
+	// Reset the shared fake-IM response vars (see reproSetup).
+	reproIMConv = nil
+	reproIMConvs = nil
+	reproIMMsgs = nil
+
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	t.Setenv("TS_WEBHOOK_SECRET_KEY", reproWebhookSecret)
+
+	imURL := reproFakeIM().URL
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	cfg := ctx.GetConfig()
+	cfg.MessageSaveAcrossDevice = false
+	cfg.WuKongIM.APIURL = imURL
+
+	require.NoError(t, ctx.Cache().Set(cfg.Cache.TokenCachePrefix+testutil.Token, testutil.UID+"@test"))
+
+	csSeedSpace(t, ctx, csSpaceDefault, "2020-01-01 00:00:00")
+	csSeedSpace(t, ctx, csSpaceB, "2021-01-01 00:00:00")
+	csSeedSpace(t, ctx, csSpaceC, "2022-01-01 00:00:00")
+	csEnsureAppBotTable(t, ctx)
+
+	r := ctx.GetRedisConn()
+	_ = r.Del("ratelimit:uid:" + testutil.UID)
+	_ = r.Del("userMaxVersion:" + testutil.UID)
+	for _, sp := range []string{csSpaceDefault, csSpaceB, csSpaceC} {
+		_ = r.Del("space:member:" + sp + ":" + testutil.UID)
+	}
+	return s, ctx
+}
+
+// csIngestDM drives the REAL message webhook for an inbound DM (peer → login
+// user) tagged with spaceID, which writes the dm_space_presence row.
+func csIngestDM(t *testing.T, s *server.Server, peer, spaceID string, seq uint32) {
+	t.Helper()
+	payload := fmt.Sprintf(`{"type":1,"content":"m%d","space_id":%q}`, seq, spaceID)
+	b64 := base64.StdEncoding.EncodeToString([]byte(payload))
+	body := fmt.Sprintf(
+		`[{"message_id":%d,"message_seq":%d,"from_uid":%q,"channel_id":%q,"channel_type":1,"timestamp":%d,"payload":%q}]`,
+		seq, seq, peer, testutil.UID, 1700000000+int(seq), b64,
+	)
+	mac := hmac.New(sha256.New, []byte(reproWebhookSecret))
+	mac.Write([]byte(body))
+	sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/webhook/message/notify", strings.NewReader(body))
+	req.Header.Set("X-Signature-256", sig)
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+// csCallConvSync drives POST /v1/conversation/sync with X-Space-ID and returns
+// the channel IDs in the response list.
+func csCallConvSync(t *testing.T, s *server.Server, spaceID string) []string {
+	t.Helper()
+	body := `{"version":0,"msg_count":50,"device_uuid":"dev-cs","recent_filter":false}`
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/conversation/sync", strings.NewReader(body))
+	req.Header.Set("token", testutil.Token)
+	req.Header.Set("X-Space-ID", spaceID)
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var wrap struct {
+		Conversations []struct {
+			ChannelID string `json:"channel_id"`
+		} `json:"conversations"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrap))
+	ids := make([]string, 0, len(wrap.Conversations))
+	for _, c := range wrap.Conversations {
+		ids = append(ids, c.ChannelID)
+	}
+	return ids
+}
+
+func csContains(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestConvSpaceCatchall_DefaultSpaceHidesElsewhereOnlyDM asserts fix 1: the
+// default Space no longer lists a bare DM whose presence rows point exclusively
+// at other Spaces — while every legacy/counter-evidenced DM keeps the catch-all.
+func TestConvSpaceCatchall_DefaultSpaceHidesElsewhereOnlyDM(t *testing.T) {
+	s, _ := csSetup(t)
+	const (
+		peerElsewhere = "cs_peer_elsewhere" // presence: spaceB only; Recents: spaceB-tagged
+		peerLegacy    = "cs_peer_legacy"    // NO presence rows; Recents: spaceB-tagged
+		peerHome      = "cs_peer_home"      // presence: spaceB AND default
+		peerUntagged  = "cs_peer_untagged"  // presence: spaceB only; Recents: untagged
+	)
+	csIngestDM(t, s, peerElsewhere, csSpaceB, 1)
+	csIngestDM(t, s, peerHome, csSpaceB, 2)
+	csIngestDM(t, s, peerHome, csSpaceDefault, 3)
+	csIngestDM(t, s, peerUntagged, csSpaceB, 4)
+
+	reproIMConvs = []*config.SyncUserConversationResp{
+		csDMConv(peerElsewhere, csSpaceB),
+		csDMConv(peerLegacy, csSpaceB),
+		csDMConv(peerHome, csSpaceDefault),
+		csDMConv(peerUntagged, ""),
+	}
+
+	inDefault := csCallConvSync(t, s, csSpaceDefault)
+	assert.False(t, csContains(inDefault, peerElsewhere),
+		"FIXED: presence 只在他空间的 DM 不再出现在默认 Space 列表")
+	assert.True(t, csContains(inDefault, peerLegacy),
+		"无 presence 行的存量 DM 保持 catch-all 现状")
+	assert.True(t, csContains(inDefault, peerHome),
+		"默认 Space 有 presence 的 DM 保留")
+	assert.True(t, csContains(inDefault, peerUntagged),
+		"Recents 含未打标消息 → 本地反证保留")
+	assert.True(t, csContains(inDefault, "botfather"),
+		"系统 bot 在默认 Space 恒可见（EnsureSystemBotsPresent）")
+
+	// The hidden DM is still visible in the Space it belongs to (Recents scan).
+	inB := csCallConvSync(t, s, csSpaceB)
+	assert.True(t, csContains(inB, peerElsewhere),
+		"被默认 Space 隐藏的 DM 在其归属 Space（B）仍可见")
+}
+
+// TestConvSpaceCatchall_SpacelessGroupAndTopicOnlyDefault asserts fix 2: a group
+// with empty group.space_id (and its topic) is listed only in the default Space.
+func TestConvSpaceCatchall_SpacelessGroupAndTopicOnlyDefault(t *testing.T) {
+	s, ctx := csSetup(t)
+	const (
+		grpBare = "cs_grp_bare" // group.space_id = ''
+		grpB    = "cs_grp_b"    // group.space_id = spaceB
+	)
+	csSeedGroup(t, ctx, grpBare, "")
+	csSeedGroup(t, ctx, grpB, csSpaceB)
+	topicBare := grpBare + "____123456789012345"
+	topicB := grpB + "____123456789012346"
+	csSeedThread(t, ctx, grpBare, "123456789012345")
+	csSeedThread(t, ctx, grpB, "123456789012346")
+
+	reproIMConvs = []*config.SyncUserConversationResp{
+		csChannelConv(grpBare, common.ChannelTypeGroup.Uint8()),
+		csChannelConv(grpB, common.ChannelTypeGroup.Uint8()),
+		csChannelConv(topicBare, common.ChannelTypeCommunityTopic.Uint8()),
+		csChannelConv(topicB, common.ChannelTypeCommunityTopic.Uint8()),
+	}
+
+	inDefault := csCallConvSync(t, s, csSpaceDefault)
+	assert.True(t, csContains(inDefault, grpBare), "空 space_id 群归属默认 Space")
+	assert.True(t, csContains(inDefault, topicBare), "空 space_id 父群的子区归属默认 Space")
+	assert.False(t, csContains(inDefault, grpB), "有归属的群不进默认 Space")
+	assert.False(t, csContains(inDefault, topicB), "有归属父群的子区不进默认 Space")
+
+	inB := csCallConvSync(t, s, csSpaceB)
+	assert.True(t, csContains(inB, grpB), "spaceB 群在 spaceB 可见")
+	assert.True(t, csContains(inB, topicB), "spaceB 父群的子区在 spaceB 可见")
+	assert.False(t, csContains(inB, grpBare),
+		"FIXED: 空 space_id 群不再出现在非默认 Space")
+	assert.False(t, csContains(inB, topicBare),
+		"FIXED: 空 space_id 父群的子区不再出现在非默认 Space")
+
+	inC := csCallConvSync(t, s, csSpaceC)
+	assert.False(t, csContains(inC, grpBare), "空 space_id 群在 spaceC 同样隐藏")
+	assert.False(t, csContains(inC, grpB), "spaceB 群在 spaceC 隐藏")
+}

--- a/modules/message/dm_cross_space_repro_test.go
+++ b/modules/message/dm_cross_space_repro_test.go
@@ -1,0 +1,567 @@
+//go:build integration
+
+package message
+
+// Post-fix end-to-end coverage for issue #484 — DM per-Space isolation.
+//
+// Originally a reproduction (DMs leaked across Spaces / mutually hid between
+// Spaces); now flipped to assert the fix, driven through the REAL registered
+// handlers against MySQL/Redis with WuKongIM mocked:
+//
+//   - Symptom 2 (was: mutual hide): conversation visibility now comes from the
+//     authoritative dm_space_presence index, written at the REAL WuKongIM
+//     message webhook (POST /v1/webhook/message/notify) and read by
+//     /v1/conversation/sync — so a DM is visible in EVERY Space it has messages
+//     in, simultaneously, independent of the shared Recents window.
+//   - Symptom 1 (was: history leak): /v1/message/channel/sync keeps an untagged
+//     DM message only in the user's default Space.
+//
+// Build-tagged `integration` (NOT compiled in the default CI `go test` job).
+// Run targeted (order-fragile like every e2e file here — register.GetModules
+// memoizes modules under a sync.Once, so handlers bind to the FIRST
+// NewTestServer's ctx/config in the process):
+//
+//	go test -tags=integration ./modules/message/ -run TestRepro484 -v
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/server"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const reproPeerUID = "peer_contact_777"
+const reproWebhookSecret = "repro-webhook-secret-484"
+
+// Three Spaces the test user belongs to. spaceDefault is joined first so it is
+// the user's default Space (GetUserDefaultSpaceID = earliest created_at). spaceB
+// and spaceC are both NON-default, which isolates the per-Space behaviour from
+// the "default Space always shows" special-case.
+const (
+	reproSpaceDefault = "spaceDefault"
+	reproSpaceB       = "spaceB"
+	reproSpaceC       = "spaceC"
+)
+
+// One long-lived fake WuKongIM for this file, serving both IM endpoints the two
+// handlers hit, off mutable response vars. Tests run sequentially (no
+// t.Parallel), so the shared vars need no lock.
+var (
+	reproIMOnce  sync.Once
+	reproIMSrv   *httptest.Server
+	reproIMConv  *config.SyncUserConversationResp   // /conversation/sync payload (single DM)
+	reproIMConvs []*config.SyncUserConversationResp // /conversation/sync payload (multi-DM); takes precedence over reproIMConv
+	reproIMMsgs  []*config.MessageResp              // /channel/messagesync payload
+)
+
+func reproFakeIM() *httptest.Server {
+	reproIMOnce.Do(func() {
+		reproIMSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/conversation/sync"):
+				convs := []*config.SyncUserConversationResp{}
+				switch {
+				case reproIMConvs != nil:
+					convs = reproIMConvs
+				case reproIMConv != nil:
+					convs = append(convs, reproIMConv)
+				}
+				_, _ = w.Write([]byte(util.ToJson(convs)))
+			case strings.HasSuffix(r.URL.Path, "/channel/messagesync"):
+				_, _ = w.Write([]byte(util.ToJson(&config.SyncChannelMessageResp{
+					StartMessageSeq: 1,
+					EndMessageSeq:   uint32(len(reproIMMsgs)),
+					Messages:        reproIMMsgs,
+				})))
+			default:
+				_, _ = w.Write([]byte("{}"))
+			}
+		}))
+	})
+	return reproIMSrv
+}
+
+// reproMsg builds an IM message with the given content marker and (optional)
+// payload.space_id tag. spaceID=="" → an UNTAGGED message.
+func reproMsg(seq uint32, content, spaceID string) *config.MessageResp {
+	payload := map[string]interface{}{"type": 1, "content": content}
+	if spaceID != "" {
+		payload["space_id"] = spaceID
+	}
+	return &config.MessageResp{
+		MessageID:   int64(seq),
+		MessageSeq:  seq,
+		ClientMsgNo: content,
+		FromUID:     reproPeerUID,
+		ChannelID:   reproPeerUID,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Timestamp:   1700000000 + int32(seq),
+		IsDeleted:   0,
+		Payload:     []byte(util.ToJson(payload)),
+	}
+}
+
+// reproDMConv wraps a single UNTAGGED recent message into a DM conversation as
+// IMSyncUserConversation would return it. Untagged Recents means the legacy
+// window-scan OR-term never matches spaceB/spaceC, so conv visibility in those
+// Spaces is driven purely by the authoritative dm_space_presence index.
+func reproDMConv() *config.SyncUserConversationResp {
+	return &config.SyncUserConversationResp{
+		ChannelID:   reproPeerUID,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Unread:      0,
+		Timestamp:   1700000099,
+		LastMsgSeq:  1,
+		Version:     100,
+		Recents:     []*config.MessageResp{reproMsg(1, "untagged-recent", "")},
+	}
+}
+
+// reproMsgFor is reproMsg for an arbitrary peer (multi-DM scenarios).
+func reproMsgFor(peer string, seq uint32, content, spaceID string) *config.MessageResp {
+	payload := map[string]interface{}{"type": 1, "content": content}
+	if spaceID != "" {
+		payload["space_id"] = spaceID
+	}
+	return &config.MessageResp{
+		MessageID:   int64(seq),
+		MessageSeq:  seq,
+		ClientMsgNo: content,
+		FromUID:     peer,
+		ChannelID:   peer,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Timestamp:   1700000000 + int32(seq),
+		Payload:     []byte(util.ToJson(payload)),
+	}
+}
+
+// reproDMConvFor builds a DM conversation for `peer` whose single recent message
+// is tagged with `spaceID` (or untagged when spaceID==""). Used to assemble a
+// multi-DM /conversation/sync payload mirroring the production snapshot.
+func reproDMConvFor(peer, content, spaceID string) *config.SyncUserConversationResp {
+	return &config.SyncUserConversationResp{
+		ChannelID:   peer,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Timestamp:   1700000099,
+		LastMsgSeq:  1,
+		Version:     100,
+		Recents:     []*config.MessageResp{reproMsgFor(peer, 1, content, spaceID)},
+	}
+}
+
+func reproSeedSpace(t *testing.T, ctx *config.Context, spaceID, createdAt string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO space (space_id, name, creator, status, created_at, updated_at) VALUES (?, ?, ?, 1, ?, ?)",
+		spaceID, spaceID, testutil.UID, createdAt, createdAt,
+	).Exec()
+	require.NoError(t, err)
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO space_member (space_id, uid, role, status, created_at, updated_at) VALUES (?, ?, 0, 1, ?, ?)",
+		spaceID, testutil.UID, createdAt, createdAt,
+	).Exec()
+	require.NoError(t, err)
+}
+
+// reproSeedGroup inserts a row into `group` with the given space_id. An empty
+// spaceID models a spaceless group whose Space cannot be resolved, so the
+// server's group filter fails open.
+func reproSeedGroup(t *testing.T, ctx *config.Context, groupNo, spaceID string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `group` (group_no, name, status, space_id) VALUES (?, ?, 1, ?)",
+		groupNo, groupNo, spaceID,
+	).Exec()
+	require.NoError(t, err)
+}
+
+// reproSeedGroupMember makes the login user an active member of groupNo.
+// conversation/sync gates group conversations behind ExistMembers
+// (api_conversation.go:474), so a group is dropped entirely unless the caller is
+// a member — orthogonal to the Space filter under test.
+func reproSeedGroupMember(t *testing.T, ctx *config.Context, groupNo string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO group_member (group_no, uid, role, status, is_deleted, version) VALUES (?, ?, 0, 1, 0, 1)",
+		groupNo, testutil.UID,
+	).Exec()
+	require.NoError(t, err)
+}
+
+// reproGroupConv builds a GROUP conversation (bare group_no, conv-level SpaceID
+// empty) as IMSyncUserConversation returns it; the server resolves its Space from
+// the `group` table (GetGroups → groupSpaceMap).
+func reproGroupConv(groupNo, content string) *config.SyncUserConversationResp {
+	return &config.SyncUserConversationResp{
+		ChannelID:   groupNo,
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		Timestamp:   1700000099,
+		LastMsgSeq:  1,
+		Version:     100,
+		Recents: []*config.MessageResp{{
+			MessageID:   1,
+			MessageSeq:  1,
+			ClientMsgNo: content,
+			FromUID:     testutil.UID,
+			ChannelID:   groupNo,
+			ChannelType: common.ChannelTypeGroup.Uint8(),
+			Timestamp:   1700000001,
+			Payload:     []byte(util.ToJson(map[string]interface{}{"type": 1, "content": content})),
+		}},
+	}
+}
+
+// reproSetup wires a fresh test server with the fake IM, seeds the three Space
+// memberships, configures the webhook HMAC secret, and clears Redis state so
+// each test is deterministic.
+func reproSetup(t *testing.T) (*server.Server, *config.Context) {
+	t.Helper()
+
+	// Reset the shared fake-IM response vars so each test is independent
+	// regardless of run order (single-conv and multi-conv tests share these).
+	reproIMConv = nil
+	reproIMConvs = nil
+	reproIMMsgs = nil
+
+	// module.Setup (common module) refuses to start without a master key.
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	// Webhook reads its HMAC secret from env at module construction.
+	t.Setenv("TS_WEBHOOK_SECRET_KEY", reproWebhookSecret)
+
+	imURL := reproFakeIM().URL
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	cfg := ctx.GetConfig()
+	cfg.MessageSaveAcrossDevice = false
+	cfg.WuKongIM.APIURL = imURL
+
+	require.NoError(t, ctx.Cache().Set(cfg.Cache.TokenCachePrefix+testutil.Token, testutil.UID+"@test"))
+
+	// spaceDefault joined first → user's default Space. B and C are non-default.
+	reproSeedSpace(t, ctx, reproSpaceDefault, "2020-01-01 00:00:00")
+	reproSeedSpace(t, ctx, reproSpaceB, "2021-01-01 00:00:00")
+	reproSeedSpace(t, ctx, reproSpaceC, "2022-01-01 00:00:00")
+	reproEnsureAppBotTable(t, ctx)
+
+	r := ctx.GetRedisConn()
+	_ = r.Del("ratelimit:uid:" + testutil.UID)
+	_ = r.Del("userMaxVersion:" + testutil.UID)
+	for _, sp := range []string{reproSpaceDefault, reproSpaceB, reproSpaceC} {
+		_ = r.Del("space:member:" + sp + ":" + testutil.UID)
+	}
+	return s, ctx
+}
+
+// reproIngestPersonMsg drives the REAL WuKongIM message webhook for an inbound
+// Person message (fromUID → channelID) tagged with spaceID, populating
+// dm_space_presence. The HMAC signature satisfies verifyRequestSignature.
+// Payload is a []byte JSON field → base64-encoded on the wire (encoding/json
+// round-trips []byte). The webhook keys presence by
+// common.GetFakeChannelIDWith(fromUID, channelID), which is symmetric — so it
+// matches the conversation read side GetFakeChannelIDWith(loginUID, peer).
+func reproIngestPersonMsg(t *testing.T, s *server.Server, fromUID, channelID, spaceID string, seq uint32) {
+	t.Helper()
+	payload := fmt.Sprintf(`{"type":1,"content":"m%d","space_id":%q}`, seq, spaceID)
+	b64 := base64.StdEncoding.EncodeToString([]byte(payload))
+	body := fmt.Sprintf(
+		`[{"message_id":%d,"message_seq":%d,"from_uid":%q,"channel_id":%q,"channel_type":1,"timestamp":%d,"payload":%q}]`,
+		seq, seq, fromUID, channelID, 1700000000+int(seq), b64,
+	)
+	mac := hmac.New(sha256.New, []byte(reproWebhookSecret))
+	mac.Write([]byte(body))
+	sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/webhook/message/notify", strings.NewReader(body))
+	req.Header.Set("X-Signature-256", sig)
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+// reproIngestDM ingests an inbound DM from the peer contact to the login user.
+func reproIngestDM(t *testing.T, s *server.Server, spaceID string, seq uint32) {
+	t.Helper()
+	reproIngestPersonMsg(t, s, reproPeerUID, testutil.UID, spaceID, seq)
+}
+
+// reproSeedBotUser marks botUID as a regular bot (user.robot=1) so GetBotUIDs
+// recognizes it and the conversation filter routes it through the bot branch.
+func reproSeedBotUser(t *testing.T, ctx *config.Context, botUID string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `user` (uid, robot) VALUES (?, 1)", botUID,
+	).Exec()
+	require.NoError(t, err)
+}
+
+// reproEnsureAppBotTable stubs an EMPTY app_bot table. The bot in these tests is
+// a robot (user.robot=1, identified by GetBotUIDs); app_bot is a SEPARATE
+// mechanism (platform/space-scoped bots) and is left empty here. But
+// CheckBotsInSpace (pkg/space) always also queries app_bot — and the message test
+// binary doesn't load the app_bot module, so that table is absent and the query
+// errors → resolveBotFilter fail-opens (skipBotFilter=true) and shows every bot in
+// every Space, masking the membership logic. Creating the empty table lets the
+// robot membership path (space_member) run for real. Only the queried columns are
+// needed (uid/status/scope/space_id); nothing inserts into it here.
+func reproEnsureAppBotTable(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"CREATE TABLE IF NOT EXISTS app_bot (" +
+			"uid VARCHAR(40) NOT NULL, status TINYINT NOT NULL DEFAULT 0, " +
+			"scope VARCHAR(20) NOT NULL DEFAULT 'platform', space_id VARCHAR(40) DEFAULT NULL)",
+	).Exec()
+	require.NoError(t, err)
+}
+
+// reproSeedBotMember makes botUID a member of spaceID (CheckBotsInSpace → in-space).
+func reproSeedBotMember(t *testing.T, ctx *config.Context, spaceID, botUID string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO space_member (space_id, uid, role, status, created_at, updated_at) VALUES (?, ?, 0, 1, NOW(), NOW())",
+		spaceID, botUID,
+	).Exec()
+	require.NoError(t, err)
+}
+
+// reproCallConvSync drives POST /v1/conversation/sync with X-Space-ID and
+// returns the channel IDs present in the response conversation list.
+func reproCallConvSync(t *testing.T, s *server.Server, spaceID string) []string {
+	t.Helper()
+	body := `{"version":0,"msg_count":50,"device_uuid":"dev-repro","recent_filter":false}`
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/conversation/sync", strings.NewReader(body))
+	req.Header.Set("token", testutil.Token)
+	// spaceID=="" models a request with NO space context (no X-Space-ID, no
+	// ?space_id) — SpaceMiddleware then passes through without setting space_id.
+	if spaceID != "" {
+		req.Header.Set("X-Space-ID", spaceID)
+	}
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var wrap struct {
+		Conversations []struct {
+			ChannelID string `json:"channel_id"`
+		} `json:"conversations"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrap))
+	ids := make([]string, 0, len(wrap.Conversations))
+	for _, c := range wrap.Conversations {
+		ids = append(ids, c.ChannelID)
+	}
+	return ids
+}
+
+// reproCallConvSyncNoSpace drives POST /v1/conversation/sync with NO space
+// context at all (no ?space_id, no X-Space-ID) — the production "client forgot
+// to send space_id" request. The handler then SKIPS FilterConversationsBySpace.
+func reproCallConvSyncNoSpace(t *testing.T, s *server.Server) []string {
+	t.Helper()
+	return reproCallConvSync(t, s, "")
+}
+
+// reproCallChannelSync drives POST /v1/message/channel/sync for the DM channel
+// with X-Space-ID and returns the content markers of the returned messages.
+func reproCallChannelSync(t *testing.T, s *server.Server, spaceID string) []string {
+	t.Helper()
+	body := `{"channel_id":"` + reproPeerUID + `","channel_type":1,"limit":100,"pull_mode":1}`
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/message/channel/sync", strings.NewReader(body))
+	req.Header.Set("token", testutil.Token)
+	req.Header.Set("X-Space-ID", spaceID)
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var resp struct {
+		Messages []struct {
+			Payload map[string]interface{} `json:"payload"`
+		} `json:"messages"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	contents := make([]string, 0, len(resp.Messages))
+	for _, m := range resp.Messages {
+		if c, ok := m.Payload["content"].(string); ok {
+			contents = append(contents, c)
+		}
+	}
+	return contents
+}
+
+func reproContains(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestRepro484_Symptom2_DMVisibleInEverySpaceItHasMessages asserts the fix for
+// symptom 2: a single DM that has messages in BOTH spaceB and spaceC is visible
+// in BOTH simultaneously — the shared Recents window no longer makes them
+// mutually exclusive. Presence is written via the REAL message webhook.
+func TestRepro484_Symptom2_DMVisibleInEverySpaceItHasMessages(t *testing.T) {
+	s, _ := reproSetup(t)
+	reproIMConv = reproDMConv() // Recents are UNTAGGED → visibility is presence-driven
+
+	// The contact was chatted with in spaceB AND spaceC (durable presence rows).
+	reproIngestDM(t, s, reproSpaceB, 1)
+	reproIngestDM(t, s, reproSpaceC, 2)
+
+	inB := reproCallConvSync(t, s, reproSpaceB)
+	inC := reproCallConvSync(t, s, reproSpaceC)
+
+	assert.True(t, reproContains(inB, reproPeerUID),
+		"DM visible in spaceB (authoritative presence), independent of the Recents window")
+	assert.True(t, reproContains(inC, reproPeerUID),
+		"FIXED symptom 2: the SAME DM is also visible in spaceC at the same time — no mutual hide")
+}
+
+// TestRepro484_Symptom2_IsolationPreserved asserts we did not over-correct: a DM
+// with messages only in spaceB is visible in spaceB but NOT in spaceC (which it
+// genuinely has no messages in).
+func TestRepro484_Symptom2_IsolationPreserved(t *testing.T) {
+	s, _ := reproSetup(t)
+	reproIMConv = reproDMConv()
+
+	reproIngestDM(t, s, reproSpaceB, 1) // only spaceB
+
+	inB := reproCallConvSync(t, s, reproSpaceB)
+	inC := reproCallConvSync(t, s, reproSpaceC)
+
+	assert.True(t, reproContains(inB, reproPeerUID), "DM visible in the Space it has messages in")
+	assert.False(t, reproContains(inC, reproPeerUID),
+		"isolation preserved: DM absent from a Space it has no messages in")
+}
+
+// TestRepro484_DefaultSpaceListsOtherSpaceOnlyDM confirms CURRENT (known)
+// behavior, NOT a desired end-state: the default-Space catch-all
+// (space_filter.go:305-309 decideConvKeepInSpace) lists EVERY bare DM in the
+// user's default Space, including a DM whose messages belong only to a
+// non-default Space. So `POST /v1/conversation/sync` with space_id = the user's
+// default Space surfaces other-Space DMs as entries. This is an open product
+// question (issue #484 follow-up), tracked here as a reproduction. By contrast a
+// non-default Space the DM has no messages in correctly hides it (the #484 fix).
+func TestRepro484_DefaultSpaceListsOtherSpaceOnlyDM(t *testing.T) {
+	s, _ := reproSetup(t)
+	// A DM whose ONLY recent message is spaceB-tagged (no untagged / no
+	// default-tagged content), so any default-Space visibility can ONLY come from
+	// the catch-all branch — not from legacy/untagged history.
+	reproIMConv = &config.SyncUserConversationResp{
+		ChannelID:   reproPeerUID,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Timestamp:   1700000099,
+		LastMsgSeq:  1,
+		Version:     100,
+		Recents:     []*config.MessageResp{reproMsg(1, "only-spaceB", reproSpaceB)},
+	}
+
+	inDefault := reproCallConvSync(t, s, reproSpaceDefault)
+	assert.True(t, reproContains(inDefault, reproPeerUID),
+		"KNOWN: default-Space catch-all lists a DM whose messages are only in non-default spaceB")
+
+	inC := reproCallConvSync(t, s, reproSpaceC)
+	assert.False(t, reproContains(inC, reproPeerUID),
+		"non-default spaceC (DM has no messages there) correctly hides it — the #484 fix")
+}
+
+// TestRepro484_Symptom1_UntaggedHistoryOnlyInDefaultSpace asserts the fix for
+// symptom 1: an untagged DM message is kept only in the user's default Space,
+// no longer leaking into every Space.
+func TestRepro484_Symptom1_UntaggedHistoryOnlyInDefaultSpace(t *testing.T) {
+	s, _ := reproSetup(t)
+
+	// One DM history: a spaceB-tagged msg, an UNTAGGED msg, a spaceC-tagged msg.
+	reproIMMsgs = []*config.MessageResp{
+		reproMsg(1, "msg-tagged-B", reproSpaceB),
+		reproMsg(2, "msg-UNTAGGED", ""),
+		reproMsg(3, "msg-tagged-C", reproSpaceC),
+	}
+
+	// Non-default Space (spaceB): only its own tagged message; untagged dropped.
+	inB := reproCallChannelSync(t, s, reproSpaceB)
+	assert.True(t, reproContains(inB, "msg-tagged-B"), "spaceB sees its own tagged msg")
+	assert.False(t, reproContains(inB, "msg-tagged-C"), "spaceB does NOT see spaceC's tagged msg")
+	assert.False(t, reproContains(inB, "msg-UNTAGGED"),
+		"FIXED symptom 1: untagged msg no longer leaks into non-default spaceB")
+
+	// Default Space: the untagged message is retained (forward-compat).
+	inDefault := reproCallChannelSync(t, s, reproSpaceDefault)
+	assert.True(t, reproContains(inDefault, "msg-UNTAGGED"), "untagged msg retained in default Space")
+	assert.False(t, reproContains(inDefault, "msg-tagged-B"), "default Space does NOT see spaceB's tagged msg")
+}
+
+// TestRepro484_Bot_SystemBotVisibleInEverySpace locks the contract that a system
+// bot DM (here botfather) is present in the conversation list of EVERY Space —
+// the #484 fix must not change this. Visibility holds via the SystemBots branch
+// in decideConvKeepInSpace (space_filter.go) and/or the EnsureSystemBotsPresent
+// fallback injection.
+func TestRepro484_Bot_SystemBotVisibleInEverySpace(t *testing.T) {
+	s, _ := reproSetup(t)
+	// botfather DM with a spaceB-tagged recent — irrelevant to a system bot, which
+	// is visible regardless of Space/messages.
+	reproIMConv = &config.SyncUserConversationResp{
+		ChannelID:   "botfather",
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Timestamp:   1700000099,
+		LastMsgSeq:  1,
+		Version:     100,
+		Recents:     []*config.MessageResp{reproMsg(1, "bot-hi", reproSpaceB)},
+	}
+
+	inDefault := reproCallConvSync(t, s, reproSpaceDefault)
+	inC := reproCallConvSync(t, s, reproSpaceC)
+
+	assert.True(t, reproContains(inDefault, "botfather"), "system bot visible in default Space")
+	assert.True(t, reproContains(inC, "botfather"), "system bot visible in non-default spaceC too")
+}
+
+// TestRepro484_Bot_RegularBotRespectsSpaceMembership verifies a regular bot
+// (user.robot=1) is visible only in Spaces it is a member of — and crucially that
+// its dm_space_presence row (written by the webhook for ANY Person message with a
+// space_id, bots included) is IGNORED: the presence/Recents check is gated behind
+// `if !botSet[channelID]`, so a bot that messaged in spaceC but is NOT a spaceC
+// member must stay hidden there. This locks the !botSet gate (space_filter.go:321).
+func TestRepro484_Bot_RegularBotRespectsSpaceMembership(t *testing.T) {
+	s, ctx := reproSetup(t)
+	const botX = "bot_x_888"
+	reproSeedBotUser(t, ctx, botX)                // recognized as a bot
+	reproSeedBotMember(t, ctx, reproSpaceB, botX) // member of spaceB only
+
+	// The bot sent a spaceC-tagged message → webhook writes presence(pair, spaceC).
+	// The bot is NOT a spaceC member, so this row must NOT make it visible there.
+	reproIngestPersonMsg(t, s, botX, testutil.UID, reproSpaceC, 1)
+
+	reproIMConv = &config.SyncUserConversationResp{
+		ChannelID:   botX,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Timestamp:   1700000099,
+		LastMsgSeq:  1,
+		Version:     100,
+		Recents:     []*config.MessageResp{reproMsg(1, "bot-msg", reproSpaceC)},
+	}
+
+	inB := reproCallConvSync(t, s, reproSpaceB)
+	inC := reproCallConvSync(t, s, reproSpaceC)
+
+	assert.True(t, reproContains(inB, botX), "regular bot visible in spaceB (it is a member)")
+	assert.False(t, reproContains(inC, botX),
+		"regular bot HIDDEN in spaceC: not a member, and its dm_space_presence row is correctly ignored for bots")
+}

--- a/modules/message/dm_presence_accessor_test.go
+++ b/modules/message/dm_presence_accessor_test.go
@@ -1,0 +1,113 @@
+//go:build integration
+
+package message
+
+// DB-level lock-down for the dm_space_presence accessors (pkg/space).
+//
+// Reviewer request (#519, Jerry-Xin): the raw SQL in UpsertDMSpacePresence /
+// DMSpacePresenceSet / DMSpacePresenceAnySet was only covered indirectly via the
+// webhook→filter integration path. This test exercises each accessor directly
+// against the real MySQL schema so its SQL contract is asserted on its own:
+//
+//   - UpsertDMSpacePresence: idempotent insert; last_timestamp advances by
+//     GREATEST (a lower ts never lowers the stored value); empty channel/space
+//     is a silent no-op (no row written).
+//   - DMSpacePresenceSet: per-Space IN filter, set keyed by fake_channel_id;
+//     empty ids / empty space short-circuit to an empty set without querying.
+//   - DMSpacePresenceAnySet: has-a-row-in-ANY-Space DISTINCT set; the
+//     "tracked but only in other Spaces" derivation the default-Space catch-all
+//     relies on (AnySet minus Set(defaultSpace)).
+//
+//	go test -tags=integration ./modules/message/ -run TestDMSpacePresenceAccessors -v
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
+	"github.com/gocraft/dbr/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDMSpacePresenceAccessors(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+	db := ctx.DB()
+
+	// Self-namespaced keys so the test is independent of rows any other suite may
+	// have left behind — CleanAllTables does not truncate dm_space_presence.
+	const (
+		fcA    = "dmpresacc_pair_a"
+		fcB    = "dmpresacc_pair_b"
+		fcC    = "dmpresacc_pair_c" // deliberately never written → absent everywhere
+		spaceA = "dmpresacc_space_a"
+		spaceB = "dmpresacc_space_b"
+	)
+	ids := []string{fcA, fcB, fcC}
+	_, err := db.DeleteBySql("DELETE FROM dm_space_presence WHERE fake_channel_id IN ?", ids).Exec()
+	require.NoError(t, err)
+
+	// --- empty-input / empty-arg guards: return empty, never error, never write.
+	set, err := spacepkg.DMSpacePresenceSet(db, nil, spaceA)
+	require.NoError(t, err)
+	assert.Empty(t, set, "Set: nil ids → empty set")
+
+	set, err = spacepkg.DMSpacePresenceSet(db, ids, "")
+	require.NoError(t, err)
+	assert.Empty(t, set, "Set: empty spaceID → empty set")
+
+	anySet, err := spacepkg.DMSpacePresenceAnySet(db, nil)
+	require.NoError(t, err)
+	assert.Empty(t, anySet, "AnySet: nil ids → empty set")
+
+	require.NoError(t, spacepkg.UpsertDMSpacePresence(db, "", spaceA, 1), "Upsert: empty channel is a no-op")
+	require.NoError(t, spacepkg.UpsertDMSpacePresence(db, fcA, "", 1), "Upsert: empty space is a no-op")
+	anySet, err = spacepkg.DMSpacePresenceAnySet(db, ids)
+	require.NoError(t, err)
+	assert.Empty(t, anySet, "no-op upserts must not write any row")
+
+	// --- seed: fcA present in spaceA(ts=100) and spaceB(ts=50); fcB in spaceB only.
+	require.NoError(t, spacepkg.UpsertDMSpacePresence(db, fcA, spaceA, 100))
+	require.NoError(t, spacepkg.UpsertDMSpacePresence(db, fcA, spaceB, 50))
+	require.NoError(t, spacepkg.UpsertDMSpacePresence(db, fcB, spaceB, 10))
+
+	// --- DMSpacePresenceSet: per-Space IN filter, keyed by fake_channel_id.
+	inSpaceA, err := spacepkg.DMSpacePresenceSet(db, ids, spaceA)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]bool{fcA: true}, inSpaceA, "spaceA holds only fcA")
+
+	inSpaceB, err := spacepkg.DMSpacePresenceSet(db, ids, spaceB)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]bool{fcA: true, fcB: true}, inSpaceB, "spaceB holds fcA + fcB")
+
+	// --- DMSpacePresenceAnySet: any-Space membership; fcC never written → absent.
+	anySet, err = spacepkg.DMSpacePresenceAnySet(db, ids)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]bool{fcA: true, fcB: true}, anySet)
+
+	// The "elsewhere-only" derivation the catch-all hides on: tracked in some
+	// Space (AnySet) but NOT in the default Space (Set(default)).
+	assert.True(t, anySet[fcB] && !inSpaceA[fcB], "fcB is tracked but absent from spaceA → elsewhere-only vs spaceA")
+	assert.False(t, anySet[fcA] && !inSpaceA[fcA], "fcA is present in spaceA → NOT elsewhere-only vs spaceA")
+
+	// --- GREATEST: a lower ts must not lower the stored value; a higher one advances it.
+	require.NoError(t, spacepkg.UpsertDMSpacePresence(db, fcA, spaceA, 40))
+	assert.Equal(t, int64(100), readPresenceTS(t, db, fcA, spaceA), "lower ts (40) keeps stored 100")
+	require.NoError(t, spacepkg.UpsertDMSpacePresence(db, fcA, spaceA, 250))
+	assert.Equal(t, int64(250), readPresenceTS(t, db, fcA, spaceA), "higher ts (250) advances the value")
+}
+
+// readPresenceTS reads last_timestamp for one (fake_channel_id, space_id) row,
+// mirroring the slice-Load idiom the accessors use.
+func readPresenceTS(t *testing.T, db *dbr.Session, fakeChannelID, spaceID string) int64 {
+	t.Helper()
+	var tss []int64
+	_, err := db.SelectBySql(
+		"SELECT last_timestamp FROM dm_space_presence WHERE fake_channel_id = ? AND space_id = ?",
+		fakeChannelID, spaceID,
+	).Load(&tss)
+	require.NoError(t, err)
+	require.Len(t, tss, 1, "exactly one row for (%s,%s)", fakeChannelID, spaceID)
+	return tss[0]
+}

--- a/modules/message/dm_prod_trace_test.go
+++ b/modules/message/dm_prod_trace_test.go
@@ -1,0 +1,121 @@
+//go:build integration
+
+package message
+
+// Server-side reproductions of the three conversation cross-Space paths that a
+// production incident + a client-side SpaceFilter diagnostic surfaced. All data
+// here is SYNTHETIC — no real uids, space ids, or names. The tests drive the
+// REAL /v1/conversation/sync handler to characterise each path so they can be
+// told apart from an actual request without needing a production capture.
+//
+// Three Spaces from the shared harness:
+//
+//	reproSpaceDefault  the user's DEFAULT Space (earliest joined)
+//	reproSpaceB        a non-default Space the user is viewing
+//	reproSpaceC        a third non-default Space (isolation contrast)
+//
+// None of these tests write dm_space_presence rows, so they characterise the
+// pre-existing behaviour independent of the #484 fix.
+//
+//	go test -tags=integration ./modules/message/ -run TestRepro484_ProdTrace -v
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	ppHumanA = "pp_human_a"
+	ppHumanB = "pp_human_b"
+	ppHumanC = "pp_human_c"
+	ppRobot  = "pp_robot_untagged" // seeded user.robot=1, messages untagged, member of no Space
+)
+
+// TestRepro484_ProdTrace_MissingSpaceID_LeaksCrossSpaceDMs reproduces the FIRST
+// path: the request carried NO space context. SpaceMiddleware fails open
+// (pkg/space/middleware.go:108-115 → c.Next() without setting space_id), so the
+// handler's `if spaceID != ""` guard skips FilterConversationsBySpace entirely
+// (api_conversation.go:889) and returns the user's DMs from EVERY Space.
+//
+// Discriminator: with identical data, the only difference between the two calls
+// is the presence of the space header. The DMs a non-default query correctly
+// drops are returned when the header is omitted — including an untagged robot DM.
+func TestRepro484_ProdTrace_MissingSpaceID_LeaksCrossSpaceDMs(t *testing.T) {
+	s, ctx := reproSetup(t)
+	// A robot (user.robot=1) that is a member of NO Space and whose messages carry
+	// no space_id → any real filter MUST drop it under a non-default Space.
+	reproSeedBotUser(t, ctx, ppRobot)
+
+	// Two human DMs tagged only with the DEFAULT Space, one untagged robot DM, and
+	// one DM that legitimately belongs to spaceB.
+	reproIMConvs = []*config.SyncUserConversationResp{
+		reproDMConvFor(ppHumanA, "default-A", reproSpaceDefault),
+		reproDMConvFor(ppHumanB, "default-B", reproSpaceDefault),
+		reproDMConvFor(ppRobot, "robot-untagged", ""),
+		reproDMConvFor(ppHumanC, "spaceB-real", reproSpaceB),
+	}
+
+	// (1) No space context → filter skipped → every DM returned.
+	noSpace := reproCallConvSyncNoSpace(t, s)
+	assert.True(t, reproContains(noSpace, ppHumanA), "no space_id: a default-only DM leaks")
+	assert.True(t, reproContains(noSpace, ppHumanB), "no space_id: a default-only DM leaks")
+	assert.True(t, reproContains(noSpace, ppRobot),
+		"no space_id: the untagged robot DM leaks too")
+	assert.True(t, reproContains(noSpace, ppHumanC), "no space_id: the spaceB DM is also present")
+
+	// (2) Same data, now WITH X-Space-ID=spaceB → filter runs → cross-Space dropped.
+	inB := reproCallConvSync(t, s, reproSpaceB)
+	assert.True(t, reproContains(inB, ppHumanC), "spaceB query keeps the DM that belongs to spaceB")
+	assert.False(t, reproContains(inB, ppHumanA), "spaceB query drops the default-only DM")
+	assert.False(t, reproContains(inB, ppHumanB), "spaceB query drops the default-only DM")
+	assert.False(t, reproContains(inB, ppRobot), "spaceB query drops the untagged robot DM")
+
+	// The delta between (1) and (2) — identical data, only the space header
+	// differs — isolates "Space filter not executed" as the leak's direct cause.
+}
+
+// TestRepro484_ProdTrace_DefaultSpaceCatchAll_ShowsAllDMs reproduces the SECOND
+// candidate: the request carried the user's DEFAULT Space. decideConvKeepInSpace's
+// catch-all (space_filter.go:305-309) returns true for EVERY bare non-bot DM when
+// filterSpaceID == defaultSpaceID — so the default Space lists DMs that belong
+// only to OTHER Spaces.
+//
+// TELL distinguishing it from the missing-space_id path: the catch-all still runs
+// the bot sub-check, so a robot DM that is NOT a member of the default Space is
+// HIDDEN. A robot that leaked in production therefore points at the
+// missing-space_id path, not this one. Capturing one real request decides between
+// them.
+func TestRepro484_ProdTrace_DefaultSpaceCatchAll_ShowsAllDMs(t *testing.T) {
+	s, ctx := reproSetup(t)
+	reproSeedBotUser(t, ctx, ppRobot) // robot, member of NO Space here
+
+	reproIMConvs = []*config.SyncUserConversationResp{
+		reproDMConvFor(ppHumanA, "only-spaceB", reproSpaceB), // human, msgs only in spaceB
+		reproDMConvFor(ppHumanB, "only-spaceC", reproSpaceC), // human, msgs only in spaceC
+		reproDMConvFor(ppRobot, "robot-untagged", ""),        // robot, untagged
+	}
+
+	// Query the DEFAULT Space → catch-all lists cross-Space HUMAN DMs...
+	def := reproCallConvSync(t, s, reproSpaceDefault)
+	assert.True(t, reproContains(def, ppHumanA),
+		"catch-all: a spaceB-only DM shows in the default Space")
+	assert.True(t, reproContains(def, ppHumanB),
+		"catch-all: a spaceC-only DM shows in the default Space")
+	// ...but the catch-all bot sub-check HIDES a robot that is not a default member.
+	assert.False(t, reproContains(def, ppRobot),
+		"catch-all hides a non-member robot — so this path alone can't explain a leaked robot")
+
+	// Contrast: a non-default Space isolates correctly (no catch-all).
+	spaceC := reproCallConvSync(t, s, reproSpaceC)
+	assert.True(t, reproContains(spaceC, ppHumanB), "spaceC query keeps the spaceC-only DM")
+	assert.False(t, reproContains(spaceC, ppHumanA), "spaceC query drops the spaceB-only DM")
+}
+
+// NOTE: the former TestRepro484_ProdTrace_SpacelessGroupShownInEverySpace
+// characterized the pre-fix bug (an empty-space_id group visible in every
+// Space). That path is now FIXED on this branch (spaceless groups/topics are
+// attributed to the default Space only), so the reproduction is superseded by
+// TestConvSpaceCatchall_SpacelessGroupAndTopicOnlyDefault, which asserts the
+// fixed behavior end-to-end.

--- a/modules/message/space_filter.go
+++ b/modules/message/space_filter.go
@@ -31,8 +31,23 @@ func FilterConversationsBySpace(
 		return conversations
 	}
 
-	// 查用户的默认 Space（最早加入的），裸 UID 旧会话只在默认 Space 显示
-	defaultSpaceID := space.GetUserDefaultSpaceID(ctx, loginUID)
+	// 查用户的默认 Space（最早加入的），裸 UID 旧会话只在默认 Space 显示。
+	// defaultSpaceID 决定空 space_id 群/子区的归属与默认-Space DM catch-all。
+	//
+	// 查询失败时置为 ""（sentinel），而非 filterSpaceID —— #519 reviewer P1
+	// (yujiawei / OctoBoooot)：若置为 filterSpaceID，非默认请求会满足下方裸 DM
+	// catch-all 门（filterSpaceID == defaultSpaceID → return true），把用户全部裸
+	// DM（含纯属他空间的）泄漏到当前 Space。per-Space DM 隔离是本 PR 要建立的安全
+	// 属性，错误路径必须 fail-closed（偏向隐藏，不偏向显示）。filterSpaceID 在过滤器
+	// 运行时恒非空（两个调用点都在 `if spaceID != ""` 内），故 "" 是「永不等于真实
+	// filterSpaceID」的 sentinel：非默认请求 catch-all 不触发、落到 presence/Recents
+	// 扫描保持隔离；空 space_id 群/子区本次请求隐藏（fail-closed，是 pre-PR「全 Space
+	// 可见」的子集，非回归）。等价于 pre-PR GetUserDefaultSpaceID 出错返回 "" 的语义。
+	defaultSpaceID, defaultSpaceErr := space.GetUserDefaultSpaceIDE(ctx, loginUID)
+	if defaultSpaceErr != nil {
+		log.Warn("查询默认 Space 失败，Space 过滤 fail-closed（defaultSpaceID 置空 sentinel）", zap.Error(defaultSpaceErr), zap.String("loginUID", loginUID))
+		defaultSpaceID = ""
+	}
 
 	// 群聊的 channel_id 是裸 group_no（没有 Space 前缀），ParseChannelID 返回 spaceID=""。
 	// 需要从 group 表查出真实 space_id。
@@ -100,7 +115,58 @@ func FilterConversationsBySpace(
 		loginUID, groupService,
 	)
 
-	return filterConversationsCore(conversations, filterSpaceID, defaultSpaceID, groupSpaceMap, externalGroupMap, botSet, botInSpace, skipGroupFilter, skipBotFilter)
+	// issue #484：DM per-Space 存在性（窗口无关的权威信号）。
+	dmPresentSet := resolveDMPresence(ctx, loginUID, filterSpaceID, bareDMUIDs)
+
+	filtered := filterConversationsCore(conversations, filterSpaceID, defaultSpaceID, groupSpaceMap, externalGroupMap, botSet, botInSpace, skipGroupFilter, skipBotFilter, dmPresentSet)
+
+	// issue #484 follow-up：默认 Space catch-all 收紧。仅在默认 Space 请求、且默认
+	// Space 解析成功时启用；presence 证据表明 DM 只属于其他 Space 且 Recents 无反证
+	// → 隐藏。任何查询失败降级为不隐藏（见 space_filter_default_catchall.go）。
+	if filterSpaceID == defaultSpaceID && defaultSpaceErr == nil {
+		elsewhereOnly := resolveDMElsewhereOnly(ctx, loginUID, defaultSpaceID, bareDMUIDs)
+		filtered = hideElsewhereOnlyDMsInDefaultSpace(
+			filtered,
+			func(c *SyncUserConversationResp) string { return c.ChannelID },
+			func(c *SyncUserConversationResp) uint8 { return c.ChannelType },
+			func(c *SyncUserConversationResp) bool { return personConvAllRecentsTaggedElsewhere(c, defaultSpaceID) },
+			elsewhereOnly, botSet, skipBotFilter,
+		)
+	}
+	return filtered
+}
+
+// resolveDMPresence 批量解析 DM 在 filterSpaceID 下的存在性（issue #484）。
+// 输入是会话里的裸 DM 对端 UID 列表；按 common.GetFakeChannelIDWith(loginUID, peer)
+// 规范化成 dm_space_presence 的主键查询，再把命中结果回映射成“对端 UID -> true”，
+// 以便 decideConvKeepInSpace 直接用 conv.ChannelID 命中。
+//
+// 失败/空输入返回 nil（优雅降级）：读侧对 nil map 取值得 false，会回退到
+// Recents 窗口扫描的 OR 项，不比现状更差，也不会误隐藏存量 DM。
+func resolveDMPresence(ctx *config.Context, loginUID, filterSpaceID string, bareDMUIDs []string) map[string]bool {
+	if ctx == nil || loginUID == "" || filterSpaceID == "" || len(bareDMUIDs) == 0 {
+		return nil
+	}
+	fakeToPeer := make(map[string]string, len(bareDMUIDs))
+	fakeIDs := make([]string, 0, len(bareDMUIDs))
+	for _, peer := range bareDMUIDs {
+		fake := common.GetFakeChannelIDWith(loginUID, peer)
+		if _, ok := fakeToPeer[fake]; ok {
+			continue
+		}
+		fakeToPeer[fake] = peer
+		fakeIDs = append(fakeIDs, fake)
+	}
+	presentFakes, err := spacepkg.DMSpacePresenceSet(ctx.DB(), fakeIDs, filterSpaceID)
+	if err != nil {
+		log.Warn("查询 dm_space_presence 失败，回退 Recents 兜底", zap.Error(err))
+		return nil
+	}
+	out := make(map[string]bool, len(presentFakes))
+	for fake := range presentFakes {
+		out[fakeToPeer[fake]] = true
+	}
+	return out
 }
 
 // filterThreadConvsByParentMembership 剔除“调用者已不是父群成员”的子区(CommunityTopic)
@@ -185,6 +251,7 @@ func filterConversationsCore(
 	botInSpace map[string]bool,
 	skipGroupFilter bool,
 	skipBotFilter bool,
+	dmPresentSet map[string]bool,
 ) []*SyncUserConversationResp {
 	filtered := make([]*SyncUserConversationResp, 0, len(conversations))
 	for _, conv := range conversations {
@@ -195,6 +262,7 @@ func filterConversationsCore(
 			skipGroupFilter, skipBotFilter,
 			// v1 兼容：群表查询失败时不过滤（与历史 FilterConversationsBySpace 一致）。
 			false,
+			dmPresentSet,
 			func(target string) bool { return personConvHasSpaceMessages(conv, target) },
 		)
 		if keep {
@@ -216,10 +284,10 @@ func filterConversationsCore(
 //     有 payload.space_id == targetSpaceID 的消息。
 //   - failClosedOnUnknownGroupSpace: 当 skipGroupFilter=true（group service 查询
 //     失败、无法确认群的 space_id）时的语义切换。
-//     - false（v1 兼容默认）：保留群/子区，不让一次 DB 抖动影响存量行为。
-//     - true（v2 sidebar 用，PR #21 Round-6 P0-1）：drop 群/子区，避免跨 Space
-//       泄露（reviewer Jerry-Xin / yujiawei）。这是 fail-closed —— 用户多刷
-//       一次即可，但绝不让 Space A 的群在 Space B 请求里露出。
+//   - false（v1 兼容默认）：保留群/子区，不让一次 DB 抖动影响存量行为。
+//   - true（v2 sidebar 用，PR #21 Round-6 P0-1）：drop 群/子区，避免跨 Space
+//     泄露（reviewer Jerry-Xin / yujiawei）。这是 fail-closed —— 用户多刷
+//     一次即可，但绝不让 Space A 的群在 Space B 请求里露出。
 func decideConvKeepInSpace(
 	channelID string,
 	channelType uint8,
@@ -229,6 +297,7 @@ func decideConvKeepInSpace(
 	botSet, botInSpace map[string]bool,
 	skipGroupFilter, skipBotFilter bool,
 	failClosedOnUnknownGroupSpace bool,
+	dmPresentSet map[string]bool,
 	hasSpaceMsg func(targetSpaceID string) bool,
 ) bool {
 	spaceID := convSpaceID
@@ -259,7 +328,12 @@ func decideConvKeepInSpace(
 			}
 		}
 		if spaceID == "" {
-			return true
+			// issue #484 follow-up：无法归属的群（group.space_id 为空 / group 表无
+			// 记录）不再全 Space 可见 —— 生产实证这是最近列表串空间的确定路径
+			// （客户端拿到 conv 级 space_id=null 只能 fail-open 渲染到每个 Space）。
+			// 归属到用户默认 Space，与 #337 裸 DM、#484 无标签 DM 历史同口径；
+			// 群表回填 space_id 后自动恢复精确归属。
+			return filterSpaceID == defaultSpaceID
 		}
 		return false
 	}
@@ -280,6 +354,12 @@ func decideConvKeepInSpace(
 			return true
 		}
 		if !botSet[channelID] {
+			// issue #484：DM 可见性以持久化的 dm_space_presence 为权威信号，
+			// 与历史 Recents 窗口扫描 OR —— presence 解决“跨窗口被挤出而隐藏”
+			// （症状2），Recents 兜底保证存量 DM 不因尚未写索引而消失。
+			if dmPresentSet[channelID] {
+				return true
+			}
 			return hasSpaceMsg != nil && hasSpaceMsg(filterSpaceID)
 		}
 	}
@@ -321,7 +401,9 @@ func filterThreadConvCore(
 			return true
 		}
 	}
-	return parentSpaceID == ""
+	// issue #484 follow-up：父群无法归属（space_id 为空/群表无记录）的子区与父群
+	// 同口径 —— 只在用户默认 Space 露出，不再全 Space 可见。
+	return parentSpaceID == "" && filterSpaceID == defaultSpaceID
 }
 
 // filterThreadConv 判断子区会话是否应在 filterSpaceID 中显示。
@@ -430,16 +512,18 @@ func newSystemBotPlaceholder(uid string) *SyncUserConversationResp {
 // 本函数仅针对 Person (DM) 路径：
 //   - GROUP channel_id 本身做 Space 隔离（不同 Space 的群 channel_id 不同），
 //     对历史消息再过滤反而会误杀老群，因此 GROUP/COMMUNITY_TOPIC 路径不走这里。
-//   - 规则（与 Android ChatActivity.filterSystemBotMessages 口径对齐）：
-//       1) payload.space_id == spaceID               → 保留（精确匹配当前 Space）
-//       2) payload.space_id == "" && !isSystemBot    → 保留（老 DM 消息向前兼容）
-//       3) payload.space_id == "" &&  isSystemBot    → 丢弃（SystemBot 无 space
-//          标签的老消息默认隐藏，避免 fileHelper/u_10000 老消息跨 Space 泄露）
-//       4) payload.space_id != "" && != spaceID      → 丢弃（跨 Space 明确污染）
+//   - 规则（issue #484 后；与三端 SpaceFilter 口径对齐）：
+//     1) payload.space_id == spaceID                         → 保留（精确匹配）
+//     2) payload.space_id == "" && !isSystemBot && 默认Space  → 保留（无标签 DM
+//     历史只在用户默认 Space 向前兼容，避免出现在每个 Space —— 症状1）
+//     3) payload.space_id == "" && !isSystemBot && 非默认Space→ 丢弃（不再 fail-open）
+//     4) payload.space_id == "" &&  isSystemBot               → 丢弃（SystemBot 无
+//     space 标签的老消息默认隐藏，避免 fileHelper/u_10000 老消息跨 Space 泄露）
+//     5) payload.space_id != "" && != spaceID                → 丢弃（跨 Space 污染）
 //
 // 调用方需保证 spaceID != ""（空串视为未启用 Space 过滤，直接返回原列表），
-// 并只对 ChannelTypePerson 调用本函数。
-func filterPersonMessagesBySpace(msgs []*MsgSyncResp, channelID, spaceID string) []*MsgSyncResp {
+// 传入 defaultSpaceID（用户默认 Space，决定规则 2/3），并只对 ChannelTypePerson 调用。
+func filterPersonMessagesBySpace(msgs []*MsgSyncResp, channelID, spaceID, defaultSpaceID string) []*MsgSyncResp {
 	if spaceID == "" || len(msgs) == 0 {
 		return msgs
 	}
@@ -454,10 +538,14 @@ func filterPersonMessagesBySpace(msgs []*MsgSyncResp, channelID, spaceID string)
 		case msid == spaceID:
 			// 精确匹配当前 Space → 保留
 			filtered = append(filtered, m)
-		case msid == "" && !isSysBot:
-			// 老 DM 消息无 space_id 字段，向前兼容保留，避免 Phase 3 前的历史
-			// 消息被一刀切隐藏（对齐 filterConversationsCore 对普通 DM 的口径）。
+		case msid == "" && !isSysBot && spaceID == defaultSpaceID:
+			// issue #484：无 space_id 的普通 DM 消息（发送方未带 X-Space-ID、
+			// Space 化之前的老消息、转发/名片）只在用户默认 Space 向前兼容保留，
+			// 不再出现在每个 Space —— 修复症状1（跨 Space 历史泄漏）。
 			filtered = append(filtered, m)
+		case msid == "" && !isSysBot:
+			// 非默认 Space：无标签 DM 消息不再 fail-open 放行，丢弃。
+			continue
 		case msid == "" && isSysBot:
 			// 系统 Bot 的无 space_id 历史消息一律隐藏。对齐 Android
 			// filterSystemBotMessages 和 iOS filterMessagesBySpace，避免
@@ -626,7 +714,14 @@ func FilterRawConversationsBySpace(
 		return conversations
 	}
 
-	defaultSpaceID := space.GetUserDefaultSpaceID(ctx, loginUID)
+	// 同 v1：defaultSpaceID 决定空 space_id 群/子区归属与 DM catch-all；失败时置为 ""
+	// sentinel（非 filterSpaceID），使非默认请求的裸 DM catch-all fail-closed，避免
+	// 跨空间 DM 泄漏（#519 reviewer P1，详见 v1 注释）。
+	defaultSpaceID, defaultSpaceErr := space.GetUserDefaultSpaceIDE(ctx, loginUID)
+	if defaultSpaceErr != nil {
+		log.Warn("v2 sidebar: 查询默认 Space 失败，Space 过滤 fail-closed（defaultSpaceID 置空 sentinel）", zap.Error(defaultSpaceErr), zap.String("loginUID", loginUID))
+		defaultSpaceID = ""
+	}
 
 	groupNoSeen := make(map[string]struct{})
 	var bareGroupNos []string
@@ -681,6 +776,9 @@ func FilterRawConversationsBySpace(
 
 	botSet, botInSpace, skipBotFilter := resolveBotFilter(ctx, filterSpaceID, bareDMUIDs)
 
+	// issue #484：DM per-Space 存在性（与 v1 同口径，窗口无关的权威信号）。
+	dmPresentSet := resolveDMPresence(ctx, loginUID, filterSpaceID, bareDMUIDs)
+
 	filtered := make([]*config.SyncUserConversationResp, 0, len(conversations))
 	for i, conv := range conversations {
 		keep := decideConvKeepInSpace(
@@ -691,11 +789,27 @@ func FilterRawConversationsBySpace(
 			// v2 sidebar 必须 fail-closed：群表查询失败时无法确认 space，drop
 			// 群/子区以免跨 Space 泄露（PR #21 Round-6 P0-1 by Jerry-Xin / yujiawei）。
 			true,
+			dmPresentSet,
 			func(target string) bool { return rawConvHasSpaceMessages(conv, target) },
 		)
 		if keep {
 			filtered = append(filtered, conv)
 		}
+	}
+
+	// issue #484 follow-up：默认 Space catch-all 收紧（与 v1 同口径，见
+	// space_filter_default_catchall.go）。
+	if filterSpaceID == defaultSpaceID && defaultSpaceErr == nil {
+		elsewhereOnly := resolveDMElsewhereOnly(ctx, loginUID, defaultSpaceID, bareDMUIDs)
+		filtered = hideElsewhereOnlyDMsInDefaultSpace(
+			filtered,
+			func(c *config.SyncUserConversationResp) string { return c.ChannelID },
+			func(c *config.SyncUserConversationResp) uint8 { return c.ChannelType },
+			func(c *config.SyncUserConversationResp) bool {
+				return rawConvAllRecentsTaggedElsewhere(c, defaultSpaceID)
+			},
+			elsewhereOnly, botSet, skipBotFilter,
+		)
 	}
 	return filtered
 }

--- a/modules/message/space_filter_default_catchall.go
+++ b/modules/message/space_filter_default_catchall.go
@@ -1,0 +1,142 @@
+package message
+
+import (
+	"encoding/json"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"go.uber.org/zap"
+
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
+)
+
+// 默认-Space DM catch-all 收紧（issue #484 follow-up）。
+//
+// decideConvKeepInSpace 的 catch-all 分支在 filterSpaceID == defaultSpaceID 时无
+// 条件保留所有裸 DM —— 包括「消息只属于其他 Space」的 DM，导致默认 Space 的最近
+// 会话列表串入他空间私聊（生产可复现）。本文件是过滤后的补充 pass：仅当存在
+// **正向持久证据**（dm_space_presence 有行、且没有一行属于默认 Space、且 Recents
+// 里没有默认/未打标消息作反证）时，才把该 DM 从默认 Space 列表中隐藏。
+//
+// 设计约束（与 #484 主修复同口径，fail-open on infra errors）：
+//   - 无任何 presence 行的存量/未打标 DM 保持 catch-all 现状（不凭空隐藏）；
+//   - presence / bot 解析任一查询失败 → 本 pass 整体跳过，不比现状隐藏更多；
+//   - 系统 Bot 永不隐藏（EnsureSystemBotsPresent 的占位契约不受影响）；
+//   - 普通 Bot 的可见性由 catch-all 内已有的成员子判定决定，本 pass 不二次裁决；
+//   - 自愈：用户在默认 Space 发一条消息即写入 presence(pair, default)，恢复可见。
+
+// resolveDMElsewhereOnly 返回「已被 presence 索引跟踪、但没有任何一行属于
+// defaultSpaceID」的裸 DM 对端集合（键为对端 UID）。任何失败返回 nil —— 调用方
+// 对 nil 集合跳过隐藏（优雅降级，不比现状更差）。
+func resolveDMElsewhereOnly(ctx *config.Context, loginUID, defaultSpaceID string, bareDMUIDs []string) map[string]bool {
+	if ctx == nil || loginUID == "" || defaultSpaceID == "" || len(bareDMUIDs) == 0 {
+		return nil
+	}
+	fakeToPeer := make(map[string]string, len(bareDMUIDs))
+	fakeIDs := make([]string, 0, len(bareDMUIDs))
+	for _, peer := range bareDMUIDs {
+		fake := common.GetFakeChannelIDWith(loginUID, peer)
+		if _, ok := fakeToPeer[fake]; ok {
+			continue
+		}
+		fakeToPeer[fake] = peer
+		fakeIDs = append(fakeIDs, fake)
+	}
+	anySet, err := spacepkg.DMSpacePresenceAnySet(ctx.DB(), fakeIDs)
+	if err != nil {
+		log.Warn("查询 dm_space_presence(any) 失败，跳过默认 Space catch-all 收紧", zap.Error(err))
+		return nil
+	}
+	if len(anySet) == 0 {
+		return nil
+	}
+	inDefault, err := spacepkg.DMSpacePresenceSet(ctx.DB(), fakeIDs, defaultSpaceID)
+	if err != nil {
+		log.Warn("查询 dm_space_presence(default) 失败，跳过默认 Space catch-all 收紧", zap.Error(err))
+		return nil
+	}
+	out := make(map[string]bool, len(anySet))
+	for fake := range anySet {
+		if !inDefault[fake] {
+			out[fakeToPeer[fake]] = true
+		}
+	}
+	return out
+}
+
+// hideElsewhereOnlyDMsInDefaultSpace 从默认 Space 的过滤结果中移除
+// elsewhereOnly 命中的裸 DM。allRecentsTaggedElsewhere 提供本地反证检查：
+// Recents 里只要有一条默认-Space 消息或未打标消息就保留（见下方两个实现）。
+// skipBotFilter=true（bot 解析失败，身份不可知）时整体跳过。
+func hideElsewhereOnlyDMsInDefaultSpace[T any](
+	convs []T,
+	chID func(T) string,
+	chType func(T) uint8,
+	allRecentsTaggedElsewhere func(T) bool,
+	elsewhereOnly map[string]bool,
+	botSet map[string]bool,
+	skipBotFilter bool,
+) []T {
+	if len(elsewhereOnly) == 0 || skipBotFilter {
+		return convs
+	}
+	kept := make([]T, 0, len(convs))
+	for _, conv := range convs {
+		id := chID(conv)
+		if chType(conv) == common.ChannelTypePerson.Uint8() &&
+			!spacepkg.SystemBots[id] && !botSet[id] &&
+			elsewhereOnly[id] && allRecentsTaggedElsewhere(conv) {
+			continue
+		}
+		kept = append(kept, conv)
+	}
+	return kept
+}
+
+// personConvAllRecentsTaggedElsewhere 判断 v1 会话的 Recents 是否**全部**明确
+// 属于其他 Space（每条都带非空 space_id 且都 != defaultSpaceID）。出现未打标 /
+// 解析不出 space_id / 默认-Space 消息即返回 false（反证成立 → 保留）。
+// 空 Recents 返回 true —— 没有本地反证，由权威 presence 决定。
+func personConvAllRecentsTaggedElsewhere(conv *SyncUserConversationResp, defaultSpaceID string) bool {
+	if conv == nil {
+		return true
+	}
+	for _, msg := range conv.Recents {
+		if msg == nil {
+			continue
+		}
+		sid := extractPayloadSpaceID(msg.Payload)
+		if sid == "" || sid == defaultSpaceID {
+			return false
+		}
+	}
+	return true
+}
+
+// rawConvAllRecentsTaggedElsewhere 是 personConvAllRecentsTaggedElsewhere 在原始
+// IM Payload []byte 形态下的对应实现（v2 sidebar 用）。payload 解析失败视同
+// 未打标（返回 false 保留）—— 隐藏决策只认清晰证据。
+func rawConvAllRecentsTaggedElsewhere(conv *config.SyncUserConversationResp, defaultSpaceID string) bool {
+	if conv == nil {
+		return true
+	}
+	for _, msg := range conv.Recents {
+		if msg == nil {
+			continue
+		}
+		sid := ""
+		if len(msg.Payload) > 0 {
+			var payload map[string]interface{}
+			if err := json.Unmarshal(msg.Payload, &payload); err == nil {
+				if s, ok := payload["space_id"].(string); ok {
+					sid = s
+				}
+			}
+		}
+		if sid == "" || sid == defaultSpaceID {
+			return false
+		}
+	}
+	return true
+}

--- a/modules/message/space_filter_default_catchall_test.go
+++ b/modules/message/space_filter_default_catchall_test.go
@@ -1,0 +1,122 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func catchallConv(peer string, recentSpaceIDs ...string) *SyncUserConversationResp {
+	recents := make([]*MsgSyncResp, 0, len(recentSpaceIDs))
+	for i, sid := range recentSpaceIDs {
+		payload := map[string]interface{}{"type": 1, "content": "m"}
+		if sid != "" {
+			payload["space_id"] = sid
+		}
+		recents = append(recents, &MsgSyncResp{MessageSeq: uint32(i + 1), Payload: payload})
+	}
+	return &SyncUserConversationResp{
+		ChannelID:   peer,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Recents:     recents,
+	}
+}
+
+func catchallHide(convs []*SyncUserConversationResp, elsewhereOnly, botSet map[string]bool, skipBotFilter bool) []string {
+	out := hideElsewhereOnlyDMsInDefaultSpace(
+		convs,
+		func(c *SyncUserConversationResp) string { return c.ChannelID },
+		func(c *SyncUserConversationResp) uint8 { return c.ChannelType },
+		func(c *SyncUserConversationResp) bool { return personConvAllRecentsTaggedElsewhere(c, "spaceDefault") },
+		elsewhereOnly, botSet, skipBotFilter,
+	)
+	ids := make([]string, 0, len(out))
+	for _, c := range out {
+		ids = append(ids, c.ChannelID)
+	}
+	return ids
+}
+
+func TestHideElsewhereOnlyDMs_HidesOnlyWithPositiveEvidence(t *testing.T) {
+	convs := []*SyncUserConversationResp{
+		catchallConv("peer_elsewhere", "spaceB"),     // presence 只在他空间 + Recents 全他空间 → 隐藏
+		catchallConv("peer_untracked", "spaceB"),     // 无 presence 行 → 保留（catch-all 现状）
+		catchallConv("peer_untagged", ""),            // Recents 有未打标消息 → 反证保留
+		catchallConv("peer_default", "spaceDefault"), // Recents 有默认 Space 消息 → 反证保留
+		catchallConv("peer_mixed", "spaceB", ""),     // 混合（含未打标）→ 反证保留
+		catchallConv("botfather", "spaceB"),          // 系统 bot → 永不隐藏
+		catchallConv("robot_x", "spaceB"),            // 普通 bot → 本 pass 不裁决
+	}
+	elsewhereOnly := map[string]bool{
+		"peer_elsewhere": true,
+		"peer_untagged":  true,
+		"peer_default":   true,
+		"peer_mixed":     true,
+		"botfather":      true,
+		"robot_x":        true,
+	}
+	botSet := map[string]bool{"robot_x": true}
+
+	kept := catchallHide(convs, elsewhereOnly, botSet, false)
+	assert.NotContains(t, kept, "peer_elsewhere", "presence 只在他空间且无反证 → 从默认 Space 隐藏")
+	assert.Contains(t, kept, "peer_untracked", "无 presence 证据 → 保持 catch-all 现状")
+	assert.Contains(t, kept, "peer_untagged", "未打标 Recents 反证 → 保留")
+	assert.Contains(t, kept, "peer_default", "默认 Space Recents 反证 → 保留")
+	assert.Contains(t, kept, "peer_mixed", "混合 Recents 含未打标 → 保留")
+	assert.Contains(t, kept, "botfather", "系统 bot 永不隐藏")
+	assert.Contains(t, kept, "robot_x", "普通 bot 的可见性由 catch-all bot 子判定决定，本 pass 不隐藏")
+}
+
+func TestHideElsewhereOnlyDMs_FailOpenGates(t *testing.T) {
+	convs := []*SyncUserConversationResp{catchallConv("peer_elsewhere", "spaceB")}
+	elsewhereOnly := map[string]bool{"peer_elsewhere": true}
+
+	// skipBotFilter=true（bot 解析失败）→ 整体跳过。
+	kept := catchallHide(convs, elsewhereOnly, nil, true)
+	assert.Contains(t, kept, "peer_elsewhere", "bot 身份不可知时不隐藏")
+
+	// elsewhereOnly 为 nil/空（presence 查询失败或无数据）→ 整体跳过。
+	kept = catchallHide(convs, nil, nil, false)
+	assert.Contains(t, kept, "peer_elsewhere", "无 presence 证据时不隐藏")
+}
+
+func TestHideElsewhereOnlyDMs_GroupUntouched(t *testing.T) {
+	group := &SyncUserConversationResp{ChannelID: "g1", ChannelType: common.ChannelTypeGroup.Uint8()}
+	kept := catchallHide([]*SyncUserConversationResp{group}, map[string]bool{"g1": true}, nil, false)
+	assert.Contains(t, kept, "g1", "非 Person 会话不受本 pass 影响")
+}
+
+func TestPersonConvAllRecentsTaggedElsewhere(t *testing.T) {
+	assert.True(t, personConvAllRecentsTaggedElsewhere(catchallConv("p"), "spaceDefault"),
+		"空 Recents 无本地反证 → true（由 presence 决定）")
+	assert.True(t, personConvAllRecentsTaggedElsewhere(catchallConv("p", "spaceB", "spaceC"), "spaceDefault"))
+	assert.False(t, personConvAllRecentsTaggedElsewhere(catchallConv("p", "spaceB", ""), "spaceDefault"),
+		"任一未打标消息 → false")
+	assert.False(t, personConvAllRecentsTaggedElsewhere(catchallConv("p", "spaceDefault"), "spaceDefault"),
+		"默认 Space 消息 → false")
+	assert.True(t, personConvAllRecentsTaggedElsewhere(nil, "spaceDefault"))
+}
+
+func TestRawConvAllRecentsTaggedElsewhere(t *testing.T) {
+	rawConv := func(payloads ...[]byte) *config.SyncUserConversationResp {
+		recents := make([]*config.MessageResp, 0, len(payloads))
+		for i, p := range payloads {
+			recents = append(recents, &config.MessageResp{MessageSeq: uint32(i + 1), Payload: p})
+		}
+		return &config.SyncUserConversationResp{ChannelID: "p", Recents: recents}
+	}
+	tagged := func(sid string) []byte {
+		return []byte(util.ToJson(map[string]interface{}{"type": 1, "space_id": sid}))
+	}
+	untagged := []byte(util.ToJson(map[string]interface{}{"type": 1}))
+
+	assert.True(t, rawConvAllRecentsTaggedElsewhere(rawConv(tagged("spaceB")), "spaceDefault"))
+	assert.False(t, rawConvAllRecentsTaggedElsewhere(rawConv(tagged("spaceDefault")), "spaceDefault"))
+	assert.False(t, rawConvAllRecentsTaggedElsewhere(rawConv(untagged), "spaceDefault"))
+	assert.False(t, rawConvAllRecentsTaggedElsewhere(rawConv([]byte("not-json")), "spaceDefault"),
+		"payload 解析失败视同未打标 → 反证保留")
+	assert.True(t, rawConvAllRecentsTaggedElsewhere(rawConv(), "spaceDefault"), "空 Recents → true")
+}

--- a/modules/message/space_filter_test.go
+++ b/modules/message/space_filter_test.go
@@ -17,10 +17,38 @@ func TestFilterConversationsBySpace_DirectMatch(t *testing.T) {
 	}
 
 	// 所有会话都有 SpaceID，不触发 bareGroupNos / bareDMUIDs 逻辑
-	result := filterConversationsCore(convs, "spaceA", "spaceA", nil, nil, nil, nil, false, false)
+	result := filterConversationsCore(convs, "spaceA", "spaceA", nil, nil, nil, nil, false, false, nil)
 	assert.Len(t, result, 2)
 	assert.Equal(t, "g1", result[0].ChannelID)
 	assert.Equal(t, "u1", result[1].ChannelID)
+}
+
+func TestFilterConversationsBySpace_DefaultLookupError_BareDMFailsClosed(t *testing.T) {
+	// Regression guard for #519 P1 (yujiawei + OctoBoooot): when
+	// GetUserDefaultSpaceIDE fails, FilterConversationsBySpace / FilterRawConversationsBySpace
+	// set defaultSpaceID = "" (a sentinel that can never equal a real, always-non-empty
+	// filterSpaceID), NOT filterSpaceID. This exercises the resulting decision directly.
+	//
+	// A bare cross-Space DM (SpaceID == "") with no presence and no Recents evidence
+	// in the requested NON-DEFAULT Space must be DROPPED — never surfaced via the
+	// bare-DM catch-all. Had the error branch used defaultSpaceID = filterSpaceID,
+	// filterSpaceID == defaultSpaceID would be true, the catch-all (space_filter.go:332)
+	// would fire, and every bare DM would leak into the requested Space.
+	convs := []*SyncUserConversationResp{
+		{ChannelID: "peer_elsewhere", ChannelType: common.ChannelTypePerson.Uint8(), SpaceID: ""},
+	}
+
+	// filterSpaceID non-empty (the guaranteed invariant), defaultSpaceID == "" error
+	// sentinel, no presence set, no groupSpaceMap/Recents evidence → fail-closed.
+	kept := filterConversationsCore(convs, "spaceB", "", nil, nil, nil, nil, false, false, nil)
+	assert.Empty(t, kept,
+		"default-Space lookup error must hide a bare cross-Space DM from a non-default Space (fail-closed), not leak it via the catch-all")
+
+	// Documents the pre-fix leak this guards against: defaultSpaceID == filterSpaceID
+	// trips the bare-DM catch-all and keeps every DM.
+	leaked := filterConversationsCore(convs, "spaceB", "spaceB", nil, nil, nil, nil, false, false, nil)
+	assert.Len(t, leaked, 1,
+		"pre-fix behavior (defaultSpaceID == filterSpaceID) trips the bare-DM catch-all — the leak this test guards against")
 }
 
 func TestFilterConversationsBySpace_SystemBotsVisible(t *testing.T) {
@@ -37,7 +65,7 @@ func TestFilterConversationsBySpace_SystemBotsVisible(t *testing.T) {
 	// 传入 botSet 标记 custom_bot 为 Bot，且不在此 Space → 不显示
 	botSet := map[string]bool{"custom_bot": true}
 	botInSpace := map[string]bool{}
-	result := filterConversationsCore(convs, "spaceB", "spaceA", nil, nil, botSet, botInSpace, false, false)
+	result := filterConversationsCore(convs, "spaceB", "spaceA", nil, nil, botSet, botInSpace, false, false, nil)
 	// 系统 Bot 可见，custom_bot（Bot 不在此 Space）不可见
 	assert.Len(t, result, 3)
 	ids := []string{result[0].ChannelID, result[1].ChannelID, result[2].ChannelID}
@@ -54,11 +82,11 @@ func TestFilterConversationsBySpace_DefaultSpaceBareConvs(t *testing.T) {
 	}
 
 	// filterSpaceID == defaultSpaceID → 旧会话保留
-	result := filterConversationsCore(convs, "spaceA", "spaceA", nil, nil, nil, nil, false, false)
+	result := filterConversationsCore(convs, "spaceA", "spaceA", nil, nil, nil, nil, false, false, nil)
 	assert.Len(t, result, 2)
 
 	// filterSpaceID != defaultSpaceID → 无 Recents 匹配 → 不显示
-	result = filterConversationsCore(convs, "spaceB", "spaceA", nil, nil, nil, nil, false, false)
+	result = filterConversationsCore(convs, "spaceB", "spaceA", nil, nil, nil, nil, false, false, nil)
 	assert.Len(t, result, 0)
 }
 
@@ -81,7 +109,7 @@ func TestFilterConversationsBySpace_NonDefaultSpaceDMVisible(t *testing.T) {
 	botInSpace := map[string]bool{"bot_in_space": true}
 
 	// filterSpaceID=spaceB != defaultSpaceID=spaceA
-	result := filterConversationsCore(convs, "spaceB", "spaceA", nil, nil, botSet, botInSpace, false, false)
+	result := filterConversationsCore(convs, "spaceB", "spaceA", nil, nil, botSet, botInSpace, false, false, nil)
 
 	// user1（Recents 有 spaceB 消息）保留；user2（Recents 只有 spaceA）过滤；
 	// bot_in_space（Bot 在此 Space）保留；custom_bot（Bot 不在此 Space）不保留
@@ -113,10 +141,33 @@ func TestFilterConversationsBySpace_NewSpaceCleanSlate(t *testing.T) {
 		},
 	}
 
-	result := filterConversationsCore(convs, "spaceNew", "spaceA", nil, nil, map[string]bool{}, map[string]bool{}, false, false)
+	result := filterConversationsCore(convs, "spaceNew", "spaceA", nil, nil, map[string]bool{}, map[string]bool{}, false, false, nil)
 
 	// 新 Space 没有任何 DM 有匹配消息 → clean slate
 	assert.Len(t, result, 0)
+}
+
+func TestFilterConversationsCore_DMPresenceVisibilityWindowIndependent(t *testing.T) {
+	// issue #484：非默认 Space 下，DM 即使 Recents 窗口被其他 Space 挤满（没有本
+	// Space 的消息），只要 dm_space_presence 命中（dmPresentSet 含该对端），也应
+	// 可见——窗口无关的权威可见性，修复症状2（DM 互斥消失）。
+	convs := []*SyncUserConversationResp{
+		{
+			ChannelID: "peerX", ChannelType: common.ChannelTypePerson.Uint8(), SpaceID: "",
+			// Recents 窗口只有 spaceC 的消息，没有 spaceB
+			Recents: []*MsgSyncResp{{Payload: map[string]interface{}{"space_id": "spaceC", "content": "hi"}}},
+		},
+	}
+
+	// 无 presence（nil）→ 回退 Recents 扫描 → spaceB 下不可见（症状2 原状）。
+	hidden := filterConversationsCore(convs, "spaceB", "spaceA", nil, nil, nil, nil, false, false, nil)
+	assert.Len(t, hidden, 0)
+
+	// 有 presence（peerX 在 spaceB 有过消息）→ 窗口无关，spaceB 下可见。
+	present := map[string]bool{"peerX": true}
+	visible := filterConversationsCore(convs, "spaceB", "spaceA", nil, nil, nil, nil, false, false, present)
+	assert.Len(t, visible, 1)
+	assert.Equal(t, "peerX", visible[0].ChannelID)
 }
 
 func TestPersonConvHasSpaceMessages(t *testing.T) {
@@ -152,7 +203,7 @@ func TestFilterConversationsBySpace_GroupSpaceMap(t *testing.T) {
 	}
 	groupMap := map[string]string{"g1": "spaceA", "g2": "spaceB"}
 
-	result := filterConversationsCore(convs, "spaceA", "spaceA", groupMap, nil, nil, nil, false, false)
+	result := filterConversationsCore(convs, "spaceA", "spaceA", groupMap, nil, nil, nil, false, false, nil)
 	assert.Len(t, result, 1)
 	assert.Equal(t, "g1", result[0].ChannelID)
 }
@@ -165,7 +216,7 @@ func TestFilterConversationsBySpace_SkipGroupFilter(t *testing.T) {
 		{ChannelID: "u1", ChannelType: common.ChannelTypePerson.Uint8(), SpaceID: "spaceA"},
 	}
 
-	result := filterConversationsCore(convs, "spaceA", "spaceA", nil, nil, nil, nil, true, false)
+	result := filterConversationsCore(convs, "spaceA", "spaceA", nil, nil, nil, nil, true, false, nil)
 	// g1, g2 保留（skipGroupFilter），u1 保留（直接匹配）
 	assert.Len(t, result, 3)
 }
@@ -179,16 +230,16 @@ func TestFilterConversationsBySpace_ExternalGroupVisibleInSourceSpace(t *testing
 	externalMap := map[string]string{"gExt": "spaceB"}
 
 	// 在 source Space（B）下可见
-	result := filterConversationsCore(convs, "spaceB", "spaceB", nil, externalMap, nil, nil, false, false)
+	result := filterConversationsCore(convs, "spaceB", "spaceB", nil, externalMap, nil, nil, false, false, nil)
 	assert.Len(t, result, 1)
 	assert.Equal(t, "gExt", result[0].ChannelID)
 
 	// 在群的原生 Space（A）下也可见
-	result = filterConversationsCore(convs, "spaceA", "spaceB", nil, externalMap, nil, nil, false, false)
+	result = filterConversationsCore(convs, "spaceA", "spaceB", nil, externalMap, nil, nil, false, false, nil)
 	assert.Len(t, result, 1)
 
 	// 在无关 Space（C）下不可见
-	result = filterConversationsCore(convs, "spaceC", "spaceB", nil, externalMap, nil, nil, false, false)
+	result = filterConversationsCore(convs, "spaceC", "spaceB", nil, externalMap, nil, nil, false, false, nil)
 	assert.Len(t, result, 0)
 }
 
@@ -201,7 +252,7 @@ func TestFilterConversationsBySpace_ExternalGroupFallbackToDefault(t *testing.T)
 	externalMap := map[string]string{"gExt": ""} // source Space 记录已失效
 
 	// defaultSpaceID=spaceB，fallback 后在 spaceB 可见
-	result := filterConversationsCore(convs, "spaceB", "spaceB", nil, externalMap, nil, nil, false, false)
+	result := filterConversationsCore(convs, "spaceB", "spaceB", nil, externalMap, nil, nil, false, false, nil)
 	assert.Len(t, result, 1)
 }
 
@@ -211,10 +262,10 @@ func TestFilterConversationsBySpace_ThreadChannelInParentGroupSpace(t *testing.T
 	}
 	groupMap := map[string]string{"g1": "spaceA"}
 
-	result := filterConversationsCore(convs, "spaceA", "spaceDefault", groupMap, nil, nil, nil, false, false)
+	result := filterConversationsCore(convs, "spaceA", "spaceDefault", groupMap, nil, nil, nil, false, false, nil)
 	assert.Len(t, result, 1)
 
-	result = filterConversationsCore(convs, "spaceB", "spaceDefault", groupMap, nil, nil, nil, false, false)
+	result = filterConversationsCore(convs, "spaceB", "spaceDefault", groupMap, nil, nil, nil, false, false, nil)
 	assert.Len(t, result, 0)
 }
 
@@ -225,7 +276,7 @@ func TestFilterConversationsBySpace_ThreadChannelNoLeakInDefaultSpace(t *testing
 	}
 	groupMap := map[string]string{"g1": "spaceA"}
 
-	result := filterConversationsCore(convs, "spaceDefault", "spaceDefault", groupMap, nil, nil, nil, false, false)
+	result := filterConversationsCore(convs, "spaceDefault", "spaceDefault", groupMap, nil, nil, nil, false, false, nil)
 	assert.Len(t, result, 0)
 }
 
@@ -236,13 +287,13 @@ func TestFilterConversationsBySpace_ThreadChannelExternalGroup(t *testing.T) {
 	groupMap := map[string]string{"gExt": "spaceA"}
 	externalMap := map[string]string{"gExt": "spaceB"}
 
-	result := filterConversationsCore(convs, "spaceB", "spaceDefault", groupMap, externalMap, nil, nil, false, false)
+	result := filterConversationsCore(convs, "spaceB", "spaceDefault", groupMap, externalMap, nil, nil, false, false, nil)
 	assert.Len(t, result, 1)
 
-	result = filterConversationsCore(convs, "spaceA", "spaceDefault", groupMap, externalMap, nil, nil, false, false)
+	result = filterConversationsCore(convs, "spaceA", "spaceDefault", groupMap, externalMap, nil, nil, false, false, nil)
 	assert.Len(t, result, 1)
 
-	result = filterConversationsCore(convs, "spaceC", "spaceDefault", groupMap, externalMap, nil, nil, false, false)
+	result = filterConversationsCore(convs, "spaceC", "spaceDefault", groupMap, externalMap, nil, nil, false, false, nil)
 	assert.Len(t, result, 0)
 }
 
@@ -256,11 +307,11 @@ func TestFilterConversationsBySpace_ThreadChannelExternalOnly(t *testing.T) {
 	externalMap := map[string]string{"gExt": "spaceB"}
 
 	// filter=spaceB 只能通过 external 路径命中
-	result := filterConversationsCore(convs, "spaceB", "spaceDefault", groupMap, externalMap, nil, nil, false, false)
+	result := filterConversationsCore(convs, "spaceB", "spaceDefault", groupMap, externalMap, nil, nil, false, false, nil)
 	assert.Len(t, result, 1)
 
 	// filter=spaceHome 只能通过直接匹配命中（不走 external）
-	result = filterConversationsCore(convs, "spaceHome", "spaceDefault", groupMap, externalMap, nil, nil, false, false)
+	result = filterConversationsCore(convs, "spaceHome", "spaceDefault", groupMap, externalMap, nil, nil, false, false, nil)
 	assert.Len(t, result, 1)
 }
 
@@ -271,19 +322,20 @@ func TestFilterConversationsBySpace_ThreadChannelExternalFallback(t *testing.T) 
 	groupMap := map[string]string{"gExt": "spaceA"}
 	externalMap := map[string]string{"gExt": ""}
 
-	result := filterConversationsCore(convs, "spaceDefault", "spaceDefault", groupMap, externalMap, nil, nil, false, false)
+	result := filterConversationsCore(convs, "spaceDefault", "spaceDefault", groupMap, externalMap, nil, nil, false, false, nil)
 	assert.Len(t, result, 1)
 }
 
 func TestFilterConversationsBySpace_ThreadChannelLegacyParent(t *testing.T) {
-	// 父群无 space_id（旧群） → 子区跟旧群一样所有 Space 可见
+	// issue #484 follow-up：父群无 space_id（旧群）的子区不再全 Space 可见，
+	// 只在用户默认 Space 露出（与旧群本体同口径）。
 	convs := []*SyncUserConversationResp{
 		{ChannelID: "gLegacy____123456789012345", ChannelType: common.ChannelTypeCommunityTopic.Uint8(), SpaceID: ""},
 	}
-	result := filterConversationsCore(convs, "spaceA", "spaceDefault", map[string]string{}, nil, nil, nil, false, false)
-	assert.Len(t, result, 1)
-	result = filterConversationsCore(convs, "spaceB", "spaceDefault", map[string]string{}, nil, nil, nil, false, false)
-	assert.Len(t, result, 1)
+	result := filterConversationsCore(convs, "spaceA", "spaceDefault", map[string]string{}, nil, nil, nil, false, false, nil)
+	assert.Len(t, result, 0, "非默认 Space 不显示旧父群的子区")
+	result = filterConversationsCore(convs, "spaceDefault", "spaceDefault", map[string]string{}, nil, nil, nil, false, false, nil)
+	assert.Len(t, result, 1, "默认 Space 保留旧父群的子区")
 }
 
 func TestFilterConversationsBySpace_ThreadChannelInvalidID(t *testing.T) {
@@ -293,7 +345,7 @@ func TestFilterConversationsBySpace_ThreadChannelInvalidID(t *testing.T) {
 	}
 	groupMap := map[string]string{"g1": "spaceA"}
 
-	result := filterConversationsCore(convs, "spaceA", "spaceDefault", groupMap, nil, nil, nil, false, false)
+	result := filterConversationsCore(convs, "spaceA", "spaceDefault", groupMap, nil, nil, nil, false, false, nil)
 	assert.Len(t, result, 1)
 	assert.Equal(t, "g1____123456789012345", result[0].ChannelID)
 }
@@ -303,7 +355,7 @@ func TestFilterConversationsBySpace_ThreadChannelSkipGroupFilter(t *testing.T) {
 		{ChannelID: "g1____123456789012345", ChannelType: common.ChannelTypeCommunityTopic.Uint8(), SpaceID: ""},
 		{ChannelID: "g2____987654321098765", ChannelType: common.ChannelTypeCommunityTopic.Uint8(), SpaceID: ""},
 	}
-	result := filterConversationsCore(convs, "spaceA", "spaceDefault", nil, nil, nil, nil, true, false)
+	result := filterConversationsCore(convs, "spaceA", "spaceDefault", nil, nil, nil, nil, true, false, nil)
 	assert.Len(t, result, 2)
 }
 
@@ -509,7 +561,7 @@ func TestSyncPipeline_SystemBotsAlwaysReturned(t *testing.T) {
 			cp := *c
 			in[i] = &cp
 		}
-		filtered := filterConversationsCore(in, filterSpaceID, defaultSpaceID, groupMap, nil, nil, nil, false, false)
+		filtered := filterConversationsCore(in, filterSpaceID, defaultSpaceID, groupMap, nil, nil, nil, false, false, nil)
 		return EnsureSystemBotsPresent(filtered)
 	}
 
@@ -571,7 +623,7 @@ func TestFilterPersonMessagesBySpace_SystemBot(t *testing.T) {
 		newMsgWithSpaceID(4, "spaceA"),
 	}
 
-	got := filterPersonMessagesBySpace(msgs, "botfather", "spaceA")
+	got := filterPersonMessagesBySpace(msgs, "botfather", "spaceA", "spaceA")
 	assert.Len(t, got, 2)
 	assert.Equal(t, int64(1), got[0].MessageID)
 	assert.Equal(t, int64(4), got[1].MessageID)
@@ -589,12 +641,34 @@ func TestFilterPersonMessagesBySpace_OrdinaryDMLegacyCompat(t *testing.T) {
 		newMsgWithSpaceID(12, "spaceB"),
 	}
 
-	got := filterPersonMessagesBySpace(msgs, "peer_uid", "spaceA")
+	got := filterPersonMessagesBySpace(msgs, "peer_uid", "spaceA", "spaceA")
 	assert.Len(t, got, 2)
 	ids := []int64{got[0].MessageID, got[1].MessageID}
 	assert.Contains(t, ids, int64(10))
 	assert.Contains(t, ids, int64(11))
 	assert.NotContains(t, ids, int64(12))
+}
+
+func TestFilterPersonMessagesBySpace_UntaggedDroppedInNonDefaultSpace(t *testing.T) {
+	// issue #484：无 space_id 的普通 DM 消息只在默认 Space 保留；在非默认 Space
+	// （spaceID != defaultSpaceID）下必须丢弃，避免跨 Space 历史泄漏（症状1）。
+	msgs := []*MsgSyncResp{
+		newMsgWithSpaceID(80, "spaceB"), // 当前 Space 的消息 → 保留
+		newMsgWithSpaceID(81, ""),       // 无标签老消息 → 非默认 Space 丢弃
+		newMsgWithSpaceID(82, "spaceC"), // 跨 Space → 丢弃
+	}
+	// filterSpaceID=spaceB, defaultSpaceID=spaceDefault（不相等）
+	got := filterPersonMessagesBySpace(msgs, "peer_uid", "spaceB", "spaceDefault")
+	assert.Len(t, got, 1)
+	assert.Equal(t, int64(80), got[0].MessageID)
+
+	// 同一批消息在默认 Space（spaceID==defaultSpaceID）下，无标签消息仍保留。
+	gotDefault := filterPersonMessagesBySpace(msgs, "peer_uid", "spaceDefault", "spaceDefault")
+	ids := make([]int64, len(gotDefault))
+	for i, m := range gotDefault {
+		ids[i] = m.MessageID
+	}
+	assert.Contains(t, ids, int64(81), "无标签消息在默认 Space 保留")
 }
 
 func TestFilterPersonMessagesBySpace_CrossSpaceDropped(t *testing.T) {
@@ -603,7 +677,7 @@ func TestFilterPersonMessagesBySpace_CrossSpaceDropped(t *testing.T) {
 		newMsgWithSpaceID(20, "spaceB"),
 		newMsgWithSpaceID(21, "spaceB"),
 	}
-	got := filterPersonMessagesBySpace(msgs, "peer_uid", "spaceA")
+	got := filterPersonMessagesBySpace(msgs, "peer_uid", "spaceA", "spaceA")
 	assert.Len(t, got, 0)
 }
 
@@ -614,7 +688,7 @@ func TestFilterPersonMessagesBySpace_AllInSpaceKept(t *testing.T) {
 		newMsgWithSpaceID(31, "spaceA"),
 		newMsgWithSpaceID(32, "spaceA"),
 	}
-	got := filterPersonMessagesBySpace(msgs, "peer_uid", "spaceA")
+	got := filterPersonMessagesBySpace(msgs, "peer_uid", "spaceA", "spaceA")
 	assert.Len(t, got, 3)
 }
 
@@ -626,16 +700,16 @@ func TestFilterPersonMessagesBySpace_EmptySpaceIDNoOp(t *testing.T) {
 		newMsgWithSpaceID(41, ""),
 		newMsgWithSpaceID(42, "spaceB"),
 	}
-	got := filterPersonMessagesBySpace(msgs, "botfather", "")
+	got := filterPersonMessagesBySpace(msgs, "botfather", "", "")
 	assert.Equal(t, msgs, got)
 }
 
 func TestFilterPersonMessagesBySpace_EmptySliceReturnsSame(t *testing.T) {
-	got := filterPersonMessagesBySpace(nil, "botfather", "spaceA")
+	got := filterPersonMessagesBySpace(nil, "botfather", "spaceA", "spaceA")
 	assert.Nil(t, got)
 
 	empty := []*MsgSyncResp{}
-	got = filterPersonMessagesBySpace(empty, "botfather", "spaceA")
+	got = filterPersonMessagesBySpace(empty, "botfather", "spaceA", "spaceA")
 	assert.Equal(t, empty, got)
 }
 
@@ -647,7 +721,7 @@ func TestFilterPersonMessagesBySpace_NilMessagesSkipped(t *testing.T) {
 		nil,
 		newMsgWithSpaceID(51, "spaceB"),
 	}
-	got := filterPersonMessagesBySpace(msgs, "peer_uid", "spaceA")
+	got := filterPersonMessagesBySpace(msgs, "peer_uid", "spaceA", "spaceA")
 	assert.Len(t, got, 1)
 	assert.Equal(t, int64(50), got[0].MessageID)
 }
@@ -658,11 +732,11 @@ func TestFilterPersonMessagesBySpace_PayloadSpaceIDWrongType(t *testing.T) {
 	msgA := &MsgSyncResp{MessageID: 60, Payload: map[string]interface{}{"space_id": 123}}
 
 	// 普通 DM：保留
-	got := filterPersonMessagesBySpace([]*MsgSyncResp{msgA}, "peer_uid", "spaceA")
+	got := filterPersonMessagesBySpace([]*MsgSyncResp{msgA}, "peer_uid", "spaceA", "spaceA")
 	assert.Len(t, got, 1)
 
 	// SystemBot：丢弃
-	got = filterPersonMessagesBySpace([]*MsgSyncResp{msgA}, "fileHelper", "spaceA")
+	got = filterPersonMessagesBySpace([]*MsgSyncResp{msgA}, "fileHelper", "spaceA", "spaceA")
 	assert.Len(t, got, 0)
 }
 
@@ -670,7 +744,7 @@ func TestFilterPersonMessagesBySpace_SystemBotListCoverage(t *testing.T) {
 	// 保证三个已知系统 Bot 都走 SystemBot 分支（老消息被丢弃）。
 	msgs := []*MsgSyncResp{newMsgWithSpaceID(70, "")}
 	for _, bot := range spacepkg.SystemBotList() {
-		got := filterPersonMessagesBySpace(msgs, bot, "spaceA")
+		got := filterPersonMessagesBySpace(msgs, bot, "spaceA", "spaceA")
 		assert.Emptyf(t, got, "SystemBot %s 的无 space_id 消息应被丢弃", bot)
 	}
 }

--- a/modules/message/space_filter_v2_test.go
+++ b/modules/message/space_filter_v2_test.go
@@ -20,7 +20,7 @@ func TestDecideConvKeepInSpace_Group_DirectSpaceMatch(t *testing.T) {
 		"grp1", common.ChannelTypeGroup.Uint8(), "",
 		"spaceA", "spaceA",
 		map[string]string{"grp1": "spaceA"}, nil,
-		nil, nil, false, false, false, nil,
+		nil, nil, false, false, false, nil, nil,
 	)
 	assert.True(t, keep, "group in spaceA must be kept when filter=spaceA")
 }
@@ -30,19 +30,28 @@ func TestDecideConvKeepInSpace_Group_SpaceMismatch_Excluded(t *testing.T) {
 		"grp1", common.ChannelTypeGroup.Uint8(), "",
 		"spaceB", "spaceA",
 		map[string]string{"grp1": "spaceA"}, nil,
-		nil, nil, false, false, false, nil,
+		nil, nil, false, false, false, nil, nil,
 	)
 	assert.False(t, keep, "group in spaceA must NOT leak into spaceB sidebar request")
 }
 
-func TestDecideConvKeepInSpace_Group_LegacyNoSpace_VisibleEverywhere(t *testing.T) {
-	keep := decideConvKeepInSpace(
+func TestDecideConvKeepInSpace_Group_LegacyNoSpace_DefaultSpaceOnly(t *testing.T) {
+	// issue #484 follow-up：无法归属的群只在默认 Space 露出，不再全 Space 可见。
+	keepNonDefault := decideConvKeepInSpace(
 		"old-grp", common.ChannelTypeGroup.Uint8(), "",
 		"spaceB", "spaceA",
 		map[string]string{}, nil,
-		nil, nil, false, false, false, nil,
+		nil, nil, false, false, false, nil, nil,
 	)
-	assert.True(t, keep, "legacy group without space_id stays visible everywhere")
+	assert.False(t, keepNonDefault, "legacy group without space_id must NOT show in a non-default Space")
+
+	keepDefault := decideConvKeepInSpace(
+		"old-grp", common.ChannelTypeGroup.Uint8(), "",
+		"spaceA", "spaceA",
+		map[string]string{}, nil,
+		nil, nil, false, false, false, nil, nil,
+	)
+	assert.True(t, keepDefault, "legacy group without space_id stays visible in the default Space")
 }
 
 func TestDecideConvKeepInSpace_Group_ExternalSourceSpace(t *testing.T) {
@@ -51,7 +60,7 @@ func TestDecideConvKeepInSpace_Group_ExternalSourceSpace(t *testing.T) {
 		"spaceX", "spaceA",
 		map[string]string{"grp1": "spaceB"},
 		map[string]string{"grp1": "spaceX"},
-		nil, nil, false, false, false, nil,
+		nil, nil, false, false, false, nil, nil,
 	)
 	assert.True(t, keep, "external group must surface in its source space")
 }
@@ -62,7 +71,7 @@ func TestDecideConvKeepInSpace_Thread_FollowsParentSpace(t *testing.T) {
 		"grp1____thr1", common.ChannelTypeCommunityTopic.Uint8(), "",
 		"spaceA", "spaceA",
 		map[string]string{"grp1": "spaceA"}, nil,
-		nil, nil, false, false, false, nil,
+		nil, nil, false, false, false, nil, nil,
 	)
 	assert.True(t, keep, "thread inherits parent group's space visibility")
 
@@ -70,7 +79,7 @@ func TestDecideConvKeepInSpace_Thread_FollowsParentSpace(t *testing.T) {
 		"grp1____thr1", common.ChannelTypeCommunityTopic.Uint8(), "",
 		"spaceB", "spaceA",
 		map[string]string{"grp1": "spaceA"}, nil,
-		nil, nil, false, false, false, nil,
+		nil, nil, false, false, false, nil, nil,
 	)
 	assert.False(t, keep, "thread of spaceA parent must not appear in spaceB sidebar")
 }
@@ -81,6 +90,7 @@ func TestDecideConvKeepInSpace_DM_DefaultSpace_KeepBareConv(t *testing.T) {
 		"spaceA", "spaceA",
 		nil, nil,
 		map[string]bool{}, map[string]bool{}, false, false, false,
+		nil,
 		func(string) bool { return false },
 	)
 	assert.True(t, keep, "bare DM stays in user's default space when no bot match")
@@ -92,6 +102,7 @@ func TestDecideConvKeepInSpace_DM_NonDefaultSpace_NoSpaceMsg_Excluded(t *testing
 		"spaceB", "spaceA",
 		nil, nil,
 		map[string]bool{}, map[string]bool{}, false, false, false,
+		nil,
 		func(string) bool { return false },
 	)
 	assert.False(t, keep, "DM with no payload.space_id match must NOT appear in non-default space")
@@ -103,9 +114,24 @@ func TestDecideConvKeepInSpace_DM_NonDefaultSpace_HasSpaceMsg_Visible(t *testing
 		"spaceB", "spaceA",
 		nil, nil,
 		map[string]bool{}, map[string]bool{}, false, false, false,
+		nil,
 		func(target string) bool { return target == "spaceB" },
 	)
 	assert.True(t, keep, "DM with payload.space_id == filter must appear in that space")
+}
+
+func TestDecideConvKeepInSpace_DM_PresenceSet_VisibleWindowIndependent(t *testing.T) {
+	// issue #484：非默认 Space 下，即使 Recents 窗口扫描（hasSpaceMsg）返回 false，
+	// 只要 dm_space_presence 命中（dmPresentSet[channelID]），DM 也应可见。
+	keep := decideConvKeepInSpace(
+		"peer1", common.ChannelTypePerson.Uint8(), "",
+		"spaceB", "spaceA",
+		nil, nil,
+		map[string]bool{}, map[string]bool{}, false, false, false,
+		map[string]bool{"peer1": true},     // presence: peer1 在 spaceB 有过消息
+		func(string) bool { return false }, // Recents 窗口里没有 spaceB
+	)
+	assert.True(t, keep, "DM with persisted presence in target space must be visible regardless of Recents window")
 }
 
 func TestDecideConvKeepInSpace_DM_BotInSpace(t *testing.T) {
@@ -114,6 +140,7 @@ func TestDecideConvKeepInSpace_DM_BotInSpace(t *testing.T) {
 		"spaceB", "spaceA",
 		nil, nil,
 		map[string]bool{"bot1": true}, map[string]bool{"bot1": true}, false, false, false,
+		nil,
 		nil,
 	)
 	assert.True(t, keep, "bot DM is visible when bot is a member of the target space")
@@ -126,6 +153,7 @@ func TestDecideConvKeepInSpace_DM_BotNotInSpace_Excluded(t *testing.T) {
 		nil, nil,
 		map[string]bool{"bot1": true}, map[string]bool{"bot1": false}, false, false, false,
 		nil,
+		nil,
 	)
 	assert.False(t, keep, "bot not in target space must be hidden in that space's sidebar")
 }
@@ -136,7 +164,7 @@ func TestDecideConvKeepInSpace_SkipGroupFilter_v1FailOpen(t *testing.T) {
 		"grp1", common.ChannelTypeGroup.Uint8(), "",
 		"spaceB", "spaceA",
 		nil, nil,
-		nil, nil, true, false, false /*v1 兼容: fail-open*/, nil,
+		nil, nil, true, false, false /*v1 兼容: fail-open*/, nil, nil,
 	)
 	assert.True(t, keep, "v1: skipGroupFilter must keep groups (兼容历史)")
 }
@@ -146,7 +174,7 @@ func TestDecideConvKeepInSpace_SkipGroupFilter_v2FailClosed_Group(t *testing.T) 
 		"grp1", common.ChannelTypeGroup.Uint8(), "",
 		"spaceB", "spaceA",
 		nil, nil,
-		nil, nil, true, false, true /*v2: fail-closed*/, nil,
+		nil, nil, true, false, true /*v2: fail-closed*/, nil, nil,
 	)
 	assert.False(t, keep,
 		"v2: skipGroupFilter 时 group 必须 drop，否则一次 GetGroups 抖动会让 Space A 群泄露到 Space B 请求")
@@ -157,7 +185,7 @@ func TestDecideConvKeepInSpace_SkipGroupFilter_v2FailClosed_Thread(t *testing.T)
 		"grp1____thr1", common.ChannelTypeCommunityTopic.Uint8(), "",
 		"spaceB", "spaceA",
 		nil, nil,
-		nil, nil, true, false, true, nil,
+		nil, nil, true, false, true, nil, nil,
 	)
 	assert.False(t, keep,
 		"v2: skipGroupFilter 时 thread 必须 drop（与父群同样语义）")

--- a/modules/space/sql/20260627000001_dm_space_presence.sql
+++ b/modules/space/sql/20260627000001_dm_space_presence.sql
@@ -1,0 +1,23 @@
+-- +migrate Up
+-- DM (Person) per-Space presence index (issue #484).
+--
+-- Records "this DM pair has at least one message tagged with this Space",
+-- keyed by the symmetric canonical pair id produced by
+-- common.GetFakeChannelIDWith(uidA, uidB). Written authoritatively at WuKongIM
+-- message-webhook ingest (modules/webhook handleMessageNotify) for Person
+-- messages carrying payload.space_id; read by the conversation Space filter
+-- (modules/message/space_filter.go) so DM visibility no longer depends on the
+-- single shared Recents window (fixes symptom 2: DMs mutually hiding between
+-- Spaces). Population is incremental; readers OR this signal with the existing
+-- Recents-window scan, so a missing row never hides a currently-visible DM.
+CREATE TABLE IF NOT EXISTS `dm_space_presence` (
+  `fake_channel_id` VARCHAR(100) NOT NULL COMMENT 'common.GetFakeChannelIDWith 规范化的 DM 对 ID',
+  `space_id`        VARCHAR(40)  NOT NULL COMMENT '该 DM 出现过消息的 Space ID',
+  `last_timestamp`  BIGINT       NOT NULL DEFAULT 0 COMMENT '该 Space 下最后一条消息的服务器时间戳(秒)',
+  `created_at`      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at`      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`fake_channel_id`, `space_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='DM 频道-Space 存在性索引(issue #484)';
+
+-- +migrate Down
+DROP TABLE IF EXISTS `dm_space_presence`;

--- a/modules/webhook/api.go
+++ b/modules/webhook/api.go
@@ -231,6 +231,30 @@ func (w *Webhook) messageNotify(c *wkhttp.Context) {
 
 }
 
+// dmSpacePresencePair 是一条待写入 dm_space_presence 的 DM-Space 存在性记录
+// （issue #484）。在消息事务内收集，事务提交后再 best-effort 落库。
+type dmSpacePresencePair struct {
+	fakeChannelID string
+	spaceID       string
+	timestamp     int64
+}
+
+// dmPayloadSpaceID 从 DM 消息 payload（原始 JSON 字节）中读取 space_id。
+// 非 JSON / 缺字段 / 类型不符均返回 ""（调用方据此跳过，不写存在性索引）。
+func dmPayloadSpaceID(payload []byte) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	m, err := util.JsonToMap(string(payload))
+	if err != nil {
+		return ""
+	}
+	if v, ok := m["space_id"].(string); ok {
+		return v
+	}
+	return ""
+}
+
 func (w *Webhook) handleMessageNotify(messages []MsgResp) ([]string, error) {
 	messageIDs := make([]string, 0, len(messages))
 	if len(messages) <= 0 {
@@ -238,6 +262,9 @@ func (w *Webhook) handleMessageNotify(messages []MsgResp) ([]string, error) {
 	}
 
 	confMessages := make([]*config.MessageResp, 0, len(messages))
+	// DM per-Space 存在性索引（issue #484）：在事务内收集，提交后再写，避免
+	// 辅助索引拖累消息持久化主链路。
+	var dmPresencePairs []dmSpacePresencePair
 
 	tx, err := w.ctx.DB().Begin()
 	if err != nil {
@@ -270,6 +297,18 @@ func (w *Webhook) handleMessageNotify(messages []MsgResp) ([]string, error) {
 		}
 		confMessages = append(confMessages, message.toConfigMessageResp())
 
+		// DM per-Space 存在性（issue #484）：仅对带权威 space_id 的非加密 Person
+		// 消息记录 (fakeChannelID, space_id)。加密消息 payload 不可解析，跳过。
+		if message.ChannelType == common.ChannelTypePerson.Uint8() &&
+			!config.SettingFromUint8(message.Setting).Signal {
+			if sid := dmPayloadSpaceID(message.Payload); sid != "" {
+				dmPresencePairs = append(dmPresencePairs, dmSpacePresencePair{
+					fakeChannelID: fakeChannelID,
+					spaceID:       sid,
+					timestamp:     int64(message.Timestamp),
+				})
+			}
+		}
 	}
 	if err := tx.Commit(); err != nil {
 		_ = tx.Rollback()
@@ -280,6 +319,16 @@ func (w *Webhook) handleMessageNotify(messages []MsgResp) ([]string, error) {
 	// 通知消息监听者
 	if len(confMessages) > 0 {
 		w.ctx.NotifyMessagesListeners(confMessages)
+	}
+
+	// DM per-Space 存在性索引（issue #484）：事务提交后 best-effort 写入，失败
+	// 仅记日志——绝不回滚已持久化的消息。读侧（modules/message/space_filter.go）
+	// 把本索引与 Recents 窗口扫描 OR，漏写在下一条消息到达时自愈。
+	for _, p := range dmPresencePairs {
+		if err := spacepkg.UpsertDMSpacePresence(w.ctx.DB(), p.fakeChannelID, p.spaceID, p.timestamp); err != nil {
+			w.Warn("写 dm_space_presence 失败（忽略，best-effort）", zap.Error(err),
+				zap.String("fakeChannelID", p.fakeChannelID), zap.String("spaceID", p.spaceID))
+		}
 	}
 	return messageIDs, nil
 }

--- a/pkg/space/dm_presence.go
+++ b/pkg/space/dm_presence.go
@@ -1,0 +1,57 @@
+package space
+
+import (
+	"github.com/gocraft/dbr/v2"
+)
+
+// DM (Person) per-Space presence index (issue #484).
+//
+// A DM is a single physical channel; multi-Space isolation was emulated by
+// scanning the shared Recents window for a payload.space_id tag, which made a
+// DM's visibility depend on which Space last filled that window (symptom 2:
+// DMs mutually hiding between Spaces). This table records, authoritatively and
+// window-independently, that a DM pair has had at least one message in a given
+// Space. It is keyed by common.GetFakeChannelIDWith(uidA, uidB) — a symmetric
+// canonical pair id, so the webhook write side (sender, peer) and the
+// conversation read side (viewer, peer) compute the same key.
+//
+// Readers OR this signal with the legacy Recents scan, so a missing row never
+// hides a currently-visible DM; population is incremental (no backfill).
+
+// UpsertDMSpacePresence records that fakeChannelID has a message in spaceID.
+// Idempotent; last_timestamp only moves forward. Best-effort by contract —
+// callers (webhook ingest) log and continue on error and must NOT let a failure
+// here roll back message persistence.
+func UpsertDMSpacePresence(session *dbr.Session, fakeChannelID, spaceID string, ts int64) error {
+	if fakeChannelID == "" || spaceID == "" {
+		return nil
+	}
+	_, err := session.InsertBySql(
+		"INSERT INTO dm_space_presence (fake_channel_id, space_id, last_timestamp) "+
+			"VALUES (?, ?, ?) "+
+			"ON DUPLICATE KEY UPDATE last_timestamp=GREATEST(last_timestamp, VALUES(last_timestamp))",
+		fakeChannelID, spaceID, ts,
+	).Exec()
+	return err
+}
+
+// DMSpacePresenceSet returns the subset of fakeChannelIDs that have at least one
+// message tagged with spaceID, as a set keyed by fake_channel_id. Empty input
+// (or empty spaceID) returns an empty set without querying.
+func DMSpacePresenceSet(session *dbr.Session, fakeChannelIDs []string, spaceID string) (map[string]bool, error) {
+	set := make(map[string]bool, len(fakeChannelIDs))
+	if len(fakeChannelIDs) == 0 || spaceID == "" {
+		return set, nil
+	}
+	var present []string
+	_, err := session.Select("fake_channel_id").From("dm_space_presence").
+		Where("fake_channel_id IN ? AND space_id = ?", fakeChannelIDs, spaceID).
+		Load(&present)
+	if err != nil {
+		return nil, err
+	}
+	for _, id := range present {
+		set[id] = true
+	}
+	return set, nil
+}

--- a/pkg/space/dm_presence_any.go
+++ b/pkg/space/dm_presence_any.go
@@ -1,0 +1,30 @@
+package space
+
+import (
+	"github.com/gocraft/dbr/v2"
+)
+
+// DMSpacePresenceAnySet returns the subset of fakeChannelIDs that have at least
+// one dm_space_presence row in ANY Space, as a set keyed by fake_channel_id.
+// Combined with DMSpacePresenceSet(ids, spaceID) a caller can derive
+// "tracked, but belongs exclusively to other Spaces" — the positive, durable
+// evidence required before hiding a DM from the default-Space catch-all
+// (issue #484 follow-up). Empty input returns an empty set without querying.
+func DMSpacePresenceAnySet(session *dbr.Session, fakeChannelIDs []string) (map[string]bool, error) {
+	set := make(map[string]bool, len(fakeChannelIDs))
+	if len(fakeChannelIDs) == 0 {
+		return set, nil
+	}
+	var present []string
+	_, err := session.SelectBySql(
+		"SELECT DISTINCT fake_channel_id FROM dm_space_presence WHERE fake_channel_id IN ?",
+		fakeChannelIDs,
+	).Load(&present)
+	if err != nil {
+		return nil, err
+	}
+	for _, id := range present {
+		set[id] = true
+	}
+	return set, nil
+}


### PR DESCRIPTION
## Summary

Consolidates **all of #484's DM/conversation per-Space isolation work** onto one
branch. Two groups of fixes, all server-side, no client change:

**A. Base #484 (DM isolation) — authoritative `dm_space_presence` index**
1. **Symptom 2 (DMs mutually hiding between Spaces):** conversation visibility
   was decided by scanning the single shared Recents window, so the most-recently
   active Space won and the other hid the DM. Now OR-ed with a durable, window-
   independent `dm_space_presence` index written at the WuKongIM message webhook.
2. **Symptom 1 (untagged DM history leaking into every Space):** `/v1/message/channel/sync`
   now keeps an untagged DM message only in the user's default Space.

**B. Recent-list cross-Space paths that reproduce with a well-formed request**
3. **Default-Space DM catch-all:** the default Space listed *every* bare DM,
   including DMs whose messages belong exclusively to other Spaces. A positive-
   evidence post-pass now hides such a DM iff `dm_space_presence` has rows for the
   pair, none for the default Space, and Recents carry no untagged/default-tagged
   counter-evidence. DMs with no presence rows keep the legacy catch-all; system
   bots exempt; regular-bot visibility stays with the existing bot sub-check;
   `skipBotFilter` or any query failure disables the pass.
4. **Spaceless group/topic:** a group with an empty `group.space_id` (and its
   topics) was visible in *every* Space; now attributed to the default Space only
   (conv filter, `filterThreadConvCore`, and sidebar `filterThreadExtsBySpace`).

## Related Issue

Fixes #484.

## Linked Spec

- `.octospec/tasks/dm-space-isolation-484/brief.md` (base isolation)
- `.octospec/tasks/conv-space-catchall-484/brief.md` (recent-list catch-all)
- Journals under `.octospec/journal/shared/`.

## Changes

- **New infra:** `dm_space_presence` table (`modules/space/sql/…`),
  `pkg/space/dm_presence.go` (`UpsertDMSpacePresence`/`DMSpacePresenceSet`) +
  `dm_presence_any.go` (`DMSpacePresenceAnySet`), post-commit best-effort write in
  `modules/webhook/api.go` (never blocks message persistence).
- **`modules/message/space_filter.go`:** `decideConvKeepInSpace` gains the
  `dmPresentSet` presence-OR (symptom 2) and the spaceless-group default-Space
  attribution; `filterThreadConvCore` mirrors it for topics; both v1
  (`FilterConversationsBySpace`) and v2 (`FilterRawConversationsBySpace`) resolve
  the default Space via `GetUserDefaultSpaceIDE` (fail-open on error) and run the
  default-Space catch-all post-pass (`space_filter_default_catchall.go`).
- **`modules/message/api.go`:** symptom-1 untagged-history default-Space policy,
  fail-open + log on default-Space lookup error.
- **`modules/message/api_sidebar.go`:** spaceless parent thread-ext attributed to
  the default Space only. The default-Space lookup there is a *soft attribution
  heuristic, not an auth boundary*, so it now fails **open** (logs + treats the
  current Space as default) — a transient `space_member` blip no longer 500s the
  whole follow tab; the genuine boundary queries (group table, external-group map)
  stay **fail-closed**.

## Testing

```
go build ./...                                          ok
go vet (incl. -tags=integration)                        ok
go test -race -shuffle=on ./modules/message/ ./pkg/space/ ./modules/webhook/   ok  (CI-parity unit)
make i18n-lint && make i18n-extract-check               ok
go test -tags=integration ./modules/message/ -run 'TestRepro484|TestConvSpaceCatchall|TestDMSpacePresenceAccessors' -v
  all PASS  (8 base #484 repro + 2 catch-all e2e + DB-level presence-accessor lock-down)
go test -tags=integration ./modules/message/ -run 'TestIntegration_Sidebar|ThreadExt|TestSidebar_'
  all PASS  (follow-tab / thread-ext space filter — covers the api_sidebar.go change)
```

Integration tests drive the real webhook (writes presence) + real sync handlers.
The repro + catch-all suites were unified onto one fake-IM + webhook secret so they
run together (the message module binds once per process via `register.GetModules`);
the sidebar suite uses its own ctx and is run isolated. Note: integration-tagged
tests are local-only — CI runs the unit tag, which is green here under
`-race -shuffle=on`. Unit suite covers the presence-OR, the catch-all
evidence/fail-open gates, counter-evidence, bot exemptions, and the presence
accessors directly.

- [x] Unit tests added/updated
- [x] Manually verified (integration suite against MySQL/Redis/WuKongIM)

## Known boundaries (surfaced in review — by design, not regressions)

- **Encrypted (Signal) DMs skip the presence write:** the payload is unparseable,
  so a DM that exists *only* as encrypted messages in another Space gets no
  presence row and the default-Space catch-all cannot hide it. This is the
  fail-open contract (never hide without positive evidence); the leak is not
  introduced here, only left unclosed for encrypted-only DMs.
- **Spaceless-group → default-Space-only is a user-visible change:** a group that
  genuinely belongs to Space B but has an empty `group.space_id` (missing
  backfill) disappears from B until backfilled. The direction is fail-closed
  (safer for a leak fix) and self-heals once `group.space_id` is populated.
- **`/v1/sidebar/sync` does not emit `space_memberships`** — it returns only
  `{items, version, follow_version}`. Only `/v1/conversation/sync`
  (`buildSpaceMemberships`) carries the authoritative wipe-replace membership
  list. Any client treating the sidebar response as a `space_memberships` source
  is reading a field the server never sends.

## Follow-up (not in this PR)

- **Production triage observability:** an `X-Internal-Token`-gated read-only
  "explain" path that replays the filter for a given uid+space and returns
  per-conversation kept/dropped + reason, so ops can diagnose from the response
  without packet capture. A global DEBUG-log switch was rejected (needs redeploy
  to flip, floods all users, can't target an after-the-fact report).
- **Efficiency:** chunk the presence `IN (…)` queries; combine the any-Space and
  per-Space presence lookups into one query; dedup/batch the webhook presence upsert.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   It makes DM/group Space visibility in `/v1/conversation/sync` and
   `/v1/sidebar/sync` authoritative rather than window-inferred: a durable
   presence index decides DM membership (both directions — show in a Space it has
   evidence for, hide from the default Space when evidence points only elsewhere),
   and unattributable groups/topics live in the default Space instead of everywhere.

2. **What could break (dependents + failure mode)?**
   Both sync endpoints share the filter. Mitigations: presence/default-Space DB
   error → no new hiding (fail-open); `skipBotFilter` → catch-all pass skipped so
   bot identity is never guessed; system bots exempt + `EnsureSystemBotsPresent`
   preserved; webhook presence write is post-commit best-effort. Accepted trade-off:
   a DM's default-Space visibility can flip as its Recents window slides between
   untagged and tagged-elsewhere messages (monotone toward the correct end state).

3. **How do you know it works?**
   End-to-end integration tests through real handlers + real webhook-written
   presence, DB-level accessor tests for the presence index, plus unit suites for
   every branch/gate. A `/code-review` (high) found no correctness regressions —
   only the accepted boundary trade-offs above and the efficiency follow-ups.

## Checklist

- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (octospec briefs/journals/log)
- [x] Followed commit message conventions (Conventional Commits)

> Note: this branch now contains the entire #484 scope (the earlier
> `fix/dm-space-isolation-484` branch was merged in and does not need its own PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmFRUBSc2x7kpDaLs3Gyco