### PR TITLE
fix(message): default-Space DM conversation preview & unread count (#484)

### DIFF
--- a/modules/message/api_conversation.go
+++ b/modules/message/api_conversation.go
@@ -888,7 +888,7 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 	// Space 过滤
 	if hasSpaceFilter {
 		// Person 频道：计算 per-Space 未读计数（在过滤之前，需要原始会话数据）
-		fillPersonSpaceUnread(syncUserConversationResps, conversations, filterSpaceID, loginUID, co.ctx)
+		fillPersonSpaceUnread(syncUserConversationResps, conversations, filterSpaceID, defaultSpaceID, loginUID, co.ctx)
 
 		syncUserConversationResps = FilterConversationsBySpace(
 			syncUserConversationResps, filterSpaceID, loginUID, co.ctx, co.groupService,

--- a/modules/message/dm_space_last_message_repro_test.go
+++ b/modules/message/dm_space_last_message_repro_test.go
@@ -165,6 +165,38 @@ func TestFix_SpaceLastMessage_DefaultSpaceUsesUntagged(t *testing.T) {
 		"the default-space preview message carries no space_id (it is the untagged one)")
 }
 
+// TestFix_SystemBotUntaggedNotInDefaultPreview is the system-bot parity regression
+// guard (PR #532 review by yujiawei/mochashanyao/Jerry-Xin/OctoBoooot): a system-bot
+// DM (botfather) whose default-Space history is untagged must NOT surface a
+// default-Space space_last_message or unread badge — mirroring the history filter's
+// rule-4 drop, so preview/badge can't show what /v1/message/channel/sync hides.
+func TestFix_SystemBotUntaggedNotInDefaultPreview(t *testing.T) {
+	const (
+		botChannel  = "botfather" // spacepkg.IsSystemBot(botfather) == true
+		spaceDefaul = "space-default-bot"
+	)
+	now := time.Now()
+	// Untagged system-bot history (default-Space by the regular-DM convention, but
+	// rule 4 drops it for system bots).
+	m1 := dmMsgRepro(botChannel, 11, now.Add(-2*time.Hour).Unix(), `{"type":1,"content":"bot-a"}`)
+	m2 := dmMsgRepro(botChannel, 12, now.Add(-1*time.Hour).Unix(), `{"type":1,"content":"bot-b"}`)
+	conv := dmIMConvMulti(botChannel, now.Add(-1*time.Hour).Unix(), 100, []*config.MessageResp{m1, m2})
+	conv.Unread = 2 // exercise the unread-count path
+	convs := []*config.SyncUserConversationResp{conv}
+
+	s, ctx := setupConvSyncE2E(t, convs)
+	seedSpaceMemberRepro(t, ctx, spaceDefaul, testutil.UID, "2020-01-01 00:00:00")
+
+	convD := findConv(callConvSyncSpace(t, s, spaceDefaul), botChannel)
+	require.NotNil(t, convD, "system-bot DM stays visible in the conversation list")
+	assert.Nil(t, convD.SpaceLastMessage,
+		"untagged system-bot messages must not become the default-space preview (rule-4 parity)")
+	if convD.SpaceUnread != nil {
+		assert.Equal(t, 0, *convD.SpaceUnread,
+			"untagged system-bot messages must not be counted as default-space unread")
+	}
+}
+
 // TestFix_FindSpaceLastMessage_DefaultMatchesUntagged pins the root-cause fix at
 // the helper level: findSpaceLastMessage now takes defaultSpaceID and treats an
 // untagged DM message as a default-Space message (the same predicate the 200-msg
@@ -180,16 +212,16 @@ func TestFix_FindSpaceLastMessage_DefaultMatchesUntagged(t *testing.T) {
 	}
 
 	// Non-default space: the tagged message is found; the untagged one never leaks.
-	got := findSpaceLastMessage(recents, spaceB, spaceDefault)
+	got := findSpaceLastMessage(recents, spaceB, spaceDefault, false)
 	require.NotNil(t, got)
 	assert.Equal(t, uint32(12), got.MessageSeq)
 
 	// Default space: the untagged default message is now matched (was nil before).
-	got = findSpaceLastMessage(recents, spaceDefault, spaceDefault)
+	got = findSpaceLastMessage(recents, spaceDefault, spaceDefault, false)
 	require.NotNil(t, got, "untagged default-space message is now resolved")
 	assert.Equal(t, uint32(11), got.MessageSeq)
 
 	// Guard: with no default configured (defaultSpaceID==""), the untagged=default
 	// convention is off and a non-default query stays strict.
-	assert.Nil(t, findSpaceLastMessage(recents, spaceDefault, ""))
+	assert.Nil(t, findSpaceLastMessage(recents, spaceDefault, "", false))
 }

--- a/modules/message/dm_space_last_message_repro_test.go
+++ b/modules/message/dm_space_last_message_repro_test.go
@@ -1,0 +1,197 @@
+//go:build integration
+
+package message
+
+// Reproduction for the default-Space DM conversation-preview leak observed on
+// the deployed test env (main) via
+//   POST /v1/conversation/sync?space_id=:space_id
+//
+// Scenario (mirrors the real capture): one physical DM channel whose history is
+//   - an UNTAGGED message  (no payload.space_id → belongs to the DEFAULT space)
+//   - a message TAGGED with a NON-default space (the globally-latest one)
+//
+// Hypothesis under test:
+//   1. Query the NON-default space  → space_last_message is that space's message
+//      (correct — it is explicitly tagged).
+//   2. Query the DEFAULT space      → space_last_message is ABSENT (nil), because
+//      findSpaceLastMessage matches strictly on payload.space_id == filterSpaceID
+//      and the default-space messages are UNTAGGED, so nothing matches. The client
+//      then falls back to recents[last] = the channel's GLOBAL last message, which
+//      is tagged for the OTHER space → the preview leaks a wrong-space message.
+//
+// This drives the REAL handler (syncUserConversation) through the registered
+// /v1/conversation route (which mounts spacepkg.SpaceMiddleware, reading
+// ?space_id=). WuKongIM is the shared httptest fake from
+// conversation_recent_filter_e2e_test.go (same package/build tag): it returns
+// our canned conversation for /conversation/sync and {} for /channel/messagesync
+// (so the findSpaceLastMessageFallback path also finds no default-tagged message
+// — same strict-match blind spot, exercised below as a pure-function check).
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/server"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dmMsgRepro builds one raw DM message with the given seq/timestamp/payload JSON.
+func dmMsgRepro(channelID string, seq uint32, ts int64, payloadJSON string) *config.MessageResp {
+	return &config.MessageResp{
+		MessageID:   int64(seq)*1000 + 1,
+		MessageSeq:  seq,
+		ClientMsgNo: channelID + "-" + strconv.FormatUint(uint64(seq), 10),
+		FromUID:     channelID,
+		ChannelID:   channelID,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Timestamp:   int32(ts),
+		Setting:     0, // not a signal message → payload parsed into the map
+		IsDeleted:   0,
+		Payload:     []byte(payloadJSON),
+	}
+}
+
+// dmIMConvMulti builds a DM conversation (as IMSyncUserConversation returns it)
+// carrying multiple recent messages; LastMsgSeq tracks the newest.
+func dmIMConvMulti(channelID string, ts, version int64, msgs []*config.MessageResp) *config.SyncUserConversationResp {
+	return &config.SyncUserConversationResp{
+		ChannelID:   channelID,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Unread:      0,
+		Timestamp:   ts,
+		LastMsgSeq:  int64(msgs[len(msgs)-1].MessageSeq),
+		Version:     version,
+		Recents:     msgs,
+	}
+}
+
+// seedSpaceMemberRepro inserts a space + membership for uid with an explicit
+// created_at (so GetUserDefaultSpaceIDE — earliest membership — is deterministic)
+// and clears the Redis membership cache so the middleware re-checks the DB.
+func seedSpaceMemberRepro(t *testing.T, ctx *config.Context, spaceID, uid, createdAt string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `space` (space_id, name, creator, status, created_at, updated_at) VALUES (?,?,?,1,?,?)",
+		spaceID, spaceID, uid, createdAt, createdAt).Exec()
+	require.NoError(t, err)
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO `space_member` (space_id, uid, role, status, created_at, updated_at) VALUES (?,?,0,1,?,?)",
+		spaceID, uid, createdAt, createdAt).Exec()
+	require.NoError(t, err)
+	_ = ctx.GetRedisConn().Del("space:member:" + spaceID + ":" + uid)
+}
+
+// callConvSyncSpace POSTs to the real route with ?space_id= and returns the full
+// decoded conversation objects (so we can inspect space_last_message / recents).
+func callConvSyncSpace(t *testing.T, s *server.Server, spaceID string) []*SyncUserConversationResp {
+	t.Helper()
+	body := `{"msg_count":50,"device_uuid":"dev-repro-` + spaceID + `"}`
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/conversation/sync?space_id="+spaceID, strings.NewReader(body))
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var wrap struct {
+		Conversations []*SyncUserConversationResp `json:"conversations"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrap))
+	return wrap.Conversations
+}
+
+func findConv(convs []*SyncUserConversationResp, channelID string) *SyncUserConversationResp {
+	for _, c := range convs {
+		if c.ChannelID == channelID {
+			return c
+		}
+	}
+	return nil
+}
+
+// TestRepro_SpaceLastMessage_DefaultSpaceLeak confirms the hypothesis end-to-end
+// through POST /v1/conversation/sync?space_id=.
+func TestRepro_SpaceLastMessage_DefaultSpaceLeak(t *testing.T) {
+	const (
+		dmChannel   = "dm-peer-repro"
+		spaceB      = "space-b-repro"       // a non-default space
+		spaceDefaul = "space-default-repro" // earliest membership → default space
+	)
+
+	now := time.Now()
+	// History: seq 11 = UNTAGGED (default-space message), seq 12 = tagged spaceB
+	// (globally latest). Matches the real capture where the latest msg is 668cc9.
+	untagged := dmMsgRepro(dmChannel, 11, now.Add(-2*time.Hour).Unix(),
+		`{"type":1,"content":"default-space-hello"}`)
+	taggedB := dmMsgRepro(dmChannel, 12, now.Add(-1*time.Hour).Unix(),
+		`{"type":1,"content":"1111","space_id":"`+spaceB+`"}`)
+
+	convs := []*config.SyncUserConversationResp{
+		dmIMConvMulti(dmChannel, now.Add(-1*time.Hour).Unix(), 100, []*config.MessageResp{untagged, taggedB}),
+	}
+
+	s, ctx := setupConvSyncE2E(t, convs)
+	// Default space MUST have the earlier created_at (GetUserDefaultSpaceIDE =
+	// earliest membership by created_at ASC).
+	seedSpaceMemberRepro(t, ctx, spaceDefaul, testutil.UID, "2020-01-01 00:00:00")
+	seedSpaceMemberRepro(t, ctx, spaceB, testutil.UID, "2020-06-01 00:00:00")
+
+	// ---- (1) NON-default space: preview is correct (explicitly tagged) ----
+	convB := findConv(callConvSyncSpace(t, s, spaceB), dmChannel)
+	require.NotNil(t, convB, "DM must be visible in its tagged (non-default) space")
+	require.NotNil(t, convB.SpaceLastMessage,
+		"non-default space: space_last_message present (tagged message found)")
+	assert.Equal(t, "1111", convB.SpaceLastMessage.Payload["content"],
+		"non-default space: preview is the spaceB-tagged message")
+	assert.Equal(t, spaceB, convB.SpaceLastMessage.Payload["space_id"])
+
+	// ---- (2) DEFAULT space: preview is WRONG (leaks the spaceB message) ----
+	convD := findConv(callConvSyncSpace(t, s, spaceDefaul), dmChannel)
+	require.NotNil(t, convD, "DM is (correctly) visible in the default space via catch-all")
+
+	// The bug: no per-space preview could be computed for the default space,
+	// because its messages are UNTAGGED and findSpaceLastMessage matches strictly
+	// on space_id == defaultSpaceID.
+	assert.Nil(t, convD.SpaceLastMessage,
+		"BUG: default-space space_last_message is nil — untagged default messages never match the strict space_id filter")
+
+	// With space_last_message absent, the client falls back to recents[last] =
+	// the channel's global-last message, which belongs to the OTHER space.
+	require.NotEmpty(t, convD.Recents, "recents present")
+	lastRecent := convD.Recents[len(convD.Recents)-1]
+	assert.Equal(t, "1111", lastRecent.Payload["content"],
+		"LEAK: default-space fallback preview is the spaceB message content")
+	assert.Equal(t, spaceB, lastRecent.Payload["space_id"],
+		"LEAK: default-space fallback preview carries the WRONG space_id (spaceB, not the default space)")
+}
+
+// TestRepro_FindSpaceLastMessage_StrictMatchBlindSpot isolates the root cause:
+// findSpaceLastMessage / the fallback both match strictly on payload.space_id ==
+// spaceID, so for the DEFAULT space (whose DM messages are UNTAGGED) they return
+// nil even when the default-space message IS in the scanned set. This is why the
+// 200-message fallback in findSpaceLastMessageFallback cannot rescue it either.
+func TestRepro_FindSpaceLastMessage_StrictMatchBlindSpot(t *testing.T) {
+	const spaceB = "space-b-repro"
+	recents := []*MsgSyncResp{
+		{MessageSeq: 11, Payload: map[string]interface{}{"type": float64(1), "content": "default-space-hello"}}, // UNTAGGED
+		{MessageSeq: 12, Payload: map[string]interface{}{"type": float64(1), "content": "1111", "space_id": spaceB}},
+	}
+
+	// Non-default space: the tagged message is found.
+	got := findSpaceLastMessage(recents, spaceB)
+	require.NotNil(t, got)
+	assert.Equal(t, uint32(12), got.MessageSeq)
+
+	// Default space: the untagged default message exists in the set but is NOT
+	// matched (no space_id key) → nil. Same strict predicate the fallback uses.
+	assert.Nil(t, findSpaceLastMessage(recents, "space-default-repro"),
+		"strict space_id match cannot find the untagged default-space message")
+}

--- a/modules/message/dm_space_last_message_repro_test.go
+++ b/modules/message/dm_space_last_message_repro_test.go
@@ -2,30 +2,27 @@
 
 package message
 
-// Reproduction for the default-Space DM conversation-preview leak observed on
-// the deployed test env (main) via
+// Regression guard for the default-Space DM conversation-preview leak observed
+// on the deployed test env (main) via
 //   POST /v1/conversation/sync?space_id=:space_id
 //
 // Scenario (mirrors the real capture): one physical DM channel whose history is
 //   - an UNTAGGED message  (no payload.space_id → belongs to the DEFAULT space)
 //   - a message TAGGED with a NON-default space (the globally-latest one)
 //
-// Hypothesis under test:
-//   1. Query the NON-default space  → space_last_message is that space's message
-//      (correct — it is explicitly tagged).
-//   2. Query the DEFAULT space      → space_last_message is ABSENT (nil), because
-//      findSpaceLastMessage matches strictly on payload.space_id == filterSpaceID
-//      and the default-space messages are UNTAGGED, so nothing matches. The client
-//      then falls back to recents[last] = the channel's GLOBAL last message, which
-//      is tagged for the OTHER space → the preview leaks a wrong-space message.
+// Behaviour after the fix (fillPersonSpaceUnread/findSpaceLastMessage now take
+// defaultSpaceID and treat an untagged DM message as a default-Space message):
+//   1. Query the NON-default space → space_last_message is that space's message
+//      (explicitly tagged); the untagged default message never leaks in.
+//   2. Query the DEFAULT space     → space_last_message is the untagged default
+//      message (NOT the other space's globally-latest one). Before the fix this
+//      was nil, so the client fell back to recents[last] and leaked a wrong-space
+//      preview.
 //
 // This drives the REAL handler (syncUserConversation) through the registered
 // /v1/conversation route (which mounts spacepkg.SpaceMiddleware, reading
 // ?space_id=). WuKongIM is the shared httptest fake from
-// conversation_recent_filter_e2e_test.go (same package/build tag): it returns
-// our canned conversation for /conversation/sync and {} for /channel/messagesync
-// (so the findSpaceLastMessageFallback path also finds no default-tagged message
-// — same strict-match blind spot, exercised below as a pure-function check).
+// conversation_recent_filter_e2e_test.go (same package/build tag).
 
 import (
 	"encoding/json"
@@ -117,9 +114,9 @@ func findConv(convs []*SyncUserConversationResp, channelID string) *SyncUserConv
 	return nil
 }
 
-// TestRepro_SpaceLastMessage_DefaultSpaceLeak confirms the hypothesis end-to-end
+// TestFix_SpaceLastMessage_DefaultSpaceUsesUntagged verifies the fix end-to-end
 // through POST /v1/conversation/sync?space_id=.
-func TestRepro_SpaceLastMessage_DefaultSpaceLeak(t *testing.T) {
+func TestFix_SpaceLastMessage_DefaultSpaceUsesUntagged(t *testing.T) {
 	const (
 		dmChannel   = "dm-peer-repro"
 		spaceB      = "space-b-repro"       // a non-default space
@@ -153,45 +150,46 @@ func TestRepro_SpaceLastMessage_DefaultSpaceLeak(t *testing.T) {
 		"non-default space: preview is the spaceB-tagged message")
 	assert.Equal(t, spaceB, convB.SpaceLastMessage.Payload["space_id"])
 
-	// ---- (2) DEFAULT space: preview is WRONG (leaks the spaceB message) ----
+	// ---- (2) DEFAULT space: preview is now the untagged default message ----
 	convD := findConv(callConvSyncSpace(t, s, spaceDefaul), dmChannel)
-	require.NotNil(t, convD, "DM is (correctly) visible in the default space via catch-all")
+	require.NotNil(t, convD, "DM is visible in the default space")
 
-	// The bug: no per-space preview could be computed for the default space,
-	// because its messages are UNTAGGED and findSpaceLastMessage matches strictly
-	// on space_id == defaultSpaceID.
-	assert.Nil(t, convD.SpaceLastMessage,
-		"BUG: default-space space_last_message is nil — untagged default messages never match the strict space_id filter")
-
-	// With space_last_message absent, the client falls back to recents[last] =
-	// the channel's global-last message, which belongs to the OTHER space.
-	require.NotEmpty(t, convD.Recents, "recents present")
-	lastRecent := convD.Recents[len(convD.Recents)-1]
-	assert.Equal(t, "1111", lastRecent.Payload["content"],
-		"LEAK: default-space fallback preview is the spaceB message content")
-	assert.Equal(t, spaceB, lastRecent.Payload["space_id"],
-		"LEAK: default-space fallback preview carries the WRONG space_id (spaceB, not the default space)")
+	// Fixed: the untagged message counts as a default-Space message, so the
+	// per-Space preview resolves to it instead of leaking the spaceB message.
+	require.NotNil(t, convD.SpaceLastMessage,
+		"default-space space_last_message is now populated from the untagged default message")
+	assert.Equal(t, "default-space-hello", convD.SpaceLastMessage.Payload["content"],
+		"default-space preview is the untagged (default) message, not the spaceB one")
+	_, hasSpaceID := convD.SpaceLastMessage.Payload["space_id"]
+	assert.False(t, hasSpaceID,
+		"the default-space preview message carries no space_id (it is the untagged one)")
 }
 
-// TestRepro_FindSpaceLastMessage_StrictMatchBlindSpot isolates the root cause:
-// findSpaceLastMessage / the fallback both match strictly on payload.space_id ==
-// spaceID, so for the DEFAULT space (whose DM messages are UNTAGGED) they return
-// nil even when the default-space message IS in the scanned set. This is why the
-// 200-message fallback in findSpaceLastMessageFallback cannot rescue it either.
-func TestRepro_FindSpaceLastMessage_StrictMatchBlindSpot(t *testing.T) {
-	const spaceB = "space-b-repro"
+// TestFix_FindSpaceLastMessage_DefaultMatchesUntagged pins the root-cause fix at
+// the helper level: findSpaceLastMessage now takes defaultSpaceID and treats an
+// untagged DM message as a default-Space message (the same predicate the 200-msg
+// fallback uses), while non-default queries stay strict.
+func TestFix_FindSpaceLastMessage_DefaultMatchesUntagged(t *testing.T) {
+	const (
+		spaceB       = "space-b-repro"
+		spaceDefault = "space-default-repro"
+	)
 	recents := []*MsgSyncResp{
 		{MessageSeq: 11, Payload: map[string]interface{}{"type": float64(1), "content": "default-space-hello"}}, // UNTAGGED
 		{MessageSeq: 12, Payload: map[string]interface{}{"type": float64(1), "content": "1111", "space_id": spaceB}},
 	}
 
-	// Non-default space: the tagged message is found.
-	got := findSpaceLastMessage(recents, spaceB)
+	// Non-default space: the tagged message is found; the untagged one never leaks.
+	got := findSpaceLastMessage(recents, spaceB, spaceDefault)
 	require.NotNil(t, got)
 	assert.Equal(t, uint32(12), got.MessageSeq)
 
-	// Default space: the untagged default message exists in the set but is NOT
-	// matched (no space_id key) → nil. Same strict predicate the fallback uses.
-	assert.Nil(t, findSpaceLastMessage(recents, "space-default-repro"),
-		"strict space_id match cannot find the untagged default-space message")
+	// Default space: the untagged default message is now matched (was nil before).
+	got = findSpaceLastMessage(recents, spaceDefault, spaceDefault)
+	require.NotNil(t, got, "untagged default-space message is now resolved")
+	assert.Equal(t, uint32(11), got.MessageSeq)
+
+	// Guard: with no default configured (defaultSpaceID==""), the untagged=default
+	// convention is off and a non-default query stays strict.
+	assert.Nil(t, findSpaceLastMessage(recents, spaceDefault, ""))
 }

--- a/modules/message/space_unread.go
+++ b/modules/message/space_unread.go
@@ -13,10 +13,16 @@ import (
 // 并填充 SpaceLastMessage（该 Space 的最后一条消息预览）。
 // 仅处理 channelType=1 的会话。
 // 通过解析消息 payload 中的 space_id 字段来统计属于指定 Space 的未读消息数。
+//
+// defaultSpaceID 用于「无标签 = 默认 Space」归属（见 dmSpaceMatch）：DM 在默认
+// Space 发送的消息不带 payload.space_id，若严格等值匹配就永远命中不到 —— 会导致
+// 默认 Space 的 space_last_message 取不到、per-Space 未读漏计，与可见性兜底
+// (decideConvKeepInSpace) / 历史过滤 (filterPersonMessagesBySpace) 口径不一致。
 func fillPersonSpaceUnread(
 	conversations []*SyncUserConversationResp,
 	rawConversations []*config.SyncUserConversationResp,
 	spaceID string,
+	defaultSpaceID string,
 	loginUID string,
 	ctx *config.Context,
 ) {
@@ -36,7 +42,7 @@ func fillPersonSpaceUnread(
 		}
 
 		// 从 Recents 中找该 Space 的最后一条消息作为预览
-		spaceLastMsg := findSpaceLastMessage(conv.Recents, spaceID)
+		spaceLastMsg := findSpaceLastMessage(conv.Recents, spaceID, defaultSpaceID)
 		if spaceLastMsg != nil {
 			conv.SpaceLastMessage = spaceLastMsg
 		}
@@ -49,7 +55,7 @@ func fillPersonSpaceUnread(
 			if raw != nil && raw.LastMsgSeq > 0 {
 				fallbackMsg := findSpaceLastMessageFallback(
 					conv.ChannelID, conv.ChannelType,
-					loginUID, spaceID, uint32(raw.LastMsgSeq), ctx,
+					loginUID, spaceID, defaultSpaceID, uint32(raw.LastMsgSeq), ctx,
 				)
 				if fallbackMsg != nil {
 					conv.SpaceLastMessage = fallbackMsg
@@ -99,32 +105,55 @@ func fillPersonSpaceUnread(
 			messages = resp.Messages
 		}
 
-		count := countSpaceUnreadFromMessages(messages, spaceID, readSeq)
+		count := countSpaceUnreadFromMessages(messages, spaceID, defaultSpaceID, readSeq)
 		conv.SpaceUnread = &count
 	}
 }
 
-// findSpaceLastMessage 从 Recents 中倒序查找最后一条 space_id 匹配的消息。
+// dmMessageSpaceID 读取消息 payload 的 space_id（缺失 / 空 / 非字符串一律视为 ""，
+// 即「无标签」）。
+func dmMessageSpaceID(payload map[string]interface{}) string {
+	if payload == nil {
+		return ""
+	}
+	if sid, ok := payload["space_id"].(string); ok {
+		return sid
+	}
+	return ""
+}
+
+// dmSpaceMatch 判断一条 space_id 为 msgSpaceID 的 DM 消息是否归属 targetSpaceID，
+// 遵循「无标签 = 默认 Space」约定：未打标（无 payload.space_id）的 DM 消息归属用户
+// 默认 Space。这与可见性兜底 (decideConvKeepInSpace) 和历史过滤
+// (filterPersonMessagesBySpace) 对未打标 DM 消息的处理保持一致。
+// defaultSpaceID == "" 时约定关闭（仅严格等值），非默认 Space 查询不受影响。
+func dmSpaceMatch(msgSpaceID, targetSpaceID, defaultSpaceID string) bool {
+	if msgSpaceID == targetSpaceID {
+		return true
+	}
+	return msgSpaceID == "" && targetSpaceID == defaultSpaceID
+}
+
+// findSpaceLastMessage 从 Recents 中倒序查找最后一条归属 spaceID 的消息。
 // 用于会话列表的消息预览，确保每个 Space 显示该 Space 的最后一条消息。
-func findSpaceLastMessage(recents []*MsgSyncResp, spaceID string) *MsgSyncResp {
+func findSpaceLastMessage(recents []*MsgSyncResp, spaceID, defaultSpaceID string) *MsgSyncResp {
 	for i := len(recents) - 1; i >= 0; i-- {
 		msg := recents[i]
-		if msg.Payload != nil {
-			if sid, ok := msg.Payload["space_id"]; ok {
-				if sidStr, ok := sid.(string); ok && sidStr == spaceID {
-					return msg
-				}
-			}
+		if msg.Payload == nil {
+			continue
+		}
+		if dmSpaceMatch(dmMessageSpaceID(msg.Payload), spaceID, defaultSpaceID) {
+			return msg
 		}
 	}
 	return nil
 }
 
 // findSpaceLastMessageFallback 在 Recents 找不到匹配消息时，
-// 从 WuKongIM 向前拉取历史消息（最多 200 条），查找最后一条 space_id 匹配的消息。
+// 从 WuKongIM 向前拉取历史消息（最多 200 条），查找最后一条归属 spaceID 的消息。
 func findSpaceLastMessageFallback(
 	channelID string, channelType uint8,
-	loginUID string, spaceID string,
+	loginUID string, spaceID, defaultSpaceID string,
 	lastMsgSeq uint32, ctx *config.Context,
 ) *MsgSyncResp {
 	if lastMsgSeq == 0 {
@@ -165,7 +194,7 @@ func findSpaceLastMessageFallback(
 		if err != nil || payloadMap == nil {
 			continue
 		}
-		if sid, ok := payloadMap["space_id"].(string); ok && sid == spaceID {
+		if dmSpaceMatch(dmMessageSpaceID(payloadMap), spaceID, defaultSpaceID) {
 			return msgRespToSyncResp(msg)
 		}
 	}
@@ -192,8 +221,9 @@ func msgRespToSyncResp(msg *config.MessageResp) *MsgSyncResp {
 	}
 }
 
-// countSpaceUnreadFromMessages 遍历消息列表，统计 seq > readSeq 且 payload.space_id == spaceID 的消息数。
-func countSpaceUnreadFromMessages(messages []*config.MessageResp, spaceID string, readSeq int64) int {
+// countSpaceUnreadFromMessages 遍历消息列表，统计 seq > readSeq 且归属 spaceID 的消息数
+// （归属判断含「无标签 = 默认 Space」约定，见 dmSpaceMatch）。
+func countSpaceUnreadFromMessages(messages []*config.MessageResp, spaceID, defaultSpaceID string, readSeq int64) int {
 	count := 0
 	for _, msg := range messages {
 		if int64(msg.MessageSeq) <= readSeq {
@@ -203,7 +233,7 @@ func countSpaceUnreadFromMessages(messages []*config.MessageResp, spaceID string
 		if err != nil || payloadMap == nil {
 			continue
 		}
-		if sid, ok := payloadMap["space_id"].(string); ok && sid == spaceID {
+		if dmSpaceMatch(dmMessageSpaceID(payloadMap), spaceID, defaultSpaceID) {
 			count++
 		}
 	}

--- a/modules/message/space_unread.go
+++ b/modules/message/space_unread.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"go.uber.org/zap"
 )
 
@@ -41,8 +42,12 @@ func fillPersonSpaceUnread(
 			continue
 		}
 
+		// 系统 Bot 的无标签历史在 filterPersonMessagesBySpace rule 4 里被隐藏，
+		// 预览/未读须同口径（见 dmSpaceMatch）。按频道身份判定一次即可。
+		isSysBot := spacepkg.IsSystemBot(conv.ChannelID)
+
 		// 从 Recents 中找该 Space 的最后一条消息作为预览
-		spaceLastMsg := findSpaceLastMessage(conv.Recents, spaceID, defaultSpaceID)
+		spaceLastMsg := findSpaceLastMessage(conv.Recents, spaceID, defaultSpaceID, isSysBot)
 		if spaceLastMsg != nil {
 			conv.SpaceLastMessage = spaceLastMsg
 		}
@@ -55,7 +60,7 @@ func fillPersonSpaceUnread(
 			if raw != nil && raw.LastMsgSeq > 0 {
 				fallbackMsg := findSpaceLastMessageFallback(
 					conv.ChannelID, conv.ChannelType,
-					loginUID, spaceID, defaultSpaceID, uint32(raw.LastMsgSeq), ctx,
+					loginUID, spaceID, defaultSpaceID, isSysBot, uint32(raw.LastMsgSeq), ctx,
 				)
 				if fallbackMsg != nil {
 					conv.SpaceLastMessage = fallbackMsg
@@ -105,7 +110,7 @@ func fillPersonSpaceUnread(
 			messages = resp.Messages
 		}
 
-		count := countSpaceUnreadFromMessages(messages, spaceID, defaultSpaceID, readSeq)
+		count := countSpaceUnreadFromMessages(messages, spaceID, defaultSpaceID, isSysBot, readSeq)
 		conv.SpaceUnread = &count
 	}
 }
@@ -123,26 +128,32 @@ func dmMessageSpaceID(payload map[string]interface{}) string {
 }
 
 // dmSpaceMatch 判断一条 space_id 为 msgSpaceID 的 DM 消息是否归属 targetSpaceID，
-// 遵循「无标签 = 默认 Space」约定：未打标（无 payload.space_id）的 DM 消息归属用户
-// 默认 Space。这与可见性兜底 (decideConvKeepInSpace) 和历史过滤
-// (filterPersonMessagesBySpace) 对未打标 DM 消息的处理保持一致。
-// defaultSpaceID == "" 时约定关闭（仅严格等值），非默认 Space 查询不受影响。
-func dmSpaceMatch(msgSpaceID, targetSpaceID, defaultSpaceID string) bool {
+// 与历史过滤 filterPersonMessagesBySpace 的 rule 2 / rule 4 逐条对齐：
+//   - msgSpaceID == targetSpaceID：显式打标，归属该 Space；
+//   - 未打标（msgSpaceID == ""）且 targetSpaceID 为默认 Space 且**非系统 Bot**：
+//     归属默认 Space（rule 2）；
+//   - 未打标且**是系统 Bot**：一律不归属（rule 4）—— 系统 Bot（botfather /
+//     fileHelper / notification / u_10000）的无标签历史在 /message/channel/sync
+//     里被隐藏，预览/未读必须同口径,否则默认 Space 会出现清不掉的幽灵未读 +
+//     历史里不存在的预览（PR #532 review by yujiawei/mochashanyao/OctoBoooot）。
+//
+// defaultSpaceID == "" 时兜底分支关闭（仅严格等值），非默认 Space 查询不受影响。
+func dmSpaceMatch(msgSpaceID, targetSpaceID, defaultSpaceID string, isSysBot bool) bool {
 	if msgSpaceID == targetSpaceID {
 		return true
 	}
-	return msgSpaceID == "" && targetSpaceID == defaultSpaceID
+	return !isSysBot && msgSpaceID == "" && targetSpaceID == defaultSpaceID
 }
 
 // findSpaceLastMessage 从 Recents 中倒序查找最后一条归属 spaceID 的消息。
 // 用于会话列表的消息预览，确保每个 Space 显示该 Space 的最后一条消息。
-func findSpaceLastMessage(recents []*MsgSyncResp, spaceID, defaultSpaceID string) *MsgSyncResp {
+func findSpaceLastMessage(recents []*MsgSyncResp, spaceID, defaultSpaceID string, isSysBot bool) *MsgSyncResp {
 	for i := len(recents) - 1; i >= 0; i-- {
 		msg := recents[i]
 		if msg.Payload == nil {
 			continue
 		}
-		if dmSpaceMatch(dmMessageSpaceID(msg.Payload), spaceID, defaultSpaceID) {
+		if dmSpaceMatch(dmMessageSpaceID(msg.Payload), spaceID, defaultSpaceID, isSysBot) {
 			return msg
 		}
 	}
@@ -154,7 +165,7 @@ func findSpaceLastMessage(recents []*MsgSyncResp, spaceID, defaultSpaceID string
 func findSpaceLastMessageFallback(
 	channelID string, channelType uint8,
 	loginUID string, spaceID, defaultSpaceID string,
-	lastMsgSeq uint32, ctx *config.Context,
+	isSysBot bool, lastMsgSeq uint32, ctx *config.Context,
 ) *MsgSyncResp {
 	if lastMsgSeq == 0 {
 		return nil
@@ -194,7 +205,7 @@ func findSpaceLastMessageFallback(
 		if err != nil || payloadMap == nil {
 			continue
 		}
-		if dmSpaceMatch(dmMessageSpaceID(payloadMap), spaceID, defaultSpaceID) {
+		if dmSpaceMatch(dmMessageSpaceID(payloadMap), spaceID, defaultSpaceID, isSysBot) {
 			return msgRespToSyncResp(msg)
 		}
 	}
@@ -222,8 +233,8 @@ func msgRespToSyncResp(msg *config.MessageResp) *MsgSyncResp {
 }
 
 // countSpaceUnreadFromMessages 遍历消息列表，统计 seq > readSeq 且归属 spaceID 的消息数
-// （归属判断含「无标签 = 默认 Space」约定，见 dmSpaceMatch）。
-func countSpaceUnreadFromMessages(messages []*config.MessageResp, spaceID, defaultSpaceID string, readSeq int64) int {
+// （归属判断含「无标签 = 默认 Space」约定 + 系统 Bot 例外，见 dmSpaceMatch）。
+func countSpaceUnreadFromMessages(messages []*config.MessageResp, spaceID, defaultSpaceID string, isSysBot bool, readSeq int64) int {
 	count := 0
 	for _, msg := range messages {
 		if int64(msg.MessageSeq) <= readSeq {
@@ -233,7 +244,7 @@ func countSpaceUnreadFromMessages(messages []*config.MessageResp, spaceID, defau
 		if err != nil || payloadMap == nil {
 			continue
 		}
-		if dmSpaceMatch(dmMessageSpaceID(payloadMap), spaceID, defaultSpaceID) {
+		if dmSpaceMatch(dmMessageSpaceID(payloadMap), spaceID, defaultSpaceID, isSysBot) {
 			count++
 		}
 	}

--- a/modules/message/space_unread_test.go
+++ b/modules/message/space_unread_test.go
@@ -34,10 +34,10 @@ func TestCountSpaceUnreadFromMessages_Basic(t *testing.T) {
 	}
 
 	// readSeq=0 → 所有消息都是未读
-	count := countSpaceUnreadFromMessages(messages, "spaceA", "", 0)
+	count := countSpaceUnreadFromMessages(messages, "spaceA", "", false, 0)
 	assert.Equal(t, 3, count)
 
-	count = countSpaceUnreadFromMessages(messages, "spaceB", "", 0)
+	count = countSpaceUnreadFromMessages(messages, "spaceB", "", false, 0)
 	assert.Equal(t, 1, count)
 }
 
@@ -51,7 +51,7 @@ func TestCountSpaceUnreadFromMessages_ReadSeqFilters(t *testing.T) {
 	}
 
 	// readSeq=3 → 只有 seq 4,5 是未读
-	count := countSpaceUnreadFromMessages(messages, "spaceA", "", 3)
+	count := countSpaceUnreadFromMessages(messages, "spaceA", "", false, 3)
 	assert.Equal(t, 2, count)
 }
 
@@ -63,15 +63,15 @@ func TestCountSpaceUnreadFromMessages_NoSpaceID(t *testing.T) {
 		makeMessageResp(3, ""),
 	}
 
-	count := countSpaceUnreadFromMessages(messages, "spaceA", "", 0)
+	count := countSpaceUnreadFromMessages(messages, "spaceA", "", false, 0)
 	assert.Equal(t, 0, count)
 }
 
 func TestCountSpaceUnreadFromMessages_EmptyMessages(t *testing.T) {
-	count := countSpaceUnreadFromMessages(nil, "spaceA", "", 0)
+	count := countSpaceUnreadFromMessages(nil, "spaceA", "", false, 0)
 	assert.Equal(t, 0, count)
 
-	count = countSpaceUnreadFromMessages([]*config.MessageResp{}, "spaceA", "", 0)
+	count = countSpaceUnreadFromMessages([]*config.MessageResp{}, "spaceA", "", false, 0)
 	assert.Equal(t, 0, count)
 }
 
@@ -82,7 +82,7 @@ func TestCountSpaceUnreadFromMessages_InvalidPayload(t *testing.T) {
 		makeMessageResp(3, "spaceA"), // 有效消息
 	}
 
-	count := countSpaceUnreadFromMessages(messages, "spaceA", "", 0)
+	count := countSpaceUnreadFromMessages(messages, "spaceA", "", false, 0)
 	assert.Equal(t, 1, count)
 }
 
@@ -98,10 +98,10 @@ func TestCountSpaceUnreadFromMessages_MixedSpaces(t *testing.T) {
 	}
 
 	// readSeq=12 → 未读: seq 13(spaceB), 14(none), 15(spaceA)
-	count := countSpaceUnreadFromMessages(messages, "spaceA", "", 12)
+	count := countSpaceUnreadFromMessages(messages, "spaceA", "", false, 12)
 	assert.Equal(t, 1, count)
 
-	count = countSpaceUnreadFromMessages(messages, "spaceB", "", 12)
+	count = countSpaceUnreadFromMessages(messages, "spaceB", "", false, 12)
 	assert.Equal(t, 1, count)
 }
 
@@ -218,23 +218,23 @@ func TestFindSpaceLastMessage_Basic(t *testing.T) {
 	}
 
 	// spaceA 的最后一条是 seq=3
-	result := findSpaceLastMessage(recents, "spaceA", "")
+	result := findSpaceLastMessage(recents, "spaceA", "", false)
 	assert.NotNil(t, result)
 	assert.Equal(t, uint32(3), result.MessageSeq)
 
 	// spaceB 的最后一条是 seq=2
-	result = findSpaceLastMessage(recents, "spaceB", "")
+	result = findSpaceLastMessage(recents, "spaceB", "", false)
 	assert.NotNil(t, result)
 	assert.Equal(t, uint32(2), result.MessageSeq)
 
 	// spaceC 没有消息
-	result = findSpaceLastMessage(recents, "spaceC", "")
+	result = findSpaceLastMessage(recents, "spaceC", "", false)
 	assert.Nil(t, result)
 }
 
 func TestFindSpaceLastMessage_EmptyRecents(t *testing.T) {
-	assert.Nil(t, findSpaceLastMessage(nil, "spaceA", ""))
-	assert.Nil(t, findSpaceLastMessage([]*MsgSyncResp{}, "spaceA", ""))
+	assert.Nil(t, findSpaceLastMessage(nil, "spaceA", "", false))
+	assert.Nil(t, findSpaceLastMessage([]*MsgSyncResp{}, "spaceA", "", false))
 }
 
 func TestFindSpaceLastMessage_NilPayload(t *testing.T) {
@@ -242,7 +242,7 @@ func TestFindSpaceLastMessage_NilPayload(t *testing.T) {
 		{MessageSeq: 1, Payload: nil},
 		{MessageSeq: 2, Payload: map[string]interface{}{"content": "no space"}},
 	}
-	assert.Nil(t, findSpaceLastMessage(recents, "spaceA", ""))
+	assert.Nil(t, findSpaceLastMessage(recents, "spaceA", "", false))
 }
 
 // TestFindSpaceLastMessage_DefaultSpaceMatchesUntagged locks the fix: when the
@@ -256,19 +256,19 @@ func TestFindSpaceLastMessage_DefaultSpaceMatchesUntagged(t *testing.T) {
 	}
 
 	// Default-Space query: the untagged message belongs to the default Space.
-	got := findSpaceLastMessage(recents, "spaceDefault", "spaceDefault")
+	got := findSpaceLastMessage(recents, "spaceDefault", "spaceDefault", false)
 	assert.NotNil(t, got)
 	assert.Equal(t, uint32(1), got.MessageSeq)
 	assert.Equal(t, "default-hello", got.Payload["content"])
 
 	// Non-default query still returns only its explicitly-tagged message; the
 	// untagged (default) message must NOT leak into a non-default Space.
-	got = findSpaceLastMessage(recents, "spaceB", "spaceDefault")
+	got = findSpaceLastMessage(recents, "spaceB", "spaceDefault", false)
 	assert.NotNil(t, got)
 	assert.Equal(t, uint32(2), got.MessageSeq)
 
 	// A non-default Space with no tagged message here stays empty.
-	assert.Nil(t, findSpaceLastMessage(recents, "spaceC", "spaceDefault"))
+	assert.Nil(t, findSpaceLastMessage(recents, "spaceC", "spaceDefault", false))
 }
 
 // TestCountSpaceUnread_DefaultSpaceCountsUntagged: the same untagged=default rule
@@ -282,9 +282,46 @@ func TestCountSpaceUnread_DefaultSpaceCountsUntagged(t *testing.T) {
 	}
 
 	// Default Space counts the two untagged messages (not the spaceB ones).
-	assert.Equal(t, 2, countSpaceUnreadFromMessages(messages, "spaceDefault", "spaceDefault", 0))
+	assert.Equal(t, 2, countSpaceUnreadFromMessages(messages, "spaceDefault", "spaceDefault", false, 0))
 	// Non-default Space counts only its own tagged messages; untagged excluded.
-	assert.Equal(t, 2, countSpaceUnreadFromMessages(messages, "spaceB", "spaceDefault", 0))
+	assert.Equal(t, 2, countSpaceUnreadFromMessages(messages, "spaceB", "spaceDefault", false, 0))
+}
+
+// TestFillPersonSpaceUnread_SystemBotUntaggedExcluded is the P1 regression guard
+// (PR #532 review by yujiawei/mochashanyao/Jerry-Xin/OctoBoooot): for a system-bot
+// DM (resolved from conv.ChannelID via spacepkg.IsSystemBot), untagged messages must
+// NOT become the default-Space preview or count toward default-Space unread —
+// mirroring filterPersonMessagesBySpace rule 4. A regular DM with the same untagged
+// messages still gets them.
+func TestFillPersonSpaceUnread_SystemBotUntaggedExcluded(t *testing.T) {
+	const def = "spaceDefault"
+	mkConv := func(channelID string) ([]*SyncUserConversationResp, []*config.SyncUserConversationResp) {
+		return []*SyncUserConversationResp{{
+				ChannelID: channelID, ChannelType: common.ChannelTypePerson.Uint8(), Unread: 2,
+				Recents: []*MsgSyncResp{
+					{MessageSeq: 1, Payload: map[string]interface{}{"content": "a"}}, // untagged
+					{MessageSeq: 2, Payload: map[string]interface{}{"content": "b"}}, // untagged
+				},
+			}},
+			[]*config.SyncUserConversationResp{{
+				ChannelID: channelID, ChannelType: common.ChannelTypePerson.Uint8(), Unread: 2, LastMsgSeq: 2,
+				Recents: []*config.MessageResp{makeMessageResp(1, ""), makeMessageResp(2, "")},
+			}}
+	}
+
+	// System bot ("botfather"): untagged excluded from default-Space preview + unread.
+	botConvs, botRaw := mkConv("botfather")
+	fillPersonSpaceUnread(botConvs, botRaw, def, def, "login", nil)
+	assert.Nil(t, botConvs[0].SpaceLastMessage, "system-bot untagged → no default-space preview")
+	assert.NotNil(t, botConvs[0].SpaceUnread)
+	assert.Equal(t, 0, *botConvs[0].SpaceUnread, "system-bot untagged → 0 default-space unread")
+
+	// Regular DM: the same untagged messages DO belong to the default Space.
+	regConvs, regRaw := mkConv("regular-peer")
+	fillPersonSpaceUnread(regConvs, regRaw, def, def, "login", nil)
+	assert.NotNil(t, regConvs[0].SpaceLastMessage, "regular DM untagged → default-space preview")
+	assert.NotNil(t, regConvs[0].SpaceUnread)
+	assert.Equal(t, 2, *regConvs[0].SpaceUnread, "regular DM untagged → counted as default-space unread")
 }
 
 func TestFillPersonSpaceUnread_SetsSpaceLastMessage(t *testing.T) {

--- a/modules/message/space_unread_test.go
+++ b/modules/message/space_unread_test.go
@@ -29,15 +29,15 @@ func TestCountSpaceUnreadFromMessages_Basic(t *testing.T) {
 		makeMessageResp(1, "spaceA"),
 		makeMessageResp(2, "spaceB"),
 		makeMessageResp(3, "spaceA"),
-		makeMessageResp(4, ""),       // 无 space_id
+		makeMessageResp(4, ""), // 无 space_id
 		makeMessageResp(5, "spaceA"),
 	}
 
 	// readSeq=0 → 所有消息都是未读
-	count := countSpaceUnreadFromMessages(messages, "spaceA", 0)
+	count := countSpaceUnreadFromMessages(messages, "spaceA", "", 0)
 	assert.Equal(t, 3, count)
 
-	count = countSpaceUnreadFromMessages(messages, "spaceB", 0)
+	count = countSpaceUnreadFromMessages(messages, "spaceB", "", 0)
 	assert.Equal(t, 1, count)
 }
 
@@ -51,7 +51,7 @@ func TestCountSpaceUnreadFromMessages_ReadSeqFilters(t *testing.T) {
 	}
 
 	// readSeq=3 → 只有 seq 4,5 是未读
-	count := countSpaceUnreadFromMessages(messages, "spaceA", 3)
+	count := countSpaceUnreadFromMessages(messages, "spaceA", "", 3)
 	assert.Equal(t, 2, count)
 }
 
@@ -63,15 +63,15 @@ func TestCountSpaceUnreadFromMessages_NoSpaceID(t *testing.T) {
 		makeMessageResp(3, ""),
 	}
 
-	count := countSpaceUnreadFromMessages(messages, "spaceA", 0)
+	count := countSpaceUnreadFromMessages(messages, "spaceA", "", 0)
 	assert.Equal(t, 0, count)
 }
 
 func TestCountSpaceUnreadFromMessages_EmptyMessages(t *testing.T) {
-	count := countSpaceUnreadFromMessages(nil, "spaceA", 0)
+	count := countSpaceUnreadFromMessages(nil, "spaceA", "", 0)
 	assert.Equal(t, 0, count)
 
-	count = countSpaceUnreadFromMessages([]*config.MessageResp{}, "spaceA", 0)
+	count = countSpaceUnreadFromMessages([]*config.MessageResp{}, "spaceA", "", 0)
 	assert.Equal(t, 0, count)
 }
 
@@ -82,7 +82,7 @@ func TestCountSpaceUnreadFromMessages_InvalidPayload(t *testing.T) {
 		makeMessageResp(3, "spaceA"), // 有效消息
 	}
 
-	count := countSpaceUnreadFromMessages(messages, "spaceA", 0)
+	count := countSpaceUnreadFromMessages(messages, "spaceA", "", 0)
 	assert.Equal(t, 1, count)
 }
 
@@ -93,15 +93,15 @@ func TestCountSpaceUnreadFromMessages_MixedSpaces(t *testing.T) {
 		makeMessageResp(11, "spaceB"),
 		makeMessageResp(12, "spaceA"),
 		makeMessageResp(13, "spaceB"),
-		makeMessageResp(14, ""),       // 无 space_id 的老消息
+		makeMessageResp(14, ""), // 无 space_id 的老消息
 		makeMessageResp(15, "spaceA"),
 	}
 
 	// readSeq=12 → 未读: seq 13(spaceB), 14(none), 15(spaceA)
-	count := countSpaceUnreadFromMessages(messages, "spaceA", 12)
+	count := countSpaceUnreadFromMessages(messages, "spaceA", "", 12)
 	assert.Equal(t, 1, count)
 
-	count = countSpaceUnreadFromMessages(messages, "spaceB", 12)
+	count = countSpaceUnreadFromMessages(messages, "spaceB", "", 12)
 	assert.Equal(t, 1, count)
 }
 
@@ -123,7 +123,7 @@ func TestFillPersonSpaceUnread_OnlyPersonChannels(t *testing.T) {
 		},
 	}
 
-	fillPersonSpaceUnread(convs, rawConvs, "spaceA", "me", nil)
+	fillPersonSpaceUnread(convs, rawConvs, "spaceA", "", "me", nil)
 
 	// Group 不应有 space_unread
 	assert.Nil(t, convs[0].SpaceUnread)
@@ -140,7 +140,7 @@ func TestFillPersonSpaceUnread_ZeroUnread(t *testing.T) {
 		{ChannelID: "user1", ChannelType: common.ChannelTypePerson.Uint8(), Unread: 0, LastMsgSeq: 10},
 	}
 
-	fillPersonSpaceUnread(convs, rawConvs, "spaceA", "me", nil)
+	fillPersonSpaceUnread(convs, rawConvs, "spaceA", "", "me", nil)
 	assert.Nil(t, convs[0].SpaceUnread)
 }
 
@@ -149,7 +149,7 @@ func TestFillPersonSpaceUnread_EmptySpaceID(t *testing.T) {
 		{ChannelID: "user1", ChannelType: common.ChannelTypePerson.Uint8(), Unread: 3},
 	}
 
-	fillPersonSpaceUnread(convs, nil, "", "me", nil)
+	fillPersonSpaceUnread(convs, nil, "", "", "me", nil)
 	assert.Nil(t, convs[0].SpaceUnread)
 }
 
@@ -173,7 +173,7 @@ func TestFillPersonSpaceUnread_RecentsCoversAllUnread(t *testing.T) {
 	}
 
 	// readSeq = 20 - 3 = 17, 未读: seq 18(A), 19(B), 20(A) → spaceA=2
-	fillPersonSpaceUnread(convs, rawConvs, "spaceA", "me", nil)
+	fillPersonSpaceUnread(convs, rawConvs, "spaceA", "", "me", nil)
 	assert.NotNil(t, convs[0].SpaceUnread)
 	assert.Equal(t, 2, *convs[0].SpaceUnread)
 }
@@ -194,7 +194,7 @@ func TestFillPersonSpaceUnread_AllUnreadInDifferentSpace(t *testing.T) {
 	}
 
 	// readSeq = 5 - 2 = 3, 未读 seq 4(B) 5(B) → spaceA=0
-	fillPersonSpaceUnread(convs, rawConvs, "spaceA", "me", nil)
+	fillPersonSpaceUnread(convs, rawConvs, "spaceA", "", "me", nil)
 	assert.NotNil(t, convs[0].SpaceUnread)
 	assert.Equal(t, 0, *convs[0].SpaceUnread)
 }
@@ -206,7 +206,7 @@ func TestFillPersonSpaceUnread_NoRawConversation(t *testing.T) {
 	}
 	rawConvs := []*config.SyncUserConversationResp{}
 
-	fillPersonSpaceUnread(convs, rawConvs, "spaceA", "me", nil)
+	fillPersonSpaceUnread(convs, rawConvs, "spaceA", "", "me", nil)
 	assert.Nil(t, convs[0].SpaceUnread)
 }
 
@@ -218,23 +218,23 @@ func TestFindSpaceLastMessage_Basic(t *testing.T) {
 	}
 
 	// spaceA 的最后一条是 seq=3
-	result := findSpaceLastMessage(recents, "spaceA")
+	result := findSpaceLastMessage(recents, "spaceA", "")
 	assert.NotNil(t, result)
 	assert.Equal(t, uint32(3), result.MessageSeq)
 
 	// spaceB 的最后一条是 seq=2
-	result = findSpaceLastMessage(recents, "spaceB")
+	result = findSpaceLastMessage(recents, "spaceB", "")
 	assert.NotNil(t, result)
 	assert.Equal(t, uint32(2), result.MessageSeq)
 
 	// spaceC 没有消息
-	result = findSpaceLastMessage(recents, "spaceC")
+	result = findSpaceLastMessage(recents, "spaceC", "")
 	assert.Nil(t, result)
 }
 
 func TestFindSpaceLastMessage_EmptyRecents(t *testing.T) {
-	assert.Nil(t, findSpaceLastMessage(nil, "spaceA"))
-	assert.Nil(t, findSpaceLastMessage([]*MsgSyncResp{}, "spaceA"))
+	assert.Nil(t, findSpaceLastMessage(nil, "spaceA", ""))
+	assert.Nil(t, findSpaceLastMessage([]*MsgSyncResp{}, "spaceA", ""))
 }
 
 func TestFindSpaceLastMessage_NilPayload(t *testing.T) {
@@ -242,7 +242,49 @@ func TestFindSpaceLastMessage_NilPayload(t *testing.T) {
 		{MessageSeq: 1, Payload: nil},
 		{MessageSeq: 2, Payload: map[string]interface{}{"content": "no space"}},
 	}
-	assert.Nil(t, findSpaceLastMessage(recents, "spaceA"))
+	assert.Nil(t, findSpaceLastMessage(recents, "spaceA", ""))
+}
+
+// TestFindSpaceLastMessage_DefaultSpaceMatchesUntagged locks the fix: when the
+// queried Space IS the default Space, an untagged DM message (no payload.space_id)
+// counts as a default-Space message, so the preview resolves to it instead of
+// leaking the channel's global-last message from another Space.
+func TestFindSpaceLastMessage_DefaultSpaceMatchesUntagged(t *testing.T) {
+	recents := []*MsgSyncResp{
+		{MessageSeq: 1, Payload: map[string]interface{}{"content": "default-hello"}},              // untagged
+		{MessageSeq: 2, Payload: map[string]interface{}{"content": "1111", "space_id": "spaceB"}}, // non-default, globally-latest
+	}
+
+	// Default-Space query: the untagged message belongs to the default Space.
+	got := findSpaceLastMessage(recents, "spaceDefault", "spaceDefault")
+	assert.NotNil(t, got)
+	assert.Equal(t, uint32(1), got.MessageSeq)
+	assert.Equal(t, "default-hello", got.Payload["content"])
+
+	// Non-default query still returns only its explicitly-tagged message; the
+	// untagged (default) message must NOT leak into a non-default Space.
+	got = findSpaceLastMessage(recents, "spaceB", "spaceDefault")
+	assert.NotNil(t, got)
+	assert.Equal(t, uint32(2), got.MessageSeq)
+
+	// A non-default Space with no tagged message here stays empty.
+	assert.Nil(t, findSpaceLastMessage(recents, "spaceC", "spaceDefault"))
+}
+
+// TestCountSpaceUnread_DefaultSpaceCountsUntagged: the same untagged=default rule
+// applies to per-Space unread counting.
+func TestCountSpaceUnread_DefaultSpaceCountsUntagged(t *testing.T) {
+	messages := []*config.MessageResp{
+		makeMessageResp(1, ""), // untagged → default
+		makeMessageResp(2, "spaceB"),
+		makeMessageResp(3, ""), // untagged → default
+		makeMessageResp(4, "spaceB"),
+	}
+
+	// Default Space counts the two untagged messages (not the spaceB ones).
+	assert.Equal(t, 2, countSpaceUnreadFromMessages(messages, "spaceDefault", "spaceDefault", 0))
+	// Non-default Space counts only its own tagged messages; untagged excluded.
+	assert.Equal(t, 2, countSpaceUnreadFromMessages(messages, "spaceB", "spaceDefault", 0))
 }
 
 func TestFillPersonSpaceUnread_SetsSpaceLastMessage(t *testing.T) {
@@ -258,7 +300,7 @@ func TestFillPersonSpaceUnread_SetsSpaceLastMessage(t *testing.T) {
 		},
 	}
 
-	fillPersonSpaceUnread(convs, nil, "spaceA", "login", nil)
+	fillPersonSpaceUnread(convs, nil, "spaceA", "", "login", nil)
 
 	// SpaceLastMessage 应为 spaceA 的消息 "111"
 	assert.NotNil(t, convs[0].SpaceLastMessage)


### PR DESCRIPTION
## Summary

The DM conversation-list preview (`space_last_message`) and per-Space unread count were computed by matching `payload.space_id == filterSpaceID` **strictly**. DM messages sent in the **default Space carry no `payload.space_id`** (untagged), so a **default-Space** `POST /v1/conversation/sync?space_id=<default>` matched nothing:

- `space_last_message` came back `nil` → the client fell back to `recents[last]` = the channel's **global-last** message, which is tagged for **another Space** → the preview leaked a wrong-Space message.
- per-Space unread likewise **under-counted** the default Space (untagged messages were skipped).

A non-default-Space query was already correct (its messages are explicitly tagged).

## Related Issue

Related to #484. This preview/unread logic (`modules/message/space_unread.go`) is **pre-existing** and is not touched by the #484 isolation revert (#529) — the defect exists independently of #519.

## Linked Spec

Issue #484 (DM per-Space isolation). This PR fixes one specific, self-contained facet (the default-Space preview/unread attribution) and can land independently of the broader isolation redesign.

## Changes

- Add `dmSpaceMatch(msgSpaceID, targetSpaceID, defaultSpaceID)` implementing the **"untagged = default Space"** convention: an untagged DM message (no `payload.space_id`) belongs to the user's default Space. This aligns the preview/unread with the visibility catch-all (`decideConvKeepInSpace`) and the message-history filter (`filterPersonMessagesBySpace`), which already treat untagged DM content as default-Space content.
- Thread `defaultSpaceID` through `fillPersonSpaceUnread` → `findSpaceLastMessage` / `findSpaceLastMessageFallback` / `countSpaceUnreadFromMessages`.
- Pass the already-resolved `defaultSpaceID` (from `GetUserDefaultSpaceIDE`) at the `/v1/conversation/sync` call site.
- **Isolation preserved:** non-default-Space queries stay strict (untagged never leaks into a non-default Space); the convention is disabled when `defaultSpaceID == ""` (falls back to prior strict behavior).
- Tests: unit (`space_unread_test.go`) + an end-to-end integration test driving the real handler through `POST /v1/conversation/sync?space_id=` (`dm_space_last_message_repro_test.go`).

## Testing

```
# unit (default build)
go test ./modules/message/ -run 'SpaceUnread|FindSpaceLastMessage|CountSpaceUnread|FillPersonSpaceUnread|DefaultSpace' -count=1
# ok — 27 tests pass (existing preserved + new default-Space cases)

# integration end-to-end (MySQL + Redis + WuKongIM)
go test -tags=integration ./modules/message/ -run 'TestFix_' -count=1
# ok — default-Space query now returns the untagged message as space_last_message
#      (content set, no space_id); non-default query still returns only its tagged message
```

- [x] Unit tests added/updated
- [x] Manually verified (end-to-end via the real `/v1/conversation/sync` route)

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?
   On the `/v1/conversation/sync` Space-filter path, `space_last_message` and `SpaceUnread` for Person (DM) channels now attribute an **untagged** DM message to the **default Space**. So a default-Space query resolves its preview to the last untagged (default) message instead of the channel's global-last message, and counts untagged messages toward default-Space unread. Non-default-Space attribution is unchanged.

2. **What could break** because of it (dependents + failure mode)?
   Scope is limited to the default-Space DM preview/unread. Only caller is the conversation-sync handler. Risk would be mis-attributing a message to the wrong Space's preview if `defaultSpaceID` were wrong — mitigated two ways: `defaultSpaceID` comes from the same `GetUserDefaultSpaceIDE` the handler already fail-closes on (500 on DB error), and an empty `defaultSpaceID` disables the convention entirely (identical to prior strict behavior). Non-default Spaces cannot start showing untagged content (the second `dmSpaceMatch` branch requires `targetSpaceID == defaultSpaceID`).

3. **How do you know it works** (specific test/repro/trace)?
   Pure-function unit tests (`TestFindSpaceLastMessage_DefaultSpaceMatchesUntagged`, `TestCountSpaceUnread_DefaultSpaceCountsUntagged`) plus an end-to-end integration test (`TestFix_SpaceLastMessage_DefaultSpaceUsesUntagged`) that drives the real handler through `POST /v1/conversation/sync?space_id=` and asserts: default-Space query → `space_last_message` = the untagged default message (content present, no `space_id`); non-default query → only its explicitly-tagged message, untagged content never leaks in. The same file first captured the pre-fix behavior (nil preview → wrong-Space fallback) and was flipped to a post-fix regression guard.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation (n/a — no doc surface)
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmFRUBSc2x7kpDaLs3Gyco)_