### PR TITLE
feat: add custom sticker display toggle

### DIFF
--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -387,6 +387,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 			DisableUserCreateSpace: boolToFlag(cn.systemSettings.SpaceDisableUserCreate()),
 			SearchEnabled:          searchEnabled,
 			MessagesSearchOn:       searchEnabled,
+			StickerCustomEnabled:   cn.systemSettings.StickerCustomEnabled(),
 			StickerHandleRequired:  cn.systemSettings.StickerHandleRequired(),
 		})
 		return
@@ -428,6 +429,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 		DisableUserCreateSpace: boolToFlag(cn.systemSettings.SpaceDisableUserCreate()),
 		SearchEnabled:          searchEnabled,
 		MessagesSearchOn:       searchEnabled,
+		StickerCustomEnabled:   cn.systemSettings.StickerCustomEnabled(),
 		StickerHandleRequired:  cn.systemSettings.StickerHandleRequired(),
 	})
 }
@@ -758,6 +760,14 @@ type appConfigResp struct {
 	// 两字段并存：search_enabled 保留作向后兼容，messages_search_on 为新真源 key。
 	// 下发 bool，前端 parseRemoteBool(true) 即可正确开关，无需 0/1 特判。
 	MessagesSearchOn bool `json:"messages_search_on"`
+
+	// StickerCustomEnabled 告知客户端是否展示自定义贴纸管理入口。值来源于
+	// system_setting sticker.custom_enabled；默认 false,便于新能力先隐藏、再从
+	// 管理台灰度放开。本字段只表达展示策略，不改变 /v1/sticker/user 的服务端权限。
+	//
+	// 与 app_config.version 解耦的原因同 LocalLoginOff / SearchEnabled：运维切展示
+	// 策略后老客户端命中 version 短路分支也必须拿到最新值，故两个分支都下发。
+	StickerCustomEnabled bool `json:"sticker_custom_enabled"`
 
 	// StickerHandleRequired 告知客户端：新增自定义贴纸（POST /v1/sticker/user）时是否
 	// 必须携带上传句柄 handle（即 /v1/file/upload?type=sticker 返回的 sticker_handle）。

--- a/modules/common/api_test.go
+++ b/modules/common/api_test.go
@@ -81,6 +81,22 @@ func setStickerHandleRequiredSetting(t *testing.T, ctx *config.Context, required
 	require.NoError(t, EnsureSystemSettings(ctx).Reload())
 }
 
+// setStickerCustomEnabledSetting upserts system_setting sticker.custom_enabled
+// and reloads the shared snapshot. This is the appconfig-facing display toggle
+// for custom sticker management.
+func setStickerCustomEnabledSetting(t *testing.T, ctx *config.Context, enabled bool) {
+	t.Helper()
+	v := "0"
+	if enabled {
+		v = "1"
+	}
+	_, err := ctx.DB().InsertInto("system_setting").
+		Columns("category", "key_name", "value", "value_type").
+		Values("sticker", "custom_enabled", v, "bool").Exec()
+	require.NoError(t, err)
+	require.NoError(t, EnsureSystemSettings(ctx).Reload())
+}
+
 func TestAddVersion(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	s, ctx := testutil.NewTestServer()
@@ -675,4 +691,53 @@ func TestGetAppConfig_StickerHandleRequired_OnVersionShortCircuit(t *testing.T) 
 	s.GetRoute().ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), `"sticker_handle_required":true`)
+}
+
+// appconfig 必须下发 sticker_custom_enabled：值来源于 system_setting
+// sticker.custom_enabled。默认 false,客户端据此隐藏自定义贴纸管理入口。
+func TestGetAppConfig_StickerCustomEnabled_DefaultFalse(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"sticker_custom_enabled":false`)
+}
+
+// system_setting sticker.custom_enabled=true → appconfig 下发 true，客户端展示自定义贴纸管理入口。
+func TestGetAppConfig_StickerCustomEnabled_True(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	setStickerCustomEnabledSetting(t, ctx, true)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"sticker_custom_enabled":true`)
+}
+
+// version 短路分支同样要下发 sticker_custom_enabled：展示开关需要与
+// app_config.version 解耦，避免 admin 切换后老客户端命中版本短路而继续使用旧值。
+func TestGetAppConfig_StickerCustomEnabled_OnVersionShortCircuit(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	setStickerCustomEnabledSetting(t, ctx, true)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig?version=99999999", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"sticker_custom_enabled":true`)
 }

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -133,6 +133,11 @@ var systemSettingSchema = []settingDef{
 	{Category: "sticker", Key: "user_max_count", Type: settingTypeInt, Description: "每个用户可创建的自定义贴纸数量上限", Positive: true,
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.StickerUserMaxCount()) }},
 
+	// 自定义贴纸管理入口展示开关。仅用于通过 appconfig 告诉客户端是否展示入口，
+	// 不改变 /v1/sticker/user 已有服务端读写权限；默认关闭，便于新能力灰度放量。
+	{Category: "sticker", Key: "custom_enabled", Type: settingTypeBool, Description: "是否向客户端展示自定义贴纸管理入口",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.StickerCustomEnabled()) }},
+
 	// 自定义贴纸上传句柄强制开关（P0: Sticker Handle Enforcement Rollout）。这是「强制
 	// 策略」，与「签名能力」OCTO_MASTER_KEY 彻底解耦——能力是部署级 env，策略是运营可
 	// 在管理台热切的 DB 真源，互不派生。关闭（默认）= 兼容期：缺 handle 暂放行并记

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -756,6 +756,14 @@ func (s *SystemSettings) StickerUserMaxCount() int {
 	return v
 }
 
+// StickerCustomEnabled reports whether clients should show the custom-sticker
+// management entry. This is a presentation toggle only; server-side CRUD
+// authorization remains governed by the /v1/sticker/user route middleware and
+// handler checks. Default false supports a controlled client rollout.
+func (s *SystemSettings) StickerCustomEnabled() bool {
+	return s.getBool("sticker", "custom_enabled", false)
+}
+
 // StickerHandleRequired reports whether custom-sticker registration must reject a
 // missing upload handle (POST /v1/sticker/user). This is the enforcement POLICY,
 // deliberately independent of the signing CAPABILITY (OCTO_MASTER_KEY): it lives

--- a/modules/common/system_settings_test.go
+++ b/modules/common/system_settings_test.go
@@ -668,3 +668,17 @@ func TestSystemSettings_SidebarRecentFilter_BoundaryValuesAccepted(t *testing.T)
 	assert.Equal(t, 0, s.SidebarRecentFilterGroupDays(), "下界 0 接受")
 	assert.Equal(t, 3650, s.SidebarRecentFilterThreadDays(), "上界 3650 接受")
 }
+
+func TestSystemSettings_StickerCustomEnabled_DefaultsFalse(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+
+	assert.False(t, s.StickerCustomEnabled(), "DB empty -> custom sticker management hidden by default")
+}
+
+func TestSystemSettings_StickerCustomEnabled_DBTrueWins(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	require.NoError(t, s.db.upsert("sticker", "custom_enabled", "1", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+
+	assert.True(t, s.StickerCustomEnabled(), "DB true -> custom sticker management enabled")
+}


### PR DESCRIPTION
## Summary
- add `sticker.custom_enabled` as an admin-tunable system setting for the custom sticker management entry
- expose `sticker_custom_enabled` from `/v1/common/appconfig` in both full and version-short-circuit responses
- cover the default false, DB true, and version-short-circuit appconfig paths plus the SystemSettings getter

## Linked Spec
- `.octospec/tasks/custom-sticker-management/brief.md`

## COMPREHENSION
1. Load-bearing behavior: `sticker_custom_enabled` is a client display toggle only; it does not change `/v1/sticker/user` server-side auth or CRUD enforcement.
2. Wire contract: appconfig must return the field even when `version` short-circuits, matching the existing dynamic-config fields.
3. Rollback: set `sticker.custom_enabled=0` in system_setting or revert this PR; default remains hidden when the row is absent.

## Tests
- `git diff --check`
- `docker run --rm -v "$PWD":/app -w /app golang:1.25 /usr/local/go/bin/go test ./modules/common -run "^$"`

Note: the targeted DB-backed appconfig tests were added but not run green locally because the Docker test container resolves `127.0.0.1:3306` to itself; it failed with MySQL connection refused before assertions.