### PR TITLE
feat(sticker): return one client-renderable path for all stickers

### DIFF
--- a/modules/sticker/api.go
+++ b/modules/sticker/api.go
@@ -149,8 +149,21 @@ func (s *Sticker) renderablePath(stored string) string {
 		return stored
 	}
 	key := strings.TrimPrefix(stored, "file/preview/")
+	// Defense-in-depth against keyspace escape: never hand a "."/".." segment to
+	// DownloadURL (url.JoinPath resolves "..", escaping the sticker/ prefix). The
+	// collect ingress already rejects such keys, but this also confines any
+	// legacy row or the self-upload path. A traversal key falls back to the
+	// stored value (a broken but non-escaping render), matching pre-change
+	// behavior where /v1/file/preview rejected "..".
+	if hasUnsafeSegment(key) {
+		return stored
+	}
 	url, err := s.fileURL.DownloadURL(key, "")
 	if err != nil || url == "" {
+		// Fail open, but make silent degradation observable: on a misconfigured
+		// backend every list item would quietly return its raw stored value.
+		// Low-cardinality — the error, never the per-user path, is logged.
+		s.Warn("解析贴纸渲染 URL 失败，回退到存储原值", zap.Error(err))
 		return stored
 	}
 	return url

--- a/modules/sticker/api.go
+++ b/modules/sticker/api.go
@@ -25,11 +25,14 @@
 package sticker
 
 import (
+	"strings"
+
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	commonmod "github.com/Mininglamp-OSS/octo-server/modules/common"
+	filemod "github.com/Mininglamp-OSS/octo-server/modules/file"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/metrics"
@@ -50,12 +53,25 @@ const (
 	defaultStickerPlaceholder = "[表情]"
 )
 
+// stickerURLResolver resolves a stored sticker object key into a directly
+// renderable, anonymous-GET download URL. It is the single capability the
+// sticker module needs from modules/file; kept as a 1-method interface so tests
+// inject a deterministic fake instead of a real storage backend. Satisfied by
+// file.IService (modules/file).
+type stickerURLResolver interface {
+	DownloadURL(path string, filename string) (string, error)
+}
+
 // Sticker 用户自定义贴纸 API。
 type Sticker struct {
 	ctx *config.Context
 	log.Log
 	db       *stickerDB
 	settings *commonmod.SystemSettings
+	// fileURL resolves a stored path into a client-renderable URL. See
+	// renderablePath — this is what lets GET /v1/sticker/user return one uniform
+	// renderable `path` for both self-uploaded and collected stickers.
+	fileURL stickerURLResolver
 }
 
 // New 创建 Sticker 实例。settings 走进程内共享单例，配额变更（管理端写
@@ -66,6 +82,7 @@ func New(ctx *config.Context) *Sticker {
 		Log:      log.NewTLog("Sticker"),
 		db:       newStickerDB(ctx),
 		settings: commonmod.EnsureSystemSettings(ctx),
+		fileURL:  filemod.NewService(ctx),
 	}
 	// 运营可见性：签发/校验 handle 的「能力」由 OCTO_MASTER_KEY 决定（stickersig.Enabled，
 	// 部署级 env），「是否强制客户端必须带 handle」的「策略」由 system_setting
@@ -105,6 +122,49 @@ func (s *Sticker) Route(r *wkhttp.WKHttp) {
 	}
 }
 
+// renderablePath normalizes a stored sticker path into a value the client can
+// drop straight into an <img src> — no per-client "absolute vs relative" branch.
+//
+// Two shapes reach the DB:
+//   - self-uploaded stickers store the /v1/file/upload response `path`, which is
+//     already an absolute anonymous-GET download/CDN URL → passed through as-is.
+//   - collected stickers (and any relative object key) store the object key. The
+//     authenticated /v1/file/preview/<key> endpoint cannot be used directly in an
+//     <img> because AuthMiddleware only reads the token from a header, so we
+//     resolve the key through the file service's DownloadURL — the same permanent
+//     public/CDN URL /v1/file/preview redirects to.
+//
+// Any leading "file/preview/" is stripped before resolving so legacy collected
+// rows (which stored the preview path) normalize identically to new rows (which
+// store the bare key). On resolve failure the stored value is returned unchanged
+// — no worse than the pre-normalization behavior.
+func (s *Sticker) renderablePath(stored string) string {
+	if stored == "" {
+		return stored
+	}
+	if strings.HasPrefix(stored, "http://") || strings.HasPrefix(stored, "https://") {
+		return stored
+	}
+	if s.fileURL == nil {
+		return stored
+	}
+	key := strings.TrimPrefix(stored, "file/preview/")
+	url, err := s.fileURL.DownloadURL(key, "")
+	if err != nil || url == "" {
+		return stored
+	}
+	return url
+}
+
+// toResp maps a model to the wire shape with a client-renderable path. Every
+// endpoint that returns a sticker funnels through here so the `path` contract is
+// uniform across list/add/collect/update.
+func (s *Sticker) toResp(m *StickerModel) stickerResp {
+	r := toStickerResp(m)
+	r.Path = s.renderablePath(r.Path)
+	return r
+}
+
 // list 返回当前用户的自定义贴纸（扁平列表，最新在前）。空集合返回
 // {"list":[]} 而非 404 —— 正是 issue #26 要消灭的噪音。
 func (s *Sticker) list(ctx *wkhttp.Context) {
@@ -119,7 +179,7 @@ func (s *Sticker) list(ctx *wkhttp.Context) {
 
 	list := make([]stickerResp, 0, len(models))
 	for _, m := range models {
-		list = append(list, toStickerResp(m))
+		list = append(list, s.toResp(m))
 	}
 	ctx.Response(listStickerResp{List: list})
 }
@@ -331,13 +391,14 @@ func (s *Sticker) add(ctx *wkhttp.Context) {
 		zap.Bool("handle_required", stickersig.Enabled()),
 		zap.Bool("shortcode_set", shortcode != ""),
 		zap.Int("keyword_count", len(decodeStickerKeywords(keywordsStore))))
-	ctx.Response(toStickerResp(m))
+	ctx.Response(s.toResp(m))
 }
 
 // collect adds a sticker sent by another user into the caller's personal
 // sticker list. Unlike add(), the source path is not required to belong to the
 // caller; it must still point at the reserved sticker object keyspace. The
-// stored path is a stable authenticated preview URL for that source object, and
+// stored path is the bare source object key; the response (and later list)
+// resolve it to a client-renderable URL via toResp → renderablePath.
 // SourcePathHash makes repeat taps idempotent without charging quota again.
 //
 // collect intentionally does not require the upload handle even when
@@ -437,7 +498,7 @@ func (s *Sticker) collect(ctx *wkhttp.Context) {
 			return
 		}
 		observeStickerCollect("idempotent_hit")
-		ctx.Response(toStickerResp(existing))
+		ctx.Response(s.toResp(existing))
 		return
 	}
 
@@ -467,9 +528,14 @@ func (s *Sticker) collect(ctx *wkhttp.Context) {
 	}
 
 	m := &StickerModel{
-		StickerID:      util.GenerUUID(),
-		UID:            loginUID,
-		Path:           source.DisplayPath,
+		StickerID: util.GenerUUID(),
+		UID:       loginUID,
+		// Store the bare object key, not the auth-gated file/preview/ path. The
+		// list/collect responses resolve it to a renderable URL via toResp →
+		// renderablePath; storing the key keeps the DB backend-agnostic (a CDN /
+		// download-host change re-resolves correctly instead of stranding a
+		// baked-in preview path).
+		Path:           source.SourceKey,
 		Placeholder:    placeholder,
 		Format:         source.Format,
 		Sort:           req.Sort,
@@ -499,7 +565,7 @@ func (s *Sticker) collect(ctx *wkhttp.Context) {
 		zap.String("format", source.Format),
 		zap.Bool("shortcode_set", shortcode != ""),
 		zap.Int("keyword_count", len(decodeStickerKeywords(keywordsStore))))
-	ctx.Response(toStickerResp(m))
+	ctx.Response(s.toResp(m))
 }
 
 // update partially updates the current user's sticker metadata. Missing fields
@@ -596,7 +662,7 @@ func (s *Sticker) update(ctx *wkhttp.Context) {
 		return
 	}
 
-	ctx.Response(toStickerResp(m))
+	ctx.Response(s.toResp(m))
 }
 
 // stickerPathClass is the outcome of authorizing a client-supplied sticker

--- a/modules/sticker/api_test.go
+++ b/modules/sticker/api_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -156,7 +157,7 @@ func TestSticker_ListEmpty(t *testing.T) {
 }
 
 func TestSticker_AddAndList(t *testing.T) {
-	route, _, _ := setupSticker(t)
+	route, _, f := setupSticker(t)
 
 	add := doRequest(t, route, "POST", "/v1/sticker/user", map[string]string{
 		"path":        validStickerPath("abc.png"),
@@ -176,7 +177,12 @@ func TestSticker_AddAndList(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, 1, len(list))
 	item := list[0].(map[string]interface{})
-	assert.Equal(t, validStickerPath("abc.png"), item["path"])
+	// path is normalized to a client-renderable URL (same transform the handler
+	// applies), never the raw auth-gated file/preview/ key.
+	wantPath := f.renderablePath(validStickerPath("abc.png"))
+	assert.Equal(t, wantPath, item["path"])
+	assert.False(t, strings.HasPrefix(item["path"].(string), "file/preview/"),
+		"list path must be a renderable URL, not the auth-gated preview key")
 	assert.Equal(t, "user", item["category"])
 	assert.Equal(t, "[笑]", item["placeholder"])
 }
@@ -196,7 +202,12 @@ func TestSticker_CollectForeignPathIdempotent(t *testing.T) {
 	require.Equal(t, http.StatusOK, first.Code, "body: %s", first.Body.String())
 	firstBody := parseJSON(t, first)
 	firstID := firstBody["sticker_id"].(string)
-	assert.Equal(t, sourcePath, firstBody["path"])
+	// Collect stores the bare object key; the response path is the normalized
+	// renderable URL (never the auth-gated file/preview/ key the client sent).
+	sourceKey := "sticker/source-uid/foreign.png"
+	assert.Equal(t, f.renderablePath(sourceKey), firstBody["path"])
+	assert.False(t, strings.HasPrefix(firstBody["path"].(string), "file/preview/"),
+		"collect path must be a renderable URL, not the auth-gated preview key")
 	assert.Equal(t, "png", firstBody["format"])
 	assert.Equal(t, "[收藏]", firstBody["placeholder"])
 	assert.Equal(t, "fav_one", firstBody["shortcode"])
@@ -216,7 +227,8 @@ func TestSticker_CollectForeignPathIdempotent(t *testing.T) {
 	stickers, err := f.db.listByUID(testutil.UID)
 	require.NoError(t, err)
 	require.Len(t, stickers, 1)
-	assert.Equal(t, sourcePath, stickers[0].Path)
+	assert.Equal(t, sourceKey, stickers[0].Path, "collect stores the bare object key, not the preview path")
+	assert.Equal(t, sourceKey, stickers[0].SourcePath)
 	assert.NotEmpty(t, stickers[0].SourcePathHash)
 }
 

--- a/modules/sticker/api_test.go
+++ b/modules/sticker/api_test.go
@@ -170,6 +170,12 @@ func TestSticker_AddAndList(t *testing.T) {
 	assert.NotEmpty(t, ab["sticker_id"])
 	assert.Equal(t, "user", ab["category"])
 	assert.Equal(t, "png", ab["format"])
+	// The immediate add response is normalized too (all four endpoints funnel
+	// through toResp), not just the later list read.
+	wantPath := f.renderablePath(validStickerPath("abc.png"))
+	assert.Equal(t, wantPath, ab["path"])
+	assert.False(t, strings.HasPrefix(ab["path"].(string), "file/preview/"),
+		"add response path must be a renderable URL, not the auth-gated preview key")
 
 	w := doRequest(t, route, "GET", "/v1/sticker/user", nil)
 	body := parseJSON(t, w)
@@ -179,7 +185,6 @@ func TestSticker_AddAndList(t *testing.T) {
 	item := list[0].(map[string]interface{})
 	// path is normalized to a client-renderable URL (same transform the handler
 	// applies), never the raw auth-gated file/preview/ key.
-	wantPath := f.renderablePath(validStickerPath("abc.png"))
 	assert.Equal(t, wantPath, item["path"])
 	assert.False(t, strings.HasPrefix(item["path"].(string), "file/preview/"),
 		"list path must be a renderable URL, not the auth-gated preview key")
@@ -293,6 +298,12 @@ func TestSticker_CollectRejectsInvalidSourcePath(t *testing.T) {
 		{"unsupported extension", "file/preview/sticker/source-uid/x.tiff"},
 		{"missing extension", "file/preview/sticker/source-uid/x"},
 		{"nested object", "file/preview/sticker/source-uid/nested/x.png"},
+		// Path-traversal keys must be rejected at ingress so they never reach
+		// storage or renderablePath → DownloadURL (which would resolve ".." and
+		// escape the sticker/ keyspace to the bucket root).
+		{"parent traversal segment", "sticker/../x.png"},
+		{"parent traversal via preview prefix", "file/preview/sticker/../x.png"},
+		{"parent traversal via absolute url", "https://cdn.example.com/bucket/sticker/../x.png"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/modules/sticker/model.go
+++ b/modules/sticker/model.go
@@ -212,11 +212,36 @@ func parseCollectStickerObjectKey(candidate string, re *regexp.Regexp) (collectS
 		return collectStickerSource{}, false
 	}
 	sourceKey := "sticker/" + m[1] + "/" + m[2] + "." + m[3]
+	// Reject path-traversal / relative segments before the key is ever stored.
+	// The regex's `[^/]+` matches "." and "..", so `sticker/../a.png` parses to
+	// SourceKey "sticker/../a.png". That key is later resolved by renderablePath
+	// via DownloadURL → url.JoinPath, which RESOLVES "..", collapsing the
+	// "sticker/" prefix and escaping the sticker keyspace to the bucket root
+	// (e.g. "<base>/bucket/a.png"). Confining at ingress keeps traversal keys out
+	// of the DB and out of every downstream consumer (this one and file/preview).
+	if hasUnsafeSegment(sourceKey) {
+		return collectStickerSource{}, false
+	}
 	return collectStickerSource{
 		SourceKey:   sourceKey,
 		DisplayPath: "file/preview/" + sourceKey,
 		Format:      format,
 	}, true
+}
+
+// hasUnsafeSegment reports whether key contains a "." or ".." path segment. A
+// ".." segment lets url.JoinPath (used by every storage backend's DownloadURL)
+// escape the object key's intended prefix; "." is normalized away and never
+// legitimate in a generated sticker key. Percent-encoded forms ("%2e%2e") are
+// intentionally NOT decoded here: url.JoinPath leaves them literal (verified),
+// so they cannot traverse — only literal segments can.
+func hasUnsafeSegment(key string) bool {
+	for _, seg := range strings.Split(key, "/") {
+		if seg == "." || seg == ".." {
+			return true
+		}
+	}
+	return false
 }
 
 func stickerSourcePathHash(sourceKey string) string {

--- a/modules/sticker/render_test.go
+++ b/modules/sticker/render_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,16 +18,23 @@ func (f fakeURLResolver) DownloadURL(path, filename string) (string, error) {
 	return f.fn(path, filename)
 }
 
+// newRenderSticker builds a Sticker with just the logger + resolver wired — the
+// only fields renderablePath touches — so the guard/fallback branches (which log
+// a warning) do not nil-panic on the embedded logger.
+func newRenderSticker(r stickerURLResolver) *Sticker {
+	return &Sticker{Log: log.NewTLog("sticker-render-test"), fileURL: r}
+}
+
 func TestRenderablePath(t *testing.T) {
 	const resolved = "https://cdn.example.com/sticker/uid/a.png"
 
 	// resolver records the key it was asked to resolve so we can assert the
 	// "file/preview/" prefix was stripped before resolution.
 	var gotKey string
-	ok := &Sticker{fileURL: fakeURLResolver{fn: func(path, _ string) (string, error) {
+	ok := newRenderSticker(fakeURLResolver{fn: func(path, _ string) (string, error) {
 		gotKey = path
 		return resolved, nil
-	}}}
+	}})
 
 	t.Run("absolute http passes through untouched", func(t *testing.T) {
 		gotKey = ""
@@ -59,22 +67,38 @@ func TestRenderablePath(t *testing.T) {
 		assert.Equal(t, "", ok.renderablePath(""))
 	})
 
+	t.Run("traversal key is not resolved (defense in depth)", func(t *testing.T) {
+		gotKey = ""
+		// A ".." segment must never reach DownloadURL: url.JoinPath would resolve
+		// it and escape the sticker/ keyspace. renderablePath returns the stored
+		// value unchanged (a broken but non-escaping render) instead.
+		assert.Equal(t, "sticker/../a.png", ok.renderablePath("sticker/../a.png"))
+		assert.Empty(t, gotKey, "resolver must not be called for a traversal key")
+	})
+
+	t.Run("traversal key via preview prefix is not resolved", func(t *testing.T) {
+		gotKey = ""
+		in := "file/preview/sticker/../a.png"
+		assert.Equal(t, in, ok.renderablePath(in))
+		assert.Empty(t, gotKey, "resolver must not be called for a traversal key")
+	})
+
 	t.Run("resolver error falls back to stored value", func(t *testing.T) {
-		s := &Sticker{fileURL: fakeURLResolver{fn: func(string, string) (string, error) {
+		s := newRenderSticker(fakeURLResolver{fn: func(string, string) (string, error) {
 			return "", errors.New("boom")
-		}}}
+		}})
 		assert.Equal(t, "sticker/uid/a.png", s.renderablePath("sticker/uid/a.png"))
 	})
 
 	t.Run("empty resolver result falls back to stored value", func(t *testing.T) {
-		s := &Sticker{fileURL: fakeURLResolver{fn: func(string, string) (string, error) {
+		s := newRenderSticker(fakeURLResolver{fn: func(string, string) (string, error) {
 			return "", nil
-		}}}
+		}})
 		assert.Equal(t, "sticker/uid/a.png", s.renderablePath("sticker/uid/a.png"))
 	})
 
 	t.Run("nil resolver falls back to stored value", func(t *testing.T) {
-		s := &Sticker{}
+		s := newRenderSticker(nil)
 		assert.Equal(t, "sticker/uid/a.png", s.renderablePath("sticker/uid/a.png"))
 	})
 }

--- a/modules/sticker/render_test.go
+++ b/modules/sticker/render_test.go
@@ -1,0 +1,80 @@
+package sticker
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeURLResolver is a deterministic stickerURLResolver so renderablePath can be
+// unit-tested without a real object-storage backend.
+type fakeURLResolver struct {
+	fn func(path, filename string) (string, error)
+}
+
+func (f fakeURLResolver) DownloadURL(path, filename string) (string, error) {
+	return f.fn(path, filename)
+}
+
+func TestRenderablePath(t *testing.T) {
+	const resolved = "https://cdn.example.com/sticker/uid/a.png"
+
+	// resolver records the key it was asked to resolve so we can assert the
+	// "file/preview/" prefix was stripped before resolution.
+	var gotKey string
+	ok := &Sticker{fileURL: fakeURLResolver{fn: func(path, _ string) (string, error) {
+		gotKey = path
+		return resolved, nil
+	}}}
+
+	t.Run("absolute http passes through untouched", func(t *testing.T) {
+		gotKey = ""
+		in := "http://cdn.example.com/x.png"
+		assert.Equal(t, in, ok.renderablePath(in))
+		assert.Empty(t, gotKey, "resolver must not be called for an absolute URL")
+	})
+
+	t.Run("absolute https passes through untouched", func(t *testing.T) {
+		gotKey = ""
+		in := "https://cdn.example.com/x.png"
+		assert.Equal(t, in, ok.renderablePath(in))
+		assert.Empty(t, gotKey, "resolver must not be called for an absolute URL")
+	})
+
+	t.Run("bare object key is resolved", func(t *testing.T) {
+		gotKey = ""
+		assert.Equal(t, resolved, ok.renderablePath("sticker/uid/a.png"))
+		assert.Equal(t, "sticker/uid/a.png", gotKey)
+	})
+
+	t.Run("file/preview prefix is stripped before resolving", func(t *testing.T) {
+		gotKey = ""
+		assert.Equal(t, resolved, ok.renderablePath("file/preview/sticker/uid/a.png"))
+		assert.Equal(t, "sticker/uid/a.png", gotKey,
+			"leading file/preview/ must be stripped so legacy rows resolve like bare keys")
+	})
+
+	t.Run("empty stays empty", func(t *testing.T) {
+		assert.Equal(t, "", ok.renderablePath(""))
+	})
+
+	t.Run("resolver error falls back to stored value", func(t *testing.T) {
+		s := &Sticker{fileURL: fakeURLResolver{fn: func(string, string) (string, error) {
+			return "", errors.New("boom")
+		}}}
+		assert.Equal(t, "sticker/uid/a.png", s.renderablePath("sticker/uid/a.png"))
+	})
+
+	t.Run("empty resolver result falls back to stored value", func(t *testing.T) {
+		s := &Sticker{fileURL: fakeURLResolver{fn: func(string, string) (string, error) {
+			return "", nil
+		}}}
+		assert.Equal(t, "sticker/uid/a.png", s.renderablePath("sticker/uid/a.png"))
+	})
+
+	t.Run("nil resolver falls back to stored value", func(t *testing.T) {
+		s := &Sticker{}
+		assert.Equal(t, "sticker/uid/a.png", s.renderablePath("sticker/uid/a.png"))
+	})
+}


### PR DESCRIPTION
## Summary

`GET /v1/sticker/user` returned two different shapes in the same `path`
field: self-uploaded stickers carried an absolute anonymous-GET download
URL, while collected stickers (added in #533) carried the auth-gated
`file/preview/...` object key. That key is not directly renderable in an
`<img>` because `AuthMiddleware` only reads the token from a request
header, so every client had to branch on the path shape to render a list.

This normalizes the contract server-side so `path` is always a directly
renderable URL, regardless of how the sticker was added. No client-side
resolver is needed.

## Related Issue

Follow-up to #533 (sticker collect endpoint).

## Linked Spec

No brief; small follow-up hardening the response contract of #533.
Load-bearing (changes the `path` field semantics), so COMPREHENSION is
filled below.

## Changes

- Add a 1-method `stickerURLResolver` interface (satisfied by
  `file.IService`) and inject `file.NewService(ctx)` into the sticker
  module, mirroring the `modules/group` DI pattern.
- Add `renderablePath`: absolute `http(s)://` values pass through; object
  keys (and any leading `file/preview/`) resolve via `DownloadURL` to the
  same permanent public/CDN URL the preview redirect yields; resolve
  failure / empty result / nil resolver fall back to the stored value.
- Route every sticker response (list/add/collect/update) through a single
  `toResp` mapper so the `path` contract is uniform.
- `collect` now stores the bare object key instead of the preview path,
  keeping storage backend-agnostic (a CDN/host change re-resolves at read
  time). Idempotency is unaffected — it is keyed on `SourcePathHash`.
- No new response field, no client change, no migration: legacy rows
  normalize on read.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

- `go test ./modules/sticker/` — full package green (incl. the new
  `TestRenderablePath` unit test and updated add/collect integration
  assertions).
- `go build ./...`, `go vet ./modules/sticker/`, `gofmt -l`,
  `golangci-lint run ./modules/sticker/...` — all clean (0 issues).

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   It changes what `GET /v1/sticker/user` (and the add/collect/update
   responses) put in each sticker's `path`: instead of echoing the stored
   value verbatim, the server now resolves it to a client-renderable URL
   in one `toResp` mapper. `collect` also switches its stored value from
   the auth-gated `file/preview/...` path to the bare object key.

2. **What could break** because of it (dependents + failure mode)?

   Any client that relied on `path` being the exact string it uploaded
   (self-upload) or the `file/preview/...` key (collect) will now see a
   resolved URL. This is a superset of renderable values — old clients
   that fed `path` into an `<img>` keep working (absolute URLs already
   were, collected ones now are). The main risk is a client that parsed
   the object key out of `path`; none is known server-side. Resolution
   itself is fail-safe: on `DownloadURL` error the stored value is
   returned unchanged, so a misconfigured backend degrades to today's
   behavior rather than dropping the sticker.

3. **How do you know it works** (specific test/repro/trace)?

   `TestRenderablePath` covers passthrough of absolute URLs, key
   resolution, `file/preview/` prefix stripping, and error/empty/nil
   fallback with a deterministic fake resolver.
   `TestSticker_AddAndList` and `TestSticker_CollectForeignPathIdempotent`
   assert the endpoint returns the normalized value and that `collect`
   persists the bare key. `git diff --check origin/main...HEAD` is clean.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)