### PR TITLE
fix(group): async reconcile for orphan group channels #394

### DIFF
--- a/modules/group/1module.go
+++ b/modules/group/1module.go
@@ -1,6 +1,7 @@
 package group
 
 import (
+	"context"
 	"embed"
 	"fmt"
 	"time"
@@ -30,8 +31,30 @@ func init() {
 		// source_space_* / home_space_* 字段，让 Web/Android/iOS UserInfo 能区分
 		// "同 Space 非好友 → 直接发消息" vs "跨 Space 外部成员 → 仅可在群内交流"。
 		user.RegisterGroupMemberExternalProvider(api.groupService.GetMemberExternalFields)
+
+		// #394：孤儿群频道 reconcile worker。CreateGroup 在 IM 频道创建失败 / 补偿删除失败 /
+		// 崩溃窗口可能残留 channel_synced=0 的群；worker 周期性扫描并幂等补建频道，收敛为
+		// 最终一致。默认关闭（DM_GROUP_CHANNEL_RECONCILE_ENABLED），灰度友好。
+		reconcileWorker := NewReconcileWorker(ctx.(*config.Context), LoadReconcileConfig())
+		// workerCancel 每次 Start 重建，让未来的 graceful-reload 拿到新鲜 ctx；框架当前只
+		// Start 一次，这里的幂等是防误用（与 thread archive worker 同策略）。
+		var workerCancel context.CancelFunc
+
 		return register.Module{
 			Name: "group",
+			Start: func() error {
+				workerCtx, cancel := context.WithCancel(context.Background())
+				workerCancel = cancel
+				reconcileWorker.Start(workerCtx)
+				return nil
+			},
+			Stop: func() error {
+				if workerCancel != nil {
+					workerCancel()
+				}
+				reconcileWorker.Stop()
+				return nil
+			},
 			SetupAPI: func() register.APIRouter {
 				return api
 			},

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -38,6 +38,35 @@ func (d *DB) Insert(m *Model) error {
 	return err
 }
 
+// SetChannelSyncedTx 在事务内把某群的 channel_synced 置为指定值（#394）。
+// CreateGroup 在插入群记录后立刻置 0（Model 不含该列，落库走 DEFAULT 1，故需显式翻 0），
+// 使「群已提交、IM 频道尚未确认」这一状态持久可见，交给 reconcile worker 兜底补建。
+func (d *DB) SetChannelSyncedTx(groupNo string, synced int, tx *dbr.Tx) error {
+	_, err := tx.Update("group").Set("channel_synced", synced).Where("group_no=?", groupNo).Exec()
+	return err
+}
+
+// SetChannelSynced 事务外把某群 channel_synced 置为指定值（#394）。
+// CreateGroup 在 IM 频道创建**确认成功**后置 1；reconcile worker 补建成功后同样置 1。
+// 幂等：重复置同一值无副作用。
+func (d *DB) SetChannelSynced(groupNo string, synced int) error {
+	_, err := d.session.Update("group").Set("channel_synced", synced).Where("group_no=?", groupNo).Exec()
+	return err
+}
+
+// QueryUnsyncedChannelGroups 返回 channel_synced=0 且 created_at < cutoff 的群编号（#394）。
+// cutoff 是「宽限截止时刻」：只有创建超过宽限期仍未确认的群才被视作孤儿候选，避免和正在
+// 进行中的建群事务（尚未走到置 1）竞争。按 id 升序 + LIMIT 分批，配合复合索引
+// group_channel_synced_created 走 index range。
+func (d *DB) QueryUnsyncedChannelGroups(cutoff time.Time, limit int) ([]string, error) {
+	var groupNos []string
+	_, err := d.session.SelectBySql(
+		"SELECT group_no FROM `group` WHERE channel_synced=0 AND created_at < ? ORDER BY id ASC LIMIT ?",
+		cutoff.Format("2006-01-02 15:04:05"), limit,
+	).Load(&groupNos)
+	return groupNos, err
+}
+
 // 修改群类型
 func (d *DB) UpdateGroupTypeTx(groupNo string, groupType GroupType, tx *dbr.Tx) error {
 	_, err := tx.Update("group").Set("group_type", int(groupType)).Where("group_no=?", groupNo).Exec()

--- a/modules/group/metrics.go
+++ b/modules/group/metrics.go
@@ -1,0 +1,35 @@
+package group
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// 本文件登记 group 模块的 Prometheus 指标（#394 reconcile 可观测性）。
+//
+// 设计取舍（与 modules/oidc/metrics.go 一致）：
+//   - 注册到全局默认 Registry（promauto.New*），由基础设施统一暴露 /metrics。
+//   - Counter 带 result 维度，便于 Grafana 切分 orphan 检出 / 修复 / 失败比例。
+//   - 不加 group_no / space_id 这类高基维 label，避免 Prometheus 内存爆炸。
+const groupMetricNamespace = "group"
+
+var (
+	// metricReconcileTickTotal reconcile worker 每次 tick 的出口分布：
+	// ran（正常跑完）| error（查询孤儿失败提前返回）。
+	metricReconcileTickTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: groupMetricNamespace,
+		Name:      "channel_reconcile_tick_total",
+		Help:      "Channel reconcile worker tick outcomes (ran|error).",
+	}, []string{"result"})
+
+	// metricReconcileOrphanTotal 单个孤儿群的处理出口分布：
+	//   detected  — 本轮扫描发现的 channel_synced=0 孤儿候选（每个候选 +1）；
+	//   resolved  — 成功补建 IM 频道并翻 channel_synced=1；
+	//   im_failed — IMCreateOrUpdateChannel 失败，留待下个 tick 重试；
+	//   mark_failed — 频道补建成功但翻 channel_synced=1 失败，下个 tick 会再确认。
+	metricReconcileOrphanTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: groupMetricNamespace,
+		Name:      "channel_reconcile_orphan_total",
+		Help:      "Channel reconcile per-orphan outcomes (detected|resolved|im_failed|mark_failed).",
+	}, []string{"result"})
+)

--- a/modules/group/reconcile_config.go
+++ b/modules/group/reconcile_config.go
@@ -1,0 +1,76 @@
+package group
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ReconcileConfig 孤儿群频道 reconcile worker 的运行参数（#394）。
+type ReconcileConfig struct {
+	// Enabled 总开关。disabled 时 worker 不启动 ticker。
+	Enabled bool
+	// Interval 两次 tick 之间的间隔。<=0 视为禁用。
+	Interval time.Duration
+	// Grace 宽限期：只 reconcile created_at 早于 (now-Grace) 的未同步群，避免和正在
+	// 进行中的建群事务（尚未走到 channel_synced=1）竞争。<=0 时回退默认值。
+	Grace time.Duration
+	// BatchSize 单个 tick 扫描 / 处理的孤儿上限。<=0 或越界回退 / 截断。
+	BatchSize int
+}
+
+const (
+	envReconcileEnabled   = "DM_GROUP_CHANNEL_RECONCILE_ENABLED"
+	envReconcileInterval  = "DM_GROUP_CHANNEL_RECONCILE_INTERVAL"
+	envReconcileGrace     = "DM_GROUP_CHANNEL_RECONCILE_GRACE"
+	envReconcileBatchSize = "DM_GROUP_CHANNEL_RECONCILE_BATCH_SIZE"
+
+	defaultReconcileInterval  = 5 * time.Minute
+	defaultReconcileGrace     = 2 * time.Minute
+	defaultReconcileBatchSize = 200
+	// maxReconcileBatchSize 防止运维误填巨数把单 tick 变成对 WuKongIM 的洪峰调用。
+	maxReconcileBatchSize = 2000
+)
+
+// LoadReconcileConfig 从环境变量装载配置。
+// 错误 / 越界值一律回退默认值，避免运维误填导致 worker 行为失控。
+// 默认 Enabled=false：新兜底路径显式开启（灰度友好），与 #394「不引入非预期后台流量」一致。
+func LoadReconcileConfig() ReconcileConfig {
+	return ReconcileConfig{
+		Enabled:   parseReconcileBool(os.Getenv(envReconcileEnabled)),
+		Interval:  parseReconcileDuration(os.Getenv(envReconcileInterval), defaultReconcileInterval),
+		Grace:     parseReconcileDuration(os.Getenv(envReconcileGrace), defaultReconcileGrace),
+		BatchSize: parseReconcileBoundedInt(os.Getenv(envReconcileBatchSize), defaultReconcileBatchSize, maxReconcileBatchSize),
+	}
+}
+
+func parseReconcileBool(raw string) bool {
+	v := strings.ToLower(strings.TrimSpace(raw))
+	return v == "true" || v == "1"
+}
+
+func parseReconcileDuration(raw string, def time.Duration) time.Duration {
+	if raw == "" {
+		return def
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return def
+	}
+	return d
+}
+
+func parseReconcileBoundedInt(raw string, def, max int) int {
+	if raw == "" {
+		return def
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return def
+	}
+	if n > max {
+		return max
+	}
+	return n
+}

--- a/modules/group/reconcile_config_test.go
+++ b/modules/group/reconcile_config_test.go
@@ -1,0 +1,102 @@
+package group
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestLoadReconcileConfig_Issue394(t *testing.T) {
+	envs := []string{
+		envReconcileEnabled, envReconcileInterval, envReconcileGrace, envReconcileBatchSize,
+	}
+	// 保存并清空相关 env，测试结束后恢复，避免污染其他用例。
+	saved := map[string]string{}
+	for _, e := range envs {
+		saved[e] = os.Getenv(e)
+		os.Unsetenv(e)
+	}
+	defer func() {
+		for _, e := range envs {
+			if v, ok := saved[e]; ok && v != "" {
+				os.Setenv(e, v)
+			} else {
+				os.Unsetenv(e)
+			}
+		}
+	}()
+
+	tests := []struct {
+		name string
+		env  map[string]string
+		want ReconcileConfig
+	}{
+		{
+			name: "defaults when unset (disabled by default)",
+			env:  map[string]string{},
+			want: ReconcileConfig{
+				Enabled:   false,
+				Interval:  defaultReconcileInterval,
+				Grace:     defaultReconcileGrace,
+				BatchSize: defaultReconcileBatchSize,
+			},
+		},
+		{
+			name: "all valid overrides",
+			env: map[string]string{
+				envReconcileEnabled:   "true",
+				envReconcileInterval:  "30s",
+				envReconcileGrace:     "1m",
+				envReconcileBatchSize: "50",
+			},
+			want: ReconcileConfig{
+				Enabled:   true,
+				Interval:  30 * time.Second,
+				Grace:     time.Minute,
+				BatchSize: 50,
+			},
+		},
+		{
+			name: "enabled=1 alias; invalid/negative fall back to defaults",
+			env: map[string]string{
+				envReconcileEnabled:   "1",
+				envReconcileInterval:  "not-a-duration",
+				envReconcileGrace:     "-5s",
+				envReconcileBatchSize: "0",
+			},
+			want: ReconcileConfig{
+				Enabled:   true,
+				Interval:  defaultReconcileInterval,
+				Grace:     defaultReconcileGrace,
+				BatchSize: defaultReconcileBatchSize,
+			},
+		},
+		{
+			name: "batch size clamped to max",
+			env: map[string]string{
+				envReconcileBatchSize: "999999",
+			},
+			want: ReconcileConfig{
+				Enabled:   false,
+				Interval:  defaultReconcileInterval,
+				Grace:     defaultReconcileGrace,
+				BatchSize: maxReconcileBatchSize,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, e := range envs {
+				os.Unsetenv(e)
+			}
+			for k, v := range tt.env {
+				os.Setenv(k, v)
+			}
+			got := LoadReconcileConfig()
+			if got != tt.want {
+				t.Errorf("LoadReconcileConfig() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/modules/group/reconcile_worker.go
+++ b/modules/group/reconcile_worker.go
@@ -1,0 +1,199 @@
+package group
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+
+	"go.uber.org/zap"
+)
+
+// reconcileStore ReconcileWorker 对持久层的最小依赖，便于单测注入 stub（无需真实 DB）。
+type reconcileStore interface {
+	// QueryUnsyncedChannelGroups 返回 channel_synced=0 且 created_at<cutoff 的群编号。
+	QueryUnsyncedChannelGroups(cutoff time.Time, limit int) ([]string, error)
+	// SubscribableMemberUIDs 返回某群「可订阅」成员 uid（is_deleted=0 且 status=normal）。
+	SubscribableMemberUIDs(groupNo string) ([]string, error)
+	// SetChannelSynced 把某群 channel_synced 置为指定值。
+	SetChannelSynced(groupNo string, synced int) error
+}
+
+// channelCreator 抽出 IM 频道创建能力（生产实现是 *config.Context），便于单测 mock。
+// IMCreateOrUpdateChannel 语义为「创建或更新」，天然幂等——重复补建已存在的频道安全。
+type channelCreator interface {
+	IMCreateOrUpdateChannel(req *config.ChannelCreateReq) error
+}
+
+// dbReconcileStore 把 *group.DB 适配到 reconcileStore（生产实现）。
+type dbReconcileStore struct{ db *DB }
+
+func (s dbReconcileStore) QueryUnsyncedChannelGroups(cutoff time.Time, limit int) ([]string, error) {
+	return s.db.QueryUnsyncedChannelGroups(cutoff, limit)
+}
+
+func (s dbReconcileStore) SubscribableMemberUIDs(groupNo string) ([]string, error) {
+	return s.db.querySubscribableMemberUIDsWithGroupNo(groupNo)
+}
+
+func (s dbReconcileStore) SetChannelSynced(groupNo string, synced int) error {
+	return s.db.SetChannelSynced(groupNo, synced)
+}
+
+// ReconcileWorker 周期性扫描 channel_synced=0 的孤儿群，幂等补建其 WuKongIM 频道，
+// 成功后翻 channel_synced=1（#394）。它是 CreateGroup 补偿删除失败 / 进程崩溃窗口的
+// 兜底：把「可查询但无 backing 频道」的永久孤儿收敛为最终一致。
+type ReconcileWorker struct {
+	cfg   ReconcileConfig
+	store reconcileStore
+	im    channelCreator
+	now   func() time.Time
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+	log.Log
+}
+
+// NewReconcileWorker 构造生产 worker：从 *config.Context 派生 DB store 与 IM 频道创建能力。
+func NewReconcileWorker(ctx *config.Context, cfg ReconcileConfig) *ReconcileWorker {
+	return &ReconcileWorker{
+		cfg:   cfg,
+		store: dbReconcileStore{db: NewDB(ctx)},
+		im:    ctx,
+		now:   time.Now,
+		Log:   log.NewTLog("GroupChannelReconcileWorker"),
+	}
+}
+
+// Start 启动后台 ticker。Enabled=false / Interval<=0 时不启动新 goroutine，但仍先停掉
+// 可能存在的旧 goroutine（防未来热更留孤儿 ticker）。重复调用幂等：先 stop 再 start。
+func (w *ReconcileWorker) Start(ctx context.Context) {
+	if w.cancel != nil {
+		w.cancel()
+		w.wg.Wait()
+		w.cancel = nil
+	}
+	if !w.cfg.Enabled || w.cfg.Interval <= 0 {
+		w.Info("group channel reconcile worker disabled",
+			zap.Bool("enabled", w.cfg.Enabled),
+			zap.Duration("interval", w.cfg.Interval))
+		return
+	}
+	rctx, cancel := context.WithCancel(ctx)
+	w.cancel = cancel
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+		t := time.NewTicker(w.cfg.Interval)
+		defer t.Stop()
+		w.Info("group channel reconcile worker started",
+			zap.Duration("interval", w.cfg.Interval),
+			zap.Duration("grace", w.cfg.Grace),
+			zap.Int("batch_size", w.cfg.BatchSize))
+		for {
+			select {
+			case <-rctx.Done():
+				return
+			case <-t.C:
+				resolved, err := w.RunOnce(rctx)
+				if err != nil && !errors.Is(err, context.Canceled) {
+					w.Error("group channel reconcile run failed", zap.Error(err))
+					continue
+				}
+				if resolved > 0 {
+					w.Info("group channel reconcile run", zap.Int("resolved", resolved))
+				}
+			}
+		}
+	}()
+}
+
+// Stop 通知 worker 退出并等待当前 RunOnce 跑完。
+func (w *ReconcileWorker) Stop() {
+	if w.cancel != nil {
+		w.cancel()
+	}
+	w.wg.Wait()
+}
+
+// RunOnce 执行一轮 reconcile：拉一批孤儿群 → 逐个幂等补建频道 → 成功翻 channel_synced=1。
+// 返回本轮成功修复的孤儿数。
+//
+// 安全保护：
+//   - BatchSize<=0 视为禁用，直接返回 (0,nil)；Grace<=0 时回退默认宽限，避免和进行中的
+//     建群事务竞争（cutoff = now-grace）。
+//   - 单个孤儿处理失败（IM 创建 / 翻标记）只 log+metric，不中断整批——下个 tick 自然重试。
+//   - ctx 取消时立即停止派发，返回 ctx.Err() 让上层区分「正常停机」vs「异常」。
+func (w *ReconcileWorker) RunOnce(ctx context.Context) (int, error) {
+	batch := w.cfg.BatchSize
+	if batch <= 0 {
+		return 0, nil
+	}
+	grace := w.cfg.Grace
+	if grace <= 0 {
+		grace = defaultReconcileGrace
+	}
+	cutoff := w.now().Add(-grace)
+
+	groupNos, err := w.store.QueryUnsyncedChannelGroups(cutoff, batch)
+	if err != nil {
+		metricReconcileTickTotal.WithLabelValues("error").Inc()
+		return 0, err
+	}
+	metricReconcileTickTotal.WithLabelValues("ran").Inc()
+
+	var resolved int
+	for _, groupNo := range groupNos {
+		if err := ctx.Err(); err != nil {
+			return resolved, err
+		}
+		metricReconcileOrphanTotal.WithLabelValues("detected").Inc()
+		if w.reconcileOne(groupNo) {
+			resolved++
+		}
+	}
+	return resolved, nil
+}
+
+// reconcileOne 修复单个孤儿群：拉当前可订阅成员 → 幂等补建 IM 频道 → 翻 channel_synced=1。
+// 返回是否成功修复（频道已确认在且标记已翻 1）。
+//
+// 关键点：
+//   - 订阅者取自 group_member 权威列表（与 IMDatasource.Subscribers 回调同源），WuKongIM
+//     后续重载订阅也会以它为准，故此处传空列表也不会丢成员——但仍显式带上，缩短可见窗口。
+//   - IMCreateOrUpdateChannel 幂等：即便频道其实已存在（进程在翻标记前崩溃的场景），
+//     重复调用只是刷新，安全。
+func (w *ReconcileWorker) reconcileOne(groupNo string) bool {
+	subscribers, err := w.store.SubscribableMemberUIDs(groupNo)
+	if err != nil {
+		// 拉成员失败不阻断补建：WuKongIM 会从 Subscribers 数据源回填，仍以空列表补建频道，
+		// 至少消除「无 backing 频道」这一硬性缺陷；成员列表下个订阅重载自愈。
+		w.Warn("reconcile: query subscribers failed, creating channel with empty list",
+			zap.Error(err), zap.String("groupNo", groupNo))
+		subscribers = nil
+	}
+	if err := w.im.IMCreateOrUpdateChannel(&config.ChannelCreateReq{
+		ChannelID:   groupNo,
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		Subscribers: subscribers,
+	}); err != nil {
+		metricReconcileOrphanTotal.WithLabelValues("im_failed").Inc()
+		w.Warn("reconcile: create IM channel failed, will retry next tick",
+			zap.Error(err), zap.String("groupNo", groupNo))
+		return false
+	}
+	if err := w.store.SetChannelSynced(groupNo, 1); err != nil {
+		// 频道已补建成功，但标记没翻——下个 tick 会再次命中该行、确认频道已在后补翻 1。
+		metricReconcileOrphanTotal.WithLabelValues("mark_failed").Inc()
+		w.Warn("reconcile: channel created but mark channel_synced=1 failed, will retry next tick",
+			zap.Error(err), zap.String("groupNo", groupNo))
+		return false
+	}
+	metricReconcileOrphanTotal.WithLabelValues("resolved").Inc()
+	w.Info("reconcile: orphan group channel recreated", zap.String("groupNo", groupNo))
+	return true
+}

--- a/modules/group/reconcile_worker_test.go
+++ b/modules/group/reconcile_worker_test.go
@@ -1,0 +1,235 @@
+package group
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubReconcileStore 模拟持久层：可配置待返回的孤儿群、成员列表与注入错误，
+// 并记录 SetChannelSynced 调用，供断言修复动作。
+type stubReconcileStore struct {
+	orphans      []string
+	queryErr     error
+	subscribers  map[string][]string
+	subErr       error
+	setErr       error
+	gotCutoff    time.Time
+	gotLimit     int
+	syncedGroups []string // 记录 SetChannelSynced(x, 1) 的入参顺序
+	queryCalls   int
+}
+
+func (s *stubReconcileStore) QueryUnsyncedChannelGroups(cutoff time.Time, limit int) ([]string, error) {
+	s.queryCalls++
+	s.gotCutoff = cutoff
+	s.gotLimit = limit
+	if s.queryErr != nil {
+		return nil, s.queryErr
+	}
+	return s.orphans, nil
+}
+
+func (s *stubReconcileStore) SubscribableMemberUIDs(groupNo string) ([]string, error) {
+	if s.subErr != nil {
+		return nil, s.subErr
+	}
+	return s.subscribers[groupNo], nil
+}
+
+func (s *stubReconcileStore) SetChannelSynced(groupNo string, synced int) error {
+	if s.setErr != nil {
+		return s.setErr
+	}
+	if synced == 1 {
+		s.syncedGroups = append(s.syncedGroups, groupNo)
+	}
+	return nil
+}
+
+// stubChannelCreator 记录补建频道调用；failFor 中的 group 返回错误，模拟 IM 侧失败。
+type stubChannelCreator struct {
+	created []*config.ChannelCreateReq
+	failFor map[string]bool
+	err     error
+}
+
+func (c *stubChannelCreator) IMCreateOrUpdateChannel(req *config.ChannelCreateReq) error {
+	c.created = append(c.created, req)
+	if c.err != nil {
+		return c.err
+	}
+	if c.failFor[req.ChannelID] {
+		return errors.New("im create failed for " + req.ChannelID)
+	}
+	return nil
+}
+
+func newTestReconcileWorker(cfg ReconcileConfig, store reconcileStore, im channelCreator, now time.Time) *ReconcileWorker {
+	return &ReconcileWorker{
+		cfg:   cfg,
+		store: store,
+		im:    im,
+		now:   func() time.Time { return now },
+		Log:   log.NewTLog("GroupChannelReconcileWorkerTest"),
+	}
+}
+
+func testReconcileCfg() ReconcileConfig {
+	return ReconcileConfig{
+		Enabled:   true,
+		Interval:  time.Minute,
+		Grace:     2 * time.Minute,
+		BatchSize: 100,
+	}
+}
+
+// Test_Issue394_ReconcileRecreatesOrphanChannel 是核心回归：一个 channel_synced=0 的
+// 孤儿群（CreateGroup 补偿删除失败 / 崩溃窗口的残留），reconcile worker 必须幂等补建其
+// WuKongIM 频道（带当前订阅成员），并翻 channel_synced=1，从而消除「可查询但无 backing
+// 频道」的永久孤儿。worker 出现之前该行为不存在（孤儿永久残留）→ 本测试是 RED→GREEN 的信号。
+func Test_Issue394_ReconcileRecreatesOrphanChannel(t *testing.T) {
+	store := &stubReconcileStore{
+		orphans:     []string{"g-orphan-1"},
+		subscribers: map[string][]string{"g-orphan-1": {"u1", "u2"}},
+	}
+	im := &stubChannelCreator{}
+	w := newTestReconcileWorker(testReconcileCfg(), store, im, time.Now())
+
+	resolved, err := w.RunOnce(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, resolved, "the single orphan should be reconciled")
+
+	require.Len(t, im.created, 1, "IM channel should be (re)created exactly once")
+	got := im.created[0]
+	assert.Equal(t, "g-orphan-1", got.ChannelID)
+	assert.Equal(t, common.ChannelTypeGroup.Uint8(), got.ChannelType)
+	assert.Equal(t, []string{"u1", "u2"}, got.Subscribers, "current members must be passed as subscribers")
+
+	assert.Equal(t, []string{"g-orphan-1"}, store.syncedGroups, "orphan must be flipped channel_synced=1 after confirmed create")
+}
+
+// Test_Issue394_ReconcileGraceCutoff 断言扫描 cutoff = now - grace，且 limit = batch size，
+// 保证 worker 不会和正在进行中的建群事务（尚未走到 channel_synced=1）竞争。
+func Test_Issue394_ReconcileGraceCutoff(t *testing.T) {
+	now := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
+	cfg := testReconcileCfg()
+	cfg.Grace = 90 * time.Second
+	cfg.BatchSize = 37
+	store := &stubReconcileStore{}
+	w := newTestReconcileWorker(cfg, store, &stubChannelCreator{}, now)
+
+	_, err := w.RunOnce(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, now.Add(-90*time.Second), store.gotCutoff)
+	assert.Equal(t, 37, store.gotLimit)
+}
+
+// Test_Issue394_ReconcileIMFailureRetries 断言 IM 补建失败时不翻 channel_synced，
+// 该孤儿留待下个 tick 重试（最终一致，不会误标记为已修复）。
+func Test_Issue394_ReconcileIMFailureRetries(t *testing.T) {
+	store := &stubReconcileStore{
+		orphans:     []string{"g-fail", "g-ok"},
+		subscribers: map[string][]string{"g-fail": {"u1"}, "g-ok": {"u2"}},
+	}
+	im := &stubChannelCreator{failFor: map[string]bool{"g-fail": true}}
+	w := newTestReconcileWorker(testReconcileCfg(), store, im, time.Now())
+
+	resolved, err := w.RunOnce(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, resolved, "only the healthy orphan resolves")
+	assert.Equal(t, []string{"g-ok"}, store.syncedGroups, "failed orphan must NOT be marked synced")
+	assert.Len(t, im.created, 2, "both orphans attempted; failure does not abort the batch")
+}
+
+// Test_Issue394_ReconcileMarkFailureNotResolved 断言频道补建成功但翻标记失败时不计为
+// 已修复——下个 tick 会再次命中并重试（幂等），避免「频道在但 DB 标记漂移」被误判修复。
+func Test_Issue394_ReconcileMarkFailureNotResolved(t *testing.T) {
+	store := &stubReconcileStore{
+		orphans:     []string{"g1"},
+		subscribers: map[string][]string{"g1": {"u1"}},
+		setErr:      errors.New("db down"),
+	}
+	im := &stubChannelCreator{}
+	w := newTestReconcileWorker(testReconcileCfg(), store, im, time.Now())
+
+	resolved, err := w.RunOnce(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, resolved)
+	assert.Len(t, im.created, 1, "channel still (idempotently) created")
+}
+
+// Test_Issue394_ReconcileSubscriberQueryFailureStillCreates 断言拉成员失败时仍补建频道
+// （空订阅），至少消除「无 backing 频道」的硬缺陷；成员由后续订阅重载自愈。
+func Test_Issue394_ReconcileSubscriberQueryFailureStillCreates(t *testing.T) {
+	store := &stubReconcileStore{
+		orphans: []string{"g1"},
+		subErr:  errors.New("member query failed"),
+	}
+	im := &stubChannelCreator{}
+	w := newTestReconcileWorker(testReconcileCfg(), store, im, time.Now())
+
+	resolved, err := w.RunOnce(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, resolved)
+	require.Len(t, im.created, 1)
+	assert.Empty(t, im.created[0].Subscribers)
+	assert.Equal(t, []string{"g1"}, store.syncedGroups)
+}
+
+func Test_Issue394_ReconcileDisabledByBatchSize(t *testing.T) {
+	cfg := testReconcileCfg()
+	cfg.BatchSize = 0
+	store := &stubReconcileStore{orphans: []string{"g1"}}
+	w := newTestReconcileWorker(cfg, store, &stubChannelCreator{}, time.Now())
+
+	resolved, err := w.RunOnce(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, resolved)
+	assert.Equal(t, 0, store.queryCalls, "must not query DB when batch size disabled")
+}
+
+func Test_Issue394_ReconcileQueryErrorPropagates(t *testing.T) {
+	store := &stubReconcileStore{queryErr: errors.New("select failed")}
+	w := newTestReconcileWorker(testReconcileCfg(), store, &stubChannelCreator{}, time.Now())
+
+	resolved, err := w.RunOnce(context.Background())
+	require.Error(t, err)
+	assert.Equal(t, 0, resolved)
+}
+
+func Test_Issue394_ReconcileContextCancelStopsBatch(t *testing.T) {
+	store := &stubReconcileStore{
+		orphans:     []string{"g1", "g2", "g3"},
+		subscribers: map[string][]string{},
+	}
+	im := &stubChannelCreator{}
+	w := newTestReconcileWorker(testReconcileCfg(), store, im, time.Now())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 立即取消：RunOnce 拉到批后应在处理首个孤儿前就退出。
+	resolved, err := w.RunOnce(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 0, resolved)
+	assert.Empty(t, im.created, "cancelled context must not dispatch any IM create")
+}
+
+// Test_Issue394_ReconcileStartDisabledNoGoroutine 断言 Enabled=false 时 Start 不起 ticker。
+func Test_Issue394_ReconcileStartDisabledNoGoroutine(t *testing.T) {
+	cfg := testReconcileCfg()
+	cfg.Enabled = false
+	store := &stubReconcileStore{orphans: []string{"g1"}}
+	w := newTestReconcileWorker(cfg, store, &stubChannelCreator{}, time.Now())
+
+	w.Start(context.Background())
+	defer w.Stop()
+	time.Sleep(20 * time.Millisecond)
+	assert.Equal(t, 0, store.queryCalls, "disabled worker must not tick")
+}

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -1185,6 +1185,16 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 		return nil, errors.New("failed to insert group record")
 	}
 
+	// #394：把新群标记为「IM 频道待确认」(channel_synced=0)。Model 不含该列，InsertTx
+	// 落库走 DEFAULT 1，故这里在**同一事务内**显式翻 0——使「群已提交、频道未确认」这一
+	// 中间态随事务一起持久化。只有下方 IMCreateOrUpdateChannel 确认成功后才翻回 1；否则
+	// （补偿删除失败 / commit 与 IM 创建之间崩溃）该行留在 0，由 reconcile worker 兜底补建，
+	// 杜绝「可查询但无 backing 频道」的永久孤儿群。
+	if err := s.db.SetChannelSyncedTx(groupNo, 0, tx); err != nil {
+		s.Error("mark group channel_synced=0 failed", zap.Error(err), zap.String("groupNo", groupNo))
+		return nil, errors.New("failed to mark group channel unsynced")
+	}
+
 	// 插入成员
 	realMemberUIDs := make([]string, 0, len(memberUsers))
 	memberVos := make([]*config.UserBaseVo, 0, len(memberUsers))
@@ -1322,6 +1332,14 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 			s.Error("compensating delete group failed", zap.Error(delErr), zap.String("groupNo", groupNo))
 		}
 		return nil, errors.New("failed to create IM channel, group has been rolled back")
+	}
+
+	// #394：IM 频道确认创建成功——翻 channel_synced=1，把该群移出 reconcile worker 的
+	// 扫描集。best-effort：若这里失败，行仍停在 0，worker 下个 tick 会发现它、确认频道已在
+	// （IMCreateOrUpdateChannel 幂等）后补翻 1，最终一致，不影响本次建群成功返回。
+	if err := s.db.SetChannelSynced(groupNo, 1); err != nil {
+		s.Error("mark group channel_synced=1 failed (reconcile worker will heal)",
+			zap.Error(err), zap.String("groupNo", groupNo))
 	}
 
 	// 发送群创建通知

--- a/modules/group/sql/20260702000001_group_channel_synced.sql
+++ b/modules/group/sql/20260702000001_group_channel_synced.sql
@@ -1,0 +1,70 @@
+-- +migrate Up
+-- #394：CreateGroup 在事务提交后才创建 WuKongIM 频道，若 IM 创建失败会跑一段
+-- best-effort 补偿删除；补偿删除本身非原子、只记日志，一旦它也失败（或进程在
+-- commit 与 IM 创建之间崩溃），group 行就残留为「无 backing IM 频道的孤儿群」，
+-- 客户端永远无法收发消息。channel_synced 是持久化的 outbox 标记：
+--   channel_synced=1 → 频道已确认创建（稳定态）；
+--   channel_synced=0 → 频道尚未确认，等待 reconcile worker 兜底补建。
+-- 只有 CreateGroup 路径会在事务内把新群写成 0，并在 IM 创建确认成功后翻成 1；
+-- 其余所有插入路径都不触碰该列，落库即 DEFAULT 1（视为已同步），零行为变更。
+--
+-- 存量行：ADD COLUMN ... NOT NULL DEFAULT 1 会把所有既有 group 行一次性回填为 1
+-- （它们本就有频道），因此 reconcile worker 不会把存量群误判成孤儿。无需 NULL 哨兵
+-- 三步法——期望的回填值恰是列默认值。整块用存在性守卫包裹，跨迁移重试幂等收敛。
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_channel_synced;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __group_channel_synced()
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND COLUMN_NAME = 'channel_synced') THEN
+    ALTER TABLE `group`
+      ADD COLUMN `channel_synced` TINYINT NOT NULL DEFAULT 1
+        COMMENT 'IM频道是否已确认创建 1.已同步(默认/稳定态) 0.待reconcile补建(仅CreateGroup失败窗口)';
+  END IF;
+
+  -- reconcile worker 的扫描谓词是 (channel_synced=0 AND created_at < cutoff)，
+  -- 复合索引让「找孤儿」永远走 index range 而非全表扫（孤儿是极少数，绝大多数行=1）。
+  IF NOT EXISTS (SELECT 1 FROM information_schema.STATISTICS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND INDEX_NAME = 'group_channel_synced_created') THEN
+    CREATE INDEX `group_channel_synced_created` ON `group` (`channel_synced`, `created_at`);
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __group_channel_synced();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_channel_synced;
+-- +migrate StatementEnd
+
+-- +migrate Down
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_channel_synced_down;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __group_channel_synced_down()
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.STATISTICS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND INDEX_NAME = 'group_channel_synced_created') THEN
+    DROP INDEX `group_channel_synced_created` ON `group`;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND COLUMN_NAME = 'channel_synced') THEN
+    ALTER TABLE `group` DROP COLUMN `channel_synced`;
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __group_channel_synced_down();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_channel_synced_down;
+-- +migrate StatementEnd


### PR DESCRIPTION
<!-- multica:bug-fix-report v1 -->

# Bug Fix — Issue #394 — orphan group rows (async reconcile)

## Summary

`group.CreateGroup` commits `group` + `group_member` in a DB transaction, then creates
the WuKongIM channel **after** `tx.Commit()`. On IM-create failure it runs a best-effort
compensating delete that **only logs on failure** — so if that delete also fails (DB blip /
deadlock / connection drop) or the process crashes between commit and IM-create, the group
row survives **orphaned**: queryable/listable but with no backing IM channel, unmessageable
forever. This is pre-existing shared-layer behavior (all create paths go through
`CreateGroup`), not a regression.

## Fix — durable marker + async reconcile

The IM channel lives in WuKongIM, not the SQL tx, so it can't be enrolled in `tx`; the local
compensating delete narrows but cannot eliminate the window. Closed durably with an
outbox-style flag + reconcile job:

- **Migration** `20260702000001_group_channel_synced.sql`: adds
  `group.channel_synced TINYINT NOT NULL DEFAULT 1` + composite index
  `(channel_synced, created_at)`. `DEFAULT 1` backfills all existing rows and every
  non-CreateGroup insert path to `1` (= synced) → **zero behavior change**, no false orphans.
- **CreateGroup**: marks `channel_synced=0` in-tx right after the group insert; flips to `1`
  only after a **confirmed** `IMCreateOrUpdateChannel`. Any commit/crash/delete-fail window
  leaves the row at `0`.
- **ReconcileWorker** (`reconcile_worker.go`): periodic ticker scans `channel_synced=0` rows
  older than a grace period, **idempotently** (re)creates the IM channel with the group's
  current subscribable members, then flips `channel_synced=1`. Per-orphan failures only
  log+metric and retry next tick. Observable via prometheus counters
  (`group_channel_reconcile_tick_total`, `group_channel_reconcile_orphan_total`) + logs.
  **Default disabled** (`DM_GROUP_CHANNEL_RECONCILE_ENABLED`), wired into module `Start`/`Stop`.

Covers both failure modes in the issue: IM-fail + delete-fail, and
crash-between-commit-and-IM. Eventually consistent, idempotent, least-destructive
(re-creates the channel rather than hard-deleting valid group data).

## Config (env, all optional)

| Env | Default | Meaning |
|---|---|---|
| `DM_GROUP_CHANNEL_RECONCILE_ENABLED` | `false` | master switch (gradual-rollout friendly) |
| `DM_GROUP_CHANNEL_RECONCILE_INTERVAL` | `5m` | tick interval |
| `DM_GROUP_CHANNEL_RECONCILE_GRACE` | `2m` | only reconcile groups older than this (avoids racing in-flight creates) |
| `DM_GROUP_CHANNEL_RECONCILE_BATCH_SIZE` | `200` | per-tick scan/process cap (max 2000) |

## Files

- `modules/group/sql/20260702000001_group_channel_synced.sql` (new migration, idempotent up/down)
- `modules/group/service.go` (+18) — flag in-tx / confirm after IM create
- `modules/group/db.go` (+29) — `SetChannelSyncedTx` / `SetChannelSynced` / `QueryUnsyncedChannelGroups`
- `modules/group/reconcile_worker.go` (new) — worker + RunOnce
- `modules/group/reconcile_config.go` (new) — env config loader
- `modules/group/metrics.go` (new) — prometheus counters
- `modules/group/1module.go` (+23) — Start/Stop wiring
- `modules/group/reconcile_worker_test.go` / `reconcile_config_test.go` (new) — unit tests

## Tests

Stub-based, no DB dependency (`Test_Issue394_*`, `TestLoadReconcileConfig_Issue394`): orphan
re-create + mark-synced, grace cutoff, IM-fail retry, mark-fail retry, subscriber-query-fail
fallback, disabled/empty batch, query-error propagation, ctx-cancel, disabled Start. All pass.

## Behavior note

When the compensating delete itself fails (the orphan window), reconcile re-creates the
channel and the group becomes fully live — the least-destructive resolution. A creator whose
client saw the transient error will see the group on refresh.

## Rollback

Feature-flag disable (`DM_GROUP_CHANNEL_RECONCILE_ENABLED=false`, the default) fully disables
the worker with no schema rollback needed. The migration's `+migrate Down` drops the column +
index if a full revert is required.
