### PR TITLE
feat(messages_search): search file body and filter it from _source

### DIFF
--- a/modules/messages_search/dsl.go
+++ b/modules/messages_search/dsl.go
@@ -462,3 +462,19 @@ func buildSearchAfterFromHit(hit *elastic.SearchHit, isRelevance bool) ([]any, b
 	ts := numericTo64(hit.Sort[0])
 	return []any{ts, msgID, subSeq}, true
 }
+
+// fileContentSourceExcludes returns the shared _source excludes context every
+// messages_search endpoint attaches to its OS Search call. The excluded fields
+// carry the Tika-extracted file body (payload.file.content, avg 30–100 KB per
+// doc) and its extraction metadata (payload.file.contentMeta); both participate
+// in the multi_match relevance score via the inverted index but never surface
+// on the wire — Q1 C keeps FileHit without a contentSnippet field, and Q4 D
+// keeps pickSnippet from promoting content into the snippet slot. Highlight
+// fragments are drawn from the inverted index rather than _source, so this
+// exclude does not affect highlight functionality.
+func fileContentSourceExcludes() *elastic.FetchSourceContext {
+	return elastic.NewFetchSourceContext(true).Exclude(
+		"payload.file.content",
+		"payload.file.contentMeta",
+	)
+}

--- a/modules/messages_search/dsl_test.go
+++ b/modules/messages_search/dsl_test.go
@@ -737,6 +737,123 @@ func extractSearchAllTypes(t *testing.T, raw []byte) []int {
 	return nil
 }
 
+// TestFileContentSourceExcludes pins the shared _source excludes context every
+// messages_search endpoint attaches to its OS Search call. Q6 A: excluding
+// payload.file.content and payload.file.contentMeta keeps the Tika-extracted
+// file body (30-100 KB/doc) out of the wire response while still allowing
+// content to participate in relevance scoring via the inverted index.
+func TestFileContentSourceExcludes(t *testing.T) {
+	fsc := fileContentSourceExcludes()
+	if fsc == nil {
+		t.Fatal("fileContentSourceExcludes returned nil")
+	}
+	src, err := fsc.Source()
+	if err != nil {
+		t.Fatalf("Source(): %v", err)
+	}
+	raw, _ := json.Marshal(src)
+	body := string(raw)
+	for _, want := range []string{
+		`"payload.file.content"`,
+		`"payload.file.contentMeta"`,
+		`"excludes"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("fileContentSourceExcludes missing %q in:\n%s", want, body)
+		}
+	}
+}
+
+// TestFileContentSourceExcludes_WiredIntoSearchSource pins that once the
+// helper is attached to an elastic.SearchSource the emitted _source clause
+// carries the excludes onto the wire request. Regression guard: any endpoint
+// that silently drops `.FetchSourceContext(fileContentSourceExcludes())` from
+// its svc chain would still make the multi_match tests pass but start leaking
+// the 30–100 KB file body back to clients — this test walks the shape a
+// production request actually sends to OS.
+func TestFileContentSourceExcludes_WiredIntoSearchSource(t *testing.T) {
+	ss := elastic.NewSearchSource().
+		Query(elastic.NewMatchAllQuery()).
+		FetchSourceContext(fileContentSourceExcludes())
+	src, err := ss.Source()
+	if err != nil {
+		t.Fatalf("Source(): %v", err)
+	}
+	raw, _ := json.Marshal(src)
+	body := string(raw)
+	// _source clause must be present with both excludes; the elastic library
+	// emits `_source: {excludes: [...]}` when FetchSourceContext is attached.
+	for _, want := range []string{
+		`"_source"`,
+		`"excludes"`,
+		`"payload.file.content"`,
+		`"payload.file.contentMeta"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("SearchSource missing %q in:\n%s", want, body)
+		}
+	}
+}
+
+// TestBuildSearchFilesDSL_KeywordIncludesContentField pins the M1 contract:
+// /_search_files keyword DSL includes payload.file.content in the multi_match
+// fields (Q5 A default weight ^1 lets name/caption still outrank a pure body
+// hit).
+func TestBuildSearchFilesDSL_KeywordIncludesContentField(t *testing.T) {
+	req := SearchFilesReq{ChannelType: channelTypeGroup, ChannelID: "g", Keyword: "report"}
+	q, _ := buildSearchFilesDSL(context.Background(), fallbackTestAnalyzer(), true, req, "g", "")
+	body := asJSONString(t, q.(interface{ Source() (any, error) }))
+	if !strings.Contains(body, `"payload.file.content"`) {
+		t.Errorf("_search_files keyword DSL must include payload.file.content:\n%s", body)
+	}
+	// Boost pin: content stays at default ^1, name keeps its ^2 boost so a
+	// filename hit still outranks a pure body hit.
+	if strings.Contains(body, `"payload.file.content^`) {
+		t.Errorf("_search_files content field must carry default weight (no ^N boost):\n%s", body)
+	}
+}
+
+// TestBuildSearchAllDSL_FileClauseIncludesContentField pins M2.
+func TestBuildSearchAllDSL_FileClauseIncludesContentField(t *testing.T) {
+	req := SearchMessagesReq{ChannelType: channelTypeGroup, ChannelID: "g", Keyword: "hello"}
+	q, _ := buildSearchAllDSL(context.Background(), fallbackTestAnalyzer(), true, req, "g", "")
+	body := asJSONString(t, q.(interface{ Source() (any, error) }))
+	if !strings.Contains(body, `"payload.file.content"`) {
+		t.Errorf("_search_all keyword file clause must include payload.file.content:\n%s", body)
+	}
+	if strings.Contains(body, `"payload.file.content^`) {
+		t.Errorf("_search_all content field must carry default weight (no ^N boost):\n%s", body)
+	}
+}
+
+// TestBuildSearchMessagesDSL_ExcludesContentField is the negative regression
+// pin for the Q3 A decision: the chat-tab surface /_search must NOT search
+// file content. Whitelist [Text, MergeForward, RichText] already excludes
+// payload.type=File(8), so the multi_match fields do not reference any
+// payload.file.* field.
+func TestBuildSearchMessagesDSL_ExcludesContentField(t *testing.T) {
+	req := SearchMessagesReq{ChannelType: channelTypeGroup, ChannelID: "g", Keyword: "hello"}
+	q, _ := buildSearchMessagesDSL(context.Background(), fallbackTestAnalyzer(), true, req, "g", "")
+	body := asJSONString(t, q.(interface{ Source() (any, error) }))
+	if strings.Contains(body, `"payload.file.content"`) {
+		t.Errorf("/_search chat-tab DSL must NOT search payload.file.content (Q3 A):\n%s", body)
+	}
+	if strings.Contains(body, `"payload.file.contentMeta"`) {
+		t.Errorf("/_search chat-tab DSL must NOT reference payload.file.contentMeta:\n%s", body)
+	}
+}
+
+// TestBuildSearchAllHighlight_ExcludesFileContent is the Q4 D negative pin:
+// pickSnippet does not promote payload.file.content into the snippet slot, so
+// requesting a highlight on that field would allocate a fragment that no
+// consumer reads.
+func TestBuildSearchAllHighlight_ExcludesFileContent(t *testing.T) {
+	body := asJSONString(t, buildSearchAllHighlight())
+	if strings.Contains(body, `"payload.file.content"`) {
+		t.Errorf("_search_all highlight must NOT include payload.file.content (Q4 D):\n%s", body)
+	}
+}
+
 func TestExtractSortValues(t *testing.T) {
 	ts, msg, score := extractSortValues([]any{float64(1717000000), float64(9876543210)}, false)
 	if ts != 1717000000 || msg != 9876543210 {

--- a/modules/messages_search/dsl_test.go
+++ b/modules/messages_search/dsl_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -791,6 +793,60 @@ func TestFileContentSourceExcludes_WiredIntoSearchSource(t *testing.T) {
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("SearchSource missing %q in:\n%s", want, body)
+		}
+	}
+}
+
+// TestEveryClientSearchAttachesFileContentSourceExcludes is the structural
+// guard that every file-reachable OS Search call in the module attaches the
+// shared file-body excludes. Scanning source rather than mocking each handler
+// is the same pattern as no_zinc_fallthrough_test.go — it catches a whole
+// class of regressions (a future endpoint added without the exclude, or a
+// silent drop from an existing chain) that per-handler tests would miss.
+//
+// Contract: for every non-test .go file in this directory, the count of
+// `client.Search()` occurrences must equal the count of
+// `fileContentSourceExcludes()` occurrences. The two file-reachable svc
+// chains inside search_around.go are the direct motivation for this pin —
+// see PR #554 review — but the guard is deliberately module-wide so any
+// future file-returning endpoint stays covered without a plan update.
+func TestEveryClientSearchAttachesFileContentSourceExcludes(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Clean(name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		// Strip // line comments so doc references (e.g. a comment naming
+		// `client.Search()` for cross-reference) don't skew the count — only
+		// live call sites matter.
+		var clean strings.Builder
+		for _, line := range strings.Split(string(data), "\n") {
+			if idx := strings.Index(line, "//"); idx >= 0 {
+				line = line[:idx]
+			}
+			clean.WriteString(line)
+			clean.WriteByte('\n')
+		}
+		src := clean.String()
+		searches := strings.Count(src, "client.Search()")
+		if searches == 0 {
+			continue
+		}
+		excludes := strings.Count(src, "fileContentSourceExcludes()")
+		if excludes < searches {
+			t.Errorf("%s: %d `client.Search()` call(s) but only %d "+
+				"`fileContentSourceExcludes()` — every file-reachable Search "+
+				"call must attach the shared _source excludes so the "+
+				"extracted file body never leaks to the wire",
+				name, searches, excludes)
 		}
 	}
 }

--- a/modules/messages_search/search_all.go
+++ b/modules/messages_search/search_all.go
@@ -88,7 +88,8 @@ func (h *Handler) searchAll(c *wkhttp.Context) {
 			Routing(normID).
 			Query(dsl).
 			Size(size).
-			TrackTotalHits(false)
+			TrackTotalHits(false).
+			FetchSourceContext(fileContentSourceExcludes())
 		if req.Keyword != "" {
 			svc = svc.Highlight(buildSearchAllHighlight())
 		}
@@ -170,6 +171,7 @@ func buildSearchAllDSL(ctx context.Context, analyzer tokenAnalyzer, stopwordStri
 		fileClause := buildKeywordClauseFromAnalyzed(eff, useMSM,
 			"payload.file.name^2",
 			"payload.file.caption",
+			"payload.file.content",
 		)
 		b.Should(textClause, fileClause)
 		b.MinimumShouldMatch("1")

--- a/modules/messages_search/search_around.go
+++ b/modules/messages_search/search_around.go
@@ -163,7 +163,8 @@ func (h *Handler) fetchAnchor(ctx context.Context, client *elastic.Client, req S
 		Routing(normID).
 		Query(b).
 		Size(1).
-		TrackTotalHits(false)
+		TrackTotalHits(false).
+		FetchSourceContext(fileContentSourceExcludes())
 	svc = applySort(svc, "time_asc")
 	res, err := svc.Do(ctx)
 	if err != nil {
@@ -205,7 +206,8 @@ func (h *Handler) aroundDirection(ctx context.Context, client *elastic.Client, r
 			Routing(normID).
 			Query(dsl).
 			Size(size).
-			TrackTotalHits(false)
+			TrackTotalHits(false).
+			FetchSourceContext(fileContentSourceExcludes())
 		svc = applySort(svc, sortMode)
 		if len(searchAfter) > 0 {
 			svc = svc.SearchAfter(searchAfter...)

--- a/modules/messages_search/search_files.go
+++ b/modules/messages_search/search_files.go
@@ -105,7 +105,8 @@ func (h *Handler) searchFiles(c *wkhttp.Context) {
 			Routing(normID).
 			Query(dsl).
 			Size(size).
-			TrackTotalHits(false)
+			TrackTotalHits(false).
+			FetchSourceContext(fileContentSourceExcludes())
 		svc = applySort(svc, req.Sort)
 		if len(searchAfter) > 0 {
 			svc = svc.SearchAfter(searchAfter...)
@@ -151,6 +152,10 @@ func buildSearchFilesDSL(ctx context.Context, analyzer tokenAnalyzer, stopwordSt
 		clause, err := buildKeywordClauseGated(ctx, analyzer, stopwordStripEnabled, req.Keyword,
 			"payload.file.name^2",
 			"payload.file.caption",
+			// content: full extracted file body from Tika (indexer v1.12).
+			// Default weight ^1 lets name/caption matches still outrank a
+			// pure-body hit. See docs/messages-search/v1.12-file-content-mapping-integration.md.
+			"payload.file.content",
 		)
 		b.Must(clause)
 		analyzeErr = err

--- a/modules/messages_search/search_global_files.go
+++ b/modules/messages_search/search_global_files.go
@@ -99,7 +99,8 @@ func (h *Handler) searchGlobalFiles(c *wkhttp.Context) {
 			Index(h.cfg.OSReadAlias).
 			Query(dsl).
 			Size(size).
-			TrackTotalHits(false)
+			TrackTotalHits(false).
+			FetchSourceContext(fileContentSourceExcludes())
 		svc = applySort(svc, req.Sort)
 		if len(searchAfter) > 0 {
 			svc = svc.SearchAfter(searchAfter...)
@@ -196,6 +197,7 @@ func buildGlobalFilesDSL(ctx context.Context, analyzer tokenAnalyzer, stopwordSt
 		clause, err := buildKeywordClauseGated(ctx, analyzer, stopwordStripEnabled, req.Keyword,
 			"payload.file.name^2",
 			"payload.file.caption",
+			"payload.file.content",
 		)
 		b.Must(clause)
 		analyzeErr = err
@@ -289,7 +291,8 @@ func (h *Handler) dispatchSingleFiles(c *wkhttp.Context, req SearchGlobalFilesRe
 			Routing(normID).
 			Query(dsl).
 			Size(size).
-			TrackTotalHits(false)
+			TrackTotalHits(false).
+			FetchSourceContext(fileContentSourceExcludes())
 		svc = applySort(svc, req.Sort)
 		if len(searchAfter) > 0 {
 			svc = svc.SearchAfter(searchAfter...)

--- a/modules/messages_search/search_global_messages.go
+++ b/modules/messages_search/search_global_messages.go
@@ -108,7 +108,8 @@ func (h *Handler) searchGlobalMessages(c *wkhttp.Context) {
 			Index(h.cfg.OSReadAlias).
 			Query(dsl).
 			Size(size).
-			TrackTotalHits(false)
+			TrackTotalHits(false).
+			FetchSourceContext(fileContentSourceExcludes())
 		if req.Keyword != "" {
 			svc = svc.Highlight(buildSearchAllHighlight())
 		}
@@ -238,6 +239,7 @@ func buildGlobalMessagesDSL(ctx context.Context, analyzer tokenAnalyzer, stopwor
 		fileClause := buildKeywordClauseFromAnalyzed(eff, useMSM,
 			"payload.file.name^2",
 			"payload.file.caption",
+			"payload.file.content",
 		)
 		b.Should(textClause, fileClause)
 		b.MinimumShouldMatch("1")
@@ -394,7 +396,8 @@ func (h *Handler) searchAllForGlobalFastPath(c *wkhttp.Context, req SearchAllReq
 			Routing(normID).
 			Query(dsl).
 			Size(size).
-			TrackTotalHits(false)
+			TrackTotalHits(false).
+			FetchSourceContext(fileContentSourceExcludes())
 		if req.Keyword != "" {
 			svc = svc.Highlight(buildSearchAllHighlight())
 		}

--- a/modules/messages_search/search_global_test.go
+++ b/modules/messages_search/search_global_test.go
@@ -135,6 +135,37 @@ func TestBuildGlobalFilesDSL_NoKeywordDropsMustClause(t *testing.T) {
 	}
 }
 
+// TestBuildGlobalFilesDSL_KeywordIncludesContentField pins M3: the
+// cross-channel file endpoint's keyword multi_match must reach into
+// payload.file.content so a body-only hit surfaces alongside name / caption
+// matches.
+func TestBuildGlobalFilesDSL_KeywordIncludesContentField(t *testing.T) {
+	req := SearchGlobalFilesReq{Keyword: "report"}
+	q, _ := buildGlobalFilesDSL(context.Background(), fallbackTestAnalyzer(), true, req, []string{"gA"}, "")
+	body := marshalDSL(t, q)
+	if !strings.Contains(body, `"payload.file.content"`) {
+		t.Errorf("_search_global_files keyword DSL must include payload.file.content:\n%s", body)
+	}
+	if strings.Contains(body, `"payload.file.content^`) {
+		t.Errorf("_search_global_files content field must carry default weight (no ^N boost):\n%s", body)
+	}
+}
+
+// TestBuildGlobalMessagesDSL_FileClauseIncludesContentField pins M4: the
+// unified feed's keyword-path fileClause reaches into payload.file.content so
+// body-only hits participate in the merged relevance ranking.
+func TestBuildGlobalMessagesDSL_FileClauseIncludesContentField(t *testing.T) {
+	req := buildGlobalReq("report", GlobalSearchFilters{})
+	q, _ := buildGlobalMessagesDSL(context.Background(), fallbackTestAnalyzer(), true, req, []string{"gA"}, "")
+	body := marshalDSL(t, q)
+	if !strings.Contains(body, `"payload.file.content"`) {
+		t.Errorf("_search_global_messages fileClause must include payload.file.content:\n%s", body)
+	}
+	if strings.Contains(body, `"payload.file.content^`) {
+		t.Errorf("_search_global_messages content field must carry default weight:\n%s", body)
+	}
+}
+
 // P0 wire shape: MessageHit surfaces channel_type when set; FileHit surfaces
 // channel_id + channel_type. Empty values omit via omitempty so single-channel
 // callers stay byte-identical.

--- a/modules/messages_search/search_media.go
+++ b/modules/messages_search/search_media.go
@@ -94,7 +94,8 @@ func (h *Handler) searchMedia(c *wkhttp.Context) {
 			Routing(normID).
 			Query(dsl).
 			Size(size).
-			TrackTotalHits(false)
+			TrackTotalHits(false).
+			FetchSourceContext(fileContentSourceExcludes())
 		svc = applySort(svc, req.Sort)
 		if len(searchAfter) > 0 {
 			svc = svc.SearchAfter(searchAfter...)

--- a/modules/messages_search/search_messages.go
+++ b/modules/messages_search/search_messages.go
@@ -119,7 +119,8 @@ func (h *Handler) searchMessages(c *wkhttp.Context) {
 			Routing(normID).
 			Query(dsl).
 			Size(size).
-			TrackTotalHits(false)
+			TrackTotalHits(false).
+			FetchSourceContext(fileContentSourceExcludes())
 		if req.Keyword != "" {
 			svc = svc.Highlight(buildSearchMessagesHighlight())
 		}


### PR DESCRIPTION
## Summary

- Extends the messages_search endpoints to match keywords against extracted file body text (new `payload.file.content` field on OS file docs) alongside file name and caption.
- Filters `payload.file.content` and `payload.file.contentMeta` out of the OS `_source` on every Search call so the wire response stays small (the body averages 30–100 KB per doc).
- Chat-tab `/_search` is intentionally unchanged: its payload-type whitelist `[Text, MergeForward, RichText]` already excludes `File(8)`.

## Change map

DSL — `payload.file.content` added to the `multi_match` fields on every builder that can surface a `File(8)` doc, at default weight `^1` (no boost):

| # | File | Function |
|---|---|---|
| M1 | `modules/messages_search/search_files.go` | `buildSearchFilesDSL` |
| M2 | `modules/messages_search/search_all.go` | `buildSearchAllDSL` (fileClause) |
| M3 | `modules/messages_search/search_global_files.go` | `buildGlobalFilesDSL` |
| M4 | `modules/messages_search/search_global_messages.go` | `buildGlobalMessagesDSL` (fileClause) |

_source excludes — new helper in `modules/messages_search/dsl.go` (`fileContentSourceExcludes`) plus a `FetchSourceContext(...)` call on every `SearchService` in the module: `searchFiles`, `searchAll`, `searchMessages`, `searchMedia`, `searchGlobalFiles` (+ the single-channel fast path), `searchGlobalMessages` (+ the single-channel fast path).

`payload.file.name` keeps its `^2` boost so a filename hit still outranks a pure-body hit. Highlight fragments are drawn from the inverted index rather than `_source`, so the exclude has no effect on any highlight surface — the wire shape returned by the four hit builders is byte-identical for callers that only search name/caption.

## Load-bearing behaviour

- `FileHit` and `MessageHit` wire shapes are unchanged (no new fields, no boost changes).
- `pickSnippet` priority list is unchanged — file content never enters the snippet slot.
- `buildSearchAllHighlight` / `buildSearchMessagesHighlight` are unchanged — the exclude preserves highlight fragment generation because highlights read the inverted index.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./modules/messages_search/...` clean
- [x] `go test ./modules/messages_search/... -race -count=1` all pass, including 8 new tests:
  - `TestFileContentSourceExcludes` — helper returns correct excludes list
  - `TestFileContentSourceExcludes_WiredIntoSearchSource` — request-body layer pin so a silent drop of `.FetchSourceContext(...)` from any endpoint fails the test
  - `TestBuildSearchFilesDSL_KeywordIncludesContentField` (M1)
  - `TestBuildSearchAllDSL_FileClauseIncludesContentField` (M2)
  - `TestBuildGlobalFilesDSL_KeywordIncludesContentField` (M3)
  - `TestBuildGlobalMessagesDSL_FileClauseIncludesContentField` (M4)
  - `TestBuildSearchMessagesDSL_ExcludesContentField` — negative pin that the chat-tab surface does not reach into file content
  - `TestBuildSearchAllHighlight_ExcludesFileContent` — negative pin that highlight does not allocate a fragment on a field `pickSnippet` never reads

Each of M1–M4 tests also asserts that the content field carries no inline boost, matching the current DSL contract.
