### PR TITLE
feat(common): expose dmloop_on / dmpersonal_on launch flags via appconfig

### DIFF
--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -390,6 +390,8 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 			StickerCustomEnabled:   cn.systemSettings.StickerCustomEnabled(),
 			StickerHandleRequired:  cn.systemSettings.StickerHandleRequired(),
 			DocsOn:                 cn.systemSettings.DocsEnabled(),
+			DmloopOn:               cn.systemSettings.DmloopEnabled(),
+			DmpersonalOn:           cn.systemSettings.DmpersonalEnabled(),
 			// Sticker 上限:短路分支同样下发,让老客户端在管理台放宽/收窄后
 			// 也能立刻拿到最新值。
 			StickerUploadLimits: buildStickerUploadLimitsResp(cn.systemSettings),
@@ -436,6 +438,8 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 		StickerCustomEnabled:   cn.systemSettings.StickerCustomEnabled(),
 		StickerHandleRequired:  cn.systemSettings.StickerHandleRequired(),
 		DocsOn:                 cn.systemSettings.DocsEnabled(),
+		DmloopOn:               cn.systemSettings.DmloopEnabled(),
+		DmpersonalOn:           cn.systemSettings.DmpersonalEnabled(),
 		// Sticker 上限:客户端本地预校验用,兜底仍在服务端 modules/file 侧。
 		StickerUploadLimits: buildStickerUploadLimitsResp(cn.systemSettings),
 	})
@@ -808,6 +812,13 @@ type appConfigResp struct {
 	// 与 app_config.version 解耦的原因同 LocalLoginOff / SearchEnabled：运维切展示
 	// 策略后老客户端命中 version 短路分支也必须拿到最新值，故两个分支都下发。
 	DocsOn bool `json:"docs_on"`
+
+	// dmloop.enabled / dmpersonal.enabled；默认 false —— loop(回路)与「我的/运行时」入口在
+	// 后端服务就绪前先隐藏,上线后由管理台切对应 system_setting 灰度放开。两者分开:
+	// 「我的」将重设计脱离 loop、可独立放量。只表达展示策略,不承担服务端鉴权。与 app_config.version
+	// 解耦(同 DocsOn):运维切策略后老客户端命中 version 短路分支也须拿到最新值,故两分支都下发。
+	DmloopOn     bool `json:"dmloop_on"`
+	DmpersonalOn bool `json:"dmpersonal_on"`
 
 	// StickerUploadLimits 是自定义贴纸上传的操作端可调上限，与 sticker.upload_*
 	// system_setting 同源（SystemSettings.StickerUpload{MaxSizeKB,MaxDimension,

--- a/modules/common/api_test.go
+++ b/modules/common/api_test.go
@@ -807,6 +807,92 @@ func TestGetAppConfig_DocsOn_OnVersionShortCircuit(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"docs_on":true`)
 }
 
+// setModuleEnabledSetting upserts a `<category>.enabled` bool system_setting and
+// reloads the shared snapshot. Generic sibling of setDocsEnabledSetting for the
+// dmloop / dmpersonal launch flags. Call AFTER cleanAllTablesAndReloadSettings.
+func setModuleEnabledSetting(t *testing.T, ctx *config.Context, category string, enabled bool) {
+	t.Helper()
+	v := "0"
+	if enabled {
+		v = "1"
+	}
+	_, err := ctx.DB().InsertInto("system_setting").
+		Columns("category", "key_name", "value", "value_type").
+		Values(category, "enabled", v, "bool").Exec()
+	require.NoError(t, err)
+	require.NoError(t, EnsureSystemSettings(ctx).Reload())
+}
+
+// appconfig 必须下发 dmloop_on / dmpersonal_on:值来源于 system_setting dmloop.enabled /
+// dmpersonal.enabled。默认 false,客户端据此隐藏「回路」「我的/运行时」入口(后端服务上线前)。
+func TestGetAppConfig_LoopFlags_DefaultFalse(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"dmloop_on":false`)
+	assert.Contains(t, w.Body.String(), `"dmpersonal_on":false`)
+}
+
+// 两个开关独立:dmloop.enabled=true 只放开「回路」,dmpersonal 保持默认关。
+func TestGetAppConfig_DmloopOn_TrueIndependentOfPersonal(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	setModuleEnabledSetting(t, ctx, "dmloop", true)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"dmloop_on":true`)
+	assert.Contains(t, w.Body.String(), `"dmpersonal_on":false`)
+}
+
+// dmpersonal.enabled=true 只放开「我的/运行时」,dmloop 保持默认关(证明两开关解耦)。
+func TestGetAppConfig_DmpersonalOn_TrueIndependentOfLoop(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	setModuleEnabledSetting(t, ctx, "dmpersonal", true)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"dmpersonal_on":true`)
+	assert.Contains(t, w.Body.String(), `"dmloop_on":false`)
+}
+
+// version 短路分支同样下发两开关:展示开关须与 app_config.version 解耦,避免 admin 切换后
+// 老客户端命中版本短路而继续用旧值(同 docs_on)。
+func TestGetAppConfig_LoopFlags_OnVersionShortCircuit(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	setModuleEnabledSetting(t, ctx, "dmloop", true)
+	setModuleEnabledSetting(t, ctx, "dmpersonal", true)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig?version=99999999", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"dmloop_on":true`)
+	assert.Contains(t, w.Body.String(), `"dmpersonal_on":true`)
+}
+
 // setStickerUploadLimitsSettings upserts the three sticker upload knobs
 // (size KB / max dim / allowed formats CSV) and reloads the shared snapshot.
 // Passing "" for any of them skips writing that row so tests can exercise the

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -156,6 +156,17 @@ var systemSettingSchema = []settingDef{
 	{Category: "docs", Key: "enabled", Type: settingTypeBool, Description: "是否向客户端展示文档(docs)模块入口（octo-docs-backend 上线前默认关闭）",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.DocsEnabled()) }},
 
+	// Loop(回路)模块展示开关。loop 依赖后端服务 + fleet 代理 + daemon runtime 一整套,未就绪前
+	// 默认关闭;feature 分支合入 main 也不暴露,上线后由管理台切 dmloop.enabled 灰度放量。仅表达
+	// 展示策略,不承担服务端鉴权(/fleet 鉴权在后端)。经 GET /v1/common/appconfig 的 dmloop_on 下发给客户端。
+	{Category: "dmloop", Key: "enabled", Type: settingTypeBool, Description: "是否向客户端展示 Loop(回路)模块入口（后端服务上线前默认关闭）",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.DmloopEnabled()) }},
+
+	// 「我的 / 运行时」模块展示开关。与 dmloop.enabled 分开:「我的」后续会重新设计、脱离
+	// loop 独立演进,故独立门控以便分阶段放量。默认关闭。经 appconfig 的 dmpersonal_on 下发。
+	{Category: "dmpersonal", Key: "enabled", Type: settingTypeBool, Description: "是否向客户端展示「我的/运行时」模块入口（默认关闭；与 dmloop 分开以便独立放量）",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.DmpersonalEnabled()) }},
+
 	// 自定义贴纸上传限制（sticker-upload-compression 任务）。原先硬编码在
 	// modules/file/const.go；挪进 system_setting 后可灰度/回滚，且每键都有
 	// 服务端硬上限（stickerUpload*HardCap / stickerCompress*HardCap），误配也不会

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -793,6 +793,21 @@ func (s *SystemSettings) DocsEnabled() bool {
 	return s.getBool("docs", "enabled", false)
 }
 
+// DmloopEnabled reports whether the Loop(回路)module entry should be shown to
+// clients. Default false — the loop feature (backend service + fleet proxy +
+// daemon runtimes) stays hidden until ops flips dmloop.enabled after those deps
+// are deployed. Display policy only; /fleet auth lives in the backend.
+func (s *SystemSettings) DmloopEnabled() bool {
+	return s.getBool("dmloop", "enabled", false)
+}
+
+// DmpersonalEnabled reports whether the「我的/运行时」(personal) module entry
+// should be shown. Kept separate from dmloop.enabled because 我的 will be
+// redesigned to decouple from loop and may roll out on its own schedule.
+func (s *SystemSettings) DmpersonalEnabled() bool {
+	return s.getBool("dmpersonal", "enabled", false)
+}
+
 // ---------------------------------------------------------------------------
 // Custom-sticker upload constraints + optional server-side compression
 // (sticker-upload-compression task).


### PR DESCRIPTION
Backend half of the loop launch switch (paired with octo-web PR #689). Mirrors the existing `docs_on` appconfig switch so the web client can hide the 回路 / 我的 NavRail entries until ops enables them after the loop backend + its deps are deployed. Fail-safe default off.

## What
- `system_settings.go`: `DmloopEnabled()` / `DmpersonalEnabled()` getters (`getBool(category,"enabled",false)`, mirror `DocsEnabled()`).
- `system_setting_schema.go`: `dmloop.enabled` / `dmpersonal.enabled` schema entries (admin-tunable, hot-reload).
- `api.go` `AppConfigResp`: `DmloopOn` / `DmpersonalOn` (`json:"dmloop_on"`/`"dmpersonal_on"`), populated in **both** the version-short-circuit branch and the full response (same as `DocsOn` — decoupled from `app_config.version` so ops toggles reach old clients that hit the short-circuit).
- `api_test.go`: default-false, per-flag independence, and version-short-circuit tests (mirror the `docs_on` suite).

**Two independent flags** because 我的/运行时 will be redesigned to decouple from loop and may roll out on its own schedule.

Display policy only — /fleet auth stays in the backend.

## Blast radius (Rule 8)
Additive: two new system_setting keys + two new appconfig response fields. No change to existing fields/behavior; existing consumers (docsOn etc.) untouched. Both population sites updated (verified).

## Verification
- `go build ./modules/common/...` + `go vet` clean.
- Unit tests mirror the proven `docs_on` suite (both branches); they need the CI MySQL/Redis test DB (local dev MySQL is on :23306, tests expect :3306), so they run in CI.
- **Real-env e2e** (dev): rebuilt + restarted dev server on this branch, set system_setting dmloop.enabled=1 + dmpersonal.enabled=1, then the web client's `/v1/common/appconfig` returned `dmloop_on:true`/`dmpersonal_on:true` and the 回路/我的 NavRail entries appeared; absent → hidden (default false).
- Claude code-reviewer: clean (verified both population sites + getters/schema). Codex adversarial-review: approve.

Ops enables via the admin system-settings API (POST /v1/manager/common/system_setting) — no code deploy to flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)