### PR TITLE
fix(group): durable async reconcile for orphan group channels #394

### DIFF
--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -75,6 +75,14 @@ func New(ctx *config.Context) *Group {
 	g.ctx.AddEventListener(event.OrgOrDeptEmployeeUpdate, g.handleOrgOrDeptEmployeeUpdate)
 	g.ctx.AddEventListener(event.OrgEmployeeExit, g.handleOrgEmployeeExit)
 	source.SetGroupMemberProvider(g)
+
+	// #394: 启动群 IM 频道 reconcile 定时任务，兜底 CreateGroup 补偿删除失败 / 崩溃留下的孤儿群。
+	// 生产环境自启；测试环境(Test)不起 cron，由测试直接驱动 reconcileOnce。
+	if !g.ctx.GetConfig().Test {
+		if err := newChannelReconcileScheduler(g.ctx).Start(); err != nil {
+			g.Error("failed to start group channel reconcile scheduler", zap.Error(err))
+		}
+	}
 	return g
 }
 

--- a/modules/group/db_channel_outbox.go
+++ b/modules/group/db_channel_outbox.go
@@ -1,0 +1,72 @@
+package group
+
+import (
+	"time"
+
+	"github.com/gocraft/dbr/v2"
+)
+
+// ChannelOutboxModel 群 IM 频道创建事务发件箱行（表 group_channel_outbox）。
+//
+// 一行 == 「某 group_no 的 IM 频道尚未确认创建」。建群事务内写入，随 group/group_member
+// 一起原子提交；IM 频道确认成功后删除。见迁移 20260714000001_group_channel_outbox.sql 与
+// reconcile.go。收口 #394 的孤儿群窗口。
+type ChannelOutboxModel struct {
+	Id          int64
+	GroupNo     string
+	ChannelType int
+	Attempts    int
+	LastError   string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// insertChannelOutboxTx 在建群事务内写入一条待确认频道的 outbox 行。
+//
+// 只显式写 group_no / channel_type，其余列(attempts/last_error/时间戳)交给表默认值，
+// 避免把 Go 零值时间写进 TIMESTAMP 列。group_no 唯一键；建群 group_no 是新 UUID 不会撞键，
+// 但仍用 ON DUPLICATE KEY 兜底重试幂等（重复建同 group_no 时不报错、不重置退避计数）。
+func (d *DB) insertChannelOutboxTx(groupNo string, channelType uint8, tx *dbr.Tx) error {
+	_, err := tx.InsertBySql(
+		"INSERT INTO group_channel_outbox (group_no, channel_type) VALUES (?, ?) "+
+			"ON DUPLICATE KEY UPDATE channel_type=VALUES(channel_type)",
+		groupNo, int(channelType),
+	).Exec()
+	return err
+}
+
+// deleteChannelOutbox 删除某 group_no 的 outbox 行（IM 频道已确认 / 群行已不存在的清理）。
+// 幂等：行不存在时删 0 行、不报错。
+func (d *DB) deleteChannelOutbox(groupNo string) error {
+	_, err := d.session.DeleteFrom("group_channel_outbox").Where("group_no=?", groupNo).Exec()
+	return err
+}
+
+// listDueChannelOutbox 返回 updated_at 早于 before 的 outbox 行（超过宽限期、可 reconcile 的），
+// 按 updated_at 升序（最久未处理优先），最多 limit 行。宽限期让 in-flight 建群（尚在 tx.Commit 与
+// IM 创建之间的正常窗口）不被误当孤儿处理。
+func (d *DB) listDueChannelOutbox(before time.Time, limit int) ([]*ChannelOutboxModel, error) {
+	var models []*ChannelOutboxModel
+	_, err := d.session.Select("*").
+		From("group_channel_outbox").
+		Where("updated_at < ?", before).
+		OrderDir("updated_at", true).
+		Limit(uint64(limit)).
+		Load(&models)
+	return models, err
+}
+
+// markChannelOutboxAttempt 记一次失败尝试：attempts+1、写 last_error、并借 ON UPDATE
+// CURRENT_TIMESTAMP 推进 updated_at（既是观测，也让下一轮 due 判定按最近尝试时间退避，
+// 避免同一坏行每个 tick 都被打）。lastErr 截断到列宽 512。
+func (d *DB) markChannelOutboxAttempt(groupNo, lastErr string) error {
+	if len(lastErr) > 512 {
+		lastErr = lastErr[:512]
+	}
+	_, err := d.session.Update("group_channel_outbox").
+		Set("attempts", dbr.Expr("attempts+1")).
+		Set("last_error", lastErr).
+		Where("group_no=?", groupNo).
+		Exec()
+	return err
+}

--- a/modules/group/reconcile.go
+++ b/modules/group/reconcile.go
@@ -1,0 +1,160 @@
+package group
+
+import (
+	"sync"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/robfig/cron/v3"
+	"go.uber.org/zap"
+)
+
+// #394 孤儿群 reconcile 调参。
+const (
+	// reconcileCronExpr reconcile 扫描频率（每分钟）。孤儿是低频事件，分钟级足够把
+	// 「有 group 行、无 IM 频道」的窗口收敛到最终一致，同时不给 DB/IM 压力。
+	reconcileCronExpr = "@every 1m"
+
+	// reconcileGrace 宽限期：只处理 updated_at 早于 now-grace 的 outbox 行。正常建群在
+	// tx.Commit() 与 IM 创建之间会短暂留有 outbox 行（随即被删），宽限期保证这些 in-flight
+	// 行不被误当孤儿重复建频道。也是失败行的退避基准（markChannelOutboxAttempt 推进 updated_at）。
+	reconcileGrace = 2 * time.Minute
+
+	// reconcileBatch 单轮最多处理的 outbox 行数，防止积压时一轮打爆 IM/DB；剩余的下一轮继续。
+	reconcileBatch = 200
+)
+
+// channelReconciler 扫描 group_channel_outbox，为「已提交但 IM 频道未确认」的群幂等重建频道
+// （或清理已消失群的陈旧 outbox 行），收口 #394 的孤儿群窗口。
+//
+// createChannel / subscribersOf 以字段注入，生产走真实 WuKongIM + 成员表；测试可注入桩，
+// 无需 live WuKongIM 即可覆盖两种失败模式的恢复路径。
+type channelReconciler struct {
+	log.Log
+	db            *DB
+	grace         time.Duration
+	batch         int
+	createChannel func(*config.ChannelCreateReq) error
+	subscribersOf func(groupNo string) ([]string, error)
+}
+
+func newChannelReconciler(ctx *config.Context) *channelReconciler {
+	db := NewDB(ctx)
+	return &channelReconciler{
+		Log:           log.NewTLog("GroupChannelReconciler"),
+		db:            db,
+		grace:         reconcileGrace,
+		batch:         reconcileBatch,
+		createChannel: ctx.IMCreateOrUpdateChannel,
+		subscribersOf: db.querySubscribableMemberUIDsWithGroupNo,
+	}
+}
+
+// reconcileOnce 处理一批到期 outbox 行。返回本轮 (found 扫到, resolved 已收口, failed 本轮未成功)。
+// 全程幂等，可安全重复运行 / 多实例并发（IM 创建是 upsert、删行幂等、宽限期挡住 in-flight）。
+func (r *channelReconciler) reconcileOnce() (found, resolved, failed int, err error) {
+	due, err := r.db.listDueChannelOutbox(time.Now().Add(-r.grace), r.batch)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	found = len(due)
+	for _, o := range due {
+		g, qErr := r.db.QueryWithGroupNo(o.GroupNo)
+		if qErr != nil {
+			r.Error("reconcile: query group failed", zap.Error(qErr), zap.String("groupNo", o.GroupNo))
+			_ = r.db.markChannelOutboxAttempt(o.GroupNo, qErr.Error())
+			failed++
+			continue
+		}
+		if g == nil {
+			// group 行已不存在：补偿删除成功但 outbox 删除失败，或群随后被解散。
+			// 无需 IM 频道，清理陈旧 outbox 行即为收口。
+			if delErr := r.db.deleteChannelOutbox(o.GroupNo); delErr != nil {
+				r.Error("reconcile: delete stale outbox failed", zap.Error(delErr), zap.String("groupNo", o.GroupNo))
+				failed++
+				continue
+			}
+			resolved++
+			continue
+		}
+
+		subs, sErr := r.subscribersOf(o.GroupNo)
+		if sErr != nil {
+			r.Error("reconcile: load subscribers failed", zap.Error(sErr), zap.String("groupNo", o.GroupNo))
+			_ = r.db.markChannelOutboxAttempt(o.GroupNo, sErr.Error())
+			failed++
+			continue
+		}
+
+		if cErr := r.createChannel(&config.ChannelCreateReq{
+			ChannelID:   o.GroupNo,
+			ChannelType: common.ChannelTypeGroup.Uint8(),
+			Subscribers: subs,
+		}); cErr != nil {
+			// IM 仍不可用：记一次尝试并保留 outbox 行，下一轮按退避重试（最终一致）。
+			_ = r.db.markChannelOutboxAttempt(o.GroupNo, cErr.Error())
+			r.Warn("reconcile: recreate IM channel failed, will retry",
+				zap.Error(cErr), zap.String("groupNo", o.GroupNo), zap.Int("attempts", o.Attempts+1))
+			failed++
+			continue
+		}
+
+		if delErr := r.db.deleteChannelOutbox(o.GroupNo); delErr != nil {
+			// 频道已建好但删行失败：下一轮会幂等重建频道(无副作用)再重试删行。
+			r.Error("reconcile: delete outbox after channel recreate failed", zap.Error(delErr), zap.String("groupNo", o.GroupNo))
+			failed++
+			continue
+		}
+		r.Info("reconcile: recovered orphan group channel", zap.String("groupNo", o.GroupNo), zap.Int("subscribers", len(subs)))
+		resolved++
+	}
+	if found > 0 {
+		r.Info("group channel reconcile sweep done",
+			zap.Int("found", found), zap.Int("resolved", resolved), zap.Int("failed", failed))
+	}
+	return found, resolved, failed, nil
+}
+
+// channelReconcileScheduler 定时驱动 channelReconciler（仿 opanalytics/backup 的 cron 调度）。
+type channelReconcileScheduler struct {
+	log.Log
+	reconciler *channelReconciler
+	cron       *cron.Cron
+	entryID    cron.EntryID
+	mu         sync.Mutex
+	started    bool
+}
+
+func newChannelReconcileScheduler(ctx *config.Context) *channelReconcileScheduler {
+	return &channelReconcileScheduler{
+		Log:        log.NewTLog("GroupChannelReconcileScheduler"),
+		reconciler: newChannelReconciler(ctx),
+		cron:       cron.New(),
+	}
+}
+
+// Start 启动调度器（幂等）。出错只返回 error，由调用方记日志，不 panic。
+func (s *channelReconcileScheduler) Start() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.started {
+		return nil
+	}
+	entryID, err := s.cron.AddFunc(reconcileCronExpr, s.runOnce)
+	if err != nil {
+		return err
+	}
+	s.entryID = entryID
+	s.cron.Start()
+	s.started = true
+	s.Info("group channel reconcile scheduler started", zap.String("cron", reconcileCronExpr))
+	return nil
+}
+
+func (s *channelReconcileScheduler) runOnce() {
+	if _, _, _, err := s.reconciler.reconcileOnce(); err != nil {
+		s.Error("group channel reconcile tick failed", zap.Error(err))
+	}
+}

--- a/modules/group/reconcile_test.go
+++ b/modules/group/reconcile_test.go
@@ -1,0 +1,196 @@
+package group
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #394 — CreateGroup 的补偿删除是非原子的：IM 频道创建失败后，若「已提交的 group/
+// group_member 补偿删除」自身也失败（DB 抖动），或进程崩在 tx.Commit() 与 IM 创建之间，就会
+// 留下「有 group 行、无 IM 频道」的孤儿群，客户端永远无法进入。
+//
+// 修复：建群事务内写 group_channel_outbox 行（原子提交），IM 频道确认后删除；后台 reconcile
+// 定时扫描超过宽限期仍存在的行，用当前成员幂等重建频道 —— 或清理 group 行已消失的陈旧 outbox 行。
+// 下列用例用注入桩（无需 live WuKongIM）覆盖验收要求的两种失败模式及其最终一致收口。
+
+// seedOrphanGroup 直接落一个「已提交 + 待确认频道」的群：group 行、一名正常成员、以及一条
+// outbox 行 —— 即 IM 创建失败(补偿删除也失败) 或 commit 后崩溃所留下的孤儿状态。
+func seedOrphanGroup(t *testing.T, ctx *config.Context, groupNo string, members ...string) {
+	t.Helper()
+	db := NewDB(ctx)
+	require.NoError(t, db.Insert(&Model{
+		GroupNo:        groupNo,
+		Name:           "orphan-" + groupNo,
+		Status:         GroupStatusNormal,
+		AllowExternal:  1,
+		AllowNoMention: 1,
+	}))
+	for _, uid := range members {
+		require.NoError(t, db.InsertMember(&MemberModel{
+			GroupNo: groupNo,
+			UID:     uid,
+			Role:    MemberRoleCommon,
+			Status:  int(common.GroupMemberStatusNormal),
+		}))
+	}
+	seedOutboxRow(t, ctx, groupNo)
+}
+
+// seedOutboxRow 直接插入一条 outbox 行（channel_type=群）。
+func seedOutboxRow(t *testing.T, ctx *config.Context, groupNo string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO group_channel_outbox (group_no, channel_type) VALUES (?, ?)",
+		groupNo, int(common.ChannelTypeGroup.Uint8()),
+	).Exec()
+	require.NoError(t, err)
+}
+
+func outboxExists(t *testing.T, ctx *config.Context, groupNo string) bool {
+	t.Helper()
+	var n int
+	err := ctx.DB().SelectBySql("SELECT COUNT(*) FROM group_channel_outbox WHERE group_no=?", groupNo).LoadOne(&n)
+	require.NoError(t, err)
+	return n > 0
+}
+
+func outboxAttempts(t *testing.T, ctx *config.Context, groupNo string) int {
+	t.Helper()
+	var n int
+	err := ctx.DB().SelectBySql("SELECT attempts FROM group_channel_outbox WHERE group_no=?", groupNo).LoadOne(&n)
+	require.NoError(t, err)
+	return n
+}
+
+// newTestReconciler 构造一个使用真实测试 DB、但 IM 创建与订阅者来源均可注入的 reconciler。
+// grace 设为负值，使刚插入的 outbox 行立即被判为「到期」。
+func newTestReconciler(ctx *config.Context, createChannel func(*config.ChannelCreateReq) error) *channelReconciler {
+	r := newChannelReconciler(ctx)
+	r.grace = -time.Hour // 让所有 outbox 行立即到期，避免测试等待真实 2min 宽限期
+	if createChannel != nil {
+		r.createChannel = createChannel
+	}
+	return r
+}
+
+// Test_Issue394_ReconcileRecoversOrphanGroupChannel 验收①/③（失败模式：IM-fail + 补偿删除失败，
+// 以及 commit 后崩溃）：孤儿群被 reconcile 用当前成员幂等重建频道并收口，group 行完好保留。
+func Test_Issue394_ReconcileRecoversOrphanGroupChannel(t *testing.T) {
+	_, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	const groupNo = "g394_recover"
+	seedOrphanGroup(t, ctx, groupNo, "u1", "u2")
+
+	var gotReq *config.ChannelCreateReq
+	r := newTestReconciler(ctx, func(req *config.ChannelCreateReq) error {
+		gotReq = req
+		return nil
+	})
+
+	found, resolved, failed, err := r.reconcileOnce()
+	require.NoError(t, err)
+	require.Equal(t, 1, found)
+	require.Equal(t, 1, resolved)
+	require.Equal(t, 0, failed)
+
+	// 频道用群的当前成员重建（幂等 upsert）。
+	require.NotNil(t, gotReq, "reconcile 必须为孤儿群调用 IM 频道创建")
+	require.Equal(t, groupNo, gotReq.ChannelID)
+	require.Equal(t, common.ChannelTypeGroup.Uint8(), gotReq.ChannelType)
+	require.ElementsMatch(t, []string{"u1", "u2"}, gotReq.Subscribers)
+
+	// 收口后 outbox 行删除；group 行仍在（绝不删掉有成员的群）。
+	require.False(t, outboxExists(t, ctx, groupNo), "频道确认后 outbox 行必须删除")
+	g, err := NewDB(ctx).QueryWithGroupNo(groupNo)
+	require.NoError(t, err)
+	require.NotNil(t, g, "reconcile 必须保留 group 行")
+}
+
+// Test_Issue394_ReconcileRetriesWhileIMDown 验收①/②：IM 仍不可用时保留 outbox 行并累加尝试次数
+// （可观测退避），IM 恢复后下一轮幂等收口 —— 最终一致，孤儿不会永久残留。
+func Test_Issue394_ReconcileRetriesWhileIMDown(t *testing.T) {
+	_, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	const groupNo = "g394_retry"
+	seedOrphanGroup(t, ctx, groupNo, "u1")
+
+	// 第一轮：IM 仍挂。
+	imDown := true
+	r := newTestReconciler(ctx, func(req *config.ChannelCreateReq) error {
+		if imDown {
+			return errors.New("wukongim unavailable")
+		}
+		return nil
+	})
+
+	found, resolved, failed, err := r.reconcileOnce()
+	require.NoError(t, err)
+	require.Equal(t, 1, found)
+	require.Equal(t, 0, resolved)
+	require.Equal(t, 1, failed)
+	require.True(t, outboxExists(t, ctx, groupNo), "IM 未恢复时 outbox 行必须保留待重试")
+	require.Equal(t, 1, outboxAttempts(t, ctx, groupNo), "失败一次应累加 attempts")
+
+	// 第二轮：IM 恢复 → 收口。
+	imDown = false
+	found, resolved, failed, err = r.reconcileOnce()
+	require.NoError(t, err)
+	require.Equal(t, 1, found)
+	require.Equal(t, 1, resolved)
+	require.Equal(t, 0, failed)
+	require.False(t, outboxExists(t, ctx, groupNo), "IM 恢复后应幂等收口并删除 outbox 行")
+}
+
+// Test_Issue394_ReconcileCleansStaleOutboxWhenGroupGone 反向局部失败：补偿删除删掉了 group/成员，
+// 但 outbox 删除失败留下陈旧 outbox 行。reconcile 发现 group 已不存在 → 不建频道，直接清理该行。
+func Test_Issue394_ReconcileCleansStaleOutboxWhenGroupGone(t *testing.T) {
+	_, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	const groupNo = "g394_stale"
+	seedOutboxRow(t, ctx, groupNo) // 只有 outbox 行，没有 group 行
+
+	called := false
+	r := newTestReconciler(ctx, func(req *config.ChannelCreateReq) error {
+		called = true
+		return nil
+	})
+
+	found, resolved, failed, err := r.reconcileOnce()
+	require.NoError(t, err)
+	require.Equal(t, 1, found)
+	require.Equal(t, 1, resolved)
+	require.Equal(t, 0, failed)
+	require.False(t, called, "group 已不存在时不应重建频道")
+	require.False(t, outboxExists(t, ctx, groupNo), "陈旧 outbox 行必须被清理")
+}
+
+// Test_Issue394_ReconcileSkipsInFlightWithinGrace 宽限期保护：正常建群在 commit 与 IM 创建之间
+// 短暂留有的 outbox 行（updated_at≈now）不被误当孤儿处理。
+func Test_Issue394_ReconcileSkipsInFlightWithinGrace(t *testing.T) {
+	_, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	const groupNo = "g394_inflight"
+	seedOrphanGroup(t, ctx, groupNo, "u1")
+
+	called := false
+	r := newChannelReconciler(ctx) // 真实宽限期 2min
+	r.createChannel = func(req *config.ChannelCreateReq) error { called = true; return nil }
+
+	found, resolved, failed, err := r.reconcileOnce()
+	require.NoError(t, err)
+	require.Equal(t, 0, found, "宽限期内的 in-flight outbox 行不应被扫到")
+	require.Equal(t, 0, resolved)
+	require.Equal(t, 0, failed)
+	require.False(t, called, "宽限期内不应触发频道重建")
+	require.True(t, outboxExists(t, ctx, groupNo), "in-flight outbox 行必须保留")
+}

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -1286,6 +1286,15 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 		}
 	}
 
+	// #394 事务发件箱：在提交前写入一条「IM 频道待确认」的 outbox 行，随 group/group_member
+	// 一起原子提交。IM 频道在 WuKongIM 而非本库、无法入 tx；有了这行，即便 commit 后 IM 创建失败
+	// 且补偿删除也失败（或崩在 commit 与 IM 之间），后台 reconcile 也能据此把孤儿群收口到最终一致。
+	// 频道确认成功后（见下）删除该行。
+	if err := s.db.insertChannelOutboxTx(groupNo, common.ChannelTypeGroup.Uint8(), tx); err != nil {
+		s.Error("insert channel outbox failed", zap.Error(err), zap.String("groupNo", groupNo))
+		return nil, errors.New("failed to record channel creation intent")
+	}
+
 	// 提交事务
 	if err := tx.Commit(); err != nil {
 		s.Error("commit transaction failed", zap.Error(err))
@@ -1344,7 +1353,16 @@ func (s *Service) CreateGroup(req *CreateGroupServiceReq) (*CreateGroupServiceRe
 		if _, delErr := s.ctx.DB().DeleteFrom("group").Where("group_no=?", groupNo).Exec(); delErr != nil {
 			s.Error("compensating delete group failed", zap.Error(delErr), zap.String("groupNo", groupNo))
 		}
+		// #394: 补偿删除是 best-effort（自身失败则 group 行残留）。这里**不**删 outbox 行——
+		// 保留它，让后台 reconcile 兜底：补偿全成功时 reconcile 发现 group 已不存在会清掉陈旧 outbox；
+		// 补偿失败留下孤儿群时 reconcile 会用当前成员幂等重建频道。二者都收口到最终一致。
 		return nil, errors.New("failed to create IM channel, group has been rolled back")
+	}
+
+	// #394: IM 频道确认创建成功，删除 outbox 行（结束该群的待确认状态）。删除失败不阻断建群——
+	// reconcile 下一轮会幂等重建频道(无副作用)再重试删行，不会产生孤儿。
+	if delErr := s.db.deleteChannelOutbox(groupNo); delErr != nil {
+		s.Error("delete channel outbox after IM channel created failed (reconcile will retry)", zap.Error(delErr), zap.String("groupNo", groupNo))
 	}
 
 	// 发送群创建通知

--- a/modules/group/sql/20260714000001_group_channel_outbox.sql
+++ b/modules/group/sql/20260714000001_group_channel_outbox.sql
@@ -1,0 +1,64 @@
+-- +migrate Up
+-- 群 IM 频道创建「事务发件箱」(transactional outbox) —— 收口 CreateGroup 的孤儿群窗口 (#394)。
+--
+-- 背景：CreateGroup 在 tx.Commit() 后才调 IMCreateOrUpdateChannel；IM 失败时做 best-effort
+-- 补偿删除，但补偿删除自身失败(或 commit 与 IM 之间进程崩溃)会留下「有 group 行、无 IM 频道」
+-- 的孤儿群 —— 客户端永远无法进入。IM 频道在 WuKongIM 而非本库，无法入 tx，点修无法根除。
+--
+-- 方案：建群同一事务内往本表写一行 outbox（group_no 唯一），随 group/group_member 一起原子提交；
+-- IM 频道确认创建成功后删除该行。于是「本表存在某 group_no 的行」== 「该群的 IM 频道尚未确认」。
+-- 后台 reconcile 定时任务扫描超过宽限期(grace)仍存在的行，用当前成员幂等重建频道并删行；
+-- group 行已不存在的陈旧 outbox 行直接清理。存量群不写本表 → 永不被触碰。
+--
+-- 恢复安全：整段用 INFORMATION_SCHEMA 守卫保证部分执行后重试可重入。
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_channel_outbox;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __group_channel_outbox()
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.TABLES
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group_channel_outbox') THEN
+    CREATE TABLE `group_channel_outbox` (
+      `id`           BIGINT       NOT NULL AUTO_INCREMENT,
+      `group_no`     VARCHAR(40)  NOT NULL COMMENT '待确认 IM 频道的群编号',
+      `channel_type` SMALLINT     NOT NULL DEFAULT 2 COMMENT 'WuKongIM 频道类型(群=2)',
+      `attempts`     INT          NOT NULL DEFAULT 0 COMMENT 'reconcile 重试次数(观测/退避用)',
+      `last_error`   VARCHAR(512) NOT NULL DEFAULT '' COMMENT '最近一次重建失败原因(截断)',
+      `created_at`   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '写入时间(建群时刻)',
+      `updated_at`   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '最近一次 reconcile 尝试时间(due 判定与退避基准)',
+      PRIMARY KEY (`id`),
+      UNIQUE KEY `uk_group_no` (`group_no`),
+      KEY `idx_updated_at` (`updated_at`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='群 IM 频道创建事务发件箱(#394 孤儿群 reconcile)';
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __group_channel_outbox();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_channel_outbox;
+-- +migrate StatementEnd
+
+-- +migrate Down
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_channel_outbox_down;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+CREATE PROCEDURE __group_channel_outbox_down()
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.TABLES
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'group_channel_outbox') THEN
+    DROP TABLE `group_channel_outbox`;
+  END IF;
+END;
+-- +migrate StatementEnd
+
+CALL __group_channel_outbox_down();
+
+-- +migrate StatementBegin
+DROP PROCEDURE IF EXISTS __group_channel_outbox_down;
+-- +migrate StatementEnd


### PR DESCRIPTION
## Summary

`group.CreateGroup` commits the group + members, then creates the WuKongIM channel **after** commit. On IM failure it runs a best-effort compensating delete — but that delete is itself non-atomic and only logs on failure, so a DB blip (or a crash between `tx.Commit()` and the IM create) can leave a **group row with no backing IM channel**: an orphan clients can never message. Fixes #394.

The IM channel lives outside the SQL transaction and can't be enrolled in it, so a point fix can't close the window. This PR adds a **transactional outbox + async reconcile**:

- New table `group_channel_outbox`. `CreateGroup` writes one row **inside the same tx** as `group`/`group_member` (atomic with the commit) and deletes it only after the IM channel is confirmed created. A surviving row means "channel not yet confirmed".
- A per-minute reconcile job (`channelReconcileScheduler`) scans outbox rows older than a 2-min grace period and, for each, **idempotently re-creates the channel from the group's current members** (recover-first — never deletes a member-bearing group), or cleans up a stale row whose group no longer exists. All outcomes are logged (`found`/`resolved`/`failed`).

Both failure modes converge to eventual consistency; the compensating delete is kept as the fast path and the outbox is the durable backstop.

## Scope

- Shared `group.CreateGroup` — Web / Bot / integration all benefit.
- Existing groups never get an outbox row and are never touched. No other insert path (system-group / org-dept / `AddGroup`) is modified.

## Verification

- New regression tests (`reconcile_test.go`) cover: recover orphan, retry-while-IM-down → heal, stale-outbox cleanup when group gone, and grace-window skip — all with an injected IM stub (no live WuKongIM needed).
- Full `./modules/group/` suite passes under `-race -shuffle=on` against real MySQL 8.0 + Redis + WuKongIM `v2.2.4-20260313` (CI-equivalent stack), which also exercises the `CreateGroup` happy path (outbox insert → IM create → outbox delete) end-to-end. No new failures.

## Deployment

- Requires the additive migration `20260714000001_group_channel_outbox.sql` (recovery-safe, `INFORMATION_SCHEMA`-guarded). No backfill, no config, no feature flag. Backward compatible.

🤖 Draft for review squad (qa + security + code).
