### PR TITLE
feat: add filespace document backend

### DIFF
--- a/.octospec/tasks/filespace-documents-backend/brief.md
+++ b/.octospec/tasks/filespace-documents-backend/brief.md
@@ -1,0 +1,58 @@
+---
+type: Task
+title: "Task: filespace-documents-backend"
+description: Scope the octo-server Filespace document backend changes onto latest main with Octospec load-bearing rules.
+tags: [filespace, document, space-isolation, error-handling, rate-limit, testing]
+timestamp: 2026-07-08T17:05:52+08:00
+slug: filespace-documents-backend
+upstream: Mininglamp-OSS/octo-server#552
+source: self
+---
+
+# Task: filespace-documents-backend
+
+## Goal
+
+Prepare the `octo-server` Filespace document backend PR so it contains only the business changes required for Filespace document/asset functionality, is based on the latest `Mininglamp-OSS/octo-server` main branch, and satisfies Octospec verification before review.
+
+## Background
+
+The PR branch `filespace-v1` was rebased on the latest `origin/main`, then narrowed to the Filespace backend surface. The intended scope is the new `modules/document` implementation plus the required file/search/module/i18n integration. Unrelated base app configuration, group avatar, message/sidebar, user sticker upload, voice adapter, seed script, and static/config changes are out of scope.
+
+Earlier broad-merge verification exposed compile blockers in unrelated or loosely related areas, which must stay resolved while narrowing the PR:
+
+- `modules/base/app` redeclares `StatusDisable` and `StatusEnable`, and mixes typed `Status` with `int`.
+- `modules/file/api.go` has unused imports and calls `f.stickerUploadHandlers(r)` even though the method is not present in the branch.
+
+Octospec review also identified load-bearing concerns in the Filespace document API:
+
+- Document read/list/state paths must not leak tenant assets, spaces, bindings, members, events, or storage paths across space ownership or membership boundaries.
+- User-facing HTTP errors must use localized error handling with registered `pkg/errcode` codes.
+- Authenticated document routes must keep the shared UID rate limiter and space middleware.
+
+## Load-bearing list
+
+- `space-isolation`: every document, asset, space, binding, member, event, preview, and download access path must enforce tenant space and user ownership or membership. Do not expose resources solely because they share `tenant_space_id`.
+- `error-handling`: user-facing document/file errors must use localized error envelopes through `httperr.ResponseErrorL` and registered `pkg/errcode` entries. Do not add raw `c.ResponseError`, `c.JSON`, or `AbortWithStatusJSON` responses for user-facing failures.
+- `rate-limit`: authenticated `/v1/documents` routes must remain behind `SharedUIDRateLimiter`, `AuthMiddleware`, and `SpaceMiddleware`.
+- `testing`: add or keep focused tests for access isolation, preview/download authorization, business route behavior, and regression coverage for error envelopes.
+- `commit-style`: PR description and later commits must stay in English conventional style and link the task/PR context.
+
+## Out of scope
+
+- `octo-web`, `octo-deployment`, and `octo-matter` changes.
+- Sticker upload implementation unrelated to Filespace document assets.
+- Voice adapter, group avatar, message/sidebar, and base app legacy refactors unless they are strictly required by Filespace document behavior.
+- Demo seed scripts and static config changes unless explicitly required for a reviewed demo scenario.
+- Broad formatting, generated churn, or unrelated dependency/config updates.
+
+## Acceptance
+
+- PR diff is narrowed to Filespace document backend business scope and any necessary integration points.
+- Branch remains based on the latest `Mininglamp-OSS/octo-server` main branch.
+- `go test ./...` compiles, with unrelated local infrastructure failures documented if they cannot be reproduced cleanly.
+- Focused tests pass for `modules/document`, affected `modules/file`, affected `modules/search`, and affected `modules/common` paths.
+- Document list/state/read/preview/download paths only return data the authenticated user can access.
+- No document response exposes internal storage paths unless explicitly authorized and intended by the API contract.
+- User-facing errors in touched document/file paths use localized registered error codes.
+- CI for the PR is green or any remaining failure is clearly outside this task and documented.

--- a/internal/modules.go
+++ b/internal/modules.go
@@ -34,6 +34,7 @@ import (
 	_ "github.com/Mininglamp-OSS/octo-server/modules/channel"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/common"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/document"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/file"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/group"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/incomingwebhook"

--- a/modules/document/1module.go
+++ b/modules/document/1module.go
@@ -1,0 +1,25 @@
+package document
+
+import (
+	"embed"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
+)
+
+//go:embed sql
+var sqlFS embed.FS
+
+//go:embed swagger/api.yaml
+var swaggerContent string
+
+func init() {
+	register.AddModule(func(ctx interface{}) register.Module {
+		return register.Module{
+			Name:     "document",
+			SetupAPI: func() register.APIRouter { return New(ctx.(*config.Context)) },
+			SQLDir:   register.NewSQLFS(sqlFS),
+			Swagger:  swaggerContent,
+		}
+	})
+}

--- a/modules/document/api.go
+++ b/modules/document/api.go
@@ -1,0 +1,402 @@
+package document
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
+	"go.uber.org/zap"
+)
+
+type Document struct {
+	ctx *config.Context
+	log.Log
+	service *DocumentService
+}
+
+func New(ctx *config.Context) *Document {
+	return &Document{
+		ctx:     ctx,
+		Log:     log.NewTLog("Document"),
+		service: NewDocumentService(newDocumentDB(ctx)),
+	}
+}
+
+func (d *Document) Route(r *wkhttp.WKHttp) {
+	uidLimit := appwkhttp.SharedUIDRateLimiter(r, d.ctx)
+	auth := r.Group("/v1/documents", d.ctx.AuthMiddleware(r), uidLimit, spacepkg.SpaceMiddleware(d.ctx))
+	{
+		auth.GET("/state", d.state)
+		auth.POST("/upload", d.upload)
+		auth.POST("/archive", d.archive)
+		auth.POST("/spaces", d.createSpace)
+		auth.POST("/spaces/:space_id", d.updateSpace)
+		auth.POST("/spaces/:space_id/disable", d.disableSpace)
+		auth.POST("/spaces/:space_id/bind-conversation", d.bindConversation)
+		auth.GET("/spaces/:space_id/bindings/search", d.searchSpaceBindings)
+		auth.POST("/spaces/:space_id/bindings/:binding_id/remove", d.unbindConversation)
+		auth.GET("/spaces/:space_id/members/search", d.searchSpaceMembers)
+		auth.POST("/spaces/:space_id/members", d.saveSpaceMember)
+		auth.POST("/spaces/:space_id/members/:member_uid/remove", d.removeSpaceMember)
+		auth.POST("/:asset_id/rename", d.renameAsset)
+		auth.POST("/:asset_id/move", d.moveAsset)
+		auth.POST("/:asset_id/preview", d.preview)
+		auth.POST("/:asset_id/download", d.download)
+		auth.POST("/:asset_id/trash", d.trash)
+		auth.POST("/:asset_id/restore", d.restore)
+		auth.POST("/:asset_id/permanent-delete", d.permanentDelete)
+		auth.POST("/trash/empty", d.emptyTrash)
+		auth.GET("/channel-storage-space", d.channelStorageSpace)
+		auth.GET("/source/check", d.checkSource)
+	}
+}
+
+func (d *Document) createSpace(c *wkhttp.Context) {
+	var req SaveSpaceReq
+	if err := c.BindJSON(&req); err != nil {
+		d.respondInvalidRequest(c, err)
+		return
+	}
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	state, err := d.service.CreateSpace(c.GetLoginUID(), tenantSpaceID, req)
+	d.respondState(c, state, err)
+}
+
+func (d *Document) updateSpace(c *wkhttp.Context) {
+	var req SaveSpaceReq
+	if err := c.BindJSON(&req); err != nil {
+		d.respondInvalidRequest(c, err)
+		return
+	}
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	state, err := d.service.UpdateSpace(c.GetLoginUID(), tenantSpaceID, c.Param("space_id"), req)
+	d.respondState(c, state, err)
+}
+
+func (d *Document) disableSpace(c *wkhttp.Context) {
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	state, err := d.service.DisableSpace(c.GetLoginUID(), tenantSpaceID, c.Param("space_id"))
+	d.respondState(c, state, err)
+}
+
+func (d *Document) saveSpaceMember(c *wkhttp.Context) {
+	var req SaveSpaceMemberReq
+	if err := c.BindJSON(&req); err != nil {
+		d.respondInvalidRequest(c, err)
+		return
+	}
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	state, err := d.service.UpsertSpaceMember(c.GetLoginUID(), tenantSpaceID, c.Param("space_id"), req)
+	d.respondState(c, state, err)
+}
+
+func (d *Document) searchSpaceMembers(c *wkhttp.Context) {
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	candidates, err := d.service.SearchSpaceMemberCandidates(
+		c.GetLoginUID(),
+		tenantSpaceID,
+		c.Param("space_id"),
+		c.Query("keyword"),
+	)
+	if err != nil {
+		d.respondDocumentError(c, err, false)
+		return
+	}
+	c.Response(candidates)
+}
+
+func (d *Document) removeSpaceMember(c *wkhttp.Context) {
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	state, err := d.service.RemoveSpaceMember(c.GetLoginUID(), tenantSpaceID, c.Param("space_id"), c.Param("member_uid"))
+	d.respondState(c, state, err)
+}
+
+func (d *Document) renameAsset(c *wkhttp.Context) {
+	var req RenameAssetReq
+	if err := c.BindJSON(&req); err != nil {
+		d.respondInvalidRequest(c, err)
+		return
+	}
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	state, err := d.service.RenameAsset(c.GetLoginUID(), tenantSpaceID, c.Param("asset_id"), req)
+	d.respondState(c, state, err)
+}
+
+func (d *Document) moveAsset(c *wkhttp.Context) {
+	var req MoveAssetReq
+	if err := c.BindJSON(&req); err != nil {
+		d.respondInvalidRequest(c, err)
+		return
+	}
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	state, err := d.service.MoveAsset(c.GetLoginUID(), tenantSpaceID, c.Param("asset_id"), req)
+	d.respondState(c, state, err)
+}
+
+func (d *Document) permanentDelete(c *wkhttp.Context) {
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	state, err := d.service.PermanentDelete(c.GetLoginUID(), tenantSpaceID, c.Param("asset_id"))
+	d.respondState(c, state, err)
+}
+
+func (d *Document) emptyTrash(c *wkhttp.Context) {
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	state, err := d.service.EmptyTrash(c.GetLoginUID(), tenantSpaceID)
+	d.respondState(c, state, err)
+}
+
+func (d *Document) bindConversation(c *wkhttp.Context) {
+	var req BindConversationReq
+	if err := c.BindJSON(&req); err != nil {
+		d.respondInvalidRequest(c, err)
+		return
+	}
+	if req.DocumentSpaceID == "" {
+		req.DocumentSpaceID = c.Param("space_id")
+	}
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	state, err := d.service.BindConversation(c.GetLoginUID(), tenantSpaceID, req)
+	d.respondState(c, state, err)
+}
+
+func (d *Document) unbindConversation(c *wkhttp.Context) {
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	state, err := d.service.UnbindConversation(c.GetLoginUID(), tenantSpaceID, c.Param("space_id"), c.Param("binding_id"))
+	d.respondState(c, state, err)
+}
+
+func (d *Document) searchSpaceBindings(c *wkhttp.Context) {
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	candidates, err := d.service.SearchBindingConversations(
+		c.GetLoginUID(),
+		tenantSpaceID,
+		c.Param("space_id"),
+		c.Query("keyword"),
+	)
+	if err != nil {
+		d.respondDocumentError(c, err, false)
+		return
+	}
+	c.Response(candidates)
+}
+
+func (d *Document) channelStorageSpace(c *wkhttp.Context) {
+	sourceChannelType, _ := strconv.Atoi(c.Query("source_channel_type"))
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	resp, err := d.service.ChannelStorageSpace(
+		c.GetLoginUID(),
+		tenantSpaceID,
+		c.Query("source_channel_id"),
+		uint8(sourceChannelType),
+	)
+	if err != nil {
+		d.respondDocumentError(c, err, false)
+		return
+	}
+	c.Response(resp)
+}
+
+func (d *Document) state(c *wkhttp.Context) {
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	state, err := d.service.State(c.GetLoginUID(), tenantSpaceID)
+	d.respondState(c, state, err)
+}
+
+func (d *Document) upload(c *wkhttp.Context) {
+	var req UploadReq
+	if err := c.BindJSON(&req); err != nil {
+		d.respondInvalidRequest(c, err)
+		return
+	}
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	state, err := d.service.Upload(c.GetLoginUID(), tenantSpaceID, req)
+	d.respondState(c, state, err)
+}
+
+func (d *Document) archive(c *wkhttp.Context) {
+	var req ArchiveReq
+	if err := c.BindJSON(&req); err != nil {
+		d.respondInvalidRequest(c, err)
+		return
+	}
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	state, err := d.service.Archive(c.GetLoginUID(), tenantSpaceID, req)
+	d.respondState(c, state, err)
+}
+
+func (d *Document) preview(c *wkhttp.Context) {
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	state, err := d.service.Preview(c.GetLoginUID(), tenantSpaceID, c.Param("asset_id"))
+	d.respondState(c, state, err)
+}
+
+func (d *Document) download(c *wkhttp.Context) {
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	state, err := d.service.Download(c.GetLoginUID(), tenantSpaceID, c.Param("asset_id"))
+	d.respondState(c, state, err)
+}
+
+func (d *Document) trash(c *wkhttp.Context) {
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	state, err := d.service.Trash(c.GetLoginUID(), tenantSpaceID, c.Param("asset_id"))
+	d.respondState(c, state, err)
+}
+
+func (d *Document) restore(c *wkhttp.Context) {
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	state, err := d.service.Restore(c.GetLoginUID(), tenantSpaceID, c.Param("asset_id"))
+	d.respondState(c, state, err)
+}
+
+func (d *Document) checkSource(c *wkhttp.Context) {
+	assetID := c.Query("asset_id")
+	tenantSpaceID, ok := d.requestTenantSpaceID(c)
+	if !ok {
+		return
+	}
+	accessible, err := d.service.CheckSource(c.GetLoginUID(), tenantSpaceID, assetID)
+	if err != nil {
+		d.Error("检查来源会话失败", zap.Error(err))
+		d.respondDocumentError(c, err, false)
+		return
+	}
+	c.Response(map[string]bool{"accessible": accessible})
+}
+
+func (d *Document) requestTenantSpaceID(c *wkhttp.Context) (string, bool) {
+	tenantSpaceID, ok := tenantSpaceID(c)
+	if !ok {
+		d.respondDocumentError(c, errors.New("空间不能为空"), false)
+		return "", false
+	}
+	return tenantSpaceID, true
+}
+
+func (d *Document) respondState(c *wkhttp.Context, state *DocumentStateResp, err error) {
+	if err != nil {
+		d.respondDocumentError(c, err, true)
+		return
+	}
+	c.Response(state)
+}
+
+func (d *Document) respondInvalidRequest(c *wkhttp.Context, err error) {
+	d.Warn("文档中心请求参数无效", zap.Error(err))
+	httperr.ResponseErrorL(c, errcode.ErrDocumentRequestInvalid, nil, nil)
+}
+
+func (d *Document) respondDocumentError(c *wkhttp.Context, err error, mutation bool) {
+	code := documentErrorCode(err, mutation)
+	if code.Internal {
+		d.Error("文档中心请求失败", zap.String("code", code.ID), zap.Error(err))
+	} else {
+		d.Warn("文档中心请求失败", zap.String("code", code.ID), zap.Error(err))
+	}
+	httperr.ResponseErrorL(c, code, nil, nil)
+}
+
+func documentErrorCode(err error, mutation bool) codes.Code {
+	if err == nil {
+		return errcode.ErrDocumentQueryFailed
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "不存在"):
+		return errcode.ErrDocumentNotFound
+	case strings.Contains(msg, "无权") ||
+		strings.Contains(msg, "不是空间成员") ||
+		strings.Contains(msg, "仅空间所有者") ||
+		strings.Contains(msg, "文件已在回收站") ||
+		strings.Contains(msg, "只能彻底删除回收站"):
+		return errcode.ErrDocumentForbidden
+	case strings.Contains(msg, "不能为空") ||
+		strings.Contains(msg, "无效") ||
+		strings.Contains(msg, "缺失") ||
+		strings.Contains(msg, "已存在") ||
+		strings.Contains(msg, "不支持") ||
+		strings.Contains(msg, "非法"):
+		return errcode.ErrDocumentRequestInvalid
+	case mutation:
+		return errcode.ErrDocumentStoreFailed
+	default:
+		return errcode.ErrDocumentQueryFailed
+	}
+}
+
+func tenantSpaceID(c *wkhttp.Context) (string, bool) {
+	if spaceID := spacepkg.GetSpaceID(c); spaceID != "" {
+		return spaceID, true
+	}
+	return "", false
+}

--- a/modules/document/api_test.go
+++ b/modules/document/api_test.go
@@ -1,0 +1,63 @@
+package document
+
+import (
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() { gin.SetMode(gin.TestMode) }
+
+func TestTenantSpaceIDUsesOnlyMiddlewareValidatedSpace(t *testing.T) {
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ginCtx.Request = httptest.NewRequest("GET", "/v1/documents/state?space_id=forged-query", nil)
+	ginCtx.Request.Header.Set("X-Space-ID", "forged-header")
+	ginCtx.Set("space_id", "validated-space")
+	c := &wkhttp.Context{Context: ginCtx}
+
+	spaceID, ok := tenantSpaceID(c)
+
+	assert.True(t, ok)
+	assert.Equal(t, "validated-space", spaceID)
+}
+
+func TestTenantSpaceIDRejectsMissingMiddlewareSpace(t *testing.T) {
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ginCtx.Request = httptest.NewRequest("GET", "/v1/documents/state?space_id=forged-query", nil)
+	ginCtx.Request.Header.Set("X-Space-ID", "forged-header")
+	c := &wkhttp.Context{Context: ginCtx}
+
+	spaceID, ok := tenantSpaceID(c)
+
+	assert.False(t, ok)
+	assert.Empty(t, spaceID)
+}
+
+func TestDocumentErrorCodeClassifiesBusinessErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		mutation bool
+		wantID   string
+	}{
+		{"space_name_duplicate", errors.New("空间名称已存在"), true, errcode.ErrDocumentRequestInvalid.ID},
+		{"owner_only_denied", errors.New("仅空间所有者可操作"), true, errcode.ErrDocumentForbidden.ID},
+		{"permanent_delete_guard", errors.New("只能彻底删除回收站文件"), true, errcode.ErrDocumentForbidden.ID},
+		{"invalid_filename", errors.New("文件名非法"), true, errcode.ErrDocumentRequestInvalid.ID},
+		{"unsupported_transfer", errors.New("暂不支持转让空间"), true, errcode.ErrDocumentRequestInvalid.ID},
+		{"missing_resource", errors.New("文档不存在"), false, errcode.ErrDocumentNotFound.ID},
+		{"unknown_mutation", errors.New("database timeout"), true, errcode.ErrDocumentStoreFailed.ID},
+		{"unknown_query", errors.New("database timeout"), false, errcode.ErrDocumentQueryFailed.ID},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := documentErrorCode(tt.err, tt.mutation)
+			assert.Equal(t, tt.wantID, got.ID)
+		})
+	}
+}

--- a/modules/document/db.go
+++ b/modules/document/db.go
@@ -1,0 +1,503 @@
+package document
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/gocraft/dbr/v2"
+)
+
+type documentDB struct {
+	ctx     *config.Context
+	session *dbr.Session
+}
+
+func newDocumentDB(ctx *config.Context) *documentDB {
+	return &documentDB{
+		ctx:     ctx,
+		session: ctx.DB(),
+	}
+}
+
+func (d *documentDB) ListSpaces(uid, tenantSpaceID string) ([]*DocumentSpaceModel, error) {
+	var spaces []*DocumentSpaceModel
+	_, err := d.session.SelectBySql(
+		`SELECT ds.*
+		 FROM document_space ds
+		 WHERE ds.tenant_space_id=? AND ds.status=1
+		   AND (
+		     ds.owner_uid=?
+		     OR EXISTS (
+		       SELECT 1
+		       FROM document_space_member dsm
+		       WHERE dsm.tenant_space_id=ds.tenant_space_id
+		         AND dsm.document_space_id=ds.space_id
+		         AND dsm.uid=?
+		         AND dsm.status=1
+		     )
+		   )
+		 ORDER BY ds.created_at DESC`,
+		tenantSpaceID,
+		uid,
+		uid,
+	).Load(&spaces)
+	return spaces, err
+}
+
+func (d *documentDB) ListAllSpaces(uid, tenantSpaceID string) ([]*DocumentSpaceModel, error) {
+	var spaces []*DocumentSpaceModel
+	_, err := d.session.Select("*").From("document_space").
+		Where("tenant_space_id=?", tenantSpaceID).
+		OrderDesc("created_at").
+		Load(&spaces)
+	return spaces, err
+}
+
+func (d *documentDB) EnsureDefaultSpace(uid, tenantSpaceID string) (*DocumentSpaceModel, error) {
+	spaces, err := d.ListSpaces(uid, tenantSpaceID)
+	if err != nil {
+		return nil, err
+	}
+	if len(spaces) > 0 {
+		return spaces[0], nil
+	}
+	now := nowDBTime()
+	space := &DocumentSpaceModel{
+		SpaceID:       "DOCSPACE-" + util.GenerUUID(),
+		Name:          "团队文档空间",
+		Description:   "默认文档空间",
+		OwnerUID:      uid,
+		TenantSpaceID: tenantSpaceID,
+		Status:        1,
+	}
+	space.CreatedAt = now
+	space.UpdatedAt = now
+	if _, err := d.session.InsertInto("document_space").Columns(util.AttrToUnderscore(space)...).Record(space).Exec(); err != nil {
+		return nil, err
+	}
+	return space, nil
+}
+
+func (d *documentDB) GetSpace(spaceID, uid, tenantSpaceID string) (*DocumentSpaceModel, error) {
+	var space *DocumentSpaceModel
+	_, err := d.session.Select("*").From("document_space").
+		Where("space_id=? and tenant_space_id=? and status=1", spaceID, tenantSpaceID).
+		Load(&space)
+	return space, err
+}
+
+func (d *documentDB) SaveSpace(space *DocumentSpaceModel) error {
+	_, err := d.session.InsertInto("document_space").Columns(util.AttrToUnderscore(space)...).Record(space).Exec()
+	return err
+}
+
+func (d *documentDB) UpdateSpace(space *DocumentSpaceModel) error {
+	_, err := d.session.Update("document_space").
+		Set("name", space.Name).
+		Set("description", space.Description).
+		Set("owner_uid", space.OwnerUID).
+		Set("status", space.Status).
+		Set("updated_at", time.Now()).
+		Where("space_id=? and tenant_space_id=?", space.SpaceID, space.TenantSpaceID).
+		Exec()
+	return err
+}
+
+func (d *documentDB) ListSpaceBindings(uid, tenantSpaceID string) ([]*DocumentSpaceBindingModel, error) {
+	var bindings []*DocumentSpaceBindingModel
+	_, err := d.session.Select("*").From("document_space_binding").
+		Where("tenant_space_id=? and status=1", tenantSpaceID).
+		OrderDesc("created_at").
+		Load(&bindings)
+	return bindings, err
+}
+
+func (d *documentDB) SaveSpaceBinding(binding *DocumentSpaceBindingModel) error {
+	tx, err := d.session.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	if _, err := tx.Update("document_space_binding").
+		Set("status", 0).
+		Set("updated_at", time.Now()).
+		Where("tenant_space_id=? and source_channel_id=? and source_channel_type=? and document_space_id<>?",
+			binding.TenantSpaceID,
+			binding.SourceChannelID,
+			binding.SourceChannelType,
+			binding.DocumentSpaceID,
+		).
+		Exec(); err != nil {
+		return err
+	}
+	_, err = tx.InsertBySql(
+		`INSERT INTO document_space_binding
+			(binding_id, document_space_id, source_channel_id, source_channel_type, source_name, created_by, tenant_space_id, status, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 ON DUPLICATE KEY UPDATE
+			source_name=VALUES(source_name),
+			created_by=VALUES(created_by),
+			status=VALUES(status),
+			updated_at=VALUES(updated_at)`,
+		binding.BindingID,
+		binding.DocumentSpaceID,
+		binding.SourceChannelID,
+		binding.SourceChannelType,
+		binding.SourceName,
+		binding.CreatedBy,
+		binding.TenantSpaceID,
+		binding.Status,
+		binding.CreatedAt.String(),
+		binding.UpdatedAt.String(),
+	).Exec()
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (d *documentDB) RemoveSpaceBinding(spaceID, bindingID, tenantSpaceID string) error {
+	_, err := d.session.Update("document_space_binding").
+		Set("status", 0).
+		Set("updated_at", time.Now()).
+		Where("document_space_id=? and binding_id=? and tenant_space_id=?", spaceID, bindingID, tenantSpaceID).
+		Exec()
+	return err
+}
+
+func (d *documentDB) ListSpaceMembers(uid, tenantSpaceID string) ([]*DocumentSpaceMemberModel, error) {
+	var members []*DocumentSpaceMemberModel
+	_, err := d.session.Select("*").From("document_space_member").
+		Where("tenant_space_id=? and status=1", tenantSpaceID).
+		OrderDesc("created_at").
+		Load(&members)
+	return members, err
+}
+
+func (d *documentDB) SearchUsers(uid, tenantSpaceID, keyword string, limit int) ([]*DocumentUserCandidateModel, error) {
+	keyword = strings.TrimSpace(keyword)
+	if keyword == "" {
+		return []*DocumentUserCandidateModel{}, nil
+	}
+	if limit <= 0 || limit > 20 {
+		limit = 20
+	}
+	like := "%" + keyword + "%"
+	var users []*DocumentUserCandidateModel
+	_, err := d.session.SelectBySql(
+		`SELECT DISTINCT
+			u.uid,
+			IFNULL(u.name, '') AS name,
+			IFNULL(u.username, '') AS username,
+			IFNULL(u.email, '') AS email,
+			IFNULL(u.phone, '') AS phone
+		 FROM `+"`user`"+` u
+		 INNER JOIN space_member sm ON sm.uid=u.uid AND sm.space_id=? AND sm.status=1
+		 WHERE u.status=1
+		   AND IFNULL(u.robot,0)=0
+		   AND (u.uid LIKE ? OR u.name LIKE ? OR u.username LIKE ? OR u.email LIKE ? OR u.phone LIKE ?)
+		 ORDER BY name ASC, username ASC
+		 LIMIT ?`,
+		tenantSpaceID,
+		like,
+		like,
+		like,
+		like,
+		like,
+		limit,
+	).Load(&users)
+	return users, err
+}
+
+func (d *documentDB) SearchGroups(uid, tenantSpaceID, keyword string, limit int) ([]*DocumentGroupCandidateModel, error) {
+	keyword = strings.TrimSpace(keyword)
+	if keyword == "" {
+		return []*DocumentGroupCandidateModel{}, nil
+	}
+	if limit <= 0 || limit > 20 {
+		limit = 20
+	}
+	like := "%" + keyword + "%"
+	var groups []*DocumentGroupCandidateModel
+	_, err := d.session.SelectBySql(
+		`SELECT g.group_no, IFNULL(g.name, '') AS name, IFNULL(g.space_id, '') AS space_id
+		 FROM group_member gm
+		 INNER JOIN `+"`group`"+` g ON g.group_no=gm.group_no AND g.status=1
+		 WHERE gm.uid=? AND gm.is_deleted=0 AND gm.status=1
+		   AND (g.space_id=? OR IFNULL(g.space_id, '')='' OR IFNULL(gm.source_space_id, '')=?)
+		   AND (g.group_no LIKE ? OR g.name LIKE ?)
+		 ORDER BY g.updated_at DESC
+		 LIMIT ?`,
+		uid,
+		tenantSpaceID,
+		tenantSpaceID,
+		like,
+		like,
+		limit,
+	).Load(&groups)
+	return groups, err
+}
+
+func (d *documentDB) SaveSpaceMember(member *DocumentSpaceMemberModel) error {
+	_, err := d.session.InsertBySql(
+		`INSERT INTO document_space_member
+			(member_id, document_space_id, uid, name, role, source, created_by, tenant_space_id, status, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 ON DUPLICATE KEY UPDATE
+			name=VALUES(name),
+			role=VALUES(role),
+			status=VALUES(status),
+			updated_at=VALUES(updated_at)`,
+		member.MemberID,
+		member.DocumentSpaceID,
+		member.UID,
+		member.Name,
+		member.Role,
+		member.Source,
+		member.CreatedBy,
+		member.TenantSpaceID,
+		member.Status,
+		member.CreatedAt.String(),
+		member.UpdatedAt.String(),
+	).Exec()
+	return err
+}
+
+func (d *documentDB) RemoveSpaceMember(spaceID, memberUID, tenantSpaceID string) error {
+	_, err := d.session.Update("document_space_member").
+		Set("status", 0).
+		Set("updated_at", time.Now()).
+		Where("document_space_id=? and uid=? and tenant_space_id=?", spaceID, memberUID, tenantSpaceID).
+		Exec()
+	return err
+}
+
+func (d *documentDB) ListAssets(uid, tenantSpaceID string) ([]*DocumentAssetModel, error) {
+	var assets []*DocumentAssetModel
+	_, err := d.session.Select("*").From("document_asset").
+		Where("tenant_space_id=?", tenantSpaceID).
+		OrderDesc("last_access_at").
+		OrderDesc("created_at").
+		Load(&assets)
+	if err == nil {
+		d.populateSourceMessageSeqs(assets)
+	}
+	return assets, err
+}
+
+func (d *documentDB) GetAsset(assetID, uid, tenantSpaceID string) (*DocumentAssetModel, error) {
+	var asset *DocumentAssetModel
+	_, err := d.session.Select("*").From("document_asset").
+		Where("asset_id=? and tenant_space_id=?", assetID, tenantSpaceID).
+		Load(&asset)
+	if err == nil && asset != nil {
+		d.populateSourceMessageSeqs([]*DocumentAssetModel{asset})
+	}
+	return asset, err
+}
+
+type documentMessageSeqRow struct {
+	MessageID   string `db:"message_id"`
+	ClientMsgNo string `db:"client_msg_no"`
+	MessageSeq  uint32 `db:"message_seq"`
+}
+
+func (d *documentDB) populateSourceMessageSeqs(assets []*DocumentAssetModel) {
+	messageIDs := make([]string, 0, len(assets))
+	for _, asset := range assets {
+		if asset.SourceMessageID != "" {
+			messageIDs = append(messageIDs, asset.SourceMessageID)
+		}
+	}
+	if len(messageIDs) == 0 {
+		return
+	}
+
+	seqs := make(map[string]uint32)
+	for _, table := range []string{"message", "message1", "message2", "message3", "message4"} {
+		rows := make([]*documentMessageSeqRow, 0)
+		_, err := d.session.SelectBySql(
+			fmt.Sprintf("SELECT message_id, client_msg_no, message_seq FROM `%s` WHERE message_id IN ? OR client_msg_no IN ?", table),
+			messageIDs,
+			messageIDs,
+		).Load(&rows)
+		if err != nil {
+			continue
+		}
+		for _, row := range rows {
+			if row.MessageID != "" {
+				seqs[row.MessageID] = row.MessageSeq
+			}
+			if row.ClientMsgNo != "" {
+				seqs[row.ClientMsgNo] = row.MessageSeq
+			}
+		}
+	}
+	for _, asset := range assets {
+		asset.SourceMessageSeq = seqs[asset.SourceMessageID]
+	}
+}
+
+func (d *documentDB) SaveAsset(asset *DocumentAssetModel) error {
+	var lastAccessAt interface{}
+	if asset.LastAccessAt != nil {
+		lastAccessAt = asset.LastAccessAt.String()
+	}
+	_, err := d.session.InsertBySql(
+		`INSERT INTO document_asset
+			(asset_id, name, kind, extension, size, storage_path,
+			 source_type, source_channel_id, source_channel_type, source_message_id, source_name,
+			 uploader_uid, uploader_name, owner_uid, owner_name, tenant_space_id,
+			 document_space_id, original_space_id, visibility, status, downloads, previewable,
+			 last_access_at, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?,
+			 ?, ?, ?, ?, ?,
+			 ?, ?, ?, ?, ?,
+			 ?, ?, ?, ?, ?, ?,
+			 ?, ?, ?)`,
+		asset.AssetID,
+		asset.Name,
+		asset.Kind,
+		asset.Extension,
+		asset.Size,
+		asset.StoragePath,
+		asset.SourceType,
+		asset.SourceChannelID,
+		asset.SourceChannelType,
+		asset.SourceMessageID,
+		asset.SourceName,
+		asset.UploaderUID,
+		asset.UploaderName,
+		asset.OwnerUID,
+		asset.OwnerName,
+		asset.TenantSpaceID,
+		asset.DocumentSpaceID,
+		asset.OriginalSpaceID,
+		asset.Visibility,
+		asset.Status,
+		asset.Downloads,
+		asset.Previewable,
+		lastAccessAt,
+		asset.CreatedAt.String(),
+		asset.UpdatedAt.String(),
+	).Exec()
+	return err
+}
+
+func (d *documentDB) UpdateAsset(asset *DocumentAssetModel) error {
+	var lastAccessAt interface{}
+	if asset.LastAccessAt != nil {
+		lastAccessAt = asset.LastAccessAt.String()
+	}
+	_, err := d.session.Update("document_asset").
+		Set("name", asset.Name).
+		Set("kind", asset.Kind).
+		Set("extension", asset.Extension).
+		Set("document_space_id", asset.DocumentSpaceID).
+		Set("original_space_id", asset.OriginalSpaceID).
+		Set("visibility", asset.Visibility).
+		Set("status", asset.Status).
+		Set("downloads", asset.Downloads).
+		Set("last_access_at", lastAccessAt).
+		Set("updated_at", time.Now()).
+		Where("asset_id=? and tenant_space_id=?", asset.AssetID, asset.TenantSpaceID).
+		Exec()
+	return err
+}
+
+func (d *documentDB) DeleteAsset(assetID, tenantSpaceID string) error {
+	_, err := d.session.DeleteFrom("document_asset").
+		Where("asset_id=? and tenant_space_id=?", assetID, tenantSpaceID).
+		Exec()
+	return err
+}
+
+func (d *documentDB) AddEvent(event *DocumentEventModel) error {
+	_, err := d.session.InsertInto("document_asset_event").Columns(util.AttrToUnderscore(event)...).Record(event).Exec()
+	return err
+}
+
+func (d *documentDB) ListEvents(uid, tenantSpaceID string, limit int) ([]*DocumentEventModel, error) {
+	var events []*DocumentEventModel
+	query := d.session.Select("*").From("document_asset_event").
+		Where("tenant_space_id=?", tenantSpaceID).
+		OrderDesc("created_at").
+		OrderDesc("id")
+	if limit > 0 {
+		query = query.Limit(uint64(limit))
+	}
+	_, err := query.Load(&events)
+	return events, err
+}
+
+func (d *documentDB) CanAccessSource(uid, tenantSpaceID, sourceChannelID string, sourceChannelType uint8) (bool, error) {
+	if sourceChannelID == "" {
+		return false, nil
+	}
+	if sourceChannelType == 2 {
+		var count int
+		_, err := d.session.SelectBySql(
+			`SELECT count(*)
+			 FROM group_member gm
+			 INNER JOIN `+"`group`"+` g ON g.group_no=gm.group_no AND g.status=1 AND g.space_id=?
+			 WHERE gm.group_no=? AND gm.uid=? AND gm.status=1 AND gm.is_deleted=0`,
+			tenantSpaceID,
+			sourceChannelID,
+			uid,
+		).Load(&count)
+		return count > 0, err
+	}
+	return sourceChannelID == uid, nil
+}
+
+func (d *documentDB) CanAccessSources(uid, tenantSpaceID string, sources []documentSourceRef) (map[string]bool, error) {
+	result := make(map[string]bool, len(sources))
+	groupIDs := make([]string, 0, len(sources))
+	seenGroups := make(map[string]struct{}, len(sources))
+	for _, source := range sources {
+		if strings.TrimSpace(source.ChannelID) == "" {
+			continue
+		}
+		if source.ChannelType != 2 {
+			if source.ChannelID == uid {
+				result[documentSourceKey(source.ChannelID, source.ChannelType)] = true
+			}
+			continue
+		}
+		if _, ok := seenGroups[source.ChannelID]; ok {
+			continue
+		}
+		seenGroups[source.ChannelID] = struct{}{}
+		groupIDs = append(groupIDs, source.ChannelID)
+	}
+	if len(groupIDs) == 0 {
+		return result, nil
+	}
+
+	rows := make([]struct {
+		GroupNo string `db:"group_no"`
+	}, 0, len(groupIDs))
+	_, err := d.session.SelectBySql(
+		`SELECT DISTINCT gm.group_no
+		 FROM group_member gm
+		 INNER JOIN `+"`group`"+` g ON g.group_no=gm.group_no AND g.status=1 AND g.space_id=?
+		 WHERE gm.group_no IN ?
+		   AND gm.uid=?
+		   AND gm.status=1
+		   AND gm.is_deleted=0`,
+		tenantSpaceID,
+		groupIDs,
+		uid,
+	).Load(&rows)
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		result[documentSourceKey(row.GroupNo, 2)] = true
+	}
+	return result, nil
+}

--- a/modules/document/model.go
+++ b/modules/document/model.go
@@ -1,0 +1,334 @@
+package document
+
+import (
+	"path/filepath"
+	"strings"
+	"time"
+
+	dbbase "github.com/Mininglamp-OSS/octo-server/pkg/db"
+)
+
+const (
+	StatusConversation = "conversation"
+	StatusArchived     = "archived"
+	StatusDeleted      = "deleted"
+
+	VisibilityConversation = "conversation"
+	VisibilitySpace        = "space"
+
+	KindPDF   = "pdf"
+	KindDoc   = "doc"
+	KindSheet = "sheet"
+	KindImage = "image"
+	KindZip   = "zip"
+
+	SourceTypePerson = "单聊"
+	SourceTypeGroup  = "群聊"
+	SourceTypeApp    = "上传"
+
+	SourceNameDirectUpload = "直接上传"
+
+	SpaceRoleOwner  = "owner"
+	SpaceRoleAdmin  = "admin"
+	SpaceRoleEditor = "editor"
+	SpaceRoleViewer = "viewer"
+)
+
+type DocumentSpaceModel struct {
+	SpaceID       string
+	Name          string
+	Description   string
+	OwnerUID      string
+	TenantSpaceID string
+	Status        int
+	dbbase.BaseModel
+}
+
+type DocumentSpaceBindingModel struct {
+	BindingID         string
+	DocumentSpaceID   string
+	SourceChannelID   string
+	SourceChannelType uint8
+	SourceName        string
+	CreatedBy         string
+	TenantSpaceID     string
+	Status            int
+	dbbase.BaseModel
+}
+
+type DocumentSpaceMemberModel struct {
+	MemberID        string
+	DocumentSpaceID string
+	UID             string
+	Name            string
+	Role            string
+	Source          string
+	CreatedBy       string
+	TenantSpaceID   string
+	Status          int
+	dbbase.BaseModel
+}
+
+type DocumentUserCandidateModel struct {
+	UID      string
+	Name     string
+	Username string
+	Email    string
+	Phone    string
+}
+
+type DocumentGroupCandidateModel struct {
+	GroupNo string
+	Name    string
+	SpaceID string
+}
+
+type DocumentAssetModel struct {
+	AssetID           string
+	Name              string
+	Kind              string
+	Extension         string
+	Size              int64
+	StoragePath       string
+	SourceType        string
+	SourceChannelID   string
+	SourceChannelType uint8
+	SourceMessageID   string
+	SourceMessageSeq  uint32 `db:"-"`
+	SourceName        string
+	UploaderUID       string
+	UploaderName      string
+	OwnerUID          string
+	OwnerName         string
+	TenantSpaceID     string
+	DocumentSpaceID   string
+	OriginalSpaceID   string
+	Visibility        string
+	Status            string
+	Downloads         int
+	Previewable       int
+	LastAccessAt      *dbbase.Time
+	dbbase.BaseModel
+}
+
+type DocumentEventModel struct {
+	EventID       string
+	AssetID       string
+	ActorUID      string
+	Action        string
+	Detail        string
+	TenantSpaceID string
+	dbbase.BaseModel
+}
+
+type DocumentAssetResp struct {
+	ID                string                 `json:"id"`
+	Name              string                 `json:"name"`
+	Kind              string                 `json:"kind"`
+	Extension         string                 `json:"extension"`
+	Size              int64                  `json:"size"`
+	StoragePath       string                 `json:"storagePath"`
+	Owner             string                 `json:"owner"`
+	Uploader          string                 `json:"uploader"`
+	SourceName        string                 `json:"sourceName"`
+	SourceChannelID   string                 `json:"sourceChannelId"`
+	SourceChannelType uint8                  `json:"sourceChannelType"`
+	SourceType        string                 `json:"sourceType"`
+	SpaceName         string                 `json:"spaceName"`
+	Visibility        string                 `json:"visibility"`
+	Status            string                 `json:"status"`
+	CreatedAt         string                 `json:"createdAt"`
+	LastAccessAt      string                 `json:"lastAccessAt"`
+	Downloads         int                    `json:"downloads"`
+	Previewable       bool                   `json:"previewable"`
+	Flow              []string               `json:"flow"`
+	SourceRef         *DocumentSourceRefResp `json:"sourceRef,omitempty"`
+	Permissions       DocumentPermissionResp `json:"permissions"`
+}
+
+type DocumentSourceRefResp struct {
+	ChannelID   string `json:"channelId"`
+	ChannelType uint8  `json:"channelType"`
+	ChannelName string `json:"channelName"`
+	MessageID   string `json:"messageId"`
+	MessageSeq  uint32 `json:"messageSeq"`
+	SenderUID   string `json:"senderUid"`
+	SenderName  string `json:"senderName"`
+	SentAt      string `json:"sentAt"`
+}
+
+type DocumentPermissionResp struct {
+	CanPreview  bool     `json:"canPreview"`
+	CanDownload bool     `json:"canDownload"`
+	CanArchive  bool     `json:"canArchive"`
+	CanEdit     bool     `json:"canEdit"`
+	CanDelete   bool     `json:"canDelete"`
+	CanRestore  bool     `json:"canRestore"`
+	CanManage   bool     `json:"canManage"`
+	Summary     string   `json:"summary"`
+	Reasons     []string `json:"reasons"`
+}
+
+type DocumentSpaceMemberResp struct {
+	UID      string `json:"uid"`
+	Name     string `json:"name"`
+	Role     string `json:"role"`
+	Source   string `json:"source"`
+	JoinedAt string `json:"joinedAt"`
+}
+
+type DocumentMemberCandidateResp struct {
+	UID           string `json:"uid"`
+	Name          string `json:"name"`
+	Username      string `json:"username,omitempty"`
+	Email         string `json:"email,omitempty"`
+	Phone         string `json:"phone,omitempty"`
+	AlreadyMember bool   `json:"alreadyMember"`
+}
+
+type DocumentGroupBindingCandidateResp struct {
+	ChannelID                  string `json:"channelId"`
+	ChannelType                uint8  `json:"channelType"`
+	Name                       string `json:"name"`
+	BoundSpaceID               string `json:"boundSpaceId,omitempty"`
+	BoundSpaceName             string `json:"boundSpaceName,omitempty"`
+	AlreadyBoundToCurrentSpace bool   `json:"alreadyBoundToCurrentSpace"`
+}
+
+type DocumentChannelStorageSpaceResp struct {
+	SpaceID   string `json:"spaceId"`
+	SpaceName string `json:"spaceName"`
+}
+
+type DocumentSpaceBindingResp struct {
+	ID          string `json:"id"`
+	ChannelID   string `json:"channelId"`
+	ChannelType uint8  `json:"channelType"`
+	Name        string `json:"name"`
+	CreatedBy   string `json:"createdBy"`
+}
+
+type DocumentSpaceResp struct {
+	ID                 string                      `json:"id"`
+	Name               string                      `json:"name"`
+	Owner              string                      `json:"owner"`
+	FileCount          int                         `json:"fileCount"`
+	MemberCount        int                         `json:"memberCount"`
+	Members            []*DocumentSpaceMemberResp  `json:"members"`
+	BoundConversations []*DocumentSpaceBindingResp `json:"boundConversations"`
+	PinnedFileIDs      []string                    `json:"pinnedFileIds"`
+	Description        string                      `json:"description"`
+}
+
+type DocumentAuditResp struct {
+	ID     string `json:"id"`
+	Time   string `json:"time"`
+	Actor  string `json:"actor"`
+	Action string `json:"action"`
+	Target string `json:"target"`
+	Detail string `json:"detail"`
+}
+
+type DocumentStateResp struct {
+	Files  []*DocumentAssetResp `json:"files"`
+	Spaces []*DocumentSpaceResp `json:"spaces"`
+	Audits []*DocumentAuditResp `json:"audits"`
+}
+
+type UploadReq struct {
+	Name            string `json:"name"`
+	Extension       string `json:"extension"`
+	Size            int64  `json:"size"`
+	StoragePath     string `json:"storage_path"`
+	DocumentSpaceID string `json:"document_space_id"`
+	UploaderName    string `json:"uploader_name"`
+}
+
+type ArchiveReq struct {
+	AssetID           string `json:"asset_id"`
+	DocumentSpaceID   string `json:"document_space_id"`
+	Name              string `json:"name"`
+	Extension         string `json:"extension"`
+	Size              int64  `json:"size"`
+	StoragePath       string `json:"storage_path"`
+	SourceType        string `json:"source_type"`
+	SourceChannelID   string `json:"source_channel_id"`
+	SourceChannelType uint8  `json:"source_channel_type"`
+	SourceMessageID   string `json:"source_message_id"`
+	SourceName        string `json:"source_name"`
+	UploaderUID       string `json:"uploader_uid"`
+	UploaderName      string `json:"uploader_name"`
+}
+
+type BindConversationReq struct {
+	DocumentSpaceID   string `json:"document_space_id"`
+	SourceChannelID   string `json:"source_channel_id"`
+	SourceChannelType uint8  `json:"source_channel_type"`
+	SourceName        string `json:"source_name"`
+}
+
+type SaveSpaceReq struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type SaveSpaceMemberReq struct {
+	UID  string `json:"uid"`
+	Name string `json:"name"`
+	Role string `json:"role"`
+}
+
+type RenameAssetReq struct {
+	Name string `json:"name"`
+}
+
+type MoveAssetReq struct {
+	DocumentSpaceID string `json:"document_space_id"`
+}
+
+func documentKind(extension string) string {
+	ext := strings.ToLower(strings.TrimPrefix(extension, "."))
+	switch ext {
+	case "pdf":
+		return KindPDF
+	case "xls", "xlsx", "csv":
+		return KindSheet
+	case "png", "jpg", "jpeg", "gif", "webp":
+		return KindImage
+	case "zip", "rar", "7z":
+		return KindZip
+	default:
+		return KindDoc
+	}
+}
+
+func normalizeExtension(name, extension string) string {
+	ext := strings.TrimSpace(extension)
+	if ext == "" {
+		ext = filepath.Ext(name)
+	}
+	if ext == "" {
+		return ""
+	}
+	if !strings.HasPrefix(ext, ".") {
+		ext = "." + ext
+	}
+	return strings.ToLower(ext)
+}
+
+func previewableForExtension(extension string) int {
+	switch strings.ToLower(strings.TrimPrefix(extension, ".")) {
+	case "zip", "rar", "7z":
+		return 0
+	default:
+		return 1
+	}
+}
+
+func formatDBTime(t dbbase.Time) string {
+	return t.String()
+}
+
+func nowDBTime() dbbase.Time {
+	return dbbase.Time(time.Now())
+}

--- a/modules/document/service.go
+++ b/modules/document/service.go
@@ -1,0 +1,1761 @@
+package document
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+)
+
+type documentRepository interface {
+	ListSpaces(uid, tenantSpaceID string) ([]*DocumentSpaceModel, error)
+	ListAllSpaces(uid, tenantSpaceID string) ([]*DocumentSpaceModel, error)
+	EnsureDefaultSpace(uid, tenantSpaceID string) (*DocumentSpaceModel, error)
+	GetSpace(spaceID, uid, tenantSpaceID string) (*DocumentSpaceModel, error)
+	SaveSpace(space *DocumentSpaceModel) error
+	UpdateSpace(space *DocumentSpaceModel) error
+	ListSpaceBindings(uid, tenantSpaceID string) ([]*DocumentSpaceBindingModel, error)
+	SaveSpaceBinding(binding *DocumentSpaceBindingModel) error
+	RemoveSpaceBinding(spaceID, bindingID, tenantSpaceID string) error
+	ListSpaceMembers(uid, tenantSpaceID string) ([]*DocumentSpaceMemberModel, error)
+	SearchUsers(uid, tenantSpaceID, keyword string, limit int) ([]*DocumentUserCandidateModel, error)
+	SearchGroups(uid, tenantSpaceID, keyword string, limit int) ([]*DocumentGroupCandidateModel, error)
+	SaveSpaceMember(member *DocumentSpaceMemberModel) error
+	RemoveSpaceMember(spaceID, memberUID, tenantSpaceID string) error
+	ListAssets(uid, tenantSpaceID string) ([]*DocumentAssetModel, error)
+	GetAsset(assetID, uid, tenantSpaceID string) (*DocumentAssetModel, error)
+	SaveAsset(asset *DocumentAssetModel) error
+	UpdateAsset(asset *DocumentAssetModel) error
+	DeleteAsset(assetID, tenantSpaceID string) error
+	AddEvent(event *DocumentEventModel) error
+	ListEvents(uid, tenantSpaceID string, limit int) ([]*DocumentEventModel, error)
+	CanAccessSource(uid, tenantSpaceID, sourceChannelID string, sourceChannelType uint8) (bool, error)
+	CanAccessSources(uid, tenantSpaceID string, sources []documentSourceRef) (map[string]bool, error)
+}
+
+type documentSourceRef struct {
+	ChannelID   string
+	ChannelType uint8
+}
+
+type DocumentService struct {
+	repo documentRepository
+}
+
+func NewDocumentService(repo documentRepository) *DocumentService {
+	return &DocumentService{repo: repo}
+}
+
+func (s *DocumentService) State(uid, tenantSpaceID string) (*DocumentStateResp, error) {
+	if strings.TrimSpace(uid) == "" {
+		return nil, errors.New("uid is required")
+	}
+	space, err := s.repo.EnsureDefaultSpace(uid, tenantSpaceID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.saveOwnerMember(uid, tenantSpaceID, space); err != nil {
+		return nil, err
+	}
+	return s.buildState(uid, tenantSpaceID)
+}
+
+func (s *DocumentService) CreateSpace(uid, tenantSpaceID string, req SaveSpaceReq) (*DocumentStateResp, error) {
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return nil, errors.New("空间名称不能为空")
+	}
+	if err := s.ensureSpaceNameAvailable("", tenantSpaceID, name); err != nil {
+		return nil, err
+	}
+	now := nowDBTime()
+	space := &DocumentSpaceModel{
+		SpaceID:       "DOCSPACE-" + util.GenerUUID(),
+		Name:          name,
+		Description:   strings.TrimSpace(req.Description),
+		OwnerUID:      uid,
+		TenantSpaceID: tenantSpaceID,
+		Status:        1,
+	}
+	space.CreatedAt = now
+	space.UpdatedAt = now
+	if err := s.repo.SaveSpace(space); err != nil {
+		return nil, err
+	}
+	if err := s.saveOwnerMember(uid, tenantSpaceID, space); err != nil {
+		return nil, err
+	}
+	if err := s.addEvent(uid, tenantSpaceID, space.SpaceID, "新建空间", space.Name); err != nil {
+		return nil, err
+	}
+	return s.buildState(uid, tenantSpaceID)
+}
+
+func (s *DocumentService) UpdateSpace(uid, tenantSpaceID, spaceID string, req SaveSpaceReq) (*DocumentStateResp, error) {
+	space, err := s.resolveSpace(uid, tenantSpaceID, spaceID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireSpaceAdmin(uid, tenantSpaceID, space.SpaceID); err != nil {
+		return nil, err
+	}
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return nil, errors.New("空间名称不能为空")
+	}
+	if err := s.ensureSpaceNameAvailable(space.SpaceID, tenantSpaceID, name); err != nil {
+		return nil, err
+	}
+	space.Name = name
+	space.Description = strings.TrimSpace(req.Description)
+	space.UpdatedAt = nowDBTime()
+	if err := s.repo.UpdateSpace(space); err != nil {
+		return nil, err
+	}
+	if err := s.addEvent(uid, tenantSpaceID, space.SpaceID, "编辑空间", space.Name); err != nil {
+		return nil, err
+	}
+	return s.buildState(uid, tenantSpaceID)
+}
+
+func (s *DocumentService) DisableSpace(uid, tenantSpaceID, spaceID string) (*DocumentStateResp, error) {
+	space, err := s.resolveSpace(uid, tenantSpaceID, spaceID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireSpaceOwner(uid, space); err != nil {
+		return nil, err
+	}
+	space.Status = 0
+	space.UpdatedAt = nowDBTime()
+	if err := s.repo.UpdateSpace(space); err != nil {
+		return nil, err
+	}
+	if err := s.addEvent(uid, tenantSpaceID, space.SpaceID, "停用空间", space.Name); err != nil {
+		return nil, err
+	}
+	return s.buildState(uid, tenantSpaceID)
+}
+
+func (s *DocumentService) UpsertSpaceMember(uid, tenantSpaceID, spaceID string, req SaveSpaceMemberReq) (*DocumentStateResp, error) {
+	space, err := s.resolveSpace(uid, tenantSpaceID, spaceID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireSpaceAdmin(uid, tenantSpaceID, space.SpaceID); err != nil {
+		return nil, err
+	}
+	memberUID := strings.TrimSpace(req.UID)
+	if memberUID == "" {
+		return nil, errors.New("成员不能为空")
+	}
+	role := normalizeSpaceRole(req.Role)
+	if role == SpaceRoleOwner {
+		return nil, errors.New("所有者转让暂不支持在成员编辑中完成")
+	}
+	now := nowDBTime()
+	member := &DocumentSpaceMemberModel{
+		MemberID:        "MEM-" + util.GenerUUID(),
+		DocumentSpaceID: space.SpaceID,
+		UID:             memberUID,
+		Name:            fallbackString(req.Name, memberUID),
+		Role:            role,
+		Source:          "手动添加",
+		CreatedBy:       uid,
+		TenantSpaceID:   tenantSpaceID,
+		Status:          1,
+	}
+	member.CreatedAt = now
+	member.UpdatedAt = now
+	if err := s.repo.SaveSpaceMember(member); err != nil {
+		return nil, err
+	}
+	if err := s.addEvent(uid, tenantSpaceID, space.SpaceID, "设置成员", fmt.Sprintf("%s 为 %s", member.Name, role)); err != nil {
+		return nil, err
+	}
+	return s.buildState(uid, tenantSpaceID)
+}
+
+func (s *DocumentService) SearchSpaceMemberCandidates(uid, tenantSpaceID, spaceID, keyword string) ([]*DocumentMemberCandidateResp, error) {
+	space, err := s.resolveSpace(uid, tenantSpaceID, spaceID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireSpaceAdmin(uid, tenantSpaceID, space.SpaceID); err != nil {
+		return nil, err
+	}
+	keyword = strings.TrimSpace(keyword)
+	if keyword == "" {
+		return []*DocumentMemberCandidateResp{}, nil
+	}
+	users, err := s.repo.SearchUsers(uid, tenantSpaceID, keyword, 20)
+	if err != nil {
+		return nil, err
+	}
+	members, err := s.repo.ListSpaceMembers(uid, tenantSpaceID)
+	if err != nil {
+		return nil, err
+	}
+	memberUIDs := map[string]bool{space.OwnerUID: true}
+	for _, member := range members {
+		if member.DocumentSpaceID == space.SpaceID && member.Status == 1 {
+			memberUIDs[member.UID] = true
+		}
+	}
+	resp := make([]*DocumentMemberCandidateResp, 0, len(users))
+	for _, user := range users {
+		if strings.TrimSpace(user.UID) == "" {
+			continue
+		}
+		resp = append(resp, &DocumentMemberCandidateResp{
+			UID:           user.UID,
+			Name:          fallbackString(user.Name, user.UID),
+			Username:      user.Username,
+			AlreadyMember: memberUIDs[user.UID],
+		})
+	}
+	return resp, nil
+}
+
+func (s *DocumentService) RemoveSpaceMember(uid, tenantSpaceID, spaceID, memberUID string) (*DocumentStateResp, error) {
+	space, err := s.resolveSpace(uid, tenantSpaceID, spaceID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireSpaceAdmin(uid, tenantSpaceID, space.SpaceID); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(memberUID) == "" {
+		return nil, errors.New("成员不能为空")
+	}
+	if memberUID == space.OwnerUID {
+		return nil, errors.New("不能移除空间所有者")
+	}
+	if err := s.repo.RemoveSpaceMember(space.SpaceID, memberUID, tenantSpaceID); err != nil {
+		return nil, err
+	}
+	if err := s.addEvent(uid, tenantSpaceID, space.SpaceID, "移除成员", memberUID); err != nil {
+		return nil, err
+	}
+	return s.buildState(uid, tenantSpaceID)
+}
+
+func (s *DocumentService) Upload(uid, tenantSpaceID string, req UploadReq) (*DocumentStateResp, error) {
+	if strings.TrimSpace(req.Name) == "" {
+		return nil, errors.New("文件名不能为空")
+	}
+	space, err := s.resolveSpace(uid, tenantSpaceID, req.DocumentSpaceID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireSpaceEditor(uid, tenantSpaceID, space.SpaceID); err != nil {
+		return nil, err
+	}
+	extension := normalizeExtension(req.Name, req.Extension)
+	now := nowDBTime()
+	displayName := fallbackString(req.UploaderName, uid)
+	asset := &DocumentAssetModel{
+		AssetID:         "DOC-" + util.GenerUUID(),
+		Name:            req.Name,
+		Kind:            documentKind(extension),
+		Extension:       extension,
+		Size:            req.Size,
+		StoragePath:     req.StoragePath,
+		SourceType:      SourceTypeApp,
+		SourceName:      SourceNameDirectUpload,
+		UploaderUID:     uid,
+		UploaderName:    displayName,
+		OwnerUID:        uid,
+		OwnerName:       displayName,
+		TenantSpaceID:   tenantSpaceID,
+		DocumentSpaceID: space.SpaceID,
+		OriginalSpaceID: space.SpaceID,
+		Visibility:      VisibilitySpace,
+		Status:          StatusArchived,
+		Downloads:       0,
+		Previewable:     previewableForExtension(extension),
+		LastAccessAt:    &now,
+	}
+	asset.CreatedAt = now
+	asset.UpdatedAt = now
+	if err := s.repo.SaveAsset(asset); err != nil {
+		return nil, err
+	}
+	if err := s.addEvent(uid, tenantSpaceID, asset.AssetID, "上传", fmt.Sprintf("上传到%s", space.Name)); err != nil {
+		return nil, err
+	}
+	return s.buildState(uid, tenantSpaceID)
+}
+
+func (s *DocumentService) Archive(uid, tenantSpaceID string, req ArchiveReq) (*DocumentStateResp, error) {
+	space, err := s.resolveArchiveSpace(uid, tenantSpaceID, req)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireSpaceEditor(uid, tenantSpaceID, space.SpaceID); err != nil {
+		return nil, err
+	}
+	asset, err := s.repo.GetAsset(req.AssetID, uid, tenantSpaceID)
+	if err != nil {
+		return nil, err
+	}
+	if asset != nil {
+		if asset.Visibility == VisibilityConversation {
+			if err := s.requireReadable(uid, tenantSpaceID, asset); err != nil {
+				return nil, err
+			}
+		} else if err := s.requireEditable(uid, tenantSpaceID, asset); err != nil {
+			return nil, err
+		}
+	}
+	sourceChannelID := req.SourceChannelID
+	sourceChannelType := req.SourceChannelType
+	if asset != nil {
+		sourceChannelID = asset.SourceChannelID
+		sourceChannelType = asset.SourceChannelType
+	}
+	if err := s.requireSourceAccess(uid, tenantSpaceID, sourceChannelID, sourceChannelType); err != nil {
+		return nil, err
+	}
+	now := nowDBTime()
+	if asset == nil {
+		extension := normalizeExtension(req.Name, req.Extension)
+		asset = &DocumentAssetModel{
+			AssetID:           "DOC-" + util.GenerUUID(),
+			Name:              req.Name,
+			Kind:              documentKind(extension),
+			Extension:         extension,
+			Size:              req.Size,
+			StoragePath:       req.StoragePath,
+			SourceType:        fallbackString(req.SourceType, SourceTypeGroup),
+			SourceChannelID:   req.SourceChannelID,
+			SourceChannelType: req.SourceChannelType,
+			SourceMessageID:   req.SourceMessageID,
+			SourceName:        req.SourceName,
+			UploaderUID:       uid,
+			UploaderName:      fallbackString(req.UploaderName, uid),
+			OwnerUID:          uid,
+			OwnerName:         uid,
+			TenantSpaceID:     tenantSpaceID,
+			DocumentSpaceID:   space.SpaceID,
+			OriginalSpaceID:   space.SpaceID,
+			Visibility:        VisibilitySpace,
+			Status:            StatusArchived,
+			Previewable:       previewableForExtension(extension),
+			LastAccessAt:      &now,
+		}
+		asset.CreatedAt = now
+		asset.UpdatedAt = now
+		if err := s.repo.SaveAsset(asset); err != nil {
+			return nil, err
+		}
+	} else {
+		asset.DocumentSpaceID = space.SpaceID
+		if asset.OriginalSpaceID == "" {
+			asset.OriginalSpaceID = space.SpaceID
+		}
+		asset.Visibility = VisibilitySpace
+		asset.Status = StatusArchived
+		asset.UpdatedAt = now
+		asset.LastAccessAt = &now
+		if err := s.repo.UpdateAsset(asset); err != nil {
+			return nil, err
+		}
+	}
+	if err := s.addEvent(uid, tenantSpaceID, asset.AssetID, "归档", fmt.Sprintf("归档到%s", space.Name)); err != nil {
+		return nil, err
+	}
+	return s.buildState(uid, tenantSpaceID)
+}
+
+func (s *DocumentService) RenameAsset(uid, tenantSpaceID, assetID string, req RenameAssetReq) (*DocumentStateResp, error) {
+	asset, err := s.requireAsset(uid, tenantSpaceID, assetID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireEditable(uid, tenantSpaceID, asset); err != nil {
+		return nil, err
+	}
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return nil, errors.New("文件名不能为空")
+	}
+	if strings.ContainsAny(name, `\/:*?"<>|`) {
+		return nil, errors.New("文件名包含非法字符")
+	}
+	oldName := asset.Name
+	extension := normalizeExtension(name, "")
+	asset.Name = name
+	asset.Extension = extension
+	asset.Kind = documentKind(extension)
+	asset.UpdatedAt = nowDBTime()
+	if err := s.repo.UpdateAsset(asset); err != nil {
+		return nil, err
+	}
+	if err := s.addEvent(uid, tenantSpaceID, asset.AssetID, "重命名", fmt.Sprintf("%s -> %s", oldName, name)); err != nil {
+		return nil, err
+	}
+	return s.buildState(uid, tenantSpaceID)
+}
+
+func (s *DocumentService) MoveAsset(uid, tenantSpaceID, assetID string, req MoveAssetReq) (*DocumentStateResp, error) {
+	asset, err := s.requireAsset(uid, tenantSpaceID, assetID)
+	if err != nil {
+		return nil, err
+	}
+	if asset.Status != StatusArchived {
+		return nil, errors.New("只有空间文件可以移动")
+	}
+	if err := s.requireEditable(uid, tenantSpaceID, asset); err != nil {
+		return nil, err
+	}
+	targetSpace, err := s.resolveSpace(uid, tenantSpaceID, req.DocumentSpaceID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireSpaceEditor(uid, tenantSpaceID, targetSpace.SpaceID); err != nil {
+		return nil, err
+	}
+	oldSpaceID := asset.DocumentSpaceID
+	asset.DocumentSpaceID = targetSpace.SpaceID
+	asset.OriginalSpaceID = targetSpace.SpaceID
+	asset.Visibility = VisibilitySpace
+	asset.UpdatedAt = nowDBTime()
+	if err := s.repo.UpdateAsset(asset); err != nil {
+		return nil, err
+	}
+	oldSpaceName := oldSpaceID
+	if oldSpace, err := s.repo.GetSpace(oldSpaceID, uid, tenantSpaceID); err == nil && oldSpace != nil {
+		oldSpaceName = oldSpace.Name
+	}
+	if err := s.addEvent(uid, tenantSpaceID, asset.AssetID, "移动空间", fmt.Sprintf("%s -> %s", oldSpaceName, targetSpace.Name)); err != nil {
+		return nil, err
+	}
+	return s.buildState(uid, tenantSpaceID)
+}
+
+func (s *DocumentService) BindConversation(uid, tenantSpaceID string, req BindConversationReq) (*DocumentStateResp, error) {
+	space, err := s.resolveSpace(uid, tenantSpaceID, req.DocumentSpaceID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireSpaceAdmin(uid, tenantSpaceID, space.SpaceID); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(req.SourceChannelID) == "" {
+		return nil, errors.New("来源会话不能为空")
+	}
+	if req.SourceChannelType == 0 {
+		return nil, errors.New("来源会话类型不能为空")
+	}
+	if err := s.requireSourceAccess(uid, tenantSpaceID, req.SourceChannelID, req.SourceChannelType); err != nil {
+		return nil, err
+	}
+	if existing, err := s.activeBindingForSource(uid, tenantSpaceID, req.SourceChannelID, req.SourceChannelType); err != nil {
+		return nil, err
+	} else if existing != nil && existing.DocumentSpaceID != space.SpaceID {
+		role, err := s.spaceRole(uid, tenantSpaceID, existing.DocumentSpaceID)
+		if err != nil {
+			return nil, err
+		}
+		if role != SpaceRoleOwner && role != SpaceRoleAdmin {
+			return nil, errors.New("无权修改已有绑定")
+		}
+	}
+	sourceName := fallbackString(req.SourceName, req.SourceChannelID)
+	now := nowDBTime()
+	binding := &DocumentSpaceBindingModel{
+		BindingID:         "BIND-" + util.GenerUUID(),
+		DocumentSpaceID:   space.SpaceID,
+		SourceChannelID:   req.SourceChannelID,
+		SourceChannelType: req.SourceChannelType,
+		SourceName:        sourceName,
+		CreatedBy:         uid,
+		TenantSpaceID:     tenantSpaceID,
+		Status:            1,
+	}
+	binding.CreatedAt = now
+	binding.UpdatedAt = now
+	if err := s.repo.SaveSpaceBinding(binding); err != nil {
+		return nil, err
+	}
+	if err := s.addEvent(uid, tenantSpaceID, space.SpaceID, "绑定群聊", fmt.Sprintf("%s 设为%s默认归档空间", sourceName, space.Name)); err != nil {
+		return nil, err
+	}
+	return s.buildState(uid, tenantSpaceID)
+}
+
+func (s *DocumentService) SearchBindingConversations(uid, tenantSpaceID, spaceID, keyword string) ([]*DocumentGroupBindingCandidateResp, error) {
+	space, err := s.resolveSpace(uid, tenantSpaceID, spaceID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireSpaceAdmin(uid, tenantSpaceID, space.SpaceID); err != nil {
+		return nil, err
+	}
+	keyword = strings.TrimSpace(keyword)
+	if keyword == "" {
+		return []*DocumentGroupBindingCandidateResp{}, nil
+	}
+	groups, err := s.repo.SearchGroups(uid, tenantSpaceID, keyword, 20)
+	if err != nil {
+		return nil, err
+	}
+	activeBindings, err := s.repo.ListSpaceBindings(uid, tenantSpaceID)
+	if err != nil {
+		return nil, err
+	}
+	accessibleSpaces, err := s.repo.ListSpaces(uid, tenantSpaceID)
+	if err != nil {
+		return nil, err
+	}
+	spaceNameByID := make(map[string]string, len(accessibleSpaces))
+	for _, item := range accessibleSpaces {
+		spaceNameByID[item.SpaceID] = item.Name
+	}
+	bindingByChannel := make(map[string]*DocumentSpaceBindingModel, len(activeBindings))
+	for _, binding := range activeBindings {
+		if binding.Status != 1 {
+			continue
+		}
+		bindingByChannel[documentSourceKey(binding.SourceChannelID, binding.SourceChannelType)] = binding
+	}
+
+	resp := make([]*DocumentGroupBindingCandidateResp, 0, len(groups))
+	for _, group := range groups {
+		if group == nil || strings.TrimSpace(group.GroupNo) == "" {
+			continue
+		}
+		candidate := &DocumentGroupBindingCandidateResp{
+			ChannelID:   group.GroupNo,
+			ChannelType: 2,
+			Name:        fallbackString(group.Name, group.GroupNo),
+		}
+		if binding := bindingByChannel[documentSourceKey(group.GroupNo, 2)]; binding != nil {
+			if binding.DocumentSpaceID == space.SpaceID {
+				candidate.BoundSpaceID = binding.DocumentSpaceID
+				candidate.BoundSpaceName = space.Name
+				candidate.AlreadyBoundToCurrentSpace = true
+			} else if boundSpaceName := strings.TrimSpace(spaceNameByID[binding.DocumentSpaceID]); boundSpaceName != "" {
+				candidate.BoundSpaceID = binding.DocumentSpaceID
+				candidate.BoundSpaceName = boundSpaceName
+			}
+		}
+		resp = append(resp, candidate)
+	}
+	return resp, nil
+}
+
+func (s *DocumentService) ChannelStorageSpace(uid, tenantSpaceID, sourceChannelID string, sourceChannelType uint8) (*DocumentChannelStorageSpaceResp, error) {
+	if strings.TrimSpace(sourceChannelID) != "" && sourceChannelType != 0 {
+		if err := s.requireSourceAccess(uid, tenantSpaceID, sourceChannelID, sourceChannelType); err != nil {
+			return nil, err
+		}
+	}
+	space, err := s.boundSpaceForSource(uid, tenantSpaceID, sourceChannelID, sourceChannelType)
+	if err != nil {
+		return nil, err
+	}
+	if space == nil {
+		return &DocumentChannelStorageSpaceResp{}, nil
+	}
+	return &DocumentChannelStorageSpaceResp{
+		SpaceID:   space.SpaceID,
+		SpaceName: space.Name,
+	}, nil
+}
+
+func (s *DocumentService) UnbindConversation(uid, tenantSpaceID, spaceID, bindingID string) (*DocumentStateResp, error) {
+	space, err := s.resolveSpace(uid, tenantSpaceID, spaceID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireSpaceAdmin(uid, tenantSpaceID, space.SpaceID); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(bindingID) == "" {
+		return nil, errors.New("绑定关系不能为空")
+	}
+	if err := s.repo.RemoveSpaceBinding(space.SpaceID, bindingID, tenantSpaceID); err != nil {
+		return nil, err
+	}
+	if err := s.addEvent(uid, tenantSpaceID, space.SpaceID, "解绑群聊", bindingID); err != nil {
+		return nil, err
+	}
+	return s.buildState(uid, tenantSpaceID)
+}
+
+func (s *DocumentService) Preview(uid, tenantSpaceID, assetID string) (*DocumentStateResp, error) {
+	asset, err := s.requireAsset(uid, tenantSpaceID, assetID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireReadable(uid, tenantSpaceID, asset); err != nil {
+		return nil, err
+	}
+	now := nowDBTime()
+	asset.LastAccessAt = &now
+	asset.UpdatedAt = now
+	if err := s.repo.UpdateAsset(asset); err != nil {
+		return nil, err
+	}
+	if err := s.addEvent(uid, tenantSpaceID, asset.AssetID, "预览", "在线预览"); err != nil {
+		return nil, err
+	}
+	return s.buildState(uid, tenantSpaceID)
+}
+
+func (s *DocumentService) Download(uid, tenantSpaceID, assetID string) (*DocumentStateResp, error) {
+	asset, err := s.requireAsset(uid, tenantSpaceID, assetID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireReadable(uid, tenantSpaceID, asset); err != nil {
+		return nil, err
+	}
+	now := nowDBTime()
+	asset.Downloads++
+	asset.LastAccessAt = &now
+	asset.UpdatedAt = now
+	if err := s.repo.UpdateAsset(asset); err != nil {
+		return nil, err
+	}
+	if err := s.addEvent(uid, tenantSpaceID, asset.AssetID, "下载", "下载文件"); err != nil {
+		return nil, err
+	}
+	return s.buildState(uid, tenantSpaceID)
+}
+
+func (s *DocumentService) Trash(uid, tenantSpaceID, assetID string) (*DocumentStateResp, error) {
+	asset, err := s.requireAsset(uid, tenantSpaceID, assetID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireManageable(uid, tenantSpaceID, asset); err != nil {
+		return nil, err
+	}
+	now := nowDBTime()
+	asset.Status = StatusDeleted
+	asset.UpdatedAt = now
+	if err := s.repo.UpdateAsset(asset); err != nil {
+		return nil, err
+	}
+	if err := s.addEvent(uid, tenantSpaceID, asset.AssetID, "删除", "移动到回收站"); err != nil {
+		return nil, err
+	}
+	return s.buildState(uid, tenantSpaceID)
+}
+
+func (s *DocumentService) Restore(uid, tenantSpaceID, assetID string) (*DocumentStateResp, error) {
+	asset, err := s.requireAsset(uid, tenantSpaceID, assetID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireManageable(uid, tenantSpaceID, asset); err != nil {
+		return nil, err
+	}
+	now := nowDBTime()
+	if asset.DocumentSpaceID != "" || asset.OriginalSpaceID != "" {
+		if asset.DocumentSpaceID == "" {
+			asset.DocumentSpaceID = asset.OriginalSpaceID
+		}
+		asset.Status = StatusArchived
+		asset.Visibility = VisibilitySpace
+	} else {
+		asset.Status = StatusConversation
+		asset.Visibility = VisibilityConversation
+	}
+	asset.UpdatedAt = now
+	if err := s.repo.UpdateAsset(asset); err != nil {
+		return nil, err
+	}
+	if err := s.addEvent(uid, tenantSpaceID, asset.AssetID, "恢复", "从回收站恢复"); err != nil {
+		return nil, err
+	}
+	return s.buildState(uid, tenantSpaceID)
+}
+
+func (s *DocumentService) PermanentDelete(uid, tenantSpaceID, assetID string) (*DocumentStateResp, error) {
+	asset, err := s.requireAsset(uid, tenantSpaceID, assetID)
+	if err != nil {
+		return nil, err
+	}
+	if asset.Status != StatusDeleted {
+		return nil, errors.New("只有回收站文件可以永久删除")
+	}
+	if err := s.requireManageable(uid, tenantSpaceID, asset); err != nil {
+		return nil, err
+	}
+	if err := s.repo.DeleteAsset(asset.AssetID, tenantSpaceID); err != nil {
+		return nil, err
+	}
+	if err := s.addEvent(uid, tenantSpaceID, asset.AssetID, "永久删除", asset.Name); err != nil {
+		return nil, err
+	}
+	return s.buildState(uid, tenantSpaceID)
+}
+
+func (s *DocumentService) EmptyTrash(uid, tenantSpaceID string) (*DocumentStateResp, error) {
+	assets, err := s.repo.ListAssets(uid, tenantSpaceID)
+	if err != nil {
+		return nil, err
+	}
+	deletedCount := 0
+	for _, asset := range assets {
+		if asset.Status != StatusDeleted {
+			continue
+		}
+		if err := s.requireManageable(uid, tenantSpaceID, asset); err != nil {
+			continue
+		}
+		if err := s.repo.DeleteAsset(asset.AssetID, tenantSpaceID); err != nil {
+			return nil, err
+		}
+		deletedCount++
+	}
+	if err := s.addEvent(uid, tenantSpaceID, "trash", "清空回收站", fmt.Sprintf("永久删除%d个文件", deletedCount)); err != nil {
+		return nil, err
+	}
+	return s.buildState(uid, tenantSpaceID)
+}
+
+func (s *DocumentService) CheckSource(uid, tenantSpaceID, assetID string) (bool, error) {
+	asset, err := s.requireAsset(uid, tenantSpaceID, assetID)
+	if err != nil {
+		return false, err
+	}
+	if err := s.requireReadable(uid, tenantSpaceID, asset); err != nil {
+		return false, err
+	}
+	if strings.TrimSpace(asset.SourceChannelID) == "" {
+		return false, nil
+	}
+	return s.repo.CanAccessSource(uid, tenantSpaceID, asset.SourceChannelID, asset.SourceChannelType)
+}
+
+func (s *DocumentService) requireAsset(uid, tenantSpaceID, assetID string) (*DocumentAssetModel, error) {
+	asset, err := s.repo.GetAsset(assetID, uid, tenantSpaceID)
+	if err != nil {
+		return nil, err
+	}
+	if asset == nil {
+		return nil, errors.New("文件不存在")
+	}
+	return asset, nil
+}
+
+func (s *DocumentService) requireReadable(uid, tenantSpaceID string, asset *DocumentAssetModel) error {
+	if asset.Status == StatusDeleted {
+		return errors.New("文件已在回收站")
+	}
+	if asset.OwnerUID == uid || asset.UploaderUID == uid {
+		return nil
+	}
+	if strings.TrimSpace(asset.DocumentSpaceID) != "" {
+		space, err := s.repo.GetSpace(asset.DocumentSpaceID, uid, tenantSpaceID)
+		if err != nil {
+			return err
+		}
+		members, err := s.repo.ListSpaceMembers(uid, tenantSpaceID)
+		if err != nil {
+			return err
+		}
+		if space != nil && userHasSpaceAccess(uid, space, members) {
+			return nil
+		}
+	}
+	if asset.Visibility != VisibilityConversation {
+		return errors.New("无权访问文件")
+	}
+	if strings.TrimSpace(asset.SourceChannelID) == "" {
+		return errors.New("来源会话缺失")
+	}
+	allowed, err := s.repo.CanAccessSource(uid, tenantSpaceID, asset.SourceChannelID, asset.SourceChannelType)
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return errors.New("无权访问来源会话")
+	}
+	return nil
+}
+
+func (s *DocumentService) requireSourceAccess(uid, tenantSpaceID, sourceChannelID string, sourceChannelType uint8) error {
+	if strings.TrimSpace(sourceChannelID) == "" {
+		return nil
+	}
+	if sourceChannelType == 0 {
+		return errors.New("来源会话类型不能为空")
+	}
+	allowed, err := s.repo.CanAccessSource(uid, tenantSpaceID, sourceChannelID, sourceChannelType)
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return errors.New("无权访问来源会话")
+	}
+	return nil
+}
+
+func (s *DocumentService) requireManageable(uid, tenantSpaceID string, asset *DocumentAssetModel) error {
+	if asset.OwnerUID == uid || asset.UploaderUID == uid {
+		return nil
+	}
+	if strings.TrimSpace(asset.DocumentSpaceID) == "" {
+		return errors.New("无权管理文件")
+	}
+	space, err := s.repo.GetSpace(asset.DocumentSpaceID, uid, tenantSpaceID)
+	if err != nil {
+		return err
+	}
+	if space != nil {
+		return s.requireSpaceAdmin(uid, tenantSpaceID, space.SpaceID)
+	}
+	return errors.New("无权管理文件")
+}
+
+func (s *DocumentService) requireEditable(uid, tenantSpaceID string, asset *DocumentAssetModel) error {
+	if asset.Status == StatusDeleted {
+		return errors.New("回收站文件不可编辑")
+	}
+	if asset.OwnerUID == uid || asset.UploaderUID == uid {
+		return nil
+	}
+	if strings.TrimSpace(asset.DocumentSpaceID) == "" {
+		return errors.New("无权编辑文件")
+	}
+	return s.requireSpaceEditor(uid, tenantSpaceID, asset.DocumentSpaceID)
+}
+
+func (s *DocumentService) resolveSpace(uid, tenantSpaceID, documentSpaceID string) (*DocumentSpaceModel, error) {
+	if strings.TrimSpace(documentSpaceID) != "" {
+		space, err := s.repo.GetSpace(documentSpaceID, uid, tenantSpaceID)
+		if err != nil {
+			return nil, err
+		}
+		if space == nil {
+			return nil, errors.New("目标空间不存在")
+		}
+		return space, nil
+	}
+	return s.repo.EnsureDefaultSpace(uid, tenantSpaceID)
+}
+
+func (s *DocumentService) resolveArchiveSpace(uid, tenantSpaceID string, req ArchiveReq) (*DocumentSpaceModel, error) {
+	if strings.TrimSpace(req.DocumentSpaceID) != "" {
+		return s.resolveSpace(uid, tenantSpaceID, req.DocumentSpaceID)
+	}
+	if strings.TrimSpace(req.SourceChannelID) == "" || req.SourceChannelType == 0 {
+		return nil, errors.New("文档空间不能为空")
+	}
+	space, err := s.boundSpaceForSource(uid, tenantSpaceID, req.SourceChannelID, req.SourceChannelType)
+	if err != nil {
+		return nil, err
+	}
+	if space == nil {
+		return nil, errors.New("该会话未设置群文档存储空间")
+	}
+	return space, nil
+}
+
+func (s *DocumentService) boundSpaceForSource(uid, tenantSpaceID, sourceChannelID string, sourceChannelType uint8) (*DocumentSpaceModel, error) {
+	sourceChannelID = strings.TrimSpace(sourceChannelID)
+	if sourceChannelID == "" || sourceChannelType == 0 {
+		return nil, nil
+	}
+	binding, err := s.activeBindingForSource(uid, tenantSpaceID, sourceChannelID, sourceChannelType)
+	if err != nil || binding == nil {
+		return nil, err
+	}
+	space, err := s.repo.GetSpace(binding.DocumentSpaceID, uid, tenantSpaceID)
+	if err != nil || space == nil {
+		return space, err
+	}
+	members, err := s.repo.ListSpaceMembers(uid, tenantSpaceID)
+	if err != nil {
+		return nil, err
+	}
+	if !userHasSpaceAccess(uid, space, members) {
+		return nil, nil
+	}
+	return space, nil
+}
+
+func (s *DocumentService) activeBindingForSource(uid, tenantSpaceID, sourceChannelID string, sourceChannelType uint8) (*DocumentSpaceBindingModel, error) {
+	sourceChannelID = strings.TrimSpace(sourceChannelID)
+	if sourceChannelID == "" || sourceChannelType == 0 {
+		return nil, nil
+	}
+	bindings, err := s.repo.ListSpaceBindings(uid, tenantSpaceID)
+	if err != nil {
+		return nil, err
+	}
+	for _, binding := range bindings {
+		if binding.Status == 1 &&
+			binding.SourceChannelID == sourceChannelID &&
+			binding.SourceChannelType == sourceChannelType &&
+			strings.TrimSpace(binding.DocumentSpaceID) != "" {
+			return binding, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *DocumentService) ensureSpaceNameAvailable(currentSpaceID, tenantSpaceID, name string) error {
+	spaces, err := s.repo.ListAllSpaces("", tenantSpaceID)
+	if err != nil {
+		return err
+	}
+	for _, space := range spaces {
+		if space.SpaceID != currentSpaceID && strings.EqualFold(space.Name, name) {
+			return errors.New("空间名称已存在")
+		}
+	}
+	return nil
+}
+
+func (s *DocumentService) saveOwnerMember(uid, tenantSpaceID string, space *DocumentSpaceModel) error {
+	if space == nil || strings.TrimSpace(space.OwnerUID) == "" {
+		return nil
+	}
+	members, err := s.repo.ListSpaceMembers(uid, tenantSpaceID)
+	if err == nil {
+		for _, member := range members {
+			if member.DocumentSpaceID == space.SpaceID && member.UID == space.OwnerUID && member.Status == 1 {
+				return nil
+			}
+		}
+	}
+	now := nowDBTime()
+	member := &DocumentSpaceMemberModel{
+		MemberID:        "MEM-" + util.GenerUUID(),
+		DocumentSpaceID: space.SpaceID,
+		UID:             space.OwnerUID,
+		Name:            fallbackString(space.OwnerUID, uid),
+		Role:            SpaceRoleOwner,
+		Source:          "创建人",
+		CreatedBy:       uid,
+		TenantSpaceID:   tenantSpaceID,
+		Status:          1,
+	}
+	member.CreatedAt = now
+	member.UpdatedAt = now
+	return s.repo.SaveSpaceMember(member)
+}
+
+func (s *DocumentService) requireSpaceOwner(uid string, space *DocumentSpaceModel) error {
+	if space != nil && space.OwnerUID == uid {
+		return nil
+	}
+	return errors.New("仅空间所有者可操作")
+}
+
+func (s *DocumentService) requireSpaceAdmin(uid, tenantSpaceID, spaceID string) error {
+	role, err := s.spaceRole(uid, tenantSpaceID, spaceID)
+	if err != nil {
+		return err
+	}
+	if role == SpaceRoleOwner || role == SpaceRoleAdmin {
+		return nil
+	}
+	return errors.New("无权管理空间")
+}
+
+func (s *DocumentService) requireSpaceEditor(uid, tenantSpaceID, spaceID string) error {
+	role, err := s.spaceRole(uid, tenantSpaceID, spaceID)
+	if err != nil {
+		return err
+	}
+	if role == SpaceRoleOwner || role == SpaceRoleAdmin || role == SpaceRoleEditor {
+		return nil
+	}
+	return errors.New("无权编辑空间文件")
+}
+
+func (s *DocumentService) spaceRole(uid, tenantSpaceID, spaceID string) (string, error) {
+	space, err := s.repo.GetSpace(spaceID, uid, tenantSpaceID)
+	if err != nil {
+		return "", err
+	}
+	if space != nil && space.OwnerUID == uid {
+		return SpaceRoleOwner, nil
+	}
+	members, err := s.repo.ListSpaceMembers(uid, tenantSpaceID)
+	if err != nil {
+		return "", err
+	}
+	for _, member := range members {
+		if member.DocumentSpaceID == spaceID && member.UID == uid && member.Status == 1 {
+			return normalizeSpaceRole(member.Role), nil
+		}
+	}
+	return "", nil
+}
+
+func (s *DocumentService) addEvent(uid, tenantSpaceID, assetID, action, detail string) error {
+	now := nowDBTime()
+	event := &DocumentEventModel{
+		EventID:       "EVT-" + util.GenerUUID(),
+		AssetID:       assetID,
+		ActorUID:      uid,
+		Action:        action,
+		Detail:        detail,
+		TenantSpaceID: tenantSpaceID,
+	}
+	event.CreatedAt = now
+	event.UpdatedAt = now
+	return s.repo.AddEvent(event)
+}
+
+func (s *DocumentService) buildState(uid, tenantSpaceID string) (*DocumentStateResp, error) {
+	spaces, err := s.repo.ListSpaces(uid, tenantSpaceID)
+	if err != nil {
+		return nil, err
+	}
+	allSpaces, err := s.repo.ListAllSpaces(uid, tenantSpaceID)
+	if err != nil {
+		return nil, err
+	}
+	assets, err := s.repo.ListAssets(uid, tenantSpaceID)
+	if err != nil {
+		return nil, err
+	}
+	bindings, err := s.repo.ListSpaceBindings(uid, tenantSpaceID)
+	if err != nil {
+		return nil, err
+	}
+	members, err := s.repo.ListSpaceMembers(uid, tenantSpaceID)
+	if err != nil {
+		return nil, err
+	}
+	events, err := s.repo.ListEvents(uid, tenantSpaceID, 50)
+	if err != nil {
+		return nil, err
+	}
+
+	spaceByID := make(map[string]*DocumentSpaceModel, len(allSpaces))
+	fileCountBySpace := make(map[string]int)
+	bindingsBySpace := make(map[string][]*DocumentSpaceBindingResp)
+	membersBySpace := make(map[string][]*DocumentSpaceMemberResp)
+	for _, space := range allSpaces {
+		spaceByID[space.SpaceID] = space
+	}
+	for _, binding := range bindings {
+		if binding.Status == 1 && binding.DocumentSpaceID != "" {
+			bindingsBySpace[binding.DocumentSpaceID] = append(bindingsBySpace[binding.DocumentSpaceID], &DocumentSpaceBindingResp{
+				ID:          binding.BindingID,
+				ChannelID:   binding.SourceChannelID,
+				ChannelType: binding.SourceChannelType,
+				Name:        binding.SourceName,
+				CreatedBy:   binding.CreatedBy,
+			})
+		}
+	}
+	for _, member := range members {
+		if member.Status != 1 || member.DocumentSpaceID == "" {
+			continue
+		}
+		membersBySpace[member.DocumentSpaceID] = append(membersBySpace[member.DocumentSpaceID], &DocumentSpaceMemberResp{
+			UID:      member.UID,
+			Name:     fallbackString(member.Name, member.UID),
+			Role:     normalizeSpaceRole(member.Role),
+			Source:   fallbackString(member.Source, "手动添加"),
+			JoinedAt: formatDBTime(member.CreatedAt),
+		})
+	}
+	for _, space := range spaces {
+		hasOwner := false
+		for _, member := range membersBySpace[space.SpaceID] {
+			if member.UID == space.OwnerUID {
+				member.Role = SpaceRoleOwner
+				hasOwner = true
+				break
+			}
+		}
+		if !hasOwner {
+			membersBySpace[space.SpaceID] = append([]*DocumentSpaceMemberResp{{
+				UID:      space.OwnerUID,
+				Name:     space.OwnerUID,
+				Role:     SpaceRoleOwner,
+				Source:   "创建人",
+				JoinedAt: formatDBTime(space.CreatedAt),
+			}}, membersBySpace[space.SpaceID]...)
+		}
+	}
+	accessibleAssets := make([]*DocumentAssetModel, 0, len(assets))
+	accessibleAssetIDs := make(map[string]struct{}, len(assets))
+	accessibleSpaceIDs := make(map[string]struct{}, len(spaces))
+	for _, space := range spaces {
+		accessibleSpaceIDs[space.SpaceID] = struct{}{}
+	}
+	sourceAccess, err := s.accessibleSourcesForState(uid, tenantSpaceID, assets, spaceByID, members)
+	if err != nil {
+		return nil, err
+	}
+	for _, asset := range assets {
+		space := spaceByID[asset.DocumentSpaceID]
+		allowed, err := s.canReadAssetWithSources(uid, tenantSpaceID, asset, space, members, sourceAccess)
+		if err != nil {
+			return nil, err
+		}
+		if !allowed {
+			continue
+		}
+		accessibleAssets = append(accessibleAssets, asset)
+		accessibleAssetIDs[asset.AssetID] = struct{}{}
+		if asset.Status == StatusArchived && asset.DocumentSpaceID != "" {
+			fileCountBySpace[asset.DocumentSpaceID]++
+		}
+	}
+
+	resp := &DocumentStateResp{
+		Files:  make([]*DocumentAssetResp, 0, len(accessibleAssets)),
+		Spaces: make([]*DocumentSpaceResp, 0, len(spaces)),
+		Audits: make([]*DocumentAuditResp, 0, len(events)),
+	}
+	for _, asset := range accessibleAssets {
+		resp.Files = append(resp.Files, assetToResp(
+			asset,
+			spaceByID[asset.DocumentSpaceID],
+			membersBySpace[asset.DocumentSpaceID],
+			uid,
+		))
+	}
+	for _, space := range spaces {
+		resp.Spaces = append(resp.Spaces, &DocumentSpaceResp{
+			ID:                 space.SpaceID,
+			Name:               space.Name,
+			Owner:              space.OwnerUID,
+			FileCount:          fileCountBySpace[space.SpaceID],
+			MemberCount:        len(membersBySpace[space.SpaceID]),
+			Members:            ensureMembersSlice(membersBySpace[space.SpaceID]),
+			BoundConversations: ensureBindingsSlice(bindingsBySpace[space.SpaceID]),
+			PinnedFileIDs:      []string{},
+			Description:        space.Description,
+		})
+	}
+	for _, event := range events {
+		if _, ok := accessibleAssetIDs[event.AssetID]; !ok {
+			if _, ok := accessibleSpaceIDs[event.AssetID]; !ok {
+				continue
+			}
+		}
+		resp.Audits = append(resp.Audits, &DocumentAuditResp{
+			ID:     event.EventID,
+			Time:   formatDBTime(event.CreatedAt),
+			Actor:  event.ActorUID,
+			Action: event.Action,
+			Target: event.AssetID,
+			Detail: event.Detail,
+		})
+	}
+	return resp, nil
+}
+
+func (s *DocumentService) accessibleSourcesForState(uid, tenantSpaceID string, assets []*DocumentAssetModel, spaces map[string]*DocumentSpaceModel, members []*DocumentSpaceMemberModel) (map[string]bool, error) {
+	sources := make([]documentSourceRef, 0)
+	seen := make(map[string]struct{})
+	for _, asset := range assets {
+		if asset == nil || asset.TenantSpaceID != tenantSpaceID {
+			continue
+		}
+		if asset.OwnerUID == uid || asset.UploaderUID == uid {
+			continue
+		}
+		if space := spaces[asset.DocumentSpaceID]; space != nil && userHasSpaceAccess(uid, space, members) {
+			continue
+		}
+		if asset.Visibility != VisibilityConversation || strings.TrimSpace(asset.SourceChannelID) == "" {
+			continue
+		}
+		key := documentSourceKey(asset.SourceChannelID, asset.SourceChannelType)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		sources = append(sources, documentSourceRef{
+			ChannelID:   asset.SourceChannelID,
+			ChannelType: asset.SourceChannelType,
+		})
+	}
+	return s.repo.CanAccessSources(uid, tenantSpaceID, sources)
+}
+
+func (s *DocumentService) canReadAsset(uid, tenantSpaceID string, asset *DocumentAssetModel, space *DocumentSpaceModel, members []*DocumentSpaceMemberModel) (bool, error) {
+	return s.canReadAssetWithSources(uid, tenantSpaceID, asset, space, members, nil)
+}
+
+func (s *DocumentService) canReadAssetWithSources(uid, tenantSpaceID string, asset *DocumentAssetModel, space *DocumentSpaceModel, members []*DocumentSpaceMemberModel, sourceAccess map[string]bool) (bool, error) {
+	if asset == nil || asset.TenantSpaceID != tenantSpaceID {
+		return false, nil
+	}
+	if asset.OwnerUID == uid || asset.UploaderUID == uid {
+		return true, nil
+	}
+	if space != nil && userHasSpaceAccess(uid, space, members) {
+		return true, nil
+	}
+	if asset.Visibility != VisibilityConversation || strings.TrimSpace(asset.SourceChannelID) == "" {
+		return false, nil
+	}
+	if sourceAccess != nil {
+		return sourceAccess[documentSourceKey(asset.SourceChannelID, asset.SourceChannelType)], nil
+	}
+	return s.repo.CanAccessSource(uid, tenantSpaceID, asset.SourceChannelID, asset.SourceChannelType)
+}
+
+func assetToResp(asset *DocumentAssetModel, space *DocumentSpaceModel, members []*DocumentSpaceMemberResp, uid string) *DocumentAssetResp {
+	spaceName := "会话文件"
+	if space != nil {
+		spaceName = space.Name
+		if space.Status != 1 {
+			spaceName += "（已停用）"
+		}
+	}
+	createdAt := formatDBTime(asset.CreatedAt)
+	lastAccessAt := createdAt
+	if asset.LastAccessAt != nil {
+		lastAccessAt = asset.LastAccessAt.String()
+	}
+	owner := fallbackString(asset.OwnerName, asset.OwnerUID)
+	uploader := fallbackString(asset.UploaderName, asset.UploaderUID)
+	flow := []string{}
+	if asset.SourceName != "" {
+		flow = append(flow, "来自"+asset.SourceName)
+	}
+	if asset.Status == StatusArchived && spaceName != "" {
+		flow = append(flow, "归档到"+spaceName)
+	}
+	if asset.SourceType == SourceTypeApp {
+		flow = []string{"直接上传", "保存到" + spaceName}
+	}
+	if asset.Status == StatusDeleted {
+		flow = append(flow, "移动到回收站")
+	}
+	sourceRef := buildSourceRef(asset, createdAt)
+	permissions := buildDocumentPermissions(asset, space, members, uid)
+	return &DocumentAssetResp{
+		ID:                asset.AssetID,
+		Name:              asset.Name,
+		Kind:              asset.Kind,
+		Extension:         strings.TrimPrefix(asset.Extension, "."),
+		Size:              asset.Size,
+		StoragePath:       "",
+		Owner:             owner,
+		Uploader:          uploader,
+		SourceName:        asset.SourceName,
+		SourceChannelID:   asset.SourceChannelID,
+		SourceChannelType: asset.SourceChannelType,
+		SourceType:        asset.SourceType,
+		SpaceName:         spaceName,
+		Visibility:        asset.Visibility,
+		Status:            asset.Status,
+		CreatedAt:         createdAt,
+		LastAccessAt:      lastAccessAt,
+		Downloads:         asset.Downloads,
+		Previewable:       asset.Previewable == 1,
+		Flow:              flow,
+		SourceRef:         sourceRef,
+		Permissions:       permissions,
+	}
+}
+
+func ensureMembersSlice(items []*DocumentSpaceMemberResp) []*DocumentSpaceMemberResp {
+	if items == nil {
+		return []*DocumentSpaceMemberResp{}
+	}
+	return items
+}
+
+func ensureBindingsSlice(items []*DocumentSpaceBindingResp) []*DocumentSpaceBindingResp {
+	if items == nil {
+		return []*DocumentSpaceBindingResp{}
+	}
+	return items
+}
+
+func buildSourceRef(asset *DocumentAssetModel, createdAt string) *DocumentSourceRefResp {
+	if strings.TrimSpace(asset.SourceChannelID) == "" && strings.TrimSpace(asset.SourceMessageID) == "" {
+		return nil
+	}
+	return &DocumentSourceRefResp{
+		ChannelID:   asset.SourceChannelID,
+		ChannelType: asset.SourceChannelType,
+		ChannelName: asset.SourceName,
+		MessageID:   asset.SourceMessageID,
+		MessageSeq:  asset.SourceMessageSeq,
+		SenderUID:   fallbackString(asset.UploaderUID, asset.OwnerUID),
+		SenderName:  fallbackString(asset.UploaderName, asset.OwnerName),
+		SentAt:      createdAt,
+	}
+}
+
+func buildDocumentPermissions(asset *DocumentAssetModel, space *DocumentSpaceModel, members []*DocumentSpaceMemberResp, uid string) DocumentPermissionResp {
+	isOwner := asset.OwnerUID == uid || asset.UploaderUID == uid
+	isSpaceOwner := space != nil && space.OwnerUID == uid
+	spaceRole := ""
+	if isSpaceOwner {
+		spaceRole = SpaceRoleOwner
+	} else {
+		for _, member := range members {
+			if member.UID == uid {
+				spaceRole = normalizeSpaceRole(member.Role)
+				break
+			}
+		}
+	}
+	isSpaceAdmin := spaceRole == SpaceRoleOwner || spaceRole == SpaceRoleAdmin
+	isSpaceEditor := isSpaceAdmin || spaceRole == SpaceRoleEditor
+	hasSpaceAccess := isSpaceOwner || spaceRole != ""
+	canManage := isOwner || isSpaceAdmin
+	canEdit := isOwner || isSpaceEditor
+	canRead := isOwner || hasSpaceAccess || asset.Visibility == VisibilityConversation
+	active := asset.Status != StatusDeleted
+	reasons := []string{}
+	if isOwner {
+		reasons = append(reasons, "上传者/拥有者")
+	}
+	if isSpaceOwner {
+		reasons = append(reasons, "空间管理员")
+	} else if isSpaceAdmin {
+		reasons = append(reasons, "空间管理员")
+	} else if spaceRole == SpaceRoleEditor {
+		reasons = append(reasons, "空间编辑者")
+	}
+	if asset.Visibility == VisibilitySpace && space != nil {
+		reasons = append(reasons, "空间成员可访问")
+	}
+	if asset.Visibility == VisibilityConversation {
+		reasons = append(reasons, "来源会话成员可访问")
+	}
+	if len(reasons) == 0 {
+		reasons = append(reasons, "拥有访问权限")
+	}
+	summary := strings.Join(reasons, "、")
+	return DocumentPermissionResp{
+		CanPreview:  active && canRead && asset.Previewable == 1,
+		CanDownload: active && canRead,
+		CanArchive:  active && asset.Status == StatusConversation,
+		CanEdit:     active && canEdit,
+		CanDelete:   active && canManage,
+		CanRestore:  asset.Status == StatusDeleted && canManage,
+		CanManage:   canManage,
+		Summary:     summary,
+		Reasons:     reasons,
+	}
+}
+
+func normalizeSpaceRole(role string) string {
+	switch role {
+	case SpaceRoleOwner, SpaceRoleAdmin, SpaceRoleEditor, SpaceRoleViewer:
+		return role
+	default:
+		return SpaceRoleViewer
+	}
+}
+
+func userHasSpaceAccess(uid string, space *DocumentSpaceModel, members []*DocumentSpaceMemberModel) bool {
+	if space == nil {
+		return false
+	}
+	if space.OwnerUID == uid {
+		return true
+	}
+	for _, member := range members {
+		if member.DocumentSpaceID == space.SpaceID && member.UID == uid && member.Status == 1 {
+			return true
+		}
+	}
+	return false
+}
+
+func fallbackString(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}
+
+func documentSourceKey(sourceChannelID string, sourceChannelType uint8) string {
+	return fmt.Sprintf("%s:%d", sourceChannelID, sourceChannelType)
+}
+
+type memoryRepository struct {
+	spaces                []*DocumentSpaceModel
+	bindings              []*DocumentSpaceBindingModel
+	members               []*DocumentSpaceMemberModel
+	users                 []*DocumentUserCandidateModel
+	groups                []*DocumentGroupCandidateModel
+	assets                []*DocumentAssetModel
+	events                []*DocumentEventModel
+	accessibleSources     map[string]map[string]bool
+	canAccessSourceCalls  int
+	canAccessSourcesCalls int
+}
+
+func newMemoryRepository() *memoryRepository {
+	return &memoryRepository{}
+}
+
+func (r *memoryRepository) ListSpaces(uid, tenantSpaceID string) ([]*DocumentSpaceModel, error) {
+	items := make([]*DocumentSpaceModel, 0, len(r.spaces))
+	for _, space := range r.spaces {
+		if space.Status == 1 && space.TenantSpaceID == tenantSpaceID && userHasSpaceAccess(uid, space, r.members) {
+			items = append(items, cloneSpace(space))
+		}
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].CreatedAt.String() > items[j].CreatedAt.String() })
+	return items, nil
+}
+
+func (r *memoryRepository) ListAllSpaces(uid, tenantSpaceID string) ([]*DocumentSpaceModel, error) {
+	items := make([]*DocumentSpaceModel, 0, len(r.spaces))
+	for _, space := range r.spaces {
+		if space.TenantSpaceID == tenantSpaceID {
+			items = append(items, cloneSpace(space))
+		}
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].CreatedAt.String() > items[j].CreatedAt.String() })
+	return items, nil
+}
+
+func (r *memoryRepository) EnsureDefaultSpace(uid, tenantSpaceID string) (*DocumentSpaceModel, error) {
+	for _, space := range r.spaces {
+		if space.TenantSpaceID == tenantSpaceID && space.Status == 1 {
+			return cloneSpace(space), nil
+		}
+	}
+	now := nowDBTime()
+	space := &DocumentSpaceModel{
+		SpaceID:       "DOCSPACE-" + util.GenerUUID(),
+		Name:          "团队文档空间",
+		Description:   "默认文档空间",
+		OwnerUID:      uid,
+		TenantSpaceID: tenantSpaceID,
+		Status:        1,
+	}
+	space.CreatedAt = now
+	space.UpdatedAt = now
+	r.spaces = append(r.spaces, space)
+	return cloneSpace(space), nil
+}
+
+func (r *memoryRepository) GetSpace(spaceID, uid, tenantSpaceID string) (*DocumentSpaceModel, error) {
+	for _, space := range r.spaces {
+		if space.SpaceID == spaceID && space.TenantSpaceID == tenantSpaceID && space.Status == 1 {
+			return cloneSpace(space), nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *memoryRepository) SaveSpace(space *DocumentSpaceModel) error {
+	r.spaces = append(r.spaces, cloneSpace(space))
+	return nil
+}
+
+func (r *memoryRepository) UpdateSpace(space *DocumentSpaceModel) error {
+	for i, item := range r.spaces {
+		if item.SpaceID == space.SpaceID && item.TenantSpaceID == space.TenantSpaceID {
+			r.spaces[i] = cloneSpace(space)
+			return nil
+		}
+	}
+	return errors.New("space not found")
+}
+
+func (r *memoryRepository) ListSpaceBindings(uid, tenantSpaceID string) ([]*DocumentSpaceBindingModel, error) {
+	items := make([]*DocumentSpaceBindingModel, 0, len(r.bindings))
+	for _, binding := range r.bindings {
+		if binding.TenantSpaceID == tenantSpaceID && binding.Status == 1 {
+			items = append(items, cloneBinding(binding))
+		}
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].CreatedAt.String() > items[j].CreatedAt.String() })
+	return items, nil
+}
+
+func (r *memoryRepository) SaveSpaceBinding(binding *DocumentSpaceBindingModel) error {
+	for i, item := range r.bindings {
+		if item.TenantSpaceID == binding.TenantSpaceID &&
+			item.SourceChannelID == binding.SourceChannelID &&
+			item.SourceChannelType == binding.SourceChannelType {
+			if item.DocumentSpaceID == binding.DocumentSpaceID {
+				r.bindings[i] = cloneBinding(binding)
+				return nil
+			}
+			cp := cloneBinding(item)
+			cp.Status = 0
+			cp.UpdatedAt = nowDBTime()
+			r.bindings[i] = cp
+		}
+	}
+	r.bindings = append(r.bindings, cloneBinding(binding))
+	return nil
+}
+
+func (r *memoryRepository) RemoveSpaceBinding(spaceID, bindingID, tenantSpaceID string) error {
+	for i, item := range r.bindings {
+		if item.BindingID == bindingID && item.DocumentSpaceID == spaceID && item.TenantSpaceID == tenantSpaceID {
+			cp := cloneBinding(item)
+			cp.Status = 0
+			cp.UpdatedAt = nowDBTime()
+			r.bindings[i] = cp
+			return nil
+		}
+	}
+	return nil
+}
+
+func (r *memoryRepository) ListSpaceMembers(uid, tenantSpaceID string) ([]*DocumentSpaceMemberModel, error) {
+	items := make([]*DocumentSpaceMemberModel, 0, len(r.members))
+	for _, member := range r.members {
+		if member.TenantSpaceID == tenantSpaceID && member.Status == 1 {
+			items = append(items, cloneMember(member))
+		}
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].CreatedAt.String() > items[j].CreatedAt.String() })
+	return items, nil
+}
+
+func (r *memoryRepository) SearchUsers(uid, tenantSpaceID, keyword string, limit int) ([]*DocumentUserCandidateModel, error) {
+	keyword = strings.ToLower(strings.TrimSpace(keyword))
+	if keyword == "" {
+		return []*DocumentUserCandidateModel{}, nil
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	items := make([]*DocumentUserCandidateModel, 0, limit)
+	for _, user := range r.users {
+		if user == nil || strings.TrimSpace(user.UID) == "" {
+			continue
+		}
+		haystack := strings.ToLower(strings.Join([]string{
+			user.UID,
+			user.Name,
+			user.Username,
+			user.Email,
+			user.Phone,
+		}, " "))
+		if strings.Contains(haystack, keyword) {
+			cp := *user
+			items = append(items, &cp)
+			if len(items) >= limit {
+				break
+			}
+		}
+	}
+	return items, nil
+}
+
+func (r *memoryRepository) SearchGroups(uid, tenantSpaceID, keyword string, limit int) ([]*DocumentGroupCandidateModel, error) {
+	keyword = strings.ToLower(strings.TrimSpace(keyword))
+	if keyword == "" {
+		return []*DocumentGroupCandidateModel{}, nil
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	items := make([]*DocumentGroupCandidateModel, 0, limit)
+	for _, group := range r.groups {
+		if group == nil || strings.TrimSpace(group.GroupNo) == "" {
+			continue
+		}
+		if group.SpaceID != "" && group.SpaceID != tenantSpaceID {
+			continue
+		}
+		haystack := strings.ToLower(strings.Join([]string{group.GroupNo, group.Name}, " "))
+		if strings.Contains(haystack, keyword) {
+			cp := *group
+			items = append(items, &cp)
+			if len(items) >= limit {
+				break
+			}
+		}
+	}
+	return items, nil
+}
+
+func (r *memoryRepository) SaveSpaceMember(member *DocumentSpaceMemberModel) error {
+	for i, item := range r.members {
+		if item.TenantSpaceID == member.TenantSpaceID &&
+			item.DocumentSpaceID == member.DocumentSpaceID &&
+			item.UID == member.UID {
+			existing := cloneMember(member)
+			existing.CreatedAt = item.CreatedAt
+			existing.Source = item.Source
+			existing.CreatedBy = item.CreatedBy
+			r.members[i] = existing
+			return nil
+		}
+	}
+	r.members = append(r.members, cloneMember(member))
+	return nil
+}
+
+func (r *memoryRepository) RemoveSpaceMember(spaceID, memberUID, tenantSpaceID string) error {
+	for i, item := range r.members {
+		if item.TenantSpaceID == tenantSpaceID && item.DocumentSpaceID == spaceID && item.UID == memberUID {
+			cp := cloneMember(item)
+			cp.Status = 0
+			cp.UpdatedAt = nowDBTime()
+			r.members[i] = cp
+			return nil
+		}
+	}
+	return nil
+}
+
+func (r *memoryRepository) ListAssets(uid, tenantSpaceID string) ([]*DocumentAssetModel, error) {
+	items := make([]*DocumentAssetModel, 0, len(r.assets))
+	for _, asset := range r.assets {
+		if asset.TenantSpaceID == tenantSpaceID {
+			items = append(items, cloneAsset(asset))
+		}
+	}
+	sort.Slice(items, func(i, j int) bool {
+		left := items[i].CreatedAt.String()
+		right := items[j].CreatedAt.String()
+		if items[i].LastAccessAt != nil {
+			left = items[i].LastAccessAt.String()
+		}
+		if items[j].LastAccessAt != nil {
+			right = items[j].LastAccessAt.String()
+		}
+		return left > right
+	})
+	return items, nil
+}
+
+func (r *memoryRepository) GetAsset(assetID, uid, tenantSpaceID string) (*DocumentAssetModel, error) {
+	for _, asset := range r.assets {
+		if asset.AssetID == assetID && asset.TenantSpaceID == tenantSpaceID {
+			return cloneAsset(asset), nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *memoryRepository) SaveAsset(asset *DocumentAssetModel) error {
+	r.assets = append(r.assets, cloneAsset(asset))
+	return nil
+}
+
+func (r *memoryRepository) UpdateAsset(asset *DocumentAssetModel) error {
+	for i, item := range r.assets {
+		if item.AssetID == asset.AssetID && item.TenantSpaceID == asset.TenantSpaceID {
+			r.assets[i] = cloneAsset(asset)
+			return nil
+		}
+	}
+	return errors.New("asset not found")
+}
+
+func (r *memoryRepository) DeleteAsset(assetID, tenantSpaceID string) error {
+	next := r.assets[:0]
+	for _, item := range r.assets {
+		if item.AssetID == assetID && item.TenantSpaceID == tenantSpaceID {
+			continue
+		}
+		next = append(next, item)
+	}
+	r.assets = next
+	return nil
+}
+
+func (r *memoryRepository) AddEvent(event *DocumentEventModel) error {
+	r.events = append([]*DocumentEventModel{cloneEvent(event)}, r.events...)
+	return nil
+}
+
+func (r *memoryRepository) ListEvents(uid, tenantSpaceID string, limit int) ([]*DocumentEventModel, error) {
+	items := make([]*DocumentEventModel, 0, len(r.events))
+	for _, event := range r.events {
+		if event.TenantSpaceID == tenantSpaceID {
+			items = append(items, cloneEvent(event))
+		}
+		if limit > 0 && len(items) >= limit {
+			break
+		}
+	}
+	return items, nil
+}
+
+func (r *memoryRepository) CanAccessSource(uid, tenantSpaceID, sourceChannelID string, sourceChannelType uint8) (bool, error) {
+	r.canAccessSourceCalls++
+	if r.accessibleSources == nil {
+		return sourceChannelID != "", nil
+	}
+	members := r.accessibleSources[fmt.Sprintf("%s:%d", sourceChannelID, sourceChannelType)]
+	if members == nil {
+		return false, nil
+	}
+	return members[uid], nil
+}
+
+func (r *memoryRepository) CanAccessSources(uid, tenantSpaceID string, sources []documentSourceRef) (map[string]bool, error) {
+	r.canAccessSourcesCalls++
+	result := make(map[string]bool, len(sources))
+	for _, source := range sources {
+		if strings.TrimSpace(source.ChannelID) == "" {
+			continue
+		}
+		key := documentSourceKey(source.ChannelID, source.ChannelType)
+		if r.accessibleSources == nil {
+			result[key] = true
+			continue
+		}
+		members := r.accessibleSources[key]
+		if members != nil && members[uid] {
+			result[key] = true
+		}
+	}
+	return result, nil
+}
+
+func cloneSpace(space *DocumentSpaceModel) *DocumentSpaceModel {
+	if space == nil {
+		return nil
+	}
+	cp := *space
+	return &cp
+}
+
+func cloneAsset(asset *DocumentAssetModel) *DocumentAssetModel {
+	if asset == nil {
+		return nil
+	}
+	cp := *asset
+	if asset.LastAccessAt != nil {
+		v := *asset.LastAccessAt
+		cp.LastAccessAt = &v
+	}
+	return &cp
+}
+
+func cloneBinding(binding *DocumentSpaceBindingModel) *DocumentSpaceBindingModel {
+	if binding == nil {
+		return nil
+	}
+	cp := *binding
+	return &cp
+}
+
+func cloneMember(member *DocumentSpaceMemberModel) *DocumentSpaceMemberModel {
+	if member == nil {
+		return nil
+	}
+	cp := *member
+	return &cp
+}
+
+func cloneEvent(event *DocumentEventModel) *DocumentEventModel {
+	if event == nil {
+		return nil
+	}
+	cp := *event
+	return &cp
+}

--- a/modules/document/service_test.go
+++ b/modules/document/service_test.go
@@ -1,0 +1,1230 @@
+package document
+
+import (
+	"testing"
+)
+
+func TestServiceUploadCreatesSpaceAsset(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{{
+		SpaceID:       "doc-space-1",
+		Name:          "产品部公共空间",
+		OwnerUID:      "u1",
+		TenantSpaceID: "tenant-1",
+		Status:        1,
+	}}
+	service := NewDocumentService(repo)
+
+	state, err := service.Upload("u1", "tenant-1", UploadReq{
+		Name:            "需求清单.xlsx",
+		Extension:       ".xlsx",
+		Size:            2048,
+		StoragePath:     "/documents/需求清单.xlsx",
+		DocumentSpaceID: "doc-space-1",
+		UploaderName:    "陈一",
+	})
+
+	if err != nil {
+		t.Fatalf("Upload returned error: %v", err)
+	}
+	if len(state.Files) != 1 {
+		t.Fatalf("expected one file, got %d", len(state.Files))
+	}
+	file := state.Files[0]
+	if file.Name != "需求清单.xlsx" {
+		t.Fatalf("unexpected file name: %s", file.Name)
+	}
+	if file.Status != StatusArchived {
+		t.Fatalf("expected archived status, got %s", file.Status)
+	}
+	if file.SourceName != SourceNameDirectUpload {
+		t.Fatalf("expected direct upload source, got %s", file.SourceName)
+	}
+	if file.Uploader != "陈一" {
+		t.Fatalf("expected uploader display name, got %s", file.Uploader)
+	}
+	if file.Owner != "陈一" {
+		t.Fatalf("expected owner display name, got %s", file.Owner)
+	}
+	if state.Spaces[0].FileCount != 1 {
+		t.Fatalf("expected space file count 1, got %d", state.Spaces[0].FileCount)
+	}
+}
+
+func TestServiceStateDoesNotLeakSpaceAssetsToNonMember(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{{
+		SpaceID:       "private-space",
+		Name:          "私有项目空间",
+		OwnerUID:      "owner",
+		TenantSpaceID: "tenant-1",
+		Status:        1,
+	}}
+	repo.assets = []*DocumentAssetModel{{
+		AssetID:         "asset-private",
+		Name:            "private-plan.pdf",
+		Kind:            KindPDF,
+		Extension:       ".pdf",
+		Size:            2048,
+		StoragePath:     "common/private-plan.pdf",
+		UploaderUID:     "owner",
+		UploaderName:    "空间 Owner",
+		OwnerUID:        "owner",
+		TenantSpaceID:   "tenant-1",
+		DocumentSpaceID: "private-space",
+		Visibility:      VisibilitySpace,
+		Status:          StatusArchived,
+		Previewable:     1,
+	}}
+	service := NewDocumentService(repo)
+
+	state, err := service.State("outsider", "tenant-1")
+
+	if err != nil {
+		t.Fatalf("State returned error: %v", err)
+	}
+	if len(state.Files) != 0 {
+		t.Fatalf("expected no leaked files, got %#v", state.Files)
+	}
+	for _, space := range state.Spaces {
+		if space.ID == "private-space" {
+			t.Fatalf("expected private space to stay hidden from non-member: %#v", state.Spaces)
+		}
+	}
+}
+
+func TestServiceBuildStateBatchesConversationSourceAccess(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.assets = []*DocumentAssetModel{
+		{
+			AssetID:           "asset-visible",
+			Name:              "visible.pdf",
+			Kind:              KindPDF,
+			Extension:         ".pdf",
+			Size:              2048,
+			StoragePath:       "common/visible.pdf",
+			UploaderUID:       "owner",
+			OwnerUID:          "owner",
+			TenantSpaceID:     "tenant-1",
+			Visibility:        VisibilityConversation,
+			SourceChannelID:   "group-visible",
+			SourceChannelType: 2,
+			Status:            StatusConversation,
+			Previewable:       1,
+		},
+		{
+			AssetID:           "asset-hidden",
+			Name:              "hidden.pdf",
+			Kind:              KindPDF,
+			Extension:         ".pdf",
+			Size:              2048,
+			StoragePath:       "common/hidden.pdf",
+			UploaderUID:       "owner",
+			OwnerUID:          "owner",
+			TenantSpaceID:     "tenant-1",
+			Visibility:        VisibilityConversation,
+			SourceChannelID:   "group-hidden",
+			SourceChannelType: 2,
+			Status:            StatusConversation,
+			Previewable:       1,
+		},
+	}
+	repo.accessibleSources = map[string]map[string]bool{
+		"group-visible:2": {"reader": true},
+	}
+	service := NewDocumentService(repo)
+
+	state, err := service.buildState("reader", "tenant-1")
+	if err != nil {
+		t.Fatalf("buildState returned error: %v", err)
+	}
+	if len(state.Files) != 1 || state.Files[0].ID != "asset-visible" {
+		t.Fatalf("expected only visible conversation asset, got %#v", state.Files)
+	}
+	if repo.canAccessSourceCalls != 0 {
+		t.Fatalf("expected buildState to avoid per-asset CanAccessSource calls, got %d", repo.canAccessSourceCalls)
+	}
+	if repo.canAccessSourcesCalls != 1 {
+		t.Fatalf("expected one batched CanAccessSources call, got %d", repo.canAccessSourcesCalls)
+	}
+}
+
+func TestServiceArchiveMessageFileMovesConversationAssetToSpace(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{{
+		SpaceID:       "doc-space-1",
+		Name:          "华东交付部空间",
+		OwnerUID:      "u1",
+		TenantSpaceID: "tenant-1",
+		Status:        1,
+	}}
+	repo.assets = []*DocumentAssetModel{{
+		AssetID:           "asset-1",
+		Name:              "现场计划.pdf",
+		Kind:              KindPDF,
+		Extension:         ".pdf",
+		Size:              4096,
+		SourceType:        SourceTypeGroup,
+		SourceName:        "华东项目交付群",
+		SourceChannelID:   "group-1",
+		SourceChannelType: 2,
+		UploaderUID:       "u2",
+		UploaderName:      "张沐",
+		OwnerUID:          "u2",
+		TenantSpaceID:     "tenant-1",
+		DocumentSpaceID:   "",
+		Visibility:        VisibilityConversation,
+		Status:            StatusConversation,
+		Previewable:       1,
+	}}
+	service := NewDocumentService(repo)
+
+	state, err := service.Archive("u1", "tenant-1", ArchiveReq{
+		AssetID:         "asset-1",
+		DocumentSpaceID: "doc-space-1",
+	})
+
+	if err != nil {
+		t.Fatalf("Archive returned error: %v", err)
+	}
+	file := state.Files[0]
+	if file.Status != StatusArchived {
+		t.Fatalf("expected archived, got %s", file.Status)
+	}
+	if file.SpaceName != "华东交付部空间" {
+		t.Fatalf("expected target space name, got %s", file.SpaceName)
+	}
+	if state.Spaces[0].FileCount != 1 {
+		t.Fatalf("expected target space count 1, got %d", state.Spaces[0].FileCount)
+	}
+}
+
+func TestServiceArchiveNewAssetUsesCallerAsUploader(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{{
+		SpaceID:       "doc-space-1",
+		Name:          "产品部公共空间",
+		OwnerUID:      "u1",
+		TenantSpaceID: "tenant-1",
+		Status:        1,
+	}}
+	service := NewDocumentService(repo)
+
+	_, err := service.Archive("u1", "tenant-1", ArchiveReq{
+		AssetID:         "msg-file-1",
+		Name:            "会议纪要.pdf",
+		Extension:       ".pdf",
+		StoragePath:     "common/documents/meeting.pdf",
+		DocumentSpaceID: "doc-space-1",
+		UploaderUID:     "victim",
+		UploaderName:    "伪造上传人",
+	})
+
+	if err != nil {
+		t.Fatalf("Archive returned error: %v", err)
+	}
+	if len(repo.assets) != 1 {
+		t.Fatalf("expected one archived asset, got %d", len(repo.assets))
+	}
+	if repo.assets[0].UploaderUID != "u1" {
+		t.Fatalf("expected archive uploader to be caller, got %s", repo.assets[0].UploaderUID)
+	}
+	if repo.assets[0].AssetID == "msg-file-1" {
+		t.Fatalf("expected archive asset id to be server-generated")
+	}
+	if got := repo.assets[0].AssetID; len(got) < 4 || got[:4] != "DOC-" {
+		t.Fatalf("expected generated DOC- asset id, got %s", got)
+	}
+}
+
+func TestServiceUploadAndArchiveRequireSpaceEditor(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{{
+		SpaceID:       "private-space",
+		Name:          "私有交付空间",
+		OwnerUID:      "owner",
+		TenantSpaceID: "tenant-1",
+		Status:        1,
+	}}
+	service := NewDocumentService(repo)
+
+	if _, err := service.Upload("outsider", "tenant-1", UploadReq{
+		Name:            "unauthorized.pdf",
+		Extension:       ".pdf",
+		StoragePath:     "common/unauthorized.pdf",
+		DocumentSpaceID: "private-space",
+	}); err == nil {
+		t.Fatalf("expected Upload to reject non-editor space writes")
+	}
+
+	if _, err := service.Archive("outsider", "tenant-1", ArchiveReq{
+		AssetID:         "asset-unauthorized",
+		Name:            "unauthorized.pdf",
+		Extension:       ".pdf",
+		StoragePath:     "common/unauthorized.pdf",
+		DocumentSpaceID: "private-space",
+	}); err == nil {
+		t.Fatalf("expected Archive to reject non-editor space writes")
+	}
+}
+
+func TestServiceArchiveRejectsRehomingAssetWithoutEditAccess(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{
+		{
+			SpaceID:       "victim-space",
+			Name:          "受限空间",
+			OwnerUID:      "victim",
+			TenantSpaceID: "tenant-1",
+			Status:        1,
+		},
+		{
+			SpaceID:       "attacker-space",
+			Name:          "攻击者空间",
+			OwnerUID:      "attacker",
+			TenantSpaceID: "tenant-1",
+			Status:        1,
+		},
+	}
+	repo.assets = []*DocumentAssetModel{{
+		AssetID:         "asset-victim",
+		Name:            "private-plan.pdf",
+		Kind:            KindPDF,
+		Extension:       ".pdf",
+		Size:            2048,
+		StoragePath:     "common/private-plan.pdf",
+		SourceType:      SourceTypeApp,
+		SourceName:      SourceNameDirectUpload,
+		UploaderUID:     "victim",
+		OwnerUID:        "victim",
+		TenantSpaceID:   "tenant-1",
+		DocumentSpaceID: "victim-space",
+		Visibility:      VisibilitySpace,
+		Status:          StatusArchived,
+		Previewable:     1,
+	}}
+	service := NewDocumentService(repo)
+
+	if _, err := service.Archive("attacker", "tenant-1", ArchiveReq{
+		AssetID:         "asset-victim",
+		DocumentSpaceID: "attacker-space",
+	}); err == nil {
+		t.Fatalf("expected Archive to reject rehoming an asset without edit access")
+	}
+	if got := repo.assets[0].DocumentSpaceID; got != "victim-space" {
+		t.Fatalf("expected asset to remain in victim space, got %s", got)
+	}
+}
+
+func TestServiceArchiveRejectsConversationAssetWithForgedSource(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{
+		{
+			SpaceID:       "attacker-space",
+			Name:          "攻击者空间",
+			OwnerUID:      "attacker",
+			TenantSpaceID: "tenant-1",
+			Status:        1,
+		},
+	}
+	repo.assets = []*DocumentAssetModel{{
+		AssetID:           "asset-victim-conversation",
+		Name:              "secret-chat-file.pdf",
+		Kind:              KindPDF,
+		Extension:         ".pdf",
+		Size:              2048,
+		StoragePath:       "common/secret-chat-file.pdf",
+		SourceType:        SourceTypeGroup,
+		SourceName:        "受限群聊",
+		SourceChannelID:   "group-victim",
+		SourceChannelType: 2,
+		UploaderUID:       "victim",
+		OwnerUID:          "victim",
+		TenantSpaceID:     "tenant-1",
+		Visibility:        VisibilityConversation,
+		Status:            StatusConversation,
+		Previewable:       1,
+	}}
+	repo.accessibleSources = map[string]map[string]bool{
+		"group-attacker:2": {"attacker": true},
+		"group-victim:2":   {"attacker": false},
+	}
+	service := NewDocumentService(repo)
+
+	if _, err := service.Archive("attacker", "tenant-1", ArchiveReq{
+		AssetID:           "asset-victim-conversation",
+		DocumentSpaceID:   "attacker-space",
+		SourceChannelID:   "group-attacker",
+		SourceChannelType: 2,
+	}); err == nil {
+		t.Fatalf("expected Archive to reject forged source access for conversation assets")
+	}
+	if got := repo.assets[0].DocumentSpaceID; got != "" {
+		t.Fatalf("expected conversation asset to remain unarchived, got space %s", got)
+	}
+}
+
+func TestServiceArchiveRejectsUnreadableConversationAssetWithEmptySource(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{{
+		SpaceID:       "attacker-space",
+		Name:          "攻击者空间",
+		OwnerUID:      "attacker",
+		TenantSpaceID: "tenant-1",
+		Status:        1,
+	}}
+	repo.assets = []*DocumentAssetModel{{
+		AssetID:       "asset-empty-source",
+		Name:          "orphan-chat-file.pdf",
+		Kind:          KindPDF,
+		Extension:     ".pdf",
+		Size:          2048,
+		StoragePath:   "common/orphan-chat-file.pdf",
+		UploaderUID:   "victim",
+		OwnerUID:      "victim",
+		TenantSpaceID: "tenant-1",
+		Visibility:    VisibilityConversation,
+		Status:        StatusConversation,
+		Previewable:   1,
+	}}
+	service := NewDocumentService(repo)
+
+	if _, err := service.Archive("attacker", "tenant-1", ArchiveReq{
+		AssetID:         "asset-empty-source",
+		DocumentSpaceID: "attacker-space",
+	}); err == nil {
+		t.Fatalf("expected Archive to reject unreadable empty-source conversation asset")
+	}
+	if got := repo.assets[0].DocumentSpaceID; got != "" {
+		t.Fatalf("expected conversation asset to remain unarchived, got space %s", got)
+	}
+}
+
+func TestServiceBindConversationRequiresSourceAccess(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{{
+		SpaceID:       "doc-space-1",
+		Name:          "产品部公共空间",
+		OwnerUID:      "owner",
+		TenantSpaceID: "tenant-1",
+		Status:        1,
+	}}
+	repo.accessibleSources = map[string]map[string]bool{
+		"group-secret:2": {"owner": false},
+	}
+	service := NewDocumentService(repo)
+
+	if _, err := service.BindConversation("owner", "tenant-1", BindConversationReq{
+		DocumentSpaceID:   "doc-space-1",
+		SourceChannelID:   "group-secret",
+		SourceChannelType: 2,
+		SourceName:        "秘密项目群",
+	}); err == nil {
+		t.Fatalf("expected BindConversation to reject inaccessible source channels")
+	}
+}
+
+func TestServiceBindConversationDoesNotRebindInaccessibleSpace(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{
+		{
+			SpaceID:       "current-space",
+			Name:          "当前空间",
+			OwnerUID:      "u1",
+			TenantSpaceID: "tenant-1",
+			Status:        1,
+		},
+		{
+			SpaceID:       "private-space",
+			Name:          "私有空间",
+			OwnerUID:      "u2",
+			TenantSpaceID: "tenant-1",
+			Status:        1,
+		},
+	}
+	repo.bindings = []*DocumentSpaceBindingModel{{
+		BindingID:         "bind-private",
+		DocumentSpaceID:   "private-space",
+		SourceChannelID:   "group-1",
+		SourceChannelType: 2,
+		SourceName:        "产品方案讨论群",
+		CreatedBy:         "u2",
+		TenantSpaceID:     "tenant-1",
+		Status:            1,
+	}}
+	repo.accessibleSources = map[string]map[string]bool{
+		"group-1:2": {"u1": true},
+	}
+	service := NewDocumentService(repo)
+
+	if _, err := service.BindConversation("u1", "tenant-1", BindConversationReq{
+		DocumentSpaceID:   "current-space",
+		SourceChannelID:   "group-1",
+		SourceChannelType: 2,
+		SourceName:        "产品方案讨论群",
+	}); err == nil {
+		t.Fatalf("expected BindConversation to reject rebinding an inaccessible space")
+	}
+}
+
+func TestServiceBindingDiscoveryHidesInaccessibleBoundSpace(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{
+		{
+			SpaceID:       "current-space",
+			Name:          "当前空间",
+			OwnerUID:      "u1",
+			TenantSpaceID: "tenant-1",
+			Status:        1,
+		},
+		{
+			SpaceID:       "private-space",
+			Name:          "私有空间",
+			OwnerUID:      "u2",
+			TenantSpaceID: "tenant-1",
+			Status:        1,
+		},
+	}
+	repo.bindings = []*DocumentSpaceBindingModel{{
+		BindingID:         "bind-private",
+		DocumentSpaceID:   "private-space",
+		SourceChannelID:   "group-1",
+		SourceChannelType: 2,
+		SourceName:        "产品方案讨论群",
+		CreatedBy:         "u2",
+		TenantSpaceID:     "tenant-1",
+		Status:            1,
+	}}
+	repo.groups = []*DocumentGroupCandidateModel{{
+		GroupNo: "group-1",
+		Name:    "产品方案讨论群",
+		SpaceID: "tenant-1",
+	}}
+	service := NewDocumentService(repo)
+
+	candidates, err := service.SearchBindingConversations("u1", "tenant-1", "current-space", "产品")
+	if err != nil {
+		t.Fatalf("SearchBindingConversations returned error: %v", err)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("expected one candidate, got %d", len(candidates))
+	}
+	if candidates[0].BoundSpaceID != "" || candidates[0].BoundSpaceName != "" {
+		t.Fatalf("expected inaccessible bound space to stay hidden, got %#v", candidates[0])
+	}
+
+	storageSpace, err := service.ChannelStorageSpace("u1", "tenant-1", "group-1", 2)
+	if err != nil {
+		t.Fatalf("ChannelStorageSpace returned error: %v", err)
+	}
+	if storageSpace.SpaceID != "" || storageSpace.SpaceName != "" {
+		t.Fatalf("expected inaccessible storage space to stay hidden, got %#v", storageSpace)
+	}
+}
+
+func TestServiceArchiveUsesBoundGroupStorageSpaceWhenSpaceIDEmpty(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{{
+		SpaceID:       "doc-space-1",
+		Name:          "产品部公共空间",
+		OwnerUID:      "u1",
+		TenantSpaceID: "tenant-1",
+		Status:        1,
+	}}
+	repo.bindings = []*DocumentSpaceBindingModel{{
+		BindingID:         "bind-1",
+		DocumentSpaceID:   "doc-space-1",
+		SourceChannelID:   "group-1",
+		SourceChannelType: 2,
+		SourceName:        "产品方案讨论群",
+		CreatedBy:         "u1",
+		TenantSpaceID:     "tenant-1",
+		Status:            1,
+	}}
+	service := NewDocumentService(repo)
+
+	state, err := service.Archive("u1", "tenant-1", ArchiveReq{
+		AssetID:           "msg-1",
+		Name:              "需求清单.xlsx",
+		Extension:         ".xlsx",
+		Size:              2048,
+		StoragePath:       "common/documents/demo/requirements.xlsx",
+		SourceType:        SourceTypeGroup,
+		SourceChannelID:   "group-1",
+		SourceChannelType: 2,
+		SourceName:        "产品方案讨论群",
+		UploaderUID:       "u2",
+		UploaderName:      "张沐",
+	})
+
+	if err != nil {
+		t.Fatalf("Archive returned error: %v", err)
+	}
+	file := state.Files[0]
+	if file.SpaceName != "产品部公共空间" {
+		t.Fatalf("expected bound storage space, got %s", file.SpaceName)
+	}
+	if file.Status != StatusArchived || file.Visibility != VisibilitySpace {
+		t.Fatalf("expected archived space file, got status=%s visibility=%s", file.Status, file.Visibility)
+	}
+}
+
+func TestServiceRebindingGroupKeepsOnlyLatestStorageSpace(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{
+		{
+			SpaceID:       "doc-space-1",
+			Name:          "产品部公共空间",
+			OwnerUID:      "u1",
+			TenantSpaceID: "tenant-1",
+			Status:        1,
+		},
+		{
+			SpaceID:       "doc-space-2",
+			Name:          "QA复验空间",
+			OwnerUID:      "u1",
+			TenantSpaceID: "tenant-1",
+			Status:        1,
+		},
+	}
+	repo.groups = []*DocumentGroupCandidateModel{{
+		GroupNo: "group-1",
+		Name:    "产品方案讨论群",
+		SpaceID: "tenant-1",
+	}}
+	service := NewDocumentService(repo)
+
+	if _, err := service.BindConversation("u1", "tenant-1", BindConversationReq{
+		DocumentSpaceID:   "doc-space-1",
+		SourceChannelID:   "group-1",
+		SourceChannelType: 2,
+		SourceName:        "产品方案讨论群",
+	}); err != nil {
+		t.Fatalf("first BindConversation returned error: %v", err)
+	}
+	if _, err := service.BindConversation("u1", "tenant-1", BindConversationReq{
+		DocumentSpaceID:   "doc-space-2",
+		SourceChannelID:   "group-1",
+		SourceChannelType: 2,
+		SourceName:        "产品方案讨论群",
+	}); err != nil {
+		t.Fatalf("second BindConversation returned error: %v", err)
+	}
+
+	storageSpace, err := service.ChannelStorageSpace("u1", "tenant-1", "group-1", 2)
+	if err != nil {
+		t.Fatalf("ChannelStorageSpace returned error: %v", err)
+	}
+	if storageSpace.SpaceName != "QA复验空间" {
+		t.Fatalf("expected latest bound space, got %s", storageSpace.SpaceName)
+	}
+	candidates, err := service.SearchBindingConversations("u1", "tenant-1", "doc-space-2", "产品")
+	if err != nil {
+		t.Fatalf("SearchBindingConversations returned error: %v", err)
+	}
+	if len(candidates) != 1 || !candidates[0].AlreadyBoundToCurrentSpace {
+		t.Fatalf("expected candidate bound to current space, got %#v", candidates)
+	}
+}
+
+func TestServiceTrashAndRestoreKeepBusinessClosedLoop(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{{
+		SpaceID:       "doc-space-1",
+		Name:          "公司制度空间",
+		OwnerUID:      "u1",
+		TenantSpaceID: "tenant-1",
+		Status:        1,
+	}}
+	repo.assets = []*DocumentAssetModel{{
+		AssetID:         "asset-1",
+		Name:            "制度更新说明.docx",
+		Kind:            KindDoc,
+		Extension:       ".docx",
+		Size:            1024,
+		SourceType:      SourceTypeGroup,
+		SourceName:      "行政制度发布群",
+		UploaderUID:     "u1",
+		UploaderName:    "周岚",
+		OwnerUID:        "u1",
+		TenantSpaceID:   "tenant-1",
+		DocumentSpaceID: "doc-space-1",
+		Visibility:      VisibilitySpace,
+		Status:          StatusArchived,
+		Previewable:     1,
+	}}
+	service := NewDocumentService(repo)
+
+	deleted, err := service.Trash("u1", "tenant-1", "asset-1")
+	if err != nil {
+		t.Fatalf("Trash returned error: %v", err)
+	}
+	if deleted.Files[0].Status != StatusDeleted {
+		t.Fatalf("expected deleted, got %s", deleted.Files[0].Status)
+	}
+	if deleted.Spaces[0].FileCount != 0 {
+		t.Fatalf("expected space count 0 after trash, got %d", deleted.Spaces[0].FileCount)
+	}
+
+	restored, err := service.Restore("u1", "tenant-1", "asset-1")
+	if err != nil {
+		t.Fatalf("Restore returned error: %v", err)
+	}
+	if restored.Files[0].Status != StatusArchived {
+		t.Fatalf("expected archived after restore, got %s", restored.Files[0].Status)
+	}
+	if restored.Spaces[0].FileCount != 1 {
+		t.Fatalf("expected space count 1 after restore, got %d", restored.Spaces[0].FileCount)
+	}
+}
+
+func TestServiceBindConversationShowsOnDocumentSpace(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{{
+		SpaceID:       "doc-space-1",
+		Name:          "产品部公共空间",
+		OwnerUID:      "u1",
+		TenantSpaceID: "tenant-1",
+		Status:        1,
+	}}
+	service := NewDocumentService(repo)
+
+	state, err := service.BindConversation("u1", "tenant-1", BindConversationReq{
+		DocumentSpaceID:   "doc-space-1",
+		SourceChannelID:   "grp_product_docs",
+		SourceChannelType: 2,
+		SourceName:        "产品方案讨论群",
+	})
+
+	if err != nil {
+		t.Fatalf("BindConversation returned error: %v", err)
+	}
+	if len(state.Spaces) != 1 {
+		t.Fatalf("expected one space, got %d", len(state.Spaces))
+	}
+	if got := state.Spaces[0].BoundConversations; len(got) != 1 || got[0].Name != "产品方案讨论群" {
+		t.Fatalf("expected bound conversation, got %#v", got)
+	}
+
+	unbound, err := service.UnbindConversation("u1", "tenant-1", "doc-space-1", state.Spaces[0].BoundConversations[0].ID)
+	if err != nil {
+		t.Fatalf("UnbindConversation returned error: %v", err)
+	}
+	if got := unbound.Spaces[0].BoundConversations; len(got) != 0 {
+		t.Fatalf("expected no bound conversation after unbind, got %#v", got)
+	}
+}
+
+func TestServiceCheckSourceRequiresAccessibleConversation(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.assets = []*DocumentAssetModel{{
+		AssetID:           "asset-1",
+		Name:              "产品方案.pdf",
+		Kind:              KindPDF,
+		Extension:         ".pdf",
+		SourceType:        SourceTypeGroup,
+		SourceChannelID:   "grp_product_docs",
+		SourceChannelType: 2,
+		SourceName:        "产品方案讨论群",
+		TenantSpaceID:     "tenant-1",
+		Status:            StatusConversation,
+		Visibility:        VisibilityConversation,
+		Previewable:       1,
+	}}
+	repo.accessibleSources = map[string]map[string]bool{
+		"grp_product_docs:2": {
+			"u1": true,
+			"u2": false,
+		},
+	}
+	service := NewDocumentService(repo)
+
+	allowed, err := service.CheckSource("u1", "tenant-1", "asset-1")
+	if err != nil {
+		t.Fatalf("CheckSource returned error for allowed user: %v", err)
+	}
+	if !allowed {
+		t.Fatalf("expected allowed user to access source")
+	}
+
+	if denied, err := service.CheckSource("u2", "tenant-1", "asset-1"); err == nil || denied {
+		t.Fatalf("expected denied user to be rejected, allowed=%v err=%v", denied, err)
+	}
+}
+
+func TestServiceStateIncludesSourceReferenceAndPermissions(t *testing.T) {
+	repo := newMemoryRepository()
+	created := nowDBTime()
+	repo.spaces = []*DocumentSpaceModel{{
+		SpaceID:       "doc-space-1",
+		Name:          "产品部公共空间",
+		OwnerUID:      "space-owner",
+		TenantSpaceID: "tenant-1",
+		Status:        1,
+	}}
+	repo.assets = []*DocumentAssetModel{{
+		AssetID:           "asset-1",
+		Name:              "需求清单.xlsx",
+		Kind:              KindSheet,
+		Extension:         ".xlsx",
+		Size:              4096,
+		SourceType:        SourceTypeGroup,
+		SourceName:        "产品方案讨论群",
+		SourceChannelID:   "grp_product_docs",
+		SourceChannelType: 2,
+		SourceMessageID:   "2406171002",
+		UploaderUID:       "pm_chen",
+		UploaderName:      "陈一",
+		OwnerUID:          "pm_chen",
+		OwnerName:         "陈一",
+		TenantSpaceID:     "tenant-1",
+		DocumentSpaceID:   "doc-space-1",
+		Visibility:        VisibilitySpace,
+		Status:            StatusArchived,
+		Previewable:       1,
+	}}
+	repo.assets[0].CreatedAt = created
+	repo.accessibleSources = map[string]map[string]bool{
+		"grp_product_docs:2": {"pm_chen": true},
+	}
+	service := NewDocumentService(repo)
+
+	state, err := service.State("pm_chen", "tenant-1")
+	if err != nil {
+		t.Fatalf("State returned error: %v", err)
+	}
+	file := state.Files[0]
+	if file.SourceRef == nil {
+		t.Fatalf("expected source reference")
+	}
+	if file.SourceRef.MessageID != "2406171002" {
+		t.Fatalf("expected source message id, got %s", file.SourceRef.MessageID)
+	}
+	if file.SourceRef.ChannelID != "grp_product_docs" || file.SourceRef.ChannelType != 2 {
+		t.Fatalf("unexpected source channel: %#v", file.SourceRef)
+	}
+	if file.SourceRef.SenderName != "陈一" {
+		t.Fatalf("expected sender display name, got %s", file.SourceRef.SenderName)
+	}
+	if file.SourceRef.SentAt == "" {
+		t.Fatalf("expected source sent time")
+	}
+	if !file.Permissions.CanPreview || !file.Permissions.CanDownload || !file.Permissions.CanDelete {
+		t.Fatalf("owner should have preview/download/delete permissions: %#v", file.Permissions)
+	}
+	if file.Permissions.Summary == "" {
+		t.Fatalf("expected permission summary")
+	}
+}
+
+func TestServicePreviewRequiresConversationAccess(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.assets = []*DocumentAssetModel{{
+		AssetID:           "asset-1",
+		Name:              "客户账号截图.png",
+		Kind:              KindImage,
+		Extension:         ".png",
+		SourceType:        SourceTypeGroup,
+		SourceChannelID:   "grp_delivery_docs",
+		SourceChannelType: 2,
+		SourceName:        "华东项目交付群",
+		TenantSpaceID:     "tenant-1",
+		Visibility:        VisibilityConversation,
+		Status:            StatusConversation,
+		Previewable:       1,
+	}}
+	repo.accessibleSources = map[string]map[string]bool{
+		"grp_delivery_docs:2": {"outsider": false},
+	}
+	service := NewDocumentService(repo)
+
+	if _, err := service.Preview("outsider", "tenant-1", "asset-1"); err == nil {
+		t.Fatalf("expected preview to reject users outside the source conversation")
+	}
+}
+
+func TestServiceTrashRequiresManagePermission(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{{
+		SpaceID:       "doc-space-1",
+		Name:          "产品部公共空间",
+		OwnerUID:      "space-owner",
+		TenantSpaceID: "tenant-1",
+		Status:        1,
+	}}
+	repo.assets = []*DocumentAssetModel{{
+		AssetID:         "asset-1",
+		Name:            "产品方案.pdf",
+		Kind:            KindPDF,
+		Extension:       ".pdf",
+		UploaderUID:     "pm_chen",
+		OwnerUID:        "pm_chen",
+		TenantSpaceID:   "tenant-1",
+		DocumentSpaceID: "doc-space-1",
+		Visibility:      VisibilitySpace,
+		Status:          StatusArchived,
+		Previewable:     1,
+	}}
+	service := NewDocumentService(repo)
+
+	if _, err := service.Trash("ordinary-user", "tenant-1", "asset-1"); err == nil {
+		t.Fatalf("expected trash to reject users without manage permission")
+	}
+}
+
+func TestServiceRenameAndMoveFileRequireSpaceEditPermission(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{{
+		SpaceID:       "space-a",
+		Name:          "产品部公共空间",
+		OwnerUID:      "owner",
+		TenantSpaceID: "tenant-1",
+		Status:        1,
+	}, {
+		SpaceID:       "space-b",
+		Name:          "华东交付空间",
+		OwnerUID:      "owner",
+		TenantSpaceID: "tenant-1",
+		Status:        1,
+	}}
+	repo.members = []*DocumentSpaceMemberModel{{
+		MemberID:        "mem-1",
+		DocumentSpaceID: "space-a",
+		UID:             "editor",
+		Name:            "编辑成员",
+		Role:            SpaceRoleEditor,
+		TenantSpaceID:   "tenant-1",
+		Status:          1,
+	}, {
+		MemberID:        "mem-2",
+		DocumentSpaceID: "space-b",
+		UID:             "editor",
+		Name:            "编辑成员",
+		Role:            SpaceRoleEditor,
+		TenantSpaceID:   "tenant-1",
+		Status:          1,
+	}}
+	repo.assets = []*DocumentAssetModel{{
+		AssetID:         "asset-1",
+		Name:            "旧名称.docx",
+		Kind:            KindDoc,
+		Extension:       ".docx",
+		UploaderUID:     "uploader",
+		OwnerUID:        "uploader",
+		TenantSpaceID:   "tenant-1",
+		DocumentSpaceID: "space-a",
+		Visibility:      VisibilitySpace,
+		Status:          StatusArchived,
+		Previewable:     1,
+	}}
+	service := NewDocumentService(repo)
+
+	renamed, err := service.RenameAsset("editor", "tenant-1", "asset-1", RenameAssetReq{Name: "新名称.docx"})
+	if err != nil {
+		t.Fatalf("RenameAsset returned error: %v", err)
+	}
+	if renamed.Files[0].Name != "新名称.docx" {
+		t.Fatalf("expected renamed file, got %s", renamed.Files[0].Name)
+	}
+
+	moved, err := service.MoveAsset("editor", "tenant-1", "asset-1", MoveAssetReq{DocumentSpaceID: "space-b"})
+	if err != nil {
+		t.Fatalf("MoveAsset returned error: %v", err)
+	}
+	if moved.Files[0].SpaceName != "华东交付空间" {
+		t.Fatalf("expected moved file space, got %s", moved.Files[0].SpaceName)
+	}
+	if !moved.Files[0].Permissions.CanEdit {
+		t.Fatalf("expected editor to keep edit permission after move: %#v", moved.Files[0].Permissions)
+	}
+	if moved.Files[0].Permissions.CanManage || moved.Files[0].Permissions.CanDelete {
+		t.Fatalf("editor should not gain delete/manage permission: %#v", moved.Files[0].Permissions)
+	}
+
+	movedAgain, err := service.MoveAsset("editor", "tenant-1", "asset-1", MoveAssetReq{DocumentSpaceID: "space-a"})
+	if err != nil {
+		t.Fatalf("MoveAsset second move returned error: %v", err)
+	}
+	if movedAgain.Files[0].SpaceName != "产品部公共空间" {
+		t.Fatalf("expected file to move back, got %s", movedAgain.Files[0].SpaceName)
+	}
+
+	if _, err := service.RenameAsset("viewer", "tenant-1", "asset-1", RenameAssetReq{Name: "不可改.docx"}); err == nil {
+		t.Fatalf("expected viewer rename to be rejected")
+	}
+}
+
+func TestServiceSpaceLifecycleAndMembers(t *testing.T) {
+	repo := newMemoryRepository()
+	service := NewDocumentService(repo)
+
+	created, err := service.CreateSpace("owner", "tenant-1", SaveSpaceReq{Name: "交付知识库", Description: "交付材料"})
+	if err != nil {
+		t.Fatalf("CreateSpace returned error: %v", err)
+	}
+	if len(created.Spaces) != 1 || created.Spaces[0].Name != "交付知识库" {
+		t.Fatalf("expected created space, got %#v", created.Spaces)
+	}
+	if created.Spaces[0].MemberCount != 1 || created.Spaces[0].Members[0].Role != SpaceRoleOwner {
+		t.Fatalf("expected owner member, got %#v", created.Spaces[0].Members)
+	}
+
+	spaceID := created.Spaces[0].ID
+	updated, err := service.UpdateSpace("owner", "tenant-1", spaceID, SaveSpaceReq{Name: "交付资料库", Description: "项目交付资料"})
+	if err != nil {
+		t.Fatalf("UpdateSpace returned error: %v", err)
+	}
+	if updated.Spaces[0].Name != "交付资料库" || updated.Spaces[0].Description != "项目交付资料" {
+		t.Fatalf("expected updated space info, got %#v", updated.Spaces[0])
+	}
+
+	withMember, err := service.UpsertSpaceMember("owner", "tenant-1", spaceID, SaveSpaceMemberReq{UID: "u2", Name: "刘青", Role: SpaceRoleEditor})
+	if err != nil {
+		t.Fatalf("UpsertSpaceMember returned error: %v", err)
+	}
+	if withMember.Spaces[0].MemberCount != 2 {
+		t.Fatalf("expected two members, got %d", withMember.Spaces[0].MemberCount)
+	}
+
+	repo.members[1].Source = "验收预置"
+	roleUpdated, err := service.UpsertSpaceMember("owner", "tenant-1", spaceID, SaveSpaceMemberReq{UID: "u2", Name: "刘青", Role: SpaceRoleAdmin})
+	if err != nil {
+		t.Fatalf("UpsertSpaceMember role update returned error: %v", err)
+	}
+	var updatedMember *DocumentSpaceMemberResp
+	for _, member := range roleUpdated.Spaces[0].Members {
+		if member.UID == "u2" {
+			updatedMember = member
+			break
+		}
+	}
+	if updatedMember == nil {
+		t.Fatalf("expected updated member in state")
+	}
+	if updatedMember.Role != SpaceRoleAdmin {
+		t.Fatalf("expected updated role admin, got %s", updatedMember.Role)
+	}
+	if updatedMember.Source != "验收预置" {
+		t.Fatalf("expected role update to preserve source, got %s", updatedMember.Source)
+	}
+
+	withoutMember, err := service.RemoveSpaceMember("owner", "tenant-1", spaceID, "u2")
+	if err != nil {
+		t.Fatalf("RemoveSpaceMember returned error: %v", err)
+	}
+	if withoutMember.Spaces[0].MemberCount != 1 {
+		t.Fatalf("expected one member after removal, got %d", withoutMember.Spaces[0].MemberCount)
+	}
+
+	disabled, err := service.DisableSpace("owner", "tenant-1", spaceID)
+	if err != nil {
+		t.Fatalf("DisableSpace returned error: %v", err)
+	}
+	if len(disabled.Spaces) != 0 {
+		t.Fatalf("expected disabled space hidden from active state, got %#v", disabled.Spaces)
+	}
+}
+
+func TestServiceSearchSpaceMemberCandidates(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{{
+		SpaceID:       "space-product",
+		Name:          "产品部公共空间",
+		OwnerUID:      "owner",
+		TenantSpaceID: "tenant-1",
+		Status:        1,
+	}}
+	repo.members = []*DocumentSpaceMemberModel{{
+		MemberID:        "mem-owner",
+		DocumentSpaceID: "space-product",
+		UID:             "owner",
+		Name:            "空间所有者",
+		Role:            SpaceRoleOwner,
+		TenantSpaceID:   "tenant-1",
+		Status:          1,
+	}, {
+		MemberID:        "mem-qa",
+		DocumentSpaceID: "space-product",
+		UID:             "qa_wang01",
+		Name:            "王敏",
+		Role:            SpaceRoleEditor,
+		TenantSpaceID:   "tenant-1",
+		Status:          1,
+	}}
+	repo.users = []*DocumentUserCandidateModel{{
+		UID:      "qa_wang01",
+		Name:     "王敏",
+		Username: "qa_wang01",
+	}, {
+		UID:      "sales_wang01",
+		Name:     "王强",
+		Username: "sales_wang01",
+		Email:    "sales@example.com",
+	}, {
+		UID:      "legal_chen01",
+		Name:     "陈法务",
+		Username: "legal_chen01",
+	}}
+	service := NewDocumentService(repo)
+
+	candidates, err := service.SearchSpaceMemberCandidates("owner", "tenant-1", "space-product", "wang")
+	if err != nil {
+		t.Fatalf("SearchSpaceMemberCandidates returned error: %v", err)
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("expected two candidates, got %#v", candidates)
+	}
+	if !candidates[0].AlreadyMember {
+		t.Fatalf("expected existing member to be marked already member: %#v", candidates[0])
+	}
+	if candidates[1].AlreadyMember {
+		t.Fatalf("expected non-member candidate to be selectable: %#v", candidates[1])
+	}
+	if _, err := service.SearchSpaceMemberCandidates("qa_wang01", "tenant-1", "space-product", "wang"); err == nil {
+		t.Fatalf("expected non-admin member search to be rejected")
+	}
+}
+
+func TestServiceStateUsesStableEmptyArraysForSpaces(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{{
+		SpaceID:       "doc-space-1",
+		Name:          "产品部公共空间",
+		OwnerUID:      "owner",
+		TenantSpaceID: "tenant-1",
+		Status:        1,
+	}}
+	service := NewDocumentService(repo)
+
+	state, err := service.State("owner", "tenant-1")
+	if err != nil {
+		t.Fatalf("State returned error: %v", err)
+	}
+	if len(state.Spaces) != 1 {
+		t.Fatalf("expected one active space, got %d", len(state.Spaces))
+	}
+	if state.Spaces[0].Members == nil {
+		t.Fatalf("expected members to be an empty/stable array, got nil")
+	}
+	if state.Spaces[0].BoundConversations == nil {
+		t.Fatalf("expected bound conversations to be an empty/stable array, got nil")
+	}
+	if state.Spaces[0].PinnedFileIDs == nil {
+		t.Fatalf("expected pinned file ids to be an empty/stable array, got nil")
+	}
+}
+
+func TestServiceStateKeepsDisabledSpaceNameForHistoricalFiles(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{{
+		SpaceID:       "space-disabled",
+		Name:          "停用交付空间",
+		OwnerUID:      "owner",
+		TenantSpaceID: "tenant-1",
+		Status:        0,
+	}}
+	repo.assets = []*DocumentAssetModel{{
+		AssetID:         "asset-1",
+		Name:            "历史交付材料.pdf",
+		Kind:            KindPDF,
+		Extension:       ".pdf",
+		UploaderUID:     "owner",
+		OwnerUID:        "owner",
+		TenantSpaceID:   "tenant-1",
+		DocumentSpaceID: "space-disabled",
+		Visibility:      VisibilitySpace,
+		Status:          StatusArchived,
+		Previewable:     1,
+	}}
+	service := NewDocumentService(repo)
+
+	state, err := service.State("owner", "tenant-1")
+	if err != nil {
+		t.Fatalf("State returned error: %v", err)
+	}
+	if len(state.Spaces) != 1 {
+		t.Fatalf("expected EnsureDefaultSpace to create one active space, got %#v", state.Spaces)
+	}
+	if state.Spaces[0].Name == "停用交付空间" {
+		t.Fatalf("disabled space should not appear in active space list")
+	}
+	if len(state.Files) != 1 {
+		t.Fatalf("expected one historical file, got %d", len(state.Files))
+	}
+	if state.Files[0].SpaceName != "停用交付空间（已停用）" {
+		t.Fatalf("expected disabled space name to be preserved, got %s", state.Files[0].SpaceName)
+	}
+}
+
+func TestServicePermanentDeleteAndEmptyTrash(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.assets = []*DocumentAssetModel{{
+		AssetID:       "asset-1",
+		Name:          "待清理.docx",
+		UploaderUID:   "u1",
+		OwnerUID:      "u1",
+		TenantSpaceID: "tenant-1",
+		Status:        StatusDeleted,
+		Visibility:    VisibilitySpace,
+	}, {
+		AssetID:       "asset-2",
+		Name:          "待清理2.docx",
+		UploaderUID:   "u1",
+		OwnerUID:      "u1",
+		TenantSpaceID: "tenant-1",
+		Status:        StatusDeleted,
+		Visibility:    VisibilitySpace,
+	}}
+	service := NewDocumentService(repo)
+
+	afterDelete, err := service.PermanentDelete("u1", "tenant-1", "asset-1")
+	if err != nil {
+		t.Fatalf("PermanentDelete returned error: %v", err)
+	}
+	if len(afterDelete.Files) != 1 || afterDelete.Files[0].ID != "asset-2" {
+		t.Fatalf("expected only asset-2 to remain, got %#v", afterDelete.Files)
+	}
+
+	emptied, err := service.EmptyTrash("u1", "tenant-1")
+	if err != nil {
+		t.Fatalf("EmptyTrash returned error: %v", err)
+	}
+	if len(emptied.Files) != 0 {
+		t.Fatalf("expected empty state after empty trash, got %#v", emptied.Files)
+	}
+}
+
+func TestServiceEmptyTrashAuditDoesNotLeakToNonMember(t *testing.T) {
+	repo := newMemoryRepository()
+	repo.spaces = []*DocumentSpaceModel{{
+		SpaceID:       "private-space",
+		Name:          "私有空间",
+		OwnerUID:      "owner",
+		TenantSpaceID: "tenant-1",
+		Status:        1,
+	}}
+	repo.assets = []*DocumentAssetModel{{
+		AssetID:         "asset-private-trash",
+		Name:            "private-trash.pdf",
+		UploaderUID:     "owner",
+		OwnerUID:        "owner",
+		TenantSpaceID:   "tenant-1",
+		DocumentSpaceID: "private-space",
+		Status:          StatusDeleted,
+		Visibility:      VisibilitySpace,
+	}}
+	service := NewDocumentService(repo)
+
+	if _, err := service.EmptyTrash("owner", "tenant-1"); err != nil {
+		t.Fatalf("EmptyTrash returned error: %v", err)
+	}
+	state, err := service.State("outsider", "tenant-1")
+	if err != nil {
+		t.Fatalf("State returned error: %v", err)
+	}
+	for _, audit := range state.Audits {
+		if audit.Target == "trash" {
+			t.Fatalf("expected trash audit to stay hidden from non-member, got %#v", state.Audits)
+		}
+	}
+}

--- a/modules/document/sql/20260617000001_document.sql
+++ b/modules/document/sql/20260617000001_document.sql
@@ -1,0 +1,67 @@
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS document_space (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    space_id VARCHAR(64) NOT NULL,
+    name VARCHAR(128) NOT NULL,
+    description VARCHAR(255) NOT NULL DEFAULT '',
+    owner_uid VARCHAR(64) NOT NULL,
+    tenant_space_id VARCHAR(64) NOT NULL DEFAULT '',
+    status TINYINT NOT NULL DEFAULT 1,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_document_space_id (space_id),
+    KEY idx_document_space_tenant (tenant_space_id, status)
+);
+
+CREATE TABLE IF NOT EXISTS document_asset (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    asset_id VARCHAR(64) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    kind VARCHAR(32) NOT NULL DEFAULT 'doc',
+    extension VARCHAR(32) NOT NULL DEFAULT '',
+    size BIGINT NOT NULL DEFAULT 0,
+    storage_path TEXT,
+    source_type VARCHAR(32) NOT NULL DEFAULT '',
+    source_channel_id VARCHAR(128) NOT NULL DEFAULT '',
+    source_channel_type TINYINT NOT NULL DEFAULT 0,
+    source_message_id VARCHAR(64) NOT NULL DEFAULT '',
+    source_name VARCHAR(255) NOT NULL DEFAULT '',
+    uploader_uid VARCHAR(64) NOT NULL DEFAULT '',
+    uploader_name VARCHAR(128) NOT NULL DEFAULT '',
+    owner_uid VARCHAR(64) NOT NULL DEFAULT '',
+    owner_name VARCHAR(128) NOT NULL DEFAULT '',
+    tenant_space_id VARCHAR(64) NOT NULL DEFAULT '',
+    document_space_id VARCHAR(64) NOT NULL DEFAULT '',
+    original_space_id VARCHAR(64) NOT NULL DEFAULT '',
+    visibility VARCHAR(32) NOT NULL DEFAULT 'space',
+    status VARCHAR(32) NOT NULL DEFAULT 'archived',
+    downloads INT NOT NULL DEFAULT 0,
+    previewable TINYINT NOT NULL DEFAULT 1,
+    last_access_at DATETIME NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_document_asset_id (tenant_space_id, asset_id),
+    KEY idx_document_asset_tenant_status (tenant_space_id, status, updated_at),
+    KEY idx_document_asset_space (tenant_space_id, document_space_id, status),
+    KEY idx_document_asset_source (source_channel_id, source_channel_type, source_message_id)
+);
+
+CREATE TABLE IF NOT EXISTS document_asset_event (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    event_id VARCHAR(64) NOT NULL,
+    asset_id VARCHAR(64) NOT NULL,
+    actor_uid VARCHAR(64) NOT NULL,
+    action VARCHAR(32) NOT NULL,
+    detail VARCHAR(255) NOT NULL DEFAULT '',
+    tenant_space_id VARCHAR(64) NOT NULL DEFAULT '',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_document_event_id (event_id),
+    KEY idx_document_event_asset (asset_id, created_at),
+    KEY idx_document_event_tenant (tenant_space_id, created_at)
+);
+
+-- +migrate Down
+DROP TABLE IF EXISTS document_asset_event;
+DROP TABLE IF EXISTS document_asset;
+DROP TABLE IF EXISTS document_space;

--- a/modules/document/sql/20260617000002_document_space_binding.sql
+++ b/modules/document/sql/20260617000002_document_space_binding.sql
@@ -1,0 +1,21 @@
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS document_space_binding (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    binding_id VARCHAR(64) NOT NULL,
+    document_space_id VARCHAR(64) NOT NULL,
+    source_channel_id VARCHAR(128) NOT NULL,
+    source_channel_type TINYINT NOT NULL DEFAULT 0,
+    source_name VARCHAR(255) NOT NULL DEFAULT '',
+    created_by VARCHAR(64) NOT NULL DEFAULT '',
+    tenant_space_id VARCHAR(64) NOT NULL DEFAULT '',
+    status TINYINT NOT NULL DEFAULT 1,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_document_space_binding_id (binding_id),
+    UNIQUE KEY uk_document_space_binding_source (tenant_space_id, document_space_id, source_channel_id, source_channel_type),
+    KEY idx_document_space_binding_tenant (tenant_space_id, status),
+    KEY idx_document_space_binding_space (tenant_space_id, document_space_id, status)
+);
+
+-- +migrate Down
+DROP TABLE IF EXISTS document_space_binding;

--- a/modules/document/sql/20260617000003_document_space_member.sql
+++ b/modules/document/sql/20260617000003_document_space_member.sql
@@ -1,0 +1,22 @@
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS document_space_member (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    member_id VARCHAR(64) NOT NULL,
+    document_space_id VARCHAR(64) NOT NULL,
+    uid VARCHAR(64) NOT NULL,
+    name VARCHAR(128) NOT NULL DEFAULT '',
+    role VARCHAR(32) NOT NULL DEFAULT 'viewer',
+    source VARCHAR(32) NOT NULL DEFAULT '手动添加',
+    created_by VARCHAR(64) NOT NULL DEFAULT '',
+    tenant_space_id VARCHAR(64) NOT NULL DEFAULT '',
+    status TINYINT NOT NULL DEFAULT 1,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_document_space_member_id (member_id),
+    UNIQUE KEY uk_document_space_member_uid (tenant_space_id, document_space_id, uid),
+    KEY idx_document_space_member_space (tenant_space_id, document_space_id, status),
+    KEY idx_document_space_member_uid_lookup (tenant_space_id, uid, status)
+);
+
+-- +migrate Down
+DROP TABLE IF EXISTS document_space_member;

--- a/modules/document/swagger/api.yaml
+++ b/modules/document/swagger/api.yaml
@@ -1,0 +1,83 @@
+openapi: 3.0.0
+info:
+  title: Octo Document Center API
+  version: 1.0.0
+paths:
+  /v1/documents/state:
+    get:
+      summary: Get document center state
+      responses:
+        "200":
+          description: Document state
+  /v1/documents/upload:
+    post:
+      summary: Create a document asset for an uploaded file
+      responses:
+        "200":
+          description: Updated document state
+  /v1/documents/archive:
+    post:
+      summary: Archive a conversation file into a document space
+      responses:
+        "200":
+          description: Updated document state
+  /v1/documents/spaces/{space_id}/bind-conversation:
+    post:
+      summary: Bind a source conversation to a document space
+      parameters:
+        - name: space_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Updated document state
+  /v1/documents/{asset_id}/preview:
+    post:
+      summary: Mark a document asset as previewed
+      parameters:
+        - name: asset_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Updated document state
+  /v1/documents/{asset_id}/download:
+    post:
+      summary: Mark a document asset as downloaded
+      parameters:
+        - name: asset_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Updated document state
+  /v1/documents/{asset_id}/trash:
+    post:
+      summary: Move a document asset to trash
+      parameters:
+        - name: asset_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Updated document state
+  /v1/documents/{asset_id}/restore:
+    post:
+      summary: Restore a document asset
+      parameters:
+        - name: asset_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Updated document state

--- a/modules/file/api.go
+++ b/modules/file/api.go
@@ -28,6 +28,9 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
 	"github.com/Mininglamp-OSS/octo-server/pkg/metrics"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	"github.com/Mininglamp-OSS/octo-server/pkg/stickersig"
@@ -73,6 +76,8 @@ func New(ctx *config.Context) *File {
 
 // Route 路由
 func (f *File) Route(r *wkhttp.WKHttp) {
+	r.Any("/v1/file/local", f.handleLocalSignedFile)
+
 	auth := r.Group("/v1/file", f.ctx.AuthMiddleware(r))
 	stickerUploadHandlers := f.stickerUploadHandlers(r)
 	{
@@ -119,6 +124,235 @@ func stickerOnlyLimiter(limiter wkhttp.HandlerFunc) wkhttp.HandlerFunc {
 		}
 		limiter(c)
 	}
+}
+
+func (f *File) handleLocalSignedFile(c *wkhttp.Context) {
+	writeLocalFileCORSHeaders(c)
+	if c.Request.Method == http.MethodOptions {
+		c.Status(http.StatusNoContent)
+		return
+	}
+	switch c.Request.Method {
+	case http.MethodGet:
+		f.serveLocalSignedFile(c, true)
+	case http.MethodHead:
+		f.serveLocalSignedFile(c, false)
+	case http.MethodPut:
+		f.putLocalSignedFile(c)
+	default:
+		f.respondLocalFileError(c, errcode.ErrFileMethodNotAllowed, errors.New("method not allowed"))
+	}
+}
+
+func writeLocalFileCORSHeaders(c *wkhttp.Context) {
+	c.Header("Access-Control-Allow-Methods", "GET, HEAD, PUT, OPTIONS")
+	c.Header("Access-Control-Allow-Headers", "Content-Type, Content-Length, Content-Disposition, Range")
+	c.Header("Access-Control-Expose-Headers", "Content-Length, Content-Type, Content-Disposition, Accept-Ranges")
+}
+
+func (f *File) serveLocalSignedFile(c *wkhttp.Context, includeBody bool) {
+	req, err := localSignedRequestFromQuery(c, http.MethodGet)
+	if err != nil {
+		f.respondLocalFileError(c, errcode.ErrFileForbidden, err)
+		return
+	}
+	if err := verifyLocalFileRequest(req, c.Query("sig"), time.Now()); err != nil {
+		f.respondLocalFileError(c, errcode.ErrFileForbidden, err)
+		return
+	}
+
+	reader, contentType, err := f.service.GetFile(req.Path)
+	if err != nil {
+		f.respondLocalFileError(c, errcode.ErrFileNotFound, err)
+		return
+	}
+	defer reader.Close()
+
+	filename := req.Filename
+	if filename == "" {
+		filename = filepath.Base(req.Path)
+	}
+	filename = sanitizeFilename(filename)
+	disposition := req.Disposition
+	if disposition != "inline" {
+		disposition = "attachment"
+	}
+	if disposition == "inline" && !localFileInlineAllowed(contentType) {
+		disposition = "attachment"
+		contentType = "application/octet-stream"
+	}
+
+	c.Header("Content-Type", contentType)
+	c.Header("X-Content-Type-Options", "nosniff")
+	escapedFilename := url.PathEscape(filename)
+	c.Header("Content-Disposition", fmt.Sprintf("%s; filename*=UTF-8''%s", disposition, escapedFilename))
+	c.Status(http.StatusOK)
+	if includeBody {
+		_, _ = io.Copy(c.Writer, reader)
+	}
+}
+
+func (f *File) putLocalSignedFile(c *wkhttp.Context) {
+	req, err := localSignedRequestFromQuery(c, http.MethodPut)
+	if err != nil {
+		f.respondLocalFileError(c, errcode.ErrFileForbidden, err)
+		return
+	}
+	if err := verifyLocalFileRequest(req, c.Query("sig"), time.Now()); err != nil {
+		f.respondLocalFileError(c, errcode.ErrFileForbidden, err)
+		return
+	}
+	localBackend := f.localFileBackend()
+	if localBackend == nil {
+		f.respondLocalFileError(c, errcode.ErrFileForbidden, errors.New("本地文件服务未启用"))
+		return
+	}
+	releaseNonce, err := localBackend.reserveUploadNonce(req)
+	if err != nil {
+		f.respondLocalFileError(c, errcode.ErrFileRequestInvalid, err)
+		return
+	}
+	uploadSucceeded := false
+	defer func() {
+		releaseNonce(uploadSucceeded)
+	}()
+	if req.FileSize <= 0 || req.FileSize > MaxFileSize {
+		f.respondLocalFileError(c, errcode.ErrFilePayloadTooLarge, fmt.Errorf("文件大小不能超过%dMB", MaxFileSize/1024/1024))
+		return
+	}
+	if c.Request.ContentLength >= 0 && c.Request.ContentLength != req.FileSize {
+		f.respondLocalFileError(c, errcode.ErrFileRequestInvalid, errors.New("上传内容长度与签名不一致"))
+		return
+	}
+	ext := strings.ToLower(filepath.Ext(req.Path))
+	if ext == "" || IsBlockedExtension(ext) || !IsAllowedExtension(ext) {
+		f.respondLocalFileError(c, errcode.ErrFileRequestInvalid, errors.New("不支持的文件类型"))
+		return
+	}
+	if existing, _, err := f.service.GetFile(req.Path); err == nil {
+		_ = existing.Close()
+		f.respondLocalFileError(c, errcode.ErrFileRequestInvalid, errors.New("签名上传路径已存在"))
+		return
+	}
+	body := http.MaxBytesReader(c.Writer, c.Request.Body, req.FileSize+1)
+
+	contentType := req.ContentType
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	_, err = f.service.UploadFile(req.Path, contentType, req.ContentDisposition, func(w io.Writer) error {
+		written, copyErr := io.Copy(w, body)
+		if copyErr != nil {
+			return copyErr
+		}
+		if written != req.FileSize {
+			return errors.New("上传内容长度与签名不一致")
+		}
+		return nil
+	})
+	if err != nil {
+		f.respondLocalFileError(c, errcode.ErrFileStoreFailed, err)
+		return
+	}
+	uploadSucceeded = true
+	c.Response(map[string]string{
+		"path": req.Path,
+	})
+}
+
+func (f *File) localFileBackend() *LocalFileService {
+	service, ok := f.service.(*Service)
+	if !ok {
+		return nil
+	}
+	localBackend, ok := service.uploadService.(*LocalFileService)
+	if !ok {
+		return nil
+	}
+	return localBackend
+}
+
+func localFileInlineAllowed(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		mediaType = contentType
+	}
+	switch strings.ToLower(mediaType) {
+	case "application/pdf",
+		"image/gif",
+		"image/jpeg",
+		"image/png",
+		"image/webp",
+		"text/plain":
+		return true
+	default:
+		return false
+	}
+}
+
+func (f *File) respondLocalFileError(c *wkhttp.Context, code codes.Code, err error) {
+	if code.Internal {
+		f.Error("本地签名文件请求失败", zap.String("code", code.ID), zap.Error(err))
+	} else {
+		f.Warn("本地签名文件请求失败", zap.String("code", code.ID), zap.Error(err))
+	}
+	httperr.ResponseErrorLWithStatus(c, code, nil, nil)
+}
+
+func localSignedRequestFromQuery(c *wkhttp.Context, method string) (localFileSignedRequest, error) {
+	if c.Query("method") != method {
+		return localFileSignedRequest{}, errors.New("文件链接方法无效")
+	}
+	path := c.Query("path")
+	if strings.TrimSpace(path) == "" {
+		return localFileSignedRequest{}, errors.New("path参数不能为空")
+	}
+	sanitized, err := sanitizePath(path)
+	if err != nil {
+		return localFileSignedRequest{}, errors.New("无效的文件路径")
+	}
+	sanitized = strings.TrimPrefix(filepath.ToSlash(sanitized), "/")
+	if sanitized == "" || sanitized == "." {
+		return localFileSignedRequest{}, errors.New("path参数不能为空")
+	}
+	expiresAt, err := strconv.ParseInt(c.Query("expires"), 10, 64)
+	if err != nil || expiresAt <= 0 {
+		return localFileSignedRequest{}, errors.New("文件链接过期时间无效")
+	}
+	fileSize := int64(0)
+	if raw := strings.TrimSpace(c.Query("fileSize")); raw != "" {
+		fileSize, err = strconv.ParseInt(raw, 10, 64)
+		if err != nil || fileSize <= 0 {
+			return localFileSignedRequest{}, errors.New("文件大小参数无效")
+		}
+	}
+	disposition := c.Query("disposition")
+	if disposition != "" && disposition != "inline" && disposition != "attachment" {
+		return localFileSignedRequest{}, errors.New("文件展示方式无效")
+	}
+	contentDisposition := c.Query("contentDisposition")
+	if encoded := strings.TrimSpace(c.Query("contentDispositionB64")); encoded != "" {
+		decoded, decodeErr := base64.RawURLEncoding.DecodeString(encoded)
+		if decodeErr != nil {
+			return localFileSignedRequest{}, errors.New("文件下载名称参数无效")
+		}
+		contentDisposition = string(decoded)
+	}
+	filename := c.Query("filename")
+	if filename != "" {
+		filename = sanitizeFilename(filename)
+	}
+	return localFileSignedRequest{
+		Method:             method,
+		Path:               sanitized,
+		Filename:           filename,
+		Disposition:        disposition,
+		ContentType:        c.Query("contentType"),
+		ContentDisposition: contentDisposition,
+		FileSize:           fileSize,
+		ExpiresAt:          expiresAt,
+		Nonce:              c.Query("nonce"),
+	}, nil
 }
 
 func (f *File) makeImageCompose(c *wkhttp.Context) {
@@ -856,15 +1090,10 @@ func (f *File) getUploadCredentials(c *wkhttp.Context) {
 		return
 	}
 
-	if ext != "" {
-		inferred := mime.TypeByExtension(ext)
-		if inferred != "" {
-			contentType = inferred
-		}
-	}
 	if contentType == "" {
 		contentType = "application/octet-stream"
 	}
+	contentType = inferContentType(contentType, ext)
 
 	// When both path and filename are provided, path determines the objectKey
 	// while filename is used for Content-Disposition (friendly download name).

--- a/modules/file/api_unit_test.go
+++ b/modules/file/api_unit_test.go
@@ -204,6 +204,7 @@ type mockService struct {
 	composeErr         error
 	lastObjectPath     string
 	lastGetObjectPath  string
+	lastContentType    string
 	lastContentDisp    string
 	lastFileSize       int64
 	presignedGetErr    error
@@ -240,6 +241,7 @@ func (m *mockService) GetFile(path string) (io.ReadCloser, string, error) {
 
 func (m *mockService) PresignedPutURL(objectPath string, contentType string, contentDisposition string, fileSize int64, expires time.Duration) (string, string, error) {
 	m.lastObjectPath = objectPath
+	m.lastContentType = contentType
 	m.lastContentDisp = contentDisposition
 	m.lastFileSize = fileSize
 	return "https://example.com/upload?" + objectPath, "https://example.com/download/" + objectPath, nil
@@ -562,36 +564,32 @@ func TestGetUploadCredentials_FallbackWithoutFilename(t *testing.T) {
 	assert.Equal(t, "", mockSvc.lastContentDisp)
 }
 
-func TestStickerOnlyLimiterScopesToStickerUploads(t *testing.T) {
+func TestGetUploadCredentials_ResponseContentTypeMatchesSignedContentType(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	var hits int
-	limiter := func(c *wkhttp.Context) {
-		hits++
-		c.Header("X-Test-Limiter", "hit")
-		c.Next()
+	mockSvc := &mockService{}
+	f := &File{
+		Log:     log.NewTLog("FileTest"),
+		service: mockSvc,
 	}
-	terminal := func(c *wkhttp.Context) {
-		c.Response(map[string]bool{"ok": true})
-	}
-	r := wkhttp.New()
-	r.POST("/v1/file/upload", stickerOnlyLimiter(limiter), terminal)
 
-	nonSticker := httptest.NewRecorder()
-	req, err := http.NewRequest(http.MethodPost, "/v1/file/upload?type=chat", nil)
-	require.NoError(t, err)
-	r.ServeHTTP(nonSticker, req)
-	require.Equal(t, http.StatusOK, nonSticker.Code)
-	assert.Equal(t, 0, hits)
-	assert.Empty(t, nonSticker.Header().Get("X-Test-Limiter"))
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	q := url.Values{}
+	q.Set("type", "chat")
+	q.Set("path", "/2/grp_product_docs/test.md")
+	q.Set("filename", "test.md")
+	q.Set("contentType", "text/markdown")
+	q.Set("fileSize", "16")
+	c.Request, _ = http.NewRequest(http.MethodGet, "/v1/file/upload/credentials?"+q.Encode(), nil)
+	wkCtx := &wkhttp.Context{Context: c}
+	f.getUploadCredentials(wkCtx)
 
-	sticker := httptest.NewRecorder()
-	req, err = http.NewRequest(http.MethodPost, "/v1/file/upload?type=sticker", nil)
-	require.NoError(t, err)
-	r.ServeHTTP(sticker, req)
-	require.Equal(t, http.StatusOK, sticker.Code)
-	assert.Equal(t, 1, hits)
-	assert.Equal(t, "hit", sticker.Header().Get("X-Test-Limiter"))
+	require.Equal(t, http.StatusOK, w.Code, "response body: %s", w.Body.String())
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, mockSvc.lastContentType, resp["contentType"])
+	require.Equal(t, "text/markdown; charset=utf-8", resp["contentType"])
 }
 
 func TestBuildContentDisposition_UsesInline(t *testing.T) {

--- a/modules/file/const.go
+++ b/modules/file/const.go
@@ -18,6 +18,11 @@ import (
 // (api.go).
 const fileServiceAwsS3 = "awsS3"
 
+// fileServiceLocal stores files on the octo-server filesystem and serves them
+// through short-lived signed URLs. It is intended for single-node deployments
+// and local verification where MinIO/OSS/COS/S3 is not available.
+const fileServiceLocal = "local"
+
 // fileMagicNumbers 文件魔数签名映射表
 // 用于验证文件内容是否与扩展名声称的类型一致
 var fileMagicNumbers = map[string][][]byte{

--- a/modules/file/service.go
+++ b/modules/file/service.go
@@ -83,6 +83,9 @@ func NewService(ctx *config.Context) IService {
 		// switch over together.
 		uploadService = NewServiceS3(ctx)
 		backend = "s3"
+	} else if service == config.FileService(fileServiceLocal) {
+		uploadService = NewLocalFileService(ctx)
+		backend = "local"
 	} else {
 		uploadService = NewSeaweedFS(ctx)
 		backend = "seaweedfs"

--- a/modules/file/service_local.go
+++ b/modules/file/service_local.go
@@ -1,0 +1,378 @@
+package file
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"go.uber.org/zap"
+)
+
+type LocalFileService struct {
+	log.Log
+	ctx *config.Context
+}
+
+type localFileMetadata struct {
+	ContentType        string    `json:"contentType"`
+	ContentDisposition string    `json:"contentDisposition,omitempty"`
+	UpdatedAt          time.Time `json:"updatedAt"`
+}
+
+func NewLocalFileService(ctx *config.Context) *LocalFileService {
+	return &LocalFileService{
+		Log: log.NewTLog("LocalFileService"),
+		ctx: ctx,
+	}
+}
+
+func (s *LocalFileService) UploadFile(filePath string, contentType string, contentDisposition string, copyFileWriter func(io.Writer) error) (map[string]interface{}, error) {
+	objectPath, diskPath, err := s.diskPath(filePath)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(diskPath), 0o755); err != nil {
+		return nil, err
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(diskPath), ".upload-*")
+	if err != nil {
+		return nil, err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if err := copyFileWriter(tmp); err != nil {
+		_ = tmp.Close()
+		return nil, err
+	}
+	if err := tmp.Close(); err != nil {
+		return nil, err
+	}
+	if err := os.Rename(tmpName, diskPath); err != nil {
+		return nil, err
+	}
+	if err := s.writeMetadata(objectPath, localFileMetadata{
+		ContentType:        ensureTextCharset(contentType),
+		ContentDisposition: contentDisposition,
+		UpdatedAt:          time.Now(),
+	}); err != nil {
+		s.Warn("写入本地文件元数据失败", zap.String("path", objectPath), zap.Error(err))
+	}
+	return map[string]interface{}{
+		"path": objectPath,
+	}, nil
+}
+
+func (s *LocalFileService) DownloadURL(path string, filename string) (string, error) {
+	disposition := "inline"
+	if strings.TrimSpace(filename) != "" {
+		disposition = "attachment"
+	}
+	return s.PresignedGetURL(path, filename, disposition, 24*time.Hour)
+}
+
+func (s *LocalFileService) GetFile(path string) (io.ReadCloser, string, error) {
+	objectPath, diskPath, err := s.diskPath(path)
+	if err != nil {
+		return nil, "", err
+	}
+	file, err := os.Open(diskPath)
+	if err != nil {
+		return nil, "", err
+	}
+	contentType := s.contentType(objectPath)
+	return file, contentType, nil
+}
+
+func (s *LocalFileService) PresignedPutURL(objectPath string, contentType string, contentDisposition string, fileSize int64, expires time.Duration) (string, string, error) {
+	if fileSize <= 0 {
+		return "", "", fmt.Errorf("预签名上传必须提供正向的 fileSize（字节数）")
+	}
+	if fileSize > MaxFileSize {
+		return "", "", fmt.Errorf("文件大小不能超过%dMB", MaxFileSize/1024/1024)
+	}
+	normalized, _, err := s.diskPath(objectPath)
+	if err != nil {
+		return "", "", err
+	}
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	contentType = ensureTextCharset(contentType)
+	expiresAt := localFileExpiresAt(expires)
+	nonce, err := newLocalFileNonce()
+	if err != nil {
+		return "", "", err
+	}
+	uploadURL, err := s.signedURL(localFileSignedRequest{
+		Method:             "PUT",
+		Path:               normalized,
+		ContentType:        contentType,
+		ContentDisposition: contentDisposition,
+		FileSize:           fileSize,
+		ExpiresAt:          expiresAt,
+		Nonce:              nonce,
+	})
+	if err != nil {
+		return "", "", err
+	}
+	downloadURL, err := s.PresignedGetURL(normalized, filepath.Base(normalized), "inline", expires)
+	if err != nil {
+		return "", "", err
+	}
+	return uploadURL, downloadURL, nil
+}
+
+func (s *LocalFileService) PresignedGetURL(objectPath string, filename string, disposition string, expires time.Duration) (string, error) {
+	normalized, _, err := s.diskPath(objectPath)
+	if err != nil {
+		return "", err
+	}
+	if disposition != "inline" {
+		disposition = "attachment"
+	}
+	return s.signedURL(localFileSignedRequest{
+		Method:      "GET",
+		Path:        normalized,
+		Filename:    sanitizeFilename(filename),
+		Disposition: disposition,
+		ExpiresAt:   localFileExpiresAt(expires),
+	})
+}
+
+func (s *LocalFileService) signedURL(req localFileSignedRequest) (string, error) {
+	base := strings.TrimRight(s.ctx.GetConfig().External.APIBaseURL, "/")
+	if base == "" {
+		base = "/v1"
+	}
+	u, err := url.Parse(base + "/file/local")
+	if err != nil {
+		return "", err
+	}
+	values := url.Values{}
+	values.Set("method", req.Method)
+	values.Set("path", req.Path)
+	values.Set("expires", strconv.FormatInt(req.ExpiresAt, 10))
+	if req.Filename != "" {
+		values.Set("filename", req.Filename)
+	}
+	if req.Disposition != "" {
+		values.Set("disposition", req.Disposition)
+	}
+	if req.ContentType != "" {
+		values.Set("contentType", req.ContentType)
+	}
+	if req.ContentDisposition != "" {
+		values.Set("contentDispositionB64", base64.RawURLEncoding.EncodeToString([]byte(req.ContentDisposition)))
+	}
+	if req.FileSize > 0 {
+		values.Set("fileSize", strconv.FormatInt(req.FileSize, 10))
+	}
+	if req.Nonce != "" {
+		values.Set("nonce", req.Nonce)
+	}
+	signature, err := signLocalFileRequest(req)
+	if err != nil {
+		return "", err
+	}
+	values.Set("sig", signature)
+	u.RawQuery = values.Encode()
+	return u.String(), nil
+}
+
+func (s *LocalFileService) diskPath(objectPath string) (string, string, error) {
+	sanitized, err := sanitizePath(objectPath)
+	if err != nil {
+		return "", "", err
+	}
+	normalized := strings.TrimPrefix(filepath.ToSlash(sanitized), "/")
+	if normalized == "" || normalized == "." {
+		return "", "", fmt.Errorf("文件路径不能为空")
+	}
+	if strings.HasPrefix(normalized, "../") || strings.Contains(normalized, "/../") {
+		return "", "", fmt.Errorf("文件路径不允许包含目录遍历字符")
+	}
+	root := s.rootDir()
+	diskPath := filepath.Join(root, filepath.FromSlash(normalized))
+	cleanRoot := filepath.Clean(root)
+	cleanDiskPath := filepath.Clean(diskPath)
+	if cleanDiskPath != cleanRoot && !strings.HasPrefix(cleanDiskPath, cleanRoot+string(os.PathSeparator)) {
+		return "", "", fmt.Errorf("文件路径越界")
+	}
+	return normalized, cleanDiskPath, nil
+}
+
+func (s *LocalFileService) rootDir() string {
+	root := strings.TrimSpace(s.ctx.GetConfig().RootDir)
+	if root == "" {
+		root = "tsdddata"
+	}
+	return filepath.Join(root, "files")
+}
+
+func (s *LocalFileService) metadataPath(objectPath string) string {
+	return filepath.Join(s.rootDir(), ".metadata", filepath.FromSlash(objectPath)+".json")
+}
+
+func (s *LocalFileService) writeMetadata(objectPath string, meta localFileMetadata) error {
+	path := s.metadataPath(objectPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	body, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, body, 0o644)
+}
+
+func (s *LocalFileService) uploadNoncePath(req localFileSignedRequest) string {
+	sum := sha256.Sum256([]byte(req.Path + "\n" + req.Nonce))
+	return filepath.Join(s.rootDir(), ".upload-nonce", hex.EncodeToString(sum[:])+".used")
+}
+
+func (s *LocalFileService) reserveUploadNonce(req localFileSignedRequest) (func(success bool), error) {
+	if req.Method != "PUT" || strings.TrimSpace(req.Nonce) == "" {
+		return nil, fmt.Errorf("签名上传 nonce 缺失")
+	}
+	path := s.uploadNoncePath(req)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		if os.IsExist(err) {
+			return nil, fmt.Errorf("签名上传链接已使用")
+		}
+		return nil, err
+	}
+	_, writeErr := fmt.Fprintf(file, "%s\n", time.Now().UTC().Format(time.RFC3339Nano))
+	closeErr := file.Close()
+	if writeErr != nil {
+		_ = os.Remove(path)
+		return nil, writeErr
+	}
+	if closeErr != nil {
+		_ = os.Remove(path)
+		return nil, closeErr
+	}
+	return func(success bool) {
+		if !success {
+			_ = os.Remove(path)
+		}
+	}, nil
+}
+
+func (s *LocalFileService) contentType(objectPath string) string {
+	body, err := os.ReadFile(s.metadataPath(objectPath))
+	if err == nil {
+		var meta localFileMetadata
+		if json.Unmarshal(body, &meta) == nil && meta.ContentType != "" {
+			return ensureTextCharset(meta.ContentType)
+		}
+	}
+	ext := strings.ToLower(filepath.Ext(objectPath))
+	if detected := mime.TypeByExtension(ext); detected != "" {
+		return ensureTextCharset(detected)
+	}
+	if fallback, ok := textExtFallback[ext]; ok {
+		return ensureTextCharset(fallback)
+	}
+	return "application/octet-stream"
+}
+
+type localFileSignedRequest struct {
+	Method             string
+	Path               string
+	Filename           string
+	Disposition        string
+	ContentType        string
+	ContentDisposition string
+	FileSize           int64
+	ExpiresAt          int64
+	Nonce              string
+}
+
+func localFileExpiresAt(expires time.Duration) int64 {
+	if expires <= 0 {
+		expires = 30 * time.Minute
+	}
+	return time.Now().Add(expires).Unix()
+}
+
+func signLocalFileRequest(req localFileSignedRequest) (string, error) {
+	key, err := localFileSigningKey()
+	if err != nil {
+		return "", err
+	}
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write([]byte(localFileCanonicalString(req)))
+	return hex.EncodeToString(mac.Sum(nil)), nil
+}
+
+func verifyLocalFileRequest(req localFileSignedRequest, signature string, now time.Time) error {
+	if req.ExpiresAt <= 0 || now.Unix() > req.ExpiresAt {
+		return fmt.Errorf("文件链接已过期")
+	}
+	if req.Method == "PUT" && strings.TrimSpace(req.Nonce) == "" {
+		return fmt.Errorf("签名上传 nonce 缺失")
+	}
+	if strings.TrimSpace(signature) == "" {
+		return fmt.Errorf("文件链接签名不能为空")
+	}
+	expected, err := signLocalFileRequest(req)
+	if err != nil {
+		return err
+	}
+	if !hmac.Equal([]byte(expected), []byte(signature)) {
+		return fmt.Errorf("文件链接签名无效")
+	}
+	return nil
+}
+
+func localFileCanonicalString(req localFileSignedRequest) string {
+	return strings.Join([]string{
+		req.Method,
+		req.Path,
+		req.Filename,
+		req.Disposition,
+		req.ContentType,
+		req.ContentDisposition,
+		strconv.FormatInt(req.FileSize, 10),
+		strconv.FormatInt(req.ExpiresAt, 10),
+		req.Nonce,
+	}, "\n")
+}
+
+func newLocalFileNonce() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b[:]), nil
+}
+
+func localFileSigningKey() ([]byte, error) {
+	master := os.Getenv("OCTO_MASTER_KEY")
+	if len(master) != 32 {
+		return nil, fmt.Errorf("OCTO_MASTER_KEY must be exactly 32 bytes for local file signing")
+	}
+	mac := hmac.New(sha256.New, []byte(master))
+	_, _ = mac.Write([]byte("octo/local-file/v1"))
+	return mac.Sum(nil), nil
+}

--- a/modules/file/service_local_test.go
+++ b/modules/file/service_local_test.go
@@ -1,0 +1,302 @@
+package file
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/stretchr/testify/require"
+)
+
+func newLocalFileTestContext(t *testing.T) *config.Context {
+	t.Helper()
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	cfg := config.New()
+	cfg.RootDir = t.TempDir()
+	cfg.FileService = config.FileService(fileServiceLocal)
+	cfg.External.APIBaseURL = "http://octo.local/v1"
+	return config.NewContext(cfg)
+}
+
+func TestLocalFileSigningKeyUsesOctoMasterKey(t *testing.T) {
+	req := localFileSignedRequest{
+		Method:    "GET",
+		Path:      "common/documents/readme.txt",
+		ExpiresAt: time.Now().Add(time.Minute).Unix(),
+	}
+
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	sig, err := signLocalFileRequest(req)
+	require.NoError(t, err)
+	require.NoError(t, verifyLocalFileRequest(req, sig, time.Now()))
+
+	t.Setenv("OCTO_MASTER_KEY", "abcdef0123456789abcdef0123456789")
+	require.Error(t, verifyLocalFileRequest(req, sig, time.Now()))
+
+	t.Setenv("OCTO_MASTER_KEY", "short")
+	_, err = signLocalFileRequest(req)
+	require.Error(t, err)
+}
+
+func TestLocalFileService_UploadReadAndSignDownload(t *testing.T) {
+	ctx := newLocalFileTestContext(t)
+	svc := NewLocalFileService(ctx)
+
+	_, err := svc.UploadFile("common/documents/readme.txt", "text/plain; charset=utf-8", "", func(w io.Writer) error {
+		_, copyErr := io.Copy(w, strings.NewReader("hello local file"))
+		return copyErr
+	})
+	require.NoError(t, err)
+
+	rc, contentType, err := svc.GetFile("common/documents/readme.txt")
+	require.NoError(t, err)
+	defer rc.Close()
+
+	body, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Equal(t, "hello local file", string(body))
+	require.Equal(t, "text/plain; charset=utf-8", contentType)
+
+	signed, err := svc.PresignedGetURL("common/documents/readme.txt", "需求文档.txt", "inline", 30*time.Minute)
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(signed)
+	require.NoError(t, err)
+	require.Equal(t, "http", parsed.Scheme)
+	require.Equal(t, "octo.local", parsed.Host)
+	require.Equal(t, "/v1/file/local", parsed.Path)
+	require.Equal(t, "common/documents/readme.txt", parsed.Query().Get("path"))
+	require.Equal(t, "inline", parsed.Query().Get("disposition"))
+	require.NotEmpty(t, parsed.Query().Get("sig"))
+}
+
+func TestFile_LocalSignedRouteServesContentAndRejectsTampering(t *testing.T) {
+	ctx := newLocalFileTestContext(t)
+	f := New(ctx)
+	svc, ok := f.service.(*Service).uploadService.(*LocalFileService)
+	require.True(t, ok)
+	_, err := svc.UploadFile("common/documents/readme.txt", "text/plain; charset=utf-8", "", func(w io.Writer) error {
+		_, copyErr := io.Copy(w, strings.NewReader("hello route"))
+		return copyErr
+	})
+	require.NoError(t, err)
+
+	r := wkhttp.New()
+	f.Route(r)
+
+	signed, err := svc.PresignedGetURL("common/documents/readme.txt", "readme.txt", "attachment", 30*time.Minute)
+	require.NoError(t, err)
+	parsed, err := url.Parse(signed)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, parsed.RequestURI(), nil)
+	req.Header.Set("Origin", "http://localhost:3001")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "hello route", rec.Body.String())
+	require.Contains(t, rec.Header().Get("Content-Disposition"), "attachment")
+	require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+
+	req = httptest.NewRequest(http.MethodHead, parsed.RequestURI(), nil)
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Empty(t, rec.Body.String())
+	require.Contains(t, rec.Header().Get("Content-Disposition"), "attachment")
+
+	req = httptest.NewRequest(http.MethodOptions, parsed.RequestURI(), nil)
+	req.Header.Set("Origin", "http://localhost:3001")
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+
+	query := parsed.Query()
+	query.Set("path", "common/documents/other.txt")
+	parsed.RawQuery = query.Encode()
+	req = httptest.NewRequest(http.MethodGet, parsed.RequestURI(), nil)
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestFile_LocalSignedRouteAcceptsPresignedPutRoundtrip(t *testing.T) {
+	ctx := newLocalFileTestContext(t)
+	f := New(ctx)
+	svc, ok := f.service.(*Service).uploadService.(*LocalFileService)
+	require.True(t, ok)
+
+	payload := "hello signed put"
+	contentType := "text/markdown; charset=utf-8"
+	contentDisposition := `inline; filename="notes.md"; filename*=UTF-8''notes.md`
+	signed, _, err := svc.PresignedPutURL(
+		"chat/2/test-local-put.md",
+		contentType,
+		contentDisposition,
+		int64(len(payload)),
+		30*time.Minute,
+	)
+	require.NoError(t, err)
+	parsed, err := url.Parse(signed)
+	require.NoError(t, err)
+	require.NotEmpty(t, parsed.Query().Get("nonce"))
+	require.Empty(t, parsed.Query().Get("contentDisposition"))
+	require.NotEmpty(t, parsed.Query().Get("contentDispositionB64"))
+
+	r := wkhttp.New()
+	f.Route(r)
+
+	req := httptest.NewRequest(http.MethodPut, parsed.RequestURI(), strings.NewReader(payload))
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Content-Disposition", contentDisposition)
+	req.Header.Set("Origin", "http://localhost:3001")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+
+	rc, storedContentType, err := svc.GetFile("chat/2/test-local-put.md")
+	require.NoError(t, err)
+	defer rc.Close()
+	body, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Equal(t, payload, string(body))
+	require.Equal(t, contentType, storedContentType)
+
+	_, diskPath, err := svc.diskPath("chat/2/test-local-put.md")
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(diskPath))
+
+	req = httptest.NewRequest(http.MethodPut, parsed.RequestURI(), strings.NewReader(payload))
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Content-Disposition", contentDisposition)
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+}
+
+func TestFile_LocalSignedPutRejectsBoundaryViolations(t *testing.T) {
+	ctx := newLocalFileTestContext(t)
+	f := New(ctx)
+	svc, ok := f.service.(*Service).uploadService.(*LocalFileService)
+	require.True(t, ok)
+
+	r := wkhttp.New()
+	f.Route(r)
+
+	t.Run("content_length_mismatch", func(t *testing.T) {
+		payload := "short"
+		signed, _, err := svc.PresignedPutURL(
+			"chat/2/mismatch.txt",
+			"text/plain; charset=utf-8",
+			"",
+			int64(len(payload)+1),
+			30*time.Minute,
+		)
+		require.NoError(t, err)
+		rec := performLocalSignedPut(t, r, signed, payload, "text/plain; charset=utf-8", "")
+		require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	})
+
+	t.Run("file_size_over_limit", func(t *testing.T) {
+		signed, err := svc.signedURL(localFileSignedRequest{
+			Method:      http.MethodPut,
+			Path:        "chat/2/oversize.txt",
+			ContentType: "text/plain; charset=utf-8",
+			FileSize:    MaxFileSize + 1,
+			ExpiresAt:   time.Now().Add(30 * time.Minute).Unix(),
+			Nonce:       "oversize-nonce",
+		})
+		require.NoError(t, err)
+		rec := performLocalSignedPut(t, r, signed, "tiny", "text/plain; charset=utf-8", "")
+		require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code, rec.Body.String())
+	})
+
+	t.Run("blocked_extension", func(t *testing.T) {
+		payload := "binary"
+		signed, _, err := svc.PresignedPutURL(
+			"chat/2/malware.exe",
+			"application/octet-stream",
+			"",
+			int64(len(payload)),
+			30*time.Minute,
+		)
+		require.NoError(t, err)
+		rec := performLocalSignedPut(t, r, signed, payload, "application/octet-stream", "")
+		require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	})
+
+	t.Run("path_exists", func(t *testing.T) {
+		path := "chat/2/existing.txt"
+		_, err := svc.UploadFile(path, "text/plain; charset=utf-8", "", func(w io.Writer) error {
+			_, copyErr := io.Copy(w, strings.NewReader("already here"))
+			return copyErr
+		})
+		require.NoError(t, err)
+
+		payload := "replacement"
+		signed, _, err := svc.PresignedPutURL(
+			path,
+			"text/plain; charset=utf-8",
+			"",
+			int64(len(payload)),
+			30*time.Minute,
+		)
+		require.NoError(t, err)
+		rec := performLocalSignedPut(t, r, signed, payload, "text/plain; charset=utf-8", "")
+		require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	})
+}
+
+func TestFile_LocalSignedGetDowngradesUnsafeInlineContent(t *testing.T) {
+	ctx := newLocalFileTestContext(t)
+	f := New(ctx)
+	svc, ok := f.service.(*Service).uploadService.(*LocalFileService)
+	require.True(t, ok)
+	_, err := svc.UploadFile("common/page.html", "text/html; charset=utf-8", "", func(w io.Writer) error {
+		_, copyErr := io.Copy(w, strings.NewReader("<html>unsafe</html>"))
+		return copyErr
+	})
+	require.NoError(t, err)
+
+	signed, err := svc.PresignedGetURL("common/page.html", "page.html", "inline", 30*time.Minute)
+	require.NoError(t, err)
+	parsed, err := url.Parse(signed)
+	require.NoError(t, err)
+
+	r := wkhttp.New()
+	f.Route(r)
+	req := httptest.NewRequest(http.MethodGet, parsed.RequestURI(), nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	require.Equal(t, "application/octet-stream", rec.Header().Get("Content-Type"))
+	require.Contains(t, rec.Header().Get("Content-Disposition"), "attachment")
+	require.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
+}
+
+func performLocalSignedPut(t *testing.T, r *wkhttp.WKHttp, signedURL string, payload string, contentType string, contentDisposition string) *httptest.ResponseRecorder {
+	t.Helper()
+	parsed, err := url.Parse(signedURL)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPut, parsed.RequestURI(), strings.NewReader(payload))
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	if contentDisposition != "" {
+		req.Header.Set("Content-Disposition", contentDisposition)
+	}
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}

--- a/modules/file/service_metrics_test.go
+++ b/modules/file/service_metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-server/pkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -72,6 +73,32 @@ func depOpSampleCount(t *testing.T, reg *prometheus.Registry, op string) uint64 
 		}
 	}
 	return n
+}
+
+func TestNewServiceSetsStableBackendLabel(t *testing.T) {
+	tests := []struct {
+		name        string
+		fileService config.FileService
+		wantBackend string
+	}{
+		{name: "aws s3", fileService: config.FileService(fileServiceAwsS3), wantBackend: "s3"},
+		{name: "local", fileService: config.FileService(fileServiceLocal), wantBackend: "local"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.New()
+			cfg.FileService = tt.fileService
+
+			svc, ok := NewService(config.NewContext(cfg)).(*Service)
+			if !ok {
+				t.Fatalf("NewService returned %T, want *Service", svc)
+			}
+			if svc.backend != tt.wantBackend {
+				t.Fatalf("backend = %q, want %q", svc.backend, tt.wantBackend)
+			}
+		})
+	}
 }
 
 func TestServiceUploadFile_TransparentAndObserved(t *testing.T) {

--- a/modules/search/api.go
+++ b/modules/search/api.go
@@ -487,10 +487,20 @@ func (s *Search) global(c *wkhttp.Context) {
 			})
 		}
 	}
+	documentResps := make([]*documentSearchResp, 0)
+	if req.OnlyMessage == 0 {
+		documentResps, err = s.searchDocuments(loginUID, searchSpaceID, req.Keyword, req.Limit)
+		if err != nil {
+			s.Error("查询文档资产错误", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrSearchMessageQueryFailed, nil, nil)
+			return
+		}
+	}
 	c.Response(map[string]interface{}{
-		"friends":  friendResps,
-		"groups":   groupResps,
-		"messages": messagesResp,
+		"friends":   friendResps,
+		"groups":    groupResps,
+		"messages":  messagesResp,
+		"documents": documentResps,
 	})
 }
 

--- a/modules/search/api_test.go
+++ b/modules/search/api_test.go
@@ -1,11 +1,18 @@
 package search
 
 import (
+	"database/sql"
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/modules/document"
+	dbbase "github.com/Mininglamp-OSS/octo-server/pkg/db"
+	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestShouldIncludeGroupForSpace(t *testing.T) {
@@ -31,6 +38,185 @@ func TestShouldIncludeGroupForSpace(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestBuildDocumentSearchRespHighlightsNameAndCarriesSourceTrace(t *testing.T) {
+	createdAt := dbbase.Time{}
+	asset := &document.DocumentAssetModel{
+		AssetID:           "doc-1",
+		Name:              "Q3 客户现场实施计划.pdf",
+		Kind:              document.KindPDF,
+		Extension:         ".pdf",
+		Size:              2048,
+		SourceType:        document.SourceTypeGroup,
+		SourceName:        "华东项目交付群",
+		SourceChannelID:   "group-east",
+		SourceChannelType: common.ChannelTypeGroup.Uint8(),
+		SourceMessageID:   "2406171002",
+		UploaderName:      "周岚",
+		Status:            document.StatusConversation,
+	}
+	asset.CreatedAt = createdAt
+
+	resp := buildDocumentSearchResp(asset, "华东交付部空间", 91002, "客户")
+
+	assert.Equal(t, "doc-1", resp.ID)
+	assert.Equal(t, "Q3 <mark>客户</mark>现场实施计划.pdf", resp.Name)
+	assert.Equal(t, document.SourceTypeGroup, resp.SourceType)
+	assert.Equal(t, "华东项目交付群", resp.SourceName)
+	assert.Equal(t, "group-east", resp.SourceChannelID)
+	assert.Equal(t, common.ChannelTypeGroup.Uint8(), resp.SourceChannelType)
+	assert.Equal(t, "2406171002", resp.SourceMessageID)
+	assert.Equal(t, uint32(91002), resp.SourceMessageSeq)
+	assert.Equal(t, "华东交付部空间", resp.SpaceName)
+	assert.Equal(t, "周岚", resp.Uploader)
+}
+
+func TestDocumentSearchSQLGatesSpaceVisibleDocsBySpaceAccess(t *testing.T) {
+	sql := documentSearchSQL()
+
+	assert.Contains(t, sql, "da.document_space_id<>''")
+	assert.Contains(t, sql, "ds.status=1")
+	assert.Contains(t, sql, "ds.owner_uid=?")
+	assert.Contains(t, sql, "document_space_member dsm")
+	assert.Contains(t, sql, "dsm.uid=?")
+	assert.NotContains(t, sql, "da.visibility=?\n\t\t     OR")
+}
+
+func TestSearchDocumentsExecutesSpaceIsolationSQL(t *testing.T) {
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	ctx := newSearchDocumentDBContext(t)
+
+	_, err := ctx.DB().InsertInto("document_space").
+		Columns("space_id", "name", "owner_uid", "tenant_space_id", "status").
+		Values("space-visible", "可见空间", "owner", "tenant-a", 1).
+		Values("space-disabled", "停用空间", "owner", "tenant-a", 0).
+		Values("space-other", "其他空间", "owner", "tenant-a", 1).
+		Values("space-cross", "跨租户空间", "owner", "tenant-b", 1).
+		Exec()
+	require.NoError(t, err)
+
+	_, err = ctx.DB().InsertInto("document_space_member").
+		Columns("member_id", "document_space_id", "uid", "name", "role", "tenant_space_id", "status").
+		Values("member-visible", "space-visible", "reader", "Reader", document.SpaceRoleViewer, "tenant-a", 1).
+		Exec()
+	require.NoError(t, err)
+
+	insertAsset := func(assetID, name, tenantSpaceID, documentSpaceID string) {
+		t.Helper()
+		_, insertErr := ctx.DB().InsertInto("document_asset").
+			Columns("asset_id", "name", "kind", "extension", "size", "storage_path", "uploader_uid", "owner_uid", "tenant_space_id", "document_space_id", "visibility", "status").
+			Values(assetID, name, document.KindPDF, ".pdf", 1024, "common/"+assetID+".pdf", "owner", "owner", tenantSpaceID, documentSpaceID, document.VisibilitySpace, document.StatusArchived).
+			Exec()
+		require.NoError(t, insertErr)
+	}
+	insertAsset("asset-visible", "Quarterly visible.pdf", "tenant-a", "space-visible")
+	insertAsset("asset-disabled", "Quarterly disabled.pdf", "tenant-a", "space-disabled")
+	insertAsset("asset-other", "Quarterly other.pdf", "tenant-a", "space-other")
+	insertAsset("asset-cross", "Quarterly cross.pdf", "tenant-b", "space-cross")
+
+	results, err := New(ctx).searchDocuments("reader", "tenant-a", "Quarterly", 20)
+	require.NoError(t, err)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, "asset-visible", results[0].ID)
+	assert.Equal(t, "可见空间", results[0].SpaceName)
+}
+
+func newSearchDocumentDBContext(t *testing.T) *config.Context {
+	t.Helper()
+	addr := os.Getenv("OCTO_TEST_MYSQL_ADDR")
+	if addr == "" {
+		addr = "root:demo@tcp(127.0.0.1)/octo_search_document_test?charset=utf8mb4&parseTime=true"
+	}
+	ensureSearchDocumentDB(t, addr)
+
+	cfg := config.New()
+	cfg.Test = true
+	cfg.DB.MySQLAddr = addr
+	cfg.DB.Migration = false
+	ctx := config.NewContext(cfg)
+
+	for _, stmt := range []string{
+		"DROP TABLE IF EXISTS `group_member`",
+		"DROP TABLE IF EXISTS `group`",
+		"DROP TABLE IF EXISTS `document_space_member`",
+		"DROP TABLE IF EXISTS `document_asset`",
+		"DROP TABLE IF EXISTS `document_space`",
+		`CREATE TABLE ` + "`group`" + ` (
+			id BIGINT PRIMARY KEY AUTO_INCREMENT,
+			group_no VARCHAR(64) NOT NULL,
+			space_id VARCHAR(64) NOT NULL DEFAULT '',
+			status TINYINT NOT NULL DEFAULT 1
+		)`,
+		`CREATE TABLE group_member (
+			id BIGINT PRIMARY KEY AUTO_INCREMENT,
+			group_no VARCHAR(64) NOT NULL,
+			uid VARCHAR(64) NOT NULL,
+			status TINYINT NOT NULL DEFAULT 1,
+			is_deleted TINYINT NOT NULL DEFAULT 0
+		)`,
+		`CREATE TABLE document_space (
+			id BIGINT PRIMARY KEY AUTO_INCREMENT,
+			space_id VARCHAR(64) NOT NULL,
+			name VARCHAR(128) NOT NULL,
+			owner_uid VARCHAR(64) NOT NULL,
+			tenant_space_id VARCHAR(64) NOT NULL DEFAULT '',
+			status TINYINT NOT NULL DEFAULT 1
+		)`,
+		`CREATE TABLE document_space_member (
+			id BIGINT PRIMARY KEY AUTO_INCREMENT,
+			member_id VARCHAR(64) NOT NULL,
+			document_space_id VARCHAR(64) NOT NULL,
+			uid VARCHAR(64) NOT NULL,
+			name VARCHAR(128) NOT NULL DEFAULT '',
+			role VARCHAR(32) NOT NULL DEFAULT 'viewer',
+			tenant_space_id VARCHAR(64) NOT NULL DEFAULT '',
+			status TINYINT NOT NULL DEFAULT 1
+		)`,
+		`CREATE TABLE document_asset (
+			id BIGINT PRIMARY KEY AUTO_INCREMENT,
+			asset_id VARCHAR(64) NOT NULL,
+			name VARCHAR(255) NOT NULL,
+			kind VARCHAR(32) NOT NULL DEFAULT 'doc',
+			extension VARCHAR(32) NOT NULL DEFAULT '',
+			size BIGINT NOT NULL DEFAULT 0,
+			storage_path TEXT,
+			source_type VARCHAR(32) NOT NULL DEFAULT '',
+			source_channel_id VARCHAR(128) NOT NULL DEFAULT '',
+			source_channel_type TINYINT NOT NULL DEFAULT 0,
+			source_message_id VARCHAR(64) NOT NULL DEFAULT '',
+			source_name VARCHAR(255) NOT NULL DEFAULT '',
+			uploader_uid VARCHAR(64) NOT NULL DEFAULT '',
+			uploader_name VARCHAR(128) NOT NULL DEFAULT '',
+			owner_uid VARCHAR(64) NOT NULL DEFAULT '',
+			owner_name VARCHAR(128) NOT NULL DEFAULT '',
+			tenant_space_id VARCHAR(64) NOT NULL DEFAULT '',
+			document_space_id VARCHAR(64) NOT NULL DEFAULT '',
+			visibility VARCHAR(32) NOT NULL DEFAULT 'space',
+			status VARCHAR(32) NOT NULL DEFAULT 'archived',
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			last_access_at DATETIME NULL
+		)`,
+	} {
+		_, err := ctx.DB().UpdateBySql(stmt).Exec()
+		require.NoError(t, err, "exec schema statement: %s", stmt)
+	}
+	return ctx
+}
+
+func ensureSearchDocumentDB(t *testing.T, addr string) {
+	t.Helper()
+	parsed, err := mysqldriver.ParseDSN(addr)
+	require.NoError(t, err)
+	dbName := parsed.DBName
+	require.NotEmpty(t, dbName, "test DSN must include a database name")
+	parsed.DBName = ""
+	db, err := sql.Open("mysql", parsed.FormatDSN())
+	require.NoError(t, err)
+	defer db.Close()
+	_, err = db.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci", dbName))
+	require.NoError(t, err)
 }
 
 func TestCollectChannelIDs_ThreadMessage(t *testing.T) {

--- a/modules/search/document.go
+++ b/modules/search/document.go
@@ -1,0 +1,231 @@
+package search
+
+import (
+	"fmt"
+	"html"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-server/modules/document"
+	dbbase "github.com/Mininglamp-OSS/octo-server/pkg/db"
+	"go.uber.org/zap"
+)
+
+type documentSearchResp struct {
+	ID                string `json:"id"`
+	Name              string `json:"name"`
+	Kind              string `json:"kind"`
+	Extension         string `json:"extension"`
+	Size              int64  `json:"size"`
+	SourceType        string `json:"source_type"`
+	SourceName        string `json:"source_name"`
+	SourceChannelID   string `json:"source_channel_id"`
+	SourceChannelType uint8  `json:"source_channel_type"`
+	SourceMessageID   string `json:"source_message_id"`
+	SourceMessageSeq  uint32 `json:"source_message_seq"`
+	SpaceName         string `json:"space_name"`
+	Uploader          string `json:"uploader"`
+	Status            string `json:"status"`
+	CreatedAt         string `json:"created_at"`
+}
+
+type documentSearchRow struct {
+	AssetID           string      `db:"asset_id"`
+	Name              string      `db:"name"`
+	Kind              string      `db:"kind"`
+	Extension         string      `db:"extension"`
+	Size              int64       `db:"size"`
+	SourceType        string      `db:"source_type"`
+	SourceName        string      `db:"source_name"`
+	SourceChannelID   string      `db:"source_channel_id"`
+	SourceChannelType uint8       `db:"source_channel_type"`
+	SourceMessageID   string      `db:"source_message_id"`
+	UploaderUID       string      `db:"uploader_uid"`
+	UploaderName      string      `db:"uploader_name"`
+	OwnerUID          string      `db:"owner_uid"`
+	OwnerName         string      `db:"owner_name"`
+	TenantSpaceID     string      `db:"tenant_space_id"`
+	DocumentSpaceID   string      `db:"document_space_id"`
+	Visibility        string      `db:"visibility"`
+	Status            string      `db:"status"`
+	CreatedAt         dbbase.Time `db:"created_at"`
+	SpaceName         string      `db:"space_name"`
+}
+
+type sourceMessageSeqRow struct {
+	MessageID   string `db:"message_id"`
+	ClientMsgNo string `db:"client_msg_no"`
+	MessageSeq  uint32 `db:"message_seq"`
+}
+
+func buildDocumentSearchResp(asset *document.DocumentAssetModel, spaceName string, sourceMessageSeq uint32, keyword string) *documentSearchResp {
+	return &documentSearchResp{
+		ID:                asset.AssetID,
+		Name:              highlightSearchText(asset.Name, keyword),
+		Kind:              asset.Kind,
+		Extension:         asset.Extension,
+		Size:              asset.Size,
+		SourceType:        asset.SourceType,
+		SourceName:        asset.SourceName,
+		SourceChannelID:   asset.SourceChannelID,
+		SourceChannelType: asset.SourceChannelType,
+		SourceMessageID:   asset.SourceMessageID,
+		SourceMessageSeq:  sourceMessageSeq,
+		SpaceName:         spaceName,
+		Uploader:          asset.UploaderName,
+		Status:            asset.Status,
+		CreatedAt:         asset.CreatedAt.String(),
+	}
+}
+
+func highlightSearchText(text, keyword string) string {
+	escaped := html.EscapeString(text)
+	trimmed := strings.TrimSpace(keyword)
+	if trimmed == "" {
+		return escaped
+	}
+	return strings.ReplaceAll(escaped, html.EscapeString(trimmed), fmt.Sprintf("<mark>%s</mark>", html.EscapeString(trimmed)))
+}
+
+func (s *Search) searchDocuments(uid, tenantSpaceID, keyword string, limit int) ([]*documentSearchResp, error) {
+	keyword = strings.TrimSpace(keyword)
+	if tenantSpaceID == "" || keyword == "" {
+		return []*documentSearchResp{}, nil
+	}
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+
+	like := "%" + keyword + "%"
+	rows := make([]*documentSearchRow, 0)
+	_, err := s.ctx.DB().SelectBySql(
+		documentSearchSQL(),
+		tenantSpaceID,
+		document.StatusDeleted,
+		like, like, like, like,
+		uid,
+		uid,
+		uid,
+		uid,
+		document.VisibilityConversation,
+		tenantSpaceID,
+		uid,
+		uid,
+		limit,
+	).Load(&rows)
+	if err != nil {
+		return nil, err
+	}
+
+	messageIDs := make([]string, 0, len(rows))
+	for _, row := range rows {
+		if row.SourceMessageID != "" {
+			messageIDs = append(messageIDs, row.SourceMessageID)
+		}
+	}
+	messageSeqs := s.lookupSourceMessageSeqs(messageIDs)
+
+	resp := make([]*documentSearchResp, 0, len(rows))
+	for _, row := range rows {
+		asset := &document.DocumentAssetModel{
+			AssetID:           row.AssetID,
+			Name:              row.Name,
+			Kind:              row.Kind,
+			Extension:         row.Extension,
+			Size:              row.Size,
+			SourceType:        row.SourceType,
+			SourceName:        row.SourceName,
+			SourceChannelID:   row.SourceChannelID,
+			SourceChannelType: row.SourceChannelType,
+			SourceMessageID:   row.SourceMessageID,
+			UploaderUID:       row.UploaderUID,
+			UploaderName:      row.UploaderName,
+			OwnerUID:          row.OwnerUID,
+			OwnerName:         row.OwnerName,
+			TenantSpaceID:     row.TenantSpaceID,
+			DocumentSpaceID:   row.DocumentSpaceID,
+			Visibility:        row.Visibility,
+			Status:            row.Status,
+		}
+		asset.CreatedAt = row.CreatedAt
+		resp = append(resp, buildDocumentSearchResp(asset, row.SpaceName, messageSeqs[row.SourceMessageID], keyword))
+	}
+	return resp, nil
+}
+
+func documentSearchSQL() string {
+	return `SELECT
+			da.asset_id, da.name, da.kind, da.extension, da.size,
+			da.source_type, da.source_name, da.source_channel_id, da.source_channel_type, da.source_message_id,
+			da.uploader_uid, da.uploader_name, da.owner_uid, da.owner_name,
+			da.tenant_space_id, da.document_space_id, da.visibility, da.status, da.created_at,
+			COALESCE(ds.name, '') AS space_name
+		 FROM document_asset da
+		 LEFT JOIN document_space ds ON ds.space_id=da.document_space_id AND ds.tenant_space_id=da.tenant_space_id
+		 WHERE da.tenant_space_id=?
+		   AND da.status<>?
+		   AND (da.name LIKE ? OR da.source_name LIKE ? OR da.uploader_name LIKE ? OR COALESCE(ds.name, '') LIKE ?)
+		   AND (
+		     da.uploader_uid=?
+		     OR da.owner_uid=?
+		     OR (
+		       da.document_space_id<>''
+		       AND ds.status=1
+		       AND (
+		         ds.owner_uid=?
+		         OR EXISTS (
+		           SELECT 1
+		           FROM document_space_member dsm
+		           WHERE dsm.tenant_space_id=da.tenant_space_id
+		             AND dsm.document_space_id=da.document_space_id
+		             AND dsm.uid=?
+		             AND dsm.status=1
+		         )
+		       )
+		     )
+		     OR (
+		       da.visibility=?
+		       AND (
+		         (
+		           da.source_channel_type=2
+		           AND EXISTS (
+		             SELECT 1 FROM group_member gm
+		             INNER JOIN ` + "`group`" + ` g ON g.group_no=gm.group_no AND g.status=1 AND g.space_id=?
+		             WHERE gm.group_no=da.source_channel_id AND gm.uid=? AND gm.status=1 AND gm.is_deleted=0
+		           )
+		         )
+		         OR (da.source_channel_type<>2 AND da.source_channel_id=?)
+		       )
+		     )
+		   )
+		 ORDER BY da.last_access_at DESC, da.created_at DESC
+		 LIMIT ?`
+}
+
+func (s *Search) lookupSourceMessageSeqs(messageIDs []string) map[string]uint32 {
+	result := make(map[string]uint32)
+	if len(messageIDs) == 0 {
+		return result
+	}
+	tables := []string{"message", "message1", "message2", "message3", "message4"}
+	for _, table := range tables {
+		rows := make([]*sourceMessageSeqRow, 0)
+		_, err := s.ctx.DB().SelectBySql(
+			fmt.Sprintf("SELECT message_id, client_msg_no, message_seq FROM `%s` WHERE message_id IN ? OR client_msg_no IN ?", table),
+			messageIDs,
+			messageIDs,
+		).Load(&rows)
+		if err != nil {
+			s.Warn("查询文档来源消息序号失败，跳过分片", zap.String("table", table), zap.Error(err))
+			continue
+		}
+		for _, row := range rows {
+			if row.MessageID != "" {
+				result[row.MessageID] = row.MessageSeq
+			}
+			if row.ClientMsgNo != "" {
+				result[row.ClientMsgNo] = row.MessageSeq
+			}
+		}
+	}
+	return result
+}

--- a/pkg/errcode/document.go
+++ b/pkg/errcode/document.go
@@ -1,0 +1,39 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// err.server.document.* — modules/document business error codes.
+var (
+	ErrDocumentRequestInvalid = register(codes.Code{
+		ID:             "err.server.document.request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid document request.",
+		SafeDetailKeys: []string{"field"},
+	})
+	ErrDocumentForbidden = register(codes.Code{
+		ID:             "err.server.document.forbidden",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You do not have permission to access this document resource.",
+	})
+	ErrDocumentNotFound = register(codes.Code{
+		ID:             "err.server.document.not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Document resource not found.",
+	})
+	ErrDocumentQueryFailed = register(codes.Code{
+		ID:             "err.server.document.query_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to query document data.",
+		Internal:       true,
+	})
+	ErrDocumentStoreFailed = register(codes.Code{
+		ID:             "err.server.document.store_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to update document data.",
+		Internal:       true,
+	})
+)

--- a/pkg/errcode/file.go
+++ b/pkg/errcode/file.go
@@ -1,0 +1,44 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// err.server.file.* — modules/file business error codes.
+var (
+	ErrFileRequestInvalid = register(codes.Code{
+		ID:             "err.server.file.request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid file request.",
+		SafeDetailKeys: []string{"field"},
+	})
+	ErrFileForbidden = register(codes.Code{
+		ID:             "err.server.file.forbidden",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "The file link is invalid or expired.",
+	})
+	ErrFileNotFound = register(codes.Code{
+		ID:             "err.server.file.not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "File not found.",
+	})
+	ErrFilePayloadTooLarge = register(codes.Code{
+		ID:             "err.server.file.payload_too_large",
+		HTTPStatus:     http.StatusRequestEntityTooLarge,
+		DefaultMessage: "The uploaded file exceeds the maximum allowed size.",
+		SafeDetailKeys: []string{"max_mb"},
+	})
+	ErrFileMethodNotAllowed = register(codes.Code{
+		ID:             "err.server.file.method_not_allowed",
+		HTTPStatus:     http.StatusMethodNotAllowed,
+		DefaultMessage: "Method not allowed.",
+	})
+	ErrFileStoreFailed = register(codes.Code{
+		ID:             "err.server.file.store_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to store file data.",
+		Internal:       true,
+	})
+)

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -932,6 +932,43 @@ other = "查询群搜索数据失败。"
 ["err.server.search.user_query_failed"]
 other = "查询用户搜索数据失败。"
 
+# ---- err.server.file.* (modules/file: api.go) ----
+
+["err.server.file.request_invalid"]
+other = "文件请求参数无效。"
+
+["err.server.file.forbidden"]
+other = "文件链接无效或已过期。"
+
+["err.server.file.not_found"]
+other = "文件不存在。"
+
+["err.server.file.payload_too_large"]
+other = "上传文件超过大小限制。"
+
+["err.server.file.method_not_allowed"]
+other = "不支持该请求方法。"
+
+["err.server.file.store_failed"]
+other = "保存文件数据失败。"
+
+# ---- err.server.document.* (modules/document: api.go) ----
+
+["err.server.document.request_invalid"]
+other = "文档请求参数无效。"
+
+["err.server.document.forbidden"]
+other = "你无权访问该文档资源。"
+
+["err.server.document.not_found"]
+other = "文档资源不存在。"
+
+["err.server.document.query_failed"]
+other = "查询文档数据失败。"
+
+["err.server.document.store_failed"]
+other = "更新文档数据失败。"
+
 # ---- err.server.statistics.* (modules/statistics: api.go) ----
 
 ["err.server.statistics.request_invalid"]

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -294,6 +294,39 @@ other = "The group and the category are not in the same space."
 ["err.server.category.store_failed"]
 other = "Failed to update category data."
 
+["err.server.document.forbidden"]
+other = "You do not have permission to access this document resource."
+
+["err.server.document.not_found"]
+other = "Document resource not found."
+
+["err.server.document.query_failed"]
+other = "Failed to query document data."
+
+["err.server.document.request_invalid"]
+other = "Invalid document request."
+
+["err.server.document.store_failed"]
+other = "Failed to update document data."
+
+["err.server.file.forbidden"]
+other = "The file link is invalid or expired."
+
+["err.server.file.method_not_allowed"]
+other = "Method not allowed."
+
+["err.server.file.not_found"]
+other = "File not found."
+
+["err.server.file.payload_too_large"]
+other = "The uploaded file exceeds the maximum allowed size."
+
+["err.server.file.request_invalid"]
+other = "Invalid file request."
+
+["err.server.file.store_failed"]
+other = "Failed to store file data."
+
 ["err.server.group.already_member"]
 other = "You are already a member of this group."
 


### PR DESCRIPTION
## Summary
- Add Filespace document backend module, migrations, service/API layer, and module registration.
- Add local signed file storage support needed by Filespace document upload/download flows.
- Add document results to global search.
- Register localized document/file error codes and keep new document routes behind auth, space middleware, and shared UID rate limiting.
- Narrow the PR by removing unrelated file0617 changes from base app, group, message, user, voice adapter, demo seed, static config, and deployment-adjacent files.

## Review Fixes
- Gate Upload/Archive/Bind/Rebind/Unbind/Search/State/Preview/Download paths by tenant, source access, and document-space role or membership.
- Gate Archive existing-asset rehoming with edit access for non-conversation assets, preventing direct-upload/private-space asset hijacking.
- Validate Archive existing assets against the asset stored source channel, not request-supplied source fields, preventing forged conversation-source rehoming.
- Exclude disabled document spaces from global document search by requiring active `document_space.status=1` on the space branch.
- Hide inaccessible bound-space id/name from binding discovery and channel storage-space lookup.
- Scope member search to the tenant space directory and stop returning email/phone in document member candidate responses.
- Stop returning raw document storage paths in document asset responses.
- Make local signed file upload enforce exact signed size and extension policy, and harden local signed download content disposition.

## Linked Spec
- `.octospec/tasks/filespace-documents-backend/brief.md`

## Verification
- `go test ./modules/document ./modules/file ./modules/search ./modules/base/app -count=1`
- `make i18n-extract-check && make i18n-lint`
- `go test ./...` was run earlier; remaining failures are existing local test DB migration-state failures in unrelated integration packages, e.g. `testutil.NewTestServer` cannot create a migration plan for legacy migration files, plus an existing user destroy test DB schema mismatch.

## Notes
- Current PR head is `fd956fcefb21d08bc6b353150f0cf86fc4bb2b31`.

Closes #573
