### PR TITLE
feat: internal card dispatch boundary — sole trusted in-process type-17 origination (dormant foundation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,6 +326,27 @@ jobs:
       - name: Reject direct PERSONAL MsgSendReq literals
         run: go run ./tools/lint-personal-msgsendreq ./modules
 
+  card-dispatch-lint:
+    needs: [changes]
+    if: |
+      (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
+      needs.changes.outputs.code == 'true'
+    # Internal card producers must use the producer-bound carddispatch sender.
+    # This AST guard is a review backstop for recognizable type-17 construction
+    # and transport flows; runtime payload passthrough is guarded at ingress.
+    name: Card Dispatch Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Reject unreviewed internal type-17 transport owners
+        run: make card-dispatch-lint
+
   i18n-extract-check:
     needs: [changes]
     if: |

--- a/.octospec/tasks/card-message-internal-dispatch/brief.md
+++ b/.octospec/tasks/card-message-internal-dispatch/brief.md
@@ -1,12 +1,12 @@
 ---
 type: Task
 title: "Task: card-message-internal-dispatch"
-description: Add the only supported in-process path for business modules to send trusted interactive cards.
+description: Add the only supported in-process path for business modules to send trusted interactive cards, grounded in the summary-forward and docs-share scenarios.
 tags: ["message", "card", "internal", "trust-boundary", "wire-contract", "auth", "space", "isolation", "acl", "rate-limit", "observability", "testing"]
-timestamp: 2026-07-13T16:17:40+08:00
+timestamp: 2026-07-13T17:00:00+08:00
 # --- octospec extension fields ---
 slug: card-message-internal-dispatch
-upstream: self
+upstream: octo-server#571
 source: self
 ---
 
@@ -18,7 +18,10 @@ source: self
 ## Goal
 
 Add `internal/carddispatch` as the only supported path for an in-process
-business module to originate an `InteractiveCard` (`type=17`) message.
+business module to originate an `InteractiveCard` (`type=17`) message, so that
+server-side scenarios — smart-summary results delivered/forwarded into chats as
+cards, docs share-link cards, and future system cards — have one reviewed,
+trusted origination boundary instead of ad-hoc sends.
 
 The dispatcher binds a reviewed producer capability to one configured active
 bot identity, authorizes the exact Space and target using live database state,
@@ -28,16 +31,88 @@ size recheck in a fixed order, makes at most one `SendMessageWithResult`
 transport attempt per invocation, and emits bounded metrics and structured
 logs.
 
-This closes the architectural hole where a future business module could call
-`config.Context.SendMessageWithResult` directly with a hand-built type-17 map
-and accidentally skip sender trust, Space/target ACLs, authoritative `plain`, or
-the final post-mutation 512 KiB check.
+This closes the architectural hole where a business module (or an internal
+S2S caller relaying through one) could reach `config.Context.SendMessage` /
+`SendMessageWithResult` with a hand-built type-17 map and skip sender trust,
+Space/target ACLs, authoritative `plain`, or the final post-mutation 512 KiB
+check. The cross-repo research below shows this hole is not hypothetical:
+`POST /v1/internal/notify` already forwards a caller-supplied payload map
+verbatim as the trusted `notification` User Bot (Decision 14 closes that
+specific gap in this task).
 
-No HTTP endpoint is added. Existing Bot API, legacy Robot API, and Incoming
-Webhook producers keep their current ingress-specific paths in this task; the
-new boundary governs server-internal business producers.
+No new HTTP endpoint is added. Existing Bot API, legacy Robot API, and
+Incoming Webhook producers keep their current ingress-specific paths in this
+task; the new boundary governs server-internal business producers. The only
+behavior change to an existing endpoint is the fail-closed card-payload
+rejection on `/v1/internal/notify` (Decision 14).
 
 ## Background
+
+### Cross-repo scenario research (2026-07-13)
+
+The two motivating scenarios were traced end-to-end across the four repos.
+
+**Scenario A — 智能总结投递/转发到会话 (smart-summary → chat):**
+
+- `octo-smart-summary` is a standalone Go sidecar (separate binaries
+  `summary-api` / `summary-worker`), not an octo-server module. After a summary
+  task terminates, the worker pushes a **plain-text DM** itself:
+  `POST {OCTO_API_URL}/v1/internal/notify` with header `X-Internal-Token`
+  (`SUMMARY_NOTIFY_TOKEN`), body payload hardcoded to `{"type":1,"content":…}`
+  (`internal/notify/notify.go:283-291`, `internal/notify/client.go:83,156`).
+  Per-recipient dedup/retry state lives in its `summary_notification` table.
+- Delivery back into the **origin group/thread** is explicitly a future
+  enhancement (`internal/notify/target.go:34-37`); today every origin falls
+  back to a creator DM. The repo has zero card/type-17 code.
+- On the octo-server side, `modules/notify` owns that ingress:
+  `POST /v1/internal/notify` and `/v1/internal/notify/batch`
+  (`modules/notify/api.go:90-95`), gated by `NOTIFY_INTERNAL_TOKEN`
+  (fail-closed when unset, constant-time compare). It verifies Space
+  membership, then fans out **DM-only** sends via
+  `config.NewPersonalMsgSendReq` from the static system bot
+  `notification` with a bounded 20-goroutine pool (`api.go:243-303`).
+- The `notification` sender is a **full User Bot**: `ensureNotifyBot`
+  provisions the `user` row, `app` row, and a `robot` row with `status=1`
+  (`modules/notify/bot_manager.go:52-87`). `modules/botidentity` therefore
+  resolves it as an active bot and `modules/cardtrust` trusts it as a card
+  sender.
+- In `octo-web`, "转发到聊天" for a summary sends the summary text as plain
+  `MessageText` chunks via the WuKongIM JS SDK
+  (`packages/dmworksummary/src/pages/SummaryDetailPage.tsx:1018-1043`).
+
+**Scenario B — docs 文档分享链接卡片 (docs share-link card):**
+
+- `octo-docs-backend` (TypeScript/Hocuspocus) has **no outbound IM capability
+  at all** — stated in source (`src/api/routes/accessRequests.ts:13-17`); its
+  octo-server integration is identity-only (token→uid, uid→profile). Share-to-
+  chat is split: docs-backend authorizes recipients (`forward-grant`, invite
+  tokens); the message itself is sent by the web client.
+- In `octo-web`, doc sharing sends a plain `MessageText` whose body is
+  Markdown `**title**\n[url](<url>)` via the JS SDK
+  (`packages/dmworkbase/src/Components/WKBase/index.tsx` `runDocForward`,
+  `ForwardModal/forwardMessageText.ts:55-58`). There is no link-card/unfurl
+  rendering.
+
+**Established platform facts relevant to both:**
+
+- The web client is **receive/render-only** for type-17 by design ("波 1 web
+  不发送 type-17", `packages/dmworkbase/src/Messages/InteractiveCard/`
+  `InteractiveCardContent.ts:22,59`); only re-forwarding an already-received
+  display-only card exists. So every card origination for these scenarios must
+  happen server-side — exactly the boundary this task builds.
+- Inside octo-server, only three modules can emit type-17 today, each with its
+  own ingress trust: `modules/bot_api/send.go`, `modules/robot/api.go`,
+  `modules/incomingwebhook`. All other `SendMessage*` call sites send fixed
+  non-card types from static system identities (`notify`, `botfather`,
+  `app_bot` welcome, group/thread/user system tips).
+- **Live gap:** `modules/notify.deliverNotification` forwards the
+  caller-supplied payload map to transport without any type restriction. A
+  holder of `NOTIFY_INTERNAL_TOKEN` can thus emit a hand-built `type=17` map
+  as the **trusted** `notification` bot, skipping `cardmsg.Enabled`,
+  `Validate`, `Finalize`, authoritative `plain`, and the 512 KiB gates. The
+  planned AST guard cannot see this shape (no card construction in
+  octo-server source — the map arrives over HTTP), so it needs the runtime
+  gate in Decision 14.
 
 ### Existing authoritative pieces
 
@@ -46,7 +121,10 @@ new boundary governs server-internal business producers.
   - `Validate` enforces the profile/version, structure, URL, depth/node and
     complete-payload limits;
   - `Finalize` overwrites untrusted `plain` and rechecks the enriched payload;
-  - `RecheckPayloadSize` checks the final bytes after any later mutation.
+  - `RecheckPayloadSize` checks the final bytes after any later mutation;
+  - `IsCardPayload` / `IsCardRawPayload` are the single card-shape detectors;
+  - profiles: `octo/v1` is display-only, `octo/v2` is the only interactive
+    profile (`profiles.go:19-22`).
 - `modules/botidentity` resolves live bot authority:
   `robot.status=1` or `app_bot.status=1`; `user.robot=1` is presentation only;
   ambiguous or failed lookups fail closed.
@@ -55,6 +133,10 @@ new boundary governs server-internal business producers.
   - `modules/bot_api/send.go`;
   - `modules/robot/api.go`;
   - `modules/incomingwebhook/api.go` + `card.go`.
+- `modules/notify` owns the internal S2S notification ingress
+  (`/v1/internal/notify*`, `X-Internal-Token`) and the static `notification`
+  User Bot (see research above). It is an existing trust surface of this
+  boundary, not a card producer.
 - `pkg/cardmsg/producer_completeness_test.go` already proves every producer that
   expands `mention.ais` performs a final size recheck. It does not prevent a new
   internal producer from bypassing all of the other gates.
@@ -66,35 +148,262 @@ new boundary governs server-internal business producers.
 
 ### Why this is a separate P0
 
-The App Bot trust task fixes consumers of already-sent cards. It deliberately
-does not authorize new in-process producers. Internal dispatch is a separate
-load-bearing boundary: a server module is not authenticated by Bot API
-middleware, so it needs an explicit producer capability and cannot inherit
-HTTP-layer bot/Space checks by accident.
+The App Bot trust task (card-message-appbot-trust, PR #570 lineage) fixes
+consumers of already-sent cards — display masking and the `card_action` gate.
+It deliberately does not authorize new in-process producers. Internal dispatch
+is a separate load-bearing boundary: a server module is not authenticated by
+Bot API middleware, so it needs an explicit producer capability and cannot
+inherit HTTP-layer bot/Space checks by accident.
 
-### Implementation gate: pilot producer must be named
+### Industry practice alignment
 
-Before `/octospec-go card-message-internal-dispatch` enables a pilot producer, a
-maintainer must replace the following `TBD` values in this brief. A deliberately
-dormant foundation may leave them unresolved, but it must register no production
-producer. Do not implement a mutable generic "send as any UID" service while
-they are unknown.
+The design was cross-checked against the public behavior of major IM
+platforms (Slack Block Kit, Feishu/Lark interactive cards, DingTalk robots,
+Microsoft Teams Adaptive Cards — the same card family octo uses). The core
+decisions match established practice:
 
-| Required input | Value |
+- Rich interactive messages are bot/app-only origination; human clients cannot
+  forge them — matches Decision 2.
+- Channel authorization is checked live at send time (Slack `not_in_channel`;
+  Feishu/DingTalk bots must be members of a group before posting into it) —
+  matches Decision 4. For posting **without** membership, DMWork adopts the
+  reviewed member-exempt mode analogous to Slack's `chat:write.public`
+  (no-join posting to public channels), scoped to normal in-Space groups with
+  a recorded triggering member action since DMWork has no public/private
+  split; Feishu/DingTalk reach the same user-visible end state by keeping
+  group robots outside the member list/count.
+- Fallback text next to the rich body is app/platform-authored (Slack `text`
+  alongside blocks; Teams/Feishu card summaries on push surfaces) — matches
+  authoritative `plain`.
+- Interaction callbacks route only to the app that owns the message, and
+  webhook-only identities cannot receive interactions (Teams Incoming Webhook
+  cards cannot carry `Action.Submit`; Feishu custom group bots send
+  non-interactive cards only) — matches Decision 5 and the existing `iwh_`
+  restriction.
+- The platform boundary does schema validation plus hard size caps (Teams
+  ≈28 KB per card, Slack block-count/length limits) — the 512 KiB
+  `pkg/cardmsg` cap is permissive by comparison, not aggressive.
+- First-party traffic goes through the same gateway as third-party traffic (no
+  internal bypass) — matches Decisions 12 and 14.
+- postMessage-style send APIs are not idempotent; retry semantics live in the
+  caller — matches Decision 8.
+
+Two places this design is deliberately weaker than public platforms, declared
+here rather than discovered later:
+
+- **No per-channel send-rate control** (Slack enforces ≈1 msg/s/channel;
+  DingTalk webhooks 20 msg/min/group). Acceptable for the DM-only pilot; a
+  reviewed per-channel rate rule is a **precondition of widening any producer
+  to group/thread targets**.
+- **No cluster-wide quota** — Decision 9's semaphore is per process, while
+  public platform quotas are global. The cluster-cap decision is likewise part
+  of the group/thread widening review, not this task.
+
+## Method: how a scenario onboards (方法概览)
+
+The supported end-to-end path for "some internal service wants to send a card"
+is fixed by this task:
+
+```
+external sidecar service            octo-server process
+(smart-summary, docs-backend, …)
+        │  internal S2S ingress            ┌─────────────────────────────┐
+        └─ X-Internal-Token endpoint ────▶ │ owning business module      │
+           (or the feature is already      │  holds a producer-bound     │
+            in-process: no ingress hop)    │  carddispatch.Sender        │
+                                           └──────────────┬──────────────┘
+                                                          ▼
+                                           internal/carddispatch pipeline:
+                                           producer gate → live bot identity
+                                           → live Space/target ACL → envelope
+                                           → Validate → enrich → Finalize
+                                           → size recheck → ONE transport call
+```
+
+- The **producer** is always an octo-server module (the ingress endpoint's
+  owner for sidecar-driven scenarios; the feature module itself for in-process
+  scenarios). Sidecar services never hold card-send authority directly; their
+  S2S token authenticates them to their ingress module only.
+- The **sender identity** is always a configured active bot resolved live via
+  `modules/botidentity` — never a human UID, never caller-supplied.
+- The web client stays receive-only for type-17; no client card-send path is
+  introduced for these scenarios.
+
+Applied to the motivating scenarios (Scenario A splits into two sub-paths
+with different readiness):
+
+- **Pilot — `summary-notify` (Scenario A1, worker-driven notification):**
+  `modules/notify` becomes the first producer. The existing summary
+  completion/failure DM upgrades from plain text to a display-only (`octo/v1`)
+  card; the sender is a **dedicated `summary` bot** (decided 2026-07-13;
+  provisioning mirrors the `ensureNotifyBot` user+app+robot pattern), while
+  the generic text-notification path keeps the `notification` bot unchanged.
+  The ingress, token, membership verification, and smart-summary's retry/dedup
+  state machine all stay as they are. When smart-summary later implements
+  origin group/thread回发, the same producer widens its allowed channel types
+  in a separate reviewed change — that review must also settle the per-channel
+  rate rule and cluster-cap questions (see Industry practice alignment), and
+  the delivery policy is **member-exempt posting to the origin group**
+  (Decision 4 mode, confirmed 2026-07-13): the bot never joins — member list
+  and 群人数 are untouched — consent comes from the creating member having
+  bound the task to that group, the dispatcher re-verifies group lifecycle
+  and exact Space at send time, and delivery falls back to the creator DM
+  when the group is no longer eligible. The dispatcher's group/thread
+  authorization rules (Decision 4) are specified now so that widening is a
+  config review, not a design change.
+- **Candidate — `summary-forward-card` (Scenario A2, user-triggered
+  转发到聊天):** today the web client sends the summary as plain-text chunks
+  itself; the web cannot and will not send type-17, so a card version means
+  "human triggers, bot sends". The lean shape reuses existing machinery end to
+  end: the forward UI calls a new user-facing endpoint on **summary-api** (the
+  content owner — it already authenticates web users and owns summary
+  visibility), and smart-summary relays through its **existing**
+  `X-Internal-Token` ingress client with the chosen target channel plus
+  `actor_uid` (a field `NotifyReq` already carries); the octo-server producer
+  additionally verifies the actor is an active member of the target channel
+  before dispatch. No reverse octo-server→smart-summary channel and no content
+  round-trip is needed — content authority stays with its owner, which also
+  removes the card-forgery concern. The new endpoint is smart-summary scope;
+  the candidate slot here is reserved.
+  **Message ownership (decided 2026-07-13): bot-sent with a prominent
+  forwarder-attribution card header** (forwarder avatar + name + "分享了智能
+  总结"), matching Slack/Feishu share flows. User-identity (OBO) card
+  forwarding is rejected — the card protocol already forbids OBO cards
+  platform-wide (Decision 2b, see Decision 4) and relaying OBO through a
+  static-token internal ingress would constitute the forbidden "send as any
+  UID" capability. **Targets are split by type (decided 2026-07-13):
+  group/thread targets get the bot card via the member-exempt posting mode
+  (Decision 4) — the bot never joins, member list and count are untouched;
+  person targets keep today's user-identity plain-text forward and get no
+  card.** A person channel is strictly two-party: a bot cannot post into the
+  张三↔李四 conversation at all — a bot DM lands in the bot's own conversation
+  with the recipient, out of context. Slack and Feishu likewise bar apps from
+  posting into human↔human DMs (Slack share-to-DM is the user's own message).
+  Bot-DM cards exist only as A1 notifications inside the summary bot's own
+  conversation.
+- **Candidate — `docs-share-card` (Scenario B):** blocked on ingress design:
+  docs-backend has no octo-server message client and no bot identity, and the
+  share message is currently client-sent. Onboarding requires (a) a docs S2S
+  ingress or an octo-server share endpoint, and (b) a provisioned docs bot
+  identity — both out of scope here. The dispatcher contract already covers
+  what it will need (group + DM targets, display-only profile, explicit
+  Space).
+
+### Interactive cards (octo/v2): how future action scenarios fit
+
+Foreseeable scenarios where the recipient acts on the card — merge a PR,
+close an issue, approve an access/authorization request — are deliberately
+accommodated by this contract and require **no new dispatch machinery**. The
+pilot's cards are display-only (`octo/v1`) with a deep link, but nothing in
+the pilot blocks a later interactive producer. What changes for an
+interactive producer is what it must bring, not how it dispatches:
+
+- **The Decision 5 gate is the whole difference.** A producer registered for
+  `octo/v2` must name the existing bot event consumer that owns `card_action`
+  for its sender bot; the registry refuses the interactive profile otherwise
+  (already in Acceptance › Capability and configuration). Sending an
+  interactive card goes through the exact same pipeline.
+- **The action loop is the existing one**, hardened by
+  card-message-appbot-trust: recipient taps → `POST /v1/message/card/action`
+  → live sender-trust check → `card_action` event on the **sender bot's**
+  event queue → the bot's owning service polls `/v1/bot/events` and ACKs via
+  Bot API. The dispatcher never adds a second callback route (Out of scope
+  holds).
+- **Sender identity choice is therefore scenario-driven.** An interactive
+  producer's bot must be backed by a service that actually runs the event
+  poll loop: e.g. a GitHub-integration bot whose sidecar executes merge/close
+  against GitHub, or a docs bot whose backend executes the approval, then
+  reflects the outcome by **editing the card** through the existing card-edit
+  path (`card_seq` / `pkg/cardrevision`) instead of sending a new card.
+  Display-only producers (the pilot) may use consumer-less bots; upgrading a
+  producer to `octo/v2` later means giving its bot an event consumer first —
+  or registering a separate producer bound to a bot that has one.
+- **Executor responsibilities stay outside the dispatcher**: authorize the
+  acting user in the target system at execution time (a visible button is
+  NOT authorization — the event's actor identity must be checked against the
+  external system's ACL), and handle the poll/ACK at-least-once delivery
+  idempotently (dedup on event/card identity before executing side effects
+  like a merge).
+
+These scenarios (`devops` PR/issue cards, `docs` approval cards) are far
+candidates: each onboards with its own producer table row, a named event
+consumer, and its own brief for the executor side. They are listed here so
+the registry/config schema is designed with the action-owner field from day
+one rather than retrofitted.
+
+### Card template and deep-link (designed, confirmed 2026-07-13)
+
+**Template — a `ResourceCard` family in a small server-side shared library**
+(e.g. `pkg/cardtmpl`), consumed by producer modules only; the carddispatch
+core never imports it (Decision 11 acyclicity — the dispatcher validates via
+`pkg/cardmsg`, it does not know templates). Sidecar services keep sending
+structured fields (the decided ingress contract); template knowledge lives in
+exactly one place. Signature:
+
+```
+ResourceCard{ icon, title, attribution?, excerpt, facts[],
+              primaryAction{title,url}, localActions[]?, lang }
+```
+
+Rendered with octo/v1 whitelist elements only (`ColumnSet` icon+title header,
+subtle attribution `TextBlock` — the decided forwarder-attribution header for
+A2, excerpt `TextBlock`, `FactSet` metadata, `ActionSet` with `Action.OpenUrl`
+"查看详情" plus optional `Action.CopyToClipboard`). One template instantiates
+all near scenarios: A1 completion/failure notification, A2 forward card, the
+future docs share card. Constraints by construction: URLs are absolute https
+(Decision 3d positive allowlist); the excerpt is server-truncated (~300 chars)
+so payloads stay far under `MaxPayloadBytes` and today's chunked-forward hack
+disappears; `plain` needs no template work (`Finalize` recomputes it); labels
+render per recipient via `i18n.OutboundLanguage` (same discipline as email
+templates). Guard tests: JSON snapshot per instantiation plus a test that
+every template output passes `cardmsg.Validate` under `octo/v1` — template
+drift fails CI.
+
+**Deep-link — standalone web route `/s/:taskId?sp={spaceId}`**, mirroring the
+battle-tested `/d/:docId` machinery (cold-load → login bounce → multi-session
+sid recovery, XIN-398 test suite). Root cause of the historical removed link
+(`octo-smart-summary internal/notify/notify.go:396`): summary detail has only
+in-app `WKApp.route` panels (`/summary/detail`), no browser URL route — the
+design closes exactly that hole. Logged-in behavior: enter the app and call
+the existing `WKApp.openSummaryDetail(taskId)`; no standalone renderer is
+needed in wave 1. The URL is built by the octo-server template layer from
+`External` config (reuse `External.WebLoginURL`'s origin or add
+`External.WebBaseURL` — decided at the enablement config review);
+smart-summary passes `taskId` only and never builds URLs. Anti-regression
+contract: octo-web ships a route-contract test asserting `/s/:taskId` is
+registered, octo-server ships a template test pinning the link shape — a path
+change is an explicit cross-repo contract change, so the "link points
+nowhere" failure cannot silently recur.
+
+## Implementation gate: pilot producer table
+
+Before `/octospec-go card-message-internal-dispatch` enables a pilot producer,
+a maintainer must confirm this table. All pilot decisions are now
+**maintainer-confirmed (2026-07-13)**: concurrency, duplicate tolerance,
+replicas, sender bot, message ownership, member-exempt group posting, and the
+card template + deep-link design (Method › Card template and deep-link). The
+remaining work on the template/deep-link is **verification, not decision**:
+the pilot enablement PRs must land the `/s/:taskId` route-contract test in
+octo-web and the template snapshot/Validate guard tests in octo-server before
+the producer is enabled. A deliberately dormant foundation may ship first,
+but it must register no production producer while any row is unconfirmed. Do
+not implement a mutable generic "send as any UID" service.
+
+| Required input | Pilot: `summary-notify` |
 | --- | --- |
-| Producer ID (stable, low-cardinality) | `TBD` |
-| Owning module / constructor | `TBD` |
-| Sender bot UID configuration source | `TBD` |
-| Allowed channel types | `TBD` |
-| Allowed card profiles / action-event owner | `TBD` |
-| Required Space source | `TBD` |
-| Expected peak concurrency / QPS | `TBD` |
-| Business retry/idempotency requirement | `TBD` |
-| Process replicas / required cluster-wide cap | `TBD` |
+| Producer ID (stable, low-cardinality) | `summary-notify` |
+| Owning module / constructor | `modules/notify`; it obtains its producer-bound `Sender` from the single registry composed at server bootstrap (exact wiring resolved in implementation per Decision 11 — must fit the `register.AddModule` module system without mutable package-global registration) |
+| Sender bot UID configuration source | **Decided 2026-07-13: a dedicated `summary` bot** (static UID, provisioned as a full User Bot via the same user+app+robot pattern as `ensureNotifyBot`, `robot.status=1` — botidentity-active). The `notification` bot keeps the generic text-notification path only; separating identities keeps DM-notification duty and future group membership/branding decoupled |
+| Allowed channel types | DM (person) only at pilot; group/thread widening is a separate reviewed change tied to smart-summary origin回发, and that review must include a per-channel rate rule and the cluster-cap decision. Group/thread sends use the member-exempt posting mode (Decision 4): the bot joins no group, member list and 群人数 unchanged |
+| Allowed card profiles / action-event owner | `octo/v1` (display-only) only; `octo/v2` forbidden — the `summary` bot has no bot-event consumer polling `/v1/bot/events`, so no one could own `card_action` (see Method › Interactive cards for the upgrade path) |
+| Required Space source | `NotifyReq.space_id` supplied by the internal caller and member-verified by notify's `memberCache`; the dispatcher independently re-verifies live Space/membership (Decision 3). DM policy = system-notification mode (space-member DM, Decision 4) |
+| Expected peak concurrency / QPS | max-in-flight **20** per process (mirrors notify's existing bounded send pool) — **confirmed 2026-07-13** |
+| Business retry/idempotency requirement | smart-summary already retries per recipient with `summary_notification` dedup state ⇒ at-least-once from the caller side; a transport-ambiguous failure may duplicate a card; dispatcher stays single-attempt (Decision 8). **Confirmed 2026-07-13: duplicates are acceptable for notification cards; no outbox** |
+| Process replicas / required cluster-wide cap | **Confirmed 2026-07-13: per-process bound accepted, no cluster-wide cap required.** Record the actual replica count in the deployment/config review that enables the pilot |
 
-The foundation may be implemented with no enabled production registration, but
-it must not be presented as end-to-end useful until one concrete producer is
-reviewed against this table.
+| Required input | Candidates: `summary-forward-card`, `docs-share-card` |
+| --- | --- |
+| All rows | `TBD` — both blocked on ingress design (a summary-api forward endpoint + actor-verified ingress extension; a docs S2S ingress + docs bot identity — see Method section); neither may be registered until its own table is filled and confirmed |
 
 ## Decisions locked by this task
 
@@ -125,10 +434,36 @@ reviewed against this table.
    App Bots are DM-only, require the existing friend opt-in, and a scope=space
    App Bot may only target an active member of its own active Space. Platform
    App Bots require an active target Space and active recipient membership.
-   User Bots require creator/friend authorization for DMs; group/thread sends
+   User Bots require creator/friend authorization for DMs — except a producer
+   whose registered Space policy is the reviewed **system-notification DM
+   mode**, which instead authorizes DMs by active membership in the verified
+   Space (the semantics `modules/notify` delivers today; industry analog:
+   Slack app DMs and Feishu in-tenant application messages need no
+   friendship). The mode is per-producer registry config, never
+   caller-selectable, and the pilot uses it. Group/thread sends
    require an active internal bot member, a normal parent group, a non-deleted
-   active thread, and exact Space equality. DB errors fail closed. OBO is not
-   supported by internal dispatch.
+   active thread, and exact Space equality — except a producer with the
+   reviewed **member-exempt group posting mode** (confirmed for the summary
+   producers 2026-07-13): the bot posts to a normal group or valid thread in
+   the exact verified Space **without a membership row**, so it never appears
+   in the member list and never increases the member count
+   (`QueryMemberCount` today counts `robot=1` rows, so joining would inflate
+   群人数); every such send must be attributable to a recorded triggering
+   member action in the owning module (task creation, forward click), and
+   group/thread lifecycle plus Space equality remain verified fail-closed at
+   send time. Transport needs no membership (group system tips already post
+   member-less, `modules/group/event.go:36`); this is policy, and the
+   industry analog is Slack `chat:write.public` no-join posting, scoped to
+   normal in-Space groups because DMWork has no public/private split. The
+   dispatcher never mutates membership to make a send succeed (no auto-join);
+   a producer without this mode that is not an active internal member fails
+   closed. DB errors fail closed. OBO
+   is not supported by internal dispatch — consistent with the card protocol's
+   platform-wide prohibition of OBO cards (card-message-protocol Decision 2b:
+   Bot API rejects card + `on_behalf_of` with
+   `err.server.bot_api.card_obo_forbidden`, `modules/bot_api/send.go:92-105`;
+   revisiting that is a card-protocol contract change, not an internal-dispatch
+   option).
 5. **Dispatcher owns the envelope.** The public request accepts a card document
    plus a supported profile, not an arbitrary message payload. The dispatcher
    sets `type`, `card_version`, and profile; caller-supplied `plain`, `space_id`,
@@ -189,7 +524,8 @@ reviewed against this table.
     guard and must onboard through the dispatcher (or add a narrowly reviewed
     external-ingress exemption). The guard is a review backstop for known Go
     syntax/data-flow shapes, not a claim that static analysis is a runtime
-    security boundary.
+    security boundary. It cannot see payload-passthrough shapes where the card
+    map arrives over HTTP — that class is closed at runtime by Decision 14.
 13. **Request-time authorization, no lock across transport.** Identity and ACL
     state are queried without a decision cache on every invocation. The
     dispatcher does not hold database locks or a transaction open across the IM
@@ -198,6 +534,17 @@ reviewed against this table.
     requests fail closed. If the pilot requires linearizable revocation of an
     in-flight send, that stronger cross-system protocol must be designed before
     implementation rather than claimed by this package.
+14. **Existing internal notify ingress fails closed on card payloads.**
+    `modules/notify.deliverNotification` rejects any request whose payload
+    `cardmsg.IsCardPayload` reports as a card (covering `/v1/internal/notify`
+    and `/batch`) before membership verification and with zero transport
+    calls, responding through a registered `pkg/errcode` code (e.g.
+    `err.server.notify.card_not_allowed`, 400, non-Internal) via
+    `httperr.ResponseErrorL`. Today's only known caller (smart-summary) sends
+    `type=1` text exclusively, so no legitimate traffic changes. This gate is
+    the runtime complement to Decision 12 for the trusted `notification`
+    sender; it may only be removed by onboarding notify's card path through
+    `internal/carddispatch` (the `summary-notify` pilot).
 
 ## Proposed internal contract
 
@@ -235,6 +582,11 @@ request. The implementation must document that boundary and must not fake
 cancellation by leaking a goroutine. A context-aware transport extension is a
 separate octo-lib change unless accepted into this task before implementation.
 
+Fan-out stays caller-side: a producer sending one card to N recipients calls
+`Send` N times inside its own loop (as notify does today), each call
+individually authorized and bounded by the producer's in-flight budget. The
+dispatcher does not accept target lists.
+
 Internal errors are typed Go errors with a stable bounded category:
 `invalid_request`, `feature_disabled`, `producer_disabled`,
 `identity_untrusted`, `target_denied`, `card_invalid`, `payload_too_large`,
@@ -256,6 +608,11 @@ caller must map them through that endpoint's registered `errcode` facade.
 - **Card wire contract (`wire-contract`, `trust-boundary`)** — `pkg/cardmsg`
   remains the sole profile/schema authority; `plain` and `space_id` are
   server-authored, and the exact serialized wire payload stays <=512 KiB.
+- **Internal notify ingress (`trust-boundary`, `wire-contract`)** —
+  `/v1/internal/notify*` keeps its text-notification contract for existing
+  callers (smart-summary sends `type=1`); its auth stays `X-Internal-Token`
+  fail-closed; it additionally stops relaying card-shaped payloads
+  (Decision 14). The `notification` bot provisioning is untouched.
 - **Existing ingress behavior (`bot-api`, `wire-contract`)** — Bot API, Robot
   API, and Incoming Webhook validation order, error envelopes, OBO behavior,
   rate limits, and metrics do not change merely because the internal package is
@@ -278,16 +635,40 @@ caller must map them through that endpoint's registered `errcode` facade.
 
 ## Out of scope
 
-- Selecting or implementing the first business producer while the pilot table
-  above remains `TBD`.
+- Enabling the `summary-notify` pilot (switching the summary notification body
+  from text to a card) while any ⚠️ row in the pilot table lacks maintainer
+  sign-off. The foundation plus the Decision 14 gate may ship dormant first.
+- Implementing smart-summary origin group/thread回发 (its `target.go` routing
+  or widening the pilot's channel types) — a separate task in
+  octo-smart-summary + a reviewed config change here, whose review must settle
+  per-channel rate control and the cluster-wide cap (see Industry practice
+  alignment).
+- A platform-level "group robots" presentation change — segmenting `robot=1`
+  members out of the member list and `QueryMemberCount` (Feishu/DingTalk
+  style, also fixing existing AI bots inflating 群人数). It is the long-term
+  alternative to member-exempt posting and a separate product task.
+- The `summary-forward-card` candidate end-to-end: the summary-api forward
+  endpoint (human triggers, bot sends) and the internal-ingress extension for
+  actor-verified channel targets. Only its candidate slot in the table is
+  reserved.
+- The `docs-share-card` producer end-to-end: a docs S2S ingress or share
+  endpoint, docs bot identity provisioning, docs-backend outbound IM client,
+  and any card-composition UI. Only its candidate slot in the table is
+  reserved.
+- Any client-side card sending in octo-web; the web stays receive-only for
+  type-17.
 - Replacing or refactoring `/v1/bot/sendMessage`, legacy Robot API send,
-  Incoming Webhook push/card send, or their public error contracts.
+  Incoming Webhook push/card send, or their public error contracts. Beyond the
+  Decision 14 card gate, `/v1/internal/notify*` behavior (text payload
+  passthrough, DM fan-out, membership filtering, legacy error envelope) is
+  unchanged.
 - Incoming Webhook card actions/callbacks; webhook identities still have no bot
   event consumer.
 - A new internal `card_action` callback/event bus. Interactive profiles retain
   the existing sender-bot event ownership and poll/ACK contract.
-- OBO, fan-out, streams, subscribers, transient/no-persist cards, mention
-  expansion, broadcast cards, typing/read receipts, or card edits/revisions.
+- OBO, fan-out inside the dispatcher, streams, subscribers, transient/no-persist
+  cards, mention expansion, broadcast cards, typing/read receipts, or card
+  edits/revisions.
 - New card profiles/elements/actions, renderer changes, or changes to
   `pkg/cardmsg` limits.
 - New HTTP/gRPC routes, auth middleware, Space middleware, or client SDKs.
@@ -307,12 +688,17 @@ caller must map them through that endpoint's registered `errcode` facade.
 
 ### Planning gate
 
-- The pilot-producer table has no `TBD` values before implementation starts, or
-  the implementation is explicitly limited to a disabled foundation with no
-  claim of end-to-end production usefulness.
-- The chosen sender UID/config source, target kinds, Space source, concurrency,
-  card profile/action owner, replica multiplier, and retry requirements receive
-  maintainer sign-off in this brief.
+- All `summary-notify` pilot decisions are maintainer-confirmed (2026-07-13):
+  concurrency, duplicate tolerance, replicas, sender bot (dedicated `summary`
+  bot), message ownership (bot-sent + forwarder attribution, no OBO),
+  member-exempt group posting, and the card template + deep-link design.
+  Registering/enabling the pilot additionally requires the design's guard
+  tests to exist and pass (see Acceptance › Card template and deep-link).
+  Until then the implementation is explicitly limited to a disabled
+  foundation plus the Decision 14 gate, with no claim of end-to-end
+  production usefulness.
+- `summary-forward-card` and `docs-share-card` remain unregistered until their
+  own tables are filled and reviewed.
 
 ### Capability and configuration
 
@@ -335,13 +721,19 @@ caller must map them through that endpoint's registered `errcode` facade.
   User Bot and App Bot, presentation-only `user.robot=1`, cross-table ambiguity,
   live User Bot creator and App Bot scope/Space policy metadata, and DB errors.
   No failed branch reaches the transport capture.
-- DM tests cover User Bot creator/friend allow, stranger deny, active Space
-  membership, wrong/missing Space, App Bot platform/scope-space rules, and App
-  Bot group/thread denial.
+- DM tests cover User Bot creator/friend allow, stranger deny,
+  system-notification-mode allow for a non-friend active Space member and deny
+  outside the verified Space, active Space membership, wrong/missing Space,
+  App Bot platform/scope-space rules, and App Bot group/thread denial.
 - Group/thread tests cover exact authoritative Space match, normal vs
   disabled/disbanded group, active/internal/blacklisted/deleted/non-member bot,
   valid/malformed/archived/deleted thread, and DB failure. All denials fail
   closed before card finalization/transport.
+- Member-exempt-mode tests prove a producer with the mode posts to a normal
+  same-Space group with **no membership row and no member-list/count side
+  effects**, is still denied on disbanded/disabled groups, wrong Space, and
+  invalid threads; a producer without the mode is denied as a non-member; and
+  no dispatch code path creates or mutates group membership.
 - Multi-Space tests prove the explicit request Space is verified and the
   dispatcher never silently selects the first membership.
 
@@ -363,6 +755,28 @@ caller must map them through that endpoint's registered `errcode` facade.
 - A boundary test starts below the size limit, grows during authoritative
   enrichment, and is rejected by `Finalize`/the final size gate. No mutation
   occurs after the explicit recheck before serialization/dispatch.
+
+### Internal notify card gate (Decision 14)
+
+- Integration tests prove a card-shaped payload (`type=17` map, per
+  `cardmsg.IsCardPayload`) to `/v1/internal/notify` and
+  `/v1/internal/notify/batch` is rejected with the registered error code and
+  produces zero `SendMessage` calls; a `type=1` text payload on the same
+  requests still delivers (existing smart-summary contract unchanged).
+- The new error code passes `make i18n-extract-check` + `make i18n-lint` and
+  has a zh-CN translation.
+
+### Card template and deep-link (pilot enablement)
+
+- Every `ResourceCard` template instantiation has a JSON snapshot test and
+  passes `cardmsg.Validate` under `octo/v1`; the excerpt truncation bound is
+  tested; template labels resolve via `i18n.OutboundLanguage`.
+- The deep-link is built only by the octo-server template layer from
+  `External` config; a template test pins the `/s/{taskId}?sp={spaceId}`
+  shape. smart-summary never constructs the URL.
+- octo-web registers the standalone `/s/:taskId` route with a route-contract
+  test (mirroring the `/d/:docId` cold-load/login/sid patterns); logged-in
+  navigation reaches the existing summary detail view.
 
 ### Dispatch, overload, and observability
 
@@ -399,7 +813,7 @@ caller must map them through that endpoint's registered `errcode` facade.
 - Focused commands pass:
   - `go test -race -cover ./internal/carddispatch/...`
   - target-authorizer DB integration tests;
-  - `go test ./pkg/cardmsg/... ./modules/botidentity/...`
+  - `go test ./pkg/cardmsg/... ./modules/botidentity/... ./modules/notify/...`
   - `go run ./tools/lint-card-dispatch ./modules ./internal`
   - `go vet ./internal/carddispatch/...`
   - `make i18n-extract-check && make i18n-lint`
@@ -407,9 +821,10 @@ caller must map them through that endpoint's registered `errcode` facade.
   - `git diff --check`
 - Broader package/full tests run with the repo's per-package MySQL/Redis reset
   discipline where local infrastructure permits.
-- With zero enabled production registrations, deployment is behaviorally inert.
-  Enabling the pilot is a separate reviewed config/code change with rollback by
-  disabling/removing that one registration; existing public producers continue
-  unaffected.
+- With zero enabled production registrations, deployment is behaviorally inert
+  except the Decision 14 rejection of card-shaped internal notify payloads
+  (no known legitimate caller sends them). Enabling the `summary-notify` pilot
+  is a separate reviewed config/code change with rollback by disabling/removing
+  that one registration; existing public producers continue unaffected.
 - Finish writes a shared journal/log entry and opens a separate PR with Linked
   Spec and substantive COMPREHENSION answers.

--- a/.octospec/tasks/card-message-internal-dispatch/brief.md
+++ b/.octospec/tasks/card-message-internal-dispatch/brief.md
@@ -451,7 +451,11 @@ not implement a mutable generic "send as any UID" service.
    群人数); every such send must be attributable to a recorded triggering
    member action in the owning module (task creation, forward click), and
    group/thread lifecycle plus Space equality remain verified fail-closed at
-   send time. Transport needs no membership (group system tips already post
+   send time. Member-exempt is *no-membership-required*, not
+   *membership-ignored*: an **explicit ban is still honored** — a bot carrying
+   a blacklisted group-member row (`group_member.status=2`) was deliberately
+   removed by an admin and is denied even in this mode. Transport needs no
+   membership (group system tips already post
    member-less, `modules/group/event.go:36`); this is policy, and the
    industry analog is Slack `chat:write.public` no-join posting, scoped to
    normal in-Space groups because DMWork has no public/private split. The
@@ -731,9 +735,10 @@ caller must map them through that endpoint's registered `errcode` facade.
   closed before card finalization/transport.
 - Member-exempt-mode tests prove a producer with the mode posts to a normal
   same-Space group with **no membership row and no member-list/count side
-  effects**, is still denied on disbanded/disabled groups, wrong Space, and
-  invalid threads; a producer without the mode is denied as a non-member; and
-  no dispatch code path creates or mutates group membership.
+  effects**, is still denied on disbanded/disabled groups, wrong Space,
+  invalid threads, and when the bot carries an explicit blacklist row
+  (`group_member.status=2`); a producer without the mode is denied as a
+  non-member; and no dispatch code path creates or mutates group membership.
 - Multi-Space tests prove the explicit request Space is verified and the
   dispatcher never silently selects the first membership.
 

--- a/.octospec/tasks/card-message-internal-dispatch/context.yaml
+++ b/.octospec/tasks/card-message-internal-dispatch/context.yaml
@@ -1,0 +1,14 @@
+injected:
+  - id: space-isolation
+    source: repo
+  - id: trust-boundary
+    source: repo
+  - id: error-handling
+    source: repo
+  - id: rate-limit
+    source: repo
+  - id: testing
+    source: repo
+  - id: commit-style
+    source: repo
+brief: .octospec/tasks/card-message-internal-dispatch/brief.md

--- a/.octospec/tasks/card-message-internal-dispatch/handoff.md
+++ b/.octospec/tasks/card-message-internal-dispatch/handoff.md
@@ -1,0 +1,185 @@
+# Handoff — card-message-internal-dispatch
+
+> Forward-looking guide for the next stage. The spec is `brief.md` in this
+> directory; this file says **where we are** and **what to do next**.
+> Last updated 2026-07-13.
+
+## TL;DR
+
+This task ships as **two PRs**:
+
+- **PR 1 — P1 (done):** the dormant `internal/carddispatch` foundation. Reviewed,
+  `go build/vet/test` green, **zero production producers registered**, so the only
+  runtime behaviour change is the notify card-payload gate (Decision 14). This is
+  the current `feat/card-message-internal-dispatch` branch.
+- **PR 2 — P2 (next stage):** enable the `summary-notify` pilot — a code/config
+  change across three repos that registers the first producer and turns summary
+  DMs into cards. Gated only by landing the template/deep-link guard tests.
+
+Every pilot decision is maintainer-confirmed (2026-07-13). Keeping P1 and P2 as
+separate PRs is deliberate (brief › rollout): the foundation is behaviourally
+inert, so it can merge and sit; enabling the pilot is the reviewed change with a
+one-line rollback (remove the producer spec).
+
+### PR hygiene note
+
+`feat/card-message-internal-dispatch` is based on a main that already carries
+#570 (App Bot card trust) and other merged work. When opening **PR 1**, base it
+on a main with #570 merged (or stack it on #570) so the foundation PR's diff is
+*only* `internal/carddispatch`, `pkg/cardtmpl`, `tools/lint-card-dispatch`, the
+notify gate, the botidentity resolver extension, and this task's docs — not a
+re-diff of #570.
+
+## Current state
+
+| Item | State |
+| --- | --- |
+| Brief (`brief.md`) | Complete; all decisions confirmed 2026-07-13 |
+| Foundation (`internal/carddispatch/`, `pkg/cardtmpl/`, `tools/lint-card-dispatch/`) | Implemented, `go build/vet/test` green |
+| Registry wiring (`main.go:346` `installCardDispatch`) | `NewRegistry(deps, nil)` — **zero producers**, behaviourally inert |
+| Decision 14 notify gate (`modules/notify/api.go`) | **Live** — rejects card-shaped payloads on `/v1/internal/notify[/batch]` |
+| Code review | Done; F1/F2/F3/F5 fixed (commit `d815947`), F4/F6 deferred (see below) |
+| Branches | `feat/card-message-internal-dispatch` = impl + review fixes. `claude/card-message-dispatch-f7ubz3` = brief only (now redundant; brief is byte-identical on feat) |
+
+## The P1 → P2 (dormant → enabled) boundary
+
+Enabling a producer is **one reviewed config/code change**: build a
+`carddispatch.ProducerSpec`, pass it to `NewRegistry`, obtain the bound
+`Sender`, and inject only that `Sender` into the owning module. Rollback =
+remove that one spec. Until then (all of P1) the package is a no-op except the
+notify gate.
+
+## P2 (PR 2) — enable the `summary-notify` pilot (DM summary cards)
+
+Cross-repo; land together. Owning module is `modules/notify`.
+
+### 2a. octo-server — provision the summary bot
+
+- Add a dedicated `summary` bot (static UID) provisioned as a full User Bot
+  (`user` + `app` + `robot.status=1`), mirroring `modules/notify/bot_manager.go`
+  `ensureNotifyBot`. Keep the `notification` bot for the generic text path.
+- Confirm `modules/botidentity` resolves the new UID as `KindUserBot`.
+
+### 2b. octo-server — register the pilot producer + inject the Sender
+
+In `installCardDispatch` (`main.go:346`) register the spec and thread the bound
+sender into `notify.New`:
+
+```go
+spec := carddispatch.ProducerSpec{
+    ID:                  "summary-notify",
+    Enabled:             true,
+    SenderUID:           notify.SummaryBotUID,            // the new summary bot
+    AllowedChannelTypes: []uint8{common.ChannelTypePerson.Uint8()}, // DM only at pilot
+    AllowedProfiles:     []string{cardmsg.ProfileV1},     // display-only
+    SpacePolicy:         carddispatch.SpacePolicySystemNotification, // notify semantics
+    GroupPolicy:         carddispatch.GroupPolicyMemberRequired,     // unused at DM pilot; group回发 flips to MemberExempt
+    ActionEventOwner:    "",                              // no octo/v2, no card_action owner
+    MaxInFlight:         20,                              // confirmed 2026-07-13
+}
+registry := carddispatch.NewRegistry(deps, []carddispatch.ProducerSpec{spec})
+// carddispatch.Install(ctx, registry) as today, then:
+sender, _ := registry.Sender("summary-notify")           // inject into notify.New(ctx, sender)
+```
+
+- `notify` builds the card via `cardtmpl.BuildSummaryResourceCard(...)` and calls
+  `sender.Send(ctx, target, card)` for the DM path. **Do not** send the card
+  through the existing `/v1/internal/notify` text path — that path stays
+  text-only and now rejects cards by design.
+- Web base URL for the deep link comes from `External` config
+  (`cardtmpl.summaryDeepLink` takes it as a param; reuse `External.WebLoginURL`
+  origin, decided at this review).
+
+### 2c. octo-smart-summary — send structured fields, not a hand-built card
+
+- Today the worker posts `{"type":1,"content":text}` to `/v1/internal/notify`
+  (`internal/notify/notify.go:283`, `client.go`). For cards, send **structured
+  fields** (title, time range, participant/message counts, `summary_id`) to the
+  card path; octo-server owns the template. Keep the existing per-recipient
+  `summary_notification` dedup/retry state machine and `X-Internal-Token`.
+- Duplicates on transport-ambiguous failure are accepted (no outbox) — confirmed.
+
+### 2d. octo-web — add the `/s/:taskId` deep-link route
+
+- Register a standalone browser route `/s/:taskId?sp={spaceId}` mirroring the
+  `/d/:docId` machinery (cold-load → login bounce → multi-session sid recovery,
+  the XIN-398 `recoverSession` suite). Logged-in navigation calls the existing
+  `WKApp.openSummaryDetail(taskId)`. No new renderer needed; type-17 already
+  renders. Add a route-contract test asserting `/s/:taskId` is registered.
+
+### P2 gating tests (must land with enablement)
+
+- octo-server: `pkg/cardtmpl` snapshot + `cardmsg.Validate` guards (exist);
+  the `summaryDeepLink` shape test.
+- octo-web: `/s/:taskId` route-contract test.
+- The DB-backed authorizer tests (`TestDBAuthorizerPolicyMatrix` etc.) run on
+  sqlite locally but should run against MySQL in CI per the brief.
+
+## After P2 (later PRs — brief has the detail)
+
+Each of these is its own follow-up PR after the pilot is live.
+
+- **group回发 (Scenario A1 group):** flip the pilot's `GroupPolicy` to
+  `GroupPolicyMemberExempt` and widen `AllowedChannelTypes`. This review MUST
+  add a **per-channel rate rule** and settle the **cluster-wide cap** (see
+  brief › Industry practice alignment). Member-exempt already honors explicit
+  group bans (F3). Delivery = post if group eligible, else creator-DM fallback.
+- **A2 user forward (`summary-forward-card`):** a new user-facing forward
+  endpoint on **summary-api** relaying through the existing `X-Internal-Token`
+  ingress with `actor_uid`; octo-server verifies the actor is an active member
+  of the target channel. Bot-sent card with a forwarder-attribution header;
+  **no OBO** (card-protocol Decision 2b). Person targets keep today's
+  plain-text forward — a bot cannot post into a two-party human DM.
+- **`docs-share-card`:** blocked on a docs S2S ingress + docs bot identity;
+  copy the A2 forward shape once those exist.
+
+## Locked decisions (2026-07-13)
+
+| Decision | Value |
+| --- | --- |
+| Sender identity | dedicated `summary` bot (not `notification`) |
+| Message ownership | bot-sent + forwarder-attribution header; OBO rejected |
+| Pilot channels / profile | DM only / `octo/v1` display-only |
+| Group posting (post-P2) | member-exempt: no membership required, member list/count untouched, **explicit ban honored** |
+| Concurrency | MaxInFlight 20 / process |
+| Duplicates | acceptable on transport-ambiguous failure; no outbox |
+| Cluster cap | none; per-process semaphore (replica count recorded at deploy review) |
+| Template + deep-link | `ResourceCard` in `pkg/cardtmpl`; `/s/:taskId?sp=` route |
+
+## Code-review status
+
+Fixed on `d815947` (this branch): **F1** wrapper-evasion in the guard, **F2**
+allowlist path-anchoring, **F3** member-exempt honors group bans, **F5** optional
+card icon. Deferred (non-blocking):
+
+- **F4 (low):** `tools/lint-card-dispatch` cross-file *constant-of-constant*
+  chains are file-order dependent (a package-level fixed point would close it).
+  Exotic shape; guard is a backstop.
+- **F6 (nit):** `cardtmpl.labelsForLanguage` hardcodes the two action labels
+  instead of using the i18n message catalog. Fine for two fixed strings.
+
+## Verify (focused command set from brief acceptance)
+
+```bash
+go test -race -cover ./internal/carddispatch/...
+go test ./pkg/cardmsg/... ./pkg/cardtmpl/... ./modules/botidentity/... ./modules/notify/...
+go run ./tools/lint-card-dispatch ./modules ./internal
+go vet ./internal/carddispatch/...
+make i18n-extract-check && make i18n-lint
+golangci-lint run ./...
+git diff --check
+```
+
+## Gotchas for the next implementer
+
+- **Don't route cards through `/v1/internal/notify`** — that path is text-only
+  and rejects cards (Decision 14). Cards go through the injected `Sender`.
+- **The `Sender` is producer-bound** — `SendRequest` has no `from_uid` and no
+  arbitrary payload; you pass a `Target` + a `Card{Profile, Document}` only.
+- **Registry is immutable** — one production instance owns all budgets; register
+  specs at bootstrap, never from `init()`.
+- **The guard must stay green** — adding any new type-17 transport owner fails
+  `tools/lint-card-dispatch`; onboard through the dispatcher or add a reviewed
+  path-anchored allowlist entry with a reason.
+- **DB authorizer tests use sqlite locally** but exercise real SQL — run them in
+  MySQL CI before enabling the pilot.

--- a/.octospec/tasks/card-message-internal-dispatch/handoff.md
+++ b/.octospec/tasks/card-message-internal-dispatch/handoff.md
@@ -115,6 +115,22 @@ sender, _ := registry.Sender("summary-notify")           // inject into notify.N
 - The DB-backed authorizer tests (`TestDBAuthorizerPolicyMatrix` etc.) run on
   sqlite locally but should run against MySQL in CI per the brief.
 
+### P2 preconditions raised in the P1 review (#577)
+
+- **WuKongIM transport timeout.** `SendMessageWithResult` → `network.Post` uses
+  a zero-value `http.Client{}` with no timeout, and the dispatcher holds a
+  producer in-flight slot across that call. A hung upstream would pin slots
+  until `busy`. Pre-existing platform-wide (every `SendMessage*` caller,
+  including today's notify pool) and cancellable transport is out of P1 scope —
+  but ensure the WuKongIM client carries a request timeout before enabling the
+  pilot, so the per-producer budget can't be pinned by a slow upstream.
+- **Large-integer JSON precision (octo/v2 only).** The card document is decoded
+  with default `json.Unmarshal`, so bare JSON numbers become `float64` (ints
+  above 2^53 lose precision on re-serialize). Harmless for `octo/v1` display
+  cards (strings/enums/URLs) and consistent with the `bot_api` ingress. If a
+  future `octo/v2` producer places large integer IDs in card data, switch that
+  path to `json.Decoder` + `UseNumber()`.
+
 ## After P2 (later PRs — brief has the detail)
 
 Each of these is its own follow-up PR after the pilot is live.

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ env-test:
 #                   - lint-unregistered-code: no inline codes.Code{} literals
 #                     passed to httperr.ResponseErrorL (registry bypass)
 
-.PHONY: i18n-extract i18n-extract-check i18n-merge i18n-lint
+.PHONY: i18n-extract i18n-extract-check i18n-merge i18n-lint card-dispatch-lint
 
 i18n-extract:
 	go run ./pkg/i18n/cmd/octo-i18n-extract
@@ -60,6 +60,9 @@ i18n-lint:
 
 i18n-extract-check:
 	go run ./pkg/i18n/cmd/octo-i18n-extract -check
+
+card-dispatch-lint:
+	go run ./tools/lint-card-dispatch ./modules ./internal
 
 i18n-merge: i18n-extract
 	@command -v goi18n >/dev/null 2>&1 || { \

--- a/internal/carddispatch/authorizer_db.go
+++ b/internal/carddispatch/authorizer_db.go
@@ -1,0 +1,185 @@
+package carddispatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/gocraft/dbr/v2"
+)
+
+type DBAuthorizer struct {
+	session *dbr.Session
+}
+
+func NewDBAuthorizer(session *dbr.Session) *DBAuthorizer {
+	return &DBAuthorizer{session: session}
+}
+
+func (a *DBAuthorizer) Authorize(ctx context.Context, identity *botidentity.Identity, target Target, policy AuthorizationPolicy) error {
+	if ctx == nil || identity == nil || a == nil || a.session == nil {
+		return denyTarget(errors.New("authorization dependencies unavailable"))
+	}
+	if err := ctx.Err(); err != nil {
+		return denyTarget(err)
+	}
+	active, err := a.count("SELECT COUNT(*) FROM space WHERE space_id=? AND status=1", target.SpaceID)
+	if err != nil {
+		return denyTarget(fmt.Errorf("query target space: %w", err))
+	}
+	if active == 0 {
+		return denyTarget(errors.New("target space is not active"))
+	}
+
+	switch target.ChannelType {
+	case common.ChannelTypePerson.Uint8():
+		return a.authorizeDM(identity, target, policy)
+	case common.ChannelTypeGroup.Uint8():
+		return a.authorizeGroup(identity, target.SpaceID, target.ChannelID, policy)
+	case common.ChannelTypeCommunityTopic.Uint8():
+		return a.authorizeThread(identity, target, policy)
+	default:
+		return denyTarget(errors.New("unsupported target type"))
+	}
+}
+
+func (a *DBAuthorizer) authorizeDM(identity *botidentity.Identity, target Target, policy AuthorizationPolicy) error {
+	targetMember, err := a.count(
+		"SELECT COUNT(*) FROM space_member WHERE space_id=? AND uid=? AND status=1",
+		target.SpaceID, target.ChannelID,
+	)
+	if err != nil {
+		return denyTarget(fmt.Errorf("query target membership: %w", err))
+	}
+	if targetMember == 0 {
+		return denyTarget(errors.New("recipient is not an active member of target space"))
+	}
+
+	switch identity.Kind {
+	case botidentity.KindAppBot:
+		switch identity.AppScope {
+		case botidentity.ScopePlatform:
+		case botidentity.ScopeSpace:
+			if identity.AppSpaceID == "" || identity.AppSpaceID != target.SpaceID {
+				return denyTarget(errors.New("space app bot scope mismatch"))
+			}
+		default:
+			return denyTarget(errors.New("unknown app bot scope"))
+		}
+		friend, err := a.friend(identity.UID, target.ChannelID)
+		if err != nil {
+			return denyTarget(fmt.Errorf("query app bot friend relation: %w", err))
+		}
+		if !friend {
+			return denyTarget(errors.New("app bot conversation not started"))
+		}
+		return nil
+
+	case botidentity.KindUserBot:
+		if policy.SpacePolicy == SpacePolicySystemNotification {
+			return nil
+		}
+		if policy.SpacePolicy != SpacePolicyMembership {
+			return denyTarget(errors.New("unsupported user bot space policy"))
+		}
+		senderMember, err := a.count(
+			"SELECT COUNT(*) FROM space_member WHERE space_id=? AND uid=? AND status=1",
+			target.SpaceID, identity.UID,
+		)
+		if err != nil {
+			return denyTarget(fmt.Errorf("query sender membership: %w", err))
+		}
+		if senderMember == 0 {
+			return denyTarget(errors.New("sender is not authorized in target space"))
+		}
+		if identity.CreatorUID != "" && identity.CreatorUID == target.ChannelID {
+			return nil
+		}
+		friend, err := a.friend(identity.UID, target.ChannelID)
+		if err != nil {
+			return denyTarget(fmt.Errorf("query user bot friend relation: %w", err))
+		}
+		if !friend {
+			return denyTarget(errors.New("user bot target is not creator or friend"))
+		}
+		return nil
+	default:
+		return denyTarget(errors.New("identity is not a supported bot"))
+	}
+}
+
+func (a *DBAuthorizer) authorizeGroup(identity *botidentity.Identity, spaceID, groupNo string, policy AuthorizationPolicy) error {
+	if identity.Kind != botidentity.KindUserBot {
+		return denyTarget(errors.New("app bots cannot target groups"))
+	}
+	var row struct {
+		SpaceID string `db:"space_id"`
+		Status  int    `db:"status"`
+	}
+	err := a.session.SelectBySql(
+		"SELECT space_id, status FROM `group` WHERE group_no=? LIMIT 1", groupNo,
+	).LoadOne(&row)
+	if err != nil {
+		return denyTarget(fmt.Errorf("query group: %w", err))
+	}
+	if row.Status != group.GroupStatusNormal || row.SpaceID == "" || row.SpaceID != spaceID {
+		return denyTarget(errors.New("group is not active in target space"))
+	}
+	if policy.GroupPolicy == GroupPolicyMemberExempt {
+		return nil
+	}
+	if policy.GroupPolicy != GroupPolicyMemberRequired {
+		return denyTarget(errors.New("unsupported group policy"))
+	}
+	member, err := a.count(
+		"SELECT COUNT(*) FROM group_member WHERE group_no=? AND uid=? AND status=1 AND is_deleted=0 AND is_external=0 AND robot=1",
+		groupNo, identity.UID,
+	)
+	if err != nil {
+		return denyTarget(fmt.Errorf("query bot group membership: %w", err))
+	}
+	if member == 0 {
+		return denyTarget(errors.New("bot is not an active internal group member"))
+	}
+	return nil
+}
+
+func (a *DBAuthorizer) authorizeThread(identity *botidentity.Identity, target Target, policy AuthorizationPolicy) error {
+	groupNo, shortID, err := thread.ParseChannelID(target.ChannelID)
+	if err != nil {
+		return denyTarget(err)
+	}
+	var status int
+	err = a.session.SelectBySql(
+		"SELECT status FROM thread WHERE group_no=? AND short_id=? LIMIT 1", groupNo, shortID,
+	).LoadOne(&status)
+	if err != nil {
+		return denyTarget(fmt.Errorf("query thread: %w", err))
+	}
+	if status != thread.ThreadStatusActive {
+		return denyTarget(errors.New("thread is not active"))
+	}
+	return a.authorizeGroup(identity, target.SpaceID, groupNo, policy)
+}
+
+func (a *DBAuthorizer) friend(uid, targetUID string) (bool, error) {
+	count, err := a.count(
+		"SELECT COUNT(*) FROM friend WHERE uid=? AND to_uid=? AND is_deleted=0",
+		uid, targetUID,
+	)
+	return count > 0, err
+}
+
+func (a *DBAuthorizer) count(query string, args ...interface{}) (int, error) {
+	var count int
+	err := a.session.SelectBySql(query, args...).LoadOne(&count)
+	return count, err
+}
+
+func denyTarget(cause error) error {
+	return fmt.Errorf("%w: %v", ErrTargetDenied, cause)
+}

--- a/internal/carddispatch/authorizer_db.go
+++ b/internal/carddispatch/authorizer_db.go
@@ -130,6 +130,20 @@ func (a *DBAuthorizer) authorizeGroup(identity *botidentity.Identity, spaceID, g
 		return denyTarget(errors.New("group is not active in target space"))
 	}
 	if policy.GroupPolicy == GroupPolicyMemberExempt {
+		// Member-exempt posting does not require a membership row, but it must
+		// still honor an explicit ban: a bot with a blacklisted membership row
+		// was deliberately removed by a group admin and must not reappear via
+		// this mode. Absence of any row (the pilot bot never joins) still posts.
+		blacklisted, err := a.count(
+			"SELECT COUNT(*) FROM group_member WHERE group_no=? AND uid=? AND status=? AND is_deleted=0",
+			groupNo, identity.UID, int(common.GroupMemberStatusBlacklist),
+		)
+		if err != nil {
+			return denyTarget(fmt.Errorf("query bot group blacklist: %w", err))
+		}
+		if blacklisted > 0 {
+			return denyTarget(errors.New("bot is blacklisted from target group"))
+		}
 		return nil
 	}
 	if policy.GroupPolicy != GroupPolicyMemberRequired {

--- a/internal/carddispatch/authorizer_db_test.go
+++ b/internal/carddispatch/authorizer_db_test.go
@@ -1,0 +1,199 @@
+package carddispatch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/gocraft/dbr/v2"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newAuthorizerDB(t *testing.T) *dbr.Session {
+	t.Helper()
+	conn, err := dbr.Open("sqlite3", ":memory:", nil)
+	require.NoError(t, err)
+	conn.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = conn.Close() })
+	session := conn.NewSession(nil)
+	statements := []string{
+		`CREATE TABLE space (space_id TEXT PRIMARY KEY, status INTEGER NOT NULL)`,
+		`CREATE TABLE space_member (space_id TEXT NOT NULL, uid TEXT NOT NULL, status INTEGER NOT NULL)`,
+		`CREATE TABLE friend (uid TEXT NOT NULL, to_uid TEXT NOT NULL, is_deleted INTEGER NOT NULL)`,
+		`CREATE TABLE "group" (group_no TEXT PRIMARY KEY, space_id TEXT NOT NULL, status INTEGER NOT NULL)`,
+		`CREATE TABLE group_member (group_no TEXT NOT NULL, uid TEXT NOT NULL, status INTEGER NOT NULL, is_deleted INTEGER NOT NULL, is_external INTEGER NOT NULL, robot INTEGER NOT NULL)`,
+		`CREATE TABLE thread (short_id TEXT NOT NULL, group_no TEXT NOT NULL, status INTEGER NOT NULL, PRIMARY KEY (group_no, short_id))`,
+		`INSERT INTO space(space_id,status) VALUES ('space-a',1),('space-b',1),('space-disabled',2)`,
+		`INSERT INTO space_member(space_id,uid,status) VALUES
+			('space-a','bot-user',1),
+			('space-a','owner-a',1),
+			('space-a','friend-a',1),
+			('space-a','member-a',1),
+			('space-a','stranger-a',1),
+			('space-b','outside-b',1),
+			('space-disabled','disabled-member',1)`,
+		`INSERT INTO friend(uid,to_uid,is_deleted) VALUES
+			('bot-user','friend-a',0),
+			('app-platform','member-a',0),
+			('app-space','member-a',0)`,
+		`INSERT INTO "group"(group_no,space_id,status) VALUES
+			('group-ok','space-a',1),
+			('group-no-member','space-a',1),
+			('group-blacklisted','space-a',1),
+			('group-external','space-a',1),
+			('group-deleted-member','space-a',1),
+			('group-disabled','space-a',0),
+			('group-disbanded','space-a',2),
+			('group-wrong-space','space-b',1)`,
+		`INSERT INTO group_member(group_no,uid,status,is_deleted,is_external,robot) VALUES
+			('group-ok','bot-user',1,0,0,1),
+			('group-blacklisted','bot-user',2,0,0,1),
+			('group-external','bot-user',1,0,1,1),
+			('group-deleted-member','bot-user',1,1,0,1)`,
+		`INSERT INTO thread(short_id,group_no,status) VALUES
+			('123456789012345','group-ok',1),
+			('123456789012346','group-ok',2),
+			('123456789012347','group-ok',3),
+			('123456789012348','group-no-member',1)`,
+	}
+	for _, statement := range statements {
+		_, err := session.Exec(statement)
+		require.NoError(t, err, "statement=%s", statement)
+	}
+	return session
+}
+
+func TestDBAuthorizerPolicyMatrix(t *testing.T) {
+	session := newAuthorizerDB(t)
+	authorizer := NewDBAuthorizer(session)
+	userBot := &botidentity.Identity{UID: "bot-user", Kind: botidentity.KindUserBot, CreatorUID: "owner-a"}
+	platformApp := &botidentity.Identity{UID: "app-platform", Kind: botidentity.KindAppBot, AppScope: botidentity.ScopePlatform}
+	spaceApp := &botidentity.Identity{UID: "app-space", Kind: botidentity.KindAppBot, AppScope: botidentity.ScopeSpace, AppSpaceID: "space-a"}
+	standard := AuthorizationPolicy{SpacePolicy: SpacePolicyMembership, GroupPolicy: GroupPolicyMemberRequired}
+	systemNotification := AuthorizationPolicy{SpacePolicy: SpacePolicySystemNotification, GroupPolicy: GroupPolicyMemberRequired}
+	memberExempt := AuthorizationPolicy{SpacePolicy: SpacePolicyMembership, GroupPolicy: GroupPolicyMemberExempt}
+
+	cases := []struct {
+		name     string
+		identity *botidentity.Identity
+		target   Target
+		policy   AuthorizationPolicy
+		allowed  bool
+	}{
+		{name: "user bot creator dm", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "owner-a", ChannelType: common.ChannelTypePerson.Uint8()}, policy: standard, allowed: true},
+		{name: "user bot friend dm", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "friend-a", ChannelType: common.ChannelTypePerson.Uint8()}, policy: standard, allowed: true},
+		{name: "user bot stranger dm", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "stranger-a", ChannelType: common.ChannelTypePerson.Uint8()}, policy: standard},
+		{name: "system notification dm to active member", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "stranger-a", ChannelType: common.ChannelTypePerson.Uint8()}, policy: systemNotification, allowed: true},
+		{name: "system notification outside verified space", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "outside-b", ChannelType: common.ChannelTypePerson.Uint8()}, policy: systemNotification},
+		{name: "disabled space", identity: userBot, target: Target{SpaceID: "space-disabled", ChannelID: "disabled-member", ChannelType: common.ChannelTypePerson.Uint8()}, policy: systemNotification},
+		{name: "platform app dm", identity: platformApp, target: Target{SpaceID: "space-a", ChannelID: "member-a", ChannelType: common.ChannelTypePerson.Uint8()}, policy: standard, allowed: true},
+		{name: "platform app dm without friend", identity: platformApp, target: Target{SpaceID: "space-a", ChannelID: "stranger-a", ChannelType: common.ChannelTypePerson.Uint8()}, policy: standard},
+		{name: "space app dm", identity: spaceApp, target: Target{SpaceID: "space-a", ChannelID: "member-a", ChannelType: common.ChannelTypePerson.Uint8()}, policy: standard, allowed: true},
+		{name: "space app wrong space", identity: spaceApp, target: Target{SpaceID: "space-b", ChannelID: "outside-b", ChannelType: common.ChannelTypePerson.Uint8()}, policy: standard},
+		{name: "app bot unknown scope", identity: &botidentity.Identity{UID: "app-platform", Kind: botidentity.KindAppBot, AppScope: "unknown"}, target: Target{SpaceID: "space-a", ChannelID: "member-a", ChannelType: common.ChannelTypePerson.Uint8()}, policy: standard},
+		{name: "user bot missing sender membership", identity: &botidentity.Identity{UID: "bot-missing", Kind: botidentity.KindUserBot, CreatorUID: "owner-a"}, target: Target{SpaceID: "space-a", ChannelID: "owner-a", ChannelType: common.ChannelTypePerson.Uint8()}, policy: standard},
+		{name: "user bot invalid space policy", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "owner-a", ChannelType: common.ChannelTypePerson.Uint8()}, policy: AuthorizationPolicy{SpacePolicy: "invalid", GroupPolicy: GroupPolicyMemberRequired}},
+		{name: "unsupported identity kind", identity: &botidentity.Identity{UID: "bot-user", Kind: "unknown"}, target: Target{SpaceID: "space-a", ChannelID: "owner-a", ChannelType: common.ChannelTypePerson.Uint8()}, policy: standard},
+		{name: "app bot group denied", identity: platformApp, target: Target{SpaceID: "space-a", ChannelID: "group-ok", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: standard},
+		{name: "user bot group member", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "group-ok", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: standard, allowed: true},
+		{name: "user bot group non-member", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "group-no-member", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: standard},
+		{name: "member exempt group", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "group-no-member", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: memberExempt, allowed: true},
+		{name: "blacklisted bot member", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "group-blacklisted", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: standard},
+		{name: "external bot member", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "group-external", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: standard},
+		{name: "deleted bot member", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "group-deleted-member", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: standard},
+		{name: "disabled group", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "group-disabled", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: memberExempt},
+		{name: "disbanded group", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "group-disbanded", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: memberExempt},
+		{name: "wrong space group", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "group-wrong-space", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: memberExempt},
+		{name: "missing group", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "group-missing", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: memberExempt},
+		{name: "invalid group policy", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "group-ok", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: AuthorizationPolicy{SpacePolicy: SpacePolicyMembership, GroupPolicy: "invalid"}},
+		{name: "active thread", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: thread.BuildChannelID("group-ok", "123456789012345"), ChannelType: common.ChannelTypeCommunityTopic.Uint8()}, policy: standard, allowed: true},
+		{name: "member exempt active thread", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: thread.BuildChannelID("group-no-member", "123456789012348"), ChannelType: common.ChannelTypeCommunityTopic.Uint8()}, policy: memberExempt, allowed: true},
+		{name: "archived thread", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: thread.BuildChannelID("group-ok", "123456789012346"), ChannelType: common.ChannelTypeCommunityTopic.Uint8()}, policy: standard},
+		{name: "deleted thread", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: thread.BuildChannelID("group-ok", "123456789012347"), ChannelType: common.ChannelTypeCommunityTopic.Uint8()}, policy: standard},
+		{name: "malformed thread", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "bad-thread", ChannelType: common.ChannelTypeCommunityTopic.Uint8()}, policy: standard},
+		{name: "missing thread", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: thread.BuildChannelID("group-ok", "999999999999999"), ChannelType: common.ChannelTypeCommunityTopic.Uint8()}, policy: standard},
+		{name: "unsupported channel", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "x", ChannelType: common.ChannelTypeInfo.Uint8()}, policy: standard},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := authorizer.Authorize(context.Background(), tc.identity, tc.target, tc.policy)
+			if tc.allowed {
+				require.NoError(t, err)
+				return
+			}
+			assert.ErrorIs(t, err, ErrTargetDenied)
+		})
+	}
+}
+
+func TestDBAuthorizerMemberExemptDoesNotMutateMembership(t *testing.T) {
+	session := newAuthorizerDB(t)
+	authorizer := NewDBAuthorizer(session)
+	identity := &botidentity.Identity{UID: "bot-user", Kind: botidentity.KindUserBot, CreatorUID: "owner-a"}
+	target := Target{SpaceID: "space-a", ChannelID: "group-no-member", ChannelType: common.ChannelTypeGroup.Uint8()}
+	policy := AuthorizationPolicy{SpacePolicy: SpacePolicyMembership, GroupPolicy: GroupPolicyMemberExempt}
+
+	var before int
+	require.NoError(t, session.SelectBySql("SELECT COUNT(*) FROM group_member WHERE group_no=? AND uid=?", target.ChannelID, identity.UID).LoadOne(&before))
+	require.NoError(t, authorizer.Authorize(context.Background(), identity, target, policy))
+	var after int
+	require.NoError(t, session.SelectBySql("SELECT COUNT(*) FROM group_member WHERE group_no=? AND uid=?", target.ChannelID, identity.UID).LoadOne(&after))
+	assert.Zero(t, before)
+	assert.Equal(t, before, after)
+}
+
+func TestDBAuthorizerFailsClosedOnDatabaseError(t *testing.T) {
+	conn, err := dbr.Open("sqlite3", ":memory:", nil)
+	require.NoError(t, err)
+	session := conn.NewSession(nil)
+	require.NoError(t, conn.Close())
+	authorizer := NewDBAuthorizer(session)
+	identity := &botidentity.Identity{UID: "bot-user", Kind: botidentity.KindUserBot}
+	err = authorizer.Authorize(context.Background(), identity, validTarget(), AuthorizationPolicy{})
+	assert.ErrorIs(t, err, ErrTargetDenied)
+}
+
+func TestDBAuthorizerRejectsUnavailableDependenciesAndCancellation(t *testing.T) {
+	session := newAuthorizerDB(t)
+	identity := &botidentity.Identity{UID: "bot-user", Kind: botidentity.KindUserBot}
+	policy := AuthorizationPolicy{SpacePolicy: SpacePolicyMembership, GroupPolicy: GroupPolicyMemberRequired}
+
+	assert.ErrorIs(t, NewDBAuthorizer(nil).Authorize(context.Background(), identity, validTarget(), policy), ErrTargetDenied)
+	assert.ErrorIs(t, NewDBAuthorizer(session).Authorize(context.Background(), nil, validTarget(), policy), ErrTargetDenied)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.ErrorIs(t, NewDBAuthorizer(session).Authorize(ctx, identity, validTarget(), policy), ErrTargetDenied)
+}
+
+func TestDBAuthorizerFailsClosedAtEveryStorageStage(t *testing.T) {
+	identity := &botidentity.Identity{UID: "bot-user", Kind: botidentity.KindUserBot, CreatorUID: "owner-a"}
+	standard := AuthorizationPolicy{SpacePolicy: SpacePolicyMembership, GroupPolicy: GroupPolicyMemberRequired}
+	cases := []struct {
+		name   string
+		drop   string
+		id     *botidentity.Identity
+		target Target
+		policy AuthorizationPolicy
+	}{
+		{name: "recipient membership", drop: "space_member", id: identity, target: Target{SpaceID: "space-a", ChannelID: "owner-a", ChannelType: common.ChannelTypePerson.Uint8()}, policy: standard},
+		{name: "friend relation", drop: "friend", id: &botidentity.Identity{UID: "app-platform", Kind: botidentity.KindAppBot, AppScope: botidentity.ScopePlatform}, target: Target{SpaceID: "space-a", ChannelID: "member-a", ChannelType: common.ChannelTypePerson.Uint8()}, policy: standard},
+		{name: "group", drop: "`group`", id: identity, target: Target{SpaceID: "space-a", ChannelID: "group-ok", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: standard},
+		{name: "group membership", drop: "group_member", id: identity, target: Target{SpaceID: "space-a", ChannelID: "group-ok", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: standard},
+		{name: "thread", drop: "thread", id: identity, target: Target{SpaceID: "space-a", ChannelID: thread.BuildChannelID("group-ok", "123456789012345"), ChannelType: common.ChannelTypeCommunityTopic.Uint8()}, policy: standard},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			session := newAuthorizerDB(t)
+			_, err := session.Exec("DROP TABLE " + tc.drop)
+			require.NoError(t, err)
+			err = NewDBAuthorizer(session).Authorize(context.Background(), tc.id, tc.target, tc.policy)
+			assert.ErrorIs(t, err, ErrTargetDenied)
+		})
+	}
+}

--- a/internal/carddispatch/authorizer_db_test.go
+++ b/internal/carddispatch/authorizer_db_test.go
@@ -102,6 +102,8 @@ func TestDBAuthorizerPolicyMatrix(t *testing.T) {
 		{name: "user bot group member", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "group-ok", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: standard, allowed: true},
 		{name: "user bot group non-member", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "group-no-member", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: standard},
 		{name: "member exempt group", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "group-no-member", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: memberExempt, allowed: true},
+		{name: "member exempt normal member group", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "group-ok", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: memberExempt, allowed: true},
+		{name: "member exempt honors explicit blacklist", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "group-blacklisted", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: memberExempt},
 		{name: "blacklisted bot member", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "group-blacklisted", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: standard},
 		{name: "external bot member", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "group-external", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: standard},
 		{name: "deleted bot member", identity: userBot, target: Target{SpaceID: "space-a", ChannelID: "group-deleted-member", ChannelType: common.ChannelTypeGroup.Uint8()}, policy: standard},

--- a/internal/carddispatch/context.go
+++ b/internal/carddispatch/context.go
@@ -1,0 +1,34 @@
+package carddispatch
+
+import "errors"
+
+const registryContextKey = "octo-server.internal.carddispatch.registry.v1"
+
+type ValueStore interface {
+	SetValue(value interface{}, key string)
+	Value(key string) interface{}
+}
+
+// Install publishes one immutable registry into one application context. It is
+// called only by the single-threaded bootstrap path before module construction.
+func Install(ctx ValueStore, registry *Registry) error {
+	if ctx == nil || registry == nil {
+		return errors.New("carddispatch: registry install requires context and registry")
+	}
+	if ctx.Value(registryContextKey) != nil {
+		return ErrRegistryAlreadyInstalled
+	}
+	ctx.SetValue(registry, registryContextKey)
+	return nil
+}
+
+func SenderFromContext(ctx ValueStore, id ProducerID) (Sender, error) {
+	if ctx == nil {
+		return nil, categorized(CategoryProducerDisabled, errors.New("application context unavailable"))
+	}
+	registry, ok := ctx.Value(registryContextKey).(*Registry)
+	if !ok || registry == nil {
+		return nil, categorized(CategoryProducerDisabled, errors.New("registry unavailable"))
+	}
+	return registry.Sender(id)
+}

--- a/internal/carddispatch/dispatch.go
+++ b/internal/carddispatch/dispatch.go
@@ -1,0 +1,229 @@
+package carddispatch
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/reqid"
+	"go.uber.org/zap"
+)
+
+type producerSender struct {
+	spec             ProducerSpec
+	identityResolver IdentityResolver
+	authorizer       Authorizer
+	transport        Transport
+	metrics          *Metrics
+	logger           interface {
+		Info(msg string, fields ...zap.Field)
+		Error(msg string, fields ...zap.Field)
+	}
+	featureEnabled func() bool
+	slots          chan struct{}
+}
+
+func (s *producerSender) Send(ctx context.Context, target Target, card Card) (result *Result, err error) {
+	producer := string(s.spec.ID)
+	targetLabel := normalizedTargetKind(target.ChannelType)
+	started := s.metrics.begin(producer, targetLabel)
+	terminal := CategoryDispatchFailed
+	defer func() { s.metrics.finish(producer, targetLabel, started, terminal) }()
+
+	if err := validateRequest(ctx, target, card); err != nil {
+		terminal = CategoryInvalidRequest
+		return nil, categorized(terminal, err)
+	}
+	if !s.featureEnabled() {
+		terminal = CategoryFeatureDisabled
+		return nil, categorized(terminal, errors.New("global card feature disabled"))
+	}
+	if !containsUint8(s.spec.AllowedChannelTypes, target.ChannelType) || !containsString(s.spec.AllowedProfiles, card.Profile) {
+		terminal = CategoryProducerDisabled
+		return nil, categorized(terminal, errors.New("producer policy does not allow target or profile"))
+	}
+
+	select {
+	case s.slots <- struct{}{}:
+		s.metrics.addInFlight(producer, 1)
+		defer func() {
+			<-s.slots
+			s.metrics.addInFlight(producer, -1)
+		}()
+	default:
+		terminal = CategoryBusy
+		return nil, categorized(terminal, errors.New("producer concurrency saturated"))
+	}
+
+	// The caller can mutate its RawMessage immediately after this copy without
+	// racing validation, finalization, or transport serialization.
+	document := append([]byte(nil), card.Document...)
+	if err := ctx.Err(); err != nil {
+		terminal = CategoryDispatchFailed
+		return nil, categorized(terminal, err)
+	}
+
+	identity, resolveErr := s.identityResolver.Resolve(s.spec.SenderUID)
+	if resolveErr != nil || identity == nil || identity.UID != s.spec.SenderUID || strings.HasPrefix(identity.UID, "iwh_") {
+		terminal = CategoryIdentityUntrusted
+		if resolveErr == nil {
+			resolveErr = errors.New("bound sender is not an active authoritative bot")
+		}
+		return nil, categorized(terminal, resolveErr)
+	}
+	if identity.Kind != botidentity.KindUserBot && identity.Kind != botidentity.KindAppBot {
+		terminal = CategoryIdentityUntrusted
+		return nil, categorized(terminal, errors.New("unsupported bot identity kind"))
+	}
+
+	policy := AuthorizationPolicy{SpacePolicy: s.spec.SpacePolicy, GroupPolicy: s.spec.GroupPolicy}
+	if authErr := s.authorizer.Authorize(ctx, identity, target, policy); authErr != nil {
+		terminal = CategoryTargetDenied
+		return nil, categorized(terminal, authErr)
+	}
+
+	var cardDocument map[string]interface{}
+	if decodeErr := json.Unmarshal(document, &cardDocument); decodeErr != nil || len(cardDocument) == 0 {
+		terminal = CategoryCardInvalid
+		if decodeErr == nil {
+			decodeErr = errors.New("card document must be a non-empty JSON object")
+		}
+		return nil, categorized(terminal, decodeErr)
+	}
+	payload := map[string]interface{}{
+		"type":         cardmsg.InteractiveCard.Int(),
+		"card_version": cardmsg.CardVersion,
+		"profile":      card.Profile,
+		"card":         cardDocument,
+	}
+	if validateErr := cardmsg.Validate(payload); validateErr != nil {
+		terminal = cardErrorCategory(validateErr)
+		return nil, categorized(terminal, validateErr)
+	}
+
+	// Authorization has already established this exact active Space. It is the
+	// only source allowed to enrich the wire envelope.
+	payload["space_id"] = target.SpaceID
+	if finalizeErr := cardmsg.Finalize(payload); finalizeErr != nil {
+		terminal = cardErrorCategory(finalizeErr)
+		return nil, categorized(terminal, finalizeErr)
+	}
+	if sizeErr := cardmsg.RecheckPayloadSize(payload); sizeErr != nil {
+		terminal = cardErrorCategory(sizeErr)
+		return nil, categorized(terminal, sizeErr)
+	}
+	wire, marshalErr := json.Marshal(payload)
+	if marshalErr != nil {
+		terminal = CategoryCardInvalid
+		return nil, categorized(terminal, marshalErr)
+	}
+	if err := ctx.Err(); err != nil {
+		terminal = CategoryDispatchFailed
+		return nil, categorized(terminal, err)
+	}
+
+	response, transportErr := s.transport.SendMessageWithResult(&config.MsgSendReq{
+		Header:      config.MsgHeader{RedDot: 1},
+		FromUID:     s.spec.SenderUID,
+		ChannelID:   target.ChannelID,
+		ChannelType: target.ChannelType,
+		Payload:     wire,
+	})
+	if transportErr != nil || response == nil {
+		terminal = CategoryDispatchFailed
+		if transportErr == nil {
+			transportErr = errors.New("transport returned an empty result")
+		}
+		if s.logger != nil {
+			s.logger.Error("internal card dispatch failed",
+				zap.String("request_id", reqid.FromContext(ctx)),
+				zap.String("producer", producer),
+				zap.String("sender_kind", string(identity.Kind)),
+				zap.String("space_id", target.SpaceID),
+				zap.String("target_kind", targetLabel),
+				zap.Error(transportErr))
+		}
+		return nil, categorized(terminal, transportErr)
+	}
+
+	terminal = CategoryOK
+	result = &Result{
+		MessageID:   response.MessageID,
+		MessageSeq:  response.MessageSeq,
+		ClientMsgNo: response.ClientMsgNo,
+	}
+	if s.logger != nil {
+		s.logger.Info("internal card dispatched",
+			zap.String("request_id", reqid.FromContext(ctx)),
+			zap.String("producer", producer),
+			zap.String("sender_kind", string(identity.Kind)),
+			zap.String("space_id", target.SpaceID),
+			zap.String("target_kind", targetLabel),
+			zap.Int64("message_id", result.MessageID),
+			zap.Uint32("message_seq", result.MessageSeq),
+			zap.String("client_msg_no", result.ClientMsgNo))
+	}
+	return result, nil
+}
+
+func validateRequest(ctx context.Context, target Target, card Card) error {
+	if ctx == nil {
+		return errors.New("context is required")
+	}
+	if strings.TrimSpace(target.SpaceID) == "" || strings.TrimSpace(target.ChannelID) == "" {
+		return errors.New("space and channel are required")
+	}
+	switch target.ChannelType {
+	case common.ChannelTypePerson.Uint8(), common.ChannelTypeGroup.Uint8(), common.ChannelTypeCommunityTopic.Uint8():
+	default:
+		return fmt.Errorf("unsupported channel type %d", target.ChannelType)
+	}
+	if strings.TrimSpace(card.Profile) == "" || len(card.Document) == 0 {
+		return errors.New("profile and card document are required")
+	}
+	return nil
+}
+
+func cardErrorCategory(err error) Category {
+	if errors.Is(err, cardmsg.ErrCardPayloadTooLarge) {
+		return CategoryPayloadTooLarge
+	}
+	return CategoryCardInvalid
+}
+
+func normalizedTargetKind(channelType uint8) string {
+	switch channelType {
+	case common.ChannelTypePerson.Uint8():
+		return "person"
+	case common.ChannelTypeGroup.Uint8():
+		return "group"
+	case common.ChannelTypeCommunityTopic.Uint8():
+		return "thread"
+	default:
+		return "unknown"
+	}
+}
+
+func containsUint8(values []uint8, want uint8) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/carddispatch/dispatch.go
+++ b/internal/carddispatch/dispatch.go
@@ -61,8 +61,12 @@ func (s *producerSender) Send(ctx context.Context, target Target, card Card) (re
 		return nil, categorized(terminal, errors.New("producer concurrency saturated"))
 	}
 
-	// The caller can mutate its RawMessage immediately after this copy without
-	// racing validation, finalization, or transport serialization.
+	// Snapshot the caller's bytes: once copied, a caller that retains and later
+	// mutates its RawMessage cannot affect validation, finalization, or
+	// transport serialization, which all read this private copy. (A caller that
+	// mutates the same slice *concurrently* with this call is a caller-side data
+	// race the copy cannot prevent; callers must not share a Card across
+	// goroutines mid-Send.)
 	document := append([]byte(nil), card.Document...)
 	if err := ctx.Err(); err != nil {
 		terminal = CategoryDispatchFailed

--- a/internal/carddispatch/dispatch_test.go
+++ b/internal/carddispatch/dispatch_test.go
@@ -1,0 +1,677 @@
+package carddispatch
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type fakeIdentityResolver struct {
+	identity *botidentity.Identity
+	err      error
+	calls    atomic.Int32
+	hook     func()
+}
+
+func (f *fakeIdentityResolver) Resolve(string) (*botidentity.Identity, error) {
+	f.calls.Add(1)
+	if f.hook != nil {
+		f.hook()
+	}
+	return f.identity, f.err
+}
+
+type fakeAuthorizer struct {
+	err    error
+	calls  atomic.Int32
+	target Target
+	policy AuthorizationPolicy
+	hook   func()
+}
+
+func (f *fakeAuthorizer) Authorize(_ context.Context, _ *botidentity.Identity, target Target, policy AuthorizationPolicy) error {
+	f.calls.Add(1)
+	f.target = target
+	f.policy = policy
+	if f.hook != nil {
+		f.hook()
+	}
+	return f.err
+}
+
+type fakeTransport struct {
+	mu      sync.Mutex
+	calls   int
+	req     *config.MsgSendReq
+	resp    *config.MsgSendResp
+	err     error
+	started chan struct{}
+	release chan struct{}
+}
+
+type fakeLogger struct {
+	infoCalls  atomic.Int32
+	errorCalls atomic.Int32
+}
+
+func (f *fakeLogger) Info(string, ...zap.Field)  { f.infoCalls.Add(1) }
+func (f *fakeLogger) Debug(string, ...zap.Field) {}
+func (f *fakeLogger) Error(string, ...zap.Field) { f.errorCalls.Add(1) }
+func (f *fakeLogger) Warn(string, ...zap.Field)  {}
+
+type fakeValueStore struct {
+	mu     sync.Mutex
+	values map[string]interface{}
+}
+
+func (f *fakeValueStore) SetValue(value interface{}, key string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.values == nil {
+		f.values = make(map[string]interface{})
+	}
+	f.values[key] = value
+}
+
+func (f *fakeValueStore) Value(key string) interface{} {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.values[key]
+}
+
+func (f *fakeTransport) SendMessageWithResult(req *config.MsgSendReq) (*config.MsgSendResp, error) {
+	f.mu.Lock()
+	f.calls++
+	copyReq := *req
+	copyReq.Payload = append([]byte(nil), req.Payload...)
+	f.req = &copyReq
+	started := f.started
+	release := f.release
+	f.mu.Unlock()
+	if started != nil {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+	}
+	if release != nil {
+		<-release
+	}
+	return f.resp, f.err
+}
+
+func (f *fakeTransport) snapshot() (int, *config.MsgSendReq) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls, f.req
+}
+
+func validCardDocument() json.RawMessage {
+	return json.RawMessage(`{"type":"AdaptiveCard","version":"1.5","body":[{"type":"TextBlock","text":"**hello**"}]}`)
+}
+
+func validSpec() ProducerSpec {
+	return ProducerSpec{
+		ID:                  "summary-notify",
+		Enabled:             true,
+		SenderUID:           "summary",
+		AllowedChannelTypes: []uint8{common.ChannelTypePerson.Uint8()},
+		AllowedProfiles:     []string{cardmsg.ProfileV1},
+		SpacePolicy:         SpacePolicySystemNotification,
+		GroupPolicy:         GroupPolicyMemberRequired,
+		MaxInFlight:         1,
+	}
+}
+
+func validTarget() Target {
+	return Target{SpaceID: "space-a", ChannelID: "user-a", ChannelType: common.ChannelTypePerson.Uint8()}
+}
+
+func newHarness(t *testing.T, spec ProducerSpec) (*Registry, *fakeIdentityResolver, *fakeAuthorizer, *fakeTransport, *prometheus.Registry) {
+	t.Helper()
+	resolver := &fakeIdentityResolver{identity: &botidentity.Identity{
+		UID:        spec.SenderUID,
+		Kind:       botidentity.KindUserBot,
+		CreatorUID: "owner-a",
+	}}
+	authorizer := &fakeAuthorizer{}
+	transport := &fakeTransport{resp: &config.MsgSendResp{MessageID: 42, MessageSeq: 7, ClientMsgNo: "client-42"}}
+	promRegistry := prometheus.NewRegistry()
+	registry := NewRegistry(Dependencies{
+		IdentityResolver: resolver,
+		Authorizer:       authorizer,
+		Transport:        transport,
+		Metrics:          NewMetrics(promRegistry),
+		FeatureEnabled:   func() bool { return true },
+	}, []ProducerSpec{spec})
+	return registry, resolver, authorizer, transport, promRegistry
+}
+
+func requireCategory(t *testing.T, want Category, err error) {
+	t.Helper()
+	require.Error(t, err)
+	assert.Equal(t, want, CategoryOf(err), "err=%v", err)
+}
+
+func TestRegistryFailsClosedForUnavailableProducer(t *testing.T) {
+	base := validSpec()
+	cases := []struct {
+		name  string
+		specs []ProducerSpec
+		id    ProducerID
+	}{
+		{name: "unknown", specs: []ProducerSpec{base}, id: "missing"},
+		{name: "disabled", specs: []ProducerSpec{func() ProducerSpec { s := base; s.Enabled = false; return s }()}, id: base.ID},
+		{name: "missing sender config", specs: []ProducerSpec{func() ProducerSpec { s := base; s.SenderUID = ""; return s }()}, id: base.ID},
+		{name: "duplicate", specs: []ProducerSpec{base, base}, id: base.ID},
+		{name: "invalid concurrency", specs: []ProducerSpec{func() ProducerSpec { s := base; s.MaxInFlight = 0; return s }()}, id: base.ID},
+		{name: "interactive without owner", specs: []ProducerSpec{func() ProducerSpec { s := base; s.AllowedProfiles = []string{cardmsg.ProfileV2}; return s }()}, id: base.ID},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := NewRegistry(Dependencies{}, tc.specs)
+			sender, err := reg.Sender(tc.id)
+			assert.Nil(t, sender)
+			requireCategory(t, CategoryProducerDisabled, err)
+		})
+	}
+}
+
+func TestDuplicateProducerEmitsOneConfigurationError(t *testing.T) {
+	spec := validSpec()
+	promRegistry := prometheus.NewRegistry()
+	logger := &fakeLogger{}
+	registry := NewRegistry(Dependencies{
+		Metrics: NewMetrics(promRegistry),
+		Logger:  logger,
+	}, []ProducerSpec{spec, spec})
+
+	sender, err := registry.Sender(spec.ID)
+	assert.Nil(t, sender)
+	requireCategory(t, CategoryProducerDisabled, err)
+	assert.Equal(t, int32(1), logger.errorCalls.Load())
+	families, err := promRegistry.Gather()
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), gatheredCounter(t, families,
+		"dmwork_card_dispatch_config_error_total",
+		map[string]string{"producer": "summary-notify", "reason": "duplicate"}))
+}
+
+func TestRegistryRejectsMalformedInteractiveActionOwner(t *testing.T) {
+	spec := validSpec()
+	spec.AllowedProfiles = []string{cardmsg.ProfileV2}
+	spec.ActionEventOwner = "../../unbounded callback"
+	registry, _, _, _, _ := newHarness(t, spec)
+
+	sender, err := registry.Sender(spec.ID)
+	assert.Nil(t, sender)
+	requireCategory(t, CategoryProducerDisabled, err)
+}
+
+func TestRegistryRejectsEveryInvalidConfigurationClass(t *testing.T) {
+	base := validSpec()
+	cases := []struct {
+		name   string
+		mutate func(*ProducerSpec)
+	}{
+		{name: "invalid id", mutate: func(s *ProducerSpec) { s.ID = "Invalid" }},
+		{name: "synthetic webhook sender", mutate: func(s *ProducerSpec) { s.SenderUID = "iwh_not-a-bot" }},
+		{name: "excessive concurrency", mutate: func(s *ProducerSpec) { s.MaxInFlight = 1001 }},
+		{name: "missing target types", mutate: func(s *ProducerSpec) { s.AllowedChannelTypes = nil }},
+		{name: "unsupported target type", mutate: func(s *ProducerSpec) { s.AllowedChannelTypes = []uint8{255} }},
+		{name: "duplicate target type", mutate: func(s *ProducerSpec) { s.AllowedChannelTypes = []uint8{1, 1} }},
+		{name: "missing profiles", mutate: func(s *ProducerSpec) { s.AllowedProfiles = nil }},
+		{name: "unsupported profile", mutate: func(s *ProducerSpec) { s.AllowedProfiles = []string{"octo/unknown"} }},
+		{name: "duplicate profile", mutate: func(s *ProducerSpec) { s.AllowedProfiles = []string{cardmsg.ProfileV1, cardmsg.ProfileV1} }},
+		{name: "invalid space policy", mutate: func(s *ProducerSpec) { s.SpacePolicy = "invalid" }},
+		{name: "invalid group policy", mutate: func(s *ProducerSpec) { s.GroupPolicy = "invalid" }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := base
+			tc.mutate(&spec)
+			registry, _, _, _, _ := newHarness(t, spec)
+			sender, err := registry.Sender(spec.ID)
+			assert.Nil(t, sender)
+			requireCategory(t, CategoryProducerDisabled, err)
+		})
+	}
+}
+
+func TestInstallRegistryIsPerContextAndSingleAssignment(t *testing.T) {
+	regA, _, _, _, _ := newHarness(t, validSpec())
+	regB, _, _, _, _ := newHarness(t, validSpec())
+	ctxA := &fakeValueStore{}
+	ctxB := &fakeValueStore{}
+
+	require.NoError(t, Install(ctxA, regA))
+	require.ErrorIs(t, Install(ctxA, regB), ErrRegistryAlreadyInstalled)
+	require.NoError(t, Install(ctxB, regB))
+
+	senderA, err := SenderFromContext(ctxA, "summary-notify")
+	require.NoError(t, err)
+	senderB, err := SenderFromContext(ctxB, "summary-notify")
+	require.NoError(t, err)
+	assert.NotSame(t, senderA, senderB)
+}
+
+func TestRegistryCopiesProducerConfiguration(t *testing.T) {
+	spec := validSpec()
+	reg, _, _, _, _ := newHarness(t, spec)
+	spec.SenderUID = "attacker"
+	spec.AllowedProfiles[0] = cardmsg.ProfileV2
+	spec.AllowedChannelTypes[0] = common.ChannelTypeGroup.Uint8()
+
+	sender, err := reg.Sender("summary-notify")
+	require.NoError(t, err)
+	_, err = sender.Send(context.Background(), validTarget(), Card{Profile: cardmsg.ProfileV1, Document: validCardDocument()})
+	require.NoError(t, err)
+}
+
+func TestSendBuildsAuthoritativeEnvelopeAndReturnsTransportResult(t *testing.T) {
+	reg, resolver, authorizer, transport, _ := newHarness(t, validSpec())
+	sender, err := reg.Sender("summary-notify")
+	require.NoError(t, err)
+
+	result, err := sender.Send(context.Background(), validTarget(), Card{
+		Profile:  cardmsg.ProfileV1,
+		Document: validCardDocument(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, &Result{MessageID: 42, MessageSeq: 7, ClientMsgNo: "client-42"}, result)
+	assert.Equal(t, int32(1), resolver.calls.Load())
+	assert.Equal(t, int32(1), authorizer.calls.Load())
+	assert.Equal(t, SpacePolicySystemNotification, authorizer.policy.SpacePolicy)
+
+	calls, req := transport.snapshot()
+	require.Equal(t, 1, calls)
+	require.NotNil(t, req)
+	assert.Equal(t, "summary", req.FromUID)
+	assert.Equal(t, "user-a", req.ChannelID)
+	assert.Equal(t, common.ChannelTypePerson.Uint8(), req.ChannelType)
+	assert.Empty(t, req.StreamNo)
+	assert.Empty(t, req.Subscribers)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(req.Payload, &payload))
+	assert.Equal(t, float64(cardmsg.InteractiveCard.Int()), payload["type"])
+	assert.Equal(t, cardmsg.CardVersion, payload["card_version"])
+	assert.Equal(t, cardmsg.ProfileV1, payload["profile"])
+	assert.Equal(t, "space-a", payload["space_id"])
+	assert.Equal(t, "hello", payload["plain"])
+	assert.NotContains(t, payload, "from_uid")
+	assert.NotContains(t, payload, "on_behalf_of")
+	assert.NotContains(t, payload, "mention")
+	require.NoError(t, cardmsg.Validate(payload))
+	require.NoError(t, cardmsg.RecheckPayloadSize(payload))
+	assert.LessOrEqual(t, len(req.Payload), cardmsg.MaxPayloadBytes)
+}
+
+func TestSendFailClosedStagesNeverReachTransport(t *testing.T) {
+	tests := []struct {
+		name          string
+		mutate        func(*ProducerSpec, *fakeIdentityResolver, *fakeAuthorizer, *fakeTransport)
+		target        Target
+		card          Card
+		want          Category
+		wantResolver  int32
+		wantAuthorize int32
+	}{
+		{name: "invalid target", target: Target{}, card: Card{Profile: cardmsg.ProfileV1, Document: validCardDocument()}, want: CategoryInvalidRequest},
+		{name: "profile denied", target: validTarget(), card: Card{Profile: cardmsg.ProfileV2, Document: validCardDocument()}, want: CategoryProducerDisabled},
+		{name: "identity missing", mutate: func(_ *ProducerSpec, r *fakeIdentityResolver, _ *fakeAuthorizer, _ *fakeTransport) { r.identity = nil }, target: validTarget(), card: Card{Profile: cardmsg.ProfileV1, Document: validCardDocument()}, want: CategoryIdentityUntrusted, wantResolver: 1},
+		{name: "identity lookup error", mutate: func(_ *ProducerSpec, r *fakeIdentityResolver, _ *fakeAuthorizer, _ *fakeTransport) {
+			r.err = errors.New("db down")
+		}, target: validTarget(), card: Card{Profile: cardmsg.ProfileV1, Document: validCardDocument()}, want: CategoryIdentityUntrusted, wantResolver: 1},
+		{name: "acl denied", mutate: func(_ *ProducerSpec, _ *fakeIdentityResolver, a *fakeAuthorizer, _ *fakeTransport) {
+			a.err = ErrTargetDenied
+		}, target: validTarget(), card: Card{Profile: cardmsg.ProfileV1, Document: validCardDocument()}, want: CategoryTargetDenied, wantResolver: 1, wantAuthorize: 1},
+		{name: "invalid card after authorization", target: validTarget(), card: Card{Profile: cardmsg.ProfileV1, Document: json.RawMessage(`{"type":"AdaptiveCard","version":"1.5","body":[{"type":"Unknown"}]}`)}, want: CategoryCardInvalid, wantResolver: 1, wantAuthorize: 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := validSpec()
+			reg, resolver, authorizer, transport, _ := newHarness(t, spec)
+			if tc.mutate != nil {
+				tc.mutate(&spec, resolver, authorizer, transport)
+			}
+			sender, err := reg.Sender("summary-notify")
+			require.NoError(t, err)
+			result, err := sender.Send(context.Background(), tc.target, tc.card)
+			assert.Nil(t, result)
+			requireCategory(t, tc.want, err)
+			assert.Equal(t, tc.wantResolver, resolver.calls.Load())
+			assert.Equal(t, tc.wantAuthorize, authorizer.calls.Load())
+			calls, _ := transport.snapshot()
+			assert.Zero(t, calls)
+		})
+	}
+}
+
+func TestSendFeatureGatePrecedesIdentityLookup(t *testing.T) {
+	spec := validSpec()
+	resolver := &fakeIdentityResolver{identity: &botidentity.Identity{UID: spec.SenderUID, Kind: botidentity.KindUserBot}}
+	authorizer := &fakeAuthorizer{}
+	transport := &fakeTransport{}
+	reg := NewRegistry(Dependencies{
+		IdentityResolver: resolver,
+		Authorizer:       authorizer,
+		Transport:        transport,
+		FeatureEnabled:   func() bool { return false },
+	}, []ProducerSpec{spec})
+	sender, err := reg.Sender(spec.ID)
+	require.NoError(t, err)
+
+	_, err = sender.Send(context.Background(), validTarget(), Card{Profile: cardmsg.ProfileV1, Document: validCardDocument()})
+	requireCategory(t, CategoryFeatureDisabled, err)
+	assert.Zero(t, resolver.calls.Load())
+	assert.Zero(t, authorizer.calls.Load())
+	calls, _ := transport.snapshot()
+	assert.Zero(t, calls)
+}
+
+func TestSendRejectsInvalidContextIdentityAndTransportResult(t *testing.T) {
+	t.Run("cancelled before identity lookup", func(t *testing.T) {
+		reg, resolver, _, transport, _ := newHarness(t, validSpec())
+		sender, err := reg.Sender("summary-notify")
+		require.NoError(t, err)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err = sender.Send(ctx, validTarget(), Card{Profile: cardmsg.ProfileV1, Document: validCardDocument()})
+		requireCategory(t, CategoryDispatchFailed, err)
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Zero(t, resolver.calls.Load())
+		calls, _ := transport.snapshot()
+		assert.Zero(t, calls)
+	})
+
+	t.Run("identity uid mismatch", func(t *testing.T) {
+		reg, resolver, _, transport, _ := newHarness(t, validSpec())
+		resolver.identity.UID = "different-bot"
+		sender, err := reg.Sender("summary-notify")
+		require.NoError(t, err)
+		_, err = sender.Send(context.Background(), validTarget(), Card{Profile: cardmsg.ProfileV1, Document: validCardDocument()})
+		requireCategory(t, CategoryIdentityUntrusted, err)
+		calls, _ := transport.snapshot()
+		assert.Zero(t, calls)
+	})
+
+	t.Run("unsupported identity kind", func(t *testing.T) {
+		reg, resolver, _, transport, _ := newHarness(t, validSpec())
+		resolver.identity.Kind = "unknown"
+		sender, err := reg.Sender("summary-notify")
+		require.NoError(t, err)
+		_, err = sender.Send(context.Background(), validTarget(), Card{Profile: cardmsg.ProfileV1, Document: validCardDocument()})
+		requireCategory(t, CategoryIdentityUntrusted, err)
+		calls, _ := transport.snapshot()
+		assert.Zero(t, calls)
+	})
+
+	t.Run("empty transport result", func(t *testing.T) {
+		reg, _, _, transport, _ := newHarness(t, validSpec())
+		transport.resp = nil
+		sender, err := reg.Sender("summary-notify")
+		require.NoError(t, err)
+		_, err = sender.Send(context.Background(), validTarget(), Card{Profile: cardmsg.ProfileV1, Document: validCardDocument()})
+		requireCategory(t, CategoryDispatchFailed, err)
+		calls, _ := transport.snapshot()
+		assert.Equal(t, 1, calls)
+	})
+}
+
+func TestSendRejectsMalformedRequestsAndDocuments(t *testing.T) {
+	reg, _, _, transport, _ := newHarness(t, validSpec())
+	sender, err := reg.Sender("summary-notify")
+	require.NoError(t, err)
+	cases := []struct {
+		name   string
+		ctx    context.Context
+		target Target
+		card   Card
+		want   Category
+	}{
+		{name: "nil context", target: validTarget(), card: Card{Profile: cardmsg.ProfileV1, Document: validCardDocument()}, want: CategoryInvalidRequest},
+		{name: "unsupported target", ctx: context.Background(), target: Target{SpaceID: "space-a", ChannelID: "x", ChannelType: 255}, card: Card{Profile: cardmsg.ProfileV1, Document: validCardDocument()}, want: CategoryInvalidRequest},
+		{name: "missing document", ctx: context.Background(), target: validTarget(), card: Card{Profile: cardmsg.ProfileV1}, want: CategoryInvalidRequest},
+		{name: "malformed json", ctx: context.Background(), target: validTarget(), card: Card{Profile: cardmsg.ProfileV1, Document: json.RawMessage(`{"type":`)}, want: CategoryCardInvalid},
+		{name: "empty object", ctx: context.Background(), target: validTarget(), card: Card{Profile: cardmsg.ProfileV1, Document: json.RawMessage(`{}`)}, want: CategoryCardInvalid},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := sender.Send(tc.ctx, tc.target, tc.card)
+			requireCategory(t, tc.want, err)
+		})
+	}
+	calls, _ := transport.snapshot()
+	assert.Zero(t, calls)
+}
+
+func TestSendEmitsOneSafeTerminalLog(t *testing.T) {
+	build := func(transport *fakeTransport, logger *fakeLogger) Sender {
+		spec := validSpec()
+		registry := NewRegistry(Dependencies{
+			IdentityResolver: &fakeIdentityResolver{identity: &botidentity.Identity{UID: spec.SenderUID, Kind: botidentity.KindUserBot}},
+			Authorizer:       &fakeAuthorizer{},
+			Transport:        transport,
+			Metrics:          NewMetrics(prometheus.NewRegistry()),
+			Logger:           logger,
+			FeatureEnabled:   func() bool { return true },
+		}, []ProducerSpec{spec})
+		sender, err := registry.Sender(spec.ID)
+		require.NoError(t, err)
+		return sender
+	}
+
+	successLogger := &fakeLogger{}
+	successTransport := &fakeTransport{resp: &config.MsgSendResp{MessageID: 1}}
+	_, err := build(successTransport, successLogger).Send(context.Background(), validTarget(), Card{Profile: cardmsg.ProfileV1, Document: validCardDocument()})
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), successLogger.infoCalls.Load())
+	assert.Zero(t, successLogger.errorCalls.Load())
+
+	failureLogger := &fakeLogger{}
+	failureTransport := &fakeTransport{err: errors.New("transport failed")}
+	_, err = build(failureTransport, failureLogger).Send(context.Background(), validTarget(), Card{Profile: cardmsg.ProfileV1, Document: validCardDocument()})
+	requireCategory(t, CategoryDispatchFailed, err)
+	assert.Zero(t, failureLogger.infoCalls.Load())
+	assert.Equal(t, int32(1), failureLogger.errorCalls.Load())
+}
+
+func TestSendOwnsImmutableDocumentSnapshot(t *testing.T) {
+	document := validCardDocument()
+	original := append([]byte(nil), document...)
+	reg, resolver, _, transport, _ := newHarness(t, validSpec())
+	resolver.hook = func() {
+		for i := range document {
+			document[i] = ' '
+		}
+	}
+	sender, err := reg.Sender("summary-notify")
+	require.NoError(t, err)
+
+	_, err = sender.Send(context.Background(), validTarget(), Card{Profile: cardmsg.ProfileV1, Document: document})
+	require.NoError(t, err)
+	_, req := transport.snapshot()
+	require.NotNil(t, req)
+	assert.Contains(t, string(req.Payload), "hello")
+	assert.JSONEq(t, string(original), string(validCardDocument()))
+}
+
+func TestSendRejectsPayloadThatOverflowsAfterAuthoritativeEnrichment(t *testing.T) {
+	padding := strings.Repeat("x", cardmsg.MaxPayloadBytes)
+	doc := json.RawMessage(`{"type":"AdaptiveCard","version":"1.5","padding":"` + padding + `","body":[]}`)
+	for len(doc) > 0 {
+		var card map[string]interface{}
+		require.NoError(t, json.Unmarshal(doc, &card))
+		base := map[string]interface{}{
+			"type":         cardmsg.InteractiveCard.Int(),
+			"card_version": cardmsg.CardVersion,
+			"profile":      cardmsg.ProfileV1,
+			"card":         card,
+		}
+		raw, err := json.Marshal(base)
+		require.NoError(t, err)
+		delta := len(raw) - (cardmsg.MaxPayloadBytes - 1)
+		if delta == 0 {
+			break
+		}
+		padding = padding[:len(padding)-delta]
+		doc = json.RawMessage(`{"type":"AdaptiveCard","version":"1.5","padding":"` + padding + `","body":[]}`)
+	}
+
+	reg, _, _, transport, _ := newHarness(t, validSpec())
+	sender, err := reg.Sender("summary-notify")
+	require.NoError(t, err)
+	_, err = sender.Send(context.Background(), validTarget(), Card{Profile: cardmsg.ProfileV1, Document: doc})
+	requireCategory(t, CategoryPayloadTooLarge, err)
+	calls, _ := transport.snapshot()
+	assert.Zero(t, calls)
+}
+
+func TestSendChecksCancellationImmediatelyBeforeTransport(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	reg, _, authorizer, transport, _ := newHarness(t, validSpec())
+	authorizer.hook = cancel
+	sender, err := reg.Sender("summary-notify")
+	require.NoError(t, err)
+
+	_, err = sender.Send(ctx, validTarget(), Card{Profile: cardmsg.ProfileV1, Document: validCardDocument()})
+	requireCategory(t, CategoryDispatchFailed, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	calls, _ := transport.snapshot()
+	assert.Zero(t, calls)
+}
+
+func TestSendMakesOneTransportAttemptWithoutRetry(t *testing.T) {
+	reg, _, _, transport, _ := newHarness(t, validSpec())
+	transport.err = errors.New("ambiguous transport failure")
+	sender, err := reg.Sender("summary-notify")
+	require.NoError(t, err)
+
+	result, err := sender.Send(context.Background(), validTarget(), Card{Profile: cardmsg.ProfileV1, Document: validCardDocument()})
+	assert.Nil(t, result)
+	requireCategory(t, CategoryDispatchFailed, err)
+	calls, _ := transport.snapshot()
+	assert.Equal(t, 1, calls)
+}
+
+func TestSendConcurrencyLimitFailsFastAndReleasesSlot(t *testing.T) {
+	reg, _, _, transport, _ := newHarness(t, validSpec())
+	transport.started = make(chan struct{}, 1)
+	transport.release = make(chan struct{})
+	sender, err := reg.Sender("summary-notify")
+	require.NoError(t, err)
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, sendErr := sender.Send(context.Background(), validTarget(), Card{Profile: cardmsg.ProfileV1, Document: validCardDocument()})
+		firstDone <- sendErr
+	}()
+	<-transport.started
+
+	_, err = sender.Send(context.Background(), validTarget(), Card{Profile: cardmsg.ProfileV1, Document: validCardDocument()})
+	requireCategory(t, CategoryBusy, err)
+	close(transport.release)
+	require.NoError(t, <-firstDone)
+
+	transport.release = nil
+	_, err = sender.Send(context.Background(), validTarget(), Card{Profile: cardmsg.ProfileV1, Document: validCardDocument()})
+	require.NoError(t, err)
+	calls, _ := transport.snapshot()
+	assert.Equal(t, 2, calls)
+}
+
+func TestMetricsUseBoundedLabelsAndOneTerminalResult(t *testing.T) {
+	reg, _, _, _, promRegistry := newHarness(t, validSpec())
+	sender, err := reg.Sender("summary-notify")
+	require.NoError(t, err)
+	_, err = sender.Send(context.Background(), validTarget(), Card{Profile: cardmsg.ProfileV1, Document: validCardDocument()})
+	require.NoError(t, err)
+
+	families, err := promRegistry.Gather()
+	require.NoError(t, err)
+	wantLabels := map[string]map[string]bool{
+		"dmwork_card_dispatch_attempt_total":    {"producer": true, "target": true},
+		"dmwork_card_dispatch_result_total":     {"producer": true, "target": true, "result": true},
+		"dmwork_card_dispatch_duration_seconds": {"producer": true, "target": true, "result": true},
+		"dmwork_card_dispatch_in_flight":        {"producer": true},
+	}
+	for _, family := range families {
+		allowed, ok := wantLabels[family.GetName()]
+		if !ok {
+			continue
+		}
+		for _, metric := range family.Metric {
+			for _, label := range metric.Label {
+				assert.True(t, allowed[label.GetName()], "%s has forbidden label %s", family.GetName(), label.GetName())
+				assert.NotContains(t, []string{"uid", "channel_id", "space_id", "message_id"}, label.GetName())
+			}
+		}
+	}
+
+	assert.Equal(t, float64(1), gatheredCounter(t, families, "dmwork_card_dispatch_attempt_total", map[string]string{"producer": "summary-notify", "target": "person"}))
+	assert.Equal(t, float64(1), gatheredCounter(t, families, "dmwork_card_dispatch_result_total", map[string]string{"producer": "summary-notify", "target": "person", "result": "ok"}))
+	assert.Equal(t, float64(0), gatheredGauge(t, families, "dmwork_card_dispatch_in_flight", map[string]string{"producer": "summary-notify"}))
+}
+
+func gatheredCounter(t *testing.T, families []*dto.MetricFamily, name string, labels map[string]string) float64 {
+	t.Helper()
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.Metric {
+			if metricHasLabels(metric.Label, labels) {
+				return metric.GetCounter().GetValue()
+			}
+		}
+	}
+	t.Fatalf("counter %s labels=%v not found", name, labels)
+	return 0
+}
+
+func gatheredGauge(t *testing.T, families []*dto.MetricFamily, name string, labels map[string]string) float64 {
+	t.Helper()
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.Metric {
+			if metricHasLabels(metric.Label, labels) {
+				return metric.GetGauge().GetValue()
+			}
+		}
+	}
+	t.Fatalf("gauge %s labels=%v not found", name, labels)
+	return 0
+}
+
+func metricHasLabels(pairs []*dto.LabelPair, want map[string]string) bool {
+	if len(pairs) != len(want) {
+		return false
+	}
+	for _, pair := range pairs {
+		if want[pair.GetName()] != pair.GetValue() {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/carddispatch/errors.go
+++ b/internal/carddispatch/errors.go
@@ -1,0 +1,63 @@
+package carddispatch
+
+import (
+	"errors"
+	"fmt"
+)
+
+type Category string
+
+const (
+	CategoryOK                Category = "ok"
+	CategoryInvalidRequest    Category = "invalid_request"
+	CategoryFeatureDisabled   Category = "feature_disabled"
+	CategoryProducerDisabled  Category = "producer_disabled"
+	CategoryIdentityUntrusted Category = "identity_untrusted"
+	CategoryTargetDenied      Category = "target_denied"
+	CategoryCardInvalid       Category = "card_invalid"
+	CategoryPayloadTooLarge   Category = "payload_too_large"
+	CategoryBusy              Category = "busy"
+	CategoryDispatchFailed    Category = "dispatch_failed"
+)
+
+var (
+	ErrTargetDenied             = errors.New("carddispatch: target denied")
+	ErrRegistryAlreadyInstalled = errors.New("carddispatch: registry already installed")
+)
+
+type Error struct {
+	Category Category
+	Cause    error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Cause == nil {
+		return "carddispatch: " + string(e.Category)
+	}
+	return fmt.Sprintf("carddispatch: %s: %v", e.Category, e.Cause)
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+func CategoryOf(err error) Category {
+	if err == nil {
+		return CategoryOK
+	}
+	var dispatchErr *Error
+	if errors.As(err, &dispatchErr) {
+		return dispatchErr.Category
+	}
+	return CategoryDispatchFailed
+}
+
+func categorized(category Category, cause error) error {
+	return &Error{Category: category, Cause: cause}
+}

--- a/internal/carddispatch/metrics.go
+++ b/internal/carddispatch/metrics.go
@@ -1,0 +1,74 @@
+package carddispatch
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type Metrics struct {
+	attempts     *prometheus.CounterVec
+	results      *prometheus.CounterVec
+	duration     *prometheus.HistogramVec
+	inFlight     *prometheus.GaugeVec
+	configErrors *prometheus.CounterVec
+}
+
+func NewMetrics(reg prometheus.Registerer) *Metrics {
+	if reg == nil {
+		return nil
+	}
+	m := &Metrics{
+		attempts: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "dmwork_card_dispatch_attempt_total",
+			Help: "Total trusted internal card dispatch attempts.",
+		}, []string{"producer", "target"}),
+		results: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "dmwork_card_dispatch_result_total",
+			Help: "Terminal trusted internal card dispatch results.",
+		}, []string{"producer", "target", "result"}),
+		duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "dmwork_card_dispatch_duration_seconds",
+			Help:    "Trusted internal card dispatch duration.",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"producer", "target", "result"}),
+		inFlight: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "dmwork_card_dispatch_in_flight",
+			Help: "Current trusted internal card dispatch calls holding a producer slot.",
+		}, []string{"producer"}),
+		configErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "dmwork_card_dispatch_config_error_total",
+			Help: "Invalid trusted internal card producer configurations.",
+		}, []string{"producer", "reason"}),
+	}
+	reg.MustRegister(m.attempts, m.results, m.duration, m.inFlight, m.configErrors)
+	return m
+}
+
+func (m *Metrics) begin(producer, target string) time.Time {
+	if m != nil {
+		m.attempts.WithLabelValues(producer, target).Inc()
+	}
+	return time.Now()
+}
+
+func (m *Metrics) finish(producer, target string, start time.Time, result Category) {
+	if m == nil {
+		return
+	}
+	label := string(result)
+	m.results.WithLabelValues(producer, target, label).Inc()
+	m.duration.WithLabelValues(producer, target, label).Observe(time.Since(start).Seconds())
+}
+
+func (m *Metrics) addInFlight(producer string, delta float64) {
+	if m != nil {
+		m.inFlight.WithLabelValues(producer).Add(delta)
+	}
+}
+
+func (m *Metrics) configError(producer, reason string) {
+	if m != nil {
+		m.configErrors.WithLabelValues(producer, reason).Inc()
+	}
+}

--- a/internal/carddispatch/observability_source_test.go
+++ b/internal/carddispatch/observability_source_test.go
@@ -1,0 +1,102 @@
+package carddispatch
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestObservabilitySourceUsesOnlyReviewedMetricLabels(t *testing.T) {
+	file, err := parser.ParseFile(token.NewFileSet(), "metrics.go", nil, 0)
+	require.NoError(t, err)
+	allowed := map[string]bool{
+		"producer": true,
+		"target":   true,
+		"result":   true,
+		"reason":   true,
+	}
+
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || len(call.Args) < 2 ||
+			(selector.Sel.Name != "NewCounterVec" && selector.Sel.Name != "NewHistogramVec" && selector.Sel.Name != "NewGaugeVec") {
+			return true
+		}
+		labels, ok := call.Args[len(call.Args)-1].(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		for _, element := range labels.Elts {
+			literal, ok := element.(*ast.BasicLit)
+			if !ok || literal.Kind != token.STRING {
+				continue
+			}
+			label, unquoteErr := strconv.Unquote(literal.Value)
+			require.NoError(t, unquoteErr)
+			assert.True(t, allowed[label], "unreviewed/high-cardinality metric label %q", label)
+		}
+		return true
+	})
+}
+
+func TestDispatchLogsCannotIncludeSerializedCardContent(t *testing.T) {
+	file, err := parser.ParseFile(token.NewFileSet(), "dispatch.go", nil, 0)
+	require.NoError(t, err)
+	allowedFields := map[string]bool{
+		"request_id":    true,
+		"producer":      true,
+		"sender_kind":   true,
+		"space_id":      true,
+		"target_kind":   true,
+		"message_id":    true,
+		"message_seq":   true,
+		"client_msg_no": true,
+	}
+	allowedConstructors := map[string]bool{
+		"String": true,
+		"Int64":  true,
+		"Uint32": true,
+		"Error":  true,
+	}
+
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		method, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || (method.Sel.Name != "Info" && method.Sel.Name != "Error") {
+			return true
+		}
+		logger, ok := method.X.(*ast.SelectorExpr)
+		if !ok || logger.Sel.Name != "logger" {
+			return true
+		}
+		for _, argument := range call.Args[1:] {
+			fieldCall, ok := argument.(*ast.CallExpr)
+			require.True(t, ok, "dispatch log fields must use explicit zap constructors")
+			constructor, ok := fieldCall.Fun.(*ast.SelectorExpr)
+			require.True(t, ok, "dispatch log fields must use explicit zap constructors")
+			assert.True(t, allowedConstructors[constructor.Sel.Name], "unsafe zap field constructor %s", constructor.Sel.Name)
+			if constructor.Sel.Name == "Error" {
+				continue
+			}
+			require.NotEmpty(t, fieldCall.Args)
+			keyLiteral, ok := fieldCall.Args[0].(*ast.BasicLit)
+			require.True(t, ok)
+			key, unquoteErr := strconv.Unquote(keyLiteral.Value)
+			require.NoError(t, unquoteErr)
+			assert.True(t, allowedFields[key], "unreviewed dispatch log field %q", key)
+		}
+		return true
+	})
+}

--- a/internal/carddispatch/registry.go
+++ b/internal/carddispatch/registry.go
@@ -1,0 +1,169 @@
+package carddispatch
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"go.uber.org/zap"
+)
+
+const maxProducerIDBytes = 64
+
+var producerIDPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
+
+type Registry struct {
+	senders map[ProducerID]*producerSender
+	invalid map[ProducerID]struct{}
+}
+
+func NewRegistry(deps Dependencies, specs []ProducerSpec) *Registry {
+	registry := &Registry{
+		senders: make(map[ProducerID]*producerSender),
+		invalid: make(map[ProducerID]struct{}),
+	}
+	counts := make(map[ProducerID]int, len(specs))
+	for _, spec := range specs {
+		counts[spec.ID]++
+	}
+	duplicateRejected := make(map[ProducerID]struct{})
+	for _, input := range specs {
+		if counts[input.ID] > 1 {
+			if _, rejected := duplicateRejected[input.ID]; !rejected {
+				registry.reject(deps, input.ID, "duplicate")
+				duplicateRejected[input.ID] = struct{}{}
+			}
+			continue
+		}
+		if !input.Enabled {
+			registry.invalid[input.ID] = struct{}{}
+			continue
+		}
+		spec := copyProducerSpec(input)
+		if reason := validateSpec(spec, deps); reason != "" {
+			registry.reject(deps, spec.ID, reason)
+			continue
+		}
+		featureEnabled := deps.FeatureEnabled
+		if featureEnabled == nil {
+			featureEnabled = cardmsg.Enabled
+		}
+		registry.senders[spec.ID] = &producerSender{
+			spec:             spec,
+			identityResolver: deps.IdentityResolver,
+			authorizer:       deps.Authorizer,
+			transport:        deps.Transport,
+			metrics:          deps.Metrics,
+			logger:           deps.Logger,
+			featureEnabled:   featureEnabled,
+			slots:            make(chan struct{}, spec.MaxInFlight),
+		}
+	}
+	return registry
+}
+
+func (r *Registry) Sender(id ProducerID) (Sender, error) {
+	if r == nil {
+		return nil, categorized(CategoryProducerDisabled, errors.New("registry unavailable"))
+	}
+	sender, ok := r.senders[id]
+	if !ok {
+		return nil, categorized(CategoryProducerDisabled, fmt.Errorf("producer %q unavailable", id))
+	}
+	return sender, nil
+}
+
+func (r *Registry) reject(deps Dependencies, id ProducerID, reason string) {
+	r.invalid[id] = struct{}{}
+	delete(r.senders, id)
+	producer := metricProducerLabel(id)
+	deps.Metrics.configError(producer, reason)
+	if deps.Logger != nil {
+		deps.Logger.Error("card dispatch producer configuration rejected",
+			zap.String("producer", producer), zap.String("reason", reason))
+	}
+}
+
+func copyProducerSpec(input ProducerSpec) ProducerSpec {
+	input.AllowedChannelTypes = append([]uint8(nil), input.AllowedChannelTypes...)
+	input.AllowedProfiles = append([]string(nil), input.AllowedProfiles...)
+	return input
+}
+
+func validateSpec(spec ProducerSpec, deps Dependencies) string {
+	if len(spec.ID) == 0 || len(spec.ID) > maxProducerIDBytes || !producerIDPattern.MatchString(string(spec.ID)) {
+		return "invalid_id"
+	}
+	if strings.TrimSpace(spec.SenderUID) == "" || strings.HasPrefix(spec.SenderUID, "iwh_") {
+		return "invalid_sender"
+	}
+	if spec.MaxInFlight <= 0 || spec.MaxInFlight > 1000 {
+		return "invalid_concurrency"
+	}
+	if len(spec.AllowedChannelTypes) == 0 || !validChannelTypes(spec.AllowedChannelTypes) {
+		return "invalid_targets"
+	}
+	if len(spec.AllowedProfiles) == 0 || !validProfiles(spec.AllowedProfiles, spec.ActionEventOwner) {
+		return "invalid_profiles"
+	}
+	if spec.SpacePolicy != SpacePolicyMembership && spec.SpacePolicy != SpacePolicySystemNotification {
+		return "invalid_space_policy"
+	}
+	if spec.GroupPolicy != GroupPolicyMemberRequired && spec.GroupPolicy != GroupPolicyMemberExempt {
+		return "invalid_group_policy"
+	}
+	if deps.IdentityResolver == nil || deps.Authorizer == nil || deps.Transport == nil {
+		return "missing_dependency"
+	}
+	return ""
+}
+
+func validChannelTypes(types []uint8) bool {
+	seen := make(map[uint8]struct{}, len(types))
+	for _, channelType := range types {
+		switch channelType {
+		case common.ChannelTypePerson.Uint8(), common.ChannelTypeGroup.Uint8(), common.ChannelTypeCommunityTopic.Uint8():
+		default:
+			return false
+		}
+		if _, duplicate := seen[channelType]; duplicate {
+			return false
+		}
+		seen[channelType] = struct{}{}
+	}
+	return true
+}
+
+func validProfiles(profiles []string, actionEventOwner string) bool {
+	accepted := make(map[string]struct{})
+	for _, profile := range cardmsg.AcceptedProfiles() {
+		accepted[profile] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(profiles))
+	for _, profile := range profiles {
+		if _, ok := accepted[profile]; !ok {
+			return false
+		}
+		if _, duplicate := seen[profile]; duplicate {
+			return false
+		}
+		seen[profile] = struct{}{}
+		if profile == cardmsg.ProfileV2 {
+			owner := strings.TrimSpace(actionEventOwner)
+			if len(owner) == 0 || len(owner) > maxProducerIDBytes || !producerIDPattern.MatchString(owner) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func metricProducerLabel(id ProducerID) string {
+	if producerIDPattern.MatchString(string(id)) {
+		return string(id)
+	}
+	return "invalid"
+}

--- a/internal/carddispatch/types.go
+++ b/internal/carddispatch/types.go
@@ -1,0 +1,88 @@
+// Package carddispatch is the sole supported boundary for trusted in-process
+// InteractiveCard origination. It owns producer capability, authorization,
+// envelope construction, final bytes, concurrency, and transport semantics.
+package carddispatch
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	liblog "github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
+)
+
+type ProducerID string
+
+type SpacePolicy string
+
+const (
+	SpacePolicyMembership         SpacePolicy = "membership"
+	SpacePolicySystemNotification SpacePolicy = "system_notification"
+)
+
+type GroupPolicy string
+
+const (
+	GroupPolicyMemberRequired GroupPolicy = "member_required"
+	GroupPolicyMemberExempt   GroupPolicy = "member_exempt"
+)
+
+type Target struct {
+	SpaceID     string
+	ChannelID   string
+	ChannelType uint8
+}
+
+type Card struct {
+	Profile  string
+	Document json.RawMessage
+}
+
+type Result struct {
+	MessageID   int64
+	MessageSeq  uint32
+	ClientMsgNo string
+}
+
+type Sender interface {
+	Send(ctx context.Context, target Target, card Card) (*Result, error)
+}
+
+type ProducerSpec struct {
+	ID                  ProducerID
+	Enabled             bool
+	SenderUID           string
+	AllowedChannelTypes []uint8
+	AllowedProfiles     []string
+	SpacePolicy         SpacePolicy
+	GroupPolicy         GroupPolicy
+	ActionEventOwner    string
+	MaxInFlight         int
+}
+
+type AuthorizationPolicy struct {
+	SpacePolicy SpacePolicy
+	GroupPolicy GroupPolicy
+}
+
+type IdentityResolver interface {
+	Resolve(uid string) (*botidentity.Identity, error)
+}
+
+type Authorizer interface {
+	Authorize(ctx context.Context, identity *botidentity.Identity, target Target, policy AuthorizationPolicy) error
+}
+
+type Transport interface {
+	SendMessageWithResult(req *config.MsgSendReq) (*config.MsgSendResp, error)
+}
+
+type Dependencies struct {
+	IdentityResolver IdentityResolver
+	Authorizer       Authorizer
+	Transport        Transport
+	Metrics          *Metrics
+	Logger           liblog.Log
+	FeatureEnabled   func() bool
+}

--- a/main.go
+++ b/main.go
@@ -19,8 +19,10 @@ import (
 	libwkhttp "github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-lib/server"
 	_ "github.com/Mininglamp-OSS/octo-server/internal"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	commonapi "github.com/Mininglamp-OSS/octo-server/modules/base/common"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
+	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/accesslog"
 	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
@@ -220,6 +222,13 @@ func runAPI(ctx *config.Context) {
 	// 由 sticker 模块在 New() 时落值——策略源在 system_setting(common 模块),故不在此组合根
 	// 设置,避免反向依赖 modules/sticker。
 	metrics.NewStickerMetrics(prometheus.DefaultRegisterer)
+	// Install the one process registry before register.GetModules constructs
+	// module instances. The foundation rollout deliberately has no production
+	// producer registrations; later enablement injects only a bound Sender into
+	// its owning module after the cross-repository route/contract gates pass.
+	if err := installCardDispatch(ctx); err != nil {
+		panic(fmt.Errorf("install internal card dispatch registry: %w", err))
+	}
 	// 构造进程级共享头像渲染缓存,并把观测 hooks 接到上面注册的头像指标。所有头像端点
 	// (user 的 UserAvatar;群组头像渲染合并后亦然——#478)经 avatarrender.GetOrRender
 	// 共用这一个实例:共享 LRU + 同一个渲染信号量(后者唯一,才是真正的进程级渲染并发
@@ -332,6 +341,18 @@ func runAPI(ctx *config.Context) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func installCardDispatch(ctx *config.Context) error {
+	deps := carddispatch.Dependencies{
+		IdentityResolver: botidentity.New(ctx),
+		Authorizer:       carddispatch.NewDBAuthorizer(ctx.DB()),
+		Transport:        ctx,
+		Metrics:          carddispatch.NewMetrics(prometheus.DefaultRegisterer),
+		Logger:           log.NewTLog("CardDispatch"),
+	}
+	registry := carddispatch.NewRegistry(deps, nil)
+	return carddispatch.Install(ctx, registry)
 }
 
 func printServerInfo(ctx *config.Context) {

--- a/main_carddispatch_test.go
+++ b/main_carddispatch_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestCardDispatchRegistryInstalledBeforeModuleConstruction(t *testing.T) {
+	source, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	text := string(source)
+	install := strings.Index(text, "installCardDispatch(ctx)")
+	setup := strings.Index(text, "module.Setup(ctx)")
+	if install < 0 {
+		t.Fatal("main must install the per-context card dispatch registry")
+	}
+	if setup < 0 || install > setup {
+		t.Fatal("card dispatch registry must be installed before module.Setup constructs producers")
+	}
+}
+
+func TestDormantFoundationRegistersNoProductionProducer(t *testing.T) {
+	source, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	if !strings.Contains(string(source), "carddispatch.NewRegistry(deps, nil)") {
+		t.Fatal("foundation rollout must install an empty registry until cross-repo enablement gates pass")
+	}
+}

--- a/modules/botidentity/resolver.go
+++ b/modules/botidentity/resolver.go
@@ -17,6 +17,10 @@ type Kind string
 const (
 	KindUserBot Kind = "user_bot"
 	KindAppBot  Kind = "app_bot"
+
+	// ScopePlatform and ScopeSpace are the authoritative app_bot.scope values.
+	ScopePlatform = "platform"
+	ScopeSpace    = "space"
 )
 
 var (
@@ -29,36 +33,47 @@ var (
 
 // Identity is the minimum authoritative metadata consumers need.
 type Identity struct {
-	UID  string
-	Kind Kind
+	UID        string
+	Kind       Kind
+	CreatorUID string
+	AppScope   string
+	AppSpaceID string
 }
 
 type activeKindStore interface {
-	activeKinds(uid string) (userBot bool, appBot bool, err error)
+	lookup(uid string) (identityRecord, error)
+}
+
+type identityRecord struct {
+	UserBot    bool   `db:"user_bot"`
+	CreatorUID string `db:"creator_uid"`
+	AppBot     bool   `db:"app_bot"`
+	AppScope   string `db:"app_scope"`
+	AppSpaceID string `db:"app_space_id"`
 }
 
 type dbActiveKindStore struct {
 	session *dbr.Session
 }
 
-// activeKinds reads both lifecycle authorities in one statement. MySQL gives
-// the two EXISTS predicates one statement snapshot, so an ambiguous result is
-// detected consistently without a precedence rule or a two-query race.
-func (s *dbActiveKindStore) activeKinds(uid string) (bool, bool, error) {
-	var row struct {
-		UserBot int `db:"user_bot"`
-		AppBot  int `db:"app_bot"`
-	}
+// lookup reads both lifecycle authorities and their authorization metadata in
+// one statement snapshot. This prevents kind and policy metadata from drifting
+// across separate queries while an identity is unpublished or reconfigured.
+func (s *dbActiveKindStore) lookup(uid string) (identityRecord, error) {
+	var row identityRecord
 	err := s.session.SelectBySql(`
 		SELECT
 			EXISTS(SELECT 1 FROM robot WHERE robot_id=? AND status=1) AS user_bot,
-			EXISTS(SELECT 1 FROM app_bot WHERE uid=? AND status=1) AS app_bot`,
-		uid, uid,
+			COALESCE((SELECT creator_uid FROM robot WHERE robot_id=? AND status=1 LIMIT 1), '') AS creator_uid,
+			EXISTS(SELECT 1 FROM app_bot WHERE uid=? AND status=1) AS app_bot,
+			COALESCE((SELECT scope FROM app_bot WHERE uid=? AND status=1 LIMIT 1), '') AS app_scope,
+			COALESCE((SELECT space_id FROM app_bot WHERE uid=? AND status=1 LIMIT 1), '') AS app_space_id`,
+		uid, uid, uid, uid, uid,
 	).LoadOne(&row)
 	if err != nil {
-		return false, false, err
+		return identityRecord{}, err
 	}
-	return row.UserBot == 1, row.AppBot == 1, nil
+	return row, nil
 }
 
 // Resolver performs live authoritative lookups. It intentionally has no
@@ -83,18 +98,23 @@ func (r *Resolver) Resolve(uid string) (*Identity, error) {
 	if r == nil || r.store == nil {
 		return nil, ErrResolverUnavailable
 	}
-	userBot, appBot, err := r.store.activeKinds(uid)
+	record, err := r.store.lookup(uid)
 	if err != nil {
 		return nil, fmt.Errorf("resolve bot identity %q: %w", uid, err)
 	}
-	if userBot && appBot {
+	if record.UserBot && record.AppBot {
 		return nil, fmt.Errorf("%w: uid %q is active in robot and app_bot", ErrAmbiguousIdentity, uid)
 	}
-	if userBot {
-		return &Identity{UID: uid, Kind: KindUserBot}, nil
+	if record.UserBot {
+		return &Identity{UID: uid, Kind: KindUserBot, CreatorUID: record.CreatorUID}, nil
 	}
-	if appBot {
-		return &Identity{UID: uid, Kind: KindAppBot}, nil
+	if record.AppBot {
+		return &Identity{
+			UID:        uid,
+			Kind:       KindAppBot,
+			AppScope:   record.AppScope,
+			AppSpaceID: record.AppSpaceID,
+		}, nil
 	}
 	return nil, nil
 }

--- a/modules/botidentity/resolver_integration_test.go
+++ b/modules/botidentity/resolver_integration_test.go
@@ -20,21 +20,21 @@ func TestResolverAgainstAuthoritativeBotTables(t *testing.T) {
 	conn.SetMaxOpenConns(1)
 	t.Cleanup(func() { _ = conn.Close() })
 	session := conn.NewSession(nil)
-	_, err = session.Exec("CREATE TABLE robot (robot_id TEXT PRIMARY KEY, status INTEGER NOT NULL)")
+	_, err = session.Exec("CREATE TABLE robot (robot_id TEXT PRIMARY KEY, status INTEGER NOT NULL, creator_uid TEXT NOT NULL DEFAULT '')")
 	require.NoError(t, err)
-	_, err = session.Exec("CREATE TABLE app_bot (uid TEXT PRIMARY KEY, status INTEGER NOT NULL)")
+	_, err = session.Exec("CREATE TABLE app_bot (uid TEXT PRIMARY KEY, status INTEGER NOT NULL, scope TEXT NOT NULL DEFAULT 'platform', space_id TEXT)")
 	require.NoError(t, err)
 	_, err = session.Exec("CREATE TABLE user (uid TEXT PRIMARY KEY, robot INTEGER NOT NULL, status INTEGER NOT NULL)")
 	require.NoError(t, err)
 
 	insertRobot := func(uid string, status int) {
 		t.Helper()
-		_, err := session.InsertBySql("INSERT INTO robot(robot_id,status) VALUES(?,?)", uid, status).Exec()
+		_, err := session.InsertBySql("INSERT INTO robot(robot_id,status,creator_uid) VALUES(?,?,?)", uid, status, "owner-"+uid).Exec()
 		require.NoError(t, err)
 	}
 	insertAppBot := func(uid string, status int) {
 		t.Helper()
-		_, err := session.InsertBySql("INSERT INTO app_bot(uid,status) VALUES(?,?)", uid, status).Exec()
+		_, err := session.InsertBySql("INSERT INTO app_bot(uid,status,scope,space_id) VALUES(?,?,?,?)", uid, status, "space", "space-a").Exec()
 		require.NoError(t, err)
 	}
 
@@ -85,6 +85,13 @@ func TestResolverAgainstAuthoritativeBotTables(t *testing.T) {
 			require.NotNil(t, got)
 			assert.Equal(t, tt.uid, got.UID)
 			assert.Equal(t, tt.wantKind, got.Kind)
+			if tt.wantKind == KindUserBot {
+				assert.Equal(t, "owner-"+tt.uid, got.CreatorUID)
+			}
+			if tt.wantKind == KindAppBot {
+				assert.Equal(t, ScopeSpace, got.AppScope)
+				assert.Equal(t, "space-a", got.AppSpaceID)
+			}
 		})
 	}
 }

--- a/modules/botidentity/resolver_test.go
+++ b/modules/botidentity/resolver_test.go
@@ -12,15 +12,14 @@ import (
 )
 
 type fakeActiveKindStore struct {
-	userBot bool
-	appBot  bool
-	err     error
-	calls   int
+	record identityRecord
+	err    error
+	calls  int
 }
 
-func (f *fakeActiveKindStore) activeKinds(string) (bool, bool, error) {
+func (f *fakeActiveKindStore) lookup(string) (identityRecord, error) {
 	f.calls++
-	return f.userBot, f.appBot, f.err
+	return f.record, f.err
 }
 
 func TestResolverResolve(t *testing.T) {
@@ -36,9 +35,9 @@ func TestResolverResolve(t *testing.T) {
 	}{
 		{name: "empty uid", uid: "", store: &fakeActiveKindStore{}, wantNil: true, calls: 0},
 		{name: "missing", uid: "missing", store: &fakeActiveKindStore{}, wantNil: true, calls: 1},
-		{name: "active user bot", uid: "user_bot", store: &fakeActiveKindStore{userBot: true}, wantKind: KindUserBot, calls: 1},
-		{name: "published app bot", uid: "app_bot", store: &fakeActiveKindStore{appBot: true}, wantKind: KindAppBot, calls: 1},
-		{name: "ambiguous active identity", uid: "both", store: &fakeActiveKindStore{userBot: true, appBot: true}, wantErr: ErrAmbiguousIdentity, calls: 1},
+		{name: "active user bot", uid: "user_bot", store: &fakeActiveKindStore{record: identityRecord{UserBot: true, CreatorUID: "owner"}}, wantKind: KindUserBot, calls: 1},
+		{name: "published app bot", uid: "app_bot", store: &fakeActiveKindStore{record: identityRecord{AppBot: true, AppScope: ScopeSpace, AppSpaceID: "space-a"}}, wantKind: KindAppBot, calls: 1},
+		{name: "ambiguous active identity", uid: "both", store: &fakeActiveKindStore{record: identityRecord{UserBot: true, AppBot: true}}, wantErr: ErrAmbiguousIdentity, calls: 1},
 		{name: "lookup failure", uid: "broken", store: &fakeActiveKindStore{err: dbErr}, wantErr: dbErr, calls: 1},
 	}
 
@@ -58,6 +57,13 @@ func TestResolverResolve(t *testing.T) {
 					require.NotNil(t, got)
 					assert.Equal(t, tt.uid, got.UID)
 					assert.Equal(t, tt.wantKind, got.Kind)
+					if tt.wantKind == KindUserBot {
+						assert.Equal(t, "owner", got.CreatorUID)
+					}
+					if tt.wantKind == KindAppBot {
+						assert.Equal(t, ScopeSpace, got.AppScope)
+						assert.Equal(t, "space-a", got.AppSpaceID)
+					}
 				}
 			}
 			assert.Equal(t, tt.calls, tt.store.calls)
@@ -66,14 +72,14 @@ func TestResolverResolve(t *testing.T) {
 }
 
 func TestResolverActivePreservesErrors(t *testing.T) {
-	r := &Resolver{store: &fakeActiveKindStore{userBot: true, appBot: true}}
+	r := &Resolver{store: &fakeActiveKindStore{record: identityRecord{UserBot: true, AppBot: true}}}
 	active, err := r.Active("both")
 	assert.False(t, active)
 	assert.ErrorIs(t, err, ErrAmbiguousIdentity)
 }
 
 func TestResolverActive(t *testing.T) {
-	r := &Resolver{store: &fakeActiveKindStore{appBot: true}}
+	r := &Resolver{store: &fakeActiveKindStore{record: identityRecord{AppBot: true}}}
 	active, err := r.Active("app")
 	require.NoError(t, err)
 	assert.True(t, active)
@@ -98,24 +104,25 @@ func TestDBActiveKindStore(t *testing.T) {
 
 	t.Run("returns both predicates", func(t *testing.T) {
 		store, mock := newStore(t)
-		mock.ExpectQuery(`(?s)SELECT.*EXISTS.*robot.*EXISTS.*app_bot`).
-			WillReturnRows(sqlmock.NewRows([]string{"user_bot", "app_bot"}).AddRow(1, 0))
+		mock.ExpectQuery(`(?s)SELECT.*EXISTS.*robot.*creator_uid.*EXISTS.*app_bot.*scope.*space_id`).
+			WillReturnRows(sqlmock.NewRows([]string{"user_bot", "creator_uid", "app_bot", "app_scope", "app_space_id"}).AddRow(1, "owner-a", 0, "", ""))
 
-		userBot, appBot, err := store.activeKinds("bot")
+		record, err := store.lookup("bot")
 		require.NoError(t, err)
-		assert.True(t, userBot)
-		assert.False(t, appBot)
+		assert.True(t, record.UserBot)
+		assert.False(t, record.AppBot)
+		assert.Equal(t, "owner-a", record.CreatorUID)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
 	t.Run("preserves query error", func(t *testing.T) {
 		store, mock := newStore(t)
 		dbErr := errors.New("query failed")
-		mock.ExpectQuery(`(?s)SELECT.*EXISTS.*robot.*EXISTS.*app_bot`).WillReturnError(dbErr)
+		mock.ExpectQuery(`(?s)SELECT.*EXISTS.*robot.*creator_uid.*EXISTS.*app_bot.*scope.*space_id`).WillReturnError(dbErr)
 
-		userBot, appBot, err := store.activeKinds("bot")
-		assert.False(t, userBot)
-		assert.False(t, appBot)
+		record, err := store.lookup("bot")
+		assert.False(t, record.UserBot)
+		assert.False(t, record.AppBot)
 		assert.ErrorIs(t, err, dbErr)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})

--- a/modules/notify/api.go
+++ b/modules/notify/api.go
@@ -15,12 +15,17 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/base/app"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/gocraft/dbr/v2"
 	"go.uber.org/zap"
 )
 
 // InternalTokenHeader is the header key for internal service authentication.
 const InternalTokenHeader = "X-Internal-Token"
+
+var errNotifyCardNotAllowed = errors.New("card payload not allowed on internal notify ingress")
 
 // Notify 通知模块
 type Notify struct {
@@ -135,6 +140,10 @@ func (n *Notify) sendNotify(c *wkhttp.Context) {
 
 	resp, err := n.deliverNotification(&req)
 	if err != nil {
+		if errors.Is(err, errNotifyCardNotAllowed) {
+			httperr.ResponseErrorL(c, errcode.ErrNotifyCardNotAllowed, nil, nil)
+			return
+		}
 		n.Error("投递通知失败", zap.Error(err), zap.String("space_id", req.SpaceID))
 		c.ResponseErrorWithStatus(errors.New("internal error"), http.StatusInternalServerError)
 		return
@@ -156,6 +165,14 @@ func (n *Notify) sendNotifyBatch(c *wkhttp.Context) {
 	if len(req.Notifications) > 50 {
 		c.ResponseErrorWithStatus(errors.New("批量上限50条"), http.StatusBadRequest)
 		return
+	}
+	// Preflight the whole batch before delivering any earlier text item. This
+	// preserves the zero-transport guarantee when a later entry is a card.
+	for i := range req.Notifications {
+		if cardmsg.IsCardPayload(req.Notifications[i].Payload) {
+			httperr.ResponseErrorL(c, errcode.ErrNotifyCardNotAllowed, nil, nil)
+			return
+		}
 	}
 
 	hasErrors := false
@@ -184,6 +201,12 @@ func (n *Notify) sendNotifyBatch(c *wkhttp.Context) {
 
 // deliverNotification 校验、过滤、投递
 func (n *Notify) deliverNotification(req *NotifyReq) (*NotifyResp, error) {
+	if req != nil && cardmsg.IsCardPayload(req.Payload) {
+		return nil, errNotifyCardNotAllowed
+	}
+	if req == nil {
+		return nil, errors.New("request不能为空")
+	}
 	if req.SpaceID == "" {
 		return nil, errors.New("space_id不能为空")
 	}

--- a/modules/notify/notify_integration_test.go
+++ b/modules/notify/notify_integration_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/app"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/gin-gonic/gin"
 	"github.com/gocraft/dbr/v2"
 	"github.com/gocraft/dbr/v2/dialect"
@@ -43,14 +45,14 @@ func init() {
 type stubUserService struct {
 	user.IService
 
-	mu                sync.Mutex
-	users             map[string]*user.Resp // keyed by username
-	addUserErr        error
-	addUserCount      int32
-	addUserDelay      time.Duration
+	mu                 sync.Mutex
+	users              map[string]*user.Resp // keyed by username
+	addUserErr         error
+	addUserCount       int32
+	addUserDelay       time.Duration
 	getByUsernameCalls int32
-	updateUserCount   int32
-	updateUserErr     error
+	updateUserCount    int32
+	updateUserErr      error
 }
 
 func newStubUserService() *stubUserService {
@@ -98,9 +100,9 @@ func (s *stubUserService) UpdateUser(req user.UserUpdateReq) error {
 
 // stubAppService mocks app.IService.
 type stubAppService struct {
-	createErr      error
-	createCount    int32
-	deleteCount    int32
+	createErr   error
+	createCount int32
+	deleteCount int32
 }
 
 func (s *stubAppService) GetApp(appID string) (*app.Resp, error) {
@@ -491,6 +493,45 @@ func TestIntegration_SendNotify_InternalErrorSurfaces500(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "internal error")
 }
 
+func TestIntegration_InternalNotifyRejectsCardPayloadBeforeAnyDelivery(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	db, _, closeDB := newMockedDBSession(t)
+	defer closeDB()
+
+	n := newTestNotify(ctx, db, newStubUserService(), &stubAppService{}, "tk")
+	r := buildRouter(n)
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	h := http.Header{}
+	h.Set(InternalTokenHeader, "tk")
+	cardPayload := map[string]interface{}{
+		"type":         cardmsg.InteractiveCard.Int(),
+		"card_version": cardmsg.CardVersion,
+		"profile":      cardmsg.ProfileV1,
+		"card":         map[string]interface{}{"type": "AdaptiveCard", "version": cardmsg.CardVersion},
+	}
+
+	t.Run("single", func(t *testing.T) {
+		w := doJSONRequest(t, r, http.MethodPost, "/v1/internal/notify", h, NotifyReq{
+			SpaceID: "space-a", Service: "summary", Targets: []string{"user-a"}, Payload: cardPayload,
+		})
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), `"code":"err.server.notify.card_not_allowed"`)
+		assert.Zero(t, atomic.LoadInt32(&wk.messageCount))
+	})
+
+	t.Run("batch preflights every entry before delivering text", func(t *testing.T) {
+		w := doJSONRequest(t, r, http.MethodPost, "/v1/internal/notify/batch", h, BatchNotifyReq{Notifications: []NotifyReq{
+			{SpaceID: "space-a", Service: "summary", Targets: []string{"user-a"}, Payload: map[string]interface{}{"type": 1, "content": "legacy"}},
+			{SpaceID: "space-a", Service: "summary", Targets: []string{"user-b"}, Payload: cardPayload},
+		}})
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), `"code":"err.server.notify.card_not_allowed"`)
+		assert.Zero(t, atomic.LoadInt32(&wk.messageCount))
+	})
+}
+
 func TestIntegration_SendNotifyBatch_Empty(t *testing.T) {
 	wk := newWuKongServer()
 	defer wk.close()
@@ -591,8 +632,8 @@ func TestIntegration_SendNotifyBatch_AllSuccess_200(t *testing.T) {
 	h.Set(InternalTokenHeader, "tk")
 	body := BatchNotifyReq{
 		Notifications: []NotifyReq{
-			{SpaceID: spaceID, Service: "svc", Targets: []string{"uid_a"}, Payload: map[string]interface{}{"k": "v1"}},
-			{SpaceID: spaceID, Service: "svc", Targets: []string{"uid_b"}, Payload: map[string]interface{}{"k": "v2"}},
+			{SpaceID: spaceID, Service: "svc", Targets: []string{"uid_a"}, Payload: map[string]interface{}{"type": 1, "content": "v1"}},
+			{SpaceID: spaceID, Service: "svc", Targets: []string{"uid_b"}, Payload: map[string]interface{}{"type": 1, "content": "v2"}},
 		},
 	}
 	w := doJSONRequest(t, r, "POST", "/v1/internal/notify/batch", h, body)
@@ -797,7 +838,6 @@ func TestIntegration_EnsureBot_BotOK_SkipsCreation(t *testing.T) {
 	assert.Equal(t, int32(0), atomic.LoadInt32(&us.getByUsernameCalls))
 }
 
-
 // When memberCache is empty for the space, deliverNotification drives
 // memberCache.refresh which issues a `SELECT uid FROM space_member ...` query.
 func TestIntegration_Deliver_CacheMiss_RefreshesFromDB(t *testing.T) {
@@ -836,7 +876,6 @@ func TestIntegration_Deliver_CacheMiss_RefreshesFromDB(t *testing.T) {
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"uid_b"}, resp2.Delivered)
 }
-
 
 func TestIntegration_HandleSpaceMemberEvent_InvalidatesCache(t *testing.T) {
 	wk := newWuKongServer()

--- a/pkg/cardtmpl/resource.go
+++ b/pkg/cardtmpl/resource.go
@@ -1,0 +1,206 @@
+// Package cardtmpl owns reviewed server-side Adaptive Card templates. It does
+// not dispatch messages; producer modules pass its document to carddispatch.
+package cardtmpl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+const (
+	MaxExcerptRunes = 300
+	maxFacts        = 20
+	maxTitleRunes   = 200
+	maxFactRunes    = 500
+)
+
+type Fact struct {
+	Title string
+	Value string
+}
+
+type ResourceCard struct {
+	IconURL     string
+	Title       string
+	Attribution string
+	Excerpt     string
+	Facts       []Fact
+	CopyText    string
+}
+
+func BuildSummaryResourceCard(
+	ctx context.Context,
+	webLoginURL string,
+	taskID string,
+	spaceID string,
+	resource ResourceCard,
+) (json.RawMessage, error) {
+	if strings.TrimSpace(taskID) == "" || strings.TrimSpace(spaceID) == "" {
+		return nil, errors.New("cardtmpl: task ID and space ID are required")
+	}
+	if strings.TrimSpace(resource.Title) == "" || utf8.RuneCountInString(resource.Title) > maxTitleRunes {
+		return nil, errors.New("cardtmpl: resource title is invalid")
+	}
+	if len(resource.Facts) > maxFacts {
+		return nil, errors.New("cardtmpl: too many facts")
+	}
+	for _, fact := range resource.Facts {
+		if strings.TrimSpace(fact.Title) == "" || strings.TrimSpace(fact.Value) == "" ||
+			utf8.RuneCountInString(fact.Title) > maxFactRunes || utf8.RuneCountInString(fact.Value) > maxFactRunes {
+			return nil, errors.New("cardtmpl: invalid fact")
+		}
+	}
+	if len(resource.CopyText) > cardmsg.MaxCopyTextBytes {
+		return nil, errors.New("cardtmpl: copy text too large")
+	}
+	if err := requireHTTPS(resource.IconURL); err != nil {
+		return nil, fmt.Errorf("cardtmpl: icon URL: %w", err)
+	}
+	deepLink, err := summaryDeepLink(webLoginURL, taskID, spaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	lang := i18n.OutboundLanguage(ctx)
+	labels := labelsForLanguage(lang)
+	titleItems := []interface{}{
+		map[string]interface{}{
+			"type":   "TextBlock",
+			"text":   escapeMarkdown(resource.Title),
+			"weight": "Bolder",
+			"wrap":   true,
+		},
+	}
+	if strings.TrimSpace(resource.Attribution) != "" {
+		titleItems = append(titleItems, map[string]interface{}{
+			"type":     "TextBlock",
+			"text":     escapeMarkdown(resource.Attribution),
+			"isSubtle": true,
+			"spacing":  "None",
+			"wrap":     true,
+		})
+	}
+	body := []interface{}{
+		map[string]interface{}{
+			"type": "ColumnSet",
+			"columns": []interface{}{
+				map[string]interface{}{
+					"type":  "Column",
+					"width": "auto",
+					"items": []interface{}{
+						map[string]interface{}{"type": "Image", "url": resource.IconURL, "size": "Small"},
+					},
+				},
+				map[string]interface{}{
+					"type":  "Column",
+					"width": "stretch",
+					"items": titleItems,
+				},
+			},
+		},
+	}
+	if excerpt := truncateRunes(strings.TrimSpace(resource.Excerpt), MaxExcerptRunes); excerpt != "" {
+		body = append(body, map[string]interface{}{
+			"type": "TextBlock",
+			"text": escapeMarkdown(excerpt),
+			"wrap": true,
+		})
+	}
+	if len(resource.Facts) > 0 {
+		facts := make([]interface{}, 0, len(resource.Facts))
+		for _, fact := range resource.Facts {
+			facts = append(facts, map[string]interface{}{
+				"title": escapeMarkdown(fact.Title),
+				"value": escapeMarkdown(fact.Value),
+			})
+		}
+		body = append(body, map[string]interface{}{"type": "FactSet", "facts": facts})
+	}
+	actions := []interface{}{
+		map[string]interface{}{"type": "Action.OpenUrl", "title": labels.viewDetails, "url": deepLink},
+	}
+	if resource.CopyText != "" {
+		actions = append(actions, map[string]interface{}{
+			"type": "Action.CopyToClipboard", "title": labels.copy, "text": resource.CopyText,
+		})
+	}
+	body = append(body, map[string]interface{}{"type": "ActionSet", "actions": actions})
+
+	document := map[string]interface{}{
+		"type":    "AdaptiveCard",
+		"version": cardmsg.CardVersion,
+		"body":    body,
+	}
+	raw, err := json.Marshal(document)
+	if err != nil {
+		return nil, fmt.Errorf("cardtmpl: marshal resource card: %w", err)
+	}
+	return json.RawMessage(raw), nil
+}
+
+func summaryDeepLink(webLoginURL, taskID, spaceID string) (string, error) {
+	base, err := url.Parse(strings.TrimSpace(webLoginURL))
+	if err != nil || base.Scheme != "https" || base.Host == "" {
+		return "", errors.New("cardtmpl: web base URL must be absolute https")
+	}
+	origin := (&url.URL{Scheme: base.Scheme, Host: base.Host}).String()
+	return origin + "/s/" + url.PathEscape(taskID) + "?sp=" + url.QueryEscape(spaceID), nil
+}
+
+func requireHTTPS(raw string) error {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return errors.New("must be absolute https")
+	}
+	return nil
+}
+
+func truncateRunes(value string, limit int) string {
+	runes := []rune(value)
+	if len(runes) <= limit {
+		return value
+	}
+	if limit <= 1 {
+		return "…"
+	}
+	return string(runes[:limit-1]) + "…"
+}
+
+func escapeMarkdown(value string) string {
+	replacer := strings.NewReplacer(
+		`\`, `\\`,
+		`*`, `\*`,
+		`_`, `\_`,
+		`[`, `\[`,
+		`]`, `\]`,
+		`(`, `\(`,
+		`)`, `\)`,
+		`<`, `\<`,
+		`>`, `\>`,
+		"`", "\\`",
+		`#`, `\#`,
+		`~`, `\~`,
+		`|`, `\|`,
+	)
+	return replacer.Replace(value)
+}
+
+type localizedLabels struct {
+	viewDetails string
+	copy        string
+}
+
+func labelsForLanguage(lang string) localizedLabels {
+	if strings.EqualFold(lang, "zh-CN") || strings.HasPrefix(strings.ToLower(lang), "zh-") {
+		return localizedLabels{viewDetails: "查看详情", copy: "复制"}
+	}
+	return localizedLabels{viewDetails: "View details", copy: "Copy"}
+}

--- a/pkg/cardtmpl/resource.go
+++ b/pkg/cardtmpl/resource.go
@@ -61,8 +61,13 @@ func BuildSummaryResourceCard(
 	if len(resource.CopyText) > cardmsg.MaxCopyTextBytes {
 		return nil, errors.New("cardtmpl: copy text too large")
 	}
-	if err := requireHTTPS(resource.IconURL); err != nil {
-		return nil, fmt.Errorf("cardtmpl: icon URL: %w", err)
+	// The icon is optional; when present it must be an absolute https URL (the
+	// same positive-allowlist rule cardmsg.Validate re-checks). An empty icon
+	// simply omits the leading image column.
+	if resource.IconURL != "" {
+		if err := requireHTTPS(resource.IconURL); err != nil {
+			return nil, fmt.Errorf("cardtmpl: icon URL: %w", err)
+		}
 	}
 	deepLink, err := summaryDeepLink(webLoginURL, taskID, spaceID)
 	if err != nil {
@@ -88,8 +93,9 @@ func BuildSummaryResourceCard(
 			"wrap":     true,
 		})
 	}
-	body := []interface{}{
-		map[string]interface{}{
+	var header map[string]interface{}
+	if resource.IconURL != "" {
+		header = map[string]interface{}{
 			"type": "ColumnSet",
 			"columns": []interface{}{
 				map[string]interface{}{
@@ -105,8 +111,12 @@ func BuildSummaryResourceCard(
 					"items": titleItems,
 				},
 			},
-		},
+		}
+	} else {
+		// No icon: place the title block(s) directly, without a column wrapper.
+		header = map[string]interface{}{"type": "Container", "items": titleItems}
 	}
+	body := []interface{}{header}
 	if excerpt := truncateRunes(strings.TrimSpace(resource.Excerpt), MaxExcerptRunes); excerpt != "" {
 		body = append(body, map[string]interface{}{
 			"type": "TextBlock",

--- a/pkg/cardtmpl/resource_test.go
+++ b/pkg/cardtmpl/resource_test.go
@@ -76,6 +76,42 @@ func TestBuildSummaryResourceCardSnapshotAndValidation(t *testing.T) {
 	require.NoError(t, cardmsg.Validate(envelope))
 }
 
+func TestBuildSummaryResourceCardIconIsOptional(t *testing.T) {
+	resource := exampleResourceCard()
+	resource.IconURL = ""
+	document, err := BuildSummaryResourceCard(
+		localizedContext("en-US"),
+		"https://im.example.com/login",
+		"task-1",
+		"space-1",
+		resource,
+	)
+	require.NoError(t, err)
+
+	var card struct {
+		Body []map[string]interface{} `json:"body"`
+	}
+	require.NoError(t, json.Unmarshal(document, &card))
+	require.NotEmpty(t, card.Body)
+	assert.Equal(t, "Container", card.Body[0]["type"], "no-icon header should be a plain Container, not a ColumnSet")
+	assert.NotContains(t, string(document), `"type":"Image"`)
+
+	envelope := map[string]interface{}{
+		"type":         cardmsg.InteractiveCard.Int(),
+		"card_version": cardmsg.CardVersion,
+		"profile":      cardmsg.ProfileV1,
+		"card":         mustDecodeCard(t, document),
+	}
+	require.NoError(t, cardmsg.Validate(envelope))
+}
+
+func mustDecodeCard(t *testing.T, document []byte) map[string]interface{} {
+	t.Helper()
+	var card map[string]interface{}
+	require.NoError(t, json.Unmarshal(document, &card))
+	return card
+}
+
 func TestBuildSummaryResourceCardUsesOutboundLanguage(t *testing.T) {
 	document, err := BuildSummaryResourceCard(
 		localizedContext("zh-CN"),

--- a/pkg/cardtmpl/resource_test.go
+++ b/pkg/cardtmpl/resource_test.go
@@ -1,0 +1,151 @@
+package cardtmpl
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func localizedContext(lang string) context.Context {
+	return i18n.WithLanguage(context.Background(), i18n.LanguageDecision{
+		Language: lang,
+		Source:   i18n.LanguageSourceUser,
+	})
+}
+
+func exampleResourceCard() ResourceCard {
+	return ResourceCard{
+		IconURL:     "https://static.example.com/summary.png",
+		Title:       "Quarterly summary",
+		Attribution: "Alice shared a smart summary",
+		Excerpt:     "Revenue increased by **18%**.",
+		Facts: []Fact{
+			{Title: "Status", Value: "Completed"},
+			{Title: "Messages", Value: "128"},
+		},
+		CopyText: "summary-42",
+	}
+}
+
+func TestBuildSummaryResourceCardSnapshotAndValidation(t *testing.T) {
+	document, err := BuildSummaryResourceCard(
+		localizedContext("en-US"),
+		"https://im.example.com/login?redirect=1",
+		"task/42",
+		"space a",
+		exampleResourceCard(),
+	)
+	require.NoError(t, err)
+
+	want := `{
+	  "type":"AdaptiveCard",
+	  "version":"1.5",
+	  "body":[
+	    {"type":"ColumnSet","columns":[
+	      {"type":"Column","width":"auto","items":[{"type":"Image","url":"https://static.example.com/summary.png","size":"Small"}]},
+	      {"type":"Column","width":"stretch","items":[
+	        {"type":"TextBlock","text":"Quarterly summary","weight":"Bolder","wrap":true},
+	        {"type":"TextBlock","text":"Alice shared a smart summary","isSubtle":true,"spacing":"None","wrap":true}
+	      ]}
+	    ]},
+	    {"type":"TextBlock","text":"Revenue increased by \\*\\*18%\\*\\*.","wrap":true},
+	    {"type":"FactSet","facts":[{"title":"Status","value":"Completed"},{"title":"Messages","value":"128"}]},
+	    {"type":"ActionSet","actions":[
+	      {"type":"Action.OpenUrl","title":"View details","url":"https://im.example.com/s/task%2F42?sp=space+a"},
+	      {"type":"Action.CopyToClipboard","title":"Copy","text":"summary-42"}
+	    ]}
+	  ]
+	}`
+	assert.JSONEq(t, want, string(document))
+
+	var card map[string]interface{}
+	require.NoError(t, json.Unmarshal(document, &card))
+	envelope := map[string]interface{}{
+		"type":         cardmsg.InteractiveCard.Int(),
+		"card_version": cardmsg.CardVersion,
+		"profile":      cardmsg.ProfileV1,
+		"card":         card,
+	}
+	require.NoError(t, cardmsg.Validate(envelope))
+}
+
+func TestBuildSummaryResourceCardUsesOutboundLanguage(t *testing.T) {
+	document, err := BuildSummaryResourceCard(
+		localizedContext("zh-CN"),
+		"https://im.example.com/login",
+		"task-1",
+		"space-1",
+		exampleResourceCard(),
+	)
+	require.NoError(t, err)
+	assert.Contains(t, string(document), `"title":"查看详情"`)
+	assert.Contains(t, string(document), `"title":"复制"`)
+}
+
+func TestBuildSummaryResourceCardEscapesExternalMarkdownLeaves(t *testing.T) {
+	resource := exampleResourceCard()
+	resource.Title = `[forged](javascript:alert(1)) **admin**`
+	resource.Attribution = `<https://evil.example>`
+	resource.Excerpt = `![image](https://evil.example/x.png)`
+	resource.Facts = []Fact{{Title: "[role]", Value: "**owner**"}}
+	document, err := BuildSummaryResourceCard(
+		localizedContext("en-US"),
+		"https://im.example.com/login",
+		"task-1",
+		"space-1",
+		resource,
+	)
+	require.NoError(t, err)
+	assert.NotContains(t, string(document), `"text":"[forged](`)
+	assert.Contains(t, string(document), `\\[forged\\]\\(javascript:alert\\(1\\)\\)`)
+	assert.Contains(t, string(document), `\\*\\*owner\\*\\*`)
+}
+
+func TestBuildSummaryResourceCardBoundsExcerptByRunes(t *testing.T) {
+	resource := exampleResourceCard()
+	resource.Excerpt = strings.Repeat("摘", MaxExcerptRunes+50)
+	document, err := BuildSummaryResourceCard(
+		localizedContext("zh-CN"),
+		"https://im.example.com/login",
+		"task-1",
+		"space-1",
+		resource,
+	)
+	require.NoError(t, err)
+
+	var card struct {
+		Body []map[string]interface{} `json:"body"`
+	}
+	require.NoError(t, json.Unmarshal(document, &card))
+	require.GreaterOrEqual(t, len(card.Body), 2)
+	excerpt, _ := card.Body[1]["text"].(string)
+	assert.LessOrEqual(t, utf8.RuneCountInString(excerpt), MaxExcerptRunes)
+	assert.True(t, strings.HasSuffix(excerpt, "…"))
+}
+
+func TestBuildSummaryResourceCardRejectsUnsafeInputs(t *testing.T) {
+	cases := []struct {
+		name       string
+		webBaseURL string
+		resource   ResourceCard
+	}{
+		{name: "non https web base", webBaseURL: "http://im.example.com/login", resource: exampleResourceCard()},
+		{name: "unsafe icon", webBaseURL: "https://im.example.com/login", resource: func() ResourceCard { r := exampleResourceCard(); r.IconURL = "javascript:alert(1)"; return r }()},
+		{name: "missing title", webBaseURL: "https://im.example.com/login", resource: func() ResourceCard { r := exampleResourceCard(); r.Title = ""; return r }()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			document, err := BuildSummaryResourceCard(localizedContext("en-US"), tc.webBaseURL, "task-1", "space-1", tc.resource)
+			assert.Nil(t, document)
+			assert.Error(t, err)
+		})
+	}
+}

--- a/pkg/errcode/notify.go
+++ b/pkg/errcode/notify.go
@@ -1,0 +1,13 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+var ErrNotifyCardNotAllowed = register(codes.Code{
+	ID:             "err.server.notify.card_not_allowed",
+	HTTPStatus:     http.StatusBadRequest,
+	DefaultMessage: "Card payloads are not allowed on the internal notification endpoint.",
+})

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -39,6 +39,9 @@ other = "资源不存在。"
 ["err.shared.internal"]
 other = "服务器内部错误。"
 
+["err.server.notify.card_not_allowed"]
+other = "内部通知接口不允许发送卡片消息。"
+
 ["err.server.thread.group_no_invalid"]
 other = "群编号无效。"
 

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -588,6 +588,9 @@ other = "Search service is temporarily unavailable."
 ["err.server.messages_search.validation_failed"]
 other = "Invalid search request."
 
+["err.server.notify.card_not_allowed"]
+other = "Card payloads are not allowed on the internal notification endpoint."
+
 ["err.server.oidc.bind_already_bound"]
 other = "This identity is already bound. Please sign in via OIDC to continue."
 

--- a/tools/lint-card-dispatch/main.go
+++ b/tools/lint-card-dispatch/main.go
@@ -16,18 +16,24 @@ import (
 	"strings"
 )
 
+// AllowlistEntry names one exact reviewed type-17 transport owner. Path is the
+// import-path-style directory suffix (e.g. "modules/bot_api"), NOT a bare
+// package name: matching on the package identifier alone would let any new
+// directory that merely declares the same `package name` + receiver.method
+// inherit the exemption, re-opening the "hidden directory bypass" Decision 12
+// forbids. Anchoring on the path keeps each entry a single reviewed location.
 type AllowlistEntry struct {
-	Package  string
+	Path     string
 	Receiver string
 	Function string
 	Reason   string
 }
 
 var defaultAllowlist = []AllowlistEntry{
-	{Package: "bot_api", Receiver: "BotAPI", Function: "sendMessage", Reason: "reviewed authenticated Bot API card ingress"},
-	{Package: "robot", Receiver: "Robot", Function: "sendMessage", Reason: "reviewed legacy Robot API card ingress"},
-	{Package: "incomingwebhook", Receiver: "IncomingWebhook", Function: "handlePush", Reason: "reviewed Incoming Webhook card ingress"},
-	{Package: "carddispatch", Receiver: "producerSender", Function: "Send", Reason: "sole reviewed server-internal card dispatch boundary"},
+	{Path: "modules/bot_api", Receiver: "BotAPI", Function: "sendMessage", Reason: "reviewed authenticated Bot API card ingress"},
+	{Path: "modules/robot", Receiver: "Robot", Function: "sendMessage", Reason: "reviewed legacy Robot API card ingress"},
+	{Path: "modules/incomingwebhook", Receiver: "IncomingWebhook", Function: "handlePush", Reason: "reviewed Incoming Webhook card ingress"},
+	{Path: "internal/carddispatch", Receiver: "producerSender", Function: "Send", Reason: "sole reviewed server-internal card dispatch boundary"},
 }
 
 type Finding struct {
@@ -59,6 +65,7 @@ type functionAlias struct {
 
 type packageInfo struct {
 	name          string
+	dir           string
 	functions     map[functionKey][]*functionInfo
 	allFunctions  []*functionInfo
 	cardConstants map[string]struct{}
@@ -107,6 +114,7 @@ func Scan(roots []string, allowlist []AllowlistEntry) ([]Finding, error) {
 		if pkg == nil {
 			pkg = &packageInfo{
 				name:          file.Name.Name,
+				dir:           filepath.Dir(path),
 				functions:     make(map[functionKey][]*functionInfo),
 				cardConstants: make(map[string]struct{}),
 			}
@@ -131,9 +139,13 @@ func Scan(roots []string, allowlist []AllowlistEntry) ([]Finding, error) {
 				line:  position.Line,
 				calls: make(map[functionKey]struct{}),
 			}
-			receivers := receiverBindings(fn, key.receiver)
+			// bindings maps in-scope identifiers (the method receiver plus locals
+			// whose type is syntactically knowable) to their struct type name, so
+			// a transport call reached through a method on a package-local value —
+			// not just the enclosing receiver — still records a call-graph edge.
+			bindings := collectLocalBindings(fn.Body, receiverBindings(fn, key.receiver))
 			constants := functionCardConstants(fn.Body, pkg.cardConstants)
-			aliases := functionAliases(fn.Body, receivers)
+			aliases := functionAliases(fn.Body, bindings)
 			ast.Inspect(fn.Body, func(node ast.Node) bool {
 				switch value := node.(type) {
 				case *ast.CompositeLit:
@@ -144,6 +156,14 @@ func Scan(roots []string, allowlist []AllowlistEntry) ([]Finding, error) {
 					if assignmentContainsCardType(value, constants) {
 						info.constructsCard = true
 					}
+				case *ast.SelectorExpr:
+					// Any syntactic reference to the transport selector counts,
+					// whether it is called, stored in a field, or passed as a
+					// higher-order value. A value form still hands transport to
+					// another site, so it cannot be a loophole in the backstop.
+					if isTransportReference(value) {
+						info.directTransport = true
+					}
 				case *ast.CallExpr:
 					if identifier, ok := value.Fun.(*ast.Ident); ok {
 						if alias, exists := aliases[identifier.Name]; exists {
@@ -152,10 +172,10 @@ func Scan(roots []string, allowlist []AllowlistEntry) ([]Finding, error) {
 							} else {
 								info.calls[alias.function] = struct{}{}
 							}
-						} else if called, exists := calledFunctionKey(value.Fun, receivers); exists {
+						} else if called, exists := calledFunctionKey(value.Fun, bindings); exists {
 							info.calls[called] = struct{}{}
 						}
-					} else if called, ok := calledFunctionKey(value.Fun, receivers); ok {
+					} else if called, ok := calledFunctionKey(value.Fun, bindings); ok {
 						info.calls[called] = struct{}{}
 					}
 					name := calledName(value.Fun)
@@ -173,12 +193,12 @@ func Scan(roots []string, allowlist []AllowlistEntry) ([]Finding, error) {
 		}
 	}
 
-	allowed := make(map[string]struct{}, len(allowlist))
+	allowed := make([]AllowlistEntry, 0, len(allowlist))
 	for _, entry := range allowlist {
-		if entry.Package == "" || entry.Function == "" || entry.Reason == "" {
+		if entry.Path == "" || entry.Function == "" || entry.Reason == "" {
 			continue
 		}
-		allowed[allowlistKey(entry.Package, functionKey{receiver: entry.Receiver, name: entry.Function})] = struct{}{}
+		allowed = append(allowed, entry)
 	}
 
 	var findings []Finding
@@ -188,7 +208,7 @@ func Scan(roots []string, allowlist []AllowlistEntry) ([]Finding, error) {
 			if !function.constructsCard || !function.directTransport {
 				continue
 			}
-			if isAllowed(allowed, pkg.name, function.key) {
+			if isAllowed(allowed, pkg.dir, function.key) {
 				continue
 			}
 			findings = append(findings, Finding{
@@ -209,13 +229,13 @@ func Scan(roots []string, allowlist []AllowlistEntry) ([]Finding, error) {
 	return findings, nil
 }
 
-func propagate(pkg *packageInfo, allowed map[string]struct{}) {
+func propagate(pkg *packageInfo, allowed []AllowlistEntry) {
 	changed := true
 	for changed {
 		changed = false
 		for _, function := range pkg.allFunctions {
 			for called := range function.calls {
-				if isAllowed(allowed, pkg.name, called) {
+				if isAllowed(allowed, pkg.dir, called) {
 					continue
 				}
 				for _, callee := range pkg.functions[called] {
@@ -233,13 +253,26 @@ func propagate(pkg *packageInfo, allowed map[string]struct{}) {
 	}
 }
 
-func allowlistKey(packageName string, function functionKey) string {
-	return packageName + "\x00" + function.receiver + "\x00" + function.name
+// isAllowed reports whether a function in package directory pkgDir is a reviewed
+// transport owner. It matches on the directory path (suffix, so the tool works
+// regardless of the root prefix the caller passes) plus the exact receiver and
+// function name — never on the bare package identifier.
+func isAllowed(allowed []AllowlistEntry, pkgDir string, function functionKey) bool {
+	for _, entry := range allowed {
+		if entry.Receiver == function.receiver && entry.Function == function.name && pkgDirMatchesPath(pkgDir, entry.Path) {
+			return true
+		}
+	}
+	return false
 }
 
-func isAllowed(allowed map[string]struct{}, packageName string, function functionKey) bool {
-	_, ok := allowed[allowlistKey(packageName, function)]
-	return ok
+func pkgDirMatchesPath(pkgDir, allowPath string) bool {
+	pkgDir = filepath.ToSlash(pkgDir)
+	allowPath = strings.Trim(filepath.ToSlash(allowPath), "/")
+	if allowPath == "" {
+		return false
+	}
+	return pkgDir == allowPath || strings.HasSuffix(pkgDir, "/"+allowPath)
 }
 
 func declaredFunctionKey(fn *ast.FuncDecl) functionKey {
@@ -259,6 +292,77 @@ func receiverBindings(fn *ast.FuncDecl, receiverType string) map[string]string {
 		bindings[name.Name] = receiverType
 	}
 	return bindings
+}
+
+// collectLocalBindings extends the receiver bindings with local variables whose
+// struct type is syntactically knowable (`var s T`, `s := T{…}`, `s := &T{…}`).
+// This lets calledFunctionKey record `s.method()` edges for a package-local
+// value, closing the extract-method wrapper evasion. Unknowable types (e.g. a
+// constructor return) are simply skipped; the guard stays a best-effort
+// backstop for recognizable shapes.
+func collectLocalBindings(body *ast.BlockStmt, base map[string]string) map[string]string {
+	bindings := make(map[string]string, len(base))
+	for name, typ := range base {
+		bindings[name] = typ
+	}
+	bind := func(name string, expr ast.Expr) {
+		if name == "" || name == "_" {
+			return
+		}
+		if typ := exprTypeName(expr); typ != "" {
+			bindings[name] = typ
+		}
+	}
+	ast.Inspect(body, func(node ast.Node) bool {
+		switch stmt := node.(type) {
+		case *ast.AssignStmt:
+			for index, left := range stmt.Lhs {
+				if index >= len(stmt.Rhs) {
+					continue
+				}
+				if identifier, ok := left.(*ast.Ident); ok {
+					bind(identifier.Name, stmt.Rhs[index])
+				}
+			}
+		case *ast.DeclStmt:
+			generated, ok := stmt.Decl.(*ast.GenDecl)
+			if !ok || generated.Tok != token.VAR {
+				return true
+			}
+			for _, spec := range generated.Specs {
+				values, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for index, name := range values.Names {
+					if values.Type != nil {
+						if typ := typeName(values.Type); typ != "" && name.Name != "_" {
+							bindings[name.Name] = typ
+						}
+					}
+					if index < len(values.Values) {
+						bind(name.Name, values.Values[index])
+					}
+				}
+			}
+		}
+		return true
+	})
+	return bindings
+}
+
+// exprTypeName recovers a struct type name from a value expression when it is a
+// composite literal (`T{…}`) or address-of composite (`&T{…}`).
+func exprTypeName(expression ast.Expr) string {
+	switch value := expression.(type) {
+	case *ast.CompositeLit:
+		return typeName(value.Type)
+	case *ast.UnaryExpr:
+		if value.Op == token.AND {
+			return exprTypeName(value.X)
+		}
+	}
+	return ""
 }
 
 func functionCardConstants(body *ast.BlockStmt, packageConstants map[string]struct{}) map[string]struct{} {

--- a/tools/lint-card-dispatch/main.go
+++ b/tools/lint-card-dispatch/main.go
@@ -1,0 +1,544 @@
+// Command lint-card-dispatch rejects new in-process type-17 transport owners.
+// It is a review backstop for recognizable Go call/data-flow shapes; runtime
+// payload passthrough is separately guarded at its ingress.
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type AllowlistEntry struct {
+	Package  string
+	Receiver string
+	Function string
+	Reason   string
+}
+
+var defaultAllowlist = []AllowlistEntry{
+	{Package: "bot_api", Receiver: "BotAPI", Function: "sendMessage", Reason: "reviewed authenticated Bot API card ingress"},
+	{Package: "robot", Receiver: "Robot", Function: "sendMessage", Reason: "reviewed legacy Robot API card ingress"},
+	{Package: "incomingwebhook", Receiver: "IncomingWebhook", Function: "handlePush", Reason: "reviewed Incoming Webhook card ingress"},
+	{Package: "carddispatch", Receiver: "producerSender", Function: "Send", Reason: "sole reviewed server-internal card dispatch boundary"},
+}
+
+type Finding struct {
+	Package  string
+	Receiver string
+	Function string
+	File     string
+	Line     int
+}
+
+type functionKey struct {
+	receiver string
+	name     string
+}
+
+type functionInfo struct {
+	key             functionKey
+	file            string
+	line            int
+	constructsCard  bool
+	directTransport bool
+	calls           map[functionKey]struct{}
+}
+
+type functionAlias struct {
+	function  functionKey
+	transport bool
+}
+
+type packageInfo struct {
+	name          string
+	functions     map[functionKey][]*functionInfo
+	allFunctions  []*functionInfo
+	cardConstants map[string]struct{}
+}
+
+func main() {
+	roots := os.Args[1:]
+	if len(roots) == 0 {
+		roots = []string{"./modules", "./internal"}
+	}
+	findings, err := Scan(roots, defaultAllowlist)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	if len(findings) == 0 {
+		return
+	}
+	for _, finding := range findings {
+		symbol := finding.Function
+		if finding.Receiver != "" {
+			symbol = finding.Receiver + "." + symbol
+		}
+		fmt.Fprintf(os.Stderr, "%s:%d: %s.%s constructs a type-17 card and reaches SendMessage transport\n",
+			finding.File, finding.Line, finding.Package, symbol)
+	}
+	os.Exit(1)
+}
+
+func Scan(roots []string, allowlist []AllowlistEntry) ([]Finding, error) {
+	files, err := goFiles(roots)
+	if err != nil {
+		return nil, err
+	}
+	fset := token.NewFileSet()
+	packages := make(map[string]*packageInfo)
+	parsed := make(map[string]*ast.File, len(files))
+	for _, path := range files {
+		file, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, parseErr)
+		}
+		parsed[path] = file
+		key := filepath.Dir(path) + "\x00" + file.Name.Name
+		pkg := packages[key]
+		if pkg == nil {
+			pkg = &packageInfo{
+				name:          file.Name.Name,
+				functions:     make(map[functionKey][]*functionInfo),
+				cardConstants: make(map[string]struct{}),
+			}
+			packages[key] = pkg
+		}
+		collectCardConstants(file, pkg.cardConstants)
+	}
+
+	for path, file := range parsed {
+		key := filepath.Dir(path) + "\x00" + file.Name.Name
+		pkg := packages[key]
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			position := fset.Position(fn.Pos())
+			key := declaredFunctionKey(fn)
+			info := &functionInfo{
+				key:   key,
+				file:  path,
+				line:  position.Line,
+				calls: make(map[functionKey]struct{}),
+			}
+			receivers := receiverBindings(fn, key.receiver)
+			constants := functionCardConstants(fn.Body, pkg.cardConstants)
+			aliases := functionAliases(fn.Body, receivers)
+			ast.Inspect(fn.Body, func(node ast.Node) bool {
+				switch value := node.(type) {
+				case *ast.CompositeLit:
+					if compositeContainsCardType(value, constants) {
+						info.constructsCard = true
+					}
+				case *ast.AssignStmt:
+					if assignmentContainsCardType(value, constants) {
+						info.constructsCard = true
+					}
+				case *ast.CallExpr:
+					if identifier, ok := value.Fun.(*ast.Ident); ok {
+						if alias, exists := aliases[identifier.Name]; exists {
+							if alias.transport {
+								info.directTransport = true
+							} else {
+								info.calls[alias.function] = struct{}{}
+							}
+						} else if called, exists := calledFunctionKey(value.Fun, receivers); exists {
+							info.calls[called] = struct{}{}
+						}
+					} else if called, ok := calledFunctionKey(value.Fun, receivers); ok {
+						info.calls[called] = struct{}{}
+					}
+					name := calledName(value.Fun)
+					if name == "SendMessage" || name == "SendMessageWithResult" {
+						info.directTransport = true
+					}
+					if isCardMarkerCall(value.Fun) {
+						info.constructsCard = true
+					}
+				}
+				return true
+			})
+			pkg.functions[info.key] = append(pkg.functions[info.key], info)
+			pkg.allFunctions = append(pkg.allFunctions, info)
+		}
+	}
+
+	allowed := make(map[string]struct{}, len(allowlist))
+	for _, entry := range allowlist {
+		if entry.Package == "" || entry.Function == "" || entry.Reason == "" {
+			continue
+		}
+		allowed[allowlistKey(entry.Package, functionKey{receiver: entry.Receiver, name: entry.Function})] = struct{}{}
+	}
+
+	var findings []Finding
+	for _, pkg := range packages {
+		propagate(pkg, allowed)
+		for _, function := range pkg.allFunctions {
+			if !function.constructsCard || !function.directTransport {
+				continue
+			}
+			if isAllowed(allowed, pkg.name, function.key) {
+				continue
+			}
+			findings = append(findings, Finding{
+				Package: pkg.name, Receiver: function.key.receiver, Function: function.key.name,
+				File: function.file, Line: function.line,
+			})
+		}
+	}
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].File != findings[j].File {
+			return findings[i].File < findings[j].File
+		}
+		if findings[i].Line != findings[j].Line {
+			return findings[i].Line < findings[j].Line
+		}
+		return findings[i].Function < findings[j].Function
+	})
+	return findings, nil
+}
+
+func propagate(pkg *packageInfo, allowed map[string]struct{}) {
+	changed := true
+	for changed {
+		changed = false
+		for _, function := range pkg.allFunctions {
+			for called := range function.calls {
+				if isAllowed(allowed, pkg.name, called) {
+					continue
+				}
+				for _, callee := range pkg.functions[called] {
+					if callee.constructsCard && !function.constructsCard {
+						function.constructsCard = true
+						changed = true
+					}
+					if callee.directTransport && !function.directTransport {
+						function.directTransport = true
+						changed = true
+					}
+				}
+			}
+		}
+	}
+}
+
+func allowlistKey(packageName string, function functionKey) string {
+	return packageName + "\x00" + function.receiver + "\x00" + function.name
+}
+
+func isAllowed(allowed map[string]struct{}, packageName string, function functionKey) bool {
+	_, ok := allowed[allowlistKey(packageName, function)]
+	return ok
+}
+
+func declaredFunctionKey(fn *ast.FuncDecl) functionKey {
+	key := functionKey{name: fn.Name.Name}
+	if fn.Recv != nil && len(fn.Recv.List) > 0 {
+		key.receiver = typeName(fn.Recv.List[0].Type)
+	}
+	return key
+}
+
+func receiverBindings(fn *ast.FuncDecl, receiverType string) map[string]string {
+	bindings := make(map[string]string)
+	if receiverType == "" || fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return bindings
+	}
+	for _, name := range fn.Recv.List[0].Names {
+		bindings[name.Name] = receiverType
+	}
+	return bindings
+}
+
+func functionCardConstants(body *ast.BlockStmt, packageConstants map[string]struct{}) map[string]struct{} {
+	constants := make(map[string]struct{}, len(packageConstants))
+	for name := range packageConstants {
+		constants[name] = struct{}{}
+	}
+
+	changed := true
+	for changed {
+		changed = false
+		ast.Inspect(body, func(node ast.Node) bool {
+			declaration, ok := node.(*ast.DeclStmt)
+			if !ok {
+				return true
+			}
+			generated, ok := declaration.Decl.(*ast.GenDecl)
+			if !ok || (generated.Tok != token.CONST && generated.Tok != token.VAR) {
+				return true
+			}
+			for _, spec := range generated.Specs {
+				values, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for index, name := range values.Names {
+					if _, exists := constants[name.Name]; exists || index >= len(values.Values) {
+						continue
+					}
+					if expressionIsCardType(values.Values[index], constants) {
+						constants[name.Name] = struct{}{}
+						changed = true
+					}
+				}
+			}
+			return true
+		})
+	}
+	return constants
+}
+
+func functionAliases(body *ast.BlockStmt, receivers map[string]string) map[string]functionAlias {
+	aliases := make(map[string]functionAlias)
+	ast.Inspect(body, func(node ast.Node) bool {
+		switch value := node.(type) {
+		case *ast.AssignStmt:
+			for index, left := range value.Lhs {
+				if index >= len(value.Rhs) {
+					continue
+				}
+				name, ok := left.(*ast.Ident)
+				if ok {
+					registerFunctionAlias(aliases, name.Name, value.Rhs[index], receivers)
+				}
+			}
+		case *ast.DeclStmt:
+			generated, ok := value.Decl.(*ast.GenDecl)
+			if !ok {
+				return true
+			}
+			for _, spec := range generated.Specs {
+				values, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for index, name := range values.Names {
+					if index < len(values.Values) {
+						registerFunctionAlias(aliases, name.Name, values.Values[index], receivers)
+					}
+				}
+			}
+		}
+		return true
+	})
+	return aliases
+}
+
+func registerFunctionAlias(aliases map[string]functionAlias, name string, expression ast.Expr, receivers map[string]string) {
+	if identifier, ok := expression.(*ast.Ident); ok {
+		if alias, exists := aliases[identifier.Name]; exists {
+			aliases[name] = alias
+			return
+		}
+	}
+	if isTransportReference(expression) {
+		aliases[name] = functionAlias{transport: true}
+		return
+	}
+	if function, ok := calledFunctionKey(expression, receivers); ok {
+		aliases[name] = functionAlias{function: function}
+	}
+}
+
+func isTransportReference(expression ast.Expr) bool {
+	selector, ok := expression.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	return selector.Sel.Name == "SendMessage" || selector.Sel.Name == "SendMessageWithResult"
+}
+
+func calledFunctionKey(expression ast.Expr, receivers map[string]string) (functionKey, bool) {
+	switch value := expression.(type) {
+	case *ast.Ident:
+		return functionKey{name: value.Name}, true
+	case *ast.SelectorExpr:
+		receiver, ok := value.X.(*ast.Ident)
+		if !ok {
+			return functionKey{}, false
+		}
+		receiverType := receivers[receiver.Name]
+		if receiverType == "" {
+			return functionKey{}, false
+		}
+		return functionKey{receiver: receiverType, name: value.Sel.Name}, true
+	default:
+		return functionKey{}, false
+	}
+}
+
+func typeName(expression ast.Expr) string {
+	switch value := expression.(type) {
+	case *ast.Ident:
+		return value.Name
+	case *ast.StarExpr:
+		return typeName(value.X)
+	case *ast.IndexExpr:
+		return typeName(value.X)
+	case *ast.IndexListExpr:
+		return typeName(value.X)
+	case *ast.ParenExpr:
+		return typeName(value.X)
+	default:
+		return ""
+	}
+}
+
+func goFiles(roots []string) ([]string, error) {
+	var files []string
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() {
+				switch entry.Name() {
+				case ".git", ".context", "testdata", "vendor":
+					if path != root {
+						return filepath.SkipDir
+					}
+				}
+				return nil
+			}
+			if strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") {
+				files = append(files, path)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("scan %s: %w", root, err)
+		}
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func collectCardConstants(file *ast.File, out map[string]struct{}) {
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || (gen.Tok != token.CONST && gen.Tok != token.VAR) {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			valueSpec, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for index, name := range valueSpec.Names {
+				if index < len(valueSpec.Values) && expressionIsCardType(valueSpec.Values[index], out) {
+					out[name.Name] = struct{}{}
+				}
+			}
+		}
+	}
+}
+
+func compositeContainsCardType(literal *ast.CompositeLit, constants map[string]struct{}) bool {
+	for _, element := range literal.Elts {
+		pair, ok := element.(*ast.KeyValueExpr)
+		if !ok || stringLiteral(pair.Key) != "type" {
+			continue
+		}
+		if expressionIsCardType(pair.Value, constants) {
+			return true
+		}
+	}
+	return false
+}
+
+func assignmentContainsCardType(assignment *ast.AssignStmt, constants map[string]struct{}) bool {
+	for index, left := range assignment.Lhs {
+		if index >= len(assignment.Rhs) {
+			continue
+		}
+		mapIndex, ok := left.(*ast.IndexExpr)
+		if !ok || stringLiteral(mapIndex.Index) != "type" {
+			continue
+		}
+		if expressionIsCardType(assignment.Rhs[index], constants) {
+			return true
+		}
+	}
+	return false
+}
+
+func expressionIsCardType(expression ast.Expr, constants map[string]struct{}) bool {
+	switch value := expression.(type) {
+	case *ast.BasicLit:
+		if value.Kind != token.INT {
+			return false
+		}
+		n, err := strconv.ParseInt(value.Value, 0, 64)
+		return err == nil && n == 17
+	case *ast.Ident:
+		_, ok := constants[value.Name]
+		return ok
+	case *ast.SelectorExpr:
+		return value.Sel.Name == "InteractiveCard"
+	case *ast.CallExpr:
+		return isInteractiveCardIntCall(value)
+	default:
+		return false
+	}
+}
+
+func isInteractiveCardIntCall(call *ast.CallExpr) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != "Int" {
+		return false
+	}
+	receiver, ok := selector.X.(*ast.SelectorExpr)
+	return ok && receiver.Sel.Name == "InteractiveCard"
+}
+
+func isCardMarkerCall(expression ast.Expr) bool {
+	selector, ok := expression.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	base, ok := selector.X.(*ast.Ident)
+	if !ok || base.Name != "cardmsg" {
+		return false
+	}
+	switch selector.Sel.Name {
+	case "Validate", "Finalize", "RecheckPayloadSize":
+		return true
+	default:
+		return false
+	}
+}
+
+func calledName(expression ast.Expr) string {
+	switch value := expression.(type) {
+	case *ast.Ident:
+		return value.Name
+	case *ast.SelectorExpr:
+		return value.Sel.Name
+	default:
+		return ""
+	}
+}
+
+func stringLiteral(expression ast.Expr) string {
+	literal, ok := expression.(*ast.BasicLit)
+	if !ok || literal.Kind != token.STRING {
+		return ""
+	}
+	value, err := strconv.Unquote(literal.Value)
+	if err != nil {
+		return ""
+	}
+	return value
+}

--- a/tools/lint-card-dispatch/main.go
+++ b/tools/lint-card-dispatch/main.go
@@ -178,8 +178,7 @@ func Scan(roots []string, allowlist []AllowlistEntry) ([]Finding, error) {
 					} else if called, ok := calledFunctionKey(value.Fun, bindings); ok {
 						info.calls[called] = struct{}{}
 					}
-					name := calledName(value.Fun)
-					if name == "SendMessage" || name == "SendMessageWithResult" {
+					if isTransportName(calledName(value.Fun)) {
 						info.directTransport = true
 					}
 					if isCardMarkerCall(value.Fun) {
@@ -461,7 +460,23 @@ func isTransportReference(expression ast.Expr) bool {
 	if !ok {
 		return false
 	}
-	return selector.Sel.Name == "SendMessage" || selector.Sel.Name == "SendMessageWithResult"
+	return isTransportName(selector.Sel.Name)
+}
+
+// isTransportName lists the octo-lib Context methods that hand a payload to the
+// IM transport. SendMessageBatch also carries an arbitrary []byte payload, so a
+// type-17 card sent through it is caught like SendMessage / SendMessageWithResult.
+// NOTE: this guard is intra-package and matches recognizable call/data-flow
+// shapes only — a transport call reached across packages, or built via
+// reflection/codegen, is out of its scope; the runtime ingress gate
+// (Decision 14) is the authoritative defense, this is defense-in-depth.
+func isTransportName(name string) bool {
+	switch name {
+	case "SendMessage", "SendMessageWithResult", "SendMessageBatch":
+		return true
+	default:
+		return false
+	}
 }
 
 func calledFunctionKey(expression ast.Expr, receivers map[string]string) (functionKey, bool) {

--- a/tools/lint-card-dispatch/main_test.go
+++ b/tools/lint-card-dispatch/main_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeFixture(t *testing.T, dir, name, source string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(source), 0o600))
+}
+
+func TestScanRejectsInternalCardTransportBypasses(t *testing.T) {
+	cases := []struct {
+		name  string
+		files map[string]string
+	}{
+		{
+			name: "direct SendMessage literal",
+			files: map[string]string{"bypass.go": `package bad
+func bypass() { payload := map[string]interface{}{"type": 17}; ctx.SendMessage(payload) }
+`},
+		},
+		{
+			name: "direct SendMessageWithResult constant",
+			files: map[string]string{"bypass.go": `package bad
+func bypass() { payload := map[string]interface{}{"type": cardmsg.InteractiveCard.Int()}; ctx.SendMessageWithResult(payload) }
+`},
+		},
+		{
+			name: "package local transport wrapper",
+			files: map[string]string{"bypass.go": `package bad
+func dispatch(v interface{}) { ctx.SendMessage(v) }
+func bypass() { payload := map[string]interface{}{"type": 17}; dispatch(payload) }
+`},
+		},
+		{
+			name: "construction and transport split across files",
+			files: map[string]string{
+				"card.go": `package bad
+func makeCard() interface{} { return map[string]interface{}{"type": 17} }
+`,
+				"send.go": `package bad
+func dispatch(v interface{}) { ctx.SendMessageWithResult(v) }
+func bypass() { dispatch(makeCard()) }
+`,
+			},
+		},
+		{
+			name: "local constant card type",
+			files: map[string]string{"bypass.go": `package bad
+func bypass() {
+	const interactiveCard = 17
+	payload := map[string]interface{}{"type": interactiveCard}
+	ctx.SendMessage(payload)
+}
+`},
+		},
+		{
+			name: "card type assigned after map construction",
+			files: map[string]string{"bypass.go": `package bad
+func bypass() {
+	payload := map[string]interface{}{}
+	payload["type"] = 17
+	ctx.SendMessageWithResult(payload)
+}
+`},
+		},
+		{
+			name: "transport method alias",
+			files: map[string]string{"bypass.go": `package bad
+func bypass() {
+	send := ctx.SendMessage
+	payload := map[string]interface{}{"type": 17}
+	send(payload)
+}
+`},
+		},
+		{
+			name: "package local wrapper alias",
+			files: map[string]string{"bypass.go": `package bad
+func dispatch(v interface{}) { ctx.SendMessage(v) }
+func bypass() {
+	send := dispatch
+	payload := map[string]interface{}{"type": 17}
+	send(payload)
+}
+`},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for name, source := range tc.files {
+				writeFixture(t, dir, name, source)
+			}
+			findings, err := Scan([]string{dir}, nil)
+			require.NoError(t, err)
+			require.Len(t, findings, 1)
+			assert.Contains(t, findings[0].Function, "bypass")
+		})
+	}
+}
+
+func TestScanAllowlistIsExactFunctionNotPackageWide(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "send.go", `package bot_api
+func sendMessage() { payload := map[string]interface{}{"type": 17}; ctx.SendMessageWithResult(payload) }
+func secondBypass() { payload := map[string]interface{}{"type": 17}; ctx.SendMessageWithResult(payload) }
+`)
+	allow := []AllowlistEntry{{Package: "bot_api", Function: "sendMessage", Reason: "reviewed external ingress"}}
+	findings, err := Scan([]string{dir}, allow)
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	assert.Equal(t, "secondBypass", findings[0].Function)
+}
+
+func TestScanDoesNotTreatCardRejectionAsConstruction(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "gate.go", `package notify
+func deliver(payload map[string]interface{}) {
+	if cardmsg.IsCardPayload(payload) { return }
+	ctx.SendMessage(map[string]interface{}{"type": 1, "content": "text"})
+}
+`)
+
+	findings, err := Scan([]string{dir}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+}
+
+func TestScanStopsPropagationAtAllowlistedProducer(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "producer.go", `package ingress
+func handlePush() {
+	payload := map[string]interface{}{"type": 17}
+	ctx.SendMessageWithResult(payload)
+}
+func route() { handlePush() }
+`)
+	allow := []AllowlistEntry{{Package: "ingress", Function: "handlePush", Reason: "reviewed ingress"}}
+
+	findings, err := Scan([]string{dir}, allow)
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+}
+
+func TestScanSeparatesMethodsByReceiver(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "receivers.go", `package clean
+type builder struct{}
+func (b *builder) step() { _ = map[string]interface{}{"type": 17} }
+func (b *builder) route() { b.step() }
+
+type transport struct{}
+func (s *transport) step() { ctx.SendMessage(nil) }
+`)
+
+	findings, err := Scan([]string{dir}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+}
+
+func TestDefaultAllowlistHasReasonsAndRepositoryPasses(t *testing.T) {
+	for _, entry := range defaultAllowlist {
+		assert.NotEmpty(t, entry.Package)
+		assert.NotEmpty(t, entry.Function)
+		assert.NotEmpty(t, entry.Reason)
+	}
+	findings, err := Scan([]string{"../../modules", "../../internal"}, defaultAllowlist)
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+}

--- a/tools/lint-card-dispatch/main_test.go
+++ b/tools/lint-card-dispatch/main_test.go
@@ -41,6 +41,12 @@ func bypass() { payload := map[string]interface{}{"type": cardmsg.InteractiveCar
 `},
 		},
 		{
+			name: "direct SendMessageBatch",
+			files: map[string]string{"bypass.go": `package bad
+func bypass() { payload := map[string]interface{}{"type": 17}; ctx.SendMessageBatch(payload) }
+`},
+		},
+		{
 			name: "package local transport wrapper",
 			files: map[string]string{"bypass.go": `package bad
 func dispatch(v interface{}) { ctx.SendMessage(v) }

--- a/tools/lint-card-dispatch/main_test.go
+++ b/tools/lint-card-dispatch/main_test.go
@@ -14,6 +14,15 @@ func writeFixture(t *testing.T, dir, name, source string) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(source), 0o600))
 }
 
+// writeFixtureIn writes into dir/subdir, creating it, so a fixture package can
+// live at a directory path the allowlist can anchor on.
+func writeFixtureIn(t *testing.T, dir, subdir, name, source string) {
+	t.Helper()
+	full := filepath.Join(dir, subdir)
+	require.NoError(t, os.MkdirAll(full, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(full, name), []byte(source), 0o600))
+}
+
 func TestScanRejectsInternalCardTransportBypasses(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -109,15 +118,30 @@ func bypass() {
 
 func TestScanAllowlistIsExactFunctionNotPackageWide(t *testing.T) {
 	dir := t.TempDir()
-	writeFixture(t, dir, "send.go", `package bot_api
+	writeFixtureIn(t, dir, "bot_api", "send.go", `package bot_api
 func sendMessage() { payload := map[string]interface{}{"type": 17}; ctx.SendMessageWithResult(payload) }
 func secondBypass() { payload := map[string]interface{}{"type": 17}; ctx.SendMessageWithResult(payload) }
 `)
-	allow := []AllowlistEntry{{Package: "bot_api", Function: "sendMessage", Reason: "reviewed external ingress"}}
+	allow := []AllowlistEntry{{Path: "bot_api", Function: "sendMessage", Reason: "reviewed external ingress"}}
 	findings, err := Scan([]string{dir}, allow)
 	require.NoError(t, err)
 	require.Len(t, findings, 1)
 	assert.Equal(t, "secondBypass", findings[0].Function)
+}
+
+// F2: an impostor directory that merely reuses an allowlisted package name +
+// receiver.method is NOT exempt, because the allowlist anchors on the path.
+func TestScanAllowlistDoesNotExemptImpostorPackageName(t *testing.T) {
+	dir := t.TempDir()
+	writeFixtureIn(t, dir, "evil", "send.go", `package carddispatch
+type producerSender struct{}
+func (s *producerSender) Send() { payload := map[string]interface{}{"type": 17}; ctx.SendMessageWithResult(payload) }
+`)
+	findings, err := Scan([]string{dir}, defaultAllowlist)
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	assert.Equal(t, "Send", findings[0].Function)
+	assert.Equal(t, "producerSender", findings[0].Receiver)
 }
 
 func TestScanDoesNotTreatCardRejectionAsConstruction(t *testing.T) {
@@ -136,18 +160,99 @@ func deliver(payload map[string]interface{}) {
 
 func TestScanStopsPropagationAtAllowlistedProducer(t *testing.T) {
 	dir := t.TempDir()
-	writeFixture(t, dir, "producer.go", `package ingress
+	writeFixtureIn(t, dir, "ingress", "producer.go", `package ingress
 func handlePush() {
 	payload := map[string]interface{}{"type": 17}
 	ctx.SendMessageWithResult(payload)
 }
 func route() { handlePush() }
 `)
-	allow := []AllowlistEntry{{Package: "ingress", Function: "handlePush", Reason: "reviewed ingress"}}
+	allow := []AllowlistEntry{{Path: "ingress", Function: "handlePush", Reason: "reviewed ingress"}}
 
 	findings, err := Scan([]string{dir}, allow)
 	require.NoError(t, err)
 	assert.Empty(t, findings)
+}
+
+// F1: a transport call reached through a method/field/higher-order value —
+// not the enclosing receiver — must still be caught.
+func TestScanRejectsWrapperTransportEvasions(t *testing.T) {
+	cases := []struct {
+		name  string
+		files map[string]string
+	}{
+		{
+			name: "extract-method wrapper on package-local value",
+			files: map[string]string{"bypass.go": `package bad
+type sender struct{}
+func (s *sender) go2(v interface{}) { ctx.SendMessage(v) }
+func bypass() {
+	s := sender{}
+	payload := map[string]interface{}{"type": 17}
+	s.go2(payload)
+}
+`},
+		},
+		{
+			name: "extract-method wrapper via pointer value",
+			files: map[string]string{"bypass.go": `package bad
+type sender struct{}
+func (s *sender) go2(v interface{}) { ctx.SendMessage(v) }
+func bypass() {
+	s := &sender{}
+	payload := map[string]interface{}{"type": 17}
+	s.go2(payload)
+}
+`},
+		},
+		{
+			name: "transport stored in a struct field",
+			files: map[string]string{"bypass.go": `package bad
+type box struct{ fn func(interface{}) }
+func bypass() {
+	b := box{fn: ctx.SendMessage}
+	payload := map[string]interface{}{"type": 17}
+	b.fn(payload)
+}
+`},
+		},
+		{
+			name: "transport passed as a higher-order argument",
+			files: map[string]string{"bypass.go": `package bad
+func run(fn func(interface{}), v interface{}) { fn(v) }
+func bypass() {
+	payload := map[string]interface{}{"type": 17}
+	run(ctx.SendMessageWithResult, payload)
+}
+`},
+		},
+		{
+			name: "construction and transport split across receiver methods",
+			files: map[string]string{"bypass.go": `package bad
+type maker struct{}
+func (m *maker) build() interface{} { return map[string]interface{}{"type": 17} }
+type pusher struct{}
+func (s *pusher) push(v interface{}) { ctx.SendMessage(v) }
+func bypass() {
+	m := maker{}
+	s := pusher{}
+	s.push(m.build())
+}
+`},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for name, source := range tc.files {
+				writeFixture(t, dir, name, source)
+			}
+			findings, err := Scan([]string{dir}, nil)
+			require.NoError(t, err)
+			require.Len(t, findings, 1)
+			assert.Contains(t, findings[0].Function, "bypass")
+		})
+	}
 }
 
 func TestScanSeparatesMethodsByReceiver(t *testing.T) {
@@ -168,7 +273,7 @@ func (s *transport) step() { ctx.SendMessage(nil) }
 
 func TestDefaultAllowlistHasReasonsAndRepositoryPasses(t *testing.T) {
 	for _, entry := range defaultAllowlist {
-		assert.NotEmpty(t, entry.Package)
+		assert.NotEmpty(t, entry.Path)
 		assert.NotEmpty(t, entry.Function)
 		assert.NotEmpty(t, entry.Reason)
 	}


### PR DESCRIPTION
## Summary

Adds `internal/carddispatch` as the **only** supported path for an in-process
business module to originate an `InteractiveCard` (`type=17`) message. The
dispatcher binds a reviewed producer capability to one configured active bot
identity, authorizes the exact Space/target from live DB state, owns the card
envelope, runs `cardmsg.Validate → authoritative Space enrichment → Finalize →
final size recheck` in a fixed order, makes at most one `SendMessageWithResult`
attempt, and emits bounded metrics/logs.

This is a **P1 dormant foundation**: no production producer is registered
(`NewRegistry(deps, nil)`), so deployment is behaviourally inert except one
runtime gate — `/v1/internal/notify[/batch]` now rejects card-shaped payloads
(Decision 14), closing the hole where an internal-token holder could emit a
trusted type-17 map bypassing every card gate. Enabling the `summary-notify`
pilot is a separate P2 PR (see the handoff doc).

## Related Issue

Refs #571

## Linked Spec

`.octospec/tasks/card-message-internal-dispatch/brief.md` (spec + locked
decisions). Next-stage plan: `.octospec/tasks/card-message-internal-dispatch/handoff.md`.

## Changes

- **`internal/carddispatch`** — capability-bound `Sender` (no caller `from_uid`/
  payload), immutable `Registry` (no `init()` global; unknown/duplicate/disabled/
  misconfigured producers fail closed), fixed-order dispatch pipeline, live
  `DBAuthorizer` (Space/DM/group/thread ACLs, fail-closed on every DB error),
  per-producer in-flight semaphore (`busy` on saturation), bounded Prometheus
  metrics + AST source guards for label/log vocabulary.
- **`pkg/cardtmpl`** — reviewed `ResourceCard` template (octo/v1, markdown-escaped
  leaves, https-only actions, rune-bounded excerpt, optional icon, deep link
  built server-side from `External` config).
- **`modules/botidentity`** — resolver extended to return `creator_uid` / app
  `scope` / `space_id` in one live snapshot.
- **`modules/notify`** — Decision 14 gate: `/v1/internal/notify[/batch]` rejects
  card payloads (`err.server.notify.card_not_allowed`, + zh-CN) before delivery,
  zero transport calls; batch pre-flights the whole request.
- **`tools/lint-card-dispatch`** — AST no-bypass guard (CI): only the reviewed
  external ingresses + `internal/carddispatch` may own type-17 transport;
  allowlist anchored on the import path.
- **Docs** — brief + handoff.

## Testing

```
go build ./... && go vet ./internal/carddispatch/... ./pkg/cardtmpl/...
go test ./internal/carddispatch/... ./pkg/cardtmpl/... ./tools/lint-card-dispatch/...
go run ./tools/lint-card-dispatch ./modules ./internal   # exit 0
```

- [x] Unit tests added/updated (dispatch pipeline, registry, policy matrix,
  fail-closed storage stages, member-exempt + explicit-ban, metrics/label
  guards, template snapshot/validate, guard wrapper/impostor evasions)
- [x] Manually verified (build/vet/test/guard green locally; DB authorizer
  tests run on in-memory sqlite locally, MySQL in CI per the brief)

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?** It creates a
   single trusted origination point for type-17 cards from server-internal code:
   sender trust (live `botidentity`, `iwh_`/human rejected), explicit Space +
   live target ACL, server-authored `plain`/`space_id`, and the ≤512 KiB final
   check are enforced in a fixed order before one transport attempt. It also
   closes the notify payload-passthrough hole at runtime (Decision 14). No
   production producer is enabled, so no new card traffic is emitted yet.

2. **What could break (dependents + failure mode)?** The only live behaviour
   change is `/v1/internal/notify[/batch]` rejecting card-shaped payloads; the
   sole known caller (smart-summary) sends `type=1` text only, so no legitimate
   traffic changes — a mis-sent card now gets `err.server.notify.card_not_allowed`
   instead of an untrusted send. The AST guard fails CI if any new non-test
   package pairs card construction with direct `SendMessage*`; onboard through
   the dispatcher or add a path-anchored allowlist entry with a reason.

3. **How do you know it works?** Table-driven + DB-backed tests cover the policy
   matrix, fail-closed on every DB error/not-found, exact validation order with
   zero transport on any denial, one-call success/error, overload/`busy`, the
   metric-label and no-card-in-logs source guards, and the notify card gate
   (card rejected with zero `SendMessage`, text still delivered). The guard runs
   clean against `./modules ./internal` and fails fixtures for each bypass shape
   including method/field/higher-order wrappers and impostor same-name packages.

## Checklist

- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (brief + handoff)
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNzozZG65vnBy78CgYA5NT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNzozZG65vnBy78CgYA5NT)_