### PR TITLE
feat(sticker): expose upload limits via appconfig

### DIFF
--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -390,6 +390,9 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 			StickerCustomEnabled:   cn.systemSettings.StickerCustomEnabled(),
 			StickerHandleRequired:  cn.systemSettings.StickerHandleRequired(),
 			DocsOn:                 cn.systemSettings.DocsEnabled(),
+			// Sticker 上限:短路分支同样下发,让老客户端在管理台放宽/收窄后
+			// 也能立刻拿到最新值。
+			StickerUploadLimits: buildStickerUploadLimitsResp(cn.systemSettings),
 		})
 		return
 	}
@@ -433,7 +436,21 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 		StickerCustomEnabled:   cn.systemSettings.StickerCustomEnabled(),
 		StickerHandleRequired:  cn.systemSettings.StickerHandleRequired(),
 		DocsOn:                 cn.systemSettings.DocsEnabled(),
+		// Sticker 上限:客户端本地预校验用,兜底仍在服务端 modules/file 侧。
+		StickerUploadLimits: buildStickerUploadLimitsResp(cn.systemSettings),
 	})
+}
+
+// buildStickerUploadLimitsResp 从 SystemSettings 派生一份 stickerUploadLimitsResp
+// 快照。两个 handler 分支(version-shortcut / full-refresh)都用它,避免字段
+// 组装漂移。SystemSettings.StickerUpload* getter 各自内部已做 hard-cap clamp,
+// 拿到的都是安全值。
+func buildStickerUploadLimitsResp(s *SystemSettings) stickerUploadLimitsResp {
+	return stickerUploadLimitsResp{
+		MaxSizeKB:      s.StickerUploadMaxSizeKB(),
+		MaxDimension:   s.StickerUploadMaxDimension(),
+		AllowedFormats: s.StickerUploadAllowedFormats(),
+	}
 }
 
 // oidcProviders 返回 OIDC provider 元数据数组,让前端不再硬编码 provider id/name/authorize_path。
@@ -791,6 +808,44 @@ type appConfigResp struct {
 	// 与 app_config.version 解耦的原因同 LocalLoginOff / SearchEnabled：运维切展示
 	// 策略后老客户端命中 version 短路分支也必须拿到最新值，故两个分支都下发。
 	DocsOn bool `json:"docs_on"`
+
+	// StickerUploadLimits 是自定义贴纸上传的操作端可调上限，与 sticker.upload_*
+	// system_setting 同源（SystemSettings.StickerUpload{MaxSizeKB,MaxDimension,
+	// AllowedFormats}）。用途：让客户端在选图后本地预校验（提示"最大 X MB / 最长
+	// Y px / 支持 gif/png..."），避免大图/非法扩展名先跑完 HTTP 上传才被服务端拒
+	// —— 尤其对移动端流量友好。
+	//
+	// 客户端预校验只是 UX 优化；服务端 modules/file 侧仍对每个 sticker upload
+	// 请求做同一份 stickerLimits 快照兜底（size/format/dimension 三层），客户端
+	// 缓存过期或被绕过都不影响安全边界。默认值与 PR #544 之前的历史硬编码严格
+	// 等价（1024 KB / 512 px / [.gif,.png,.jpg,.jpeg,.webp]），运营不动 knob
+	// 时行为完全无回归。
+	//
+	// 与 app_config.version 解耦的原因同 StickerHandleRequired / DocsOn：运维在
+	// 管理台放宽/收窄上限后，老客户端命中 version 短路分支也必须拿到最新值，否则
+	// 被本地缓存住失去实时性，故两个分支都下发。
+	//
+	// 独立命名空间（不叫 sticker_upload_*）的原因：三个字段是一组"上限"，一起
+	// 生效、一起提示；单独包一层让客户端解析和展示逻辑天然聚合，未来若加非上限
+	// 类的 sticker upload 字段（例如上传行为 toggle）也不会污染这个 object。
+	// 现有的 sticker_custom_enabled / sticker_handle_required 是平铺 bool，形态
+	// 与 limits object 差异明显，风格分裂可接受；语义相近的字段（同为 upload
+	// 上限）优先聚合，与 OIDCProviders 这类 nested resp 同思路。
+	//
+	// 不下发压缩相关 knob（compress_enabled / compress_target_kb /
+	// compress_max_concurrency / compress_timeout_ms）—— 这些是服务端"影子"参数，
+	// 响应字段结构不变、无对应客户端行为，曝光只会泄露实现细节。
+	StickerUploadLimits stickerUploadLimitsResp `json:"sticker_upload_limits"`
+}
+
+// stickerUploadLimitsResp 是 appConfigResp.sticker_upload_limits 的形状。
+// 三个字段一起下发,一起用于客户端预校验。字段名不再带 sticker_upload_ 前缀
+// —— 已经在命名空间下。allowed_formats 内每项含前导点、小写、按输入 CSV
+// 顺序保留(见 SystemSettings.StickerUploadAllowedFormats 契约)。
+type stickerUploadLimitsResp struct {
+	MaxSizeKB      int      `json:"max_size_kb"`
+	MaxDimension   int      `json:"max_dimension"`
+	AllowedFormats []string `json:"allowed_formats"`
 }
 
 type oidcProviderResp struct {

--- a/modules/common/api_test.go
+++ b/modules/common/api_test.go
@@ -806,3 +806,91 @@ func TestGetAppConfig_DocsOn_OnVersionShortCircuit(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), `"docs_on":true`)
 }
+
+// setStickerUploadLimitsSettings upserts the three sticker upload knobs
+// (size KB / max dim / allowed formats CSV) and reloads the shared snapshot.
+// Passing "" for any of them skips writing that row so tests can exercise the
+// "default when unset" branch selectively. Call AFTER cleanAllTablesAndReloadSettings.
+func setStickerUploadLimitsSettings(t *testing.T, ctx *config.Context, sizeKB, maxDim, allowedCSV string) {
+	t.Helper()
+	if sizeKB != "" {
+		_, err := ctx.DB().InsertInto("system_setting").
+			Columns("category", "key_name", "value", "value_type").
+			Values("sticker", "upload_max_size_kb", sizeKB, "int").Exec()
+		require.NoError(t, err)
+	}
+	if maxDim != "" {
+		_, err := ctx.DB().InsertInto("system_setting").
+			Columns("category", "key_name", "value", "value_type").
+			Values("sticker", "upload_max_dimension", maxDim, "int").Exec()
+		require.NoError(t, err)
+	}
+	if allowedCSV != "" {
+		_, err := ctx.DB().InsertInto("system_setting").
+			Columns("category", "key_name", "value", "value_type").
+			Values("sticker", "upload_allowed_formats", allowedCSV, "string").Exec()
+		require.NoError(t, err)
+	}
+	require.NoError(t, EnsureSystemSettings(ctx).Reload())
+}
+
+// appconfig 必须下发 sticker_upload_* 上限。未配置时 = SystemSettings 侧默认
+// (1024 KB / 512 px / 全 5 位图),与 PR #544 之前的历史硬编码严格等价。客户端
+// 据此做本地预校验,失败时提示用户"最大 X MB / X px / 支持 gif/png/..."。
+func TestGetAppConfig_StickerUploadLimits_DefaultsMatchHistoricalHardcoded(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx) // wipes system_setting → 3 keys absent → defaults served
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	// 嵌套 struct 序列化顺序 = 定义顺序(max_size_kb → max_dimension → allowed_formats),
+	// 因此可以整段字符串匹配。allowed_formats 未配置回退默认 5 位图,顺序 =
+	// stickerUploadRasterAllowlist 定义顺序。
+	assert.Contains(t, body, `"sticker_upload_limits":{"max_size_kb":1024,"max_dimension":512,"allowed_formats":[".gif",".png",".jpg",".jpeg",".webp"]}`)
+}
+
+// 运营在管理台把 3 个上限都放宽/收窄 → appconfig 下发新值(客户端本地预校验
+// 立刻跟随)。同时验证 allowed_formats CSV 归一化(小写、加点、去空格、去重、
+// 非位图丢弃、按输入 CSV 顺序保留)在下发字段里成立。
+func TestGetAppConfig_StickerUploadLimits_DBOverrideServed(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	setStickerUploadLimitsSettings(t, ctx, "3072", "900", "PNG, gif , mp4") // mp4 非位图会被读侧丢弃
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	// 归一化:PNG→.png,gif→.gif,mp4 丢弃;顺序按输入 CSV 保留(稳定,便于
+	// 客户端展示/日志用),下发就是 [".png",".gif"]。
+	assert.Contains(t, body, `"sticker_upload_limits":{"max_size_kb":3072,"max_dimension":900,"allowed_formats":[".png",".gif"]}`)
+}
+
+// version 短路分支同样要下发 sticker_upload_limits:运维在管理台调整后老客户端
+// 命中版本短路也必须拿到最新值,否则被本地缓存住失去实时性(与 StickerHandleRequired
+// / DocsOn 同样的解耦约束)。
+func TestGetAppConfig_StickerUploadLimits_OnVersionShortCircuit(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	setStickerUploadLimitsSettings(t, ctx, "3072", "900", "png,jpg")
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig?version=99999999", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `"sticker_upload_limits":{"max_size_kb":3072,"max_dimension":900,"allowed_formats":[".png",".jpg"]}`)
+}


### PR DESCRIPTION
## Summary

Follow-up to #544. That PR made sticker upload limits (max size / max dimension / allowed formats) operator-tunable but only enforced them on the server. Clients still hardcode ~1 MB / 512 px / 5 formats, and the moment ops narrows or widens any knob, the client's local pre-check drifts from the server's authoritative gate — users pay for the upload before hearing "too big / wrong format".

Expose the three limits via the existing `GET /v1/common/appconfig` channel (same fabric as `sticker_handle_required` / `docs_on`) so clients can pre-check locally after file selection and show accurate `max X MB / Y px / gif,png,…` hints. This is a UX optimisation; the server-side `stickerLimits` snapshot in `modules/file` remains the security boundary and is unchanged.

## Wire shape

```json
{
  "sticker_upload_limits": {
    "max_size_kb": 1024,
    "max_dimension": 512,
    "allowed_formats": [".gif", ".png", ".jpg", ".jpeg", ".webp"]
  }
}
```

The three fields are always emitted together, always consumed together (single pre-check pass), and always change together (ops adjusts the "limits" set as one unit), so they live under one namespaced object rather than three flat fields. Existing flat `sticker_` fields (`sticker_custom_enabled`, `sticker_handle_required`) stay flat — unrelated booleans consumed by different client code paths; moving them would be a breaking change requiring cross-client coordination.

Both handler branches (version-shortcut and full-refresh) compose the sub-response through a single `buildStickerUploadLimitsResp` helper so the two branches can't drift.

## Not surfaced

Compression knobs (`compress_enabled` / `compress_target_kb` / `compress_max_concurrency` / `compress_timeout_ms`) are intentionally omitted. They are server-side shadow parameters — response shape doesn't change with them, no corresponding client behaviour, and exposing them would only leak implementation detail.

## Client contract compatibility

- Additive: new JSON field on a widely-cached response; older clients that ignore unknown fields see zero regression.
- Defaults (unset in `system_setting`) match the pre-#544 hardcoded behaviour exactly (1024 KB / 512 px / all 5 raster formats), so clients that never opt in to the new field remain byte-for-byte compatible.
- Same version-decoupling as `sticker_handle_required` / `docs_on`: served on the version-shortcut branch too, so an old client that cache-hits on `version` still sees the current limits after ops flips them.

## Test plan

Three new integration tests in `modules/common/api_test.go`, mirroring the `TestGetAppConfig_StickerHandleRequired_*` pattern:

- [x] `TestGetAppConfig_StickerUploadLimits_DefaultsMatchHistoricalHardcoded` — no `system_setting` rows → defaults match the pre-#544 hardcoded values.
- [x] `TestGetAppConfig_StickerUploadLimits_DBOverrideServed` — ops writes narrower values → appconfig serves them; verifies CSV normalisation (lowercase, dot-prefix, whitespace strip, non-raster drop, input-CSV order preserved) reaches the wire.
- [x] `TestGetAppConfig_StickerUploadLimits_OnVersionShortCircuit` — same values served on the `?version=…` short-circuit branch.

Local: `go test -race -count=1 ./modules/common/` — green after drop&recreate of the test DB.

## Follow-ups (not in scope)

- Client-side consumption (Android / iOS / Web) — separate work in the client repos.
- Rewriting the flat `sticker_custom_enabled` / `sticker_handle_required` into a `sticker` namespace — breaking change, needs cross-client coordination and would be its own PR.