### PR TITLE
feat(loop): gate Loop & 我的/运行时 entries behind appconfig launch flags

### DIFF
--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -390,6 +390,8 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 			StickerCustomEnabled:   cn.systemSettings.StickerCustomEnabled(),
 			StickerHandleRequired:  cn.systemSettings.StickerHandleRequired(),
 			DocsOn:                 cn.systemSettings.DocsEnabled(),
+			DmloopOn:               cn.systemSettings.DmloopEnabled(),
+			DmpersonalOn:           cn.systemSettings.DmpersonalEnabled(),
 			// Sticker 上限:短路分支同样下发,让老客户端在管理台放宽/收窄后
 			// 也能立刻拿到最新值。
 			StickerUploadLimits: buildStickerUploadLimitsResp(cn.systemSettings),
@@ -436,6 +438,8 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 		StickerCustomEnabled:   cn.systemSettings.StickerCustomEnabled(),
 		StickerHandleRequired:  cn.systemSettings.StickerHandleRequired(),
 		DocsOn:                 cn.systemSettings.DocsEnabled(),
+		DmloopOn:               cn.systemSettings.DmloopEnabled(),
+		DmpersonalOn:           cn.systemSettings.DmpersonalEnabled(),
 		// Sticker 上限:客户端本地预校验用,兜底仍在服务端 modules/file 侧。
 		StickerUploadLimits: buildStickerUploadLimitsResp(cn.systemSettings),
 	})
@@ -808,6 +812,13 @@ type appConfigResp struct {
 	// 与 app_config.version 解耦的原因同 LocalLoginOff / SearchEnabled：运维切展示
 	// 策略后老客户端命中 version 短路分支也必须拿到最新值，故两个分支都下发。
 	DocsOn bool `json:"docs_on"`
+
+	// dmloop.enabled / dmpersonal.enabled；默认 false —— loop(回路)与「我的/运行时」入口在
+	// 后端服务就绪前先隐藏,上线后由管理台切对应 system_setting 灰度放开。两者分开:
+	// 「我的」将重设计脱离 loop、可独立放量。只表达展示策略,不承担服务端鉴权。与 app_config.version
+	// 解耦(同 DocsOn):运维切策略后老客户端命中 version 短路分支也须拿到最新值,故两分支都下发。
+	DmloopOn     bool `json:"dmloop_on"`
+	DmpersonalOn bool `json:"dmpersonal_on"`
 
 	// StickerUploadLimits 是自定义贴纸上传的操作端可调上限，与 sticker.upload_*
 	// system_setting 同源（SystemSettings.StickerUpload{MaxSizeKB,MaxDimension,

--- a/modules/common/api_test.go
+++ b/modules/common/api_test.go
@@ -807,6 +807,92 @@ func TestGetAppConfig_DocsOn_OnVersionShortCircuit(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"docs_on":true`)
 }
 
+// setModuleEnabledSetting upserts a `<category>.enabled` bool system_setting and
+// reloads the shared snapshot. Generic sibling of setDocsEnabledSetting for the
+// dmloop / dmpersonal launch flags. Call AFTER cleanAllTablesAndReloadSettings.
+func setModuleEnabledSetting(t *testing.T, ctx *config.Context, category string, enabled bool) {
+	t.Helper()
+	v := "0"
+	if enabled {
+		v = "1"
+	}
+	_, err := ctx.DB().InsertInto("system_setting").
+		Columns("category", "key_name", "value", "value_type").
+		Values(category, "enabled", v, "bool").Exec()
+	require.NoError(t, err)
+	require.NoError(t, EnsureSystemSettings(ctx).Reload())
+}
+
+// appconfig 必须下发 dmloop_on / dmpersonal_on:值来源于 system_setting dmloop.enabled /
+// dmpersonal.enabled。默认 false,客户端据此隐藏「回路」「我的/运行时」入口(后端服务上线前)。
+func TestGetAppConfig_LoopFlags_DefaultFalse(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"dmloop_on":false`)
+	assert.Contains(t, w.Body.String(), `"dmpersonal_on":false`)
+}
+
+// 两个开关独立:dmloop.enabled=true 只放开「回路」,dmpersonal 保持默认关。
+func TestGetAppConfig_DmloopOn_TrueIndependentOfPersonal(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	setModuleEnabledSetting(t, ctx, "dmloop", true)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"dmloop_on":true`)
+	assert.Contains(t, w.Body.String(), `"dmpersonal_on":false`)
+}
+
+// dmpersonal.enabled=true 只放开「我的/运行时」,dmloop 保持默认关(证明两开关解耦)。
+func TestGetAppConfig_DmpersonalOn_TrueIndependentOfLoop(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	setModuleEnabledSetting(t, ctx, "dmpersonal", true)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"dmpersonal_on":true`)
+	assert.Contains(t, w.Body.String(), `"dmloop_on":false`)
+}
+
+// version 短路分支同样下发两开关:展示开关须与 app_config.version 解耦,避免 admin 切换后
+// 老客户端命中版本短路而继续用旧值(同 docs_on)。
+func TestGetAppConfig_LoopFlags_OnVersionShortCircuit(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	setModuleEnabledSetting(t, ctx, "dmloop", true)
+	setModuleEnabledSetting(t, ctx, "dmpersonal", true)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig?version=99999999", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"dmloop_on":true`)
+	assert.Contains(t, w.Body.String(), `"dmpersonal_on":true`)
+}
+
 // setStickerUploadLimitsSettings upserts the three sticker upload knobs
 // (size KB / max dim / allowed formats CSV) and reloads the shared snapshot.
 // Passing "" for any of them skips writing that row so tests can exercise the

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -156,6 +156,17 @@ var systemSettingSchema = []settingDef{
 	{Category: "docs", Key: "enabled", Type: settingTypeBool, Description: "是否向客户端展示文档(docs)模块入口（octo-docs-backend 上线前默认关闭）",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.DocsEnabled()) }},
 
+	// Loop(回路)模块展示开关。loop 依赖后端服务 + fleet 代理 + daemon runtime 一整套,未就绪前
+	// 默认关闭;feature 分支合入 main 也不暴露,上线后由管理台切 dmloop.enabled 灰度放量。仅表达
+	// 展示策略,不承担服务端鉴权(/fleet 鉴权在后端)。经 GET /v1/common/appconfig 的 dmloop_on 下发给客户端。
+	{Category: "dmloop", Key: "enabled", Type: settingTypeBool, Description: "是否向客户端展示 Loop(回路)模块入口（后端服务上线前默认关闭）",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.DmloopEnabled()) }},
+
+	// 「我的 / 运行时」模块展示开关。与 dmloop.enabled 分开:「我的」后续会重新设计、脱离
+	// loop 独立演进,故独立门控以便分阶段放量。默认关闭。经 appconfig 的 dmpersonal_on 下发。
+	{Category: "dmpersonal", Key: "enabled", Type: settingTypeBool, Description: "是否向客户端展示「我的/运行时」模块入口（默认关闭；与 dmloop 分开以便独立放量）",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.DmpersonalEnabled()) }},
+
 	// 自定义贴纸上传限制（sticker-upload-compression 任务）。原先硬编码在
 	// modules/file/const.go；挪进 system_setting 后可灰度/回滚，且每键都有
 	// 服务端硬上限（stickerUpload*HardCap / stickerCompress*HardCap），误配也不会

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -793,6 +793,21 @@ func (s *SystemSettings) DocsEnabled() bool {
 	return s.getBool("docs", "enabled", false)
 }
 
+// DmloopEnabled reports whether the Loop(回路)module entry should be shown to
+// clients. Default false — the loop feature (backend service + fleet proxy +
+// daemon runtimes) stays hidden until ops flips dmloop.enabled after those deps
+// are deployed. Display policy only; /fleet auth lives in the backend.
+func (s *SystemSettings) DmloopEnabled() bool {
+	return s.getBool("dmloop", "enabled", false)
+}
+
+// DmpersonalEnabled reports whether the「我的/运行时」(personal) module entry
+// should be shown. Kept separate from dmloop.enabled because 我的 will be
+// redesigned to decouple from loop and may roll out on its own schedule.
+func (s *SystemSettings) DmpersonalEnabled() bool {
+	return s.getBool("dmpersonal", "enabled", false)
+}
+
 // ---------------------------------------------------------------------------
 // Custom-sticker upload constraints + optional server-side compression
 // (sticker-upload-compression task).


### PR DESCRIPTION
Closes #575

## Goal

Ship the Loop(回路) feature branch into `main` without exposing the Loop entry (or the related 「我的/运行时」entry) on clients. Both stay hidden until their backend dependencies (loop service + fleet proxy + daemon runtimes) are deployed, then ops gray-releases each independently from the admin console — no client build required.

## Changes

- **`modules/common/system_setting_schema.go`** — register two bool system settings: `dmloop.enabled` and `dmpersonal.enabled`, both defaulting to `false`.
- **`modules/common/system_settings.go`** — add `DmloopEnabled()` / `DmpersonalEnabled()` accessors reading those settings.
- **`modules/common/api.go`** — add `dmloop_on` / `dmpersonal_on` to `appConfigResp` and emit them on **both** the normal branch and the `version` short-circuit branch, so admin toggles reach old clients that hit the version short-circuit (decoupled from `app_config.version`, same treatment as `docs_on`).
- **`modules/common/api_test.go`** — coverage for: default-false, each flag toggling independently, and both flags present on the version short-circuit branch.

These are display-policy flags only; `/fleet` server-side authorization is unaffected and lives in the backend.

## Verification

- `golangci-lint run ./modules/common/...` → 0 issues (golangci-lint 2.12.2).
- Unit tests in `api_test.go`:
  - `TestGetAppConfig_LoopFlags_DefaultFalse`
  - `TestGetAppConfig_DmloopOn_TrueIndependentOfPersonal`
  - `TestGetAppConfig_DmpersonalOn_TrueIndependentOfLoop`
  - `TestGetAppConfig_LoopFlags_OnVersionShortCircuit`
- Branch rebased onto latest `main` (no divergence, clean).