### PR TITLE
fix(message): space-ize DM recents in per-Space conversation sync

### DIFF
--- a/modules/message/api_conversation.go
+++ b/modules/message/api_conversation.go
@@ -894,6 +894,13 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 			syncUserConversationResps, filterSpaceID, loginUID, co.ctx, co.groupService,
 		)
 
+		// 把保留下来的 Person DM 的 Recents 空间化：只保留当前 Space 的消息，使
+		// recents[0]（客户端 SpaceFilter 读取的「最后一条消息」）恒属于当前 Space，
+		// 修复「DM 在按空间的最近会话列表中缺失」—— 客户端此前按全局最新（跨 Space）
+		// 消息的 space_id 把整条会话过滤掉。必须在 fillPersonSpaceUnread（算
+		// SpaceLastMessage）与 FilterConversationsBySpace（keep 判定读原始 Recents）之后。
+		spaceizePersonRecents(syncUserConversationResps, filterSpaceID, defaultSpaceID)
+
 		// YUJ-216 / GH#1280: 系统 Bot（botfather 等）在所有 Space 都应可见。
 		// IM 核心按 version 增量返回 conversation，若系统 Bot 在此次 window 内
 		// 没有新消息，Space 过滤后就会缺席；移动端没有前端兜底，会直接丢失 entry。

--- a/modules/message/dm_recents_spaceize_repro_test.go
+++ b/modules/message/dm_recents_spaceize_repro_test.go
@@ -1,0 +1,92 @@
+//go:build integration
+
+package message
+
+// End-to-end regression guard for "DM conversation missing from the per-Space
+// recent list", observed via POST /v1/conversation/sync?space_id=:space_id.
+//
+// Scenario (mirrors the real capture): one physical DM channel with messages in
+// two non-default Spaces, whose globally-latest message belongs to Space B. The
+// client keys its per-Space show/hide decision on the LAST message in recents
+// (recents[0].payload.space_id). Before the fix the server passed WuKongIM's raw
+// recents through untouched, so Space A's response carried Space B's message at
+// recents[0] and the client hid the whole conversation — even though the server
+// kept it (hasSpaceMsg/presence).
+//
+// After the fix (spaceizePersonRecents), each kept DM's recents is narrowed to the
+// queried Space, so recents[0] always belongs to that Space.
+//
+// Reuses the shared httptest WuKongIM fake + helpers from
+// dm_space_last_message_repro_test.go / conversation_recent_filter_e2e_test.go.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFix_ConversationSync_SpaceizesDMRecents drives the real handler through the
+// registered /v1/conversation route and asserts the per-Space recents narrowing.
+func TestFix_ConversationSync_SpaceizesDMRecents(t *testing.T) {
+	const (
+		dmChannel   = "dm-peer-recents"
+		spaceA      = "space-a-recents"      // non-default
+		spaceB      = "space-b-recents"      // non-default, holds the globally-latest msg
+		spaceDefaul = "space-default-recents" // earliest membership → default Space
+	)
+
+	now := time.Now()
+	// History: seq 11 tagged Space A, seq 12 tagged Space B (globally latest, like
+	// the captured "1111"/668cc9 message).
+	msgA := dmMsgRepro(dmChannel, 11, now.Add(-2*time.Hour).Unix(),
+		`{"type":1,"content":"hi-from-A","space_id":"`+spaceA+`"}`)
+	msgB := dmMsgRepro(dmChannel, 12, now.Add(-1*time.Hour).Unix(),
+		`{"type":1,"content":"1111","space_id":"`+spaceB+`"}`)
+
+	convs := []*config.SyncUserConversationResp{
+		dmIMConvMulti(dmChannel, now.Add(-1*time.Hour).Unix(), 100,
+			[]*config.MessageResp{msgA, msgB}),
+	}
+
+	s, ctx := setupConvSyncE2E(t, convs)
+	// Default Space MUST have the earliest created_at (GetUserDefaultSpaceIDE =
+	// earliest membership); Space A / B are non-default.
+	seedSpaceMemberRepro(t, ctx, spaceDefaul, testutil.UID, "2020-01-01 00:00:00")
+	seedSpaceMemberRepro(t, ctx, spaceA, testutil.UID, "2020-06-01 00:00:00")
+	seedSpaceMemberRepro(t, ctx, spaceB, testutil.UID, "2020-07-01 00:00:00")
+
+	// ---- Space A: the DM is present and its recents carry ONLY the Space-A msg ----
+	convA := findConv(callConvSyncSpace(t, s, spaceA), dmChannel)
+	require.NotNil(t, convA, "DM active in Space A must appear in Space A's recent list")
+	require.NotEmpty(t, convA.Recents, "Space A recents must carry the Space-A message")
+	for _, m := range convA.Recents {
+		assert.Equal(t, spaceA, spaceIDOf(m),
+			"Space A recents must not contain any other Space's message")
+	}
+	assert.Equal(t, spaceA, spaceIDOf(convA.Recents[0]),
+		"recents[0] — the client's per-Space hide signal — belongs to Space A")
+
+	// ---- Space B: symmetric, only its own message ----
+	convB := findConv(callConvSyncSpace(t, s, spaceB), dmChannel)
+	require.NotNil(t, convB, "DM active in Space B must appear in Space B's recent list")
+	require.NotEmpty(t, convB.Recents)
+	for _, m := range convB.Recents {
+		assert.Equal(t, spaceB, spaceIDOf(m),
+			"Space B recents must not contain any other Space's message")
+	}
+}
+
+// spaceIDOf reads payload.space_id from a decoded recents message ("" if absent).
+func spaceIDOf(m *MsgSyncResp) string {
+	if m == nil || m.Payload == nil {
+		return ""
+	}
+	if sid, ok := m.Payload["space_id"].(string); ok {
+		return sid
+	}
+	return ""
+}

--- a/modules/message/space_filter.go
+++ b/modules/message/space_filter.go
@@ -442,6 +442,55 @@ func personConvHasSpaceMessages(conv *SyncUserConversationResp, targetSpaceID st
 	return false
 }
 
+// spaceizePersonRecents 把每条 Person (DM) 会话的 Recents 收敛到当前 Space —— 直接复用
+// filterPersonMessagesBySpace（/v1/message/channel/sync 的同一份 DM 空间归属规则：精确匹配，
+// 或「无标签 = 默认 Space」的裸 DM 约定；系统 Bot 走 rule 4，只保留精确打标当前 Space 的消息）。
+// 复用而非再抄一遍判定逻辑，避免与历史过滤漂移出两套「哪条消息属于哪个 Space」的口径。
+//
+// 背景（本 PR 修复的会话缺失 bug）：客户端 SpaceFilter 按会话「最后一条消息」（recents[0]）的
+// payload.space_id 判定该会话归属哪个 Space；而服务端此前把 WuKongIM 的 Recents（物理频道的
+// 全局最新窗口，与 Space 无关）原样透传。于是一条在 Space A、Space B 都有消息的 DM，其全局最新
+// 一条属于 B，客户端就把整条会话过滤出 Space A —— 即便服务端 decideConvKeepInSpace 已判定它属于
+// Space A（presence / hasSpaceMsg），也会在客户端消失。这与历史过滤 filterPersonMessagesBySpace
+// 是同一类问题，只是会话同步的 Recents 之前漏做了空间化。
+//
+// 空间化后窗口里每一条都属于当前 Space，recents[0]（无论客户端把哪端当「最新」）恒为当前 Space
+// 的消息，可见性判定不再被跨 Space 的最新消息带偏。过滤后为空（当前 Space 的消息在窗口外）时
+// Recents 保持为空：客户端读不到跨 Space 的 recents[0]，不再误隐藏该会话（它已被
+// decideConvKeepInSpace 判定属于当前 Space，会以空预览行正常展示 —— 时间/排序走会话级 timestamp、
+// 未读走 space_unread、预览走 space_last_message）。不用 SpaceLastMessage 回填 recents：预览已由
+// space_last_message 承载，空 recents 也不会触发隐藏；回填反而会把一条绕过 channelOffset/
+// deviceOffset、缺富化字段的兜底消息塞进 recents[0]，与其余 recents 口径不一致。
+//
+// 隔离安全（space-isolation 规则）：只放行归属当前 Space 的消息，不会把 Space B 的消息内容泄漏进
+// Space A 的响应；当前 Space 无消息时收敛为空（fail-closed，宁可空预览也不泄漏跨 Space 消息）。
+//
+// 仅处理 ChannelTypePerson；Group / CommunityTopic 的 Space 隔离在 channel_id 层完成，其 Recents
+// 不受影响。系统 Bot（botfather / fileHelper / u_10000 等）同样空间化：filterPersonMessagesBySpace
+// 内部按 isSysBot 走 rule 4，untagged 历史一律不归属任何 Space、只保留精确打标当前 Space 的消息，
+// 与预览/未读 (fillPersonSpaceUnread) 同口径。系统 Bot 的会话可见性另由 EnsureSystemBotsPresent +
+// 客户端豁免保证（始终展示，与本收敛无关）；这里只收敛其 Recents，避免历史里被隐藏的 untagged /
+// 跨 Space 消息经 recents[0] 当预览漏出（#532 同口径）。
+//
+// 会话级 last_msg_seq / last_client_msg_no 不改动：它们是 WuKongIM 增量同步游标（客户端据其推进
+// version），须保持全局口径；Web/扩展端不读它们做 Space 过滤，跨端 Space 判定的权威信号是消息级
+// payload.space_id（即 Recents）。
+//
+// 必须在 fillPersonSpaceUnread 与 FilterConversationsBySpace 之后调用：两者都读原始（未收窄）
+// Recents —— 前者据此算 space_last_message / space_unread，后者据此做 keep 判定（hasSpaceMsg），
+// 提前收窄会破坏它们。
+func spaceizePersonRecents(conversations []*SyncUserConversationResp, spaceID, defaultSpaceID string) {
+	if spaceID == "" {
+		return
+	}
+	for _, conv := range conversations {
+		if conv == nil || conv.ChannelType != common.ChannelTypePerson.Uint8() {
+			continue
+		}
+		conv.Recents = filterPersonMessagesBySpace(conv.Recents, conv.ChannelID, spaceID, defaultSpaceID)
+	}
+}
+
 // EnsureSystemBotsPresent 保证 Space-scoped sync 响应中一定包含系统 Bot
 // （目前 botfather / u_10000 / fileHelper）的 conversation entry。
 //

--- a/modules/message/space_recents_spaceize_test.go
+++ b/modules/message/space_recents_spaceize_test.go
@@ -1,0 +1,185 @@
+package message
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recMsg builds a minimal recents message carrying an optional space_id tag.
+// spaceID=="" → an untagged message (no payload.space_id key at all).
+func recMsg(seq uint32, spaceID string) *MsgSyncResp {
+	payload := map[string]interface{}{
+		"type":    float64(1),
+		"content": "m" + strconv.FormatUint(uint64(seq), 10),
+	}
+	if spaceID != "" {
+		payload["space_id"] = spaceID
+	}
+	return &MsgSyncResp{
+		MessageSeq:  seq,
+		ClientMsgNo: "cmn-" + strconv.FormatUint(uint64(seq), 10),
+		Payload:     payload,
+	}
+}
+
+func personConv(channelID string, recents ...*MsgSyncResp) *SyncUserConversationResp {
+	return &SyncUserConversationResp{
+		ChannelID:   channelID,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Recents:     recents,
+	}
+}
+
+func recentSeqs(conv *SyncUserConversationResp) []uint32 {
+	out := make([]uint32, 0, len(conv.Recents))
+	for _, m := range conv.Recents {
+		out = append(out, m.MessageSeq)
+	}
+	return out
+}
+
+// TestSpaceizePersonRecents_KeepsOnlyCurrentSpace is the core of the fix: a DM
+// active in two Spaces whose globally-latest message belongs to another Space
+// must, when queried for Space A, expose only Space-A messages in recents — so
+// recents[0] (the client's per-Space hide signal) belongs to Space A.
+func TestSpaceizePersonRecents_KeepsOnlyCurrentSpace(t *testing.T) {
+	conv := personConv("peer", recMsg(11, "spaceA"), recMsg(12, "spaceB"))
+	spaceizePersonRecents([]*SyncUserConversationResp{conv}, "spaceA", "spaceDefault")
+
+	require.Equal(t, []uint32{11}, recentSeqs(conv))
+	assert.Equal(t, "spaceA", conv.Recents[0].Payload["space_id"],
+		"recents[0] must belong to the queried Space")
+}
+
+// TestSpaceizePersonRecents_WindowMissEmptiesRecents: when the current-Space
+// message is out of the WuKongIM window, recents collapses to empty (the
+// cross-Space message is dropped). We intentionally do NOT backfill recents from
+// SpaceLastMessage — the preview is carried by space_last_message, and empty
+// recents does not trigger client hiding; backfilling would surface an
+// offset-bypassing, under-enriched fallback message as recents[0]. SpaceLastMessage
+// (the preview) is left untouched.
+func TestSpaceizePersonRecents_WindowMissEmptiesRecents(t *testing.T) {
+	conv := personConv("peer", recMsg(12, "spaceB")) // window holds only the cross-Space msg
+	seed := recMsg(3, "spaceA")                      // fillPersonSpaceUnread's fallback result
+	conv.SpaceLastMessage = seed
+
+	spaceizePersonRecents([]*SyncUserConversationResp{conv}, "spaceA", "spaceDefault")
+
+	assert.Empty(t, conv.Recents,
+		"cross-Space recents dropped and NOT backfilled from SpaceLastMessage")
+	assert.Same(t, seed, conv.SpaceLastMessage,
+		"SpaceLastMessage (the preview) is left intact")
+}
+
+// TestSpaceizePersonRecents_DegenerateEmptiesRatherThanLeakCrossSpace reproduces
+// the captured bug exactly: the DM is kept for Space A (via presence/hasSpaceMsg,
+// decided upstream) but Space A's message is unreachable, so SpaceLastMessage is
+// nil. The cross-Space message MUST be stripped from recents — leaving it would
+// make the client hide the whole conversation. Empty recents renders as a visible,
+// preview-less row (verified client-side), which is the intended outcome.
+func TestSpaceizePersonRecents_DegenerateEmptiesRatherThanLeakCrossSpace(t *testing.T) {
+	conv := personConv("peer", recMsg(12, "spaceB")) // only cross-Space; no SpaceLastMessage
+	spaceizePersonRecents([]*SyncUserConversationResp{conv}, "spaceA", "spaceDefault")
+
+	assert.Empty(t, conv.Recents,
+		"cross-Space recents[0] must be removed so the client stops hiding the kept conversation")
+}
+
+// TestSpaceizePersonRecents_DefaultSpaceMatchesUntagged: in the default Space an
+// untagged DM message belongs to that Space (the bare-DM convention, aligned with
+// findSpaceLastMessage / filterPersonMessagesBySpace rule 2).
+func TestSpaceizePersonRecents_DefaultSpaceMatchesUntagged(t *testing.T) {
+	conv := personConv("peer", recMsg(11, ""), recMsg(12, "spaceB")) // untagged + spaceB
+	spaceizePersonRecents([]*SyncUserConversationResp{conv}, "spaceDefault", "spaceDefault")
+
+	require.Equal(t, []uint32{11}, recentSeqs(conv))
+	_, tagged := conv.Recents[0].Payload["space_id"]
+	assert.False(t, tagged, "the surviving message is the untagged default-Space one")
+}
+
+// TestSpaceizePersonRecents_NonDefaultDropsUntagged: an untagged message must NOT
+// leak into a NON-default Space (rule 3 — no fail-open across Spaces).
+func TestSpaceizePersonRecents_NonDefaultDropsUntagged(t *testing.T) {
+	conv := personConv("peer", recMsg(11, "")) // untagged only
+	spaceizePersonRecents([]*SyncUserConversationResp{conv}, "spaceA", "spaceDefault")
+
+	assert.Empty(t, conv.Recents,
+		"untagged messages belong to the default Space, never a non-default one")
+}
+
+// TestSpaceizePersonRecents_SystemBotSpaceFiltered: system-bot recents ARE
+// space-filtered, on the same footing as their message history
+// (filterPersonMessagesBySpace rule 4) and preview/unread (fillPersonSpaceUnread):
+// untagged history belongs to no Space and is dropped; only exact-tagged
+// current-Space messages survive. The conversation itself stays visible via
+// EnsureSystemBotsPresent + the client's system-bot exemption (not exercised here).
+func TestSpaceizePersonRecents_SystemBotSpaceFiltered(t *testing.T) {
+	// botfather is a system bot (spacepkg.IsSystemBot("botfather") == true).
+	// Untagged + cross-Space messages are both dropped for a system bot.
+	conv := personConv("botfather", recMsg(11, ""), recMsg(12, "spaceB"))
+	spaceizePersonRecents([]*SyncUserConversationResp{conv}, "spaceA", "spaceDefault")
+	assert.Empty(t, conv.Recents,
+		"system-bot untagged/cross-Space recents are dropped (rule-4 parity)")
+
+	// A message tagged with exactly the queried Space survives.
+	conv2 := personConv("botfather", recMsg(11, ""), recMsg(12, "spaceA"))
+	spaceizePersonRecents([]*SyncUserConversationResp{conv2}, "spaceA", "spaceDefault")
+	require.Equal(t, []uint32{12}, recentSeqs(conv2),
+		"a message tagged with the queried Space survives for a system bot")
+
+	// Even in the DEFAULT Space, untagged system-bot history does NOT count — this
+	// pins that the isSysBot flag is threaded through (a plain DM would keep it).
+	conv3 := personConv("botfather", recMsg(11, ""))
+	spaceizePersonRecents([]*SyncUserConversationResp{conv3}, "spaceDefault", "spaceDefault")
+	assert.Empty(t, conv3.Recents,
+		"untagged system-bot history is not a default-Space message (rule-4 parity)")
+}
+
+// TestSpaceizePersonRecents_NonPersonUntouched: GROUP/COMMUNITY_TOPIC isolation is
+// enforced at the channel_id layer; their recents must not be touched here.
+func TestSpaceizePersonRecents_NonPersonUntouched(t *testing.T) {
+	conv := &SyncUserConversationResp{
+		ChannelID:   "g1",
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		Recents:     []*MsgSyncResp{recMsg(11, "spaceB")},
+	}
+	spaceizePersonRecents([]*SyncUserConversationResp{conv}, "spaceA", "spaceDefault")
+
+	require.Equal(t, []uint32{11}, recentSeqs(conv),
+		"group recents are isolated at the channel_id layer, not here")
+}
+
+// TestSpaceizePersonRecents_EmptySpaceIDNoop: no Space filter active → untouched.
+func TestSpaceizePersonRecents_EmptySpaceIDNoop(t *testing.T) {
+	conv := personConv("peer", recMsg(11, "spaceA"), recMsg(12, "spaceB"))
+	spaceizePersonRecents([]*SyncUserConversationResp{conv}, "", "")
+
+	require.Equal(t, []uint32{11, 12}, recentSeqs(conv), "no Space filter → recents unchanged")
+}
+
+// TestSpaceizePersonRecents_PreservesOrderAcrossMultipleMatches: relative order is
+// preserved and interleaved cross-Space messages are dropped, so whichever end the
+// client treats as "newest" stays a current-Space message.
+func TestSpaceizePersonRecents_PreservesOrderAcrossMultipleMatches(t *testing.T) {
+	conv := personConv("peer",
+		recMsg(10, "spaceA"),
+		recMsg(11, "spaceB"),
+		recMsg(12, "spaceA"),
+	)
+	spaceizePersonRecents([]*SyncUserConversationResp{conv}, "spaceA", "spaceDefault")
+
+	require.Equal(t, []uint32{10, 12}, recentSeqs(conv))
+}
+
+// TestSpaceizePersonRecents_NilSafe: nil conversations and nil recents entries are
+// skipped without panicking.
+func TestSpaceizePersonRecents_NilSafe(t *testing.T) {
+	conv := personConv("peer", nil, recMsg(12, "spaceA"), nil)
+	spaceizePersonRecents([]*SyncUserConversationResp{nil, conv}, "spaceA", "spaceDefault")
+
+	require.Equal(t, []uint32{12}, recentSeqs(conv))
+}


### PR DESCRIPTION
## Summary

DMs active in more than one Space went missing from the per-Space recent list (`POST /v1/conversation/sync?space_id=`). The server passed WuKongIM's raw `recents` (the physical channel's global-latest window, Space-agnostic) straight through, so `recents[0]` could belong to another Space. The web/extension SpaceFilter keys its show/hide decision on `recents[0].payload.space_id`, so it hid the whole conversation — even though the server had *kept* it (via `presence` / `hasSpaceMsg`). This narrows each kept Person DM's `recents` to the queried Space so `recents[0]` always belongs to it.

## Related Issue

No tracked issue number (captured on the deployed test env). Related to the DM per-Space isolation work in #484 and the preview fix in #532 — neither narrowed conversation-sync `recents`, which is where the client keys visibility.

## Linked Spec

Load-bearing (space isolation). Root cause, fix rationale, and the alternatives considered are documented in this PR body + the COMPREHENSION section below; no separate `brief.md`.

## Changes

- Add `spaceizePersonRecents` (`modules/message/space_filter.go`), called in `syncUserConversation` right after `FilterConversationsBySpace`: it narrows each kept **Person DM**'s `recents` to the queried Space by **reusing `filterPersonMessagesBySpace`** — the same rule already applied to `/v1/message/channel/sync` history (exact match, `untagged = default` bare-DM convention, system-bot rule 4) — so the two paths can't drift.
- When the Space has no in-window message, `recents` collapses to empty: the client renders a visible, preview-less row (verified: empty recents does **not** trigger hiding; preview comes from `space_last_message`). `recents` is deliberately **not** backfilled from `SpaceLastMessage` (that fallback message bypasses `channelOffset`/`deviceOffset` and lacks the enrichment every real recents entry has).
- System bots (botfather / fileHelper / u_10000) are narrowed on the same footing as their history + preview/unread; they stay visible via `EnsureSystemBotsPresent` + the client's system-bot exemption.
- `last_msg_seq` / `last_client_msg_no` left untouched (WuKongIM incremental-sync cursor; no client reads them for Space filtering).

## Testing

- `go test ./modules/message/ -run TestSpaceizePersonRecents` — 10 unit cases pass (cross-Space narrowing, default-Space untagged match, non-default drops untagged, system-bot rule 4, order preservation, window-miss → empty, nil-safety). These carry no build tag, so **they run in CI**.
- `go vet ./modules/message/` clean on default and `-tags integration`.
- i18n linters (`lint-direct-error-response`, `lint-unregistered-code`) + the legacy-response source guard pass (no error-handling surface touched).
- **Manually verified end-to-end** against local MySQL 8.0 + Redis (WuKongIM faked for the sync call) through the real `/v1/conversation/sync` handler, as a red/green check: **without** the fix the DM's Space-A `recents` leaks the Space-B message and `TestFix_ConversationSync_SpaceizesDMRecents` **FAILS**; **with** the fix it **PASSES**.
- ⚠️ **CI does not run the `//go:build integration` e2e repro.** CI's Test job runs `go test` without `-tags integration` (`ci.yml`), so `TestFix_ConversationSync_SpaceizesDMRecents` (like the existing `dm_space_last_message_repro_test.go`) is a **manual** regression check, not a CI-gated one. The CI-gated coverage for this change is the unit suite above.

- [x] Unit tests added/updated
- [x] Manually verified — red/green end-to-end via the real `/v1/conversation/sync` handler against local MySQL + Redis.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   In the Space-filtered conversation-sync response, *after* the keep/drop decision, it rewrites each kept Person DM's `recents` to contain only messages belonging to the queried Space (reusing `filterPersonMessagesBySpace`). This makes `recents[0]` — the field the client's SpaceFilter reads to decide show/hide — always belong to the current Space. Group/thread recents, the conversation-level cursor, and the keep decision are untouched.

2. **What could break because of it (dependents + failure mode)?**
   Consumers of DM `recents` in this response now see a Space-narrowed list. For a DM with no in-window current-Space message, `recents` is empty → client shows a visible preview-less row, preview falls back to `space_last_message`. System bots with only untagged history now show empty recents in every Space (intended: matches rule 4 / #532; they stay visible via `EnsureSystemBotsPresent`). **Ordering constraint:** must run *after* `fillPersonSpaceUnread` (reads full recents for `space_last_message` / `space_unread`) and `FilterConversationsBySpace` (reads full recents for `hasSpaceMsg`) — running earlier would empty recents and break both. Isolation is strengthened, not weakened: cross-Space message content is stripped, fail-closed to empty when a current-Space message can't be resolved.

3. **How do you know it works (specific test/repro/trace)?**
   Red/green end-to-end: `TestFix_ConversationSync_SpaceizesDMRecents` builds one DM with a Space-A message and a globally-latest Space-B message, queries each Space through the real route, and asserts `recents` carries only that Space's messages and `recents[0].space_id == queried space` — it FAILS with the fix reverted and PASSES with it in place (run locally against MySQL + Redis). Unit tests pin the predicate branches (incl. system-bot rule 4, default-untagged, window-miss → empty). Client-side behavior (recents[0] drives hide; empty recents is safe; `space_last_message` drives preview) was traced in `octo-web` `SpaceService.tsx` / `Convert.ts` / `Model.tsx`.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation — n/a (behavior documented in code comments + this PR)
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)