### PR TITLE
fix(message): keep system-bot DM history visible under X-Space-ID

### DIFF
--- a/.octospec/journal/shared/system-bot-dm-history.md
+++ b/.octospec/journal/shared/system-bot-dm-history.md
@@ -1,0 +1,59 @@
+---
+type: Journal
+title: "system-bot-dm-history: system-bot DM history must not be Space-filtered"
+description: Exempt system bots from filterPersonMessagesBySpace so botfather/fileHelper/u_10000 history is not returned empty under an X-Space-ID
+tags: [space, isolation, message, bot, systembot]
+timestamp: 2026-07-03T00:00:00Z
+---
+
+# system-bot-dm-history
+
+Branch `fix/system-bot-dm-history` (based on latest `origin/main`, which already
+carries #484 / PR #519).
+
+## What was done
+
+`filterPersonMessagesBySpace` (`modules/message/space_filter.go`) now **early-returns
+the full message list for system bots** (`spacepkg.IsSystemBot(channelID)`), before
+the per-message Space switch. System bots (`botfather` / `u_10000` / `fileHelper` /
+`notification`) are Space-independent and must always be visible — the conversation
+list already forces them into every Space via `EnsureSystemBotsPresent`, so their DM
+history must not be Space-filtered either. The old rule 4
+(`payload.space_id == "" && isSysBot → drop`) was silently emptying botfather history
+whenever the sync request carried an `X-Space-ID`. With the early return, the
+`isSysBot` variable and its switch cases are removed; the remaining switch handles
+only regular DMs (rules 1–4 renumbered, #484 symptom-1 semantics unchanged).
+
+## Root cause / attribution
+
+- Bug origin: YUJ-219-A / #1283 (`e39b69f`, 2026-05-04) added the system-bot
+  message-drop branch. **Not** introduced by #484 (PR #519) — verified by diff:
+  #484 only changed the `!isSysBot` regular-DM branch; the system-bot path is
+  byte-identical before/after #484, and the filter call + its `X-Space-ID` gate in
+  `syncChannelMessage` (`api.go`) pre-date #484.
+- Read-time filter only: the endpoint filters the sync **response**, never writes
+  or deletes. WuKongIM storage is intact; the fix restores history immediately
+  (no backfill). Worst case was a client that wipe-replaced its local cache on the
+  empty response — self-heals on the next sync.
+
+## Verification
+
+- Reproduced first (pure function): botfather untagged history 0/2 under a Space,
+  2/2 without X-Space-ID; a regular peer 2/2 in default (isolates rule 4 as cause).
+- Flipped 3 existing YUJ-219-A tests that locked the drop behavior
+  (`_SystemBot`, `_PayloadSpaceIDWrongType` fileHelper case, `_SystemBotListCoverage`)
+  to assert full-visibility; `_SystemBotListCoverage` now also covers the
+  **non-default** Space (the exact production repro).
+- #484 guard kept: `_UntaggedDroppedInNonDefaultSpace` / `_OrdinaryDMLegacyCompat`
+  still green (regular untagged DM stays default-Space-only).
+- `go test -race -shuffle=on ./modules/message/ ./pkg/space/` green; `go build`,
+  `go vet` green.
+
+## Learnings
+
+- Two Space contracts must stay in lockstep: conversation-list visibility
+  (`EnsureSystemBotsPresent` / `decideConvKeepInSpace`) and message-history
+  visibility (`filterPersonMessagesBySpace`). A system bot shown in the list but
+  empty on open is the smell of the two diverging.
+- Follow-up: confirm whether the client `filterSystemBotMessages` (Android/iOS)
+  also drops system-bot history; if so the server fix alone won't surface it.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,20 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-03
+
+- **Fix** — Task `system-bot-dm-history`: system-bot DM history was returned empty
+  from `/v1/message/channel/sync` whenever the request carried an `X-Space-ID`.
+  `filterPersonMessagesBySpace` now early-returns the full list for system bots
+  (`botfather`/`u_10000`/`fileHelper`/`notification`) — they are Space-independent
+  and already forced into every Space's conversation list by `EnsureSystemBotsPresent`,
+  so their history must not be Space-filtered. Root cause is YUJ-219-A / #1283
+  (`e39b69f`), **not** #484 (verified by diff: #484 only touched the regular-DM
+  branch). Read-time filter only — no data loss, no backfill. Flipped 3 YUJ-219-A
+  tests that locked the drop behavior; added non-default-Space coverage. Brief +
+  journal under `.octospec/tasks/system-bot-dm-history/` and
+  `.octospec/journal/shared/system-bot-dm-history.md`.
+
 ## 2026-07-02
 
 - **Change** — Task `conv-space-catchall-484` (issue #484 follow-up): closed the

--- a/.octospec/tasks/system-bot-dm-history/brief.md
+++ b/.octospec/tasks/system-bot-dm-history/brief.md
@@ -1,0 +1,65 @@
+---
+type: Task
+title: "Task: system-bot-dm-history"
+description: System-bot DM history must not be Space-filtered — botfather/fileHelper/u_10000 returned empty from /message/channel/sync under an X-Space-ID.
+tags: [space, isolation, message, bot, systembot]
+timestamp: 2026-07-03T00:00:00Z
+# --- octospec extension fields ---
+slug: system-bot-dm-history
+upstream: octo-server (regression of YUJ-219-A / #1283)
+source: self
+---
+
+# Task: system-bot-dm-history
+
+## Goal
+
+Stop `filterPersonMessagesBySpace` from dropping a **system bot**'s DM history.
+`POST /v1/message/channel/sync` for a system bot (`botfather` / `u_10000` /
+`fileHelper` / `notification`) returns `messages: []` whenever the request
+carries a validated `X-Space-ID`, because the bot's messages are Space-agnostic
+(`payload.space_id == ""`) and the filter's system-bot branch drops all untagged
+system-bot messages. System bots are Space-**independent** and must always be
+visible, so their history must never be Space-filtered.
+
+## Background
+
+`filterPersonMessagesBySpace` (YUJ-219-A / #1283, commit `e39b69f`, 2026-05-04)
+added message-level Space filtering to close a cross-Space DM-history leak. Its
+rule 4 (`payload.space_id == "" && isSystemBot → drop`) hides untagged system-bot
+history — but this directly contradicts the invariant in `pkg/space/query.go`
+("系统 Bot … 必须始终对客户端可见") and the conversation-list contract
+(`EnsureSystemBotsPresent` forces system bots into every Space's list). Net effect:
+the conversation list shows botfather, but opening it returns empty history.
+
+This is **not** introduced by #484 (PR #519): that PR only changed the
+`!isSysBot` (regular-DM) branch (untagged history → default-Space-only); the
+system-bot branch is byte-identical before and after #484. Read-time filter only
+— no stored data is deleted; the fix restores history immediately, no backfill.
+
+## Load-bearing list
+
+- `modules/message/space_filter.go` `filterPersonMessagesBySpace` — message-level
+  Space filter for the DM history endpoint (`/v1/message/channel/sync`).
+- Invariant `pkg/space/query.go` `SystemBots` / `IsSystemBot` — system bots are
+  Space-independent and always visible.
+- Conversation-list contract `EnsureSystemBotsPresent` / `decideConvKeepInSpace`
+  (`SystemBots[channelID] → keep`) — must stay consistent with history visibility.
+- #484 symptom-1 rule (regular untagged DM → default-Space-only) — must NOT
+  regress.
+
+## Out of scope
+
+- Client-side `filterSystemBotMessages` (Android/iOS) — if the clients also
+  Space-filter system-bot history, they need a matching change; tracked separately.
+- The regular-DM (`!isSystemBot`) rules — unchanged.
+- Any storage / migration / backfill (read-time filter only).
+
+## Acceptance
+
+- `filterPersonMessagesBySpace(msgs, "<systembot>", spaceID, defaultSpaceID)`
+  returns the **full** list unchanged for every system bot, in both default and
+  non-default Spaces, incl. untagged messages.
+- #484 guard: a regular peer's untagged DM is still kept only in the default
+  Space and dropped in a non-default Space.
+- `go test -race ./modules/message/ ./pkg/space/` green; CI green.

--- a/modules/message/space_filter.go
+++ b/modules/message/space_filter.go
@@ -512,14 +512,17 @@ func newSystemBotPlaceholder(uid string) *SyncUserConversationResp {
 // 本函数仅针对 Person (DM) 路径：
 //   - GROUP channel_id 本身做 Space 隔离（不同 Space 的群 channel_id 不同），
 //     对历史消息再过滤反而会误杀老群，因此 GROUP/COMMUNITY_TOPIC 路径不走这里。
-//   - 规则（issue #484 后；与三端 SpaceFilter 口径对齐）：
-//     1) payload.space_id == spaceID                         → 保留（精确匹配）
-//     2) payload.space_id == "" && !isSystemBot && 默认Space  → 保留（无标签 DM
-//     历史只在用户默认 Space 向前兼容，避免出现在每个 Space —— 症状1）
-//     3) payload.space_id == "" && !isSystemBot && 非默认Space→ 丢弃（不再 fail-open）
-//     4) payload.space_id == "" &&  isSystemBot               → 丢弃（SystemBot 无
-//     space 标签的老消息默认隐藏，避免 fileHelper/u_10000 老消息跨 Space 泄露）
-//     5) payload.space_id != "" && != spaceID                → 丢弃（跨 Space 污染）
+//   - 系统 Bot（botfather/u_10000/fileHelper/notification）豁免：与 Space 无关，
+//     必须始终对客户端可见（pkg/space query.go 的不变量；会话列表侧由
+//     EnsureSystemBotsPresent 保证其在每个 Space 出现）。系统 Bot 的 DM 是全局
+//     单会话，历史同样不按 Space 过滤 —— 否则会话列表里有 botfather、点进去
+//     /message/channel/sync 却返回空。全局单会话不存在"跨 Space 泄露"。
+//   - 普通 DM 规则（issue #484 后；与三端 SpaceFilter 口径对齐）：
+//     1) payload.space_id == spaceID          → 保留（精确匹配）
+//     2) payload.space_id == "" && 默认Space   → 保留（无标签 DM 历史只在用户默认
+//     Space 向前兼容，避免出现在每个 Space —— 症状1）
+//     3) payload.space_id == "" && 非默认Space → 丢弃（不再 fail-open）
+//     4) payload.space_id != "" && != spaceID  → 丢弃（跨 Space 污染）
 //
 // 调用方需保证 spaceID != ""（空串视为未启用 Space 过滤，直接返回原列表），
 // 传入 defaultSpaceID（用户默认 Space，决定规则 2/3），并只对 ChannelTypePerson 调用。
@@ -527,7 +530,13 @@ func filterPersonMessagesBySpace(msgs []*MsgSyncResp, channelID, spaceID, defaul
 	if spaceID == "" || len(msgs) == 0 {
 		return msgs
 	}
-	isSysBot := spacepkg.IsSystemBot(channelID)
+	// 系统 Bot 与 Space 无关，历史全量可见（见函数注释）。早返回，避免其无
+	// space_id 的消息被下方规则一刀切隐藏 —— 修复「带 X-Space-ID 时 botfather /
+	// fileHelper / u_10000 历史返回空」。与 EnsureSystemBotsPresent / query.go 的
+	// 「系统 Bot 必须始终可见」不变量对齐。
+	if spacepkg.IsSystemBot(channelID) {
+		return msgs
+	}
 	filtered := make([]*MsgSyncResp, 0, len(msgs))
 	for _, m := range msgs {
 		if m == nil {
@@ -538,21 +547,16 @@ func filterPersonMessagesBySpace(msgs []*MsgSyncResp, channelID, spaceID, defaul
 		case msid == spaceID:
 			// 精确匹配当前 Space → 保留
 			filtered = append(filtered, m)
-		case msid == "" && !isSysBot && spaceID == defaultSpaceID:
+		case msid == "" && spaceID == defaultSpaceID:
 			// issue #484：无 space_id 的普通 DM 消息（发送方未带 X-Space-ID、
 			// Space 化之前的老消息、转发/名片）只在用户默认 Space 向前兼容保留，
 			// 不再出现在每个 Space —— 修复症状1（跨 Space 历史泄漏）。
 			filtered = append(filtered, m)
-		case msid == "" && !isSysBot:
+		case msid == "":
 			// 非默认 Space：无标签 DM 消息不再 fail-open 放行，丢弃。
 			continue
-		case msid == "" && isSysBot:
-			// 系统 Bot 的无 space_id 历史消息一律隐藏。对齐 Android
-			// filterSystemBotMessages 和 iOS filterMessagesBySpace，避免
-			// 老的 botfather/fileHelper/u_10000 对话全量跨 Space 暴露。
-			continue
-		case msid != spaceID:
-			// 明确跨 Space，丢弃。
+		default:
+			// 明确跨 Space（msid != "" 且 != spaceID），丢弃。
 			continue
 		}
 	}

--- a/modules/message/space_filter_test.go
+++ b/modules/message/space_filter_test.go
@@ -611,22 +611,18 @@ func newMsgWithSpaceID(messageID int64, spaceID string) *MsgSyncResp {
 }
 
 func TestFilterPersonMessagesBySpace_SystemBot(t *testing.T) {
-	// channelID = "botfather"（SystemBot）
-	// 当前 Space = spaceA，按规则：
-	//   - spaceA 消息保留
-	//   - spaceB 消息丢弃
-	//   - 无 space_id 消息丢弃（SystemBot 老消息默认隐藏，对齐 Android filterSystemBotMessages）
+	// channelID = "botfather"（SystemBot）与 Space 无关，历史全量可见，不做 Space
+	// 过滤 —— 系统 Bot 是全局单会话，EnsureSystemBotsPresent 已保证其在每个 Space
+	// 的会话列表出现，历史同理。修复「带 X-Space-ID 时 botfather 历史返回空」。
 	msgs := []*MsgSyncResp{
 		newMsgWithSpaceID(1, "spaceA"),
 		newMsgWithSpaceID(2, "spaceB"),
-		newMsgWithSpaceID(3, ""), // 老 SystemBot 消息
+		newMsgWithSpaceID(3, ""), // 无 space_id 的系统 Bot 消息（此前 bug 会被丢弃）
 		newMsgWithSpaceID(4, "spaceA"),
 	}
 
 	got := filterPersonMessagesBySpace(msgs, "botfather", "spaceA", "spaceA")
-	assert.Len(t, got, 2)
-	assert.Equal(t, int64(1), got[0].MessageID)
-	assert.Equal(t, int64(4), got[1].MessageID)
+	assert.Equal(t, msgs, got, "系统 Bot 历史不按 Space 过滤，原样全部返回")
 }
 
 func TestFilterPersonMessagesBySpace_OrdinaryDMLegacyCompat(t *testing.T) {
@@ -728,24 +724,29 @@ func TestFilterPersonMessagesBySpace_NilMessagesSkipped(t *testing.T) {
 
 func TestFilterPersonMessagesBySpace_PayloadSpaceIDWrongType(t *testing.T) {
 	// payload.space_id 不是字符串（例如异常数据）→ 视为空值，按"无 space_id"
-	// 分支处理（普通 DM 保留 / SystemBot 丢弃）。
+	// 分支处理（普通 DM 在默认 Space 保留）。
 	msgA := &MsgSyncResp{MessageID: 60, Payload: map[string]interface{}{"space_id": 123}}
 
-	// 普通 DM：保留
+	// 普通 DM（默认 Space）：保留
 	got := filterPersonMessagesBySpace([]*MsgSyncResp{msgA}, "peer_uid", "spaceA", "spaceA")
 	assert.Len(t, got, 1)
 
-	// SystemBot：丢弃
+	// SystemBot：与 Space 无关，历史全量可见（不因 space_id 异常类型被丢）
 	got = filterPersonMessagesBySpace([]*MsgSyncResp{msgA}, "fileHelper", "spaceA", "spaceA")
-	assert.Len(t, got, 0)
+	assert.Len(t, got, 1, "系统 Bot 消息豁免 Space 过滤")
 }
 
 func TestFilterPersonMessagesBySpace_SystemBotListCoverage(t *testing.T) {
-	// 保证三个已知系统 Bot 都走 SystemBot 分支（老消息被丢弃）。
+	// 所有已知系统 Bot 都豁免 Space 过滤：无 space_id 的历史消息在任意 Space（默认
+	// 或非默认）都保留 —— 修复「带 X-Space-ID 时 botfather/fileHelper/u_10000 历史
+	// 返回空」。非默认 Space（filterSpaceID != defaultSpaceID）正是线上复现场景。
 	msgs := []*MsgSyncResp{newMsgWithSpaceID(70, "")}
 	for _, bot := range spacepkg.SystemBotList() {
-		got := filterPersonMessagesBySpace(msgs, bot, "spaceA", "spaceA")
-		assert.Emptyf(t, got, "SystemBot %s 的无 space_id 消息应被丢弃", bot)
+		gotNonDefault := filterPersonMessagesBySpace(msgs, bot, "spaceB", "spaceDefault")
+		assert.Lenf(t, gotNonDefault, 1, "SystemBot %s 的无 space_id 历史在非默认 Space 也应保留", bot)
+
+		gotDefault := filterPersonMessagesBySpace(msgs, bot, "spaceDefault", "spaceDefault")
+		assert.Lenf(t, gotDefault, 1, "SystemBot %s 的无 space_id 历史在默认 Space 应保留", bot)
 	}
 }
 


### PR DESCRIPTION
## Summary

`POST /v1/message/channel/sync` returned `messages: []` for **system-bot DMs**
(`botfather` / `u_10000` / `fileHelper` / `notification`) whenever the request
carried a validated `X-Space-ID`. System-bot messages are Space-agnostic
(`payload.space_id == ""`), and `filterPersonMessagesBySpace` dropped every
untagged system-bot message — so the conversation list showed botfather (forced
in by `EnsureSystemBotsPresent`) but opening it was empty.

System bots are **Space-independent and must always be visible**
(`pkg/space/query.go` invariant). This PR exempts them from
`filterPersonMessagesBySpace` (early return of the full list before the
per-message Space switch), making history visibility consistent with the
conversation-list contract. Regular-DM rules — including #484's symptom-1
(untagged history → default-Space-only) — are unchanged.

**This is not a #484/PR #519 regression.** Verified by diff: #484 only changed the
`!isSysBot` (regular-DM) branch; the system-bot branch and the filter's
`X-Space-ID` gate in `syncChannelMessage` are byte-identical before/after #484.
Root cause is **YUJ-219-A / #1283** (`e39b69f`, 2026-05-04), which first added the
system-bot message-drop branch.

**No data loss.** This is a read-time filter on the sync *response* — it never
writes or deletes. WuKongIM storage is intact; the fix restores history
immediately, no backfill/migration.

## Related Issue

Regression of YUJ-219-A / #1283 (system-bot DM history). No new issue filed.

## Linked Spec

- `.octospec/tasks/system-bot-dm-history/brief.md`
- Journal: `.octospec/journal/shared/system-bot-dm-history.md`

## Changes

- `modules/message/space_filter.go` — `filterPersonMessagesBySpace` early-returns
  the full list when `spacepkg.IsSystemBot(channelID)`; removed the now-dead
  `isSysBot` variable and its switch cases (rules simplified to regular-DM only).
- `modules/message/space_filter_test.go` — flipped the 3 YUJ-219-A tests that
  locked the drop behavior (`_SystemBot`, `_PayloadSpaceIDWrongType` fileHelper
  case, `_SystemBotListCoverage`) to assert full visibility;
  `_SystemBotListCoverage` now also covers the **non-default** Space (the repro).
- `.octospec/` — task brief, journal, and log entry.

## Testing

```
go build ./...                                                 ok
go vet ./modules/message/... ./pkg/space/...                   ok
make i18n-lint && make i18n-extract-check                      ok
go test -race -shuffle=on ./modules/message/ ./pkg/space/      ok  (CI-parity unit)
go test ./modules/message/ -run TestFilterPersonMessagesBySpace -v   all PASS
```

Reproduced first at the pure-function level (botfather untagged history 0/2 under
a Space; 2/2 without X-Space-ID; regular peer 2/2 in default — isolating the
system-bot branch as the cause), then fixed and locked with the flipped/extended
tests.

- [x] Unit tests added/updated
- [x] Manually verified (pure-function repro + CI-parity unit run)

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   It stops the DM message-history filter (`filterPersonMessagesBySpace`, used by
   `/v1/message/channel/sync`) from Space-filtering system-bot conversations.
   System bots now return their complete history in every Space, matching the
   conversation-list guarantee (`EnsureSystemBotsPresent` / `SystemBots`
   always-visible). Only the system-bot branch changes; regular-DM filtering
   (exact-match, untagged→default-only, cross-Space drop) is untouched.

2. **What could break (dependents + failure mode)?**
   Only `syncChannelMessage` calls this function, only for Person channels, only
   when a validated `X-Space-ID` is present. The exemption strictly *widens* what
   a system-bot sync returns (never narrows a regular DM), so it cannot introduce
   a cross-Space leak for regular DMs. System bots are global single conversations
   — returning their full history in any Space is correct, not a leak. Client-side
   `filterSystemBotMessages` (Android/iOS) may still filter; if so the server fix
   alone won't surface it — tracked as a follow-up in the brief.

3. **How do you know it works?**
   Pure-function repro reproduced the empty result and isolated rule 4 as the
   cause; the fix flips it to full visibility. Regression tests assert every
   system bot returns its untagged history in both default and non-default Spaces,
   and a #484 guard test confirms regular untagged DMs are still default-Space-only.
   CI-parity unit run green under `-race -shuffle=on`.

## Checklist

- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (octospec brief/journal/log)
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmFRUBSc2x7kpDaLs3Gyco

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmFRUBSc2x7kpDaLs3Gyco)_