### PR TITLE
fix(space): align member-join column collations to fix MySQL 1267 in GetSpaceMembers

### DIFF
--- a/modules/space/db_member_collation_repro_test.go
+++ b/modules/space/db_member_collation_repro_test.go
@@ -1,0 +1,121 @@
+package space
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// collationOf returns the COLLATION_NAME of a single column in the test schema.
+func collationOf(t *testing.T, table, column string) string {
+	t.Helper()
+	var name string
+	_, err := testCtx.DB().SelectBySql(
+		"SELECT COLLATION_NAME FROM information_schema.columns "+
+			"WHERE table_schema = DATABASE() AND table_name = ? AND column_name = ?",
+		table, column,
+	).Load(&name)
+	require.NoError(t, err)
+	return name
+}
+
+func mustExec(t *testing.T, sql string) {
+	t.Helper()
+	_, err := testCtx.DB().UpdateBySql(sql).Exec()
+	require.NoError(t, err, sql)
+}
+
+// alignUpStatements reads the shipped migration file and returns its "+migrate
+// Up" statements. The repro test executes exactly what production runs, so the
+// green half proves the migration on disk — not a hand-copied variant — resolves
+// the 1267.
+func alignUpStatements(t *testing.T) []string {
+	t.Helper()
+	raw, err := sqlFS.ReadFile("sql/20260707000001_align_member_join_collation.sql")
+	require.NoError(t, err)
+	body := string(raw)
+	if i := strings.Index(body, "-- +migrate Down"); i >= 0 {
+		body = body[:i]
+	}
+	body = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(body), "-- +migrate Up"))
+
+	// Drop comment / blank lines first so a ';' inside a comment does not split
+	// a statement, then split the remaining SQL on ';'.
+	var kept []string
+	for _, ln := range strings.Split(body, "\n") {
+		s := strings.TrimSpace(ln)
+		if s == "" || strings.HasPrefix(s, "--") {
+			continue
+		}
+		kept = append(kept, ln)
+	}
+
+	var stmts []string
+	for _, chunk := range strings.Split(strings.Join(kept, "\n"), ";") {
+		if stmt := strings.TrimSpace(chunk); stmt != "" {
+			stmts = append(stmts, stmt)
+		}
+	}
+	require.Len(t, stmts, 4, "migration should carry four ALTER statements")
+	return stmts
+}
+
+// TestQueryMembersCollationMismatch1267 reproduces XIN-459 / XIN-476: when the
+// GetSpaceMembers join keys drift onto different collations (as they do on a
+// fresh MySQL 8 dev DB whose server default is utf8mb4_0900_ai_ci), queryMembers
+// aborts with MySQL error 1267 and the endpoint returns 400. Applying the
+// collation-alignment migration makes every join key share utf8mb4_general_ci,
+// after which the same query succeeds and the name-fallback chain still works.
+func TestQueryMembersCollationMismatch1267(t *testing.T) {
+	_, _, err := setup(t)
+	require.NoError(t, err)
+
+	// Force the local-style drift: put the migration-created join keys on the
+	// MySQL 8 server default (utf8mb4_0900_ai_ci) while user_verification keeps
+	// the utf8mb4_general_ci its DDL pins. Only the uv.user_id = sm.uid
+	// comparison then mixes collations — exactly the reported failure shape.
+	mustExec(t, "ALTER TABLE `space_member` MODIFY `uid` VARCHAR(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL DEFAULT ''")
+	mustExec(t, "ALTER TABLE `user` MODIFY `uid` VARCHAR(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL DEFAULT ''")
+	mustExec(t, "ALTER TABLE `robot` MODIFY `robot_id` VARCHAR(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL DEFAULT ''")
+	mustExec(t, "ALTER TABLE `user_verification` MODIFY `user_id` VARCHAR(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL")
+	require.Equal(t, "utf8mb4_0900_ai_ci", collationOf(t, "space_member", "uid"))
+	require.Equal(t, "utf8mb4_general_ci", collationOf(t, "user_verification", "user_id"))
+
+	const spaceId = "sp-collfix"
+	seedMemberSearchSpace(t, spaceId, testutil.UID)
+	const uid = "u-collfix"
+	seedFallbackUser(t, uid, "")
+	seedFallbackVerification(t, uid, "Zhang Wei")
+	seedMemberSearchMember(t, spaceId, uid, 0, 1)
+
+	// RED: mismatched collation on the uv join aborts the whole query with 1267.
+	_, err = testSpaceDB.queryMembers(spaceId, testutil.UID, 1, 100)
+	require.Error(t, err, "expected MySQL 1267 before collation alignment")
+	assert.Contains(t, strings.ToLower(err.Error()), "illegal mix of collations", err.Error())
+
+	// Apply the shipped migration verbatim.
+	for _, stmt := range alignUpStatements(t) {
+		mustExec(t, stmt)
+	}
+
+	// GREEN: every join key now shares one collation, so the query succeeds and
+	// the user.name -> user_verification.real_name fallback is intact.
+	members, err := testSpaceDB.queryMembers(spaceId, testutil.UID, 1, 100)
+	require.NoError(t, err, "query must succeed after collation alignment")
+	m, ok := findMemberDetail(members, uid)
+	require.True(t, ok, "seeded member missing from result")
+	assert.Equal(t, "Zhang Wei", m.DisplayName(), "real_name fallback must survive the fix")
+
+	for _, c := range []struct{ table, column string }{
+		{"space_member", "uid"},
+		{"user", "uid"},
+		{"robot", "robot_id"},
+		{"user_verification", "user_id"},
+	} {
+		assert.Equal(t, "utf8mb4_general_ci", collationOf(t, c.table, c.column),
+			"%s.%s should be aligned to utf8mb4_general_ci", c.table, c.column)
+	}
+}

--- a/modules/space/sql/20260707000001_align_member_join_collation.sql
+++ b/modules/space/sql/20260707000001_align_member_join_collation.sql
@@ -1,0 +1,35 @@
+-- +migrate Up
+
+-- Fix MySQL 1267 (Illegal mix of collations) in GetSpaceMembers.
+--
+-- queryMembers (modules/space/db.go) LEFT JOINs space_member.uid against three
+-- columns: user.uid, user_verification.user_id and robot.robot_id. On a fresh
+-- MySQL 8 instance every table created without an explicit COLLATE inherits the
+-- server default (utf8mb4_0900_ai_ci), while user_verification pins
+-- utf8mb4_general_ci in its own DDL. Comparing two different collations makes
+-- MySQL abort the whole statement with error 1267, which surfaces to the client
+-- as a 400 (err.server.space.query_failed) and leaves every member name showing
+-- as a raw uid.
+--
+-- Pin every uid-family join key to one explicit collation (utf8mb4_general_ci,
+-- the collation already used in production and by user_verification) so the
+-- comparison is well-defined in every environment. Fixing the columns at the
+-- schema level is the durable fix; a per-query COLLATE clause would only paper
+-- over a single call site and leave the rest of the schema drifting.
+--
+-- MODIFY COLUMN to a fixed collation is idempotent: once a column already is
+-- utf8mb4_general_ci the statement is a no-op, so re-running the migration is
+-- safe. Column type / nullability / default / comment are kept identical to the
+-- original DDL so only the collation changes.
+
+ALTER TABLE `space_member`      MODIFY `uid`      VARCHAR(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '' COMMENT '成员uid';
+ALTER TABLE `user`              MODIFY `uid`      VARCHAR(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '' COMMENT '用户唯一ID';
+ALTER TABLE `robot`             MODIFY `robot_id` VARCHAR(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '' COMMENT '机器人ID';
+ALTER TABLE `user_verification` MODIFY `user_id`  VARCHAR(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL COMMENT 'OCTO 用户 UID';
+
+-- +migrate Down
+
+-- No-op: the pre-alignment collation was environment-dependent (the MySQL server
+-- default at table-creation time), so there is no single meaningful value to
+-- revert to. Leaving the join keys aligned on utf8mb4_general_ci is safe and is
+-- the intended steady state.


### PR DESCRIPTION
## Summary

Fixes a MySQL `1267 Illegal mix of collations` error that aborts `GetSpaceMembers` and returns a 400, causing every space member to render as a raw uid and the manager member list to fail to load.

## Related Issue

Root cause tracked in XIN-459; this PR resolves XIN-476.

## Linked Spec

XIN-476 — align the `GetSpaceMembers` join-key collations at the schema level (idempotent migration, no per-query `COLLATE` band-aid).

## Root cause

`queryMembers` (`modules/space/db.go`) LEFT JOINs `space_member.uid` against three columns:

```sql
LEFT JOIN user u                ON u.uid = sm.uid
LEFT JOIN user_verification uv  ON uv.user_id = sm.uid
LEFT JOIN robot r               ON r.robot_id = sm.uid
```

`user_verification` pins `utf8mb4_general_ci` in its DDL, while the tables created without an explicit `COLLATE` inherit the server default. On a fresh MySQL 8 instance that default is `utf8mb4_0900_ai_ci`, so `uv.user_id = sm.uid` compares two different collations and MySQL aborts the whole statement with 1267 -> `err.server.space.query_failed` (400).

## Changes

- `modules/space/sql/20260707000001_align_member_join_collation.sql` — idempotent migration pinning all four uid-family join keys (`space_member.uid`, `user.uid`, `robot.robot_id`, `user_verification.user_id`) to `utf8mb4_general_ci` (production's existing collation). Column type / nullability / default / comment are unchanged — only the collation moves. `MODIFY COLUMN` to a fixed collation is a no-op once already aligned, so the migration is safe to re-run.
- `modules/space/db_member_collation_repro_test.go` — regression test that forces the collation drift, asserts `queryMembers` fails with 1267, applies the shipped migration file verbatim, then asserts the query succeeds with the `user.name -> user_verification.real_name` fallback intact and every join key aligned.

All four join keys must share one collation, not just the two named in the report: pinning only `space_member.uid` and `user_verification.user_id` would shift the mismatch onto the `user`/`robot` joins. `utf8mb4_general_ci` is chosen because it is what production already uses, so the migration is a no-op there and only converges divergent dev/local databases.

## Testing

```
$ go test ./modules/space/ -run TestQueryMembersCollationMismatch1267 -v
--- PASS: TestQueryMembersCollationMismatch1267 (0.15s)

$ go test ./modules/space/
ok  	github.com/Mininglamp-OSS/octo-server/modules/space
```

Verified red->green locally against MySQL 8.0.46: the test reproduces error `1267 (HY000): Illegal mix of collations (utf8mb4_0900_ai_ci,IMPLICIT) and (utf8mb4_general_ci,IMPLICIT)` before the migration and passes after. Also confirmed the migration applies cleanly on a fresh-boot database.

- [x] Unit tests added/updated
- [x] Manually verified

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path? It normalizes the collation of the uid-family columns that `GetSpaceMembers` joins on, so `space_member.uid` and the three joined columns are all `utf8mb4_general_ci`. Column semantics (type, length, nullability, default) are untouched; only the collation metadata changes, and the values are ASCII uids so no ordering/uniqueness behavior shifts.

2. **What could break** because of it (dependents + failure mode)? The migration rebuilds the indexes on `space_member.uid`, `user.uid`, `robot.robot_id`. On a production DB already on `utf8mb4_general_ci` the `MODIFY` is a no-op. The only behavioral risk would be a case-sensitivity change, but both `utf8mb4_0900_ai_ci` and `utf8mb4_general_ci` are case/accent-insensitive and the columns hold ASCII uids, so equality/uniqueness results are unchanged.

3. **How do you know it works** (specific test/repro/trace)? `TestQueryMembersCollationMismatch1267` forces the drift, asserts the exact 1267 error string, applies the shipped SQL file (parsed from disk, not a hand-copied copy), and asserts the query then succeeds. The full `modules/space` suite passes.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
