### PR TITLE
feat(card): Action.ToggleVisibility + CopyToClipboard local actions (octo/v1)

### DIFF
--- a/.octospec/tasks/card-message-interaction/brief.md
+++ b/.octospec/tasks/card-message-interaction/brief.md
@@ -256,7 +256,13 @@ the mapping onto this brief:
 ## Out of scope
 
 - **P3**: `Action.Execute`/auto-refresh, templating/data-binding,
-  `Action.ShowCard`/`ToggleVisibility`, ephemeral (仅本人可见) responses,
+  `Action.ShowCard`, ephemeral (仅本人可见) responses,
+  <!-- `Action.ToggleVisibility` + element `id`/`isVisible`/`targetElements` and the
+       octo-custom `Action.CopyToClipboard` shipped as octo/v1 **local actions**
+       (no server callback) in task `card-message-toggle-visibility`; the D12
+       manifest gained an additive `actions` list advertising the octo/v1 local
+       action set. See `docs/card-protocol.md` §2.2. -->
+
   multi-step forms, cross-ecosystem card mapping, designer tooling,
   bot-side real-time event delivery (D5), **per-element `fallback`**
   (AC-standard element-level degradation — the rendering half of capability

--- a/.octospec/tasks/card-message-toggle-visibility/brief.md
+++ b/.octospec/tasks/card-message-toggle-visibility/brief.md
@@ -158,8 +158,10 @@ advertises `elements`/`inputs` but has **no** actions field.
    **verbatim, not rendered**, so **no URL/markdown allowlist applies**; the
    producer-side rule "don't copy hidden/sensitive fields" is a client/producer
    concern, not a server structural check. Add a `MaxCopyTextBytes = 4 << 10`
-   constant to `pkg/cardmsg/cardmsg.go` (source-of-truth; not surfaced in manifest
-   `limits` this PR unless trivially symmetric).
+   constant to `pkg/cardmsg/cardmsg.go` (source-of-truth) and advertise it in the
+   manifest `limits` as `max_copy_text_bytes` (PR#561 review #1 — symmetric with
+   `max_nodes`/`max_depth`/`max_payload_bytes`, so producers feature-detect the
+   threshold instead of learning it via a rejected send).
 
 ## Load-bearing list
 <!-- touches: tags drive rule injection. -->

--- a/.octospec/tasks/card-message-toggle-visibility/brief.md
+++ b/.octospec/tasks/card-message-toggle-visibility/brief.md
@@ -1,0 +1,214 @@
+---
+type: Task
+title: "Task: card-message-toggle-visibility"
+description: Add Action.ToggleVisibility (+ element id / isVisible / targetElements) to the octo/v1 display profile of the pkg/cardmsg card validator, and advertise the local action set in the GET /v1/bot/card/profile capability manifest. Enables server-authored collapsible sections (e.g. "collapse/expand reasoning") as a purely local, no-callback client interaction. CopyToClipboard is a separate follow-up.
+tags: ["card", "wire-contract", "trust-boundary", "bot-api", "validator", "testing", "commit"]
+timestamp: 2026-07-10T00:00:00Z
+# --- octospec extension fields ---
+slug: card-message-toggle-visibility
+upstream: self
+source: self
+---
+
+# Task: card-message-toggle-visibility
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+Let card producers author **collapsible sections** (fold/expand a subtree — e.g.
+the "收起推理 / 展开推理" control in the deep-thinking card) by supporting the
+standard Adaptive Cards `Action.ToggleVisibility` action plus its supporting
+element attributes (`id`, `isVisible`, `targetElements`) in the octo card
+validator.
+
+**Placed in `octo/v1` (the display profile), NOT a new `octo/v2`/`octo/v3` tier.**
+`ToggleVisibility` is a purely local UI toggle: it flips client-side visibility
+state and makes **no server callback** (it does not hit `POST
+/v1/message/card/action`, enqueues no `card_action` event, needs no idempotency /
+membership / anti-forgery). That is exactly the class of `Action.OpenUrl`, which
+already lives in `octo/v1`. The capability line therefore becomes:
+
+- **octo/v1** = display + local, no-server-callback interactions
+  (`Action.OpenUrl` navigation, `Action.ToggleVisibility` fold/expand).
+- **octo/v2** = interactions that call back to the server
+  (`Action.Submit`, `Input.*`).
+
+`card_version` stays pinned at `"1.5"` (ToggleVisibility is AC 1.2 core, well
+within 1.5 — this is a white-list *additive* change, not a version bump, per the
+house rule already applied to Input.Number/Date/Time).
+
+Also: **advertise the accepted local action set** in the `GET
+/v1/bot/card/profile` manifest so producers (bot SDKs, the OpenClaw adapter) can
+feature-detect ToggleVisibility instead of probing with a 400. The manifest today
+advertises `elements`/`inputs` but has **no** actions field.
+
+## Background
+
+- **Source request**: client/product ask to render collapsible AI-reasoning cards
+  (fold/expand reasoning steps) plus a local "copy" affordance. This brief covers
+  only the fold/expand half; copy (`Action.CopyToClipboard`) is a separate
+  follow-up PR.
+- **Authoritative validator**: `pkg/cardmsg` is the single write-strict authority
+  for InteractiveCard (ContentType=17). `docs/card-protocol.md` is a mirror; the
+  master interaction contract is
+  `.octospec/tasks/card-message-interaction/brief.md`. `ToggleVisibility` +
+  `isVisible`/`targetElements` are currently listed there and in
+  `docs/card-protocol.md:44` as a **future** item — this task promotes it to
+  supported. Amend doc + master brief together with the code.
+- **Current behavior (verified)**:
+  - `pkg/cardmsg/validate.go` `action()` (`:596-643`) whitelists only
+    `Action.OpenUrl` (both profiles) and `Action.Submit` (octo/v2); everything
+    else → `ErrCardUnknownAction`. `Action.ToggleVisibility` is therefore rejected
+    today — asserted by `pkg/cardmsg/cardmsg_test.go:127-130` (via `selectAction`).
+  - The walker (`walker.element`, `:163-458`) recurses into all subtrees
+    regardless of any `isVisible` flag and counts every node toward
+    `MaxNodes`/`MaxDepth` — so "hidden content is still fully validated + budgeted"
+    already holds for free.
+  - `id` is only registered/uniqueness-checked for `Action.Submit` and `Input.*`
+    (`walker.registerID`/`seenIDs`, `:127-137`); display-element `id` is currently
+    tolerated as an unknown scalar (never registered, never referenced).
+  - Manifest handler `modules/bot_api/card_profile.go:36-53` returns
+    `enabled/card_version/profiles/elements/inputs/limits`, every value sourced
+    from `pkg/cardmsg` authorities (`DisplayElements()`/`InputElements()`/
+    `AcceptedProfiles()`). No `actions` field exists yet.
+  - Whitelist authority pattern to mirror: `pkg/cardmsg/whitelist.go`
+    (`displayElements`/`inputElements` + `DisplayElements()`/`InputElements()`),
+    locked by `TestDisplayElementsAuthority`/`TestInputElementsAuthority`
+    (`whitelist_test.go`).
+- **Rollout ordering note (load-bearing for release, not for this diff)**:
+  server discovery ≠ client rendering. The web renderer does **not** call
+  `/v1/bot/card/profile`; it hard-codes its own support set and whole-card-
+  downgrades to `plain` on any unknown action. So once the server accepts +
+  advertises ToggleVisibility and a producer emits it, **un-updated web clients
+  downgrade the entire card to plain** (losing even renderable parts). Safe
+  rollout is web-render-support-first, or keep `OCTO_CARD_MESSAGE_ENABLED` gated
+  until the client ships. This task does not flip the gate.
+
+## Design decisions to pin (for confirmation)
+
+1. **Profile**: allow `Action.ToggleVisibility` in **both** profiles (no
+   `w.interactive` gate) — it is octo/v1-tier. `card_version` unchanged (`1.5`);
+   `AcceptedProfiles()` unchanged (still `{octo/v1, octo/v2}`); **no octo/v3**.
+2. **`Action.ToggleVisibility` shape**:
+   - `targetElements` (optional per AC, but a toggle with none is a no-op —
+     **require present + non-empty array**). Each entry is either a **string**
+     (element id) or an **object** `{elementId: string, isVisible?: bool}` (AC
+     `TargetElement`). Reject any entry that is neither, whose `elementId` is
+     missing/empty, or whose `isVisible` (when present) is non-boolean.
+   - Counts toward the node budget like any other action (`w.bump`).
+   - No `url`/`data` semantics; no `SubmitAction` dispatch involvement (it is not
+     a Submit — `interactive.go` findSubmit* naturally ignores it, unchanged).
+3. **Element `id` + reference integrity (forward-safe)**: collect every element
+   `id` (display + input) into a frame set during the walk; collect every
+   `targetElements` reference into a pending list; **after** the full walk verify
+   each reference resolves to a declared **element** id. This handles forward
+   references (toggle may appear before or after its target). A dangling reference
+   → reject.
+4. **`id` uniqueness / namespace**: any element that declares an `id` registers it
+   frame-uniquely, coordinated with the existing `seenIDs` used for
+   `Action.Submit`/`Input.*` — one unified frame-unique id space (matches AC's
+   card-global id model). `targetElements` resolve against ids declared by
+   **elements** (not action ids). Duplicate id anywhere in the frame → reject.
+   (This is a *new* constraint on display-element ids, which were previously
+   unconstrained; risk is low because no prior feature gave display ids meaning,
+   so producers do not set — let alone duplicate — them. Called out for review.)
+5. **`isVisible`**: universal AC element attribute — when present on any element,
+   must be boolean, else reject. Hidden subtree still fully walked + budgeted
+   (already true).
+6. **Manifest `actions` field (additive wire contract)**: refactor the action
+   whitelist into a `pkg/cardmsg` data authority mirroring
+   `displayElements`/`inputElements` — e.g. `displayActions = ["Action.OpenUrl",
+   "Action.ToggleVisibility"]` (octo/v1 local actions) with a `DisplayActions()`
+   accessor, and lock it against the validator accept-set with a new
+   `TestDisplayActionsAuthority` guard. Add `"actions": cardmsg.DisplayActions()`
+   to the manifest response. `Action.Submit` remains discoverable via the
+   `octo/v2` profile tier (status quo — Submit is not advertised by name today);
+   optionally add a symmetric `interactive_actions` list, but default is to keep
+   this PR minimal and add only `actions`.
+7. **Error mapping**: reuse existing `pkg/cardmsg` sentinels — structural
+   problems (`targetElements` wrong shape, non-boolean `isVisible`, duplicate id)
+   map to `ErrCardBadShape`; a dangling `targetElements` reference may use a
+   dedicated internal sentinel (e.g. `ErrCardTargetMissing`) that still collapses
+   to the send path's existing single generic card-invalid 400 (anti-enumeration)
+   — **no new `pkg/errcode` code, no new i18n toml entry, no new migration**.
+
+## Load-bearing list
+<!-- touches: tags drive rule injection. -->
+- **Card validator trust boundary** (`pkg/cardmsg/validate.go`) — the "校验面 ≥
+  渲染面 / 派发面" invariant: any newly accepted action/attribute must be fully
+  validated so nothing renderable escapes the whitelist. `touches: trust-boundary,
+  wire-contract, validator`.
+- **Whitelist single-authority + anti-drift** (`pkg/cardmsg/whitelist.go`,
+  `profiles.go`) — action accept-set becomes a data authority feeding both the
+  validator and the manifest; must stay drift-locked by a guard test.
+  `touches: wire-contract`.
+- **Capability manifest wire contract** (`modules/bot_api/card_profile.go`, D12)
+  — additive-only (`actions` added; nothing renamed/removed/retyped); values
+  sourced from `pkg/cardmsg` constants, never re-typed literals.
+  `touches: wire-contract, bot-api`.
+- **Frame-unique id semantics** (`walker.seenIDs`) — extending the id namespace
+  from Submit/Input to all elements must not break existing Submit/Input id
+  uniqueness or the `card_action` addressing / idempotency keys that rely on it.
+  `touches: wire-contract`.
+- **Node/depth budget accounting** (`MaxNodes`/`MaxDepth`) — ToggleVisibility
+  actions and toggled/hidden subtrees continue to count; no budget bypass via
+  hidden nodes. `touches: validator`.
+- **bot_api endpoint** (`GET /v1/bot/card/profile`) — deployment-level, bot-token
+  auth, no SpaceMiddleware, no new rate limiter (unchanged); still returns 200 +
+  full manifest when disabled. `touches: bot-api`.
+- **Tests** — validator + manifest guard/behavior tests. `touches: testing`.
+- **Commit style** — Conventional Commits, English. `touches: commit`.
+
+## Out of scope
+- `Action.CopyToClipboard` (octo custom action) — separate follow-up PR.
+- Any change to `Action.Submit` / `Input.*` / the `card_action` server-callback
+  loop, idempotency, membership, or `interactive.go` dispatch.
+- Introducing `octo/v3` or bumping `card_version` off `"1.5"`.
+- Narrowing `selectAction + Submit` (a separate product-policy question).
+- Per-element `fallback` (named P3 mechanism) and any client/web renderer work
+  (web is owned separately; it hard-codes its own whitelist and downgrades to
+  `plain`).
+- Flipping `OCTO_CARD_MESSAGE_ENABLED`.
+- New DB table / migration / `pkg/errcode` code / i18n toml entry.
+
+## Acceptance
+<!-- Machine-checkable where possible. -->
+- `go test ./pkg/cardmsg/...` passes, with new cases:
+  - `Action.ToggleVisibility` in `card.actions[]` whose `targetElements`
+    reference an existing element `id` → `Validate` returns nil in **both**
+    `octo/v1` and `octo/v2`.
+  - `Action.ToggleVisibility` carried via a `Container.selectAction` → accepted
+    (this **flips** `cardmsg_test.go:127-130`, which currently expects
+    `ErrCardUnknownAction`; update that case).
+  - `targetElements` string form and `{elementId, isVisible}` object form both
+    accepted; entry that is neither / missing `elementId` / non-boolean
+    `isVisible` → `ErrCardBadShape`.
+  - `targetElements` referencing a non-existent id → rejected
+    (`ErrCardBadShape` or `ErrCardTargetMissing`).
+  - Forward reference (toggle element ordered before its target in `body`) →
+    accepted.
+  - Duplicate element `id` in a frame → `ErrCardBadShape`; and an element `id`
+    colliding with an `Action.Submit`/`Input.*` id in the same frame → rejected.
+  - Non-boolean `isVisible` on any element → `ErrCardBadShape`.
+  - `isVisible:false` subtree containing an over-budget node or a `javascript:`
+    URL is **still** rejected (visibility does not exempt budget/URL checks).
+- Manifest: `modules/bot_api/card_profile_test.go` updated so `GET
+  /v1/bot/card/profile` response includes `actions` containing
+  `"Action.OpenUrl"` and `"Action.ToggleVisibility"`, sourced from
+  `cardmsg.DisplayActions()`.
+- New `TestDisplayActionsAuthority` in `pkg/cardmsg` locks `DisplayActions()`
+  equal to the validator's octo/v1 action accept-set (drift guard, mirroring
+  `TestDisplayElementsAuthority`).
+- `interactive.go` / `interactive_test.go` unchanged and green (no Submit-dispatch
+  impact); `AcceptedProfiles()` still `{octo/v1, octo/v2}`; `cardmsg.CardVersion`
+  still `"1.5"`.
+- `make i18n-extract-check` and `make i18n-lint` pass unchanged (no new codes /
+  raw responses).
+- `golangci-lint run ./pkg/cardmsg/... ./modules/bot_api/...` clean.
+- `docs/card-protocol.md` and
+  `.octospec/tasks/card-message-interaction/brief.md` updated together to move
+  ToggleVisibility/`isVisible`/`targetElements` from "future" to "supported
+  (octo/v1)", and to document the new manifest `actions` field.
+- Work committed on branch `claude/client-ac-requirements-fvoizm`.

--- a/.octospec/tasks/card-message-toggle-visibility/brief.md
+++ b/.octospec/tasks/card-message-toggle-visibility/brief.md
@@ -89,6 +89,13 @@ advertises `elements`/`inputs` but has **no** actions field.
   downgrade the entire card to plain** (losing even renderable parts). Safe
   rollout is web-render-support-first, or keep `OCTO_CARD_MESSAGE_ENABLED` gated
   until the client ships. This task does not flip the gate.
+- **Rollout checklist — backward-incompatible id tightening (PR#561 review)**:
+  display-element `id`s were previously tolerated as unknown scalars; they are now
+  registered into the shared frame-unique namespace, so a card that **reuses** a
+  display `id` now fails closed (whole-card 400). Blast radius is low (feature
+  gated off by default; no known producer assigns display ids today), but before
+  flipping `OCTO_CARD_MESSAGE_ENABLED` confirm no already-deployed/authored cards
+  rely on duplicate display ids so early adopters aren't surprised.
 
 ## Design decisions to pin (for confirmation)
 

--- a/.octospec/tasks/card-message-toggle-visibility/brief.md
+++ b/.octospec/tasks/card-message-toggle-visibility/brief.md
@@ -1,7 +1,7 @@
 ---
 type: Task
 title: "Task: card-message-toggle-visibility"
-description: Add Action.ToggleVisibility (+ element id / isVisible / targetElements) to the octo/v1 display profile of the pkg/cardmsg card validator, and advertise the local action set in the GET /v1/bot/card/profile capability manifest. Enables server-authored collapsible sections (e.g. "collapse/expand reasoning") as a purely local, no-callback client interaction. CopyToClipboard is a separate follow-up.
+description: Add the octo/v1 local-action batch to the pkg/cardmsg card validator — Action.ToggleVisibility (+ element id / isVisible / targetElements) and the octo-custom Action.CopyToClipboard — and advertise the accepted local action set in the GET /v1/bot/card/profile capability manifest. Enables server-authored collapsible sections ("collapse/expand reasoning") and copy-to-clipboard affordances as purely local, no-server-callback client interactions.
 tags: ["card", "wire-contract", "trust-boundary", "bot-api", "validator", "testing", "commit"]
 timestamp: 2026-07-10T00:00:00Z
 # --- octospec extension fields ---
@@ -17,21 +17,25 @@ source: self
 
 ## Goal
 
-Let card producers author **collapsible sections** (fold/expand a subtree — e.g.
-the "收起推理 / 展开推理" control in the deep-thinking card) by supporting the
-standard Adaptive Cards `Action.ToggleVisibility` action plus its supporting
-element attributes (`id`, `isVisible`, `targetElements`) in the octo card
-validator.
+Add the **octo/v1 local-action batch** to the octo card validator so producers
+can author **collapsible sections** (fold/expand a subtree — e.g. the "收起推理 /
+展开推理" control in the deep-thinking card) and **copy-to-clipboard** affordances:
 
-**Placed in `octo/v1` (the display profile), NOT a new `octo/v2`/`octo/v3` tier.**
-`ToggleVisibility` is a purely local UI toggle: it flips client-side visibility
-state and makes **no server callback** (it does not hit `POST
-/v1/message/card/action`, enqueues no `card_action` event, needs no idempotency /
-membership / anti-forgery). That is exactly the class of `Action.OpenUrl`, which
-already lives in `octo/v1`. The capability line therefore becomes:
+- `Action.ToggleVisibility` (standard AC) plus its supporting element attributes
+  `id` / `isVisible` / `targetElements`.
+- `Action.CopyToClipboard` (octo-custom action; standard AC has none) carrying a
+  `text` payload the client copies locally.
+
+**Both go in `octo/v1` (the display profile), NOT a new `octo/v2`/`octo/v3` tier.**
+Each is a purely local interaction that makes **no server callback** (neither hits
+`POST /v1/message/card/action`, enqueues a `card_action` event, nor needs
+idempotency / membership / anti-forgery). That is exactly the class of
+`Action.OpenUrl`, which already lives in `octo/v1`. The capability line therefore
+becomes:
 
 - **octo/v1** = display + local, no-server-callback interactions
-  (`Action.OpenUrl` navigation, `Action.ToggleVisibility` fold/expand).
+  (`Action.OpenUrl` navigation, `Action.ToggleVisibility` fold/expand,
+  `Action.CopyToClipboard` local copy).
 - **octo/v2** = interactions that call back to the server
   (`Action.Submit`, `Input.*`).
 
@@ -119,20 +123,36 @@ advertises `elements`/`inputs` but has **no** actions field.
    (already true).
 6. **Manifest `actions` field (additive wire contract)**: refactor the action
    whitelist into a `pkg/cardmsg` data authority mirroring
-   `displayElements`/`inputElements` — e.g. `displayActions = ["Action.OpenUrl",
-   "Action.ToggleVisibility"]` (octo/v1 local actions) with a `DisplayActions()`
-   accessor, and lock it against the validator accept-set with a new
-   `TestDisplayActionsAuthority` guard. Add `"actions": cardmsg.DisplayActions()`
-   to the manifest response. `Action.Submit` remains discoverable via the
-   `octo/v2` profile tier (status quo — Submit is not advertised by name today);
-   optionally add a symmetric `interactive_actions` list, but default is to keep
-   this PR minimal and add only `actions`.
+   `displayElements`/`inputElements` — `displayActions = ["Action.OpenUrl",
+   "Action.ToggleVisibility", "Action.CopyToClipboard"]` (octo/v1 local actions)
+   with a `DisplayActions()` accessor, locked against the validator accept-set
+   with a new `TestDisplayActionsAuthority` guard. Add `"actions":
+   cardmsg.DisplayActions()` to the manifest response. `Action.Submit` remains
+   discoverable via the `octo/v2` profile tier (status quo — Submit is not
+   advertised by name today); optionally add a symmetric `interactive_actions`
+   list, but default is to keep this PR minimal and add only `actions`.
 7. **Error mapping**: reuse existing `pkg/cardmsg` sentinels — structural
-   problems (`targetElements` wrong shape, non-boolean `isVisible`, duplicate id)
-   map to `ErrCardBadShape`; a dangling `targetElements` reference may use a
-   dedicated internal sentinel (e.g. `ErrCardTargetMissing`) that still collapses
-   to the send path's existing single generic card-invalid 400 (anti-enumeration)
-   — **no new `pkg/errcode` code, no new i18n toml entry, no new migration**.
+   problems (`targetElements` wrong shape, non-boolean `isVisible`, duplicate id,
+   missing/oversized/non-string `CopyToClipboard.text`) map to `ErrCardBadShape`;
+   a dangling `targetElements` reference may use a dedicated internal sentinel
+   (e.g. `ErrCardTargetMissing`) that still collapses to the send path's existing
+   single generic card-invalid 400 (anti-enumeration) — **no new `pkg/errcode`
+   code, no new i18n toml entry, no new migration**.
+8. **`Action.CopyToClipboard` (octo-custom, octo/v1)**: standard AC has no copy
+   action — this is an octo extension; the type name follows the client doc's
+   proposed protocol `{type:"Action.CopyToClipboard", title?, text}` (unprefixed
+   — the only collision risk is a hypothetical future Microsoft action of the
+   same name, judged acceptable, no vendor prefix per the doc). Allowed in **both**
+   profiles (octo/v1-tier, no `w.interactive` gate). Validation: `text`
+   **required, string, ≤ `MaxCopyTextBytes` (4 KiB)**; `title` optional string;
+   the action counts toward the node budget (`w.bump`). **No server callback** —
+   the client copies `text` locally; it never hits `/v1/message/card/action` and
+   enqueues no event, so `interactive.go` dispatch is untouched. `text` is copied
+   **verbatim, not rendered**, so **no URL/markdown allowlist applies**; the
+   producer-side rule "don't copy hidden/sensitive fields" is a client/producer
+   concern, not a server structural check. Add a `MaxCopyTextBytes = 4 << 10`
+   constant to `pkg/cardmsg/cardmsg.go` (source-of-truth; not surfaced in manifest
+   `limits` this PR unless trivially symmetric).
 
 ## Load-bearing list
 <!-- touches: tags drive rule injection. -->
@@ -162,7 +182,6 @@ advertises `elements`/`inputs` but has **no** actions field.
 - **Commit style** — Conventional Commits, English. `touches: commit`.
 
 ## Out of scope
-- `Action.CopyToClipboard` (octo custom action) — separate follow-up PR.
 - Any change to `Action.Submit` / `Input.*` / the `card_action` server-callback
   loop, idempotency, membership, or `interactive.go` dispatch.
 - Introducing `octo/v3` or bumping `card_version` off `"1.5"`.
@@ -194,10 +213,16 @@ advertises `elements`/`inputs` but has **no** actions field.
   - Non-boolean `isVisible` on any element → `ErrCardBadShape`.
   - `isVisible:false` subtree containing an over-budget node or a `javascript:`
     URL is **still** rejected (visibility does not exempt budget/URL checks).
+  - `Action.CopyToClipboard` with a valid `text` → accepted in **both** profiles;
+    missing `text` / non-string `text` / `text` > 4 KiB → `ErrCardBadShape`;
+    optional `title` accepted; `text` carrying a `javascript:`/`data:` string is
+    **accepted** (verbatim clipboard content, not a URL surface).
+  - `Action.CopyToClipboard` does not appear in `SubmitAction` dispatch results
+    (it is not a Submit) — `interactive.go`/`interactive_test.go` untouched.
 - Manifest: `modules/bot_api/card_profile_test.go` updated so `GET
   /v1/bot/card/profile` response includes `actions` containing
-  `"Action.OpenUrl"` and `"Action.ToggleVisibility"`, sourced from
-  `cardmsg.DisplayActions()`.
+  `"Action.OpenUrl"`, `"Action.ToggleVisibility"`, and
+  `"Action.CopyToClipboard"`, sourced from `cardmsg.DisplayActions()`.
 - New `TestDisplayActionsAuthority` in `pkg/cardmsg` locks `DisplayActions()`
   equal to the validator's octo/v1 action accept-set (drift guard, mirroring
   `TestDisplayElementsAuthority`).
@@ -210,5 +235,7 @@ advertises `elements`/`inputs` but has **no** actions field.
 - `docs/card-protocol.md` and
   `.octospec/tasks/card-message-interaction/brief.md` updated together to move
   ToggleVisibility/`isVisible`/`targetElements` from "future" to "supported
-  (octo/v1)", and to document the new manifest `actions` field.
+  (octo/v1)", document the octo-custom `Action.CopyToClipboard` (octo/v1,
+  `text` ≤ 4 KiB, local copy, no callback), and document the new manifest
+  `actions` field.
 - Work committed on branch `claude/client-ac-requirements-fvoizm`.

--- a/.octospec/tasks/card-message-toggle-visibility/context.yaml
+++ b/.octospec/tasks/card-message-toggle-visibility/context.yaml
@@ -1,0 +1,12 @@
+injected:
+  - id: trust-boundary
+    source: repo
+  - id: error-handling
+    source: repo
+  - id: space-isolation
+    source: repo
+  - id: testing
+    source: repo
+  - id: commit-style
+    source: repo
+brief: .octospec/tasks/card-message-toggle-visibility/brief.md

--- a/docs/card-protocol.md
+++ b/docs/card-protocol.md
@@ -86,7 +86,9 @@ allowlist —— 服务端用**完整 CommonMark 解析器**（非模式匹配�
 - 引用的 `id` **必须存在于本卡**（全卡遍历后统一解析 —— 前向引用安全，target 可先于/
   后于其 toggle 出现）；悬空引用整卡拒。
 - 元素 `id` **帧内唯一**（与 `Action.Submit`/`Input.*` 共享同一 id 空间，对齐 AC 的
-  card-global id 模型）。`isVisible` 出现时必须是 bool。
+  card-global id 模型）。`id` 可声明在**任意 id 承载节点**——顶层展示/输入元素、`Column`、
+  `TableRow`/`TableCell`、`ImageSet` 子 `Image`——且**任一均可作 `targetElements` 目标**
+  （校验器逐节点登记，不留缺口）。`isVisible` 出现时必须是 bool。
 - **隐藏内容不豁免任何校验**：`isVisible:false` 的子树仍完整走白名单/URL allowlist、
   计入节点/深度预算（隐藏节点不得成为绕过通道 —— 校验面 ≥ 渲染面）。
 

--- a/docs/card-protocol.md
+++ b/docs/card-protocol.md
@@ -99,7 +99,8 @@ allowlist —— 服务端用**完整 CommonMark 解析器**（非模式匹配�
 ```
 
 - `text` 必填、字符串、≤ **4 KiB**（`cardmsg.MaxCopyTextBytes`，按 **UTF-8 字节**计、非字符数
-  ——与 `Input.Text` 同口径；4096 字节 ≈ 1365 个 CJK 字符）；`title` 可选字符串。
+  ——与 `Input.Text` 同口径；4096 字节 ≈ 1365 个 CJK 字符；manifest `limits.max_copy_text_bytes`
+  同步下发，供 producer 按阈值 feature-detect）；`title` 可选字符串。
 - `text` **逐字复制、不渲染** —— 无 URL/markdown 面，不过 allowlist。「勿复制隐藏/敏感
   字段」是生产者/客户端职责，非服务端结构校验。
 

--- a/docs/card-protocol.md
+++ b/docs/card-protocol.md
@@ -98,7 +98,8 @@ allowlist —— 服务端用**完整 CommonMark 解析器**（非模式匹配�
 { "type": "Action.CopyToClipboard", "title": "复制", "text": "SELECT ..." }
 ```
 
-- `text` 必填、字符串、≤ **4 KiB**（`cardmsg.MaxCopyTextBytes`）；`title` 可选字符串。
+- `text` 必填、字符串、≤ **4 KiB**（`cardmsg.MaxCopyTextBytes`，按 **UTF-8 字节**计、非字符数
+  ——与 `Input.Text` 同口径；4096 字节 ≈ 1365 个 CJK 字符）；`title` 可选字符串。
 - `text` **逐字复制、不渲染** —— 无 URL/markdown 面，不过 allowlist。「勿复制隐藏/敏感
   字段」是生产者/客户端职责，非服务端结构校验。
 

--- a/docs/card-protocol.md
+++ b/docs/card-protocol.md
@@ -39,9 +39,10 @@
 | 类别 | 允许 |
 |---|---|
 | 元素 | `TextBlock`（markdown 子集，§2.1）、`RichTextBlock`、`Image`、`ImageSet`、`Container`、`ColumnSet`（含 `Column` 列）、`FactSet`、`Table`、`ActionSet`（`RichTextBlock`/`ImageSet`/`Table`/`ActionSet` 为 P3-3 Tier 1 追加，均 AC ≤1.5：ImageSet 1.0 / RichTextBlock 1.2 / ActionSet 1.2 / Table 1.5） |
-| 动作 | `Action.OpenUrl`；元素/整卡 `selectAction` **仅当**携带 `Action.OpenUrl` |
+| 动作（本地，无服务端回调） | `Action.OpenUrl`、`Action.ToggleVisibility`（折叠/展开，见 §2.2）、`Action.CopyToClipboard`（octo 自定义本地复制，见 §2.2）；元素/整卡 `selectAction` 携带上述任一本地动作亦可（分期继承） |
+| 元素通用属性 | `id`（帧内唯一，与 `Action.Submit`/`Input.*` 共享同一 id 空间）、`isVisible`（bool；隐藏子树仍完整校验、计入预算，见 §2.2） |
 | P2 起（octo/v2） | `Action.Submit`（含 selectAction/ActionSet 携带）、`Input.Text` / `Input.Toggle` / `Input.ChoiceSet` / `Input.Number` / `Input.Date` / `Input.Time`（id 必填且帧内唯一；后三者 P3-3 追加，均 AC 1.0、仍在 `card_version:"1.5"` 内，为白名单增量而非版本升级） |
-| 暂不支持（后续按需） | `Media`(1.1)、`Action.ShowCard`(1.0)、`Action.ToggleVisibility`(1.2)、`Action.Execute`(1.4)、模板/数据绑定，以及 AC 1.6 元素 |
+| 暂不支持（后续按需） | `Media`(1.1)、`Action.ShowCard`(1.0)、`Action.Execute`(1.4)、模板/数据绑定，以及 AC 1.6 元素 |
 
 结构与大小上限（全部 ingress 一致）：
 
@@ -68,6 +69,37 @@ allowlist —— 服务端用**完整 CommonMark 解析器**（非模式匹配�
 `http(s)` 目标（含反斜杠破坏 scheme 的 `javascript\:…`）一律拒绝。plain 派生时剥离
 语法字符（链接降为链接文本）。
 
+### 2.2 本地折叠与复制（octo/v1 本地动作）
+
+均为**纯端上、无服务端回调**的动作（不走 `message/card/action`、不入 `card_action`
+事件、无幂等/权限），与 `Action.OpenUrl` 同档，故落 **octo/v1**。
+
+**`Action.ToggleVisibility`** —— 折叠/展开目标子树（如「收起推理 / 展开推理」）：
+
+```json
+{ "type": "Container", "id": "reasoning", "isVisible": false, "items": [] }
+{ "type": "Action.ToggleVisibility", "title": "展开推理", "targetElements": ["reasoning"] }
+```
+
+- `targetElements` 必填、非空数组；每项是元素 `id` 字符串，或 AC `TargetElement`
+  对象 `{ "elementId": "id", "isVisible": true|false }`。
+- 引用的 `id` **必须存在于本卡**（全卡遍历后统一解析 —— 前向引用安全，target 可先于/
+  后于其 toggle 出现）；悬空引用整卡拒。
+- 元素 `id` **帧内唯一**（与 `Action.Submit`/`Input.*` 共享同一 id 空间，对齐 AC 的
+  card-global id 模型）。`isVisible` 出现时必须是 bool。
+- **隐藏内容不豁免任何校验**：`isVisible:false` 的子树仍完整走白名单/URL allowlist、
+  计入节点/深度预算（隐藏节点不得成为绕过通道 —— 校验面 ≥ 渲染面）。
+
+**`Action.CopyToClipboard`**（octo 自定义，标准 AC 无）—— 本地复制一段明文：
+
+```json
+{ "type": "Action.CopyToClipboard", "title": "复制", "text": "SELECT ..." }
+```
+
+- `text` 必填、字符串、≤ **4 KiB**（`cardmsg.MaxCopyTextBytes`）；`title` 可选字符串。
+- `text` **逐字复制、不渲染** —— 无 URL/markdown 面，不过 allowlist。「勿复制隐藏/敏感
+  字段」是生产者/客户端职责，非服务端结构校验。
+
 ## 3. profile 协商与降级链
 
 - **服务端**：P1 只接受 `profile:"octo/v1"` + `card_version:"1.5"`，其它值
@@ -77,12 +109,15 @@ allowlist —— 服务端用**完整 CommonMark 解析器**（非模式匹配�
   2. 不认识 `profile`（更新的服务端/更旧的客户端）→ 渲染 `plain`；
   3. 连 `type:17` 都不认识（存量客户端）→ octo-lib 未知类型兜底文案。
 - P2 产者能力发现：`GET /v1/bot/card/profile`（D12，随 P2 落地）返回部署的
-  `enabled` / `card_version` / `profiles` / `elements` / `inputs` / `limits` 清单（只增不改）；
-  `elements`/`inputs` 是本部署接受的展示元素 / 交互输入白名单（源自 `pkg/cardmsg`
-  权威列表；`elements` 只列**顶层可放置**元素——`Column` 是 `ColumnSet` 的子列、由
-  `ColumnSet` 涵盖，不单列），供 producer 按**元素粒度**前向兼容协商——即便 `card_version` 停在 `"1.5"`，
-  也能探测是否接受 `Input.Number/Date/Time` 等 additive 新增元素。P1 期间生产者以发送被
-  400/`card_disabled` 拒绝为「未启用」信号。
+  `enabled` / `card_version` / `profiles` / `elements` / `inputs` / `actions` / `limits`
+  清单（只增不改）；`elements`/`inputs`/`actions` 是本部署接受的展示元素 / 交互输入 /
+  **本地动作**白名单（源自 `pkg/cardmsg` 权威列表；`elements` 只列**顶层可放置**元素——
+  `Column` 是 `ColumnSet` 的子列、由 `ColumnSet` 涵盖，不单列；`actions` 只列 octo/v1
+  本地动作 `Action.OpenUrl`/`ToggleVisibility`/`CopyToClipboard`——`Action.Submit` 属
+  octo/v2、经 `profiles` 隐式发现，不在 `actions` 内），供 producer 按**元素/动作粒度**
+  前向兼容协商——即便 `card_version` 停在 `"1.5"`、`profiles` 不变，也能探测是否接受
+  `Input.Number/Date/Time`、`ToggleVisibility`/`CopyToClipboard` 等 additive 新增能力。
+  P1 期间生产者以发送被 400/`card_disabled` 拒绝为「未启用」信号。
 
 ## 4. 信任模型（谁能发卡、谁能信卡）
 

--- a/modules/bot_api/card_profile.go
+++ b/modules/bot_api/card_profile.go
@@ -56,6 +56,9 @@ func (ba *BotAPI) botCardProfile(c *wkhttp.Context) {
 			"max_depth":            cardmsg.MaxDepth,
 			"max_input_text_bytes": cardmsg.MaxInputTextBytes,
 			"max_inputs_bytes":     cardmsg.MaxInputsBytes,
+			// Action.CopyToClipboard.text 的 UTF-8 字节上限（与 actions 里的 CopyToClipboard
+			// 对称，供 producer 按阈值 feature-detect，免去「发一条超限卡看 400」探测）。
+			"max_copy_text_bytes": cardmsg.MaxCopyTextBytes,
 		},
 	})
 }

--- a/modules/bot_api/card_profile.go
+++ b/modules/bot_api/card_profile.go
@@ -11,8 +11,8 @@ package bot_api
 //
 // 清单值全部取自 pkg/cardmsg 常量（**单一权威**，D12.2）—— 绝不在此重抄字面量，否则
 // 常量变更时清单会与校验器静默漂移。profiles 取 cardmsg.AcceptedProfiles()（与校验器
-// interactiveByProfile 的接受集同源）；elements/inputs 取 cardmsg.DisplayElements()/
-// InputElements()（与校验器白名单同源，反漂移由 pkg/cardmsg 守卫测试锁定）。
+// interactiveByProfile 的接受集同源）；elements/inputs/actions 取 cardmsg.DisplayElements()/
+// InputElements()/DisplayActions()（与校验器白名单同源，反漂移由 pkg/cardmsg 守卫测试锁定）。
 //
 // enabled 直取 cardmsg.Enabled()（部署级 rollout 开关）：即便关闭也返回 200 + 全清单
 // —— feature detection 正是目的；只有 send/edit 路径在关闭时拒绝（send.go:97）。
@@ -43,6 +43,13 @@ func (ba *BotAPI) botCardProfile(c *wkhttp.Context) {
 		// additive 新增元素，消除「版本号不变 → gate 无法分辨新旧 1.5 部署」的错配。
 		"elements": cardmsg.DisplayElements(),
 		"inputs":   cardmsg.InputElements(),
+		// actions：本部署接受的 octo/v1 **本地动作**白名单（OpenUrl / ToggleVisibility /
+		// CopyToClipboard —— 无服务端回调，源自 pkg/cardmsg 权威列表 DisplayActions()，
+		// 反漂移由 TestDisplayActionsAuthority 锁定）。producer 据此按**动作粒度**前向兼容
+		// 协商——即便 card_version 停在 "1.5"、profiles 不变，也能探测本部署是否接受
+		// ToggleVisibility / CopyToClipboard 等 additive 新增本地动作。Action.Submit 属
+		// octo/v2 交互档，经 profiles 隐式发现、不在此列。
+		"actions": cardmsg.DisplayActions(),
 		"limits": map[string]interface{}{
 			"max_payload_bytes":    cardmsg.MaxPayloadBytes,
 			"max_nodes":            cardmsg.MaxNodes,

--- a/modules/bot_api/card_profile_test.go
+++ b/modules/bot_api/card_profile_test.go
@@ -55,6 +55,7 @@ type cardProfileManifest struct {
 	Profiles    []string `json:"profiles"`
 	Elements    []string `json:"elements"`
 	Inputs      []string `json:"inputs"`
+	Actions     []string `json:"actions"`
 	Limits      struct {
 		MaxPayloadBytes   int `json:"max_payload_bytes"`
 		MaxNodes          int `json:"max_nodes"`
@@ -79,6 +80,7 @@ func TestBotCardProfile_ElementsInputsFromConstants(t *testing.T) {
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &m))
 	assert.Equal(t, cardmsg.DisplayElements(), m.Elements)
 	assert.Equal(t, cardmsg.InputElements(), m.Inputs)
+	assert.Equal(t, cardmsg.DisplayActions(), m.Actions)
 }
 
 // TestBotCardProfile_ValuesFromConstants：清单每个值必须等于 pkg/cardmsg 常量
@@ -168,7 +170,7 @@ func TestBotCardProfile_AdditiveContractFieldSet(t *testing.T) {
 	for k := range raw {
 		gotTop = append(gotTop, k)
 	}
-	assert.ElementsMatch(t, []string{"enabled", "card_version", "profiles", "limits", "elements", "inputs"}, gotTop,
+	assert.ElementsMatch(t, []string{"enabled", "card_version", "profiles", "limits", "elements", "inputs", "actions"}, gotTop,
 		"D12 additive-only：顶层字段集冻结（新增新字段，绝不改名/删除）")
 
 	var limits map[string]json.RawMessage

--- a/modules/bot_api/card_profile_test.go
+++ b/modules/bot_api/card_profile_test.go
@@ -62,6 +62,7 @@ type cardProfileManifest struct {
 		MaxDepth          int `json:"max_depth"`
 		MaxInputTextBytes int `json:"max_input_text_bytes"`
 		MaxInputsBytes    int `json:"max_inputs_bytes"`
+		MaxCopyTextBytes  int `json:"max_copy_text_bytes"`
 	} `json:"limits"`
 }
 
@@ -102,6 +103,7 @@ func TestBotCardProfile_ValuesFromConstants(t *testing.T) {
 	assert.Equal(t, cardmsg.MaxDepth, m.Limits.MaxDepth)
 	assert.Equal(t, cardmsg.MaxInputTextBytes, m.Limits.MaxInputTextBytes)
 	assert.Equal(t, cardmsg.MaxInputsBytes, m.Limits.MaxInputsBytes)
+	assert.Equal(t, cardmsg.MaxCopyTextBytes, m.Limits.MaxCopyTextBytes)
 }
 
 // TestBotCardProfile_DisabledStillReturnsManifestAndSendRejects（D12.3）：rollout
@@ -181,5 +183,6 @@ func TestBotCardProfile_AdditiveContractFieldSet(t *testing.T) {
 	}
 	assert.ElementsMatch(t, []string{
 		"max_payload_bytes", "max_nodes", "max_depth", "max_input_text_bytes", "max_inputs_bytes",
+		"max_copy_text_bytes",
 	}, gotLimits, "D12 additive-only：limits 字段集冻结")
 }

--- a/pkg/cardmsg/cardmsg.go
+++ b/pkg/cardmsg/cardmsg.go
@@ -65,6 +65,11 @@ const (
 	// MaxDepth 卡片树的嵌套深度上限（Decision 3c）。
 	MaxDepth = 16
 
+	// MaxCopyTextBytes Action.CopyToClipboard.text 的字节上限（octo/v1 自定义本地动作；
+	// 复制到剪贴板的明文，4KiB 与单条 Input.Text 同量级）。text 逐字复制、不渲染，无
+	// URL/markdown 面，故只做「必填 + 大小」结构校验。
+	MaxCopyTextBytes = 4 << 10
+
 	// PlaceholderCard 空卡兜底 / 内容型展示占位（Decision 8：plain 永不为空）。
 	PlaceholderCard = "[卡片]"
 	// PlaceholderImage Image 元素在 plain 里的占位，与 RichText 的 [图片] 一致。

--- a/pkg/cardmsg/cardmsg_test.go
+++ b/pkg/cardmsg/cardmsg_test.go
@@ -124,10 +124,12 @@ func TestValidateWhitelistRejections(t *testing.T) {
 			"type":         "Container",
 			"selectAction": map[string]interface{}{"type": "Action.Submit", "data": map[string]interface{}{}},
 		}), ErrCardUnknownAction},
-		{"Action.ToggleVisibility(未支持,AC1.2)", cardWithBody(map[string]interface{}{
+		// Action.ToggleVisibility 现为 octo/v1 本地动作（见 local_actions_test.go 正/反用例）；
+		// 缺 targetElements 时按结构非法拒（不再是「未知动作」）。
+		{"Action.ToggleVisibility 缺 targetElements", cardWithBody(map[string]interface{}{
 			"type":         "Container",
 			"selectAction": map[string]interface{}{"type": "Action.ToggleVisibility"},
-		}), ErrCardUnknownAction},
+		}), ErrCardBadShape},
 	} {
 		if err := Validate(envelope(tc.card)); !errors.Is(err, tc.want) {
 			t.Errorf("%s: err=%v want %v", tc.name, err, tc.want)

--- a/pkg/cardmsg/local_actions_test.go
+++ b/pkg/cardmsg/local_actions_test.go
@@ -185,7 +185,8 @@ func TestWhitespaceID(t *testing.T) {
 	if err := Validate(v2Envelope(wsInput)); !errors.Is(err, ErrCardBadShape) {
 		t.Errorf("Input 纯空白 id 应按必填拒, err=%v", err)
 	}
-	// 展示元素纯空白 id 不登记 → toggle 指向它按悬空引用拒。
+	// 展示元素纯空白 id 不登记；toggle 指向纯空白 ref 在 parse 期即拒（targetElementID 同口径
+	// TrimSpace，PR#561 review #2）——仍为整卡 ErrCardBadShape。
 	wsTarget := cardWithBodyAndActions(
 		[]interface{}{map[string]interface{}{"type": "Container", "id": " ", "items": []interface{}{}}},
 		[]interface{}{toggle(" ")},

--- a/pkg/cardmsg/local_actions_test.go
+++ b/pkg/cardmsg/local_actions_test.go
@@ -102,6 +102,55 @@ func TestToggleVisibilityInvalid(t *testing.T) {
 	}
 }
 
+// tableWithCell 构造一张单行单元格的 Table（单元格可带 id/isVisible/items）。
+func tableWithCell(cell map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{"type": "Table", "rows": []interface{}{
+		map[string]interface{}{"type": "TableRow", "cells": []interface{}{cell}},
+	}}
+}
+
+// imageSetWith 构造一张含单张 Image 的 ImageSet（Image 可带 id/isVisible）。
+func imageSetWith(img map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{"type": "ImageSet", "images": []interface{}{img}}
+}
+
+// TestToggleTargetsNestedNodes：ToggleVisibility 可引用嵌套 id 承载节点（TableCell/TableRow/
+// ImageSet 子 Image），且这些节点的 id 同样帧内唯一、isVisible 同样校验 bool —— 每类 id 承载
+// 节点都被 noteIDAndVisibility 覆盖，不留缺口（code-review 发现 #1）。
+func TestToggleTargetsNestedNodes(t *testing.T) {
+	// TableCell id 作合法 toggle 目标。
+	cellTarget := cardWithBodyAndActions(
+		[]interface{}{tableWithCell(map[string]interface{}{"type": "TableCell", "id": "cell1", "items": []interface{}{}})},
+		[]interface{}{toggle("cell1")},
+	)
+	if err := Validate(envelope(cellTarget)); err != nil {
+		t.Errorf("ToggleVisibility 引用 TableCell id 应放行, err=%v", err)
+	}
+	// ImageSet 子 Image id 作合法 toggle 目标。
+	imgTarget := cardWithBodyAndActions(
+		[]interface{}{imageSetWith(map[string]interface{}{"type": "Image", "id": "img1", "url": "https://example.com/i.png"})},
+		[]interface{}{toggle("img1")},
+	)
+	if err := Validate(envelope(imgTarget)); err != nil {
+		t.Errorf("ToggleVisibility 引用 ImageSet 子 Image id 应放行, err=%v", err)
+	}
+	// TableCell id 撞顶层元素 id → 帧内重复拒。
+	dupCell := cardWithBody(
+		section("dup"),
+		tableWithCell(map[string]interface{}{"type": "TableCell", "id": "dup", "items": []interface{}{}}),
+	)
+	if err := Validate(envelope(dupCell)); !errors.Is(err, ErrCardBadShape) {
+		t.Errorf("TableCell id 撞顶层 id 应拒, err=%v", err)
+	}
+	// TableCell isVisible 非 bool → 拒（该节点的 isVisible 现同样被校验）。
+	badVisCell := cardWithBody(
+		tableWithCell(map[string]interface{}{"type": "TableCell", "isVisible": "no", "items": []interface{}{}}),
+	)
+	if err := Validate(envelope(badVisCell)); !errors.Is(err, ErrCardBadShape) {
+		t.Errorf("TableCell isVisible 非布尔应拒, err=%v", err)
+	}
+}
+
 // TestElementIDUniqueness：任意元素声明的 id 帧内唯一，且与 Action.Submit / Input.* 共享同一
 // 命名空间（重复即拒）。
 func TestElementIDUniqueness(t *testing.T) {

--- a/pkg/cardmsg/local_actions_test.go
+++ b/pkg/cardmsg/local_actions_test.go
@@ -1,0 +1,203 @@
+package cardmsg
+
+// card-message-toggle-visibility：octo/v1 本地动作（无服务端回调）——
+// Action.ToggleVisibility（+ 元素 id / isVisible / targetElements）与 octo 自定义
+// Action.CopyToClipboard 的校验器正/反用例。两者均属 octo/v1 展示档（两 profile 均放行），
+// 不进 card/action 派发闭环（见 TestLocalActionsNotSubmitDispatch）。
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// cardWithActions 构造一张 body 为空、只带 root actions 的最小卡。
+func cardWithActions(actions ...interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"type": "AdaptiveCard", "version": "1.5",
+		"body": []interface{}{}, "actions": actions,
+	}
+}
+
+// cardWithBodyAndActions 构造带指定 body + root actions 的卡（ToggleVisibility 需要
+// body 里有可被 targetElements 引用的元素）。
+func cardWithBodyAndActions(body, actions []interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"type": "AdaptiveCard", "version": "1.5",
+		"body": body, "actions": actions,
+	}
+}
+
+// toggle 构造一个 Action.ToggleVisibility（targetElements 直传）。
+func toggle(targetElements ...interface{}) map[string]interface{} {
+	return map[string]interface{}{"type": "Action.ToggleVisibility", "targetElements": targetElements}
+}
+
+// section 构造一个带 id 的空 Container（折叠目标）。
+func section(id string) map[string]interface{} {
+	return map[string]interface{}{"type": "Container", "id": id, "items": []interface{}{}}
+}
+
+// TestToggleVisibilityValid：合法 ToggleVisibility（引用存在的元素 id）两档均放行，含前向引用、
+// 字符串/对象两种 targetElements 形态、selectAction 携带。
+func TestToggleVisibilityValid(t *testing.T) {
+	cards := map[string]map[string]interface{}{
+		"root action 引用 body 元素": cardWithBodyAndActions(
+			[]interface{}{section("sec")},
+			[]interface{}{toggle("sec")},
+		),
+		"对象形态 targetElements": cardWithBodyAndActions(
+			[]interface{}{section("sec")},
+			[]interface{}{toggle(map[string]interface{}{"elementId": "sec", "isVisible": false})},
+		),
+		"多目标混合形态": cardWithBodyAndActions(
+			[]interface{}{section("a"), section("b")},
+			[]interface{}{toggle("a", map[string]interface{}{"elementId": "b"})},
+		),
+		// 前向引用：ActionSet 里的 toggle 出现在其 target（后一个 Container）之前，全卡走完才解析。
+		"body 内前向引用": cardWithBody(
+			map[string]interface{}{"type": "ActionSet", "actions": []interface{}{toggle("later")}},
+			section("later"),
+		),
+		// selectAction 携带 toggle（分期继承 —— 本地动作 octo/v1 放行）。
+		"selectAction 携带 toggle": cardWithBody(
+			map[string]interface{}{"type": "Container", "id": "self", "items": []interface{}{},
+				"selectAction": map[string]interface{}{"type": "Action.ToggleVisibility",
+					"targetElements": []interface{}{"self"}}},
+		),
+	}
+	for name, card := range cards {
+		if err := Validate(envelope(card)); err != nil {
+			t.Errorf("octo/v1 %s 应放行, err=%v", name, err)
+		}
+		if err := Validate(v2Envelope(card)); err != nil {
+			t.Errorf("octo/v2 %s 应放行, err=%v", name, err)
+		}
+	}
+}
+
+// TestToggleVisibilityInvalid：结构非法 / 悬空引用一律整卡拒（ErrCardBadShape）。
+func TestToggleVisibilityInvalid(t *testing.T) {
+	for name, card := range map[string]map[string]interface{}{
+		"缺 targetElements": cardWithActions(map[string]interface{}{"type": "Action.ToggleVisibility"}),
+		"targetElements 非数组": cardWithActions(map[string]interface{}{
+			"type": "Action.ToggleVisibility", "targetElements": "sec"}),
+		"targetElements 空数组": cardWithActions(toggle()),
+		"悬空引用（无此 id）": cardWithBodyAndActions(
+			[]interface{}{section("sec")}, []interface{}{toggle("nope")}),
+		"条目空字符串": cardWithBodyAndActions(
+			[]interface{}{section("sec")}, []interface{}{toggle("")}),
+		"对象缺 elementId": cardWithBodyAndActions(
+			[]interface{}{section("sec")}, []interface{}{toggle(map[string]interface{}{"isVisible": true})}),
+		"对象 isVisible 非布尔": cardWithBodyAndActions(
+			[]interface{}{section("sec")},
+			[]interface{}{toggle(map[string]interface{}{"elementId": "sec", "isVisible": "yes"})}),
+		"条目既非字符串也非对象": cardWithBodyAndActions(
+			[]interface{}{section("sec")}, []interface{}{toggle(float64(1))}),
+	} {
+		if err := Validate(envelope(card)); !errors.Is(err, ErrCardBadShape) {
+			t.Errorf("%s 应 ErrCardBadShape, err=%v", name, err)
+		}
+	}
+}
+
+// TestElementIDUniqueness：任意元素声明的 id 帧内唯一，且与 Action.Submit / Input.* 共享同一
+// 命名空间（重复即拒）。
+func TestElementIDUniqueness(t *testing.T) {
+	// 两个展示元素同 id。
+	dupDisplay := cardWithBody(section("x"), section("x"))
+	if err := Validate(envelope(dupDisplay)); !errors.Is(err, ErrCardBadShape) {
+		t.Errorf("重复展示元素 id 应拒, err=%v", err)
+	}
+	// 展示元素 id 撞 Action.Submit id（octo/v2）。
+	dupSubmit := cardWithBodyAndActions(
+		[]interface{}{section("dup")},
+		[]interface{}{map[string]interface{}{"type": "Action.Submit", "id": "dup"}},
+	)
+	if err := Validate(v2Envelope(dupSubmit)); !errors.Is(err, ErrCardBadShape) {
+		t.Errorf("展示元素 id 撞 Submit id 应拒, err=%v", err)
+	}
+	// 展示元素 id 撞 Input.* id（octo/v2）。
+	dupInput := cardWithBody(
+		section("f"),
+		map[string]interface{}{"type": "Input.Text", "id": "f"},
+	)
+	if err := Validate(v2Envelope(dupInput)); !errors.Is(err, ErrCardBadShape) {
+		t.Errorf("展示元素 id 撞 Input id 应拒, err=%v", err)
+	}
+}
+
+// TestIsVisibleAndHiddenSubtree：isVisible 必须是布尔；且隐藏子树（isVisible:false）仍完整
+// 校验、计入预算 —— 可见性不豁免 URL/深度检查（trust-boundary：校验面 ≥ 渲染面）。
+func TestIsVisibleAndHiddenSubtree(t *testing.T) {
+	// isVisible 非布尔 → 拒。
+	badVis := cardWithBody(map[string]interface{}{"type": "TextBlock", "text": "x", "isVisible": "no"})
+	if err := Validate(envelope(badVis)); !errors.Is(err, ErrCardBadShape) {
+		t.Errorf("isVisible 非布尔应拒, err=%v", err)
+	}
+	// 隐藏容器内藏 javascript: URL → 仍被 URL allowlist 拒（可见性不豁免）。
+	hiddenBadURL := cardWithBody(map[string]interface{}{
+		"type": "Container", "isVisible": false, "items": []interface{}{
+			map[string]interface{}{"type": "Image", "url": "javascript:alert(1)"},
+		},
+	})
+	if err := Validate(envelope(hiddenBadURL)); !errors.Is(err, ErrCardBadURLScheme) {
+		t.Errorf("隐藏子树内 javascript: URL 应仍被拒, err=%v", err)
+	}
+	// 隐藏容器内超深嵌套 → 仍被深度预算拒（可见性不豁免预算）。
+	node := map[string]interface{}{"type": "TextBlock", "text": "x"}
+	for i := 0; i < MaxDepth+4; i++ {
+		node = map[string]interface{}{"type": "Container", "items": []interface{}{node}}
+	}
+	node["isVisible"] = false // 最外层隐藏
+	hiddenTooDeep := cardWithBody(node)
+	if err := Validate(envelope(hiddenTooDeep)); !errors.Is(err, ErrCardTooDeep) {
+		t.Errorf("隐藏子树超深仍应被深度预算拒, err=%v", err)
+	}
+}
+
+// TestCopyToClipboard：text 必填/字符串/≤4KiB；title 可选字符串；text 逐字复制（javascript:
+// 字符串照收，非 URL 面）；两档均放行。
+func TestCopyToClipboard(t *testing.T) {
+	// 合法（两档）。
+	for name, card := range map[string]map[string]interface{}{
+		"仅 text":       cardWithActions(map[string]interface{}{"type": "Action.CopyToClipboard", "text": "cmd"}),
+		"含 title":      cardWithActions(map[string]interface{}{"type": "Action.CopyToClipboard", "title": "复制", "text": "cmd"}),
+		"text 是 js 明文": cardWithActions(map[string]interface{}{"type": "Action.CopyToClipboard", "text": "javascript:alert(1)"}),
+		"text 恰好 4KiB": cardWithActions(map[string]interface{}{"type": "Action.CopyToClipboard", "text": strings.Repeat("a", MaxCopyTextBytes)}),
+	} {
+		if err := Validate(envelope(card)); err != nil {
+			t.Errorf("octo/v1 %s 应放行, err=%v", name, err)
+		}
+		if err := Validate(v2Envelope(card)); err != nil {
+			t.Errorf("octo/v2 %s 应放行, err=%v", name, err)
+		}
+	}
+	// 非法。
+	for name, card := range map[string]map[string]interface{}{
+		"缺 text":      cardWithActions(map[string]interface{}{"type": "Action.CopyToClipboard"}),
+		"text 非字符串":   cardWithActions(map[string]interface{}{"type": "Action.CopyToClipboard", "text": float64(1)}),
+		"text 空串":     cardWithActions(map[string]interface{}{"type": "Action.CopyToClipboard", "text": ""}),
+		"text 超 4KiB": cardWithActions(map[string]interface{}{"type": "Action.CopyToClipboard", "text": strings.Repeat("a", MaxCopyTextBytes+1)}),
+		"title 非字符串":  cardWithActions(map[string]interface{}{"type": "Action.CopyToClipboard", "title": float64(1), "text": "x"}),
+	} {
+		if err := Validate(envelope(card)); !errors.Is(err, ErrCardBadShape) {
+			t.Errorf("%s 应 ErrCardBadShape, err=%v", name, err)
+		}
+	}
+}
+
+// TestLocalActionsNotSubmitDispatch：本地动作绝不进 card/action 派发（校验面 == 派发面）——
+// 带 id 的 ToggleVisibility 用 SubmitAction 查不到（它不是 Action.Submit）。
+func TestLocalActionsNotSubmitDispatch(t *testing.T) {
+	card := cardWithBodyAndActions(
+		[]interface{}{section("sec")},
+		[]interface{}{map[string]interface{}{"type": "Action.ToggleVisibility",
+			"id": "tog", "targetElements": []interface{}{"sec"}}},
+	)
+	raw, _ := json.Marshal(envelope(card))
+	if _, found := SubmitAction(raw, "tog"); found {
+		t.Error("ToggleVisibility 不应被 SubmitAction 命中（非 Action.Submit，不进派发闭环）")
+	}
+}

--- a/pkg/cardmsg/local_actions_test.go
+++ b/pkg/cardmsg/local_actions_test.go
@@ -177,6 +177,32 @@ func TestElementIDUniqueness(t *testing.T) {
 	}
 }
 
+// TestWhitespaceID：纯空白 id 视同缺失（PR#561 review nit）—— 输入控件纯空白 id 按「必填」拒；
+// 展示元素纯空白 id 不登记（不可作 target，指向它 → 悬空 fail-closed）。
+func TestWhitespaceID(t *testing.T) {
+	// Input.* 纯空白 id → 按必填拒（octo/v2）。
+	wsInput := cardWithBody(map[string]interface{}{"type": "Input.Text", "id": "  "})
+	if err := Validate(v2Envelope(wsInput)); !errors.Is(err, ErrCardBadShape) {
+		t.Errorf("Input 纯空白 id 应按必填拒, err=%v", err)
+	}
+	// 展示元素纯空白 id 不登记 → toggle 指向它按悬空引用拒。
+	wsTarget := cardWithBodyAndActions(
+		[]interface{}{map[string]interface{}{"type": "Container", "id": " ", "items": []interface{}{}}},
+		[]interface{}{toggle(" ")},
+	)
+	if err := Validate(envelope(wsTarget)); !errors.Is(err, ErrCardBadShape) {
+		t.Errorf("toggle 指向纯空白 id 应悬空拒, err=%v", err)
+	}
+	// 两个展示元素同为纯空白 id → 均不登记，故**不**判重复（可正常通过）。
+	twoWS := cardWithBody(
+		map[string]interface{}{"type": "Container", "id": " ", "items": []interface{}{}},
+		map[string]interface{}{"type": "Container", "id": " ", "items": []interface{}{}},
+	)
+	if err := Validate(envelope(twoWS)); err != nil {
+		t.Errorf("两个纯空白 id 展示元素均不登记，应不判重复, err=%v", err)
+	}
+}
+
 // TestIsVisibleAndHiddenSubtree：isVisible 必须是布尔；且隐藏子树（isVisible:false）仍完整
 // 校验、计入预算 —— 可见性不豁免 URL/深度检查（trust-boundary：校验面 ≥ 渲染面）。
 func TestIsVisibleAndHiddenSubtree(t *testing.T) {

--- a/pkg/cardmsg/validate.go
+++ b/pkg/cardmsg/validate.go
@@ -147,14 +147,20 @@ func (w *walker) registerID(kind, id string) error {
 	return nil
 }
 
-// noteIDAndVisibility 处理任意卡片节点上通用的 id / isVisible 属性 —— 由**每一个访问 id/isVisible
-// 承载节点**的位置调用（element() 展示/输入元素、column() 列、imageChild() ImageSet 子 Image、
-// Table 的 row/cell），使「任意声明 id 的节点都可作 ToggleVisibility 目标、且其 id 帧内唯一、
-// isVisible 为 bool」这条不变量无缺口（无节点类型被漏登记 → 不会误拒合法 toggle 目标）：
+// noteIDAndVisibility 处理**可寻址元素/容器**上通用的 id / isVisible 属性 —— 由每一个此类节点的
+// 访问点调用：element()（展示/输入元素）、column()（列）、imageChild()（ImageSet 子 Image）、
+// Table 的 row/cell。使「任一声明 id 的可寻址节点都可作 ToggleVisibility 目标、其 id 帧内唯一、
+// isVisible 为 bool」这条不变量在**可寻址节点**上无缺口。
+//
+// 刻意不覆盖两类**叶子/内联节点**（PR#561 review：AC 未在其上定义 id/isVisible，也不可作 toggle
+// 目标）：FactSet.facts[] 的 Fact（title/value 叶子，checkConstrainedChild 已约束其无子集合）与
+// RichTextBlock.inlines[] 的 TextRun（内联 run）。它们的 title/value markdown、selectAction 仍完整
+// 校验 + 计入预算（无渲染面逃逸）；其上若出现 id 不登记（targetElements 指向它 → 悬空 fail-closed）、
+// isVisible 不做 bool 校验（AC 无该语义，惰性放过）。
 //   - isVisible 出现时必须是 bool（否则结构非法）；
-//   - id 出现且为非空字符串时，登记进帧内唯一命名空间（registerID，与 Action.Submit/Input.*
-//     共享）并记入 elementIDs 供 targetElements 解析。非字符串 / 空 id 保持宽容（前向兼容，
-//     且无法作为合法 target）。
+//   - id 出现且 TrimSpace 后非空时，登记进帧内唯一命名空间（registerID，与 Action.Submit/Input.*
+//     共享）并记入 elementIDs 供 targetElements 解析。非字符串 / 空 / 纯空白 id 保持宽容
+//     （前向兼容，且无法作为合法 target）。
 //
 // 隐藏节点（isVisible:false）仍由调用方照常递归、计入节点/深度预算 —— 可见性**不豁免**任何
 // 白名单/URL/预算校验（trust-boundary：校验面 ≥ 渲染面，隐藏子树不得成为绕过通道）。
@@ -164,7 +170,7 @@ func (w *walker) noteIDAndVisibility(node map[string]interface{}) error {
 			return fmt.Errorf("%w: isVisible 必须是布尔", ErrCardBadShape)
 		}
 	}
-	if id, ok := node["id"].(string); ok && id != "" {
+	if id, ok := node["id"].(string); ok && strings.TrimSpace(id) != "" {
 		if err := w.registerID("element", id); err != nil {
 			return err
 		}
@@ -480,9 +486,10 @@ func (w *walker) element(el map[string]interface{}, depth int) error {
 		if !w.interactive {
 			return fmt.Errorf("%w: %q（octo/v2 起）", ErrCardUnknownElement, t)
 		}
-		// D1：输入控件 id 必填（提交时 inputs 以 id 为键）。帧内唯一 + 记入 elementIDs 已由
-		// element() 顶部 noteIDAndVisibility 统一登记（非空字符串 id 即登记），此处只强制「必填」。
-		if id, _ := el["id"].(string); id == "" {
+		// D1：输入控件 id 必填且须有意义（提交时 inputs 以 id 为键）。帧内唯一 + 记入 elementIDs
+		// 已由 element() 顶部 noteIDAndVisibility 统一登记（TrimSpace 后非空即登记），此处只强制
+		// 「必填」——与登记同口径用 TrimSpace，纯空白 id 视同缺失（PR#561 review nit）。
+		if id, _ := el["id"].(string); strings.TrimSpace(id) == "" {
 			return fmt.Errorf("%w: %s.id 必填", ErrCardBadShape, t)
 		}
 		// Input.label / Input.errorMessage 与 TextBlock.text 同为 AC markdown 渲染面

--- a/pkg/cardmsg/validate.go
+++ b/pkg/cardmsg/validate.go
@@ -147,7 +147,10 @@ func (w *walker) registerID(kind, id string) error {
 	return nil
 }
 
-// noteIDAndVisibility 处理任意卡片节点上通用的 id / isVisible 属性（展示元素、Column 共用）：
+// noteIDAndVisibility 处理任意卡片节点上通用的 id / isVisible 属性 —— 由**每一个访问 id/isVisible
+// 承载节点**的位置调用（element() 展示/输入元素、column() 列、imageChild() ImageSet 子 Image、
+// Table 的 row/cell），使「任意声明 id 的节点都可作 ToggleVisibility 目标、且其 id 帧内唯一、
+// isVisible 为 bool」这条不变量无缺口（无节点类型被漏登记 → 不会误拒合法 toggle 目标）：
 //   - isVisible 出现时必须是 bool（否则结构非法）；
 //   - id 出现且为非空字符串时，登记进帧内唯一命名空间（registerID，与 Action.Submit/Input.*
 //     共享）并记入 elementIDs 供 targetElements 解析。非字符串 / 空 id 保持宽容（前向兼容，
@@ -400,6 +403,10 @@ func (w *walker) element(el map[string]interface{}, depth int) error {
 				if err := checkConstrainedChild(row, "Table.rows[]", "TableRow", "cells"); err != nil {
 					return err
 				}
+				// TableRow 也可携带 id / isVisible（可作 ToggleVisibility 目标）—— 与展示元素同权威登记/校验。
+				if err := w.noteIDAndVisibility(row); err != nil {
+					return err
+				}
 				cells, present := row["cells"]
 				if !present {
 					continue
@@ -420,6 +427,10 @@ func (w *walker) element(el map[string]interface{}, depth int) error {
 					//（{"type":"Image","url":"javascript:"} 会被当扁平 cell、其 url 永不走查）及 typeless
 					// 伪装容器（PR#556 review P1：校验面 ≥ 渲染面）。
 					if err := checkConstrainedChild(cell, "Table.rows[].cells[]", "TableCell", "items"); err != nil {
+						return err
+					}
+					// TableCell 也可携带 id / isVisible（可作 ToggleVisibility 目标）—— 同权威登记/校验。
+					if err := w.noteIDAndVisibility(cell); err != nil {
 						return err
 					}
 					if err := checkNodeURLs(cell); err != nil {
@@ -578,6 +589,10 @@ func (w *walker) imageChild(img map[string]interface{}, depth int) error {
 		return err
 	}
 	if err := checkNodeURLs(img); err != nil {
+		return err
+	}
+	// ImageSet 子 Image 也可携带 id / isVisible（可作 ToggleVisibility 目标）—— 与展示元素同权威登记/校验。
+	if err := w.noteIDAndVisibility(img); err != nil {
 		return err
 	}
 	if err := w.selectAction(img); err != nil {

--- a/pkg/cardmsg/validate.go
+++ b/pkg/cardmsg/validate.go
@@ -755,14 +755,16 @@ func (w *walker) toggleVisibility(act map[string]interface{}) error {
 func targetElementID(item interface{}) (string, error) {
 	switch v := item.(type) {
 	case string:
-		if v == "" {
-			return "", fmt.Errorf("%w: targetElements 条目 id 不能为空", ErrCardBadShape)
+		// 与 noteIDAndVisibility 的登记口径一致：纯空白 id 视同缺失，在 parse 期即拒
+		// （否则纯空白 ref 会晚到 resolveTargetRefs 才作悬空拒 —— 同为 fail-closed，但理由更含糊）。
+		if strings.TrimSpace(v) == "" {
+			return "", fmt.Errorf("%w: targetElements 条目 id 不能为空/纯空白", ErrCardBadShape)
 		}
 		return v, nil
 	case map[string]interface{}:
 		id, _ := v["elementId"].(string)
-		if id == "" {
-			return "", fmt.Errorf("%w: targetElements 条目缺 elementId", ErrCardBadShape)
+		if strings.TrimSpace(id) == "" {
+			return "", fmt.Errorf("%w: targetElements 条目缺 elementId（或纯空白）", ErrCardBadShape)
 		}
 		if vis, present := v["isVisible"]; present {
 			if _, ok := vis.(bool); !ok {

--- a/pkg/cardmsg/validate.go
+++ b/pkg/cardmsg/validate.go
@@ -92,7 +92,9 @@ func validateCard(card map[string]interface{}, interactive bool) error {
 			return err
 		}
 	}
-	return nil
+	// 全卡遍历结束 —— 统一解析 ToggleVisibility.targetElements 引用（前向引用安全：所有元素 id
+	// 此时都已收集）。
+	return w.resolveTargetRefs()
 }
 
 // interactiveByProfile 报告 profile 对应的能力档位；未知 profile 返回 (false,
@@ -118,13 +120,22 @@ type walker struct {
 	// interactive octo/v2 档位放行 Action.Submit 与 Input.*（P2 D1）。octo/v1 恒为
 	// false（interactiveByProfile 只对 octo/v2 置 true）。
 	interactive bool
-	// seenIDs P2 D1（round-3 nit）：Action.Submit / Input.* 的 id 必须帧内唯一 ——
-	// D3 action 寻址、D4 幂等键、D11 inputs 声明匹配都以 id 为键，重复 id 会让这三处
-	// 语义歧义。懒初始化（仅 octo/v2 帧才有交互元素）。
+	// seenIDs 帧内 id 唯一命名空间：Action.Submit / Input.* 的 id（P2 D1：D3 action 寻址、
+	// D4 幂等键、D11 inputs 声明匹配以 id 为键，重复 id 三处语义歧义），以及任意声明 id 的
+	// 展示元素（ToggleVisibility.targetElements 以 id 寻址，重复 id 让目标歧义）。三类共享**一个**
+	// 帧内唯一空间（对齐 AC 的 card-global id 模型）。懒初始化。
 	seenIDs map[string]struct{}
+	// elementIDs 帧内**元素**声明的 id 集合（展示 + 输入元素；不含 action id）——
+	// Action.ToggleVisibility.targetElements 引用的解析目标。懒初始化。
+	elementIDs map[string]struct{}
+	// targetRefs 遍历期累积的 ToggleVisibility.targetElements 引用；全卡走完后由
+	// resolveTargetRefs 统一校验存在性 —— 前向引用安全（target 可先于/后于 toggle 出现）。
+	targetRefs []string
 }
 
-// registerID 记录一个 Action.Submit / Input.* 的 id 并强制帧内唯一（P2 D1）。
+// registerID 记录一个 Action.Submit / Input.* / 展示元素 的 id 并强制帧内唯一（P2 D1 +
+// ToggleVisibility）。三类共享同一 seenIDs 空间：Submit id 与元素 id 同名亦判重复（对齐 AC 的
+// card-global id 模型；重复 id 会让 action 寻址 / targetElements 寻址歧义）。
 func (w *walker) registerID(kind, id string) error {
 	if w.seenIDs == nil {
 		w.seenIDs = make(map[string]struct{})
@@ -133,6 +144,44 @@ func (w *walker) registerID(kind, id string) error {
 		return fmt.Errorf("%w: %s.id %q 帧内重复", ErrCardBadShape, kind, id)
 	}
 	w.seenIDs[id] = struct{}{}
+	return nil
+}
+
+// noteIDAndVisibility 处理任意卡片节点上通用的 id / isVisible 属性（展示元素、Column 共用）：
+//   - isVisible 出现时必须是 bool（否则结构非法）；
+//   - id 出现且为非空字符串时，登记进帧内唯一命名空间（registerID，与 Action.Submit/Input.*
+//     共享）并记入 elementIDs 供 targetElements 解析。非字符串 / 空 id 保持宽容（前向兼容，
+//     且无法作为合法 target）。
+//
+// 隐藏节点（isVisible:false）仍由调用方照常递归、计入节点/深度预算 —— 可见性**不豁免**任何
+// 白名单/URL/预算校验（trust-boundary：校验面 ≥ 渲染面，隐藏子树不得成为绕过通道）。
+func (w *walker) noteIDAndVisibility(node map[string]interface{}) error {
+	if vis, present := node["isVisible"]; present {
+		if _, ok := vis.(bool); !ok {
+			return fmt.Errorf("%w: isVisible 必须是布尔", ErrCardBadShape)
+		}
+	}
+	if id, ok := node["id"].(string); ok && id != "" {
+		if err := w.registerID("element", id); err != nil {
+			return err
+		}
+		if w.elementIDs == nil {
+			w.elementIDs = make(map[string]struct{})
+		}
+		w.elementIDs[id] = struct{}{}
+	}
+	return nil
+}
+
+// resolveTargetRefs 在全卡遍历结束后校验所有 ToggleVisibility.targetElements 引用都指向本帧
+// 声明的元素 id（elementIDs 集）。**全卡走完才解析** —— 支持前向引用（target 可先于/后于其
+// toggle 出现）。悬空引用 → 结构非法（整卡拒）。
+func (w *walker) resolveTargetRefs() error {
+	for _, ref := range w.targetRefs {
+		if _, ok := w.elementIDs[ref]; !ok {
+			return fmt.Errorf("%w: Action.ToggleVisibility.targetElements 引用不存在的元素 id %q", ErrCardBadShape, ref)
+		}
+	}
 	return nil
 }
 
@@ -174,6 +223,11 @@ func (w *walker) element(el map[string]interface{}, depth int) error {
 	// FactSet 等「叶子」上的 selectAction 会「派发期可解析、发送期没校验」，Action.Submit
 	// 的 D1 帧内唯一 id / data-必须是对象被旁路（PR#548 review：校验面必须 ≥ 派发面）。
 	if err := w.selectAction(el); err != nil {
+		return err
+	}
+	// id / isVisible 是任意元素通用属性 —— 登记 id（帧内唯一 + 记入 targetElements 解析集）、
+	// 校验 isVisible 为 bool。置于类型分派前，覆盖所有展示/输入元素。
+	if err := w.noteIDAndVisibility(el); err != nil {
 		return err
 	}
 	t, _ := el["type"].(string)
@@ -415,13 +469,10 @@ func (w *walker) element(el map[string]interface{}, depth int) error {
 		if !w.interactive {
 			return fmt.Errorf("%w: %q（octo/v2 起）", ErrCardUnknownElement, t)
 		}
-		// D1：输入控件 id 必填且帧内唯一（提交时 inputs 以 id 为键）。
-		id, _ := el["id"].(string)
-		if id == "" {
+		// D1：输入控件 id 必填（提交时 inputs 以 id 为键）。帧内唯一 + 记入 elementIDs 已由
+		// element() 顶部 noteIDAndVisibility 统一登记（非空字符串 id 即登记），此处只强制「必填」。
+		if id, _ := el["id"].(string); id == "" {
 			return fmt.Errorf("%w: %s.id 必填", ErrCardBadShape, t)
-		}
-		if err := w.registerID(t, id); err != nil {
-			return err
 		}
 		// Input.label / Input.errorMessage 与 TextBlock.text 同为 AC markdown 渲染面
 		// （AC 1.3+：label 富文本标签、errorMessage 校验失败提示），其 markdown 链接
@@ -549,6 +600,10 @@ func (w *walker) column(col map[string]interface{}, depth int) error {
 	if err := checkNodeURLs(col); err != nil {
 		return err
 	}
+	// Column 也可携带 id / isVisible（可作 ToggleVisibility 目标）—— 与展示元素同权威登记/校验。
+	if err := w.noteIDAndVisibility(col); err != nil {
+		return err
+	}
 	// Column 必须是 Column 且只带 items 子集合（type 缺省放行 —— AC 允许省略）——堵伪类型/typeless
 	// 伪装列把未走查子树藏进 rows/columns 等越界字段绕过（PR#556 review：全 flat-validated 子位置同一
 	// 纪律，校验面 ≥ 渲染面）。
@@ -613,6 +668,14 @@ func (w *walker) action(a interface{}) error {
 			return fmt.Errorf("%w: Action.OpenUrl.url 必填", ErrCardBadShape)
 		}
 		return checkURL(u)
+	case "Action.ToggleVisibility":
+		// octo/v1 本地动作（折叠/展开，无服务端回调，与 Action.OpenUrl 同档）—— 两档均放行，
+		// 不受 w.interactive 门控。selectAction / inlineAction / ActionSet 携带时同样走到这里
+		// （分期继承）。targetElements 引用在全卡走完后由 resolveTargetRefs 统一解析（前向引用）。
+		return w.toggleVisibility(act)
+	case "Action.CopyToClipboard":
+		// octo 自定义本地动作（标准 AC 无此动作）—— 复制 text 到剪贴板、无服务端回调，两档均放行。
+		return w.copyToClipboard(act)
 	case "Action.Submit":
 		// P2 动作（octo/v2，sibling brief D1）。octo/v1 一律拒绝 —— selectAction
 		// 携带时同样走到这里（分期继承：selectAction 继承所载动作的分期）。
@@ -640,6 +703,73 @@ func (w *walker) action(a interface{}) error {
 	default:
 		return fmt.Errorf("%w: %q", ErrCardUnknownAction, t)
 	}
+}
+
+// toggleVisibility 校验 Action.ToggleVisibility（octo/v1 本地折叠动作）。targetElements 必填、
+// 非空数组；每项是元素 id 字符串或 AC TargetElement 对象 {elementId:string, isVisible?:bool}。
+// 引用的元素 id 存在性在全卡遍历结束后由 resolveTargetRefs 统一校验（前向引用安全）。
+// 本动作无 URL/回调面 —— 端上纯本地翻转可见性。
+func (w *walker) toggleVisibility(act map[string]interface{}) error {
+	te, present := act["targetElements"]
+	if !present {
+		return fmt.Errorf("%w: Action.ToggleVisibility.targetElements 必填", ErrCardBadShape)
+	}
+	list, ok := te.([]interface{})
+	if !ok || len(list) == 0 {
+		return fmt.Errorf("%w: Action.ToggleVisibility.targetElements 必须是非空数组", ErrCardBadShape)
+	}
+	for _, item := range list {
+		id, err := targetElementID(item)
+		if err != nil {
+			return err
+		}
+		w.targetRefs = append(w.targetRefs, id)
+	}
+	return nil
+}
+
+// targetElementID 从一个 targetElements 条目提取被引用的元素 id：AC 允许字符串简写（元素 id）或
+// 对象全写 {elementId:string, isVisible?:bool}。两形态外 / 空 elementId / 非布尔 isVisible → 结构非法。
+func targetElementID(item interface{}) (string, error) {
+	switch v := item.(type) {
+	case string:
+		if v == "" {
+			return "", fmt.Errorf("%w: targetElements 条目 id 不能为空", ErrCardBadShape)
+		}
+		return v, nil
+	case map[string]interface{}:
+		id, _ := v["elementId"].(string)
+		if id == "" {
+			return "", fmt.Errorf("%w: targetElements 条目缺 elementId", ErrCardBadShape)
+		}
+		if vis, present := v["isVisible"]; present {
+			if _, ok := vis.(bool); !ok {
+				return "", fmt.Errorf("%w: targetElements 条目 isVisible 必须是布尔", ErrCardBadShape)
+			}
+		}
+		return id, nil
+	default:
+		return "", fmt.Errorf("%w: targetElements 条目必须是字符串或对象", ErrCardBadShape)
+	}
+}
+
+// copyToClipboard 校验 octo 自定义 Action.CopyToClipboard（本地复制，无服务端回调）。text 必填、
+// 字符串、≤ MaxCopyTextBytes；title 可选字符串。text **逐字复制、不渲染** —— 无 URL/markdown 面，
+// 不过 allowlist（生产者「勿复制隐藏/敏感字段」是产者/客户端职责，非服务端结构校验）。
+func (w *walker) copyToClipboard(act map[string]interface{}) error {
+	text, ok := act["text"].(string)
+	if !ok || text == "" {
+		return fmt.Errorf("%w: Action.CopyToClipboard.text 必填且必须是非空字符串", ErrCardBadShape)
+	}
+	if len(text) > MaxCopyTextBytes {
+		return fmt.Errorf("%w: Action.CopyToClipboard.text 超过 %d 字节上限", ErrCardBadShape, MaxCopyTextBytes)
+	}
+	if title, present := act["title"]; present {
+		if _, ok := title.(string); !ok {
+			return fmt.Errorf("%w: Action.CopyToClipboard.title 必须是字符串", ErrCardBadShape)
+		}
+	}
+	return nil
 }
 
 // checkURL 执行 Decision 3d 的正向 allowlist：仅接受「绝对」http/https URL。

--- a/pkg/cardmsg/whitelist.go
+++ b/pkg/cardmsg/whitelist.go
@@ -39,6 +39,26 @@ func DisplayElements() []string { return append([]string(nil), displayElements..
 // InputElements 返回 octo/v2 交互输入白名单副本（D12 清单据此下发 inputs；同上纪律）。
 func InputElements() []string { return append([]string(nil), inputElements...) }
 
+// displayActions 是 octo/v1 展示档接受的**本地动作**白名单 —— 无服务端回调、纯端上生效，与
+// Action.OpenUrl 同档：标准 AC 的 Action.OpenUrl（跳转）、Action.ToggleVisibility（折叠/展开）
+// 与 octo 自定义 Action.CopyToClipboard（本地复制）。D12 能力清单据此下发 actions。
+//
+// Action.Submit 属 octo/v2 交互档（回调服务端、走 card/action 闭环），**刻意不在此列** ——
+// 经 profiles 档位隐式发现（同 inputs 与 octo/v2 的关系）。
+//
+// 与 displayElements 同纪律（非结构性单一权威）：校验器 action() 对每个动作是**逐类型手写
+// case**（OpenUrl 查 url、ToggleVisibility 查 targetElements、CopyToClipboard 查 text，校验体
+// 各不相同），故 displayActions↔校验器接受集的一致性**由 TestDisplayActionsAuthority 逐个守卫**
+// —— 新增本地动作必须同时给校验器加 case 并让该测试通过，否则清单会广播一个校验器拒绝的动作
+// （漂移 = 谎报能力）。additive-only：只增不改名/删除。
+var displayActions = []string{
+	"Action.OpenUrl", "Action.ToggleVisibility", "Action.CopyToClipboard",
+}
+
+// DisplayActions 返回 octo/v1 本地动作白名单副本（D12 清单据此下发 actions；单一权威，调用方
+// MUST 用它而非重抄字面量）。每次返回新切片，调用方改不到内部状态。
+func DisplayActions() []string { return append([]string(nil), displayActions...) }
+
 // isInputElement 报告 t 是否为 octo/v2 交互输入元素（成员属于 inputElements）。校验器
 // （validate.go element 派发）与 inputs 采集（collectInputSpecsFromElements）共用它，确保
 // 「发送期放行集」「提交期声明采集集」「D12 清单 inputs」恒等。

--- a/pkg/cardmsg/whitelist_test.go
+++ b/pkg/cardmsg/whitelist_test.go
@@ -93,3 +93,47 @@ func TestDisplayElementsAuthority(t *testing.T) {
 		t.Errorf("非白名单元素 Bogus 应拒, err=%v", err)
 	}
 }
+
+// TestDisplayActionsAuthority：DisplayActions() 与校验器 action() 的 octo/v1 **本地动作**接受集
+// 一致。同 displayElements——校验器对每个动作是手写 case（OpenUrl 查 url、ToggleVisibility 查
+// targetElements、CopyToClipboard 查 text），一致性靠本测试逐个守卫：遍历 DisplayActions()，每个
+// 动作放进 card.actions[] 跑 octo/v1 Validate；缺 fixture 即 fail，逼「新增本地动作」必须同时给校验器
+// 加 case 并补 fixture 证明真被接受（否则 D12 清单 actions 谎报能力）。Action.Submit 属 octo/v2
+// 交互档，刻意不在 DisplayActions() 里——本测试同时断言它在 octo/v1 被拒。
+func TestDisplayActionsAuthority(t *testing.T) {
+	want := []string{"Action.OpenUrl", "Action.ToggleVisibility", "Action.CopyToClipboard"}
+	got := DisplayActions()
+	if !slices.Equal(got, want) {
+		t.Fatalf("DisplayActions()=%v, want %v", got, want)
+	}
+	// 每个本地动作 → 一份放进 card.actions[] 的最小合法 octo/v1 卡。ToggleVisibility 需要一个存在的
+	// 目标元素 id（其 targetElements 引用在全卡走完后解析）。
+	fixtures := map[string]map[string]interface{}{
+		"Action.OpenUrl": cardWithActions(
+			map[string]interface{}{"type": "Action.OpenUrl", "url": "https://example.com"}),
+		"Action.ToggleVisibility": cardWithBodyAndActions(
+			[]interface{}{section("sec")},
+			[]interface{}{toggle("sec")}),
+		"Action.CopyToClipboard": cardWithActions(
+			map[string]interface{}{"type": "Action.CopyToClipboard", "text": "cmd"}),
+	}
+	for _, typ := range got {
+		card, ok := fixtures[typ]
+		if !ok {
+			t.Errorf("本地动作 %s 缺校验 fixture —— 新增本地动作必须补 fixture 证明校验器接受它"+
+				"（否则 displayActions↔校验器漂移、D12 清单 actions 谎报能力）", typ)
+			continue
+		}
+		if err := Validate(envelope(card)); err != nil {
+			t.Errorf("本地动作 %s 应通过 octo/v1 校验, err=%v", typ, err)
+		}
+	}
+	// 非白名单动作被拒。
+	if err := Validate(envelope(cardWithActions(map[string]interface{}{"type": "Action.Bogus"}))); !errors.Is(err, ErrCardUnknownAction) {
+		t.Errorf("非白名单动作 Action.Bogus 应拒, err=%v", err)
+	}
+	// Action.Submit 属 octo/v2——octo/v1 下必须拒（不在 displayActions）。
+	if err := Validate(envelope(cardWithActions(map[string]interface{}{"type": "Action.Submit", "id": "s"}))); !errors.Is(err, ErrCardUnknownAction) {
+		t.Errorf("Action.Submit 在 octo/v1 应拒, err=%v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds the **octo/v1 local-action batch** to the `pkg/cardmsg` card validator — actions that render/act purely client-side with **no server callback**, the same class as the existing `Action.OpenUrl`:

- `Action.ToggleVisibility` (standard AC) for collapsible sections (e.g. "collapse/expand reasoning"), plus its supporting element attributes: frame-unique `id`, boolean `isVisible`, and `targetElements`.
- `Action.CopyToClipboard` (octo-custom) for local copy of a `text` payload.

Both stay in **octo/v1** (no new `octo/v3`; `card_version` stays `"1.5"`). The accepted local action set is advertised via a new additive `actions` field on `GET /v1/bot/card/profile`.

## Related Issue

N/A — no tracked issue; spec-driven change (see Linked Spec).

## Linked Spec

`.octospec/tasks/card-message-toggle-visibility/brief.md`

## Changes

- **`pkg/cardmsg/validate.go`** — `action()` gains `Action.ToggleVisibility` (validates `targetElements` is a non-empty array of element-id strings or `{elementId,isVisible?}` objects; referenced ids resolved against the frame's declared element ids **after the full walk**, so forward references are safe) and `Action.CopyToClipboard` (`text` required/string/≤4 KiB, optional `title`). A new `noteIDAndVisibility` helper is wired into **every id-bearing node** — top-level elements, `Column`, `TableRow`/`TableCell`, and `ImageSet` child `Image` — registering each `id` into the existing frame-unique namespace (shared with `Action.Submit`/`Input.*`) and validating `isVisible` is boolean. Hidden (`isVisible:false`) subtrees are still fully whitelist/URL/budget validated — visibility exempts nothing.
- **`pkg/cardmsg/whitelist.go`** — action whitelist lifted into a `DisplayActions()` single authority (mirrors `DisplayElements()`/`InputElements()`).
- **`pkg/cardmsg/cardmsg.go`** — `MaxCopyTextBytes = 4 KiB` constant.
- **`modules/bot_api/card_profile.go`** — additive `actions` field on the D12 manifest, sourced from `DisplayActions()`.
- **Docs** — `docs/card-protocol.md` §2.2 (fold/copy semantics) + manifest `actions`; master brief `card-message-interaction` moves ToggleVisibility from "future" to "supported (octo/v1)".

Out of scope: `Action.Submit`/`Input.*`/the `card_action` server-callback loop (`interactive.go` untouched); no `octo/v3`; no `card_version` bump; no new `pkg/errcode`/i18n/migration. Rollout stays gated by `OCTO_CARD_MESSAGE_ENABLED`.

## Testing

```
go test ./pkg/cardmsg/...     # PASS (incl. new local_actions_test.go + TestDisplayActionsAuthority)
golangci-lint run ./pkg/cardmsg/... ./modules/bot_api/...   # 0 issues
make i18n-extract-check && make i18n-lint   # OK (no new codes / raw responses)
go vet ./pkg/cardmsg/... ./modules/bot_api/...   # clean
```

New coverage in `pkg/cardmsg/local_actions_test.go`: valid toggle (root/selectAction, forward-reference, string + `{elementId}` forms, nested Table-cell/ImageSet-image targets); dangling ref; malformed/empty `targetElements`; duplicate & cross-namespace `id`; non-boolean `isVisible`; hidden subtree still URL/depth-rejected; `CopyToClipboard` text required/≤4 KiB/`title` string; local actions absent from `SubmitAction` dispatch. `TestDisplayActionsAuthority` drift-locks `DisplayActions()` to the validator accept-set.

- [x] Unit tests added/updated
- [x] Manually verified — the validator is a pure function driven end-to-end by the unit tests above (`Validate()` on real envelopes). The `bot_api` manifest test (`card_profile_test.go`, asserts `actions == DisplayActions()` + frozen additive field set) compiles clean and runs in CI (needs MySQL, unavailable in the dev sandbox).

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   It widens the InteractiveCard write-strict validator (the "校验面 ≥ 渲染面" trust boundary) to accept two no-callback local actions and element visibility/id attributes. New accepted surfaces carry nothing renderable-dangerous: `ToggleVisibility` references are id strings only; `CopyToClipboard.text` is copied verbatim (never rendered → no URL/markdown allowlist needed). Element `id` uniqueness is unified into one frame-wide namespace; `targetElements` resolution is deferred to end-of-walk for forward-reference safety. Hidden subtrees stay fully validated + budget-counted.

2. **What could break (dependents + failure mode)?**
   Dependents are card producers (bot SDK / OpenClaw adapter) and the web renderer. Behavior change: display-element `id`s are now frame-unique-enforced (previously tolerated), so a card reusing a display id now fails **closed** (whole-card 400, not a leak). Mitigated — feature is gated off by default and no client renders these yet. The manifest gains `actions` (additive-only; the additive-field-set test enforces no rename/removal). Cross-repo parity: the web renderer must mirror the same id/isVisible/targetElements rules and the **byte-length** `text` cap, else a server-accepted card downgrades to plain (safe) — flagged to the client team. No security regression: no new URL/markdown surface, hidden content still validated.

3. **How do you know it works (specific test/repro/trace)?**
   The table-driven tests enumerated under Testing exercise every new accept/reject path through `Validate()` (the real entry point), including the security-relevant cases (hidden `javascript:` URL rejected, over-depth hidden subtree rejected, local actions never entering `SubmitAction` dispatch). `TestDisplayActionsAuthority` guarantees the advertised manifest can't drift from the validator. Full suite + lint + i18n + vet all green.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwG5xPp4xTNEkWsQ1SoKjV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwG5xPp4xTNEkWsQ1SoKjV)_