### PR TITLE
feat(group/thread): 群/子区改名放开给活跃人类成员（robot 及外部成员除外）

### DIFF
--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -1155,29 +1155,58 @@ func (g *Group) groupUpdate(c *wkhttp.Context) {
 		respondGroupInfoError(c, err)
 		return
 	}
-	// 查询是否是管理者
-	isManager, err := g.db.QueryIsGroupManagerOrCreator(groupNo, loginUID)
-	if err != nil {
-		g.Error("查询是否是群管理者失败！", zap.Error(err))
-		httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
-		return
-	}
-	if !isManager {
-		httperr.ResponseErrorL(c, errcode.ErrGroupManagerOnly, nil, nil)
-		return
-	}
-
+	// 先探测请求包含哪些字段，用于按字段档位做差异化权限校验。
 	// invite 属性不走 Service（Service 只处理 name/notice），仍走原有逻辑
 	inviteValue, hasInvite := groupMap[common.GroupAttrKeyInvite]
 	nameValue, hasName := groupMap[common.GroupAttrKeyName]
 	noticeValue, hasNotice := groupMap[common.GroupAttrKeyNotice]
+	avatarTextValue, hasAvatarText := groupMap[attrKeyAvatarText]
+	avatarColorValue, hasAvatarColor := groupMap[attrKeyAvatarColor]
+
+	// 权限分档：
+	//   高级字段（notice/invite/avatar_text/avatar_color）——仍需管理员/群主。
+	//   仅改名（只含 name、不含任何高级字段）——任何活跃人类成员即可，龙虾除外。
+	//   其它（既无 name 也无高级字段）——保守走管理员校验兜底。
+	hasAdvanced := hasNotice || hasInvite || hasAvatarText || hasAvatarColor
+	if hasAdvanced || !hasName {
+		isManager, err := g.db.QueryIsGroupManagerOrCreator(groupNo, loginUID)
+		if err != nil {
+			g.Error("查询是否是群管理者失败！", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
+			return
+		}
+		if !isManager {
+			httperr.ResponseErrorL(c, errcode.ErrGroupManagerOnly, nil, nil)
+			return
+		}
+	} else {
+		// 仅改名：低风险写，活跃人类成员即可，龙虾(robot)不是普通成员，禁止其改名。
+		isActive, err := g.db.ExistMemberActive(loginUID, groupNo)
+		if err != nil {
+			g.Error("查询是否是活跃群成员失败！", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
+			return
+		}
+		if !isActive {
+			httperr.ResponseErrorL(c, errcode.ErrGroupNotMember, nil, nil)
+			return
+		}
+		var isBot int
+		if err := g.ctx.DB().SelectBySql("SELECT COALESCE((SELECT robot FROM `user` WHERE uid=? LIMIT 1), 0)", loginUID).LoadOne(&isBot); err != nil {
+			g.Error("查询用户是否为龙虾失败！", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
+			return
+		}
+		if isBot == 1 {
+			httperr.ResponseErrorL(c, errcode.ErrGroupNotMember, nil, nil)
+			return
+		}
+	}
 
 	// 自定义群头像文字/颜色（二次弹窗保存）：先在任何 mutation 之前完成解析与校验，构造
 	// avatarReq。这样非法的 avatar 字段会在 name/notice/invite 落库之前返回 400，避免
 	// 「返回 400 却已部分写入群名」的非原子部分写入。avatar_text 空串清除自定义文字（回退
 	// is_named 规则:老群群名/新群双人图标），avatar_color "" / "-1" 清除自定义色（回退派生）。超限直接拒绝，不静默截断。
-	avatarTextValue, hasAvatarText := groupMap[attrKeyAvatarText]
-	avatarColorValue, hasAvatarColor := groupMap[attrKeyAvatarColor]
 	var avatarReq *UpdateGroupAvatarCustomServiceReq
 	if hasAvatarText || hasAvatarColor {
 		avatarReq = &UpdateGroupAvatarCustomServiceReq{

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -1180,8 +1180,11 @@ func (g *Group) groupUpdate(c *wkhttp.Context) {
 			return
 		}
 	} else {
-		// 仅改名：低风险写，活跃人类成员即可，龙虾(robot)不是普通成员，禁止其改名。
-		isActive, err := g.db.ExistMemberActive(loginUID, groupNo)
+		// 仅改名：低风险写，内部活跃人类成员即可，龙虾(robot)不是普通成员，禁止其改名。
+		// 用 ExistMemberActiveInternal（带 is_external=0）而非 ExistMemberActive，保留旧
+		// QueryIsGroupManagerOrCreator 门禁的 is_external=0 边界，避免跨 Space 外部成员越权
+		// 改名（YUJ-231 / GH#1289，P1）。
+		isActive, err := g.db.ExistMemberActiveInternal(loginUID, groupNo)
 		if err != nil {
 			g.Error("查询是否是活跃群成员失败！", zap.Error(err))
 			httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
@@ -1191,13 +1194,14 @@ func (g *Group) groupUpdate(c *wkhttp.Context) {
 			httperr.ResponseErrorL(c, errcode.ErrGroupNotMember, nil, nil)
 			return
 		}
-		var isBot int
-		if err := g.ctx.DB().SelectBySql("SELECT COALESCE((SELECT robot FROM `user` WHERE uid=? LIMIT 1), 0)", loginUID).LoadOne(&isBot); err != nil {
+		// 龙虾(robot)排除：复用 Service.IsRobot 单一数据源，避免与其重复内联 SQL。
+		isBot, err := g.groupService.IsRobot(loginUID)
+		if err != nil {
 			g.Error("查询用户是否为龙虾失败！", zap.Error(err))
 			httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
 			return
 		}
-		if isBot == 1 {
+		if isBot {
 			httperr.ResponseErrorL(c, errcode.ErrGroupNotMember, nil, nil)
 			return
 		}

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -180,6 +180,19 @@ func (d *DB) ExistMemberActive(uid string, groupNo string) (bool, error) {
 	return count > 0, err
 }
 
+// ExistMemberActiveInternal 是 ExistMemberActive 的收紧变体：在 is_deleted=0 AND
+// status=Normal 之外额外要求 is_external=0，即只把「内部活跃人类成员」视为存在。
+// 放开的群/子区改名门禁用它替代 ExistMemberActive，避免跨 Space 的外部成员
+// (is_external=1) 越权改名——旧的 QueryIsGroupManagerOrCreator 门禁本就带 is_external=0
+// 边界，放宽为活跃成员时必须保留该边界（YUJ-231 / GH#1289，P1）。
+func (d *DB) ExistMemberActiveInternal(uid string, groupNo string) (bool, error) {
+	var count int64
+	_, err := d.session.Select("count(*)").From("group_member").
+		Where("group_no=? and uid=? and is_deleted=0 and is_external=0 and status=?",
+			groupNo, uid, common.GroupMemberStatusNormal).Load(&count)
+	return count > 0, err
+}
+
 func (d *DB) existMembers(groupNos []string, uid string) ([]string, error) {
 	var results []string
 	_, err := d.session.Select("group_no").From("group_member").Where("group_no in ? and uid=? and is_deleted=0", groupNos, uid).Load(&results)

--- a/modules/group/rename_permission_matrix_test.go
+++ b/modules/group/rename_permission_matrix_test.go
@@ -20,6 +20,13 @@ import (
 // avatar_update_test.go 的 seedCreatorGroup 同风格。
 func seedRenameMatrixGroup(t *testing.T, g *Group, groupNo, creatorUID string, role, memberStatus, robot int) {
 	t.Helper()
+	seedRenameMatrixGroupExternal(t, g, groupNo, creatorUID, role, memberStatus, robot, 0)
+}
+
+// seedRenameMatrixGroupExternal 是 seedRenameMatrixGroup 的扩展变体，额外指定操作者成员行的
+// is_external 档位，用于复现「跨 Space 外部成员改名应被拒绝」的边界（YUJ-231 / GH#1289）。
+func seedRenameMatrixGroupExternal(t *testing.T, g *Group, groupNo, creatorUID string, role, memberStatus, robot, isExternal int) {
+	t.Helper()
 
 	uniq := util.GenerUUID()[:8]
 	require.NoError(t, g.userDB.Insert(&user.Model{UID: creatorUID, Name: "创建者", ShortNo: "rm_c_" + uniq}))
@@ -34,7 +41,7 @@ func seedRenameMatrixGroup(t *testing.T, g *Group, groupNo, creatorUID string, r
 	}))
 	// 操作者成员行。
 	require.NoError(t, g.db.InsertMember(&MemberModel{
-		GroupNo: groupNo, UID: testutil.UID, Role: role, Status: memberStatus,
+		GroupNo: groupNo, UID: testutil.UID, Role: role, Status: memberStatus, IsExternal: isExternal,
 		Version: 2, Vercode: fmt.Sprintf("%s@1", util.GenerUUID()),
 	}))
 }
@@ -101,6 +108,29 @@ func TestGroupRename_BlacklistMember_NameOnly_Denied(t *testing.T) {
 	got, err := g.db.QueryWithGroupNo(groupNo)
 	require.NoError(t, err)
 	require.Equal(t, "原始群名", got.Name, "黑名单成员改名应被拒绝，群名不变")
+}
+
+// TestGroupRename_ExternalMember_NameOnly_Denied 覆盖安全边界：
+// 跨 Space 外部成员（is_external=1）即便活跃、人类、状态正常，也禁止改名——放宽后的
+// 门禁必须保留旧 QueryIsGroupManagerOrCreator 的 is_external=0 边界（YUJ-231 / GH#1289，P1）。
+func TestGroupRename_ExternalMember_NameOnly_Denied(t *testing.T) {
+	s, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	wireI18nRendererForGroupTest(s)
+	g := New(ctx)
+
+	const groupNo = "rm_name_ext"
+	// 操作者活跃、人类、状态正常，但 is_external=1（跨 Space 外部成员）。
+	seedRenameMatrixGroupExternal(t, g, groupNo, "rm_creator_ext", MemberRoleCommon, int(common.GroupMemberStatusNormal), 0, 1)
+
+	w := putGroupUpdate(t, s.GetRoute(), groupNo, map[string]string{"name": "外部成员改名"})
+	require.Equal(t, http.StatusBadRequest, w.Code, "wire status 固定 400, body=%s", w.Body.String())
+	require.Contains(t, w.Body.String(), "err.server.group.not_group_member",
+		"外部成员改名应被拒绝, body=%s", w.Body.String())
+
+	got, err := g.db.QueryWithGroupNo(groupNo)
+	require.NoError(t, err)
+	require.Equal(t, "原始群名", got.Name, "外部成员改名应被拒绝，群名不变")
 }
 
 // TestGroupRename_NormalMemberWithAdvancedFields_Denied 覆盖新行为④：

--- a/modules/group/rename_permission_matrix_test.go
+++ b/modules/group/rename_permission_matrix_test.go
@@ -1,0 +1,177 @@
+package group
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/stretchr/testify/require"
+)
+
+// seedRenameMatrixGroup 建一个由 creatorUID 创建的群，并把 token 对应用户
+// （testutil.UID）作为一名成员写入——角色 role、成员状态 memberStatus、user.robot=robot。
+// 这样 groupUpdate 的分档权限校验（活跃人类成员 / 龙虾 / 黑名单 / 管理员）都能被精确复现。
+//
+// 通过直插 DB 而非走 CreateGroup/AddMember，避免依赖已停的 IM(:5001)，与
+// avatar_update_test.go 的 seedCreatorGroup 同风格。
+func seedRenameMatrixGroup(t *testing.T, g *Group, groupNo, creatorUID string, role, memberStatus, robot int) {
+	t.Helper()
+
+	uniq := util.GenerUUID()[:8]
+	require.NoError(t, g.userDB.Insert(&user.Model{UID: creatorUID, Name: "创建者", ShortNo: "rm_c_" + uniq}))
+	// token 对应的操作者（testutil.UID）——按 robot 档位决定是否为龙虾。
+	require.NoError(t, g.userDB.Insert(&user.Model{UID: testutil.UID, Name: "操作者", ShortNo: "rm_o_" + uniq, Robot: robot}))
+
+	require.NoError(t, g.db.Insert(&Model{GroupNo: groupNo, Name: "原始群名", Creator: creatorUID, Status: GroupStatusNormal, Version: 1}))
+	// 群主成员行。
+	require.NoError(t, g.db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: creatorUID, Role: MemberRoleCreator, Status: int(common.GroupMemberStatusNormal),
+		Version: 1, Vercode: fmt.Sprintf("%s@1", util.GenerUUID()),
+	}))
+	// 操作者成员行。
+	require.NoError(t, g.db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: testutil.UID, Role: role, Status: memberStatus,
+		Version: 2, Vercode: fmt.Sprintf("%s@1", util.GenerUUID()),
+	}))
+}
+
+// TestGroupRename_NormalActiveHumanMember_NameOnly_Allowed 覆盖新行为①：
+// 仅改 name 时，普通活跃人类成员即可改名，无需管理员/群主。
+func TestGroupRename_NormalActiveHumanMember_NameOnly_Allowed(t *testing.T) {
+	s, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	wireI18nRendererForGroupTest(s)
+	g := New(ctx)
+
+	const groupNo = "rm_name_ok"
+	// 操作者是普通成员（非创建者/管理员）、活跃、人类。
+	seedRenameMatrixGroup(t, g, groupNo, "rm_creator_1", MemberRoleCommon, int(common.GroupMemberStatusNormal), 0)
+
+	w := putGroupUpdate(t, s.GetRoute(), groupNo, map[string]string{"name": "新群名"})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	got, err := g.db.QueryWithGroupNo(groupNo)
+	require.NoError(t, err)
+	require.Equal(t, "新群名", got.Name, "普通活跃人类成员应能仅改名成功")
+}
+
+// TestGroupRename_Robot_NameOnly_Denied 覆盖新行为②：
+// 龙虾(robot)即使是活跃成员也禁止改名。
+func TestGroupRename_Robot_NameOnly_Denied(t *testing.T) {
+	s, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	wireI18nRendererForGroupTest(s)
+	g := New(ctx)
+
+	const groupNo = "rm_name_bot"
+	// 操作者是活跃普通成员，但 user.robot=1。
+	seedRenameMatrixGroup(t, g, groupNo, "rm_creator_2", MemberRoleCommon, int(common.GroupMemberStatusNormal), 1)
+
+	w := putGroupUpdate(t, s.GetRoute(), groupNo, map[string]string{"name": "龙虾改名"})
+	require.Equal(t, http.StatusBadRequest, w.Code, "wire status 固定 400, body=%s", w.Body.String())
+	require.Contains(t, w.Body.String(), "err.server.group.not_group_member",
+		"龙虾改名应被拒绝, body=%s", w.Body.String())
+
+	got, err := g.db.QueryWithGroupNo(groupNo)
+	require.NoError(t, err)
+	require.Equal(t, "原始群名", got.Name, "龙虾改名应被拒绝，群名不变")
+}
+
+// TestGroupRename_BlacklistMember_NameOnly_Denied 覆盖新行为③：
+// 黑名单成员（status=blacklist）非活跃成员，禁止改名。
+func TestGroupRename_BlacklistMember_NameOnly_Denied(t *testing.T) {
+	s, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	wireI18nRendererForGroupTest(s)
+	g := New(ctx)
+
+	const groupNo = "rm_name_black"
+	// 操作者被拉黑（人类），ExistMemberActive 为 false。
+	seedRenameMatrixGroup(t, g, groupNo, "rm_creator_3", MemberRoleCommon, int(common.GroupMemberStatusBlacklist), 0)
+
+	w := putGroupUpdate(t, s.GetRoute(), groupNo, map[string]string{"name": "黑名单改名"})
+	require.Equal(t, http.StatusBadRequest, w.Code, "wire status 固定 400, body=%s", w.Body.String())
+	require.Contains(t, w.Body.String(), "err.server.group.not_group_member",
+		"黑名单成员改名应被拒绝, body=%s", w.Body.String())
+
+	got, err := g.db.QueryWithGroupNo(groupNo)
+	require.NoError(t, err)
+	require.Equal(t, "原始群名", got.Name, "黑名单成员改名应被拒绝，群名不变")
+}
+
+// TestGroupRename_NormalMemberWithAdvancedFields_Denied 覆盖新行为④：
+// 普通成员带高级字段（name + notice/invite/avatar 混合）时取最高档，仍需管理员/群主。
+func TestGroupRename_NormalMemberWithAdvancedFields_Denied(t *testing.T) {
+	// 混合请求里的每一种高级字段都应把权限档位抬到「需要管理员」。
+	cases := []struct {
+		name string
+		body map[string]string
+	}{
+		{"name+notice", map[string]string{"name": "混合1", "notice": "新公告"}},
+		{"name+invite", map[string]string{"name": "混合2", "invite": "1"}},
+		{"name+avatar_text", map[string]string{"name": "混合3", attrKeyAvatarText: "研发"}},
+		{"name+avatar_color", map[string]string{"name": "混合4", attrKeyAvatarColor: "5"}},
+	}
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, ctx := newTestServer(t)
+			require.NoError(t, testutil.CleanAllTables(ctx))
+			wireI18nRendererForGroupTest(s)
+			g := New(ctx)
+
+			groupNo := fmt.Sprintf("rm_adv_%d", i)
+			// 操作者是活跃普通人类成员——仅改名可放行，但带了高级字段就必须是管理员。
+			seedRenameMatrixGroup(t, g, groupNo, fmt.Sprintf("rm_creator_adv_%d", i), MemberRoleCommon, int(common.GroupMemberStatusNormal), 0)
+
+			w := putGroupUpdate(t, s.GetRoute(), groupNo, tc.body)
+			require.Equal(t, http.StatusBadRequest, w.Code, "wire status 固定 400, body=%s", w.Body.String())
+			require.Contains(t, w.Body.String(), "err.server.group.manager_only",
+				"普通成员带高级字段应要求管理员, body=%s", w.Body.String())
+
+			got, err := g.db.QueryWithGroupNo(groupNo)
+			require.NoError(t, err)
+			require.Equal(t, "原始群名", got.Name, "被拒绝时群名不应被写入")
+		})
+	}
+}
+
+// TestGroupUpdate_EmptyBodyOrUnknownField_FailClosed 覆盖新行为⑤：
+// 空 body → request_invalid；只含未知字段（既无 name 也无高级字段）→ fail-closed 走管理员，
+// 普通成员被拒。
+func TestGroupUpdate_EmptyBodyOrUnknownField_FailClosed(t *testing.T) {
+	// 空 body：请求非法。
+	t.Run("empty body -> request_invalid", func(t *testing.T) {
+		s, ctx := newTestServer(t)
+		require.NoError(t, testutil.CleanAllTables(ctx))
+		wireI18nRendererForGroupTest(s)
+		g := New(ctx)
+
+		const groupNo = "rm_empty"
+		seedRenameMatrixGroup(t, g, groupNo, "rm_creator_empty", MemberRoleCommon, int(common.GroupMemberStatusNormal), 0)
+
+		w := putGroupUpdate(t, s.GetRoute(), groupNo, map[string]string{})
+		require.Equal(t, http.StatusBadRequest, w.Code, "wire status 固定 400, body=%s", w.Body.String())
+		require.Contains(t, w.Body.String(), "err.server.group.request_invalid",
+			"空 body 应是请求非法, body=%s", w.Body.String())
+	})
+
+	// 只含未知字段：不落入「仅改名」放开分支，fail-closed 走管理员校验；普通成员被拒。
+	t.Run("unknown field only -> manager required (fail-closed)", func(t *testing.T) {
+		s, ctx := newTestServer(t)
+		require.NoError(t, testutil.CleanAllTables(ctx))
+		wireI18nRendererForGroupTest(s)
+		g := New(ctx)
+
+		const groupNo = "rm_unknown"
+		seedRenameMatrixGroup(t, g, groupNo, "rm_creator_unknown", MemberRoleCommon, int(common.GroupMemberStatusNormal), 0)
+
+		w := putGroupUpdate(t, s.GetRoute(), groupNo, map[string]string{"totally_unknown_field": "x"})
+		require.Equal(t, http.StatusBadRequest, w.Code, "wire status 固定 400, body=%s", w.Body.String())
+		require.Contains(t, w.Body.String(), "err.server.group.manager_only",
+			"仅含未知字段应 fail-closed 走管理员校验, body=%s", w.Body.String())
+	})
+}

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -72,6 +72,8 @@ type IService interface {
 	GetMemberUIDsOfManager(groupNo string) ([]string, error)
 	// 是否是创建者或管理者
 	IsCreatorOrManager(groupNo string, uid string) (bool, error)
+	// IsRobot 判断某 uid 是否为龙虾(robot)账号（user.robot=1）。
+	IsRobot(uid string) (bool, error)
 	// 获取成员总数量和在线数量
 	// 第一个返回参数为成员总数量
 	// 第二个返回参数为在线数量
@@ -564,6 +566,16 @@ func (s *Service) GetMemberUIDsOfManager(groupNo string) ([]string, error) {
 
 func (s *Service) IsCreatorOrManager(groupNo string, uid string) (bool, error) {
 	return s.db.QueryIsGroupManagerOrCreator(groupNo, uid)
+}
+
+// IsRobot 判断某 uid 是否为龙虾(robot)账号（user.robot=1）。
+func (s *Service) IsRobot(uid string) (bool, error) {
+	var isBot int
+	err := s.ctx.DB().SelectBySql("SELECT COALESCE((SELECT robot FROM `user` WHERE uid=? LIMIT 1), 0)", uid).LoadOne(&isBot)
+	if err != nil {
+		return false, err
+	}
+	return isBot == 1, nil
 }
 
 func (s *Service) GetMemberTotalAndOnlineCount(groupNo string) (int, int, error) {

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -84,6 +84,10 @@ type IService interface {
 	// 白名单语义、fail-closed），排除被拉黑成员。供绕过 IM 直查本地分表的读/发门禁，
 	// 以及子区(CommunityTopic)解析父群后的读/写门禁使用，防止被拉黑用户越权读子区内容。
 	ExistMemberActive(groupNo string, uid string) (bool, error)
+	// ExistMemberActiveInternal 是 ExistMemberActive 的收紧变体：额外要求 is_external=0，
+	// 只把「内部活跃人类成员」视为存在。放开的群/子区改名门禁用它保留 is_external=0
+	// 安全边界，避免跨 Space 外部成员越权改名（YUJ-231 / GH#1289，P1）。
+	ExistMemberActiveInternal(groupNo string, uid string) (bool, error)
 	// 成员是否在某群里存在 返回对应在群里的群编号
 	ExistMembers(groupNos []string, uid string) ([]string, error)
 	// ExistMembersActive 批量版 ExistMemberActive：返回 uid 处于「活跃」状态
@@ -601,6 +605,13 @@ func (s *Service) ExistMember(groupNo string, uid string) (bool, error) {
 // 子区(CommunityTopic)读/发门禁用它替代 ExistMember，避免被拉黑用户越权读/发（YUJ-4185 CR 整改）。
 func (s *Service) ExistMemberActive(groupNo string, uid string) (bool, error) {
 	return s.db.ExistMemberActive(uid, groupNo)
+}
+
+// ExistMemberActiveInternal 是 ExistMemberActive 的收紧变体：额外要求 is_external=0，
+// 只把「内部活跃人类成员」视为存在。放开的群/子区改名门禁用它保留 is_external=0
+// 安全边界，避免跨 Space 外部成员越权改名（YUJ-231 / GH#1289，P1）。
+func (s *Service) ExistMemberActiveInternal(groupNo string, uid string) (bool, error) {
+	return s.db.ExistMemberActiveInternal(uid, groupNo)
 }
 
 func (s *Service) ExistMembers(groupNos []string, uid string) ([]string, error) {

--- a/modules/thread/rename_permission_matrix_test.go
+++ b/modules/thread/rename_permission_matrix_test.go
@@ -21,6 +21,13 @@ import (
 // 只验证 UpdateName 的权限分档，不依赖频道创建。
 func seedRenameThread(t *testing.T, memberStatus, robot int) (*Service, string, string, string) {
 	t.Helper()
+	return seedRenameThreadExternal(t, memberStatus, robot, 0)
+}
+
+// seedRenameThreadExternal 是 seedRenameThread 的扩展变体，额外指定操作者父群成员行的
+// is_external 档位，用于复现「跨 Space 外部成员改子区名应被拒绝」的边界（YUJ-231 / GH#1289）。
+func seedRenameThreadExternal(t *testing.T, memberStatus, robot, isExternal int) (*Service, string, string, string) {
+	t.Helper()
 
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
@@ -43,9 +50,9 @@ func seedRenameThread(t *testing.T, memberStatus, robot int) (*Service, string, 
 		GroupNo: groupNo, UID: threadCreatorUID, Role: group.MemberRoleCommon,
 		Status: int(common.GroupMemberStatusNormal), Version: 1, Vercode: util.GenerUUID(),
 	}))
-	// 操作者成员行——状态按档位。
+	// 操作者成员行——状态与 is_external 按档位。
 	require.NoError(t, groupDB.InsertMember(&group.MemberModel{
-		GroupNo: groupNo, UID: operatorUID, Role: group.MemberRoleCommon,
+		GroupNo: groupNo, UID: operatorUID, Role: group.MemberRoleCommon, IsExternal: isExternal,
 		Status: memberStatus, Version: 2, Vercode: util.GenerUUID(),
 	}))
 
@@ -103,4 +110,19 @@ func TestThreadUpdateName_BlacklistMember_Denied(t *testing.T) {
 	got, err := svc.GetThread(groupNo, shortID, operatorUID)
 	require.NoError(t, err)
 	require.Equal(t, "原始子区名", got.Name, "黑名单成员被拒后子区名不变")
+}
+
+// TestThreadUpdateName_ExternalMember_Denied 覆盖安全边界：
+// 跨 Space 外部成员（is_external=1）即便活跃、人类、状态正常，也禁止改子区名——放宽后的
+// 门禁必须保留 is_external=0 边界（YUJ-231 / GH#1289，P1）。
+func TestThreadUpdateName_ExternalMember_Denied(t *testing.T) {
+	svc, groupNo, shortID, operatorUID := seedRenameThreadExternal(t, int(common.GroupMemberStatusNormal), 0, 1)
+
+	err := svc.UpdateName(groupNo, shortID, operatorUID, "外部成员改名")
+	require.Error(t, err, "外部成员应被拒绝改子区名")
+	require.Contains(t, err.Error(), "no permission")
+
+	got, err := svc.GetThread(groupNo, shortID, operatorUID)
+	require.NoError(t, err)
+	require.Equal(t, "原始子区名", got.Name, "外部成员被拒后子区名不变")
 }

--- a/modules/thread/rename_permission_matrix_test.go
+++ b/modules/thread/rename_permission_matrix_test.go
@@ -1,0 +1,106 @@
+package thread
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/stretchr/testify/require"
+)
+
+// seedRenameThread 建一个父群 + 一名操作者成员 + 一个活跃子区（子区创建者是另一个人，
+// 用来证明「改名不再要求创建者/管理员」）。操作者的成员状态 memberStatus、user.robot=robot
+// 由调用方指定，覆盖活跃人类 / 龙虾 / 黑名单三档。
+//
+// 直插 DB（不走 CreateThread）以规避已停的 IM(:5001)——与 group 侧 seed 同策略，
+// 只验证 UpdateName 的权限分档，不依赖频道创建。
+func seedRenameThread(t *testing.T, memberStatus, robot int) (*Service, string, string, string) {
+	t.Helper()
+
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	uniq := util.GenerUUID()[:8]
+	operatorUID := "op_" + uniq
+	threadCreatorUID := "tc_" + uniq
+
+	userDB := user.NewDB(ctx)
+	// 操作者：按档位决定成员状态与是否龙虾。
+	require.NoError(t, userDB.Insert(&user.Model{UID: operatorUID, Name: "操作者", ShortNo: "t_o_" + uniq, Robot: robot}))
+	// 子区创建者：另一名普通成员。
+	require.NoError(t, userDB.Insert(&user.Model{UID: threadCreatorUID, Name: "子区创建者", ShortNo: "t_c_" + uniq}))
+
+	groupNo := strings.ReplaceAll(util.GenerUUID(), "-", "")
+	groupDB := group.NewDB(ctx)
+	require.NoError(t, groupDB.Insert(&group.Model{GroupNo: groupNo, Name: "父群", Creator: threadCreatorUID, Status: 1, Version: 1}))
+	// 子区创建者是活跃群成员。
+	require.NoError(t, groupDB.InsertMember(&group.MemberModel{
+		GroupNo: groupNo, UID: threadCreatorUID, Role: group.MemberRoleCommon,
+		Status: int(common.GroupMemberStatusNormal), Version: 1, Vercode: util.GenerUUID(),
+	}))
+	// 操作者成员行——状态按档位。
+	require.NoError(t, groupDB.InsertMember(&group.MemberModel{
+		GroupNo: groupNo, UID: operatorUID, Role: group.MemberRoleCommon,
+		Status: memberStatus, Version: 2, Vercode: util.GenerUUID(),
+	}))
+
+	// 活跃子区，创建者是 threadCreatorUID（非操作者）。
+	shortID := fmt.Sprintf("%d", ctx.UserIDGen.Generate().Int64())
+	tdb := NewDB(ctx)
+	require.NoError(t, tdb.Insert(&Model{
+		ShortID:    shortID,
+		GroupNo:    groupNo,
+		Name:       "原始子区名",
+		CreatorUID: threadCreatorUID,
+		Status:     ThreadStatusActive,
+		Version:    1,
+	}))
+
+	svc := NewService(ctx).(*Service)
+	return svc, groupNo, shortID, operatorUID
+}
+
+// TestThreadUpdateName_NormalActiveHumanMember_Allowed 覆盖新行为：
+// 父群普通活跃人类成员（非子区创建者/管理员）即可改子区名。
+func TestThreadUpdateName_NormalActiveHumanMember_Allowed(t *testing.T) {
+	svc, groupNo, shortID, operatorUID := seedRenameThread(t, int(common.GroupMemberStatusNormal), 0)
+
+	err := svc.UpdateName(groupNo, shortID, operatorUID, "新子区名")
+	require.NoError(t, err, "普通活跃人类成员应能改子区名")
+
+	got, err := svc.GetThread(groupNo, shortID, operatorUID)
+	require.NoError(t, err)
+	require.Equal(t, "新子区名", got.Name)
+}
+
+// TestThreadUpdateName_Robot_Denied 覆盖新行为：龙虾(robot)禁止改子区名。
+func TestThreadUpdateName_Robot_Denied(t *testing.T) {
+	svc, groupNo, shortID, operatorUID := seedRenameThread(t, int(common.GroupMemberStatusNormal), 1)
+
+	err := svc.UpdateName(groupNo, shortID, operatorUID, "龙虾改名")
+	require.Error(t, err, "龙虾应被拒绝改子区名")
+	require.Contains(t, err.Error(), "no permission")
+
+	got, err := svc.GetThread(groupNo, shortID, operatorUID)
+	require.NoError(t, err)
+	require.Equal(t, "原始子区名", got.Name, "龙虾被拒后子区名不变")
+}
+
+// TestThreadUpdateName_BlacklistMember_Denied 覆盖新行为：
+// 被父群拉黑的成员（非活跃）禁止改子区名。
+func TestThreadUpdateName_BlacklistMember_Denied(t *testing.T) {
+	svc, groupNo, shortID, operatorUID := seedRenameThread(t, int(common.GroupMemberStatusBlacklist), 0)
+
+	err := svc.UpdateName(groupNo, shortID, operatorUID, "黑名单改名")
+	require.Error(t, err, "黑名单成员应被拒绝改子区名")
+	require.Contains(t, err.Error(), "no permission")
+
+	got, err := svc.GetThread(groupNo, shortID, operatorUID)
+	require.NoError(t, err)
+	require.Equal(t, "原始子区名", got.Name, "黑名单成员被拒后子区名不变")
+}

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -429,12 +429,14 @@ func (s *Service) UpdateName(groupNo, shortID, operatorUID, name string) error {
 
 	// 企业微信式解散语义（产品决策 2026-06）：子区改名属低风险写，解散后仍允许——
 	// 对齐会话置顶（group/api.go:groupSettingUpdate 的 settingActionMap 豁免解散校验）。
-	// 故此处不再调 ensureGroupNotDisbanded；改名仍受下方「父群活跃成员 + creator/admin」
-	// 权限校验保护。建子区 / 加入 / 归档 / 删除 / GROUP.md 仍由各自守卫拦截。
+	// 故此处不再调 ensureGroupNotDisbanded；改名仍受下方「父群内部活跃人类成员 + 龙虾排除」
+	// 权限校验保护（creator/admin 限制已放开）。建子区 / 加入 / 归档 / 删除 / GROUP.md 仍由各自守卫拦截。
 
-	// 子区操作权来自「父群活跃成员」身份：被拉黑/移出父群的用户即使是子区创建者也
-	// 无权改名。fail-closed。
-	isActive, err := s.groupService.ExistMemberActive(thread.GroupNo, operatorUID)
+	// 子区操作权来自「父群内部活跃成员」身份：被拉黑/移出父群的用户即使是子区创建者也
+	// 无权改名；跨 Space 外部成员(is_external=1)同样无权。fail-closed。
+	// 用 ExistMemberActiveInternal（带 is_external=0）保留旧门禁的 is_external=0 边界
+	// （YUJ-231 / GH#1289，P1）。
+	isActive, err := s.groupService.ExistMemberActiveInternal(thread.GroupNo, operatorUID)
 	if err != nil {
 		return fmt.Errorf("check active membership: %w", err)
 	}

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -433,7 +433,7 @@ func (s *Service) UpdateName(groupNo, shortID, operatorUID, name string) error {
 	// 权限校验保护。建子区 / 加入 / 归档 / 删除 / GROUP.md 仍由各自守卫拦截。
 
 	// 子区操作权来自「父群活跃成员」身份：被拉黑/移出父群的用户即使是子区创建者也
-	// 无权改名。必须在授予 creator/admin 特权之前先校验。fail-closed。
+	// 无权改名。fail-closed。
 	isActive, err := s.groupService.ExistMemberActive(thread.GroupNo, operatorUID)
 	if err != nil {
 		return fmt.Errorf("check active membership: %w", err)
@@ -442,14 +442,14 @@ func (s *Service) UpdateName(groupNo, shortID, operatorUID, name string) error {
 		return errors.New("no permission to update")
 	}
 
-	if thread.CreatorUID != operatorUID {
-		isManager, err := s.groupService.IsCreatorOrManager(thread.GroupNo, operatorUID)
-		if err != nil {
-			return fmt.Errorf("check permission: %w", err)
-		}
-		if !isManager {
-			return errors.New("no permission to update")
-		}
+	// 改名为低风险写：任何活跃的人类成员都可改子区名，无需是创建者/管理员。
+	// 但龙虾(robot)不是普通成员，禁止其调用改名。
+	isRobot, err := s.groupService.IsRobot(operatorUID)
+	if err != nil {
+		return fmt.Errorf("check robot: %w", err)
+	}
+	if isRobot {
+		return errors.New("no permission to update")
 	}
 
 	if err := s.db.UpdateName(shortID, name, s.threadVersionGen()); err != nil {


### PR DESCRIPTION
## 背景
改名属低风险写操作，此前统一要求创建者/管理员，权限过严。本 PR 按字段档位重新划分群/子区改名权限。关联 #541。

## 改动
- **子区改名**（`modules/thread/service.go` UpdateName）：保留「父群活跃成员」fail-closed 校验；移除「非创建者必须是管理员」的收紧逻辑；新增拒绝龙虾(robot)调用者。净效果：任何父群活跃人类成员均可改子区名，龙虾除外。
- **群改名**（`modules/group/api.go` groupUpdate）：将原单一管理员总闸替换为分档：
  - 仅含 `name` 字段：活跃人类成员即可（龙虾除外）。
  - 含高级字段（`notice`/`invite`/`avatar_text`/`avatar_color`）或混合请求：仍需管理员/群主（取最高档）。
  - 其它未知字段：保守走管理员校验兜底。
  - 字段存在性探测提前到权限校验之前；解散守卫、avatar 预校验、非原子部分写入防护均保持不变。
- **group Service**（`modules/group/service.go`）：新增 `IsRobot(uid)` 判断 `user.robot=1`。

## 验证
- `go build ./...` 通过。
- 单测依赖 MySQL/Redis/WuKongIM 运行环境，本地无该依赖故未执行。