### PR TITLE
fix(card): trust published App Bots as card senders

### DIFF
--- a/.octospec/journal/shared/card-message-appbot-trust.md
+++ b/.octospec/journal/shared/card-message-appbot-trust.md
@@ -1,0 +1,79 @@
+---
+type: Journal
+title: "Journal: card-message-appbot-trust"
+description: Close the App Bot card trust gap with one authoritative identity resolver and a verified action event lifecycle.
+tags: ["message", "card", "app-bot", "bot-api", "trust-boundary", "auth", "testing"]
+timestamp: 2026-07-13T16:01:27+08:00
+# --- octospec extension fields ---
+task: card-message-appbot-trust
+source: self
+---
+
+# Journal: card-message-appbot-trust
+
+## What was done
+
+- Added `modules/botidentity`, a live, cache-free resolver over the two lifecycle
+  authorities: `robot.robot_id/status=1` and `app_bot.uid/status=1`. One SQL
+  statement reads both predicates from the same snapshot. Missing/inactive rows
+  resolve to no identity; simultaneous active rows return a typed invariant error.
+  `user.robot=1` is never consulted as authorization.
+- Rewired `modules/cardtrust` to the unified resolver while preserving its
+  bounded LRU, 60-second TTL, `iwh_` display shortcut, positive/negative caching,
+  and no-cache-on-error fail-closed behavior.
+- Rewired `POST /v1/message/card/action` to use the live resolver for the stored
+  sender UID. Existing `robotService` remains the typed-event enqueue path, so
+  the queue and `card_action` wire shape are unchanged.
+- Added regression coverage for User Bot/App Bot/inactive/presentation-only/
+  ambiguous/error identities, push and search display projection, and a complete
+  App Bot `action -> poll -> ACK -> absent-on-repoll` lifecycle. Unpublish blocks
+  a first action immediately; republish permits it without changing idempotency.
+
+## Structural learnings
+
+- Bot presentation and bot authority are different layers. `user.robot=1` is a
+  UI hint; lifecycle authorization must resolve the owning authoritative table.
+  When two independent tables can claim one UID, a precedence rule hides data
+  corruption. A single-statement resolver can detect the invariant and fail closed.
+- Cache placement belongs to the consumer. Display masking tolerates the existing
+  short TTL, while side-effect authorization must read live state. A package-level
+  identity cache would have silently weakened App Bot unpublish semantics.
+
+## octospec rules injected
+
+- **space-isolation**: only the stored sender predicate changed; channel binding,
+  membership, Space/group/thread status, visibility, revoke/delete, and
+  idempotency gates are unchanged and the full card-action matrix stays green.
+- **trust-boundary**: only active User Bots, published App Bots, and existing
+  `iwh_` display identities expose stored `plain`; errors and ambiguous identities
+  fail closed. Webhook actions remain rejected.
+- **error-handling**: resolver errors use the existing localized query-failed
+  envelope; inactive/unknown identities use the existing collapsed invalid action.
+- **rate-limit**: no route, middleware, or Redis frequency-counter change.
+
+## Verification
+
+- TDD checkpoints: `3599b793` (RED reproducers), `2b5f9519` (GREEN fix).
+- `go test -race ./modules/botidentity/... ./modules/cardtrust/...` — PASS.
+- `go test -cover ./modules/botidentity/...` — PASS, 96.2% statements.
+- `go test -tags integration ./modules/botidentity -run '^TestResolverAgainstAuthoritativeBotTables$' -count=1` — PASS.
+- `go test -tags integration ./modules/message -run '^TestCardAction' -count=1` — PASS after CI-style MySQL/Redis reset.
+- Published App Bot push/search projection tests — PASS after per-package reset.
+- `go test ./modules/bot_api/...` and `go test ./pkg/cardmsg/... ./modules/cardtrust/...` — PASS.
+- `go vet`, `make i18n-extract-check`, `make i18n-lint`, and `git diff --check` — PASS.
+
+## Gotchas worth remembering
+
+- The repo's shared local `test` schema must be dropped/recreated between module
+  packages, matching `.github/workflows/ci.yml`; otherwise one package's partial
+  migration set causes another package to fail with `unknown migration in
+  database`. Redis must also be flushed for rate-limit/action/event isolation.
+- `golangci-lint` was not installed in this workspace. The focused vet, repo i18n
+  linters, race tests, integration suites, and diff check ran successfully; CI
+  remains the authoritative full golangci gate.
+
+## Deliberately deferred
+
+`internal/carddispatch`, internal producers, incoming-webhook action/callback
+support, and bot-send pipeline changes remain out of scope until a concrete
+internal caller is specified.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,20 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-13 (card-message-appbot-trust)
+
+- **Fix** — Closed the P0 App Bot card trust split without changing the send
+  pipeline: added a cache-free `modules/botidentity` authority over active
+  `robot` and published `app_bot` rows (same-statement ambiguity detection,
+  `user.robot` never authorizes), moved `cardtrust` display masking onto it while
+  retaining the 60-second bounded cache, and made `card/action` resolve sender
+  identity live before enqueueing through the unchanged robot event queue. Added
+  push/search projection coverage plus App Bot unpublish/republish and full
+  action -> poll -> ACK lifecycle tests. `internal/carddispatch` remains a
+  separate task. Brief/context under
+  `.octospec/tasks/card-message-appbot-trust/`; shared journal
+  `.octospec/journal/shared/card-message-appbot-trust.md`.
+
 ## 2026-07-09 (sticker-oversized-store-guard)
 
 - **Fix** — Task `sticker-oversized-store-guard` (code-review fix on

--- a/.octospec/tasks/card-message-appbot-trust/brief.md
+++ b/.octospec/tasks/card-message-appbot-trust/brief.md
@@ -1,0 +1,218 @@
+---
+type: Task
+title: "Task: card-message-appbot-trust"
+description: Make published App Bots first-class trusted card senders across display masking and the card-action event loop.
+tags: ["message", "card", "bot-api", "app-bot", "wire-contract", "trust-boundary", "auth", "space", "isolation", "acl", "error-response", "i18n", "rate-limit", "testing"]
+timestamp: 2026-07-13T00:00:00+08:00
+# --- octospec extension fields ---
+slug: card-message-appbot-trust
+upstream: self
+source: self
+---
+
+# Task: card-message-appbot-trust
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+Close the existing App Bot card-sender trust gap without changing the card send
+pipeline, target authorization, Space enrichment, or wire contract.
+
+A published App Bot can already authenticate to `/v1/bot/*`, send type-17 card
+payloads, poll `/v1/bot/events`, ACK events, and edit its own cards. App Bot
+creation persists an `app_bot` row and a `user.robot=1` presentation row, but
+does not create a `robot` table row. Two server-side card trust gates currently
+call `robot.ExistRobot` and therefore reject/mask App Bot cards after send:
+
+- `modules/cardtrust.Resolver`, used by offline push and message-search card
+  projections;
+- `POST /v1/message/card/action`, before enqueueing `card_action` to the sender's
+  bot event queue.
+
+Introduce one authoritative bot-identity resolver that recognizes both active
+User Bots and published App Bots, then use it at those two trust gates. A valid
+App Bot card must retain trusted `plain` on server-authored display surfaces and
+deliver a valid Submit action through the existing App Bot event poll/ACK loop.
+
+User journey:
+
+- As a published App Bot owner, I can send an interactive DM card; the recipient
+  sees the trusted card fallback text, taps a valid action, and my App Bot polls
+  exactly one `card_action` event and ACKs it through existing Bot API routes.
+
+## Background
+
+### Existing identity models
+
+- User Bot authority: `robot.robot_id` with `robot.status=1`.
+- App Bot authority: `app_bot.uid` with `app_bot.status=1` (`StatusPublished`).
+- App Bot presentation: `user.uid=app_bot.uid`, `user.robot=1`.
+- Incoming webhook identity: synthetic `iwh_` prefix, intentionally trusted for
+  display but intentionally rejected by `card/action` because it has no bot event
+  consumer.
+
+Bot API authentication already distinguishes User Bot and App Bot tokens. The
+App Bot event routes are UID-keyed Redis operations; typed events do not require
+a `robot` DB row. The missing component is a shared authoritative predicate for
+“is this UID currently an active bot identity that may own a card action?”.
+
+### Decisions locked by this task
+
+1. **Complete App Bot card support.** Do not disable App Bot cards or hide the
+   card profile. Active User Bots and published App Bots are trusted bot card
+   senders.
+2. **One resolver, no HTTP-module dependency.** Add a small library package
+   (proposed name `modules/botidentity`) that reads the existing `robot` and
+   `app_bot` tables without importing `modules/robot`, `modules/app_bot`, or
+   `modules/bot_api`. This avoids import cycles and keeps lifecycle authority in
+   the existing tables.
+3. **Fail closed.** Empty, unknown, disabled/unpublished, deleted, ambiguous, or
+   lookup-error identities are not trusted. A UID simultaneously active in both
+   bot tables is an invariant violation and returns an explicit internal error;
+   no precedence rule silently chooses one kind.
+4. **Live action authorization.** `cardAction` resolves sender identity on every
+   first action attempt. It does not use the presentation cache, preserving
+   immediate App Bot unpublish/revocation for side effects.
+5. **Presentation cache stays bounded.** `modules/cardtrust` retains its current
+   LRU capacity, 60-second TTL, webhook-prefix shortcut, and “do not cache lookup
+   errors” behavior. The cached value now comes from the unified resolver.
+6. **Event transport is unchanged.** A valid App Bot action is enqueued by the
+   existing `robotService.EnqueueBotTypedEvent(msgM.FromUID, ...)`, then polled
+   and ACKed through existing `/v1/bot/events` routes. No new queue or event
+   schema is introduced.
+7. **No behavior change for other senders.** Active User Bot and `iwh_` display
+   trust remains unchanged; webhook actions, human-forged cards, and inactive
+   bot actions remain rejected.
+
+## Load-bearing list
+
+<!-- touches: trust-boundary, wire-contract, auth, bot-api, space, isolation,
+     acl, error-response, i18n, rate-limit, testing -->
+
+- **Bot identity trust (`trust-boundary`, `auth`)** — `robot.status=1` and
+  `app_bot.status=1` are the only bot-table authority states. `user.robot=1`
+  alone is presentation metadata and must not authorize an action.
+- **Display masking (`trust-boundary`, `wire-contract`)** — type-17 stored
+  `plain` may surface only for an active User Bot, published App Bot, or existing
+  `iwh_` sender. Human/unknown/inactive senders and lookup errors remain masked
+  to `[卡片]`.
+- **Card action side effects (`acl`, `space`, `isolation`)** — only the sender
+  identity predicate changes. Existing anti-IDOR channel binding, operator
+  membership, group/thread status, canonical visibility, revoke/delete/expiry,
+  action-id, input-shape, rate-limit, and idempotency gates must remain byte-for-
+  byte behaviorally unchanged.
+- **Event ownership (`bot-api`, `wire-contract`)** — a successful action is
+  enqueued to the stored message `from_uid`; it must be retrievable only by that
+  authenticated App Bot and retain the existing additive `card_action`
+  `event_data` shape.
+- **Revocation semantics** — App Bot unpublish/delete must block new action side
+  effects immediately through the live resolver. Presentation masking may lag
+  by the existing cache TTL, matching current User Bot cache semantics.
+- **Failure handling (`error-response`, `i18n`)** — resolver/storage failures in
+  `cardAction` use the existing localized query-failed envelope; an inactive or
+  untrusted sender uses the existing collapsed card-action-invalid response.
+  No new raw HTTP error path or new client-visible identity enumeration is added.
+- **Rate limiting (`rate-limit`)** — no route or middleware changes. The existing
+  authenticated `card/action` shared UID limiter and Bot API/global limits stay
+  in force; no new Redis request-frequency counter is introduced.
+- **Testing (`testing`)** — resolver behavior, cardtrust cache semantics, live
+  action authorization, App Bot event poll/ACK, and unchanged negative sender
+  cases require focused tests. DB/Redis-backed tests clean state and reset any
+  shared rate-limit buckets they touch.
+
+## Out of scope
+
+- `internal/carddispatch`, internal producer registry/configuration, direct-send
+  source guards, or onboarding an internal business producer. These become a
+  separate task when the first concrete internal caller and target capability
+  are known.
+- Refactoring `/v1/bot/sendMessage`, its validation order, target authorization,
+  Space resolution, mention handling, metrics, or IM dispatch.
+- Changes to non-card sends, OBO, fan-out, typing, read receipts, message sync,
+  bot card edit/CAS, card revision history, or card-profile response fields.
+- Incoming webhook profiles/actions/callbacks or changes to its display trust.
+- Legacy robot API changes.
+- New card elements, actions, profiles, limits, or client-renderer behavior.
+- New database migrations or copying App Bot rows into the `robot` table.
+- Changing the existing 60-second presentation-cache TTL or adding distributed
+  invalidation for it.
+- Send idempotency, `client_msg_no`, outbox, retries, or exactly-once semantics.
+- New metrics. Existing structured error logs remain the observability surface
+  for identity lookup failures in this narrowly scoped fix.
+
+## Acceptance
+
+### Unified identity resolver
+
+- The resolver returns a typed result (`user_bot` or `app_bot`) and the minimum
+  authoritative metadata required by consumers; a boolean convenience method
+  may wrap it but cannot swallow lookup/invariant errors.
+- Table-driven unit tests and a DB-backed integration test prove:
+  - `robot.status=1` → trusted User Bot;
+  - disabled/deleted/missing `robot` → not trusted;
+  - `app_bot.status=1` → trusted App Bot;
+  - draft/unpublished/deleted/missing `app_bot` → not trusted;
+  - a `user.robot=1` row without an active bot-table row → not trusted;
+  - UID active in both tables → explicit ambiguous-identity error;
+  - DB failure → error and no trusted result.
+- Resolver queries use the current DB state. No package-level mutable identity
+  cache is added.
+
+### Display trust
+
+- `modules/cardtrust.New` uses the unified resolver instead of
+  `robot.NewService`/`robot.ExistRobot`.
+- Tests prove active User Bot, published App Bot, and `iwh_` sender are trusted;
+  inactive App Bot, presentation-only `user.robot=1`, human, empty UID, nil
+  resolver, and lookup error are untrusted.
+- Existing cache behavior remains covered: successful positive/negative verdicts
+  cache for the configured TTL; lookup errors are not cached and are retried.
+- Offline-push and message-search card projection tests include a published App
+  Bot case and expose authoritative stored `plain` rather than `[卡片]`.
+
+### Card action and App Bot event lifecycle
+
+- `cardAction` uses the live unified resolver for the stored sender UID and keeps
+  `robotService` only for event enqueue.
+- Existing User Bot happy path and webhook/human/inactive-bot negative tests stay
+  green.
+- A DB/Redis-backed App Bot flow proves:
+  1. a published App Bot sender plus an otherwise-valid card action returns
+     `{accepted:true,replay:false}`;
+  2. exactly one typed `card_action` event is written for the App Bot UID;
+  3. the same App Bot token can poll `/v1/bot/events` and receives that event
+     with the existing `event_type`/`event_data` contract;
+  4. `/v1/bot/events/:event_id/ack` removes it;
+  5. a later poll does not return the ACKed event.
+- Unpublishing the App Bot before a first action attempt yields the existing
+  localized invalid response and enqueues no event. Re-publishing permits a new
+  valid attempt; action idempotency behavior remains unchanged.
+- Existing action visibility tests (cross-channel IDOR, membership,
+  group/thread status, expires, visibles, revoke/delete, inputs) remain green,
+  demonstrating that only sender identity changed.
+
+### Verification gates
+
+- TDD RED is captured before production changes and the same focused targets
+  pass GREEN afterward; Conventional Commit checkpoints remain reachable from
+  this branch.
+- `gofmt` and `git diff --check` pass.
+- New resolver package coverage is at least 80%:
+  - `go test -cover ./modules/botidentity/...`
+- Focused suites pass:
+  - `go test ./modules/cardtrust/...`
+  - published-App-Bot push/search projection tests;
+  - relevant `modules/message` card-action integration tests;
+  - relevant `modules/bot_api` event poll/ACK tests.
+- Broader gates pass where local infrastructure permits:
+  - `go test ./pkg/cardmsg/... ./modules/cardtrust/... ./modules/bot_api/...`
+  - `go test ./...`
+  - `make i18n-extract-check` and `make i18n-lint`
+  - `golangci-lint run ./...`
+- octospec Implement records injected rules in `context.yaml`; Check confirms
+  every load-bearing rule against the actual diff and verifies no out-of-scope
+  send/Space/permission behavior changed.
+- Finish writes the shared journal/log entry and opens a PR against `main` with
+  Linked Spec and substantive COMPREHENSION answers.

--- a/.octospec/tasks/card-message-appbot-trust/context.yaml
+++ b/.octospec/tasks/card-message-appbot-trust/context.yaml
@@ -12,6 +12,7 @@ touched_paths:
   - modules/cardtrust/cardtrust.go
   - modules/cardtrust/cardtrust_test.go
   - modules/webhook/common_card_test.go
+  - modules/messages_search/card_appbot_integration_test.go
   - modules/message/api.go
   - modules/message/api_card_action.go
   - modules/message/api_card_action_test.go
@@ -82,7 +83,8 @@ injected_rules:
     why: >
       TDD covers resolver classification and failure modes, cardtrust cache
       behavior, live App Bot action authorization, and the event poll/ACK
-      lifecycle. DB-backed tests use testutil cleanup and clear Redis state.
+      lifecycle. The resolver uses an isolated SQL integration database; HTTP
+      tests use testutil cleanup and explicitly clear shared Redis state.
   - id: commit-style
     priority: 60
     load_bearing: false

--- a/.octospec/tasks/card-message-appbot-trust/context.yaml
+++ b/.octospec/tasks/card-message-appbot-trust/context.yaml
@@ -1,0 +1,95 @@
+# octospec context — records which rules were injected for this task and why.
+# Resolution: brief.md load-bearing tags ∪ touched file paths → matched rules
+# (see .octospec/rules/_index.yaml inject_when).
+schema_version: 1
+task: card-message-appbot-trust
+brief: .octospec/tasks/card-message-appbot-trust/brief.md
+
+touched_paths:
+  - modules/botidentity/resolver.go
+  - modules/botidentity/resolver_test.go
+  - modules/botidentity/resolver_integration_test.go
+  - modules/cardtrust/cardtrust.go
+  - modules/cardtrust/cardtrust_test.go
+  - modules/webhook/common_card_test.go
+  - modules/message/api.go
+  - modules/message/api_card_action.go
+  - modules/message/api_card_action_test.go
+
+load_bearing_tags:
+  - trust-boundary
+  - wire-contract
+  - auth
+  - bot-api
+  - space
+  - isolation
+  - acl
+  - error-response
+  - i18n
+  - rate-limit
+  - testing
+
+injected_rules:
+  - id: space-isolation
+    priority: 92
+    load_bearing: true
+    matched_by:
+      paths: ["modules/**/*.go"]
+      touches: ["space", "isolation", "auth", "bot-api", "acl"]
+    why: >
+      card/action is a side-effect boundary. The change may replace only the
+      stored sender identity predicate; existing channel binding, operator
+      membership, Space, group/thread status, visibility, and event ownership
+      gates must remain unchanged and fail closed.
+  - id: trust-boundary
+    priority: 90
+    load_bearing: true
+    matched_by:
+      paths: ["modules/webhook/**/*.go"]
+      touches: ["trust-boundary", "wire-contract", "webhook"]
+    why: >
+      Stored card plain text may surface only for an active User Bot, a
+      published App Bot, or the existing incoming-webhook synthetic identity.
+      Human, presentation-only, inactive, ambiguous, and lookup-error identities
+      remain untrusted; webhook action rejection remains unchanged.
+  - id: error-handling
+    priority: 85
+    load_bearing: true
+    matched_by:
+      paths: ["modules/**/*.go"]
+      touches: ["error-response", "i18n", "wire-contract"]
+    why: >
+      Identity lookup and invariant errors at card/action continue through the
+      existing localized query-failed envelope, while inactive or unknown
+      senders continue through the collapsed invalid-action response. No raw
+      response or client-visible identity enumeration is introduced.
+  - id: rate-limit
+    priority: 80
+    load_bearing: true
+    matched_by:
+      paths: ["modules/**/*.go"]
+      touches: ["rate-limit"]
+    why: >
+      No route or middleware changes are allowed. The existing shared UID rate
+      limiter on card/action and Bot API limits remain in force; integration
+      setup explicitly clears shared Redis rate-limit state.
+  - id: testing
+    priority: 70
+    load_bearing: false
+    matched_by:
+      paths: ["modules/**/*_test.go", "**/*_test.go"]
+      touches: ["testing"]
+    why: >
+      TDD covers resolver classification and failure modes, cardtrust cache
+      behavior, live App Bot action authorization, and the event poll/ACK
+      lifecycle. DB-backed tests use testutil cleanup and clear Redis state.
+  - id: commit-style
+    priority: 60
+    load_bearing: false
+    matched_by:
+      paths: ["**"]
+      touches: ["commit"]
+    why: >
+      RED and GREEN checkpoints use English Conventional Commit messages and
+      remain reachable from the task branch; the final PR links this spec and
+      answers the load-bearing comprehension questions.

--- a/.octospec/tasks/card-message-internal-dispatch/brief.md
+++ b/.octospec/tasks/card-message-internal-dispatch/brief.md
@@ -1,0 +1,415 @@
+---
+type: Task
+title: "Task: card-message-internal-dispatch"
+description: Add the only supported in-process path for business modules to send trusted interactive cards.
+tags: ["message", "card", "internal", "trust-boundary", "wire-contract", "auth", "space", "isolation", "acl", "rate-limit", "observability", "testing"]
+timestamp: 2026-07-13T16:17:40+08:00
+# --- octospec extension fields ---
+slug: card-message-internal-dispatch
+upstream: self
+source: self
+---
+
+# Task: card-message-internal-dispatch
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+Add `internal/carddispatch` as the only supported path for an in-process
+business module to originate an `InteractiveCard` (`type=17`) message.
+
+The dispatcher binds a reviewed producer capability to one configured active
+bot identity, authorizes the exact Space and target using live database state,
+owns the card envelope, applies the global and per-producer gates, runs
+`cardmsg.Validate` / server enrichment / `cardmsg.Finalize` / final serialized
+size recheck in a fixed order, makes at most one `SendMessageWithResult`
+transport attempt per invocation, and emits bounded metrics and structured
+logs.
+
+This closes the architectural hole where a future business module could call
+`config.Context.SendMessageWithResult` directly with a hand-built type-17 map
+and accidentally skip sender trust, Space/target ACLs, authoritative `plain`, or
+the final post-mutation 512 KiB check.
+
+No HTTP endpoint is added. Existing Bot API, legacy Robot API, and Incoming
+Webhook producers keep their current ingress-specific paths in this task; the
+new boundary governs server-internal business producers.
+
+## Background
+
+### Existing authoritative pieces
+
+- `pkg/cardmsg` is the card protocol authority:
+  - `cardmsg.Enabled()` reads `OCTO_CARD_MESSAGE_ENABLED`;
+  - `Validate` enforces the profile/version, structure, URL, depth/node and
+    complete-payload limits;
+  - `Finalize` overwrites untrusted `plain` and rechecks the enriched payload;
+  - `RecheckPayloadSize` checks the final bytes after any later mutation.
+- `modules/botidentity` resolves live bot authority:
+  `robot.status=1` or `app_bot.status=1`; `user.robot=1` is presentation only;
+  ambiguous or failed lookups fail closed.
+- The three current external ingress producers already implement their own
+  trust and permission boundaries before calling the IM transport:
+  - `modules/bot_api/send.go`;
+  - `modules/robot/api.go`;
+  - `modules/incomingwebhook/api.go` + `card.go`.
+- `pkg/cardmsg/producer_completeness_test.go` already proves every producer that
+  expands `mention.ais` performs a final size recheck. It does not prevent a new
+  internal producer from bypassing all of the other gates.
+- `config.MsgSendReq` has no caller-supplied `client_msg_no`, and
+  `SendMessageWithResult` has no context-aware overload. It returns the
+  server-generated `message_id`, `message_seq`, and `client_msg_no` only after a
+  successful transport response. Exactly-once retry cannot be truthfully
+  promised by this task.
+
+### Why this is a separate P0
+
+The App Bot trust task fixes consumers of already-sent cards. It deliberately
+does not authorize new in-process producers. Internal dispatch is a separate
+load-bearing boundary: a server module is not authenticated by Bot API
+middleware, so it needs an explicit producer capability and cannot inherit
+HTTP-layer bot/Space checks by accident.
+
+### Implementation gate: pilot producer must be named
+
+Before `/octospec-go card-message-internal-dispatch` enables a pilot producer, a
+maintainer must replace the following `TBD` values in this brief. A deliberately
+dormant foundation may leave them unresolved, but it must register no production
+producer. Do not implement a mutable generic "send as any UID" service while
+they are unknown.
+
+| Required input | Value |
+| --- | --- |
+| Producer ID (stable, low-cardinality) | `TBD` |
+| Owning module / constructor | `TBD` |
+| Sender bot UID configuration source | `TBD` |
+| Allowed channel types | `TBD` |
+| Allowed card profiles / action-event owner | `TBD` |
+| Required Space source | `TBD` |
+| Expected peak concurrency / QPS | `TBD` |
+| Business retry/idempotency requirement | `TBD` |
+| Process replicas / required cluster-wide cap | `TBD` |
+
+The foundation may be implemented with no enabled production registration, but
+it must not be presented as end-to-end useful until one concrete producer is
+reviewed against this table.
+
+## Decisions locked by this task
+
+1. **Capability-bound API, no arbitrary sender.** A caller obtains a
+   producer-specific `Sender` from an immutable registry/factory. `SendRequest`
+   contains no `from_uid` and no free-form producer string. The registry binds a
+   known `ProducerID` to its configured sender UID, allowed channel types,
+   allowed card profiles, Space policy, enable flag, and concurrency budget.
+   Unknown/unconfigured producers fail closed. No mutable package-global
+   registration from module `init()` is allowed.
+2. **Live bot authority.** Every send resolves the bound sender with
+   `modules/botidentity`; disabled/unpublished/deleted/missing, ambiguous, and
+   lookup-error identities are rejected before target queries or transport.
+   Synthetic `iwh_` identities and human UIDs are never accepted as internal
+   action-owning card senders. Dispatch authorization also needs the current
+   User Bot `creator_uid`, or App Bot `scope` and `space_id`; extend the unified
+   resolver result (or add a resolver method) so identity kind and this policy
+   metadata come from one authoritative live statement/snapshot. Do not create
+   a second, competing bot-kind resolver in `carddispatch`.
+3. **Explicit Space, never default-by-accident.** Every request carries a
+   trusted `SpaceID` obtained by the owning module, not from card content. The
+   dispatcher verifies that the Space is active, the sender is authorized in
+   that exact Space, and the recipient is an active member for DMs; groups and
+   threads must have the same authoritative Space. It does not choose the first
+   membership for a multi-Space bot. The verified value is the only `space_id`
+   placed in the envelope and is injected into DM payloads.
+4. **Target permission is live and at least as strict as Bot API self-send.**
+   App Bots are DM-only, require the existing friend opt-in, and a scope=space
+   App Bot may only target an active member of its own active Space. Platform
+   App Bots require an active target Space and active recipient membership.
+   User Bots require creator/friend authorization for DMs; group/thread sends
+   require an active internal bot member, a normal parent group, a non-deleted
+   active thread, and exact Space equality. DB errors fail closed. OBO is not
+   supported by internal dispatch.
+5. **Dispatcher owns the envelope.** The public request accepts a card document
+   plus a supported profile, not an arbitrary message payload. The dispatcher
+   sets `type`, `card_version`, and profile; caller-supplied `plain`, `space_id`,
+   OBO keys, sender fields, subscribers, stream fields, or other top-level
+   transport metadata are impossible through the API. Initial scope rejects
+   mentions; a later mention feature must extend the dispatcher and retain the
+   post-expansion recheck rather than bypass it.
+   An `octo/v2` producer must name the existing bot event consumer that owns
+   `card_action`; a producer with no such consumer is restricted to the
+   non-interactive profile. The dispatcher does not create a second callback
+   route for internal modules.
+6. **Dispatcher owns an immutable input snapshot.** The API accepts a standard
+   Adaptive Card document as bytes (or defensively deep-copies an equivalent
+   typed value) before validation. It never mutates or retains caller-owned maps
+   or slices. Concurrent caller mutation therefore cannot race validation,
+   final size checking, or transport serialization.
+7. **Fixed validation order.** The order is part of the contract:
+   structural request check -> global feature gate -> producer policy/gate ->
+   acquire producer in-flight slot -> snapshot input -> live bot identity ->
+   live Space/target authorization -> build envelope -> `cardmsg.Validate` ->
+   authoritative Space enrichment -> `cardmsg.Finalize` ->
+   `cardmsg.RecheckPayloadSize` on the exact wire map -> serialize that map ->
+   recheck context -> at most one transport call. No mutation is allowed after
+   the final recheck; the serialized bytes passed to `MsgSendReq.Payload` are
+   the bytes whose map passed that check.
+8. **One transport attempt, no hidden retry.** The dispatcher calls
+   `SendMessageWithResult` once and returns its typed result/error. It does not
+   start a goroutine, retry an ambiguous transport failure, or claim
+   exactly-once delivery. Callers must not blindly retry transport-ambiguous
+   failures. If the pilot requires retries, stable `client_msg_no` support and
+   an outbox/idempotency design must be added to this brief before implementation.
+9. **Bound internal blast radius.** Each producer has a small, reviewed
+   in-process max-in-flight limit. Saturation returns a typed `busy` error and
+   never waits unboundedly. This is business concurrency control, not an HTTP
+   rate limiter and not a hand-written Redis request-frequency counter. The
+   limit is per process; effective cluster concurrency is replicas multiplied
+   by this value. If the pilot needs a cluster-wide QPS/concurrency cap, that is
+   a separate explicit distributed-control requirement, not an implied property
+   of this semaphore.
+10. **Bounded observability.** Emit attempt/result counters, duration, and
+   in-flight metrics with only reviewed low-cardinality labels (`producer`,
+   normalized target kind, bounded result). Structured logs include request ID,
+   producer, sender kind, Space, target kind and returned message IDs on success;
+   never card JSON, user inputs, tokens, or channel/user IDs as metric labels.
+11. **Single composition point and acyclic dependencies.** Construct one
+    registry per application context, then inject only the producer-bound
+    `Sender` into the owning module. Multiple registries must not create
+    independent copies of the same producer's semaphore/metrics. The dispatcher
+    may depend on narrow repository/transport interfaces and
+    `modules/botidentity`, but must not import a potential producer module;
+    production adapters are composed outside the core package to avoid cycles.
+12. **Mechanized no-bypass rule.** Add an AST/source guard to CI. The exact
+    existing external ingress producers and `internal/carddispatch` are the only
+    allowlisted type-17 transport owners. Allowlist exact existing symbols or
+    call sites with reasons, not an entire directory that could hide a new
+    bypass. A new non-test package that combines card construction/type-17
+    references with direct `SendMessage` or `SendMessageWithResult` fails the
+    guard and must onboard through the dispatcher (or add a narrowly reviewed
+    external-ingress exemption). The guard is a review backstop for known Go
+    syntax/data-flow shapes, not a claim that static analysis is a runtime
+    security boundary.
+13. **Request-time authorization, no lock across transport.** Identity and ACL
+    state are queried without a decision cache on every invocation. The
+    dispatcher does not hold database locks or a transaction open across the IM
+    network call. A concurrent unpublish, membership removal, or Space disable
+    can therefore race with the already-authorized in-flight request; later
+    requests fail closed. If the pilot requires linearizable revocation of an
+    in-flight send, that stronger cross-system protocol must be designed before
+    implementation rather than claimed by this package.
+
+## Proposed internal contract
+
+Names may change during implementation, but these authority boundaries may not:
+
+```go
+type ProducerID string
+
+type Target struct {
+    SpaceID    string
+    ChannelID  string
+    ChannelType uint8
+}
+
+type Card struct {
+    Profile  string
+    Document json.RawMessage // standard Adaptive Card document; copied on entry
+}
+
+type Sender interface {
+    Send(ctx context.Context, target Target, card Card) (*Result, error)
+}
+
+type Result struct {
+    MessageID   int64
+    MessageSeq  uint32
+    ClientMsgNo string
+}
+```
+
+`context.Context` must be checked before expensive DB work and again immediately
+before transport, and used for tracing/log correlation. The current octo-lib
+transport is not cancellable; cancellation after the call starts cannot stop the
+request. The implementation must document that boundary and must not fake
+cancellation by leaking a goroutine. A context-aware transport extension is a
+separate octo-lib change unless accepted into this task before implementation.
+
+Internal errors are typed Go errors with a stable bounded category:
+`invalid_request`, `feature_disabled`, `producer_disabled`,
+`identity_untrusted`, `target_denied`, `card_invalid`, `payload_too_large`,
+`busy`, and `dispatch_failed`. They are not HTTP/i18n envelopes. A future HTTP
+caller must map them through that endpoint's registered `errcode` facade.
+
+## Load-bearing list
+
+<!-- touches: trust-boundary, wire-contract, auth, space, isolation, acl,
+     rate-limit, testing -->
+
+- **Producer trust (`trust-boundary`, `auth`)** — only immutable reviewed
+  producer capabilities can obtain a sender; live bot tables remain the
+  lifecycle authority. The send request has no caller-controlled sender field;
+  in-repository misuse remains covered by code review and the source guard.
+- **Tenant/target authorization (`space`, `isolation`, `acl`)** — explicit
+  Space binding, active membership, group/thread lifecycle, DM relationship,
+  App Bot scope and channel-type restrictions all fail closed before dispatch.
+- **Card wire contract (`wire-contract`, `trust-boundary`)** — `pkg/cardmsg`
+  remains the sole profile/schema authority; `plain` and `space_id` are
+  server-authored, and the exact serialized wire payload stays <=512 KiB.
+- **Existing ingress behavior (`bot-api`, `wire-contract`)** — Bot API, Robot
+  API, and Incoming Webhook validation order, error envelopes, OBO behavior,
+  rate limits, and metrics do not change merely because the internal package is
+  added. Their allowlist entries are explicit and source-tested.
+- **Transport failure semantics** — one call, no automatic retry, no false
+  exactly-once guarantee. A non-OK/ambiguous IM response returns
+  `dispatch_failed` and records a bounded result metric.
+- **Authorization consistency** — every invocation reads current identity and
+  ACL state without a decision cache, but no DB lock spans the IM call; rollback
+  disables new sends and does not retract an already-authorized in-flight send.
+- **Overload control (`rate-limit`)** — producer concurrency is bounded in
+  process and configurable/reviewed; the replica multiplier is explicit and no
+  new public route or Redis frequency counter is introduced.
+- **Observability** — all terminal branches increment exactly one bounded result
+  outcome; duration/in-flight are correct under error/panic-safe defers; content
+  and high-cardinality identifiers never become metric labels.
+- **Testing (`testing`)** — policy matrix, fail-closed storage paths, exact
+  validation order, final bytes, no-dispatch-on-denial, one-call success/error,
+  overload behavior, metrics, and the direct-send guard require tests.
+
+## Out of scope
+
+- Selecting or implementing the first business producer while the pilot table
+  above remains `TBD`.
+- Replacing or refactoring `/v1/bot/sendMessage`, legacy Robot API send,
+  Incoming Webhook push/card send, or their public error contracts.
+- Incoming Webhook card actions/callbacks; webhook identities still have no bot
+  event consumer.
+- A new internal `card_action` callback/event bus. Interactive profiles retain
+  the existing sender-bot event ownership and poll/ACK contract.
+- OBO, fan-out, streams, subscribers, transient/no-persist cards, mention
+  expansion, broadcast cards, typing/read receipts, or card edits/revisions.
+- New card profiles/elements/actions, renderer changes, or changes to
+  `pkg/cardmsg` limits.
+- New HTTP/gRPC routes, auth middleware, Space middleware, or client SDKs.
+- Durable outbox, retries, caller-supplied/stable `client_msg_no`, exactly-once
+  delivery, or transport cancellation. These require an explicit contract
+  change, not an invisible dispatcher retry.
+- Linearizable revocation across MySQL authorization state and the WuKongIM
+  network call, or recall of an already-dispatched card.
+- A distributed/cluster-wide rate or concurrency limiter. The initial
+  max-in-flight budget is per process unless the pilot planning gate requires a
+  stronger cap.
+- Database migrations solely for the dormant dispatcher foundation.
+- A dynamic admin UI or runtime API for registering producers. Registration is
+  code/config reviewed and immutable for the process lifetime.
+
+## Acceptance
+
+### Planning gate
+
+- The pilot-producer table has no `TBD` values before implementation starts, or
+  the implementation is explicitly limited to a disabled foundation with no
+  claim of end-to-end production usefulness.
+- The chosen sender UID/config source, target kinds, Space source, concurrency,
+  card profile/action owner, replica multiplier, and retry requirements receive
+  maintainer sign-off in this brief.
+
+### Capability and configuration
+
+- `internal/carddispatch` exposes a producer-bound `Sender`; send requests have
+  no sender UID or arbitrary payload/transport fields.
+- Registry tests prove unknown, duplicate, disabled, and missing-config
+  producers cannot obtain/use a sender. The registry is immutable after
+  construction, exactly one production instance owns all producer budgets, and
+  test instances do not share mutable global state.
+- Enabled producer startup/config validation checks non-empty bounded IDs,
+  configured sender UID, allowed target kinds/profiles, positive max-in-flight,
+  and Space policy. An interactive profile also requires a named compatible
+  action-event owner. Invalid config fails only that producer closed and emits
+  one safe log plus a bounded configuration-error metric; it never falls back to
+  a caller UID or a default producer.
+
+### Identity and target authorization
+
+- Table-driven unit tests plus DB-backed tests cover active/inactive/missing
+  User Bot and App Bot, presentation-only `user.robot=1`, cross-table ambiguity,
+  live User Bot creator and App Bot scope/Space policy metadata, and DB errors.
+  No failed branch reaches the transport capture.
+- DM tests cover User Bot creator/friend allow, stranger deny, active Space
+  membership, wrong/missing Space, App Bot platform/scope-space rules, and App
+  Bot group/thread denial.
+- Group/thread tests cover exact authoritative Space match, normal vs
+  disabled/disbanded group, active/internal/blacklisted/deleted/non-member bot,
+  valid/malformed/archived/deleted thread, and DB failure. All denials fail
+  closed before card finalization/transport.
+- Multi-Space tests prove the explicit request Space is verified and the
+  dispatcher never silently selects the first membership.
+
+### Payload pipeline
+
+- The dispatcher constructs `type=17`, pinned `card_version`, and selected
+  profile itself. Tests prove caller data cannot set/retain `plain`, `space_id`,
+  sender, OBO, stream, subscribers, mention, or transport headers.
+- Tests prove the dispatcher copies the input document before decoding and does
+  not mutate caller-owned bytes/maps; the same private snapshot feeds validation,
+  plain derivation, final size checking, serialization, and transport.
+- Call-order tests freeze the required sequence. Invalid card, disabled feature,
+  identity/ACL failure, and enriched/final payload overflow each produce zero
+  transport calls.
+- Success tests prove `plain` is recomputed, verified `space_id` is injected,
+  `cardmsg.Validate` and `Finalize` accept the final envelope, exact serialized
+  bytes are <= `cardmsg.MaxPayloadBytes`, and the captured `MsgSendReq` has the
+  bound bot UID and normalized target.
+- A boundary test starts below the size limit, grows during authoritative
+  enrichment, and is rejected by `Finalize`/the final size gate. No mutation
+  occurs after the explicit recheck before serialization/dispatch.
+
+### Dispatch, overload, and observability
+
+- Success returns the exact `message_id`, `message_seq`, and `client_msg_no`
+  from one captured `SendMessageWithResult` call. Transport failure is returned
+  without retry; cancellation before dispatch produces zero calls.
+- Concurrency tests prove each producer never exceeds its configured in-flight
+  bound, saturated calls fail fast with `busy`, and slots are released on every
+  terminal branch. Tests and docs state that this bound is per process.
+- Metrics tests use an isolated Prometheus registry and prove exactly one
+  terminal result increment per attempt, duration/in-flight correctness, and a
+  fixed label vocabulary. A source test rejects UID/channel/Space/message ID as
+  labels and rejects logging serialized card content.
+
+### No-bypass guard
+
+- A new AST-based tool/test scans non-test Go sources and fails fixtures for:
+  direct internal type-17 `SendMessage`, direct
+  `SendMessageWithResult`, literal/constant card construction paired with a
+  transport call, package-local wrapper/alias use, and splitting
+  construction/call across files in one package.
+- The allowlist contains only exact existing external ingress symbols/call sites
+  and `internal/carddispatch`, with a reason for each. Adding an exemption is a
+  load-bearing review change; fixtures also prove that adding a second bypass in
+  an otherwise allowlisted package still fails.
+- The guard is wired into CI and the existing
+  `TestType17ProducerSizeRecheckCompleteness` remains green.
+
+### Verification and rollout
+
+- TDD RED/GREEN checkpoints remain reachable from the implementation branch.
+- New dispatcher/authorizer critical business logic has >=90% statement and
+  branch-oriented matrix coverage; overall new package coverage is >=80%.
+- Focused commands pass:
+  - `go test -race -cover ./internal/carddispatch/...`
+  - target-authorizer DB integration tests;
+  - `go test ./pkg/cardmsg/... ./modules/botidentity/...`
+  - `go run ./tools/lint-card-dispatch ./modules ./internal`
+  - `go vet ./internal/carddispatch/...`
+  - `make i18n-extract-check && make i18n-lint`
+  - `golangci-lint run ./...`
+  - `git diff --check`
+- Broader package/full tests run with the repo's per-package MySQL/Redis reset
+  discipline where local infrastructure permits.
+- With zero enabled production registrations, deployment is behaviorally inert.
+  Enabling the pilot is a separate reviewed config/code change with rollback by
+  disabling/removing that one registration; existing public producers continue
+  unaffected.
+- Finish writes a shared journal/log entry and opens a separate PR with Linked
+  Spec and substantive COMPREHENSION answers.

--- a/modules/botidentity/resolver.go
+++ b/modules/botidentity/resolver.go
@@ -1,0 +1,110 @@
+// Package botidentity resolves the authoritative lifecycle identity behind a
+// bot UID. It deliberately reads only the robot and app_bot tables: user.robot
+// is presentation metadata and is not an authorization source.
+package botidentity
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/gocraft/dbr/v2"
+)
+
+// Kind identifies which authoritative bot table owns a UID.
+type Kind string
+
+const (
+	KindUserBot Kind = "user_bot"
+	KindAppBot  Kind = "app_bot"
+)
+
+var (
+	// ErrAmbiguousIdentity indicates a broken cross-table uniqueness invariant.
+	// Callers must fail closed rather than silently choosing one bot kind.
+	ErrAmbiguousIdentity = errors.New("ambiguous bot identity")
+	// ErrResolverUnavailable indicates a construction or wiring failure.
+	ErrResolverUnavailable = errors.New("bot identity resolver unavailable")
+)
+
+// Identity is the minimum authoritative metadata consumers need.
+type Identity struct {
+	UID  string
+	Kind Kind
+}
+
+type activeKindStore interface {
+	activeKinds(uid string) (userBot bool, appBot bool, err error)
+}
+
+type dbActiveKindStore struct {
+	session *dbr.Session
+}
+
+// activeKinds reads both lifecycle authorities in one statement. MySQL gives
+// the two EXISTS predicates one statement snapshot, so an ambiguous result is
+// detected consistently without a precedence rule or a two-query race.
+func (s *dbActiveKindStore) activeKinds(uid string) (bool, bool, error) {
+	var row struct {
+		UserBot int `db:"user_bot"`
+		AppBot  int `db:"app_bot"`
+	}
+	err := s.session.SelectBySql(`
+		SELECT
+			EXISTS(SELECT 1 FROM robot WHERE robot_id=? AND status=1) AS user_bot,
+			EXISTS(SELECT 1 FROM app_bot WHERE uid=? AND status=1) AS app_bot`,
+		uid, uid,
+	).LoadOne(&row)
+	if err != nil {
+		return false, false, err
+	}
+	return row.UserBot == 1, row.AppBot == 1, nil
+}
+
+// Resolver performs live authoritative lookups. It intentionally has no
+// package-level cache; consumers that need presentation caching own it locally.
+type Resolver struct {
+	store activeKindStore
+}
+
+func New(ctx *config.Context) *Resolver {
+	if ctx == nil {
+		return &Resolver{}
+	}
+	return &Resolver{store: &dbActiveKindStore{session: ctx.DB()}}
+}
+
+// Resolve returns nil when uid is not an active bot identity. Lookup and
+// invariant errors are preserved so callers cannot accidentally fail open.
+func (r *Resolver) Resolve(uid string) (*Identity, error) {
+	if uid == "" {
+		return nil, nil
+	}
+	if r == nil || r.store == nil {
+		return nil, ErrResolverUnavailable
+	}
+	userBot, appBot, err := r.store.activeKinds(uid)
+	if err != nil {
+		return nil, fmt.Errorf("resolve bot identity %q: %w", uid, err)
+	}
+	if userBot && appBot {
+		return nil, fmt.Errorf("%w: uid %q is active in robot and app_bot", ErrAmbiguousIdentity, uid)
+	}
+	if userBot {
+		return &Identity{UID: uid, Kind: KindUserBot}, nil
+	}
+	if appBot {
+		return &Identity{UID: uid, Kind: KindAppBot}, nil
+	}
+	return nil, nil
+}
+
+// Active is a boolean convenience that preserves all lookup and invariant
+// errors. It must not be used to collapse an error into an unqualified false.
+func (r *Resolver) Active(uid string) (bool, error) {
+	identity, err := r.Resolve(uid)
+	if err != nil {
+		return false, err
+	}
+	return identity != nil, nil
+}

--- a/modules/botidentity/resolver_integration_test.go
+++ b/modules/botidentity/resolver_integration_test.go
@@ -1,0 +1,80 @@
+//go:build integration
+
+package botidentity
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolverAgainstAuthoritativeBotTables(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+
+	insertRobot := func(uid string, status int) {
+		t.Helper()
+		_, err := ctx.DB().InsertBySql("INSERT INTO robot(robot_id,status) VALUES(?,?)", uid, status).Exec()
+		require.NoError(t, err)
+	}
+	insertAppBot := func(id, uid string, status int) {
+		t.Helper()
+		_, err := ctx.DB().InsertBySql(`
+			INSERT INTO app_bot(id,uid,display_name,scope,status,token,created_by)
+			VALUES(?,?,?,'platform',?,?,?)`, id, uid, uid, status, "app_token_"+id, "owner").Exec()
+		require.NoError(t, err)
+	}
+
+	insertRobot("active_robot", 1)
+	insertRobot("disabled_robot", 0)
+	insertAppBot("published", "published_bot", 1)
+	insertAppBot("draft", "draft_bot", 0)
+	insertAppBot("unpublished", "unpublished_bot", 2)
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO user(uid,name,robot,status) VALUES(?,?,1,1)",
+		"presentation_only", "Presentation Only",
+	).Exec()
+	require.NoError(t, err)
+	insertRobot("ambiguous_bot", 1)
+	insertAppBot("ambiguous", "ambiguous_bot", 1)
+
+	r := New(ctx)
+	tests := []struct {
+		name     string
+		uid      string
+		wantKind Kind
+		wantNil  bool
+		wantErr  error
+	}{
+		{name: "active robot", uid: "active_robot", wantKind: KindUserBot},
+		{name: "disabled robot", uid: "disabled_robot", wantNil: true},
+		{name: "missing robot", uid: "missing_robot", wantNil: true},
+		{name: "published app bot", uid: "published_bot", wantKind: KindAppBot},
+		{name: "draft app bot", uid: "draft_bot", wantNil: true},
+		{name: "unpublished app bot", uid: "unpublished_bot", wantNil: true},
+		{name: "presentation metadata only", uid: "presentation_only", wantNil: true},
+		{name: "ambiguous identity", uid: "ambiguous_bot", wantErr: ErrAmbiguousIdentity},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := r.Resolve(tt.uid)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, tt.uid, got.UID)
+			assert.Equal(t, tt.wantKind, got.Kind)
+		})
+	}
+}

--- a/modules/botidentity/resolver_integration_test.go
+++ b/modules/botidentity/resolver_integration_test.go
@@ -5,43 +5,53 @@ package botidentity
 import (
 	"testing"
 
-	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/gocraft/dbr/v2"
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestResolverAgainstAuthoritativeBotTables(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
-	require.NoError(t, testutil.CleanAllTables(ctx))
-	defer func() { _ = testutil.CleanAllTables(ctx) }()
+	// Use an isolated real SQL database rather than the process-wide MySQL test
+	// schema: resolver semantics need only the three authoritative columns, and
+	// isolation avoids cross-package migration/cleanup races.
+	conn, err := dbr.Open("sqlite3", ":memory:", nil)
+	require.NoError(t, err)
+	conn.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = conn.Close() })
+	session := conn.NewSession(nil)
+	_, err = session.Exec("CREATE TABLE robot (robot_id TEXT PRIMARY KEY, status INTEGER NOT NULL)")
+	require.NoError(t, err)
+	_, err = session.Exec("CREATE TABLE app_bot (uid TEXT PRIMARY KEY, status INTEGER NOT NULL)")
+	require.NoError(t, err)
+	_, err = session.Exec("CREATE TABLE user (uid TEXT PRIMARY KEY, robot INTEGER NOT NULL, status INTEGER NOT NULL)")
+	require.NoError(t, err)
 
 	insertRobot := func(uid string, status int) {
 		t.Helper()
-		_, err := ctx.DB().InsertBySql("INSERT INTO robot(robot_id,status) VALUES(?,?)", uid, status).Exec()
+		_, err := session.InsertBySql("INSERT INTO robot(robot_id,status) VALUES(?,?)", uid, status).Exec()
 		require.NoError(t, err)
 	}
-	insertAppBot := func(id, uid string, status int) {
+	insertAppBot := func(uid string, status int) {
 		t.Helper()
-		_, err := ctx.DB().InsertBySql(`
-			INSERT INTO app_bot(id,uid,display_name,scope,status,token,created_by)
-			VALUES(?,?,?,'platform',?,?,?)`, id, uid, uid, status, "app_token_"+id, "owner").Exec()
+		_, err := session.InsertBySql("INSERT INTO app_bot(uid,status) VALUES(?,?)", uid, status).Exec()
 		require.NoError(t, err)
 	}
 
-	insertRobot("active_robot", 1)
-	insertRobot("disabled_robot", 0)
-	insertAppBot("published", "published_bot", 1)
-	insertAppBot("draft", "draft_bot", 0)
-	insertAppBot("unpublished", "unpublished_bot", 2)
-	_, err := ctx.DB().InsertBySql(
-		"INSERT INTO user(uid,name,robot,status) VALUES(?,?,1,1)",
-		"presentation_only", "Presentation Only",
+	insertRobot("identity_test_active_robot", 1)
+	insertRobot("identity_test_disabled_robot", 0)
+	insertAppBot("identity_test_published_bot", 1)
+	insertAppBot("identity_test_draft_bot", 0)
+	insertAppBot("identity_test_unpublished_bot", 2)
+	_, err = session.InsertBySql(
+		"INSERT INTO user(uid,robot,status) VALUES(?,1,1)",
+		"identity_test_presentation_only",
 	).Exec()
 	require.NoError(t, err)
-	insertRobot("ambiguous_bot", 1)
-	insertAppBot("ambiguous", "ambiguous_bot", 1)
+	insertRobot("identity_test_ambiguous_bot", 1)
+	insertAppBot("identity_test_ambiguous_bot", 1)
 
-	r := New(ctx)
+	r := &Resolver{store: &dbActiveKindStore{session: session}}
 	tests := []struct {
 		name     string
 		uid      string
@@ -49,14 +59,14 @@ func TestResolverAgainstAuthoritativeBotTables(t *testing.T) {
 		wantNil  bool
 		wantErr  error
 	}{
-		{name: "active robot", uid: "active_robot", wantKind: KindUserBot},
-		{name: "disabled robot", uid: "disabled_robot", wantNil: true},
-		{name: "missing robot", uid: "missing_robot", wantNil: true},
-		{name: "published app bot", uid: "published_bot", wantKind: KindAppBot},
-		{name: "draft app bot", uid: "draft_bot", wantNil: true},
-		{name: "unpublished app bot", uid: "unpublished_bot", wantNil: true},
-		{name: "presentation metadata only", uid: "presentation_only", wantNil: true},
-		{name: "ambiguous identity", uid: "ambiguous_bot", wantErr: ErrAmbiguousIdentity},
+		{name: "active robot", uid: "identity_test_active_robot", wantKind: KindUserBot},
+		{name: "disabled robot", uid: "identity_test_disabled_robot", wantNil: true},
+		{name: "missing robot", uid: "identity_test_missing_robot", wantNil: true},
+		{name: "published app bot", uid: "identity_test_published_bot", wantKind: KindAppBot},
+		{name: "draft app bot", uid: "identity_test_draft_bot", wantNil: true},
+		{name: "unpublished app bot", uid: "identity_test_unpublished_bot", wantNil: true},
+		{name: "presentation metadata only", uid: "identity_test_presentation_only", wantNil: true},
+		{name: "ambiguous identity", uid: "identity_test_ambiguous_bot", wantErr: ErrAmbiguousIdentity},
 	}
 
 	for _, tt := range tests {

--- a/modules/botidentity/resolver_test.go
+++ b/modules/botidentity/resolver_test.go
@@ -1,0 +1,70 @@
+package botidentity
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeActiveKindStore struct {
+	userBot bool
+	appBot  bool
+	err     error
+	calls   int
+}
+
+func (f *fakeActiveKindStore) activeKinds(string) (bool, bool, error) {
+	f.calls++
+	return f.userBot, f.appBot, f.err
+}
+
+func TestResolverResolve(t *testing.T) {
+	dbErr := errors.New("db unavailable")
+	tests := []struct {
+		name     string
+		uid      string
+		store    *fakeActiveKindStore
+		wantKind Kind
+		wantNil  bool
+		wantErr  error
+		calls    int
+	}{
+		{name: "empty uid", uid: "", store: &fakeActiveKindStore{}, wantNil: true, calls: 0},
+		{name: "missing", uid: "missing", store: &fakeActiveKindStore{}, wantNil: true, calls: 1},
+		{name: "active user bot", uid: "user_bot", store: &fakeActiveKindStore{userBot: true}, wantKind: KindUserBot, calls: 1},
+		{name: "published app bot", uid: "app_bot", store: &fakeActiveKindStore{appBot: true}, wantKind: KindAppBot, calls: 1},
+		{name: "ambiguous active identity", uid: "both", store: &fakeActiveKindStore{userBot: true, appBot: true}, wantErr: ErrAmbiguousIdentity, calls: 1},
+		{name: "lookup failure", uid: "broken", store: &fakeActiveKindStore{err: dbErr}, wantErr: dbErr, calls: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Resolver{store: tt.store}
+			got, err := r.Resolve(tt.uid)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, got)
+			} else {
+				require.NoError(t, err)
+				if tt.wantNil {
+					assert.Nil(t, got)
+				} else {
+					require.NotNil(t, got)
+					assert.Equal(t, tt.uid, got.UID)
+					assert.Equal(t, tt.wantKind, got.Kind)
+				}
+			}
+			assert.Equal(t, tt.calls, tt.store.calls)
+		})
+	}
+}
+
+func TestResolverActivePreservesErrors(t *testing.T) {
+	r := &Resolver{store: &fakeActiveKindStore{userBot: true, appBot: true}}
+	active, err := r.Active("both")
+	assert.False(t, active)
+	assert.ErrorIs(t, err, ErrAmbiguousIdentity)
+}

--- a/modules/botidentity/resolver_test.go
+++ b/modules/botidentity/resolver_test.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gocraft/dbr/v2"
+	"github.com/gocraft/dbr/v2/dialect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -67,4 +70,53 @@ func TestResolverActivePreservesErrors(t *testing.T) {
 	active, err := r.Active("both")
 	assert.False(t, active)
 	assert.ErrorIs(t, err, ErrAmbiguousIdentity)
+}
+
+func TestResolverActive(t *testing.T) {
+	r := &Resolver{store: &fakeActiveKindStore{appBot: true}}
+	active, err := r.Active("app")
+	require.NoError(t, err)
+	assert.True(t, active)
+}
+
+func TestResolverUnavailable(t *testing.T) {
+	r := New(nil)
+	identity, err := r.Resolve("bot")
+	assert.Nil(t, identity)
+	assert.ErrorIs(t, err, ErrResolverUnavailable)
+}
+
+func TestDBActiveKindStore(t *testing.T) {
+	newStore := func(t *testing.T) (*dbActiveKindStore, sqlmock.Sqlmock) {
+		t.Helper()
+		rawDB, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = rawDB.Close() })
+		conn := &dbr.Connection{DB: rawDB, EventReceiver: &dbr.NullEventReceiver{}, Dialect: dialect.MySQL}
+		return &dbActiveKindStore{session: conn.NewSession(nil)}, mock
+	}
+
+	t.Run("returns both predicates", func(t *testing.T) {
+		store, mock := newStore(t)
+		mock.ExpectQuery(`(?s)SELECT.*EXISTS.*robot.*EXISTS.*app_bot`).
+			WillReturnRows(sqlmock.NewRows([]string{"user_bot", "app_bot"}).AddRow(1, 0))
+
+		userBot, appBot, err := store.activeKinds("bot")
+		require.NoError(t, err)
+		assert.True(t, userBot)
+		assert.False(t, appBot)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("preserves query error", func(t *testing.T) {
+		store, mock := newStore(t)
+		dbErr := errors.New("query failed")
+		mock.ExpectQuery(`(?s)SELECT.*EXISTS.*robot.*EXISTS.*app_bot`).WillReturnError(dbErr)
+
+		userBot, appBot, err := store.activeKinds("bot")
+		assert.False(t, userBot)
+		assert.False(t, appBot)
+		assert.ErrorIs(t, err, dbErr)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
 }

--- a/modules/cardtrust/cardtrust.go
+++ b/modules/cardtrust/cardtrust.go
@@ -10,11 +10,11 @@
 // each carried a private copy, so a hardening in one surface silently left the
 // other leaking attacker-controlled plain.
 //
-// Layering: this is a leaf that imports modules/robot only; robot and
-// incomingwebhook do NOT import it, so there is no cycle. The `iwh_` prefix is
-// re-declared here (production code must not cross-import modules/incomingwebhook
-// per its display.go layering note); a test pins it to the exported contract
-// constant.
+// Layering: this imports the table-backed modules/botidentity library only;
+// robot, app_bot, and incomingwebhook do NOT import it, so there is no cycle.
+// The `iwh_` prefix is re-declared here (production code must not cross-import
+// modules/incomingwebhook per its display.go layering note); a test pins it to
+// the exported contract constant.
 package cardtrust
 
 import (
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
-	"github.com/Mininglamp-OSS/octo-server/modules/robot"
+	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"go.uber.org/zap"
 )
@@ -39,18 +39,17 @@ const (
 	cacheCapacity = 4_096
 	// cacheTTL soft-expiry. A masking verdict is not safety-critical to the
 	// second (a deleted bot's own past cards showing plain briefly is not a
-	// threat; a forged non-bot card is never cached as trusted because
-	// ExistRobot returns false for it), so a generous window is fine. Fail-open
-	// lookups (DB error) are never cached.
+	// threat; a forged non-bot card is never cached as trusted because the
+	// authoritative resolver returns no identity), so a generous window is fine.
+	// Failed lookups are never cached.
 	cacheTTL = 60 * time.Second
 )
 
-// robotExister is the minimal robot capability cardtrust needs — narrowed from
-// robot.IService so the resolver depends only on the one method it uses (and so
-// tests can inject a stub without implementing the full service). *robot.Service
-// satisfies it.
-type robotExister interface {
-	ExistRobot(uid string) (bool, error)
+// botIdentityResolver is the minimal authoritative capability cardtrust needs.
+// The consumer owns this narrow interface so tests can inject a deterministic
+// resolver without depending on either lifecycle module.
+type botIdentityResolver interface {
+	Resolve(uid string) (*botidentity.Identity, error)
 }
 
 type verdict struct {
@@ -61,15 +60,15 @@ type verdict struct {
 // Resolver answers Trusted(fromUID). Construct ONCE per module (store on the
 // handler/struct or a package singleton) so the LRU persists across the
 // per-recipient push fan-out and across search pages — a large group's offline
-// push then costs one ExistRobot query instead of one per recipient.
+// push then costs one identity query instead of one per recipient.
 type Resolver struct {
-	svc   robotExister
-	cache *lru.Cache[string, verdict]
-	ttl   time.Duration
-	log   *zap.Logger
+	identity botIdentityResolver
+	cache    *lru.Cache[string, verdict]
+	ttl      time.Duration
+	log      *zap.Logger
 }
 
-// New builds a Resolver backed by the read-only robot service.
+// New builds a Resolver backed by the authoritative bot identity resolver.
 func New(ctx *config.Context) *Resolver {
 	c, err := lruNew(cacheCapacity)
 	if err != nil {
@@ -77,38 +76,42 @@ func New(ctx *config.Context) *Resolver {
 		// unreachable — fail loudly during init.
 		panic(fmt.Sprintf("cardtrust: cache init: %v", err))
 	}
-	return &Resolver{svc: robot.NewService(ctx), cache: c, ttl: cacheTTL, log: zap.L()}
+	return &Resolver{identity: botidentity.New(ctx), cache: c, ttl: cacheTTL, log: zap.L()}
 }
 
 // lruNew wraps the typed LRU constructor so tests can build a Resolver with an
-// injected robot.IService without going through New's robot.NewService(ctx).
+// injected identity resolver without going through New's botidentity.New(ctx).
 func lruNew(capacity int) (*lru.Cache[string, verdict], error) {
 	return lru.New[string, verdict](capacity)
 }
 
 // Trusted reports whether a type-17 message from fromUID may surface its stored
 // plain. Webhook synthetic senders (iwh_ prefix) are trusted by construction;
-// bot senders are resolved via ExistRobot (active robots only) and cached.
+// bot senders are resolved from active robot / published app_bot rows and cached.
 // **Fail-closed**: on a lookup error the sender is treated as untrusted and the
 // error verdict is NOT cached (so a transient DB blip cannot mask a legit bot's
 // cards for the whole TTL).
 func (r *Resolver) Trusted(fromUID string) bool {
+	if r == nil || fromUID == "" {
+		return false
+	}
 	if strings.HasPrefix(fromUID, webhookIDPrefix) {
 		return true
 	}
-	if r == nil {
+	if r.identity == nil || r.cache == nil {
 		return false
 	}
 	if v, ok := r.cache.Get(fromUID); ok && (r.ttl <= 0 || time.Since(v.at) <= r.ttl) {
 		return v.trusted
 	}
-	isBot, err := r.svc.ExistRobot(fromUID)
+	identity, err := r.identity.Resolve(fromUID)
 	if err != nil {
 		if r.log != nil {
 			r.log.Warn("cardtrust: sender 身份查询失败,按不可信处理", zap.Error(err), zap.String("fromUID", fromUID))
 		}
 		return false
 	}
-	r.cache.Add(fromUID, verdict{trusted: isBot, at: time.Now()})
-	return isBot
+	trusted := identity != nil
+	r.cache.Add(fromUID, verdict{trusted: trusted, at: time.Now()})
+	return trusted
 }

--- a/modules/cardtrust/cardtrust_test.go
+++ b/modules/cardtrust/cardtrust_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
 	"github.com/Mininglamp-OSS/octo-server/modules/incomingwebhook"
 	"github.com/stretchr/testify/assert"
 )
@@ -15,57 +16,79 @@ func TestWebhookPrefixConsistency(t *testing.T) {
 	assert.Equal(t, incomingwebhook.WebhookIDPrefix, webhookIDPrefix)
 }
 
-// fakeRobot 是 robot.IService.ExistRobot 的测试替身，记录调用次数以验证缓存。
-type fakeRobot struct {
-	bots  map[string]bool
+// fakeBotIdentity 是统一 bot identity resolver 的测试替身，记录调用次数以验证缓存。
+type fakeBotIdentity struct {
+	kinds map[string]botidentity.Kind
 	err   error
 	calls int
 }
 
-func (f *fakeRobot) ExistRobot(uid string) (bool, error) {
+func (f *fakeBotIdentity) Resolve(uid string) (*botidentity.Identity, error) {
 	f.calls++
 	if f.err != nil {
-		return false, f.err
+		return nil, f.err
 	}
-	return f.bots[uid], nil
+	kind, ok := f.kinds[uid]
+	if !ok {
+		return nil, nil
+	}
+	return &botidentity.Identity{UID: uid, Kind: kind}, nil
 }
 
-// newTestResolver 绕过 robot.NewService，直接注入 fake（cardtrust.New 需要
+// newTestResolver 绕过 botidentity.New，直接注入 fake（cardtrust.New 需要
 // *config.Context，测试里只关心判定 + 缓存逻辑）。
-func newTestResolver(t *testing.T, f *fakeRobot) *Resolver {
+func newTestResolver(t *testing.T, f *fakeBotIdentity) *Resolver {
 	t.Helper()
 	c, err := lruNew(cacheCapacity)
 	assert.NoError(t, err)
-	return &Resolver{svc: f, cache: c, ttl: cacheTTL}
+	return &Resolver{identity: f, cache: c, ttl: cacheTTL}
 }
 
 func TestTrustedWebhookPrefix(t *testing.T) {
-	f := &fakeRobot{}
+	f := &fakeBotIdentity{}
 	r := newTestResolver(t, f)
 	assert.True(t, r.Trusted("iwh_abc"), "webhook 合成身份可信")
-	assert.Equal(t, 0, f.calls, "iwh_ 前缀不应查 robot 表")
+	assert.Equal(t, 0, f.calls, "iwh_ 前缀不应查询 bot identity")
 }
 
 func TestTrustedBotCached(t *testing.T) {
-	f := &fakeRobot{bots: map[string]bool{"bot_x": true, "human_y": false}}
+	f := &fakeBotIdentity{kinds: map[string]botidentity.Kind{
+		"user_bot": botidentity.KindUserBot,
+		"app_bot":  botidentity.KindAppBot,
+	}}
 	r := newTestResolver(t, f)
 
-	assert.True(t, r.Trusted("bot_x"))
-	assert.True(t, r.Trusted("bot_x"), "第二次应命中缓存")
-	assert.Equal(t, 1, f.calls, "同 uid 只查一次 robot 表(缓存生效)")
+	assert.True(t, r.Trusted("user_bot"))
+	assert.True(t, r.Trusted("user_bot"), "第二次应命中缓存")
+	assert.Equal(t, 1, f.calls, "同 uid 只解析一次身份(缓存生效)")
+
+	assert.True(t, r.Trusted("app_bot"), "published App Bot 可信")
+	assert.True(t, r.Trusted("app_bot"), "App Bot 肯定裁决同样缓存")
+	assert.Equal(t, 2, f.calls)
 
 	assert.False(t, r.Trusted("human_y"), "非 bot 不可信")
 	assert.False(t, r.Trusted("human_y"))
-	assert.Equal(t, 2, f.calls, "否定裁决同样缓存")
+	assert.Equal(t, 3, f.calls, "否定裁决同样缓存")
 }
 
 func TestTrustedFailClosedNotCached(t *testing.T) {
-	f := &fakeRobot{err: errors.New("db down")}
+	f := &fakeBotIdentity{err: errors.New("db down")}
 	r := newTestResolver(t, f)
 	assert.False(t, r.Trusted("bot_z"), "查询失败 → fail-closed 不可信")
 	// 错误裁决不得缓存：DB 恢复后应重新查询而非粘住 [卡片]
 	f.err = nil
-	f.bots = map[string]bool{"bot_z": true}
+	f.kinds = map[string]botidentity.Kind{"bot_z": botidentity.KindAppBot}
 	assert.True(t, r.Trusted("bot_z"), "错误裁决不缓存,恢复后重查得到 true")
 	assert.Equal(t, 2, f.calls)
+}
+
+func TestTrustedFailClosedForEmptyNilAndAmbiguousIdentity(t *testing.T) {
+	var nilResolver *Resolver
+	assert.False(t, nilResolver.Trusted("bot"))
+
+	f := &fakeBotIdentity{err: botidentity.ErrAmbiguousIdentity}
+	r := newTestResolver(t, f)
+	assert.False(t, r.Trusted(""), "empty uid 不可信")
+	assert.False(t, r.Trusted("ambiguous"), "跨表身份冲突必须 fail closed")
+	assert.Equal(t, 1, f.calls, "empty uid 应在本地拒绝，不查询 resolver")
 }

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkevent"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
+	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
 	"github.com/Mininglamp-OSS/octo-server/modules/channel"
 	chservice "github.com/Mininglamp-OSS/octo-server/modules/channel/service"
 	commonapi "github.com/Mininglamp-OSS/octo-server/modules/common"
@@ -204,6 +205,10 @@ func truncateRunes(s string, maxRunes int) string {
 	return s
 }
 
+type botIdentityResolver interface {
+	Resolve(uid string) (*botidentity.Identity, error)
+}
+
 // Message 消息相关API
 type Message struct {
 	ctx *config.Context
@@ -221,7 +226,10 @@ type Message struct {
 	pinnedDB            *pinnedDB
 	userService         user.IService
 	groupService        group.IService
-	// robotService 仅用于 GetCreatorUID (YUJ-60 允许 bot 创建者撤回自己 bot 发的消息)。
+	// botIdentity performs live sender authorization for card/action. It has no
+	// cache so App Bot unpublish/revocation takes effect on the next first action.
+	botIdentity botIdentityResolver
+	// robotService retains robot-specific owner, mention, and event-queue operations.
 	robotService   robot.IService
 	commonService  commonapi.IService
 	fileService    file.IService
@@ -272,7 +280,8 @@ func New(ctx *config.Context) *Message {
 		remindersDB:         newRemindersDB(ctx),
 		pinnedDB:            newPinnedDB(ctx),
 		userService:         user.NewService(ctx),
-		// robotService: 只读 robot 服务，用于 hasRevokePermission 判断 bot 所有者。
+		botIdentity:         botidentity.New(ctx),
+		// robotService: robot owner/mention lookups and typed event enqueue.
 		robotService:   robot.NewService(ctx),
 		commonService:  commonapi.NewService(ctx),
 		fileService:    file.NewService(ctx),

--- a/modules/message/api_card_action.go
+++ b/modules/message/api_card_action.go
@@ -87,16 +87,22 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 		return
 	}
 
-	// D3 ③sender 必须是 bot 身份（layer (c)）。iwh_ webhook 合成发送者不是 robot
-	// （D7：webhook 卡片无事件消费端）、被绕过渲染门禁的人类发送者卡片，都在此
-	// fail-closed —— 伪造卡片点了也没有任何效果。
-	senderIsBot, err := m.robotService.ExistRobot(msgM.FromUID)
+	// D3 ③sender 必须是当前有效 bot 身份（layer (c)）：robot.status=1 或
+	// app_bot.status=1。这里每次首击都实时解析，不使用展示缓存，确保 App Bot
+	// unpublish/revoke 立即阻止副作用。iwh_ webhook 没有事件消费端、人类发送者也
+	// 没有权威 bot 行，均 fail-closed。
+	if m.botIdentity == nil {
+		m.Error("bot identity resolver 未初始化", zap.String("fromUID", msgM.FromUID))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		return
+	}
+	senderIdentity, err := m.botIdentity.Resolve(msgM.FromUID)
 	if err != nil {
 		m.Error("查询发送者 bot 身份失败", zap.Error(err), zap.String("fromUID", msgM.FromUID))
 		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
-	if !senderIsBot {
+	if senderIdentity == nil {
 		m.Warn("卡片动作目标消息 sender 非 bot,拒绝", zap.String("fromUID", msgM.FromUID), zap.String("messageID", req.MessageID))
 		httperr.ResponseErrorL(c, errcode.ErrMessageCardActionInvalid, nil, nil)
 		return

--- a/modules/message/api_card_action_test.go
+++ b/modules/message/api_card_action_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/go-redis/redis"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const cardActionBotUID = "bot_card_1"
@@ -99,6 +100,14 @@ func seedCardBot(t *testing.T, ctx *config.Context, robotID string) {
 	t.Helper()
 	_, err := ctx.DB().InsertBySql("insert into robot(robot_id,status) values(?,1)", robotID).Exec()
 	assert.NoError(t, err)
+}
+
+func seedCardAppBot(t *testing.T, ctx *config.Context, id, uid, token string, status int) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(`
+		INSERT INTO app_bot(id,uid,display_name,scope,status,token,created_by)
+		VALUES(?,?,?,'platform',?,?,?)`, id, uid, uid, status, token, "owner").Exec()
+	require.NoError(t, err)
 }
 
 func seedCardMessage(t *testing.T, ctx *config.Context, messageID int64, fromUID, channelID string, channelType uint8, payload []byte) {
@@ -210,6 +219,113 @@ func TestCardActionEndToEndAndIdempotency(t *testing.T) {
 	claimTTL, err := rds.TTL(claimKey).Result()
 	assert.NoError(t, err)
 	assert.Greater(t, claimTTL, time.Hour, "confirm 后应为 24h 级 TTL,而非 60s pending")
+}
+
+func TestCardActionAppBotEventPollAndAckLifecycle(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+	resetCardActionState(t, ctx)
+
+	const (
+		appID    = "card_action_app"
+		appUID   = "card_action_app_bot"
+		appToken = "app_card_action_lifecycle_token"
+	)
+	seedCardAppBot(t, ctx, appID, appUID, appToken, 1)
+	fake := common.GetFakeChannelIDWith(testutil.UID, appUID)
+	seedCardMessage(t, ctx, 9051, appUID, fake, common.ChannelTypePerson.Uint8(), cardV2EnvelopeJSON(t, "approve_btn"))
+
+	actionBody := map[string]interface{}{
+		"message_id":   "9051",
+		"channel_id":   appUID,
+		"channel_type": common.ChannelTypePerson.Uint8(),
+		"action_id":    "approve_btn",
+		"inputs":       map[string]interface{}{"comment": "ship it"},
+		"client_token": "app-action-1",
+	}
+	postAction := func() *httptest.ResponseRecorder {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodPost, "/v1/message/card/action", bytes.NewReader([]byte(util.ToJson(actionBody))))
+		require.NoError(t, err)
+		req.Header.Set("token", testutil.Token)
+		s.GetRoute().ServeHTTP(w, req)
+		return w
+	}
+	poll := func() (*httptest.ResponseRecorder, struct {
+		Status  int `json:"status"`
+		Results []struct {
+			EventID   int64                  `json:"event_id"`
+			EventType string                 `json:"event_type"`
+			EventData map[string]interface{} `json:"event_data"`
+		} `json:"results"`
+	}) {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodPost, "/v1/bot/events", strings.NewReader(`{"event_id":0,"limit":20}`))
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+appToken)
+		s.GetRoute().ServeHTTP(w, req)
+		var body struct {
+			Status  int `json:"status"`
+			Results []struct {
+				EventID   int64                  `json:"event_id"`
+				EventType string                 `json:"event_type"`
+				EventData map[string]interface{} `json:"event_data"`
+			} `json:"results"`
+		}
+		if w.Code == http.StatusOK {
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		}
+		return w, body
+	}
+
+	// Live authorization: unpublish must block a first attempt immediately and
+	// must not enqueue or claim the action.
+	_, err := ctx.DB().Exec("UPDATE app_bot SET status=2 WHERE uid=?", appUID)
+	require.NoError(t, err)
+	w := postAction()
+	assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "Invalid card action.")
+	rds := redis.NewClient(&redis.Options{Addr: ctx.GetConfig().DB.RedisAddr, Password: ctx.GetConfig().DB.RedisPass})
+	defer rds.Close()
+	n, err := rds.ZCard("robotEvent:" + appUID).Result()
+	require.NoError(t, err)
+	assert.Zero(t, n)
+
+	// Re-publishing permits the same previously unclaimed action.
+	_, err = ctx.DB().Exec("UPDATE app_bot SET status=1 WHERE uid=?", appUID)
+	require.NoError(t, err)
+	w = postAction()
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), `"accepted":true`)
+	assert.Contains(t, w.Body.String(), `"replay":false`)
+	n, err = rds.ZCard("robotEvent:" + appUID).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n, "exactly one App Bot event must be queued")
+
+	pollW, events := poll()
+	require.Equal(t, http.StatusOK, pollW.Code, pollW.Body.String())
+	require.Equal(t, 1, events.Status)
+	require.Len(t, events.Results, 1)
+	event := events.Results[0]
+	assert.Equal(t, cardmsg.EventTypeCardAction, event.EventType)
+	assert.Equal(t, "9051", event.EventData["message_id"])
+	assert.Equal(t, appUID, event.EventData["channel_id"])
+	assert.Equal(t, testutil.UID, event.EventData["operator_uid"])
+
+	ackW := httptest.NewRecorder()
+	ackReq, err := http.NewRequest(http.MethodPost, fmt.Sprintf("/v1/bot/events/%d/ack", event.EventID), nil)
+	require.NoError(t, err)
+	ackReq.Header.Set("Authorization", "Bearer "+appToken)
+	s.GetRoute().ServeHTTP(ackW, ackReq)
+	require.Equal(t, http.StatusOK, ackW.Code, ackW.Body.String())
+
+	pollW, events = poll()
+	require.Equal(t, http.StatusOK, pollW.Code, pollW.Body.String())
+	assert.Empty(t, events.Results, "ACKed App Bot event must not be returned again")
 }
 
 func TestCardActionTrustModel(t *testing.T) {

--- a/modules/message/api_card_action_test.go
+++ b/modules/message/api_card_action_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/app_bot"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/robot"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
@@ -105,8 +106,8 @@ func seedCardBot(t *testing.T, ctx *config.Context, robotID string) {
 func seedCardAppBot(t *testing.T, ctx *config.Context, id, uid, token string, status int) {
 	t.Helper()
 	_, err := ctx.DB().InsertBySql(`
-		INSERT INTO app_bot(id,uid,display_name,scope,status,token,created_by)
-		VALUES(?,?,?,'platform',?,?,?)`, id, uid, uid, status, token, "owner").Exec()
+		INSERT INTO app_bot(id,uid,display_name,scope,space_id,status,token,created_by)
+		VALUES(?,?,?,'platform','',?,?,?)`, id, uid, uid, status, token, "owner").Exec()
 	require.NoError(t, err)
 }
 
@@ -223,6 +224,7 @@ func TestCardActionEndToEndAndIdempotency(t *testing.T) {
 
 func TestCardActionAppBotEventPollAndAckLifecycle(t *testing.T) {
 	t.Setenv(cardmsg.EnvEnabled, "true")
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
 	s, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	defer func() { _ = testutil.CleanAllTables(ctx) }()

--- a/modules/messages_search/card_appbot_integration_test.go
+++ b/modules/messages_search/card_appbot_integration_test.go
@@ -1,0 +1,38 @@
+//go:build integration
+
+package messages_search
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/cardtrust"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSingleMessageHitPublishedAppBotProjection(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+
+	_, err := ctx.DB().InsertBySql(`
+		INSERT INTO app_bot(id,uid,display_name,scope,status,token,created_by)
+		VALUES('search_app','app_search_1','Search App','platform',1,'app_search_token_1','owner')`).Exec()
+	require.NoError(t, err)
+
+	cardType := payloadTypeCard
+	doc := Doc{
+		MessageID: 9017,
+		From:      "app_search_1",
+		Payload:   &Payload{Type: &cardType},
+		PayloadRaw: json.RawMessage(
+			`{"type":17,"card":{"body":[{"type":"TextBlock","text":"内部字段"}]},"plain":"App Bot 审批单","card_version":"1.5","profile":"octo/v1"}`,
+		),
+	}
+
+	h := &Handler{cardTrust: cardtrust.New(ctx)}
+	mh := h.singleMessageHit(doc, "g_1", 0, nil)
+	assert.Equal(t, "App Bot 审批单", mh.Snippet)
+}

--- a/modules/messages_search/card_appbot_integration_test.go
+++ b/modules/messages_search/card_appbot_integration_test.go
@@ -13,11 +13,27 @@ import (
 )
 
 func TestSingleMessageHitPublishedAppBotProjection(t *testing.T) {
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
 	_, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	defer func() { _ = testutil.CleanAllTables(ctx) }()
+	_, err := ctx.DB().Exec(`CREATE TABLE IF NOT EXISTS app_bot (
+		id VARCHAR(40) PRIMARY KEY,
+		uid VARCHAR(40) UNIQUE NOT NULL,
+		display_name VARCHAR(100) NOT NULL,
+		description VARCHAR(500) DEFAULT '',
+		avatar VARCHAR(200) DEFAULT '',
+		scope VARCHAR(20) NOT NULL DEFAULT 'platform',
+		space_id VARCHAR(40) DEFAULT NULL,
+		status TINYINT NOT NULL DEFAULT 0,
+		token VARCHAR(100) UNIQUE NOT NULL,
+		created_by VARCHAR(40) NOT NULL,
+		created_at DATETIME NOT NULL DEFAULT NOW(),
+		updated_at DATETIME NOT NULL DEFAULT NOW() ON UPDATE NOW()
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci`)
+	require.NoError(t, err)
 
-	_, err := ctx.DB().InsertBySql(`
+	_, err = ctx.DB().InsertBySql(`
 		INSERT INTO app_bot(id,uid,display_name,scope,status,token,created_by)
 		VALUES('search_app','app_search_1','Search App','platform',1,'app_search_token_1','owner')`).Exec()
 	require.NoError(t, err)

--- a/modules/webhook/common_card_test.go
+++ b/modules/webhook/common_card_test.go
@@ -43,6 +43,20 @@ func TestCardSenderTrusted(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, cardSenderTrusted(ctx, "bot_push_1"))
 
+	// published app_bot 表在册（status=1）→ 可信；无需 robot 表兼容行。
+	_, err = ctx.DB().InsertBySql(`
+		INSERT INTO app_bot(id,uid,display_name,scope,status,token,created_by)
+		VALUES('push_app','app_push_1','Push App','platform',1,'app_push_token_1','owner')`).Exec()
+	assert.NoError(t, err)
+	assert.True(t, cardSenderTrusted(ctx, "app_push_1"))
+
+	// user.robot 只是展示元数据，不能单独建立卡片信任。
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO user(uid,name,robot,status) VALUES('presentation_only_push','Presentation Only',1,1)",
+	).Exec()
+	assert.NoError(t, err)
+	assert.False(t, cardSenderTrusted(ctx, "presentation_only_push"))
+
 	// 普通用户 → 不可信（直连长连接可伪造 type-17,plain 攻击者可控）
 	assert.False(t, cardSenderTrusted(ctx, "human_9527"))
 }
@@ -55,6 +69,10 @@ func TestGetMessageAlertCard(t *testing.T) {
 	ctx.GetConfig().Push.ContentDetailOn = true
 
 	_, err := ctx.DB().InsertBySql("insert into robot(robot_id,status) values(?,1)", "bot_push_2").Exec()
+	assert.NoError(t, err)
+	_, err = ctx.DB().InsertBySql(`
+		INSERT INTO app_bot(id,uid,display_name,scope,status,token,created_by)
+		VALUES('push_alert_app','app_push_alert','Push Alert App','platform',1,'app_push_alert_token','owner')`).Exec()
 	assert.NoError(t, err)
 
 	payload := []byte(`{"type":17,"card":{"body":[{"type":"TextBlock","text":"内部字段"}]},"plain":"审批单 #42:待审批","card_version":"1.5","profile":"octo/v1"}`)
@@ -76,6 +94,10 @@ func TestGetMessageAlertCard(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "审批单 #42:待审批", alert, "bot sender 推送正文 = 权威 plain")
 	assert.NotContains(t, alert, "{", "APNs/FCM alert 不得出现原始卡 JSON")
+
+	alert, err = getMessageAlert(mk("app_push_alert"), toUser, ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "审批单 #42:待审批", alert, "published App Bot 推送正文 = 权威 plain")
 
 	alert, err = getMessageAlert(mk("human_9527"), toUser, ctx)
 	assert.NoError(t, err)

--- a/modules/webhook/common_card_test.go
+++ b/modules/webhook/common_card_test.go
@@ -9,11 +9,31 @@ import (
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/stretchr/testify/assert"
 )
+
+func ensurePushAppBotTable(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	_, err := ctx.DB().Exec(`CREATE TABLE IF NOT EXISTS app_bot (
+		id VARCHAR(40) PRIMARY KEY,
+		uid VARCHAR(40) UNIQUE NOT NULL,
+		display_name VARCHAR(100) NOT NULL,
+		description VARCHAR(500) DEFAULT '',
+		avatar VARCHAR(200) DEFAULT '',
+		scope VARCHAR(20) NOT NULL DEFAULT 'platform',
+		space_id VARCHAR(40) DEFAULT NULL,
+		status TINYINT NOT NULL DEFAULT 0,
+		token VARCHAR(100) UNIQUE NOT NULL,
+		created_by VARCHAR(40) NOT NULL,
+		created_at DATETIME NOT NULL DEFAULT NOW(),
+		updated_at DATETIME NOT NULL DEFAULT NOW() ON UPDATE NOW()
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci`)
+	assert.NoError(t, err)
+}
 
 // 验收(PR#543 review B1):type-17 必须通过 containSupportType 门,否则离线推送
 // 在 getMessageAlert 之前就把卡片当「不支持类型」丢弃 —— 下面的 alert 遮蔽分支
@@ -34,6 +54,7 @@ func TestCardTypeReachesPushGate(t *testing.T) {
 func TestCardSenderTrusted(t *testing.T) {
 	_, ctx := testutil.NewTestServer()
 	defer func() { _ = testutil.CleanAllTables(ctx) }()
+	ensurePushAppBotTable(t, ctx)
 
 	// iwh_ 合成身份 → 可信（无需查库）
 	assert.True(t, cardSenderTrusted(ctx, "iwh_abc123"))
@@ -66,6 +87,7 @@ func TestCardSenderTrusted(t *testing.T) {
 func TestGetMessageAlertCard(t *testing.T) {
 	_, ctx := testutil.NewTestServer()
 	defer func() { _ = testutil.CleanAllTables(ctx) }()
+	ensurePushAppBotTable(t, ctx)
 	ctx.GetConfig().Push.ContentDetailOn = true
 
 	_, err := ctx.DB().InsertBySql("insert into robot(robot_id,status) values(?,1)", "bot_push_2").Exec()


### PR DESCRIPTION
## Summary

Close the P0 trust-chain gap where App Bots could send interactive cards but server-side display masking and card actions only recognized `robot` rows.

## Related Issue

Closes #571

## Linked Spec

- Primary implementation: `.octospec/tasks/card-message-appbot-trust/brief.md`
- Planning-only follow-up: `.octospec/tasks/card-message-internal-dispatch/brief.md`

## Changes

- Add a cache-free `modules/botidentity` resolver over active `robot` and published `app_bot` rows, with same-statement ambiguity detection and fail-closed errors.
- Rewire `modules/cardtrust` to the unified resolver while preserving the existing bounded 60-second display cache and incoming-webhook shortcut.
- Resolve the stored card sender live in `POST /v1/message/card/action`; keep the existing robot event queue and wire contract unchanged.
- Cover App Bot display projection and the full action -> event poll -> ACK lifecycle, including immediate unpublish rejection and republish recovery.
- Record the App Bot trust octospec context, verification evidence, and shared journal.
- Add a separate planning-only P0 brief for `internal/carddispatch`, with a mandatory pilot-producer gate; no dispatcher implementation is included in this PR.

## Testing

- [x] `go test -race ./modules/botidentity/... ./modules/cardtrust/...`
- [x] `go test -cover ./modules/botidentity/...` (96.2% statements)
- [x] `go test -tags integration ./modules/botidentity -run '^TestResolverAgainstAuthoritativeBotTables$' -count=1`
- [x] `go test -tags integration ./modules/message -run '^TestCardAction' -count=1`
- [x] Published App Bot webhook-push and message-search projection tests
- [x] `go test ./modules/bot_api/...`
- [x] `go test ./pkg/cardmsg/... ./modules/cardtrust/...`
- [x] `go vet ./modules/botidentity/... ./modules/cardtrust/... ./modules/message`
- [x] `make i18n-extract-check && make i18n-lint`
- [x] `git diff --check origin/main`

`golangci-lint` is not installed in this local workspace; CI remains the authoritative full lint gate.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   It replaces the two robot-only card trust checks with one authoritative resolver. A UID is trusted only when `robot.status=1` or `app_bot.status=1`; `user.robot=1` never authorizes. Display consumers retain their existing short cache, while card actions resolve live state before any idempotency claim or event side effect. All channel, Space, membership, visibility, revoke/delete, input, and event ownership gates remain unchanged.

2. **What could break because of it (dependents + failure mode)?**

   A resolver query failure now masks display text and returns the existing query-failed envelope for actions, which is intentionally fail-closed. A corrupt UID active in both tables is also rejected instead of receiving an implicit precedence. The new query adds one indexed statement on first display-cache miss and on each first action attempt; no new cache, queue, route, migration, or wire field is introduced.

3. **How do you know it works (specific test/repro/trace)?**

   The RED checkpoint reproduced the missing resolver and App Bot action rejection. The GREEN suites cover both bot kinds, inactive/missing/presentation-only/ambiguous/error identities, cache retry behavior, push/search authoritative `plain`, and the HTTP/Redis flow: unpublished App Bot rejects with no event, republish accepts exactly once, the same App Bot token polls one `card_action`, ACK removes it, and the next poll is empty. The complete existing `TestCardAction*` matrix remains green.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
