### PR TITLE
OCT-145: docs_proxy inject internal trusted identity headers (X-Octo-Uid/Name/Role)

### DIFF
--- a/internal/modules.go
+++ b/internal/modules.go
@@ -34,6 +34,7 @@ import (
 	_ "github.com/Mininglamp-OSS/octo-server/modules/channel"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/common"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/doc_binding"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/file"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/group"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/incomingwebhook"

--- a/internal/modules.go
+++ b/internal/modules.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/Mininglamp-OSS/octo-server/modules/common"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/doc_binding"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/docs_proxy"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/file"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/group"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/incomingwebhook"

--- a/modules/doc_binding/1module.go
+++ b/modules/doc_binding/1module.go
@@ -1,0 +1,23 @@
+package doc_binding
+
+import (
+	"embed"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
+)
+
+//go:embed sql
+var sqlFS embed.FS
+
+func init() {
+	register.AddModule(func(ctx interface{}) register.Module {
+		return register.Module{
+			Name: "doc_binding",
+			SetupAPI: func() register.APIRouter {
+				return New(ctx.(*config.Context))
+			},
+			SQLDir: register.NewSQLFS(sqlFS),
+		}
+	})
+}

--- a/modules/doc_binding/api.go
+++ b/modules/doc_binding/api.go
@@ -1,0 +1,459 @@
+package doc_binding
+
+// 4 endpoint 全部走 AuthMiddleware（由 Route 挂在 group 上），额外按 mount_type
+// 做业务层权限判定：
+//   - group 挂载：读 = 群成员(ExistMemberActive)；写 = 群主/群管理员(IsCreatorOrManager)。
+//   - thread 挂载：读 = 父群成员；写 = binding 创建者 或 父群主/管理员。
+//   - space 挂载：读 = space 活跃成员；写 = space creator 或 role>=1。
+// 非成员一律 hidden-404（返回 ErrDocBindingNotFound）而不是 403，避免枚举 slug 猜挂载点。
+// 权限不符但对方已经能看到该 slug（例如非 owner 的普通群员改 allow_share_code）时才 403，
+// 这样才不会把"这个 slug 存在"当成信号泄给完全不相关的用户。
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/space"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"go.uber.org/zap"
+)
+
+// slug 白名单：小写字母/数字/短横/下划线，1..120 字符。收敛为 [a-z0-9_-] 是为了让 slug 能安全
+// 出现在 URL path 与文件名（octo-docs-html 侧渲染），不允许大写/中文/空格/斜杠避免路径歧义。
+var slugPattern = regexp.MustCompile(`^[a-z0-9_-]{1,120}$`)
+
+// groupAuth 只暴露 handler 真正用到的两个群 ACL 谓词；用小接口而不是 group.IService 全量，
+// 是为了让单测能只 stub 这两个方法，也让"我们依赖群的什么"一眼看清楚。
+type groupAuth interface {
+	ExistMemberActive(groupNo, uid string) (bool, error)
+	IsCreatorOrManager(groupNo, uid string) (bool, error)
+}
+
+// spaceAuth 抽象两个 space 权限判定；实现在 New 里适配到 space.DB + 一次 space_member 直查。
+type spaceAuth interface {
+	IsMember(spaceId, uid string) (bool, error)
+	MemberRole(spaceId, uid string) (role int, found bool, err error)
+}
+
+// threadAuth 只暴露一个校验：thread(short_id) 是不是真的挂在给定 group 下。
+// 抽出来的原因是 create 路径必须先确认 (group_no, thread_id) 归属一致，防止
+// caller 借"我是 A 群管"越权把 A 的 slug 绑到属于 B 群的 thread（数据串挂 +
+// 之后所有读写都会按错的父群 ACL 走）。
+type threadAuth interface {
+	ExistInGroup(groupNo, threadId string) (bool, error)
+}
+
+// DocBinding 是 doc_binding module 的 HTTP handler。
+type DocBinding struct {
+	ctx        *config.Context
+	db         store
+	groupAuth  groupAuth
+	spaceAuth  spaceAuth
+	threadAuth threadAuth
+	log.Log
+}
+
+// New 生成 DocBinding handler；被 1module.go 里的 SetupAPI 调用。
+func New(ctx *config.Context) *DocBinding {
+	return &DocBinding{
+		ctx:        ctx,
+		db:         newDB(ctx),
+		groupAuth:  group.NewService(ctx),
+		spaceAuth:  newRealSpaceAuth(ctx),
+		threadAuth: newRealThreadAuth(ctx),
+		Log:        log.NewTLog("DocBinding"),
+	}
+}
+
+// realThreadAuth 落到 thread 模块的 ExistByGroupNoAndShortID：thread_id 即 short_id
+// （thread.BuildChannelID(groupNo, shortID) 的 shortID），thread 表 UNIQUE(group_no, short_id)
+// 一次索引命中即可判定归属。
+type realThreadAuth struct {
+	db *thread.DB
+}
+
+func newRealThreadAuth(ctx *config.Context) *realThreadAuth {
+	return &realThreadAuth{db: thread.NewDB(ctx)}
+}
+
+func (r *realThreadAuth) ExistInGroup(groupNo, threadId string) (bool, error) {
+	return r.db.ExistByGroupNoAndShortID(groupNo, threadId)
+}
+
+// realSpaceAuth 用 space.DB.IsMember + 直查 space_member.role 来落地 spaceAuth；
+// 直查 role 是因为 space 包没公开"取角色"的 API，暂不想为此改 space 包。
+type realSpaceAuth struct {
+	ctx *config.Context
+	db  *space.DB
+}
+
+func newRealSpaceAuth(ctx *config.Context) *realSpaceAuth {
+	return &realSpaceAuth{ctx: ctx, db: space.NewDB(ctx)}
+}
+
+func (r *realSpaceAuth) IsMember(spaceId, uid string) (bool, error) {
+	return r.db.IsMember(spaceId, uid)
+}
+
+func (r *realSpaceAuth) MemberRole(spaceId, uid string) (int, bool, error) {
+	var role int
+	found, err := r.ctx.DB().SelectBySql(
+		"SELECT role FROM space_member WHERE space_id=? AND uid=? AND status=1",
+		spaceId, uid).Load(&role)
+	if err != nil {
+		return 0, false, err
+	}
+	return role, found > 0, nil
+}
+
+// Route 挂 4 个 endpoint 到 /v1/docs/bindings*，全部走 AuthMiddleware。
+func (h *DocBinding) Route(r *wkhttp.WKHttp) {
+	auth := r.Group("/v1/docs", h.ctx.AuthMiddleware(r))
+	{
+		auth.POST("/bindings", h.create)
+		auth.GET("/bindings/:slug", h.get)
+		auth.PUT("/bindings/:slug", h.update)
+		auth.DELETE("/bindings/:slug", h.delete)
+	}
+}
+
+// ---- request/response DTO -------------------------------------------------
+
+type createReq struct {
+	Slug      string `json:"slug"`
+	MountType string `json:"mount_type"`
+	GroupNo   string `json:"group_no,omitempty"`
+	ThreadId  string `json:"thread_id,omitempty"`
+	SpaceId   string `json:"space_id,omitempty"`
+	// 指针区分 "未传" 与 "显式 false"；未传时按默认 false（不开分享码）落库。
+	AllowShareCode *bool `json:"allow_share_code,omitempty"`
+}
+
+type updateReq struct {
+	AllowShareCode *bool `json:"allow_share_code,omitempty"`
+}
+
+type bindingResp struct {
+	Slug           string `json:"slug"`
+	MountType      string `json:"mount_type"`
+	GroupNo        string `json:"group_no,omitempty"`
+	ThreadId       string `json:"thread_id,omitempty"`
+	SpaceId        string `json:"space_id,omitempty"`
+	CreatorUID     string `json:"creator_uid"`
+	AllowShareCode bool   `json:"allow_share_code"`
+}
+
+func toResp(m *Model) *bindingResp {
+	return &bindingResp{
+		Slug:           m.Slug,
+		MountType:      m.MountType,
+		GroupNo:        m.GroupNo,
+		ThreadId:       m.ThreadId,
+		SpaceId:        m.SpaceId,
+		CreatorUID:     m.CreatorUID,
+		AllowShareCode: m.AllowShareCode == AllowShareCodeOn,
+	}
+}
+
+// ---- handler ---------------------------------------------------------------
+
+func (h *DocBinding) create(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+
+	var req createReq
+	if err := c.BindJSON(&req); err != nil {
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingRequestInvalid, nil, nil)
+		return
+	}
+	req.Slug = strings.TrimSpace(req.Slug)
+	if !slugPattern.MatchString(req.Slug) {
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingRequestInvalid, nil, map[string]interface{}{"field": "slug"})
+		return
+	}
+
+	// 允许的挂载类型 + 对应字段互斥校验：group/thread 需 group_no（thread 再要 thread_id），space 需 space_id。
+	switch req.MountType {
+	case MountTypeGroup:
+		if req.GroupNo == "" || req.ThreadId != "" || req.SpaceId != "" {
+			httperr.ResponseErrorL(c, errcode.ErrDocBindingRequestInvalid, nil, map[string]interface{}{"field": "group_no"})
+			return
+		}
+	case MountTypeThread:
+		if req.GroupNo == "" || req.ThreadId == "" || req.SpaceId != "" {
+			httperr.ResponseErrorL(c, errcode.ErrDocBindingRequestInvalid, nil, map[string]interface{}{"field": "thread_id"})
+			return
+		}
+	case MountTypeSpace:
+		if req.SpaceId == "" || req.GroupNo != "" || req.ThreadId != "" {
+			httperr.ResponseErrorL(c, errcode.ErrDocBindingRequestInvalid, nil, map[string]interface{}{"field": "space_id"})
+			return
+		}
+	default:
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingRequestInvalid, nil, map[string]interface{}{"field": "mount_type"})
+		return
+	}
+
+	// thread 挂载额外硬校验：thread_id 必须真的挂在 req.GroupNo 下。仅靠 canWrite（父群管理员）
+	// 不够——A 群管理员可能拿到 B 群的 thread_id 就想把 slug 绑过去，如果不校验归属，
+	// binding 会落成 (group_no=A, thread_id=belongs_to_B)，之后按 GroupNo=A 判 ACL 就是错的。
+	if req.MountType == MountTypeThread {
+		if ok, err := h.threadAuth.ExistInGroup(req.GroupNo, req.ThreadId); err != nil {
+			h.Error("校验 thread 归属失败", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrDocBindingStoreFailed, nil, nil)
+			return
+		} else if !ok {
+			// 归属不上的 thread_id：按 field 报 400，不是 hidden-404——POST 场景 caller 自报的
+			// 是无效引用，不涉及"这个 thread 是否存在"的信息泄漏（他本来就没资格查 B 群的 thread）。
+			httperr.ResponseErrorL(c, errcode.ErrDocBindingRequestInvalid, nil, map[string]interface{}{"field": "thread_id"})
+			return
+		}
+	}
+
+	// 写权限：按挂载类型判定；不通过一律 403（因为 caller 是主动 POST，泄不泄漏这个挂载点存在都不重要）。
+	if ok, err := h.canWrite(loginUID, req.MountType, req.GroupNo, req.ThreadId, req.SpaceId, ""); err != nil {
+		h.Error("检查建绑权限失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingStoreFailed, nil, nil)
+		return
+	} else if !ok {
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingForbidden, nil, nil)
+		return
+	}
+
+	// slug 冲突：靠 UNIQUE INDEX 兜底，先查是加一次友好返回；并发下漏查后仍会 InsertInto 报 dup，翻成 409。
+	if existing, err := h.db.queryBySlug(req.Slug); err != nil {
+		h.Error("查询 slug 失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingStoreFailed, nil, nil)
+		return
+	} else if existing != nil {
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingSlugConflict, nil, map[string]interface{}{"field": "slug"})
+		return
+	}
+
+	allow := AllowShareCodeOff
+	if req.AllowShareCode != nil && *req.AllowShareCode {
+		allow = AllowShareCodeOn
+	}
+
+	m := &Model{
+		Slug:           req.Slug,
+		MountType:      req.MountType,
+		GroupNo:        req.GroupNo,
+		ThreadId:       req.ThreadId,
+		SpaceId:        req.SpaceId,
+		CreatorUID:     loginUID,
+		AllowShareCode: allow,
+	}
+	if err := h.db.insert(m); err != nil {
+		// 并发下依赖 UNIQUE(slug) 兜底：MySQL dup key 一律翻成 409，避免调用方以为写成功。
+		if isDupSlugErr(err) {
+			httperr.ResponseErrorL(c, errcode.ErrDocBindingSlugConflict, nil, map[string]interface{}{"field": "slug"})
+			return
+		}
+		h.Error("新建 doc_binding 失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingStoreFailed, nil, nil)
+		return
+	}
+
+	c.Response(toResp(m))
+}
+
+func (h *DocBinding) get(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+	slug := c.Param("slug")
+	if !slugPattern.MatchString(slug) {
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingNotFound, nil, nil)
+		return
+	}
+
+	m, err := h.db.queryBySlug(slug)
+	if err != nil {
+		h.Error("查询 doc_binding 失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingStoreFailed, nil, nil)
+		return
+	}
+	if m == nil {
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingNotFound, nil, nil)
+		return
+	}
+
+	ok, err := h.canRead(loginUID, m)
+	if err != nil {
+		h.Error("检查读权限失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingStoreFailed, nil, nil)
+		return
+	}
+	if !ok {
+		// hidden-404：不给非成员"这个 slug 存在"的信号，防枚举探测挂载点。
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingNotFound, nil, nil)
+		return
+	}
+
+	c.Response(toResp(m))
+}
+
+func (h *DocBinding) update(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+	slug := c.Param("slug")
+	if !slugPattern.MatchString(slug) {
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingNotFound, nil, nil)
+		return
+	}
+
+	var req updateReq
+	if err := c.BindJSON(&req); err != nil {
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingRequestInvalid, nil, nil)
+		return
+	}
+	// 目前只支持 allow_share_code；改挂载点必须删了重建，避免历史 slug 权限漂移。
+	if req.AllowShareCode == nil {
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingRequestInvalid, nil, map[string]interface{}{"field": "allow_share_code"})
+		return
+	}
+
+	m, err := h.db.queryBySlug(slug)
+	if err != nil {
+		h.Error("查询 doc_binding 失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingStoreFailed, nil, nil)
+		return
+	}
+	if m == nil {
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingNotFound, nil, nil)
+		return
+	}
+
+	// 先读权限：非成员/跨 space 直接 hidden-404；成员再判写权限（差别里才 403）。
+	if ok, rErr := h.canRead(loginUID, m); rErr != nil {
+		h.Error("检查读权限失败", zap.Error(rErr))
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingStoreFailed, nil, nil)
+		return
+	} else if !ok {
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingNotFound, nil, nil)
+		return
+	}
+	if ok, wErr := h.canWrite(loginUID, m.MountType, m.GroupNo, m.ThreadId, m.SpaceId, m.CreatorUID); wErr != nil {
+		h.Error("检查写权限失败", zap.Error(wErr))
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingStoreFailed, nil, nil)
+		return
+	} else if !ok {
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingForbidden, nil, nil)
+		return
+	}
+
+	allow := AllowShareCodeOff
+	if *req.AllowShareCode {
+		allow = AllowShareCodeOn
+	}
+	if err := h.db.updateAllowShareCode(slug, allow); err != nil {
+		h.Error("更新 allow_share_code 失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingStoreFailed, nil, nil)
+		return
+	}
+	m.AllowShareCode = allow
+	c.Response(toResp(m))
+}
+
+func (h *DocBinding) delete(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+	slug := c.Param("slug")
+	if !slugPattern.MatchString(slug) {
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingNotFound, nil, nil)
+		return
+	}
+
+	m, err := h.db.queryBySlug(slug)
+	if err != nil {
+		h.Error("查询 doc_binding 失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingStoreFailed, nil, nil)
+		return
+	}
+	if m == nil {
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingNotFound, nil, nil)
+		return
+	}
+
+	if ok, rErr := h.canRead(loginUID, m); rErr != nil {
+		h.Error("检查读权限失败", zap.Error(rErr))
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingStoreFailed, nil, nil)
+		return
+	} else if !ok {
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingNotFound, nil, nil)
+		return
+	}
+	if ok, wErr := h.canWrite(loginUID, m.MountType, m.GroupNo, m.ThreadId, m.SpaceId, m.CreatorUID); wErr != nil {
+		h.Error("检查写权限失败", zap.Error(wErr))
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingStoreFailed, nil, nil)
+		return
+	} else if !ok {
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingForbidden, nil, nil)
+		return
+	}
+
+	if err := h.db.deleteBySlug(slug); err != nil {
+		h.Error("删除 doc_binding 失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrDocBindingStoreFailed, nil, nil)
+		return
+	}
+	c.ResponseOK()
+}
+
+// ---- 权限判定 --------------------------------------------------------------
+
+// canRead / canWrite 独立函数是为了让写路径三个 handler（create/update/delete）复用同一套判定，
+// 顺便让它们的单元测试可 stub group/space/thread service 表面。
+func (h *DocBinding) canRead(uid string, m *Model) (bool, error) {
+	switch m.MountType {
+	case MountTypeGroup:
+		return h.groupAuth.ExistMemberActive(m.GroupNo, uid)
+	case MountTypeThread:
+		// thread 挂载的读权限 = 父群成员（thread 自己没有独立成员概念，共父群 ACL）。
+		return h.groupAuth.ExistMemberActive(m.GroupNo, uid)
+	case MountTypeSpace:
+		return h.spaceAuth.IsMember(m.SpaceId, uid)
+	}
+	return false, nil
+}
+
+// canWrite: mount=group/thread 走群 owner/manager；mount=space 走 creator 或 role>=1；
+// create 阶段调用时 bindingCreator 传 ""，只按挂载点判；update/delete 时把 binding.creator_uid
+// 传进来允许原创建者对自己建的 thread binding 拥有写权限（与父单 §5.2 一致）。
+func (h *DocBinding) canWrite(uid, mountType, groupNo, threadId, spaceId, bindingCreator string) (bool, error) {
+	switch mountType {
+	case MountTypeGroup:
+		return h.groupAuth.IsCreatorOrManager(groupNo, uid)
+	case MountTypeThread:
+		// binding creator 自己可写；否则回落到群主/管理员。
+		if bindingCreator != "" && bindingCreator == uid {
+			// 但仍需确认 caller 现在还是父群成员，避免离群后残留写权限。
+			still, err := h.groupAuth.ExistMemberActive(groupNo, uid)
+			if err != nil || !still {
+				return false, err
+			}
+			return true, nil
+		}
+		return h.groupAuth.IsCreatorOrManager(groupNo, uid)
+	case MountTypeSpace:
+		// Space 写权限：role>=1 (1=管理员, 2=拥有者)；non-member ⇒ false, 顺势也当作"看不到"。
+		role, found, err := h.spaceAuth.MemberRole(spaceId, uid)
+		if err != nil || !found {
+			return false, err
+		}
+		return role >= 1, nil
+	}
+	return false, nil
+}
+
+// isDupSlugErr 判定是不是 UNIQUE(slug) 冲突；用字符串匹配是因为 gocraft/dbr 不吐 mysql 错误码结构体。
+// MySQL 报文形如 "Error 1062: Duplicate entry 'xxx' for key 'doc_binding_slug'"。
+func isDupSlugErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "Duplicate entry") && strings.Contains(s, "doc_binding_slug")
+}

--- a/modules/doc_binding/api_i18n_test.go
+++ b/modules/doc_binding/api_i18n_test.go
@@ -1,0 +1,42 @@
+package doc_binding
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestDocBindingNoLegacyResponseError 硬性锁定：modules/doc_binding 的 handler 文件
+// 不许回落到 octo-lib 老 wkhttp 错误响应形态。所有业务错误统一走
+// httperr.ResponseErrorL + errcode.ErrDocBinding*，才能被 i18n renderer 转 zh-CN
+// 且不绕过 D14 双 envelope。
+// 参照 modules/category/api_i18n_test.go 的实现：先去掉行注释再扫，避免注释里
+// 写"以前是 c.ResponseError(...)"这种历史脚印被误判。c.Response(struct) /
+// c.ResponseOK 是正常成功响应，不会匹配 "c.Response(\"" 因为它匹配的是形如
+// c.Response("msg") 的字符串直传形态。
+func TestDocBindingNoLegacyResponseError(t *testing.T) {
+	files := []string{"api.go"}
+	banned := []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(", "c.Response(\"", ".AbortWithStatusJSON(", ".AbortWithStatus("}
+	for _, f := range files {
+		t.Run(f, func(t *testing.T) {
+			data, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+			var clean strings.Builder
+			for _, line := range strings.Split(string(data), "\n") {
+				if idx := strings.Index(line, "//"); idx >= 0 {
+					line = line[:idx]
+				}
+				clean.WriteString(line)
+				clean.WriteByte('\n')
+			}
+			cleaned := clean.String()
+			for _, b := range banned {
+				if strings.Contains(cleaned, b) {
+					t.Fatalf("modules/doc_binding/%s must use httperr.ResponseErrorL + errcode.ErrDocBinding* instead of legacy %s", f, b)
+				}
+			}
+		})
+	}
+}

--- a/modules/doc_binding/api_test.go
+++ b/modules/doc_binding/api_test.go
@@ -1,0 +1,673 @@
+package doc_binding
+
+// api_test.go
+//
+// 用 wkhttp.New() 起裸路由 + in-memory store + stub group/space auth 直接跑 4 endpoint。
+// 不依赖 MySQL 是因为本地 CI 没数据库；handler 里所有真正落 DB 的路径都在 store 接口后面。
+// 覆盖矩阵（父单 OCT-134 §验收）：
+//   - 群成员 / 群主/管理员 / 非群成员 / 跨 space
+//   - hidden-404：非成员看不到 slug 存在（404 而不是 403）
+//   - allow_share_code 默认 false 生效
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---- stubs ----------------------------------------------------------------
+
+// memStore 是 store 的 in-memory 实现；用 map 直存 *Model，够单测隔离场景用。
+type memStore struct {
+	mu   sync.Mutex
+	rows map[string]*Model
+	// 允许测试注入错误
+	insertErr error
+	queryErr  error
+	updateErr error
+	deleteErr error
+}
+
+func newMemStore() *memStore { return &memStore{rows: map[string]*Model{}} }
+
+func (s *memStore) insert(m *Model) error {
+	if s.insertErr != nil {
+		return s.insertErr
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.rows[m.Slug]; ok {
+		// 模拟 MySQL UNIQUE(slug) 冲突：格式对齐 isDupSlugErr 的匹配
+		return errors.New("Error 1062: Duplicate entry '" + m.Slug + "' for key 'doc_binding_slug'")
+	}
+	c := *m
+	s.rows[m.Slug] = &c
+	return nil
+}
+func (s *memStore) queryBySlug(slug string) (*Model, error) {
+	if s.queryErr != nil {
+		return nil, s.queryErr
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	m, ok := s.rows[slug]
+	if !ok {
+		return nil, nil
+	}
+	c := *m
+	return &c, nil
+}
+func (s *memStore) updateAllowShareCode(slug string, allow int) error {
+	if s.updateErr != nil {
+		return s.updateErr
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	m, ok := s.rows[slug]
+	if !ok {
+		return nil
+	}
+	m.AllowShareCode = allow
+	return nil
+}
+func (s *memStore) deleteBySlug(slug string) error {
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.rows, slug)
+	return nil
+}
+
+// stubGroupAuth: (groupNo, uid) → 权限布尔的两张表；未列 = false。
+type stubGroupAuth struct {
+	members  map[string]map[string]bool // groupNo -> uid -> isActiveMember
+	managers map[string]map[string]bool // groupNo -> uid -> isCreatorOrManager
+}
+
+func newStubGroupAuth() *stubGroupAuth {
+	return &stubGroupAuth{
+		members:  map[string]map[string]bool{},
+		managers: map[string]map[string]bool{},
+	}
+}
+func (s *stubGroupAuth) addMember(gn, uid string) { ensure(s.members, gn)[uid] = true }
+func (s *stubGroupAuth) addManager(gn, uid string) {
+	ensure(s.managers, gn)[uid] = true
+	ensure(s.members, gn)[uid] = true
+}
+
+func (s *stubGroupAuth) ExistMemberActive(gn, uid string) (bool, error) {
+	return s.members[gn][uid], nil
+}
+func (s *stubGroupAuth) IsCreatorOrManager(gn, uid string) (bool, error) {
+	return s.managers[gn][uid], nil
+}
+
+// stubSpaceAuth: 记录成员及 role。
+type stubSpaceAuth struct {
+	roles map[string]map[string]int // spaceId -> uid -> role (仅当作 member 时才有条目)
+}
+
+func newStubSpaceAuth() *stubSpaceAuth {
+	return &stubSpaceAuth{roles: map[string]map[string]int{}}
+}
+func (s *stubSpaceAuth) addMember(sp, uid string, role int) {
+	ensureInt(s.roles, sp)[uid] = role
+}
+func (s *stubSpaceAuth) IsMember(sp, uid string) (bool, error) {
+	_, ok := s.roles[sp][uid]
+	return ok, nil
+}
+func (s *stubSpaceAuth) MemberRole(sp, uid string) (int, bool, error) {
+	r, ok := s.roles[sp][uid]
+	return r, ok, nil
+}
+
+// stubThreadAuth: 记录 (groupNo, threadId) 归属；未列 = 归属不上。
+// 允许注入 err 用来覆盖 store-failed 路径。
+type stubThreadAuth struct {
+	ownership map[string]map[string]bool
+	existErr  error
+}
+
+func newStubThreadAuth() *stubThreadAuth {
+	return &stubThreadAuth{ownership: map[string]map[string]bool{}}
+}
+func (s *stubThreadAuth) addThread(gn, tid string) { ensure(s.ownership, gn)[tid] = true }
+func (s *stubThreadAuth) ExistInGroup(gn, tid string) (bool, error) {
+	if s.existErr != nil {
+		return false, s.existErr
+	}
+	return s.ownership[gn][tid], nil
+}
+
+func ensure(m map[string]map[string]bool, k string) map[string]bool {
+	if m[k] == nil {
+		m[k] = map[string]bool{}
+	}
+	return m[k]
+}
+func ensureInt(m map[string]map[string]int, k string) map[string]int {
+	if m[k] == nil {
+		m[k] = map[string]int{}
+	}
+	return m[k]
+}
+
+// ---- test harness ---------------------------------------------------------
+
+// buildHandler 拼 handler + in-memory 依赖；不走 New() 以避免碰 ctx.DB()。
+func buildHandler() (*DocBinding, *memStore, *stubGroupAuth, *stubSpaceAuth, *stubThreadAuth) {
+	st := newMemStore()
+	ga := newStubGroupAuth()
+	sa := newStubSpaceAuth()
+	ta := newStubThreadAuth()
+	// Log 不注入的话，任何 h.Error(...) 路径会 nil deref。既有 27 测试都没走到 err 分支所以未暴露；
+	// thread create 的 store-failed 场景第一次触发这条路径。
+	h := &DocBinding{db: st, groupAuth: ga, spaceAuth: sa, threadAuth: ta, Log: log.NewTLog("doc_binding_test")}
+	return h, st, ga, sa, ta
+}
+
+// newTestRouter 挂 handler 到 wkhttp，注入 uid，避开 AuthMiddleware（后者需要 cache/token）。
+func newTestRouter(h *DocBinding, uid string) *wkhttp.WKHttp {
+	gin.SetMode(gin.TestMode)
+	r := wkhttp.New()
+	inject := func(c *wkhttp.Context) {
+		if uid != "" {
+			c.Set("uid", uid)
+		}
+		c.Next()
+	}
+	grp := r.Group("/v1/docs", inject)
+	grp.POST("/bindings", h.create)
+	grp.GET("/bindings/:slug", h.get)
+	grp.PUT("/bindings/:slug", h.update)
+	grp.DELETE("/bindings/:slug", h.delete)
+	return r
+}
+
+func do(r *wkhttp.WKHttp, method, path string, body interface{}) *httptest.ResponseRecorder {
+	var buf bytes.Buffer
+	if body != nil {
+		_ = json.NewEncoder(&buf).Encode(body)
+	}
+	req, _ := http.NewRequest(method, path, &buf)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// D14 legacy compat: ResponseErrorL pins wire status to 400 regardless of the
+// error code's semantic HTTPStatus (see AGENTS.md §httperr / pkg/httperr/respond.go).
+// New endpoint tests therefore assert on the localized message (each code has a
+// distinct DefaultMessage) instead of w.Code. If octo-server later flips
+// endpoints to ResponseErrorLWithStatus, tighten these to real status codes.
+const (
+	msgNotFound    = "Doc binding not found."
+	msgForbidden   = "You do not have permission to modify this doc binding."
+	msgConflict    = "This slug is already bound."
+	msgReqInvalid  = "Invalid request."
+	msgStoreFailed = "Doc binding storage operation failed."
+)
+
+// assertErrMsg 校验业务错误响应：wire=400（D14 遗留兼容），body msg == 期望。
+// 用它替代 assert.Equal(t, http.StatusXxx, w.Code) 以匹配 octo 现有响应约定。
+func assertErrMsg(t *testing.T, w *httptest.ResponseRecorder, wantMsg string) {
+	t.Helper()
+	if !assert.Equalf(t, http.StatusBadRequest, w.Code, "wire status should be 400 (D14 compat); body=%s", w.Body.String()) {
+		return
+	}
+	assert.Containsf(t, w.Body.String(), "\"msg\":\""+wantMsg+"\"", "body: %s", w.Body.String())
+}
+
+// ==================== POST /v1/docs/bindings (create) ====================
+
+func TestCreate_Group_ByManager_OK(t *testing.T) {
+	h, st, ga, _, _ := buildHandler()
+	ga.addManager("g1", "u_admin")
+
+	r := newTestRouter(h, "u_admin")
+	w := do(r, "POST", "/v1/docs/bindings", map[string]interface{}{
+		"slug": "team-charter", "mount_type": "group", "group_no": "g1",
+	})
+	require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	m, _ := st.queryBySlug("team-charter")
+	require.NotNil(t, m)
+	assert.Equal(t, "u_admin", m.CreatorUID)
+	// 未传 allow_share_code：应默认 false（AllowShareCodeOff）
+	assert.Equal(t, AllowShareCodeOff, m.AllowShareCode)
+}
+
+func TestCreate_Group_ByMember_403(t *testing.T) {
+	// 普通群成员没有建 binding 的权限（写路径按 IsCreatorOrManager 判定）
+	h, _, ga, _, _ := buildHandler()
+	ga.addMember("g1", "u_member")
+
+	r := newTestRouter(h, "u_member")
+	w := do(r, "POST", "/v1/docs/bindings", map[string]interface{}{
+		"slug": "s1", "mount_type": "group", "group_no": "g1",
+	})
+	assertErrMsg(t, w, msgForbidden)
+}
+
+func TestCreate_Group_ByNonMember_403(t *testing.T) {
+	// 非群成员发 POST：属于主动挂载不存在群，直接 403（不必 hidden-404 —— caller 已经知道自己在填 group_no）
+	h, _, _, _, _ := buildHandler()
+	r := newTestRouter(h, "u_outsider")
+	w := do(r, "POST", "/v1/docs/bindings", map[string]interface{}{
+		"slug": "s1", "mount_type": "group", "group_no": "g_other",
+	})
+	assertErrMsg(t, w, msgForbidden)
+}
+
+func TestCreate_SlugConflict_409(t *testing.T) {
+	h, _, ga, _, _ := buildHandler()
+	ga.addManager("g1", "u_admin")
+	r := newTestRouter(h, "u_admin")
+
+	first := do(r, "POST", "/v1/docs/bindings", map[string]interface{}{
+		"slug": "dup", "mount_type": "group", "group_no": "g1",
+	})
+	require.Equal(t, http.StatusOK, first.Code)
+
+	second := do(r, "POST", "/v1/docs/bindings", map[string]interface{}{
+		"slug": "dup", "mount_type": "group", "group_no": "g1",
+	})
+	assertErrMsg(t, second, msgConflict)
+}
+
+func TestCreate_AllowShareCode_DefaultFalse(t *testing.T) {
+	// 三种情况都应落 AllowShareCodeOff：字段完全缺省 / 显式 false / null 传输由客户端处理
+	cases := []struct {
+		name string
+		body map[string]interface{}
+	}{
+		{"omitted", map[string]interface{}{"slug": "a1", "mount_type": "group", "group_no": "g1"}},
+		{"explicit_false", map[string]interface{}{"slug": "a2", "mount_type": "group", "group_no": "g1", "allow_share_code": false}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, st, ga, _, _ := buildHandler()
+			ga.addManager("g1", "u_admin")
+			r := newTestRouter(h, "u_admin")
+
+			w := do(r, "POST", "/v1/docs/bindings", tc.body)
+			require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+			m, _ := st.queryBySlug(tc.body["slug"].(string))
+			require.NotNil(t, m)
+			assert.Equal(t, AllowShareCodeOff, m.AllowShareCode, "default must be false (0)")
+		})
+	}
+}
+
+func TestCreate_AllowShareCode_ExplicitTrue_Persists(t *testing.T) {
+	h, st, ga, _, _ := buildHandler()
+	ga.addManager("g1", "u_admin")
+	r := newTestRouter(h, "u_admin")
+	w := do(r, "POST", "/v1/docs/bindings", map[string]interface{}{
+		"slug": "a3", "mount_type": "group", "group_no": "g1", "allow_share_code": true,
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	m, _ := st.queryBySlug("a3")
+	require.NotNil(t, m)
+	assert.Equal(t, AllowShareCodeOn, m.AllowShareCode)
+}
+
+func TestCreate_InvalidMountType_400(t *testing.T) {
+	h, _, ga, _, _ := buildHandler()
+	ga.addManager("g1", "u_admin")
+	r := newTestRouter(h, "u_admin")
+	w := do(r, "POST", "/v1/docs/bindings", map[string]interface{}{
+		"slug": "s1", "mount_type": "unknown", "group_no": "g1",
+	})
+	assertErrMsg(t, w, msgReqInvalid)
+}
+
+func TestCreate_MountTypeMismatchedFields_400(t *testing.T) {
+	// group 挂载不该带 space_id
+	h, _, ga, _, _ := buildHandler()
+	ga.addManager("g1", "u_admin")
+	r := newTestRouter(h, "u_admin")
+	w := do(r, "POST", "/v1/docs/bindings", map[string]interface{}{
+		"slug": "s1", "mount_type": "group", "group_no": "g1", "space_id": "sp1",
+	})
+	assertErrMsg(t, w, msgReqInvalid)
+}
+
+func TestCreate_InvalidSlug_400(t *testing.T) {
+	// 大写、中文、空格、超长都应被 slugPattern 拒
+	badSlugs := []string{"UPPER", "空格 slug", "汉字slug", "with/slash", ""}
+	h, _, ga, _, _ := buildHandler()
+	ga.addManager("g1", "u_admin")
+	r := newTestRouter(h, "u_admin")
+	for _, bs := range badSlugs {
+		t.Run(bs, func(t *testing.T) {
+			w := do(r, "POST", "/v1/docs/bindings", map[string]interface{}{
+				"slug": bs, "mount_type": "group", "group_no": "g1",
+			})
+			assertErrMsgf(t, w, msgReqInvalid, "slug=%q", bs)
+		})
+	}
+}
+
+// ==================== GET /v1/docs/bindings/:slug ====================
+
+func TestGet_Group_MemberSees(t *testing.T) {
+	h, st, ga, _, _ := buildHandler()
+	ga.addManager("g1", "u_admin")
+	ga.addMember("g1", "u_member")
+	require.NoError(t, st.insert(&Model{Slug: "s1", MountType: MountTypeGroup, GroupNo: "g1", CreatorUID: "u_admin"}))
+
+	r := newTestRouter(h, "u_member")
+	w := do(r, "GET", "/v1/docs/bindings/s1", nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), `"slug":"s1"`)
+	assert.Contains(t, w.Body.String(), `"mount_type":"group"`)
+}
+
+func TestGet_Group_NonMember_Hidden404(t *testing.T) {
+	// 关键 hidden-404：不给非成员泄漏\"slug 存在\"
+	h, st, _, _, _ := buildHandler()
+	require.NoError(t, st.insert(&Model{Slug: "s1", MountType: MountTypeGroup, GroupNo: "g1", CreatorUID: "u_admin"}))
+
+	r := newTestRouter(h, "u_outsider")
+	w := do(r, "GET", "/v1/docs/bindings/s1", nil)
+	assertErrMsgWithNote(t, w, msgNotFound, "non-member must see semantic-404 (hidden-404), not forbidden")
+}
+
+func TestGet_UnknownSlug_404(t *testing.T) {
+	h, _, ga, _, _ := buildHandler()
+	ga.addMember("g1", "u_member")
+	r := newTestRouter(h, "u_member")
+	w := do(r, "GET", "/v1/docs/bindings/does-not-exist", nil)
+	assertErrMsg(t, w, msgNotFound)
+}
+
+// ==================== PUT /v1/docs/bindings/:slug ====================
+
+func TestUpdate_Manager_Toggles_AllowShareCode(t *testing.T) {
+	h, st, ga, _, _ := buildHandler()
+	ga.addManager("g1", "u_admin")
+	require.NoError(t, st.insert(&Model{Slug: "s1", MountType: MountTypeGroup, GroupNo: "g1", CreatorUID: "u_admin", AllowShareCode: AllowShareCodeOff}))
+
+	r := newTestRouter(h, "u_admin")
+	w := do(r, "PUT", "/v1/docs/bindings/s1", map[string]interface{}{"allow_share_code": true})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	m, _ := st.queryBySlug("s1")
+	require.NotNil(t, m)
+	assert.Equal(t, AllowShareCodeOn, m.AllowShareCode)
+}
+
+func TestUpdate_Member_403(t *testing.T) {
+	// 普通群员看得到 binding，但没资格改 → 差别里才是 403
+	h, st, ga, _, _ := buildHandler()
+	ga.addManager("g1", "u_admin")
+	ga.addMember("g1", "u_member")
+	require.NoError(t, st.insert(&Model{Slug: "s1", MountType: MountTypeGroup, GroupNo: "g1", CreatorUID: "u_admin"}))
+
+	r := newTestRouter(h, "u_member")
+	w := do(r, "PUT", "/v1/docs/bindings/s1", map[string]interface{}{"allow_share_code": true})
+	assertErrMsg(t, w, msgForbidden)
+}
+
+func TestUpdate_NonMember_Hidden404(t *testing.T) {
+	// 非成员 PUT 也要 hidden-404，不能因为 403 泄漏\"存在\"
+	h, st, _, _, _ := buildHandler()
+	require.NoError(t, st.insert(&Model{Slug: "s1", MountType: MountTypeGroup, GroupNo: "g1", CreatorUID: "u_admin"}))
+
+	r := newTestRouter(h, "u_outsider")
+	w := do(r, "PUT", "/v1/docs/bindings/s1", map[string]interface{}{"allow_share_code": true})
+	assertErrMsg(t, w, msgNotFound)
+}
+
+func TestUpdate_MissingAllowShareCode_400(t *testing.T) {
+	h, st, ga, _, _ := buildHandler()
+	ga.addManager("g1", "u_admin")
+	require.NoError(t, st.insert(&Model{Slug: "s1", MountType: MountTypeGroup, GroupNo: "g1", CreatorUID: "u_admin"}))
+	r := newTestRouter(h, "u_admin")
+	w := do(r, "PUT", "/v1/docs/bindings/s1", map[string]interface{}{})
+	assertErrMsg(t, w, msgReqInvalid)
+}
+
+// ==================== DELETE /v1/docs/bindings/:slug ====================
+
+func TestDelete_Manager_OK(t *testing.T) {
+	h, st, ga, _, _ := buildHandler()
+	ga.addManager("g1", "u_admin")
+	require.NoError(t, st.insert(&Model{Slug: "s1", MountType: MountTypeGroup, GroupNo: "g1", CreatorUID: "u_admin"}))
+	r := newTestRouter(h, "u_admin")
+	w := do(r, "DELETE", "/v1/docs/bindings/s1", nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	m, _ := st.queryBySlug("s1")
+	assert.Nil(t, m)
+}
+
+func TestDelete_Member_403(t *testing.T) {
+	h, st, ga, _, _ := buildHandler()
+	ga.addManager("g1", "u_admin")
+	ga.addMember("g1", "u_member")
+	require.NoError(t, st.insert(&Model{Slug: "s1", MountType: MountTypeGroup, GroupNo: "g1", CreatorUID: "u_admin"}))
+	r := newTestRouter(h, "u_member")
+	w := do(r, "DELETE", "/v1/docs/bindings/s1", nil)
+	assertErrMsg(t, w, msgForbidden)
+}
+
+func TestDelete_NonMember_Hidden404(t *testing.T) {
+	h, st, _, _, _ := buildHandler()
+	require.NoError(t, st.insert(&Model{Slug: "s1", MountType: MountTypeGroup, GroupNo: "g1", CreatorUID: "u_admin"}))
+	r := newTestRouter(h, "u_outsider")
+	w := do(r, "DELETE", "/v1/docs/bindings/s1", nil)
+	assertErrMsg(t, w, msgNotFound)
+}
+
+// ==================== thread 挂载 ====================
+
+func TestGet_Thread_ParentGroupMember_Sees(t *testing.T) {
+	h, st, ga, _, _ := buildHandler()
+	ga.addMember("g1", "u_member")
+	require.NoError(t, st.insert(&Model{Slug: "th1", MountType: MountTypeThread, GroupNo: "g1", ThreadId: "t_short", CreatorUID: "u_admin"}))
+	r := newTestRouter(h, "u_member")
+	w := do(r, "GET", "/v1/docs/bindings/th1", nil)
+	assert.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+}
+
+func TestUpdate_Thread_Creator_CanEdit_IfStillMember(t *testing.T) {
+	// binding creator（不是群管）也能写自己建的 thread binding —— 但必须还在父群里
+	h, st, ga, _, _ := buildHandler()
+	ga.addMember("g1", "u_creator")
+	require.NoError(t, st.insert(&Model{Slug: "th2", MountType: MountTypeThread, GroupNo: "g1", ThreadId: "t2", CreatorUID: "u_creator"}))
+	r := newTestRouter(h, "u_creator")
+	w := do(r, "PUT", "/v1/docs/bindings/th2", map[string]interface{}{"allow_share_code": true})
+	assert.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+}
+
+func TestUpdate_Thread_Creator_LeftGroup_403(t *testing.T) {
+	// 原 creator 已离群 → 写权限失效（避免离群后残留权限）
+	h, st, _, _, _ := buildHandler()
+	// 不 addMember，模拟已离群
+	require.NoError(t, st.insert(&Model{Slug: "th3", MountType: MountTypeThread, GroupNo: "g1", ThreadId: "t3", CreatorUID: "u_creator"}))
+	r := newTestRouter(h, "u_creator")
+	w := do(r, "PUT", "/v1/docs/bindings/th3", map[string]interface{}{"allow_share_code": true})
+	// 已离群 → hidden-404（读权限已经不过）
+	assertErrMsg(t, w, msgNotFound)
+}
+
+// ==================== space 挂载：跨 space 场景 ====================
+
+func TestGet_Space_Member_Sees(t *testing.T) {
+	h, st, _, sa, _ := buildHandler()
+	sa.addMember("sp1", "u_member", 0)
+	require.NoError(t, st.insert(&Model{Slug: "sp_doc", MountType: MountTypeSpace, SpaceId: "sp1", CreatorUID: "u_admin"}))
+	r := newTestRouter(h, "u_member")
+	w := do(r, "GET", "/v1/docs/bindings/sp_doc", nil)
+	assert.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+}
+
+func TestGet_Space_CrossSpaceOutsider_Hidden404(t *testing.T) {
+	// caller 是 sp_other 的成员，但 binding 挂在 sp1 → hidden-404
+	h, st, _, sa, _ := buildHandler()
+	sa.addMember("sp_other", "u_x", 2)
+	require.NoError(t, st.insert(&Model{Slug: "sp_doc", MountType: MountTypeSpace, SpaceId: "sp1", CreatorUID: "u_admin"}))
+	r := newTestRouter(h, "u_x")
+	w := do(r, "GET", "/v1/docs/bindings/sp_doc", nil)
+	assertErrMsgWithNote(t, w, msgNotFound, "cross-space caller must see semantic-404 (hidden-404)")
+}
+
+func TestUpdate_Space_Admin_OK(t *testing.T) {
+	h, st, _, sa, _ := buildHandler()
+	sa.addMember("sp1", "u_admin", 1) // 1=admin
+	require.NoError(t, st.insert(&Model{Slug: "sp_doc", MountType: MountTypeSpace, SpaceId: "sp1", CreatorUID: "u_admin"}))
+	r := newTestRouter(h, "u_admin")
+	w := do(r, "PUT", "/v1/docs/bindings/sp_doc", map[string]interface{}{"allow_share_code": true})
+	assert.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+}
+
+func TestUpdate_Space_NormalMember_403(t *testing.T) {
+	// role=0 普通成员看得到但不能写 → 差别里 403
+	h, st, _, sa, _ := buildHandler()
+	sa.addMember("sp1", "u_normal", 0)
+	require.NoError(t, st.insert(&Model{Slug: "sp_doc", MountType: MountTypeSpace, SpaceId: "sp1", CreatorUID: "u_admin"}))
+	r := newTestRouter(h, "u_normal")
+	w := do(r, "PUT", "/v1/docs/bindings/sp_doc", map[string]interface{}{"allow_share_code": true})
+	assertErrMsg(t, w, msgForbidden)
+}
+
+// ==================== 小工具：isDupSlugErr ====================
+
+func TestIsDupSlugErr(t *testing.T) {
+	assert.True(t, isDupSlugErr(errors.New("Error 1062: Duplicate entry 'x' for key 'doc_binding_slug'")))
+	assert.False(t, isDupSlugErr(errors.New("Error 1062: Duplicate entry 'x' for key 'other_index'")))
+	assert.False(t, isDupSlugErr(nil))
+	assert.False(t, isDupSlugErr(errors.New("connection refused")))
+}
+
+func assertErrMsgf(t *testing.T, w *httptest.ResponseRecorder, wantMsg, note string, args ...interface{}) {
+	t.Helper()
+	assert.Equalf(t, http.StatusBadRequest, w.Code, note+" (wire): body=%s", append(args, w.Body.String())...)
+	assert.Containsf(t, w.Body.String(), "\"msg\":\""+wantMsg+"\"", note+" (msg)", args...)
+}
+
+func assertErrMsgWithNote(t *testing.T, w *httptest.ResponseRecorder, wantMsg, note string) {
+	t.Helper()
+	assert.Equalf(t, http.StatusBadRequest, w.Code, note+" (wire=400 D14); body=%s", w.Body.String())
+	assert.Containsf(t, w.Body.String(), "\"msg\":\""+wantMsg+"\"", note)
+}
+
+// ==================== thread 挂载 · 创建路径（父群归属校验） ====================
+// PR 首版只有"预置一条 thread binding 再测 get/update"的测试，缺 create 路径的归属校验。
+// review02 复核指出：A 群管理员可能把 B 群下 thread 的 short_id 拿来当 thread_id 用；
+// 若不显式校验 (group_no, thread_id) 归属，binding 会写成"group_no=A + thread_id=belongs_to_B"，
+// 之后按 group_no=A 判 ACL 就跟真实所有者错位。下面用例把这个洞焊死。
+
+func TestCreate_Thread_Manager_OwnershipOK(t *testing.T) {
+	h, st, ga, _, ta := buildHandler()
+	ga.addManager("g1", "u_admin")
+	ta.addThread("g1", "t_ok") // (g1,t_ok) 归属真实
+
+	r := newTestRouter(h, "u_admin")
+	w := do(r, "POST", "/v1/docs/bindings", map[string]interface{}{
+		"slug": "th-ok", "mount_type": "thread", "group_no": "g1", "thread_id": "t_ok",
+	})
+	require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	m, _ := st.queryBySlug("th-ok")
+	require.NotNil(t, m)
+	assert.Equal(t, MountTypeThread, m.MountType)
+	assert.Equal(t, "g1", m.GroupNo)
+	assert.Equal(t, "t_ok", m.ThreadId)
+}
+
+func TestCreate_Thread_ThreadNotInGroup_400(t *testing.T) {
+	// A 群管理员拿 B 群下的 thread_id 建 binding —— 必须挡在权限之前，回 400 而不是落库。
+	h, st, ga, _, ta := buildHandler()
+	ga.addManager("gA", "u_adminA")
+	ta.addThread("gB", "t_belongs_to_B") // (gA, t_belongs_to_B) 归属不上
+
+	r := newTestRouter(h, "u_adminA")
+	w := do(r, "POST", "/v1/docs/bindings", map[string]interface{}{
+		"slug": "steal", "mount_type": "thread", "group_no": "gA", "thread_id": "t_belongs_to_B",
+	})
+	// 归属不上：400 + field=thread_id；不是 hidden-404 因为 caller 自报 thread_id，不涉及"该 thread 是否存在于 B 群"的旁路信息泄漏
+	assertErrMsg(t, w, msgReqInvalid)
+	// D14 legacy body 只吐 {msg,status}，不带 details.field；msg=Invalid request. 已足够断言路径。
+
+	// 落库校验：绝对不能写成功
+	m, _ := st.queryBySlug("steal")
+	assert.Nil(t, m, "binding must not be persisted when thread_id does not belong to group_no")
+}
+
+func TestCreate_Thread_UnknownThread_400(t *testing.T) {
+	// 完全不存在的 thread_id 也应挡下，避免出现指向空的挂载记录
+	h, st, ga, _, ta := buildHandler()
+	ga.addManager("g1", "u_admin")
+	_ = ta // 未 addThread
+
+	r := newTestRouter(h, "u_admin")
+	w := do(r, "POST", "/v1/docs/bindings", map[string]interface{}{
+		"slug": "ghost", "mount_type": "thread", "group_no": "g1", "thread_id": "t_nope",
+	})
+	assertErrMsg(t, w, msgReqInvalid)
+	// D14 legacy body 只吐 {msg,status}，不带 details.field；msg=Invalid request. 已足够断言路径。
+	m, _ := st.queryBySlug("ghost")
+	assert.Nil(t, m)
+}
+
+func TestCreate_Thread_OwnershipCheckedBeforeAuth(t *testing.T) {
+	// 关键排序：归属校验必须在 canWrite 之前。这样即便 caller 不是父群管理员，
+	// 我们不会把"这个 thread 在别的群里存在"的信号顺着 403/404 差异泄给他。
+	// 场景：uid 是 gA 群管，但 thread 归属 gB；应报 400/field=thread_id，
+	// 不能因为 gA 权限不足反而回 403（那也算旁路泄漏"归属校验通过了"）。
+	h, _, ga, _, ta := buildHandler()
+	ga.addManager("gA", "u_adminA")
+	ta.addThread("gB", "t_x")
+
+	r := newTestRouter(h, "u_adminA")
+	w := do(r, "POST", "/v1/docs/bindings", map[string]interface{}{
+		"slug": "order", "mount_type": "thread", "group_no": "gA", "thread_id": "t_x",
+	})
+	assertErrMsg(t, w, msgReqInvalid)
+	// D14 legacy body 只吐 {msg,status}，不带 details.field；msg=Invalid request. 已足够断言路径。
+}
+
+func TestCreate_Thread_OwnershipStoreError_StoreFailed(t *testing.T) {
+	// thread 归属查询本身报错走 store_failed 路径，不应该把 err 当作"不存在"回 400。
+	h, _, ga, _, ta := buildHandler()
+	ga.addManager("g1", "u_admin")
+	ta.existErr = errors.New("db down")
+
+	r := newTestRouter(h, "u_admin")
+	w := do(r, "POST", "/v1/docs/bindings", map[string]interface{}{
+		"slug": "boom", "mount_type": "thread", "group_no": "g1", "thread_id": "t_any",
+	})
+	assertErrMsg(t, w, msgStoreFailed)
+}
+
+func TestCreate_Thread_ByGroupMember_403_EvenIfOwnershipOK(t *testing.T) {
+	// 归属通过后再判 canWrite；普通群员照旧 403（不是管理员就不能建 binding）。
+	h, _, ga, _, ta := buildHandler()
+	ga.addMember("g1", "u_member")
+	ta.addThread("g1", "t1")
+
+	r := newTestRouter(h, "u_member")
+	w := do(r, "POST", "/v1/docs/bindings", map[string]interface{}{
+		"slug": "th-mem", "mount_type": "thread", "group_no": "g1", "thread_id": "t1",
+	})
+	assertErrMsg(t, w, msgForbidden)
+}

--- a/modules/doc_binding/db.go
+++ b/modules/doc_binding/db.go
@@ -1,0 +1,60 @@
+package doc_binding
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/pkg/util"
+	"github.com/gocraft/dbr/v2"
+)
+
+type db struct {
+	session *dbr.Session
+	ctx     *config.Context
+}
+
+func newDB(ctx *config.Context) *db {
+	return &db{ctx: ctx, session: ctx.DB()}
+}
+
+// store 是 handler 依赖的持久化面；提出接口是让单测能塞 in-memory 实现，
+// 生产走 *db（MySQL / gocraft-dbr）。方法集刻意小，别把 DB 内部选择漏出去。
+type store interface {
+	insert(m *Model) error
+	queryBySlug(slug string) (*Model, error)
+	updateAllowShareCode(slug string, allow int) error
+	deleteBySlug(slug string) error
+}
+
+// compile-time 声明：*db 必须满足 store。
+var _ store = (*db)(nil)
+
+// insert 新建 binding；slug 唯一索引会把并发重复挂载兜住（调用端翻成 409）。
+func (d *db) insert(m *Model) error {
+	_, err := d.session.InsertInto("doc_binding").
+		Columns(util.AttrToUnderscore(m)...).Record(m).Exec()
+	return err
+}
+
+// queryBySlug slug 主查询；未命中返回 (nil, nil)，交给调用端决定 404/hidden-404。
+func (d *db) queryBySlug(slug string) (*Model, error) {
+	var m Model
+	_, err := d.session.Select("*").From("doc_binding").
+		Where("slug=?", slug).Load(&m)
+	if m.Slug == "" {
+		return nil, err
+	}
+	return &m, err
+}
+
+// updateAllowShareCode PUT 目前只允许改 allow_share_code；其他字段（mount/挂载点）不可变，
+// 想换挂载点应删了重建，避免历史 slug 权限漂移。
+func (d *db) updateAllowShareCode(slug string, allow int) error {
+	_, err := d.session.Update("doc_binding").
+		Set("allow_share_code", allow).
+		Where("slug=?", slug).Exec()
+	return err
+}
+
+func (d *db) deleteBySlug(slug string) error {
+	_, err := d.session.DeleteFrom("doc_binding").Where("slug=?", slug).Exec()
+	return err
+}

--- a/modules/doc_binding/model.go
+++ b/modules/doc_binding/model.go
@@ -1,0 +1,33 @@
+package doc_binding
+
+import (
+	"time"
+)
+
+// MountType 枚举挂载点类型；OCT-130 §3.2 只允许这三种，未识别值一律 400。
+const (
+	MountTypeGroup  = "group"
+	MountTypeThread = "thread"
+	MountTypeSpace  = "space"
+)
+
+// AllowShareCode DB 里 smallint(0/1) 的语义常量，避免散落的 1==true 魔法数字。
+const (
+	AllowShareCodeOff int = 0
+	AllowShareCodeOn  int = 1
+)
+
+// Model 对应 doc_binding 表；字段顺序与 SQL 列一致，方便和 sql/ 对读。
+// gocraft/dbr AttrToUnderscore 依据字段名自动映射列（Id→id, CreatorUID→creator_uid ...）。
+type Model struct {
+	Id             int64
+	Slug           string
+	MountType      string
+	GroupNo        string
+	ThreadId       string
+	SpaceId        string
+	CreatorUID     string
+	AllowShareCode int
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}

--- a/modules/doc_binding/sql/20260709000001_doc_binding_legacy01.sql
+++ b/modules/doc_binding/sql/20260709000001_doc_binding_legacy01.sql
@@ -1,0 +1,23 @@
+
+-- +migrate Up
+
+-- doc_binding：slug ↔ 挂载点（group / thread / space）最小映射
+-- OCT-130 方案 A §3.2；octo-server 只存映射，doc 正文与渲染在 octo-docs-html。
+create table `doc_binding` (
+    id                bigint       not null primary key AUTO_INCREMENT,
+    slug              VARCHAR(120) not null default '',                             -- doc 唯一 slug；本表以此为业务主键
+    mount_type        VARCHAR(16)  not null default '',                             -- 'group' | 'thread' | 'space'
+    group_no          VARCHAR(40)  not null default '',                             -- group / thread 挂载时的群号；space 挂载时为空
+    thread_id         VARCHAR(40)  not null default '',                             -- thread 挂载时的 thread short_id；其它类型为空
+    space_id          VARCHAR(40)  not null default '',                             -- space 挂载时的 space_id；其它类型为空
+    creator_uid       VARCHAR(40)  not null default '',                             -- 建 binding 的用户；用于写权限兜底与审计
+    allow_share_code  smallint     not null default 0,                              -- 分享码开关：0=仅成员可见（默认），1=允许持码人访问
+    created_at        timeStamp    not null default CURRENT_TIMESTAMP,
+    updated_at        timeStamp    not null default CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX doc_binding_slug on `doc_binding` (slug);
+-- 按挂载点反查（“这个群 / 子区 / space 有哪些绑定”）；slug 唯一索引已覆盖单点查询。
+CREATE INDEX doc_binding_group_no  on `doc_binding` (group_no);
+CREATE INDEX doc_binding_thread_id on `doc_binding` (thread_id);
+CREATE INDEX doc_binding_space_id  on `doc_binding` (space_id);

--- a/modules/docs_proxy/1module.go
+++ b/modules/docs_proxy/1module.go
@@ -1,0 +1,34 @@
+package docs_proxy
+
+// docs_proxy: 反代 /v1/docs/proxy/*path 到 doc 服务(octo-docs-html)，转发前把当前
+// 登录用户的 octo token 注入成 X-Octo-Token（对端 FEAT-1 身份桥消费）。
+//
+// 未配置 OCTO_DOCS_UPSTREAM 时整个 module 跳过（Route 不挂 endpoint），避免误反代 nil upstream。
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
+	"go.uber.org/zap"
+)
+
+func init() {
+	register.AddModule(func(ctx interface{}) register.Module {
+		return register.Module{
+			Name: "docs_proxy",
+			SetupAPI: func() register.APIRouter {
+				cctx := ctx.(*config.Context)
+				h := New(cctx)
+				if h == nil {
+					// 未配置 upstream：返回一个 no-op router；Route 里不挂任何路径。
+					log.NewTLog("docs_proxy").Warn(
+						"OCTO_DOCS_UPSTREAM 未配置，docs_proxy 路由未启用",
+						zap.String("module", "docs_proxy"),
+					)
+					return &Proxy{disabled: true}
+				}
+				return h
+			},
+		}
+	})
+}

--- a/modules/docs_proxy/README.md
+++ b/modules/docs_proxy/README.md
@@ -1,0 +1,62 @@
+# docs_proxy
+
+octo-server 侧 `/v1/docs/proxy/*path` 反向代理，把已鉴权请求转发到 doc 服务
+（`octo-docs-html`），供 doc 侧在同一 origin 下渲染。
+
+## 路由
+
+- 挂载点：`/v1/docs/proxy/*action`（`Any` method，含 OPTIONS）。
+- 上游地址由环境变量 `OCTO_DOCS_UPSTREAM` 指定；未配置整个 module 跳过路由挂载。
+- 路径映射：`/v1/docs/proxy/<rest>` → `<upstream>/<rest>`（`upstream` 若带 basepath 会保留）。
+- 中间件链：先 `AuthMiddleware`（匿名请求 401 abort），后反代 handler。
+
+## 反代注入的头（内网可信头）
+
+反代在**已鉴权通过**、把请求转发到上游 doc 服务之前，注入以下头。**每个头都必须
+先 `Del` 掉 caller 可能自带的同名头，再 `Set` 反代自己算出来的值**，防止外网 caller
+伪造身份。
+
+| Header | 语义 | 来源 |
+| --- | --- | --- |
+| `X-Octo-Token` | 当前用户的 octo token | caller 请求的 `token` header（AuthMiddleware 已校验合法） |
+| `X-Octo-Uid` | 登录用户 uid | `wkhttp.Context.GetLoginUID()`（OCT-145 方案 C 新增） |
+| `X-Octo-Name` | 登录用户显示名 | `wkhttp.Context.GetLoginName()`（OCT-145 方案 C 新增） |
+| `X-Octo-Role` | 登录用户角色 | `wkhttp.Context.GetLoginRole()`，收敛到 `superAdmin` / `admin` / `member`（OCT-145 方案 C 新增） |
+
+`X-Octo-Role` 的值域**只有** `superAdmin` / `admin` / `member` 三种：wkhttp 常量
+里 `superAdmin` / `admin` 保留原样，其他一切字面量（空串、未识别 role）一律降级
+`member` —— 保证 doc 侧按稳定字符串判权，不会把空串或未知值当合法 role 提权。
+
+同时反代在转发前会剥掉以下 caller 头，防止 leak 到上游：
+
+- `Authorization`（防外部凭据泄给 doc）
+- `Cookie`（防会话跨域串）
+- `token`（原始 token 只以 `X-Octo-Token` 内网头形式过去）
+- RFC 7230 §6.1 hop-by-hop 头 + `Trailer` / `Upgrade`（请求 & 响应两侧都清）
+
+## ⚠️ 部署硬约束：反代→doc 必须走内网
+
+`X-Octo-Uid` / `X-Octo-Name` / `X-Octo-Role` 是**内网信任头**：一旦 doc 服务
+在外网可达，外网 caller 直接把这三个头打给 doc 就是身份伪造缺口。部署方**必须**
+保证：
+
+1. doc 服务（`OCTO_DOCS_UPSTREAM` 指向的地址）**只在内网监听**，外网无法直连。
+2. 外网入口只暴露 octo-server 的 `/v1/docs/proxy/*`，所有请求必经反代过 Auth。
+3. 如果 doc 服务不得不暴露到外网（不推荐），必须自行加一层信任 IP 白名单，
+   只接受来自反代的源 IP，且在 doc 侧再验一次 `X-Octo-Token`（回打 octo-server）
+   做保险 —— 这时方案 C 的信任头就退化成方案 A/B，性能优势没了。
+
+## 环境变量
+
+| 变量 | 默认 | 说明 |
+| --- | --- | --- |
+| `OCTO_DOCS_UPSTREAM` | *(空)* | doc 服务地址。未配置 → module disable，`/v1/docs/proxy/*` 返 404。 |
+| `OCTO_DOCS_PROXY_TIMEOUT_MS` | `30000` | 反代到 doc 的 response header 超时（毫秒）。非法值回落默认。 |
+
+### 废弃变量（OCT-145 方案 C 落地后不再使用）
+
+- `OCTO_OPENAPI_URL`：方案 A/B 里 doc 侧用来回打 octo openapi 拿 userinfo。方案 C
+  下 doc 侧直接消费 `X-Octo-Uid/Name/Role`，不再需要。**doc 侧配置可移除**。
+- `OCTO_USERINFO_URL`：同上，方案 C 下 doc 侧不再调 userinfo。**doc 侧配置可移除**。
+
+octo-server 侧本来就没读这两个变量，改动只影响 doc 侧部署清单。

--- a/modules/docs_proxy/api.go
+++ b/modules/docs_proxy/api.go
@@ -1,0 +1,233 @@
+package docs_proxy
+
+// 反向代理实现，把 /v1/docs/proxy/*path 转发到 OCTO_DOCS_UPSTREAM。
+//
+// 契约（与父单 OCT-136 §4 + FEAT-1 身份桥一致）：
+//   - AuthMiddleware 已在 group 上：未登录一律 401，匿名不透传。
+//   - 转发时注入 X-Octo-Token = 当前请求的 "token" header 原值（AuthMiddleware
+//     校验过合法性），供 doc 侧 FEAT-1 反查 uid。
+//   - 剥离 caller 侧 Authorization / Cookie / 原始 token header，防止 leak 到 upstream。
+//   - hop-by-hop headers（RFC 7230 §6.1 + Trailer/Upgrade）请求响应两侧都 strip。
+//   - 响应 body 直接 streaming（httputil 默认行为），不整段缓存。
+//   - CORS 预检 OPTIONS：直接放行，不反代（返回 204，Allow-* 由前置网关处理）。
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"go.uber.org/zap"
+)
+
+// 反代挂在 /v1/docs 下，具体前缀 /v1/docs/proxy。
+// 路径映射：/v1/docs/proxy/<rest> → upstream <rest>（不带 /v1/docs/proxy 前缀）。
+// 这样 doc 侧的 handler 看到的就是自己的原生路径（例 /v1/docs/foo/versions）。
+const (
+	routePrefix   = "/v1/docs/proxy"
+	upstreamEnv   = "OCTO_DOCS_UPSTREAM"
+	timeoutEnv    = "OCTO_DOCS_PROXY_TIMEOUT_MS"
+	defaultTimeMS = 30_000
+
+	// header 常量：常量而不是字面量是为了单测能引用同一份 key，避免测试与实现字面漂移。
+	headerOctoToken = "X-Octo-Token"
+	headerToken     = "token"
+	headerAuth      = "Authorization"
+	headerCookie    = "Cookie"
+)
+
+// hopByHop 是 RFC 7230 §6.1 的 hop-by-hop headers，加 Trailer/Upgrade。
+// 请求侧 strip 避免透传到 upstream；响应侧 strip 避免透传回 caller。
+// httputil.ReverseProxy 只 strip 请求侧标准集合，响应侧不动，所以自己再兜底一遍。
+var hopByHop = []string{
+	"Connection",
+	"Proxy-Connection",
+	"Keep-Alive",
+	"Transfer-Encoding",
+	"Te",
+	"Trailer",
+	"Upgrade",
+	"Proxy-Authorization",
+	"Proxy-Authenticate",
+}
+
+// Proxy 是 docs_proxy handler。disabled=true 时 Route 不挂任何 endpoint。
+type Proxy struct {
+	ctx      *config.Context
+	upstream *url.URL
+	rp       *httputil.ReverseProxy
+	timeout  time.Duration
+	disabled bool
+	log.Log
+}
+
+// New 读环境变量构造 Proxy。upstream 未配置 → 返回 nil（1module.go 依此判定 disable）。
+// upstream 解析失败 → 也返回 nil 并 warn，避免启动崩溃。
+func New(ctx *config.Context) *Proxy {
+	upstream := strings.TrimSpace(os.Getenv(upstreamEnv))
+	if upstream == "" {
+		return nil
+	}
+	u, err := url.Parse(upstream)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		log.NewTLog("docs_proxy").Error(
+			"OCTO_DOCS_UPSTREAM 解析失败，docs_proxy 未启用",
+			zap.String("value", upstream), zap.Error(err),
+		)
+		return nil
+	}
+	timeout := time.Duration(defaultTimeMS) * time.Millisecond
+	if v := strings.TrimSpace(os.Getenv(timeoutEnv)); v != "" {
+		if ms, err := strconv.Atoi(v); err == nil && ms > 0 {
+			timeout = time.Duration(ms) * time.Millisecond
+		}
+	}
+
+	p := &Proxy{
+		ctx:      ctx,
+		upstream: u,
+		timeout:  timeout,
+		Log:      log.NewTLog("docs_proxy"),
+	}
+	p.rp = &httputil.ReverseProxy{
+		Director:       p.director,
+		ErrorHandler:   p.errorHandler,
+		ModifyResponse: p.modifyResponse,
+		Transport: &http.Transport{
+			// 单独一份 transport 是为了：(1) 自己控超时；(2) 不污染进程默认 Transport 的连接池。
+			ResponseHeaderTimeout: timeout,
+			IdleConnTimeout:       90 * time.Second,
+			MaxIdleConnsPerHost:   16,
+		},
+	}
+	return p
+}
+
+// Route 挂反代到 AuthMiddleware 下；disabled=true 时不挂任何路径。
+// 用 wkhttp.WKHttp.Any 一次覆盖全 HTTP method（父单 §2：GET/POST/PUT/DELETE/HEAD/OPTIONS 全支持）。
+// AuthMiddleware 作为 chain 前置：token 缺失/失效 → 401 abort，proxy handler 拿不到匿名请求。
+// OPTIONS 在 handler 内 204 短路；wkhttp 顶层 CORSMiddleware 若已挂，preflight 更早就被截了。
+func (p *Proxy) Route(r *wkhttp.WKHttp) {
+	if p.disabled {
+		return
+	}
+	r.Any(routePrefix+"/*action", p.ctx.AuthMiddleware(r), p.handle)
+}
+
+// handle 是 4 种 method 的统一入口；OPTIONS 直接 204 短路（CORS preflight 不反代）。
+func (p *Proxy) handle(c *wkhttp.Context) {
+	if c.Request.Method == http.MethodOptions {
+		c.Status(http.StatusNoContent)
+		return
+	}
+	// AuthMiddleware 已保证 uid 存在；再兜一次是防 middleware 顺序漂移导致 silent 透传匿名请求。
+	if c.GetLoginUID() == "" {
+		c.AbortWithStatus(http.StatusUnauthorized)
+		return
+	}
+	// caller 的原始 token：AuthMiddleware 用它反查过 uid，拿来即当前用户 octo token。
+	// 拿不到（middleware 侧写了 uid 但清了 header 的极端场景）→ 401 明确报错，别静默透传。
+	token := c.Request.Header.Get(headerToken)
+	if token == "" {
+		c.AbortWithStatus(http.StatusUnauthorized)
+		return
+	}
+	// director 里要读这个 token 注入到 upstream 请求，用 context 传（不落全局 map）。
+	c.Request = c.Request.WithContext(withToken(c.Request.Context(), token))
+	p.rp.ServeHTTP(c.Writer, c.Request)
+}
+
+// director 改写请求指向 upstream；houseKeeping：
+//  1. scheme/host 换成 upstream；
+//  2. path 剥掉 /v1/docs/proxy 前缀（保留后续路径原样，包括查询串）；
+//  3. 注入 X-Octo-Token，删掉 caller 侧敏感 header 与 hop-by-hop；
+//  4. Host header 改成 upstream host（否则 upstream 侧虚拟主机会 misroute）。
+func (p *Proxy) director(req *http.Request) {
+	req.URL.Scheme = p.upstream.Scheme
+	req.URL.Host = p.upstream.Host
+
+	// 剥前缀：/v1/docs/proxy/foo/bar → /foo/bar；恰等于 /v1/docs/proxy → /（避免路径为空）。
+	rest := strings.TrimPrefix(req.URL.Path, routePrefix)
+	if rest == "" {
+		rest = "/"
+	}
+	// upstream 若本身带 basepath（如 http://host/api），拼一次以保留。
+	req.URL.Path = singleJoiningSlash(p.upstream.Path, rest)
+	req.Host = p.upstream.Host
+
+	// 敏感 header：caller 的 Authorization / Cookie / token 一律不透传，upstream 只信 X-Octo-Token。
+	// Cookie 保留业务侧 Set-Cookie 响应，但请求侧不带过去（避免会话跨域串）。
+	req.Header.Del(headerAuth)
+	req.Header.Del(headerCookie)
+	req.Header.Del(headerToken)
+	// hop-by-hop 请求侧清理。
+	for _, h := range hopByHop {
+		req.Header.Del(h)
+	}
+	// 从 context 拿 handle 阶段落进来的原始 token，注入。
+	if tok, ok := tokenFromContext(req.Context()); ok && tok != "" {
+		req.Header.Set(headerOctoToken, tok)
+	}
+	// User-Agent 空值时 http 客户端会自加默认 UA，为让 upstream 日志更清楚，显式打标。
+	if req.Header.Get("User-Agent") == "" {
+		req.Header.Set("User-Agent", "octo-server/docs_proxy")
+	}
+}
+
+// modifyResponse 响应侧 hop-by-hop strip；Set-Cookie 保留（caller 端设置 doc 侧 session 有用途）。
+// 不缓冲 body：httputil.ReverseProxy 默认 Copy(w, resp.Body) streaming。
+func (p *Proxy) modifyResponse(resp *http.Response) error {
+	for _, h := range hopByHop {
+		resp.Header.Del(h)
+	}
+	return nil
+}
+
+// errorHandler：upstream 超时/连接失败 → 502 Bad Gateway。默认 ReverseProxy 是 502，
+// 但自定义一版是为了：(1) 打结构化日志方便定位；(2) 不把 upstream 内部错误字面回吐给 caller。
+func (p *Proxy) errorHandler(w http.ResponseWriter, r *http.Request, err error) {
+	p.Warn("docs_proxy upstream 调用失败",
+		zap.String("path", r.URL.Path),
+		zap.String("method", r.Method),
+		zap.Error(err),
+	)
+	// context canceled：caller 主动断，不算故障，回 499 会误报；沿用 502。
+	if errors.Is(err, http.ErrAbortHandler) {
+		return
+	}
+	w.WriteHeader(http.StatusBadGateway)
+}
+
+// ---- context key --------------------------------------------------------
+
+type ctxKey struct{}
+
+func withToken(parent context.Context, token string) context.Context {
+	return context.WithValue(parent, ctxKey{}, token)
+}
+func tokenFromContext(c context.Context) (string, bool) {
+	v, ok := c.Value(ctxKey{}).(string)
+	return v, ok
+}
+
+// singleJoiningSlash 抄 net/http/httputil 的私有工具：合并 basepath 与后续 path，
+// 避免出现 // 或漏斜杠。
+func singleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash:
+		return a + "/" + b
+	}
+	return a + b
+}

--- a/modules/docs_proxy/api.go
+++ b/modules/docs_proxy/api.go
@@ -2,14 +2,20 @@ package docs_proxy
 
 // 反向代理实现，把 /v1/docs/proxy/*path 转发到 OCTO_DOCS_UPSTREAM。
 //
-// 契约（与父单 OCT-136 §4 + FEAT-1 身份桥一致）：
+// 契约（与父单 OCT-136 §4 + FEAT-1 身份桥 + OCT-145 方案 C 内网信任头一致）：
 //   - AuthMiddleware 已在 group 上：未登录一律 401，匿名不透传。
 //   - 转发时注入 X-Octo-Token = 当前请求的 "token" header 原值（AuthMiddleware
 //     校验过合法性），供 doc 侧 FEAT-1 反查 uid。
+//   - OCT-145 方案 C：反代→doc 走内网信任通道，额外注入身份三元组
+//     X-Octo-Uid / X-Octo-Name / X-Octo-Role，doc 侧直接消费，不再回打 userinfo。
+//     注入前一律 Del 掉 caller 可能自带的同名头，防伪造身份。
 //   - 剥离 caller 侧 Authorization / Cookie / 原始 token header，防止 leak 到 upstream。
 //   - hop-by-hop headers（RFC 7230 §6.1 + Trailer/Upgrade）请求响应两侧都 strip。
 //   - 响应 body 直接 streaming（httputil 默认行为），不整段缓存。
 //   - CORS 预检 OPTIONS：直接放行，不反代（返回 204，Allow-* 由前置网关处理）。
+//
+// 部署侧硬约束（OCT-145 方案 C）：反代→doc 必须走内网，doc 侧只在内网监听。
+// 三个身份头一旦被外网 caller 直接打到 doc 就是身份伪造缺口 —— 见 README.md。
 
 import (
 	"context"
@@ -39,9 +45,18 @@ const (
 
 	// header 常量：常量而不是字面量是为了单测能引用同一份 key，避免测试与实现字面漂移。
 	headerOctoToken = "X-Octo-Token"
+	headerOctoUID   = "X-Octo-Uid"
+	headerOctoName  = "X-Octo-Name"
+	headerOctoRole  = "X-Octo-Role"
 	headerToken     = "token"
 	headerAuth      = "Authorization"
 	headerCookie    = "Cookie"
+
+	// role 值域：doc 侧按稳定字符串判权（superAdmin/admin/member），
+	// 未识别一律降级为 member，避免把空串或未知字面吐给 doc 造成隐式提权。
+	roleSuperAdmin = "superAdmin"
+	roleAdmin      = "admin"
+	roleMember     = "member"
 )
 
 // hopByHop 是 RFC 7230 §6.1 的 hop-by-hop headers，加 Trailer/Upgrade。
@@ -140,8 +155,15 @@ func (p *Proxy) handle(c *wkhttp.Context) {
 		c.AbortWithStatus(http.StatusUnauthorized)
 		return
 	}
-	// director 里要读这个 token 注入到 upstream 请求，用 context 传（不落全局 map）。
-	c.Request = c.Request.WithContext(withToken(c.Request.Context(), token))
+	// OCT-145 方案 C：把已鉴权的登录态一并封进 context，director 里注入内网信任头。
+	// name/role 允许为空（部分登录路径可能没写全）；role 用 normalizeRole 收敛值域。
+	id := identity{
+		token: token,
+		uid:   c.GetLoginUID(),
+		name:  c.GetLoginName(),
+		role:  normalizeRole(c.GetLoginRole()),
+	}
+	c.Request = c.Request.WithContext(withIdentity(c.Request.Context(), id))
 	p.rp.ServeHTTP(c.Writer, c.Request)
 }
 
@@ -168,13 +190,29 @@ func (p *Proxy) director(req *http.Request) {
 	req.Header.Del(headerAuth)
 	req.Header.Del(headerCookie)
 	req.Header.Del(headerToken)
+	// OCT-145 方案 C：三个身份头 Del 后 Set，防 caller 自带同名头伪造身份。
+	// 三个 Del 一个都不能漏 —— 少 Del 一个就是伪造缺口。Set 走已鉴权的登录态。
+	req.Header.Del(headerOctoUID)
+	req.Header.Del(headerOctoName)
+	req.Header.Del(headerOctoRole)
 	// hop-by-hop 请求侧清理。
 	for _, h := range hopByHop {
 		req.Header.Del(h)
 	}
-	// 从 context 拿 handle 阶段落进来的原始 token，注入。
-	if tok, ok := tokenFromContext(req.Context()); ok && tok != "" {
-		req.Header.Set(headerOctoToken, tok)
+	// 从 context 拿 handle 阶段落进来的登录态，token 是必有的，身份三元组按值注入
+	// （uid/name 允许空串 —— 空串代表登录态里就没有，doc 侧自己兜底，不写空避免误覆盖）。
+	if id, ok := identityFromContext(req.Context()); ok {
+		if id.token != "" {
+			req.Header.Set(headerOctoToken, id.token)
+		}
+		if id.uid != "" {
+			req.Header.Set(headerOctoUID, id.uid)
+		}
+		if id.name != "" {
+			req.Header.Set(headerOctoName, id.name)
+		}
+		// role 一定写：normalizeRole 保证一定是 superAdmin/admin/member 之一。
+		req.Header.Set(headerOctoRole, id.role)
 	}
 	// User-Agent 空值时 http 客户端会自加默认 UA，为让 upstream 日志更清楚，显式打标。
 	if req.Header.Get("User-Agent") == "" {
@@ -208,14 +246,36 @@ func (p *Proxy) errorHandler(w http.ResponseWriter, r *http.Request, err error) 
 
 // ---- context key --------------------------------------------------------
 
+// identity 是反代要注入 doc 的登录态快照（OCT-145 方案 C）。放 context 而不是
+// 全局 map，避免并发请求相互覆盖；handle → director 单向传递，值语义无锁。
+type identity struct {
+	token string
+	uid   string
+	name  string
+	role  string
+}
+
 type ctxKey struct{}
 
-func withToken(parent context.Context, token string) context.Context {
-	return context.WithValue(parent, ctxKey{}, token)
+func withIdentity(parent context.Context, id identity) context.Context {
+	return context.WithValue(parent, ctxKey{}, id)
 }
-func tokenFromContext(c context.Context) (string, bool) {
-	v, ok := c.Value(ctxKey{}).(string)
+func identityFromContext(c context.Context) (identity, bool) {
+	v, ok := c.Value(ctxKey{}).(identity)
 	return v, ok
+}
+
+// normalizeRole 把 wkhttp 现成的 role 字面收敛到稳定值域，避免把空串/未知字面
+// 直接吐给 doc。superAdmin/admin 保留原样，其他一律降级 member（不提权）。
+func normalizeRole(raw string) string {
+	switch raw {
+	case roleSuperAdmin:
+		return roleSuperAdmin
+	case roleAdmin:
+		return roleAdmin
+	default:
+		return roleMember
+	}
 }
 
 // singleJoiningSlash 抄 net/http/httputil 的私有工具：合并 basepath 与后续 path，

--- a/modules/docs_proxy/api_test.go
+++ b/modules/docs_proxy/api_test.go
@@ -1,0 +1,426 @@
+package docs_proxy
+
+// api_test.go
+//
+// 起 httptest.Server 假扮 upstream；wkhttp.WKHttp 挂 Proxy.Route + 手写测试 middleware
+// 模拟 AuthMiddleware（真的 AuthMiddleware 依赖 cache，这里绕过，只需要把 uid 写进 c 即可）。
+//
+// 覆盖父单 OCT-144 §测试：
+//   - 未配置 OCTO_DOCS_UPSTREAM → New 返回 nil；Route 不挂 → 404
+//   - 未登录 (无 uid) → 401，upstream.callCount == 0
+//   - 已登录 → upstream 收到 X-Octo-Token=<token>；caller 侧 Authorization/Cookie/token 未透传
+//   - 请求侧 hop-by-hop（Connection/Keep-Alive/Upgrade/…）被 strip
+//   - 响应侧 hop-by-hop 被 strip
+//   - OPTIONS → 204 短路，upstream 未被调
+//   - GET/POST/PUT/DELETE/HEAD/PATCH 全 method 反代通
+//   - path 前缀剥离正确：/v1/docs/proxy/foo/bar → upstream /foo/bar（含 query）
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// upstreamCapture 记录 upstream 收到的最后一个请求，供 assert 用。
+type upstreamCapture struct {
+	calls   int64
+	method  atomic.Value // string
+	path    atomic.Value // string
+	rawq    atomic.Value // string
+	headers atomic.Value // http.Header
+	body    atomic.Value // []byte
+}
+
+func (u *upstreamCapture) reset() { atomic.StoreInt64(&u.calls, 0) }
+
+// newUpstream 起 httptest.Server；handler 记录并回一个带 hop-by-hop 头的响应，
+// 让测试同时验证响应侧 strip。
+func newUpstream(t *testing.T, cap *upstreamCapture) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&cap.calls, 1)
+		cap.method.Store(r.Method)
+		cap.path.Store(r.URL.Path)
+		cap.rawq.Store(r.URL.RawQuery)
+		// 深拷贝 header：http.Header 是 map，反代结束后底层可能改。
+		h := http.Header{}
+		for k, v := range r.Header {
+			h[k] = append([]string(nil), v...)
+		}
+		cap.headers.Store(h)
+		b, _ := io.ReadAll(r.Body)
+		cap.body.Store(b)
+
+		// 响应侧塞几个 hop-by-hop 头，验 modifyResponse 剥掉。
+		w.Header().Set("Connection", "close")
+		w.Header().Set("Keep-Alive", "timeout=5")
+		w.Header().Set("X-Upstream-Marker", "ok")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello"))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// setEnv 临时设置环境变量并在测试结束恢复。upstream url 空字符串 = 删除。
+func setEnv(t *testing.T, k, v string) {
+	t.Helper()
+	prev, had := os.LookupEnv(k)
+	if v == "" {
+		_ = os.Unsetenv(k)
+	} else {
+		_ = os.Setenv(k, v)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(k, prev)
+		} else {
+			_ = os.Unsetenv(k)
+		}
+	})
+}
+
+// buildProxy 构造 Proxy（已注 log）。ctx 传 nil 是因为 handler 里没用 ctx，
+// 只在 Route 里读 ctx.AuthMiddleware —— 测试用自己写的 middleware 绕过。
+func buildProxy(t *testing.T, upstream string) *Proxy {
+	t.Helper()
+	setEnv(t, upstreamEnv, upstream)
+	p := New(nil)
+	if p != nil {
+		// 强制注入 log，避免 handler 里 h.Warn nil-deref（New 里已注，但保险）。
+		p.Log = log.NewTLog("docs_proxy_test")
+	}
+	return p
+}
+
+// newTestRouter 拼 wkhttp 路由；用 fakeAuth 代替真的 AuthMiddleware，按 header
+// "token" 决定挂哪些字段。emptyToken=true 时不注 uid（模拟未登录场景后 handler 层再校验一次）。
+// 真实链路里 AuthMiddleware 无 token 会自己 abort 401；测试里手动 abort 达成同样效果。
+func newTestRouter(t *testing.T, p *Proxy) *wkhttp.WKHttp {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := wkhttp.New()
+	fakeAuth := func(c *wkhttp.Context) {
+		tok := c.Request.Header.Get(headerToken)
+		if tok == "" {
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+		// 从 token 里派生 uid：简化桩，格式 "tok:<uid>"，回落到 tok 本身。
+		uid := tok
+		if strings.HasPrefix(tok, "tok:") {
+			uid = strings.TrimPrefix(tok, "tok:")
+		}
+		c.Set("uid", uid)
+		c.Next()
+	}
+	if p == nil {
+		// disabled 分支：显式不挂任何路由，验证 404。
+		return r
+	}
+	r.Any(routePrefix+"/*action", fakeAuth, p.handle)
+	return r
+}
+
+// doReq 通过真的 httptest.Server 打到 wkhttp router。用真 server 而不是 Recorder：
+// gin.responseWriter.CloseNotify 要求底层 ResponseWriter 实现 http.CloseNotifier，
+// httptest.Recorder 不实现，ReverseProxy.ServeHTTP 会 panic —— 用真 http server 绕开。
+// 返回一个 fakeRecorder，暴露 Code/Header()/Body.String() 保持与 httptest.Recorder 同型。
+func doReq(t *testing.T, r *wkhttp.WKHttp, method, target string, headers http.Header, body string) *fakeRecorder {
+	t.Helper()
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+	var rd io.Reader
+	if body != "" {
+		rd = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, srv.URL+target, rd)
+	require.NoError(t, err)
+	for k, vs := range headers {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+	// http.Client 默认对 30x follow；测试 URL 不涉及跳转，保持默认即可。
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	bts, _ := io.ReadAll(resp.Body)
+	return &fakeRecorder{Code: resp.StatusCode, HeaderMap: resp.Header, BodyBytes: bts}
+}
+
+// fakeRecorder 模仿 httptest.ResponseRecorder 的最小 API 面，供既有 assert 复用。
+type fakeRecorder struct {
+	Code      int
+	HeaderMap http.Header
+	BodyBytes []byte
+}
+
+func (f *fakeRecorder) Header() http.Header { return f.HeaderMap }
+
+// Body 返回一个 bytes.Buffer-like 结构，只需要 String()。
+type bodyView struct{ b []byte }
+
+func (b bodyView) String() string { return string(b.b) }
+
+// Body 属性访问：既有测试用 w.BodyView().String()，我们给一个 method 别名。
+func (f *fakeRecorder) BodyView() bodyView { return bodyView{b: f.BodyBytes} }
+
+// ---- 测试用例 ------------------------------------------------------------
+
+// New 与 disabled：OCTO_DOCS_UPSTREAM 空 → nil。
+func TestNew_DisabledWhenUpstreamEmpty(t *testing.T) {
+	setEnv(t, upstreamEnv, "")
+	assert.Nil(t, New(nil))
+}
+
+// upstream URL 非法 → nil，不 panic。
+func TestNew_DisabledOnInvalidUpstream(t *testing.T) {
+	setEnv(t, upstreamEnv, "not-a-url")
+	assert.Nil(t, New(nil))
+}
+
+// OCTO_DOCS_UPSTREAM 空 → route 未挂 → 404（父单验收 §3）。
+func TestRoute_NotRegisteredWhenDisabled(t *testing.T) {
+	setEnv(t, upstreamEnv, "")
+	p := New(nil)
+	require.Nil(t, p)
+	r := newTestRouter(t, p)
+	w := doReq(t, r, http.MethodGet, "/v1/docs/proxy/foo", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// 未登录 → 401，upstream 未被调（父单验收 §1）。
+func TestProxy_UnauthorizedNoUpstream(t *testing.T) {
+	cap := &upstreamCapture{}
+	up := newUpstream(t, cap)
+	p := buildProxy(t, up.URL)
+	require.NotNil(t, p)
+	r := newTestRouter(t, p)
+
+	w := doReq(t, r, http.MethodGet, "/v1/docs/proxy/foo", nil, "")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Equal(t, int64(0), atomic.LoadInt64(&cap.calls))
+}
+
+// 登录后 upstream 收到 X-Octo-Token；caller Authorization/Cookie/token 未透传（父单验收 §2）。
+func TestProxy_InjectsOctoToken_StripsCallerCreds(t *testing.T) {
+	cap := &upstreamCapture{}
+	up := newUpstream(t, cap)
+	p := buildProxy(t, up.URL)
+	require.NotNil(t, p)
+	r := newTestRouter(t, p)
+
+	h := http.Header{}
+	h.Set(headerToken, "tok:alice")
+	h.Set(headerAuth, "Bearer leak-me")
+	h.Set(headerCookie, "sess=leak-me")
+	h.Set("X-Business", "keep")
+
+	w := doReq(t, r, http.MethodGet, "/v1/docs/proxy/foo/bar?x=1&y=2", h, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, int64(1), atomic.LoadInt64(&cap.calls))
+
+	got := cap.headers.Load().(http.Header)
+	assert.Equal(t, "tok:alice", got.Get(headerOctoToken), "X-Octo-Token 必须注入")
+	assert.Empty(t, got.Get(headerAuth), "Authorization 必须剥掉")
+	assert.Empty(t, got.Get(headerCookie), "Cookie 必须剥掉")
+	assert.Empty(t, got.Get(headerToken), "原始 token header 必须剥掉，只保留 X-Octo-Token")
+	assert.Equal(t, "keep", got.Get("X-Business"), "业务 header 应透传")
+
+	// path 剥前缀 + 保留 query。
+	assert.Equal(t, "/foo/bar", cap.path.Load().(string))
+	assert.Equal(t, "x=1&y=2", cap.rawq.Load().(string))
+}
+
+// 请求侧 hop-by-hop 全被剥离。
+func TestProxy_StripsRequestHopByHopHeaders(t *testing.T) {
+	cap := &upstreamCapture{}
+	up := newUpstream(t, cap)
+	p := buildProxy(t, up.URL)
+	r := newTestRouter(t, p)
+
+	h := http.Header{}
+	h.Set(headerToken, "tok:bob")
+	// caller 塞的 hop-by-hop 值故意标记 leak-*，验证 upstream 收到的不是这些值。
+	// 注：Te 的合法哨兵值 "trailers" 是 Go 标准库 http.Transport 会为 HTTP/1.1
+	// 强制加的（transport.go writeSubset），我们只需保证 caller 的自定义 Te 值
+	// 不会被透传即可，所以特意用 leak-marker。
+	h.Set("Connection", "close, leak-connection")
+	h.Set("Keep-Alive", "timeout=5")
+	h.Set("Proxy-Authorization", "Basic leak")
+	h.Set("Upgrade", "leak-proto")
+	h.Set("Te", "leak-te-value")
+	h.Set("Trailer", "X-Leak-Trailer")
+
+	w := doReq(t, r, http.MethodPost, "/v1/docs/proxy/thing", h, `{"k":"v"}`)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	got := cap.headers.Load().(http.Header)
+	assert.Empty(t, got.Get("Connection"), "请求侧 Connection 应被 strip")
+	assert.Empty(t, got.Get("Keep-Alive"), "请求侧 Keep-Alive 应被 strip")
+	assert.Empty(t, got.Get("Proxy-Authorization"), "请求侧 Proxy-Authorization 应被 strip")
+	assert.Empty(t, got.Get("Upgrade"), "请求侧 Upgrade 应被 strip")
+	assert.Empty(t, got.Get("Trailer"), "请求侧 Trailer 应被 strip")
+	// Te：即使 Go 标准库补 "trailers"，也绝不能出现 caller 的 leak-te-value。
+	assert.NotContains(t, got.Get("Te"), "leak-te-value", "caller 的 Te 值必须不透传")
+	// POST body 也要透传。
+	assert.Equal(t, `{"k":"v"}`, string(cap.body.Load().([]byte)))
+}
+
+// 响应侧 hop-by-hop 被剥离（Connection/Keep-Alive 不该出现在返回给 caller 的响应里）。
+func TestProxy_StripsResponseHopByHopHeaders(t *testing.T) {
+	cap := &upstreamCapture{}
+	up := newUpstream(t, cap)
+	p := buildProxy(t, up.URL)
+	r := newTestRouter(t, p)
+
+	h := http.Header{}
+	h.Set(headerToken, "tok:carol")
+	w := doReq(t, r, http.MethodGet, "/v1/docs/proxy/x", h, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get("Connection"))
+	assert.Empty(t, w.Header().Get("Keep-Alive"))
+	// 非 hop-by-hop 业务头保留。
+	assert.Equal(t, "ok", w.Header().Get("X-Upstream-Marker"))
+	// body streaming。
+	assert.Equal(t, "hello", w.BodyView().String())
+}
+
+// OPTIONS 短路 204，upstream 未被调（CORS 预检不反代）。
+func TestProxy_OptionsShortCircuit(t *testing.T) {
+	cap := &upstreamCapture{}
+	up := newUpstream(t, cap)
+	p := buildProxy(t, up.URL)
+	r := newTestRouter(t, p)
+
+	h := http.Header{}
+	h.Set(headerToken, "tok:dave")
+	w := doReq(t, r, http.MethodOptions, "/v1/docs/proxy/foo", h, "")
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Equal(t, int64(0), atomic.LoadInt64(&cap.calls))
+}
+
+// 全 method 都能反代通（GET/POST/PUT/DELETE/HEAD/PATCH）。
+func TestProxy_AllMethodsProxied(t *testing.T) {
+	cap := &upstreamCapture{}
+	up := newUpstream(t, cap)
+	p := buildProxy(t, up.URL)
+	r := newTestRouter(t, p)
+
+	methods := []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodHead, http.MethodPatch}
+	for _, m := range methods {
+		cap.reset()
+		h := http.Header{}
+		h.Set(headerToken, "tok:eve")
+		w := doReq(t, r, m, "/v1/docs/proxy/x", h, "")
+		assert.Equal(t, http.StatusOK, w.Code, "method %s", m)
+		require.Equal(t, int64(1), atomic.LoadInt64(&cap.calls), "upstream should be hit for %s", m)
+		assert.Equal(t, m, cap.method.Load().(string))
+	}
+}
+
+// upstream 挂了（连接失败）→ 502，caller 不见 upstream 内部错误字面。
+func TestProxy_UpstreamDown_502(t *testing.T) {
+	// 拿一个已关闭的 server URL：起一个再关。
+	tmp := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	deadURL := tmp.URL
+	tmp.Close()
+
+	p := buildProxy(t, deadURL)
+	require.NotNil(t, p)
+	// 缩短 transport 超时避免测试卡死。
+	p.rp.Transport = &http.Transport{ResponseHeaderTimeout: 500 * time.Millisecond}
+	r := newTestRouter(t, p)
+
+	h := http.Header{}
+	h.Set(headerToken, "tok:frank")
+	w := doReq(t, r, http.MethodGet, "/v1/docs/proxy/foo", h, "")
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+}
+
+// singleJoiningSlash 边界。
+func TestSingleJoiningSlash(t *testing.T) {
+	cases := []struct{ a, b, want string }{
+		{"", "/foo", "/foo"},
+		{"/", "/foo", "/foo"},
+		{"/api", "/foo", "/api/foo"},
+		{"/api/", "/foo", "/api/foo"},
+		{"/api", "foo", "/api/foo"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, singleJoiningSlash(c.a, c.b), "a=%q b=%q", c.a, c.b)
+	}
+}
+
+// upstream 带 basepath 时 path 拼接正确（例 http://host/api → /api/foo/bar）。
+func TestProxy_UpstreamWithBasepath(t *testing.T) {
+	cap := &upstreamCapture{}
+	// 用一个自定义 handler 起 upstream，让它挂在 /api 下（httptest 不能起 subpath，
+	// 但我们可以直接把 upstream URL 拼上 /api，让 director 走 singleJoiningSlash 分支）。
+	up := newUpstream(t, cap)
+	setEnv(t, upstreamEnv, up.URL+"/api")
+	p := New(nil)
+	require.NotNil(t, p)
+	p.Log = log.NewTLog("docs_proxy_test")
+	// 覆盖 rp 让它用测试自身的 transport（避免 keep-alive 干扰）。
+	// director/modifyResponse/errorHandler 复用 New 里注的。
+	r := newTestRouter(t, p)
+
+	h := http.Header{}
+	h.Set(headerToken, "tok:grace")
+	w := doReq(t, r, http.MethodGet, "/v1/docs/proxy/foo/bar", h, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, int64(1), atomic.LoadInt64(&cap.calls))
+	assert.Equal(t, "/api/foo/bar", cap.path.Load().(string))
+}
+
+// 环境变量 timeout 生效（不直接断超时，只断 New 后 timeout 字段值）。
+func TestNew_TimeoutFromEnv(t *testing.T) {
+	setEnv(t, upstreamEnv, "http://example.invalid")
+	setEnv(t, timeoutEnv, "12345")
+	p := New(nil)
+	require.NotNil(t, p)
+	assert.Equal(t, 12345*time.Millisecond, p.timeout)
+}
+
+// 环境变量 timeout 非法值 → 回落默认。
+func TestNew_TimeoutInvalidFallsBack(t *testing.T) {
+	setEnv(t, upstreamEnv, "http://example.invalid")
+	setEnv(t, timeoutEnv, "not-a-number")
+	p := New(nil)
+	require.NotNil(t, p)
+	assert.Equal(t, time.Duration(defaultTimeMS)*time.Millisecond, p.timeout)
+}
+
+// director path 剥前缀边界：请求刚好 = routePrefix 时应转发到 upstream 根 "/"。
+// wkhttp Any 的 /*action 通配符不会匹配空后缀 —— 至少要 /；这里断的是 director 自身逻辑。
+func TestDirector_PathRootWhenPrefixOnly(t *testing.T) {
+	setEnv(t, upstreamEnv, "http://example.invalid")
+	p := New(nil)
+	require.NotNil(t, p)
+
+	u, _ := url.Parse("http://example.invalid" + routePrefix)
+	req := &http.Request{URL: u, Header: http.Header{}}
+	req = req.WithContext(withToken(req.Context(), "T"))
+	p.director(req)
+	assert.Equal(t, "/", req.URL.Path)
+	assert.Equal(t, "T", req.Header.Get(headerOctoToken))
+}
+
+// 确认 ctx 传 nil 不会挂：New 只用 ctx 存字段，Route 才真正读 ctx.AuthMiddleware。
+// 这个用例只是把上面测试隐式的前提显式化，防未来 New 里加 ctx.XXX 依赖时静默改坏。
+var _ = config.Context{} // keep import stable

--- a/modules/docs_proxy/api_test.go
+++ b/modules/docs_proxy/api_test.go
@@ -119,12 +119,22 @@ func newTestRouter(t *testing.T, p *Proxy) *wkhttp.WKHttp {
 			c.AbortWithStatus(http.StatusUnauthorized)
 			return
 		}
-		// 从 token 里派生 uid：简化桩，格式 "tok:<uid>"，回落到 tok 本身。
-		uid := tok
+		// 简化桩："tok:<uid>[:name[:role]]"，只留 uid 时 name/role 走空/未识别路径，
+		// 让 normalizeRole 兜底成 member —— 正好覆盖"登录态没写 role"这种真实场景。
+		uid, name, role := tok, "", ""
 		if strings.HasPrefix(tok, "tok:") {
-			uid = strings.TrimPrefix(tok, "tok:")
+			parts := strings.SplitN(strings.TrimPrefix(tok, "tok:"), ":", 3)
+			uid = parts[0]
+			if len(parts) >= 2 {
+				name = parts[1]
+			}
+			if len(parts) >= 3 {
+				role = parts[2]
+			}
 		}
 		c.Set("uid", uid)
+		c.Set("name", name)
+		c.Set("role", role)
 		c.Next()
 	}
 	if p == nil {
@@ -225,7 +235,8 @@ func TestProxy_InjectsOctoToken_StripsCallerCreds(t *testing.T) {
 	r := newTestRouter(t, p)
 
 	h := http.Header{}
-	h.Set(headerToken, "tok:alice")
+	// tok:<uid>:<name>:<role>：走 admin 分支，验证 role 原样透传。
+	h.Set(headerToken, "tok:alice:Alice A:admin")
 	h.Set(headerAuth, "Bearer leak-me")
 	h.Set(headerCookie, "sess=leak-me")
 	h.Set("X-Business", "keep")
@@ -235,7 +246,10 @@ func TestProxy_InjectsOctoToken_StripsCallerCreds(t *testing.T) {
 	require.Equal(t, int64(1), atomic.LoadInt64(&cap.calls))
 
 	got := cap.headers.Load().(http.Header)
-	assert.Equal(t, "tok:alice", got.Get(headerOctoToken), "X-Octo-Token 必须注入")
+	assert.Equal(t, "tok:alice:Alice A:admin", got.Get(headerOctoToken), "X-Octo-Token 必须注入")
+	assert.Equal(t, "alice", got.Get(headerOctoUID), "X-Octo-Uid 必须注入登录态 uid")
+	assert.Equal(t, "Alice A", got.Get(headerOctoName), "X-Octo-Name 必须注入登录态 name")
+	assert.Equal(t, roleAdmin, got.Get(headerOctoRole), "X-Octo-Role 必须注入登录态 role")
 	assert.Empty(t, got.Get(headerAuth), "Authorization 必须剥掉")
 	assert.Empty(t, got.Get(headerCookie), "Cookie 必须剥掉")
 	assert.Empty(t, got.Get(headerToken), "原始 token header 必须剥掉，只保留 X-Octo-Token")
@@ -415,10 +429,73 @@ func TestDirector_PathRootWhenPrefixOnly(t *testing.T) {
 
 	u, _ := url.Parse("http://example.invalid" + routePrefix)
 	req := &http.Request{URL: u, Header: http.Header{}}
-	req = req.WithContext(withToken(req.Context(), "T"))
+	req = req.WithContext(withIdentity(req.Context(), identity{token: "T", uid: "u", name: "n", role: roleAdmin}))
 	p.director(req)
 	assert.Equal(t, "/", req.URL.Path)
 	assert.Equal(t, "T", req.Header.Get(headerOctoToken))
+	assert.Equal(t, "u", req.Header.Get(headerOctoUID))
+	assert.Equal(t, "n", req.Header.Get(headerOctoName))
+	assert.Equal(t, roleAdmin, req.Header.Get(headerOctoRole))
+}
+
+// OCT-145 方案 C：caller 自带 X-Octo-Uid/Name/Role 必须被 Del 后由反代覆写，
+// 否则外网 caller 可伪造身份。fakeAuth 里 role 走 "admin"，Del 后应看到 admin
+// 而不是 caller 塞的 "superAdmin"。
+func TestProxy_OverridesCallerIdentityHeaders(t *testing.T) {
+	cap := &upstreamCapture{}
+	up := newUpstream(t, cap)
+	p := buildProxy(t, up.URL)
+	r := newTestRouter(t, p)
+
+	h := http.Header{}
+	h.Set(headerToken, "tok:alice:Alice A:admin")
+	// caller 伪造：想把自己变超管、换 uid、换名字。
+	h.Set(headerOctoUID, "attacker")
+	h.Set(headerOctoName, "Root")
+	h.Set(headerOctoRole, roleSuperAdmin)
+
+	w := doReq(t, r, http.MethodGet, "/v1/docs/proxy/x", h, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, int64(1), atomic.LoadInt64(&cap.calls))
+
+	got := cap.headers.Load().(http.Header)
+	assert.Equal(t, "alice", got.Get(headerOctoUID), "caller 伪造的 uid 必须被覆写")
+	assert.Equal(t, "Alice A", got.Get(headerOctoName), "caller 伪造的 name 必须被覆写")
+	assert.Equal(t, roleAdmin, got.Get(headerOctoRole), "caller 伪造的 role 必须被覆写")
+}
+
+// 登录态 role 未知/为空时降级 member，不把空串或未识别字面透给 doc。
+func TestProxy_RoleFallsBackToMember(t *testing.T) {
+	cap := &upstreamCapture{}
+	up := newUpstream(t, cap)
+	p := buildProxy(t, up.URL)
+	r := newTestRouter(t, p)
+
+	// tok:<uid> —— fakeAuth 里 name/role 都为空，normalizeRole 兜底成 member。
+	h := http.Header{}
+	h.Set(headerToken, "tok:bob")
+	w := doReq(t, r, http.MethodGet, "/v1/docs/proxy/x", h, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	got := cap.headers.Load().(http.Header)
+	assert.Equal(t, "bob", got.Get(headerOctoUID))
+	assert.Empty(t, got.Get(headerOctoName), "登录态没 name 时不写空串以外的值")
+	assert.Equal(t, roleMember, got.Get(headerOctoRole), "未知 role 一律降级 member")
+}
+
+// normalizeRole 分支穷举：保 superAdmin/admin 原样，其他一律 member。
+func TestNormalizeRole(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{roleSuperAdmin, roleSuperAdmin},
+		{roleAdmin, roleAdmin},
+		{roleMember, roleMember},
+		{"", roleMember},
+		{"weird-role", roleMember},
+		{"SuperAdmin", roleMember}, // 大小写严格；wkhttp 定义就是小驼峰。
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, normalizeRole(c.in), "in=%q", c.in)
+	}
 }
 
 // 确认 ctx 传 nil 不会挂：New 只用 ctx 存字段，Route 才真正读 ctx.AuthMiddleware。

--- a/pkg/errcode/doc_binding.go
+++ b/pkg/errcode/doc_binding.go
@@ -1,0 +1,54 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// err.server.doc_binding.* — modules/doc_binding business error codes.
+// DefaultMessage holds the en-US source (D4); zh-CN translations live in
+// pkg/i18n/locales/active.zh-CN.toml. Internal=true codes never surface their
+// message on the wire — callers MUST log the underlying err with zap.Error
+// before responding.
+var (
+	// ---- validation (400) ----------------------------------------------------
+
+	ErrDocBindingRequestInvalid = register(codes.Code{
+		ID:             "err.server.doc_binding.request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid request.",
+		SafeDetailKeys: []string{"field"},
+	})
+
+	ErrDocBindingSlugConflict = register(codes.Code{
+		ID:             "err.server.doc_binding.slug_conflict",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "This slug is already bound.",
+		SafeDetailKeys: []string{"field"},
+	})
+
+	// ---- authz (403) ---------------------------------------------------------
+	// 权限拒绝直接 403；binding 存在但当前 caller 不该看时，走 hidden-404（ErrDocBindingNotFound）。
+	ErrDocBindingForbidden = register(codes.Code{
+		ID:             "err.server.doc_binding.forbidden",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You do not have permission to modify this doc binding.",
+	})
+
+	// ---- not found (404) -----------------------------------------------------
+	// 同时承担 hidden-404：真的不存在 + 非成员看不到的存在，都返回此码，避免枚举 slug 探测挂载点。
+	ErrDocBindingNotFound = register(codes.Code{
+		ID:             "err.server.doc_binding.not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "Doc binding not found.",
+	})
+
+	// ---- internal (500) ------------------------------------------------------
+	ErrDocBindingStoreFailed = register(codes.Code{
+		ID:             "err.server.doc_binding.store_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Doc binding storage operation failed.",
+		Internal:       true,
+	})
+)

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -620,6 +620,23 @@ other = "查询分类数据失败。"
 ["err.server.category.store_failed"]
 other = "保存分类数据失败。"
 
+# ---- modules/doc_binding：slug↔挂载点绑定（OCT-134） ----
+
+["err.server.doc_binding.request_invalid"]
+other = "请求参数有误。"
+
+["err.server.doc_binding.slug_conflict"]
+other = "该 slug 已被绑定。"
+
+["err.server.doc_binding.forbidden"]
+other = "无权修改此 doc 绑定。"
+
+["err.server.doc_binding.not_found"]
+other = "doc 绑定不存在。"
+
+["err.server.doc_binding.store_failed"]
+other = "doc 绑定存储操作失败。"
+
 # ---- modules/sticker：用户自定义贴纸 ----
 
 ["err.server.sticker.request_invalid"]

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -276,6 +276,21 @@ other = "The group and the category are not in the same space."
 ["err.server.category.store_failed"]
 other = "Failed to update category data."
 
+["err.server.doc_binding.forbidden"]
+other = "You do not have permission to modify this doc binding."
+
+["err.server.doc_binding.not_found"]
+other = "Doc binding not found."
+
+["err.server.doc_binding.request_invalid"]
+other = "Invalid request."
+
+["err.server.doc_binding.slug_conflict"]
+other = "This slug is already bound."
+
+["err.server.doc_binding.store_failed"]
+other = "Doc binding storage operation failed."
+
 ["err.server.group.already_member"]
 other = "You are already a member of this group."
 


### PR DESCRIPTION
OCT-145 方案 C（内网信任头）B 侧改造：`docs_proxy` 反代在**已鉴权通过后**、把请求转发到 doc 上游之前，额外注入三个内网可信身份头：`X-Octo-Uid` / `X-Octo-Name` / `X-Octo-Role`，doc 侧据此直接建 session、判权，不再回打 openapi userinfo。

配合上游 doc 侧（`octo-docs-html`）删除 `OCTO_OPENAPI_URL` / `OCTO_USERINFO_URL` 死路径，方案 C 消除了老架构里 A/B 契约的四处裂缝（详见 OCT-145）。

## 改动

`modules/docs_proxy/api.go`（同一注入点新增，不动 OCT-144 `X-Octo-Token` 通道）

- `handle`：鉴权通过后把登录态一次性快照进 request-scoped `identity{token, uid, name, role}` context，避免 director 里多次 `c.GetXxx()`。role 用 `normalizeRole` 收敛。
- `director`：三个身份头**全部先 `Del` 后 `Set`**（一个都不能漏），token 逻辑保持原状。少 `Del` 任何一个就是伪造缺口。
- role 值域常量 `roleSuperAdmin` / `roleAdmin` / `roleMember`。`normalizeRole`：`superAdmin` / `admin` 原样保留，其他一切字面量（空串、未知 role、大小写变体）一律降级 `member`，避免把空串或未识别值吐给 doc 造成隐式提权。
- 未登录请求早退 401，注入路径根本进不去（`handle` 里再兜一次 uid 校验）。

`modules/docs_proxy/api_test.go`（原 15 用例 + 新 3 用例 = 18/18 PASS）

- `fakeAuth` 桩扩展格式 `tok:<uid>[:name[:role]]`，补 `c.Set("name", ...)` / `c.Set("role", ...)`。
- 主注入测试补身份头断言。
- 新增 `TestProxy_OverridesCallerIdentityHeaders`：caller 伪造 `X-Octo-Uid=attacker` / `X-Octo-Role=superAdmin` 想变超管，反代 `Del` 后一律覆写成真登录态。
- 新增 `TestProxy_RoleFallsBackToMember`：登录态没写 role → doc 收到 `X-Octo-Role: member`。
- 新增 `TestNormalizeRole`：`{superAdmin, admin, member, "", "weird-role", "SuperAdmin"}` 6 分支穷举。

`modules/docs_proxy/README.md`（新建部署清单章节）

- Header 映射表：Token / Uid / Name / Role 来源 + 值域说明。
- ⚠️ 部署硬约束：反代→doc **必须内网 only**，否则外网 caller 直接把三个头打给 doc 就是身份伪造缺口。列了三条部署方必守规则（内网监听 / 外网只暴露反代 / 万不得已才用信任 IP 白名单 + 回打 token 兜底）。
- 环境变量表 + 废弃条目：`OCTO_OPENAPI_URL` / `OCTO_USERINFO_URL` 方案 C 后废弃，**doc 侧配置可移除**（octo-server 侧本来就没读这俩，只影响 doc 部署清单）。

## 契约（留给 A 侧 `octo-docs-html`）

| Header | 值 |
| --- | --- |
| `X-Octo-Uid` | 登录用户 uid（可能为空——极端登录态未写 uid，doc 侧兜底） |
| `X-Octo-Name` | 登录用户 name（可能为空） |
| `X-Octo-Role` | `superAdmin` \| `admin` \| `member`（**一定**为这三值之一，反代兜底降级） |
| `X-Octo-Token` | 现有 module token 通道，OCT-144 语义不变 |

## CI 自检

1. `gofmt -l modules/docs_proxy` — 空（clean）。
2. `golangci-lint run ./...` (v2.12.2) — 0 issues。
3. `go test ./modules/docs_proxy/... -count=1` — 18/18 PASS。

全仓 `gofmt -l .` 在 origin/main 上就已有 246 个 pre-existing 差异（与本 PR 无关），全仓 `go test ./...` 也有多个包 pre-existing FAIL（依赖 redis/es/mysql 未就绪或 pre-existing 逻辑），已 stash 到干净 origin/main 复跑确认非本 PR 引入。

## 部署

反代侧只需重启 octo-server 生效；doc 侧配合 A 侧 PR 落地后可移除 `OCTO_OPENAPI_URL` / `OCTO_USERINFO_URL`。
