### PR TITLE
fix(group): allow group admins to update group avatar (#520)

### DIFF
--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -718,14 +718,17 @@ func (g *Group) avatarUpload(c *wkhttp.Context) {
 	}
 	defer file.Close()
 
-	isCreator, err := g.db.QueryIsGroupCreator(groupNo, loginUID)
+	// 群头像上传与群名 / 设置 / 群公告(GROUP.md)一致，放行给创建者或管理员
+	// (octo-server#520)。QueryIsGroupManagerOrCreator 额外要求 is_external=0 且
+	// status=normal，因此非正常态的创建者(外部/黑名单)会被拒绝——本就不应执行该操作。
+	isCreatorOrManager, err := g.db.QueryIsGroupManagerOrCreator(groupNo, loginUID)
 	if err != nil {
-		g.Error("查询群创建者失败！", zap.Error(err))
+		g.Error("查询群管理者或创建者失败！", zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
 		return
 	}
-	if !isCreator {
-		httperr.ResponseErrorL(c, errcode.ErrGroupCreatorOnly, nil, nil)
+	if !isCreatorOrManager {
+		httperr.ResponseErrorL(c, errcode.ErrGroupCreatorOrManagerOnly, nil, nil)
 		return
 	}
 
@@ -1176,7 +1179,9 @@ func (g *Group) groupUpdate(c *wkhttp.Context) {
 			return
 		}
 		if !isManager {
-			httperr.ResponseErrorL(c, errcode.ErrGroupManagerOnly, nil, nil)
+			// 决策用 QueryIsGroupManagerOrCreator(创建者或管理员均可)，错误码需与之一致，
+			// 而非只提管理员的 ErrGroupManagerOnly (octo-server#520)。
+			httperr.ResponseErrorL(c, errcode.ErrGroupCreatorOrManagerOnly, nil, nil)
 			return
 		}
 	} else {

--- a/modules/group/api_i18n_regression_test.go
+++ b/modules/group/api_i18n_regression_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
@@ -298,4 +299,90 @@ func TestGroupAvatarUpload_PostCommitNotifyFailureRespondsOK(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code, "post-commit notify failure should not fail committed upload, body=%s", w.Body.String())
 	assert.Contains(t, w.Body.String(), `"status":200`)
 	assert.NotEmpty(t, mockFS.uploadedPath)
+}
+
+// newAvatarUploadServer wires a group with `testutil.UID` as a member of the
+// given role and returns a router serving only avatarUpload plus the mock file
+// service. Role/status/isExternal let a caller reproduce the admin, non-member
+// and abnormal-owner permission boundaries around octo-server#520.
+func newAvatarUploadServer(t *testing.T, groupNo, creator string, role, status, isExternal int) (http.Handler, *mockAvatarUploadFileService) {
+	t.Helper()
+	_, ctx := newTestServer(t)
+	assert.NoError(t, testutil.CleanAllTables(ctx))
+
+	f := New(ctx)
+	mockFS := &mockAvatarUploadFileService{}
+	f.fileService = mockFS
+
+	assert.NoError(t, f.userDB.Insert(&user.Model{UID: testutil.UID, Name: "uploader", ShortNo: "up_" + groupNo}))
+	assert.NoError(t, f.db.Insert(&Model{
+		GroupNo: groupNo,
+		Name:    "avatar perm",
+		Creator: creator,
+		Status:  GroupStatusNormal,
+		Version: 1,
+	}))
+	// role < 0 means "not a member" — skip the group_member row entirely.
+	if role >= 0 {
+		assert.NoError(t, f.db.InsertMember(&MemberModel{
+			GroupNo:    groupNo,
+			UID:        testutil.UID,
+			Role:       role,
+			Status:     status,
+			IsExternal: isExternal,
+			Version:    1,
+			Vercode:    groupNo + "@1",
+		}))
+	}
+
+	r := wkhttp.New()
+	r.POST("/v1/groups/:group_no/avatar", ctx.AuthMiddleware(r), f.avatarUpload)
+	return r, mockFS
+}
+
+// postAvatar builds a valid multipart body carrying a "file" field and issues
+// the upload as testutil.UID.
+func postAvatar(t *testing.T, handler http.Handler, groupNo string) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile("file", "avatar.png")
+	assert.NoError(t, err)
+	_, err = fw.Write([]byte("png"))
+	assert.NoError(t, err)
+	assert.NoError(t, mw.Close())
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("POST", "/v1/groups/"+groupNo+"/avatar", &buf)
+	assert.NoError(t, err)
+	req.Header.Set("token", testutil.Token)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+// TestGroupAvatarUpload_AdminSucceeds pins the octo-server#520 fix: a group
+// admin (role=manager, normal/internal) may upload the group avatar, aligning
+// avatar upload with group name / settings / notice. Before the fix the
+// QueryIsGroupCreator gate returned 403 for anyone but the owner.
+func TestGroupAvatarUpload_AdminSucceeds(t *testing.T) {
+	handler, mockFS := newAvatarUploadServer(t, "g-avatar-admin", "other-owner", MemberRoleManager, int(common.GroupMemberStatusNormal), 0)
+
+	w := postAvatar(t, handler, "g-avatar-admin")
+	assert.Equal(t, http.StatusOK, w.Code, "群管理员上传头像应成功, body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), `"status":200`)
+	assert.NotEmpty(t, mockFS.uploadedPath, "成功路径应真正上传对象")
+}
+
+// TestGroupAvatarUpload_NonManagerForbidden pins that a regular member (neither
+// owner nor admin) still gets 403, now surfaced with the aligned
+// creator_or_manager_only error ID rather than the old creator_only.
+func TestGroupAvatarUpload_NonManagerForbidden(t *testing.T) {
+	handler, mockFS := newAvatarUploadServer(t, "g-avatar-common", "other-owner", MemberRoleCommon, int(common.GroupMemberStatusNormal), 0)
+
+	w := postAvatar(t, handler, "g-avatar-common")
+	assert.Equal(t, http.StatusBadRequest, w.Code, "wire status 固定 400, body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "err.server.group.creator_or_manager_only",
+		"普通成员上传头像应是 403 creator_or_manager_only, body=%s", w.Body.String())
+	assert.Empty(t, mockFS.uploadedPath, "被拒绝时不应上传任何对象")
 }

--- a/modules/group/avatar_get_test.go
+++ b/modules/group/avatar_get_test.go
@@ -213,7 +213,7 @@ func TestGroupAvatarGetCustomTextNotTruncated(t *testing.T) {
 	require.NotEqual(t, truncated, w.Body.Bytes(), "custom text must NOT be GroupNameText-truncated to 2")
 }
 
-// TestGroupAvatarGetUploadedRedirects 覆盖群主已上传自定义头像（is_upload_avatar=1）
+// TestGroupAvatarGetUploadedRedirects 覆盖群主/管理员已上传自定义头像（is_upload_avatar=1）
 // → 维持历史行为：重定向到对象存储，不进服务端渲染。
 func TestGroupAvatarGetUploadedRedirects(t *testing.T) {
 	s, ctx := newTestServer(t)

--- a/modules/group/avatar_version_test.go
+++ b/modules/group/avatar_version_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestGroupAvatarVersionDBRoundTrip 覆盖群主手动上传头像的落库路径：
+// TestGroupAvatarVersionDBRoundTrip 覆盖群主/管理员手动上传头像的落库路径：
 // updateAvatar 必须写入版本化对象 path、版本号，并把 is_upload_avatar 置 1
 // （后者是阻止旧的自动合成事件覆盖手动头像的关键标志）。QueryWithGroupNo
 // 读回这些字段，avatarGet 据此选择 versioned/legacy path。
@@ -31,7 +31,7 @@ func TestGroupAvatarVersionDBRoundTrip(t *testing.T) {
 	require.Equal(t, 0, before.IsUploadAvatar)
 	require.Equal(t, int64(0), before.AvatarVersion)
 
-	// 群主手动上传：写版本化 path + 版本号 + is_upload_avatar=1。
+	// 群主/管理员手动上传：写版本化 path + 版本号 + is_upload_avatar=1。
 	const version int64 = 1733300000000000002
 	avatarPath := ctx.GetConfig().GetGroupAvatarFilePath(groupNo, version)
 	require.NoError(t, g.db.updateAvatar(avatarPath, version, groupNo))


### PR DESCRIPTION
<!-- multica:bug-fix-report v1 -->

## Summary

Group **admins** got `403` when uploading a group avatar, while only the **owner** succeeded (Mininglamp-OSS/octo-web#510, reproduced Web/iOS/Android). Avatar upload was the only group-profile write still gated owner-only; group name / settings / notice are already manager-or-creator.

## Root cause

`modules/group/api.go` `avatarUpload` gated with `QueryIsGroupCreator` / `ErrGroupCreatorOnly`, so any non-owner (including admins) was denied.

## Fix

- `avatarUpload`: gate on `QueryIsGroupManagerOrCreator` and return `ErrGroupCreatorOrManagerOnly`, aligning avatar upload with group name / settings / notice.
- `groupUpdate` (change group name): fix a pre-existing errcode mismatch — it decides with `QueryIsGroupManagerOrCreator` but returned `ErrGroupManagerOnly` (`manager_only`); now returns `ErrGroupCreatorOrManagerOnly` (`creator_or_manager_only`) to match the decision.
- Neutralize stale "群主 uploaded" wording in avatar test comments.

## Behavior boundary (confirmed)

`QueryIsGroupManagerOrCreator` additionally requires `is_external=0 AND status=normal`, whereas `QueryIsGroupCreator` did not. An **abnormal-state owner** (external / blacklisted / non-normal) goes allowed→denied; **normal owners are unaffected**. Per triage this is accepted — an abnormal-state owner should not be performing the action anyway.

## Tests

Added to `modules/group/api_i18n_regression_test.go`:
- `TestGroupAvatarUpload_AdminSucceeds` — group admin (role=manager, normal/internal) uploads avatar → `200` (fails before fix).
- `TestGroupAvatarUpload_NonManagerForbidden` — regular member → `403` `err.server.group.creator_or_manager_only`, no object uploaded.

Existing `TestGroupAvatarUpload_PostCommitNotifyFailureRespondsOK` continues to cover the owner path.

## Compatibility

Relaxation (403→allowed) is backward compatible. The error ID changes `creator_only`→`creator_or_manager_only`; octo-web#510 already expects this rollout. No new error codes registered — both codes already exist and are widely used, so i18n markers are unchanged. Clients (web/ios/android) already expose the avatar-edit entry to admins, so no client gating change is required.

## Verification

- `go build ./modules/group/...` — pass
- `go vet ./modules/group/` — pass
- `TestGroupNoLegacyResponseError` source guard — pass (no raw/legacy error responses introduced)
- Full package test execution is blocked locally by a pre-existing test-DB migration/seed inconsistency (fresh-DB migration fails at `20220222000001_user_legacy01.sql`, unrelated to this change and reproduced on the unmodified baseline). CI has a correctly seeded schema.

## Rollback

Straight `git revert` — no migration, config, or feature flag involved.
