### PR TITLE
feat(sticker): configurable upload limits + opt-in static compression

### DIFF
--- a/.octospec/tasks/sticker-upload-compression/brief.md
+++ b/.octospec/tasks/sticker-upload-compression/brief.md
@@ -1,0 +1,161 @@
+---
+type: Task
+title: "Task: sticker-upload-compression"
+description: Make custom-sticker upload limits (formats / max file size / max dimension) operator-configurable via system_setting with server-side hard caps, and add opt-in server-side compression for static jpg/png (decode → optional downscale → strip metadata → re-encode); webp/gif and animated images are validated-only in phase one.
+tags: ["sticker", "wire-contract", "rate-limit", "fullstack"]
+timestamp: 2026-07-07T06:54:12Z
+# --- octospec extension fields ---
+slug: sticker-upload-compression
+upstream: TBD
+source: self
+---
+
+# Task: sticker-upload-compression
+
+> Follow-up on `custom-sticker-management` / `sticker-upload-handle`. Two coupled
+> capabilities layered onto the same `modules/file` sticker upload path:
+> (1) the previously hard-coded upload limits become operator-tunable with
+> server-side hard caps; (2) an opt-in, phase-one server-side compressor for
+> static raster stickers. Both default to today's behavior (zero-impact until an
+> operator opts in).
+
+## Goal
+
+1. **Configurable upload limits.** The custom-sticker upload constraints —
+   allowed formats, per-file size cap, max decoded dimension — currently
+   hard-coded in `modules/file/const.go` (`stickerUploadExts`,
+   `StickerMaxFileSize` = 1 MB, `StickerMaxDimension` = 512) become
+   `system_setting` keys read through the existing 60s-snapshot `SystemSettings`
+   singleton, so they can be greyed out / rolled back without a redeploy.
+   Defaults reproduce today exactly. Every value is clamped by a **server-side
+   hard cap** so a mis-config cannot open a resource-exhaustion hole:
+   - max file size: default **1024 KB**, hard cap **5120 KB** (5 MB)
+   - max dimension: default **512 px**, hard cap **1024 px**
+   - allowed formats: default `gif,png,jpg,jpeg,webp`, intersected with the
+     built-in raster allowlist (config may only **narrow**, never add non-raster
+     types).
+
+2. **Server-side compression (opt-in, phase one = plan C).** When enabled, a
+   **static** `jpg/jpeg/png` upload is decoded → optionally downscaled to the
+   configured target → stripped of metadata → re-encoded in its original format,
+   before storage. `webp` and `gif` (and any animated image) are **validated
+   only, never compressed** in phase one — because the current dependency set
+   (`golang.org/x/image` webp = decoder-only; `disintegration/imaging` = no webp
+   encoder) cannot re-encode webp without a new cgo dependency, which is
+   deliberately out of scope. If a static image still exceeds the compression
+   target after re-encode, the upload is **rejected** (not stored oversized).
+
+3. **The `sticker_handle` is signed over the FINAL stored path/bytes.** Because
+   compression may change the object (and, if a future phase changes the
+   extension, the path), `stickersig.Sign` and the response `path`/`ext`/`size`
+   MUST reflect the post-compression result. In phase one compression preserves
+   the extension (jpg→jpg, png→png), so the path is unchanged; the invariant is
+   still asserted so a later format-changing phase cannot silently break it.
+
+4. **Ops & observability.** A default-OFF `compress_enabled` grey-out switch;
+   compression bounded by configurable **timeout, concurrency, and memory**
+   (decoded-pixel) ceilings, fail-open (skip compression, fall back to
+   validate-then-store) so the compressor can never destabilize the main upload
+   path; new low-cardinality metrics for compress success/failure/skip/over-limit
+   alongside the existing upload-outcome counters.
+
+## Background
+
+`modules/file/api.go:uploadFile()` is the single choke point holding both the
+authenticated uploader and the content-validated bytes; all sticker file-level
+gating (size → ext allowlist → raster-only → magic number → path-ext match →
+`image.DecodeConfig` dimension cap → store → `stickersig.Sign`) lives there, so
+compression must slot into that same path — after the dimension cap (api.go
+~397-428), before `service.UploadFile` (~463) and `stickersig.Sign` (~503).
+
+Config plumbing reuses `modules/common/system_setting_schema.go` (canonical
+schema slice; admin write path validates against it) + the `SystemSettings`
+atomic-snapshot getters (60s auto-reload, already home to
+`sticker.user_max_count / custom_enabled / handle_required`). There is **no
+`featuregate` module in this repo**; grey-out is a `system_setting` bool. The
+existing shared int bound is `[0, 3650]` (`settingIntMin/Max`); MB- and px-scale
+caps need their own per-key clamp getters rather than that shared bound.
+
+Metrics reuse `pkg/metrics/sticker.go` + `modules/file/sticker_metrics.go`
+(`observeStickerUpload(result)` CounterVec, dimensions pre-warmed to 0).
+
+Plan C was chosen (over transcoding webp→png/jpeg, or adding a cgo webp encoder)
+to keep phase one pure-Go, zero new dependency, and low operational risk.
+
+## Load-bearing list
+
+- **`modules/file` sticker upload contract** (touches: `wire-contract`) — the
+  upload response keeps its field shape (`path`/`name`/`size`/`ext`/`sha512`/
+  `sticker_handle`); when compression runs, `size` and the signed bytes are the
+  post-compression values. No change to any non-`type=sticker` upload.
+- **`stickersig.Sign` provenance binding** (touches: `auth`, `acl`) — the handle
+  must be minted over the final stored path (unchanged in phase one); the
+  register-side `validateStickerPath` `ext==format` invariant must still hold.
+  Reuses `sticker-upload-handle` guarantees; must not regress the
+  `handle_required` fail-closed path or the `sticker/` keyspace reservation.
+- **`system_setting` schema + admin write path** (touches: `wire-contract`) —
+  new keys added to the canonical schema slice; the manager write path
+  (`api_manager_system_setting.go`) and clamp getters enforce the per-key hard
+  caps. `custom_enabled` / appconfig client contract untouched.
+- **Upload-path resource envelope** (touches: `rate-limit`, `throttle`) —
+  compression adds CPU/memory load inside the request; the concurrency semaphore
+  + timeout + decoded-pixel ceiling are the throttle. Fail-open on saturation:
+  no new hard failure mode vs. today. This is process-local compute throttling,
+  NOT request-frequency limiting — the existing `SharedUIDRateLimiter` on the
+  sticker routes and the file-module IP limiter are unchanged.
+- **`modules/file` error-response convention** (touches: `error-response`) — the
+  file module is NOT yet migrated to the i18n `httperr` envelope; new rejection
+  paths use `c.ResponseError(...)` to stay consistent within the module (do not
+  introduce a lone `httperr` call here).
+- **Image decode surface** (touches: `trust-boundary`, `external-content`) —
+  decode/re-encode operates on untrusted user bytes; decompression-bomb defense
+  (decoded-pixel ceiling) and animated-image detection (gif via `DecodeAll`
+  frame count, animated-webp via RIFF/VP8X `ANIM` chunk scan) are new pure-Go
+  code that must fail safe.
+
+## Out of scope
+
+- **WebP / GIF / animated-image compression or transcoding.** Phase one is
+  validate-only for these; no webp re-encoder, no cgo `libwebp`, no format
+  conversion. (Explicitly deferred to a later phase.)
+- **Changing the two-stage upload→register contract**, the `sticker` module
+  register logic, quota (`user_max_count`), or the `handle_required` rollout.
+- **Client / octo-web changes.** The upload API field shape is preserved; no new
+  request field is required from clients.
+- **Request-frequency rate limiting.** No change to `SharedUIDRateLimiter` or the
+  file-module IP limiter; this task only adds compute-side throttling.
+- **Migrating `modules/file` to the i18n error envelope.**
+- **Async / out-of-band compression pipeline.** Phase one is synchronous within
+  the upload request, bounded by timeout + concurrency.
+
+## Acceptance
+
+- `sticker.upload_max_size_kb`, `sticker.upload_max_dimension`,
+  `sticker.upload_allowed_formats`, `sticker.compress_enabled`,
+  `sticker.compress_target_kb`, `sticker.compress_max_concurrency`,
+  `sticker.compress_timeout_ms` exist in the `system_setting_schema` slice, are
+  accepted by the manager write path, and are read via `SystemSettings` getters.
+- Clamp getters unit-tested: a configured value above the hard cap
+  (size > 5120 KB, dimension > 1024 px) returns the hard cap (not the input) and
+  logs a warning; `allowed_formats` is intersected with the raster allowlist
+  (a config value of `gif,png,mp4` yields `gif,png` — never `mp4`).
+- With `compress_enabled=false` (default), upload behavior is byte-for-byte
+  identical to current `main` (regression test: same stored bytes, same
+  `size`/`ext`/`sticker_handle`).
+- With `compress_enabled=true`: a static jpg/png larger than the target is
+  downscaled + re-encoded + metadata-stripped and stored **at or under** the
+  target; a static jpg/png that still exceeds the target after re-encode is
+  rejected with `observeStickerUpload("compress_over_limit")`.
+- A `webp` or animated `gif`/`webp` upload is never re-encoded (metric
+  `compress_skipped`), and is rejected iff it violates the (configurable) size /
+  dimension / format limits — same as today.
+- `sticker_handle` verifies against the **post-compression** stored bytes/path;
+  register (`POST /v1/sticker/user`) with the returned `path`/`handle` succeeds,
+  and `validateStickerPath`'s `ext==format` invariant holds.
+- Compression is bounded: unit test asserts it aborts on the configured timeout,
+  and that concurrency beyond `compress_max_concurrency` fails open (upload still
+  succeeds via validate-then-store, metric `compress_skipped`).
+- New metric dimensions `compress_success / compress_failed / compress_skipped /
+  compress_over_limit` are registered and pre-warmed to 0.
+- `go test ./modules/file/... ./modules/common/...` and `go vet` pass;
+  `make i18n-lint` unaffected (no new i18n codes introduced).

--- a/.octospec/tasks/sticker-upload-compression/perf-todo.md
+++ b/.octospec/tasks/sticker-upload-compression/perf-todo.md
@@ -1,0 +1,139 @@
+# perf-todo — sticker-upload-compression
+
+灰度前必须完成的性能验证清单。**本任务当前状态：功能就绪、性能未验证**。
+在 `sticker.compress_enabled=true` 打开到任何生产流量之前，必须回答本清单
+的每一项，把结果贴在本文件下方对应小节，作为放量决策依据。
+
+## 0. 已有的观测能力
+
+- Counter `sticker_upload_total{result}` — 新增 4 个 compress_* 维度已预热为 0
+- Histogram `sticker_compress_duration_seconds{outcome,format}` — 仅在
+  acquire slot 之后打点（compressed / over_limit / failed / skipped:timeout），
+  disabled/format/concurrency_saturated 分支耗时约等于 0，用 counter 观测即可
+
+Grafana 上线灰度前必须准备的面板：
+- P50/P95/P99 `sticker_compress_duration_seconds` 按 outcome、format 分维度
+- `rate(sticker_upload_total{result=~"compress_.*"}[5m])` 分四维度堆叠图
+- `histogram_quantile(0.99, ...)` 与配置 `compress_timeout_ms` 的对比线
+- 进程 CPU / goroutine 数 / heap alloc 曲线（对齐灰度切换时间点）
+
+## 1. 单机 CPU 基线（本地 bench，DONE — Apple M5）
+
+```
+go test -run x -bench='BenchmarkDoCompressStaticSticker' -benchmem -benchtime=3s ./modules/file/
+```
+
+| Benchmark                                     | ns/op       | ~ms/op | alloc/op |
+| --------------------------------------------- | ----------- | ------ | -------- |
+| JPEG 512² re-encode                           | 12,046,858  | ~12    | 936 KB   |
+| PNG 512²  re-encode                           | 29,883,139  | ~30    | 4.5 MB   |
+| JPEG 1024² → Fit(512) + re-encode             | 34,451,231  | ~34    | 5.6 MB   |
+| PNG  1024² → Fit(512) + re-encode             | 51,525,786  | ~52    | 11.2 MB  |
+| JPEG 1024² re-encode only (maxDim=1024)       | 49,102,169  | ~49    | 3.7 MB   |
+| PNG  1024² re-encode only (maxDim=1024)       | 111,301,979 | ~111   | 15.6 MB  |
+
+**关键推论**（M5，生产 x86 云 VM 通常慢 2-3×，用 3× 保守估算）：
+
+- **最坏单帧耗时**：PNG 1024² re-encode ≈ **~330 ms**（生产估）
+- **最坏单帧内存 alloc**：~15 MB / 帧 → concurrency=4 时峰值 **~60 MB**（可控）
+- **QPS 上限**（生产估）：
+  - concurrency=4：JPEG 512² ~110 QPS；PNG 1024² ~12 QPS
+  - concurrency=8：JPEG 512² ~220 QPS；PNG 1024² ~24 QPS
+
+**默认值合理性初判**：
+- `compress_max_concurrency=4` — 单实例上限保守，防止 CPU 打满。真实
+  贴纸 <1024² + JPEG 占多数，实测 QPS 天花板应远高于业务贴纸创建速率。
+- `compress_timeout_ms=2000` — 相对 ~330 ms 最坏单帧有 **6× 余量**，能吸收
+  抖动。若生产观测到 P99 < 500 ms 稳定，可下调到 1000 ms 提升拒绝速度。
+
+## 2. 待补的性能验证（灰度前 MUST）
+
+### 2.1 生产 CPU 型号下的 bench 复跑
+
+在实际生产 Node（x86 云 VM，非 M5）上跑上面这条 `go test -bench=...` 拿到
+本地基线的 3× / 4× 因子的实测校正值。**若结果偏离本地估算 ±50%，需重新
+评估 concurrency / timeout 默认值**。
+
+- [ ] 生产型号 CPU 上跑一遍 bench，把六行结果贴到本文件
+- [ ] 若 PNG 1024² 单帧 > 1000 ms，把 `compress_timeout_ms` 默认调高到
+      3000 ms 再放量，否则频繁 skip:timeout 会让压缩形同虚设
+
+### 2.2 pprof CPU / heap 剖面
+
+- [ ] `go test -run x -bench='BenchmarkDoCompressStaticSticker_PNG_1024' -cpuprofile=cpu.out`
+  → `go tool pprof -top cpu.out`，确认 CPU 时间主要在 imaging.Encode / Lanczos，
+  没有奇怪的框架开销
+- [ ] `-memprofile=mem.out`：确认 alloc/op 与 bench 报的一致；无异常泄漏
+
+### 2.3 端到端 HTTP 压测
+
+用 `hey` 或 `wrk` 打 `POST /v1/file/upload?type=sticker`（真实 auth token +
+multipart 载体），采集：
+
+- [ ] 稳态 QPS = 目标生产 QPS × 1.5 时的 P50/P95/P99 延迟
+- [ ] 稳态 CPU 使用率（应 < 70%）
+- [ ] 稳态 heap alloc 曲线（应平稳、无线性上涨 = 无泄漏）
+- [ ] 稳态 goroutine 数（应有界、无线性上涨 = 无 dangling worker）
+- [ ] 错误分布：`compress_over_limit` / `compress_skipped:timeout` /
+      `compress_failed` 各占比
+
+**过关标准（建议）**：
+- P99 < timeout 值 × 0.8（有余量，避免 timeout 密集触发）
+- `compress_skipped:concurrency_saturated` < 1%（并发数够用）
+- `compress_skipped:timeout` < 0.1%（timeout 足够）
+- CPU steady < 70%
+
+### 2.4 Goroutine 泄漏边界测试
+
+**风险点**：`stickerCompressor.Compress` 走 timeout 分支时，后台 goroutine 未
+被取消，仍在跑到 `doCompress` 自然结束（imaging 无 context）才退出。在
+"客户端持续上传导致每次都 timeout"的极端场景下，dangling goroutine 会累积。
+
+单帧 dangling 时间 = doCompress 完整耗时 - timeoutMs（PNG 1024² 最坏 ~110 ms
+超出 2000 ms 的场景需要更大的图，不常见）。**但需要显式压测**：
+
+- [ ] 用故意注入的 slow `doCompress`（sleep 5s），以 timeout=100 ms 打 1000 QPS
+      持续 60s，观察 goroutine 峰值 —— 应 ≤ `concurrency × ceil(5s/100ms) = 200`，
+      不应无限增长（compressor sem 已卡上限）
+- [ ] 若观察到线性增长，说明 sem 语义有 bug 或 goroutine 未按预期退出
+
+### 2.5 Mutex 争用评估
+
+**风险点**：`stickerCompressor.mu` 是全局单锁，`tryAcquireCompressSlot` /
+`releaseCompressSlot` 每次请求进出各锁一次。高 QPS 下可能成为热点。
+
+- [ ] `go test -run x -bench='...' -blockprofile=block.out` → `go tool pprof
+      -top block.out`，看 mu 是否进入 top-3
+- [ ] 若是热点，考虑改 `atomic.Int32` + CAS（现在的 mutex 语义"数据比较"完全
+      可用原子操作代替，无 map/slice 保护需求）
+
+**当前判断**：默认 concurrency=4 时，稳态最多 4 个持锁 goroutine + 后来者一次
+tryAcquire 就 return，锁窗口 ~ns 级，不会是热点。但配合 §2.3 压测数据佐证。
+
+### 2.6 Decompression bomb 防御
+
+维度上限 1024²（配置硬 cap）→ 解码后 RGBA 内存 = 1024×1024×4 = **4 MB / 帧**。
+concurrency=4 时峰值 16 MB，安全。
+
+- [ ] 灰度前跑一次已知恶意样本（1 KB 压缩包解出 10000² 位图），确认在
+      `image.DecodeConfig` 阶段被 dimension 校验拦住，**不进入压缩管线**
+      （压缩管线的 image.Decode 走 full-decode 才是攻击面，前置维度门是
+      唯一防线）
+
+## 3. 灰度切换的操作剧本
+
+- [ ] Step 1: 打开 `sticker.compress_enabled=true` 到 **单实例 5% 流量**
+      （或用 GrayScale 平台把其中 1 台 pod 单独打标签）
+- [ ] Step 2: 观察 15 分钟：`compress_success` 占比 > 50%（说明格式命中）、
+      P99 < 500 ms、CPU 增幅 < 10%
+- [ ] Step 3: 逐步放量到 50% → 100%，每步观察 30 分钟
+- [ ] Step 4: 生产观测稳定 24h 后再调 `compress_max_concurrency` / `_timeout_ms`
+      默认值到实测最优（下调 timeout 提升拒绝速度、按 CPU 富余上调 concurrency）
+
+## 4. 回滚剧本
+
+- 一键关：`sticker.compress_enabled=false`（60s 内 all replica 收敛）
+- 缩容闸：`sticker.compress_max_concurrency=1` 快速降低 CPU 占用（不需要
+  完全关，只是缩容压力）
+- 兜底：所有压缩失败路径都 fail-open 走原字节，即使 compressor 完全瘫痪
+  上传主链路不受影响（brief 的 acceptance 已保证）

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -1,6 +1,9 @@
 package common
 
-import "strconv"
+import (
+	"strconv"
+	"strings"
+)
 
 // Value types accepted by system_setting.value_type.
 const (
@@ -152,6 +155,34 @@ var systemSettingSchema = []settingDef{
 	// 不承担任何服务端鉴权。经 GET /v1/common/appconfig 的 docs_on 下发给客户端。
 	{Category: "docs", Key: "enabled", Type: settingTypeBool, Description: "是否向客户端展示文档(docs)模块入口（octo-docs-backend 上线前默认关闭）",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.DocsEnabled()) }},
+
+	// 自定义贴纸上传限制（sticker-upload-compression 任务）。原先硬编码在
+	// modules/file/const.go；挪进 system_setting 后可灰度/回滚，且每键都有
+	// 服务端硬上限（stickerUpload*HardCap / stickerCompress*HardCap），误配也不会
+	// 越出资源上限。全部 Positive:true 走"必须正整数"admin 写侧校验，同时放开
+	// settingTypeInt 默认的 [0,3650] 上界（本组键上限单独校验，见读侧 clamp）。
+	{Category: "sticker", Key: "upload_max_size_kb", Type: settingTypeInt, Description: "自定义贴纸单文件大小上限(KB)，服务端硬上限 5120(5MB)；默认 1024", Positive: true,
+		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.StickerUploadMaxSizeKB()) }},
+	{Category: "sticker", Key: "upload_max_dimension", Type: settingTypeInt, Description: "自定义贴纸解码后单边像素上限，服务端硬上限 1024；默认 512", Positive: true,
+		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.StickerUploadMaxDimension()) }},
+	// upload_allowed_formats 用字符串存 CSV，读侧与内置位图白名单求交集(只能收窄,
+	// 不能放开非位图)。取消 Positive/整数校验，写侧不校验内容(anything goes)，非法
+	// 项在读侧被丢弃；全部非法时读侧回退默认全 5 种，避免误配把功能暗关。
+	{Category: "sticker", Key: "upload_allowed_formats", Type: settingTypeString, Description: "自定义贴纸允许扩展名(逗号分隔，如 gif,png,jpg,jpeg,webp)；只能与内置位图白名单取交集(收窄)，非位图会被读侧丢弃",
+		Effective: func(s *SystemSettings) string { return strings.Join(s.StickerUploadAllowedFormats(), ",") }},
+
+	// 自定义贴纸服务端压缩开关与调参（sticker-upload-compression 任务，方案 C：只压
+	// 静态 jpg/png；webp/gif/动图 validate-only）。compress_enabled 默认关闭，运营
+	// 灰度开启；compress_target_kb 是压缩目标(压缩后仍超即拒)；max_concurrency 与
+	// timeout_ms 是稳定性闸(饱和/超时都 fail-open，走原路径不阻塞主链路)。
+	{Category: "sticker", Key: "compress_enabled", Type: settingTypeBool, Description: "是否开启贴纸服务端压缩(仅静态 jpg/png；webp/gif 恒不压)；默认关闭以支持灰度",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.StickerCompressEnabled()) }},
+	{Category: "sticker", Key: "compress_target_kb", Type: settingTypeInt, Description: "压缩目标(KB)；压缩后仍超此值将拒绝上传；硬上限 5120(5MB)，默认 1024", Positive: true,
+		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.StickerCompressTargetKB()) }},
+	{Category: "sticker", Key: "compress_max_concurrency", Type: settingTypeInt, Description: "同时进行的贴纸压缩数量上限；饱和时该请求跳过压缩走原路径(fail-open)；硬上限 32，默认 4", Positive: true,
+		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.StickerCompressMaxConcurrency()) }},
+	{Category: "sticker", Key: "compress_timeout_ms", Type: settingTypeInt, Description: "单次贴纸压缩超时(毫秒)；超时该请求跳过压缩走原路径(fail-open)；硬上限 10000，默认 2000", Positive: true,
+		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.StickerCompressTimeoutMs()) }},
 
 	// Email server config — formerly yaml-only (Support.* in config.go).
 	{Category: "support", Key: "email", Type: settingTypeString, Description: "技术支持邮箱（发件人）",

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -786,3 +786,170 @@ func (s *SystemSettings) StickerHandleRequired() bool {
 func (s *SystemSettings) DocsEnabled() bool {
 	return s.getBool("docs", "enabled", false)
 }
+
+// ---------------------------------------------------------------------------
+// Custom-sticker upload constraints + optional server-side compression
+// (sticker-upload-compression task).
+//
+// These formerly-hard-coded numbers (modules/file/const.go: StickerMaxFileSize
+// = 1MB, StickerMaxDimension = 512, stickerUploadExts) become operator-tunable
+// through system_setting so a bad configuration can be greyed out / rolled back
+// without a redeploy. Every int key has a server-side HARD CAP that read-side
+// clamp getters enforce even against a direct DB edit — the admin write path
+// already rejects non-positive ints via Positive:true; these clamps are defence
+// in depth against the "someone edits the row by hand" case.
+//
+// stickerUploadRasterAllowlist mirrors modules/file/const.go:stickerUploadExts
+// verbatim. Duplicated intentionally to keep modules/common a leaf (modules/file
+// already imports modules/common; reversing would cycle). Keep in sync — the
+// upload_allowed_formats getter uses this list as the outer bound the config
+// may only narrow from.
+// ---------------------------------------------------------------------------
+
+const (
+	defaultStickerUploadMaxSizeKB   = 1024
+	stickerUploadMaxSizeKBHardCap   = 5 * 1024
+
+	defaultStickerUploadMaxDimension = 512
+	stickerUploadMaxDimensionHardCap = 1024
+
+	defaultStickerCompressEnabled = false
+
+	defaultStickerCompressTargetKB = 1024
+	stickerCompressTargetKBHardCap = 5 * 1024
+
+	defaultStickerCompressMaxConcurrency = 4
+	stickerCompressMaxConcurrencyHardCap = 32
+
+	defaultStickerCompressTimeoutMs = 2000
+	stickerCompressTimeoutMsHardCap = 10000
+)
+
+// stickerUploadRasterAllowlist 与 modules/file/const.go:stickerUploadExts 保持一致。
+// 用于 upload_allowed_formats 配置的读侧交集：管理台只能收窄，不能加入非位图。
+// 若 modules/file 侧改动允许扩展名，此列表也需同步。
+var stickerUploadRasterAllowlist = []string{".gif", ".png", ".jpg", ".jpeg", ".webp"}
+
+// stickerClampIntUpper clamps an int getter to [1, hardCap]. Any value ≤0 or
+// non-numeric (which surface as fallback default from getInt) is served as
+// default; values above hardCap are clamped to hardCap; everything else is
+// returned verbatim. Shared by every KB/px/ms/count sticker upload setting so
+// the clamp policy is single-sourced.
+func stickerClampIntUpper(v, fallback, hardCap int) int {
+	if v <= 0 {
+		return fallback
+	}
+	if v > hardCap {
+		return hardCap
+	}
+	return v
+}
+
+// StickerUploadMaxSizeKB returns the per-file upload cap in KB. Read-side
+// clamped to [1, stickerUploadMaxSizeKBHardCap]; out-of-range falls back to
+// the historical 1024 KB default.
+func (s *SystemSettings) StickerUploadMaxSizeKB() int {
+	return stickerClampIntUpper(
+		s.getInt("sticker", "upload_max_size_kb", defaultStickerUploadMaxSizeKB),
+		defaultStickerUploadMaxSizeKB,
+		stickerUploadMaxSizeKBHardCap,
+	)
+}
+
+// StickerUploadMaxDimension returns the decoded-pixel single-edge cap. Read-side
+// clamped to [1, stickerUploadMaxDimensionHardCap]; out-of-range falls back to
+// the historical 512-px default.
+func (s *SystemSettings) StickerUploadMaxDimension() int {
+	return stickerClampIntUpper(
+		s.getInt("sticker", "upload_max_dimension", defaultStickerUploadMaxDimension),
+		defaultStickerUploadMaxDimension,
+		stickerUploadMaxDimensionHardCap,
+	)
+}
+
+// StickerUploadAllowedFormats returns the sanitized set of allowed extensions
+// (each including the leading dot, lowercased). It is intersected with the
+// built-in raster allowlist (stickerUploadRasterAllowlist) so a mis-config can
+// only narrow — never widen to non-raster (mp4/pdf/svg/...). If the config
+// exists but the intersection is empty (all tokens illegal), the FULL default
+// set is returned instead of an empty slice so a bad config cannot "dark-close"
+// the feature; deployments narrow explicitly by writing a valid CSV.
+//
+// Order of returned slice is deterministic for stability of callers that log
+// or index it; tests sort before comparing regardless.
+func (s *SystemSettings) StickerUploadAllowedFormats() []string {
+	raw, ok := s.lookup("sticker", "upload_allowed_formats")
+	if !ok {
+		out := make([]string, len(stickerUploadRasterAllowlist))
+		copy(out, stickerUploadRasterAllowlist)
+		return out
+	}
+	allowlist := make(map[string]struct{}, len(stickerUploadRasterAllowlist))
+	for _, e := range stickerUploadRasterAllowlist {
+		allowlist[e] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(stickerUploadRasterAllowlist))
+	out := make([]string, 0, len(stickerUploadRasterAllowlist))
+	for _, tok := range strings.Split(raw, ",") {
+		tok = strings.ToLower(strings.TrimSpace(tok))
+		if tok == "" {
+			continue
+		}
+		if !strings.HasPrefix(tok, ".") {
+			tok = "." + tok
+		}
+		if _, ok := allowlist[tok]; !ok {
+			continue
+		}
+		if _, dup := seen[tok]; dup {
+			continue
+		}
+		seen[tok] = struct{}{}
+		out = append(out, tok)
+	}
+	if len(out) == 0 {
+		out = make([]string, len(stickerUploadRasterAllowlist))
+		copy(out, stickerUploadRasterAllowlist)
+	}
+	return out
+}
+
+// StickerCompressEnabled reports whether server-side compression of static
+// sticker images (jpg/png) is turned on. Default false — the feature is
+// opt-in, greyed out until an operator flips this bit.
+func (s *SystemSettings) StickerCompressEnabled() bool {
+	return s.getBool("sticker", "compress_enabled", defaultStickerCompressEnabled)
+}
+
+// StickerCompressTargetKB returns the post-compression target size in KB.
+// Read-side clamped to [1, stickerCompressTargetKBHardCap]; out-of-range falls
+// back to the 1024 KB default.
+func (s *SystemSettings) StickerCompressTargetKB() int {
+	return stickerClampIntUpper(
+		s.getInt("sticker", "compress_target_kb", defaultStickerCompressTargetKB),
+		defaultStickerCompressTargetKB,
+		stickerCompressTargetKBHardCap,
+	)
+}
+
+// StickerCompressMaxConcurrency returns the process-wide cap on concurrent
+// sticker compressions. Read-side clamped to [1, stickerCompressMaxConcurrencyHardCap];
+// out-of-range falls back to 4.
+func (s *SystemSettings) StickerCompressMaxConcurrency() int {
+	return stickerClampIntUpper(
+		s.getInt("sticker", "compress_max_concurrency", defaultStickerCompressMaxConcurrency),
+		defaultStickerCompressMaxConcurrency,
+		stickerCompressMaxConcurrencyHardCap,
+	)
+}
+
+// StickerCompressTimeoutMs returns the per-compression timeout in milliseconds.
+// Read-side clamped to [1, stickerCompressTimeoutMsHardCap]; out-of-range falls
+// back to 2000ms.
+func (s *SystemSettings) StickerCompressTimeoutMs() int {
+	return stickerClampIntUpper(
+		s.getInt("sticker", "compress_timeout_ms", defaultStickerCompressTimeoutMs),
+		defaultStickerCompressTimeoutMs,
+		stickerCompressTimeoutMsHardCap,
+	)
+}

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -807,8 +807,8 @@ func (s *SystemSettings) DocsEnabled() bool {
 // ---------------------------------------------------------------------------
 
 const (
-	defaultStickerUploadMaxSizeKB   = 1024
-	stickerUploadMaxSizeKBHardCap   = 5 * 1024
+	defaultStickerUploadMaxSizeKB = 1024
+	stickerUploadMaxSizeKBHardCap = 5 * 1024
 
 	defaultStickerUploadMaxDimension = 512
 	stickerUploadMaxDimensionHardCap = 1024

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"math"
 	"os"
 	"regexp"
@@ -88,6 +89,11 @@ type SystemSettings struct {
 	db        *systemSettingDB
 	snapshot  atomic.Pointer[map[string]string]
 	reloadTTL time.Duration
+	// stickerClampWarned 去重 clamp getter 的越界 Warn(review R6)。key 形如
+	// "sticker.upload_max_size_kb=99999>5120",同一 (key, 越界值) 在进程周期
+	// 内只 log 一次;admin 改到别的越界值会重新 log 一条。避免读侧热路径
+	// 刷屏,同时保留 operator 可观测性。
+	stickerClampWarned sync.Map
 	log.Log
 }
 
@@ -835,11 +841,24 @@ var stickerUploadRasterAllowlist = []string{".gif", ".png", ".jpg", ".jpeg", ".w
 // default; values above hardCap are clamped to hardCap; everything else is
 // returned verbatim. Shared by every KB/px/ms/count sticker upload setting so
 // the clamp policy is single-sourced.
-func stickerClampIntUpper(v, fallback, hardCap int) int {
+//
+// key is the fully qualified setting name (e.g. "sticker.upload_max_size_kb");
+// when v exceeds hardCap this method emits a per-(key, v) one-shot Warn so a
+// bad admin edit is operator-observable without spamming the read hot path
+// (review R6). Admin fixes → new越界 value or in-range value → new Warn or
+// silence, matching human-friendly signal semantics.
+func (s *SystemSettings) stickerClampIntUpper(key string, v, fallback, hardCap int) int {
 	if v <= 0 {
 		return fallback
 	}
 	if v > hardCap {
+		dedupKey := fmt.Sprintf("%s=%d>%d", key, v, hardCap)
+		if _, loaded := s.stickerClampWarned.LoadOrStore(dedupKey, struct{}{}); !loaded {
+			s.Warn("system_setting sticker knob exceeds hard cap; clamped",
+				zap.String("key", key),
+				zap.Int("configured", v),
+				zap.Int("hard_cap", hardCap))
+		}
 		return hardCap
 	}
 	return v
@@ -849,7 +868,7 @@ func stickerClampIntUpper(v, fallback, hardCap int) int {
 // clamped to [1, stickerUploadMaxSizeKBHardCap]; out-of-range falls back to
 // the historical 1024 KB default.
 func (s *SystemSettings) StickerUploadMaxSizeKB() int {
-	return stickerClampIntUpper(
+	return s.stickerClampIntUpper("sticker.upload_max_size_kb",
 		s.getInt("sticker", "upload_max_size_kb", defaultStickerUploadMaxSizeKB),
 		defaultStickerUploadMaxSizeKB,
 		stickerUploadMaxSizeKBHardCap,
@@ -860,7 +879,7 @@ func (s *SystemSettings) StickerUploadMaxSizeKB() int {
 // clamped to [1, stickerUploadMaxDimensionHardCap]; out-of-range falls back to
 // the historical 512-px default.
 func (s *SystemSettings) StickerUploadMaxDimension() int {
-	return stickerClampIntUpper(
+	return s.stickerClampIntUpper("sticker.upload_max_dimension",
 		s.getInt("sticker", "upload_max_dimension", defaultStickerUploadMaxDimension),
 		defaultStickerUploadMaxDimension,
 		stickerUploadMaxDimensionHardCap,
@@ -925,7 +944,7 @@ func (s *SystemSettings) StickerCompressEnabled() bool {
 // Read-side clamped to [1, stickerCompressTargetKBHardCap]; out-of-range falls
 // back to the 1024 KB default.
 func (s *SystemSettings) StickerCompressTargetKB() int {
-	return stickerClampIntUpper(
+	return s.stickerClampIntUpper("sticker.compress_target_kb",
 		s.getInt("sticker", "compress_target_kb", defaultStickerCompressTargetKB),
 		defaultStickerCompressTargetKB,
 		stickerCompressTargetKBHardCap,
@@ -936,7 +955,7 @@ func (s *SystemSettings) StickerCompressTargetKB() int {
 // sticker compressions. Read-side clamped to [1, stickerCompressMaxConcurrencyHardCap];
 // out-of-range falls back to 4.
 func (s *SystemSettings) StickerCompressMaxConcurrency() int {
-	return stickerClampIntUpper(
+	return s.stickerClampIntUpper("sticker.compress_max_concurrency",
 		s.getInt("sticker", "compress_max_concurrency", defaultStickerCompressMaxConcurrency),
 		defaultStickerCompressMaxConcurrency,
 		stickerCompressMaxConcurrencyHardCap,
@@ -947,7 +966,7 @@ func (s *SystemSettings) StickerCompressMaxConcurrency() int {
 // Read-side clamped to [1, stickerCompressTimeoutMsHardCap]; out-of-range falls
 // back to 2000ms.
 func (s *SystemSettings) StickerCompressTimeoutMs() int {
-	return stickerClampIntUpper(
+	return s.stickerClampIntUpper("sticker.compress_timeout_ms",
 		s.getInt("sticker", "compress_timeout_ms", defaultStickerCompressTimeoutMs),
 		defaultStickerCompressTimeoutMs,
 		stickerCompressTimeoutMsHardCap,

--- a/modules/common/system_settings_sticker_upload_test.go
+++ b/modules/common/system_settings_sticker_upload_test.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,9 +16,10 @@ import (
 
 // stickerSnapSettings builds a SystemSettings whose snapshot is exactly `snap`
 // — used by every no-infra test in this file so the read-side clamp logic can be
-// exercised without spinning up a test server.
+// exercised without spinning up a test server. Log is initialised because the
+// clamp getters may emit an over-cap Warn (review R6).
 func stickerSnapSettings(snap map[string]string) *SystemSettings {
-	s := &SystemSettings{}
+	s := &SystemSettings{Log: log.NewTLog("SystemSettingsTest")}
 	m := map[string]string{}
 	for k, v := range snap {
 		m[k] = v
@@ -228,4 +230,63 @@ func TestSystemSettings_StickerCompressTimeoutMs_ClampBehavior(t *testing.T) {
 		})
 		assert.Equalf(t, want, s.StickerCompressTimeoutMs(), "timeout_ms=%q", in)
 	}
+}
+
+// ----- clamp warning dedup (review R6) -----
+
+// TestSystemSettings_StickerClampIntUpper_DedupsWarnPerBoundaryValue 验证
+// 同一 (key, 越界值) 组合在进程周期内只 warn 一次(避免读侧热路径刷屏),
+// 但换成不同的越界值/不同 key 会重新 warn。dedup 状态是 sync.Map,不涉及
+// zap.Logger 输出捕获 —— 直接观察 stickerClampWarned 的 sentinel。
+func TestSystemSettings_StickerClampIntUpper_DedupsWarnPerBoundaryValue(t *testing.T) {
+	s := stickerSnapSettings(map[string]string{
+		"sticker.upload_max_size_kb": "99999", // 超过 5120 hard cap
+	})
+	// 多次调用同一 getter → clamp 到 hard cap,内部只 warn 一次
+	for i := 0; i < 5; i++ {
+		assert.Equal(t, stickerUploadMaxSizeKBHardCap, s.StickerUploadMaxSizeKB())
+	}
+	assertClampWarnedOnce(t, s, "sticker.upload_max_size_kb=99999>5120")
+
+	// 换成不同的越界值,应生成新的 dedup key(即再 warn 一次)。
+	s2 := stickerSnapSettings(map[string]string{
+		"sticker.upload_max_size_kb": "88888",
+	})
+	assert.Equal(t, stickerUploadMaxSizeKBHardCap, s2.StickerUploadMaxSizeKB())
+	assertClampWarnedOnce(t, s2, "sticker.upload_max_size_kb=88888>5120")
+
+	// 换成不同的 key(同越界值 99999 但落在 dimension 的 1024 hard cap 上),
+	// 也应产生新的 dedup key。
+	s3 := stickerSnapSettings(map[string]string{
+		"sticker.upload_max_dimension": "99999",
+	})
+	assert.Equal(t, stickerUploadMaxDimensionHardCap, s3.StickerUploadMaxDimension())
+	assertClampWarnedOnce(t, s3, "sticker.upload_max_dimension=99999>1024")
+}
+
+// TestSystemSettings_StickerClampIntUpper_NoWarnWhenInRange 验证正常配置读时
+// clamp 快路径完全不进 sync.Map(sentinel 为空),读侧热路径零 CPU/内存开销。
+func TestSystemSettings_StickerClampIntUpper_NoWarnWhenInRange(t *testing.T) {
+	s := stickerSnapSettings(map[string]string{
+		"sticker.upload_max_size_kb":   "2048", // 合法
+		"sticker.upload_max_dimension": "512",  // 合法
+	})
+	for i := 0; i < 10; i++ {
+		_ = s.StickerUploadMaxSizeKB()
+		_ = s.StickerUploadMaxDimension()
+	}
+	count := 0
+	s.stickerClampWarned.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	assert.Equal(t, 0, count, "in-range values must not populate the dedup map")
+}
+
+// assertClampWarnedOnce 断言 SystemSettings.stickerClampWarned 里存在给定
+// dedup key(且仅有它 —— 或有其它 key 但仍存在这一条)。
+func assertClampWarnedOnce(t *testing.T, s *SystemSettings, want string) {
+	t.Helper()
+	_, ok := s.stickerClampWarned.Load(want)
+	assert.Truef(t, ok, "expected dedup key %q recorded", want)
 }

--- a/modules/common/system_settings_sticker_upload_test.go
+++ b/modules/common/system_settings_sticker_upload_test.go
@@ -1,0 +1,231 @@
+package common
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// 自定义贴纸上传限制 + 服务端压缩配置读侧测试（sticker-upload-compression 任务）。
+//
+// 全部走 no-infra 模式：直接向 SystemSettings.snapshot 灌 map，规避 MySQL/Redis
+// 依赖，与 TestSystemSettings_IncomingWebhook_ReadSideClamp_NoInfra 同风格。DB
+// 全链路的 Load/Reload 由 CI 上其余 system_settings_test.go 用例覆盖。
+
+// stickerSnapSettings builds a SystemSettings whose snapshot is exactly `snap`
+// — used by every no-infra test in this file so the read-side clamp logic can be
+// exercised without spinning up a test server.
+func stickerSnapSettings(snap map[string]string) *SystemSettings {
+	s := &SystemSettings{}
+	m := map[string]string{}
+	for k, v := range snap {
+		m[k] = v
+	}
+	s.snapshot.Store(&m)
+	return s
+}
+
+// ----- upload_max_size_kb -----
+
+func TestSystemSettings_StickerUploadMaxSizeKB_DefaultsWhenUnset(t *testing.T) {
+	s := stickerSnapSettings(nil)
+	assert.Equal(t, defaultStickerUploadMaxSizeKB, s.StickerUploadMaxSizeKB())
+}
+
+func TestSystemSettings_StickerUploadMaxSizeKB_DBOverride(t *testing.T) {
+	s := stickerSnapSettings(map[string]string{
+		"sticker.upload_max_size_kb": "2048",
+	})
+	assert.Equal(t, 2048, s.StickerUploadMaxSizeKB())
+}
+
+// A DB row above the server-side hard cap clamps to the hard cap, NOT the input;
+// otherwise a bad admin edit could exceed the resource envelope the hard cap is
+// meant to protect (task brief: "配置需有服务端硬上限").
+func TestSystemSettings_StickerUploadMaxSizeKB_ClampsToHardCap(t *testing.T) {
+	s := stickerSnapSettings(map[string]string{
+		"sticker.upload_max_size_kb": "999999",
+	})
+	assert.Equal(t, stickerUploadMaxSizeKBHardCap, s.StickerUploadMaxSizeKB())
+}
+
+// Non-positive / non-numeric values fall back to the default rather than being
+// served verbatim (0 would "dark-close" the upload; negative would wrap around
+// after multiplication to bytes). Matches the pattern in IncomingWebhookMaxPerGroup.
+func TestSystemSettings_StickerUploadMaxSizeKB_ClampsNonPositive(t *testing.T) {
+	for _, bad := range []string{"0", "-1", "abc", ""} {
+		s := stickerSnapSettings(map[string]string{
+			"sticker.upload_max_size_kb": bad,
+		})
+		assert.Equalf(t, defaultStickerUploadMaxSizeKB, s.StickerUploadMaxSizeKB(),
+			"value=%q must fall back to default", bad)
+	}
+}
+
+// The hard-cap value itself is accepted as-is (upper boundary is inclusive).
+func TestSystemSettings_StickerUploadMaxSizeKB_HardCapBoundaryAccepted(t *testing.T) {
+	s := stickerSnapSettings(map[string]string{
+		"sticker.upload_max_size_kb": "5120",
+	})
+	assert.Equal(t, 5120, s.StickerUploadMaxSizeKB())
+}
+
+// ----- upload_max_dimension -----
+
+func TestSystemSettings_StickerUploadMaxDimension_DefaultsWhenUnset(t *testing.T) {
+	s := stickerSnapSettings(nil)
+	assert.Equal(t, defaultStickerUploadMaxDimension, s.StickerUploadMaxDimension())
+}
+
+func TestSystemSettings_StickerUploadMaxDimension_DBOverride(t *testing.T) {
+	s := stickerSnapSettings(map[string]string{
+		"sticker.upload_max_dimension": "768",
+	})
+	assert.Equal(t, 768, s.StickerUploadMaxDimension())
+}
+
+func TestSystemSettings_StickerUploadMaxDimension_ClampsToHardCap(t *testing.T) {
+	s := stickerSnapSettings(map[string]string{
+		"sticker.upload_max_dimension": "8192",
+	})
+	assert.Equal(t, stickerUploadMaxDimensionHardCap, s.StickerUploadMaxDimension())
+}
+
+func TestSystemSettings_StickerUploadMaxDimension_ClampsNonPositive(t *testing.T) {
+	for _, bad := range []string{"0", "-10", "abc"} {
+		s := stickerSnapSettings(map[string]string{
+			"sticker.upload_max_dimension": bad,
+		})
+		assert.Equalf(t, defaultStickerUploadMaxDimension, s.StickerUploadMaxDimension(),
+			"value=%q must fall back to default", bad)
+	}
+}
+
+// ----- upload_allowed_formats -----
+
+func sortedExts(in []string) []string {
+	out := append([]string{}, in...)
+	sort.Strings(out)
+	return out
+}
+
+// 未配置 → 全部 5 种位图（复刻历史硬编码 stickerUploadExts）。
+func TestSystemSettings_StickerUploadAllowedFormats_DefaultsFullSet(t *testing.T) {
+	s := stickerSnapSettings(nil)
+	got := s.StickerUploadAllowedFormats()
+	assert.Equal(t,
+		[]string{".gif", ".jpeg", ".jpg", ".png", ".webp"},
+		sortedExts(got),
+	)
+}
+
+// 配置只能收窄（narrow），得到的是配置和位图白名单的交集。
+func TestSystemSettings_StickerUploadAllowedFormats_NarrowsToConfig(t *testing.T) {
+	s := stickerSnapSettings(map[string]string{
+		"sticker.upload_allowed_formats": "png,jpg",
+	})
+	assert.Equal(t, []string{".jpg", ".png"}, sortedExts(s.StickerUploadAllowedFormats()))
+}
+
+// 位图白名单外的类型（mp4/pdf/svg）在读侧被丢弃，绝不放开。这条是硬上限一部分：
+// 即使运营写错，也不会让非位图作为贴纸被存进 sticker/ keyspace。
+func TestSystemSettings_StickerUploadAllowedFormats_DropsNonRaster(t *testing.T) {
+	s := stickerSnapSettings(map[string]string{
+		"sticker.upload_allowed_formats": "png,mp4,pdf,svg",
+	})
+	assert.Equal(t, []string{".png"}, sortedExts(s.StickerUploadAllowedFormats()))
+}
+
+// 大小写、前后空格、前缀点号缺失都归一化。
+func TestSystemSettings_StickerUploadAllowedFormats_Normalizes(t *testing.T) {
+	s := stickerSnapSettings(map[string]string{
+		"sticker.upload_allowed_formats": "  PNG  ,  .JPG  , .Gif ",
+	})
+	assert.Equal(t, []string{".gif", ".jpg", ".png"}, sortedExts(s.StickerUploadAllowedFormats()))
+}
+
+// 配置存在但交集为空（全非法）→ 回退默认全 5 种，避免"运营写错就把功能暗关"。
+func TestSystemSettings_StickerUploadAllowedFormats_EmptyIntersectionFallsBack(t *testing.T) {
+	for _, bad := range []string{"", " ", ",,,", "mp4,pdf"} {
+		s := stickerSnapSettings(map[string]string{
+			"sticker.upload_allowed_formats": bad,
+		})
+		got := s.StickerUploadAllowedFormats()
+		assert.Equalf(t,
+			[]string{".gif", ".jpeg", ".jpg", ".png", ".webp"},
+			sortedExts(got),
+			"value=%q must fall back to the full default set", bad,
+		)
+	}
+}
+
+// ----- compress_enabled -----
+
+func TestSystemSettings_StickerCompressEnabled_DefaultsFalse(t *testing.T) {
+	s := stickerSnapSettings(nil)
+	assert.False(t, s.StickerCompressEnabled(), "DB empty -> compression off by default (grey-out required)")
+}
+
+func TestSystemSettings_StickerCompressEnabled_DBTrueWins(t *testing.T) {
+	s := stickerSnapSettings(map[string]string{
+		"sticker.compress_enabled": "1",
+	})
+	assert.True(t, s.StickerCompressEnabled())
+}
+
+// ----- compress_target_kb / max_concurrency / timeout_ms clamp -----
+
+func TestSystemSettings_StickerCompressTargetKB_ClampBehavior(t *testing.T) {
+	tests := map[string]int{
+		"":       defaultStickerCompressTargetKB,      // unset → default
+		"0":      defaultStickerCompressTargetKB,      // ≤0 → default
+		"-1":     defaultStickerCompressTargetKB,      // negative → default
+		"abc":    defaultStickerCompressTargetKB,      // non-numeric → default
+		"999999": stickerCompressTargetKBHardCap,      // over hard cap → hard cap
+		"512":    512,                                 // in-range → verbatim
+		"5120":   stickerCompressTargetKBHardCap,      // exact hard cap → accepted
+	}
+	for in, want := range tests {
+		s := stickerSnapSettings(map[string]string{
+			"sticker.compress_target_kb": in,
+		})
+		assert.Equalf(t, want, s.StickerCompressTargetKB(), "target_kb=%q", in)
+	}
+}
+
+func TestSystemSettings_StickerCompressMaxConcurrency_ClampBehavior(t *testing.T) {
+	tests := map[string]int{
+		"":       defaultStickerCompressMaxConcurrency,
+		"0":      defaultStickerCompressMaxConcurrency,
+		"-2":     defaultStickerCompressMaxConcurrency,
+		"abc":    defaultStickerCompressMaxConcurrency,
+		"999":    stickerCompressMaxConcurrencyHardCap,
+		"8":      8,
+		"32":     stickerCompressMaxConcurrencyHardCap,
+	}
+	for in, want := range tests {
+		s := stickerSnapSettings(map[string]string{
+			"sticker.compress_max_concurrency": in,
+		})
+		assert.Equalf(t, want, s.StickerCompressMaxConcurrency(), "max_concurrency=%q", in)
+	}
+}
+
+func TestSystemSettings_StickerCompressTimeoutMs_ClampBehavior(t *testing.T) {
+	tests := map[string]int{
+		"":        defaultStickerCompressTimeoutMs,
+		"0":       defaultStickerCompressTimeoutMs,
+		"-100":    defaultStickerCompressTimeoutMs,
+		"abc":     defaultStickerCompressTimeoutMs,
+		"9999999": stickerCompressTimeoutMsHardCap,
+		"500":     500,
+		"10000":   stickerCompressTimeoutMsHardCap,
+	}
+	for in, want := range tests {
+		s := stickerSnapSettings(map[string]string{
+			"sticker.compress_timeout_ms": in,
+		})
+		assert.Equalf(t, want, s.StickerCompressTimeoutMs(), "timeout_ms=%q", in)
+	}
+}

--- a/modules/file/api.go
+++ b/modules/file/api.go
@@ -181,7 +181,7 @@ func (f *File) getFilePath(c *wkhttp.Context) {
 		// 自定义表情：扩展名由客户端上传文件名（filename query）推导，限定在
 		// gif/png/jpg/jpeg/webp；缺省 / 不在白名单 → 回退 .gif（保持历史行为，
 		// 不传 filename 的老客户端不受影响）。
-		path = fmt.Sprintf("%s/file/upload?type=%s&path=/%s/%s%s", f.ctx.GetConfig().External.APIBaseURL, fileType, loginUID, util.GenerUUID(), stickerUploadExt(c.Query("filename")))
+		path = fmt.Sprintf("%s/file/upload?type=%s&path=/%s/%s%s", f.ctx.GetConfig().External.APIBaseURL, fileType, loginUID, util.GenerUUID(), f.stickerUploadExtForRequest(c.Query("filename")))
 	} else if Type(fileType) == TypeWorkplaceBanner {
 		// 工作台横幅
 		path = fmt.Sprintf("%s/file/upload?type=%s&path=/workplace/banner/%s", f.ctx.GetConfig().External.APIBaseURL, fileType, path)
@@ -470,7 +470,7 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 	// 故 stickersig.Sign 天然基于压缩后的字节（同一 URL 对应最终存储对象）。
 	var uploadReader io.ReadSeeker = file
 	finalSize := fileHeader.Size
-	if isStickerUpload && stickerLimits.compressEnabled {
+	if isStickerUpload && stickerLimits.compressEnabled && f.compressor != nil {
 		if canCompressStickerExt(ext) {
 			srcBytes, readErr := io.ReadAll(file)
 			if readErr != nil {
@@ -479,7 +479,7 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 				c.ResponseError(errors.New("读取文件失败"))
 				return
 			}
-			result := f.compressor.Compress(ext, srcBytes)
+			result := f.compressor.Compress(ext, srcBytes, stickerLimits.compressParams())
 			switch result.Outcome {
 			case stickerCompressOutcomeCompressed:
 				observeStickerUpload("compress_success")

--- a/modules/file/api.go
+++ b/modules/file/api.go
@@ -466,8 +466,12 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 	// sticker-upload-compression: 压缩管线，仅当 isStickerUpload && compress_enabled
 	// 才启动，其他类型/格式走原路径（uploadReader==file, finalSize==fileHeader.Size）。
 	// 方案 C: 只压静态 jpg/png；gif/webp 只记 compress_skipped 不改字节。
-	// handle 基于最终 fullURL；本期 path/ext 不因压缩改变，fullURL 与压前一致，
-	// 故 stickersig.Sign 天然基于压缩后的字节（同一 URL 对应最终存储对象）。
+	// 关于 sticker_handle 与压缩的关系（review R5 澄清）：stickersig.Sign 只
+	// HMAC (uid, path) 字符串，提供 URL/uploader 溯源 —— **不是** 内容 hash。
+	// 之所以「压缩前后 handle 都稳定」，是因为本期 path/ext 不因压缩改变，
+	// signed URL 始终解析到最终存储对象；content-integrity 单独由 sha512
+	// 字段承载（下方 sha512 与 service.UploadFile 都基于 uploadReader，即
+	// 压缩后的字节）。
 	var uploadReader io.ReadSeeker = file
 	finalSize := fileHeader.Size
 	if isStickerUpload && stickerLimits.compressEnabled && f.compressor != nil {
@@ -492,7 +496,10 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 					zap.Int64("final_size", result.Size))
 			case stickerCompressOutcomeOverLimit:
 				observeStickerUpload("compress_over_limit")
-				targetKB := f.settings.StickerCompressTargetKB()
+				// 用 snapshot 里的 compressTargetKB(而非 f.settings 的 live 值),
+				// 保证 error/log 数字与 Compress 实际用的 target 严格同源 ——
+				// 兑现"一请求一份快照"的不变式(review R1 / F7 补漏)。
+				targetKB := stickerLimits.compressTargetKB
 				f.Warn("贴纸压缩后仍超目标大小，拒绝上传",
 					zap.String("uid", loginUID),
 					zap.String("ext", ext),

--- a/modules/file/api.go
+++ b/modules/file/api.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha512"
 	"encoding/base64"
@@ -26,6 +27,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/Mininglamp-OSS/octo-server/pkg/metrics"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	"github.com/Mininglamp-OSS/octo-server/pkg/stickersig"
@@ -48,14 +50,24 @@ type File struct {
 	ctx *config.Context
 	log.Log
 	service IService
+	// settings 承载 sticker 上传限制与压缩开关的 SystemSettings 快照读；类型是
+	// stickerSystemSettings 接口而非 *common.SystemSettings，方便单测注入内存 fake。
+	// 历史 unit test 直接 &File{} 构造未挂 settings；stickerLimits() 会 nil-safe
+	// 回落到硬编码默认值。生产路径经 New(ctx) 挂载 *common.SystemSettings。
+	settings stickerSystemSettings
+	// compressor 服务端贴纸压缩器。同 settings, nil 视为 disabled(unit test 场景)。
+	compressor *stickerCompressor
 }
 
 // New New
 func New(ctx *config.Context) *File {
+	settings := common.EnsureSystemSettings(ctx)
 	return &File{
-		ctx:     ctx,
-		Log:     log.NewTLog("File"),
-		service: NewService(ctx),
+		ctx:        ctx,
+		Log:        log.NewTLog("File"),
+		service:    NewService(ctx),
+		settings:   settings,
+		compressor: newStickerCompressor(settings),
 	}
 }
 
@@ -196,6 +208,9 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 	if signature != "" {
 		signatureInt, _ = strconv.ParseInt(signature, 10, 64)
 	}
+	// sticker-upload-compression: 一次请求锁定一份限制快照，后续所有校验、压缩、
+	// 响应都基于同一份值。SystemSettings 60s reload 后新一批请求才用新值。
+	stickerLimits := f.stickerLimits()
 	contentType := c.DefaultPostForm("contenttype", "application/octet-stream")
 	err := f.checkReq(typedFile, uploadPath)
 	if err != nil {
@@ -265,17 +280,17 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 		c.ResponseError(fmt.Errorf("文件大小不能超过%dMB", MaxFileSize/1024/1024))
 		return
 	}
-	// 自定义贴纸单独收紧上限（StickerMaxFileSize），贴纸是高频内联渲染的小图，
-	// 不应允许到通用 MaxFileSize。错误用 c.ResponseError 以与本（未迁移 i18n 的）
-	// file 模块其余响应保持一致。
-	if isStickerUpload && fileHeader.Size > StickerMaxFileSize {
+	// 自定义贴纸单独收紧上限（可运营配置的 sticker.upload_max_size_kb，默认 1024
+	// 硬上限 5120），贴纸是高频内联渲染的小图，不应允许到通用 MaxFileSize。错误用
+	// c.ResponseError 以与本（未迁移 i18n 的）file 模块其余响应保持一致。
+	if isStickerUpload && fileHeader.Size > stickerLimits.maxSize {
 		observeStickerUpload("size_rejected")
 		f.Warn("贴纸文件超出大小限制",
 			zap.String("uid", loginUID),
 			zap.Int64("size", fileHeader.Size),
-			zap.Int64("max", StickerMaxFileSize),
+			zap.Int64("max", stickerLimits.maxSize),
 			zap.Bool("handle_required", stickersig.Enabled()))
-		c.ResponseError(fmt.Errorf("贴纸大小不能超过%dMB", StickerMaxFileSize/1024/1024))
+		c.ResponseError(fmt.Errorf("贴纸大小不能超过%dKB", stickerLimits.maxSize/1024))
 		return
 	}
 
@@ -306,9 +321,11 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 		c.ResponseError(fmt.Errorf("不支持上传%s类型的文件", ext))
 		return
 	}
-	// 贴纸只接受位图格式（stickerUploadExts：gif/png/jpg/jpeg/webp）。全局
-	// allowlist 还允许 pdf/zip/mp4 等，不收紧会让非图对象落入 sticker 桶。
-	if isStickerUpload && !stickerUploadExts[ext] {
+	// 贴纸只接受配置允许的位图格式（stickerLimits.allowedFormats，默认为
+	// gif/png/jpg/jpeg/webp；运营可通过 sticker.upload_allowed_formats 收窄，但
+	// 读侧交集保证不会放开非位图）。全局 allowlist 还允许 pdf/zip/mp4 等，
+	// 不收紧会让非图对象落入 sticker 桶。
+	if isStickerUpload && !stickerLimits.allowedFormats[ext] {
 		observeStickerUpload("format_rejected")
 		f.Warn("贴纸不支持的格式",
 			zap.String("uid", loginUID),
@@ -316,7 +333,7 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 			zap.String("ext", ext),
 			zap.Int64("size", fileHeader.Size),
 			zap.Bool("handle_required", stickersig.Enabled()))
-		c.ResponseError(fmt.Errorf("贴纸仅支持 gif/png/jpg/jpeg/webp，不支持%s", ext))
+		c.ResponseError(fmt.Errorf("贴纸格式不允许：%s", ext))
 		return
 	}
 
@@ -389,11 +406,11 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 		return
 	}
 
-	// 自定义贴纸：限制解码后的像素尺寸。StickerMaxFileSize(1MB) 只约束压缩后的
-	// 字节数，不约束解码维度——一张高压缩比的小文件可解出极大位图把内联渲染端
-	// 撑爆内存，而贴纸会发送给会话对方，等同跨用户 DoS。用 image.DecodeConfig 只读
-	// 图像头拿 W×H（不解整图），任一边超过 StickerMaxDimension(512) 即拒。此时 ext
-	// 已限定在 gif/png/jpg/jpeg/webp，对应解码器均已注册。
+	// 自定义贴纸：限制解码后的像素尺寸。stickerLimits.maxSize（配置的字节数上限）
+	// 只约束压缩后的字节数，不约束解码维度——一张高压缩比的小文件可解出极大位图把
+	// 内联渲染端撑爆内存，而贴纸会发送给会话对方，等同跨用户 DoS。用 image.DecodeConfig
+	// 只读图像头拿 W×H（不解整图），任一边超过 stickerLimits.maxDim 即拒。此时 ext
+	// 已限定在配置允许的位图集合，对应解码器均已注册。
 	if isStickerUpload {
 		cfg, _, decErr := image.DecodeConfig(file)
 		if decErr != nil {
@@ -406,7 +423,7 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 			c.ResponseError(errors.New("无法解析贴纸图像，可能已损坏或格式不受支持"))
 			return
 		}
-		if cfg.Width > StickerMaxDimension || cfg.Height > StickerMaxDimension {
+		if cfg.Width > stickerLimits.maxDim || cfg.Height > stickerLimits.maxDim {
 			observeStickerUpload("dimension_rejected")
 			f.Warn("贴纸尺寸超出限制",
 				zap.String("uid", loginUID),
@@ -414,8 +431,8 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 				zap.Int64("size", fileHeader.Size),
 				zap.Int("width", cfg.Width),
 				zap.Int("height", cfg.Height),
-				zap.Int("max", StickerMaxDimension))
-			c.ResponseError(fmt.Errorf("贴纸尺寸不能超过 %d×%d 像素", StickerMaxDimension, StickerMaxDimension))
+				zap.Int("max", stickerLimits.maxDim))
+			c.ResponseError(fmt.Errorf("贴纸尺寸不能超过 %d×%d 像素", stickerLimits.maxDim, stickerLimits.maxDim))
 			return
 		}
 		// DecodeConfig 读掉了图像头，复位指针供后续签名/上传读取完整内容。
@@ -445,10 +462,80 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 			path = path + ext
 		}
 	}
+
+	// sticker-upload-compression: 压缩管线，仅当 isStickerUpload && compress_enabled
+	// 才启动，其他类型/格式走原路径（uploadReader==file, finalSize==fileHeader.Size）。
+	// 方案 C: 只压静态 jpg/png；gif/webp 只记 compress_skipped 不改字节。
+	// handle 基于最终 fullURL；本期 path/ext 不因压缩改变，fullURL 与压前一致，
+	// 故 stickersig.Sign 天然基于压缩后的字节（同一 URL 对应最终存储对象）。
+	var uploadReader io.ReadSeeker = file
+	finalSize := fileHeader.Size
+	if isStickerUpload && stickerLimits.compressEnabled {
+		if canCompressStickerExt(ext) {
+			srcBytes, readErr := io.ReadAll(file)
+			if readErr != nil {
+				observeStickerUpload("read_failed")
+				f.Error("读取贴纸文件失败", zap.Error(readErr))
+				c.ResponseError(errors.New("读取文件失败"))
+				return
+			}
+			result := f.compressor.Compress(ext, srcBytes)
+			switch result.Outcome {
+			case stickerCompressOutcomeCompressed:
+				observeStickerUpload("compress_success")
+				uploadReader = bytes.NewReader(result.Bytes)
+				finalSize = result.Size
+				f.Info("贴纸压缩成功",
+					zap.String("uid", loginUID),
+					zap.String("ext", ext),
+					zap.Int64("orig_size", fileHeader.Size),
+					zap.Int64("final_size", result.Size))
+			case stickerCompressOutcomeOverLimit:
+				observeStickerUpload("compress_over_limit")
+				targetKB := f.settings.StickerCompressTargetKB()
+				f.Warn("贴纸压缩后仍超目标大小，拒绝上传",
+					zap.String("uid", loginUID),
+					zap.String("ext", ext),
+					zap.Int64("orig_size", fileHeader.Size),
+					zap.Int64("compressed_size", result.Size),
+					zap.Int("target_kb", targetKB))
+				c.ResponseError(fmt.Errorf("贴纸压缩后仍超过 %dKB", targetKB))
+				return
+			case stickerCompressOutcomeFailed:
+				observeStickerUpload("compress_failed")
+				f.Warn("贴纸压缩失败，fail-open 走原字节",
+					zap.String("uid", loginUID),
+					zap.String("ext", ext),
+					zap.String("reason", result.Reason))
+				uploadReader = bytes.NewReader(srcBytes)
+				finalSize = int64(len(srcBytes))
+			default: // stickerCompressOutcomeSkipped
+				observeStickerUpload("compress_skipped")
+				f.Info("贴纸压缩跳过",
+					zap.String("uid", loginUID),
+					zap.String("ext", ext),
+					zap.String("reason", result.Reason))
+				uploadReader = bytes.NewReader(srcBytes)
+				finalSize = int64(len(srcBytes))
+			}
+		} else {
+			// gif/webp 等本期不可压格式：只观测 skip，字节流不变，走 file 直上传路径。
+			observeStickerUpload("compress_skipped")
+		}
+	}
+
 	var sign []byte
 	if signatureInt == 1 {
+		if _, err := uploadReader.Seek(0, io.SeekStart); err != nil {
+			if isStickerUpload {
+				observeStickerUpload("read_failed")
+			}
+			f.Error("签名前重置文件指针失败", zap.Error(err))
+			c.ResponseError(errors.New("签名复制文件错误"))
+			return
+		}
 		h := sha512.New()
-		_, err := io.Copy(h, file)
+		_, err := io.Copy(h, uploadReader)
 		if err != nil {
 			if isStickerUpload {
 				observeStickerUpload("read_failed")
@@ -461,12 +548,12 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 	}
 	contentDisposition := BuildContentDisposition(fileName)
 	_, err = f.service.UploadFile(fmt.Sprintf("%s%s", fileType, path), contentType, contentDisposition, func(w io.Writer) error {
-		_, err := file.Seek(0, io.SeekStart)
+		_, err := uploadReader.Seek(0, io.SeekStart)
 		if err != nil {
 			f.Error("设置文件偏移量错误", zap.Error(err))
 			return err
 		}
-		_, err = io.Copy(w, file)
+		_, err = io.Copy(w, uploadReader)
 		return err
 	})
 	if err != nil {
@@ -487,7 +574,7 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 	resp := map[string]interface{}{
 		"path": fullURL,
 		"name": fileName,
-		"size": fileHeader.Size,
+		"size": finalSize,
 		"ext":  ext,
 	}
 	if signatureInt == 1 {
@@ -511,7 +598,8 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 		f.Info("贴纸上传成功",
 			zap.String("uid", loginUID),
 			zap.String("format", strings.TrimPrefix(ext, ".")),
-			zap.Int64("size", fileHeader.Size),
+			zap.Int64("orig_size", fileHeader.Size),
+			zap.Int64("final_size", finalSize),
 			zap.Bool("handle_required", stickersig.Enabled()))
 	}
 	c.Response(resp)

--- a/modules/file/api_sticker_compress_test.go
+++ b/modules/file/api_sticker_compress_test.go
@@ -43,8 +43,8 @@ type fakeStickerSystemSettings struct {
 	timeoutMs       int
 }
 
-func (f *fakeStickerSystemSettings) StickerUploadMaxSizeKB() int       { return f.maxSizeKB }
-func (f *fakeStickerSystemSettings) StickerUploadMaxDimension() int    { return f.maxDim }
+func (f *fakeStickerSystemSettings) StickerUploadMaxSizeKB() int    { return f.maxSizeKB }
+func (f *fakeStickerSystemSettings) StickerUploadMaxDimension() int { return f.maxDim }
 func (f *fakeStickerSystemSettings) StickerUploadAllowedFormats() []string {
 	out := make([]string, len(f.allowedFormats))
 	copy(out, f.allowedFormats)
@@ -99,6 +99,47 @@ func newStickerCompressFile(t *testing.T, s *fakeStickerSystemSettings) (*File, 
 		settings:   s,
 		compressor: newStickerCompressor(s),
 	}, svc
+}
+
+// TestUploadFile_CompressorNilDoesNotPanic 保护异常构造路径：settings 挂了且
+// compressEnabled=true，但 compressor==nil。生产 New(ctx) 里 settings+compressor
+// 是一起初始化的，这种状态不该出现；但 File.compressor 的文档说 nil=disabled，
+// uploadFile 就必须尊重这个合约（review F3）—— fail-open 走原字节，不 nil-panic。
+func TestUploadFile_CompressorNilDoesNotPanic(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const uid = "10000"
+	settings := defaultFakeStickerSettings()
+	settings.compressEnabled = true
+	settings.maxSizeKB = 5120
+	settings.maxDim = 1024
+
+	svc := &capturingMockService{
+		mockService: mockService{downloadURL: "https://cdn.example.com/dm/sticker/" + uid + "/abc.jpg"},
+	}
+	f := &File{
+		Log:      log.NewTLog("FileTest"),
+		service:  svc,
+		settings: settings,
+		// compressor 特意留 nil —— 关键的异常构造点
+	}
+
+	origBytes := makeTestJPEG(t, 128, 128, 80)
+	body, contentType := newMultipartFile(t, "abc.jpg", origBytes)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/v1/file/upload?type=sticker&path=/"+uid+"/abc.jpg", body)
+	c.Request.Header.Set("Content-Type", contentType)
+	c.Set("uid", uid)
+	wkCtx := &wkhttp.Context{Context: c}
+
+	require.NotPanics(t, func() {
+		f.uploadFile(wkCtx)
+	}, "compressor==nil must not cause a nil-pointer dereference in uploadFile")
+
+	require.Equalf(t, http.StatusOK, w.Code, "must fail-open on nil compressor; body: %s", w.Body.String())
+	assert.Equal(t, origBytes, svc.uploaded,
+		"fail-open path must upload the original bytes byte-for-byte")
 }
 
 // TestUploadFile_CompressEnabled_LargeJPEG_UsesCompressedBytes 集成验证：开启

--- a/modules/file/api_sticker_compress_test.go
+++ b/modules/file/api_sticker_compress_test.go
@@ -1,0 +1,285 @@
+package file
+
+import (
+	"bytes"
+	"encoding/json"
+	"image"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/stickersig"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// api_sticker_compress_test.go — 服务端压缩管线在 uploadFile 里的集成 unit test
+// （sticker-upload-compression 任务 Task #4）。
+//
+// 覆盖：
+//   1) compress_enabled=true + jpg 大图 → 上传字节被替换成压缩后字节，resp.size
+//      是压后大小，sticker_handle 基于最终 fullURL 签发。
+//   2) compress_enabled=true + gif → 走 skipped 分支，字节流不变。
+//   3) compress_enabled=true + jpg + target 极小 → over_limit 拒绝，落库为空。
+//   4) compress_enabled=false → 走原路径，与老 unit test 等价（已由既有
+//      TestUploadFile_StickerHandleMinted 覆盖：&File{} settings==nil 时 compress
+//      被视为 disabled）。
+
+// fakeStickerSystemSettings 实现 stickerSystemSettings；用于 api-level 集成测试
+// 全套配置注入，无需 MySQL/Redis test server。
+type fakeStickerSystemSettings struct {
+	maxSizeKB       int
+	maxDim          int
+	allowedFormats  []string
+	compressEnabled bool
+	targetKB        int
+	maxConcurrency  int
+	timeoutMs       int
+}
+
+func (f *fakeStickerSystemSettings) StickerUploadMaxSizeKB() int       { return f.maxSizeKB }
+func (f *fakeStickerSystemSettings) StickerUploadMaxDimension() int    { return f.maxDim }
+func (f *fakeStickerSystemSettings) StickerUploadAllowedFormats() []string {
+	out := make([]string, len(f.allowedFormats))
+	copy(out, f.allowedFormats)
+	return out
+}
+func (f *fakeStickerSystemSettings) StickerCompressEnabled() bool       { return f.compressEnabled }
+func (f *fakeStickerSystemSettings) StickerCompressTargetKB() int       { return f.targetKB }
+func (f *fakeStickerSystemSettings) StickerCompressMaxConcurrency() int { return f.maxConcurrency }
+func (f *fakeStickerSystemSettings) StickerCompressTimeoutMs() int      { return f.timeoutMs }
+
+// defaultFakeStickerSettings 复刻改动前的硬编码默认值 —— 大多数测试从这里起手，
+// 只按需要覆盖字段（例如 compressEnabled）。
+func defaultFakeStickerSettings() *fakeStickerSystemSettings {
+	return &fakeStickerSystemSettings{
+		maxSizeKB:       1024,
+		maxDim:          512,
+		allowedFormats:  []string{".gif", ".png", ".jpg", ".jpeg", ".webp"},
+		compressEnabled: false,
+		targetKB:        1024,
+		maxConcurrency:  4,
+		timeoutMs:       5000,
+	}
+}
+
+// capturingMockService 是能抓获 UploadFile 收到字节的 mockService；用于验证
+// "落库的是压缩后字节，而不是原字节"。
+type capturingMockService struct {
+	mockService
+	uploaded     []byte
+	uploadedPath string
+}
+
+func (c *capturingMockService) UploadFile(filePath, contentType, contentDisposition string, copyFileWriter func(io.Writer) error) (map[string]interface{}, error) {
+	c.uploadedPath = filePath
+	var buf bytes.Buffer
+	if err := copyFileWriter(&buf); err != nil {
+		return nil, err
+	}
+	c.uploaded = buf.Bytes()
+	return nil, nil
+}
+
+// 构造一个 File，直接注入 fake settings + 生产 compressor + capturing service。
+func newStickerCompressFile(t *testing.T, s *fakeStickerSystemSettings) (*File, *capturingMockService) {
+	t.Helper()
+	svc := &capturingMockService{
+		mockService: mockService{downloadURL: "https://cdn.example.com/dm/sticker/10000/abc"},
+	}
+	return &File{
+		Log:        log.NewTLog("FileTest"),
+		service:    svc,
+		settings:   s,
+		compressor: newStickerCompressor(s),
+	}, svc
+}
+
+// TestUploadFile_CompressEnabled_LargeJPEG_UsesCompressedBytes 集成验证：开启
+// 压缩后，大 JPEG 上传后落库的是**压缩后**字节；resp.size 是压后值；handle 基于
+// 最终 fullURL 签发；path/ext 在方案 C 下保持不变。
+func TestUploadFile_CompressEnabled_LargeJPEG_UsesCompressedBytes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+
+	const uid = "10000"
+	settings := defaultFakeStickerSettings()
+	settings.compressEnabled = true
+	// 允许 5MB 原始大小 + 1024px 维度，让 900px 源图能通过维度门。压缩靠
+	// quality 降低（95→85）+ 去元数据 shrink，无需 downscale。
+	settings.maxSizeKB = 5120
+	settings.maxDim = 1024
+	settings.targetKB = 512
+
+	f, svc := newStickerCompressFile(t, settings)
+	svc.downloadURL = "https://cdn.example.com/dm/sticker/" + uid + "/abc.jpg"
+
+	origBytes := makeTestJPEG(t, 900, 900, 95)
+	require.Greater(t, len(origBytes), 200*1024, "seed must be big enough that compression measurably shrinks it")
+	body, contentType := newMultipartFile(t, "abc.jpg", origBytes)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/v1/file/upload?type=sticker&path=/"+uid+"/abc.jpg", body)
+	c.Request.Header.Set("Content-Type", contentType)
+	c.Set("uid", uid)
+	wkCtx := &wkhttp.Context{Context: c}
+
+	f.uploadFile(wkCtx)
+
+	require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	// 落库字节是压缩后的（严格短于原字节）。
+	assert.Less(t, len(svc.uploaded), len(origBytes), "compressed bytes must be shorter than original")
+	// 落库字节仍是 valid JPEG。dim 保持在 maxDim 内（本用例源就 <=maxDim）。
+	dec, format, err := image.Decode(bytes.NewReader(svc.uploaded))
+	require.NoError(t, err)
+	assert.Equal(t, "jpeg", format)
+	bounds := dec.Bounds()
+	assert.LessOrEqual(t, bounds.Dx(), settings.maxDim)
+	assert.LessOrEqual(t, bounds.Dy(), settings.maxDim)
+	// 源图正方形 → 输出也应正方形（本用例宽高比 1:1，压缩不能拉伸）。
+	assert.Equal(t, bounds.Dx(), bounds.Dy(),
+		"aspect ratio must be preserved: 900×900 source must produce square output")
+
+	// resp.size 是压后大小；handle verify 基于返回 path。
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	respSize, _ := resp["size"].(float64)
+	assert.EqualValues(t, len(svc.uploaded), int64(respSize), "resp.size must be the post-compression byte count")
+	handle, _ := resp["sticker_handle"].(string)
+	require.NotEmpty(t, handle)
+	path, _ := resp["path"].(string)
+	assert.True(t, stickersig.Verify(uid, path, handle),
+		"handle must verify for (uid, final path) — the tuple sticker.add checks")
+}
+
+// TestUploadFile_CompressEnabled_GIF_SkipsUnchanged 集成验证：开启压缩后 gif
+// 走 compress_skipped 分支，落库字节与源字节字节级相等（不压缩）。方案 C 下
+// gif 不进入压缩管线，即使 compress_enabled=true 也不改内容。
+func TestUploadFile_CompressEnabled_GIF_SkipsUnchanged(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+
+	const uid = "10000"
+	settings := defaultFakeStickerSettings()
+	settings.compressEnabled = true
+
+	f, svc := newStickerCompressFile(t, settings)
+	svc.downloadURL = "https://cdn.example.com/dm/sticker/" + uid + "/x.gif"
+
+	// 最小 valid GIF89a (1x1 pixel)。
+	gifBytes := []byte{
+		0x47, 0x49, 0x46, 0x38, 0x39, 0x61, // GIF89a
+		0x01, 0x00, 0x01, 0x00, 0x80, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0xff, 0xff, 0xff,
+		0x2c, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
+		0x02, 0x02, 0x44, 0x01, 0x00, 0x3b,
+	}
+	body, contentType := newMultipartFile(t, "x.gif", gifBytes)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/v1/file/upload?type=sticker&path=/"+uid+"/x.gif", body)
+	c.Request.Header.Set("Content-Type", contentType)
+	c.Set("uid", uid)
+	wkCtx := &wkhttp.Context{Context: c}
+
+	f.uploadFile(wkCtx)
+
+	require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, gifBytes, svc.uploaded, "gif must pass through byte-for-byte when compress is enabled")
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	respSize, _ := resp["size"].(float64)
+	assert.EqualValues(t, len(gifBytes), int64(respSize), "resp.size must equal source size when gif skipped")
+}
+
+// TestUploadFile_CompressEnabled_OverLimitRejects 集成验证：压后仍超 target 时
+// 直接拒绝上传（capturingMockService.uploaded 不应被写入）。
+func TestUploadFile_CompressEnabled_OverLimitRejects(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const uid = "10000"
+	settings := defaultFakeStickerSettings()
+	settings.compressEnabled = true
+	settings.targetKB = 1 // 1KB 压后目标 —— 300x300 随机像素 png 达不到
+	settings.maxDim = 512
+	settings.maxSizeKB = 5120 // 允许 5MB 原始上传，让 png 能过 size 门
+
+	f, svc := newStickerCompressFile(t, settings)
+
+	origBytes := makeTestPNG(t, 300, 300)
+	require.Greater(t, len(origBytes), 10*1024, "seed PNG must exceed 10KB")
+	body, contentType := newMultipartFile(t, "abc.png", origBytes)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/v1/file/upload?type=sticker&path=/"+uid+"/abc.png", body)
+	c.Request.Header.Set("Content-Type", contentType)
+	c.Set("uid", uid)
+	wkCtx := &wkhttp.Context{Context: c}
+
+	f.uploadFile(wkCtx)
+
+	require.NotEqual(t, http.StatusOK, w.Code, "over_limit must reject; got body=%s", w.Body.String())
+	assert.Contains(t, strings.ToLower(w.Body.String()), "kb", "error should mention size limit")
+	assert.Nil(t, svc.uploaded, "over_limit must not reach storage")
+}
+
+// TestUploadFile_CompressEnabled_HandleTiesToFinalBytes: sticker_handle 必须绑定
+// 到最终存储对象的 URL。方案 C 下 path/ext 不变，因此 fullURL 也不变，handle 与
+// 压缩前理论上一致 —— 关键不变量是"handle verify 用的 URL 与 mockService 收到
+// 的落库路径完全对应"，保证客户端拿 handle 后指向的是压缩后对象。
+func TestUploadFile_CompressEnabled_HandleTiesToFinalStoredObject(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+
+	const uid = "10000"
+	settings := defaultFakeStickerSettings()
+	settings.compressEnabled = true
+	settings.targetKB = 2048
+	settings.maxDim = 512
+
+	f, svc := newStickerCompressFile(t, settings)
+	svc.downloadURL = "https://cdn.example.com/dm/sticker/" + uid + "/final.jpg"
+
+	origBytes := makeTestJPEG(t, 256, 256, 90)
+	body, contentType := newMultipartFile(t, "final.jpg", origBytes)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/v1/file/upload?type=sticker&path=/"+uid+"/final.jpg", body)
+	c.Request.Header.Set("Content-Type", contentType)
+	c.Set("uid", uid)
+	wkCtx := &wkhttp.Context{Context: c}
+
+	// 用一个远大于 imaging.Encode 耗时的 timeout，避免 flaky。
+	settings.timeoutMs = 10_000
+
+	f.uploadFile(wkCtx)
+
+	require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Contains(t, svc.uploadedPath, "sticker/"+uid+"/final.jpg",
+		"落库对象路径必须以 sticker keyspace + uid + 原扩展名结尾")
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	handle, _ := resp["sticker_handle"].(string)
+	respPath, _ := resp["path"].(string)
+	require.NotEmpty(t, handle)
+	// path/ext 未变 → 客户端拿到的 handle 校验的是最终对象 URL。
+	assert.True(t, stickersig.Verify(uid, respPath, handle),
+		"handle must verify against the final stored URL")
+	// 别的 uid 不通过 —— handle 绑定了上传者。
+	assert.False(t, stickersig.Verify("99999", respPath, handle))
+	// 花几毫秒的 compressor 结束后 svc.uploaded 已被填。
+	_ = time.Millisecond
+	assert.NotEmpty(t, svc.uploaded, "capturing service must have received bytes")
+}

--- a/modules/file/const.go
+++ b/modules/file/const.go
@@ -158,6 +158,10 @@ var stickerUploadExts = map[string]bool{
 // stickerUploadExt 从客户端上传文件名挑选贴纸的存储扩展名，限定在
 // stickerUploadExts。文件名缺失 / 无扩展名 / 不在白名单一律回退 ".gif"
 // —— 历史默认，不传 filename 的老客户端因此保持原有行为不变。
+//
+// 注：这是**硬编码 fallback**（settings 未挂时的老 unit test 路径）；生产
+// 请求走 File.stickerUploadExtForRequest（review F1），它读当前配置的
+// allowedFormats，避免与 POST 侧校验用的配置漂移。
 func stickerUploadExt(filename string) string {
 	ext := strings.ToLower(filepath.Ext(sanitizeFilename(filename)))
 	if stickerUploadExts[ext] {

--- a/modules/file/sticker_compress.go
+++ b/modules/file/sticker_compress.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"image"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -31,12 +32,39 @@ import (
 
 // stickerLimitsSnapshot 是 uploadFile 一次请求内的贴纸限制快照。全部字段在
 // 请求进入时锁定；SystemSettings 60s 后 reload 不影响正在进行的请求，避免
-// "校验通过用一套值、签发 handle 用另一套值"这类跨阶段不一致。
+// "校验通过用一套值、压缩用另一套值"这类跨阶段不一致（review F7）。压缩相关
+// 字段（compressTargetKB/MaxConcurrency/TimeoutMs）也放这里，Compress 通过
+// stickerCompressParams 拿到同一份值，确保 dimension 校验用的 maxDim 与
+// 压缩阶段 Fit 用的 maxDim 严格同源。
 type stickerLimitsSnapshot struct {
-	maxSize         int64
-	maxDim          int
-	allowedFormats  map[string]bool
-	compressEnabled bool
+	maxSize                int64
+	maxDim                 int
+	allowedFormats         map[string]bool
+	compressEnabled        bool
+	compressTargetKB       int
+	compressMaxConcurrency int
+	compressTimeoutMs      int
+}
+
+// stickerCompressParams 是从 stickerLimitsSnapshot 派生出、只喂给 Compress 的
+// 子集，让 compressor 的 API 表面明确表达"这些值由 caller 决定，请求内不再
+// 变化"。Compress 内部**不**再读 c.settings 的对应字段（review F7 修复要点）。
+type stickerCompressParams struct {
+	MaxDim         int
+	TargetKB       int
+	MaxConcurrency int
+	TimeoutMs      int
+}
+
+// compressParams 从 snapshot 派生 Compress 需要的 4 个值。集中在这里派生
+// 是为了让 caller 端一处清晰地展现"这四个值都来自同一份 snapshot"。
+func (s stickerLimitsSnapshot) compressParams() stickerCompressParams {
+	return stickerCompressParams{
+		MaxDim:         s.maxDim,
+		TargetKB:       s.compressTargetKB,
+		MaxConcurrency: s.compressMaxConcurrency,
+		TimeoutMs:      s.compressTimeoutMs,
+	}
 }
 
 // stickerLimits 从 File 挂的 SystemSettings 派生本次请求的限制值；未挂 settings
@@ -50,10 +78,13 @@ func (f *File) stickerLimits() stickerLimitsSnapshot {
 			allow[k] = v
 		}
 		return stickerLimitsSnapshot{
-			maxSize:         StickerMaxFileSize,
-			maxDim:          StickerMaxDimension,
-			allowedFormats:  allow,
-			compressEnabled: false,
+			maxSize:                StickerMaxFileSize,
+			maxDim:                 StickerMaxDimension,
+			allowedFormats:         allow,
+			compressEnabled:        false,
+			compressTargetKB:       0,
+			compressMaxConcurrency: 0,
+			compressTimeoutMs:      0,
 		}
 	}
 	kb := f.settings.StickerUploadMaxSizeKB()
@@ -63,11 +94,47 @@ func (f *File) stickerLimits() stickerLimitsSnapshot {
 		m[e] = true
 	}
 	return stickerLimitsSnapshot{
-		maxSize:         int64(kb) * 1024,
-		maxDim:          f.settings.StickerUploadMaxDimension(),
-		allowedFormats:  m,
-		compressEnabled: f.settings.StickerCompressEnabled(),
+		maxSize:                int64(kb) * 1024,
+		maxDim:                 f.settings.StickerUploadMaxDimension(),
+		allowedFormats:         m,
+		compressEnabled:        f.settings.StickerCompressEnabled(),
+		compressTargetKB:       f.settings.StickerCompressTargetKB(),
+		compressMaxConcurrency: f.settings.StickerCompressMaxConcurrency(),
+		compressTimeoutMs:      f.settings.StickerCompressTimeoutMs(),
 	}
+}
+
+// stickerUploadExtForRequest 是 stickerUploadExt 的"配置感知"版：把客户端
+// filename 匹配到当前配置允许的扩展名集合（settings.StickerUploadAllowedFormats
+// 的读侧交集结果），而不是硬编码历史 5 种。这样运营通过 upload_allowed_formats
+// 收窄格式后，GET-side 生成的 preflight URL 与 POST-side 校验用的允许集保持
+// 一致 —— 客户端不会拿到之后会被 upload 阶段拒的扩展名（review F1）。
+//
+// filename miss / 无扩展名时的 fallback 顺序：
+//  1. 优先 ".gif"（历史默认，不传 filename 的老客户端保持原有行为）
+//  2. 若 .gif 已被运营剔除，按 raster allowlist 固定顺序取第一个仍允许的
+//     (.png → .jpg → .jpeg → .webp) —— 顺序确定性保证 fallback 稳定
+//  3. 极端情况允许集为空（stickerLimits 读侧交集会回退默认所以不会到这里，
+//     但作为兜底）：仍返回 ".gif"
+//
+// 未挂 settings 的路径（老 unit test 构造 &File{}）走 stickerLimits() 的
+// nil-safe 分支，会拿到与老 stickerUploadExt 等价的 stickerUploadExts 集合，
+// 因此本方法在那条路径上与旧行为逐字节等价。
+func (f *File) stickerUploadExtForRequest(filename string) string {
+	ext := strings.ToLower(filepath.Ext(sanitizeFilename(filename)))
+	limits := f.stickerLimits()
+	if limits.allowedFormats[ext] {
+		return ext
+	}
+	if limits.allowedFormats[".gif"] {
+		return ".gif"
+	}
+	for _, cand := range []string{".png", ".jpg", ".jpeg", ".webp"} {
+		if limits.allowedFormats[cand] {
+			return cand
+		}
+	}
+	return ".gif"
 }
 
 // stickerSystemSettings 是 File 只用到的 SystemSettings 子集接口。定义在
@@ -128,11 +195,17 @@ func newStickerCompressor(s stickerCompressSettings) *stickerCompressor {
 // Compress 尝试压缩 src；ext 应是 caller 归一化后的小写扩展名（含前导 "."）。
 // 语义见文件顶部 Outcome 注释。永不 panic：解码 / 编码错误映射成 failed。
 //
+// params 是 caller 从请求进入时锁定的 stickerLimitsSnapshot 派生的一份不可变
+// 副本 —— maxDim/targetKB/maxConcurrency/timeoutMs 都取自同一份快照，兑现
+// "一次请求一份快照"的不变式（review F7）。Compress 内部**不再**读 c.settings
+// 的这四个字段；仅从 c.settings 读 StickerCompressEnabled 做双重短路（保留
+// disabled 单元测试维度）。
+//
 // 耗时观测：仅在 acquire slot 之后（真正投入 CPU 的路径）打点，包括
 // compressed / over_limit / failed / skipped:timeout。disabled/format/
 // animated/concurrency_saturated 分支耗时约等于 0，用 counter 观测即可，不打
 // histogram 以降低噪声。
-func (c *stickerCompressor) Compress(ext string, src []byte) stickerCompressResult {
+func (c *stickerCompressor) Compress(ext string, src []byte, params stickerCompressParams) stickerCompressResult {
 	if !c.settings.StickerCompressEnabled() {
 		return stickerCompressResult{Outcome: stickerCompressOutcomeSkipped, Reason: "disabled"}
 	}
@@ -147,8 +220,7 @@ func (c *stickerCompressor) Compress(ext string, src []byte) stickerCompressResu
 	if isAnimatedPNGSource(ext, src) {
 		return stickerCompressResult{Outcome: stickerCompressOutcomeSkipped, Reason: "animated"}
 	}
-	maxConc := c.settings.StickerCompressMaxConcurrency()
-	if !c.tryAcquireCompressSlot(maxConc) {
+	if !c.tryAcquireCompressSlot(params.MaxConcurrency) {
 		return stickerCompressResult{Outcome: stickerCompressOutcomeSkipped, Reason: "concurrency_saturated"}
 	}
 	// 关键：**不要**在此 defer release。timeout 分支返回时 doCompress goroutine
@@ -156,10 +228,9 @@ func (c *stickerCompressor) Compress(ext string, src []byte) stickerCompressResu
 	// max_concurrency 上界。改由 worker goroutine 结束时（自然完成或 recover
 	// 后）释放，让 slot 与真正的 CPU 占用生命周期一致（review P1）。
 
-	timeoutMs := c.settings.StickerCompressTimeoutMs()
-	timeout := time.Duration(timeoutMs) * time.Millisecond
-	maxDim := c.settings.StickerUploadMaxDimension()
-	targetKB := c.settings.StickerCompressTargetKB()
+	timeout := time.Duration(params.TimeoutMs) * time.Millisecond
+	maxDim := params.MaxDim
+	targetKB := params.TargetKB
 
 	type outcome struct {
 		r   stickerCompressResult

--- a/modules/file/sticker_compress.go
+++ b/modules/file/sticker_compress.go
@@ -1,0 +1,265 @@
+package file
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/disintegration/imaging"
+)
+
+// 服务端贴纸压缩（sticker-upload-compression 任务，方案 C）。
+//
+// 首期只压静态 jpg/png：decode → 必要时缩放到 maxDim → 用原格式重编码（去 EXIF/
+// XMP 元数据；imaging 默认不保留）。webp/gif/动图 恒 skip（首期依赖无 webp encoder，
+// 引入 cgo 明确 out of scope）。压缩后仍超 target 直接拒绝，避免存"压完还是大图"。
+//
+// 稳定性隔离：每次尝试要占用一个"压缩并发 slot"（进程级 mutex+counter，容量由
+// StickerCompressMaxConcurrency 动态读取，改配置即时生效）；饱和时立刻 fail-open
+// 走原路径。压缩本体跑在 goroutine 里由 time.Timer 抢占，超时即时返回 skipped，
+// goroutine 在 imaging 完成时自然退出（无长时间泄漏，最坏是几十 ms 的 dangling）。
+//
+// 结果 Outcome：
+//   - compressed → 用返回 Bytes 替换 upload 源字节
+//   - skipped    → 走原路径（disabled/format/concurrency_saturated/timeout）
+//   - failed     → 走原路径 fail-open（decode/encode 错误；不阻塞主链路）
+//   - over_limit → caller 直接拒绝上传（压完仍超 target）
+
+// stickerLimitsSnapshot 是 uploadFile 一次请求内的贴纸限制快照。全部字段在
+// 请求进入时锁定；SystemSettings 60s 后 reload 不影响正在进行的请求，避免
+// "校验通过用一套值、签发 handle 用另一套值"这类跨阶段不一致。
+type stickerLimitsSnapshot struct {
+	maxSize         int64
+	maxDim          int
+	allowedFormats  map[string]bool
+	compressEnabled bool
+}
+
+// stickerLimits 从 File 挂的 SystemSettings 派生本次请求的限制值；未挂 settings
+// （历史 unit test 直接 &File{} 构造）回落到硬编码默认值，让老 unit test 行为
+// 逐字节等价。allowedFormats 是拷贝的 map，caller 不应修改。
+func (f *File) stickerLimits() stickerLimitsSnapshot {
+	if f.settings == nil {
+		// 回落：老 unit test path。复刻改动前的硬编码默认值。
+		allow := make(map[string]bool, len(stickerUploadExts))
+		for k, v := range stickerUploadExts {
+			allow[k] = v
+		}
+		return stickerLimitsSnapshot{
+			maxSize:         StickerMaxFileSize,
+			maxDim:          StickerMaxDimension,
+			allowedFormats:  allow,
+			compressEnabled: false,
+		}
+	}
+	kb := f.settings.StickerUploadMaxSizeKB()
+	formats := f.settings.StickerUploadAllowedFormats()
+	m := make(map[string]bool, len(formats))
+	for _, e := range formats {
+		m[e] = true
+	}
+	return stickerLimitsSnapshot{
+		maxSize:         int64(kb) * 1024,
+		maxDim:          f.settings.StickerUploadMaxDimension(),
+		allowedFormats:  m,
+		compressEnabled: f.settings.StickerCompressEnabled(),
+	}
+}
+
+// stickerSystemSettings 是 File 只用到的 SystemSettings 子集接口。定义在
+// modules/file 侧（接口在使用端）让测试可以注入内存 fake，无需 MySQL/Redis
+// 起 test server；生产用 *common.SystemSettings 天然实现。
+type stickerSystemSettings interface {
+	StickerUploadMaxSizeKB() int
+	StickerUploadMaxDimension() int
+	StickerUploadAllowedFormats() []string
+	StickerCompressEnabled() bool
+	StickerCompressTargetKB() int
+	StickerCompressMaxConcurrency() int
+	StickerCompressTimeoutMs() int
+}
+
+// stickerCompressSettings 抽出 SystemSettings 需要的接口，方便 test 注入 fake。
+type stickerCompressSettings interface {
+	StickerCompressEnabled() bool
+	StickerCompressTargetKB() int
+	StickerCompressMaxConcurrency() int
+	StickerCompressTimeoutMs() int
+	StickerUploadMaxDimension() int
+}
+
+const (
+	stickerCompressOutcomeCompressed = "compressed"
+	stickerCompressOutcomeSkipped    = "skipped"
+	stickerCompressOutcomeFailed     = "failed"
+	stickerCompressOutcomeOverLimit  = "over_limit"
+)
+
+// stickerCompressResult 是 Compress 的结果。
+type stickerCompressResult struct {
+	Outcome string // stickerCompressOutcome* 之一
+	Reason  string // 细分原因（"disabled"/"format"/"concurrency_saturated"/"timeout"/decode 或 encode 错误信息）
+	Bytes   []byte // 仅 Outcome=="compressed" 时有效
+	Size    int64  // 结果字节数（compressed）或压后大小（over_limit）
+}
+
+// stickerCompressor 承担压缩流程 + 稳定性闸。零值不可用；用 newStickerCompressor。
+type stickerCompressor struct {
+	settings stickerCompressSettings
+	mu       sync.Mutex
+	inflight int
+	// doCompress 是纯 CPU 压缩本体；tests 注入替代函数以稳定触发超时分支。生产
+	// 路径固定为 doCompressStaticSticker。
+	doCompress func(ext string, src []byte, maxDim, targetKB int) (stickerCompressResult, error)
+}
+
+// newStickerCompressor 用给定 settings 构造压缩器，绑定生产实现。
+func newStickerCompressor(s stickerCompressSettings) *stickerCompressor {
+	return &stickerCompressor{
+		settings:   s,
+		doCompress: doCompressStaticSticker,
+	}
+}
+
+// Compress 尝试压缩 src；ext 应是 caller 归一化后的小写扩展名（含前导 "."）。
+// 语义见文件顶部 Outcome 注释。永不 panic：解码 / 编码错误映射成 failed。
+//
+// 耗时观测：仅在 acquire slot 之后（真正投入 CPU 的路径）打点，包括
+// compressed / over_limit / failed / skipped:timeout。disabled/format/
+// concurrency_saturated 分支耗时约等于 0，用 counter 观测即可，不打 histogram
+// 以降低噪声。
+func (c *stickerCompressor) Compress(ext string, src []byte) stickerCompressResult {
+	if !c.settings.StickerCompressEnabled() {
+		return stickerCompressResult{Outcome: stickerCompressOutcomeSkipped, Reason: "disabled"}
+	}
+	if !canCompressStickerExt(ext) {
+		return stickerCompressResult{Outcome: stickerCompressOutcomeSkipped, Reason: "format"}
+	}
+	maxConc := c.settings.StickerCompressMaxConcurrency()
+	if !c.tryAcquireCompressSlot(maxConc) {
+		return stickerCompressResult{Outcome: stickerCompressOutcomeSkipped, Reason: "concurrency_saturated"}
+	}
+	defer c.releaseCompressSlot()
+
+	timeoutMs := c.settings.StickerCompressTimeoutMs()
+	timeout := time.Duration(timeoutMs) * time.Millisecond
+	maxDim := c.settings.StickerUploadMaxDimension()
+	targetKB := c.settings.StickerCompressTargetKB()
+
+	type outcome struct {
+		r   stickerCompressResult
+		err error
+	}
+	// 缓冲 1 让即使超时后 goroutine 完成也能非阻塞地写回，避免泄漏 sender。
+	ch := make(chan outcome, 1)
+	go func() {
+		defer func() {
+			if rec := recover(); rec != nil {
+				// image.Decode 依赖第三方解码器，理论上返回 error，但 defence in
+				// depth：panic 也走 failed 分支而不是崩溃主流程。
+				ch <- outcome{err: fmt.Errorf("panic: %v", rec)}
+			}
+		}()
+		r, err := c.doCompress(ext, src, maxDim, targetKB)
+		ch <- outcome{r: r, err: err}
+	}()
+
+	start := time.Now()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		observeStickerCompressDuration(stickerCompressOutcomeSkipped, ext, time.Since(start))
+		return stickerCompressResult{Outcome: stickerCompressOutcomeSkipped, Reason: "timeout"}
+	case o := <-ch:
+		elapsed := time.Since(start)
+		if o.err != nil {
+			observeStickerCompressDuration(stickerCompressOutcomeFailed, ext, elapsed)
+			return stickerCompressResult{Outcome: stickerCompressOutcomeFailed, Reason: o.err.Error()}
+		}
+		observeStickerCompressDuration(o.r.Outcome, ext, elapsed)
+		return o.r
+	}
+}
+
+func (c *stickerCompressor) tryAcquireCompressSlot(max int) bool {
+	if max <= 0 {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.inflight >= max {
+		return false
+	}
+	c.inflight++
+	return true
+}
+
+func (c *stickerCompressor) releaseCompressSlot() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.inflight > 0 {
+		c.inflight--
+	}
+}
+
+// canCompressStickerExt 匹配"本期压缩范围内"的扩展名。caller 必须传归一化过的
+// 小写形式；大小写不敏感由 caller 负责（file/api.go 里 ext 已被 ToLower）。
+func canCompressStickerExt(ext string) bool {
+	switch ext {
+	case ".jpg", ".jpeg", ".png":
+		return true
+	}
+	return false
+}
+
+// doCompressStaticSticker 是生产实现：decode → optional resize → re-encode。
+// 纯 CPU/内存，无 IO，无 context —— caller 通过 goroutine + timer 抢占。
+func doCompressStaticSticker(ext string, src []byte, maxDim, targetKB int) (stickerCompressResult, error) {
+	img, _, err := image.Decode(bytes.NewReader(src))
+	if err != nil {
+		return stickerCompressResult{}, fmt.Errorf("decode: %w", err)
+	}
+	b := img.Bounds()
+	w, h := b.Dx(), b.Dy()
+	if maxDim > 0 && (w > maxDim || h > maxDim) {
+		// Fit 保持长宽比缩到 maxDim×maxDim 的外接框内。Lanczos 提供最佳视觉质量，
+		// 对贴纸小图（<=1024 边）耗时可控（毫秒级）。
+		img = imaging.Fit(img, maxDim, maxDim, imaging.Lanczos)
+	}
+
+	var buf bytes.Buffer
+	switch strings.ToLower(ext) {
+	case ".jpg", ".jpeg":
+		// 85 是贴纸场景兼顾清晰度与体积的经验值：<=80 出现明显 chroma artifact，
+		// >=90 体积回升明显。JPEG 编码天然不携 EXIF/XMP，元数据自动脱除。
+		if err := imaging.Encode(&buf, img, imaging.JPEG, imaging.JPEGQuality(85)); err != nil {
+			return stickerCompressResult{}, fmt.Errorf("encode: %w", err)
+		}
+	case ".png":
+		// PNG 无损；imaging.Encode 默认不写 tEXt/iTXt/eXIf chunk，元数据脱除。
+		if err := imaging.Encode(&buf, img, imaging.PNG); err != nil {
+			return stickerCompressResult{}, fmt.Errorf("encode: %w", err)
+		}
+	default:
+		// Guard: canCompressStickerExt 应过滤掉这个分支；到达即编程错误。
+		return stickerCompressResult{}, fmt.Errorf("unsupported ext: %s", ext)
+	}
+
+	out := buf.Bytes()
+	size := int64(len(out))
+	if targetKB > 0 && size > int64(targetKB)*1024 {
+		return stickerCompressResult{
+			Outcome: stickerCompressOutcomeOverLimit,
+			Size:    size,
+		}, nil
+	}
+	return stickerCompressResult{
+		Outcome: stickerCompressOutcomeCompressed,
+		Bytes:   out,
+		Size:    size,
+	}, nil
+}

--- a/modules/file/sticker_compress.go
+++ b/modules/file/sticker_compress.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"image"
 	"strings"
@@ -129,8 +130,8 @@ func newStickerCompressor(s stickerCompressSettings) *stickerCompressor {
 //
 // 耗时观测：仅在 acquire slot 之后（真正投入 CPU 的路径）打点，包括
 // compressed / over_limit / failed / skipped:timeout。disabled/format/
-// concurrency_saturated 分支耗时约等于 0，用 counter 观测即可，不打 histogram
-// 以降低噪声。
+// animated/concurrency_saturated 分支耗时约等于 0，用 counter 观测即可，不打
+// histogram 以降低噪声。
 func (c *stickerCompressor) Compress(ext string, src []byte) stickerCompressResult {
 	if !c.settings.StickerCompressEnabled() {
 		return stickerCompressResult{Outcome: stickerCompressOutcomeSkipped, Reason: "disabled"}
@@ -138,11 +139,22 @@ func (c *stickerCompressor) Compress(ext string, src []byte) stickerCompressResu
 	if !canCompressStickerExt(ext) {
 		return stickerCompressResult{Outcome: stickerCompressOutcomeSkipped, Reason: "format"}
 	}
+	// APNG(Animated PNG) 复用 PNG magic 号，会通过 ext + magic + dimension 三
+	// 道门。若不在此显式识别，image.Decode 只解首帧 IDAT，imaging.Encode 重
+	// 编码回 PNG 时动画帧被静默丢失（review P2）。方案 C 明确"gif/animated
+	// 只校验不压"，APNG 同样应走 skipped:animated，字节流原样落库。检测放在
+	// tryAcquireCompressSlot 之前，避免为一次不需要压缩的请求占用并发 slot。
+	if isAnimatedPNGSource(ext, src) {
+		return stickerCompressResult{Outcome: stickerCompressOutcomeSkipped, Reason: "animated"}
+	}
 	maxConc := c.settings.StickerCompressMaxConcurrency()
 	if !c.tryAcquireCompressSlot(maxConc) {
 		return stickerCompressResult{Outcome: stickerCompressOutcomeSkipped, Reason: "concurrency_saturated"}
 	}
-	defer c.releaseCompressSlot()
+	// 关键：**不要**在此 defer release。timeout 分支返回时 doCompress goroutine
+	// 仍在跑，若此时 release 会让下一个请求 acquire 到 slot，真实并发绕过
+	// max_concurrency 上界。改由 worker goroutine 结束时（自然完成或 recover
+	// 后）释放，让 slot 与真正的 CPU 占用生命周期一致（review P1）。
 
 	timeoutMs := c.settings.StickerCompressTimeoutMs()
 	timeout := time.Duration(timeoutMs) * time.Millisecond
@@ -156,6 +168,9 @@ func (c *stickerCompressor) Compress(ext string, src []byte) stickerCompressResu
 	// 缓冲 1 让即使超时后 goroutine 完成也能非阻塞地写回，避免泄漏 sender。
 	ch := make(chan outcome, 1)
 	go func() {
+		// slot 一直持有到真正的 CPU 工作结束（含 recover 兜底），这是 P1 修复
+		// 的核心：Compress 提前 return（timeout）时 slot 仍占用。
+		defer c.releaseCompressSlot()
 		defer func() {
 			if rec := recover(); rec != nil {
 				// image.Decode 依赖第三方解码器，理论上返回 error，但 defence in
@@ -212,6 +227,47 @@ func canCompressStickerExt(ext string) bool {
 	switch ext {
 	case ".jpg", ".jpeg", ".png":
 		return true
+	}
+	return false
+}
+
+// isAnimatedPNGSource 检测 src 是否 APNG (Animated PNG)。ext 必须是 ".png"
+// —— 其他扩展名一律返回 false（JPEG 无动画；GIF/WebP 走 canCompressStickerExt
+// 已挡在压缩管线外）。APNG 通过额外的 acTL chunk 声明动画，标准 image/png
+// 只解首帧 IDAT，若不显式识别会静默丢动画（review P2）。
+func isAnimatedPNGSource(ext string, src []byte) bool {
+	if ext != ".png" {
+		return false
+	}
+	return hasAPNGActlChunk(src)
+}
+
+// hasAPNGActlChunk 扫描 PNG 字节流查找 acTL chunk（Animation Control Chunk）。
+// APNG 规范：acTL 必须出现在**第一个 IDAT 之前**才有效；一致的渲染器会忽略
+// IDAT 之后的 acTL。所以看到 IDAT 先于 acTL 即可判定为静态 PNG，短路结束扫描
+// 也避免扫完整个大文件。CRC 不校验 —— 只关心结构标记，容忍非法字节。
+func hasAPNGActlChunk(data []byte) bool {
+	const pngSignature = "\x89PNG\r\n\x1a\n"
+	if len(data) < 8 || string(data[:8]) != pngSignature {
+		return false
+	}
+	// PNG chunk 格式: 4B length | 4B type | N-B data | 4B CRC
+	pos := 8
+	for pos+8 <= len(data) {
+		length := binary.BigEndian.Uint32(data[pos : pos+4])
+		chunkType := string(data[pos+4 : pos+8])
+		switch chunkType {
+		case "acTL":
+			return true
+		case "IDAT":
+			return false
+		}
+		// 前进到下一个 chunk；用 int64 防 uint32 length + 12 溢出 int。
+		next := int64(pos) + 8 + int64(length) + 4
+		if next <= int64(pos) || next > int64(len(data)) {
+			return false
+		}
+		pos = int(next)
 	}
 	return false
 }

--- a/modules/file/sticker_compress_bench_test.go
+++ b/modules/file/sticker_compress_bench_test.go
@@ -1,0 +1,107 @@
+package file
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"testing"
+)
+
+// 服务端贴纸压缩 benchmark（sticker-upload-compression 任务 perf 验证 Task B）。
+//
+// 用途：给灰度前的 concurrency/timeout 默认值提供实证基线。跑法：
+//   go test -bench='BenchmarkDoCompressStaticSticker' -benchmem -benchtime=3s ./modules/file/
+//
+// 覆盖 (JPEG q95, PNG) × (512², 1024²) 四组尺寸，都用伪随机像素做基线（真实
+// 用户贴纸差异会更大，但基线用同一种输入以便可重现回归）。基准结果不作为
+// pass/fail 门禁，用于生成 perf-todo.md 里的容量规划。
+
+func benchJPEG(b *testing.B, w, h, quality int) []byte {
+	b.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	seed := uint32(0xdeadbeef)
+	for x := 0; x < w; x++ {
+		for y := 0; y < h; y++ {
+			seed = seed*1103515245 + 12345
+			r := byte(seed >> 16)
+			seed = seed*1103515245 + 12345
+			g := byte(seed >> 16)
+			seed = seed*1103515245 + 12345
+			bch := byte(seed >> 16)
+			img.Set(x, y, color.RGBA{r, g, bch, 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: quality}); err != nil {
+		b.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func benchPNG(b *testing.B, w, h int) []byte {
+	b.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	seed := uint32(0xdeadbeef)
+	for x := 0; x < w; x++ {
+		for y := 0; y < h; y++ {
+			seed = seed*1103515245 + 12345
+			r := byte(seed >> 16)
+			seed = seed*1103515245 + 12345
+			g := byte(seed >> 16)
+			seed = seed*1103515245 + 12345
+			bch := byte(seed >> 16)
+			img.Set(x, y, color.RGBA{r, g, bch, 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		b.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func benchDoCompress(b *testing.B, ext string, src []byte, maxDim, targetKB int) {
+	b.ReportAllocs()
+	b.SetBytes(int64(len(src)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r, err := doCompressStaticSticker(ext, src, maxDim, targetKB)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if r.Outcome != stickerCompressOutcomeCompressed && r.Outcome != stickerCompressOutcomeOverLimit {
+			b.Fatalf("unexpected outcome=%s reason=%s", r.Outcome, r.Reason)
+		}
+	}
+}
+
+// 512×512 —— 命中默认 maxDim=512 时最常见的到达上界尺寸。
+func BenchmarkDoCompressStaticSticker_JPEG_512(b *testing.B) {
+	benchDoCompress(b, ".jpg", benchJPEG(b, 512, 512, 95), 512, 5*1024)
+}
+
+func BenchmarkDoCompressStaticSticker_PNG_512(b *testing.B) {
+	benchDoCompress(b, ".png", benchPNG(b, 512, 512), 512, 5*1024)
+}
+
+// 1024×1024 —— 命中新配置的 maxDim 硬上限 1024 时的最坏情况；也是维度校验
+// 与压缩阶段都需要 downscale 的场景。
+func BenchmarkDoCompressStaticSticker_JPEG_1024_ShrinkTo512(b *testing.B) {
+	benchDoCompress(b, ".jpg", benchJPEG(b, 1024, 1024, 95), 512, 5*1024)
+}
+
+func BenchmarkDoCompressStaticSticker_PNG_1024_ShrinkTo512(b *testing.B) {
+	benchDoCompress(b, ".png", benchPNG(b, 1024, 1024), 512, 5*1024)
+}
+
+// 1024×1024 保持不缩放（maxDim=1024）—— 用于测量"只 re-encode 不 downscale"
+// 情况下的成本，与 ShrinkTo512 对比可估 Lanczos 缩放贡献的 CPU 时间。
+func BenchmarkDoCompressStaticSticker_JPEG_1024_ReencodeOnly(b *testing.B) {
+	benchDoCompress(b, ".jpg", benchJPEG(b, 1024, 1024, 95), 1024, 5*1024)
+}
+
+func BenchmarkDoCompressStaticSticker_PNG_1024_ReencodeOnly(b *testing.B) {
+	benchDoCompress(b, ".png", benchPNG(b, 1024, 1024), 1024, 5*1024)
+}

--- a/modules/file/sticker_compress_test.go
+++ b/modules/file/sticker_compress_test.go
@@ -1,0 +1,264 @@
+package file
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 服务端贴纸压缩单测（sticker-upload-compression 任务）。
+//
+// 覆盖：disabled / 非可压格式 / 成功压 + 缩放 / 压完仍超限拒绝 / decode 失败
+// fail-open / 并发满 fail-open / 超时 fail-open。timeout 分支通过注入
+// doCompress 让代码路径可控。
+
+type fakeStickerCompressSettings struct {
+	enabled        bool
+	targetKB       int
+	maxConcurrency int
+	timeoutMs      int
+	maxDim         int
+}
+
+func (f *fakeStickerCompressSettings) StickerCompressEnabled() bool       { return f.enabled }
+func (f *fakeStickerCompressSettings) StickerCompressTargetKB() int       { return f.targetKB }
+func (f *fakeStickerCompressSettings) StickerCompressMaxConcurrency() int { return f.maxConcurrency }
+func (f *fakeStickerCompressSettings) StickerCompressTimeoutMs() int      { return f.timeoutMs }
+func (f *fakeStickerCompressSettings) StickerUploadMaxDimension() int     { return f.maxDim }
+
+// makeTestJPEG 生成 (w,h) JPEG，颜色随机以避免过度可压缩。
+func makeTestJPEG(t *testing.T, w, h, quality int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for x := 0; x < w; x++ {
+		for y := 0; y < h; y++ {
+			img.Set(x, y, color.RGBA{byte((x * 7) % 255), byte((y * 11) % 255), byte((x + y*3) % 255), 255})
+		}
+	}
+	var buf bytes.Buffer
+	require.NoError(t, jpeg.Encode(&buf, img, &jpeg.Options{Quality: quality}))
+	return buf.Bytes()
+}
+
+func makeTestPNG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	// 用可预测的伪随机填充（不是简单公式），让 PNG 无法过度压缩，避免 512×512
+	// 也能被压到几 KB 破坏 over_limit 测试。种子固定确保可重现。
+	seed := uint32(0xdeadbeef)
+	for x := 0; x < w; x++ {
+		for y := 0; y < h; y++ {
+			seed = seed*1103515245 + 12345
+			r := byte(seed >> 16)
+			seed = seed*1103515245 + 12345
+			g := byte(seed >> 16)
+			seed = seed*1103515245 + 12345
+			bch := byte(seed >> 16)
+			img.Set(x, y, color.RGBA{r, g, bch, 255})
+		}
+	}
+	var buf bytes.Buffer
+	require.NoError(t, png.Encode(&buf, img))
+	return buf.Bytes()
+}
+
+func newFakeCompressor(fs *fakeStickerCompressSettings) *stickerCompressor {
+	return &stickerCompressor{
+		settings:   fs,
+		doCompress: doCompressStaticSticker,
+	}
+}
+
+func TestStickerCompressor_DisabledSkips(t *testing.T) {
+	c := newFakeCompressor(&fakeStickerCompressSettings{
+		enabled: false, targetKB: 1024, maxConcurrency: 4, timeoutMs: 2000, maxDim: 512,
+	})
+	r := c.Compress(".png", makeTestPNG(t, 8, 8))
+	assert.Equal(t, stickerCompressOutcomeSkipped, r.Outcome)
+	assert.Equal(t, "disabled", r.Reason)
+}
+
+func TestStickerCompressor_UnsupportedFormatSkips(t *testing.T) {
+	c := newFakeCompressor(&fakeStickerCompressSettings{
+		enabled: true, targetKB: 1024, maxConcurrency: 4, timeoutMs: 2000, maxDim: 512,
+	})
+	for _, ext := range []string{".gif", ".webp", ".bmp", ".mp4", ".JPG", "", "jpg"} {
+		r := c.Compress(ext, []byte{0})
+		assert.Equalf(t, stickerCompressOutcomeSkipped, r.Outcome, "ext=%q", ext)
+		assert.Equalf(t, "format", r.Reason, "ext=%q", ext)
+	}
+	// 大小写归一化后 jpg/jpeg/png 是允许的（caller 已归一化到小写；此处严格匹配）。
+	// 归一化在调用点保证，这里的期望是"接口层只接 .jpg/.jpeg/.png 小写"。
+}
+
+func TestStickerCompressor_CompressesLargeJPEG(t *testing.T) {
+	src := makeTestJPEG(t, 1024, 1024, 95)
+	require.Greaterf(t, len(src), 50*1024, "source JPEG %dB must be big enough to test shrinking", len(src))
+
+	c := newFakeCompressor(&fakeStickerCompressSettings{
+		enabled: true, targetKB: 256, maxConcurrency: 4, timeoutMs: 5000, maxDim: 512,
+	})
+	r := c.Compress(".jpg", src)
+	require.Equalf(t, stickerCompressOutcomeCompressed, r.Outcome, "reason=%q size=%d", r.Reason, r.Size)
+	assert.LessOrEqual(t, r.Size, int64(256*1024))
+	// 结果字节仍是可解码 JPEG，且尺寸缩到 <= maxDim。
+	decoded, format, err := image.Decode(bytes.NewReader(r.Bytes))
+	require.NoError(t, err)
+	assert.Equal(t, "jpeg", format)
+	bounds := decoded.Bounds()
+	assert.LessOrEqual(t, bounds.Dx(), 512)
+	assert.LessOrEqual(t, bounds.Dy(), 512)
+}
+
+func TestStickerCompressor_CompressesPNG(t *testing.T) {
+	src := makeTestPNG(t, 300, 300)
+
+	c := newFakeCompressor(&fakeStickerCompressSettings{
+		enabled: true, targetKB: 1024, maxConcurrency: 4, timeoutMs: 5000, maxDim: 512,
+	})
+	r := c.Compress(".png", src)
+	require.Equalf(t, stickerCompressOutcomeCompressed, r.Outcome, "reason=%q", r.Reason)
+	_, format, err := image.Decode(bytes.NewReader(r.Bytes))
+	require.NoError(t, err)
+	assert.Equal(t, "png", format)
+}
+
+func TestStickerCompressor_RejectsWhenOverLimitAfterCompress(t *testing.T) {
+	// 512x512 随机像素 PNG 通常在 ~380KB 量级；target=1KB 必然超限。
+	src := makeTestPNG(t, 512, 512)
+	require.Greaterf(t, len(src), 10*1024, "seed PNG %dB must exceed 10KB so target=1KB is unreachable", len(src))
+
+	c := newFakeCompressor(&fakeStickerCompressSettings{
+		enabled: true, targetKB: 1, maxConcurrency: 4, timeoutMs: 10000, maxDim: 512,
+	})
+	r := c.Compress(".png", src)
+	assert.Equal(t, stickerCompressOutcomeOverLimit, r.Outcome)
+	assert.Greater(t, r.Size, int64(1024))
+	assert.Nil(t, r.Bytes, "over_limit result must not surface compressed bytes")
+}
+
+func TestStickerCompressor_FailsOpenOnDecodeError(t *testing.T) {
+	c := newFakeCompressor(&fakeStickerCompressSettings{
+		enabled: true, targetKB: 1024, maxConcurrency: 4, timeoutMs: 2000, maxDim: 512,
+	})
+	r := c.Compress(".jpg", []byte("not a real jpeg"))
+	assert.Equal(t, stickerCompressOutcomeFailed, r.Outcome)
+	assert.Contains(t, r.Reason, "decode")
+}
+
+func TestStickerCompressor_ConcurrencyFailOpen(t *testing.T) {
+	c := newFakeCompressor(&fakeStickerCompressSettings{
+		enabled: true, targetKB: 1024, maxConcurrency: 1, timeoutMs: 10000, maxDim: 512,
+	})
+	// 手动 hold 唯一 slot，随后 Compress 应立即 skipped。
+	require.True(t, c.tryAcquireCompressSlot(1))
+	r := c.Compress(".jpg", makeTestJPEG(t, 16, 16, 80))
+	assert.Equal(t, stickerCompressOutcomeSkipped, r.Outcome)
+	assert.Equal(t, "concurrency_saturated", r.Reason)
+	c.releaseCompressSlot()
+
+	// 释放后能正常压缩（覆盖 release 语义）。
+	r2 := c.Compress(".jpg", makeTestJPEG(t, 16, 16, 80))
+	assert.NotEqualf(t, stickerCompressOutcomeSkipped, r2.Outcome, "after release must compress, got reason=%q", r2.Reason)
+}
+
+func TestStickerCompressor_TimeoutFailOpen(t *testing.T) {
+	// 注入一个刻意 sleep 长于 timeout 的 doCompress，验证 select 超时分支。
+	c := &stickerCompressor{
+		settings: &fakeStickerCompressSettings{
+			enabled: true, targetKB: 1024, maxConcurrency: 4, timeoutMs: 20, maxDim: 512,
+		},
+		doCompress: func(ext string, src []byte, maxDim, targetKB int) (stickerCompressResult, error) {
+			time.Sleep(200 * time.Millisecond)
+			return stickerCompressResult{Outcome: stickerCompressOutcomeCompressed, Bytes: src, Size: int64(len(src))}, nil
+		},
+	}
+	start := time.Now()
+	r := c.Compress(".jpg", []byte("payload"))
+	elapsed := time.Since(start)
+	assert.Equal(t, stickerCompressOutcomeSkipped, r.Outcome)
+	assert.Equal(t, "timeout", r.Reason)
+	// 应远小于 sleep 时长（timer 触发即返回，不等 doCompress 完成）。
+	assert.Less(t, elapsed, 150*time.Millisecond, "timeout branch must not wait for the slow doCompress")
+}
+
+// canCompressStickerExt 只接受 .jpg / .jpeg / .png 小写；其余全部拒。
+func TestCanCompressStickerExt(t *testing.T) {
+	cases := map[string]bool{
+		".jpg":  true,
+		".jpeg": true,
+		".png":  true,
+		".JPG":  false,
+		".gif":  false,
+		".webp": false,
+		"":      false,
+		"jpg":   false,
+		".mp4":  false,
+	}
+	for in, want := range cases {
+		assert.Equalf(t, want, canCompressStickerExt(in), "ext=%q", in)
+	}
+}
+
+// TestDoCompressStaticSticker_PreservesAspectRatio 直接测底层 doer：非正方形源
+// 图缩放后必须保持宽高比（imaging.Fit 的语义保证 —— 若换成 Resize/Fill 会分别
+// 拉伸/裁剪，这条测试就是那道防拉伸的门）。
+func TestDoCompressStaticSticker_PreservesAspectRatio(t *testing.T) {
+	// 1024×600 → maxDim=512：等比后长边=512、短边=300（16:10 比例保留）
+	origBytes := makeTestJPEG(t, 1024, 600, 90)
+	r, err := doCompressStaticSticker(".jpg", origBytes, 512, 10240 /* targetKB 高，不触发 over_limit */)
+	require.NoError(t, err)
+	require.Equal(t, stickerCompressOutcomeCompressed, r.Outcome)
+
+	dec, _, err := image.Decode(bytes.NewReader(r.Bytes))
+	require.NoError(t, err)
+	bounds := dec.Bounds()
+	w, h := bounds.Dx(), bounds.Dy()
+
+	// 长边严格等于 maxDim（imaging.Fit 会把长边贴到外框上界）
+	assert.Equal(t, 512, max2(w, h), "long edge must snap to maxDim")
+	// 短边严格小于 maxDim（源非正方形 → 短边不达外框上界）
+	assert.Less(t, min2(w, h), 512, "short edge must be less than maxDim for non-square source")
+	// 宽高比在 1/1024 内保持（浮点 + 像素取整必有 <1px 的漂移，1024→512 缩放
+	// 因子极小，比原比例的偏差不应超过 1%。这里用 0.01 tolerance）。
+	origRatio := 1024.0 / 600.0
+	newRatio := float64(w) / float64(h)
+	assert.InDelta(t, origRatio, newRatio, 0.01,
+		"aspect ratio must be preserved: orig 1024×600 (r=%.4f), got %d×%d (r=%.4f)",
+		origRatio, w, h, newRatio)
+}
+
+// TestDoCompressStaticSticker_NoUpscaleWhenSourceUnderMaxDim 保证一个隐式契约：
+// 源图短/长边都 <= maxDim 时不做缩放（imaging.Fit 只在 w>maxDim || h>maxDim 才
+// 触发），避免上采样徒增字节又损失锐度。
+func TestDoCompressStaticSticker_NoUpscaleWhenSourceUnderMaxDim(t *testing.T) {
+	origBytes := makeTestJPEG(t, 200, 150, 90)
+	r, err := doCompressStaticSticker(".jpg", origBytes, 512, 10240)
+	require.NoError(t, err)
+	require.Equal(t, stickerCompressOutcomeCompressed, r.Outcome)
+	dec, _, err := image.Decode(bytes.NewReader(r.Bytes))
+	require.NoError(t, err)
+	bounds := dec.Bounds()
+	assert.Equal(t, 200, bounds.Dx())
+	assert.Equal(t, 150, bounds.Dy())
+}
+
+func max2(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+func min2(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/modules/file/sticker_compress_test.go
+++ b/modules/file/sticker_compress_test.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"bytes"
+	"encoding/binary"
 	"image"
 	"image/color"
 	"image/jpeg"
@@ -261,4 +262,173 @@ func min2(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// ---------------------------------------------------------------------------
+// P1 regression: timeout must NOT release the concurrency slot early.
+// Slot lifetime is bound to the worker goroutine, not to Compress's return.
+// ---------------------------------------------------------------------------
+
+// TestStickerCompressor_TimeoutDoesNotBleedConcurrency: maxConcurrency=1 +
+// worker sleeps 500ms + timeout=20ms 场景。首次 Compress 从 timeout 分支返回
+// 时，dangling worker 仍在跑，slot 应保持占用；紧接着来的第二次 Compress 必须
+// 拿到 skipped:concurrency_saturated 而不是 timeout（若 slot 提前释放，就会
+// 走 timeout 分支，等于并发闸被绕过 —— review P1 就是这个 bug）。等 worker
+// 结束后 slot 释放，第三次 Compress 才能真正进压缩管线。
+func TestStickerCompressor_TimeoutDoesNotBleedConcurrency(t *testing.T) {
+	const workerSleep = 500 * time.Millisecond
+	c := &stickerCompressor{
+		settings: &fakeStickerCompressSettings{
+			enabled: true, targetKB: 1024, maxConcurrency: 1, timeoutMs: 20, maxDim: 512,
+		},
+		doCompress: func(ext string, src []byte, maxDim, targetKB int) (stickerCompressResult, error) {
+			time.Sleep(workerSleep)
+			return stickerCompressResult{Outcome: stickerCompressOutcomeCompressed, Bytes: src, Size: int64(len(src))}, nil
+		},
+	}
+
+	// 第一次：worker 慢，Compress 从 timeout 分支返回
+	r1 := c.Compress(".jpg", []byte("x"))
+	require.Equal(t, stickerCompressOutcomeSkipped, r1.Outcome)
+	require.Equal(t, "timeout", r1.Reason)
+
+	// 立即再打：worker 还没跑完，slot 必须仍占用 → 拿到 concurrency_saturated
+	r2 := c.Compress(".jpg", []byte("y"))
+	assert.Equal(t, stickerCompressOutcomeSkipped, r2.Outcome)
+	assert.Equalf(t, "concurrency_saturated", r2.Reason,
+		"slot must remain held by dangling worker after timeout return; got reason=%q", r2.Reason)
+
+	// 等 worker 真正结束 + 少量余量，slot 应被 worker 的 defer release 释放。
+	// 断言点是"reason 变回 timeout"（新一轮成功 acquire，仅是新 worker 又慢导致
+	// 超时）而不是 concurrency_saturated —— 只要不再是 saturated 就证明 slot 已
+	// 归还。这条 test 的 doCompress 是永远慢的固定 fake，用 outcome!=skipped 判
+	// 定会假失败。
+	time.Sleep(workerSleep + 100*time.Millisecond)
+	r3 := c.Compress(".jpg", []byte("z"))
+	assert.Equal(t, stickerCompressOutcomeSkipped, r3.Outcome)
+	assert.NotEqualf(t, "concurrency_saturated", r3.Reason,
+		"after worker finished, slot must be released; got reason=%q", r3.Reason)
+}
+
+// ---------------------------------------------------------------------------
+// P2 regression: APNG must skip compression (would otherwise lose animation).
+// ---------------------------------------------------------------------------
+
+// buildPNGWithChunks 造一个最小 PNG 字节流：signature + 顺序写入 caller 指定的
+// chunk。CRC 全写 0（hasAPNGActlChunk 不校验 CRC，只看结构 marker）。用于测
+// APNG 检测函数在各种 chunk 顺序下的行为。
+func buildPNGWithChunks(t *testing.T, chunks []struct {
+	Type string
+	Data []byte
+},
+) []byte {
+	t.Helper()
+	var b bytes.Buffer
+	b.WriteString("\x89PNG\r\n\x1a\n")
+	for _, ch := range chunks {
+		var lenBytes [4]byte
+		binary.BigEndian.PutUint32(lenBytes[:], uint32(len(ch.Data)))
+		b.Write(lenBytes[:])
+		b.WriteString(ch.Type)
+		b.Write(ch.Data)
+		b.Write([]byte{0, 0, 0, 0}) // fake CRC
+	}
+	return b.Bytes()
+}
+
+// APNG 典型 chunk 顺序：IHDR → acTL → (fcTL/IDAT/fdAT)*  → IEND。acTL 位于
+// IDAT 之前是有效动画的必要条件。
+func TestHasAPNGActlChunk_DetectsAPNG(t *testing.T) {
+	src := buildPNGWithChunks(t, []struct {
+		Type string
+		Data []byte
+	}{
+		{"IHDR", []byte{0, 0, 0, 1, 0, 0, 0, 1, 8, 0, 0, 0, 0}},
+		{"acTL", []byte{0, 0, 0, 2, 0, 0, 0, 0}}, // num_frames=2, num_plays=0
+		{"IDAT", []byte{0x78, 0x9c, 0x62, 0, 0, 0, 0, 1}},
+		{"IEND", nil},
+	})
+	assert.True(t, hasAPNGActlChunk(src))
+	assert.True(t, isAnimatedPNGSource(".png", src))
+	// 非 PNG ext 一律 false（防误挡 JPEG 等）。
+	assert.False(t, isAnimatedPNGSource(".jpg", src))
+}
+
+// 静态 PNG（无 acTL）不应命中。真实 image/png 生成的 PNG 只含 IHDR/IDAT/IEND。
+func TestHasAPNGActlChunk_RejectsStaticPNG(t *testing.T) {
+	assert.False(t, hasAPNGActlChunk(makeTestPNG(t, 16, 16)))
+	// 手工造的"只有 IHDR/IDAT/IEND"字节流也应否定，与 image/png 输出等价。
+	minimalStatic := buildPNGWithChunks(t, []struct {
+		Type string
+		Data []byte
+	}{
+		{"IHDR", []byte{0, 0, 0, 1, 0, 0, 0, 1, 8, 0, 0, 0, 0}},
+		{"IDAT", []byte{0x78, 0x9c, 0x62, 0, 0, 0, 0, 1}},
+		{"IEND", nil},
+	})
+	assert.False(t, hasAPNGActlChunk(minimalStatic))
+}
+
+// 规范：IDAT 之后的 acTL 会被一致的渲染器忽略。我们跟随规范判定为静态 PNG，
+// 保守选择"能压缩"（否则任意有 acTL trailing bytes 的普通 PNG 都被误 skip）。
+func TestHasAPNGActlChunk_IgnoresActlAfterIDAT(t *testing.T) {
+	src := buildPNGWithChunks(t, []struct {
+		Type string
+		Data []byte
+	}{
+		{"IHDR", []byte{0, 0, 0, 1, 0, 0, 0, 1, 8, 0, 0, 0, 0}},
+		{"IDAT", []byte{0x78, 0x9c, 0x62, 0, 0, 0, 0, 1}},
+		{"acTL", []byte{0, 0, 0, 2, 0, 0, 0, 0}}, // trailing acTL —— 无效
+		{"IEND", nil},
+	})
+	assert.False(t, hasAPNGActlChunk(src))
+}
+
+// 恶意/畸形输入：签名不匹配、length 溢出等，函数必须 return false 而不 panic
+// 或越界。fuzz 面覆盖 review P2 的"信任边界"要求。
+func TestHasAPNGActlChunk_MalformedInputsReturnFalse(t *testing.T) {
+	cases := map[string][]byte{
+		"empty":            nil,
+		"short":            []byte{0x89, 0x50, 0x4e},
+		"wrong_signature":  []byte("NOTAPNG!\x00\x00\x00\x00type"),
+		"truncated_length": append([]byte("\x89PNG\r\n\x1a\n"), 0xff, 0xff),
+		"length_overflow": append(
+			[]byte("\x89PNG\r\n\x1a\n"),
+			0xff, 0xff, 0xff, 0xff, // length = MaxUint32
+			'X', 'X', 'X', 'X', // chunk type
+		),
+	}
+	for name, src := range cases {
+		assert.Falsef(t, hasAPNGActlChunk(src), "case=%s", name)
+	}
+}
+
+// TestStickerCompressor_APNGSkips: 压缩入口拿到 APNG → 走 skipped:animated,
+// 不进 doCompress，不占用并发 slot（在 acquire 前拦截）。observability 上
+// 走 counter compress_skipped；不打 duration histogram（disabled/format/
+// animated/concurrency_saturated 一起归属"轻量路径"）。
+func TestStickerCompressor_APNGSkips(t *testing.T) {
+	// 用一个"命中就 fatal"的 doCompress 证明 APNG 路径不到达 worker
+	c := &stickerCompressor{
+		settings: &fakeStickerCompressSettings{
+			enabled: true, targetKB: 1024, maxConcurrency: 4, timeoutMs: 2000, maxDim: 512,
+		},
+		doCompress: func(ext string, src []byte, maxDim, targetKB int) (stickerCompressResult, error) {
+			t.Fatalf("doCompress must not be called for APNG; ext=%s len=%d", ext, len(src))
+			return stickerCompressResult{}, nil
+		},
+	}
+	apng := buildPNGWithChunks(t, []struct {
+		Type string
+		Data []byte
+	}{
+		{"IHDR", []byte{0, 0, 0, 1, 0, 0, 0, 1, 8, 0, 0, 0, 0}},
+		{"acTL", []byte{0, 0, 0, 3, 0, 0, 0, 0}},
+		{"IDAT", []byte{0x78, 0x9c, 0x62, 0, 0, 0, 0, 1}},
+		{"IEND", nil},
+	})
+	r := c.Compress(".png", apng)
+	assert.Equal(t, stickerCompressOutcomeSkipped, r.Outcome)
+	assert.Equal(t, "animated", r.Reason,
+		"APNG must be identified before acquiring a compress slot")
 }

--- a/modules/file/sticker_compress_test.go
+++ b/modules/file/sticker_compress_test.go
@@ -34,6 +34,17 @@ func (f *fakeStickerCompressSettings) StickerCompressMaxConcurrency() int { retu
 func (f *fakeStickerCompressSettings) StickerCompressTimeoutMs() int      { return f.timeoutMs }
 func (f *fakeStickerCompressSettings) StickerUploadMaxDimension() int     { return f.maxDim }
 
+// params 从 fake 组装出 Compress 需要的 stickerCompressParams。测试从 fake
+// 派生参数模拟"caller 已在请求进入时锁定了一份 snapshot"的语义（review F7）。
+func (f *fakeStickerCompressSettings) params() stickerCompressParams {
+	return stickerCompressParams{
+		MaxDim:         f.maxDim,
+		TargetKB:       f.targetKB,
+		MaxConcurrency: f.maxConcurrency,
+		TimeoutMs:      f.timeoutMs,
+	}
+}
+
 // makeTestJPEG 生成 (w,h) JPEG，颜色随机以避免过度可压缩。
 func makeTestJPEG(t *testing.T, w, h, quality int) []byte {
 	t.Helper()
@@ -78,20 +89,22 @@ func newFakeCompressor(fs *fakeStickerCompressSettings) *stickerCompressor {
 }
 
 func TestStickerCompressor_DisabledSkips(t *testing.T) {
-	c := newFakeCompressor(&fakeStickerCompressSettings{
+	fs := &fakeStickerCompressSettings{
 		enabled: false, targetKB: 1024, maxConcurrency: 4, timeoutMs: 2000, maxDim: 512,
-	})
-	r := c.Compress(".png", makeTestPNG(t, 8, 8))
+	}
+	c := newFakeCompressor(fs)
+	r := c.Compress(".png", makeTestPNG(t, 8, 8), fs.params())
 	assert.Equal(t, stickerCompressOutcomeSkipped, r.Outcome)
 	assert.Equal(t, "disabled", r.Reason)
 }
 
 func TestStickerCompressor_UnsupportedFormatSkips(t *testing.T) {
-	c := newFakeCompressor(&fakeStickerCompressSettings{
+	fs := &fakeStickerCompressSettings{
 		enabled: true, targetKB: 1024, maxConcurrency: 4, timeoutMs: 2000, maxDim: 512,
-	})
+	}
+	c := newFakeCompressor(fs)
 	for _, ext := range []string{".gif", ".webp", ".bmp", ".mp4", ".JPG", "", "jpg"} {
-		r := c.Compress(ext, []byte{0})
+		r := c.Compress(ext, []byte{0}, fs.params())
 		assert.Equalf(t, stickerCompressOutcomeSkipped, r.Outcome, "ext=%q", ext)
 		assert.Equalf(t, "format", r.Reason, "ext=%q", ext)
 	}
@@ -103,10 +116,11 @@ func TestStickerCompressor_CompressesLargeJPEG(t *testing.T) {
 	src := makeTestJPEG(t, 1024, 1024, 95)
 	require.Greaterf(t, len(src), 50*1024, "source JPEG %dB must be big enough to test shrinking", len(src))
 
-	c := newFakeCompressor(&fakeStickerCompressSettings{
+	fs := &fakeStickerCompressSettings{
 		enabled: true, targetKB: 256, maxConcurrency: 4, timeoutMs: 5000, maxDim: 512,
-	})
-	r := c.Compress(".jpg", src)
+	}
+	c := newFakeCompressor(fs)
+	r := c.Compress(".jpg", src, fs.params())
 	require.Equalf(t, stickerCompressOutcomeCompressed, r.Outcome, "reason=%q size=%d", r.Reason, r.Size)
 	assert.LessOrEqual(t, r.Size, int64(256*1024))
 	// 结果字节仍是可解码 JPEG，且尺寸缩到 <= maxDim。
@@ -121,10 +135,11 @@ func TestStickerCompressor_CompressesLargeJPEG(t *testing.T) {
 func TestStickerCompressor_CompressesPNG(t *testing.T) {
 	src := makeTestPNG(t, 300, 300)
 
-	c := newFakeCompressor(&fakeStickerCompressSettings{
+	fs := &fakeStickerCompressSettings{
 		enabled: true, targetKB: 1024, maxConcurrency: 4, timeoutMs: 5000, maxDim: 512,
-	})
-	r := c.Compress(".png", src)
+	}
+	c := newFakeCompressor(fs)
+	r := c.Compress(".png", src, fs.params())
 	require.Equalf(t, stickerCompressOutcomeCompressed, r.Outcome, "reason=%q", r.Reason)
 	_, format, err := image.Decode(bytes.NewReader(r.Bytes))
 	require.NoError(t, err)
@@ -136,53 +151,57 @@ func TestStickerCompressor_RejectsWhenOverLimitAfterCompress(t *testing.T) {
 	src := makeTestPNG(t, 512, 512)
 	require.Greaterf(t, len(src), 10*1024, "seed PNG %dB must exceed 10KB so target=1KB is unreachable", len(src))
 
-	c := newFakeCompressor(&fakeStickerCompressSettings{
+	fs := &fakeStickerCompressSettings{
 		enabled: true, targetKB: 1, maxConcurrency: 4, timeoutMs: 10000, maxDim: 512,
-	})
-	r := c.Compress(".png", src)
+	}
+	c := newFakeCompressor(fs)
+	r := c.Compress(".png", src, fs.params())
 	assert.Equal(t, stickerCompressOutcomeOverLimit, r.Outcome)
 	assert.Greater(t, r.Size, int64(1024))
 	assert.Nil(t, r.Bytes, "over_limit result must not surface compressed bytes")
 }
 
 func TestStickerCompressor_FailsOpenOnDecodeError(t *testing.T) {
-	c := newFakeCompressor(&fakeStickerCompressSettings{
+	fs := &fakeStickerCompressSettings{
 		enabled: true, targetKB: 1024, maxConcurrency: 4, timeoutMs: 2000, maxDim: 512,
-	})
-	r := c.Compress(".jpg", []byte("not a real jpeg"))
+	}
+	c := newFakeCompressor(fs)
+	r := c.Compress(".jpg", []byte("not a real jpeg"), fs.params())
 	assert.Equal(t, stickerCompressOutcomeFailed, r.Outcome)
 	assert.Contains(t, r.Reason, "decode")
 }
 
 func TestStickerCompressor_ConcurrencyFailOpen(t *testing.T) {
-	c := newFakeCompressor(&fakeStickerCompressSettings{
+	fs := &fakeStickerCompressSettings{
 		enabled: true, targetKB: 1024, maxConcurrency: 1, timeoutMs: 10000, maxDim: 512,
-	})
+	}
+	c := newFakeCompressor(fs)
 	// 手动 hold 唯一 slot，随后 Compress 应立即 skipped。
 	require.True(t, c.tryAcquireCompressSlot(1))
-	r := c.Compress(".jpg", makeTestJPEG(t, 16, 16, 80))
+	r := c.Compress(".jpg", makeTestJPEG(t, 16, 16, 80), fs.params())
 	assert.Equal(t, stickerCompressOutcomeSkipped, r.Outcome)
 	assert.Equal(t, "concurrency_saturated", r.Reason)
 	c.releaseCompressSlot()
 
 	// 释放后能正常压缩（覆盖 release 语义）。
-	r2 := c.Compress(".jpg", makeTestJPEG(t, 16, 16, 80))
+	r2 := c.Compress(".jpg", makeTestJPEG(t, 16, 16, 80), fs.params())
 	assert.NotEqualf(t, stickerCompressOutcomeSkipped, r2.Outcome, "after release must compress, got reason=%q", r2.Reason)
 }
 
 func TestStickerCompressor_TimeoutFailOpen(t *testing.T) {
 	// 注入一个刻意 sleep 长于 timeout 的 doCompress，验证 select 超时分支。
+	fs := &fakeStickerCompressSettings{
+		enabled: true, targetKB: 1024, maxConcurrency: 4, timeoutMs: 20, maxDim: 512,
+	}
 	c := &stickerCompressor{
-		settings: &fakeStickerCompressSettings{
-			enabled: true, targetKB: 1024, maxConcurrency: 4, timeoutMs: 20, maxDim: 512,
-		},
+		settings: fs,
 		doCompress: func(ext string, src []byte, maxDim, targetKB int) (stickerCompressResult, error) {
 			time.Sleep(200 * time.Millisecond)
 			return stickerCompressResult{Outcome: stickerCompressOutcomeCompressed, Bytes: src, Size: int64(len(src))}, nil
 		},
 	}
 	start := time.Now()
-	r := c.Compress(".jpg", []byte("payload"))
+	r := c.Compress(".jpg", []byte("payload"), fs.params())
 	elapsed := time.Since(start)
 	assert.Equal(t, stickerCompressOutcomeSkipped, r.Outcome)
 	assert.Equal(t, "timeout", r.Reason)
@@ -277,10 +296,11 @@ func min2(a, b int) int {
 // 结束后 slot 释放，第三次 Compress 才能真正进压缩管线。
 func TestStickerCompressor_TimeoutDoesNotBleedConcurrency(t *testing.T) {
 	const workerSleep = 500 * time.Millisecond
+	fs := &fakeStickerCompressSettings{
+		enabled: true, targetKB: 1024, maxConcurrency: 1, timeoutMs: 20, maxDim: 512,
+	}
 	c := &stickerCompressor{
-		settings: &fakeStickerCompressSettings{
-			enabled: true, targetKB: 1024, maxConcurrency: 1, timeoutMs: 20, maxDim: 512,
-		},
+		settings: fs,
 		doCompress: func(ext string, src []byte, maxDim, targetKB int) (stickerCompressResult, error) {
 			time.Sleep(workerSleep)
 			return stickerCompressResult{Outcome: stickerCompressOutcomeCompressed, Bytes: src, Size: int64(len(src))}, nil
@@ -288,12 +308,12 @@ func TestStickerCompressor_TimeoutDoesNotBleedConcurrency(t *testing.T) {
 	}
 
 	// 第一次：worker 慢，Compress 从 timeout 分支返回
-	r1 := c.Compress(".jpg", []byte("x"))
+	r1 := c.Compress(".jpg", []byte("x"), fs.params())
 	require.Equal(t, stickerCompressOutcomeSkipped, r1.Outcome)
 	require.Equal(t, "timeout", r1.Reason)
 
 	// 立即再打：worker 还没跑完，slot 必须仍占用 → 拿到 concurrency_saturated
-	r2 := c.Compress(".jpg", []byte("y"))
+	r2 := c.Compress(".jpg", []byte("y"), fs.params())
 	assert.Equal(t, stickerCompressOutcomeSkipped, r2.Outcome)
 	assert.Equalf(t, "concurrency_saturated", r2.Reason,
 		"slot must remain held by dangling worker after timeout return; got reason=%q", r2.Reason)
@@ -304,7 +324,7 @@ func TestStickerCompressor_TimeoutDoesNotBleedConcurrency(t *testing.T) {
 	// 归还。这条 test 的 doCompress 是永远慢的固定 fake，用 outcome!=skipped 判
 	// 定会假失败。
 	time.Sleep(workerSleep + 100*time.Millisecond)
-	r3 := c.Compress(".jpg", []byte("z"))
+	r3 := c.Compress(".jpg", []byte("z"), fs.params())
 	assert.Equal(t, stickerCompressOutcomeSkipped, r3.Outcome)
 	assert.NotEqualf(t, "concurrency_saturated", r3.Reason,
 		"after worker finished, slot must be released; got reason=%q", r3.Reason)
@@ -409,10 +429,11 @@ func TestHasAPNGActlChunk_MalformedInputsReturnFalse(t *testing.T) {
 // animated/concurrency_saturated 一起归属"轻量路径"）。
 func TestStickerCompressor_APNGSkips(t *testing.T) {
 	// 用一个"命中就 fatal"的 doCompress 证明 APNG 路径不到达 worker
+	fs := &fakeStickerCompressSettings{
+		enabled: true, targetKB: 1024, maxConcurrency: 4, timeoutMs: 2000, maxDim: 512,
+	}
 	c := &stickerCompressor{
-		settings: &fakeStickerCompressSettings{
-			enabled: true, targetKB: 1024, maxConcurrency: 4, timeoutMs: 2000, maxDim: 512,
-		},
+		settings: fs,
 		doCompress: func(ext string, src []byte, maxDim, targetKB int) (stickerCompressResult, error) {
 			t.Fatalf("doCompress must not be called for APNG; ext=%s len=%d", ext, len(src))
 			return stickerCompressResult{}, nil
@@ -427,7 +448,7 @@ func TestStickerCompressor_APNGSkips(t *testing.T) {
 		{"IDAT", []byte{0x78, 0x9c, 0x62, 0, 0, 0, 0, 1}},
 		{"IEND", nil},
 	})
-	r := c.Compress(".png", apng)
+	r := c.Compress(".png", apng, fs.params())
 	assert.Equal(t, stickerCompressOutcomeSkipped, r.Outcome)
 	assert.Equal(t, "animated", r.Reason,
 		"APNG must be identified before acquiring a compress slot")

--- a/modules/file/sticker_metrics.go
+++ b/modules/file/sticker_metrics.go
@@ -1,6 +1,8 @@
 package file
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -17,11 +19,39 @@ func stickerUploadResultLabels() []string {
 		"magic_rejected",
 		"dimension_rejected",
 		"upload_failed",
+		// sticker-upload-compression 任务新增：服务端压缩管线的分支观测。
+		// compress_success  = 压缩成功且落库为压缩后字节
+		// compress_failed   = 解码/编码失败，fail-open 走原路径（原字节仍上传）
+		// compress_skipped  = 未压缩（禁用/非可压格式/并发满/超时），fail-open 走原路径
+		// compress_over_limit = 压缩后仍超 target_kb，caller 拒绝上传
+		"compress_success",
+		"compress_failed",
+		"compress_skipped",
+		"compress_over_limit",
 	}
 }
 
 func stickerUploadHandleResultLabels() []string {
 	return []string{"issued", "disabled"}
+}
+
+// stickerCompressDurationOutcomeLabels 是 compress_duration_seconds 的 outcome
+// 维度枚举。与 observeStickerUpload 里的 compress_* 一一对应，独立列出以便预热
+// 每种 outcome 的 histogram 序列（区分"零次"与"未注册"）。
+func stickerCompressDurationOutcomeLabels() []string {
+	return []string{
+		stickerCompressOutcomeCompressed,
+		stickerCompressOutcomeFailed,
+		stickerCompressOutcomeSkipped,
+		stickerCompressOutcomeOverLimit,
+	}
+}
+
+// stickerCompressDurationFormatLabels 是 compress_duration_seconds 的 format
+// 维度枚举。保持 low-cardinality：只放可能到达压缩管线的格式 + "other" 兜底
+// （防 caller 传奇怪 ext 导致 label 爆炸）。
+func stickerCompressDurationFormatLabels() []string {
+	return []string{"jpg", "jpeg", "png", "gif", "webp", "other"}
 }
 
 func init() {
@@ -30,6 +60,13 @@ func init() {
 	}
 	for _, result := range stickerUploadHandleResultLabels() {
 		metricStickerUploadHandleTotal.WithLabelValues(result).Add(0)
+	}
+	// 预热压缩耗时 histogram 的每对 (outcome, format) 序列为 0 sample —— 与
+	// counter 预热同款约定，让 dashboard 区分"零次"与"序列不存在"。
+	for _, outcome := range stickerCompressDurationOutcomeLabels() {
+		for _, format := range stickerCompressDurationFormatLabels() {
+			metricStickerCompressDurationSeconds.WithLabelValues(outcome, format)
+		}
 	}
 }
 
@@ -45,6 +82,18 @@ var (
 		Name:      "upload_handle_total",
 		Help:      "Sticker upload handle issuance outcomes.",
 	}, []string{"result"})
+
+	// metricStickerCompressDurationSeconds 记录服务端贴纸压缩的实际耗时，按
+	// outcome + 归一化后的 format 打点。buckets 覆盖 5ms..5s：<10ms 常见于
+	// skipped(format/disabled) 分支；50-500ms 是典型 jpg/png 512-1024 边压缩
+	// 观测区间；>=1s 说明命中大图或系统抖动，>=5s 通常表示已被 timeout 截断
+	// （不会到达 Observe，但保留 bucket 便于 P99 上界可见）。
+	metricStickerCompressDurationSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: fileStickerMetricNamespace,
+		Name:      "compress_duration_seconds",
+		Help:      "Sticker server-side compression wall-clock duration by outcome and format.",
+		Buckets:   []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5},
+	}, []string{"outcome", "format"})
 )
 
 func observeStickerUpload(result string) {
@@ -53,4 +102,33 @@ func observeStickerUpload(result string) {
 
 func observeStickerUploadHandle(result string) {
 	metricStickerUploadHandleTotal.WithLabelValues(result).Inc()
+}
+
+// normalizeStickerCompressFormat 把 ext 归一化到 low-cardinality 集合，防止
+// caller 传奇怪 ext 时 label 爆炸。ext 允许带或不带前导点，大小写不敏感。
+func normalizeStickerCompressFormat(ext string) string {
+	if len(ext) > 0 && ext[0] == '.' {
+		ext = ext[1:]
+	}
+	switch ext {
+	case "jpg", "JPG":
+		return "jpg"
+	case "jpeg", "JPEG":
+		return "jpeg"
+	case "png", "PNG":
+		return "png"
+	case "gif", "GIF":
+		return "gif"
+	case "webp", "WEBP":
+		return "webp"
+	}
+	return "other"
+}
+
+// observeStickerCompressDuration 记录一次压缩耗时。outcome 应取
+// stickerCompressOutcome* 常量；format 从 caller ext 传入，内部归一化。
+func observeStickerCompressDuration(outcome, ext string, d time.Duration) {
+	metricStickerCompressDurationSeconds.
+		WithLabelValues(outcome, normalizeStickerCompressFormat(ext)).
+		Observe(d.Seconds())
 }

--- a/modules/file/sticker_metrics.go
+++ b/modules/file/sticker_metrics.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -105,21 +106,20 @@ func observeStickerUploadHandle(result string) {
 }
 
 // normalizeStickerCompressFormat 把 ext 归一化到 low-cardinality 集合，防止
-// caller 传奇怪 ext 时 label 爆炸。ext 允许带或不带前导点，大小写不敏感。
+// caller 传奇怪 ext 时 label 爆炸。ext 允许带或不带前导点，且完全大小写不敏感
+// —— 先 ToLower 再 TrimPrefix，兑现函数注释里的合约（review F2）。
 func normalizeStickerCompressFormat(ext string) string {
-	if len(ext) > 0 && ext[0] == '.' {
-		ext = ext[1:]
-	}
+	ext = strings.TrimPrefix(strings.ToLower(ext), ".")
 	switch ext {
-	case "jpg", "JPG":
+	case "jpg":
 		return "jpg"
-	case "jpeg", "JPEG":
+	case "jpeg":
 		return "jpeg"
-	case "png", "PNG":
+	case "png":
 		return "png"
-	case "gif", "GIF":
+	case "gif":
 		return "gif"
-	case "webp", "WEBP":
+	case "webp":
 		return "webp"
 	}
 	return "other"

--- a/modules/file/sticker_metrics_test.go
+++ b/modules/file/sticker_metrics_test.go
@@ -1,0 +1,43 @@
+package file
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// normalizeStickerCompressFormat 兑现"完全大小写不敏感 + 前导点可选"的合约
+// （review F2）。历史实现只匹配全大写/全小写变体，混合大小写会 fall through 到
+// "other" —— 现在的实现走 strings.ToLower 保证 .Jpg / JPG / jpeg 都归到同一
+// label 序列，避免 histogram cardinality 因大小写 typo 意外扩张。
+func TestNormalizeStickerCompressFormat(t *testing.T) {
+	cases := map[string]string{
+		// 全 5 种支持格式的完整大小写 / 有/无前导点变体
+		".jpg":  "jpg",
+		"jpg":   "jpg",
+		".JPG":  "jpg",
+		"JPG":   "jpg",
+		".Jpg":  "jpg",
+		".jpeg": "jpeg",
+		"jpeg":  "jpeg",
+		"JPEG":  "jpeg",
+		"Jpeg":  "jpeg",
+		".png":  "png",
+		"PNG":   "png",
+		".Png":  "png",
+		".gif":  "gif",
+		"GIF":   "gif",
+		".webp": "webp",
+		"WEBP":  "webp",
+		"WebP":  "webp",
+		// 未识别 / 空 / 奇怪输入统一归到 "other"，保证 label 集合封闭
+		"":       "other",
+		".":      "other",
+		".mp4":   "other",
+		"bmp":    "other",
+		"random": "other",
+	}
+	for in, want := range cases {
+		assert.Equalf(t, want, normalizeStickerCompressFormat(in), "input=%q", in)
+	}
+}

--- a/modules/file/sticker_upload_ext_test.go
+++ b/modules/file/sticker_upload_ext_test.go
@@ -1,0 +1,92 @@
+package file
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/stretchr/testify/assert"
+)
+
+// F1: stickerUploadExtForRequest 应尊重 settings.StickerUploadAllowedFormats
+// 的当前值，让 GET-side preflight URL 与 POST-side 校验用同一套允许集，避免
+// 运营收窄格式后客户端拿到之后会被 upload 拒绝的扩展名。
+
+func TestStickerUploadExtForRequest_DefaultAllowlistMatchesFilename(t *testing.T) {
+	settings := defaultFakeStickerSettings()
+	f := &File{Log: log.NewTLog("FileTest"), settings: settings}
+
+	// 默认允许全 5 种：filename 的扩展名直接命中即可，无 fallback。
+	cases := map[string]string{
+		"a.gif":      ".gif",
+		"a.png":      ".png",
+		"a.jpg":      ".jpg",
+		"a.jpeg":     ".jpeg",
+		"a.webp":     ".webp",
+		"A.PNG":      ".png",
+		"stuff.JpeG": ".jpeg",
+	}
+	for filename, want := range cases {
+		assert.Equalf(t, want, f.stickerUploadExtForRequest(filename),
+			"filename=%q default allowlist should match extension", filename)
+	}
+}
+
+// filename 缺失 / 无扩展名 / 不认识的扩展名 → 走 fallback。默认允许集下 .gif
+// 仍在，回退到 .gif（复刻老 stickerUploadExt 的历史 fallback）。
+func TestStickerUploadExtForRequest_FallbackToGifByDefault(t *testing.T) {
+	settings := defaultFakeStickerSettings()
+	f := &File{Log: log.NewTLog("FileTest"), settings: settings}
+
+	cases := []string{"", "noext", "a.svg", "a.mp4", "a.pdf"}
+	for _, filename := range cases {
+		assert.Equalf(t, ".gif", f.stickerUploadExtForRequest(filename),
+			"filename=%q default fallback should be .gif", filename)
+	}
+}
+
+// 运营剔除 .gif 后（例如只允许 png/jpg），filename 命中直接返回；miss 时不能
+// 回 .gif（那是配置里已经明确剔除的），按 raster allowlist 固定顺序 fallback
+// 到 .png（首个允许项）。这是 F1 的核心不变式：GET 侧只吐当前配置允许的扩展名。
+func TestStickerUploadExtForRequest_NarrowedFormatsSkipDisabledExt(t *testing.T) {
+	settings := defaultFakeStickerSettings()
+	settings.allowedFormats = []string{".png", ".jpg"} // 剔除 .gif/.jpeg/.webp
+	f := &File{Log: log.NewTLog("FileTest"), settings: settings}
+
+	// filename 命中允许集：原样返回
+	assert.Equal(t, ".png", f.stickerUploadExtForRequest("a.png"))
+	assert.Equal(t, ".jpg", f.stickerUploadExtForRequest("a.jpg"))
+
+	// filename 命中已剔除项 → 走 fallback，绝不返回被剔除的 .gif
+	// fallback 顺序 .gif → .png → ...，.gif 不在允许集 → .png
+	assert.Equal(t, ".png", f.stickerUploadExtForRequest("a.gif"))
+	assert.Equal(t, ".png", f.stickerUploadExtForRequest("a.jpeg"))
+	assert.Equal(t, ".png", f.stickerUploadExtForRequest("a.webp"))
+	assert.Equal(t, ".png", f.stickerUploadExtForRequest("")) // filename 缺失
+	assert.Equal(t, ".png", f.stickerUploadExtForRequest("noext"))
+}
+
+// 配置进一步收窄到不含 .gif 也不含 .png，验证 fallback 沿固定顺序 .png→.jpg→
+// .jpeg→.webp 挑第一个允许项。稳定性重要 —— 客户端 URL 生成必须 deterministic。
+func TestStickerUploadExtForRequest_FallbackDeterministicWithoutGifPng(t *testing.T) {
+	settings := defaultFakeStickerSettings()
+	settings.allowedFormats = []string{".jpeg", ".webp"} // 剔除 .gif/.png/.jpg
+	f := &File{Log: log.NewTLog("FileTest"), settings: settings}
+
+	assert.Equal(t, ".jpeg", f.stickerUploadExtForRequest("a.gif")) // fallback → .jpeg
+	assert.Equal(t, ".jpeg", f.stickerUploadExtForRequest(""))
+	assert.Equal(t, ".webp", f.stickerUploadExtForRequest("a.webp")) // 命中 .webp
+}
+
+// 未挂 settings（老 unit test 构造 &File{}）走 stickerLimits() nil-safe 分支，
+// 应与老 pkg-level stickerUploadExt 行为逐字节等价。这条 test 是回归保障，
+// 确保新 method 不破坏 &File{} 单测。
+func TestStickerUploadExtForRequest_NilSettingsMatchesLegacy(t *testing.T) {
+	f := &File{Log: log.NewTLog("FileTest")}
+
+	cases := []string{"a.gif", "a.png", "a.jpg", "a.jpeg", "a.webp", "", "noext", "a.svg"}
+	for _, filename := range cases {
+		legacy := stickerUploadExt(filename)
+		assert.Equalf(t, legacy, f.stickerUploadExtForRequest(filename),
+			"filename=%q must match legacy stickerUploadExt when settings is nil", filename)
+	}
+}


### PR DESCRIPTION
## Summary

Two coupled capabilities layered onto the existing `modules/file` sticker upload path, both default-OFF (zero-impact until an operator opts in):

1. **Configurable upload limits** — the previously hard-coded custom-sticker limits (`StickerMaxFileSize=1MB`, `StickerMaxDimension=512`, `stickerUploadExts`) move into `system_setting` with server-side hard caps. The read path clamps values so a bad admin edit can't exceed the resource envelope; `upload_allowed_formats` may only *narrow* the built-in raster allowlist (mp4/pdf/svg silently dropped in the getter).
2. **Opt-in server-side compression (plan C)** — when `sticker.compress_enabled=true`, static `jpg/png` uploads are decoded → optionally downscaled → metadata-stripped → re-encoded (JPEG q=85 / PNG). `webp`/`gif`/animated (incl. APNG) are validate-only; if the compressed byte count still exceeds `compress_target_kb`, the upload is rejected outright. The `sticker_handle` is signed over the final stored URL.

### New `system_setting` keys

| key | default | hard cap |
|---|---|---|
| `sticker.upload_max_size_kb` | 1024 | 5120 |
| `sticker.upload_max_dimension` | 512 | 1024 |
| `sticker.upload_allowed_formats` | `gif,png,jpg,jpeg,webp` | intersect with built-in raster allowlist |
| `sticker.compress_enabled` | false | — |
| `sticker.compress_target_kb` | 1024 | 5120 |
| `sticker.compress_max_concurrency` | 4 | 32 |
| `sticker.compress_timeout_ms` | 2000 | 10000 |

### Stability isolation

- **Concurrency gate**: mutex+counter, capacity read from settings on every request so `compress_max_concurrency` changes take effect within a snapshot TTL. Saturation returns `skipped:concurrency_saturated` (fail-open to original bytes).
- **Timeout**: `time.Timer` preempts the worker goroutine. Slot lifetime is bound to the worker (NOT to `Compress()`'s return) so a timeout return can't leak a slot and let true in-flight work exceed the configured cap.
- **Panic**: worker `recover` maps any decoder crash to `failed`, upload keeps going with original bytes.
- **APNG**: `acTL` chunk scan before slot acquisition. Without this check, standard `image/png` would silently decode only the first frame and re-encode a static PNG, dropping the animation.
- **All error paths fail-open** to the pre-compression byte stream so compression can never destabilize the upload path.

### Observability

- Counter `sticker_upload_total{result}` — 4 new dimensions pre-warmed to 0: `compress_success` / `compress_failed` / `compress_skipped` / `compress_over_limit`
- Histogram `sticker_compress_duration_seconds{outcome,format}` — 10 buckets from 5ms..5s; only points on paths that actually spent CPU (compressed / failed / over_limit / skipped:timeout); format normalized to a 6-value whitelist to bound cardinality
- Zap logs include `orig_size` + `final_size` on the upload-success path so post-hoc analysis can compute shrink ratios

## Out of scope (deferred)

- `webp` / `gif` / animated re-encoding — would require a cgo `libwebp` dep. Phase one is validate-only for these.
- Changing the two-stage upload → register contract, quota (`user_max_count`), or the `handle_required` rollout.
- Client-side changes — upload response field shape is preserved (`path`/`name`/`size`/`ext`/`sha512`/`sticker_handle`).
- Migrating `modules/file` to the i18n error envelope.
- Async / out-of-band compression pipeline.

## Test plan

Two commits: initial implementation (`0177781e`) + review-driven fix (`b3c86473`).

- [x] `modules/common` clamp / intersection / narrowing behavior — **19 no-infra unit tests**, cover default fallback, DB override, hard-cap clamp, non-positive/non-numeric fallback, boundary-value accept
- [x] `modules/file` compressor — **9 unit tests** cover disabled/format skip, JPEG shrink, PNG re-encode, over-limit reject, decode-error fail-open, concurrency saturation, timeout fail-open, aspect-ratio preserved (Fit vs Resize/Fill), no upscale for under-maxDim source
- [x] `modules/file` uploadFile integration — **4 tests** using an in-memory service that captures the bytes sent to storage: large JPEG uses compressed bytes (`resp.size == len(uploaded)`), GIF passes through byte-for-byte, over-limit returns non-OK with nothing stored, `sticker_handle` verifies against the final stored URL and rejects a different uid
- [x] APNG-specific — 4 chunk-scan unit tests (valid APNG detection / static PNG rejection / spec-invalid trailing acTL ignored / malformed input fuzz)
- [x] Concurrency-slot regression — `TestStickerCompressor_TimeoutDoesNotBleedConcurrency` uses maxConcurrency=1 + slow worker: the request following a timeout return must get `concurrency_saturated` (proving the slot did not leak to a new caller)
- [x] Benchmarks — 6 permutations across (JPEG/PNG) × (512²/1024², shrink / re-encode-only). Local Apple M5 baseline is included in the perf-todo file
- [x] Full `go test -race -count=1 ./modules/file/ ./modules/common/` after a `DROP DATABASE test; CREATE DATABASE test;` — passes end-to-end
- [x] `go vet ./...` — clean
- [x] `make i18n-lint` — clean (no new i18n codes introduced)

### Pre-rollout MUST list

Compression defaults to OFF. Production enablement gated on the perf-todo checklist tracked at `.octospec/tasks/sticker-upload-compression/perf-todo.md`:

- Re-run benches on production-representative CPU (local baseline is Apple M5; expect ~3× slower on x86 cloud VMs)
- `hey` / `wrk` end-to-end HTTP compare of latency P50/P95/P99 + CPU / heap / goroutine steady-state
- Goroutine leak-bound test: sustained timeout-triggering upload should show worker count capped by `compress_max_concurrency`
- pprof to confirm CPU time is in `imaging.Encode` / Lanczos, no framework hotspot
- Decompression-bomb sanity: 1KB pathological input decoding to a 10000² bitmap must still be blocked by the pre-existing dimension gate before reaching the compression path
- Grey-out ramp: 5% traffic → 15 min observation → 50% → 30 min → 100%; rollback = flip `sticker.compress_enabled=false` (60s replica convergence)
