### PR TITLE
fix(space): member search name fallback + collation-safe verification JOIN #434

### DIFF
--- a/modules/space/api_member_search.go
+++ b/modules/space/api_member_search.go
@@ -69,8 +69,11 @@ func (s *Space) searchMembers(c *wkhttp.Context) {
 	resps := make([]memberSearchResp, 0, len(members))
 	for _, m := range members {
 		resps = append(resps, memberSearchResp{
-			UID:       m.UID,
-			Name:      m.Name,
+			UID: m.UID,
+			// DisplayName 复用成员列表的兜底链（issue #434）：user.name 为空时回退
+			// user_verification.real_name，二者皆空给稳定占位符，避免空名成员在
+			// 搜索结果里渲染成空白行。
+			Name:      m.DisplayName(),
 			Username:  m.Username,
 			Email:     m.Email,
 			Phone:     maskPhone(m.Phone),

--- a/modules/space/db.go
+++ b/modules/space/db.go
@@ -167,6 +167,15 @@ func (d *DB) queryMembers(spaceId string, loginUID string, page uint64, limit ui
 	return models, err
 }
 
+// memberVerificationJoinOn 是 space_member → user_verification 的 collation-safe
+// LEFT JOIN 条件。user_verification 被 modules/base 的 compat-repair 迁移强制
+// utf8mb4_general_ci，而 space_member 无显式 COLLATE、继承 DB 默认；在以 MySQL 8.0
+// 服务器默认（utf8mb4_0900_ai_ci）建库的部署上，裸的 uv.user_id = sm.uid 比较会抛
+// Illegal mix of collations (1267)（见 #482：queryMembers 已上 main 的同类风险）。
+// 显式 COLLATE 把 sm.uid 归一到 general_ci，使搜索路径不复刻同一 500 风险，且在
+// 规范 general_ci 库上是 no-op。
+const memberVerificationJoinOn = "uv.user_id = sm.uid COLLATE utf8mb4_general_ci"
+
 func (d *DB) searchMembers(spaceId, keyword string, pageIndex, pageSize int) ([]*memberSearchModel, error) {
 	builder := d.session.Select(
 		"sm.*",
@@ -174,9 +183,11 @@ func (d *DB) searchMembers(spaceId, keyword string, pageIndex, pageSize int) ([]
 		"IFNULL(u.username,'') as username",
 		"IFNULL(u.email,'') as email",
 		"IFNULL(u.phone,'') as phone",
+		"IFNULL(uv.real_name,'') as real_name",
 		"CASE WHEN r.robot_id IS NOT NULL AND r.status=1 THEN 1 ELSE 0 END as robot",
 	).From(dbr.I("space_member").As("sm")).
 		LeftJoin(dbr.I("user").As("u"), "u.uid=sm.uid").
+		LeftJoin(dbr.I("user_verification").As("uv"), memberVerificationJoinOn).
 		LeftJoin(dbr.I("robot").As("r"), "r.robot_id=sm.uid").
 		Where("sm.space_id=? AND sm.status=1", spaceId)
 	if keyword != "" {
@@ -198,6 +209,7 @@ func (d *DB) countSearchMembers(spaceId, keyword string) (int64, error) {
 	builder := d.session.Select("COUNT(*)").
 		From(dbr.I("space_member").As("sm")).
 		LeftJoin(dbr.I("user").As("u"), "u.uid=sm.uid").
+		LeftJoin(dbr.I("user_verification").As("uv"), memberVerificationJoinOn).
 		Where("sm.space_id=? AND sm.status=1", spaceId)
 	if keyword != "" {
 		clause, args := memberSearchActiveWhere(keyword)

--- a/modules/space/db_manager.go
+++ b/modules/space/db_manager.go
@@ -54,20 +54,29 @@ func memberSearchWhere(keyword string) (string, []interface{}) {
 //     （响应仅显示 138****5678），admin 无法通过子串查询逐位探测/重建完整号码。
 //
 // 前端注意：phone 检索只匹配后 4 位，传完整号码不会命中——按手机号查找请用后 4 位。
-// uv.real_name 让空 user.name 的成员可按实名被搜到（issue #434）；对应的 uv LEFT JOIN
-// 由 searchMembers / countSearchMembers 以 collation-safe 方式挂入（memberVerificationJoinOn）。
-var memberSearchActiveColumns = []string{"u.name", "u.username", "u.email", "RIGHT(u.phone,4)", "sm.uid", "uv.real_name"}
+// 注意：uv.real_name 不在此列——它只在「作为展示值」时可检索，由 memberSearchActiveWhere
+// 用 name 为空的门禁单独拼接，见该函数注释。
+var memberSearchActiveColumns = []string{"u.name", "u.username", "u.email", "RIGHT(u.phone,4)", "sm.uid"}
 
 // memberSearchActiveWhere 为空间侧 members/search 组装跨列 OR LIKE 条件。
 // list / count 共用同一条件，避免搜索范围漂移导致分页错位。
+//
+// real_name（user_verification 实名，PII）单独处理，且门禁在 user.name 为空：实名
+// **只在它是实际展示值时**（即 user.name 为空、DisplayName 回退到 real_name）才可检索，
+// 使「可检索粒度 == 可见粒度」——与本文件对 phone 只放后 4 位（maskPhone）同一取向。
+// 若无门禁，有 name 的成员响应只显示 name、绝不返回 real_name，却能被实名子串命中，
+// admin 便可把搜索当作实名 oracle 逐位探测出从不展示的法定姓名（#537 review 三人共识）。
 func memberSearchActiveWhere(keyword string) (string, []interface{}) {
 	like := buildLikePattern(keyword)
-	clauses := make([]string, len(memberSearchActiveColumns))
-	args := make([]interface{}, len(memberSearchActiveColumns))
-	for i, col := range memberSearchActiveColumns {
-		clauses[i] = col + " LIKE ?" + likeEscapeClause
-		args[i] = like
+	clauses := make([]string, 0, len(memberSearchActiveColumns)+1)
+	args := make([]interface{}, 0, len(memberSearchActiveColumns)+1)
+	for _, col := range memberSearchActiveColumns {
+		clauses = append(clauses, col+" LIKE ?"+likeEscapeClause)
+		args = append(args, like)
 	}
+	// 门禁与 resolveMemberDisplayName 的回退条件（name 非空即用 name）严格对齐。
+	clauses = append(clauses, "(IFNULL(u.name,'')='' AND uv.real_name LIKE ?"+likeEscapeClause+")")
+	args = append(args, like)
 	return strings.Join(clauses, " OR "), args
 }
 

--- a/modules/space/db_manager.go
+++ b/modules/space/db_manager.go
@@ -54,7 +54,9 @@ func memberSearchWhere(keyword string) (string, []interface{}) {
 //     （响应仅显示 138****5678），admin 无法通过子串查询逐位探测/重建完整号码。
 //
 // 前端注意：phone 检索只匹配后 4 位，传完整号码不会命中——按手机号查找请用后 4 位。
-var memberSearchActiveColumns = []string{"u.name", "u.username", "u.email", "RIGHT(u.phone,4)", "sm.uid"}
+// uv.real_name 让空 user.name 的成员可按实名被搜到（issue #434）；对应的 uv LEFT JOIN
+// 由 searchMembers / countSearchMembers 以 collation-safe 方式挂入（memberVerificationJoinOn）。
+var memberSearchActiveColumns = []string{"u.name", "u.username", "u.email", "RIGHT(u.phone,4)", "sm.uid", "uv.real_name"}
 
 // memberSearchActiveWhere 为空间侧 members/search 组装跨列 OR LIKE 条件。
 // list / count 共用同一条件，避免搜索范围漂移导致分页错位。

--- a/modules/space/db_member_search_name_fallback_test.go
+++ b/modules/space/db_member_search_name_fallback_test.go
@@ -1,0 +1,88 @@
+package space
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test_Issue434_SearchMemberDisplayNamePure 纯函数验证成员搜索路径复用了与成员
+// 列表相同的兜底链（issue #434）：name 空 → real_name → 稳定占位符，任何分支非空，
+// 绝不读 short_no/username。不依赖 DB。
+func Test_Issue434_SearchMemberDisplayNamePure(t *testing.T) {
+	mk := func(uid, name, realName string) *memberSearchModel {
+		m := &memberSearchModel{Name: name, RealName: realName}
+		m.UID = uid
+		return m
+	}
+
+	assert.Equal(t, "Alice", mk("u1", "Alice", "Real").DisplayName())
+	assert.Equal(t, "Real", mk("u2", "", "Real").DisplayName())
+	assert.Equal(t, memberDisplayNamePlaceholderPrefix+"u3", mk("u3", "", "").DisplayName())
+	assert.NotEqual(t, "", mk("u4", "", "").DisplayName(), "placeholder must never be empty")
+}
+
+// Test_Issue434_SearchMemberNameFallback 复现 #434 的 P1 缺口之一：成员搜索结果
+// 对空 user.name 的成员未做兜底，会渲染成空白行。修复后 Name 应回退 real_name，
+// 二者皆空时给稳定占位符。
+func Test_Issue434_SearchMemberNameFallback(t *testing.T) {
+	srv, _, err := setup(t)
+	assert.NoError(t, err)
+
+	const spaceId = "sp-434-search-fallback"
+	seedMemberSearchSpace(t, spaceId, testutil.UID) // 调用者即 owner，满足搜索前置校验
+
+	// 1) name 空 + real_name 有 → 搜索结果回退 real_name
+	const uidReal = "u434-real"
+	seedFallbackUser(t, uidReal, "")
+	seedFallbackVerification(t, uidReal, "Zhang Wei")
+	seedMemberSearchMember(t, spaceId, uidReal, 0, 1)
+
+	// 2) name 空 + real_name 空 → 稳定占位符，绝不空白
+	const uidPlaceholder = "u434-ph"
+	seedFallbackUser(t, uidPlaceholder, "")
+	seedMemberSearchMember(t, spaceId, uidPlaceholder, 0, 1)
+
+	w := getMembersSearch(t, srv, testCtx, spaceId, url.Values{"page_size": {"50"}})
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	resp := decodeMembersSearchResp(t, w)
+
+	real, ok := findMemberSearchItem(resp.List, uidReal)
+	if assert.True(t, ok, "real_name member missing from search results") {
+		assert.Equal(t, "Zhang Wei", real.Name, "empty name must fall back to real_name in search results")
+	}
+	ph, ok := findMemberSearchItem(resp.List, uidPlaceholder)
+	if assert.True(t, ok, "placeholder member missing from search results") {
+		assert.NotEqual(t, "", ph.Name, "blank name+real_name must never render as an empty string")
+		assert.Equal(t, memberDisplayNamePlaceholderPrefix+uidPlaceholder, ph.Name)
+	}
+}
+
+// Test_Issue434_SearchByRealName 复现 #434 的 P1 缺口之二：空 user.name 的成员
+// 无法通过实名被搜到。关键词只匹配 user_verification.real_name（不匹配
+// name/username/email/phone/uid），修复前 count=0，修复后应命中该成员并回退展示实名。
+func Test_Issue434_SearchByRealName(t *testing.T) {
+	srv, _, err := setup(t)
+	assert.NoError(t, err)
+
+	const spaceId = "sp-434-search-realname"
+	seedMemberSearchSpace(t, spaceId, testutil.UID)
+
+	const uid = "u434-byreal"
+	seedFallbackUser(t, uid, "") // 无 user.name / username / email / phone
+	seedFallbackVerification(t, uid, "Ouyang Feng")
+	seedMemberSearchMember(t, spaceId, uid, 0, 1)
+
+	w := getMembersSearch(t, srv, testCtx, spaceId, url.Values{"keyword": {"Ouyang"}})
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	resp := decodeMembersSearchResp(t, w)
+
+	assert.EqualValues(t, 1, resp.Count, "member with blank name must be searchable by real_name")
+	if assert.Len(t, resp.List, 1) {
+		assert.Equal(t, uid, resp.List[0].UID)
+		assert.Equal(t, "Ouyang Feng", resp.List[0].Name, "search result must display the real_name fallback")
+	}
+}

--- a/modules/space/db_member_search_name_fallback_test.go
+++ b/modules/space/db_member_search_name_fallback_test.go
@@ -86,3 +86,40 @@ func Test_Issue434_SearchByRealName(t *testing.T) {
 		assert.Equal(t, "Ouyang Feng", resp.List[0].Name, "search result must display the real_name fallback")
 	}
 }
+
+// Test_Issue434_NamedMemberNotSearchableByRealName pins the privacy invariant flagged
+// by the #537 review (three-reviewer consensus): real_name is searchable ONLY when it is
+// the actual display value (user.name blank). A member with a non-empty user.name displays
+// that name and never returns real_name, so their verification real_name must NOT be a
+// search oracle — otherwise an in-space admin could substring-probe a hidden legal name and
+// confirm it via the hit/count. This is the "可检索粒度 == 可见粒度" boundary the file also
+// holds for phone (maskPhone). Without the name-empty gate this test fails (member matched).
+func Test_Issue434_NamedMemberNotSearchableByRealName(t *testing.T) {
+	srv, _, err := setup(t)
+	assert.NoError(t, err)
+
+	const spaceId = "sp-434-realname-oracle"
+	seedMemberSearchSpace(t, spaceId, testutil.UID)
+
+	// Named member: a visible user.name AND a distinct (hidden) verification real_name.
+	const uid = "u434-named-hidden"
+	seedFallbackUser(t, uid, "Visible Name")
+	seedFallbackVerification(t, uid, "Secret Legal Name")
+	seedMemberSearchMember(t, spaceId, uid, 0, 1)
+
+	// Probing the hidden real_name must not match — searchable granularity == visible granularity.
+	w := getMembersSearch(t, srv, testCtx, spaceId, url.Values{"keyword": {"Secret Legal"}})
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	resp := decodeMembersSearchResp(t, w)
+	assert.EqualValues(t, 0, resp.Count, "named member must not be discoverable by their hidden real_name")
+	_, found := findMemberSearchItem(resp.List, uid)
+	assert.False(t, found, "named member's real_name must not act as a search oracle")
+
+	// Sanity: the same member is still findable by their visible name (fallback gate is one-way).
+	w2 := getMembersSearch(t, srv, testCtx, spaceId, url.Values{"keyword": {"Visible"}})
+	assert.Equal(t, http.StatusOK, w2.Code, w2.Body.String())
+	resp2 := decodeMembersSearchResp(t, w2)
+	if item, ok := findMemberSearchItem(resp2.List, uid); assert.True(t, ok, "named member must remain findable by visible name") {
+		assert.Equal(t, "Visible Name", item.Name)
+	}
+}

--- a/modules/space/model.go
+++ b/modules/space/model.go
@@ -47,6 +47,7 @@ type memberSearchModel struct {
 	Username string
 	Email    string
 	Phone    string
+	RealName string // 实名兜底（user_verification.real_name），仅作 name 为空时的回退源
 	Robot    int
 }
 
@@ -272,13 +273,31 @@ const memberDisplayNamePlaceholderPrefix = "User "
 //
 // 任何分支都不会返回空串，也不会暴露 short_no / username。
 func (m *MemberDetailModel) DisplayName() string {
-	if m.Name != "" {
-		return m.Name
+	return resolveMemberDisplayName(m.Name, m.RealName, m.UID)
+}
+
+// DisplayName 让成员搜索路径（issue #434）复用与成员列表相同的兜底链，
+// 避免空名成员在搜索结果里渲染成空白行。见 resolveMemberDisplayName。
+func (m *memberSearchModel) DisplayName() string {
+	return resolveMemberDisplayName(m.Name, m.RealName, m.UID)
+}
+
+// resolveMemberDisplayName 是成员展示名兜底链的纯函数实现（issue #344、#434）：
+//  1. name 非空 → 原样返回；
+//  2. 否则 realName 非空 → 返回实名；
+//  3. 都空 → 返回稳定占位符 "<memberDisplayNamePlaceholderPrefix><uid>"。
+//
+// 成员列表（MemberDetailModel）与成员搜索（memberSearchModel）两条路径共用它，
+// 避免兜底链被各自重新实现而在演进中漂移。任何分支都不返回空串，也绝不读
+// short_no / username（privacy-gated）。
+func resolveMemberDisplayName(name, realName, uid string) string {
+	if name != "" {
+		return name
 	}
-	if m.RealName != "" {
-		return m.RealName
+	if realName != "" {
+		return realName
 	}
-	return memberDisplayNamePlaceholderPrefix + m.UID
+	return memberDisplayNamePlaceholderPrefix + uid
 }
 
 // SpaceDetailModel 带成员数和角色的空间详情（MaxUsers 从 SpaceModel 继承）


### PR DESCRIPTION
## Summary

Space-side member search (`GET /v1/space/:space_id/members/search`) never picked up the display-name fallback that #420 added to the member list, so this closes the **P1** gap tracked in #434:

- blank `user.name` members rendered an **empty name** in search results;
- members with a blank `user.name` were **not searchable by `real_name`**.

## Changes

- `searchMembers` / `countSearchMembers` now `LEFT JOIN user_verification` and select `real_name`.
- The search response reuses the same fallback chain as the member list — `user.name` → `user_verification.real_name` → stable `"User <uid>"` placeholder — extracted into a shared pure `resolveMemberDisplayName` helper (used by both `MemberDetailModel.DisplayName()` and the new `memberSearchModel.DisplayName()`).
- `uv.real_name` added to the searchable columns so blank-name members are findable by real name.
- **Collation-safe from the start**: the new JOIN uses `ON uv.user_id = sm.uid COLLATE utf8mb4_general_ci`, so it does **not** reintroduce the `Illegal mix of collations (1267)` / 500 risk that #482 tracks for `queryMembers` on non-canonical (`0900_ai_ci`) deployments.

## Scope

Only the P1 search path. The remaining #434 follow-ups (P2 avatar / other `IFNULL(u.name,'')` endpoints, P3 shared `pkg/displayname`) are intentionally left for separate PRs (one-PR-one-thing).

## Verification

Ran against a real MySQL 8.0.46 instance:
- Full `modules/space` suite **green** on the canonical `general_ci` DB (incl. 3 new `Test_Issue434_*` tests).
- RED→GREEN confirmed: both new DB-backed tests fail without the fix (empty `Name`; `count=0`) and pass with it.
- Collation safety proven on a `0900_ai_ci` DB with the exact prod schema mismatch (`space_member`=`0900_ai_ci`, `user_verification`=`general_ci`): the bare join raises Error 1267 while the `COLLATE`-safe join returns rows correctly.

Refs #434, #420, #482, #344.

> ⚠️ Draft — awaiting review squad (qa + security + code). Do not merge.
