### PR TITLE
feat(sticker): downscale oversized static stickers to a configurable target

### DIFF
--- a/.octospec/journal/shared/sticker-downscale-store.md
+++ b/.octospec/journal/shared/sticker-downscale-store.md
@@ -88,4 +88,3 @@ to the same source as its own guard is silently inert. When a validation gate an
 a downstream transform read the same limit, the transform can be unreachable —
 worth a decoupling check whenever a resize/normalize step sits behind a reject
 gate keyed on the same dimension.
-</content>

--- a/.octospec/journal/shared/sticker-downscale-store.md
+++ b/.octospec/journal/shared/sticker-downscale-store.md
@@ -1,0 +1,91 @@
+---
+type: Journal
+title: "Journal: sticker-downscale-store (accept-large-then-downscale for static stickers)"
+description: Record of the phase-two sticker compression change — decouple the compressor's imaging.Fit downscale target from the upload dimension gate via a new server-side system_setting sticker.compress_max_dimension, so static jpg/png larger than the target (but within the unchanged accept ceiling) are downscaled before re-encode+store instead of being stored at full size. Zero-impact default (unset == upload_max_dimension == no downscale). Accept hard cap stays 1024; webp/gif still validate-only.
+tags: ["sticker", "wire-contract", "external-content", "throttle", "testing"]
+timestamp: 2026-07-09T12:30:28Z
+# --- octospec extension fields ---
+task: sticker-downscale-store
+upstream: sticker-upload-compression (phase two)
+source: self
+---
+
+# Journal: sticker-downscale-store
+
+## What was done
+
+The `sticker-upload-compression` compressor already carried an
+`imaging.Fit(img, maxDim, maxDim, Lanczos)` downscale step, but it was
+**unreachable on the production path**: `stickerLimitsSnapshot.compressParams()`
+sourced its `MaxDim` from `s.maxDim` — the exact value the upload dimension gate
+(`api.go` decode-config check) enforces — so after the gate `w,h ≤ maxDim` always
+held and `Fit` never fired. The compressor only ever re-encoded at the original
+size. This task decouples the shrink target from the accept gate so "accept a
+larger static image, downscale it, then store" actually works.
+
+- **`modules/common/system_settings.go`** — new getter
+  `StickerCompressMaxDimension()`. Semantics: unset/≤0 → falls back to
+  `StickerUploadMaxDimension()` (no extra downscale; byte-for-byte identical to
+  before); a value above the effective `upload_max_dimension` is meaningless
+  (shrink target can't exceed the accept ceiling) → clamped DOWN to it with a
+  dedup Warn (reuses the `stickerClampWarned` sync.Map, same as the sibling
+  clamp getters); an in-range `[1, upload_max_dimension]` value is returned
+  verbatim. No independent hard cap — the accept ceiling (itself hard-capped at
+  1024) is the upper bound, so decoded-pixel memory is unchanged.
+- **`modules/common/system_setting_schema.go`** — one new canonical key
+  `sticker.compress_max_dimension` (`settingTypeInt`, `Positive:true`, so it opts
+  out of the shared `[0,3650]` bound; read-side clamp enforces `≤
+  upload_max_dimension`). NOT exposed via `GET /v1/common/appconfig` — it's a
+  server-side compression knob, not a client pre-check limit.
+- **`modules/file/sticker_compress.go`** — added `compressMaxDim` to
+  `stickerLimitsSnapshot` (populated from the new getter in the production branch,
+  and `= StickerMaxDimension` in the nil-settings fallback so old unit tests stay
+  equivalent), added `StickerCompressMaxDimension()` to the `stickerSystemSettings`
+  interface, and changed `compressParams().MaxDim` to return `compressMaxDim`
+  instead of `maxDim`. That one-value swap is the whole behavior change:
+  `doCompressStaticSticker` and the `api.go` dimension gate are untouched — the
+  gate still reads `maxDim`, the compressor now Fits into the smaller
+  `compressMaxDim`.
+
+## Invariants preserved
+
+- **Accept gate / decompression-bomb defense unchanged.** `upload_max_dimension`
+  (hard cap 1024) still bounds the full-decode pixel buffer; the new setting only
+  shrinks WITHIN that ceiling, so the memory envelope (≤ 1024²×4 = 4 MB/frame ×
+  concurrency) is not widened. Decision (recorded in brief): keep the 1024 accept
+  cap — this task does NOT accept genuinely huge images.
+- **Wire contract.** Response shape unchanged; `size` + signed bytes are the
+  post-downscale values (same mechanism as post-compression). `ext`/`path`
+  unchanged (jpg→jpg, png→png) so the `stickersig` handle and
+  `validateStickerPath` `ext==format` invariant still hold.
+- **Zero-impact default.** Unset key → `compressMaxDim == maxDim` → `Fit` never
+  fires → identical to `main`. Regression test asserts a 700² source is stored at
+  700² when the key is unset.
+- **webp/gif/animated still validate-only** — a non-compressible format cannot be
+  downscaled (phase-one scope unchanged).
+
+## Tests
+
+- `system_settings_sticker_upload_test.go` — 5 no-infra getter cases: unset→
+  ceiling, unset-tracks-raised-ceiling, non-positive→ceiling, in-range verbatim,
+  above-ceiling→clamp-down + dedup Warn.
+- `api_sticker_compress_test.go` — 2 api-level integration cases:
+  `LargeImage_DownscaledAndStored` (1024² jpg, `upload_max_dimension=1024` +
+  `compress_max_dimension=512` → stored 512×512, aspect preserved, `size` =
+  post-downscale, handle verifies) and `UnsetCompressMaxDim_NoDownscale`
+  (regression: 700² stored at 700² when the key is unset). Fake
+  `fakeStickerSystemSettings` extended with `compressMaxDim` mirroring the
+  production fallback.
+- `go vet` clean; both full test binaries compile; `make i18n-lint` unaffected
+  (no new codes). Perf: this is the previously-measured "ShrinkTo512" bench path
+  (JPEG 1024²→512 ≈ 61 ms, PNG ≈ 94 ms on x86 Xeon), well within
+  `compress_timeout_ms`.
+
+## Learning
+
+The dead `imaging.Fit` branch is a good reminder that a "configurable" knob wired
+to the same source as its own guard is silently inert. When a validation gate and
+a downstream transform read the same limit, the transform can be unreachable —
+worth a decoupling check whenever a resize/normalize step sits behind a reject
+gate keyed on the same dimension.
+</content>

--- a/.octospec/journal/shared/sticker-oversized-default.md
+++ b/.octospec/journal/shared/sticker-oversized-default.md
@@ -64,10 +64,12 @@ The compute path (`doCompressStaticSticker` → `imaging.Fit` to
 - **Zero-impact when compression off (default).** `effectiveGateDim` returns
   `upload_max_dimension` (512) for every format, and the compressor never runs.
 - **Known edge — APNG.** APNG has ext `.png` so it passes the widened gate, but
-  the compressor detects it (`isAnimatedPNGSource`) and stores it un-shrunk
-  (`skipped:animated`). A 513–1024² APNG is thus stored at full size — rare,
-  bounded by the 1024 hard cap, documented in `effectiveGateDim`. Tightening
-  would need an acTL scan at the gate (deferred).
+  the compressor detects it (`isAnimatedPNGSource`) and can't shrink it
+  (`skipped:animated`). **Superseded by `sticker-oversized-store-guard`:** a
+  >`upload_max_dimension` APNG is now fail-closed **rejected** (not stored), so the
+  ≤`upload_max_dimension` stored invariant holds for animated PNGs too; a
+  ≤`upload_max_dimension` APNG is stored as-is. (This entry originally said such an
+  APNG was stored at full size — true only for the pre-guard increment.)
 
 ## Tests
 
@@ -96,4 +98,3 @@ feature is on) can be made "correct out of the box" without flipping the
 auto-shrink" while preserving the compressor's cautious rollout — and, as a
 bonus, avoided a client-contract change by making the gate compress-aware instead
 of raising the advertised limit.
-</content>

--- a/.octospec/journal/shared/sticker-oversized-default.md
+++ b/.octospec/journal/shared/sticker-oversized-default.md
@@ -1,0 +1,99 @@
+---
+type: Journal
+title: "Journal: sticker-oversized-default (>512 static jpg/png auto-shrinks to 512 by default)"
+description: Make ">512px static jpg/png downscale to 512" the built-in default of the sticker compressor. compress_max_dimension default flips to 512 (decoupled from upload_max_dimension, clamped [1,1024]); the upload dimension gate becomes compress-aware — jpg/png accept up to the 1024 hard cap when compression is on (then shrink), gif/webp and compress-off stay gated at upload_max_dimension (512). compress_enabled stays default-false (gray-scale rollout preserved); zero-impact when off.
+tags: ["sticker", "wire-contract", "external-content", "throttle", "testing"]
+timestamp: 2026-07-09T12:58:13Z
+# --- octospec extension fields ---
+task: sticker-oversized-default
+upstream: sticker-downscale-store (follow-up)
+source: self
+---
+
+# Journal: sticker-oversized-default
+
+## What was done
+
+`sticker-downscale-store` made downscale *possible* but defaulted
+`compress_max_dimension` to "= upload ceiling" (no shrink), so ">512 shrinks to
+512" required hand-tuning three knobs. The product intent is simpler: **anything
+over 512 should be compressed to 512**, and that should be automatic once
+compression is enabled — without flipping compression on for every deployment
+(the compressor keeps its designed gray-scale rollout).
+
+Chosen approach (option B): keep `compress_enabled` default-false and
+`upload_max_dimension` default-512 (so the appconfig client contract and the
+compress-off gate are untouched), and instead:
+
+- **`compress_max_dimension` default → 512**, clamp range `[1, 1024]` (the
+  decoded-pixel hard cap), **decoupled** from `upload_max_dimension`. The getter
+  collapsed to the shared `stickerClampIntUpper` helper like its siblings.
+- **Compress-aware dimension gate** (`modules/file`): new
+  `stickerLimitsSnapshot.effectiveGateDim(ext)` returns the compressible-accept
+  ceiling `stickerCompressAcceptMaxDim` (1024) for jpg/png **when compression is
+  on**, else `maxDim` (upload_max_dimension, 512). `api.go` uses it instead of
+  the raw `maxDim`. So oversized static jpg/png are admitted to be shrunk;
+  gif/webp (can't be re-encoded) and every upload when compression is off stay
+  gated at 512.
+
+The compute path (`doCompressStaticSticker` → `imaging.Fit` to
+`compress_max_dimension`) is unchanged — this is the previously-measured
+"ShrinkTo512" bench path (JPEG 1024²→512 ≈ 61 ms, PNG ≈ 94 ms, ≪ timeout).
+
+## Why this shape
+
+- **Chosen over "raise upload_max_dimension default to 1024".** That literal
+  reading would ripple into the client contract: appconfig advertises
+  `upload_max_dimension`, so it would jump to 1024 while the compress-off gate
+  stayed 512 — an inconsistency (client told 1024, server rejects at 512). Making
+  the gate compress-aware and leaving `upload_max_dimension` at 512 keeps
+  appconfig honest and unchanged, and keeps compress-off byte-for-byte identical.
+- **Compressible-accept ceiling fixed at the 1024 hard cap, not a new knob.** It
+  is invisible in stored output (images are shrunk to `compress_max_dimension`
+  anyway) and is the memory-safe maximum (1024²×4 = 4 MB decode/frame), so it
+  needs no tuning.
+
+## Invariants & envelope
+
+- **Decompression-bomb / decode-memory bound unchanged.** The widened gate tops
+  out at the SAME 1024 hard cap; gif/webp + compress-off stay at 512; the gate
+  still fails closed on `DecodeConfig` error.
+- **Wire contract unchanged.** Response shape, `ext`/`path` (jpg→jpg), handle,
+  and appconfig `StickerUploadLimits.MaxDimension` (still `upload_max_dimension` =
+  512) are untouched. `size`/signed bytes reflect the downscaled object as before.
+- **Zero-impact when compression off (default).** `effectiveGateDim` returns
+  `upload_max_dimension` (512) for every format, and the compressor never runs.
+- **Known edge — APNG.** APNG has ext `.png` so it passes the widened gate, but
+  the compressor detects it (`isAnimatedPNGSource`) and stores it un-shrunk
+  (`skipped:animated`). A 513–1024² APNG is thus stored at full size — rare,
+  bounded by the 1024 hard cap, documented in `effectiveGateDim`. Tightening
+  would need an acTL scan at the gate (deferred).
+
+## Tests
+
+- `system_settings_sticker_upload_test.go` — rewrote the 5 `compress_max_dimension`
+  getter cases for the new semantics: default 512; decoupled from
+  `upload_max_dimension`; ≤0/non-numeric → 512; in-range `[1,1024]` verbatim;
+  `>1024` → 1024 + dedup Warn.
+- `api_sticker_compress_test.go` — made `fakeStickerSystemSettings` faithful
+  (unset → 512); added `OversizedJPEG_AcceptedAndDownscaled_DefaultUploadDim`
+  (1024² jpg accepted with `upload_max_dimension=512`, stored 512²),
+  `OversizedGIF_RejectedWhenCompressOn` (600² gif rejected at 512),
+  `OversizedJPEG_RejectedWhenCompressOff` (zero-impact: 600² jpg rejected at 512
+  when compression off), and repurposed the old unset-test into
+  `DefaultCompressMaxDim_ShrinksOversizedTo512`. Reconciled
+  `LargeJPEG_UsesCompressedBytes` (pinned `compressMaxDim=1024` to keep testing
+  quality-only compression).
+- Full file + common sticker suites pass; `go vet` clean; both test binaries
+  compile; `make i18n-lint` unaffected; appconfig tests untouched.
+
+## Learning
+
+When a "default" request lands on a feature that was deliberately opt-in
+(gray-scale), separate the two axes: the *config default* (what happens once the
+feature is on) can be made "correct out of the box" without flipping the
+*feature default* (whether it's on at all). Here that let us deliver "big images
+auto-shrink" while preserving the compressor's cautious rollout — and, as a
+bonus, avoided a client-contract change by making the gate compress-aware instead
+of raising the advertised limit.
+</content>

--- a/.octospec/journal/shared/sticker-oversized-store-guard.md
+++ b/.octospec/journal/shared/sticker-oversized-store-guard.md
@@ -91,4 +91,3 @@ was intentionally best-effort/fail-open, so the widen created a hole on every
 fallback path. When you relax a bound trusting a downstream transform, assert the
 post-transform invariant explicitly rather than trusting the transform to always
 run — especially when the transform is fail-open by design.
-</content>

--- a/.octospec/journal/shared/sticker-oversized-store-guard.md
+++ b/.octospec/journal/shared/sticker-oversized-store-guard.md
@@ -1,0 +1,94 @@
+---
+type: Journal
+title: "Journal: sticker-oversized-store-guard (fail-closed on oversized-uncompressed stickers)"
+description: Fix the review-found regression where the compress-aware dimension gate admitted >512 jpg/png on the premise that compression downscales them, but every fail-open path (nil compressor, skipped on concurrency-saturation/timeout, failed, or compress_max_dimension > upload_max_dimension) stored the original oversized image up to 1024². Added a post-compression guard using the compressor's actual output dimension so a stored sticker never exceeds upload_max_dimension; deduped the cross-package 1024 constant.
+tags: ["sticker", "wire-contract", "external-content", "throttle", "testing"]
+timestamp: 2026-07-09T13:58:59Z
+# --- octospec extension fields ---
+task: sticker-oversized-store-guard
+upstream: code-review of sticker-oversized-default
+source: self
+---
+
+# Journal: sticker-oversized-store-guard
+
+## What was done
+
+An xhigh code review of `sticker-oversized-default` (5 independent finder agents,
+strong convergence) surfaced a real regression I introduced: `effectiveGateDim`
+widens the jpg/png dimension gate to 1024 when compression is on, trusting the
+compressor to downscale to `compress_max_dimension`. But the compressor is
+deliberately fail-open — so on `skipped:concurrency_saturated`, `skipped:timeout`,
+`failed` (decode error), `f.compressor==nil`, or a `compress_max_dimension >
+upload_max_dimension` mis-config, `uploadFile` stored the **original oversized
+bytes** (up to 1024², 4× the 512 pixel budget) and served them inline to
+conversation peers — the exact cross-user decode-DoS the dimension cap exists to
+prevent, reachable under load and attackable by saturating the 4 compress slots.
+
+Fix — enforce "stored dimension ≤ `upload_max_dimension`, on every path", without
+giving up compression's *quality* fail-open:
+
+- **`stickerCompressResult.OutMaxDim`** — the compressor now reports the actual
+  post-compression single-edge dimension for `compressed`/`over_limit`
+  (`doCompressStaticSticker` reads `img.Bounds()` after the optional Fit).
+- **`api.go` store guard** — capture `stickerSrcMaxDim = max(cfg.W, cfg.H)` at the
+  dimension gate; track `finalStoredMaxDim` (= `result.OutMaxDim` on the compressed
+  path, else the source dim, the default for every store-original branch); after
+  the compress block, `if finalStoredMaxDim > upload_max_dimension` →
+  `observeStickerUpload("compress_oversized_rejected")` + reject. Placed AFTER the
+  whole compress block so it also covers the nil-compressor / compress-off skip
+  (which never enter the block).
+- **New terminal metric** `compress_oversized_rejected` (registered + pre-warmed),
+  distinct from the `compress_skipped/failed` sub-outcome so ops can see the guard
+  firing during rollout.
+- **Constant dedup** (finding 6) — exported `common.StickerUploadMaxDimensionHardCap`
+  (alias of the unexported cap) and pointed `stickerCompressAcceptMaxDim` at it, so
+  the compressible-accept ceiling and the decode hard cap are a single source of
+  truth (a hand-synced 1024 literal could have drifted and re-widened the gate).
+- **Schema note** — `compress_max_dimension` description now recommends
+  `≤ upload_max_dimension` (else post-compress-oversized images are fail-closed).
+- **Test cleanup** (finding 7) — `DownscaledAndStored` now uses the shared
+  `uploadStickerForTest` helper instead of re-inlining the multipart boilerplate.
+
+## Why this shape (design notes)
+
+- **Guard, not gate-narrowing.** The gate SHOULD admit big jpg/png to shrink them;
+  the bug is that admission was decoupled from a guaranteed ≤cap outcome. Checking
+  the *actual output dimension* after the fact re-couples them robustly and covers
+  the `compress_max_dimension > upload_max_dimension` mis-config too (compressed but
+  not shrunk → OutMaxDim > cap → rejected), which a boolean "was compressed" flag
+  would have missed.
+- **Dimension fail-CLOSED, quality fail-OPEN.** Compression still never fails an
+  upload for encode/timeout/saturation reasons *when the source already fits*
+  (≤ upload_max_dimension → guard passes → stored original). Only an oversized
+  source that couldn't be shrunk is rejected — the safe choice, since storing it
+  is the harm.
+- **Metric is a terminal label**, emitted in place of `success`; the
+  `compress_skipped/failed` sub-outcome still records why compression didn't run,
+  matching the existing sub+terminal counter design (a compressed success already
+  emits both `compress_success` and `success`).
+
+## Tests
+
+`api_sticker_compress_test.go` — four guard regressions, each a 1024² jpg with
+`upload_max_dimension=512`, asserting reject + nothing stored:
+`OversizedGuard_NilCompressorRejects` (finding 5), `_CompressFailedRejects`
+(injected failing `doCompress`), `_CompressTimeoutRejects` (injected slow
+`doCompress` + 5 ms timeout → skipped:timeout, finding 1), and
+`_CompressMaxDimAboveUploadDimRejects` (finding 3 mis-config → compressed-but-1024
+→ rejected). Happy path (`OversizedJPEG_AcceptedAndDownscaled_DefaultUploadDim`,
+1024²→512 stored) still green, proving the guard doesn't reject shrinkable images.
+All no-infra file + common getter tests pass; `go vet` clean; both test binaries
+compile; `make i18n-lint` unaffected. (Infra-only `TestGetAppConfig_*` /
+`StickerCustomEnabled` panic on MySQL connect in this sandbox — pre-existing,
+untouched by this change.)
+
+## Learning
+
+A "widen the gate because a later step will bring it back in bounds" change is
+only as safe as that later step is guaranteed. Here the later step (compression)
+was intentionally best-effort/fail-open, so the widen created a hole on every
+fallback path. When you relax a bound trusting a downstream transform, assert the
+post-transform invariant explicitly rather than trusting the transform to always
+run — especially when the transform is fail-open by design.
+</content>

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,25 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-09 (sticker-oversized-store-guard)
+
+- **Fix** — Task `sticker-oversized-store-guard` (code-review fix on
+  `sticker-oversized-default`): close the regression where the compress-aware
+  gate admitted >512 jpg/png trusting compression to downscale, but every
+  fail-open path (nil compressor, skipped:concurrency_saturated/timeout, failed,
+  or compress_max_dimension > upload_max_dimension) stored the original oversized
+  image up to 1024² and served it to peers — reachable under load / attackable by
+  saturating the compress slots. Added `stickerCompressResult.OutMaxDim` (actual
+  post-compression dimension) + an `api.go` post-block guard that rejects
+  (`compress_oversized_rejected`, new pre-warmed terminal metric) when the final
+  stored dimension exceeds `upload_max_dimension` — dimension fail-CLOSED while
+  compression quality stays fail-OPEN. Deduped the cross-package 1024 literal
+  (exported `common.StickerUploadMaxDimensionHardCap`, referenced by modules/file).
+  Schema note recommends `compress_max_dimension ≤ upload_max_dimension`; test
+  helper reuse cleanup. Four guard regressions (nil/failed/timeout/mis-config) +
+  unbroken happy path. No new errcode / i18n / DB / appconfig change. Briefs
+  `.octospec/tasks/sticker-oversized-store-guard/`.
+
 ## 2026-07-09 (sticker-oversized-default)
 
 - **Change** — Task `sticker-oversized-default` (follow-up to

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,23 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-09 (sticker-downscale-store)
+
+- **Change** — Task `sticker-downscale-store` (phase two of
+  `sticker-upload-compression`): decouple the compressor's `imaging.Fit` downscale
+  target from the upload dimension gate. New server-side key
+  `sticker.compress_max_dimension` (int, `Positive:true`, read-side clamped to
+  `≤ upload_max_dimension`, unset ⇒ `= upload_max_dimension` ⇒ no downscale). Swap
+  `stickerLimitsSnapshot.compressParams().MaxDim` from `maxDim` (accept gate) to a
+  new `compressMaxDim` field so static jpg/png larger than the target but within
+  the unchanged accept ceiling are downscaled before re-encode+store, instead of
+  the Fit branch being unreachable (gate/target were same-source, so it never
+  fired). Accept hard cap stays 1024 (decompression-bomb envelope unchanged);
+  webp/gif still validate-only; not exposed via appconfig. Zero-impact default,
+  byte-for-byte identical to `main` when unset. New getter clamp tests (no-infra)
+  + api-level downscale/regression tests. No new errcode / i18n / DB / migration.
+  Brief `.octospec/tasks/sticker-downscale-store/brief.md`.
+
 ## 2026-07-09 (P3-3)
 
 - **Change** — Task `card-message-p3-rich-inputs` (card message P3-3): extend the

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -39,8 +39,10 @@ change-log convention (§7). Newest first.
   client contract stay **512/unchanged** (compress-aware gate avoids the
   appconfig ripple a 1024 default would cause). Zero-impact when compression off
   (gate = 512 for all formats, compressor never runs). Known edge: APNG (ext
-  `.png`) passes the widened gate but stores un-shrunk (`skipped:animated`),
-  bounded by 1024. Getter tests rewritten; gate integration tests added; fake made
+  `.png`) passes the widened gate but can't be shrunk (`skipped:animated`) — later
+  fail-closed **rejected** by `sticker-oversized-store-guard` if >
+  `upload_max_dimension` (this entry's pre-guard "stored un-shrunk" no longer
+  holds). Getter tests rewritten; gate integration tests added; fake made
   faithful to the 512 default. No new errcode / i18n / DB / migration / appconfig
   field. Brief `.octospec/tasks/sticker-oversized-default/brief.md`.
 

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,27 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-09 (sticker-oversized-default)
+
+- **Change** — Task `sticker-oversized-default` (follow-up to
+  `sticker-downscale-store`): make ">512px static jpg/png auto-shrinks to 512" the
+  built-in default once compression is enabled, without turning compression on for
+  every deployment. `compress_max_dimension` default flips 0(=ceiling)→**512**,
+  decoupled from `upload_max_dimension`, clamp `[1,1024]` (getter collapsed to the
+  shared `stickerClampIntUpper`). New compress-aware dimension gate
+  (`stickerLimitsSnapshot.effectiveGateDim`): jpg/png accept up to the **1024**
+  hard cap when `compress_enabled=true` (then shrink to `compress_max_dimension`),
+  gif/webp and compress-off stay gated at `upload_max_dimension` (512).
+  `compress_enabled` default stays **false** (gray-scale rollout preserved);
+  `upload_max_dimension` default and the appconfig `StickerUploadLimits`
+  client contract stay **512/unchanged** (compress-aware gate avoids the
+  appconfig ripple a 1024 default would cause). Zero-impact when compression off
+  (gate = 512 for all formats, compressor never runs). Known edge: APNG (ext
+  `.png`) passes the widened gate but stores un-shrunk (`skipped:animated`),
+  bounded by 1024. Getter tests rewritten; gate integration tests added; fake made
+  faithful to the 512 default. No new errcode / i18n / DB / migration / appconfig
+  field. Brief `.octospec/tasks/sticker-oversized-default/brief.md`.
+
 ## 2026-07-09 (sticker-downscale-store)
 
 - **Change** — Task `sticker-downscale-store` (phase two of

--- a/.octospec/tasks/sticker-downscale-store/brief.md
+++ b/.octospec/tasks/sticker-downscale-store/brief.md
@@ -116,5 +116,3 @@ well within `compress_timeout_ms`.
   (`dimension_rejected` unchanged); the accept hard cap is still 1024.
 - `go test ./modules/file/... ./modules/common/...` and `go vet` pass;
   `make i18n-lint` unaffected (no new i18n codes).
-</content>
-</invoke>

--- a/.octospec/tasks/sticker-downscale-store/brief.md
+++ b/.octospec/tasks/sticker-downscale-store/brief.md
@@ -1,0 +1,120 @@
+---
+type: Task
+title: "Task: sticker-downscale-store"
+description: Decouple the sticker compression downscale target from the upload dimension gate via a new sticker.compress_max_dimension setting, so static jpg/png larger than the target (but within the accept ceiling) are downscaled before re-encode+store instead of being stored at full size. Zero-impact default.
+tags: ["sticker", "wire-contract", "external-content", "throttle"]
+timestamp: 2026-07-09T12:30:28Z
+# --- octospec extension fields ---
+slug: sticker-downscale-store
+upstream: TBD
+source: self
+---
+
+# Task: sticker-downscale-store
+
+> Phase-two follow-up on `sticker-upload-compression`. That task shipped the
+> compressor with an `imaging.Fit` downscale step, but wired its target to the
+> SAME value as the upload dimension gate (`upload_max_dimension`). Because the
+> gate already rejects anything above that value, the downscale branch is
+> unreachable on the production path — the compressor only ever re-encodes at the
+> original size. This task decouples the two so "accept a larger static image,
+> downscale it, then store" actually works.
+
+## Goal
+
+Add a new operator-tunable `system_setting` key **`sticker.compress_max_dimension`**
+that is the target single-edge length the compressor downscales static `jpg/png`
+INTO, independent of the `upload_max_dimension` accept gate.
+
+- Semantics: unset / ≤0 → fall back to `StickerUploadMaxDimension()` (i.e. **no
+  extra downscale → byte-for-byte identical to today**). Set → clamped to
+  `[1, StickerUploadMaxDimension()]` (a target may only be **≤** the accept
+  ceiling; a larger value is meaningless and is clamped down).
+- Effect: with `upload_max_dimension=1024` + `compress_max_dimension=512` +
+  `compress_enabled=true`, a static 1024² jpg/png is accepted at the gate,
+  `imaging.Fit`-downscaled to fit 512×512 (aspect-ratio preserved), metadata
+  stripped, re-encoded in its original format, and stored small.
+- **The accept ceiling and the decompression-bomb gate are unchanged.** The
+  `upload_max_dimension` hard cap stays **1024** (decided: keep it — no raising
+  the accept ceiling, so full-decode memory stays ≤ 1024²×4 = 4 MB/frame). This
+  task does NOT accept genuinely huge images; it only lets in-band static images
+  between the target and the accept ceiling be shrunk.
+
+## Background
+
+`modules/file/sticker_compress.go:doCompressStaticSticker` already contains the
+`imaging.Fit(img, maxDim, maxDim, Lanczos)` downscale. The dead-path root cause:
+`stickerLimitsSnapshot.compressParams().MaxDim` returns `s.maxDim` — the very
+value the dimension gate (`modules/file/api.go:426`) enforces — so after the gate
+`w,h ≤ maxDim` always holds and `Fit` never fires. The fix is a one-value
+decouple: give `compressParams()` a separate `compressMaxDim` sourced from the new
+setting, leave the gate reading `maxDim`.
+
+Config plumbing mirrors the sibling sticker keys exactly: canonical schema slice
+entry (`system_setting_schema.go`), a clamp getter on `SystemSettings`
+(`system_settings.go`), read through the 60s snapshot, surfaced in the
+`stickerLimitsSnapshot` locked once per request (review F7 one-request-one-snapshot
+invariant). The compress bench already measured this path — `perf-todo.md`
+"ShrinkTo512" rows (JPEG 1024²→512 ≈ 61 ms, PNG 1024²→512 ≈ 94 ms on x86 Xeon),
+well within `compress_timeout_ms`.
+
+## Load-bearing list
+
+- **`modules/file` sticker upload contract** (touches: `wire-contract`) — response
+  field shape unchanged (`path`/`name`/`size`/`ext`/`sha512`/`sticker_handle`);
+  when downscale runs, `size` and the signed bytes are the post-downscale values,
+  exactly as post-compression today. No new request field. `ext`/`path` unchanged
+  (jpg→jpg, png→png) so the `stickersig` handle and `validateStickerPath`
+  `ext==format` invariant still hold.
+- **Image decode / resource envelope** (touches: `external-content`, `throttle`) —
+  downscale runs inside the existing compressor goroutine, bounded by the SAME
+  timeout + concurrency semaphore; no new resource path. Full-decode memory is
+  still bounded by the UNCHANGED accept gate (`upload_max_dimension` ≤ 1024), the
+  decompression-bomb defense. This task must not weaken that gate or raise its
+  hard cap.
+- **`system_setting` schema + admin write path** (touches: `wire-contract`) — one
+  new int key added to the canonical slice, `Positive:true`, hard-cap enforced by
+  the read-side clamp getter (`≤ upload_max_dimension`). `custom_enabled` /
+  appconfig client contract untouched (this key is server-side only; not exposed
+  via appconfig — clients don't need the compression target for pre-check).
+- **Zero-impact default** — with the key unset (every current deployment),
+  `compressMaxDim == maxDim`, `Fit` still never fires, and behavior is identical
+  to `main`.
+
+## Out of scope
+
+- Raising the `upload_max_dimension` accept hard cap (stays 1024). Accepting
+  genuinely huge images (phone-screenshot scale) to downscale is explicitly NOT
+  done here (would need a memory-budget review + concurrency retune).
+- WebP / GIF / animated compression or downscale — still validate-only (phase-one
+  scope unchanged); a non-compressible format cannot be downscaled.
+- Exposing `compress_max_dimension` through `GET /v1/common/appconfig` — it's a
+  server-side compression knob, not a client pre-check limit.
+- Changing the upload→register contract, `stickersig`, quota, or handle rollout.
+- Migrating `modules/file` to the i18n error envelope (no new error surface added
+  by this task).
+
+## Acceptance
+
+- `sticker.compress_max_dimension` exists in the `system_setting_schema` slice
+  (`Positive:true`, int), is accepted by the manager write path, and is read via a
+  `SystemSettings.StickerCompressMaxDimension()` getter.
+- Clamp getter unit-tested: unset → equals `StickerUploadMaxDimension()`; a value
+  ≤0 or non-numeric → equals `StickerUploadMaxDimension()`; a value above the
+  effective `upload_max_dimension` → clamped down to it; an in-range value is
+  returned verbatim.
+- With `compress_max_dimension` unset (default), upload is byte-for-byte identical
+  to current `main` (regression: same stored bytes / `size` / `sticker_handle` for
+  a static jpg that already fits).
+- With `upload_max_dimension=1024`, `compress_enabled=true`,
+  `compress_max_dimension=512`: a static 1024² jpg/png is stored with both edges
+  ≤ 512 (aspect-ratio preserved), `size` reflects the downscaled bytes, and the
+  `sticker_handle` verifies against the post-downscale stored object.
+- A `gif`/`webp` upload is never downscaled (still `compress_skipped`); a 1024²
+  gif under the accept gate is stored unchanged.
+- The dimension gate still rejects anything above `upload_max_dimension`
+  (`dimension_rejected` unchanged); the accept hard cap is still 1024.
+- `go test ./modules/file/... ./modules/common/...` and `go vet` pass;
+  `make i18n-lint` unaffected (no new i18n codes).
+</content>
+</invoke>

--- a/.octospec/tasks/sticker-downscale-store/context.yaml
+++ b/.octospec/tasks/sticker-downscale-store/context.yaml
@@ -1,0 +1,17 @@
+injected:
+  - id: error-handling
+    source: repo
+    why: matched via wire-contract tag + modules/**/*.go path. No new error surface added — the only rejection path (over_limit) is pre-existing; modules/file stays on c.ResponseError per sibling task. No new i18n codes → make i18n-lint unaffected.
+  - id: rate-limit
+    source: repo
+    why: matched via throttle tag. Compression concurrency semaphore is process-local compute throttle (explicitly allowed exception), NOT a request-frequency Redis counter. Unchanged by this task.
+  - id: trust-boundary
+    source: repo
+    why: matched via external-content tag (image decode of untrusted bytes). "Bound the payload" applies — the decompression-bomb dimension gate (upload_max_dimension, hard cap 1024) is UNCHANGED; new compress_max_dimension only shrinks WITHIN the accept ceiling, so decoded-pixel memory envelope is not widened.
+  - id: testing
+    source: repo
+    why: no-infra snapshot tests for the clamp getter (stickerSnapSettings); api-level integration tests inject fake settings + capturing service, no MySQL/Redis.
+  - id: commit-style
+    source: repo
+    why: English Conventional Commits (feat:).
+brief: .octospec/tasks/sticker-downscale-store/brief.md

--- a/.octospec/tasks/sticker-oversized-default/brief.md
+++ b/.octospec/tasks/sticker-oversized-default/brief.md
@@ -108,4 +108,3 @@ decode/frame), so it needs no tuning.
 - Existing sticker upload/compress tests still pass unchanged.
 - `go test ./modules/file/... ./modules/common/...` and `go vet` pass;
   appconfig tests unaffected; `make i18n-lint` unaffected.
-</content>

--- a/.octospec/tasks/sticker-oversized-default/brief.md
+++ b/.octospec/tasks/sticker-oversized-default/brief.md
@@ -1,0 +1,111 @@
+---
+type: Task
+title: "Task: sticker-oversized-default"
+description: Make ">512px static jpg/png auto-downscale to 512" the built-in default of the sticker compressor — set compress_max_dimension default to 512 and make the upload dimension gate compress-aware (jpg/png accept up to the 1024 hard cap when compression is on, then shrink; gif/webp and compress-off stay gated at upload_max_dimension). compress_enabled stays default-false (gray-scale rollout preserved); zero-impact when off.
+tags: ["sticker", "wire-contract", "external-content", "throttle"]
+timestamp: 2026-07-09T12:58:13Z
+# --- octospec extension fields ---
+slug: sticker-oversized-default
+upstream: sticker-downscale-store (phase two follow-up)
+source: self
+---
+
+# Task: sticker-oversized-default
+
+> Follow-up on `sticker-downscale-store`. That task added
+> `compress_max_dimension` but defaulted it to "= upload ceiling" (no downscale),
+> so an operator had to hand-tune three knobs to get ">512 shrinks to 512". The
+> product intent is simpler: **anything over 512 should be compressed (shrunk to
+> 512)** — and that should be the default behavior of the compressor, not a
+> three-knob opt-in. `compress_enabled` itself stays default-false so the
+> compressor keeps its designed gray-scale rollout (perf-todo playbook).
+
+## Goal
+
+When an operator enables compression (`compress_enabled=true`, the single
+gray-scale switch), a static jpg/png larger than 512px is downscaled to 512 and
+stored — with no further per-deploy tuning. Two changes:
+
+1. **`compress_max_dimension` default → 512** (was "= upload ceiling"). Clamp
+   range becomes `[1, 1024]` (the decoded-pixel hard cap), decoupled from
+   `upload_max_dimension`. It is the jpg/png shrink target.
+
+2. **Compress-aware dimension gate.** The gate's effective max is:
+   - jpg/png **and** `compress_enabled` → the compressible-accept ceiling **1024**
+     (= the existing dimension hard cap), so oversized static images are admitted
+     to be shrunk;
+   - otherwise (gif/webp/animated, or compression off) → `upload_max_dimension`
+     (default 512), unchanged.
+
+   So gif/webp (which cannot be re-encoded/shrunk in phase C) and every upload
+   when compression is off stay gated at 512 exactly as today.
+
+**`upload_max_dimension`, `compress_enabled`, and the appconfig client contract
+are unchanged.** `upload_max_dimension` (default 512) remains the advertised
+limit, the gif/webp gate, and the compress-off gate. This keeps the appconfig
+`StickerUploadLimits.MaxDimension` at 512 (no client-contract change) and keeps
+compress-off byte-for-byte identical to `main`.
+
+## Background
+
+`sticker-downscale-store` already routes `compressParams().MaxDim` from
+`compressMaxDim`; the compressor's `imaging.Fit` shrinks to it. The only reason
+">512 shrinks to 512" was not automatic: `compress_max_dimension` defaulted to
+the accept ceiling (so no shrink) and the gate rejected >512 before the
+compressor could see it. This task flips the default and widens the gate for
+compressible formats only — the compute path is unchanged (the "ShrinkTo512"
+bench rows already measured it: JPEG 1024²→512 ≈ 61 ms, PNG ≈ 94 ms, ≪ timeout).
+
+The compressible-accept ceiling is fixed at the dimension hard cap (1024) rather
+than a new operator knob: it is invisible in stored output (images are shrunk to
+`compress_max_dimension` anyway) and is the memory-safe maximum (1024²×4 = 4 MB
+decode/frame), so it needs no tuning.
+
+## Load-bearing list
+
+- **`modules/file` sticker upload contract** (touches: `wire-contract`) — response
+  shape unchanged; `size`/signed bytes are post-downscale (as today when
+  compression runs). `ext`/`path` unchanged (jpg→jpg, png→png) so `stickersig`
+  handle + `validateStickerPath` `ext==format` hold. appconfig
+  `StickerUploadLimits.MaxDimension` stays `upload_max_dimension` (512) — no
+  client-facing change.
+- **Dimension gate / decompression-bomb defense** (touches: `external-content`) —
+  the gate now admits jpg/png up to 1024 when compression is on, but 1024 is the
+  UNCHANGED decoded-pixel hard cap, so the decode-memory envelope (≤ 1024²×4 =
+  4 MB/frame) is not widened. gif/webp and compress-off stay at 512. The gate is
+  still the only decode-dimension bound; it must fail closed on decode error.
+- **Resource envelope** (touches: `throttle`) — downscale runs in the existing
+  compressor goroutine under the unchanged timeout + concurrency semaphore; no
+  new resource path.
+- **Zero-impact when compression off** — with `compress_enabled=false` (default),
+  the gate is `upload_max_dimension` (512) for every format and the compressor
+  never runs, so behavior is identical to `main`.
+
+## Out of scope
+
+- Changing `compress_enabled`'s default (stays false — gray-scale rollout
+  preserved) or `upload_max_dimension`'s default (stays 512).
+- Making the compressible-accept ceiling an operator knob (fixed at the 1024 hard
+  cap).
+- WebP / GIF / animated downscale (still validate-only; a non-compressible format
+  cannot be shrunk, so >512 of those is rejected at the 512 gate, not stored big).
+- Any appconfig field-shape or advertised-value change.
+- Async/out-of-band compression.
+
+## Acceptance
+
+- `StickerCompressMaxDimension()` unset → 512; a value > 1024 clamps to 1024
+  (with dedup Warn); an in-range `[1,1024]` value is verbatim; value ≤0/non-numeric
+  → 512. (Decoupled from `upload_max_dimension`.)
+- With `compress_enabled=true`, `upload_max_dimension=512` (default),
+  `compress_max_dimension` unset: a static **1024² jpg/png is accepted** (not
+  rejected at 512) and **stored at 512×512** (aspect preserved); `size`/handle
+  reflect the downscaled object.
+- With `compress_enabled=true`: a **>512 gif is rejected** at the 512 gate
+  (`dimension_rejected`) — not stored oversized.
+- With `compress_enabled=false` (default): a **>512 jpg is rejected** at the 512
+  gate (compress-off path unchanged) — zero-impact regression proof.
+- Existing sticker upload/compress tests still pass unchanged.
+- `go test ./modules/file/... ./modules/common/...` and `go vet` pass;
+  appconfig tests unaffected; `make i18n-lint` unaffected.
+</content>

--- a/.octospec/tasks/sticker-oversized-default/context.yaml
+++ b/.octospec/tasks/sticker-oversized-default/context.yaml
@@ -1,0 +1,17 @@
+injected:
+  - id: error-handling
+    source: repo
+    why: matched via wire-contract tag + modules/**/*.go. No new error surface — the dimension-gate rejection is pre-existing (c.ResponseError, file module not i18n-migrated); only the gate's effective max changed. No new i18n codes → make i18n-lint unaffected.
+  - id: rate-limit
+    source: repo
+    why: matched via throttle tag. Downscale runs in the existing compressor goroutine under the unchanged concurrency semaphore + timeout; no request-frequency counter touched.
+  - id: trust-boundary
+    source: repo
+    why: matched via external-content tag (image decode of untrusted bytes). "Bound the payload" — the gate now admits jpg/png up to 1024 when compression is on, but 1024 is the UNCHANGED decoded-pixel hard cap, so the decode-memory envelope is not widened; gif/webp + compress-off stay at 512; gate still fails closed on decode error.
+  - id: testing
+    source: repo
+    why: no-infra snapshot getter tests + api-level integration tests inject fake settings + capturing service (no MySQL/Redis). Fake made faithful to production default (unset compress_max_dimension → 512).
+  - id: commit-style
+    source: repo
+    why: English Conventional Commits (feat:).
+brief: .octospec/tasks/sticker-oversized-default/brief.md

--- a/.octospec/tasks/sticker-oversized-store-guard/brief.md
+++ b/.octospec/tasks/sticker-oversized-store-guard/brief.md
@@ -81,4 +81,3 @@ reference it from `modules/file` so the compressible-accept ceiling can't drift.
 - `stickerCompressAcceptMaxDim == common.StickerUploadMaxDimensionHardCap`.
 - `go test ./modules/file/... ./modules/common/...` (no-infra subset) + `go vet`
   pass; `make i18n-lint` unaffected.
-</content>

--- a/.octospec/tasks/sticker-oversized-store-guard/brief.md
+++ b/.octospec/tasks/sticker-oversized-store-guard/brief.md
@@ -1,0 +1,84 @@
+---
+type: Task
+title: "Task: sticker-oversized-store-guard"
+description: Fix the review-found regression where the compress-aware dimension gate admits >512 jpg/png on the assumption compression downscales them, but every path where compression does NOT actually shrink (nil compressor, skipped on concurrency-saturation/timeout, failed fail-open, or compress_max_dimension > upload_max_dimension) stored the original oversized image. Add a fail-closed post-compression guard so a stored sticker never exceeds upload_max_dimension.
+tags: ["sticker", "wire-contract", "external-content", "throttle"]
+timestamp: 2026-07-09T13:58:59Z
+# --- octospec extension fields ---
+slug: sticker-oversized-store-guard
+upstream: code-review of sticker-oversized-default
+source: self
+---
+
+# Task: sticker-oversized-store-guard
+
+> Fix for the top code-review finding on `sticker-oversized-default`. The
+> compress-aware gate (`effectiveGateDim`) widens the jpg/png dimension gate to
+> 1024 when compression is on, on the premise that the compressor downscales to
+> `compress_max_dimension`. But the compressor is deliberately fail-open, so on
+> concurrency-saturation / timeout / decode-failure — and when `f.compressor`
+> is nil, or `compress_max_dimension > upload_max_dimension` — the original
+> oversized bytes were stored and served to conversation peers, up to 1024²
+> (4× the 512 pixel budget). Old behavior rejected anything >512 outright, so
+> this was a regression in the cross-user decode-DoS protection, reachable under
+> load and deliberately attackable by saturating the compress slots.
+
+## Goal
+
+Enforce the invariant **stored sticker dimension ≤ `upload_max_dimension`, on
+every path**, without giving up compression's quality fail-open:
+
+- The compressor reports the actual output dimension (`OutMaxDim`) for the
+  `compressed`/`over_limit` outcomes.
+- `uploadFile` records the source dimension at the gate and, after the compress
+  block, computes `finalStoredMaxDim` (= compressed output dim on the compressed
+  path, else the source dim) and **rejects** (`compress_oversized_rejected`) if it
+  exceeds `upload_max_dimension`.
+- Dimension stays fail-CLOSED even though compression quality stays fail-open: an
+  oversized upload that could not be shrunk is rejected, never stored big.
+
+Also dedup the two `1024` literals (finding 6): export the common hard cap and
+reference it from `modules/file` so the compressible-accept ceiling can't drift.
+
+## Load-bearing list
+
+- **Decode-DoS / dimension bound** (touches: `external-content`) — restores the
+  guarantee that a stored/served sticker is ≤ `upload_max_dimension` for every
+  format and every compression outcome. The accept gate still admits jpg/png up
+  to the 1024 hard cap (bounded decode memory), but nothing >`upload_max_dimension`
+  is stored.
+- **`modules/file` upload contract** (touches: `wire-contract`) — happy path
+  unchanged (a 1024² jpg still accepted + shrunk to 512 + stored + handle-signed);
+  only the fail-open-oversized paths now reject instead of storing. New terminal
+  metric label `compress_oversized_rejected` (pre-warmed).
+- **Resource envelope** (touches: `throttle`) — the guard is a pure dimension
+  comparison after the existing compress block; no new compute or I/O.
+- **Cross-package constant** — `stickerCompressAcceptMaxDim` now references
+  `common.StickerUploadMaxDimensionHardCap` (single source of truth).
+
+## Out of scope
+
+- Changing `effectiveGateDim`'s widening (the gate correctly admits jpg/png up to
+  1024 to shrink them; the fix is the post-store guard, not narrowing the gate).
+- Clamping `compress_max_dimension ≤ upload_max_dimension` in the getter (kept
+  decoupled; the mis-config is instead caught fail-closed by the guard and flagged
+  in the schema description).
+- appconfig field shape / advertised value (still `upload_max_dimension`; now
+  honest since stored ≤ it).
+- WebP/GIF/animated handling (unchanged; they were never widened).
+
+## Acceptance
+
+- With `compress_enabled=true`, `upload_max_dimension=512`: a 1024² jpg/png is
+  rejected with `compress_oversized_rejected` (not stored) when compression does
+  not shrink it — covered for: `f.compressor==nil`; injected `failed`; injected
+  `skipped:timeout`; and `compress_max_dimension=1024 > upload_max_dimension=512`.
+- The happy path is unbroken: a 1024² jpg with `compress_max_dimension=512` is
+  still accepted, downscaled to 512×512, stored, and handle-verified.
+- gif/webp and compress-off paths unchanged (source ≤ gate ≤ upload_max_dimension,
+  guard never fires).
+- `compress_oversized_rejected` label is registered and pre-warmed to 0.
+- `stickerCompressAcceptMaxDim == common.StickerUploadMaxDimensionHardCap`.
+- `go test ./modules/file/... ./modules/common/...` (no-infra subset) + `go vet`
+  pass; `make i18n-lint` unaffected.
+</content>

--- a/.octospec/tasks/sticker-oversized-store-guard/context.yaml
+++ b/.octospec/tasks/sticker-oversized-store-guard/context.yaml
@@ -1,0 +1,17 @@
+injected:
+  - id: error-handling
+    source: repo
+    why: matched via wire-contract tag + modules/**/*.go. The new rejection uses c.ResponseError (modules/file is unmigrated, out of scope per prior briefs); no new i18n code → make i18n-lint unaffected (verified).
+  - id: rate-limit
+    source: repo
+    why: matched via throttle tag. Guard is a dimension comparison after the existing compress block; no request-frequency counter touched.
+  - id: trust-boundary
+    source: repo
+    why: matched via external-content tag. Core of the fix: "bound the payload" — restore the stored/served dimension bound (≤ upload_max_dimension) that the widened gate had decoupled from actual downscaling; fail-closed on every non-shrunk path.
+  - id: testing
+    source: repo
+    why: api-level guard tests inject fake settings + capturing service + an injected doCompress (fail/slow) to drive the failed/timeout fail-open paths deterministically; no MySQL/Redis.
+  - id: commit-style
+    source: repo
+    why: English Conventional Commits (fix:).
+brief: .octospec/tasks/sticker-oversized-store-guard/brief.md

--- a/.octospec/tasks/sticker-upload-compression/perf-todo.md
+++ b/.octospec/tasks/sticker-upload-compression/perf-todo.md
@@ -54,16 +54,38 @@ go test -run x -bench='BenchmarkDoCompressStaticSticker' -benchmem -benchtime=3s
 本地基线的 3× / 4× 因子的实测校正值。**若结果偏离本地估算 ±50%，需重新
 评估 concurrency / timeout 默认值**。
 
-- [ ] 生产型号 CPU 上跑一遍 bench，把六行结果贴到本文件
-- [ ] 若 PNG 1024² 单帧 > 1000 ms，把 `compress_timeout_ms` 默认调高到
-      3000 ms 再放量，否则频繁 skip:timeout 会让压缩形同虚设
+- [x] 生产型号 CPU 上跑一遍 bench，把六行结果贴到本文件（下表）
+- [x] 若 PNG 1024² 单帧 > 1000 ms，把 `compress_timeout_ms` 默认调高到
+      3000 ms 再放量 —— **不触发**：实测 PNG 1024² re-encode ≈ 196 ms ≪ 1000 ms。
+
+**实测结果（Intel Xeon @ 2.10GHz · 4C / 16GB · go1.25 linux/amd64 · benchtime=3s）：**
+
+| Benchmark                          | ns/op       | ~ms/op | alloc/op | vs M5 |
+| ---------------------------------- | ----------- | ------ | -------- | ----- |
+| JPEG 512² re-encode                | 20,566,280  | ~20.6  | 936 KB   | 1.71× |
+| PNG 512²  re-encode                | 51,683,464  | ~51.7  | 4.5 MB   | 1.72× |
+| JPEG 1024² → Fit(512) + re-encode  | 60,956,346  | ~61.0  | 5.6 MB   | 1.79× |
+| PNG  1024² → Fit(512) + re-encode  | 93,828,696  | ~93.8  | 11.2 MB  | 1.80× |
+| JPEG 1024² re-encode only          | 82,974,862  | ~83.0  | 3.7 MB   | 1.69× |
+| PNG  1024² re-encode only          | 195,586,513 | ~195.6 | 15.6 MB  | 1.76× |
+
+**结论：**
+- **实测慢化仅 ~1.7–1.8×**（文档原用 3× 保守估算）；偏差朝安全方向，**默认值无需重调**。
+- **最坏单帧 PNG 1024² ≈ 196 ms ≪ 1000 ms**，`compress_timeout_ms=2000` 有 ~10× 余量。
+- 单实例吞吐天花板（concurrency=4）：512² JPEG ≈ 200 QPS、512² PNG ≈ 77 QPS、
+  最坏 1024² PNG ≈ 20 QPS，均远高于业务贴纸创建速率；峰值内存 4×15.6 MB ≈ 60 MB 可控。
+- **注意**：当前实现下压缩 `maxDim` 与维度门 `upload_max_dimension` **同源**，`imaging.Fit`
+  在生产路径不触发，故「ShrinkTo512」两行是理论值——实际只命中 512²(默认) 或
+  1024² ReencodeOnly(maxDim 拉满) 两档。若后续做「大图缩小后存」（解耦
+  `compress_max_dimension`），ShrinkTo512 才成为实际路径，其成本已由上表覆盖。
 
 ### 2.2 pprof CPU / heap 剖面
 
-- [ ] `go test -run x -bench='BenchmarkDoCompressStaticSticker_PNG_1024' -cpuprofile=cpu.out`
-  → `go tool pprof -top cpu.out`，确认 CPU 时间主要在 imaging.Encode / Lanczos，
-  没有奇怪的框架开销
-- [ ] `-memprofile=mem.out`：确认 alloc/op 与 bench 报的一致；无异常泄漏
+- [x] `go test -run x -bench='BenchmarkDoCompressStaticSticker_PNG_1024' -cpuprofile=cpu.out`
+  → `go tool pprof -top cpu.out`：CPU ~100% 落在 PNG 编码链（`image/png.filter` 23.8%
+  + `flate.deflate` 34.6% + `paeth`/`abs8`/`filterPaeth` 等），**无异常框架开销**。✅
+- [~] `-benchmem` 已随上表采集 alloc/op（512² PNG 4.5 MB / 1024² PNG 15.6 MB，与 §1 同量级）；
+  独立 `-memprofile` 泄漏剖面待补。
 
 ### 2.3 端到端 HTTP 压测
 

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -183,11 +183,11 @@ var systemSettingSchema = []settingDef{
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.StickerCompressMaxConcurrency()) }},
 	{Category: "sticker", Key: "compress_timeout_ms", Type: settingTypeInt, Description: "单次贴纸压缩超时(毫秒)；超时该请求跳过压缩走原路径(fail-open)；硬上限 10000，默认 2000", Positive: true,
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.StickerCompressTimeoutMs()) }},
-	// compress_max_dimension 是压缩缩放目标边长(仅静态 jpg/png)：大于此边长的图等比
-	// 缩小后再重编码落库。与接收维度门 upload_max_dimension 解耦——门是接收上限+解压
-	// 炸弹防御，此值是缩放目标。默认(未配置)=upload_max_dimension 即不额外缩放(零影响)；
-	// 读侧 clamp 到 ≤ upload_max_dimension(缩放目标不能大于接收上限)，无独立硬上限。
-	{Category: "sticker", Key: "compress_max_dimension", Type: settingTypeInt, Description: "贴纸压缩缩放目标边长(px，仅静态 jpg/png)；大于此值等比缩小后再存；须 ≤ upload_max_dimension，默认=不缩放", Positive: true,
+	// compress_max_dimension 是压缩缩放目标边长(仅静态 jpg/png)：压缩开启后，大于此
+	// 边长的静态图等比缩小到此值再重编码落库。默认 512 —— 让「>512 缩到 512」成为压缩
+	// 开启后的开箱行为。维度门对 jpg/png 在压缩开启时放宽到硬上限 1024(随后缩到此值)，
+	// gif/webp 及压缩关闭时仍受 upload_max_dimension 约束。硬上限 1024。
+	{Category: "sticker", Key: "compress_max_dimension", Type: settingTypeInt, Description: "贴纸压缩缩放目标边长(px，仅静态 jpg/png)；压缩开启后大于此值等比缩小再存；硬上限 1024，默认 512", Positive: true,
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.StickerCompressMaxDimension()) }},
 
 	// Email server config — formerly yaml-only (Support.* in config.go).

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -187,7 +187,7 @@ var systemSettingSchema = []settingDef{
 	// 边长的静态图等比缩小到此值再重编码落库。默认 512 —— 让「>512 缩到 512」成为压缩
 	// 开启后的开箱行为。维度门对 jpg/png 在压缩开启时放宽到硬上限 1024(随后缩到此值)，
 	// gif/webp 及压缩关闭时仍受 upload_max_dimension 约束。硬上限 1024。
-	{Category: "sticker", Key: "compress_max_dimension", Type: settingTypeInt, Description: "贴纸压缩缩放目标边长(px，仅静态 jpg/png)；压缩开启后大于此值等比缩小再存；硬上限 1024，默认 512", Positive: true,
+	{Category: "sticker", Key: "compress_max_dimension", Type: settingTypeInt, Description: "贴纸压缩缩放目标边长(px，仅静态 jpg/png)；压缩开启后大于此值等比缩小再存；硬上限 1024，默认 512。建议 ≤ upload_max_dimension，否则压后仍超 upload_max_dimension 的图会被 fail-closed 拒绝", Positive: true,
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.StickerCompressMaxDimension()) }},
 
 	// Email server config — formerly yaml-only (Support.* in config.go).

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -183,6 +183,12 @@ var systemSettingSchema = []settingDef{
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.StickerCompressMaxConcurrency()) }},
 	{Category: "sticker", Key: "compress_timeout_ms", Type: settingTypeInt, Description: "单次贴纸压缩超时(毫秒)；超时该请求跳过压缩走原路径(fail-open)；硬上限 10000，默认 2000", Positive: true,
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.StickerCompressTimeoutMs()) }},
+	// compress_max_dimension 是压缩缩放目标边长(仅静态 jpg/png)：大于此边长的图等比
+	// 缩小后再重编码落库。与接收维度门 upload_max_dimension 解耦——门是接收上限+解压
+	// 炸弹防御，此值是缩放目标。默认(未配置)=upload_max_dimension 即不额外缩放(零影响)；
+	// 读侧 clamp 到 ≤ upload_max_dimension(缩放目标不能大于接收上限)，无独立硬上限。
+	{Category: "sticker", Key: "compress_max_dimension", Type: settingTypeInt, Description: "贴纸压缩缩放目标边长(px，仅静态 jpg/png)；大于此值等比缩小后再存；须 ≤ upload_max_dimension，默认=不缩放", Positive: true,
+		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.StickerCompressMaxDimension()) }},
 
 	// Email server config — formerly yaml-only (Support.* in config.go).
 	{Category: "support", Key: "email", Type: settingTypeString, Description: "技术支持邮箱（发件人）",

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -829,6 +829,13 @@ const (
 
 	defaultStickerCompressTimeoutMs = 2000
 	stickerCompressTimeoutMsHardCap = 10000
+
+	// defaultStickerCompressMaxDimension is the shrink target the compressor
+	// downscales static jpg/png into. 512 makes ">512 shrinks to 512" the built-in
+	// behavior once compression is enabled. Its hard cap is
+	// stickerUploadMaxDimensionHardCap (1024) — shrink target and compressible-accept
+	// ceiling share the decoded-pixel bound.
+	defaultStickerCompressMaxDimension = 512
 )
 
 // stickerUploadRasterAllowlist 与 modules/file/const.go:stickerUploadExts 保持一致。
@@ -974,38 +981,22 @@ func (s *SystemSettings) StickerCompressTimeoutMs() int {
 }
 
 // StickerCompressMaxDimension returns the target single-edge length the
-// compressor downscales static jpg/png INTO (sticker-downscale-store task).
-// It is decoupled from the upload dimension gate: the gate
-// (StickerUploadMaxDimension) is the ACCEPT ceiling + decompression-bomb bound;
-// this value is the SHRINK target the compressor's imaging.Fit fits into.
+// compressor downscales static jpg/png INTO (sticker-downscale-store /
+// sticker-oversized-default). It is the SHRINK target the compressor's
+// imaging.Fit fits into, decoupled from the upload dimension gate.
 //
-// Semantics:
-//   - unset / ≤0 → falls back to StickerUploadMaxDimension() (no extra downscale;
-//     byte-for-byte identical to pre-task behavior — imaging.Fit never fires
-//     because the value equals the gate that already rejected larger images).
-//   - a value above the effective upload_max_dimension is meaningless (a shrink
-//     target cannot exceed the accept ceiling) → clamped DOWN to it, with a
-//     dedup Warn so the mis-config is operator-observable.
-//   - an in-range [1, upload_max_dimension] value is returned verbatim; static
-//     jpg/png larger than it (but within the gate) get downscaled before store.
-//
-// There is no independent hard cap here: the accept ceiling
-// (StickerUploadMaxDimension, itself hard-capped at 1024) is the upper bound, so
-// the decoded-pixel memory envelope is unchanged by this setting.
+// Read-side clamped to [1, stickerUploadMaxDimensionHardCap] (the 1024
+// decoded-pixel hard cap — the compressible-accept ceiling and the shrink target
+// share that bound); unset / ≤0 / non-numeric falls back to the 512 default,
+// which makes ">512 static jpg/png shrinks to 512" the built-in behavior once
+// compression is enabled. NOT tied to upload_max_dimension: the dimension gate
+// admits compressible formats up to the hard cap (see modules/file
+// effectiveGateDim) and this value only decides how far they are shrunk before
+// store.
 func (s *SystemSettings) StickerCompressMaxDimension() int {
-	ceiling := s.StickerUploadMaxDimension()
-	v := s.getInt("sticker", "compress_max_dimension", 0)
-	if v <= 0 {
-		return ceiling
-	}
-	if v > ceiling {
-		dedupKey := fmt.Sprintf("sticker.compress_max_dimension=%d>%d", v, ceiling)
-		if _, loaded := s.stickerClampWarned.LoadOrStore(dedupKey, struct{}{}); !loaded {
-			s.Warn("system_setting sticker.compress_max_dimension exceeds upload_max_dimension; clamped",
-				zap.Int("configured", v),
-				zap.Int("upload_max_dimension", ceiling))
-		}
-		return ceiling
-	}
-	return v
+	return s.stickerClampIntUpper("sticker.compress_max_dimension",
+		s.getInt("sticker", "compress_max_dimension", defaultStickerCompressMaxDimension),
+		defaultStickerCompressMaxDimension,
+		stickerUploadMaxDimensionHardCap,
+	)
 }

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -819,6 +819,13 @@ const (
 	defaultStickerUploadMaxDimension = 512
 	stickerUploadMaxDimensionHardCap = 1024
 
+	// StickerUploadMaxDimensionHardCap is the exported alias of the decoded-pixel
+	// dimension hard cap (== stickerUploadMaxDimensionHardCap). modules/file
+	// references it so the compressible-accept ceiling shares this single source
+	// of truth rather than re-declaring a bare 1024 literal (review finding: a
+	// hand-synced duplicate could silently drift and re-widen the bomb gate).
+	StickerUploadMaxDimensionHardCap = stickerUploadMaxDimensionHardCap
+
 	defaultStickerCompressEnabled = false
 
 	defaultStickerCompressTargetKB = 1024

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -972,3 +972,40 @@ func (s *SystemSettings) StickerCompressTimeoutMs() int {
 		stickerCompressTimeoutMsHardCap,
 	)
 }
+
+// StickerCompressMaxDimension returns the target single-edge length the
+// compressor downscales static jpg/png INTO (sticker-downscale-store task).
+// It is decoupled from the upload dimension gate: the gate
+// (StickerUploadMaxDimension) is the ACCEPT ceiling + decompression-bomb bound;
+// this value is the SHRINK target the compressor's imaging.Fit fits into.
+//
+// Semantics:
+//   - unset / ≤0 → falls back to StickerUploadMaxDimension() (no extra downscale;
+//     byte-for-byte identical to pre-task behavior — imaging.Fit never fires
+//     because the value equals the gate that already rejected larger images).
+//   - a value above the effective upload_max_dimension is meaningless (a shrink
+//     target cannot exceed the accept ceiling) → clamped DOWN to it, with a
+//     dedup Warn so the mis-config is operator-observable.
+//   - an in-range [1, upload_max_dimension] value is returned verbatim; static
+//     jpg/png larger than it (but within the gate) get downscaled before store.
+//
+// There is no independent hard cap here: the accept ceiling
+// (StickerUploadMaxDimension, itself hard-capped at 1024) is the upper bound, so
+// the decoded-pixel memory envelope is unchanged by this setting.
+func (s *SystemSettings) StickerCompressMaxDimension() int {
+	ceiling := s.StickerUploadMaxDimension()
+	v := s.getInt("sticker", "compress_max_dimension", 0)
+	if v <= 0 {
+		return ceiling
+	}
+	if v > ceiling {
+		dedupKey := fmt.Sprintf("sticker.compress_max_dimension=%d>%d", v, ceiling)
+		if _, loaded := s.stickerClampWarned.LoadOrStore(dedupKey, struct{}{}); !loaded {
+			s.Warn("system_setting sticker.compress_max_dimension exceeds upload_max_dimension; clamped",
+				zap.Int("configured", v),
+				zap.Int("upload_max_dimension", ceiling))
+		}
+		return ceiling
+	}
+	return v
+}

--- a/modules/common/system_settings_sticker_upload_test.go
+++ b/modules/common/system_settings_sticker_upload_test.go
@@ -180,13 +180,13 @@ func TestSystemSettings_StickerCompressEnabled_DBTrueWins(t *testing.T) {
 
 func TestSystemSettings_StickerCompressTargetKB_ClampBehavior(t *testing.T) {
 	tests := map[string]int{
-		"":       defaultStickerCompressTargetKB,      // unset → default
-		"0":      defaultStickerCompressTargetKB,      // ≤0 → default
-		"-1":     defaultStickerCompressTargetKB,      // negative → default
-		"abc":    defaultStickerCompressTargetKB,      // non-numeric → default
-		"999999": stickerCompressTargetKBHardCap,      // over hard cap → hard cap
-		"512":    512,                                 // in-range → verbatim
-		"5120":   stickerCompressTargetKBHardCap,      // exact hard cap → accepted
+		"":       defaultStickerCompressTargetKB, // unset → default
+		"0":      defaultStickerCompressTargetKB, // ≤0 → default
+		"-1":     defaultStickerCompressTargetKB, // negative → default
+		"abc":    defaultStickerCompressTargetKB, // non-numeric → default
+		"999999": stickerCompressTargetKBHardCap, // over hard cap → hard cap
+		"512":    512,                            // in-range → verbatim
+		"5120":   stickerCompressTargetKBHardCap, // exact hard cap → accepted
 	}
 	for in, want := range tests {
 		s := stickerSnapSettings(map[string]string{
@@ -198,13 +198,13 @@ func TestSystemSettings_StickerCompressTargetKB_ClampBehavior(t *testing.T) {
 
 func TestSystemSettings_StickerCompressMaxConcurrency_ClampBehavior(t *testing.T) {
 	tests := map[string]int{
-		"":       defaultStickerCompressMaxConcurrency,
-		"0":      defaultStickerCompressMaxConcurrency,
-		"-2":     defaultStickerCompressMaxConcurrency,
-		"abc":    defaultStickerCompressMaxConcurrency,
-		"999":    stickerCompressMaxConcurrencyHardCap,
-		"8":      8,
-		"32":     stickerCompressMaxConcurrencyHardCap,
+		"":    defaultStickerCompressMaxConcurrency,
+		"0":   defaultStickerCompressMaxConcurrency,
+		"-2":  defaultStickerCompressMaxConcurrency,
+		"abc": defaultStickerCompressMaxConcurrency,
+		"999": stickerCompressMaxConcurrencyHardCap,
+		"8":   8,
+		"32":  stickerCompressMaxConcurrencyHardCap,
 	}
 	for in, want := range tests {
 		s := stickerSnapSettings(map[string]string{
@@ -230,6 +230,58 @@ func TestSystemSettings_StickerCompressTimeoutMs_ClampBehavior(t *testing.T) {
 		})
 		assert.Equalf(t, want, s.StickerCompressTimeoutMs(), "timeout_ms=%q", in)
 	}
+}
+
+// ----- compress_max_dimension (sticker-downscale-store) -----
+
+// 未配置 → 回落接收上限 StickerUploadMaxDimension()（不额外缩放）。默认接收上限
+// 是 512，所以未配 compress_max_dimension 时缩放目标也 = 512。
+func TestSystemSettings_StickerCompressMaxDimension_DefaultsToUploadCeiling(t *testing.T) {
+	s := stickerSnapSettings(nil)
+	assert.Equal(t, s.StickerUploadMaxDimension(), s.StickerCompressMaxDimension())
+	assert.Equal(t, defaultStickerUploadMaxDimension, s.StickerCompressMaxDimension())
+}
+
+// 未配 compress_max_dimension 但接收上限被调高 → 缩放目标跟随接收上限（仍不缩放）。
+func TestSystemSettings_StickerCompressMaxDimension_UnsetTracksRaisedCeiling(t *testing.T) {
+	s := stickerSnapSettings(map[string]string{
+		"sticker.upload_max_dimension": "1024",
+	})
+	assert.Equal(t, 1024, s.StickerCompressMaxDimension())
+}
+
+// ≤0 / 非数字 → 回落接收上限（等价未配置：不缩放，绝不 dark-close）。
+func TestSystemSettings_StickerCompressMaxDimension_NonPositiveFallsBackToCeiling(t *testing.T) {
+	for _, bad := range []string{"0", "-1", "abc", ""} {
+		s := stickerSnapSettings(map[string]string{
+			"sticker.upload_max_dimension":   "1024",
+			"sticker.compress_max_dimension": bad,
+		})
+		assert.Equalf(t, 1024, s.StickerCompressMaxDimension(),
+			"value=%q must fall back to the accept ceiling", bad)
+	}
+}
+
+// 合法且 ≤ 接收上限 → 原样返回（这是真正激活 downscale 的路径）。
+func TestSystemSettings_StickerCompressMaxDimension_InRangeVerbatim(t *testing.T) {
+	s := stickerSnapSettings(map[string]string{
+		"sticker.upload_max_dimension":   "1024",
+		"sticker.compress_max_dimension": "512",
+	})
+	assert.Equal(t, 512, s.StickerCompressMaxDimension())
+}
+
+// 缩放目标 > 接收上限无意义 → clamp 到接收上限，并记一次去重 Warn。
+func TestSystemSettings_StickerCompressMaxDimension_ClampsToUploadCeiling(t *testing.T) {
+	s := stickerSnapSettings(map[string]string{
+		"sticker.upload_max_dimension":   "512",
+		"sticker.compress_max_dimension": "1024",
+	})
+	for i := 0; i < 3; i++ {
+		assert.Equal(t, 512, s.StickerCompressMaxDimension(),
+			"target above the accept ceiling clamps down to it")
+	}
+	assertClampWarnedOnce(t, s, "sticker.compress_max_dimension=1024>512")
 }
 
 // ----- clamp warning dedup (review R6) -----

--- a/modules/common/system_settings_sticker_upload_test.go
+++ b/modules/common/system_settings_sticker_upload_test.go
@@ -232,56 +232,56 @@ func TestSystemSettings_StickerCompressTimeoutMs_ClampBehavior(t *testing.T) {
 	}
 }
 
-// ----- compress_max_dimension (sticker-downscale-store) -----
+// ----- compress_max_dimension (sticker-oversized-default) -----
 
-// 未配置 → 回落接收上限 StickerUploadMaxDimension()（不额外缩放）。默认接收上限
-// 是 512，所以未配 compress_max_dimension 时缩放目标也 = 512。
-func TestSystemSettings_StickerCompressMaxDimension_DefaultsToUploadCeiling(t *testing.T) {
+// 未配置 → 512 默认缩放目标（让「>512 缩到 512」成为压缩开启后的开箱行为）。
+// 与 upload_max_dimension 解耦：即使接收门是 512，缩放目标仍独立取 512 默认。
+func TestSystemSettings_StickerCompressMaxDimension_DefaultsTo512(t *testing.T) {
 	s := stickerSnapSettings(nil)
-	assert.Equal(t, s.StickerUploadMaxDimension(), s.StickerCompressMaxDimension())
-	assert.Equal(t, defaultStickerUploadMaxDimension, s.StickerCompressMaxDimension())
+	assert.Equal(t, defaultStickerCompressMaxDimension, s.StickerCompressMaxDimension())
+	assert.Equal(t, 512, s.StickerCompressMaxDimension())
 }
 
-// 未配 compress_max_dimension 但接收上限被调高 → 缩放目标跟随接收上限（仍不缩放）。
-func TestSystemSettings_StickerCompressMaxDimension_UnsetTracksRaisedCeiling(t *testing.T) {
+// 与 upload_max_dimension 解耦：接收门调低到 384 不影响缩放目标默认 512
+// （缩放目标的上界是 1024 硬上限，不是 upload_max_dimension）。
+func TestSystemSettings_StickerCompressMaxDimension_DecoupledFromUploadDim(t *testing.T) {
 	s := stickerSnapSettings(map[string]string{
-		"sticker.upload_max_dimension": "1024",
-	})
-	assert.Equal(t, 1024, s.StickerCompressMaxDimension())
-}
-
-// ≤0 / 非数字 → 回落接收上限（等价未配置：不缩放，绝不 dark-close）。
-func TestSystemSettings_StickerCompressMaxDimension_NonPositiveFallsBackToCeiling(t *testing.T) {
-	for _, bad := range []string{"0", "-1", "abc", ""} {
-		s := stickerSnapSettings(map[string]string{
-			"sticker.upload_max_dimension":   "1024",
-			"sticker.compress_max_dimension": bad,
-		})
-		assert.Equalf(t, 1024, s.StickerCompressMaxDimension(),
-			"value=%q must fall back to the accept ceiling", bad)
-	}
-}
-
-// 合法且 ≤ 接收上限 → 原样返回（这是真正激活 downscale 的路径）。
-func TestSystemSettings_StickerCompressMaxDimension_InRangeVerbatim(t *testing.T) {
-	s := stickerSnapSettings(map[string]string{
-		"sticker.upload_max_dimension":   "1024",
-		"sticker.compress_max_dimension": "512",
+		"sticker.upload_max_dimension": "384",
 	})
 	assert.Equal(t, 512, s.StickerCompressMaxDimension())
 }
 
-// 缩放目标 > 接收上限无意义 → clamp 到接收上限，并记一次去重 Warn。
-func TestSystemSettings_StickerCompressMaxDimension_ClampsToUploadCeiling(t *testing.T) {
+// ≤0 / 非数字 → 回落默认 512（绝不 dark-close）。
+func TestSystemSettings_StickerCompressMaxDimension_NonPositiveFallsBackToDefault(t *testing.T) {
+	for _, bad := range []string{"0", "-1", "abc", ""} {
+		s := stickerSnapSettings(map[string]string{
+			"sticker.compress_max_dimension": bad,
+		})
+		assert.Equalf(t, defaultStickerCompressMaxDimension, s.StickerCompressMaxDimension(),
+			"value=%q must fall back to 512", bad)
+	}
+}
+
+// 合法且 ≤ 硬上限 1024 → 原样返回（可 > upload_max_dimension，两者解耦）。
+func TestSystemSettings_StickerCompressMaxDimension_InRangeVerbatim(t *testing.T) {
+	for in, want := range map[string]int{"384": 384, "512": 512, "768": 768, "1024": 1024} {
+		s := stickerSnapSettings(map[string]string{
+			"sticker.compress_max_dimension": in,
+		})
+		assert.Equalf(t, want, s.StickerCompressMaxDimension(), "compress_max_dimension=%q", in)
+	}
+}
+
+// 缩放目标 > 1024 硬上限 → clamp 到 1024，并记一次去重 Warn。
+func TestSystemSettings_StickerCompressMaxDimension_ClampsToHardCap(t *testing.T) {
 	s := stickerSnapSettings(map[string]string{
-		"sticker.upload_max_dimension":   "512",
-		"sticker.compress_max_dimension": "1024",
+		"sticker.compress_max_dimension": "4096",
 	})
 	for i := 0; i < 3; i++ {
-		assert.Equal(t, 512, s.StickerCompressMaxDimension(),
-			"target above the accept ceiling clamps down to it")
+		assert.Equal(t, stickerUploadMaxDimensionHardCap, s.StickerCompressMaxDimension(),
+			"target above the 1024 hard cap clamps down to it")
 	}
-	assertClampWarnedOnce(t, s, "sticker.compress_max_dimension=1024>512")
+	assertClampWarnedOnce(t, s, "sticker.compress_max_dimension=4096>1024")
 }
 
 // ----- clamp warning dedup (review R6) -----

--- a/modules/file/api.go
+++ b/modules/file/api.go
@@ -411,6 +411,11 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 	// 内联渲染端撑爆内存，而贴纸会发送给会话对方，等同跨用户 DoS。用 image.DecodeConfig
 	// 只读图像头拿 W×H（不解整图），任一边超过 stickerLimits.maxDim 即拒。此时 ext
 	// 已限定在配置允许的位图集合，对应解码器均已注册。
+	//
+	// stickerSrcMaxDim 记住源图单边像素上限，供压缩块之后的 fail-closed 守卫复用：
+	// 维度门对 jpg/png 放宽到 1024 的前提是"压缩会把它缩到 upload_max_dimension 内"，
+	// 该前提在 compressor==nil / skipped / failed 时不成立，届时用它判断是否拒绝。
+	var stickerSrcMaxDim int
 	if isStickerUpload {
 		cfg, _, decErr := image.DecodeConfig(file)
 		if decErr != nil {
@@ -438,6 +443,7 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 			c.ResponseError(fmt.Errorf("贴纸尺寸不能超过 %d×%d 像素", gateMaxDim, gateMaxDim))
 			return
 		}
+		stickerSrcMaxDim = max(cfg.Width, cfg.Height)
 		// DecodeConfig 读掉了图像头，复位指针供后续签名/上传读取完整内容。
 		if _, err := file.Seek(0, io.SeekStart); err != nil {
 			observeStickerUpload("read_failed")
@@ -477,6 +483,10 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 	// 压缩后的字节）。
 	var uploadReader io.ReadSeeker = file
 	finalSize := fileHeader.Size
+	// finalStoredMaxDim 是最终落库图像的单边像素上限。默认=源尺寸（所有"存原图"
+	// 分支：compressor==nil / skipped / failed / gif-webp / 压缩关闭）；仅 compressed
+	// 分支改成压后实际尺寸。压缩块之后据它 fail-closed 兜住超限图（见块后守卫）。
+	finalStoredMaxDim := stickerSrcMaxDim
 	if isStickerUpload && stickerLimits.compressEnabled && f.compressor != nil {
 		if canCompressStickerExt(ext) {
 			srcBytes, readErr := io.ReadAll(file)
@@ -492,6 +502,7 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 				observeStickerUpload("compress_success")
 				uploadReader = bytes.NewReader(result.Bytes)
 				finalSize = result.Size
+				finalStoredMaxDim = result.OutMaxDim
 				f.Info("贴纸压缩成功",
 					zap.String("uid", loginUID),
 					zap.String("ext", ext),
@@ -532,6 +543,24 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 			// gif/webp 等本期不可压格式：只观测 skip，字节流不变，走 file 直上传路径。
 			observeStickerUpload("compress_skipped")
 		}
+	}
+
+	// sticker-oversized-store-guard：维度门为 jpg/png 放宽到接收硬上限(1024)的前提是
+	// 压缩会把它缩到 upload_max_dimension 内。凡压缩实际未缩到位——compressor==nil
+	// (整块跳过)、skipped(并发满/超时/animated)、failed(fail-open 存原字节)，或
+	// compress_max_dimension 被配得大于 upload_max_dimension 导致压后仍超——此处
+	// fail-closed 拒绝，避免存/发超过接收上限的大图（否则并发饱和/超时下就把 1024²
+	// 未压缩大图推给会话对端，正是维度门要防的跨用户 DoS）。gif/webp 与压缩关闭时门
+	// 未放宽，finalStoredMaxDim=源尺寸≤maxDim，天然不触发。
+	if isStickerUpload && finalStoredMaxDim > stickerLimits.maxDim {
+		observeStickerUpload("compress_oversized_rejected")
+		f.Warn("贴纸维度超出上限且未能压缩缩小，拒绝上传",
+			zap.String("uid", loginUID),
+			zap.String("ext", ext),
+			zap.Int("stored_max_dim", finalStoredMaxDim),
+			zap.Int("max", stickerLimits.maxDim))
+		c.ResponseError(fmt.Errorf("贴纸尺寸不能超过 %d×%d 像素", stickerLimits.maxDim, stickerLimits.maxDim))
+		return
 	}
 
 	var sign []byte

--- a/modules/file/api.go
+++ b/modules/file/api.go
@@ -423,7 +423,10 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 			c.ResponseError(errors.New("无法解析贴纸图像，可能已损坏或格式不受支持"))
 			return
 		}
-		if cfg.Width > stickerLimits.maxDim || cfg.Height > stickerLimits.maxDim {
+		// 维度门对 jpg/png 在压缩开启时放宽到 1024（随后 downscale 到 compress_max_dimension），
+		// gif/webp 及压缩关闭时仍用 upload_max_dimension —— 见 effectiveGateDim。
+		gateMaxDim := stickerLimits.effectiveGateDim(ext)
+		if cfg.Width > gateMaxDim || cfg.Height > gateMaxDim {
 			observeStickerUpload("dimension_rejected")
 			f.Warn("贴纸尺寸超出限制",
 				zap.String("uid", loginUID),
@@ -431,8 +434,8 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 				zap.Int64("size", fileHeader.Size),
 				zap.Int("width", cfg.Width),
 				zap.Int("height", cfg.Height),
-				zap.Int("max", stickerLimits.maxDim))
-			c.ResponseError(fmt.Errorf("贴纸尺寸不能超过 %d×%d 像素", stickerLimits.maxDim, stickerLimits.maxDim))
+				zap.Int("max", gateMaxDim))
+			c.ResponseError(fmt.Errorf("贴纸尺寸不能超过 %d×%d 像素", gateMaxDim, gateMaxDim))
 			return
 		}
 		// DecodeConfig 读掉了图像头，复位指针供后续签名/上传读取完整内容。

--- a/modules/file/api.go
+++ b/modules/file/api.go
@@ -502,7 +502,13 @@ func (f *File) uploadFile(c *wkhttp.Context) {
 				observeStickerUpload("compress_success")
 				uploadReader = bytes.NewReader(result.Bytes)
 				finalSize = result.Size
-				finalStoredMaxDim = result.OutMaxDim
+				// 只在 OutMaxDim 可信(>0)时用它做落库维度守卫；<=0 视为 compressor
+				// 未如约报告尺寸，回退到源尺寸（Fit 只会缩小，源尺寸是安全上界）——
+				// 超限源因此 fail-closed 被拒，而不是盲信 0 放行超限图（review P2
+				// 纵深防御，防未来 compressor 变体静默 fail-open）。
+				if result.OutMaxDim > 0 {
+					finalStoredMaxDim = result.OutMaxDim
+				}
 				f.Info("贴纸压缩成功",
 					zap.String("uid", loginUID),
 					zap.String("ext", ext),

--- a/modules/file/api_sticker_compress_test.go
+++ b/modules/file/api_sticker_compress_test.go
@@ -3,6 +3,7 @@ package file
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"image"
 	"image/color"
 	"image/gif"
@@ -459,17 +460,7 @@ func TestUploadFile_CompressEnabled_LargeImage_DownscaledAndStored(t *testing.T)
 	f, svc := newStickerCompressFile(t, settings)
 	svc.downloadURL = "https://cdn.example.com/dm/sticker/" + uid + "/big.jpg"
 
-	origBytes := makeTestJPEG(t, 1024, 1024, 90)
-	body, contentType := newMultipartFile(t, "big.jpg", origBytes)
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request, _ = http.NewRequest(http.MethodPost, "/v1/file/upload?type=sticker&path=/"+uid+"/big.jpg", body)
-	c.Request.Header.Set("Content-Type", contentType)
-	c.Set("uid", uid)
-	wkCtx := &wkhttp.Context{Context: c}
-
-	f.uploadFile(wkCtx)
+	w := uploadStickerForTest(t, f, uid, "big.jpg", makeTestJPEG(t, 1024, 1024, 90))
 
 	require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
 	dec, format, err := image.Decode(bytes.NewReader(svc.uploaded))
@@ -519,4 +510,109 @@ func TestUploadFile_CompressEnabled_DefaultCompressMaxDim_ShrinksOversizedTo512(
 	bounds := dec.Bounds()
 	assert.Equal(t, 512, bounds.Dx(), "default compress_max_dimension (512) must shrink an 800² source to 512")
 	assert.Equal(t, 512, bounds.Dy())
+}
+
+// ----- sticker-oversized-store-guard regression (review findings 1/2/5) -----
+//
+// 维度门为 jpg/png 放宽到 1024 的前提是压缩会把图缩到 upload_max_dimension 内。以下
+// 用例覆盖"压缩实际没缩到位"的各条 fail-open 路径：都必须 fail-closed 拒绝，绝不把
+// 超过 upload_max_dimension 的大图落库。
+
+// A) compressor==nil：整块跳过，源 1024² jpg 若不拦就会原样落库。
+func TestUploadFile_OversizedGuard_NilCompressorRejects(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const uid = "10000"
+	settings := defaultFakeStickerSettings()
+	settings.compressEnabled = true
+	settings.maxSizeKB = 5120
+	settings.maxDim = 512 // upload_max_dimension
+
+	svc := &capturingMockService{
+		mockService: mockService{downloadURL: "https://cdn.example.com/dm/sticker/" + uid + "/big.jpg"},
+	}
+	f := &File{
+		Log:      log.NewTLog("FileTest"),
+		service:  svc,
+		settings: settings,
+		// compressor 特意留 nil
+	}
+
+	w := uploadStickerForTest(t, f, uid, "big.jpg", makeTestJPEG(t, 1024, 1024, 90))
+
+	require.NotEqualf(t, http.StatusOK, w.Code, "nil compressor must not store an oversized image; body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "512")
+	assert.Nil(t, svc.uploaded, "oversized image must not reach storage on the nil-compressor path")
+}
+
+// B) failed（decode/encode 出错，fail-open 走原字节）：注入必败 doCompress。
+func TestUploadFile_OversizedGuard_CompressFailedRejects(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const uid = "10000"
+	settings := defaultFakeStickerSettings()
+	settings.compressEnabled = true
+	settings.maxSizeKB = 5120
+	settings.maxDim = 512
+	settings.targetKB = 4096
+	settings.timeoutMs = 10_000
+
+	f, svc := newStickerCompressFile(t, settings)
+	f.compressor.doCompress = func(ext string, src []byte, maxDim, targetKB int) (stickerCompressResult, error) {
+		return stickerCompressResult{}, errors.New("injected decode failure")
+	}
+
+	w := uploadStickerForTest(t, f, uid, "big.jpg", makeTestJPEG(t, 1024, 1024, 90))
+
+	require.NotEqualf(t, http.StatusOK, w.Code, "compress-failed fail-open must not store an oversized image; body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "512")
+	assert.Nil(t, svc.uploaded, "oversized image must not reach storage on the failed path")
+}
+
+// C) skipped:timeout（并发饱和/超时同类）：注入慢 doCompress + 极小 timeout。
+func TestUploadFile_OversizedGuard_CompressTimeoutRejects(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const uid = "10000"
+	settings := defaultFakeStickerSettings()
+	settings.compressEnabled = true
+	settings.maxSizeKB = 5120
+	settings.maxDim = 512
+	settings.targetKB = 4096
+	settings.timeoutMs = 5 // 极小超时，doCompress 必然抢占失败
+
+	f, svc := newStickerCompressFile(t, settings)
+	f.compressor.doCompress = func(ext string, src []byte, maxDim, targetKB int) (stickerCompressResult, error) {
+		time.Sleep(300 * time.Millisecond) // 远超 5ms timeout → Compress 返回 skipped:timeout
+		return stickerCompressResult{Outcome: stickerCompressOutcomeCompressed, Bytes: src, Size: int64(len(src)), OutMaxDim: 512}, nil
+	}
+
+	w := uploadStickerForTest(t, f, uid, "big.jpg", makeTestJPEG(t, 1024, 1024, 90))
+
+	require.NotEqualf(t, http.StatusOK, w.Code, "compress-timeout skip must not store an oversized image; body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "512")
+	assert.Nil(t, svc.uploaded, "oversized image must not reach storage on the timeout-skip path")
+}
+
+// D) 配置陷阱：compress_max_dimension(1024) > upload_max_dimension(512)。1024² jpg
+// 压后仍 1024（Fit 目标 1024，不缩），guard 用压后实际尺寸 fail-closed 拒绝。
+func TestUploadFile_OversizedGuard_CompressMaxDimAboveUploadDimRejects(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const uid = "10000"
+	settings := defaultFakeStickerSettings()
+	settings.compressEnabled = true
+	settings.maxSizeKB = 5120
+	settings.maxDim = 512          // upload_max_dimension
+	settings.compressMaxDim = 1024 // 大于 upload_max_dimension 的错误配置
+	settings.targetKB = 4096
+	settings.timeoutMs = 10_000
+
+	f, svc := newStickerCompressFile(t, settings)
+
+	w := uploadStickerForTest(t, f, uid, "big.jpg", makeTestJPEG(t, 1024, 1024, 90))
+
+	require.NotEqualf(t, http.StatusOK, w.Code, "compressed-but-not-shrunk (target>upload_max) must be rejected; body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "512")
+	assert.Nil(t, svc.uploaded, "image compressed but still above upload_max_dimension must not be stored")
 }

--- a/modules/file/api_sticker_compress_test.go
+++ b/modules/file/api_sticker_compress_test.go
@@ -36,6 +36,7 @@ import (
 type fakeStickerSystemSettings struct {
 	maxSizeKB       int
 	maxDim          int
+	compressMaxDim  int // 0 → 回落 maxDim（不缩放），镜像生产 getter 语义
 	allowedFormats  []string
 	compressEnabled bool
 	targetKB        int
@@ -54,6 +55,15 @@ func (f *fakeStickerSystemSettings) StickerCompressEnabled() bool       { return
 func (f *fakeStickerSystemSettings) StickerCompressTargetKB() int       { return f.targetKB }
 func (f *fakeStickerSystemSettings) StickerCompressMaxConcurrency() int { return f.maxConcurrency }
 func (f *fakeStickerSystemSettings) StickerCompressTimeoutMs() int      { return f.timeoutMs }
+
+// StickerCompressMaxDimension 镜像生产 getter：未设置(≤0) → 回落接收上限
+// maxDim（不额外缩放）；设置了则用配置值（测试据此触发 downscale 路径）。
+func (f *fakeStickerSystemSettings) StickerCompressMaxDimension() int {
+	if f.compressMaxDim <= 0 {
+		return f.maxDim
+	}
+	return f.compressMaxDim
+}
 
 // defaultFakeStickerSettings 复刻改动前的硬编码默认值 —— 大多数测试从这里起手，
 // 只按需要覆盖字段（例如 compressEnabled）。
@@ -323,4 +333,96 @@ func TestUploadFile_CompressEnabled_HandleTiesToFinalStoredObject(t *testing.T) 
 	// 花几毫秒的 compressor 结束后 svc.uploaded 已被填。
 	_ = time.Millisecond
 	assert.NotEmpty(t, svc.uploaded, "capturing service must have received bytes")
+}
+
+// TestUploadFile_CompressEnabled_LargeImage_DownscaledAndStored 集成验证
+// sticker-downscale-store：当 compress_max_dimension < upload_max_dimension 时，
+// 一张在接收门内（≤ upload_max_dimension）但大于缩放目标的静态图，被等比缩到
+// 缩放目标后再落库。这条路径在解耦前不可达（门/目标同源，Fit 恒不触发）。
+func TestUploadFile_CompressEnabled_LargeImage_DownscaledAndStored(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+
+	const uid = "10000"
+	settings := defaultFakeStickerSettings()
+	settings.compressEnabled = true
+	settings.maxSizeKB = 5120     // 允许大原图过 size 门
+	settings.maxDim = 1024        // 接收上限：1024² 源图能过维度门
+	settings.compressMaxDim = 512 // 缩放目标：解耦后小于接收门 → 触发 Fit
+	settings.targetKB = 2048      // 缩后 512² 远小于此，不会 over_limit
+	settings.timeoutMs = 10_000   // 远大于编码耗时，避免 flaky
+
+	f, svc := newStickerCompressFile(t, settings)
+	svc.downloadURL = "https://cdn.example.com/dm/sticker/" + uid + "/big.jpg"
+
+	origBytes := makeTestJPEG(t, 1024, 1024, 90)
+	body, contentType := newMultipartFile(t, "big.jpg", origBytes)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/v1/file/upload?type=sticker&path=/"+uid+"/big.jpg", body)
+	c.Request.Header.Set("Content-Type", contentType)
+	c.Set("uid", uid)
+	wkCtx := &wkhttp.Context{Context: c}
+
+	f.uploadFile(wkCtx)
+
+	require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	dec, format, err := image.Decode(bytes.NewReader(svc.uploaded))
+	require.NoError(t, err)
+	assert.Equal(t, "jpeg", format)
+	bounds := dec.Bounds()
+	// 1024² 正方形 Fit 进 512×512 外接框 → 恰好 512×512（等比、不放大）。
+	assert.Equal(t, 512, bounds.Dx(), "long edge must be downscaled to compress_max_dimension")
+	assert.Equal(t, 512, bounds.Dy())
+	assert.LessOrEqual(t, bounds.Dx(), settings.compressMaxDim)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	respSize, _ := resp["size"].(float64)
+	assert.EqualValues(t, len(svc.uploaded), int64(respSize), "resp.size must be the post-downscale byte count")
+	handle, _ := resp["sticker_handle"].(string)
+	path, _ := resp["path"].(string)
+	require.NotEmpty(t, handle)
+	assert.True(t, stickersig.Verify(uid, path, handle),
+		"handle must verify against the post-downscale stored object")
+}
+
+// TestUploadFile_CompressEnabled_UnsetCompressMaxDim_NoDownscale 回归：未配置
+// compress_max_dimension（回落 = upload_max_dimension）时，压缩仍只重编码、绝不
+// 缩放 —— 尺寸逐像素保持，兑现「零影响默认」不变式。
+func TestUploadFile_CompressEnabled_UnsetCompressMaxDim_NoDownscale(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+
+	const uid = "10000"
+	settings := defaultFakeStickerSettings()
+	settings.compressEnabled = true
+	settings.maxSizeKB = 5120
+	settings.maxDim = 1024
+	// compressMaxDim 特意留 0 → fake 回落 maxDim(1024)，与生产 getter 语义一致。
+	settings.targetKB = 4096
+	settings.timeoutMs = 10_000
+
+	f, svc := newStickerCompressFile(t, settings)
+	svc.downloadURL = "https://cdn.example.com/dm/sticker/" + uid + "/keep.jpg"
+
+	origBytes := makeTestJPEG(t, 700, 700, 90) // 700 < 1024 门，且 == 缩放目标下不触发 Fit
+	body, contentType := newMultipartFile(t, "keep.jpg", origBytes)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/v1/file/upload?type=sticker&path=/"+uid+"/keep.jpg", body)
+	c.Request.Header.Set("Content-Type", contentType)
+	c.Set("uid", uid)
+	wkCtx := &wkhttp.Context{Context: c}
+
+	f.uploadFile(wkCtx)
+
+	require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	dec, _, err := image.Decode(bytes.NewReader(svc.uploaded))
+	require.NoError(t, err)
+	bounds := dec.Bounds()
+	assert.Equal(t, 700, bounds.Dx(), "unset compress_max_dimension must NOT downscale")
+	assert.Equal(t, 700, bounds.Dy(), "unset compress_max_dimension must NOT downscale")
 }

--- a/modules/file/api_sticker_compress_test.go
+++ b/modules/file/api_sticker_compress_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"hash/crc32"
 	"image"
 	"image/color"
 	"image/gif"
@@ -18,6 +19,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/pkg/stickersig"
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -340,6 +342,62 @@ func TestUploadFile_CompressEnabled_HandleTiesToFinalStoredObject(t *testing.T) 
 	assert.NotEmpty(t, svc.uploaded, "capturing service must have received bytes")
 }
 
+// makeTestAPNG 生成 (w,h) 的 APNG：先用 image/png 编一张真 PNG（IHDR 声明 w×h，
+// 供 image.DecodeConfig 取维度），再在 IHDR 之后、IDAT 之前插入一个 acTL chunk，
+// 让 isAnimatedPNGSource 判定为动图（acTL 只按结构识别、不校验 CRC）。
+// PNG 布局固定：8B 签名 + IHDR chunk(4 len + 4 "IHDR" + 13 data + 4 crc = 25B)。
+func makeTestAPNG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	// 复用 makeTestPNG 生成真 PNG（签名 + IHDR + … + IDAT + IEND），再在 IHDR 之后、
+	// IDAT 之前插入一个 acTL chunk 使其成为 APNG。CRC 必须**有效**：Go 的 image.Decode
+	// 会校验未知 chunk 的 CRC，若为 0 整图解码失败——那样一旦动图检测被破坏，图会走
+	// decode-failed 而非 compressed，测试就无法区分"识别为动图"与"字节损坏"（review）。
+	// PNG 布局固定：8B 签名 + IHDR chunk(4 len + 4 "IHDR" + 13 data + 4 crc = 25B)。
+	b := makeTestPNG(t, w, h)
+	const ihdrEnd = 8 + 25
+	require.Greater(t, len(b), ihdrEnd, "encoded PNG shorter than signature+IHDR")
+	data := []byte{
+		0x00, 0x00, 0x00, 0x01, // num_frames = 1
+		0x00, 0x00, 0x00, 0x00, // num_plays = 0
+	}
+	crc := crc32.ChecksumIEEE(append([]byte("acTL"), data...)) // CRC 覆盖 type+data
+	actl := []byte{0x00, 0x00, 0x00, 0x08, 'a', 'c', 'T', 'L'}
+	actl = append(actl, data...)
+	actl = append(actl, byte(crc>>24), byte(crc>>16), byte(crc>>8), byte(crc))
+	out := make([]byte, 0, len(b)+len(actl))
+	out = append(out, b[:ihdrEnd]...)
+	out = append(out, actl...)
+	out = append(out, b[ihdrEnd:]...)
+	return out
+}
+
+// 命名回归（review 共识）：一张 >512 的 APNG（.png 扩展名）通过放宽到 1024 的维度门，
+// 但压缩阶段被识别为 animated → skipped:animated（无法缩放），落库维度守卫据源尺寸
+// fail-closed 拒绝。用 compress_oversized_rejected 计数正向断言"是守卫拒的、不是维度门
+// 拒的"（两处错误文案相同，无法只靠 body 区分）；有效 acTL CRC 保证一旦动图检测失效，
+// 图会解码→缩到 512→落库(200) 而非静默通过本用例。
+func TestUploadFile_OversizedGuard_AnimatedPNGRejected(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const uid = "10000"
+	settings := defaultFakeStickerSettings()
+	settings.compressEnabled = true
+	settings.maxSizeKB = 5120
+	settings.maxDim = 512
+	settings.timeoutMs = 10_000
+
+	f, svc := newStickerCompressFile(t, settings)
+
+	before := testutil.ToFloat64(metricStickerUploadTotal.WithLabelValues("compress_oversized_rejected"))
+	w := uploadStickerForTest(t, f, uid, "anim.png", makeTestAPNG(t, 600, 600))
+
+	require.NotEqualf(t, http.StatusOK, w.Code, "a 600² APNG can't be shrunk and must be rejected, not stored; body: %s", w.Body.String())
+	assert.Nil(t, svc.uploaded, "oversized animated PNG must not reach storage")
+	after := testutil.ToFloat64(metricStickerUploadTotal.WithLabelValues("compress_oversized_rejected"))
+	assert.Equal(t, float64(1), after-before,
+		"must be rejected by the oversized store-guard, not the dimension gate")
+}
+
 // makeTestGIF 生成 (w,h) 的单帧 GIF；gif.Encode 会把 RGBA 量化到调色板。
 func makeTestGIF(t *testing.T, w, h int) []byte {
 	t.Helper()
@@ -518,7 +576,7 @@ func TestUploadFile_CompressEnabled_DefaultCompressMaxDim_ShrinksOversizedTo512(
 // 用例覆盖"压缩实际没缩到位"的各条 fail-open 路径：都必须 fail-closed 拒绝，绝不把
 // 超过 upload_max_dimension 的大图落库。
 
-// A) compressor==nil：整块跳过，源 1024² jpg 若不拦就会原样落库。
+// compressor==nil：整块跳过，源 1024² jpg 若不拦就会原样落库。
 func TestUploadFile_OversizedGuard_NilCompressorRejects(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -545,7 +603,7 @@ func TestUploadFile_OversizedGuard_NilCompressorRejects(t *testing.T) {
 	assert.Nil(t, svc.uploaded, "oversized image must not reach storage on the nil-compressor path")
 }
 
-// B) failed（decode/encode 出错，fail-open 走原字节）：注入必败 doCompress。
+// failed（decode/encode 出错，fail-open 走原字节）：注入必败 doCompress。
 func TestUploadFile_OversizedGuard_CompressFailedRejects(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -569,7 +627,7 @@ func TestUploadFile_OversizedGuard_CompressFailedRejects(t *testing.T) {
 	assert.Nil(t, svc.uploaded, "oversized image must not reach storage on the failed path")
 }
 
-// C) skipped:timeout（并发饱和/超时同类）：注入慢 doCompress + 极小 timeout。
+// skipped:timeout（并发饱和/超时同类）：注入慢 doCompress + 极小 timeout。
 func TestUploadFile_OversizedGuard_CompressTimeoutRejects(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -594,7 +652,39 @@ func TestUploadFile_OversizedGuard_CompressTimeoutRejects(t *testing.T) {
 	assert.Nil(t, svc.uploaded, "oversized image must not reach storage on the timeout-skip path")
 }
 
-// D) 配置陷阱：compress_max_dimension(1024) > upload_max_dimension(512)。1024² jpg
+// 纵深防御（review P2）：compressed 结局但 OutMaxDim<=0（未来 compressor 变体忘填 /
+// 返回 0），守卫不可盲信 —— 回退到源尺寸判断，超限即拒。注入 OutMaxDim=0 + 1024² 源
+// → 必须 fail-closed 拒绝，而不是把未知尺寸的图放行落库。（注入的 doCompress 直接返回
+// compressed，忽略 maxDim/targetKB，故本用例不设 compressMaxDim/targetKB。）
+func TestUploadFile_OversizedGuard_CompressedZeroOutMaxDimRejects(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const uid = "10000"
+	settings := defaultFakeStickerSettings()
+	settings.compressEnabled = true
+	settings.maxSizeKB = 5120
+	settings.maxDim = 512
+	settings.timeoutMs = 10_000
+
+	f, svc := newStickerCompressFile(t, settings)
+	// 注入"压缩成功但没报告输出尺寸"的 compressor（OutMaxDim 留 0）。
+	f.compressor.doCompress = func(ext string, src []byte, maxDim, targetKB int) (stickerCompressResult, error) {
+		return stickerCompressResult{
+			Outcome:   stickerCompressOutcomeCompressed,
+			Bytes:     src,
+			Size:      int64(len(src)),
+			OutMaxDim: 0, // 关键：未填充
+		}, nil
+	}
+
+	w := uploadStickerForTest(t, f, uid, "x.jpg", makeTestJPEG(t, 1024, 1024, 90))
+
+	require.NotEqualf(t, http.StatusOK, w.Code, "compressed outcome with OutMaxDim<=0 on an oversized source must fail closed; body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "512")
+	assert.Nil(t, svc.uploaded, "must not store when OutMaxDim is untrustworthy on an oversized source")
+}
+
+// 配置陷阱：compress_max_dimension(1024) > upload_max_dimension(512)。1024² jpg
 // 压后仍 1024（Fit 目标 1024，不缩），guard 用压后实际尺寸 fail-closed 拒绝。
 func TestUploadFile_OversizedGuard_CompressMaxDimAboveUploadDimRejects(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/modules/file/api_sticker_compress_test.go
+++ b/modules/file/api_sticker_compress_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"image"
+	"image/color"
+	"image/gif"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -56,11 +58,11 @@ func (f *fakeStickerSystemSettings) StickerCompressTargetKB() int       { return
 func (f *fakeStickerSystemSettings) StickerCompressMaxConcurrency() int { return f.maxConcurrency }
 func (f *fakeStickerSystemSettings) StickerCompressTimeoutMs() int      { return f.timeoutMs }
 
-// StickerCompressMaxDimension 镜像生产 getter：未设置(≤0) → 回落接收上限
-// maxDim（不额外缩放）；设置了则用配置值（测试据此触发 downscale 路径）。
+// StickerCompressMaxDimension 镜像生产 getter：未设置(≤0) → 512 默认缩放目标；
+// 设置了则用配置值（测试据此触发/关闭 downscale 路径）。
 func (f *fakeStickerSystemSettings) StickerCompressMaxDimension() int {
 	if f.compressMaxDim <= 0 {
-		return f.maxDim
+		return 512 // = common.defaultStickerCompressMaxDimension
 	}
 	return f.compressMaxDim
 }
@@ -163,9 +165,11 @@ func TestUploadFile_CompressEnabled_LargeJPEG_UsesCompressedBytes(t *testing.T) 
 	settings := defaultFakeStickerSettings()
 	settings.compressEnabled = true
 	// 允许 5MB 原始大小 + 1024px 维度，让 900px 源图能通过维度门。压缩靠
-	// quality 降低（95→85）+ 去元数据 shrink，无需 downscale。
+	// quality 降低（95→85）+ 去元数据 shrink，无需 downscale：显式把缩放目标设成
+	// 1024（≥源 900）以隔离本用例只测重编码、不测 downscale。
 	settings.maxSizeKB = 5120
 	settings.maxDim = 1024
+	settings.compressMaxDim = 1024
 	settings.targetKB = 512
 
 	f, svc := newStickerCompressFile(t, settings)
@@ -335,6 +339,106 @@ func TestUploadFile_CompressEnabled_HandleTiesToFinalStoredObject(t *testing.T) 
 	assert.NotEmpty(t, svc.uploaded, "capturing service must have received bytes")
 }
 
+// makeTestGIF 生成 (w,h) 的单帧 GIF；gif.Encode 会把 RGBA 量化到调色板。
+func makeTestGIF(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for x := 0; x < w; x++ {
+		for y := 0; y < h; y++ {
+			img.Set(x, y, color.RGBA{byte(x % 255), byte(y % 255), 128, 255})
+		}
+	}
+	var buf bytes.Buffer
+	require.NoError(t, gif.Encode(&buf, img, nil))
+	return buf.Bytes()
+}
+
+// uploadStickerForTest 跑一次贴纸上传，返回 recorder 供断言。集中构造 multipart +
+// gin 上下文，避免每个门测试重复样板。
+func uploadStickerForTest(t *testing.T, f *File, uid, name string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	mbody, contentType := newMultipartFile(t, name, body)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/v1/file/upload?type=sticker&path=/"+uid+"/"+name, mbody)
+	c.Request.Header.Set("Content-Type", contentType)
+	c.Set("uid", uid)
+	f.uploadFile(&wkhttp.Context{Context: c})
+	return w
+}
+
+// TestUploadFile_OversizedJPEG_AcceptedAndDownscaled_DefaultUploadDim 是
+// sticker-oversized-default 的核心验证：upload_max_dimension 保持默认 512，但压缩
+// 开启后一张 1024² jpg **不再被 512 门拒**（可压格式放宽到 1024 接收），并被 downscale
+// 到 compress_max_dimension=512 落库。
+func TestUploadFile_OversizedJPEG_AcceptedAndDownscaled_DefaultUploadDim(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+
+	const uid = "10000"
+	settings := defaultFakeStickerSettings()
+	settings.compressEnabled = true
+	settings.maxSizeKB = 5120     // 允许大原图过 size 门
+	settings.maxDim = 512         // upload_max_dimension 保持默认 512
+	settings.compressMaxDim = 512 // 缩放目标 512
+	settings.targetKB = 2048
+	settings.timeoutMs = 10_000
+
+	f, svc := newStickerCompressFile(t, settings)
+	svc.downloadURL = "https://cdn.example.com/dm/sticker/" + uid + "/big.jpg"
+
+	w := uploadStickerForTest(t, f, uid, "big.jpg", makeTestJPEG(t, 1024, 1024, 90))
+
+	require.Equalf(t, http.StatusOK, w.Code, "1024² jpg must be accepted (gate widened to 1024) not rejected at 512; body: %s", w.Body.String())
+	dec, format, err := image.Decode(bytes.NewReader(svc.uploaded))
+	require.NoError(t, err)
+	assert.Equal(t, "jpeg", format)
+	b := dec.Bounds()
+	assert.Equal(t, 512, b.Dx(), "long edge must be downscaled to compress_max_dimension (512)")
+	assert.Equal(t, 512, b.Dy())
+}
+
+// TestUploadFile_OversizedGIF_RejectedWhenCompressOn 验证：gif 无法缩放，压缩开启
+// 也**不**放宽接收门 —— 一张 >512 的 gif 仍在 upload_max_dimension(512) 门被拒，
+// 不会被当作大图存进来。
+func TestUploadFile_OversizedGIF_RejectedWhenCompressOn(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const uid = "10000"
+	settings := defaultFakeStickerSettings()
+	settings.compressEnabled = true
+	settings.maxSizeKB = 5120
+	settings.maxDim = 512 // gif 仍受此约束
+
+	f, svc := newStickerCompressFile(t, settings)
+
+	w := uploadStickerForTest(t, f, uid, "big.gif", makeTestGIF(t, 600, 600))
+
+	require.NotEqualf(t, http.StatusOK, w.Code, "600² gif must be rejected at the 512 gate; body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "512")
+	assert.Nil(t, svc.uploaded, "rejected gif must not reach storage")
+}
+
+// TestUploadFile_OversizedJPEG_RejectedWhenCompressOff 是零影响回归：压缩关闭时，
+// 即使 jpg 可压，也**不**放宽接收门 —— >512 jpg 仍被 512 门拒，与改动前一致。
+func TestUploadFile_OversizedJPEG_RejectedWhenCompressOff(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const uid = "10000"
+	settings := defaultFakeStickerSettings()
+	settings.compressEnabled = false // 关键：压缩关闭
+	settings.maxSizeKB = 5120
+	settings.maxDim = 512
+
+	f, svc := newStickerCompressFile(t, settings)
+
+	w := uploadStickerForTest(t, f, uid, "big.jpg", makeTestJPEG(t, 600, 600, 90))
+
+	require.NotEqualf(t, http.StatusOK, w.Code, "with compress off, >512 jpg must be rejected at 512 (zero-impact); body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "512")
+	assert.Nil(t, svc.uploaded, "rejected jpg must not reach storage")
+}
+
 // TestUploadFile_CompressEnabled_LargeImage_DownscaledAndStored 集成验证
 // sticker-downscale-store：当 compress_max_dimension < upload_max_dimension 时，
 // 一张在接收门内（≤ upload_max_dimension）但大于缩放目标的静态图，被等比缩到
@@ -388,10 +492,10 @@ func TestUploadFile_CompressEnabled_LargeImage_DownscaledAndStored(t *testing.T)
 		"handle must verify against the post-downscale stored object")
 }
 
-// TestUploadFile_CompressEnabled_UnsetCompressMaxDim_NoDownscale 回归：未配置
-// compress_max_dimension（回落 = upload_max_dimension）时，压缩仍只重编码、绝不
-// 缩放 —— 尺寸逐像素保持，兑现「零影响默认」不变式。
-func TestUploadFile_CompressEnabled_UnsetCompressMaxDim_NoDownscale(t *testing.T) {
+// TestUploadFile_CompressEnabled_DefaultCompressMaxDim_ShrinksOversizedTo512 是
+// sticker-oversized-default 的默认行为验证：**未配置** compress_max_dimension（回落
+// 默认 512）时，压缩开启后一张 800² jpg 被自动缩到 512 —— 无需运营额外调旋钮。
+func TestUploadFile_CompressEnabled_DefaultCompressMaxDim_ShrinksOversizedTo512(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
 
@@ -399,30 +503,20 @@ func TestUploadFile_CompressEnabled_UnsetCompressMaxDim_NoDownscale(t *testing.T
 	settings := defaultFakeStickerSettings()
 	settings.compressEnabled = true
 	settings.maxSizeKB = 5120
-	settings.maxDim = 1024
-	// compressMaxDim 特意留 0 → fake 回落 maxDim(1024)，与生产 getter 语义一致。
+	settings.maxDim = 512 // upload_max_dimension 保持默认
+	// compressMaxDim 特意留 0 → fake 回落默认 512，与生产 getter 语义一致。
 	settings.targetKB = 4096
 	settings.timeoutMs = 10_000
 
 	f, svc := newStickerCompressFile(t, settings)
-	svc.downloadURL = "https://cdn.example.com/dm/sticker/" + uid + "/keep.jpg"
+	svc.downloadURL = "https://cdn.example.com/dm/sticker/" + uid + "/big.jpg"
 
-	origBytes := makeTestJPEG(t, 700, 700, 90) // 700 < 1024 门，且 == 缩放目标下不触发 Fit
-	body, contentType := newMultipartFile(t, "keep.jpg", origBytes)
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request, _ = http.NewRequest(http.MethodPost, "/v1/file/upload?type=sticker&path=/"+uid+"/keep.jpg", body)
-	c.Request.Header.Set("Content-Type", contentType)
-	c.Set("uid", uid)
-	wkCtx := &wkhttp.Context{Context: c}
-
-	f.uploadFile(wkCtx)
+	w := uploadStickerForTest(t, f, uid, "big.jpg", makeTestJPEG(t, 800, 800, 90))
 
 	require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
 	dec, _, err := image.Decode(bytes.NewReader(svc.uploaded))
 	require.NoError(t, err)
 	bounds := dec.Bounds()
-	assert.Equal(t, 700, bounds.Dx(), "unset compress_max_dimension must NOT downscale")
-	assert.Equal(t, 700, bounds.Dy(), "unset compress_max_dimension must NOT downscale")
+	assert.Equal(t, 512, bounds.Dx(), "default compress_max_dimension (512) must shrink an 800² source to 512")
+	assert.Equal(t, 512, bounds.Dy())
 }

--- a/modules/file/sticker_compress.go
+++ b/modules/file/sticker_compress.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/disintegration/imaging"
 )
 
@@ -78,11 +79,12 @@ func (s stickerLimitsSnapshot) compressParams() stickerCompressParams {
 }
 
 // stickerCompressAcceptMaxDim 是「压缩开启时可压格式(jpg/png)」的接收维度上限：
-// 放宽到与 common.stickerUploadMaxDimensionHardCap 一致的 1024（解码像素硬上限），
-// 让 >upload_max_dimension 的静态图能被接收进来随后 downscale 到 compressMaxDim。
+// 放宽到解码像素硬上限（common.StickerUploadMaxDimensionHardCap = 1024），让
+// >upload_max_dimension 的静态图能被接收进来随后 downscale 到 compressMaxDim。
 // 保持在硬上限而非另设旋钮：它在落库输出里不可见（图恒被缩到 compressMaxDim），
-// 且 1024²×4=4MB/帧是内存安全上界，无需运营调。若 common 侧硬上限变动需同步。
-const stickerCompressAcceptMaxDim = 1024
+// 且 1024²×4=4MB/帧是内存安全上界，无需运营调。直接引用 common 导出常量，单一
+// 真源，避免两处 1024 字面量漂移（review finding：漂移会悄悄再放宽 bomb 门）。
+const stickerCompressAcceptMaxDim = common.StickerUploadMaxDimensionHardCap
 
 // effectiveGateDim 返回本次上传的维度门上限（sticker-oversized-default）。
 // 可压格式(jpg/png)且压缩开启时放宽到 stickerCompressAcceptMaxDim（随后 Fit 到
@@ -210,6 +212,11 @@ type stickerCompressResult struct {
 	Reason  string // 细分原因（"disabled"/"format"/"concurrency_saturated"/"timeout"/decode 或 encode 错误信息）
 	Bytes   []byte // 仅 Outcome=="compressed" 时有效
 	Size    int64  // 结果字节数（compressed）或压后大小（over_limit）
+	// OutMaxDim 是压缩后图像的单边像素上限（max(w,h)），仅 compressed/over_limit
+	// 有效（其余分支为 0，caller 用源图尺寸兜底）。caller 用它做「落库维度不得超过
+	// upload_max_dimension」的 fail-closed 守卫：Fit 目标(compressMaxDim)可能 ≥ 源边
+	// 或被配置成大于 upload_max_dimension，只有实际压后尺寸才能证明缩到了上限内。
+	OutMaxDim int
 }
 
 // stickerCompressor 承担压缩流程 + 稳定性闸。零值不可用；用 newStickerCompressor。
@@ -416,15 +423,21 @@ func doCompressStaticSticker(ext string, src []byte, maxDim, targetKB int) (stic
 
 	out := buf.Bytes()
 	size := int64(len(out))
+	// 压后实际单边像素上限（缩放/不缩放都取最终 img 尺寸），供 caller 的
+	// 「落库维度不得超过 upload_max_dimension」fail-closed 守卫使用。
+	ob := img.Bounds()
+	outMaxDim := max(ob.Dx(), ob.Dy())
 	if targetKB > 0 && size > int64(targetKB)*1024 {
 		return stickerCompressResult{
-			Outcome: stickerCompressOutcomeOverLimit,
-			Size:    size,
+			Outcome:   stickerCompressOutcomeOverLimit,
+			Size:      size,
+			OutMaxDim: outMaxDim,
 		}, nil
 	}
 	return stickerCompressResult{
-		Outcome: stickerCompressOutcomeCompressed,
-		Bytes:   out,
-		Size:    size,
+		Outcome:   stickerCompressOutcomeCompressed,
+		Bytes:     out,
+		Size:      size,
+		OutMaxDim: outMaxDim,
 	}, nil
 }

--- a/modules/file/sticker_compress.go
+++ b/modules/file/sticker_compress.go
@@ -42,10 +42,10 @@ type stickerLimitsSnapshot struct {
 	// api.go 的维度门拒绝，永不进压缩管线。
 	maxDim         int
 	allowedFormats map[string]bool
-	// compressMaxDim 是压缩阶段 imaging.Fit 的缩放目标边长（sticker-downscale-store
-	// 任务），与 maxDim **解耦**：静态 jpg/png 若原边长 > compressMaxDim（但 ≤ maxDim
-	// 已过门），会被等比缩到 compressMaxDim 外接框内再重编码。默认 compressMaxDim ==
-	// maxDim 时 Fit 不触发（逐字节兼容压缩前行为）。
+	// compressMaxDim 是压缩阶段 imaging.Fit 的缩放目标边长，与 maxDim 解耦（默认 512）：
+	// 压缩开启时，jpg/png 经 effectiveGateDim 放宽接收到 1024，凡原边长 > compressMaxDim
+	// 者等比缩到 compressMaxDim 外接框内再重编码；compressMaxDim ≥ 源边长时 Fit 不触发
+	// （仅重编码）。gif/webp 及压缩关闭时不走此路径。
 	compressMaxDim         int
 	compressEnabled        bool
 	compressTargetKB       int
@@ -75,6 +75,30 @@ func (s stickerLimitsSnapshot) compressParams() stickerCompressParams {
 		MaxConcurrency: s.compressMaxConcurrency,
 		TimeoutMs:      s.compressTimeoutMs,
 	}
+}
+
+// stickerCompressAcceptMaxDim 是「压缩开启时可压格式(jpg/png)」的接收维度上限：
+// 放宽到与 common.stickerUploadMaxDimensionHardCap 一致的 1024（解码像素硬上限），
+// 让 >upload_max_dimension 的静态图能被接收进来随后 downscale 到 compressMaxDim。
+// 保持在硬上限而非另设旋钮：它在落库输出里不可见（图恒被缩到 compressMaxDim），
+// 且 1024²×4=4MB/帧是内存安全上界，无需运营调。若 common 侧硬上限变动需同步。
+const stickerCompressAcceptMaxDim = 1024
+
+// effectiveGateDim 返回本次上传的维度门上限（sticker-oversized-default）。
+// 可压格式(jpg/png)且压缩开启时放宽到 stickerCompressAcceptMaxDim（随后 Fit 到
+// compressMaxDim）；否则——非可压格式(gif/webp) 或压缩关闭——用 maxDim(=
+// upload_max_dimension)。因此压缩关闭时对所有格式恒等于旧的 512 门（逐字节兼容），
+// 大 gif/webp 也不会因放宽而被存成大图。
+//
+// 已知边界：APNG 的扩展名是 .png，canCompressStickerExt 为 true，故会通过放宽门；
+// 但压缩阶段 isAnimatedPNGSource 识别后走 skipped:animated，原样落库（不缩放）。
+// 即一张 513–1024² 的 APNG 会以原尺寸存，比 512 大 —— 但仍 ≤ 解码硬上限 1024²，
+// 内存有界。APNG 罕见，此边界可接受；如需收紧可在门处加 acTL 扫描（暂不做）。
+func (s stickerLimitsSnapshot) effectiveGateDim(ext string) int {
+	if s.compressEnabled && canCompressStickerExt(ext) {
+		return stickerCompressAcceptMaxDim
+	}
+	return s.maxDim
 }
 
 // stickerLimits 从 File 挂的 SystemSettings 派生本次请求的限制值；未挂 settings

--- a/modules/file/sticker_compress.go
+++ b/modules/file/sticker_compress.go
@@ -37,9 +37,16 @@ import (
 // stickerCompressParams 拿到同一份值，确保 dimension 校验用的 maxDim 与
 // 压缩阶段 Fit 用的 maxDim 严格同源。
 type stickerLimitsSnapshot struct {
-	maxSize                int64
-	maxDim                 int
-	allowedFormats         map[string]bool
+	maxSize int64
+	// maxDim 是上传接收维度门（+ 解压炸弹防御）用的接收上限：任一边超过即在
+	// api.go 的维度门拒绝，永不进压缩管线。
+	maxDim         int
+	allowedFormats map[string]bool
+	// compressMaxDim 是压缩阶段 imaging.Fit 的缩放目标边长（sticker-downscale-store
+	// 任务），与 maxDim **解耦**：静态 jpg/png 若原边长 > compressMaxDim（但 ≤ maxDim
+	// 已过门），会被等比缩到 compressMaxDim 外接框内再重编码。默认 compressMaxDim ==
+	// maxDim 时 Fit 不触发（逐字节兼容压缩前行为）。
+	compressMaxDim         int
 	compressEnabled        bool
 	compressTargetKB       int
 	compressMaxConcurrency int
@@ -58,9 +65,12 @@ type stickerCompressParams struct {
 
 // compressParams 从 snapshot 派生 Compress 需要的 4 个值。集中在这里派生
 // 是为了让 caller 端一处清晰地展现"这四个值都来自同一份 snapshot"。
+// MaxDim 取 compressMaxDim（缩放目标）而非 maxDim（接收门）—— 这是
+// sticker-downscale-store 解耦的关键：让 imaging.Fit 能把 (compressMaxDim, maxDim]
+// 区间内的静态 jpg/png 缩到 compressMaxDim，而不再因门/目标同源恒不触发。
 func (s stickerLimitsSnapshot) compressParams() stickerCompressParams {
 	return stickerCompressParams{
-		MaxDim:         s.maxDim,
+		MaxDim:         s.compressMaxDim,
 		TargetKB:       s.compressTargetKB,
 		MaxConcurrency: s.compressMaxConcurrency,
 		TimeoutMs:      s.compressTimeoutMs,
@@ -78,8 +88,10 @@ func (f *File) stickerLimits() stickerLimitsSnapshot {
 			allow[k] = v
 		}
 		return stickerLimitsSnapshot{
-			maxSize:                StickerMaxFileSize,
-			maxDim:                 StickerMaxDimension,
+			maxSize: StickerMaxFileSize,
+			maxDim:  StickerMaxDimension,
+			// nil-settings 回落：compressMaxDim == maxDim → Fit 不触发，保持老行为。
+			compressMaxDim:         StickerMaxDimension,
 			allowedFormats:         allow,
 			compressEnabled:        false,
 			compressTargetKB:       0,
@@ -96,6 +108,7 @@ func (f *File) stickerLimits() stickerLimitsSnapshot {
 	return stickerLimitsSnapshot{
 		maxSize:                int64(kb) * 1024,
 		maxDim:                 f.settings.StickerUploadMaxDimension(),
+		compressMaxDim:         f.settings.StickerCompressMaxDimension(),
 		allowedFormats:         m,
 		compressEnabled:        f.settings.StickerCompressEnabled(),
 		compressTargetKB:       f.settings.StickerCompressTargetKB(),
@@ -148,6 +161,7 @@ type stickerSystemSettings interface {
 	StickerCompressTargetKB() int
 	StickerCompressMaxConcurrency() int
 	StickerCompressTimeoutMs() int
+	StickerCompressMaxDimension() int
 }
 
 // stickerCompressSettings 抽出 SystemSettings 需要的接口，方便 test 注入 fake。

--- a/modules/file/sticker_compress.go
+++ b/modules/file/sticker_compress.go
@@ -93,9 +93,10 @@ const stickerCompressAcceptMaxDim = common.StickerUploadMaxDimensionHardCap
 // 大 gif/webp 也不会因放宽而被存成大图。
 //
 // 已知边界：APNG 的扩展名是 .png，canCompressStickerExt 为 true，故会通过放宽门；
-// 但压缩阶段 isAnimatedPNGSource 识别后走 skipped:animated，原样落库（不缩放）。
-// 即一张 513–1024² 的 APNG 会以原尺寸存，比 512 大 —— 但仍 ≤ 解码硬上限 1024²，
-// 内存有界。APNG 罕见，此边界可接受；如需收紧可在门处加 acTL 扫描（暂不做）。
+// 但压缩阶段 isAnimatedPNGSource 识别后走 skipped:animated（无法缩放）。此时由 api.go
+// 压缩块之后的落库维度守卫据源尺寸兜底：>upload_max_dimension 的 APNG 被 fail-closed
+// 拒绝、绝不以原尺寸落库；≤upload_max_dimension 的 APNG 原样存。即放宽门放进来的超限
+// 动图最终被拒，与 gif/webp 一致，不破坏"落库恒 ≤ upload_max_dimension"不变量。
 func (s stickerLimitsSnapshot) effectiveGateDim(ext string) int {
 	if s.compressEnabled && canCompressStickerExt(ext) {
 		return stickerCompressAcceptMaxDim

--- a/modules/file/sticker_metrics.go
+++ b/modules/file/sticker_metrics.go
@@ -25,10 +25,14 @@ func stickerUploadResultLabels() []string {
 		// compress_failed   = 解码/编码失败，fail-open 走原路径（原字节仍上传）
 		// compress_skipped  = 未压缩（禁用/非可压格式/并发满/超时），fail-open 走原路径
 		// compress_over_limit = 压缩后仍超 target_kb，caller 拒绝上传
+		// compress_oversized_rejected = 维度门为 jpg/png 放宽到接收硬上限后，压缩实际
+		//   未把图缩到 upload_max_dimension 以内（compressor==nil / skipped / failed /
+		//   compress_max_dimension 配得过大），fail-closed 拒绝，避免存/发超限大图。
 		"compress_success",
 		"compress_failed",
 		"compress_skipped",
 		"compress_over_limit",
+		"compress_oversized_rejected",
 	}
 }
 


### PR DESCRIPTION
## Summary

Lets the custom-sticker server-side compressor **accept a static jpg/png larger than the stored-dimension cap and downscale it** to an operator-configured target before storing, instead of rejecting it outright. Adds the `sticker.compress_max_dimension` setting (default **512**, so ">512 shrinks to 512" is the built-in behavior once compression is enabled), makes the upload dimension gate compress-aware, and adds a **fail-closed guard** so an oversized sticker is never stored uncompressed on any fail-open path. Also records an x86 compression benchmark baseline.

Compression itself stays **opt-in** (`sticker.compress_enabled` default `false` — the gray-scale rollout playbook in `perf-todo.md` is preserved). With compression off (default), behavior is **byte-for-byte identical to `main`**.

## Related Issue

N/A — follow-up on the `sticker-upload-compression` line of work; no tracking issue.

## Linked Spec

- `.octospec/tasks/sticker-downscale-store/brief.md` — decouple the shrink target from the accept gate
- `.octospec/tasks/sticker-oversized-default/brief.md` — make ">512 → 512" the default + compress-aware gate
- `.octospec/tasks/sticker-oversized-store-guard/brief.md` — fail-closed guard (code-review fix)
- `.octospec/tasks/sticker-upload-compression/perf-todo.md` — x86 Xeon bench baseline (§2.1/§2.2 filled)

## Changes

- **`f6ec19c` docs** — record the x86 Xeon (2.10 GHz) compression bench: measured slowdown vs the M5 baseline is ~1.7–1.8× (better than the 3× estimate), worst frame PNG 1024² ≈ 196 ms ≪ the 2000 ms timeout; CPU profile is ~100 % PNG encode, no framework overhead. Defaults need no re-tuning.
- **`b09e330` feat** — new `sticker.compress_max_dimension` setting; `stickerLimitsSnapshot.compressParams().MaxDim` now sources a dedicated `compressMaxDim` (the `imaging.Fit` shrink target) instead of the upload gate, so the previously-dead downscale branch is reachable. Zero-impact default.
- **`ce89799` feat** — flip `compress_max_dimension` default to 512 and make the dimension gate compress-aware (`effectiveGateDim`): jpg/png accept up to the 1024 decode hard cap when compression is on (then shrink), gif/webp and compress-off stay gated at `upload_max_dimension` (512). Chosen over raising `upload_max_dimension`'s default so the appconfig client contract and the compress-off gate are unchanged.
- **`f09336b` fix** — the widened gate admitted >512 jpg/png trusting compression to shrink them, but on the fail-open paths (nil compressor, `skipped:concurrency_saturated`/`timeout`, `failed`, or `compress_max_dimension > upload_max_dimension`) the original oversized bytes were stored/served. Added `stickerCompressResult.OutMaxDim` (actual post-compression dimension) + a post-block guard that rejects (`compress_oversized_rejected`, new pre-warmed metric) when the final stored dimension would exceed `upload_max_dimension`. Dimension is fail-CLOSED; compression quality stays fail-OPEN. Also deduped the cross-package `1024` literal via exported `common.StickerUploadMaxDimensionHardCap`.

Invariant delivered: **a stored/served sticker is always ≤ `upload_max_dimension`**, and decode memory stays ≤ the unchanged 1024 hard cap.

## Testing

- `go test ./modules/file/... ./modules/common/...` — all no-infra sticker/compress/getter cases pass, including 4 new guard regressions (nil compressor / injected `failed` / injected `timeout` / `compress_max_dimension > upload_max_dimension`), the compress-aware gate tests (oversized gif rejected, oversized jpg accepted+shrunk, compress-off zero-impact), and the happy path (1024²→512 stored + `sticker_handle` verified).
- `go vet ./modules/file/ ./modules/common/` clean; both full test binaries compile.
- `make i18n-lint` unaffected (no new error codes; the `modules/file` handler is not i18n-migrated — out of scope, tracked in the briefs).
- Benchmark: `go test -bench=BenchmarkDoCompressStaticSticker -benchmem` on x86 Xeon, results recorded in `perf-todo.md`.
- Note: full-infra tests (`testutil.NewTestServer` → MySQL/Redis/WuKongIM) run in CI; this branch's sandbox ran the no-infra subset. The infra-only `TestGetAppConfig_*` / `StickerCustomEnabled` tests are untouched by this change.

- [x] Unit tests added/updated
- [x] Manually verified (bench + no-infra suites)

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   The `modules/file` sticker upload **dimension gate** — the decode-DoS bound that keeps an oversized sticker from blowing up memory when rendered inline on a conversation peer — becomes compress-aware. Static jpg/png are admitted up to the 1024 decode hard cap when compression is enabled, then `imaging.Fit`-downscaled to `compress_max_dimension` (default 512) before store; gif/webp, compression-off, and every path where compression doesn't actually shrink remain bounded at `upload_max_dimension` (512). A post-compression guard rejects fail-closed if the final stored dimension would exceed `upload_max_dimension`. Net: a stored/served sticker is always ≤ `upload_max_dimension`; decode memory is bounded by the unchanged 1024 hard cap; `ext`/`path`/`sticker_handle` and the appconfig contract are unchanged.

2. **What could break (dependents + failure mode)?**
   (a) A deployment that raised `upload_max_dimension` above 512 **and** enabled compression will now downscale jpg/png to 512 (the `compress_max_dimension` default) while gif/webp keep their limit — a documented, format-dependent size change; operators set `compress_max_dimension` to override. (b) A mis-config `compress_max_dimension > upload_max_dimension` makes oversized jpg/png fail-closed reject (schema description warns). (c) The compressor now reads `img.Bounds()` post-Fit (trivial). All failure modes are **fail-closed reject with a dimension error, never oversized storage**. With `compress_enabled=false` (default) nothing changes.

3. **How do you know it works (specific test/repro/trace)?**
   The 4 guard regressions each upload a 1024² jpg with `upload_max_dimension=512` and assert reject + `svc.uploaded == nil` on exactly the paths that previously stored oversized (nil compressor, injected `failed`, injected slow-doCompress+5 ms timeout → `skipped:timeout`, and `compress_max_dimension=1024`). `TestUploadFile_OversizedJPEG_AcceptedAndDownscaled_DefaultUploadDim` proves a shrinkable 1024² jpg is still accepted and stored at 512×512 (guard doesn't over-reject). The x86 bench (`perf-todo.md` §2.1) shows the downscale path is ~60–100 ms, ≪ the 2000 ms timeout, so it won't routinely trip the timeout it guards against.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (briefs, journals, `.octospec/log.md`, schema descriptions)
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9CQZioBKrZBRGcMBfn9rN

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9CQZioBKrZBRGcMBfn9rN)_