### PR TITLE
feat(cardmsg): P3-3 rich inputs + AC 1.5 display elements (ImageSet/RichTextBlock/Table/ActionSet) + D12 manifest

### DIFF
--- a/.octospec/journal/shared/card-message-p3-rich-inputs.md
+++ b/.octospec/journal/shared/card-message-p3-rich-inputs.md
@@ -1,0 +1,88 @@
+---
+type: Journal
+title: "Journal: card-message-p3-rich-inputs (card message P3-3)"
+description: Record of P3-3 — extend the octo/v2 input whitelist with Input.Number/Date/Time (all AC 1.0, within the pinned card_version "1.5"; additive, no version bump), add submit-time value validation (finite Number + declared min/max, Date YYYY-MM-DD, Time HH:MM), refactor the whitelist into a single pkg/cardmsg authority that validator + collector + dispatcher + D12 manifest all derive from, and additively advertise elements/inputs on GET /v1/bot/card/profile. No new errcode/DB/endpoint.
+tags: ["card", "wire-contract", "trust-boundary", "bot-api", "testing"]
+timestamp: 2026-07-09T01:00:00Z
+# --- octospec extension fields ---
+task: card-message-p3-rich-inputs
+upstream: card-message-interaction P3-3
+source: self
+---
+
+# Journal: card-message-p3-rich-inputs (card message P3-3)
+
+## What was done
+
+Delivered the server half of P3-3 (richer card inputs). Octo's octo/v2 whitelist
+accepted only 3 of Adaptive Cards' 6 input elements; added the missing three.
+
+- **`pkg/cardmsg/whitelist.go` (new)** — the single authority for the element
+  whitelists: `displayElements` (octo/v1 display set, shared) and `inputElements`
+  (octo/v2 interactive inputs), plus `DisplayElements()` / `InputElements()`
+  accessors. `isInputElement` moved here. The validator, the submit-time inputs
+  collector, the dispatch walker, and the D12 manifest now all derive from these
+  two slices — no re-typed literals anywhere.
+- **`validate.go`** — send-time whitelist extended to `Input.Number/Date/Time`.
+  The `element()` type switch no longer enumerates input literals; unknown types
+  fall through to `default` and are accepted iff `isInputElement(t)`, so adding
+  an input element is a one-line change in `whitelist.go`.
+- **`inputs.go`** — submit-time value validation for the new types (trust
+  boundary D11): Number = finite numeric + declared `min`/`max`; Date =
+  `YYYY-MM-DD` + declared range; Time = `HH:MM` (24h) + declared range; `""`
+  passes as "unfilled". `isRequired`/`regex` remain client-UX + bot concerns.
+- **`interactive.go`** — dispatch (`findSubmitInElements`) walks `inlineAction`
+  via the same `isInputElement` predicate as validation.
+- **`modules/bot_api/card_profile.go`** — D12 manifest additively advertises
+  `elements` and `inputs` (from the cardmsg authority) so producers can
+  feature-detect at element granularity even while `card_version` stays "1.5".
+- **`docs/card-protocol.md`** kept a faithful mirror (§2 whitelist, §3 manifest,
+  §7.1 inputs trust boundary).
+
+No new errcode / i18n / DB / migration / endpoint; wire contract additive-only.
+Verified live against adaptivecards.io that all three new inputs are AC 1.0 and
+`Data.Query` (dynamic typeahead) is AC 1.6 — so this stays inside the pinned 1.5.
+
+## Structural learnings
+
+- **Widening a whitelist means widening every surface that mirrors it — and the
+  cleanest way to guarantee that is one predicate/authority all surfaces derive
+  from.** This change touches four surfaces of the same whitelist: send-time
+  validation, submit-time input collection, action dispatch, and the capability
+  manifest. Two review bugs came precisely from surfaces that were *not* driven
+  by a shared authority: (1) dispatch still hardcoded the old 3 input types, so
+  `Input.Number/Date/Time.inlineAction` validated at send but was undispatchable
+  → a "send-ok, click-invalid" dead button; (2) the manifest would have re-typed
+  the input list. Routing validation + collection + dispatch + manifest all
+  through `isInputElement` / `InputElements()` makes the four physically
+  incapable of drifting. Guard tests (`TestInputElementsAuthority`,
+  `TestSubmitActionDispatchRichInputInlineAction`) pin the symmetry.
+- **`strconv.ParseFloat` accepts non-finite tokens without error.** `"NaN"`,
+  `"Inf"`, `"+Inf"`, `"Infinity"` (case-insensitive) all parse to a valid
+  `float64` with `err == nil`, and `NaN` compares `false` against every bound —
+  so a naive `ParseFloat` + `min/max` check silently accepts non-finite values.
+  Any numeric wire-input validator must add an explicit
+  `math.IsNaN || math.IsInf` reject. This is the numeric analogue of the
+  "validation surface must cover the whole value space" discipline.
+
+## Gotchas
+
+- Additive-within-1.5 is invisible to version-based negotiation. Because the
+  three new inputs are additive to octo/v2 and `card_version` stays "1.5", a
+  version-only capability gate cannot distinguish a deployment that accepts them
+  from an older 1.5 deployment that 400s them. The manifest's new `elements` /
+  `inputs` arrays are exactly the element-granularity probe that closes this gap.
+- Host has no `go` binary; unit tests were run via a workspace-local
+  `.context/go` (go1.25.12) reusing the host module cache. `pkg/cardmsg` is pure;
+  `modules/bot_api` / `modules/message` card tests need MySQL (`octo-test-mysql`)
+  + `OCTO_MASTER_KEY` (exactly 32 bytes).
+
+## Open (deferred, in brief)
+
+- Whether server-enforced `min/max` (chosen default, consistent with ChoiceSet /
+  Toggle declared-value checks) should instead be delegated to bot business
+  validation — flagged for maintainer confirmation.
+- AC 1.6 `Data.Query` (dynamic typeahead) is a separate XL item: it needs a new
+  synchronous client→bot query channel that Octo's async event-queue model does
+  not have. Sequenced after modal forms (Goal 4), gated on a real
+  remote/huge-choice-set need.

--- a/.octospec/journal/shared/card-message-p3-rich-inputs.md
+++ b/.octospec/journal/shared/card-message-p3-rich-inputs.md
@@ -28,11 +28,12 @@ accepted only 3 of Adaptive Cards' 6 input elements; added the missing three.
   fall through to `default` and are accepted iff `isInputElement(t)`, so adding
   an input element is a one-line change in `whitelist.go`.
 - **`inputs.go`** — submit-time **format** validation for the new types (trust
-  boundary D11): Number = finite numeric (reject `NaN`/`±Inf`); Date =
-  `YYYY-MM-DD`; Time = `HH:MM` (24h); `""` passes as "unfilled". `min`/`max`
-  range is **not** server-enforced (delegated to bot — see Open item, resolved
-  by maintainer in PR#556 review); `isRequired`/`regex` likewise remain
-  client-UX + bot concerns.
+  boundary D11): Number = strict JSON-number grammar + finite (reject `NaN`/`±Inf`
+  and `ParseFloat`'s Go-only superset `1_000`/`0x1p4`/leading-`+`/…); Date =
+  `YYYY-MM-DD`; Time = `HH:MM` (24h); `""` passes as "unfilled"; a `default` arm
+  fail-closes an unhandled declared input type. `min`/`max` range is **not**
+  server-enforced (delegated to bot — see Open item, resolved by maintainer in
+  PR#556 review); `isRequired`/`regex` likewise remain client-UX + bot concerns.
 - **`interactive.go`** — dispatch (`findSubmitInElements`) walks `inlineAction`
   via the same `isInputElement` predicate as validation.
 - **`modules/bot_api/card_profile.go`** — D12 manifest additively advertises
@@ -59,15 +60,31 @@ Verified live against adaptivecards.io that all three new inputs are AC 1.0 and
   through `isInputElement` / `InputElements()` makes the four physically
   incapable of drifting. Guard tests (`TestInputElementsAuthority`,
   `TestSubmitActionDispatchRichInputInlineAction`) pin the symmetry.
-- **`strconv.ParseFloat` accepts non-finite tokens without error.** `"NaN"`,
-  `"Inf"`, `"+Inf"`, `"Infinity"` (case-insensitive) all parse to a valid
-  `float64` with `err == nil` — so a `ParseFloat`-only "is it a number" check
-  silently accepts non-finite values, and `NaN` further compares `false` against
-  any bound (i.e. it would also slip past a naive `min/max` gate). Non-finite is
-  not a valid numeric input regardless of whether a range is enforced: any
-  numeric wire-input validator must add an explicit `math.IsNaN || math.IsInf`
-  reject. This is the numeric analogue of the "validation surface must cover the
-  whole value space" discipline.
+- **`strconv.ParseFloat` accepts a *superset* of the JSON/JS number grammar — in
+  two independent ways.** (1) Non-finite tokens: `"NaN"`, `"Inf"`, `"+Inf"`,
+  `"Infinity"` (case-insensitive) all parse to a valid `float64` with `err == nil`
+  (and `NaN` compares `false` against any bound, slipping past a naive min/max gate
+  too). (2) Go-only lexical forms: underscore digit separators (`"1_000"`), hex
+  floats (`"0x1p4"`), a leading `+`, and leading zeros all parse fine. Both classes
+  mean a `ParseFloat`-only "is it a number" check blesses strings that the *bot's*
+  JSON parser (the downstream consumer) rejects or reads differently — a silent
+  value corruption across the trust boundary. A wire-input numeric validator must
+  validate against the **consumer's** grammar (strict RFC 8259 JSON-number regexp),
+  then reject non-finite explicitly (`math.IsNaN || math.IsInf`, for overflow like
+  `"1e999"→±Inf`). The server's "valid number" must equal what the value re-parses
+  to downstream — not merely "Go can parse it" (PR#556 review #2).
+- **A capability manifest derived from a whitelist must advertise each element in
+  the position the manifest implies — and its drift-guard must test that position,
+  not any legal one.** The D12 `elements` list read as "top-level display elements a
+  producer can place in `body`", but included `Column` — which the validator only
+  accepts *nested inside `ColumnSet`* (no top-level `Column` case). So the manifest
+  advertised a placement the validator rejects. The guard test masked it by wrapping
+  the `Column` fixture in a `ColumnSet` ("legal position"), so it validated a
+  position the manifest does *not* imply. Fix: drop `Column` from the list (it is
+  structurally subsumed by `ColumnSet`) and make the guard validate every advertised
+  element as a **top-level `body` element** — the exact shape the manifest promises.
+  A drift guard that tests a *different* position than the contract promises is not a
+  guard (PR#556 review #4).
 
 ## Gotchas
 

--- a/.octospec/journal/shared/card-message-p3-rich-inputs.md
+++ b/.octospec/journal/shared/card-message-p3-rich-inputs.md
@@ -116,3 +116,10 @@ Table(1.5) / ActionSet(1.2)**（版本实测 adaptivecards.io）。每个元素�
 Gotcha：修正了既有 `TestValidateWhitelistRejections` 把 Table 误标「AC 1.6 应拒」——Table 实为
 **1.5**、现已支持，替换为仍未支持的 Media(1.1)/ToggleVisibility(1.2) 保持负向覆盖。仍未支持
 （后续按需）：Media、Action.ShowCard/ToggleVisibility/Execute、模板/数据绑定、AC 1.6 元素。
+
+Gotcha 2（review 追加）：Table 是**第三个**需要同步的镜像面证据。加 Table 时补了校验
+（`w.elements` 递归 cell.items）和派发（`findSubmitInElements` 递归 Table），却漏了**提交期 input
+采集**（`collectInputSpecsFromElements` 只递归 Container/ColumnSet）。后果：Table 单元格里的
+`Input.*` 发送/派发都通过，提交却被当「未声明」拒。修复=采集侧也递归 Table cell items。教训重申：
+「校验 / 派发 / **采集**」是同一白名单的三个消费面，任何递归容器都必须三处同步——理想是共享一个
+遍历器，退而求其次是每个面都有守卫测试（本次补 `TestTier1TableCellInputCollected`）。

--- a/.octospec/journal/shared/card-message-p3-rich-inputs.md
+++ b/.octospec/journal/shared/card-message-p3-rich-inputs.md
@@ -96,3 +96,23 @@ Verified live against adaptivecards.io that all three new inputs are AC 1.0 and
   synchronous client→bot query channel that Octo's async event-queue model does
   not have. Sequenced after modal forms (Goal 4), gated on a real
   remote/huge-choice-set need.
+
+## Tier 1 追加 — AC 1.5 展示元素补全（同 PR，PR#556 讨论后加入）
+
+同一 PR 内把 octo/v2 展示白名单补齐到 AC ≤1.5：新增 **ImageSet(1.0) / RichTextBlock(1.2) /
+Table(1.5) / ActionSet(1.2)**（版本实测 adaptivecards.io）。每个元素覆盖四个面：
+
+- **校验**（validate.go）：ImageSet 逐图复用 Image 纪律（新 `imageChild`）；RichTextBlock 遍历
+  inlines、TextRun.selectAction 过 URL allowlist（TextRun 非 markdown，text 无链接面）；Table
+  递归 rows→cells→items（计入节点/深度预算）+ cell selectAction/backgroundImage；ActionSet.actions
+  走动作 allowlist（Submit 仍受 octo/v2 门控）。
+- **派发对称**（interactive.go）：`findSubmitInElements` 同步遍历 ActionSet.actions、Table
+  cells、ImageSet images、RichTextBlock inlines 的 selectAction —— 与本 PR 的 inlineAction 教训
+  同源（校验面 == 派发面，防「发送通过、点击死按钮」）。
+- **plain 派生**（plain.go）：RichTextBlock 拼接文本、ImageSet 每图 `[图片]`、Table 递归 cells；
+  ActionSet 不参与。
+- **单一权威**（whitelist.go `displayElements`）：D12 清单 `elements` 自动带上四者。
+
+Gotcha：修正了既有 `TestValidateWhitelistRejections` 把 Table 误标「AC 1.6 应拒」——Table 实为
+**1.5**、现已支持，替换为仍未支持的 Media(1.1)/ToggleVisibility(1.2) 保持负向覆盖。仍未支持
+（后续按需）：Media、Action.ShowCard/ToggleVisibility/Execute、模板/数据绑定、AC 1.6 元素。

--- a/.octospec/journal/shared/card-message-p3-rich-inputs.md
+++ b/.octospec/journal/shared/card-message-p3-rich-inputs.md
@@ -95,10 +95,18 @@ Verified live against adaptivecards.io that all three new inputs are AC 1.0 and
   items:[<js TextBlock>]}` smuggled the nested `javascript:` past the send-time URL allowlist:
   the flat handler doesn't walk `items`, and the type-dispatch that *would* have is bypassed
   because the handler never looked at `type`. The fix is the same one-liner `column()` already
-  had — reject a present `type` ≠ the expected leaf type. General rule: whenever you shortcut
-  the type-dispatched walker to validate a positionally-constrained child as a known shape, you
-  inherit the obligation to *enforce* that shape's type; the allowlist's "校验面 ≥ 渲染面"
-  invariant is only as strong as the weakest place a foreign subtree can enter (PR#556 review P1).
+  had — reject a present `type` ≠ the expected leaf type. **But a *conditional* type-check
+  (`if type present`) leaves a residual: a *typeless* child skips the reject and is still not
+  recursed — the same subtree smuggles in without a `type` label.** The complete closure is a
+  *closed-set leaf contract*, not a type label: a leaf child (Image/TextRun) must ALSO carry no
+  child-collection field at all (`items`/`columns`/`rows`/`cells`/`inlines`/`actions`/`facts`/
+  `images` — `rejectLeafSubtree`), because a leaf never has a subtree regardless of how it is
+  (or isn't) labeled. Enforce the *shape* (leaf = no subtree), not just the type string. General
+  rule: whenever you shortcut the type-dispatched walker to validate a positionally-constrained
+  child as a known shape, you inherit the obligation to enforce that shape completely — type AND
+  the absence of any nested collection; the allowlist's "校验面 ≥ 渲染面" invariant is only as
+  strong as the weakest place a foreign subtree can enter, labeled or not (PR#556 review P1 +
+  its typeless residual — two review rounds: the conditional fix, then the closed-set closure).
 
 ## Gotchas
 

--- a/.octospec/journal/shared/card-message-p3-rich-inputs.md
+++ b/.octospec/journal/shared/card-message-p3-rich-inputs.md
@@ -105,8 +105,16 @@ Verified live against adaptivecards.io that all three new inputs are AC 1.0 and
   rule: whenever you shortcut the type-dispatched walker to validate a positionally-constrained
   child as a known shape, you inherit the obligation to enforce that shape completely — type AND
   the absence of any nested collection; the allowlist's "校验面 ≥ 渲染面" invariant is only as
-  strong as the weakest place a foreign subtree can enter, labeled or not (PR#556 review P1 +
-  its typeless residual — two review rounds: the conditional fix, then the closed-set closure).
+  strong as the weakest place a foreign subtree can enter, labeled or not. **And "the weakest
+  place" means EVERY such position, not just the one flagged:** reviewers found this class one
+  child collection at a time (ImageSet → its typeless variant → Table rows/cells), each round a
+  fresh instance of the identical bug. The durable fix is to generalize the discipline into one
+  shared helper (`checkConstrainedChild`: a type-pin via a shared `childTypeMatches` predicate +
+  a closed-set `rejectForeignSubtree`) and apply it to ALL flat-validated child positions at once
+  (columns / images / inlines / table rows·cells / facts) — plus reuse the same predicate on the
+  dispatch side so validate-surface == dispatch-surface cannot drift. Patching only the flagged
+  instance guarantees another round on the next one (PR#556 review P1 — three rounds: conditional
+  type-check → typeless closed-set → whole-class generalization).
 
 ## Gotchas
 

--- a/.octospec/journal/shared/card-message-p3-rich-inputs.md
+++ b/.octospec/journal/shared/card-message-p3-rich-inputs.md
@@ -1,7 +1,7 @@
 ---
 type: Journal
 title: "Journal: card-message-p3-rich-inputs (card message P3-3)"
-description: Record of P3-3 — extend the octo/v2 input whitelist with Input.Number/Date/Time (all AC 1.0, within the pinned card_version "1.5"; additive, no version bump), add submit-time value validation (finite Number + declared min/max, Date YYYY-MM-DD, Time HH:MM), refactor the whitelist into a single pkg/cardmsg authority that validator + collector + dispatcher + D12 manifest all derive from, and additively advertise elements/inputs on GET /v1/bot/card/profile. No new errcode/DB/endpoint.
+description: Record of P3-3 — extend the octo/v2 input whitelist with Input.Number/Date/Time (all AC 1.0, within the pinned card_version "1.5"; additive, no version bump), add submit-time format validation (finite Number, Date YYYY-MM-DD, Time HH:MM; min/max range not server-enforced — delegated to bot per PR#556 review), refactor the whitelist into a single pkg/cardmsg authority that validator + collector + dispatcher + D12 manifest all derive from, and additively advertise elements/inputs on GET /v1/bot/card/profile. No new errcode/DB/endpoint.
 tags: ["card", "wire-contract", "trust-boundary", "bot-api", "testing"]
 timestamp: 2026-07-09T01:00:00Z
 # --- octospec extension fields ---
@@ -27,10 +27,12 @@ accepted only 3 of Adaptive Cards' 6 input elements; added the missing three.
   The `element()` type switch no longer enumerates input literals; unknown types
   fall through to `default` and are accepted iff `isInputElement(t)`, so adding
   an input element is a one-line change in `whitelist.go`.
-- **`inputs.go`** — submit-time value validation for the new types (trust
-  boundary D11): Number = finite numeric + declared `min`/`max`; Date =
-  `YYYY-MM-DD` + declared range; Time = `HH:MM` (24h) + declared range; `""`
-  passes as "unfilled". `isRequired`/`regex` remain client-UX + bot concerns.
+- **`inputs.go`** — submit-time **format** validation for the new types (trust
+  boundary D11): Number = finite numeric (reject `NaN`/`±Inf`); Date =
+  `YYYY-MM-DD`; Time = `HH:MM` (24h); `""` passes as "unfilled". `min`/`max`
+  range is **not** server-enforced (delegated to bot — see Open item, resolved
+  by maintainer in PR#556 review); `isRequired`/`regex` likewise remain
+  client-UX + bot concerns.
 - **`interactive.go`** — dispatch (`findSubmitInElements`) walks `inlineAction`
   via the same `isInputElement` predicate as validation.
 - **`modules/bot_api/card_profile.go`** — D12 manifest additively advertises
@@ -59,11 +61,13 @@ Verified live against adaptivecards.io that all three new inputs are AC 1.0 and
   `TestSubmitActionDispatchRichInputInlineAction`) pin the symmetry.
 - **`strconv.ParseFloat` accepts non-finite tokens without error.** `"NaN"`,
   `"Inf"`, `"+Inf"`, `"Infinity"` (case-insensitive) all parse to a valid
-  `float64` with `err == nil`, and `NaN` compares `false` against every bound —
-  so a naive `ParseFloat` + `min/max` check silently accepts non-finite values.
-  Any numeric wire-input validator must add an explicit
-  `math.IsNaN || math.IsInf` reject. This is the numeric analogue of the
-  "validation surface must cover the whole value space" discipline.
+  `float64` with `err == nil` — so a `ParseFloat`-only "is it a number" check
+  silently accepts non-finite values, and `NaN` further compares `false` against
+  any bound (i.e. it would also slip past a naive `min/max` gate). Non-finite is
+  not a valid numeric input regardless of whether a range is enforced: any
+  numeric wire-input validator must add an explicit `math.IsNaN || math.IsInf`
+  reject. This is the numeric analogue of the "validation surface must cover the
+  whole value space" discipline.
 
 ## Gotchas
 
@@ -77,12 +81,18 @@ Verified live against adaptivecards.io that all three new inputs are AC 1.0 and
   `modules/bot_api` / `modules/message` card tests need MySQL (`octo-test-mysql`)
   + `OCTO_MASTER_KEY` (exactly 32 bytes).
 
-## Open (deferred, in brief)
+## Resolved / Open
 
-- Whether server-enforced `min/max` (chosen default, consistent with ChoiceSet /
-  Toggle declared-value checks) should instead be delegated to bot business
-  validation — flagged for maintainer confirmation.
-- AC 1.6 `Data.Query` (dynamic typeahead) is a separate XL item: it needs a new
+- **RESOLVED (PR#556 review, maintainer)** — `min/max` range is **not**
+  server-enforced; it is delegated to bot business validation. The server only
+  format/type-checks (finite number / `YYYY-MM-DD` / `HH:MM`). Rationale: AC's
+  own schema defines `min/max` as an ignorable *hint* (so a spec-conforming
+  client can submit out-of-range), and card/action collapses all validation
+  errors to one anti-enumeration `invalid` (so a range rejection gives the user
+  no actionable feedback). Unlike `ChoiceSet` choices (a *constitutive* bound —
+  a value outside them is forged), `min/max` is *advisory*, in the same class as
+  `isRequired`/`regex` which were already not enforced.
+- **Open** — AC 1.6 `Data.Query` (dynamic typeahead) is a separate XL item: it needs a new
   synchronous client→bot query channel that Octo's async event-queue model does
   not have. Sequenced after modal forms (Goal 4), gated on a real
   remote/huge-choice-set need.

--- a/.octospec/journal/shared/card-message-p3-rich-inputs.md
+++ b/.octospec/journal/shared/card-message-p3-rich-inputs.md
@@ -85,6 +85,20 @@ Verified live against adaptivecards.io that all three new inputs are AC 1.0 and
   element as a **top-level `body` element** — the exact shape the manifest promises.
   A drift guard that tests a *different* position than the contract promises is not a
   guard (PR#556 review #4).
+- **A handler that iterates a fixed-type child collection MUST enforce the child's declared
+  type — otherwise a mislabeled child bypasses the type-dispatched validation that would have
+  recursed it.** Top-level `element()` dispatches by `type`, so a `Container` in `body` is
+  routed to the Container case and its `items` are walked. But `ImageSet.images[]` and
+  `RichTextBlock.inlines[]` call a *flat leaf* handler (`imageChild` / inline branch) on
+  **every** child regardless of type — validating it as an Image/TextRun (url / selectAction
+  only) and never recursing `items`. So a child mislabeled `{"type":"Container", url:ok,
+  items:[<js TextBlock>]}` smuggled the nested `javascript:` past the send-time URL allowlist:
+  the flat handler doesn't walk `items`, and the type-dispatch that *would* have is bypassed
+  because the handler never looked at `type`. The fix is the same one-liner `column()` already
+  had — reject a present `type` ≠ the expected leaf type. General rule: whenever you shortcut
+  the type-dispatched walker to validate a positionally-constrained child as a known shape, you
+  inherit the obligation to *enforce* that shape's type; the allowlist's "校验面 ≥ 渲染面"
+  invariant is only as strong as the weakest place a foreign subtree can enter (PR#556 review P1).
 
 ## Gotchas
 

--- a/.octospec/learnings/pending/card-message-p3-rich-inputs.md
+++ b/.octospec/learnings/pending/card-message-p3-rich-inputs.md
@@ -1,0 +1,62 @@
+---
+type: Learning
+title: "Widening a whitelist means widening every mirror surface — drive them from one predicate, not copies"
+description: When a value/type whitelist is enforced at several points (send-time validation, consumer collection, action dispatch, capability manifest), extending it at one point silently desynchronizes the others. Route every surface through a single shared predicate/authority and pin the symmetry with a test — otherwise you ship validated-but-undispatchable inputs (dead buttons) or a manifest that advertises capabilities the enforcement path rejects.
+tags: ["wire-contract", "trust-boundary", "whitelist", "testing", "review"]
+timestamp: 2026-07-09T01:00:00Z
+# --- octospec extension fields ---
+source: self
+origin_task: card-message-p3-rich-inputs
+origin_pr: self
+status: pending
+candidate_rule: error-handling
+---
+
+# Widening a whitelist means widening every mirror surface — drive them from one predicate, not copies
+
+## Context
+
+P3-3 added `Input.Number/Date/Time` to the card octo/v2 input whitelist. The
+same whitelist is consulted at **four** places in `pkg/cardmsg` +
+`modules/bot_api`:
+
+1. send-time validation (`validate.go element()`),
+2. submit-time input collection (`inputs.go collectInputSpecs`),
+3. action dispatch (`interactive.go findSubmitInElements` — walks `inlineAction`),
+4. the D12 capability manifest (`card_profile.go` — advertises the set).
+
+Extending only (1) shipped two latent defects caught in review:
+
+- Dispatch (3) still hardcoded `t == "Input.Text" || "Input.Toggle" ||
+  "Input.ChoiceSet"`, so a new-type `inlineAction` Submit **validated at send but
+  was undispatchable** → the button renders and clicking it returns invalid: a
+  "send-ok, click-invalid" dead button. Security invariant (dispatch ⊆
+  validation) still held; the bug was the inverse — validated-but-unreachable.
+- The manifest (4) would have re-typed the list literal, drifting from the
+  validator on the next change.
+
+## Principle
+
+A whitelist enforced at N surfaces is one fact with N copies. **Make the copies
+one:** define the set once (`inputElements` + `isInputElement()` /
+`InputElements()`), and have validation, collection, dispatch, and the manifest
+all derive from it. Then pin the symmetry with tests:
+
+- `TestInputElementsAuthority` — every member is accepted by the validator,
+  non-members rejected (validation == the list).
+- `TestSubmitActionDispatchRichInputInlineAction` — every member's `inlineAction`
+  Submit is both send-valid and dispatchable (dispatch == validation).
+
+## Applicability
+
+Any type/format/capability whitelist with more than one consumer: element
+whitelists, accepted MIME/scheme sets, feature-flag manifests, protocol
+version/profile sets. If you cannot route every surface through one authority,
+at minimum ship a drift-guard test asserting the surfaces agree.
+
+## Related
+
+- `verify-io-before-latency-metric` (pending) — similar "the guard must cover
+  the whole surface, not the happy path" theme.
+- Sibling: `card-message-p2-capability-manifest` learning (manifest fields must
+  source from a single in-package authority).

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,27 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-09 (P3-3)
+
+- **Change** — Task `card-message-p3-rich-inputs` (card message P3-3): extend the
+  octo/v2 input whitelist with `Input.Number/Date/Time` (all AC 1.0, within the
+  pinned `card_version:"1.5"` — additive, no version bump). Submit-time value
+  validation added (Number = finite numeric + declared min/max; Date =
+  `YYYY-MM-DD` + range; Time = `HH:MM` + range; `""` = unfilled;
+  `isRequired`/`regex` still not server-enforced). Refactored the element
+  whitelist into a single `pkg/cardmsg` authority (`whitelist.go`:
+  `displayElements`/`inputElements` + `DisplayElements()`/`InputElements()` +
+  `isInputElement`) that send-time validation, submit-time collection, action
+  dispatch, and the D12 manifest all derive from — no drifting literals. D12
+  `GET /v1/bot/card/profile` additively advertises `elements`/`inputs` for
+  element-granularity feature detection. Two review-caught fixes folded in:
+  reject non-finite `Input.Number` (NaN/±Inf bypass `ParseFloat`+bounds), and
+  symmetric `inlineAction` dispatch for the new types (no dead buttons). No new
+  errcode / i18n / DB / migration / endpoint; additive-only wire contract. Brief
+  + journal under `.octospec/tasks/card-message-p3-rich-inputs/` and
+  `.octospec/journal/shared/card-message-p3-rich-inputs.md`; learning candidate
+  in `.octospec/learnings/pending/`.
+
 ## 2026-07-08 (PR-D)
 
 - **Change** — Task `card-message-p2-capability-manifest` (PR-D, card message P2

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -47,9 +47,12 @@ change-log convention (§7). Newest first.
   (`ImageSet.images[]`) and the `RichTextBlock.inlines[]` object branch accepted a child
   without enforcing its declared `type` and never recursed its `items`, so a mislabeled child
   (`{"type":"Container","url":"http://ok","items":[TextBlock with javascript:]}`) passed
-  `Validate` with the nested `javascript:` link unchecked. Now both reject a present `type` ≠
-  `Image`/`TextRun` (same discipline as `column()`), restoring "校验面 ≥ 渲染面"
-  (`TestTier1MislabeledChildRejected`). Also completed `TableRow.selectAction` (P2): added it to
+  `Validate` with the nested `javascript:` link unchecked. Now both enforce a *leaf* contract —
+  reject a present `type` ≠ `Image`/`TextRun` (same discipline as `column()`) AND reject any
+  child-collection field (`items`/`columns`/… via `rejectLeafSubtree`), which also closes the
+  **typeless-child residual** a conditional `if type present` check leaves open (a no-`type`
+  child with a nested subtree) — restoring "校验面 ≥ 渲染面" (`TestTier1MislabeledChildRejected`
+  covers typed + typeless). Also completed `TableRow.selectAction` (P2): added it to
   validation (`w.selectAction(row)`) and dispatch (`findSubmitInElements` reads
   `row.selectAction`) symmetrically — row was the only node whose `selectAction` was neither
   validated nor dispatched. Brief updated; `inputs` manifest field confirmed in-scope.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -42,6 +42,17 @@ change-log convention (§7). Newest first.
   1.5, now supported) → replaced with still-unsupported Media(1.1)/ToggleVisibility(1.2).
   Still out (later, on demand): Media, Action.ShowCard/ToggleVisibility/Execute, templating,
   AC 1.6.
+- **Change** — Same task/PR, review hardening (PR#556 review of head `7559c526`): fixed a
+  **send-time URL-allowlist bypass (P1)** in the two Tier-1 flat-leaf handlers — `imageChild`
+  (`ImageSet.images[]`) and the `RichTextBlock.inlines[]` object branch accepted a child
+  without enforcing its declared `type` and never recursed its `items`, so a mislabeled child
+  (`{"type":"Container","url":"http://ok","items":[TextBlock with javascript:]}`) passed
+  `Validate` with the nested `javascript:` link unchecked. Now both reject a present `type` ≠
+  `Image`/`TextRun` (same discipline as `column()`), restoring "校验面 ≥ 渲染面"
+  (`TestTier1MislabeledChildRejected`). Also completed `TableRow.selectAction` (P2): added it to
+  validation (`w.selectAction(row)`) and dispatch (`findSubmitInElements` reads
+  `row.selectAction`) symmetrically — row was the only node whose `selectAction` was neither
+  validated nor dispatched. Brief updated; `inputs` manifest field confirmed in-scope.
 
 ## 2026-07-08 (PR-D)
 

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -56,6 +56,19 @@ change-log convention (§7). Newest first.
   validation (`w.selectAction(row)`) and dispatch (`findSubmitInElements` reads
   `row.selectAction`) symmetrically — row was the only node whose `selectAction` was neither
   validated nor dispatched. Brief updated; `inputs` manifest field confirmed in-scope.
+- **Change** — Same task/PR, review hardening cont'd (heads `2c8f1003`→`85baabdf`, three
+  reviewers): the foreign-typed-child bypass turned out to recur one child collection at a time
+  (ImageSet → its typeless variant → `Table` rows/cells), so generalized the fix into one shared
+  discipline instead of patching each instance. New `checkConstrainedChild` (type-pin via a shared
+  `childTypeMatches` predicate + closed-set `rejectForeignSubtree`) is now applied to **every**
+  flat-validated child position — `ColumnSet.columns[]`, `ImageSet.images[]`,
+  `RichTextBlock.inlines[]`, `Table.rows[]`/`cells[]`, `FactSet.facts[]` — closing the `Table`
+  send-time bypass (mislabeled cell as `Image` with a `javascript:` url; mislabeled/typeless row
+  hiding an un-recursed `items` subtree) plus the Column/Fact instances of the same class. The
+  dispatch walker (`findSubmitInElements`) reuses the same `childTypeMatches` predicate to skip
+  foreign-typed children, so validate-surface == dispatch-surface can't drift (P2). Tests:
+  `TestTier1MislabeledChildRejected` (Table/Column/Fact, typed + typeless) +
+  `TestTier1DispatchSkipsMislabeledChild`. Lesson: patch the class, not the flagged instance.
 
 ## 2026-07-08 (PR-D)
 

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -9,18 +9,25 @@ change-log convention (§7). Newest first.
 - **Change** — Task `card-message-p3-rich-inputs` (card message P3-3): extend the
   octo/v2 input whitelist with `Input.Number/Date/Time` (all AC 1.0, within the
   pinned `card_version:"1.5"` — additive, no version bump). Submit-time value
-  validation added (Number = finite numeric + declared min/max; Date =
-  `YYYY-MM-DD` + range; Time = `HH:MM` + range; `""` = unfilled;
-  `isRequired`/`regex` still not server-enforced). Refactored the element
+  validation added (format/type only: Number = finite JSON number; Date =
+  `YYYY-MM-DD`; Time = `HH:MM`; `""` = unfilled; declared min/max range NOT
+  server-enforced — delegated to bot, same class as `isRequired`/`regex`, which
+  likewise stay unenforced). Refactored the element
   whitelist into a single `pkg/cardmsg` authority (`whitelist.go`:
   `displayElements`/`inputElements` + `DisplayElements()`/`InputElements()` +
   `isInputElement`) that send-time validation, submit-time collection, action
   dispatch, and the D12 manifest all derive from — no drifting literals. D12
   `GET /v1/bot/card/profile` additively advertises `elements`/`inputs` for
-  element-granularity feature detection. Two review-caught fixes folded in:
-  reject non-finite `Input.Number` (NaN/±Inf bypass `ParseFloat`+bounds), and
-  symmetric `inlineAction` dispatch for the new types (no dead buttons). No new
-  errcode / i18n / DB / migration / endpoint; additive-only wire contract. Brief
+  element-granularity feature detection. Review-caught fixes folded in: reject
+  non-finite `Input.Number` (NaN/±Inf bypass `ParseFloat`); strict JSON-number
+  grammar so the server's "valid number" matches the bot's JSON parser (reject
+  `ParseFloat`'s Go-only superset — `1_000`/`0x1p4`/leading-`+`/leading-zero —
+  which would silently corrupt the value the bot re-parses); `default`
+  fail-closed arm in the submit-time type switch; `Column` dropped from the
+  manifest `elements` (it is a `ColumnSet` child, not a top-level element the
+  validator accepts — advertising it lied about capability); and symmetric
+  `inlineAction` dispatch for the new types (no dead buttons). No new errcode /
+  i18n / DB / migration / endpoint; additive-only wire contract. Brief
   + journal under `.octospec/tasks/card-message-p3-rich-inputs/` and
   `.octospec/journal/shared/card-message-p3-rich-inputs.md`; learning candidate
   in `.octospec/learnings/pending/`.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -24,6 +24,17 @@ change-log convention (§7). Newest first.
   + journal under `.octospec/tasks/card-message-p3-rich-inputs/` and
   `.octospec/journal/shared/card-message-p3-rich-inputs.md`; learning candidate
   in `.octospec/learnings/pending/`.
+- **Change** — Same task/PR, follow-on: **AC 1.5 display-element completion (Tier 1)** —
+  added `ImageSet`(1.0) / `RichTextBlock`(1.2) / `Table`(1.5) / `ActionSet`(1.2) to the
+  octo/v2 display whitelist (versions verified against adaptivecards.io). Each covers
+  send-time validation (structure + URL allowlist + recursion budget), dispatch symmetry
+  (`findSubmitInElements` walks ActionSet.actions / Table cells / ImageSet images /
+  RichTextBlock inlines for Submit — no dead buttons), plain derivation, and D12 manifest
+  `elements` (auto via the displayElements single authority). Corrected the pre-existing
+  `TestValidateWhitelistRejections` which mislabeled Table as "AC 1.6, reject" (Table is
+  1.5, now supported) → replaced with still-unsupported Media(1.1)/ToggleVisibility(1.2).
+  Still out (later, on demand): Media, Action.ShowCard/ToggleVisibility/Execute, templating,
+  AC 1.6.
 
 ## 2026-07-08 (PR-D)
 

--- a/.octospec/tasks/card-message-p3-rich-inputs/brief.md
+++ b/.octospec/tasks/card-message-p3-rich-inputs/brief.md
@@ -121,3 +121,18 @@ source: self
    `YYYY-MM-DD` / `HH:MM`),区间交 bot 业务逻辑。
 2. **`docs/card-protocol.md` 镜像修订**是否需 maintainer sign-off——roadmap 未把 P3-3 标为
    需 sign-off（区别于 P3-1），倾向按「additive、随代码同 PR 改文档」处理。
+
+## Tier 1 追加（同 PR，PR#556 讨论后加入）
+
+在同一 PR 内把 octo/v2 **展示元素**白名单补齐到 AC ≤1.5，新增 4 个展示元素（实测 adaptivecards.io
+版本）：`ImageSet`(1.0) / `RichTextBlock`(1.2) / `Table`(1.5) / `ActionSet`(1.2)。纯展示类，octo/v1+v2
+均放行；`ActionSet` 内的 `Action.Submit` 仍受 octo/v2 门控。每个元素覆盖：发送期校验（结构 +
+URL allowlist + 递归节点/深度预算）、派发对称（`findSubmitInElements` 遍历 ActionSet.actions /
+Table cells / ImageSet images / RichTextBlock inlines 的 Submit，防死按钮）、plain 派生、D12 清单
+`elements` 自动同步（displayElements 单一权威）。
+
+Acceptance（追加）：`go test -race ./pkg/cardmsg/` 覆盖四元素 v1/v2 放行、URL allowlist 拒
+`javascript:`、结构错拒、Submit 派发对称、plain 派生；`TestDisplayElementsAuthority` 逐 fixture
+守卫 displayElements↔校验器一致；修正既有 `TestValidateWhitelistRejections`（Table 实为 1.5 已支持，
+替换为 Media/ToggleVisibility）。仍未支持（后续按需）：Media、ShowCard/ToggleVisibility/Execute、
+模板绑定、AC 1.6。

--- a/.octospec/tasks/card-message-p3-rich-inputs/brief.md
+++ b/.octospec/tasks/card-message-p3-rich-inputs/brief.md
@@ -1,0 +1,118 @@
+---
+type: Task
+title: "Task: card-message-p3-rich-inputs"
+description: 卡片消息 octo/v2 白名单扩容 Input.Number/Date/Time + 提交期值校验（AC 1.5 内，不升版本）
+tags: ["error-response", "wire-contract", "trust-boundary", "test"]
+timestamp: 2026-07-09T00:00:00+08:00
+# --- octospec extension fields ---
+slug: card-message-p3-rich-inputs
+upstream: card-message-interaction P3-3
+source: self
+---
+
+# Task: card-message-p3-rich-inputs
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+把卡片消息 octo/v2 交互档的输入元素白名单从 3 个（`Input.Text` / `Input.Toggle` /
+`Input.ChoiceSet`）扩到 6 个，补齐 **`Input.Number` / `Input.Date` / `Input.Time`**。
+三者都是 Adaptive Cards **1.0** 元素，完全落在已固定的 `card_version: "1.5"` 内——
+**这是白名单增量，不是版本升级、不是信封/事件契约变更**（对照 P3-1 的 `expires_at`
+新增信封字段才需 maintainer sign-off）。
+
+改动落在两处纯服务端逻辑：
+
+1. **发送期白名单**（`pkg/cardmsg/validate.go`）：新类型并入现有 octo/v2 Input.*
+   分支，继承同一套纪律——id 必填且帧内唯一（`registerID`）、`label`/`errorMessage`
+   markdown 链接目标走同一正向 URL allowlist、`inlineAction` 路由校验。octo/v1 携带
+   新类型仍拒（越级）。
+2. **提交期值校验**（`pkg/cardmsg/inputs.go` `ValidateInputs` + `collectInputSpecs`）：
+   延续「形状可信」信任边界（声明过 + 类型对 + 有界），对三类新输入按声明帧校验上行值：
+   - `Input.Number`：值必须可解析为数字；若声明帧带 `min`/`max` 则强制区间；`""`（未填）放行。
+   - `Input.Date`：值必须是 `YYYY-MM-DD`；若声明帧带 `min`/`max`（ISO 日期）则强制区间；`""` 放行。
+   - `Input.Time`：值必须是 `HH:MM`（24h）；若声明帧带 `min`/`max`（`HH:MM`）则强制区间；`""` 放行。
+
+同时用测试锁定校验器对 **1.5 内 renderer-only 风格属性**的容忍：`Input.Text`
+`style:"password"`、`Input.ChoiceSet` `style:"filtered"|"expanded"`（当前校验器只白名单
+已知键、忽略未知属性，预期无需改码——测试是为防回归）。`filtered` 可搜索下拉由此在 1.5
+内可用、零服务端往返（客户端本地过滤静态 choices）。
+
+**为什么锁 1.5、不做 AC 1.6 `Data.Query`**：`Data.Query` 是动态 typeahead，需要一条
+「表单填写中实时查在线 bot」的同步查询通道，与 Octo 的 server-authoritative 静态帧 +
+异步事件队列模型冲突，是比 modal 还重的独立大项——不在本任务范围（见 P3-ROADMAP.md
+「Decision: keep the target at 1.5」）。
+
+## Background
+
+- 现状核实：`pkg/cardmsg/validate.go:262` 的 octo/v2 分支只接受 `Input.Text` /
+  `Input.Toggle` / `Input.ChoiceSet`；`Input.Number`/`Date`/`Time` 落入 `default:`
+  → `ErrCardUnknownElement`（发送期 400）。
+- 提交期信任边界：`pkg/cardmsg/inputs.go` 顶部注释确立「声明过、类型对、有上限」为
+  bot 拿到的「形状可信」值；`isRequired`/`regex` **有意不在服务端强制**（表单完整性是
+  端上 UX + bot 业务校验的事）——本任务沿用该原则，仅做「声明+类型+区间」校验。
+- 错误映射（决定无需新 errcode）：
+  - 发送期 `cardmsg.Validate` 错误由 ingress 调用方映射（`modules/bot_api/send.go:106`、
+    `modules/incomingwebhook/card.go:58`、`modules/robot/api.go:781`），沿用既有码。
+  - 提交期 `card/action` 把所有 `cardmsg.ValidateInputs` 错误**统一折叠**进
+    `errcode.ErrMessageCardActionInvalid`（`modules/message/api_card_action.go:207-210`，
+    反枚举），新类型的值非法同样归入此码——**不新增 errcode、不改 i18n**。
+- 契约镜像：`docs/card-protocol.md` §2（第 43 行枚举 octo/v2 输入集）+ §7（P2 契约冻结）
+  是 `pkg/cardmsg/` 的**权威镜像**，白名单一变必须同步改文档以保镜像忠实。
+- 客户端渲染（web/Android/iOS 三端加 date/number/time 控件 + 内联校验 UX）是 P3-3 的
+  真实大头成本，但**不在 octo-server 仓库范围**；本任务只交付服务端「线上已承载客户端
+  所需」的那一半。
+
+## Load-bearing list
+
+- **error-response / wire-contract** — octo/v2 发送期白名单是对外校验契约；扩容会改变
+  「哪些 AC 元素被接受」的可观测行为。必须保持：octo/v1 携带新类型仍 400（越级拒绝）、
+  发送期错误码不变、提交期错误仍统一折叠为 `ErrMessageCardActionInvalid`。
+- **trust-boundary** — `card/action` 上行 `inputs` 是不可信用户输入；新类型必须纳入
+  `ValidateInputs` 的 fail-closed 声明校验（未声明键拒、类型不符拒），不得给出「已声明但
+  不校验值」的天窗。`label`/`errorMessage`/`inlineAction`/`selectAction` 的 URL/动作面
+  必须与现有 Input.* 同权威过 allowlist。
+- **wire-contract（docs 镜像）** — `docs/card-protocol.md` §2 第 43 行 + §7 必须与
+  `pkg/cardmsg` 白名单同步更新，否则镜像失真。此项需确认属 roadmap 已定调的「additive、
+  无需 maintainer sign-off」范畴（对照 P3-1 明确需 sign-off）。
+- **test** — 现有 `pkg/cardmsg/interactive_test.go` 的白名单门控（`TestValidateV2WhitelistGating`）
+  与信任边界（`TestValidateInputsTrustBoundary` / `TestValidateInputsMultiSelect`）测试是
+  回归基线，新类型须补对应用例，不得破坏既有断言。
+
+## Out of scope
+
+- **不升 `cardmsg.CardVersion`**（保持 `"1.5"`）；不引入 AC 1.6 任何元素/属性。
+- **AC 1.6 `Data.Query` / `choices.data` 动态 typeahead**——独立大项，排在 Goal 4 之后。
+- **服务端不强制 `isRequired` / `regex`**——保持现有信任边界原则（客户端 UX + bot 业务校验）。
+- **客户端三端渲染器**（date/number/time 控件、内联校验 UX、`filtered` 下拉渲染）——不在本仓库。
+- **不新增 errcode、不改 i18n locales、不新增/改端点、无 DB/迁移。**
+- **不改 `expires_at` / 审批超时（P3-1）、WS 实时推送（P3-2）、可观测性（G1）** 等其他 P3 项。
+
+## Acceptance
+
+机器可校验：
+
+- `go test ./pkg/cardmsg/...` 全绿；新增用例覆盖：
+  - `Input.Number`/`Date`/`Time` 在 octo/v2 放行、在 octo/v1 拒（`ErrCardUnknownElement`）；
+  - 三类新输入缺 `id` → `ErrCardBadShape`；帧内 id 重复 → 冲突拒；
+  - 新类型的 `label`/`errorMessage` 携带 `javascript:` markdown 链接 → 拒（URL allowlist）；
+  - `ValidateInputs`：
+    - `Input.Number` 非数字值 → `ErrCardInputInvalid`；越 `min`/`max` → 拒；区间内 + `""` → 放行；
+    - `Input.Date` 非 `YYYY-MM-DD` → 拒；越 `min`/`max` → 拒；合法 + `""` → 放行；
+    - `Input.Time` 非 `HH:MM` → 拒；越 `min`/`max` → 拒；合法 + `""` → 放行；
+    - 未声明键仍 fail-closed 拒；
+  - 风格容忍：`Input.Text style:"password"`、`Input.ChoiceSet style:"filtered"|"expanded"` 发送期放行。
+- `docs/card-protocol.md` §2/§7 已列出 6 个输入元素，与 `pkg/cardmsg` 白名单一致。
+- 既有 `pkg/cardmsg`、`modules/message` card_action 相关测试不回归。
+- `go build ./...` 通过；`make i18n-extract-check` / `make i18n-lint` 无新增违规（预期：未触
+  errcode，本项应无变化）。
+
+## 待确认（human confirm）
+
+1. **min/max 区间是否服务端强制**：默认选「强制」（与 `Input.ChoiceSet` 校验声明 choices、
+   `Input.Toggle` 校验 valueOn/valueOff 同构，符合信任边界「有界」语义）。若你认为区间也应
+   下放到 bot 业务校验（只做格式校验），我改为仅校验「是合法数字/日期/时间」。
+2. **`docs/card-protocol.md` 镜像修订**是否需 maintainer sign-off——roadmap 未把 P3-3 标为
+   需 sign-off（区别于 P3-1），倾向按「additive、随代码同 PR 改文档」处理。

--- a/.octospec/tasks/card-message-p3-rich-inputs/brief.md
+++ b/.octospec/tasks/card-message-p3-rich-inputs/brief.md
@@ -29,11 +29,12 @@ source: self
    分支，继承同一套纪律——id 必填且帧内唯一（`registerID`）、`label`/`errorMessage`
    markdown 链接目标走同一正向 URL allowlist、`inlineAction` 路由校验。octo/v1 携带
    新类型仍拒（越级）。
-2. **提交期值校验**（`pkg/cardmsg/inputs.go` `ValidateInputs` + `collectInputSpecs`）：
-   延续「形状可信」信任边界（声明过 + 类型对 + 有界），对三类新输入按声明帧校验上行值：
-   - `Input.Number`：值必须可解析为数字；若声明帧带 `min`/`max` 则强制区间；`""`（未填）放行。
-   - `Input.Date`：值必须是 `YYYY-MM-DD`；若声明帧带 `min`/`max`（ISO 日期）则强制区间；`""` 放行。
-   - `Input.Time`：值必须是 `HH:MM`（24h）；若声明帧带 `min`/`max`（`HH:MM`）则强制区间；`""` 放行。
+2. **提交期值校验**（`pkg/cardmsg/inputs.go` `ValidateInputs`）：延续「形状可信」信任边界
+   （声明过 + 类型对），对三类新输入按声明帧校验上行值的**格式**。`min`/`max` 区间**不**
+   服务端强制（下放 bot 业务校验，「待确认 #1」已定稿，见文末）：
+   - `Input.Number`：值必须可解析为**有限数**（显式拒 `NaN`/`±Inf`）；`""`（未填）放行。
+   - `Input.Date`：值必须是 `YYYY-MM-DD`；`""` 放行。
+   - `Input.Time`：值必须是 `HH:MM`（24h）；`""` 放行。
 
 同时用测试锁定校验器对 **1.5 内 renderer-only 风格属性**的容忍：`Input.Text`
 `style:"password"`、`Input.ChoiceSet` `style:"filtered"|"expanded"`（当前校验器只白名单
@@ -98,10 +99,10 @@ source: self
   - `Input.Number`/`Date`/`Time` 在 octo/v2 放行、在 octo/v1 拒（`ErrCardUnknownElement`）；
   - 三类新输入缺 `id` → `ErrCardBadShape`；帧内 id 重复 → 冲突拒；
   - 新类型的 `label`/`errorMessage` 携带 `javascript:` markdown 链接 → 拒（URL allowlist）；
-  - `ValidateInputs`：
-    - `Input.Number` 非数字值 → `ErrCardInputInvalid`；越 `min`/`max` → 拒；区间内 + `""` → 放行；
-    - `Input.Date` 非 `YYYY-MM-DD` → 拒；越 `min`/`max` → 拒；合法 + `""` → 放行；
-    - `Input.Time` 非 `HH:MM` → 拒；越 `min`/`max` → 拒；合法 + `""` → 放行；
+  - `ValidateInputs`（只做格式/类型校验；min/max 区间**不**服务端强制 —— 即便声明了 min/max，越界的合法值也放行）：
+    - `Input.Number` 非数字 / 非有限数（`NaN`/`±Inf`）→ `ErrCardInputInvalid`；合法有限数（含声明区间外）+ `""` → 放行；
+    - `Input.Date` 非 `YYYY-MM-DD` → 拒；合法格式（含声明区间外）+ `""` → 放行；
+    - `Input.Time` 非 `HH:MM` → 拒；合法格式（含声明区间外）+ `""` → 放行；
     - 未声明键仍 fail-closed 拒；
   - 风格容忍：`Input.Text style:"password"`、`Input.ChoiceSet style:"filtered"|"expanded"` 发送期放行。
 - `docs/card-protocol.md` §2/§7 已列出 6 个输入元素，与 `pkg/cardmsg` 白名单一致。
@@ -111,8 +112,12 @@ source: self
 
 ## 待确认（human confirm）
 
-1. **min/max 区间是否服务端强制**：默认选「强制」（与 `Input.ChoiceSet` 校验声明 choices、
-   `Input.Toggle` 校验 valueOn/valueOff 同构，符合信任边界「有界」语义）。若你认为区间也应
-   下放到 bot 业务校验（只做格式校验），我改为仅校验「是合法数字/日期/时间」。
+1. **min/max 区间是否服务端强制** — **已定稿：不强制，下放 bot**（PR#556 review，maintainer 拍板）。
+   理由:(a) AC 官方 schema 把 `Input.Number/Date/Time` 的 min/max 定义为「hint … may be ignored
+   by some clients」——合规客户端可提交越界值,服务端强制会拒掉合法用户操作;(b) card/action 把
+   所有 `ValidateInputs` 错误折叠成单一 `ErrMessageCardActionInvalid`(反枚举),越界拒绝让用户收到
+   无从更正的笼统错;(c) 区别于 `Input.ChoiceSet` 的 choices(**构成性**约束,值不在其中即伪造)——
+   min/max 是**建议性**约束,与 `isRequired`/`regex` 同类。故服务端只做格式/类型校验(有限数 /
+   `YYYY-MM-DD` / `HH:MM`),区间交 bot 业务逻辑。
 2. **`docs/card-protocol.md` 镜像修订**是否需 maintainer sign-off——roadmap 未把 P3-3 标为
    需 sign-off（区别于 P3-1），倾向按「additive、随代码同 PR 改文档」处理。

--- a/.octospec/tasks/card-message-p3-rich-inputs/brief.md
+++ b/.octospec/tasks/card-message-p3-rich-inputs/brief.md
@@ -128,11 +128,22 @@ source: self
 版本）：`ImageSet`(1.0) / `RichTextBlock`(1.2) / `Table`(1.5) / `ActionSet`(1.2)。纯展示类，octo/v1+v2
 均放行；`ActionSet` 内的 `Action.Submit` 仍受 octo/v2 门控。每个元素覆盖：发送期校验（结构 +
 URL allowlist + 递归节点/深度预算）、派发对称（`findSubmitInElements` 遍历 ActionSet.actions /
-Table cells / ImageSet images / RichTextBlock inlines 的 Submit，防死按钮）、plain 派生、D12 清单
-`elements` 自动同步（displayElements 单一权威）。
+Table cells / ImageSet images / RichTextBlock inlines / TableRow 的 Submit，防死按钮）、plain 派生、
+D12 清单 `elements` **及 `inputs`** 自动同步（displayElements/inputElements 单一权威 —— 元素粒度能力
+探测两者都需，故 manifest 同时下发；PR#556 review 确认 `inputs` 在范围内，非 over-build）。
 
 Acceptance（追加）：`go test -race ./pkg/cardmsg/` 覆盖四元素 v1/v2 放行、URL allowlist 拒
 `javascript:`、结构错拒、Submit 派发对称、plain 派生；`TestDisplayElementsAuthority` 逐 fixture
 守卫 displayElements↔校验器一致；修正既有 `TestValidateWhitelistRejections`（Table 实为 1.5 已支持，
 替换为 Media/ToggleVisibility）。仍未支持（后续按需）：Media、ShowCard/ToggleVisibility/Execute、
 模板绑定、AC 1.6。
+
+Tier 1 review 加固（PR#556 review，head `7559c526` 后）：
+- **URL allowlist 绕过（P1，阻塞）修复** —— `ImageSet.images[]` / `RichTextBlock.inlines[]` 的子元素
+  必须钉死类型（present 且 ≠ `Image`/`TextRun` → `ErrCardUnknownElement`，同 `column()` 纪律）。原逻辑
+  把伪类型子元素（如 `type:"Container"`）当扁平 Image/TextRun 只校 url/selectAction、其 `items` 永不
+  递归 → 可夹带 `javascript:` 链接绕过发送期 allowlist（违反「校验面 ≥ 渲染面」，PR#543 铁律）。
+  `TestTier1MislabeledChildRejected` 守卫。
+- **`TableRow.selectAction`（P2）补齐** —— 校验（`w.selectAction(row)`）+ 派发（`findSubmitInElements`
+  读 `row.selectAction`）对称补上，使「每个节点的 selectAction 都过同一 allowlist」不留缺口（row 原为
+  唯一漏网节点）。

--- a/.octospec/tasks/card-message-p3-rich-inputs/brief.md
+++ b/.octospec/tasks/card-message-p3-rich-inputs/brief.md
@@ -138,14 +138,20 @@ Acceptance（追加）：`go test -race ./pkg/cardmsg/` 覆盖四元素 v1/v2 �
 替换为 Media/ToggleVisibility）。仍未支持（后续按需）：Media、ShowCard/ToggleVisibility/Execute、
 模板绑定、AC 1.6。
 
-Tier 1 review 加固（PR#556 review，head `7559c526`/`2c8f1003` 后）：
-- **URL allowlist 绕过（P1，阻塞）修复** —— `ImageSet.images[]` / `RichTextBlock.inlines[]` 的子元素
-  必须是**叶子**（Image/TextRun）：类型 present 时 ≠ `Image`/`TextRun` 即拒（`ErrCardUnknownElement`，
-  同 `column()`），**且不得携带任何子集合字段**（`items`/`columns`/`rows`/`cells`/`inlines`/`actions`/
-  `facts`/`images` → `rejectLeafSubtree`）。原逻辑把伪类型子元素当扁平 Image/TextRun 只校 url/selectAction、
-  其 `items` 永不递归 → 夹带 `javascript:` 链接绕过发送期 allowlist（违反「校验面 ≥ 渲染面」，PR#543 铁律）。
-  仅靠类型门（`if type present`）挡不住 **typeless 伪装容器**（无 type + 带 items）—— 该 residual 由
-  `rejectLeafSubtree` 兜底。`TestTier1MislabeledChildRejected`（覆盖伪类型 + typeless 两变体）守卫。
+Tier 1 review 加固（PR#556 review，head `7559c526`→`85baabdf` 多轮）：
+- **flat-validated 子元素的 URL allowlist 绕过（P1，阻塞）—— 全类关闭。** octo 有若干「按位置约束、扁平
+  校验」的子集合位置：`ColumnSet.columns[]`、`ImageSet.images[]`、`RichTextBlock.inlines[]`、`Table.rows[]`·
+  `cells[]`、`FactSet.facts[]`。原逻辑对其中多数不钉子元素类型、也不递归其子树，于是伪类型
+  （`{"type":"Container","items":[…]}`）或 typeless（`{"items":[…]}`）的「伪装容器」被当扁平叶子只校
+  url/selectAction、其 `items` 子树永不走查 → 夹带 `javascript:` 绕过发送期 allowlist（违反「校验面 ≥ 渲染
+  面」，PR#543 铁律）。三位 reviewer 分轮逐个揪出（ImageSet/RichTextBlock → typeless residual → Table）。
+  **统一纪律 `checkConstrainedChild`**：每个约束子位置显式 type 必须匹配其契约类型（缺省放行，同 `column()`），
+  且除该类型合法的那个子集合字段外不得携带任何 `childCollectionFields`。叶子（Image/TextRun/Fact）不许任何
+  子集合；`TableRow` 只许 `cells`、`TableCell`/`Column` 只许 `items`。
+- **派发面 == 校验面（P2）** —— `findSubmitInElements` 对 ImageSet/RichTextBlock/Table 子元素用**同一
+  `childTypeMatches` 谓词**跳过校验期会拒的伪类型子元素，两面共用判定、结构上不可能漂移。
+- `TestTier1MislabeledChildRejected`（伪类型 + typeless，覆盖 Table/Column/Fact）+
+  `TestTier1DispatchSkipsMislabeledChild` 守卫；合规 Image/TextRun/Table 帧不受影响（`TestTier1ElementsAccepted` 仍绿）。
 - **`TableRow.selectAction`（P2）补齐** —— 校验（`w.selectAction(row)`）+ 派发（`findSubmitInElements`
   读 `row.selectAction`）对称补上，使「每个节点的 selectAction 都过同一 allowlist」不留缺口（row 原为
   唯一漏网节点）。

--- a/.octospec/tasks/card-message-p3-rich-inputs/brief.md
+++ b/.octospec/tasks/card-message-p3-rich-inputs/brief.md
@@ -138,12 +138,14 @@ Acceptance（追加）：`go test -race ./pkg/cardmsg/` 覆盖四元素 v1/v2 �
 替换为 Media/ToggleVisibility）。仍未支持（后续按需）：Media、ShowCard/ToggleVisibility/Execute、
 模板绑定、AC 1.6。
 
-Tier 1 review 加固（PR#556 review，head `7559c526` 后）：
+Tier 1 review 加固（PR#556 review，head `7559c526`/`2c8f1003` 后）：
 - **URL allowlist 绕过（P1，阻塞）修复** —— `ImageSet.images[]` / `RichTextBlock.inlines[]` 的子元素
-  必须钉死类型（present 且 ≠ `Image`/`TextRun` → `ErrCardUnknownElement`，同 `column()` 纪律）。原逻辑
-  把伪类型子元素（如 `type:"Container"`）当扁平 Image/TextRun 只校 url/selectAction、其 `items` 永不
-  递归 → 可夹带 `javascript:` 链接绕过发送期 allowlist（违反「校验面 ≥ 渲染面」，PR#543 铁律）。
-  `TestTier1MislabeledChildRejected` 守卫。
+  必须是**叶子**（Image/TextRun）：类型 present 时 ≠ `Image`/`TextRun` 即拒（`ErrCardUnknownElement`，
+  同 `column()`），**且不得携带任何子集合字段**（`items`/`columns`/`rows`/`cells`/`inlines`/`actions`/
+  `facts`/`images` → `rejectLeafSubtree`）。原逻辑把伪类型子元素当扁平 Image/TextRun 只校 url/selectAction、
+  其 `items` 永不递归 → 夹带 `javascript:` 链接绕过发送期 allowlist（违反「校验面 ≥ 渲染面」，PR#543 铁律）。
+  仅靠类型门（`if type present`）挡不住 **typeless 伪装容器**（无 type + 带 items）—— 该 residual 由
+  `rejectLeafSubtree` 兜底。`TestTier1MislabeledChildRejected`（覆盖伪类型 + typeless 两变体）守卫。
 - **`TableRow.selectAction`（P2）补齐** —— 校验（`w.selectAction(row)`）+ 派发（`findSubmitInElements`
   读 `row.selectAction`）对称补上，使「每个节点的 selectAction 都过同一 allowlist」不留缺口（row 原为
   唯一漏网节点）。

--- a/docs/card-protocol.md
+++ b/docs/card-protocol.md
@@ -38,10 +38,10 @@
 
 | 类别 | 允许 |
 |---|---|
-| 元素 | `TextBlock`（markdown 子集，§2.1）、`Image`、`Container`、`ColumnSet`/`Column`、`FactSet` |
+| 元素 | `TextBlock`（markdown 子集，§2.1）、`RichTextBlock`、`Image`、`ImageSet`、`Container`、`ColumnSet`/`Column`、`FactSet`、`Table`、`ActionSet`（`RichTextBlock`/`ImageSet`/`Table`/`ActionSet` 为 P3-3 Tier 1 追加，均 AC ≤1.5：ImageSet 1.0 / RichTextBlock 1.2 / ActionSet 1.2 / Table 1.5） |
 | 动作 | `Action.OpenUrl`；元素/整卡 `selectAction` **仅当**携带 `Action.OpenUrl` |
-| P2 起（octo/v2） | `Action.Submit`（含 selectAction 携带）、`Input.Text` / `Input.Toggle` / `Input.ChoiceSet` / `Input.Number` / `Input.Date` / `Input.Time`（id 必填且帧内唯一；后三者 P3-3 追加，均 AC 1.0、仍在 `card_version:"1.5"` 内，为白名单增量而非版本升级） |
-| 永不（P3 再议） | `Action.Execute`、`Action.ShowCard`、`ToggleVisibility`、模板/数据绑定、`Table` 等 AC 1.6 元素 |
+| P2 起（octo/v2） | `Action.Submit`（含 selectAction/ActionSet 携带）、`Input.Text` / `Input.Toggle` / `Input.ChoiceSet` / `Input.Number` / `Input.Date` / `Input.Time`（id 必填且帧内唯一；后三者 P3-3 追加，均 AC 1.0、仍在 `card_version:"1.5"` 内，为白名单增量而非版本升级） |
+| 暂不支持（后续按需） | `Media`(1.1)、`Action.ShowCard`(1.0)、`Action.ToggleVisibility`(1.2)、`Action.Execute`(1.4)、模板/数据绑定，以及 AC 1.6 元素 |
 
 结构与大小上限（全部 ingress 一致）：
 
@@ -110,10 +110,11 @@ allowlist —— 服务端用**完整 CommonMark 解析器**（非模式匹配�
 按文档序遍历 `card.body`：
 
 - `TextBlock` → 剥离 markdown 后的文本；
+- `RichTextBlock` → 拼接 `inlines[]` 的文本（字符串 run + `TextRun.text`；TextRun 非 markdown，不剥离）；
 - `FactSet` → 逐条 `"title: value"` 行；
-- `Image` → `[图片]`；
-- 容器类（`Container`/`ColumnSet`/`Column`）→ 递归；
-- 动作（按钮）**不参与**（按钮是操作面不是内容）。
+- `Image` → `[图片]`；`ImageSet` → 每张图一个 `[图片]`；
+- 容器类（`Container`/`ColumnSet`/`Column`、`Table` 的 `rows→cells→items`）→ 递归；
+- 动作（按钮，含 `ActionSet`）**不参与**（按钮是操作面不是内容）。
 
 段落以换行拼接；结果为空 → `[卡片]` 兜底。**客户端提交的 `plain` 值一律被
 覆盖**。incoming webhook 的 `text` 字段是**兜底种子**：仅当派生结果为空时

--- a/docs/card-protocol.md
+++ b/docs/card-protocol.md
@@ -170,8 +170,9 @@ robot API（legacy）`/robot/sendMessage` 同样接受 type-17（校验与 bot i
 - **乱序防护**：可选 `card_seq`（单调递增）；带上时旧帧 → 409。
 - **inputs 信任边界**：提交键必须命中生效帧声明的 `Input.*` id（未声明
   fail-closed），值为字符串、逐类型校验、总量 ≤ 16 KiB。P3-3 起 `Input.Number`
-  按数值+声明 min/max 校验、`Input.Date`（YYYY-MM-DD）/`Input.Time`（HH:MM）按
-  格式+声明区间校验，三者 `""` 均视为未填放行（`isRequired`/`regex` 不服务端强制）。
+  校验为有限数、`Input.Date`（YYYY-MM-DD）/`Input.Time`（HH:MM）校验格式，三者 `""`
+  均视为未填放行；`min`/`max` 区间与 `isRequired`/`regex` 一样**不服务端强制**（AC 规范
+  定义 min/max 为可忽略 hint，区间校验交 bot 业务逻辑，PR#556 定稿）。
 - **`event_data.space_id`**（PR#548 P1-3）：卡片**来源 Space**，服务端从存储行
   解析（群/子区取群 SpaceID；DM 取发送时注入 payload 的 `space_id`），**非**操作者
   请求上下文 Space；无权威值时省略该键（fail-closed），消费方按可选字段处理。

--- a/docs/card-protocol.md
+++ b/docs/card-protocol.md
@@ -40,7 +40,7 @@
 |---|---|
 | 元素 | `TextBlock`（markdown 子集，§2.1）、`Image`、`Container`、`ColumnSet`/`Column`、`FactSet` |
 | 动作 | `Action.OpenUrl`；元素/整卡 `selectAction` **仅当**携带 `Action.OpenUrl` |
-| P2 起（octo/v2） | `Action.Submit`（含 selectAction 携带）、`Input.Text` / `Input.Toggle` / `Input.ChoiceSet`（id 必填且帧内唯一） |
+| P2 起（octo/v2） | `Action.Submit`（含 selectAction 携带）、`Input.Text` / `Input.Toggle` / `Input.ChoiceSet` / `Input.Number` / `Input.Date` / `Input.Time`（id 必填且帧内唯一；后三者 P3-3 追加，均 AC 1.0、仍在 `card_version:"1.5"` 内，为白名单增量而非版本升级） |
 | 永不（P3 再议） | `Action.Execute`、`Action.ShowCard`、`ToggleVisibility`、模板/数据绑定、`Table` 等 AC 1.6 元素 |
 
 结构与大小上限（全部 ingress 一致）：
@@ -77,7 +77,10 @@ allowlist —— 服务端用**完整 CommonMark 解析器**（非模式匹配�
   2. 不认识 `profile`（更新的服务端/更旧的客户端）→ 渲染 `plain`；
   3. 连 `type:17` 都不认识（存量客户端）→ octo-lib 未知类型兜底文案。
 - P2 产者能力发现：`GET /v1/bot/card/profile`（D12，随 P2 落地）返回部署的
-  `enabled` / `card_version` / `profiles` / `limits` 清单（只增不改）；P1 期间生产者以发送被
+  `enabled` / `card_version` / `profiles` / `elements` / `inputs` / `limits` 清单（只增不改）；
+  `elements`/`inputs` 是本部署接受的展示元素 / 交互输入白名单（源自 `pkg/cardmsg`
+  权威列表），供 producer 按**元素粒度**前向兼容协商——即便 `card_version` 停在 `"1.5"`，
+  也能探测是否接受 `Input.Number/Date/Time` 等 additive 新增元素。P1 期间生产者以发送被
   400/`card_disabled` 拒绝为「未启用」信号。
 
 ## 4. 信任模型（谁能发卡、谁能信卡）
@@ -166,7 +169,9 @@ robot API（legacy）`/robot/sendMessage` 同样接受 type-17（校验与 bot i
   tombstone、`transient:true` 的进度帧不入史）。
 - **乱序防护**：可选 `card_seq`（单调递增）；带上时旧帧 → 409。
 - **inputs 信任边界**：提交键必须命中生效帧声明的 `Input.*` id（未声明
-  fail-closed），值为字符串、逐类型校验、总量 ≤ 16 KiB。
+  fail-closed），值为字符串、逐类型校验、总量 ≤ 16 KiB。P3-3 起 `Input.Number`
+  按数值+声明 min/max 校验、`Input.Date`（YYYY-MM-DD）/`Input.Time`（HH:MM）按
+  格式+声明区间校验，三者 `""` 均视为未填放行（`isRequired`/`regex` 不服务端强制）。
 - **`event_data.space_id`**（PR#548 P1-3）：卡片**来源 Space**，服务端从存储行
   解析（群/子区取群 SpaceID；DM 取发送时注入 payload 的 `space_id`），**非**操作者
   请求上下文 Space；无权威值时省略该键（fail-closed），消费方按可选字段处理。

--- a/docs/card-protocol.md
+++ b/docs/card-protocol.md
@@ -38,7 +38,7 @@
 
 | 类别 | 允许 |
 |---|---|
-| 元素 | `TextBlock`（markdown 子集，§2.1）、`RichTextBlock`、`Image`、`ImageSet`、`Container`、`ColumnSet`/`Column`、`FactSet`、`Table`、`ActionSet`（`RichTextBlock`/`ImageSet`/`Table`/`ActionSet` 为 P3-3 Tier 1 追加，均 AC ≤1.5：ImageSet 1.0 / RichTextBlock 1.2 / ActionSet 1.2 / Table 1.5） |
+| 元素 | `TextBlock`（markdown 子集，§2.1）、`RichTextBlock`、`Image`、`ImageSet`、`Container`、`ColumnSet`（含 `Column` 列）、`FactSet`、`Table`、`ActionSet`（`RichTextBlock`/`ImageSet`/`Table`/`ActionSet` 为 P3-3 Tier 1 追加，均 AC ≤1.5：ImageSet 1.0 / RichTextBlock 1.2 / ActionSet 1.2 / Table 1.5） |
 | 动作 | `Action.OpenUrl`；元素/整卡 `selectAction` **仅当**携带 `Action.OpenUrl` |
 | P2 起（octo/v2） | `Action.Submit`（含 selectAction/ActionSet 携带）、`Input.Text` / `Input.Toggle` / `Input.ChoiceSet` / `Input.Number` / `Input.Date` / `Input.Time`（id 必填且帧内唯一；后三者 P3-3 追加，均 AC 1.0、仍在 `card_version:"1.5"` 内，为白名单增量而非版本升级） |
 | 暂不支持（后续按需） | `Media`(1.1)、`Action.ShowCard`(1.0)、`Action.ToggleVisibility`(1.2)、`Action.Execute`(1.4)、模板/数据绑定，以及 AC 1.6 元素 |
@@ -79,7 +79,8 @@ allowlist —— 服务端用**完整 CommonMark 解析器**（非模式匹配�
 - P2 产者能力发现：`GET /v1/bot/card/profile`（D12，随 P2 落地）返回部署的
   `enabled` / `card_version` / `profiles` / `elements` / `inputs` / `limits` 清单（只增不改）；
   `elements`/`inputs` 是本部署接受的展示元素 / 交互输入白名单（源自 `pkg/cardmsg`
-  权威列表），供 producer 按**元素粒度**前向兼容协商——即便 `card_version` 停在 `"1.5"`，
+  权威列表；`elements` 只列**顶层可放置**元素——`Column` 是 `ColumnSet` 的子列、由
+  `ColumnSet` 涵盖，不单列），供 producer 按**元素粒度**前向兼容协商——即便 `card_version` 停在 `"1.5"`，
   也能探测是否接受 `Input.Number/Date/Time` 等 additive 新增元素。P1 期间生产者以发送被
   400/`card_disabled` 拒绝为「未启用」信号。
 

--- a/modules/bot_api/card_profile.go
+++ b/modules/bot_api/card_profile.go
@@ -11,7 +11,8 @@ package bot_api
 //
 // 清单值全部取自 pkg/cardmsg 常量（**单一权威**，D12.2）—— 绝不在此重抄字面量，否则
 // 常量变更时清单会与校验器静默漂移。profiles 取 cardmsg.AcceptedProfiles()（与校验器
-// interactiveByProfile 的接受集同源）。
+// interactiveByProfile 的接受集同源）；elements/inputs 取 cardmsg.DisplayElements()/
+// InputElements()（与校验器白名单同源，反漂移由 pkg/cardmsg 守卫测试锁定）。
 //
 // enabled 直取 cardmsg.Enabled()（部署级 rollout 开关）：即便关闭也返回 200 + 全清单
 // —— feature detection 正是目的；只有 send/edit 路径在关闭时拒绝（send.go:97）。
@@ -36,6 +37,12 @@ func (ba *BotAPI) botCardProfile(c *wkhttp.Context) {
 		"enabled":      cardmsg.Enabled(),
 		"card_version": cardmsg.CardVersion,
 		"profiles":     cardmsg.AcceptedProfiles(),
+		// elements/inputs：本部署接受的展示元素 / 交互输入白名单（源自 pkg/cardmsg 权威
+		// 列表，D12.2 单一权威）。producer / J3 gate 据此按**元素粒度**做前向兼容协商——
+		// 即便 card_version 停在 "1.5"，也能探测本部署是否接受 Input.Number/Date/Time 等
+		// additive 新增元素，消除「版本号不变 → gate 无法分辨新旧 1.5 部署」的错配。
+		"elements": cardmsg.DisplayElements(),
+		"inputs":   cardmsg.InputElements(),
 		"limits": map[string]interface{}{
 			"max_payload_bytes":    cardmsg.MaxPayloadBytes,
 			"max_nodes":            cardmsg.MaxNodes,

--- a/modules/bot_api/card_profile_test.go
+++ b/modules/bot_api/card_profile_test.go
@@ -53,6 +53,8 @@ type cardProfileManifest struct {
 	Enabled     bool     `json:"enabled"`
 	CardVersion string   `json:"card_version"`
 	Profiles    []string `json:"profiles"`
+	Elements    []string `json:"elements"`
+	Inputs      []string `json:"inputs"`
 	Limits      struct {
 		MaxPayloadBytes   int `json:"max_payload_bytes"`
 		MaxNodes          int `json:"max_nodes"`
@@ -60,6 +62,23 @@ type cardProfileManifest struct {
 		MaxInputTextBytes int `json:"max_input_text_bytes"`
 		MaxInputsBytes    int `json:"max_inputs_bytes"`
 	} `json:"limits"`
+}
+
+// TestBotCardProfile_ElementsInputsFromConstants（D12.2）：elements/inputs 深等 cardmsg
+// 权威白名单 —— 供 J3 gate 按元素/输入粒度做前向兼容协商（即便 card_version 不变，也能
+// 探测本部署是否接受 Input.Number/Date/Time 等新增元素，消除「版本号不动 → gate 无法
+// 分辨新旧 1.5 部署」的错配）。
+func TestBotCardProfile_ElementsInputsFromConstants(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	handler, _ := setupBotCardProfile(t)
+
+	w := getCardProfile(t, handler, cpBotToken)
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var m cardProfileManifest
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &m))
+	assert.Equal(t, cardmsg.DisplayElements(), m.Elements)
+	assert.Equal(t, cardmsg.InputElements(), m.Inputs)
 }
 
 // TestBotCardProfile_ValuesFromConstants：清单每个值必须等于 pkg/cardmsg 常量
@@ -149,7 +168,7 @@ func TestBotCardProfile_AdditiveContractFieldSet(t *testing.T) {
 	for k := range raw {
 		gotTop = append(gotTop, k)
 	}
-	assert.ElementsMatch(t, []string{"enabled", "card_version", "profiles", "limits"}, gotTop,
+	assert.ElementsMatch(t, []string{"enabled", "card_version", "profiles", "limits", "elements", "inputs"}, gotTop,
 		"D12 additive-only：顶层字段集冻结（新增新字段，绝不改名/删除）")
 
 	var limits map[string]json.RawMessage

--- a/pkg/cardmsg/cardmsg_test.go
+++ b/pkg/cardmsg/cardmsg_test.go
@@ -113,7 +113,7 @@ func TestValidateWhitelistRejections(t *testing.T) {
 		want error
 	}{
 		{"Input.Text 元素", cardWithBody(map[string]interface{}{"type": "Input.Text", "id": "x"}), ErrCardUnknownElement},
-		{"Table 元素(1.6)", cardWithBody(map[string]interface{}{"type": "Table"}), ErrCardUnknownElement},
+		{"Media 元素(未支持,AC1.1)", cardWithBody(map[string]interface{}{"type": "Media"}), ErrCardUnknownElement},
 		{"Action.Submit", map[string]interface{}{"body": []interface{}{}, "actions": []interface{}{
 			map[string]interface{}{"type": "Action.Submit", "title": "OK"},
 		}}, ErrCardUnknownAction},
@@ -124,7 +124,10 @@ func TestValidateWhitelistRejections(t *testing.T) {
 			"type":         "Container",
 			"selectAction": map[string]interface{}{"type": "Action.Submit", "data": map[string]interface{}{}},
 		}), ErrCardUnknownAction},
-		{"ActionSet 不在白名单", cardWithBody(map[string]interface{}{"type": "ActionSet"}), ErrCardUnknownElement},
+		{"Action.ToggleVisibility(未支持,AC1.2)", cardWithBody(map[string]interface{}{
+			"type":         "Container",
+			"selectAction": map[string]interface{}{"type": "Action.ToggleVisibility"},
+		}), ErrCardUnknownAction},
 	} {
 		if err := Validate(envelope(tc.card)); !errors.Is(err, tc.want) {
 			t.Errorf("%s: err=%v want %v", tc.name, err, tc.want)

--- a/pkg/cardmsg/inputs.go
+++ b/pkg/cardmsg/inputs.go
@@ -186,9 +186,10 @@ func collectInputSpecsFromElements(items []interface{}, specs map[string]inputSp
 				specs[id] = spec
 			}
 		}
-		// items/columns 仅对容器类递归，与 Validate 一致（叶子元素的 items/columns
-		// 发送期不被遍历，派发侧也不得把其中的 input id 当作「已声明」，否则 D11 声明面
-		// > 校验面 —— 与 findSubmitInElements 同口径）。
+		// items/columns/cells 仅对容器类递归，与 Validate / findSubmitInElements 完全一致
+		// （叶子元素的 items 发送期不被遍历，采集侧也不得把其中的 input id 当作「已声明」，
+		// 否则声明面 > 校验面）。Table.rows→cells→items 同样承载标准元素（含 Input.*），必须
+		// 递归 —— 否则 Table 单元格内的输入发送/派发都通过、提交却被当「未声明」拒（PR#556）。
 		switch t {
 		case "Container":
 			if sub, ok := el["items"].([]interface{}); ok {
@@ -200,6 +201,26 @@ func collectInputSpecsFromElements(items []interface{}, specs map[string]inputSp
 					if col, ok := c.(map[string]interface{}); ok {
 						if sub, ok := col["items"].([]interface{}); ok {
 							collectInputSpecsFromElements(sub, specs)
+						}
+					}
+				}
+			}
+		case "Table":
+			if rows, ok := el["rows"].([]interface{}); ok {
+				for _, r := range rows {
+					row, ok := r.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					cells, ok := row["cells"].([]interface{})
+					if !ok {
+						continue
+					}
+					for _, c := range cells {
+						if cell, ok := c.(map[string]interface{}); ok {
+							if sub, ok := cell["items"].([]interface{}); ok {
+								collectInputSpecsFromElements(sub, specs)
+							}
 						}
 					}
 				}

--- a/pkg/cardmsg/inputs.go
+++ b/pkg/cardmsg/inputs.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -24,6 +25,15 @@ const (
 	// MaxInputsBytes inputs 序列化总量上限（D11）。
 	MaxInputsBytes = 16 << 10
 )
+
+// jsonNumberPattern 是 RFC 8259 JSON 数字文法（= JS Number / bot 端 JSON 解析口径）：
+// 可选前导负号、整数部分无前导零、可选小数、可选指数。刻意**不**用 strconv.ParseFloat
+// 判定「是不是数字」：ParseFloat 接受 Go 专有文法——下划线分隔（"1_000"）、十六进制浮点
+// （"0x1p4"）、前导 "+"、前导零、裸 "NaN"/"Inf"——是 JSON/JS Number 的**超集**，会放行
+// bot 端 JSON 解析器拒绝或解读不同的串，造成「服务端判合法、bot 拿到的却是另一个数 / 解析
+// 失败」的静默数值错位。用严格文法先把服务端的「合法数字」钉到与 bot 收到的 JSON 一致的
+// 口径，再用 ParseFloat 求值兜溢出（PR#556 review）。
+var jsonNumberPattern = regexp.MustCompile(`^-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][-+]?[0-9]+)?$`)
 
 // inputSpec 是生效帧里一个已声明 Input.* 元素的校验视图。
 type inputSpec struct {
@@ -43,7 +53,7 @@ type inputSpec struct {
 //   - 值必须是字符串；Input.Text ≤ 4KiB；Input.Toggle 必须等于 valueOn/valueOff；
 //     Input.ChoiceSet 必须命中声明的 choice value（multiSelect 为逗号分隔子集，
 //     单选允许 "" 表示未选择）；
-//   - P3-3：Input.Number 值必须可解析为有限数；Input.Date 必须是 YYYY-MM-DD；
+//   - P3-3：Input.Number 必须是合法 JSON 数字且有限；Input.Date 必须是 YYYY-MM-DD；
 //     Input.Time 必须是 HH:MM(24h)；三者 "" 均视为未填放行。min/max 区间**不**服务端
 //     强制（AC 规范定义为可忽略 hint，区间校验下放 bot，与 isRequired/regex 同）；
 //   - 序列化总量 ≤ 16KiB。
@@ -96,19 +106,21 @@ func ValidateInputs(envelopeRaw []byte, inputs map[string]interface{}) error {
 				}
 			}
 		case "Input.Number":
-			// 空串=未填（isRequired 不服务端强制）；否则必须可解析为有限数。min/max 区间
-			// 不服务端强制（下放 bot，见 inputSpec 注释）。
+			// 空串=未填（isRequired 不服务端强制）；否则必须匹配严格 JSON 数字文法。min/max
+			// 区间不服务端强制（下放 bot，见 inputSpec 注释）。
 			if s == "" {
 				break
 			}
-			n, err := strconv.ParseFloat(s, 64)
-			if err != nil {
+			// 先过严格 JSON 数字文法（见 jsonNumberPattern 注释：ParseFloat 的文法是 JSON/JS
+			// Number 的超集，会静默放行 bot 端解析不同的串）。
+			if !jsonNumberPattern.MatchString(s) {
 				return fmt.Errorf("%w: input %q 不是合法数字", ErrCardInputInvalid, key)
 			}
-			// strconv.ParseFloat 接受 NaN/±Inf/Infinity 且不报错；非有限数不是合法数值输入，
-			// 拒（信任边界：交给 bot 的值必须是「形状可信」的有限数 —— 这是格式/类型校验，与
-			// 下放给 bot 的 range 无关）。
-			if math.IsNaN(n) || math.IsInf(n, 0) {
+			// 文法已排除 NaN/Inf 字面量与 Go 专有形态；ParseFloat 在此仅用于求值兜数值溢出
+			// （如 "1e999"→±Inf，返回 ErrRange）。非有限数不是合法数值输入，不得当「形状可信」
+			// 值透传给 bot（信任边界：格式/类型校验，与已下放 bot 的 range 无关）。
+			n, err := strconv.ParseFloat(s, 64)
+			if err != nil || math.IsNaN(n) || math.IsInf(n, 0) {
 				return fmt.Errorf("%w: input %q 不是有限数", ErrCardInputInvalid, key)
 			}
 		case "Input.Date":
@@ -127,6 +139,12 @@ func ValidateInputs(envelopeRaw []byte, inputs map[string]interface{}) error {
 			if !isValidTime(s) {
 				return fmt.Errorf("%w: input %q 不是合法时间(HH:MM)", ErrCardInputInvalid, key)
 			}
+		default:
+			// 声明帧里出现「已白名单收集、但校验器无对应 case」的输入类型：fail-closed 拒。
+			// 当前不可达——collectInputSpecs 只从 isInputElement（inputElements）收集，六类都
+			// 有 case——但显式兜底防止未来往 inputElements 加类型却漏加 case 时退化成 fail-open
+			// （「已声明即放行任意值」的天窗）。与信任边界「未覆盖即拒」一致（PR#556 review）。
+			return fmt.Errorf("%w: input %q 类型 %q 无值校验", ErrCardInputInvalid, key, spec.typ)
 		}
 	}
 	return nil
@@ -159,6 +177,9 @@ func collectInputSpecsFromElements(items []interface{}, specs map[string]inputSp
 		if isInputElement(t) {
 			if id, _ := el["id"].(string); id != "" {
 				spec := inputSpec{typ: t}
+				// 仅 Toggle/ChoiceSet 需采集额外声明（valueOn/off、choices、multiSelect）；
+				// Text/Number/Date/Time 只需 typ（提交期值校验只看格式，不采集 min/max —— 区间
+				// 不服务端强制，见 inputSpec 注释），故无 case。
 				switch t {
 				case "Input.Toggle":
 					spec.valueOn, spec.valueOff = "true", "false"
@@ -180,8 +201,6 @@ func collectInputSpecsFromElements(items []interface{}, specs map[string]inputSp
 						}
 					}
 					spec.multiSelect, _ = el["isMultiSelect"].(bool)
-					// Input.Number/Date/Time：只需 typ（值校验只看格式，不采集 min/max
-					// —— 区间不服务端强制，见 inputSpec 注释）。
 				}
 				specs[id] = spec
 			}

--- a/pkg/cardmsg/inputs.go
+++ b/pkg/cardmsg/inputs.go
@@ -32,14 +32,10 @@ type inputSpec struct {
 	multiSelect bool                // isMultiSelect：值为逗号分隔子集（AC 线上格式）
 	valueOn     string              // Input.Toggle；缺省 "true"/"false"
 	valueOff    string
-	// P3-3 声明区间（Number/Date/Time）。存在性由 hasMin/hasMax 标记 —— 缺省即不设界
-	// （区间是「形状可信」的一部分，与 ChoiceSet 校验声明 choices 同构；isRequired/regex
-	// 仍不在服务端强制）。Number 用数值界，Date/Time 用同格式字符串界（固定格式下字典序
-	// == 时序）。malformed 的生产者界在采集期被丢弃（fail-open，绝不因生产者界非法而拒
-	// 用户值）。
-	hasMin, hasMax bool
-	minNum, maxNum float64 // Input.Number
-	minStr, maxStr string  // Input.Date（YYYY-MM-DD）/ Input.Time（HH:MM）
+	// Number/Date/Time 只校验格式，不采集 min/max —— 区间不服务端强制（PR#556 review：
+	// AC 规范把 min/max 定义为「可被客户端忽略的 hint」，合规客户端可提交越界值，而
+	// card/action 把错误折叠成单一 invalid，越界拒绝会让用户收到无从更正的笼统错；区间
+	// 校验下放 bot 业务逻辑，与 isRequired/regex 同）。
 }
 
 // ValidateInputs 按 D11 校验 card/action 请求的 inputs（fail-closed）：
@@ -47,9 +43,9 @@ type inputSpec struct {
 //   - 值必须是字符串；Input.Text ≤ 4KiB；Input.Toggle 必须等于 valueOn/valueOff；
 //     Input.ChoiceSet 必须命中声明的 choice value（multiSelect 为逗号分隔子集，
 //     单选允许 "" 表示未选择）；
-//   - P3-3：Input.Number 值必须可解析为数字、在声明 min/max 内；Input.Date 必须是
-//     YYYY-MM-DD、在声明区间内；Input.Time 必须是 HH:MM(24h)、在声明区间内；三者
-//     "" 均视为未填放行（isRequired 不服务端强制）；
+//   - P3-3：Input.Number 值必须可解析为有限数；Input.Date 必须是 YYYY-MM-DD；
+//     Input.Time 必须是 HH:MM(24h)；三者 "" 均视为未填放行。min/max 区间**不**服务端
+//     强制（AC 规范定义为可忽略 hint，区间校验下放 bot，与 isRequired/regex 同）；
 //   - 序列化总量 ≤ 16KiB。
 //
 // envelopeRaw 是「生效卡片」信封字节（content_edit 优先，与 SubmitAction 的取帧
@@ -100,7 +96,8 @@ func ValidateInputs(envelopeRaw []byte, inputs map[string]interface{}) error {
 				}
 			}
 		case "Input.Number":
-			// 空串=未填（isRequired 不服务端强制）；否则必须可解析为数字，且在声明区间内。
+			// 空串=未填（isRequired 不服务端强制）；否则必须可解析为有限数。min/max 区间
+			// 不服务端强制（下放 bot，见 inputSpec 注释）。
 			if s == "" {
 				break
 			}
@@ -108,45 +105,27 @@ func ValidateInputs(envelopeRaw []byte, inputs map[string]interface{}) error {
 			if err != nil {
 				return fmt.Errorf("%w: input %q 不是合法数字", ErrCardInputInvalid, key)
 			}
-			// strconv.ParseFloat 接受 NaN/±Inf/Infinity 且不报错；NaN 与 min/max 的比较恒
-			// false 会绕过区间校验。非有限数不是合法数值输入，拒（信任边界：交给 bot 的值必须
-			// 是「形状可信」的有限数）。
+			// strconv.ParseFloat 接受 NaN/±Inf/Infinity 且不报错；非有限数不是合法数值输入，
+			// 拒（信任边界：交给 bot 的值必须是「形状可信」的有限数 —— 这是格式/类型校验，与
+			// 下放给 bot 的 range 无关）。
 			if math.IsNaN(n) || math.IsInf(n, 0) {
 				return fmt.Errorf("%w: input %q 不是有限数", ErrCardInputInvalid, key)
 			}
-			if spec.hasMin && n < spec.minNum {
-				return fmt.Errorf("%w: input %q 小于声明下界", ErrCardInputInvalid, key)
-			}
-			if spec.hasMax && n > spec.maxNum {
-				return fmt.Errorf("%w: input %q 大于声明上界", ErrCardInputInvalid, key)
-			}
 		case "Input.Date":
+			// 空串=未填；否则必须是 YYYY-MM-DD。声明区间不服务端强制（同 Number）。
 			if s == "" {
 				break
 			}
 			if !isValidDate(s) {
 				return fmt.Errorf("%w: input %q 不是合法日期(YYYY-MM-DD)", ErrCardInputInvalid, key)
 			}
-			// 固定 YYYY-MM-DD 格式下字典序即时序，直接比较字符串。
-			if spec.hasMin && s < spec.minStr {
-				return fmt.Errorf("%w: input %q 早于声明下界", ErrCardInputInvalid, key)
-			}
-			if spec.hasMax && s > spec.maxStr {
-				return fmt.Errorf("%w: input %q 晚于声明上界", ErrCardInputInvalid, key)
-			}
 		case "Input.Time":
+			// 空串=未填；否则必须是 HH:MM(24h)。声明区间不服务端强制（同 Number）。
 			if s == "" {
 				break
 			}
 			if !isValidTime(s) {
 				return fmt.Errorf("%w: input %q 不是合法时间(HH:MM)", ErrCardInputInvalid, key)
-			}
-			// 固定 HH:MM(24h) 格式下字典序即时序。
-			if spec.hasMin && s < spec.minStr {
-				return fmt.Errorf("%w: input %q 早于声明下界", ErrCardInputInvalid, key)
-			}
-			if spec.hasMax && s > spec.maxStr {
-				return fmt.Errorf("%w: input %q 晚于声明上界", ErrCardInputInvalid, key)
 			}
 		}
 	}
@@ -201,29 +180,8 @@ func collectInputSpecsFromElements(items []interface{}, specs map[string]inputSp
 						}
 					}
 					spec.multiSelect, _ = el["isMultiSelect"].(bool)
-				case "Input.Number":
-					// AC min/max 为 JSON 数字。
-					if v, ok := el["min"].(float64); ok {
-						spec.hasMin, spec.minNum = true, v
-					}
-					if v, ok := el["max"].(float64); ok {
-						spec.hasMax, spec.maxNum = true, v
-					}
-				case "Input.Date":
-					// AC min/max 为 ISO 日期字符串；仅在生产者界本身合法时启用（fail-open）。
-					if v, ok := el["min"].(string); ok && isValidDate(v) {
-						spec.hasMin, spec.minStr = true, v
-					}
-					if v, ok := el["max"].(string); ok && isValidDate(v) {
-						spec.hasMax, spec.maxStr = true, v
-					}
-				case "Input.Time":
-					if v, ok := el["min"].(string); ok && isValidTime(v) {
-						spec.hasMin, spec.minStr = true, v
-					}
-					if v, ok := el["max"].(string); ok && isValidTime(v) {
-						spec.hasMax, spec.maxStr = true, v
-					}
+					// Input.Number/Date/Time：只需 typ（值校验只看格式，不采集 min/max
+					// —— 区间不服务端强制，见 inputSpec 注释）。
 				}
 				specs[id] = spec
 			}

--- a/pkg/cardmsg/inputs.go
+++ b/pkg/cardmsg/inputs.go
@@ -12,7 +12,10 @@ package cardmsg
 import (
 	"encoding/json"
 	"fmt"
+	"math"
+	"strconv"
 	"strings"
+	"time"
 )
 
 const (
@@ -29,6 +32,14 @@ type inputSpec struct {
 	multiSelect bool                // isMultiSelect：值为逗号分隔子集（AC 线上格式）
 	valueOn     string              // Input.Toggle；缺省 "true"/"false"
 	valueOff    string
+	// P3-3 声明区间（Number/Date/Time）。存在性由 hasMin/hasMax 标记 —— 缺省即不设界
+	// （区间是「形状可信」的一部分，与 ChoiceSet 校验声明 choices 同构；isRequired/regex
+	// 仍不在服务端强制）。Number 用数值界，Date/Time 用同格式字符串界（固定格式下字典序
+	// == 时序）。malformed 的生产者界在采集期被丢弃（fail-open，绝不因生产者界非法而拒
+	// 用户值）。
+	hasMin, hasMax bool
+	minNum, maxNum float64 // Input.Number
+	minStr, maxStr string  // Input.Date（YYYY-MM-DD）/ Input.Time（HH:MM）
 }
 
 // ValidateInputs 按 D11 校验 card/action 请求的 inputs（fail-closed）：
@@ -36,6 +47,9 @@ type inputSpec struct {
 //   - 值必须是字符串；Input.Text ≤ 4KiB；Input.Toggle 必须等于 valueOn/valueOff；
 //     Input.ChoiceSet 必须命中声明的 choice value（multiSelect 为逗号分隔子集，
 //     单选允许 "" 表示未选择）；
+//   - P3-3：Input.Number 值必须可解析为数字、在声明 min/max 内；Input.Date 必须是
+//     YYYY-MM-DD、在声明区间内；Input.Time 必须是 HH:MM(24h)、在声明区间内；三者
+//     "" 均视为未填放行（isRequired 不服务端强制）；
 //   - 序列化总量 ≤ 16KiB。
 //
 // envelopeRaw 是「生效卡片」信封字节（content_edit 优先，与 SubmitAction 的取帧
@@ -85,6 +99,55 @@ func ValidateInputs(envelopeRaw []byte, inputs map[string]interface{}) error {
 					return fmt.Errorf("%w: input %q 不是声明的选项", ErrCardInputInvalid, key)
 				}
 			}
+		case "Input.Number":
+			// 空串=未填（isRequired 不服务端强制）；否则必须可解析为数字，且在声明区间内。
+			if s == "" {
+				break
+			}
+			n, err := strconv.ParseFloat(s, 64)
+			if err != nil {
+				return fmt.Errorf("%w: input %q 不是合法数字", ErrCardInputInvalid, key)
+			}
+			// strconv.ParseFloat 接受 NaN/±Inf/Infinity 且不报错；NaN 与 min/max 的比较恒
+			// false 会绕过区间校验。非有限数不是合法数值输入，拒（信任边界：交给 bot 的值必须
+			// 是「形状可信」的有限数）。
+			if math.IsNaN(n) || math.IsInf(n, 0) {
+				return fmt.Errorf("%w: input %q 不是有限数", ErrCardInputInvalid, key)
+			}
+			if spec.hasMin && n < spec.minNum {
+				return fmt.Errorf("%w: input %q 小于声明下界", ErrCardInputInvalid, key)
+			}
+			if spec.hasMax && n > spec.maxNum {
+				return fmt.Errorf("%w: input %q 大于声明上界", ErrCardInputInvalid, key)
+			}
+		case "Input.Date":
+			if s == "" {
+				break
+			}
+			if !isValidDate(s) {
+				return fmt.Errorf("%w: input %q 不是合法日期(YYYY-MM-DD)", ErrCardInputInvalid, key)
+			}
+			// 固定 YYYY-MM-DD 格式下字典序即时序，直接比较字符串。
+			if spec.hasMin && s < spec.minStr {
+				return fmt.Errorf("%w: input %q 早于声明下界", ErrCardInputInvalid, key)
+			}
+			if spec.hasMax && s > spec.maxStr {
+				return fmt.Errorf("%w: input %q 晚于声明上界", ErrCardInputInvalid, key)
+			}
+		case "Input.Time":
+			if s == "" {
+				break
+			}
+			if !isValidTime(s) {
+				return fmt.Errorf("%w: input %q 不是合法时间(HH:MM)", ErrCardInputInvalid, key)
+			}
+			// 固定 HH:MM(24h) 格式下字典序即时序。
+			if spec.hasMin && s < spec.minStr {
+				return fmt.Errorf("%w: input %q 早于声明下界", ErrCardInputInvalid, key)
+			}
+			if spec.hasMax && s > spec.maxStr {
+				return fmt.Errorf("%w: input %q 晚于声明上界", ErrCardInputInvalid, key)
+			}
 		}
 	}
 	return nil
@@ -114,7 +177,7 @@ func collectInputSpecsFromElements(items []interface{}, specs map[string]inputSp
 			continue
 		}
 		t, _ := el["type"].(string)
-		if t == "Input.Text" || t == "Input.Toggle" || t == "Input.ChoiceSet" {
+		if isInputElement(t) {
 			if id, _ := el["id"].(string); id != "" {
 				spec := inputSpec{typ: t}
 				switch t {
@@ -138,6 +201,29 @@ func collectInputSpecsFromElements(items []interface{}, specs map[string]inputSp
 						}
 					}
 					spec.multiSelect, _ = el["isMultiSelect"].(bool)
+				case "Input.Number":
+					// AC min/max 为 JSON 数字。
+					if v, ok := el["min"].(float64); ok {
+						spec.hasMin, spec.minNum = true, v
+					}
+					if v, ok := el["max"].(float64); ok {
+						spec.hasMax, spec.maxNum = true, v
+					}
+				case "Input.Date":
+					// AC min/max 为 ISO 日期字符串；仅在生产者界本身合法时启用（fail-open）。
+					if v, ok := el["min"].(string); ok && isValidDate(v) {
+						spec.hasMin, spec.minStr = true, v
+					}
+					if v, ok := el["max"].(string); ok && isValidDate(v) {
+						spec.hasMax, spec.maxStr = true, v
+					}
+				case "Input.Time":
+					if v, ok := el["min"].(string); ok && isValidTime(v) {
+						spec.hasMin, spec.minStr = true, v
+					}
+					if v, ok := el["max"].(string); ok && isValidTime(v) {
+						spec.hasMax, spec.maxStr = true, v
+					}
 				}
 				specs[id] = spec
 			}
@@ -162,4 +248,23 @@ func collectInputSpecsFromElements(items []interface{}, specs map[string]inputSp
 			}
 		}
 	}
+}
+
+// isValidDate 校验 AC Input.Date 线上值格式（严格 YYYY-MM-DD + 真实日历日）。
+// 先卡定宽/分隔位（拒非零填充如 "2026-7-9"），再用 time.Parse 拒非法日历日（如 13 月）。
+func isValidDate(s string) bool {
+	if len(s) != 10 || s[4] != '-' || s[7] != '-' {
+		return false
+	}
+	_, err := time.Parse("2006-01-02", s)
+	return err == nil
+}
+
+// isValidTime 校验 AC Input.Time 线上值格式（严格 HH:MM 24h）。
+func isValidTime(s string) bool {
+	if len(s) != 5 || s[2] != ':' {
+		return false
+	}
+	_, err := time.Parse("15:04", s)
+	return err == nil
 }

--- a/pkg/cardmsg/interactive.go
+++ b/pkg/cardmsg/interactive.go
@@ -115,6 +115,10 @@ func findSubmitInElements(items []interface{}, actionID string) (map[string]inte
 			if imgs, ok := el["images"].([]interface{}); ok {
 				for _, it := range imgs {
 					if img, ok := it.(map[string]interface{}); ok {
+						// 派发面 == 校验面：非 Image 子元素发送期已拒，派发侧同 childTypeMatches 跳过，两面不漂移（PR#556 review P2）。
+						if !childTypeMatches(img, "Image") {
+							continue
+						}
 						if d, ok := findSubmitAction(img["selectAction"], actionID); ok {
 							return d, true
 						}
@@ -126,6 +130,10 @@ func findSubmitInElements(items []interface{}, actionID string) (map[string]inte
 			if inls, ok := el["inlines"].([]interface{}); ok {
 				for _, it := range inls {
 					if inl, ok := it.(map[string]interface{}); ok {
+						// 同上：非 TextRun 内联对象发送期已拒，派发侧同判定跳过（PR#556 review P2）。
+						if !childTypeMatches(inl, "TextRun") {
+							continue
+						}
 						if d, ok := findSubmitAction(inl["selectAction"], actionID); ok {
 							return d, true
 						}
@@ -141,6 +149,10 @@ func findSubmitInElements(items []interface{}, actionID string) (map[string]inte
 					if !ok {
 						continue
 					}
+					// 非 TableRow 发送期已拒，派发侧同判定跳过（PR#556 review P2）。
+					if !childTypeMatches(row, "TableRow") {
+						continue
+					}
 					// 行级 selectAction 可载 Submit（发送期 w.selectAction(row) 已对齐校验，
 					// PR#556 review P2）。
 					if d, ok := findSubmitAction(row["selectAction"], actionID); ok {
@@ -153,6 +165,10 @@ func findSubmitInElements(items []interface{}, actionID string) (map[string]inte
 					for _, c := range cells {
 						cell, ok := c.(map[string]interface{})
 						if !ok {
+							continue
+						}
+						// 非 TableCell 发送期已拒，派发侧同判定跳过（PR#556 review P2）。
+						if !childTypeMatches(cell, "TableCell") {
 							continue
 						}
 						if d, ok := findSubmitAction(cell["selectAction"], actionID); ok {

--- a/pkg/cardmsg/interactive.go
+++ b/pkg/cardmsg/interactive.go
@@ -68,8 +68,10 @@ func findSubmitInElements(items []interface{}, actionID string) (map[string]inte
 		if d, ok := findSubmitAction(el["selectAction"], actionID); ok {
 			return d, true
 		}
-		// inlineAction：仅 Input.*（发送期只在 Input 分支校验），派发面 ≤ 校验面。
-		if t == "Input.Text" || t == "Input.Toggle" || t == "Input.ChoiceSet" {
+		// inlineAction：仅 Input.*（发送期只在输入分支校验）。派发面用与校验器同一个
+		// isInputElement 谓词，保证「校验面 == 派发面」—— 否则 Input.Number/Date/Time 的
+		// inlineAction Submit 会「发送通过、点击 not-found」死按钮（P3-3）。
+		if isInputElement(t) {
 			if d, ok := findSubmitAction(el["inlineAction"], actionID); ok {
 				return d, true
 			}

--- a/pkg/cardmsg/interactive.go
+++ b/pkg/cardmsg/interactive.go
@@ -76,9 +76,10 @@ func findSubmitInElements(items []interface{}, actionID string) (map[string]inte
 				return d, true
 			}
 		}
-		// items/columns 仅对容器类递归，与 Validate 完全一致（发送期只有 Container 递归
-		// items、ColumnSet 递归 columns→Column.items）——否则藏在叶子 items[] 下的
-		// Submit 会「派发可解析、发送期没校验」（PR#548 review：派发面必须 ≤ 校验面）。
+		// 容器/动作面递归，与 Validate 完全一致（发送期递归的位置：Container.items、
+		// ColumnSet→Column.items、以及 P3-3 Tier 1 的 Table→cells.items、ActionSet.actions、
+		// ImageSet.images[].selectAction、RichTextBlock.inlines[].selectAction）——否则藏在
+		// 未遍历位置的 Submit 会「派发可解析、发送期没校验」，或反之成为死按钮（派发面 == 校验面）。
 		switch t {
 		case "Container":
 			if sub, ok := el["items"].([]interface{}); ok {
@@ -99,6 +100,63 @@ func findSubmitInElements(items []interface{}, actionID string) (map[string]inte
 					if sub, ok := col["items"].([]interface{}); ok {
 						if d, ok := findSubmitInElements(sub, actionID); ok {
 							return d, true
+						}
+					}
+				}
+			}
+		case "ActionSet":
+			// P3-3 Tier 1：Submit 可出现在 body 的 ActionSet.actions（发送期 element() 走
+			// w.action 校验），派发侧对齐遍历。
+			if d, ok := findSubmitAction(el["actions"], actionID); ok {
+				return d, true
+			}
+		case "ImageSet":
+			// ImageSet.images[].selectAction 可载 Submit（发送期 imageChild 校验），对齐。
+			if imgs, ok := el["images"].([]interface{}); ok {
+				for _, it := range imgs {
+					if img, ok := it.(map[string]interface{}); ok {
+						if d, ok := findSubmitAction(img["selectAction"], actionID); ok {
+							return d, true
+						}
+					}
+				}
+			}
+		case "RichTextBlock":
+			// RichTextBlock.inlines[] 里的 TextRun.selectAction 可载 Submit（发送期校验），对齐。
+			if inls, ok := el["inlines"].([]interface{}); ok {
+				for _, it := range inls {
+					if inl, ok := it.(map[string]interface{}); ok {
+						if d, ok := findSubmitAction(inl["selectAction"], actionID); ok {
+							return d, true
+						}
+					}
+				}
+			}
+		case "Table":
+			// Table rows→cells：单元格 selectAction + 递归 cell.items（与发送期 Table 校验
+			// 完全一致，派发面 == 校验面）。
+			if rows, ok := el["rows"].([]interface{}); ok {
+				for _, r := range rows {
+					row, ok := r.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					cells, ok := row["cells"].([]interface{})
+					if !ok {
+						continue
+					}
+					for _, c := range cells {
+						cell, ok := c.(map[string]interface{})
+						if !ok {
+							continue
+						}
+						if d, ok := findSubmitAction(cell["selectAction"], actionID); ok {
+							return d, true
+						}
+						if sub, ok := cell["items"].([]interface{}); ok {
+							if d, ok := findSubmitInElements(sub, actionID); ok {
+								return d, true
+							}
 						}
 					}
 				}

--- a/pkg/cardmsg/interactive.go
+++ b/pkg/cardmsg/interactive.go
@@ -133,13 +133,18 @@ func findSubmitInElements(items []interface{}, actionID string) (map[string]inte
 				}
 			}
 		case "Table":
-			// Table rows→cells：单元格 selectAction + 递归 cell.items（与发送期 Table 校验
-			// 完全一致，派发面 == 校验面）。
+			// Table rows→cells：行 selectAction + 单元格 selectAction + 递归 cell.items（与发送
+			// 期 Table 校验完全一致，派发面 == 校验面）。
 			if rows, ok := el["rows"].([]interface{}); ok {
 				for _, r := range rows {
 					row, ok := r.(map[string]interface{})
 					if !ok {
 						continue
+					}
+					// 行级 selectAction 可载 Submit（发送期 w.selectAction(row) 已对齐校验，
+					// PR#556 review P2）。
+					if d, ok := findSubmitAction(row["selectAction"], actionID); ok {
+						return d, true
 					}
 					cells, ok := row["cells"].([]interface{})
 					if !ok {

--- a/pkg/cardmsg/plain.go
+++ b/pkg/cardmsg/plain.go
@@ -113,6 +113,56 @@ func collectPlain(items []interface{}, segs *[]string) {
 			if sub, ok := el["items"].([]interface{}); ok {
 				collectPlain(sub, segs)
 			}
+		case "RichTextBlock":
+			// inlines 是字符串或 TextRun{text}。TextRun 不渲染 markdown（AC 语义），故直接
+			// 拼接文本、不走 stripMarkdown；整块作为一段。
+			if inlines, ok := el["inlines"].([]interface{}); ok {
+				var b strings.Builder
+				for _, it := range inlines {
+					switch inl := it.(type) {
+					case string:
+						b.WriteString(inl)
+					case map[string]interface{}:
+						if s, _ := inl["text"].(string); s != "" {
+							b.WriteString(s)
+						}
+					}
+				}
+				if t := strings.TrimSpace(b.String()); t != "" {
+					*segs = append(*segs, t)
+				}
+			}
+		case "ImageSet":
+			// 每张图一个 [图片] 占位（与单 Image 对等）。
+			if imgs, ok := el["images"].([]interface{}); ok {
+				for range imgs {
+					*segs = append(*segs, PlaceholderImage)
+				}
+			}
+		case "Table":
+			// 递归 rows→cells→items（与 Container/ColumnSet 同款内容遍历）。
+			if rows, ok := el["rows"].([]interface{}); ok {
+				for _, r := range rows {
+					row, ok := r.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					cells, ok := row["cells"].([]interface{})
+					if !ok {
+						continue
+					}
+					for _, c := range cells {
+						cell, ok := c.(map[string]interface{})
+						if !ok {
+							continue
+						}
+						if items, ok := cell["items"].([]interface{}); ok {
+							collectPlain(items, segs)
+						}
+					}
+				}
+			}
+		// ActionSet：动作（按钮）不参与 plain —— 按钮是操作面不是内容，无 case。
 		case "ColumnSet":
 			if cols, ok := el["columns"].([]interface{}); ok {
 				for _, c := range cols {

--- a/pkg/cardmsg/rich_inputs_test.go
+++ b/pkg/cardmsg/rich_inputs_test.go
@@ -1,0 +1,220 @@
+package cardmsg
+
+// card-message-p3-rich-inputs（P3-3）：octo/v2 输入白名单扩容
+// Input.Number/Date/Time（均 AC 1.0，落在固定 card_version="1.5" 内），
+// 发送期继承现有 Input.* 纪律；提交期按「形状可信」信任边界校验值
+// （声明过 + 类型对 + 声明区间内），isRequired/regex 仍不服务端强制。
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// numDateTimeCard 构造仅含单个新输入元素的 octo/v2 卡片。
+func richInputCard(el map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"type": "AdaptiveCard", "version": "1.5",
+		"body": []interface{}{el},
+	}
+}
+
+// TestValidateV2RichInputWhitelist：Number/Date/Time 在 octo/v2 放行、octo/v1 越级拒。
+func TestValidateV2RichInputWhitelist(t *testing.T) {
+	for _, typ := range []string{"Input.Number", "Input.Date", "Input.Time"} {
+		el := map[string]interface{}{"type": typ, "id": "f"}
+		if err := Validate(v2Envelope(richInputCard(el))); err != nil {
+			t.Errorf("octo/v2 应放行 %s, err=%v", typ, err)
+		}
+		if err := Validate(envelope(richInputCard(el))); !errors.Is(err, ErrCardUnknownElement) {
+			t.Errorf("octo/v1 携带 %s 应拒(越级), err=%v", typ, err)
+		}
+	}
+}
+
+// TestValidateV2RichInputIDRequired：新类型缺 id → ErrCardBadShape。
+func TestValidateV2RichInputIDRequired(t *testing.T) {
+	for _, typ := range []string{"Input.Number", "Input.Date", "Input.Time"} {
+		el := map[string]interface{}{"type": typ} // 无 id
+		if err := Validate(v2Envelope(richInputCard(el))); !errors.Is(err, ErrCardBadShape) {
+			t.Errorf("%s 缺 id 应拒, err=%v", typ, err)
+		}
+	}
+}
+
+// TestValidateV2RichInputDuplicateID：新类型 id 帧内重复 → 冲突拒。
+func TestValidateV2RichInputDuplicateID(t *testing.T) {
+	card := map[string]interface{}{
+		"type": "AdaptiveCard", "version": "1.5",
+		"body": []interface{}{
+			map[string]interface{}{"type": "Input.Number", "id": "dup"},
+			map[string]interface{}{"type": "Input.Date", "id": "dup"},
+		},
+	}
+	if err := Validate(v2Envelope(card)); err == nil {
+		t.Error("帧内重复 id 应拒，实际放行")
+	}
+}
+
+// TestValidateV2RichInputLabelURL：新类型 label/errorMessage 的 javascript: markdown 链接 → 拒。
+func TestValidateV2RichInputLabelURL(t *testing.T) {
+	for _, field := range []string{"label", "errorMessage"} {
+		el := map[string]interface{}{
+			"type": "Input.Number", "id": "n",
+			field: "点[这里](javascript:alert(1))",
+		}
+		if err := Validate(v2Envelope(richInputCard(el))); !errors.Is(err, ErrCardBadURLScheme) {
+			t.Errorf("Input.Number.%s 的 javascript: 链接应拒, err=%v", field, err)
+		}
+	}
+}
+
+// TestValidateStyleTolerance：1.5 内 renderer-only 风格属性应被发送期容忍。
+func TestValidateStyleTolerance(t *testing.T) {
+	cases := []map[string]interface{}{
+		{"type": "Input.Text", "id": "p", "style": "password"},
+		{"type": "Input.ChoiceSet", "id": "c1", "style": "filtered",
+			"choices": []interface{}{map[string]interface{}{"title": "A", "value": "a"}}},
+		{"type": "Input.ChoiceSet", "id": "c2", "style": "expanded",
+			"choices": []interface{}{map[string]interface{}{"title": "A", "value": "a"}}},
+	}
+	for _, el := range cases {
+		if err := Validate(v2Envelope(richInputCard(el))); err != nil {
+			t.Errorf("style=%v 应被容忍, err=%v", el["style"], err)
+		}
+	}
+}
+
+// TestValidateInputsNumber：Input.Number 值校验（格式 + min/max + 空放行）。
+func TestValidateInputsNumber(t *testing.T) {
+	env := v2Envelope(richInputCard(map[string]interface{}{
+		"type": "Input.Number", "id": "qty", "min": float64(1), "max": float64(10),
+	}))
+	raw, _ := json.Marshal(env)
+
+	ok := []string{"1", "10", "5", "3.5", ""} // 区间内 + 空(未填)放行
+	for _, v := range ok {
+		if err := ValidateInputs(raw, map[string]interface{}{"qty": v}); err != nil {
+			t.Errorf("Input.Number 合法值 %q 应通过, err=%v", v, err)
+		}
+	}
+	bad := []string{"abc", "0", "11", "1e3"} // 非数字 / 越下界 / 越上界
+	for _, v := range bad {
+		if err := ValidateInputs(raw, map[string]interface{}{"qty": v}); !errors.Is(err, ErrCardInputInvalid) {
+			t.Errorf("Input.Number 非法值 %q 应拒, err=%v", v, err)
+		}
+	}
+}
+
+// TestValidateInputsNumberNoBounds：未声明 min/max 时只校验「是数字」。
+func TestValidateInputsNumberNoBounds(t *testing.T) {
+	env := v2Envelope(richInputCard(map[string]interface{}{"type": "Input.Number", "id": "n"}))
+	raw, _ := json.Marshal(env)
+	if err := ValidateInputs(raw, map[string]interface{}{"n": "999999"}); err != nil {
+		t.Errorf("无界 Input.Number 任意数字应通过, err=%v", err)
+	}
+	if err := ValidateInputs(raw, map[string]interface{}{"n": "-3.14"}); err != nil {
+		t.Errorf("无界 Input.Number 负数应通过, err=%v", err)
+	}
+	if err := ValidateInputs(raw, map[string]interface{}{"n": "x"}); !errors.Is(err, ErrCardInputInvalid) {
+		t.Errorf("Input.Number 非数字应拒, err=%v", err)
+	}
+}
+
+// TestValidateInputsDate：Input.Date 值校验（YYYY-MM-DD + 区间 + 空放行）。
+func TestValidateInputsDate(t *testing.T) {
+	env := v2Envelope(richInputCard(map[string]interface{}{
+		"type": "Input.Date", "id": "day", "min": "2026-01-01", "max": "2026-12-31",
+	}))
+	raw, _ := json.Marshal(env)
+
+	ok := []string{"2026-01-01", "2026-12-31", "2026-07-09", ""}
+	for _, v := range ok {
+		if err := ValidateInputs(raw, map[string]interface{}{"day": v}); err != nil {
+			t.Errorf("Input.Date 合法值 %q 应通过, err=%v", v, err)
+		}
+	}
+	bad := []string{"2026/07/09", "07-09-2026", "2025-12-31", "2027-01-01", "2026-13-01", "notadate"}
+	for _, v := range bad {
+		if err := ValidateInputs(raw, map[string]interface{}{"day": v}); !errors.Is(err, ErrCardInputInvalid) {
+			t.Errorf("Input.Date 非法值 %q 应拒, err=%v", v, err)
+		}
+	}
+}
+
+// TestValidateInputsTime：Input.Time 值校验（HH:MM 24h + 区间 + 空放行）。
+func TestValidateInputsTime(t *testing.T) {
+	env := v2Envelope(richInputCard(map[string]interface{}{
+		"type": "Input.Time", "id": "t", "min": "09:00", "max": "18:00",
+	}))
+	raw, _ := json.Marshal(env)
+
+	ok := []string{"09:00", "18:00", "12:30", ""}
+	for _, v := range ok {
+		if err := ValidateInputs(raw, map[string]interface{}{"t": v}); err != nil {
+			t.Errorf("Input.Time 合法值 %q 应通过, err=%v", v, err)
+		}
+	}
+	bad := []string{"8:00", "08:60", "24:00", "18:01", "08:59", "0900", "notatime"}
+	for _, v := range bad {
+		if err := ValidateInputs(raw, map[string]interface{}{"t": v}); !errors.Is(err, ErrCardInputInvalid) {
+			t.Errorf("Input.Time 非法值 %q 应拒, err=%v", v, err)
+		}
+	}
+}
+
+// TestValidateInputsRichUndeclared：新类型仍受 fail-closed（未声明键拒 / 非字符串拒）。
+func TestValidateInputsRichUndeclared(t *testing.T) {
+	env := v2Envelope(richInputCard(map[string]interface{}{"type": "Input.Number", "id": "n"}))
+	raw, _ := json.Marshal(env)
+	if err := ValidateInputs(raw, map[string]interface{}{"ghost": "1"}); !errors.Is(err, ErrCardInputInvalid) {
+		t.Errorf("未声明键应拒, err=%v", err)
+	}
+	if err := ValidateInputs(raw, map[string]interface{}{"n": 123}); !errors.Is(err, ErrCardInputInvalid) {
+		t.Errorf("非字符串值应拒, err=%v", err)
+	}
+}
+
+// TestValidateInputsNumberRejectsNonFinite：Input.Number 必须拒非有限数。strconv.ParseFloat
+// 接受 "NaN"/"Inf"/"Infinity"（大小写、正负变体）且**不报 error**，其中 NaN 与 min/max 的
+// 所有比较恒 false → 会绕过区间校验。非有限数不是合法数值输入，不得当「形状可信」值透传
+// 给 bot（信任边界）。无界与有界 Number 都必须显式拒。
+func TestValidateInputsNumberRejectsNonFinite(t *testing.T) {
+	nonFinite := []string{"NaN", "nan", "Inf", "inf", "+Inf", "-Inf", "Infinity", "-infinity"}
+	unbounded := v2Envelope(richInputCard(map[string]interface{}{"type": "Input.Number", "id": "n"}))
+	rawU, _ := json.Marshal(unbounded)
+	bounded := v2Envelope(richInputCard(map[string]interface{}{
+		"type": "Input.Number", "id": "n", "min": float64(1), "max": float64(10),
+	}))
+	rawB, _ := json.Marshal(bounded)
+	for _, v := range nonFinite {
+		if err := ValidateInputs(rawU, map[string]interface{}{"n": v}); !errors.Is(err, ErrCardInputInvalid) {
+			t.Errorf("无界 Input.Number 应拒非有限数 %q, err=%v", v, err)
+		}
+		if err := ValidateInputs(rawB, map[string]interface{}{"n": v}); !errors.Is(err, ErrCardInputInvalid) {
+			t.Errorf("有界 Input.Number 应拒非有限数 %q, err=%v", v, err)
+		}
+	}
+}
+
+// TestSubmitActionDispatchRichInputInlineAction：Number/Date/Time 的 inlineAction Submit
+// 发送期校验通过后必须派发期可解析 —— 否则「发送通过、点击 invalid」死按钮。发送期已对全部
+// isInputElement 校验 inlineAction，派发侧必须对齐（校验面 == 派发面，同
+// TestSubmitActionDispatchMatchesValidation，覆盖 P3-3 新增输入类型）。
+func TestSubmitActionDispatchRichInputInlineAction(t *testing.T) {
+	for _, typ := range []string{"Input.Number", "Input.Date", "Input.Time"} {
+		env := v2Envelope(cardWithBody(map[string]interface{}{
+			"type": typ, "id": "f",
+			"inlineAction": map[string]interface{}{
+				"type": "Action.Submit", "id": "go", "data": map[string]interface{}{"k": "v"},
+			},
+		}))
+		if err := Validate(env); err != nil {
+			t.Errorf("%s.inlineAction Submit 发送期应通过, err=%v", typ, err)
+		}
+		raw, _ := json.Marshal(env)
+		if d, found := SubmitAction(raw, "go"); !found || d["k"] != "v" {
+			t.Errorf("%s.inlineAction Submit 应派发可解析, found=%v d=%v", typ, found, d)
+		}
+	}
+}

--- a/pkg/cardmsg/rich_inputs_test.go
+++ b/pkg/cardmsg/rich_inputs_test.go
@@ -2,8 +2,9 @@ package cardmsg
 
 // card-message-p3-rich-inputs（P3-3）：octo/v2 输入白名单扩容
 // Input.Number/Date/Time（均 AC 1.0，落在固定 card_version="1.5" 内），
-// 发送期继承现有 Input.* 纪律；提交期按「形状可信」信任边界校验值
-// （声明过 + 类型对 + 声明区间内），isRequired/regex 仍不服务端强制。
+// 发送期继承现有 Input.* 纪律；提交期按「形状可信」信任边界只校验值的**格式/类型**
+// （声明过 + 类型对），min/max 区间不服务端强制（下放 bot，PR#556）；isRequired/regex
+// 同样不服务端强制。
 
 import (
 	"encoding/json"
@@ -11,7 +12,7 @@ import (
 	"testing"
 )
 
-// numDateTimeCard 构造仅含单个新输入元素的 octo/v2 卡片。
+// richInputCard 构造仅含单个新输入元素的 octo/v2 卡片。
 func richInputCard(el map[string]interface{}) map[string]interface{} {
 	return map[string]interface{}{
 		"type": "AdaptiveCard", "version": "1.5",
@@ -183,12 +184,16 @@ func TestValidateInputsRichUndeclared(t *testing.T) {
 	}
 }
 
-// TestValidateInputsNumberRejectsNonFinite：Input.Number 必须拒非有限数。strconv.ParseFloat
-// 接受 "NaN"/"Inf"/"Infinity"（大小写、正负变体）且**不报 error** —— 非有限数不是合法数值
-// 输入，不得当「形状可信」值透传给 bot（信任边界；这是格式/类型校验，与已下放 bot 的
-// min/max range 无关）。声明与未声明 min/max 的 Number 都必须显式拒。
+// TestValidateInputsNumberRejectsNonFinite：Input.Number 必须拒非有限数——两层防线。
+// (1) 字面 "NaN"/"Inf"/"Infinity"（strconv.ParseFloat 接受且**不报 error**）被严格 JSON 数字
+// 文法门先挡下（非 JSON 数字形态）；(2) 文法合法但数值溢出的 "1e999"→±Inf 由 ParseFloat 的
+// ErrRange + math.IsInf 挡下。非有限数不是合法数值输入，不得当「形状可信」值透传给 bot
+// （信任边界；格式/类型校验，与已下放 bot 的 min/max range 无关）。声明与未声明 min/max 都拒。
 func TestValidateInputsNumberRejectsNonFinite(t *testing.T) {
-	nonFinite := []string{"NaN", "nan", "Inf", "inf", "+Inf", "-Inf", "Infinity", "-infinity"}
+	nonFinite := []string{
+		"NaN", "nan", "Inf", "inf", "+Inf", "-Inf", "Infinity", "-infinity", // 文法门挡下
+		"1e999", "-1e999", "1E1000", // 文法合法但溢出 → 有限检查挡下
+	}
 	unbounded := v2Envelope(richInputCard(map[string]interface{}{"type": "Input.Number", "id": "n"}))
 	rawU, _ := json.Marshal(unbounded)
 	bounded := v2Envelope(richInputCard(map[string]interface{}{
@@ -224,5 +229,68 @@ func TestSubmitActionDispatchRichInputInlineAction(t *testing.T) {
 		if d, found := SubmitAction(raw, "go"); !found || d["k"] != "v" {
 			t.Errorf("%s.inlineAction Submit 应派发可解析, found=%v d=%v", typ, found, d)
 		}
+	}
+}
+
+// TestValidateInputsNumberRejectsParseFloatSuperset：strconv.ParseFloat 的文法是 JSON/JS
+// Number 的**超集**（十六进制浮点 "0x1p4"、前导 "+"、前导零、裸小数点、下划线分隔等它都能
+// 解析成有限数），会放行 bot 端 JSON 解析器拒绝或解读不同的串，造成静默数值错位。严格 JSON
+// 数字文法必须把这些非 JSON 形态一并拒——仅靠 ParseFloat+有限检查会漏（PR#556 review #2）。
+func TestValidateInputsNumberRejectsParseFloatSuperset(t *testing.T) {
+	env := v2Envelope(richInputCard(map[string]interface{}{"type": "Input.Number", "id": "n"}))
+	raw, _ := json.Marshal(env)
+	// ParseFloat 宽容 / 非 JSON 数字文法的形态——全部必须拒。
+	nonJSON := []string{
+		"0x1p4", // 十六进制浮点（ParseFloat=16）
+		"+5",    // 前导 +
+		"05",    // 前导零
+		".5",    // 缺整数部分
+		"5.",    // 缺小数部分
+		"1_000", // 下划线分隔（Go 数字字面量）
+		" 5",    // 前导空白
+		"5 ",    // 尾随空白
+		"1e",    // 残缺指数
+		"٥",     // 非 ASCII 数字（Unicode 数字必须拒，[0-9] 只认 ASCII）
+	}
+	for _, v := range nonJSON {
+		if err := ValidateInputs(raw, map[string]interface{}{"n": v}); !errors.Is(err, ErrCardInputInvalid) {
+			t.Errorf("Input.Number 应拒非 JSON 数字文法 %q, err=%v", v, err)
+		}
+	}
+	// 反向锚点：合法 JSON 数字（含指数、负号、小数、-0）必须仍放行。
+	okJSON := []string{"0", "-0", "42", "-7", "3.14", "1e3", "1E3", "1.5e-3", "-2.5E+2"}
+	for _, v := range okJSON {
+		if err := ValidateInputs(raw, map[string]interface{}{"n": v}); err != nil {
+			t.Errorf("Input.Number 合法 JSON 数字 %q 应放行, err=%v", v, err)
+		}
+	}
+}
+
+// TestValidateInputsRichInputNested：新输入类型声明在嵌套 Container / ColumnSet>Column 内时，
+// 提交期 collectInputSpecs 仍能递归采集到并按类型校验（采集面覆盖新类型，与发送期遍历同口径）。
+func TestValidateInputsRichInputNested(t *testing.T) {
+	card := map[string]interface{}{
+		"type": "AdaptiveCard", "version": "1.5",
+		"body": []interface{}{
+			map[string]interface{}{"type": "Container", "items": []interface{}{
+				map[string]interface{}{"type": "Input.Number", "id": "qty"},
+			}},
+			map[string]interface{}{"type": "ColumnSet", "columns": []interface{}{
+				map[string]interface{}{"type": "Column", "items": []interface{}{
+					map[string]interface{}{"type": "Input.Date", "id": "day"},
+				}},
+			}},
+		},
+	}
+	raw, _ := json.Marshal(v2Envelope(card))
+	if err := ValidateInputs(raw, map[string]interface{}{"qty": "5", "day": "2026-07-09"}); err != nil {
+		t.Errorf("嵌套声明的合法输入应放行, err=%v", err)
+	}
+	// 非法值按类型拒 —— 证明递归确实采集到了 spec 并施加了类型/格式校验（而非未声明放行）。
+	if err := ValidateInputs(raw, map[string]interface{}{"qty": "0x1p4"}); !errors.Is(err, ErrCardInputInvalid) {
+		t.Errorf("嵌套 Input.Number 非法值应拒, err=%v", err)
+	}
+	if err := ValidateInputs(raw, map[string]interface{}{"day": "2026/07/09"}); !errors.Is(err, ErrCardInputInvalid) {
+		t.Errorf("嵌套 Input.Date 非法格式应拒, err=%v", err)
 	}
 }

--- a/pkg/cardmsg/rich_inputs_test.go
+++ b/pkg/cardmsg/rich_inputs_test.go
@@ -85,23 +85,25 @@ func TestValidateStyleTolerance(t *testing.T) {
 	}
 }
 
-// TestValidateInputsNumber：Input.Number 值校验（格式 + min/max + 空放行）。
+// TestValidateInputsNumber：Input.Number 只校验「是合法有限数」——声明了 min/max 也**不**
+// 服务端强制（区间外的合法数字照样放行，range 下放 bot，PR#556）。空串=未填放行。
 func TestValidateInputsNumber(t *testing.T) {
+	// 刻意声明 min/max，用来验证越界值仍放行（服务端不强制区间）。
 	env := v2Envelope(richInputCard(map[string]interface{}{
 		"type": "Input.Number", "id": "qty", "min": float64(1), "max": float64(10),
 	}))
 	raw, _ := json.Marshal(env)
 
-	ok := []string{"1", "10", "5", "3.5", ""} // 区间内 + 空(未填)放行
+	ok := []string{"1", "10", "5", "3.5", "", "0", "11", "1e3", "-7", "999999"} // 含越界值：区间不强制
 	for _, v := range ok {
 		if err := ValidateInputs(raw, map[string]interface{}{"qty": v}); err != nil {
-			t.Errorf("Input.Number 合法值 %q 应通过, err=%v", v, err)
+			t.Errorf("Input.Number 合法有限数 %q 应通过（min/max 不强制）, err=%v", v, err)
 		}
 	}
-	bad := []string{"abc", "0", "11", "1e3"} // 非数字 / 越下界 / 越上界
+	bad := []string{"abc", "1,000", "12/34", "x"} // 只有非数字才拒
 	for _, v := range bad {
 		if err := ValidateInputs(raw, map[string]interface{}{"qty": v}); !errors.Is(err, ErrCardInputInvalid) {
-			t.Errorf("Input.Number 非法值 %q 应拒, err=%v", v, err)
+			t.Errorf("Input.Number 非数字 %q 应拒, err=%v", v, err)
 		}
 	}
 }
@@ -121,44 +123,50 @@ func TestValidateInputsNumberNoBounds(t *testing.T) {
 	}
 }
 
-// TestValidateInputsDate：Input.Date 值校验（YYYY-MM-DD + 区间 + 空放行）。
+// TestValidateInputsDate：Input.Date 只校验 YYYY-MM-DD 格式 + 空放行；声明 min/max 不
+// 服务端强制（区间外的合法日期照样放行，range 下放 bot，PR#556）。
 func TestValidateInputsDate(t *testing.T) {
 	env := v2Envelope(richInputCard(map[string]interface{}{
 		"type": "Input.Date", "id": "day", "min": "2026-01-01", "max": "2026-12-31",
 	}))
 	raw, _ := json.Marshal(env)
 
-	ok := []string{"2026-01-01", "2026-12-31", "2026-07-09", ""}
+	// 合法格式（含声明区间外的 2025-12-31 / 2027-01-01）+ 空 → 放行。
+	ok := []string{"2026-01-01", "2026-12-31", "2026-07-09", "2025-12-31", "2027-01-01", ""}
 	for _, v := range ok {
 		if err := ValidateInputs(raw, map[string]interface{}{"day": v}); err != nil {
-			t.Errorf("Input.Date 合法值 %q 应通过, err=%v", v, err)
+			t.Errorf("Input.Date 合法格式 %q 应通过（区间不强制）, err=%v", v, err)
 		}
 	}
-	bad := []string{"2026/07/09", "07-09-2026", "2025-12-31", "2027-01-01", "2026-13-01", "notadate"}
+	// 非法格式仍拒（错分隔 / 错顺序 / 非法日历日 / 非零填充 / 乱码）。
+	bad := []string{"2026/07/09", "07-09-2026", "2026-13-01", "2026-7-9", "notadate"}
 	for _, v := range bad {
 		if err := ValidateInputs(raw, map[string]interface{}{"day": v}); !errors.Is(err, ErrCardInputInvalid) {
-			t.Errorf("Input.Date 非法值 %q 应拒, err=%v", v, err)
+			t.Errorf("Input.Date 非法格式 %q 应拒, err=%v", v, err)
 		}
 	}
 }
 
-// TestValidateInputsTime：Input.Time 值校验（HH:MM 24h + 区间 + 空放行）。
+// TestValidateInputsTime：Input.Time 只校验 HH:MM(24h) 格式 + 空放行；声明 min/max 不
+// 服务端强制（区间外的合法时间照样放行，range 下放 bot，PR#556）。
 func TestValidateInputsTime(t *testing.T) {
 	env := v2Envelope(richInputCard(map[string]interface{}{
 		"type": "Input.Time", "id": "t", "min": "09:00", "max": "18:00",
 	}))
 	raw, _ := json.Marshal(env)
 
-	ok := []string{"09:00", "18:00", "12:30", ""}
+	// 合法格式（含声明区间外的 08:59 / 18:01）+ 空 → 放行。
+	ok := []string{"09:00", "18:00", "12:30", "08:59", "18:01", "00:00", "23:59", ""}
 	for _, v := range ok {
 		if err := ValidateInputs(raw, map[string]interface{}{"t": v}); err != nil {
-			t.Errorf("Input.Time 合法值 %q 应通过, err=%v", v, err)
+			t.Errorf("Input.Time 合法格式 %q 应通过（区间不强制）, err=%v", v, err)
 		}
 	}
-	bad := []string{"8:00", "08:60", "24:00", "18:01", "08:59", "0900", "notatime"}
+	// 非法格式仍拒。
+	bad := []string{"8:00", "08:60", "24:00", "0900", "notatime"}
 	for _, v := range bad {
 		if err := ValidateInputs(raw, map[string]interface{}{"t": v}); !errors.Is(err, ErrCardInputInvalid) {
-			t.Errorf("Input.Time 非法值 %q 应拒, err=%v", v, err)
+			t.Errorf("Input.Time 非法格式 %q 应拒, err=%v", v, err)
 		}
 	}
 }
@@ -176,9 +184,9 @@ func TestValidateInputsRichUndeclared(t *testing.T) {
 }
 
 // TestValidateInputsNumberRejectsNonFinite：Input.Number 必须拒非有限数。strconv.ParseFloat
-// 接受 "NaN"/"Inf"/"Infinity"（大小写、正负变体）且**不报 error**，其中 NaN 与 min/max 的
-// 所有比较恒 false → 会绕过区间校验。非有限数不是合法数值输入，不得当「形状可信」值透传
-// 给 bot（信任边界）。无界与有界 Number 都必须显式拒。
+// 接受 "NaN"/"Inf"/"Infinity"（大小写、正负变体）且**不报 error** —— 非有限数不是合法数值
+// 输入，不得当「形状可信」值透传给 bot（信任边界；这是格式/类型校验，与已下放 bot 的
+// min/max range 无关）。声明与未声明 min/max 的 Number 都必须显式拒。
 func TestValidateInputsNumberRejectsNonFinite(t *testing.T) {
 	nonFinite := []string{"NaN", "nan", "Inf", "inf", "+Inf", "-Inf", "Infinity", "-infinity"}
 	unbounded := v2Envelope(richInputCard(map[string]interface{}{"type": "Input.Number", "id": "n"}))

--- a/pkg/cardmsg/tier1_elements_test.go
+++ b/pkg/cardmsg/tier1_elements_test.go
@@ -1,0 +1,188 @@
+package cardmsg
+
+// card-message P3-3 Tier 1：AC 1.5 展示元素补全 —— ImageSet(1.0)/RichTextBlock(1.2)/
+// Table(1.5)/ActionSet(1.2)。四者都是展示类（octo/v1+v2 均放行；ActionSet 内的
+// Action.Submit 仍受 octo/v2 门控）。每个元素覆盖四个面：发送期校验、URL allowlist、
+// 派发对称（可载 Submit 处）、plain 派生。
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// ---- 发送期放行（v2 + v1，纯展示两档均可）----
+
+func TestTier1ElementsAccepted(t *testing.T) {
+	cards := map[string]map[string]interface{}{
+		"ImageSet": cardWithBody(map[string]interface{}{
+			"type": "ImageSet", "images": []interface{}{
+				map[string]interface{}{"type": "Image", "url": "https://example.com/a.png"},
+			}}),
+		"RichTextBlock": cardWithBody(map[string]interface{}{
+			"type": "RichTextBlock", "inlines": []interface{}{
+				"plain run ", map[string]interface{}{"type": "TextRun", "text": "styled"},
+			}}),
+		"Table": cardWithBody(map[string]interface{}{
+			"type": "Table", "rows": []interface{}{
+				map[string]interface{}{"type": "TableRow", "cells": []interface{}{
+					map[string]interface{}{"type": "TableCell", "items": []interface{}{
+						map[string]interface{}{"type": "TextBlock", "text": "cell"},
+					}},
+				}},
+			}}),
+		"ActionSet": cardWithBody(map[string]interface{}{
+			"type": "ActionSet", "actions": []interface{}{
+				map[string]interface{}{"type": "Action.OpenUrl", "url": "https://example.com"},
+			}}),
+	}
+	for name, card := range cards {
+		if err := Validate(v2Envelope(card)); err != nil {
+			t.Errorf("octo/v2 应放行 %s, err=%v", name, err)
+		}
+		if err := Validate(envelope(card)); err != nil {
+			t.Errorf("octo/v1 应放行展示元素 %s, err=%v", name, err)
+		}
+	}
+}
+
+// ---- URL allowlist：javascript: 必须被拒（校验面 ≥ 渲染/派发面）----
+
+func TestTier1ElementsURLAllowlist(t *testing.T) {
+	bad := map[string]map[string]interface{}{
+		"ImageSet.image.url": cardWithBody(map[string]interface{}{
+			"type": "ImageSet", "images": []interface{}{
+				map[string]interface{}{"type": "Image", "url": "javascript:alert(1)"},
+			}}),
+		"ImageSet.image.selectAction": cardWithBody(map[string]interface{}{
+			"type": "ImageSet", "images": []interface{}{
+				map[string]interface{}{"type": "Image", "url": "https://example.com/a.png",
+					"selectAction": map[string]interface{}{"type": "Action.OpenUrl", "url": "javascript:x"}},
+			}}),
+		"RichTextBlock.textrun.selectAction": cardWithBody(map[string]interface{}{
+			"type": "RichTextBlock", "inlines": []interface{}{
+				map[string]interface{}{"type": "TextRun", "text": "t",
+					"selectAction": map[string]interface{}{"type": "Action.OpenUrl", "url": "javascript:x"}},
+			}}),
+		"Table.cell.nested.image": cardWithBody(map[string]interface{}{
+			"type": "Table", "rows": []interface{}{
+				map[string]interface{}{"type": "TableRow", "cells": []interface{}{
+					map[string]interface{}{"type": "TableCell", "items": []interface{}{
+						map[string]interface{}{"type": "Image", "url": "javascript:x"},
+					}},
+				}},
+			}}),
+		"Table.cell.selectAction": cardWithBody(map[string]interface{}{
+			"type": "Table", "rows": []interface{}{
+				map[string]interface{}{"type": "TableRow", "cells": []interface{}{
+					map[string]interface{}{"type": "TableCell",
+						"selectAction": map[string]interface{}{"type": "Action.OpenUrl", "url": "javascript:x"},
+						"items":        []interface{}{}},
+				}},
+			}}),
+		"ActionSet.action.openurl": cardWithBody(map[string]interface{}{
+			"type": "ActionSet", "actions": []interface{}{
+				map[string]interface{}{"type": "Action.OpenUrl", "url": "javascript:x"},
+			}}),
+	}
+	for name, card := range bad {
+		if err := Validate(v2Envelope(card)); !errors.Is(err, ErrCardBadURLScheme) {
+			t.Errorf("%s 的 javascript: 应被拒(ErrCardBadURLScheme), err=%v", name, err)
+		}
+	}
+}
+
+// ---- 结构错误 ----
+
+func TestTier1ElementsBadShape(t *testing.T) {
+	bad := map[string]map[string]interface{}{
+		"ImageSet.images 非数组":       cardWithBody(map[string]interface{}{"type": "ImageSet", "images": "x"}),
+		"RichTextBlock.inlines 非数组": cardWithBody(map[string]interface{}{"type": "RichTextBlock", "inlines": "x"}),
+		"Table.rows 非数组":            cardWithBody(map[string]interface{}{"type": "Table", "rows": "x"}),
+		"ActionSet.actions 非数组":     cardWithBody(map[string]interface{}{"type": "ActionSet", "actions": "x"}),
+	}
+	for name, card := range bad {
+		if err := Validate(v2Envelope(card)); !errors.Is(err, ErrCardBadShape) {
+			t.Errorf("%s 应拒(ErrCardBadShape), err=%v", name, err)
+		}
+	}
+}
+
+// ---- 派发对称：Submit 藏在这些位置必须可派发（否则死按钮）----
+
+func TestTier1SubmitDispatchSymmetry(t *testing.T) {
+	sub := func(id string) map[string]interface{} {
+		return map[string]interface{}{"type": "Action.Submit", "id": id, "data": map[string]interface{}{"k": "v"}}
+	}
+	cases := map[string]map[string]interface{}{
+		"ActionSet.actions": cardWithBody(map[string]interface{}{
+			"type": "ActionSet", "actions": []interface{}{sub("go")},
+		}),
+		"ImageSet.image.selectAction": cardWithBody(map[string]interface{}{
+			"type": "ImageSet", "images": []interface{}{
+				map[string]interface{}{"type": "Image", "url": "https://example.com/a.png", "selectAction": sub("go")},
+			}}),
+		"RichTextBlock.textrun.selectAction": cardWithBody(map[string]interface{}{
+			"type": "RichTextBlock", "inlines": []interface{}{
+				map[string]interface{}{"type": "TextRun", "text": "t", "selectAction": sub("go")},
+			}}),
+		"Table.cell.selectAction": cardWithBody(map[string]interface{}{
+			"type": "Table", "rows": []interface{}{
+				map[string]interface{}{"type": "TableRow", "cells": []interface{}{
+					map[string]interface{}{"type": "TableCell", "selectAction": sub("go"), "items": []interface{}{}},
+				}},
+			}}),
+		"Table.cell.nested.selectAction": cardWithBody(map[string]interface{}{
+			"type": "Table", "rows": []interface{}{
+				map[string]interface{}{"type": "TableRow", "cells": []interface{}{
+					map[string]interface{}{"type": "TableCell", "items": []interface{}{
+						map[string]interface{}{"type": "Container", "items": []interface{}{}, "selectAction": sub("go")},
+					}},
+				}},
+			}}),
+	}
+	for name, card := range cases {
+		env := v2Envelope(card)
+		if err := Validate(env); err != nil {
+			t.Errorf("%s 发送期应通过, err=%v", name, err)
+		}
+		raw, _ := json.Marshal(env)
+		if d, found := SubmitAction(raw, "go"); !found || d["k"] != "v" {
+			t.Errorf("%s 的 Submit 应派发可解析, found=%v d=%v", name, found, d)
+		}
+	}
+}
+
+// ---- plain 派生 ----
+
+func TestTier1PlainDerivation(t *testing.T) {
+	card := cardWithBody(
+		map[string]interface{}{"type": "RichTextBlock", "inlines": []interface{}{
+			"Hello ", map[string]interface{}{"type": "TextRun", "text": "world"},
+		}},
+		map[string]interface{}{"type": "ImageSet", "images": []interface{}{
+			map[string]interface{}{"type": "Image", "url": "https://example.com/a.png"},
+		}},
+		map[string]interface{}{"type": "Table", "rows": []interface{}{
+			map[string]interface{}{"type": "TableRow", "cells": []interface{}{
+				map[string]interface{}{"type": "TableCell", "items": []interface{}{
+					map[string]interface{}{"type": "TextBlock", "text": "cellfact"},
+				}},
+			}},
+		}},
+		map[string]interface{}{"type": "ActionSet", "actions": []interface{}{
+			map[string]interface{}{"type": "Action.OpenUrl", "url": "https://example.com", "title": "btn"},
+		}},
+	)
+	plain := BuildPlain(card)
+	for _, want := range []string{"Hello world", PlaceholderImage, "cellfact"} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("plain 应含 %q, got=%q", want, plain)
+		}
+	}
+	// ActionSet 的按钮标题不入 plain（动作是操作面）。
+	if strings.Contains(plain, "btn") {
+		t.Errorf("ActionSet 按钮标题不应入 plain, got=%q", plain)
+	}
+}

--- a/pkg/cardmsg/tier1_elements_test.go
+++ b/pkg/cardmsg/tier1_elements_test.go
@@ -121,6 +121,16 @@ func TestTier1MislabeledChildRejected(t *testing.T) {
 			"type": "RichTextBlock", "inlines": []interface{}{
 				map[string]interface{}{"type": "Container", "items": jsChild()},
 			}}),
+		// typeless 变体（residual，PR#556 review）：无 type 字段的「伪装容器」—— 仅靠 type 门禁
+		// （if type present）挡不住，必须靠 rejectLeafSubtree 兜底（子集合字段即拒）。
+		"ImageSet.child.typeless.items": cardWithBody(map[string]interface{}{
+			"type": "ImageSet", "images": []interface{}{
+				map[string]interface{}{"url": "https://ok.com/a.png", "items": jsChild()},
+			}}),
+		"RichTextBlock.inline.typeless.items": cardWithBody(map[string]interface{}{
+			"type": "RichTextBlock", "inlines": []interface{}{
+				map[string]interface{}{"items": jsChild()},
+			}}),
 	}
 	for name, card := range bad {
 		if err := Validate(v2Envelope(card)); !errors.Is(err, ErrCardUnknownElement) {

--- a/pkg/cardmsg/tier1_elements_test.go
+++ b/pkg/cardmsg/tier1_elements_test.go
@@ -122,7 +122,7 @@ func TestTier1MislabeledChildRejected(t *testing.T) {
 				map[string]interface{}{"type": "Container", "items": jsChild()},
 			}}),
 		// typeless 变体（residual，PR#556 review）：无 type 字段的「伪装容器」—— 仅靠 type 门禁
-		// （if type present）挡不住，必须靠 rejectLeafSubtree 兜底（子集合字段即拒）。
+		// （if type present）挡不住，必须靠 rejectForeignSubtree 兜底（越界子集合字段即拒）。
 		"ImageSet.child.typeless.items": cardWithBody(map[string]interface{}{
 			"type": "ImageSet", "images": []interface{}{
 				map[string]interface{}{"url": "https://ok.com/a.png", "items": jsChild()},
@@ -130,6 +130,36 @@ func TestTier1MislabeledChildRejected(t *testing.T) {
 		"RichTextBlock.inline.typeless.items": cardWithBody(map[string]interface{}{
 			"type": "RichTextBlock", "inlines": []interface{}{
 				map[string]interface{}{"items": jsChild()},
+			}}),
+		// Table 行/单元格：伪类型 + typeless —— Table 是最后一个未钉类型的子集合（PR#556 review P1）。
+		"Table.cell.type=Image": cardWithBody(map[string]interface{}{
+			"type": "Table", "rows": []interface{}{
+				map[string]interface{}{"type": "TableRow", "cells": []interface{}{
+					map[string]interface{}{"type": "Image", "url": "javascript:alert(1)"},
+				}},
+			}}),
+		"Table.row.type=Container": cardWithBody(map[string]interface{}{
+			"type": "Table", "rows": []interface{}{
+				map[string]interface{}{"type": "Container", "items": jsChild()},
+			}}),
+		"Table.row.typeless.items": cardWithBody(map[string]interface{}{
+			"type": "Table", "rows": []interface{}{
+				map[string]interface{}{"items": jsChild()},
+			}}),
+		"Table.cell.typeless.columns": cardWithBody(map[string]interface{}{
+			"type": "Table", "rows": []interface{}{
+				map[string]interface{}{"type": "TableRow", "cells": []interface{}{
+					map[string]interface{}{"columns": jsChild()},
+				}},
+			}}),
+		// Column / Fact：类型合法但夹带越界子集合字段（全 flat-validated 子位置同一纪律）。
+		"Column.foreign.rows": cardWithBody(map[string]interface{}{
+			"type": "ColumnSet", "columns": []interface{}{
+				map[string]interface{}{"type": "Column", "rows": jsChild()},
+			}}),
+		"FactSet.fact.items": cardWithBody(map[string]interface{}{
+			"type": "FactSet", "facts": []interface{}{
+				map[string]interface{}{"title": "t", "value": "v", "items": jsChild()},
 			}}),
 	}
 	for name, card := range bad {
@@ -261,5 +291,38 @@ func TestTier1TableCellInputCollected(t *testing.T) {
 	// 反向：未声明 id 仍 fail-closed 拒（确认没顺手把声明面开太大）。
 	if err := ValidateInputs(raw, map[string]interface{}{"ghost": "x"}); !errors.Is(err, ErrCardInputInvalid) {
 		t.Errorf("未声明 input 仍应拒, err=%v", err)
+	}
+}
+
+// TestTier1DispatchSkipsMislabeledChild：派发面 == 校验面 —— 即便一帧（绕过发送校验）在
+// ImageSet/RichTextBlock/Table 子位置放了伪类型子元素携带 Submit，findSubmitInElements 也按
+// childTypeMatches 跳过、不派发（防「校验拒、派发认」漂移，PR#556 review P2）。
+func TestTier1DispatchSkipsMislabeledChild(t *testing.T) {
+	sub := map[string]interface{}{"type": "Action.Submit", "id": "go", "data": map[string]interface{}{"k": "v"}}
+	frames := map[string]map[string]interface{}{
+		"ImageSet.foreign.child": cardWithBody(map[string]interface{}{
+			"type": "ImageSet", "images": []interface{}{
+				map[string]interface{}{"type": "Container", "selectAction": sub},
+			}}),
+		"RichTextBlock.foreign.inline": cardWithBody(map[string]interface{}{
+			"type": "RichTextBlock", "inlines": []interface{}{
+				map[string]interface{}{"type": "Container", "selectAction": sub},
+			}}),
+		"Table.foreign.row": cardWithBody(map[string]interface{}{
+			"type": "Table", "rows": []interface{}{
+				map[string]interface{}{"type": "Container", "selectAction": sub},
+			}}),
+		"Table.foreign.cell": cardWithBody(map[string]interface{}{
+			"type": "Table", "rows": []interface{}{
+				map[string]interface{}{"type": "TableRow", "cells": []interface{}{
+					map[string]interface{}{"type": "Image", "selectAction": sub},
+				}},
+			}}),
+	}
+	for name, card := range frames {
+		raw, _ := json.Marshal(v2Envelope(card))
+		if d, found := SubmitAction(raw, "go"); found {
+			t.Errorf("%s：伪类型子元素上的 Submit 不应被派发（派发面须 == 校验面）, d=%v", name, d)
+		}
 	}
 }

--- a/pkg/cardmsg/tier1_elements_test.go
+++ b/pkg/cardmsg/tier1_elements_test.go
@@ -186,3 +186,30 @@ func TestTier1PlainDerivation(t *testing.T) {
 		t.Errorf("ActionSet 按钮标题不应入 plain, got=%q", plain)
 	}
 }
+
+// TestTier1TableCellInputCollected：Table cell 内的 Input.* 提交期必须被采集为「已声明」。
+// 发送期（w.elements 递归 cell.items）与派发期（findSubmitInElements 递归 Table）都进 cell，
+// 采集期 collectInputSpecsFromElements 也必须递归 Table cell items —— 否则合法提交会被当
+// 「未声明 input」拒（三个镜像面必须同步，PR#556 review）。
+func TestTier1TableCellInputCollected(t *testing.T) {
+	env := v2Envelope(cardWithBody(map[string]interface{}{
+		"type": "Table", "rows": []interface{}{
+			map[string]interface{}{"type": "TableRow", "cells": []interface{}{
+				map[string]interface{}{"type": "TableCell", "items": []interface{}{
+					map[string]interface{}{"type": "Input.Text", "id": "table_field"},
+				}},
+			}},
+		}}))
+	if err := Validate(env); err != nil {
+		t.Fatalf("Table 内 Input.Text 发送期应通过, err=%v", err)
+	}
+	raw, _ := json.Marshal(env)
+	// 已声明的 table 内 input 提交必须放行（不能被当未声明拒）。
+	if err := ValidateInputs(raw, map[string]interface{}{"table_field": "hi"}); err != nil {
+		t.Errorf("Table cell 内已声明 input 的提交应通过, err=%v", err)
+	}
+	// 反向：未声明 id 仍 fail-closed 拒（确认没顺手把声明面开太大）。
+	if err := ValidateInputs(raw, map[string]interface{}{"ghost": "x"}); !errors.Is(err, ErrCardInputInvalid) {
+		t.Errorf("未声明 input 仍应拒, err=%v", err)
+	}
+}

--- a/pkg/cardmsg/tier1_elements_test.go
+++ b/pkg/cardmsg/tier1_elements_test.go
@@ -81,6 +81,12 @@ func TestTier1ElementsURLAllowlist(t *testing.T) {
 						"items":        []interface{}{}},
 				}},
 			}}),
+		"Table.row.selectAction": cardWithBody(map[string]interface{}{
+			"type": "Table", "rows": []interface{}{
+				map[string]interface{}{"type": "TableRow",
+					"selectAction": map[string]interface{}{"type": "Action.OpenUrl", "url": "javascript:x"},
+					"cells":        []interface{}{}},
+			}}),
 		"ActionSet.action.openurl": cardWithBody(map[string]interface{}{
 			"type": "ActionSet", "actions": []interface{}{
 				map[string]interface{}{"type": "Action.OpenUrl", "url": "javascript:x"},
@@ -89,6 +95,36 @@ func TestTier1ElementsURLAllowlist(t *testing.T) {
 	for name, card := range bad {
 		if err := Validate(v2Envelope(card)); !errors.Is(err, ErrCardBadURLScheme) {
 			t.Errorf("%s 的 javascript: 应被拒(ErrCardBadURLScheme), err=%v", name, err)
+		}
+	}
+}
+
+// TestTier1MislabeledChildRejected：ImageSet.images[] / RichTextBlock.inlines[] 内塞入伪类型
+// 子元素（如 type=Container）必须被拒 —— 否则该子树的 items 永不走查，可夹带 javascript: 链接
+// 绕过发送期 URL allowlist（PR#556 review P1：校验面必须 ≥ 渲染面）。伪类型在类型门即被拒
+// （ErrCardUnknownElement），其内嵌 js 根本到不了。这类是 TestTier1ElementsURLAllowlist（只测
+// 正确类型子元素）漏掉的一面。
+func TestTier1MislabeledChildRejected(t *testing.T) {
+	jsChild := func() []interface{} {
+		return []interface{}{
+			map[string]interface{}{"type": "TextBlock", "text": "[x](javascript:alert(1))"},
+		}
+	}
+	bad := map[string]map[string]interface{}{
+		// url 合法但类型伪装成 Container：旧逻辑当扁平 Image 只校 url、放过 items 里的 js。
+		"ImageSet.child.type=Container": cardWithBody(map[string]interface{}{
+			"type": "ImageSet", "images": []interface{}{
+				map[string]interface{}{"type": "Container", "url": "https://ok.com/a.png", "items": jsChild()},
+			}}),
+		// inline 对象伪装成 Container：旧逻辑只校 selectAction、放过 items 里的 js。
+		"RichTextBlock.inline.type=Container": cardWithBody(map[string]interface{}{
+			"type": "RichTextBlock", "inlines": []interface{}{
+				map[string]interface{}{"type": "Container", "items": jsChild()},
+			}}),
+	}
+	for name, card := range bad {
+		if err := Validate(v2Envelope(card)); !errors.Is(err, ErrCardUnknownElement) {
+			t.Errorf("%s 伪类型子元素应被拒(ErrCardUnknownElement), err=%v", name, err)
 		}
 	}
 }
@@ -126,6 +162,10 @@ func TestTier1SubmitDispatchSymmetry(t *testing.T) {
 		"RichTextBlock.textrun.selectAction": cardWithBody(map[string]interface{}{
 			"type": "RichTextBlock", "inlines": []interface{}{
 				map[string]interface{}{"type": "TextRun", "text": "t", "selectAction": sub("go")},
+			}}),
+		"Table.row.selectAction": cardWithBody(map[string]interface{}{
+			"type": "Table", "rows": []interface{}{
+				map[string]interface{}{"type": "TableRow", "selectAction": sub("go"), "cells": []interface{}{}},
 			}}),
 		"Table.cell.selectAction": cardWithBody(map[string]interface{}{
 			"type": "Table", "rows": []interface{}{

--- a/pkg/cardmsg/validate.go
+++ b/pkg/cardmsg/validate.go
@@ -240,6 +240,11 @@ func (w *walker) element(el map[string]interface{}, depth int) error {
 				if err := w.bump(depth + 1); err != nil {
 					return err
 				}
+				// Fact 是叶子（title/value）—— 不得携带任何子集合字段（PR#556 review：flat-validated 子位置
+				// 同一纪律，堵伪装容器夹带未走查子树）。
+				if err := checkConstrainedChild(fact, "FactSet.facts[]", ""); err != nil {
+					return err
+				}
 				for _, k := range [2]string{"title", "value"} {
 					if v, ok := fact[k]; ok {
 						s, isStr := v.(string)
@@ -294,16 +299,10 @@ func (w *walker) element(el map[string]interface{}, depth int) error {
 					if err := w.bump(depth + 1); err != nil {
 						return err
 					}
-					// AC：inlines[] 的对象必须是**叶子 TextRun**：显式给出 type 时必须是 "TextRun"
-					// （同 column()/imageChild 纪律），且不得携带子集合字段（rejectLeafSubtree）——
-					// 堵住伪类型 / typeless 的「伪装容器」把未校验 URL 面藏在 items 等子树里绕过
-					// （PR#556 review P1 + residual：校验面 ≥ 渲染面）。
-					if t, present := inl["type"]; present {
-						if s, _ := t.(string); s != "TextRun" {
-							return fmt.Errorf("%w: RichTextBlock.inlines[] 内元素类型 %v", ErrCardUnknownElement, t)
-						}
-					}
-					if err := rejectLeafSubtree(inl, "RichTextBlock.inlines[]"); err != nil {
+					// AC：inlines[] 的对象必须是**叶子 TextRun**：type 显式给出时必须是 "TextRun"，且
+					// 不得携带子集合字段 —— 堵住伪类型 / typeless 的「伪装容器」把未校验 URL 面藏在
+					// items 等子树里绕过（PR#556 review P1 + residual：校验面 ≥ 渲染面）。
+					if err := checkConstrainedChild(inl, "RichTextBlock.inlines[]", "TextRun"); err != nil {
 						return err
 					}
 					if err := w.selectAction(inl); err != nil {
@@ -341,6 +340,12 @@ func (w *walker) element(el map[string]interface{}, depth int) error {
 				if err := w.selectAction(row); err != nil {
 					return err
 				}
+				// TableRow 必须是 TableRow 且只带 cells 子集合（同 column()/imageChild 纪律）——堵伪类型
+				//（{"type":"Container","items":[…]}）/ typeless（{"items":[…]}）伪装行把未走查子树藏进
+				// items 等绕过（PR#556 review P1：校验面 ≥ 渲染面）。
+				if err := checkConstrainedChild(row, "Table.rows[]", "TableRow", "cells"); err != nil {
+					return err
+				}
 				cells, present := row["cells"]
 				if !present {
 					continue
@@ -355,6 +360,12 @@ func (w *walker) element(el map[string]interface{}, depth int) error {
 						return fmt.Errorf("%w: TableCell 必须是对象", ErrCardBadShape)
 					}
 					if err := w.bump(depth + 2); err != nil {
+						return err
+					}
+					// TableCell 必须是 TableCell 且只带 items 子集合 —— 堵伪类型单元格
+					//（{"type":"Image","url":"javascript:"} 会被当扁平 cell、其 url 永不走查）及 typeless
+					// 伪装容器（PR#556 review P1：校验面 ≥ 渲染面）。
+					if err := checkConstrainedChild(cell, "Table.rows[].cells[]", "TableCell", "items"); err != nil {
 						return err
 					}
 					if err := checkNodeURLs(cell); err != nil {
@@ -450,41 +461,69 @@ func (w *walker) element(el map[string]interface{}, depth int) error {
 // 常省略 type），故这里补齐顶层 "Image" case 依赖 element() 提供的公共校验：节点预算、
 // backgroundImage 等 URL 面（checkNodeURLs）、selectAction，再加 Image 自身的 url 必填 +
 // 正向 allowlist。
-// leafChildCollectionFields 是承载子元素 / 子集合的字段名。ImageSet.images[] 的 Image、
-// RichTextBlock.inlines[] 的 TextRun 都是**叶子**，绝不该有这些字段 —— 出现即是「伪装成叶子的
-// 容器」在夹带未被走查的子树（PR#556 review P1 + residual：typeless 子元素也走这层兜底）。
-var leafChildCollectionFields = [...]string{
+// childCollectionFields 是 octo 支持的容器/集合类元素的全部「子集合」字段名 —— 承载子元素的
+// 数组字段。任何按位置约束的子节点（column / imageChild / inline / table row·cell / fact）只允许
+// 其类型契约内的那个（或零个）子集合字段，其余一律视为「伪装容器」夹带未走查子树。
+var childCollectionFields = [...]string{
 	"items", "columns", "rows", "cells", "inlines", "actions", "facts", "images",
 }
 
-// rejectLeafSubtree 拒绝一个「应为叶子」的节点携带任何子集合字段 —— 堵住 typeless / 伪类型子
-// 元素把未校验的 URL 面藏在 items 等子树里绕过发送期 allowlist（校验面 ≥ 渲染面）。类型门只挡
-// 「显式伪类型」（type 存在且不符）；**typeless 的伪装容器（无 type + 带 items）靠这层挡** ——
-// imageChild 与 RichTextBlock inline 共用。Image/TextRun 是叶子，本就无这些字段，合规卡不受影响。
-func rejectLeafSubtree(node map[string]interface{}, where string) error {
-	for _, f := range leafChildCollectionFields {
-		if _, present := node[f]; present {
-			return fmt.Errorf("%w: %s 内元素不得携带子集合字段 %q（应为叶子）", ErrCardUnknownElement, where, f)
+// childTypeMatches 报告 node 的显式 type 是否为 expected（type 缺省视为相符 —— AC 允许省略 type，
+// 显式给出则必须相符，同 column() 纪律）。**校验期与派发期共用同一判定**：校验期据此拒（reject
+// foreign child），派发期据此跳过（skip），两面结构上不可能漂移（PR#556 review：shared predicate）。
+func childTypeMatches(node map[string]interface{}, expected string) bool {
+	t, present := node["type"]
+	if !present {
+		return true
+	}
+	s, _ := t.(string)
+	return s == expected
+}
+
+// rejectForeignSubtree 拒绝一个按位置约束的子节点携带其类型契约之外的子集合字段。allowed 是该
+// 节点合法的子集合字段（叶子 Image/TextRun/Fact 传空；TableRow 传 "cells"；TableCell/Column 传
+// "items"）。堵住伪类型 / typeless 的「伪装容器」把未走查的 URL 面藏在越界子树里绕过发送期
+// allowlist —— 校验面 ≥ 渲染面（类型门只挡显式伪类型，此层兜 typeless 及「类型合法但夹带越界
+// 子树」，PR#556 review P1 + residual）。
+func rejectForeignSubtree(node map[string]interface{}, where string, allowed ...string) error {
+	for _, f := range childCollectionFields {
+		if _, present := node[f]; !present {
+			continue
+		}
+		permitted := false
+		for _, a := range allowed {
+			if f == a {
+				permitted = true
+				break
+			}
+		}
+		if !permitted {
+			return fmt.Errorf("%w: %s 携带非法子集合字段 %q（超出其类型契约）", ErrCardUnknownElement, where, f)
 		}
 	}
 	return nil
+}
+
+// checkConstrainedChild 校验一个「按位置约束」的子节点（ColumnSet.columns[] / ImageSet.images[] /
+// RichTextBlock.inlines[] / Table.rows[]·cells[] / FactSet.facts[]）：显式 type 必须是 expectedType
+// （缺省放行；expectedType=="" 表示该位置无类型标签，如 Fact），且除 allowedCollections 外不得携带
+// 任何子集合字段。是「校验面 ≥ 渲染面」在所有 flat-validated 子位置上的统一纪律（PR#556 review）。
+func checkConstrainedChild(node map[string]interface{}, where, expectedType string, allowedCollections ...string) error {
+	if expectedType != "" && !childTypeMatches(node, expectedType) {
+		return fmt.Errorf("%w: %s 内元素类型 %v", ErrCardUnknownElement, where, node["type"])
+	}
+	return rejectForeignSubtree(node, where, allowedCollections...)
 }
 
 func (w *walker) imageChild(img map[string]interface{}, depth int) error {
 	if err := w.bump(depth); err != nil {
 		return err
 	}
-	// AC：ImageSet.images[] 每项必须是**叶子 Image**：显式给出 type 时必须是 "Image"（同
-	// column() 纪律），且不得携带任何子集合字段（rejectLeafSubtree）。否则伪类型
-	// （{"type":"Container",…}）或 typeless（{"url":ok,"items":[…]}）的「伪装容器」会被当扁平
-	// Image 只校 url、其 items 子树永不走查 —— 夹带 javascript: 链接绕过发送期校验（PR#556
-	// review P1 + residual：校验面必须 ≥ 渲染面，同 PR#543 对 backgroundImage/iconUrl 立的铁律）。
-	if t, present := img["type"]; present {
-		if s, _ := t.(string); s != "Image" {
-			return fmt.Errorf("%w: ImageSet.images[] 内元素类型 %v", ErrCardUnknownElement, t)
-		}
-	}
-	if err := rejectLeafSubtree(img, "ImageSet.images[]"); err != nil {
+	// AC：ImageSet.images[] 每项必须是**叶子 Image**：type 显式给出时必须是 "Image"，且不得携带
+	// 任何子集合字段。否则伪类型（{"type":"Container",…}）或 typeless（{"url":ok,"items":[…]}）的
+	// 「伪装容器」会被当扁平 Image 只校 url、其 items 子树永不走查 —— 夹带 javascript: 链接绕过发送
+	// 期校验（PR#556 review P1 + residual：校验面必须 ≥ 渲染面，同 column()/PR#543）。
+	if err := checkConstrainedChild(img, "ImageSet.images[]", "Image"); err != nil {
 		return err
 	}
 	if err := checkNodeURLs(img); err != nil {
@@ -510,10 +549,11 @@ func (w *walker) column(col map[string]interface{}, depth int) error {
 	if err := checkNodeURLs(col); err != nil {
 		return err
 	}
-	if t, present := col["type"]; present {
-		if s, _ := t.(string); s != "Column" {
-			return fmt.Errorf("%w: columns 内元素类型 %v", ErrCardUnknownElement, t)
-		}
+	// Column 必须是 Column 且只带 items 子集合（type 缺省放行 —— AC 允许省略）——堵伪类型/typeless
+	// 伪装列把未走查子树藏进 rows/columns 等越界字段绕过（PR#556 review：全 flat-validated 子位置同一
+	// 纪律，校验面 ≥ 渲染面）。
+	if err := checkConstrainedChild(col, "ColumnSet.columns[]", "Column", "items"); err != nil {
+		return err
 	}
 	if items, present := col["items"]; present {
 		list, ok := items.([]interface{})

--- a/pkg/cardmsg/validate.go
+++ b/pkg/cardmsg/validate.go
@@ -259,10 +259,18 @@ func (w *walker) element(el map[string]interface{}, depth int) error {
 				}
 			}
 		}
-	case "Input.Text", "Input.Toggle", "Input.ChoiceSet":
-		// P2 元素（octo/v2 白名单，sibling brief D1）。octo/v1 一律拒绝：正常情况
-		// octo/v2 信封已被 profile 协商挡在前面，此分支拦截「octo/v1 信封携带
-		// P2 元素」的越级形状。
+	default:
+		// octo/v2 交互输入（Input.*）。白名单单一权威 = inputElements（whitelist.go）——
+		// 校验器不枚举字面量，新增输入元素只改 inputElements 一处，发送期放行 / inputs 采集
+		// / D12 清单三方自动同步（D12.2 反漂移）。非输入类型即未知元素。
+		// 六个输入元素共享发送期纪律：id 必填且帧内唯一、label/errorMessage 的 markdown URL
+		// 面走正向 allowlist、inlineAction 路由。Number/Date/Time 为 P3-3 追加（AC 1.0，落在
+		// 固定 card_version="1.5" 内，白名单增量而非版本升级）。
+		if !isInputElement(t) {
+			return fmt.Errorf("%w: %q", ErrCardUnknownElement, t)
+		}
+		// octo/v1 一律拒绝：正常情况 octo/v2 信封已被 profile 协商挡在前面，此分支拦截
+		// 「octo/v1 信封携带交互元素」的越级形状。
 		if !w.interactive {
 			return fmt.Errorf("%w: %q（octo/v2 起）", ErrCardUnknownElement, t)
 		}
@@ -304,8 +312,6 @@ func (w *walker) element(el map[string]interface{}, depth int) error {
 		if err := w.inlineAction(el); err != nil {
 			return err
 		}
-	default:
-		return fmt.Errorf("%w: %q", ErrCardUnknownElement, t)
 	}
 	return nil
 }

--- a/pkg/cardmsg/validate.go
+++ b/pkg/cardmsg/validate.go
@@ -294,14 +294,17 @@ func (w *walker) element(el map[string]interface{}, depth int) error {
 					if err := w.bump(depth + 1); err != nil {
 						return err
 					}
-					// AC：inlines[] 的对象必须是 TextRun；显式给出 type 时必须是 "TextRun"（同
-					// column()/imageChild 纪律）—— 拒伪类型对象，堵住「非 TextRun 子树夹带未校验
-					// URL 面」的绕过（PR#556 review P1：校验面 ≥ 渲染面）。TextRun 是叶子，类型钉死
-					// 后无嵌套子树需递归。
+					// AC：inlines[] 的对象必须是**叶子 TextRun**：显式给出 type 时必须是 "TextRun"
+					// （同 column()/imageChild 纪律），且不得携带子集合字段（rejectLeafSubtree）——
+					// 堵住伪类型 / typeless 的「伪装容器」把未校验 URL 面藏在 items 等子树里绕过
+					// （PR#556 review P1 + residual：校验面 ≥ 渲染面）。
 					if t, present := inl["type"]; present {
 						if s, _ := t.(string); s != "TextRun" {
 							return fmt.Errorf("%w: RichTextBlock.inlines[] 内元素类型 %v", ErrCardUnknownElement, t)
 						}
+					}
+					if err := rejectLeafSubtree(inl, "RichTextBlock.inlines[]"); err != nil {
+						return err
 					}
 					if err := w.selectAction(inl); err != nil {
 						return err
@@ -447,19 +450,42 @@ func (w *walker) element(el map[string]interface{}, depth int) error {
 // 常省略 type），故这里补齐顶层 "Image" case 依赖 element() 提供的公共校验：节点预算、
 // backgroundImage 等 URL 面（checkNodeURLs）、selectAction，再加 Image 自身的 url 必填 +
 // 正向 allowlist。
+// leafChildCollectionFields 是承载子元素 / 子集合的字段名。ImageSet.images[] 的 Image、
+// RichTextBlock.inlines[] 的 TextRun 都是**叶子**，绝不该有这些字段 —— 出现即是「伪装成叶子的
+// 容器」在夹带未被走查的子树（PR#556 review P1 + residual：typeless 子元素也走这层兜底）。
+var leafChildCollectionFields = [...]string{
+	"items", "columns", "rows", "cells", "inlines", "actions", "facts", "images",
+}
+
+// rejectLeafSubtree 拒绝一个「应为叶子」的节点携带任何子集合字段 —— 堵住 typeless / 伪类型子
+// 元素把未校验的 URL 面藏在 items 等子树里绕过发送期 allowlist（校验面 ≥ 渲染面）。类型门只挡
+// 「显式伪类型」（type 存在且不符）；**typeless 的伪装容器（无 type + 带 items）靠这层挡** ——
+// imageChild 与 RichTextBlock inline 共用。Image/TextRun 是叶子，本就无这些字段，合规卡不受影响。
+func rejectLeafSubtree(node map[string]interface{}, where string) error {
+	for _, f := range leafChildCollectionFields {
+		if _, present := node[f]; present {
+			return fmt.Errorf("%w: %s 内元素不得携带子集合字段 %q（应为叶子）", ErrCardUnknownElement, where, f)
+		}
+	}
+	return nil
+}
+
 func (w *walker) imageChild(img map[string]interface{}, depth int) error {
 	if err := w.bump(depth); err != nil {
 		return err
 	}
-	// AC：ImageSet.images[] 每项必须是 Image；显式给出 type 时必须是 "Image"（同 column()
-	// 对 Column 的纪律）。否则一个 {"type":"Container","url":"http://ok","items":[…]} 会被当
-	// 扁平 Image 只校验 url、其 items 永不走查 —— 夹带 javascript: 链接的子树绕过发送期校验
-	// （PR#556 review P1：校验面必须 ≥ 渲染面，同 PR#543 对 backgroundImage/iconUrl 立的铁律）。
-	// Image 是叶子，类型钉死后无嵌套子树需递归。
+	// AC：ImageSet.images[] 每项必须是**叶子 Image**：显式给出 type 时必须是 "Image"（同
+	// column() 纪律），且不得携带任何子集合字段（rejectLeafSubtree）。否则伪类型
+	// （{"type":"Container",…}）或 typeless（{"url":ok,"items":[…]}）的「伪装容器」会被当扁平
+	// Image 只校 url、其 items 子树永不走查 —— 夹带 javascript: 链接绕过发送期校验（PR#556
+	// review P1 + residual：校验面必须 ≥ 渲染面，同 PR#543 对 backgroundImage/iconUrl 立的铁律）。
 	if t, present := img["type"]; present {
 		if s, _ := t.(string); s != "Image" {
 			return fmt.Errorf("%w: ImageSet.images[] 内元素类型 %v", ErrCardUnknownElement, t)
 		}
+	}
+	if err := rejectLeafSubtree(img, "ImageSet.images[]"); err != nil {
+		return err
 	}
 	if err := checkNodeURLs(img); err != nil {
 		return err

--- a/pkg/cardmsg/validate.go
+++ b/pkg/cardmsg/validate.go
@@ -259,8 +259,118 @@ func (w *walker) element(el map[string]interface{}, depth int) error {
 				}
 			}
 		}
+	case "ImageSet":
+		// AC 1.0：一组 Image。images[] 每项是 Image 对象，逐个走与顶层 "Image" 同款纪律
+		// （url 必填 + 正向 allowlist；backgroundImage/selectAction 等 URL/动作面同校验）。
+		if imgs, present := el["images"]; present {
+			list, ok := imgs.([]interface{})
+			if !ok {
+				return fmt.Errorf("%w: ImageSet.images 必须是数组", ErrCardBadShape)
+			}
+			for _, it := range list {
+				img, ok := it.(map[string]interface{})
+				if !ok {
+					return fmt.Errorf("%w: ImageSet.images 元素必须是对象", ErrCardBadShape)
+				}
+				if err := w.imageChild(img, depth+1); err != nil {
+					return err
+				}
+			}
+		}
+	case "RichTextBlock":
+		// AC 1.2：inlines[] 是字符串或 TextRun 对象。TextRun 不渲染 markdown（AC 语义，
+		// 故 text 无 markdown URL 面），但可携带 selectAction —— 那是动作/URL 面，逐个走
+		// allowlist（校验面 ≥ 派发面；element() 顶部只校验 RichTextBlock 自身的 selectAction）。
+		if inlines, present := el["inlines"]; present {
+			list, ok := inlines.([]interface{})
+			if !ok {
+				return fmt.Errorf("%w: RichTextBlock.inlines 必须是数组", ErrCardBadShape)
+			}
+			for _, it := range list {
+				switch inl := it.(type) {
+				case string:
+					// 纯文本 run，无 URL/动作面。
+				case map[string]interface{}:
+					if err := w.bump(depth + 1); err != nil {
+						return err
+					}
+					if err := w.selectAction(inl); err != nil {
+						return err
+					}
+				default:
+					return fmt.Errorf("%w: RichTextBlock.inlines 元素必须是字符串或对象", ErrCardBadShape)
+				}
+			}
+		}
+	case "Table":
+		// AC 1.5：rows[] → TableRow.cells[] → TableCell.items[]（递归标准元素）。行/单元格
+		// 计入节点预算；行/单元格的 backgroundImage、单元格的 selectAction 都是 URL/动作面。
+		if rows, present := el["rows"]; present {
+			list, ok := rows.([]interface{})
+			if !ok {
+				return fmt.Errorf("%w: Table.rows 必须是数组", ErrCardBadShape)
+			}
+			for _, r := range list {
+				row, ok := r.(map[string]interface{})
+				if !ok {
+					return fmt.Errorf("%w: TableRow 必须是对象", ErrCardBadShape)
+				}
+				if err := w.bump(depth + 1); err != nil {
+					return err
+				}
+				if err := checkNodeURLs(row); err != nil {
+					return err
+				}
+				cells, present := row["cells"]
+				if !present {
+					continue
+				}
+				clist, ok := cells.([]interface{})
+				if !ok {
+					return fmt.Errorf("%w: TableRow.cells 必须是数组", ErrCardBadShape)
+				}
+				for _, c := range clist {
+					cell, ok := c.(map[string]interface{})
+					if !ok {
+						return fmt.Errorf("%w: TableCell 必须是对象", ErrCardBadShape)
+					}
+					if err := w.bump(depth + 2); err != nil {
+						return err
+					}
+					if err := checkNodeURLs(cell); err != nil {
+						return err
+					}
+					if err := w.selectAction(cell); err != nil {
+						return err
+					}
+					if items, present := cell["items"]; present {
+						ilist, ok := items.([]interface{})
+						if !ok {
+							return fmt.Errorf("%w: TableCell.items 必须是数组", ErrCardBadShape)
+						}
+						if err := w.elements(ilist, depth+3); err != nil {
+							return err
+						}
+					}
+				}
+			}
+		}
+	case "ActionSet":
+		// AC 1.2：body 内的动作组。actions[] 每项走同一动作 allowlist（Action.OpenUrl；
+		// Action.Submit 仍受 octo/v2 门控）。Submit 由此可出现在 body（非仅 card.actions /
+		// selectAction），派发侧 findSubmitInElements 已对齐遍历 ActionSet.actions。
+		if acts, present := el["actions"]; present {
+			list, ok := acts.([]interface{})
+			if !ok {
+				return fmt.Errorf("%w: ActionSet.actions 必须是数组", ErrCardBadShape)
+			}
+			for _, a := range list {
+				if err := w.action(a); err != nil {
+					return err
+				}
+			}
+		}
 	default:
-		// octo/v2 交互输入（Input.*）。白名单单一权威 = inputElements（whitelist.go）——
 		// 校验器不枚举字面量，新增输入元素只改 inputElements 一处，发送期放行 / inputs 采集
 		// / D12 清单三方自动同步（D12.2 反漂移）。非输入类型即未知元素。
 		// 六个输入元素共享发送期纪律：id 必填且帧内唯一、label/errorMessage 的 markdown URL
@@ -314,6 +424,27 @@ func (w *walker) element(el map[string]interface{}, depth int) error {
 		}
 	}
 	return nil
+}
+
+// imageChild 校验 ImageSet 内的单个 Image。ImageSet.images 不经 element() 分派（其项
+// 常省略 type），故这里补齐顶层 "Image" case 依赖 element() 提供的公共校验：节点预算、
+// backgroundImage 等 URL 面（checkNodeURLs）、selectAction，再加 Image 自身的 url 必填 +
+// 正向 allowlist。
+func (w *walker) imageChild(img map[string]interface{}, depth int) error {
+	if err := w.bump(depth); err != nil {
+		return err
+	}
+	if err := checkNodeURLs(img); err != nil {
+		return err
+	}
+	if err := w.selectAction(img); err != nil {
+		return err
+	}
+	u, _ := img["url"].(string)
+	if u == "" {
+		return fmt.Errorf("%w: ImageSet.images[].url 必填", ErrCardBadShape)
+	}
+	return checkURL(u)
 }
 
 // column 校验 ColumnSet 中的单列。AC 允许 Column 省略 type 字段；显式给出时必须

--- a/pkg/cardmsg/validate.go
+++ b/pkg/cardmsg/validate.go
@@ -294,6 +294,15 @@ func (w *walker) element(el map[string]interface{}, depth int) error {
 					if err := w.bump(depth + 1); err != nil {
 						return err
 					}
+					// AC：inlines[] 的对象必须是 TextRun；显式给出 type 时必须是 "TextRun"（同
+					// column()/imageChild 纪律）—— 拒伪类型对象，堵住「非 TextRun 子树夹带未校验
+					// URL 面」的绕过（PR#556 review P1：校验面 ≥ 渲染面）。TextRun 是叶子，类型钉死
+					// 后无嵌套子树需递归。
+					if t, present := inl["type"]; present {
+						if s, _ := t.(string); s != "TextRun" {
+							return fmt.Errorf("%w: RichTextBlock.inlines[] 内元素类型 %v", ErrCardUnknownElement, t)
+						}
+					}
 					if err := w.selectAction(inl); err != nil {
 						return err
 					}
@@ -319,6 +328,14 @@ func (w *walker) element(el map[string]interface{}, depth int) error {
 					return err
 				}
 				if err := checkNodeURLs(row); err != nil {
+					return err
+				}
+				// TableRow.selectAction 与其它一切节点的 selectAction 同权威过 allowlist
+				// （element() 顶部对每个 body 元素、column()/cell 都无条件校验 selectAction；row
+				// 原先漏了这一层 —— 补齐使「每个节点的 selectAction 都被校验」不留缺口，OpenUrl 的
+				// javascript: 面在 row 上也被拒；派发侧 findSubmitInElements 对齐读 row.selectAction，
+				// PR#556 review P2）。
+				if err := w.selectAction(row); err != nil {
 					return err
 				}
 				cells, present := row["cells"]
@@ -433,6 +450,16 @@ func (w *walker) element(el map[string]interface{}, depth int) error {
 func (w *walker) imageChild(img map[string]interface{}, depth int) error {
 	if err := w.bump(depth); err != nil {
 		return err
+	}
+	// AC：ImageSet.images[] 每项必须是 Image；显式给出 type 时必须是 "Image"（同 column()
+	// 对 Column 的纪律）。否则一个 {"type":"Container","url":"http://ok","items":[…]} 会被当
+	// 扁平 Image 只校验 url、其 items 永不走查 —— 夹带 javascript: 链接的子树绕过发送期校验
+	// （PR#556 review P1：校验面必须 ≥ 渲染面，同 PR#543 对 backgroundImage/iconUrl 立的铁律）。
+	// Image 是叶子，类型钉死后无嵌套子树需递归。
+	if t, present := img["type"]; present {
+		if s, _ := t.(string); s != "Image" {
+			return fmt.Errorf("%w: ImageSet.images[] 内元素类型 %v", ErrCardUnknownElement, t)
+		}
 	}
 	if err := checkNodeURLs(img); err != nil {
 		return err

--- a/pkg/cardmsg/whitelist.go
+++ b/pkg/cardmsg/whitelist.go
@@ -19,7 +19,9 @@ package cardmsg
 // 二者都是 additive-only（同 event_data / D12 wire 演进规则）：只增不改名/删除。
 
 var displayElements = []string{
-	"TextBlock", "Image", "Container", "ColumnSet", "Column", "FactSet",
+	"TextBlock", "RichTextBlock", "Image", "ImageSet",
+	"Container", "ColumnSet", "Column", "FactSet",
+	"Table", "ActionSet",
 }
 
 var inputElements = []string{

--- a/pkg/cardmsg/whitelist.go
+++ b/pkg/cardmsg/whitelist.go
@@ -1,12 +1,20 @@
 package cardmsg
 
-// 卡片元素白名单的**单一权威**（card-message-interaction D12.2 / P3-3）。
+// 卡片元素白名单（card-message-interaction D12.2 / P3-3）。二者对外都是 D12 能力清单
+// （GET /v1/bot/card/profile 下发 elements/inputs）的来源，绝不在各处重抄字面量；但它们
+// 与校验器的绑定强度**不同**，注意区分（PR#556 review：勿把 displayElements 也说成三方
+// 结构性单一权威）：
 //
-// displayElements（octo/v1 展示元素，两档共用）与 inputElements（octo/v2 交互输入，
-// octo/v1 携带越级拒）是校验器（validate.go）、inputs 采集（inputs.go 的 isInputElement）、
-// D12 能力清单（GET /v1/bot/card/profile 下发 elements/inputs）三处的共同来源 —— 绝不在
-// 各处重抄字面量，否则白名单变更时对外清单会与校验器静默漂移（清单漂移 = 对 producer /
-// J3 gate 谎报能力）。新增元素只在此追加一处，三方自动同步。
+//   - inputElements（octo/v2 交互输入，octo/v1 携带越级拒）是**真正的三方结构性单一权威**：
+//     校验器（validate.go element() 的 default 分支经 isInputElement）、inputs 采集
+//     （inputs.go collectInputSpecs 经 isInputElement）、D12 清单 inputs 都从它派生 —— 新增
+//     输入元素只改这一处，三方自动同步、不可能漂移。
+//   - displayElements（octo/v1 展示元素，两档共用）只是 **D12 清单 elements 的来源**。校验器
+//     对展示元素是**逐类型手写 case**（TextBlock 查 markdown、Image 查 url、Container 递归
+//     items、ColumnSet 递归 columns、FactSet 查 facts —— 各自校验体不同，无法像输入那样并成
+//     一个 isInputElement 分支）。因此 displayElements 与校验器接受集的一致性**不是结构性
+//     保证，而是由 TestDisplayElementsAuthority 逐个 Validate 守卫**：往这里加展示元素必须
+//     同时给校验器加 case 并让该测试通过，否则清单会广播一个校验器拒绝的元素（漂移 = 谎报能力）。
 //
 // 二者都是 additive-only（同 event_data / D12 wire 演进规则）：只增不改名/删除。
 

--- a/pkg/cardmsg/whitelist.go
+++ b/pkg/cardmsg/whitelist.go
@@ -9,18 +9,21 @@ package cardmsg
 //     校验器（validate.go element() 的 default 分支经 isInputElement）、inputs 采集
 //     （inputs.go collectInputSpecs 经 isInputElement）、D12 清单 inputs 都从它派生 —— 新增
 //     输入元素只改这一处，三方自动同步、不可能漂移。
-//   - displayElements（octo/v1 展示元素，两档共用）只是 **D12 清单 elements 的来源**。校验器
-//     对展示元素是**逐类型手写 case**（TextBlock 查 markdown、Image 查 url、Container 递归
-//     items、ColumnSet 递归 columns、FactSet 查 facts —— 各自校验体不同，无法像输入那样并成
-//     一个 isInputElement 分支）。因此 displayElements 与校验器接受集的一致性**不是结构性
-//     保证，而是由 TestDisplayElementsAuthority 逐个 Validate 守卫**：往这里加展示元素必须
-//     同时给校验器加 case 并让该测试通过，否则清单会广播一个校验器拒绝的元素（漂移 = 谎报能力）。
+//   - displayElements（octo/v1 展示元素，两档共用）只是 **D12 清单 elements 的来源**，且只列
+//     **顶层可放置**的展示元素。校验器对展示元素是**逐类型手写 case**（TextBlock 查 markdown、
+//     Image 查 url、Container 递归 items、ColumnSet 递归 columns、FactSet 查 facts —— 各自校验体
+//     不同，无法像输入那样并成一个 isInputElement 分支）。因此 displayElements 与校验器接受集的
+//     一致性**不是结构性保证，而是由 TestDisplayElementsAuthority 逐个按顶层 body 元素 Validate
+//     守卫**：往这里加展示元素必须同时给校验器加顶层 case 并让该测试通过，否则清单会广播一个
+//     校验器拒绝的元素（漂移 = 谎报能力）。Column 刻意**不**在其中——它非独立元素、只作 ColumnSet
+//     的子列（element() 无顶层 Column case，顶层 Column 会被拒），由 ColumnSet 结构性涵盖
+//     （PR#556 review）。
 //
 // 二者都是 additive-only（同 event_data / D12 wire 演进规则）：只增不改名/删除。
 
 var displayElements = []string{
 	"TextBlock", "RichTextBlock", "Image", "ImageSet",
-	"Container", "ColumnSet", "Column", "FactSet",
+	"Container", "ColumnSet", "FactSet",
 	"Table", "ActionSet",
 }
 

--- a/pkg/cardmsg/whitelist.go
+++ b/pkg/cardmsg/whitelist.go
@@ -1,0 +1,39 @@
+package cardmsg
+
+// 卡片元素白名单的**单一权威**（card-message-interaction D12.2 / P3-3）。
+//
+// displayElements（octo/v1 展示元素，两档共用）与 inputElements（octo/v2 交互输入，
+// octo/v1 携带越级拒）是校验器（validate.go）、inputs 采集（inputs.go 的 isInputElement）、
+// D12 能力清单（GET /v1/bot/card/profile 下发 elements/inputs）三处的共同来源 —— 绝不在
+// 各处重抄字面量，否则白名单变更时对外清单会与校验器静默漂移（清单漂移 = 对 producer /
+// J3 gate 谎报能力）。新增元素只在此追加一处，三方自动同步。
+//
+// 二者都是 additive-only（同 event_data / D12 wire 演进规则）：只增不改名/删除。
+
+var displayElements = []string{
+	"TextBlock", "Image", "Container", "ColumnSet", "Column", "FactSet",
+}
+
+var inputElements = []string{
+	"Input.Text", "Input.Toggle", "Input.ChoiceSet",
+	"Input.Number", "Input.Date", "Input.Time",
+}
+
+// DisplayElements 返回 octo/v1 展示元素白名单副本（D12 清单据此下发 elements；单一权威，
+// 调用方 MUST 用它而非重抄字面量）。每次返回新切片，调用方改不到内部状态。
+func DisplayElements() []string { return append([]string(nil), displayElements...) }
+
+// InputElements 返回 octo/v2 交互输入白名单副本（D12 清单据此下发 inputs；同上纪律）。
+func InputElements() []string { return append([]string(nil), inputElements...) }
+
+// isInputElement 报告 t 是否为 octo/v2 交互输入元素（成员属于 inputElements）。校验器
+// （validate.go element 派发）与 inputs 采集（collectInputSpecsFromElements）共用它，确保
+// 「发送期放行集」「提交期声明采集集」「D12 清单 inputs」恒等。
+func isInputElement(t string) bool {
+	for _, e := range inputElements {
+		if t == e {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cardmsg/whitelist_test.go
+++ b/pkg/cardmsg/whitelist_test.go
@@ -49,26 +49,39 @@ func TestInputElementsAuthority(t *testing.T) {
 	}
 }
 
-// TestDisplayElementsAuthority：DisplayElements() 与文档 §2 展示元素集一致，且每个成员
-// 放在合法位置都不被校验器判为未知元素；非成员被拒。
+// TestDisplayElementsAuthority：DisplayElements() 与文档 §2 展示元素集一致，且**逐个从
+// 列表派生**校验（PR#556 review）——不像 inputElements 那样有结构性单一权威（校验器对展示
+// 元素是逐类型手写 case），displayElements↔校验器一致性只能靠这个测试守卫。故遍历
+// DisplayElements()，每个元素放在合法位置跑 Validate；缺 fixture 即 fail —— 逼「新增展示
+// 元素」必须同时给校验器加 case 并补 fixture 证明它真被接受，而非只往清单加一行（否则 D12
+// 清单会广播一个校验器拒绝的元素 = 谎报能力）。
 func TestDisplayElementsAuthority(t *testing.T) {
 	want := []string{"TextBlock", "Image", "Container", "ColumnSet", "Column", "FactSet"}
 	got := DisplayElements()
 	if !equalStrs(got, want) {
 		t.Fatalf("DisplayElements()=%v, want %v", got, want)
 	}
-	// 所有展示元素放在合法位置（Column 只存在于 ColumnSet 内）应整卡通过。
-	card := cardWithBody(
-		map[string]interface{}{"type": "TextBlock", "text": "x"},
-		map[string]interface{}{"type": "Image", "url": "https://example.com/i.png"},
-		map[string]interface{}{"type": "Container", "items": []interface{}{}},
-		map[string]interface{}{"type": "ColumnSet", "columns": []interface{}{
+	// 每个展示元素 → 一份放在合法位置的最小卡片（Column 只能在 ColumnSet 内，故包一层）。
+	fixtures := map[string]map[string]interface{}{
+		"TextBlock": cardWithBody(map[string]interface{}{"type": "TextBlock", "text": "x"}),
+		"Image":     cardWithBody(map[string]interface{}{"type": "Image", "url": "https://example.com/i.png"}),
+		"Container": cardWithBody(map[string]interface{}{"type": "Container", "items": []interface{}{}}),
+		"ColumnSet": cardWithBody(map[string]interface{}{"type": "ColumnSet", "columns": []interface{}{}}),
+		"Column": cardWithBody(map[string]interface{}{"type": "ColumnSet", "columns": []interface{}{
 			map[string]interface{}{"type": "Column", "items": []interface{}{}},
-		}},
-		map[string]interface{}{"type": "FactSet", "facts": []interface{}{}},
-	)
-	if err := Validate(v2Envelope(card)); err != nil {
-		t.Errorf("全部展示元素应通过校验, err=%v", err)
+		}}),
+		"FactSet": cardWithBody(map[string]interface{}{"type": "FactSet", "facts": []interface{}{}}),
+	}
+	for _, typ := range got {
+		card, ok := fixtures[typ]
+		if !ok {
+			t.Errorf("展示元素 %s 缺校验 fixture —— 新增展示元素必须补 fixture 证明校验器接受它"+
+				"（否则 displayElements↔校验器漂移、D12 清单谎报能力）", typ)
+			continue
+		}
+		if err := Validate(v2Envelope(card)); err != nil {
+			t.Errorf("展示元素 %s 应通过校验, err=%v", typ, err)
+		}
 	}
 	// 非白名单元素被拒。
 	if err := Validate(v2Envelope(cardWithBody(map[string]interface{}{"type": "Bogus"}))); !errors.Is(err, ErrCardUnknownElement) {

--- a/pkg/cardmsg/whitelist_test.go
+++ b/pkg/cardmsg/whitelist_test.go
@@ -1,0 +1,77 @@
+package cardmsg
+
+// card-message-p3-rich-inputs（P3-3）：卡片元素白名单「单一权威」守卫。
+// DisplayElements()/InputElements() 是校验器（validate.go）、inputs 采集（inputs.go）、
+// D12 能力清单（GET /v1/bot/card/profile）三处共用的权威列表 —— 这些测试锁死列表成员
+// 与校验器实际接受集不漂移（清单据此下发，漂移=对外谎报能力）。
+
+import (
+	"errors"
+	"testing"
+)
+
+func equalStrs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestInputElementsAuthority：InputElements() 与文档/校验器一致 —— 每个成员 octo/v2
+// 放行、octo/v1 越级拒；非成员 Input.*（Input.Rating）即便 octo/v2 也拒。
+func TestInputElementsAuthority(t *testing.T) {
+	want := []string{
+		"Input.Text", "Input.Toggle", "Input.ChoiceSet",
+		"Input.Number", "Input.Date", "Input.Time",
+	}
+	got := InputElements()
+	if !equalStrs(got, want) {
+		t.Fatalf("InputElements()=%v, want %v", got, want)
+	}
+	for _, typ := range got {
+		el := map[string]interface{}{"type": typ, "id": "f"}
+		if err := Validate(v2Envelope(richInputCard(el))); err != nil {
+			t.Errorf("octo/v2 应放行权威成员 %s, err=%v", typ, err)
+		}
+		if err := Validate(envelope(richInputCard(el))); !errors.Is(err, ErrCardUnknownElement) {
+			t.Errorf("octo/v1 应越级拒 %s, err=%v", typ, err)
+		}
+	}
+	// 非白名单 Input.*：校验器必须拒（列表是唯一放行来源）。
+	bogus := map[string]interface{}{"type": "Input.Rating", "id": "r"}
+	if err := Validate(v2Envelope(richInputCard(bogus))); !errors.Is(err, ErrCardUnknownElement) {
+		t.Errorf("非白名单 Input.Rating 应拒, err=%v", err)
+	}
+}
+
+// TestDisplayElementsAuthority：DisplayElements() 与文档 §2 展示元素集一致，且每个成员
+// 放在合法位置都不被校验器判为未知元素；非成员被拒。
+func TestDisplayElementsAuthority(t *testing.T) {
+	want := []string{"TextBlock", "Image", "Container", "ColumnSet", "Column", "FactSet"}
+	got := DisplayElements()
+	if !equalStrs(got, want) {
+		t.Fatalf("DisplayElements()=%v, want %v", got, want)
+	}
+	// 所有展示元素放在合法位置（Column 只存在于 ColumnSet 内）应整卡通过。
+	card := cardWithBody(
+		map[string]interface{}{"type": "TextBlock", "text": "x"},
+		map[string]interface{}{"type": "Image", "url": "https://example.com/i.png"},
+		map[string]interface{}{"type": "Container", "items": []interface{}{}},
+		map[string]interface{}{"type": "ColumnSet", "columns": []interface{}{
+			map[string]interface{}{"type": "Column", "items": []interface{}{}},
+		}},
+		map[string]interface{}{"type": "FactSet", "facts": []interface{}{}},
+	)
+	if err := Validate(v2Envelope(card)); err != nil {
+		t.Errorf("全部展示元素应通过校验, err=%v", err)
+	}
+	// 非白名单元素被拒。
+	if err := Validate(v2Envelope(cardWithBody(map[string]interface{}{"type": "Bogus"}))); !errors.Is(err, ErrCardUnknownElement) {
+		t.Errorf("非白名单元素 Bogus 应拒, err=%v", err)
+	}
+}

--- a/pkg/cardmsg/whitelist_test.go
+++ b/pkg/cardmsg/whitelist_test.go
@@ -7,20 +7,9 @@ package cardmsg
 
 import (
 	"errors"
+	"slices"
 	"testing"
 )
-
-func equalStrs(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
 
 // TestInputElementsAuthority：InputElements() 与文档/校验器一致 —— 每个成员 octo/v2
 // 放行、octo/v1 越级拒；非成员 Input.*（Input.Rating）即便 octo/v2 也拒。
@@ -30,7 +19,7 @@ func TestInputElementsAuthority(t *testing.T) {
 		"Input.Number", "Input.Date", "Input.Time",
 	}
 	got := InputElements()
-	if !equalStrs(got, want) {
+	if !slices.Equal(got, want) {
 		t.Fatalf("InputElements()=%v, want %v", got, want)
 	}
 	for _, typ := range got {
@@ -52,20 +41,23 @@ func TestInputElementsAuthority(t *testing.T) {
 // TestDisplayElementsAuthority：DisplayElements() 与文档 §2 展示元素集一致，且**逐个从
 // 列表派生**校验（PR#556 review）——不像 inputElements 那样有结构性单一权威（校验器对展示
 // 元素是逐类型手写 case），displayElements↔校验器一致性只能靠这个测试守卫。故遍历
-// DisplayElements()，每个元素放在合法位置跑 Validate；缺 fixture 即 fail —— 逼「新增展示
-// 元素」必须同时给校验器加 case 并补 fixture 证明它真被接受，而非只往清单加一行（否则 D12
+// DisplayElements()，每个元素放在 body **顶层**跑 Validate；缺 fixture 即 fail —— 逼「新增展示
+// 元素」必须同时给校验器加顶层 case 并补 fixture 证明它真被接受，而非只往清单加一行（否则 D12
 // 清单会广播一个校验器拒绝的元素 = 谎报能力）。
 func TestDisplayElementsAuthority(t *testing.T) {
 	want := []string{
 		"TextBlock", "RichTextBlock", "Image", "ImageSet",
-		"Container", "ColumnSet", "Column", "FactSet",
+		"Container", "ColumnSet", "FactSet",
 		"Table", "ActionSet",
 	}
 	got := DisplayElements()
-	if !equalStrs(got, want) {
+	if !slices.Equal(got, want) {
 		t.Fatalf("DisplayElements()=%v, want %v", got, want)
 	}
-	// 每个展示元素 → 一份放在合法位置的最小卡片（Column 只能在 ColumnSet 内，故包一层）。
+	// 每个展示元素 → 一份把它放在 body **顶层**的最小卡片（诚实校验：清单广告的是顶层可放置
+	// 元素，故 fixture 必须按顶层位置校验、不得包裹遮盖。Column 已不在清单——它只作 ColumnSet
+	// 子列、无顶层 case，顶层 Column 会被校验器拒；若误加回 displayElements，这里缺顶层 fixture
+	// 即 fail，挡住谎报）。
 	fixtures := map[string]map[string]interface{}{
 		"TextBlock":     cardWithBody(map[string]interface{}{"type": "TextBlock", "text": "x"}),
 		"RichTextBlock": cardWithBody(map[string]interface{}{"type": "RichTextBlock", "inlines": []interface{}{"x"}}),
@@ -75,10 +67,7 @@ func TestDisplayElementsAuthority(t *testing.T) {
 		}}),
 		"Container": cardWithBody(map[string]interface{}{"type": "Container", "items": []interface{}{}}),
 		"ColumnSet": cardWithBody(map[string]interface{}{"type": "ColumnSet", "columns": []interface{}{}}),
-		"Column": cardWithBody(map[string]interface{}{"type": "ColumnSet", "columns": []interface{}{
-			map[string]interface{}{"type": "Column", "items": []interface{}{}},
-		}}),
-		"FactSet": cardWithBody(map[string]interface{}{"type": "FactSet", "facts": []interface{}{}}),
+		"FactSet":   cardWithBody(map[string]interface{}{"type": "FactSet", "facts": []interface{}{}}),
 		"Table": cardWithBody(map[string]interface{}{"type": "Table", "rows": []interface{}{
 			map[string]interface{}{"type": "TableRow", "cells": []interface{}{
 				map[string]interface{}{"type": "TableCell", "items": []interface{}{}},

--- a/pkg/cardmsg/whitelist_test.go
+++ b/pkg/cardmsg/whitelist_test.go
@@ -56,21 +56,37 @@ func TestInputElementsAuthority(t *testing.T) {
 // 元素」必须同时给校验器加 case 并补 fixture 证明它真被接受，而非只往清单加一行（否则 D12
 // 清单会广播一个校验器拒绝的元素 = 谎报能力）。
 func TestDisplayElementsAuthority(t *testing.T) {
-	want := []string{"TextBlock", "Image", "Container", "ColumnSet", "Column", "FactSet"}
+	want := []string{
+		"TextBlock", "RichTextBlock", "Image", "ImageSet",
+		"Container", "ColumnSet", "Column", "FactSet",
+		"Table", "ActionSet",
+	}
 	got := DisplayElements()
 	if !equalStrs(got, want) {
 		t.Fatalf("DisplayElements()=%v, want %v", got, want)
 	}
 	// 每个展示元素 → 一份放在合法位置的最小卡片（Column 只能在 ColumnSet 内，故包一层）。
 	fixtures := map[string]map[string]interface{}{
-		"TextBlock": cardWithBody(map[string]interface{}{"type": "TextBlock", "text": "x"}),
-		"Image":     cardWithBody(map[string]interface{}{"type": "Image", "url": "https://example.com/i.png"}),
+		"TextBlock":     cardWithBody(map[string]interface{}{"type": "TextBlock", "text": "x"}),
+		"RichTextBlock": cardWithBody(map[string]interface{}{"type": "RichTextBlock", "inlines": []interface{}{"x"}}),
+		"Image":         cardWithBody(map[string]interface{}{"type": "Image", "url": "https://example.com/i.png"}),
+		"ImageSet": cardWithBody(map[string]interface{}{"type": "ImageSet", "images": []interface{}{
+			map[string]interface{}{"type": "Image", "url": "https://example.com/i.png"},
+		}}),
 		"Container": cardWithBody(map[string]interface{}{"type": "Container", "items": []interface{}{}}),
 		"ColumnSet": cardWithBody(map[string]interface{}{"type": "ColumnSet", "columns": []interface{}{}}),
 		"Column": cardWithBody(map[string]interface{}{"type": "ColumnSet", "columns": []interface{}{
 			map[string]interface{}{"type": "Column", "items": []interface{}{}},
 		}}),
 		"FactSet": cardWithBody(map[string]interface{}{"type": "FactSet", "facts": []interface{}{}}),
+		"Table": cardWithBody(map[string]interface{}{"type": "Table", "rows": []interface{}{
+			map[string]interface{}{"type": "TableRow", "cells": []interface{}{
+				map[string]interface{}{"type": "TableCell", "items": []interface{}{}},
+			}},
+		}}),
+		"ActionSet": cardWithBody(map[string]interface{}{"type": "ActionSet", "actions": []interface{}{
+			map[string]interface{}{"type": "Action.OpenUrl", "url": "https://example.com"},
+		}}),
 	}
 	for _, typ := range got {
 		card, ok := fixtures[typ]


### PR DESCRIPTION
## Summary

P3-3 (server half): extend the card message octo/v2 input whitelist from 3 to 6
input elements by adding **`Input.Number` / `Input.Date` / `Input.Time`**. All
three are Adaptive Cards **1.0** elements and stay inside the pinned
`card_version: "1.5"` — this is an **additive whitelist change, not a version
bump and not an envelope/event contract change**.

The three client renderers (web/Android/iOS) are the real cost of P3-3 and are
out of scope here; this PR ships only the server half — "the wire now carries
what the clients need" plus submit-time trust-boundary validation of the new
values, and an element-granularity capability advertisement so producers can
feature-detect the expansion.

## Related Issue

Roadmap item **card-message-interaction P3-3** (rich inputs + validation UX).
No standalone GitHub issue.

## Linked Spec

`.octospec/tasks/card-message-p3-rich-inputs/brief.md`

## Changes

- **`pkg/cardmsg/whitelist.go` (new)** — single authority for the element
  whitelists: `displayElements` (octo/v1 display set) and `inputElements`
  (octo/v2 inputs), with `DisplayElements()` / `InputElements()` accessors;
  `isInputElement` moved here. Validator, submit-time collector, dispatch, and
  the D12 manifest all derive from these — no re-typed literals.
- **`pkg/cardmsg/validate.go`** — send-time whitelist accepts the three new
  inputs; `element()` routes inputs through `isInputElement` (via `default`)
  instead of literal case labels, keeping send-time discipline unchanged (id
  required + frame-unique, `label`/`errorMessage` URL allowlist, `inlineAction`
  routing).
- **`pkg/cardmsg/inputs.go`** — submit-time value validation (D11 trust
  boundary): Number = **finite** numeric + declared `min`/`max`; Date =
  `YYYY-MM-DD` + declared range; Time = `HH:MM` (24h) + declared range; `""`
  passes as "unfilled". Non-finite guard rejects `NaN`/`±Inf` (which
  `strconv.ParseFloat` accepts without error and which bypass min/max compares).
  `isRequired`/`regex` remain client-UX + bot concerns.
- **`pkg/cardmsg/interactive.go`** — dispatch (`findSubmitInElements`) walks
  `inlineAction` via the same `isInputElement` predicate as validation, so
  `Input.Number/Date/Time.inlineAction` Submit is dispatchable (no "send-ok,
  click-invalid" dead button).
- **`modules/bot_api/card_profile.go`** — D12 manifest
  (`GET /v1/bot/card/profile`) additively advertises `elements` and `inputs`
  from the cardmsg authority, so producers can feature-detect at element
  granularity even while `card_version` stays `"1.5"`.
- **`docs/card-protocol.md`** — kept a faithful mirror (§2 whitelist, §3
  manifest fields, §7.1 inputs trust boundary).

No new errcode / i18n / DB / migration / endpoint. Wire contract is
additive-only.

## Testing

Run with a local Go 1.25.12 toolchain (MySQL-backed tests against the test DB):

- `go test -race ./pkg/cardmsg/` — whitelist authority, Number/Date/Time value
  validation (incl. non-finite), style tolerance (`filtered`/`password`/
  `expanded`), and `inlineAction` dispatch symmetry.
- `go test ./modules/bot_api -run TestBotCardProfile` — manifest field-set pin +
  `elements`/`inputs` deep-equal to the cardmsg authority.
- `go test ./modules/message -run 'Test.*Card'` — card_action dispatch, no
  regression.
- `go build ./...`, `make i18n-extract-check`, `make i18n-lint` — all pass.

- [x] Unit tests added/updated
- [x] Manually verified (test output above)

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   It widens the octo/v2 send-time element whitelist by three input types and
   adds submit-time value validation for them. On the send path, the accepted
   element set grows; the per-element discipline (id uniqueness, URL allowlist on
   `label`/`errorMessage`/`inlineAction`) is applied to the new types via the
   same code as the existing three. On the `card/action` submit path, the new
   inputs' values are validated as "shape-trusted" (declared id + correct type +
   within declared bounds; non-finite numbers rejected) before being passed to
   the bot. The element whitelist becomes a single authority that four surfaces
   (validation, collection, dispatch, manifest) derive from.

2. **What could break because of it (dependents + failure mode)?**
   - Older deployments (pre-this-change) still 400 the new inputs; because
     `card_version` stays `"1.5"`, a version-only capability gate can't tell them
     apart — mitigated by the new manifest `elements`/`inputs` element-granularity
     probe. Producers should feature-detect before emitting the new inputs.
   - Clients that don't render the new inputs degrade the whole card to `plain`
     (§8, no per-element fallback) — a rollout-coordination concern, not a
     server regression.
   - Dispatch symmetry: extending validation without extending dispatch would
     have produced a dead button; fixed by routing both through `isInputElement`
     and pinned by a test.
   - Non-finite `Input.Number`: without the guard, `NaN` would pass min/max
     silently — fixed and tested.

3. **How do you know it works (specific test/repro/trace)?**
   `pkg/cardmsg` tests assert: each new type accepted in octo/v2 and rejected in
   octo/v1; missing/duplicate id rejected; `javascript:` markdown links in
   `label`/`errorMessage` rejected; Number rejects non-numeric/non-finite/out-of-
   range and passes in-range + empty; Date/Time reject bad format/out-of-range and
   pass valid + empty; `inlineAction` Submit on all six inputs is both send-valid
   and dispatchable; `InputElements()`/`DisplayElements()` equal the validator's
   accepted sets. `modules/bot_api` asserts the manifest advertises the exact
   cardmsg lists. All green under `-race`.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
