### PR TITLE
fix(group): async reconcile for orphan groups without IM channel #394

### DIFF
--- a/modules/group/1module.go
+++ b/modules/group/1module.go
@@ -1,6 +1,7 @@
 package group
 
 import (
+	"context"
 	"embed"
 	"fmt"
 	"time"
@@ -30,8 +31,27 @@ func init() {
 		// source_space_* / home_space_* 字段，让 Web/Android/iOS UserInfo 能区分
 		// "同 Space 非好友 → 直接发消息" vs "跨 Space 外部成员 → 仅可在群内交流"。
 		user.RegisterGroupMemberExternalProvider(api.groupService.GetMemberExternalFields)
+
+		// #394 孤儿群对账 worker：收口 CreateGroup「commit 后建频道」失败留下的孤儿群。
+		// workerCancel 每次 Start 重建，给未来 graceful-reload 留余地（当前框架只 Start 一次）。
+		reconciler := NewChannelReconciler(ctx.(*config.Context), LoadChannelReconcileConfig())
+		var reconcilerCancel context.CancelFunc
+
 		return register.Module{
 			Name: "group",
+			Start: func() error {
+				workerCtx, cancel := context.WithCancel(context.Background())
+				reconcilerCancel = cancel
+				reconciler.Start(workerCtx)
+				return nil
+			},
+			Stop: func() error {
+				if reconcilerCancel != nil {
+					reconcilerCancel()
+				}
+				reconciler.Stop()
+				return nil
+			},
 			SetupAPI: func() register.APIRouter {
 				return api
 			},

--- a/modules/group/channel_reconcile_config.go
+++ b/modules/group/channel_reconcile_config.go
@@ -1,0 +1,96 @@
+package group
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ChannelReconcileConfig 孤儿群 IM 频道对账 worker 的运行参数。#394
+type ChannelReconcileConfig struct {
+	// Enabled 总开关。默认 true——这是数据一致性兜底，正常运行下只是每 Interval 跑一次
+	// 廉价的空查询（无 channel_synced=0 行时零动作），默认开启才能让 #394 修复开箱生效。
+	Enabled bool
+	// Interval 两次扫描之间的间隔。<=0 回退默认值。
+	Interval time.Duration
+	// Grace 宽限期：只处理 created_at 早于 now-Grace 的未同步群，避免与仍在途的建群主
+	// 路径抢跑（建群 commit 后尚未标记 synced 的极短窗口）。<0 回退默认值。
+	Grace time.Duration
+	// BatchSize 单轮最多处理的孤儿群数，给 IM/DB 限流。<=0 回退默认值。
+	BatchSize int
+}
+
+const (
+	envReconcileEnabled  = "GROUP_CHANNEL_RECONCILE_ENABLED"
+	envReconcileInterval = "GROUP_CHANNEL_RECONCILE_INTERVAL"
+	envReconcileGrace    = "GROUP_CHANNEL_RECONCILE_GRACE"
+	envReconcileBatch    = "GROUP_CHANNEL_RECONCILE_BATCH"
+
+	defaultReconcileInterval = 5 * time.Minute
+	defaultReconcileGrace    = 5 * time.Minute
+	defaultReconcileBatch    = 200
+	// maxReconcileBatch 防止运维误填巨数把单轮对账变成长时间 IM 风暴。
+	maxReconcileBatch = 2000
+)
+
+// LoadChannelReconcileConfig 从环境变量装载配置。错误 / 越界值一律回退默认值。
+func LoadChannelReconcileConfig() ChannelReconcileConfig {
+	return ChannelReconcileConfig{
+		Enabled:   parseBoolDefault(os.Getenv(envReconcileEnabled), true),
+		Interval:  parsePositiveDuration(os.Getenv(envReconcileInterval), defaultReconcileInterval),
+		Grace:     parseNonNegativeDuration(os.Getenv(envReconcileGrace), defaultReconcileGrace),
+		BatchSize: parseBoundedPositiveInt(os.Getenv(envReconcileBatch), defaultReconcileBatch, maxReconcileBatch),
+	}
+}
+
+// parseBoolDefault: 空值回退 def；显式 "false"/"0" → false，"true"/"1" → true，其它回 def。
+func parseBoolDefault(raw string, def bool) bool {
+	v := strings.ToLower(strings.TrimSpace(raw))
+	switch v {
+	case "":
+		return def
+	case "true", "1":
+		return true
+	case "false", "0":
+		return false
+	default:
+		return def
+	}
+}
+
+func parsePositiveDuration(raw string, def time.Duration) time.Duration {
+	if raw == "" {
+		return def
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return def
+	}
+	return d
+}
+
+func parseNonNegativeDuration(raw string, def time.Duration) time.Duration {
+	if raw == "" {
+		return def
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d < 0 {
+		return def
+	}
+	return d
+}
+
+func parseBoundedPositiveInt(raw string, def, max int) int {
+	if raw == "" {
+		return def
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return def
+	}
+	if n > max {
+		return max
+	}
+	return n
+}

--- a/modules/group/channel_reconciler.go
+++ b/modules/group/channel_reconciler.go
@@ -1,0 +1,161 @@
+package group
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+
+	"go.uber.org/zap"
+)
+
+// reconcileDB 抽出 ChannelReconciler 需要的最小 DB 接口，便于单测 mock。
+type reconcileDB interface {
+	QueryUnsyncedGroupNos(before time.Time, limit int) ([]string, error)
+	QueryMemberUIDsWithGroupNo(groupNo string) ([]string, error)
+	MarkChannelSynced(groupNo string) error
+	DeleteOrphanGroup(groupNo string) error
+}
+
+// reconcileIM 抽出重建 IM 频道所需的最小接口（*config.Context 实现之），便于单测 mock。
+type reconcileIM interface {
+	IMCreateOrUpdateChannel(req *config.ChannelCreateReq) error
+}
+
+// ChannelReconciler 周期性扫描 channel_synced=0 的群，收口 CreateGroup「commit 后建频道」
+// 留下的孤儿群：有成员 → 幂等重建 IM 频道并标记 synced；无成员（补偿删除已删成员但群行
+// 残留）→ 硬删除孤儿群行。实现最终一致，闭合 #394 的孤儿窗口。
+type ChannelReconciler struct {
+	cfg ChannelReconcileConfig
+	db  reconcileDB
+	im  reconcileIM
+	now func() time.Time
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+	log.Log
+}
+
+// NewChannelReconciler 构造 worker。生产路径用 group.NewDB 和 config.Context 注入。
+func NewChannelReconciler(ctx *config.Context, cfg ChannelReconcileConfig) *ChannelReconciler {
+	return &ChannelReconciler{
+		cfg: cfg,
+		db:  NewDB(ctx),
+		im:  ctx,
+		now: time.Now,
+		Log: log.NewTLog("GroupChannelReconciler"),
+	}
+}
+
+// Start 启动后台 ticker。Enabled=false 或参数非法时不启动新 goroutine，但仍先停掉可能
+// 存在的旧 goroutine——避免未来热更新留下孤儿 ticker。重复调用幂等。
+func (w *ChannelReconciler) Start(ctx context.Context) {
+	if w.cancel != nil {
+		w.cancel()
+		w.wg.Wait()
+		w.cancel = nil
+	}
+	if !w.cfg.Enabled || w.cfg.Interval <= 0 || w.cfg.BatchSize <= 0 {
+		w.Info("group channel reconciler disabled",
+			zap.Bool("enabled", w.cfg.Enabled),
+			zap.Duration("interval", w.cfg.Interval),
+			zap.Int("batch_size", w.cfg.BatchSize))
+		return
+	}
+	rctx, cancel := context.WithCancel(ctx)
+	w.cancel = cancel
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+		t := time.NewTicker(w.cfg.Interval)
+		defer t.Stop()
+		w.Info("group channel reconciler started",
+			zap.Duration("interval", w.cfg.Interval),
+			zap.Duration("grace", w.cfg.Grace),
+			zap.Int("batch_size", w.cfg.BatchSize))
+		for {
+			select {
+			case <-rctx.Done():
+				return
+			case <-t.C:
+				recreated, deleted, err := w.RunOnce(rctx)
+				if err != nil && !errors.Is(err, context.Canceled) {
+					w.Error("group channel reconcile run failed", zap.Error(err))
+					continue
+				}
+				if recreated > 0 || deleted > 0 {
+					w.Info("group channel reconcile run",
+						zap.Int("recreated", recreated),
+						zap.Int("deleted", deleted))
+				}
+			}
+		}
+	}()
+}
+
+// Stop 通知 worker 退出并等待当前 RunOnce 跑完。
+func (w *ChannelReconciler) Stop() {
+	if w.cancel != nil {
+		w.cancel()
+	}
+	w.wg.Wait()
+}
+
+// RunOnce 执行一轮对账：取一批 channel_synced=0 且早于宽限期的群，逐个收口。
+// 返回本轮 (重建频道数, 硬删除孤儿数, err)。单个群失败只记日志、不中断整批——
+// 下一轮 tick 会重试（IMCreateOrUpdateChannel 是 upsert 幂等，重跑安全）。
+func (w *ChannelReconciler) RunOnce(ctx context.Context) (int, int, error) {
+	if w.cfg.BatchSize <= 0 {
+		return 0, 0, nil
+	}
+	before := w.now().Add(-w.cfg.Grace)
+	groupNos, err := w.db.QueryUnsyncedGroupNos(before, w.cfg.BatchSize)
+	if err != nil {
+		return 0, 0, err
+	}
+	var recreated, deleted int
+	for _, groupNo := range groupNos {
+		if err := ctx.Err(); err != nil {
+			return recreated, deleted, err
+		}
+		uids, err := w.db.QueryMemberUIDsWithGroupNo(groupNo)
+		if err != nil {
+			w.Error("reconcile: query members failed", zap.String("groupNo", groupNo), zap.Error(err))
+			continue
+		}
+		if len(uids) == 0 {
+			// 补偿删除部分成功：成员已删、群行残留 → 群无有效成员、不可恢复，硬删除孤儿。
+			if err := w.db.DeleteOrphanGroup(groupNo); err != nil {
+				w.Error("reconcile: delete memberless orphan failed", zap.String("groupNo", groupNo), zap.Error(err))
+				continue
+			}
+			deleted++
+			w.Info("reconcile: hard-deleted memberless orphan group", zap.String("groupNo", groupNo))
+			continue
+		}
+		// 有成员 → 幂等重建 IM 频道，成功后标记 synced。失败留到下轮重试。
+		if err := w.im.IMCreateOrUpdateChannel(&config.ChannelCreateReq{
+			ChannelID:   groupNo,
+			ChannelType: common.ChannelTypeGroup.Uint8(),
+			Subscribers: uids,
+		}); err != nil {
+			w.Error("reconcile: recreate IM channel failed, will retry next round",
+				zap.String("groupNo", groupNo), zap.Error(err))
+			continue
+		}
+		if err := w.db.MarkChannelSynced(groupNo); err != nil {
+			// 频道已建成、仅标记失败：下轮再跑一次（IMCreate 幂等）即可收敛，无害。
+			w.Error("reconcile: mark synced failed after channel recreate",
+				zap.String("groupNo", groupNo), zap.Error(err))
+			continue
+		}
+		recreated++
+		w.Info("reconcile: recreated IM channel for orphan group",
+			zap.String("groupNo", groupNo), zap.Int("subscribers", len(uids)))
+	}
+	return recreated, deleted, nil
+}

--- a/modules/group/channel_reconciler_test.go
+++ b/modules/group/channel_reconciler_test.go
@@ -1,0 +1,244 @@
+package group
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubReconcileDB 模拟对账 worker 的 DB 面：一批未同步群 + 每群成员映射，
+// 并记录 MarkChannelSynced / DeleteOrphanGroup 的调用，用于断言收口动作。
+type stubReconcileDB struct {
+	unsynced    []string
+	members     map[string][]string
+	queryErr    error
+	memberErr   map[string]error
+	syncErr     map[string]error
+	deleteErr   map[string]error
+	syncedCalls []string
+	deleteCalls []string
+	gotBefore   time.Time
+	gotLimit    int
+}
+
+func (s *stubReconcileDB) QueryUnsyncedGroupNos(before time.Time, limit int) ([]string, error) {
+	s.gotBefore = before
+	s.gotLimit = limit
+	if s.queryErr != nil {
+		return nil, s.queryErr
+	}
+	return s.unsynced, nil
+}
+
+func (s *stubReconcileDB) QueryMemberUIDsWithGroupNo(groupNo string) ([]string, error) {
+	if s.memberErr != nil {
+		if err := s.memberErr[groupNo]; err != nil {
+			return nil, err
+		}
+	}
+	return s.members[groupNo], nil
+}
+
+func (s *stubReconcileDB) MarkChannelSynced(groupNo string) error {
+	if s.syncErr != nil {
+		if err := s.syncErr[groupNo]; err != nil {
+			return err
+		}
+	}
+	s.syncedCalls = append(s.syncedCalls, groupNo)
+	return nil
+}
+
+func (s *stubReconcileDB) DeleteOrphanGroup(groupNo string) error {
+	if s.deleteErr != nil {
+		if err := s.deleteErr[groupNo]; err != nil {
+			return err
+		}
+	}
+	s.deleteCalls = append(s.deleteCalls, groupNo)
+	return nil
+}
+
+// stubReconcileIM 记录每次 IMCreateOrUpdateChannel 的请求，并可按 channelID 注入失败。
+type stubReconcileIM struct {
+	calls  []*config.ChannelCreateReq
+	failed map[string]error
+}
+
+func (s *stubReconcileIM) IMCreateOrUpdateChannel(req *config.ChannelCreateReq) error {
+	s.calls = append(s.calls, req)
+	if s.failed != nil {
+		if err := s.failed[req.ChannelID]; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func newTestReconciler(cfg ChannelReconcileConfig, db reconcileDB, im reconcileIM, now time.Time) *ChannelReconciler {
+	return &ChannelReconciler{
+		cfg: cfg,
+		db:  db,
+		im:  im,
+		now: func() time.Time { return now },
+		Log: log.NewTLog("GroupChannelReconcilerTest"),
+	}
+}
+
+func reconcileTestCfg() ChannelReconcileConfig {
+	return ChannelReconcileConfig{
+		Enabled:   true,
+		Interval:  time.Minute,
+		Grace:     5 * time.Minute,
+		BatchSize: 100,
+	}
+}
+
+// Test_Issue394_ReconcileRecreatesChannelForOrphanWithMembers 复现并验证核心修复：
+// CreateGroup「commit 后建频道」失败 + 补偿删除也失败留下的孤儿群（channel_synced=0，
+// 成员仍在），对账 worker 必须幂等重建 IM 频道并标记 synced。
+//
+// 修复前：无对账路径，孤儿群永久存在——群可被列出却无 IM 频道，客户端永远无法发消息。
+func Test_Issue394_ReconcileRecreatesChannelForOrphanWithMembers(t *testing.T) {
+	db := &stubReconcileDB{
+		unsynced: []string{"g1"},
+		members:  map[string][]string{"g1": {"u1", "u2"}},
+	}
+	im := &stubReconcileIM{}
+	w := newTestReconciler(reconcileTestCfg(), db, im, time.Unix(1_700_000_000, 0))
+
+	recreated, deleted, err := w.RunOnce(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, recreated, "orphan with members must have its channel recreated")
+	assert.Equal(t, 0, deleted)
+
+	require.Len(t, im.calls, 1, "must call IMCreateOrUpdateChannel exactly once")
+	assert.Equal(t, "g1", im.calls[0].ChannelID)
+	assert.ElementsMatch(t, []string{"u1", "u2"}, im.calls[0].Subscribers, "subscribers must be the group's members")
+	assert.Equal(t, []string{"g1"}, db.syncedCalls, "must mark synced after successful recreate")
+	assert.Empty(t, db.deleteCalls, "a group with members must never be hard-deleted")
+}
+
+// Test_Issue394_ReconcileHardDeletesMemberlessOrphan 验证补偿删除部分成功的场景：
+// group_member 已删、group 行残留 → 群无有效成员、不可恢复 → 硬删除孤儿群行。
+func Test_Issue394_ReconcileHardDeletesMemberlessOrphan(t *testing.T) {
+	db := &stubReconcileDB{
+		unsynced: []string{"g_empty"},
+		members:  map[string][]string{"g_empty": {}},
+	}
+	im := &stubReconcileIM{}
+	w := newTestReconciler(reconcileTestCfg(), db, im, time.Unix(1_700_000_000, 0))
+
+	recreated, deleted, err := w.RunOnce(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, recreated)
+	assert.Equal(t, 1, deleted, "memberless orphan must be hard-deleted")
+
+	assert.Empty(t, im.calls, "must not recreate a channel for a memberless orphan")
+	assert.Equal(t, []string{"g_empty"}, db.deleteCalls)
+	assert.Empty(t, db.syncedCalls)
+}
+
+// Test_Issue394_ReconcileLeavesUnsyncedWhenIMStillFailing 验证幂等重试语义：
+// 若重建 IM 频道仍失败，worker 不标记 synced、不删除——群留待下一轮重试，绝不丢数据。
+func Test_Issue394_ReconcileLeavesUnsyncedWhenIMStillFailing(t *testing.T) {
+	db := &stubReconcileDB{
+		unsynced: []string{"g_imdown"},
+		members:  map[string][]string{"g_imdown": {"u1"}},
+	}
+	im := &stubReconcileIM{failed: map[string]error{"g_imdown": errors.New("IM still down")}}
+	w := newTestReconciler(reconcileTestCfg(), db, im, time.Unix(1_700_000_000, 0))
+
+	recreated, deleted, err := w.RunOnce(context.Background())
+	require.NoError(t, err, "a single group's IM failure must not fail the whole batch")
+	assert.Equal(t, 0, recreated)
+	assert.Equal(t, 0, deleted)
+	assert.Empty(t, db.syncedCalls, "must not mark synced when the channel recreate failed")
+	assert.Empty(t, db.deleteCalls, "must not delete a group that still has members")
+}
+
+// Test_Issue394_ReconcileProcessesMixedBatchAndContinuesOnPerItemError 验证一个群
+// 出错不影响同批其它群，且混合场景（重建 + 删除）都被正确收口。
+func Test_Issue394_ReconcileProcessesMixedBatchAndContinuesOnPerItemError(t *testing.T) {
+	db := &stubReconcileDB{
+		unsynced: []string{"g_members", "g_qerr", "g_empty"},
+		members: map[string][]string{
+			"g_members": {"u1"},
+			"g_empty":   {},
+		},
+		memberErr: map[string]error{"g_qerr": errors.New("transient query error")},
+	}
+	im := &stubReconcileIM{}
+	w := newTestReconciler(reconcileTestCfg(), db, im, time.Unix(1_700_000_000, 0))
+
+	recreated, deleted, err := w.RunOnce(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, recreated, "g_members must be recreated despite g_qerr failing")
+	assert.Equal(t, 1, deleted, "g_empty must be deleted despite g_qerr failing")
+	assert.Equal(t, []string{"g_members"}, db.syncedCalls)
+	assert.Equal(t, []string{"g_empty"}, db.deleteCalls)
+}
+
+// Test_Issue394_ReconcileGracePeriodPassedToQuery 验证宽限期：查询下界必须是 now-Grace，
+// 使得刚建、IM 创建可能仍在途的新群被跳过，不与建群主路径抢跑。
+func Test_Issue394_ReconcileGracePeriodPassedToQuery(t *testing.T) {
+	db := &stubReconcileDB{}
+	now := time.Unix(1_700_000_000, 0)
+	cfg := reconcileTestCfg()
+	cfg.Grace = 10 * time.Minute
+	w := newTestReconciler(cfg, db, &stubReconcileIM{}, now)
+
+	_, _, err := w.RunOnce(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, now.Add(-10*time.Minute), db.gotBefore, "query cutoff must be now-Grace")
+	assert.Equal(t, cfg.BatchSize, db.gotLimit)
+}
+
+// Test_Issue394_ReconcileQueryErrorSurfaces 验证批量查询失败时向上返回错误（供 Start 记日志）。
+func Test_Issue394_ReconcileQueryErrorSurfaces(t *testing.T) {
+	db := &stubReconcileDB{queryErr: errors.New("db down")}
+	w := newTestReconciler(reconcileTestCfg(), db, &stubReconcileIM{}, time.Unix(1_700_000_000, 0))
+
+	_, _, err := w.RunOnce(context.Background())
+	require.Error(t, err)
+}
+
+// Test_Issue394_ReconcileDisabledConfigNoop 验证 BatchSize<=0 时 RunOnce 直接空转，不查库。
+func Test_Issue394_ReconcileDisabledConfigNoop(t *testing.T) {
+	db := &stubReconcileDB{unsynced: []string{"g1"}, members: map[string][]string{"g1": {"u1"}}}
+	cfg := reconcileTestCfg()
+	cfg.BatchSize = 0
+	w := newTestReconciler(cfg, db, &stubReconcileIM{}, time.Unix(1_700_000_000, 0))
+
+	recreated, deleted, err := w.RunOnce(context.Background())
+	require.NoError(t, err)
+	assert.Zero(t, recreated)
+	assert.Zero(t, deleted)
+	assert.True(t, db.gotBefore.IsZero(), "must not query when disabled")
+}
+
+// Test_Issue394_LoadChannelReconcileConfigDefaults 验证默认开启 + 默认参数，且 env 显式关闭生效。
+func Test_Issue394_LoadChannelReconcileConfigDefaults(t *testing.T) {
+	t.Setenv(envReconcileEnabled, "")
+	t.Setenv(envReconcileInterval, "")
+	t.Setenv(envReconcileGrace, "")
+	t.Setenv(envReconcileBatch, "")
+	cfg := LoadChannelReconcileConfig()
+	assert.True(t, cfg.Enabled, "reconciler must default ON so the #394 fix works out of the box")
+	assert.Equal(t, defaultReconcileInterval, cfg.Interval)
+	assert.Equal(t, defaultReconcileGrace, cfg.Grace)
+	assert.Equal(t, defaultReconcileBatch, cfg.BatchSize)
+
+	t.Setenv(envReconcileEnabled, "false")
+	assert.False(t, LoadChannelReconcileConfig().Enabled, "explicit false must disable")
+
+	t.Setenv(envReconcileEnabled, "true")
+	t.Setenv(envReconcileBatch, "99999")
+	assert.Equal(t, maxReconcileBatch, LoadChannelReconcileConfig().BatchSize, "oversized batch clamps to max")
+}

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -50,6 +50,56 @@ func (d *DB) UpdateGroupType(groupNo string, groupType GroupType) error {
 	return err
 }
 
+// MarkChannelUnsyncedTx 在事务内把 group.channel_synced 置 0（IM 频道尚未确认创建）。
+// CreateGroup 在群行插入后、commit 前调用；提交后的建频道失败若补偿删除也失败，
+// 残留的群行 channel_synced 停在 0，被 ChannelReconciler 发现并收口。#394
+func (d *DB) MarkChannelUnsyncedTx(groupNo string, tx *dbr.Tx) error {
+	_, err := tx.Update("group").Set("channel_synced", 0).Where("group_no=?", groupNo).Exec()
+	return err
+}
+
+// MarkChannelSynced 把 group.channel_synced 置 1（IM 频道已确认创建）。
+func (d *DB) MarkChannelSynced(groupNo string) error {
+	_, err := d.session.Update("group").Set("channel_synced", 1).Where("group_no=?", groupNo).Exec()
+	return err
+}
+
+// QueryUnsyncedGroupNos 返回 channel_synced=0 且 created_at < before 的群编号（最多 limit 个）。
+// before 是宽限期上界：跳过刚建、IM 创建可能仍在途的新群，避免与建群主路径抢跑。
+func (d *DB) QueryUnsyncedGroupNos(before time.Time, limit int) ([]string, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	var groupNos []string
+	_, err := d.session.Select("group_no").
+		From("group").
+		Where("channel_synced=0 AND created_at < ?", before).
+		OrderDir("created_at", true).
+		Limit(uint64(limit)).
+		Load(&groupNos)
+	return groupNos, err
+}
+
+// QueryMemberUIDsWithGroupNo 返回某群全部未删除成员 uid（对账重建 IM 频道订阅者用）。
+func (d *DB) QueryMemberUIDsWithGroupNo(groupNo string) ([]string, error) {
+	var uids []string
+	_, err := d.session.Select("uid").
+		From("group_member").
+		Where("group_no=? AND is_deleted=0", groupNo).
+		Load(&uids)
+	return uids, err
+}
+
+// DeleteOrphanGroup 硬删除孤儿群行（连同残留 group_member）。用于补偿删除部分成功
+// （group_member 已删、group 行残留）→ 群已无有效成员、不可恢复的场景。
+func (d *DB) DeleteOrphanGroup(groupNo string) error {
+	if _, err := d.session.DeleteFrom("group_member").Where("group_no=?", groupNo).Exec(); err != nil {
+		return err
+	}
+	_, err := d.session.DeleteFrom("group").Where("group_no=?", groupNo).Exec()
+	return err
+}
+
 // InsertMemberTx 插入群成员信息(带事务)
 func (d *DB) InsertMemberTx(m *MemberModel, tx *dbr.Tx) error {
 	_, err := tx.InsertInto("group_member").Columns(util.AttrToUnderscore(m)...).Record(m).Exec()

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -1185,6 +1185,14 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 		return nil, errors.New("failed to insert group record")
 	}
 
+	// 标记 IM 频道尚未确认创建：本群走「commit 后建频道」路径，提交后若建频道失败且
+	// 补偿删除也失败（或进程崩在 commit 与建频道之间），残留群行的 channel_synced 停在 0，
+	// 由 ChannelReconciler 发现并重建频道 / 硬删除，闭合孤儿窗口。#394
+	if err := s.db.MarkChannelUnsyncedTx(groupNo, tx); err != nil {
+		s.Error("mark channel unsynced failed", zap.Error(err), zap.String("groupNo", groupNo))
+		return nil, errors.New("failed to mark channel unsynced")
+	}
+
 	// 插入成员
 	realMemberUIDs := make([]string, 0, len(memberUsers))
 	memberVos := make([]*config.UserBaseVo, 0, len(memberUsers))
@@ -1322,6 +1330,14 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 			s.Error("compensating delete group failed", zap.Error(delErr), zap.String("groupNo", groupNo))
 		}
 		return nil, errors.New("failed to create IM channel, group has been rolled back")
+	}
+
+	// IM 频道创建确认成功 → 标记 channel_synced=1，使对账 worker 不再扫这条群。
+	// best-effort：标记失败只记日志——频道已建成，下轮对账会再跑一次（IMCreate 幂等），
+	// 无害；绝不能因标记失败而回滚已成功的建群。#394
+	if err := s.db.MarkChannelSynced(groupNo); err != nil {
+		s.Error("mark channel synced failed (channel created OK; reconciler will re-sync)",
+			zap.Error(err), zap.String("groupNo", groupNo))
 	}
 
 	// 发送群创建通知

--- a/modules/group/sql/20260705000001_group_channel_synced.sql
+++ b/modules/group/sql/20260705000001_group_channel_synced.sql
@@ -1,0 +1,72 @@
+-- +migrate Up
+-- channel_synced 标记群的 IM 频道是否已确认创建（1=已同步，0=待对账）。
+-- 背景：CreateGroup 在事务提交后才创建 WuKongIM 频道；频道创建失败时做 best-effort
+-- 补偿删除，若补偿删除自身也失败（DB 抖动）或进程在「commit 后、建频道前」崩溃，
+-- group 行会残留成没有 IM 频道的孤儿。channel_synced=0 让后台对账 worker
+-- （ChannelReconciler）能发现这些孤儿并重建频道 / 硬删除，实现最终一致。#394
+--
+-- 语义：只有 CreateGroup 主路径在插入群行后、commit 前显式写 0，建频道确认后写 1；
+-- 其它建群路径（系统群 event.go 在事务内建频道、AddGroup 管理接口）无需参与对账，
+-- 一律取默认值 1。故列默认值取 1，存量行也回填 1——零行为回归、无误报。
+--
+-- 恢复安全（recovery-safe）三步法：ALTER TABLE 隐式提交、不可回滚，回填不能塞进
+-- 「列是否存在」守卫里（一旦 ADD 已提交、回填中途失败，重试会跳过整块，存量行停在
+-- 建列默认值）。改用可空哨兵：
+--   1) 先以 NULL（无默认）建列：存量行 = NULL「尚未回填」；
+--   2) 无条件回填 `WHERE channel_synced IS NULL`：幂等、只动未回填行；
+--   3) 再 MODIFY 为 NOT NULL DEFAULT 1：新建群默认已同步，CreateGroup 显式写 0。
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_channel_synced;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __group_channel_synced()
+BEGIN
+  -- Step 1: 以可空（无默认）建列——存量行 = NULL「尚未回填」。守卫保证可重入。
+  IF NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND COLUMN_NAME = 'channel_synced') THEN
+    ALTER TABLE `group`
+      ADD COLUMN `channel_synced` TINYINT NULL COMMENT 'IM频道是否已确认创建(1)/待对账(0);孤儿群对账用 #394';
+  END IF;
+
+  -- Step 2: 回填存量行为 1（视为已同步、零行为回归）。仅命中 NULL 行，幂等可重试。
+  UPDATE `group` SET `channel_synced` = 1 WHERE `channel_synced` IS NULL;
+
+  -- Step 3: 收紧为 NOT NULL DEFAULT 1（新建群默认已同步）。守卫在「当前可空」时才执行。
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND COLUMN_NAME = 'channel_synced' AND IS_NULLABLE = 'YES') THEN
+    ALTER TABLE `group`
+      MODIFY COLUMN `channel_synced` TINYINT NOT NULL DEFAULT 1 COMMENT 'IM频道是否已确认创建(1)/待对账(0);孤儿群对账用 #394';
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __group_channel_synced();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_channel_synced;
+-- +migrate StatementEnd
+
+-- +migrate Down
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_channel_synced_down;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __group_channel_synced_down()
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group'
+         AND COLUMN_NAME = 'channel_synced') THEN
+    ALTER TABLE `group` DROP COLUMN `channel_synced`;
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __group_channel_synced_down();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_channel_synced_down;
+-- +migrate StatementEnd


### PR DESCRIPTION
<!-- multica:bug-fix-report v1 -->

# Bug Fix — Issue #394 — PR #<PR-N>

## 1. Executive Summary
- **Bug**: `group.CreateGroup` creates the IM channel after `tx.Commit()`; if the IM create fails and its best-effort compensating delete *also* fails (or the process crashes between commit and IM create), the committed `group` row survives with no backing IM channel — an orphan clients can never message.
- **Root Cause**: `modules/group/service.go:CreateGroup` — the IM channel lives in WuKongIM (outside the SQL tx), and the post-commit cleanup only logs on failure, so a double-failure/crash leaves a residue that nothing ever reconciles.
- **Fix Approach**: cross-cutting (new `channel_synced` flag + async reconcile worker) — a point fix is impossible per the issue (the channel can't be enrolled in `tx`).
- **Risk Level**: Low
- **PR**: #<PR-N> draft

## 2. Issue Context
- Title: CreateGroup compensating delete is non-atomic → orphan group rows (needs async reconcile)
- Reporter: split out of #381 (refs #377); dispatched via Multica triage
- bug-verified by: self (deterministic reasoning + repro tests; no human gate for auto-dispatched backend bugs)
- Affected: shared `group.CreateGroup` — all create paths (Web / Bot / integration). Low-frequency, not a regression, not exploitable.

## 3. Reproduction
**Environment**: Go 1.26 unit tests (mocked DB + IM); logic path is server-side, no live infra needed for the repro.
**Steps**:
1. Create a group; force `IMCreateOrUpdateChannel` to fail (existing integration test already does this via a dead WuKongIM port).
2. Force the compensating `DELETE` to also fail (DB blip) — or crash between `tx.Commit()` and the IM create.
**Expected**: no `group` row is ever left queryable without a backing IM channel.
**Actual (pre-fix)**: the committed `group`/`group_member` rows survive with no channel; nothing reconciles them → permanent orphan.
**Evidence**: `Test_Issue394_ReconcileRecreatesChannelForOrphanWithMembers` (and siblings) exercise the orphan states; pre-fix there was no reconcile path at all, so the orphan is permanent by construction.

## 4. RCA
**Method**: Fault tree
**Analysis**: IM channel state is external to the SQL transaction → post-commit create needed → create can fail → compensating delete is itself non-transactional, best-effort, log-only → on delete-also-fails or crash-between-commit-and-create, the row persists → no background process re-checks it → permanent orphan.
**Root cause**: absence of a durable, eventually-consistent reconcile for the "committed group without confirmed IM channel" state in `modules/group/service.go:CreateGroup`.

## 5. Fix Description
**Files changed**:
- `modules/group/sql/20260705000001_group_channel_synced.sql` (+72) — add `channel_synced` column (recovery-safe nullable-sentinel migration; existing rows backfilled to 1).
- `modules/group/service.go` (+16) — `CreateGroup` marks `channel_synced=0` in-tx after the group insert, flips to 1 only after a confirmed IM create (best-effort; a failed flip is harmless — reconciler re-syncs).
- `modules/group/db.go` (+50) — `MarkChannelUnsyncedTx` / `MarkChannelSynced` / `QueryUnsyncedGroupNos` / `QueryMemberUIDsWithGroupNo` / `DeleteOrphanGroup`.
- `modules/group/channel_reconciler.go` (+161) — `ChannelReconciler` background worker (mirrors the existing `thread.ArchiveWorker` shape): scans unsynced groups older than a grace period; members present → idempotent `IMCreateOrUpdateChannel` + mark synced; members gone → hard-delete the orphan.
- `modules/group/channel_reconcile_config.go` (+96) — env-driven config, **enabled by default** (`GROUP_CHANNEL_RECONCILE_*`).
- `modules/group/1module.go` (+20) — wire `Start`/`Stop` for the worker into the group module.

**Change summary**: A new `channel_synced` flag makes the orphan state queryable; only `CreateGroup` opts in (writes 0), every other create path and all existing rows default to 1, so behaviour is unchanged elsewhere. A background reconciler closes the window durably and idempotently — surviving both the double-failure and the crash-between-commit-and-IM modes, and consistent whether it re-creates the channel or hard-deletes an unrecoverable (memberless) orphan.

**Does NOT change**: the existing fast-path compensating delete (kept — it still narrows the window on the common case); the `Model` struct (deliberately no `ChannelSynced` field, so other insert paths keep the DB `DEFAULT 1`; dbr scans the unmapped column into a throwaway on `SELECT *`); any API surface or wire contract.

## 6. Regression Tests
| Test | File | Purpose | Before | After |
|---|---|---|---|---|
| `Test_Issue394_ReconcileRecreatesChannelForOrphanWithMembers` | `channel_reconciler_test.go` | orphan w/ members → idempotent channel recreate + mark synced | FAIL (no reconcile path) | PASS |
| `Test_Issue394_ReconcileHardDeletesMemberlessOrphan` | `channel_reconciler_test.go` | partial-compensation orphan (members gone) → hard-delete | FAIL | PASS |
| `Test_Issue394_ReconcileLeavesUnsyncedWhenIMStillFailing` | `channel_reconciler_test.go` | IM still down → no sync/delete, retry next round | FAIL | PASS |
| `Test_Issue394_ReconcileProcessesMixedBatchAndContinuesOnPerItemError` | `channel_reconciler_test.go` | per-item error isolation | FAIL | PASS |
| `Test_Issue394_ReconcileGracePeriodPassedToQuery` | `channel_reconciler_test.go` | cutoff = now−Grace (skip in-flight creates) | FAIL | PASS |
| `Test_Issue394_ReconcileQueryErrorSurfaces` / `...DisabledConfigNoop` / `...LoadChannelReconcileConfigDefaults` | `channel_reconciler_test.go` | error propagation, disabled no-op, default-on config | FAIL | PASS |

## 7. CI Status
- Linter: not run here (no `golangci-lint` in sandbox); `go vet ./modules/group/...` clean; `go build ./...` clean.
- Unit: `go test ./modules/group/ -run Test_Issue394` → all PASS (mocked, infra-free).
- Integration: the group package's DB/IM-backed tests require MySQL + Redis + WuKongIM (per CLAUDE.md). Not available in this sandbox — they fail identically **before and after** my change (e.g. `TestQueryBotsInvitedByUIDTx_BasicMatch` fails on a clean `git stash` of my work too: `dial tcp 127.0.0.1:5001: connection refused`). Per baseline-diff rule: **new_failures = 0** (all failures are pre-existing/environmental).
- Coverage delta: +reconciler paths covered; N/A precise % (infra-gated suite).

## 8. Deployment Notes
- Migration required?: **yes** — `20260705000001_group_channel_synced.sql` (recovery-safe, re-entrant; ADD COLUMN + backfill existing rows to 1 + tighten to `NOT NULL DEFAULT 1`).
- Config change?: optional — `GROUP_CHANNEL_RECONCILE_ENABLED` (default `true`), `_INTERVAL` (5m), `_GRACE` (5m), `_BATCH` (200, clamped ≤2000).
- Feature flag: reconciler defaults **on** (it's a data-consistency safety net; a healthy system matches zero rows → cheap no-op query per interval). Set `GROUP_CHANNEL_RECONCILE_ENABLED=false` to disable.
- Compatibility: backward-preserved. Existing rows + all non-CreateGroup insert paths → `channel_synced=1`; no read/write contract changes.

## 9. Rollback Plan
**Pattern**: feature-flag-disable (immediate) → revert (full).
**Steps**:
1. Immediate: set `GROUP_CHANNEL_RECONCILE_ENABLED=false` — stops the worker; `CreateGroup` still functions (the extra in-tx flag write and the post-commit mark are harmless no-ops for consumers).
2. Full: revert the PR. The `channel_synced` column can be left in place (unused) or dropped via the migration's `-- +migrate Down`.
**Detection** (trigger rollback): spike in `GroupChannelReconciler` error logs (`recreate IM channel failed` / `delete memberless orphan failed`), unexpected group-delete volume, or IM-side load from reconcile recreate calls.

---
_Generated by backend-engineer · awaiting review squad (qa+security+code)_
