### PR TITLE
fix(backend): materialise creator thread ext row #557

### DIFF
--- a/modules/conversation_ext/integration_test.go
+++ b/modules/conversation_ext/integration_test.go
@@ -702,3 +702,120 @@ func BenchmarkFollowChannel_Materialize500(b *testing.B) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// issue #557 / OCTO-2228: EnsureCreatorFollowsThread —— 创建者无条件补子区行
+//
+// Bug: 只要创建者本人没有关注父频道，无论用哪个客户端建子区，这个子区都不会进
+// 创建者自己的关注 Tab（CreateThread 不给创建者落 user_conversation_ext 行，
+// OnThreadCreated fanout 也只覆盖 auto_follow_threads=1 的已关注者）。
+// Fix: 创建 hook 里无条件为创建者落一行子区 ext 行，且**不**碰父群行。
+// ---------------------------------------------------------------------------
+
+// 场景 1（核心复现）：创建者未关注父群（无群 ext 行）时创建子区 → 关注 Tab 出现该子区。
+func TestIntegration_Issue557_EnsureCreatorFollowsThread_NoParentFollow_CreatesThreadRow(t *testing.T) {
+	_, svc := newIntegrationDB(t)
+
+	const uid, space, grp, shortID = "int-557-u1", "sp-557", "int-557-grp1", "thr-557-1"
+	threadChannelID := grp + "____" + shortID
+
+	// 前置：创建者对父群完全没有 ext 行（从未关注 / 从未取关）。
+	parent, err := svc.db.Get(uid, space, targetTypeGroup, grp)
+	require.NoError(t, err)
+	require.Nil(t, parent, "precondition: creator has no parent-group ext row")
+	threadRow, err := svc.db.Get(uid, space, targetTypeThread, threadChannelID)
+	require.NoError(t, err)
+	require.Nil(t, threadRow, "precondition: no thread ext row before creation")
+
+	// 动作：补创建者子区行。
+	require.NoError(t, svc.EnsureCreatorFollowsThread(uid, space, grp, shortID))
+
+	// 断言：子区 ext 行必须出现在创建者关注 Tab（ListThreadExts 是 Tab 的读口径）。
+	threadRow2, err := svc.db.Get(uid, space, targetTypeThread, threadChannelID)
+	require.NoError(t, err)
+	require.NotNil(t, threadRow2, "creator's thread ext row must exist after EnsureCreatorFollowsThread")
+
+	threads, err := svc.db.ListThreadExts(uid, space)
+	require.NoError(t, err)
+	require.Len(t, threads, 1, "关注 Tab 应恰好出现这一条新子区")
+	assert.Equal(t, threadChannelID, threads[0].TargetID)
+
+	// 关键边界：**不得**因创建子区而给父群落行/拉回关注（octo-web #293 P1）。
+	parentAfter, err := svc.db.Get(uid, space, targetTypeGroup, grp)
+	require.NoError(t, err)
+	assert.Nil(t, parentAfter,
+		"EnsureCreatorFollowsThread 不得触碰父群行——创建者没关注过父群，这里不应凭空造一行群行")
+}
+
+// 场景 2（P1 red-line）：创建者曾显式取关父群（group_unfollowed=1）时创建子区 →
+// 子区出现在关注 Tab，但父群 group_unfollowed 标志必须保持 1（不被副作用拉回关注）。
+func TestIntegration_Issue557_EnsureCreatorFollowsThread_PreservesUnfollowedParent(t *testing.T) {
+	_, svc := newIntegrationDB(t)
+
+	const uid, space, grp, shortID = "int-557-u2", "sp-557", "int-557-grp2", "thr-557-2"
+	threadChannelID := grp + "____" + shortID
+
+	// 前置：创建者显式取关了父群。
+	require.NoError(t, svc.UnfollowChannel(uid, space, grp))
+	parent, err := svc.db.Get(uid, space, targetTypeGroup, grp)
+	require.NoError(t, err)
+	require.NotNil(t, parent)
+	require.Equal(t, int8(1), parent.GroupUnfollowed, "precondition: parent group explicitly unfollowed")
+
+	// 动作：创建者建子区补行。
+	require.NoError(t, svc.EnsureCreatorFollowsThread(uid, space, grp, shortID))
+
+	// 断言 1：子区行出现。
+	threadRow, err := svc.db.Get(uid, space, targetTypeThread, threadChannelID)
+	require.NoError(t, err)
+	assert.NotNil(t, threadRow, "creator's thread ext row must be created even when parent is unfollowed")
+
+	// 断言 2（P1）：父群 group_unfollowed 仍为 1 —— 创建子区不得把取关过的父群拖回关注。
+	parentAfter, err := svc.db.Get(uid, space, targetTypeGroup, grp)
+	require.NoError(t, err)
+	require.NotNil(t, parentAfter)
+	assert.Equal(t, int8(1), parentAfter.GroupUnfollowed,
+		"group_unfollowed 必须保持 1：创建子区不应副作用地把用户显式取关过的父群拉回关注 Tab")
+}
+
+// 场景 3（幂等）：重复触发只留一行，不产生脏行，且保留创建者手动调过的 follow_sort。
+func TestIntegration_Issue557_EnsureCreatorFollowsThread_Idempotent(t *testing.T) {
+	_, svc := newIntegrationDB(t)
+
+	const uid, space, grp, shortID = "int-557-u3", "sp-557", "int-557-grp3", "thr-557-3"
+	threadChannelID := grp + "____" + shortID
+
+	require.NoError(t, svc.EnsureCreatorFollowsThread(uid, space, grp, shortID))
+
+	// 模拟创建者手动调过关注 Tab 排序。
+	require.NoError(t, svc.db.Upsert(uid, space, targetTypeThread, threadChannelID, ConvExtFields{
+		FollowSort: intPtr(42),
+	}))
+
+	// 再次触发（重复创建/重试）——必须幂等：不重建行、不覆盖 follow_sort。
+	require.NoError(t, svc.EnsureCreatorFollowsThread(uid, space, grp, shortID))
+
+	threads, err := svc.db.ListThreadExts(uid, space)
+	require.NoError(t, err)
+	require.Len(t, threads, 1, "重复触发不得产生第二行")
+	assert.Equal(t, 42, threads[0].FollowSort,
+		"INSERT IGNORE 必须保留创建者手动调过的 follow_sort，重复触发不覆盖")
+
+	// follow_version 单调递增（每次写都 bump），客户端可据此刷新。
+	var version int64
+	require.NoError(t, svc.session.SelectBySql(
+		"SELECT version FROM "+followVersionTable+" WHERE uid=? AND space_id=?",
+		uid, space,
+	).LoadOne(&version))
+	assert.GreaterOrEqual(t, version, int64(2), "两次写至少 bump 到 version=2")
+}
+
+// 场景 4（输入校验）：空 space_id / group_no / short_id 必须报错，不静默写脏行。
+func TestIntegration_Issue557_EnsureCreatorFollowsThread_ValidatesInput(t *testing.T) {
+	_, svc := newIntegrationDB(t)
+
+	assert.Error(t, svc.EnsureCreatorFollowsThread("", "sp", "grp", "sid"), "empty uid must error")
+	assert.Error(t, svc.EnsureCreatorFollowsThread("u", "", "grp", "sid"), "empty space_id must error")
+	assert.Error(t, svc.EnsureCreatorFollowsThread("u", "sp", "", "sid"), "empty group_no must error")
+	assert.Error(t, svc.EnsureCreatorFollowsThread("u", "sp", "grp", ""), "empty short_id must error")
+}

--- a/modules/conversation_ext/service.go
+++ b/modules/conversation_ext/service.go
@@ -978,6 +978,56 @@ func (s *Service) FollowThread(uid, spaceID, threadChannelID string) error {
 }
 
 // ---------------------------------------------------------------------------
+// EnsureCreatorFollowsThread — materialise the creator's own thread ext row
+// ---------------------------------------------------------------------------
+
+// EnsureCreatorFollowsThread 无条件为「子区创建者本人」在 user_conversation_ext
+// 里落一行子区 ext 行（等价于把创建者视为该子区的 follower），让新建子区立即出现在
+// 创建者自己的关注 Tab —— 不再依赖创建者事先关注了父频道（issue #557 / OCTO-2228）。
+//
+// 与 FollowThread 的关键区别（issue #557 注意事项 / octo-web #293 P1）：
+//   - **不触碰父群 ext 行**。FollowThread 会把父群 group_unfollowed 清零把父群拖回
+//     关注 Tab；本方法只写子区行。若创建者曾显式取关过父群，那一状态必须保留——
+//     「创建子区」这个动作不应副作用地把用户取关过的父群拉回关注列表。
+//   - 因此这里既不 upsert 父群行、也不改 auto_follow_threads，只落子区行本身。
+//
+// 幂等与写口径与 OnThreadCreated fanout 一致：
+//   - 同一 tx 内先 BumpFollowVersionTx（在 version 行拿 X 锁）再写 ext 行，与
+//     FollowChannel / UnfollowChannel / OnThreadCreated 等全部写路径同序，避免
+//     (version vs ext) 反向死锁。
+//   - upsertTx 空 ConvExtFields → INSERT IGNORE：重复触发不产生脏行，也不覆盖
+//     创建者可能已手动调过的 follow_sort。
+//
+// 调用方（thread.Service.CreateThread）应在 thread 自身 tx commit 之后、任何客户端
+// 可观察的子区频道消息之前 best-effort 调用；失败只记日志不阻断 thread 创建（下次
+// FollowChannel / refollow / 新子区 fanout 会补齐）。
+func (s *Service) EnsureCreatorFollowsThread(uid, spaceID, groupNo, shortID string) error {
+	if err := validateBase(uid, spaceID); err != nil {
+		return err
+	}
+	if groupNo == "" {
+		return errors.New("group_no must not be empty")
+	}
+	if shortID == "" {
+		return errors.New("short_id must not be empty")
+	}
+	threadChannelID := groupNo + threadSeparator + shortID
+
+	return s.withTx("EnsureCreatorFollowsThread", func(tx *dbr.Tx) error {
+		// 锁序：先 bump version（version 行 X 锁）再写 ext 行，与全包写路径同序。
+		if _, err := BumpFollowVersionTx(tx, uid, spaceID); err != nil {
+			return fmt.Errorf("EnsureCreatorFollowsThread bump version: %w", err)
+		}
+		// 只落子区行；**不**碰父群行（不清 group_unfollowed，见上方注释）。
+		// 空 fields → INSERT IGNORE，幂等且保留既有 follow_sort。
+		if err := upsertTx(tx, uid, spaceID, targetTypeThread, threadChannelID, ConvExtFields{}); err != nil {
+			return fmt.Errorf("EnsureCreatorFollowsThread upsert thread: %w", err)
+		}
+		return nil
+	})
+}
+
+// ---------------------------------------------------------------------------
 // UnfollowThread — delete thread ext row only
 // ---------------------------------------------------------------------------
 

--- a/modules/thread/api.go
+++ b/modules/thread/api.go
@@ -191,6 +191,14 @@ func (t *Thread) createThread(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	loginName := c.GetLoginName()
 
+	// issue #557 / OCTO-2228：取请求所处的 Space（?space_id 优先，否则 X-Space-ID
+	// header），用于给创建者落子区 ext 行。thread 路由组未挂 SpaceMiddleware，故这里
+	// 与 SpaceMiddleware 同口径手动提取；为空时 CreateThread 会跳过 creator-follow。
+	creatorSpaceID := strings.TrimSpace(c.Query("space_id"))
+	if creatorSpaceID == "" {
+		creatorSpaceID = strings.TrimSpace(c.GetHeader("X-Space-ID"))
+	}
+
 	// 验证 groupNo 格式
 	if !IsValidGroupNo(groupNo) {
 		respondThreadInvalidGroupNo(c)
@@ -232,6 +240,7 @@ func (t *Thread) createThread(c *wkhttp.Context) {
 		Name:                 req.Name,
 		CreatorUID:           loginUID,
 		CreatorName:          loginName,
+		CreatorSpaceID:       creatorSpaceID,
 		SourceMessageID:      req.SourceMessageID,
 		SourceMessagePayload: req.SourceMessagePayload,
 	})

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -105,10 +105,14 @@ func NewService(ctx *config.Context) IService {
 
 // CreateThreadReq 创建子区请求
 type CreateThreadReq struct {
-	GroupNo              string
-	Name                 string
-	CreatorUID           string
-	CreatorName          string
+	GroupNo     string
+	Name        string
+	CreatorUID  string
+	CreatorName string
+	// CreatorSpaceID 是创建请求所处的 Space（X-Space-ID / ?space_id），用于给创建者
+	// 落一行子区 user_conversation_ext（关注 Tab 是按 space_id 隔离读的，必须与创建者
+	// 读关注列表用的 space 一致）。为空时跳过 creator-follow（best-effort，见 CreateThread）。
+	CreatorSpaceID       string
 	SourceMessageID      *int64
 	SourceMessagePayload json.RawMessage // 源消息原始 payload，用于拷贝到子区
 }
@@ -307,6 +311,29 @@ func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
 				zap.String("groupNo", req.GroupNo),
 				zap.String("shortID", shortID),
 				zap.Error(err))
+		}
+
+		// issue #557 / OCTO-2228：无条件给「创建者本人」落一行子区 ext，让新建子区
+		// 立即出现在创建者自己的关注 Tab —— 不依赖创建者事先关注了父频道。fanout
+		// 只覆盖 auto_follow_threads=1 的已关注者，创建者不被特殊对待，所以这里补齐。
+		// 与 fanout 同为 best-effort post-commit hook：失败只警告，不回滚 thread 创建。
+		// 顺序与 OnThreadCreated 一致——排在两条客户端可观察消息之前，保证创建者的
+		// 客户端拉 sidebar 时 ext 行已存在。CreatorSpaceID 为空（客户端未带 space）时
+		// 跳过，退化到既有行为，不影响 thread 创建。
+		if req.CreatorSpaceID != "" {
+			if err := convSvc.EnsureCreatorFollowsThread(req.CreatorUID, req.CreatorSpaceID, req.GroupNo, shortID); err != nil {
+				s.Warn("EnsureCreatorFollowsThread 失败（thread 已创建，创建者关注 Tab 会延迟到下次 follow/refollow 补齐）",
+					zap.String("groupNo", req.GroupNo),
+					zap.String("shortID", shortID),
+					zap.String("creatorUID", req.CreatorUID),
+					zap.String("spaceID", req.CreatorSpaceID),
+					zap.Error(err))
+			}
+		} else {
+			s.Warn("CreateThread 缺少 space_id，跳过 creator-follow ext 落行（创建者关注 Tab 暂不出现新子区）",
+				zap.String("groupNo", req.GroupNo),
+				zap.String("shortID", shortID),
+				zap.String("creatorUID", req.CreatorUID))
 		}
 	}
 


### PR DESCRIPTION
<!-- multica:bug-fix-report v1 -->

# Bug Fix — Issue #557 — 创建子区后创建者自己看不到（关注 Tab 不出现）

## 1. Executive Summary
- **Bug**: 创建者手工建子区后，若本人未关注父频道，新子区不出现在创建者自己的「关注」Tab（跨 iOS/Android/PC/web 全端）。
- **Root Cause**: `modules/thread/service.go:CreateThread` 不给创建者写 `user_conversation_ext` 行；`modules/conversation_ext/service.go:OnThreadCreated` fanout 只覆盖 `auto_follow_threads=1` 的已关注者，创建者不被特殊对待。
- **Fix Approach**: minimal（后端 server 侧根治，一处改动全端生效）
- **Risk Level**: Low
- **PR**: draft

## 2. Issue Context
- Title: 创建子区后创建者自己看不到（关注 Tab 不出现）—— 后端应为创建者无条件补 thread ext 行，全端根治
- Reporter: octo-server#557
- bug-verified by: self（issue 已由 triager 定 `type:bug`；根因已在 body 中定位到具体 file:fn）
- Affected: 全端子区创建路径（`POST /v1/groups/:group_no/threads`），凡创建者未关注父频道

## 3. Reproduction
**Environment**: octo-server (Go 1.26)，MySQL（`user_conversation_ext` + `user_follow_version`）
**Steps**:
1. 用户 A 是群 G 成员，但**未关注** G（`user_conversation_ext` 无 G 的 group 行，或 `group_unfollowed=1`）。
2. A 在 G 内创建子区 T。
3. A 打开自己的「关注」Tab（读口径 `ListThreadExts(uid, space)`）。

**Expected**: 关注 Tab 出现刚创建的子区 T。
**Actual**: T 不出现——`user_conversation_ext` 里没有 A 对 T 的行。
**Evidence**: 集成回归测试 `Test..._NoParentFollow_CreatesThreadRow` 在未加 fix 时 RED（"creator's thread ext row must exist" 断言失败），加 fix 后 GREEN。

## 4. RCA
**Method**: 5 Whys
**Analysis**:
1. 子区为何不进 A 的关注 Tab？→ Tab 只读 `user_conversation_ext` 里 target_type=5 的行，A 没有 T 的行。
2. 为何没有行？→ 落行两条路径都没覆盖 A：
   - `CreateThread` 只写 `thread_member`（IM 发消息权限）+ 把创建者加进 IM subscribers，**从不**写 `user_conversation_ext`。
   - `OnThreadCreated` fanout 只给 `target_type=group AND auto_follow_threads=1`（已明确关注父频道）的成员补行，创建者不被特殊对待。
3. 为何创建者不被特殊对待？→ 原设计把「关注子区」完全等同于「关注了父频道后的自动跟随」，漏掉了「用户主动创建 = 天然应可见」这一 propriety。
**Root cause**: `thread.CreateThread` 提交路径缺少「为创建者本人物化子区 ext 行」的步骤；`conversation_ext.OnThreadCreated` 的 fanout 资格判定不含创建者。

## 5. Fix Description
**Files changed**:
- `modules/conversation_ext/service.go` (+50) — 新增 `EnsureCreatorFollowsThread(uid, spaceID, groupNo, shortID)`。
- `modules/thread/service.go` (+~31) — `CreateThreadReq` 加 `CreatorSpaceID`；在 `OnThreadCreated` 之后 best-effort 调用 creator-follow。
- `modules/thread/api.go` (+9) — `createThread` 从 `?space_id` / `X-Space-ID` 提取创建者 space。
- `modules/conversation_ext/integration_test.go` (+117) — 4 个回归测试。

**Change summary**: 在 thread 创建 hook（`CreateThread` commit 之后、任何客户端可观察的子区频道消息之前）无条件为创建者补一行子区 `user_conversation_ext`。新方法与 `OnThreadCreated` fanout 同口径：先 `BumpFollowVersionTx`（version 行 X 锁）再 `upsertTx` 空 fields → INSERT IGNORE，保证锁序一致 + 幂等（重复触发不产生脏行、保留创建者手动调过的 `follow_sort`）。space_id 取自创建请求（关注 Tab 按 space 隔离读，须与创建者读列表用的 space 一致）；为空时跳过，退化到既有行为。一处改动 iOS/web/PC/Android 全端生效。

**Does NOT change** (scope 边界):
- **不**触碰父群 `user_conversation_ext` 行，**不**清 `group_unfollowed`、**不**改 `auto_follow_threads`——创建子区不得副作用地把用户显式取关过的父群拖回关注 Tab（octo-web #293 第一版被 reviewer 拒的 P1）。这与 `FollowThread`（会连带清父群 blacklist）刻意不同。
- 不改 fanout 对其他成员的资格逻辑；不改 IM 频道 / 源消息 / 创建通知的既有顺序约束。

## 6. Regression Tests
| Test | File | Purpose | Before | After |
|---|---|---|---|---|
| `TestIntegration_Issue557_..._NoParentFollow_CreatesThreadRow` | `integration_test.go` | 创建者未关注父群 → 子区进关注 Tab，且不凭空造父群行 | FAIL | PASS |
| `TestIntegration_Issue557_..._PreservesUnfollowedParent` | `integration_test.go` | 创建者曾取关父群 → 子区进 Tab 但 `group_unfollowed` 保持 1（P1 red-line） | FAIL | PASS |
| `TestIntegration_Issue557_..._Idempotent` | `integration_test.go` | 重复触发只留一行、保留 `follow_sort`、version 单调递增 | PASS* | PASS |
| `TestIntegration_Issue557_..._ValidatesInput` | `integration_test.go` | 空 uid/space/group/short 报错，不静默写脏行 | PASS* | PASS |

\* 幂等/校验用例天然依赖新方法存在；核心 RED→GREEN 由前两个行为用例证明（stub 掉 fix 落行逻辑后二者 FAIL，恢复后 GREEN）。

## 7. CI Status
- Build: `go build ./...` pass；`go vet ./modules/thread/ ./modules/conversation_ext/` clean；`gofmt` clean。
- Unit: `go test ./modules/conversation_ext/`（非 integration）pass。
- Integration: 新增 4 个用例本地对真实 MySQL 全 PASS（RED→GREEN 已验证）。
- 说明: `modules/thread` 的 `NewTestServer` 系测试需完整 MySQL+Redis+WuKongIM 基础设施，本地环境不具备（setup 阶段 panic，与本改动无关）；核心行为由 `conversation_ext` 集成用例覆盖。
- Coverage delta: N/A（新增行为路径 + 覆盖测试）。

## 8. Deployment Notes
- Migration required?: **no**（复用既有 `user_conversation_ext` / `user_follow_version` 表）。
- Config change?: no
- Feature flag: no
- Compatibility: 向后兼容。best-effort post-commit hook，失败或 space 为空只警告不阻断 thread 创建；缺失行由下次 FollowChannel/refollow/新子区 fanout 补齐。

## 9. Rollback Plan
**Pattern**: revert（单 commit，无 schema/数据迁移）。
**Steps**:
1. `git revert <sha>` 或直接回滚该 PR。
2. 无需数据清理——INSERT IGNORE 落的行是合法的关注行，回滚后仅停止新落行，历史行无害保留。
**Detection** (trigger rollback): thread 创建 P99 延迟异常上升，或 `EnsureCreatorFollowsThread` warning 日志激增（DB 死锁 / 写失败）。

---
_Generated by backend-engineer · awaiting review squad (qa+security+code)_
