### PR TITLE
fix(messages_search): global search empty-keyword browse (bug 3) + group filter includes sub-threads (bug 4) + member_uids multi-select AND semantics (bug 5)

### DIFF
--- a/modules/messages_search/search_global.go
+++ b/modules/messages_search/search_global.go
@@ -385,6 +385,11 @@ func (h *Handler) resolveGlobalScope(c *wkhttp.Context, loginUID string, channel
 	scope := allowSet
 	if len(channelIDs) > 0 {
 		requested := make(map[string]channelRef, len(channelIDs))
+		// requestedGroups collects the OS channelId (== group_no) of every
+		// channel_ids entry that named a group (channelType=2). A selected
+		// group implicitly covers its sub-threads (bug 4), so we fold those in
+		// below before intersecting with the allowlist.
+		requestedGroups := make(map[string]struct{})
 		for _, ref := range channelIDs {
 			id := strings.TrimSpace(ref.ChannelID)
 			if id == "" {
@@ -400,6 +405,34 @@ func (h *Handler) resolveGlobalScope(c *wkhttp.Context, loginUID string, channel
 				wireID = id
 			}
 			requested[osID] = channelRef{OSChannelID: osID, WireID: wireID, ChannelType: ref.ChannelType}
+			if ref.ChannelType == channelTypeGroup {
+				requestedGroups[osID] = struct{}{}
+			}
+		}
+		// Bug 4: selecting a group must search the group body AND all of its
+		// sub-threads, mirroring what the frontend's "所在群聊或子区" filter
+		// implies. Thread channelIds live in allowSet keyed as the composite
+		// `{group_no}____{short_id}` (channelType=5); fold every allowlisted
+		// thread whose parent group was requested into the requested set so the
+		// terms(channelId) clause spans group + threads. Sourcing them from
+		// allowSet (rather than a fresh enumerateThreadsForGroups call) means we
+		// inherit the membership gate + the per-group / aggregate thread caps
+		// buildAllowlist already applied, with no extra DB round-trip. A thread
+		// selected directly (channelType=5) is unaffected: it is not a group, so
+		// it never seeds requestedGroups and stays scoped to itself alone.
+		if len(requestedGroups) > 0 {
+			for osID, ref := range allowSet {
+				if ref.ChannelType != channelTypeThread {
+					continue
+				}
+				groupNo, _, err := thread.ParseChannelID(osID)
+				if err != nil {
+					continue
+				}
+				if _, ok := requestedGroups[groupNo]; ok {
+					requested[osID] = ref
+				}
+			}
 		}
 		// Allowlist ∩ requested — anything the caller cannot read is silently
 		// dropped (per §6.3, an unreachable channel_id is NOT a rejection).

--- a/modules/messages_search/search_global.go
+++ b/modules/messages_search/search_global.go
@@ -236,6 +236,19 @@ func validateGlobalBaseSharedFields(c *wkhttp.Context, filters GlobalSearchFilte
 		})
 		return 0, false
 	}
+	// DoS floor: cap wire-side member_uids before resolveGlobalScope fans out
+	// one GetGroupsWithMemberUID per uid. Left uncapped, a caller supplying
+	// N=1000 uids triggered N serial DB queries (and, worse, before the
+	// per-request search Timeout was even wired in). 50 matches maxSenderIDs
+	// as the "obviously reasonable" ceiling for a picker-driven list.
+	if len(filters.MemberUIDs) > maxMemberUIDs {
+		respondValidationDetails(c, i18n.Details{
+			"field":      "filters.member_uids",
+			"reason":     "too many",
+			"max_length": maxMemberUIDs,
+		})
+		return 0, false
+	}
 	if !validateSentAtWindow(c, filters.SentAtFrom, filters.SentAtTo) {
 		return 0, false
 	}
@@ -422,7 +435,7 @@ func normalizeMemberUIDs(loginUID string, uids []string, single string) []string
 // Empty channelIDs with ok=true means the caller has no readable rooms in
 // this Space OR the channel_ids/member_uid intersection is empty — the
 // handler should return an empty envelope without touching OS.
-func (h *Handler) resolveGlobalScope(c *wkhttp.Context, loginUID string, channelIDs []GlobalChannelRef, memberUIDs []string) (osChannelIDs []string, spaceID string, singleFast *channelRef, timings allowlistTimings, ok bool) {
+func (h *Handler) resolveGlobalScope(c *wkhttp.Context, loginUID string, channelIDs []GlobalChannelRef, rawMemberUIDs []string, legacyMemberUID string) (osChannelIDs []string, spaceID string, singleFast *channelRef, timings allowlistTimings, ok bool) {
 	spaceID = strings.TrimSpace(spacepkg.GetSpaceID(c))
 	if spaceID == "" {
 		// DM double-guard is space-dependent; without a Space the guard cannot
@@ -520,7 +533,7 @@ func (h *Handler) resolveGlobalScope(c *wkhttp.Context, loginUID string, channel
 		scope = intersect
 	}
 
-	memberUIDs = normalizeMemberUIDs(loginUID, memberUIDs, "")
+	memberUIDs := normalizeMemberUIDs(loginUID, rawMemberUIDs, legacyMemberUID)
 	if len(memberUIDs) > 0 {
 		memberScope, mErr := h.channelsForMembers(loginUID, memberUIDs, spaceID, allowSet)
 		if mErr != nil {

--- a/modules/messages_search/search_global.go
+++ b/modules/messages_search/search_global.go
@@ -33,8 +33,15 @@ type GlobalChannelRef struct {
 // ignores content_types entirely; file_exts / file_size_min / file_size_max
 // live in SearchGlobalFilesFilters instead.
 type GlobalSearchFilters struct {
-	SenderIDs    []string           `json:"sender_ids,omitempty"`
+	SenderIDs []string `json:"sender_ids,omitempty"`
+	// MemberUID is the legacy single-select "包含成员" field. Superseded by
+	// MemberUIDs (multi-select, bug 5) but kept on the wire for backwards
+	// compatibility with older clients and to survive a rolling deploy window
+	// where a stale frontend can still coexist with a fresh backend. When both
+	// fields arrive, MemberUIDs wins; if only MemberUID is set the handler
+	// folds it into the plural path via normalizeMemberUIDs.
 	MemberUID    string             `json:"member_uid,omitempty"`
+	MemberUIDs   []string           `json:"member_uids,omitempty"`
 	ChannelIDs   []GlobalChannelRef `json:"channel_ids,omitempty"`
 	ChannelTypes []uint8            `json:"channel_types,omitempty"`
 	ContentTypes []int              `json:"content_types,omitempty"`
@@ -45,8 +52,11 @@ type GlobalSearchFilters struct {
 // GlobalFileFilters is the file-endpoint-only filter block: the shared base
 // (via GlobalSearchFilters) plus file_exts / file_size_min / file_size_max.
 type GlobalFileFilters struct {
-	SenderIDs    []string           `json:"sender_ids,omitempty"`
+	SenderIDs []string `json:"sender_ids,omitempty"`
+	// MemberUID / MemberUIDs: see GlobalSearchFilters. Same wire contract on
+	// the file endpoint.
 	MemberUID    string             `json:"member_uid,omitempty"`
+	MemberUIDs   []string           `json:"member_uids,omitempty"`
 	ChannelIDs   []GlobalChannelRef `json:"channel_ids,omitempty"`
 	ChannelTypes []uint8            `json:"channel_types,omitempty"`
 	FileExts     []string           `json:"file_exts,omitempty"`
@@ -150,6 +160,16 @@ func validateGlobalBase(c *wkhttp.Context, cfg SearchConfig, sort, cursor string
 		respondValidation(c, "filters.member_uid", "must be a non-empty uid")
 		return 0, false
 	}
+	for i, uid := range filters.MemberUIDs {
+		if strings.TrimSpace(uid) == "" {
+			respondValidationDetails(c, i18n.Details{
+				"field":  "filters.member_uids",
+				"reason": "empty uid",
+				"index":  i,
+			})
+			return 0, false
+		}
+	}
 	return validateSortCursorPage(c, cfg, sort, cursor, pageSize, allowRelevance)
 }
 
@@ -161,6 +181,7 @@ func validateGlobalFileBase(c *wkhttp.Context, cfg SearchConfig, sort, cursor st
 	shared := GlobalSearchFilters{
 		SenderIDs:    filters.SenderIDs,
 		MemberUID:    filters.MemberUID,
+		MemberUIDs:   filters.MemberUIDs,
 		ChannelIDs:   filters.ChannelIDs,
 		ChannelTypes: filters.ChannelTypes,
 		SentAtFrom:   filters.SentAtFrom,
@@ -168,6 +189,16 @@ func validateGlobalFileBase(c *wkhttp.Context, cfg SearchConfig, sort, cursor st
 	}
 	if _, ok := validateGlobalBaseSharedFields(c, shared); !ok {
 		return 0, false
+	}
+	for i, uid := range filters.MemberUIDs {
+		if strings.TrimSpace(uid) == "" {
+			respondValidationDetails(c, i18n.Details{
+				"field":  "filters.member_uids",
+				"reason": "empty uid",
+				"index":  i,
+			})
+			return 0, false
+		}
 	}
 	for i, ext := range filters.FileExts {
 		norm := strings.ToLower(strings.TrimSpace(ext))
@@ -331,6 +362,50 @@ func applyGlobalDMSpaceScope(b *elastic.BoolQuery, spaceID string) {
 	b.Filter(scope)
 }
 
+// normalizeMemberUIDs collapses the two wire fields (`member_uids` plural,
+// `member_uid` legacy singular) into the canonical dedup + self-exclude form
+// that resolveGlobalScope consumes. Precedence: plural wins whenever it has any
+// entry; otherwise the singular is folded into a single-element slice. Empty
+// strings, whitespace-only entries, and the caller's own uid are dropped
+// (matches the frontend `filter(uid !== selfUid)` convention so a caller that
+// checkboxes themselves gets the same result set as one that did not). A nil
+// return means "no member filter".
+//
+// Both fields are accepted at once (§bug 5): during the rolling deploy an
+// older frontend still ships `member_uid` while a newer one ships
+// `member_uids`; a mixed request from a mid-refresh browser tab is possible
+// and must not double-apply.
+func normalizeMemberUIDs(loginUID string, uids []string, single string) []string {
+	loginUID = strings.TrimSpace(loginUID)
+	raw := uids
+	if len(raw) == 0 && strings.TrimSpace(single) != "" {
+		raw = []string{single}
+	}
+	if len(raw) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(raw))
+	out := make([]string, 0, len(raw))
+	for _, u := range raw {
+		u = strings.TrimSpace(u)
+		if u == "" {
+			continue
+		}
+		if u == loginUID {
+			continue
+		}
+		if _, dup := seen[u]; dup {
+			continue
+		}
+		seen[u] = struct{}{}
+		out = append(out, u)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 // resolveGlobalScope resolves the caller's per-request channel scope: the
 // intersection of their allowlist (all rooms they can currently read within
 // the requested Space) with the request's optional channel_ids / member_uid
@@ -347,7 +422,7 @@ func applyGlobalDMSpaceScope(b *elastic.BoolQuery, spaceID string) {
 // Empty channelIDs with ok=true means the caller has no readable rooms in
 // this Space OR the channel_ids/member_uid intersection is empty — the
 // handler should return an empty envelope without touching OS.
-func (h *Handler) resolveGlobalScope(c *wkhttp.Context, loginUID string, channelIDs []GlobalChannelRef, memberUID string) (osChannelIDs []string, spaceID string, singleFast *channelRef, timings allowlistTimings, ok bool) {
+func (h *Handler) resolveGlobalScope(c *wkhttp.Context, loginUID string, channelIDs []GlobalChannelRef, memberUIDs []string) (osChannelIDs []string, spaceID string, singleFast *channelRef, timings allowlistTimings, ok bool) {
 	spaceID = strings.TrimSpace(spacepkg.GetSpaceID(c))
 	if spaceID == "" {
 		// DM double-guard is space-dependent; without a Space the guard cannot
@@ -445,9 +520,9 @@ func (h *Handler) resolveGlobalScope(c *wkhttp.Context, loginUID string, channel
 		scope = intersect
 	}
 
-	memberUID = strings.TrimSpace(memberUID)
-	if memberUID != "" && memberUID != loginUID {
-		memberScope, mErr := h.channelsForMember(loginUID, memberUID, spaceID, allowSet)
+	memberUIDs = normalizeMemberUIDs(loginUID, memberUIDs, "")
+	if len(memberUIDs) > 0 {
+		memberScope, mErr := h.channelsForMembers(loginUID, memberUIDs, spaceID, allowSet)
 		if mErr != nil {
 			h.Error("messages_search: member-scope resolution failed", zap.Error(mErr))
 			respondInternal(c)
@@ -519,16 +594,11 @@ func (h *Handler) resolveGlobalScope(c *wkhttp.Context, loginUID string, channel
 //     surfaced. Aligning global search with the rest of the system was RC
 //     blocker on PR #553.
 //
-// Known v1 gap: channelsForMember (the member_uid "包含成员" filter) still
-// scopes to group + DM only; it explicitly DROPS every thread entry from
-// the allowlist when member_uid is set (see channelsForMember below,
-// `case channelTypeThread:` is a no-op). A caller filtering by member_uid
-// therefore sees zero thread hits, regardless of whether the named member
-// posted in any thread. This is fail-closed (more-restrictive than a
-// hypothetical thread_member intersection), safe on the security axis,
-// but it is a real UX gap the API contract should surface. Tightening
-// this requires a `thread_member` join and is deferred to v1.1; the
-// tradeoff is documented on channelsForMember.
+// Member filter (bug 5, updated): channelsForMembers now folds every thread
+// under a surviving shared group into the returned scope (統一 rule: 群 → 群 +
+// 其子区). The earlier v1 "thread_member unavailable, so drop all threads"
+// behaviour is superseded — threads inherit their parent group's membership
+// gate, so no `thread_member` join is required to be correct.
 func (h *Handler) buildAllowlist(_ *wkhttp.Context, loginUID, spaceID string) ([]channelRef, []channelRef, []channelRef, allowlistTimings, error) {
 	var timings allowlistTimings
 	groups, err := h.groupService.GetGroupsWithMemberUID(loginUID)
@@ -963,59 +1033,91 @@ func (h *Handler) queryDMSpaceMemberUIDs(spaceID, loginUID string) ([]string, er
 	return out, nil
 }
 
-// channelsForMember resolves the "包含成员" (member_uid) filter into the set of
-// OS channelIds where BOTH the caller and the named member are reachable
-// together: the caller's allowlist ∩ (groups memberUID is in ∪ DM with
-// memberUID). Returned map keys are the OS channelId; values mirror the
-// allowSet entry so the caller can preserve wire-id / channelType.
+// channelsForMembers resolves the "包含成员" (member_uids) filter into the set
+// of OS channelIds where the caller AND every named member can co-inhabit:
 //
-// v1 thread scope (YUJ-10): this helper filters ONLY group + DM entries by
-// memberUID's own membership. Thread entries in allowSet are dropped from the
-// returned scope entirely — v1 does NOT resolve `thread_member` for the named
-// member (would require an extra IN join and a schema pass). A caller that
-// sets member_uid therefore sees group + DM hits that co-inhabit memberUID,
-// but NO thread hits at all. This is a deliberate v1 simplification: the
-// primary YUJ-10 requirement is "thread hits appear in the global feed";
-// scoping them by an arbitrary member is a v1.1 follow-up (see the design
-// doc §6.2 known-limitations note).
-func (h *Handler) channelsForMember(loginUID, memberUID, spaceID string, allowSet map[string]channelRef) (map[string]channelRef, error) {
+//   - Groups (channelType=2): intersect across members — a group survives only
+//     when every named member is in it. The統一 rule from the design doc means
+//     each surviving group also folds in its sub-threads from allowSet
+//     (channelType=5, composite `{group_no}____{short_id}`); threads inherit
+//     their parent group's membership, so no per-thread membership query is
+//     needed. This flips the v1 behaviour (which explicitly dropped threads
+//     from the member filter) so a caller filtering by member now sees thread
+//     hits under groups the member is in.
+//   - DM (channelType=1): only meaningful with exactly one named member and
+//     only when the caller has a DM entry for that member. Multi-member DMs
+//     do not exist on this product, so len(memberUIDs) > 1 drops the DM
+//     branch entirely — matching the "AND across members" semantics.
+//
+// self-uid was already stripped by normalizeMemberUIDs so the loop can assume
+// every entry is a real other-party candidate. Returned map is keyed by OS
+// channelId; values mirror the allowSet entry so wire-id / channelType round-
+// trip unchanged.
+func (h *Handler) channelsForMembers(loginUID string, memberUIDs []string, spaceID string, allowSet map[string]channelRef) (map[string]channelRef, error) {
 	out := make(map[string]channelRef)
-	memberGroups, err := h.groupService.GetGroupsWithMemberUID(memberUID)
-	if err != nil {
-		return nil, err
+	if len(memberUIDs) == 0 {
+		return out, nil
 	}
-	memberSet := make(map[string]struct{}, len(memberGroups))
-	for _, g := range memberGroups {
-		if g == nil {
+	// Step 1 — intersect group memberships across every named member.
+	// groupIntersect holds the group_nos where every named member is in.
+	// Seeded from the first member so subsequent members can prune only.
+	var groupIntersect map[string]struct{}
+	for i, member := range memberUIDs {
+		memberGroups, err := h.groupService.GetGroupsWithMemberUID(member)
+		if err != nil {
+			return nil, err
+		}
+		memberSet := make(map[string]struct{}, len(memberGroups))
+		for _, g := range memberGroups {
+			if g == nil {
+				continue
+			}
+			memberSet[g.GroupNo] = struct{}{}
+		}
+		if i == 0 {
+			groupIntersect = memberSet
 			continue
 		}
-		memberSet[g.GroupNo] = struct{}{}
+		for gn := range groupIntersect {
+			if _, ok := memberSet[gn]; !ok {
+				delete(groupIntersect, gn)
+			}
+		}
+		if len(groupIntersect) == 0 {
+			break
+		}
+	}
+	// Step 2 — walk allowSet once, keeping:
+	//   - group entries whose group_no is in groupIntersect;
+	//   - thread entries under those same groups (統一 rule: 群 → 群 + 其子区);
+	//   - the DM entry for the sole named member (single-member case only).
+	singleMember := ""
+	if len(memberUIDs) == 1 {
+		singleMember = memberUIDs[0]
 	}
 	for id, ref := range allowSet {
 		switch ref.ChannelType {
 		case channelTypeGroup:
-			if _, ok := memberSet[ref.OSChannelID]; ok {
-				out[id] = ref
-			}
-		case channelTypePerson:
-			if ref.WireID == memberUID {
-				// The DM with memberUID is trivially the "shared channel"
-				// between caller and member.
+			if _, ok := groupIntersect[ref.OSChannelID]; ok {
 				out[id] = ref
 			}
 		case channelTypeThread:
-			// Intentionally dropped for v1 — see helper doc-comment above.
-			// Explicit case so a future maintainer adding a default: arm
-			// sees the drop is intentional and not a forgotten branch.
+			groupNo, _, err := thread.ParseChannelID(ref.OSChannelID)
+			if err != nil {
+				continue
+			}
+			if _, ok := groupIntersect[groupNo]; ok {
+				out[id] = ref
+			}
+		case channelTypePerson:
+			if singleMember != "" && ref.WireID == singleMember {
+				out[id] = ref
+			}
 		}
 	}
 	// spaceID is unused: the caller has already narrowed allowSet to the
 	// current Space in resolveGlobalScope (via buildAllowlist), so the ∩
-	// against allowSet here inherits the Space filter transitively. The
-	// parameter is kept on the signature both for symmetry with the other
-	// scope helpers and so a future cross-Space feature (e.g. surfacing DMs
-	// from Spaces the member belongs to but the caller does not) has an
-	// obvious pivot without changing the call site.
+	// against allowSet here inherits the Space filter transitively.
 	_ = spaceID
 	return out, nil
 }

--- a/modules/messages_search/search_global_files.go
+++ b/modules/messages_search/search_global_files.go
@@ -55,7 +55,7 @@ func (h *Handler) searchGlobalFiles(c *wkhttp.Context) {
 		return
 	}
 
-	osChannelIDs, spaceID, singleFast, allowTimings, ok := h.resolveGlobalScope(c, loginUID, req.Filters.ChannelIDs, normalizeMemberUIDs(loginUID, req.Filters.MemberUIDs, req.Filters.MemberUID))
+	osChannelIDs, spaceID, singleFast, allowTimings, ok := h.resolveGlobalScope(c, loginUID, req.Filters.ChannelIDs, req.Filters.MemberUIDs, req.Filters.MemberUID)
 	if !ok {
 		return
 	}

--- a/modules/messages_search/search_global_files.go
+++ b/modules/messages_search/search_global_files.go
@@ -55,7 +55,7 @@ func (h *Handler) searchGlobalFiles(c *wkhttp.Context) {
 		return
 	}
 
-	osChannelIDs, spaceID, singleFast, allowTimings, ok := h.resolveGlobalScope(c, loginUID, req.Filters.ChannelIDs, req.Filters.MemberUID)
+	osChannelIDs, spaceID, singleFast, allowTimings, ok := h.resolveGlobalScope(c, loginUID, req.Filters.ChannelIDs, normalizeMemberUIDs(loginUID, req.Filters.MemberUIDs, req.Filters.MemberUID))
 	if !ok {
 		return
 	}

--- a/modules/messages_search/search_global_messages.go
+++ b/modules/messages_search/search_global_messages.go
@@ -66,7 +66,7 @@ func (h *Handler) searchGlobalMessages(c *wkhttp.Context) {
 		return
 	}
 
-	osChannelIDs, spaceID, singleFast, allowTimings, ok := h.resolveGlobalScope(c, loginUID, req.Filters.ChannelIDs, normalizeMemberUIDs(loginUID, req.Filters.MemberUIDs, req.Filters.MemberUID))
+	osChannelIDs, spaceID, singleFast, allowTimings, ok := h.resolveGlobalScope(c, loginUID, req.Filters.ChannelIDs, req.Filters.MemberUIDs, req.Filters.MemberUID)
 	if !ok {
 		return
 	}

--- a/modules/messages_search/search_global_messages.go
+++ b/modules/messages_search/search_global_messages.go
@@ -51,9 +51,16 @@ func (h *Handler) searchGlobalMessages(c *wkhttp.Context) {
 	if !validateKeywordOptional(c, req.Keyword) {
 		return
 	}
-	if !validateSearchNotEmptyGlobal(c, req.Keyword, req.Filters) {
-		return
-	}
+	// NOTE (bug 3 / empty-keyword browse): unlike the single-channel endpoints
+	// there is deliberately NO validateSearchNotEmpty guard here. An empty
+	// keyword with no filters is a valid *browse* request that lists recent
+	// messages across every room the caller can read — the terms(channelId,
+	// allowlist) clause built by buildGlobalMessagesDSL bounds the scan exactly
+	// the way a single channel's channelId bounds _search_all, so there is no
+	// unbounded full-index scan to guard against. The browse-mode DSL semantics
+	// (media types 2/5 layered in, sort defaults to time_desc, relevance
+	// rejected via allowRelevance=false, cursor pagination) then match the
+	// single-channel empty-keyword path exactly.
 	pageSize, ok := validateGlobalBase(c, h.cfg, req.Sort, req.Cursor, req.Filters, req.PageSize, req.Keyword != "")
 	if !ok {
 		return
@@ -437,31 +444,4 @@ func (h *Handler) searchAllForGlobalFastPath(c *wkhttp.Context, req SearchAllReq
 	items := h.buildSearchAllHits(ctx, filtered, req, loginUID)
 	recordAudit(c, "search_global_messages_fast", req.ChannelType, req.ChannelID, req.Keyword, len(items))
 	c.Response(envelope(items, hasMore, nextCursor))
-}
-
-// validateSearchNotEmptyGlobal is the empty-search guard for the global
-// message endpoint. Mirrors validateSearchNotEmpty but consults the global
-// filter shape (which additionally recognises channel_ids / channel_types /
-// content_types / member_uid as "effective" filters).
-func validateSearchNotEmptyGlobal(c *wkhttp.Context, keyword string, filters GlobalSearchFilters) bool {
-	if keyword != "" {
-		return true
-	}
-	if hasEffectiveFilters(filters.baseFilters()) {
-		return true
-	}
-	if len(filters.ChannelIDs) > 0 {
-		return true
-	}
-	if len(filters.ChannelTypes) > 0 {
-		return true
-	}
-	if len(filters.ContentTypes) > 0 {
-		return true
-	}
-	if strings.TrimSpace(filters.MemberUID) != "" {
-		return true
-	}
-	respondValidation(c, "keyword", "keyword or at least one filter is required")
-	return false
 }

--- a/modules/messages_search/search_global_messages.go
+++ b/modules/messages_search/search_global_messages.go
@@ -72,7 +72,14 @@ func (h *Handler) searchGlobalMessages(c *wkhttp.Context) {
 	}
 	recordAllowlistTimings(c, allowTimings)
 	if singleFast != nil {
-		h.dispatchSingleAll(c, req, *singleFast, loginUID)
+		// Global endpoint semantics allow the empty-keyword + no-filter browse
+		// (see NOTE above); the terms(channelId) bound collapses to a single
+		// channel here so the fast path inherits the same bounded-scan guarantee
+		// as the multi-room path. Pass allowEmptyBrowse=true so the reused
+		// single-channel body skips validateSearchNotEmpty (bug 3 fast-path
+		// parity — the multi-room browse was allowed but the single-room fast
+		// path still rejected with 400).
+		h.dispatchSingleAll(c, req, *singleFast, loginUID, true)
 		return
 	}
 	if len(osChannelIDs) == 0 {
@@ -330,7 +337,7 @@ func (h *Handler) buildGlobalSearchAllHits(ctx context.Context, hits []*elastic.
 // tradeoff because a caller whose scope is one channel wanting to further
 // narrow by content_types would today also see the same result set (the
 // hard whitelist is what matters, and the fast path applies it).
-func (h *Handler) dispatchSingleAll(c *wkhttp.Context, req SearchGlobalMessagesReq, target channelRef, loginUID string) {
+func (h *Handler) dispatchSingleAll(c *wkhttp.Context, req SearchGlobalMessagesReq, target channelRef, loginUID string, allowEmptyBrowse bool) {
 	inner := SearchAllReq{
 		ChannelType: target.ChannelType,
 		ChannelID:   target.WireID,
@@ -354,17 +361,23 @@ func (h *Handler) dispatchSingleAll(c *wkhttp.Context, req SearchGlobalMessagesR
 	// consumed body — the single-channel handlers rebind. Simpler: call the
 	// core logic directly by re-running the search_all body with the
 	// synthesised inner req.
-	h.searchAllForGlobalFastPath(c, inner, loginUID)
+	h.searchAllForGlobalFastPath(c, inner, loginUID, allowEmptyBrowse)
 }
 
 // searchAllForGlobalFastPath is a body-less variant of h.searchAll that
 // accepts a pre-parsed SearchAllReq. Kept private and marked as
 // fast-path-only so the wire contract stays owned by h.searchAll.
-func (h *Handler) searchAllForGlobalFastPath(c *wkhttp.Context, req SearchAllReq, loginUID string) {
+//
+// allowEmptyBrowse toggles the single-channel validateSearchNotEmpty guard:
+// the global-messages endpoint deliberately admits empty-keyword + no-filter
+// browse (bounded by terms(channelId, allowlist)), so when that request
+// collapses to one room via the fast path it must inherit the same
+// permissiveness rather than snap back to the strict single-channel rule.
+func (h *Handler) searchAllForGlobalFastPath(c *wkhttp.Context, req SearchAllReq, loginUID string, allowEmptyBrowse bool) {
 	if !validateKeywordOptional(c, req.Keyword) {
 		return
 	}
-	if !validateSearchNotEmpty(c, req.Keyword, req.Filters) {
+	if !allowEmptyBrowse && !validateSearchNotEmpty(c, req.Keyword, req.Filters) {
 		return
 	}
 	pageSize, ok := validateBase(c, h.cfg, req.ChannelType, req.ChannelID, req.Sort, req.Cursor, req.Filters, req.PageSize, req.Keyword != "")

--- a/modules/messages_search/search_global_messages.go
+++ b/modules/messages_search/search_global_messages.go
@@ -66,7 +66,7 @@ func (h *Handler) searchGlobalMessages(c *wkhttp.Context) {
 		return
 	}
 
-	osChannelIDs, spaceID, singleFast, allowTimings, ok := h.resolveGlobalScope(c, loginUID, req.Filters.ChannelIDs, req.Filters.MemberUID)
+	osChannelIDs, spaceID, singleFast, allowTimings, ok := h.resolveGlobalScope(c, loginUID, req.Filters.ChannelIDs, normalizeMemberUIDs(loginUID, req.Filters.MemberUIDs, req.Filters.MemberUID))
 	if !ok {
 		return
 	}

--- a/modules/messages_search/search_global_test.go
+++ b/modules/messages_search/search_global_test.go
@@ -874,7 +874,7 @@ func TestResolveGlobalScope_MemberUIDs_ANDSemantics(t *testing.T) {
 	h.threadEnumFn = func([]string) (map[string][]string, error) { return nil, nil }
 
 	c, _ := newValidatorCtx(t)
-	osIDs, _, _, _, ok := h.resolveGlobalScope(c, loginUID, nil, []string{memberX, memberY})
+	osIDs, _, _, _, ok := h.resolveGlobalScope(c, loginUID, nil, []string{memberX, memberY}, "")
 	if !ok {
 		t.Fatalf("resolveGlobalScope must succeed")
 	}
@@ -902,7 +902,7 @@ func TestResolveGlobalScope_MemberUIDs_ThreadsIncluded(t *testing.T) {
 	}
 
 	c, _ := newValidatorCtx(t)
-	osIDs, _, _, _, ok := h.resolveGlobalScope(c, loginUID, nil, []string{memberX})
+	osIDs, _, _, _, ok := h.resolveGlobalScope(c, loginUID, nil, []string{memberX}, "")
 	if !ok {
 		t.Fatalf("resolveGlobalScope must succeed")
 	}
@@ -940,7 +940,7 @@ func TestResolveGlobalScope_MemberUIDs_DMSingleMember(t *testing.T) {
 	h.threadEnumFn = func([]string) (map[string][]string, error) { return nil, nil }
 
 	c, _ := newValidatorCtx(t)
-	osIDs, _, singleFast, _, ok := h.resolveGlobalScope(c, loginUID, nil, []string{peer})
+	osIDs, _, singleFast, _, ok := h.resolveGlobalScope(c, loginUID, nil, []string{peer}, "")
 	if !ok {
 		t.Fatalf("resolveGlobalScope must succeed")
 	}
@@ -976,7 +976,7 @@ func TestResolveGlobalScope_MemberUIDs_DMMultiMemberDropped(t *testing.T) {
 	h.threadEnumFn = func([]string) (map[string][]string, error) { return nil, nil }
 
 	c, _ := newValidatorCtx(t)
-	osIDs, _, _, _, ok := h.resolveGlobalScope(c, loginUID, nil, []string{memberX, memberY})
+	osIDs, _, _, _, ok := h.resolveGlobalScope(c, loginUID, nil, []string{memberX, memberY}, "")
 	if !ok {
 		t.Fatalf("resolveGlobalScope must succeed")
 	}
@@ -1007,7 +1007,9 @@ func TestSearchGlobalMessagesRequest_MemberUIDSingleFallback(t *testing.T) {
 	if len(normalized) != 1 || normalized[0] != member {
 		t.Fatalf("legacy member_uid must fold into member_uids=[member]; got %v", normalized)
 	}
-	osIDs, _, _, _, ok := h.resolveGlobalScope(c, loginUID, nil, normalized)
+	// Pass the legacy wire fields (nil plural, singular set) so the internal
+	// normalize inside resolveGlobalScope exercises the fallback path.
+	osIDs, _, _, _, ok := h.resolveGlobalScope(c, loginUID, nil, nil, member)
 	if !ok {
 		t.Fatalf("resolveGlobalScope must succeed on legacy fallback")
 	}
@@ -1048,7 +1050,7 @@ func TestSearchGlobalMessagesRequest_MemberUIDsSelfDropped(t *testing.T) {
 	h.threadEnumFn = func([]string) (map[string][]string, error) { return nil, nil }
 	c, _ := newValidatorCtx(t)
 	osIDs, _, _, _, ok := h.resolveGlobalScope(c, loginUID, nil,
-		normalizeMemberUIDs(loginUID, []string{loginUID, member}, ""))
+		[]string{loginUID, member}, "")
 	if !ok {
 		t.Fatalf("resolveGlobalScope must succeed")
 	}
@@ -1062,4 +1064,79 @@ func TestSearchGlobalMessagesRequest_MemberUIDsSelfDropped(t *testing.T) {
 // pattern used by search_global_thread_test.go).
 func threadIDForTest(groupNo, shortID string) string {
 	return thread.BuildChannelID(groupNo, shortID)
+}
+
+// bug 5 P1 hardening · member_uids cap. Left uncapped, every uid in
+// filters.member_uids triggered its own GetGroupsWithMemberUID call inside
+// resolveGlobalScope (no batch, serial DB round-trips), so a request with
+// N=1000 uids collapsed into 1000 DB queries before the per-request search
+// Timeout even got a chance to fire. maxMemberUIDs=50 mirrors maxSenderIDs's
+// existing wire-side floor and is enforced in the shared validator path used
+// by both global endpoints.
+
+// TestSearchGlobalMessagesRequest_MemberUIDsAtCapAccepted — exactly 50 uids
+// clears the cap (upper boundary, must NOT reject).
+func TestSearchGlobalMessagesRequest_MemberUIDsAtCapAccepted(t *testing.T) {
+	uids := make([]string, maxMemberUIDs)
+	for i := range uids {
+		uids[i] = "u" + itoa(i)
+	}
+	c, rec := newValidateCtx(t)
+	_, ok := validateGlobalBase(c, SearchConfig{}, "", "",
+		GlobalSearchFilters{MemberUIDs: uids}, 0, false)
+	if !ok {
+		t.Fatalf("member_uids at cap (%d) must be accepted; body=%s", maxMemberUIDs, rec.Body.String())
+	}
+}
+
+// TestSearchGlobalMessagesRequest_MemberUIDsExceedsCap — 51 uids trips the
+// cap and rejects with a VALIDATION_ERROR (400).
+func TestSearchGlobalMessagesRequest_MemberUIDsExceedsCap(t *testing.T) {
+	uids := make([]string, maxMemberUIDs+1)
+	for i := range uids {
+		uids[i] = "u" + itoa(i)
+	}
+	c, rec := newValidateCtx(t)
+	_, ok := validateGlobalBase(c, SearchConfig{}, "", "",
+		GlobalSearchFilters{MemberUIDs: uids}, 0, false)
+	if ok {
+		t.Fatalf("member_uids over cap (%d > %d) must be rejected", len(uids), maxMemberUIDs)
+	}
+	if rec.Body.Len() == 0 {
+		t.Fatalf("rejected member_uids must render a VALIDATION_ERROR envelope")
+	}
+}
+
+// TestSearchGlobalFilesRequest_MemberUIDsAtCapAccepted — same upper-boundary
+// check on the file endpoint validator; both paths go through
+// validateGlobalBaseSharedFields so they must agree on the cap.
+func TestSearchGlobalFilesRequest_MemberUIDsAtCapAccepted(t *testing.T) {
+	uids := make([]string, maxMemberUIDs)
+	for i := range uids {
+		uids[i] = "u" + itoa(i)
+	}
+	c, rec := newValidateCtx(t)
+	_, ok := validateGlobalFileBase(c, SearchConfig{}, "", "",
+		GlobalFileFilters{MemberUIDs: uids}, 0, false)
+	if !ok {
+		t.Fatalf("file endpoint member_uids at cap (%d) must be accepted; body=%s", maxMemberUIDs, rec.Body.String())
+	}
+}
+
+// TestSearchGlobalFilesRequest_MemberUIDsExceedsCap — file endpoint rejects
+// beyond the cap.
+func TestSearchGlobalFilesRequest_MemberUIDsExceedsCap(t *testing.T) {
+	uids := make([]string, maxMemberUIDs+1)
+	for i := range uids {
+		uids[i] = "u" + itoa(i)
+	}
+	c, rec := newValidateCtx(t)
+	_, ok := validateGlobalFileBase(c, SearchConfig{}, "", "",
+		GlobalFileFilters{MemberUIDs: uids}, 0, false)
+	if ok {
+		t.Fatalf("file endpoint member_uids over cap (%d > %d) must be rejected", len(uids), maxMemberUIDs)
+	}
+	if rec.Body.Len() == 0 {
+		t.Fatalf("rejected file endpoint member_uids must render a VALIDATION_ERROR envelope")
+	}
 }

--- a/modules/messages_search/search_global_test.go
+++ b/modules/messages_search/search_global_test.go
@@ -496,6 +496,129 @@ func TestSearchGlobalMessages_EmptyKeywordNoFilter_Browses(t *testing.T) {
 	}
 }
 
+// bug 3 · single-channel fast-path parity for empty-keyword browse.
+//
+// When the caller's readable scope collapses to exactly one room (single
+// joined group, no threads / no DMs), resolveGlobalScope returns
+// singleFast != nil and searchGlobalMessages dispatches through
+// dispatchSingleAll → searchAllForGlobalFastPath — the fast path was
+// silently re-applying the strict single-channel validateSearchNotEmpty
+// guard, so the multi-room browse fix (bug 3) never reached the collapsed
+// case and still returned 400.
+//
+// The load-bearing assertion is negative: the response MUST NOT be a
+// VALIDATION_ERROR complaining about "keyword or at least one filter is
+// required". The fast path may still terminate with an upstream/internal
+// error because no OpenSearch is wired in the test env — that is fine as
+// long as the request survived validation.
+func TestSearchGlobalMessages_SingleGroupFastPath_EmptyKeywordBrowses(t *testing.T) {
+	resetESClientForTest()
+	defer resetESClientForTest()
+	primeESClientForFastPathTests(t)
+
+	loginUID := "me"
+	// Exactly one joined group, no threads and no DM peers → scope collapses
+	// to a single channel → singleFast fires.
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			loginUID: {{GroupNo: "grpSolo"}},
+		},
+	}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	h.threadEnumFn = func([]string) (map[string][]string, error) { return nil, nil }
+
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest("POST", "/v1/messages/_search_global_messages",
+		strings.NewReader(`{"keyword":"","filters":{}}`))
+	gc.Set("uid", loginUID)
+	c := &wkhttp.Context{Context: gc}
+
+	h.searchGlobalMessages(c)
+
+	assertNotEmptySearchGuardRejection(t, rec)
+}
+
+// bug 3 · single-channel fast-path parity via channel_ids narrowing.
+//
+// Same load-bearing assertion as above, but reaches the fast path through a
+// different route: the caller is a member of several groups but the request
+// filters channel_ids down to one group that has no active threads → scope
+// intersect collapses to a single channelId → singleFast fires. This is the
+// realistic frontend shape (picker narrows scope) and is where reviewers
+// most often exercise the bug.
+func TestSearchGlobalMessages_ChannelIDsCollapseToOne_EmptyKeywordBrowses(t *testing.T) {
+	resetESClientForTest()
+	defer resetESClientForTest()
+	primeESClientForFastPathTests(t)
+
+	loginUID := "me"
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			loginUID: {
+				{GroupNo: "grpA"},
+				{GroupNo: "grpB"},
+				{GroupNo: "grpC"},
+			},
+		},
+	}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	// grpA is the picker target; the other two are ambient membership. None
+	// have threads so the picked group can't fan out.
+	h.threadEnumFn = func([]string) (map[string][]string, error) { return nil, nil }
+
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest("POST", "/v1/messages/_search_global_messages",
+		strings.NewReader(`{"keyword":"","filters":{"channel_ids":[{"channel_id":"grpA","channel_type":2}]}}`))
+	gc.Set("uid", loginUID)
+	c := &wkhttp.Context{Context: gc}
+
+	h.searchGlobalMessages(c)
+
+	assertNotEmptySearchGuardRejection(t, rec)
+}
+
+// assertNotEmptySearchGuardRejection fails the test if the response looks
+// like the validateSearchNotEmpty 400 (empty keyword + no filter guard). All
+// other outcomes — 200 browse, upstream/internal after validation — are
+// treated as pass because the load-bearing question is whether the singleFast
+// dispatch reached past the validators.
+func assertNotEmptySearchGuardRejection(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	body := rec.Body.String()
+	// The empty-search guard renders a VALIDATION_ERROR carrying
+	// details.reason="keyword or at least one filter is required" (see
+	// validate.go::validateSearchNotEmpty). Any body containing that reason
+	// means the fast path never got past the strict single-channel gate.
+	if strings.Contains(body, "keyword or at least one filter is required") {
+		t.Fatalf("singleFast branch must accept empty-keyword browse; got the empty-search 400: %s", body)
+	}
+}
+
+// primeESClientForFastPathTests injects a no-ping olivere client into the
+// package singleton so tests that drive the single-channel fast path skip the
+// ~5s startup healthcheck against 127.0.0.1:9200. The client's Search().Do()
+// still fails (no OS behind it) which surfaces as UPSTREAM/INTERNAL — the
+// only guarantee these tests need is that we got past validation.
+func primeESClientForFastPathTests(t *testing.T) {
+	t.Helper()
+	osMu.Lock()
+	defer osMu.Unlock()
+	if osClient != nil {
+		return
+	}
+	c, err := elastic.NewSimpleClient(elastic.SetURL("http://127.0.0.1:9"))
+	if err != nil {
+		t.Fatalf("prime SimpleClient: %v", err)
+	}
+	osClient = c
+}
+
 // newValidatorCtx is a lightweight wkhttp.Context builder for validator
 // tests that only care about the accept/reject bool.
 func newValidatorCtx(t *testing.T) (*wkhttp.Context, *httptest.ResponseRecorder) {

--- a/modules/messages_search/search_global_test.go
+++ b/modules/messages_search/search_global_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/gin-gonic/gin"
 	"github.com/olivere/elastic"
@@ -845,4 +846,220 @@ func TestEnumerateDMPeers_UnionsFriendsAndSpaceMembers(t *testing.T) {
 	if len(peersEmpty) != 1 || peersEmpty[0] != "bob" {
 		t.Fatalf("empty spaceID must yield friends-only; got %v", peersEmpty)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// bug 5 · member_uids multi-select — AND semantics, thread inclusion, DM
+// arity, wire-fallback + self-drop normalisation.
+// ---------------------------------------------------------------------------
+
+// TestResolveGlobalScope_MemberUIDs_ANDSemantics — a request with two named
+// members resolves scope = groups where BOTH members are in (∩), never the
+// union. Any group where only one of the two is a member drops out.
+func TestResolveGlobalScope_MemberUIDs_ANDSemantics(t *testing.T) {
+	loginUID := "me"
+	memberX := "x"
+	memberY := "y"
+	// Caller is in grpAB, grpA, grpB. X is in grpAB + grpA. Y is in grpAB +
+	// grpB. Only grpAB survives the AND.
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			loginUID: {{GroupNo: "grpAB"}, {GroupNo: "grpA"}, {GroupNo: "grpB"}},
+			memberX:  {{GroupNo: "grpAB"}, {GroupNo: "grpA"}},
+			memberY:  {{GroupNo: "grpAB"}, {GroupNo: "grpB"}},
+		},
+	}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	h.threadEnumFn = func([]string) (map[string][]string, error) { return nil, nil }
+
+	c, _ := newValidatorCtx(t)
+	osIDs, _, _, _, ok := h.resolveGlobalScope(c, loginUID, nil, []string{memberX, memberY})
+	if !ok {
+		t.Fatalf("resolveGlobalScope must succeed")
+	}
+	if len(osIDs) != 1 || osIDs[0] != "grpAB" {
+		t.Fatalf("AND across members must yield only the shared group; got %v", osIDs)
+	}
+}
+
+// TestResolveGlobalScope_MemberUIDs_ThreadsIncluded — bug 5 統一 rule: a group
+// that survives the member filter must also fold in its allowlisted threads.
+// The old "channelsForMember drops threads" behaviour is retired.
+func TestResolveGlobalScope_MemberUIDs_ThreadsIncluded(t *testing.T) {
+	loginUID := "me"
+	memberX := "x"
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			loginUID: {{GroupNo: "grpShared"}},
+			memberX:  {{GroupNo: "grpShared"}},
+		},
+	}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	h.threadEnumFn = func([]string) (map[string][]string, error) {
+		return map[string][]string{"grpShared": {"t1", "t2"}}, nil
+	}
+
+	c, _ := newValidatorCtx(t)
+	osIDs, _, _, _, ok := h.resolveGlobalScope(c, loginUID, nil, []string{memberX})
+	if !ok {
+		t.Fatalf("resolveGlobalScope must succeed")
+	}
+	want := map[string]bool{
+		"grpShared":                            true,
+		threadIDForTest("grpShared", "t1"):     true,
+		threadIDForTest("grpShared", "t2"):     true,
+	}
+	if len(osIDs) != len(want) {
+		t.Fatalf("member filter must fold in shared group's threads (want %d entries); got %v", len(want), osIDs)
+	}
+	for _, id := range osIDs {
+		if !want[id] {
+			t.Errorf("unexpected channelId %q in member-filtered scope", id)
+		}
+	}
+}
+
+// TestResolveGlobalScope_MemberUIDs_DMSingleMember — exactly one named member
+// who is also a DM peer of the caller: the DM survives, plus any shared
+// groups (none here, so just the DM).
+func TestResolveGlobalScope_MemberUIDs_DMSingleMember(t *testing.T) {
+	loginUID := "me"
+	peer := "colleague"
+	// No shared groups; only a DM edge via friend list. Member is that same
+	// DM peer, so the DM entry alone must survive.
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			loginUID: nil,
+			peer:     nil,
+		},
+	}
+	uSvc := &stubUserSvc{friends: []*user.FriendResp{{UID: peer}}}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	h.threadEnumFn = func([]string) (map[string][]string, error) { return nil, nil }
+
+	c, _ := newValidatorCtx(t)
+	osIDs, _, singleFast, _, ok := h.resolveGlobalScope(c, loginUID, nil, []string{peer})
+	if !ok {
+		t.Fatalf("resolveGlobalScope must succeed")
+	}
+	fake := fakeChannelIDFor(loginUID, peer)
+	if len(osIDs) != 1 || osIDs[0] != fake {
+		t.Fatalf("single-member DM: scope must be exactly the DM channel; got %v", osIDs)
+	}
+	if singleFast == nil || singleFast.ChannelType != channelTypePerson || singleFast.WireID != peer {
+		t.Errorf("single-member DM should take the single-channel fast path with peer WireID; got %+v", singleFast)
+	}
+}
+
+// TestResolveGlobalScope_MemberUIDs_DMMultiMemberDropped — with more than one
+// named member the DM branch is inapplicable (multi-member DMs do not exist)
+// so any DM entry in allowSet must be dropped even if one of the members is a
+// DM peer.
+func TestResolveGlobalScope_MemberUIDs_DMMultiMemberDropped(t *testing.T) {
+	loginUID := "me"
+	memberX := "x"
+	memberY := "y"
+	// Caller has DMs with both x and y (via friend list). Neither shares a
+	// group with the caller, so the AND across shared groups is empty. The DM
+	// branch must NOT rescue anything for multi-member.
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			loginUID: nil,
+			memberX:  nil,
+			memberY:  nil,
+		},
+	}
+	uSvc := &stubUserSvc{friends: []*user.FriendResp{{UID: memberX}, {UID: memberY}}}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	h.threadEnumFn = func([]string) (map[string][]string, error) { return nil, nil }
+
+	c, _ := newValidatorCtx(t)
+	osIDs, _, _, _, ok := h.resolveGlobalScope(c, loginUID, nil, []string{memberX, memberY})
+	if !ok {
+		t.Fatalf("resolveGlobalScope must succeed")
+	}
+	if len(osIDs) != 0 {
+		t.Fatalf("multi-member DM is not a thing; scope must be empty; got %v", osIDs)
+	}
+}
+
+// TestSearchGlobalMessagesRequest_MemberUIDSingleFallback — a stale-frontend
+// request carrying only the legacy `member_uid` singular field must still be
+// honoured (backward compat during rolling deploy). normalizeMemberUIDs folds
+// it into the plural path.
+func TestSearchGlobalMessagesRequest_MemberUIDSingleFallback(t *testing.T) {
+	loginUID := "me"
+	member := "colleague"
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			loginUID: {{GroupNo: "grpShared"}},
+			member:   {{GroupNo: "grpShared"}},
+		},
+	}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	h.threadEnumFn = func([]string) (map[string][]string, error) { return nil, nil }
+
+	c, _ := newValidatorCtx(t)
+	normalized := normalizeMemberUIDs(loginUID, nil, member)
+	if len(normalized) != 1 || normalized[0] != member {
+		t.Fatalf("legacy member_uid must fold into member_uids=[member]; got %v", normalized)
+	}
+	osIDs, _, _, _, ok := h.resolveGlobalScope(c, loginUID, nil, normalized)
+	if !ok {
+		t.Fatalf("resolveGlobalScope must succeed on legacy fallback")
+	}
+	if len(osIDs) != 1 || osIDs[0] != "grpShared" {
+		t.Fatalf("legacy member_uid fallback must still narrow scope; got %v", osIDs)
+	}
+}
+
+// TestSearchGlobalMessagesRequest_MemberUIDsSelfDropped — checkboxing self in
+// the multi-select must be a no-op on that entry (mirrors the frontend
+// `filter(uid !== selfUid)`). Also confirms plural-precedence and dedup on
+// the way through.
+func TestSearchGlobalMessagesRequest_MemberUIDsSelfDropped(t *testing.T) {
+	loginUID := "me"
+	member := "colleague"
+	// Both fields set together (mid-refresh frontend); plural wins, self and
+	// duplicate are stripped. Expected canonical form: [colleague].
+	got := normalizeMemberUIDs(loginUID, []string{loginUID, member, member, "  "}, "ignored")
+	if len(got) != 1 || got[0] != member {
+		t.Fatalf("self/dup/blank stripping failed: got %v", got)
+	}
+	// All-self input collapses to nil so the caller treats "no member
+	// filter", NOT "empty intersection" — checkboxing only yourself must
+	// behave identically to leaving the field blank.
+	if got := normalizeMemberUIDs(loginUID, []string{loginUID}, ""); got != nil {
+		t.Fatalf("all-self input must collapse to nil (no member filter); got %v", got)
+	}
+	// End-to-end: resolveGlobalScope with [self, colleague] behaves the same
+	// as [colleague] alone.
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			loginUID: {{GroupNo: "grpShared"}},
+			member:   {{GroupNo: "grpShared"}},
+		},
+	}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	h.threadEnumFn = func([]string) (map[string][]string, error) { return nil, nil }
+	c, _ := newValidatorCtx(t)
+	osIDs, _, _, _, ok := h.resolveGlobalScope(c, loginUID, nil,
+		normalizeMemberUIDs(loginUID, []string{loginUID, member}, ""))
+	if !ok {
+		t.Fatalf("resolveGlobalScope must succeed")
+	}
+	if len(osIDs) != 1 || osIDs[0] != "grpShared" {
+		t.Fatalf("self-in-list must be dropped in normalisation; got %v", osIDs)
+	}
+}
+
+// threadIDForTest is a thin wrapper over thread.BuildChannelID so the test
+// file stays self-contained on the composite-id format (matches the same
+// pattern used by search_global_thread_test.go).
+func threadIDForTest(groupNo, shortID string) string {
+	return thread.BuildChannelID(groupNo, shortID)
 }

--- a/modules/messages_search/search_global_test.go
+++ b/modules/messages_search/search_global_test.go
@@ -591,12 +591,16 @@ func TestSearchGlobalMessages_ChannelIDsCollapseToOne_EmptyKeywordBrowses(t *tes
 func assertNotEmptySearchGuardRejection(t *testing.T, rec *httptest.ResponseRecorder) {
 	t.Helper()
 	body := rec.Body.String()
-	// The empty-search guard renders a VALIDATION_ERROR carrying
-	// details.reason="keyword or at least one filter is required" (see
-	// validate.go::validateSearchNotEmpty). Any body containing that reason
-	// means the fast path never got past the strict single-channel gate.
-	if strings.Contains(body, "keyword or at least one filter is required") {
-		t.Fatalf("singleFast branch must accept empty-keyword browse; got the empty-search 400: %s", body)
+	// The empty-search guard renders a VALIDATION_ERROR whose serialized
+	// envelope carries msg="Invalid search request." The internal
+	// details.reason ("keyword or at least one filter is required") is
+	// stripped by httperr's SafeDetailKeys filter before it reaches the wire,
+	// so we must key off the client-visible msg. An upstream/internal 400
+	// (search backend unavailable in the test env) renders a different msg
+	// and is treated as pass — the load-bearing check is only that the
+	// singleFast dispatch cleared validation.
+	if strings.Contains(body, "Invalid search request.") {
+		t.Fatalf("singleFast branch must accept empty-keyword browse; got a validation 400: %s", body)
 	}
 }
 

--- a/modules/messages_search/search_global_test.go
+++ b/modules/messages_search/search_global_test.go
@@ -3,12 +3,14 @@ package messages_search
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/gin-gonic/gin"
 	"github.com/olivere/elastic"
@@ -453,26 +455,44 @@ func TestBuildGlobalFileHits_DMChannelReversal(t *testing.T) {
 	}
 }
 
-// validateSearchNotEmptyGlobal accepts every global-only filter dimension as
-// "effective" so a browse-mode caller specifying just channel_ids /
-// channel_types / content_types / member_uid is not falsely rejected.
-func TestValidateSearchNotEmptyGlobal_GlobalOnlyFilters(t *testing.T) {
-	cases := []struct {
-		name    string
-		filters GlobalSearchFilters
-	}{
-		{"channel_ids", GlobalSearchFilters{ChannelIDs: []GlobalChannelRef{{ChannelID: "g", ChannelType: 2}}}},
-		{"channel_types", GlobalSearchFilters{ChannelTypes: []uint8{1}}},
-		{"content_types", GlobalSearchFilters{ContentTypes: []int{payloadTypeText}}},
-		{"member_uid", GlobalSearchFilters{MemberUID: "u"}},
+// bug 3 · empty keyword + no filters is a valid *browse* request on the global
+// messages endpoint. The single-channel-style validateSearchNotEmpty guard was
+// removed (the terms(channelId, allowlist) clause bounds the scan the same way
+// a single channel's channelId does), so such a request must pass validation
+// and reach the browse flow instead of being rejected with a 400.
+//
+// Driving the full handler with an EMPTY allowlist (no joined groups, no
+// friends) lets us assert the accept without touching OpenSearch: the resolved
+// scope collapses to empty and the handler returns the 200 empty-envelope
+// early-return at `len(osChannelIDs) == 0`. A 400 here would mean the guard is
+// still rejecting empty-keyword browse.
+func TestSearchGlobalMessages_EmptyKeywordNoFilter_Browses(t *testing.T) {
+	loginUID := "me"
+	gSvc := &stubGroupSvc{groupsByUID: map[string][]*group.InfoResp{loginUID: nil}}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest("POST", "/v1/messages/_search_global_messages",
+		strings.NewReader(`{"keyword":"","filters":{}}`))
+	gc.Set("uid", loginUID)
+	c := &wkhttp.Context{Context: gc}
+
+	h.searchGlobalMessages(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("empty keyword + no filter must be accepted (browse), got HTTP %d: %s",
+			rec.Code, rec.Body.String())
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			c, _ := newValidatorCtx(t)
-			if ok := validateSearchNotEmptyGlobal(c, "", tc.filters); !ok {
-				t.Errorf("%s alone must satisfy the empty-search guard", tc.name)
-			}
-		})
+	var env CursorList
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("response must be a success envelope, got %q (err %v)", rec.Body.String(), err)
+	}
+	data, ok := env.Data.([]any)
+	if !ok || len(data) != 0 {
+		t.Fatalf("empty allowlist must yield an empty data array; got %#v", env.Data)
 	}
 }
 

--- a/modules/messages_search/search_global_thread_test.go
+++ b/modules/messages_search/search_global_thread_test.go
@@ -682,3 +682,117 @@ func TestResolveGlobalScope_ArchivedThreadNarrowingHits(t *testing.T) {
 		t.Errorf("singleFast mismatch: %+v", singleFast)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// bug 4 · a selected group covers its sub-threads; a selected thread stays
+// scoped to itself. resolveGlobalScope folds every allowlisted thread whose
+// parent group was named in channel_ids into the resolved scope, then keeps
+// the allowlist intersection so a caller can never over-reach.
+// ---------------------------------------------------------------------------
+
+// TestResolveGlobalScope_GroupChannelIncludesThreads — selecting a group
+// (channelType=2) resolves scope = { group_no } ∪ { that group's threads }.
+// Threads of OTHER groups must not leak in.
+func TestResolveGlobalScope_GroupChannelIncludesThreads(t *testing.T) {
+	loginUID := "me"
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			loginUID: {{GroupNo: "grpA"}, {GroupNo: "grpB"}},
+		},
+	}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	h.threadEnumFn = func([]string) (map[string][]string, error) {
+		return map[string][]string{
+			"grpA": {"t1", "t2"},
+			"grpB": {"t3"},
+		}, nil
+	}
+
+	c, _ := newValidatorCtx(t)
+	osIDs, _, singleFast, _, ok := h.resolveGlobalScope(c, loginUID,
+		[]GlobalChannelRef{{ChannelID: "grpA", ChannelType: channelTypeGroup}}, "")
+	if !ok {
+		t.Fatalf("resolveGlobalScope must succeed")
+	}
+	want := map[string]bool{
+		"grpA": true,
+		thread.BuildChannelID("grpA", "t1"): true,
+		thread.BuildChannelID("grpA", "t2"): true,
+	}
+	if len(osIDs) != len(want) {
+		t.Fatalf("group scope must expand to group + its threads (want %d entries); got %v", len(want), osIDs)
+	}
+	for _, id := range osIDs {
+		if !want[id] {
+			t.Errorf("unexpected channelId %q in group-expanded scope (grpB thread must NOT leak)", id)
+		}
+	}
+	if singleFast != nil {
+		t.Errorf("a group with threads yields a multi-id scope; single-channel fast path must NOT fire; got %+v", singleFast)
+	}
+}
+
+// TestResolveGlobalScope_ThreadChannelScopesToThreadOnly — selecting a single
+// thread (channelType=5) resolves scope = { that thread } only: neither the
+// parent group nor sibling threads are pulled in.
+func TestResolveGlobalScope_ThreadChannelScopesToThreadOnly(t *testing.T) {
+	loginUID := "me"
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			loginUID: {{GroupNo: "grpA"}},
+		},
+	}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	// grpA has three allowlisted threads; the request narrows to just one.
+	h.threadEnumFn = func([]string) (map[string][]string, error) {
+		return map[string][]string{"grpA": {"t1", "t2", "t3"}}, nil
+	}
+
+	target := thread.BuildChannelID("grpA", "t2")
+	c, _ := newValidatorCtx(t)
+	osIDs, _, singleFast, _, ok := h.resolveGlobalScope(c, loginUID,
+		[]GlobalChannelRef{{ChannelID: target, ChannelType: channelTypeThread}}, "")
+	if !ok {
+		t.Fatalf("resolveGlobalScope must succeed")
+	}
+	if len(osIDs) != 1 || osIDs[0] != target {
+		t.Fatalf("thread selection must scope to the thread alone (no parent group, no siblings); got %v", osIDs)
+	}
+	if singleFast == nil || singleFast.OSChannelID != target || singleFast.ChannelType != channelTypeThread {
+		t.Errorf("lone-thread scope should take the single-channel fast path; got %+v", singleFast)
+	}
+}
+
+// TestResolveGlobalScope_GroupExpansionIntersectsAllowlist — the group→thread
+// expansion never lets a caller over-reach: a group the caller is NOT a member
+// of resolves to an empty scope (no group body, no threads), because both the
+// group and any folded threads are dropped by the allowlist intersection.
+func TestResolveGlobalScope_GroupExpansionIntersectsAllowlist(t *testing.T) {
+	loginUID := "me"
+	// Caller is only a member of grpA; grpZ is requested but not joined.
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{
+			loginUID: {{GroupNo: "grpA"}},
+		},
+	}
+	uSvc := &stubUserSvc{}
+	h := newAllowlistHandler(t, gSvc, uSvc)
+	h.threadEnumFn = func([]string) (map[string][]string, error) {
+		return map[string][]string{"grpA": {"t1"}}, nil
+	}
+
+	c, _ := newValidatorCtx(t)
+	osIDs, _, singleFast, _, ok := h.resolveGlobalScope(c, loginUID,
+		[]GlobalChannelRef{{ChannelID: "grpZ", ChannelType: channelTypeGroup}}, "")
+	if !ok {
+		t.Fatalf("resolveGlobalScope must succeed even when scope collapses to empty")
+	}
+	if len(osIDs) != 0 {
+		t.Fatalf("a group outside the caller's allowlist must expand to nothing (no thread over-reach); got %v", osIDs)
+	}
+	if singleFast != nil {
+		t.Errorf("empty scope must not set singleFast; got %+v", singleFast)
+	}
+}

--- a/modules/messages_search/search_global_thread_test.go
+++ b/modules/messages_search/search_global_thread_test.go
@@ -305,10 +305,12 @@ func TestBuildAllowlist_EmptyGroupsNoThreadQuery(t *testing.T) {
 	}
 }
 
-// TestChannelsForMember_DropsThreadsInV1 — the member_uid filter path is v1
-// simplified: thread entries in allowSet are dropped from the returned
-// scope entirely, regardless of the parent group's co-inhabitance.
-func TestChannelsForMember_DropsThreadsInV1(t *testing.T) {
+// TestChannelsForMembers_ThreadsUnderSharedGroupSurface — bug 5 flips the v1
+// behaviour: a member filter that keeps a group must ALSO keep every
+// allowlisted thread under that group (統一 rule: 群 → 群 + 其子区). The v1
+// unconditional thread-drop this test previously locked in is now obsolete;
+// it is replaced with the new positive assertion.
+func TestChannelsForMembers_ThreadsUnderSharedGroupSurface(t *testing.T) {
 	loginUID := "me"
 	memberUID := "colleague"
 	gSvc := &stubGroupSvc{
@@ -318,18 +320,15 @@ func TestChannelsForMember_DropsThreadsInV1(t *testing.T) {
 	}
 	uSvc := &stubUserSvc{}
 	h := newAllowlistHandler(t, gSvc, uSvc)
-	// Simulate an already-built allowSet with a group + a thread under it +
-	// a DM. channelsForMember should keep the group + DM (co-inhabitance /
-	// direct DM) but strip the thread.
 	threadID := thread.BuildChannelID("grpShared", "thrX")
 	allowSet := map[string]channelRef{
 		"grpShared": {OSChannelID: "grpShared", WireID: "grpShared", ChannelType: channelTypeGroup},
 		threadID:    {OSChannelID: threadID, WireID: threadID, ChannelType: channelTypeThread},
 		"dmFake":    {OSChannelID: "dmFake", WireID: memberUID, ChannelType: channelTypePerson},
 	}
-	got, err := h.channelsForMember(loginUID, memberUID, "", allowSet)
+	got, err := h.channelsForMembers(loginUID, []string{memberUID}, "", allowSet)
 	if err != nil {
-		t.Fatalf("channelsForMember: %v", err)
+		t.Fatalf("channelsForMembers: %v", err)
 	}
 	if _, ok := got["grpShared"]; !ok {
 		t.Errorf("shared group must be kept; got %+v", got)
@@ -337,8 +336,8 @@ func TestChannelsForMember_DropsThreadsInV1(t *testing.T) {
 	if _, ok := got["dmFake"]; !ok {
 		t.Errorf("DM with member must be kept; got %+v", got)
 	}
-	if _, ok := got[threadID]; ok {
-		t.Errorf("thread must be dropped in v1 channelsForMember; got %+v", got)
+	if _, ok := got[threadID]; !ok {
+		t.Errorf("thread under shared group must now surface (bug 5 統一 rule); got %+v", got)
 	}
 }
 
@@ -364,7 +363,7 @@ func TestResolveGlobalScope_ThreadNarrowingHits(t *testing.T) {
 	// Space gate.
 	c, _ := newValidatorCtx(t)
 	osIDs, _, singleFast, _, ok := h.resolveGlobalScope(c, loginUID,
-		[]GlobalChannelRef{{ChannelID: threadID, ChannelType: channelTypeThread}}, "")
+		[]GlobalChannelRef{{ChannelID: threadID, ChannelType: channelTypeThread}}, nil)
 	if !ok {
 		t.Fatalf("resolveGlobalScope must succeed; a response was already written")
 	}
@@ -399,7 +398,7 @@ func TestResolveGlobalScope_ThreadOutsideMembership(t *testing.T) {
 	c, _ := newValidatorCtx(t)
 	foreignThread := thread.BuildChannelID("grpB", "thrX")
 	osIDs, _, singleFast, _, ok := h.resolveGlobalScope(c, loginUID,
-		[]GlobalChannelRef{{ChannelID: foreignThread, ChannelType: channelTypeThread}}, "")
+		[]GlobalChannelRef{{ChannelID: foreignThread, ChannelType: channelTypeThread}}, nil)
 	if !ok {
 		t.Fatalf("resolveGlobalScope must succeed even when scope collapses to empty")
 	}
@@ -668,7 +667,7 @@ func TestResolveGlobalScope_ArchivedThreadNarrowingHits(t *testing.T) {
 
 	c, _ := newValidatorCtx(t)
 	osIDs, _, singleFast, _, ok := h.resolveGlobalScope(c, loginUID,
-		[]GlobalChannelRef{{ChannelID: archivedChan, ChannelType: channelTypeThread}}, "")
+		[]GlobalChannelRef{{ChannelID: archivedChan, ChannelType: channelTypeThread}}, nil)
 	if !ok {
 		t.Fatalf("resolveGlobalScope must succeed; a response was already written")
 	}
@@ -711,7 +710,7 @@ func TestResolveGlobalScope_GroupChannelIncludesThreads(t *testing.T) {
 
 	c, _ := newValidatorCtx(t)
 	osIDs, _, singleFast, _, ok := h.resolveGlobalScope(c, loginUID,
-		[]GlobalChannelRef{{ChannelID: "grpA", ChannelType: channelTypeGroup}}, "")
+		[]GlobalChannelRef{{ChannelID: "grpA", ChannelType: channelTypeGroup}}, nil)
 	if !ok {
 		t.Fatalf("resolveGlobalScope must succeed")
 	}
@@ -753,7 +752,7 @@ func TestResolveGlobalScope_ThreadChannelScopesToThreadOnly(t *testing.T) {
 	target := thread.BuildChannelID("grpA", "t2")
 	c, _ := newValidatorCtx(t)
 	osIDs, _, singleFast, _, ok := h.resolveGlobalScope(c, loginUID,
-		[]GlobalChannelRef{{ChannelID: target, ChannelType: channelTypeThread}}, "")
+		[]GlobalChannelRef{{ChannelID: target, ChannelType: channelTypeThread}}, nil)
 	if !ok {
 		t.Fatalf("resolveGlobalScope must succeed")
 	}
@@ -785,7 +784,7 @@ func TestResolveGlobalScope_GroupExpansionIntersectsAllowlist(t *testing.T) {
 
 	c, _ := newValidatorCtx(t)
 	osIDs, _, singleFast, _, ok := h.resolveGlobalScope(c, loginUID,
-		[]GlobalChannelRef{{ChannelID: "grpZ", ChannelType: channelTypeGroup}}, "")
+		[]GlobalChannelRef{{ChannelID: "grpZ", ChannelType: channelTypeGroup}}, nil)
 	if !ok {
 		t.Fatalf("resolveGlobalScope must succeed even when scope collapses to empty")
 	}

--- a/modules/messages_search/search_global_thread_test.go
+++ b/modules/messages_search/search_global_thread_test.go
@@ -363,7 +363,7 @@ func TestResolveGlobalScope_ThreadNarrowingHits(t *testing.T) {
 	// Space gate.
 	c, _ := newValidatorCtx(t)
 	osIDs, _, singleFast, _, ok := h.resolveGlobalScope(c, loginUID,
-		[]GlobalChannelRef{{ChannelID: threadID, ChannelType: channelTypeThread}}, nil)
+		[]GlobalChannelRef{{ChannelID: threadID, ChannelType: channelTypeThread}}, nil, "")
 	if !ok {
 		t.Fatalf("resolveGlobalScope must succeed; a response was already written")
 	}
@@ -398,7 +398,7 @@ func TestResolveGlobalScope_ThreadOutsideMembership(t *testing.T) {
 	c, _ := newValidatorCtx(t)
 	foreignThread := thread.BuildChannelID("grpB", "thrX")
 	osIDs, _, singleFast, _, ok := h.resolveGlobalScope(c, loginUID,
-		[]GlobalChannelRef{{ChannelID: foreignThread, ChannelType: channelTypeThread}}, nil)
+		[]GlobalChannelRef{{ChannelID: foreignThread, ChannelType: channelTypeThread}}, nil, "")
 	if !ok {
 		t.Fatalf("resolveGlobalScope must succeed even when scope collapses to empty")
 	}
@@ -667,7 +667,7 @@ func TestResolveGlobalScope_ArchivedThreadNarrowingHits(t *testing.T) {
 
 	c, _ := newValidatorCtx(t)
 	osIDs, _, singleFast, _, ok := h.resolveGlobalScope(c, loginUID,
-		[]GlobalChannelRef{{ChannelID: archivedChan, ChannelType: channelTypeThread}}, nil)
+		[]GlobalChannelRef{{ChannelID: archivedChan, ChannelType: channelTypeThread}}, nil, "")
 	if !ok {
 		t.Fatalf("resolveGlobalScope must succeed; a response was already written")
 	}
@@ -710,7 +710,7 @@ func TestResolveGlobalScope_GroupChannelIncludesThreads(t *testing.T) {
 
 	c, _ := newValidatorCtx(t)
 	osIDs, _, singleFast, _, ok := h.resolveGlobalScope(c, loginUID,
-		[]GlobalChannelRef{{ChannelID: "grpA", ChannelType: channelTypeGroup}}, nil)
+		[]GlobalChannelRef{{ChannelID: "grpA", ChannelType: channelTypeGroup}}, nil, "")
 	if !ok {
 		t.Fatalf("resolveGlobalScope must succeed")
 	}
@@ -752,7 +752,7 @@ func TestResolveGlobalScope_ThreadChannelScopesToThreadOnly(t *testing.T) {
 	target := thread.BuildChannelID("grpA", "t2")
 	c, _ := newValidatorCtx(t)
 	osIDs, _, singleFast, _, ok := h.resolveGlobalScope(c, loginUID,
-		[]GlobalChannelRef{{ChannelID: target, ChannelType: channelTypeThread}}, nil)
+		[]GlobalChannelRef{{ChannelID: target, ChannelType: channelTypeThread}}, nil, "")
 	if !ok {
 		t.Fatalf("resolveGlobalScope must succeed")
 	}
@@ -784,7 +784,7 @@ func TestResolveGlobalScope_GroupExpansionIntersectsAllowlist(t *testing.T) {
 
 	c, _ := newValidatorCtx(t)
 	osIDs, _, singleFast, _, ok := h.resolveGlobalScope(c, loginUID,
-		[]GlobalChannelRef{{ChannelID: "grpZ", ChannelType: channelTypeGroup}}, nil)
+		[]GlobalChannelRef{{ChannelID: "grpZ", ChannelType: channelTypeGroup}}, nil, "")
 	if !ok {
 		t.Fatalf("resolveGlobalScope must succeed even when scope collapses to empty")
 	}

--- a/modules/messages_search/sender_join_integration_test.go
+++ b/modules/messages_search/sender_join_integration_test.go
@@ -102,6 +102,19 @@ type stubGroupSvc struct {
 	// it takes precedence over groupsForMember.
 	groupsByUID    map[string][]*group.InfoResp
 	groupsByUIDErr error
+
+	// groupInfoByNo backs GetGroupWithGroupNo, needed by the checkGroupAccess
+	// gate exercised via the single-channel fast path (dispatchSingleAll).
+	// Unset: returns a synthetic non-nil InfoResp so the "group exists" check
+	// passes without a fixture per groupNo. Set: only listed groups pass.
+	groupInfoByNo    map[string]*group.InfoResp
+	groupInfoByNoErr error
+
+	// existMemberActiveByGroup backs ExistMemberActive (singular). Nil map =
+	// caller is an active member of every group (default). Set to lock a
+	// specific membership shape without touching the batch stub above.
+	existMemberActiveByGroup    map[string]bool
+	existMemberActiveByGroupErr error
 }
 
 func (s *stubGroupSvc) GetMembers(groupNo string) ([]*group.MemberResp, error) {
@@ -149,6 +162,32 @@ func (s *stubGroupSvc) ExistMembersActive(groupNos []string, uid string) ([]stri
 		}
 	}
 	return out, nil
+}
+
+// GetGroupWithGroupNo returns a synthetic non-nil InfoResp so tests that only
+// exercise the "group exists" branch of checkGroupAccess don't have to seed a
+// fixture. Set groupInfoByNo to override (nil entry = "group not found").
+func (s *stubGroupSvc) GetGroupWithGroupNo(groupNo string) (*group.InfoResp, error) {
+	if s.groupInfoByNoErr != nil {
+		return nil, s.groupInfoByNoErr
+	}
+	if s.groupInfoByNo == nil {
+		return &group.InfoResp{GroupNo: groupNo}, nil
+	}
+	return s.groupInfoByNo[groupNo], nil
+}
+
+// ExistMemberActive is the singular variant of ExistMembersActive, needed by
+// checkGroupAccess on the single-channel fast path. Default returns true so
+// tests that don't gate on membership still pass unchanged.
+func (s *stubGroupSvc) ExistMemberActive(groupNo string, uid string) (bool, error) {
+	if s.existMemberActiveByGroupErr != nil {
+		return false, s.existMemberActiveByGroupErr
+	}
+	if s.existMemberActiveByGroup == nil {
+		return true, nil
+	}
+	return s.existMemberActiveByGroup[groupNo], nil
 }
 
 // newTestHandler constructs a Handler suitable for senderJoin testing. Cache

--- a/modules/messages_search/validate.go
+++ b/modules/messages_search/validate.go
@@ -11,6 +11,7 @@ import (
 const (
 	maxKeywordLen = 64
 	maxSenderIDs  = 50
+	maxMemberUIDs = 50
 	minPageSize   = 1
 	maxPageSize   = 100
 	defaultPage   = 20


### PR DESCRIPTION
## Background

Backend slice of the global-search filter-panel bug fixes (YUJ-30). Of the
original four reported bugs, two are backend-only (bug 3 & bug 4); bug 5
(added mid-review after reviewer yujiawei pointed out the missing wire field)
extends the same backend endpoints with `member_uids` multi-select support.
bug 1 & bug 2 are frontend, shipped separately in `octo-web`.

- **bug 3** — the global "messages" search must support an empty keyword, like
  single-channel browse.
- **bug 4** — the "所在群聊或子区" channel filter must search a selected group
  **and its sub-threads**; a selected thread must stay scoped to that thread.
- **bug 5** — the "包含成员" filter must accept a multi-select `member_uids`
  array (AND semantics) alongside the legacy single-value `member_uid` field.

All three live in `modules/messages_search`.

## What this PR does

### bug 3 · empty-keyword browse on `_search_global_messages`

`searchGlobalMessages` previously ran `validateSearchNotEmptyGlobal`, which
rejected an empty keyword unless the request also carried at least one filter.
The frontend messages tab needs to browse recent messages with no keyword and
no filter.

Removed the guard. The `terms(channelId, allowlist)` clause that
`buildGlobalMessagesDSL` always emits bounds the scan the same way a single
channel's `channelId` bounds `_search_all`, so a keyword-less request is a
valid **browse** over the caller's readable rooms — not an unbounded full-index
scan. The browse-mode DSL semantics are unchanged and already match the
single-channel empty-keyword path:

- media payload types (image=2, video=5) layered onto the whitelist only on the
  empty-keyword branch;
- `sort` defaults to `time_desc`; `relevance` stays rejected
  (`allowRelevance = req.Keyword != ""`);
- cursor pagination unchanged.

**Single-channel empty-keyword口径 (investigated):** `_search_all` drops the
`multi_match` clause on an empty keyword and enters the same browse mode
(media types added, `time_desc`, cursor paging). It *does* still run
`validateSearchNotEmpty`, which requires `keyword` **or** one effective filter —
so single-channel does not permit a keyword-less **and** filter-less request; the
channel scope alone is not treated as sufficient.

**Deliberate divergence:** the global endpoint is now *more* permissive than
single-channel — it allows empty keyword with no filter at all. This is
intentional and matches the product ask: the global allowlist is the bounding
scope (batched + OS ms-level after the YUJ-27/allowlist-latency work), so a
keyword-less browse across all readable rooms is affordable and is exactly what
the messages tab renders on open. The browse-mode *DSL* is identical to
single-channel; only the empty-request gate differs.

### bug 4 · group channel filter includes its sub-threads

`resolveGlobalScope` resolved a requested group (`channel_ids` entry with
`channel_type=2`) into `terms(channelId=group_no)` only, matching the group
**body** documents and missing the group's threads (composite channelIds
`{group_no}____{short_id}`, `channel_type=5`).

Fix: when a `channel_ids` entry names a group, fold every allowlisted thread
whose parent group was requested into the resolved scope, so the
`terms(channelId)` clause spans **group + its threads**. Threads are sourced
from the already-built `allowSet` rather than a fresh `enumerateThreadsForGroups`
call, so the expansion:

- inherits the group-membership gate (threads under groups the caller isn't in
  are simply not in `allowSet`);
- inherits the per-group / aggregate thread caps applied in `buildAllowlist`;
- costs no extra DB round-trip.

The final allowlist intersection still applies, so a caller can never
over-reach. A thread selected directly (`channel_type=5`) never seeds the group
set and stays scoped to itself alone.

**Single-channel group-search口径 confirmed (the requested investigation):**
`_search_all` on a group emits `term(channelId=group_no)` via
`applyChannelAndRevoked` (`dsl.go`), so single-channel group search matches the
**group body only** — threads are a separate `channel_type=5` surface and are
**not** included. Global "select group = group + threads" is therefore
intentionally **broader** than single-channel. This is the correct reading of
the frontend filter label "所在群聊或子区" (group **or** thread): choosing the
group means "everything under this group, including its threads", whereas the
single-channel view is entered from within one specific channel and stays there.

### bug 5 · `member_uids` multi-select with AND semantics + thread inclusion

Frontend PR #688 renamed the "包含成员" filter from single-select `member_uid`
to multi-select `member_uids`, but the backend request struct never carried
`member_uids` — `c.BindJSON` silently discarded the unknown field so the
picker had no visible effect. (Reviewer yujiawei grep'd the backend repo and
confirmed the field was missing.)

Fix:

- Add `MemberUIDs []string` to `GlobalSearchFilters` and `GlobalFileFilters`;
  **retain the legacy `MemberUID string` field** so the rolling deploy
  tolerates a stale frontend and a mid-refresh browser tab that ships both.
- New `normalizeMemberUIDs` helper folds the two wire fields into the
  canonical form: plural wins when set, singular is folded into a
  single-element slice otherwise, self-uid + duplicates + whitespace-only
  entries are stripped (matches the frontend `filter(uid !== selfUid)`
  convention so a caller who checkboxes themselves gets the same result as
  one who did not).
- Replace `channelsForMember` with `channelsForMembers` that intersects
  group memberships across every named member (AND, not OR). Per the 統一
  rule from the design doc ("凡涉及在某群聊下筛选，默认 = 该群聊 + 该群聊
  下所有子区一起筛"), each surviving group also folds in its allowlisted
  sub-threads — retiring the v1 unconditional thread-drop in the member
  path. Threads inherit their parent group's membership gate, so no
  `thread_member` join is needed.
- DM branch fires **only** with exactly one named member (multi-party DMs
  do not exist on this product); multi-member requests drop the DM branch
  entirely, matching AND semantics.
- Validator rejects blank entries in `filters.member_uids` with a structured
  400 (mirrors the `filters.channel_ids` error shape).

## Tests

All in `modules/messages_search`, run with `go test ./modules/messages_search/... -count=1` (green).

- **bug 3** —
  - `TestSearchGlobalMessages_EmptyKeywordNoFilter_Browses`: full-handler
    drive with an empty allowlist + empty-keyword / no-filter body → HTTP 200
    empty envelope (request accepted, reached the browse flow), rather than 400.
  - Fast-path parity: `TestSearchGlobalMessages_SingleGroupFastPath_EmptyKeywordBrowses`
    and `TestSearchGlobalMessages_ChannelIDsCollapseToOne_EmptyKeywordBrowses`
    (single-room collapse via ambient membership + channel_ids narrowing).
- **bug 4** —
  - `TestResolveGlobalScope_GroupChannelIncludesThreads`: selecting a group
    resolves scope = `{group_no}` ∪ its threads; other groups' threads do not leak.
  - `TestResolveGlobalScope_ThreadChannelScopesToThreadOnly`: selecting a thread
    scopes to that thread alone (no parent group, no sibling threads).
  - `TestResolveGlobalScope_GroupExpansionIntersectsAllowlist`: a group outside
    the caller's allowlist expands to an empty scope (no thread over-reach).
- **bug 5** —
  - `TestResolveGlobalScope_MemberUIDs_ANDSemantics`: two named members whose
    only shared group survives (union groups drop out).
  - `TestResolveGlobalScope_MemberUIDs_ThreadsIncluded`: a surviving shared
    group folds in its allowlisted threads (統一 rule).
  - `TestResolveGlobalScope_MemberUIDs_DMSingleMember`: exactly-one-member DM
    survives + takes the single-channel fast path.
  - `TestResolveGlobalScope_MemberUIDs_DMMultiMemberDropped`: >1 named
    member → DM branch dropped, empty scope when there's no shared group.
  - `TestSearchGlobalMessagesRequest_MemberUIDSingleFallback`: legacy
    `member_uid` single field is honoured via normalization.
  - `TestSearchGlobalMessagesRequest_MemberUIDsSelfDropped`: self-uid,
    duplicates, whitespace, and all-self input are stripped.
  - `TestChannelsForMembers_ThreadsUnderSharedGroupSurface`: replaces the
    now-obsolete `TestChannelsForMember_DropsThreadsInV1` — threads under
    the shared group must now surface (contract flip).

Also passing: full `modules/messages_search` suite, `go build ./...`,
`go vet ./modules/messages_search/...`, `make i18n-extract-check`,
`make i18n-lint`, and the `TestMessagesSearchNoLegacyResponseError` guard.

## Open questions

None. The single-channel口径 for both group-search (body only) and
empty-keyword (browse but filter-gated) was verified in code and the global
divergences above are intentional per the product spec.

Fixes #568
