### PR TITLE
fix(space): apply display-name fallback to member search path #434

### DIFF
--- a/modules/space/api_member_search.go
+++ b/modules/space/api_member_search.go
@@ -69,8 +69,10 @@ func (s *Space) searchMembers(c *wkhttp.Context) {
 	resps := make([]memberSearchResp, 0, len(members))
 	for _, m := range members {
 		resps = append(resps, memberSearchResp{
-			UID:       m.UID,
-			Name:      m.Name,
+			UID: m.UID,
+			// name 兜底链（issue #344 / #434）：空 user.name 回退 real_name，
+			// 再回退稳定占位符，与成员列表口径一致，避免搜索结果展示空名。
+			Name:      m.DisplayName(),
 			Username:  m.Username,
 			Email:     m.Email,
 			Phone:     maskPhone(m.Phone),

--- a/modules/space/db.go
+++ b/modules/space/db.go
@@ -168,15 +168,23 @@ func (d *DB) queryMembers(spaceId string, loginUID string, page uint64, limit ui
 }
 
 func (d *DB) searchMembers(spaceId, keyword string, pageIndex, pageSize int) ([]*memberSearchModel, error) {
+	// name 兜底链（issue #344 / #434）：与 queryMembers 对齐，u.name 为空时回退
+	// user_verification.real_name，映射层（memberSearchModel.DisplayName）再给稳定
+	// 占位符。uv JOIN 显式 COLLATE utf8mb4_general_ci：user_verification 被 compat-repair
+	// 强制转成 general_ci，而 space_member 只继承库默认；非规范 collation 部署下二者
+	// 直接比较会触发 Illegal mix of collations (1267)（见 #482），这里固定 general_ci
+	// 保证搜索路径不引入同一 500 风险。
 	builder := d.session.Select(
 		"sm.*",
 		"IFNULL(u.name,'') as name",
+		"IFNULL(uv.real_name,'') as real_name",
 		"IFNULL(u.username,'') as username",
 		"IFNULL(u.email,'') as email",
 		"IFNULL(u.phone,'') as phone",
 		"CASE WHEN r.robot_id IS NOT NULL AND r.status=1 THEN 1 ELSE 0 END as robot",
 	).From(dbr.I("space_member").As("sm")).
 		LeftJoin(dbr.I("user").As("u"), "u.uid=sm.uid").
+		LeftJoin(dbr.I("user_verification").As("uv"), "uv.user_id=sm.uid COLLATE utf8mb4_general_ci").
 		LeftJoin(dbr.I("robot").As("r"), "r.robot_id=sm.uid").
 		Where("sm.space_id=? AND sm.status=1", spaceId)
 	if keyword != "" {
@@ -195,9 +203,13 @@ func (d *DB) searchMembers(spaceId, keyword string, pageIndex, pageSize int) ([]
 }
 
 func (d *DB) countSearchMembers(spaceId, keyword string) (int64, error) {
+	// list / count 共用 memberSearchActiveWhere（含 uv.real_name），故 count 侧也要挂
+	// 同一 uv JOIN，否则关键字命中 real_name 时两侧口径漂移导致分页错位 / 计数不符。
+	// COLLATE 理由同 searchMembers。
 	builder := d.session.Select("COUNT(*)").
 		From(dbr.I("space_member").As("sm")).
 		LeftJoin(dbr.I("user").As("u"), "u.uid=sm.uid").
+		LeftJoin(dbr.I("user_verification").As("uv"), "uv.user_id=sm.uid COLLATE utf8mb4_general_ci").
 		Where("sm.space_id=? AND sm.status=1", spaceId)
 	if keyword != "" {
 		clause, args := memberSearchActiveWhere(keyword)

--- a/modules/space/db_manager.go
+++ b/modules/space/db_manager.go
@@ -54,7 +54,11 @@ func memberSearchWhere(keyword string) (string, []interface{}) {
 //     （响应仅显示 138****5678），admin 无法通过子串查询逐位探测/重建完整号码。
 //
 // 前端注意：phone 检索只匹配后 4 位，传完整号码不会命中——按手机号查找请用后 4 位。
-var memberSearchActiveColumns = []string{"u.name", "u.username", "u.email", "RIGHT(u.phone,4)", "sm.uid"}
+//
+// uv.real_name（issue #434）：空 user.name 的成员以 real_name 作展示名，故也让其
+// 可按 real_name 检索，保持「可检索粒度 == 可见粒度」；调用方（searchMembers /
+// countSearchMembers）必须已挂 user_verification 的 LEFT JOIN。
+var memberSearchActiveColumns = []string{"u.name", "uv.real_name", "u.username", "u.email", "RIGHT(u.phone,4)", "sm.uid"}
 
 // memberSearchActiveWhere 为空间侧 members/search 组装跨列 OR LIKE 条件。
 // list / count 共用同一条件，避免搜索范围漂移导致分页错位。

--- a/modules/space/db_member_search_fallback_test.go
+++ b/modules/space/db_member_search_fallback_test.go
@@ -1,0 +1,69 @@
+package space
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func findSearchModel(list []*memberSearchModel, uid string) (*memberSearchModel, bool) {
+	for _, m := range list {
+		if m.UID == uid {
+			return m, true
+		}
+	}
+	return nil, false
+}
+
+// Test_Issue434_SearchMemberNameFallback 验证 issue #434（#344 的 follow-up）：
+// 成员搜索路径（searchMembers / countSearchMembers）此前未做 #420 给成员列表
+// 加的 name 兜底——空 user.name 的成员在搜索结果里展示空名，且无法按
+// user_verification.real_name 检索。本测试锁定与成员列表一致的行为：
+//  1. name 空 + real_name 有 → 搜索结果 DisplayName() 回退到 real_name；
+//  2. name 空 + real_name 空 → 稳定占位符（非空、不含隐私字段）；
+//  3. 可按 real_name 检索到 blank-name 成员，且 count 与 list 口径一致。
+func Test_Issue434_SearchMemberNameFallback(t *testing.T) {
+	_, _, err := setup(t)
+	assert.NoError(t, err)
+
+	const spaceId = "sp-search-namefallback"
+	seedMemberSearchSpace(t, spaceId, testutil.UID)
+
+	// 1) name 空 + real_name 有
+	const uidRealName = "u-search-realname"
+	seedFallbackUser(t, uidRealName, "")
+	seedFallbackVerification(t, uidRealName, "Zhang Wei")
+	seedMemberSearchMember(t, spaceId, uidRealName, 0, 1)
+
+	// 2) name 空 + real_name 空（无 verification 行 → LEFT JOIN 给空串）
+	const uidPlaceholder = "u-search-placeholder"
+	seedFallbackUser(t, uidPlaceholder, "")
+	seedMemberSearchMember(t, spaceId, uidPlaceholder, 0, 1)
+
+	// 空 keyword：全部成员，real_name 兜底生效
+	all, err := testSpaceDB.searchMembers(spaceId, "", 1, 100)
+	assert.NoError(t, err)
+	if m, ok := findSearchModel(all, uidRealName); assert.True(t, ok, "real_name member missing in search") {
+		assert.Equal(t, "", m.Name, "user.name should be empty")
+		assert.Equal(t, "Zhang Wei", m.RealName)
+		assert.Equal(t, "Zhang Wei", m.DisplayName(), "empty name must fall back to real_name in search")
+	}
+	if m, ok := findSearchModel(all, uidPlaceholder); assert.True(t, ok, "placeholder member missing in search") {
+		assert.Equal(t, "", m.Name)
+		assert.Equal(t, "", m.RealName)
+		assert.Equal(t, memberDisplayNamePlaceholderPrefix+uidPlaceholder, m.DisplayName(),
+			"empty name+real_name must fall back to stable placeholder")
+	}
+
+	// 按 real_name 检索：应命中 blank-name 成员（此前搜不到 → 本 issue 的核心缺陷）
+	byReal, err := testSpaceDB.searchMembers(spaceId, "Zhang", 1, 100)
+	assert.NoError(t, err)
+	_, ok := findSearchModel(byReal, uidRealName)
+	assert.True(t, ok, "member must be searchable by real_name")
+
+	// count 与 list 口径一致（同一 keyword 两侧都要含 uv JOIN，否则分页错位）
+	cnt, err := testSpaceDB.countSearchMembers(spaceId, "Zhang")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), cnt, "count must match real_name search list")
+}

--- a/modules/space/model.go
+++ b/modules/space/model.go
@@ -44,10 +44,17 @@ type MemberModel struct {
 type memberSearchModel struct {
 	MemberModel
 	Name     string
+	RealName string // 实名兜底（user_verification.real_name），仅作 name 为空时的回退源
 	Username string
 	Email    string
 	Phone    string
 	Robot    int
+}
+
+// DisplayName 返回搜索结果里成员的展示名，复用与成员列表（MemberDetailModel）
+// 相同的兜底链（issue #344 / #434），避免两条路径对空名成员的展示口径漂移。
+func (m *memberSearchModel) DisplayName() string {
+	return resolveMemberDisplayName(m.Name, m.RealName, m.UID)
 }
 
 // InvitationModel 邀请表模型
@@ -265,6 +272,24 @@ type MemberDetailModel struct {
 // 用它兜底不泄露新信息——但禁止用 short_no / username 兜底（privacy-gated）。
 const memberDisplayNamePlaceholderPrefix = "User "
 
+// resolveMemberDisplayName 是成员展示名兜底链的单一实现（issue #344 / #434）：
+//  1. name 非空 → 原样返回；
+//  2. 否则 realName 非空 → 返回实名；
+//  3. 都空 → 返回稳定占位符 "User <uid>"。
+//
+// 任何分支都不会返回空串，也不会暴露 short_no / username（privacy-gated）。
+// 成员列表（MemberDetailModel）与成员搜索（memberSearchModel）共用它，避免两条
+// 路径的兜底口径与占位格式漂移。
+func resolveMemberDisplayName(name, realName, uid string) string {
+	if name != "" {
+		return name
+	}
+	if realName != "" {
+		return realName
+	}
+	return memberDisplayNamePlaceholderPrefix + uid
+}
+
 // DisplayName 返回成员的展示名，按 issue #344 的兜底链解析：
 //  1. user.name 非空 → 原样返回；
 //  2. 否则 user_verification.real_name 非空 → 返回实名；
@@ -272,13 +297,7 @@ const memberDisplayNamePlaceholderPrefix = "User "
 //
 // 任何分支都不会返回空串，也不会暴露 short_no / username。
 func (m *MemberDetailModel) DisplayName() string {
-	if m.Name != "" {
-		return m.Name
-	}
-	if m.RealName != "" {
-		return m.RealName
-	}
-	return memberDisplayNamePlaceholderPrefix + m.UID
+	return resolveMemberDisplayName(m.Name, m.RealName, m.UID)
 }
 
 // SpaceDetailModel 带成员数和角色的空间详情（MaxUsers 从 SpaceModel 继承）


### PR DESCRIPTION
<!-- multica:bug-fix-report v1 -->

# Bug Fix — Issue #434 — PR (draft)

## 1. Executive Summary
- **Bug**: The paginated member **search** path never got #344's display-name fallback — blank-`name` members render empty in search results and cannot be found by their `real_name`.
- **Root Cause**: `modules/space/db.go:searchMembers`/`countSearchMembers` join only `user` (not `user_verification`) and select bare `IFNULL(u.name,'')`; the fallback #420 added lives solely in `queryMembers`.
- **Fix Approach**: localized (space module only)
- **Risk Level**: Low
- **PR**: draft — awaiting review squad

## 2. Issue Context
- Title: Follow-up: display-name fallback remaining paths + user_verification JOIN collation risk (#344)
- Reporter: lml2468 (GH)
- bug-verified by: self (reproduced at DB layer via RED→GREEN regression test)
- Affected: `GET /v1/space/:space_id/members/search` on any deployment with blank-`name` members
- **Scope note**: This PR addresses only the **P1 — search path has no fallback** item. The 🔴 collation-JOIN risk was split into **#482** and is out of scope here; P2 (avatar / other `IFNULL(u.name,'')` endpoints) and P3 (shared `pkg/displayname`) remain follow-ups (see §5 boundary).

## 3. Reproduction
**Environment**: Go 1.26, MySQL 8.0 (`test` DB, `utf8mb4_general_ci`), `modules/space` package tests.
**Steps**:
1. Seed a `space_member` whose `user.name` is empty but has `user_verification.real_name = "Zhang Wei"`.
2. Call `searchMembers(spaceId, "", …)` → result item shows empty display name.
3. Call `searchMembers(spaceId, "Zhang", …)` → member is **not** returned.
**Expected**: display name falls back to `real_name` (then to a stable `User <uid>` placeholder); member is searchable by `real_name`.
**Actual**: empty name; not searchable by `real_name`.
**Evidence** (`Test_Issue434_SearchMemberNameFallback`, before fix):
```
Error: Not equal — "" != "Zhang Wei"   (empty name must fall back to real_name in search)
Error: Should be true                  (member must be searchable by real_name)
--- FAIL: Test_Issue434_SearchMemberNameFallback
```

## 4. RCA
**Method**: 5 Whys
**Analysis**: Search shows empty names → because response maps bare `m.Name` → because `searchMembers` selects only `IFNULL(u.name,'')` and never joins `user_verification` → because #420 (issue #344 fix) only touched the member **list** (`queryMembers` + `MemberDetailModel.DisplayName()`), not the search path added later in #389 → the two read paths diverged.
**Root cause**: `modules/space/db.go:searchMembers`/`countSearchMembers` (+ `api_member_search.go` mapping) omit the `user_verification` fallback that `queryMembers` has.

## 5. Fix Description
**Files changed**:
- `modules/space/db.go` — `searchMembers` + `countSearchMembers`: add `LEFT JOIN user_verification`, select `real_name`.
- `modules/space/db_manager.go` — `memberSearchActiveColumns`: add `uv.real_name` (searchable by real name).
- `modules/space/model.go` — add `memberSearchModel.RealName` + `DisplayName()`; extract shared `resolveMemberDisplayName()`; `MemberDetailModel.DisplayName()` now delegates to it.
- `modules/space/api_member_search.go` — response maps `m.DisplayName()` instead of `m.Name`.
- `modules/space/db_member_search_fallback_test.go` — new regression test.
**Change summary**: The search path now resolves display names through the same fallback chain as the member list (`name → real_name → "User <uid>"`) and lets admins find members by `real_name`. List and count share one JOIN so keyword hits on `real_name` don't drift pagination. The new `user_verification` JOIN pins `COLLATE utf8mb4_general_ci` on the ON clause so the search path does **not** re-introduce the `space_member`↔`user_verification` collation-mix 500 that #482 tracks for `queryMembers` on non-canonical DBs.
**Does NOT change** (scope boundary): `queryMembers`'s existing raw JOIN (owned by #482); avatar rendering / other `IFNULL(u.name,'')` endpoints (P2); no shared `pkg/displayname` package (P3); no privacy widening — `short_no`/`username` are still never used as a fallback, and `phone` search remains last-4-only.

## 6. Regression Tests
| Test | File | Purpose | Before | After |
|---|---|---|---|---|
| Test_Issue434_SearchMemberNameFallback | `db_member_search_fallback_test.go` | search shows real_name fallback + placeholder; searchable by real_name; count==list | FAIL | PASS |
| TestQueryMembersNameFallback | `db_member_name_fallback_test.go` | existing list fallback unaffected by helper refactor | PASS | PASS |
| TestMemberDisplayNamePure | `db_member_name_fallback_test.go` | pure fallback precedence | PASS | PASS |

## 7. CI Status
- Build: `go build ./modules/space/` pass
- Vet: `go vet ./modules/space/` pass
- gofmt: clean
- Unit (regression, DB layer): RED→GREEN verified in a clean DB window — the three tests above PASS with the fix, and `Test_Issue434_*` FAILs without it.
- Note: the sandbox's shared MySQL was intermittently reset/offline (another workspace runner races the shared `test` DB), so the full HTTP-level search suite could not be run to completion locally. CI drops+recreates `test` per package (`utf8mb4_general_ci`) and is the authoritative gate; the change is behavior-preserving for populated names (`DisplayName()` returns `m.Name` unchanged when non-empty).
- Coverage delta: N/A (not measured — DB env unavailable)

## 8. Deployment Notes
- Migration required?: no
- Config change?: no
- Feature flag: no
- Compatibility: backward-compatible. `memberSearchResp.name` now shows a non-empty display name for blank-`name` members (previously empty); response shape unchanged. Members become findable by `real_name` on the admin-scoped (role ≥ admin) search endpoint.

## 9. Rollback Plan
**Pattern**: revert
**Steps**: 1. `git revert` the two commits on this branch. 2. Redeploy. No data/migration changes to unwind.
**Detection** (trigger rollback): spike in 5xx on `GET /v1/space/:space_id/members/search`, or `Illegal mix of collations (1267)` in logs for that endpoint.

---
_Generated by backend-engineer · awaiting review squad (qa+security+code)_
