### PR TITLE
fix(space): member search display-name fallback + real_name search #434

### DIFF
--- a/modules/space/api_member_search.go
+++ b/modules/space/api_member_search.go
@@ -69,8 +69,10 @@ func (s *Space) searchMembers(c *wkhttp.Context) {
 	resps := make([]memberSearchResp, 0, len(members))
 	for _, m := range members {
 		resps = append(resps, memberSearchResp{
-			UID:       m.UID,
-			Name:      m.Name,
+			UID: m.UID,
+			// DisplayName 走 issue #344/#434 兜底链：name 空时回退 real_name，
+			// 皆空时给稳定占位符——空名成员不再渲染为空白行，与成员列表一致。
+			Name:      m.DisplayName(),
 			Username:  m.Username,
 			Email:     m.Email,
 			Phone:     maskPhone(m.Phone),

--- a/modules/space/api_member_search_fallback_test.go
+++ b/modules/space/api_member_search_fallback_test.go
@@ -1,0 +1,92 @@
+package space
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test_Issue434_SearchBlankNameMemberFallsBackToRealName pins the #434 P1 defect:
+// the display-name fallback shipped in #420 for the member LIST was never applied
+// to the sibling member SEARCH path, so blank-name members rendered as empty rows.
+// After the fix the search result must reuse the same #344 fallback chain:
+//  1. user.name empty + user_verification.real_name set → real_name is returned;
+//  2. both empty → the stable "User <uid>" placeholder, never an empty string;
+//  3. a populated user.name is returned unchanged (real_name must not override it).
+func Test_Issue434_SearchBlankNameMemberFallsBackToRealName(t *testing.T) {
+	srv, _, err := setup(t)
+	assert.NoError(t, err)
+
+	const spaceId = "sp-434-search-fallback"
+	seedMemberSearchSpace(t, spaceId, testutil.UID)
+
+	// case 1: name empty + real_name present → real_name
+	const uidRealName = "u434-realname"
+	seedFallbackUser(t, uidRealName, "")
+	seedFallbackVerification(t, uidRealName, "Zhang Wei")
+	seedMemberSearchMember(t, spaceId, uidRealName, 0, 1)
+
+	// case 2: name empty + real_name empty → stable placeholder
+	const uidPlaceholder = "u434-placeholder"
+	seedFallbackUser(t, uidPlaceholder, "")
+	seedMemberSearchMember(t, spaceId, uidPlaceholder, 0, 1)
+
+	// case 3: populated name wins over a present real_name
+	const uidNamed = "u434-named"
+	seedFallbackUser(t, uidNamed, "Alice")
+	seedFallbackVerification(t, uidNamed, "Should Not Win")
+	seedMemberSearchMember(t, spaceId, uidNamed, 0, 1)
+
+	w := getMembersSearch(t, srv, testCtx, spaceId, url.Values{"page_size": {"50"}})
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	resp := decodeMembersSearchResp(t, w)
+
+	if it, ok := findMemberSearchItem(resp.List, uidRealName); assert.True(t, ok, "real_name member missing from search") {
+		assert.Equal(t, "Zhang Wei", it.Name, "blank name must fall back to real_name in search results")
+	}
+	if it, ok := findMemberSearchItem(resp.List, uidPlaceholder); assert.True(t, ok, "placeholder member missing from search") {
+		assert.NotEqual(t, "", it.Name, "blank-name member must never render an empty name")
+		assert.Equal(t, memberDisplayNamePlaceholderPrefix+uidPlaceholder, it.Name)
+		// privacy gate: the placeholder must not leak short_no / username.
+		assert.NotContains(t, it.Name, "short_no")
+	}
+	if it, ok := findMemberSearchItem(resp.List, uidNamed); assert.True(t, ok, "named member missing from search") {
+		assert.Equal(t, "Alice", it.Name, "a populated name must be returned unchanged")
+	}
+}
+
+// Test_Issue434_MembersSearchableByRealName pins the other half of the #434 P1
+// defect: members were not searchable by their verified real_name. After the fix
+// a keyword matching only user_verification.real_name must surface the member, and
+// list + count must stay in lockstep (both join user_verification) so pagination
+// does not drift.
+func Test_Issue434_MembersSearchableByRealName(t *testing.T) {
+	srv, _, err := setup(t)
+	assert.NoError(t, err)
+
+	const spaceId = "sp-434-search-by-realname"
+	seedMemberSearchSpace(t, spaceId, testutil.UID)
+
+	// Target: blank user.name, real_name only. A keyword hitting real_name must find it.
+	const uidTarget = "u434-search-target"
+	seedFallbackUser(t, uidTarget, "")
+	seedFallbackVerification(t, uidTarget, "Ouyang Distinctive")
+	seedMemberSearchMember(t, spaceId, uidTarget, 0, 1)
+
+	// Decoy: unrelated member that must not match the real_name keyword.
+	seedMemberSearchUser(t, "u434-decoy", "Bob Decoy", "bob_decoy", "", "")
+	seedMemberSearchMember(t, spaceId, "u434-decoy", 0, 1)
+
+	w := getMembersSearch(t, srv, testCtx, spaceId, url.Values{"keyword": {"Ouyang"}})
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	resp := decodeMembersSearchResp(t, w)
+
+	assert.EqualValues(t, 1, resp.Count, "count must reflect the real_name match (list/count must share the uv join)")
+	if assert.Len(t, resp.List, 1, "member must be searchable by real_name") {
+		assert.Equal(t, uidTarget, resp.List[0].UID)
+		assert.Equal(t, "Ouyang Distinctive", resp.List[0].Name)
+	}
+}

--- a/modules/space/db.go
+++ b/modules/space/db.go
@@ -168,15 +168,27 @@ func (d *DB) queryMembers(spaceId string, loginUID string, page uint64, limit ui
 }
 
 func (d *DB) searchMembers(spaceId, keyword string, pageIndex, pageSize int) ([]*memberSearchModel, error) {
+	// name 兜底链（issue #344/#434）：u.name 为空时回退 user_verification.real_name，
+	// 二者皆空时由 mapping 层（memberSearchModel.DisplayName）给稳定占位符——与成员
+	// 列表 queryMembers 对齐，使空名成员在搜索结果里不再渲染为空白行。
+	//
+	// user_verification.user_id 被 base compat-repair 迁移强制转为 utf8mb4_general_ci，
+	// 而 space_member 无显式 COLLATE、随库默认（非规范部署可能是 8.0 的 0900_ai_ci）。
+	// 列对列等值缺少可强制的字面量，MySQL 8.0 会抛 Error 1267（Illegal mix of
+	// collations）。故在 ON 子句用 COLLATE utf8mb4_general_ci 把 sm.uid 显式钉到公共
+	// collation，不依赖「库默认即 general_ci」的隐式假设（沿用 bot_api/resolve_targets
+	// 的既有做法；#420 给 queryMembers 留下的同类风险另单 #482 跟踪）。
 	builder := d.session.Select(
 		"sm.*",
 		"IFNULL(u.name,'') as name",
+		"IFNULL(uv.real_name,'') as real_name",
 		"IFNULL(u.username,'') as username",
 		"IFNULL(u.email,'') as email",
 		"IFNULL(u.phone,'') as phone",
 		"CASE WHEN r.robot_id IS NOT NULL AND r.status=1 THEN 1 ELSE 0 END as robot",
 	).From(dbr.I("space_member").As("sm")).
 		LeftJoin(dbr.I("user").As("u"), "u.uid=sm.uid").
+		LeftJoin(dbr.I("user_verification").As("uv"), "uv.user_id = sm.uid COLLATE utf8mb4_general_ci").
 		LeftJoin(dbr.I("robot").As("r"), "r.robot_id=sm.uid").
 		Where("sm.space_id=? AND sm.status=1", spaceId)
 	if keyword != "" {
@@ -195,9 +207,14 @@ func (d *DB) searchMembers(spaceId, keyword string, pageIndex, pageSize int) ([]
 }
 
 func (d *DB) countSearchMembers(spaceId, keyword string) (int64, error) {
+	// list / count 共用 memberSearchActiveWhere，而该条件现含 uv.real_name（#434），
+	// 故 count 也须挂同一 user_verification LEFT JOIN，否则关键字命中 real_name 时
+	// list 与 count 的行集漂移会导致分页错位。JOIN 的 COLLATE 钉法同 searchMembers。
+	// user_verification.user_id 是主键（1:1），LEFT JOIN 不会放大 COUNT(*)。
 	builder := d.session.Select("COUNT(*)").
 		From(dbr.I("space_member").As("sm")).
 		LeftJoin(dbr.I("user").As("u"), "u.uid=sm.uid").
+		LeftJoin(dbr.I("user_verification").As("uv"), "uv.user_id = sm.uid COLLATE utf8mb4_general_ci").
 		Where("sm.space_id=? AND sm.status=1", spaceId)
 	if keyword != "" {
 		clause, args := memberSearchActiveWhere(keyword)

--- a/modules/space/db_manager.go
+++ b/modules/space/db_manager.go
@@ -52,9 +52,11 @@ func memberSearchWhere(keyword string) (string, []interface{}) {
 //   - email 明文匹配、明文返回（工作邮箱，无需掩码）；
 //   - phone 仅匹配后 4 位（RIGHT(u.phone,4)），使「可检索粒度 == 可见粒度」
 //     （响应仅显示 138****5678），admin 无法通过子串查询逐位探测/重建完整号码。
+//   - real_name（user_verification.real_name）纳入检索，使空名成员可按实名搜到
+//     （issue #434 P1）；仅管理员可见、且已随成员列表展示，检索粒度未越出展示粒度。
 //
 // 前端注意：phone 检索只匹配后 4 位，传完整号码不会命中——按手机号查找请用后 4 位。
-var memberSearchActiveColumns = []string{"u.name", "u.username", "u.email", "RIGHT(u.phone,4)", "sm.uid"}
+var memberSearchActiveColumns = []string{"u.name", "uv.real_name", "u.username", "u.email", "RIGHT(u.phone,4)", "sm.uid"}
 
 // memberSearchActiveWhere 为空间侧 members/search 组装跨列 OR LIKE 条件。
 // list / count 共用同一条件，避免搜索范围漂移导致分页错位。

--- a/modules/space/model.go
+++ b/modules/space/model.go
@@ -44,10 +44,17 @@ type MemberModel struct {
 type memberSearchModel struct {
 	MemberModel
 	Name     string
+	RealName string // 实名兜底（user_verification.real_name），仅作 name 为空时的回退源
 	Username string
 	Email    string
 	Phone    string
 	Robot    int
+}
+
+// DisplayName 返回搜索结果成员的展示名，复用 issue #344 的兜底链（见
+// resolveMemberDisplayName），使成员搜索与成员列表对空名成员的渲染一致（#434）。
+func (m *memberSearchModel) DisplayName() string {
+	return resolveMemberDisplayName(m.Name, m.RealName, m.UID)
 }
 
 // InvitationModel 邀请表模型
@@ -265,6 +272,24 @@ type MemberDetailModel struct {
 // 用它兜底不泄露新信息——但禁止用 short_no / username 兜底（privacy-gated）。
 const memberDisplayNamePlaceholderPrefix = "User "
 
+// resolveMemberDisplayName 是成员展示名兜底链的单一实现（issue #344/#434）：
+//  1. name 非空 → 原样返回；
+//  2. 否则 realName 非空 → 返回实名；
+//  3. 都空 → 返回稳定占位符 "User <uid>"。
+//
+// 任何分支都不会返回空串，也不会暴露 short_no / username（privacy-gated）。
+// 供成员列表（MemberDetailModel）与成员搜索（memberSearchModel）共用，避免同一
+// 兜底链在模块内重复实现（跨模块共享的 pkg/displayname 抽取见 #434 P3，另单跟踪）。
+func resolveMemberDisplayName(name, realName, uid string) string {
+	if name != "" {
+		return name
+	}
+	if realName != "" {
+		return realName
+	}
+	return memberDisplayNamePlaceholderPrefix + uid
+}
+
 // DisplayName 返回成员的展示名，按 issue #344 的兜底链解析：
 //  1. user.name 非空 → 原样返回；
 //  2. 否则 user_verification.real_name 非空 → 返回实名；
@@ -272,13 +297,7 @@ const memberDisplayNamePlaceholderPrefix = "User "
 //
 // 任何分支都不会返回空串，也不会暴露 short_no / username。
 func (m *MemberDetailModel) DisplayName() string {
-	if m.Name != "" {
-		return m.Name
-	}
-	if m.RealName != "" {
-		return m.RealName
-	}
-	return memberDisplayNamePlaceholderPrefix + m.UID
+	return resolveMemberDisplayName(m.Name, m.RealName, m.UID)
 }
 
 // SpaceDetailModel 带成员数和角色的空间详情（MaxUsers 从 SpaceModel 继承）


### PR DESCRIPTION
<!-- multica:bug-fix-report v1 -->

# Bug Fix — Issue #434 — member-search display-name fallback + real_name search

## 1. Executive Summary
- **Bug**: The display-name fallback shipped in #420 for the member *list* was never applied to the sibling member *search* path — blank-name members render as empty rows in search results, and members cannot be searched by their verified `real_name`.
- **Root Cause**: `modules/space/api_member_search.go` mapped `memberSearchResp.Name = m.Name` (raw `user.name`), and `db.go searchMembers`/`countSearchMembers` never joined `user_verification`, so `real_name` was neither returned as a fallback nor made searchable (`db_manager.go memberSearchActiveColumns`).
- **Fix Approach**: localized (single module `modules/space`)
- **Risk Level**: Low
- **PR**: draft (this PR)

## 2. Issue Context
- Title: Follow-up: display-name fallback remaining paths + user_verification JOIN collation risk (#344)
- Reporter: lml2468 (GH)
- bug-verified by: self (triage confidence 0.8; the P1 defect is a clear expected-vs-actual on a shipping path)
- Affected: `main` — the `GET /v1/space/:space_id/members/search` endpoint (added in #389)
- **Scope note**: this is an umbrella issue. Only the **P1** item is fixed here. The 🔴 P0 `user_verification` JOIN collation risk on `queryMembers` is already split out to **#482** and is deliberately NOT touched. P2 (avatar consistency), P2 (other bare-`user.name` endpoints) and P3 (shared `pkg/displayname`) are left for their own trackers per the triager's split recommendation (see §5 boundaries and the follow-up list posted on the tracker).

## 3. Reproduction
**Environment**: octo-server on `main`, MySQL + Redis + WuKongIM (CI test harness / `testutil.NewTestServer`).
**Steps**:
1. Seed a space member whose `user.name` is empty but who has a `user_verification.real_name` (e.g. "Zhang Wei").
2. Call `GET /v1/space/{space_id}/members/search` as a space admin.
3. Also call it with `?keyword=Zhang` (matching only the real_name).

**Expected**:
- The member renders with `name = "Zhang Wei"` (real_name fallback); a member with neither name nor real_name renders the stable `"User <uid>"` placeholder.
- Searching by `Zhang` returns that member.

**Actual (before fix)**:
- The member renders with `name = ""` (empty row).
- Searching by `Zhang` returns nothing (`count = 0`) — members are not searchable by real_name.

**Evidence**: captured as two regression tests (`Test_Issue434_*`, §6) that are RED against the pre-fix code by construction (they compile against the old model and assert on the endpoint response). Local end-to-end execution was **not possible in this sandbox** — no MySQL/WuKongIM is running here (only unrelated Postgres containers), and the octo-server suite hard-requires them. The tests run in CI, which provisions the canonical `utf8mb4_general_ci` test DB.

## 4. RCA
**Method**: 5 Whys
**Analysis**:
- Empty name in search → resp used raw `m.Name`. Why? → `searchMembers` never sourced `real_name`. Why? → the query didn't join `user_verification` and `memberSearchModel` had no `RealName`. Why? → #420 only patched the *list* path (`queryMembers` + `MemberDetailModel.DisplayName`) and left the search path (added independently in #389) untouched. Why? → the fallback lived in a space-local method with no shared reuse point, so the sibling path silently diverged.
**Root cause**: `modules/space/api_member_search.go:searchMembers` (mapping raw `m.Name`) + `modules/space/db.go:searchMembers`/`countSearchMembers` (no `user_verification` join) + `modules/space/db_manager.go:memberSearchActiveColumns` (no `uv.real_name` column) — the #344 fallback chain was never wired into the search path.

## 5. Fix Description
**Files changed**:
- `modules/space/model.go` (+21/-7) — extract the fallback chain into one in-module helper `resolveMemberDisplayName(name, realName, uid)`; `MemberDetailModel.DisplayName()` now delegates to it (behavior-preserving); add `RealName` field + `DisplayName()` to `memberSearchModel`.
- `modules/space/db.go` (+17) — `searchMembers` selects `IFNULL(uv.real_name,'')` and adds a `LEFT JOIN user_verification`; `countSearchMembers` adds the same join to stay row-set-consistent with the list.
- `modules/space/db_manager.go` (+3/-1) — add `uv.real_name` to `memberSearchActiveColumns` so members are searchable by real name.
- `modules/space/api_member_search.go` (+4/-2) — map `Name: m.DisplayName()` instead of raw `m.Name`.

**Change summary**: The member-search path now reuses the exact #344 fallback chain (`name → real_name → "User <uid>"`), so blank-name members render a meaningful name and are searchable by their verified real name. List and count share the same `user_verification` join, so pagination cannot drift.

**Collation safety (does NOT reintroduce #482)**: the new `space_member → user_verification` join is the same cross-collation shape that #482 tracks for `queryMembers`. To avoid re-introducing that latent `Illegal mix of collations (1267)` on non-canonical DBs, the new join ON-clause explicitly pins `uv.user_id = sm.uid COLLATE utf8mb4_general_ci` — the established codebase pattern (`modules/bot_api/resolve_targets.go`). This makes the new join self-contained and independent of #482's outcome, rather than depending on the implicit "DB default is general_ci" assumption. `user_verification.user_id` is a PRIMARY KEY (1:1), so the LEFT JOIN cannot inflate `COUNT(*)`.

**Does NOT change** (scope boundaries):
- `queryMembers` and its existing join — the P0 collation fix is #482.
- Avatar rendering in `modules/user` (P2), `db_manager.go` `creator_name`/`applicant_name`/admin member list (P2), and the shared `pkg/displayname` extraction (P3) — deferred to their own trackers.
- No change to what contact fields are returned, masking (`maskPhone`), authz gates, or pagination clamps.

## 6. Regression Tests
| Test | File | Purpose | Before | After |
|---|---|---|---|---|
| Test_Issue434_SearchBlankNameMemberFallsBackToRealName | `api_member_search_fallback_test.go` | blank name → real_name; both empty → "User <uid>"; populated name unchanged | FAIL | PASS |
| Test_Issue434_MembersSearchableByRealName | `api_member_search_fallback_test.go` | keyword matching only real_name surfaces the member; list & count agree | FAIL | PASS |

## 7. CI Status
- Linter: `golangci-lint run ./modules/space/...` → **0 issues** (local); `gofmt -l` clean.
- Build/vet: `go build ./modules/space/...` and `go vet ./modules/space/...` → **pass** (tests compile).
- Unit/integration: **not run locally** — no MySQL/WuKongIM in this sandbox; delegated to CI on the PR.
- Baseline diff: not collected locally (integration suite needs a DB the sandbox lacks). Change is query-additive and localized; new-failure judgement is deferred to CI. Coverage delta: N/A (local run blocked).
- Legacy-response guard: `api_member_search.go` is already listed in `TestSpaceNoLegacyResponseError`; no new raw error responses were added.

## 8. Deployment Notes
- Migration required?: **no** — query-only change; no schema change.
- Config change?: no.
- Feature flag: no.
- Compatibility: backward-compatible — response shape unchanged; `name` is now populated (fallback) where it was previously empty; `real_name` becomes an additional searchable column (admin-only endpoint, already active-space + role≥admin gated, and real_name is already surfaced by the member list).

## 9. Rollback Plan
**Pattern**: revert (single PR, no data/schema migration).
**Steps**: 1. Revert this PR. 2. Redeploy — no data cleanup needed.
**Detection** (trigger rollback): a spike in 500s on `GET /v1/space/:space_id/members/search` (e.g. an unexpected collation error on a non-canonical DB despite the pinned COLLATE), or member-search result/count divergence reports.

---
_Generated by backend-engineer · awaiting review squad (qa+security+code)_
