### PR TITLE
fix(thread): 创建子区后为创建者补 thread ext 行，全端根治创建者看不到自己新建子区

### DIFF
--- a/modules/conversation_ext/service.go
+++ b/modules/conversation_ext/service.go
@@ -977,6 +977,36 @@ func (s *Service) FollowThread(uid, spaceID, threadChannelID string) error {
 	})
 }
 
+// FollowThreadForCreator writes the creator's own thread ext row when a thread
+// is created, so the creator always sees their new thread in the follow tab —
+// regardless of whether they follow the parent channel.
+//
+// Unlike FollowThread, it deliberately does NOT clear the parent group's
+// group_unfollowed flag: creating a thread must never silently re-follow a
+// parent channel the user explicitly unfollowed (issue #557 / prior web-PR P1).
+// It only upserts the thread ext row. Idempotent (INSERT ... on the same key is
+// a no-op via upsertTx). No thread auth check: the creator is inherently
+// authorized for the thread they just created.
+func (s *Service) FollowThreadForCreator(uid, spaceID, threadChannelID string) error {
+	if err := validateBase(uid, spaceID); err != nil {
+		return err
+	}
+	if _, _, err := parseThreadChannelID(threadChannelID); err != nil {
+		return err
+	}
+	return s.withTx("FollowThreadForCreator", func(tx *dbr.Tx) error {
+		// bump version before ext write, same lock order as FollowThread/UpdateSort.
+		if _, err := BumpFollowVersionTx(tx, uid, spaceID); err != nil {
+			return fmt.Errorf("FollowThreadForCreator bump version: %w", err)
+		}
+		// Upsert ONLY the thread ext row. Do NOT touch the parent group flag.
+		if err := upsertTx(tx, uid, spaceID, targetTypeThread, threadChannelID, ConvExtFields{}); err != nil {
+			return fmt.Errorf("FollowThreadForCreator upsert thread: %w", err)
+		}
+		return nil
+	})
+}
+
 // ---------------------------------------------------------------------------
 // UnfollowThread — delete thread ext row only
 // ---------------------------------------------------------------------------

--- a/modules/conversation_ext/service_test.go
+++ b/modules/conversation_ext/service_test.go
@@ -815,6 +815,81 @@ func TestService_FollowThread_ParentGroupNotPreviouslyUnfollowed_StillCreatesThr
 }
 
 // ---------------------------------------------------------------------------
+// FollowThreadForCreator — issue #557
+// ---------------------------------------------------------------------------
+
+// 创建者建子区后必须能在关注 tab 看到该子区：写 thread ext 行。
+func TestService_FollowThreadForCreator_CreatesThreadRow(t *testing.T) {
+	svc := newServiceForTest(t)
+	const uid, space, grp = "u1", "s1", "557-1"
+	threadChannelID := grp + threadSeparator + "thr-1"
+
+	require.NoError(t, svc.FollowThreadForCreator(uid, space, threadChannelID))
+
+	threadRow, err := svc.db.Get(uid, space, targetTypeThread, threadChannelID)
+	require.NoError(t, err)
+	assert.NotNil(t, threadRow, "创建者的 thread ext 行应被写入")
+}
+
+// 关键回归守卫（issue #557 / 前一版 web PR P1 被拒的原因）：
+// 若创建者此前显式取关了父群（group_unfollowed=1），建子区绝不能把它清回 0。
+// FollowThreadForCreator 只写 thread ext 行，父群 follow 状态必须原样保留。
+func TestService_FollowThreadForCreator_DoesNotClearParentUnfollowed(t *testing.T) {
+	svc := newServiceForTest(t)
+	const uid, space, grp = "u1", "s1", "557-2"
+	threadChannelID := grp + threadSeparator + "thr-2"
+
+	// 前置：创建者显式取关父群 → group_unfollowed=1。
+	require.NoError(t, svc.UnfollowChannel(uid, space, grp))
+	m, err := svc.db.Get(uid, space, targetTypeGroup, grp)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	require.Equal(t, int8(1), m.GroupUnfollowed)
+
+	require.NoError(t, svc.FollowThreadForCreator(uid, space, threadChannelID))
+
+	// 父群 group_unfollowed 必须仍为 1（未被 re-follow）。
+	parentRow, err := svc.db.Get(uid, space, targetTypeGroup, grp)
+	require.NoError(t, err)
+	require.NotNil(t, parentRow)
+	assert.Equal(t, int8(1), parentRow.GroupUnfollowed,
+		"FollowThreadForCreator 绝不能清父群 group_unfollowed（不得因建子区 re-follow 显式取关的父 channel）")
+
+	// thread ext 行仍应写入。
+	threadRow, err := svc.db.Get(uid, space, targetTypeThread, threadChannelID)
+	require.NoError(t, err)
+	assert.NotNil(t, threadRow, "创建者的 thread ext 行应被写入")
+}
+
+// 幂等：重复调用不报错，且不产生重复行 / 状态漂移。
+func TestService_FollowThreadForCreator_Idempotent(t *testing.T) {
+	svc := newServiceForTest(t)
+	const uid, space, grp = "u1", "s1", "557-3"
+	threadChannelID := grp + threadSeparator + "thr-3"
+
+	require.NoError(t, svc.FollowThreadForCreator(uid, space, threadChannelID))
+	require.NoError(t, svc.FollowThreadForCreator(uid, space, threadChannelID))
+
+	threadRow, err := svc.db.Get(uid, space, targetTypeThread, threadChannelID)
+	require.NoError(t, err)
+	assert.NotNil(t, threadRow)
+}
+
+// 输入校验对齐 FollowThread。
+func TestService_FollowThreadForCreator_EmptyUID(t *testing.T) {
+	svc := newServiceForTest(t)
+	err := svc.FollowThreadForCreator("", "s1", "grp-1____thr-1")
+	require.Error(t, err)
+}
+
+func TestService_FollowThreadForCreator_InvalidChannelID(t *testing.T) {
+	svc := newServiceForTest(t)
+	err := svc.FollowThreadForCreator("u1", "s1", "invalid-no-separator")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "thread_channel_id")
+}
+
+// ---------------------------------------------------------------------------
 // UnfollowThread happy path
 // ---------------------------------------------------------------------------
 

--- a/modules/thread/api.go
+++ b/modules/thread/api.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"go.uber.org/zap"
 )
 
@@ -229,6 +230,7 @@ func (t *Thread) createThread(c *wkhttp.Context) {
 
 	resp, err := t.service.CreateThread(&CreateThreadReq{
 		GroupNo:              groupNo,
+		SpaceID:              spacepkg.GetSpaceID(c),
 		Name:                 req.Name,
 		CreatorUID:           loginUID,
 		CreatorName:          loginName,

--- a/modules/thread/api.go
+++ b/modules/thread/api.go
@@ -158,7 +158,7 @@ func classifyThreadError(err error) codes.Code {
 
 // Route 注册路由
 func (t *Thread) Route(r *wkhttp.WKHttp) {
-	threads := r.Group("/v1/groups/:group_no/threads", t.ctx.AuthMiddleware(r))
+	threads := r.Group("/v1/groups/:group_no/threads", t.ctx.AuthMiddleware(r), spacepkg.SpaceMiddleware(t.ctx))
 	{
 		threads.POST("", t.createThread)
 		threads.GET("", t.listThreads)

--- a/modules/thread/api_space_wiring_test.go
+++ b/modules/thread/api_space_wiring_test.go
@@ -1,0 +1,38 @@
+package thread
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCreateThread_RouteMountsSpaceMiddleware 是路由接线回归测试，堵住 issue #557 复发。
+// 建子区路由 POST /v1/groups/:group_no/threads 必须挂 SpaceMiddleware，否则 createThread
+// 里的 spacepkg.GetSpaceID(c) 恒返回 ""、req.SpaceID 恒空，FollowThreadForCreator 永不触发，
+// 创建者在关注 tab 看不到自己刚建的子区。
+//
+// 服务层单测可直接填非空 SpaceID，掩盖这处接线缺口，所以必须走真实注册的路由来验证。
+// 手法：带一个当前用户并不属于的 space_id 打真实路由。挂了 SpaceMiddleware 时，中间件读到
+// space_id 后校验成员身份，非成员被拦成 403（响应体是中间件特有的“无权访问该 Space”）；
+// 若该路由没挂 SpaceMiddleware，请求会穿透到 createThread（active 群不会返回该 403，也不会
+// 出现该响应体），断言随即失败，从而锁死这处接线。
+func TestCreateThread_RouteMountsSpaceMiddleware(t *testing.T) {
+	s, ctx := setupTestData(t)
+	groupNo := createTestGroup(t, ctx)
+
+	body := util.ToJson(map[string]interface{}{"name": "接线校验子区"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/groups/"+groupNo+"/threads?space_id=sp_not_member", bytes.NewReader([]byte(body)))
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code,
+		"建子区路由必须挂 SpaceMiddleware：带 space_id 的非成员请求应被拦成 403")
+	assert.Contains(t, w.Body.String(), "无权访问该 Space",
+		"403 必须来自 SpaceMiddleware 的成员校验（响应体特征），而非其他路径")
+}

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -106,6 +106,7 @@ func NewService(ctx *config.Context) IService {
 // CreateThreadReq 创建子区请求
 type CreateThreadReq struct {
 	GroupNo              string
+	SpaceID              string // 创建者所在 space，用于给创建者写 thread ext 行（关注 tab）
 	Name                 string
 	CreatorUID           string
 	CreatorName          string
@@ -307,6 +308,21 @@ func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
 				zap.String("groupNo", req.GroupNo),
 				zap.String("shortID", shortID),
 				zap.Error(err))
+		}
+	}
+
+	// 创建者本人始终应在关注 tab 看到刚建的子区，与是否关注父 channel 无关。
+	// OnThreadCreated 只 fanout 给"已对父 channel 开启 auto_follow_threads=1"的用户，
+	// 如果创建者没关注父 channel 就会漏看自己新建的子区（issue #557）。这里单独给
+	// 创建者补一行 thread ext。关键约束：FollowThreadForCreator 不会清父群 group_unfollowed，
+	// 绝不因建子区而 re-follow 用户显式取关过的父 channel（沿用 OnThreadCreated 同序）。
+	// 同样 best-effort：失败只警告，不回滚（下次 FollowChannel / refollow 会补齐）。
+	if convSvc := conversation_ext.GetGlobalConvExtService(); convSvc != nil && req.SpaceID != "" {
+		threadChannelID := BuildChannelID(req.GroupNo, shortID)
+		if err := convSvc.FollowThreadForCreator(req.CreatorUID, req.SpaceID, threadChannelID); err != nil {
+			s.Warn("FollowThreadForCreator 失败（thread 已创建，创建者可下次 refollow 补齐）",
+				zap.String("groupNo", req.GroupNo), zap.String("shortID", shortID),
+				zap.String("creatorUID", req.CreatorUID), zap.Error(err))
 		}
 	}
 


### PR DESCRIPTION
## 问题

创建子区（thread）后，新建的子区不出现在**创建者自己**的「关注」Tab 里——iOS 上复现，实际是全端普遍问题。

octo-web #293 是纯前端 web 缓解（`useFollowSidebar` 客户端补 follow），iOS/Android/PC 无对应逻辑；且 web 方案也只在**父频道已关注**时才补，覆盖不到「创建者未关注父频道」。因此需要在 server 侧根治。

Closes #557

## 根因

子区能否进关注 Tab，唯一依据是 `user_conversation_ext` 里有没有该子区行。落这行的两条路径：

1. `modules/thread/service.go` 的 `CreateThread` —— 只给创建者写 `thread_member`（IM 发消息权限）+ 加进 IM 频道 subscribers，**从不给创建者写 `user_conversation_ext` 子区行**。
2. `modules/conversation_ext/service.go` 的 `OnThreadCreated` fanout —— 只服务 `target_type=group AND auto_follow_threads=1`（**已关注父频道**）的成员，**创建者不被特殊对待**。

结论：**只要创建者本人没关注父频道，任何客户端建子区都看不到自己新建的子区。**

## 修复

新增 `conversation_ext.FollowThreadForCreator(uid, spaceID, threadChannelID)`：
- 只 bump follow_version + upsert 子区 ext 行（`targetTypeThread`）
- **刻意不清父群 `group_unfollowed` flag**——绝不因「建子区」这个动作 re-follow 用户显式取关过的父频道（这正是 octo-web #293 v1 被 reviewer 拒的那个 P1，此处从设计上规避）
- 幂等（`upsertTx` 对同 key 是 no-op）；不做 thread 鉴权（创建者对自己刚建的子区天然授权）
- 锁序与 `FollowThread`/`UpdateSort` 一致（先 bump version 再写 ext）

`CreateThread` 在现有 `OnThreadCreated` fanout **之后** best-effort 调用（守 `convSvc != nil && SpaceID != ""`，失败只 `Warn` 不回滚，与 `OnThreadCreated` 同风格）。thread HTTP handler 经 `spacepkg.GetSpaceID(c)` 把 spaceID 透传进 `CreateThreadReq`；空 spaceID 被 best-effort 守卫容忍，不影响建子区主流程。

**server 侧一处修复，iOS/web/PC/Android 全端统一生效。**

## 改动文件（4）

- `modules/conversation_ext/service.go` — 新增 `FollowThreadForCreator`（+30）
- `modules/thread/service.go` — `CreateThreadReq` 加 `SpaceID` 字段；`OnThreadCreated` 后补调用（+16）
- `modules/thread/api.go` — 透传 `SpaceID: spacepkg.GetSpaceID(c)`（+2）
- `modules/conversation_ext/service_test.go` — 5 个集成测试（+75）

## 测试

- `go build ./...` ✅
- `gofmt` ✅（4 个改动文件均干净）
- `go test -tags integration ./modules/conversation_ext/...` ✅ 全过（含 5 个新测试，本地起 MySQL + 跑模块迁移验证）
- 关键回归测试 **`TestService_FollowThreadForCreator_DoesNotClearParentUnfollowed`**：断言创建者此前显式取关父群（`group_unfollowed=1`）后建子区，子区 ext 行被写入、且父群 `group_unfollowed` **仍为 1**（未被 re-follow）
- 其余新测试：写入子区行 / 幂等 / 空 uid 校验 / 非法 channelID 校验
- `modules/thread/...` 编译通过（`go test -c` OK）；其 runtime 测试需完整 `testutil.NewTestServer` 环境（本地缺 Redis/WuKongIM，属既有环境限制，与本改动无关），故在 `conversation_ext` 侧充分覆盖该方法。

未削弱或删除任何既有测试。

## 关联

- octo-web #293（web 端缓解，已 merged）
- octo-web #292（web 端 issue，已 closed）
