### PR TITLE
feat(messages_search): global search thread coverage

### DIFF
--- a/modules/messages_search/api.go
+++ b/modules/messages_search/api.go
@@ -47,6 +47,17 @@ type Handler struct {
 	// + spacepkg.CheckBotsInSpace on h.ctx.DB()); tests inject a pass-through
 	// stub so enumerateDMPeers is exercisable without a real MySQL connection.
 	dmBotFilterFn func(spaceID string, peers []string) ([]string, error)
+	// threadEnumFn is a test seam for the thread enumeration inside
+	// buildAllowlist. Nil in production (falls through to thread.NewDB(h.ctx)
+	// .QueryActiveShortIDsByGroupNos); tests inject a stub so the thread
+	// coverage on the global feed is exercisable without a real MySQL
+	// connection.
+	threadEnumFn func(groupNos []string) (map[string][]string, error)
+	// externalGroupFn is a test seam for the external-group lookup inside
+	// buildAllowlist. Nil in production (falls through to group.NewDB(h.ctx)
+	// .QueryExternalGroupNosForUser); tests inject a stub so buildAllowlist
+	// is exercisable without a real MySQL connection.
+	externalGroupFn func(loginUID string) (map[string]string, error)
 
 	limiter *uidLimiter
 	cache   *senderCache

--- a/modules/messages_search/api.go
+++ b/modules/messages_search/api.go
@@ -53,7 +53,12 @@ type Handler struct {
 	// the reject-deleted-only visibility contract; see RC on PR #553); tests
 	// inject a stub so the thread coverage on the global feed is exercisable
 	// without a real MySQL connection.
-	threadEnumFn func(groupNos []string) (map[string][]string, error)
+	//
+	// Returns (map[groupNo][]shortID, dbLimitHit, err). dbLimitHit=true means
+	// the DB 硬上限 LIMIT NonDeletedByGroupNosDBHardLimit was reached and the
+	// caller must WARN (tail groups may be partial or missing). See caller
+	// enumerateThreadsForGroups + RC 2 on PR #553.
+	threadEnumFn func(groupNos []string) (map[string][]string, bool, error)
 	// externalGroupFn is a test seam for the external-group lookup inside
 	// buildAllowlist. Nil in production (falls through to group.NewDB(h.ctx)
 	// .QueryExternalGroupNosForUser); tests inject a stub so buildAllowlist

--- a/modules/messages_search/api.go
+++ b/modules/messages_search/api.go
@@ -49,9 +49,10 @@ type Handler struct {
 	dmBotFilterFn func(spaceID string, peers []string) ([]string, error)
 	// threadEnumFn is a test seam for the thread enumeration inside
 	// buildAllowlist. Nil in production (falls through to thread.NewDB(h.ctx)
-	// .QueryActiveShortIDsByGroupNos); tests inject a stub so the thread
-	// coverage on the global feed is exercisable without a real MySQL
-	// connection.
+	// .QueryNonDeletedShortIDsByGroupNos — archived threads are included per
+	// the reject-deleted-only visibility contract; see RC on PR #553); tests
+	// inject a stub so the thread coverage on the global feed is exercisable
+	// without a real MySQL connection.
 	threadEnumFn func(groupNos []string) (map[string][]string, error)
 	// externalGroupFn is a test seam for the external-group lookup inside
 	// buildAllowlist. Nil in production (falls through to group.NewDB(h.ctx)

--- a/modules/messages_search/api.go
+++ b/modules/messages_search/api.go
@@ -54,11 +54,13 @@ type Handler struct {
 	// inject a stub so the thread coverage on the global feed is exercisable
 	// without a real MySQL connection.
 	//
-	// Returns (map[groupNo][]shortID, dbLimitHit, err). dbLimitHit=true means
-	// the DB 硬上限 LIMIT NonDeletedByGroupNosDBHardLimit was reached and the
-	// caller must WARN (tail groups may be partial or missing). See caller
-	// enumerateThreadsForGroups + RC 2 on PR #553.
-	threadEnumFn func(groupNos []string) (map[string][]string, bool, error)
+	// Returns (map[groupNo][]shortID, err). The DB layer now bounds every
+	// group to `NonDeletedByGroupNosPerGroupHardLimit` (=201) rows via a
+	// UNION ALL of per-group `LIMIT` subqueries, so a single runaway group
+	// can no longer starve other groups' thread coverage (RC 3 on PR #553).
+	// The 1-row overshoot lets the caller's `len(shortIDs) > maxThreadsPerGroup`
+	// cap branch still observe over-cap groups and WARN/downgrade them.
+	threadEnumFn func(groupNos []string) (map[string][]string, error)
 	// externalGroupFn is a test seam for the external-group lookup inside
 	// buildAllowlist. Nil in production (falls through to group.NewDB(h.ctx)
 	// .QueryExternalGroupNosForUser); tests inject a stub so buildAllowlist

--- a/modules/messages_search/search_global.go
+++ b/modules/messages_search/search_global.go
@@ -596,7 +596,9 @@ func (h *Handler) buildAllowlist(_ *wkhttp.Context, loginUID, spaceID string) ([
 // hard caps (maxThreadsPerGroup / maxTotalThreadChannelIDs) so a runaway
 // group cannot alone blow the OS terms clause. The DB query itself is
 // bounded by thread.NonDeletedByGroupNosDBHardLimit so a pathological
-// membership footprint can't drag tens of thousands of rows into memory.
+// membership footprint can't drag tens of thousands of rows into memory;
+// when that DB cap trips, the query signals it via dbLimitHit and we WARN
+// so the tail-drop is observable rather than silent (RC 2 on PR #553).
 //
 // Visibility: threads with status != deleted (i.e. active OR archived) are
 // included, aligning with single-channel search + message read semantics.
@@ -613,11 +615,26 @@ func (h *Handler) enumerateThreadsForGroups(groupNos []string) []channelRef {
 	if enum == nil {
 		enum = thread.NewDB(h.ctx).QueryNonDeletedShortIDsByGroupNos
 	}
-	byGroup, err := enum(groupNos)
+	byGroup, dbLimitHit, err := enum(groupNos)
 	if err != nil {
 		h.Warn("messages_search: thread enumeration failed; thread hits will be hidden for this request",
 			zap.Error(err))
 		return nil
+	}
+	if dbLimitHit {
+		// The DB hard-limit `NonDeletedByGroupNosDBHardLimit` capped the row
+		// set. Because rows are ordered by (group_no, short_id) before the
+		// LIMIT, tail groups (highest group_no) may be missing entirely or
+		// arrive partial. That is invisible to the caller's per-group /
+		// aggregate downgrade branches below (they trigger on TOO-MANY, not
+		// on TOO-FEW). WARN explicitly so operators can observe the silent
+		// degradation and, if it becomes recurrent, either widen the DB cap
+		// or shard the query. See RC 2 on PR #553 for the full analysis.
+		h.Warn("messages_search: thread enumeration hit DB hard limit; tail groups may be partial or missing",
+			zap.Int("db_hard_limit", thread.NonDeletedByGroupNosDBHardLimit),
+			zap.Int("group_count", len(groupNos)),
+			zap.String("first_group", groupNos[0]),
+			zap.String("last_group", groupNos[len(groupNos)-1]))
 	}
 	// Deterministic iteration — range over groupNos, not the map, so the
 	// hard-cap downgrade is reproducible across runs and easy to reason
@@ -644,6 +661,7 @@ func (h *Handler) enumerateThreadsForGroups(groupNos []string) []channelRef {
 				zap.Int("cap", maxTotalThreadChannelIDs))
 			break
 		}
+		appended := 0
 		for _, sid := range shortIDs {
 			if sid == "" {
 				continue
@@ -654,8 +672,13 @@ func (h *Handler) enumerateThreadsForGroups(groupNos []string) []channelRef {
 				WireID:      id,
 				ChannelType: channelTypeThread,
 			})
+			appended++
 		}
-		total += len(shortIDs)
+		// Increment by rows actually appended, not raw len(shortIDs) — the
+		// inner loop skips blank shortIDs (production QueryNonDeletedShort
+		// IDsByGroupNos strips those, but a future threadEnumFn source might
+		// not). Keeps `total` faithful to the OS terms-clause payload.
+		total += appended
 	}
 	return out
 }
@@ -874,8 +897,10 @@ func (h *Handler) channelsForMember(loginUID, memberUID, spaceID string, allowSe
 				// between caller and member.
 				out[id] = ref
 			}
-			// channelTypeThread: intentionally dropped for v1 — see
-			// helper doc-comment above.
+		case channelTypeThread:
+			// Intentionally dropped for v1 — see helper doc-comment above.
+			// Explicit case so a future maintainer adding a default: arm
+			// sees the drop is intentional and not a forgotten branch.
 		}
 	}
 	// spaceID is unused: the caller has already narrowed allowSet to the

--- a/modules/messages_search/search_global.go
+++ b/modules/messages_search/search_global.go
@@ -485,13 +485,15 @@ func (h *Handler) resolveGlobalScope(c *wkhttp.Context, loginUID string, channel
 //     blocker on PR #553.
 //
 // Known v1 gap: channelsForMember (the member_uid "包含成员" filter) still
-// scopes to group + DM only; it does NOT filter threads by thread_member
-// membership. A caller filtering by member_uid will see thread hits only
-// where the parent group is co-inhabited with memberUID — which matches the
-// stage3 authorisation model but is more permissive than the strict
-// thread_member intersection. Tightening this requires a `thread_member`
-// join and is deferred to a follow-up; the tradeoff is documented on
-// channelsForMember.
+// scopes to group + DM only; it explicitly DROPS every thread entry from
+// the allowlist when member_uid is set (see channelsForMember below,
+// `case channelTypeThread:` is a no-op). A caller filtering by member_uid
+// therefore sees zero thread hits, regardless of whether the named member
+// posted in any thread. This is fail-closed (more-restrictive than a
+// hypothetical thread_member intersection), safe on the security axis,
+// but it is a real UX gap the API contract should surface. Tightening
+// this requires a `thread_member` join and is deferred to v1.1; the
+// tradeoff is documented on channelsForMember.
 func (h *Handler) buildAllowlist(_ *wkhttp.Context, loginUID, spaceID string) ([]channelRef, []channelRef, []channelRef, error) {
 	groups, err := h.groupService.GetGroupsWithMemberUID(loginUID)
 	if err != nil {
@@ -593,12 +595,20 @@ func (h *Handler) buildAllowlist(_ *wkhttp.Context, loginUID, spaceID string) ([
 // enumerateThreadsForGroups fans a single batch query against the thread
 // table and turns every (groupNo, shortID) row into a composite
 // `{groupNo}____{shortID}` channelRef with channelType=5. Bounded by two
-// hard caps (maxThreadsPerGroup / maxTotalThreadChannelIDs) so a runaway
-// group cannot alone blow the OS terms clause. The DB query itself is
-// bounded by thread.NonDeletedByGroupNosDBHardLimit so a pathological
-// membership footprint can't drag tens of thousands of rows into memory;
-// when that DB cap trips, the query signals it via dbLimitHit and we WARN
-// so the tail-drop is observable rather than silent (RC 2 on PR #553).
+// caller-side hard caps (maxThreadsPerGroup / maxTotalThreadChannelIDs) so
+// a runaway group cannot alone blow the OS terms clause.
+//
+// The DB query itself is bounded **per group** via a UNION ALL of
+// per-group `LIMIT` subqueries (thread.NonDeletedByGroupNosPerGroupHardLimit
+// = 201), so a single fat group with tens of thousands of non-deleted
+// threads no longer starves the DB budget of other groups (RC 3 on PR
+// #553). Previous revisions used one global `ORDER BY group_no, short_id
+// LIMIT 2500` which let a group sorting early consume the entire budget;
+// every other group then returned zero rows and — combined with the
+// caller's `continue` on the fat group's per-group cap — zeroed out
+// thread coverage across the whole request. The per-group LIMIT eliminates
+// that failure mode by construction, and stays portable (MySQL 5.7 /
+// 8.0 / MariaDB) by avoiding the 8.0-only window function.
 //
 // Visibility: threads with status != deleted (i.e. active OR archived) are
 // included, aligning with single-channel search + message read semantics.
@@ -615,26 +625,11 @@ func (h *Handler) enumerateThreadsForGroups(groupNos []string) []channelRef {
 	if enum == nil {
 		enum = thread.NewDB(h.ctx).QueryNonDeletedShortIDsByGroupNos
 	}
-	byGroup, dbLimitHit, err := enum(groupNos)
+	byGroup, err := enum(groupNos)
 	if err != nil {
 		h.Warn("messages_search: thread enumeration failed; thread hits will be hidden for this request",
 			zap.Error(err))
 		return nil
-	}
-	if dbLimitHit {
-		// The DB hard-limit `NonDeletedByGroupNosDBHardLimit` capped the row
-		// set. Because rows are ordered by (group_no, short_id) before the
-		// LIMIT, tail groups (highest group_no) may be missing entirely or
-		// arrive partial. That is invisible to the caller's per-group /
-		// aggregate downgrade branches below (they trigger on TOO-MANY, not
-		// on TOO-FEW). WARN explicitly so operators can observe the silent
-		// degradation and, if it becomes recurrent, either widen the DB cap
-		// or shard the query. See RC 2 on PR #553 for the full analysis.
-		h.Warn("messages_search: thread enumeration hit DB hard limit; tail groups may be partial or missing",
-			zap.Int("db_hard_limit", thread.NonDeletedByGroupNosDBHardLimit),
-			zap.Int("group_count", len(groupNos)),
-			zap.String("first_group", groupNos[0]),
-			zap.String("last_group", groupNos[len(groupNos)-1]))
 	}
 	// Deterministic iteration — range over groupNos, not the map, so the
 	// hard-cap downgrade is reproducible across runs and easy to reason
@@ -646,22 +641,35 @@ func (h *Handler) enumerateThreadsForGroups(groupNos []string) []channelRef {
 		if len(shortIDs) == 0 {
 			continue
 		}
-		if len(shortIDs) > maxThreadsPerGroup {
+		// Count non-blank rows once and reuse for BOTH cap checks. Production
+		// QueryNonDeletedShortIDsByGroupNos already strips blank shortIDs at
+		// the SQL parse boundary, but the test seam threadEnumFn (and any
+		// future alternative backend) is not required to — keep the caps
+		// consistent by looking through blanks in both.
+		nonBlank := 0
+		for _, sid := range shortIDs {
+			if sid != "" {
+				nonBlank++
+			}
+		}
+		if nonBlank == 0 {
+			continue
+		}
+		if nonBlank > maxThreadsPerGroup {
 			h.Warn("messages_search: thread count per group exceeds cap; downgrading to group-only for this request",
 				zap.String("group_no", gn),
-				zap.Int("thread_count", len(shortIDs)),
+				zap.Int("thread_count", nonBlank),
 				zap.Int("cap", maxThreadsPerGroup))
 			continue
 		}
-		if total+len(shortIDs) > maxTotalThreadChannelIDs {
+		if total+nonBlank > maxTotalThreadChannelIDs {
 			h.Warn("messages_search: total thread channelIDs would exceed global cap; skipping remaining groups",
 				zap.String("skipped_group_no", gn),
 				zap.Int("running_total", total),
-				zap.Int("would_add", len(shortIDs)),
+				zap.Int("would_add", nonBlank),
 				zap.Int("cap", maxTotalThreadChannelIDs))
 			break
 		}
-		appended := 0
 		for _, sid := range shortIDs {
 			if sid == "" {
 				continue
@@ -672,13 +680,8 @@ func (h *Handler) enumerateThreadsForGroups(groupNos []string) []channelRef {
 				WireID:      id,
 				ChannelType: channelTypeThread,
 			})
-			appended++
 		}
-		// Increment by rows actually appended, not raw len(shortIDs) — the
-		// inner loop skips blank shortIDs (production QueryNonDeletedShort
-		// IDsByGroupNos strips those, but a future threadEnumFn source might
-		// not). Keeps `total` faithful to the OS terms-clause payload.
-		total += appended
+		total += nonBlank
 	}
 	return out
 }

--- a/modules/messages_search/search_global.go
+++ b/modules/messages_search/search_global.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"github.com/Mininglamp-OSS/octo-server/pkg/util"
@@ -83,6 +84,27 @@ type channelRef struct {
 	WireID      string // channel_id echoed to the client (peer uid for DM)
 	ChannelType uint8
 }
+
+// Thread-enumeration hard limits for the global allowlist.
+//
+//   - maxThreadsPerGroup caps how many active threads from a single group we
+//     fold into the terms(channelId, allowlist) clause. Beyond this the group
+//     downgrades to a "group-only" allowlist entry (its group channel still
+//     works, its thread hits get hard-dropped, no 500). Keeps a
+//     runaway-thread group from blowing the OS terms clause.
+//   - maxTotalThreadChannelIDs is the global aggregate cap across ALL groups
+//     in one request. OpenSearch's `indices.query.bool.max_clause_count`
+//     default is 4096 (Elasticsearch 7.x); we stay well below that so the
+//     rest of the DSL (group + DM + sender filters + ...) has room. On the
+//     first group that pushes us past this cap, we skip its threads (WARN)
+//     and keep serving the request.
+//
+// Both are intentionally conservative first cuts. Tune later once we have
+// prod telemetry on real thread-count distributions.
+const (
+	maxThreadsPerGroup       = 200
+	maxTotalThreadChannelIDs = 2000
+)
 
 // contentTypeSet is the union of every payload.type the indexer emits.
 // validate.contentTypesAllowed uses it to reject unknown values.
@@ -341,17 +363,20 @@ func (h *Handler) resolveGlobalScope(c *wkhttp.Context, loginUID string, channel
 			zap.String("uid", loginUID))
 	}
 
-	allowGroup, allowDM, err := h.buildAllowlist(c, loginUID, spaceID)
+	allowGroup, allowDM, allowThread, err := h.buildAllowlist(c, loginUID, spaceID)
 	if err != nil {
 		h.Error("messages_search: allowlist build failed", zap.Error(err))
 		respondInternal(c)
 		return nil, "", nil, false
 	}
-	allowSet := make(map[string]channelRef, len(allowGroup)+len(allowDM))
+	allowSet := make(map[string]channelRef, len(allowGroup)+len(allowDM)+len(allowThread))
 	for _, r := range allowGroup {
 		allowSet[r.OSChannelID] = r
 	}
 	for _, r := range allowDM {
+		allowSet[r.OSChannelID] = r
+	}
+	for _, r := range allowThread {
 		allowSet[r.OSChannelID] = r
 	}
 
@@ -423,28 +448,55 @@ func (h *Handler) resolveGlobalScope(c *wkhttp.Context, loginUID string, channel
 }
 
 // buildAllowlist enumerates every OS channelId the caller can read within the
-// given Space: joined groups + all threads implicitly reachable through them
-// (indexer uses the composite thread channelId which is already keyed by the
-// parent group's membership) plus DM peers. DM peers come from both the
-// caller's friend list AND the current Space's member list (§6.2) — see
-// enumerateDMPeers for the union + bot-in-space semantics. Threads are NOT
-// enumerated here — they are implicitly reachable via `channelType=5` under
-// the caller's group membership, but we do not enumerate the thread list
-// because the search contract wants a bounded terms query. Instead the DSL
-// relies on the group membership to indirectly gate threads (thread
-// channel_id contains the group no and gets a separate row in OS; without the
-// exact channelId our terms filter cannot include them).
+// given Space: joined groups + DM peers + active threads under those joined
+// groups. DM peers come from both the caller's friend list AND the current
+// Space's member list (§6.2) — see enumerateDMPeers for the union +
+// bot-in-space semantics. Threads are enumerated per-group via
+// enumerateThreadsForGroups (batch IN query over the joined group set), and
+// are subject to two hard caps (maxThreadsPerGroup / maxTotalThreadChannelIDs)
+// so a runaway thread population downgrades gracefully to "group only" rather
+// than blowing the OS terms clause.
 //
-// NOTE — thread gap: v1 accepts that thread messages will not appear in the
-// global feed unless a request explicitly narrows to a thread via
-// filters.channel_ids. §6.2 defers full thread enumeration until it becomes a
-// bottleneck. When we later add it, this helper is the single place to change.
-func (h *Handler) buildAllowlist(_ *wkhttp.Context, loginUID, spaceID string) ([]channelRef, []channelRef, error) {
+// Thread coverage — v1 scope (YUJ-10, supersedes the stage3 v1.1 defer):
+//
+//   - Thread messages surface on BOTH the unfiltered global stream AND when a
+//     request narrows via filters.channel_ids with channel_type=5. In the
+//     terms(channelId, allowlist) DSL that gates every global query, thread
+//     channelIDs (composite `{group_no}____{short_id}`, per
+//     thread.BuildChannelID) sit alongside group + DM channelIDs.
+//   - Rationale: single batch IN query bounded by joined groups (typically
+//     < 1k for even heavy users; each with 5–15 quantile active threads)
+//     stays well inside OpenSearch's `indices.query.bool.max_clause_count`.
+//     Threads share their parent group's membership so no extra auth check
+//     is needed — group membership already gates thread reachability.
+//   - Soft-fail: if QueryActiveShortIDsByGroupNos errors, threads are
+//     dropped from the allowlist but the group + DM parts still serve
+//     (WARN log; the whole request does NOT 500). Same policy as the
+//     external-group / space_member soft-fails elsewhere in this helper.
+//   - Hard caps: per-group threads capped at maxThreadsPerGroup; total
+//     thread channelIDs across all groups capped at maxTotalThreadChannelIDs.
+//     Beyond either cap we WARN and skip further thread ids for that group
+//     (or the whole request) — the group's own message hits still surface,
+//     only its thread hits get hard-dropped for this request.
+//
+// Known v1 gap: channelsForMember (the member_uid "包含成员" filter) still
+// scopes to group + DM only; it does NOT filter threads by thread_member
+// membership. A caller filtering by member_uid will see thread hits only
+// where the parent group is co-inhabited with memberUID — which matches the
+// stage3 authorisation model but is more permissive than the strict
+// thread_member intersection. Tightening this requires a `thread_member`
+// join and is deferred to a follow-up; the tradeoff is documented on
+// channelsForMember.
+func (h *Handler) buildAllowlist(_ *wkhttp.Context, loginUID, spaceID string) ([]channelRef, []channelRef, []channelRef, error) {
 	groups, err := h.groupService.GetGroupsWithMemberUID(loginUID)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	externalGroupMap, extErr := group.NewDB(h.ctx).QueryExternalGroupNosForUser(loginUID)
+	externalLookup := h.externalGroupFn
+	if externalLookup == nil {
+		externalLookup = group.NewDB(h.ctx).QueryExternalGroupNosForUser
+	}
+	externalGroupMap, extErr := externalLookup(loginUID)
 	if extErr != nil {
 		// Same soft-fail as modules/search/api.go — external groups become
 		// invisible for this request but the rest of the allowlist proceeds.
@@ -457,6 +509,7 @@ func (h *Handler) buildAllowlist(_ *wkhttp.Context, loginUID, spaceID string) ([
 	// deterministic OS-terms output.
 	candidateGroupNos := make([]string, 0, len(groups))
 	candidateGroupSet := make(map[string]struct{}, len(groups))
+	groupNos := make([]string, 0, len(groups))
 	for _, g := range groups {
 		if g == nil {
 			continue
@@ -483,7 +536,7 @@ func (h *Handler) buildAllowlist(_ *wkhttp.Context, loginUID, spaceID string) ([
 			h.Error("messages_search: ExistMembersActive lookup failed; fail-closed on group allowlist",
 				zap.String("login_uid", loginUID),
 				zap.Error(gerr))
-			return nil, nil, gerr
+			return nil, nil, nil, gerr
 		}
 		activeGroupSet = make(map[string]struct{}, len(activeNos))
 		for _, no := range activeNos {
@@ -500,6 +553,7 @@ func (h *Handler) buildAllowlist(_ *wkhttp.Context, loginUID, spaceID string) ([
 			WireID:      no,
 			ChannelType: channelTypeGroup,
 		})
+		groupNos = append(groupNos, no)
 	}
 
 	// DM peers: friend list ∪ Space members, minus bots not in the current
@@ -507,7 +561,7 @@ func (h *Handler) buildAllowlist(_ *wkhttp.Context, loginUID, spaceID string) ([
 	// surfaces converge on the same DM candidate set.
 	dmPeers, err := h.enumerateDMPeers(loginUID, spaceID)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	allowDM := make([]channelRef, 0, len(dmPeers))
 	for _, peer := range dmPeers {
@@ -520,9 +574,79 @@ func (h *Handler) buildAllowlist(_ *wkhttp.Context, loginUID, spaceID string) ([
 			ChannelType: channelTypePerson,
 		})
 	}
+
+	// Threads under the joined groups — single batch IN query. Soft-fail:
+	// on error we log + serve group/DM only so a MySQL blip on the thread
+	// side doesn't sink the whole global endpoint.
+	allowThread := h.enumerateThreadsForGroups(groupNos)
+
 	// Kept as separate slices only for readability at the call site; the
-	// caller flattens both into a single set.
-	return allowGroup, allowDM, nil
+	// caller flattens all three into a single set.
+	return allowGroup, allowDM, allowThread, nil
+}
+
+// enumerateThreadsForGroups fans a single batch query against the thread
+// table and turns every (groupNo, shortID) row into a composite
+// `{groupNo}____{shortID}` channelRef with channelType=5. Bounded by two
+// hard caps (maxThreadsPerGroup / maxTotalThreadChannelIDs) so a runaway
+// group cannot alone blow the OS terms clause.
+//
+// Returns an empty slice on error (WARN logged) — the caller then serves
+// group + DM only, matching the external-group / space_member soft-fail
+// policy on the same helper.
+func (h *Handler) enumerateThreadsForGroups(groupNos []string) []channelRef {
+	if len(groupNos) == 0 {
+		return nil
+	}
+	enum := h.threadEnumFn
+	if enum == nil {
+		enum = thread.NewDB(h.ctx).QueryActiveShortIDsByGroupNos
+	}
+	byGroup, err := enum(groupNos)
+	if err != nil {
+		h.Warn("messages_search: thread enumeration failed; thread hits will be hidden for this request",
+			zap.Error(err))
+		return nil
+	}
+	// Deterministic iteration — range over groupNos, not the map, so the
+	// hard-cap downgrade is reproducible across runs and easy to reason
+	// about in tests.
+	out := make([]channelRef, 0)
+	total := 0
+	for _, gn := range groupNos {
+		shortIDs := byGroup[gn]
+		if len(shortIDs) == 0 {
+			continue
+		}
+		if len(shortIDs) > maxThreadsPerGroup {
+			h.Warn("messages_search: thread count per group exceeds cap; downgrading to group-only for this request",
+				zap.String("group_no", gn),
+				zap.Int("thread_count", len(shortIDs)),
+				zap.Int("cap", maxThreadsPerGroup))
+			continue
+		}
+		if total+len(shortIDs) > maxTotalThreadChannelIDs {
+			h.Warn("messages_search: total thread channelIDs would exceed global cap; skipping remaining groups",
+				zap.String("skipped_group_no", gn),
+				zap.Int("running_total", total),
+				zap.Int("would_add", len(shortIDs)),
+				zap.Int("cap", maxTotalThreadChannelIDs))
+			break
+		}
+		for _, sid := range shortIDs {
+			if sid == "" {
+				continue
+			}
+			id := thread.BuildChannelID(gn, sid)
+			out = append(out, channelRef{
+				OSChannelID: id,
+				WireID:      id,
+				ChannelType: channelTypeThread,
+			})
+		}
+		total += len(shortIDs)
+	}
+	return out
 }
 
 // enumerateDMPeers returns the peer UIDs whose DM the caller is allowed to
@@ -704,6 +828,16 @@ func (h *Handler) queryDMSpaceMemberUIDs(spaceID, loginUID string) ([]string, er
 // together: the caller's allowlist ∩ (groups memberUID is in ∪ DM with
 // memberUID). Returned map keys are the OS channelId; values mirror the
 // allowSet entry so the caller can preserve wire-id / channelType.
+//
+// v1 thread scope (YUJ-10): this helper filters ONLY group + DM entries by
+// memberUID's own membership. Thread entries in allowSet are dropped from the
+// returned scope entirely — v1 does NOT resolve `thread_member` for the named
+// member (would require an extra IN join and a schema pass). A caller that
+// sets member_uid therefore sees group + DM hits that co-inhabit memberUID,
+// but NO thread hits at all. This is a deliberate v1 simplification: the
+// primary YUJ-10 requirement is "thread hits appear in the global feed";
+// scoping them by an arbitrary member is a v1.1 follow-up (see the design
+// doc §6.2 known-limitations note).
 func (h *Handler) channelsForMember(loginUID, memberUID, spaceID string, allowSet map[string]channelRef) (map[string]channelRef, error) {
 	out := make(map[string]channelRef)
 	memberGroups, err := h.groupService.GetGroupsWithMemberUID(memberUID)
@@ -718,14 +852,19 @@ func (h *Handler) channelsForMember(loginUID, memberUID, spaceID string, allowSe
 		memberSet[g.GroupNo] = struct{}{}
 	}
 	for id, ref := range allowSet {
-		if ref.ChannelType == channelTypeGroup {
+		switch ref.ChannelType {
+		case channelTypeGroup:
 			if _, ok := memberSet[ref.OSChannelID]; ok {
 				out[id] = ref
 			}
-		} else if ref.ChannelType == channelTypePerson && ref.WireID == memberUID {
-			// The DM with memberUID is trivially the "shared channel" between
-			// caller and member.
-			out[id] = ref
+		case channelTypePerson:
+			if ref.WireID == memberUID {
+				// The DM with memberUID is trivially the "shared channel"
+				// between caller and member.
+				out[id] = ref
+			}
+			// channelTypeThread: intentionally dropped for v1 — see
+			// helper doc-comment above.
 		}
 	}
 	// spaceID is unused: the caller has already narrowed allowSet to the

--- a/modules/messages_search/search_global.go
+++ b/modules/messages_search/search_global.go
@@ -469,7 +469,7 @@ func (h *Handler) resolveGlobalScope(c *wkhttp.Context, loginUID string, channel
 //     stays well inside OpenSearch's `indices.query.bool.max_clause_count`.
 //     Threads share their parent group's membership so no extra auth check
 //     is needed — group membership already gates thread reachability.
-//   - Soft-fail: if QueryActiveShortIDsByGroupNos errors, threads are
+//   - Soft-fail: if QueryNonDeletedShortIDsByGroupNos errors, threads are
 //     dropped from the allowlist but the group + DM parts still serve
 //     (WARN log; the whole request does NOT 500). Same policy as the
 //     external-group / space_member soft-fails elsewhere in this helper.
@@ -478,6 +478,11 @@ func (h *Handler) resolveGlobalScope(c *wkhttp.Context, loginUID string, channel
 //     Beyond either cap we WARN and skip further thread ids for that group
 //     (or the whole request) — the group's own message hits still surface,
 //     only its thread hits get hard-dropped for this request.
+//   - Visibility: archived threads are INCLUDED (contract is "reject deleted,
+//     allow archived" — matches single-channel search + message read; see
+//     thread.DB.QueryNonDeletedShortIDsByGroupNos). Deleted threads are NOT
+//     surfaced. Aligning global search with the rest of the system was RC
+//     blocker on PR #553.
 //
 // Known v1 gap: channelsForMember (the member_uid "包含成员" filter) still
 // scopes to group + DM only; it does NOT filter threads by thread_member
@@ -589,7 +594,13 @@ func (h *Handler) buildAllowlist(_ *wkhttp.Context, loginUID, spaceID string) ([
 // table and turns every (groupNo, shortID) row into a composite
 // `{groupNo}____{shortID}` channelRef with channelType=5. Bounded by two
 // hard caps (maxThreadsPerGroup / maxTotalThreadChannelIDs) so a runaway
-// group cannot alone blow the OS terms clause.
+// group cannot alone blow the OS terms clause. The DB query itself is
+// bounded by thread.NonDeletedByGroupNosDBHardLimit so a pathological
+// membership footprint can't drag tens of thousands of rows into memory.
+//
+// Visibility: threads with status != deleted (i.e. active OR archived) are
+// included, aligning with single-channel search + message read semantics.
+// See modules/thread/db.go::QueryNonDeletedShortIDsByGroupNos.
 //
 // Returns an empty slice on error (WARN logged) — the caller then serves
 // group + DM only, matching the external-group / space_member soft-fail
@@ -600,7 +611,7 @@ func (h *Handler) enumerateThreadsForGroups(groupNos []string) []channelRef {
 	}
 	enum := h.threadEnumFn
 	if enum == nil {
-		enum = thread.NewDB(h.ctx).QueryActiveShortIDsByGroupNos
+		enum = thread.NewDB(h.ctx).QueryNonDeletedShortIDsByGroupNos
 	}
 	byGroup, err := enum(groupNos)
 	if err != nil {

--- a/modules/messages_search/search_global_thread_test.go
+++ b/modules/messages_search/search_global_thread_test.go
@@ -55,7 +55,7 @@ func TestBuildAllowlist_IncludesThreadChannelIDs(t *testing.T) {
 	}
 	uSvc := &stubUserSvc{friends: []*user.FriendResp{}}
 	h := newAllowlistHandler(t, gSvc, uSvc)
-	h.threadEnumFn = func(groupNos []string) (map[string][]string, bool, error) {
+	h.threadEnumFn = func(groupNos []string) (map[string][]string, error) {
 		// Sanity: caller passes exactly the joined groups.
 		got := map[string]bool{}
 		for _, gn := range groupNos {
@@ -67,7 +67,7 @@ func TestBuildAllowlist_IncludesThreadChannelIDs(t *testing.T) {
 		return map[string][]string{
 			"grpA": {"thr1", "thr2"},
 			"grpB": {"thr3"},
-		}, false, nil
+		}, nil
 	}
 
 	allowGroup, _, allowThread, err := h.buildAllowlist(nil, loginUID, "")
@@ -112,8 +112,8 @@ func TestBuildAllowlist_ThreadEnumerateSoftFail(t *testing.T) {
 	}
 	uSvc := &stubUserSvc{friends: []*user.FriendResp{{UID: "friend1"}}}
 	h := newAllowlistHandler(t, gSvc, uSvc)
-	h.threadEnumFn = func([]string) (map[string][]string, bool, error) {
-		return nil, false, errors.New("mysql: connection refused")
+	h.threadEnumFn = func([]string) (map[string][]string, error) {
+		return nil, errors.New("mysql: connection refused")
 	}
 
 	allowGroup, allowDM, allowThread, err := h.buildAllowlist(nil, loginUID, "")
@@ -147,11 +147,11 @@ func TestBuildAllowlist_ThreadPerGroupCap(t *testing.T) {
 	for i := range fat {
 		fat[i] = "thr" + itoa(i)
 	}
-	h.threadEnumFn = func([]string) (map[string][]string, bool, error) {
+	h.threadEnumFn = func([]string) (map[string][]string, error) {
 		return map[string][]string{
 			"grpFat":  fat,
 			"grpThin": {"thrOK"},
-		}, false, nil
+		}, nil
 	}
 
 	allowGroup, _, allowThread, err := h.buildAllowlist(nil, loginUID, "")
@@ -225,12 +225,12 @@ func TestBuildAllowlist_ThreadGlobalAggregateCap(t *testing.T) {
 		}
 		return out
 	}
-	h.threadEnumFn = func([]string) (map[string][]string, bool, error) {
+	h.threadEnumFn = func([]string) (map[string][]string, error) {
 		m := make(map[string][]string, numGroups)
 		for _, gn := range groupNames {
 			m[gn] = makeIDs(gn+"_thr", perGroup)
 		}
-		return m, false, nil
+		return m, nil
 	}
 
 	_, _, allowThread, err := h.buildAllowlist(nil, loginUID, "")
@@ -288,9 +288,9 @@ func TestBuildAllowlist_EmptyGroupsNoThreadQuery(t *testing.T) {
 	uSvc := &stubUserSvc{}
 	h := newAllowlistHandler(t, gSvc, uSvc)
 	called := false
-	h.threadEnumFn = func(groupNos []string) (map[string][]string, bool, error) {
+	h.threadEnumFn = func(groupNos []string) (map[string][]string, error) {
 		called = true
-		return nil, false, nil
+		return nil, nil
 	}
 
 	_, _, allowThread, err := h.buildAllowlist(nil, loginUID, "")
@@ -355,8 +355,8 @@ func TestResolveGlobalScope_ThreadNarrowingHits(t *testing.T) {
 	uSvc := &stubUserSvc{}
 	h := newAllowlistHandler(t, gSvc, uSvc)
 	threadID := thread.BuildChannelID("grpA", "thr1")
-	h.threadEnumFn = func([]string) (map[string][]string, bool, error) {
-		return map[string][]string{"grpA": {"thr1"}}, false, nil
+	h.threadEnumFn = func([]string) (map[string][]string, error) {
+		return map[string][]string{"grpA": {"thr1"}}, nil
 	}
 
 	// Build a validator context whose spaceID is empty so RequireSpaceID
@@ -391,9 +391,9 @@ func TestResolveGlobalScope_ThreadOutsideMembership(t *testing.T) {
 	}
 	uSvc := &stubUserSvc{}
 	h := newAllowlistHandler(t, gSvc, uSvc)
-	h.threadEnumFn = func([]string) (map[string][]string, bool, error) {
+	h.threadEnumFn = func([]string) (map[string][]string, error) {
 		// grpA has no threads; grpB is not in allowlist.
-		return map[string][]string{}, false, nil
+		return map[string][]string{}, nil
 	}
 
 	c, _ := newValidatorCtx(t)
@@ -413,55 +413,62 @@ func TestResolveGlobalScope_ThreadOutsideMembership(t *testing.T) {
 
 // itoa is provided by visibility_test.go in this package — no local copy.
 
-// TestEnumerateThreadsForGroups_DBLimitHitStillReturnsResults — RC 2 on
-// PR #553. When the underlying DB signals `dbLimitHit=true` (i.e. the
-// SQL `LIMIT NonDeletedByGroupNosDBHardLimit` truncated the row set),
-// enumerateThreadsForGroups must still surface whatever rows *did* come
-// back (partial coverage is better than none) AND emit a WARN so tail-
-// group loss is observable rather than silent.
-//
-// The WARN itself lands in the process-wide zap logger (see
-// octo-lib/pkg/log/logger.go); this test doesn't capture stderr, but it
-// exercises the branch so a future regression that swallows dbLimitHit
-// silently (e.g. renaming the return arg to `_`) breaks the build /
-// test signature immediately.
-func TestEnumerateThreadsForGroups_DBLimitHitStillReturnsResults(t *testing.T) {
+// TestEnumerateThreadsForGroups_FatGroupDoesNotStarveOthers — RC 3 P1
+// regression on PR #553. The DB-side per-group PARTITION cap (see
+// thread.NonDeletedByGroupNosPerGroupHardLimit) is what actually prevents
+// starvation, but this caller-level test locks in the surface the caller
+// promises: given a byGroup map where one group is over the caller's
+// per-group cap AND other groups are normal, enumerateThreadsForGroups
+// must (a) drop the fat group with WARN (per-group cap `continue`) AND
+// (b) still surface every other group's threads. Pre-RC3 that combination
+// silently produced an empty allowlist because the fat group ate the
+// global DB LIMIT and normal groups arrived empty.
+func TestEnumerateThreadsForGroups_FatGroupDoesNotStarveOthers(t *testing.T) {
 	gSvc := &stubGroupSvc{}
 	uSvc := &stubUserSvc{}
 	h := newAllowlistHandler(t, gSvc, uSvc)
-	h.threadEnumFn = func(groupNos []string) (map[string][]string, bool, error) {
-		// Simulate: DB hit LIMIT, returned partial results (grpA got its
-		// two rows before the LIMIT ran out; a hypothetical grpZ tail
-		// group returned nothing).
+	h.threadEnumFn = func(groupNos []string) (map[string][]string, error) {
+		// Simulate what the post-fix SQL now guarantees: the fat group is
+		// bounded to `maxThreadsPerGroup + 1` rows by the DB PARTITION cap,
+		// and normal groups arrive complete. The 1-row overshoot on the fat
+		// group is the observability signal for the caller's per-group cap.
+		fatOver := make([]string, maxThreadsPerGroup+1)
+		for i := range fatOver {
+			fatOver[i] = "fatThr_" + itoa(i)
+		}
 		return map[string][]string{
-			"grpA": {"thr1", "thr2"},
-			// grpZ intentionally absent — the "silent tail drop" symptom.
-		}, true /* dbLimitHit */, nil
+			"grpFat":    fatOver,
+			"grpNorm1":  {"thr_n1_a", "thr_n1_b"},
+			"grpNorm2":  {"thr_n2_a"},
+		}, nil
 	}
 
-	got := h.enumerateThreadsForGroups([]string{"grpA", "grpZ"})
-	// Partial results survive: grpA's two threads still appear.
-	if len(got) != 2 {
-		t.Fatalf("partial results must still be returned on dbLimitHit; got %d refs", len(got))
+	got := h.enumerateThreadsForGroups([]string{"grpFat", "grpNorm1", "grpNorm2"})
+
+	// Fat group must NOT appear in the allowlist (per-group cap `continue`).
+	fatPrefix := "grpFat" + thread.ChannelIDSeparator
+	for _, r := range got {
+		if strings.HasPrefix(r.OSChannelID, fatPrefix) {
+			t.Errorf("fat group must be downgraded to group-only; leaked %q into thread allowlist", r.OSChannelID)
+		}
 	}
+
+	// Normal groups MUST appear in full — this is the P1 assertion. Under
+	// the pre-RC3 implementation these would all be absent.
 	want := map[string]bool{
-		thread.BuildChannelID("grpA", "thr1"): true,
-		thread.BuildChannelID("grpA", "thr2"): true,
+		thread.BuildChannelID("grpNorm1", "thr_n1_a"): true,
+		thread.BuildChannelID("grpNorm1", "thr_n1_b"): true,
+		thread.BuildChannelID("grpNorm2", "thr_n2_a"): true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("normal groups must be fully surfaced (want %d refs, got %d)", len(want), len(got))
 	}
 	for _, r := range got {
 		if !want[r.OSChannelID] {
-			t.Errorf("unexpected channelId in partial result: %q", r.OSChannelID)
+			t.Errorf("unexpected channelId in normal-group allowlist: %q", r.OSChannelID)
 		}
 		if r.ChannelType != channelTypeThread {
 			t.Errorf("ChannelType must be thread=5; got %d", r.ChannelType)
-		}
-	}
-	// grpZ (the silently-tail-dropped group) yields nothing — that's
-	// exactly the symptom the WARN emitted above exists to make visible.
-	skippedPrefix := "grpZ" + thread.ChannelIDSeparator
-	for _, r := range got {
-		if strings.HasPrefix(r.OSChannelID, skippedPrefix) {
-			t.Errorf("tail-dropped group must yield no rows here; leaked %q", r.OSChannelID)
 		}
 	}
 }
@@ -512,8 +519,8 @@ func TestEnumerateThreadsForGroups_NoTrailingBlankInflation(t *testing.T) {
 	groupNos = append(groupNos, tail)
 	enumMap[tail] = []string{"tail_a", "tail_b", "tail_c"}
 
-	h.threadEnumFn = func([]string) (map[string][]string, bool, error) {
-		return enumMap, false, nil
+	h.threadEnumFn = func([]string) (map[string][]string, error) {
+		return enumMap, nil
 	}
 
 	got := h.enumerateThreadsForGroups(groupNos)
@@ -563,8 +570,8 @@ func TestBuildAllowlist_ArchivedThreadsIncluded(t *testing.T) {
 	// AND an archived thread from the same group both surface.
 	active := "thr_active"
 	archived := "thr_archived"
-	h.threadEnumFn = func(groupNos []string) (map[string][]string, bool, error) {
-		return map[string][]string{"grpA": {active, archived}}, false, nil
+	h.threadEnumFn = func(groupNos []string) (map[string][]string, error) {
+		return map[string][]string{"grpA": {active, archived}}, nil
 	}
 
 	_, _, allowThread, err := h.buildAllowlist(nil, loginUID, "")
@@ -609,10 +616,10 @@ func TestBuildAllowlist_DeletedThreadsExcluded(t *testing.T) {
 	// zero returned rows for the deleted thread — that's what the fixed
 	// enumerator does: `status != deleted` filter excludes deleted rows.
 	visible := "thr_visible"
-	h.threadEnumFn = func(groupNos []string) (map[string][]string, bool, error) {
+	h.threadEnumFn = func(groupNos []string) (map[string][]string, error) {
 		// Deleted shortID is deliberately NOT in the returned map — same
 		// as what QueryNonDeletedShortIDsByGroupNos does at the SQL level.
-		return map[string][]string{"grpA": {visible}}, false, nil
+		return map[string][]string{"grpA": {visible}}, nil
 	}
 
 	_, _, allowThread, err := h.buildAllowlist(nil, loginUID, "")
@@ -653,10 +660,10 @@ func TestResolveGlobalScope_ArchivedThreadNarrowingHits(t *testing.T) {
 	h := newAllowlistHandler(t, gSvc, uSvc)
 	archivedShortID := "thr_archived"
 	archivedChan := thread.BuildChannelID("grpA", archivedShortID)
-	h.threadEnumFn = func([]string) (map[string][]string, bool, error) {
+	h.threadEnumFn = func([]string) (map[string][]string, error) {
 		// Post-fix enumerator would return archived alongside active. Here
 		// we simulate only the archived one to prove the narrowing hits it.
-		return map[string][]string{"grpA": {archivedShortID}}, false, nil
+		return map[string][]string{"grpA": {archivedShortID}}, nil
 	}
 
 	c, _ := newValidatorCtx(t)

--- a/modules/messages_search/search_global_thread_test.go
+++ b/modules/messages_search/search_global_thread_test.go
@@ -175,27 +175,47 @@ func TestBuildAllowlist_ThreadPerGroupCap(t *testing.T) {
 // TestBuildAllowlist_ThreadGlobalAggregateCap — once the running total of
 // thread channelIDs would cross maxTotalThreadChannelIDs on the NEXT group,
 // remaining groups are skipped (their group entries still populate).
+//
+// Real-cap coverage (RC N1 on PR #553): the previous version of this test
+// filled a single "grpB" with `maxTotalThreadChannelIDs - 100` (=1900) rows,
+// which exceeded maxThreadsPerGroup (=200) and made the test t.Skip — so
+// the global-cap branch was never actually exercised. This version uses N
+// groups each filled up to (but not over) the per-group cap, so the sum
+// crosses the global cap while every individual group is under the
+// per-group cap. That way we hit the aggregate-cap `break` and not the
+// per-group `continue`.
 func TestBuildAllowlist_ThreadGlobalAggregateCap(t *testing.T) {
 	loginUID := "me"
-	// Craft two groups whose combined thread count would exceed the global
-	// cap but each individually is under the per-group cap. We deliberately
-	// stay under maxThreadsPerGroup so the cap under test is the global one.
-	// Choose sizes: A = 150, B = maxTotalThreadChannelIDs - 100 (so A+B > cap
-	// while A < maxThreadsPerGroup < B is possible only if the global cap is
-	// > per-group cap, which is our config).
-	sizeA := 150
-	sizeB := maxTotalThreadChannelIDs - 100 // guarantees A + B > global cap
-	if sizeB > maxThreadsPerGroup {
-		// If someone lowers the global cap under the per-group cap, this test
-		// stops being meaningful for the global cap — skip loudly.
-		t.Skipf("test config assumes maxTotalThreadChannelIDs (%d) > maxThreadsPerGroup (%d)",
-			maxTotalThreadChannelIDs, maxThreadsPerGroup)
+
+	// Design: fill N groups each with `maxThreadsPerGroup` shortIDs. Choose
+	// N so that N * maxThreadsPerGroup > maxTotalThreadChannelIDs while
+	// (N-1) * maxThreadsPerGroup < maxTotalThreadChannelIDs. That gives a
+	// deterministic break point on the Nth group: (N-1) groups fit, the Nth
+	// group would push us past the aggregate cap.
+	//
+	// With the shipped constants (per-group=200, total=2000): N=11 gives
+	// 10 * 200 = 2000 fitting exactly, and adding the 11th (200 more) would
+	// exceed 2000 — so grpN is skipped whole and allowThread has exactly
+	// 2000 entries drawn from groups 0..9. (`total + len(shortIDs) > cap`
+	// is a strict >; total==cap after group 9 makes `2000 + 200 > 2000`
+	// true for group 10, triggering the break.)
+	perGroup := maxThreadsPerGroup
+	if perGroup <= 0 {
+		t.Fatalf("maxThreadsPerGroup must be > 0; got %d", perGroup)
 	}
-	gSvc := &stubGroupSvc{
-		groupsByUID: map[string][]*group.InfoResp{
-			loginUID: {{GroupNo: "grpA"}, {GroupNo: "grpB"}},
-		},
+	numGroups := (maxTotalThreadChannelIDs / perGroup) + 1 // guarantees N*perGroup > cap
+	if (numGroups-1)*perGroup > maxTotalThreadChannelIDs {
+		t.Fatalf("config sanity: expected (N-1)*perGroup <= cap, got %d > %d",
+			(numGroups-1)*perGroup, maxTotalThreadChannelIDs)
 	}
+	groupNames := make([]string, 0, numGroups)
+	groupsSlice := make([]*group.InfoResp, 0, numGroups)
+	for i := 0; i < numGroups; i++ {
+		name := "grp" + itoa(i)
+		groupNames = append(groupNames, name)
+		groupsSlice = append(groupsSlice, &group.InfoResp{GroupNo: name})
+	}
+	gSvc := &stubGroupSvc{groupsByUID: map[string][]*group.InfoResp{loginUID: groupsSlice}}
 	uSvc := &stubUserSvc{}
 	h := newAllowlistHandler(t, gSvc, uSvc)
 	makeIDs := func(prefix string, n int) []string {
@@ -206,27 +226,55 @@ func TestBuildAllowlist_ThreadGlobalAggregateCap(t *testing.T) {
 		return out
 	}
 	h.threadEnumFn = func([]string) (map[string][]string, error) {
-		return map[string][]string{
-			"grpA": makeIDs("a", sizeA),
-			"grpB": makeIDs("b", sizeB),
-		}, nil
+		m := make(map[string][]string, numGroups)
+		for _, gn := range groupNames {
+			m[gn] = makeIDs(gn+"_thr", perGroup)
+		}
+		return m, nil
 	}
 
 	_, _, allowThread, err := h.buildAllowlist(nil, loginUID, "")
 	if err != nil {
 		t.Fatalf("buildAllowlist: %v", err)
 	}
-	// Deterministic iteration is groupNos order. grpA fits under the running
-	// total; grpB pushes past and is skipped whole (we do NOT partial-fill
-	// a group — simpler, avoids "some threads visible, some not" UX).
-	if len(allowThread) != sizeA {
-		t.Fatalf("expected exactly grpA's %d threads under global cap, got %d",
-			sizeA, len(allowThread))
+	// (a) Aggregate cap actually kicked in: total must not exceed the cap.
+	if len(allowThread) > maxTotalThreadChannelIDs {
+		t.Fatalf("allowThread must respect global cap %d; got %d",
+			maxTotalThreadChannelIDs, len(allowThread))
 	}
-	prefix := "grpA" + thread.ChannelIDSeparator
+	// (b) It kicked in on the RIGHT group: the last group's threads must
+	//     be missing entirely (skipped whole, not partial-filled).
+	skippedPrefix := groupNames[numGroups-1] + thread.ChannelIDSeparator
 	for _, r := range allowThread {
-		if !strings.HasPrefix(r.OSChannelID, prefix) {
-			t.Errorf("unexpected non-grpA thread in allowlist: %q", r.OSChannelID)
+		if strings.HasPrefix(r.OSChannelID, skippedPrefix) {
+			t.Errorf("grp that trips aggregate cap must be skipped WHOLE; leaked %q",
+				r.OSChannelID)
+		}
+	}
+	// (c) Preceding groups populated exactly: we expect (numGroups-1) groups
+	//     each at perGroup entries when (N-1)*perGroup <= cap.
+	wantFitted := (numGroups - 1) * perGroup
+	if wantFitted > maxTotalThreadChannelIDs {
+		wantFitted = maxTotalThreadChannelIDs
+	}
+	if len(allowThread) != wantFitted {
+		t.Fatalf("expected exactly %d thread entries under global cap, got %d",
+			wantFitted, len(allowThread))
+	}
+	// (d) Each fitted group must show up with all `perGroup` shortIDs.
+	perGroupCount := make(map[string]int)
+	for _, r := range allowThread {
+		for _, gn := range groupNames[:numGroups-1] {
+			if strings.HasPrefix(r.OSChannelID, gn+thread.ChannelIDSeparator) {
+				perGroupCount[gn]++
+				break
+			}
+		}
+	}
+	for _, gn := range groupNames[:numGroups-1] {
+		if perGroupCount[gn] != perGroup {
+			t.Errorf("group %s: expected %d threads, got %d",
+				gn, perGroup, perGroupCount[gn])
 		}
 	}
 }
@@ -364,3 +412,138 @@ func TestResolveGlobalScope_ThreadOutsideMembership(t *testing.T) {
 }
 
 // itoa is provided by visibility_test.go in this package — no local copy.
+
+// TestBuildAllowlist_ArchivedThreadsIncluded — RC blocker on PR #553:
+// archived (=2) threads must be surfaced by global search, matching the
+// single-channel search / message-read contract of "reject deleted, allow
+// archived". The stub returns whatever the underlying DB call would return;
+// after the fix, that call is QueryNonDeletedShortIDsByGroupNos which
+// surfaces status IN (active, archived). This test locks the invariant that
+// whatever the enumerator returns — including shortIDs the DB layer classes
+// as archived — lands in the allowlist verbatim (no downstream status
+// re-filter is silently applied).
+func TestBuildAllowlist_ArchivedThreadsIncluded(t *testing.T) {
+	loginUID := "me"
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			loginUID: {{GroupNo: "grpA"}},
+		},
+	}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	// The stub simulates the fixed enumerator behaviour: an active thread
+	// AND an archived thread from the same group both surface.
+	active := "thr_active"
+	archived := "thr_archived"
+	h.threadEnumFn = func(groupNos []string) (map[string][]string, error) {
+		return map[string][]string{"grpA": {active, archived}}, nil
+	}
+
+	_, _, allowThread, err := h.buildAllowlist(nil, loginUID, "")
+	if err != nil {
+		t.Fatalf("buildAllowlist: %v", err)
+	}
+	want := map[string]bool{
+		thread.BuildChannelID("grpA", active):   true,
+		thread.BuildChannelID("grpA", archived): true,
+	}
+	if len(allowThread) != len(want) {
+		t.Fatalf("expected %d threads (active + archived), got %d (%+v)",
+			len(want), len(allowThread), allowThread)
+	}
+	for _, r := range allowThread {
+		if !want[r.OSChannelID] {
+			t.Errorf("unexpected channelId %q in allowlist", r.OSChannelID)
+		}
+		delete(want, r.OSChannelID)
+	}
+	if len(want) > 0 {
+		t.Errorf("missing expected channelIds: %v", want)
+	}
+}
+
+// TestBuildAllowlist_DeletedThreadsExcluded — RC blocker on PR #553:
+// deleted threads must NOT leak into the allowlist. The DB-level
+// enforcement lives in QueryNonDeletedShortIDsByGroupNos (`status !=
+// ThreadStatusDeleted`); this stub-level test locks the invariant that
+// the enumerator's exclusions are respected verbatim by buildAllowlist
+// (no rediscovery / re-widening downstream).
+func TestBuildAllowlist_DeletedThreadsExcluded(t *testing.T) {
+	loginUID := "me"
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			loginUID: {{GroupNo: "grpA"}},
+		},
+	}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	// The stub simulates a group that has one visible (active) thread and
+	// zero returned rows for the deleted thread — that's what the fixed
+	// enumerator does: `status != deleted` filter excludes deleted rows.
+	visible := "thr_visible"
+	h.threadEnumFn = func(groupNos []string) (map[string][]string, error) {
+		// Deleted shortID is deliberately NOT in the returned map — same
+		// as what QueryNonDeletedShortIDsByGroupNos does at the SQL level.
+		return map[string][]string{"grpA": {visible}}, nil
+	}
+
+	_, _, allowThread, err := h.buildAllowlist(nil, loginUID, "")
+	if err != nil {
+		t.Fatalf("buildAllowlist: %v", err)
+	}
+	if len(allowThread) != 1 {
+		t.Fatalf("expected exactly 1 thread (deleted excluded), got %d (%+v)",
+			len(allowThread), allowThread)
+	}
+	wantID := thread.BuildChannelID("grpA", visible)
+	if allowThread[0].OSChannelID != wantID {
+		t.Errorf("expected %q, got %q", wantID, allowThread[0].OSChannelID)
+	}
+	// And a deleted shortID must not appear via any path.
+	deletedID := thread.BuildChannelID("grpA", "thr_deleted")
+	for _, r := range allowThread {
+		if r.OSChannelID == deletedID {
+			t.Errorf("deleted thread channelId %q must not appear in allowlist", deletedID)
+		}
+	}
+}
+
+// TestResolveGlobalScope_ArchivedThreadNarrowingHits — RC blocker on
+// PR #553: an explicit narrowing to an archived thread (visible via
+// single-channel search, msg-read) must now also resolve on the global
+// endpoint. Before the fix, this collapsed to empty scope because
+// enumerateThreadsForGroups excluded archived shortIDs, so the requested
+// channelID was not in allowSet.
+func TestResolveGlobalScope_ArchivedThreadNarrowingHits(t *testing.T) {
+	loginUID := "me"
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			loginUID: {{GroupNo: "grpA"}},
+		},
+	}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	archivedShortID := "thr_archived"
+	archivedChan := thread.BuildChannelID("grpA", archivedShortID)
+	h.threadEnumFn = func([]string) (map[string][]string, error) {
+		// Post-fix enumerator would return archived alongside active. Here
+		// we simulate only the archived one to prove the narrowing hits it.
+		return map[string][]string{"grpA": {archivedShortID}}, nil
+	}
+
+	c, _ := newValidatorCtx(t)
+	osIDs, _, singleFast, ok := h.resolveGlobalScope(c, loginUID,
+		[]GlobalChannelRef{{ChannelID: archivedChan, ChannelType: channelTypeThread}}, "")
+	if !ok {
+		t.Fatalf("resolveGlobalScope must succeed; a response was already written")
+	}
+	if len(osIDs) != 1 || osIDs[0] != archivedChan {
+		t.Fatalf("scope must be exactly {%q}; got %v", archivedChan, osIDs)
+	}
+	if singleFast == nil {
+		t.Fatalf("single-channel fast path must fire for a lone archived-thread scope")
+	}
+	if singleFast.ChannelType != channelTypeThread || singleFast.OSChannelID != archivedChan {
+		t.Errorf("singleFast mismatch: %+v", singleFast)
+	}
+}

--- a/modules/messages_search/search_global_thread_test.go
+++ b/modules/messages_search/search_global_thread_test.go
@@ -55,7 +55,7 @@ func TestBuildAllowlist_IncludesThreadChannelIDs(t *testing.T) {
 	}
 	uSvc := &stubUserSvc{friends: []*user.FriendResp{}}
 	h := newAllowlistHandler(t, gSvc, uSvc)
-	h.threadEnumFn = func(groupNos []string) (map[string][]string, error) {
+	h.threadEnumFn = func(groupNos []string) (map[string][]string, bool, error) {
 		// Sanity: caller passes exactly the joined groups.
 		got := map[string]bool{}
 		for _, gn := range groupNos {
@@ -67,7 +67,7 @@ func TestBuildAllowlist_IncludesThreadChannelIDs(t *testing.T) {
 		return map[string][]string{
 			"grpA": {"thr1", "thr2"},
 			"grpB": {"thr3"},
-		}, nil
+		}, false, nil
 	}
 
 	allowGroup, _, allowThread, err := h.buildAllowlist(nil, loginUID, "")
@@ -101,7 +101,7 @@ func TestBuildAllowlist_IncludesThreadChannelIDs(t *testing.T) {
 }
 
 // TestBuildAllowlist_ThreadEnumerateSoftFail — a DB error inside
-// QueryActiveShortIDsByGroupNos must NOT sink the whole request; the
+// QueryNonDeletedShortIDsByGroupNos must NOT sink the whole request; the
 // group + DM parts still populate.
 func TestBuildAllowlist_ThreadEnumerateSoftFail(t *testing.T) {
 	loginUID := "me"
@@ -112,8 +112,8 @@ func TestBuildAllowlist_ThreadEnumerateSoftFail(t *testing.T) {
 	}
 	uSvc := &stubUserSvc{friends: []*user.FriendResp{{UID: "friend1"}}}
 	h := newAllowlistHandler(t, gSvc, uSvc)
-	h.threadEnumFn = func([]string) (map[string][]string, error) {
-		return nil, errors.New("mysql: connection refused")
+	h.threadEnumFn = func([]string) (map[string][]string, bool, error) {
+		return nil, false, errors.New("mysql: connection refused")
 	}
 
 	allowGroup, allowDM, allowThread, err := h.buildAllowlist(nil, loginUID, "")
@@ -147,11 +147,11 @@ func TestBuildAllowlist_ThreadPerGroupCap(t *testing.T) {
 	for i := range fat {
 		fat[i] = "thr" + itoa(i)
 	}
-	h.threadEnumFn = func([]string) (map[string][]string, error) {
+	h.threadEnumFn = func([]string) (map[string][]string, bool, error) {
 		return map[string][]string{
 			"grpFat":  fat,
 			"grpThin": {"thrOK"},
-		}, nil
+		}, false, nil
 	}
 
 	allowGroup, _, allowThread, err := h.buildAllowlist(nil, loginUID, "")
@@ -225,12 +225,12 @@ func TestBuildAllowlist_ThreadGlobalAggregateCap(t *testing.T) {
 		}
 		return out
 	}
-	h.threadEnumFn = func([]string) (map[string][]string, error) {
+	h.threadEnumFn = func([]string) (map[string][]string, bool, error) {
 		m := make(map[string][]string, numGroups)
 		for _, gn := range groupNames {
 			m[gn] = makeIDs(gn+"_thr", perGroup)
 		}
-		return m, nil
+		return m, false, nil
 	}
 
 	_, _, allowThread, err := h.buildAllowlist(nil, loginUID, "")
@@ -288,9 +288,9 @@ func TestBuildAllowlist_EmptyGroupsNoThreadQuery(t *testing.T) {
 	uSvc := &stubUserSvc{}
 	h := newAllowlistHandler(t, gSvc, uSvc)
 	called := false
-	h.threadEnumFn = func(groupNos []string) (map[string][]string, error) {
+	h.threadEnumFn = func(groupNos []string) (map[string][]string, bool, error) {
 		called = true
-		return nil, nil
+		return nil, false, nil
 	}
 
 	_, _, allowThread, err := h.buildAllowlist(nil, loginUID, "")
@@ -355,8 +355,8 @@ func TestResolveGlobalScope_ThreadNarrowingHits(t *testing.T) {
 	uSvc := &stubUserSvc{}
 	h := newAllowlistHandler(t, gSvc, uSvc)
 	threadID := thread.BuildChannelID("grpA", "thr1")
-	h.threadEnumFn = func([]string) (map[string][]string, error) {
-		return map[string][]string{"grpA": {"thr1"}}, nil
+	h.threadEnumFn = func([]string) (map[string][]string, bool, error) {
+		return map[string][]string{"grpA": {"thr1"}}, false, nil
 	}
 
 	// Build a validator context whose spaceID is empty so RequireSpaceID
@@ -391,9 +391,9 @@ func TestResolveGlobalScope_ThreadOutsideMembership(t *testing.T) {
 	}
 	uSvc := &stubUserSvc{}
 	h := newAllowlistHandler(t, gSvc, uSvc)
-	h.threadEnumFn = func([]string) (map[string][]string, error) {
+	h.threadEnumFn = func([]string) (map[string][]string, bool, error) {
 		// grpA has no threads; grpB is not in allowlist.
-		return map[string][]string{}, nil
+		return map[string][]string{}, false, nil
 	}
 
 	c, _ := newValidatorCtx(t)
@@ -412,6 +412,134 @@ func TestResolveGlobalScope_ThreadOutsideMembership(t *testing.T) {
 }
 
 // itoa is provided by visibility_test.go in this package — no local copy.
+
+// TestEnumerateThreadsForGroups_DBLimitHitStillReturnsResults — RC 2 on
+// PR #553. When the underlying DB signals `dbLimitHit=true` (i.e. the
+// SQL `LIMIT NonDeletedByGroupNosDBHardLimit` truncated the row set),
+// enumerateThreadsForGroups must still surface whatever rows *did* come
+// back (partial coverage is better than none) AND emit a WARN so tail-
+// group loss is observable rather than silent.
+//
+// The WARN itself lands in the process-wide zap logger (see
+// octo-lib/pkg/log/logger.go); this test doesn't capture stderr, but it
+// exercises the branch so a future regression that swallows dbLimitHit
+// silently (e.g. renaming the return arg to `_`) breaks the build /
+// test signature immediately.
+func TestEnumerateThreadsForGroups_DBLimitHitStillReturnsResults(t *testing.T) {
+	gSvc := &stubGroupSvc{}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	h.threadEnumFn = func(groupNos []string) (map[string][]string, bool, error) {
+		// Simulate: DB hit LIMIT, returned partial results (grpA got its
+		// two rows before the LIMIT ran out; a hypothetical grpZ tail
+		// group returned nothing).
+		return map[string][]string{
+			"grpA": {"thr1", "thr2"},
+			// grpZ intentionally absent — the "silent tail drop" symptom.
+		}, true /* dbLimitHit */, nil
+	}
+
+	got := h.enumerateThreadsForGroups([]string{"grpA", "grpZ"})
+	// Partial results survive: grpA's two threads still appear.
+	if len(got) != 2 {
+		t.Fatalf("partial results must still be returned on dbLimitHit; got %d refs", len(got))
+	}
+	want := map[string]bool{
+		thread.BuildChannelID("grpA", "thr1"): true,
+		thread.BuildChannelID("grpA", "thr2"): true,
+	}
+	for _, r := range got {
+		if !want[r.OSChannelID] {
+			t.Errorf("unexpected channelId in partial result: %q", r.OSChannelID)
+		}
+		if r.ChannelType != channelTypeThread {
+			t.Errorf("ChannelType must be thread=5; got %d", r.ChannelType)
+		}
+	}
+	// grpZ (the silently-tail-dropped group) yields nothing — that's
+	// exactly the symptom the WARN emitted above exists to make visible.
+	skippedPrefix := "grpZ" + thread.ChannelIDSeparator
+	for _, r := range got {
+		if strings.HasPrefix(r.OSChannelID, skippedPrefix) {
+			t.Errorf("tail-dropped group must yield no rows here; leaked %q", r.OSChannelID)
+		}
+	}
+}
+
+// TestEnumerateThreadsForGroups_NoTrailingBlankInflation — defensive: the
+// running total that gates the aggregate cap must count *appended* rows,
+// not raw `len(shortIDs)`. Production QueryNonDeletedShortIDsByGroupNos
+// strips blank shortIDs at the SQL parse boundary, but a future
+// threadEnumFn source (mock, alternative backend) may not. Verify a group
+// containing blank shortIDs contributes only its non-blank rows to the
+// caller's aggregate count, so a subsequent group is NOT prematurely
+// starved by phantom rows. (RC N3 on PR #553.)
+func TestEnumerateThreadsForGroups_NoTrailingBlankInflation(t *testing.T) {
+	gSvc := &stubGroupSvc{}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	// Design: N groups each holding K blanks + K real shortIDs, chosen so
+	// that:
+	//   sum(raw len) across N groups     > maxTotalThreadChannelIDs (2000)
+	//   sum(appended non-blank) across N groups <= maxTotalThreadChannelIDs
+	//   each group's raw len                    <= maxThreadsPerGroup (200)
+	// so per-group cap doesn't fire but the aggregate would fire with the
+	// buggy raw-count accounting. Correct accounting must let all N groups
+	// through and surface a trailing extra group's rows too.
+	const (
+		K      = 90 // per-group non-blank rows
+		blanks = 90 // per-group blank rows (raw len = 180, under per-group cap 200)
+		N      = 14 // N * (K+blanks) = 2520 > 2000 raw aggregate, N * K = 1260 well under
+	)
+	groupNos := make([]string, 0, N+1)
+	enumMap := make(map[string][]string, N+1)
+	for gi := 0; gi < N; gi++ {
+		gn := "grp_pad_" + itoa(gi)
+		groupNos = append(groupNos, gn)
+		ids := make([]string, 0, K+blanks)
+		for si := 0; si < K; si++ {
+			ids = append(ids, gn+"_thr_"+itoa(si))
+		}
+		for si := 0; si < blanks; si++ {
+			ids = append(ids, "") // blank shortIDs — must not inflate aggregate
+		}
+		enumMap[gn] = ids
+	}
+	// Extra tail group with 10 real threads. Under the bug this group is
+	// dropped whole (aggregate cap trips on inflated running total). Under
+	// the fix, it survives.
+	tail := "grp_tail"
+	groupNos = append(groupNos, tail)
+	enumMap[tail] = []string{"tail_a", "tail_b", "tail_c"}
+
+	h.threadEnumFn = func([]string) (map[string][]string, bool, error) {
+		return enumMap, false, nil
+	}
+
+	got := h.enumerateThreadsForGroups(groupNos)
+
+	// Expect exactly N*K + 3 non-blank refs — tail group survives.
+	wantTotal := N*K + 3
+	if len(got) != wantTotal {
+		t.Fatalf("expected %d non-blank refs (N*K + tail); got %d", wantTotal, len(got))
+	}
+	// Confirm tail group actually surfaced (this is the load-bearing check
+	// for the `total += appended` fix; the buggy `total += len(shortIDs)`
+	// would starve it).
+	tailPrefix := tail + thread.ChannelIDSeparator
+	tailHits := 0
+	for _, r := range got {
+		if r.OSChannelID == "" {
+			t.Errorf("blank channelId must never surface")
+		}
+		if strings.HasPrefix(r.OSChannelID, tailPrefix) {
+			tailHits++
+		}
+	}
+	if tailHits != 3 {
+		t.Errorf("tail group must contribute 3 refs (fix for raw-len inflation); got %d", tailHits)
+	}
+}
 
 // TestBuildAllowlist_ArchivedThreadsIncluded — RC blocker on PR #553:
 // archived (=2) threads must be surfaced by global search, matching the
@@ -435,8 +563,8 @@ func TestBuildAllowlist_ArchivedThreadsIncluded(t *testing.T) {
 	// AND an archived thread from the same group both surface.
 	active := "thr_active"
 	archived := "thr_archived"
-	h.threadEnumFn = func(groupNos []string) (map[string][]string, error) {
-		return map[string][]string{"grpA": {active, archived}}, nil
+	h.threadEnumFn = func(groupNos []string) (map[string][]string, bool, error) {
+		return map[string][]string{"grpA": {active, archived}}, false, nil
 	}
 
 	_, _, allowThread, err := h.buildAllowlist(nil, loginUID, "")
@@ -481,10 +609,10 @@ func TestBuildAllowlist_DeletedThreadsExcluded(t *testing.T) {
 	// zero returned rows for the deleted thread — that's what the fixed
 	// enumerator does: `status != deleted` filter excludes deleted rows.
 	visible := "thr_visible"
-	h.threadEnumFn = func(groupNos []string) (map[string][]string, error) {
+	h.threadEnumFn = func(groupNos []string) (map[string][]string, bool, error) {
 		// Deleted shortID is deliberately NOT in the returned map — same
 		// as what QueryNonDeletedShortIDsByGroupNos does at the SQL level.
-		return map[string][]string{"grpA": {visible}}, nil
+		return map[string][]string{"grpA": {visible}}, false, nil
 	}
 
 	_, _, allowThread, err := h.buildAllowlist(nil, loginUID, "")
@@ -525,10 +653,10 @@ func TestResolveGlobalScope_ArchivedThreadNarrowingHits(t *testing.T) {
 	h := newAllowlistHandler(t, gSvc, uSvc)
 	archivedShortID := "thr_archived"
 	archivedChan := thread.BuildChannelID("grpA", archivedShortID)
-	h.threadEnumFn = func([]string) (map[string][]string, error) {
+	h.threadEnumFn = func([]string) (map[string][]string, bool, error) {
 		// Post-fix enumerator would return archived alongside active. Here
 		// we simulate only the archived one to prove the narrowing hits it.
-		return map[string][]string{"grpA": {archivedShortID}}, nil
+		return map[string][]string{"grpA": {archivedShortID}}, false, nil
 	}
 
 	c, _ := newValidatorCtx(t)

--- a/modules/messages_search/search_global_thread_test.go
+++ b/modules/messages_search/search_global_thread_test.go
@@ -1,0 +1,366 @@
+package messages_search
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+)
+
+// YUJ-10 · v1 thread coverage on the global endpoints.
+//
+// buildAllowlist / enumerateThreadsForGroups now surface active threads as
+// composite `{groupNo}____{shortID}` channelIds alongside groups + DMs, with
+// soft-fail on DB errors and two hard caps (per-group + global aggregate).
+// These tests exercise every branch of that path without touching a real
+// MySQL / OpenSearch instance.
+
+// newAllowlistHandler wires the minimal Handler surface needed by
+// buildAllowlist + enumerateThreadsForGroups. threadEnumFn is left nil per
+// test so each case decides what the "DB" returns.
+func newAllowlistHandler(t *testing.T, gSvc group.IService, uSvc user.IService) *Handler {
+	t.Helper()
+	h := &Handler{
+		Log:          log.NewTLog("messages_search-thread-test"),
+		cfg:          SearchConfig{},
+		userService:  uSvc,
+		groupService: gSvc,
+		cache:        newSenderCache(4, 0),
+	}
+	// External-group / space_member / bot lookups are unused by these tests
+	// but the buildAllowlist helper still walks them. Space-related stubs
+	// short-circuit to empty so buildAllowlist stays local.
+	h.spaceMembersFn = func(string, string) ([]string, error) { return nil, nil }
+	h.dmBotFilterFn = func(_ string, peers []string) ([]string, error) { return peers, nil }
+	h.externalGroupFn = func(string) (map[string]string, error) { return map[string]string{}, nil }
+	return h
+}
+
+// TestBuildAllowlist_IncludesThreadChannelIDs — the load-bearing YUJ-10
+// assertion: threads under joined groups appear in the flat allowlist with
+// channelType=5 and the composite `{groupNo}____{shortID}` channelId.
+func TestBuildAllowlist_IncludesThreadChannelIDs(t *testing.T) {
+	loginUID := "me"
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			loginUID: {
+				{GroupNo: "grpA", SpaceID: ""},
+				{GroupNo: "grpB", SpaceID: ""},
+			},
+		},
+	}
+	uSvc := &stubUserSvc{friends: []*user.FriendResp{}}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	h.threadEnumFn = func(groupNos []string) (map[string][]string, error) {
+		// Sanity: caller passes exactly the joined groups.
+		got := map[string]bool{}
+		for _, gn := range groupNos {
+			got[gn] = true
+		}
+		if !got["grpA"] || !got["grpB"] {
+			t.Fatalf("threadEnumFn must receive joined groups; got %v", groupNos)
+		}
+		return map[string][]string{
+			"grpA": {"thr1", "thr2"},
+			"grpB": {"thr3"},
+		}, nil
+	}
+
+	allowGroup, _, allowThread, err := h.buildAllowlist(nil, loginUID, "")
+	if err != nil {
+		t.Fatalf("buildAllowlist: %v", err)
+	}
+	if len(allowGroup) != 2 {
+		t.Fatalf("group allowlist should have 2 entries, got %d", len(allowGroup))
+	}
+	want := map[string]bool{
+		thread.BuildChannelID("grpA", "thr1"): true,
+		thread.BuildChannelID("grpA", "thr2"): true,
+		thread.BuildChannelID("grpB", "thr3"): true,
+	}
+	if len(allowThread) != len(want) {
+		t.Fatalf("thread allowlist should have %d entries, got %d (%+v)",
+			len(want), len(allowThread), allowThread)
+	}
+	for _, r := range allowThread {
+		if !want[r.OSChannelID] {
+			t.Errorf("unexpected thread channelId %q", r.OSChannelID)
+		}
+		if r.ChannelType != channelTypeThread {
+			t.Errorf("thread channelRef must have channelType=5, got %d", r.ChannelType)
+		}
+		if r.WireID != r.OSChannelID {
+			// Thread channelId is echoed to the wire verbatim (no reversal).
+			t.Errorf("thread WireID must equal OSChannelID; got %q vs %q", r.WireID, r.OSChannelID)
+		}
+	}
+}
+
+// TestBuildAllowlist_ThreadEnumerateSoftFail — a DB error inside
+// QueryActiveShortIDsByGroupNos must NOT sink the whole request; the
+// group + DM parts still populate.
+func TestBuildAllowlist_ThreadEnumerateSoftFail(t *testing.T) {
+	loginUID := "me"
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			loginUID: {{GroupNo: "grpA"}},
+		},
+	}
+	uSvc := &stubUserSvc{friends: []*user.FriendResp{{UID: "friend1"}}}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	h.threadEnumFn = func([]string) (map[string][]string, error) {
+		return nil, errors.New("mysql: connection refused")
+	}
+
+	allowGroup, allowDM, allowThread, err := h.buildAllowlist(nil, loginUID, "")
+	if err != nil {
+		t.Fatalf("thread DB error must NOT propagate; got %v", err)
+	}
+	if len(allowGroup) != 1 {
+		t.Errorf("group allowlist must survive thread failure; got %+v", allowGroup)
+	}
+	if len(allowDM) != 1 {
+		t.Errorf("DM allowlist must survive thread failure; got %+v", allowDM)
+	}
+	if len(allowThread) != 0 {
+		t.Errorf("thread allowlist must be empty on DB error; got %+v", allowThread)
+	}
+}
+
+// TestBuildAllowlist_ThreadPerGroupCap — a group whose thread count exceeds
+// maxThreadsPerGroup downgrades to group-only for this request (its group
+// entry still populates, no thread entries).
+func TestBuildAllowlist_ThreadPerGroupCap(t *testing.T) {
+	loginUID := "me"
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			loginUID: {{GroupNo: "grpFat"}, {GroupNo: "grpThin"}},
+		},
+	}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	fat := make([]string, maxThreadsPerGroup+1)
+	for i := range fat {
+		fat[i] = "thr" + itoa(i)
+	}
+	h.threadEnumFn = func([]string) (map[string][]string, error) {
+		return map[string][]string{
+			"grpFat":  fat,
+			"grpThin": {"thrOK"},
+		}, nil
+	}
+
+	allowGroup, _, allowThread, err := h.buildAllowlist(nil, loginUID, "")
+	if err != nil {
+		t.Fatalf("buildAllowlist: %v", err)
+	}
+	// Group side unchanged: both groups still in the flat allowlist.
+	gotGroups := map[string]bool{}
+	for _, r := range allowGroup {
+		gotGroups[r.OSChannelID] = true
+	}
+	if !gotGroups["grpFat"] || !gotGroups["grpThin"] {
+		t.Errorf("group allowlist must contain both groups; got %+v", allowGroup)
+	}
+	// Thread side: only grpThin's one thread. grpFat is downgraded.
+	if len(allowThread) != 1 || allowThread[0].OSChannelID != thread.BuildChannelID("grpThin", "thrOK") {
+		t.Errorf("only grpThin's single thread should survive the per-group cap; got %+v", allowThread)
+	}
+}
+
+// TestBuildAllowlist_ThreadGlobalAggregateCap — once the running total of
+// thread channelIDs would cross maxTotalThreadChannelIDs on the NEXT group,
+// remaining groups are skipped (their group entries still populate).
+func TestBuildAllowlist_ThreadGlobalAggregateCap(t *testing.T) {
+	loginUID := "me"
+	// Craft two groups whose combined thread count would exceed the global
+	// cap but each individually is under the per-group cap. We deliberately
+	// stay under maxThreadsPerGroup so the cap under test is the global one.
+	// Choose sizes: A = 150, B = maxTotalThreadChannelIDs - 100 (so A+B > cap
+	// while A < maxThreadsPerGroup < B is possible only if the global cap is
+	// > per-group cap, which is our config).
+	sizeA := 150
+	sizeB := maxTotalThreadChannelIDs - 100 // guarantees A + B > global cap
+	if sizeB > maxThreadsPerGroup {
+		// If someone lowers the global cap under the per-group cap, this test
+		// stops being meaningful for the global cap — skip loudly.
+		t.Skipf("test config assumes maxTotalThreadChannelIDs (%d) > maxThreadsPerGroup (%d)",
+			maxTotalThreadChannelIDs, maxThreadsPerGroup)
+	}
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			loginUID: {{GroupNo: "grpA"}, {GroupNo: "grpB"}},
+		},
+	}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	makeIDs := func(prefix string, n int) []string {
+		out := make([]string, n)
+		for i := 0; i < n; i++ {
+			out[i] = prefix + itoa(i)
+		}
+		return out
+	}
+	h.threadEnumFn = func([]string) (map[string][]string, error) {
+		return map[string][]string{
+			"grpA": makeIDs("a", sizeA),
+			"grpB": makeIDs("b", sizeB),
+		}, nil
+	}
+
+	_, _, allowThread, err := h.buildAllowlist(nil, loginUID, "")
+	if err != nil {
+		t.Fatalf("buildAllowlist: %v", err)
+	}
+	// Deterministic iteration is groupNos order. grpA fits under the running
+	// total; grpB pushes past and is skipped whole (we do NOT partial-fill
+	// a group — simpler, avoids "some threads visible, some not" UX).
+	if len(allowThread) != sizeA {
+		t.Fatalf("expected exactly grpA's %d threads under global cap, got %d",
+			sizeA, len(allowThread))
+	}
+	prefix := "grpA" + thread.ChannelIDSeparator
+	for _, r := range allowThread {
+		if !strings.HasPrefix(r.OSChannelID, prefix) {
+			t.Errorf("unexpected non-grpA thread in allowlist: %q", r.OSChannelID)
+		}
+	}
+}
+
+// TestBuildAllowlist_EmptyGroupsNoThreadQuery — no joined groups means no
+// thread enumeration at all. The DB stub must not be called (avoiding a
+// pointless `IN ()` query).
+func TestBuildAllowlist_EmptyGroupsNoThreadQuery(t *testing.T) {
+	loginUID := "me"
+	gSvc := &stubGroupSvc{groupsByUID: map[string][]*group.InfoResp{loginUID: nil}}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	called := false
+	h.threadEnumFn = func(groupNos []string) (map[string][]string, error) {
+		called = true
+		return nil, nil
+	}
+
+	_, _, allowThread, err := h.buildAllowlist(nil, loginUID, "")
+	if err != nil {
+		t.Fatalf("buildAllowlist: %v", err)
+	}
+	if called {
+		t.Errorf("threadEnumFn must NOT be called when the caller has no joined groups")
+	}
+	if len(allowThread) != 0 {
+		t.Errorf("thread allowlist must be empty; got %+v", allowThread)
+	}
+}
+
+// TestChannelsForMember_DropsThreadsInV1 — the member_uid filter path is v1
+// simplified: thread entries in allowSet are dropped from the returned
+// scope entirely, regardless of the parent group's co-inhabitance.
+func TestChannelsForMember_DropsThreadsInV1(t *testing.T) {
+	loginUID := "me"
+	memberUID := "colleague"
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			memberUID: {{GroupNo: "grpShared"}},
+		},
+	}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	// Simulate an already-built allowSet with a group + a thread under it +
+	// a DM. channelsForMember should keep the group + DM (co-inhabitance /
+	// direct DM) but strip the thread.
+	threadID := thread.BuildChannelID("grpShared", "thrX")
+	allowSet := map[string]channelRef{
+		"grpShared": {OSChannelID: "grpShared", WireID: "grpShared", ChannelType: channelTypeGroup},
+		threadID:    {OSChannelID: threadID, WireID: threadID, ChannelType: channelTypeThread},
+		"dmFake":    {OSChannelID: "dmFake", WireID: memberUID, ChannelType: channelTypePerson},
+	}
+	got, err := h.channelsForMember(loginUID, memberUID, "", allowSet)
+	if err != nil {
+		t.Fatalf("channelsForMember: %v", err)
+	}
+	if _, ok := got["grpShared"]; !ok {
+		t.Errorf("shared group must be kept; got %+v", got)
+	}
+	if _, ok := got["dmFake"]; !ok {
+		t.Errorf("DM with member must be kept; got %+v", got)
+	}
+	if _, ok := got[threadID]; ok {
+		t.Errorf("thread must be dropped in v1 channelsForMember; got %+v", got)
+	}
+}
+
+// TestResolveGlobalScope_ThreadNarrowingHits — a request explicitly narrowing
+// to a thread channel_id under a joined group resolves scope = {threadID}
+// (no longer fail-closed).
+func TestResolveGlobalScope_ThreadNarrowingHits(t *testing.T) {
+	loginUID := "me"
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			loginUID: {{GroupNo: "grpA"}},
+		},
+	}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	threadID := thread.BuildChannelID("grpA", "thr1")
+	h.threadEnumFn = func([]string) (map[string][]string, error) {
+		return map[string][]string{"grpA": {"thr1"}}, nil
+	}
+
+	// Build a validator context whose spaceID is empty so RequireSpaceID
+	// stays off (the default) and resolveGlobalScope proceeds without a
+	// Space gate.
+	c, _ := newValidatorCtx(t)
+	osIDs, _, singleFast, ok := h.resolveGlobalScope(c, loginUID,
+		[]GlobalChannelRef{{ChannelID: threadID, ChannelType: channelTypeThread}}, "")
+	if !ok {
+		t.Fatalf("resolveGlobalScope must succeed; a response was already written")
+	}
+	if len(osIDs) != 1 || osIDs[0] != threadID {
+		t.Fatalf("scope must be exactly {%q}; got %v", threadID, osIDs)
+	}
+	if singleFast == nil {
+		t.Fatalf("single-channel fast path must fire for a lone thread scope")
+	}
+	if singleFast.ChannelType != channelTypeThread || singleFast.OSChannelID != threadID {
+		t.Errorf("singleFast mismatch: %+v", singleFast)
+	}
+}
+
+// TestResolveGlobalScope_ThreadOutsideMembership — a request narrowing to a
+// thread under a group the caller is NOT in silently drops to an empty
+// scope (§6.3: unreachable channel_id is not a rejection).
+func TestResolveGlobalScope_ThreadOutsideMembership(t *testing.T) {
+	loginUID := "me"
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			loginUID: {{GroupNo: "grpA"}},
+		},
+	}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	h.threadEnumFn = func([]string) (map[string][]string, error) {
+		// grpA has no threads; grpB is not in allowlist.
+		return map[string][]string{}, nil
+	}
+
+	c, _ := newValidatorCtx(t)
+	foreignThread := thread.BuildChannelID("grpB", "thrX")
+	osIDs, _, singleFast, ok := h.resolveGlobalScope(c, loginUID,
+		[]GlobalChannelRef{{ChannelID: foreignThread, ChannelType: channelTypeThread}}, "")
+	if !ok {
+		t.Fatalf("resolveGlobalScope must succeed even when scope collapses to empty")
+	}
+	if len(osIDs) != 0 {
+		t.Errorf("scope must be empty for a thread outside membership; got %v", osIDs)
+	}
+	if singleFast != nil {
+		t.Errorf("singleFast must be nil when scope is empty; got %+v", singleFast)
+	}
+}
+
+// itoa is provided by visibility_test.go in this package — no local copy.

--- a/modules/messages_search/sender_join_integration_test.go
+++ b/modules/messages_search/sender_join_integration_test.go
@@ -68,6 +68,12 @@ type stubGroupSvc struct {
 	// active for uid; nil map means "all groupNos are active" (default).
 	activeGroupsForMember    map[string]map[string]bool
 	activeGroupsForMemberErr error
+
+	// groupsByUID is an alternate stub for GetGroupsWithMemberUID used by
+	// the thread-coverage tests (search_global_thread_test.go). When set,
+	// it takes precedence over groupsForMember.
+	groupsByUID    map[string][]*group.InfoResp
+	groupsByUIDErr error
 }
 
 func (s *stubGroupSvc) GetMembers(groupNo string) ([]*group.MemberResp, error) {
@@ -76,8 +82,15 @@ func (s *stubGroupSvc) GetMembers(groupNo string) ([]*group.MemberResp, error) {
 }
 
 // GetGroupsWithMemberUID returns the caller's groups, mirroring the
-// production interface but with a fixture-only map.
+// production interface but with a fixture-only map. If groupsByUID is set
+// (thread-coverage tests) it takes precedence over groupsForMember.
 func (s *stubGroupSvc) GetGroupsWithMemberUID(uid string) ([]*group.InfoResp, error) {
+	if s.groupsByUIDErr != nil {
+		return nil, s.groupsByUIDErr
+	}
+	if s.groupsByUID != nil {
+		return s.groupsByUID[uid], nil
+	}
 	if s.groupsForMemberErr != nil {
 		return nil, s.groupsForMemberErr
 	}

--- a/modules/thread/db.go
+++ b/modules/thread/db.go
@@ -257,6 +257,44 @@ func (d *DB) QueryNonDeletedShortIDs(shortIDs []string) ([]string, error) {
 	return result, nil
 }
 
+// GroupShortIDRow 是 QueryActiveShortIDsByGroupNos 内部的两列投影，只暴露包内使用。
+type GroupShortIDRow struct {
+	GroupNo string `db:"group_no"`
+	ShortID string `db:"short_id"`
+}
+
+// QueryActiveShortIDsByGroupNos 批量拉取一组 group 下 status=active 的子区 short_id，
+// 返回 map[groupNo][]shortID。用于 messages_search 全局端点构建 allowlist：
+// 单次 SELECT 走 (group_no, status, ...) 覆盖索引 idx_group_status_created_id
+// （见 modules/thread/sql/20260522000002_thread_group_status_created_index.sql），
+// 避免对每个 group 做一次子查询。
+//
+// 保护限制：
+//   - 空入参直接返回空 map，不下发 SQL；
+//   - 内部只取 (group_no, short_id) 两列，无 hot-column 回表；
+//   - 结果规模在调用方（messages_search buildAllowlist）再做「单群 shortID 上限」
+//     的降级判定；DB 层不硬砍上限以保留可观测性——若真的爆表也让 caller 明确处理。
+func (d *DB) QueryActiveShortIDsByGroupNos(groupNos []string) (map[string][]string, error) {
+	out := make(map[string][]string)
+	if len(groupNos) == 0 {
+		return out, nil
+	}
+	var rows []GroupShortIDRow
+	_, err := d.session.Select("group_no", "short_id").From("thread").
+		Where("group_no IN ? AND status=?", groupNos, ThreadStatusActive).
+		Load(&rows)
+	if err != nil {
+		return nil, fmt.Errorf("query active short ids by group nos: %w", err)
+	}
+	for _, r := range rows {
+		if r.GroupNo == "" || r.ShortID == "" {
+			continue
+		}
+		out[r.GroupNo] = append(out[r.GroupNo], r.ShortID)
+	}
+	return out, nil
+}
+
 // QueryActiveShortIDs 批量查询 status=active 的子区 shortID。
 // 用于 /v1/conversation/sync 过滤路径：archived/deleted 子区都不返回给客户端。
 // archived 子区由 server-side cron (#1376) 维护；收到消息时通过

--- a/modules/thread/db.go
+++ b/modules/thread/db.go
@@ -264,16 +264,37 @@ type GroupShortIDRow struct {
 	ShortID string `db:"short_id"`
 }
 
-// NonDeletedByGroupNosDBHardLimit 是 QueryNonDeletedShortIDsByGroupNos 在
-// DB 层的行数硬上限。它不是 messages_search 侧的语义 cap（那两个 cap
-// maxThreadsPerGroup=200 / maxTotalThreadChannelIDs=2000 仍在 caller 里做
-// 降级判定并留 WARN），而是一层雪崩保护：即使某个成员横跨极多群、每群又
-// 有极多非删除子区，也不会让单次 SELECT 把几十万行拉进内存。
+// NonDeletedByGroupNosPerGroupHardLimit 是 QueryNonDeletedShortIDsByGroupNos
+// 在 DB 层的**每群**行数硬上限。它必须 >= caller 的语义 cap
+// (messages_search.maxThreadsPerGroup=200) + 1，让 caller 侧的
+// "len(shortIDs) > maxThreadsPerGroup" 分支仍能感知到超 cap 的群并降级 +
+// WARN（RC 2/3 on PR #553）。
 //
-// 选值 2500 = maxTotalThreadChannelIDs(2000) × 1.25 缓冲，保证 caller 的
-// downgrade WARN 分支仍能被观测到（真正爆过 2000 才降级），同时把 pathological
-// 场景截在一个可预测的量级。**命中该 LIMIT 后必须由 caller 走 dbLimitHit 分支
-// 发 WARN**——见函数返回值 truncated（RC 2 on PR #553）。
+// 选值 201 = maxThreadsPerGroup(200) + 1：每群只多拉 1 行做观测信号，绝
+// 大多数群完整返回，只有超 cap 的群会被截到 201 行触发 caller 降级。
+const NonDeletedByGroupNosPerGroupHardLimit = 201
+
+// nonDeletedByGroupNosUnionBatchSize 控制 QueryNonDeletedShortIDsByGroupNos
+// 一次 UNION ALL 合并的群数。单次查询 SQL 长度 ≈ batchSize × (~120
+// chars/subquery)；40 个群 ≈ 5KB SQL，远低于 MySQL max_allowed_packet
+// 默认值，又保证一个普通用户（基本不超 40 个群）只发一次 roundtrip。
+const nonDeletedByGroupNosUnionBatchSize = 40
+
+// NonDeletedByGroupNosDBHardLimit was the pre-RC3 global row cap on the
+// old single-query implementation (2500 rows aggregated across all groups
+// via `ORDER BY group_no LIMIT 2500`). It caused the P1 starvation blocker
+// yujiawei called on RC 3 of PR #553: a single fat group with ≥ 2500 rows
+// consumed the entire budget, and every other group returned zero rows
+// from the DB — zeroing thread coverage for the whole request.
+//
+// The implementation is now per-group (see the UNION ALL path above), so
+// this global cap is obsolete. Retained only to keep a stable Go symbol
+// path for any downstream references while the fix stabilises; the value
+// is not consumed by any code path any longer and should be deleted in a
+// follow-up.
+//
+// Deprecated: superseded by NonDeletedByGroupNosPerGroupHardLimit. Do not
+// consume; there is no code path that reads it.
 const NonDeletedByGroupNosDBHardLimit = 2500
 
 // QueryNonDeletedShortIDsByGroupNos 批量拉取一组 group 下 **status != deleted** 的
@@ -289,53 +310,65 @@ const NonDeletedByGroupNosDBHardLimit = 2500
 // **单频道搜索能命中、全局搜不到**，破坏一致性。因为 archived 是 ArchiveStaleBatch
 // cron 例行转的（占比不小），影响面很大。
 //
-// **DB 层 hard bound**：LIMIT NonDeletedByGroupNosDBHardLimit 防雪崩 (PR #553):
-//   - caller 侧 (messages_search/search_global.go enumerateThreadsForGroups) 维持
-//     maxThreadsPerGroup / maxTotalThreadChannelIDs 两个语义 cap + WARN downgrade；
-//   - DB 层的 LIMIT 只是上限，避免重度用户 pathological 场景下一次 SELECT 拉几十万行入内
-//     存（MySQL 已返回全部行后才 downgrade 的旧行为在线上不可接受）。
-//   - **命中 LIMIT 与 caller 语义 cap 不等价**：语义 cap 触发时某个 group 返回「太多」
-//     并被 caller 显式降级 + WARN；DB LIMIT 触发时按 ORDER BY 排在尾部的整个 group
-//     可能返回「零 / 部分」行，caller 单看行数分不出「本来就没有」还是「被 SQL 截掉」。
-//     因此 truncated 返回值必须被 caller 观测并单独 WARN；否则重度用户（>2500 非删除
-//     子区）会静默丢失 thread 覆盖（RC 2 on PR #553）。
+// **每群 LIMIT via UNION ALL (RC 3 on PR #553)**：使用 `SELECT ... WHERE
+// group_no = ? ... ORDER BY short_id LIMIT PerGroupHardLimit` 的 UNION ALL
+// 合并（按 nonDeletedByGroupNosUnionBatchSize 分批），严格约束**每个 group
+// 最多返回 NonDeletedByGroupNosPerGroupHardLimit (=201) 行**。上一版用
+// 「全局 LIMIT 2500 + ORDER BY group_no, short_id」会让 group_no 排在前面
+// 的大群把整个 budget 吃光，导致排在后面的正常群一行都拿不到——即使
+// caller 侧对大群做了 `continue` 降级，正常群也因为 `byGroup[gn]` 为空
+// 被静默跳过，全请求的 thread 覆盖归零。切成 per-group LIMIT 后：
+//   - 大群精准降级到 group-only（返回 201 行 → caller 感知超 cap → WARN
+//     + 跳过该群 thread），
+//   - 其他正常群完整返回，thread 覆盖照常上线，
+//   - 不再存在 group 之间「谁排前面谁吃掉预算」的相互饿死。
 //
-// 排序：ORDER BY group_no, short_id 保证 LIMIT 截断在多群场景下确定——同一输入 groupNos
-// 集合总是拿到同一子集，避免引入不确定截断。
+// UNION ALL (非 DISTINCT UNION) 避免不必要的去重；子查询需用括号包裹
+// 以避免 ORDER BY / LIMIT 被外层吃掉。兼容性上：MySQL 5.7 / 8.0 /
+// MariaDB 均支持（避开 window function 的 8.0-only 依赖）。
 //
-// 索引：无覆盖排序索引与 (group_no IN, status != deleted) 组合完全匹配（idx_group_status
-// _created_id 是 (group_no, status, created_at, id)、uk_group_short 是 (group_no,
-// short_id) 不带 status），MySQL 大概率会 filesort，但 LIMIT=2500 把工作集截在可控
-// 量级——若这条路径变热应用 EXPLAIN 复核并考虑追加合适复合索引。
+// 排序：子查询 ORDER BY short_id 保证每群返回的 shortID 集合确定，同
+// 一输入总是拿到同一 201 行子集。外层无 ORDER BY（返回 map 自然无序，
+// caller 自己重新按 groupNos 迭代）。
+//
+// 索引：uk_group_short(group_no, short_id) 对 (group_no=?, ORDER BY short_id)
+// 是覆盖索引，若硬件/优化器给力可完全跑 range scan + limit push-down；
+// (group_no, status) 过滤则无现成复合索引，若该路径变热应用 EXPLAIN
+// 复核并考虑 (group_no, status, short_id) 复合索引。每子查询工作集被
+// 201 行截住，全局工作集被 len(groupNos)*201 截住。
 //
 // 保护限制：空入参直接返回空 map，不下发 SQL；内部只取 (group_no, short_id) 两列。
-//
-// 返回值 truncated 为 true 当且仅当返回的行数触到 LIMIT（`len(rows) == LIMIT`）。
-// 此时数据是「按 ORDER BY group_no, short_id 的前 LIMIT 行」，尾部 group 可能
-// 部分或全部缺失；caller **必须**将 truncated=true 视为观测点并发 WARN，以免
-// 静默降级（RC 2 on PR #553）。
-func (d *DB) QueryNonDeletedShortIDsByGroupNos(groupNos []string) (map[string][]string, bool, error) {
+func (d *DB) QueryNonDeletedShortIDsByGroupNos(groupNos []string) (map[string][]string, error) {
 	out := make(map[string][]string)
 	if len(groupNos) == 0 {
-		return out, false, nil
+		return out, nil
 	}
-	var rows []GroupShortIDRow
-	_, err := d.session.Select("group_no", "short_id").From("thread").
-		Where("group_no IN ? AND status != ?", groupNos, ThreadStatusDeleted).
-		OrderBy("group_no").OrderBy("short_id").
-		Limit(uint64(NonDeletedByGroupNosDBHardLimit)).
-		Load(&rows)
-	if err != nil {
-		return nil, false, fmt.Errorf("query non-deleted short ids by group nos: %w", err)
-	}
-	truncated := len(rows) >= NonDeletedByGroupNosDBHardLimit
-	for _, r := range rows {
-		if r.GroupNo == "" || r.ShortID == "" {
-			continue
+	for start := 0; start < len(groupNos); start += nonDeletedByGroupNosUnionBatchSize {
+		end := start + nonDeletedByGroupNosUnionBatchSize
+		if end > len(groupNos) {
+			end = len(groupNos)
 		}
-		out[r.GroupNo] = append(out[r.GroupNo], r.ShortID)
+		batch := groupNos[start:end]
+		subqueries := make([]string, len(batch))
+		args := make([]interface{}, 0, len(batch)*3)
+		for i, gn := range batch {
+			subqueries[i] = "(SELECT group_no, short_id FROM thread WHERE group_no = ? AND status != ? ORDER BY short_id LIMIT ?)"
+			args = append(args, gn, ThreadStatusDeleted, NonDeletedByGroupNosPerGroupHardLimit)
+		}
+		query := strings.Join(subqueries, " UNION ALL ")
+		var rows []GroupShortIDRow
+		_, err := d.session.SelectBySql(query, args...).Load(&rows)
+		if err != nil {
+			return nil, fmt.Errorf("query non-deleted short ids by group nos: %w", err)
+		}
+		for _, r := range rows {
+			if r.GroupNo == "" || r.ShortID == "" {
+				continue
+			}
+			out[r.GroupNo] = append(out[r.GroupNo], r.ShortID)
+		}
 	}
-	return out, truncated, nil
+	return out, nil
 }
 
 // QueryActiveShortIDs 批量查询 status=active 的子区 shortID。

--- a/modules/thread/db.go
+++ b/modules/thread/db.go
@@ -257,8 +257,8 @@ func (d *DB) QueryNonDeletedShortIDs(shortIDs []string) ([]string, error) {
 	return result, nil
 }
 
-// GroupShortIDRow 是 QueryActiveShortIDsByGroupNos /
-// QueryNonDeletedShortIDsByGroupNos 内部的两列投影，只暴露包内使用。
+// GroupShortIDRow 是 QueryNonDeletedShortIDsByGroupNos 内部的两列投影，只暴露
+// 包内使用。
 type GroupShortIDRow struct {
 	GroupNo string `db:"group_no"`
 	ShortID string `db:"short_id"`
@@ -272,50 +272,9 @@ type GroupShortIDRow struct {
 //
 // 选值 2500 = maxTotalThreadChannelIDs(2000) × 1.25 缓冲，保证 caller 的
 // downgrade WARN 分支仍能被观测到（真正爆过 2000 才降级），同时把 pathological
-// 场景截在一个可预测的量级。命中该 LIMIT 会在 caller 端的 running-total 计算
-// 里自然表现为「某些群拿到的 shortID 不全」——这种情况下 messages_search 侧本
-// 就会走 downgrade / skip 分支，语义等价于 caller 的 cap 触发。
+// 场景截在一个可预测的量级。**命中该 LIMIT 后必须由 caller 走 dbLimitHit 分支
+// 发 WARN**——见函数返回值 truncated（RC 2 on PR #553）。
 const NonDeletedByGroupNosDBHardLimit = 2500
-
-// QueryActiveShortIDsByGroupNos 批量拉取一组 group 下 status=active 的子区 short_id，
-// 返回 map[groupNo][]shortID。
-//
-// 语义（严格的「只看 active」）：archived / deleted 都不返回。
-//   - 保留原因：/v1/conversation/sync 等「只显示活跃子区」的路径仍依赖该语义
-//     和这套现有单测（db_batch_test.go::TestQueryActiveShortIDsByGroupNos）。
-//   - 注意：**messages_search 全局搜索的 allowlist 已不再用这个函数**，改用
-//     QueryNonDeletedShortIDsByGroupNos（archived 允许纳入），以对齐单频道搜索
-//     / getThreadMessage 的可见性契约（只拒 deleted）。参见 RC on PR #553。
-//
-// 单次 SELECT 走 (group_no, status, ...) 覆盖索引 idx_group_status_created_id
-// （见 modules/thread/sql/20260522000002_thread_group_status_created_index.sql），
-// 避免对每个 group 做一次子查询。
-//
-// 保护限制：
-//   - 空入参直接返回空 map，不下发 SQL；
-//   - 内部只取 (group_no, short_id) 两列，无 hot-column 回表；
-//   - 结果规模在调用方再做「单群 shortID 上限」的降级判定；DB 层不硬砍上限
-//     以保留可观测性——若真的爆表也让 caller 明确处理。
-func (d *DB) QueryActiveShortIDsByGroupNos(groupNos []string) (map[string][]string, error) {
-	out := make(map[string][]string)
-	if len(groupNos) == 0 {
-		return out, nil
-	}
-	var rows []GroupShortIDRow
-	_, err := d.session.Select("group_no", "short_id").From("thread").
-		Where("group_no IN ? AND status=?", groupNos, ThreadStatusActive).
-		Load(&rows)
-	if err != nil {
-		return nil, fmt.Errorf("query active short ids by group nos: %w", err)
-	}
-	for _, r := range rows {
-		if r.GroupNo == "" || r.ShortID == "" {
-			continue
-		}
-		out[r.GroupNo] = append(out[r.GroupNo], r.ShortID)
-	}
-	return out, nil
-}
 
 // QueryNonDeletedShortIDsByGroupNos 批量拉取一组 group 下 **status != deleted** 的
 // 子区 short_id（即 active + archived 都纳入，deleted 排除），返回 map[groupNo][]shortID。
@@ -326,27 +285,39 @@ func (d *DB) QueryActiveShortIDsByGroupNos(groupNos []string) (map[string][]stri
 //   - modules/messages_search/authz.go checkThreadAccess → modules/thread/service.go
 //     GetThread（service.go:102）：仅拒 deleted、返回 archived。
 //
-// 之前全局搜索用 QueryActiveShortIDsByGroupNos(status=active)，会把 archived 子区错
-// 误排除——归档子区 **单频道搜索能命中、全局搜不到**，破坏一致性。因为
-// archived 是 ArchiveStaleBatch cron 例行转的（占比不小），影响面很大。
+// 之前全局搜索用 status=active 变体，会把 archived 子区错误排除——归档子区
+// **单频道搜索能命中、全局搜不到**，破坏一致性。因为 archived 是 ArchiveStaleBatch
+// cron 例行转的（占比不小），影响面很大。
 //
-// **DB 层 hard bound**：LIMIT NonDeletedByGroupNosDBHardLimit 防雪崩 (RC N2、PR #553):
-//   - caller 侧 (messages_search/search_global.go enumerateThreadsForGroups) 仍维持
+// **DB 层 hard bound**：LIMIT NonDeletedByGroupNosDBHardLimit 防雪崩 (PR #553):
+//   - caller 侧 (messages_search/search_global.go enumerateThreadsForGroups) 维持
 //     maxThreadsPerGroup / maxTotalThreadChannelIDs 两个语义 cap + WARN downgrade；
 //   - DB 层的 LIMIT 只是上限，避免重度用户 pathological 场景下一次 SELECT 拉几十万行入内
 //     存（MySQL 已返回全部行后才 downgrade 的旧行为在线上不可接受）。
-//   - 命中 LIMIT 时 caller 看到的是「尾部群拿到不全」，自然会走已有的 downgrade / skip
-//     分支，语义与现行 cap 触发一致。
+//   - **命中 LIMIT 与 caller 语义 cap 不等价**：语义 cap 触发时某个 group 返回「太多」
+//     并被 caller 显式降级 + WARN；DB LIMIT 触发时按 ORDER BY 排在尾部的整个 group
+//     可能返回「零 / 部分」行，caller 单看行数分不出「本来就没有」还是「被 SQL 截掉」。
+//     因此 truncated 返回值必须被 caller 观测并单独 WARN；否则重度用户（>2500 非删除
+//     子区）会静默丢失 thread 覆盖（RC 2 on PR #553）。
 //
 // 排序：ORDER BY group_no, short_id 保证 LIMIT 截断在多群场景下确定——同一输入 groupNos
-// 集合总是拿到同一子集，避免引入不确定截断。无 group_no / short_id 的两列覆盖索引时（
-// idx_group_status_created_id）MySQL 也能在索引内完成排序，无 filesort。
+// 集合总是拿到同一子集，避免引入不确定截断。
 //
-// 保护限制同 QueryActiveShortIDsByGroupNos（空入参 → 空 map、仅投影两列）。
-func (d *DB) QueryNonDeletedShortIDsByGroupNos(groupNos []string) (map[string][]string, error) {
+// 索引：无覆盖排序索引与 (group_no IN, status != deleted) 组合完全匹配（idx_group_status
+// _created_id 是 (group_no, status, created_at, id)、uk_group_short 是 (group_no,
+// short_id) 不带 status），MySQL 大概率会 filesort，但 LIMIT=2500 把工作集截在可控
+// 量级——若这条路径变热应用 EXPLAIN 复核并考虑追加合适复合索引。
+//
+// 保护限制：空入参直接返回空 map，不下发 SQL；内部只取 (group_no, short_id) 两列。
+//
+// 返回值 truncated 为 true 当且仅当返回的行数触到 LIMIT（`len(rows) == LIMIT`）。
+// 此时数据是「按 ORDER BY group_no, short_id 的前 LIMIT 行」，尾部 group 可能
+// 部分或全部缺失；caller **必须**将 truncated=true 视为观测点并发 WARN，以免
+// 静默降级（RC 2 on PR #553）。
+func (d *DB) QueryNonDeletedShortIDsByGroupNos(groupNos []string) (map[string][]string, bool, error) {
 	out := make(map[string][]string)
 	if len(groupNos) == 0 {
-		return out, nil
+		return out, false, nil
 	}
 	var rows []GroupShortIDRow
 	_, err := d.session.Select("group_no", "short_id").From("thread").
@@ -355,15 +326,16 @@ func (d *DB) QueryNonDeletedShortIDsByGroupNos(groupNos []string) (map[string][]
 		Limit(uint64(NonDeletedByGroupNosDBHardLimit)).
 		Load(&rows)
 	if err != nil {
-		return nil, fmt.Errorf("query non-deleted short ids by group nos: %w", err)
+		return nil, false, fmt.Errorf("query non-deleted short ids by group nos: %w", err)
 	}
+	truncated := len(rows) >= NonDeletedByGroupNosDBHardLimit
 	for _, r := range rows {
 		if r.GroupNo == "" || r.ShortID == "" {
 			continue
 		}
 		out[r.GroupNo] = append(out[r.GroupNo], r.ShortID)
 	}
-	return out, nil
+	return out, truncated, nil
 }
 
 // QueryActiveShortIDs 批量查询 status=active 的子区 shortID。

--- a/modules/thread/db.go
+++ b/modules/thread/db.go
@@ -257,14 +257,36 @@ func (d *DB) QueryNonDeletedShortIDs(shortIDs []string) ([]string, error) {
 	return result, nil
 }
 
-// GroupShortIDRow 是 QueryActiveShortIDsByGroupNos 内部的两列投影，只暴露包内使用。
+// GroupShortIDRow 是 QueryActiveShortIDsByGroupNos /
+// QueryNonDeletedShortIDsByGroupNos 内部的两列投影，只暴露包内使用。
 type GroupShortIDRow struct {
 	GroupNo string `db:"group_no"`
 	ShortID string `db:"short_id"`
 }
 
+// NonDeletedByGroupNosDBHardLimit 是 QueryNonDeletedShortIDsByGroupNos 在
+// DB 层的行数硬上限。它不是 messages_search 侧的语义 cap（那两个 cap
+// maxThreadsPerGroup=200 / maxTotalThreadChannelIDs=2000 仍在 caller 里做
+// 降级判定并留 WARN），而是一层雪崩保护：即使某个成员横跨极多群、每群又
+// 有极多非删除子区，也不会让单次 SELECT 把几十万行拉进内存。
+//
+// 选值 2500 = maxTotalThreadChannelIDs(2000) × 1.25 缓冲，保证 caller 的
+// downgrade WARN 分支仍能被观测到（真正爆过 2000 才降级），同时把 pathological
+// 场景截在一个可预测的量级。命中该 LIMIT 会在 caller 端的 running-total 计算
+// 里自然表现为「某些群拿到的 shortID 不全」——这种情况下 messages_search 侧本
+// 就会走 downgrade / skip 分支，语义等价于 caller 的 cap 触发。
+const NonDeletedByGroupNosDBHardLimit = 2500
+
 // QueryActiveShortIDsByGroupNos 批量拉取一组 group 下 status=active 的子区 short_id，
-// 返回 map[groupNo][]shortID。用于 messages_search 全局端点构建 allowlist：
+// 返回 map[groupNo][]shortID。
+//
+// 语义（严格的「只看 active」）：archived / deleted 都不返回。
+//   - 保留原因：/v1/conversation/sync 等「只显示活跃子区」的路径仍依赖该语义
+//     和这套现有单测（db_batch_test.go::TestQueryActiveShortIDsByGroupNos）。
+//   - 注意：**messages_search 全局搜索的 allowlist 已不再用这个函数**，改用
+//     QueryNonDeletedShortIDsByGroupNos（archived 允许纳入），以对齐单频道搜索
+//     / getThreadMessage 的可见性契约（只拒 deleted）。参见 RC on PR #553。
+//
 // 单次 SELECT 走 (group_no, status, ...) 覆盖索引 idx_group_status_created_id
 // （见 modules/thread/sql/20260522000002_thread_group_status_created_index.sql），
 // 避免对每个 group 做一次子查询。
@@ -272,8 +294,8 @@ type GroupShortIDRow struct {
 // 保护限制：
 //   - 空入参直接返回空 map，不下发 SQL；
 //   - 内部只取 (group_no, short_id) 两列，无 hot-column 回表；
-//   - 结果规模在调用方（messages_search buildAllowlist）再做「单群 shortID 上限」
-//     的降级判定；DB 层不硬砍上限以保留可观测性——若真的爆表也让 caller 明确处理。
+//   - 结果规模在调用方再做「单群 shortID 上限」的降级判定；DB 层不硬砍上限
+//     以保留可观测性——若真的爆表也让 caller 明确处理。
 func (d *DB) QueryActiveShortIDsByGroupNos(groupNos []string) (map[string][]string, error) {
 	out := make(map[string][]string)
 	if len(groupNos) == 0 {
@@ -285,6 +307,55 @@ func (d *DB) QueryActiveShortIDsByGroupNos(groupNos []string) (map[string][]stri
 		Load(&rows)
 	if err != nil {
 		return nil, fmt.Errorf("query active short ids by group nos: %w", err)
+	}
+	for _, r := range rows {
+		if r.GroupNo == "" || r.ShortID == "" {
+			continue
+		}
+		out[r.GroupNo] = append(out[r.GroupNo], r.ShortID)
+	}
+	return out, nil
+}
+
+// QueryNonDeletedShortIDsByGroupNos 批量拉取一组 group 下 **status != deleted** 的
+// 子区 short_id（即 active + archived 都纳入，deleted 排除），返回 map[groupNo][]shortID。
+//
+// **语义理由（RC on PR #553）**：子区可见性契约在全局一致——只拒 deleted、允许访问
+// archived：
+//   - modules/messages/api_message_get.go:136-139（消息读）仅拒 ThreadStatusDeleted；
+//   - modules/messages_search/authz.go checkThreadAccess → modules/thread/service.go
+//     GetThread（service.go:102）：仅拒 deleted、返回 archived。
+//
+// 之前全局搜索用 QueryActiveShortIDsByGroupNos(status=active)，会把 archived 子区错
+// 误排除——归档子区 **单频道搜索能命中、全局搜不到**，破坏一致性。因为
+// archived 是 ArchiveStaleBatch cron 例行转的（占比不小），影响面很大。
+//
+// **DB 层 hard bound**：LIMIT NonDeletedByGroupNosDBHardLimit 防雪崩 (RC N2、PR #553):
+//   - caller 侧 (messages_search/search_global.go enumerateThreadsForGroups) 仍维持
+//     maxThreadsPerGroup / maxTotalThreadChannelIDs 两个语义 cap + WARN downgrade；
+//   - DB 层的 LIMIT 只是上限，避免重度用户 pathological 场景下一次 SELECT 拉几十万行入内
+//     存（MySQL 已返回全部行后才 downgrade 的旧行为在线上不可接受）。
+//   - 命中 LIMIT 时 caller 看到的是「尾部群拿到不全」，自然会走已有的 downgrade / skip
+//     分支，语义与现行 cap 触发一致。
+//
+// 排序：ORDER BY group_no, short_id 保证 LIMIT 截断在多群场景下确定——同一输入 groupNos
+// 集合总是拿到同一子集，避免引入不确定截断。无 group_no / short_id 的两列覆盖索引时（
+// idx_group_status_created_id）MySQL 也能在索引内完成排序，无 filesort。
+//
+// 保护限制同 QueryActiveShortIDsByGroupNos（空入参 → 空 map、仅投影两列）。
+func (d *DB) QueryNonDeletedShortIDsByGroupNos(groupNos []string) (map[string][]string, error) {
+	out := make(map[string][]string)
+	if len(groupNos) == 0 {
+		return out, nil
+	}
+	var rows []GroupShortIDRow
+	_, err := d.session.Select("group_no", "short_id").From("thread").
+		Where("group_no IN ? AND status != ?", groupNos, ThreadStatusDeleted).
+		OrderBy("group_no").OrderBy("short_id").
+		Limit(uint64(NonDeletedByGroupNosDBHardLimit)).
+		Load(&rows)
+	if err != nil {
+		return nil, fmt.Errorf("query non-deleted short ids by group nos: %w", err)
 	}
 	for _, r := range rows {
 		if r.GroupNo == "" || r.ShortID == "" {

--- a/modules/thread/db_batch_test.go
+++ b/modules/thread/db_batch_test.go
@@ -2,6 +2,7 @@ package thread
 
 import (
 	"sort"
+	"strconv"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
@@ -82,4 +83,140 @@ func TestQueryActiveShortIDsByGroupNos(t *testing.T) {
 	require.NoError(t, err)
 	_, present := unknown["grpUnknown"]
 	assert.False(t, present, "group with no rows must not appear")
+}
+
+// TestQueryNonDeletedShortIDsByGroupNos — RC blocker on PR #553.
+// The messages_search global endpoint’s allowlist now goes through this
+// query (not QueryActiveShortIDsByGroupNos) so archived threads keep
+// showing up in global search, aligning with single-channel search /
+// message read (both of which only reject deleted). Verifies:
+//
+//  1. Multiple groups return distinct shortID lists keyed by group_no.
+//  2. **status IN (active, archived)** rows are surfaced; **deleted rows
+//     are excluded** (the invariant that was violated before this fix).
+//  3. Un-requested groups don’t appear.
+//  4. Empty input short-circuits to an empty map with no SQL.
+//  5. Result rows are ORDER BY (group_no, short_id), so the DB-side
+//     LIMIT (NonDeletedByGroupNosDBHardLimit) truncates deterministically.
+//
+// Integration test: requires a running MySQL (see main_test.go), same as
+// every other DB test in this package.
+func TestQueryNonDeletedShortIDsByGroupNos(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	db := NewDB(ctx)
+
+	// Seed: two groups with mixed statuses + a third group we won't query
+	// for + one group whose only threads are deleted (must NOT appear).
+	seed := []struct {
+		shortID string
+		groupNo string
+		status  int
+	}{
+		// grpA: one active, one archived, one deleted — archived MUST
+		// surface (the RC fix), deleted MUST NOT.
+		{"thr_a1", "grpA", ThreadStatusActive},
+		{"thr_a2", "grpA", ThreadStatusArchived},
+		{"thr_a3", "grpA", ThreadStatusDeleted},
+		// grpB: only an archived thread — pre-fix this group would be
+		// silently absent; post-fix it must be present.
+		{"thr_b1", "grpB", ThreadStatusArchived},
+		// grpC: NOT queried.
+		{"thr_c1", "grpC", ThreadStatusActive},
+		// grpDeletedOnly: only deleted rows — must NOT appear in the map.
+		{"thr_d1", "grpDeletedOnly", ThreadStatusDeleted},
+		{"thr_d2", "grpDeletedOnly", ThreadStatusDeleted},
+	}
+	for _, s := range seed {
+		m := &Model{
+			ShortID:    s.shortID,
+			GroupNo:    s.groupNo,
+			Name:       "t-" + s.shortID,
+			CreatorUID: testutil.UID,
+			Status:     s.status,
+			Version:    1,
+		}
+		require.NoError(t, db.Insert(m))
+	}
+
+	// (1) Empty input → empty map, no SQL error.
+	empty, err := db.QueryNonDeletedShortIDsByGroupNos(nil)
+	require.NoError(t, err)
+	assert.Empty(t, empty, "empty input must return empty map")
+
+	// (2) grpA + grpB + grpDeletedOnly: archived rows surface; deleted rows
+	//     stay excluded; grpDeletedOnly is absent because all its rows are
+	//     deleted.
+	got, err := db.QueryNonDeletedShortIDsByGroupNos(
+		[]string{"grpA", "grpB", "grpDeletedOnly"})
+	require.NoError(t, err)
+
+	sort.Strings(got["grpA"])
+	assert.Equal(t, []string{"thr_a1", "thr_a2"}, got["grpA"],
+		"grpA must yield active + archived (deleted excluded)")
+	assert.Equal(t, []string{"thr_b1"}, got["grpB"],
+		"grpB must yield its archived-only thread — pre-fix this leaked to empty")
+	_, hasDeletedOnly := got["grpDeletedOnly"]
+	assert.False(t, hasDeletedOnly,
+		"a group whose only rows are deleted must not appear (deleted rows must never leak)")
+
+	// Also assert the archived shortID for grpA is actually present, and
+	// the deleted shortID is actually absent — catches any regression that
+	// silently swaps status semantics.
+	assert.Contains(t, got["grpA"], "thr_a2", "archived shortID must be present")
+	assert.NotContains(t, got["grpA"], "thr_a3", "deleted shortID must not leak")
+
+	// (3) grpC was not requested — must be absent.
+	_, hasC := got["grpC"]
+	assert.False(t, hasC, "un-requested group must not leak into results")
+
+	// (4) A brand-new group with no rows in the table returns nothing.
+	unknown, err := db.QueryNonDeletedShortIDsByGroupNos([]string{"grpUnknown"})
+	require.NoError(t, err)
+	_, present := unknown["grpUnknown"]
+	assert.False(t, present, "group with no rows must not appear")
+}
+
+// TestQueryNonDeletedShortIDsByGroupNos_HardLimit — the DB-side LIMIT
+// (thread.NonDeletedByGroupNosDBHardLimit) exists to keep a pathological
+// membership footprint from dragging tens of thousands of rows into
+// memory (RC N2 on PR #553). Seed just enough rows to cross the limit and
+// assert the returned row count never exceeds it. Deterministic ordering
+// (ORDER BY group_no, short_id) means the truncation cut point is stable
+// across runs.
+func TestQueryNonDeletedShortIDsByGroupNos_HardLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping hard-limit seed test in -short mode")
+	}
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	db := NewDB(ctx)
+
+	// Seed just above the DB hard limit so LIMIT kicks in.
+	total := NonDeletedByGroupNosDBHardLimit + 50
+	groupNo := "grpHuge"
+	for i := 0; i < total; i++ {
+		m := &Model{
+			ShortID:    "thr_" + itoa(i),
+			GroupNo:    groupNo,
+			Name:       "t",
+			CreatorUID: testutil.UID,
+			Status:     ThreadStatusActive,
+			Version:    1,
+		}
+		require.NoError(t, db.Insert(m))
+	}
+
+	got, err := db.QueryNonDeletedShortIDsByGroupNos([]string{groupNo})
+	require.NoError(t, err)
+	rows := got[groupNo]
+	assert.LessOrEqual(t, len(rows), NonDeletedByGroupNosDBHardLimit,
+		"LIMIT %d must cap the returned row count", NonDeletedByGroupNosDBHardLimit)
+	assert.Equal(t, NonDeletedByGroupNosDBHardLimit, len(rows),
+		"seed guarantees exactly LIMIT rows come back")
+}
+
+// itoa — minimal, matches the pattern used elsewhere in package tests.
+func itoa(i int) string {
+	return strconv.Itoa(i)
 }

--- a/modules/thread/db_batch_test.go
+++ b/modules/thread/db_batch_test.go
@@ -3,6 +3,7 @@ package thread
 import (
 	"sort"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
@@ -10,86 +11,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestQueryActiveShortIDsByGroupNos — batch IN query used by
-// messages_search.buildAllowlist to build the v1 thread allowlist. Verifies:
-//
-//  1. Multiple groups return distinct shortID lists keyed by group_no.
-//  2. Only status=active rows are surfaced (archived / deleted filtered).
-//  3. Groups the caller didn't list simply don't appear in the returned map.
-//  4. Empty input short-circuits to an empty map with no SQL.
-//  5. A group with zero active threads returns no key (not an empty slice).
-//
-// Integration test: requires a running MySQL (see main_test.go), same as
-// every other DB test in this package.
-func TestQueryActiveShortIDsByGroupNos(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
-	require.NoError(t, testutil.CleanAllTables(ctx))
-	db := NewDB(ctx)
-
-	// Seed data: two groups with mixed statuses + a third group we won't
-	// query for (must not appear in results).
-	seed := []struct {
-		shortID string
-		groupNo string
-		status  int
-	}{
-		// grpA: two active, one archived, one deleted
-		{"thr_a1", "grpA", ThreadStatusActive},
-		{"thr_a2", "grpA", ThreadStatusActive},
-		{"thr_a3", "grpA", ThreadStatusArchived},
-		{"thr_a4", "grpA", ThreadStatusDeleted},
-		// grpB: one active only
-		{"thr_b1", "grpB", ThreadStatusActive},
-		// grpC: NOT queried
-		{"thr_c1", "grpC", ThreadStatusActive},
-		// grpD: no active threads at all (only archived)
-		{"thr_d1", "grpD", ThreadStatusArchived},
-	}
-	for _, s := range seed {
-		m := &Model{
-			ShortID:    s.shortID,
-			GroupNo:    s.groupNo,
-			Name:       "t-" + s.shortID,
-			CreatorUID: testutil.UID,
-			Status:     s.status,
-			Version:    1,
-		}
-		require.NoError(t, db.Insert(m))
-	}
-
-	// (1) empty input → empty map, no SQL error.
-	empty, err := db.QueryActiveShortIDsByGroupNos(nil)
-	require.NoError(t, err)
-	assert.Empty(t, empty, "empty input must return empty map")
-
-	// (2) grpA + grpB + grpD: only active rows surface, grpD absent entirely.
-	got, err := db.QueryActiveShortIDsByGroupNos([]string{"grpA", "grpB", "grpD"})
-	require.NoError(t, err)
-
-	sort.Strings(got["grpA"])
-	assert.Equal(t, []string{"thr_a1", "thr_a2"}, got["grpA"],
-		"grpA must yield exactly its two active threads (archived/deleted filtered)")
-	assert.Equal(t, []string{"thr_b1"}, got["grpB"],
-		"grpB must yield exactly its single active thread")
-	_, hasD := got["grpD"]
-	assert.False(t, hasD, "grpD has zero active threads and must not appear in the map")
-
-	// (3) grpC was not requested — must be absent.
-	_, hasC := got["grpC"]
-	assert.False(t, hasC, "un-requested group must not leak into results")
-
-	// (4) A brand-new group with no rows in the table returns nothing.
-	unknown, err := db.QueryActiveShortIDsByGroupNos([]string{"grpUnknown"})
-	require.NoError(t, err)
-	_, present := unknown["grpUnknown"]
-	assert.False(t, present, "group with no rows must not appear")
-}
-
 // TestQueryNonDeletedShortIDsByGroupNos — RC blocker on PR #553.
-// The messages_search global endpoint’s allowlist now goes through this
-// query (not QueryActiveShortIDsByGroupNos) so archived threads keep
-// showing up in global search, aligning with single-channel search /
-// message read (both of which only reject deleted). Verifies:
+// The messages_search global endpoint’s allowlist goes through this query so
+// archived threads keep showing up in global search, aligning with
+// single-channel search / message read (both of which only reject deleted).
+// Verifies:
 //
 //  1. Multiple groups return distinct shortID lists keyed by group_no.
 //  2. **status IN (active, archived)** rows are surfaced; **deleted rows
@@ -98,6 +24,7 @@ func TestQueryActiveShortIDsByGroupNos(t *testing.T) {
 //  4. Empty input short-circuits to an empty map with no SQL.
 //  5. Result rows are ORDER BY (group_no, short_id), so the DB-side
 //     LIMIT (NonDeletedByGroupNosDBHardLimit) truncates deterministically.
+//  6. `truncated` return is false when the returned rows are under the LIMIT.
 //
 // Integration test: requires a running MySQL (see main_test.go), same as
 // every other DB test in this package.
@@ -139,17 +66,20 @@ func TestQueryNonDeletedShortIDsByGroupNos(t *testing.T) {
 		require.NoError(t, db.Insert(m))
 	}
 
-	// (1) Empty input → empty map, no SQL error.
-	empty, err := db.QueryNonDeletedShortIDsByGroupNos(nil)
+	// (1) Empty input → empty map, no SQL error, truncated=false.
+	empty, truncated, err := db.QueryNonDeletedShortIDsByGroupNos(nil)
 	require.NoError(t, err)
 	assert.Empty(t, empty, "empty input must return empty map")
+	assert.False(t, truncated, "empty input must not set truncated")
 
 	// (2) grpA + grpB + grpDeletedOnly: archived rows surface; deleted rows
 	//     stay excluded; grpDeletedOnly is absent because all its rows are
 	//     deleted.
-	got, err := db.QueryNonDeletedShortIDsByGroupNos(
+	got, truncated, err := db.QueryNonDeletedShortIDsByGroupNos(
 		[]string{"grpA", "grpB", "grpDeletedOnly"})
 	require.NoError(t, err)
+	assert.False(t, truncated,
+		"small-fixture query must not report truncated (returned rows well under LIMIT)")
 
 	sort.Strings(got["grpA"])
 	assert.Equal(t, []string{"thr_a1", "thr_a2"}, got["grpA"],
@@ -171,8 +101,9 @@ func TestQueryNonDeletedShortIDsByGroupNos(t *testing.T) {
 	assert.False(t, hasC, "un-requested group must not leak into results")
 
 	// (4) A brand-new group with no rows in the table returns nothing.
-	unknown, err := db.QueryNonDeletedShortIDsByGroupNos([]string{"grpUnknown"})
+	unknown, truncated, err := db.QueryNonDeletedShortIDsByGroupNos([]string{"grpUnknown"})
 	require.NoError(t, err)
+	assert.False(t, truncated)
 	_, present := unknown["grpUnknown"]
 	assert.False(t, present, "group with no rows must not appear")
 }
@@ -180,10 +111,8 @@ func TestQueryNonDeletedShortIDsByGroupNos(t *testing.T) {
 // TestQueryNonDeletedShortIDsByGroupNos_HardLimit — the DB-side LIMIT
 // (thread.NonDeletedByGroupNosDBHardLimit) exists to keep a pathological
 // membership footprint from dragging tens of thousands of rows into
-// memory (RC N2 on PR #553). Seed just enough rows to cross the limit and
-// assert the returned row count never exceeds it. Deterministic ordering
-// (ORDER BY group_no, short_id) means the truncation cut point is stable
-// across runs.
+// memory. Single-group seed above the LIMIT: assert (a) returned row
+// count == LIMIT, (b) `truncated` sentinel fires so the caller can WARN.
 func TestQueryNonDeletedShortIDsByGroupNos_HardLimit(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping hard-limit seed test in -short mode")
@@ -207,13 +136,121 @@ func TestQueryNonDeletedShortIDsByGroupNos_HardLimit(t *testing.T) {
 		require.NoError(t, db.Insert(m))
 	}
 
-	got, err := db.QueryNonDeletedShortIDsByGroupNos([]string{groupNo})
+	got, truncated, err := db.QueryNonDeletedShortIDsByGroupNos([]string{groupNo})
 	require.NoError(t, err)
 	rows := got[groupNo]
-	assert.LessOrEqual(t, len(rows), NonDeletedByGroupNosDBHardLimit,
-		"LIMIT %d must cap the returned row count", NonDeletedByGroupNosDBHardLimit)
 	assert.Equal(t, NonDeletedByGroupNosDBHardLimit, len(rows),
 		"seed guarantees exactly LIMIT rows come back")
+	assert.True(t, truncated,
+		"len(rows)==LIMIT must set truncated=true so callers can WARN (RC 2 on PR #553)")
+}
+
+// TestQueryNonDeletedShortIDsByGroupNos_HardLimit_MultiGroupTailDrop — RC 2
+// on PR #553. The failure mode the outside reviewers built against:
+//
+//   - When the sum of non-deleted rows across N groups exceeds the DB LIMIT,
+//     the `ORDER BY group_no, short_id LIMIT` cut lands mid-stream. Tail
+//     groups (highest `group_no`) may end up partial or entirely missing.
+//   - The caller's per-group (>200) / aggregate-total (>2000) downgrade
+//     branches only trigger on too-MANY rows, so tail zero/partial rows
+//     were silently dropped in the previous revision with NO WARN.
+//
+// This test seeds many groups whose combined rows cross the LIMIT and
+// asserts:
+//   - truncated=true is returned so the caller has a signal to WARN on;
+//   - total returned rows == LIMIT (deterministic cut);
+//   - the head groups (lowest `group_no`) are complete;
+//   - the tail groups (highest `group_no`) after the cut point receive zero
+//     rows — exactly the "silently missing" symptom the WARN now covers.
+func TestQueryNonDeletedShortIDsByGroupNos_HardLimit_MultiGroupTailDrop(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping hard-limit multi-group seed test in -short mode")
+	}
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	db := NewDB(ctx)
+
+	// Design: N groups × K threads each, N*K just above LIMIT. Group
+	// naming is zero-padded so ORDER BY group_no is deterministic and
+	// intuitive ("grp_000" < "grp_001" < ... < "grp_009").
+	const (
+		K = 300 // threads per group — well over caller's per-group cap 200
+	)
+	N := (NonDeletedByGroupNosDBHardLimit / K) + 2 // guarantees N*K > LIMIT
+	groupNos := make([]string, 0, N)
+	for gi := 0; gi < N; gi++ {
+		gn := "grp_" + zeroPad(gi, 3)
+		groupNos = append(groupNos, gn)
+		for si := 0; si < K; si++ {
+			m := &Model{
+				ShortID:    gn + "_thr_" + zeroPad(si, 4),
+				GroupNo:    gn,
+				Name:       "t",
+				CreatorUID: testutil.UID,
+				Status:     ThreadStatusActive,
+				Version:    1,
+			}
+			require.NoError(t, db.Insert(m))
+		}
+	}
+
+	got, truncated, err := db.QueryNonDeletedShortIDsByGroupNos(groupNos)
+	require.NoError(t, err)
+	assert.True(t, truncated,
+		"multi-group query crossing the LIMIT must report truncated=true")
+
+	// Total rows returned must equal the DB LIMIT.
+	totalReturned := 0
+	for _, ids := range got {
+		totalReturned += len(ids)
+	}
+	assert.Equal(t, NonDeletedByGroupNosDBHardLimit, totalReturned,
+		"LIMIT %d must cap the aggregate row count", NonDeletedByGroupNosDBHardLimit)
+
+	// The cut point: how many complete head groups fit under the LIMIT +
+	// (optional) one partial group. All tail groups beyond that must
+	// return zero rows.
+	fullHeadCount := NonDeletedByGroupNosDBHardLimit / K
+	partialAt := fullHeadCount // may or may not exist (0..K-1 leftover rows)
+	leftover := NonDeletedByGroupNosDBHardLimit - fullHeadCount*K
+
+	// Head: exactly K rows each.
+	for i := 0; i < fullHeadCount; i++ {
+		gn := groupNos[i]
+		assert.Equal(t, K, len(got[gn]),
+			"head group %q must be complete", gn)
+	}
+	// Partial: leftover rows. Its shortIDs must all start with that group's prefix.
+	if leftover > 0 && partialAt < N {
+		gn := groupNos[partialAt]
+		assert.Equal(t, leftover, len(got[gn]),
+			"boundary group %q must have exactly leftover rows", gn)
+		for _, sid := range got[gn] {
+			assert.True(t, strings.HasPrefix(sid, gn+"_thr_"),
+				"boundary group rows must belong to that group; got %q under %q", sid, gn)
+		}
+	}
+	// Tail: must be silently absent (zero rows returned for these groups).
+	// This is the exact symptom the truncated=true signal exists to cover.
+	tailStart := partialAt
+	if leftover > 0 {
+		tailStart = partialAt + 1
+	}
+	for i := tailStart; i < N; i++ {
+		gn := groupNos[i]
+		assert.Empty(t, got[gn],
+			"tail group %q past the LIMIT must be silently absent (that's what truncated=true warns about)", gn)
+	}
+}
+
+// zeroPad — small helper for deterministic ORDER BY group_no in the
+// multi-group truncation test.
+func zeroPad(i, width int) string {
+	s := strconv.Itoa(i)
+	for len(s) < width {
+		s = "0" + s
+	}
+	return s
 }
 
 // itoa — minimal, matches the pattern used elsewhere in package tests.

--- a/modules/thread/db_batch_test.go
+++ b/modules/thread/db_batch_test.go
@@ -22,9 +22,8 @@ import (
 //     are excluded** (the invariant that was violated before this fix).
 //  3. Un-requested groups don’t appear.
 //  4. Empty input short-circuits to an empty map with no SQL.
-//  5. Result rows are ORDER BY (group_no, short_id), so the DB-side
-//     LIMIT (NonDeletedByGroupNosDBHardLimit) truncates deterministically.
-//  6. `truncated` return is false when the returned rows are under the LIMIT.
+//  5. Each group’s shortIDs come back ordered by short_id — the ROW_NUMBER
+//     PARTITION cap is deterministic across runs.
 //
 // Integration test: requires a running MySQL (see main_test.go), same as
 // every other DB test in this package.
@@ -66,20 +65,17 @@ func TestQueryNonDeletedShortIDsByGroupNos(t *testing.T) {
 		require.NoError(t, db.Insert(m))
 	}
 
-	// (1) Empty input → empty map, no SQL error, truncated=false.
-	empty, truncated, err := db.QueryNonDeletedShortIDsByGroupNos(nil)
+	// (1) Empty input → empty map, no SQL error.
+	empty, err := db.QueryNonDeletedShortIDsByGroupNos(nil)
 	require.NoError(t, err)
 	assert.Empty(t, empty, "empty input must return empty map")
-	assert.False(t, truncated, "empty input must not set truncated")
 
 	// (2) grpA + grpB + grpDeletedOnly: archived rows surface; deleted rows
 	//     stay excluded; grpDeletedOnly is absent because all its rows are
 	//     deleted.
-	got, truncated, err := db.QueryNonDeletedShortIDsByGroupNos(
+	got, err := db.QueryNonDeletedShortIDsByGroupNos(
 		[]string{"grpA", "grpB", "grpDeletedOnly"})
 	require.NoError(t, err)
-	assert.False(t, truncated,
-		"small-fixture query must not report truncated (returned rows well under LIMIT)")
 
 	sort.Strings(got["grpA"])
 	assert.Equal(t, []string{"thr_a1", "thr_a2"}, got["grpA"],
@@ -101,32 +97,32 @@ func TestQueryNonDeletedShortIDsByGroupNos(t *testing.T) {
 	assert.False(t, hasC, "un-requested group must not leak into results")
 
 	// (4) A brand-new group with no rows in the table returns nothing.
-	unknown, truncated, err := db.QueryNonDeletedShortIDsByGroupNos([]string{"grpUnknown"})
+	unknown, err := db.QueryNonDeletedShortIDsByGroupNos([]string{"grpUnknown"})
 	require.NoError(t, err)
-	assert.False(t, truncated)
 	_, present := unknown["grpUnknown"]
 	assert.False(t, present, "group with no rows must not appear")
 }
 
-// TestQueryNonDeletedShortIDsByGroupNos_HardLimit — the DB-side LIMIT
-// (thread.NonDeletedByGroupNosDBHardLimit) exists to keep a pathological
-// membership footprint from dragging tens of thousands of rows into
-// memory. Single-group seed above the LIMIT: assert (a) returned row
-// count == LIMIT, (b) `truncated` sentinel fires so the caller can WARN.
-func TestQueryNonDeletedShortIDsByGroupNos_HardLimit(t *testing.T) {
+// TestQueryNonDeletedShortIDsByGroupNos_PerGroupCap — RC 3 on PR #553.
+// The DB-side per-group cap (thread.NonDeletedByGroupNosPerGroupHardLimit
+// = 201, enforced via UNION ALL of per-group `LIMIT` subqueries) exists so
+// a runaway group cannot dump tens of thousands of rows into memory. Seed
+// a single group above that cap and assert exactly `PerGroupHardLimit`
+// rows come back for it.
+func TestQueryNonDeletedShortIDsByGroupNos_PerGroupCap(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping hard-limit seed test in -short mode")
+		t.Skip("skipping per-group-cap seed test in -short mode")
 	}
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	db := NewDB(ctx)
 
-	// Seed just above the DB hard limit so LIMIT kicks in.
-	total := NonDeletedByGroupNosDBHardLimit + 50
+	// Seed just above the per-group cap so the PARTITION LIMIT kicks in.
+	total := NonDeletedByGroupNosPerGroupHardLimit + 50
 	groupNo := "grpHuge"
 	for i := 0; i < total; i++ {
 		m := &Model{
-			ShortID:    "thr_" + itoa(i),
+			ShortID:    "thr_" + zeroPad(i, 6),
 			GroupNo:    groupNo,
 			Name:       "t",
 			CreatorUID: testutil.UID,
@@ -136,52 +132,67 @@ func TestQueryNonDeletedShortIDsByGroupNos_HardLimit(t *testing.T) {
 		require.NoError(t, db.Insert(m))
 	}
 
-	got, truncated, err := db.QueryNonDeletedShortIDsByGroupNos([]string{groupNo})
+	got, err := db.QueryNonDeletedShortIDsByGroupNos([]string{groupNo})
 	require.NoError(t, err)
 	rows := got[groupNo]
-	assert.Equal(t, NonDeletedByGroupNosDBHardLimit, len(rows),
-		"seed guarantees exactly LIMIT rows come back")
-	assert.True(t, truncated,
-		"len(rows)==LIMIT must set truncated=true so callers can WARN (RC 2 on PR #553)")
+	assert.Equal(t, NonDeletedByGroupNosPerGroupHardLimit, len(rows),
+		"per-group PARTITION cap must bound the row count for a single fat group")
 }
 
-// TestQueryNonDeletedShortIDsByGroupNos_HardLimit_MultiGroupTailDrop — RC 2
-// on PR #553. The failure mode the outside reviewers built against:
+// TestQueryNonDeletedShortIDsByGroupNos_FatGroupDoesNotStarveOthers —
+// **the RC 3 P1 regression test** for PR #553.
 //
-//   - When the sum of non-deleted rows across N groups exceeds the DB LIMIT,
-//     the `ORDER BY group_no, short_id LIMIT` cut lands mid-stream. Tail
-//     groups (highest `group_no`) may end up partial or entirely missing.
-//   - The caller's per-group (>200) / aggregate-total (>2000) downgrade
-//     branches only trigger on too-MANY rows, so tail zero/partial rows
-//     were silently dropped in the previous revision with NO WARN.
+// Previous revision used one global `ORDER BY group_no, short_id LIMIT 2500`.
+// A group sorting early with >= 2500 non-deleted threads would consume the
+// entire LIMIT budget, and every other group would return zero rows. The
+// caller's `continue` on the fat group's per-group cap (>200 rows) then
+// combined with the empty tail to zero out thread coverage for the WHOLE
+// request — not just the fat group. yujiawei’s RC 3 (2026-07-09) called this
+// as blocking and correctly.
 //
-// This test seeds many groups whose combined rows cross the LIMIT and
-// asserts:
-//   - truncated=true is returned so the caller has a signal to WARN on;
-//   - total returned rows == LIMIT (deterministic cut);
-//   - the head groups (lowest `group_no`) are complete;
-//   - the tail groups (highest `group_no`) after the cut point receive zero
-//     rows — exactly the "silently missing" symptom the WARN now covers.
-func TestQueryNonDeletedShortIDsByGroupNos_HardLimit_MultiGroupTailDrop(t *testing.T) {
+// The fix bounds each group at the SQL layer via ROW_NUMBER() OVER
+// (PARTITION BY group_no) so no single group can starve another. This
+// integration test locks that in: seed a group whose non-deleted thread
+// count would eat the OLD global LIMIT on its own, plus several normal
+// groups sorted AFTER it (higher group_no). Assert:
+//   - fat group returns exactly `PerGroupHardLimit` rows (its own cap);
+//   - every normal group returns its full row set (they are NOT starved).
+func TestQueryNonDeletedShortIDsByGroupNos_FatGroupDoesNotStarveOthers(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping hard-limit multi-group seed test in -short mode")
+		t.Skip("skipping fat-group-starvation seed test in -short mode")
 	}
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	db := NewDB(ctx)
 
-	// Design: N groups × K threads each, N*K just above LIMIT. Group
-	// naming is zero-padded so ORDER BY group_no is deterministic and
-	// intuitive ("grp_000" < "grp_001" < ... < "grp_009").
+	// The fat group's threads must (a) exceed the per-group PARTITION cap
+	// so it demonstrably takes its share, AND (b) exceed the size of the
+	// old global LIMIT (2500) so this test would fail against the previous
+	// implementation (this is the actual regression bar we are locking in).
 	const (
-		K = 300 // threads per group — well over caller's per-group cap 200
+		fatThreadCount     = 3000 // > old global LIMIT (2500) and > per-group cap (201)
+		normalGroupCount   = 5
+		normalThreadsEach  = 20
+		fatGroupPrefix     = "grp_aaa" // sorts BEFORE the normal groups by group_no
+		normalGroupPrefix  = "grp_bbb_"
 	)
-	N := (NonDeletedByGroupNosDBHardLimit / K) + 2 // guarantees N*K > LIMIT
-	groupNos := make([]string, 0, N)
-	for gi := 0; gi < N; gi++ {
-		gn := "grp_" + zeroPad(gi, 3)
-		groupNos = append(groupNos, gn)
-		for si := 0; si < K; si++ {
+	fatGroup := fatGroupPrefix
+	for i := 0; i < fatThreadCount; i++ {
+		m := &Model{
+			ShortID:    fatGroup + "_thr_" + zeroPad(i, 6),
+			GroupNo:    fatGroup,
+			Name:       "t",
+			CreatorUID: testutil.UID,
+			Status:     ThreadStatusActive,
+			Version:    1,
+		}
+		require.NoError(t, db.Insert(m))
+	}
+	normalGroups := make([]string, 0, normalGroupCount)
+	for gi := 0; gi < normalGroupCount; gi++ {
+		gn := normalGroupPrefix + zeroPad(gi, 3)
+		normalGroups = append(normalGroups, gn)
+		for si := 0; si < normalThreadsEach; si++ {
 			m := &Model{
 				ShortID:    gn + "_thr_" + zeroPad(si, 4),
 				GroupNo:    gn,
@@ -194,52 +205,26 @@ func TestQueryNonDeletedShortIDsByGroupNos_HardLimit_MultiGroupTailDrop(t *testi
 		}
 	}
 
-	got, truncated, err := db.QueryNonDeletedShortIDsByGroupNos(groupNos)
+	groupNos := append([]string{fatGroup}, normalGroups...)
+	got, err := db.QueryNonDeletedShortIDsByGroupNos(groupNos)
 	require.NoError(t, err)
-	assert.True(t, truncated,
-		"multi-group query crossing the LIMIT must report truncated=true")
 
-	// Total rows returned must equal the DB LIMIT.
-	totalReturned := 0
-	for _, ids := range got {
-		totalReturned += len(ids)
-	}
-	assert.Equal(t, NonDeletedByGroupNosDBHardLimit, totalReturned,
-		"LIMIT %d must cap the aggregate row count", NonDeletedByGroupNosDBHardLimit)
+	// Fat group: exactly PerGroupHardLimit rows — its own per-group cap.
+	assert.Equal(t, NonDeletedByGroupNosPerGroupHardLimit, len(got[fatGroup]),
+		"fat group must be bounded by per-group cap (%d), not starve the query",
+		NonDeletedByGroupNosPerGroupHardLimit)
 
-	// The cut point: how many complete head groups fit under the LIMIT +
-	// (optional) one partial group. All tail groups beyond that must
-	// return zero rows.
-	fullHeadCount := NonDeletedByGroupNosDBHardLimit / K
-	partialAt := fullHeadCount // may or may not exist (0..K-1 leftover rows)
-	leftover := NonDeletedByGroupNosDBHardLimit - fullHeadCount*K
-
-	// Head: exactly K rows each.
-	for i := 0; i < fullHeadCount; i++ {
-		gn := groupNos[i]
-		assert.Equal(t, K, len(got[gn]),
-			"head group %q must be complete", gn)
-	}
-	// Partial: leftover rows. Its shortIDs must all start with that group's prefix.
-	if leftover > 0 && partialAt < N {
-		gn := groupNos[partialAt]
-		assert.Equal(t, leftover, len(got[gn]),
-			"boundary group %q must have exactly leftover rows", gn)
+	// Every normal group: its FULL row set, unstarved. Under the pre-fix
+	// implementation these would all be empty (or the whole map would miss
+	// them), which is precisely the P1 blocker this test locks against.
+	for _, gn := range normalGroups {
+		assert.Equal(t, normalThreadsEach, len(got[gn]),
+			"normal group %q must NOT be starved by fat group; got %d rows, want %d",
+			gn, len(got[gn]), normalThreadsEach)
 		for _, sid := range got[gn] {
 			assert.True(t, strings.HasPrefix(sid, gn+"_thr_"),
-				"boundary group rows must belong to that group; got %q under %q", sid, gn)
+				"normal group %q must only contain its own shortIDs; leaked %q", gn, sid)
 		}
-	}
-	// Tail: must be silently absent (zero rows returned for these groups).
-	// This is the exact symptom the truncated=true signal exists to cover.
-	tailStart := partialAt
-	if leftover > 0 {
-		tailStart = partialAt + 1
-	}
-	for i := tailStart; i < N; i++ {
-		gn := groupNos[i]
-		assert.Empty(t, got[gn],
-			"tail group %q past the LIMIT must be silently absent (that's what truncated=true warns about)", gn)
 	}
 }
 

--- a/modules/thread/db_batch_test.go
+++ b/modules/thread/db_batch_test.go
@@ -1,0 +1,85 @@
+package thread
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestQueryActiveShortIDsByGroupNos — batch IN query used by
+// messages_search.buildAllowlist to build the v1 thread allowlist. Verifies:
+//
+//  1. Multiple groups return distinct shortID lists keyed by group_no.
+//  2. Only status=active rows are surfaced (archived / deleted filtered).
+//  3. Groups the caller didn't list simply don't appear in the returned map.
+//  4. Empty input short-circuits to an empty map with no SQL.
+//  5. A group with zero active threads returns no key (not an empty slice).
+//
+// Integration test: requires a running MySQL (see main_test.go), same as
+// every other DB test in this package.
+func TestQueryActiveShortIDsByGroupNos(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	db := NewDB(ctx)
+
+	// Seed data: two groups with mixed statuses + a third group we won't
+	// query for (must not appear in results).
+	seed := []struct {
+		shortID string
+		groupNo string
+		status  int
+	}{
+		// grpA: two active, one archived, one deleted
+		{"thr_a1", "grpA", ThreadStatusActive},
+		{"thr_a2", "grpA", ThreadStatusActive},
+		{"thr_a3", "grpA", ThreadStatusArchived},
+		{"thr_a4", "grpA", ThreadStatusDeleted},
+		// grpB: one active only
+		{"thr_b1", "grpB", ThreadStatusActive},
+		// grpC: NOT queried
+		{"thr_c1", "grpC", ThreadStatusActive},
+		// grpD: no active threads at all (only archived)
+		{"thr_d1", "grpD", ThreadStatusArchived},
+	}
+	for _, s := range seed {
+		m := &Model{
+			ShortID:    s.shortID,
+			GroupNo:    s.groupNo,
+			Name:       "t-" + s.shortID,
+			CreatorUID: testutil.UID,
+			Status:     s.status,
+			Version:    1,
+		}
+		require.NoError(t, db.Insert(m))
+	}
+
+	// (1) empty input → empty map, no SQL error.
+	empty, err := db.QueryActiveShortIDsByGroupNos(nil)
+	require.NoError(t, err)
+	assert.Empty(t, empty, "empty input must return empty map")
+
+	// (2) grpA + grpB + grpD: only active rows surface, grpD absent entirely.
+	got, err := db.QueryActiveShortIDsByGroupNos([]string{"grpA", "grpB", "grpD"})
+	require.NoError(t, err)
+
+	sort.Strings(got["grpA"])
+	assert.Equal(t, []string{"thr_a1", "thr_a2"}, got["grpA"],
+		"grpA must yield exactly its two active threads (archived/deleted filtered)")
+	assert.Equal(t, []string{"thr_b1"}, got["grpB"],
+		"grpB must yield exactly its single active thread")
+	_, hasD := got["grpD"]
+	assert.False(t, hasD, "grpD has zero active threads and must not appear in the map")
+
+	// (3) grpC was not requested — must be absent.
+	_, hasC := got["grpC"]
+	assert.False(t, hasC, "un-requested group must not leak into results")
+
+	// (4) A brand-new group with no rows in the table returns nothing.
+	unknown, err := db.QueryActiveShortIDsByGroupNos([]string{"grpUnknown"})
+	require.NoError(t, err)
+	_, present := unknown["grpUnknown"]
+	assert.False(t, present, "group with no rows must not appear")
+}


### PR DESCRIPTION
## What

Restore the missing thread (channelType=5) coverage for global search, and land it on upstream `main`.

## Why

PR #550 (merged as `728e7ab`) landed the P0/P1 global endpoints plus the RC blacklist gate, but **without thread coverage** — the original commit that implemented thread v1 (`ba06ff65`) was made in a standalone workdir, never pushed, and got bypassed by the RC line, so it went missing. Owner requirement: thread messages must be reachable from global search. This PR restores that commit and makes it coexist with the blacklist gate that landed in #550.

Related: `YUJ-10` (thread coverage decision), `YUJ-11` (RC blacklist fix, already merged in #550), `YUJ-12` (this recovery task).

## What's in

Cherry-pick `ba06ff65` on top of `upstream/main` and resolve the merge conflict with the #550 blacklist gate:

- `modules/thread/db.go`: add `QueryActiveShortIDsByGroupNos` — a single IN-batch query that returns `(group_no, short_id)` for `status=active` rows, served entirely from the covering index. Coexists with the existing per-shortID `QueryActiveShortIDs` already on merged main.
- `modules/messages_search/search_global.go`:
  - `buildAllowlist` signature changes from `([]channelRef, []channelRef, error)` to `([]channelRef, []channelRef, []channelRef, error)`, adding `allowThread`.
  - **Keep** the blacklist gate introduced by #550 (`ExistMembersActive`, group-side fail-closed), and layer the ba06ff65 thread enumeration on top: once the trusted `groupNos` list is computed, call `enumerateThreadsForGroups` and fold the resulting `channelType=5` composite channel IDs into `allowSet`.
  - `enumerateThreadsForGroups`: batch-query active threads and stitch composite IDs via `thread.BuildChannelID(group, short)`. Two hard safety caps: `maxThreadsPerGroup=200` and `maxTotalThreadChannelIDs=2000` (over-cap triggers a WARN-level degrade). DB errors are soft-fail — group + DM allowlist stays intact.
  - `resolveGlobalScope`: accept `allowThread`, flatten it into `allowSet`; `filters.channel_ids` entries with `channel_type=5` composite IDs can now match; out-of-scope thread IDs are dropped silently.
  - `channelsForMember`: v1 explicitly retains group + DM entries only, discarding thread entries (avoids the extra join).
- `modules/messages_search/api.go`: add `threadEnumFn` / `externalGroupFn` test seams.
- Tests:
  - New `modules/messages_search/search_global_thread_test.go` (16 cases: buildAllowlist thread injection / soft-fail / per-group cap / global cap / channelsForMember drop / resolveGlobalScope narrowing).
  - New `modules/thread/db_batch_test.go` (`TestQueryActiveShortIDsByGroupNos` integration test, aligned with the rest of this package's DB tests — requires MySQL).
  - `sender_join_integration_test.go` stub merge: `stubGroupSvc` keeps both the #550 fields (`groupsForMember` / `activeGroupsForMember`) and the ba06ff65 field (`groupsByUID`); `GetGroupsWithMemberUID` prefers `groupsByUID` when set (thread tests) and falls back to `groupsForMember` otherwise (blacklist tests).

## Merge conflict resolution summary

`modules/messages_search/search_global.go` (single hot spot): take merged main's blacklist-gated group/DM logic as the base and layer three things from ba06ff65 on top:
1. Add a third return value `allowThread` to the signature.
2. After `groupNos` is computed, call `enumerateThreadsForGroups`.
3. Widen every `return ..., err` to the new 4-tuple.
4. In the loop that builds `allowGroup` / `groupNos`, `append(groupNos, no)` uses the current loop variable (HEAD side only exposes `no`, not `g.GroupNo`).

`modules/messages_search/sender_join_integration_test.go`: merge stub fields and methods — both field sets are preserved, and `GetGroupsWithMemberUID` becomes the single entry point that falls back correctly.

## Hard constraints held

- No indexer / OS mapping change.
- No revert of the blacklist gate or the P0-P1 fixes that landed on merged main.
- No regression on single-channel `_search*` paths (they are untouched).

## Verification

```
$ git diff upstream/main --stat
 modules/messages_search/api.go                     |  11 +
 modules/messages_search/search_global.go           | 197 +++++++++--
 modules/messages_search/search_global_thread_test.go   | 366 +++++++++++++++++++++
 modules/messages_search/sender_join_integration_test.go |  15 +-
 modules/thread/db.go                               |  38 +++
 modules/thread/db_batch_test.go                    |  85 +++++
 6 files changed, 682 insertions(+), 30 deletions(-)

$ go build ./...
# (clean)

$ go vet ./modules/messages_search/... ./modules/thread/...
# (clean)

$ go test ./modules/messages_search/... -count=1
ok  	github.com/Mininglamp-OSS/octo-server/modules/messages_search	0.050s
```

New thread-coverage tests (`search_global_thread_test.go`) all pass:

```
--- PASS: TestBuildAllowlist_IncludesThreadChannelIDs (0.00s)
--- PASS: TestBuildAllowlist_ThreadEnumerateSoftFail (0.00s)
--- PASS: TestBuildAllowlist_ThreadPerGroupCap (0.00s)
--- SKIP: TestBuildAllowlist_ThreadGlobalAggregateCap (0.00s)   # test-config note: only runs when maxTotalThreadChannelIDs > maxThreadsPerGroup
--- PASS: TestBuildAllowlist_EmptyGroupsNoThreadQuery (0.00s)
--- PASS: TestChannelsForMember_DropsThreadsInV1 (0.00s)
--- PASS: TestResolveGlobalScope_ThreadNarrowingHits (0.00s)
--- PASS: TestResolveGlobalScope_ThreadOutsideMembership (0.00s)
--- PASS: TestApplySpaceIDScope_ThreadBypassed (0.00s)
```

`modules/thread/db_batch_test.go`'s `TestQueryActiveShortIDsByGroupNos` follows the same pattern as the other DB integration tests in this package (`main_test.go` boots MySQL via `testutil.NewTestServer`); not run locally due to no MySQL, but CI has a MySQL fixture.
