### PR TITLE
fix(group): allow group admins to update group avatar, aligning with group name/settings

### DIFF
--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -540,7 +540,7 @@ func (g *Group) avatarGet(c *wkhttp.Context) {
 		return
 	}
 
-	// 群主已上传自定义头像：重定向到版本化对象存储（沿用历史逻辑）。
+	// 已上传自定义头像（群主或管理员上传）：重定向到版本化对象存储（沿用历史逻辑）。
 	if groupInfo.IsUploadAvatar == 1 {
 		path := g.ctx.GetConfig().GetGroupAvatarFilePath(groupNo, groupInfo.AvatarVersion)
 		downloadUrl, err := g.fileService.DownloadURL(path, "")
@@ -718,14 +718,17 @@ func (g *Group) avatarUpload(c *wkhttp.Context) {
 	}
 	defer file.Close()
 
-	isCreator, err := g.db.QueryIsGroupCreator(groupNo, loginUID)
+	// 群主与群管理员均可修改群头像，与改群名 / 群设置 / 群公告(GROUP.md)的权限档位
+	// 对齐(#520)。注意 QueryIsGroupManagerOrCreator 额外要求 is_external=0 且
+	// status=normal，故异常状态(外部/非正常)的群主会被拒——这是有意的(异常状态本不应操作)。
+	isManagerOrCreator, err := g.db.QueryIsGroupManagerOrCreator(groupNo, loginUID)
 	if err != nil {
-		g.Error("查询群创建者失败！", zap.Error(err))
+		g.Error("查询群管理员或创建者失败！", zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
 		return
 	}
-	if !isCreator {
-		httperr.ResponseErrorL(c, errcode.ErrGroupCreatorOnly, nil, nil)
+	if !isManagerOrCreator {
+		httperr.ResponseErrorL(c, errcode.ErrGroupCreatorOrManagerOnly, nil, nil)
 		return
 	}
 
@@ -1163,7 +1166,7 @@ func (g *Group) groupUpdate(c *wkhttp.Context) {
 		return
 	}
 	if !isManager {
-		httperr.ResponseErrorL(c, errcode.ErrGroupManagerOnly, nil, nil)
+		httperr.ResponseErrorL(c, errcode.ErrGroupCreatorOrManagerOnly, nil, nil)
 		return
 	}
 
@@ -2872,7 +2875,7 @@ func (g *Group) memberUpdate(c *wkhttp.Context) {
 	}
 	if !isManager && loginUID != memberUID {
 		g.Error("只有管理员才能修改其他人的成员信息！")
-		httperr.ResponseErrorL(c, errcode.ErrGroupManagerOnly, nil, nil)
+		httperr.ResponseErrorL(c, errcode.ErrGroupCreatorOrManagerOnly, nil, nil)
 		return
 	}
 	memberModel, err := g.db.QueryMemberWithUID(memberUID, groupNo)
@@ -3511,7 +3514,7 @@ func (g *Group) blacklist(c *wkhttp.Context) {
 		return
 	}
 	if !isManager {
-		httperr.ResponseErrorL(c, errcode.ErrGroupManagerOnly, nil, nil)
+		httperr.ResponseErrorL(c, errcode.ErrGroupCreatorOrManagerOnly, nil, nil)
 		return
 	}
 	// #354 · Bot 跟人走：拉黑/解除拉黑级联到目标用户名下在群的 bot

--- a/modules/group/avatar_upload_permission_test.go
+++ b/modules/group/avatar_upload_permission_test.go
@@ -1,0 +1,93 @@
+package group
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGroupAvatarUpload_ManagerAllowed_CommonDenied covers the #520 relaxation:
+// the group owner AND an admin can upload the group avatar, while a plain
+// member is still rejected with creator_or_manager_only. Uses the mock file
+// service (no real object storage); the permission gate runs before the upload.
+func TestGroupAvatarUpload_ManagerAllowed_CommonDenied(t *testing.T) {
+	_, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	f := New(ctx)
+	mockFS := &mockAvatarUploadFileService{}
+	f.fileService = mockFS
+
+	const (
+		groupNo      = "g-avatar-perm-520"
+		managerUID   = "20000"
+		managerToken = "token-manager-20000"
+		commonUID    = "30000"
+		commonToken  = "token-common-30000"
+	)
+
+	// Register manager/common token→uid (creator reuses testutil.Token/UID).
+	cfg := ctx.GetConfig()
+	require.NoError(t, ctx.Cache().Set(cfg.Cache.TokenCachePrefix+managerToken, managerUID+"@test"))
+	require.NoError(t, ctx.Cache().Set(cfg.Cache.TokenCachePrefix+commonToken, commonUID+"@test"))
+
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: testutil.UID, Name: "owner", ShortNo: "u_owner_520"}))
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: managerUID, Name: "manager", ShortNo: "u_mgr_520"}))
+
+	// Group with three roles: creator / manager / common.
+	require.NoError(t, f.db.Insert(&Model{GroupNo: groupNo, Name: "权限群", Creator: testutil.UID, Status: GroupStatusNormal, Version: 1}))
+	require.NoError(t, f.db.InsertMember(&MemberModel{GroupNo: groupNo, UID: testutil.UID, Role: MemberRoleCreator, Status: 1, Version: 1, Vercode: "c@1"}))
+	require.NoError(t, f.db.InsertMember(&MemberModel{GroupNo: groupNo, UID: managerUID, Role: MemberRoleManager, Status: 1, Version: 1, Vercode: "m@1"}))
+	require.NoError(t, f.db.InsertMember(&MemberModel{GroupNo: groupNo, UID: commonUID, Role: MemberRoleCommon, Status: 1, Version: 1, Vercode: "n@1"}))
+
+	r := wkhttp.New()
+	r.POST("/v1/groups/:group_no/avatar", ctx.AuthMiddleware(r), f.avatarUpload)
+
+	upload := func(t *testing.T, token string) *httptest.ResponseRecorder {
+		t.Helper()
+		var buf bytes.Buffer
+		mw := multipart.NewWriter(&buf)
+		fw, err := mw.CreateFormFile("file", "avatar.png")
+		require.NoError(t, err)
+		_, err = fw.Write([]byte("png"))
+		require.NoError(t, err)
+		require.NoError(t, mw.Close())
+
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("POST", "/v1/groups/"+groupNo+"/avatar", &buf)
+		require.NoError(t, err)
+		req.Header.Set("token", token)
+		req.Header.Set("Content-Type", mw.FormDataContentType())
+		r.ServeHTTP(w, req)
+		return w
+	}
+
+	// Owner: still allowed (unchanged behavior).
+	require.Equal(t, http.StatusOK, upload(t, testutil.Token).Code, "owner should upload")
+
+	// Admin: now allowed (#520 relaxation, aligned with group name/settings).
+	wMgr := upload(t, managerToken)
+	require.Equal(t, http.StatusOK, wMgr.Code, "group admin should be allowed to upload, body=%s", wMgr.Body.String())
+	require.Contains(t, wMgr.Body.String(), `"status":200`)
+
+	// Plain member: still rejected. The test-env wire body carries only the
+	// localized message + status (no error.code field), so assert on the message.
+	// "owner or an administrator" is unique to ErrGroupCreatorOrManagerOnly and
+	// distinguishes it from the old creator_only ("Only the group owner can…"),
+	// proving the member is rejected by the new (post-relaxation) code.
+	// Reset the mock first so the empty-uploadedPath assertion proves the denial
+	// happens BEFORE storage (owner/manager successes above already set it).
+	mockFS.uploadedPath = ""
+	wCommon := upload(t, commonToken)
+	require.Contains(t, wCommon.Body.String(), "owner or an administrator",
+		"plain member should be rejected with creator_or_manager_only, body=%s", wCommon.Body.String())
+	require.Contains(t, wCommon.Body.String(), `"status":400`, "denied member should get wire 400")
+	require.Empty(t, mockFS.uploadedPath, "permission denial must occur before the upload reaches object storage")
+}


### PR DESCRIPTION
## Problem
Group **admins** were denied (403 `creator_only`) when uploading a group avatar, while the **owner** succeeded — reported via Mininglamp-OSS/octo-web#510, reproduced on Web/iOS/Android. Avatar upload was the only group-profile write still gated owner-only; group name / settings / notice (GROUP.md) are all already manager-or-creator.

## Changes
- **`avatarUpload`**: gate on `QueryIsGroupManagerOrCreator` / `ErrGroupCreatorOrManagerOnly` instead of `QueryIsGroupCreator` / `ErrGroupCreatorOnly`, aligning group-avatar upload with group name/settings/notice.
- **Fix a pre-existing errcode mismatch** in `groupUpdate` / `memberUpdate` / `blacklist`: each gates on manager-or-creator but returned `ErrGroupManagerOnly` ("Only a group administrator…"); now returns `ErrGroupCreatorOrManagerOnly` (so a rejected **owner** no longer sees the self-contradictory "admin only" message).
- Neutralize a stale "群主 uploaded" comment on the avatar read path.
- Add `TestGroupAvatarUpload_ManagerAllowed_CommonDenied`.

## Known behavior boundary (intentional)
`QueryIsGroupManagerOrCreator` additionally requires `is_external=0 AND status=normal`, whereas the old `QueryIsGroupCreator` did not. So an **abnormal-state owner** (external / non-normal) is now denied. **Normal owners are unaffected** — an abnormal-state owner should not be performing this action anyway.

## Tests
`TestGroupAvatarUpload_ManagerAllowed_CommonDenied` — real `avatarUpload` handler + real AuthMiddleware + real MySQL role query + multipart HTTP; asserts:
- owner uploads → 200
- **admin uploads → 200** (the fix)
- plain member → rejected with `creator_or_manager_only`, and the mock storage's `uploadedPath` stays empty (denial happens **before** storage)

Full `modules/group` suite passes (MySQL + Redis + WuKongIM); no regressions. Error-code change verified: no existing test asserted the old `manager_only` code.

## Verification (real dev server, cross-process curl)
Reproduced before, confirmed after — same steps (admin Bob uploads to a group owned by Alice):

| | before | after |
| --- | --- | --- |
| admin (non-owner) upload | `403 err.server.group.creator_only` | **`{status:200}`** |
| owner upload (control) | 200 | 200 |

## Compatibility
Relaxation (403→allowed) is backward compatible; the error ID changes `creator_only`→`creator_or_manager_only`. Clients (web/ios/android) already show the avatar-edit entry to admins, so they work automatically once this ships (octo-web#510 tracks the client side).

Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)