### PR TITLE
feat: add sticker collect endpoint

### DIFF
--- a/.octospec/tasks/sticker-collect/brief.md
+++ b/.octospec/tasks/sticker-collect/brief.md
@@ -1,0 +1,53 @@
+---
+type: Task
+title: "Task: sticker-collect"
+description: Add a server-side endpoint for collecting sticker-message paths into a user's custom sticker list.
+tags: ["sticker", "api", "database", "quota"]
+timestamp: 2026-07-03T00:00:00Z
+# --- octospec extension fields ---
+slug: sticker-collect
+upstream: "manual"
+source: self
+---
+
+# Task: sticker-collect
+
+## Goal
+Add `POST /v1/sticker/user/collect` so a client can add a sticker from an
+existing sticker message into the caller's personal sticker list without
+re-uploading the file.
+
+## Background
+The existing `POST /v1/sticker/user` endpoint is intentionally upload-oriented:
+it only accepts the caller's own `sticker/{uid}/...` path and may require an
+upload handle. Sticker-message collection has a different source: a sticker path
+already present in a message payload, often under another user's UID segment.
+
+This first version stores a reference to the source sticker object instead of
+copying bytes into the collecting user's directory. The current file service
+does not expose a storage-backend-neutral object-copy abstraction across
+MinIO/S3/COS/OSS/Qiniu.
+
+## Load-bearing list
+- Authenticated `/v1/sticker` routes keep `AuthMiddleware` and shared UID rate limiting.
+- Per-user quota still uses `sticker.user_max_count` and the existing user-row lock.
+- Repeated collection of the same source path by the same UID is idempotent.
+- Only reserved `sticker/{source_uid}/{file}.{gif|png|jpg|jpeg|webp}` paths are accepted.
+- `sticker.handle_required` remains an upload-registration policy for `POST /v1/sticker/user`; collect intentionally has no handle parameter.
+
+## Out of scope
+- Verifying that the caller can read the exact source message that carried the sticker path.
+- Server-side object copy or reference counting.
+- Object existence HEAD/check before insert.
+- Garbage collection semantics for collected references.
+
+## Known Trade-Offs
+- Because collect stores a reference, future object-store GC or source-user cleanup could create dangling collected stickers unless reference counting or copy-on-collect is added.
+- Source sticker deletion currently soft-deletes only DB rows and does not delete the object; collected references depend on that retention behavior.
+- Path-only source validation does not prove message access. A follow-up API can accept message identity and derive the sticker path server-side.
+
+## Acceptance
+- Same source path collected twice by the same user returns the existing sticker and does not consume quota twice.
+- Soft-deleting a collected sticker releases the live idempotency slot and allows re-collecting it.
+- Invalid/non-sticker paths are rejected through the localized sticker error envelope.
+- Collect success, idempotent hit, invalid path, quota, query, and store outcomes are observable through low-cardinality metrics.

--- a/modules/sticker/api.go
+++ b/modules/sticker/api.go
@@ -339,28 +339,40 @@ func (s *Sticker) add(ctx *wkhttp.Context) {
 // caller; it must still point at the reserved sticker object keyspace. The
 // stored path is a stable authenticated preview URL for that source object, and
 // SourcePathHash makes repeat taps idempotent without charging quota again.
+//
+// collect intentionally does not require the upload handle even when
+// sticker.handle_required=true: the endpoint is for a sticker URL already
+// carried in a message, and the only accepted source is the reserved sticker/
+// keyspace that file upload protects from non-sticker writes. With the current
+// path-only contract this is a collect-specific trust boundary, not a general
+// replacement for add()'s same-user upload-handle proof.
 func (s *Sticker) collect(ctx *wkhttp.Context) {
 	loginUID := ctx.GetLoginUID()
 
 	var req collectStickerReq
 	if err := ctx.BindJSON(&req); err != nil {
+		observeStickerCollect("validation_failed")
 		respondStickerRequestInvalid(ctx, "")
 		return
 	}
 	if req.Path == "" {
+		observeStickerCollect("path_invalid")
 		respondStickerRequestInvalid(ctx, "path")
 		return
 	}
 	if len(req.Path) > maxStickerCollectPathLen {
+		observeStickerCollect("path_invalid")
 		respondStickerRequestInvalid(ctx, "path")
 		return
 	}
 	source, ok := parseCollectStickerSourcePath(req.Path)
 	if !ok {
+		observeStickerCollect("path_invalid")
 		respondStickerRequestInvalid(ctx, "path")
 		return
 	}
 	if len(source.DisplayPath) > maxStickerPathLen || len(source.SourceKey) > maxStickerPathLen {
+		observeStickerCollect("path_invalid")
 		respondStickerRequestInvalid(ctx, "path")
 		return
 	}
@@ -369,20 +381,24 @@ func (s *Sticker) collect(ctx *wkhttp.Context) {
 		placeholder = defaultStickerPlaceholder
 	}
 	if len([]rune(placeholder)) > maxStickerPlaceholderLen {
+		observeStickerCollect("validation_failed")
 		respondStickerRequestInvalid(ctx, "placeholder")
 		return
 	}
 	if req.Sort < 0 {
+		observeStickerCollect("validation_failed")
 		respondStickerRequestInvalid(ctx, "sort")
 		return
 	}
 	shortcode, ok := normalizeStickerShortcode(req.Shortcode)
 	if !ok {
+		observeStickerCollect("validation_failed")
 		respondStickerShortcodeInvalid(ctx)
 		return
 	}
 	keywordsStore, _, ok := normalizeStickerKeywords(req.Keywords)
 	if !ok {
+		observeStickerCollect("validation_failed")
 		respondStickerKeywordsInvalid(ctx)
 		return
 	}
@@ -393,6 +409,7 @@ func (s *Sticker) collect(ctx *wkhttp.Context) {
 	tx, err := s.ctx.DB().Begin()
 	if err != nil {
 		s.Error("开启事务失败", zap.Error(err))
+		observeStickerCollect("store_failed")
 		httperr.ResponseErrorL(ctx, errcode.ErrStickerStoreFailed, nil, nil)
 		return
 	}
@@ -400,6 +417,7 @@ func (s *Sticker) collect(ctx *wkhttp.Context) {
 
 	if err := s.db.lockUserRowTx(tx, loginUID); err != nil {
 		s.Error("锁定用户行失败", zap.Error(err))
+		observeStickerCollect("store_failed")
 		httperr.ResponseErrorL(ctx, errcode.ErrStickerStoreFailed, nil, nil)
 		return
 	}
@@ -407,23 +425,18 @@ func (s *Sticker) collect(ctx *wkhttp.Context) {
 	existing, err := s.db.queryByUIDAndSourcePathHashTx(tx, loginUID, sourceHash)
 	if err != nil {
 		s.Error("查询已收藏贴纸失败", zap.Error(err), zap.String("uid", loginUID))
+		observeStickerCollect("query_failed")
 		httperr.ResponseErrorL(ctx, errcode.ErrStickerQueryFailed, nil, nil)
 		return
-	}
-	if existing == nil {
-		existing, err = s.db.queryByUIDAndPathTx(tx, loginUID, source.DisplayPath)
-		if err != nil {
-			s.Error("按 path 查询已收藏贴纸失败", zap.Error(err), zap.String("uid", loginUID))
-			httperr.ResponseErrorL(ctx, errcode.ErrStickerQueryFailed, nil, nil)
-			return
-		}
 	}
 	if existing != nil {
 		if err := tx.Commit(); err != nil {
 			s.Error("提交事务失败", zap.Error(err))
+			observeStickerCollect("store_failed")
 			httperr.ResponseErrorL(ctx, errcode.ErrStickerStoreFailed, nil, nil)
 			return
 		}
+		observeStickerCollect("idempotent_hit")
 		ctx.Response(toStickerResp(existing))
 		return
 	}
@@ -431,20 +444,24 @@ func (s *Sticker) collect(ctx *wkhttp.Context) {
 	count, err := s.db.countByUIDTx(tx, loginUID)
 	if err != nil {
 		s.Error("查询贴纸数量失败", zap.Error(err))
+		observeStickerCollect("query_failed")
 		httperr.ResponseErrorL(ctx, errcode.ErrStickerQueryFailed, nil, nil)
 		return
 	}
 	if count >= max {
+		observeStickerCollect("quota_exceeded")
 		respondStickerQuotaExceeded(ctx, max)
 		return
 	}
 	conflict, err := s.db.shortcodeExistsTx(tx, loginUID, shortcode, "")
 	if err != nil {
 		s.Error("查询贴纸 shortcode 冲突失败", zap.Error(err), zap.String("uid", loginUID))
+		observeStickerCollect("query_failed")
 		httperr.ResponseErrorL(ctx, errcode.ErrStickerQueryFailed, nil, nil)
 		return
 	}
 	if conflict {
+		observeStickerCollect("shortcode_conflict")
 		respondStickerShortcodeConflict(ctx)
 		return
 	}
@@ -464,15 +481,18 @@ func (s *Sticker) collect(ctx *wkhttp.Context) {
 	}
 	if err := s.db.insertTx(tx, m); err != nil {
 		s.Error("收藏贴纸失败", zap.Error(err), zap.String("uid", loginUID), zap.String("source_path", source.SourceKey))
+		observeStickerCollect("store_failed")
 		httperr.ResponseErrorL(ctx, errcode.ErrStickerStoreFailed, nil, nil)
 		return
 	}
 	if err := tx.Commit(); err != nil {
 		s.Error("提交事务失败", zap.Error(err))
+		observeStickerCollect("store_failed")
 		httperr.ResponseErrorL(ctx, errcode.ErrStickerStoreFailed, nil, nil)
 		return
 	}
 
+	observeStickerCollect("success")
 	s.Info("贴纸收藏成功",
 		zap.String("uid", loginUID),
 		zap.String("source_path", source.SourceKey),

--- a/modules/sticker/api.go
+++ b/modules/sticker/api.go
@@ -43,6 +43,7 @@ import (
 // oversized value gets a clean 400 instead of a DB truncation/error.
 const (
 	maxStickerPathLen        = 512
+	maxStickerCollectPathLen = 2048
 	maxStickerPlaceholderLen = 100
 	// defaultStickerPlaceholder is stored when the client sends no placeholder,
 	// so conversation digests / push notifications have a sensible fallback.
@@ -98,6 +99,7 @@ func (s *Sticker) Route(r *wkhttp.WKHttp) {
 	{
 		auth.GET("/user", s.list)
 		auth.POST("/user", s.add)
+		auth.POST("/user/collect", s.collect)
 		auth.PUT("/user/:sticker_id", s.update)
 		auth.DELETE("/user/:sticker_id", s.delete)
 	}
@@ -327,6 +329,154 @@ func (s *Sticker) add(ctx *wkhttp.Context) {
 		zap.String("uid", loginUID),
 		zap.String("format", format),
 		zap.Bool("handle_required", stickersig.Enabled()),
+		zap.Bool("shortcode_set", shortcode != ""),
+		zap.Int("keyword_count", len(decodeStickerKeywords(keywordsStore))))
+	ctx.Response(toStickerResp(m))
+}
+
+// collect adds a sticker sent by another user into the caller's personal
+// sticker list. Unlike add(), the source path is not required to belong to the
+// caller; it must still point at the reserved sticker object keyspace. The
+// stored path is a stable authenticated preview URL for that source object, and
+// SourcePathHash makes repeat taps idempotent without charging quota again.
+func (s *Sticker) collect(ctx *wkhttp.Context) {
+	loginUID := ctx.GetLoginUID()
+
+	var req collectStickerReq
+	if err := ctx.BindJSON(&req); err != nil {
+		respondStickerRequestInvalid(ctx, "")
+		return
+	}
+	if req.Path == "" {
+		respondStickerRequestInvalid(ctx, "path")
+		return
+	}
+	if len(req.Path) > maxStickerCollectPathLen {
+		respondStickerRequestInvalid(ctx, "path")
+		return
+	}
+	source, ok := parseCollectStickerSourcePath(req.Path)
+	if !ok {
+		respondStickerRequestInvalid(ctx, "path")
+		return
+	}
+	if len(source.DisplayPath) > maxStickerPathLen || len(source.SourceKey) > maxStickerPathLen {
+		respondStickerRequestInvalid(ctx, "path")
+		return
+	}
+	placeholder := req.Placeholder
+	if placeholder == "" {
+		placeholder = defaultStickerPlaceholder
+	}
+	if len([]rune(placeholder)) > maxStickerPlaceholderLen {
+		respondStickerRequestInvalid(ctx, "placeholder")
+		return
+	}
+	if req.Sort < 0 {
+		respondStickerRequestInvalid(ctx, "sort")
+		return
+	}
+	shortcode, ok := normalizeStickerShortcode(req.Shortcode)
+	if !ok {
+		respondStickerShortcodeInvalid(ctx)
+		return
+	}
+	keywordsStore, _, ok := normalizeStickerKeywords(req.Keywords)
+	if !ok {
+		respondStickerKeywordsInvalid(ctx)
+		return
+	}
+
+	sourceHash := stickerSourcePathHash(source.SourceKey)
+	max := s.settings.StickerUserMaxCount()
+
+	tx, err := s.ctx.DB().Begin()
+	if err != nil {
+		s.Error("开启事务失败", zap.Error(err))
+		httperr.ResponseErrorL(ctx, errcode.ErrStickerStoreFailed, nil, nil)
+		return
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	if err := s.db.lockUserRowTx(tx, loginUID); err != nil {
+		s.Error("锁定用户行失败", zap.Error(err))
+		httperr.ResponseErrorL(ctx, errcode.ErrStickerStoreFailed, nil, nil)
+		return
+	}
+
+	existing, err := s.db.queryByUIDAndSourcePathHashTx(tx, loginUID, sourceHash)
+	if err != nil {
+		s.Error("查询已收藏贴纸失败", zap.Error(err), zap.String("uid", loginUID))
+		httperr.ResponseErrorL(ctx, errcode.ErrStickerQueryFailed, nil, nil)
+		return
+	}
+	if existing == nil {
+		existing, err = s.db.queryByUIDAndPathTx(tx, loginUID, source.DisplayPath)
+		if err != nil {
+			s.Error("按 path 查询已收藏贴纸失败", zap.Error(err), zap.String("uid", loginUID))
+			httperr.ResponseErrorL(ctx, errcode.ErrStickerQueryFailed, nil, nil)
+			return
+		}
+	}
+	if existing != nil {
+		if err := tx.Commit(); err != nil {
+			s.Error("提交事务失败", zap.Error(err))
+			httperr.ResponseErrorL(ctx, errcode.ErrStickerStoreFailed, nil, nil)
+			return
+		}
+		ctx.Response(toStickerResp(existing))
+		return
+	}
+
+	count, err := s.db.countByUIDTx(tx, loginUID)
+	if err != nil {
+		s.Error("查询贴纸数量失败", zap.Error(err))
+		httperr.ResponseErrorL(ctx, errcode.ErrStickerQueryFailed, nil, nil)
+		return
+	}
+	if count >= max {
+		respondStickerQuotaExceeded(ctx, max)
+		return
+	}
+	conflict, err := s.db.shortcodeExistsTx(tx, loginUID, shortcode, "")
+	if err != nil {
+		s.Error("查询贴纸 shortcode 冲突失败", zap.Error(err), zap.String("uid", loginUID))
+		httperr.ResponseErrorL(ctx, errcode.ErrStickerQueryFailed, nil, nil)
+		return
+	}
+	if conflict {
+		respondStickerShortcodeConflict(ctx)
+		return
+	}
+
+	m := &StickerModel{
+		StickerID:      util.GenerUUID(),
+		UID:            loginUID,
+		Path:           source.DisplayPath,
+		Placeholder:    placeholder,
+		Format:         source.Format,
+		Sort:           req.Sort,
+		Shortcode:      shortcode,
+		Keywords:       keywordsStore,
+		SourcePath:     source.SourceKey,
+		SourcePathHash: sourceHash,
+		Status:         1,
+	}
+	if err := s.db.insertTx(tx, m); err != nil {
+		s.Error("收藏贴纸失败", zap.Error(err), zap.String("uid", loginUID), zap.String("source_path", source.SourceKey))
+		httperr.ResponseErrorL(ctx, errcode.ErrStickerStoreFailed, nil, nil)
+		return
+	}
+	if err := tx.Commit(); err != nil {
+		s.Error("提交事务失败", zap.Error(err))
+		httperr.ResponseErrorL(ctx, errcode.ErrStickerStoreFailed, nil, nil)
+		return
+	}
+
+	s.Info("贴纸收藏成功",
+		zap.String("uid", loginUID),
+		zap.String("source_path", source.SourceKey),
+		zap.String("format", source.Format),
 		zap.Bool("shortcode_set", shortcode != ""),
 		zap.Int("keyword_count", len(decodeStickerKeywords(keywordsStore))))
 	ctx.Response(toStickerResp(m))

--- a/modules/sticker/api_test.go
+++ b/modules/sticker/api_test.go
@@ -184,6 +184,8 @@ func TestSticker_AddAndList(t *testing.T) {
 func TestSticker_CollectForeignPathIdempotent(t *testing.T) {
 	route, _, f := setupSticker(t)
 
+	beforeSuccess := promtestutil.ToFloat64(metricStickerCollectTotal.WithLabelValues("success"))
+	beforeIDHit := promtestutil.ToFloat64(metricStickerCollectTotal.WithLabelValues("idempotent_hit"))
 	sourcePath := "file/preview/sticker/source-uid/foreign.png"
 	first := doRequest(t, route, "POST", "/v1/sticker/user/collect", map[string]interface{}{
 		"path":        sourcePath,
@@ -198,6 +200,7 @@ func TestSticker_CollectForeignPathIdempotent(t *testing.T) {
 	assert.Equal(t, "png", firstBody["format"])
 	assert.Equal(t, "[收藏]", firstBody["placeholder"])
 	assert.Equal(t, "fav_one", firstBody["shortcode"])
+	assert.Equal(t, beforeSuccess+1, promtestutil.ToFloat64(metricStickerCollectTotal.WithLabelValues("success")))
 
 	second := doRequest(t, route, "POST", "/v1/sticker/user/collect", map[string]interface{}{
 		"path":        sourcePath,
@@ -208,6 +211,7 @@ func TestSticker_CollectForeignPathIdempotent(t *testing.T) {
 	secondBody := parseJSON(t, second)
 	assert.Equal(t, firstID, secondBody["sticker_id"], "same source path must be idempotent")
 	assert.Equal(t, "[收藏]", secondBody["placeholder"], "idempotent collect must return existing record")
+	assert.Equal(t, beforeIDHit+1, promtestutil.ToFloat64(metricStickerCollectTotal.WithLabelValues("idempotent_hit")))
 
 	stickers, err := f.db.listByUID(testutil.UID)
 	require.NoError(t, err)
@@ -243,9 +247,31 @@ func TestSticker_CollectAlreadyExistsDoesNotConsumeQuota(t *testing.T) {
 	assert.Len(t, stickers, 1)
 }
 
+func TestSticker_CollectAfterDeleteCreatesNewRecord(t *testing.T) {
+	route, _, _ := setupSticker(t)
+
+	sourcePath := "file/preview/sticker/source-uid/readd.png"
+	first := doRequest(t, route, "POST", "/v1/sticker/user/collect", map[string]string{
+		"path": sourcePath,
+	})
+	require.Equal(t, http.StatusOK, first.Code, "body: %s", first.Body.String())
+	firstID := parseJSON(t, first)["sticker_id"].(string)
+
+	del := doRequest(t, route, "DELETE", "/v1/sticker/user/"+firstID, nil)
+	require.Equal(t, http.StatusOK, del.Code, "body: %s", del.Body.String())
+
+	second := doRequest(t, route, "POST", "/v1/sticker/user/collect", map[string]string{
+		"path": sourcePath,
+	})
+	require.Equal(t, http.StatusOK, second.Code, "body: %s", second.Body.String())
+	secondID := parseJSON(t, second)["sticker_id"].(string)
+	assert.NotEqual(t, firstID, secondID, "soft delete must release live collect idempotency")
+}
+
 func TestSticker_CollectRejectsInvalidSourcePath(t *testing.T) {
 	route, _, _ := setupSticker(t)
 
+	beforePathInvalid := promtestutil.ToFloat64(metricStickerCollectTotal.WithLabelValues("path_invalid"))
 	cases := []struct {
 		name string
 		path string
@@ -264,6 +290,24 @@ func TestSticker_CollectRejectsInvalidSourcePath(t *testing.T) {
 			assertStickerErrorCode(t, w, "err.server.sticker.request_invalid")
 		})
 	}
+	assert.Equal(t, beforePathInvalid+float64(len(cases)), promtestutil.ToFloat64(metricStickerCollectTotal.WithLabelValues("path_invalid")))
+}
+
+func TestSticker_CollectMetricsForQuota(t *testing.T) {
+	route, ctx, _ := setupSticker(t)
+	setStickerQuota(t, ctx, 1)
+
+	ok := doRequest(t, route, "POST", "/v1/sticker/user/collect", map[string]string{
+		"path": "file/preview/sticker/source-uid/quota-metric-ok.png",
+	})
+	require.Equal(t, http.StatusOK, ok.Code, "body: %s", ok.Body.String())
+
+	beforeQuota := promtestutil.ToFloat64(metricStickerCollectTotal.WithLabelValues("quota_exceeded"))
+	w := doRequest(t, route, "POST", "/v1/sticker/user/collect", map[string]string{
+		"path": "file/preview/sticker/source-uid/quota-metric.png",
+	})
+	assertStickerErrorCode(t, w, "err.server.sticker.quota_exceeded")
+	assert.Equal(t, beforeQuota+1, promtestutil.ToFloat64(metricStickerCollectTotal.WithLabelValues("quota_exceeded")))
 }
 
 func TestSticker_UpdatePartialAndListSortOrder(t *testing.T) {

--- a/modules/sticker/api_test.go
+++ b/modules/sticker/api_test.go
@@ -181,6 +181,91 @@ func TestSticker_AddAndList(t *testing.T) {
 	assert.Equal(t, "[笑]", item["placeholder"])
 }
 
+func TestSticker_CollectForeignPathIdempotent(t *testing.T) {
+	route, _, f := setupSticker(t)
+
+	sourcePath := "file/preview/sticker/source-uid/foreign.png"
+	first := doRequest(t, route, "POST", "/v1/sticker/user/collect", map[string]interface{}{
+		"path":        sourcePath,
+		"placeholder": "[收藏]",
+		"shortcode":   "fav_one",
+		"keywords":    []string{"收藏", "贴纸"},
+	})
+	require.Equal(t, http.StatusOK, first.Code, "body: %s", first.Body.String())
+	firstBody := parseJSON(t, first)
+	firstID := firstBody["sticker_id"].(string)
+	assert.Equal(t, sourcePath, firstBody["path"])
+	assert.Equal(t, "png", firstBody["format"])
+	assert.Equal(t, "[收藏]", firstBody["placeholder"])
+	assert.Equal(t, "fav_one", firstBody["shortcode"])
+
+	second := doRequest(t, route, "POST", "/v1/sticker/user/collect", map[string]interface{}{
+		"path":        sourcePath,
+		"placeholder": "[重复点击不应覆盖]",
+		"shortcode":   "ignored",
+	})
+	require.Equal(t, http.StatusOK, second.Code, "body: %s", second.Body.String())
+	secondBody := parseJSON(t, second)
+	assert.Equal(t, firstID, secondBody["sticker_id"], "same source path must be idempotent")
+	assert.Equal(t, "[收藏]", secondBody["placeholder"], "idempotent collect must return existing record")
+
+	stickers, err := f.db.listByUID(testutil.UID)
+	require.NoError(t, err)
+	require.Len(t, stickers, 1)
+	assert.Equal(t, sourcePath, stickers[0].Path)
+	assert.NotEmpty(t, stickers[0].SourcePathHash)
+}
+
+func TestSticker_CollectAlreadyExistsDoesNotConsumeQuota(t *testing.T) {
+	route, ctx, f := setupSticker(t)
+	setStickerQuota(t, ctx, 1)
+
+	sourcePath := "file/preview/sticker/source-uid/quota.png"
+	first := doRequest(t, route, "POST", "/v1/sticker/user/collect", map[string]string{
+		"path": sourcePath,
+	})
+	require.Equal(t, http.StatusOK, first.Code, "body: %s", first.Body.String())
+
+	second := doRequest(t, route, "POST", "/v1/sticker/user/collect", map[string]string{
+		"path": sourcePath,
+	})
+	require.Equal(t, http.StatusOK, second.Code, "repeat collect must not fail quota: %s", second.Body.String())
+	assert.Equal(t, parseJSON(t, first)["sticker_id"], parseJSON(t, second)["sticker_id"])
+
+	other := doRequest(t, route, "POST", "/v1/sticker/user/collect", map[string]string{
+		"path": "file/preview/sticker/source-uid/other.png",
+	})
+	env := decodeErrEnvelope(t, other.Body.Bytes())
+	assert.Equal(t, "err.server.sticker.quota_exceeded", env.Error.Code)
+
+	stickers, err := f.db.listByUID(testutil.UID)
+	require.NoError(t, err)
+	assert.Len(t, stickers, 1)
+}
+
+func TestSticker_CollectRejectsInvalidSourcePath(t *testing.T) {
+	route, _, _ := setupSticker(t)
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"empty", ""},
+		{"non sticker url", "https://example.com/avatar/x.png"},
+		{"unsupported extension", "file/preview/sticker/source-uid/x.tiff"},
+		{"missing extension", "file/preview/sticker/source-uid/x"},
+		{"nested object", "file/preview/sticker/source-uid/nested/x.png"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := doRequest(t, route, "POST", "/v1/sticker/user/collect", map[string]string{
+				"path": tc.path,
+			})
+			assertStickerErrorCode(t, w, "err.server.sticker.request_invalid")
+		})
+	}
+}
+
 func TestSticker_UpdatePartialAndListSortOrder(t *testing.T) {
 	route, _, _ := setupSticker(t)
 

--- a/modules/sticker/db.go
+++ b/modules/sticker/db.go
@@ -80,6 +80,33 @@ func (d *stickerDB) countByUIDTx(tx *dbr.Tx, uid string) (int, error) {
 	return count, err
 }
 
+func (d *stickerDB) queryByUIDAndSourcePathHashTx(tx *dbr.Tx, uid, sourcePathHash string) (*StickerModel, error) {
+	if sourcePathHash == "" {
+		return nil, nil
+	}
+	var model *StickerModel
+	_, err := tx.Select("*").From("sticker").
+		Where("uid=? and status=1 and source_path_hash=?", uid, sourcePathHash).
+		Limit(1).
+		Load(&model)
+	if errors.Is(err, dbr.ErrNotFound) {
+		return nil, nil
+	}
+	return model, err
+}
+
+func (d *stickerDB) queryByUIDAndPathTx(tx *dbr.Tx, uid, path string) (*StickerModel, error) {
+	var model *StickerModel
+	_, err := tx.Select("*").From("sticker").
+		Where("uid=? and status=1 and path=?", uid, path).
+		Limit(1).
+		Load(&model)
+	if errors.Is(err, dbr.ErrNotFound) {
+		return nil, nil
+	}
+	return model, err
+}
+
 func (d *stickerDB) queryByIDAndUIDTx(tx *dbr.Tx, stickerID, uid string) (*StickerModel, error) {
 	var model *StickerModel
 	_, err := tx.Select("*").From("sticker").

--- a/modules/sticker/db.go
+++ b/modules/sticker/db.go
@@ -95,18 +95,6 @@ func (d *stickerDB) queryByUIDAndSourcePathHashTx(tx *dbr.Tx, uid, sourcePathHas
 	return model, err
 }
 
-func (d *stickerDB) queryByUIDAndPathTx(tx *dbr.Tx, uid, path string) (*StickerModel, error) {
-	var model *StickerModel
-	_, err := tx.Select("*").From("sticker").
-		Where("uid=? and status=1 and path=?", uid, path).
-		Limit(1).
-		Load(&model)
-	if errors.Is(err, dbr.ErrNotFound) {
-		return nil, nil
-	}
-	return model, err
-}
-
 func (d *stickerDB) queryByIDAndUIDTx(tx *dbr.Tx, stickerID, uid string) (*StickerModel, error) {
 	var model *StickerModel
 	_, err := tx.Select("*").From("sticker").

--- a/modules/sticker/metrics.go
+++ b/modules/sticker/metrics.go
@@ -22,9 +22,25 @@ func stickerRegisterResultLabels() []string {
 	}
 }
 
+func stickerCollectResultLabels() []string {
+	return []string{
+		"success",
+		"idempotent_hit",
+		"validation_failed",
+		"path_invalid",
+		"quota_exceeded",
+		"shortcode_conflict",
+		"query_failed",
+		"store_failed",
+	}
+}
+
 func init() {
 	for _, result := range stickerRegisterResultLabels() {
 		metricStickerRegisterTotal.WithLabelValues(result).Add(0)
+	}
+	for _, result := range stickerCollectResultLabels() {
+		metricStickerCollectTotal.WithLabelValues(result).Add(0)
 	}
 }
 
@@ -34,6 +50,16 @@ var metricStickerRegisterTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 	Help:      "Custom sticker registration outcomes by low-cardinality result.",
 }, []string{"result"})
 
+var metricStickerCollectTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Namespace: stickerMetricNamespace,
+	Name:      "collect_total",
+	Help:      "Custom sticker collect outcomes by low-cardinality result.",
+}, []string{"result"})
+
 func observeStickerRegister(result string) {
 	metricStickerRegisterTotal.WithLabelValues(result).Inc()
+}
+
+func observeStickerCollect(result string) {
+	metricStickerCollectTotal.WithLabelValues(result).Inc()
 }

--- a/modules/sticker/model.go
+++ b/modules/sticker/model.go
@@ -1,7 +1,10 @@
 package sticker
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -24,7 +27,12 @@ type StickerModel struct {
 	Sort        int
 	Shortcode   string
 	Keywords    string
-	Status      int
+	SourcePath  string
+	// SourcePathHash is set only for "collect from message" records. Direct
+	// upload registrations keep it empty so the collect-only unique key does not
+	// affect existing custom-sticker creation.
+	SourcePathHash string
+	Status         int
 	db.BaseModel
 }
 
@@ -159,6 +167,63 @@ func validateStickerPath(path, loginUID, format string) bool {
 	return ext == format && isAllowedStickerFormat(ext)
 }
 
+type collectStickerSource struct {
+	SourceKey   string
+	DisplayPath string
+	Format      string
+}
+
+var (
+	stickerSourceObjectKeyExactRe = regexp.MustCompile(`^sticker/([^/]+)/([^/]+)\.([A-Za-z0-9]+)$`)
+	stickerSourceObjectKeyTailRe  = regexp.MustCompile(`(?:^|/)sticker/([^/]+)/([^/]+)\.([A-Za-z0-9]+)$`)
+)
+
+func parseCollectStickerSourcePath(raw string) (collectStickerSource, bool) {
+	pathValue := strings.TrimSpace(raw)
+	if pathValue == "" {
+		return collectStickerSource{}, false
+	}
+	if i := strings.IndexAny(pathValue, "?#"); i >= 0 {
+		pathValue = pathValue[:i]
+	}
+
+	candidate := pathValue
+	if u, err := url.Parse(pathValue); err == nil && u.Scheme != "" && u.Host != "" {
+		candidate = u.Path
+	}
+	candidate = strings.TrimPrefix(candidate, "/")
+
+	if strings.HasPrefix(candidate, "file/preview/") {
+		return parseCollectStickerObjectKey(strings.TrimPrefix(candidate, "file/preview/"), stickerSourceObjectKeyExactRe)
+	}
+	if strings.HasPrefix(candidate, "sticker/") {
+		return parseCollectStickerObjectKey(candidate, stickerSourceObjectKeyExactRe)
+	}
+	return parseCollectStickerObjectKey(candidate, stickerSourceObjectKeyTailRe)
+}
+
+func parseCollectStickerObjectKey(candidate string, re *regexp.Regexp) (collectStickerSource, bool) {
+	m := re.FindStringSubmatch(candidate)
+	if m == nil {
+		return collectStickerSource{}, false
+	}
+	format := normalizeStickerFormat(m[3])
+	if !isAllowedStickerFormat(format) {
+		return collectStickerSource{}, false
+	}
+	sourceKey := "sticker/" + m[1] + "/" + m[2] + "." + m[3]
+	return collectStickerSource{
+		SourceKey:   sourceKey,
+		DisplayPath: "file/preview/" + sourceKey,
+		Format:      format,
+	}, true
+}
+
+func stickerSourcePathHash(sourceKey string) string {
+	sum := sha256.Sum256([]byte(sourceKey))
+	return hex.EncodeToString(sum[:])
+}
+
 // ---------- Request ----------
 
 type addStickerReq struct {
@@ -177,6 +242,14 @@ type addStickerReq struct {
 	// always rejected; a missing handle is rejected only when the policy is on. See
 	// classifyStickerPath.
 	Handle string `json:"handle"`
+}
+
+type collectStickerReq struct {
+	Path        string   `json:"path"`
+	Placeholder string   `json:"placeholder"`
+	Sort        int      `json:"sort"`
+	Shortcode   string   `json:"shortcode"`
+	Keywords    []string `json:"keywords"`
 }
 
 type updateStickerReq struct {

--- a/modules/sticker/model_test.go
+++ b/modules/sticker/model_test.go
@@ -45,3 +45,72 @@ func TestValidateStickerPath(t *testing.T) {
 		})
 	}
 }
+
+func TestParseCollectStickerSourcePath(t *testing.T) {
+	cases := []struct {
+		name        string
+		path        string
+		wantOK      bool
+		wantKey     string
+		wantDisplay string
+		wantFormat  string
+	}{
+		{
+			name:        "relative preview path",
+			path:        "file/preview/sticker/source-uid/abc.png",
+			wantOK:      true,
+			wantKey:     "sticker/source-uid/abc.png",
+			wantDisplay: "file/preview/sticker/source-uid/abc.png",
+			wantFormat:  "png",
+		},
+		{
+			name:        "absolute CDN URL strips query and prefix",
+			path:        "https://cdn.example.com/bucket/sticker/source-uid/abc.webp?X-Amz-Signature=deadbeef",
+			wantOK:      true,
+			wantKey:     "sticker/source-uid/abc.webp",
+			wantDisplay: "file/preview/sticker/source-uid/abc.webp",
+			wantFormat:  "webp",
+		},
+		{
+			name:        "raw object key",
+			path:        "sticker/source-uid/abc.GIF",
+			wantOK:      true,
+			wantKey:     "sticker/source-uid/abc.GIF",
+			wantDisplay: "file/preview/sticker/source-uid/abc.GIF",
+			wantFormat:  "gif",
+		},
+		{name: "non sticker URL", path: "https://example.com/avatar/abc.png", wantOK: false},
+		{name: "nested sticker object rejected", path: "file/preview/sticker/source-uid/nested/abc.png", wantOK: false},
+		{name: "unsupported format rejected", path: "file/preview/sticker/source-uid/abc.tiff", wantOK: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseCollectStickerSourcePath(tc.path)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got.SourceKey != tc.wantKey || got.DisplayPath != tc.wantDisplay || got.Format != tc.wantFormat {
+				t.Fatalf("parseCollectStickerSourcePath(%q) = %+v, want key=%q display=%q format=%q",
+					tc.path, got, tc.wantKey, tc.wantDisplay, tc.wantFormat)
+			}
+		})
+	}
+}
+
+func TestStickerSourcePathHashStable(t *testing.T) {
+	a := stickerSourcePathHash("sticker/source-uid/abc.png")
+	b := stickerSourcePathHash("sticker/source-uid/abc.png")
+	c := stickerSourcePathHash("sticker/source-uid/other.png")
+	if a == "" || len(a) != 64 {
+		t.Fatalf("hash length = %d, want 64", len(a))
+	}
+	if a != b {
+		t.Fatalf("hash must be stable for the same source path")
+	}
+	if a == c {
+		t.Fatalf("hash must differ for different source paths")
+	}
+}

--- a/modules/sticker/sql/20260703000001_sticker_collect.sql
+++ b/modules/sticker/sql/20260703000001_sticker_collect.sql
@@ -1,0 +1,90 @@
+-- +migrate Up
+-- Track the source object for sticker-message collection. Direct uploads keep
+-- source_path_hash empty; only live collected rows participate in the unique
+-- key via the generated column, so existing multi-upload behavior is unchanged.
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __sticker_collect;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __sticker_collect()
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'sticker'
+         AND COLUMN_NAME = 'source_path') THEN
+    ALTER TABLE `sticker`
+      ADD COLUMN `source_path` VARCHAR(512) NOT NULL DEFAULT '' COMMENT '收藏来源贴纸对象 key（sticker/{uid}/{file}）' AFTER `keywords`;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'sticker'
+         AND COLUMN_NAME = 'source_path_hash') THEN
+    ALTER TABLE `sticker`
+      ADD COLUMN `source_path_hash` CHAR(64) NOT NULL DEFAULT '' COMMENT '收藏来源贴纸对象 key 的 sha256 hex' AFTER `source_path`;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'sticker'
+         AND COLUMN_NAME = 'source_path_hash_live') THEN
+    ALTER TABLE `sticker`
+      ADD COLUMN `source_path_hash_live` CHAR(64)
+        GENERATED ALWAYS AS (
+          CASE
+            WHEN `status` = 1 AND `source_path_hash` <> '' THEN `source_path_hash`
+            ELSE NULL
+          END
+        ) STORED COMMENT 'live 收藏幂等唯一键辅助列' AFTER `source_path_hash`;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.STATISTICS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'sticker'
+         AND INDEX_NAME = 'uk_uid_source_path_hash_live') THEN
+    ALTER TABLE `sticker`
+      ADD UNIQUE KEY `uk_uid_source_path_hash_live` (`uid`, `source_path_hash_live`);
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __sticker_collect();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __sticker_collect;
+-- +migrate StatementEnd
+
+-- +migrate Down
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __sticker_collect_down;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __sticker_collect_down()
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.STATISTICS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'sticker'
+         AND INDEX_NAME = 'uk_uid_source_path_hash_live') THEN
+    ALTER TABLE `sticker` DROP INDEX `uk_uid_source_path_hash_live`;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'sticker'
+         AND COLUMN_NAME = 'source_path_hash_live') THEN
+    ALTER TABLE `sticker` DROP COLUMN `source_path_hash_live`;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'sticker'
+         AND COLUMN_NAME = 'source_path_hash') THEN
+    ALTER TABLE `sticker` DROP COLUMN `source_path_hash`;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'sticker'
+         AND COLUMN_NAME = 'source_path') THEN
+    ALTER TABLE `sticker` DROP COLUMN `source_path`;
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __sticker_collect_down();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __sticker_collect_down;
+-- +migrate StatementEnd


### PR DESCRIPTION
## Summary

Add a server-side sticker collect endpoint so clients can add a sticker-message path to the current user's custom stickers without re-uploading the file.

## Related Issue

Manual request.

## Linked Spec

`.octospec/tasks/sticker-collect/brief.md`

## Changes

- Add `POST /v1/sticker/user/collect` under the authenticated sticker routes.
- Accept existing `sticker/{source_uid}/{file}` paths, normalize them to `file/preview/sticker/...`, and infer the sticker format from the source path.
- Add `source_path` and `source_path_hash` metadata plus a live-only unique key for idempotency.
- Enforce the existing `sticker.user_max_count` quota only for new collect records; repeated collects return the existing sticker.
- Add low-cardinality collect metrics for success, idempotent hits, invalid paths, quota rejection, shortcode conflicts, query failures, and store failures.
- Document first-version trade-offs: reference-based storage, path-only source validation, and future GC/copy considerations.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

Commands run:

```bash
docker run --rm --network host -e GIN_MODE=release \
  -v /Users/fangling/conductor/workspaces/octo-server/kyoto:/src \
  -v /Users/fangling/conductor/workspaces/octo-server/kyoto/.context/go-cache/pkg:/go/pkg \
  -v /Users/fangling/conductor/workspaces/octo-server/kyoto/.context/go-cache/build:/root/.cache/go-build \
  -w /src golang:1.25 go test ./modules/sticker

git diff --check origin/main...HEAD
```

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

It adds a separate collect path for custom stickers. The existing upload registration endpoint remains owner-bound and handle-aware. The new collect endpoint accepts only reserved sticker object paths, records a source hash for idempotency, and uses the existing per-user quota transaction/lock before inserting new rows.

2. **What could break** because of it (dependents + failure mode)?

Clients may now receive a mix of existing upload paths and normalized `file/preview/sticker/...` paths in `GET /v1/sticker/user`; older clients must be able to render preview paths. Because this version stores references instead of copying objects, future object-store GC or source-user cleanup could create dangling collected stickers unless follow-up copy/reference-counting is added. The path-only contract also does not prove source message access.

3. **How do you know it works** (specific test/repro/trace)?

`go test ./modules/sticker` covers foreign-path collection, idempotent repeat collection, quota behavior, soft-delete then re-collect, invalid source paths, source-path parsing/hash stability, and collect metrics. `git diff --check origin/main...HEAD` is clean.

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
