### PR TITLE
fix(base): make searchetl migration idempotent to avoid boot panic #528

### DIFF
--- a/modules/base/searchetl_migration_test.go
+++ b/modules/base/searchetl_migration_test.go
@@ -1,0 +1,64 @@
+package base
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	migrate "github.com/rubenv/sql-migrate"
+	"github.com/stretchr/testify/require"
+)
+
+// searchetlMigrationFile is the migration whose Up DDL this test exercises. Kept as a named
+// constant so the test fails loudly (file-not-found) if the migration is ever renamed.
+const searchetlMigrationFile = "20260614000001_searchetl_init.sql"
+
+// Test_Issue528_SearchetlMigrationIdempotentWhenTableExists reproduces the octo-server#528
+// boot panic: octo_etl_es_cursor is owned by the standalone octo-search-indexer, which shares
+// this database. When the indexer starts first it creates the table, but octo-server may not
+// yet have recorded this migration ID in gorp_migrations (new DB / first boot) — so sql-migrate
+// executes the Up DDL against an already-existing table.
+//
+// We reproduce that "indexer-first" world by pre-creating the table ourselves, then run this
+// migration's OWN Up statements verbatim (parsed from the embedded sql FS, exactly what
+// rubenv/sql-migrate runs in production). A bare `CREATE TABLE` fails with Error 1050 (RED,
+// pre-fix); `CREATE TABLE IF NOT EXISTS` is a no-op and succeeds (GREEN, post-fix). Reading the
+// DDL from the real file keeps the test honest if the migration ever drifts.
+func Test_Issue528_SearchetlMigrationIdempotentWhenTableExists(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+
+	// Never leave the shared test schema in a half-created state for later tests.
+	defer func() {
+		_, _ = ctx.DB().UpdateBySql("DROP TABLE IF EXISTS `octo_etl_es_cursor`").Exec()
+	}()
+
+	// Arrange: reproduce the octo-search-indexer-first world where the table already exists
+	// before octo-server applies this migration ID. (NewTestServer's migration run may already
+	// have created it; DROP + CREATE makes the precondition deterministic regardless of setup.)
+	_, _ = ctx.DB().UpdateBySql("DROP TABLE IF EXISTS `octo_etl_es_cursor`").Exec()
+	_, err := ctx.DB().UpdateBySql(
+		"CREATE TABLE `octo_etl_es_cursor` (" +
+			"`shard_table` VARCHAR(64) NOT NULL, " +
+			"`last_id` BIGINT NOT NULL DEFAULT 0, " +
+			"`updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, " +
+			"PRIMARY KEY (`shard_table`)" +
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+	).Exec()
+	require.NoError(t, err, "scaffold: pre-create octo_etl_es_cursor as octo-search-indexer would")
+
+	// Act: run the migration's real Up statements verbatim against the pre-existing table.
+	data, err := sqlFS.ReadFile("sql/" + searchetlMigrationFile)
+	require.NoError(t, err, "read migration %s from embedded sql FS", searchetlMigrationFile)
+	m, err := migrate.ParseMigration(searchetlMigrationFile, bytes.NewReader(data))
+	require.NoError(t, err, "parse migration %s", searchetlMigrationFile)
+	require.NotEmpty(t, m.Up, "migration %s has no Up statements", searchetlMigrationFile)
+
+	// Assert: applying Up over an existing table must NOT error (the #528 boot panic).
+	for _, stmt := range m.Up {
+		_, err := ctx.DB().UpdateBySql(stmt).Exec()
+		require.NoError(t, err,
+			"migration %s Up must be idempotent against a pre-existing table (octo-server#528): %s",
+			searchetlMigrationFile, stmt)
+	}
+}

--- a/modules/base/sql/20260614000001_searchetl_init.sql
+++ b/modules/base/sql/20260614000001_searchetl_init.sql
@@ -6,9 +6,11 @@
 -- deleting the file would make sql-migrate panic on boot (unknown migration in database,
 -- IgnoreUnknown=false). The file was moved here (DB-neutral; the ID is unchanged) when
 -- modules/searchetl was deleted, and base is always loaded (blank-imported + embeds sql/).
--- Because the ID is already applied, sql-migrate skips this migration on every boot — the
--- CREATE TABLE below never re-runs. The octo_etl_es_cursor table is now owned by the
--- standalone searchetl-producer.
+-- The octo_etl_es_cursor table is now owned by the standalone searchetl-producer
+-- (octo-search-indexer), which shares this database. Because that component may create the
+-- table BEFORE octo-server has recorded this migration ID (new DB / first boot), the Up DDL
+-- can still execute against an already-existing table — so it MUST stay idempotent
+-- (CREATE TABLE IF NOT EXISTS) to avoid an Error 1050 panic on boot. See octo-server#528.
 --
 -- searchetl 消息检索 ETL 抽取水位（YUJ-4530 ETL→Kafka→ES indexer）。
 -- 每个 message 分片表一行，记录已投递到 Kafka 的最大主键 id 水位。
@@ -17,7 +19,7 @@
 -- 增量抽取按 PK `WHERE id>last_id ORDER BY id LIMIT batch` keyset 分页；水位只推进到
 -- 「落库已超过 lag（稳定性滞后窗口）」的稳定前缀末尾，杜绝低 id 晚提交被游标越过的并发漏扫。
 -- 撤回/删除态不走该游标（路线甲：读时回 MySQL join 过滤），本游标只跑正文一条流。
-CREATE TABLE `octo_etl_es_cursor` (
+CREATE TABLE IF NOT EXISTS `octo_etl_es_cursor` (
   `shard_table` VARCHAR(64) NOT NULL          COMMENT 'message 分片表名 (message / message1 / ...)',
   `last_id`     BIGINT      NOT NULL DEFAULT 0 COMMENT '已投递到 Kafka 的最大 message.id 水位',
   `updated_at`  TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '行更新时间',


### PR DESCRIPTION
## Summary

Make the retained `searchetl` migration idempotent so `octo-server` no longer panics on boot when it shares a database with `octo-search-indexer`.

## Related Issue

Fixes #528

## Linked Spec

Bug #528 (well-diagnosed by reporter; minimal-scope fix). No separate spec — see COMPREHENSION below.

## Changes

- `modules/base/sql/20260614000001_searchetl_init.sql`: `CREATE TABLE` → `CREATE TABLE IF NOT EXISTS` for `octo_etl_es_cursor`, and corrected the header NOTE which encoded the false "the CREATE TABLE below never re-runs" premise.
- `modules/base/searchetl_migration_test.go`: regression test `Test_Issue528_SearchetlMigrationIdempotentWhenTableExists` — pre-creates the table (indexer-first world) then runs this migration's real Up statements verbatim; asserts no error.

## Testing

- [x] Unit tests added/updated — new DB-backed regression test.
- [ ] Manually verified — local sandbox has no MySQL; `go build ./modules/base/...` and `go vet ./modules/base/` pass. RED→GREEN pivot runs in CI (which provides MySQL). Pre-fix the test hits Error 1050; post-fix it passes.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   The boot-time migration runner (`sql-migrate`) applies each unrecorded migration ID's Up DDL. This migration's Up now issues `CREATE TABLE IF NOT EXISTS` instead of a bare `CREATE TABLE`. The DDL becomes a no-op when `octo_etl_es_cursor` already exists, instead of failing with Error 1050. The migration ID and sequence are unchanged, so `gorp_migrations` continuity is preserved.

2. **What could break because of it (dependents + failure mode)?**
   Negligible. `IF NOT EXISTS` only suppresses the "already exists" error; on a clean DB the table is created exactly as before (same columns/engine/charset). The only behavioral difference is that if a *pre-existing* `octo_etl_es_cursor` has a divergent schema, this migration will no longer overwrite/fail — it silently skips. That is the correct contract now that the table is owned by `octo-search-indexer`; octo-server should not be the authority on its shape.

3. **How do you know it works (specific test/repro/trace)?**
   `Test_Issue528_SearchetlMigrationIdempotentWhenTableExists` reproduces the reporter's indexer-first scenario: it pre-creates the table, then executes the migration file's own parsed Up statements verbatim (same path `rubenv/sql-migrate` runs in prod). Before the fix that raises Error 1050 (the panic in the issue); after the fix it succeeds. The test reads the DDL from the embedded FS, so it stays honest if the migration drifts.
