### PR TITLE
feat(notify): summary-notify card pilot — first internal card producer

### DIFF
--- a/.octospec/journal/shared/summary-notify-pilot.md
+++ b/.octospec/journal/shared/summary-notify-pilot.md
@@ -1,0 +1,79 @@
+---
+type: Journal
+title: "Journal: summary-notify pilot (card-message-internal-dispatch P2)"
+description: Record of enabling the first internal card producer — the summary-notify DM card path in modules/notify on top of the dormant internal/carddispatch foundation.
+tags: ["card", "internal", "trust-boundary", "notify", "producer", "pilot", "cross-repo"]
+timestamp: 2026-07-13T15:44:34Z
+# --- octospec extension fields ---
+task: card-message-internal-dispatch
+upstream: octo-server#571
+source: self
+---
+# Journal: summary-notify pilot (card-message-internal-dispatch P2)
+
+## What was done
+
+Enabled the first production `internal/carddispatch` producer (`summary-notify`)
+on top of the dormant P1 foundation (PR #577 lineage), turning the summary
+completion/failure DM from plain text into a display-only (`octo/v1`)
+ResourceCard. Scope is octo-server only; DM (person) targets only.
+
+- **2a — summary bot.** Added a dedicated `summary` User Bot
+  (`user`+`app`+`robot.status=1`) provisioned via the same idempotent pattern as
+  `ensureNotifyBot`. The `notification` bot keeps the generic text path
+  untouched; identities stay decoupled.
+- **2b — producer wiring.** Registered the `summary-notify` `ProducerSpec`
+  (DM-only, `octo/v1`, `SpacePolicySystemNotification`, `MaxInFlight` 20) in
+  `installCardDispatch`; `modules/notify` obtains its bound `Sender` from the
+  registry already installed in `*config.Context` via `SenderFromContext` —
+  no `register.AddModule` change, no package-global registration (Decision 1/11).
+- **Card path.** `NotifyReq` gained an optional structured `Card` field
+  (`SummaryCardFields`, not a type-17 map). When present, notify builds the card
+  once via `cardtmpl.BuildSummaryResourceCard` and dispatches per verified
+  recipient through the bound `Sender`, reusing the existing member-verify →
+  actor-exclude → fan-out machinery. `Payload` and `Card` are mutually
+  exclusive.
+- **Contract.** `.octospec/tasks/card-message-internal-dispatch/summary-notify-contract.md`
+  captures the cross-repo wire contract for octo-smart-summary.
+
+## Structural learnings / gotchas
+
+- **Reuse the existing ingress, do not add a route.** The brief locks "no new
+  HTTP endpoint" and points the pilot at `NotifyReq`/notify's `memberCache`.
+  The card path therefore extends `NotifyReq` (a structured `Card` field), it
+  is NOT a new `/v1/internal/notify/summary-card` route. Decision 14's raw-card
+  rejection is unaffected because `Card` is structured fields, not a type-17
+  payload map.
+- **Preserve `NotifyResp{delivered,filtered}`.** octo-smart-summary's entire
+  per-recipient dedup/retry/sweep state machine keys off this response. The
+  card path maps `Sender.Send` success → `delivered[uid]`, `target_denied` /
+  `dispatch_failed` → `filtered[uid]=reason`, so the sidecar needs zero
+  response-handling change and its silent-success guard still holds.
+- **Template ownership is server-side.** The sidecar sends raw fields
+  (`task_no`, title, time range, counts, failure reason); octo-server composes
+  labels + the `/s/{task_no}?sp={space_id}` deep link. Deep-link identifier is
+  `summary_task.task_no` (opaque, unique), never the autoincrement `id`.
+- **Dual-mode request needs an explicit both-present reject.** A request struct
+  with two mutually-exclusive modes (`Payload` vs `Card`) must 400 when BOTH are
+  set, not only when both are absent — otherwise one mode is silently dropped.
+  Caught in review (`err.server.notify.card_invalid`).
+- **Deep link requires https.** `cardtmpl` fail-closes on non-https; the base
+  URL source (`External.WebLoginURL` origin vs a new `External.WebBaseURL`) is
+  deferred to the enablement config review, and prod must be https.
+
+## Verification
+
+`go vet` clean; `internal/carddispatch` race+cover 92.4%; `modules/notify`,
+`pkg/cardtmpl`, `pkg/cardmsg` tests green; `lint-card-dispatch` guard green;
+`make i18n-extract-check` + `make i18n-lint` green; `git diff --check` clean.
+
+## Rollout / dependencies
+
+Stacked on the P1 foundation branch (`feat/card-message-internal-dispatch`),
+NOT main — the `internal/carddispatch` foundation is not yet merged to main.
+End-to-end requires two other repos (out of scope here): octo-web must ship the
+`/s/:taskId` route (else the deep link is dead), and octo-smart-summary must
+switch its terminal-state notification from the text payload to the structured
+`Card` field per the contract. Until then this producer is inert (only the
+holder of `NOTIFY_INTERNAL_TOKEN` can reach it, and it still sends text).
+Rollback: global `OCTO_CARD_MESSAGE_ENABLED=false` or remove the one spec.

--- a/.octospec/learnings/pending/dual-mode-request-mutual-exclusion.md
+++ b/.octospec/learnings/pending/dual-mode-request-mutual-exclusion.md
@@ -1,0 +1,28 @@
+---
+type: Learning
+title: "Dual-mode request struct must reject both-present, not just both-absent"
+description: When one request struct carries two mutually-exclusive modes (legacy field vs new structured field), enforce the both-set → 400 guard too, or one mode is silently dropped.
+tags: ["api", "validation", "trust-boundary", "review"]
+timestamp: 2026-07-13T15:44:34Z
+# --- octospec extension fields ---
+source: self
+origin_task: card-message-internal-dispatch
+origin_pr: dmwork-org/octo-server (summary-notify pilot)
+status: pending
+candidate_rule: error-handling
+---
+# Dual-mode request struct must reject both-present, not just both-absent
+
+When an existing ingress struct is extended so one request can arrive in two
+mutually-exclusive shapes — here `NotifyReq.Payload` (legacy text) XOR
+`NotifyReq.Card` (new structured card) — the handler naturally grows a
+"neither is set → 400" guard. It is easy to forget the symmetric case: if a
+caller sets BOTH, the dispatch branch picks one (`Card != nil` wins) and
+silently discards the other, which diverges from the written contract and hides
+caller bugs.
+
+**Rule candidate:** for any dual-mode request field pair, add an explicit
+both-present → 400 rejection (a registered `errcode`, not a raw error) next to
+the both-absent guard. A `switch { case A && B: reject; case !A && !B: reject }`
+makes the exclusivity total. Caught in review on the summary-notify pilot
+(`err.server.notify.card_invalid`).

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -361,6 +361,16 @@ change-log convention (§7). Newest first.
   templates, slash commands (PR #418).
 - **Creation** — Dogfood task `member-list-name-fallback` (#344 → PR #420).
 
+## 2026-07-13 (card-message-internal-dispatch P2)
+
+- **Pilot** — Enabled the first `internal/carddispatch` producer
+  (`summary-notify`): dedicated `summary` bot + producer spec + `NotifyReq.Card`
+  structured branch building `octo/v1` DM cards via `cardtmpl` and dispatching
+  through the bound `Sender` (per-recipient fan-out, `NotifyResp` preserved).
+  Stacked on the P1 foundation branch, not main. Cross-repo (octo-web route,
+  octo-smart-summary switch) tracked in the summary-notify contract. See
+  [journal](journal/shared/summary-notify-pilot.md).
+
 ## 2026-06-19 (tooling)
 
 - **Update** — Synced OKF-aware slash commands, workflow skill, and task brief

--- a/.octospec/tasks/card-message-internal-dispatch/summary-notify-contract.md
+++ b/.octospec/tasks/card-message-internal-dispatch/summary-notify-contract.md
@@ -1,0 +1,115 @@
+# summary-notify 卡片通知 — 跨仓 ingress 契约(草稿）
+
+> 仓内草稿,供 octo-server P2(`summary-notify` pilot）实现时对齐,PR 打开后整理成英文
+> issue/comment 同步给 `Mininglamp-OSS/octo-smart-summary`。
+> 关联:brief.md(本目录)、handoff.md、octo-server PR #577(P1 地基)。
+> 状态:待 smart-summary owner 确认字段清单。最后更新 2026-07-13。
+
+## 背景一句话
+
+今天 smart-summary worker 在任务终态后 `POST /v1/internal/notify` 发**纯文本 DM**
+(`payload:{type:1,content:<整段文案>}`),per-recipient 一请求一收件人,dedup/retry 靠
+自己的 `summary_notification` 表 + `Sweep`。P2 把这条 DM **从纯文本升级为 `octo/v1`
+展示卡片**,发送方换成专用 `summary` bot,经 octo-server `internal/carddispatch` 边界
+派发。**不新增 HTTP 路由**(brief Goal / Out-of-scope),而是**扩展现有
+`/v1/internal/notify` 的 `NotifyReq`**。
+
+## 契约要点(锁定项)
+
+1. **同端点、同 token、同粒度**:仍是 `POST /v1/internal/notify`,头 `X-Internal-Token`,
+   **一请求一收件人**(`targets` 单元素)。smart-summary 的 claim/markSent/markFailed/
+   Sweep 状态机、`space_id`/`service`/`actor_uid` 语义**全部不变**。
+2. **`payload` 与 `card` 二选一**:
+   - 发文本(现状,其它 service 继续用):填 `payload:{type:1,content:...}`,`card` 省略。
+   - 发卡片(summary pilot):填结构化 `card`,`payload` 省略(server 侧 binding 从
+     `required` 放宽为二者其一)。
+3. **禁止客户端手搓 type-17 map**:Decision 14 仍然生效——`payload` 若被
+   `cardmsg.IsCardPayload` 判为卡片(`type=17`),**照旧 400 拒绝**。卡片只能走
+   结构化 `card` 字段,由 octo-server 用模板生成 type-17 wire,smart-summary 永远不构造
+   Adaptive Card JSON。
+4. **响应契约不变**:仍返回 `NotifyResp{delivered:[], filtered:{uid:reason}}`。卡片派发
+   成功 → uid 进 `delivered`;`target_denied`/`dispatch_failed`/建卡失败 → uid 进
+   `filtered`。smart-summary 现有「只认 `delivered[]` 判真送达 + 非成员进 filtered 重试」
+   的逻辑**一行不用改**(`recipientIsActiveMember` 预检可保留,carddispatch 的 target
+   校验会 fail-closed 兜底)。
+5. **模板/文案/链接归属 octo-server**:smart-summary **只发原始字段**;卡片布局、按钮
+   文案(查看详情/复制)、FactSet 标签、`/s/{task_no}?sp={space_id}` deep-link,全部由
+   octo-server `pkg/cardtmpl` + `i18n.OutboundLanguage` 生成。smart-summary 不再拼
+   「查看结果:<link>」(旧字段 `payload.result_url` 作废)。
+
+## 请求体(卡片模式)
+
+```jsonc
+POST /v1/internal/notify
+X-Internal-Token: <SUMMARY_NOTIFY_TOKEN>
+{
+  "space_id":  "spc_xxx",          // 现状:必填,server 用 memberCache 校验收件人
+  "service":   "summary-service",  // 现状不变
+  "targets":   ["uid_recipient"],  // 现状:单收件人
+  "actor_uid": "",                 // 现状:DM 通知留空
+  "card": {                        // 新增:非空即走 summary-notify 卡片 producer
+    "task_no":    "TN_20260713_abcd",   // ★ 见下「标识」
+    "kind":       "completed",          // "completed" | "failed"
+    "title":      "产品周会纪要",         // 原始标题(server 负责转义/截断)
+    "time_range": "2026-07-06 10:00 ~ 2026-07-13 10:00", // 见下「时间/计数」
+    "members":    5,                    // 参与人数;<=0 省略该行
+    "msg_count":  128,                  // 消息条数;<=0 省略该行
+    "generated_at": "2026-07-13 15:04", // 完成时间字符串;空则省略
+    "reason":     ""                    // failed 时的脱敏原因;completed 留空
+  }
+}
+```
+
+`payload` 与 `card` 同时缺失 → 400;两者同时存在 → 400(避免歧义)。
+
+## 三个约定(建议默认,待确认)
+
+- **标识 `task_no`(不是自增 `id`)**:deep-link `/s/{task_no}?sp={space_id}` 用
+  `summary_task.task_no`(varchar unique)。理由:不可枚举 + 与前端
+  `WKApp.openSummaryDetail` 对齐。**待 smart-summary 确认前端 detail 入口用的是 task_no
+  还是 id。**
+- **时间字段传「已格式化字符串」**:`time_range` / `generated_at` 由 smart-summary 用它
+  自己的 `internal/timezone`(东八区)格式化后传字符串,octo-server 原样填进 FactSet 值。
+  理由:octo-server 无该业务时区配置,避免时区漂移。**标签(“时间范围”)仍由 octo-server
+  按收件人语言本地化。**
+- **计数传 int**:`members` / `msg_count` 传整数,octo-server 按 `i18n.OutboundLanguage`
+  组装「参与成员:N 人」「消息数量:N 条」,单位随语言。
+
+## 字段来源(smart-summary 侧现成)
+
+| card 字段 | smart-summary 来源 |
+| --- | --- |
+| `task_no` | `SummaryTask.TaskNo` |
+| `kind` | `kindForStatus(status)`(completed/failed) |
+| `title` | `SummaryTask.Title` |
+| `time_range` | `formatTimeRange(task)`(现有) |
+| `members` | `participantCount(task)`(现有) |
+| `msg_count` | `summary_result.total_msg_count`(现有 `resultMeta`) |
+| `generated_at` | `summary_result.generated_at` 格式化(现有 `resultMeta`) |
+| `reason` | 现有 `errorSanitizer` 脱敏后的失败原因 |
+
+空间名(现在 smart-summary 自己 resolve)在卡片里不再需要——octo-server 侧可按 space_id
+自行渲染或省略,减少两边重复。
+
+## octo-server 侧(本 PR 落地,cross-repo 之外)
+
+- 新增专用 `summary` bot(user+app+robot.status=1),`notification` bot 只留纯文本路径。
+- 注册 `summary-notify` producer(DM/`octo/v1`/system-notification/MaxInFlight 20),
+  经 `SenderFromContext` 注入 notify。
+- `card` 分支:`memberCache.verify` → `cardtmpl` 建卡 → 每个成员 `sender.Send` → 汇总
+  `delivered/filtered`。**建卡/配置(如 deep-link 非 https)失败降级为原纯文本 DM**,
+  保证通知必达(此为 octo-server 侧策略,brief 未强制,PR 说明)。
+
+## enablement 门(端到端上线前必须齐)
+
+1. **octo-web** 上线 `/s/:taskId` 路由(否则「查看详情」死链)——独立 PR;
+2. octo-server 落 `cardtmpl` snapshot/Validate + deep-link 形状测试(本 PR);
+3. **smart-summary** 切换发送从 `payload` 文本 → `card` 字段(独立 PR,最后做)。
+
+在 (1)(3) 到位前,octo-server 侧行为惰性:无 `card` 请求即无卡片流量;全局
+`OCTO_CARD_MESSAGE_ENABLED` 为总开关,回滚可移除 producer spec 或关该 env。
+
+## 明确不在本契约内
+
+原群/thread 回发(member-exempt 群发)、A2 用户转发卡片、docs 分享卡片、per-channel
+限速与 cluster cap——均为后续独立任务(brief Out-of-scope)。

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/module"
 	libdb "github.com/Mininglamp-OSS/octo-lib/pkg/db"
@@ -23,10 +24,12 @@ import (
 	commonapi "github.com/Mininglamp-OSS/octo-server/modules/base/common"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
+	"github.com/Mininglamp-OSS/octo-server/modules/notify"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/accesslog"
 	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
 	"github.com/Mininglamp-OSS/octo-server/pkg/avatarrender"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	octodb "github.com/Mininglamp-OSS/octo-server/pkg/db"
 	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/Mininglamp-OSS/octo-server/pkg/metrics"
@@ -351,9 +354,34 @@ func installCardDispatch(ctx *config.Context) error {
 		Metrics:          carddispatch.NewMetrics(prometheus.DefaultRegisterer),
 		Logger:           log.NewTLog("CardDispatch"),
 	}
-	registry := carddispatch.NewRegistry(deps, nil)
+	// summary-notify pilot (brief › pilot table, all rows confirmed 2026-07-13):
+	// dedicated `summary` User Bot, DM-only, display-only octo/v1,
+	// system-notification Space policy, in-flight 20/process. modules/notify
+	// obtains this producer's bound Sender via carddispatch.SenderFromContext.
+	//
+	// Registration is inert until modules/notify receives a structured card
+	// request (NotifyReq.Card) AND OCTO_CARD_MESSAGE_ENABLED is on; end-to-end
+	// enablement additionally depends on octo-web shipping the /s/:taskId route
+	// and octo-smart-summary switching its send from text to the card fields.
+	specs := []carddispatch.ProducerSpec{
+		{
+			ID:                  summaryNotifyProducerID,
+			Enabled:             true,
+			SenderUID:           notify.SummaryBotUIDValue,
+			AllowedChannelTypes: []uint8{common.ChannelTypePerson.Uint8()},
+			AllowedProfiles:     []string{cardmsg.ProfileV1},
+			SpacePolicy:         carddispatch.SpacePolicySystemNotification,
+			GroupPolicy:         carddispatch.GroupPolicyMemberRequired, // unused at DM pilot; must be a valid value
+			MaxInFlight:         20,
+		},
+	}
+	registry := carddispatch.NewRegistry(deps, specs)
 	return carddispatch.Install(ctx, registry)
 }
+
+// summaryNotifyProducerID mirrors modules/notify's producer ID. Kept here so the
+// composition root can register the spec without importing an unexported const.
+const summaryNotifyProducerID = carddispatch.ProducerID("summary-notify")
 
 func printServerInfo(ctx *config.Context) {
 	infoStr := `

--- a/main.go
+++ b/main.go
@@ -354,6 +354,11 @@ func installCardDispatch(ctx *config.Context) error {
 		Metrics:          carddispatch.NewMetrics(prometheus.DefaultRegisterer),
 		Logger:           log.NewTLog("CardDispatch"),
 	}
+	registry := carddispatch.NewRegistry(deps, summaryNotifyProducerSpecs())
+	return carddispatch.Install(ctx, registry)
+}
+
+func summaryNotifyProducerSpecs() []carddispatch.ProducerSpec {
 	// summary-notify pilot (brief › pilot table, all rows confirmed 2026-07-13):
 	// dedicated `summary` User Bot, DM-only, display-only octo/v1,
 	// system-notification Space policy, in-flight 20/process. modules/notify
@@ -363,7 +368,7 @@ func installCardDispatch(ctx *config.Context) error {
 	// request (NotifyReq.Card) AND OCTO_CARD_MESSAGE_ENABLED is on; end-to-end
 	// enablement additionally depends on octo-web shipping the /s/:taskId route
 	// and octo-smart-summary switching its send from text to the card fields.
-	specs := []carddispatch.ProducerSpec{
+	return []carddispatch.ProducerSpec{
 		{
 			ID:                  summaryNotifyProducerID,
 			Enabled:             true,
@@ -375,8 +380,6 @@ func installCardDispatch(ctx *config.Context) error {
 			MaxInFlight:         20,
 		},
 	}
-	registry := carddispatch.NewRegistry(deps, specs)
-	return carddispatch.Install(ctx, registry)
 }
 
 // summaryNotifyProducerID mirrors modules/notify's producer ID. Kept here so the

--- a/main_carddispatch_test.go
+++ b/main_carddispatch_test.go
@@ -4,6 +4,11 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/modules/notify"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 )
 
 func TestCardDispatchRegistryInstalledBeforeModuleConstruction(t *testing.T) {
@@ -22,12 +27,35 @@ func TestCardDispatchRegistryInstalledBeforeModuleConstruction(t *testing.T) {
 	}
 }
 
-func TestDormantFoundationRegistersNoProductionProducer(t *testing.T) {
-	source, err := os.ReadFile("main.go")
-	if err != nil {
-		t.Fatalf("read main.go: %v", err)
+func TestSummaryNotifyIsOnlyProductionCardProducer(t *testing.T) {
+	specs := summaryNotifyProducerSpecs()
+	if len(specs) != 1 {
+		t.Fatalf("production registry has %d producers; want summary-notify only", len(specs))
 	}
-	if !strings.Contains(string(source), "carddispatch.NewRegistry(deps, nil)") {
-		t.Fatal("foundation rollout must install an empty registry until cross-repo enablement gates pass")
+
+	spec := specs[0]
+	if spec.ID != carddispatch.ProducerID("summary-notify") {
+		t.Fatalf("producer ID = %q; want summary-notify", spec.ID)
+	}
+	if !spec.Enabled {
+		t.Fatal("summary-notify producer must be enabled")
+	}
+	if spec.SenderUID != notify.SummaryBotUIDValue {
+		t.Fatalf("sender UID = %q; want %q", spec.SenderUID, notify.SummaryBotUIDValue)
+	}
+	if len(spec.AllowedChannelTypes) != 1 || spec.AllowedChannelTypes[0] != common.ChannelTypePerson.Uint8() {
+		t.Fatalf("allowed channel types = %v; want DM only", spec.AllowedChannelTypes)
+	}
+	if len(spec.AllowedProfiles) != 1 || spec.AllowedProfiles[0] != cardmsg.ProfileV1 {
+		t.Fatalf("allowed profiles = %v; want octo/v1 only", spec.AllowedProfiles)
+	}
+	if spec.SpacePolicy != carddispatch.SpacePolicySystemNotification {
+		t.Fatalf("space policy = %q; want system_notification", spec.SpacePolicy)
+	}
+	if spec.GroupPolicy != carddispatch.GroupPolicyMemberRequired {
+		t.Fatalf("group policy = %q; want member_required", spec.GroupPolicy)
+	}
+	if spec.MaxInFlight != 20 {
+		t.Fatalf("max in flight = %d; want 20", spec.MaxInFlight)
 	}
 }

--- a/modules/notify/api.go
+++ b/modules/notify/api.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"sync/atomic"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
@@ -44,7 +45,7 @@ type Notify struct {
 	botMu         sync.Mutex
 	botOK         bool
 	summaryBotMu  sync.Mutex
-	summaryBotOK  bool
+	summaryBotOK  atomic.Bool
 	cardSender    carddispatch.Sender
 	internalToken string
 	log.Log
@@ -105,7 +106,7 @@ func New(ctx *config.Context) *Notify {
 			n.Info("Notify bot ready")
 		}
 		n.ensureSummaryBotReady()
-		if n.summaryBotOK {
+		if n.summaryBotOK.Load() {
 			n.Info("Summary bot ready")
 		}
 	}()
@@ -117,12 +118,12 @@ func New(ctx *config.Context) *Notify {
 // (idempotent, retriable). The summary bot is the sender for both the card and
 // the text-fallback path, so both require it to exist.
 func (n *Notify) ensureSummaryBotReady() {
-	if n.summaryBotOK {
+	if n.summaryBotOK.Load() {
 		return
 	}
 	n.summaryBotMu.Lock()
-	if !n.summaryBotOK {
-		n.summaryBotOK = n.ensureSummaryBot()
+	if !n.summaryBotOK.Load() {
+		n.summaryBotOK.Store(n.ensureSummaryBot())
 	}
 	n.summaryBotMu.Unlock()
 }
@@ -178,7 +179,7 @@ func (n *Notify) sendNotify(c *wkhttp.Context) {
 	// Card present) bind cleanly. payload and card are mutually exclusive
 	// (contract); a text request that carries neither keeps the legacy 400.
 	switch {
-	case req.Card != nil && len(req.Payload) > 0:
+	case req.Card != nil && req.Payload != nil:
 		httperr.ResponseErrorL(c, errcode.ErrNotifyCardInvalid, nil, nil)
 		return
 	case req.Card == nil && len(req.Payload) == 0:

--- a/modules/notify/api.go
+++ b/modules/notify/api.go
@@ -43,7 +43,7 @@ type Notify struct {
 	db            *dbr.Session
 	memberCache   *memberCache
 	botMu         sync.Mutex
-	botOK         bool
+	botOK         atomic.Bool
 	summaryBotMu  sync.Mutex
 	summaryBotOK  atomic.Bool
 	cardSender    carddispatch.Sender
@@ -98,11 +98,11 @@ func New(ctx *config.Context) *Notify {
 			}
 		}()
 		n.botMu.Lock()
-		if !n.botOK {
-			n.botOK = n.ensureNotifyBot()
+		if !n.botOK.Load() {
+			n.botOK.Store(n.ensureNotifyBot())
 		}
 		n.botMu.Unlock()
-		if n.botOK {
+		if n.botOK.Load() {
 			n.Info("Notify bot ready")
 		}
 		n.ensureSummaryBotReady()
@@ -314,14 +314,14 @@ func (n *Notify) deliverNotification(req *NotifyReq) (*NotifyResp, error) {
 	}
 
 	// 确保 Bot 存在（失败可重试，不用 sync.Once）
-	if !n.botOK {
+	if !n.botOK.Load() {
 		n.botMu.Lock()
-		if !n.botOK {
-			n.botOK = n.ensureNotifyBot()
+		if !n.botOK.Load() {
+			n.botOK.Store(n.ensureNotifyBot())
 		}
 		n.botMu.Unlock()
 	}
-	if !n.botOK {
+	if !n.botOK.Load() {
 		return nil, errors.New("notify bot unavailable")
 	}
 

--- a/modules/notify/api.go
+++ b/modules/notify/api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/app"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
@@ -25,7 +26,13 @@ import (
 // InternalTokenHeader is the header key for internal service authentication.
 const InternalTokenHeader = "X-Internal-Token"
 
-var errNotifyCardNotAllowed = errors.New("card payload not allowed on internal notify ingress")
+// summaryNotifyProducerID is the carddispatch producer this module owns.
+const summaryNotifyProducerID = "summary-notify"
+
+var (
+	errNotifyCardNotAllowed = errors.New("card payload not allowed on internal notify ingress")
+	errNotifyCardInvalid    = errors.New("card notification request is invalid")
+)
 
 // Notify 通知模块
 type Notify struct {
@@ -36,6 +43,9 @@ type Notify struct {
 	memberCache   *memberCache
 	botMu         sync.Mutex
 	botOK         bool
+	summaryBotMu  sync.Mutex
+	summaryBotOK  bool
+	cardSender    carddispatch.Sender
 	internalToken string
 	log.Log
 }
@@ -57,6 +67,15 @@ func New(ctx *config.Context) *Notify {
 		Log:           log.NewTLog("Notify"),
 	}
 
+	// Obtain the producer-bound card Sender from the single registry composed at
+	// bootstrap (main.installCardDispatch, before module construction). A missing
+	// registration is non-fatal: card notifications degrade to the text DM path.
+	if sender, senderErr := carddispatch.SenderFromContext(ctx, summaryNotifyProducerID); senderErr != nil {
+		n.Warn("summary-notify card sender unavailable; card notifications will degrade to text", zap.Error(senderErr))
+	} else {
+		n.cardSender = sender
+	}
+
 	// 注册缓存失效回调（通过 event 包避免循环依赖）
 	event.SpaceMemberCacheInvalidator = func(spaceID string) {
 		n.memberCache.invalidate(spaceID)
@@ -70,7 +89,7 @@ func New(ctx *config.Context) *Notify {
 	// 监听成员加入事件
 	ctx.AddEventListener(event.SpaceMemberJoin, n.handleSpaceMemberEvent)
 
-	// 启动时创建全局通知 Bot（单例，带 panic recovery）
+	// 启动时创建全局通知 Bot + 专用 summary Bot（单例，带 panic recovery）
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
@@ -85,9 +104,27 @@ func New(ctx *config.Context) *Notify {
 		if n.botOK {
 			n.Info("Notify bot ready")
 		}
+		n.ensureSummaryBotReady()
+		if n.summaryBotOK {
+			n.Info("Summary bot ready")
+		}
 	}()
 
 	return n
+}
+
+// ensureSummaryBotReady provisions the dedicated summary bot on demand
+// (idempotent, retriable). The summary bot is the sender for both the card and
+// the text-fallback path, so both require it to exist.
+func (n *Notify) ensureSummaryBotReady() {
+	if n.summaryBotOK {
+		return
+	}
+	n.summaryBotMu.Lock()
+	if !n.summaryBotOK {
+		n.summaryBotOK = n.ensureSummaryBot()
+	}
+	n.summaryBotMu.Unlock()
 }
 
 // Route 路由配置
@@ -137,11 +174,26 @@ func (n *Notify) sendNotify(c *wkhttp.Context) {
 		c.ResponseErrorWithStatus(errors.New("参数格式错误"), http.StatusBadRequest)
 		return
 	}
+	// Payload dropped its binding:"required" so card requests (Payload absent,
+	// Card present) bind cleanly. payload and card are mutually exclusive
+	// (contract); a text request that carries neither keeps the legacy 400.
+	switch {
+	case req.Card != nil && len(req.Payload) > 0:
+		httperr.ResponseErrorL(c, errcode.ErrNotifyCardInvalid, nil, nil)
+		return
+	case req.Card == nil && len(req.Payload) == 0:
+		c.ResponseErrorWithStatus(errors.New("payload不能为空"), http.StatusBadRequest)
+		return
+	}
 
-	resp, err := n.deliverNotification(&req)
+	resp, err := n.dispatchNotify(&req)
 	if err != nil {
 		if errors.Is(err, errNotifyCardNotAllowed) {
 			httperr.ResponseErrorL(c, errcode.ErrNotifyCardNotAllowed, nil, nil)
+			return
+		}
+		if errors.Is(err, errNotifyCardInvalid) {
+			httperr.ResponseErrorL(c, errcode.ErrNotifyCardInvalid, nil, nil)
 			return
 		}
 		n.Error("投递通知失败", zap.Error(err), zap.String("space_id", req.SpaceID))
@@ -149,6 +201,15 @@ func (n *Notify) sendNotify(c *wkhttp.Context) {
 		return
 	}
 	c.Response(resp)
+}
+
+// dispatchNotify routes a single request to the card producer path (when a
+// structured Card is present) or the legacy text path.
+func (n *Notify) dispatchNotify(req *NotifyReq) (*NotifyResp, error) {
+	if req != nil && req.Card != nil {
+		return n.deliverCardNotification(req)
+	}
+	return n.deliverNotification(req)
 }
 
 // sendNotifyBatch handles POST /v1/internal/notify/batch
@@ -168,7 +229,13 @@ func (n *Notify) sendNotifyBatch(c *wkhttp.Context) {
 	}
 	// Preflight the whole batch before delivering any earlier text item. This
 	// preserves the zero-transport guarantee when a later entry is a card.
+	// Card notifications are single-endpoint only (they fan out through the
+	// carddispatch producer), so a Card in a batch entry is rejected outright.
 	for i := range req.Notifications {
+		if req.Notifications[i].Card != nil {
+			httperr.ResponseErrorL(c, errcode.ErrNotifyCardInvalid, nil, nil)
+			return
+		}
 		if cardmsg.IsCardPayload(req.Notifications[i].Payload) {
 			httperr.ResponseErrorL(c, errcode.ErrNotifyCardNotAllowed, nil, nil)
 			return

--- a/modules/notify/bot_manager.go
+++ b/modules/notify/bot_manager.go
@@ -15,6 +15,13 @@ const (
 	NotifyBotUIDValue = "notification"
 	// notifyBotName is the display name.
 	notifyBotName = "通知助手"
+	// SummaryBotUIDValue is the static UID for the dedicated summary-notification
+	// bot (the `summary-notify` carddispatch producer's sender). It is a full
+	// User Bot provisioned exactly like the notification bot; keeping it separate
+	// decouples DM-notification duty from future summary-card branding/membership.
+	SummaryBotUIDValue = "summary"
+	// summaryBotName is the summary bot display name.
+	summaryBotName = "总结助手"
 )
 
 // NotifyBotUID returns the static notification bot UID.
@@ -22,11 +29,29 @@ func NotifyBotUID() string {
 	return NotifyBotUIDValue
 }
 
+// SummaryBotUID returns the static summary bot UID.
+func SummaryBotUID() string {
+	return SummaryBotUIDValue
+}
+
 // ensureNotifyBot creates the global notification bot if it doesn't exist (idempotent).
 // Returns true if the bot is ready for use.
 func (n *Notify) ensureNotifyBot() bool {
-	botUID := NotifyBotUIDValue
+	return n.ensureBot(NotifyBotUIDValue, notifyBotName)
+}
 
+// ensureSummaryBot creates the dedicated summary bot if it doesn't exist
+// (idempotent). Returns true if the bot is ready for use. It mirrors the
+// notification-bot provisioning so botidentity resolves it as an active
+// KindUserBot (robot.status=1).
+func (n *Notify) ensureSummaryBot() bool {
+	return n.ensureBot(SummaryBotUIDValue, summaryBotName)
+}
+
+// ensureBot provisions a static full User Bot (user + app + robot.status=1) for
+// botUID if absent (idempotent), repairing an orphan user, and returns true when
+// the bot is ready. It is the shared body for the notification and summary bots.
+func (n *Notify) ensureBot(botUID, botName string) bool {
 	// Check if user already exists
 	userResp, err := n.userService.GetUserWithUsername(botUID)
 	if err != nil {
@@ -35,13 +60,13 @@ func (n *Notify) ensureNotifyBot() bool {
 	}
 	if userResp != nil {
 		// Bot exists — ensure name is correct and repair if needed
-		if userResp.Name != notifyBotName {
-			name := notifyBotName
+		if userResp.Name != botName {
+			name := botName
 			if err = n.userService.UpdateUser(user.UserUpdateReq{UID: botUID, Name: &name}); err != nil {
 				n.Error("更新notify bot名称失败", zap.Error(err), zap.String("botUID", botUID))
 			}
 		}
-		n.syncBotNameToWuKongIM(botUID, notifyBotName)
+		n.syncBotNameToWuKongIM(botUID, botName)
 		n.repairBotIfNeeded(botUID)
 		return true
 	}
@@ -52,7 +77,7 @@ func (n *Notify) ensureNotifyBot() bool {
 	if err = n.userService.AddUser(&user.AddUserReq{
 		UID:      botUID,
 		Username: botUID,
-		Name:     notifyBotName,
+		Name:     botName,
 		Robot:    1,
 	}); err != nil {
 		n.Error("创建notify bot用户失败", zap.Error(err), zap.String("botUID", botUID))
@@ -98,7 +123,7 @@ func (n *Notify) ensureNotifyBot() bool {
 	}
 
 	// Step 5: Sync bot name to WuKongIM
-	n.syncBotNameToWuKongIM(botUID, notifyBotName)
+	n.syncBotNameToWuKongIM(botUID, botName)
 
 	n.Info("Notify bot 创建成功", zap.String("botUID", botUID))
 	return true

--- a/modules/notify/card.go
+++ b/modules/notify/card.go
@@ -1,0 +1,283 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"go.uber.org/zap"
+)
+
+// deliverCardNotification is the summary-notify card path. It mirrors
+// deliverNotification (dedup → actor exclusion → live member verification →
+// bounded fan-out) but delivers an octo/v1 card through the producer-bound
+// carddispatch.Sender. If a card cannot be built (feature disabled, sender
+// unavailable, or template/config error such as a non-https deep-link origin),
+// the whole request degrades once to the plain-text DM so a summary
+// notification is never silently lost. Per-recipient dispatch errors
+// (busy/dispatch_failed/target_denied) surface in Filtered so the caller's
+// existing retry/dedup state machine handles them, exactly as the text path.
+func (n *Notify) deliverCardNotification(req *NotifyReq) (*NotifyResp, error) {
+	if req == nil || req.Card == nil {
+		return nil, errNotifyCardInvalid
+	}
+	card := req.Card
+	if strings.TrimSpace(req.SpaceID) == "" || len(req.Targets) == 0 || len(req.Targets) > 200 {
+		return nil, errNotifyCardInvalid
+	}
+	if strings.TrimSpace(card.TaskNo) == "" || strings.TrimSpace(card.Title) == "" {
+		return nil, errNotifyCardInvalid
+	}
+	if card.Kind != SummaryCardKindCompleted && card.Kind != SummaryCardKindFailed {
+		return nil, errNotifyCardInvalid
+	}
+
+	// Dedup + actor exclusion (same as the text path).
+	targets := dedupTargets(req.Targets)
+	if req.ActorUID != "" {
+		tmp := make([]string, 0, len(targets))
+		for _, uid := range targets {
+			if uid != req.ActorUID {
+				tmp = append(tmp, uid)
+			}
+		}
+		targets = tmp
+	}
+
+	// Live membership verification. The dispatcher independently re-verifies
+	// Space/target (Decision 3); this pre-filter mirrors the text path so a
+	// non-member never reaches transport and is reported in Filtered.
+	members, filteredMap, err := n.memberCache.verify(n.db, req.SpaceID, targets)
+	if err != nil {
+		return nil, fmt.Errorf("member verification failed: %w", err)
+	}
+	if len(members) == 0 {
+		return &NotifyResp{Delivered: []string{}, Filtered: filteredMap}, nil
+	}
+
+	// Both the card and the text fallback are sent by the summary bot, so it
+	// must exist. Retry from the caller if provisioning has not completed yet.
+	n.ensureSummaryBotReady()
+	if !n.summaryBotOK {
+		return nil, errors.New("summary bot unavailable")
+	}
+
+	// Deployment default outbound language (no per-request negotiation on the
+	// internal ingress); mirrors the email/botfather outbound discipline.
+	lang := i18n.OutboundLanguage(context.Background())
+
+	// Decide card vs text once, up front. A build failure degrades the entire
+	// request to text rather than dropping the notification.
+	canCard := n.cardSender != nil && cardmsg.Enabled()
+	var document json.RawMessage
+	if canCard {
+		doc, buildErr := n.buildSummaryCard(context.Background(), req.SpaceID, card, lang)
+		if buildErr != nil {
+			n.Warn("build summary card failed, degrading to text",
+				zap.Error(buildErr), zap.String("space_id", req.SpaceID), zap.String("task_no", card.TaskNo))
+			canCard = false
+		} else {
+			document = doc
+		}
+	}
+	fallbackText := ""
+	if !canCard {
+		fallbackText = buildSummaryFallbackText(card, lang)
+	}
+
+	type sendResult struct {
+		uid    string
+		reason string // empty => delivered
+	}
+	resultCh := make(chan sendResult, len(members))
+	sem := make(chan struct{}, 20)
+
+	for _, targetUID := range members {
+		sem <- struct{}{}
+		go func(uid string) {
+			defer func() { <-sem }()
+			reason := ""
+			if canCard {
+				_, sendErr := n.cardSender.Send(
+					context.Background(),
+					carddispatch.Target{
+						SpaceID:     req.SpaceID,
+						ChannelID:   uid,
+						ChannelType: common.ChannelTypePerson.Uint8(),
+					},
+					carddispatch.Card{Profile: cardmsg.ProfileV1, Document: document},
+				)
+				if sendErr != nil {
+					reason = string(carddispatch.CategoryOf(sendErr))
+					n.Warn("投递总结卡片失败",
+						zap.String("target", uid), zap.String("space_id", req.SpaceID),
+						zap.String("category", reason), zap.Error(sendErr))
+				}
+			} else if txtErr := n.sendSummaryText(uid, req.SpaceID, fallbackText); txtErr != nil {
+				reason = "send_failed"
+				n.Warn("投递总结文本失败",
+					zap.String("target", uid), zap.String("space_id", req.SpaceID), zap.Error(txtErr))
+			}
+			resultCh <- sendResult{uid: uid, reason: reason}
+		}(targetUID)
+	}
+
+	delivered := make([]string, 0, len(members))
+	for range members {
+		r := <-resultCh
+		if r.reason == "" {
+			delivered = append(delivered, r.uid)
+		} else {
+			filteredMap[r.uid] = r.reason
+		}
+	}
+
+	n.Info("notify_card_delivered",
+		zap.String("service", req.Service),
+		zap.String("space_id", req.SpaceID),
+		zap.String("task_no", card.TaskNo),
+		zap.String("kind", card.Kind),
+		zap.Bool("as_card", canCard),
+		zap.Int("targets", len(req.Targets)),
+		zap.Int("delivered", len(delivered)),
+		zap.Int("filtered", len(filteredMap)),
+	)
+
+	return &NotifyResp{Delivered: delivered, Filtered: filteredMap}, nil
+}
+
+// buildSummaryCard renders the octo/v1 ResourceCard document for a summary
+// notification. Labels/layout/deep-link are owned here (per contract); the deep
+// link origin comes from External.WebLoginURL and must be https (cardtmpl
+// enforces it — a non-https origin returns an error and triggers text fallback).
+func (n *Notify) buildSummaryCard(ctx context.Context, spaceID string, card *SummaryCardFields, lang string) (json.RawMessage, error) {
+	labels := summaryLabelsFor(lang)
+	facts := make([]cardtmpl.Fact, 0, 4)
+	if tr := strings.TrimSpace(card.TimeRange); tr != "" {
+		facts = append(facts, cardtmpl.Fact{Title: labels.timeRange, Value: tr})
+	}
+	if card.Members > 0 {
+		facts = append(facts, cardtmpl.Fact{Title: labels.members, Value: fmt.Sprintf(labels.membersValue, card.Members)})
+	}
+	if card.MsgCount > 0 {
+		facts = append(facts, cardtmpl.Fact{Title: labels.msgCount, Value: fmt.Sprintf(labels.msgCountValue, card.MsgCount)})
+	}
+	if gen := strings.TrimSpace(card.GeneratedAt); gen != "" {
+		facts = append(facts, cardtmpl.Fact{Title: labels.generatedAt, Value: gen})
+	}
+
+	attribution := labels.completedBanner
+	excerpt := ""
+	if card.Kind == SummaryCardKindFailed {
+		attribution = labels.failedBanner
+		if reason := strings.TrimSpace(card.Reason); reason != "" {
+			excerpt = labels.failedPrefix + reason
+		}
+	}
+
+	webLoginURL := n.ctx.GetConfig().External.WebLoginURL
+	return cardtmpl.BuildSummaryResourceCard(ctx, webLoginURL, card.TaskNo, spaceID, cardtmpl.ResourceCard{
+		Title:       card.Title,
+		Attribution: attribution,
+		Excerpt:     excerpt,
+		Facts:       facts,
+	})
+}
+
+// sendSummaryText delivers the plain-text fallback DM from the summary bot,
+// reusing the same PERSONAL builder + space_id injection as the text path.
+func (n *Notify) sendSummaryText(uid, spaceID, text string) error {
+	payload := map[string]interface{}{"type": 1, "content": text}
+	return n.ctx.SendMessage(config.NewPersonalMsgSendReq(
+		uid,
+		SummaryBotUIDValue,
+		payload,
+		spaceID,
+		config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}},
+	))
+}
+
+// buildSummaryFallbackText composes the plain-text DM used when a card cannot be
+// built. It mirrors the fields the card would carry so no information is lost.
+func buildSummaryFallbackText(card *SummaryCardFields, lang string) string {
+	labels := summaryLabelsFor(lang)
+	var b strings.Builder
+	title := strings.TrimSpace(card.Title)
+	if card.Kind == SummaryCardKindFailed {
+		fmt.Fprintf(&b, labels.failedHeadline, title)
+		if reason := strings.TrimSpace(card.Reason); reason != "" {
+			fmt.Fprintf(&b, "\n%s%s", labels.failedPrefix, reason)
+		}
+		return b.String()
+	}
+	fmt.Fprintf(&b, labels.completedHeadline, title)
+	if tr := strings.TrimSpace(card.TimeRange); tr != "" {
+		fmt.Fprintf(&b, "\n%s%s", labels.timeRange+labels.kvSep, tr)
+	}
+	if card.Members > 0 {
+		fmt.Fprintf(&b, "\n%s"+labels.membersValue, labels.members+labels.kvSep, card.Members)
+	}
+	if card.MsgCount > 0 {
+		fmt.Fprintf(&b, "\n%s"+labels.msgCountValue, labels.msgCount+labels.kvSep, card.MsgCount)
+	}
+	if gen := strings.TrimSpace(card.GeneratedAt); gen != "" {
+		fmt.Fprintf(&b, "\n%s%s", labels.generatedAt+labels.kvSep, gen)
+	}
+	return b.String()
+}
+
+type summaryLabels struct {
+	completedBanner   string
+	failedBanner      string
+	timeRange         string
+	members           string
+	membersValue      string // fmt verb for the count, e.g. "%d 人"
+	msgCount          string
+	msgCountValue     string // e.g. "%d 条"
+	generatedAt       string
+	failedPrefix      string
+	kvSep             string
+	completedHeadline string // fmt verb for the title, used by the text fallback
+	failedHeadline    string
+}
+
+func summaryLabelsFor(lang string) summaryLabels {
+	if strings.EqualFold(lang, "zh-CN") || strings.HasPrefix(strings.ToLower(lang), "zh") {
+		return summaryLabels{
+			completedBanner:   "总结已生成完成",
+			failedBanner:      "总结生成失败",
+			timeRange:         "时间范围",
+			members:           "参与成员",
+			membersValue:      "%d 人",
+			msgCount:          "消息数量",
+			msgCountValue:     "%d 条",
+			generatedAt:       "生成时间",
+			failedPrefix:      "失败原因：",
+			kvSep:             "：",
+			completedHeadline: "你的总结「%s」已生成完成。",
+			failedHeadline:    "你的总结「%s」生成失败。",
+		}
+	}
+	return summaryLabels{
+		completedBanner:   "Summary ready",
+		failedBanner:      "Summary failed",
+		timeRange:         "Time range",
+		members:           "Participants",
+		membersValue:      "%d",
+		msgCount:          "Messages",
+		msgCountValue:     "%d",
+		generatedAt:       "Generated at",
+		failedPrefix:      "Reason: ",
+		kvSep:             ": ",
+		completedHeadline: "Your summary \"%s\" is ready.",
+		failedHeadline:    "Your summary \"%s\" failed to generate.",
+	}
+}

--- a/modules/notify/card.go
+++ b/modules/notify/card.go
@@ -66,7 +66,7 @@ func (n *Notify) deliverCardNotification(req *NotifyReq) (*NotifyResp, error) {
 	// Both the card and the text fallback are sent by the summary bot, so it
 	// must exist. Retry from the caller if provisioning has not completed yet.
 	n.ensureSummaryBotReady()
-	if !n.summaryBotOK {
+	if !n.summaryBotOK.Load() {
 		return nil, errors.New("summary bot unavailable")
 	}
 

--- a/modules/notify/card_test.go
+++ b/modules/notify/card_test.go
@@ -27,23 +27,33 @@ func validCard() *SummaryCardFields {
 	}
 }
 
-func TestSummaryBotReadinessIsRaceSafe(t *testing.T) {
-	var n Notify
+func assertReadinessIsRaceSafe(t *testing.T, ready *atomic.Bool) {
+	t.Helper()
 	var wg sync.WaitGroup
 
 	for i := 0; i < 100; i++ {
 		wg.Add(2)
-		go func(ready bool) {
+		go func(readyValue bool) {
 			defer wg.Done()
-			n.summaryBotOK.Store(ready)
+			ready.Store(readyValue)
 		}(i%2 == 0)
 		go func() {
 			defer wg.Done()
-			_ = n.summaryBotOK.Load()
+			_ = ready.Load()
 		}()
 	}
 
 	wg.Wait()
+}
+
+func TestSummaryBotReadinessIsRaceSafe(t *testing.T) {
+	var n Notify
+	assertReadinessIsRaceSafe(t, &n.summaryBotOK)
+}
+
+func TestNotifyBotReadinessIsRaceSafe(t *testing.T) {
+	var n Notify
+	assertReadinessIsRaceSafe(t, &n.botOK)
 }
 
 func TestDeliverCardNotification_ValidationRejectsBadFields(t *testing.T) {

--- a/modules/notify/card_test.go
+++ b/modules/notify/card_test.go
@@ -1,0 +1,169 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validCard returns a minimal well-formed completed card request field set.
+func validCard() *SummaryCardFields {
+	return &SummaryCardFields{
+		TaskNo:      "TN_abcd",
+		Kind:        SummaryCardKindCompleted,
+		Title:       "产品周会纪要",
+		TimeRange:   "2026-07-06 10:00 ~ 2026-07-13 10:00",
+		Members:     5,
+		MsgCount:    128,
+		GeneratedAt: "2026-07-13 15:04",
+	}
+}
+
+func TestDeliverCardNotification_ValidationRejectsBadFields(t *testing.T) {
+	n := &Notify{} // validation short-circuits before any DB/cache access
+
+	cases := map[string]NotifyReq{
+		"missing card":    {SpaceID: "s", Targets: []string{"u"}},
+		"missing space":   {Targets: []string{"u"}, Card: validCard()},
+		"empty targets":   {SpaceID: "s", Targets: nil, Card: validCard()},
+		"missing task_no": {SpaceID: "s", Targets: []string{"u"}, Card: &SummaryCardFields{Kind: SummaryCardKindCompleted, Title: "t"}},
+		"missing title":   {SpaceID: "s", Targets: []string{"u"}, Card: &SummaryCardFields{TaskNo: "n", Kind: SummaryCardKindCompleted}},
+		"unknown kind":    {SpaceID: "s", Targets: []string{"u"}, Card: &SummaryCardFields{TaskNo: "n", Kind: "weird", Title: "t"}},
+	}
+	for name, req := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := req
+			_, err := n.deliverCardNotification(&r)
+			require.ErrorIs(t, err, errNotifyCardInvalid)
+		})
+	}
+}
+
+func TestBuildSummaryCard_ProducesValidOctoV1(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+	n := newTestNotify(ctx, nil, nil, nil, "tk")
+
+	for _, kind := range []string{SummaryCardKindCompleted, SummaryCardKindFailed} {
+		t.Run(kind, func(t *testing.T) {
+			card := validCard()
+			card.Kind = kind
+			if kind == SummaryCardKindFailed {
+				card.Reason = "AI 处理失败，请稍后重试"
+			}
+			doc, err := n.buildSummaryCard(context.Background(), "spc_1", card, "zh-CN")
+			require.NoError(t, err)
+
+			var cardObj map[string]interface{}
+			require.NoError(t, json.Unmarshal(doc, &cardObj))
+			envelope := map[string]interface{}{
+				"type":         cardmsg.InteractiveCard.Int(),
+				"card_version": cardmsg.CardVersion,
+				"profile":      cardmsg.ProfileV1,
+				"card":         cardObj,
+			}
+			require.NoError(t, cardmsg.Validate(envelope), "template output must pass octo/v1 Validate")
+			// Deep link built from WebLoginURL origin only, /s/{task_no}?sp={space}.
+			assert.Contains(t, string(doc), "https://im.example.com/s/TN_abcd?sp=spc_1")
+			assert.NotContains(t, string(doc), "/login")
+		})
+	}
+}
+
+func TestBuildSummaryCard_RejectsNonHTTPSDeepLinkOrigin(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "http://im.example.com" // not https
+	n := newTestNotify(ctx, nil, nil, nil, "tk")
+
+	_, err := n.buildSummaryCard(context.Background(), "spc_1", validCard(), "zh-CN")
+	require.Error(t, err, "a non-https origin must fail card build so the caller degrades to text")
+}
+
+func TestBuildSummaryFallbackText(t *testing.T) {
+	completed := buildSummaryFallbackText(validCard(), "zh-CN")
+	assert.Contains(t, completed, "你的总结「产品周会纪要」已生成完成。")
+	assert.Contains(t, completed, "时间范围：2026-07-06 10:00 ~ 2026-07-13 10:00")
+	assert.Contains(t, completed, "参与成员：5 人")
+	assert.Contains(t, completed, "消息数量：128 条")
+
+	failed := &SummaryCardFields{TaskNo: "n", Kind: SummaryCardKindFailed, Title: "周报", Reason: "超时"}
+	text := buildSummaryFallbackText(failed, "zh-CN")
+	assert.Contains(t, text, "你的总结「周报」生成失败。")
+	assert.Contains(t, text, "失败原因：超时")
+}
+
+// When no card sender is wired (or the card feature is off), a card request must
+// still deliver — as a plain-text DM from the summary bot — never be dropped.
+func TestDeliverCardNotification_DegradesToTextWhenSenderUnavailable(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	n := newTestNotify(ctx, nil, nil, nil, "tk")
+	n.cardSender = nil    // no producer bound → cannot build a card
+	n.summaryBotOK = true // summary bot already provisioned
+	primeMemberCache(n, "spc_1", "uid_a")
+
+	resp, err := n.deliverCardNotification(&NotifyReq{
+		SpaceID: "spc_1", Service: "summary-service", Targets: []string{"uid_a"}, Card: validCard(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"uid_a"}, resp.Delivered)
+	assert.Empty(t, resp.Filtered)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&wk.messageCount), "exactly one text DM should be sent")
+}
+
+// payload and card are mutually exclusive on the single endpoint (contract).
+func TestIntegration_NotifyRejectsPayloadAndCardTogether(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	db, _, closeDB := newMockedDBSession(t)
+	defer closeDB()
+
+	n := newTestNotify(ctx, db, newStubUserService(), &stubAppService{}, "tk")
+	r := buildRouter(n)
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	h := http.Header{}
+	h.Set(InternalTokenHeader, "tk")
+
+	w := doJSONRequest(t, r, http.MethodPost, "/v1/internal/notify", h, NotifyReq{
+		SpaceID: "spc_1", Service: "summary-service", Targets: []string{"uid_a"},
+		Payload: map[string]interface{}{"type": 1, "content": "ok"}, Card: validCard(),
+	})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "err.server.notify.card_invalid")
+	assert.Zero(t, atomic.LoadInt32(&wk.messageCount))
+}
+
+func TestIntegration_NotifyBatchRejectsCardField(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	db, _, closeDB := newMockedDBSession(t)
+	defer closeDB()
+
+	n := newTestNotify(ctx, db, newStubUserService(), &stubAppService{}, "tk")
+	r := buildRouter(n)
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	h := http.Header{}
+	h.Set(InternalTokenHeader, "tk")
+
+	w := doJSONRequest(t, r, http.MethodPost, "/v1/internal/notify/batch", h, BatchNotifyReq{Notifications: []NotifyReq{
+		{SpaceID: "spc_1", Service: "summary-service", Targets: []string{"uid_a"}, Payload: map[string]interface{}{"type": 1, "content": "ok"}},
+		{SpaceID: "spc_1", Service: "summary-service", Targets: []string{"uid_b"}, Card: validCard()},
+	}})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "err.server.notify.card_invalid")
+	assert.Zero(t, atomic.LoadInt32(&wk.messageCount))
+}

--- a/modules/notify/card_test.go
+++ b/modules/notify/card_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -24,6 +25,25 @@ func validCard() *SummaryCardFields {
 		MsgCount:    128,
 		GeneratedAt: "2026-07-13 15:04",
 	}
+}
+
+func TestSummaryBotReadinessIsRaceSafe(t *testing.T) {
+	var n Notify
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func(ready bool) {
+			defer wg.Done()
+			n.summaryBotOK.Store(ready)
+		}(i%2 == 0)
+		go func() {
+			defer wg.Done()
+			_ = n.summaryBotOK.Load()
+		}()
+	}
+
+	wg.Wait()
 }
 
 func TestDeliverCardNotification_ValidationRejectsBadFields(t *testing.T) {
@@ -110,8 +130,8 @@ func TestDeliverCardNotification_DegradesToTextWhenSenderUnavailable(t *testing.
 	defer wk.close()
 	ctx := newTestContext(t, wk)
 	n := newTestNotify(ctx, nil, nil, nil, "tk")
-	n.cardSender = nil    // no producer bound → cannot build a card
-	n.summaryBotOK = true // summary bot already provisioned
+	n.cardSender = nil         // no producer bound → cannot build a card
+	n.summaryBotOK.Store(true) // summary bot already provisioned
 	primeMemberCache(n, "spc_1", "uid_a")
 
 	resp, err := n.deliverCardNotification(&NotifyReq{
@@ -137,13 +157,20 @@ func TestIntegration_NotifyRejectsPayloadAndCardTogether(t *testing.T) {
 	h := http.Header{}
 	h.Set(InternalTokenHeader, "tk")
 
-	w := doJSONRequest(t, r, http.MethodPost, "/v1/internal/notify", h, NotifyReq{
-		SpaceID: "spc_1", Service: "summary-service", Targets: []string{"uid_a"},
-		Payload: map[string]interface{}{"type": 1, "content": "ok"}, Card: validCard(),
-	})
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "err.server.notify.card_invalid")
-	assert.Zero(t, atomic.LoadInt32(&wk.messageCount))
+	for name, payload := range map[string]map[string]interface{}{
+		"non-empty payload": {"type": 1, "content": "ok"},
+		"empty payload":     {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			w := doJSONRequest(t, r, http.MethodPost, "/v1/internal/notify", h, NotifyReq{
+				SpaceID: "spc_1", Service: "summary-service", Targets: []string{"uid_a"},
+				Payload: payload, Card: validCard(),
+			})
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Contains(t, w.Body.String(), "err.server.notify.card_invalid")
+			assert.Zero(t, atomic.LoadInt32(&wk.messageCount))
+		})
+	}
 }
 
 func TestIntegration_NotifyBatchRejectsCardField(t *testing.T) {

--- a/modules/notify/model.go
+++ b/modules/notify/model.go
@@ -1,14 +1,42 @@
 package notify
 
 // NotifyReq 通知请求
+//
+// Payload 与 Card 二选一:
+//   - 文本通知(现状):填 Payload{type:1,content:...},Card 省略。
+//   - 卡片通知(summary-notify pilot):填结构化 Card,Payload 省略。服务端用
+//     pkg/cardtmpl 生成 octo/v1 卡片,经 internal/carddispatch 派发。调用方永不
+//     构造 type-17 map(Decision 14 仍拒绝 payload 里的 card 形状)。
 type NotifyReq struct {
 	SpaceID  string                 `json:"space_id" binding:"required"`
 	Service  string                 `json:"service" binding:"required"`
 	Event    string                 `json:"event"`
 	Targets  []string               `json:"targets" binding:"required"`
 	ActorUID string                 `json:"actor_uid"`
-	Payload  map[string]interface{} `json:"payload" binding:"required"`
+	Payload  map[string]interface{} `json:"payload"`
+	Card     *SummaryCardFields     `json:"card"`
 }
+
+// SummaryCardFields 是 summary-notify 卡片通知的结构化入参(跨仓契约,见
+// .octospec/tasks/card-message-internal-dispatch/summary-notify-contract.md)。
+// 只承载原始字段;文案标签、布局、deep-link 由服务端 pkg/cardtmpl +
+// i18n.OutboundLanguage 生成。时间字段由调用方按其时区格式化后传字符串,计数传整数。
+type SummaryCardFields struct {
+	TaskNo      string `json:"task_no"`      // summary_task.task_no,用于 /s/{task_no}?sp={space_id}
+	Kind        string `json:"kind"`         // "completed" | "failed"
+	Title       string `json:"title"`        // 总结标题(服务端转义/截断)
+	TimeRange   string `json:"time_range"`   // 已格式化的时间范围;空则省略
+	Members     int    `json:"members"`      // 参与人数;<=0 省略
+	MsgCount    int    `json:"msg_count"`    // 消息条数;<=0 省略
+	GeneratedAt string `json:"generated_at"` // 已格式化的生成时间;空则省略
+	Reason      string `json:"reason"`       // failed 的脱敏原因;completed 留空
+}
+
+// Card notification kinds.
+const (
+	SummaryCardKindCompleted = "completed"
+	SummaryCardKindFailed    = "failed"
+)
 
 // BatchNotifyReq 批量通知请求
 type BatchNotifyReq struct {

--- a/modules/notify/notify_integration_test.go
+++ b/modules/notify/notify_integration_test.go
@@ -359,7 +359,7 @@ func TestIntegration_InternalAuth_CorrectToken_ReachesHandler(t *testing.T) {
 
 	// Set botOK so deliverNotification proceeds.
 	const spaceID = "sp_auth_ok"
-	n.botOK = true
+	n.botOK.Store(true)
 	primeMemberCache(n, spaceID, "uid_a")
 
 	r := buildRouter(n)
@@ -588,7 +588,7 @@ func TestIntegration_SendNotifyBatch_MixedResults_207(t *testing.T) {
 
 	n := newTestNotify(ctx, db, newStubUserService(), &stubAppService{}, "tk")
 	const goodSpace = "sp_good"
-	n.botOK = true
+	n.botOK.Store(true)
 	primeMemberCache(n, goodSpace, "uid_a")
 
 	r := buildRouter(n)
@@ -623,7 +623,7 @@ func TestIntegration_SendNotifyBatch_AllSuccess_200(t *testing.T) {
 
 	n := newTestNotify(ctx, db, newStubUserService(), &stubAppService{}, "tk")
 	const spaceID = "sp_all_ok"
-	n.botOK = true
+	n.botOK.Store(true)
 	primeMemberCache(n, spaceID, "uid_a", "uid_b")
 
 	r := buildRouter(n)
@@ -655,7 +655,7 @@ func TestIntegration_Deliver_DeduplicatesTargets(t *testing.T) {
 
 	n := newTestNotify(ctx, db, newStubUserService(), &stubAppService{}, "tk")
 	const spaceID = "sp_dedup"
-	n.botOK = true
+	n.botOK.Store(true)
 	primeMemberCache(n, spaceID, "uid_a", "uid_b")
 
 	resp, err := n.deliverNotification(&NotifyReq{
@@ -679,7 +679,7 @@ func TestIntegration_Deliver_ExcludesActor(t *testing.T) {
 
 	n := newTestNotify(ctx, db, newStubUserService(), &stubAppService{}, "tk")
 	const spaceID = "sp_actor"
-	n.botOK = true
+	n.botOK.Store(true)
 	primeMemberCache(n, spaceID, "uid_a", "uid_b", "uid_actor")
 
 	resp, err := n.deliverNotification(&NotifyReq{
@@ -703,7 +703,7 @@ func TestIntegration_Deliver_NonMembersAreFiltered(t *testing.T) {
 
 	n := newTestNotify(ctx, db, newStubUserService(), &stubAppService{}, "tk")
 	const spaceID = "sp_filter"
-	n.botOK = true
+	n.botOK.Store(true)
 	primeMemberCache(n, spaceID, "uid_a") // only uid_a is a member
 
 	resp, err := n.deliverNotification(&NotifyReq{
@@ -730,7 +730,7 @@ func TestIntegration_Deliver_SendFailure_MarksFiltered(t *testing.T) {
 
 	n := newTestNotify(ctx, db, newStubUserService(), &stubAppService{}, "tk")
 	const spaceID = "sp_sendfail"
-	n.botOK = true
+	n.botOK.Store(true)
 	primeMemberCache(n, spaceID, "uid_a", "uid_b")
 
 	resp, err := n.deliverNotification(&NotifyReq{
@@ -759,7 +759,7 @@ func TestIntegration_Deliver_PartialSendFailure(t *testing.T) {
 
 	n := newTestNotify(ctx, db, newStubUserService(), &stubAppService{}, "tk")
 	const spaceID = "sp_partial"
-	n.botOK = true
+	n.botOK.Store(true)
 	primeMemberCache(n, spaceID, "uid_a", "uid_b", "uid_c")
 
 	resp, err := n.deliverNotification(&NotifyReq{
@@ -806,7 +806,7 @@ func TestIntegration_Deliver_AllNonMembers_NoBotCreation(t *testing.T) {
 	// No WuKongIM /message/send either.
 	assert.Equal(t, int32(0), atomic.LoadInt32(&wk.messageCount))
 
-	botReady := n.botOK
+	botReady := n.botOK.Load()
 	assert.False(t, botReady, "botOK must not be flipped for empty deliveries")
 }
 
@@ -832,7 +832,7 @@ func TestIntegration_EnsureBot_BotOK_SkipsCreation(t *testing.T) {
 
 	us := newStubUserService()
 	n := newTestNotify(ctx, db, us, &stubAppService{}, "tk")
-	n.botOK = true
+	n.botOK.Store(true)
 
 	// Should not panic or call userService
 	assert.Equal(t, int32(0), atomic.LoadInt32(&us.getByUsernameCalls))
@@ -853,7 +853,7 @@ func TestIntegration_Deliver_CacheMiss_RefreshesFromDB(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"uid"}).AddRow("uid_a").AddRow("uid_b"))
 
 	n := newTestNotify(ctx, db, newStubUserService(), &stubAppService{}, "tk")
-	n.botOK = true
+	n.botOK.Store(true)
 
 	resp, err := n.deliverNotification(&NotifyReq{
 		SpaceID: spaceID,

--- a/pilote2e/summary_card_wukongim_test.go
+++ b/pilote2e/summary_card_wukongim_test.go
@@ -1,0 +1,416 @@
+//go:build pilote2e
+
+// Package pilote2e is a live end-to-end harness for the summary-notify card
+// pilot. Unlike the mock-backed modules/notify tests, it drives the REAL
+// internal/carddispatch producer (real botidentity resolution + real
+// DBAuthorizer against MySQL + real WuKongIM transport) and then independently
+// reads the message back out of WuKongIM to prove a type-17 card is actually
+// persisted — i.e. "是否真的入库 WuKongIM".
+//
+// Requires the integration stack (MySQL 127.0.0.1:3306 root/demo/test,
+// Redis 127.0.0.1:6379, WuKongIM 127.0.0.1:5001) and the build tag:
+//
+//	go test -tags pilote2e ./pilote2e/ -run TestSummaryCard -v
+package pilote2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	liblog "github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	_ "github.com/Mininglamp-OSS/octo-server/internal" // blank-import every module so module.Setup migrates the full schema (space/space_member/robot/app_bot/group/thread ...)
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
+	"github.com/Mininglamp-OSS/octo-server/modules/notify"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	e2eSpaceID   = "spc_pilote2e"
+	e2eSummaryID = "summary" // must match notify.SummaryBotUIDValue
+	e2eProducer  = carddispatch.ProducerID("summary-notify")
+)
+
+// TestSummaryCard_DispatchesAndPersistsInWuKongIM simulates what octo-smart-summary
+// will do once it switches to the card field: it builds the octo/v1 ResourceCard
+// exactly as modules/notify.buildSummaryCard does, dispatches it through the
+// producer-bound Sender, and then reads the recipient's DM channel back out of
+// WuKongIM to confirm the type-17 card landed.
+func TestSummaryCard_DispatchesAndPersistsInWuKongIM(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true") // deployment card gate ON (cardmsg.Enabled())
+	// The full module set (blank-imported internal) wires the `common` module,
+	// which refuses to boot without these 32-byte secrets. Mirror the CI env.
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	t.Setenv("OCTO_USER_API_KEY_SECRET", "0123456789abcdef0123456789abcdef")
+
+	// WuKongIM persists its channel log in ~/.wukong ACROSS test runs (only MySQL
+	// is truncated by CleanAllTables), so use a fresh recipient per run — the
+	// summary↔recipient personal channel then holds exactly this run's card.
+	recipient := fmt.Sprintf("uid_pilote2e_%d", time.Now().UnixNano())
+
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+
+	seedSpace(t, ctx)
+	seedSpaceMember(t, ctx, recipient)
+	seedSummaryRobot(t, ctx)
+
+	// Build the ONE process registry exactly like main.installCardDispatch, with
+	// the summary-notify producer enabled (DM-only, octo/v1, system-notification).
+	deps := carddispatch.Dependencies{
+		IdentityResolver: botidentity.New(ctx),
+		Authorizer:       carddispatch.NewDBAuthorizer(ctx.DB()),
+		Transport:        ctx,
+		Metrics:          carddispatch.NewMetrics(prometheus.NewRegistry()),
+		Logger:           liblog.NewTLog("pilote2e"),
+	}
+	registry := carddispatch.NewRegistry(deps, []carddispatch.ProducerSpec{{
+		ID:                  e2eProducer,
+		Enabled:             true,
+		SenderUID:           e2eSummaryID,
+		AllowedChannelTypes: []uint8{common.ChannelTypePerson.Uint8()},
+		AllowedProfiles:     []string{cardmsg.ProfileV1},
+		SpacePolicy:         carddispatch.SpacePolicySystemNotification,
+		GroupPolicy:         carddispatch.GroupPolicyMemberRequired,
+		MaxInFlight:         20,
+	}})
+	sender, err := registry.Sender(e2eProducer)
+	require.NoError(t, err, "summary-notify producer must be registered")
+
+	// Build the card the same way notify.buildSummaryCard does.
+	doc, err := cardtmpl.BuildSummaryResourceCard(
+		context.Background(),
+		"https://im.example.com/login", // External.WebLoginURL origin
+		"TN_pilote2e_0001",
+		e2eSpaceID,
+		cardtmpl.ResourceCard{
+			Title:       "产品周会纪要",
+			Attribution: "总结已生成完成",
+			Facts: []cardtmpl.Fact{
+				{Title: "时间范围", Value: "2026-07-06 10:00 ~ 2026-07-13 10:00"},
+				{Title: "参与成员", Value: "5 人"},
+				{Title: "消息数量", Value: "128 条"},
+			},
+		},
+	)
+	require.NoError(t, err, "card build must succeed")
+
+	// Dispatch through the real producer → real WuKongIM.
+	result, err := sender.Send(context.Background(),
+		carddispatch.Target{SpaceID: e2eSpaceID, ChannelID: recipient, ChannelType: common.ChannelTypePerson.Uint8()},
+		carddispatch.Card{Profile: cardmsg.ProfileV1, Document: doc},
+	)
+	require.NoError(t, err, "dispatch must succeed")
+	require.NotNil(t, result)
+	t.Logf("dispatch result: message_id=%d message_seq=%d client_msg_no=%s", result.MessageID, result.MessageSeq, result.ClientMsgNo)
+	// WuKongIM's /message/send returns a globally-unique message_id synchronously;
+	// message_seq (the per-channel sequence) is assigned during persistence and is
+	// 0 in this version's send response — the authoritative persistence proof is
+	// the read-back below, which surfaces the assigned channel sequence.
+	assert.NotZero(t, result.MessageID, "WuKongIM must assign a message_id")
+
+	// Independent confirmation: read the recipient's DM channel back out of
+	// WuKongIM and assert the persisted payload is the exact type-17 card we sent.
+	msg := readBackType17(t, ctx.GetConfig().WuKongIM.APIURL, recipient, result.MessageID)
+	require.NotNil(t, msg, "the dispatched type-17 card must be readable from WuKongIM channel log")
+
+	assert.EqualValues(t, cardmsg.InteractiveCard.Int(), intOf(msg["type"]), "persisted payload must be type=17")
+	assert.Equal(t, cardmsg.ProfileV1, msg["profile"], "profile must be octo/v1")
+	assert.Equal(t, e2eSpaceID, msg["space_id"], "server-authored space_id must be on the wire")
+	assert.NotZero(t, intOf(msg["__message_seq"]), "message must be persisted with a channel sequence")
+	assert.EqualValues(t, result.MessageID, intOf(msg["__message_id"]), "read-back is the exact message we dispatched")
+	assert.Equal(t, e2eSummaryID, msg["__from_uid"], "sender on the wire is the bound summary bot, not a caller-supplied uid")
+	t.Logf("read-back persisted card: message_id=%d message_seq=%d from_uid=%v", intOf(msg["__message_id"]), intOf(msg["__message_seq"]), msg["__from_uid"])
+	t.Logf("read-back persisted card payload: %s", compactJSON(msg))
+}
+
+// TestSummaryNotify_HTTPEndpointDeliversCardToWuKongIM is the most faithful
+// simulation of the smart-summary call: it POSTs the cross-repo card contract
+// body to the real POST /v1/internal/notify handler (structured Card field, no
+// hand-built type-17 map), lets modules/notify build the card server-side and
+// fan it out through the producer, and confirms the type-17 card persisted in
+// WuKongIM. The summary bot is provisioned by notify.New itself (not seeded).
+func TestSummaryNotify_HTTPEndpointDeliversCardToWuKongIM(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	t.Setenv("OCTO_USER_API_KEY_SECRET", "0123456789abcdef0123456789abcdef")
+	t.Setenv("NOTIFY_INTERNAL_TOKEN", "pilote2e-token")
+
+	recipient := fmt.Sprintf("uid_pilote2e_http_%d", time.Now().UnixNano())
+
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+
+	seedSpace(t, ctx)
+	seedSpaceMember(t, ctx, recipient)
+
+	// Install the producer registry, then construct a notify instance that picks
+	// up the bound card Sender (main.installCardDispatch happens before module
+	// construction in production; here we replicate that ordering for one notify).
+	deps := carddispatch.Dependencies{
+		IdentityResolver: botidentity.New(ctx),
+		Authorizer:       carddispatch.NewDBAuthorizer(ctx.DB()),
+		Transport:        ctx,
+		Metrics:          carddispatch.NewMetrics(prometheus.NewRegistry()),
+		Logger:           liblog.NewTLog("pilote2e-http"),
+	}
+	registry := carddispatch.NewRegistry(deps, []carddispatch.ProducerSpec{{
+		ID:                  e2eProducer,
+		Enabled:             true,
+		SenderUID:           e2eSummaryID,
+		AllowedChannelTypes: []uint8{common.ChannelTypePerson.Uint8()},
+		AllowedProfiles:     []string{cardmsg.ProfileV1},
+		SpacePolicy:         carddispatch.SpacePolicySystemNotification,
+		GroupPolicy:         carddispatch.GroupPolicyMemberRequired,
+		MaxInFlight:         20,
+	}})
+	require.NoError(t, carddispatch.Install(ctx, registry))
+
+	n := notify.New(ctx) // wires the card Sender + starts async summary-bot provisioning
+	r := wkhttp.New()
+	n.Route(r)
+	r.SetErrorRenderer(octoi18n.NewErrorRenderer(octoi18n.NewLocalizer(octoi18n.DefaultLanguage)))
+
+	// The exact cross-repo contract body smart-summary will POST.
+	reqBody := notify.NotifyReq{
+		SpaceID: e2eSpaceID,
+		Service: "summary-service",
+		Targets: []string{recipient},
+		Card: &notify.SummaryCardFields{
+			TaskNo:      "TN_pilote2e_http",
+			Kind:        notify.SummaryCardKindCompleted,
+			Title:       "产品周会纪要",
+			TimeRange:   "2026-07-06 10:00 ~ 2026-07-13 10:00",
+			Members:     5,
+			MsgCount:    128,
+			GeneratedAt: "2026-07-13 15:04",
+		},
+	}
+	body, _ := json.Marshal(reqBody)
+
+	// Poll until the async summary-bot provisioning completes (card path returns
+	// "summary bot unavailable" → 500 until then), then assert the card delivered.
+	var delivered []string
+	var lastCode int
+	var lastBody string
+	for attempt := 0; attempt < 40; attempt++ {
+		req, _ := http.NewRequest(http.MethodPost, "/v1/internal/notify", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(notify.InternalTokenHeader, "pilote2e-token")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		lastCode, lastBody = w.Code, w.Body.String()
+		if w.Code == http.StatusOK {
+			var resp struct {
+				Delivered []string          `json:"delivered"`
+				Filtered  map[string]string `json:"filtered"`
+			}
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			delivered = resp.Delivered
+			break
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	require.Equal(t, http.StatusOK, lastCode, "notify card POST must succeed (last body: %s)", truncate(lastBody))
+	require.Equal(t, []string{recipient}, delivered, "the recipient must receive the card")
+
+	// Confirm the type-17 card persisted in the recipient's DM channel.
+	msg := readBackType17(t, ctx.GetConfig().WuKongIM.APIURL, recipient, 0)
+	require.NotNil(t, msg, "a type-17 card must be readable from WuKongIM channel log")
+	assert.EqualValues(t, cardmsg.InteractiveCard.Int(), intOf(msg["type"]))
+	assert.Equal(t, cardmsg.ProfileV1, msg["profile"])
+	assert.Equal(t, e2eSpaceID, msg["space_id"], "server-authored space_id on the wire")
+	assert.Equal(t, e2eSummaryID, msg["__from_uid"], "delivered by the bound summary bot")
+	// The deep link the server built from External.WebLoginURL + task_no.
+	assert.Contains(t, compactJSON(msg), "https://im.example.com/s/TN_pilote2e_http?sp="+e2eSpaceID)
+	t.Logf("HTTP-path persisted card: message_id=%d message_seq=%d from_uid=%v",
+		intOf(msg["__message_id"]), intOf(msg["__message_seq"]), msg["__from_uid"])
+}
+
+// The seed helpers insert the minimal authoritative rows the system-notification
+// DM authorization reads. NOT NULL string columns are set explicitly so the
+// inserts survive strict sql_mode.
+
+func seedSpace(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	_, err := ctx.DB().InsertInto("space").
+		Pair("space_id", e2eSpaceID).
+		Pair("name", "pilote2e").
+		Pair("description", "").
+		Pair("logo", "").
+		Pair("creator", "uid_pilote2e_creator").
+		Pair("status", 1).
+		Exec()
+	require.NoError(t, err, "seed space")
+}
+
+func seedSpaceMember(t *testing.T, ctx *config.Context, uid string) {
+	t.Helper()
+	_, err := ctx.DB().InsertInto("space_member").
+		Pair("space_id", e2eSpaceID).
+		Pair("uid", uid).
+		Pair("role", 0).
+		Pair("status", 1).
+		Exec()
+	require.NoError(t, err, "seed space_member")
+}
+
+// seedSummaryRobot registers the summary bot as an active robot so botidentity
+// resolves it as KindUserBot without going through notify's async provisioning.
+func seedSummaryRobot(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	_, err := ctx.DB().InsertInto("robot").
+		Pair("robot_id", e2eSummaryID).
+		Pair("token", "").
+		Pair("status", 1).
+		Pair("placeholder", "").
+		Pair("username", e2eSummaryID).
+		Pair("app_id", "").
+		Pair("creator_uid", "").
+		Pair("description", "").
+		Pair("bot_token", "").
+		Pair("im_token_cache", "").
+		Pair("bot_commands", "").
+		Exec()
+	require.NoError(t, err, "seed robot (summary bot)")
+}
+
+// readBackType17 polls WuKongIM's /channel/messagesync for the summary↔recipient
+// personal channel (from both login perspectives) and returns the persisted
+// payload whose message_id equals wantID, decoded to a map with the WuKongIM
+// envelope metadata (__message_id/__message_seq/__from_uid) attached. Returns
+// nil if that message does not surface within the poll window.
+func readBackType17(t *testing.T, apiURL, recipient string, wantID int64) map[string]interface{} {
+	t.Helper()
+	perspectives := []struct{ login, channel string }{
+		{login: recipient, channel: e2eSummaryID},
+		{login: e2eSummaryID, channel: recipient},
+	}
+	for attempt := 0; attempt < 15; attempt++ {
+		for _, p := range perspectives {
+			for _, m := range channelMessageSync(t, apiURL, p.login, p.channel) {
+				if wantID > 0 && intOf(m["message_id"]) != wantID {
+					continue
+				}
+				payload := decodePayload(m)
+				if payload == nil || intOf(payload["type"]) != int64(cardmsg.InteractiveCard.Int()) {
+					continue
+				}
+				payload["__message_id"] = intOf(m["message_id"])
+				payload["__message_seq"] = intOf(m["message_seq"])
+				payload["__from_uid"] = m["from_uid"]
+				return payload
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return nil
+}
+
+func channelMessageSync(t *testing.T, apiURL, loginUID, channelID string) []map[string]interface{} {
+	t.Helper()
+	body, _ := json.Marshal(map[string]interface{}{
+		"login_uid":         loginUID,
+		"channel_id":        channelID,
+		"channel_type":      common.ChannelTypePerson.Uint8(),
+		"start_message_seq": 0,
+		"end_message_seq":   0,
+		"pull_mode":         1,
+		"limit":             100,
+	})
+	resp, err := http.Post(apiURL+"/channel/messagesync", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Logf("messagesync post error (login=%s channel=%s): %v", loginUID, channelID, err)
+		return nil
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Logf("messagesync status=%d (login=%s channel=%s) body=%s", resp.StatusCode, loginUID, channelID, truncate(string(raw)))
+		return nil
+	}
+	// Response is either {"messages":[...]} or a bare array depending on version.
+	// Decode with UseNumber: WuKongIM message_id is a ~2^61 snowflake that would
+	// lose precision as a float64, breaking the exact message_id match.
+	var obj struct {
+		Messages []map[string]interface{} `json:"messages"`
+	}
+	if dec := newNumberDecoder(raw); dec.Decode(&obj) == nil && obj.Messages != nil {
+		return obj.Messages
+	}
+	var arr []map[string]interface{}
+	if newNumberDecoder(raw).Decode(&arr) == nil {
+		return arr
+	}
+	t.Logf("messagesync unparsed body (login=%s channel=%s): %s", loginUID, channelID, truncate(string(raw)))
+	return nil
+}
+
+// decodePayload extracts and JSON-decodes a WuKongIM message's payload, which is
+// base64-encoded on the wire.
+func decodePayload(m map[string]interface{}) map[string]interface{} {
+	enc, ok := m["payload"].(string)
+	if !ok || enc == "" {
+		return nil
+	}
+	dec, err := base64.StdEncoding.DecodeString(enc)
+	if err != nil {
+		return nil
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(dec, &payload); err != nil {
+		return nil
+	}
+	return payload
+}
+
+func newNumberDecoder(raw []byte) *json.Decoder {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	return dec
+}
+
+func intOf(v interface{}) int64 {
+	switch n := v.(type) {
+	case float64:
+		return int64(n)
+	case int64:
+		return n
+	case int:
+		return int64(n)
+	case json.Number:
+		i, _ := n.Int64()
+		return i
+	}
+	return 0
+}
+
+func compactJSON(v interface{}) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}
+
+func truncate(s string) string {
+	if len(s) > 400 {
+		return s[:400] + "…"
+	}
+	return s
+}

--- a/pkg/errcode/notify.go
+++ b/pkg/errcode/notify.go
@@ -11,3 +11,9 @@ var ErrNotifyCardNotAllowed = register(codes.Code{
 	HTTPStatus:     http.StatusBadRequest,
 	DefaultMessage: "Card payloads are not allowed on the internal notification endpoint.",
 })
+
+var ErrNotifyCardInvalid = register(codes.Code{
+	ID:             "err.server.notify.card_invalid",
+	HTTPStatus:     http.StatusBadRequest,
+	DefaultMessage: "The card notification request is invalid.",
+})

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -42,6 +42,9 @@ other = "服务器内部错误。"
 ["err.server.notify.card_not_allowed"]
 other = "内部通知接口不允许发送卡片消息。"
 
+["err.server.notify.card_invalid"]
+other = "卡片通知请求无效。"
+
 ["err.server.thread.group_no_invalid"]
 other = "群编号无效。"
 

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -588,6 +588,9 @@ other = "Search service is temporarily unavailable."
 ["err.server.messages_search.validation_failed"]
 other = "Invalid search request."
 
+["err.server.notify.card_invalid"]
+other = "The card notification request is invalid."
+
 ["err.server.notify.card_not_allowed"]
 other = "Card payloads are not allowed on the internal notification endpoint."
 


### PR DESCRIPTION
## Summary

Enables the **first production `internal/carddispatch` producer** (`summary-notify`),
upgrading the summary completion/failure DM from plain text to a display-only
(`octo/v1`) `ResourceCard`. Builds on the dispatcher foundation merged in #577.
octo-server scope only; **DM (person) targets only**.

## Related Issue

Refs #571. Foundation: #577 (merged).

## Linked Spec

- `.octospec/tasks/card-message-internal-dispatch/brief.md` (pilot table + Decisions 1/3/4/11/14)
- `.octospec/tasks/card-message-internal-dispatch/summary-notify-contract.md` (cross-repo wire contract)

## Changes

- **`summary` bot** — provision a dedicated User Bot (`user`+`app`+`robot.status=1`)
  via the same idempotent pattern as `ensureNotifyBot`; the `notification` bot keeps
  the generic text path untouched.
- **Producer wiring** — register the `summary-notify` `ProducerSpec` (DM-only, `octo/v1`,
  `SpacePolicySystemNotification`, `MaxInFlight` 20) in `installCardDispatch`;
  `modules/notify` obtains its bound `Sender` from the registry already in
  `*config.Context` via `SenderFromContext` — no `register.AddModule` change, no
  package-global registration (Decision 1/11).
- **Card path** — add optional structured `NotifyReq.Card` (`SummaryCardFields`, **not**
  a type-17 map). When present, build the card once via
  `cardtmpl.BuildSummaryResourceCard` and dispatch per verified recipient through the
  bound `Sender`, reusing the existing member-verify → actor-exclude → fan-out and
  preserving the `NotifyResp{delivered,filtered}` contract.
- `Payload` and `Card` are **mutually exclusive**: both-present → 400
  `err.server.notify.card_invalid`; both-absent keeps the legacy 400.
- Docs: cross-repo contract + journal/log/pending-learning.

## Testing

```
go vet ./internal/carddispatch/... ./modules/notify/...        # clean
go test -race -cover ./internal/carddispatch/...               # 92.4%
go test ./modules/notify/... ./pkg/cardtmpl/... ./pkg/cardmsg/...  # ok
go run ./tools/lint-card-dispatch ./modules ./internal         # guard green
make i18n-extract-check && make i18n-lint                      # green
git diff --check                                               # clean
```

- [x] Unit/integration tests added/updated
- [x] Manually verified via test suite

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   It turns `modules/notify` into a trusted card *producer*: a structured
   `NotifyReq.Card` request is authored into an `octo/v1` card by `cardtmpl` and
   dispatched through the producer-bound `carddispatch.Sender`, which runs the full
   fail-closed pipeline (live bot identity → live Space/member ACL → `Validate` →
   authoritative `plain`/`space_id` → final size recheck → one transport call). The
   legacy `type=1` text path and Decision 14's raw-card rejection are unchanged —
   `Card` carries structured fields, never a type-17 map.

2. **What could break because of it (dependents + failure mode)?**
   The only live dependent is octo-smart-summary via `/v1/internal/notify`; it still
   sends text today, so behavior is unchanged until it opts into `Card`. If it does,
   the per-recipient `NotifyResp{delivered,filtered}` shape is preserved so its
   dedup/retry/sweep keeps working. A non-https base URL fails the card build
   fail-closed; the deep link is dead until octo-web ships `/s/:taskId`. Bad input
   (both `Payload`+`Card`) is rejected 400 rather than silently dropping one.

3. **How do you know it works?**
   `internal/carddispatch` policy-matrix + payload-pipeline tests (92.4% cover),
   `modules/notify` integration tests for the card branch / mutual-exclusion / batch
   rejection, the AST no-bypass guard, and the i18n gate all pass (commands above).

## Cross-repo dependency (must sync)

End-to-end needs two other repos, **out of scope here**:
- **octo-web** — ship the standalone `/s/:taskId?sp={spaceId}` route (mirroring `/d/:docId`);
  until then the card's detail link is dead.
- **octo-smart-summary** — switch the worker terminal-state notification from the text
  payload to the structured `Card` field per `summary-notify-contract.md` (a tracking
  issue will be filed on that repo).

Inert until both land (only the `NOTIFY_INTERNAL_TOKEN` holder can reach it, and it
still sends text). Rollback: `OCTO_CARD_MESSAGE_ENABLED=false` or remove the one spec.

## Checklist

- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (contract + journal/log)
- [x] Followed commit message conventions (Conventional Commits)
