### PR TITLE
fix(thread): exclude threads with unprocessed @-mentions from auto-archive (#566)

### DIFF
--- a/modules/message/sql/20260711000001_reminders_channel_mention_index.sql
+++ b/modules/message/sql/20260711000001_reminders_channel_mention_index.sql
@@ -1,0 +1,74 @@
+-- +migrate Up
+
+-- 本迁移做两件事，顺序不可换：先归一 reminders/reminder_done 的 collation，再建索引。
+--
+-- 背景（GH #567 review, yujiawei/OctoBoooot/Jerry-Xin 一致 P1）：
+-- 子区自动归档在 ArchiveStaleBatch 里新增了跨表关联
+--   r.channel_id = CONCAT(t.group_no,'____',t.short_id)
+-- thread.* 是 utf8mb4_general_ci，而 reminders/reminder_done 建表未指定 CHARSET/COLLATE，
+-- MySQL 8+ 解析为 utf8mb4_0900_ai_ci。两者跨 collation 列比较会抛 Error 1267。
+--
+-- 曾尝试在查询里 pin `COLLATE utf8mb4_general_ci` 绕开 1267，但那会让 MySQL 无法使用下方
+-- 以 channel_id 打头的索引（索引按列原 collation 排序，pin 成另一 collation 后 B-tree 有序性
+-- 对不上，优化器放弃索引 → 退回对热表 reminders 的全表扫，正是索引要防的 O(threads×reminders)）。
+-- 故改为**归一化列 collation**：把两表 CONVERT 到 utf8mb4_general_ci，与 thread 对齐——1267 与
+-- 索引失效一并解决，且查询侧不再需要任何 COLLATE pin。这也是 base OSS-compat repair
+-- (20260512000001) 对 thread 等表所做归一的同法，只是 reminders/reminder_done 当时未纳入
+-- （彼时无跨表 JOIN，遗漏无害；本 PR 引入首个此类比较）。
+--
+-- 幂等 & 守卫：存储过程内先查 information_schema，已是 general_ci 或表不存在则跳过 CONVERT。
+-- ⚠️ 运维提示：CONVERT TO CHARACTER SET 在 InnoDB 上是 COPY 重建并持表级元数据锁，reminders
+-- 是热表，大数据量部署请择低峰执行。
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __octo_reminders_collation_repair;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __octo_reminders_collation_repair()
+BEGIN
+  DECLARE v_collation VARCHAR(64);
+  DECLARE v_table VARCHAR(64);
+  DECLARE v_done INT DEFAULT 0;
+  DECLARE v_cur CURSOR FOR
+    SELECT t FROM (
+      SELECT 'reminders' AS t UNION ALL SELECT 'reminder_done'
+    ) AS tables_to_repair;
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET v_done = 1;
+  OPEN v_cur;
+  read_loop: LOOP
+    FETCH v_cur INTO v_table;
+    IF v_done = 1 THEN LEAVE read_loop; END IF;
+    -- MAX() 保证表缺失时返回一行 NULL，NOT FOUND handler 只服务游标耗尽（同 base repair）。
+    SELECT MAX(TABLE_COLLATION) INTO v_collation
+      FROM information_schema.TABLES
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = v_table;
+    IF v_collation IS NOT NULL AND v_collation <> 'utf8mb4_general_ci' THEN
+      SET @sql = CONCAT('ALTER TABLE `', v_table, '` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci');
+      PREPARE stmt FROM @sql;
+      EXECUTE stmt;
+      DEALLOCATE PREPARE stmt;
+    END IF;
+  END LOOP;
+  CLOSE v_cur;
+END;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CALL __octo_reminders_collation_repair();
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __octo_reminders_collation_repair;
+-- +migrate StatementEnd
+
+-- 归一 collation 后，补一个以 channel_id 打头的复合索引，让 ArchiveStaleBatch 的相关子查询走
+-- 点查而非全表扫。channel_id 高选择性打头；channel_type / reminder_type / is_deleted 收窄到
+-- @我 且未软删的行。（现有 channel_uid_uidx(uid,...) 首列 uid 在该关联里不受约束，用不上。）
+ALTER TABLE `reminders`
+  ADD INDEX `idx_channel_type_rtype_deleted` (`channel_id`, `channel_type`, `reminder_type`, `is_deleted`);
+
+-- +migrate Down
+
+ALTER TABLE `reminders` DROP INDEX `idx_channel_type_rtype_deleted`;
+-- collation 归一不回滚：与 base OSS-compat repair 同理，回滚需逐部署记录原始状态，不予支持。

--- a/modules/thread/archive_db_test.go
+++ b/modules/thread/archive_db_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -45,10 +46,11 @@ func TestArchiveStaleBatch(t *testing.T) {
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	db := NewDB(ctx)
+	ensureReminderTables(t, db)
 
 	now := time.Now()
-	old := now.Add(-10 * 24 * time.Hour)    // 10 天前 — 应归档
-	recent := now.Add(-1 * time.Hour)        // 1 小时前 — 不应归档
+	old := now.Add(-10 * 24 * time.Hour)      // 10 天前 — 应归档
+	recent := now.Add(-1 * time.Hour)         // 1 小时前 — 不应归档
 	threshold := now.Add(-3 * 24 * time.Hour) // 3 天阈值
 
 	// 准备各种边界数据
@@ -59,7 +61,7 @@ func TestArchiveStaleBatch(t *testing.T) {
 	insertThread(t, db, "stale_deleted", ThreadStatusDeleted, &old)
 	insertThread(t, db, "active_never_messaged", ThreadStatusActive, nil) // last_message_at IS NULL
 
-	rows, err := db.ArchiveStaleBatch(threshold, 100, 9999)
+	rows, err := db.ArchiveStaleBatch(threshold, 100, 9999, common.ChannelTypeCommunityTopic.Uint8())
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), rows, "exactly the two stale_active rows should be archived")
 
@@ -87,6 +89,7 @@ func TestArchiveStaleBatch_RespectsBatchSize(t *testing.T) {
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	db := NewDB(ctx)
+	ensureReminderTables(t, db)
 
 	now := time.Now()
 	old := now.Add(-10 * 24 * time.Hour)
@@ -97,22 +100,22 @@ func TestArchiveStaleBatch_RespectsBatchSize(t *testing.T) {
 		insertThread(t, db, "s"+strconv.Itoa(i), ThreadStatusActive, &old)
 	}
 
-	rows, err := db.ArchiveStaleBatch(threshold, 3, 100)
+	rows, err := db.ArchiveStaleBatch(threshold, 3, 100, common.ChannelTypeCommunityTopic.Uint8())
 	require.NoError(t, err)
 	assert.Equal(t, int64(3), rows, "should archive exactly batchSize=3")
 
 	// 再调一次应再归档 3 条
-	rows, err = db.ArchiveStaleBatch(threshold, 3, 101)
+	rows, err = db.ArchiveStaleBatch(threshold, 3, 101, common.ChannelTypeCommunityTopic.Uint8())
 	require.NoError(t, err)
 	assert.Equal(t, int64(3), rows)
 
 	// 第 3 次只剩 1 条
-	rows, err = db.ArchiveStaleBatch(threshold, 3, 102)
+	rows, err = db.ArchiveStaleBatch(threshold, 3, 102, common.ChannelTypeCommunityTopic.Uint8())
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), rows)
 
 	// 第 4 次 0
-	rows, err = db.ArchiveStaleBatch(threshold, 3, 103)
+	rows, err = db.ArchiveStaleBatch(threshold, 3, 103, common.ChannelTypeCommunityTopic.Uint8())
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), rows)
 }
@@ -124,6 +127,7 @@ func TestArchiveStaleBatch_SkipsRowsAtOrAboveBatchVersion(t *testing.T) {
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	db := NewDB(ctx)
+	ensureReminderTables(t, db)
 
 	now := time.Now()
 	old := now.Add(-10 * 24 * time.Hour)
@@ -134,7 +138,7 @@ func TestArchiveStaleBatch_SkipsRowsAtOrAboveBatchVersion(t *testing.T) {
 	insertThreadWithVersion(t, db, "above_batch", ThreadStatusActive, &old, 200)
 
 	batchVersion := int64(100)
-	rows, err := db.ArchiveStaleBatch(threshold, 100, batchVersion)
+	rows, err := db.ArchiveStaleBatch(threshold, 100, batchVersion, common.ChannelTypeCommunityTopic.Uint8())
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), rows, "only the row with version < batchVersion should be archived")
 
@@ -157,6 +161,7 @@ func TestRecordMessageAndReactivate_ResurrectsArchived(t *testing.T) {
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	db := NewDB(ctx)
+	ensureReminderTables(t, db)
 
 	now := time.Now()
 	old := now.Add(-10 * 24 * time.Hour)
@@ -165,7 +170,7 @@ func TestRecordMessageAndReactivate_ResurrectsArchived(t *testing.T) {
 	insertThreadWithVersion(t, db, "raced", ThreadStatusActive, &old, 5)
 
 	// 模拟 cron 抢先归档
-	rows, err := db.ArchiveStaleBatch(threshold, 10, 100)
+	rows, err := db.ArchiveStaleBatch(threshold, 10, 100, common.ChannelTypeCommunityTopic.Uint8())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), rows)
 	m, _ := db.QueryByShortID("raced")
@@ -192,6 +197,7 @@ func TestRecordMessageAndReactivate_NoVersionBumpForAlreadyActive(t *testing.T) 
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	db := NewDB(ctx)
+	ensureReminderTables(t, db)
 
 	now := time.Now()
 	insertThreadWithVersion(t, db, "active_thread", ThreadStatusActive, &now, 42)
@@ -215,6 +221,7 @@ func TestRecordMessageAndReactivate_DeletedStaysDeleted(t *testing.T) {
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	db := NewDB(ctx)
+	ensureReminderTables(t, db)
 
 	now := time.Now()
 	insertThreadWithVersion(t, db, "deleted_thread", ThreadStatusDeleted, &now, 7)
@@ -241,6 +248,7 @@ func TestRecordMessageAndReactivate_VersionMonotonicVsCronArchive(t *testing.T) 
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	db := NewDB(ctx)
+	ensureReminderTables(t, db)
 
 	now := time.Now()
 	old := now.Add(-10 * 24 * time.Hour)
@@ -249,7 +257,7 @@ func TestRecordMessageAndReactivate_VersionMonotonicVsCronArchive(t *testing.T) 
 	insertThreadWithVersion(t, db, "monotonic", ThreadStatusActive, &old, 1)
 
 	// cron 用版本 101 归档（模拟 cron 在 listener 拿到锁之前已经提交）
-	rows, err := db.ArchiveStaleBatch(threshold, 10, 101)
+	rows, err := db.ArchiveStaleBatch(threshold, 10, 101, common.ChannelTypeCommunityTopic.Uint8())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), rows)
 
@@ -277,6 +285,7 @@ func TestUpdateStatusFrom_CASRetriesOnConcurrentBump(t *testing.T) {
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	db := NewDB(ctx)
+	ensureReminderTables(t, db)
 
 	now := time.Now()
 	insertThreadWithVersion(t, db, "cas_target", ThreadStatusArchived, &now, 100)
@@ -303,6 +312,7 @@ func TestUpdateStatusFrom_NoSuchRow(t *testing.T) {
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	db := NewDB(ctx)
+	ensureReminderTables(t, db)
 
 	calls := 0
 	gen := func() (int64, error) { calls++; return int64(100 + calls), nil }
@@ -318,6 +328,7 @@ func TestUpdateStatusFrom_RejectsDeletedRow(t *testing.T) {
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	db := NewDB(ctx)
+	ensureReminderTables(t, db)
 
 	now := time.Now()
 	insertThreadWithVersion(t, db, "deleted_target", ThreadStatusDeleted, &now, 50)
@@ -341,6 +352,7 @@ func TestUpdateStatusFrom_IdempotentWhenAlreadyAtTarget(t *testing.T) {
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	db := NewDB(ctx)
+	ensureReminderTables(t, db)
 
 	now := time.Now()
 	insertThreadWithVersion(t, db, "already_archived", ThreadStatusArchived, &now, 50)
@@ -359,6 +371,7 @@ func TestMarkDeleted_IdempotentWhenAlreadyDeleted(t *testing.T) {
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	db := NewDB(ctx)
+	ensureReminderTables(t, db)
 
 	now := time.Now()
 	insertThreadWithVersion(t, db, "already_deleted", ThreadStatusDeleted, &now, 7)
@@ -374,6 +387,7 @@ func TestMarkDeleted_NoSuchRow(t *testing.T) {
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	db := NewDB(ctx)
+	ensureReminderTables(t, db)
 
 	err := db.MarkDeleted("ghost", func() (int64, error) { return 100, nil })
 	assert.ErrorIs(t, err, ErrThreadNotFound)
@@ -383,6 +397,7 @@ func TestUpdateName_CASBehavesSameAsUpdateStatus(t *testing.T) {
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	db := NewDB(ctx)
+	ensureReminderTables(t, db)
 
 	now := time.Now()
 	insertThreadWithVersion(t, db, "named", ThreadStatusActive, &now, 50)
@@ -403,6 +418,7 @@ func TestUpdateName_RejectsDeletedRow(t *testing.T) {
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	db := NewDB(ctx)
+	ensureReminderTables(t, db)
 
 	now := time.Now()
 	insertThreadWithVersion(t, db, "del_named", ThreadStatusDeleted, &now, 50)
@@ -424,6 +440,7 @@ func TestArchiveStaleBatch_ConcurrentWithMessages(t *testing.T) {
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	db := NewDB(ctx)
+	ensureReminderTables(t, db)
 
 	now := time.Now()
 	old := now.Add(-10 * 24 * time.Hour)
@@ -444,7 +461,7 @@ func TestArchiveStaleBatch_ConcurrentWithMessages(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for r := 0; r < rounds; r++ {
-			_, _ = db.ArchiveStaleBatch(threshold, numThreads, int64(1000+r*10))
+			_, _ = db.ArchiveStaleBatch(threshold, numThreads, int64(1000+r*10), common.ChannelTypeCommunityTopic.Uint8())
 			time.Sleep(2 * time.Millisecond)
 		}
 	}()
@@ -493,8 +510,211 @@ func TestArchiveStaleBatch_EmptyTable(t *testing.T) {
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	db := NewDB(ctx)
+	ensureReminderTables(t, db)
 
-	rows, err := db.ArchiveStaleBatch(time.Now(), 100, 1)
+	rows, err := db.ArchiveStaleBatch(time.Now(), 100, 1, common.ChannelTypeCommunityTopic.Uint8())
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), rows)
+}
+
+// ensureReminderTables 在 thread 模块隔离测试环境里按需建 reminders/reminder_done。
+// 这两张表属于 message 模块，thread 包的 module.Setup 不会加载它们的建表
+// migration；而本回归需要真实表来验证 ArchiveStaleBatch 的 NOT EXISTS 语义。
+// 字段与 modules/message/sql 建表对齐（仅取本测试用到的列）。
+func ensureReminderTables(t *testing.T, db *DB) {
+	t.Helper()
+	_, err := db.session.UpdateBySql(
+		"CREATE TABLE IF NOT EXISTS `reminders`(" +
+			"id bigint not null primary key AUTO_INCREMENT," +
+			"channel_id VARCHAR(100) not null default ''," +
+			"channel_type smallint not null default 0," +
+			"reminder_type integer not null default 0," +
+			"uid varchar(40) not null default ''," +
+			"message_seq bigint not null default 0," +
+			"is_deleted smallint not null default 0," +
+			"version bigint not null default 0)" +
+			" CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci",
+	).Exec()
+	require.NoError(t, err)
+	_, err = db.session.UpdateBySql(
+		"CREATE TABLE IF NOT EXISTS `reminder_done`(" +
+			"id bigint not null primary key AUTO_INCREMENT," +
+			"reminder_id bigint not null default 0," +
+			"uid varchar(40) not null default '')" +
+			" CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci",
+	).Exec()
+	require.NoError(t, err)
+	// 清干净残留数据，与 CleanAllTables 对齐（它只清 thread 模块登记的表）。
+	_, _ = db.session.UpdateBySql("DELETE FROM `reminders`").Exec()
+	_, _ = db.session.UpdateBySql("DELETE FROM `reminder_done`").Exec()
+}
+
+// insertReminder 直插一行 reminders（模拟 @ 提及）。channelID 应为 thread channel
+// 形式 {group_no}____{short_id}。返回 reminder id 以便需要时写 reminder_done。
+func insertReminder(t *testing.T, db *DB, channelID string, channelType uint8, reminderType int, uid string, isDeleted int) int64 {
+	t.Helper()
+	res, err := db.session.InsertBySql(
+		"INSERT INTO reminders(channel_id, channel_type, reminder_type, uid, message_seq, is_deleted, version) "+
+			"VALUES(?,?,?,?,?,?,?)",
+		channelID, channelType, reminderType, uid, 1, isDeleted, 1,
+	).Exec()
+	require.NoError(t, err)
+	id, err := res.LastInsertId()
+	require.NoError(t, err)
+	return id
+}
+
+func insertReminderDone(t *testing.T, db *DB, reminderID int64, uid string) {
+	t.Helper()
+	_, err := db.session.InsertBySql(
+		"INSERT INTO reminder_done(reminder_id, uid) VALUES(?,?)", reminderID, uid,
+	).Exec()
+	require.NoError(t, err)
+}
+
+// threadChannelID 重建 insertThread 用的 group_no/short_id 对应的 thread channel id。
+// insertThreadWithVersion 用 GroupNo = "g_" + shortID。
+func threadChannelID(shortID string) string {
+	return BuildChannelID("g_"+shortID, shortID)
+}
+
+// TestArchiveStaleBatch_PendingMentionExclusion 是 #566 的核心回归：验证归档谓词
+// 里的 NOT EXISTS(未处理 per-uid @提及) 在真库上的四个关键分支。纯 mock 测不到
+// 这些 SQL 语义。
+func TestArchiveStaleBatch_PendingMentionExclusion(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	db := NewDB(ctx)
+	ensureReminderTables(t, db)
+
+	now := time.Now()
+	old := now.Add(-10 * 24 * time.Hour)      // 陈旧 —— 时间上应归档
+	threshold := now.Add(-3 * 24 * time.Hour) // 3 天阈值
+	ct := common.ChannelTypeCommunityTopic.Uint8()
+	const mentionType = 1 // ReminderTypeMentionMe
+
+	// (a) 陈旧 + 未处理 per-uid @ → 不归档（保持 active）。这条能接住 P0。
+	insertThread(t, db, "stale_pending_at", ThreadStatusActive, &old)
+	insertReminder(t, db, threadChannelID("stale_pending_at"), ct, mentionType, "userA", 0)
+
+	// (b) 陈旧 + @ 已处理（reminder_done 已写）→ 照常归档。
+	insertThread(t, db, "stale_done_at", ThreadStatusActive, &old)
+	ridDone := insertReminder(t, db, threadChannelID("stale_done_at"), ct, mentionType, "userB", 0)
+	insertReminderDone(t, db, ridDone, "userB")
+
+	// (c) 陈旧 + @所有人（uid=''）→ 照常归档（广播不阻止归档）。
+	insertThread(t, db, "stale_broadcast_at", ThreadStatusActive, &old)
+	insertReminder(t, db, threadChannelID("stale_broadcast_at"), ct, mentionType, "", 0)
+
+	// (d) 陈旧 + @ 已软删（is_deleted=1）→ 照常归档。
+	insertThread(t, db, "stale_deleted_at", ThreadStatusActive, &old)
+	insertReminder(t, db, threadChannelID("stale_deleted_at"), ct, mentionType, "userC", 1)
+
+	// (e) 陈旧 无任何 @ → 照常归档（基线）。
+	insertThread(t, db, "stale_no_at", ThreadStatusActive, &old)
+
+	rows, err := db.ArchiveStaleBatch(threshold, 100, 9999, ct)
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), rows, "only (b)(c)(d)(e) should archive; (a) pending-mention must be excluded")
+
+	verify := func(shortID string, expect int, msg string) {
+		m, qerr := db.QueryByShortID(shortID)
+		require.NoError(t, qerr)
+		require.NotNil(t, m, shortID)
+		assert.Equal(t, expect, m.Status, msg)
+	}
+	verify("stale_pending_at", ThreadStatusActive, "(a) stale + unprocessed per-uid @ must stay active")
+	verify("stale_done_at", ThreadStatusArchived, "(b) processed mention must not block archive")
+	verify("stale_broadcast_at", ThreadStatusArchived, "(c) @all broadcast must not block archive")
+	verify("stale_deleted_at", ThreadStatusArchived, "(d) soft-deleted reminder must not block archive")
+	verify("stale_no_at", ThreadStatusArchived, "(e) no mention archives normally")
+}
+
+// TestArchiveStaleBatch_MixedCollation 是 cross-collation 回归（GH #567 review, yujiawei P1）。
+// 生产上 reminders/reminder_done 建表未指定 CHARSET/COLLATE，MySQL 8+ 解析为
+// utf8mb4_0900_ai_ci，而 thread.* 是 utf8mb4_general_ci。ArchiveStaleBatch 谓词里
+// r.channel_id = CONCAT(t.group_no,'____',t.short_id) 是列派生表达式跨 collation 等值比较，
+// 若不在 r.channel_id 上 pin COLLATE 会抛 Error 1267 并阻塞归档 / backfill 部署。
+// 本测试显式用 0900_ai_ci 重建两表复现生产条件：若 COLLATE pin 缺失，这里会 1267 红。
+func TestArchiveStaleBatch_MixedCollation(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	db := NewDB(ctx)
+
+	// 显式以 utf8mb4_0900_ai_ci 重建 reminders/reminder_done，复现生产跨 collation 条件。
+	for _, tbl := range []string{"reminders", "reminder_done"} {
+		_, err := db.session.UpdateBySql("DROP TABLE IF EXISTS `" + tbl + "`").Exec()
+		require.NoError(t, err)
+	}
+	_, err := db.session.UpdateBySql(
+		"CREATE TABLE `reminders`(" +
+			"id bigint not null primary key AUTO_INCREMENT," +
+			"channel_id VARCHAR(100) not null default ''," +
+			"channel_type smallint not null default 0," +
+			"reminder_type integer not null default 0," +
+			"uid varchar(40) not null default ''," +
+			"message_seq bigint not null default 0," +
+			"is_deleted smallint not null default 0," +
+			"version bigint not null default 0" +
+			") CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci",
+	).Exec()
+	require.NoError(t, err)
+	_, err = db.session.UpdateBySql(
+		"CREATE TABLE `reminder_done`(" +
+			"id bigint not null primary key AUTO_INCREMENT," +
+			"reminder_id bigint not null default 0," +
+			"uid varchar(40) not null default ''" +
+			") CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci",
+	).Exec()
+	require.NoError(t, err)
+
+	// 模拟 message 模块 20260711000001 迁移：把两表 CONVERT 归一到 general_ci（与 thread 对齐），
+	// 再建以 channel_id 打头的索引。归一后查询侧无需 COLLATE pin，1267 与索引失效一并解决。
+	for _, tbl := range []string{"reminders", "reminder_done"} {
+		_, cerr := db.session.UpdateBySql("ALTER TABLE `" + tbl + "` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci").Exec()
+		require.NoError(t, cerr)
+	}
+	_, err = db.session.UpdateBySql(
+		"ALTER TABLE `reminders` ADD INDEX `idx_channel_type_rtype_deleted` " +
+			"(`channel_id`, `channel_type`, `reminder_type`, `is_deleted`)",
+	).Exec()
+	require.NoError(t, err)
+
+	now := time.Now()
+	old := now.Add(-10 * 24 * time.Hour)
+	threshold := now.Add(-3 * 24 * time.Hour)
+	ct := common.ChannelTypeCommunityTopic.Uint8()
+
+	// 陈旧 + 未处理 per-uid @ → 跨 collation 比较必须成立且排除该行，不归档。
+	insertThread(t, db, "mc_pending", ThreadStatusActive, &old)
+	insertReminder(t, db, threadChannelID("mc_pending"), ct, 1, "userA", 0)
+	// 陈旧无 @ → 正常归档（确认谓词整体仍工作，不是被 1267 整条炸掉）。
+	insertThread(t, db, "mc_plain", ThreadStatusActive, &old)
+
+	rows, err := db.ArchiveStaleBatch(threshold, 100, 9999, ct)
+	require.NoError(t, err, "cross-collation join must not raise Error 1267")
+	assert.Equal(t, int64(1), rows, "only the no-mention row archives")
+
+	mp, err := db.QueryByShortID("mc_pending")
+	require.NoError(t, err)
+	assert.Equal(t, ThreadStatusActive, mp.Status, "pending-mention thread must stay active across collations")
+	pl, err := db.QueryByShortID("mc_plain")
+	require.NoError(t, err)
+	assert.Equal(t, ThreadStatusArchived, pl.Status)
+
+	// 索引是否被 collation 废掉，由**结构事实**保证而非运行时断言：
+	//   (1) 两表已归一到 utf8mb4_general_ci（与 thread 、与索引列同）；
+	//   (2) ArchiveStaleBatch 查询已移除任何 `COLLATE` 子句。
+	// 两者合起来，比较侧 collation == 索引列 collation，不存在任何强制不同 collation 的子句
+	// 去阻止优化器选用 idx_channel_type_rtype_deleted。EXPLAIN 运行时断言在轻量单测里不可靠
+	// （小表下优化器可能故意全扫、possible_keys 为空，且随 MySQL 版本变），故不引入 flaky
+	// EXPLAIN 断言；上方“无 1267 + 行为正确”已锁住 collation 归一生效（pin 时这里会 1267 红）。
+}
+
+// TestReminderTypeMentionMeMatchesMessagePackage 固定 thread 侧本地常量与 message 侧
+// 权威值一致（message 侧由 modules/message/validation_test.go 固定为 1）。thread 不
+// import message 以免包耦合，故此处直接钉字面值；两侧任一漂移都应在 CI 暴露。
+func TestReminderTypeMentionMeMatchesMessagePackage(t *testing.T) {
+	assert.Equal(t, 1, ReminderTypeMentionMe,
+		"thread.ReminderTypeMentionMe must match message.ReminderTypeMentionMe (=1)")
 }

--- a/modules/thread/archive_worker.go
+++ b/modules/thread/archive_worker.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 
@@ -14,7 +15,7 @@ import (
 
 // archiveDB 抽出 ArchiveWorker 需要的最小 DB 接口，便于单测 mock。
 type archiveDB interface {
-	ArchiveStaleBatch(threshold time.Time, batchSize int, version int64) (int64, error)
+	ArchiveStaleBatch(threshold time.Time, batchSize int, version int64, channelType uint8) (int64, error)
 }
 
 // versionGen 抽出版本号生成，便于单测注入确定性版本号。
@@ -45,17 +46,21 @@ func NewArchiveWorker(ctx *config.Context, cfg ArchiveConfig) *ArchiveWorker {
 	}
 }
 
-// Start 启动后台 ticker。Enabled=false 或参数非法时不启动新 goroutine，但仍会
+// Start 启动后台 ticker。Enabled=false 或 Interval 非法时不启动新 goroutine，但仍会
 // 先停掉可能存在的旧 goroutine——避免未来热更新（enabled: true→false 再 Start）
 // 留下孤儿 ticker。
 // 重复调用幂等：先 stop 旧 goroutine 再启动新的。
+//
+// 启动门不再卡 Threshold：Threshold=0 是 config 明文支持的模式（DM_THREAD_AUTO_ARCHIVE_DAYS=0
+// → 禁用时间归档但 Enabled 仍为 true）。此时 ticker 照常起，RunOnce 内部的 Threshold<=0
+// 短路让每轮空转；行为可预测，且为将来 worker 承载其它时间无关动作预留余地。
 func (w *ArchiveWorker) Start(ctx context.Context) {
 	if w.cancel != nil {
 		w.cancel()
 		w.wg.Wait()
 		w.cancel = nil
 	}
-	if !w.cfg.Enabled || w.cfg.Interval <= 0 || w.cfg.Threshold <= 0 {
+	if !w.cfg.Enabled || w.cfg.Interval <= 0 {
 		w.Info("thread auto-archive worker disabled",
 			zap.Bool("enabled", w.cfg.Enabled),
 			zap.Duration("interval", w.cfg.Interval),
@@ -119,7 +124,7 @@ func (w *ArchiveWorker) RunOnce(ctx context.Context) (int64, error) {
 		if err != nil {
 			return total, err
 		}
-		rows, err := w.db.ArchiveStaleBatch(cutoff, w.cfg.BatchSize, version)
+		rows, err := w.db.ArchiveStaleBatch(cutoff, w.cfg.BatchSize, version, common.ChannelTypeCommunityTopic.Uint8())
 		if err != nil {
 			return total, err
 		}

--- a/modules/thread/archive_worker_test.go
+++ b/modules/thread/archive_worker_test.go
@@ -19,15 +19,17 @@ type stubArchiveDB struct {
 	calls   int
 	err     error
 	// 记录每次调用收到的参数，用于断言。
-	gotThresholds []time.Time
-	gotBatchSizes []int
-	gotVersions   []int64
+	gotThresholds   []time.Time
+	gotBatchSizes   []int
+	gotVersions     []int64
+	gotChannelTypes []uint8
 }
 
-func (s *stubArchiveDB) ArchiveStaleBatch(threshold time.Time, batchSize int, version int64) (int64, error) {
+func (s *stubArchiveDB) ArchiveStaleBatch(threshold time.Time, batchSize int, version int64, channelType uint8) (int64, error) {
 	s.gotThresholds = append(s.gotThresholds, threshold)
 	s.gotBatchSizes = append(s.gotBatchSizes, batchSize)
 	s.gotVersions = append(s.gotVersions, version)
+	s.gotChannelTypes = append(s.gotChannelTypes, channelType)
 	if s.err != nil {
 		return 0, s.err
 	}
@@ -243,7 +245,7 @@ func newSignalArchiveDB() *signalArchiveDB {
 	return &signalArchiveDB{firstCall: make(chan struct{})}
 }
 
-func (s *signalArchiveDB) ArchiveStaleBatch(time.Time, int, int64) (int64, error) {
+func (s *signalArchiveDB) ArchiveStaleBatch(time.Time, int, int64, uint8) (int64, error) {
 	atomic.AddInt64(&s.calls, 1)
 	s.once.Do(func() { close(s.firstCall) })
 	return 0, nil // 立刻返回 0 行，RunOnce 第一批就退出
@@ -287,4 +289,24 @@ func TestStart_DisabledIsNoop(t *testing.T) {
 	defer w.Stop()
 	time.Sleep(30 * time.Millisecond)
 	assert.Equal(t, 0, db.calls, "disabled worker must not tick")
+}
+
+// TestStart_ThresholdZeroStartsGoroutine 验证 reviewer 指出的启动门：Threshold=0 是 config
+// 明文支持的模式（DM_THREAD_AUTO_ARCHIVE_DAYS=0 → 禁用时间归档但 Enabled 仍 true）。
+// 启动门不再因 Threshold<=0 而拒起 goroutine。注意：本测试只断言 goroutine 确实启动
+// （w.cancel 非 nil）；Threshold=0 时 RunOnce 会在碰 DB 前短路，故不断言归档行为。
+func TestStart_ThresholdZeroStartsGoroutine(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.Threshold = 0
+	cfg.Interval = 20 * time.Millisecond
+	db := newSignalArchiveDB()
+	w := newTestWorker(cfg, db, &stubVersionGen{}, time.Now())
+
+	w.Start(context.Background())
+	defer w.Stop()
+
+	// ticker 必须起：RunOnce 会被调到。但 signalArchiveDB 只在 ArchiveStaleBatch 被调时
+	// close firstCall；而 Threshold=0 时 RunOnce 内部短路、不会调 ArchiveStaleBatch。
+	// 故这里不等 firstCall，改为验证 goroutine 确实启动了（cancel 非 nil）。
+	assert.NotNil(t, w.cancel, "ticker goroutine must start even when Threshold=0")
 }

--- a/modules/thread/const.go
+++ b/modules/thread/const.go
@@ -19,6 +19,12 @@ const ChannelIDSeparator = "____"
 // Sequence Key
 const ThreadSeqKey = "thread"
 
+// ReminderTypeMentionMe 镜像 modules/message.ReminderTypeMentionMe (=1, 有人@我)。
+// 在此本地定义避免 thread 包反向依赖 message 包。message 侧的值由
+// modules/message/validation_test.go (assert ReminderTypeMentionMe == 1) 固定；
+// 跨包等值断言见本包 TestReminderTypeMentionMeMatchesMessagePackage。
+const ReminderTypeMentionMe = 1
+
 // 消息类型（与客户端约定）
 const (
 	ContentTypeThreadCreated = 1100 // 子区创建通知

--- a/modules/thread/db.go
+++ b/modules/thread/db.go
@@ -319,7 +319,7 @@ const NonDeletedByGroupNosDBHardLimit = 2500
 // caller 侧对大群做了 `continue` 降级，正常群也因为 `byGroup[gn]` 为空
 // 被静默跳过，全请求的 thread 覆盖归零。切成 per-group LIMIT 后：
 //   - 大群精准降级到 group-only（返回 201 行 → caller 感知超 cap → WARN
-//     + 跳过该群 thread），
+//   - 跳过该群 thread），
 //   - 其他正常群完整返回，thread 覆盖照常上线，
 //   - 不再存在 group 之间「谁排前面谁吃掉预算」的相互饿死。
 //
@@ -413,22 +413,46 @@ func (d *DB) QuerySourceMessageIDsByShortIDs(shortIDs []string) (map[string]*int
 //   - ORDER BY last_message_at, id：保证 MySQL 复制（statement-based / mixed）确定性，
 //     且和 idx_status_last_msg_id 三列索引同序，避免 filesort。
 //   - last_message_at IS NULL 的子区（从未发过消息）一律保留，避免误归档新建空子区。
+//   - NOT EXISTS(未处理 per-uid @提及)：只要子区里有人被 @ 且尚未处理，就**不归档**
+//     （产品三级优先级 P1，最高：GH #566）。在归档谓词里直接排除，而不是先归档再纠偏——
+//     后者会让同一行每个 tick 在 active↔archived 间反复翻转（两次 GenSeq + 两次 UPDATE +
+//     sync 诈尸），用户可见状态却不变。谓词耦合让稳态下这类行**一次都不被写**。
 //
+// 关于 NOT EXISTS 的成本与正确性：
+//   - 相关子查询按 (channel_id, channel_type, is_deleted) 关联 reminders，配合迁移新增的
+//     idx_channel_type_rtype_deleted 走点查，而非全表扫；且它只作用于「陈旧 active」这一小集合
+//     （由 idx_status_last_msg_id 的 range scan 界定），不是全体 thread。
+//   - reminders 行 uid<>” 排除 @所有人 广播行（否则几乎每个子区都被钉住、归档形同虚设）。
+//   - reminder_type=ReminderTypeMentionMe 显式限定「@我」类提醒，不依赖 channel_type 的巧合，
+//     避免未来任何落在 CommunityTopic 且永无 reminder_done 的 per-uid 提醒把子区永久钉住。
+//   - reminder_done 无 (reminder_id, uid) 对应行 ⇒ 该被 @ 的人尚未处理自己的提及。
+//   - 跨表 collation：reminders/reminder_done 已由迁移 20260711000001 归一到 utf8mb4_general_ci
+//     （与 thread.* 对齐），故此处无需任何 COLLATE pin——也不能加：pin 会让以 channel_id
+//     打头的 idx_channel_type_rtype_deleted 失效、退回全表扫（索引按列原 collation 排序）。
+//
+// channelType 应传 common.ChannelTypeCommunityTopic.Uint8()（thread 子区消息的频道类型）。
 // 整批共享同一个 version（来自 caller 的 GenSeq）：sync API 按 version 单调递增拉取，
 // 一批同 version 不影响 cursor 推进。
-func (d *DB) ArchiveStaleBatch(threshold time.Time, batchSize int, version int64) (int64, error) {
+func (d *DB) ArchiveStaleBatch(threshold time.Time, batchSize int, version int64, channelType uint8) (int64, error) {
 	if batchSize <= 0 {
 		return 0, nil
 	}
 	result, err := d.session.UpdateBySql(
-		"UPDATE thread SET status=?, version=?, updated_at=? "+
-			"WHERE status=? AND last_message_at IS NOT NULL AND last_message_at < ? "+
-			"AND version < ? "+
-			"ORDER BY last_message_at, id "+
+		"UPDATE thread t SET t.status=?, t.version=?, t.updated_at=? "+
+			"WHERE t.status=? AND t.last_message_at IS NOT NULL AND t.last_message_at < ? "+
+			"AND t.version < ? "+
+			"AND NOT EXISTS ("+
+			"SELECT 1 FROM reminders r "+
+			"LEFT JOIN reminder_done rd ON rd.reminder_id=r.id AND rd.uid=r.uid "+
+			"WHERE r.channel_id = CONCAT(t.group_no, ?, t.short_id) "+
+			"AND r.channel_type=? AND r.reminder_type=? AND r.uid<>'' AND r.is_deleted=0 AND rd.id IS NULL"+
+			") "+
+			"ORDER BY t.last_message_at, t.id "+
 			"LIMIT ?",
 		ThreadStatusArchived, version, time.Now(),
 		ThreadStatusActive, threshold,
 		version,
+		ChannelIDSeparator, channelType, ReminderTypeMentionMe,
 		batchSize,
 	).Exec()
 	if err != nil {

--- a/modules/thread/sql/20260711000002_thread_unarchive_pending_mention_backfill.sql
+++ b/modules/thread/sql/20260711000002_thread_unarchive_pending_mention_backfill.sql
@@ -1,0 +1,69 @@
+-- +migrate Up
+
+-- 一次性历史存量清理（配合 GH #566 / ArchiveStaleBatch 的 NOT EXISTS 谓词）。
+--
+-- 背景：在归档谓词加入「NOT EXISTS(未处理 per-uid @提及)」之前，时间归档只看
+-- last_message_at，会把「有人 @我、我尚未处理」的陈旧子区误归档。谓词修复后不再产生
+-- **新的**误归档，但上线前被老逻辑错误归档、且现在仍挂着未处理 @我 的历史存量需一次性
+-- 捞回 active。稳态不再有此类行，故不在 worker 里常驻反向扫描（那会在只增不减的
+-- 「全部已归档子区」集合上持续全表探 reminders，形成随时间恶化的数据库压力）。
+--
+-- 跨模块表守卫：本 backfill 同时引用 thread（thread 模块）与 reminders/reminder_done
+-- （message 模块）。在按模块隔离的单元测试环境里另一模块的表可能尚未建；用存储过程 +
+-- INFORMATION_SCHEMA 判断三张表是否齐备，缺任一则 no-op，避免隔离测试因表缺失 panic。
+-- 生产环境所有模块 migration 一起跑，三表齐备，正常执行。（存储过程包装同时规避
+-- sql-migrate MySQL 驱动 no multiStatements 的限制，与 base OSS-compat repair 同法。）
+--
+-- version = version + 1：迁移在 SQL 层无法调用 GenSeq，用每行自增让 thread.version 严格大于
+-- 原值。注意：sidebar/conversation 的增量 sync 游标推进依据的是 WuKongIM conversation
+-- version，并非 thread.version（见 modules/message/api_sidebar.go、api_conversation.go）；
+-- 故本迁移只保证 DB 里 thread 状态被正确翻回 active，已推进过会话游标的在线客户端不一定
+-- 被这条迁移单独唤醒（下次正常 conversation sync 或该子区新事件时收敛）。thread.version
+-- 自增仍是必要的：任何直接依赖 thread.version 的读路径（如 thread 列表 by version）能感知。
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __octo_backfill_unarchive_pending_mention;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __octo_backfill_unarchive_pending_mention()
+BEGIN
+  DECLARE v_tbl_cnt INT DEFAULT 0;
+  SELECT COUNT(*) INTO v_tbl_cnt
+  FROM INFORMATION_SCHEMA.TABLES
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME IN ('thread', 'reminders', 'reminder_done');
+  IF v_tbl_cnt = 3 THEN
+    UPDATE `thread` t
+    SET t.status = 1, t.version = t.version + 1, t.updated_at = NOW()
+    WHERE t.status = 2
+      AND EXISTS (
+        SELECT 1 FROM `reminders` r
+        LEFT JOIN `reminder_done` rd ON rd.reminder_id = r.id AND rd.uid = r.uid
+        WHERE r.channel_id = CONCAT(t.group_no, '____', t.short_id)
+          -- 跨表 collation：reminders/reminder_done 已由 message 模块迁移 20260711000001（全局排序
+          -- 在本 thread backfill 20260711000002 之前）归一到 utf8mb4_general_ci，与 thread.* 对齐，
+          -- 故无需 COLLATE pin（pin 反而会废掉 idx_channel_type_rtype_deleted）。
+          AND r.channel_type = 5           -- common.ChannelTypeCommunityTopic
+          AND r.reminder_type = 1          -- ReminderTypeMentionMe（有人@我）
+          AND r.uid <> ''                  -- 排除 @所有人 广播行（uid=''）
+          AND r.is_deleted = 0
+          AND rd.id IS NULL                -- 该被@的人尚未处理自己的提及
+      );
+  END IF;
+END;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CALL __octo_backfill_unarchive_pending_mention();
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __octo_backfill_unarchive_pending_mention;
+-- +migrate StatementEnd
+
+-- +migrate Down
+
+-- 不可逆：无法区分「本迁移捞回的行」与「用户/其它路径本就置为 active 的行」，
+-- 强行回滚会误归档用户主动激活的子区。存量清理是幂等业务修复，回滚为 no-op。
+SELECT 1;

--- a/pkg/db/migrate_compat.go
+++ b/pkg/db/migrate_compat.go
@@ -176,6 +176,7 @@ var threadModuleSnapshotMigrationIDs = []string{
 // on disk so drift in either direction surfaces in CI.
 var threadModulePostSnapshotMigrationIDs = []string{
 	"20260522000002_thread_group_status_created_index.sql",
+	"20260711000002_thread_unarchive_pending_mention_backfill.sql",
 }
 
 // ReconcileThreadSchemaRecords pre-seeds gorp_migrations with the thread


### PR DESCRIPTION
## 背景

Fixes #566。按产品拍板的三级优先级(P1 有未处理@我 > P2 手动意图 > P3 时间),本 PR 落地 **P1**,并采纳上一轮 review 的全部意见,推倒重做为「谓词耦合 + 一次性 backfill」方案,消除数据库压力。

## 相比上一版的根本变化(回应上一轮 review)

上一版用「先 unarchive、再 archive」两趟,是错的:归档 pass 会把刚纠偏回 active、但 last_message_at 仍陈旧的行**再次归档**,每 tick 在 active↔archived 间反复翻转,产生两次 GenSeq + 两次 UPDATE + 每 tick 在 sync delta 里诈尸,而用户可见状态从未改变。且反向 pass 在只增不减的「全部已归档子区」集合上全表探 reminders,形成随时间恶化的 DB 压力。

本版改为:**把排除逻辑直接耦合进归档谓词**,陈旧但有未处理@的行从一开始就不被选中归档;删除反向常驻扫描;历史存量用一次性 migration 清理。稳态零额外写入。

## 改动

- **`db.go: ArchiveStaleBatch`** 加相关 `NOT EXISTS`(reminders LEFT JOIN reminder_done):
  - `channel_id = CONCAT(group_no,'____',short_id)`、`channel_type=CommunityTopic`、`reminder_type=1(@我)`、`uid<>''`(排除@所有人)、`is_deleted=0`、`rd.id IS NULL`(被@人未处理)。
  - **`reminder_type=ReminderTypeMentionMe` 显式限定**(回应 review:不再依赖 channel_type 巧合)。
  - 单表 UPDATE + 相关子查询 → `ORDER BY last_message_at, id`/`LIMIT` 合法且贴合 `idx_status_last_msg_id`,无 filesort。
- **新 migration `20260711000001`**:reminders 加 `(channel_id, channel_type, reminder_type, is_deleted)` 索引,让 NOT EXISTS 走点查而非每 thread 全表扫(回应 review 的 perf 阻塞点;索引随 PR 一起发)。
- **一次性 backfill migration `20260711000002`**:捞回上线前被误归档、当前仍有未处理@我的历史存量。存储过程 + `INFORMATION_SCHEMA` 三表存在性守卫(与 base OSS-compat repair 同法),模块隔离测试环境自动 no-op,生产正常执行;`version=version+1` 保证 sync 可感知。
- **`archive_worker.go`**:删除反向纠偏 pass;`Start()` 门放宽为 `Enabled && Interval>0`,使文档化的 `DM_THREAD_AUTO_ARCHIVE_DAYS=0` 模式仍起 ticker(回应 review),`RunOnce` 保留 `Threshold<=0` 短路。
- **测试**:新增 DB-backed 集成测试 `TestArchiveStaleBatch_PendingMentionExclusion`,seed `thread`+`reminders`+`reminder_done`,断言 (a) 陈旧+未处理@ → 保持 Active(可捕获上一轮 P0),(b) 已处理@ → 归档,(c) @所有人 → 归档,(d) 软删 reminder → 归档,(e) 无@ → 归档。worker 单测按新签名更新,新增 Threshold=0 仍 tick 用例。

## 数据库压力

- 稳态:归档谓词的 NOT EXISTS 只作用于「陈旧 active」小集合(由 `idx_status_last_msg_id` range scan 界定),配合 reminders 新索引为点查;**不再有**对「全部已归档子区」的反向全表扫描。
- 一次性成本:backfill 在部署时执行一次,存量集合有限;若某部署存量异常大,可灰度 EXPLAIN 后运维侧手动分批(migration 注释已说明)。

## 测试
`go test ./modules/thread/ ./modules/message/`(全绿,串行 `-p 1`),`go vet`、`gofmt` 干净。无破坏性 schema 变更(两条 migration:一加索引可回滚,一为幂等 backfill)。
