### PR TITLE
feat(cardmsg): P2 card revision history (D10) — side table, query API, clear + tombstone

### DIFF
--- a/.octospec/journal/shared/card-message-p2-revision-history.md
+++ b/.octospec/journal/shared/card-message-p2-revision-history.md
@@ -1,0 +1,87 @@
+---
+type: Journal
+title: "Journal: card-message-p2-revision-history (PR-C, card message P2 D10)"
+description: Record of PR-C — the D10 card revision history side table, query API, transient flag, bot clear+tombstone, and revoke cleanup, stacked on PR-B; includes two P1 fixes from verify (query-side withdraw gate + revoke-cleanup ordering).
+tags: ["message", "card", "wire-contract", "bot-api", "rate-limit", "space", "isolation", "error-response", "i18n"]
+timestamp: 2026-07-08T11:30:00Z
+# --- octospec extension fields ---
+task: card-message-p2-revision-history
+upstream: self
+source: self
+---
+
+# Journal: card-message-p2-revision-history (PR-C, card message P2 D10)
+
+## What was done
+
+Shipped D10 of the `card-message-interaction` contract — a queryable card
+revision history that the D6 latest-frame-only `content_edit` model cannot
+answer on its own. Stacked on PR-B (#548).
+
+- **`pkg/cardrevision`**: shared store over the new `octo_message_card_revision`
+  table (written by `modules/bot_api` on card edits/clear, read by
+  `modules/message`) — `AppendFrame` (+ cap-20 prune, rune-safe `plain`
+  truncate), `Query` (newest-first, incl. tombstones), `Clear` (tx: delete
+  frames + write auditable tombstone), `DeleteByMessageID`.
+- **`modules/bot_api`**: `botMessageEdit` appends a non-transient frame after
+  the content write (best-effort); new `POST /v1/bot/message/card/revisions/clear`
+  (owner-checked, writes a tombstone).
+- **`modules/message`**: `GET /v1/message/card/revisions` (summary / `full=1`);
+  extracted `authorizeCardChannelMember` shared with `card/action`; revoke
+  deletes a card's revisions.
+- **`pkg/cardmsg`**: `Transient` / `PlainFromContentEdit`.
+
+## Structural learnings
+
+- **Shared-table access via a `pkg/` store, not per-module raw SQL.** The
+  revision table is written by `bot_api` and read by `message` (same split as
+  `message_extra`). Instead of duplicating column-level SQL across two modules,
+  a `pkg/cardrevision.Store` wrapping `ctx.DB()`'s `*dbr.Session` centralizes
+  the schema. Both modules construct it. This is the cleaner pattern when a new
+  shared table has more than one accessing module.
+- **Extract the auth gate the moment a second endpoint needs it.** PR-C's
+  `GET /card/revisions` needs the exact anti-IDOR channel-binding + membership
+  gate `card/action` already had. Factoring `authorizeCardChannelMember`
+  (parameterized by the invalid/denied errcodes) made both endpoints share one
+  implementation — the brief explicitly called for this to prevent drift.
+- **New table → `octo_` prefix.** The parent brief's illustrative name
+  `message_card_revision` was overridden to `octo_message_card_revision` per the
+  repo's new-table naming rule; the prefix-less legacy tables are untouched.
+
+## Gotchas worth remembering (verify + code-review)
+
+- **Actionability/queryability must not outlive visibility.** The GET endpoint
+  first shipped with only the channel-membership gate and would have served the
+  revision content of a **revoked / globally-deleted / operator-locally-deleted**
+  card as long as the rows existed — the same class of gap PR-B hit on the action
+  path. Fixed with a shared `isCardMessageWithdrawn` (mirrors
+  `api_message_get.go:241`) applied on the query path, returning an empty list.
+  **Any new read/write path over a message must apply the same
+  revoke/is_deleted/user-local-delete visibility gate the existing single-message
+  read applies — and must NOT rely on a best-effort cleanup elsewhere.** See the
+  promoted learning.
+- **The lifecycle gate is only ONE layer of the canonical read (PR#549 review
+  B1).** Even after `isCardMessageWithdrawn`, the query still enforced a strict
+  *subset* of `respondSingleMessage`: it omitted the `visibles` allowlist, the
+  per-user read offset, the channel offset, and message expiry — so a
+  visibles-excluded or offset-truncated group member could still read the full
+  revision history (and with `full=1`, complete historical envelopes) though the
+  canonical single read hides it. Revision history discloses *more* than a single
+  action trigger, so its gate must be ≥ the action path's, not a subset. Fixed by
+  extracting `cardCanonicalVisibleToViewer` (visibles / expiry / user-offset /
+  channel-offset) out of `card/action` and calling it from **both** endpoints;
+  the query returns an empty list on a visibility miss (mirrors the withdrawn
+  path, no existence leak). New test `TestCardRevisionsCanonicalVisibility` pins
+  the visibles-excluded and offset-truncated cases. The lesson generalized: a
+  derived surface must match the canonical read in **every** layer, not just the
+  one that was top-of-mind — see the promoted learning.
+- **Best-effort cleanup must run right after the state commit, before any
+  fail-and-return step.** The revoke revision-cleanup was first placed after
+  `SendRevoke`; a `SendRevoke` failure returns early, so the DB would be marked
+  revoked while the revision rows survived. Moved to immediately after the revoke
+  transaction commits (before the notify loop). The query-side withdraw gate is
+  the second layer so a delete failure still can't leak.
+
+## Out of scope (sibling PR)
+
+D12 capability manifest (`GET /v1/bot/card/profile`) → PR-D.

--- a/.octospec/learnings/pending/card-message-p2-revision-history.md
+++ b/.octospec/learnings/pending/card-message-p2-revision-history.md
@@ -1,0 +1,76 @@
+---
+type: Learning
+title: "Every new read/write path over a message must reapply the visibility gate — not rely on cleanup"
+description: New endpoints touching a message (actions, history, projections) must reapply the revoke/is_deleted/user-local-delete visibility gate the single-message read applies; deleting derived data on revoke is a best-effort second layer, never the sole guarantee.
+tags: ["trust-boundary", "space", "isolation", "visibility", "message", "review"]
+timestamp: 2026-07-08T11:30:00Z
+# --- octospec extension fields ---
+source: self
+origin_task: card-message-p2-revision-history
+origin_pr: self
+status: pending
+candidate_rule: space-isolation
+---
+
+# Every new read/write path over a message must reapply the visibility gate — not rely on cleanup
+
+## Context
+
+This gap surfaced **three times** across the card message P2 PRs, on two
+different endpoints and across two *dimensions* of the canonical read gate:
+
+- **PR-B** (`POST /v1/message/card/action`): first shipped reading
+  `message_extra` only for `content_edit`, so a **revoked / deleted** card was
+  still actionable (a stale tap drove a bot event after the card was recalled).
+- **PR-C** (`GET /v1/message/card/revisions`), lifecycle dimension: first
+  shipped with only the channel-membership gate, so a **revoked / globally-deleted /
+  operator-locally-deleted** card's revision *content* was still queryable as
+  long as the rows existed.
+- **PR-C review B1** (`GET /v1/message/card/revisions`), canonical-visibility
+  dimension: even after the lifecycle gate was added, the query still enforced a
+  strict **subset** of the canonical read — it omitted the `visibles` allowlist,
+  the per-user read offset, the channel offset, and message expiry. A group
+  member excluded by a non-empty `visibles`, or whose read/channel offset was
+  past the message (cleared history), could still read the full revision history
+  (`full=1` → complete historical envelopes) though the canonical single read
+  would hide it. Fixed by extracting `cardCanonicalVisibleToViewer` (visibles /
+  expiry / offset) and calling it from **both** `card/action` and the query, so
+  the two endpoints share one visibility口径.
+
+Each time the established single-message read path (`respondSingleMessage` /
+`api_message_get.go`) already had the correct, complete gate — and each new
+endpoint reapplied only *part* of it. The canonical read is the reference; a
+derived surface must match it in **every** layer (membership + group/thread
+status + lifecycle revoke/delete + visibles + offset + expiry), not just the
+layer that was top-of-mind.
+
+A tempting-but-wrong mitigation on PR-C was "delete the derived rows on revoke."
+That does not cover `is_deleted` (global delete) or user-local delete (neither
+triggers the revoke path), and the delete was best-effort and mis-ordered
+(after the notify step, which could return early). Deletion is a second layer;
+it is never the guarantee.
+
+## The rule
+
+- **Any new endpoint that reads or acts on a stored message** (actions, edit
+  history, revision history, projections, previews, exports) MUST reapply the
+  **complete** visibility gate the canonical single-message read applies, in
+  every layer: channel membership + group/thread status +
+  `message_extra.revoke` / `message_extra.is_deleted` (global) +
+  `message_user_extra.message_is_deleted` (operator) + the `visibles` allowlist +
+  per-user read offset + channel offset + message expiry. Extract each dimension
+  into a shared helper (`authorizeCardChannelMember`, `isCardMessageWithdrawn`,
+  `cardCanonicalVisibleToViewer`) so the endpoints cannot drift and cannot ship a
+  *subset*.
+- **A derived surface must never be MORE permissive than the canonical read.**
+  Reviewers should diff the new gate against `respondSingleMessage` layer by
+  layer; "membership + one lifecycle check" is a subset, not the gate. Revision
+  history in particular discloses *more* than a single action trigger, so its
+  gate must be at least as strict as the action path's.
+- **Actionability and queryability must not outlive visibility.** If a message
+  is not viewable via the normal read, no derived surface may act on it or expose
+  its content.
+- **Cleaning up derived data on revoke is a best-effort second layer, not the
+  primary guarantee.** It must run immediately after the state-change commit and
+  before any step that can fail-and-return (e.g. an IM notify). The read/act path
+  must still gate independently, so a missed/failed cleanup cannot leak.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,25 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-08 (PR-C)
+
+- **Change** — Task `card-message-p2-revision-history` (PR-C, card message P2
+  D10): card revision history. New `octo_message_card_revision` side table +
+  `pkg/cardrevision` shared store (written by bot_api on edits/clear, read by
+  message), `GET /v1/message/card/revisions` (summary / full=1) reusing the
+  extracted `authorizeCardChannelMember` gate, bot revision clear + auditable
+  tombstone, `transient` frame flag (progress frames skip history), and revoke
+  cleanup. Verify caught two P1s (fixed): the query path lacked the
+  revoke/deleted/user-local-delete visibility gate, and the revoke cleanup was
+  mis-ordered after the notify step. Code-review (B1) then caught that the query
+  still enforced a *subset* of the canonical read — missing the `visibles`
+  allowlist / read-offset / channel-offset / expiry layers `card/action` carries;
+  fixed by extracting `cardCanonicalVisibleToViewer` and sharing it across both
+  endpoints (+ `TestCardRevisionsCanonicalVisibility`). Stacked on PR-B; zero
+  octo-im changes. Journal:
+  `.octospec/journal/shared/card-message-p2-revision-history.md`;
+  learning: `.octospec/learnings/pending/card-message-p2-revision-history.md`.
+
 ## 2026-07-08
 
 - **Change** — Task `card-message-p2-action-loop` (PR-B, card message P2

--- a/.octospec/tasks/card-message-p2-revision-history/brief.md
+++ b/.octospec/tasks/card-message-p2-revision-history/brief.md
@@ -1,0 +1,181 @@
+---
+type: Task
+title: "Task: card-message-p2-revision-history"
+description: PR-C of the card message P2 protocol — D10 card revision history. A side table octo_message_card_revision appended by the botMessageEdit card branch (non-transient frames only, cap 20), a GET /v1/message/card/revisions query API (Auth → Space → SharedUIDRateLimiter + channel-membership, same gate as card/action), an optional envelope `transient` flag that keeps progress frames out of history, bot-driven revision clearing that writes an auditable tombstone row, and revision cleanup on message revoke. Stacks on PR-B. Zero octo-im changes.
+tags: ["message", "card", "wire-contract", "bot-api", "rate-limit", "space", "isolation", "error-response", "i18n", "testing"]
+timestamp: 2026-07-08T10:00:00Z
+# --- octospec extension fields ---
+slug: card-message-p2-revision-history
+upstream: self
+source: self
+---
+
+# Task: card-message-p2-revision-history
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+Ship **D10 of the card message P2 contract** (`card-message-interaction`): a
+queryable **card revision history**. The full-frame-replacement model of D6
+(each `botMessageEdit` overwrites `message_extra.content_edit` with a complete
+new envelope, latest-frame-only) means the message table cannot answer "这张卡
+以前是什么" — which approval-class cards owe their audience. PR-C adds a side
+table that records each non-transient frame as a complete renderable envelope,
+plus a member-visible query API.
+
+```
+bot rewrites card → botMessageEdit content_edit (PR-B D6/D9)
+                  → IF NOT transient: append octo_message_card_revision row (frame + plain + editor + time)
+                  → cap 20 non-transient frames/message (oldest evicted)
+member opens history → GET /v1/message/card/revisions (Auth → Space → UID-limit + membership)
+                     → summary list by default; ?full=1 returns full renderable frames
+bot clears history → tombstone row (editor + time + cleared count), itself visible in the listing
+message revoked    → revisions deleted (a revoked message leaves no queryable content history)
+```
+
+**Stacking**: PR-C builds on **PR-B** (`feat/card-message-p2-action-loop`,
+#548) — it hooks the revision append into PR-B's D6 `botMessageEdit` card branch
+and reuses PR-B's `pkg/cardmsg` type-17 helpers. PR-C's PR is opened with
+**base = PR-B's branch** (stacked diff), retargeted to `main` after PR-B merges.
+
+## Decisions (inherited from D10, with implementation-level bindings)
+
+| # | Decision | Binding |
+|---|---|---|
+| D10.1 | **Side table = `octo_message_card_revision`** (NOT the brief's illustrative `message_card_revision` — repo rule: new tables MUST carry the `octo_` prefix, `dm_`/prefix-less reserved for legacy). Columns: `message_id`, `channel_id`, `channel_type`, `card_seq` (nullable — the frame's D9 seq if any), `content` TEXT (full renderable frame envelope; NULL for tombstone), `plain` (list summary; NULL for tombstone), `is_tombstone`, `cleared_count`, `editor_uid`, `edited_at`, + `db.BaseModel`. Index `(message_id, id)`. Shared-table pattern like `message_extra`: **written by `modules/bot_api` raw SQL, read by `modules/message`** — no cross-module service dependency. Migration lives in `modules/message/sql/`. | new migration + db layer |
+| D10.2 | **Appended by the D6 `botMessageEdit` card branch** (`modules/bot_api/send.go`, PR-B), alongside the `content_edit` overwrite, **only for non-transient frames**. `content_edit` storage stays latest-frame-only (render path unchanged); the revision table is the history surface. `editor_uid` = the editing bot. Append is best-effort-after-commit relative to the content write: the card update MUST NOT fail if the revision append fails (log + continue), since the durable card state is `content_edit`, not the history. | send.go card branch |
+| D10.3 | **Cap 20 non-transient frames per message** (tunable const). On append, evict the oldest frame rows beyond the cap for that `message_id`. Tombstone rows are audit markers, not frames — they do NOT count toward the cap and are not evicted by it. | append + prune |
+| D10.4 | **Envelope gains optional `transient: true`** — progress frames (thinking / tool-state) marked transient are applied to `content_edit` normally (D6/D9 unchanged) but **never enter the revision table**, so approval-state changes aren't drowned by progress noise. `cardmsg` gains a `Transient(payload)` reader (mirrors `CardSeq`); `transient` is a tolerated optional envelope field (forward-compat, not whitelisted per-element). | pkg/cardmsg + send.go |
+| D10.5 | **Query API `GET /v1/message/card/revisions`** — `AuthMiddleware` → Space → `SharedUIDRateLimiter` + **channel-membership check identical to `card/action`** (D3 anti-IDOR: bind channel from the stored message row, then membership of that channel). Request: `message_id`, `channel_id`, `channel_type` (channel params are the anti-IDOR lookup key, same as card/action — NOT taken as an authorization subject), `limit`, `full`. Default returns a summary list (`card_seq`/`plain`/`editor_uid`/`edited_at` + tombstone rows); `full=1` returns each frame's complete envelope. Visibility = **all channel members** (same permission as message edit history, D10(a)). | new message endpoint |
+| D10.6 | **Erasure allowed but explicitly recorded** (D10(b)): a bot may clear its own card's revisions via a new bot endpoint (bot-token, must own the message). Clearing deletes the frame rows and writes a **tombstone row** (`is_tombstone=1`, `cleared_count`, `editor_uid`, `edited_at`) that itself appears in the history — erasure is auditable, not silent. | new bot endpoint |
+| D10.7 | **Revoke deletes revisions** (D10(b)): when a message is revoked (`modules/message` revoke path), its `octo_message_card_revision` rows are deleted (best-effort) — a revoked message leaves no queryable content history. | revoke hook |
+
+## API surface (wire definitions)
+
+**`GET /v1/message/card/revisions?message_id=&channel_id=&channel_type=&limit=&full=`**
+(new — Auth → Space → SharedUIDRateLimiter + membership):
+
+```json
+// summary mode (default); full=1 adds a "card": {…full envelope…} field per non-tombstone row
+{ "revisions": [
+    { "card_seq": 2, "plain": "审批单 #42:✅ 已通过", "editor_uid": "bot_x", "edited_at": 1751791500 },
+    { "tombstone": true, "cleared": 3, "editor_uid": "bot_x", "edited_at": 1751791400 },
+    { "card_seq": 1, "plain": "审批单 #42:待审批", "editor_uid": "bot_x", "edited_at": 1751791234 } ] }
+// newest-first; errors: non-member 403-class / non-card message / channel mismatch → i18n envelope
+```
+
+**`POST /v1/bot/message/card/revisions/clear`** (new — bot-token, same middleware
+chain as other `bot_api` routes):
+
+```json
+{ "message_id": "8234567890123456789", "channel_id": "g_9f2c...", "channel_type": 2 }
+// bot must own the target message (sender == robotID); deletes frame rows, writes a tombstone.
+// errors: not-owner / non-card / non-bot-sender → i18n envelope
+```
+
+**`transient` on the type-17 edit envelope** (D10.4) — optional, consumed by the
+D6 `botMessageEdit` branch:
+
+```json
+{ "type": 17, "card": {...}, "card_version": "1.5", "profile": "octo/v2",
+  "card_seq": 5, "transient": true }
+// transient:true → content_edit updated (D6/D9), NO revision row appended.
+```
+
+Authoritative doc `docs/card-protocol.md` already carries the D10 contract (P1
+deliverable) — implementation must not drift; amend doc + brief together or not
+at all.
+
+## Load-bearing list
+<!-- touches tags: wire-contract, bot-api, rate-limit, space, isolation,
+     error-response, i18n, testing -->
+
+- **New side table `octo_message_card_revision`** (`wire-contract`): shared-table
+  pattern (written by `bot_api`, read by `message`, like `message_extra`).
+  Migration in `modules/message/sql/` following the repo's plain-DDL / `octo_`
+  prefix / MySQL-8 conventions. The revision-row shape (frame + plain + editor +
+  time + tombstone) is a stored contract the query API projects.
+- **`botMessageEdit` card branch append** (`bot-api`): `modules/bot_api/send.go`
+  (PR-B's D6 branch) gains a post-content-write revision append for non-transient
+  frames + cap-20 prune. **The card update MUST NOT fail if the append fails** —
+  `content_edit` is the durable state; the history is a secondary surface (log on
+  append error, still return OK + fire the CMD).
+- **New authenticated read endpoint `GET /v1/message/card/revisions`**
+  (`rate-limit`, `space`, `isolation`, `wire-contract`): mounted on the existing
+  `/v1/message` group (Auth → SharedUIDRateLimiter → Space, mount order per repo
+  rule). **The channel-membership + anti-IDOR binding MUST be identical to
+  `card/action`** (bind channel from the stored row, membership of that channel,
+  `ExistMemberActive` for group/topic, fake-channel containment for person). To
+  avoid drift, factor the card-message member gate into a shared helper reused by
+  both `cardAction` and the revisions handler (touches PR-B's
+  `api_card_action.go`).
+- **New bot clear endpoint `POST /v1/bot/message/card/revisions/clear`**
+  (`bot-api`, `trust-boundary`): bot ownership (sender == robotID) validated
+  before clearing, mirroring `botMessageEdit`'s YUJ-60-lineage own-message guard.
+  Writes a tombstone row (auditable erasure).
+- **Revoke hook** (`message`): the `revoke` path deletes the message's revision
+  rows (best-effort; must not fail the revoke).
+- **`transient` envelope field** (`wire-contract`): `pkg/cardmsg.Transient`
+  reader; tolerated optional field, not per-element whitelisted.
+- **Error responses** (`error-response`, `i18n`): all new rejections via
+  `httperr.ResponseErrorL` + registered `pkg/errcode` codes + zh-CN; i18n
+  make-target suite green; new handler files join the module
+  `Test<Module>NoLegacyResponseError` guard lists.
+- **Protocol doc**: `docs/card-protocol.md` D10 section — no drift.
+
+## Out of scope
+
+- **PR-B surface** (D3–D9/D11 + octo/v2 whitelist): shipped in #548, this PR
+  stacks on it and only adds the D10 delta.
+- **D12 capability manifest** (`GET /v1/bot/card/profile`) — sibling PR-D.
+- **P3**: `Action.Execute`/auto-refresh, per-element `fallback`, templating,
+  bot-side real-time delivery.
+- **octo-im**: zero code changes (history is a pure octo-server read surface;
+  no CMD/refresh change — the revision table is queried on demand, not synced).
+- **Client history UI**: client repos render the revisions response; not here.
+- **Revision diffing / partial-frame history**: only complete-frame snapshots
+  are stored (the D6 full-replacement model makes each frame independently
+  renderable); no structural diff between frames.
+- **Editing/attributing non-bot revisions**: only bot card edits produce
+  revisions (P2 keeps cards bot-sender-only); no human/OBO revision authorship.
+
+## Acceptance
+
+All machine-checkable unless noted:
+
+- `go test ./pkg/cardmsg/... ./modules/message/... ./modules/bot_api/...` pass;
+  `make i18n-extract && make i18n-extract-check && make i18n-lint` green with
+  zh-CN entries; `golangci-lint run ./...` clean; guard tests updated.
+- **Append (D10.2/D10.3)**: a non-transient card edit appends exactly one
+  revision row (`content` = the full frame, `plain` = server-recomputed summary,
+  `editor_uid` = the bot, `card_seq` carried through) while `content_edit` still
+  holds only the latest frame; a **`transient: true`** edit updates `content_edit`
+  (D6/D9 intact) but appends **nothing**; the 21st non-transient frame evicts the
+  oldest so the table holds ≤ 20 frame rows for that message; an append failure
+  does **not** fail the card edit (edit still returns OK, CMD still fires —
+  asserted with an injected append error).
+- **Query API (D10.5)**: a channel member gets the message's revisions
+  newest-first (summary shape by default; `full=1` returns each frame's complete
+  envelope, and each returned frame validates through `cardmsg.Validate`); a
+  **non-member → 403-class** i18n envelope; a **cross-channel IDOR** (member of A
+  submits a `message_id` in B with A's `channel_id`) → rejected (same stored-row
+  binding assertions as `card/action`, for both person and group channels); a
+  non-card / non-existent message → 400-class.
+- **Clear + tombstone (D10.6)**: a bot clearing its own card's revisions deletes
+  the frame rows and appends a tombstone row (`tombstone:true`, `cleared:N`,
+  `editor_uid`, `edited_at`) that appears in the subsequent listing; a bot
+  clearing **another** bot's card → rejected (ownership).
+- **Revoke cleanup (D10.7)**: revoking a card message deletes its revision rows
+  (a subsequent revisions query returns empty); revoke still succeeds if the
+  revision delete errors (best-effort).
+- **Rate limiting**: the revisions route inherits `SharedUIDRateLimiter` after
+  auth on the `/v1/message` group (bucket reset in test setup per testing rule).
+- **Member gate parity**: the extracted shared card-message member gate is used
+  by BOTH `cardAction` and the revisions handler (asserted by a test exercising
+  the same non-member / IDOR rejections on the revisions route).
+- **Migration**: `octo_message_card_revision` created via a
+  `modules/message/sql/` migration; naming/engine/charset consistent with
+  existing scripts; `octo_` prefix.
+- `docs/card-protocol.md` D10 section matches this brief (human-reviewed).

--- a/.octospec/tasks/card-message-p2-revision-history/context.yaml
+++ b/.octospec/tasks/card-message-p2-revision-history/context.yaml
@@ -1,0 +1,12 @@
+injected:
+  - id: error-handling
+    source: repo
+  - id: rate-limit
+    source: repo
+  - id: space-isolation
+    source: repo
+  - id: trust-boundary
+    source: repo
+  - id: testing
+    source: repo
+brief: .octospec/tasks/card-message-p2-revision-history/brief.md

--- a/modules/bot_api/api_i18n_test.go
+++ b/modules/bot_api/api_i18n_test.go
@@ -37,6 +37,7 @@ func TestBotAPINoLegacyResponseError(t *testing.T) {
 		"auth.go", "register.go", "commands.go", "events.go", "mention_pref.go",
 		"sync.go", "typing.go", "send.go", "threads.go", "file.go", "groups.go",
 		"voice_adapter.go", "obo_api.go", "resolve_targets.go", "incoming_webhook.go",
+		"card_revision.go",
 	}
 	banned := []string{
 		".ResponseError(",

--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/modules/voice_adapter"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardrevision"
 )
 
 const (
@@ -47,6 +48,9 @@ type BotAPI struct {
 	// AFTER dispatchFanout succeeds so we only enqueue events that
 	// WuKongIM actually accepted.
 	robotService          robot.IService
+	// cardRevisions is the D10 card revision history store (shared table
+	// octo_message_card_revision; written here on bot card edits + clear).
+	cardRevisions         *cardrevision.Store
 	speechClient          *voice_adapter.SpeechClient
 	maxVoiceContextLength int
 	maxBodySize           int64
@@ -182,6 +186,7 @@ func NewBotAPI(ctx *config.Context) *BotAPI {
 		userDB:                user.NewDB(ctx),
 		threadService:         thread.NewService(ctx),
 		robotService:          robot.NewService(ctx),
+		cardRevisions:         cardrevision.NewStore(ctx.DB()),
 		speechClient:          voice_adapter.NewSpeechClient(speechURL, speechKey, time.Duration(timeoutSec)*time.Second),
 		maxVoiceContextLength: maxCtxLen,
 		maxBodySize:           maxBodySize,
@@ -243,6 +248,7 @@ func (ba *BotAPI) Route(r *wkhttp.WKHttp) {
 		botAPI.GET("/upload/credentials", ba.botUploadCredentials)
 		botAPI.GET("/upload/presigned", ba.botUploadPresigned)
 		botAPI.POST("/message/edit", ba.botMessageEdit)
+		botAPI.POST("/message/card/revisions/clear", ba.botCardRevisionsClear) // D10.6 清除卡片修订(写墓碑)
 		botAPI.GET("/user/info", ba.getUserInfo)
 		// Voice context API (User Bot only)
 		botAPI.PUT("/voice/context", ba.botPutVoiceContext)

--- a/modules/bot_api/card_p2_edit_im_test.go
+++ b/modules/bot_api/card_p2_edit_im_test.go
@@ -506,3 +506,91 @@ func TestBotCardEditOwnershipAndLifecycleIM(t *testing.T) {
 	_ = ctx.DB().Select("content_edit").From("message_extra").Where("message_id=?", ownID).LoadOne(&edited)
 	assert.NotContains(t, edited, "done_btn", "撤回卡片编辑不得写入 content_edit")
 }
+
+// TestBotCardRevisionsIM 验证 D10：非 transient 卡片编辑追加修订帧、transient 帧不
+// 入历史、清除端点删帧 + 写墓碑（需 WuKongIM）。
+func TestBotCardRevisionsIM(t *testing.T) {
+	skipWithoutIMBot(t)
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	s, ctx := testutil.NewTestServer()
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+
+	const revBot, revTok = "bot_card_rev", "bf_card_rev_token"
+	_, err := ctx.DB().InsertBySql("insert into robot(robot_id,bot_token,status) values(?,?,1)", revBot, revTok).Exec()
+	assert.NoError(t, err)
+	for _, pair := range [][2]string{{revBot, testutil.UID}, {testutil.UID, revBot}} {
+		_, ferr := ctx.DB().InsertBySql("insert into friend(uid,to_uid,is_deleted) values(?,?,0)", pair[0], pair[1]).Exec()
+		assert.NoError(t, ferr)
+	}
+	do := func(path string, body map[string]interface{}) *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", path, bytes.NewReader([]byte(util.ToJson(body))))
+		req.Header.Set("Authorization", "Bearer "+revTok)
+		s.GetRoute().ServeHTTP(w, req)
+		return w
+	}
+	frameCount := func(msgID string) int {
+		var n int
+		_ = ctx.DB().Select("count(*)").From("octo_message_card_revision").Where("message_id=? and is_tombstone=0", msgID).LoadOne(&n)
+		return n
+	}
+	tombstoneCount := func(msgID string) int {
+		var n int
+		_ = ctx.DB().Select("count(*)").From("octo_message_card_revision").Where("message_id=? and is_tombstone=1", msgID).LoadOne(&n)
+		return n
+	}
+
+	w := do("/v1/bot/sendMessage", map[string]interface{}{
+		"channel_id": testutil.UID, "channel_type": common.ChannelTypePerson.Uint8(),
+		"payload": imCardEnvelope("s0", -1),
+	})
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var sendResp struct {
+		MessageID int64 `json:"message_id"`
+	}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &sendResp))
+	msgID := fmt.Sprintf("%d", sendResp.MessageID)
+	var msgSeq uint32
+	for i := 0; i < 20; i++ {
+		sr, serr := ctx.IMSearchMessages(&config.MsgSearchReq{
+			ChannelID: testutil.UID, ChannelType: common.ChannelTypePerson.Uint8(),
+			MessageIds: []int64{sendResp.MessageID}, LoginUID: revBot,
+		})
+		if serr == nil && sr != nil && len(sr.Messages) > 0 && sr.Messages[0].MessageSeq > 0 {
+			msgSeq = sr.Messages[0].MessageSeq
+			break
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	assert.NotZero(t, msgSeq)
+	edit := func(env map[string]interface{}) *httptest.ResponseRecorder {
+		return do("/v1/bot/message/edit", map[string]interface{}{
+			"message_id": msgID, "message_seq": msgSeq,
+			"channel_id": testutil.UID, "channel_type": common.ChannelTypePerson.Uint8(),
+			"content_edit": util.ToJson(env),
+		})
+	}
+
+	// ① 非 transient 编辑 → 追加 1 帧。
+	assert.Equal(t, http.StatusOK, edit(imCardEnvelope("s1", 2)).Code)
+	assert.Equal(t, 1, frameCount(msgID))
+
+	// ② transient 编辑 → content_edit 更新但不入历史（仍 1 帧）。
+	transient := imCardEnvelope("s2", 3)
+	transient["transient"] = true
+	assert.Equal(t, http.StatusOK, edit(transient).Code)
+	assert.Equal(t, 1, frameCount(msgID), "transient 帧不入修订历史")
+
+	// ③ 再一次非 transient 编辑 → 2 帧。
+	assert.Equal(t, http.StatusOK, edit(imCardEnvelope("s3", 4)).Code)
+	assert.Equal(t, 2, frameCount(msgID))
+
+	// ④ 清除端点：删帧 + 写墓碑。
+	w = do("/v1/bot/message/card/revisions/clear", map[string]interface{}{
+		"message_id": msgID, "channel_id": testutil.UID, "channel_type": common.ChannelTypePerson.Uint8(),
+	})
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), `"cleared":2`)
+	assert.Equal(t, 0, frameCount(msgID), "清除后无帧")
+	assert.Equal(t, 1, tombstoneCount(msgID), "清除写一条墓碑")
+}

--- a/modules/bot_api/card_revision.go
+++ b/modules/bot_api/card_revision.go
@@ -1,0 +1,98 @@
+package bot_api
+
+// card-message-interaction P2 D10.6：bot 清除自己卡片的修订历史（可审计的擦除）。
+// 删除该消息的全部非墓碑帧并写一条墓碑行（editor+时间+清除帧数），墓碑本身出现在
+// 历史列表里 —— 擦除有据可查，不是静默删除。
+//
+// POST /v1/bot/message/card/revisions/clear —— bot-token 鉴权（与其它 bot_api 路由
+// 同中间件链），属主校验（消息 from_uid == 调用 bot）沿用 botMessageEdit 的
+// YUJ-60-lineage 归属守卫。
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"go.uber.org/zap"
+)
+
+// botCardRevisionsClear handles POST /v1/bot/message/card/revisions/clear.
+func (ba *BotAPI) botCardRevisionsClear(c *wkhttp.Context) {
+	var req struct {
+		MessageID   string `json:"message_id"`
+		ChannelID   string `json:"channel_id"`
+		ChannelType uint8  `json:"channel_type"`
+	}
+	if err := c.BindJSON(&req); err != nil {
+		respondBotAPIRequestInvalid(c, "")
+		return
+	}
+	if strings.TrimSpace(req.MessageID) == "" {
+		respondBotAPIRequestInvalid(c, "message_id")
+		return
+	}
+	if strings.TrimSpace(req.ChannelID) == "" {
+		respondBotAPIRequestInvalid(c, "channel_id")
+		return
+	}
+	if req.ChannelType == 0 {
+		respondBotAPIRequestInvalid(c, "channel_type")
+		return
+	}
+	if !cardmsg.Enabled() {
+		httperr.ResponseErrorL(c, errcode.ErrBotAPICardDisabled, nil, nil)
+		return
+	}
+	robotID := getRobotIDFromContext(c)
+
+	msgIDInt, perr := strconv.ParseInt(req.MessageID, 10, 64)
+	if perr != nil {
+		respondBotAPIRequestInvalid(c, "message_id")
+		return
+	}
+	// 属主 + 卡片校验：按 message_id 查存储消息，验证 sender==调用 bot（YUJ-60 归属）
+	// 且为 type-17 卡片（对非卡片写墓碑无意义）。
+	syncResp, err := ba.ctx.IMSearchMessages(&config.MsgSearchReq{
+		ChannelID:   req.ChannelID,
+		ChannelType: req.ChannelType,
+		MessageIds:  []int64{msgIDInt},
+		LoginUID:    robotID,
+	})
+	if err != nil {
+		ba.Error("查询卡片修订清除目标消息失败", zap.Error(err), zap.String("messageID", req.MessageID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
+		return
+	}
+	if syncResp == nil || len(syncResp.Messages) == 0 {
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIMessageNotFound, nil, nil)
+		return
+	}
+	if syncResp.Messages[0].FromUID != robotID {
+		ba.Warn("非属主 bot 清除卡片修订,拒绝", zap.String("fromUID", syncResp.Messages[0].FromUID), zap.String("robotID", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPICardRevisionClearForbidden, nil, nil)
+		return
+	}
+	if !cardmsg.IsCardRawPayload(syncResp.Messages[0].Payload) {
+		respondBotAPIRequestInvalid(c, "message_id")
+		return
+	}
+
+	// 墓碑行的 channel_id 与帧行同口径（person 频道用 fakeChannelID）。
+	fakeChannelID := req.ChannelID
+	if req.ChannelType == common.ChannelTypePerson.Uint8() {
+		fakeChannelID = common.GetFakeChannelIDWith(robotID, req.ChannelID)
+	}
+	cleared, err := ba.cardRevisions.Clear(req.MessageID, fakeChannelID, req.ChannelType, robotID, time.Now().Unix())
+	if err != nil {
+		ba.Error("清除卡片修订失败", zap.Error(err), zap.String("messageID", req.MessageID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
+		return
+	}
+	c.Response(map[string]interface{}{"cleared": cleared})
+}

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardrevision"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
@@ -973,6 +974,27 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 			ba.Error("card 编辑(无 card_seq)写入失败！", zap.Error(werr), zap.String("messageID", req.MessageID))
 			httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 			return
+		}
+	}
+
+	// P2 D10：非 transient 卡片帧追加修订历史（best-effort —— content_edit 已是
+	// 权威状态，history 是次级面，append 失败只记日志、不阻断编辑）。richtext 编辑
+	// 与 transient 进度帧不入历史。
+	if editIsCard && !cardmsg.TransientFromContentEdit(req.ContentEdit) {
+		rev := cardrevision.Revision{
+			MessageID:   req.MessageID,
+			ChannelID:   fakeChannelID,
+			ChannelType: req.ChannelType,
+			Content:     dbr.NewNullString(req.ContentEdit),
+			Plain:       cardmsg.PlainFromContentEdit(req.ContentEdit),
+			EditorUID:   robotID,
+			EditedAt:    int64(editedAt),
+		}
+		if hasCardSeq {
+			rev.CardSeq = dbr.NewNullInt64(cardSeq)
+		}
+		if rerr := ba.cardRevisions.AppendFrame(rev); rerr != nil {
+			ba.Error("卡片修订历史追加失败(不影响编辑)", zap.Error(rerr), zap.String("messageID", req.MessageID))
 		}
 	}
 

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardrevision"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
@@ -228,6 +229,9 @@ type Message struct {
 	threadDB       *thread.DB
 	// cardClaims card/action 的 D4 幂等 claim 存储（card_action_claims.go）。
 	cardClaims *cardActionClaimStore
+	// cardRevisions D10 卡片修订历史 store（共享表 octo_message_card_revision；
+	// 此处读查询 + 撤回删除）。
+	cardRevisions *cardrevision.Store
 	// groupDB: 直查 group 表，区分"群不存在"和"群已解散"两种 404 情况，
 	// groupService.GetGroupWithGroupNo 把 nil 也包成 error 不便分辨。
 	groupDB  *group.DB
@@ -276,6 +280,7 @@ func New(ctx *config.Context) *Message {
 		threadDB:       thread.NewDB(ctx),
 		groupDB:        group.NewDB(ctx),
 		cardClaims:     newCardActionClaimStore(ctx),
+		cardRevisions:  cardrevision.NewStore(ctx.DB()),
 		stopChan:       make(chan struct{}),
 	}
 	m.ctx.AddEventListener(event.GroupMemberAdd, m.handleGroupMemberAddEvent)
@@ -310,6 +315,7 @@ func (m *Message) Route(r *wkhttp.WKHttp) {
 		message.GET("/sync/sensitivewords", m.syncSensitiveWords) // 同步敏感词
 		message.POST("/edit", m.messageEdit)                      // 消息编辑
 		message.POST("/card/action", m.cardAction)                // 卡片动作上行（card-message-interaction P2 D3）
+		message.GET("/card/revisions", m.getCardRevisions)        // 卡片修订历史查询（P2 D10）
 		message.POST("/reminder/sync", m.reminderSync)            // 同步提醒
 		message.POST("/reminder/done", m.reminderDone)            // 提醒已处理完成
 		message.GET("/prohibit_words/sync", m.syncProhibitWords)  // 同步违禁词
@@ -2824,6 +2830,15 @@ func (m *Message) revoke(c *wkhttp.Context) {
 	}
 	if eventID > 0 {
 		m.ctx.EventCommit(eventID)
+	}
+	// P2 D10.7：撤回提交后立即删除卡片修订历史（best-effort）—— 必须在 SendRevoke
+	// 通知**之前**，否则通知失败提前返回会漏删，DB 已标撤回却留下可查询内容历史。
+	// 非卡片消息为 no-op。查询端另有 revoke/deleted 可见性兜底（isCardMessageWithdrawn），
+	// 两层都在，删除失败也不会泄漏。
+	if cardmsg.IsCardRawPayload(message.Payload) {
+		if derr := m.cardRevisions.DeleteByMessageID(messageIDStr); derr != nil {
+			m.Error("撤回卡片时删除修订历史失败(不影响撤回;查询端有可见性兜底)", zap.Error(derr), zap.String("messageID", messageIDStr))
+		}
 	}
 	for _, msgID := range msgIds {
 		messageIDI, _ := strconv.ParseInt(msgID, 10, 64)

--- a/modules/message/api_card_action.go
+++ b/modules/message/api_card_action.go
@@ -35,6 +35,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
 	"go.uber.org/zap"
 )
 
@@ -78,98 +79,12 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 		return
 	}
 
-	// D3 ①存储行定位 + 频道绑定（round-3 P1-4 anti-IDOR）。消息表按 channel_id
-	// 分表路由，查询 WHERE 同时钉 (channel_id, channel_type, message_id) —— 查得到
-	// 即证明「请求声明的频道 == 存储行的频道」；不一致/不存在统一 400（防枚举，
-	// 两者不可区分）。person 频道的 fake id 由 (loginUID, 对端) 生成，指着别人
-	// 会话的 message_id 天然查不到。
-	lookupChannelID := req.ChannelID
-	switch req.ChannelType {
-	case common.ChannelTypePerson.Uint8():
-		lookupChannelID = common.GetFakeChannelIDWith(loginUID, req.ChannelID)
-	case common.ChannelTypeGroup.Uint8(), common.ChannelTypeCommunityTopic.Uint8():
-		// group / topic：消息就存于声明频道本身。
-	default:
-		respondMessageRequestInvalid(c, "channel_type")
+	// D3 ①②：anti-IDOR 频道绑定 + 存储频道成员资格（抽为共享门禁，与卡片修订查询
+	// 复用同一口径，避免两端授权漂移）。
+	msgM, handled := m.authorizeCardChannelMember(c, loginUID, req.MessageID, req.ChannelID, req.ChannelType,
+		errcode.ErrMessageCardActionInvalid, errcode.ErrMessageCardActionDenied)
+	if handled {
 		return
-	}
-	msgM, err := m.db.queryMessageByID(lookupChannelID, req.ChannelType, req.MessageID)
-	if err != nil {
-		m.Error("查询卡片动作目标消息失败", zap.Error(err), zap.String("messageID", req.MessageID))
-		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
-		return
-	}
-	if msgM == nil || len(msgM.Payload) == 0 || !cardmsg.IsCardRawPayload(msgM.Payload) {
-		httperr.ResponseErrorL(c, errcode.ErrMessageCardActionInvalid, nil, nil)
-		return
-	}
-
-	// D3 ②成员资格 —— 判定对象取自存储行（assert, don't assume：即使 WHERE 已
-	// 证明一致，这里也只读 msgM.* 而非 req.*，让「存储行是授权主体」在代码形状上
-	// 成立）。person：操作者必须是存储 fake 频道的会话双方之一；group/topic：显式
-	// 成员校验（ExistMemberActive 单点查询 —— 白名单变体，排除被拉黑成员）。
-	switch msgM.ChannelType {
-	case common.ChannelTypePerson.Uint8():
-		if !fakeChannelContainsUID(msgM.ChannelID, loginUID) {
-			httperr.ResponseErrorL(c, errcode.ErrMessageCardActionDenied, nil, nil)
-			return
-		}
-	default:
-		groupNo := msgM.ChannelID
-		var threadShortID string
-		if msgM.ChannelType == common.ChannelTypeCommunityTopic.Uint8() {
-			parent, shortID, perr := thread.ParseChannelID(msgM.ChannelID)
-			if perr != nil {
-				respondMessageRequestInvalid(c, "channel_id")
-				return
-			}
-			groupNo = parent
-			threadShortID = shortID
-		}
-		// D3 ②群状态门禁(PR#548 review H1/P1-a)：复刻单条读 requireGroupMember
-		// (api_message_get.go:184) —— 仅 GroupStatusNormal + Disband 可见,Disabled
-		// (管理员禁用)及未来非正常状态 fail closed。原动作路径只查成员资格、漏了群状态：
-		// 禁用群会置 group.Status=Disabled 但成员行仍 status=Normal、ExistMemberActive
-		// 照样为 true —— 于是被禁用群里的成员读路径已 404,却仍能枚举 message_id 触发
-		// bot 副作用。归并单一 invalid(防枚举)。Disband 与读路径同口径放行(bot 编辑路径
-		// 自身 isGroupDisbanded 拦解散群,副作用无法落地,不在此额外收紧)。
-		statusVisible, serr := m.groupStatusVisibleForAction(groupNo)
-		if serr != nil {
-			m.Error("查询群状态失败", zap.Error(serr), zap.String("groupNo", groupNo))
-			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
-			return
-		}
-		if !statusVisible {
-			m.Warn("卡片动作目标群非可见状态,拒绝", zap.String("groupNo", groupNo))
-			httperr.ResponseErrorL(c, errcode.ErrMessageCardActionInvalid, nil, nil)
-			return
-		}
-		// D3 ②子区状态门禁(PR#548 review P2-a)：复刻单条读 getThreadMessage
-		// (api_message_get.go:139) —— 已删除子区(ThreadStatusDeleted)按不存在处理;
-		// 归档子区允许(读历史,与读路径同口径)。
-		if threadShortID != "" {
-			t, terr := m.threadDB.QueryByGroupNoAndShortID(groupNo, threadShortID)
-			if terr != nil {
-				m.Error("查询子区失败", zap.Error(terr), zap.String("groupNo", groupNo), zap.String("shortID", threadShortID))
-				httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
-				return
-			}
-			if t == nil || t.Status == thread.ThreadStatusDeleted {
-				m.Warn("卡片动作目标子区已删除,拒绝", zap.String("groupNo", groupNo), zap.String("shortID", threadShortID))
-				httperr.ResponseErrorL(c, errcode.ErrMessageCardActionInvalid, nil, nil)
-				return
-			}
-		}
-		isMember, err := m.groupService.ExistMemberActive(groupNo, loginUID)
-		if err != nil {
-			m.Error("查询群成员失败", zap.Error(err), zap.String("groupNo", groupNo))
-			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
-			return
-		}
-		if !isMember {
-			httperr.ResponseErrorL(c, errcode.ErrMessageCardActionDenied, nil, nil)
-			return
-		}
 	}
 
 	// D3 ③sender 必须是 bot 身份（layer (c)）。iwh_ webhook 合成发送者不是 robot
@@ -221,44 +136,17 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 	// respondSingleMessage 同口径 —— 否则被 visibles 排除 / 已清理历史的成员，虽过了
 	// 成员+sender+revoke/删除门禁，仍能枚举可读的 message_id 触发不可见卡片的 bot
 	// 副作用。上面已覆盖 revoke/is_deleted + 操作者本地删除；这里补 visibles 白名单
-	// + 消息过期 + 用户清理偏移 + 频道偏移。全部归并到单一 invalid（防枚举）。
-	// visibles 白名单：基于原始 payload 字节解析，对 type-17 卡片同样生效。
-	if !visiblesAllows(msgM.Payload, loginUID) {
-		m.Warn("卡片动作目标消息 visibles 未命中,拒绝", zap.String("messageID", req.MessageID), zap.String("uid", loginUID))
+	// + 消息过期 + 用户清理偏移 + 频道偏移（抽为 cardCanonicalVisibleToViewer，与
+	// card/revisions 共用同一口径）。查询失败 fail-closed 回 500；不可见归并单一 invalid
+	// （防枚举）。
+	if visible, verr := m.cardCanonicalVisibleToViewer(msgM, loginUID); verr != nil {
+		m.Error("查询卡片动作目标消息可见性失败", zap.Error(verr), zap.String("messageID", req.MessageID))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		return
+	} else if !visible {
+		m.Warn("卡片动作目标消息对操作者不可见,拒绝", zap.String("messageID", req.MessageID), zap.String("uid", loginUID))
 		httperr.ResponseErrorL(c, errcode.ErrMessageCardActionInvalid, nil, nil)
 		return
-	}
-	// 消息自身过期（Expire 秒 TTL，自 Timestamp 起算）—— 与 from() 同口径。
-	if msgM.Expire > 0 && time.Now().Unix()-int64(msgM.Expire) >= int64(msgM.Timestamp) {
-		m.Warn("卡片动作目标消息已过期,拒绝", zap.String("messageID", req.MessageID))
-		httperr.ResponseErrorL(c, errcode.ErrMessageCardActionInvalid, nil, nil)
-		return
-	}
-	// 用户清理偏移 + 频道偏移 —— 消息存储频道 msgM.ChannelID 即读路径 channelID
-	// （group=groupNo / topic=topic 频道）。person 单条读不经 respondSingleMessage、
-	// 偏移语义未确立，跳过（2 方 DM：visibles 恒过，已由成员+生命周期门禁兜住），
-	// 也避免对已是 fake id 的 person 频道二次 fake 化。
-	if msgM.ChannelType != common.ChannelTypePerson.Uint8() {
-		if userOffset, oerr := m.channelOffsetDB.queryWithUIDAndChannel(loginUID, msgM.ChannelID, msgM.ChannelType); oerr != nil {
-			m.Error("查询用户清理偏移失败", zap.Error(oerr), zap.String("messageID", req.MessageID))
-			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
-			return
-		} else if userOffset != nil && msgM.MessageSeq <= userOffset.MessageSeq {
-			m.Warn("卡片动作目标消息在用户清理偏移之前,拒绝", zap.String("messageID", req.MessageID), zap.String("uid", loginUID))
-			httperr.ResponseErrorL(c, errcode.ErrMessageCardActionInvalid, nil, nil)
-			return
-		}
-		channelOffsetSeq, cerr := m.lookupChannelOffsetSeq(msgM.ChannelID, msgM.ChannelType, loginUID)
-		if cerr != nil {
-			m.Error("查询频道偏移失败", zap.Error(cerr), zap.String("messageID", req.MessageID))
-			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
-			return
-		}
-		if channelOffsetSeq != 0 && msgM.MessageSeq <= channelOffsetSeq {
-			m.Warn("卡片动作目标消息在频道偏移之前,拒绝", zap.String("messageID", req.MessageID))
-			httperr.ResponseErrorL(c, errcode.ErrMessageCardActionInvalid, nil, nil)
-			return
-		}
 	}
 
 	// D4 ⑤幂等 claim —— **先于生效帧 / inputs 校验**（P1-4, PR#548 review）。业务
@@ -382,6 +270,98 @@ func fakeChannelContainsUID(fakeChannelID, uid string) bool {
 	return len(parts) == 2 && (parts[0] == uid || parts[1] == uid)
 }
 
+// authorizeCardChannelMember 执行卡片消息端点共享的 D3 ①②：anti-IDOR 频道绑定
+// （按请求声明的频道查存储消息 —— 查得到即证明「声明频道 == 存储行的频道」）+ 存储
+// 频道成员资格（person：会话双方之一；group/topic：ExistMemberActive 白名单单点查）。
+// 成功返回存储消息；失败已写好 i18n 错误响应（绑定/不存在/非卡片 → invalidCode，
+// 非成员 → deniedCode，防枚举）并返回 (nil, true=已处理)。cardAction 与卡片修订查询
+// 共用本门禁，保证两端授权口径不漂移（PR-C brief 要求）。
+func (m *Message) authorizeCardChannelMember(c *wkhttp.Context, loginUID, messageID, channelID string, channelType uint8, invalidCode, deniedCode codes.Code) (*messageModel, bool) {
+	lookupChannelID := channelID
+	switch channelType {
+	case common.ChannelTypePerson.Uint8():
+		lookupChannelID = common.GetFakeChannelIDWith(loginUID, channelID)
+	case common.ChannelTypeGroup.Uint8(), common.ChannelTypeCommunityTopic.Uint8():
+		// group / topic：消息就存于声明频道本身。
+	default:
+		respondMessageRequestInvalid(c, "channel_type")
+		return nil, true
+	}
+	msgM, err := m.db.queryMessageByID(lookupChannelID, channelType, messageID)
+	if err != nil {
+		m.Error("查询卡片消息失败", zap.Error(err), zap.String("messageID", messageID))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		return nil, true
+	}
+	if msgM == nil || len(msgM.Payload) == 0 || !cardmsg.IsCardRawPayload(msgM.Payload) {
+		httperr.ResponseErrorL(c, invalidCode, nil, nil)
+		return nil, true
+	}
+	switch msgM.ChannelType {
+	case common.ChannelTypePerson.Uint8():
+		if !fakeChannelContainsUID(msgM.ChannelID, loginUID) {
+			httperr.ResponseErrorL(c, deniedCode, nil, nil)
+			return nil, true
+		}
+	default:
+		groupNo := msgM.ChannelID
+		var threadShortID string
+		if msgM.ChannelType == common.ChannelTypeCommunityTopic.Uint8() {
+			parent, shortID, perr := thread.ParseChannelID(msgM.ChannelID)
+			if perr != nil {
+				respondMessageRequestInvalid(c, "channel_id")
+				return nil, true
+			}
+			groupNo = parent
+			threadShortID = shortID
+		}
+		// D3 ②群状态门禁(PR#548 review H1/P1-a)：复刻单条读 requireGroupMember
+		// (api_message_get.go:184) —— 仅 GroupStatusNormal + Disband 可见,Disabled
+		// (管理员禁用)及未来非正常状态 fail closed。只查成员资格会漏群状态：禁用群置
+		// group.Status=Disabled 但成员行仍 status=Normal、ExistMemberActive 照样为 true
+		// —— 于是被禁用群里的成员读路径已 404,却仍能枚举 message_id 触发副作用。归并单一
+		// invalid(防枚举)。Disband 与读路径同口径放行。
+		statusVisible, serr := m.groupStatusVisibleForAction(groupNo)
+		if serr != nil {
+			m.Error("查询群状态失败", zap.Error(serr), zap.String("groupNo", groupNo))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+			return nil, true
+		}
+		if !statusVisible {
+			m.Warn("卡片目标群非可见状态,拒绝", zap.String("groupNo", groupNo))
+			httperr.ResponseErrorL(c, invalidCode, nil, nil)
+			return nil, true
+		}
+		// D3 ②子区状态门禁(PR#548 review P2-a)：复刻单条读 getThreadMessage
+		// (api_message_get.go:139) —— 已删除子区(ThreadStatusDeleted)按不存在处理;
+		// 归档子区允许(读历史,与读路径同口径)。
+		if threadShortID != "" {
+			t, terr := m.threadDB.QueryByGroupNoAndShortID(groupNo, threadShortID)
+			if terr != nil {
+				m.Error("查询子区失败", zap.Error(terr), zap.String("groupNo", groupNo), zap.String("shortID", threadShortID))
+				httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+				return nil, true
+			}
+			if t == nil || t.Status == thread.ThreadStatusDeleted {
+				m.Warn("卡片目标子区已删除,拒绝", zap.String("groupNo", groupNo), zap.String("shortID", threadShortID))
+				httperr.ResponseErrorL(c, invalidCode, nil, nil)
+				return nil, true
+			}
+		}
+		isMember, merr := m.groupService.ExistMemberActive(groupNo, loginUID)
+		if merr != nil {
+			m.Error("查询群成员失败", zap.Error(merr), zap.String("groupNo", groupNo))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+			return nil, true
+		}
+		if !isMember {
+			httperr.ResponseErrorL(c, deniedCode, nil, nil)
+			return nil, true
+		}
+	}
+	return msgM, false
+}
+
 // resolveCardOriginSpaceID 解析卡片的**权威来源 Space**（P1-3, PR#548 review）。
 // card_action 事件的 space_id 必须来自卡片自身的存储权威,而非操作者请求上下文的
 // Space —— SpaceMiddleware 只证明操作者是所声明 Space 的成员,不证明卡片属于该
@@ -426,6 +406,42 @@ func (m *Message) groupSpaceIDOrEmpty(groupNo string) string {
 	return g.SpaceID
 }
 
+// cardCanonicalVisibleToViewer 复刻单条读 respondSingleMessage 的「内容可见性」层
+// (api_message_get.go)——成员资格 + 生命周期(revoke/删除)之外的第四类门禁:
+// visibles 白名单 / 消息过期(Expire 秒 TTL) / 用户清理偏移 / 频道偏移。card/action
+// 与 card/revisions 共用本 helper,防止两端可见性口径漂移(与 authorizeCardChannelMember
+// 同理:被 visibles 排除或历史已清理的成员,虽过成员+生命周期门禁,仍不得读到不可见卡片
+// 的内容/触发其副作用)。person 频道跳过偏移(单条读不经 respondSingleMessage、偏移语义
+// 未确立;2 方 DM visibles 恒过,已由成员+生命周期兜住;也避免对已是 fake id 的 person
+// 频道二次 fake 化)。返回 (true,nil)=可见;(false,nil)=对该 viewer 不可见(调用方决定
+// invalid / 空列表);(false,err)=偏移查询失败(调用方 fail-closed 回 500)。
+func (m *Message) cardCanonicalVisibleToViewer(msgM *messageModel, loginUID string) (bool, error) {
+	if !visiblesAllows(msgM.Payload, loginUID) {
+		return false, nil
+	}
+	if msgM.Expire > 0 && time.Now().Unix()-int64(msgM.Expire) >= int64(msgM.Timestamp) {
+		return false, nil
+	}
+	if msgM.ChannelType == common.ChannelTypePerson.Uint8() {
+		return true, nil
+	}
+	userOffset, oerr := m.channelOffsetDB.queryWithUIDAndChannel(loginUID, msgM.ChannelID, msgM.ChannelType)
+	if oerr != nil {
+		return false, oerr
+	}
+	if userOffset != nil && msgM.MessageSeq <= userOffset.MessageSeq {
+		return false, nil
+	}
+	channelOffsetSeq, cerr := m.lookupChannelOffsetSeq(msgM.ChannelID, msgM.ChannelType, loginUID)
+	if cerr != nil {
+		return false, cerr
+	}
+	if channelOffsetSeq != 0 && msgM.MessageSeq <= channelOffsetSeq {
+		return false, nil
+	}
+	return true, nil
+}
+
 // groupStatusVisibleForAction 复刻单条读 requireGroupMember 的群状态门禁
 // (api_message_get.go:184)：仅 GroupStatusNormal + GroupStatusDisband 可见,
 // Disabled(管理员禁用)及未来非正常状态 fail closed。刻意用 groupDB.QueryWithGroupNo
@@ -442,4 +458,30 @@ func (m *Message) groupStatusVisibleForAction(groupNo string) (bool, error) {
 		return false, nil
 	}
 	return true, nil
+}
+
+// isCardMessageWithdrawn 报告一张卡片是否已从可见消息面回收 —— 已撤回
+// (message_extra.revoke) / 全局删除 (message_extra.is_deleted) / 操作者本地删除
+// (message_user_extra.message_is_deleted)。与单条读 api_message_get.go:241 同口径。
+//
+// 动作端点(cardAction ④)内联了同一三项检查(那里顺带复用已查出的 extra 取生效帧,
+// 避免二次查询);查询端点(getCardRevisions)调用本 helper 做可见性兜底 —— 两处必须
+// 保持同步:动作与历史内容都不得在卡片被回收后仍可达(D10「revoked message leaves
+// no queryable content history」;且不依赖 revoke 时 best-effort 删除是否成功)。
+func (m *Message) isCardMessageWithdrawn(messageID, loginUID string) (bool, error) {
+	extra, err := m.messageExtraDB.queryWithMessageID(messageID)
+	if err != nil {
+		return false, err
+	}
+	if extra != nil && (extra.Revoke == 1 || extra.IsDeleted == 1) {
+		return true, nil
+	}
+	userExtras, err := m.messageUserExtraDB.queryWithMessageIDsAndUID([]string{messageID}, loginUID)
+	if err != nil {
+		return false, err
+	}
+	if len(userExtras) > 0 && userExtras[0].MessageIsDeleted == 1 {
+		return true, nil
+	}
+	return false, nil
 }

--- a/modules/message/api_card_revisions.go
+++ b/modules/message/api_card_revisions.go
@@ -1,0 +1,114 @@
+package message
+
+// card-message-interaction P2 D10.5：卡片修订历史查询。
+// GET /v1/message/card/revisions?message_id=&channel_id=&channel_type=&limit=&full=
+// —— AuthMiddleware → SharedUIDRateLimiter → Space（挂在 /v1/message 组）+ 与
+// card/action 同一门禁栈（authorizeCardChannelMember：anti-IDOR 频道绑定 + 存储
+// 频道成员资格）+ 生命周期兜底（isCardMessageWithdrawn）+ canonical 可见性
+// （cardCanonicalVisibleToViewer：visibles / 过期 / 偏移）—— 可见性 ≥ card/action、
+// 与单条读 respondSingleMessage 同口径（PR#549 review B1：修订历史披露多于单次动作，
+// 门禁不得更宽）。默认返回摘要列表；full=1 每条非墓碑行附完整可渲染帧信封。墓碑行
+// （清除审计）也出现在列表里。
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"go.uber.org/zap"
+)
+
+// getCardRevisions handles GET /v1/message/card/revisions.
+func (m *Message) getCardRevisions(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+	messageID := c.Query("message_id")
+	channelID := c.Query("channel_id")
+	if messageID == "" || channelID == "" {
+		respondMessageRequestInvalid(c, "message_id")
+		return
+	}
+	channelTypeI, err := strconv.ParseUint(c.Query("channel_type"), 10, 8)
+	if err != nil || channelTypeI == 0 {
+		respondMessageRequestInvalid(c, "channel_type")
+		return
+	}
+	limit := 0
+	if s := c.Query("limit"); s != "" {
+		if v, perr := strconv.Atoi(s); perr == nil {
+			limit = v
+		}
+	}
+	full := c.Query("full") == "1"
+
+	// D10.5 门禁：与 card/action 同口径（anti-IDOR 绑定 + 存储频道成员）。非卡片/
+	// 不存在/频道不匹配 → invalid；非成员 → denied（防枚举）。
+	msgM, handled := m.authorizeCardChannelMember(c, loginUID, messageID, channelID, uint8(channelTypeI),
+		errcode.ErrMessageCardRevisionInvalid, errcode.ErrMessageCardRevisionDenied)
+	if handled {
+		return
+	}
+
+	// 撤回/删除可见性兜底（PR-C verify P1）：已撤回 / 全局删除 / 操作者本地删除的卡片
+	// 无可查询内容历史（D10「revoked message leaves no queryable content history」）。
+	// 与 card/action 同口径,且不依赖 revoke 时 best-effort 删除是否成功 —— 双层防御:
+	// 即便修订行仍在（删除失败 / is_deleted / user-local-delete 本就不触发删除），
+	// 查询也返回空列表。
+	if withdrawn, werr := m.isCardMessageWithdrawn(messageID, loginUID); werr != nil {
+		m.Error("查询卡片撤回/删除状态失败", zap.Error(werr), zap.String("messageID", messageID))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		return
+	} else if withdrawn {
+		c.Response(map[string]interface{}{"revisions": []map[string]interface{}{}})
+		return
+	}
+
+	// canonical 可见性对齐（PR#549 review B1）：修订历史披露的内容比单次动作触发更多，
+	// 门禁必须 ≥ card/action。成员+生命周期之外补第四类可见性 —— visibles 白名单 /
+	// 消息过期 / 用户清理偏移 / 频道偏移（cardCanonicalVisibleToViewer，与 card/action
+	// 共用）。被 visibles 排除 / 偏移截断 / 已过期的成员看不到卡片本身，也就看不到它的
+	// 历史帧：不可见 → 空列表（与 withdrawn 同处理，不泄漏存在性）；查询失败 fail-closed。
+	if visible, verr := m.cardCanonicalVisibleToViewer(msgM, loginUID); verr != nil {
+		m.Error("查询卡片修订可见性失败", zap.Error(verr), zap.String("messageID", messageID))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		return
+	} else if !visible {
+		c.Response(map[string]interface{}{"revisions": []map[string]interface{}{}})
+		return
+	}
+
+	revs, err := m.cardRevisions.Query(messageID, limit)
+	if err != nil {
+		m.Error("查询卡片修订历史失败", zap.Error(err), zap.String("messageID", messageID))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		return
+	}
+
+	items := make([]map[string]interface{}, 0, len(revs))
+	for _, r := range revs {
+		if r.IsTombstone == 1 {
+			items = append(items, map[string]interface{}{
+				"tombstone":  true,
+				"cleared":    r.ClearedCount,
+				"editor_uid": r.EditorUID,
+				"edited_at":  r.EditedAt,
+			})
+			continue
+		}
+		item := map[string]interface{}{
+			"plain":      r.Plain,
+			"editor_uid": r.EditorUID,
+			"edited_at":  r.EditedAt,
+		}
+		if r.CardSeq.Valid {
+			item["card_seq"] = r.CardSeq.Int64
+		}
+		if full && r.Content.Valid && r.Content.String != "" {
+			// 完整帧信封逐字返回（写入时已过 cardmsg.Validate/Finalize）。
+			item["card"] = json.RawMessage(r.Content.String)
+		}
+		items = append(items, item)
+	}
+	c.Response(map[string]interface{}{"revisions": items})
+}

--- a/modules/message/api_card_revisions_test.go
+++ b/modules/message/api_card_revisions_test.go
@@ -1,0 +1,300 @@
+//go:build integration
+
+// 构建约束（与 api_card_action_test.go 一致，PR#548 CI 修复）：本文件经
+// testutil.NewTestServer 跑 sql-migrate，必须带 integration tag —— modules/message
+// 默认构建混有「手建最小表」的单元测试，跑迁移的用例与之在 -race -shuffle 下并存会撞
+// Error 1050 Table already exists（本包 e2e 文件皆 //go:build integration）。
+package message
+
+// card-message-interaction P2 D10 集成测试（MySQL + Redis，无需 WuKongIM）。
+// spec: .octospec/tasks/card-message-interaction/brief.md；执行 brief:
+// .octospec/tasks/card-message-p2-revision-history/brief.md。
+//
+// 覆盖：GET /v1/message/card/revisions 成员门禁(复用 authorizeCardChannelMember)、
+// summary/full=1 投影、墓碑行渲染、跨频道 IDOR、cap 20 裁剪、撤回删除(store 直测)。
+// bot 编辑追加 / clear 端点由 bot_api 的 IM-gated 用例承接。
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardrevision"
+	"github.com/gocraft/dbr/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+// seedRevisionFrame 经 store 追加一条非墓碑帧（同时验证 AppendFrame + cap 裁剪）。
+func seedRevisionFrame(t *testing.T, store *cardrevision.Store, messageID, channelID string, channelType uint8, cardSeq int64, plain, actionID string) {
+	t.Helper()
+	env := cardV2EnvelopeJSON(t, actionID)
+	err := store.AppendFrame(cardrevision.Revision{
+		MessageID:   messageID,
+		ChannelID:   channelID,
+		ChannelType: channelType,
+		CardSeq:     dbr.NewNullInt64(cardSeq),
+		Content:     dbr.NewNullString(string(env)),
+		Plain:       plain,
+		EditorUID:   cardActionBotUID,
+		EditedAt:    1751791200 + cardSeq,
+	})
+	assert.NoError(t, err)
+}
+
+func TestCardRevisionsQuery(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	s, ctx := testutil.NewTestServer()
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+	resetCardActionState(t, ctx)
+	store := cardrevision.NewStore(ctx.DB())
+
+	seedCardBot(t, ctx, cardActionBotUID)
+	fake := common.GetFakeChannelIDWith(testutil.UID, cardActionBotUID)
+	seedCardMessage(t, ctx, 9201, cardActionBotUID, fake, common.ChannelTypePerson.Uint8(), cardV2EnvelopeJSON(t, "approve_btn"))
+	seedRevisionFrame(t, store, "9201", fake, common.ChannelTypePerson.Uint8(), 1, "审批单 #42:待审批", "approve_btn")
+	seedRevisionFrame(t, store, "9201", fake, common.ChannelTypePerson.Uint8(), 2, "审批单 #42:已通过", "done_btn")
+
+	get := func(q string) *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/v1/message/card/revisions?"+q, nil)
+		req.Header.Set("token", testutil.Token)
+		s.GetRoute().ServeHTTP(w, req)
+		return w
+	}
+	base := fmt.Sprintf("message_id=9201&channel_id=%s&channel_type=%d", cardActionBotUID, common.ChannelTypePerson.Uint8())
+
+	// ① 成员 summary 查询：最新在前，字段齐全，默认不带 full card。
+	w := get(base)
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var resp struct {
+		Revisions []map[string]interface{} `json:"revisions"`
+	}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Len(t, resp.Revisions, 2)
+	assert.EqualValues(t, 2, resp.Revisions[0]["card_seq"], "最新帧在前")
+	assert.Equal(t, "审批单 #42:已通过", resp.Revisions[0]["plain"])
+	assert.Equal(t, cardActionBotUID, resp.Revisions[0]["editor_uid"])
+	assert.Nil(t, resp.Revisions[0]["card"], "summary 模式不含完整帧")
+
+	// ② full=1：附完整帧信封，且能过 cardmsg.Validate。
+	w = get(base + "&full=1")
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	rawCard, ok := resp.Revisions[0]["card"]
+	assert.True(t, ok, "full=1 应带 card")
+	cardBytes, _ := json.Marshal(rawCard)
+	var env map[string]interface{}
+	assert.NoError(t, json.Unmarshal(cardBytes, &env))
+	assert.NoError(t, cardmsg.Validate(env), "full 帧应过校验器")
+
+	// ③ 墓碑行：store.Clear 删帧 + 写墓碑，出现在列表里。
+	cleared, err := store.Clear("9201", fake, common.ChannelTypePerson.Uint8(), cardActionBotUID, 1751791300)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, cleared, "清除 2 帧")
+	w = get(base)
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Len(t, resp.Revisions, 1)
+	assert.Equal(t, true, resp.Revisions[0]["tombstone"])
+	assert.EqualValues(t, 2, resp.Revisions[0]["cleared"])
+}
+
+func TestCardRevisionsMemberGate(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	s, ctx := testutil.NewTestServer()
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+	resetCardActionState(t, ctx)
+	store := cardrevision.NewStore(ctx.DB())
+
+	seedCardBot(t, ctx, cardActionBotUID)
+	get := func(q string) *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/v1/message/card/revisions?"+q, nil)
+		req.Header.Set("token", testutil.Token)
+		s.GetRoute().ServeHTTP(w, req)
+		return w
+	}
+
+	// 群卡片，testutil.UID 非成员 → denied（复用 card/action 同门禁）。群行须为
+	// Normal 状态，把唯一拒因隔离到「非成员」（否则会先撞群状态门禁 → invalid）。
+	_, err := ctx.DB().InsertBySql("INSERT INTO `group`(group_no, name, status, space_id) VALUES(?, 'grt', ?, '')", "g_rev_test", group.GroupStatusNormal).Exec()
+	assert.NoError(t, err)
+	seedCardMessage(t, ctx, 9202, cardActionBotUID, "g_rev_test", common.ChannelTypeGroup.Uint8(), cardV2EnvelopeJSON(t, "approve_btn"))
+	seedRevisionFrame(t, store, "9202", "g_rev_test", common.ChannelTypeGroup.Uint8(), 1, "x", "approve_btn")
+	w := get(fmt.Sprintf("message_id=9202&channel_id=g_rev_test&channel_type=%d", common.ChannelTypeGroup.Uint8()))
+	assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "You are not allowed to view this card's revisions.")
+
+	// 跨频道 IDOR：B 群消息 + B 的 channel_id，非成员 → denied（绑定源自存储行）。
+	_, err = ctx.DB().InsertBySql("INSERT INTO `group`(group_no, name, status, space_id) VALUES(?, 'grb', ?, '')", "g_rev_b", group.GroupStatusNormal).Exec()
+	assert.NoError(t, err)
+	seedCardMessage(t, ctx, 9203, cardActionBotUID, "g_rev_b", common.ChannelTypeGroup.Uint8(), cardV2EnvelopeJSON(t, "approve_btn"))
+	w = get(fmt.Sprintf("message_id=9203&channel_id=g_rev_b&channel_type=%d", common.ChannelTypeGroup.Uint8()))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "You are not allowed to view this card's revisions.")
+
+	// person fake 频道指群消息 → 绑定不匹配（查不到）→ invalid。
+	w = get(fmt.Sprintf("message_id=9203&channel_id=%s&channel_type=%d", cardActionBotUID, common.ChannelTypePerson.Uint8()))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid card revision request.")
+}
+
+func TestCardRevisionsCapAndDelete(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	_, ctx := testutil.NewTestServer()
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+	store := cardrevision.NewStore(ctx.DB())
+	fake := common.GetFakeChannelIDWith(testutil.UID, cardActionBotUID)
+
+	// cap 裁剪：追加 cap+5 帧，仅保留最新 cap 帧。
+	for i := 1; i <= cardrevision.CapFrames+5; i++ {
+		seedRevisionFrame(t, store, "9301", fake, common.ChannelTypePerson.Uint8(), int64(i), fmt.Sprintf("f%d", i), "approve_btn")
+	}
+	revs, err := store.Query("9301", 1000)
+	assert.NoError(t, err)
+	assert.Len(t, revs, cardrevision.CapFrames, "非墓碑帧应被裁剪到 cap")
+	assert.EqualValues(t, cardrevision.CapFrames+5, revs[0].CardSeq.Int64, "保留的是最新帧")
+
+	// DeleteByMessageID（撤回清理的底层）：删后查询为空。
+	assert.NoError(t, store.DeleteByMessageID("9301"))
+	revs, err = store.Query("9301", 1000)
+	assert.NoError(t, err)
+	assert.Len(t, revs, 0, "删除后应无修订")
+}
+
+// TestCardRevisionsWithdrawnHidden 验证撤回/删除可见性兜底（verify P1）：即便修订
+// 行仍在，已撤回 / 全局删除 / 操作者本地删除的卡片，GET 返回空列表（不泄漏历史内容）。
+func TestCardRevisionsWithdrawnHidden(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	s, ctx := testutil.NewTestServer()
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+	resetCardActionState(t, ctx)
+	store := cardrevision.NewStore(ctx.DB())
+	fake := common.GetFakeChannelIDWith(testutil.UID, cardActionBotUID)
+
+	get := func(msgID string) *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		q := fmt.Sprintf("message_id=%s&channel_id=%s&channel_type=%d", msgID, cardActionBotUID, common.ChannelTypePerson.Uint8())
+		req, _ := http.NewRequest("GET", "/v1/message/card/revisions?"+q, nil)
+		req.Header.Set("token", testutil.Token)
+		s.GetRoute().ServeHTTP(w, req)
+		return w
+	}
+	emptyRevisions := func(w *httptest.ResponseRecorder) bool {
+		var resp struct {
+			Revisions []map[string]interface{} `json:"revisions"`
+		}
+		return json.Unmarshal(w.Body.Bytes(), &resp) == nil && len(resp.Revisions) == 0
+	}
+
+	// 三种回收态：revoke / 全局 is_deleted / 操作者 message_is_deleted。每种都有修订
+	// 行存在，但 GET 必须返回空（内容历史不可查）。
+	cases := []struct {
+		msgID  int64
+		seedWD func(msgID string)
+	}{
+		{9401, func(id string) {
+			_, e := ctx.DB().InsertBySql("INSERT INTO message_extra (message_id,message_seq,channel_id,channel_type,`revoke`,version) VALUES (?,?,?,?,?,?)",
+				id, 1, fake, common.ChannelTypePerson.Uint8(), 1, 1).Exec()
+			assert.NoError(t, e)
+		}},
+		{9402, func(id string) {
+			_, e := ctx.DB().InsertBySql("INSERT INTO message_extra (message_id,message_seq,channel_id,channel_type,is_deleted,version) VALUES (?,?,?,?,?,?)",
+				id, 1, fake, common.ChannelTypePerson.Uint8(), 1, 1).Exec()
+			assert.NoError(t, e)
+		}},
+		{9403, func(id string) {
+			_, e := ctx.DB().InsertBySql("INSERT INTO message_user_extra (uid,message_id,message_seq,channel_id,channel_type,message_is_deleted) VALUES (?,?,?,?,?,?)",
+				testutil.UID, id, 1, fake, common.ChannelTypePerson.Uint8(), 1).Exec()
+			assert.NoError(t, e)
+		}},
+	}
+	for _, tc := range cases {
+		idStr := fmt.Sprintf("%d", tc.msgID)
+		seedCardMessage(t, ctx, tc.msgID, cardActionBotUID, fake, common.ChannelTypePerson.Uint8(), cardV2EnvelopeJSON(t, "approve_btn"))
+		seedRevisionFrame(t, store, idStr, fake, common.ChannelTypePerson.Uint8(), 1, "content-should-be-hidden", "approve_btn")
+		tc.seedWD(idStr)
+		w := get(idStr)
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		assert.True(t, emptyRevisions(w), "回收态卡片(%s)应返回空修订", idStr)
+		assert.NotContains(t, w.Body.String(), "content-should-be-hidden", "不得泄漏历史内容")
+	}
+}
+
+// TestCardRevisionsCanonicalVisibility 验证修订查询与单条读同口径的第四类可见性
+// (PR#549 review B1)：被 visibles 白名单排除 / 被用户清理偏移截断的群成员，虽过
+// 成员+生命周期门禁，仍看不到卡片本身 —— 其修订历史也必须返回空（不泄漏内容/存在
+// 性），与 card/action 共用 cardCanonicalVisibleToViewer。
+func TestCardRevisionsCanonicalVisibility(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	s, ctx := testutil.NewTestServer()
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+	resetCardActionState(t, ctx)
+	store := cardrevision.NewStore(ctx.DB())
+	seedCardBot(t, ctx, cardActionBotUID)
+
+	// 正常群 + testutil.UID 为成员 —— 让唯一区分点落在 visibles / offset。
+	_, err := ctx.DB().InsertBySql("INSERT INTO `group`(group_no, name, status, space_id) VALUES(?, 'grv', ?, '')", "g_rev_vis", group.GroupStatusNormal).Exec()
+	assert.NoError(t, err)
+	_, err = ctx.DB().InsertBySql("insert into group_member(group_no,uid) values(?,?)", "g_rev_vis", testutil.UID).Exec()
+	assert.NoError(t, err)
+
+	get := func(msgID string) *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		q := fmt.Sprintf("message_id=%s&channel_id=g_rev_vis&channel_type=%d", msgID, common.ChannelTypeGroup.Uint8())
+		req, _ := http.NewRequest("GET", "/v1/message/card/revisions?"+q, nil)
+		req.Header.Set("token", testutil.Token)
+		s.GetRoute().ServeHTTP(w, req)
+		return w
+	}
+	emptyRevisions := func(w *httptest.ResponseRecorder) bool {
+		var resp struct {
+			Revisions []map[string]interface{} `json:"revisions"`
+		}
+		return json.Unmarshal(w.Body.Bytes(), &resp) == nil && len(resp.Revisions) == 0
+	}
+	withVisibles := func(uids ...string) []byte {
+		var env map[string]interface{}
+		assert.NoError(t, json.Unmarshal(cardV2EnvelopeJSON(t, "approve_btn"), &env))
+		vis := make([]interface{}, 0, len(uids))
+		for _, u := range uids {
+			vis = append(vis, u)
+		}
+		env["visibles"] = vis
+		b, _ := json.Marshal(env)
+		return b
+	}
+
+	// ① visibles 只含别人 → 成员看不到卡片，其历史返回空（修订行仍在）。
+	seedCardMessage(t, ctx, 9210, cardActionBotUID, "g_rev_vis", common.ChannelTypeGroup.Uint8(), withVisibles("someone_else"))
+	seedRevisionFrame(t, store, "9210", "g_rev_vis", common.ChannelTypeGroup.Uint8(), 1, "visibles-hidden-content", "approve_btn")
+	w := get("9210")
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.True(t, emptyRevisions(w), "visibles 排除成员应得空修订")
+	assert.NotContains(t, w.Body.String(), "visibles-hidden-content", "不得泄漏被 visibles 排除卡片的历史内容")
+
+	// ② 对照：visibles 含操作者 → 正常返回历史。
+	seedCardMessage(t, ctx, 9211, cardActionBotUID, "g_rev_vis", common.ChannelTypeGroup.Uint8(), withVisibles(testutil.UID))
+	seedRevisionFrame(t, store, "9211", "g_rev_vis", common.ChannelTypeGroup.Uint8(), 1, "visible-content", "approve_btn")
+	w = get("9211")
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.False(t, emptyRevisions(w), "visibles 含操作者应返回历史")
+
+	// ③ 用户清理偏移截断：offset.message_seq(=5) ≥ 卡片 seq(=1) → 成员已清理该消息，
+	//    历史返回空。用 newChannelOffsetDB.insertOrUpdate 走分表逻辑（勿裸 INSERT 撞错分片）。
+	seedCardMessage(t, ctx, 9212, cardActionBotUID, "g_rev_vis", common.ChannelTypeGroup.Uint8(), cardV2EnvelopeJSON(t, "approve_btn"))
+	seedRevisionFrame(t, store, "9212", "g_rev_vis", common.ChannelTypeGroup.Uint8(), 1, "offset-truncated-content", "approve_btn")
+	err = newChannelOffsetDB(ctx).insertOrUpdate(&channelOffsetModel{
+		UID: testutil.UID, ChannelID: "g_rev_vis", ChannelType: common.ChannelTypeGroup.Uint8(), MessageSeq: 5,
+	})
+	assert.NoError(t, err)
+	w = get("9212")
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.True(t, emptyRevisions(w), "偏移截断成员应得空修订")
+	assert.NotContains(t, w.Body.String(), "offset-truncated-content", "不得泄漏偏移截断卡片的历史内容")
+}

--- a/modules/message/api_i18n_test.go
+++ b/modules/message/api_i18n_test.go
@@ -26,6 +26,7 @@ func TestMessageNoLegacyResponseError(t *testing.T) {
 		"api.go", "api_manager.go", "api_pinned.go", "api_conversation.go",
 		"api_message_get.go", "api_reminders.go", "api_channel_files.go", "api_sidebar.go",
 		"api_card_action.go",
+		"api_card_revisions.go",
 	}
 	banned := []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(", "c.Response(\""}
 	for _, f := range files {

--- a/modules/message/sql/20250708000002_message_legacy01.sql
+++ b/modules/message/sql/20250708000002_message_legacy01.sql
@@ -1,0 +1,23 @@
+-- +migrate Up
+
+-- card-message-interaction P2 D10：卡片消息修订历史侧表。
+-- 由 bot 编辑路径(botMessageEdit 卡片分支)在 content_edit 覆盖之外追加非 transient
+-- 帧(每帧一整份可渲染信封);cap 20 非墓碑帧/消息(应用层裁剪);清除写墓碑行(审计);
+-- 消息撤回时删除。查询端 GET /v1/message/card/revisions(成员可见)。octo_ 前缀(新表规约)。
+CREATE TABLE `octo_message_card_revision` (
+  `id`           BIGINT       NOT NULL AUTO_INCREMENT,
+  `message_id`   VARCHAR(20)  NOT NULL DEFAULT '' COMMENT '卡片消息ID',
+  `channel_id`   VARCHAR(100) NOT NULL DEFAULT '' COMMENT '存储行频道ID(person=fakeChannelID)',
+  `channel_type` TINYINT      NOT NULL DEFAULT 0  COMMENT '频道类型',
+  `card_seq`     BIGINT       DEFAULT NULL         COMMENT '该帧 card_seq(D9); NULL=无序号',
+  `content`      TEXT                              COMMENT '完整帧信封(可渲染); 墓碑行为 NULL',
+  `plain`        VARCHAR(512) NOT NULL DEFAULT '' COMMENT '列表摘要(server 权威 plain 截断)',
+  `is_tombstone` TINYINT      NOT NULL DEFAULT 0  COMMENT '1=清除墓碑行(审计, 无 content)',
+  `cleared_count` INT         NOT NULL DEFAULT 0  COMMENT '墓碑行清除的帧数',
+  `editor_uid`   VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '编辑/清除者uid(bot)',
+  `edited_at`    BIGINT       NOT NULL DEFAULT 0  COMMENT '编辑/清除时间(纪元秒)',
+  `created_at`   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '行创建时间',
+  `updated_at`   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '行更新时间',
+  PRIMARY KEY (`id`),
+  KEY `idx_message` (`message_id`,`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='卡片消息修订历史(D10)';

--- a/pkg/cardmsg/interactive.go
+++ b/pkg/cardmsg/interactive.go
@@ -207,3 +207,31 @@ func decodeEnvelope(raw string) (map[string]interface{}, error) {
 	}
 	return payload, nil
 }
+
+// Transient 读取信封可选的 transient 标记（P2 D10.4）。transient 帧照常应用到
+// content_edit（D6/D9 不变），但不进修订历史 —— 进度帧（thinking/tool-state）不
+// 淹没审批态变更。缺失/非布尔按 false（非 transient，入历史）。
+func Transient(payload map[string]interface{}) bool {
+	t, _ := payload["transient"].(bool)
+	return t
+}
+
+// TransientFromContentEdit 从编辑体 JSON 读取 transient。
+func TransientFromContentEdit(contentEdit string) bool {
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(contentEdit), &payload); err != nil {
+		return false
+	}
+	return Transient(payload)
+}
+
+// PlainFromContentEdit 从编辑体 JSON 读取服务端权威 plain（Finalize 重算后的值），
+// 供修订历史存列表摘要。缺失返回空串。
+func PlainFromContentEdit(contentEdit string) string {
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(contentEdit), &payload); err != nil {
+		return ""
+	}
+	s, _ := payload["plain"].(string)
+	return s
+}

--- a/pkg/cardrevision/cardrevision.go
+++ b/pkg/cardrevision/cardrevision.go
@@ -1,0 +1,135 @@
+// Package cardrevision owns the D10 card revision history side table
+// (octo_message_card_revision): the queryable "这张卡以前是什么" surface that
+// the D6 full-frame-replacement model (latest-frame-only content_edit) cannot
+// answer on its own.
+//
+// card-message-interaction P2 D10（spec: .octospec/tasks/card-message-interaction/
+// brief.md；执行 brief: .octospec/tasks/card-message-p2-revision-history/brief.md）。
+//
+// 共享表模式（同 message_extra）：写入方是 modules/bot_api（bot 编辑追加帧 /
+// 清除写墓碑），读取方是 modules/message（GET 查询 / 撤回删除）。两侧都用本 Store
+// 经 ctx.DB() 的 *dbr.Session 访问，schema 知识集中在此，避免跨模块 raw SQL 漂移。
+package cardrevision
+
+import (
+	"github.com/gocraft/dbr/v2"
+)
+
+const table = "octo_message_card_revision"
+
+// CapFrames 每消息保留的非墓碑帧上限（D10.3）。墓碑行是审计标记，不计入 cap，
+// 也不被裁剪。
+const CapFrames = 20
+
+// MaxQueryLimit 查询接口的返回条数硬上限（防一次拉全表）。
+const MaxQueryLimit = 100
+
+// maxPlainRunes 摘要列 plain 的字符上限（对齐 VARCHAR(512)，rune-safe 截断防溢出）。
+const maxPlainRunes = 512
+
+// Revision 是一条卡片修订记录：非墓碑帧（IsTombstone=0，带 Content/Plain/CardSeq）
+// 或清除墓碑（IsTombstone=1，Content 为 NULL，ClearedCount>0）。字段名经 dbr 默认
+// camelCase→snake_case 映射到列（与 messageExtraModel 同约定，无需 db tag）。
+type Revision struct {
+	ID           int64
+	MessageID    string
+	ChannelID    string
+	ChannelType  uint8
+	CardSeq      dbr.NullInt64
+	Content      dbr.NullString
+	Plain        string
+	IsTombstone  int
+	ClearedCount int
+	EditorUID    string
+	EditedAt     int64
+	dbBaseCreatedUpdated
+}
+
+// dbBaseCreatedUpdated 占位 created_at/updated_at 两列，Load "SELECT *" 时不至于因
+// 多出的列报错（dbr 对未知列宽容，但保留字段更明确）。
+type dbBaseCreatedUpdated struct {
+	CreatedAt dbr.NullTime `db:"created_at"`
+	UpdatedAt dbr.NullTime `db:"updated_at"`
+}
+
+// Store 是修订表的数据访问层，包裹一个 *dbr.Session（来自 ctx.DB()）。
+type Store struct {
+	session *dbr.Session
+}
+
+// NewStore 构造 Store。
+func NewStore(session *dbr.Session) *Store {
+	return &Store{session: session}
+}
+
+// AppendFrame 追加一条非墓碑帧并把该消息的非墓碑帧裁剪到 CapFrames（保留最新）。
+// 由 bot 编辑路径在 content_edit 落库成功后调用（仅非 transient 帧）；返回的 err
+// 供调用方记日志——history 是次级面，append 失败不得阻断卡片更新（content_edit 才
+// 是权威状态）。
+func (s *Store) AppendFrame(rev Revision) error {
+	if r := []rune(rev.Plain); len(r) > maxPlainRunes {
+		rev.Plain = string(r[:maxPlainRunes]) // rune-safe 截断，避免 VARCHAR(512) 溢出
+	}
+	if _, err := s.session.InsertBySql(
+		"INSERT INTO "+table+" (message_id,channel_id,channel_type,card_seq,content,plain,is_tombstone,cleared_count,editor_uid,edited_at) VALUES (?,?,?,?,?,?,0,0,?,?)",
+		rev.MessageID, rev.ChannelID, rev.ChannelType, rev.CardSeq, rev.Content, rev.Plain, rev.EditorUID, rev.EditedAt,
+	).Exec(); err != nil {
+		return err
+	}
+	// 裁剪：删除超出 cap 的最旧非墓碑帧（墓碑行不参与）。子查询套派生表以绕过
+	// MySQL「不能 DELETE 正在子查询里引用的同表」限制。
+	_, err := s.session.DeleteBySql(
+		"DELETE FROM "+table+" WHERE message_id=? AND is_tombstone=0 AND id NOT IN "+
+			"(SELECT id FROM (SELECT id FROM "+table+" WHERE message_id=? AND is_tombstone=0 ORDER BY id DESC LIMIT ?) t)",
+		rev.MessageID, rev.MessageID, CapFrames,
+	).Exec()
+	return err
+}
+
+// Query 返回该消息的修订记录（含墓碑），按 id 倒序（最新在前），最多 limit 条。
+func (s *Store) Query(messageID string, limit int) ([]*Revision, error) {
+	if limit <= 0 || limit > MaxQueryLimit {
+		limit = MaxQueryLimit
+	}
+	var list []*Revision
+	_, err := s.session.SelectBySql(
+		"SELECT * FROM "+table+" WHERE message_id=? ORDER BY id DESC LIMIT ?", messageID, limit,
+	).Load(&list)
+	return list, err
+}
+
+// Clear 删除该消息的所有非墓碑帧并写入一条墓碑行（审计：editor+时间+清除帧数）。
+// 在单事务内 count→delete→insert，返回被清除的帧数。由 bot 清除端点调用（属主校验
+// 在调用方完成）。
+func (s *Store) Clear(messageID, channelID string, channelType uint8, editorUID string, editedAt int64) (int, error) {
+	tx, err := s.session.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	var cleared int
+	if err := tx.SelectBySql("SELECT count(*) FROM "+table+" WHERE message_id=? AND is_tombstone=0", messageID).LoadOne(&cleared); err != nil {
+		return 0, err
+	}
+	if _, err := tx.DeleteBySql("DELETE FROM "+table+" WHERE message_id=? AND is_tombstone=0", messageID).Exec(); err != nil {
+		return 0, err
+	}
+	if _, err := tx.InsertBySql(
+		"INSERT INTO "+table+" (message_id,channel_id,channel_type,plain,is_tombstone,cleared_count,editor_uid,edited_at) VALUES (?,?,?,'',1,?,?,?)",
+		messageID, channelID, channelType, cleared, editorUID, editedAt,
+	).Exec(); err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return cleared, nil
+}
+
+// DeleteByMessageID 删除该消息的全部修订行（含墓碑）。撤回消息时调用（best-effort，
+// 撤回不得因此失败）。
+func (s *Store) DeleteByMessageID(messageID string) error {
+	_, err := s.session.DeleteBySql("DELETE FROM "+table+" WHERE message_id=?", messageID).Exec()
+	return err
+}

--- a/pkg/errcode/bot_api.go
+++ b/pkg/errcode/bot_api.go
@@ -406,4 +406,11 @@ var (
 		HTTPStatus:     http.StatusConflict,
 		DefaultMessage: "Card update rejected: stale card_seq.",
 	})
+	// ErrBotAPICardRevisionClearForbidden P2 D10.6：bot 只能清除自己发的卡片的
+	// 修订历史（属主校验失败 —— sender != 调用 bot）。
+	ErrBotAPICardRevisionClearForbidden = register(codes.Code{
+		ID:             "err.server.bot_api.card_revision_clear_forbidden",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You can only clear revisions of your own cards.",
+	})
 )

--- a/pkg/errcode/message.go
+++ b/pkg/errcode/message.go
@@ -214,4 +214,18 @@ var (
 		HTTPStatus:     http.StatusConflict,
 		DefaultMessage: "This card action is being processed, please retry.",
 	})
+	// ErrMessageCardRevisionInvalid P2 D10.5：卡片修订查询的单一 400 归并码
+	// （非卡片 / 不存在 / 频道不匹配；防枚举，具体原因只进日志）。
+	ErrMessageCardRevisionInvalid = register(codes.Code{
+		ID:             "err.server.message.card_revision_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid card revision request.",
+	})
+	// ErrMessageCardRevisionDenied P2 D10.5：查看者不是卡片所在频道的成员
+	// （与 card_action 同门禁；唯一 403 语义）。
+	ErrMessageCardRevisionDenied = register(codes.Code{
+		ID:             "err.server.message.card_revision_denied",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You are not allowed to view this card's revisions.",
+	})
 )

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -1241,6 +1241,12 @@ other = "你无权对该卡片执行此操作。"
 ["err.server.message.card_action_in_progress"]
 other = "该卡片动作正在处理中，请稍后重试。"
 
+["err.server.message.card_revision_invalid"]
+other = "卡片修订查询无效。"
+
+["err.server.message.card_revision_denied"]
+other = "你无权查看该卡片的修订历史。"
+
 ["err.server.bot_api.card_disabled"]
 other = "当前部署未启用卡片消息。"
 
@@ -1255,6 +1261,9 @@ other = "卡片消息暂不支持编辑。"
 
 ["err.server.bot_api.card_seq_conflict"]
 other = "卡片更新被拒绝：card_seq 已过期。"
+
+["err.server.bot_api.card_revision_clear_forbidden"]
+other = "只能清除自己发送的卡片的修订历史。"
 
 ["err.server.robot.card_edit_forbidden"]
 other = "卡片消息不支持编辑。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -72,6 +72,9 @@ other = "Invalid card payload."
 ["err.server.bot_api.card_obo_forbidden"]
 other = "Card messages cannot be sent on behalf of a user."
 
+["err.server.bot_api.card_revision_clear_forbidden"]
+other = "You can only clear revisions of your own cards."
+
 ["err.server.bot_api.card_seq_conflict"]
 other = "Card update rejected: stale card_seq."
 
@@ -488,6 +491,12 @@ other = "Invalid card action."
 
 ["err.server.message.card_edit_forbidden"]
 other = "Card messages cannot be edited."
+
+["err.server.message.card_revision_denied"]
+other = "You are not allowed to view this card's revisions."
+
+["err.server.message.card_revision_invalid"]
+other = "Invalid card revision request."
 
 ["err.server.message.card_send_forbidden"]
 other = "Card messages can only be sent by bots or webhooks."


### PR DESCRIPTION
> ✅ **#548 (PR-B) is merged into `main`.** This PR is now rebased onto `main` and the diff below is the **D10-only delta** (3 commits: brief → impl → octospec finish). The rebase resolved the squash-merge conflicts by (1) keeping PR-B's merged hardening — the group-status + thread-status gates were folded into the shared `authorizeCardChannelMember` helper so no #548 security fix regresses — and (2) tagging the new revisions test `//go:build integration` to match the sibling e2e files.

## Summary

PR-C of the card message P2 protocol — **D10 card revision history**. The D6 full-frame-replacement model keeps `message_extra.content_edit` latest-frame-only, so the message table cannot answer "这张卡以前是什么". PR-C adds a side table recording each non-transient frame as a complete renderable envelope, plus a member-visible query API. Zero octo-im changes. D12 capability manifest is sibling PR-D.

## Related Issue

Self-sourced octospec task. Contract: `.octospec/tasks/card-message-interaction/brief.md` (D10). Built on #548 (now merged).

## Linked Spec

`.octospec/tasks/card-message-p2-revision-history/brief.md`

## Changes (PR-C delta)

- **`pkg/cardrevision`** (new): shared store over `octo_message_card_revision` (written by `bot_api` on card edits/clear, read by `message` — same split as `message_extra`). `AppendFrame` (+ cap-20 prune, rune-safe `plain` truncate), `Query` (newest-first, incl. tombstones), `Clear` (tx: delete frames + write an auditable tombstone), `DeleteByMessageID`.
- **Migration**: `octo_message_card_revision` (`octo_` prefix per repo rule; the brief's illustrative `message_card_revision` overridden).
- **`pkg/cardmsg`**: `Transient` / `TransientFromContentEdit` / `PlainFromContentEdit`.
- **`modules/bot_api`**: `botMessageEdit` appends a non-transient frame **after** the content write (best-effort — `content_edit` is authoritative, append failure never blocks the edit; `transient:true` frames skip history); new `POST /v1/bot/message/card/revisions/clear` (owner-checked, writes a tombstone).
- **`modules/message`**: `GET /v1/message/card/revisions` (summary / `full=1`), reusing the extracted `authorizeCardChannelMember` gate shared with `card/action`; revoke deletes a card's revisions (after commit, before notify); an `isCardMessageWithdrawn` visibility fallback hides history for revoked / globally-deleted / operator-locally-deleted cards even if rows remain.
- errcodes (revision invalid/denied, bot clear forbidden) + zh-CN + en markers + guard lists.

## Testing

Local MySQL + Redis + WuKongIM containers.

- `modules/message`: `TestCardRevisionsQuery` (summary / `full=1` re-validates via `cardmsg.Validate` / tombstone rendering), `TestCardRevisionsMemberGate` (non-member denied / cross-channel IDOR / person-points-at-group invalid), `TestCardRevisionsCapAndDelete` (cap-20 eviction + delete), `TestCardRevisionsWithdrawnHidden` (revoke / is_deleted / user-local-delete all return empty). `card/action` suite unchanged (no regression).
- `modules/bot_api` (`-race`): `TestBotCardRevisionsIM` (non-transient append / transient skip / clear → tombstone). D6/D9 suite unchanged.
- `go build ./...`, `golangci-lint run` 0 issues, i18n suite green.

- [x] Unit tests added/updated
- [x] Manually verified

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   Adds a second consumer of the card-message trust surface: a member-visible **read** endpoint for revision history, and a bot-only **clear** write. Both go through the same anti-IDOR channel-binding + membership gate as `card/action` (extracted into `authorizeCardChannelMember`). Card edits now also append to a side table on the `botMessageEdit` path. The revoke path gains a revision-cleanup step.

2. **What could break because of it (dependents + failure mode)?**
   (a) The append rides `botMessageEdit` — it is best-effort *after* the `content_edit` write, so an append failure logs and continues (the card edit and its CMD fanout are unaffected). (b) The new table is written by `bot_api` and read by `message` via a shared `pkg/cardrevision.Store`; a migration adds `octo_message_card_revision`. (c) Revocation now deletes revision rows after the revoke commit; if that delete fails, the query endpoint's `isCardMessageWithdrawn` gate still hides the history — two independent layers. (d) The extracted member gate is now shared by two endpoints; its behavior is pinned by both `card/action` and revisions tests.

3. **How do you know it works (specific test/repro/trace)?**
   `TestCardRevisionsWithdrawnHidden` seeds revision rows then marks the message revoked / is_deleted / user-local-deleted and asserts the GET returns an empty list and does not leak content — covering the verify-phase P1. `TestCardRevisionsMemberGate` asserts non-member → 403-class and cross-channel IDOR rejection (same stored-row binding as `card/action`). `TestBotCardRevisionsIM` (real WuKongIM) asserts a non-transient edit appends exactly one frame, a `transient:true` edit appends none, and the clear endpoint deletes frames + writes one tombstone. `TestCardRevisionsCapAndDelete` pins cap-20 eviction.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (docs/card-protocol.md already carries the D10 contract; no drift)
- [x] Followed commit message conventions (Conventional Commits)

